### PR TITLE
[CBRD-20309] Redesign vacuum data flush.

### DIFF
--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -48,6 +48,7 @@
 #define VACUUM_ER_LOG_TOPOPS		1024	/* Log starting/ending system operations and their recovery. */
 #define VACUUM_ER_LOG_ARCHIVES		2048	/* Log when archives are removed or when vacuum fails to find archives. */
 #define VACUUM_ER_LOG_JOBS		4096	/* Log job generation, interrupt, finish */
+#define VACUUM_ER_LOG_FLUSH_DATA	8192	/* Log flushing vacuum data. */
 
 #define VACUUM_ER_LOG_VERBOSE		0xFFFFFFFF	/* Log all activity related to vacuum. */
 #define VACUUM_IS_ER_LOG_LEVEL_SET(er_log_level) \
@@ -287,10 +288,7 @@ extern int vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p);
 extern LOG_PAGEID vacuum_min_log_pageid_to_keep (THREAD_ENTRY * thread_p);
 extern void vacuum_notify_server_crashed (LOG_LSA * recovery_lsa);
 extern void vacuum_notify_server_shutdown (void);
-#if defined (SERVER_MODE)
-extern void vacuum_notify_flush_data (void);
-extern bool vacuum_is_vacuum_data_flushed (void);
-#endif /* SERVER_MODE */
+extern void vacuum_notify_need_flush (int need_flush);
 extern int vacuum_rv_redo_vacuum_complete (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int vacuum_rv_redo_initialize_data_page (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int vacuum_rv_undoredo_first_data_page (THREAD_ENTRY * thread_p, LOG_RCV * rcv);


### PR DESCRIPTION
Issue explained:
1. Vacuum master deallocates a page VPID1 once it was filled with vacuumed blocks.
2. Checkpoint starts and notifies master to flush vacuum data. Master flushes all existing pages.
3. Vacuum master reallocated page VPID1 and appends it to vacuum data pages. The oldest_unflushed_lsa and dirty flags are not modified. Note that oldest_unflushed_lsa is older than checkpoint LSA.
4. Checkpoint checks page VPID1 and since oldest_unflushed_lsa preceeds checkpoint LSA, it wants to flush it to disk. However, the page is help by vacuum master.
5. 5 minutes passes the checkpoint thread times out on page latch.

The case was missed when vacuum data flush was implemented. Current implementation was a temporary one and it was meant to be changed.

Therefore, it was changed to new implementation:
1. Vacuum master no longer flushes pages. Checkpoint will have to do it.
2. When checkpoint reaches a vacuum data page, first it tries a conditional latch. It will succeed if page is not latched by vacuum master (page is not first or last vacuum data page).
3. If conditional latch fails, checkpoint notifies vacuum of its intention and requests unconditional latch on page.
4. On next vacuum master iteration, it will notice the flush intention of checkpoint. Master unfixes pages and fixes them again, giving checkpoint thread a chance to obtain its latch and flush the page.
5. Other changes:
 - When new pages are allocated for vacuum data or dropped files, we use NEW_PAGE fetch mode instead of OLD_PAGE.
 - Updated vacuum_fix_data_page to handle NULL first and last pages.
 - vacuum_Data.flush_vacuum_data is now volatile, to avoid compile optimization skipping setting the memory value to 1/0.
 - added VACUUM_ER_LOG_FLUSH_DATA logging.