### PR TITLE
[CBRD-20545] fixes assertion and check for perfmon_add_stat_at_offset

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -4089,12 +4089,6 @@ perfmon_add_stat_at_offset (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, const in
   assert (pstat_Global.initialized);
   assert (psid >= 0 && psid < PSTAT_COUNT);
 
-  if (!perfmon_is_perf_tracking ())
-    {
-      /* No need to collect statistics since no one is interested. */
-      return;
-    }
-
   metadata = &pstat_Metadata[psid];
 
   /* Update statistics. */

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -4086,8 +4086,14 @@ perfmon_add_stat_at_offset (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, const in
 {
   PSTAT_METADATA *metadata = NULL;
 
-  assert (perfmon_is_perf_tracking ());
+  assert (pstat_Global.initialized);
   assert (psid >= 0 && psid < PSTAT_COUNT);
+
+  if (!perfmon_is_perf_tracking ())
+    {
+      /* No need to collect statistics since no one is interested. */
+      return;
+    }
 
   metadata = &pstat_Metadata[psid];
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20545

watcher disappeared during collection. It is known race condition. 
