### PR TITLE
[CBRD-20389] fix an inconsistent vacuum data page state where its oldest_unflush_lsa_is set but dirty flag

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4535,7 +4535,8 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
       VPID_COPY (&log_Gl.hdr.vacuum_data_first_vpid, &save_first_page->next_page);
       vacuum_Data.first_page = *data_page;
 
-      vacuum_unfix_data_page (thread_p, save_first_page);
+      /* to make it sure the page is marked as dirty */
+      vacuum_set_dirty_data_page (thread_p, save_first_page, FREE);
       if (file_dealloc_page (thread_p, &vacuum_Data.vacuum_data_file, &save_first_vpid, FILE_VACUUM_DATA) != NO_ERROR)
 	{
 	  assert_release (false);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -6087,6 +6087,9 @@ pgbuf_unlatch_bcb_upon_unfix (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, int h
       assert (bufptr->latch_mode != PGBUF_LATCH_VICTIM);
       assert (bufptr->latch_mode != PGBUF_LATCH_VICTIM_INVALID);
 
+      /* When oldest_unflush_lsa of a page is set, its dirty mark should also be set */
+      assert (LSA_ISNULL (&bufptr->oldest_unflush_lsa) || bufptr->dirty);
+
       /* there could be some synchronous flushers on the BCB queue */
       /* When the page buffer in LRU_1_Zone, do not move the page buffer into the top of LRU. This is an intention for
        * performance. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20389

A checkpoint flushed the page which was the first Vacuum data page and the page had not had a change, then the page was about to be deallocated. To write RVVAC_DATA_MODIFY_FIRST_PAGE log set oldest_unflush_lsa of the page and deallocated the page. The page remains as non-dirty. Then, the page is re-allocated as a Vacuum data page and the assertion hit. Its oldest_unflush_lsa is set, while its dirty flag is not.

It also includes an assertion of `pgbuf_unfix` for easier detection of such inconsistencies. 
