### PR TITLE
[CBRD-20299] Reset vacuum_Block_data_buffer circular queue after using it for recovery.

### DIFF
--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -2630,6 +2630,26 @@ lf_circular_queue_destroy (LOCK_FREE_CIRCULAR_QUEUE * queue)
   free (queue);
 }
 
+/*
+ * lf_circular_queue_async_reset () - Reset lock-free circular queue.
+ *				      NOTE: The function should not be called while concurrent threads produce or
+ *					    consume entries.
+ *
+ * return	  : Void.
+ * queue (in/out) : Lock-free circular queue.
+ */
+void
+lf_circular_queue_async_reset (LOCK_FREE_CIRCULAR_QUEUE * queue)
+{
+  int es_idx;
+  queue->produce_cursor = 0;
+  queue->consume_cursor = 0;
+
+  for (es_idx = 0; es_idx < queue->capacity; es_idx++)
+    {
+      queue->entry_state[es_idx] = es_idx | LFCQ_READY_FOR_PRODUCE;
+    }
+}
 
 /*
  * lf_bitmap_init () - initialize lock free bitmap

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -415,6 +415,7 @@ extern void *lf_circular_queue_async_peek (LOCK_FREE_CIRCULAR_QUEUE * queue);
 extern bool lf_circular_queue_async_push_ahead (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data);
 extern LOCK_FREE_CIRCULAR_QUEUE *lf_circular_queue_create (unsigned int capacity, int data_size);
 extern void lf_circular_queue_destroy (LOCK_FREE_CIRCULAR_QUEUE * queue);
+extern void lf_circular_queue_async_reset (LOCK_FREE_CIRCULAR_QUEUE * queue);
 
 /* lock free bitmap */
 extern int lf_bitmap_init (LF_BITMAP * bitmap, LF_BITMAP_STYLE style, int entries_cnt, float usage_threshold);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5170,6 +5170,8 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_recover_lost_block_data");
       return error_code;
     }
+
+  lf_circular_queue_async_reset (vacuum_Block_data_buffer);
   return NO_ERROR;
 }
 


### PR DESCRIPTION
The vacuum_Block_data_buffer circular queue is left in an inconsistent state after it is hackishly used for recovery vacuum data blocks.

Fix by resetting to the queue to original state.