### PR TITLE
[CBRD-20542] Added the flag in the other structures

### DIFF
--- a/src/compat/dbi_compat.h
+++ b/src/compat/dbi_compat.h
@@ -2774,12 +2774,13 @@ union db_char
   {
     unsigned char style;
     unsigned char codeset;
-    bool is_max_string;
+    unsigned char is_max_string;
   } info;
   struct
   {
     unsigned char style;
     unsigned char codeset;
+    unsigned char is_max_string;
     unsigned char size;
     char buf[DB_SMALL_CHAR_BUF_SIZE];
   } sm;
@@ -2787,6 +2788,7 @@ union db_char
   {
     unsigned char style;
     unsigned char codeset;
+    unsigned char is_max_string;
     int size;
     char *buf;
   } medium;
@@ -2794,6 +2796,7 @@ union db_char
   {
     unsigned char style;
     unsigned char codeset;
+    unsigned char is_max_string;
     DB_LARGE_STRING *str;
   } large;
 };

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -776,12 +776,13 @@ union db_char
   {
     unsigned char style;
     unsigned char codeset;
-    bool is_max_string;
+    unsigned char is_max_string;
   } info;
   struct
   {
     unsigned char style;
     unsigned char codeset;
+    unsigned char is_max_string;
     unsigned char size;
     char buf[DB_SMALL_CHAR_BUF_SIZE];
   } sm;
@@ -789,6 +790,7 @@ union db_char
   {
     unsigned char style;
     unsigned char codeset;
+    unsigned char is_max_string;
     int size;
     char *buf;
   } medium;
@@ -796,6 +798,7 @@ union db_char
   {
     unsigned char style;
     unsigned char codeset;
+    unsigned char is_max_string;
     DB_LARGE_STRING *str;
   } large;
 };


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20542

This adds the `is_max_string` flag in the `sm`, `medium` and `large` structures from the `db_char` union. Also, it has been redefined to `unsigned char`.