### PR TITLE
[CBRD-20303] Do prepare insert with XASL fixed for special inserts

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -17771,6 +17771,7 @@ pt_to_odku_info (PARSER_CONTEXT * parser, PT_NODE * insert, XASL_NODE * xasl)
 		  prev = node;
 		  continue;
 		}
+	      /* Found attribute in non null list. */
 
 	      if (DB_IS_NULL (val))
 		{
@@ -17780,20 +17781,7 @@ pt_to_odku_info (PARSER_CONTEXT * parser, PT_NODE * insert, XASL_NODE * xasl)
 		  error = ER_OBJ_ATTRIBUTE_CANT_BE_NULL;
 		  goto exit_on_error;
 		}
-	      /* remove the node from the non_null_attrs list since we've already checked that the attr will be
-	       * non-null and the engine need not check again. */
-	      if (prev == NULL)
-		{
-		  insert->info.insert.odku_non_null_attrs = insert->info.insert.odku_non_null_attrs->next;
-		}
-	      else
-		{
-		  prev->next = node->next;
-		}
-
-	      /* free the node */
-	      node->next = NULL;	/* cut-off link */
-	      parser_free_tree (parser, node);
+	      /* Break loop since we already found attribute. */
 	      break;
 	    }
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -125,51 +125,51 @@ static int
 do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** class_, PT_NODE ** update, PT_NODE * values);
 
 #define MAX_SERIAL_INVARIANT	8
-     typedef struct serial_invariant SERIAL_INVARIANT;
+typedef struct serial_invariant SERIAL_INVARIANT;
 
 /* an invariant which serial must hold */
-     struct serial_invariant
-     {
-       DB_VALUE val1;
-       DB_VALUE val2;
-       PT_OP_TYPE cmp_op;
-       int val1_msgid;		/* the proper message id for val1. 0 means val1 should not be responsible for the
+struct serial_invariant
+{
+  DB_VALUE val1;
+  DB_VALUE val2;
+  PT_OP_TYPE cmp_op;
+  int val1_msgid;		/* the proper message id for val1. 0 means val1 should not be responsible for the
 				 * invariant voilation */
-       int val2_msgid;		/* the proper message id for val2. 0 means val2 should not be responsible for the
+  int val2_msgid;		/* the proper message id for val2. 0 means val2 should not be responsible for the
 				 * invariant voilation */
-       int error_type;		/* ER_QPROC_SERIAL_RANGE_OVERFLOW or ER_INVALID_SERIAL_VALUE */
-     };
+  int error_type;		/* ER_QPROC_SERIAL_RANGE_OVERFLOW or ER_INVALID_SERIAL_VALUE */
+};
 
 /*
  * eval_insert_value -
  * Structure is passed as argument to parser_walk_tree when insert values are
  * evaluated and stores the information required for evaluation.
  */
-     typedef struct eval_insert_value EVAL_INSERT_VALUE;
-     struct eval_insert_value
-     {
-       UINTPTR spec_id;		/* insert spec_id */
-       PT_NODE *attr_list;	/* list of insert attribute names */
-       PT_NODE *value_list;	/* list of insert values values */
-       int crt_attr_index;	/* current attribute index */
-       bool reevaluate_needed;	/* currently evaluated insert value may need to be reevaluated with next execution */
-       bool replace_names;	/* true if names may need to be replaced with each evaluation */
-     };
+typedef struct eval_insert_value EVAL_INSERT_VALUE;
+struct eval_insert_value
+{
+  UINTPTR spec_id;		/* insert spec_id */
+  PT_NODE *attr_list;		/* list of insert attribute names */
+  PT_NODE *value_list;		/* list of insert values values */
+  int crt_attr_index;		/* current attribute index */
+  bool reevaluate_needed;	/* currently evaluated insert value may need to be reevaluated with next execution */
+  bool replace_names;		/* true if names may need to be replaced with each evaluation */
+};
 
-     static void initialize_serial_invariant (SERIAL_INVARIANT * invariant, DB_VALUE val1, DB_VALUE val2,
-					      PT_OP_TYPE cmp_op, int val1_msgid, int val2_msgid, int error_type);
-     static int check_serial_invariants (SERIAL_INVARIANT * invariants, int num_invariants, int *ret_msg_id);
-     static bool truncate_need_repl_log (PT_NODE * statement);
-     static int do_check_for_empty_classes_in_delete (PARSER_CONTEXT * parser, PT_NODE * statement);
+static void initialize_serial_invariant (SERIAL_INVARIANT * invariant, DB_VALUE val1, DB_VALUE val2,
+					 PT_OP_TYPE cmp_op, int val1_msgid, int val2_msgid, int error_type);
+static int check_serial_invariants (SERIAL_INVARIANT * invariants, int num_invariants, int *ret_msg_id);
+static bool truncate_need_repl_log (PT_NODE * statement);
+static int do_check_for_empty_classes_in_delete (PARSER_CONTEXT * parser, PT_NODE * statement);
 
-     static int do_evaluate_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement);
-     static void do_clear_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement);
-     static PT_NODE *do_replace_names_for_insert_values_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg,
-							     int *continue_walk);
-     static int do_prepare_insert_internal (PARSER_CONTEXT * parser, PT_NODE * statement);
-     static int do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * statement,
-				    const char **savepoint_name, int *row_count_ptr);
-     static void init_compile_context (PARSER_CONTEXT * parser);
+static int do_evaluate_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement);
+static void do_clear_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement);
+static PT_NODE *do_replace_names_for_insert_values_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg,
+							int *continue_walk);
+static int do_prepare_insert_internal (PARSER_CONTEXT * parser, PT_NODE * statement);
+static int do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * statement,
+			       const char **savepoint_name, int *row_count_ptr);
+static void init_compile_context (PARSER_CONTEXT * parser);
 
 /*
  * initialize_serial_invariant() - initialize a serial invariant
@@ -184,9 +184,9 @@ do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** class
  *
  * Note:
  */
-     static void
-       initialize_serial_invariant (SERIAL_INVARIANT * invariant, DB_VALUE val1, DB_VALUE val2, PT_OP_TYPE cmp_op,
-				    int val1_msgid, int val2_msgid, int error_type)
+static void
+initialize_serial_invariant (SERIAL_INVARIANT * invariant, DB_VALUE val1, DB_VALUE val2, PT_OP_TYPE cmp_op,
+			     int val1_msgid, int val2_msgid, int error_type)
 {
   invariant->val1 = val1;
   invariant->val2 = val2;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -13175,6 +13175,12 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
       goto cleanup;
     }
 
+  /* One additional check for insert.server_allowed. */
+  if (statement->info.insert.server_allowed != SERVER_INSERT_IS_ALLOWED)
+    {
+      goto cleanup;
+    }
+
   /* prevent blob, clob plan cache */
   for (attr_list = statement->info.insert.attr_list; attr_list != NULL; attr_list = attr_list->next)
     {

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -11804,6 +11804,13 @@ do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * st
       goto cleanup;
     }
 
+  /* Check if server allows an insert. */
+  error = is_server_insert_allowed (parser, statement);
+  if (error != NO_ERROR || statement->info.insert.server_allowed != SERVER_INSERT_IS_ALLOWED)
+    {
+      goto cleanup;
+    }
+
   flag = statement->info.insert.spec->info.spec.flag;
 
   into = statement->info.insert.into_var;
@@ -13175,8 +13182,9 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
       goto cleanup;
     }
 
-  /* One additional check for insert.server_allowed. */
-  if (statement->info.insert.server_allowed != SERVER_INSERT_IS_ALLOWED)
+  /* Check if server allows an insert. */
+  error = is_server_insert_allowed (parser, statement);
+  if (error != NO_ERROR || statement->info.insert.server_allowed != SERVER_INSERT_IS_ALLOWED)
     {
       goto cleanup;
     }
@@ -17082,13 +17090,6 @@ do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** class
   int error = NO_ERROR;
   int upd_has_uniques = 0;
   bool has_default_values_list = false;
-
-  /* Check if server allows an insert. */
-  error = is_server_insert_allowed (parser, statement);
-  if (error != NO_ERROR || statement->info.insert.server_allowed != SERVER_INSERT_IS_ALLOWED)
-    {
-      return error;
-    }
 
   /* Check non null attrs. */
   if (values->info.node_list.list_type == PT_IS_DEFAULT_VALUE)

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -121,8 +121,8 @@
 static void do_set_trace_to_query_flag (QUERY_FLAG * query_flag);
 static void do_send_plan_trace_to_session (PARSER_CONTEXT * parser);
 static int do_vacuum (PARSER_CONTEXT * parser, PT_NODE * statement);
-static int
-do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** class_, PT_NODE ** update, PT_NODE * values);
+static int do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** class_,
+			     PT_NODE ** update, PT_NODE * values);
 
 #define MAX_SERIAL_INVARIANT	8
 typedef struct serial_invariant SERIAL_INVARIANT;
@@ -11793,7 +11793,7 @@ do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * st
 
   degree = 0;
   class_ = statement->info.insert.spec->info.spec.flat_entity_list;
-
+  flag = statement->info.insert.spec->info.spec.flag;
   /* clear any previous error indicator because the rest of do_insert is sensitive to er_errid(). */
   er_clear ();
 
@@ -11803,8 +11803,6 @@ do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * st
       ASSERT_ERROR ();
       goto cleanup;
     }
-
-  flag = statement->info.insert.spec->info.spec.flag;
 
   into = statement->info.insert.into_var;
   if (into != NULL && PT_IS_NAME_NODE (into) && into->info.name.meta_class == PT_PARAMETER)
@@ -17075,12 +17073,25 @@ do_send_plan_trace_to_session (PARSER_CONTEXT * parser)
     }
 }
 
+/*
+ * do_insert_checks ()	  : - Does preliminary checks for an insert statement.
+ *
+ * return		  : NO_ERROR or error code.
+ * parser(in)		  : Parser context.
+ * statement(in)	  : Parse tree of the insert statement to be checked.
+ * class_(in)		  : 
+ * update(in/out)	  : Update attribute.
+ * values(in)		  : Values to be inserted.
+ */
+
 static int
 do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** class_, PT_NODE ** update, PT_NODE * values)
 {
   int error = NO_ERROR;
   int upd_has_uniques = 0;
   bool has_default_values_list = false;
+
+  *update = NULL;
 
   /* Check if server allows an insert. */
   error = is_server_insert_allowed (parser, statement);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -11806,7 +11806,7 @@ do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * st
 
   /* Check if server allows an insert. */
   error = is_server_insert_allowed (parser, statement);
-  if (error != NO_ERROR || statement->info.insert.server_allowed != SERVER_INSERT_IS_ALLOWED)
+  if (error != NO_ERROR)
     {
       goto cleanup;
     }
@@ -13175,17 +13175,18 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
   class_ = statement->info.insert.spec->info.spec.flat_entity_list;
   values = statement->info.insert.value_clauses;
 
-  error = do_insert_checks (parser, statement, &class_, &update, values);
-  if (error != NO_ERROR)
-    {
-      ASSERT_ERROR ();
-      goto cleanup;
-    }
-
   /* Check if server allows an insert. */
   error = is_server_insert_allowed (parser, statement);
   if (error != NO_ERROR || statement->info.insert.server_allowed != SERVER_INSERT_IS_ALLOWED)
     {
+      goto cleanup;
+    }
+
+
+  error = do_insert_checks (parser, statement, &class_, &update, values);
+  if (error != NO_ERROR)
+    {
+      ASSERT_ERROR ();
       goto cleanup;
     }
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -13245,7 +13245,6 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
   error = is_server_insert_allowed (parser, statement);
   if (error != NO_ERROR || statement->info.insert.server_allowed != SERVER_INSERT_IS_ALLOWED)
     {
-      ASSERT_ERROR ();
       goto cleanup;
     }
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -11797,7 +11797,7 @@ do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * st
   /* clear any previous error indicator because the rest of do_insert is sensitive to er_errid(). */
   er_clear ();
 
-  error = do_preliminary_checks (parser, statement, class_, update, value_clauses);
+  error = do_insert_checks (parser, statement, class_, update, &value_clauses);
   if (error != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -13168,7 +13168,7 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
   class_ = statement->info.insert.spec->info.spec.flat_entity_list;
   values = statement->info.insert.value_clauses;
 
-  error = do_preliminary_checks (parser, statement, class_, update, values);
+  error = do_insert_checks (parser, statement, class_, update, &values);
   if (error != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -17063,7 +17063,7 @@ do_send_plan_trace_to_session (PARSER_CONTEXT * parser)
 }
 
 static int
-do_preliminary_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * class_, PT_NODE * update,
+do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * class_, PT_NODE ** update,
 		       PT_NODE * values)
 {
   int error = NO_ERROR;
@@ -17096,8 +17096,8 @@ do_preliminary_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * c
 
   if (statement->info.insert.odku_assignments != NULL)
     {
-      update = do_create_odku_stmt (parser, statement);
-      if (update == NULL)
+      *update = do_create_odku_stmt (parser, statement);
+      if (*update == NULL)
 	{
 	  error = ER_FAILED;
 	  return error;
@@ -17107,7 +17107,7 @@ do_preliminary_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * c
 	  int server_allowed = 0;
 	  error =
 	    is_server_update_allowed (parser, &statement->info.insert.odku_non_null_attrs, &upd_has_uniques,
-				      &server_allowed, update);
+				      &server_allowed, *update);
 
 	  if (error != NO_ERROR)
 	    {

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -121,55 +121,55 @@
 static void do_set_trace_to_query_flag (QUERY_FLAG * query_flag);
 static void do_send_plan_trace_to_session (PARSER_CONTEXT * parser);
 static int do_vacuum (PARSER_CONTEXT * parser, PT_NODE * statement);
+static int
+do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** class_, PT_NODE ** update, PT_NODE * values);
 
 #define MAX_SERIAL_INVARIANT	8
-
-
-typedef struct serial_invariant SERIAL_INVARIANT;
+     typedef struct serial_invariant SERIAL_INVARIANT;
 
 /* an invariant which serial must hold */
-struct serial_invariant
-{
-  DB_VALUE val1;
-  DB_VALUE val2;
-  PT_OP_TYPE cmp_op;
-  int val1_msgid;		/* the proper message id for val1. 0 means val1 should not be responsible for the
+     struct serial_invariant
+     {
+       DB_VALUE val1;
+       DB_VALUE val2;
+       PT_OP_TYPE cmp_op;
+       int val1_msgid;		/* the proper message id for val1. 0 means val1 should not be responsible for the
 				 * invariant voilation */
-  int val2_msgid;		/* the proper message id for val2. 0 means val2 should not be responsible for the
+       int val2_msgid;		/* the proper message id for val2. 0 means val2 should not be responsible for the
 				 * invariant voilation */
-  int error_type;		/* ER_QPROC_SERIAL_RANGE_OVERFLOW or ER_INVALID_SERIAL_VALUE */
-};
+       int error_type;		/* ER_QPROC_SERIAL_RANGE_OVERFLOW or ER_INVALID_SERIAL_VALUE */
+     };
 
 /*
  * eval_insert_value -
  * Structure is passed as argument to parser_walk_tree when insert values are
  * evaluated and stores the information required for evaluation.
  */
-typedef struct eval_insert_value EVAL_INSERT_VALUE;
-struct eval_insert_value
-{
-  UINTPTR spec_id;		/* insert spec_id */
-  PT_NODE *attr_list;		/* list of insert attribute names */
-  PT_NODE *value_list;		/* list of insert values values */
-  int crt_attr_index;		/* current attribute index */
-  bool reevaluate_needed;	/* currently evaluated insert value may need to be reevaluated with next execution */
-  bool replace_names;		/* true if names may need to be replaced with each evaluation */
-};
+     typedef struct eval_insert_value EVAL_INSERT_VALUE;
+     struct eval_insert_value
+     {
+       UINTPTR spec_id;		/* insert spec_id */
+       PT_NODE *attr_list;	/* list of insert attribute names */
+       PT_NODE *value_list;	/* list of insert values values */
+       int crt_attr_index;	/* current attribute index */
+       bool reevaluate_needed;	/* currently evaluated insert value may need to be reevaluated with next execution */
+       bool replace_names;	/* true if names may need to be replaced with each evaluation */
+     };
 
-static void initialize_serial_invariant (SERIAL_INVARIANT * invariant, DB_VALUE val1, DB_VALUE val2, PT_OP_TYPE cmp_op,
-					 int val1_msgid, int val2_msgid, int error_type);
-static int check_serial_invariants (SERIAL_INVARIANT * invariants, int num_invariants, int *ret_msg_id);
-static bool truncate_need_repl_log (PT_NODE * statement);
-static int do_check_for_empty_classes_in_delete (PARSER_CONTEXT * parser, PT_NODE * statement);
+     static void initialize_serial_invariant (SERIAL_INVARIANT * invariant, DB_VALUE val1, DB_VALUE val2,
+					      PT_OP_TYPE cmp_op, int val1_msgid, int val2_msgid, int error_type);
+     static int check_serial_invariants (SERIAL_INVARIANT * invariants, int num_invariants, int *ret_msg_id);
+     static bool truncate_need_repl_log (PT_NODE * statement);
+     static int do_check_for_empty_classes_in_delete (PARSER_CONTEXT * parser, PT_NODE * statement);
 
-static int do_evaluate_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement);
-static void do_clear_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement);
-static PT_NODE *do_replace_names_for_insert_values_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg,
-							int *continue_walk);
-static int do_prepare_insert_internal (PARSER_CONTEXT * parser, PT_NODE * statement);
-static int do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * statement,
-			       const char **savepoint_name, int *row_count_ptr);
-static void init_compile_context (PARSER_CONTEXT * parser);
+     static int do_evaluate_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement);
+     static void do_clear_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement);
+     static PT_NODE *do_replace_names_for_insert_values_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg,
+							     int *continue_walk);
+     static int do_prepare_insert_internal (PARSER_CONTEXT * parser, PT_NODE * statement);
+     static int do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * statement,
+				    const char **savepoint_name, int *row_count_ptr);
+     static void init_compile_context (PARSER_CONTEXT * parser);
 
 /*
  * initialize_serial_invariant() - initialize a serial invariant
@@ -184,9 +184,9 @@ static void init_compile_context (PARSER_CONTEXT * parser);
  *
  * Note:
  */
-static void
-initialize_serial_invariant (SERIAL_INVARIANT * invariant, DB_VALUE val1, DB_VALUE val2, PT_OP_TYPE cmp_op,
-			     int val1_msgid, int val2_msgid, int error_type)
+     static void
+       initialize_serial_invariant (SERIAL_INVARIANT * invariant, DB_VALUE val1, DB_VALUE val2, PT_OP_TYPE cmp_op,
+				    int val1_msgid, int val2_msgid, int error_type)
 {
   invariant->val1 = val1;
   invariant->val2 = val2;
@@ -11797,7 +11797,7 @@ do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * st
   /* clear any previous error indicator because the rest of do_insert is sensitive to er_errid(). */
   er_clear ();
 
-  error = do_insert_checks (parser, statement, class_, &update, value_clauses);
+  error = do_insert_checks (parser, statement, &class_, &update, value_clauses);
   if (error != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -13168,7 +13168,7 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
   class_ = statement->info.insert.spec->info.spec.flat_entity_list;
   values = statement->info.insert.value_clauses;
 
-  error = do_insert_checks (parser, statement, class_, &update, values);
+  error = do_insert_checks (parser, statement, &class_, &update, values);
   if (error != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -17071,7 +17071,7 @@ do_send_plan_trace_to_session (PARSER_CONTEXT * parser)
 }
 
 static int
-do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * class_, PT_NODE ** update, PT_NODE * values)
+do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** class_, PT_NODE ** update, PT_NODE * values)
 {
   int error = NO_ERROR;
   int upd_has_uniques = 0;
@@ -17136,7 +17136,7 @@ do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * class_
   if (statement->info.insert.do_replace || statement->info.insert.odku_assignments != NULL)
     {
       int allowed = 0;
-      error = is_replace_or_odku_allowed (class_->info.name.db_object, &allowed);
+      error = is_replace_or_odku_allowed ((*class_)->info.name.db_object, &allowed);
       if (error != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -17152,7 +17152,7 @@ do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * class_
     }
 
   /* fetch the class for instance write purpose */
-  if (!locator_fetch_class (class_->info.name.db_object, DB_FETCH_CLREAD_INSTWRITE))
+  if (!locator_fetch_class ((*class_)->info.name.db_object, DB_FETCH_CLREAD_INSTWRITE))
     {
       ASSERT_ERROR_AND_SET (error);
       return error;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20303

Only the simple insert was handled using the XASL cache hit/miss, while the other special inserts, like REPLACE and ODKU, were handled client-side with generation and caching of XASL, but no usage of that cache. Everytime a new XASL was generated instead of getting it from the cache. Now we changed that and it will first try to get the XASL from the cache before generating it.