### PR TITLE
[CBRD-20210] S_LOCK on referenced table when altering a trigger.

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -6338,17 +6338,38 @@ do_alter_trigger (PARSER_CONTEXT * parser, PT_NODE * statement)
 
 	  for (t = triggers; t != NULL && error == NO_ERROR; t = t->next)
 	    {
+	      /* If trigger is on a class, lock it (S_LOCK) to block concurrent DML statements. */
+	      trigger = tr_map_trigger (t->op, false);
+	      if (trigger->class_mop != NULL)
+		{
+		  if (locator_fetch_class (trigger->class_mop, DB_FETCH_SCAN) == NULL)
+		    {
+		      ASSERT_ERROR_AND_SET (error);
+		      break;
+		    }
+		}
+
 	      if (status != TR_STATUS_INVALID)
 		{
 		  error = tr_set_status (t->op, status, false);
+		  if (error != NO_ERROR)
+		    {
+		      ASSERT_ERROR ();
+		      break;
+		    }
 		}
 
-	      if (error == NO_ERROR && p_node != NULL)
+	      if (p_node != NULL)
 		{
 		  error = tr_set_priority (t->op, priority, false);
+		  if (error != NO_ERROR)
+		    {
+		      ASSERT_ERROR ();
+		      break;
+		    }
 		}
 
-	      if (error == NO_ERROR && trigger_owner != NULL)
+	      if (trigger_owner != NULL)
 		{
 		  assert (trigger_name != NULL);
 
@@ -6368,35 +6389,21 @@ do_alter_trigger (PARSER_CONTEXT * parser, PT_NODE * statement)
 		  trigger_name = trigger_name->next;
 		}
 
-	      if (error == NO_ERROR && has_trigger_comment)
+	      if (has_trigger_comment)
 		{
 		  error = tr_set_comment (t->op, trigger_comment, false);
+		  if (error != NO_ERROR)
+		    {
+		      ASSERT_ERROR ();
+		      break;
+		    }
 		}
 
-	      mop1 = ws_mvcc_latest_version (t->op);
 	      error = locator_flush_instance (t->op);
 	      if (error != NO_ERROR)
 		{
+		  ASSERT_ERROR ();
 		  break;
-		}
-
-	      mop2 = ws_mvcc_latest_version (t->op);
-	      if (ws_mop_compare (mop1, mop2) != 0)
-		{
-		  trigger = tr_map_trigger (t->op, false);
-		  if (trigger == NULL)
-		    {
-		      continue;
-		    }
-
-		  /* update the class hierarchy with new (latest) db_trigger instance mop. Otherwise, the class record
-		   * refer the old version of db_trigger instance. The old version may be removed by VACUUM <=> remove
-		   * class trigger. */
-		  error = sm_touch_class (trigger->class_mop);
-		  if (error != NO_ERROR)
-		    {
-		      break;
-		    }
 		}
 	    }
 	}

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -6338,17 +6338,6 @@ do_alter_trigger (PARSER_CONTEXT * parser, PT_NODE * statement)
 
 	  for (t = triggers; t != NULL && error == NO_ERROR; t = t->next)
 	    {
-	      /* If trigger is on a class, lock it (S_LOCK) to block concurrent DML statements. */
-	      trigger = tr_map_trigger (t->op, false);
-	      if (trigger->class_mop != NULL)
-		{
-		  if (locator_fetch_class (trigger->class_mop, DB_FETCH_SCAN) == NULL)
-		    {
-		      ASSERT_ERROR_AND_SET (error);
-		      break;
-		    }
-		}
-
 	      if (status != TR_STATUS_INVALID)
 		{
 		  error = tr_set_status (t->op, status, false);
@@ -6404,6 +6393,17 @@ do_alter_trigger (PARSER_CONTEXT * parser, PT_NODE * statement)
 		{
 		  ASSERT_ERROR ();
 		  break;
+		}
+
+	      /* If trigger is on a class, lock it (S_LOCK) to block concurrent DML statements. */
+	      trigger = tr_map_trigger (t->op, false);
+	      if (trigger->class_mop != NULL)
+		{
+		  if (locator_fetch_class (trigger->class_mop, DB_FETCH_SCAN) == NULL)
+		    {
+		      ASSERT_ERROR_AND_SET (error);
+		      break;
+		    }
 		}
 	    }
 	}

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3108,8 +3108,12 @@ end:
       vacuum_finished_block_vacuum (thread_p, data, vacuum_complete);
     }
 
+#if defined (SERVER_MODE)
   /* Unfix all pages now. Normally all pages should already be unfixed. */
   pgbuf_unfix_all (thread_p);
+#else /* !SERVER_MODE */ /* SA_MODE */
+  /* Do not unfix all in stand-alone. Not yet. We need to keep vacuum data pages fixed. */
+#endif /* SA_MODE */
 
   PERF_UTIME_TRACKER_TIME_AND_RESTART (thread_p, &perf_tracker, mnt_vac_worker_execute_time);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20210

We used to have SCH_M_LOCK in banana, because trigger OID changed when altered. Therefore, db_class entry of table also had to be updated (where trigger OID's were kept).

We no longer change trigger OID and we do not require to update db_class entry. We still use S_LOCK to prevent conflicts with concurrent DML statements.