### PR TITLE
[CBRD-20290] Remove setting vacuum_Global_oldest_active_mvccid in vacuum_load_data_from_disk.

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5296,13 +5296,13 @@ vacuum_compare_dropped_files (const void *a, const void *b)
 static int
 vacuum_add_dropped_file (THREAD_ENTRY * thread_p, VFID * vfid, MVCCID mvccid, LOG_RCV * rcv, LOG_LSA * postpone_ref_lsa)
 {
-  MVCCID save_mvccid;
-  VPID vpid, prev_vpid;
-  int page_count, mem_size, compare;
+  MVCCID save_mvccid = MVCCID_NULL;
+  VPID vpid = VPID_INITIALIZER, prev_vpid = VPID_INITIALIZER;
+  int page_count = 0, mem_size = 0, compare = 0;
   char *ptr = NULL;
   VACUUM_DROPPED_FILES_PAGE *page = NULL, *new_page = NULL;
-  INT16 min, max, mid, position;
-  LOG_DATA_ADDR addr;
+  INT16 min = -1, max = -1, mid = -1, position = -1;
+  LOG_DATA_ADDR addr = LOG_DATA_ADDR_INITIALIZER;
   LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
 
 #if !defined (NDEBUG)
@@ -5954,12 +5954,12 @@ vacuum_notify_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv, LOG_LSA * po
 static int
 vacuum_cleanup_dropped_files (THREAD_ENTRY * thread_p)
 {
-  VPID vpid;
+  VPID vpid = VPID_INITIALIZER;
   VACUUM_DROPPED_FILES_PAGE *page = NULL;
-  int page_count, mem_size;
-  VPID last_page_vpid, last_non_empty_page_vpid;
+  int page_count = 0, mem_size = 0;
+  VPID last_page_vpid = VPID_INITIALIZER, last_non_empty_page_vpid = VPID_INITIALIZER;
   INT16 removed_entries[VACUUM_DROPPED_FILES_MAX_PAGE_CAPACITY];
-  INT16 n_removed_entries, i;
+  INT16 n_removed_entries = 0, i;
 #if !defined (NDEBUG)
   VACUUM_TRACK_DROPPED_FILES *track_page = (VACUUM_TRACK_DROPPED_FILES *) vacuum_Track_dropped_files;
 #endif

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2454,8 +2454,8 @@ vacuum_process_vacuum_data (THREAD_ENTRY * thread_p)
   int n_wakeup_workers;
   int n_available_workers;
   int n_jobs;
-  INT64 vacuum_block_data_buffer_aprox_size;
-  INT64 vacuum_finished_jobs_queue_aprox_size;
+  UINT64 vacuum_block_data_buffer_aprox_size;
+  UINT64 vacuum_finished_jobs_queue_aprox_size;
 #else	/* !SERVER_MODE */		   /* SA_MODE */
   VACUUM_DATA_ENTRY vacuum_data_entry;
   bool save_check_interrupt;
@@ -3538,7 +3538,7 @@ vacuum_finished_block_vacuum (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data,
 
 #if defined (SERVER_MODE)
   /* Hurry master wakeup if finished job queue is getting filled. */
-  if (lf_circular_queue_approx_size (vacuum_Finished_job_queue) >= vacuum_Finished_job_queue->capacity / 2)
+  if ((UINT64) lf_circular_queue_approx_size (vacuum_Finished_job_queue) >= vacuum_Finished_job_queue->capacity / 2)
     {
       /* Wakeup master to process finished jobs. */
       thread_wakeup_vacuum_master_thread ();

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -126,7 +126,7 @@ struct locator_return_nxobj
   int area_offset;		/* Relative offset to recdes->data in the communication area */
 };
 
-extern int vacuum_Global_oldest_active_blockers_counter;
+extern INT32 vacuum_Global_oldest_active_blockers_counter;
 
 bool locator_Dont_check_foreign_key = false;
 
@@ -12560,7 +12560,7 @@ xlocator_upgrade_instances_domain (THREAD_ENTRY * thread_p, OID * class_oid, int
     }
   else
     {
-      assert (ATOMIC_INC_32 (&vacuum_Global_oldest_active_blockers_counter, 0) > 0);
+      assert (vacuum_Global_oldest_active_blockers_counter > 0);
     }
 
   /* Can't use vacuum_Global_oldest_active_mvccid here. That's because we want to avoid scenarios where VACUUM compute
@@ -13170,7 +13170,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 	}
       else
 	{
-	  assert (ATOMIC_INC_32 (&vacuum_Global_oldest_active_blockers_counter, 0) > 0);
+	  assert (vacuum_Global_oldest_active_blockers_counter > 0);
 	}
 
       if (threshold_mvccid == MVCCID_NULL)

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -201,7 +201,7 @@ static const int LOG_REC_UNDO_MAX_ATTEMPTS = 3;
 /* true: Skip logging, false: Don't skip logging */
 static bool log_No_logging = false;
 
-extern int vacuum_Global_oldest_active_blockers_counter;
+extern INT32 vacuum_Global_oldest_active_blockers_counter;
 
 static bool log_verify_dbcreation (THREAD_ENTRY * thread_p, VOLID volid, const INT64 * log_dbcreation);
 static int log_create_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const char *logpath,
@@ -5908,7 +5908,7 @@ log_complete (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_RECTYPE iscommitted,
 	{
 	  ATOMIC_INC_32 (&vacuum_Global_oldest_active_blockers_counter, -1);
 	  tdes->block_global_oldest_active_until_commit = false;
-	  assert (ATOMIC_INC_32 (&vacuum_Global_oldest_active_blockers_counter, 0) >= 0);
+	  assert (vacuum_Global_oldest_active_blockers_counter >= 0);
 	}
 
 #if defined (HAVE_ATOMIC_BUILTINS)
@@ -6205,7 +6205,7 @@ log_complete_for_2pc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_RECTYPE isco
 	{
 	  ATOMIC_INC_32 (&vacuum_Global_oldest_active_blockers_counter, -1);
 	  tdes->block_global_oldest_active_until_commit = false;
-	  assert (ATOMIC_INC_32 (&vacuum_Global_oldest_active_blockers_counter, 0) >= 0);
+	  assert (vacuum_Global_oldest_active_blockers_counter >= 0);
 	}
 
 #if defined(HAVE_ATOMIC_BUILTINS)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4085,6 +4085,7 @@ prior_lsa_next_record_internal (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * node, 
 	  assert (log_Gl.hdr.last_block_oldest_mvccid <= vacuum_get_global_oldest_active_mvccid ());
 	  log_Gl.hdr.last_block_oldest_mvccid = vacuum_get_global_oldest_active_mvccid ();
 	  log_Gl.hdr.last_block_newest_mvccid = mvccid;
+	  assert (!MVCC_ID_PRECEDES (mvccid, log_Gl.hdr.last_block_oldest_mvccid));
 	}
       else
 	{


### PR DESCRIPTION
The code that initialized vacuum_Global_oldest_active_mvccid in recovery of vacuum data is legacy code. When vacuum data is loaded, the server is already started. Setting global oldest to log_Gl.hdr.mvcc_next_id is incorrect (hence the issue).