### PR TITLE
[CBRD-20462] remove REPAIR option for Windows ARP

### DIFF
--- a/cmake/CPackWixPatch.cmake.in
+++ b/cmake/CPackWixPatch.cmake.in
@@ -123,7 +123,8 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
-      <Property Id="ARPNOMODIFY" Value="1"/>
+      <Property Id="ARPNOREPAIR" Value="yes" Secure="yes"/>
+      <Property Id="ARPNOMODIFY" Value="yes" Secure="yes"/>
       <Dialog Id="CustomInstallDirDlg" Width="370" Height="270" Title="!(loc.InstallDirDlg_Title)">
         <Control Id="OptionalText" Type="Text" X="120" Y="215" Width="250" Height="18" Transparent="yes" NoPrefix="yes" Hidden="yes" Text="The directory name may not consist of white space.">
           <Condition Action="show"><![CDATA[INSTALL_ROOT >< " "]]></Condition>


### PR DESCRIPTION
Fix to remove the 'REPAIR' option in Windows ARP (Add/Remove Program)