### PR TITLE
[CBRD-20190] Fix long heap page latch times during locator_check_btree_entries

### DIFF
--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -9760,7 +9760,7 @@ locator_check_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, HFID * hfid, 
   scan_init_index_scan (&isid, NULL, mvcc_snapshot);
 
   /* Start a scan cursor and a class attribute information */
-  if (heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, true, false, mvcc_snapshot) != NO_ERROR)
+  if (heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, false, false, mvcc_snapshot) != NO_ERROR)
     {
       return DISK_ERROR;
     }
@@ -9806,7 +9806,7 @@ locator_check_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, HFID * hfid, 
   inst_oid.pageid = NULL_PAGEID;
   inst_oid.slotid = NULL_SLOTID;
 
-  while ((scan = heap_next (thread_p, hfid, class_oid, &inst_oid, &peek, &scan_cache, PEEK)) == S_SUCCESS)
+  while ((scan = heap_next (thread_p, hfid, class_oid, &inst_oid, &peek, &scan_cache, COPY)) == S_SUCCESS)
     {
       num_heap_oids++;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20190

In the testing scenario, we had two index keys with 100k objects each. These two keys covered almost all instance of the class. During `locator_check_btree_entries`, the objects are fetched from heap and then looked up in index. Fetching objects used heap_next and kept the page latched until all its objects were verified. The page has 480 objects and each must be looked up in about 150 overflow OID's pages. This could take a long time, even longer than 5 minutes, which caused the latch timeout on heap page for a vacuum worker.