### PR TITLE
[CBRD-20239] Fix checking interrupted jobs when loading vacuum data. Notify vacuum of shutdown request before ending threads.

### DIFF
--- a/contrib/gdb_debugging_scripts/vacuum.gdb
+++ b/contrib/gdb_debugging_scripts/vacuum.gdb
@@ -23,8 +23,8 @@ define vacuum_print_entries
     while $i < $datap->index_free
       set $entry = $datap->data + $i
       printf "blockid=%lld, flags = %llx, start_lsa=(%lld, %d), oldest=%d, newest=%d\n", \
-              $entry->blockid & 0x3FFFFFFFFFFFFFFF, \
-              $entry->blockid & 0xC000000000000000, \
+              $entry->blockid & 0x1FFFFFFFFFFFFFFF, \
+              $entry->blockid & 0xE000000000000000, \
               (long long int) $entry->start_lsa.pageid, \
               (int) $entry->start_lsa.offset, \
               $entry->oldest_mvccid, $entry->newest_mvccid

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3828,15 +3828,16 @@ vacuum_load_data_from_disk (THREAD_ENTRY * thread_p)
 	    }
 	}
       VPID_COPY (&next_vpid, &data_page->next_page);
-      if (!VPID_ISNULL (&next_vpid))
+      if (VPID_ISNULL (&next_vpid))
 	{
-	  vacuum_unfix_data_page (thread_p, data_page);
-	  data_page = vacuum_fix_data_page (thread_p, &next_vpid);
-	  if (data_page == NULL)
-	    {
-	      ASSERT_ERROR_AND_SET (error_code);
-	      goto error;
-	    }
+	  break;
+	}
+      vacuum_unfix_data_page (thread_p, data_page);
+      data_page = vacuum_fix_data_page (thread_p, &next_vpid);
+      if (data_page == NULL)
+	{
+	  ASSERT_ERROR_AND_SET (error_code);
+	  goto error;
 	}
     }
   assert (data_page != NULL);

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -285,6 +285,7 @@ extern void vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * st
 extern int vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p);
 extern LOG_PAGEID vacuum_min_log_pageid_to_keep (THREAD_ENTRY * thread_p);
 extern void vacuum_notify_server_crashed (LOG_LSA * recovery_lsa);
+extern void vacuum_notify_server_shutdown (void);
 #if defined (SERVER_MODE)
 extern void vacuum_notify_flush_data (void);
 extern bool vacuum_is_vacuum_data_flushed (void);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -4002,6 +4002,9 @@ xboot_shutdown_server (THREAD_ENTRY * thread_p, ER_FINAL_CODE is_er_final)
       boot_check_db_at_num_shutdowns (true);
 #endif /* CUBRID_DEBUG */
 
+      /* Start by notifying vacuum that shutdown was requested. */
+      vacuum_notify_server_shutdown ();
+
       sysprm_set_force (prm_get_name (PRM_ID_SUPPRESS_FSYNC), "0");
       /* Shutdown the system with the system transaction */
       logtb_set_to_system_tran_index (thread_p);


### PR DESCRIPTION
The next block of code in vacuum_load_data_from_disk has two purposes: to find interrupted jobs and mark them accordingly and to find last vacuum data page:
```c
  while (!VPID_ISNULL (&data_page->next_page))
    {
      VPID_COPY (&next_vpid, &data_page->next_page);
      vacuum_unfix_data_page (thread_p, data_page);
      data_page = vacuum_fix_data_page (thread_p, &next_vpid);
      if (data_page == NULL)
	{
	  ASSERT_ERROR_AND_SET (error_code);
	  goto error;
	}
      if (data_page->index_unvacuumed >= 0)
	{
	  assert (data_page->index_unvacuumed < vacuum_Data.page_data_max_count);
	  assert (data_page->index_unvacuumed <= data_page->index_free);
	  for (i = data_page->index_unvacuumed; i < data_page->index_free; i++)
	    {
	      entry = &data_page->data[i];
	      if (VACUUM_BLOCK_STATUS_IS_IN_PROGRESS (entry->blockid))
		{
		  /* Reset in progress flag, mark the job as interrupted and update last_blockid. */
		  VACUUM_BLOCK_STATUS_SET_AVAILABLE (entry->blockid);
		  VACUUM_BLOCK_SET_INTERRUPTED (entry->blockid);
		}
	    }
	}
    }
```

However, the way it was written, the first vacuum data page is unfixed directly and it its entries were not checked. They remained "in progress" and master skipped them when generating new jobs. The loop was fixed to check all pages.

Another thing I observed while investigating above issue is that same job was generated, picked up by a vacuum worker and interrupted several times during shutdown. Since vacuum master thread is ended after all workers, it keeps generating a job after it is interrupted. Since vacuum workers are interrupted one by one, the job can be generated several times.

I have added a notification at the start of shutdown. After being notified of shutdown request, master no longer generates new jobs and workers no longer pick new jobs.