### PR TITLE
[CBRD-20405] Fix bad assert in lock-free circular queue produce/consume; Improve lock-free circular queue unit test

### DIFF
--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -2539,6 +2539,9 @@ lf_circular_queue_produce (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data)
   UINT64 old_state;
   UINT64 new_state;
   volatile UINT64 *entry_state_p;
+#if !defined (NDEBUG) || defined (UNITTEST_CQ)
+  bool was_not_ready = false;
+#endif /* !NDEBUG || UNITTEST_CQ */
 
   assert (data != NULL);
 
@@ -2562,13 +2565,11 @@ lf_circular_queue_produce (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data)
       /* Compute entry's index in circular queue */
       entry_index = (int) produce_cursor % queue->capacity;
       entry_state_p = &queue->entry_state[entry_index];
-      if (ATOMIC_LOAD_64 (entry_state_p) == ((produce_cursor - queue->capacity) | LFCQ_RESERVED_FOR_CONSUME))
-	{
-	  /* The entry at produce_cursor is being consumed still. The consume cursor is behind one generation and
-	   * it was already incremented, but the consumer did not yet finish consuming. We can consider the queue
-	   * is still full since we don't want to loop here for an indefinite time. */
-	  return false;
-	}
+
+#if !defined (NDEBUG) || defined (UNITTEST_CQ)
+      was_not_ready =
+	ATOMIC_LOAD_64 (entry_state_p) == ((produce_cursor - queue->capacity) | LFCQ_RESERVED_FOR_CONSUME);
+#endif /* !NDEBUG || UNITTEST_CQ */
 
       /* Change state to RESERVED_FOR_PRODUCE. The expected current state is produce_cursor | LFCQ_READY_FOR_PRODUCE.
        * The produce cursor is included in the state to avoid reusing same produce cursor in a scenario like:
@@ -2605,8 +2606,11 @@ lf_circular_queue_produce (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data)
 	}
       else
 	{
-	  /* The entry at current produce cursor was already "produced". The cursor should already be incremented. */
-	  assert (queue->produce_cursor > produce_cursor);
+#if !defined (NDEBUG) || defined (UNITTEST_CQ)
+	  /* The entry at current produce cursor was already "produced". The cursor should already be incremented or
+	   * maybe it was not ready when ATOMIC_CAS was called, but now it is. */
+	  assert ((queue->produce_cursor > produce_cursor) || was_not_ready);
+#endif /* !NDEBUG || UNITTEST_CQ */
 	}
       /* Loop again. */
     }
@@ -2644,6 +2648,9 @@ lf_circular_queue_consume (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data)
   UINT64 old_state;
   UINT64 new_state;
   volatile UINT64 *entry_state_p;
+#if !defined (NDEBUG) || defined (UNITTEST_CQ)
+  bool was_not_ready = false;
+#endif /* !NDEBUG || UNITTEST_CQ */
 
   /* Loop until an entry can be consumed or until queue is empty */
   /* Since there may be more than one consumer and no locks is used, a consume cursor and entry states are used to
@@ -2663,14 +2670,10 @@ lf_circular_queue_consume (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data)
 
       /* Compute entry's index in circular queue */
       entry_index = (int) consume_cursor % queue->capacity;
-
       entry_state_p = &queue->entry_state[entry_index];
-      if (ATOMIC_LOAD_64 (entry_state_p) == (consume_cursor | LFCQ_RESERVED_FOR_PRODUCE))
-	{
-	  /* We are here because produce_cursor was incremented but the entry at consume_cursor was not produced yet.
-	   * We can consider the queue empty since we don't want to loop here for an indefinite time. */
-	  return false;
-	}
+#if !defined (NDEBUG) || defined (UNITTEST_CQ)
+      was_not_ready = ATOMIC_LOAD_64 (entry_state_p) == (consume_cursor | LFCQ_RESERVED_FOR_PRODUCE);
+#endif /* !NDEBUG || UNITTEST_CQ */
 
       /* Try to set entry state from READY_FOR_CONSUME to RESERVED_FOR_CONSUME. */
       old_state = consume_cursor | LFCQ_READY_FOR_CONSUME;
@@ -2697,8 +2700,11 @@ lf_circular_queue_consume (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data)
 	}
       else
 	{
-	  /* The entry at current consume cursor was already "consumed". The cursor should already be incremented. */
+#if !defined (NDEBUG) || defined (UNITTEST_CQ)
+	  /* The entry at current consume cursor was already "consumed". The cursor should already be incremented or it
+	   * was not ready when ATOMIC_CAS was called but now it is. */
 	  assert (queue->consume_cursor > consume_cursor);
+#endif /* !NDEBUG || UNITTEST_CQ */
 	}
       /* Loop again. */
     }

--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -2703,7 +2703,7 @@ lf_circular_queue_consume (LOCK_FREE_CIRCULAR_QUEUE * queue, void *data)
 #if !defined (NDEBUG) || defined (UNITTEST_CQ)
 	  /* The entry at current consume cursor was already "consumed". The cursor should already be incremented or it
 	   * was not ready when ATOMIC_CAS was called but now it is. */
-	  assert (queue->consume_cursor > consume_cursor);
+	  assert ((queue->consume_cursor > consume_cursor) || was_not_ready);
 #endif /* !NDEBUG || UNITTEST_CQ */
 	}
       /* Loop again. */

--- a/src/executables/unittests_cqueue.c
+++ b/src/executables/unittests_cqueue.c
@@ -50,7 +50,7 @@ begin (char *test_name)
     {
       putchar (' ');
     }
-  printf ("...");
+  printf ("... \n");
 
   gettimeofday (&start_time, NULL);
 

--- a/src/executables/unittests_cqueue.c
+++ b/src/executables/unittests_cqueue.c
@@ -101,7 +101,7 @@ test_circular_queue_consumer (void *param)
 	  local_nconsumed = ATOMIC_INC_64 (&global_nconsumed, 1);
 	  if (local_nconsumed % 100000 == 0)
 	    {
-	      printf (" Consumed %d entries \n ", local_nconsumed);
+	      printf (" Consumed %d entries \n", local_nconsumed);
 	    }
 	}
     }
@@ -155,6 +155,8 @@ test_cqueue (int num_consumers, int num_producers)
     {
       return fail ("too many threads");
     }
+
+  begin ("one consumer / 50 producers");
 
   global_nconsumed = 0;
   global_nproduced = 0;

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -233,11 +233,11 @@ if(UNIX)
   target_include_directories(unittests_area PRIVATE ${EP_INCLUDES})
   target_link_libraries(unittests_area LINK_PRIVATE cubrid ${CURSES_LIBRARIES})
 
-  set(UNITTESTS_AREA_SOURCES
+  set(UNITTESTS_CQUEUE_SOURCES
     ${EXECUTABLES_DIR}/unittests_cqueue.c
     )
-  add_executable(unittests_cqueue ${UNITTESTS_AREA_SOURCES})
-  target_compile_definitions(unittests_cqueue PRIVATE SERVER_MODE ${COMMON_DEFS})
+  add_executable(unittests_cqueue ${UNITTESTS_CQUEUE_SOURCES})
+  target_compile_definitions(unittests_cqueue PRIVATE UNITTEST_CQ SERVER_MODE ${COMMON_DEFS})
   target_include_directories(unittests_cqueue PRIVATE ${EP_INCLUDES})
   target_link_libraries(unittests_cqueue LINK_PRIVATE cubrid ${CURSES_LIBRARIES})
   


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20405

lock_free.c
* Fix assert expecting that consume/produce cursor is incremented. There is one case when the cursor might not increment if the entry was not yet ready for produce/consume in the beginning. Reserving the entry fails, but by the time the assert is reached, the status was changed to ready for produce/consume. The assert was updated to check if the status was not ready when cursors is not incremented. The purpose of the assert was to make sure we don't spin over and over in the same context. If the status of entry has changed from not ready to ready to produce/consume by the time assert check is verified, we know that the context has changed for the next loop.
* Asserts abort execution in release mode also when UNITTEST_CQ is defined.

unittests_cqueue.c
* Define UNITTEST_CQ macro.
* Call begin () function when the test is started.
* Add a limit on the number of operations to be executed.
* Intermediary prints number of produced/consumed operations to show user progress.