### PR TITLE
[CBRD-20483] logpb_flush_all_append_pages: check physical pageids to be successive before collecting buffer for flush

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4196,6 +4196,11 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	      /* not successive pages */
 	      break;
 	    }
+          if (prv_bufptr->phy_pageid + 1 != bufptr->phy_pageid)
+            {
+              /* not successive pages on disk */
+              break;
+            }
 	}
 
       if (logpb_writev_append_pages (thread_p, &flush_info->toflush[idxflush], i - idxflush) == NULL)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4196,11 +4196,11 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	      /* not successive pages */
 	      break;
 	    }
-          if (prv_bufptr->phy_pageid + 1 != bufptr->phy_pageid) 
-            {
-              /* not successive pages on disk */
-              break;
-            }
+	  if (prv_bufptr->phy_pageid + 1 != bufptr->phy_pageid)
+	    {
+	      /* not successive pages on disk */
+	      break;
+	    }
 	}
 
       if (logpb_writev_append_pages (thread_p, &flush_info->toflush[idxflush], i - idxflush) == NULL)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4196,7 +4196,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	      /* not successive pages */
 	      break;
 	    }
-          if (prv_bufptr->phy_pageid + 1 != bufptr->phy_pageid)
+          if (prv_bufptr->phy_pageid + 1 != bufptr->phy_pageid) 
             {
               /* not successive pages on disk */
               break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20483

This is a slip of logpb_flush_all_append_pages refactoring. Sorry for the error :).

However, log entries are really useful!