### PR TITLE
[CBRD-20185] disk_stab_init: fix flushing pages; fix nsects_sys

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -4340,13 +4340,23 @@ disk_stab_init (THREAD_ENTRY * thread_p, DISK_VOLUME_HEADER * volheader)
 
       if (volheader->purpose != DB_TEMPORARY_DATA_PURPOSE)
 	{
-	  log_append_redo_data2 (thread_p, RVDK_INITMAP, NULL, page_stab, NULL_OFFSET, sizeof (nsects_sys),
-				 &nsects_sys);
-	  nsects_sys = 0;
+	  DKNSECTS nsects_set = nsects_sys - nsect_copy;
+	  log_append_redo_data2 (thread_p, RVDK_INITMAP, NULL, page_stab, NULL_OFFSET, sizeof (nsects_set),
+				 &nsects_set);
 	}
-      pgbuf_set_dirty_and_free (thread_p, page_stab);
+      if (!LOG_ISRESTARTED ())
+	{
+	  /* page buffer will invalidated and pages will not be flushed. */
+	  pgbuf_set_dirty (thread_p, page_stab, DONT_FREE);
+	  pgbuf_flush (thread_p, page_stab, FREE);
+	  page_stab = NULL;
+	}
+      else
+	{
+	  pgbuf_set_dirty_and_free (thread_p, page_stab);
+	}
 
-      nsects_sys -= nsect_copy;
+      nsects_sys = nsect_copy;
       nsect_copy = 0;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20185

* volumes are booted before recovery. the temporary purpose volumes are reset and their pages are set dirty, however, right before recovery, the page buffer is invalidated without flushing any bcb. the changes are then lost. fix by flushing pages immediately if LOG_ISRESTARTED is false.
* correct nsects_sys changes and logging.