### PR TITLE
[CBRD-20437] fixes UMR of class_oid_local from heap_get_visible_version_internal

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24088,7 +24088,7 @@ heap_get_visible_version_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * c
 
   MVCC_SNAPSHOT *mvcc_snapshot = NULL;
   MVCC_REC_HEADER mvcc_header = MVCC_REC_HEADER_INITIALIZER;
-  OID class_oid_local;
+  OID class_oid_local = OID_INITIALIZER;
 
   assert (context->scan_cache != NULL);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20437

It just fixes the first issue of CBRD-20437. 
`class_oid_local` was not initialized. 
