### PR TITLE
[CBRD-20533] Fix performance monitor redesign issues

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -2342,7 +2342,7 @@ perfmon_server_dump_stats_to_buffer (const UINT64 * stats, char *buffer, int buf
 	}
     }
 
-  while (i < PSTAT_COUNT && remained_size > 0)
+  for (; i < PSTAT_COUNT && remained_size > 0; i++)
     {
       if (substr != NULL)
 	{
@@ -2364,7 +2364,6 @@ perfmon_server_dump_stats_to_buffer (const UINT64 * stats, char *buffer, int buf
 	  return;
 	}
       pstat_Metadata[i].f_dump_in_buffer (p, &(stats[pstat_Metadata[i].start_offset]), &remained_size);
-      i++;
     }
 
   buffer[buf_size - 1] = '\0';

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -1964,7 +1964,7 @@ perfmon_get_from_statistic (THREAD_ENTRY * thread_p, const int statistic_id)
 void
 perfmon_lk_waited_time_on_objects (THREAD_ENTRY * thread_p, int lock_mode, UINT64 amount)
 {
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
 
   perfmon_add_stat (thread_p, PSTAT_LK_NUM_WAITED_TIME_ON_OBJECTS, amount);
   assert (lock_mode >= NA_LOCK && lock_mode <= SCH_M_LOCK);
@@ -2024,7 +2024,7 @@ perfmon_pbx_fix (THREAD_ENTRY * thread_p, int page_type, int page_found_mode, in
   int module;
   int offset;
 
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
 
   module = perfmon_get_module_type (thread_p);
 
@@ -2051,7 +2051,7 @@ perfmon_pbx_promote (THREAD_ENTRY * thread_p, int page_type, int promote_cond, i
   int module;
   int offset;
 
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
 
   module = perfmon_get_module_type (thread_p);
 
@@ -2078,7 +2078,7 @@ perfmon_pbx_unfix (THREAD_ENTRY * thread_p, int page_type, int buf_dirty, int di
   int module;
   int offset;
 
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
 
   module = perfmon_get_module_type (thread_p);
 
@@ -2105,7 +2105,7 @@ perfmon_pbx_lock_acquire_time (THREAD_ENTRY * thread_p, int page_type, int page_
   int module;
   int offset;
 
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
 
   module = perfmon_get_module_type (thread_p);
 
@@ -2133,7 +2133,7 @@ perfmon_pbx_hold_acquire_time (THREAD_ENTRY * thread_p, int page_type, int page_
   int module;
   int offset;
 
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
 
   module = perfmon_get_module_type (thread_p);
 
@@ -2160,7 +2160,7 @@ perfmon_pbx_fix_acquire_time (THREAD_ENTRY * thread_p, int page_type, int page_f
   int module;
   int offset;
 
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
 
   module = perfmon_get_module_type (thread_p);
 
@@ -2186,7 +2186,7 @@ perfmon_mvcc_snapshot (THREAD_ENTRY * thread_p, int snapshot, int rec_type, int 
 {
   int offset;
 
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
 
   assert (snapshot >= PERF_SNAPSHOT_SATISFIES_DELETE && snapshot < PERF_SNAPSHOT_CNT);
   assert (rec_type >= PERF_SNAPSHOT_RECORD_INSERTED_VACUUMED && rec_type < PERF_SNAPSHOT_RECORD_TYPE_CNT);
@@ -4127,7 +4127,7 @@ perfmon_add_at_offset (THREAD_ENTRY * thread_p, int offset, UINT64 amount)
 #endif /* SERVER_MODE || SA_MODE */
 
   assert (offset >= 0 && offset < pstat_Global.n_stat_values);
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
 
   /* Update global statistic. */
   statvalp = pstat_Global.global_stats + offset;
@@ -4191,7 +4191,7 @@ perfmon_set_at_offset (THREAD_ENTRY * thread_p, int offset, int statval)
 #endif /* SERVER_MODE || SA_MODE */
 
   assert (offset >= 0 && offset < pstat_Global.n_stat_values);
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
 
   /* Update global statistic. */
   statvalp = pstat_Global.global_stats + offset;
@@ -4259,7 +4259,7 @@ perfmon_time_at_offset (THREAD_ENTRY * thread_p, int offset, UINT64 timediff)
 #endif /* SERVER_MODE || SA_MODE */
 
   assert (offset >= 0 && offset < pstat_Global.n_stat_values);
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
 
   /* Update global statistics. */
   statvalp = pstat_Global.global_stats + offset;

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -4015,6 +4015,7 @@ perfmon_stop_watch (THREAD_ENTRY * thread_p)
 
   pstat_Global.is_watching[tran_index] = false;
 }
+#endif /* SERVER_MODE || SA_MODE */
 
 /*
  * perfmon_is_perf_tracking () - Returns true if there are active threads
@@ -4040,7 +4041,6 @@ perfmon_is_perf_tracking_and_active (int activation_flag)
 {
   return perfmon_is_perf_tracking () && (activation_flag & pstat_Global.activation_flag);
 }
-#endif /* SERVER_MODE || SA_MODE */
 
 /*
  *  Add/set stats section.

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -503,23 +503,27 @@ PSTAT_METADATA pstat_Metadata[] = {
 #define PSTAT_COUNTER_TIMER_MAX_TIME_VALUE(startvalp) ((startvalp) + 2)
 #define PSTAT_COUNTER_TIMER_AVG_TIME_VALUE(startvalp) ((startvalp) + 3)
 
-static void perfmon_add_at_offset (THREAD_ENTRY * thread_p, int offset, UINT64 amount);
-static void perfmon_add_stat_at_offset (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, const int offset, UINT64 amount);
-static void perfmon_set_at_offset (THREAD_ENTRY * thread_p, int offset, int statval);
-static void perfmon_time_at_offset (THREAD_ENTRY * thread_p, int offset, UINT64 timediff);
+STATIC_INLINE void perfmon_add_at_offset (THREAD_ENTRY * thread_p, int offset, UINT64 amount)
+  __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void perfmon_add_stat_at_offset (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, const int offset,
+					       UINT64 amount) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void perfmon_set_at_offset (THREAD_ENTRY * thread_p, int offset, int statval)
+  __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void perfmon_time_at_offset (THREAD_ENTRY * thread_p, int offset, UINT64 timediff)
+  __attribute__ ((ALWAYS_INLINE));
 
 static void perfmon_server_calc_stats (UINT64 * stats);
 
-static const char *perfmon_stat_module_name (const int module);
-static INLINE int perfmon_get_module_type (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
-static const char *perfmon_stat_page_type_name (const int page_type);
-static const char *perfmon_stat_page_mode_name (const int page_mode);
-static const char *perfmon_stat_holder_latch_name (const int holder_latch);
-static const char *perfmon_stat_cond_type_name (const int cond_type);
-static const char *perfmon_stat_promote_cond_name (const int cond_type);
-static const char *perfmon_stat_snapshot_name (const int snapshot);
-static const char *perfmon_stat_snapshot_record_type (const int rec_type);
-static const char *perfmon_stat_lock_mode_name (const int lock_mode);
+STATIC_INLINE const char *perfmon_stat_module_name (const int module) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE int perfmon_get_module_type (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_page_type_name (const int page_type) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_page_mode_name (const int page_mode) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_holder_latch_name (const int holder_latch) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_cond_type_name (const int cond_type) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_promote_cond_name (const int cond_type) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_snapshot_name (const int snapshot) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_snapshot_record_type (const int rec_type) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_lock_mode_name (const int lock_mode) __attribute__ ((ALWAYS_INLINE));
 
 #if defined(CS_MODE) || defined(SA_MODE)
 bool perfmon_Iscollecting_stats = false;
@@ -1960,17 +1964,11 @@ perfmon_get_from_statistic (THREAD_ENTRY * thread_p, const int statistic_id)
 void
 perfmon_lk_waited_time_on_objects (THREAD_ENTRY * thread_p, int lock_mode, UINT64 amount)
 {
-  UINT64 *stats;
+  assert (perfmon_is_perf_tracking ());
 
-  stats = perfmon_server_get_stats (thread_p);
-  if (stats != NULL)
-    {
-      perfmon_add_stat (thread_p, PSTAT_LK_NUM_WAITED_TIME_ON_OBJECTS, amount);
-
-      assert (lock_mode >= NA_LOCK && lock_mode <= SCH_M_LOCK);
-
-      perfmon_add_stat_at_offset (thread_p, PSTAT_OBJ_LOCK_TIME_COUNTERS, lock_mode, amount);
-    }
+  perfmon_add_stat (thread_p, PSTAT_LK_NUM_WAITED_TIME_ON_OBJECTS, amount);
+  assert (lock_mode >= NA_LOCK && lock_mode <= SCH_M_LOCK);
+  perfmon_add_stat_at_offset (thread_p, PSTAT_OBJ_LOCK_TIME_COUNTERS, lock_mode, amount);
 }
 
 UINT64
@@ -2023,26 +2021,23 @@ perfmon_get_stats_and_clear (THREAD_ENTRY * thread_p, const char *stat_name)
 void
 perfmon_pbx_fix (THREAD_ENTRY * thread_p, int page_type, int page_found_mode, int latch_mode, int cond_type)
 {
-  UINT64 *stats;
   int module;
   int offset;
 
-  stats = perfmon_server_get_stats (thread_p);
-  if (stats != NULL)
-    {
-      module = perfmon_get_module_type (thread_p);
+  assert (perfmon_is_perf_tracking ());
 
-      assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
-      assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
-      assert (page_found_mode >= PERF_PAGE_MODE_OLD_LOCK_WAIT && page_found_mode < PERF_PAGE_MODE_CNT);
-      assert (latch_mode >= PERF_HOLDER_LATCH_READ && latch_mode < PERF_HOLDER_LATCH_CNT);
-      assert (cond_type >= PERF_CONDITIONAL_FIX && cond_type < PERF_CONDITIONAL_FIX_CNT);
+  module = perfmon_get_module_type (thread_p);
 
-      offset = PERF_PAGE_FIX_STAT_OFFSET (module, page_type, page_found_mode, latch_mode, cond_type);
-      assert (offset < PERF_PAGE_FIX_COUNTERS);
+  assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
+  assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
+  assert (page_found_mode >= PERF_PAGE_MODE_OLD_LOCK_WAIT && page_found_mode < PERF_PAGE_MODE_CNT);
+  assert (latch_mode >= PERF_HOLDER_LATCH_READ && latch_mode < PERF_HOLDER_LATCH_CNT);
+  assert (cond_type >= PERF_CONDITIONAL_FIX && cond_type < PERF_CONDITIONAL_FIX_CNT);
 
-      perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_FIX_COUNTERS, offset, 1);
-    }
+  offset = PERF_PAGE_FIX_STAT_OFFSET (module, page_type, page_found_mode, latch_mode, cond_type);
+  assert (offset < PERF_PAGE_FIX_COUNTERS);
+
+  perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_FIX_COUNTERS, offset, 1);
 }
 
 /*
@@ -2053,27 +2048,24 @@ void
 perfmon_pbx_promote (THREAD_ENTRY * thread_p, int page_type, int promote_cond, int holder_latch, int success,
 		     UINT64 amount)
 {
-  UINT64 *stats;
   int module;
   int offset;
 
-  stats = perfmon_server_get_stats (thread_p);
-  if (stats != NULL)
-    {
-      module = perfmon_get_module_type (thread_p);
+  assert (perfmon_is_perf_tracking ());
 
-      assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
-      assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
-      assert (promote_cond >= PERF_PROMOTE_ONLY_READER && promote_cond < PERF_PROMOTE_CONDITION_CNT);
-      assert (holder_latch >= PERF_HOLDER_LATCH_READ && holder_latch < PERF_HOLDER_LATCH_CNT);
-      assert (success == 0 || success == 1);
+  module = perfmon_get_module_type (thread_p);
 
-      offset = PERF_PAGE_PROMOTE_STAT_OFFSET (module, page_type, promote_cond, holder_latch, success);
-      assert (offset < PERF_PAGE_PROMOTE_COUNTERS);
+  assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
+  assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
+  assert (promote_cond >= PERF_PROMOTE_ONLY_READER && promote_cond < PERF_PROMOTE_CONDITION_CNT);
+  assert (holder_latch >= PERF_HOLDER_LATCH_READ && holder_latch < PERF_HOLDER_LATCH_CNT);
+  assert (success == 0 || success == 1);
 
-      perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_PROMOTE_COUNTERS, offset, 1);
-      perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_PROMOTE_TIME_COUNTERS, offset, amount);
-    }
+  offset = PERF_PAGE_PROMOTE_STAT_OFFSET (module, page_type, promote_cond, holder_latch, success);
+  assert (offset < PERF_PAGE_PROMOTE_COUNTERS);
+
+  perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_PROMOTE_COUNTERS, offset, 1);
+  perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_PROMOTE_TIME_COUNTERS, offset, amount);
 }
 
 /*
@@ -2083,26 +2075,23 @@ perfmon_pbx_promote (THREAD_ENTRY * thread_p, int page_type, int promote_cond, i
 void
 perfmon_pbx_unfix (THREAD_ENTRY * thread_p, int page_type, int buf_dirty, int dirtied_by_holder, int holder_latch)
 {
-  UINT64 *stats;
   int module;
   int offset;
 
-  stats = perfmon_server_get_stats (thread_p);
-  if (stats != NULL)
-    {
-      module = perfmon_get_module_type (thread_p);
+  assert (perfmon_is_perf_tracking ());
 
-      assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
-      assert (page_type > PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
-      assert (buf_dirty == 0 || buf_dirty == 1);
-      assert (dirtied_by_holder == 0 || dirtied_by_holder == 1);
-      assert (holder_latch >= PERF_HOLDER_LATCH_READ && holder_latch < PERF_HOLDER_LATCH_CNT);
+  module = perfmon_get_module_type (thread_p);
 
-      offset = PERF_PAGE_UNFIX_STAT_OFFSET (module, page_type, buf_dirty, dirtied_by_holder, holder_latch);
-      assert (offset < PERF_PAGE_UNFIX_COUNTERS);
+  assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
+  assert (page_type > PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
+  assert (buf_dirty == 0 || buf_dirty == 1);
+  assert (dirtied_by_holder == 0 || dirtied_by_holder == 1);
+  assert (holder_latch >= PERF_HOLDER_LATCH_READ && holder_latch < PERF_HOLDER_LATCH_CNT);
 
-      perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_UNFIX_COUNTERS, offset, 1);
-    }
+  offset = PERF_PAGE_UNFIX_STAT_OFFSET (module, page_type, buf_dirty, dirtied_by_holder, holder_latch);
+  assert (offset < PERF_PAGE_UNFIX_COUNTERS);
+
+  perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_UNFIX_COUNTERS, offset, 1);
 }
 
 /*
@@ -2113,27 +2102,24 @@ void
 perfmon_pbx_lock_acquire_time (THREAD_ENTRY * thread_p, int page_type, int page_found_mode, int latch_mode,
 			       int cond_type, UINT64 amount)
 {
-  UINT64 *stats;
   int module;
   int offset;
 
-  stats = perfmon_server_get_stats (thread_p);
-  if (stats != NULL)
-    {
-      module = perfmon_get_module_type (thread_p);
+  assert (perfmon_is_perf_tracking ());
 
-      assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
-      assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
-      assert (page_found_mode >= PERF_PAGE_MODE_OLD_LOCK_WAIT && page_found_mode < PERF_PAGE_MODE_CNT);
-      assert (latch_mode >= PERF_HOLDER_LATCH_READ && latch_mode < PERF_HOLDER_LATCH_CNT);
-      assert (cond_type >= PERF_CONDITIONAL_FIX && cond_type < PERF_CONDITIONAL_FIX_CNT);
-      assert (amount > 0);
+  module = perfmon_get_module_type (thread_p);
 
-      offset = PERF_PAGE_LOCK_TIME_OFFSET (module, page_type, page_found_mode, latch_mode, cond_type);
-      assert (offset < PERF_PAGE_LOCK_TIME_COUNTERS);
+  assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
+  assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
+  assert (page_found_mode >= PERF_PAGE_MODE_OLD_LOCK_WAIT && page_found_mode < PERF_PAGE_MODE_CNT);
+  assert (latch_mode >= PERF_HOLDER_LATCH_READ && latch_mode < PERF_HOLDER_LATCH_CNT);
+  assert (cond_type >= PERF_CONDITIONAL_FIX && cond_type < PERF_CONDITIONAL_FIX_CNT);
+  assert (amount > 0);
 
-      perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_LOCK_TIME_COUNTERS, offset, amount);
-    }
+  offset = PERF_PAGE_LOCK_TIME_OFFSET (module, page_type, page_found_mode, latch_mode, cond_type);
+  assert (offset < PERF_PAGE_LOCK_TIME_COUNTERS);
+
+  perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_LOCK_TIME_COUNTERS, offset, amount);
 }
 
 /*
@@ -2144,26 +2130,23 @@ void
 perfmon_pbx_hold_acquire_time (THREAD_ENTRY * thread_p, int page_type, int page_found_mode, int latch_mode,
 			       UINT64 amount)
 {
-  UINT64 *stats;
   int module;
   int offset;
 
-  stats = perfmon_server_get_stats (thread_p);
-  if (stats != NULL)
-    {
-      module = perfmon_get_module_type (thread_p);
+  assert (perfmon_is_perf_tracking ());
 
-      assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
-      assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
-      assert (page_found_mode >= PERF_PAGE_MODE_OLD_LOCK_WAIT && page_found_mode < PERF_PAGE_MODE_CNT);
-      assert (latch_mode >= PERF_HOLDER_LATCH_READ && latch_mode < PERF_HOLDER_LATCH_CNT);
-      assert (amount > 0);
+  module = perfmon_get_module_type (thread_p);
 
-      offset = PERF_PAGE_HOLD_TIME_OFFSET (module, page_type, page_found_mode, latch_mode);
-      assert (offset < PERF_PAGE_HOLD_TIME_COUNTERS);
+  assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
+  assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
+  assert (page_found_mode >= PERF_PAGE_MODE_OLD_LOCK_WAIT && page_found_mode < PERF_PAGE_MODE_CNT);
+  assert (latch_mode >= PERF_HOLDER_LATCH_READ && latch_mode < PERF_HOLDER_LATCH_CNT);
+  assert (amount > 0);
 
-      perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_HOLD_TIME_COUNTERS, offset, amount);
-    }
+  offset = PERF_PAGE_HOLD_TIME_OFFSET (module, page_type, page_found_mode, latch_mode);
+  assert (offset < PERF_PAGE_HOLD_TIME_COUNTERS);
+
+  perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_HOLD_TIME_COUNTERS, offset, amount);
 }
 
 /*
@@ -2174,27 +2157,24 @@ void
 perfmon_pbx_fix_acquire_time (THREAD_ENTRY * thread_p, int page_type, int page_found_mode, int latch_mode,
 			      int cond_type, UINT64 amount)
 {
-  UINT64 *stats;
   int module;
   int offset;
 
-  stats = perfmon_server_get_stats (thread_p);
-  if (stats != NULL)
-    {
-      module = perfmon_get_module_type (thread_p);
+  assert (perfmon_is_perf_tracking ());
 
-      assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
-      assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
-      assert (page_found_mode >= PERF_PAGE_MODE_OLD_LOCK_WAIT && page_found_mode < PERF_PAGE_MODE_CNT);
-      assert (latch_mode >= PERF_HOLDER_LATCH_READ && latch_mode < PERF_HOLDER_LATCH_CNT);
-      assert (cond_type >= PERF_CONDITIONAL_FIX && cond_type < PERF_CONDITIONAL_FIX_CNT);
-      assert (amount > 0);
+  module = perfmon_get_module_type (thread_p);
 
-      offset = PERF_PAGE_FIX_TIME_OFFSET (module, page_type, page_found_mode, latch_mode, cond_type);
-      assert (offset < PERF_PAGE_FIX_TIME_COUNTERS);
+  assert (module >= PERF_MODULE_SYSTEM && module < PERF_MODULE_CNT);
+  assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
+  assert (page_found_mode >= PERF_PAGE_MODE_OLD_LOCK_WAIT && page_found_mode < PERF_PAGE_MODE_CNT);
+  assert (latch_mode >= PERF_HOLDER_LATCH_READ && latch_mode < PERF_HOLDER_LATCH_CNT);
+  assert (cond_type >= PERF_CONDITIONAL_FIX && cond_type < PERF_CONDITIONAL_FIX_CNT);
+  assert (amount > 0);
 
-      perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_FIX_TIME_COUNTERS, offset, amount);
-    }
+  offset = PERF_PAGE_FIX_TIME_OFFSET (module, page_type, page_found_mode, latch_mode, cond_type);
+  assert (offset < PERF_PAGE_FIX_TIME_COUNTERS);
+
+  perfmon_add_stat_at_offset (thread_p, PSTAT_PBX_FIX_TIME_COUNTERS, offset, amount);
 }
 
 /*
@@ -2204,20 +2184,17 @@ perfmon_pbx_fix_acquire_time (THREAD_ENTRY * thread_p, int page_type, int page_f
 void
 perfmon_mvcc_snapshot (THREAD_ENTRY * thread_p, int snapshot, int rec_type, int visibility)
 {
-  UINT64 *stats;
   int offset;
 
-  stats = perfmon_server_get_stats (thread_p);
-  if (stats != NULL)
-    {
-      assert (snapshot >= PERF_SNAPSHOT_SATISFIES_DELETE && snapshot < PERF_SNAPSHOT_CNT);
-      assert (rec_type >= PERF_SNAPSHOT_RECORD_INSERTED_VACUUMED && rec_type < PERF_SNAPSHOT_RECORD_TYPE_CNT);
-      assert (visibility >= PERF_SNAPSHOT_INVISIBLE && visibility < PERF_SNAPSHOT_VISIBILITY_CNT);
-      offset = PERF_MVCC_SNAPSHOT_OFFSET (snapshot, rec_type, visibility);
-      assert (offset < PERF_MVCC_SNAPSHOT_COUNTERS);
+  assert (perfmon_is_perf_tracking ());
 
-      perfmon_add_stat_at_offset (thread_p, PSTAT_MVCC_SNAPSHOT_COUNTERS, offset, 1);
-    }
+  assert (snapshot >= PERF_SNAPSHOT_SATISFIES_DELETE && snapshot < PERF_SNAPSHOT_CNT);
+  assert (rec_type >= PERF_SNAPSHOT_RECORD_INSERTED_VACUUMED && rec_type < PERF_SNAPSHOT_RECORD_TYPE_CNT);
+  assert (visibility >= PERF_SNAPSHOT_INVISIBLE && visibility < PERF_SNAPSHOT_VISIBILITY_CNT);
+  offset = PERF_MVCC_SNAPSHOT_OFFSET (snapshot, rec_type, visibility);
+  assert (offset < PERF_MVCC_SNAPSHOT_COUNTERS);
+
+  perfmon_add_stat_at_offset (thread_p, PSTAT_MVCC_SNAPSHOT_COUNTERS, offset, 1);
 }
 
 #endif /* SERVER_MODE || SA_MODE */
@@ -2723,7 +2700,7 @@ perfmon_server_calc_stats (UINT64 * stats)
 /*
  * perfmon_stat_module_name () -
  */
-static const char *
+STATIC_INLINE const char *
 perfmon_stat_module_name (const int module)
 {
   switch (module)
@@ -2791,7 +2768,7 @@ perfmon_get_module_type (THREAD_ENTRY * thread_p)
 /*
  * perf_stat_page_type_name () -
  */
-static const char *
+STATIC_INLINE const char *
 perfmon_stat_page_type_name (const int page_type)
 {
   switch (page_type)
@@ -2843,7 +2820,7 @@ perfmon_stat_page_type_name (const int page_type)
 /*
  * perfmon_stat_page_mode_name () -
  */
-static const char *
+STATIC_INLINE const char *
 perfmon_stat_page_mode_name (const int page_mode)
 {
   switch (page_mode)
@@ -2867,7 +2844,7 @@ perfmon_stat_page_mode_name (const int page_mode)
 /*
  * perfmon_stat_holder_latch_name () -
  */
-static const char *
+STATIC_INLINE const char *
 perfmon_stat_holder_latch_name (const int holder_latch)
 {
   switch (holder_latch)
@@ -2887,7 +2864,7 @@ perfmon_stat_holder_latch_name (const int holder_latch)
 /*
  * perfmon_stat_cond_type_name () -
  */
-static const char *
+STATIC_INLINE const char *
 perfmon_stat_cond_type_name (const int cond_type)
 {
   switch (cond_type)
@@ -2907,7 +2884,7 @@ perfmon_stat_cond_type_name (const int cond_type)
 /*
  * perfmon_stat_snapshot_name () -
  */
-static const char *
+STATIC_INLINE const char *
 perfmon_stat_snapshot_name (const int snapshot)
 {
   switch (snapshot)
@@ -2929,7 +2906,7 @@ perfmon_stat_snapshot_name (const int snapshot)
 /*
  * perfmon_stat_snapshot_record_type () -
  */
-static const char *
+STATIC_INLINE const char *
 perfmon_stat_snapshot_record_type (const int rec_type)
 {
   switch (rec_type)
@@ -2960,7 +2937,7 @@ perfmon_stat_snapshot_record_type (const int rec_type)
   return "ERROR";
 }
 
-static const char *
+STATIC_INLINE const char *
 perfmon_stat_lock_mode_name (const int lock_mode)
 {
   switch (lock_mode)
@@ -2996,7 +2973,7 @@ perfmon_stat_lock_mode_name (const int lock_mode)
 /*
  * perfmon_stat_cond_type_name () -
  */
-static const char *
+STATIC_INLINE const char *
 perfmon_stat_promote_cond_name (const int cond_type)
 {
   switch (cond_type)
@@ -4047,7 +4024,7 @@ perfmon_stop_watch (THREAD_ENTRY * thread_p)
 bool
 perfmon_is_perf_tracking (void)
 {
-  return pstat_Global.n_watchers > 0;
+  return pstat_Global.initialized && pstat_Global.n_watchers > 0;
 }
 
 /*
@@ -4082,10 +4059,9 @@ perfmon_add_stat (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, UINT64 amount)
 {
   PSTAT_METADATA *metadata = NULL;
 
-  assert (pstat_Global.initialized);
   assert (psid >= 0 && psid < PSTAT_COUNT);
 
-  if (pstat_Global.n_watchers <= 0)
+  if (!perfmon_is_perf_tracking ())
     {
       /* No need to collect statistics since no one is interested. */
       return;
@@ -4107,19 +4083,13 @@ perfmon_add_stat (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, UINT64 amount)
  * offset (in)   : offset at which to add the amount
  * amount (in)	 : Amount to add.
  */
-void
+STATIC_INLINE void
 perfmon_add_stat_at_offset (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, const int offset, UINT64 amount)
 {
   PSTAT_METADATA *metadata = NULL;
 
-  assert (pstat_Global.initialized);
+  assert (perfmon_is_perf_tracking ());
   assert (psid >= 0 && psid < PSTAT_COUNT);
-
-  if (pstat_Global.n_watchers <= 0)
-    {
-      /* No need to collect statistics since no one is interested. */
-      return;
-    }
 
   metadata = &pstat_Metadata[psid];
 
@@ -4148,7 +4118,7 @@ perfmon_inc_stat (THREAD_ENTRY * thread_p, PERF_STAT_ID psid)
  * offset (in)	 : Offset to statistics value.
  * amount (in)	 : Amount to add.
  */
-static void
+STATIC_INLINE void
 perfmon_add_at_offset (THREAD_ENTRY * thread_p, int offset, UINT64 amount)
 {
   UINT64 *statvalp = NULL;
@@ -4157,6 +4127,7 @@ perfmon_add_at_offset (THREAD_ENTRY * thread_p, int offset, UINT64 amount)
 #endif /* SERVER_MODE || SA_MODE */
 
   assert (offset >= 0 && offset < pstat_Global.n_stat_values);
+  assert (perfmon_is_perf_tracking ());
 
   /* Update global statistic. */
   statvalp = pstat_Global.global_stats + offset;
@@ -4191,7 +4162,7 @@ perfmon_set_stat (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, int statval)
   assert (pstat_Global.initialized);
   assert (psid >= 0 && psid < PSTAT_COUNT);
 
-  if (pstat_Global.n_watchers <= 0)
+  if (!perfmon_is_perf_tracking ())
     {
       /* No need to collect statistics since no one is interested. */
       return;
@@ -4211,7 +4182,7 @@ perfmon_set_stat (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, int statval)
  * offset (in)   : Offset to statistic value.
  * statval (in)	 : New statistic value.
  */
-static void
+STATIC_INLINE void
 perfmon_set_at_offset (THREAD_ENTRY * thread_p, int offset, int statval)
 {
   UINT64 *statvalp = NULL;
@@ -4220,6 +4191,7 @@ perfmon_set_at_offset (THREAD_ENTRY * thread_p, int offset, int statval)
 #endif /* SERVER_MODE || SA_MODE */
 
   assert (offset >= 0 && offset < pstat_Global.n_stat_values);
+  assert (perfmon_is_perf_tracking ());
 
   /* Update global statistic. */
   statvalp = pstat_Global.global_stats + offset;
@@ -4254,7 +4226,7 @@ perfmon_time_stat (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, UINT64 timediff)
   assert (pstat_Global.initialized);
   assert (psid >= 0 && psid < PSTAT_COUNT);
 
-  if (pstat_Global.n_watchers <= 0)
+  if (!perfmon_is_perf_tracking ())
     {
       /* No need to collect statistics since no one is interested. */
       return;
@@ -4276,7 +4248,7 @@ perfmon_time_stat (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, UINT64 timediff)
  *
  * NOTE: There will be three values modified: counter, total time and max time.
  */
-static void
+STATIC_INLINE void
 perfmon_time_at_offset (THREAD_ENTRY * thread_p, int offset, UINT64 timediff)
 {
   /* Update global statistics */
@@ -4287,6 +4259,7 @@ perfmon_time_at_offset (THREAD_ENTRY * thread_p, int offset, UINT64 timediff)
 #endif /* SERVER_MODE || SA_MODE */
 
   assert (offset >= 0 && offset < pstat_Global.n_stat_values);
+  assert (perfmon_is_perf_tracking ());
 
   /* Update global statistics. */
   statvalp = pstat_Global.global_stats + offset;

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -603,9 +603,10 @@ extern void perfmon_copy_values (UINT64 * src, UINT64 * dest);
 #if defined (SERVER_MODE) || defined (SA_MODE)
 extern void perfmon_start_watch (THREAD_ENTRY * thread_p);
 extern void perfmon_stop_watch (THREAD_ENTRY * thread_p);
+#endif /* SERVER_MODE || SA_MODE */
+
 extern bool perfmon_is_perf_tracking (void);
 extern bool perfmon_is_perf_tracking_and_active (int activation_flag);
-#endif /* SERVER_MODE || SA_MODE */
 
 extern void perfmon_add_stat (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, UINT64 amount);
 extern void perfmon_inc_stat (THREAD_ENTRY * thread_p, PERF_STAT_ID psid);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3231,13 +3231,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   common_ha_mode = prm_get_integer_value (PRM_ID_HA_MODE);
 #endif /* SERVER_MODE */
 
-  error_code = perfmon_initialize (MAX_NTRANS);
-  if (error_code != NO_ERROR)
-    {
-      ASSERT_ERROR ();
-      goto error;
-    }
-
   if (db_name == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_BO_UNKNOWN_DATABASE, 1, db_name);
@@ -3365,6 +3358,13 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   error_code = css_init_conn_list ();
   if (error_code != NO_ERROR)
     {
+      goto error;
+    }
+
+  error_code = perfmon_initialize (MAX_NTRANS);
+  if (error_code != NO_ERROR)
+    {
+      ASSERT_ERROR ();
       goto error;
     }
 

--- a/src/transaction/mvcc.c
+++ b/src/transaction/mvcc.c
@@ -257,7 +257,7 @@ mvcc_satisfies_snapshot (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, 
       if (!MVCC_IS_FLAG_SET (rec_header, OR_MVCC_FLAG_VALID_INSID))
 	{
 	  /* Record was inserted and is visible for all transactions */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_SNAPSHOT, PERF_SNAPSHOT_RECORD_INSERTED_VACUUMED,
 				     PERF_SNAPSHOT_VISIBLE);
@@ -268,7 +268,7 @@ mvcc_satisfies_snapshot (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, 
       else if (MVCC_IS_REC_INSERTED_BY_ME (thread_p, rec_header))
 	{
 	  /* Record was inserted by current transaction and is visible */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_SNAPSHOT,
 				     PERF_SNAPSHOT_RECORD_INSERTED_CURR_TRAN, PERF_SNAPSHOT_VISIBLE);
@@ -279,7 +279,7 @@ mvcc_satisfies_snapshot (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, 
 	{
 	  /* Record was inserted by an active transaction or by a transaction that has committed after snapshot was
 	   * obtained. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_SNAPSHOT,
 				     PERF_SNAPSHOT_RECORD_INSERTED_OTHER_TRAN, PERF_SNAPSHOT_INVISIBLE);
@@ -289,7 +289,7 @@ mvcc_satisfies_snapshot (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, 
       else
 	{
 	  /* The inserter transaction has committed and the record is visible to current transaction. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      if (rec_header->mvcc_ins_id != MVCCID_ALL_VISIBLE && vacuum_is_mvccid_vacuumed (rec_header->mvcc_ins_id))
 		{
@@ -311,7 +311,7 @@ mvcc_satisfies_snapshot (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, 
       if (MVCC_IS_REC_DELETED_BY_ME (thread_p, rec_header))
 	{
 	  /* The record was deleted by current transaction and it is not visible anymore. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_SNAPSHOT, PERF_SNAPSHOT_RECORD_DELETED_CURR_TRAN,
 				     PERF_SNAPSHOT_INVISIBLE);
@@ -323,7 +323,7 @@ mvcc_satisfies_snapshot (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, 
 	  /* !!TODO: Is this check necessary? It seems that if inserter is active, then so will be the deleter (actually
 	   *       they will be the same). It only adds an extra-check in a function frequently called.
 	   */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_SNAPSHOT, PERF_SNAPSHOT_RECORD_INSERTED_DELETED,
 				     PERF_SNAPSHOT_INVISIBLE);
@@ -334,7 +334,7 @@ mvcc_satisfies_snapshot (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, 
 	{
 	  /* The record was deleted by an active transaction or by a transaction that has committed after snapshot was
 	   * obtained. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_SNAPSHOT,
 				     PERF_SNAPSHOT_RECORD_DELETED_OTHER_TRAN, PERF_SNAPSHOT_VISIBLE);
@@ -344,7 +344,7 @@ mvcc_satisfies_snapshot (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, 
       else
 	{
 	  /* The deleter transaction has committed and the record is not visible to current transaction. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      if (vacuum_is_mvccid_vacuumed (rec_header->mvcc_del_id))
 		{
@@ -422,7 +422,7 @@ mvcc_satisfies_vacuum (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, MV
 	{
 	  /* 1: Record is all visible, and insert MVCCID was already removed/replaced. 2: Record was recently inserted
 	   * and is not yet visible to all active transactions. Cannot vacuum insert MVCCID. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      if (MVCC_IS_HEADER_DELID_VALID (rec_header)
 		  && MVCC_IS_REC_DELETED_SINCE_MVCCID (rec_header, oldest_mvccid))
@@ -447,7 +447,7 @@ mvcc_satisfies_vacuum (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, MV
 	{
 	  /* The inserter transaction has committed and the record is visible to all running transactions. Insert
 	   * MVCCID and previous version lsa can be removed. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_VACUUM, PERF_SNAPSHOT_RECORD_INSERTED_COMMITED,
 				     PERF_SNAPSHOT_VISIBLE);
@@ -458,7 +458,7 @@ mvcc_satisfies_vacuum (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, MV
   else
     {
       /* The deleter transaction has committed and the record is not visible to any running transactions. */
-      if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+      if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	{
 	  perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_VACUUM, PERF_SNAPSHOT_RECORD_DELETED_COMMITTED,
 				 PERF_SNAPSHOT_VISIBLE);
@@ -490,7 +490,7 @@ mvcc_satisfies_delete (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header)
       if (!MVCC_IS_FLAG_SET (rec_header, OR_MVCC_FLAG_VALID_INSID))
 	{
 	  /* Record was inserted and is visible for all transactions */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_DELETE, PERF_SNAPSHOT_RECORD_INSERTED_VACUUMED,
 				     PERF_SNAPSHOT_VISIBLE);
@@ -501,7 +501,7 @@ mvcc_satisfies_delete (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header)
       if (MVCC_IS_REC_INSERTED_BY_ME (thread_p, rec_header))
 	{
 	  /* Record is only visible to current transaction and can be safely deleted. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_DELETE, PERF_SNAPSHOT_RECORD_INSERTED_CURR_TRAN,
 				     PERF_SNAPSHOT_VISIBLE);
@@ -511,7 +511,7 @@ mvcc_satisfies_delete (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header)
       else if (MVCC_IS_REC_INSERTER_ACTIVE (thread_p, rec_header))
 	{
 	  /* Record is inserted by an active transaction and is not visible to current transaction. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_DELETE, PERF_SNAPSHOT_RECORD_INSERTED_OTHER_TRAN,
 				     PERF_SNAPSHOT_INVISIBLE);
@@ -521,7 +521,7 @@ mvcc_satisfies_delete (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header)
       else
 	{
 	  /* The inserter transaction has committed and the record can be deleted by current transaction. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      if (rec_header->mvcc_ins_id != MVCCID_ALL_VISIBLE && vacuum_is_mvccid_vacuumed (rec_header->mvcc_ins_id))
 		{
@@ -543,7 +543,7 @@ mvcc_satisfies_delete (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header)
       if (MVCC_IS_REC_DELETED_BY_ME (thread_p, rec_header))
 	{
 	  /* Record was already deleted by me... */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_DELETE, PERF_SNAPSHOT_RECORD_DELETED_CURR_TRAN,
 				     PERF_SNAPSHOT_INVISIBLE);
@@ -553,7 +553,7 @@ mvcc_satisfies_delete (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header)
       else if (MVCC_IS_REC_DELETER_ACTIVE (thread_p, rec_header))
 	{
 	  /* Record was deleted by an active transaction. Current transaction must wait until the deleter completes. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_DELETE, PERF_SNAPSHOT_RECORD_DELETED_OTHER_TRAN,
 				     PERF_SNAPSHOT_INVISIBLE);
@@ -563,7 +563,7 @@ mvcc_satisfies_delete (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header)
       else
 	{
 	  /* Record was already deleted and the deleter has committed. Cannot be updated by current transaction. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      if (vacuum_is_mvccid_vacuumed (rec_header->mvcc_del_id))
 		{
@@ -617,7 +617,7 @@ mvcc_satisfies_dirty (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, MVC
       if (!MVCC_IS_FLAG_SET (rec_header, OR_MVCC_FLAG_VALID_INSID))
 	{
 	  /* Record was inserted and is visible for all transactions */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_DIRTY, PERF_SNAPSHOT_RECORD_INSERTED_VACUUMED,
 				     PERF_SNAPSHOT_VISIBLE);
@@ -627,7 +627,7 @@ mvcc_satisfies_dirty (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, MVC
       else if (MVCC_IS_REC_INSERTED_BY_ME (thread_p, rec_header))
 	{
 	  /* Record was inserted by current transaction and is visible */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_DIRTY, PERF_SNAPSHOT_RECORD_INSERTED_CURR_TRAN,
 				     PERF_SNAPSHOT_VISIBLE);
@@ -638,7 +638,7 @@ mvcc_satisfies_dirty (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, MVC
 	{
 	  /* Record is inserted by an active transaction and is visible */
 	  snapshot->lowest_active_mvccid = MVCC_GET_INSID (rec_header);
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_DIRTY, PERF_SNAPSHOT_RECORD_INSERTED_OTHER_TRAN,
 				     PERF_SNAPSHOT_VISIBLE);
@@ -648,7 +648,7 @@ mvcc_satisfies_dirty (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, MVC
       else
 	{
 	  /* Record is inserted by committed transaction. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      if (rec_header->mvcc_ins_id != MVCCID_ALL_VISIBLE && vacuum_is_mvccid_vacuumed (rec_header->mvcc_ins_id))
 		{
@@ -670,7 +670,7 @@ mvcc_satisfies_dirty (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, MVC
       if (MVCC_IS_REC_DELETED_BY_ME (thread_p, rec_header))
 	{
 	  /* Record was deleted by current transaction and is not visible */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_DIRTY, PERF_SNAPSHOT_RECORD_DELETED_CURR_TRAN,
 				     PERF_SNAPSHOT_INVISIBLE);
@@ -681,7 +681,7 @@ mvcc_satisfies_dirty (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, MVC
 	{
 	  /* Record was deleted by other active transaction and is still visible */
 	  snapshot->highest_completed_mvccid = rec_header->mvcc_del_id;
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      perfmon_mvcc_snapshot (thread_p, PERF_SNAPSHOT_SATISFIES_DIRTY, PERF_SNAPSHOT_RECORD_DELETED_OTHER_TRAN,
 				     PERF_SNAPSHOT_VISIBLE);
@@ -692,7 +692,7 @@ mvcc_satisfies_dirty (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, MVC
       else
 	{
 	  /* Record was already deleted and the deleter has committed. */
-	  if (perfmon_get_activation_flag () & PERFMON_ACTIVE_MVCC_SNAPSHOT)
+	  if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_MVCC_SNAPSHOT))
 	    {
 	      if (vacuum_is_mvccid_vacuumed (rec_header->mvcc_del_id))
 		{


### PR DESCRIPTION
Affected issues:
http://jira.cubrid.org/browse/CBRD-20533
http://jira.cubrid.org/browse/CBRD-20535
http://jira.cubrid.org/browse/CBRD-20536

Maybe also:
http://jira.cubrid.org/browse/CBRD-20538

- performance statistics: skip collecting stats if perfmon is not initialized
- STATIC_INLINE internal perfmon functions
- check perfmon is tracking before calling perfmon_mvcc_snapshot
- initialize perfmon on server after css_init_conn_list