### PR TITLE
[CBRD-20654] fixes bad unfix of file_temp_reset_user_pages

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -7992,7 +7992,7 @@ file_temp_reset_user_pages (THREAD_ENTRY * thread_p, const VFID * vfid)
       vpid_next = extdata_part_ftab->vpid_next;
       if (page_ftab != page_fhead)
 	{
-	  pgbuf_unfix (thread_p, page_fhead);
+	  pgbuf_unfix (thread_p, page_ftab);
 	}
       page_ftab = NULL;
       if (VPID_ISNULL (&vpid_next))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20654

It should unfix `page_ftab` not `page_fhead`.