### PR TITLE
[CBRD-20440] Fixed memory leak that causes dump in server

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12498,6 +12498,12 @@ heap_midxkey_key_generate (THREAD_ENTRY * thread_p, RECDES * recdes, DB_MIDXKEY 
 	  (*(att->domain->type->index_writeval)) (&buf, &value);
 	  OR_ENABLE_BOUND_BIT (nullmap_ptr, k);
 	}
+
+      if (!DB_IS_NULL (&value) && value.need_clear == true)
+	{
+	  pr_clear_value (&value);
+	}
+
       k++;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20440

Fixed a memory leak regarding a `dbvalue` that was not freed.