### PR TITLE
[CBRD-20579] fixes client crash when a bad SQL hint is given to UPDAT…

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -6625,11 +6625,11 @@ exit_on_error:
     {
       parser_free_tree (parser, *use_idx);
     }
-  if (*index_ss != NULL)
+  if (index_ss != NULL && *index_ss != NULL)
     {
       parser_free_tree (parser, *index_ss);
     }
-  if (*index_ls != NULL)
+  if (index_ls != NULL && *index_ls != NULL)
     {
       parser_free_tree (parser, *index_ls);
     }


### PR DESCRIPTION
…E/DELETE

http://jira.cubrid.org/browse/CBRD-20578

When a bad SQLhint is given to UPDATE and DELETE statement, client crashes. 