### PR TITLE
[CBRD-20435] fixed xlocator_fetch for release build to figure out class_oid when a client does not know

### DIFF
--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2450,6 +2450,7 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
       OID_SET_NULL (class_oid);
     }
 
+#if !defined (NDEBUG)
   if (OID_ISNULL (class_oid))
     {
       /*
@@ -2485,6 +2486,7 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 	      || ((class_lock = lock_get_object_lock (oid_Root_class_oid, NULL,
 						      LOG_FIND_THREAD_TRAN_INDEX (thread_p))) == S_LOCK
 		  || class_lock >= SIX_LOCK)));
+#endif /* DEBUG */
 
   /* 
    * Lock and fetch the object.

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2443,7 +2443,6 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
   /* Compute operation type */
   operation_type = locator_decide_operation_type (lock, fetch_version_type);
 
-#if !defined (NDEBUG)
   if (class_oid == NULL)
     {
       /* The class_oid is not known by the caller. */
@@ -2486,7 +2485,6 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 	      || ((class_lock = lock_get_object_lock (oid_Root_class_oid, NULL,
 						      LOG_FIND_THREAD_TRAN_INDEX (thread_p))) == S_LOCK
 		  || class_lock >= SIX_LOCK)));
-#endif
 
   /* 
    * Lock and fetch the object.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20435

It is also a slip of #105.
When a client does not know class_oid, it just to pass `NULL` to let server to figure it out. 
Only debugging builds did.

