### PR TITLE
[CBRD-20411] fixes file_allocset_compact_page_table to set page as di…

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -9179,6 +9179,7 @@ file_allocset_compact_page_table (THREAD_ENTRY * thread_p, PAGE_PTR fhdr_pgptr, 
   addr.offset = to_start_offset;
   log_append_undo_data (thread_p, RVFL_IDSTABLE, &addr, CAST_BUFLEN (((char *) to_outptr - (char *) to_aid_ptr)),
 			to_aid_ptr);
+  pgbuf_set_dirty (thread_p, to_pgptr, DONT_FREE);	/* to make it sure */
   length = 0;
 
   while (!VPID_EQ (&from_vpid, &allocset->end_pages_vpid) || from_aid_ptr <= from_outptr)
@@ -9285,6 +9286,7 @@ file_allocset_compact_page_table (THREAD_ENTRY * thread_p, PAGE_PTR fhdr_pgptr, 
 	  addr.offset = to_start_offset;
 	  log_append_undo_data (thread_p, RVFL_IDSTABLE, &addr, CAST_BUFLEN ((char *) to_outptr - (char *) to_aid_ptr),
 				to_aid_ptr);
+	  pgbuf_set_dirty (thread_p, to_pgptr, DONT_FREE);	/* to make it sure */
 	  length = 0;
 	}
 


### PR DESCRIPTION
…rty when it tries to compact an allocset to make everything sure.

http://jira.cubrid.org/browse/CBRD-20411

To compact an allocset may leave it as it was. Since the logic writes an undo log from the beginning, it is better to make the page as dirty when it logs. 
