### PR TITLE
[CBRD-20200] Disable "in-place" update on catalog entries.

### DIFF
--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -3925,6 +3925,8 @@ catcls_update_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
   if (uflag == true)
     {
       HEAP_OPERATION_CONTEXT update_context;
+      MVCC_REC_HEADER *old_mvcc_header_p = NULL;
+      MVCC_REC_HEADER mvcc_header;
 
       record.length = catcls_guess_record_length (value_p);
       record.area_size = record.length;
@@ -4241,28 +4243,6 @@ catcls_update_catalog_classes (THREAD_ENTRY * thread_p, const char *name_p, RECD
     {
       return (catcls_insert_catalog_classes (thread_p, record_p));
     }
-
-  /* check whether mvcc update or update in place is needed */
-#if defined (SERVER_MODE)
-  if (!HEAP_IS_UPDATE_INPLACE (force_in_place))
-    {
-      bool need_mvcc_update;
-
-      if (catcls_is_mvcc_update_needed (thread_p, &oid, &need_mvcc_update) != NO_ERROR)
-	{
-	  goto error;
-	}
-      if (!need_mvcc_update)
-	{
-	  force_in_place = UPDATE_INPLACE_CURRENT_MVCCID;
-	}
-    }
-#else
-  if (!HEAP_IS_UPDATE_INPLACE (force_in_place))
-    {
-      force_in_place = UPDATE_INPLACE_CURRENT_MVCCID;
-    }
-#endif /* SERVER_MODE */
 
   value_p = catcls_get_or_value_from_class_record (thread_p, record_p);
   if (value_p == NULL)

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -3924,8 +3924,6 @@ catcls_update_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
   if (uflag == true)
     {
       HEAP_OPERATION_CONTEXT update_context;
-      MVCC_REC_HEADER *old_mvcc_header_p = NULL;
-      MVCC_REC_HEADER mvcc_header;
 
       record.length = catcls_guess_record_length (value_p);
       record.area_size = record.length;

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -190,7 +190,6 @@ static int catcls_convert_attr_id_to_name (THREAD_ENTRY * thread_p, OR_BUF * orb
 static void catcls_apply_component_type (OR_VALUE * value_p, int type);
 static int catcls_resolution_space (int name_space);
 static void catcls_apply_resolutions (OR_VALUE * value_p, OR_VALUE * resolution_p);
-static int catcls_is_mvcc_update_needed (THREAD_ENTRY * thread_p, OID * oid, bool * need_mvcc_update);
 static int catcls_replace_entry_oid (THREAD_ENTRY * thread_p, OID * entry_class_oid, OID * entry_new_oid);
 static int catcls_get_or_value_from_partition (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VALUE * value_p);
 
@@ -4135,81 +4134,6 @@ error:
     }
 
   return ER_FAILED;
-}
-
-/*
- * catcls_is_mvcc_update_needed () - check whether mvcc update is needed
- *   return: error code
- *   thread_p(in): thread entry
- *   oid(in): OID
- *   need_mvcc_update(in/out): true, if mvcc update is needed
- */
-int
-catcls_is_mvcc_update_needed (THREAD_ENTRY * thread_p, OID * oid, bool * need_mvcc_update)
-{
-  MVCC_REC_HEADER mvcc_rec_header;
-  int error = NO_ERROR;
-  OID forward_oid;
-  INT16 record_type;
-  PGBUF_WATCHER home_page_watcher;
-  PGBUF_WATCHER fwd_page_watcher;
-
-  PGBUF_INIT_WATCHER (&home_page_watcher, PGBUF_ORDERED_HEAP_NORMAL, PGBUF_ORDERED_NULL_HFID);
-  PGBUF_INIT_WATCHER (&fwd_page_watcher, PGBUF_ORDERED_HEAP_NORMAL, PGBUF_ORDERED_NULL_HFID);
-
-  assert (oid != NULL && need_mvcc_update != NULL);
-  if (heap_prepare_get_record (thread_p, oid, NULL, &forward_oid, &home_page_watcher, &fwd_page_watcher,
-			       &record_type, PGBUF_LATCH_READ, false, LOG_ERROR_IF_DELETED) != S_SUCCESS)
-    {
-      goto error;
-    }
-
-  if (heap_get_mvcc_header (thread_p, oid, &forward_oid, home_page_watcher.pgptr, fwd_page_watcher.pgptr,
-			    record_type, &mvcc_rec_header) != S_SUCCESS)
-    {
-      goto error;
-    }
-
-#if defined (SERVER_MODE)
-  if (mvcc_rec_header.mvcc_ins_id == logtb_get_current_mvccid (thread_p))
-    {
-      /* The record is inserted by current transaction, update in-place can be used instead of duplicating record */
-      *need_mvcc_update = false;
-    }
-  else
-    {
-      /* MVCC update */
-      *need_mvcc_update = true;
-    }
-#else	/* !SERVER_MODE */		   /* SA_MODE */
-  *need_mvcc_update = false;
-#endif /* SA_MODE */
-
-  if (home_page_watcher.pgptr != NULL)
-    {
-      pgbuf_ordered_unfix_and_init (thread_p, home_page_watcher.pgptr, &home_page_watcher);
-    }
-
-  if (fwd_page_watcher.pgptr != NULL)
-    {
-      pgbuf_ordered_unfix_and_init (thread_p, fwd_page_watcher.pgptr, &fwd_page_watcher);
-    }
-
-  return NO_ERROR;
-
-error:
-  if (home_page_watcher.pgptr != NULL)
-    {
-      pgbuf_ordered_unfix_and_init (thread_p, home_page_watcher.pgptr, &home_page_watcher);
-    }
-
-  if (fwd_page_watcher.pgptr != NULL)
-    {
-      pgbuf_ordered_unfix_and_init (thread_p, fwd_page_watcher.pgptr, &fwd_page_watcher);
-    }
-
-  error = er_errid ();
-  return ((error == NO_ERROR) ? ER_FAILED : error);
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20200

The issue is caused by not setting the link to log record with previous version when doing update-in-place.

The first alter does an MVCC update on db_class entry which also sets the LSA to previous version in heap record. The second alter does an update-in-place operation on same db_class entry (same-transaction update optimization) which does not set the LSA link to log record.

The MVCC versioning design in banana milestone had a huge problem modifying schemas in certain cases. For instance, creating a class with 1000 partitions would add each partition separately and flush/update the catalog class entries every time. As a consequence, the instances in catalog classes were updated 1k times and for each instance we created 1k versions.

To fix the problem we used "same-transaction update" optimization. If the version we wanted to update was already inserted or update by current transaction, we were using update in-place (like a non-MVCC design would do) instead of MVCC update.

Currently, we no longer have heap versions, but rather LSA links to log records where old versions can be found. From heap update point of view, the difference between non-mvcc in-place update and mvcc update is almost nothing (setting an LSA in record header is the only important difference).

A bigger difference appears when selecting the visible version. If a class which was concurrently altered by adding 1k partition is inspected ("select * from db_class where class_name = class_with_1k_partitions"), we have to iterate through 1k log records to find the visible version. However, this is not an interesting case, as concurrent inspection & major class alteration is unusual.

The sql regressions were successfully passed.