### PR TITLE
[CBRD-20687] disk_rv_undo_format: expect temporary volumes

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -1159,7 +1159,7 @@ disk_rv_undo_format (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
     }
   else
     {
-      /* must be next volume that was not added yet to cache */
+      /* must be next volume that was not added yet to cache or a temporary volume */
       assert (disk_Cache->nvols_perm <= volid);
       assert (disk_Cache->vols[volid].purpose == DISK_UNKNOWN_PURPOSE);
       assert (disk_Cache->vols[volid].nsect_free == 0);

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -1160,7 +1160,7 @@ disk_rv_undo_format (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   else
     {
       /* must be next volume that was not added yet to cache */
-      assert (disk_Cache->nvols_perm == volid);
+      assert (disk_Cache->nvols_perm <= volid);
       assert (disk_Cache->vols[volid].purpose == DISK_UNKNOWN_PURPOSE);
       assert (disk_Cache->vols[volid].nsect_free == 0);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20687

Creating temporary volumes also log undo of RVDK_FORMAT. If the log is rollbacked, it is not yet added to cache. If it is undone during recovery, no temporary volumes are loaded to cache. It is enough to update volid check to:

> assert (disk_Cache->nvols_perm <= volid);