### PR TITLE
[CBRD-20599] revert potential leak fix on fetch_copy_dbval

### DIFF
--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4485,11 +4485,6 @@ fetch_copy_dbval (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       *dbval = *tmp;
     }
 
-  if (readonly_val != NULL && readonly_val->need_clear == true)
-    {
-      pr_clear_value (readonly_val);
-    }
-
   return result;
 }
 


### PR DESCRIPTION
This fixes:
http://jira.cubrid.org/browse/CBRD-20599
http://jira.cubrid.org/browse/CBRD-20600
http://jira.cubrid.org/browse/CBRD-20601
http://jira.cubrid.org/browse/CBRD-20603
http://jira.cubrid.org/browse/CBRD-20604

I know the patch may cause potential memory leak but I've not found a counter case. 
I'd like to propose to revert the change to fix the regression cases and consider a fix for potential leaks with a repro case.
