### PR TITLE
[CBRD-20594] Clear val list regu variable before btree search in case of index covering

### DIFF
--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -2284,6 +2284,7 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
     }
   else
     {
+      /**/
       REGU_VARIABLE_LIST p;
       for (p = iscan_id->indx_cov.regu_val_list; p; p = p->next)
 	{

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5591,7 +5591,6 @@ scan_next_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 			  qfile_close_scan (thread_p, isidp->indx_cov.lsid);
 			  qfile_destroy_list (thread_p, isidp->indx_cov.list_id);
 			  QFILE_FREE_AND_INIT_LIST_ID (isidp->indx_cov.list_id);
-
 			  isidp->indx_cov.list_id =
 			    qfile_open_list (thread_p, isidp->indx_cov.type_list, NULL, isidp->indx_cov.query_id, 0);
 			  if (isidp->indx_cov.list_id == NULL)

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5478,6 +5478,16 @@ scan_next_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	       * first time */
 	      assert_release (!isidp->iss.use || isidp->iss.current_op == ISS_OP_NONE);
 
+	      if (SCAN_IS_INDEX_COVERED (isidp))
+		{
+		  /* TO DO - comment */
+		  REGU_VARIABLE_LIST p;
+		  for (p = isidp->indx_cov.regu_val_list; p; p = p->next)
+		    {
+		      pr_clear_value (p->value.vfetch_to);
+		    }
+		}
+
 	      ret = call_get_next_index_oidset (thread_p, scan_id, isidp, true);
 	      if (ret != S_SUCCESS)
 		{
@@ -5578,10 +5588,18 @@ scan_next_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
 		      if (SCAN_IS_INDEX_COVERED (isidp))
 			{
+			  REGU_VARIABLE_LIST p;
 			  /* close current list and start a new one */
 			  qfile_close_scan (thread_p, isidp->indx_cov.lsid);
 			  qfile_destroy_list (thread_p, isidp->indx_cov.list_id);
 			  QFILE_FREE_AND_INIT_LIST_ID (isidp->indx_cov.list_id);
+
+
+			  for (p = isidp->indx_cov.regu_val_list; p; p = p->next)
+			    {
+			      pr_clear_value (p->value.vfetch_to);
+			    }
+
 			  isidp->indx_cov.list_id =
 			    qfile_open_list (thread_p, isidp->indx_cov.type_list, NULL, isidp->indx_cov.query_id, 0);
 			  if (isidp->indx_cov.list_id == NULL)

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -2284,7 +2284,7 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
     }
   else
     {
-      /**/
+      /* Clear output val list to avoid memory leak. */
       REGU_VARIABLE_LIST p;
       for (p = iscan_id->indx_cov.regu_val_list; p; p = p->next)
 	{

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -2282,6 +2282,14 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
     {
       return NO_ERROR;
     }
+  else
+    {
+      REGU_VARIABLE_LIST p;
+      for (p = iscan_id->indx_cov.regu_val_list; p; p = p->next)
+	{
+	  pr_clear_value (p->value.vfetch_to);
+	}
+    }
 
   switch (indx_infop->range_type)
     {
@@ -5478,16 +5486,6 @@ scan_next_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	       * first time */
 	      assert_release (!isidp->iss.use || isidp->iss.current_op == ISS_OP_NONE);
 
-	      if (SCAN_IS_INDEX_COVERED (isidp))
-		{
-		  /* TO DO - comment */
-		  REGU_VARIABLE_LIST p;
-		  for (p = isidp->indx_cov.regu_val_list; p; p = p->next)
-		    {
-		      pr_clear_value (p->value.vfetch_to);
-		    }
-		}
-
 	      ret = call_get_next_index_oidset (thread_p, scan_id, isidp, true);
 	      if (ret != S_SUCCESS)
 		{
@@ -5588,17 +5586,10 @@ scan_next_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
 		      if (SCAN_IS_INDEX_COVERED (isidp))
 			{
-			  REGU_VARIABLE_LIST p;
 			  /* close current list and start a new one */
 			  qfile_close_scan (thread_p, isidp->indx_cov.lsid);
 			  qfile_destroy_list (thread_p, isidp->indx_cov.list_id);
 			  QFILE_FREE_AND_INIT_LIST_ID (isidp->indx_cov.list_id);
-
-
-			  for (p = isidp->indx_cov.regu_val_list; p; p = p->next)
-			    {
-			      pr_clear_value (p->value.vfetch_to);
-			    }
 
 			  isidp->indx_cov.list_id =
 			    qfile_open_list (thread_p, isidp->indx_cov.type_list, NULL, isidp->indx_cov.query_id, 0);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20594

The crash is caused by memory leak. The leak occurs when executes a join and the inner is scanned using index coverage. The index is scanned twice.
Currently, index coverage uses the same db_value to write in partial result (`iscan_id->indx_cov.list_id`) and in final result (`xasl->list_id`). Thus, the value is used to dump in index coverage list file first, through `iscan_id->indx_cov.output_val_list` regu variable (`btree_dump_curr_key` function).
After index scanning, the values is used to write in xasl list file through `xasl->outptr_list` (`qexec_end_one_iteration` function).
The value must be cleared if we scan the same tree twice. Otherwise, the db_value written with `xasl->outptr_list` will not be clearead and will be filled with the next scanned value (`btree_dump_curr_key` function).
There are 3 possible fixes:
* clear the value at scan beginning in `scan_get_index_oidset`
* clear the value at the beginning of in `btree_dump_curr_key`
* uses a new regu variable

I choose the first fix for now - seems to be simply and fast.