### PR TITLE
[CBRD-20255] Handle vacuum data page deallocation when empty page is not first vacuum data page.

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -588,7 +588,8 @@ static void vacuum_update_oldest_unvacuumed_mvccid (THREAD_ENTRY * thread_p);
 static void vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p);
 static int vacuum_compare_blockids (const void *ptr1, const void *ptr2);
 static void vacuum_data_mark_finished (THREAD_ENTRY * thread_p);
-static void vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE ** data_page);
+static void vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_page,
+				    VACUUM_DATA_PAGE ** data_page);
 static void vacuum_data_initialize_new_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * data_page);
 static int vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p);
 static int vacuum_data_flush (THREAD_ENTRY * thread_p);
@@ -4174,6 +4175,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
   VACUUM_LOG_BLOCKID page_unvacuumed_blockid;
   VACUUM_LOG_BLOCKID page_free_blockid;
   VACUUM_DATA_PAGE *data_page = NULL;
+  VACUUM_DATA_PAGE *prev_data_page = NULL;
   VACUUM_DATA_ENTRY *data = NULL;
   VACUUM_DATA_ENTRY *page_unvacuumed_data = NULL;
   INT16 n_finished_blocks = 0;
@@ -4265,11 +4267,15 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 	    {
 	      /* Nothing left in page to be vacuumed. */
 
-	      vacuum_data_empty_page (thread_p, &data_page);
+	      vacuum_data_empty_page (thread_p, prev_data_page, &data_page);
 	      /* Should have advanced on next page. */
 	      if (data_page == NULL)
 		{
 		  /* No next page */
+		  if (prev_data_page != NULL)
+		    {
+		      vacuum_unfix_data_page (thread_p, prev_data_page);
+		    }
 		  if (n_finished_blocks > index)
 		    {
 		      assert (false);
@@ -4319,6 +4325,11 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 	      vacuum_set_dirty_data_page (thread_p, data_page, DONT_FREE);
 	    }
 	}
+
+      if (prev_data_page != NULL)
+	{
+	  vacuum_unfix_data_page (thread_p, prev_data_page);
+	}
       if (index == n_finished_blocks)
 	{
 	  /* All finished blocks have been consumed. */
@@ -4333,12 +4344,14 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 	  vacuum_unfix_data_page (thread_p, data_page);
 	  return;
 	}
+      
+      prev_data_page = data_page;
       VPID_COPY (&next_vpid, &data_page->next_page);
-      vacuum_unfix_data_page (thread_p, data_page);
       data_page = vacuum_fix_data_page (thread_p, &next_vpid);
       if (data_page == NULL)
 	{
 	  assert_release (false);
+	  vacuum_unfix_data_page (thread_p, prev_data_page);
 	  return;
 	}
       page_start_index = index;
@@ -4347,6 +4360,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
       page_unvacuumed_blockid = VACUUM_BLOCKID_WITHOUT_FLAGS (page_unvacuumed_data->blockid);
       page_free_blockid = page_unvacuumed_blockid + (data_page->index_free - data_page->index_unvacuumed);
     }
+  assert (prev_data_page == NULL);
 
   /* We need to update vacuum_Data.keep_from_log_pageid in case archives must be purged. */
   vacuum_update_keep_from_log_pageid (thread_p);
@@ -4362,23 +4376,19 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 /*
  * vacuum_data_empty_page () - Handle empty vacuum data page.
  *
- * return	      : Void.
- * thread_p (in)      : Thread entry.
- * data_page (in/out) : Empty page as input, prev page as output..
+ * return	       : Void.
+ * thread_p (in)       : Thread entry.
+ * prev_data_page (in) : Previous vacuum data page.
+ * data_page (in/out)  : Empty page as input, prev page as output..
  */
 static void
-vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE ** data_page)
+vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_page, VACUUM_DATA_PAGE ** data_page)
 {
   /* We can have three expected cases here:
    * 1. This is the first and only page. We won't deallocate, just reset the page.
    * 2. This is the first page, but there are other pages too. We will deallocate the page and update the first page.
-   * 3. This is the second page and last. This is a rare case when second page (and last) has few entries that get
-   *    vacuumed before the entries of the first page (which also has only few entries). In this case we deallocate
-   *    the page.
-   *
-   * It is theoretically possible to have an empty page that doesn't fit none of the above case. The distance between
-   * first unvacuumed and last vacuumed should be more than one page (~120 entries for a 4k page, ~500 entries for 16k
-   * page). If this happens, we might have to make bigger changes.
+   * 3. Page is not first and must be deallocated. If the page is last in vacuum data, vacuum_Data.last_page must be
+   *	changed to prev_data_page. Link in prev_data_page must be update.
    */
   assert (data_page != NULL && *data_page != NULL);
   assert ((*data_page)->index_unvacuumed == (*data_page)->index_free);
@@ -4460,41 +4470,38 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE ** data_page)
       /* Case 3 */
       VACUUM_DATA_PAGE *save_last_page = NULL;
       VPID save_page_vpid = VPID_INITIALIZER;
+      VPID save_next_vpid = VPID_INITIALIZER;
 
-      /* This must be second and last page. */
-      pgbuf_get_vpid ((PAGE_PTR) (*data_page), &save_page_vpid);
-      if (*data_page != vacuum_Data.last_page)
-	{
-	  VPID next_vpid = VPID_INITIALIZER;
-	  assert_release (false);
-	  vacuum_er_log (VACUUM_ER_LOG_ERROR | VACUUM_ER_LOG_VACUUM_DATA,
-			 "VACUUM ERROR: Empty page %d|%d is not first and is not last. Unexpected!\n",
-			 save_page_vpid.volid, save_page_vpid.pageid);
-	  /* Go to next page. */
-	  VPID_COPY (&next_vpid, &(*data_page)->next_page);
-	  vacuum_unfix_data_page (thread_p, *data_page);
-	  *data_page = vacuum_fix_data_page (thread_p, &next_vpid);
-	  return;
-	}
-      pgbuf_get_vpid ((PAGE_PTR) (*data_page), &save_page_vpid);
-      if (!VPID_EQ (&vacuum_Data.first_page->next_page, &save_page_vpid))
+      /* We must have prev_data_page. */
+      if (prev_data_page == NULL)
 	{
 	  assert_release (false);
 	  vacuum_er_log (VACUUM_ER_LOG_ERROR | VACUUM_ER_LOG_VACUUM_DATA,
-			 "VACUUM ERROR: Empty page %d|%d is not first and is not second. Unexpected!\n",
-			 save_page_vpid.volid, save_page_vpid.pageid);
-	  /* No next page */
+			 "VACUUM ERROR: No previous data page is unexpected!!!\n");
 	  vacuum_unfix_data_page (thread_p, *data_page);
 	  return;
 	}
 
-      /* We must deallocate the second (and last) page, reset first page and update vacuum_Data.last_page. */
       (void) log_start_system_op (thread_p);
 
-      save_last_page = vacuum_Data.last_page;
-      vacuum_Data.last_page = vacuum_Data.first_page;
-
+      /* We need to unfix page before deallocating. But if it is last vacuum data page, we must first change
+       * vacuum_Data.last_page.
+       */
+      if (vacuum_Data.last_page == *data_page)
+	{
+	  save_last_page = *data_page;
+	  vacuum_Data.last_page = prev_data_page;
+	}
+      else
+	{
+	  /* Save link to next page. */
+	  VPID_COPY (&save_next_vpid, &data_page->next_page)
+	}
+      /* Save data page VPID. */
+      pgbuf_get_vpid ((PAGE_PTR) (*data_page), &save_page_vpid);
+      /* Unfix data page. */
       vacuum_unfix_data_page (thread_p, *data_page);
+      /* Deallocate data page. */
       if (file_dealloc_page (thread_p, &vacuum_Data.vacuum_data_file, &save_page_vpid, FILE_VACUUM_DATA) != NO_ERROR)
 	{
 	  assert_release (false);
@@ -4503,35 +4510,42 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE ** data_page)
 			 save_page_vpid.volid, save_page_vpid.pageid);
 	  log_end_system_op (thread_p, LOG_RESULT_TOPOP_ABORT);
 
-	  vacuum_Data.last_page = save_last_page;
+	  if (save_last_page)
+	    {
+	      /* Revert vacuum_Data.last_page change. */
+	      vacuum_Data.last_page = save_last_page;
+	    }
 	  return;
 	}
-      /* Remove link in first page. */
+      /* Update link in previous page. */
       log_append_undoredo_data2 (thread_p, RVVAC_DATA_SET_LINK, NULL, (PAGE_PTR) vacuum_Data.first_page, 0,
-				 sizeof (VPID), 0, &vacuum_Data.first_page->next_page, NULL);
+				 sizeof (VPID), sizeof (VPID), &prev_data_page->next_page, &save_next_vpid);
       VPID_SET_NULL (&vacuum_Data.first_page->next_page);
 
       log_end_system_op (thread_p, LOG_RESULT_TOPOP_COMMIT);
 
-      if (vacuum_Data.first_page->index_unvacuumed > 0)
+      if (prev_data_page == vacuum_Data.last_page && prev_data_page->index_unvacuumed > 0)
 	{
 	  /* Move data at the beginning. */
-	  assert (vacuum_Data.first_page->index_free > vacuum_Data.first_page->index_unvacuumed);
+	  assert (prev_data_page->index_free > prev_data_page->index_unvacuumed);
 
-	  memmove (vacuum_Data.first_page->data,
-		   vacuum_Data.first_page->data + vacuum_Data.first_page->index_unvacuumed,
-		   (vacuum_Data.first_page->index_free - vacuum_Data.first_page->index_unvacuumed)
-		   * sizeof (VACUUM_DATA_ENTRY));
-	  vacuum_Data.first_page->index_free -= vacuum_Data.first_page->index_unvacuumed;
-	  vacuum_Data.first_page->index_unvacuumed = 0;
+	  memmove (prev_data_page->data, prev_data_page->data + prev_data_page->index_unvacuumed,
+		   (prev_data_page->index_free - prev_data_page->index_unvacuumed) * sizeof (VACUUM_DATA_ENTRY));
+	  prev_data_page->index_free -= prev_data_page->index_unvacuumed;
+	  prev_data_page->index_unvacuumed = 0;
 
 	  /* Log changes. No data is actually removed, just relocated (so redo data is NULL). */
-	  log_append_redo_data2 (thread_p, RVVAC_DATA_FINISHED_BLOCKS, NULL, (PAGE_PTR) vacuum_Data.first_page, 0, 0,
-				 NULL);
+	  log_append_redo_data2 (thread_p, RVVAC_DATA_FINISHED_BLOCKS, NULL, (PAGE_PTR) prev_data_page, 0, 0, NULL);
 	  vacuum_set_dirty_data_page (thread_p, vacuum_Data.first_page, DONT_FREE);
 	}
 
       assert (*data_page == NULL);
+      /* Move *data_page to next page. */
+      if (!VPID_ISNULL (&prev_data_page->next_page))
+	{
+	  *data_page = vacuum_fix_data_page (thread_p, &(*data_page)->next_page);
+	  assert (*data_page != NULL);
+	}
     }
 }
 

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4495,7 +4495,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
       else
 	{
 	  /* Save link to next page. */
-	  VPID_COPY (&save_next_vpid, &data_page->next_page)
+	  VPID_COPY (&save_next_vpid, &(*data_page)->next_page);
 	}
       /* Save data page VPID. */
       pgbuf_get_vpid ((PAGE_PTR) (*data_page), &save_page_vpid);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4518,9 +4518,9 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 	  return;
 	}
       /* Update link in previous page. */
-      log_append_undoredo_data2 (thread_p, RVVAC_DATA_SET_LINK, NULL, (PAGE_PTR) vacuum_Data.first_page, 0,
-				 sizeof (VPID), sizeof (VPID), &prev_data_page->next_page, &save_next_vpid);
-      VPID_SET_NULL (&vacuum_Data.first_page->next_page);
+      log_append_undoredo_data2 (thread_p, RVVAC_DATA_SET_LINK, NULL, (PAGE_PTR) prev_data_page, 0, sizeof (VPID),
+				 sizeof (VPID), &prev_data_page->next_page, &save_next_vpid);
+      VPID_COPY (&prev_data_page->next_page, &save_next_vpid);
 
       log_end_system_op (thread_p, LOG_RESULT_TOPOP_COMMIT);
 
@@ -4536,7 +4536,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 
 	  /* Log changes. No data is actually removed, just relocated (so redo data is NULL). */
 	  log_append_redo_data2 (thread_p, RVVAC_DATA_FINISHED_BLOCKS, NULL, (PAGE_PTR) prev_data_page, 0, 0, NULL);
-	  vacuum_set_dirty_data_page (thread_p, vacuum_Data.first_page, DONT_FREE);
+	  vacuum_set_dirty_data_page (thread_p, prev_data_page, DONT_FREE);
 	}
 
       assert (*data_page == NULL);

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -296,9 +296,8 @@ extern int vacuum_rv_undoredo_first_data_page (THREAD_ENTRY * thread_p, LOG_RCV 
 extern void vacuum_rv_undoredo_first_data_page_dump (FILE * fp, int length, void *data);
 extern int vacuum_rv_redo_data_finished (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern void vacuum_rv_redo_data_finished_dump (FILE * fp, int length, void *data);
-extern int vacuum_rv_undo_data_set_link (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
-extern int vacuum_rv_redo_data_set_link (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
-extern void vacuum_rv_redo_data_set_link_dump (FILE * fp, int length, void *data);
+extern int vacuum_rv_undoredo_data_set_link (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
+extern void vacuum_rv_undoredo_data_set_link_dump (FILE * fp, int length, void *data);
 extern int vacuum_rv_redo_append_data (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern void vacuum_rv_redo_append_data_dump (FILE * fp, int length, void *data);
 

--- a/src/transaction/recovery.c
+++ b/src/transaction/recovery.c
@@ -418,12 +418,12 @@ struct rvfun RV_fun[] = {
    heap_rv_undoredo_update_and_update_chain,
    log_rv_dump_hexa,
    log_rv_dump_hexa},
-  {RVHF_MVCC_REMOVE_PARTITION_LINK,	    /* Obsolete */
+  {RVHF_MVCC_REMOVE_PARTITION_LINK,	/* Obsolete */
    "RVHF_MVCC_REMOVE_PARTITION_LINK",
    NULL,
    NULL,
    NULL, NULL},
-  {RVHF_PARTITION_LINK_FLAG,	      /* Obsolete */
+  {RVHF_PARTITION_LINK_FLAG,	/* Obsolete */
    "RVHF_PARTITION_LINK_FLAG",
    NULL,
    NULL,
@@ -478,7 +478,7 @@ struct rvfun RV_fun[] = {
    overflow_rv_link,
    overflow_rv_link_dump,
    overflow_rv_link_dump},
-  {RVOVF_NEWPAGE_DELETE_RELOCATED,	      /* Obsolete. */
+  {RVOVF_NEWPAGE_DELETE_RELOCATED,	/* Obsolete. */
    "RVOVF_NEWPAGE_DELETE_RELOCATED",
    NULL,
    NULL,
@@ -677,7 +677,7 @@ struct rvfun RV_fun[] = {
    btree_rv_redo_delete_index,
    NULL,
    NULL},
-   {RVBT_MVCC_UPDATE_SAME_KEY,
+  {RVBT_MVCC_UPDATE_SAME_KEY,
    "RVBT_MVCC_UPDATE_SAME_KEY",
    NULL,
    NULL,
@@ -875,11 +875,11 @@ struct rvfun RV_fun[] = {
    NULL,
    NULL},
   {RVVAC_DATA_SET_LINK,
-   "RVVAC_DATA_INIT_NEW_PAGE",
-   vacuum_rv_undo_data_set_link,
-   vacuum_rv_redo_data_set_link,
-   NULL,
-   vacuum_rv_redo_data_set_link_dump},
+   "RVVAC_DATA_SET_LINK",
+   vacuum_rv_undoredo_data_set_link,
+   vacuum_rv_undoredo_data_set_link,
+   vacuum_rv_undoredo_data_set_link_dump,
+   vacuum_rv_undoredo_data_set_link_dump},
   {RVVAC_DATA_FINISHED_BLOCKS,
    "RVVAC_DATA_FINISHED_BLOCKS",
    NULL,


### PR DESCRIPTION
The initial implementation assumed that since jobs are generated in order, the vacuum data pages will become empty also in order. Therefore, if a page is empty, it must be the first page.

The assumption was wrong. In some special circumstances, jobs from vacuum data pages that are not first can be finished first. For instance, if we have a lot of log data without any MVCC operation log records, the vacuum data pages will only have few actualy jobs to generate.

Normally, there is a fair amount of time between two successive job generations. It is very likely that jobs will also be finished in the same order. However, after restart or in stressful scenarios, vacuum master can generate multiple jobs in the same iteration. The chance that jobs are not finished in order become higher. Therefore, chances to finish all jobs from a vacuum data page another than first becomes also more likely.

I added the vacuum_data_empty_function that can handle all cases for empty vacuum data page.

The assert generated by the issue was also used as an indication of "leaked" pages (pages marked as started by never executed, or jobs finished that were never marked as finished). We could not use it anymore. Therefore, I added a counter called in_progress_distance (counts all finished jobs after first in progress job). If this is higher than 200, we assume something bad has happened.