### PR TITLE
[CBRD-20238] Update assert check in log_append_dboutside_redo: vacuum master can call function because it allocates pages for vacuum data.

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -2535,7 +2535,7 @@ log_append_dboutside_redo (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, int l
     }
 
   /* Vacuum workers are not allowed to use this type of log records. */
-  assert (!VACUUM_IS_THREAD_VACUUM (thread_p));
+  assert (!VACUUM_IS_THREAD_VACUUM_WORKER (thread_p));
 
   /* Find transaction descriptor for current logging transaction */
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20238