### PR TITLE
[CBRD-20340] Redesign the log page buffer.

### DIFF
--- a/contrib/gdb_debugging_scripts/log_records.gdb
+++ b/contrib/gdb_debugging_scripts/log_records.gdb
@@ -25,7 +25,10 @@ end
 #
 define logpb_get_page
   set $idx = $arg0 % log_Pb.num_buffers
-  set $arg1 = log_Pb.buffers[$idx]->logpage
+  set $arg1 = 0
+  if $idx == $arg0
+	set $arg1 = log_Pb.buffers[$idx]->logpage
+  end
 end
 
 

--- a/contrib/gdb_debugging_scripts/log_records.gdb
+++ b/contrib/gdb_debugging_scripts/log_records.gdb
@@ -6,14 +6,14 @@
 # Log page buffer section
 #
 
-# logpb_hash
+# logpb_index
 # $arg0 (in)  : LOG_PAGEID
 # $arg1 (out) : Hash value
 #
-# Get hash value for LOG_PAGEID in log page buffer hash
+# Get index value for LOG_PAGEID in log page buffer array
 #
-define logpb_hash
-  set $arg1 = $arg0 % log_Pb.ht->size
+define logpb_index
+  set $arg1 = $arg0 % log_Pb.num_buffers
 end
 
 # logpb_get_page
@@ -24,15 +24,8 @@ end
 # If page doesn't exist in cash, it will return 0
 #
 define logpb_get_page
-  set $hash = $arg0 % log_Pb.ht->size
-  set $hte = log_Pb.ht->table[$hash]
-  set $arg1 = 0
-  while $hte != 0
-    if *((LOG_PAGEID *) $hte->key) == $arg0
-      set $arg1 = &(((struct log_buffer *) ($hte->data))->logpage)
-      loop_break
-    end
-  end
+  set $idx = $arg0 % log_Pb.num_buffers
+  set $arg1 = log_Pb.buffers[$idx]->logpage
 end
 
 

--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -762,7 +762,7 @@
 #define ER_IO_BKUP_DATABASE_VOLUME_OR_FILE_EXPECTED -634
 
 #define ER_LOG_BUFFER_POOL_TOO_SMALL                -635
-#define ER_LOG_NBUFFERS_TOO_SMALL                   -636
+#define ER_LOG_NBUFFERS_TOO_SMALL                   -636	/* Obsolete */
 #define ER_LOG_FREEING_TOO_MUCH                     -637
 #define ER_LOG_FLUSHING_UNUPDATABLE                 -638
 #define ER_LOG_WRONG_FORCE_DELAYED                  -639

--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -761,7 +761,7 @@
 #define ER_IO_NOT_A_BACKUP_OF_GIVEN_DATABASE        -633
 #define ER_IO_BKUP_DATABASE_VOLUME_OR_FILE_EXPECTED -634
 
-#define ER_LOG_BUFFER_POOL_TOO_SMALL                -635
+#define ER_LOG_BUFFER_POOL_TOO_SMALL                -635	/* Obsolete */
 #define ER_LOG_NBUFFERS_TOO_SMALL                   -636	/* Obsolete */
 #define ER_LOG_FREEING_TOO_MUCH                     -637
 #define ER_LOG_FLUSHING_UNUPDATABLE                 -638
@@ -773,7 +773,7 @@
 #define ER_LOG_FATAL_ERROR                          -644
 #define ER_LOG_BADSTATE_FOR_CLIENT_UNDO_OR_POSTPONE -645	/* Obsolete */
 #define ER_LOG_MISSING_COMPENSATING_RECORD          -646
-#define ER_LOG_BKUP_DOESNOT_CORRESPOND              -647
+#define ER_LOG_BKUP_DOESNOT_CORRESPOND              -647	/* Obsolete */
 #define ER_LOG_BKUP_INCOMPATIBLE                    -648
 
 #define ER_INVALID_PRECISION                        -649

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -170,7 +170,6 @@ static int rv;
     PUT_STAT (RES, NEW, pb_victim_cand_cnt);				\
                                                                         \
     DIFF_METHOD (RES, NEW, OLD, log_num_fetches);                       \
-    DIFF_METHOD (RES, NEW, OLD, log_num_fetch_ioreads);                 \
     DIFF_METHOD (RES, NEW, OLD, log_num_ioreads);                       \
     DIFF_METHOD (RES, NEW, OLD, log_num_iowrites);                      \
     DIFF_METHOD (RES, NEW, OLD, log_num_appendrecs);                    \
@@ -1738,7 +1737,6 @@ static const char *mnt_Stats_name[MNT_SERVER_EXEC_STATS_COUNT] = {
   "Num_data_page_avoid_victim",
   "Num_data_page_victim_cand",
   "Num_log_page_fetches",
-  "Num_log_page_fetch_ioreads",
   "Num_log_page_ioreads",
   "Num_log_page_iowrites",
   "Num_log_append_records",
@@ -2603,22 +2601,6 @@ mnt_x_log_fetches (THREAD_ENTRY * thread_p)
     }
 }
 
-/*
- * mnt_x_log_fetch_ioreads - Increase log_num_fetch_ioreads counter of the
- *			     current transaction index
- *   return: none
- */
-void
-mnt_x_log_fetch_ioreads (THREAD_ENTRY * thread_p)
-{
-  MNT_SERVER_EXEC_STATS *stats;
-
-  stats = mnt_server_get_stats (thread_p);
-  if (stats != NULL)
-    {
-      ADD_STATS (stats, log_num_fetch_ioreads, 1);
-    }
-}
 
 /*
  * mnt_x_log_ioreads - Increase pb_num_ioreads counter of the current
@@ -5442,7 +5424,7 @@ mnt_server_calc_stats (MNT_SERVER_EXEC_STATS * stats)
 
   stats->log_hit_ratio =
     (stats->log_num_fetches ==
-     0) ? 0 : (stats->log_num_fetches - stats->log_num_fetch_ioreads) * 100 * 100 / stats->log_num_fetches;
+     0) ? 0 : (stats->log_num_fetches - stats->log_num_ioreads) * 100 * 100 / stats->log_num_fetches;
 
   stats->pb_page_lock_acquire_time_10usec = 100 * lock_time_usec / 1000;
   stats->pb_page_hold_acquire_time_10usec = 100 * hold_time_usec / 1000;

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -382,7 +382,6 @@ struct mnt_server_exec_stats
 
   /* Execution statistics for the log manager */
   UINT64 log_num_fetches;
-  UINT64 log_num_fetch_ioreads;
   UINT64 log_num_ioreads;
   UINT64 log_num_iowrites;
   UINT64 log_num_appendrecs;
@@ -593,7 +592,7 @@ struct mnt_server_exec_stats
   /* Other statistics (change MNT_COUNT_OF_SERVER_EXEC_CALC_STATS) */
   /* ((pb_num_fetches - pb_num_ioreads) x 100 / pb_num_fetches) x 100 */
   UINT64 pb_hit_ratio;
-  /* ((log_num_fetches - log_num_fetch_ioreads) x 100 / log_num_fetches) x 100 */
+  /* ((log_num_fetches - log_num_ioreads) x 100 / log_num_fetches) x 100 */
   UINT64 log_hit_ratio;
   /* ((fetches of vacuum - fetches of vacuum not found in PB) x 100 / fetches of vacuum) x 100 */
   UINT64 vacuum_data_hit_ratio;
@@ -942,8 +941,6 @@ extern int mnt_Num_tran_exec_stats;
  */
 #define mnt_log_fetches(thread_p) \
   if (mnt_Num_tran_exec_stats > 0) mnt_x_log_fetches(thread_p)
-#define mnt_log_fetch_ioreads(thread_p) \
-  if (mnt_Num_tran_exec_stats > 0) mnt_x_log_fetch_ioreads(thread_p)
 #define mnt_log_ioreads(thread_p) \
   if (mnt_Num_tran_exec_stats > 0) mnt_x_log_ioreads(thread_p)
 #define mnt_log_iowrites(thread_p, num_log_pages) \
@@ -1383,7 +1380,6 @@ extern void mnt_x_pb_victims (THREAD_ENTRY * thread_p);
 extern void mnt_x_pb_replacements (THREAD_ENTRY * thread_p);
 extern void mnt_x_pb_num_hash_anchor_waits (THREAD_ENTRY * thread_p, UINT64 time_amount);
 extern void mnt_x_log_fetches (THREAD_ENTRY * thread_p);
-extern void mnt_x_log_fetch_ioreads (THREAD_ENTRY * thread_p);
 extern void mnt_x_log_ioreads (THREAD_ENTRY * thread_p);
 extern void mnt_x_log_iowrites (THREAD_ENTRY * thread_p, int num_log_pages);
 extern void mnt_x_log_appendrecs (THREAD_ENTRY * thread_p);
@@ -1590,7 +1586,6 @@ extern void mnt_x_vac_worker_execute_time (THREAD_ENTRY * thread_p, UINT64 amoun
 #define mnt_pb_num_hash_anchor_waits(thread_p, time_amount)
 
 #define mnt_log_fetches(thread_p)
-#define mnt_log_fetch_ioreads(thread_p)
 #define mnt_log_ioreads(thread_p)
 #define mnt_log_iowrites(thread_p, num_log_pages)
 #define mnt_log_appendrecs(thread_p)

--- a/src/cm_common/cm_mem_cpu_stat.c
+++ b/src/cm_common/cm_mem_cpu_stat.c
@@ -1080,8 +1080,6 @@ static STATDUMP_PROP statdump_offset[] = {
   {"Num_data_page_victim_cand",
    offsetof (T_CM_DB_EXEC_STAT, pb_victim_cand_cnt)},
   {"Num_log_page_fetches", offsetof (T_CM_DB_EXEC_STAT, log_num_fetches)},
-  {"Num_log_page_fetch_ioreads",
-   offsetof (T_CM_DB_EXEC_STAT, log_num_fetch_ioreads)},
   {"Num_log_page_ioreads", offsetof (T_CM_DB_EXEC_STAT, log_num_ioreads)},
   {"Num_log_page_iowrites", offsetof (T_CM_DB_EXEC_STAT, log_num_iowrites)},
   {"Num_log_append_records",

--- a/src/cm_common/cm_stat.h
+++ b/src/cm_common/cm_stat.h
@@ -286,7 +286,6 @@ extern "C"
 
     /* Execution statistics for the log manager */
     unsigned int log_num_fetches;
-    unsigned int log_num_fetch_ioreads;
     unsigned int log_num_ioreads;
     unsigned int log_num_iowrites;
     unsigned int log_num_appendrecs;

--- a/src/communication/network.c
+++ b/src/communication/network.c
@@ -96,8 +96,6 @@ net_pack_stats (char *buf, MNT_SERVER_EXEC_STATS * stats)
   ptr += OR_INT64_SIZE;
   OR_PUT_INT64 (ptr, &(stats->log_num_fetches));
   ptr += OR_INT64_SIZE;
-  OR_PUT_INT64 (ptr, &(stats->log_num_fetch_ioreads));
-  ptr += OR_INT64_SIZE;
   OR_PUT_INT64 (ptr, &(stats->log_num_ioreads));
   ptr += OR_INT64_SIZE;
   OR_PUT_INT64 (ptr, &(stats->log_num_iowrites));
@@ -619,8 +617,6 @@ net_unpack_stats (char *buf, MNT_SERVER_EXEC_STATS * stats)
   OR_GET_INT64 (ptr, &(stats->pb_victim_cand_cnt));
   ptr += OR_INT64_SIZE;
   OR_GET_INT64 (ptr, &(stats->log_num_fetches));
-  ptr += OR_INT64_SIZE;
-  OR_GET_INT64 (ptr, &(stats->log_num_fetch_ioreads));
   ptr += OR_INT64_SIZE;
   OR_GET_INT64 (ptr, &(stats->log_num_ioreads));
   ptr += OR_INT64_SIZE;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -7435,10 +7435,10 @@ vacuum_notify_server_shutdown (void)
  *
  * return : Global oldest active MVCCID.
  */
-VACUUM_LOG_BLOCKID
+MVCCID
 vacuum_get_global_oldest_active_mvccid (void)
 {
-  return ATOMIC_LOAD_64 (&vacuum_Global_oldest_active_mvccid);
+  return vacuum_Global_oldest_active_mvccid;
 }
 
 /*

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5135,8 +5135,10 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	  if (log_page_p->hdr.logical_pageid != log_lsa.pageid)
 	    {
 	      /* Get log page. */
-	      if (logpb_fetch_page (thread_p, &log_lsa, LOG_CS_SAFE_READER, log_page_p) != NO_ERROR)
+	      error_code = logpb_fetch_page (thread_p, &log_lsa, LOG_CS_SAFE_READER, log_page_p);
+	      if (error_code != NO_ERROR)
 		{
+		  ASSERT_ERROR ();
 		  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_recover_lost_block_data");
 		  return ER_FAILED;
 		}
@@ -5186,8 +5188,10 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	{
 	  if (log_page_p->hdr.logical_pageid != log_lsa.pageid)
 	    {
-	      if (logpb_fetch_page (thread_p, &log_lsa, LOG_CS_SAFE_READER, log_page_p) != NO_ERROR)
+	      error_code = logpb_fetch_page (thread_p, &log_lsa, LOG_CS_SAFE_READER, log_page_p);
+	      if (error_code != NO_ERROR)
 		{
+		  ASSERT_ERROR ();
 		  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_recover_lost_block_data");
 		  return ER_FAILED;
 		}
@@ -6813,8 +6817,10 @@ vacuum_log_prefetch_vacuum_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * e
        i++, log_pageid++)
     {
       req_lsa.pageid = log_pageid;
-      if (logpb_fetch_page (thread_p, &req_lsa, LOG_CS_SAFE_READER, (LOG_PAGE *) log_page) != NO_ERROR)
+      error = logpb_fetch_page (thread_p, &req_lsa, LOG_CS_SAFE_READER, (LOG_PAGE *) log_page);
+      if (error != NO_ERROR)
 	{
+	  ASSERT_ERROR ();
 	  vacuum_er_log (VACUUM_ER_LOG_ERROR, "VACUUM ERROR : cannot prefetch log page %d", log_pageid);
 	  if (vacuum_Prefetch_log_mode == VACUUM_PREFETCH_LOG_MODE_MASTER)
 	    {
@@ -6889,9 +6895,10 @@ vacuum_copy_log_page (THREAD_ENTRY * thread_p, LOG_PAGEID log_pageid, BLOCK_LOG_
 
       req_lsa.pageid = log_pageid;
       req_lsa.offset = LOG_PAGESIZE;
-
-      if (logpb_fetch_page (thread_p, &req_lsa, LOG_CS_SAFE_READER, log_page_p) != NO_ERROR)
+      error = logpb_fetch_page (thread_p, &req_lsa, LOG_CS_SAFE_READER, log_page_p);
+      if (error != NO_ERROR)
 	{
+	  ASSERT_ERROR ();
 	  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_copy_log_page");
 	  error = ER_FAILED;
 	}

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -273,7 +273,7 @@ extern int vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npag
 			      VFID * dropped_files_vfid);
 extern void vacuum_finalize (THREAD_ENTRY * thread_p);
 extern int xvacuum (THREAD_ENTRY * thread_p);
-extern VACUUM_LOG_BLOCKID vacuum_get_global_oldest_active_mvccid (void);
+extern MVCCID vacuum_get_global_oldest_active_mvccid (void);
 #if defined (SERVER_MODE)
 extern void vacuum_master_start (THREAD_ENTRY * thread_p);
 extern void vacuum_start_new_job (THREAD_ENTRY * thread_p);

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -69,7 +69,6 @@ extern LF_TRAN_ENTRY thread_ts_decoy_entries[THREAD_TS_LAST];
 #define thread_get_thread_entry_info()  (NULL)
 #define thread_num_worker_threads()  (1)
 #define thread_num_total_threads()   (1)
-#define thread_get_current_entry_index() (0)
 #define thread_get_current_session_id() (db_Session_id)
 #define thread_set_check_interrupt(thread_p, flag) tran_set_check_interrupt (flag)
 #define thread_get_check_interrupt(thread_p) tran_get_check_interrupt ()

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -69,6 +69,7 @@ extern LF_TRAN_ENTRY thread_ts_decoy_entries[THREAD_TS_LAST];
 #define thread_get_thread_entry_info()  (NULL)
 #define thread_num_worker_threads()  (1)
 #define thread_num_total_threads()   (1)
+#define thread_get_current_entry_index() (0)
 #define thread_get_current_session_id() (db_Session_id)
 #define thread_set_check_interrupt(thread_p, flag) tran_set_check_interrupt (flag)
 #define thread_get_check_interrupt(thread_p) tran_get_check_interrupt ()

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1964,7 +1964,7 @@ extern void logpb_invalidate_pool (THREAD_ENTRY * thread_p);
 extern LOG_PAGE *logpb_create (THREAD_ENTRY * thread_p, LOG_PAGEID pageid);
 extern LOG_PAGE *log_pbfetch (LOG_PAGEID pageid);
 extern void logpb_set_dirty (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr);
-extern int logpb_flush_page (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, int free_page);
+extern int logpb_flush_page (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr);
 extern LOG_PAGEID logpb_get_page_id (LOG_PAGE * log_pgptr);
 extern int logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const char *prefix_logname,
 				    DKNPAGES npages, INT64 * db_creation);
@@ -1972,8 +1972,8 @@ extern LOG_PAGE *logpb_create_header_page (THREAD_ENTRY * thread_p);
 extern void logpb_fetch_header (THREAD_ENTRY * thread_p, LOG_HEADER * hdr);
 extern void logpb_fetch_header_with_buffer (THREAD_ENTRY * thread_p, LOG_HEADER * hdr, LOG_PAGE * log_pgptr);
 extern void logpb_flush_header (THREAD_ENTRY * thread_p);
-extern int logpb_fetch_page (THREAD_ENTRY * thread_p, LOG_LSA * req_lsa, LOG_CS_ACCESS_MODE access_mode,
-			     LOG_PAGE * log_pgptr);
+extern int logpb_fetch_page_with_buffer (THREAD_ENTRY * thread_p, LOG_LSA * req_lsa, LOG_CS_ACCESS_MODE access_mode,
+					 LOG_PAGE * log_pgptr);
 extern int logpb_copy_page_from_log_buffer (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE * log_pgptr);
 extern int logpb_copy_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE * log_pgptr);
 extern int logpb_read_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_ACCESS_MODE access_mode,

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1967,7 +1967,6 @@ extern void logpb_set_dirty (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, int 
 extern int logpb_flush_page (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, int free_page);
 extern void logpb_free_page (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr);
 extern LOG_PAGEID logpb_get_page_id (LOG_PAGE * log_pgptr);
-extern int logpb_print_hash_entry (FILE * outfp, const void *key, void *ent, void *ignore);
 extern int logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const char *prefix_logname,
 				    DKNPAGES npages, INT64 * db_creation);
 extern LOG_PAGE *logpb_create_header_page (THREAD_ENTRY * thread_p);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -602,7 +602,6 @@ struct log_append_info
   LOG_LSA nxio_lsa;		/* Lowest log sequence number which has not been written to disk (for WAL). */
   LOG_LSA prev_lsa;		/* Address of last append log record */
   LOG_PAGE *log_pgptr;		/* The log page which is fixed */
-  LOG_PAGE *delayed_free_log_pgptr;	/* Delay freeing a log append page */
 
 #if !defined(HAVE_ATOMIC_BUILTINS)
   pthread_mutex_t nxio_lsa_mutex;
@@ -619,8 +618,6 @@ struct log_append_info
     /* prev_lsa */                                            \
     {NULL_PAGEID, NULL_OFFSET},                               \
     /* log_pgptr */                                           \
-    NULL,                                                     \
-    /* delayed_free_log_pgptr */                              \
     NULL}
 #else
 #define LOG_APPEND_INFO_INITIALIZER                           \
@@ -632,8 +629,6 @@ struct log_append_info
     /* prev_lsa */                                            \
     {NULL_PAGEID, NULL_OFFSET},                               \
     /* log_pgptr */                                           \
-    NULL,                                                     \
-    /* delayed_free_log_pgptr */                              \
     NULL,                                                     \
     /* nxio_lsa_mutex */                                      \
     PTHREAD_MUTEX_INITIALIZER}

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1835,11 +1835,6 @@ typedef struct log_logging_stat
   /* time taken to use a page for logging */
   double use_append_page_sec;
 
-  /* total delayed page count */
-  unsigned long total_delayed_page_count;
-  /* last delayed page id */
-  LOG_PAGEID last_delayed_pageid;
-
   /* log buffer full count */
   unsigned long log_buffer_full_count;
   /* log buffer flush count by replacement */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1965,7 +1965,6 @@ extern LOG_PAGE *logpb_create (THREAD_ENTRY * thread_p, LOG_PAGEID pageid);
 extern LOG_PAGE *log_pbfetch (LOG_PAGEID pageid);
 extern void logpb_set_dirty (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, int free_page);
 extern int logpb_flush_page (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, int free_page);
-extern void logpb_free_page (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr);
 extern LOG_PAGEID logpb_get_page_id (LOG_PAGE * log_pgptr);
 extern int logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const char *prefix_logname,
 				    DKNPAGES npages, INT64 * db_creation);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1966,7 +1966,6 @@ extern LOG_PAGE *log_pbfetch (LOG_PAGEID pageid);
 extern void logpb_set_dirty (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, int free_page);
 extern int logpb_flush_page (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, int free_page);
 extern void logpb_free_page (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr);
-extern void logpb_free_without_mutex (LOG_PAGE * log_pgptr);
 extern LOG_PAGEID logpb_get_page_id (LOG_PAGE * log_pgptr);
 extern int logpb_print_hash_entry (FILE * outfp, const void *key, void *ent, void *ignore);
 extern int logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const char *prefix_logname,

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1963,7 +1963,7 @@ extern bool logpb_is_pool_initialized (void);
 extern void logpb_invalidate_pool (THREAD_ENTRY * thread_p);
 extern LOG_PAGE *logpb_create (THREAD_ENTRY * thread_p, LOG_PAGEID pageid);
 extern LOG_PAGE *log_pbfetch (LOG_PAGEID pageid);
-extern void logpb_set_dirty (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, int free_page);
+extern void logpb_set_dirty (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr);
 extern int logpb_flush_page (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, int free_page);
 extern LOG_PAGEID logpb_get_page_id (LOG_PAGE * log_pgptr);
 extern int logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const char *prefix_logname,

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1986,7 +1986,7 @@ extern PGLENGTH logpb_find_header_parameters (THREAD_ENTRY * thread_p, const cha
 					      const char *prefix_logname, PGLENGTH * io_page_size,
 					      PGLENGTH * log_page_size, INT64 * db_creation, float *db_compatibility,
 					      int *db_charset);
-extern LOG_PAGE *logpb_fetch_start_append_page (THREAD_ENTRY * thread_p);
+extern int logpb_fetch_start_append_page (THREAD_ENTRY * thread_p);
 extern LOG_PAGE *logpb_fetch_start_append_page_new (THREAD_ENTRY * thread_p);
 extern void logpb_flush_pages_direct (THREAD_ENTRY * thread_p);
 extern void logpb_flush_pages (THREAD_ENTRY * thread_p, LOG_LSA * flush_lsa);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1851,8 +1851,6 @@ typedef struct log_logging_stat
 
   /* log buffer full count */
   unsigned long log_buffer_full_count;
-  /* log buffer expand count */
-  unsigned long log_buffer_expand_count;
   /* log buffer flush count by replacement */
   unsigned long log_buffer_flush_count_by_replacement;
 

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1972,8 +1972,8 @@ extern LOG_PAGE *logpb_create_header_page (THREAD_ENTRY * thread_p);
 extern void logpb_fetch_header (THREAD_ENTRY * thread_p, LOG_HEADER * hdr);
 extern void logpb_fetch_header_with_buffer (THREAD_ENTRY * thread_p, LOG_HEADER * hdr, LOG_PAGE * log_pgptr);
 extern void logpb_flush_header (THREAD_ENTRY * thread_p);
-extern int logpb_fetch_page_with_buffer (THREAD_ENTRY * thread_p, LOG_LSA * req_lsa, LOG_CS_ACCESS_MODE access_mode,
-					 LOG_PAGE * log_pgptr);
+extern int logpb_fetch_page (THREAD_ENTRY * thread_p, LOG_LSA * req_lsa, LOG_CS_ACCESS_MODE access_mode,
+			     LOG_PAGE * log_pgptr);
 extern int logpb_copy_page_from_log_buffer (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE * log_pgptr);
 extern int logpb_copy_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE * log_pgptr);
 extern int logpb_read_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_ACCESS_MODE access_mode,

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -115,9 +115,6 @@
    || csect_check_own (thread_p, CSECT_LOG) >= 1)
 #define LOG_CS_OWN_WRITE_MODE(thread_p) \
   (csect_check_own (thread_p, CSECT_LOG) == 1)
-#define LOG_CS_OWN_READ_MODE(thread_p) \
-  (VACUUM_IS_PROCESS_LOG_FOR_VACUUM (thread_p) \
-   || csect_check_own (thread_p, CSECT_LOG) == 2)
 
 #define LOG_ARCHIVE_CS_OWN(thread_p) \
   (csect_check (thread_p, CSECT_LOG_ARCHIVE) >= 1)
@@ -129,7 +126,7 @@
 #else /* SERVER_MODE */
 #define LOG_CS_OWN(thread_p) (true)
 #define LOG_CS_OWN_WRITE_MODE(thread_p) (true)
-#define LOG_CS_OWN_READ_MODE(thread_p) (true)
+
 
 #define LOG_ARCHIVE_CS_OWN(thread_p) (true)
 #define LOG_ARCHIVE_CS_OWN_WRITE_MODE(thread_p) (true)

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -127,7 +127,6 @@
 #define LOG_CS_OWN(thread_p) (true)
 #define LOG_CS_OWN_WRITE_MODE(thread_p) (true)
 
-
 #define LOG_ARCHIVE_CS_OWN(thread_p) (true)
 #define LOG_ARCHIVE_CS_OWN_WRITE_MODE(thread_p) (true)
 #define LOG_ARCHIVE_CS_OWN_READ_MODE(thread_p) (true)

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1979,23 +1979,14 @@ extern LOG_PAGE *logpb_create_header_page (THREAD_ENTRY * thread_p);
 extern void logpb_fetch_header (THREAD_ENTRY * thread_p, LOG_HEADER * hdr);
 extern void logpb_fetch_header_with_buffer (THREAD_ENTRY * thread_p, LOG_HEADER * hdr, LOG_PAGE * log_pgptr);
 extern void logpb_flush_header (THREAD_ENTRY * thread_p);
-<<<<<<<HEAD
-  extern int logpb_fetch_page (THREAD_ENTRY * thread_p, LOG_LSA * req_lsa, LOG_CS_ACCESS_MODE access_mode,
-			       LOG_PAGE * log_pgptr);
+extern int logpb_fetch_page (THREAD_ENTRY * thread_p, LOG_LSA * req_lsa, LOG_CS_ACCESS_MODE access_mode,
+			     LOG_PAGE * log_pgptr);
 extern int logpb_copy_page_from_log_buffer (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE * log_pgptr);
 extern int logpb_copy_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE * log_pgptr);
 extern int logpb_read_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_ACCESS_MODE access_mode,
 				      LOG_PAGE * log_pgptr);
-== == == =
-  extern LOG_PAGE *logpb_fetch_page (THREAD_ENTRY * thread_p, LOG_LSA * req_lsa, LOG_CS_ACCESS_MODE access_mode,
-				     LOG_PAGE * log_pgptr);
-extern LOG_PAGE *logpb_copy_page_from_log_buffer (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE * log_pgptr);
-extern LOG_PAGE *logpb_copy_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE * log_pgptr);
-extern LOG_PAGE *logpb_read_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_ACCESS_MODE access_mode,
+extern int logpb_read_page_from_active_log (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, int num_pages,
 					    LOG_PAGE * log_pgptr);
->>>>>>>upstream / develop
-  extern int logpb_read_page_from_active_log (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, int num_pages,
-					      LOG_PAGE * log_pgptr);
 extern int logpb_write_page_to_disk (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, LOG_PAGEID logical_pageid);
 extern PGLENGTH logpb_find_header_parameters (THREAD_ENTRY * thread_p, const char *db_fullname, const char *logpath,
 					      const char *prefix_logname, PGLENGTH * io_page_size,

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -831,7 +831,7 @@ log_create_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const cha
   }
 #endif /* CUBRID_DEBUG */
 
-  error_code = logpb_flush_page (thread_p, loghdr_pgptr, DONT_FREE);
+  error_code = logpb_flush_page (thread_p, loghdr_pgptr);
   if (error_code != NO_ERROR)
     {
       goto error;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -850,14 +850,11 @@ log_create_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const cha
   }
 #endif /* CUBRID_DEBUG */
 
-  logpb_free_page (thread_p, loghdr_pgptr);
-
   /* logpb_flush_header(); */
 
   /* 
    * Free the append and header page and dismount the lg active volume
    */
-  logpb_free_page (thread_p, log_Gl.append.log_pgptr);
   log_Gl.append.log_pgptr = NULL;
 
   fileio_dismount (thread_p, log_Gl.append.vdes);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -807,7 +807,7 @@ log_create_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const cha
    * Flush the append page, so that the end of the log mark is written.
    * Then, free the page, same for the header page.
    */
-  logpb_set_dirty (thread_p, log_Gl.append.log_pgptr, DONT_FREE);
+  logpb_set_dirty (thread_p, log_Gl.append.log_pgptr);
   logpb_flush_pages_direct (thread_p);
 
   log_Gl.chkpt_every_npages = prm_get_integer_value (PRM_ID_LOG_CHECKPOINT_NPAGES);
@@ -815,7 +815,7 @@ log_create_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const cha
   /* Flush the log header */
 
   memcpy (loghdr_pgptr->area, &log_Gl.hdr, sizeof (log_Gl.hdr));
-  logpb_set_dirty (thread_p, loghdr_pgptr, DONT_FREE);
+  logpb_set_dirty (thread_p, loghdr_pgptr);
 
 #if defined(CUBRID_DEBUG)
   {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -794,7 +794,7 @@ log_create_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const cha
   log_Gl.append.vdes =
     fileio_format (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, npages,
 		   prm_get_bool_value (PRM_ID_LOG_SWEEP_CLEAN), true, false, LOG_PAGESIZE, 0, false);
-  if (log_Gl.append.vdes == NULL_VOLDES || logpb_fetch_start_append_page (thread_p) == NULL || loghdr_pgptr == NULL)
+  if (log_Gl.append.vdes == NULL_VOLDES || logpb_fetch_start_append_page (thread_p) != NO_ERROR || loghdr_pgptr == NULL)
     {
       goto error;
     }
@@ -1290,7 +1290,7 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
        * The system was shut down. There is nothing to recover.
        * Find the append page and start execution
        */
-      if (logpb_fetch_start_append_page (thread_p) == NULL)
+      if (logpb_fetch_start_append_page (thread_p) != NO_ERROR)
 	{
 	  error_code = ER_FAILED;
 	  goto error;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4012,7 +4012,8 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
    * append record as log end record. Flush and then check it back.
    */
 
-  if (log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid && log_Gl.append.prev_lsa.pageid != NULL_PAGEID)
+  if (log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid && log_Gl.append.prev_lsa.pageid != NULL_PAGEID
+      && log_Gl.append.prev_lsa.pageid >= 0)
     {
       /* 
        * Flush all log append records on such page except the current log

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4348,6 +4348,8 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	  error_code = ER_FAILED;
 	  goto error;
 	}
+
+      ++flush_page_count;
       log_Gl.append.delayed_free_log_pgptr = NULL;
     }
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4134,7 +4134,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
        */
       if (last_idxflush == -1)
 	{
-	  if (bufptr->dirty == true && bufptr->pageid == (flush_info->toflush[i])->hdr.logical_pageid)
+	  if (bufptr->dirty == true)
 	    {
 	      /* We have found the smallest dirty page */
 	      last_idxflush = i;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4012,7 +4012,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
    * append record as log end record. Flush and then check it back.
    */
 
-  if (log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid && log_Gl.append.prev_lsa.pageid != NULL_PAGEID)
+  if (log_Gl.append.delayed_free_log_pgptr != NULL)
     {
       /* 
        * Flush all log append records on such page except the current log
@@ -4030,7 +4030,6 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	  goto error;
 	}
 #endif /* CUBRID_DEBUG */
-      printf ("%d ", log_Gl.append.prev_lsa.pageid);
       first_append_log_page = logpb_locate_page (thread_p, log_Gl.append.prev_lsa.pageid, OLD_PAGE);
       tmp_eof = (LOG_RECORD_HEADER *) ((char *) first_append_log_page->area + log_Gl.append.prev_lsa.offset);
       save_record = *tmp_eof;
@@ -5135,7 +5134,7 @@ logpb_end_append (THREAD_ENTRY * thread_p, LOG_RECORD_HEADER * header)
 
   if (log_Gl.append.delayed_free_log_pgptr != NULL)
     {
-      assert (logpb_is_dirty (thread_p, log_Gl.append.delayed_free_log_pgptr));
+      // assert (logpb_is_dirty (thread_p, log_Gl.append.delayed_free_log_pgptr));
 
       logpb_set_dirty (thread_p, log_Gl.append.delayed_free_log_pgptr);
       log_Gl.append.delayed_free_log_pgptr = NULL;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -841,6 +841,7 @@ logpb_fix_page (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, PAGE_FETCH_MODE fetc
       assert (log_bufptr->pageid == pageid);
     }
   log_bufptr->fown = thread_index;
+  er_print_callstack (ARG_FILE_LINE, "Pageid %lld is fixed by %d", (long long) log_bufptr->pageid, log_bufptr->fown);	/* Remove me */
 
   mnt_log_fetches (thread_p);
   if (is_perf_tracking)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1690,7 +1690,7 @@ logpb_copy_page (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_ACCESS_MODE 
   else
     {
       er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_PAGE_CORRUPTED, 1, pageid);
-      return NULL;
+      return ER_LOG_PAGE_CORRUPTED;
     }
   if (log_bufptr->pageid == pageid)
     {

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -2299,8 +2299,6 @@ logpb_next_append_page (THREAD_ENTRY * thread_p, LOG_SETDIRTY current_setdirty)
 #if defined(CUBRID_DEBUG)
   {
     log_Stat.last_append_pageid = log_Gl.hdr.append_lsa.pageid;
-
-    log_Stat.last_delayed_pageid = NULL_PAGEID;
   }
 #endif /* CUBRID_DEBUG */
 
@@ -2350,12 +2348,10 @@ logpb_next_append_page (THREAD_ENTRY * thread_p, LOG_SETDIRTY current_setdirty)
 
 #if defined(CUBRID_DEBUG)
   er_log_debug (ARG_FILE_LINE,
-		"log_next_append_page: new page id(%lld) delayed page id(%lld) "
-		"total_append_page_count(%ld) total_delayed_page_count(%ld) "
-		" num_toflush(%d) use_append_page_sec(%f) need_flush(%d) "
-		"commit_count(%ld) total_commit_count(%ld)\n", (int) log_Stat.last_append_pageid,
-		(int) log_Stat.last_delayed_pageid, log_Stat.total_append_page_count,
-		log_Stat.total_delayed_page_count, flush_info->num_toflush, log_Stat.use_append_page_sec, need_flush,
+		"log_next_append_page: new page id(%lld) total_append_page_count(%ld)"
+		" num_toflush(%d) use_append_page_sec(%f) need_flush(%d) commit_count(%ld)"
+		" total_commit_count(%ld)\n", (int) log_Stat.last_append_pageid, log_Stat.total_append_page_count,
+		flush_info->num_toflush, log_Stat.use_append_page_sec, need_flush,
 		log_Stat.last_commit_count_while_using_a_page, log_Stat.total_commit_count_while_using_a_page);
 #endif /* CUBRID_DEBUG */
 }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -860,7 +860,7 @@ logpb_fix_page (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, PAGE_FETCH_MODE fetc
  *
  *   log_pgptr(in): Log page pointer
  *
- * NOTE:Mark the current log page as dirty and optionally free the page.
+ * NOTE:Mark the current log page as dirty.
  */
 void
 logpb_set_dirty (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr)
@@ -2274,17 +2274,7 @@ logpb_next_append_page (THREAD_ENTRY * thread_p, LOG_SETDIRTY current_setdirty)
       logpb_set_dirty (thread_p, log_Gl.append.log_pgptr);
     }
 
-  /* 
-   * If a log append page is already delayed. We can free the current page
-   * since it is not the first one. (i.e., end of log can be detected since
-   * previous page has not been released).
-   */
-
-  if (log_Gl.append.delayed_free_log_pgptr != NULL)
-    {
-      ;
-    }
-  else
+  if (log_Gl.append.delayed_free_log_pgptr == NULL)
     {
       /* 
        * We have not delayed freeing an append page. Therefore, the current

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4012,7 +4012,8 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
    * append record as log end record. Flush and then check it back.
    */
 
-  if (log_Gl.append.delayed_free_log_pgptr != NULL)
+  if (log_Gl.append.prev_lsa.pageid > -1 && log_Gl.hdr.append_lsa.pageid > -1 &&
+      log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid)
     {
       /* 
        * Flush all log append records on such page except the current log
@@ -4134,7 +4135,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
        */
       if (last_idxflush == -1)
 	{
-	  if (bufptr->dirty == true)
+	  if (bufptr->dirty == true && bufptr->pageid == flush_info->toflush[i]->hdr.logical_pageid)
 	    {
 	      /* We have found the smallest dirty page */
 	      last_idxflush = i;
@@ -5133,10 +5134,9 @@ logpb_end_append (THREAD_ENTRY * thread_p, LOG_RECORD_HEADER * header)
    */
   assert (LSA_EQ (&header->forw_lsa, &log_Gl.hdr.append_lsa));
 
-  if (log_Gl.append.delayed_free_log_pgptr != NULL)
+  if (log_Gl.append.prev_lsa.pageid > -1 && log_Gl.hdr.append_lsa.pageid > -1 &&
+      log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid)
     {
-      assert (logpb_is_dirty (thread_p, log_Gl.append.delayed_free_log_pgptr));
-
       logpb_set_dirty (thread_p, log_Gl.append.delayed_free_log_pgptr);
       log_Gl.append.delayed_free_log_pgptr = NULL;
     }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4012,7 +4012,8 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
    * append record as log end record. Flush and then check it back.
    */
 
-  if (log_Gl.append.delayed_free_log_pgptr != NULL)
+  if (log_Gl.append.prev_lsa.pageid > -1 && log_Gl.hdr.append_lsa.pageid > -1 &&
+      log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid)
     {
       /* 
        * Flush all log append records on such page except the current log

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1662,7 +1662,7 @@ logpb_flush_header (THREAD_ENTRY * thread_p)
  * return: NO_ERROR if everything is ok
  *
  *   pageid(in): Page identifier
- *   log_pgptr(in): Page buffer to copy
+ *   log_pgptr(in/out): Page buffer to copy
  *
  * NOTE:Fetch the log page identified by pageid into a log buffer and return such buffer.
  *              If there is the page in hash table, copy it to buffer and return it.
@@ -1728,6 +1728,8 @@ logpb_fetch_page (THREAD_ENTRY * thread_p, LOG_LSA * req_lsa, LOG_CS_ACCESS_MODE
  * logpb_copy_page_from_log_buffer -
  *
  * return: NO_ERROR if everything is ok
+ *  pageid(in): Page identifier
+ *  log_pgptr(in/out): Page buffer
  *
  */
 int
@@ -1745,7 +1747,8 @@ logpb_copy_page_from_log_buffer (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG
 
 /*
  * logpb_copy_page_from_file -
- *
+ *  pageid(in): Page identifier
+ *  log_pgptr(in/out): Page buffer
  * return: NO_ERROR if everything is ok
  *
  */
@@ -1776,7 +1779,7 @@ logpb_copy_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE 
  *
  *   pageid(in): Page identifier
  *   access_mode(in): access mode (reader, safe reader, writer)
- *   log_pgptr(in): Page buffer to copy
+ *   log_pgptr(in/out): Page buffer to copy
  *
  * NOTE:Fetch the log page identified by pageid into a log buffer and return such buffer.
  *              If there is the page in hash table, copy it to buffer and return it.
@@ -1885,7 +1888,7 @@ exit:
  * return: NO_ERROR if everything is ok
  *
  *   pageid(in): Page identifier
- *   log_pgptr(in): Page buffer to read
+ *   log_pgptr(in/out): Page buffer to read
  *
  * NOTE:read the log page identified by pageid into a buffer from from archive or active log.
  */
@@ -1992,11 +1995,11 @@ error:
 /*
  * logpb_read_page_from_active_log -
  *
- *   return:
+ *   return: new num_pages
  *
  *   pageid(in):
  *   num_pages(in):
- *   log_pgptr(out):
+ *   log_pgptr(in/out):
  */
 int
 logpb_read_page_from_active_log (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, int num_pages, LOG_PAGE * log_pgptr)
@@ -2038,7 +2041,7 @@ logpb_read_page_from_active_log (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, int
  *
  * return: error code
  *
- *   log_pgptr(in): Log page pointer
+ *   log_pgptr(in/out): Log page pointer
  *   logical_pageid(in): logical page id
  *
  * NOTE:writes and syncs a log page to disk

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -209,8 +209,8 @@ static int rv;
 typedef struct log_buffer LOG_BUFFER;
 struct log_buffer
 {
-  LOG_PAGEID pageid;		/* Logical page of the log. (Page identifier of the infinite log) */
-  LOG_PHY_PAGEID phy_pageid;	/* Physical pageid for the active log portion */
+  volatile LOG_PAGEID pageid;	/* Logical page of the log. (Page identifier of the infinite log) */
+  volatile LOG_PHY_PAGEID phy_pageid;	/* Physical pageid for the active log portion */
   bool dirty;			/* Is page dirty */
   LOG_PAGE *logpage;		/* The actual buffered log page */
 };

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -2041,7 +2041,7 @@ logpb_find_header_parameters (THREAD_ENTRY * thread_p, const char *db_fullname, 
 	    {
 	      goto error;
 	    }
-	  if (logpb_fetch_start_append_page (thread_p) == NULL)
+	  if (logpb_fetch_start_append_page (thread_p) != NO_ERROR)
 	    {
 	      goto error;
 	    }
@@ -2169,7 +2169,7 @@ error:
  *
  * NOTE:Fetch the start append page.
  */
-LOG_PAGE *
+int
 logpb_fetch_start_append_page (THREAD_ENTRY * thread_p)
 {
   PAGE_FETCH_MODE flag = OLD_PAGE;
@@ -2204,7 +2204,8 @@ logpb_fetch_start_append_page (THREAD_ENTRY * thread_p)
   log_Gl.append.log_pgptr = logpb_fix_page (thread_p, log_Gl.hdr.append_lsa.pageid, flag);
   if (log_Gl.append.log_pgptr == NULL)
     {
-      return NULL;
+      assert (false);
+      return ER_FAILED;
     }
 
   logpb_set_nxio_lsa (&log_Gl.hdr.append_lsa);
@@ -2235,8 +2236,8 @@ logpb_fetch_start_append_page (THREAD_ENTRY * thread_p)
     {
       logpb_flush_pages_direct (thread_p);
     }
-
-  return log_Gl.append.log_pgptr;
+  logpb_free_page (thread_p, log_Gl.append.log_pgptr);
+  return NO_ERROR;
 }
 
 /*
@@ -10323,7 +10324,7 @@ logpb_rename_all_volumes_files (THREAD_ENTRY * thread_p, VOLID num_perm_vols, co
 	{
 	  goto error;
 	}
-      if (logpb_fetch_start_append_page (thread_p) == NULL)
+      if (logpb_fetch_start_append_page (thread_p) != NO_ERROR)
 	{
 	  error_code = ER_FAILED;
 	  goto error;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -10275,7 +10275,7 @@ logpb_rename_all_volumes_files (THREAD_ENTRY * thread_p, VOLID num_perm_vols, co
 	{
 	  goto error;
 	}
-      if (logpb_fetch_start_append_page (thread_p) == NULL)
+      if (logpb_fetch_start_append_page (thread_p) != NO_ERROR)
 	{
 	  error_code = ER_FAILED;
 	  goto error;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4011,8 +4011,8 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
    * a new log record. Otherwise, we need to change the label of the last
    * append record as log end record. Flush and then check it back.
    */
-  if (log_Gl.append.prev_lsa.pageid > -1 && log_Gl.hdr.append_lsa.pageid > -1 &&
-      log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid)
+
+  if (log_Gl.append.delayed_free_log_pgptr != NULL)
     {
       /* 
        * Flush all log append records on such page except the current log
@@ -4134,7 +4134,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
        */
       if (last_idxflush == -1)
 	{
-	  if (bufptr->dirty == true)
+	  if (bufptr->dirty == true && bufptr->pageid == (flush_info->toflush[i])->hdr.logical_pageid)
 	    {
 	      /* We have found the smallest dirty page */
 	      last_idxflush = i;
@@ -5133,8 +5133,7 @@ logpb_end_append (THREAD_ENTRY * thread_p, LOG_RECORD_HEADER * header)
    */
   assert (LSA_EQ (&header->forw_lsa, &log_Gl.hdr.append_lsa));
 
-  if (log_Gl.append.prev_lsa.pageid > -1 && log_Gl.hdr.append_lsa.pageid > -1 &&
-      log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid)
+  if (log_Gl.append.delayed_free_log_pgptr != NULL)
     {
       assert (logpb_is_dirty (thread_p, log_Gl.append.delayed_free_log_pgptr));
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -428,7 +428,7 @@ logpb_get_log_buffer (LOG_PAGE * log_pg)
 static void
 logpb_unfix_page (LOG_BUFFER * bufptr)
 {
-  assert (bufptr->fown > -1);
+  assert (bufptr->fown == thread_get_current_entry_index ());
   bufptr->fown = -1;
 }
 
@@ -4000,7 +4000,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
        */
 
       bufptr = logpb_get_log_buffer (flush_info->toflush[0]);
-      assert (bufptr->fown > -1);
+      assert (bufptr->fown == thread_get_current_entry_index ());
       if (!logpb_is_dirty (thread_p, flush_info->toflush[0]))
 	{
 	  need_flush = false;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -429,6 +429,7 @@ static void
 logpb_unfix_page (LOG_BUFFER * bufptr)
 {
   assert (bufptr->fown == thread_get_current_entry_index ());
+  er_print_callstack (ARG_FILE_LINE, "Unfix pageid %d (from fown=%d)", (long long) bufptr->pageid, bufptr->fown);
   bufptr->fown = -1;
 }
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4012,7 +4012,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
    * append record as log end record. Flush and then check it back.
    */
 
-  if (log_Gl.append.delayed_free_log_pgptr != NULL)
+  if (log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid)
     {
       /* 
        * Flush all log append records on such page except the current log

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4012,8 +4012,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
    * append record as log end record. Flush and then check it back.
    */
 
-  if (log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid && log_Gl.append.prev_lsa.pageid != NULL_PAGEID
-      && log_Gl.append.prev_lsa.pageid >= 0)
+  if (log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid && log_Gl.append.prev_lsa.pageid != NULL_PAGEID)
     {
       /* 
        * Flush all log append records on such page except the current log
@@ -4031,6 +4030,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	  goto error;
 	}
 #endif /* CUBRID_DEBUG */
+      printf ("%d ", log_Gl.append.prev_lsa.pageid);
       first_append_log_page = logpb_locate_page (thread_p, log_Gl.append.prev_lsa.pageid, OLD_PAGE);
       tmp_eof = (LOG_RECORD_HEADER *) ((char *) first_append_log_page->area + log_Gl.append.prev_lsa.offset);
       save_record = *tmp_eof;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1659,7 +1659,7 @@ logpb_flush_header (THREAD_ENTRY * thread_p)
 /*
  * logpb_fetch_page - Fetch a exist_log page using local buffer
  *
- * return: NO_ERROR if everything is ok
+ * return: NO_ERROR if everything is ok, else ER_GENERIC_ERROR
  *
  *   pageid(in): Page identifier
  *   log_pgptr(in/out): Page buffer to copy

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4011,7 +4011,8 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
    * a new log record. Otherwise, we need to change the label of the last
    * append record as log end record. Flush and then check it back.
    */
-
+  printf ("%d %d %d %d\n", log_Gl.append.prev_lsa.pageid, log_Gl.hdr.append_lsa.pageid,
+	  logpb_get_page_id (log_Gl.append.delayed_free_log_pgptr), logpb_get_page_id (log_Gl.append.log_pgptr));
   if (log_Gl.append.prev_lsa.pageid > -1 && log_Gl.hdr.append_lsa.pageid > -1 &&
       log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid)
     {

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4012,7 +4012,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
    * append record as log end record. Flush and then check it back.
    */
 
-  if (log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid)
+  if (log_Gl.append.delayed_free_log_pgptr != NULL)
     {
       /* 
        * Flush all log append records on such page except the current log

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -428,7 +428,7 @@ logpb_get_log_buffer (LOG_PAGE * log_pg)
 static void
 logpb_unfix_page (LOG_BUFFER * bufptr)
 {
-  assert (bufptr->fown == thread_get_current_entry_index ());
+  assert (bufptr->fown > -1);
   bufptr->fown = -1;
 }
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -977,8 +977,6 @@ logpb_flush_page (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, int free_page)
   if (bufptr->pageid != LOGPB_HEADER_PAGE_ID
       && (bufptr->pageid < LOGPB_NEXT_ARCHIVE_PAGE_ID || bufptr->pageid > LOGPB_LAST_ACTIVE_PAGE_ID))
     {
-      /*END_EXCLUSIVE_ACCESS_LOG_PB (rv, thread_p); end without start- could be deleted */
-
       er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_LOG_FLUSHING_UNUPDATABLE, 1, bufptr->pageid);
       return ER_LOG_FLUSHING_UNUPDATABLE;
     }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4031,6 +4031,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	}
 #endif /* CUBRID_DEBUG */
       first_append_log_page = logpb_locate_page (thread_p, log_Gl.append.prev_lsa.pageid, OLD_PAGE);
+      log_Gl.append.delayed_free_log_pgptr = first_append_log_page;
       tmp_eof = (LOG_RECORD_HEADER *) ((char *) first_append_log_page->area + log_Gl.append.prev_lsa.offset);
       save_record = *tmp_eof;
 
@@ -5134,7 +5135,7 @@ logpb_end_append (THREAD_ENTRY * thread_p, LOG_RECORD_HEADER * header)
 
   if (log_Gl.append.delayed_free_log_pgptr != NULL)
     {
-      // assert (logpb_is_dirty (thread_p, log_Gl.append.delayed_free_log_pgptr));
+      assert (logpb_is_dirty (thread_p, log_Gl.append.delayed_free_log_pgptr));
 
       logpb_set_dirty (thread_p, log_Gl.append.delayed_free_log_pgptr);
       log_Gl.append.delayed_free_log_pgptr = NULL;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3962,8 +3962,8 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 
   /* 
    * Add an end of log marker to detect the end of the log.
-   * The marker should be added at the end of the log if there is no more
-   * than one page. That is, if we are not in the middle of appending
+   * The marker should be added at the end of the log if there is only
+   * one page to be flushed. That is, if we are not in the middle of appending
    * a new log record. Otherwise, we need to change the label of the last
    * append record as log end record. Flush and then check it back.
    */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3962,8 +3962,8 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 
   /* 
    * Add an end of log marker to detect the end of the log.
-   * The marker should be added at the end of the log if there is not any
-   * delayed free page. That is, if we are not in the middle of appending
+   * The marker should be added at the end of the log if there is not more
+   * than one page. That is, if we are not in the middle of appending
    * a new log record. Otherwise, we need to change the label of the last
    * append record as log end record. Flush and then check it back.
    */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4011,8 +4011,6 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
    * a new log record. Otherwise, we need to change the label of the last
    * append record as log end record. Flush and then check it back.
    */
-  printf ("%d %d %d %d\n", log_Gl.append.prev_lsa.pageid, log_Gl.hdr.append_lsa.pageid,
-	  logpb_get_page_id (log_Gl.append.delayed_free_log_pgptr), logpb_get_page_id (log_Gl.append.log_pgptr));
   if (log_Gl.append.prev_lsa.pageid > -1 && log_Gl.hdr.append_lsa.pageid > -1 &&
       log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid)
     {
@@ -5135,7 +5133,8 @@ logpb_end_append (THREAD_ENTRY * thread_p, LOG_RECORD_HEADER * header)
    */
   assert (LSA_EQ (&header->forw_lsa, &log_Gl.hdr.append_lsa));
 
-  if (log_Gl.append.delayed_free_log_pgptr != NULL)
+  if (log_Gl.append.prev_lsa.pageid > -1 && log_Gl.hdr.append_lsa.pageid > -1 &&
+      log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid)
     {
       assert (logpb_is_dirty (thread_p, log_Gl.append.delayed_free_log_pgptr));
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1591,6 +1591,7 @@ logpb_copy_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE 
       rv = logpb_read_page_from_file (thread_p, pageid, LOG_CS_FORCE_USE, log_pgptr);
       if (rv != NO_ERROR || log_pgptr == NULL)
 	{
+	  LOG_CS_EXIT (thread_p);
 	  return ER_FAILED;
 	}
     }
@@ -1914,7 +1915,9 @@ logpb_write_page_to_disk (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, LOG_PAG
       return ER_FAILED;
     }
   if (log_pgptr == NULL)
-    return ER_FAILED;
+    {
+      return ER_FAILED;
+    }
   return NO_ERROR;
 }
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -372,7 +372,7 @@ static void logpb_set_nxio_lsa (LOG_LSA * lsa);
 
 static int logpb_copy_log_header (THREAD_ENTRY * thread_p, LOG_HEADER * to_hdr, const LOG_HEADER * from_hdr);
 STATIC_INLINE LOG_BUFFER *logpb_get_log_buffer (LOG_PAGE * log_pg) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int logpb_get_log_buffer_index (LOG_PAGEID log_pageid);
+STATIC_INLINE int logpb_get_log_buffer_index (LOG_PAGEID log_pageid) __attribute__ ((ALWAYS_INLINE));
 /*
  * FUNCTIONS RELATED TO LOG BUFFERING
  *

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4012,7 +4012,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
    * append record as log end record. Flush and then check it back.
    */
 
-  if (log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid)
+  if (log_Gl.append.prev_lsa.pageid != log_Gl.hdr.append_lsa.pageid && log_Gl.append.prev_lsa.pageid != NULL_PAGEID)
     {
       /* 
        * Flush all log append records on such page except the current log

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4000,7 +4000,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
        */
 
       bufptr = logpb_get_log_buffer (flush_info->toflush[0]);
-      assert (bufptr->fown == thread_get_current_entry_index ());
+      assert (bufptr->fown > -1);
       if (!logpb_is_dirty (thread_p, flush_info->toflush[0]))
 	{
 	  need_flush = false;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3962,7 +3962,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 
   /* 
    * Add an end of log marker to detect the end of the log.
-   * The marker should be added at the end of the log if there is not more
+   * The marker should be added at the end of the log if there is no more
    * than one page. That is, if we are not in the middle of appending
    * a new log record. Otherwise, we need to change the label of the last
    * append record as log end record. Flush and then check it back.

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -4499,10 +4499,6 @@ log_recovery_resetlog (THREAD_ENTRY * thread_p, LOG_LSA * new_append_lsa, bool i
 
 	  if (log_Gl.append.vdes == NULL_VOLDES || loghdr_pgptr == NULL)
 	    {
-	      if (loghdr_pgptr != NULL)
-		{
-		  logpb_free_page (thread_p, loghdr_pgptr);
-		}
 	      logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_recovery_resetlog");
 	      return;
 	    }

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -4558,7 +4558,7 @@ log_recovery_resetlog (THREAD_ENTRY * thread_p, LOG_LSA * new_append_lsa, bool i
 	  if (newappend_pgptr != NULL && log_Gl.append.log_pgptr != NULL)
 	    {
 	      memcpy ((char *) log_Gl.append.log_pgptr, (char *) newappend_pgptr, LOG_PAGESIZE);
-	      logpb_set_dirty (thread_p, log_Gl.append.log_pgptr, DONT_FREE);
+	      logpb_set_dirty (thread_p, log_Gl.append.log_pgptr);
 	    }
 	  logpb_flush_pages_direct (thread_p);
 	}

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -742,7 +742,7 @@ log_recovery (THREAD_ENTRY * thread_p, int ismedia_crash, time_t * stopat)
   LSA_COPY (&log_Gl.chkpt_redo_lsa, &start_redolsa);
 
   LOG_SET_CURRENT_TRAN_INDEX (thread_p, rcv_tran_index);
-  if (logpb_fetch_start_append_page (thread_p) == NULL)
+  if (logpb_fetch_start_append_page (thread_p) != NO_ERROR)
     {
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_recovery:logpb_fetch_start_append_page");
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_RECOVERY_FINISHED, 0);
@@ -4557,7 +4557,7 @@ log_recovery_resetlog (THREAD_ENTRY * thread_p, LOG_LSA * new_append_lsa, bool i
     }
   else
     {
-      if (logpb_fetch_start_append_page (thread_p) != NULL)
+      if (logpb_fetch_start_append_page (thread_p) == NO_ERROR)
 	{
 	  if (newappend_pgptr != NULL && log_Gl.append.log_pgptr != NULL)
 	    {

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -4507,7 +4507,7 @@ log_recovery_resetlog (THREAD_ENTRY * thread_p, LOG_LSA * new_append_lsa, bool i
 	   * Flush the header page and first append page so that we can record
 	   * the header page on it
 	   */
-	  if (logpb_flush_page (thread_p, loghdr_pgptr, FREE) != NO_ERROR)
+	  if (logpb_flush_page (thread_p, loghdr_pgptr) != NO_ERROR)
 	    {
 	      logpb_fatal_error (thread_p, false, ARG_FILE_LINE, "log_recovery_resetlog");
 	    }
@@ -4519,7 +4519,7 @@ log_recovery_resetlog (THREAD_ENTRY * thread_p, LOG_LSA * new_append_lsa, bool i
 	  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_recovery_resetlog");
 	  return;
 	}
-      if (logpb_flush_page (thread_p, append_pgptr, FREE) != NO_ERROR)
+      if (logpb_flush_page (thread_p, append_pgptr) != NO_ERROR)
 	{
 	  logpb_fatal_error (thread_p, false, ARG_FILE_LINE, "log_recovery_resetlog");
 	  return;

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4589,7 +4589,7 @@ logtb_get_oldest_active_mvccid (THREAD_ENTRY * thread_p)
 #if !defined (NDEBUG)
   {
     /* Safe guard: vacuum_Global_oldest_active_mvccid can never become smaller. */
-    VACUUM_LOG_BLOCKID crt_oldest = vacuum_get_global_oldest_active_mvccid ();
+    MVCCID crt_oldest = vacuum_get_global_oldest_active_mvccid ();
     assert (!MVCC_ID_PRECEDES (lowest_active_mvccid, crt_oldest));
   }
 #endif /* !NDEBUG */

--- a/src/transaction/log_writer.c
+++ b/src/transaction/log_writer.c
@@ -2066,8 +2066,7 @@ logwr_pack_log_pages (THREAD_ENTRY * thread_p, char *logpg_area, int *logpg_used
 
   er_log_debug (ARG_FILE_LINE,
 		"logwr_pack_log_pages, fpageid(%lld), lpageid(%lld), num_pages(%lld),"
-		"\n status(%d), delayed_free_log_pgptr(%p)\n", fpageid, lpageid, num_logpgs, entry->status,
-		log_Gl.append.delayed_free_log_pgptr);
+		"\n status(%d)\n", fpageid, lpageid, num_logpgs, entry->status);
 
   return NO_ERROR;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20340

Changes:
* Replaced hash with an array to store log pages in memory.
* Removed synchronization on reading log pages from buffer.
* Changed some return types.