### PR TITLE
[CBRD-20229] Fix assign vacuum worker

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5080,6 +5080,9 @@ vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p)
      vacuum_Data.last_blockid + 1 : vacuum_Data.first_page->data[vacuum_Data.first_page->index_unvacuumed].blockid);
   keep_from_blockid = VACUUM_BLOCKID_WITHOUT_FLAGS (keep_from_blockid);
   vacuum_Data.keep_from_log_pageid = VACUUM_FIRST_LOG_PAGEID_IN_BLOCK (keep_from_blockid);
+
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
+		 "VACUUM: Update keep_from_log_pageid to %lld", (long long int) vacuum_Data.keep_from_log_pageid);
 }
 
 /*

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3218,6 +3218,10 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   /* Save worker to thread entry */
   thread_p->vacuum_worker = worker;
 
+  vacuum_er_log (VACUUM_ER_LOG_WORKER,
+		 "VACUUM: Assigned vacuum_worker %p, index %d to thread %p, index %d.\n",
+		 worker, save_assigned_workers_count, thread_p, thread_p->index);
+
   if (vacuum_Prefetch_log_mode == VACUUM_PREFETCH_LOG_MODE_WORKERS && worker->prefetch_log_buffer == NULL)
     {
       size_worker_prefetch_log_buffer =

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3241,8 +3241,6 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   /* Safe guard - it is assumed that transaction descriptor is already initialized. */
   assert (worker->tdes != NULL);
 
-  /* Increment number of assigned workers */
-  vacuum_Assigned_workers_count++;
   return NO_ERROR;
 
 error:


### PR DESCRIPTION
Removed code that incremented the number of assigned vacuum workers a second time.

@eseokoh : This is not the original issue of CBRD-20229. This is the issue I reproduced by running the same scenario. The original issue did not reproduce and I could not investigate the core files on the issue because the machine IP was missing.
I can create a new issue for this problem and add the fix with the new issue number.