### PR TITLE
[CBRD-20615] Search also in computed statistics names

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -2234,7 +2234,7 @@ perfmon_server_dump_stats_to_buffer (const UINT64 * stats, char *buffer, int buf
 	  break;
 	}
 
-      if (substr != NULL && (pstat_Metadata[i].valtype != PSTAT_COMPUTED_RATIO_VALUE))
+      if (substr != NULL)
 	{
 	  s = strstr (pstat_Metadata[i].stat_name, substr);
 	}
@@ -2330,7 +2330,7 @@ perfmon_server_dump_stats (const UINT64 * stats, FILE * stream, const char *subs
 	  break;
 	}
 
-      if (substr != NULL && (pstat_Metadata[i].valtype != PSTAT_COMPUTED_RATIO_VALUE))
+      if (substr != NULL)
 	{
 	  s = strstr (pstat_Metadata[i].stat_name, substr);
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20615

I added searching also for computed statistics. In the current implementation those statistics will not appear in the statdump if the searched string isn't found in the statistic name. Basically the other statistics will not be listed as it was in the previous performance monitor implementation.