### PR TITLE
[CBRD-20565] Leak issues

### DIFF
--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -7674,6 +7674,8 @@ or_put_enumeration (OR_BUF * buf, const DB_ENUMERATION * enumeration)
 		       DB_GET_ENUM_ELEM_STRING_SIZE (db_enum), DB_GET_ENUM_ELEM_CODESET (db_enum),
 		       enumeration->collation_id);
       rc = (*(tp_String.data_writeval)) (buf, &value);
+      pr_clear_value (&value);
+
       if (rc != NO_ERROR)
 	{
 	  break;

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -7638,6 +7638,7 @@ or_packed_enumeration_size (const DB_ENUMERATION * enumeration)
 		       DB_GET_ENUM_ELEM_STRING_SIZE (db_enum), DB_GET_ENUM_ELEM_CODESET (db_enum),
 		       LANG_GET_BINARY_COLLATION (DB_GET_ENUM_ELEM_CODESET (db_enum)));
       size += (*(tp_String.data_lengthval)) (&value, 1);
+      pr_clear_value (&value);
     }
 
   return size;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20565

After the patch with the compression enhance, `lengthval` and `writeval` functions will require a clear of the possible compressed string that might be stored in the local `DB_VALUE` inside the enumeration function.