### PR TITLE
[CBRD-20430] Optimizing compressions

### DIFF
--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -3789,7 +3789,7 @@ or_get_attr_string (RECDES * record, int attr_id, int attr_index, char **string,
 	    }
 	  *alloced_string = 1;
 
-	  rc = mr_get_compressed_data_from_buffer (&buffer, *string, compressed_length, decompressed_length);
+	  rc = pr_get_compressed_data_from_buffer (&buffer, *string, compressed_length, decompressed_length);
 	  if (rc != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16406,17 +16406,11 @@ pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * va
   lzo_uint compression_length = 0;
   lzo_bytep wrkmem = NULL;
   bool compressed = false;
-  int error_abort = -1;
 
   /* Checks to be sure that we have the correct input */
   assert (DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_VARNCHAR || DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_STRING);
   assert (DB_GET_STRING_SIZE (value) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
-  if (buf->error_abort != NULL)
-    {
-      error_abort = buf->error_abort;
-      buf->error_abort = 0;
-    }
   string = DB_GET_STRING (value);
   str_length = DB_GET_STRING_SIZE (value);
   *val_size = 0;
@@ -16509,11 +16503,6 @@ pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * va
     }
 
 cleanup:
-  if (error_abort != -1)
-    {
-      buf->error_abort = error_abort;
-    }
-
   if (compressed_string != NULL)
     {
       free_and_init (compressed_string);
@@ -16522,11 +16511,6 @@ cleanup:
   if (wrkmem != NULL)
     {
       free_and_init (wrkmem);
-    }
-
-  if (rc == ER_TF_BUFFER_OVERFLOW)
-    {
-      return or_overflow (buf);
     }
 
   return rc;

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16385,7 +16385,7 @@ cleanup:
 
 /*
  * pr_get_size_and_write_string_to_buffer ()
- *	  			  : Writes a VARCHAR or VARNCHAR to buffer, without needing the buffer initialized.
+ *	  			  : Writes a VARCHAR or VARNCHAR to buffer and gets the correct size on the disk.
  *				    
  * buf(out)			  : Buffer to be written to.
  * val_p(in)			  : Memory area to be written to.

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16410,7 +16410,7 @@ mr_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val
   error_abort = buf->error_abort;
   buf->error_abort = 0;
   string = DB_GET_STRING (value);
-  str_length = DB_GET_STRING_LENGTH (value);
+  str_length = DB_GET_STRING_SIZE (value);
   *val_size = 0;
 
   /* Step 1 : Compress, if possible, the dbvalue */

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16485,7 +16485,7 @@ pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * va
     }
 
   /* Step 3 : Initialize the buffer */
-  OR_BUF_INIT (*buf, val_p, *val_size);
+  //OR_BUF_INIT (*buf, val_p, *val_size);
 
   /* Step 4 : Insert the disk representation of the dbvalue in the buffer */
 

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16491,7 +16491,7 @@ mr_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val
     {
     case DB_TYPE_VARNCHAR:
     case DB_TYPE_STRING:
-      rc = mr_write_compressed_string_to_buffer (buf, str, (int) compression_length, length, align);
+      rc = mr_write_compressed_string_to_buffer (buf, str, (int) compression_length, str_length, align);
       break;
 
     default:

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16329,11 +16329,11 @@ mr_get_compression_length (const char *string, int charlen)
 
   /* Alloc memory for the compressed string */
   /* Worst case LZO compression size from their FAQ */
-  compressed_string = malloc (length + (length / 16) + 64 + 3);
+  compressed_string = malloc (LZO_COMPRESSED_STRING_SIZE (length));
   if (compressed_string == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY,
-	      1, (size_t) (length + (length / 16) + 64 + 3));
+	      1, (size_t) (LZO_COMPRESSED_STRING_SIZE (length)));
       goto cleanup;
     }
 
@@ -16380,7 +16380,8 @@ cleanup:
 
 
 /*
- * or_write_string_to_buffer ()	  : Writes a VARCHAR or VARNCHAR to buffer, without needing the buffer initialised.
+ * mr_get_size_and_write_string_to_buffer ()
+ *	  			  : Writes a VARCHAR or VARNCHAR to buffer, without needing the buffer initialized.
  *				    
  * buf(out)			  : Buffer to be written to.
  * val_p(in)			  : Memory area to be written to.
@@ -16394,7 +16395,7 @@ cleanup:
  */
 
 int
-mr_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val_size, int align)
+mr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val_size, int align)
 {
   char *compressed_string = NULL, *string = NULL, *str = NULL;
   int rc = NO_ERROR, str_length = 0, length = 0;
@@ -16425,11 +16426,11 @@ mr_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val
 
   /* Alloc memory for the compressed string */
   /* Worst case LZO compression size from their FAQ */
-  compressed_string = malloc (str_length + (str_length / 16) + 64 + 3);
+  compressed_string = malloc (LZO_COMPRESSED_STRING_SIZE (str_length));
   if (compressed_string == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY,
-	      1, (size_t) (str_length + (str_length / 16) + 64 + 3));
+	      1, (size_t) LZO_COMPRESSED_STRING_SIZE (str_length));
       goto cleanup;
     }
 

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16405,7 +16405,7 @@ mr_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val
 
   /* Checks to be sure that we have the correct input */
   assert (DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_VARNCHAR || DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_STRING);
-  assert (DB_GET_STRING_LENGTH (value) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (DB_GET_STRING_SIZE (value) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   error_abort = buf->error_abort;
   buf->error_abort = 0;

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -10864,7 +10864,7 @@ mr_index_lengthmem_string (void *memptr, TP_DOMAIN * domain)
 
   /* generally, index key-value is short enough */
   charlen = OR_GET_BYTE (memptr);
-  if (charlen < 0xFF)
+  if (charlen < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       return or_varchar_length (charlen);
     }
@@ -11504,7 +11504,8 @@ mr_data_cmpdisk_string (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
   /* generally, data is short enough */
   str_length1 = OR_GET_BYTE (str1);
   str_length2 = OR_GET_BYTE (str2);
-  if (str_length1 < 0xFF && str_length2 < 0xFF)
+  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION &&
+      str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       str1 += OR_BYTE_SIZE;
       str2 += OR_BYTE_SIZE;
@@ -11513,11 +11514,12 @@ mr_data_cmpdisk_string (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
       return c;
     }
 
-  assert (str_length1 == 0xFF || str_length2 == 0xFF);
+  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION ||
+	  str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* String 1 */
   or_init (&buf1, str1, 0);
-  if (str_length1 == 0xFF)
+  if (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf1, &str1_compressed_length, &str1_decompressed_length);
       if (rc != NO_ERROR)
@@ -11560,7 +11562,7 @@ mr_data_cmpdisk_string (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
 
   or_init (&buf2, str2, 0);
 
-  if (str_length2 == 0xFF)
+  if (str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf2, &str2_compressed_length, &str2_decompressed_length);
       if (rc != NO_ERROR)
@@ -14355,7 +14357,8 @@ mr_data_cmpdisk_varnchar (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
   /* generally, data is short enough */
   str_length1 = OR_GET_BYTE (str1);
   str_length2 = OR_GET_BYTE (str2);
-  if (str_length1 < 0xFF && str_length2 < 0xFF)
+  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION &&
+      str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       str1 += OR_BYTE_SIZE;
       str2 += OR_BYTE_SIZE;
@@ -14365,11 +14368,12 @@ mr_data_cmpdisk_varnchar (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
       return c;
     }
 
-  assert (str_length1 == 0xFF || str_length2 == 0xFF);
+  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION ||
+	  str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* String 1 */
   or_init (&buf1, str1, 0);
-  if (str_length1 == 0xFF)
+  if (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf1, &str1_compressed_length, &str1_decompressed_length);
       if (rc != NO_ERROR)
@@ -14409,7 +14413,7 @@ mr_data_cmpdisk_varnchar (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
 
   /* String 2 */
   or_init (&buf2, str2, 0);
-  if (str_length2 == 0xFF)
+  if (str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf2, &str2_compressed_length, &str2_decompressed_length);
       if (rc != NO_ERROR)
@@ -16540,7 +16544,7 @@ mr_write_compressed_string_to_buffer (OR_BUF * buf, char *compressed_string, int
   int net_charlen = 0;
   int rc = NO_ERROR;
 
-  assert (decompressed_length >= 0xFF);
+  assert (decompressed_length >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* store the size prefix */
 

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16491,7 +16491,7 @@ mr_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val
     {
     case DB_TYPE_VARNCHAR:
     case DB_TYPE_STRING:
-      rc = mr_write_compressed_string_to_buffer (buf, str, compression_length, length, align);
+      rc = mr_write_compressed_string_to_buffer (buf, str, (int) compression_length, length, align);
       break;
 
     default:

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16484,10 +16484,7 @@ pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * va
       goto cleanup;
     }
 
-  /* Step 3 : Initialize the buffer */
-  //OR_BUF_INIT (*buf, val_p, *val_size);
-
-  /* Step 4 : Insert the disk representation of the dbvalue in the buffer */
+  /* Step 3 : Insert the disk representation of the dbvalue in the buffer */
 
   switch (DB_VALUE_DOMAIN_TYPE (value))
     {

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -888,7 +888,7 @@ static int mr_index_writeval_enumeration (OR_BUF * buf, DB_VALUE * value);
 static int mr_index_readval_enumeration (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int size, bool copy,
 					 char *copy_buf, int copy_buf_len);
 
-static int mr_write_compressed_string_to_buffer (OR_BUF * buf, char *compressed_string, int compressed_length,
+static int pr_write_compressed_string_to_buffer (OR_BUF * buf, char *compressed_string, int compressed_length,
 						 int decompressed_length, int alignment);
 
 /*
@@ -10842,7 +10842,7 @@ mr_data_lengthmem_string (void *memptr, TP_DOMAIN * domain, int disk)
 	  if (len >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	    {
 	      /* Skip the length of the string */
-	      len = mr_get_compression_length ((cur + sizeof (int)), len) + PRIM_TEMPORARY_DISK_SIZE;
+	      len = pr_get_compression_length ((cur + sizeof (int)), len) + PRIM_TEMPORARY_DISK_SIZE;
 	      len = or_packed_varchar_length (len) - PRIM_TEMPORARY_DISK_SIZE;
 	    }
 	  else
@@ -11159,7 +11159,7 @@ mr_lengthval_string_internal (DB_VALUE * value, int disk, int align)
     {
       if (len >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
-	  len = mr_get_compression_length (str, len) + PRIM_TEMPORARY_DISK_SIZE;
+	  len = pr_get_compression_length (str, len) + PRIM_TEMPORARY_DISK_SIZE;
 	  compressable = true;
 	}
 
@@ -11277,7 +11277,7 @@ mr_readval_string_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, 
 		  goto cleanup;
 		}
 
-	      rc = mr_get_compressed_data_from_buffer (buf, string, compressed_size, decompressed_size);
+	      rc = pr_get_compressed_data_from_buffer (buf, string, compressed_size, decompressed_size);
 	      if (rc != NO_ERROR)
 		{
 		  goto cleanup;
@@ -11504,8 +11504,8 @@ mr_data_cmpdisk_string (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
   /* generally, data is short enough */
   str_length1 = OR_GET_BYTE (str1);
   str_length2 = OR_GET_BYTE (str2);
-  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION &&
-      str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
+      && str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       str1 += OR_BYTE_SIZE;
       str2 += OR_BYTE_SIZE;
@@ -11514,8 +11514,8 @@ mr_data_cmpdisk_string (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
       return c;
     }
 
-  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION ||
-	  str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
+	  || str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* String 1 */
   or_init (&buf1, str1, 0);
@@ -11537,7 +11537,7 @@ mr_data_cmpdisk_string (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
 
       alloced_string1 = true;
 
-      rc = mr_get_compressed_data_from_buffer (&buf1, string1, str1_compressed_length, str1_decompressed_length);
+      rc = pr_get_compressed_data_from_buffer (&buf1, string1, str1_compressed_length, str1_decompressed_length);
       if (rc != NO_ERROR)
 	{
 	  goto cleanup;
@@ -11580,7 +11580,7 @@ mr_data_cmpdisk_string (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
 
       alloced_string2 = true;
 
-      rc = mr_get_compressed_data_from_buffer (&buf2, string2, str2_compressed_length, str2_decompressed_length);
+      rc = pr_get_compressed_data_from_buffer (&buf2, string2, str2_compressed_length, str2_decompressed_length);
       if (rc != NO_ERROR)
 	{
 	  goto cleanup;
@@ -13916,7 +13916,7 @@ mr_lengthval_varnchar_internal (DB_VALUE * value, int disk, int align)
 
       if (src_length >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
-	  src_length = mr_get_compression_length (str, src_length) + PRIM_TEMPORARY_DISK_SIZE;
+	  src_length = pr_get_compression_length (str, src_length) + PRIM_TEMPORARY_DISK_SIZE;
 	  compressable = true;
 	}
 
@@ -14103,7 +14103,7 @@ mr_readval_varnchar_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain
 		}
 
 	      /* Getting data from the buffer. */
-	      rc = mr_get_compressed_data_from_buffer (buf, string, compressed_size, decompressed_size);
+	      rc = pr_get_compressed_data_from_buffer (buf, string, compressed_size, decompressed_size);
 
 	      if (rc != NO_ERROR)
 		{
@@ -14357,8 +14357,8 @@ mr_data_cmpdisk_varnchar (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
   /* generally, data is short enough */
   str_length1 = OR_GET_BYTE (str1);
   str_length2 = OR_GET_BYTE (str2);
-  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION &&
-      str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
+      && str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       str1 += OR_BYTE_SIZE;
       str2 += OR_BYTE_SIZE;
@@ -14368,8 +14368,8 @@ mr_data_cmpdisk_varnchar (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
       return c;
     }
 
-  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION ||
-	  str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
+	  || str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* String 1 */
   or_init (&buf1, str1, 0);
@@ -14390,7 +14390,7 @@ mr_data_cmpdisk_varnchar (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
 	}
       alloced_string1 = true;
 
-      rc = mr_get_compressed_data_from_buffer (&buf1, string1, str1_compressed_length, str1_decompressed_length);
+      rc = pr_get_compressed_data_from_buffer (&buf1, string1, str1_compressed_length, str1_decompressed_length);
       if (rc != NO_ERROR)
 	{
 	  goto cleanup;
@@ -14431,7 +14431,7 @@ mr_data_cmpdisk_varnchar (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
 
       alloced_string2 = true;
 
-      rc = mr_get_compressed_data_from_buffer (&buf2, string2, str2_compressed_length, str2_decompressed_length);
+      rc = pr_get_compressed_data_from_buffer (&buf2, string2, str2_compressed_length, str2_decompressed_length);
       if (rc != NO_ERROR)
 	{
 	  goto cleanup;
@@ -16257,7 +16257,7 @@ mr_cmpval_enumeration (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, in
 }
 
 /*
- * mr_get_compressed_data_from_buffer ()	  - Uncompresses a data stored in buffer.
+ * pr_get_compressed_data_from_buffer ()	  - Uncompresses a data stored in buffer.
  *
  * return()					  : NO_ERROR or error code.
  * buf(in)					  : The buffer from which is needed decompression.
@@ -16266,7 +16266,7 @@ mr_cmpval_enumeration (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, in
  * decompressed_size(in)			  : The uncompressed data size.
  */
 int
-mr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int compressed_size, int decompressed_size)
+pr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int compressed_size, int decompressed_size)
 {
   int rc = NO_ERROR;
 
@@ -16304,7 +16304,7 @@ mr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int compressed_siz
 }
 
 /* 
- * mr_get_compression_length()		  - Simulate a compression to find its length to be stored on the disk.
+ * pr_get_compression_length()		  - Simulate a compression to find its length to be stored on the disk.
  * 
  * return()				  : The length of the compression, based on the new encoding of varchar.
  *					    If the compression fails, then it returns charlen.
@@ -16312,7 +16312,7 @@ mr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int compressed_siz
  * charlen(in)				  : The length of the string to be compressed.
  */
 int
-mr_get_compression_length (const char *string, int charlen)
+pr_get_compression_length (const char *string, int charlen)
 {
   lzo_voidp wrkmem;
   char *compressed_string = NULL;
@@ -16384,7 +16384,7 @@ cleanup:
 
 
 /*
- * mr_get_size_and_write_string_to_buffer ()
+ * pr_get_size_and_write_string_to_buffer ()
  *	  			  : Writes a VARCHAR or VARNCHAR to buffer, without needing the buffer initialized.
  *				    
  * buf(out)			  : Buffer to be written to.
@@ -16399,21 +16399,24 @@ cleanup:
  */
 
 int
-mr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val_size, int align)
+pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val_size, int align)
 {
   char *compressed_string = NULL, *string = NULL, *str = NULL;
   int rc = NO_ERROR, str_length = 0, length = 0;
   lzo_uint compression_length = 0;
   lzo_bytep wrkmem = NULL;
   bool compressed = false;
-  int error_abort = 0;
+  int error_abort = -1;
 
   /* Checks to be sure that we have the correct input */
   assert (DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_VARNCHAR || DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_STRING);
   assert (DB_GET_STRING_SIZE (value) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
-  error_abort = buf->error_abort;
-  buf->error_abort = 0;
+  if (buf->error_abort != NULL)
+    {
+      error_abort = buf->error_abort;
+      buf->error_abort = 0;
+    }
   string = DB_GET_STRING (value);
   str_length = DB_GET_STRING_SIZE (value);
   *val_size = 0;
@@ -16496,7 +16499,7 @@ mr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * va
     {
     case DB_TYPE_VARNCHAR:
     case DB_TYPE_STRING:
-      rc = mr_write_compressed_string_to_buffer (buf, str, (int) compression_length, str_length, align);
+      rc = pr_write_compressed_string_to_buffer (buf, str, (int) compression_length, str_length, align);
       break;
 
     default:
@@ -16506,7 +16509,10 @@ mr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * va
     }
 
 cleanup:
-  buf->error_abort = error_abort;
+  if (error_abort != -1)
+    {
+      buf->error_abort = error_abort;
+    }
 
   if (compressed_string != NULL)
     {
@@ -16526,7 +16532,7 @@ cleanup:
   return rc;
 }
 
-/* mr_write_compressed_string_to_buffer()	  : Similar function to the previous implementation of 
+/* pr_write_compressed_string_to_buffer()	  : Similar function to the previous implementation of 
  *						    or_put_varchar_internal.
  *
  * buf(in/out)					  : Buffer to be written the string.
@@ -16538,10 +16544,10 @@ cleanup:
  */
 
 static int
-mr_write_compressed_string_to_buffer (OR_BUF * buf, char *compressed_string, int compressed_length,
+pr_write_compressed_string_to_buffer (OR_BUF * buf, char *compressed_string, int compressed_length,
 				      int decompressed_length, int align)
 {
-  int net_charlen = 0;
+  int storage_length = 0;
   int rc = NO_ERROR;
 
   assert (decompressed_length >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
@@ -16555,16 +16561,16 @@ mr_write_compressed_string_to_buffer (OR_BUF * buf, char *compressed_string, int
       return rc;
     }
   /* Store the compressed size */
-  OR_PUT_INT (&net_charlen, compressed_length);
-  rc = or_put_data (buf, (char *) &net_charlen, OR_INT_SIZE);
+  OR_PUT_INT (&storage_length, compressed_length);
+  rc = or_put_data (buf, (char *) &storage_length, OR_INT_SIZE);
   if (rc != NO_ERROR)
     {
       return rc;
     }
 
   /* Store the decompressed size */
-  OR_PUT_INT (&net_charlen, decompressed_length);
-  rc = or_put_data (buf, (char *) &net_charlen, OR_INT_SIZE);
+  OR_PUT_INT (&storage_length, decompressed_length);
+  rc = or_put_data (buf, (char *) &storage_length, OR_INT_SIZE);
   if (rc != NO_ERROR)
     {
       return rc;
@@ -16573,16 +16579,16 @@ mr_write_compressed_string_to_buffer (OR_BUF * buf, char *compressed_string, int
   /* Get the string disk size */
   if (compressed_length > 0)
     {
-      net_charlen = compressed_length;
+      storage_length = compressed_length;
     }
   else
     {
-      net_charlen = decompressed_length;
+      storage_length = decompressed_length;
     }
 
 
   /* store the string bytes */
-  rc = or_put_data (buf, compressed_string, net_charlen);
+  rc = or_put_data (buf, compressed_string, storage_length);
   if (rc != NO_ERROR)
     {
       return rc;

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -348,9 +348,9 @@ extern int pr_area_init (void);
 extern void pr_area_final (void);
 
 extern int pr_complete_enum_value (DB_VALUE * value, TP_DOMAIN * domain);
-extern int mr_get_compression_length (const char *string, int charlen);
-extern int mr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int compressed_size, int decompressed_size);
-extern int mr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value,
+extern int pr_get_compression_length (const char *string, int charlen);
+extern int pr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int compressed_size, int decompressed_size);
+extern int pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value,
 						   int *val_size, int align);
 
 /* Because of the VARNCHAR and STRING encoding, this one could not be changed for over 255, just lower. */

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -359,6 +359,9 @@ extern int pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB
 #define PRIM_TEMPORARY_DISK_SIZE 256
 #define PRIM_COMPRESSION_LENGTH_OFFSET 4
 
+/* 1 size byte, 4 bytes the compressed size, 4 bytes the decompressed size, length and the max alignment */
+#define PRIM_STRING_MAXIMUM_DISK_SIZE(length) (OR_BYTE_SIZE + OR_INT_SIZE + OR_INT_SIZE + length + MAX_ALIGNMENT)
+
 /* Worst case scenario for compression from their FAQ */
 #define LZO_COMPRESSED_STRING_SIZE(str_length) (str_length + (str_length / 16) + 64 + 3)
 

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -353,7 +353,9 @@ extern int mr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int com
 extern int mr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value,
 						   int *val_size, int align);
 
+/* Because of the VARNCHAR and STRING encoding, this one could not be changed for over 255, just lower. */
 #define PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION 255
+
 #define PRIM_TEMPORARY_DISK_SIZE 256
 #define PRIM_COMPRESSION_LENGTH_OFFSET 4
 

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -350,10 +350,14 @@ extern void pr_area_final (void);
 extern int pr_complete_enum_value (DB_VALUE * value, TP_DOMAIN * domain);
 extern int mr_get_compression_length (const char *string, int charlen);
 extern int mr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int compressed_size, int decompressed_size);
-extern int mr_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val_size, int align);
+extern int mr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value,
+						   int *val_size, int align);
 
 #define PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION 255
 #define PRIM_TEMPORARY_DISK_SIZE 256
 #define PRIM_COMPRESSION_LENGTH_OFFSET 4
+
+/* Worst case scenario for compression from their FAQ */
+#define LZO_COMPRESSED_STRING_SIZE(str_length) (str_length + (str_length / 16) + 64 + 3)
 
 #endif /* _OBJECT_PRIMITIVE_H_ */

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -350,6 +350,7 @@ extern void pr_area_final (void);
 extern int pr_complete_enum_value (DB_VALUE * value, TP_DOMAIN * domain);
 extern int mr_get_compression_length (const char *string, int charlen);
 extern int mr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int compressed_size, int decompressed_size);
+extern int mr_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val_size, int align);
 
 #define PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION 255
 #define PRIM_TEMPORARY_DISK_SIZE 256

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -8536,7 +8536,7 @@ or_get_varchar_compression_lengths (OR_BUF * buf, int *compressed_size, int *dec
       return rc;
     }
 
-  if (size_prefix == 0xFF)
+  if (size_prefix == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       /* String was compressed */
       /* Get the compressed size */

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -1290,7 +1290,7 @@ or_varchar_length_internal (int charlen, int align)
 {
   int len;
 
-  if (charlen < 0xFF)
+  if (charlen < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       len = 1 + charlen;
     }
@@ -1360,7 +1360,7 @@ or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align)
   buf->error_abort = 0;
 
   /* store the size prefix */
-  if (charlen < 0xFF)
+  if (charlen < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_put_byte (buf, charlen);
     }
@@ -1389,11 +1389,11 @@ or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align)
 
       /* Alloc memory for the compressed string */
       /* Worst case LZO compression size from their FAQ */
-      compressed_string = malloc (charlen + (charlen / 16) + 64 + 3);
+      compressed_string = malloc (LZO_COMPRESSED_STRING_SIZE (charlen));
       if (compressed_string == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY,
-		  1, (size_t) (charlen + (charlen / 16) + 64 + 3));
+		  1, (size_t) (LZO_COMPRESSED_STRING_SIZE (charlen)));
 	  rc = ER_OUT_OF_VIRTUAL_MEMORY;
 	  goto cleanup;
 	}

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -1797,7 +1797,7 @@ vid_pack_db_value (char *lbuf, DB_VALUE * dbval)
       if (DB_GET_STRING_SIZE (dbval) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
 	  /* Get max dbval_size */
-	  val_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_SIZE (&dbval));
+	  val_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_SIZE (dbval));
 	  OR_BUF_INIT (buf, lbuf, val_size);
 
 	  rc = pr_get_size_and_write_string_to_buffer (&buf, lbuf, dbval, &val_size, INT_ALIGNMENT);

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -1796,6 +1796,10 @@ vid_pack_db_value (char *lbuf, DB_VALUE * dbval)
     {
       if (DB_GET_STRING_SIZE (dbval) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
+	  /* Get max dbval_size */
+	  val_size = OR_BYTE_SIZE + OR_INT_SIZE + OR_INT_SIZE + DB_GET_STRING_LENGTH (&dbval) + MAX_ALIGNMENT;
+	  OR_BUF_INIT (buf, lbuf, val_size);
+
 	  rc = pr_get_size_and_write_string_to_buffer (&buf, lbuf, dbval, &val_size, INT_ALIGNMENT);
 	  if (rc != NO_ERROR)
 	    {

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -1796,7 +1796,7 @@ vid_pack_db_value (char *lbuf, DB_VALUE * dbval)
     {
       if (DB_GET_STRING_SIZE (dbval) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
-	  rc = mr_get_size_and_write_string_to_buffer (&buf, lbuf, dbval, val_size, INT_ALIGNMENT);
+	  rc = pr_get_size_and_write_string_to_buffer (&buf, lbuf, dbval, &val_size, INT_ALIGNMENT);
 	  if (rc != NO_ERROR)
 	    {
 	      return NULL;

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -1797,7 +1797,7 @@ vid_pack_db_value (char *lbuf, DB_VALUE * dbval)
       if (DB_GET_STRING_SIZE (dbval) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
 	  /* Get max dbval_size */
-	  val_size = OR_BYTE_SIZE + OR_INT_SIZE + OR_INT_SIZE + DB_GET_STRING_LENGTH (&dbval) + MAX_ALIGNMENT;
+	  val_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_LENGTH (&dbval));
 	  OR_BUF_INIT (buf, lbuf, val_size);
 
 	  rc = pr_get_size_and_write_string_to_buffer (&buf, lbuf, dbval, &val_size, INT_ALIGNMENT);

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -1797,7 +1797,7 @@ vid_pack_db_value (char *lbuf, DB_VALUE * dbval)
       if (DB_GET_STRING_SIZE (dbval) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
 	  /* Get max dbval_size */
-	  val_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_LENGTH (&dbval));
+	  val_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_SIZE (&dbval));
 	  OR_BUF_INIT (buf, lbuf, val_size);
 
 	  rc = pr_get_size_and_write_string_to_buffer (&buf, lbuf, dbval, &val_size, INT_ALIGNMENT);

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -1796,7 +1796,7 @@ vid_pack_db_value (char *lbuf, DB_VALUE * dbval)
     {
       if (DB_GET_STRING_SIZE (dbval) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
-	  rc = mr_write_string_to_buffer (&buf, lbuf, dbval, val_size, INT_ALIGNMENT);
+	  rc = mr_get_size_and_write_string_to_buffer (&buf, lbuf, dbval, val_size, INT_ALIGNMENT);
 	  if (rc != NO_ERROR)
 	    {
 	      return NULL;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -17126,8 +17126,8 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
   /* generally, data is short enough */
   str_length1 = OR_GET_BYTE (str1);
   str_length2 = OR_GET_BYTE (str2);
-  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION &&
-      str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
+      && str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       str1 += OR_BYTE_SIZE;
       str2 += OR_BYTE_SIZE;
@@ -17135,8 +17135,8 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
       return c;
     }
 
-  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION ||
-	  str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
+	  || str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* String 1 */
   or_init (&buf1, str1, 0);
@@ -17158,7 +17158,7 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
 
       alloced_string1 = true;
 
-      rc = mr_get_compressed_data_from_buffer (&buf1, string1, str1_compressed_length, str1_decompressed_length);
+      rc = pr_get_compressed_data_from_buffer (&buf1, string1, str1_compressed_length, str1_decompressed_length);
       if (rc != NO_ERROR)
 	{
 	  goto cleanup;
@@ -17199,7 +17199,7 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
 
       alloced_string2 = true;
 
-      rc = mr_get_compressed_data_from_buffer (&buf2, string2, str2_compressed_length, str2_decompressed_length);
+      rc = pr_get_compressed_data_from_buffer (&buf2, string2, str2_compressed_length, str2_decompressed_length);
       if (rc != NO_ERROR)
 	{
 	  goto cleanup;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -17126,7 +17126,8 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
   /* generally, data is short enough */
   str_length1 = OR_GET_BYTE (str1);
   str_length2 = OR_GET_BYTE (str2);
-  if (str_length1 < 0xFF && str_length2 < 0xFF)
+  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION &&
+      str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       str1 += OR_BYTE_SIZE;
       str2 += OR_BYTE_SIZE;
@@ -17134,11 +17135,12 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
       return c;
     }
 
-  assert (str_length1 == 0xFF || str_length2 == 0xFF);
+  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION ||
+	  str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* String 1 */
   or_init (&buf1, str1, 0);
-  if (str_length1 == 0xFF)
+  if (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf1, &str1_compressed_length, &str1_decompressed_length);
       if (rc != NO_ERROR)
@@ -17179,7 +17181,7 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
 
   /* String 2 */
   or_init (&buf2, str2, 0);
-  if (str_length2 == 0xFF)
+  if (str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf2, &str2_compressed_length, &str2_decompressed_length);
       if (rc != NO_ERROR)

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -416,6 +416,8 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, char *tuple_val_p, int *
 	{
 	  val_size = pr_data_writeval_disk_size (dbval_p);
 
+	  OR_BUF_INIT (buf, val_p, val_size);
+
 	  rc = (*(pr_type->data_writeval)) (&buf, dbval_p);
 	}
 

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -404,7 +404,7 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, char *tuple_val_p, int *
       if ((DB_VALUE_DOMAIN_TYPE (dbval_p) == DB_TYPE_STRING || DB_VALUE_DOMAIN_TYPE (dbval_p) == DB_TYPE_VARNCHAR)
 	  && DB_GET_STRING_SIZE (dbval_p) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
-	  rc = mr_write_string_to_buffer (&buf, val_p, dbval_p, val_size, INT_ALIGNMENT);
+	  rc = mr_write_string_to_buffer (&buf, val_p, dbval_p, &val_size, INT_ALIGNMENT);
 	}
       else
 	{
@@ -7238,7 +7238,7 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 	    {
 	      /* We can alloc more than we will need for these two types of data */
 	      disk_repr_p = db_private_alloc (thread_p, DB_GET_STRING_SIZE (&dbval) + PRIM_TEMPORARY_DISK_SIZE);
-	      error = mr_write_string_to_buffer (&buf, disk_repr_p, &dbval, dbval_size, INT_ALIGNMENT);
+	      error = mr_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
 	      if (error != NO_ERROR)
 		{
 		  /* ER_TF_BUFFER_OVERFLOW means that val_size or packing is bad. */
@@ -10659,7 +10659,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 	{
 	  /* We can alloc more than we will need for these two types of data */
 	  disk_repr_p = db_private_alloc (thread_p, DB_GET_STRING_SIZE (&dbval) + PRIM_TEMPORARY_DISK_SIZE);
-	  error = mr_write_string_to_buffer (&buf, disk_repr_p, &dbval, dbval_size, INT_ALIGNMENT);
+	  error = mr_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
 	  if (error != NO_ERROR)
 	    {
 	      /* ER_TF_BUFFER_OVERFLOW means that val_size or packing is bad. */

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -407,7 +407,7 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, char *tuple_val_p, int *
 	  && DB_GET_STRING_SIZE (dbval_p) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
 	  /* Get max val_size from string */
-	  val_size = OR_BYTE_SIZE + OR_INT_SIZE + OR_INT_SIZE + DB_GET_STRING_SIZE (dbval_p) + MAX_ALIGNMENT;
+	  val_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_LENGTH (dbval_p));
 	  OR_BUF_INIT (buf, val_p, val_size);
 
 	  rc = pr_get_size_and_write_string_to_buffer (&buf, val_p, dbval_p, &val_size, INT_ALIGNMENT);
@@ -7251,7 +7251,7 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 		  return ER_OUT_OF_VIRTUAL_MEMORY;
 		}
 	      /* Get max dbval_size */
-	      dbval_size = OR_BYTE_SIZE + OR_INT_SIZE + OR_INT_SIZE + DB_GET_STRING_LENGTH (&dbval) + MAX_ALIGNMENT;
+	      dbval_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_LENGTH (&dbval));
 	      OR_BUF_INIT (buf, disk_repr_p, dbval_size);
 
 	      error = pr_get_size_and_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
@@ -10685,7 +10685,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 	    }
 
 	  /* Get max dbval_size and init the buffer */
-	  dbval_size = OR_BYTE_SIZE + OR_INT_SIZE + OR_INT_SIZE + DB_GET_STRING_LENGTH (&dbval) + MAX_ALIGNMENT;
+	  dbval_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_LENGTH (&dbval));
 	  OR_BUF_INIT (buf, disk_repr_p, dbval_size);
 
 	  error = pr_get_size_and_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -7252,7 +7252,7 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 	  else
 	    {
 	      dbval_size = pr_data_writeval_disk_size (&dbval);
-	      if ((!dbval_size) && (disk_repr_p = (char *) db_private_alloc (thread_p, dbval_size)))
+	      if (dbval_size && (disk_repr_p = (char *) db_private_alloc (thread_p, dbval_size)))
 		{
 		  OR_BUF_INIT (buf, disk_repr_p, dbval_size);
 		  error = (*(pr_type_p->data_writeval)) (&buf, &dbval);

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -404,7 +404,7 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, char *tuple_val_p, int *
       if ((DB_VALUE_DOMAIN_TYPE (dbval_p) == DB_TYPE_STRING || DB_VALUE_DOMAIN_TYPE (dbval_p) == DB_TYPE_VARNCHAR)
 	  && DB_GET_STRING_SIZE (dbval_p) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
-	  rc = mr_get_size_and_write_string_to_buffer (&buf, val_p, dbval_p, &val_size, INT_ALIGNMENT);
+	  rc = pr_get_size_and_write_string_to_buffer (&buf, val_p, dbval_p, &val_size, INT_ALIGNMENT);
 	}
       else
 	{
@@ -7244,7 +7244,7 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 		  pr_clear_value (&dbval);
 		  return ER_OUT_OF_VIRTUAL_MEMORY;
 		}
-	      error = mr_get_size_and_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
+	      error = pr_get_size_and_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
 	      if (error != NO_ERROR)
 		{
 		  /* ER_TF_BUFFER_OVERFLOW means that val_size or packing is bad. */
@@ -10673,7 +10673,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 	      error = ER_OUT_OF_VIRTUAL_MEMORY;
 	      goto exit;
 	    }
-	  error = mr_get_size_and_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
+	  error = pr_get_size_and_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
 	  if (error != NO_ERROR)
 	    {
 	      /* ER_TF_BUFFER_OVERFLOW means that val_size or packing is bad. */

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -407,7 +407,7 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, char *tuple_val_p, int *
 	  && DB_GET_STRING_SIZE (dbval_p) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
 	  /* Get max val_size from string */
-	  val_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_LENGTH (dbval_p));
+	  val_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_SIZE (dbval_p));
 	  OR_BUF_INIT (buf, val_p, val_size);
 
 	  rc = pr_get_size_and_write_string_to_buffer (&buf, val_p, dbval_p, &val_size, INT_ALIGNMENT);
@@ -7251,7 +7251,7 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 		  return ER_OUT_OF_VIRTUAL_MEMORY;
 		}
 	      /* Get max dbval_size */
-	      dbval_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_LENGTH (&dbval));
+	      dbval_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_SIZE (&dbval));
 	      OR_BUF_INIT (buf, disk_repr_p, dbval_size);
 
 	      error = pr_get_size_and_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
@@ -10685,7 +10685,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 	    }
 
 	  /* Get max dbval_size and init the buffer */
-	  dbval_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_LENGTH (&dbval));
+	  dbval_size = PRIM_STRING_MAXIMUM_DISK_SIZE (DB_GET_STRING_SIZE (&dbval));
 	  OR_BUF_INIT (buf, disk_repr_p, dbval_size);
 
 	  error = pr_get_size_and_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -426,7 +426,6 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, char *tuple_val_p, int *
       /* since each tuple data value field is already aligned with MAX_ALIGNMENT, val_size by itself can be used to
        * find the maximum alignment for the following field which is next val_header */
 
-    skip_normal_write:
       align = DB_ALIGN (val_size, MAX_ALIGNMENT);	/* to align for the next field */
       *tuple_val_size = QFILE_TUPLE_VALUE_HEADER_SIZE + align;
       QFILE_PUT_TUPLE_VALUE_LENGTH (tuple_val_p, align);
@@ -10673,7 +10672,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
       else
 	{
 	  dbval_size = pr_data_writeval_disk_size (&dbval);
-	  if ((!dbval_size) && (disk_repr_p = (char *) db_private_alloc (thread_p, dbval_size)))
+	  if (dbval_size && (disk_repr_p = (char *) db_private_alloc (thread_p, dbval_size)))
 	    {
 	      OR_BUF_INIT (buf, disk_repr_p, dbval_size);
 	      error = (*(pr_type_p->data_writeval)) (&buf, &dbval);

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -404,7 +404,7 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, char *tuple_val_p, int *
       if ((DB_VALUE_DOMAIN_TYPE (dbval_p) == DB_TYPE_STRING || DB_VALUE_DOMAIN_TYPE (dbval_p) == DB_TYPE_VARNCHAR)
 	  && DB_GET_STRING_SIZE (dbval_p) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
-	  rc = mr_write_string_to_buffer (&buf, val_p, dbval_p, &val_size, INT_ALIGNMENT);
+	  rc = mr_get_size_and_write_string_to_buffer (&buf, val_p, dbval_p, &val_size, INT_ALIGNMENT);
 	}
       else
 	{
@@ -7237,7 +7237,14 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 	    {
 	      /* We can alloc more than we will need for these two types of data */
 	      disk_repr_p = db_private_alloc (thread_p, DB_GET_STRING_SIZE (&dbval) + PRIM_TEMPORARY_DISK_SIZE);
-	      error = mr_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
+	      if (disk_repr_p == NULL)
+		{
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
+			  (size_t) (DB_GET_STRING_SIZE (&dbval) + PRIM_TEMPORARY_DISK_SIZE));
+		  pr_clear_value (&dbval);
+		  return ER_OUT_OF_VIRTUAL_MEMORY;
+		}
+	      error = mr_get_size_and_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
 	      if (error != NO_ERROR)
 		{
 		  /* ER_TF_BUFFER_OVERFLOW means that val_size or packing is bad. */
@@ -10658,7 +10665,15 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 	{
 	  /* We can alloc more than we will need for these two types of data */
 	  disk_repr_p = db_private_alloc (thread_p, DB_GET_STRING_SIZE (&dbval) + PRIM_TEMPORARY_DISK_SIZE);
-	  error = mr_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
+	  if (disk_repr_p == NULL)
+	    {
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
+		      (size_t) (DB_GET_STRING_SIZE (&dbval) + PRIM_TEMPORARY_DISK_SIZE));
+	      pr_clear_value (&dbval);
+	      error = ER_OUT_OF_VIRTUAL_MEMORY;
+	      goto exit;
+	    }
+	  error = mr_get_size_and_write_string_to_buffer (&buf, disk_repr_p, &dbval, &dbval_size, INT_ALIGNMENT);
 	  if (error != NO_ERROR)
 	    {
 	      /* ER_TF_BUFFER_OVERFLOW means that val_size or packing is bad. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20430

Since `pr_data_writeval_disk_size` would simulate a compression for `STRING` and `VARNCHAR` types, I have added another function to avoid it.