### PR TITLE
[CBRD-20155] introduce a new version info management way for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,21 @@
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+
 cmake_minimum_required(VERSION 2.8)
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -5,38 +23,76 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type (default Debug)")
 endif()
 
-#option(CMAKE_USE_RELATIVE_PATHS "Use relative paths if possible" ON)
-#mark_as_advanced(CMAKE_USE_RELATIVE_PATHS)
-
 project(CUBRID)
 
 # Version info
-file(STRINGS BUILD_NUMBER version)
-set(CUBRID_VERSION ${version})
-string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)?" "\\1;\\2;\\3;\\4" VERSION_MATCHES ${version})
-list(GET VERSION_MATCHES 0 version_major)
-set(CUBRID_MAJOR_VERSION ${version_major})
-list(GET VERSION_MATCHES 1 version_minor)
-set(CUBRID_MINOR_VERSION ${version_minor})
-list(GET VERSION_MATCHES 2 version_patch)
-set(CUBRID_PATCH_VERSION ${version_patch})
-list(GET VERSION_MATCHES 3 version_extra)
-set(CUBRID_EXTRA_VERSION ${version_extra})
+# TODO: remove BUILD_NUMBER file and replace with VERSION file
+if(EXISTS ${CMAKE_SOURCE_DIR}/VERSION)
+  set(VERSION_FILE VERSION)
+elseif(EXISTS ${CMAKE_SOURCE_DIR}/BUILD_NUMBER)
+  set(VERSION_FILE BUILD_NUMBER)
+else(EXISTS ${CMAKE_SOURCE_DIR}/VERSION)
+  message(FATAL_ERROR "Could not find a VERSION file")
+endif(EXISTS ${CMAKE_SOURCE_DIR}/VERSION)
+message(STATUS "Get version information from ${VERSION_FILE}")
+# Generate the same file in other directory to trigger cmake re-configure when the file changes
+configure_file(${VERSION_FILE} ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${VERSION_FILE}.check_cache)
+file(STRINGS ${VERSION_FILE} VERSION_STR)
+if(VERSION_STR MATCHES "[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9_]+)?")
+  string(REGEX MATCHALL "[0-9]+|-([A-Za-z0-9_]+)" VERSION_MATCHES ${VERSION_STR})
+  list(LENGTH VERSION_MATCHES VERSION_MATCHES_LENGTH)
+  list(GET VERSION_MATCHES 0 CUBRID_MAJOR_VERSION)
+  list(GET VERSION_MATCHES 1 CUBRID_MINOR_VERSION)
+  list(GET VERSION_MATCHES 2 CUBRID_PATCH_VERSION)
+else()
+  message(FATAL_ERROR "Failed to parse a version string from ${VERSION_FILE} file")
+endif()
 
-#TODO move to config.h?
-set(VERSION_DEFS
-  MAJOR_VERSION=${CUBRID_MAJOR_VERSION}
-  MINOR_VERSION=${CUBRID_MINOR_VERSION}
-  PATCH_VERSION=${CUBRID_PATCH_VERSION}
-  RELEASE_STRING=${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}.${CUBRID_PATCH_VERSION}
-  MAJOR_RELEASE_STRING=${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}
-  BUILD_NUMBER=${CUBRID_VERSION}
-  BUILD_OS=${CMAKE_SYSTEM_NAME}
-  )
+if(VERSION_MATCHES_LENGTH GREATER 3)
+  list(GET VERSION_MATCHES 3 CUBRID_EXTRA_VERSION)
+else(VERSION_MATCHES_LENGTH GREATER 3)
+  find_package(Git)
+  if(EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT_FOUND)
+    execute_process(COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD
+      OUTPUT_VARIABLE commit_count RESULT_VARIABLE git_result
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    if(git_result)
+      message(FATAL_ERROR "Could not get count information from Git")
+    endif(git_result)
+    set(CUBRID_EXTRA_VERSION ${commit_count})
+    execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --match '@{NEVERMATCH}@' --dirty=_modified
+      OUTPUT_VARIABLE commit_hash RESULT_VARIABLE git_result
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    if(git_result)
+      message(FATAL_ERROR "Could not get hash information from Git")
+    endif(git_result)
+    set(CUBRID_HASH_TAG -${commit_hash})
+    # Generate the same file in other directory to trigger cmake re-configure when the HEAD changes
+    configure_file(".git/HEAD" ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/HEAD.check_cache)
+  else(EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT_FOUND)
+    set(CUBRID_EXTRA_VERSION 0)
+  endif(EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT_FOUND)
+endif(VERSION_MATCHES_LENGTH GREATER 3)
+set(CUBRID_VERSION ${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}.${CUBRID_PATCH_VERSION}.${CUBRID_EXTRA_VERSION}${CUBRID_HASH_TAG})
 
-set(PACKAGE_STRING "${PROJECT_NAME} ${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}")
-set(PRODUCT_STRING "${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}")
+set(MAJOR_RELEASE_STRING ${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION})
+set(PACKAGE_STRING "${PROJECT_NAME} ${MAJOR_RELEASE_STRING}")
+set(PRODUCT_STRING "${MAJOR_RELEASE_STRING}")
+# TODO: change to string type for RELEASE_STRING, BUILD_NUMBER, BUILD_OS
+# TODO: remove #if defined (VERSION_STRING) in src/base/release_string.c
+set(RELEASE_STRING ${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}.${CUBRID_PATCH_VERSION})
+# BUILD_NUMBER (digital only version string) for legacy codes
+set(BUILD_NUMBER ${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}.${CUBRID_PATCH_VERSION}.${CUBRID_EXTRA_VERSION})
+set(BUILD_OS ${CMAKE_SYSTEM_NAME})
 
+if(MSVC)
+  configure_file(version.rc.cmake ${CMAKE_BINARY_DIR}/version.rc)
+  # TODO: remove version.rc files from win/*
+endif(MSVC)
+
+# Language setting
 enable_language(C CXX)
 
 # System check
@@ -56,7 +112,7 @@ if(UNIX)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--hash-style=both")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--hash-style=both")
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--hash-style=both")
-    
+
   else(CMAKE_COMPILER_IS_GNUCC)
     message(FATAL_ERROR "We currently do not support ${CMAKE_CXX_COMPILER_ID} compiler")
   endif(CMAKE_COMPILER_IS_GNUCC)
@@ -65,26 +121,26 @@ endif(UNIX)
 # check target platform
 # Test 32/64 bits
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-	set(TARGET_PLATFORM_BITS 64)
+  set(TARGET_PLATFORM_BITS 64)
 else()
-	set(TARGET_PLATFORM_BITS 32)
+  set(TARGET_PLATFORM_BITS 32)
 endif()
 
 message(STATUS "Build ${PROJECT_NAME} ${CUBRID_VERSION} ${TARGET_PLATFORM_BITS}bit ${CMAKE_BUILD_TYPE} on ${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR}")
 
 # generate parser and lexer
-set(csql_grammar_input ${CMAKE_SOURCE_DIR}/src/parser/csql_grammar.y)
-set(csql_grammar_output ${CMAKE_SOURCE_DIR}/src/parser/csql_grammar.c)
-set(csql_lexer_input ${CMAKE_SOURCE_DIR}/src/parser/csql_lexer.l)
-set(csql_lexer_output ${CMAKE_SOURCE_DIR}/src/parser/csql_lexer.c)
-set(loader_grammar_input ${CMAKE_SOURCE_DIR}/src/executables/loader_grammar.y)
-set(loader_grammar_output ${CMAKE_SOURCE_DIR}/src/executables/loader_grammar.c)
-set(loader_lexer_input ${CMAKE_SOURCE_DIR}/src/executables/loader_lexer.l)
-set(loader_lexer_output ${CMAKE_SOURCE_DIR}/src/executables/loader_lexer.c)
-set(esql_grammar_input ${CMAKE_SOURCE_DIR}/src/executables/esql_grammar.y)
-set(esql_grammar_output ${CMAKE_SOURCE_DIR}/src/executables/esql_grammar.c)
-set(esql_lexer_input ${CMAKE_SOURCE_DIR}/src/executables/esql_lexer.l)
-set(esql_lexer_output ${CMAKE_SOURCE_DIR}/src/executables/esql_lexer.c)
+set(CSQL_GRAMMAR_INPUT ${CMAKE_SOURCE_DIR}/src/parser/csql_grammar.y)
+set(CSQL_GRAMMAR_OUTPUT ${CMAKE_SOURCE_DIR}/src/parser/csql_grammar.c)
+set(CSQL_LEXER_INPUT ${CMAKE_SOURCE_DIR}/src/parser/csql_lexer.l)
+set(CSQL_LEXER_OUTPUT ${CMAKE_SOURCE_DIR}/src/parser/csql_lexer.c)
+set(LOADER_GRAMMAR_INPUT ${CMAKE_SOURCE_DIR}/src/executables/loader_grammar.y)
+set(LOADER_GRAMMAR_OUTPUT ${CMAKE_SOURCE_DIR}/src/executables/loader_grammar.c)
+set(LOADER_LEXER_INPUT ${CMAKE_SOURCE_DIR}/src/executables/loader_lexer.l)
+set(LOADER_LEXER_OUTPUT ${CMAKE_SOURCE_DIR}/src/executables/loader_lexer.c)
+set(ESQL_GRAMMAR_INPUT ${CMAKE_SOURCE_DIR}/src/executables/esql_grammar.y)
+set(ESQL_GRAMMAR_OUTPUT ${CMAKE_SOURCE_DIR}/src/executables/esql_grammar.c)
+set(ESQL_LEXER_INPUT ${CMAKE_SOURCE_DIR}/src/executables/esql_lexer.l)
+set(ESQL_LEXER_OUTPUT ${CMAKE_SOURCE_DIR}/src/executables/esql_lexer.c)
 
 if(USE_BISON_FLEX)
   # bison and flex check
@@ -99,55 +155,55 @@ if(USE_BISON_FLEX)
   find_package(FLEX)
 
   if(USE_BISON_NEWDIRECTIVE)
-    file(READ ${csql_grammar_input} yy )
-    string( REPLACE "%{/*%CODE_REQUIRES_START%*/" "%code requires{" mod_yy "${yy}" )
-    string( REPLACE "%{/*%CODE_PROVIDES_START%*/" "%code requires{" mod_yy "${mod_yy}" )
-    string( REPLACE "/*%CODE_END%*/%}" "}" mod_yy "${mod_yy}" )
+    file(READ ${CSQL_GRAMMAR_INPUT} yy )
+    string(REPLACE "%{/*%CODE_REQUIRES_START%*/" "%code requires{" mod_yy "${yy}" )
+    string(REPLACE "%{/*%CODE_PROVIDES_START%*/" "%code requires{" mod_yy "${mod_yy}" )
+    string(REPLACE "/*%CODE_END%*/%}" "}" mod_yy "${mod_yy}" )
     file(WRITE csql_grammar.yy ${mod_yy})
-    bison_target(csql_grammar csql_grammar.yy ${csql_grammar_output}
+    bison_target(csql_grammar csql_grammar.yy ${CSQL_GRAMMAR_OUTPUT}
       COMPILE_FLAGS "--no-lines --name-prefix=csql_yy -d -r all")
   else(USE_BISON_NEWDIRECTIVE)
-    bison_target(csql_grammar ${csql_grammar_input} ${csql_grammar_output}
+    bison_target(csql_grammar ${CSQL_GRAMMAR_INPUT} ${CSQL_GRAMMAR_OUTPUT}
       COMPILE_FLAGS "--no-lines --name-prefix=csql_yy -d -r all")
   endif(USE_BISON_NEWDIRECTIVE)
-  flex_target(csql_lexer ${csql_lexer_input} ${csql_lexer_output}
+  flex_target(csql_lexer ${CSQL_LEXER_INPUT} ${CSQL_LEXER_OUTPUT}
     COMPILE_FLAGS "--noline --never-interactive --prefix=csql_yy")
   add_flex_bison_dependency(csql_lexer csql_grammar)
   add_custom_target(gen_csql_grammar DEPENDS ${BISON_csql_grammar_OUTPUTS})
   add_custom_target(gen_csql_lexer DEPENDS ${FLEX_csql_lexer_OUTPUTS})
 
-  bison_target(loader_grammar ${loader_grammar_input} ${loader_grammar_output}
-      COMPILE_FLAGS "--no-lines --name-prefix=loader_yy -d -r all")
-  flex_target(loader_lexer ${loader_lexer_input} ${loader_lexer_output}
+  bison_target(loader_grammar ${LOADER_GRAMMAR_INPUT} ${LOADER_GRAMMAR_OUTPUT}
+    COMPILE_FLAGS "--no-lines --name-prefix=loader_yy -d -r all")
+  flex_target(loader_lexer ${LOADER_LEXER_INPUT} ${LOADER_LEXER_OUTPUT}
     COMPILE_FLAGS "--noline --never-interactive --prefix=loader_yy")
   add_flex_bison_dependency(loader_lexer loader_grammar)
   add_custom_target(gen_loader_grammar DEPENDS ${BISON_loader_grammar_OUTPUTS})
   add_custom_target(gen_loader_lexer DEPENDS ${FLEX_loader_lexer_OUTPUTS})
 
   if(USE_BISON_NEWDIRECTIVE)
-    file(READ ${esql_grammar_input} yy )
-    string( REPLACE "%{/*%CODE_REQUIRES_START%*/" "%code requires{" mod_yy "${yy}" )
-    string( REPLACE "%{/*%CODE_PROVIDES_START%*/" "%code requires{" mod_yy "${mod_yy}" )
-    string( REPLACE "/*%CODE_END%*/%}" "}" mod_yy "${mod_yy}" )
+    file(READ ${ESQL_GRAMMAR_INPUT} yy )
+    string(REPLACE "%{/*%CODE_REQUIRES_START%*/" "%code requires{" mod_yy "${yy}" )
+    string(REPLACE "%{/*%CODE_PROVIDES_START%*/" "%code requires{" mod_yy "${mod_yy}" )
+    string(REPLACE "/*%CODE_END%*/%}" "}" mod_yy "${mod_yy}" )
     file(WRITE esql_grammar.yy ${mod_yy})
-    bison_target(esql_grammar esql_grammar.yy ${esql_grammar_output}
+    bison_target(esql_grammar esql_grammar.yy ${ESQL_GRAMMAR_OUTPUT}
       COMPILE_FLAGS "--no-lines --name-prefix=esql_yy -d -r all")
   else(USE_BISON_NEWDIRECTIVE)
-    bison_target(esql_grammar ${esql_grammar_input} ${esql_grammar_output}
+    bison_target(esql_grammar ${ESQL_GRAMMAR_INPUT} ${ESQL_GRAMMAR_OUTPUT}
       COMPILE_FLAGS "--no-lines --name-prefix=esql_yy -d -r all")
   endif(USE_BISON_NEWDIRECTIVE)
-  flex_target(esql_lexer ${esql_lexer_input} ${esql_lexer_output}
+  flex_target(esql_lexer ${ESQL_LEXER_INPUT} ${ESQL_LEXER_OUTPUT}
     COMPILE_FLAGS "--noline --never-interactive --prefix=esql_yy")
   add_flex_bison_dependency(esql_lexer esql_grammar)
   add_custom_target(gen_esql_grammar DEPENDS ${BISON_esql_grammar_OUTPUTS})
   add_custom_target(gen_esql_lexer DEPENDS ${FLEX_esql_lexer_OUTPUTS})
 else(USE_BISON_FLEX)
-  set(BISON_csql_grammar_OUTPUTS ${csql_grammar_output})
-  set(FLEX_csql_lexer_OUTPUTS ${csql_lexer_output})
-  set(BISON_loader_grammar_OUTPUTS ${loader_grammar_output})
-  set(FLEX_loader_lexer_OUTPUTS ${loader_lexer_output})
-  set(BISON_esql_grammar_OUTPUTS ${esql_grammar_output})
-  set(FLEX_esql_lexer_OUTPUTS ${esql_lexer_output})
+  set(BISON_csql_grammar_OUTPUTS ${CSQL_GRAMMAR_OUTPUT})
+  set(FLEX_csql_lexer_OUTPUTS ${CSQL_LEXER_OUTPUT})
+  set(BISON_loader_grammar_OUTPUTS ${LOADER_GRAMMAR_OUTPUT})
+  set(FLEX_loader_lexer_OUTPUTS ${LOADER_LEXER_OUTPUT})
+  set(BISON_esql_grammar_OUTPUTS ${ESQL_GRAMMAR_OUTPUT})
+  set(FLEX_esql_lexer_OUTPUTS ${ESQL_LEXER_OUTPUT})
 endif(USE_BISON_FLEX)
 
 
@@ -162,7 +218,6 @@ include(FindJava)
 find_package(Java 1.5 COMPONENTS Development)
 
 # Build types
-# FIXME move to os/Linux.cmake ?
 if(CMAKE_BUILD_TYPE MATCHES "Coverage")
   set(CMAKE_CXX_FLAGS_COVERAGE "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
     CACHE STRING "Flags used by the c++ compiler during coverage build." FORCE )
@@ -216,7 +271,7 @@ set(TOOLS_DIR                ${CMAKE_SOURCE_DIR}/src/tools)
 set(TRANSACTION_DIR          ${CMAKE_SOURCE_DIR}/src/transaction)
 set(WIN_TOOLS_DIR            ${CMAKE_SOURCE_DIR}/src/win_tools)
 
-                                            
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(
   include
@@ -238,7 +293,8 @@ include_directories(
   src/storage
   src/thread
   src/tools
-  src/transaction)
+  src/transaction
+  )
 
 include(CheckFunctionExists)
 check_function_exists(asprintf HAVE_ASPRINTF)
@@ -315,10 +371,10 @@ if(NOT SIZEOF_SIZE_T)
 endif()
 check_type_size("pid_t" SIZEOF_PID_T)
 if(NOT SIZEOF_PID_T)
-# FIXME: util_sa.c:79 remove typedef
-if(NOT WIN32)
-  set(pid_t "int")
-endif(NOT WIN32)
+  # TODO: util_sa.c:79 remove typedef int pid_t
+  if(NOT WIN32)
+    set(pid_t "int")
+  endif(NOT WIN32)
 endif()
 set(CMAKE_REQUIRED_FLAGS "-D_LARGEFILE64_SOURCE -finfile-functions")
 check_type_size("off64_t" SIZEOF_OFF64_T)
@@ -344,9 +400,9 @@ if(HAVE_GETHOSTBYNAME_R)
 endif(HAVE_GETHOSTBYNAME_R)
 
 include(CheckSymbolExists)
-if( NOT HAVE_STDBOOL_H )
+if(NOT HAVE_STDBOOL_H )
   check_symbol_exists( "_Bool" stdbool.h HAVE__BOOL )
-endif( NOT HAVE_STDBOOL_H )
+endif(NOT HAVE_STDBOOL_H )
 
 include(CheckCSourceCompiles)
 check_c_source_compiles("#include <sys/time.h>\n#include <time.h>\nmain(){}" TIME_WITH_SYS_TIME)
@@ -381,22 +437,15 @@ endif(UNIX)
 
 
 configure_file(config.h.cmake config.h)
+# TODO: merge version.h into config.h ?
+configure_file(version.h.cmake version.h)
 
-# TODO: split multiple cmake files
-# Include the platform specifie cmake file.
-#foreach(platform_file
-#${CMAKE_SOURCE_DIR}/cmake/os/${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}.cmake
-#${CMAKE_SOURCE_DIR}/cmake/os/${CMAKE_SYSTEM_NAME}.cmake)
-#if(EXISTS ${platform_file})
-#include(${platform_file})
-#break()
-#endif()
-#endforeach()
+# platform specifie configurations
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   # Definitions for system
   add_definitions(-DGCC -DLINUX -D_GNU_SOURCE -DI386 -DX86)
-  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -W -Wwrite-strings -Wno-cast-qual -Wmissing-prototypes -Wredundant-decls -Wlong-long -Wextra -Wno-unused")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -W -Wwrite-strings -Wno-cast-qual -Wmissing-prototypes -Wredundant-decls -Wlong-long -Wextra -Wno-unused")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -W -Wwrite-strings -Wno-cast-qual -Wmissing-prototypes -Wredundant-decls -Wlong-long -Wextra -Wno-unused")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -W -Wwrite-strings -Wno-cast-qual -Wmissing-prototypes -Wredundant-decls -Wlong-long -Wextra -Wno-unused")
   if(SIZEOF_OFF64_T)
     add_definitions( -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64)
   endif(SIZEOF_OFF64_T)
@@ -427,10 +476,6 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
   if(TARGET_PLATFORM_BITS EQUAL 64)
     string(REPLACE "/DWIN32" "/D_WIN64" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
   endif(TARGET_PLATFORM_BITS EQUAL 64)
-  #if(CMAKE_BUILD_TYPE MATCHES "Release")
-  #  FIXME: remove. it can increase build elapse time
-  #  add_definitions(/Oi /Gy)
-  #endif(CMAKE_BUILD_TYPE MATCHES "Release")
   if(MSVC_VERSION GREATER 1400)
     # experimental option (it can lead the build system to a halt or creating a bad object files)
     set(PARALLEL_JOBS "0" CACHE STRING "Specifies the number of jots to build parallel. 0 means OFF")
@@ -448,7 +493,7 @@ set(COMMON_DEFS SYSV MAXPATHLEN=1024 -D_REENTRANT)
 
 # options
 # FIXME: linux 32bit build mode not working now
-  option(ENABLE_32BIT "Build for 32-bit banaries (on 64-bit platform)" OFF)
+option(ENABLE_32BIT "Build for 32-bit banaries (on 64-bit platform)" OFF)
 
 if(UNIX)
   option(USE_BISON_FLEX "Use bison and flex to generate parser and lexer" ON)
@@ -596,7 +641,7 @@ if(UNIX)
     CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
     #BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/libregex38a
     INSTALL_COMMAND make install && ${CMAKE_COMMAND} -E copy .libs/libregex38a.a ${CMAKE_CURRENT_BINARY_DIR}/external/lib
-  )
+    )
   list(APPEND EP_TARGETS ${LIBREGEX_TARGET})
   set(LIBREGEX_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libregex38a.a)
   set(LIBREGEX_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/libregex38a)
@@ -620,7 +665,7 @@ if(UNIX)
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND make buildlib
       INSTALL_COMMAND make installlib && ${CMAKE_COMMAND} -E copy .libs/libexpat.a ${CMAKE_CURRENT_BINARY_DIR}/external/lib
-    )
+      )
     set(LIBEXPAT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libexpat.a)
     set(LIBEXPAT_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/expat)
     list(APPEND EP_TARGETS ${LIBEXPAT_TARGET})
@@ -645,7 +690,7 @@ if(UNIX)
     externalproject_add(${LIBJANSSON_TARGET}
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/jansson-2.4
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
-    )
+      )
     set(LIBJANSSON_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libjansson.a)
     set(LIBJANSSON_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/jansson)
     list(APPEND EP_TARGETS ${LIBJANSSON_TARGET})
@@ -670,7 +715,7 @@ if(UNIX)
     externalproject_add(${LIBEDIT_TARGET}
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/libedit-20120601-3.0
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS} --enable-widec
-    )
+      )
     set(LIBEDIT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libedit.a)
     set(LIBEDIT_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
     list(APPEND EP_TARGETS ${LIBEDIT_TARGET})
@@ -688,7 +733,7 @@ if(UNIX)
     externalproject_add(${LIBLZO_TARGET}
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/lzo-2.03
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
-    )
+      )
     set(LIBLZO_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/liblzo2.a)
     set(LIBLZO_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/lzo)
     list(APPEND EP_TARGETS ${LIBLZO_TARGET})
@@ -713,7 +758,7 @@ if(UNIX)
     externalproject_add(${LIBGPGERROR_TARGET}
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/libgpg-error-1.11
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
-    )
+      )
     set(LIBGPG_ERROR_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libgpg-error.a)
     set(LIBGPG_ERROR_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
     list(APPEND EP_TARGETS ${LIBGPGERROR_TARGET})
@@ -735,7 +780,7 @@ if(UNIX)
       DEPENDS libgpg-error
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/libgcrypt-1.5.2
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS} CPPFLAGS=-I${CMAKE_CURRENT_BINARY_DIR}/external/include ${GRCYPT_EXTRA_OPTION}
-    )
+      )
     set(LIBGCRYPT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libgcrypt.a)
     set(LIBGCRYPT_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
     list(APPEND EP_TARGETS ${LIBGCRYPT_TARGET})
@@ -847,22 +892,3 @@ endif(WITH_CMSERVER AND EXISTS ${CMAKE_SOURCE_DIR}/cubridmanager)
 install(DIRECTORY DESTINATION ${CUBRID_LOGDIR})
 install(DIRECTORY DESTINATION ${CUBRID_TMPDIR})
 
-# install external pre-built DLLs
-if(WIN32)
-  # FIXME: add custom target for external dlls? - ref. http://stackoverflow.com/questions/14474659/cmake-how-to-have-a-target-for-copying-files
-  if(TARGET_PLATFORM_BITS EQUAL 32)
-    file(GLOB TARGET_DLLS
-      ${CMAKE_SOURCE_DIR}/win/external/dll/*.dll
-      ${CMAKE_SOURCE_DIR}/win/external/dll/Win32/*.dll
-    )
-  else(TARGET_PLATFORM_BITS EQUAL 32)
-    file(GLOB TARGET_DLLS
-      ${CMAKE_SOURCE_DIR}/win/external/dll/*.dll
-      ${CMAKE_SOURCE_DIR}/win/external/dll/x64/*.dll
-    )
-  endif(TARGET_PLATFORM_BITS EQUAL 32)
-
-  install(FILES
-      ${TARGET_DLLS}
-      DESTINATION ${CUBRID_BINDIR})
-endif(WIN32)

--- a/broker/CMakeLists.txt
+++ b/broker/CMakeLists.txt
@@ -1,7 +1,22 @@
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
-
-set(BROKER_DEFS _BSD_SOURCE _XOPEN_SOURCE ASYNC_MODE DIAG_DEVEL CAS_BROKER ${VERSION_DEFS})
-
+set(BROKER_DEFS _BSD_SOURCE _XOPEN_SOURCE ASYNC_MODE DIAG_DEVEL CAS_BROKER)
 
 set(CUB_BROKER_SOURCES
   ${BROKER_DIR}/broker.c
@@ -23,7 +38,7 @@ else(UNIX)
   list(APPEND CUB_BROKER_SOURCES ${BROKER_DIR}/broker_wsa_init.c)
   list(APPEND CUB_BROKER_SOURCES ${BROKER_DIR}/cas_meta.c)
   list(APPEND CUB_BROKER_SOURCES ${BASE_DIR}/porting.c)
-  list(APPEND CUB_BROKER_SOURCES ${CMAKE_SOURCE_DIR}/win/cub_broker/version.rc)
+  list(APPEND CUB_BROKER_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(UNIX)
 # cub_broker use WinMain() on Windows platform
 add_executable(cub_broker WIN32 ${CUB_BROKER_SOURCES})
@@ -55,6 +70,7 @@ if(WIN32)
   list(APPEND BROKER_MONITOR_SOURCES ${BASE_DIR}/rand.c)
   list(APPEND BROKER_MONITOR_SOURCES ${BROKER_DIR}/broker_list.c)
   list(APPEND BROKER_MONITOR_SOURCES ${BROKER_DIR}/broker_proxy_conn.c)
+  list(APPEND BROKER_MONITOR_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(broker_monitor ${BROKER_MONITOR_SOURCES})
 target_compile_definitions(broker_monitor PRIVATE ${BROKER_DEFS})
@@ -83,6 +99,7 @@ if(WIN32)
   list(APPEND BROKER_CHANGER_SOURCES ${BASE_DIR}/porting.c)
   list(APPEND BROKER_CHANGER_SOURCES ${BROKER_DIR}/broker_list.c)
   list(APPEND BROKER_CHANGER_SOURCES ${BROKER_DIR}/broker_wsa_init.c)
+  list(APPEND BROKER_CHANGER_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(broker_changer ${BROKER_CHANGER_SOURCES})
 target_compile_definitions(broker_changer PRIVATE ${BROKER_DEFS})
@@ -115,6 +132,7 @@ if(WIN32)
   list(APPEND CUBRID_BROKER_SOURCES ${BASE_DIR}/rand.c)
   list(APPEND CUBRID_BROKER_SOURCES ${BROKER_DIR}/broker_list.c)
   list(APPEND CUBRID_BROKER_SOURCES ${BROKER_DIR}/broker_wsa_init.c)
+  list(APPEND CUBRID_BROKER_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(cubrid_broker ${CUBRID_BROKER_SOURCES})
 target_compile_definitions(cubrid_broker PRIVATE ${BROKER_DEFS})
@@ -152,6 +170,7 @@ else(UNIX)
   list(APPEND CUB_CAS_SOURCES ${BROKER_DIR}/broker_list.c)
   list(APPEND CUB_CAS_SOURCES ${BROKER_DIR}/broker_wsa_init.c)
   list(APPEND CUB_CAS_SOURCES ${BROKER_DIR}/cas_util.c)
+  list(APPEND CUB_CAS_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(UNIX)
 
 add_executable(cub_cas WIN32 ${CUB_CAS_SOURCES})
@@ -194,7 +213,7 @@ else(UNIX)
   list(APPEND CUB_PROXY_SOURCES ${BROKER_DIR}/broker_list.c)
   list(APPEND CUB_PROXY_SOURCES ${BROKER_DIR}/broker_wsa_init.c)
   list(APPEND CUB_PROXY_SOURCES ${BROKER_DIR}/cas_util.c)
-  list(APPEND CUB_PROXY_SOURCES ${CMAKE_SOURCE_DIR}/win/cub_proxy/version.rc)
+  list(APPEND CUB_PROXY_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(UNIX)
 add_executable(cub_proxy ${CUB_PROXY_SOURCES})
 set_target_properties(cub_proxy PROPERTIES PUBLIC_HEADER "${BROKER_DIR}/shard_key.h")
@@ -211,6 +230,9 @@ set(BROKER_LOG_CONVERTER_SOURCES
   ${BROKER_DIR}/broker_log_util.c
   ${BROKER_DIR}/log_top_string.c
   )
+if(WIN32)
+  list(APPEND BROKER_LOG_CONVERTER_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
+endif(WIN32)
 add_executable(broker_log_converter ${BROKER_LOG_CONVERTER_SOURCES})
 target_compile_definitions(broker_log_converter PRIVATE ${BROKER_DEFS} BROKER_LOG_CONVERTER)
 target_link_libraries(broker_log_converter LINK_PRIVATE cubridcs)
@@ -226,6 +248,7 @@ set(BROKER_LOG_RUNNER_SOURCES
   )
 if(WIN32)
   list(APPEND BROKER_LOG_RUNNER_SOURCES ${BASE_DIR}/porting.c)
+  list(APPEND BROKER_LOG_RUNNER_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(broker_log_runner ${BROKER_LOG_RUNNER_SOURCES})
 target_compile_definitions(broker_log_runner PRIVATE ${BROKER_DEFS} BROKER_LOG_RUNNER)
@@ -248,6 +271,7 @@ if(WIN32)
   list(APPEND BROKER_TESTER_SOURCES ${BROKER_DIR}/broker_filename.c)
   list(APPEND BROKER_TESTER_SOURCES ${BROKER_DIR}/broker_list.c)
   list(APPEND BROKER_TESTER_SOURCES ${BROKER_DIR}/broker_util.c)
+  list(APPEND BROKER_TESTER_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(broker_tester ${BROKER_TESTER_SOURCES})
 target_compile_definitions(broker_tester PRIVATE ${BROKER_DEFS} BROKER_TESTER)
@@ -266,6 +290,9 @@ set(BROKER_LOG_TOP_SOURCES
   ${BROKER_DIR}/log_top_string.c
   ${BROKER_DIR}/broker_log_top_tran.c
   )
+if(WIN32)
+  list(APPEND BROKER_LOG_TOP_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
+endif(WIN32)
 add_executable(broker_log_top ${BROKER_LOG_TOP_SOURCES})
 target_compile_definitions(broker_log_top PRIVATE ${BROKER_DEFS} BROKER_LOG_TOP)
 target_link_libraries(broker_log_top LINK_PRIVATE cubridcs)
@@ -278,6 +305,7 @@ set(CUBRID_REPLAY_SOURCES
   )
 if(WIN32)
   list(APPEND CUBRID_REPLAY_SOURCES ${BASE_DIR}/porting.c)
+  list(APPEND CUBRID_REPLAY_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(cubrid_replay ${CUBRID_REPLAY_SOURCES})
 target_compile_definitions(cubrid_replay PRIVATE ${BROKER_DEFS} CUBRID_REPLAY)

--- a/cas/CMakeLists.txt
+++ b/cas/CMakeLists.txt
@@ -1,3 +1,21 @@
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+
 set(LIBCAS_SOURCES
   ${BROKER_DIR}/cas.c 
   ${BROKER_DIR}/cas_network.c 

--- a/cci/CMakeLists.txt
+++ b/cci/CMakeLists.txt
@@ -1,4 +1,20 @@
-
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 set(CASCCI_SOURCES
   ${BASE_DIR}/porting.c
@@ -23,7 +39,6 @@ endif(WIN32)
 add_library(cascci SHARED ${CASCCI_SOURCES})
 set_target_properties(cascci PROPERTIES SOVERSION "${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}")
 set_target_properties(cascci PROPERTIES PUBLIC_HEADER "${CCI_DIR}/cas_cci.h;${BROKER_DIR}/cas_error.h")
-target_compile_definitions(cascci PRIVATE ${VERSION_DEFS})
 target_include_directories(cascci PRIVATE ${EP_INCLUDES})
 target_link_libraries(cascci LINK_PRIVATE ${EP_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 if(WIN32)

--- a/cm_common/CMakeLists.txt
+++ b/cm_common/CMakeLists.txt
@@ -1,4 +1,20 @@
-
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 set(CMSTAT_SOURCES
   ${CM_COMMON_DIR}/cm_mem_cpu_stat.c
@@ -17,7 +33,6 @@ target_include_directories(cmstat PRIVATE ${JAVA_INC})
 if(NOT USE_CUBRID_ENV)
   target_compile_definitions(cmstat PRIVATE ${DIR_DEFS})
 endif(NOT USE_CUBRID_ENV)
-#target_compile_definitions(cmstat PRIVATE ${VERSION_DEFS})
 target_link_libraries(cmstat LINK_PRIVATE brokeradmin)
 if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
   target_link_libraries(cmstat LINK_PRIVATE perfstat)
@@ -49,6 +64,9 @@ endif()
 set(CUB_JOBSA_SOURCES
   ${CM_COMMON_DIR}/cm_class_info_sa.c
   )
+if(WIN32)
+  list(APPEND CUB_JOBSA_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
+endif(WIN32)
 add_executable(cub_jobsa ${CUB_JOBSA_SOURCES})
 target_link_libraries(cub_jobsa cubridsa)
 
@@ -56,6 +74,9 @@ target_link_libraries(cub_jobsa cubridsa)
 set(CUB_SAINFO_SOURCES
   ${CM_COMMON_DIR}/cm_trigger_info_sa.c
   )
+if(WIN32)
+  list(APPEND CUB_SAINFO_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
+endif(WIN32)
 add_executable(cub_sainfo ${CUB_JOBSA_SOURCES})
 target_link_libraries(cub_sainfo cubridsa)
 

--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 file(GLOB conf_files "${CMAKE_SOURCE_DIR}/conf/cubrid*.conf*" "${CMAKE_SOURCE_DIR}/conf/shard*.txt")
 file(GLOB locale_files "${CMAKE_SOURCE_DIR}/conf/cubrid*.txt")

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ * Copyright (C) 2016 Search Solution Corporation. All rights reserved.
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation; version 2 of the License.
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
  *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -12,7 +13,7 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 
@@ -90,10 +91,8 @@
 
 #cmakedefine ENABLE_SYSTEMTAP 1
 
-#cmakedefine PACKAGE_STRING "@PACKAGE_STRING@"
-#cmakedefine PRODUCT_STRING "@PRODUCT_STRING@"
-
 #include "system.h"
+#include "version.h"
 
 #endif /* _CONFIG_H_ */
 

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 if(UNIX)
   # scripts for init

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -1,4 +1,20 @@
-
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 set(EXECUTABLE_SOURCES
   ${BISON_loader_grammar_OUTPUTS}
@@ -232,7 +248,7 @@ add_library(cubridcs SHARED
   )
 set_target_properties(cubridcs PROPERTIES SOVERSION "${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}")
 
-target_compile_definitions(cubridcs PRIVATE CS_MODE ${COMMON_DEFS} ${VERSION_DEFS})
+target_compile_definitions(cubridcs PRIVATE CS_MODE ${COMMON_DEFS})
 if(NOT USE_CUBRID_ENV)
   target_compile_definitions(cubridcs PRIVATE ${DIR_DEFS})
 endif(NOT USE_CUBRID_ENV)

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -1,4 +1,20 @@
-
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 set(COMPAT_SOURCES
   ${COMPAT_DIR}/cnv.c
@@ -212,7 +228,7 @@ if(WIN32)
   set_target_properties(cubrid PROPERTIES OUTPUT_NAME libcubrid)
 endif(WIN32)
 
-target_compile_definitions(cubrid PRIVATE SERVER_MODE ${COMMON_DEFS} ${VERSION_DEFS})
+target_compile_definitions(cubrid PRIVATE SERVER_MODE ${COMMON_DEFS})
 if(NOT USE_CUBRID_ENV)
   target_compile_definitions(cubrid PRIVATE ${DIR_DEFS})
 endif(NOT USE_CUBRID_ENV)

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,20 +1,37 @@
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 install(FILES ${CMAKE_SOURCE_DIR}/demo/demodb_objects ${CMAKE_SOURCE_DIR}/demo/demodb_schema
   DESTINATION ${CUBRID_DEMODIR}) 
 
 if(UNIX)
-  set(demodb_script make_cubrid_demo.sh)
+  set(DEMODB_SCRIPT make_cubrid_demo.sh)
 else(UNIX)
-  set(demodb_script make_cubrid_demo.bat)
+  set(DEMODB_SCRIPT make_cubrid_demo.bat)
 endif(UNIX)
 if(USE_CUBRID_ENV OR WIN32)
-  install(PROGRAMS ${CMAKE_SOURCE_DIR}/demo/${demodb_script}
+  install(PROGRAMS ${CMAKE_SOURCE_DIR}/demo/${DEMODB_SCRIPT}
     DESTINATION ${CUBRID_DEMODIR})
 else(USE_CUBRID_ENV OR WIN32)
-  file(READ ${CMAKE_SOURCE_DIR}/demo/${demodb_script} scr)
+  file(READ ${CMAKE_SOURCE_DIR}/demo/${DEMODB_SCRIPT} scr)
   string(REPLACE "-z \"$CUBRID\"" "! -d ${CUBRID_PREFIXDIR}/${CUBRID_DEMODIR}" mod_scr "${scr}")
   string(REPLACE "$CUBRID/demo" "${CUBRID_PREFIXDIR}/${CUBRID_DEMODIR}" mod_scr "${mod_scr}" )
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${demodb_script} ${mod_scr})
-  install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${demodb_script}
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${DEMODB_SCRIPT} ${mod_scr})
+  install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${DEMODB_SCRIPT}
     DESTINATION ${CUBRID_DEMODIR})
 endif(USE_CUBRID_ENV OR WIN32)

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -1,11 +1,28 @@
-
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 add_custom_target(jsp_build ALL
-  COMMAND ${ANT} dist -buildfile ${CMAKE_SOURCE_DIR}/java/build.xml -Dbasedir=. -Dversion=${CUBRID_VERSION} -Dsrc=${CMAKE_SOURCE_DIR}/src/jdbc
+  COMMAND ${ANT} dist -buildfile ${CMAKE_SOURCE_DIR}/java/build.xml -Dbasedir=. -Dversion=${BUILD_NUMBER} -Dsrc=${JDBC_DIR}
   COMMENT "Build JSP driver with Ant ..."
   )
 
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/jspserver.jar
+  ${JDBC_DIR}/logging.properties
   DESTINATION ${CUBRID_JAVADIR})

--- a/jdbc/CMakeLists.txt
+++ b/jdbc/CMakeLists.txt
@@ -1,24 +1,40 @@
-
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 add_custom_target(jdbc_build ALL
   COMMAND ${CMAKE_COMMAND} -E make_directory src
-  COMMAND ${CMAKE_COMMAND} -E touch src/CUBRID-JDBC-${CUBRID_VERSION}
-  COMMAND ${ANT} dist-cubrid -buildfile ${CMAKE_SOURCE_DIR}/jdbc/build.xml -Dbasedir=. -Dversion=${CUBRID_VERSION} -Dsrc=${CMAKE_SOURCE_DIR}/src/jdbc
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/${VERSION_FILE} src/CUBRID-JDBC-${BUILD_NUMBER}
+  COMMAND ${ANT} dist-cubrid -buildfile ${CMAKE_SOURCE_DIR}/jdbc/build.xml -Dbasedir=. -Dversion=${BUILD_NUMBER} -Dsrc=${JDBC_DIR}
   COMMENT "Build JDBC driver with Ant ..."
   )
 if(UNIX)
   add_custom_command(TARGET jdbc_build POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E create_symlink JDBC-${CUBRID_VERSION}-cubrid.jar cubrid_jdbc.jar
-  )
+    COMMAND ${CMAKE_COMMAND} -E create_symlink JDBC-${BUILD_NUMBER}-cubrid.jar cubrid_jdbc.jar
+    )
 else(UNIX)
   add_custom_command(TARGET jdbc_build POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy JDBC-${CUBRID_VERSION}-cubrid.jar cubrid_jdbc.jar
-  )
+    COMMAND ${CMAKE_COMMAND} -E copy JDBC-${BUILD_NUMBER}-cubrid.jar cubrid_jdbc.jar
+    )
 endif(UNIX)
 
 
 install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/JDBC-${CUBRID_VERSION}-cubrid.jar
+  ${CMAKE_CURRENT_BINARY_DIR}/JDBC-${BUILD_NUMBER}-cubrid.jar
   ${CMAKE_CURRENT_BINARY_DIR}/cubrid_jdbc.jar
-  ${CMAKE_CURRENT_BINARY_DIR}/JDBC-${CUBRID_VERSION}-cubrid-src.jar
+  ${CMAKE_CURRENT_BINARY_DIR}/JDBC-${BUILD_NUMBER}-cubrid-src.jar
   DESTINATION ${CUBRID_JDBCDIR})

--- a/locales/CMakeLists.txt
+++ b/locales/CMakeLists.txt
@@ -1,4 +1,20 @@
-
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 if(UNIX)
   install(PROGRAMS

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -1,4 +1,20 @@
-
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 set(LOCALE_DIRS 
   en_US

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -1,4 +1,20 @@
-
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 set(EXECUTABLE_SOURCES
   ${BISON_loader_grammar_OUTPUTS}
@@ -279,7 +295,7 @@ add_library(cubridsa SHARED
   )
 set_target_properties(cubridsa PROPERTIES SOVERSION "${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}")
 
-target_compile_definitions(cubridsa PRIVATE SA_MODE ${COMMON_DEFS} ${VERSION_DEFS})
+target_compile_definitions(cubridsa PRIVATE SA_MODE ${COMMON_DEFS})
 if(NOT USE_CUBRID_ENV)
   target_compile_definitions(cubridsa PRIVATE ${DIR_DEFS})
 endif(NOT USE_CUBRID_ENV)

--- a/src/base/release_string.c
+++ b/src/base/release_string.c
@@ -89,6 +89,9 @@ static const char *major_release_string = makestring (MAJOR_RELEASE_STRING);
 static const char *build_number = makestring (BUILD_NUMBER);
 static const char *package_string = PACKAGE_STRING;
 static const char *build_os = makestring (BUILD_OS);
+#if defined (VERSION_STRING)
+static const char *version_string = VERSION_STRING;
+#endif /* VERSION_STRING */
 static int bit_platform = __WORDSIZE;
 
 static REL_COMPATIBILITY rel_get_compatible_internal (const char *base_rel_str, const char *apply_rel_str,
@@ -111,16 +114,26 @@ rel_copy_version_string (char *buf, size_t len)
   snprintf (buf, len, "%s (%s) (%dbit owfs release build for %s) (%s %s)", rel_name (), rel_build_number (),
 	    rel_bit_platform (), rel_build_os (), __DATE__, __TIME__);
 #else /* CUBRID_OWFS */
+#if defined (VERSION_STRING)
+  snprintf (buf, len, "%s (%s) (%dbit release build for %s) (%s %s)", rel_name (), rel_version_string (),
+	    rel_bit_platform (), rel_build_os (), __DATE__, __TIME__);
+#else /* VERSION_STRING */
   snprintf (buf, len, "%s (%s) (%dbit release build for %s) (%s %s)", rel_name (), rel_build_number (),
 	    rel_bit_platform (), rel_build_os (), __DATE__, __TIME__);
+#endif /* VERSION_STRING */
 #endif /* !CUBRID_OWFS */
 #else /* NDEBUG */
 #if defined (CUBRID_OWFS)
   snprintf (buf, len, "%s (%s) (%dbit owfs debug build for %s) (%s %s)", rel_name (), rel_build_number (),
 	    rel_bit_platform (), rel_build_os (), __DATE__, __TIME__);
 #else /* CUBRID_OWFS */
+#if defined (VERSION_STRING)
+  snprintf (buf, len, "%s (%s) (%dbit debug build for %s) (%s %s)", rel_name (), rel_version_string (),
+	    rel_bit_platform (), rel_build_os (), __DATE__, __TIME__);
+#else /* VERSION_STRING */
   snprintf (buf, len, "%s (%s) (%dbit debug build for %s) (%s %s)", rel_name (), rel_build_number (),
 	    rel_bit_platform (), rel_build_os (), __DATE__, __TIME__);
+#endif /* VERSION_STRING */
 #endif /* !CUBRID_OWFS */
 #endif /* !NDEBUG */
 }
@@ -174,6 +187,19 @@ rel_build_os (void)
 {
   return build_os;
 }
+
+
+#if defined (VERSION_STRING)
+/*
+ * rel_version_string - Full version string of the product
+ *   return: static char string
+ */
+const char *
+rel_version_string (void)
+{
+  return version_string;
+}
+#endif /* VERSION_STRING */
 
 #if defined (ENABLE_UNUSED_FUNCTION)
 /*

--- a/src/base/release_string.h
+++ b/src/base/release_string.h
@@ -57,6 +57,9 @@ extern const char *rel_release_string (void);
 extern const char *rel_major_release_string (void);
 extern const char *rel_build_number (void);
 extern const char *rel_build_os (void);
+#if defined(VERSION_STRING)
+extern const char *rel_version_string (void);
+#endif /* VERSION_STRING */
 #if defined(ENABLE_UNUSED_FUNCTION)
 extern const char *rel_copyright_header (void);
 extern const char *rel_copyright_body (void);

--- a/timezones/CMakeLists.txt
+++ b/timezones/CMakeLists.txt
@@ -1,25 +1,41 @@
-
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 if(UNIX)
-add_custom_command(
-  OUTPUT tzlib/timezones.c
-  COMMAND ${CMAKE_COMMAND} -E make_directory tzlib
-  COMMAND CUBRID=${CMAKE_BINARY_DIR} LD_LIBRARY_PATH=$<TARGET_FILE_DIR:cubridsa> $<TARGET_FILE:cub_admin> gen_tz -i ${CMAKE_CURRENT_SOURCE_DIR}/tzdata -g new
-  DEPENDS gen_msgs_en_US
-  )
+  add_custom_command(
+    OUTPUT tzlib/timezones.c
+    COMMAND ${CMAKE_COMMAND} -E make_directory tzlib
+    COMMAND CUBRID=${CMAKE_BINARY_DIR} LD_LIBRARY_PATH=$<TARGET_FILE_DIR:cubridsa> $<TARGET_FILE:cub_admin> gen_tz -i ${CMAKE_CURRENT_SOURCE_DIR}/tzdata -g new
+    DEPENDS gen_msgs_en_US
+    )
 else(UNIX)
   if(TARGET_PLATFORM_BITS EQUAL 32)
     set(REQUIRED_DLLS
-	${CMAKE_SOURCE_DIR}/win/external/dll/jansson.dll
-	${CMAKE_SOURCE_DIR}/win/external/dll/Win32/libgcrypt.dll
-	${CMAKE_SOURCE_DIR}/win/external/dll/Win32/libgpg-error-0.dll
-       )
+      ${CMAKE_SOURCE_DIR}/win/external/dll/jansson.dll
+      ${CMAKE_SOURCE_DIR}/win/external/dll/Win32/libgcrypt.dll
+      ${CMAKE_SOURCE_DIR}/win/external/dll/Win32/libgpg-error-0.dll
+      )
   else(TARGET_PLATFORM_BITS EQUAL 32)
     set(REQUIRED_DLLS
-	${CMAKE_SOURCE_DIR}/win/external/dll/jansson64.dll
-	${CMAKE_SOURCE_DIR}/win/external/dll/x64/libgcrypt.dll
-	${CMAKE_SOURCE_DIR}/win/external/dll/x64/libgpg-error-0.dll
-       )
+      ${CMAKE_SOURCE_DIR}/win/external/dll/jansson64.dll
+      ${CMAKE_SOURCE_DIR}/win/external/dll/x64/libgcrypt.dll
+      ${CMAKE_SOURCE_DIR}/win/external/dll/x64/libgpg-error-0.dll
+      )
   endif(TARGET_PLATFORM_BITS EQUAL 32)
   add_custom_command(
     OUTPUT tzlib/timezones.c

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 if(UNIX)
   set(CCI_APPLIER_SOURCES

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 set(LIBCUBRIDESQL_SOURCES
   ${EXECUTABLES_DIR}/esql_gadget.c
@@ -25,6 +42,9 @@ set(CSQL_SOURCES
   ${BASE_DIR}/porting.c
   ${BASE_DIR}/getopt_long.c
   )
+if(WIN32)
+  list(APPEND CSQL_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
+endif(WIN32)
 add_executable(csql ${CSQL_SOURCES})
 target_compile_definitions(csql PRIVATE ${COMMON_DEFS})
 target_include_directories(csql PRIVATE ${EP_INCLUDES})
@@ -47,10 +67,7 @@ set(CUB_MASTER_SOURCES
 if(UNIX)
   list(APPEND CUB_MASTER_SOURCES ${EXECUTABLES_DIR}/master_heartbeat.c)
 else(UNIX)
-  # TODO: create rc file for VS_VERSIONINFO automatically.
-  # ref. http://stackoverflow.com/questions/6693100/how-to-generate-windows-dll-versioning-information-with-cmake
-  # ref. https://git.reviewboard.kde.org/r/121400/diff/2#0
-  list(APPEND CUB_MASTER_SOURCES ${CMAKE_SOURCE_DIR}/win/cub_master/version.rc)
+  list(APPEND CUB_MASTER_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(UNIX)
 add_executable(cub_master ${CUB_MASTER_SOURCES})
 target_compile_definitions(cub_master PRIVATE ${COMMON_DEFS})
@@ -63,7 +80,7 @@ endif(WIN32)
 
 set(CUB_SERVER_SOURCES ${EXECUTABLES_DIR}/server.c)
 if(WIN32)
-  list(APPEND CUB_SERVER_SOURCES ${CMAKE_SOURCE_DIR}/win/cub_server/version.rc)
+  list(APPEND CUB_SERVER_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(cub_server ${CUB_SERVER_SOURCES})
 target_include_directories(cub_server PRIVATE ${EP_INCLUDES})
@@ -79,6 +96,7 @@ set(CUBRID_SOURCES
   )
 if(WIN32)
   list(APPEND CUBRID_SOURCES ${BASE_DIR}/getopt_long.c)
+  list(APPEND CUBRID_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(cubrid-bin ${CUBRID_SOURCES})
 set_target_properties(cubrid-bin PROPERTIES OUTPUT_NAME cubrid)
@@ -92,6 +110,7 @@ set(CUB_COMMDB_SOURCES
   )
 if(WIN32)
   list(APPEND CUB_COMMDB_SOURCES ${BASE_DIR}/getopt_long.c)
+  list(APPEND CUB_COMMDB_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(cub_commdb ${CUB_COMMDB_SOURCES})
 target_link_libraries(cub_commdb LINK_PRIVATE cubridcs)
@@ -101,6 +120,9 @@ endif(WIN32)
 
 
 set(CUBRID_REL_SOURCES ${EXECUTABLES_DIR}/cubrid_version.c)
+if(WIN32)
+  list(APPEND CUBRID_REL_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
+endif(WIN32)
 add_executable(cubrid_rel ${CUBRID_REL_SOURCES})
 target_link_libraries(cubrid_rel LINK_PRIVATE cubridsa)
 
@@ -108,12 +130,12 @@ target_link_libraries(cubrid_rel LINK_PRIVATE cubridsa)
 set(LOADJAVA_SOURCES ${EXECUTABLES_DIR}/loadjava.c)
 if(WIN32)
   list(APPEND LOADJAVA_SOURCES ${BASE_DIR}/getopt_long.c)
+  list(APPEND LOADJAVA_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(loadjava ${LOADJAVA_SOURCES})
 if(UNIX)
   target_link_libraries(loadjava LINK_PRIVATE cubridsa)
 else(UNIX)
-  # FIXME: diff from linux build??
   target_link_libraries(loadjava LINK_PRIVATE cubridcs)
 endif(UNIX)
 
@@ -124,6 +146,9 @@ set(CUB_ADMIN_SOURCES
   ${BASE_DIR}/getopt_long.c
   ${BASE_DIR}/porting.c
   )
+if(WIN32)
+  list(APPEND CUB_ADMIN_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
+endif(WIN32)
 add_executable(cub_admin ${CUB_ADMIN_SOURCES})
 target_include_directories(cub_admin PRIVATE ${EP_INCLUDES})
 target_link_libraries(cub_admin LINK_PRIVATE ${CMAKE_DL_LIBS})
@@ -147,10 +172,10 @@ set(CUBRID_ESQL_SOURCES
   )
 if(WIN32)
   list(APPEND CUBRID_ESQL_SOURCES ${BASE_DIR}/getopt_long.c)
+  list(APPEND CUBRID_ESQL_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 set_source_files_properties(${BISON_esql_grammar_OUTPUTS} PROPERTIES GENERATED true)
 set_source_files_properties(${FLEX_esql_lexer_OUTPUTS} PROPERTIES GENERATED true)
-
 add_executable(cubrid_esql ${CUBRID_ESQL_SOURCES})
 target_include_directories(cubrid_esql PRIVATE ${CMAKE_BINARY_DIR} ${EP_INCLUDES})
 target_compile_definitions(cubrid_esql PRIVATE ${COMMON_DEFS} PRODUCE_ANSI_CODE UCI_TEMPORARY)
@@ -169,6 +194,7 @@ set(GENCAT_SOURCES
   )
 if(WIN32)
   list(APPEND GENCAT_SOURCES ${BASE_DIR}/getopt_long.c)
+  list(APPEND GENCAT_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(gencat ${GENCAT_SOURCES})
 if(WIN32)
@@ -178,7 +204,11 @@ if(WIN32)
 endif(WIN32)
 
 
-add_executable(convert_password ${EXECUTABLES_DIR}/convert_password.c)
+set(CONVERT_PASSWORD_SOURCES ${EXECUTABLES_DIR}/convert_password.c)
+if(WIN32)
+  list(APPEND CONVERT_PASSWORD_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
+endif(WIN32)
+add_executable(convert_password ${CONVERT_PASSWORD_SOURCES})
 target_include_directories(convert_password PRIVATE ${EP_INCLUDES})
 target_link_libraries(convert_password LINK_PRIVATE cubridsa)
 

--- a/version.h.cmake
+++ b/version.h.cmake
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+#ifndef _VERSION_H_
+#define _VERSION_H_
+
+#define MAJOR_VERSION @CUBRID_MAJOR_VERSION@
+#define MINOR_VERSION @CUBRID_MINOR_VERSION@
+#define PATCH_VERSION @CUBRID_PATCH_VERSION@
+#define EXTRA_VERSION @CUBRID_EXTRA_VERSION@
+#define MAJOR_RELEASE_STRING @MAJOR_RELEASE_STRING@
+#define RELEASE_STRING @RELEASE_STRING@
+
+#define BUILD_NUMBER @BUILD_NUMBER@
+#define BUILD_OS @CMAKE_SYSTEM_NAME@
+
+#define PACKAGE_STRING "@PACKAGE_STRING@"
+#define PRODUCT_STRING "@PRODUCT_STRING@"
+#define VERSION_STRING "@CUBRID_VERSION@"
+
+#endif /* _VERSION_H_ */

--- a/version.rc.cmake
+++ b/version.rc.cmake
@@ -1,0 +1,52 @@
+// Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+//
+//   This program is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation; either version 2 of the License, or
+//   (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <windows.h>
+
+#define VER_FILEVERSION @CUBRID_MAJOR_VERSION@,@CUBRID_MINOR_VERSION@,@CUBRID_PATCH_VERSION@,@CUBRID_EXTRA_VERSION@
+#define VER_FILEVERSION_STR "@CUBRID_MAJOR_VERSION@.@CUBRID_MINOR_VERSION@.@CUBRID_PATCH_VERSION@.@CUBRID_EXTRA_VERSION@\0" 
+#define VER_PRODUCTVERSION @CUBRID_MAJOR_VERSION@,@CUBRID_MINOR_VERSION@,@CUBRID_PATCH_VERSION@,0
+#define VER_PRODUCTVERSION_STR "@CUBRID_MAJOR_VERSION@.@CUBRID_MINOR_VERSION@.@CUBRID_PATCH_VERSION@\0" 
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     VER_FILEVERSION
+PRODUCTVERSION  VER_PRODUCTVERSION
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+#ifdef _DEBUG
+  FILEFLAGS VS_FF_DEBUG
+#else
+  FILEFLAGS 0x0L
+#endif
+FILEOS          VOS__WINDOWS32
+FILETYPE        VFT_APP
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904B0"
+    BEGIN
+      VALUE "CompanyName", "Search Solution Corporation"
+      VALUE "FileVersion", VER_FILEVERSION_STR
+      VALUE "LegalCopyright", "Copyright (C) 2016 Search Solution Corporation. All rights reserved."
+      VALUE "ProductName", "CUBRID"
+      VALUE "ProductVersion", VER_PRODUCTVERSION_STR
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x409, 1252
+  END
+END

--- a/win/CMakeLists.txt
+++ b/win/CMakeLists.txt
@@ -1,12 +1,29 @@
+#
+# Copyright (C) 2016 Search Solution Corporation. All rights reserved.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
 
 if(NOT WIN32)
   return()
 endif(NOT WIN32)
 
-
 set(CTRLSERVICE_SOURCES
   ${WIN_TOOLS_DIR}/ctrlservice/ctrlservice.cpp
   ${WIN_TOOLS_DIR}/ctrlservice/stdafx.cpp
+  ${CMAKE_BINARY_DIR}/version.rc
   )
 set_source_files_properties(${WIN_TOOLS_DIR}/ctrlservice/stdafx.cpp
   PROPERTIES
@@ -20,6 +37,7 @@ target_compile_definitions(ctrlservice PRIVATE _CONSOLE)
 set(CUBRIDSERVICE_SOURCES
   ${WIN_TOOLS_DIR}/cubridservice/cubridservice.cpp
   ${WIN_TOOLS_DIR}/cubridservice/stdafx.cpp
+  ${CMAKE_BINARY_DIR}/version.rc
   )
 set_source_files_properties(${WIN_TOOLS_DIR}/cubridservice/stdafx.cpp
   PROPERTIES
@@ -63,6 +81,7 @@ set(CUBRIDTRAY_SOURCES
   ${WIN_TOOLS_DIR}/cubridtray/WAS.CPP
   ${WIN_TOOLS_DIR}/cubridtray/cubridtray.odl
   ${WIN_TOOLS_DIR}/cubridtray/cubridtray.rc
+  ${CMAKE_BINARY_DIR}/version.rc
   )
 set_source_files_properties(${WIN_TOOLS_DIR}/cubridtray/STDAFX.CPP
   PROPERTIES
@@ -86,6 +105,7 @@ set(SETUPMANAGE_SOURCES
   ${WIN_TOOLS_DIR}/setupmanage/SETUPMANAGE.CPP
   ${WIN_TOOLS_DIR}/setupmanage/PATHREGULATION.CPP
   ${WIN_TOOLS_DIR}/setupmanage/stdafx.cpp
+  ${CMAKE_BINARY_DIR}/version.rc
   )
 set_source_files_properties(${WIN_TOOLS_DIR}/setupmanage/stdafx.cpp
   PROPERTIES
@@ -104,6 +124,25 @@ install(TARGETS
   setupmanage
   RUNTIME DESTINATION ${CUBRID_BINDIR}
   )
+
+# install external pre-built DLLs
+# TODO: add custom target for external dlls? 
+# ref. http://stackoverflow.com/questions/14474659/cmake-how-to-have-a-target-for-copying-files
+if(TARGET_PLATFORM_BITS EQUAL 32)
+  file(GLOB TARGET_DLLS
+    ${CMAKE_SOURCE_DIR}/win/external/dll/*.dll
+    ${CMAKE_SOURCE_DIR}/win/external/dll/Win32/*.dll
+    )
+else(TARGET_PLATFORM_BITS EQUAL 32)
+  file(GLOB TARGET_DLLS
+    ${CMAKE_SOURCE_DIR}/win/external/dll/*.dll
+    ${CMAKE_SOURCE_DIR}/win/external/dll/x64/*.dll
+    )
+endif(TARGET_PLATFORM_BITS EQUAL 32)
+
+install(FILES
+  ${TARGET_DLLS}
+  DESTINATION ${CUBRID_BINDIR})
 
 # install pdb files for debugging on windows
 install(DIRECTORY


### PR DESCRIPTION
This is a 2nd step for introducing CMake.

Add 3 files for CMake's version info management 
- VERSION file:
  - 2 dots format version string- major. minor.patch (eg: 10.1.0)
  - (extra version string will be appened to version string. commit-count and hash-tag info from Git)
  - (eg: 10.1.0.6826-35077f4) ("_modified" can be appended if you build with locally modified sources) 
- version.h.cmake template
  - cmake will replace version.h.cmake into version.h at configure.
  - generated version.h will be used for all Linux and Windows build
- version.rc.cmake template
  - cmake will replace version.rc.cmake into version.rc
  - generated version.rc will be used for Windows exe binary.

So, below files can be removed at next 3rd step:
- BUILD_NUMBER - used for Linux build. it contains 3 dots syntax version string. (eg: 10.1.0.1234)
- win/version.h - used for Windows build
- win/*/version.rc - used for Windows exe binary.

Also,
**I will remove autotools(autoconf, automake and libtools) related files at next(3rd) step.**
