### PR TITLE
[CBRD-20504] Update fix count check

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -7537,24 +7537,14 @@ vacuum_verify_vacuum_data_page_fix_count (THREAD_ENTRY * thread_p)
   assert (pgbuf_get_fix_count ((PAGE_PTR) vacuum_Data.first_page) == 1);
   assert (vacuum_Data.last_page == vacuum_Data.first_page
 	  || pgbuf_get_fix_count ((PAGE_PTR) vacuum_Data.last_page) == 1);
-
-  if (vacuum_Data.last_page == vacuum_Data.first_page)
+  if (vacuum_Data.first_page == vacuum_Data.last_page)
     {
-      return;
+      assert (pgbuf_get_hold_count (thread_p) == 1);
     }
-  VPID_COPY (&vpid, &vacuum_Data.first_page->next_page);
-  while (!VPID_EQ (&vpid, pgbuf_get_vpid_ptr ((PAGE_PTR) vacuum_Data.last_page)))
+  else
     {
-      assert (!VPID_ISNULL (&vpid));
-      pgptr = pgbuf_fix (thread_p, &vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
-      if (pgptr == NULL)
-	{
-	  ASSERT_ERROR ();
-	  return;
-	}
-      assert (pgbuf_get_fix_count (pgptr) == 1);
-      VPID_COPY (&vpid, &((VACUUM_DATA_PAGE *) pgptr)->next_page);
-      pgbuf_unfix_and_init (thread_p, pgptr);
+      assert (pgbuf_get_fix_count ((PAGE_PTR) vacuum_Data.last_page) == 1);
+      assert (pgbuf_get_hold_count (thread_p) == 2);
     }
 }
 #endif /* !NDEBUG */

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -12144,3 +12144,20 @@ pgbuf_get_fix_count (PAGE_PTR pgptr)
 
   return bufptr->fcnt;
 }
+
+/*
+ * pgbuf_get_hold_count () - Get hold count for current thread.
+ *
+ * return        : Hold count
+ * thread_p (in) : Thread entry
+ */
+int
+pgbuf_get_hold_count (THREAD_ENTRY * thread_p)
+{
+  int me =
+#if defined (SERVER_MODE)
+    thread_p ? thread_p->index :
+#endif /* SERVER_MODE */
+    thread_get_current_entry_index ();
+  return pgbuf_Pool.thrd_holder_info[me].num_hold_cnt;
+}

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -457,4 +457,5 @@ extern int pgbuf_rv_flush_page (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern void pgbuf_rv_flush_page_dump (FILE * fp, int length, void *data);
 
 extern int pgbuf_get_fix_count (PAGE_PTR pgptr);
+extern int pgbuf_get_hold_count (THREAD_ENTRY * thread_p);
 #endif /* _PAGE_BUFFER_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20504

The fix count check was outdated. A while ago we changed access on vacuum data pages and how they get flushed on checkpoint. In the crash, checkpoint thread also fixed page during fix count check. Fix count was 2 instead of 1.

The purpose of the check was not to leak any pages. Since this is vacuum data thread, the check now has two components:
1 verify first and last vacuum data pages are only fixed once.
2 get number of page holds. it should be one if last page and first page are the same, or two otherwise.