### PR TITLE
[CBRD-20357] XASL/filter predicate cache drop all

### DIFF
--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -369,7 +369,7 @@ extern int lf_hash_insert (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table, void *ke
 extern int lf_hash_insert_given (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table, void *key, void **entry, int *inserted);
 extern int lf_hash_delete (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table, void *key, int *success);
 extern int lf_hash_delete_already_locked (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table, void *key, int *success);
-extern int lf_hash_clear (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table);
+extern void lf_hash_clear (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table);
 
 /*
  * Lock free hash table iterator

--- a/src/query/filter_pred_cache.c
+++ b/src/query/filter_pred_cache.c
@@ -743,3 +743,16 @@ fpcache_compare_cleanup_candidates (const void *left, const void *right, BH_CMP_
       return BH_LT;
     }
 }
+
+/*
+ * fpcache_drop_all () - Free all filter predicate cache entries.
+ *
+ * return	 : Void.
+ * thread_p (in) : Thread entry.
+ */
+void
+fpcache_drop_all (THREAD_ENTRY * thread_p)
+{
+  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_FPCACHE);
+  lf_hash_clear (t_entry, &fpcache_Ht);
+}

--- a/src/query/filter_pred_cache.c
+++ b/src/query/filter_pred_cache.c
@@ -54,8 +54,8 @@ static INT32 fpcache_Soft_capacity = 0;
 static LF_HASH_TABLE fpcache_Ht = LF_HASH_TABLE_INITIALIZER;
 static LF_FREELIST fpcache_Ht_freelist = LF_FREELIST_INITIALIZER;
 /* TODO: Handle counter >= soft capacity. */
-static INT32 fpcache_Entry_counter = 0;
-static INT32 fpcache_Clone_counter = 0;
+static volatile INT32 fpcache_Entry_counter = 0;
+static volatile INT32 fpcache_Clone_counter = 0;
 static int fpcache_Clone_stack_size;
 
 /* Cleanup */
@@ -754,5 +754,16 @@ void
 fpcache_drop_all (THREAD_ENTRY * thread_p)
 {
   LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_FPCACHE);
+
+  /* Reset fpcache_Entry_counter and fpcache_Clone_counter.
+   * NOTE: If entries/clones are created concurrently to this, the counters may become a little off. However, exact
+   *       counters are not mandatory.
+   */
+  ATOMIC_INC_64 (&fpcache_Stat_discard, fpcache_Entry_counter);
+  fpcache_Entry_counter = 0;
+
+  ATOMIC_INC_64 (&fpcache_Stat_clone_discard, fpcache_Clone_counter);
+  fpcache_Clone_counter = 0;
+
   lf_hash_clear (t_entry, &fpcache_Ht);
 }

--- a/src/query/filter_pred_cache.h
+++ b/src/query/filter_pred_cache.h
@@ -35,6 +35,7 @@ extern int fpcache_claim (THREAD_ENTRY * thread_p, BTID * btid, OR_PREDICATE * o
 			  PRED_EXPR_WITH_CONTEXT ** pred_expr);
 extern int fpcache_retire (THREAD_ENTRY * thread_p, OID * class_oid, BTID * btid, PRED_EXPR_WITH_CONTEXT * filter_pred);
 extern void fpcache_remove_by_class (THREAD_ENTRY * thread_p, OID * class_oid);
+extern void fpcache_drop_all (THREAD_ENTRY * thread_p);
 extern void fpcache_dump (THREAD_ENTRY * thread_p, FILE * fp);
 
 #endif /* _XASL_CACHE_H_ */

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1906,7 +1906,7 @@ xqmgr_end_query (THREAD_ENTRY * thread_p, QUERY_ID query_id)
 
   assert (query_p->query_status == QUERY_COMPLETED);
 
-  /* end use of the list file of the cahed result */
+  /* end use of the list file of the cashed result */
   if (query_p->xasl_ent && query_p->list_ent)
     {
       (void) qfile_end_use_of_list_cache_entry (thread_p, query_p->list_ent, false);
@@ -1937,6 +1937,8 @@ int
 xqmgr_drop_all_query_plans (THREAD_ENTRY * thread_p)
 {
   /* TODO: Do we want to drop all query plans? */
+  xcache_drop_all (thread_p);
+  fpcache_drop_all (thread_p);
   return NO_ERROR;
 }
 

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1906,7 +1906,7 @@ xqmgr_end_query (THREAD_ENTRY * thread_p, QUERY_ID query_id)
 
   assert (query_p->query_status == QUERY_COMPLETED);
 
-  /* end use of the list file of the cashed result */
+  /* end use of the list file of the cached result */
   if (query_p->xasl_ent && query_p->list_ent)
     {
       (void) qfile_end_use_of_list_cache_entry (thread_p, query_p->list_ent, false);
@@ -1931,12 +1931,11 @@ xqmgr_end_query (THREAD_ENTRY * thread_p, QUERY_ID query_id)
  * xqmgr_drop_all_query_plans () - Drop all the stored query plans
  *   return: NO_ERROR or ER_FAILED
  *
- * Note: Clear all XASL cache entires out upon request of the client.
+ * Note: Clear all XASL/filter predicate cache entries out upon request of the client.
  */
 int
 xqmgr_drop_all_query_plans (THREAD_ENTRY * thread_p)
 {
-  /* TODO: Do we want to drop all query plans? */
   xcache_drop_all (thread_p);
   fpcache_drop_all (thread_p);
   return NO_ERROR;

--- a/src/query/xasl_cache.h
+++ b/src/query/xasl_cache.h
@@ -108,6 +108,7 @@ extern int xcache_insert (THREAD_ENTRY * thread_p, const COMPILE_CONTEXT * conte
 			  const OID * oid, int n_oid, const OID * class_oids, const int *class_locks,
 			  const int *tcards, XASL_CACHE_ENTRY ** xcache_entry);
 extern void xcache_remove_by_oid (THREAD_ENTRY * thread_p, OID * oid);
+extern void xcache_drop_all (THREAD_ENTRY * thread_p);
 extern void xcache_dump (THREAD_ENTRY * thread_p, FILE * fp);
 
 extern bool xcache_can_entry_cache_list (XASL_CACHE_ENTRY * xcache_entry);

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -5048,10 +5048,7 @@ catalog_clear_hash_table ()
 {
   LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (NULL, THREAD_TS_CATALOG);
 
-  if (lf_hash_clear (t_entry, &catalog_Hash_table) != NO_ERROR)
-    {
-      assert (false);
-    }
+  lf_hash_clear (t_entry, &catalog_Hash_table);
 }
 
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20357

* xcache_drop_all
  * Iterate through all entries and mark for delete. The implementation is similar to existing implementation of xcache_remove_by_oid.

* fpcache_drop_all
  * Use lf_hash_clear function (swap hash table with back buffer).

* lf_hash_clear
  * Fixed some potential bugs.
  * Modified return type to void (NO_ERROR was always returned).