### PR TITLE
[CBRD-20421] Fixed bad set for compressed_length

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -11313,7 +11313,7 @@ mr_readval_string_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, 
 		}
 	      if (compressed_size <= 0)
 		{
-		  assert (compressed_size != 0);
+		  assert (compressed_size == 0);
 		  str_length = decompressed_size;
 		}
 	      else
@@ -14098,7 +14098,7 @@ mr_readval_varnchar_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain
 
 	      if (compressed_size <= 0)
 		{
-		  assert (compressed_size != 0);
+		  assert (compressed_size == 0);
 		  str_length = decompressed_size;
 		}
 	      else

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -97,7 +97,6 @@ static INLINE int or_mvcc_set_prev_version_lsa (OR_BUF * buf, MVCC_REC_HEADER * 
   __attribute__ ((ALWAYS_INLINE));
 static INLINE int or_mvcc_get_prev_version_lsa (OR_BUF * buf, int mvcc_flags, LOG_LSA * prev_version_lsa)
   __attribute__ ((ALWAYS_INLINE));
-static int or_get_varchar_uncompressed_length (OR_BUF * buf, int *rc);
 
 /*
  * classobj_get_prop - searches a property list for a value with the given name
@@ -1407,8 +1406,8 @@ or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align)
 
       if (compressed_length >= charlen - 8)
 	{
-	  /* Compression failed */
-	  compressed_length = -1;
+	  /* Compression successful but its length exceeds the original length of the string. */
+	  compressed_length = 0;
 	}
 
       /* Store the compression size */
@@ -1429,7 +1428,7 @@ or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align)
 	  goto cleanup;
 	}
 
-      if (compressed_length == -1)
+      if (compressed_length == 0)
 	{
 	  /* Compression failed. */
 	  /* Store the original string bytes */
@@ -8504,7 +8503,7 @@ htond (double from)
  *
  * return			  :   NO_ERROR or error_code.
  * buf(in)			  :   The buffer where the string is stored.
- * compressed_size(out)		  :   The compressed size of the string. Set to -1 if the string was not compressed.
+ * compressed_size(out)		  :   The compressed size of the string. Set to 0 if the string was not compressed.
  * decompressed_size(out)	  :   The uncompressed size of the string.
  */
 
@@ -8547,8 +8546,8 @@ or_get_varchar_compression_lengths (OR_BUF * buf, int *compressed_size, int *dec
     }
   else
     {
-      /* String was not compressed so we set compressed_size to -1 to know that no compression happened. */
-      *compressed_size = -1;
+      /* String was not compressed so we set compressed_size to 0 to know that no compression happened. */
+      *compressed_size = 0;
       *decompressed_size = size_prefix;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20421

In case of a failed compression due to `compressed_length >= original_size - 8`, `compressed_length` was set to `-1`. But `compressed_length` is an unsigned value so in this case everything would go wrong. Changed the `compressed_length` to be set to `0`, in case of such event.

It should also fix the memory leak issue since I think that would come from the assert that caught the error. Also I have switched the asserts to catch those that might be set bad.