### PR TITLE
[CBRD-20544] remove a bad assertion of perfmon_set_stat. It may be reached without initialization.

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -4157,7 +4157,6 @@ perfmon_set_stat (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, int statval)
 {
   PSTAT_METADATA *metadata = NULL;
 
-  assert (pstat_Global.initialized);
   assert (psid >= 0 && psid < PSTAT_COUNT);
 
   if (!perfmon_is_perf_tracking ())

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -4223,12 +4223,6 @@ perfmon_time_stat (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, UINT64 timediff)
   assert (pstat_Global.initialized);
   assert (psid >= 0 && psid < PSTAT_COUNT);
 
-  if (!perfmon_is_perf_tracking ())
-    {
-      /* No need to collect statistics since no one is interested. */
-      return;
-    }
-
   metadata = &pstat_Metadata[psid];
   assert (metadata->valtype == PSTAT_COUNTER_TIMER_VALUE);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20544

`perfmon_set_start` can be reached without initialization as `restoredb` for the case.