### PR TITLE
[CBRD-20434] fixed latch leak of catalog_get_dir_oid_from_cache

### DIFF
--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -5683,6 +5683,9 @@ catalog_get_dir_oid_from_cache (THREAD_ENTRY * thread_p, const OID * class_id_p,
 	{
 	  error = ER_FAILED;
 	}
+
+      heap_scancache_end (thread_p, &scan_cache);
+
       return error;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20434

It fixes latch leak of `catalog_get_dir_oid_from_cache`. 
This is a legacy issue and #105 reveals the defect. 
