### PR TITLE
[CBRD-20155] remove modified postfix of hash tag in version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ else(VERSION_MATCHES_LENGTH GREATER 3)
       message(FATAL_ERROR "Could not get count information from Git")
     endif(git_result)
     set(CUBRID_EXTRA_VERSION ${commit_count})
-    execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --match '@{NEVERMATCH}@' --dirty=_modified
+    execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
       OUTPUT_VARIABLE commit_hash RESULT_VARIABLE git_result
       ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/build.sh
+++ b/build.sh
@@ -123,7 +123,7 @@ function build_initialize ()
     serial_number=$(echo $extra_version | cut -d - -f 1)
   elif [ -d $source_dir/.git ]; then
     serial_number=$(cd $source_dir && git rev-list --count HEAD)
-    hash_tag=$(cd $source_dir && git describe --always --match '@{NEVERMATCH}@' --dirty=_modified)
+    hash_tag=$(cd $source_dir && git rev-parse --short HEAD)
     extra_version="$serial_number-$hash_tag"
   else
     extra_version=0000-unknown


### PR DESCRIPTION
fix to do not append 'modified' string on version string.