### PR TITLE
[CBRD-20174] Removed primary_key from MVCC_REEV_DATA

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -8555,7 +8555,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
   (void) logtb_get_mvcc_snapshot (thread_p);
 
   mvcc_upddel_reev_data.copyarea = NULL;
-  SET_MVCC_UPDATE_REEV_DATA (&mvcc_reev_data, &mvcc_upddel_reev_data, V_TRUE, NULL);
+  SET_MVCC_UPDATE_REEV_DATA (&mvcc_reev_data, &mvcc_upddel_reev_data, V_TRUE);
   class_oid_cnt = update->no_classes;
   mvcc_reev_class_cnt = update->no_reev_classes;
 
@@ -9471,7 +9471,7 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 
   class_oid_cnt = delete_->no_classes;
   mvcc_reev_class_cnt = delete_->no_reev_classes;
-  SET_MVCC_UPDATE_REEV_DATA (&mvcc_reev_data, &mvcc_upddel_reev_data, V_TRUE, NULL);
+  SET_MVCC_UPDATE_REEV_DATA (&mvcc_reev_data, &mvcc_upddel_reev_data, V_TRUE);
 
   mvcc_upddel_reev_data.copyarea = NULL;
 
@@ -12041,7 +12041,7 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
       /* init scan reevaluation structure */
       INIT_SCAN_REEV_DATA (&mvcc_sel_reev_data, &range_filter, &key_filter, &data_filter, &scan_id->qualification);
       /* set reevaluation data */
-      SET_MVCC_SELECT_REEV_DATA (&mvcc_reev_data, &mvcc_sel_reev_data, V_TRUE, NULL);
+      SET_MVCC_SELECT_REEV_DATA (&mvcc_reev_data, &mvcc_sel_reev_data, V_TRUE);
       p_mvcc_reev_data = &mvcc_reev_data;
 
       /* clear list id if all reevaluations result is false */

--- a/src/query/query_executor.h
+++ b/src/query/query_executor.h
@@ -295,25 +295,23 @@
     while (0)
 
 #define SET_MVCC_SELECT_REEV_DATA(p_mvcc_reev_data, p_mvcc_sel_reev_data, \
-				  reev_filter_result, p_primary_key) \
+				  reev_filter_result) \
   do \
     { \
       assert ((p_mvcc_reev_data) != NULL); \
       (p_mvcc_reev_data)->type = REEV_DATA_SCAN; \
       (p_mvcc_reev_data)->select_reev_data = (p_mvcc_sel_reev_data); \
       (p_mvcc_reev_data)->filter_result = (reev_filter_result); \
-      (p_mvcc_reev_data)->primary_key = (p_primary_key); \
     } \
   while (0)
 
 #define SET_MVCC_UPDATE_REEV_DATA(p_mvcc_reev_data, p_mvcc_upddel_reev_data, \
-				  reev_filter_result, p_primary_key) \
+				  reev_filter_result) \
   do \
     { \
       (p_mvcc_reev_data)->type = REEV_DATA_UPDDEL; \
       (p_mvcc_reev_data)->upddel_reev_data = (p_mvcc_upddel_reev_data); \
       (p_mvcc_reev_data)->filter_result = (reev_filter_result); \
-      (p_mvcc_reev_data)->primary_key = (p_primary_key); \
     } \
   while (0)
 
@@ -657,7 +655,6 @@ struct mvcc_reev_data
     MVCC_SCAN_REEV_DATA *select_reev_data;	/* data for reevaluation at SELECT */
   };
   DB_LOGICAL filter_result;	/* the result of reevaluation if successful */
-  DB_VALUE *primary_key;	/* primary key value used in foreign key cascade UPDATE/DELETE reevaluation */
 };
 
 /*update/delete class info structure */

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -4994,7 +4994,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	  /* data filter already initialized, don't have key or range init scan reevaluation structure */
 	  INIT_SCAN_REEV_DATA (&mvcc_sel_reev_data, p_range_filter, p_key_filter, &data_filter,
 			       &scan_id->qualification);
-	  SET_MVCC_SELECT_REEV_DATA (&mvcc_reev_data, &mvcc_sel_reev_data, V_TRUE, NULL);
+	  SET_MVCC_SELECT_REEV_DATA (&mvcc_reev_data, &mvcc_sel_reev_data, V_TRUE);
 	  COPY_OID (&current_oid, &hsidp->curr_oid);
 	  if (scan_id->fixed)
 	    {
@@ -5790,7 +5790,7 @@ scan_next_index_lookup_heap (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, INDX_SC
       /* init scan reevaluation structure */
       INIT_SCAN_REEV_DATA (&mvcc_sel_reev_data, &range_filter, &key_filter, data_filter, &scan_id->qualification);
       /* set reevaluation data */
-      SET_MVCC_SELECT_REEV_DATA (&mvcc_reev_data, &mvcc_sel_reev_data, V_TRUE, NULL);
+      SET_MVCC_SELECT_REEV_DATA (&mvcc_reev_data, &mvcc_sel_reev_data, V_TRUE);
 
       sp_scan =
 	heap_mvcc_get_for_delete (thread_p, isidp->curr_oidp, NULL, &recdes, &isidp->scan_cache, scan_id->fixed,

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4659,7 +4659,6 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 
 		  if (fkref->del_action == SM_FOREIGN_KEY_CASCADE)
 		    {
-		      MVCC_REEV_DATA mvcc_reev_data, *p_mvcc_reev_data = NULL;
 		      if (lob_exist)
 			{
 			  error_code = locator_delete_lob_force (thread_p, &fkref->self_oid, oid_ptr, NULL);
@@ -4668,15 +4667,11 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 			{
 			  goto error1;
 			}
-		      /* The relationship between primary key and foreign key must be reevaluated so we provide to
-		       * reevaluation the primary key. That's because between fetch of foreign keys and the deletion
-		       * the foreign keys can be modified by other transactions. */
-		      p_mvcc_reev_data = &mvcc_reev_data;
-		      SET_MVCC_UPDATE_REEV_DATA (p_mvcc_reev_data, NULL, V_TRUE, key);
+
 		      /* oid already locked at heap_mvcc_get_for_delete */
 		      error_code =
 			locator_delete_force (thread_p, &hfid, oid_ptr, true, SINGLE_ROW_DELETE, &scan_cache,
-					      &force_count, p_mvcc_reev_data, false);
+					      &force_count, NULL, false);
 		      if (error_code == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 			{
 			  /* skip foreign keys that were already deleted. For example the "cross type" reference */

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -6382,6 +6382,12 @@ locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, 
 
   copy_recdes.data = NULL;
 
+  if (need_locking == false)
+    {
+      /* the reevaluation is not necessary if the object is already locked */
+      mvcc_reev_data = NULL;
+    }
+
   /* IMPORTANT TODO: use a different get function when need_locking==false, but make sure it gets the last version,
      not the visible one; we need only the last version to use it to retrieve the last version of the btree key */
   scan_code = heap_mvcc_get_for_delete (thread_p, oid, &class_oid, &copy_recdes, scan_cache, COPY, NULL_CHN,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20174

This field of MVCC_REEV_DATA was used incorrectly used after CBRD-20167 patch.

Also, in locator_delete_force_internal() the reevaluation data will be ignored when the object is already locked.