### PR TITLE
[CBRD-20278] fix a crash of SA_MODE shutdown followed by restart

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -714,6 +714,7 @@ vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npages, VFID * 
     }
 
   /* Initialize vacuum data */
+  vacuum_Data.shutdown_requested = false;
   /* Save vacuum data VFID. */
   VFID_COPY (&vacuum_Data.vacuum_data_file, vacuum_data_vfid);
   /* Save vacuum log block size in pages. */
@@ -778,7 +779,8 @@ vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npages, VFID * 
 #endif /* SERVER_MODE */
 
   /* Initialize finished job queue. */
-  vacuum_Finished_job_queue = lf_circular_queue_create (VACUUM_FINISHED_JOB_QUEUE_CAPACITY, sizeof (VACUUM_LOG_BLOCKID));
+  vacuum_Finished_job_queue = lf_circular_queue_create (VACUUM_FINISHED_JOB_QUEUE_CAPACITY,
+							sizeof (VACUUM_LOG_BLOCKID));
   if (vacuum_Finished_job_queue == NULL)
     {
       goto error;
@@ -2564,7 +2566,7 @@ restart:
 	  /* Must be available, cannot be in-progress. */
 	  assert (VACUUM_BLOCK_STATUS_IS_AVAILABLE (entry->blockid));
 	}
-#else	/* !SA_MODE */	     /* SERVER_MODE */
+#else	/* !SA_MODE */	       /* SERVER_MODE */
       if (!MVCC_ID_PRECEDES (entry->newest_mvccid, vacuum_Global_oldest_active_mvccid)
 	  || (entry->start_lsa.pageid + 1 >= log_Gl.append.prev_lsa.pageid))
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20278

`vacuum_Data.shutdown_requested` was not reset when SA_MODE shutdowns followed by restart. This prevents vacuum from finalizing its data. 
`createdb` with `--csql-initialization-file` option creates a new database, shutdowns it. Then it calls `csql` function to execute the given input file. `csql` subsequently calls `boot_restart_client` and `boot_restart_server`. `commit` from `boot_restart_client` complains it owns fixed buffer pages. 

The fix is to surely make `vacuum_Data.shutdown_requested` `false` during initializing vacuum.
