### PR TITLE
[CBRD-20274] Removing mvcc_link

### DIFF
--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -54,7 +54,6 @@ LF_TRAN_SYSTEM catalog_Ts = LF_TRAN_SYSTEM_INITIALIZER;
 LF_TRAN_SYSTEM sessions_Ts = LF_TRAN_SYSTEM_INITIALIZER;
 LF_TRAN_SYSTEM free_sort_list_Ts = LF_TRAN_SYSTEM_INITIALIZER;
 LF_TRAN_SYSTEM global_unique_stats_Ts = LF_TRAN_SYSTEM_INITIALIZER;
-LF_TRAN_SYSTEM partition_link_Ts = LF_TRAN_SYSTEM_INITIALIZER;
 LF_TRAN_SYSTEM hfid_table_Ts = LF_TRAN_SYSTEM_INITIALIZER;
 LF_TRAN_SYSTEM xcache_Ts = LF_TRAN_SYSTEM_INITIALIZER;
 LF_TRAN_SYSTEM fpcache_Ts = LF_TRAN_SYSTEM_INITIALIZER;
@@ -484,11 +483,6 @@ lf_initialize_transaction_systems (int max_threads)
       goto error;
     }
 
-  if (lf_tran_system_init (&partition_link_Ts, max_threads) != NO_ERROR)
-    {
-      goto error;
-    }
-
   if (lf_tran_system_init (&hfid_table_Ts, max_threads) != NO_ERROR)
     {
       goto error;
@@ -527,7 +521,6 @@ lf_destroy_transaction_systems (void)
   lf_tran_system_destroy (&sessions_Ts);
   lf_tran_system_destroy (&free_sort_list_Ts);
   lf_tran_system_destroy (&global_unique_stats_Ts);
-  lf_tran_system_destroy (&partition_link_Ts);
   lf_tran_system_destroy (&hfid_table_Ts);
   lf_tran_system_destroy (&xcache_Ts);
   lf_tran_system_destroy (&fpcache_Ts);

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -255,7 +255,6 @@ extern LF_TRAN_SYSTEM catalog_Ts;
 extern LF_TRAN_SYSTEM sessions_Ts;
 extern LF_TRAN_SYSTEM free_sort_list_Ts;
 extern LF_TRAN_SYSTEM global_unique_stats_Ts;
-extern LF_TRAN_SYSTEM partition_link_Ts;
 extern LF_TRAN_SYSTEM hfid_table_Ts;
 extern LF_TRAN_SYSTEM xcache_Ts;
 extern LF_TRAN_SYSTEM fpcache_Ts;

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -1988,7 +1988,7 @@ db_get_user_and_host_name (void)
 DB_OBJECT *
 db_get_user (void)
 {
-  return ws_mvcc_latest_version (Au_user);
+  return Au_user;
 }
 
 /*

--- a/src/compat/db_info.c
+++ b/src/compat/db_info.c
@@ -529,8 +529,6 @@ db_is_deleted (DB_OBJECT * obj)
 
   CHECK_1ARG_ERROR (obj);
 
-  obj = ws_mvcc_latest_version (obj);
-
   if (WS_IS_DELETED (obj))
     {
       return 1;

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -3030,8 +3030,6 @@ au_add_member_internal (MOP group, MOP member, int new_user)
   char *member_name;
 
   AU_DISABLE (save);
-  group = ws_mvcc_latest_version (group);
-  member = ws_mvcc_latest_version (member);
   db_make_object (&membervalue, member);
   db_make_object (&groupvalue, group);
 
@@ -5970,8 +5968,6 @@ fetch_class (MOP op, MOP * return_mop, SM_CLASS ** return_class, AU_FETCHMODE fe
       return ER_FAILED;
     }
 
-  op = ws_mvcc_latest_version (op);
-
   classmop = NULL;
   class_ = NULL;
 
@@ -6144,7 +6140,6 @@ au_fetch_class_internal (MOP op, SM_CLASS ** class_ptr, AU_FETCHMODE fetchmode, 
       er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 1, "");
       return error;
     }
-  op = ws_mvcc_latest_version (op);
 
   if (fetchmode != AU_FETCH_READ	/* not just reading */
       || WS_IS_DELETED (op)	/* marked deleted */
@@ -6344,7 +6339,6 @@ fetch_instance (MOP op, MOBJ * obj_ptr, AU_FETCHMODE fetchmode, LC_FETCH_VERSION
   /* DO NOT PUT ANY RETURNS FROM HERE UNTIL THE AU_ENABLE */
   AU_DISABLE (save);
 
-  op = ws_mvcc_latest_version (op);
   pin = ws_pin (op, 1);
   if (op->is_vid)
     {
@@ -6457,7 +6451,6 @@ au_fetch_instance (MOP op, MOBJ * obj_ptr, AU_FETCHMODE mode, LC_FETCH_VERSION_T
       return error;
     }
 
-  op = ws_mvcc_latest_version (op);
   error = fetch_class (op, &classmop, &class_, AU_FETCH_READ, BY_INSTANCE_MOP);
   if (error != NO_ERROR)
     {

--- a/src/object/object_accessor.c
+++ b/src/object/object_accessor.c
@@ -1322,9 +1322,6 @@ obj_get_value (MOP op, SM_ATTRIBUTE * att, void *mem, DB_VALUE * source, DB_VALU
       source = &att->default_value.value;
     }
 
-  /* In MVCC, we must be sure that we have the last mop version before we access the object. */
-  op = ws_mvcc_latest_version (op);
-
   if ((ws_find (op, &object) == WS_FIND_MOP_DELETED) || object == NULL)
     {
       er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_OBJ_INVALID_ARGUMENTS, 0);
@@ -2181,11 +2178,6 @@ obj_delete (MOP op)
 	  goto error_exit;
 	}
 
-      if (base_op->decached == 0 && op->is_vid && class_->class_type == SM_VCLASS_CT)
-	{
-	  base_op = ws_mvcc_latest_version (base_op);
-	}
-
       /* in some cases, the object has been decached in before trigger. we need fetch it again. */
       if (base_op->decached)
 	{
@@ -2207,11 +2199,6 @@ obj_delete (MOP op)
       if (error != NO_ERROR)
 	{
 	  goto error_exit;
-	}
-
-      if (op->decached == 0)
-	{
-	  op = ws_mvcc_latest_version (op);
 	}
 
       /* in some cases, the object has been decached in before trigger. we need fetch it again. */
@@ -4412,7 +4399,6 @@ obj_isinstance (MOP obj)
   int status;
   MOBJ object;
 
-  obj = ws_mvcc_latest_version (obj);
   if (obj != NULL)
     {
       status = locator_is_class (obj, DB_FETCH_READ);

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -5996,7 +5996,6 @@ mr_cmpval_object (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
 		}
 	      else
 		{
-		  mop1 = ws_mvcc_latest_version (mop1);
 		  o1 = WS_OID (mop1);
 		}
 	    }
@@ -6007,7 +6006,6 @@ mr_cmpval_object (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
 	}
       else
 	{
-	  mop1 = ws_mvcc_latest_version (mop1);
 	  o1 = WS_OID (mop1);
 	}
     }
@@ -6039,7 +6037,6 @@ mr_cmpval_object (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
 		}
 	      else
 		{
-		  mop2 = ws_mvcc_latest_version (mop2);
 		  o2 = WS_OID (mop2);
 		}
 	    }
@@ -6050,7 +6047,6 @@ mr_cmpval_object (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
 	}
       else
 	{
-	  mop2 = ws_mvcc_latest_version (mop2);
 	  o2 = WS_OID (mop2);
 	}
     }

--- a/src/object/object_template.c
+++ b/src/object/object_template.c
@@ -2071,7 +2071,6 @@ access_object (OBJ_TEMPLATE * template_ptr, MOP * object, MOBJ * objptr)
     }
   else
     {
-      mop = ws_mvcc_latest_version (mop);
       mop->pruning_type = template_ptr->pruning_type;
       *object = mop;
       *objptr = obj;
@@ -2527,8 +2526,6 @@ obt_apply_assignments (OBJ_TEMPLATE * template_ptr, int check_uniques, int level
 		    {
 		      trstate = NULL;
 		    }
-
-		  object = ws_mvcc_latest_version (object);
 		}
 
 	      /* in some cases, the object has been decached in before trigger. we need fetch it again. */

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -4819,7 +4819,6 @@ check_set_object (DB_VALUE * var, int *removed_ptr)
     {
       goto end;
     }
-  mop = ws_mvcc_latest_version (mop);
 
   if (!WS_IS_DELETED (mop))
     {

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -1672,7 +1672,7 @@ put_object_set (OR_BUF * buf, DB_OBJLIST * list)
 	{
 	  continue;
 	}
-      pr_write_mop (buf, ws_mvcc_latest_version (l->op));
+      pr_write_mop (buf, l->op);
     }
 
   return NO_ERROR;

--- a/src/object/work_space.c
+++ b/src/object/work_space.c
@@ -1088,7 +1088,6 @@ ws_new_mop (OID * oid, MOP class_mop)
  *    This is called in three cases:
  *    1. Newly created objects are flushed and are given a permanent OID.
  *    2. An object changes partition after update.
- *    3. MVCC is enabled and object changes OID after update.
  *
  *    If the object belongs to a partitioned class, it will
  *    have a different class oid here (i.e. the partition in

--- a/src/object/work_space.c
+++ b/src/object/work_space.c
@@ -3314,6 +3314,7 @@ ws_clear_all_hints (bool retain_lock)
     {
       ws_clear_hints (mop, false);
       next = mop->commit_link;
+      mop->commit_link = NULL;	/* remove mop from commit link (it's done) */
       if (next == mop)
 	{
 	  mop = NULL;

--- a/src/object/work_space.c
+++ b/src/object/work_space.c
@@ -3433,11 +3433,6 @@ ws_decache_allxlockmops_but_norealclasses (void)
 	      ws_decache (mop);
 	      ws_clear_hints (mop, false);
 	    }
-	  if (mop->mvcc_link != NULL && !mop->permanent_mvcc_link)
-	    {
-	      ws_decache (mop->mvcc_link);
-	      mop->mvcc_link = NULL;
-	    }
 	}
     }
 }

--- a/src/object/work_space.h
+++ b/src/object/work_space.h
@@ -666,7 +666,6 @@ extern int ws_get_mvcc_snapshot_version (void);
 extern void ws_increment_mvcc_snapshot_version (void);
 extern bool ws_is_mop_fetched_with_current_snapshot (MOP mop);
 extern void ws_set_mop_fetched_with_current_snapshot (MOP mop);
-extern MOP ws_mvcc_latest_version (MOP mop);
 
 extern bool ws_is_same_object (MOP mop1, MOP mop2);
 extern void ws_move_label_value_list (MOP dest_mop, MOP src_mop);

--- a/src/object/work_space.h
+++ b/src/object/work_space.h
@@ -127,7 +127,6 @@ struct db_object
   /* Careful whenever looping through objects using hash_link to save it and advance using this saved hash link if the
    * current mop can be removed or relocated in hash table. */
   struct db_object *commit_link;	/* link for obj to be reset at commit/abort */
-  struct db_object *mvcc_link;	/* Used by MVCC to link mops for different object versions. */
   WS_VALUE_LIST *label_value_list;	/* label value list */
   LOCK lock;			/* object lock */
   int mvcc_snapshot_version;	/* The snapshot version at the time mop object is fetched and cached. Used only when
@@ -148,9 +147,6 @@ struct db_object
   unsigned released:1;		/* set by code that knows that an instance can be released, used currently by the
 				 * loader only */
   unsigned decached:1;		/* set if mop is decached by calling ws_decache function */
-  unsigned permanent_mvcc_link:1;	/* is set to true when new MVCC version is committed. Updates done by current
-					 * transaction may be reverted, therefore the mvcc link is not permanent. On
-					 * rollback, mvcc link is removed. On commit mvcc link is made permanent. */
 };
 
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -6990,7 +6990,6 @@ update_object_tuple (PARSER_CONTEXT * parser, CLIENT_UPDATE_INFO * assigns, int 
       /* handle delete only after update to give a chance to triggers */
       if (should_delete && error == NO_ERROR)
 	{
-	  object = ws_mvcc_latest_version (object);
 	  error = locator_flush_instance (object);
 	  if (error != NO_ERROR)
 	    {

--- a/src/transaction/locator_cl.c
+++ b/src/transaction/locator_cl.c
@@ -4276,9 +4276,8 @@ locator_mflush_force (LOCATOR_MFLUSH_CACHE * mflush)
 	{
 	  if (mop_toid->mop != NULL)
 	    {
-	      assert (obj->operation == LC_FLUSH_UPDATE_PRUNE);
-
 	      obj = LC_FIND_ONEOBJ_PTR_IN_COPYAREA (mflush->mobjs, mop_toid->obj);
+	      assert (obj->operation == LC_FLUSH_UPDATE_PRUNE);
 
 	      /* Check if object OID has changed */
 	      if (!OID_ISNULL (&obj->oid) && !OID_EQ (WS_OID (mop_toid->mop->class_mop), &obj->class_oid)

--- a/src/transaction/locator_cl.c
+++ b/src/transaction/locator_cl.c
@@ -4358,6 +4358,9 @@ locator_mflush_force (LOCATOR_MFLUSH_CACHE * mflush)
 
 			  /* Update MVCC snapshot version */
 			  ws_set_mop_fetched_with_current_snapshot (new_mop);
+
+			  /* WARNING: The caller must be warned that the object OID has changed!! As the mvcc_link 
+			   * is gone, the new OID is no longer linked to the old mop */
 			}
 		    }
 		}

--- a/src/transaction/locator_cl.c
+++ b/src/transaction/locator_cl.c
@@ -4692,7 +4692,7 @@ locator_mflush (MOP mop, void *mf)
   mflush = (LOCATOR_MFLUSH_CACHE *) mf;
 
   /* Flush the instance only if it is dirty */
-  if (!WS_ISDIRTY (mop))	// || mop->mvcc_link != NULL)
+  if (!WS_ISDIRTY (mop))
     {
       if (mflush->decache)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20274

The mvcc_link was relevant only for partititions update when objects may change their `OID `and class `OID`. 
The mechanism to handle these cases was restored as it was before mvcc.