### PR TITLE
[CBRD-20359] Add entry clone count, sql hash text and sql plan text to xcache_dump

### DIFF
--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -1626,6 +1626,17 @@ xcache_dump (THREAD_ENTRY * thread_p, FILE * fp)
       fprintf (fp, "  cache flags = %08x \n", xcache_entry->xasl_id.cache_flag & XCACHE_ENTRY_FLAGS_MASK);
       fprintf (fp, "  reference count = %ld \n", ATOMIC_INC_64 (&xcache_entry->ref_count, 0));
       fprintf (fp, "  time second last used = %lld \n", (long long) xcache_entry->time_last_used.tv_sec);
+      if (xcache_Max_clones > 0)
+        {
+          fprintf (fp, "  clone count = %d \n", xcache_entry->n_cache_clones);
+        }
+      fprintf (fp, "  sql info: \n");
+      fprintf (fp, "    sql hash text = %s \n", xcache_entry->sql_info.sql_hash_text);
+      if (prm_get_bool_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN) == true)
+        {
+          fprintf (fp, "    sql plan text = %s \n",
+                   xcache_entry->sql_info.sql_plan_text ? xcache_entry->sql_info.sql_plan_text : "(NONE)");
+        }
 
       fprintf (fp, "  OID_LIST (count = %d): \n", xcache_entry->n_related_objects);
       for (oid_index = 0; oid_index < xcache_entry->n_related_objects; oid_index++)

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -1608,7 +1608,7 @@ xcache_dump (THREAD_ENTRY * thread_p, FILE * fp)
   fprintf (fp, "Deletes:                    %ld\n", XCACHE_STAT_GET (deletes));
   fprintf (fp, "Fix:                        %ld\n", XCACHE_STAT_GET (fix));
   fprintf (fp, "Unfix:                      %ld\n", XCACHE_STAT_GET (unfix));
-  fprintf (fp, "Cleanups:                   %ld\n", XCACHE_STAT_GET (cleanups));
+  fprintf (fp, "Full cache cleanups:        %ld\n", XCACHE_STAT_GET (cleanups));
   fprintf (fp, "Deletes at cleanup:	    %ld\n", XCACHE_STAT_GET (deletes_at_cleanup));
   /* add overflow, RT checks. */
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20359

The format has indeed change with XASL cache redesign. I have added some of the missing information to XASL cache dump.