### PR TITLE
[CBRD-20252] fix race condition on lf_circular_queue.

### DIFF
--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -2278,7 +2278,8 @@ lf_circular_queue_produce (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data)
 	}
 
       /* Get current produce_cursor */
-      produce_cursor = queue->produce_cursor;
+      produce_cursor = VOLATILE_ACCESS (queue->produce_cursor, INT64);
+
       /* Compute entry's index in circular queue */
       entry_index = (int) produce_cursor % queue->capacity;
 
@@ -2349,7 +2350,7 @@ lf_circular_queue_consume (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data)
 	}
 
       /* Get current consume cursor */
-      consume_cursor = queue->consume_cursor;
+      consume_cursor = VOLATILE_ACCESS (queue->consume_cursor, INT64);
 
       /* Compute entry's index in circular queue */
       entry_index = (int) consume_cursor % queue->capacity;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20252

With help of a reproduction of 10.1.0.0020, we have understood that a race condition on `vacuum_Finished_job_queue` which is a latch-free circular queue caused the trouble. 
All Vacuum workers were infinitely iterating the loop of `lf_circular_queue_produce` to produce a job, however, Vacuum master will not work because it has to think the queue is empty. Queue pointers, `consume_cursor` and `produce_cursor` were broken due to race condition.
That's why server just consumed CPUs and throughputs dropped.

10.0 may suffer from the same issue. 
