### PR TITLE
[CBRD-20302] Fix fetching the OID of old named parameter which now points to a deallocated file.

### DIFF
--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4047,6 +4047,14 @@ xlocator_does_exist (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock, LC_
 
   if (OID_ISNULL (class_oid))
     {
+      /* Quick fix: we need to check if OID is valid - meaning that page is still valid. This code is going to be
+       * removed with one of the refactoring issues anyway.
+       */
+      if (HEAP_ISVALID_OID (oid) != DISK_VALID)
+	{
+	  return LC_DOESNOT_EXIST;
+	}
+
       /* 
        * Caller does not know the class of the object. Get the class identifier
        * from disk


### PR DESCRIPTION
Fixed by checking object existance when trying to bind to an object type name parameter.

xlocator_does_exist was also updated for the NULL class OID case.