### PR TITLE
[CBRD-20161] Fix Windows build - remove db_get_session_mode from def files

### DIFF
--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -717,7 +717,6 @@ EXPORTS
     db_get_query_type_ptr
     db_get_serial_current_value
     db_get_serial_next_value
-    db_get_session_mode
     db_get_shared
     db_get_shared_attribute
     db_get_shared_attribute_names

--- a/win/cubridsa/cubridsa.def
+++ b/win/cubridsa/cubridsa.def
@@ -460,7 +460,6 @@ EXPORTS
     db_get_resultset
     db_get_serial_current_value
     db_get_serial_next_value
-    db_get_session_mode
     db_get_shared
     db_get_shared_attribute
     db_get_shared_attribute_names


### PR DESCRIPTION
`db_get_session_mode` function was removed during refactoring, however, def files still include it. This causes unresolved external symbol error. 