### PR TITLE
[CBRD-20499] not to remove archive logs during restart recovery.

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6761,11 +6761,15 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 
   if (log_max_archives == INT_MAX)
     {
-      return deleted_count;
+      return 0;			/* none is deleted */
     }
 
   /* Get first log pageid needed for vacuum before locking LOG_CS. */
   vacuum_first_pageid = vacuum_min_log_pageid_to_keep (thread_p);
+  if (vacuum_first_pageid == NULL_PAGEID)
+    {
+      return 0;			/* none is deleted */
+    }
 
   LOG_CS_ENTER (thread_p);
 
@@ -6776,7 +6780,7 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
       if (min_copied_pageid == NULL_PAGEID)
 	{
 	  LOG_CS_EXIT (thread_p);
-	  return deleted_count;
+	  return 0;		/* none is deleted */
 	}
 
       if (logpb_is_page_in_archive (min_copied_pageid))
@@ -6785,7 +6789,7 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	  if (min_copied_arv_num == -1)
 	    {
 	      LOG_CS_EXIT (thread_p);
-	      return deleted_count;
+	      return 0;		/* none is deleted */
 	    }
 	  else if (min_copied_arv_num > 1)
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20499

Archive logs needed for vacuum might be purged during restart recovery. 
It should be postponed until vacuum is available. 