### PR TITLE
[CBRD-20291] fix vacuum to correctly follow the page chain when deallocates a non-first vacuum data page.

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4542,7 +4542,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
       /* Move *data_page to next page. */
       if (!VPID_ISNULL (&prev_data_page->next_page))
 	{
-	  *data_page = vacuum_fix_data_page (thread_p, &(*data_page)->next_page);
+	  *data_page = vacuum_fix_data_page (thread_p, &prev_data_page->next_page);
 	  assert (*data_page != NULL);
 	}
     }


### PR DESCRIPTION
This is a slip of [CBRD-20255](http://jira.cubrid.org/browse/CBRD-20255) as https://github.com/CUBRID/cubrid/pull/78.

`(*data_page)` was deallocated. It should be `prev_data_page` to follow the page chain.