### PR TITLE
[CBRD-20419] Fixing crashes cause by assert

### DIFF
--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -1408,7 +1408,7 @@ or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align)
       if (compressed_length >= charlen - 8)
 	{
 	  /* Compression failed */
-	  compressed_length = 0;
+	  compressed_length = -1;
 	}
 
       /* Store the compression size */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20419

Missed out that the `or_put_varchar_internal` function set the `compressed_length` to `0`, instead of `-1`. Decided to keep the assert just to check if there are any other cases that I might have missed out.