### PR TITLE
[CBRD-20256] fixes qfile_allocate_new_page to set ER_INTERRUPTED error.

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -1514,6 +1514,7 @@ qfile_allocate_new_page (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id_p, PAG
 #if defined (SERVER_MODE)
   if (qmgr_is_query_interrupted (thread_p, list_id_p->query_id) == true)
     {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERRUPTED, 0);
       return NULL;
     }
 #endif /* SERVER_MODE */

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -21316,12 +21316,7 @@ wrapup:
   return (analytic_state.state == NO_ERROR) ? NO_ERROR : ER_FAILED;
 
 exit_on_error:
-  assert (er_errid () != NO_ERROR);
-  analytic_state.state = er_errid ();
-  if (analytic_state.state == NO_ERROR)
-    {
-      analytic_state.state = ER_FAILED;
-    }
+  ASSERT_ERROR_AND_SET (analytic_state.state);
 
   if (!finalized)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20256

The worker was interrupted but it didn't set an error. Query Executor expects an error was set.