### PR TITLE
[CBRD-20338] Wrong error display

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -13289,12 +13289,6 @@ do_execute_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
   /* end the query; reset query_id and call qmgr_end_query() */
   pt_end_query (parser, query_id_self);
 
-  if ((err < NO_ERROR) && er_errid () != NO_ERROR)
-    {
-      pt_record_error (parser, parser->statement_number, statement->line_number, statement->column_number, er_msg (),
-		       NULL);
-    }
-
   return err;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20338

Since before the `prepare insert` issue, only the simple inserts were allowed to reuse the XASL cache, if there were any simple inserts that result in an error, the error message display would be:
`In line 1, column 1,
ERROR: error message. `

Now I have removed this error type display for the inserts that are allowed to reuse the XASL cache, and now errors of this kind will be displayed as : 
` In the command from line 5,
ERROR: error message.`

For example, the `sql1.sql` from the JIRA issue reflected the errors quite good.

Previous behavior : 

```
csql -u dba basic -S -i sql1.sql
Execute OK. (0.043683 sec) Committed.
Execute OK. (0.038904 sec) Committed.
Execute OK. (0.124656 sec) Committed.
In the command from line 5,
ERROR: SQL statement violated NOT NULL constraint.
3 rows affected. (0.001145 sec) Committed.
In line 1, column 1,
ERROR: The constraint of the foreign key 'fk_t2_id_i' is invalid, due to value '
Unknown macro: {1, NULL}

Execute OK. (0.096170 sec) Committed.
Execute OK. (0.088905 sec) Committed.
Execute OK. (0.032632 sec) Committed.
In line 1, column 1,
ERROR: The constraint of the foreign key 'fk_t2_id_i' is invalid, due to value '
Unknown macro: {2, NULL}

Execute OK. (0.030037 sec) Committed.
In line 1, column 1,
ERROR: The constraint of the foreign key 'fk_t2_id_i' is invalid, due to value '
Unknown macro: {3, NULL}

1 row affected. (0.001005 sec) Committed.
In the command from line 19,
ERROR: Update/Delete operations are restricted by the foreign key 'fk_t2_id_i'.
```

And with the current behavior:

```
csql -S -udba basic -i sql1.sql
Execute OK. (0.025235 sec) Committed.
Execute OK. (0.023771 sec) Committed.
Execute OK. (0.109126 sec) Committed.

In the command from line 5,

ERROR: SQL statement violated NOT NULL constraint.

3 rows affected. (0.001265 sec) Committed.

In the command from line 7,

ERROR: The constraint of the foreign key 'fk_t2_id_i' is invalid, due to value '{1, NULL}'.

Execute OK. (0.091946 sec) Committed.
Execute OK. (0.099261 sec) Committed.
Execute OK. (0.031538 sec) Committed.

In the command from line 15,

ERROR: The constraint of the foreign key 'fk_t2_id_i' is invalid, due to value '{2, NULL}'.

Execute OK. (0.027539 sec) Committed.

In the command from line 17,

ERROR: The constraint of the foreign key 'fk_t2_id_i' is invalid, due to value '{3, NULL}'.

1 row affected. (0.000621 sec) Committed.

In the command from line 19,

ERROR: Update/Delete operations are restricted by the foreign key 'fk_t2_id_i'.


In the command from line 21,

ERROR: The primary key 'pk_t1_id_pid' referred by a foreign key 'fk_t2_id_i' is not supposed to be dropped.

Execute OK. (0.032597 sec) Committed.
```