### PR TITLE
[CBRD-20357] fixes cleanup_count of xcache_cleanup

### DIFF
--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -1872,7 +1872,7 @@ xcache_cleanup (THREAD_ENTRY * thread_p)
   /* Start cleanup. */
 
   /* How many entries do we need to cleanup? */
-  cleanup_count = (int) XCACHE_CLEANUP_RATIO *xcache_Soft_capacity + (xcache_Entry_count - xcache_Soft_capacity);
+  cleanup_count = (int) (XCACHE_CLEANUP_RATIO * xcache_Soft_capacity) + (xcache_Entry_count - xcache_Soft_capacity);
   if (cleanup_count <= 0)
     {
       /* Not enough to cleanup */


### PR DESCRIPTION
This is a regression of #151 and `cleanup_count` is badly calculated. 
