### PR TITLE
[CBRD-20219] Do not unfix all pages at the end of a vacuum job in stand-alone mode

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3108,8 +3108,12 @@ end:
       vacuum_finished_block_vacuum (thread_p, data, vacuum_complete);
     }
 
+#if defined (SERVER_MODE)
   /* Unfix all pages now. Normally all pages should already be unfixed. */
   pgbuf_unfix_all (thread_p);
+#else /* !SERVER_MODE */ /* SA_MODE */
+  /* Do not unfix all in stand-alone. Not yet. We need to keep vacuum data pages fixed. */
+#endif /* SA_MODE */
 
   PERF_UTIME_TRACKER_TIME_AND_RESTART (thread_p, &perf_tracker, mnt_vac_worker_execute_time);
 


### PR DESCRIPTION
At the end of vacuum job we call pgbuf_unfix_all. It makes sure no pages are still latched (and hits an assert if any pages are fixed). In stand-alone, while running vacuum jobs we also keep vacuum data pages latched. Therefore, we cannot call pgbuf_unfix_all.