### PR TITLE
[CBRD-20350] fix to elevate UACExecutionLevel for some cubrid utilities es on Windows build

### DIFF
--- a/broker/CMakeLists.txt
+++ b/broker/CMakeLists.txt
@@ -108,6 +108,12 @@ if(UNIX)
   target_link_libraries(broker_changer LINK_PRIVATE rt)
 else(UNIX)
   target_link_libraries(broker_changer LINK_PRIVATE ws2_32)
+  if(MSVC_VERSION LESS 1600)
+    # for VS 2008 (9.0) or less version
+    set_target_properties(broker_changer PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\"")
+  else(MSVC_VERSION LESS 1600)
+    set_target_properties(broker_changer PROPERTIES LINK_FLAGS "/level='requireAdministrator' /uiAccess='false'")
+  endif(MSVC_VERSION LESS 1600)
 endif(UNIX)
 
 
@@ -139,6 +145,12 @@ target_compile_definitions(cubrid_broker PRIVATE ${BROKER_DEFS})
 target_link_libraries(cubrid_broker LINK_PRIVATE cubridcs)
 if(WIN32)
   target_link_libraries(cubrid_broker LINK_PRIVATE ws2_32)
+  if(MSVC_VERSION LESS 1600)
+    # for VS 2008 (9.0) or less version
+    set_target_properties(cubrid_broker PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\"")
+  else(MSVC_VERSION LESS 1600)
+    set_target_properties(cubrid_broker PROPERTIES LINK_FLAGS "/level='requireAdministrator' /uiAccess='false'")
+  endif(MSVC_VERSION LESS 1600)
 endif(WIN32)
 
 
@@ -342,6 +354,7 @@ if(WIN32)
   list(APPEND BROKERADMIN_SOURCES ${BROKER_DIR}/broker_wsa_init.c)
 endif(WIN32)
 add_library(brokeradmin SHARED ${BROKERADMIN_SOURCES})
+set_target_properties(brokeradmin PROPERTIES SOVERSION "${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}")
 target_compile_definitions(brokeradmin PRIVATE ${BROKER_DEFS} _UC_ADMIN_SO_ DIAG_DEVEL)
 target_link_libraries(brokeradmin LINK_PRIVATE cubridcs)
 if(WIN32)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -97,6 +97,12 @@ set(CUBRID_SOURCES
 if(WIN32)
   list(APPEND CUBRID_SOURCES ${BASE_DIR}/getopt_long.c)
   list(APPEND CUBRID_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
+  if(MSVC_VERSION LESS 1600)
+    # for VS 2008 (9.0) or less version
+    set_target_properties(cubrid-bin PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\"")
+  else(MSVC_VERSION LESS 1600)
+    set_target_properties(cubrid-bin PROPERTIES LINK_FLAGS "/level='requireAdministrator' /uiAccess='false'")
+  endif(MSVC_VERSION LESS 1600)
 endif(WIN32)
 add_executable(cubrid-bin ${CUBRID_SOURCES})
 set_target_properties(cubrid-bin PROPERTIES OUTPUT_NAME cubrid)

--- a/win/CMakeLists.txt
+++ b/win/CMakeLists.txt
@@ -95,7 +95,7 @@ set_target_properties(cubridtray PROPERTIES COMPILE_FLAGS "/GF /YuSTDAFX.H")
 set_target_properties(cubridtray PROPERTIES OUTPUT_NAME "CUBRID_Service_Tray")
 if(MSVC_VERSION LESS 1600)
   # for VS 2008 (9.0) or less version
-  set_target_properties(cubridtray PROPERTIES LINK_FLAGS  "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\"")
+  set_target_properties(cubridtray PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\"")
 else(MSVC_VERSION LESS 1600)
   set_target_properties(cubridtray PROPERTIES LINK_FLAGS "/level='requireAdministrator' /uiAccess='false'")
 endif(MSVC_VERSION LESS 1600)


### PR DESCRIPTION
fix to popup admin's cmd window after UAC window when 'cubrid server/broker start' or 'broker_changer' command is executed on normal user's terminal.
(You need start 'cmd' as an Administrator mode to see a usage or output anyway)

Changes:
- set UACExecutionLevel to requireAdministrator for cubrid, cubrid_broker and broker_changer.

