### PR TITLE
[CBRD-20422] Fixed bad set to compression_length in mr_get_compression_length

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16345,7 +16345,7 @@ mr_get_compression_length (const char *string, int charlen)
       goto cleanup;
     }
 
-  if ((lzo_uint) length >= compressed_length + 8)
+  if ((lzo_uint) compressed_length < charlen - 8)
     {
       /* Compression successful */
       length = (int) compressed_length;

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16267,7 +16267,7 @@ mr_get_compression_length (char *string, int charlen)
       goto cleanup;
     }
 
-  if (length >= compressed_length + 8)
+  if (compressed_length < charlen - 8)
     {
       /* Compression successful */
       length = (int) compressed_length;

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16345,7 +16345,7 @@ mr_get_compression_length (const char *string, int charlen)
       goto cleanup;
     }
 
-  if ((lzo_uint) compressed_length < charlen - 8)
+  if (compressed_length < (lzo_uint) (charlen - 8))
     {
       /* Compression successful */
       length = (int) compressed_length;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20422

In or_put_varchar_internal we have set `compressed_length` to `0` when `compressed_length >= charlen - 8`. But in `mr_get_compression_length` it was set to return when `charlen >= compressed_length + 8` and it should be `charlen > compressed_length + 8`, or `compressed_length < charlen - 8`.