### PR TITLE
[CBRD-20627] disk_volume_boot: fix number of free pages for temporary purpose volumes

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2001,7 +2001,7 @@ disk_volume_boot (THREAD_ENTRY * thread_p, VOLID volid, DB_VOLPURPOSE * purpose_
 	  ASSERT_ERROR ();
 	  goto exit;
 	}
-      space_out->n_free_sects = space_out->n_total_sects - SECTOR_FROM_PAGEID (volheader->sys_lastpage);
+      space_out->n_free_sects = space_out->n_total_sects - SECTOR_FROM_PAGEID (volheader->sys_lastpage) - 1;
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20627

Fixed the free sector count of temporary purpose volume after resetting.