### PR TITLE
[CBRD-20388] Put correct page rank on watcher when group id is not initiallly provided by calling code.

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -11235,6 +11235,12 @@ exit:
 	}
     }
 
+  if (req_page_has_group == false && ret_pgptr != NULL && req_watcher->curr_rank != PGBUF_ORDERED_HEAP_HDR
+      && VPID_EQ (&req_watcher->group_id, req_vpid))
+    {
+      req_watcher->curr_rank = PGBUF_ORDERED_HEAP_HDR;
+    }
+
   return er_status;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20388