### PR TITLE
[CBRD-20502] change tdes->cs_topop implementation as SYNC_RMUTEX

### DIFF
--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -112,6 +112,8 @@ typedef struct wait_queue_search_arg
 
 #define NUM_NORMAL_CLIENTS (prm_get_integer_value(PRM_ID_CSS_MAX_CLIENTS))
 
+#define RMUTEX_NAME_CONN_ENTRY "CONN_ENTRY"
+
 static const int CSS_MAX_CLIENT_ID = INT_MAX - 1;
 
 static int css_Client_id = 0;
@@ -471,7 +473,7 @@ css_init_conn_list (void)
 	  goto error;
 	}
 
-      err = rmutex_initialize (&conn->rmutex, rmutex_Name_conn);
+      err = rmutex_initialize (&conn->rmutex, RMUTEX_NAME_CONN_ENTRY);
       if (err != NO_ERROR)
 	{
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_CONN_INIT, 0);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -84,6 +84,8 @@
 #define SockError    -1
 #endif /* WINDOWS */
 
+#define RMUTEX_NAME_TEMP_CONN_ENTRY "TEMP_CONN_ENTRY"
+
 static struct timeval css_Shutdown_timeout = { 0, 0 };
 
 static char *css_Master_server_name = NULL;	/* database identifier */
@@ -1060,7 +1062,7 @@ css_process_new_client (SOCKET master_fd)
        * Note that no name is given for its csect. also see css_is_temporary_conn_csect.
        */
       css_initialize_conn (&temp_conn, new_fd);
-      r = rmutex_initialize (&temp_conn.rmutex, NULL);
+      r = rmutex_initialize (&temp_conn.rmutex, RMUTEX_NAME_TEMP_CONN_ENTRY);
       assert (r == NO_ERROR);
 
       reason = htonl (SERVER_INACCESSIBLE_IP);
@@ -1083,7 +1085,7 @@ css_process_new_client (SOCKET master_fd)
        * Note that no name is given for its csect. also see css_is_temporary_conn_csect.
        */
       css_initialize_conn (&temp_conn, new_fd);
-      r = rmutex_initialize (&temp_conn.rmutex, NULL);
+      r = rmutex_initialize (&temp_conn.rmutex, RMUTEX_NAME_TEMP_CONN_ENTRY);
       assert (r == NO_ERROR);
 
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_CLIENTS_EXCEEDED, 1, NUM_NORMAL_TRANS);
@@ -1273,7 +1275,7 @@ css_process_new_connection_request (void)
 	  void *error_string;
 
 	  css_initialize_conn (&new_conn, new_fd);
-	  r = rmutex_initialize (&new_conn.rmutex, rmutex_Name_conn);
+	  r = rmutex_initialize (&new_conn.rmutex, RMUTEX_NAME_TEMP_CONN_ENTRY);
 	  assert (r == NO_ERROR);
 
 	  rc = css_read_header (&new_conn, &header);
@@ -1303,7 +1305,7 @@ css_process_new_connection_request (void)
 	  void *error_string;
 
 	  css_initialize_conn (&new_conn, new_fd);
-	  r = rmutex_initialize (&new_conn.rmutex, rmutex_Name_conn);
+	  r = rmutex_initialize (&new_conn.rmutex, RMUTEX_NAME_TEMP_CONN_ENTRY);
 	  assert (r == NO_ERROR);
 
 	  rc = css_read_header (&new_conn, &header);

--- a/src/thread/critical_section.c
+++ b/src/thread/critical_section.c
@@ -94,7 +94,7 @@ static const char *csect_Names[] = {
 };
 
 const char *rmutex_Name_conn = "CONN_ENTRY";
-const char *csect_Name_tdes = "TDES";
+const char *rmutex_Name_tdes_topop = "TDES_TOPOP";
 
 #define CSECT_NAME(c) ((c)->name ? (c)->name : "TEMP CONN_ENTRY")
 

--- a/src/thread/critical_section.c
+++ b/src/thread/critical_section.c
@@ -93,10 +93,7 @@ static const char *csect_Names[] = {
   "ACCESS_STATUS"
 };
 
-const char *rmutex_Name_conn = "CONN_ENTRY";
-const char *rmutex_Name_tdes_topop = "TDES_TOPOP";
-
-#define CSECT_NAME(c) ((c)->name ? (c)->name : "TEMP CONN_ENTRY")
+#define CSECT_NAME(c) ((c)->name ? (c)->name : "UNKNOWN")
 
 /* 
  * Synchronization Primitives Statistics Monitor

--- a/src/thread/critical_section.h
+++ b/src/thread/critical_section.h
@@ -75,7 +75,7 @@ enum
 #define CRITICAL_SECTION_COUNT  CSECT_LAST
 
 extern const char *rmutex_Name_conn;
-extern const char *csect_Name_tdes;
+extern const char *rmutex_Name_tdes_topop;
 
 typedef enum
 {

--- a/src/thread/critical_section.h
+++ b/src/thread/critical_section.h
@@ -74,9 +74,6 @@ enum
 
 #define CRITICAL_SECTION_COUNT  CSECT_LAST
 
-extern const char *rmutex_Name_conn;
-extern const char *rmutex_Name_tdes_topop;
-
 typedef enum
 {
   SYNC_TYPE_NONE,

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -864,7 +864,7 @@ struct log_tdes
   int gtrid;			/* Global transaction identifier; used only if this transaction is a participant to a
 				 * global transaction and it is prepared to commit. */
   LOG_CLIENTIDS client;		/* Client identification */
-  SYNC_CRITICAL_SECTION cs_topop;	/* critical section to serialize system top operations */
+  SYNC_RMUTEX rmutex_topop;	/* reentrant mutex to serialize system top operations */
   LOG_TOPOPS_STACK topops;	/* Active top system operations. Used for system permanent nested operations which are
 				 * independent from current transaction outcome. */
   LOG_2PC_GTRINFO gtrinfo;	/* Global transaction user information; used to store XID of XA interface. */

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -83,6 +83,8 @@
 #include "transaction_cl.h"
 #endif
 
+#define RMUTEX_NAME_TDES_TOPOP "TDES_TOPOP"
+
 #define MVCC_OLDEST_ACTIVE_BUFFER_LENGTH 300
 
 /* bit area sizes expressed in bits */
@@ -1990,7 +1992,7 @@ logtb_initialize_tdes (LOG_TDES * tdes, int tran_index)
   LSA_SET_NULL (&tdes->topop_lsa);
   LSA_SET_NULL (&tdes->tail_topresult_lsa);
 
-  r = rmutex_initialize (&tdes->rmutex_topop, rmutex_Name_tdes_topop);
+  r = rmutex_initialize (&tdes->rmutex_topop, RMUTEX_NAME_TDES_TOPOP);
   assert (r == NO_ERROR);
 
   tdes->topops.stack = NULL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20502

This is a preliminary to enhance monitoring of readers to `SYNC_CRITICAL_SECTION`.