### PR TITLE
[CBRD-20407] replaces CSECT_CONN_ACTIVE and CSECT_CONN_FREE with CSS_RWLOCK_ACTIVE_CONN_ANCHOR and CSS_RWLOCK_FREE_ANCHOR for each

### DIFF
--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1336,7 +1336,7 @@ css_shutdown_conn_by_tran_index (int tran_index)
 
   if (css_Active_conn_anchor != NULL)
     {
-      START_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
+      START_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
       for (conn = css_Active_conn_anchor; conn != NULL; conn = conn->next)
 	{
@@ -1350,7 +1350,7 @@ css_shutdown_conn_by_tran_index (int tran_index)
 	    }
 	}
 
-      END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
+      END_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
     }
 }
 

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -125,6 +125,9 @@ CSS_CONN_ENTRY *css_Conn_array = NULL;
 CSS_CONN_ENTRY *css_Active_conn_anchor = NULL;
 static int css_Num_active_conn = 0;
 
+SYNC_RWLOCK css_Rwlock_active_conn_anchor;
+SYNC_RWLOCK css_Rwlock_free_conn_anchor;
+
 static LAST_ACCESS_STATUS *css_Access_status_anchor = NULL;
 int css_Num_access_user = 0;
 
@@ -427,6 +430,20 @@ css_init_conn_list (void)
       return NO_ERROR;
     }
 
+  err = rwlock_initialize (CSS_RWLOCK_ACTIVE_CONN_ANCHOR, CSS_RWLOCK_ACTIVE_CONN_ANCHOR_NAME);
+  if (err != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      return err;
+    }
+
+  err = rwlock_initialize (CSS_RWLOCK_FREE_CONN_ANCHOR, CSS_RWLOCK_FREE_CONN_ANCHOR_NAME);
+  if (err != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      return err;
+    }
+
   /* 
    * allocate NUM_MASTER_CHANNEL + the total number of
    *  conn entries
@@ -516,6 +533,9 @@ css_final_conn_list (void)
 
       free_and_init (css_Conn_array);
     }
+
+  (void) rwlock_finalize (CSS_RWLOCK_ACTIVE_CONN_ANCHOR);
+  (void) rwlock_finalize (CSS_RWLOCK_FREE_CONN_ANCHOR);
 }
 
 /*
@@ -528,8 +548,9 @@ CSS_CONN_ENTRY *
 css_make_conn (SOCKET fd)
 {
   CSS_CONN_ENTRY *conn = NULL;
+  int r;
 
-  csect_enter (NULL, CSECT_CONN_FREE, INF_WAIT);
+  START_EXCLUSIVE_ACCESS_FREE_CONN_ANCHOR (r);
 
   if (css_Free_conn_anchor != NULL)
     {
@@ -541,7 +562,7 @@ css_make_conn (SOCKET fd)
       assert (css_Num_free_conn >= 0);
     }
 
-  csect_exit (NULL, CSECT_CONN_FREE);
+  END_EXCLUSIVE_ACCESS_FREE_CONN_ANCHOR (r);
 
   if (conn != NULL)
     {
@@ -565,7 +586,9 @@ css_make_conn (SOCKET fd)
 void
 css_insert_into_active_conn_list (CSS_CONN_ENTRY * conn)
 {
-  csect_enter (NULL, CSECT_CONN_ACTIVE, INF_WAIT);
+  int r;
+
+  START_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
   conn->next = css_Active_conn_anchor;
   css_Active_conn_anchor = conn;
@@ -575,7 +598,7 @@ css_insert_into_active_conn_list (CSS_CONN_ENTRY * conn)
   assert (css_Num_active_conn > 0);
   assert (css_Num_active_conn <= css_Num_max_conn);
 
-  csect_exit (NULL, CSECT_CONN_ACTIVE);
+  END_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
 }
 
 /*
@@ -597,7 +620,9 @@ css_dealloc_conn_rmutex (CSS_CONN_ENTRY * conn)
 static void
 css_dealloc_conn (CSS_CONN_ENTRY * conn)
 {
-  csect_enter (NULL, CSECT_CONN_FREE, INF_WAIT);
+  int r;
+
+  START_EXCLUSIVE_ACCESS_FREE_CONN_ANCHOR (r);
 
   conn->next = css_Free_conn_anchor;
   css_Free_conn_anchor = conn;
@@ -607,7 +632,7 @@ css_dealloc_conn (CSS_CONN_ENTRY * conn)
   assert (css_Num_free_conn > 0);
   assert (css_Num_free_conn <= css_Num_max_conn);
 
-  csect_exit (NULL, CSECT_CONN_FREE);
+  END_EXCLUSIVE_ACCESS_FREE_CONN_ANCHOR (r);
 }
 
 /*
@@ -816,8 +841,9 @@ void
 css_free_conn (CSS_CONN_ENTRY * conn)
 {
   CSS_CONN_ENTRY *p, *prev = NULL, *next;
+  int r;
 
-  csect_enter (NULL, CSECT_CONN_ACTIVE, INF_WAIT);
+  START_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
   /* find and remove from active conn list */
   for (p = css_Active_conn_anchor; p != NULL; p = next)
@@ -850,7 +876,7 @@ css_free_conn (CSS_CONN_ENTRY * conn)
   css_dealloc_conn (conn);
   css_decrement_num_conn (conn->client_type);
 
-  csect_exit (NULL, CSECT_CONN_ACTIVE);
+  END_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
 }
 
 void
@@ -912,11 +938,11 @@ void
 css_print_conn_list (void)
 {
   CSS_CONN_ENTRY *conn, *next;
-  int i;
+  int i, r;
 
   if (css_Active_conn_anchor != NULL)
     {
-      csect_enter_as_reader (NULL, CSECT_CONN_ACTIVE, INF_WAIT);
+      START_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
       fprintf (stderr, "active conn list (%d)\n", css_Num_active_conn);
 
@@ -928,7 +954,7 @@ css_print_conn_list (void)
 
       assert (i == css_Num_active_conn);
 
-      csect_exit (NULL, CSECT_CONN_ACTIVE);
+      END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
     }
 }
 
@@ -940,11 +966,11 @@ void
 css_print_free_conn_list (void)
 {
   CSS_CONN_ENTRY *conn, *next;
-  int i;
+  int i, r;
 
   if (css_Free_conn_anchor != NULL)
     {
-      csect_enter_as_reader (NULL, CSECT_CONN_FREE, INF_WAIT);
+      START_SHARED_ACCESS_FREE_CONN_ANCHOR (r);
 
       fprintf (stderr, "free conn list (%d)\n", css_Num_free_conn);
 
@@ -956,7 +982,7 @@ css_print_free_conn_list (void)
 
       assert (i == css_Num_free_conn);
 
-      csect_exit (NULL, CSECT_CONN_FREE);
+      END_SHARED_ACCESS_FREE_CONN_ANCHOR (r);
     }
 }
 
@@ -1180,10 +1206,11 @@ CSS_CONN_ENTRY *
 css_find_conn_by_tran_index (int tran_index)
 {
   CSS_CONN_ENTRY *conn = NULL, *next;
+  int r;
 
   if (css_Active_conn_anchor != NULL)
     {
-      csect_enter_as_reader (NULL, CSECT_CONN_ACTIVE, INF_WAIT);
+      START_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
       for (conn = css_Active_conn_anchor; conn != NULL; conn = next)
 	{
@@ -1194,7 +1221,7 @@ css_find_conn_by_tran_index (int tran_index)
 	    }
 	}
 
-      csect_exit (NULL, CSECT_CONN_ACTIVE);
+      END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
     }
 
   return conn;
@@ -1209,10 +1236,11 @@ CSS_CONN_ENTRY *
 css_find_conn_from_fd (SOCKET fd)
 {
   CSS_CONN_ENTRY *conn = NULL, *next;
+  int r;
 
   if (css_Active_conn_anchor != NULL)
     {
-      csect_enter_as_reader (NULL, CSECT_CONN_ACTIVE, INF_WAIT);
+      START_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
       for (conn = css_Active_conn_anchor; conn != NULL; conn = next)
 	{
@@ -1223,7 +1251,7 @@ css_find_conn_from_fd (SOCKET fd)
 	    }
 	}
 
-      csect_exit (NULL, CSECT_CONN_ACTIVE);
+      END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
     }
   return conn;
 }
@@ -1239,7 +1267,7 @@ css_get_session_ids_for_active_connections (SESSION_ID ** session_ids, int *coun
 {
   CSS_CONN_ENTRY *conn = NULL, *next = NULL;
   SESSION_ID *sessions_p = NULL;
-  int error = NO_ERROR, i = 0;
+  int error = NO_ERROR, i = 0, r;
 
   assert (count != NULL);
   if (count == NULL)
@@ -1255,7 +1283,7 @@ css_get_session_ids_for_active_connections (SESSION_ID ** session_ids, int *coun
       return NO_ERROR;
     }
 
-  csect_enter_as_reader (NULL, CSECT_CONN_ACTIVE, INF_WAIT);
+  START_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
   *count = css_Num_active_conn;
   sessions_p = (SESSION_ID *) malloc (css_Num_active_conn * sizeof (SESSION_ID));
 
@@ -1263,7 +1291,7 @@ css_get_session_ids_for_active_connections (SESSION_ID ** session_ids, int *coun
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, css_Num_active_conn * sizeof (SESSION_ID));
       error = ER_FAILED;
-      csect_exit (NULL, CSECT_CONN_ACTIVE);
+      END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
       goto error_return;
     }
 
@@ -1274,7 +1302,7 @@ css_get_session_ids_for_active_connections (SESSION_ID ** session_ids, int *coun
       i++;
     }
 
-  csect_exit (NULL, CSECT_CONN_ACTIVE);
+  END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
   *session_ids = sessions_p;
   return error;
 
@@ -1304,10 +1332,11 @@ void
 css_shutdown_conn_by_tran_index (int tran_index)
 {
   CSS_CONN_ENTRY *conn = NULL;
+  int r;
 
   if (css_Active_conn_anchor != NULL)
     {
-      csect_enter (NULL, CSECT_CONN_ACTIVE, INF_WAIT);
+      START_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
       for (conn = css_Active_conn_anchor; conn != NULL; conn = conn->next)
 	{
@@ -1321,7 +1350,7 @@ css_shutdown_conn_by_tran_index (int tran_index)
 	    }
 	}
 
-      csect_exit (NULL, CSECT_CONN_ACTIVE);
+      END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
     }
 }
 

--- a/src/connection/connection_sr.h
+++ b/src/connection/connection_sr.h
@@ -51,6 +51,80 @@ struct ip_info
 extern CSS_CONN_ENTRY *css_Conn_array;
 extern CSS_CONN_ENTRY *css_Active_conn_anchor;
 
+extern SYNC_RWLOCK css_Rwlock_active_conn_anchor;
+
+#define CSS_RWLOCK_ACTIVE_CONN_ANCHOR (&css_Rwlock_active_conn_anchor)
+#define CSS_RWLOCK_ACTIVE_CONN_ANCHOR_NAME "CSS_RWLOCK_ACTIVE_CONN_ANCHOR"
+
+#define START_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR(r) \
+  do \
+    { \
+      (r) = rwlock_write_lock (CSS_RWLOCK_ACTIVE_CONN_ANCHOR); \
+      assert ((r) == NO_ERROR); \
+    } \
+  while (0)
+
+#define END_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR(r) \
+  do \
+    { \
+      (r) = rwlock_write_unlock (CSS_RWLOCK_ACTIVE_CONN_ANCHOR); \
+      assert ((r) == NO_ERROR); \
+    } \
+  while (0)
+
+#define START_SHARED_ACCESS_ACTIVE_CONN_ANCHOR(r) \
+  do \
+    { \
+      (r) = rwlock_read_lock (CSS_RWLOCK_ACTIVE_CONN_ANCHOR); \
+      assert ((r) == NO_ERROR); \
+    } \
+  while (0)
+
+#define END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR(r) \
+  do \
+    { \
+      (r) = rwlock_read_unlock (CSS_RWLOCK_ACTIVE_CONN_ANCHOR); \
+      assert ((r) == NO_ERROR); \
+    } \
+  while (0)
+
+extern SYNC_RWLOCK css_Rwlock_free_conn_anchor;
+
+#define CSS_RWLOCK_FREE_CONN_ANCHOR (&css_Rwlock_free_conn_anchor)
+#define CSS_RWLOCK_FREE_CONN_ANCHOR_NAME "CSS_RWLOCK_FREE_CONN_ANCHOR"
+
+#define START_EXCLUSIVE_ACCESS_FREE_CONN_ANCHOR(r) \
+  do \
+    { \
+      (r) = rwlock_write_lock (CSS_RWLOCK_FREE_CONN_ANCHOR); \
+      assert ((r) == NO_ERROR); \
+    } \
+  while (0)
+
+#define END_EXCLUSIVE_ACCESS_FREE_CONN_ANCHOR(r) \
+  do \
+    { \
+      (r) = rwlock_write_unlock (CSS_RWLOCK_FREE_CONN_ANCHOR); \
+      assert ((r) == NO_ERROR); \
+    } \
+  while (0)
+
+#define START_SHARED_ACCESS_FREE_CONN_ANCHOR(r) \
+  do \
+    { \
+      (r) = rwlock_read_lock (CSS_RWLOCK_FREE_CONN_ANCHOR); \
+      assert ((r) == NO_ERROR); \
+    } \
+  while (0)
+
+#define END_SHARED_ACCESS_FREE_CONN_ANCHOR(r) \
+  do \
+    { \
+      (r) = rwlock_read_unlock (CSS_RWLOCK_FREE_CONN_ANCHOR); \
+      assert ((r) == NO_ERROR); \
+    } \
+  while (0)
+
 extern int css_Num_access_user;
 
 extern int (*css_Connect_handler) (CSS_CONN_ENTRY *);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1688,7 +1688,7 @@ css_block_all_active_conn (unsigned short stop_phase)
   CSS_CONN_ENTRY *conn;
   int r;
 
-  csect_enter (NULL, CSECT_CONN_ACTIVE, INF_WAIT);
+  START_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
   for (conn = css_Active_conn_anchor; conn != NULL; conn = conn->next)
     {
@@ -1712,7 +1712,7 @@ css_block_all_active_conn (unsigned short stop_phase)
       assert (r == NO_ERROR);
     }
 
-  csect_exit (NULL, CSECT_CONN_ACTIVE);
+  END_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
 }
 
 /*
@@ -2501,10 +2501,10 @@ css_cleanup_server_queues (unsigned int eid)
 int
 css_number_of_clients (void)
 {
-  int n = 0;
+  int n = 0, r;
   CSS_CONN_ENTRY *conn;
 
-  csect_enter_as_reader (NULL, CSECT_CONN_ACTIVE, INF_WAIT);
+  START_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
   for (conn = css_Active_conn_anchor; conn != NULL; conn = conn->next)
     {
@@ -2514,7 +2514,7 @@ css_number_of_clients (void)
 	}
     }
 
-  csect_exit (NULL, CSECT_CONN_ACTIVE);
+  END_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
   return n;
 }

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2504,7 +2504,7 @@ css_number_of_clients (void)
   int n = 0, r;
   CSS_CONN_ENTRY *conn;
 
-  START_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
+  START_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
   for (conn = css_Active_conn_anchor; conn != NULL; conn = conn->next)
     {
@@ -2514,7 +2514,7 @@ css_number_of_clients (void)
 	}
     }
 
-  END_EXCLUSIVE_ACCESS_ACTIVE_CONN_ANCHOR (r);
+  END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
   return n;
 }

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -7139,7 +7139,7 @@ add_foreign_key (DB_CTMPL * ctemplate, const PT_NODE * cnstr, const char **att_n
   const char *comment = NULL;
   size_t buf_size;
 
-  fk_info = (PT_FOREIGN_KEY_INFO *) & (cnstr->info.constraint.un.foreign_key);
+  fk_info = (PT_FOREIGN_KEY_INFO *) (&cnstr->info.constraint.un.foreign_key);
 
   n_atts = pt_length_of_list (fk_info->attrs);
   i = 0;

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -2893,7 +2893,7 @@ session_get_session_tz_region (THREAD_ENTRY * thread_p)
 static int
 session_state_verify_ref_count (THREAD_ENTRY * thread_p, SESSION_STATE * session_p)
 {
-  int ref_count = 0;
+  int ref_count = 0, r;
   CSS_CONN_ENTRY *conn;
 
   if (session_p == NULL)
@@ -2908,7 +2908,7 @@ session_state_verify_ref_count (THREAD_ENTRY * thread_p, SESSION_STATE * session
       return ER_FAILED;
     }
 
-  csect_enter_as_reader (NULL, CSECT_CONN_ACTIVE, INF_WAIT);
+  START_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
   for (conn = css_Active_conn_anchor; conn != NULL; conn = conn->next)
     {
@@ -2920,12 +2920,12 @@ session_state_verify_ref_count (THREAD_ENTRY * thread_p, SESSION_STATE * session
 
   if (ref_count != session_p->ref_count)
     {
-      csect_exit (NULL, CSECT_CONN_ACTIVE);
+      END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
       assert (0);
       return ER_FAILED;
     }
 
-  csect_exit (NULL, CSECT_CONN_ACTIVE);
+  END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
 
   return NO_ERROR;
 }

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -342,7 +342,7 @@ static int catalog_fixup_missing_class_info (THREAD_ENTRY * thread_p, OID * clas
 static DISK_ISVALID catalog_check_class_consistency (THREAD_ENTRY * thread_p, OID * class_oid);
 static void catalog_dump_disk_attribute (DISK_ATTR * atr);
 static void catalog_dump_representation (DISK_REPR * dr);
-static void catalog_clear_hash_table ();
+static void catalog_clear_hash_table (void);
 
 static void catalog_put_page_header (char *rec_p, CATALOG_PAGE_HEADER * header_p);
 static void catalog_get_disk_representation (DISK_REPR * disk_repr_p, char *rec_p);
@@ -5044,7 +5044,7 @@ catalog_dump (THREAD_ENTRY * thread_p, FILE * fp, int dump_flag)
 }
 
 static void
-catalog_clear_hash_table ()
+catalog_clear_hash_table (void)
 {
   LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (NULL, THREAD_TS_CATALOG);
 

--- a/src/thread/critical_section.c
+++ b/src/thread/critical_section.c
@@ -88,8 +88,6 @@ static const char *csect_Names[] = {
   "ACL",
   "PARTITION_CACHE",
   "EVENT_LOG_FILE",
-  "CONN_ACTIVE",
-  "CONN_FREE",
   "TEMPFILE_CACHE",
   "LOG_ARCHIVE",
   "ACCESS_STATUS"

--- a/src/thread/critical_section.c
+++ b/src/thread/critical_section.c
@@ -2064,7 +2064,7 @@ rwlock_dump_statistics (FILE * fp)
   SYNC_STATS *stats;
   int i, cnt;
 
-  fprintf (fp, "\n         RWlock Name         |Total Enter|  Max elapsed  |  Total elapsed\n");
+  fprintf (fp, "\n         RWlock Name          |Total Enter|  Max elapsed  |  Total elapsed\n");
 
   pthread_mutex_lock (&sync_Stats_lock);
 
@@ -2078,7 +2078,7 @@ rwlock_dump_statistics (FILE * fp)
 	    {
 	      cnt++;
 
-	      fprintf (fp, "%-28s |%10d | %6ld.%06ld | %6ld.%06ld\n", stats->name, stats->nenter,
+	      fprintf (fp, "%-29s |%10d | %6ld.%06ld | %6ld.%06ld\n", stats->name, stats->nenter,
 		       stats->max_elapsed.tv_sec, stats->max_elapsed.tv_usec,
 		       stats->total_elapsed.tv_sec, stats->total_elapsed.tv_usec);
 

--- a/src/thread/critical_section.h
+++ b/src/thread/critical_section.h
@@ -66,8 +66,6 @@ enum
   CSECT_ACL,			/* Latch for accessible IP list table */
   CSECT_PARTITION_CACHE,	/* Latch for partitions cache */
   CSECT_EVENT_LOG_FILE,		/* Latch for event log file */
-  CSECT_CONN_ACTIVE,		/* Latch for Active conn list */
-  CSECT_CONN_FREE,		/* Latch for Free conn list */
   CSECT_TEMPFILE_CACHE,		/* Latch for temp file cache */
   CSECT_LOG_ARCHIVE,		/* Latch for log_Gl.archive */
   CSECT_ACCESS_STATUS,		/* Latch for user access status */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20407

replaces CSECT_CONN_ACTIVE and CSECT_CONN_FREE with CSS_RWLOCK_ACTIVE_CONN_ANCHOR and CSS_RWLOCK_FREE_CONN_ANCHOR for each.
