### PR TITLE
[CBRD-20570]  Added definitions for db_private_realloc_debug and db_private_realloc_release

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -3023,7 +3023,7 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 			    {
 			      vclass_names_alloced = 1 + DB_MAX_IDENTIFIER_LENGTH;
 			    }
-			  vclass_names = db_private_realloc (NULL, vclass_names, 2 * vclass_names_alloced);
+			  vclass_names = (char *) db_private_realloc (NULL, vclass_names, 2 * vclass_names_alloced);
 
 			  if (vclass_names == NULL)
 			    {
@@ -3050,7 +3050,7 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 			    {
 			      part_tables_alloced = 1 + DB_MAX_IDENTIFIER_LENGTH;
 			    }
-			  part_tables = db_private_realloc (NULL, part_tables, 2 * part_tables_alloced);
+			  part_tables = (char *) db_private_realloc (NULL, part_tables, 2 * part_tables_alloced);
 
 			  if (part_tables == NULL)
 			    {

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -639,11 +639,11 @@ col_expand_array (COL * col, long blockindex)
 
   if (col->array)
     {
-      col->array = db_private_realloc (NULL, col->array, EXPAND (blockindex) * sizeof (DB_VALUE *));
+      col->array = (DB_VALUE **) db_private_realloc (NULL, col->array, EXPAND (blockindex) * sizeof (DB_VALUE *));
     }
   else
     {
-      col->array = db_private_alloc (NULL, EXPAND (blockindex) * sizeof (DB_VALUE *));
+      col->array = (DB_VALUE **) db_private_alloc (NULL, EXPAND (blockindex) * sizeof (DB_VALUE *));
     }
   if (!col->array)
     {

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -924,7 +924,8 @@ EXPORTS
 ; db private
 	db_private_alloc_debug
 	db_private_alloc_release
-	db_private_realloc
+	db_private_realloc_debug
+	db_private_realloc_release
 	db_private_strdup
 	db_private_free_debug
 	db_private_free_release

--- a/win/cubridsa/cubridsa.def
+++ b/win/cubridsa/cubridsa.def
@@ -795,7 +795,8 @@ EXPORTS
 ; db private
 	db_private_alloc_debug
 	db_private_alloc_release
-	db_private_realloc
+	db_private_realloc_debug
+	db_private_realloc_release
 	db_private_strdup
 	db_private_free_debug
 	db_private_free_release


### PR DESCRIPTION
After the #291 there were introduced new functions, db_private_realloc_debug and db_private_realloc_release, and was defined a macro db_private_realloc. The compilation failed because it expected to find the function db_private_realloc, not just a macro, so I removed the old macro and added db_private_realloc_debug and db_private_realloc_release.