### PR TITLE
[CBRD-20240] fix redo logging of btree_key_remove_object_and_keep_visible_first for release builds.

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -31778,13 +31778,9 @@ exit:
 }
 
 /*
- * btree_key_remove_object_and_keep_visible_first () - Remove one object and
- *						       all its info from
- *						       b-tree key. Then find
- *						       other visible version
- *						       and move it first in
- *						       leaf record. Special
- *						       case of unique index.
+ * btree_key_remove_object_and_keep_visible_first () - Remove one object and all its info from b-tree key. Then find
+ *						       other visible version and move it first in leaf record. 
+ *                                                     Special case of unique index.
  *
  * return	   : Error code.
  * thread_p (in)   : Thread entry.
@@ -31996,11 +31992,12 @@ btree_key_remove_object_and_keep_visible_first (THREAD_ENTRY * thread_p, BTID_IN
 	  goto exit;
 	}
 
+      rv_undo_data_ptr = rv_undo_data;
+      rv_redo_data_ptr = rv_redo_data;
+
 #if !defined (NDEBUG)
       /* Leaf may have been logged if object was removed from overflow page. Reset logging structures for new logging.
        */
-      rv_undo_data_ptr = rv_undo_data;
-      rv_redo_data_ptr = rv_redo_data;
       delete_helper->leaf_addr.offset = search_key->slotid;
       BTREE_RV_UNDOREDO_SET_DEBUG_INFO (&delete_helper->leaf_addr, rv_redo_data_ptr, rv_undo_data_ptr, btid_int,
 					BTREE_RV_DEBUG_ID_UNDO_INS_UNQ_MUPD);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1772,10 +1772,16 @@ log_append_undoredo_data (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DA
   LOG_CRUMB redo_crumb;
 
   /* Set undo length/data to crumb */
+  assert (0 <= undo_length);
+  assert (0 == undo_length || undo_data != NULL);
+
   undo_crumb.data = undo_data;
   undo_crumb.length = undo_length;
 
   /* Set redo length/data to crumb */
+  assert (0 <= redo_length);
+  assert (0 == redo_length || redo_data != NULL);
+
   redo_crumb.data = redo_data;
   redo_crumb.length = redo_length;
 
@@ -1797,10 +1803,16 @@ log_append_undoredo_data2 (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, const
   addr.offset = offset;
 
   /* Set undo length/data to crumb */
+  assert (0 <= undo_length);
+  assert (0 == undo_length || undo_data != NULL);
+
   undo_crumb.data = undo_data;
   undo_crumb.length = undo_length;
 
   /* Set redo length/data to crumb */
+  assert (0 <= redo_length);
+  assert (0 == redo_length || redo_data != NULL);
+
   redo_crumb.data = redo_data;
   redo_crumb.length = redo_length;
 
@@ -1839,6 +1851,9 @@ log_append_undo_data (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DATA_A
   LOG_CRUMB undo_crumb;
 
   /* Set length/data to crumb */
+  assert (0 <= length);
+  assert (0 == length || data != NULL);
+
   undo_crumb.data = data;
   undo_crumb.length = length;
 
@@ -1858,6 +1873,9 @@ log_append_undo_data2 (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, const VFI
   addr.offset = offset;
 
   /* Set length/data to crumb */
+  assert (0 <= length);
+  assert (0 == length || data != NULL);
+
   undo_crumb.data = data;
   undo_crumb.length = length;
 
@@ -1895,6 +1913,9 @@ log_append_redo_data (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DATA_A
   LOG_CRUMB redo_crumb;
 
   /* Set length/data to crumb */
+  assert (0 <= length);
+  assert (0 == length || data != NULL);
+
   redo_crumb.data = data;
   redo_crumb.length = length;
 
@@ -1914,6 +1935,9 @@ log_append_redo_data2 (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, const VFI
   addr.offset = offset;
 
   /* Set length/data to crumb */
+  assert (0 <= length);
+  assert (0 == length || data != NULL);
+
   redo_crumb.data = data;
   redo_crumb.length = length;
 
@@ -2023,9 +2047,8 @@ log_append_undoredo_crumbs (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_
    * Now do the UNDO & REDO portion
    */
 
-  node =
-    prior_lsa_alloc_and_copy_crumbs (thread_p, rectype, rcvindex, addr, num_undo_crumbs, undo_crumbs, num_redo_crumbs,
-				     redo_crumbs);
+  node = prior_lsa_alloc_and_copy_crumbs (thread_p, rectype, rcvindex, addr, num_undo_crumbs, undo_crumbs,
+					  num_redo_crumbs, redo_crumbs);
   if (node == NULL)
     {
       return;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20240

Only release builds suffer from this defect. Since `rv_redo_data_ptr` was not set, redo data length would be negative and this leads to memory overrun. 
It also includes assertions and refactoring of logging functions.