### PR TITLE
[CBRD-20494] Advance vacuum job cursor when it points to page being deallocated

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4453,6 +4453,12 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 		      data_page->index_free -= data_page->index_unvacuumed;
 		      data_page->index_unvacuumed = 0;
 		    }
+
+		  if (VPID_EQ (&vacuum_Data.vpid_job_cursor, pgbuf_get_vpid_ptr ((PAGE_PTR) data_page)))
+		    {
+		      /* Cursor may have remained behind. Update it. */
+		      vacuum_Data.blockid_job_cursor = VACUUM_BLOCKID_WITHOUT_FLAGS (data_page->data[0].blockid);
+		    }
 		}
 
 	      /* Log changes. */

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4558,6 +4558,12 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 		     vacuum_Data.first_page == vacuum_Data.last_page ?
 		     "This is also first page." : "This is different from first page.");
 
+      if (VPID_EQ (&vacuum_Data.vpid_job_cursor, pgbuf_get_vpid_ptr ((PAGE_PTR) (*data_page))))
+	{
+	  /* Set cursor next to last_blockid */
+	  vacuum_Data.blockid_job_cursor = vacuum_Data.last_blockid + 1;
+	}
+
       /* No next page */
       *data_page = NULL;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20494

The bug is possible only in stand-alone mode.

The problem is that stand-alone mode for vacuum forces a restart when finished blocks queue becomes full. Then completed blocks are removed. In some cases, the cursor can become invalid.
1. If right after current cursor we already have vacuumed blocks (e.g. blocks with no MVCC ops which are considered vacuumed from the start), they may be skipped or even removed. We need to make sure that the cursor is not left behind index_unvacuumed in cursor page.
2. When page is removed. The process can stop exactly on last vacuum data page entry. That page may be reset (if it is last) or may be removed completely (and deallocated). We need to make sure the cursor does not point to deallocated page and is moved next to it.