### PR TITLE
[CBRD-20252] Change lock-free circular queue states.

### DIFF
--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -2462,7 +2462,7 @@ lf_circular_queue_consume (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data)
     {
       memcpy (data, queue->data + (entry_index * queue->data_size), queue->data_size);
     }
-  
+
   assert (ATOMIC_LOAD_64 (entry_state_p) == new_state);
 
   /* Try to increment consume cursor. If this thread was preempted after reserving the entry and before incrementing
@@ -2581,7 +2581,7 @@ lf_circular_queue_create (unsigned int capacity, int data_size)
       return NULL;
     }
   /* Initialize all entries by expecting first generation of producers. */
-  for (index = 0; index < capacity; index ++)
+  for (index = 0; index < capacity; index++)
     {
       queue->entry_state[index] = index | LFCQ_READY_FOR_PRODUCE;
     }

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -413,7 +413,7 @@ extern bool lf_circular_queue_produce (LOCK_FREE_CIRCULAR_QUEUE * queue, void *d
 extern bool lf_circular_queue_consume (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data);
 extern void *lf_circular_queue_async_peek (LOCK_FREE_CIRCULAR_QUEUE * queue);
 extern bool lf_circular_queue_async_push_ahead (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data);
-extern LOCK_FREE_CIRCULAR_QUEUE *lf_circular_queue_create (INT32 capacity, int data_size);
+extern LOCK_FREE_CIRCULAR_QUEUE *lf_circular_queue_create (unsigned int capacity, int data_size);
 extern void lf_circular_queue_destroy (LOCK_FREE_CIRCULAR_QUEUE * queue);
 
 /* lock free bitmap */

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -399,37 +399,16 @@ typedef struct lock_free_circular_queue LOCK_FREE_CIRCULAR_QUEUE;
 struct lock_free_circular_queue
 {
   char *data;
-  INT32 *entry_state;
+  volatile UINT64 *entry_state;
   int data_size;
-  /* Use INT64 for cursors domain to make sure domain is never consumed. Otherwise it will break the
-   * LOCK_FREE_CIRCULAR_QUEUE_IS_EMPTY and LOCK_FREE_CIRCULAR_QUEUE_IS_FULL checks. */
-  INT64 consume_cursor;
-  INT64 produce_cursor;
-  INT64 capacity;
+  volatile UINT64 consume_cursor;
+  volatile UINT64 produce_cursor;
+  UINT64 capacity;
 };
 
-/* Macro's to inspect queue status and size. Note that their results is not
- * guaranteed to be precise. They can provide false positives and negatives.
- */
-/* Check if queue is empty.
- * NOTE: It can provide false positives/negatives. Use it only as early out
- *	 but do not expect that lf_circular_queue_consume will succeed.
- */
-#define LOCK_FREE_CIRCULAR_QUEUE_IS_EMPTY(queue) \
-  (queue->produce_cursor <= queue->consume_cursor)
-/* Check if queue is full */
-/* NOTE: It can provide false positives/negatives. Use it only as early out
- *	 but do not expect that lf_circular_queue_produce will succeed.
- */
-#define LOCK_FREE_CIRCULAR_QUEUE_IS_FULL(queue) \
-  (queue->consume_cursor <= queue->produce_cursor - queue->capacity + 1)
-/* Get queue size */
-/* The functions will return the exact size if there are no concurrent
- * consumers/producers. Concurrent consumers/producers may alter the result.
- */
-#define LOCK_FREE_CIRCULAR_QUEUE_APPROX_SIZE(queue) \
-  (queue->produce_cursor - queue->consume_cursor)
-
+extern bool lf_circular_queue_is_full (LOCK_FREE_CIRCULAR_QUEUE * queue);
+extern bool lf_circular_queue_is_empty (LOCK_FREE_CIRCULAR_QUEUE * queue);
+extern int lf_circular_queue_approx_size (LOCK_FREE_CIRCULAR_QUEUE * queue);
 extern bool lf_circular_queue_produce (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data);
 extern bool lf_circular_queue_consume (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data);
 extern void *lf_circular_queue_async_peek (LOCK_FREE_CIRCULAR_QUEUE * queue);

--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -725,6 +725,8 @@ extern "C"
 	(InterlockedExchangeAdd64(ptr, amount) + amount)
 #define ATOMIC_CAS_ADDR(ptr, cmp_val, swap_val) \
 	(InterlockedCompareExchange64((long long volatile *) ptr, (long long) swap_val, (long long) cmp_val) == (long long) cmp_val)
+#define ATOMIC_LOAD_64(ptr) (*(ptr))
+#define ATOMIC_STORE_64(ptr, val) (*(ptr) = val)
 #else				/* _WIN64 */
 /*
  * These functions are used on Windows 32bit OS.
@@ -745,6 +747,8 @@ extern "C"
 	(win32_exchange_add64(ptr, amount) + amount)
 #define ATOMIC_CAS_ADDR(ptr, cmp_val, swap_val) \
 	(InterlockedCompareExchange((long volatile *) ptr, (long long) swap_val, (long long) cmp_val) == (long long) cmp_val)
+#define ATOMIC_LOAD_64(ptr) ATOMIC_INC_64 (ptr, 0)
+#define ATOMIC_STORE_64(ptr, val) ATOMIC_TAS_64 (ptr, val)
 #endif				/* _WIN64 */
 
 #else				/* WINDOWS */
@@ -769,6 +773,9 @@ extern "C"
 
 #define ATOMIC_CAS_ADDR(ptr, cmp_val, swap_val) \
 	__sync_bool_compare_and_swap(ptr, cmp_val, swap_val)
+
+#define ATOMIC_LOAD_64(ptr) (*(ptr))
+#define ATOMIC_STORE_64(ptr, val) (*(ptr) = val)
 
 /* There is a gcc bug of __sync_synchronize in x86-64 when gcc version
  * less than 4.4. we can replace __sync_synchronize as mfence instruction.

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4344,7 +4344,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 	  vacuum_unfix_data_page (thread_p, data_page);
 	  return;
 	}
-      
+
       prev_data_page = data_page;
       VPID_COPY (&next_vpid, &data_page->next_page);
       data_page = vacuum_fix_data_page (thread_p, &next_vpid);
@@ -4388,7 +4388,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
    * 1. This is the first and only page. We won't deallocate, just reset the page.
    * 2. This is the first page, but there are other pages too. We will deallocate the page and update the first page.
    * 3. Page is not first and must be deallocated. If the page is last in vacuum data, vacuum_Data.last_page must be
-   *	changed to prev_data_page. Link in prev_data_page must be update.
+   *    changed to prev_data_page. Link in prev_data_page must be update.
    */
   assert (data_page != NULL && *data_page != NULL);
   assert ((*data_page)->index_unvacuumed == (*data_page)->index_free);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -944,7 +944,7 @@ vacuum_finalize (THREAD_ENTRY * thread_p)
   if (vacuum_Finished_job_queue != NULL)
     {
       vacuum_data_mark_finished (thread_p);
-      if (!LOCK_FREE_CIRCULAR_QUEUE_IS_EMPTY (vacuum_Finished_job_queue))
+      if (!lf_circular_queue_is_empty (vacuum_Finished_job_queue))
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  assert (0);
@@ -960,7 +960,7 @@ vacuum_finalize (THREAD_ENTRY * thread_p)
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  assert (0);
 	}
-      if (!LOCK_FREE_CIRCULAR_QUEUE_IS_EMPTY (vacuum_Block_data_buffer))
+      if (!lf_circular_queue_is_empty (vacuum_Block_data_buffer))
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  assert (0);
@@ -2646,7 +2646,7 @@ restart:
 
       PERF_UTIME_TRACKER_START (thread_p, &perf_tracker);
 
-      if (LOCK_FREE_CIRCULAR_QUEUE_IS_FULL (vacuum_Finished_job_queue))
+      if (lf_circular_queue_is_full (vacuum_Finished_job_queue))
 	{
 	  /* Consume vacuum_Finished_job_queue */
 	  vacuum_unfix_data_page (thread_p, data_page);
@@ -2654,7 +2654,7 @@ restart:
 	}
 #else	/* !SA_MODE */	       /* SERVER_MODE */
       /* Wakeup threads to start working on current threads. Try not to wake up more workers than necessary. */
-      n_jobs = (int) LOCK_FREE_CIRCULAR_QUEUE_APPROX_SIZE (vacuum_Job_queue);
+      n_jobs = (int) lf_circular_queue_approx_size (vacuum_Job_queue);
       n_available_workers = prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT) - vacuum_Running_workers_count;
       n_wakeup_workers = MIN (n_jobs, n_available_workers);
       if (n_wakeup_workers > 0)
@@ -2666,7 +2666,7 @@ restart:
       /* If vacuum lagged behind and this loop generated a lot of jobs, the log block buffer used by active workers
        * can fill up. We cannot allow that.
        */
-      vacuum_block_data_buffer_aprox_size = LOCK_FREE_CIRCULAR_QUEUE_APPROX_SIZE (vacuum_Block_data_buffer);
+      vacuum_block_data_buffer_aprox_size = lf_circular_queue_approx_size (vacuum_Block_data_buffer);
       if (vacuum_block_data_buffer_aprox_size > vacuum_Block_data_buffer->capacity / 2)
 	{
 	  vacuum_unfix_data_page (thread_p, data_page);
@@ -2675,7 +2675,7 @@ restart:
       /* Another buffer that is used by vacuum workers to communicate with master is the finished job queue.
        * We cannot allow this to fill either.
        */
-      vacuum_finished_jobs_queue_aprox_size = LOCK_FREE_CIRCULAR_QUEUE_APPROX_SIZE (vacuum_Finished_job_queue);
+      vacuum_finished_jobs_queue_aprox_size = lf_circular_queue_approx_size (vacuum_Finished_job_queue);
       if (vacuum_finished_jobs_queue_aprox_size >= vacuum_Finished_job_queue->capacity / 2)
 	{
 	  vacuum_unfix_data_page (thread_p, data_page);
@@ -2695,12 +2695,12 @@ restart:
 #if defined (SA_MODE)
   /* Complete vacuum for SA_MODE. This means also vacuuming based on last block being logged. */
 
-  assert (LOCK_FREE_CIRCULAR_QUEUE_IS_EMPTY (vacuum_Block_data_buffer));
+  assert (lf_circular_queue_is_empty (vacuum_Block_data_buffer));
 
   /* Remove all vacuumed entries. */
   vacuum_data_mark_finished (thread_p);
 
-  assert (LOCK_FREE_CIRCULAR_QUEUE_IS_EMPTY (vacuum_Finished_job_queue));
+  assert (lf_circular_queue_is_empty (vacuum_Finished_job_queue));
   assert (vacuum_Data.first_page == vacuum_Data.last_page);
   assert (vacuum_Data.first_page->index_unvacuumed == 0);
   assert (vacuum_Data.first_page->index_free == 0);
@@ -3538,7 +3538,7 @@ vacuum_finished_block_vacuum (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data,
 
 #if defined (SERVER_MODE)
   /* Hurry master wakeup if finished job queue is getting filled. */
-  if (LOCK_FREE_CIRCULAR_QUEUE_APPROX_SIZE (vacuum_Finished_job_queue) >= vacuum_Finished_job_queue->capacity / 2)
+  if (lf_circular_queue_approx_size (vacuum_Finished_job_queue) >= vacuum_Finished_job_queue->capacity / 2)
     {
       /* Wakeup master to process finished jobs. */
       thread_wakeup_vacuum_master_thread ();


### PR DESCRIPTION
 Lock-free circular queue changes:

    The main issue behind these changes occurs in the next scenario:

    thrd1: load queue->produce_cursor = PC1 and get preempted.
    thrd2: successfully produce at PC1. queue->produce_cursor becomes bigger than PC1.
    thrd3: successfully consume at PC1. queue->consume_cursor becomes bigger than PC1.
    thrd1: try produce at PC1. since the entry state is alread READY_FOR_PRODUCE, the thread successfully produces here, behind current consume cursor. the entry state becomes READY_FOR_CONSUME.
    all producers: when produce cursor becomes PC1 + queue->capacity, the discovered entry state is READY_FOR_CONSUME instead of READY_FOR_PRODUCE. All producers loop infinitely.

    So, we have to prevent thrd3 from producing behind consume cursor. To do so, we need to include expected produce cursor in the entry state.

    Complete changes:
    1. Extend size of entry_state to 8 bytes (UINT64). The first two bits are used for states: READY_FOR_PRODUCE, RESERVED_FOR_PRODUCE, READY_FOR_CONSUME, RESERVED_FOR_CONSUME. The remaining 62 bytes should be used for produce cursor.
    2. The transition from READY_FOR_PRODUCE to RESERVED_FOR_PRODUCE and from READY_FOR_CONSUME to RESERVED_FOR_CONSUME should also match the cursor saved in state.
    3. The transition from RESERVED_FOR_PRODUCE to READY_FOR_CONSUME maintains the cursor saved in state.
    4. The transition from RESERVED_FOR_CONSUME to READY_FOR_PRODUCE increments the cursor saved in state by queue->capacity.
    5. queue->entry_state, queue->produce_cursor and queue->consume_cursor are volatile.
    6. The cursors type was changed to UINT64. The assembly code showed additional operations to maintain the sign bit.
    7. Replace is empty, is full, approx size macro's with functions (which most likely get inlined). The code is also safer for UINT64 cursor types.
    8. Create queue also initializes each entry of entry_state with expected produce cursors.
    9. Add ATOMIC_LOAD_64 and ATOMIC_STORE_64 for WIN32 systems.