### PR TITLE
[CBRD-20177] Fixed uninitialized recdes in qexec_execute_obj_fetch()

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -11480,7 +11480,7 @@ qexec_execute_obj_fetch (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE *
   XASL_NODE *xptr;
   DB_LOGICAL ev_res;
   DB_LOGICAL ev_res2;
-  RECDES oRec;
+  RECDES oRec = RECDES_INITIALIZER;
   HEAP_SCANCACHE scan_cache;
   ACCESS_SPEC_TYPE *specp = NULL;
   OID cls_oid;


### PR DESCRIPTION
The issue was caused by a memory overrun of uninitialized variable.