### PR TITLE
[CBRD-20146] use pgbuf_check_page_ptype instead of pgbuf_set_page_ptype in overflow_insert

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4166,7 +4166,7 @@ vacuum_create_file_for_vacuum_data (THREAD_ENTRY * thread_p, VFID * vacuum_data_
       return error_code;
     }
   error_code = file_alloc (thread_p, vacuum_data_vfid, file_init_page_type, &ptype, &first_page_vpid,
-			   (PAGE_PTR *) & data_page);
+			   (PAGE_PTR *) (&data_page));
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -4259,7 +4259,7 @@ vacuum_create_file_for_dropped_files (THREAD_ENTRY * thread_p, VFID * dropped_fi
       return error_code;
     }
   error_code = file_alloc_sticky_first_page (thread_p, dropped_files_vfid, file_init_page_type, &ptype,
-					     &first_page_vpid, (PAGE_PTR *) & dropped_files_page);
+					     &first_page_vpid, (PAGE_PTR *) (&dropped_files_page));
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -4922,7 +4922,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 	      log_sysop_start (thread_p);
 
 	      error_code = file_alloc (thread_p, &vacuum_Data.vacuum_data_file, file_init_page_type, &ptype, &next_vpid,
-				       (PAGE_PTR *) & data_page);
+				       (PAGE_PTR *) (&data_page));
 	      if (error_code != NO_ERROR)
 		{
 		  /* Could not allocate new page. */
@@ -5673,7 +5673,7 @@ vacuum_add_dropped_file (THREAD_ENTRY * thread_p, VFID * vfid, MVCCID mvccid)
 
   /* Extend file */
   error_code = file_alloc (thread_p, &vacuum_Dropped_files_vfid, file_init_page_type, &ptype, &vpid,
-			   (PAGE_PTR *) & new_page);
+			   (PAGE_PTR *) (&new_page));
   if (error_code != NO_ERROR)
     {
       assert (false);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1875,7 +1875,8 @@ btree_create_overflow_key_file (THREAD_ENTRY * thread_p, BTID_INT * btid)
   /* initialize description of overflow heap file */
   btdes_ovf.btid = *btid->sys_btid;	/* structure copy */
   /* create file with at least 3 pages */
-  return file_create_with_npages (thread_p, FILE_BTREE_OVERFLOW_KEY, 3, (FILE_DESCRIPTORS *) & btdes_ovf, &btid->ovfid);
+  return file_create_with_npages (thread_p, FILE_BTREE_OVERFLOW_KEY, 3, (FILE_DESCRIPTORS *) (&btdes_ovf),
+				  &btid->ovfid);
 }
 
 /*

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -1420,15 +1420,26 @@ disk_extend (THREAD_ENTRY * thread_p, DISK_EXTEND_INFO * extend_info, DISK_RESER
 {
 #if defined (SERVER_MODE)
 #define DISK_EXTEND_TEMP_REGISTER() \
-  if (voltype == DB_TEMPORARY_VOLTYPE) \
-    {  \
-      tsc_getticks (&end_tick); \
-      tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick); \
-      TSC_ADD_TIMEVAL (thread_p->event_stats.temp_expand_time, tv_diff); \
-      thread_p->event_stats.temp_expand_pages += DISK_SECTS_NPAGES (nsect_temp_extended); \
-    }
+  do \
+    { \
+      if (voltype == DB_TEMPORARY_VOLTYPE) \
+        {  \
+          tsc_getticks (&end_tick); \
+          tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick); \
+          TSC_ADD_TIMEVAL (thread_p->event_stats.temp_expand_time, tv_diff); \
+          thread_p->event_stats.temp_expand_pages += DISK_SECTS_NPAGES (nsect_temp_extended); \
+        } \
+    } \
+  while (0)
 #define DISK_EXTEND_TEMP_COLLECT(nsects) \
-  if (voltype == DB_TEMPORARY_VOLTYPE) nsect_temp_extended += (nsects)
+  do \
+    { \
+      if (voltype == DB_TEMPORARY_VOLTYPE) \
+        { \
+          nsect_temp_extended += (nsects); \
+        } \
+    } \
+  while (0)
 #endif /* SERVER_MODE */
 
   DKNSECTS free = extend_info->nsect_free;

--- a/src/storage/overflow_file.c
+++ b/src/storage/overflow_file.c
@@ -187,7 +187,7 @@ overflow_insert (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, VPID * ovf_vpid
 	  ASSERT_ERROR ();
 	  goto exit_on_error;
 	}
-      pgbuf_set_page_ptype (thread_p, addr.pgptr, PAGE_OVERFLOW);
+      (void) pgbuf_check_page_ptype (thread_p, addr.pgptr, PAGE_OVERFLOW);
 
       /* Is this the first page ? */
       if (i == 0)


### PR DESCRIPTION
fixes incorrect usage of pgbuf_set_page_ptype and also beautify codes.