### PR TITLE
[CBRD-20576] disk_size required arguments with compatible collations

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -23715,7 +23715,6 @@ coerce_result:
     case PT_TIMEF:
     case PT_IF:
     case PT_REVERSE:
-    case PT_DISK_SIZE:
     case PT_CONNECT_BY_ROOT:
     case PT_PRIOR:
     case PT_QPRIOR:

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9023,6 +9023,7 @@ pt_is_able_to_determine_return_type (const PT_OP_TYPE op)
     case PT_TO_TIMESTAMP_TZ:
     case PT_TO_TIME_TZ:
     case PT_CRC32:
+    case PT_DISK_SIZE:
     case PT_SCHEMA_DEF:
       return true;
 
@@ -21681,7 +21682,6 @@ pt_is_op_w_collation (const PT_OP_TYPE op)
     case PT_IF:
     case PT_FIELD:
     case PT_REVERSE:
-    case PT_DISK_SIZE:
     case PT_CONNECT_BY_ROOT:
     case PT_PRIOR:
     case PT_QPRIOR:


### PR DESCRIPTION
A wrong attribute was set for disk_size function, which doesn't need collation. This is a slip of #270. I also added the disk_size function on the is_able_to_determine_return_type .
