### PR TITLE
[CBRD-20572] Fixed leak of bad value coercion

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -4532,13 +4532,15 @@ tp_can_steal_string (const DB_VALUE * val, const DB_DOMAIN * desired_domain)
     {
     case DB_TYPE_CHAR:
       return (desired_precision == original_length
-	      && (original_type == DB_TYPE_CHAR || original_type == DB_TYPE_VARCHAR));
+	      && (original_type == DB_TYPE_CHAR || original_type == DB_TYPE_VARCHAR)
+	      && DB_GET_COMPRESSED_STRING (val) == NULL);
     case DB_TYPE_VARCHAR:
       return (desired_precision >= original_length
 	      && (original_type == DB_TYPE_CHAR || original_type == DB_TYPE_VARCHAR));
     case DB_TYPE_NCHAR:
       return (desired_precision == original_length
-	      && (original_type == DB_TYPE_NCHAR || original_type == DB_TYPE_VARNCHAR));
+	      && (original_type == DB_TYPE_NCHAR || original_type == DB_TYPE_VARNCHAR)
+	      && DB_GET_COMPRESSED_STRING (val) == NULL);
     case DB_TYPE_VARNCHAR:
       return (desired_precision >= original_length
 	      && (original_type == DB_TYPE_NCHAR || original_type == DB_TYPE_VARNCHAR));

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2096,6 +2096,18 @@ pr_clear_value (DB_VALUE * value)
 	    }
 	  DB_SET_COMPRESSED_STRING (value, NULL, 0, false);
 	}
+      else if (db_type == DB_TYPE_CHAR || db_type == DB_TYPE_NCHAR)
+	{
+	  assert (value->data.ch.info.compressed_need_clear == false);
+	  if (value->data.ch.medium.compressed_buf != NULL)
+	    {
+	      if (value->data.ch.info.compressed_need_clear == true)
+		{
+		  db_private_free_and_init (NULL, value->data.ch.medium.compressed_buf);
+		}
+	    }
+
+	}
       break;
 
     case DB_TYPE_ELO:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20572

Since `VARCHAR` and `VARNCHAR` `DB_VALUE` types will now hold a possible `compressed_string`, when coercion is done, in some cases it would just change the type of the original `DB_VALUE`, therefore it might have become a `CHAR` or `NCHAR` type, types that could not have a `compressed_string` field in it. So now we just have to copy in the destination instead of just switching the types.