### PR TITLE
[CBRD-20165] introduce light weight reentrant mutex

### DIFF
--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -852,10 +852,12 @@ extern bool set_diag_value (T_DIAG_OBJ_TYPE type, int value, T_DIAG_VALUE_SETTYP
   ((int)((elapsed.tv_sec * 1000) + (int) (elapsed.tv_usec / 1000)))
 
 #if defined (EnableThreadMonitoring)
-#define MONITOR_WAITING_THREAD(elpased) \
+#define MONITOR_WAITING_THREAD(elapsed) \
     (prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD) > 0 \
-     && ((elpased).tv_sec * 1000 + (elpased).tv_usec / 1000) \
+     && ((elapsed).tv_sec * 1000 + (elapsed).tv_usec / 1000) \
          > prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
+#else
+#define MONITOR_WAITING_THREAD(elapsed) (0)
 #endif
 
 typedef struct perf_utime_tracker PERF_UTIME_TRACKER;

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -7260,8 +7260,7 @@ sthread_dump_cs_stat (THREAD_ENTRY * thread_p, unsigned int rid, char *request, 
       return;
     }
 
-  csect_dump_statistics (outfp);
-  rwlock_dump_statistics (outfp);
+  sync_dump_statistics (outfp, SYNC_TYPE_ALL);
 
   file_size = ftell (outfp);
 

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1386,15 +1386,15 @@ net_server_start (const char *server_name)
   sysprm_load_and_init (NULL, NULL);
   sysprm_set_er_log_file (server_name);
 
-  if (csect_initialize () != NO_ERROR)
+  if (sync_initialize_sync_monitor () != NO_ERROR)
     {
-      PRINT_AND_LOG_ERR_MSG ("Failed to initialize critical section\n");
+      PRINT_AND_LOG_ERR_MSG ("Failed to initialize synchronization primitives monitor\n");
       status = -1;
       goto end;
     }
-  if (rwlock_initialize_rwlock_monitor () != NO_ERROR)
+  if (csect_initialize_static_critical_sections () != NO_ERROR)
     {
-      PRINT_AND_LOG_ERR_MSG ("Failed to initialize rwlock monitor\n");
+      PRINT_AND_LOG_ERR_MSG ("Failed to initialize critical section\n");
       status = -1;
       goto end;
     }
@@ -1467,8 +1467,8 @@ net_server_start (const char *server_name)
     }
 
   thread_final_manager ();
-  (void) rwlock_finalize_rwlock_monitor ();
-  csect_finalize ();
+  csect_finalize_static_critical_sections ();
+  (void) sync_finalize_sync_monitor ();
 
 end:
 #if defined(WINDOWS)

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1386,7 +1386,7 @@ net_server_start (const char *server_name)
   sysprm_load_and_init (NULL, NULL);
   sysprm_set_er_log_file (server_name);
 
-  if (sync_initialize_sync_monitor () != NO_ERROR)
+  if (sync_initialize_sync_stats () != NO_ERROR)
     {
       PRINT_AND_LOG_ERR_MSG ("Failed to initialize synchronization primitives monitor\n");
       status = -1;
@@ -1468,7 +1468,7 @@ net_server_start (const char *server_name)
 
   thread_final_manager ();
   csect_finalize_static_critical_sections ();
-  (void) sync_finalize_sync_monitor ();
+  (void) sync_finalize_sync_stats ();
 
 end:
 #if defined(WINDOWS)

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -452,15 +452,12 @@ css_init_conn_list (void)
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_CONN_INIT, 0);
 	  return ER_CSS_CONN_INIT;
 	}
-      err = csect_initialize_critical_section (&conn->csect);
+      err = csect_initialize_critical_section (&conn->csect, csect_Name_conn);
       if (err == NO_ERROR)
 	{
 #if defined(SERVER_MODE)
 	  assert (conn->csect.cs_index == -1);
-	  assert (conn->csect.name == NULL);
-
 	  conn->csect.cs_index = CRITICAL_SECTION_COUNT + conn->idx;
-	  conn->csect.name = csect_Name_conn;
 #endif
 	}
       else

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1055,7 +1055,7 @@ css_process_new_client (SOCKET master_fd)
   if (prm_get_bool_value (PRM_ID_ACCESS_IP_CONTROL) == true && css_check_accessibility (new_fd) != NO_ERROR)
     {
       css_initialize_conn (&temp_conn, new_fd);
-      csect_initialize_critical_section (&temp_conn.csect);
+      csect_initialize_critical_section (&temp_conn.csect, csect_Name_conn);
 
       reason = htonl (SERVER_INACCESSIBLE_IP);
       css_send_data (&temp_conn, rid, (char *) &reason, (int) sizeof (int));
@@ -1074,7 +1074,7 @@ css_process_new_client (SOCKET master_fd)
   if (conn == NULL)
     {
       css_initialize_conn (&temp_conn, new_fd);
-      csect_initialize_critical_section (&temp_conn.csect);
+      csect_initialize_critical_section (&temp_conn.csect, csect_Name_conn);
 
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_CLIENTS_EXCEEDED, 1, NUM_NORMAL_TRANS);
       reason = htonl (SERVER_CLIENTS_EXCEEDED);
@@ -1263,7 +1263,7 @@ css_process_new_connection_request (void)
 	  void *error_string;
 
 	  css_initialize_conn (&new_conn, new_fd);
-	  csect_initialize_critical_section (&new_conn.csect);
+	  csect_initialize_critical_section (&new_conn.csect, csect_Name_conn);
 
 	  rc = css_read_header (&new_conn, &header);
 	  buffer_size = rid = 0;
@@ -1292,7 +1292,7 @@ css_process_new_connection_request (void)
 	  void *error_string;
 
 	  css_initialize_conn (&new_conn, new_fd);
-	  csect_initialize_critical_section (&new_conn.csect);
+	  csect_initialize_critical_section (&new_conn.csect, csect_Name_conn);
 
 	  rc = css_read_header (&new_conn, &header);
 	  buffer_size = rid = 0;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14578,7 +14578,7 @@ qexec_initialize_xasl_cache (THREAD_ENTRY * thread_p)
       return NO_ERROR;
     }
 
-  if (rwlock_initialize (QEXEC_RWLOCK_XASL_CACHE, QEXEC_RWLOCK_XASL_CACHE_NAME, RWLOCK_TRACE) != NO_ERROR)
+  if (rwlock_initialize (QEXEC_RWLOCK_XASL_CACHE, QEXEC_RWLOCK_XASL_CACHE_NAME) != NO_ERROR)
     {
       return ER_FAILED;
     }

--- a/src/thread/critical_section.c
+++ b/src/thread/critical_section.c
@@ -2364,7 +2364,7 @@ sync_consume_sync_stats_from_pool (SYNC_STATS_CHUNK * sync_stats_chunk, int idx,
   SYNC_STATS *stats;
 
   assert (sync_stats_chunk != NULL);
-  assert (sync_prim_type != SYNC_TYPE_NONE);
+  assert (SYNC_TYPE_NONE < sync_prim_type && sync_prim_type <= SYNC_TYPE_LAST);
   assert (0 <= idx && idx < NUM_ENTRIES_OF_SYNC_STATS_BLOCK);
   assert (sync_stats_chunk->block[idx].type == SYNC_TYPE_NONE);
   assert (0 <= sync_stats_chunk->num_entry_in_use
@@ -2392,7 +2392,7 @@ sync_return_sync_stats_to_pool (SYNC_STATS_CHUNK * sync_stats_chunk, int idx)
 {
   assert (sync_stats_chunk != NULL);
   assert (0 <= idx && idx < NUM_ENTRIES_OF_SYNC_STATS_BLOCK);
-  assert (sync_stats_chunk->block[idx].type != SYNC_TYPE_NONE);
+  assert (SYNC_TYPE_NONE < sync_stats_chunk->block[idx].type && sync_stats_chunk->block[idx].type <= SYNC_TYPE_LAST);
   assert (0 < sync_stats_chunk->num_entry_in_use
 	  && sync_stats_chunk->num_entry_in_use <= NUM_ENTRIES_OF_SYNC_STATS_BLOCK);
 
@@ -2491,7 +2491,7 @@ sync_deallocate_sync_stats (SYNC_STATS * stats)
 	{
 	  idx = (int) (stats - p->block);
 
-	  assert (p->block[idx].type != SYNC_TYPE_NONE);
+	  assert (SYNC_TYPE_NONE < p->block[idx].type && p->block[idx].type <= SYNC_TYPE_LAST);
 
 	  sync_return_sync_stats_to_pool (p, idx);
 

--- a/src/thread/critical_section.c
+++ b/src/thread/critical_section.c
@@ -51,18 +51,19 @@
 #undef csect_exit_critical_section
 
 #define TOTAL_AND_MAX_TIMEVAL(total, max, elapsed) \
-do { \
-  (total).tv_sec += elapsed.tv_sec; \
-  (total).tv_usec += elapsed.tv_usec; \
-  (total).tv_sec += (total).tv_usec / 1000000; \
-  (total).tv_usec %= 1000000; \
-  if (((max).tv_sec < elapsed.tv_sec) \
-      || ((max).tv_sec == elapsed.tv_sec && (max).tv_usec < elapsed.tv_usec)) \
+  do \
     { \
-      (max).tv_sec = elapsed.tv_sec; \
-      (max).tv_usec = elapsed.tv_usec; \
+      (total).tv_sec += elapsed.tv_sec; \
+      (total).tv_usec += elapsed.tv_usec; \
+      (total).tv_sec += (total).tv_usec / 1000000; \
+      (total).tv_usec %= 1000000; \
+      if (((max).tv_sec < elapsed.tv_sec) || ((max).tv_sec == elapsed.tv_sec && (max).tv_usec < elapsed.tv_usec)) \
+        { \
+          (max).tv_sec = elapsed.tv_sec; \
+          (max).tv_usec = elapsed.tv_usec; \
+        } \
     } \
-} while (0)
+  while (0)
 
 /* define critical section array */
 SYNC_CRITICAL_SECTION csectgl_Critical_sections[CRITICAL_SECTION_COUNT];
@@ -103,79 +104,60 @@ const char *csect_Name_tdes = "TDES";
  * rwlock monitor
  */
 
-#define NUM_ENTRIES_OF_RWLOCK_CHUNK 64
+#define NUM_ENTRIES_OF_SYNC_STATS_BLOCK 256
 
 /*
  * This is not a pre-allocated free rwlock chunk. 
  * Each SYNC_RWLOCK locates in its local manager. SYNC_RWLOCK Monitor only manages the pointers to the registered global RWLOCKs.
  * This makes debugging and performance trouble shooting easier.
  */
-typedef struct sync_rwlock_chunk SYNC_RWLOCK_CHUNK;
-struct sync_rwlock_chunk
+typedef struct sync_monitor_chunk SYNC_MONITOR;
+struct sync_monitor_chunk
 {
-  SYNC_RWLOCK *block[NUM_ENTRIES_OF_RWLOCK_CHUNK];
-  SYNC_RWLOCK_CHUNK *next_chunk;
+  SYNC_STATS block[NUM_ENTRIES_OF_SYNC_STATS_BLOCK];
+  SYNC_MONITOR *next;
   int hint_free_entry_idx;
   int num_entry_in_use;
-  pthread_mutex_t rwlock_monitor_mutex;
 };
 
-SYNC_RWLOCK_CHUNK rwlock_Monitor;
+SYNC_MONITOR sync_Monitor;
+pthread_mutex_t sync_Monitor_lock;
 
-static int csect_initialize_entry (int cs_index);
-static int csect_finalize_entry (int cs_index);
-static int csect_wait_on_writer_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int timeout,
+static int csect_wait_on_writer_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect, int timeout,
 				       struct timespec *to);
-static int csect_wait_on_promoter_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int timeout,
+static int csect_wait_on_promoter_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect, int timeout,
 					 struct timespec *to);
-static int csect_wakeup_waiting_writer (SYNC_CRITICAL_SECTION * cs_ptr);
-static int csect_wakeup_waiting_promoter (SYNC_CRITICAL_SECTION * cs_ptr);
-static int csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int wait_secs);
-static int csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int wait_secs);
-static int csect_check_own_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr);
+static int csect_wakeup_waiting_writer (SYNC_CRITICAL_SECTION * csect);
+static int csect_wakeup_waiting_promoter (SYNC_CRITICAL_SECTION * csect);
+static int csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect, int wait_secs);
+static int csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect, int wait_secs);
+static int csect_check_own_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect);
 
-static SYNC_RWLOCK_CHUNK *rwlock_allocate_rwlock_chunk_monitor_entry (void);
-static int rwlock_initialize_rwlock_monitor_entry (SYNC_RWLOCK_CHUNK * rwlock_chunk_entry);
-static int rwlock_consume_a_rwlock_monitor_entry (SYNC_RWLOCK_CHUNK * rwlock_chunk_entry, int idx,
-						  SYNC_RWLOCK * rwlock);
-static int rwlock_reclaim_a_rwlock_monitor_entry (SYNC_RWLOCK_CHUNK * rwlock_chunk_entry, int idx);
-static int rwlock_register_a_rwlock_entry_to_monitor (SYNC_RWLOCK * rwlock);
-static int rwlock_unregister_a_rwlock_entry_from_monitor (SYNC_RWLOCK * rwlock);
+static SYNC_MONITOR *sync_allocate_sync_monitor_entry (void);
+static int sync_initialize_sync_monitor_entry (SYNC_MONITOR * sync_monitor_entry);
+static SYNC_STATS *sync_consume_sync_stats_from_pool (SYNC_MONITOR * sync_monitor_entry, int idx,
+						      SYNC_PRIMITIVE_TYPE sync_prim_type, const char *name);
+static int sync_return_sync_stats_to_pool (SYNC_MONITOR * sync_monitor_entry, int idx);
+static SYNC_STATS *sync_allocate_sync_stats (SYNC_PRIMITIVE_TYPE sync_prim_type, const char *name);
+static int sync_deallocate_sync_stats (SYNC_STATS * stats);
+
+static void sync_reset_stats_metrics (SYNC_STATS * stats);
 
 /*
  * csect_initialize_critical_section() - initialize critical section
  *   return: 0 if success, or error code
- *   cs_ptr(in): critical section
+ *   csect(in): critical section
  */
 int
-csect_initialize_critical_section (SYNC_CRITICAL_SECTION * cs_ptr)
+csect_initialize_critical_section (SYNC_CRITICAL_SECTION * csect, const char *name)
 {
   int error_code = NO_ERROR;
-  pthread_mutexattr_t mattr;
 
-  assert (cs_ptr != NULL);
+  assert (csect != NULL);
 
-  cs_ptr->cs_index = -1;
-  cs_ptr->name = NULL;
+  csect->cs_index = -1;
 
-  error_code = pthread_mutexattr_init (&mattr);
-  if (error_code != NO_ERROR)
-    {
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEXATTR_INIT, 0);
-      assert (0);
-      return ER_CSS_PTHREAD_MUTEXATTR_INIT;
-    }
-
-#ifdef CHECK_MUTEX
-  error_code = pthread_mutexattr_settype (&mattr, PTHREAD_MUTEX_ERRORCHECK);
-  if (error_code != NO_ERROR)
-    {
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEXATTR_SETTYPE, 0);
-      return ER_CSS_PTHREAD_MUTEXATTR_SETTYPE;
-    }
-#endif /* CHECK_MUTEX */
-
-  error_code = pthread_mutex_init (&cs_ptr->lock, &mattr);
+  error_code = pthread_mutex_init (&csect->lock, NULL);
 
   if (error_code != NO_ERROR)
     {
@@ -184,7 +166,7 @@ csect_initialize_critical_section (SYNC_CRITICAL_SECTION * cs_ptr)
       return ER_CSS_PTHREAD_MUTEX_INIT;
     }
 
-  error_code = pthread_cond_init (&cs_ptr->readers_ok, NULL);
+  error_code = pthread_cond_init (&csect->readers_ok, NULL);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_INIT, 0);
@@ -192,69 +174,36 @@ csect_initialize_critical_section (SYNC_CRITICAL_SECTION * cs_ptr)
       return ER_CSS_PTHREAD_COND_INIT;
     }
 
-  cs_ptr->rwlock = 0;
-  cs_ptr->owner = ((pthread_t) 0);
-  cs_ptr->tran_index = -1;
-  cs_ptr->waiting_readers = 0;
-  cs_ptr->waiting_writers = 0;
-  cs_ptr->waiting_writers_queue = NULL;
-  cs_ptr->waiting_promoters_queue = NULL;
+  csect->name = name;
+  csect->rwlock = 0;
+  csect->owner = ((pthread_t) 0);
+  csect->tran_index = -1;
+  csect->waiting_readers = 0;
+  csect->waiting_writers = 0;
+  csect->waiting_writers_queue = NULL;
+  csect->waiting_promoters_queue = NULL;
 
-  cs_ptr->total_enter = 0;
-  cs_ptr->total_nwaits = 0;
-
-  cs_ptr->max_wait.tv_sec = 0;
-  cs_ptr->max_wait.tv_usec = 0;
-  cs_ptr->total_wait.tv_sec = 0;
-  cs_ptr->total_wait.tv_usec = 0;
-
-  error_code = pthread_mutexattr_destroy (&mattr);
-  if (error_code != NO_ERROR)
+  csect->stats = sync_allocate_sync_stats (SYNC_TYPE_CSECT, name);
+  if (csect->stats == NULL)
     {
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEXATTR_DESTROY, 0);
-      assert (0);
-      return ER_CSS_PTHREAD_MUTEXATTR_DESTROY;
+      ASSERT_ERROR_AND_SET (error_code);
+      return error_code;
     }
 
   return NO_ERROR;
 }
 
 /*
- * csect_initialize_entry() - initialize critical section entry
- *   return: 0 if success, or error code
- *   cs_index(in): critical section entry index
- */
-static int
-csect_initialize_entry (int cs_index)
-{
-  int error_code = NO_ERROR;
-  SYNC_CRITICAL_SECTION *cs_ptr;
-
-  assert (cs_index >= 0);
-  assert (cs_index < CRITICAL_SECTION_COUNT);
-
-  cs_ptr = &csectgl_Critical_sections[cs_index];
-  error_code = csect_initialize_critical_section (cs_ptr);
-  if (error_code == NO_ERROR)
-    {
-      cs_ptr->cs_index = cs_index;
-      cs_ptr->name = csect_Names[cs_index];
-    }
-
-  return error_code;
-}
-
-/*
  * csect_finalize_critical_section() - free critical section
  *   return: 0 if success, or error code
- *   cs_ptr(in): critical section
+ *   csect(in): critical section
  */
 int
-csect_finalize_critical_section (SYNC_CRITICAL_SECTION * cs_ptr)
+csect_finalize_critical_section (SYNC_CRITICAL_SECTION * csect)
 {
   int error_code = NO_ERROR;
 
-  error_code = pthread_mutex_destroy (&cs_ptr->lock);
+  error_code = pthread_mutex_destroy (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_DESTROY, 0);
@@ -262,7 +211,7 @@ csect_finalize_critical_section (SYNC_CRITICAL_SECTION * cs_ptr)
       return ER_CSS_PTHREAD_MUTEX_DESTROY;
     }
 
-  error_code = pthread_cond_destroy (&cs_ptr->readers_ok);
+  error_code = pthread_cond_destroy (&csect->readers_ok);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_DESTROY, 0);
@@ -270,111 +219,91 @@ csect_finalize_critical_section (SYNC_CRITICAL_SECTION * cs_ptr)
       return ER_CSS_PTHREAD_COND_DESTROY;
     }
 
-  cs_ptr->rwlock = 0;
-  cs_ptr->owner = ((pthread_t) 0);
-  cs_ptr->tran_index = -1;
-  cs_ptr->waiting_readers = 0;
-  cs_ptr->waiting_writers = 0;
-  cs_ptr->waiting_writers_queue = NULL;
-  cs_ptr->waiting_promoters_queue = NULL;
+  csect->name = NULL;
+  csect->rwlock = 0;
+  csect->owner = ((pthread_t) 0);
+  csect->tran_index = -1;
+  csect->waiting_readers = 0;
+  csect->waiting_writers = 0;
+  csect->waiting_writers_queue = NULL;
+  csect->waiting_promoters_queue = NULL;
 
-  cs_ptr->total_enter = 0;
-  cs_ptr->total_nwaits = 0;
-
-  cs_ptr->max_wait.tv_sec = 0;
-  cs_ptr->max_wait.tv_usec = 0;
-  cs_ptr->total_wait.tv_sec = 0;
-  cs_ptr->total_wait.tv_usec = 0;
+  error_code = sync_deallocate_sync_stats (csect->stats);
+  csect->stats = NULL;
 
   return NO_ERROR;
 }
 
 /*
- * csect_finalize_entry() - free critical section entry
+ * csect_initialize_static_critical_sections() - initialize all the critical section lock structures
  *   return: 0 if success, or error code
- *   cs_index(in): critical section entry index
  */
-static int
-csect_finalize_entry (int cs_index)
+int
+csect_initialize_static_critical_sections (void)
 {
-  int error_code = NO_ERROR;
-  SYNC_CRITICAL_SECTION *cs_ptr;
+  SYNC_CRITICAL_SECTION *csect;
+  int i, error_code = NO_ERROR;
 
-  assert (cs_index >= 0);
-  assert (cs_index < CRITICAL_SECTION_COUNT);
-
-  cs_ptr = &csectgl_Critical_sections[cs_index];
-  assert (cs_ptr->cs_index == cs_index);
-
-  error_code = csect_finalize_critical_section (cs_ptr);
-  if (error_code == NO_ERROR)
+  for (i = 0; i < CRITICAL_SECTION_COUNT; i++)
     {
-      cs_ptr->cs_index = -1;
-      cs_ptr->name = NULL;
+      csect = &csectgl_Critical_sections[i];
+
+      error_code = csect_initialize_critical_section (csect, csect_Names[i]);
+      if (error_code != NO_ERROR)
+	{
+	  break;
+	}
+
+      csect->cs_index = i;
     }
 
   return error_code;
 }
 
 /*
- * csect_initialize() - initialize all the critical section lock structures
+ * csect_finalize_static_critical_sections() - free all the critical section lock structures
  *   return: 0 if success, or error code
  */
 int
-csect_initialize (void)
+csect_finalize_static_critical_sections (void)
 {
+  SYNC_CRITICAL_SECTION *csect;
   int i, error_code = NO_ERROR;
 
   for (i = 0; i < CRITICAL_SECTION_COUNT; i++)
     {
-      error_code = csect_initialize_entry (i);
+      csect = &csectgl_Critical_sections[i];
+      assert (csect->cs_index == i);
+
+      error_code = csect_finalize_critical_section (csect);
       if (error_code != NO_ERROR)
 	{
 	  break;
 	}
-    }
 
-  return error_code;
-}
-
-/*
- * csect_finalize() - free all the critical section lock structures
- *   return: 0 if success, or error code
- */
-int
-csect_finalize (void)
-{
-  int i, error_code = NO_ERROR;
-
-  for (i = 0; i < CRITICAL_SECTION_COUNT; i++)
-    {
-      error_code = csect_finalize_entry (i);
-      if (error_code != NO_ERROR)
-	{
-	  break;
-	}
+      csect->cs_index = -1;
     }
 
   return error_code;
 }
 
 static int
-csect_wait_on_writer_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int timeout, struct timespec *to)
+csect_wait_on_writer_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect, int timeout, struct timespec *to)
 {
   THREAD_ENTRY *prev_thread_p = NULL;
   int err = NO_ERROR;
 
   thread_p->next_wait_thrd = NULL;
 
-  if (cs_ptr->waiting_writers_queue == NULL)
+  if (csect->waiting_writers_queue == NULL)
     {
       /* nobody is waiting. */
-      cs_ptr->waiting_writers_queue = thread_p;
+      csect->waiting_writers_queue = thread_p;
     }
   else
     {
       /* waits on the rear of the queue */
-      prev_thread_p = cs_ptr->waiting_writers_queue;
+      prev_thread_p = csect->waiting_writers_queue;
       while (prev_thread_p->next_wait_thrd != NULL)
 	{
 	  assert (prev_thread_p != thread_p);
@@ -388,12 +317,12 @@ csect_wait_on_writer_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_
 
   while (true)
     {
-      err = thread_suspend_with_other_mutex (thread_p, &cs_ptr->lock, timeout, to, THREAD_CSECT_WRITER_SUSPENDED);
+      err = thread_suspend_with_other_mutex (thread_p, &csect->lock, timeout, to, THREAD_CSECT_WRITER_SUSPENDED);
 
       if (DOES_THREAD_RESUME_DUE_TO_SHUTDOWN (thread_p))
 	{
 	  /* check if i'm in the queue */
-	  prev_thread_p = cs_ptr->waiting_writers_queue;
+	  prev_thread_p = csect->waiting_writers_queue;
 	  while (prev_thread_p != NULL)
 	    {
 	      if (prev_thread_p == thread_p)
@@ -428,22 +357,22 @@ csect_wait_on_writer_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_
 }
 
 static int
-csect_wait_on_promoter_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int timeout, struct timespec *to)
+csect_wait_on_promoter_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect, int timeout, struct timespec *to)
 {
   THREAD_ENTRY *prev_thread_p = NULL;
   int err = NO_ERROR;
 
   thread_p->next_wait_thrd = NULL;
 
-  if (cs_ptr->waiting_promoters_queue == NULL)
+  if (csect->waiting_promoters_queue == NULL)
     {
       /* nobody is waiting. */
-      cs_ptr->waiting_promoters_queue = thread_p;
+      csect->waiting_promoters_queue = thread_p;
     }
   else
     {
       /* waits on the rear of the queue */
-      prev_thread_p = cs_ptr->waiting_promoters_queue;
+      prev_thread_p = csect->waiting_promoters_queue;
       while (prev_thread_p->next_wait_thrd != NULL)
 	{
 	  assert (prev_thread_p != thread_p);
@@ -457,12 +386,12 @@ csect_wait_on_promoter_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
 
   while (1)
     {
-      err = thread_suspend_with_other_mutex (thread_p, &cs_ptr->lock, timeout, to, THREAD_CSECT_PROMOTER_SUSPENDED);
+      err = thread_suspend_with_other_mutex (thread_p, &csect->lock, timeout, to, THREAD_CSECT_PROMOTER_SUSPENDED);
 
       if (DOES_THREAD_RESUME_DUE_TO_SHUTDOWN (thread_p))
 	{
 	  /* check if i'm in the queue */
-	  prev_thread_p = cs_ptr->waiting_promoters_queue;
+	  prev_thread_p = csect->waiting_promoters_queue;
 	  while (prev_thread_p != NULL)
 	    {
 	      if (prev_thread_p == thread_p)
@@ -497,16 +426,16 @@ csect_wait_on_promoter_queue (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
 }
 
 static int
-csect_wakeup_waiting_writer (SYNC_CRITICAL_SECTION * cs_ptr)
+csect_wakeup_waiting_writer (SYNC_CRITICAL_SECTION * csect)
 {
   THREAD_ENTRY *waiting_thread_p = NULL;
   int error_code = NO_ERROR;
 
-  waiting_thread_p = cs_ptr->waiting_writers_queue;
+  waiting_thread_p = csect->waiting_writers_queue;
 
   if (waiting_thread_p != NULL)
     {
-      cs_ptr->waiting_writers_queue = waiting_thread_p->next_wait_thrd;
+      csect->waiting_writers_queue = waiting_thread_p->next_wait_thrd;
       waiting_thread_p->next_wait_thrd = NULL;
 
       error_code = thread_wakeup (waiting_thread_p, THREAD_CSECT_WRITER_RESUMED);
@@ -516,16 +445,16 @@ csect_wakeup_waiting_writer (SYNC_CRITICAL_SECTION * cs_ptr)
 }
 
 static int
-csect_wakeup_waiting_promoter (SYNC_CRITICAL_SECTION * cs_ptr)
+csect_wakeup_waiting_promoter (SYNC_CRITICAL_SECTION * csect)
 {
   THREAD_ENTRY *waiting_thread_p = NULL;
   int error_code = NO_ERROR;
 
-  waiting_thread_p = cs_ptr->waiting_promoters_queue;
+  waiting_thread_p = csect->waiting_promoters_queue;
 
   if (waiting_thread_p != NULL)
     {
-      cs_ptr->waiting_promoters_queue = waiting_thread_p->next_wait_thrd;
+      csect->waiting_promoters_queue = waiting_thread_p->next_wait_thrd;
       waiting_thread_p->next_wait_thrd = NULL;
 
       error_code = thread_wakeup (waiting_thread_p, THREAD_CSECT_PROMOTER_RESUMED);
@@ -537,22 +466,20 @@ csect_wakeup_waiting_promoter (SYNC_CRITICAL_SECTION * cs_ptr)
 /*
  * csect_enter_critical_section() - lock critical section
  *   return: 0 if success, or error code
- *   cs_ptr(in): critical section
+ *   csect(in): critical section
  *   wait_secs(in): timeout second
  */
 int
-csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int wait_secs)
+csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect, int wait_secs)
 {
   int error_code = NO_ERROR, r;
-#if defined (EnableThreadMonitoring)
   TSC_TICKS start_tick, end_tick;
   TSCTIMEVAL tv_diff;
-#endif
 
   TSC_TICKS wait_start_tick, wait_end_tick;
   TSCTIMEVAL wait_tv_diff;
 
-  assert (cs_ptr != NULL);
+  assert (csect != NULL);
 
   if (thread_p == NULL)
     {
@@ -560,20 +487,15 @@ csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
     }
 
 #if !defined (NDEBUG)
-  thread_rc_track_meter (thread_p, __FILE__, __LINE__, THREAD_TRACK_CSECT_ENTER_AS_WRITER, &(cs_ptr->cs_index), RC_CS,
+  thread_rc_track_meter (thread_p, __FILE__, __LINE__, THREAD_TRACK_CSECT_ENTER_AS_WRITER, &(csect->cs_index), RC_CS,
 			 MGR_DEF);
 #endif /* NDEBUG */
 
-  cs_ptr->total_enter++;
+  csect->stats->nenter++;
 
-#if defined (EnableThreadMonitoring)
-  if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
-    {
-      tsc_getticks (&start_tick);
-    }
-#endif
+  tsc_getticks (&start_tick);
 
-  error_code = pthread_mutex_lock (&cs_ptr->lock);
+  error_code = pthread_mutex_lock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_LOCK, 0);
@@ -581,29 +503,30 @@ csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
       return ER_CSS_PTHREAD_MUTEX_LOCK;
     }
 
-  while (cs_ptr->rwlock != 0 || cs_ptr->owner != ((pthread_t) 0))
+  while (csect->rwlock != 0 || csect->owner != ((pthread_t) 0))
     {
-      if (cs_ptr->rwlock < 0 && cs_ptr->owner == thread_p->tid)
+      if (csect->rwlock < 0 && csect->owner == thread_p->tid)
 	{
 	  /* 
 	   * I am holding the csect, and reenter it again as writer.
 	   * Note that rwlock will be decremented.
 	   */
+	  csect->stats->nreenter++;
 	  break;
 	}
       else
 	{
 	  if (wait_secs == INF_WAIT)
 	    {
-	      cs_ptr->waiting_writers++;
-	      cs_ptr->total_nwaits++;
+	      csect->waiting_writers++;
+	      csect->stats->nwait++;
 
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_start_tick);
 		}
 
-	      error_code = csect_wait_on_writer_queue (thread_p, cs_ptr, INF_WAIT, NULL);
+	      error_code = csect_wait_on_writer_queue (thread_p, csect, INF_WAIT, NULL);
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_end_tick);
@@ -611,10 +534,10 @@ csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
 		  TSC_ADD_TIMEVAL (thread_p->event_stats.cs_waits, wait_tv_diff);
 		}
 
-	      cs_ptr->waiting_writers--;
+	      csect->waiting_writers--;
 	      if (error_code != NO_ERROR)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -625,17 +548,17 @@ csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
 		  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_WAIT, 0);
 		  return ER_CSS_PTHREAD_COND_WAIT;
 		}
-	      if (cs_ptr->owner != ((pthread_t) 0) && cs_ptr->waiting_writers > 0)
+	      if (csect->owner != ((pthread_t) 0) && csect->waiting_writers > 0)
 		{
 		  /* 
 		   * There's one waiting to be promoted.
 		   * Note that 'owner' was not reset while demoting.
 		   * I have to yield to the waiter
 		   */
-		  error_code = csect_wakeup_waiting_promoter (cs_ptr);
+		  error_code = csect_wakeup_waiting_promoter (csect);
 		  if (error_code != NO_ERROR)
 		    {
-		      r = pthread_mutex_unlock (&cs_ptr->lock);
+		      r = pthread_mutex_unlock (&csect->lock);
 		      if (r != NO_ERROR)
 			{
 			  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -655,14 +578,14 @@ csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
 	      to.tv_sec = time (NULL) + wait_secs;
 	      to.tv_nsec = 0;
 
-	      cs_ptr->waiting_writers++;
+	      csect->waiting_writers++;
 
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_start_tick);
 		}
 
-	      error_code = csect_wait_on_writer_queue (thread_p, cs_ptr, NOT_WAIT, &to);
+	      error_code = csect_wait_on_writer_queue (thread_p, csect, NOT_WAIT, &to);
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_end_tick);
@@ -670,10 +593,10 @@ csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
 		  TSC_ADD_TIMEVAL (thread_p->event_stats.cs_waits, wait_tv_diff);
 		}
 
-	      cs_ptr->waiting_writers--;
+	      csect->waiting_writers--;
 	      if (error_code != NO_ERROR)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -692,7 +615,7 @@ csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
 	    }
 	  else
 	    {
-	      error_code = pthread_mutex_unlock (&cs_ptr->lock);
+	      error_code = pthread_mutex_unlock (&csect->lock);
 	      if (error_code != NO_ERROR)
 		{
 		  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -705,23 +628,17 @@ csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
     }
 
   /* rwlock will be < 0. It denotes that a writer owns the csect. */
-  cs_ptr->rwlock--;
+  csect->rwlock--;
 
   /* record that I am the writer of the csect. */
-  cs_ptr->owner = thread_p->tid;
-  cs_ptr->tran_index = thread_p->tran_index;
+  csect->owner = thread_p->tid;
+  csect->tran_index = thread_p->tran_index;
 
-#if defined (EnableThreadMonitoring)
-  if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
-    {
-      tsc_getticks (&end_tick);
-      tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
-      TOTAL_AND_MAX_TIMEVAL (cs_ptr->total_wait, cs_ptr->max_wait, tv_diff);
-    }
-#endif
+  tsc_getticks (&end_tick);
+  tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
+  TOTAL_AND_MAX_TIMEVAL (csect->stats->total_elapsed, csect->stats->max_elapsed, tv_diff);
 
-  error_code = pthread_mutex_unlock (&cs_ptr->lock);
-
+  error_code = pthread_mutex_unlock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -729,22 +646,20 @@ csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
       return ER_CSS_PTHREAD_MUTEX_UNLOCK;
     }
 
-#if defined (EnableThreadMonitoring)
-  if (MONITOR_WAITING_THREAD (elapsed_time))
+  if (MONITOR_WAITING_THREAD (tv_diff))
     {
-      if (cs_ptr->cs_index > 0)
+      if (csect->cs_index > 0)
 	{
-	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, cs_ptr->name,
+	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, csect->name,
 		  prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
 	}
       er_log_debug (ARG_FILE_LINE,
 		    "csect_enter_critical_section_as_reader: %6d.%06d"
-		    " %s total_enter %d total_nwaits %d max_wait %d.%06d total_wait %d.06d\n", elapsed_time.tv_sec,
-		    elapsed_time.tv_usec, cs_ptr->name, cs_ptr->total_enter, cs_ptr->total_nwaits,
-		    cs_ptr->max_wait.tv_sec, cs_ptr->max_wait.tv_usec, cs_ptr->total_wait.tv_sec,
-		    cs_ptr->total_wait.tv_usec);
+		    " %s total_enter %d ntotal_elapsed %d max_elapsed %d.%06d total_elapsed %d.06d\n", tv_diff.tv_sec,
+		    tv_diff.tv_usec, csect->name, csect->stats->nenter, csect->stats->nwait,
+		    csect->stats->max_elapsed.tv_sec, csect->stats->max_elapsed.tv_usec,
+		    csect->stats->total_elapsed.tv_sec, csect->stats->total_elapsed.tv_usec);
     }
-#endif
 
   return NO_ERROR;
 }
@@ -762,37 +677,35 @@ csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * c
 int
 csect_enter (THREAD_ENTRY * thread_p, int cs_index, int wait_secs)
 {
-  SYNC_CRITICAL_SECTION *cs_ptr;
+  SYNC_CRITICAL_SECTION *csect;
 
   assert (cs_index >= 0);
   assert (cs_index < CRITICAL_SECTION_COUNT);
 
-  cs_ptr = &csectgl_Critical_sections[cs_index];
+  csect = &csectgl_Critical_sections[cs_index];
 #if defined (SERVER_MODE)
-  assert (cs_ptr->cs_index == cs_index);
+  assert (csect->cs_index == cs_index);
 #endif
 
-  return csect_enter_critical_section (thread_p, cs_ptr, wait_secs);
+  return csect_enter_critical_section (thread_p, csect, wait_secs);
 }
 
 /*
  * csect_enter_critical_section_as_reader () - acquire a read lock
  *   return: 0 if success, or error code
- *   cs_ptr(in): critical section
+ *   csect(in): critical section
  *   wait_secs(in): timeout second
  */
 int
-csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int wait_secs)
+csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect, int wait_secs)
 {
   int error_code = NO_ERROR, r;
-#if defined (EnableThreadMonitoring)
   TSC_TICKS start_tick, end_tick;
   TSCTIMEVAL tv_diff;
-#endif
   TSC_TICKS wait_start_tick, wait_end_tick;
   TSCTIMEVAL wait_tv_diff;
 
-  assert (cs_ptr != NULL);
+  assert (csect != NULL);
 
   if (thread_p == NULL)
     {
@@ -800,20 +713,15 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
     }
 
 #if !defined (NDEBUG)
-  thread_rc_track_meter (thread_p, __FILE__, __LINE__, THREAD_TRACK_CSECT_ENTER_AS_READER, &(cs_ptr->cs_index), RC_CS,
+  thread_rc_track_meter (thread_p, __FILE__, __LINE__, THREAD_TRACK_CSECT_ENTER_AS_READER, &(csect->cs_index), RC_CS,
 			 MGR_DEF);
 #endif /* NDEBUG */
 
-  cs_ptr->total_enter++;
+  csect->stats->nenter++;
 
-#if defined (EnableThreadMonitoring)
-  if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
-    {
-      tsc_getticks (&start_tick);
-    }
-#endif
+  tsc_getticks (&start_tick);
 
-  error_code = pthread_mutex_lock (&cs_ptr->lock);
+  error_code = pthread_mutex_lock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_LOCK, 0);
@@ -821,21 +729,22 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
       return ER_CSS_PTHREAD_MUTEX_LOCK;
     }
 
-  if (cs_ptr->rwlock < 0 && cs_ptr->owner == thread_p->tid)
+  if (csect->rwlock < 0 && csect->owner == thread_p->tid)
     {
       /* writer reenters the csect as a reader. treat as writer. */
-      cs_ptr->rwlock--;
+      csect->rwlock--;
+      csect->stats->nreenter++;
     }
   else
     {
       /* reader can enter this csect without waiting writer(s) when the csect had been demoted by the other */
-      while (cs_ptr->rwlock < 0 || (cs_ptr->waiting_writers > 0 && cs_ptr->owner == ((pthread_t) 0)))
+      while (csect->rwlock < 0 || (csect->waiting_writers > 0 && csect->owner == ((pthread_t) 0)))
 	{
 	  /* reader should wait writer(s). */
 	  if (wait_secs == INF_WAIT)
 	    {
-	      cs_ptr->waiting_readers++;
-	      cs_ptr->total_nwaits++;
+	      csect->waiting_readers++;
+	      csect->stats->nwait++;
 	      thread_p->resume_status = THREAD_CSECT_READER_SUSPENDED;
 
 	      if (thread_p->event_stats.trace_slow_query == true)
@@ -843,7 +752,7 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
 		  tsc_getticks (&wait_start_tick);
 		}
 
-	      error_code = pthread_cond_wait (&cs_ptr->readers_ok, &cs_ptr->lock);
+	      error_code = pthread_cond_wait (&csect->readers_ok, &csect->lock);
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_end_tick);
@@ -851,11 +760,11 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
 		  TSC_ADD_TIMEVAL (thread_p->event_stats.cs_waits, wait_tv_diff);
 		}
 
-	      cs_ptr->waiting_readers--;
+	      csect->waiting_readers--;
 
 	      if (error_code != NO_ERROR)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_LOCK, 0);
@@ -868,7 +777,7 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
 		}
 	      if (thread_p->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -884,7 +793,7 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
 	      to.tv_sec = time (NULL) + wait_secs;
 	      to.tv_nsec = 0;
 
-	      cs_ptr->waiting_readers++;
+	      csect->waiting_readers++;
 	      thread_p->resume_status = THREAD_CSECT_READER_SUSPENDED;
 
 	      if (thread_p->event_stats.trace_slow_query == true)
@@ -892,7 +801,7 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
 		  tsc_getticks (&wait_start_tick);
 		}
 
-	      error_code = pthread_cond_timedwait (&cs_ptr->readers_ok, &cs_ptr->lock, &to);
+	      error_code = pthread_cond_timedwait (&csect->readers_ok, &csect->lock, &to);
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_end_tick);
@@ -900,11 +809,11 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
 		  TSC_ADD_TIMEVAL (thread_p->event_stats.cs_waits, wait_tv_diff);
 		}
 
-	      cs_ptr->waiting_readers--;
+	      csect->waiting_readers--;
 
 	      if (error_code != 0)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -921,7 +830,7 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
 		}
 	      if (thread_p->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -933,7 +842,7 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
 	    }
 	  else
 	    {
-	      error_code = pthread_mutex_unlock (&cs_ptr->lock);
+	      error_code = pthread_mutex_unlock (&csect->lock);
 	      if (error_code != NO_ERROR)
 		{
 		  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -945,19 +854,14 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
 	}
 
       /* rwlock will be > 0. record that a reader enters the csect. */
-      cs_ptr->rwlock++;
+      csect->rwlock++;
     }
 
-#if defined (EnableThreadMonitoring)
-  if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
-    {
-      tsc_getticks (&end_tick);
-      tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
-      TOTAL_AND_MAX_TIMEVAL (cs_ptr->total_wait, cs_ptr->max_wait, tv_diff);
-    }
-#endif
+  tsc_getticks (&end_tick);
+  tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
+  TOTAL_AND_MAX_TIMEVAL (csect->stats->total_elapsed, csect->stats->max_elapsed, tv_diff);
 
-  error_code = pthread_mutex_unlock (&cs_ptr->lock);
+  error_code = pthread_mutex_unlock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -965,21 +869,20 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
       return ER_CSS_PTHREAD_MUTEX_UNLOCK;
     }
 
-#if defined (EnableThreadMonitoring)
-  if (MONITOR_WAITING_THREAD (elapsed_time))
+  if (MONITOR_WAITING_THREAD (tv_diff))
     {
-      if (cs_ptr->cs_index > 0)
+      if (csect->cs_index > 0)
 	{
-	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, cs_ptr->name,
+	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, csect->name,
 		  prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
 	}
       er_log_debug (ARG_FILE_LINE,
-		    "csect_enter_critical_section: %6d.%06d %s total_enter %d total_nwaits %d max_wait %d.%06d"
-		    " total_wait %d.06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec, cs_ptr->name,
-		    cs_ptr->total_enter, cs_ptr->total_nwaits, cs_ptr->max_wait.tv_sec, cs_ptr->max_wait.tv_usec,
-		    cs_ptr->total_wait.tv_sec, cs_ptr->total_wait.tv_usec);
+		    "csect_enter_critical_section: %6d.%06d %s total_enter %d ntotal_elapsed %d max_elapsed %d.%06d"
+		    " total_elapsed %d.06d\n", tv_diff.tv_sec, tv_diff.tv_usec, csect->name,
+		    csect->stats->nenter, csect->stats->nwait, csect->stats->max_elapsed.tv_sec,
+		    csect->stats->max_elapsed.tv_usec, csect->stats->total_elapsed.tv_sec,
+		    csect->stats->total_elapsed.tv_usec);
     }
-#endif
 
   return NO_ERROR;
 }
@@ -995,39 +898,37 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
 int
 csect_enter_as_reader (THREAD_ENTRY * thread_p, int cs_index, int wait_secs)
 {
-  SYNC_CRITICAL_SECTION *cs_ptr;
+  SYNC_CRITICAL_SECTION *csect;
 
   assert (cs_index >= 0);
   assert (cs_index < CRITICAL_SECTION_COUNT);
 
-  cs_ptr = &csectgl_Critical_sections[cs_index];
+  csect = &csectgl_Critical_sections[cs_index];
 #if defined (SERVER_MODE)
-  assert (cs_ptr->cs_index == cs_index);
+  assert (csect->cs_index == cs_index);
 #endif
 
-  return csect_enter_critical_section_as_reader (thread_p, cs_ptr, wait_secs);
+  return csect_enter_critical_section_as_reader (thread_p, csect, wait_secs);
 }
 
 /*
  * csect_demote_critical_section () - acquire a read lock when it has write lock
  *   return: 0 if success, or error code
- *   cs_ptr(in): critical section
+ *   csect(in): critical section
  *   wait_secs(in): timeout second
  *
  * Note: Always successful because I have the write lock.
  */
 static int
-csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int wait_secs)
+csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect, int wait_secs)
 {
   int error_code = NO_ERROR, r;
-#if defined (EnableThreadMonitoring)
   TSC_TICKS start_tick, end_tick;
   TSCTIMEVAL tv_diff;
-#endif
   TSC_TICKS wait_start_tick, wait_end_tick;
   TSCTIMEVAL wait_tv_diff;
 
-  assert (cs_ptr != NULL);
+  assert (csect != NULL);
 
   if (thread_p == NULL)
     {
@@ -1035,19 +936,14 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
     }
 
 #if !defined (NDEBUG)
-  thread_rc_track_meter (thread_p, __FILE__, __LINE__, THREAD_TRACK_CSECT_DEMOTE, &(cs_ptr->cs_index), RC_CS, MGR_DEF);
+  thread_rc_track_meter (thread_p, __FILE__, __LINE__, THREAD_TRACK_CSECT_DEMOTE, &(csect->cs_index), RC_CS, MGR_DEF);
 #endif /* NDEBUG */
 
-  cs_ptr->total_enter++;
+  csect->stats->nenter++;
 
-#if defined (EnableThreadMonitoring)
-  if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
-    {
-      tsc_getticks (&start_tick);
-    }
-#endif
+  tsc_getticks (&start_tick);
 
-  error_code = pthread_mutex_lock (&cs_ptr->lock);
+  error_code = pthread_mutex_lock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_LOCK, 0);
@@ -1055,7 +951,7 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
       return ER_CSS_PTHREAD_MUTEX_LOCK;
     }
 
-  if (cs_ptr->rwlock < 0 && cs_ptr->owner == thread_p->tid)
+  if (csect->rwlock < 0 && csect->owner == thread_p->tid)
     {
       /* 
        * I have write lock. I was entered before as a writer.
@@ -1064,22 +960,22 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
        * a writer.
        */
 
-      cs_ptr->rwlock++;		/* releasing */
-      if (cs_ptr->rwlock < 0)
+      csect->rwlock++;		/* releasing */
+      if (csect->rwlock < 0)
 	{
 	  /* 
 	   * In the middle of an outer critical section, it is not possible
 	   * to be a reader. Treat as same as csect_enter_critical_section_as_reader().
 	   */
-	  cs_ptr->rwlock--;	/* entering as a writer */
+	  csect->rwlock--;	/* entering as a writer */
 	}
       else
 	{
 	  /* rwlock == 0 */
-	  cs_ptr->rwlock++;	/* entering as a reader */
+	  csect->rwlock++;	/* entering as a reader */
 #if 0
-	  cs_ptr->owner = (pthread_t) 0;
-	  cs_ptr->tran_index = -1;
+	  csect->owner = (pthread_t) 0;
+	  csect->tran_index = -1;
 #endif
 	}
     }
@@ -1088,13 +984,13 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
       /* 
        * I don't have write lock. Act like a normal reader request.
        */
-      while (cs_ptr->rwlock < 0 || cs_ptr->waiting_writers > 0)
+      while (csect->rwlock < 0 || csect->waiting_writers > 0)
 	{
 	  /* reader should wait writer(s). */
 	  if (wait_secs == INF_WAIT)
 	    {
-	      cs_ptr->waiting_readers++;
-	      cs_ptr->total_nwaits++;
+	      csect->waiting_readers++;
+	      csect->stats->nwait++;
 	      thread_p->resume_status = THREAD_CSECT_READER_SUSPENDED;
 
 	      if (thread_p->event_stats.trace_slow_query == true)
@@ -1102,7 +998,7 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
 		  tsc_getticks (&wait_start_tick);
 		}
 
-	      error_code = pthread_cond_wait (&cs_ptr->readers_ok, &cs_ptr->lock);
+	      error_code = pthread_cond_wait (&csect->readers_ok, &csect->lock);
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_end_tick);
@@ -1110,11 +1006,11 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
 		  TSC_ADD_TIMEVAL (thread_p->event_stats.cs_waits, wait_tv_diff);
 		}
 
-	      cs_ptr->waiting_readers--;
+	      csect->waiting_readers--;
 
 	      if (error_code != NO_ERROR)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_LOCK, 0);
@@ -1127,7 +1023,7 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
 		}
 	      if (thread_p->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1143,7 +1039,7 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
 	      to.tv_sec = time (NULL) + wait_secs;
 	      to.tv_nsec = 0;
 
-	      cs_ptr->waiting_readers++;
+	      csect->waiting_readers++;
 	      thread_p->resume_status = THREAD_CSECT_READER_SUSPENDED;
 
 	      if (thread_p->event_stats.trace_slow_query == true)
@@ -1151,7 +1047,7 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
 		  tsc_getticks (&wait_start_tick);
 		}
 
-	      error_code = pthread_cond_timedwait (&cs_ptr->readers_ok, &cs_ptr->lock, &to);
+	      error_code = pthread_cond_timedwait (&csect->readers_ok, &csect->lock, &to);
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_end_tick);
@@ -1159,11 +1055,11 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
 		  TSC_ADD_TIMEVAL (thread_p->event_stats.cs_waits, wait_tv_diff);
 		}
 
-	      cs_ptr->waiting_readers--;
+	      csect->waiting_readers--;
 
 	      if (error_code != 0)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1180,7 +1076,7 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
 		}
 	      if (thread_p->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1192,7 +1088,7 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
 	    }
 	  else
 	    {
-	      error_code = pthread_mutex_unlock (&cs_ptr->lock);
+	      error_code = pthread_mutex_unlock (&csect->lock);
 	      if (error_code != NO_ERROR)
 		{
 		  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1204,23 +1100,18 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
 	}
 
       /* rwlock will be > 0. record that a reader enters the csect. */
-      cs_ptr->rwlock++;
+      csect->rwlock++;
     }
 
-#if defined (EnableThreadMonitoring)
-  if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
-    {
-      tsc_getticks (&end_tick);
-      tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
-      TOTAL_AND_MAX_TIMEVAL (cs_ptr->total_wait, cs_ptr->max_wait, tv_diff);
-    }
-#endif
+  tsc_getticks (&end_tick);
+  tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
+  TOTAL_AND_MAX_TIMEVAL (csect->stats->total_elapsed, csect->stats->max_elapsed, tv_diff);
 
   /* Someone can wait for being reader. Wakeup all readers. */
-  error_code = pthread_cond_broadcast (&cs_ptr->readers_ok);
+  error_code = pthread_cond_broadcast (&csect->readers_ok);
   if (error_code != NO_ERROR)
     {
-      r = pthread_mutex_unlock (&cs_ptr->lock);
+      r = pthread_mutex_unlock (&csect->lock);
       if (r != NO_ERROR)
 	{
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1233,7 +1124,7 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
       return ER_CSS_PTHREAD_COND_BROADCAST;
     }
 
-  error_code = pthread_mutex_unlock (&cs_ptr->lock);
+  error_code = pthread_mutex_unlock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1241,21 +1132,20 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
       return ER_CSS_PTHREAD_MUTEX_UNLOCK;
     }
 
-#if defined (EnableThreadMonitoring)
-  if (MONITOR_WAITING_THREAD (elapsed_time))
+  if (MONITOR_WAITING_THREAD (tv_diff))
     {
-      if (cs_ptr->cs_index > 0)
+      if (csect->cs_index > 0)
 	{
-	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, cs_ptr->name,
+	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, csect->name,
 		  prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
 	}
       er_log_debug (ARG_FILE_LINE,
-		    "csect_demote_critical_section: %6d.%06d %s total_enter %d total_nwaits %d max_wait %d.%06d"
-		    " total_wait %d.06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec, cs_ptr->name,
-		    cs_ptr->total_enter, cs_ptr->total_nwaits, cs_ptr->max_wait.tv_sec, cs_ptr->max_wait.tv_usec,
-		    cs_ptr->total_wait.tv_sec, cs_ptr->total_wait.tv_usec);
+		    "csect_demote_critical_section: %6d.%06d %s total_enter %d ntotal_elapsed %d max_elapsed %d.%06d"
+		    " total_elapsed %d.06d\n", tv_diff.tv_sec, tv_diff.tv_usec, csect->name,
+		    csect->stats->nenter, csect->stats->nwait, csect->stats->max_elapsed.tv_sec,
+		    csect->stats->max_elapsed.tv_usec, csect->stats->total_elapsed.tv_sec,
+		    csect->stats->total_elapsed.tv_usec);
     }
-#endif
 
   return NO_ERROR;
 }
@@ -1271,35 +1161,33 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
 int
 csect_demote (THREAD_ENTRY * thread_p, int cs_index, int wait_secs)
 {
-  SYNC_CRITICAL_SECTION *cs_ptr;
+  SYNC_CRITICAL_SECTION *csect;
 
   assert (cs_index >= 0);
   assert (cs_index < CRITICAL_SECTION_COUNT);
 
-  cs_ptr = &csectgl_Critical_sections[cs_index];
-  return csect_demote_critical_section (thread_p, cs_ptr, wait_secs);
+  csect = &csectgl_Critical_sections[cs_index];
+  return csect_demote_critical_section (thread_p, csect, wait_secs);
 }
 
 /*
  * csect_promote_critical_section () - acquire a write lock when it has read lock
  *   return: 0 if success, or error code
- *   cs_ptr(in): critical section
+ *   csect(in): critical section
  *   wait_secs(in): timeout second
  *
  * Note: Always successful because I have the write lock.
  */
 static int
-csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int wait_secs)
+csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect, int wait_secs)
 {
   int error_code = NO_ERROR, r;
-#if defined (EnableThreadMonitoring)
   TSC_TICKS start_tick, end_tick;
   TSCTIMEVAL tv_diff;
-#endif
   TSC_TICKS wait_start_tick, wait_end_tick;
   TSCTIMEVAL wait_tv_diff;
 
-  assert (cs_ptr != NULL);
+  assert (csect != NULL);
 
   if (thread_p == NULL)
     {
@@ -1307,19 +1195,14 @@ csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION *
     }
 
 #if !defined (NDEBUG)
-  thread_rc_track_meter (thread_p, __FILE__, __LINE__, THREAD_TRACK_CSECT_PROMOTE, &(cs_ptr->cs_index), RC_CS, MGR_DEF);
+  thread_rc_track_meter (thread_p, __FILE__, __LINE__, THREAD_TRACK_CSECT_PROMOTE, &(csect->cs_index), RC_CS, MGR_DEF);
 #endif /* NDEBUG */
 
-  cs_ptr->total_enter++;
+  csect->stats->nenter++;
 
-#if defined (EnableThreadMonitoring)
-  if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
-    {
-      tsc_getticks (&start_tick);
-    }
-#endif
+  tsc_getticks (&start_tick);
 
-  error_code = pthread_mutex_lock (&cs_ptr->lock);
+  error_code = pthread_mutex_lock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_LOCK, 0);
@@ -1327,25 +1210,26 @@ csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION *
       return ER_CSS_PTHREAD_MUTEX_LOCK;
     }
 
-  if (cs_ptr->rwlock > 0)
+  if (csect->rwlock > 0)
     {
       /* 
        * I am a reader so that no writer is in this csect but reader(s) could be.
        * All writers are waiting on 'writers_queue' with 'waiting_writers++'.
        */
-      cs_ptr->rwlock--;		/* releasing */
+      csect->rwlock--;		/* releasing */
     }
   else
     {
-      cs_ptr->rwlock++;		/* releasing */
+      csect->rwlock++;		/* releasing */
       /* 
        * I don't have read lock. Act like a normal writer request.
        */
     }
-  while (cs_ptr->rwlock != 0)
+
+  while (csect->rwlock != 0)
     {
       /* There's another readers. So I have to wait as a writer. */
-      if (cs_ptr->rwlock < 0 && cs_ptr->owner == thread_p->tid)
+      if (csect->rwlock < 0 && csect->owner == thread_p->tid)
 	{
 	  /* 
 	   * I am holding the csect, and reenter it again as writer.
@@ -1357,15 +1241,15 @@ csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION *
 	{
 	  if (wait_secs == INF_WAIT)
 	    {
-	      cs_ptr->waiting_writers++;
-	      cs_ptr->total_nwaits++;
+	      csect->waiting_writers++;
+	      csect->stats->nwait++;
 
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_start_tick);
 		}
 
-	      error_code = csect_wait_on_promoter_queue (thread_p, cs_ptr, INF_WAIT, NULL);
+	      error_code = csect_wait_on_promoter_queue (thread_p, csect, INF_WAIT, NULL);
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_end_tick);
@@ -1373,10 +1257,10 @@ csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION *
 		  TSC_ADD_TIMEVAL (thread_p->event_stats.cs_waits, wait_tv_diff);
 		}
 
-	      cs_ptr->waiting_writers--;
+	      csect->waiting_writers--;
 	      if (error_code != NO_ERROR)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1394,14 +1278,14 @@ csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION *
 	      to.tv_sec = time (NULL) + wait_secs;
 	      to.tv_nsec = 0;
 
-	      cs_ptr->waiting_writers++;
+	      csect->waiting_writers++;
 
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_start_tick);
 		}
 
-	      error_code = csect_wait_on_promoter_queue (thread_p, cs_ptr, NOT_WAIT, &to);
+	      error_code = csect_wait_on_promoter_queue (thread_p, csect, NOT_WAIT, &to);
 	      if (thread_p->event_stats.trace_slow_query == true)
 		{
 		  tsc_getticks (&wait_end_tick);
@@ -1409,10 +1293,10 @@ csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION *
 		  TSC_ADD_TIMEVAL (thread_p->event_stats.cs_waits, wait_tv_diff);
 		}
 
-	      cs_ptr->waiting_writers--;
+	      csect->waiting_writers--;
 	      if (error_code != NO_ERROR)
 		{
-		  r = pthread_mutex_unlock (&cs_ptr->lock);
+		  r = pthread_mutex_unlock (&csect->lock);
 		  if (r != NO_ERROR)
 		    {
 		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1430,7 +1314,7 @@ csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION *
 	    }
 	  else
 	    {
-	      error_code = pthread_mutex_unlock (&cs_ptr->lock);
+	      error_code = pthread_mutex_unlock (&csect->lock);
 	      if (error_code != NO_ERROR)
 		{
 		  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1443,21 +1327,16 @@ csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION *
     }
 
   /* rwlock will be < 0. It denotes that a writer owns the csect. */
-  cs_ptr->rwlock--;
+  csect->rwlock--;
   /* record that I am the writer of the csect. */
-  cs_ptr->owner = thread_p->tid;
-  cs_ptr->tran_index = thread_p->tran_index;
+  csect->owner = thread_p->tid;
+  csect->tran_index = thread_p->tran_index;
 
-#if defined (EnableThreadMonitoring)
-  if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
-    {
-      tsc_getticks (&end_tick);
-      tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
-      TOTAL_AND_MAX_TIMEVAL (cs_ptr->total_wait, rwlock->max_wait, tv_diff);
-    }
-#endif
+  tsc_getticks (&end_tick);
+  tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
+  TOTAL_AND_MAX_TIMEVAL (csect->stats->total_elapsed, csect->stats->max_elapsed, tv_diff);
 
-  error_code = pthread_mutex_unlock (&cs_ptr->lock);
+  error_code = pthread_mutex_unlock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1465,21 +1344,20 @@ csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION *
       return ER_CSS_PTHREAD_MUTEX_UNLOCK;
     }
 
-#if defined (EnableThreadMonitoring)
-  if (MONITOR_WAITING_THREAD (elapsed_time))
+  if (MONITOR_WAITING_THREAD (tv_diff))
     {
-      if (cs_ptr->cs_index > 0)
+      if (csect->cs_index > 0)
 	{
-	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, cs_ptr->name,
+	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, csect->name,
 		  prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
 	}
       er_log_debug (ARG_FILE_LINE,
-		    "csect_promote_critical_section: %6d.%06d %s total_enter %d total_nwaits %d max_wait %d.%06d"
-		    " total_wait %d.06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec, cs_ptr->name,
-		    cs_ptr->total_enter, cs_ptr->total_nwaits, cs_ptr->max_wait.tv_sec, cs_ptr->max_wait.tv_usec,
-		    cs_ptr->total_wait.tv_sec, cs_ptr->total_wait.tv_usec);
+		    "csect_promote_critical_section: %6d.%06d %s total_enter %d ntotal_elapsed %d max_elapsed %d.%06d"
+		    " total_elapsed %d.06d\n", tv_diff.tv_sec, tv_diff.tv_usec, csect->name,
+		    csect->stats->nenter, csect->stats->nwait, csect->stats->max_elapsed.tv_sec,
+		    csect->stats->max_elapsed.tv_usec, csect->stats->total_elapsed.tv_sec,
+		    csect->stats->total_elapsed.tv_usec);
     }
-#endif
 
   return NO_ERROR;
 }
@@ -1495,27 +1373,27 @@ csect_promote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION *
 int
 csect_promote (THREAD_ENTRY * thread_p, int cs_index, int wait_secs)
 {
-  SYNC_CRITICAL_SECTION *cs_ptr;
+  SYNC_CRITICAL_SECTION *csect;
 
   assert (cs_index >= 0);
   assert (cs_index < CRITICAL_SECTION_COUNT);
 
-  cs_ptr = &csectgl_Critical_sections[cs_index];
-  return csect_promote_critical_section (thread_p, cs_ptr, wait_secs);
+  csect = &csectgl_Critical_sections[cs_index];
+  return csect_promote_critical_section (thread_p, csect, wait_secs);
 }
 
 /*
  * csect_exit_critical_section() - unlock critical section
  *   return:  0 if success, or error code
- *   cs_ptr(in): critical section
+ *   csect(in): critical section
  */
 int
-csect_exit_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr)
+csect_exit_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect)
 {
   int error_code = NO_ERROR;
   bool ww, wr, wp;
 
-  assert (cs_ptr != NULL);
+  assert (csect != NULL);
 
   if (thread_p == NULL)
     {
@@ -1523,10 +1401,10 @@ csect_exit_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs
     }
 
 #if !defined (NDEBUG)
-  thread_rc_track_meter (thread_p, __FILE__, __LINE__, THREAD_TRACK_CSECT_EXIT, &(cs_ptr->cs_index), RC_CS, MGR_DEF);
+  thread_rc_track_meter (thread_p, __FILE__, __LINE__, THREAD_TRACK_CSECT_EXIT, &(csect->cs_index), RC_CS, MGR_DEF);
 #endif /* NDEBUG */
 
-  error_code = pthread_mutex_lock (&cs_ptr->lock);
+  error_code = pthread_mutex_lock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_LOCK, 0);
@@ -1534,13 +1412,13 @@ csect_exit_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs
       return ER_CSS_PTHREAD_MUTEX_LOCK;
     }
 
-  if (cs_ptr->rwlock < 0)
+  if (csect->rwlock < 0)
     {				/* rwlock < 0 if locked for writing */
-      cs_ptr->rwlock++;
-      if (cs_ptr->rwlock < 0)
+      csect->rwlock++;
+      if (csect->rwlock < 0)
 	{
 	  /* in the middle of an outer critical section */
-	  error_code = pthread_mutex_unlock (&cs_ptr->lock);
+	  error_code = pthread_mutex_unlock (&csect->lock);
 	  if (error_code != NO_ERROR)
 	    {
 	      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1551,19 +1429,19 @@ csect_exit_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs
 	}
       else
 	{
-	  assert (cs_ptr->rwlock == 0);
-	  cs_ptr->owner = ((pthread_t) 0);
-	  cs_ptr->tran_index = -1;
+	  assert (csect->rwlock == 0);
+	  csect->owner = ((pthread_t) 0);
+	  csect->tran_index = -1;
 	}
     }
-  else if (cs_ptr->rwlock > 0)
+  else if (csect->rwlock > 0)
     {
-      cs_ptr->rwlock--;
+      csect->rwlock--;
     }
   else
     {
-      /* cs_ptr->rwlock == 0 */
-      error_code = pthread_mutex_unlock (&cs_ptr->lock);
+      /* csect->rwlock == 0 */
+      error_code = pthread_mutex_unlock (&csect->lock);
       if (error_code != NO_ERROR)
 	{
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1580,46 +1458,46 @@ csect_exit_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs
    * Keep flags that show if there are waiting readers or writers
    * so that we can wake them up outside the monitor lock.
    */
-  ww = (cs_ptr->waiting_writers > 0 && cs_ptr->rwlock == 0 && cs_ptr->owner == ((pthread_t) 0));
-  wp = (cs_ptr->waiting_writers > 0 && cs_ptr->rwlock == 0 && cs_ptr->owner != ((pthread_t) 0));
-  wr = (cs_ptr->waiting_writers == 0);
+  ww = (csect->waiting_writers > 0 && csect->rwlock == 0 && csect->owner == ((pthread_t) 0));
+  wp = (csect->waiting_writers > 0 && csect->rwlock == 0 && csect->owner != ((pthread_t) 0));
+  wr = (csect->waiting_writers == 0);
 
   /* wakeup a waiting writer first. Otherwise wakeup all readers. */
   if (wp == true)
     {
-      error_code = csect_wakeup_waiting_promoter (cs_ptr);
+      error_code = csect_wakeup_waiting_promoter (csect);
       if (error_code != NO_ERROR)
 	{
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_SIGNAL, 0);
-	  pthread_mutex_unlock (&cs_ptr->lock);
+	  pthread_mutex_unlock (&csect->lock);
 	  assert (0);
 	  return ER_CSS_PTHREAD_COND_SIGNAL;
 	}
     }
   else if (ww == true)
     {
-      error_code = csect_wakeup_waiting_writer (cs_ptr);
+      error_code = csect_wakeup_waiting_writer (csect);
       if (error_code != NO_ERROR)
 	{
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_SIGNAL, 0);
-	  pthread_mutex_unlock (&cs_ptr->lock);
+	  pthread_mutex_unlock (&csect->lock);
 	  assert (0);
 	  return ER_CSS_PTHREAD_COND_SIGNAL;
 	}
     }
   else
     {
-      error_code = pthread_cond_broadcast (&cs_ptr->readers_ok);
+      error_code = pthread_cond_broadcast (&csect->readers_ok);
       if (error_code != NO_ERROR)
 	{
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_BROADCAST, 0);
-	  pthread_mutex_unlock (&cs_ptr->lock);
+	  pthread_mutex_unlock (&csect->lock);
 	  assert (0);
 	  return ER_CSS_PTHREAD_COND_BROADCAST;
 	}
     }
 
-  error_code = pthread_mutex_unlock (&cs_ptr->lock);
+  error_code = pthread_mutex_unlock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
@@ -1642,17 +1520,17 @@ csect_exit_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs
 int
 csect_exit (THREAD_ENTRY * thread_p, int cs_index)
 {
-  SYNC_CRITICAL_SECTION *cs_ptr;
+  SYNC_CRITICAL_SECTION *csect;
 
   assert (cs_index >= 0);
   assert (cs_index < CRITICAL_SECTION_COUNT);
 
-  cs_ptr = &csectgl_Critical_sections[cs_index];
+  csect = &csectgl_Critical_sections[cs_index];
 #if defined (SERVER_MODE)
-  assert (cs_ptr->cs_index == cs_index);
+  assert (csect->cs_index == cs_index);
 #endif
 
-  return csect_exit_critical_section (thread_p, cs_ptr);
+  return csect_exit_critical_section (thread_p, csect);
 }
 
 /*
@@ -1662,27 +1540,21 @@ csect_exit (THREAD_ENTRY * thread_p, int cs_index)
 void
 csect_dump_statistics (FILE * fp)
 {
-  SYNC_CRITICAL_SECTION *cs_ptr;
+  SYNC_CRITICAL_SECTION *csect;
   int i;
 
-  fprintf (fp, "             CS Name    |Total Enter|Total Wait |   Max Wait    |  Total wait\n");
+  fprintf (fp, "         CS Name        |Total Enter|Total Wait |Total Reenter|   Max elapsed |  Total elapsed\n");
 
   for (i = 0; i < CRITICAL_SECTION_COUNT; i++)
     {
-      cs_ptr = &csectgl_Critical_sections[i];
+      csect = &csectgl_Critical_sections[i];
 
-      fprintf (fp, "%23s |%10d |%10d | %6ld.%06ld | %6ld.%06ld\n", cs_ptr->name, cs_ptr->total_enter,
-	       cs_ptr->total_nwaits, cs_ptr->max_wait.tv_sec, cs_ptr->max_wait.tv_usec, cs_ptr->total_wait.tv_sec,
-	       cs_ptr->total_wait.tv_usec);
+      fprintf (fp, "%-23s |%10d |%10d |  %10d | %6ld.%06ld | %6ld.%06ld\n",
+	       csect->name, csect->stats->nenter, csect->stats->nreenter,
+	       csect->stats->nwait, csect->stats->max_elapsed.tv_sec, csect->stats->max_elapsed.tv_usec,
+	       csect->stats->total_elapsed.tv_sec, csect->stats->total_elapsed.tv_usec);
 
-      cs_ptr->total_enter = 0;
-      cs_ptr->total_nwaits = 0;
-
-      cs_ptr->max_wait.tv_sec = 0;
-      cs_ptr->max_wait.tv_usec = 0;
-
-      cs_ptr->total_wait.tv_sec = 0;
-      cs_ptr->total_wait.tv_usec = 0;
+      sync_reset_stats_metrics (csect->stats);
     }
 
   fflush (fp);
@@ -1697,24 +1569,24 @@ csect_dump_statistics (FILE * fp)
 int
 csect_check_own (THREAD_ENTRY * thread_p, int cs_index)
 {
-  SYNC_CRITICAL_SECTION *cs_ptr;
+  SYNC_CRITICAL_SECTION *csect;
   int error_code = NO_ERROR;
 
   assert (cs_index >= 0);
   assert (cs_index < CRITICAL_SECTION_COUNT);
 
-  cs_ptr = &csectgl_Critical_sections[cs_index];
+  csect = &csectgl_Critical_sections[cs_index];
 
-  return csect_check_own_critical_section (thread_p, cs_ptr);
+  return csect_check_own_critical_section (thread_p, csect);
 }
 
 /*
  * csect_check_own_critical_section() - check if current thread is critical section owner
  *   return: true if cs's owner is me, false if not
- *   cs_ptr(in): critical section
+ *   csect(in): critical section
  */
 static int
-csect_check_own_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr)
+csect_check_own_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * csect)
 {
   int error_code = NO_ERROR, return_code;
 
@@ -1723,7 +1595,7 @@ csect_check_own_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION
       thread_p = thread_get_thread_entry_info ();
     }
 
-  error_code = pthread_mutex_lock (&cs_ptr->lock);
+  error_code = pthread_mutex_lock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_LOCK, 0);
@@ -1731,12 +1603,12 @@ csect_check_own_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION
       return ER_CSS_PTHREAD_MUTEX_LOCK;
     }
 
-  if (cs_ptr->rwlock < 0 && cs_ptr->owner == thread_p->tid)
+  if (csect->rwlock < 0 && csect->owner == thread_p->tid)
     {
       /* has the write lock */
       return_code = 1;
     }
-  else if (cs_ptr->rwlock > 0)
+  else if (csect->rwlock > 0)
     {
       /* has the read lock */
       return_code = 2;
@@ -1746,7 +1618,7 @@ csect_check_own_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION
       return_code = 0;
     }
 
-  error_code = pthread_mutex_unlock (&cs_ptr->lock);
+  error_code = pthread_mutex_unlock (&csect->lock);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_LOCK, 0);
@@ -1774,7 +1646,7 @@ csect_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values
   SHOWSTMT_ARRAY_CONTEXT *ctx = NULL;
   int i, idx, error = NO_ERROR;
   DB_VALUE *vals = NULL;
-  SYNC_CRITICAL_SECTION *cs_ptr;
+  SYNC_CRITICAL_SECTION *csect;
   char buf[256] = { 0 };
   double msec;
   DB_VALUE db_val;
@@ -1802,18 +1674,18 @@ csect_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values
 	  goto exit_on_error;
 	}
 
-      cs_ptr = &csectgl_Critical_sections[i];
+      csect = &csectgl_Critical_sections[i];
 
       /* The index of the critical section */
-      db_make_int (&vals[idx], cs_ptr->cs_index);
+      db_make_int (&vals[idx], csect->cs_index);
       idx++;
 
       /* The name of the critical section */
-      db_make_string (&vals[idx], cs_ptr->name);
+      db_make_string (&vals[idx], csect->name);
       idx++;
 
       /* 'N readers', '1 writer', 'none' */
-      ival = cs_ptr->rwlock;
+      ival = csect->rwlock;
       if (ival > 0)
 	{
 	  snprintf (buf, sizeof (buf), "%d readers", ival);
@@ -1835,15 +1707,15 @@ csect_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values
 	}
 
       /* The number of waiting readers */
-      db_make_int (&vals[idx], cs_ptr->waiting_readers);
+      db_make_int (&vals[idx], csect->waiting_readers);
       idx++;
 
       /* The number of waiting writers */
-      db_make_int (&vals[idx], cs_ptr->waiting_writers);
+      db_make_int (&vals[idx], csect->waiting_writers);
       idx++;
 
       /* The thread index of CS owner writer, NULL if no owner */
-      owner_tid = cs_ptr->owner;
+      owner_tid = csect->owner;
       if (owner_tid == 0)
 	{
 	  db_make_null (&vals[idx]);
@@ -1863,7 +1735,7 @@ csect_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values
       idx++;
 
       /* Transaction id of CS owner writer, NULL if no owner */
-      ival = cs_ptr->tran_index;
+      ival = csect->tran_index;
       if (ival == -1)
 	{
 	  db_make_null (&vals[idx]);
@@ -1875,15 +1747,15 @@ csect_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values
       idx++;
 
       /* Total count of enters */
-      db_make_bigint (&vals[idx], cs_ptr->total_enter);
+      db_make_bigint (&vals[idx], csect->stats->nenter);
       idx++;
 
       /* Total count of waiters */
-      db_make_bigint (&vals[idx], cs_ptr->total_nwaits);
+      db_make_bigint (&vals[idx], csect->stats->nwait);
       idx++;
 
       /* The thread index of waiting promoter, NULL if no waiting promoter */
-      thread_entry = cs_ptr->waiting_promoters_queue;
+      thread_entry = csect->waiting_promoters_queue;
       if (thread_entry != NULL)
 	{
 	  db_make_int (&vals[idx], thread_entry->index);
@@ -1895,7 +1767,7 @@ csect_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values
       idx++;
 
       /* Maximum waiting time (millisecond) */
-      msec = cs_ptr->max_wait.tv_sec * 1000 + cs_ptr->max_wait.tv_usec / 1000.0;
+      msec = csect->stats->max_elapsed.tv_sec * 1000 + csect->stats->max_elapsed.tv_usec / 1000.0;
       db_make_double (&db_val, msec);
       db_value_domain_init (&vals[idx], DB_TYPE_NUMERIC, 10, 3);
       error = numeric_db_value_coerce_to_num (&db_val, &vals[idx], &data_status);
@@ -1906,7 +1778,7 @@ csect_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values
 	}
 
       /* Total waiting time (millisecond) */
-      msec = cs_ptr->total_wait.tv_sec * 1000 + cs_ptr->total_wait.tv_usec / 1000.0;
+      msec = csect->stats->total_elapsed.tv_sec * 1000 + csect->stats->total_elapsed.tv_usec / 1000.0;
       db_make_double (&db_val, msec);
       db_value_domain_init (&vals[idx], DB_TYPE_NUMERIC, 10, 3);
       error = numeric_db_value_coerce_to_num (&db_val, &vals[idx], &data_status);
@@ -1939,35 +1811,17 @@ exit_on_error:
  *
  *   rwlock(in/out):
  *   name(in):
- *   for_trace(in): RWLOCK_TRACE to monitor the rwlock. Note that it should be a global SYNC_RWLOCK to be traced.
  */
 int
-rwlock_initialize (SYNC_RWLOCK * rwlock, const char *name, int for_trace)
+rwlock_initialize (SYNC_RWLOCK * rwlock, const char *name)
 {
   int error_code = NO_ERROR;
-  pthread_mutexattr_t mattr;
 
   assert (rwlock != NULL && name != NULL);
-  assert (for_trace == RWLOCK_TRACE || for_trace == RWLOCK_NOT_TRACE);
 
-  error_code = pthread_mutexattr_init (&mattr);
-  if (error_code != NO_ERROR)
-    {
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEXATTR_INIT, 0);
-      assert (0);
-      return ER_CSS_PTHREAD_MUTEXATTR_INIT;
-    }
+  rwlock->stats = NULL;
 
-#ifdef CHECK_MUTEX
-  error_code = pthread_mutexattr_settype (&mattr, PTHREAD_MUTEX_ERRORCHECK);
-  if (error_code != NO_ERROR)
-    {
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEXATTR_SETTYPE, 0);
-      return ER_CSS_PTHREAD_MUTEXATTR_SETTYPE;
-    }
-#endif /* CHECK_MUTEX */
-
-  error_code = pthread_mutex_init (&rwlock->read_lock, &mattr);
+  error_code = pthread_mutex_init (&rwlock->read_lock, NULL);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_INIT, 0);
@@ -1975,20 +1829,12 @@ rwlock_initialize (SYNC_RWLOCK * rwlock, const char *name, int for_trace)
       return ER_CSS_PTHREAD_MUTEX_INIT;
     }
 
-  error_code = pthread_mutex_init (&rwlock->global_lock, &mattr);
+  error_code = pthread_mutex_init (&rwlock->global_lock, NULL);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_INIT, 0);
       assert (0);
       return ER_CSS_PTHREAD_MUTEX_INIT;
-    }
-
-  error_code = pthread_mutexattr_destroy (&mattr);
-  if (error_code != NO_ERROR)
-    {
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEXATTR_DESTROY, 0);
-      assert (0);
-      return ER_CSS_PTHREAD_MUTEXATTR_DESTROY;
     }
 
   rwlock->name = strdup (name);
@@ -1999,19 +1845,12 @@ rwlock_initialize (SYNC_RWLOCK * rwlock, const char *name, int for_trace)
     }
 
   rwlock->num_readers = 0;
-  rwlock->for_trace = for_trace;
 
-  rwlock->total_enter = 0;
-
-  rwlock->max_wait.tv_sec = 0;
-  rwlock->max_wait.tv_usec = 0;
-
-  rwlock->total_wait.tv_sec = 0;
-  rwlock->total_wait.tv_usec = 0;
-
-  if (rwlock->for_trace == RWLOCK_TRACE)
+  rwlock->stats = sync_allocate_sync_stats (SYNC_TYPE_RWLOCK, rwlock->name);
+  if (rwlock->stats == NULL)
     {
-      error_code = rwlock_register_a_rwlock_entry_to_monitor (rwlock);
+      ASSERT_ERROR_AND_SET (error_code);
+      return error_code;
     }
 
   return error_code;
@@ -2053,10 +1892,8 @@ rwlock_finalize (SYNC_RWLOCK * rwlock)
       return ER_CSS_PTHREAD_MUTEX_DESTROY;
     }
 
-  if (rwlock->for_trace == RWLOCK_TRACE)
-    {
-      error_code = rwlock_unregister_a_rwlock_entry_from_monitor (rwlock);
-    }
+  error_code = sync_deallocate_sync_stats (rwlock->stats);
+  rwlock->stats = NULL;
 
   return error_code;
 }
@@ -2108,9 +1945,9 @@ rwlock_read_lock (SYNC_RWLOCK * rwlock)
   /* collect statistics */
   tsc_getticks (&end_tick);
   tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
-  TOTAL_AND_MAX_TIMEVAL (rwlock->total_wait, rwlock->max_wait, tv_diff);
+  TOTAL_AND_MAX_TIMEVAL (rwlock->stats->total_elapsed, rwlock->stats->max_elapsed, tv_diff);
 
-  rwlock->total_enter++;
+  rwlock->stats->nenter++;
 
   /* release the reader lock */
   error_code = pthread_mutex_unlock (&rwlock->read_lock);
@@ -2204,9 +2041,9 @@ rwlock_write_lock (SYNC_RWLOCK * rwlock)
   /* collect statistics */
   tsc_getticks (&end_tick);
   tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
-  TOTAL_AND_MAX_TIMEVAL (rwlock->total_wait, rwlock->max_wait, tv_diff);
+  TOTAL_AND_MAX_TIMEVAL (rwlock->stats->total_elapsed, rwlock->stats->max_elapsed, tv_diff);
 
-  rwlock->total_enter++;
+  rwlock->stats->nenter++;
 
   return NO_ERROR;
 }
@@ -2236,26 +2073,174 @@ rwlock_write_unlock (SYNC_RWLOCK * rwlock)
 }
 
 /*
- * rwlock_initialize_rwlock_monitor () - initialize rwlock monitor
+ * rwlock_dump_statistics() - dump rwlock statistics
+ *   return: void
+ */
+void
+rwlock_dump_statistics (FILE * fp)
+{
+  SYNC_MONITOR *p;
+  SYNC_STATS *stats;
+  int i, cnt;
+
+  fprintf (fp, "\n         RWlock Name         |Total Enter|  Max elapsed  |  Total elapsed\n");
+
+  pthread_mutex_lock (&sync_Monitor_lock);
+
+  p = &sync_Monitor;
+  while (p != NULL)
+    {
+      for (i = 0, cnt = 0; cnt < p->num_entry_in_use && i < NUM_ENTRIES_OF_SYNC_STATS_BLOCK; i++)
+	{
+	  stats = &p->block[i];
+	  if (stats->type == SYNC_TYPE_RWLOCK)
+	    {
+	      cnt++;
+
+	      fprintf (fp, "%-28s |%10d | %6ld.%06ld | %6ld.%06ld\n", stats->name, stats->nenter,
+		       stats->max_elapsed.tv_sec, stats->max_elapsed.tv_usec,
+		       stats->total_elapsed.tv_sec, stats->total_elapsed.tv_usec);
+
+	      /* reset statistics */
+	      sync_reset_stats_metrics (stats);
+	    }
+	}
+
+      p = p->next;
+    }
+
+  pthread_mutex_unlock (&sync_Monitor_lock);
+
+  fflush (fp);
+}
+
+int
+rmutex_initialize (SYNC_RMUTEX * rmutex, const char *name)
+{
+  int error_code = NO_ERROR;
+
+  assert (rmutex != NULL);
+
+  pthread_mutex_init (&rmutex->lock, NULL);
+
+  rmutex->owner = (pthread_t) 0;
+  rmutex->lock_cnt = 0;
+
+  rmutex->stats = sync_allocate_sync_stats (SYNC_TYPE_RMUTEX, name);
+  if (rmutex->stats == NULL)
+    {
+      ASSERT_ERROR_AND_SET (error_code);
+      return error_code;
+    }
+
+  return NO_ERROR;
+}
+
+int
+rmutex_finalize (SYNC_RMUTEX * rmutex)
+{
+  int err;
+
+  assert (rmutex != NULL);
+
+  pthread_mutex_destroy (&rmutex->lock);
+
+  err = sync_deallocate_sync_stats (rmutex->stats);
+  rmutex->stats = NULL;
+
+  return err;
+}
+
+int
+rmutex_lock (THREAD_ENTRY * thread_p, SYNC_RMUTEX * rmutex)
+{
+  TSC_TICKS start_tick, end_tick;
+  TSCTIMEVAL tv_diff;
+
+  assert (thread_p != NULL && rmutex != NULL);
+
+  if (rmutex->owner == thread_p->tid)
+    {
+      assert (rmutex->lock_cnt > 0);
+      rmutex->lock_cnt++;
+
+      rmutex->stats->nenter++;
+      rmutex->stats->nreenter++;
+    }
+  else
+    {
+      tsc_getticks (&start_tick);
+
+      if (pthread_mutex_lock (&rmutex->lock) != NO_ERROR)
+	{
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_LOCK, 0);
+	  assert (0);
+	  return ER_CSS_PTHREAD_MUTEX_LOCK;
+	}
+
+      /* collect statistics */
+      tsc_getticks (&end_tick);
+      tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
+      TOTAL_AND_MAX_TIMEVAL (rmutex->stats->total_elapsed, rmutex->stats->max_elapsed, tv_diff);
+
+      rmutex->stats->nenter++;
+
+      assert (rmutex->lock_cnt == 0);
+      rmutex->lock_cnt++;
+
+      rmutex->owner = thread_p->tid;
+    }
+
+  return NO_ERROR;
+}
+
+int
+rmutex_unlock (THREAD_ENTRY * thread_p, SYNC_RMUTEX * rmutex)
+{
+  assert (thread_p != NULL && rmutex != NULL);
+  assert (rmutex->lock_cnt > 0);
+  assert (rmutex->owner == thread_p->tid);
+
+  rmutex->lock_cnt--;
+
+  if (rmutex->lock_cnt == 0)
+    {
+      rmutex->owner = (pthread_t) 0;
+
+      pthread_mutex_unlock (&rmutex->lock);
+    }
+
+  return NO_ERROR;
+}
+
+static void
+sync_reset_stats_metrics (SYNC_STATS * stats)
+{
+  assert (stats != NULL);
+
+  stats->total_elapsed.tv_sec = 0;
+  stats->total_elapsed.tv_usec = 0;
+
+  stats->max_elapsed.tv_sec = 0;
+  stats->max_elapsed.tv_usec = 0;
+
+  stats->nenter = 0;
+  stats->nwait = 0;
+  stats->nreenter = 0;
+}
+
+/*
+ * sync_initialize_sync_monitor () - initialize synchronization primitives monitor
  *   return: NO_ERROR
  *
  *   called during server startup 
  */
 int
-rwlock_initialize_rwlock_monitor (void)
+sync_initialize_sync_monitor (void)
 {
   int error_code = NO_ERROR;
-  pthread_mutexattr_t mattr;
 
-  error_code = pthread_mutexattr_init (&mattr);
-  if (error_code != NO_ERROR)
-    {
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEXATTR_INIT, 0);
-      assert (0);
-      return ER_CSS_PTHREAD_MUTEXATTR_INIT;
-    }
-
-  error_code = pthread_mutex_init (&rwlock_Monitor.rwlock_monitor_mutex, &mattr);
+  error_code = pthread_mutex_init (&sync_Monitor_lock, NULL);
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_INIT, 0);
@@ -2263,35 +2248,35 @@ rwlock_initialize_rwlock_monitor (void)
       return ER_CSS_PTHREAD_MUTEX_INIT;
     }
 
-  return rwlock_initialize_rwlock_monitor_entry (&rwlock_Monitor);
+  return sync_initialize_sync_monitor_entry (&sync_Monitor);
 }
 
 /*
- * rwlock_finalize_rwlock_monitor () - finalize rwlock monitor
+ * sync_finalize_sync_monitor () - finalize synchronization primitives monitor
  *   return: NO_ERROR
  *
  *   called during server shutdown 
  */
 int
-rwlock_finalize_rwlock_monitor (void)
+sync_finalize_sync_monitor (void)
 {
-  SYNC_RWLOCK_CHUNK *p, *next;
+  SYNC_MONITOR *p, *next;
 
-  p = &rwlock_Monitor;
+  p = &sync_Monitor;
 
   /* the head entry will be kept. */
-  for (p = p->next_chunk; p != NULL; p = next)
+  for (p = p->next; p != NULL; p = next)
     {
-      next = p->next_chunk;
+      next = p->next;
 
       /* may require assertions on the chunk entry here. */
       free_and_init (p);
     }
 
   /* clear the head entry */
-  (void) rwlock_initialize_rwlock_monitor_entry (&rwlock_Monitor);
+  (void) sync_initialize_sync_monitor_entry (&sync_Monitor);
 
-  if (pthread_mutex_destroy (&rwlock_Monitor.rwlock_monitor_mutex) != NO_ERROR)
+  if (pthread_mutex_destroy (&sync_Monitor_lock) != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_DESTROY, 0);
       assert (0);
@@ -2302,118 +2287,130 @@ rwlock_finalize_rwlock_monitor (void)
 }
 
 /*
- * rwlock_allocate_rwlock_chunk_monitor_entry () - allocate a monitor entry
+ * sync_allocate_sync_monitor_entry () - allocate a monitor entry
  *   return: the allocated monitor entry or NULL
  *
  */
-static SYNC_RWLOCK_CHUNK *
-rwlock_allocate_rwlock_chunk_monitor_entry (void)
+static SYNC_MONITOR *
+sync_allocate_sync_monitor_entry (void)
 {
-  SYNC_RWLOCK_CHUNK *p;
+  SYNC_MONITOR *p;
 
-  p = (SYNC_RWLOCK_CHUNK *) malloc (sizeof (SYNC_RWLOCK_CHUNK));
+  p = (SYNC_MONITOR *) malloc (sizeof (SYNC_MONITOR));
   if (p == NULL)
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (SYNC_RWLOCK_CHUNK));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (SYNC_MONITOR));
       return NULL;
     }
 
-  rwlock_initialize_rwlock_monitor_entry (p);
+  sync_initialize_sync_monitor_entry (p);
 
   return p;
 }
 
 /*
- * rwlock_initialize_rwlock_monitor_entry () - initialize a monitor entry
+ * sync_initialize_sync_monitor_entry () - initialize a monitor entry
  *   return: NO_ERROR
  *
  */
 static int
-rwlock_initialize_rwlock_monitor_entry (SYNC_RWLOCK_CHUNK * rwlock_chunk_entry)
+sync_initialize_sync_monitor_entry (SYNC_MONITOR * sync_monitor_entry)
 {
-  assert (rwlock_chunk_entry != NULL);
+  assert (sync_monitor_entry != NULL);
 
-  memset (rwlock_chunk_entry->block, 0, NUM_ENTRIES_OF_RWLOCK_CHUNK);
-  rwlock_chunk_entry->next_chunk = NULL;
-  rwlock_chunk_entry->hint_free_entry_idx = 0;
-  rwlock_chunk_entry->num_entry_in_use = 0;
+  memset (sync_monitor_entry->block, 0, sizeof (SYNC_STATS) * NUM_ENTRIES_OF_SYNC_STATS_BLOCK);
+  sync_monitor_entry->next = NULL;
+  sync_monitor_entry->hint_free_entry_idx = 0;
+  sync_monitor_entry->num_entry_in_use = 0;
 
   return NO_ERROR;
 }
 
 /*
- * rwlock_consume_a_rwlock_monitor_entry () - 
+ * sync_consume_sync_stats_from_pool () - 
+ *   return: stats buffer
+ *
+ */
+static SYNC_STATS *
+sync_consume_sync_stats_from_pool (SYNC_MONITOR * sync_monitor_entry, int idx, SYNC_PRIMITIVE_TYPE sync_prim_type,
+				   const char *name)
+{
+  SYNC_STATS *stats;
+
+  assert (sync_monitor_entry != NULL);
+  assert (sync_prim_type != SYNC_TYPE_NONE);
+  assert (0 <= idx && idx < NUM_ENTRIES_OF_SYNC_STATS_BLOCK);
+  assert (sync_monitor_entry->block[idx].type == SYNC_TYPE_NONE);
+  assert (0 <= sync_monitor_entry->num_entry_in_use
+	  && sync_monitor_entry->num_entry_in_use < NUM_ENTRIES_OF_SYNC_STATS_BLOCK);
+
+  stats = &sync_monitor_entry->block[idx];
+
+  stats->name = name;
+  stats->type = sync_prim_type;
+  sync_reset_stats_metrics (stats);
+
+  sync_monitor_entry->num_entry_in_use++;
+  sync_monitor_entry->hint_free_entry_idx = (idx + 1) % NUM_ENTRIES_OF_SYNC_STATS_BLOCK;
+
+  return stats;
+}
+
+/*
+ * sync_return_sync_stats_to_pool () - 
  *   return: NO_ERROR
  *
  */
 static int
-rwlock_consume_a_rwlock_monitor_entry (SYNC_RWLOCK_CHUNK * rwlock_chunk_entry, int idx, SYNC_RWLOCK * rwlock)
+sync_return_sync_stats_to_pool (SYNC_MONITOR * sync_monitor_entry, int idx)
 {
-  assert (rwlock_chunk_entry != NULL && rwlock != NULL);
-  assert (0 <= idx && idx < NUM_ENTRIES_OF_RWLOCK_CHUNK);
-  assert (rwlock_chunk_entry->block[idx] == NULL);
-  assert (0 <= rwlock_chunk_entry->num_entry_in_use
-	  && rwlock_chunk_entry->num_entry_in_use < NUM_ENTRIES_OF_RWLOCK_CHUNK - 1);
+  assert (sync_monitor_entry != NULL);
+  assert (0 <= idx && idx < NUM_ENTRIES_OF_SYNC_STATS_BLOCK);
+  assert (sync_monitor_entry->block[idx].type != SYNC_TYPE_NONE);
+  assert (0 < sync_monitor_entry->num_entry_in_use
+	  && sync_monitor_entry->num_entry_in_use <= NUM_ENTRIES_OF_SYNC_STATS_BLOCK);
 
-  rwlock_chunk_entry->block[idx] = rwlock;
-  rwlock_chunk_entry->num_entry_in_use++;
-  rwlock_chunk_entry->hint_free_entry_idx = (idx + 1) % NUM_ENTRIES_OF_RWLOCK_CHUNK;
+  sync_monitor_entry->block[idx].type = SYNC_TYPE_NONE;
+  sync_monitor_entry->block[idx].name = NULL;
+
+  sync_monitor_entry->num_entry_in_use--;
+  sync_monitor_entry->hint_free_entry_idx = idx;
 
   return NO_ERROR;
 }
 
 /*
- * rwlock_reclaim_a_rwlock_monitor_entry () - 
+ * sync_allocate_sync_stats () - 
  *   return: NO_ERROR
  *
  */
-static int
-rwlock_reclaim_a_rwlock_monitor_entry (SYNC_RWLOCK_CHUNK * rwlock_chunk_entry, int idx)
+static SYNC_STATS *
+sync_allocate_sync_stats (SYNC_PRIMITIVE_TYPE sync_prim_type, const char *name)
 {
-  assert (rwlock_chunk_entry != NULL);
-  assert (0 <= idx && idx < NUM_ENTRIES_OF_RWLOCK_CHUNK);
-  assert (rwlock_chunk_entry->block[idx] != NULL);
-  assert (0 < rwlock_chunk_entry->num_entry_in_use
-	  && rwlock_chunk_entry->num_entry_in_use < NUM_ENTRIES_OF_RWLOCK_CHUNK);
-
-  rwlock_chunk_entry->block[idx] = NULL;
-  rwlock_chunk_entry->num_entry_in_use--;
-  rwlock_chunk_entry->hint_free_entry_idx = idx;
-
-  return NO_ERROR;
-}
-
-/*
- * rwlock_register_a_rwlock_entry_to_monitor () - 
- *   return: NO_ERROR
- *
- */
-static int
-rwlock_register_a_rwlock_entry_to_monitor (SYNC_RWLOCK * rwlock)
-{
-  SYNC_RWLOCK_CHUNK *p, *last_chunk, *new_chunk;
+  SYNC_MONITOR *p, *last_chunk, *new_chunk;
+  SYNC_STATS *stats = NULL;
   int i, idx;
   bool found = false;
 
-  pthread_mutex_lock (&rwlock_Monitor.rwlock_monitor_mutex);
+  pthread_mutex_lock (&sync_Monitor_lock);
 
-  p = &rwlock_Monitor;
+  p = &sync_Monitor;
   while (p != NULL)
     {
-      if (p->num_entry_in_use < NUM_ENTRIES_OF_RWLOCK_CHUNK)
+      if (p->num_entry_in_use < NUM_ENTRIES_OF_SYNC_STATS_BLOCK)
 	{
-	  assert (0 <= p->hint_free_entry_idx && p->hint_free_entry_idx < NUM_ENTRIES_OF_RWLOCK_CHUNK);
+	  assert (0 <= p->hint_free_entry_idx && p->hint_free_entry_idx < NUM_ENTRIES_OF_SYNC_STATS_BLOCK);
 
-	  for (i = 0, idx = p->hint_free_entry_idx; i < NUM_ENTRIES_OF_RWLOCK_CHUNK; i++)
+	  for (i = 0, idx = p->hint_free_entry_idx; i < NUM_ENTRIES_OF_SYNC_STATS_BLOCK; i++)
 	    {
-	      if (p->block[idx] == NULL)
+	      if (p->block[idx].type == SYNC_TYPE_NONE)
 		{
 		  found = true;
-		  rwlock_consume_a_rwlock_monitor_entry (p, idx, rwlock);
+		  stats = sync_consume_sync_stats_from_pool (p, idx, sync_prim_type, name);
 		  break;
 		}
 
-	      idx = (idx + 1) % NUM_ENTRIES_OF_RWLOCK_CHUNK;
+	      idx = (idx + 1) % NUM_ENTRIES_OF_SYNC_STATS_BLOCK;
 	    }
 
 	  assert (found == true);
@@ -2421,62 +2418,65 @@ rwlock_register_a_rwlock_entry_to_monitor (SYNC_RWLOCK * rwlock)
 
       last_chunk = p;
 
-      p = p->next_chunk;
+      p = p->next;
     }
 
   if (found == false)
     {
-      new_chunk = rwlock_allocate_rwlock_chunk_monitor_entry ();
+      /* none is available. allocate a block */
+      new_chunk = sync_allocate_sync_monitor_entry ();
       if (new_chunk == NULL)
 	{
 	  /* error was set */
-	  return ER_OUT_OF_VIRTUAL_MEMORY;
+	  pthread_mutex_unlock (&sync_Monitor_lock);
+	  return NULL;
 	}
 
-      last_chunk->next_chunk = new_chunk;
+      last_chunk->next = new_chunk;
 
-      rwlock_consume_a_rwlock_monitor_entry (new_chunk, 0, rwlock);
+      stats = sync_consume_sync_stats_from_pool (new_chunk, 0, sync_prim_type, name);
     }
 
-  pthread_mutex_unlock (&rwlock_Monitor.rwlock_monitor_mutex);
+  pthread_mutex_unlock (&sync_Monitor_lock);
 
-  return NO_ERROR;
+  return stats;
 }
 
 /*
- * rwlock_unregister_a_rwlock_entry_from_monitor () - 
+ * sync_deallocate_sync_stats () - 
  *   return: NO_ERROR
  *
  */
 static int
-rwlock_unregister_a_rwlock_entry_from_monitor (SYNC_RWLOCK * rwlock)
+sync_deallocate_sync_stats (SYNC_STATS * stats)
 {
-  SYNC_RWLOCK_CHUNK *p;
-  int i, idx;
+  SYNC_MONITOR *p;
+  int idx;
   bool found = false;
 
-  pthread_mutex_lock (&rwlock_Monitor.rwlock_monitor_mutex);
+  assert (stats != NULL);
 
-  p = &rwlock_Monitor;
+  pthread_mutex_lock (&sync_Monitor_lock);
+
+  p = &sync_Monitor;
   while (p != NULL)
     {
-      if (0 < p->num_entry_in_use)
+      if (0 < p->num_entry_in_use && p->block <= stats && stats <= p->block + NUM_ENTRIES_OF_SYNC_STATS_BLOCK)
 	{
-	  for (i = 0; i < NUM_ENTRIES_OF_RWLOCK_CHUNK; i++)
-	    {
-	      if (p->block[i] == rwlock)
-		{
-		  found = true;
-		  rwlock_reclaim_a_rwlock_monitor_entry (p, i);
-		  break;
-		}
-	    }
+	  idx = (int) (stats - p->block);
+
+	  assert (p->block[idx].type != SYNC_TYPE_NONE);
+
+	  sync_return_sync_stats_to_pool (p, idx);
+
+	  found = true;
+	  break;
 	}
 
-      p = p->next_chunk;
+      p = p->next;
     }
 
-  pthread_mutex_unlock (&rwlock_Monitor.rwlock_monitor_mutex);
+  pthread_mutex_unlock (&sync_Monitor_lock);
 
   assert (found == true);
 
@@ -2484,112 +2484,62 @@ rwlock_unregister_a_rwlock_entry_from_monitor (SYNC_RWLOCK * rwlock)
 }
 
 /*
- * rwlock_dump_statistics() - dump rwlock statistics
+ * rmutex_dump_statistics() - dump rmutex statistics
  *   return: void
  */
 void
-rwlock_dump_statistics (FILE * fp)
+rmutex_dump_statistics (FILE * fp)
 {
-  SYNC_RWLOCK_CHUNK *p;
-  SYNC_RWLOCK *rwlock;
+  SYNC_MONITOR *p;
+  SYNC_STATS *stats;
   int i, cnt;
 
-  fprintf (fp, "\n             RWlock Name     |Total Enter|   Max Wait    |  Total wait\n");
+  fprintf (fp, "\n         RMutex Name         |Total Enter|Total Reenter|  Max elapsed  |  Total elapsed\n");
 
-  pthread_mutex_lock (&rwlock_Monitor.rwlock_monitor_mutex);
+  pthread_mutex_lock (&sync_Monitor_lock);
 
-  p = &rwlock_Monitor;
+  p = &sync_Monitor;
   while (p != NULL)
     {
-      for (i = 0, cnt = 0; cnt < p->num_entry_in_use && i < NUM_ENTRIES_OF_RWLOCK_CHUNK; i++)
+      for (i = 0, cnt = 0; cnt < p->num_entry_in_use && i < NUM_ENTRIES_OF_SYNC_STATS_BLOCK; i++)
 	{
-	  rwlock = p->block[i];
-	  if (rwlock != NULL)
+	  stats = &p->block[i];
+	  if (stats->type == SYNC_TYPE_RMUTEX)
 	    {
 	      cnt++;
 
-	      fprintf (fp, "%28s |%10d | %6ld.%06ld | %6ld.%06ld\n", rwlock->name, rwlock->total_enter,
-		       rwlock->max_wait.tv_sec, rwlock->max_wait.tv_usec,
-		       rwlock->total_wait.tv_sec, rwlock->total_wait.tv_usec);
+	      fprintf (fp, "%-28s |%10d |  %10d | %6ld.%06ld | %6ld.%06ld\n", stats->name, stats->nenter,
+		       stats->nreenter, stats->max_elapsed.tv_sec, stats->max_elapsed.tv_usec,
+		       stats->total_elapsed.tv_sec, stats->total_elapsed.tv_usec);
 
 	      /* reset statistics */
-	      rwlock->total_enter = 0;
-
-	      rwlock->max_wait.tv_sec = 0;
-	      rwlock->max_wait.tv_usec = 0;
-
-	      rwlock->total_wait.tv_sec = 0;
-	      rwlock->total_wait.tv_usec = 0;
+	      sync_reset_stats_metrics (stats);
 	    }
 	}
 
-      p = p->next_chunk;
+      p = p->next;
     }
 
-  pthread_mutex_unlock (&rwlock_Monitor.rwlock_monitor_mutex);
+  pthread_mutex_unlock (&sync_Monitor_lock);
 
   fflush (fp);
 }
 
-int
-rmutex_initialize (SYNC_RMUTEX * rmutex)
+void
+sync_dump_statistics (FILE * fp, SYNC_PRIMITIVE_TYPE type)
 {
-  assert (rmutex != NULL);
-
-  pthread_mutex_init (&rmutex->lock, NULL);
-
-  rmutex->owner = (pthread_t) 0;
-  rmutex->nenters = 0;
-
-  return NO_ERROR;
-}
-
-int
-rmutex_finalize (SYNC_RMUTEX * rmutex)
-{
-  assert (rmutex != NULL);
-
-  pthread_mutex_destroy (&rmutex->lock);
-}
-
-int
-rmutex_lock (THREAD_ENTRY * thread_p, SYNC_RMUTEX * rmutex)
-{
-  assert (thread_p != NULL && rmutex != NULL);
-
-  if (rmutex->owner == thread_p->tid)
+  if (type == SYNC_TYPE_ALL || type == SYNC_TYPE_CSECT)
     {
-      assert (rmutex->nenters > 0);
-    }
-  else
-    {
-      pthread_mutex_lock (&rmutex->lock);
-
-      assert (rmutex->nenters == 0);
-
-      rmutex->owner = thread_p->tid;
+      csect_dump_statistics (fp);
     }
 
-  rmutex->nenters++;
-
-  return NO_ERROR;
-}
-
-int
-rmutex_unlock (THREAD_ENTRY * thread_p, SYNC_RMUTEX * rmutex)
-{
-  assert (thread_p != NULL && rmutex != NULL);
-  assert (rmutex->nenters > 0);
-  assert (rmutex->owner == thread_p->tid);
-
-  rmutex->nenters--;
-
-  if (rmutex->nenters == 0)
+  if (type == SYNC_TYPE_ALL || type == SYNC_TYPE_RWLOCK)
     {
-      rmutex->owner = (pthread_t) 0;
-
-      pthread_mutex_unlock (&rmutex->lock);
+      rwlock_dump_statistics (fp);
     }
 
-  return NO_ERROR;
+  if (type == SYNC_TYPE_ALL || type == SYNC_TYPE_RMUTEX)
+    {
+      rmutex_dump_statistics (fp);
+    }
 }

--- a/src/thread/critical_section.h
+++ b/src/thread/critical_section.h
@@ -81,10 +81,37 @@ enum
 extern const char *csect_Name_conn;
 extern const char *csect_Name_tdes;
 
+typedef enum
+{
+  SYNC_TYPE_NONE,
+
+  SYNC_TYPE_CSECT,		/* critical section primitive */
+  SYNC_TYPE_RWLOCK,		/* rwlock primitive */
+  SYNC_TYPE_RMUTEX,		/* re-entrant mutex */
+  SYNC_TYPE_MUTEX,		/* simple mutex */
+
+  SYNC_TYPE_LAST = SYNC_TYPE_MUTEX,
+  SYNC_TYPE_COUNT = SYNC_TYPE_LAST,
+  SYNC_TYPE_ALL = SYNC_TYPE_LAST
+} SYNC_PRIMITIVE_TYPE;
+
+typedef struct sync_stats
+{
+  SYNC_PRIMITIVE_TYPE type;
+  const char *name;
+
+  unsigned int nenter;		/* total number of acquisition. */
+  unsigned int nwait;		/* total number of waiting. only available for SYNC_TYPE_CSECT */
+  unsigned int nreenter;	/* total number of re-acquisition. available for SYNC_TYPE_CSECT, SYNC_TYPE_RMUTEX */
+
+  struct timeval total_elapsed;	/* total elapsed time to acquire the synchronization primitive */
+  struct timeval max_elapsed;	/* max elapsed time to acquire the synchronization primitive */
+} SYNC_STATS;
+
 typedef struct sync_critical_section
 {
-  int cs_index;
   const char *name;
+  int cs_index;
   pthread_mutex_t lock;		/* read/write monitor lock */
   int rwlock;			/* >0 = # readers, <0 = writer, 0 = none */
   unsigned int waiting_readers;	/* # of waiting readers */
@@ -94,36 +121,29 @@ typedef struct sync_critical_section
   THREAD_ENTRY *waiting_promoters_queue;	/* queue of waiting promoters */
   pthread_t owner;		/* CS owner writer */
   int tran_index;		/* transaction id acquiring CS */
-  unsigned int total_enter;
-  unsigned int total_nwaits;	/* total # of waiters */
-  struct timeval max_wait;
-  struct timeval total_wait;
+  SYNC_STATS *stats;
 } SYNC_CRITICAL_SECTION;
 
 typedef struct sync_rwlock
 {
+  char *name;
   pthread_mutex_t read_lock;	/* read lock. Only readers will use it. */
   pthread_mutex_t global_lock;	/* global lock */
-  char *name;			/* name strduped - should be freed */
   int num_readers;		/* # of readers. Only readers will use it. */
-  int for_trace;		/* SYNC_RWLOCK_TRACE to monitor the SYNC_RWLOCK. It should be a global SYNC_RWLOCK. */
-  unsigned int total_enter;
-  struct timeval max_wait;
-  struct timeval total_wait;
+  SYNC_STATS *stats;
 } SYNC_RWLOCK;
 
 typedef struct sync_rmutex
 {
+  char *name;
   pthread_mutex_t lock;		/* mutex */
   pthread_t owner;		/* owner thread id */
-  int nenters;			/* # of times that owner enters */
+  int lock_cnt;			/* # of times that owner enters */
+  SYNC_STATS *stats;
 } SYNC_RMUTEX;
 
-#define RWLOCK_TRACE 1
-#define RWLOCK_NOT_TRACE 0
-
-extern int csect_initialize (void);
-extern int csect_finalize (void);
+extern int csect_initialize_static_critical_sections (void);
+extern int csect_finalize_static_critical_sections (void);
 
 extern int csect_enter (THREAD_ENTRY * thread_p, int cs_index, int wait_secs);
 extern int csect_enter_as_reader (THREAD_ENTRY * thread_p, int cs_index, int wait_secs);
@@ -131,7 +151,7 @@ extern int csect_demote (THREAD_ENTRY * thread_p, int cs_index, int wait_secs);
 extern int csect_promote (THREAD_ENTRY * thread_p, int cs_index, int wait_secs);
 extern int csect_exit (THREAD_ENTRY * thread_p, int cs_index);
 
-extern int csect_initialize_critical_section (SYNC_CRITICAL_SECTION * cs_ptr);
+extern int csect_initialize_critical_section (SYNC_CRITICAL_SECTION * cs_ptr, const char *name);
 extern int csect_finalize_critical_section (SYNC_CRITICAL_SECTION * cs_ptr);
 extern int csect_enter_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr, int wait_secs);
 extern int csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * cs_ptr,
@@ -144,7 +164,7 @@ extern void csect_dump_statistics (FILE * fp);
 
 extern int csect_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values, int arg_cnt, void **ctx);
 
-extern int rwlock_initialize (SYNC_RWLOCK * rwlock, const char *name, int for_trace);
+extern int rwlock_initialize (SYNC_RWLOCK * rwlock, const char *name);
 extern int rwlock_finalize (SYNC_RWLOCK * rwlock);
 
 extern int rwlock_read_lock (SYNC_RWLOCK * rwlock);
@@ -153,19 +173,23 @@ extern int rwlock_read_unlock (SYNC_RWLOCK * rwlock);
 extern int rwlock_write_lock (SYNC_RWLOCK * rwlock);
 extern int rwlock_write_unlock (SYNC_RWLOCK * rwlock);
 
-extern int rwlock_initialize_rwlock_monitor (void);
-extern int rwlock_finalize_rwlock_monitor (void);
+extern int sync_initialize_sync_monitor (void);
+extern int sync_finalize_sync_monitor (void);
 
 extern void rwlock_dump_statistics (FILE * fp);
 
-extern int rmutex_initialize (SYNC_RMUTEX * rmutex);
+extern int rmutex_initialize (SYNC_RMUTEX * rmutex, const char *name);
 extern int rmutex_finalize (SYNC_RMUTEX * rmutex);
 
 extern int rmutex_lock (THREAD_ENTRY * thread_p, SYNC_RMUTEX * rmutex);
 extern int rmutex_unlock (THREAD_ENTRY * thread_p, SYNC_RMUTEX * rmutex);
 
+extern void rmutex_dump_statistics (FILE * fp);
+
+extern void sync_dump_statistics (FILE * fp, SYNC_PRIMITIVE_TYPE type);
+
 #if !defined(SERVER_MODE)
-#define csect_initialize_critical_section(a)
+#define csect_initialize_critical_section(a, b)
 #define csect_finalize_critical_section(a)
 #define csect_enter(a, b, c) NO_ERROR
 #define csect_enter_as_reader(a, b, c) NO_ERROR
@@ -176,14 +200,14 @@ extern int rmutex_unlock (THREAD_ENTRY * thread_p, SYNC_RMUTEX * rmutex);
 #define csect_check_own(a, b) 1
 #define csect_start_scan NULL
 
-#define rwlock_initialize(a, b, c) NO_ERROR
+#define rwlock_initialize(a, b) NO_ERROR
 #define rwlock_finalize(a) NO_ERROR
 #define rwlock_read_lock(a) NO_ERROR
 #define rwlock_read_unlock(a) NO_ERROR
 #define rwlock_write_lock(a) NO_ERROR
 #define rwlock_write_unlock(a) NO_ERROR
 
-#define rmutex_initialize(a) NO_ERROR
+#define rmutex_initialize(a, b) NO_ERROR
 #define rmutex_finalize(a) NO_ERROR
 #define rmutex_lock(a, b) NO_ERROR
 #define rmutex_unlock(a, b) NO_ERROR

--- a/src/thread/critical_section.h
+++ b/src/thread/critical_section.h
@@ -126,7 +126,7 @@ typedef struct sync_critical_section
 
 typedef struct sync_rwlock
 {
-  char *name;
+  const char *name;
   pthread_mutex_t read_lock;	/* read lock. Only readers will use it. */
   pthread_mutex_t global_lock;	/* global lock */
   int num_readers;		/* # of readers. Only readers will use it. */
@@ -135,7 +135,7 @@ typedef struct sync_rwlock
 
 typedef struct sync_rmutex
 {
-  char *name;
+  const char *name;
   pthread_mutex_t lock;		/* mutex */
   pthread_t owner;		/* owner thread id */
   int lock_cnt;			/* # of times that owner enters */
@@ -173,8 +173,8 @@ extern int rwlock_read_unlock (SYNC_RWLOCK * rwlock);
 extern int rwlock_write_lock (SYNC_RWLOCK * rwlock);
 extern int rwlock_write_unlock (SYNC_RWLOCK * rwlock);
 
-extern int sync_initialize_sync_monitor (void);
-extern int sync_finalize_sync_monitor (void);
+extern int sync_initialize_sync_stats (void);
+extern int sync_finalize_sync_stats (void);
 
 extern void rwlock_dump_statistics (FILE * fp);
 

--- a/src/thread/critical_section.h
+++ b/src/thread/critical_section.h
@@ -112,6 +112,13 @@ typedef struct sync_rwlock
   struct timeval total_wait;
 } SYNC_RWLOCK;
 
+typedef struct sync_rmutex
+{
+  pthread_mutex_t lock;		/* mutex */
+  pthread_t owner;		/* owner thread id */
+  int nenters;			/* # of times that owner enters */
+} SYNC_RMUTEX;
+
 #define RWLOCK_TRACE 1
 #define RWLOCK_NOT_TRACE 0
 
@@ -151,6 +158,12 @@ extern int rwlock_finalize_rwlock_monitor (void);
 
 extern void rwlock_dump_statistics (FILE * fp);
 
+extern int rmutex_initialize (SYNC_RMUTEX * rmutex);
+extern int rmutex_finalize (SYNC_RMUTEX * rmutex);
+
+extern int rmutex_lock (THREAD_ENTRY * thread_p, SYNC_RMUTEX * rmutex);
+extern int rmutex_unlock (THREAD_ENTRY * thread_p, SYNC_RMUTEX * rmutex);
+
 #if !defined(SERVER_MODE)
 #define csect_initialize_critical_section(a)
 #define csect_finalize_critical_section(a)
@@ -169,6 +182,11 @@ extern void rwlock_dump_statistics (FILE * fp);
 #define rwlock_read_unlock(a) NO_ERROR
 #define rwlock_write_lock(a) NO_ERROR
 #define rwlock_write_unlock(a) NO_ERROR
+
+#define rmutex_initialize(a) NO_ERROR
+#define rmutex_finalize(a) NO_ERROR
+#define rmutex_lock(a, b) NO_ERROR
+#define rmutex_unlock(a, b) NO_ERROR
 #endif /* !SERVER_MODE */
 
 #endif /* _CRITICAL_SECTION_H_ */

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1996,14 +1996,12 @@ logtb_initialize_tdes (LOG_TDES * tdes, int tran_index)
   LSA_SET_NULL (&tdes->topop_lsa);
   LSA_SET_NULL (&tdes->tail_topresult_lsa);
 
-  csect_initialize_critical_section (&tdes->cs_topop);
+  csect_initialize_critical_section (&tdes->cs_topop, csect_Name_tdes);
 
 #if defined(SERVER_MODE)
   assert (tdes->cs_topop.cs_index == -1);
-  assert (tdes->cs_topop.name == NULL);
 
   tdes->cs_topop.cs_index = CRITICAL_SECTION_COUNT + css_get_max_conn () + NUM_MASTER_CHANNEL + tdes->tran_index;
-  tdes->cs_topop.name = csect_Name_tdes;
 #endif
 
   tdes->topops.stack = NULL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20165

We have 3 kinds of synchronization primitives:
* critical section: FCFS, reentrancy, read/write mode, promotion/demotion
* rwlock: no FCFS, no reentrancy, read/write mote
* simple mutex: no FCFS, no reentrancy, only write mode

I'd like to introduce a new synchronization primitive, reentrant mutex which does not use condition variable. 
* reentrant mutex: no FCFS, reentrancy, only write mode

Pseudo codes are
```C
lock (rmutex)
{
  if (rmutex->owner == me)
    {
      assert (rmutex->nenters > 0);
    }
  else
    {
      mutex_lock (rmutex->mutex);

      assert (rmutex->nenters == 0);

      rmutex->owner = me;
    }

  rmutex->nenters++;
}

unlock (rmutex)
{
  assert (rmutex->nenters > 0);
  assert (rmutex->owner == me);

  rmutex->nenters--;

  if (rmutex->nenters == 0)
    {
      rmutex->owner = 0;

      mutex_unlock (rmutex->mutex);
    }
}
```

It is also possible to implement busy waiting version with CAS operation. However, FUTEX implementation of linux pthread mutex adopts adaptive policy which embeds busy waiting way.
I believe it would be enough to use FUTEX for general and we can also implement and use busy waiting version for a particular demand.

I'd like to also refactor statistics of synchronization primitives.