### PR TITLE
[TOOLS-4265] _op_get_db_user_id() in cm_common causes core dump

### DIFF
--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -2820,8 +2820,17 @@ _op_get_db_user_id (nvplist * res, DB_OBJECT * user)
   DB_VALUE v;
   char buf[20];
 
-  db_get (user, "password", &v);
-  snprintf (buf, sizeof (buf) - 1, "%d", db_get_int (&v));
+  db_get (user, "id", &v);
+
+  if (DB_IS_NULL (&v))
+    {
+      buf[0] = '\0';
+    }
+  else
+    {
+      snprintf (buf, sizeof (buf) - 1, "%d", db_get_int (&v));
+    }
+
   nv_add_nvp (res, "id", buf);
   db_value_clear (&v);
 }


### PR DESCRIPTION
- fixed, _op_get_db_user_id function doesn't work and it also causes
core dump like following when debug mode:

```
$ cub_manager: ../../src/compat/db_macro.c:2604: db_get_int: Assertion
`value->domain.general_info.type == DB_TYPE_INTEGER' failed.

#0 0x00000038c8e328a5 in raise () from /lib64/libc.so.6
#1 0x00000038c8e34085 in abort () from /lib64/libc.so.6
#2 0x00000038c8e2ba1e in __assert_fail_base () from /lib64/libc.so.6
#3 0x00000038c8e2bae0 in __assert_fail () from /lib64/libc.so.6
#4 0x00007f27abf567f6 in db_get_int (value=0x7f27977e9830) at
../../src/compat/db_macro.c:2604
#5 0x00007f27ad900737 in _op_get_db_user_id (res=0x7f277c00caa0,
user=0x99bae0) at ../../src/cm_common/cm_dep_tasks.c:2830
#6 0x00007f27ad8fd4c5 in cm_ts_userinfo (in=0x7f277c01dcb0,
out=0x7f277c00caa0, _dbmt_error=0x7f27977e9960 "?") at
../../src/cm_common/cm_dep_tasks.c:1368
#7 0x000000000043aadb in ts_userinfo (req=0x7f277c01dcb0,
res=0x7f277c00caa0, _dbmt_error=0x7f27977e9960 "?")
    at ../../../../cubridmanager/server/src/cm_job_task.cpp:743
#8 0x0000000000474ede in ch_process_request (req=0x7f277c01dcb0,
res=0x7f277c00caa0) at
../../../../cubridmanager/server/src/cm_server_interface.cpp:296
#9 0x0000000000475006 in cm_async_request_handler
(lpArg=0x7f279002e720) at
../../../../cubridmanager/server/src/cm_server_interface.cpp:483
#10 0x00000038c9607851 in start_thread () from /lib64/libpthread.so.0
#11 0x00000038c8ee767d in clone () from /lib64/libc.so.6
```

- releated issue : http://jira.cubrid.org/browse/TOOLS-4265