### PR TITLE
[CBRD-20401] Fix lock-free hash table & lock-free unit test

### DIFF
--- a/contrib/gdb_debugging_scripts/lock_free.gdb
+++ b/contrib/gdb_debugging_scripts/lock_free.gdb
@@ -1,0 +1,28 @@
+
+define lf_print_counters
+  printf "lf_hash_size                   %d\n", lf_hash_size
+  printf "lf_inserts                     %d\n", lf_inserts
+  printf "lf_inserts_restart             %d\n", lf_inserts_restart
+  printf "lf_list_inserts                %d\n", lf_list_inserts
+  printf "lf_list_inserts_found          %d\n", lf_list_inserts_found
+  printf "lf_list_inserts_save_temp_1    %d\n", lf_list_inserts_save_temp_1
+  printf "lf_list_inserts_save_temp_2    %d\n", lf_list_inserts_save_temp_2
+  printf "lf_list_inserts_claim          %d\n", lf_list_inserts_claim
+  printf "lf_list_inserts_fail_link      %d\n", lf_list_inserts_fail_link
+  printf "lf_list_inserts_success_link   %d\n", lf_list_inserts_success_link
+  printf "lf_deletes                     %d\n", lf_deletes
+  printf "lf_deletes_restart             %d\n", lf_deletes_restart
+  printf "lf_list_deletes                %d\n", lf_list_deletes
+  printf "lf_list_deletes_found          %d\n", lf_list_deletes_found
+  printf "lf_list_deletes_fail_mark_next %d\n", lf_list_deletes_fail_mark_next
+  printf "lf_list_deletes_fail_unlink    %d\n", lf_list_deletes_fail_unlink
+  printf "lf_list_deletes_success_unlink %d\n", lf_list_deletes_success_unlink
+  printf "lf_list_deletes_not_found      %d\n", lf_list_deletes_not_found
+  printf "lf_list_deletes_not_match      %d\n", lf_list_deletes_not_match
+  printf "lf_clears                      %d\n", lf_clears
+  printf "lf_retires                     %d\n", lf_retires
+  printf "lf_claims                      %d\n", lf_claims
+  printf "lf_claims_temp                 %d\n", lf_claims_temp
+  printf "lf_transports                  %d\n", lf_transports
+  printf "lf_temps                       %d\n", lf_temps
+  end

--- a/src/base/error_manager.h
+++ b/src/base/error_manager.h
@@ -160,7 +160,7 @@ typedef void (*PTR_FNERLOG) (int err_id);
 
 /* Macros to assert that error is set. */
 #define ASSERT_ERROR() \
-  (assert (er_errid () != NO_ERROR))
+  assert (er_errid () != NO_ERROR)
 /* This macro will also make sure the error_code to be returned is not
  * NO_ERROR.
  */

--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -1687,9 +1687,17 @@ restart_search:
 	    }
 
 	  /* lock mutex if necessary */
-	  if (edesc->using_mutex && LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_LOCK_ON_DELETE))
+	  if (edesc->using_mutex)
 	    {
-	      LF_LOCK_ENTRY (curr);
+	      if (LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_LOCK_ON_DELETE))
+		{
+		  LF_LOCK_ENTRY (curr);
+		}
+	      else
+		{
+		  /* Must be already locked! */
+		  entry_mutex = (pthread_mutex_t *) OF_GET_PTR (curr, edesc->of_mutex);
+		}
 
 	      /* since we set the mark, nobody else can delete it, so we have nothing else to check */
 	    }

--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -1628,7 +1628,7 @@ lf_list_delete (LF_TRAN_ENTRY * tran, void **list_p, void *key, int *behavior_fl
   pthread_mutex_unlock (entry_mutex); \
   entry_mutex = NULL
 
-  pthread_mutex_t *entry_mutex;
+  pthread_mutex_t *entry_mutex = NULL;
   void **curr_p, **next_p;
   void *curr, *next;
   int rv;

--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -104,8 +104,8 @@ static INT64 lf_temps = 0;
 
 #if defined (NDEBUG)
 /* Abort when calling assert even if it is not debug */
-#define assert(cond) if (!cond) abort ()
-#define assert_release(cond) if (!cond) abort ()
+#define assert(cond) if (!(cond)) abort ()
+#define assert_release(cond) if (!(cond)) abort ()
 #endif /* NDEBUG */
 #else /* !UNITTEST_LF */
 #define LF_UNITTEST_INC(lf_stat, incval)

--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -1308,6 +1308,7 @@ restart_search:
 	      if (!LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_INSERT_GIVEN) && entry != NULL)
 		{
 		  /* save this for further (local) use. */
+		  assert (tran->temp_entry == NULL);
 		  tran->temp_entry = *entry;
 
 		  /* don't keep the entry around. */
@@ -1471,6 +1472,7 @@ restart_search:
 		{
 		  if (!LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_INSERT_GIVEN))
 		    {
+		      assert (tran->temp_entry == NULL);
 		      tran->temp_entry = *entry;
 		      *entry = NULL;
 		    }

--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -1305,7 +1305,7 @@ restart_search:
 	    {
 	      /* found an entry with the same key. */
 
-	      if (!LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_INSERT_GIVEN) && entry != NULL)
+	      if (!LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_INSERT_GIVEN) && *entry != NULL)
 		{
 		  /* save this for further (local) use. */
 		  assert (tran->temp_entry == NULL);

--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -90,6 +90,8 @@ static INT64 lf_list_deletes_fail_unlink = 0;
 static INT64 lf_list_deletes_success_unlink = 0;
 static INT64 lf_list_deletes_not_found = 0;
 
+static INT64 lf_clears = 0;
+
 static INT64 lf_retires = 0;
 static INT64 lf_claims = 0;
 static INT64 lf_claims_temp = 0;
@@ -119,6 +121,8 @@ lf_reset_counters (void)
   lf_list_deletes_fail_unlink = 0;
   lf_list_deletes_success_unlink = 0;
   lf_list_deletes_not_found = 0;
+
+  lf_clears = 0;
 
   lf_retires = 0;
   lf_claims = 0;
@@ -2266,6 +2270,8 @@ lf_hash_clear (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table)
       tran->retired_list = ret_head;
 
       ATOMIC_INC_32 (&table->freelist->retired_cnt, ret_count);
+
+      ATOMIC_INC_64 (&lf_clears, ret_count);
 
       lf_tran_end_with_mb (tran);
     }

--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -2272,6 +2272,7 @@ lf_hash_clear (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table)
       ATOMIC_INC_32 (&table->freelist->retired_cnt, ret_count);
 
       ATOMIC_INC_64 (&lf_clears, ret_count);
+      ATOMIC_INC_64 (&lf_hash_size, -ret_count);
 
       lf_tran_end_with_mb (tran);
     }

--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -99,7 +99,7 @@ static INT64 lf_transports = 0;
 static INT64 lf_temps = 0;
 
 static pthread_mutex_t *lf_locked_mutex = NULL;
-const int lf_locked_line = 0;
+int lf_locked_line = 0;
 
 void
 lf_reset_counters (void)

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -331,7 +331,7 @@ extern int lf_io_list_find_or_insert (void **list_p, void *new_entry, LF_ENTRY_D
 
 extern int lf_list_find (LF_TRAN_ENTRY * tran, void **list_p, void *key, int *behavior_flags,
 			 LF_ENTRY_DESCRIPTOR * edesc, void **entry);
-extern int lf_list_delete (LF_TRAN_ENTRY * tran, void **list_p, void *key, int *behavior_flags,
+extern int lf_list_delete (LF_TRAN_ENTRY * tran, void **list_p, void *key, void *locked_entry, int *behavior_flags,
 			   LF_ENTRY_DESCRIPTOR * edesc, LF_FREELIST * freelist, int *success);
 /* TODO: Add lf_list_insert functions. So far, they are only used for lf_hash_insert. */
 
@@ -372,7 +372,8 @@ extern int lf_hash_find_or_insert (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table, 
 extern int lf_hash_insert (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table, void *key, void **entry, int *inserted);
 extern int lf_hash_insert_given (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table, void *key, void **entry, int *inserted);
 extern int lf_hash_delete (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table, void *key, int *success);
-extern int lf_hash_delete_already_locked (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table, void *key, int *success);
+extern int lf_hash_delete_already_locked (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table, void *key, void *locked_entry,
+					  int *success);
 extern void lf_hash_clear (LF_TRAN_ENTRY * tran, LF_HASH_TABLE * table);
 
 /*

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -142,6 +142,10 @@ struct lf_tran_entry
 
   /* Was transaction ID incremented? */
   bool did_incr;
+
+  /* Debug */
+  pthread_mutex_t *locked_mutex;
+  int locked_mutex_line;
 };
 
 #define LF_TRAN_ENTRY_INITIALIZER     { 0, LF_NULL_TRANSACTION_ID, NULL, NULL, NULL, -1, false }
@@ -438,6 +442,5 @@ extern int lf_bitmap_get_entry (LF_BITMAP * bitmap);
 extern int lf_bitmap_free_entry (LF_BITMAP * bitmap, int entry_idx);
 
 extern void lf_reset_counters (void);
-extern void lf_check_no_mutex (void);
 
 #endif /* _LOCK_FREE_H_ */

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -438,5 +438,6 @@ extern int lf_bitmap_get_entry (LF_BITMAP * bitmap);
 extern int lf_bitmap_free_entry (LF_BITMAP * bitmap, int entry_idx);
 
 extern void lf_reset_counters (void);
+extern void lf_check_no_mutex (void);
 
 #endif /* _LOCK_FREE_H_ */

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -143,9 +143,11 @@ struct lf_tran_entry
   /* Was transaction ID incremented? */
   bool did_incr;
 
+#if defined (UNITTEST_LF)
   /* Debug */
   pthread_mutex_t *locked_mutex;
   int locked_mutex_line;
+#endif				/* UNITTEST_LF */
 };
 
 #define LF_TRAN_ENTRY_INITIALIZER     { 0, LF_NULL_TRANSACTION_ID, NULL, NULL, NULL, -1, false }
@@ -442,6 +444,8 @@ extern void lf_bitmap_destroy (LF_BITMAP * bitmap);
 extern int lf_bitmap_get_entry (LF_BITMAP * bitmap);
 extern int lf_bitmap_free_entry (LF_BITMAP * bitmap, int entry_idx);
 
+#if defined (UNITTEST_LF)
 extern void lf_reset_counters (void);
+#endif /* UNITTEST_LF */
 
 #endif /* _LOCK_FREE_H_ */

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -437,4 +437,6 @@ extern void lf_bitmap_destroy (LF_BITMAP * bitmap);
 extern int lf_bitmap_get_entry (LF_BITMAP * bitmap);
 extern int lf_bitmap_free_entry (LF_BITMAP * bitmap, int entry_idx);
 
+extern void lf_reset_counters (void);
+
 #endif /* _LOCK_FREE_H_ */

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -34,6 +34,8 @@
 #define RAND_SIZE	RAND_BLOCKS * RAND_BLOCK_SIZE
 static int random_numbers[RAND_SIZE];
 
+#define PTHREAD_ABORT_AND_EXIT(code) abort (); pthread_exit (code)
+
 static void
 generate_random ()
 {
@@ -216,7 +218,7 @@ test_freelist_proc (void *param)
   te = lf_tran_request_entry (ts);
   if (te == NULL)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
@@ -229,7 +231,7 @@ test_freelist_proc (void *param)
 	  entry = (XENTRY *) lf_freelist_claim (te, freelist);
 	  if (entry == NULL)
 	    {
-	      pthread_exit (ER_FAILED);
+	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;
 	    }
 	}
@@ -237,7 +239,7 @@ test_freelist_proc (void *param)
 	{
 	  if (lf_freelist_retire (te, freelist, (void *) entry) != NO_ERROR)
 	    {
-	      pthread_exit (ER_FAILED);
+	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;
 	    }
 	}
@@ -247,7 +249,7 @@ test_freelist_proc (void *param)
 
   if (lf_tran_return_entry (te) != NO_ERROR)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
@@ -270,13 +272,13 @@ test_hash_proc_1 (void *param)
   te = lf_tran_request_entry (ts);
   if (te == NULL)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
   if (te->entry_idx >= RAND_BLOCKS || te->entry_idx < 0)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
   else
@@ -293,7 +295,7 @@ test_hash_proc_1 (void *param)
 	  entry = NULL;
 	  if (lf_hash_find_or_insert (te, hash, &key, &entry, NULL) != NO_ERROR)
 	    {
-	      pthread_exit (ER_FAILED);
+	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;
 	    }
 	  lf_tran_end_with_mb (te);
@@ -302,7 +304,7 @@ test_hash_proc_1 (void *param)
 	{
 	  if (lf_hash_delete (te, hash, &key, NULL) != NO_ERROR)
 	    {
-	      pthread_exit (ER_FAILED);
+	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;
 	    }
 	}
@@ -310,7 +312,7 @@ test_hash_proc_1 (void *param)
 
   if (lf_tran_return_entry (te) != NO_ERROR)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
@@ -333,13 +335,13 @@ test_hash_proc_2 (void *param)
   te = lf_tran_request_entry (ts);
   if (te == NULL)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
   if (te->entry_idx >= RAND_BLOCKS || te->entry_idx < 0)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
   else
@@ -355,12 +357,12 @@ test_hash_proc_2 (void *param)
 	{
 	  if (lf_hash_find_or_insert (te, hash, &key, &entry, NULL) != NO_ERROR)
 	    {
-	      pthread_exit (ER_FAILED);
+	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;
 	    }
 	  if (entry == NULL)
 	    {
-	      pthread_exit (ER_FAILED);
+	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;
 	    }
 
@@ -370,7 +372,7 @@ test_hash_proc_2 (void *param)
 	{
 	  if (lf_hash_delete (te, hash, &key, NULL) != NO_ERROR)
 	    {
-	      pthread_exit (ER_FAILED);
+	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;
 	    }
 	}
@@ -378,7 +380,7 @@ test_hash_proc_2 (void *param)
 
   if (lf_tran_return_entry (te) != NO_ERROR)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
@@ -404,13 +406,13 @@ test_hash_proc_3 (void *param)
   te = lf_tran_request_entry (ts);
   if (te == NULL)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
   if (te->entry_idx >= RAND_BLOCKS || te->entry_idx < 0)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
   else
@@ -424,17 +426,17 @@ test_hash_proc_3 (void *param)
 
       if (lf_hash_find_or_insert (te, hash, &key, &entry, NULL) != NO_ERROR)
 	{
-	  pthread_exit (ER_FAILED);
+	  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	  return ER_FAILED;
 	}
       if (entry == NULL)
 	{
-	  pthread_exit (ER_FAILED);
+	  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	  return ER_FAILED;
 	}
       if (entry->key != key)
 	{
-	  pthread_exit (ER_FAILED);
+	  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	  return ER_FAILED;
 	}
 
@@ -447,12 +449,12 @@ test_hash_proc_3 (void *param)
 	  local_del_op_count += entry->data;
 	  if (lf_hash_delete_already_locked (te, hash, &key, &success) != NO_ERROR)
 	    {
-	      pthread_exit (ER_FAILED);
+	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;
 	    }
 	  else if (!success)
 	    {
-	      pthread_exit (ER_FAILED);
+	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;
 	    }
 	}
@@ -464,7 +466,7 @@ test_hash_proc_3 (void *param)
 
   if (lf_tran_return_entry (te) != NO_ERROR)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
@@ -488,13 +490,13 @@ test_clear_proc_1 (void *param)
   te = lf_tran_request_entry (ts);
   if (te == NULL)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
   if (te->entry_idx >= RAND_BLOCKS || te->entry_idx < 0)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
   else
@@ -514,7 +516,7 @@ test_clear_proc_1 (void *param)
 	      entry = NULL;
 	      if (lf_hash_find_or_insert (te, hash, &key, &entry, NULL) != NO_ERROR)
 		{
-		  pthread_exit (ER_FAILED);
+		  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 		  return ER_FAILED;
 		}
 	      lf_tran_end_with_mb (te);
@@ -523,7 +525,7 @@ test_clear_proc_1 (void *param)
 	    {
 	      if (lf_hash_delete (te, hash, &key, NULL) != NO_ERROR)
 		{
-		  pthread_exit (ER_FAILED);
+		  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 		  return ER_FAILED;
 		}
 	    }
@@ -536,7 +538,7 @@ test_clear_proc_1 (void *param)
 
   if (lf_tran_return_entry (te) != NO_ERROR)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
@@ -559,13 +561,13 @@ test_clear_proc_2 (void *param)
   te = lf_tran_request_entry (ts);
   if (te == NULL)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
   if (te->entry_idx >= RAND_BLOCKS || te->entry_idx < 0)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
   else
@@ -583,12 +585,12 @@ test_clear_proc_2 (void *param)
 	    {
 	      if (lf_hash_find_or_insert (te, hash, &key, &entry, NULL) != NO_ERROR)
 		{
-		  pthread_exit (ER_FAILED);
+		  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 		  return ER_FAILED;
 		}
 	      if (entry == NULL)
 		{
-		  pthread_exit (ER_FAILED);
+		  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 		  return ER_FAILED;
 		}
 
@@ -598,7 +600,7 @@ test_clear_proc_2 (void *param)
 	    {
 	      if (lf_hash_delete (te, hash, &key, NULL) != NO_ERROR)
 		{
-		  pthread_exit (ER_FAILED);
+		  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 		  return ER_FAILED;
 		}
 	    }
@@ -611,7 +613,7 @@ test_clear_proc_2 (void *param)
 
   if (lf_tran_return_entry (te) != NO_ERROR)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
@@ -635,13 +637,13 @@ test_clear_proc_3 (void *param)
   te = lf_tran_request_entry (ts);
   if (te == NULL)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 
   if (te->entry_idx >= RAND_BLOCKS || te->entry_idx < 0)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
   else
@@ -661,12 +663,12 @@ test_clear_proc_3 (void *param)
 
       if (lf_hash_find_or_insert (te, hash, &key, &entry, NULL) != NO_ERROR)
 	{
-	  pthread_exit (ER_FAILED);
+	  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	  return ER_FAILED;
 	}
       if (entry == NULL)
 	{
-	  pthread_exit (ER_FAILED);
+	  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	  return ER_FAILED;
 	}
 
@@ -678,7 +680,7 @@ test_clear_proc_3 (void *param)
 
 	  if (lf_hash_delete_already_locked (te, hash, &key, &success) != NO_ERROR)
 	    {
-	      pthread_exit (ER_FAILED);
+	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;
 	    }
 	  else if (!success)
@@ -695,7 +697,7 @@ test_clear_proc_3 (void *param)
 
   if (lf_tran_return_entry (te) != NO_ERROR)
     {
-      pthread_exit (ER_FAILED);
+      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
       return ER_FAILED;
     }
 

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -901,9 +901,9 @@ test_hash_table (LF_ENTRY_DESCRIPTOR * edesc, int nthreads, void *(*proc) (void 
     {
       for (e = hash.buckets[i]; e != NULL; e = e->next)
 	{
-	  if (edesc->f_hash (e->key, HASH_SIZE) != i)
+	  if (edesc->f_hash (&e->key, HASH_SIZE) != i)
 	    {
-	      sprintf (msg, "hash (%d) = %d != %d", e->key, edesc->f_hash (e->key, HASH_SIZE), i);
+	      sprintf (msg, "hash (%d) = %d != %d", e->key, edesc->f_hash (&e->key, HASH_SIZE), i);
 	      return fail (msg);
 	    }
 	}

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -691,8 +691,6 @@ test_clear_proc_3 (void *param)
 	{
 	  pthread_mutex_unlock (&entry->mutex);
 	}
-
-      lf_tran_end_with_mb (te);
     }
 
   if (lf_tran_return_entry (te) != NO_ERROR)

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -1004,6 +1004,8 @@ test_hash_iterator ()
       else
 	{
 	  entry->data = i;
+	  /* end transaction */
+	  lf_tran_end_with_mb (te);
 	}
     }
 

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -376,6 +376,8 @@ test_hash_proc_2 (void *param)
 	      return ER_FAILED;
 	    }
 	}
+
+      assert (te->locked_mutex == NULL);
     }
 
   if (lf_tran_return_entry (te) != NO_ERROR)
@@ -694,7 +696,7 @@ test_clear_proc_3 (void *param)
 	  pthread_mutex_unlock (&entry->mutex);
 	}
 
-      lf_check_no_mutex ();
+      assert (te->locked_mutex == NULL);
     }
 
   if (lf_tran_return_entry (te) != NO_ERROR)

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -366,6 +366,11 @@ test_hash_proc_2 (void *param)
 	      return ER_FAILED;
 	    }
 
+	  if (te->locked_mutex != &entry->mutex)
+	    {
+	      abort ();
+	    }
+	  te->locked_mutex = NULL;
 	  pthread_mutex_unlock (&entry->mutex);
 	}
       else
@@ -462,8 +467,15 @@ test_hash_proc_3 (void *param)
 	}
       else
 	{
+	  if (te->locked_mutex != &entry->mutex)
+	    {
+	      abort ();
+	    }
+	  te->locked_mutex = NULL;
 	  pthread_mutex_unlock (&entry->mutex);
 	}
+
+      assert (te->locked_mutex == NULL);
     }
 
   if (lf_tran_return_entry (te) != NO_ERROR)
@@ -596,6 +608,12 @@ test_clear_proc_2 (void *param)
 		  return ER_FAILED;
 		}
 
+
+	      if (te->locked_mutex != &entry->mutex)
+		{
+		  abort ();
+		}
+	      te->locked_mutex = NULL;
 	      pthread_mutex_unlock (&entry->mutex);
 	    }
 	  else
@@ -611,6 +629,7 @@ test_clear_proc_2 (void *param)
 	{
 	  lf_hash_clear (te, hash);
 	}
+      assert (te->locked_mutex == NULL);
     }
 
   if (lf_tran_return_entry (te) != NO_ERROR)
@@ -688,11 +707,21 @@ test_clear_proc_3 (void *param)
 	  else if (!success)
 	    {
 	      /* cleared in the meantime */
+	      if (te->locked_mutex != &entry->mutex)
+		{
+		  abort ();
+		}
+	      te->locked_mutex = NULL;
 	      pthread_mutex_unlock (&entry->mutex);
 	    }
 	}
       else
 	{
+	  if (te->locked_mutex != &entry->mutex)
+	    {
+	      abort ();
+	    }
+	  te->locked_mutex = NULL;
 	  pthread_mutex_unlock (&entry->mutex);
 	}
 

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -182,7 +182,7 @@ static int
 fail (const char *message)
 {
   printf (" %s: %s\n", "FAILED", message);
-  assert (false);
+  abort ();
   return ER_FAILED;
 }
 
@@ -819,6 +819,8 @@ test_hash_table (LF_ENTRY_DESCRIPTOR * edesc, int nthreads, void *(*proc) (void 
 
   sprintf (msg, "hash (mutex=%s, %d threads)", edesc->using_mutex ? "y" : "n", nthreads);
   begin (msg);
+
+  lf_reset_counters ();
 
   /* initialization */
   if (nthreads > MAX_THREADS)

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -930,8 +930,8 @@ test_hash_table (LF_ENTRY_DESCRIPTOR * edesc, int nthreads, void *(*proc) (void 
 
     if (ecount + freelist.available_cnt + freelist.retired_cnt != freelist.alloc_cnt)
       {
-	sprintf (msg, "leak check fail (%d + %d + %d != %d)", ecount, freelist.available_cnt, freelist.retired_cnt,
-		 freelist.alloc_cnt);
+	sprintf (msg, "leak check fail (%d + %d + %d = %d != %d)", ecount, freelist.available_cnt, freelist.retired_cnt,
+		 ecount + freelist.available_cnt + freelist.retired_cnt, freelist.alloc_cnt);
 	return fail (msg);
       }
   }

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -849,6 +849,7 @@ test_hash_table (LF_ENTRY_DESCRIPTOR * edesc, int nthreads, void *(*proc) (void 
   pthread_t threads[MAX_THREADS];
   char msg[256];
   int i;
+  XENTRY *e = NULL;
 
   sprintf (msg, "hash (mutex=%s, %d threads)", edesc->using_mutex ? "y" : "n", nthreads);
   begin (msg);
@@ -908,7 +909,6 @@ test_hash_table (LF_ENTRY_DESCRIPTOR * edesc, int nthreads, void *(*proc) (void 
   /* count operations */
   if (edesc->using_mutex)
     {
-      XENTRY *e;
       int nondel_op_count = 0;
 
       for (i = 0; i < HASH_SIZE; i++)

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -896,6 +896,15 @@ test_hash_table (LF_ENTRY_DESCRIPTOR * edesc, int nthreads, void *(*proc) (void 
 	}
     }
 
+  for (i = 0; i < HASH_SIZE; i++)
+    {
+      if (edesc->f_hash (e->key, HASH_SIZE) != i)
+	{
+	  sprintf (msg, "hash (%d) = %d != %d", e->key, edesc->f_hash (e->key, HASH_SIZE), i);
+	  return fail (msg);
+	}
+    }
+
   /* count operations */
   if (edesc->using_mutex)
     {
@@ -907,12 +916,6 @@ test_hash_table (LF_ENTRY_DESCRIPTOR * edesc, int nthreads, void *(*proc) (void 
 	  for (e = hash.buckets[i]; e != NULL; e = e->next)
 	    {
 	      nondel_op_count += e->data;
-
-	      if (edesc->f_hash (e->key, HASH_SIZE) != i)
-		{
-		  sprintf (msg, "hash (%d) = %d != %d", e->key, edesc->f_hash (e->key, HASH_SIZE), i);
-		  return fail (msg);
-		}
 	    }
 	}
 

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -454,7 +454,7 @@ test_hash_proc_3 (void *param)
 	  int success = 0;
 
 	  local_del_op_count += entry->data;
-	  if (lf_hash_delete_already_locked (te, hash, &key, &success) != NO_ERROR)
+	  if (lf_hash_delete_already_locked (te, hash, &key, entry, &success) != NO_ERROR)
 	    {
 	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;
@@ -699,7 +699,7 @@ test_clear_proc_3 (void *param)
 	{
 	  int success = 0;
 
-	  if (lf_hash_delete_already_locked (te, hash, &key, &success) != NO_ERROR)
+	  if (lf_hash_delete_already_locked (te, hash, &key, entry, &success) != NO_ERROR)
 	    {
 	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
 	      return ER_FAILED;

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -388,7 +388,7 @@ test_hash_proc_2 (void *param)
 #undef NOPS
 }
 
-static int del_op_count = 0;
+static int del_op_count = -1;
 
 void *
 test_hash_proc_3 (void *param)
@@ -701,8 +701,6 @@ test_clear_proc_3 (void *param)
       return ER_FAILED;
     }
 
-  del_op_count = -1;
-
   pthread_exit (NO_ERROR);
 
 #undef NOPS
@@ -818,8 +816,6 @@ test_hash_table (LF_ENTRY_DESCRIPTOR * edesc, int nthreads, void *(*proc) (void 
   pthread_t threads[MAX_THREADS];
   char msg[256];
   int i;
-
-  del_op_count = 0;
 
   sprintf (msg, "hash (mutex=%s, %d threads)", edesc->using_mutex ? "y" : "n", nthreads);
   begin (msg);
@@ -962,8 +958,6 @@ test_hash_iterator ()
   pthread_t threads[NUM_THREADS];
   int i;
 
-  del_op_count = 0;
-
   begin ("hash table iterator");
 
   /* initialization */
@@ -1105,10 +1099,13 @@ main (int argc, char **argv)
   xentry_desc.using_mutex = LF_EM_USING_MUTEX;
   for (i = 1; i <= 64; i *= 2)
     {
+      /* test_hash_proc_3 uses global del_op_count */
+      del_op_count = 0;
       if (test_hash_table (&xentry_desc, i, test_hash_proc_3) != NO_ERROR)
 	{
 	  goto fail;
 	}
+      del_op_count = -1;
       if (test_hash_table (&xentry_desc, i, test_clear_proc_3) != NO_ERROR)
 	{
 	  goto fail;

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -693,6 +693,8 @@ test_clear_proc_3 (void *param)
 	{
 	  pthread_mutex_unlock (&entry->mutex);
 	}
+
+      lf_check_no_mutex ();
     }
 
   if (lf_tran_return_entry (te) != NO_ERROR)

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -445,7 +445,7 @@ test_hash_proc_3 (void *param)
 	  int success = 0;
 
 	  local_del_op_count += entry->data;
-	  if (lf_hash_delete (te, hash, &key, &success) != NO_ERROR)
+	  if (lf_hash_delete_already_locked (te, hash, &key, &success) != NO_ERROR)
 	    {
 	      pthread_exit (ER_FAILED);
 	      return ER_FAILED;
@@ -676,7 +676,7 @@ test_clear_proc_3 (void *param)
 	{
 	  int success = 0;
 
-	  if (lf_hash_delete (te, hash, &key, &success) != NO_ERROR)
+	  if (lf_hash_delete_already_locked (te, hash, &key, &success) != NO_ERROR)
 	    {
 	      pthread_exit (ER_FAILED);
 	      return ER_FAILED;

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -899,10 +899,13 @@ test_hash_table (LF_ENTRY_DESCRIPTOR * edesc, int nthreads, void *(*proc) (void 
 
   for (i = 0; i < HASH_SIZE; i++)
     {
-      if (edesc->f_hash (e->key, HASH_SIZE) != i)
+      for (e = hash.buckets[i]; e != NULL; e = e->next)
 	{
-	  sprintf (msg, "hash (%d) = %d != %d", e->key, edesc->f_hash (e->key, HASH_SIZE), i);
-	  return fail (msg);
+	  if (edesc->f_hash (e->key, HASH_SIZE) != i)
+	    {
+	      sprintf (msg, "hash (%d) = %d != %d", e->key, edesc->f_hash (e->key, HASH_SIZE), i);
+	      return fail (msg);
+	    }
 	}
     }
 

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -907,6 +907,12 @@ test_hash_table (LF_ENTRY_DESCRIPTOR * edesc, int nthreads, void *(*proc) (void 
 	  for (e = hash.buckets[i]; e != NULL; e = e->next)
 	    {
 	      nondel_op_count += e->data;
+
+	      if (edesc->f_hash (e->key, HASH_SIZE) != i)
+		{
+		  sprintf (msg, "hash (%d) = %d != %d", e->key, edesc->f_hash (e->key, HASH_SIZE), i);
+		  return fail (msg);
+		}
 	    }
 	}
 

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -710,7 +710,7 @@ session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id)
   assert (session_p->ref_count == 0);
 #endif
 
-  error = lf_hash_delete_already_locked (t_entry, &sessions.sessions_table, (void *) &id, &success);
+  error = lf_hash_delete_already_locked (t_entry, &sessions.sessions_table, (void *) &id, session_p, &success);
   if (error != NO_ERROR)
     {
       return ER_FAILED;

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -387,7 +387,8 @@ spage_free_saved_spaces (THREAD_ENTRY * thread_p, void *first_save_entry)
 	    {
 	      int success = 0;
 
-	      if (lf_hash_delete_already_locked (t_entry, &spage_saving_ht, (void *) &head->vpid, &success) != NO_ERROR)
+	      if (lf_hash_delete_already_locked (t_entry, &spage_saving_ht, (void *) &head->vpid, head, &success)
+		  != NO_ERROR)
 		{
 		  /* we don't have clear operations on this hash table, this shouldn't happen */
 		  pthread_mutex_unlock (&head->mutex);

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -1225,7 +1225,7 @@ lock_remove_resource (LK_RES * res_ptr)
   LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (NULL, THREAD_TS_OBJ_LOCK_RES);
   int success = 0, rc;
 
-  rc = lf_hash_delete_already_locked (t_entry, &lk_Gl.obj_hash_table, (void *) &res_ptr->key, &success);
+  rc = lf_hash_delete_already_locked (t_entry, &lk_Gl.obj_hash_table, (void *) &res_ptr->key, res_ptr, &success);
   if (!success)
     {
       /* this should not happen, as the hash entry is mutex protected and no clear operations are performed on the hash 
@@ -1236,6 +1236,7 @@ lock_remove_resource (LK_RES * res_ptr)
     }
   else
     {
+      assert (rc == NO_ERROR);
       return rc;
     }
 }

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -220,7 +220,7 @@ if(UNIX)
     ${EXECUTABLES_DIR}/unittests_lf.c
     )
   add_executable(unittests_lf ${UNITTESTS_LF_SOURCES})
-  target_compile_definitions(unittests_lf UNITTEST_LF PRIVATE SERVER_MODE ${COMMON_DEFS})
+  target_compile_definitions(unittests_lf PRIVATE UNITTEST_LF SERVER_MODE ${COMMON_DEFS})
   target_include_directories(unittests_lf PRIVATE ${EP_INCLUDES})
   target_link_libraries(unittests_lf LINK_PRIVATE cubridcs)
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -220,7 +220,7 @@ if(UNIX)
     ${EXECUTABLES_DIR}/unittests_lf.c
     )
   add_executable(unittests_lf ${UNITTESTS_LF_SOURCES})
-  target_compile_definitions(unittests_lf PRIVATE SERVER_MODE ${COMMON_DEFS})
+  target_compile_definitions(unittests_lf UNITTEST_LF PRIVATE SERVER_MODE ${COMMON_DEFS})
   target_include_directories(unittests_lf PRIVATE ${EP_INCLUDES})
   target_link_libraries(unittests_lf LINK_PRIVATE cubridcs)
 


### PR DESCRIPTION
I fixed several issues and I added some sanity checks in lock-free hash table & unit test.

The fix is not yet complete. There is an entry leak left. So far I discovered there is an inconsistency between the number of successful inserts and deletes and the final hash-table entry count. I can imagine only two possible scenarios:

1. Insert does not link the new entry in the hash table (even though it thinks it is successful).
2. Delete removes more than one entry in one action.