### PR TITLE
[CBRD-20175] Fix replication log : always perform index update before heap update.

### DIFF
--- a/src/executables/compactdb.c
+++ b/src/executables/compactdb.c
@@ -601,7 +601,7 @@ disk_update_instance (MOP classop, DESC_OBJ * obj, OID * oid)
     }
 
   heap_create_update_context (&update_context, hfid, oid, WS_OID (classop), Diskrec, NULL,
-			      UPDATE_INPLACE_CURRENT_MVCCID, false);
+			      UPDATE_INPLACE_CURRENT_MVCCID);
   if (heap_update_logical (NULL, &update_context) != NO_ERROR)
     {
       printf (msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_COMPACTDB, COMPACTDB_MSG_CANT_UPDATE));

--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -904,7 +904,7 @@ serial_update_serial_object (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, RECDES * r
   if (!LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true)
     {
       repl_log_insert (thread_p, serial_class_oidp, serial_oidp, LOG_REPLICATION_DATA, RVREPL_DATA_UPDATE, key_val,
-		       REPL_INFO_TYPE_RBR_NORMAL, true);
+		       REPL_INFO_TYPE_RBR_NORMAL);
       repl_add_update_lsa (thread_p, serial_oidp);
 
       if (lock_mode != X_LOCK)

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -3693,7 +3693,7 @@ catcls_insert_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
     }
 
   heap_create_update_context (&update_context, hfid_p, oid_p, class_oid_p, &record, scan_p,
-			      UPDATE_INPLACE_CURRENT_MVCCID, false);
+			      UPDATE_INPLACE_CURRENT_MVCCID);
   if (heap_update_logical (thread_p, &update_context) != NO_ERROR)
     {
       error = er_errid ();
@@ -3954,7 +3954,7 @@ catcls_update_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
 	}
 
       /* update in place */
-      heap_create_update_context (&update_context, hfid_p, oid_p, class_oid_p, &record, scan_p, force_in_place, false);
+      heap_create_update_context (&update_context, hfid_p, oid_p, class_oid_p, &record, scan_p, force_in_place);
       if (heap_update_logical (thread_p, &update_context) != NO_ERROR)
 	{
 	  assert (er_errid () != NO_ERROR);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -5827,7 +5827,7 @@ heap_assign_address (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid
   recdes.type = REC_ASSIGN_ADDRESS;
 
   /* create context */
-  heap_create_insert_context (&insert_context, (HFID *) hfid, class_oid, &recdes, NULL, false);
+  heap_create_insert_context (&insert_context, (HFID *) hfid, class_oid, &recdes, NULL);
 
   /* insert */
   rc = heap_insert_logical (thread_p, &insert_context);
@@ -21825,7 +21825,6 @@ heap_clear_operation_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p)
   OID_SET_NULL (&context->class_oid);
   context->recdes_p = NULL;
   context->scan_cache_p = NULL;
-  context->flags = 0;
 
   context->map_recdes.data = NULL;
   context->map_recdes.length = 0;
@@ -22191,8 +22190,6 @@ heap_insert_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEX
 static int
 heap_insert_handle_multipage_record (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
 {
-  bool use_bigone_maxsize = false;
-
   assert (context != NULL);
   assert (context->type == HEAP_OPERATION_INSERT || context->type == HEAP_OPERATION_UPDATE);
   assert (context->recdes_p != NULL);
@@ -22208,8 +22205,6 @@ heap_insert_handle_multipage_record (THREAD_ENTRY * thread_p, HEAP_OPERATION_CON
     {
       return ER_FAILED;
     }
-
-  use_bigone_maxsize = HEAP_OP_CONTEXT_IS_FLAG_SET (context->flags, HEAP_OP_CONTEXT_FLAG_BIGONE_MAXSIZE);
 
   /* Add a map record to point to the record in overflow */
   /* NOTE: MVCC information is held in overflow record */
@@ -22448,7 +22443,7 @@ heap_insert_newhome (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * parent_co
   assert (parent_context->type == HEAP_OPERATION_DELETE || parent_context->type == HEAP_OPERATION_UPDATE);
 
   /* build insert context */
-  heap_create_insert_context (&ins_context, &parent_context->hfid, &parent_context->class_oid, recdes_p, NULL, false);
+  heap_create_insert_context (&ins_context, &parent_context->hfid, &parent_context->class_oid, recdes_p, NULL);
 
   /* physical insertion */
   error_code = heap_find_location_and_insert_rec_newhome (thread_p, &ins_context);
@@ -24350,12 +24345,10 @@ heap_log_update_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, VFID * vfid_
  *   class_oid_p(in): class OID
  *   recdes_p(in): record descriptor to insert
  *   scancache_p(in): scan cache to use (optional)
- *   bigone_max_size(in): use maximum record size
- *			      (reserve space for an extra OID) for REC_BIGONE
  */
 void
 heap_create_insert_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID * class_oid_p, RECDES * recdes_p,
-			    HEAP_SCANCACHE * scancache_p, bool bigone_max_size)
+			    HEAP_SCANCACHE * scancache_p)
 {
   assert (context != NULL);
   assert (hfid_p != NULL);
@@ -24369,10 +24362,6 @@ heap_create_insert_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID
   context->recdes_p = recdes_p;
   context->scan_cache_p = scancache_p;
   context->type = HEAP_OPERATION_INSERT;
-  if (bigone_max_size == true)
-    {
-      HEAP_OP_CONTEXT_SET_FLAG (context->flags, HEAP_OP_CONTEXT_FLAG_BIGONE_MAXSIZE);
-    }
 }
 
 /*
@@ -24408,13 +24397,10 @@ heap_create_delete_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID
  *   recdes_p(in): updated record to write
  *   scancache_p(in): scan cache to use (optional)
  *   in_place(in): specifies if the "in place" type of the update operation
- *   bigone_max_size(in): use maximum record size
- *			      (reserve space for an extra OID) for REC_BIGONE 
  */
 void
 heap_create_update_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID * oid_p, OID * class_oid_p,
-			    RECDES * recdes_p, HEAP_SCANCACHE * scancache_p, UPDATE_INPLACE_STYLE in_place,
-			    bool bigone_max_size)
+			    RECDES * recdes_p, HEAP_SCANCACHE * scancache_p, UPDATE_INPLACE_STYLE in_place)
 {
   assert (context != NULL);
   assert (hfid_p != NULL);
@@ -24429,10 +24415,6 @@ heap_create_update_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID
   context->scan_cache_p = scancache_p;
   context->type = HEAP_OPERATION_UPDATE;
   context->update_in_place = in_place;
-  if (bigone_max_size == true)
-    {
-      HEAP_OP_CONTEXT_SET_FLAG (context->flags, HEAP_OP_CONTEXT_FLAG_BIGONE_MAXSIZE);
-    }
 }
 
 /*

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -285,7 +285,6 @@ struct heap_operation_context
   OID class_oid;		/* class object identifier */
   RECDES *recdes_p;		/* record descriptor */
   HEAP_SCANCACHE *scan_cache_p;	/* scan cache */
-  unsigned int flags;		/* flags */
 
   /* overflow transient data */
   RECDES map_recdes;		/* built record descriptor during multipage insert */
@@ -318,16 +317,6 @@ struct heap_operation_context
   /* Performance stat dump. */
   PERF_UTIME_TRACKER *time_track;
 };
-
-/* HEAP_OPERATION_CONTEXT flags */
-enum
-{
-  HEAP_OP_CONTEXT_FLAG_BIGONE_MAXSIZE = 0x0001
-};
-
-#define HEAP_OP_CONTEXT_SET_FLAG(var, flag)          ((var) |= (flag))
-#define HEAP_OP_CONTEXT_CLEAR_FLAG(var, flag)        ((var) &= (flag))
-#define HEAP_OP_CONTEXT_IS_FLAG_SET(var, flag)       ((var) & (flag))
 
 enum
 { END_SCAN, CONTINUE_SCAN };
@@ -629,12 +618,11 @@ extern int heap_scancache_quick_start_modify_with_class_oid (THREAD_ENTRY * thre
 extern SCAN_CODE heap_mvcc_lock_object (THREAD_ENTRY * thread_p, OID * oid, OID * class_oid, LOCK lock_mode,
 					SNAPSHOT_TYPE snapshot_type);
 extern void heap_create_insert_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID * class_oid_p,
-					RECDES * recdes_p, HEAP_SCANCACHE * scancache_p, bool bigone_max_size);
+					RECDES * recdes_p, HEAP_SCANCACHE * scancache_p);
 extern void heap_create_delete_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID * oid_p, OID * class_oid_p,
 					HEAP_SCANCACHE * scancache_p);
 extern void heap_create_update_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID * oid_p, OID * class_oid_p,
-					RECDES * recdes_p, HEAP_SCANCACHE * scancache_p, UPDATE_INPLACE_STYLE in_place,
-					bool bigone_max_size);
+					RECDES * recdes_p, HEAP_SCANCACHE * scancache_p, UPDATE_INPLACE_STYLE in_place);
 extern int heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);
 extern int heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);
 extern int heap_update_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -659,7 +659,7 @@ boot_add_volume (THREAD_ENTRY * thread_p, DBDEF_VOL_EXT_INFO * ext_info)
   log_append_undo_data2 (thread_p, RVPGBUF_FLUSH_PAGE, NULL, NULL, 0, sizeof (boot_db_parm_vpid), &boot_db_parm_vpid);
 
   heap_create_update_context (&update_context, &boot_Db_parm->hfid, boot_Db_parm_oid, &boot_Db_parm->rootclass_oid,
-			      &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID, false);
+			      &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID);
   if (heap_update_logical (thread_p, &update_context) != NO_ERROR)
     {
       /* Return back our global area of system parameter */
@@ -812,7 +812,7 @@ boot_remove_temp_volume (THREAD_ENTRY * thread_p, VOLID volid, REMOVE_TEMP_VOL_A
       recdes.data = (char *) boot_Db_parm;
 
       heap_create_update_context (&update_context, &boot_Db_parm->hfid, boot_Db_parm_oid, &boot_Db_parm->rootclass_oid,
-				  &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID, false);
+				  &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID);
       if (heap_update_logical (thread_p, &update_context) != NO_ERROR)
 	{
 	  boot_Db_parm->temp_nvols++;
@@ -1849,7 +1849,7 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
       recdes.data = (char *) boot_Db_parm;
 
       heap_create_update_context (&update_context, &boot_Db_parm->hfid, boot_Db_parm_oid, &boot_Db_parm->rootclass_oid,
-				  &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID, false);
+				  &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID);
       if (heap_update_logical (thread_p, &update_context) != NO_ERROR
 	  || xtran_server_commit (thread_p, false) != TRAN_UNACTIVE_COMMITTED)
 	{
@@ -1911,7 +1911,7 @@ boot_xremove_perm_volume (THREAD_ENTRY * thread_p, VOLID volid)
   recdes.data = (char *) boot_Db_parm;
 
   heap_create_update_context (&update_context, &boot_Db_parm->hfid, boot_Db_parm_oid, &boot_Db_parm->rootclass_oid,
-			      &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID, false);
+			      &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID);
   if (heap_update_logical (thread_p, &update_context) != NO_ERROR)
     {
       boot_Db_parm->nvols++;
@@ -3703,7 +3703,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       recdes.data = (char *) boot_Db_parm;
 
       heap_create_update_context (&update_context, &boot_Db_parm->hfid, boot_Db_parm_oid, &boot_Db_parm->rootclass_oid,
-				  &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID, false);
+				  &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID);
       if (heap_update_logical (thread_p, &update_context) != NO_ERROR
 	  || xtran_server_commit (thread_p, false) != TRAN_UNACTIVE_COMMITTED)
 	{
@@ -5915,7 +5915,7 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
   recdes.data = (char *) boot_Db_parm;
 
   /* Prepare context */
-  heap_create_insert_context (&heapop_context, &boot_Db_parm->hfid, &boot_Db_parm->rootclass_oid, &recdes, NULL, false);
+  heap_create_insert_context (&heapop_context, &boot_Db_parm->hfid, &boot_Db_parm->rootclass_oid, &recdes, NULL);
 
   /* Insert and fetch location */
   if (heap_insert_logical (thread_p, &heapop_context) != NO_ERROR)
@@ -5939,7 +5939,7 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
 
   /* Update boot_Db_parm */
   heap_create_update_context (&update_context, &boot_Db_parm->hfid, boot_Db_parm_oid, &boot_Db_parm->rootclass_oid,
-			      &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID, false);
+			      &recdes, NULL, UPDATE_INPLACE_CURRENT_MVCCID);
   if (heap_update_logical (thread_p, &update_context) != NO_ERROR)
     {
       goto error;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -6152,6 +6152,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	  
       heap_create_update_context (&update_context, hfid, oid, class_oid, recdes, local_scan_cache, force_in_place,
 				  use_bigone_maxsize);
+      _er_log_debug (ARG_FILE_LINE, "heap_update_logical");
       error_code = heap_update_logical (thread_p, &update_context);
       if (error_code != NO_ERROR)
 	{
@@ -6176,6 +6177,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
        * We have to set UPDATE LSA number to the log info.
        * The target log info was already created when the locator_update_index
        */
+      _er_log_debug (ARG_FILE_LINE, "before repl_add_update_lsa : repl_info.need_replication:%d", repl_info.need_replication);
       if (!LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true
 	  && repl_info.need_replication == true)
 	{
@@ -8638,6 +8640,7 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 
   mvccid = MVCCID_NULL;
 
+  _er_log_debug (ARG_FILE_LINE, "locator_update_index : OID:(%d,%d,%d)", oid->volid, oid->pageid, oid->slotid);
 #if defined(SERVER_MODE)
   if (!heap_is_mvcc_disabled_for_class (class_oid))
     {

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -6176,8 +6176,8 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
        * We have to set UPDATE LSA number to the log info.
        * The target log info was already created when the locator_update_index
        */
-      if (HEAP_IS_UPDATE_INPLACE (force_in_place) && !LOG_CHECK_LOG_APPLIER (thread_p)
-	  && log_does_allow_replication () == true && repl_info.need_replication == true)
+      if (!LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true
+	  && repl_info.need_replication == true)
 	{
 	  repl_add_update_lsa (thread_p, oid);
 	}

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -4962,7 +4962,8 @@ la_apply_update_log (LA_ITEM * item)
 
       goto end;
     }
-  if (rcvindex != RVHF_UPDATE && rcvindex != RVOVF_CHANGE_LINK && rcvindex != RVHF_MVCC_INSERT)
+  if (rcvindex != RVHF_UPDATE && rcvindex != RVOVF_CHANGE_LINK && rcvindex != RVHF_MVCC_INSERT
+      && rcvindex != RVHF_UPDATE_NOTIFY_VACUUM)
     {
       er_log_debug (ARG_FILE_LINE, "apply_update : rcvindex = %d\n", rcvindex);
       error = ER_FAILED;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -2321,7 +2321,7 @@ log_append_redo_crumbs (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DATA
   if (!LOG_CHECK_LOG_APPLIER (thread_p) && !VACUUM_IS_THREAD_VACUUM_WORKER (thread_p)
       && log_does_allow_replication () == true)
     {
-      if (rcvindex == RVHF_UPDATE || rcvindex == RVOVF_CHANGE_LINK)
+      if (rcvindex == RVHF_UPDATE || rcvindex == RVOVF_CHANGE_LINK || rcvindex == RVHF_UPDATE_NOTIFY_VACUUM)
 	{
 	  LSA_COPY (&tdes->repl_update_lsa, &tdes->tail_lsa);
 	}

--- a/src/transaction/replication.c
+++ b/src/transaction/replication.c
@@ -245,11 +245,12 @@ repl_add_update_lsa (THREAD_ENTRY * thread_p, const OID * inst_oid)
   for (i = tdes->cur_repl_record - 1; i >= 0; i--)
     {
       repl_rec = (LOG_REPL_RECORD *) & tdes->repl_records[i];
+      _er_log_debug (ARG_FILE_LINE, "before repl_add_update_lsa : repl_rec->inst_oid:(%d,%d,%d), oid:(%d,%d,%d), repl_rec->rcvindex:%d ",
+	repl_rec->inst_oid.volid, repl_rec->inst_oid.pageid, repl_rec->inst_oid.slotid,  
+	inst_oid->volid, inst_oid->pageid, inst_oid->slotid, repl_rec->rcvindex);
+
       if (OID_EQ (&repl_rec->inst_oid, inst_oid) && !LSA_ISNULL (&tdes->repl_update_lsa))
 	{
-	_er_log_debug (ARG_FILE_LINE, "before repl_add_update_lsa : oid:(%d,%d,%d), repl_rec->rcvindex:%d ",
-	  inst_oid->volid, inst_oid->pageid, inst_oid->slotid, repl_rec->rcvindex);
-
 	  assert (repl_rec->rcvindex == RVREPL_DATA_UPDATE || repl_rec->rcvindex == RVREPL_DATA_UPDATE_START
 		  || repl_rec->rcvindex == RVREPL_DATA_UPDATE_END);
 	  if (repl_rec->rcvindex == RVREPL_DATA_UPDATE || repl_rec->rcvindex == RVREPL_DATA_UPDATE_START

--- a/src/transaction/replication.c
+++ b/src/transaction/replication.c
@@ -247,6 +247,9 @@ repl_add_update_lsa (THREAD_ENTRY * thread_p, const OID * inst_oid)
       repl_rec = (LOG_REPL_RECORD *) & tdes->repl_records[i];
       if (OID_EQ (&repl_rec->inst_oid, inst_oid) && !LSA_ISNULL (&tdes->repl_update_lsa))
 	{
+	_er_log_debug (ARG_FILE_LINE, "before repl_add_update_lsa : oid:(%d,%d,%d), repl_rec->rcvindex:%d ",
+	  inst_oid->volid, inst_oid->pageid, inst_oid->slotid, repl_rec->rcvindex);
+
 	  assert (repl_rec->rcvindex == RVREPL_DATA_UPDATE || repl_rec->rcvindex == RVREPL_DATA_UPDATE_START
 		  || repl_rec->rcvindex == RVREPL_DATA_UPDATE_END);
 	  if (repl_rec->rcvindex == RVREPL_DATA_UPDATE || repl_rec->rcvindex == RVREPL_DATA_UPDATE_START

--- a/src/transaction/replication.h
+++ b/src/transaction/replication.h
@@ -79,8 +79,7 @@ extern void repl_schema_log_dump (FILE * fp, int length, void *data);
 extern void repl_log_send (void);
 extern int repl_add_update_lsa (THREAD_ENTRY * thread_p, const OID * inst_oid);
 extern int repl_log_insert (THREAD_ENTRY * thread_p, const OID * class_oid, const OID * inst_oid, LOG_RECTYPE log_type,
-			    LOG_RCVINDEX rcvindex, DB_VALUE * key_dbvalue, REPL_INFO_TYPE repl_type,
-			    bool is_update_inplace);
+			    LOG_RCVINDEX rcvindex, DB_VALUE * key_dbvalue, REPL_INFO_TYPE repl_type);
 extern int repl_log_insert_statement (THREAD_ENTRY * thread_p, REPL_INFO_SBR * repl_info);
 extern void repl_start_flush_mark (THREAD_ENTRY * thread_p);
 extern void repl_end_flush_mark (THREAD_ENTRY * thread_p, bool need_undo);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20175

Removed some unused or obsolete arguments and variables.