### PR TITLE
[CBRD-20491] cpack does not add required library

### DIFF
--- a/cmake/CPackOptions.cmake.in
+++ b/cmake/CPackOptions.cmake.in
@@ -50,6 +50,7 @@ elseif(CPACK_GENERATOR STREQUAL "RPM")
     "/etc/init.d/cubrid"
     "/etc/init.d/cubrid-ha"
     )
+  set(CPACK_RPM_PACKAGE_AUTOREQ "no")
 endif()
 
 # TODO: for windows package


### PR DESCRIPTION
cpack does not add required library
[gichoi@rnd00 build_x86_64_release]$ rpm -ivh --test CUBRID-10.1.0.6992-9c3a8af-Linux.x86_64.rpm
error: Failed dependencies:
libcubridcs.so.10()(64bit) is needed by cubrid-10.1.0.6992_9c3a8af-1.x86_64
