### PR TITLE
[CBRD-20543] fixes initialization of pstat_Global for SA_MODE.

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -3863,39 +3863,38 @@ perfmon_initialize (int num_trans)
     }
   memset (pstat_Global.global_stats, 0, PERFMON_VALUES_MEMSIZE);
 
-  if (num_trans > 0)
+  assert (num_trans > 0);
+
+  pstat_Global.n_trans = num_trans + 1;	/* 1 more for easier indexing with tran_index */
+  memsize = pstat_Global.n_trans * sizeof (UINT64 *);
+  pstat_Global.tran_stats = (UINT64 **) malloc (memsize);
+  if (pstat_Global.tran_stats == NULL)
     {
-      pstat_Global.n_trans = num_trans;
-      memsize = pstat_Global.n_trans * sizeof (UINT64 *);
-      pstat_Global.tran_stats = (UINT64 **) malloc (memsize);
-      if (pstat_Global.tran_stats == NULL)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, memsize);
-	  goto error;
-	}
-      memsize = pstat_Global.n_trans * PERFMON_VALUES_MEMSIZE;
-      pstat_Global.tran_stats[0] = (UINT64 *) malloc (memsize);
-      if (pstat_Global.tran_stats[0] == NULL)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, memsize);
-	  goto error;
-	}
-      memset (pstat_Global.tran_stats[0], 0, memsize);
-
-      for (idx = 1; idx < pstat_Global.n_trans; idx++)
-	{
-	  pstat_Global.tran_stats[idx] = pstat_Global.tran_stats[0] + pstat_Global.n_stat_values * idx;
-	}
-
-      memsize = pstat_Global.n_trans * sizeof (bool);
-      pstat_Global.is_watching = (bool *) malloc (memsize);
-      if (pstat_Global.is_watching == NULL)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, memsize);
-	  goto error;
-	}
-      memset (pstat_Global.is_watching, 0, memsize);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, memsize);
+      goto error;
     }
+  memsize = pstat_Global.n_trans * PERFMON_VALUES_MEMSIZE;
+  pstat_Global.tran_stats[0] = (UINT64 *) malloc (memsize);
+  if (pstat_Global.tran_stats[0] == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, memsize);
+      goto error;
+    }
+  memset (pstat_Global.tran_stats[0], 0, memsize);
+
+  for (idx = 1; idx < pstat_Global.n_trans; idx++)
+    {
+      pstat_Global.tran_stats[idx] = pstat_Global.tran_stats[0] + pstat_Global.n_stat_values * idx;
+    }
+
+  memsize = pstat_Global.n_trans * sizeof (bool);
+  pstat_Global.is_watching = (bool *) malloc (memsize);
+  if (pstat_Global.is_watching == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, memsize);
+      goto error;
+    }
+  memset (pstat_Global.is_watching, 0, memsize);
 
   pstat_Global.n_watchers = 0;
   goto exit;

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -836,7 +836,7 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
   area_init ();
   locator_initialize_areas ();
 
-  error_code = perfmon_initialize (0 /* No trans */ );
+  error_code = perfmon_initialize (1);	/* 1 transaction for SA_MODE */
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -5593,7 +5593,7 @@ xboot_delete (THREAD_ENTRY * thread_p, const char *db_name, bool force_delete,
 
       er_clear ();
     }
-  error_code = perfmon_initialize (0);
+  error_code = perfmon_initialize (1);	/* 1 transaction for SA_MDOE */
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20543

This is a slip of #259.
Before #259, pstat_Global was initialized twice: one for SA_MODE and the other for SERVER_MODE. 
To avoid multiple initialization, it gave 0, no. of trans for SA_MODE and MAX_TRANS for SERVER_MODE. 
As #259, it is initialized once for SA_MODE with 0 transaction. This causes the crash. 

One another change is to allocate one more transaction slot for easier indexing with tran_index. Please notice that tran_index starts with 1 and 0 is reserved for system transaction. 
