### PR TITLE
[CBRD-20629] file temporary cache: fix retiring preserved files

### DIFF
--- a/src/query/query_manager.h
+++ b/src/query/query_manager.h
@@ -150,7 +150,7 @@ extern QMGR_TEMP_FILE *qmgr_create_new_temp_file (THREAD_ENTRY * thread_p, QUERY
 extern QMGR_TEMP_FILE *qmgr_create_result_file (THREAD_ENTRY * thread_p, QUERY_ID query_id);
 extern int qmgr_free_list_temp_file (THREAD_ENTRY * thread_p, QUERY_ID query_id, QMGR_TEMP_FILE * tfile_vfidp);
 extern int qmgr_free_temp_file_list (THREAD_ENTRY * thread_p, QMGR_TEMP_FILE * tfile_vfidp, QUERY_ID query_id,
-				     bool is_error);
+				     bool is_error, bool was_preserved);
 
 #if defined (SERVER_MODE)
 extern bool qmgr_is_query_interrupted (THREAD_ENTRY * thread_p, QUERY_ID query_id);

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -2466,7 +2466,7 @@ session_free_sentry_data (THREAD_ENTRY * thread_p, SESSION_QUERY_ENTRY * sentry_
 
   if (sentry_p->temp_file != NULL)
     {
-      qmgr_free_temp_file_list (thread_p, sentry_p->temp_file, sentry_p->query_id, false);
+      qmgr_free_temp_file_list (thread_p, sentry_p->temp_file, sentry_p->query_id, false, true);
     }
 
   sessions.num_holdable_cursors--;

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -4000,7 +4000,9 @@ file_temp_retire_internal (THREAD_ENTRY * thread_p, const VFID * vfid, bool was_
 
   if (was_preserved)
     {
+      file_tempcache_lock ();
       error_code = file_tempcache_alloc_entry (&entry);
+      file_tempcache_unlock ();
       if (error_code != NO_ERROR)
 	{
 	  assert (false);

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -4007,17 +4007,23 @@ file_temp_retire_internal (THREAD_ENTRY * thread_p, const VFID * vfid, bool was_
 	{
 	  assert (false);
 	}
+      if (entry != NULL)
+	{
+	  entry->vfid = *vfid;
+	  /* type will be set later */
+	}
+      else
+	{
+	  assert (false);
+	}
     }
   else
     {
       entry = file_tempcache_pop_tran_file (thread_p, vfid);
+      assert (entry != NULL);
     }
 
-  if (entry == NULL)
-    {
-      assert_release (false);
-    }
-  else if (file_tempcache_put (thread_p, entry))
+  if (entry != NULL && file_tempcache_put (thread_p, entry))
     {
       /* cached */
       return NO_ERROR;
@@ -8453,6 +8459,10 @@ STATIC_INLINE bool
 file_tempcache_put (THREAD_ENTRY * thread_p, FILE_TEMPCACHE_ENTRY * entry)
 {
   FILE_HEADER fhead;
+
+  assert (entry != NULL);
+  assert (!VFID_ISNULL (&entry->vfid));
+  assert (entry->next == NULL);
 
   fhead.n_page_user = -1;
   if (file_header_copy (thread_p, &entry->vfid, &fhead) != NO_ERROR

--- a/src/storage/file_manager.h
+++ b/src/storage/file_manager.h
@@ -155,6 +155,7 @@ extern int file_create_ehash_dir (THREAD_ENTRY * thread_p, int npages, bool is_t
 extern void file_postpone_destroy (THREAD_ENTRY * thread_p, const VFID * vfid);
 extern int file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid);
 extern int file_temp_retire (THREAD_ENTRY * thread_p, const VFID * vfid);
+extern int file_temp_retire_preserved (THREAD_ENTRY * thread_p, const VFID * vfid);
 
 extern int file_alloc (THREAD_ENTRY * thread_p, const VFID * vfid, VPID * vpid_out);
 extern int file_alloc_and_init (THREAD_ENTRY * thread_p, const VFID * vfid, FILE_INIT_PAGE_FUNC f_init,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20629

temporary file cache retirement had a bug. it tried to find the entry of preserved file in transaction list (even though it was removed when the file was preserved).

call file_temp_retire_preserved to notify temporary file cache that the file is no longer in transaction list.