### PR TITLE
[CBRD-20196] Raise serializable conflict for deleted visible records

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -8076,9 +8076,15 @@ heap_mvcc_lock_and_get_object_version (THREAD_ENTRY * thread_p, const OID * oid,
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MVCC_SERIALIZABLE_CONFLICT, 0);
 	      goto error;
 	    }
+	  else if (mvcc_delete_info.satisfies_delete_result == DELETE_RECORD_DELETED)
+	    {
+	      /* Trying to modify version deleted by concurrent transaction, which is an isolation conflict. */
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MVCC_SERIALIZABLE_CONFLICT, 0);
+	      goto error;
+	    }
 	  else
 	    {
-	      /* Last version is also visible version. Fall through. */
+	      /* Last version is also visible version and it is not deleted. Fall through. */
 	    }
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20196

Deleted records may be still visible after locking. This case will be considered a serializable conflict.