### PR TITLE
[CBRD-20162] Fix or_mvcc_get_chn and or_mvcc_get_insid order (slip from #235)

### DIFF
--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -787,6 +787,12 @@ or_mvcc_get_header (RECDES * record, MVCC_REC_HEADER * mvcc_header)
   mvcc_header->repid = repid_and_flag_bits & OR_MVCC_REPID_MASK;
   mvcc_header->mvcc_flag = (char) ((repid_and_flag_bits >> OR_MVCC_FLAG_SHIFT_BITS) & OR_MVCC_FLAG_MASK);
 
+  mvcc_header->chn = or_mvcc_get_chn (&buf, &rc);
+  if (rc != NO_ERROR)
+    {
+      goto exit_on_error;
+    }
+
   mvcc_header->mvcc_ins_id = or_mvcc_get_insid (&buf, mvcc_header->mvcc_flag, &rc);
   if (rc != NO_ERROR)
     {
@@ -794,12 +800,6 @@ or_mvcc_get_header (RECDES * record, MVCC_REC_HEADER * mvcc_header)
     }
 
   mvcc_header->mvcc_del_id = or_mvcc_get_delid (&buf, mvcc_header->mvcc_flag, &rc);
-  if (rc != NO_ERROR)
-    {
-      goto exit_on_error;
-    }
-
-  mvcc_header->chn = or_mvcc_get_chn (&buf, &rc);
   if (rc != NO_ERROR)
     {
       goto exit_on_error;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -18968,7 +18968,7 @@ heap_set_mvcc_rec_header_on_overflow (PAGE_PTR ovf_page, MVCC_REC_HEADER * mvcc_
 
   if (!MVCC_IS_FLAG_SET (mvcc_header, OR_MVCC_FLAG_VALID_DELID))
     {
-      /* Add MVCCID_ALL_VISIBLE for delete MVCCID */
+      /* Add MVCCID_NULL for delete MVCCID */
       MVCC_SET_FLAG_BITS (mvcc_header, OR_MVCC_FLAG_VALID_DELID);
       MVCC_SET_DELID (mvcc_header, MVCCID_NULL);
     }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -18968,7 +18968,7 @@ heap_set_mvcc_rec_header_on_overflow (PAGE_PTR ovf_page, MVCC_REC_HEADER * mvcc_
 
   if (!MVCC_IS_FLAG_SET (mvcc_header, OR_MVCC_FLAG_VALID_DELID))
     {
-      /* Add MVCCID_ALL_VISIBLE for insert MVCCID */
+      /* Add MVCCID_ALL_VISIBLE for delete MVCCID */
       MVCC_SET_FLAG_BITS (mvcc_header, OR_MVCC_FLAG_VALID_DELID);
       MVCC_SET_DELID (mvcc_header, MVCCID_NULL);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20162
or_mvcc_get_chn was called after insid and delid, which caused some errors.
This is a slip for CBRD-20162.