### PR TITLE
[CBRD-20280] fix potential race condition of CAS operation.

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -778,7 +778,8 @@ vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npages, VFID * 
 #endif /* SERVER_MODE */
 
   /* Initialize finished job queue. */
-  vacuum_Finished_job_queue = lf_circular_queue_create (VACUUM_FINISHED_JOB_QUEUE_CAPACITY, sizeof (VACUUM_LOG_BLOCKID));
+  vacuum_Finished_job_queue =
+    lf_circular_queue_create (VACUUM_FINISHED_JOB_QUEUE_CAPACITY, sizeof (VACUUM_LOG_BLOCKID));
   if (vacuum_Finished_job_queue == NULL)
     {
       goto error;
@@ -2564,7 +2565,7 @@ restart:
 	  /* Must be available, cannot be in-progress. */
 	  assert (VACUUM_BLOCK_STATUS_IS_AVAILABLE (entry->blockid));
 	}
-#else	/* !SA_MODE */	     /* SERVER_MODE */
+#else	/* !SA_MODE */	       /* SERVER_MODE */
       if (!MVCC_ID_PRECEDES (entry->newest_mvccid, vacuum_Global_oldest_active_mvccid)
 	  || (entry->start_lsa.pageid + 1 >= log_Gl.append.prev_lsa.pageid))
 	{
@@ -3192,7 +3193,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
    */
   do
     {
-      save_assigned_workers_count = vacuum_Assigned_workers_count;
+      save_assigned_workers_count = VOLATILE_ACCESS (vacuum_Assigned_workers_count, INT32);
     }
   while (!ATOMIC_CAS_32 (&vacuum_Assigned_workers_count, save_assigned_workers_count, save_assigned_workers_count + 1));
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -18156,7 +18156,7 @@ heap_set_autoincrement_value (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * att
 
 	  if ((att->type == DB_TYPE_SHORT) || (att->type == DB_TYPE_INTEGER) || (att->type == DB_TYPE_BIGINT))
 	    {
-	      if (xserial_get_next_value (thread_p, &dbvalue_numeric, &att->auto_increment.serial_obj, 0,	/* no * cache */
+	      if (xserial_get_next_value (thread_p, &dbvalue_numeric, &att->auto_increment.serial_obj, 0,	/* no cache */
 					  1,	/* generate one value */
 					  GENERATE_AUTO_INCREMENT, false) != NO_ERROR)
 		{

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -2105,7 +2105,7 @@ logtb_get_new_tran_id (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 
   do
     {
-      trid = log_Gl.hdr.next_trid;
+      trid = VOLATILE_ACCESS (log_Gl.hdr.next_trid, int);
 
       next_trid = trid + 1;
       if (next_trid < 0)


### PR DESCRIPTION
I don't have a reproduction case. I guess it is very hard to find a reproduction.
https://github.com/CUBRID/cubrid/pull/73 for [CBRD-20252](http://jira.cubrid.org/browse/CBRD-20252) shown a race condition of CAS operation with a global variable and a local variable of its copy. 
It should be safer to fix potential vulnerabilities.