### PR TITLE
[CBRD-20166] replace CSECT_LOG_PB with a SYNC_RMUTEX

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1418,7 +1418,8 @@ net_server_start (const char *server_name)
   net_server_init ();
   css_initialize_server_interfaces (net_server_request, net_server_conn_down);
 
-  if (boot_restart_server (NULL, true, server_name, false, &check_coll_and_timezone, NULL) != NO_ERROR)
+  if (boot_restart_server (thread_get_thread_entry_info (), true, server_name, false, &check_coll_and_timezone,
+			   NULL) != NO_ERROR)
     {
       assert (er_errid () != NO_ERROR);
       error = er_errid ();
@@ -1442,11 +1443,11 @@ net_server_start (const char *server_name)
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
 	    }
 
-	  xboot_shutdown_server (NULL, ER_THREAD_FINAL);
+	  xboot_shutdown_server (thread_get_thread_entry_info (), ER_THREAD_FINAL);
 	}
       else
 	{
-	  (void) xboot_shutdown_server (NULL, ER_ALL_FINAL);
+	  (void) xboot_shutdown_server (thread_get_thread_entry_info (), ER_ALL_FINAL);
 	}
 
 #if defined(CUBRID_DEBUG)

--- a/src/thread/critical_section.h
+++ b/src/thread/critical_section.h
@@ -70,7 +70,6 @@ enum
   CSECT_CONN_ACTIVE,		/* Latch for Active conn list */
   CSECT_CONN_FREE,		/* Latch for Free conn list */
   CSECT_TEMPFILE_CACHE,		/* Latch for temp file cache */
-  CSECT_LOG_PB,			/* Latch for log_Pb */
   CSECT_LOG_ARCHIVE,		/* Latch for log_Gl.archive */
   CSECT_ACCESS_STATUS,		/* Latch for user access status */
   CSECT_LAST

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3363,6 +3363,11 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       error_code = ER_FAILED;
       goto error;
     }
+
+  /* note that thread entry was re-initialized */
+  thread_p = thread_get_thread_entry_info ();
+  assert (thread_p != NULL);
+
   if (er_init (prm_get_string_value (PRM_ID_ER_LOG_FILE), prm_get_integer_value (PRM_ID_ER_EXIT_ASK)) != NO_ERROR)
     {
       error_code = ER_FAILED;

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1935,7 +1935,7 @@ extern char log_Name_removed_archive[];
 
 extern int logpb_initialize_pool (THREAD_ENTRY * thread_p);
 extern void logpb_finalize_pool (THREAD_ENTRY * thread_p);
-extern bool logpb_is_initialize_pool (void);
+extern bool logpb_is_pool_initialized (void);
 extern void logpb_invalidate_pool (THREAD_ENTRY * thread_p);
 extern LOG_PAGE *logpb_create (THREAD_ENTRY * thread_p, LOG_PAGEID pageid);
 extern LOG_PAGE *log_pbfetch (LOG_PAGEID pageid);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1934,7 +1934,7 @@ extern char log_Name_removed_archive[];
   (DB_ALIGN (new_data_size + OR_SHORT_SIZE + 2 * OR_BYTE_SIZE, INT_ALIGNMENT))
 
 extern int logpb_initialize_pool (THREAD_ENTRY * thread_p);
-extern void logpb_finalize_pool (void);
+extern void logpb_finalize_pool (THREAD_ENTRY * thread_p);
 extern bool logpb_is_initialize_pool (void);
 extern void logpb_invalidate_pool (THREAD_ENTRY * thread_p);
 extern LOG_PAGE *logpb_create (THREAD_ENTRY * thread_p, LOG_PAGEID pageid);
@@ -2038,7 +2038,7 @@ extern void logpb_initialize_logging_statistics (void);
 extern int logpb_background_archiving (THREAD_ENTRY * thread_p);
 extern void xlogpb_dump_stat (FILE * outfp);
 
-extern void logpb_dump (FILE * out_fp);
+extern void logpb_dump (THREAD_ENTRY * thread_p, FILE * out_fp);
 
 extern int logpb_remove_all_in_log_path (THREAD_ENTRY * thread_p, const char *db_fullname, const char *logpath,
 					 const char *prefix_logname);
@@ -2051,20 +2051,13 @@ extern LOG_LSA *log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool 
 extern void log_2pc_define_funs (int (*get_participants) (int *particp_id_length, void **block_particps_ids),
 				 int (*lookup_participant) (void *particp_id, int num_particps,
 							    void *block_particps_ids),
-				 char *(*fmt_participant) (void *particp_id), void (*dump_participants) (FILE * fp,
-													 int
-													 block_length,
-													 void
-													 *block_particps_id),
+				 char *(*fmt_participant) (void *particp_id),
+				 void (*dump_participants) (FILE * fp, int block_length, void *block_particps_id),
 				 int (*send_prepare) (int gtrid, int num_particps, void *block_particps_ids),
 				 bool (*send_commit) (int gtrid, int num_particps, int *particp_indices,
-						      void *block_particps_ids), bool (*send_abort) (int gtrid,
-												     int num_particps,
-												     int
-												     *particp_indices,
-												     void
-												     *block_particps_ids,
-												     int collect));
+						      void *block_particps_ids),
+				 bool (*send_abort) (int gtrid, int num_particps, int *particp_indices,
+						     void *block_particps_ids, int collect));
 #endif
 extern char *log_2pc_sprintf_particp (void *particp_id);
 extern void log_2pc_dump_participants (FILE * fp, int block_length, void *block_particps_ids);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1626,7 +1626,7 @@ log_final (THREAD_ENTRY * thread_p)
 
   save_tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 
-  if (!logpb_is_initialize_pool ())
+  if (!logpb_is_pool_initialized ())
     {
       logtb_undefine_trantable (thread_p);
       LOG_CS_EXIT (thread_p);
@@ -9204,7 +9204,7 @@ log_simulate_crash (THREAD_ENTRY * thread_p, int flush_log, int flush_data_pages
 {
   LOG_CS_ENTER (thread_p);
 
-  if (log_Gl.trantable.area == NULL || !logpb_is_initialize_pool ())
+  if (log_Gl.trantable.area == NULL || !logpb_is_pool_initialized ())
     {
       LOG_CS_EXIT (thread_p);
       return;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -891,13 +891,13 @@ log_create_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const cha
 	}
     }
 
-  logpb_finalize_pool ();
+  logpb_finalize_pool (thread_p);
   LOG_CS_EXIT (thread_p);
 
   return NO_ERROR;
 
 error:
-  logpb_finalize_pool ();
+  logpb_finalize_pool (thread_p);
   LOG_CS_EXIT (thread_p);
 
   return (error_code == NO_ERROR) ? ER_FAILED : error_code;
@@ -1131,7 +1131,7 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
        * Call the function again... since we have a different setting for the
        * page size
        */
-      logpb_finalize_pool ();
+      logpb_finalize_pool (thread_p);
       fileio_dismount (thread_p, log_Gl.append.vdes);
       log_Gl.append.vdes = NULL_VOLDES;
 
@@ -1635,7 +1635,7 @@ log_final (THREAD_ENTRY * thread_p)
 
   if (log_Gl.append.vdes == NULL_VOLDES)
     {
-      logpb_finalize_pool ();
+      logpb_finalize_pool (thread_p);
       logtb_undefine_trantable (thread_p);
       LOG_CS_EXIT (thread_p);
       return;
@@ -1701,7 +1701,7 @@ log_final (THREAD_ENTRY * thread_p)
   logpb_flush_header (thread_p);
 
   /* Undefine page buffer pool and transaction table */
-  logpb_finalize_pool ();
+  logpb_finalize_pool (thread_p);
 
   logtb_undefine_trantable (thread_p);
 
@@ -7328,7 +7328,7 @@ xlog_dump (THREAD_ENTRY * thread_p, FILE * out_fp, int isforward, LOG_PAGEID sta
   LOG_CS_ENTER (thread_p);
 
   xlogtb_dump_trantable (thread_p, out_fp);
-  logpb_dump (out_fp);
+  logpb_dump (thread_p, out_fp);
   logpb_flush_pages_direct (thread_p);
   logpb_flush_header (thread_p);
 
@@ -9223,7 +9223,7 @@ log_simulate_crash (THREAD_ENTRY * thread_p, int flush_log, int flush_data_pages
 
   /* Undefine log buffer pool and transaction table */
 
-  logpb_finalize_pool ();
+  logpb_finalize_pool (thread_p);
   logtb_undefine_trantable (thread_p);
 
   LOG_CS_EXIT (thread_p);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -418,7 +418,7 @@ logtb_define_trantable (THREAD_ENTRY * thread_p, int num_expected_tran_indices, 
 
   if (logpb_is_initialize_pool ())
     {
-      logpb_finalize_pool ();
+      logpb_finalize_pool (thread_p);
     }
 
   (void) logtb_define_trantable_log_latch (thread_p, num_expected_tran_indices);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -416,7 +416,7 @@ logtb_define_trantable (THREAD_ENTRY * thread_p, int num_expected_tran_indices, 
   LOG_CS_ENTER (thread_p);
   TR_TABLE_CS_ENTER (thread_p);
 
-  if (logpb_is_initialize_pool ())
+  if (logpb_is_pool_initialized ())
     {
       logpb_finalize_pool (thread_p);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20166

- replace CSECT_LOG_PB with LOGPB_RMUTEX_LOG_PB
- macros: START_EXCLUSIVE_ACCESS_LOG_PB, END_EXCLUSIVE_ACCESS_LOG_PB
- also fixes a bug of RMUTEX implementation: duplicated sync_stats entry
- includes some miscellaneous changes
