### PR TITLE
[CBRD-20664] qexec_destroy_upddel_ehash_files: don't allow interruptions

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7990,14 +7990,23 @@ static void
 qexec_destroy_upddel_ehash_files (THREAD_ENTRY * thread_p, XASL_NODE * buildlist)
 {
   int idx;
+  bool save_interrupted;
   EHID *hash_list = buildlist->proc.buildlist.upddel_oid_locator_ehids;
+
+  save_interrupted = thread_set_check_interrupt (thread_p, false);
 
   for (idx = 0; idx < buildlist->upd_del_class_cnt; idx++)
     {
-      xehash_destroy (thread_p, &hash_list[idx]);
+      if (xehash_destroy (thread_p, &hash_list[idx]) != NO_ERROR)
+	{
+	  /* should not fail or we'll leak reserved sectors */
+	  assert (false);
+	}
     }
   db_private_free (thread_p, hash_list);
   buildlist->proc.buildlist.upddel_oid_locator_ehids = NULL;
+
+  (void) thread_set_check_interrupt (thread_p, save_interrupted);
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20664

qexec_destroy_upddel_ehash_files: don't allow interruptions while destroying ehashes