### PR TITLE
[CBRD-20639] undo: fix undoing RVBT_LOG_GLOBAL_UNIQUE_STATS_COMMIT

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7661,6 +7661,12 @@ log_rollback_record (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_PAGE * log_
 	{
 	  /* do nothing */
 	}
+      else if (rcvindex == RVBT_LOG_GLOBAL_UNIQUE_STATS_COMMIT)
+	{
+	  /* impossible. we cannot rollback anymore. */
+	  assert_release (false);
+	  rv_err = ER_FAILED;
+	}
       else if (RCV_IS_LOGICAL_COMPENSATE_MANUAL (rcvindex))
 	{
 	  /* B-tree logical logs will add a regular compensate in the modified pages. They do not require a logical

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -274,6 +274,13 @@ log_rv_undo_record (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_PAGE * log_p
 	{
 	  /* nothing to do */
 	}
+      else if (rcvindex == RVBT_LOG_GLOBAL_UNIQUE_STATS_COMMIT)
+	{
+	  /* this only modifies in memory data that is only flushed to disk on checkpoints. we need to execute undo
+	   * every time recovery is run, and we cannot compensate it. */
+	  error_code = (*RV_fun[rcvindex].undofun) (thread_p, rcv);
+	  assert (error_code == NO_ERROR);
+	}
       else if (RCV_IS_LOGICAL_COMPENSATE_MANUAL (rcvindex))
 	{
 	  /* B-tree logical logs will add a regular compensate in the modified pages. They do not require a logical


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20639

RVBT_LOG_GLOBAL_UNIQUE_STATS_COMMIT recovery index is special because it affects only in memory data structure. Global stats are only flushed on checkpoint. Therefore, their recovery should be applied every time and undoing stats should be never compensated.