### PR TITLE
[CBRD-20471] fix overwriting log_page_buffer record with end of log record during flush

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -263,6 +263,8 @@ static int log_data_length = 0;
 
 LOG_LSA NULL_LSA = { NULL_PAGEID, NULL_OFFSET };
 
+static int log_Zip_min_size_to_compress = 255;
+
 /*
  * Functions
  */
@@ -2719,7 +2721,7 @@ prior_lsa_gen_undoredo_record_from_crumbs (THREAD_ENTRY * thread_p, LOG_PRIOR_NO
       can_zip = log_zip_support && zip_undo;
     }
 
-  if (can_zip == true)
+  if (can_zip == true && (ulength >= log_Zip_min_size_to_compress || rlength >= log_Zip_min_size_to_compress))
     {
       /* Try to zip undo and/or redo data */
       total_length = 0;
@@ -2741,7 +2743,7 @@ prior_lsa_gen_undoredo_record_from_crumbs (THREAD_ENTRY * thread_p, LOG_PRIOR_NO
 	{
 	  tmp_ptr = data_ptr;
 
-	  if (ulength > 0)
+	  if (ulength >= log_Zip_min_size_to_compress)
 	    {
 	      assert (has_undo == true);
 
@@ -2756,7 +2758,7 @@ prior_lsa_gen_undoredo_record_from_crumbs (THREAD_ENTRY * thread_p, LOG_PRIOR_NO
 	      assert (CAST_BUFLEN (tmp_ptr - undo_data) == ulength);
 	    }
 
-	  if (rlength > 0)
+	  if (rlength >= log_Zip_min_size_to_compress)
 	    {
 	      assert (has_redo == true);
 
@@ -2771,9 +2773,10 @@ prior_lsa_gen_undoredo_record_from_crumbs (THREAD_ENTRY * thread_p, LOG_PRIOR_NO
 	      assert (CAST_BUFLEN (tmp_ptr - redo_data) == rlength);
 	    }
 
-	  assert (CAST_BUFLEN (tmp_ptr - data_ptr) == total_length);
+	  assert (CAST_BUFLEN (tmp_ptr - data_ptr) == total_length
+		  || ulength < log_Zip_min_size_to_compress || rlength < log_Zip_min_size_to_compress);
 
-	  if (ulength > 0 && rlength > 0)
+	  if (ulength >= log_Zip_min_size_to_compress && rlength >= log_Zip_min_size_to_compress)
 	    {
 	      (void) log_diff (ulength, undo_data, rlength, redo_data);
 
@@ -2787,11 +2790,11 @@ prior_lsa_gen_undoredo_record_from_crumbs (THREAD_ENTRY * thread_p, LOG_PRIOR_NO
 	    }
 	  else
 	    {
-	      if (ulength > 0)
+	      if (ulength >= log_Zip_min_size_to_compress)
 		{
 		  is_undo_zip = log_zip (zip_undo, ulength, undo_data);
 		}
-	      if (rlength > 0)
+	      if (rlength >= log_Zip_min_size_to_compress)
 		{
 		  is_redo_zip = log_zip (zip_redo, rlength, redo_data);
 		}
@@ -3838,8 +3841,8 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
   int last_idxflush;		/* The smallest dirty append log page to flush. This is the last one to flush. */
   int idxflush;			/* An index into the first log page buffer to flush */
   bool need_sync;		/* How we flush anything ? */
-  int pageid_for_flush;
-  int i;
+
+  int i, pageid_for_flush;
   bool need_flush = true;
   int error_code = NO_ERROR;
   int flush_page_count = 0;
@@ -4299,6 +4302,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
       /* 
        * Restore the log append record
        */
+      assert (tmp_eof != NULL);
 
       *tmp_eof = save_record;
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3985,7 +3985,6 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
        * the current append log sequence address
        */
 
-
       first_append_log_page = logpb_locate_page (thread_p, log_Gl.append.prev_lsa.pageid, OLD_PAGE);
       if (first_append_log_page == NULL)
 	{

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4327,7 +4327,6 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 
       ++flush_page_count;
       first_append_log_page = NULL;
-      copy_to_first_append = NULL;
     }
 
   flush_info->num_toflush = 0;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3998,7 +3998,11 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
       /* Overwrite it with an end of log marker */
       LSA_SET_NULL (&tmp_eof->forw_lsa);
       tmp_eof->type = LOG_END_OF_LOG;
-      logpb_write_page_to_disk (thread_p, &copy_for_first_append, pageid_for_flush);
+      if (logpb_write_page_to_disk (thread_p, &copy_for_first_append, pageid_for_flush) != NO_ERROR)
+	{
+	  error_code = ER_FAILED;
+	  goto error;
+	}
       logpb_set_dirty (thread_p, first_append_log_page);
       LSA_COPY (&log_Gl.hdr.eof_lsa, &log_Gl.append.prev_lsa);
     }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3994,13 +3994,16 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	}
 
       log_bufptr = logpb_get_log_buffer (first_append_log_page);
+
+      /* if the page is in the buffer, we clear the dirty flag to avoid to flush it again until the end of flush */
       if (log_bufptr->pageid == log_Gl.append.prev_lsa.pageid)
 	{
 	  log_bufptr->dirty = false;
 	}
 
-      copy_to_first_append = (LOG_PAGE *) malloc (LOG_PAGESIZE);
+      /* we don't want to overwrite the log page buffer, so we use a copy */
       memcpy (copy_to_first_append, first_append_log_page, LOG_PAGESIZE);
+
       first_append_pageid = log_Gl.append.prev_lsa.pageid;
       tmp_eof = (LOG_RECORD_HEADER *) ((char *) copy_to_first_append->area + log_Gl.append.prev_lsa.offset);
       save_record = *tmp_eof;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20471
When the function logpb_flush_all_append_pages is called, the page buffer is replaced with an end of log record and is read wrong by other threads, so the operation should be made on a copy, not directly on the buffer.