### PR TITLE
[CBRD-20265] fix unupdated usages of gen_tz utility. database name would be omitted.

### DIFF
--- a/msg/de_DE.utf8/utils.msg
+++ b/msg/de_DE.utf8/utils.msg
@@ -1077,7 +1077,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 gen_tz: Generieren Sie Quelldateien enthält, Zeitzone Daten, die in einer gemeinsamen\n\
         Bibliothek kompiliert werden.\n\
 Anwendung: %s gen_tz [OPTION]\n\
-           %s gen_tz -g extend [OPTION] Datenbank-Name\n\
+           %s gen_tz -g extend [OPTION] [Datenbank-Name]\n\
 \n\
 gültigen Optionen:\n\
   -i, --input-folder    Pfad zu einem Eingangsordner enthält eine Version von IANA\n\

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -1078,7 +1078,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 gen_tz: Generate source files containing timezone data to be compiled into\n\
         a shared library.\n\
 usage: %s gen_tz [OPTION]\n\
-       %s gen_tz -g extend [OPTION] database-name\n\
+       %s gen_tz -g extend [OPTION] [database-name]\n\
 \n\
 valid options:\n\
   -i, --input-folder    path to an input folder containing a version of\n\

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -1081,7 +1081,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 gen_tz: Generate source files containing timezone data to be compiled into\n\
         a shared library.\n\
 usage: %s gen_tz [OPTION]\n\
-       %s gen_tz -g extend [OPTION] database-name\n\
+       %s gen_tz -g extend [OPTION] [database-name]\n\
 \n\
 valid options:\n\
   -i, --input-folder    path to an input folder containing a version of\n\

--- a/msg/es_ES.utf8/utils.msg
+++ b/msg/es_ES.utf8/utils.msg
@@ -1078,7 +1078,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 gen_tz: Generar archivos fuente conteniendo datos de zona horaria a ser compilados dentro de\n\
         una biblioteca compartida.\n\
 uso: %s gen_tz [OPTION]\n\
-       %s gen_tz -g extend [OPTION] database-name\n\
+       %s gen_tz -g extend [OPTION] [database-name]\n\
 \n\
 opciones validas:\n\
   -i, --input-folder    camino hacia una carpeta de entradas conteniendo una version de\n\

--- a/msg/fr_FR.utf8/utils.msg
+++ b/msg/fr_FR.utf8/utils.msg
@@ -1088,7 +1088,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 gen_tz: Générer les fichiers source contenant des données de fuseau horaire à être compilés dans\n\
         une bibliothèque partagée.\n\
 usage: %s gen_tz [OPTION]\n\
-       %s gen_tz -g extend [OPTION] database-name\n\
+       %s gen_tz -g extend [OPTION] [database-name]\n\
 \n\
 options valides:\n\
   -i, --input-folder	chemin d'accès à un dossier d'entrée contenant une version des\n\

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -1078,6 +1078,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 gen_tz: Generare file sorgente contenenti dati fuso orario da elaborare in\n\
         una libreria condivisa.\n\
 uso: %s gen_tz [OPTION]\n\
+     %s gen_tz -g extend [OPTION] [nome-database]\n\
 \n\
 opzioni valide:\n\
   -i, --input-folder    path di una cartella di input che contiene una versione di\n\

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -1077,7 +1077,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 gen_tz: 共有ライブラリにコンパイルするタイムゾーンデータが含まれている\n\
         ソースファイルを生成します。\n\
 使い方: %s gen_tz [OPTION]\n\
-        %s gen_tz -g extend [OPTION] database-name\n\
+        %s gen_tz -g extend [OPTION] [database-name]\n\
 \n\
 オプション:\n\
   -i, --input-folder    IANAのタイムゾーンデータベースファイルのバージョンが\n\

--- a/msg/km_KH.utf8/utils.msg
+++ b/msg/km_KH.utf8/utils.msg
@@ -1078,7 +1078,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 gen_tz: Generate source files containing timezone data to be compiled into\n\
         a shared library.\n\
 usage: %s gen_tz [OPTION]\n\
-       %s gen_tz -g extend [OPTION] database-name\n\
+       %s gen_tz -g extend [OPTION] [database-name]\n\
 \n\
 valid options:\n\
   -i, --input-folder    path to an input folder containing a version of\n\

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -1074,7 +1074,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 61 \
 gen_tz: 타임존 데이터를 포함하는 소스 파일을 생성하여 공유 라이브러리로 컴파일\n\
 사용법: %s gen_tz [옵션]\n\
-       %s gen_tz -g extend [옵션] database-name\n\
+       %s gen_tz -g extend [옵션] [database-name]\n\
 \n\
 valid options:\n\
   -i, --input-folder    IANA 타임존 데이터베이스 파일을 포함하는 입력 디렉터리 경로\n\

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -1074,7 +1074,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 61 \
 gen_tz: 타임존 데이터를 포함하는 소스 파일을 생성하여 공유 라이브러리로 컴파일\n\
 사용법: %s gen_tz [옵션]\n\
-       %s gen_tz -g extend [옵션] database-name\n\
+       %s gen_tz -g extend [옵션] [database-name]\n\
 \n\
 valid options:\n\
   -i, --input-folder    IANA 타임존 데이터베이스 파일을 포함하는 입력 디렉터리 경로\n\

--- a/msg/ro_RO.utf8/utils.msg
+++ b/msg/ro_RO.utf8/utils.msg
@@ -1100,7 +1100,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 gen_tz: Generează fișiere ce conțin informații timezone, pentru a fi compilate\n\
         într-o librărie shared.\n\
 utilizare: %s gen_tz [OPTION]\n\
-       %s gen_tz -g extend [OPTION] database-name\n\
+       %s gen_tz -g extend [OPTION] [database-name]\n\
 \n\
 opțiuni valide:\n\
   -i, --input-folder    calea pentru un fișier input ce conține o versiune a\n\

--- a/msg/tr_TR.utf8/utils.msg
+++ b/msg/tr_TR.utf8/utils.msg
@@ -1078,7 +1078,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 gen_tz: Saat dilimi verileri ile kaynak dosyaları oluşturun paylaşılan kütüphane\n\
         derlenmiş için\n\
 kullanım: %s gen_tz [OPTION]\n\
-          %s gen_tz -g extend [OPTION] database-name\n\
+          %s gen_tz -g extend [OPTION] [database-name]\n\
 \n\
 geçerli seçenekler:\n\
   -i, --input-folder    Bir IANA saat dilimi sürümünü içeren giriş klasörünün yolunu.\n\

--- a/msg/vi_VN.utf8/utils.msg
+++ b/msg/vi_VN.utf8/utils.msg
@@ -1078,7 +1078,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 gen_tz: Generate source files containing timezone data to be compiled into\n\
         a shared library.\n\
 usage: %s gen_tz [OPTION]\n\
-       %s gen_tz -g extend [OPTION] database-name\n\
+       %s gen_tz -g extend [OPTION] [database-name]\n\
 \n\
 valid options:\n\
   -i, --input-folder    path to an input folder containing a version of\n\

--- a/msg/zh_CN.utf8/utils.msg
+++ b/msg/zh_CN.utf8/utils.msg
@@ -1077,7 +1077,7 @@ $set 51 MSGCAT_UTIL_SET_GEN_TZ
 61 \
 gen_tz: 生成包含时区数据的源文件并编译成一个共享库.\n\
 用法: %s gen_tz [选项]\n\
-       %s gen_tz -g extend [选项] 数据库名\n\
+       %s gen_tz -g extend [选项] [数据库名]\n\
 \n\
 可用选项:\n\
   -i, --input-folder    指定一个输入文件夹的路径，文件夹必须包含一个IANA的时区\n\


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20265

This is a slip of http://jira.cubrid.org/browse/CBRD-20037 which supports `extend` option of `gen_tz`. It allows to omit database name and it means to retrieve the database list file and updates all the databases listed.
