### PR TITLE
[CBRD-20510] xcache_insert: fix cache entry count when new entry is not inserted and is not recompiled

### DIFF
--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -1338,7 +1338,7 @@ xcache_insert (THREAD_ENTRY * thread_p, const COMPILE_CONTEXT * context, XASL_ST
 	      xcache_unfix (thread_p, to_be_recompiled);
 	      to_be_recompiled = NULL;
 	    }
-	  else
+	  else if (inserted)
 	    {
 	      /* new entry added */
 	      ATOMIC_INC_32 (&xcache_Entry_count, 1);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20510