### PR TITLE
[CBRD-20655] heap_hfid_cache_get: always call lf_tran_end_with_mb

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -23405,6 +23405,7 @@ heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid
 	  assert_release (false);
 	  boot_find_root_heap (&entry->hfid);
 	  entry->ftype = FILE_HEAP;
+	  lf_tran_end_with_mb (t_entry);
 	  return NO_ERROR;
 	}
 
@@ -23415,6 +23416,7 @@ heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
+	  lf_tran_end_with_mb (t_entry);
 	  return error_code;
 	}
       entry->hfid = hfid_local;
@@ -23428,6 +23430,7 @@ heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
+	  lf_tran_end_with_mb (t_entry);
 	  return error_code;
 	}
       entry->ftype = ftype_local;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20655

heap_hfid_cache_get did not always ended lock-free transaction (e.g. when error occurs while reading hfid and file type).

this may cause lock-free inconsistencies.

another shell case that may fail for the same reason:
> cubrid-testcases-private-ex/shell/_06_issues/_12_2h/bug_bts_8198/cases/bug_bts_8198.sh

