### PR TITLE
[CBRD-20432] fixed crash due to missing scancache from heap_get_alloc

### DIFF
--- a/src/executables/compactdb.c
+++ b/src/executables/compactdb.c
@@ -676,8 +676,13 @@ update_indexes (OID * class_oid, OID * obj_oid, RECDES * rec)
   RECDES oldrec = { 0, 0, 0, NULL };
   bool old_object;
   int success;
+  HEAP_GET_CONTEXT context;
+  HEAP_SCANCACHE scan_cache;
 
-  old_object = (heap_get_alloc (NULL, obj_oid, &oldrec) == NO_ERROR);
+  (void) heap_scancache_quick_start (&scan_cache);
+  heap_init_get_context (NULL, &context, obj_oid, class_oid, &oldrec, &scan_cache, COPY, NULL_CHN);
+
+  old_object = (heap_get_last_version (NULL, &context) == S_SUCCESS);
 
   if (old_object)
     {
@@ -695,10 +700,8 @@ update_indexes (OID * class_oid, OID * obj_oid, RECDES * rec)
       success = ER_FAILED;
     }
 
-  if (oldrec.data != NULL)
-    {
-      free_and_init (oldrec.data);
-    }
+  heap_clean_get_context (NULL, &context);
+  (void) heap_scancache_end (NULL, &scan_cache);
 
   return success;
 }

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1383,7 +1383,7 @@ static const char *node_type_to_string (short node_type);
 static char *key_type_to_string (char *buf, int buf_size, TP_DOMAIN * key_type);
 static int index_attrs_to_string (char *buf, int buf_size, OR_INDEX * index_p, RECDES * recdes);
 static SCAN_CODE btree_scan_for_show_index_header (THREAD_ENTRY * thread_p, DB_VALUE ** out_values, int out_cnt,
-						   const char *class_name, OR_INDEX * index_p, OID * oid_p);
+						   const char *class_name, OR_INDEX * index_p, OID * class_oid_p);
 static SCAN_CODE btree_scan_for_show_index_capacity (THREAD_ENTRY * thread_p, DB_VALUE ** out_values, int out_cnt,
 						     const char *class_name, OR_INDEX * index_p);
 static bool btree_leaf_lsa_eq (THREAD_ENTRY * thread_p, LOG_LSA * a, LOG_LSA * b);
@@ -21314,7 +21314,7 @@ btree_index_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
   char *class_name = NULL;
   OR_CLASSREP *classrep = NULL;
   SHOW_INDEX_SCAN_CTX *ctx = NULL;
-  OID *oid_p = NULL;
+  OID *class_oid_p = NULL;
   int idx_in_cache;
   int selected_index = 0;
   int i, index_idx, oid_idx;
@@ -21331,16 +21331,16 @@ btree_index_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
   index_idx = cursor % ctx->indexes_count;
   oid_idx = cursor / ctx->indexes_count;
 
-  oid_p = &ctx->class_oids[oid_idx];
+  class_oid_p = &ctx->class_oids[oid_idx];
 
-  class_name = heap_get_class_name (thread_p, oid_p);
+  class_name = heap_get_class_name (thread_p, class_oid_p);
   if (class_name == NULL)
     {
       ret = S_ERROR;
       goto cleanup;
     }
 
-  classrep = heap_classrepr_get (thread_p, oid_p, NULL, NULL_REPRID, &idx_in_cache);
+  classrep = heap_classrepr_get (thread_p, class_oid_p, NULL, NULL_REPRID, &idx_in_cache);
   if (classrep == NULL)
     {
       ret = S_ERROR;
@@ -21378,7 +21378,7 @@ btree_index_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
 
   if (ctx->show_type == SHOWSTMT_INDEX_HEADER || ctx->show_type == SHOWSTMT_ALL_INDEXES_HEADER)
     {
-      ret = btree_scan_for_show_index_header (thread_p, out_values, out_cnt, class_name, index_p, oid_p);
+      ret = btree_scan_for_show_index_header (thread_p, out_values, out_cnt, class_name, index_p, class_oid_p);
     }
   else
     {
@@ -21445,11 +21445,11 @@ btree_index_end_scan (THREAD_ENTRY * thread_p, void **ptr)
  *   out_cnt(in):
  *   class_name(in);
  *   index_p(in);
- *   oid_p(in);
+ *   class_oid_p(in);
  */
 static SCAN_CODE
 btree_scan_for_show_index_header (THREAD_ENTRY * thread_p, DB_VALUE ** out_values, int out_cnt, const char *class_name,
-				  OR_INDEX * index_p, OID * oid_p)
+				  OR_INDEX * index_p, OID * class_oid_p)
 {
   int idx = 0;
   int error = NO_ERROR;
@@ -21462,13 +21462,12 @@ btree_scan_for_show_index_header (THREAD_ENTRY * thread_p, DB_VALUE ** out_value
   int num_oids = 0, num_nulls = 0, num_keys = 0;
   bool fetch_unique_stats = false;
   int unique_stats_idx = -1;
-  RECDES recdes;
+  RECDES recdes = RECDES_INITIALIZER;
   BTID *btid_p = NULL;
+  HEAP_SCANCACHE scan_cache;
+  bool scan_cache_inited = false;
 
   assert_release (index_p != NULL);
-
-  recdes.data = NULL;
-  recdes.area_size = 0;
 
   /* get root header point */
   btid_p = &index_p->btid;
@@ -21571,15 +21570,18 @@ btree_scan_for_show_index_header (THREAD_ENTRY * thread_p, DB_VALUE ** out_value
       goto error;
     }
 
-  /* unfix page buffer before heap_get_alloc() */
+  /* unfix page buffer before heap_get_class_record() */
   if (root_page_ptr != NULL)
     {
       pgbuf_unfix_and_init (thread_p, root_page_ptr);
     }
 
+  /* Init scan_cache for heap object retrieving */
+  (void) heap_scancache_quick_start_root_hfid (thread_p, &scan_cache);
+  scan_cache_inited = true;
+
   /* Get the name list with asc/desc info of attributes */
-  error = heap_get_alloc (thread_p, oid_p, &recdes);
-  if (error != NO_ERROR)
+  if (heap_get_class_record (thread_p, class_oid_p, &recdes, &scan_cache, COPY) != S_SUCCESS)
     {
       goto error;
     }
@@ -21612,10 +21614,7 @@ btree_scan_for_show_index_header (THREAD_ENTRY * thread_p, DB_VALUE ** out_value
       db_make_int (out_values[unique_stats_idx + 2], num_keys);
     }
 
-  if (recdes.data != NULL)
-    {
-      free_and_init (recdes.data);
-    }
+  (void) heap_scancache_end (thread_p, &scan_cache);
 
   return S_SUCCESS;
 
@@ -21626,9 +21625,9 @@ error:
       pgbuf_unfix_and_init (thread_p, root_page_ptr);
     }
 
-  if (recdes.data != NULL)
+  if (scan_cache_inited)
     {
-      free_and_init (recdes.data);
+      (void) heap_scancache_end (thread_p, &scan_cache);
     }
 
   return S_ERROR;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -2565,11 +2565,12 @@ heap_classrepr_dump (THREAD_ENTRY * thread_p, FILE * fp, const OID * class_oid, 
   int disk_length;
   OR_BUF buf;
   bool copy;
-  RECDES recdes;		/* Used to obtain attrnames */
+  RECDES recdes = RECDES_INITIALIZER;	/* Used to obtain attrnames */
   int ret = NO_ERROR;
   char *index_name = NULL;
   char *string = NULL;
   int alloced_string = 0;
+  HEAP_SCANCACHE scan_cache;
 
   /* 
    * The class is feteched to print the attribute names.
@@ -2577,16 +2578,14 @@ heap_classrepr_dump (THREAD_ENTRY * thread_p, FILE * fp, const OID * class_oid, 
    * This is needed since the name of the attributes is not contained
    * in the class representation structure.
    */
-
-  recdes.data = NULL;
-  recdes.area_size = 0;
+  (void) heap_scancache_quick_start_root_hfid (thread_p, &scan_cache);
 
   if (repr == NULL)
     {
       goto exit_on_error;
     }
 
-  if (heap_get_alloc (thread_p, class_oid, &recdes) != NO_ERROR)
+  if (heap_get_class_record (thread_p, class_oid, &recdes, &scan_cache, COPY) != S_SUCCESS)
     {
       goto exit_on_error;
     }
@@ -2719,16 +2718,13 @@ heap_classrepr_dump (THREAD_ENTRY * thread_p, FILE * fp, const OID * class_oid, 
       fprintf (fp, "\n");
     }
 
-  free_and_init (recdes.data);
+  (void) heap_scancache_end (thread_p, &scan_cache);
 
   return ret;
 
 exit_on_error:
 
-  if (recdes.data)
-    {
-      free_and_init (recdes.data);
-    }
+  (void) heap_scancache_end (thread_p, &scan_cache);
 
   fprintf (fp, "Dump has been aborted...");
 
@@ -8046,81 +8042,6 @@ heap_last (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * oi
   oid->volid = hfid->vfid.volid;
 
   return heap_prev (thread_p, hfid, class_oid, oid, recdes, scan_cache, ispeeking);
-}
-
-/*
- * heap_get_alloc () - get/retrieve an object by allocating and freeing area
- *   return: NO_ERROR
- *   oid(in): Object identifier
- *   recdes(in): Record descriptor
- *
- * Note: The object associated with the given OID is copied into the
- * allocated area pointed to by the record descriptor. If the
- * object does not fit in such an area. The area is freed and a
- * new area is allocated to hold the object.
- * The caller is responsible from deallocating the area.
- *
- * Note: The area in the record descriptor is one dynamically allocated
- * with malloc and free with free_and_init.
- */
-int
-heap_get_alloc (THREAD_ENTRY * thread_p, const OID * oid, RECDES * recdes)
-{
-  HEAP_SCANCACHE scan_cache;
-  SCAN_CODE scan;
-  char *new_area;
-  int ret = NO_ERROR;
-
-  heap_scancache_quick_start (&scan_cache);
-
-  if (recdes->data == NULL)
-    {
-      recdes->area_size = DB_PAGESIZE;	/* assume that only one page is needed */
-      recdes->data = (char *) malloc (recdes->area_size);
-      if (recdes->data == NULL)
-	{
-	  ret = ER_OUT_OF_VIRTUAL_MEMORY;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ret, 1, (size_t) recdes->area_size);
-	  goto exit_on_error;
-	}
-    }
-
-  /* Get the object */
-  while ((scan = heap_get_visible_version (thread_p, oid, NULL, recdes, &scan_cache, COPY, NULL_CHN)) != S_SUCCESS)
-    {
-      if (scan == S_DOESNT_FIT)
-	{
-	  /* Is more space needed ? */
-	  new_area = (char *) realloc (recdes->data, -(recdes->length));
-	  if (new_area == NULL)
-	    {
-	      ret = ER_OUT_OF_VIRTUAL_MEMORY;
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ret, 1, (size_t) (-(recdes->length)));
-	      goto exit_on_error;
-	    }
-	  recdes->area_size = -recdes->length;
-	  recdes->data = new_area;
-	}
-      else
-	{
-	  goto exit_on_error;
-	}
-    }
-
-  heap_scancache_end (thread_p, &scan_cache);
-  return ret;
-
-exit_on_error:
-
-  heap_scancache_end (thread_p, &scan_cache);
-
-  if (recdes->data != NULL)
-    {
-      free_and_init (recdes->data);
-      recdes->area_size = 0;
-    }
-
-  return (ret == NO_ERROR) ? ER_FAILED : ret;
 }
 
 #if defined (ENABLE_UNUSED_FUNCTION)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -8066,9 +8066,12 @@ heap_last (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * oi
 int
 heap_get_alloc (THREAD_ENTRY * thread_p, const OID * oid, RECDES * recdes)
 {
+  HEAP_SCANCACHE scan_cache;
   SCAN_CODE scan;
   char *new_area;
   int ret = NO_ERROR;
+
+  heap_scancache_quick_start (&scan_cache);
 
   if (recdes->data == NULL)
     {
@@ -8083,7 +8086,7 @@ heap_get_alloc (THREAD_ENTRY * thread_p, const OID * oid, RECDES * recdes)
     }
 
   /* Get the object */
-  while ((scan = heap_get_visible_version (thread_p, oid, NULL, recdes, NULL, COPY, NULL_CHN)) != S_SUCCESS)
+  while ((scan = heap_get_visible_version (thread_p, oid, NULL, recdes, &scan_cache, COPY, NULL_CHN)) != S_SUCCESS)
     {
       if (scan == S_DOESNT_FIT)
 	{
@@ -8104,9 +8107,12 @@ heap_get_alloc (THREAD_ENTRY * thread_p, const OID * oid, RECDES * recdes)
 	}
     }
 
+  heap_scancache_end (thread_p, &scan_cache);
   return ret;
 
 exit_on_error:
+
+  heap_scancache_end (thread_p, &scan_cache);
 
   if (recdes->data != NULL)
     {

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -420,7 +420,6 @@ extern SCAN_CODE heap_first (THREAD_ENTRY * thread_p, const HFID * hfid, OID * c
 			     HEAP_SCANCACHE * scan_cache, int ispeeking);
 extern SCAN_CODE heap_last (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * oid, RECDES * recdes,
 			    HEAP_SCANCACHE * scan_cache, int ispeeking);
-extern int heap_get_alloc (THREAD_ENTRY * thread_p, const OID * oid, RECDES * recdes);
 #if defined (ENABLE_UNUSED_FUNCTION)
 extern int heap_cmp (THREAD_ENTRY * thread_p, const OID * oid, RECDES * recdes);
 #endif


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20432

This is a slip of #105.
`scancache` was not given to `heap_get_visible_version`.
