### PR TITLE
[CBRD-20415] misc fixes for performance

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -394,7 +394,7 @@ static void mnt_server_calc_stats (MNT_SERVER_EXEC_STATS * stats);
 static void mnt_server_check_stats_threshold (int tran_index, MNT_SERVER_EXEC_STATS * stats);
 
 static const char *perf_stat_module_name (const int module);
-static int perf_get_module_type (THREAD_ENTRY * thread_p);
+static INLINE int perf_get_module_type (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
 static const char *perf_stat_page_type_name (const int page_type);
 static const char *perf_stat_page_mode_name (const int page_mode);
 static const char *perf_stat_holder_latch_name (const int holder_latch);
@@ -5526,12 +5526,13 @@ perf_stat_module_name (const int module)
 /*
  * perf_get_module_type () -
  */
-static int
+STATIC_INLINE int
 perf_get_module_type (THREAD_ENTRY * thread_p)
 {
   int thread_index;
   int module_type;
-  int first_vacuum_worker_idx;
+  static int first_vacuum_worker_idx = 0;
+  static int num_worker_threads = 0;
 
 #if defined (SERVER_MODE)
   if (thread_p == NULL)
@@ -5540,13 +5541,21 @@ perf_get_module_type (THREAD_ENTRY * thread_p)
     }
 
   thread_index = thread_p->index;
-  first_vacuum_worker_idx = thread_first_vacuum_worker_thread_index ();
+
+  if (first_vacuum_worker_idx == 0)
+    {
+      first_vacuum_worker_idx = thread_first_vacuum_worker_thread_index ();
+    }
+  if (num_worker_threads == 0)
+    {
+      num_worker_threads = thread_num_worker_threads ();
+    }
 #else
   thread_index = 0;
   first_vacuum_worker_idx = 100;
 #endif
 
-  if (thread_index >= 1 && thread_index <= thread_num_worker_threads ())
+  if (thread_index >= 1 && thread_index <= num_worker_threads)
     {
       module_type = PERF_MODULE_USER;
     }

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -600,8 +600,8 @@ static int tp_domain_match_internal (const TP_DOMAIN * dom1, const TP_DOMAIN * d
 #if defined(CUBRID_DEBUG)
 static void fprint_domain (FILE * fp, TP_DOMAIN * domain);
 #endif
-static TP_DOMAIN **tp_domain_get_list_ptr (DB_TYPE type, TP_DOMAIN * setdomain);
-static TP_DOMAIN *tp_domain_get_list (DB_TYPE type, TP_DOMAIN * setdomain);
+static INLINE TP_DOMAIN **tp_domain_get_list_ptr (DB_TYPE type, TP_DOMAIN * setdomain) __attribute__ ((ALWAYS_INLINE));
+static INLINE TP_DOMAIN *tp_domain_get_list (DB_TYPE type, TP_DOMAIN * setdomain) __attribute__ ((ALWAYS_INLINE));
 
 static int tp_enumeration_match (const DB_ENUMERATION * db_enum1, const DB_ENUMERATION * db_enum2);
 static int tp_digit_number_str_to_bi (char *start, char *end, INTL_CODESET codeset, bool is_negative,
@@ -1854,7 +1854,7 @@ tp_domain_match_internal (const TP_DOMAIN * dom1, const TP_DOMAIN * dom2, TP_MAT
  *    type(in): type of value
  *    setdomain(in): used to find appropriate list of MIDXKEY
  */
-static TP_DOMAIN **
+STATIC_INLINE TP_DOMAIN **
 tp_domain_get_list_ptr (DB_TYPE type, TP_DOMAIN * setdomain)
 {
   int list_index;
@@ -1877,7 +1877,7 @@ tp_domain_get_list_ptr (DB_TYPE type, TP_DOMAIN * setdomain)
  *    type(in): type of value
  *    setdomain(in): used to find appropriate list of MIDXKEY
  */
-static TP_DOMAIN *
+STATIC_INLINE TP_DOMAIN *
 tp_domain_get_list (DB_TYPE type, TP_DOMAIN * setdomain)
 {
   TP_DOMAIN **dlist;
@@ -2618,10 +2618,10 @@ tp_domain_find_charbit (DB_TYPE type, int codeset, int collation_id, unsigned ch
    * DB_TYPE_CHAR    DB_TYPE_VARCHAR
    * DB_TYPE_BIT     DB_TYPE_VARBIT
    */
-  assert (type == DB_TYPE_NCHAR || type == DB_TYPE_VARNCHAR || type == DB_TYPE_CHAR || type == DB_TYPE_VARCHAR
+  assert (type == DB_TYPE_CHAR || type == DB_TYPE_VARCHAR || type == DB_TYPE_NCHAR || type == DB_TYPE_VARNCHAR
 	  || type == DB_TYPE_BIT || type == DB_TYPE_VARBIT);
 
-  if (type == DB_TYPE_VARNCHAR || type == DB_TYPE_VARCHAR || type == DB_TYPE_VARBIT)
+  if (type == DB_TYPE_VARCHAR || type == DB_TYPE_VARNCHAR || type == DB_TYPE_VARBIT)
     {
       /* search the list for a domain that matches */
       for (dom = tp_domain_get_list (type, NULL); dom != NULL; dom = dom->next_list)

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -5750,7 +5750,7 @@ btree_generate_prefix_domain (BTID_INT * btid)
   dbtype = TP_DOMAIN_TYPE (domain);
 
   /* varying domains did not come into use until btree revision level 1 */
-  if (!pr_is_variable_type (dbtype) && pr_is_string_type (dbtype))
+  if (dbtype == DB_TYPE_CHAR || dbtype == DB_TYPE_NCHAR || dbtype == DB_TYPE_BIT)
     {
       switch (dbtype)
 	{
@@ -5764,10 +5764,6 @@ btree_generate_prefix_domain (BTID_INT * btid)
 	  vartype = DB_TYPE_VARBIT;
 	  break;
 	default:
-	  assert (false);
-#if defined(CUBRID_DEBUG)
-	  printf ("Corrupt domain in btree_generate_prefix_domain\n");
-#endif /* CUBRID_DEBUG */
 	  return NULL;
 	}
 
@@ -19382,9 +19378,8 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
 	  return DB_UNK;
 	}
 
-      c =
-	pr_midxkey_compare (DB_GET_MIDXKEY (key1), DB_GET_MIDXKEY (key2), do_coercion, total_order, -1, start_colp,
-			    &dummy_size1, &dummy_size2, &dummy_diff_column, &dom_is_desc, &dummy_next_dom_is_desc);
+      c = pr_midxkey_compare (DB_GET_MIDXKEY (key1), DB_GET_MIDXKEY (key2), do_coercion, total_order, -1, start_colp,
+			      &dummy_size1, &dummy_size2, &dummy_diff_column, &dom_is_desc, &dummy_next_dom_is_desc);
       assert_release (c == DB_UNK || (DB_LT <= c && c <= DB_GT));
 
       if (dom_is_desc)

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -204,31 +204,6 @@ static int rv;
 /* default pages to flush in each interval during log checkpoint */
 #define PGBUF_CHKPT_BURST_PAGES 16
 
-#if defined(SERVER_MODE)
-
-#define MUTEX_LOCK_VIA_BUSY_WAIT(rv, m) \
-        do { \
-            int _loop; \
-            rv = EBUSY; \
-            for (_loop = 0; \
-		 _loop < \
-		 prm_get_integer_value (PRM_ID_MUTEX_BUSY_WAITING_CNT); \
-		 _loop++) \
-	      { \
-                rv = pthread_mutex_trylock (&(m)); \
-                if (rv == 0) { \
-                    rv = NO_ERROR; \
-                    break; \
-              } \
-            } \
-            if (rv != 0) { \
-                rv = pthread_mutex_lock (&m); \
-            } \
-        } while (0)
-#else /* SERVER_MODE */
-#define MUTEX_LOCK_VIA_BUSY_WAIT(rv, m)
-#endif /* SERVER_MODE */
-
 #define INIT_HOLDER_STAT(perf_stat) \
         do { \
             (perf_stat)->dirty_before_hold = 0; \
@@ -2409,7 +2384,8 @@ pgbuf_invalidate (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
   CAST_PGPTR_TO_BFPTR (bufptr, pgptr);
   assert (!VPID_ISNULL (&bufptr->vpid));
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
+
   /* 
    * This function is called by the caller while it is fixing the page
    * with PGBUF_LATCH_WRITE mode in CUBRID environment. Therefore,
@@ -2467,7 +2443,7 @@ pgbuf_invalidate (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
   /* bufptr->BCB_mutex has been released in above function. */
 
   /* hold BCB_mutex again to invalidate the BCB */
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
   /* check if the page should be invalidated. */
   if (VPID_ISNULL (&bufptr->vpid) || !VPID_EQ (&temp_vpid, &bufptr->vpid) || bufptr->fcnt > 0
@@ -2612,7 +2588,7 @@ pgbuf_invalidate_all (THREAD_ENTRY * thread_p, VOLID volid)
 	  continue;
 	}
 
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+      rv = pthread_mutex_lock (&bufptr->BCB_mutex);
       if (VPID_ISNULL (&bufptr->vpid) || (volid != NULL_VOLID && volid != bufptr->vpid.volid) || bufptr->fcnt > 0)
 	{
 	  /* PGBUF_LATCH_READ/PGBUF_LATCH_WRITE */
@@ -2636,7 +2612,7 @@ pgbuf_invalidate_all (THREAD_ENTRY * thread_p, VOLID volid)
 	   * Since above function releases bufptr->BCB_mutex,
 	   * the caller must hold bufptr->BCB_mutex again to invalidate the BCB.
 	   */
-	  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+	  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
 	  /* check if page invalidation should be performed on the page */
 	  if (VPID_ISNULL (&bufptr->vpid) || !VPID_EQ (&temp_vpid, &bufptr->vpid)
@@ -2701,7 +2677,7 @@ pgbuf_flush (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, int free_page)
   assert (!VPID_ISNULL (&bufptr->vpid));
 
   /* the caller is holding a page latch with PGBUF_LATCH_WRITE mode. */
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
   if (bufptr->dirty == true)
     {
@@ -2768,7 +2744,7 @@ pgbuf_flush_with_wal (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
   assert (!VPID_ISNULL (&bufptr->vpid));
 
   /* In CUBRID, the caller is holding WRITE page latch */
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
   /* Flush the page only when it is dirty */
   if (bufptr->dirty == true)
@@ -2809,7 +2785,7 @@ pgbuf_flush_all_helper (THREAD_ENTRY * thread_p, VOLID volid, bool is_unfixed_on
 	  continue;
 	}
 
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+      rv = pthread_mutex_lock (&bufptr->BCB_mutex);
       /* flush condition check */
       if ((bufptr->dirty == false) || (is_unfixed_only && bufptr->fcnt > 0)
 	  || (volid != NULL_VOLID && volid != bufptr->vpid.volid))
@@ -2967,7 +2943,7 @@ pgbuf_get_victim_candidates_from_ain (int check_count)
   victim_list = pgbuf_Pool.victim_cand_list;
   victim_count = 0;
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, pgbuf_Pool.buf_AIN_list.Ain_mutex);
+  rv = pthread_mutex_lock (&pgbuf_Pool.buf_AIN_list.Ain_mutex);
   bufptr = pgbuf_Pool.buf_AIN_list.Ain_bottom;
 
   while ((bufptr != NULL) && (check_count > 0))
@@ -3016,7 +2992,7 @@ pgbuf_get_victim_candidates_from_lru (int check_count, int victim_count)
   do
     {
       i = check_count;
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, pgbuf_Pool.buf_LRU_list[lru_idx].LRU_mutex);
+      rv = pthread_mutex_lock (&pgbuf_Pool.buf_LRU_list[lru_idx].LRU_mutex);
       bufptr = pgbuf_Pool.buf_LRU_list[lru_idx].LRU_bottom;
 
       while ((bufptr != NULL) && (bufptr->zone != PGBUF_LRU_1_ZONE) && (i > 0))
@@ -3217,7 +3193,7 @@ pgbuf_flush_victim_candidate (THREAD_ENTRY * thread_p, float flush_ratio)
 
 	  bufptr = victim_cand_list[i].bufptr;
 
-	  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+	  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 	  /* flush condition check */
 	  if (!VPID_EQ (&bufptr->vpid, &victim_cand_list[i].vpid) || bufptr->dirty == false
 	      || (bufptr->zone != PGBUF_LRU_2_ZONE && bufptr->zone != PGBUF_AIN_ZONE)
@@ -3372,7 +3348,7 @@ pgbuf_flush_checkpoint (THREAD_ENTRY * thread_p, const LOG_LSA * flush_upto_lsa,
 	}
 
       bufptr = PGBUF_FIND_BCB_PTR (bufid);
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+      rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
       /* flush condition check */
       if (bufptr->dirty == false
@@ -3654,7 +3630,7 @@ pgbuf_flush_seq_list (THREAD_ENTRY * thread_p, PGBUF_SEQ_FLUSHER * seq_flusher, 
 	  flush_if_already_flushed = false;
 	}
 
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+      rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
       if (!VPID_EQ (&bufptr->vpid, &f_list[seq_flusher->flush_idx].vpid) || bufptr->dirty == false
 	  || (flush_if_already_flushed == false && !LSA_ISNULL (&bufptr->oldest_unflush_lsa)
@@ -3752,7 +3728,7 @@ pgbuf_flush_seq_list (THREAD_ENTRY * thread_p, PGBUF_SEQ_FLUSHER * seq_flusher, 
 		      assert (pgptr_bufptr == bufptr);
 		    }
 #endif
-		  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+		  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
 		  /* get the smallest oldest_unflush_lsa */
 		  if (LSA_ISNULL (chkpt_smallest_lsa) || LSA_LT (&bufptr->oldest_unflush_lsa, chkpt_smallest_lsa))
@@ -3771,7 +3747,7 @@ pgbuf_flush_seq_list (THREAD_ENTRY * thread_p, PGBUF_SEQ_FLUSHER * seq_flusher, 
 		}
 	      else
 		{
-		  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+		  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 		  bufptr->avoid_victim = false;
 		  pthread_mutex_unlock (&bufptr->BCB_mutex);
 
@@ -6313,7 +6289,7 @@ pgbuf_block_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LATCH_MODE r
 	  /* interrupt operation */
 	  THREAD_ENTRY *thrd_entry, *prev_thrd_entry = NULL;
 
-	  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+	  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 	  thrd_entry = bufptr->next_wait_thrd;
 
 	  while (thrd_entry != NULL)
@@ -6391,7 +6367,7 @@ pgbuf_timed_sleep_error_handling (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, T
   int rv;
 #endif /* SERVER_MODE */
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
   /* case 1 : empty waiting queue */
   if (bufptr->next_wait_thrd == NULL)
@@ -6796,7 +6772,7 @@ pgbuf_search_hash_chain (PGBUF_BUFFER_HASH * hash_anchor, const VPID * vpid)
   is_perf_tracking = mnt_is_perf_tracking (thread_p);
 #endif
 
-  mbw_cnt = prm_get_integer_value (PRM_ID_MUTEX_BUSY_WAITING_CNT);
+  mbw_cnt = 0;
 
 /* one_phase: no hash-chain mutex */
 one_phase:
@@ -7751,7 +7727,7 @@ pgbuf_get_bcb_from_invalid_list (void)
       pgbuf_Pool.buf_invalid_list.invalid_cnt -= 1;
       pthread_mutex_unlock (&pgbuf_Pool.buf_invalid_list.invalid_mutex);
 
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+      rv = pthread_mutex_lock (&bufptr->BCB_mutex);
       bufptr->next_BCB = NULL;
       bufptr->zone = PGBUF_VOID_ZONE;
       return bufptr;
@@ -7861,7 +7837,7 @@ pgbuf_get_victim_from_ain_list (THREAD_ENTRY * thread_p, int max_count)
 
   assert (PGBUF_IS_2Q_ENABLED);
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, ain_list->Ain_mutex);
+  rv = pthread_mutex_lock (&ain_list->Ain_mutex);
   if (ain_list->Ain_bottom == NULL)
     {
       pthread_mutex_unlock (&ain_list->Ain_mutex);
@@ -7915,7 +7891,7 @@ pgbuf_get_victim_from_ain_list (THREAD_ENTRY * thread_p, int max_count)
 	}
     }
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
   /* Since this is the first time we actually get exclusive access to this bufptr, we have to reevaluate our choice */
   if (bufptr->dirty == true || bufptr->avoid_victim == true || bufptr->fcnt != 0 || bufptr->latch_mode != PGBUF_NO_LATCH
@@ -7930,7 +7906,7 @@ pgbuf_get_victim_from_ain_list (THREAD_ENTRY * thread_p, int max_count)
     }
   else
     {
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, ain_list->Ain_mutex);
+      rv = pthread_mutex_lock (&ain_list->Ain_mutex);
       pgbuf_remove_from_ain_list (bufptr);
       ain_list->ain_count -= 1;
       pthread_mutex_unlock (&ain_list->Ain_mutex);
@@ -7984,7 +7960,7 @@ pgbuf_get_victim_from_lru_list (THREAD_ENTRY * thread_p, const VPID * vpid, int 
   found = false;
   check_count = max_count;
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, lru_list->LRU_mutex);
+  rv = pthread_mutex_lock (&lru_list->LRU_mutex);
   bufptr = lru_list->LRU_bottom;
 
   /* search for non dirty PGBUF */
@@ -8025,7 +8001,7 @@ pgbuf_get_victim_from_lru_list (THREAD_ENTRY * thread_p, const VPID * vpid, int 
       return NULL;
     }
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
   if (bufptr->dirty == true || bufptr->avoid_victim == true || bufptr->zone != PGBUF_LRU_2_ZONE || bufptr->fcnt != 0
       || bufptr->latch_mode != PGBUF_NO_LATCH || pgbuf_is_exist_blocked_reader_writer_victim (bufptr) == true)
@@ -8037,7 +8013,7 @@ pgbuf_get_victim_from_lru_list (THREAD_ENTRY * thread_p, const VPID * vpid, int 
     }
   else
     {
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, lru_list->LRU_mutex);
+      rv = pthread_mutex_lock (&lru_list->LRU_mutex);
       /* disconnect bufptr from the LRU list */
       pgbuf_remove_from_lru_list (bufptr, lru_list);
       pthread_mutex_unlock (&lru_list->LRU_mutex);
@@ -8068,7 +8044,7 @@ pgbuf_invalidate_bcb_from_lru (PGBUF_BCB * bufptr)
 
   /* the caller is holding bufptr->BCB_mutex */
   /* delete the bufptr from the LRU list */
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, pgbuf_Pool.buf_LRU_list[lru_idx].LRU_mutex);
+  rv = pthread_mutex_lock (&pgbuf_Pool.buf_LRU_list[lru_idx].LRU_mutex);
 
   if (pgbuf_Pool.buf_LRU_list[lru_idx].LRU_top == bufptr)
     {
@@ -8123,7 +8099,7 @@ pgbuf_invalidate_bcb_from_ain (PGBUF_BCB * bufptr)
   PGBUF_AIN_LIST *ain_list;
   assert (bufptr->zone == PGBUF_AIN_ZONE);
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, pgbuf_Pool.buf_AIN_list.Ain_mutex);
+  rv = pthread_mutex_lock (&pgbuf_Pool.buf_AIN_list.Ain_mutex);
   ain_list = &pgbuf_Pool.buf_AIN_list;
   if (ain_list->Ain_top == bufptr)
     {
@@ -8174,7 +8150,7 @@ pgbuf_relocate_top_lru (PGBUF_BCB * bufptr, int dest_zone)
   lru_idx = pgbuf_get_lru_index (&bufptr->vpid);
 
   /* the caller is holding bufptr->BCB_mutex */
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, pgbuf_Pool.buf_LRU_list[lru_idx].LRU_mutex);
+  rv = pthread_mutex_lock (&pgbuf_Pool.buf_LRU_list[lru_idx].LRU_mutex);
 
   if (dest_zone == PGBUF_LRU_2_ZONE
       && (pgbuf_Pool.buf_LRU_list[lru_idx].LRU_bottom == NULL || pgbuf_Pool.buf_LRU_list[lru_idx].LRU_middle == NULL
@@ -8291,7 +8267,7 @@ pgbuf_relocate_bottom_lru (PGBUF_BCB * bufptr)
   lru_idx = pgbuf_get_lru_index (&bufptr->vpid);
 
   /* the caller is holding bufptr->BCB_mutex */
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, pgbuf_Pool.buf_LRU_list[lru_idx].LRU_mutex);
+  rv = pthread_mutex_lock (&pgbuf_Pool.buf_LRU_list[lru_idx].LRU_mutex);
 
   if (bufptr->zone == PGBUF_LRU_2_ZONE)
     {
@@ -8400,7 +8376,7 @@ pgbuf_relocate_top_ain (PGBUF_BCB * bufptr)
   /* Ain should only relocate to top new buffers */
   assert (bufptr->zone == PGBUF_VOID_ZONE || (bufptr->zone == PGBUF_AIN_ZONE && bufptr->dirty));
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, pgbuf_Pool.buf_AIN_list.Ain_mutex);
+  rv = pthread_mutex_lock (&pgbuf_Pool.buf_AIN_list.Ain_mutex);
 
   list = &pgbuf_Pool.buf_AIN_list;
 
@@ -8473,7 +8449,7 @@ pgbuf_move_from_ain_to_lru (PGBUF_BCB * bufptr)
   /* should only relocate dirty buffers from Ain */
   assert (bufptr->zone == PGBUF_AIN_ZONE);
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, pgbuf_Pool.buf_AIN_list.Ain_mutex);
+  rv = pthread_mutex_lock (&pgbuf_Pool.buf_AIN_list.Ain_mutex);
 
   list = &pgbuf_Pool.buf_AIN_list;
 
@@ -8550,7 +8526,7 @@ pgbuf_add_vpid_to_aout_list (THREAD_ENTRY * thread_p, const VPID * vpid)
 
   list = &pgbuf_Pool.buf_AOUT_list;
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, pgbuf_Pool.buf_AOUT_list.Aout_mutex);
+  rv = pthread_mutex_lock (&pgbuf_Pool.buf_AOUT_list.Aout_mutex);
 
   if (list->Aout_free == NULL)
     {
@@ -8637,7 +8613,7 @@ pgbuf_remove_vpid_from_aout_list (THREAD_ENTRY * thread_p, const VPID * vpid)
 
   /* Remove it from Aout. We were optimistic and assumed we will not find it. Unfortunately, after we get exclusive
    * access to Aout list, we have to search for it again because somebody else might have thrown it out. */
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, pgbuf_Pool.buf_AOUT_list.Aout_mutex);
+  rv = pthread_mutex_lock (&pgbuf_Pool.buf_AOUT_list.Aout_mutex);
   if (!VPID_EQ (&aout_buf->vpid, vpid))
     {
       /* Somebody else pushed our vpid out of the list. Search again */
@@ -8793,7 +8769,7 @@ pgbuf_flush_page_with_wal (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr)
   if (fileio_write (thread_p, fileio_get_volume_descriptor (bufptr->vpid.volid), iopage, bufptr->vpid.pageid,
 		    IO_PAGESIZE) == NULL)
     {
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+      rv = pthread_mutex_lock (&bufptr->BCB_mutex);
       PGBUF_SET_DIRTY (bufptr);
       LSA_COPY (&bufptr->oldest_unflush_lsa, &oldest_unflush_lsa);
 
@@ -8815,7 +8791,7 @@ pgbuf_flush_page_with_wal (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr)
 
   assert (bufptr->latch_mode != PGBUF_LATCH_VICTIM);
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
   bufptr->avoid_victim = false;
 
@@ -9028,7 +9004,7 @@ pgbuf_is_valid_page_ptr (const PAGE_PTR pgptr)
   for (bufid = 0; bufid < pgbuf_Pool.num_buffers; bufid++)
     {
       bufptr = PGBUF_FIND_BCB_PTR (bufid);
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+      rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
       if (((PAGE_PTR) (&(bufptr->iopage_buffer->iopage.page[0]))) == pgptr)
 	{
@@ -9253,7 +9229,7 @@ pgbuf_dump_if_any_fixed (void)
   for (bufid = 0; bufid < pgbuf_Pool.num_buffers; bufid++)
     {
       bufptr = PGBUF_FIND_BCB_PTR (bufid);
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+      rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
       if (bufptr->latch_mode != PGBUF_LATCH_INVALID && bufptr->fcnt > 0)
 	{
@@ -9329,7 +9305,7 @@ pgbuf_dump (void)
   for (bufid = 0; bufid < pgbuf_Pool.num_buffers; bufid++)
     {
       bufptr = PGBUF_FIND_BCB_PTR (bufid);
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+      rv = pthread_mutex_lock (&bufptr->BCB_mutex);
 
       if (bufptr->fcnt > 0)
 	{
@@ -10367,7 +10343,7 @@ pgbuf_flush_neighbor_safe (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, VPID * e
 
   *flushed = false;
 
-  MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+  rv = pthread_mutex_lock (&bufptr->BCB_mutex);
   if (!VPID_EQ (&bufptr->vpid, expected_vpid))
     {
       pthread_mutex_unlock (&bufptr->BCB_mutex);
@@ -10416,7 +10392,7 @@ pgbuf_flush_neighbor_safe (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, VPID * e
 	  error = ER_FAILED;
 	}
 
-      MUTEX_LOCK_VIA_BUSY_WAIT (rv, bufptr->BCB_mutex);
+      rv = pthread_mutex_lock (&bufptr->BCB_mutex);
       bufptr->avoid_victim = false;
       pthread_mutex_unlock (&bufptr->BCB_mutex);
 

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -58,13 +58,17 @@ static int rv;
 #define SPAGE_SEARCH_NEXT       1
 #define SPAGE_SEARCH_PREV       -1
 
+static PGLENGTH spage_User_page_size;
+
+#define SPAGE_DB_PAGESIZE (spage_User_page_size != 0 ? spage_User_page_size : db_page_size ())
+
 #define SPAGE_VERIFY_HEADER(sphdr) 				\
   do {								\
     assert ((sphdr) != NULL);					\
     assert ((sphdr)->total_free >= 0);				\
     assert ((sphdr)->cont_free >= 0);				\
     assert ((sphdr)->cont_free <= (sphdr)->total_free);		\
-    assert ((sphdr)->offset_to_free_area < DB_PAGESIZE);	\
+    assert ((sphdr)->offset_to_free_area < SPAGE_DB_PAGESIZE);	\
     assert ((sphdr)->num_records >= 0);				\
     assert ((sphdr)->num_slots >= 0);				\
     assert ((sphdr)->num_records <= (sphdr)->num_slots);	\
@@ -100,7 +104,7 @@ struct spage_save_head
   SPAGE_SAVE_ENTRY *first;	/* First saving space entry */
 };
 
-#define SPAGE_OVERFLOW(offset) ((int) (offset) > DB_PAGESIZE)
+#define SPAGE_OVERFLOW(offset) ((int) (offset) > SPAGE_DB_PAGESIZE)
 
 /*
  * Savings hash table
@@ -309,7 +313,7 @@ spage_verify_header (PAGE_PTR page_p)
 
   sphdr = (SPAGE_HEADER *) page_p;
   if (sphdr == NULL || sphdr->total_free < 0 || sphdr->cont_free < 0 || sphdr->cont_free > sphdr->total_free
-      || sphdr->offset_to_free_area >= DB_PAGESIZE
+      || sphdr->offset_to_free_area >= SPAGE_DB_PAGESIZE
       || (PTR_ALIGN (page_p + sphdr->offset_to_free_area, sphdr->alignment) != page_p + sphdr->offset_to_free_area)
       || sphdr->num_records < 0 || sphdr->num_slots < 0 || sphdr->num_records > sphdr->num_slots)
     {
@@ -794,6 +798,8 @@ spage_boot (THREAD_ENTRY * thread_p)
   assert (sizeof (SPAGE_HEADER) % DOUBLE_ALIGNMENT == 0);
   assert (sizeof (SPAGE_SLOT) == INT_ALIGNMENT);
 
+  spage_User_page_size = db_page_size ();
+
   /* initialize freelist */
   r = lf_freelist_init (&spage_saving_freelist, 100, 100, &spage_saving_entry_descriptor, &spage_saving_Ts);
   if (r != NO_ERROR)
@@ -856,7 +862,7 @@ spage_header_size (void)
 int
 spage_max_record_size (void)
 {
-  return DB_PAGESIZE - sizeof (SPAGE_HEADER) - sizeof (SPAGE_SLOT);
+  return SPAGE_DB_PAGESIZE - sizeof (SPAGE_HEADER) - sizeof (SPAGE_SLOT);
 }
 
 /*
@@ -1068,7 +1074,7 @@ spage_collect_statistics (PAGE_PTR page_p, int *npages, int *nrecords, int *rec_
       if (slot_p->record_type == REC_BIGONE)
 	{
 	  pages += 2;
-	  length += (DB_PAGESIZE * 2);	/* Assume two pages */
+	  length += (SPAGE_DB_PAGESIZE * 2);	/* Assume two pages */
 	}
 
       if (slot_p->record_type != REC_NEWHOME)
@@ -1125,7 +1131,7 @@ spage_initialize (THREAD_ENTRY * thread_p, PAGE_PTR page_p, INT16 slot_type, uns
   page_header_p->reserved1 = 0;
 
   page_header_p->anchor_type = slot_type;
-  page_header_p->total_free = DB_ALIGN (DB_PAGESIZE - sizeof (SPAGE_HEADER), alignment);
+  page_header_p->total_free = DB_ALIGN (SPAGE_DB_PAGESIZE - sizeof (SPAGE_HEADER), alignment);
 
   page_header_p->cont_free = page_header_p->total_free;
   page_header_p->offset_to_free_area = DB_ALIGN (sizeof (SPAGE_HEADER), alignment);
@@ -1263,7 +1269,7 @@ spage_compact (PAGE_PTR page_p)
 	  else
 	    {
 	      /* Move the record */
-	      if ((unsigned int) to_offset + slot_array[i]->record_length > (unsigned int) DB_PAGESIZE)
+	      if ((unsigned int) to_offset + slot_array[i]->record_length > (unsigned int) SPAGE_DB_PAGESIZE)
 		{
 		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 		  assert_release (false);
@@ -1285,7 +1291,7 @@ spage_compact (PAGE_PTR page_p)
 
   /* Make sure that the next inserted record will be aligned */
   to_offset = DB_ALIGN (to_offset, page_header_p->alignment);
-  page_header_p->total_free = (DB_PAGESIZE - to_offset - (page_header_p->num_slots * sizeof (SPAGE_SLOT)));
+  page_header_p->total_free = (SPAGE_DB_PAGESIZE - to_offset - (page_header_p->num_slots * sizeof (SPAGE_SLOT)));
   page_header_p->cont_free = page_header_p->total_free;
 
   page_header_p->offset_to_free_area = to_offset;
@@ -1868,7 +1874,7 @@ spage_insert_data (THREAD_ENTRY * thread_p, PAGE_PTR page_p, RECDES * record_des
   tmp_slot_p = (SPAGE_SLOT *) slot_p;
   if (record_descriptor_p->type != REC_ASSIGN_ADDRESS)
     {
-      if ((unsigned int) tmp_slot_p->offset_to_record + record_descriptor_p->length > (unsigned int) DB_PAGESIZE)
+      if ((unsigned int) tmp_slot_p->offset_to_record + record_descriptor_p->length > (unsigned int) SPAGE_DB_PAGESIZE)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  assert_release (false);
@@ -1879,7 +1885,7 @@ spage_insert_data (THREAD_ENTRY * thread_p, PAGE_PTR page_p, RECDES * record_des
     }
   else
     {
-      if (tmp_slot_p->offset_to_record + SSIZEOF (TRANID) > (unsigned int) DB_PAGESIZE)
+      if (tmp_slot_p->offset_to_record + SSIZEOF (TRANID) > (unsigned int) SPAGE_DB_PAGESIZE)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  assert_release (false);
@@ -2526,7 +2532,7 @@ spage_update_record_after_compact (PAGE_PTR page_p, SPAGE_HEADER * page_header_p
 
   /* Now update the record */
   spage_set_slot (slot_p, page_header_p->offset_to_free_area, record_descriptor_p->length, slot_p->record_type);
-  if (page_header_p->offset_to_free_area + record_descriptor_p->length > DB_PAGESIZE)
+  if (page_header_p->offset_to_free_area + record_descriptor_p->length > SPAGE_DB_PAGESIZE)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       assert_release (false);
@@ -3234,7 +3240,7 @@ spage_put_helper (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slot_id, in
 	}
       else
 	{
-	  if (page_header_p->offset_to_free_area + offset > DB_PAGESIZE)
+	  if (page_header_p->offset_to_free_area + offset > SPAGE_DB_PAGESIZE)
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	      assert_release (false);
@@ -3325,7 +3331,7 @@ spage_put_helper (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slot_id, in
 	}
       else
 	{
-	  if (page_header_p->offset_to_free_area + offset > DB_PAGESIZE)
+	  if (page_header_p->offset_to_free_area + offset > SPAGE_DB_PAGESIZE)
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	      assert_release (false);
@@ -3351,7 +3357,7 @@ spage_put_helper (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slot_id, in
   /* Now perform the put operation. */
   if (is_append)
     {
-      if (page_header_p->offset_to_free_area + record_descriptor_p->length > DB_PAGESIZE)
+      if (page_header_p->offset_to_free_area + record_descriptor_p->length > SPAGE_DB_PAGESIZE)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  assert_release (false);
@@ -4420,13 +4426,13 @@ spage_check (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
     }
   assert (page_header_p->num_records == nrecs);
 
-  if (used_length + page_header_p->total_free > DB_PAGESIZE)
+  if (used_length + page_header_p->total_free > SPAGE_DB_PAGESIZE)
     {
       snprintf (err_msg, sizeof (err_msg),
 		"spage_check: Inconsistent page = %d of volume = %s.\n"
-		"(Used_space + tfree > DB_PAGESIZE\n (%d + %d) > %d \n  %d > %d\n", pgbuf_get_page_id (page_p),
-		pgbuf_get_volume_label (page_p), used_length, page_header_p->total_free, DB_PAGESIZE,
-		used_length + page_header_p->total_free, DB_PAGESIZE);
+		"(Used_space + tfree > SPAGE_DB_PAGESIZE\n (%d + %d) > %d \n  %d > %d\n", pgbuf_get_page_id (page_p),
+		pgbuf_get_volume_label (page_p), used_length, page_header_p->total_free, SPAGE_DB_PAGESIZE,
+		used_length + page_header_p->total_free, SPAGE_DB_PAGESIZE);
 
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_INVALID_HEADER, 3, pgbuf_get_page_id (page_p),
 	      pgbuf_get_volume_label (page_p), err_msg);
@@ -4436,16 +4442,16 @@ spage_check (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
     }
 
   if ((page_header_p->cont_free + page_header_p->offset_to_free_area +
-       SSIZEOF (SPAGE_SLOT) * page_header_p->num_slots) > DB_PAGESIZE)
+       SSIZEOF (SPAGE_SLOT) * page_header_p->num_slots) > SPAGE_DB_PAGESIZE)
     {
       snprintf (err_msg, sizeof (err_msg),
 		"spage_check: Inconsistent page = %d of volume = %s.\n"
 		" (cfree + foffset + SIZEOF(SPAGE_SLOT) * nslots) > "
-		" DB_PAGESIZE\n (%d + %d + (%d * %d)) > %d\n %d > %d\n", pgbuf_get_page_id (page_p),
+		" SPAGE_DB_PAGESIZE\n (%d + %d + (%d * %d)) > %d\n %d > %d\n", pgbuf_get_page_id (page_p),
 		pgbuf_get_volume_label (page_p), page_header_p->cont_free, page_header_p->offset_to_free_area,
-		sizeof (SPAGE_SLOT), page_header_p->num_slots, DB_PAGESIZE,
+		sizeof (SPAGE_SLOT), page_header_p->num_slots, SPAGE_DB_PAGESIZE,
 		(page_header_p->cont_free + page_header_p->offset_to_free_area
-		 + sizeof (SPAGE_SLOT) * page_header_p->num_slots), DB_PAGESIZE);
+		 + sizeof (SPAGE_SLOT) * page_header_p->num_slots), SPAGE_DB_PAGESIZE);
 
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_INVALID_HEADER, 3, pgbuf_get_page_id (page_p),
 	      pgbuf_get_volume_label (page_p), err_msg);
@@ -4557,7 +4563,7 @@ spage_is_unknown_slot (PGSLOTID slot_id, SPAGE_HEADER * page_header_p, SPAGE_SLO
   assert (slot_p != NULL);
   SPAGE_VERIFY_HEADER (page_header_p);
 
-  max_offset = DB_PAGESIZE - page_header_p->num_slots * sizeof (SPAGE_SLOT);
+  max_offset = SPAGE_DB_PAGESIZE - page_header_p->num_slots * sizeof (SPAGE_SLOT);
 
   assert_release (slot_p->offset_to_record >= sizeof (SPAGE_HEADER) || slot_p->offset_to_record == SPAGE_EMPTY_OFFSET);
   assert_release (slot_p->offset_to_record <= max_offset);
@@ -4583,7 +4589,7 @@ spage_find_slot (PAGE_PTR page_p, SPAGE_HEADER * page_header_p, PGSLOTID slot_id
   assert (page_p != NULL);
   SPAGE_VERIFY_HEADER (page_header_p);
 
-  slot_p = (SPAGE_SLOT *) (page_p + DB_PAGESIZE - sizeof (SPAGE_SLOT));
+  slot_p = (SPAGE_SLOT *) (page_p + SPAGE_DB_PAGESIZE - sizeof (SPAGE_SLOT));
   slot_p -= slot_id;
 
   if (is_unknown_slot_check)
@@ -5101,7 +5107,7 @@ spage_slots_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_
       goto exit_on_error;
     }
 
-  ctx->pgptr = (PAGE_PTR) db_private_alloc (thread_p, DB_PAGESIZE);
+  ctx->pgptr = (PAGE_PTR) db_private_alloc (thread_p, SPAGE_DB_PAGESIZE);
   if (ctx->pgptr == NULL)
     {
       assert (er_errid () != NO_ERROR);
@@ -5126,7 +5132,7 @@ spage_slots_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_
       goto exit_on_error;
     }
 
-  memcpy (ctx->pgptr, pgptr, DB_PAGESIZE);
+  memcpy (ctx->pgptr, pgptr, SPAGE_DB_PAGESIZE);
   pgbuf_unfix_and_init (thread_p, pgptr);
 
   header = (SPAGE_HEADER *) ctx->pgptr;
@@ -5254,7 +5260,7 @@ spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
   SPAGE_VERIFY_HEADER (page_header_p);
 
   /* estimated gain after compact is >= 5% of page */
-  if (page_header_p->total_free - page_header_p->cont_free >= DB_PAGESIZE / 20)
+  if (page_header_p->total_free - page_header_p->cont_free >= SPAGE_DB_PAGESIZE / 20)
     {
       return true;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20415

This includes fixes:
* replace `thread_num_worker_threads`/`thread_first_vacuum_worker_thread_index` calls from `perf_get_module_type with locals`
* force inlining `tp_domain_get_list`/`tp_domain_get_list_ptr`. misc change of `tp_domain_get_list`
* optimize `btree_generate_prefix_domain` function
* remove `MUTEX_LOCK_VIA_BUSY_WAIT`. `mutex_busy_waiting_cnt` is now obsoleted.
* introduce `SPAGE_DB_PAGESIZE` to replace `DB_PAGESIZE` calls.