### PR TITLE
[CBRD-20524] In transform_cl.c chn was set after insert id

### DIFF
--- a/src/executables/load_object.c
+++ b/src/executables/load_object.c
@@ -585,8 +585,9 @@ desc_obj_to_disk (DESC_OBJ * obj, RECDES * record, bool * index_flag)
 
       repid_bits |= (OR_MVCC_FLAG_VALID_INSID << OR_MVCC_FLAG_SHIFT_BITS);
       or_put_int (buf, repid_bits);
-      or_put_bigint (buf, MVCCID_NULL);	/* MVCC insert id */
       or_put_int (buf, 0);	/* CHN, fixed size */
+      or_put_bigint (buf, MVCCID_NULL);	/* MVCC insert id */
+
 
       /* variable info block */
       put_varinfo (buf, obj, offset_size);

--- a/src/executables/load_object.c
+++ b/src/executables/load_object.c
@@ -588,7 +588,6 @@ desc_obj_to_disk (DESC_OBJ * obj, RECDES * record, bool * index_flag)
       or_put_int (buf, 0);	/* CHN, fixed size */
       or_put_bigint (buf, MVCCID_NULL);	/* MVCC insert id */
 
-
       /* variable info block */
       put_varinfo (buf, obj, offset_size);
 

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -844,8 +844,8 @@ tf_mem_to_disk (MOP classmop, MOBJ classobj, MOBJ volatile obj, RECDES * record,
 
       repid_bits |= (OR_MVCC_FLAG_VALID_INSID << OR_MVCC_FLAG_SHIFT_BITS);
       or_put_int (buf, repid_bits);
-      or_put_bigint (buf, MVCCID_NULL);	/* MVCC insert id */
       or_put_int (buf, chn);	/* CHN, short size */
+      or_put_bigint (buf, MVCCID_NULL);	/* MVCC insert id */
 
       /* variable info block */
       put_varinfo (buf, obj, class_, offset_size);

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -2994,8 +2994,8 @@ catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OI
 
   repr_id_bits |= (OR_MVCC_FLAG_VALID_INSID << OR_MVCC_FLAG_SHIFT_BITS);
   or_put_int (buf_p, repr_id_bits);
-  or_put_bigint (buf_p, MVCCID_NULL);	/* MVCC insert id */
   or_put_int (buf_p, chn);	/* CHN */
+  or_put_bigint (buf_p, MVCCID_NULL);	/* MVCC insert id */
   header_size = OR_MVCC_INSERT_HEADER_SIZE;
 
   /* offset table */


### PR DESCRIPTION
In transform_cl.c, in function tf_mem_to_disk, chn was set after insert id, but the order was changed, so it must be set before.