### PR TITLE
[CBRD-20417] fixed to restore a non default sized database from its backup.

### DIFF
--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -60,7 +60,8 @@ static int rv;
 
 static PGLENGTH spage_User_page_size;
 
-#define SPAGE_DB_PAGESIZE (spage_User_page_size != 0 ? spage_User_page_size : db_page_size ())
+#define SPAGE_DB_PAGESIZE \
+  (spage_User_page_size != 0 ? assert (spage_User_page_size == db_page_size ()), spage_User_page_size : db_page_size ())
 
 #define SPAGE_VERIFY_HEADER(sphdr) 				\
   do {								\

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3432,17 +3432,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   /* Initialize the transaction table */
   logtb_define_trantable (thread_p, -1, -1);
 
-  error_code = spage_boot (thread_p);
-  if (error_code != NO_ERROR)
-    {
-      goto error;
-    }
-  error_code = heap_manager_initialize ();
-  if (error_code != NO_ERROR)
-    {
-      goto error;
-    }
-
   /* 
    * How to restart the system ?
    */
@@ -3462,6 +3451,17 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 	{
 	  goto error;
 	}
+    }
+
+  error_code = spage_boot (thread_p);
+  if (error_code != NO_ERROR)
+    {
+      goto error;
+    }
+  error_code = heap_manager_initialize ();
+  if (error_code != NO_ERROR)
+    {
+      goto error;
     }
 
   /* 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20417

It is a regression of #174.
Non default sized database will not be restarted from backup, because `spage_User_page_size` is bad. To start spage and heap file manager is delayed until restoring backup. 