### PR TITLE
[CBRD-20529] lockdb forces no blocking and latching a page may fail

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7503,7 +7503,7 @@ try_again:
   /* Impossible */
   assert_release (false);
 error:
-  assert (er_errid () != NO_ERROR);
+  assert (ret == ER_LK_PAGE_TIMEOUT || er_errid () != NO_ERROR);
 
   heap_clean_get_context (thread_p, context);
   return S_ERROR;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -10630,17 +10630,6 @@ pgbuf_ordered_fix_release (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAGE_
 
       assert (ret_pgptr == NULL);
 
-      if (latch_condition == PGBUF_UNCONDITIONAL_LATCH)
-	{
-	  /* continue */
-	  er_status = er_errid ();
-	  if (er_status == NO_ERROR)
-	    {
-	      er_status = ER_FAILED;
-	    }
-	  goto exit;
-	}
-
       er_status = er_errid_if_has_error ();
       if (er_status == ER_PB_BAD_PAGEID || er_status == ER_INTERRUPTED)
 	{
@@ -10659,6 +10648,17 @@ pgbuf_ordered_fix_release (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAGE_
 	       * is set : this allows scan of pages to continue */
 	      assert (wait_msecs == LK_FORCE_ZERO_WAIT);
 	      er_status = ER_LK_PAGE_TIMEOUT;
+	    }
+	  goto exit;
+	}
+
+      if (latch_condition == PGBUF_UNCONDITIONAL_LATCH)
+	{
+	  /* continue */
+	  er_status = er_errid ();
+	  if (er_status == NO_ERROR)
+	    {
+	      er_status = ER_FAILED;
 	    }
 	  goto exit;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20529

lockdb hit assertion, because it forces no wait (this means latching will be done as conditionally) and latching a page (to show mvcc info) may fail.
This is a quick hit.