### PR TITLE
[CBRD-20483] Fix flushing log

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -220,7 +220,7 @@ struct log_buffer
  * - LOGPB_APPENDREC_IN_PROGRESS => LOGPB_APPENDREC_PARTIAL_FLUSHED_END_OF_LOG
  *   prev_lsa record is overwritten with end of log record and flushed to disk.
  * - LOGPB_APPENDREC_PARTIAL_FLUSHED_END_OF_LOG => LOGPB_APPENDREC_PARTIAL_ENDED
- *   incomplete log record is now completely flushed. logpb_flush_all_append_pages is called again.
+ *   incomplete log record is now completely appended. logpb_flush_all_append_pages is called again.
  * - LOGPB_APPENDREC_PARTIAL_ENDED => LOGPB_APPENDREC_PARTIAL_FLUSHED_ORIGINAL
  *   at the end of last flush, the prev_lsa record is restored and its page is flushed again to disk.
  * - LOGPB_APPENDREC_PARTIAL_FLUSHED_ORIGINAL => LOGPB_APPENDREC_SUCCESS

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1953,7 +1953,8 @@ logpb_write_page_to_disk (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, LOG_PAG
   assert (log_pgptr->hdr.logical_pageid == logical_pageid);
   if (logical_pageid != LOGPB_HEADER_PAGE_ID)
     {
-      assert (logical_pageid >= LOGPB_FIRST_ACTIVE_PAGE_ID);
+      /* we allow writing page as long as they do not belong to archive area */
+      assert (logical_pageid >= LOGPB_NEXT_ARCHIVE_PAGE_ID);
       assert (logical_pageid <= LOGPB_LAST_ACTIVE_PAGE_ID);
     }
   phy_pageid = logpb_to_physical_pageid (logical_pageid);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1951,12 +1951,10 @@ logpb_write_page_to_disk (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, LOG_PAG
   logpb_log ("called logpb_write_page_to_disk for logical_pageid = %lld\n", (long long int) logical_pageid);
   assert (log_pgptr != NULL);
   assert (log_pgptr->hdr.logical_pageid == logical_pageid);
-  if (logical_pageid != LOGPB_HEADER_PAGE_ID)
-    {
-      /* we allow writing page as long as they do not belong to archive area */
-      assert (logical_pageid >= LOGPB_NEXT_ARCHIVE_PAGE_ID);
-      assert (logical_pageid <= LOGPB_LAST_ACTIVE_PAGE_ID);
-    }
+  /* we allow writing page as long as they do not belong to archive area */
+  assert (logical_pageid == LOGPB_HEADER_PAGE_ID
+	  || (!LOGPB_IS_ARCHIVE_PAGE (logical_pageid) && logical_pageid <= LOGPB_LAST_ACTIVE_PAGE_ID));
+
   phy_pageid = logpb_to_physical_pageid (logical_pageid);
   logpb_log ("phy_pageid in logpb_write_page_to_disk is %lld\n", (long long int) phy_pageid);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20483

The best description can be found in this comment:
```c
  /* how this works:
   * ok, so we might have to flush several pages here. if there is only one page, the implementation is straight
   * forward, just flush the page.
   *
   * however, if there are two or more pages, we really need to make sure that the first page, where previous end of log
   * record resides (where nxio_lsa points), is flushed last! we cannot validate the new end of log record until we are
   * sure all log pages have been flushed!
   * so, we'll do a two-step flushing: in the first step we skip nxio_lsa page and flush all other pages. in the second
   * step we flush the nxio_lsa page.
   *
   * the story becomes a lot more complicated when a log entry is only partially appended before flush is called. this
   * can happen for when log page buffer becomes full. the problem here is that we cannot yet validate the flushed pages
   * before flushing this record entirely; not all pages. what we do here is replace the incomplete record with end of
   * log record (very important! not in log page buffer, but in a copy of the log page; that way we allow others to read
   * the correct version from buffer). the overwritten copy is flushed to disk.
   * when the log record is fully appended (there can be several iterations of flush if we deal with a very large log
   * record and log page buffer is very small), we call again flush again to make sure all remaining record pages are
   * written to disk. at the end of this flush iteration, the original record is written back and page is flushed again,
   * validating new record.
   *
   * to see full implementation, follow references of log_Pb.partial_append.
   *
   * todo: we might think of a better and simpler solution. the most difficult case to handle is very large log record,
   *       larger than log page buffer. since log records can theoretically be any size, the solution will have to
   *       consider this case.
   *       for now I chose a solution similar to the implementation used before the log page buffer redesign.
   */
```