### PR TITLE
[CBRD-20156] rename CRITICAL_SECTION as SYNC_CRITICAL_SECTION, RWLOCK as SYNC_RWLOCK for Windows build

### DIFF
--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -447,7 +447,7 @@ struct css_conn_entry
 #if defined(SERVER_MODE)
   int idx;			/* connection index */
   BOOT_CLIENT_TYPE client_type;
-  CRITICAL_SECTION csect;
+  SYNC_CRITICAL_SECTION csect;
   bool stop_talk;		/* block and stop this connection */
   bool ignore_repl_delay;	/* don't do reset_on_commit by the delay of replication */
   unsigned short stop_phase;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -350,7 +350,7 @@ struct parent_pos_info
 /* XASL cache related things */
 
 /* RWLOCK for XASL cache */
-RWLOCK qexec_Rwlock_xasl_cache;
+SYNC_RWLOCK qexec_Rwlock_xasl_cache;
 #define QEXEC_RWLOCK_XASL_CACHE (&qexec_Rwlock_xasl_cache)
 #define QEXEC_RWLOCK_XASL_CACHE_NAME "QEXEC_RWLOCK_XASL_CACHE"
 

--- a/src/thread/critical_section.h
+++ b/src/thread/critical_section.h
@@ -81,7 +81,7 @@ enum
 extern const char *csect_Name_conn;
 extern const char *csect_Name_tdes;
 
-typedef struct css_critical_section
+typedef struct sync_critical_section
 {
   int cs_index;
   const char *name;
@@ -98,19 +98,19 @@ typedef struct css_critical_section
   unsigned int total_nwaits;	/* total # of waiters */
   struct timeval max_wait;
   struct timeval total_wait;
-} CRITICAL_SECTION;
+} SYNC_CRITICAL_SECTION;
 
-typedef struct rwlock
+typedef struct sync_rwlock
 {
   pthread_mutex_t read_lock;	/* read lock. Only readers will use it. */
   pthread_mutex_t global_lock;	/* global lock */
   char *name;			/* name strduped - should be freed */
   int num_readers;		/* # of readers. Only readers will use it. */
-  int for_trace;		/* RWLOCK_TRACE to monitor the RWLOCK. It should be a global RWLOCK. */
+  int for_trace;		/* SYNC_RWLOCK_TRACE to monitor the SYNC_RWLOCK. It should be a global SYNC_RWLOCK. */
   unsigned int total_enter;
   struct timeval max_wait;
   struct timeval total_wait;
-} RWLOCK;
+} SYNC_RWLOCK;
 
 #define RWLOCK_TRACE 1
 #define RWLOCK_NOT_TRACE 0
@@ -124,11 +124,12 @@ extern int csect_demote (THREAD_ENTRY * thread_p, int cs_index, int wait_secs);
 extern int csect_promote (THREAD_ENTRY * thread_p, int cs_index, int wait_secs);
 extern int csect_exit (THREAD_ENTRY * thread_p, int cs_index);
 
-extern int csect_initialize_critical_section (CRITICAL_SECTION * cs_ptr);
-extern int csect_finalize_critical_section (CRITICAL_SECTION * cs_ptr);
-extern int csect_enter_critical_section (THREAD_ENTRY * thread_p, CRITICAL_SECTION * cs_ptr, int wait_secs);
-extern int csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, CRITICAL_SECTION * cs_ptr, int wait_secs);
-extern int csect_exit_critical_section (THREAD_ENTRY * thread_p, CRITICAL_SECTION * cs_ptr);
+extern int csect_initialize_critical_section (SYNC_CRITICAL_SECTION * cs_ptr);
+extern int csect_finalize_critical_section (SYNC_CRITICAL_SECTION * cs_ptr);
+extern int csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int wait_secs);
+extern int csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr,
+						   int wait_secs);
+extern int csect_exit_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr);
 
 extern int csect_check_own (THREAD_ENTRY * thread_p, int cs_index);
 
@@ -136,14 +137,14 @@ extern void csect_dump_statistics (FILE * fp);
 
 extern int csect_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values, int arg_cnt, void **ctx);
 
-extern int rwlock_initialize (RWLOCK * rwlock, const char *name, int for_trace);
-extern int rwlock_finalize (RWLOCK * rwlock);
+extern int rwlock_initialize (SYNC_RWLOCK * rwlock, const char *name, int for_trace);
+extern int rwlock_finalize (SYNC_RWLOCK * rwlock);
 
-extern int rwlock_read_lock (RWLOCK * rwlock);
-extern int rwlock_read_unlock (RWLOCK * rwlock);
+extern int rwlock_read_lock (SYNC_RWLOCK * rwlock);
+extern int rwlock_read_unlock (SYNC_RWLOCK * rwlock);
 
-extern int rwlock_write_lock (RWLOCK * rwlock);
-extern int rwlock_write_unlock (RWLOCK * rwlock);
+extern int rwlock_write_lock (SYNC_RWLOCK * rwlock);
+extern int rwlock_write_unlock (SYNC_RWLOCK * rwlock);
 
 extern int rwlock_initialize_rwlock_monitor (void);
 extern int rwlock_finalize_rwlock_monitor (void);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -870,7 +870,7 @@ struct log_tdes
   int gtrid;			/* Global transaction identifier; used only if this transaction is a participant to a
 				 * global transaction and it is prepared to commit. */
   LOG_CLIENTIDS client;		/* Client identification */
-  CRITICAL_SECTION cs_topop;	/* critical section to serialize system top operations */
+  SYNC_CRITICAL_SECTION cs_topop;	/* critical section to serialize system top operations */
   LOG_TOPOPS_STACK topops;	/* Active top system operations. Used for system permanent nested operations which are
 				 * independent from current transaction outcome. */
   LOG_2PC_GTRINFO gtrinfo;	/* Global transaction user information; used to store XID of XA interface. */


### PR DESCRIPTION
rename CRITICAL_SECTION as SYNC_CRITICAL_SECTION
rename RWLOCK as SYNC_RWLOCK