### PR TITLE
[CBRD-20416] Fixed issues caused by memory management in XASL clone

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1280,7 +1280,7 @@ static int prm_xasl_cache_max_entries_default = 1000;
 static unsigned int prm_xasl_cache_max_entries_flag = 0;
 
 int PRM_XASL_CACHE_MAX_CLONES = 1000;
-static int prm_xasl_cache_max_clones_default = 0;
+static int prm_xasl_cache_max_clones_default = 1000;
 static int prm_xasl_cache_max_clones_lower = 0;
 static int prm_xasl_cache_max_clones_upper = 2000;
 static unsigned int prm_xasl_cache_max_clones_flag = 0;

--- a/src/base/xserver_interface.h
+++ b/src/base/xserver_interface.h
@@ -148,7 +148,7 @@ extern void xlogtb_set_interrupt (THREAD_ENTRY * thread_p, int set);
 extern void xlogtb_set_suppress_repl_on_transaction (THREAD_ENTRY * thread_p, int set);
 
 extern int xlogtb_reset_wait_msecs (THREAD_ENTRY * thread_p, int wait_msecs);
-extern int xlogtb_reset_isolation (THREAD_ENTRY * thread_p, TRAN_ISOLATION isolation, bool unlock_by_isolation);
+extern int xlogtb_reset_isolation (THREAD_ENTRY * thread_p, TRAN_ISOLATION isolation);
 
 extern LOG_LSA *log_get_final_restored_lsa (void);
 extern float log_get_db_compatibility (void);

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -2200,11 +2200,11 @@ log_reset_wait_msecs (int wait_msecs)
  * NOTE:
  */
 int
-log_reset_isolation (TRAN_ISOLATION isolation, bool unlock_by_isolation)
+log_reset_isolation (TRAN_ISOLATION isolation)
 {
 #if defined(CS_MODE)
   int req_error, error_code = ER_NET_CLIENT_DATA_RECEIVE;
-  OR_ALIGNED_BUF (OR_INT_SIZE * 2) a_request;
+  OR_ALIGNED_BUF (OR_INT_SIZE) a_request;
   char *request, *ptr;
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply;
@@ -2213,7 +2213,6 @@ log_reset_isolation (TRAN_ISOLATION isolation, bool unlock_by_isolation)
   reply = OR_ALIGNED_BUF_START (a_reply);
 
   ptr = or_pack_int (request, (int) isolation);
-  ptr = or_pack_int (ptr, (int) unlock_by_isolation);
 
   req_error =
     net_client_request (NET_SERVER_LOG_RESET_ISOLATION, request, OR_ALIGNED_BUF_SIZE (a_request), reply,
@@ -2229,7 +2228,7 @@ log_reset_isolation (TRAN_ISOLATION isolation, bool unlock_by_isolation)
 
   ENTER_SERVER ();
 
-  error_code = xlogtb_reset_isolation (NULL, isolation, unlock_by_isolation);
+  error_code = xlogtb_reset_isolation (NULL, isolation);
 
   EXIT_SERVER ();
 

--- a/src/communication/network_interface_cl.h
+++ b/src/communication/network_interface_cl.h
@@ -116,7 +116,7 @@ extern int disk_get_purpose_and_space_info (VOLID volid, DISK_VOLPURPOSE * vol_p
 extern char *disk_get_fullname (VOLID volid, char *vol_fullname);
 extern bool disk_is_volume_exist (VOLID volid);
 extern int log_reset_wait_msecs (int wait_msecs);
-extern int log_reset_isolation (TRAN_ISOLATION isolation, bool unlock_by_isolation);
+extern int log_reset_isolation (TRAN_ISOLATION isolation);
 extern void log_set_interrupt (int set);
 extern int log_checkpoint (void);
 extern void log_dump_stat (FILE * outfp);

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -1757,15 +1757,14 @@ slogtb_reset_wait_msecs (THREAD_ENTRY * thread_p, unsigned int rid, char *reques
 void
 slogtb_reset_isolation (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  int isolation, unlock_by_isolation, error_code;
+  int isolation, error_code;
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply = OR_ALIGNED_BUF_START (a_reply);
   char *ptr;
 
   ptr = or_unpack_int (request, &isolation);
-  ptr = or_unpack_int (ptr, &unlock_by_isolation);
 
-  error_code = (int) xlogtb_reset_isolation (thread_p, (TRAN_ISOLATION) isolation, (bool) unlock_by_isolation);
+  error_code = (int) xlogtb_reset_isolation (thread_p, (TRAN_ISOLATION) isolation);
 
   if (error_code != NO_ERROR)
     {

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -78,12 +78,14 @@ static int
 fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd, OID * obj_oid, QFILE_TUPLE tpl,
 		  DB_VALUE ** peek_dbval)
 {
-  ARITH_TYPE *arithptr = regu_var->value.arithptr;
+  ARITH_TYPE *arithptr;
   DB_VALUE *peek_left, *peek_right, *peek_third, *peek_fourth;
   DB_VALUE tmp_value;
   TP_DOMAIN *original_domain = NULL;
   TP_DOMAIN_STATUS dom_status;
 
+  assert (regu_var != NULL);
+  arithptr = regu_var->value.arithptr;
   if (REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_ALL_CONST))
     {
       *peek_dbval = arithptr->value;
@@ -3803,6 +3805,12 @@ fetch_peek_arith_end:
 
 error:
   thread_dec_recursion_depth (thread_p);
+
+  if (original_domain)
+    {
+      /* restores regu variable domain */
+      regu_var->domain = original_domain;
+    }
 
   return ER_FAILED;
 }

--- a/src/query/filter_pred_cache.c
+++ b/src/query/filter_pred_cache.c
@@ -1,5 +1,4 @@
 /*
-ne_stack_head = -1;
  * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
  *
  *   This program is free software; you can redistribute it and/or modify

--- a/src/query/filter_pred_cache.c
+++ b/src/query/filter_pred_cache.c
@@ -286,9 +286,11 @@ fpcache_entry_uninit (void *entry)
 {
   FPCACHE_ENTRY *fpcache_entry = FPCACHE_PTR_TO_ENTRY (entry);
   THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
-  HL_HEAPID old_private_heap = db_change_private_heap (thread_p, 0);
+  HL_HEAPID old_private_heap;
   PRED_EXPR_WITH_CONTEXT *pred_expr = NULL;
   int head;
+
+  old_private_heap = db_change_private_heap (thread_p, 0);
 
   for (head = fpcache_entry->clone_stack_head; head >= 0; head--)
     {
@@ -304,10 +306,9 @@ fpcache_entry_uninit (void *entry)
   (void) db_change_private_heap (thread_p, old_private_heap);
   fpcache_entry->clone_stack_head = -1;
 
-  if (fpcache_entry->clone_stack)
+  if (fpcache_entry->clone_stack != NULL)
     {
-      free (fpcache_entry->clone_stack);
-      fpcache_entry->clone_stack = NULL;
+      free_and_init (fpcache_entry->clone_stack);
     }
 
   return NO_ERROR;

--- a/src/query/filter_pred_cache.c
+++ b/src/query/filter_pred_cache.c
@@ -1,4 +1,5 @@
 /*
+ne_stack_head = -1;
  * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
  *
  *   This program is free software; you can redistribute it and/or modify
@@ -215,7 +216,7 @@ fpcache_finalize (THREAD_ENTRY * thread_p)
       bh_destroy (thread_p, fpcache_Cleanup_bh);
       fpcache_Cleanup_bh = NULL;
     }
-  (void) db_change_private_heap (thread_p, 0);
+  (void) db_change_private_heap (thread_p, save_heapid);
 
   fpcache_Enabled = false;
 }
@@ -302,8 +303,14 @@ fpcache_entry_uninit (void *entry)
     }
 
   (void) db_change_private_heap (thread_p, old_private_heap);
+  fpcache_entry->clone_stack_head = -1;
 
-  free (fpcache_entry->clone_stack);
+  if (fpcache_entry->clone_stack)
+    {
+      free (fpcache_entry->clone_stack);
+      fpcache_entry->clone_stack = NULL;
+    }
+
   return NO_ERROR;
 }
 

--- a/src/query/query_evaluator.c
+++ b/src/query/query_evaluator.c
@@ -1869,6 +1869,12 @@ eval_pred (THREAD_ENTRY * thread_p, PRED_EXPR * pr, VAL_DESCR * vd, OID * obj_oi
 		      result = V_UNKNOWN;
 		      goto exit;
 		    }
+		  else if (!TP_IS_SET_TYPE (DB_VALUE_DOMAIN_TYPE (peek_val1)))
+		    {
+		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
+		      result = V_ERROR;
+		      goto exit;
+		    }
 
 		  result = ((db_set_size (DB_GET_SET (peek_val1)) > 0) ? V_TRUE : V_FALSE);
 		}
@@ -2233,6 +2239,11 @@ eval_pred_comp2 (THREAD_ENTRY * thread_p, PRED_EXPR * pr, VAL_DESCR * vd, OID * 
 	{
 	  return V_UNKNOWN;
 	}
+      else if (!TP_IS_SET_TYPE (DB_VALUE_DOMAIN_TYPE (peek_val1)))
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
+	  return V_ERROR;
+	}
 
       return (set_size (DB_GET_SET (peek_val1)) > 0) ? V_TRUE : V_FALSE;
     }
@@ -2328,6 +2339,11 @@ eval_pred_alsm4 (THREAD_ENTRY * thread_p, PRED_EXPR * pr, VAL_DESCR * vd, OID * 
   else if (db_value_is_null (peek_val2))
     {
       return V_UNKNOWN;
+    }
+  else if (!TP_IS_SET_TYPE (DB_VALUE_DOMAIN_TYPE (peek_val2)))
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
+      return V_ERROR;
     }
 
   if (set_size (DB_GET_SET (peek_val2)) == 0)
@@ -2588,8 +2604,8 @@ eval_fnc (THREAD_ENTRY * thread_p, PRED_EXPR * pr, DB_TYPE * single_node_type)
 	   */
 	  *single_node_type = et_alsm->item_type;
 
-	  return ((et_alsm->elemset->type !=
-		   TYPE_LIST_ID) ? (PR_EVAL_FNC) eval_pred_alsm4 : (PR_EVAL_FNC) eval_pred_alsm5);
+	  return ((et_alsm->elemset->type != TYPE_LIST_ID)
+		  ? (PR_EVAL_FNC) eval_pred_alsm4 : (PR_EVAL_FNC) eval_pred_alsm5);
 
 	case T_LIKE_EVAL_TERM:
 	  return (PR_EVAL_FNC) eval_pred_like6;

--- a/src/query/query_evaluator.h
+++ b/src/query/query_evaluator.h
@@ -189,21 +189,23 @@ struct regu_variable_node
   REGU_DATATYPE type;
 
   /* regu variable flags */
-#define REGU_VARIABLE_HIDDEN_COLUMN       0x01	/* does not go to list file */
-#define REGU_VARIABLE_FIELD_COMPARE       0x02	/* for FIELD function, marks the bottom of regu tree */
-#define REGU_VARIABLE_FIELD_NESTED        0x04	/* for FIELD function, reguvar is child in T_FIELD tree */
-#define REGU_VARIABLE_APPLY_COLLATION	  0x08	/* Apply collation from domain; flag used in context of COLLATE
-						 * modifier */
-#define REGU_VARIABLE_ANALYTIC_WINDOW     0x10	/* for analytic window func */
-#define REGU_VARIABLE_INFER_COLLATION	  0x20	/* infer collation for default parameter */
-#define REGU_VARIABLE_FETCH_ALL_CONST     0x40	/* is all constant */
-#define REGU_VARIABLE_FETCH_NOT_CONST     0x80	/* is not constant */
+#define REGU_VARIABLE_HIDDEN_COLUMN		0x01	/* does not go to list file */
+#define REGU_VARIABLE_FIELD_COMPARE		0x02	/* for FIELD function, marks the bottom of regu tree */
+#define REGU_VARIABLE_FIELD_NESTED		0x04	/* for FIELD function, reguvar is child in T_FIELD tree */
+#define REGU_VARIABLE_APPLY_COLLATION		0x08	/* Apply collation from domain; flag used in context of COLLATE
+							 * modifier */
+#define REGU_VARIABLE_ANALYTIC_WINDOW		0x10	/* for analytic window func */
+#define REGU_VARIABLE_INFER_COLLATION		0x20	/* infer collation for default parameter */
+#define REGU_VARIABLE_FETCH_ALL_CONST		0x40	/* is all constant */
+#define REGU_VARIABLE_FETCH_NOT_CONST		0x80	/* is not constant */
+#define REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE   0x100	/* clears regu variable at clone decache */
   int flags;			/* flags */
 #define REGU_VARIABLE_IS_FLAGED(e, f)    ((e)->flags & (short) (f))
 #define REGU_VARIABLE_SET_FLAG(e, f)     (e)->flags |= (short) (f)
 #define REGU_VARIABLE_CLEAR_FLAG(e, f)   (e)->flags &= (short) ~(f)
 
   TP_DOMAIN *domain;		/* domain of the value in this regu variable */
+  TP_DOMAIN *original_domain;	/* original domain, used at execution in case of XASL clones */
   DB_VALUE *vfetch_to;		/* src db_value to fetch into in qp_fetchvlist */
   struct xasl_node *xasl;	/* query xasl pointer */
   union regu_data_value
@@ -477,6 +479,7 @@ struct arith_list_node
 {
   ARITH_TYPE *next;		/* next arithmetic expression */
   TP_DOMAIN *domain;		/* resultant domain */
+  TP_DOMAIN *original_domain;	/* original resultant domain, used at execution in case of XASL clones  */
   DB_VALUE *value;		/* value of the subtree */
   REGU_VARIABLE *leftptr;	/* left operand */
   REGU_VARIABLE *rightptr;	/* right operand */
@@ -495,6 +498,8 @@ struct aggregate_accumulator
   DB_VALUE *value;		/* value of the aggregate */
   DB_VALUE *value2;		/* for GROUP_CONCAT, STTDEV and VARIANCE */
   int curr_cnt;			/* current number of items */
+  bool clear_value_at_clone_decache;	/* true, if need to clear value at clone decache */
+  bool clear_value2_at_clone_decache;	/* true, if need to clear value2 at clone decache */
 };
 
 typedef struct aggregate_accumulator_domain AGGREGATE_ACCUMULATOR_DOMAIN;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -392,6 +392,7 @@ static int qexec_clear_regu_var (XASL_NODE * xasl_p, REGU_VARIABLE * regu_var, i
 static int qexec_clear_regu_list (XASL_NODE * xasl_p, REGU_VARIABLE_LIST list, int final);
 static int qexec_clear_regu_value_list (XASL_NODE * xasl_p, REGU_VALUE_LIST * list, int final);
 static void qexec_clear_db_val_list (QPROC_DB_VALUE_LIST list);
+static int qexec_clear_sort_list (XASL_NODE * xasl_p, SORT_LIST * list, int final);
 static int qexec_clear_pred (XASL_NODE * xasl_p, PRED_EXPR * pr, int final);
 static int qexec_clear_access_spec_list (XASL_NODE * xasl_p, THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * list,
 					 int final);
@@ -401,7 +402,8 @@ static int qexec_clear_agg_list (XASL_NODE * xasl_p, AGGREGATE_TYPE * list, int 
 static void qexec_clear_head_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl_list);
 static void qexec_clear_scan_all_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl_list);
 static void qexec_clear_all_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl_list);
-static int qexec_clear_update_assignment (XASL_NODE * xasl_p, UPDATE_ASSIGNMENT * assignment, int final);
+static int qexec_clear_update_assignment (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, UPDATE_ASSIGNMENT * assignment,
+					  int final);
 static DB_LOGICAL qexec_eval_ordbynum_pred (THREAD_ENTRY * thread_p, ORDBYNUM_INFO * ordby_info);
 static int qexec_ordby_put_next (THREAD_ENTRY * thread_p, const RECDES * recdes, void *arg);
 static int qexec_orderby_distinct (THREAD_ENTRY * thread_p, XASL_NODE * xasl, QUERY_OPTIONS option,
@@ -1368,6 +1370,8 @@ qexec_clear_arith_list (XASL_NODE * xasl_p, ARITH_TYPE * list, int final)
   pg_cnt = 0;
   for (p = list; p; p = p->next)
     {
+      /* restore the original domain, in order to avoid coerce when the XASL clones will be used again */
+      p->domain = p->original_domain;
       pr_clear_value (p->value);
       pg_cnt += qexec_clear_regu_var (xasl_p, p->leftptr, final);
       pg_cnt += qexec_clear_regu_var (xasl_p, p->rightptr, final);
@@ -1401,6 +1405,9 @@ qexec_clear_regu_var (XASL_NODE * xasl_p, REGU_VARIABLE * regu_var, int final)
       return pg_cnt;
     }
 
+  /* restore the original domain, in order to avoid coerce when the XASL clones will be used again */
+  regu_var->domain = regu_var->original_domain;
+
 #if !defined(NDEBUG)
   if (REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_ALL_CONST))
     {
@@ -1426,8 +1433,23 @@ qexec_clear_regu_var (XASL_NODE * xasl_p, REGU_VARIABLE * regu_var, int final)
     case TYPE_CONSTANT:
 #if 0				/* TODO - */
     case TYPE_ORDERBY_NUM:
-#endif
-      pg_cnt += pr_clear_value (regu_var->value.dbvalptr);
+#endif      
+      if (XASL_IS_FLAGED (xasl_p, XASL_DECACHE_CLONE))
+	{
+	  if (REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))
+	    {
+	      /* clear the value since we decache the XASL clone. */
+	      (void) pr_clear_value (regu_var->value.dbvalptr);
+	    }
+	}
+      else
+	{
+	  if (!REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))
+	    {
+	      /* clear the value since we decache the XASL (not a clone). */
+	      (void) pr_clear_value (regu_var->value.dbvalptr);
+	    }
+	}
       /* Fall through */
     case TYPE_LIST_ID:
       if (regu_var->xasl != NULL && regu_var->xasl->status != XASL_CLEARED)
@@ -1447,9 +1469,21 @@ qexec_clear_regu_var (XASL_NODE * xasl_p, REGU_VARIABLE * regu_var, int final)
       pg_cnt += qexec_clear_regu_value_list (xasl_p, regu_var->value.reguval_list, final);
       break;
     case TYPE_DBVAL:
-      if (!XASL_IS_FLAGED (xasl_p, XASL_KEEP_DBVAL))
+      if (XASL_IS_FLAGED (xasl_p, XASL_DECACHE_CLONE))
 	{
-	  (void) pr_clear_value (&regu_var->value.dbval);
+	  if (REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))
+	    {
+	      /* clear the value since we decache the XASL clone. */
+	      (void) pr_clear_value (&regu_var->value.dbval);
+	    }
+	}
+      else
+	{
+	  if (!REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))
+	    {
+	      /* clear the value since we decache the XASL (not a clone). */
+	      (void) pr_clear_value (&regu_var->value.dbval);
+	    }
 	}
       break;
     case TYPE_REGU_VAR_LIST:
@@ -1531,7 +1565,28 @@ qexec_clear_db_val_list (QPROC_DB_VALUE_LIST list)
     {
       pr_clear_value (p->val);
     }
+}
 
+/*
+ * qexec_clear_sort_list () - clear the sort list
+ *   return: clear count
+ *   xasl_p(in) : xasl
+ *   list(in)   : the sort list
+ *   final(in)  : true, if finalize needed
+ */
+static int
+qexec_clear_sort_list (XASL_NODE * xasl_p, SORT_LIST * list, int final)
+{
+  SORT_LIST *p;
+  int pg_cnt;
+
+  pg_cnt = 0;
+  for (p = list; p; p = p->next)
+    {
+      /* restores the original domain */
+      p->pos_descr.dom = p->original_value_domain;
+    }
+  return pg_cnt;
 }
 
 /*
@@ -1653,7 +1708,23 @@ qexec_clear_access_spec_list (XASL_NODE * xasl_p, THREAD_ENTRY * thread_p, ACCES
 	  p->curent = NULL;
 	}
 
-      pr_clear_value (p->s_dbval);
+      if (XASL_IS_FLAGED (xasl_p, XASL_DECACHE_CLONE))
+	{
+	  if (p->clear_value_at_clone_decache)
+	    {
+	      /* clear the value since we decache the XASL clone. */
+	      pr_clear_value (p->s_dbval);
+	    }
+	}
+      else
+	{
+	  if (!p->clear_value_at_clone_decache)
+	    {
+	      /* clear the value since we decache the XASL (not a clone). */
+	      pr_clear_value (p->s_dbval);
+	    }
+	}
+
       pg_cnt += qexec_clear_pred (xasl_p, p->where_pred, final);
       pg_cnt += qexec_clear_pred (xasl_p, p->where_key, final);
       pg_cnt += qexec_clear_pred (xasl_p, p->where_range, final);
@@ -1792,6 +1863,14 @@ qexec_clear_access_spec_list (XASL_NODE * xasl_p, THREAD_ENTRY * thread_p, ACCES
 		      pg_cnt += qexec_clear_regu_var (xasl_p, indx_info->key_info.key_ranges[i].key1, final);
 		      pg_cnt += qexec_clear_regu_var (xasl_p, indx_info->key_info.key_ranges[i].key2, final);
 		    }
+		  if (indx_info->key_info.key_limit_l)
+		    {
+		      pg_cnt += qexec_clear_regu_var (xasl_p, indx_info->key_info.key_limit_l, final);
+		    }
+		  if (indx_info->key_info.key_limit_u)
+		    {
+		      pg_cnt += qexec_clear_regu_var (xasl_p, indx_info->key_info.key_limit_u, final);
+		    }
 		}
 	    }
 	  break;
@@ -1864,8 +1943,33 @@ qexec_clear_agg_list (XASL_NODE * xasl_p, AGGREGATE_TYPE * list, int final)
   pg_cnt = 0;
   for (p = list; p; p = p->next)
     {
-      pr_clear_value (p->accumulator.value);
-      pr_clear_value (p->accumulator.value2);
+      if (XASL_IS_FLAGED (xasl_p, XASL_DECACHE_CLONE))
+	{
+	  if (p->accumulator.clear_value_at_clone_decache)
+	    {
+	      /* clear the value since we decache the XASL clone. */
+	      pr_clear_value (p->accumulator.value);
+	    }
+
+	  if (p->accumulator.clear_value2_at_clone_decache)
+	    {
+	      /* clear the value since we decache the XASL (not a clone). */
+	      pr_clear_value (p->accumulator.value2);
+	    }
+	}
+      else
+	{
+	  if (!p->accumulator.clear_value_at_clone_decache)
+	    {
+	      pr_clear_value (p->accumulator.value);
+	    }
+
+	  if (!p->accumulator.clear_value2_at_clone_decache)
+	    {
+	      pr_clear_value (p->accumulator.value2);
+	    }
+	}
+
       pg_cnt += qexec_clear_regu_var (xasl_p, &p->operand, final);
     }
 
@@ -1971,11 +2075,15 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool final)
 	{
 	  pr_clear_value (xasl->instnum_val);
 	}
+
       pg_cnt += qexec_clear_pred (xasl, xasl->instnum_pred, final);
       if (xasl->ordbynum_val)
 	{
 	  pr_clear_value (xasl->ordbynum_val);
 	}
+
+      pg_cnt += qexec_clear_sort_list (xasl, xasl->after_iscan_list, final);
+      pg_cnt += qexec_clear_sort_list (xasl, xasl->orderby_list, final);
       pg_cnt += qexec_clear_pred (xasl, xasl->ordbynum_pred, final);
 
       if (xasl->orderby_limit)
@@ -2061,6 +2169,9 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool final)
 	  {
 	    pg_cnt += qexec_clear_xasl (thread_p, buildlist->eptr_list, final);
 	  }
+
+	pg_cnt += qexec_clear_sort_list (xasl, buildlist->groupby_list, final);
+	pg_cnt += qexec_clear_sort_list (xasl, buildlist->after_groupby_list, final);
 
 	if (xasl->curr_spec)
 	  {
@@ -2209,7 +2320,7 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool final)
 	for (i = 0; i < xasl->proc.update.num_assigns; i++)
 	  {
 	    assignment = &(xasl->proc.update.assigns[i]);
-	    pg_cnt += qexec_clear_update_assignment (xasl, assignment, final);
+	    pg_cnt += qexec_clear_update_assignment (thread_p, xasl, assignment, final);
 	  }
       }
       break;
@@ -2225,7 +2336,7 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool final)
 	  for (i = 0; i < xasl->proc.insert.odku->num_assigns; i++)
 	    {
 	      assignment = &(xasl->proc.insert.odku->assignments[i]);
-	      pg_cnt += qexec_clear_update_assignment (xasl, assignment, final);
+	      pg_cnt += qexec_clear_update_assignment (thread_p, xasl, assignment, final);
 	    }
 	}
       if (xasl->proc.insert.valptr_lists != NULL && xasl->proc.insert.num_val_lists > 0)
@@ -2357,21 +2468,33 @@ qexec_clear_all_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl_list)
 }
 
 /*
- * qexec_clear_update_assignment () -
- *   return:
- *   thread_p(in) :
- *   assignment(in)   :
- *   final(in)  :
+ * qexec_clear_update_assignment () - clear update assignement
+ *   return: clear count
+ *   thread_p(in)   : thread entry
+ *   assignment(in) : the assignement
+ *   final(in)	    : true, if finalize needed
  */
 static int
-qexec_clear_update_assignment (XASL_NODE * xasl_p, UPDATE_ASSIGNMENT * assignment, int final)
+qexec_clear_update_assignment (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, UPDATE_ASSIGNMENT * assignment, int final)
 {
   int pg_cnt;
 
   pg_cnt = 0;
-  if (!XASL_IS_FLAGED (xasl_p, XASL_KEEP_DBVAL))
+  if (XASL_IS_FLAGED (xasl_p, XASL_DECACHE_CLONE))
     {
-      (void) pr_clear_value (assignment->constant);
+      if (assignment->clear_value_at_clone_decache)
+	{
+	  /* clear the value since we decache the XASL clone. */
+	  (void) pr_clear_value (assignment->constant);
+	}
+    }
+  else
+    {
+      if (!assignment->clear_value_at_clone_decache)
+	{
+	  /* clear the value since we decache the XASL (not a clone). */
+	  (void) pr_clear_value (assignment->constant);
+	}
     }
 
   if (assignment->regu_var != NULL)
@@ -12207,7 +12330,8 @@ qexec_init_instnum_val (XASL_NODE * xasl, THREAD_ENTRY * thread_p, XASL_STATE * 
 	}
     }
 
-  xasl->instnum_flag &= (0xff - (XASL_INSTNUM_FLAG_SCAN_CHECK + XASL_INSTNUM_FLAG_SCAN_STOP));
+  xasl->instnum_flag &= ~(XASL_INSTNUM_FLAG_SCAN_CHECK | XASL_INSTNUM_FLAG_SCAN_STOP
+			  | XASL_INSTNUM_FLAG_SCAN_LAST_STOP);
 
   return NO_ERROR;
 
@@ -20543,9 +20667,9 @@ qexec_clear_pred_context (THREAD_ENTRY * thread_p, PRED_EXPR_WITH_CONTEXT * pred
 
   memset (&xasl_node, 0, sizeof (XASL_NODE));
 
-  if (!dealloc_dbvalues)
+  if (dealloc_dbvalues)
     {
-      XASL_SET_FLAG (&xasl_node, XASL_KEEP_DBVAL);
+      XASL_SET_FLAG (&xasl_node, XASL_DECACHE_CLONE);
     }
 
   qexec_clear_pred (&xasl_node, pred_filter->pred, true);
@@ -20585,7 +20709,6 @@ qexec_clear_partition_expression (THREAD_ENTRY * thread_p, REGU_VARIABLE * expr)
   XASL_NODE xasl_node;
 
   memset (&xasl_node, 0, sizeof (XASL_NODE));
-
   qexec_clear_regu_var (&xasl_node, expr, true);
 
   return NO_ERROR;
@@ -21634,10 +21757,20 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
   bool full_columns = false;
   char *string = NULL;
   int alloced_string = 0;
+  HL_HEAPID save_heapid = 0;
 
   if (xasl == NULL || xasl_state == NULL)
     {
       return ER_FAILED;
+    }
+
+  for (regu_var_p = xasl->outptr_list->valptrp, i = 0; regu_var_p; regu_var_p = regu_var_p->next, i++)
+    {
+      if (REGU_VARIABLE_IS_FLAGED (&regu_var_p->value, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))
+	{
+	  save_heapid = db_change_private_heap (thread_p, 0);
+	  break;
+	}
     }
 
   if (qexec_start_mainblock_iterations (thread_p, xasl, xasl_state) != NO_ERROR)
@@ -21964,6 +22097,11 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
       db_private_free_and_init (thread_p, tplrec.tpl);
     }
 
+  if (save_heapid != 0)
+    {
+      (void) db_change_private_heap (thread_p, save_heapid);
+    }
+
   return NO_ERROR;
 
 exit_on_error:
@@ -21998,6 +22136,11 @@ exit_on_error:
   if (tplrec.tpl)
     {
       db_private_free_and_init (thread_p, tplrec.tpl);
+    }
+
+  if (save_heapid != 0)
+    {
+      (void) db_change_private_heap (thread_p, save_heapid);
     }
 
   xasl->status = XASL_FAILURE;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1433,7 +1433,7 @@ qexec_clear_regu_var (XASL_NODE * xasl_p, REGU_VARIABLE * regu_var, int final)
     case TYPE_CONSTANT:
 #if 0				/* TODO - */
     case TYPE_ORDERBY_NUM:
-#endif      
+#endif
       if (XASL_IS_FLAGED (xasl_p, XASL_DECACHE_CLONE))
 	{
 	  if (REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -392,7 +392,7 @@ static int qexec_clear_regu_var (XASL_NODE * xasl_p, REGU_VARIABLE * regu_var, i
 static int qexec_clear_regu_list (XASL_NODE * xasl_p, REGU_VARIABLE_LIST list, int final);
 static int qexec_clear_regu_value_list (XASL_NODE * xasl_p, REGU_VALUE_LIST * list, int final);
 static void qexec_clear_db_val_list (QPROC_DB_VALUE_LIST list);
-static int qexec_clear_sort_list (XASL_NODE * xasl_p, SORT_LIST * list, int final);
+static void qexec_clear_sort_list (XASL_NODE * xasl_p, SORT_LIST * list, int final);
 static int qexec_clear_pred (XASL_NODE * xasl_p, PRED_EXPR * pr, int final);
 static int qexec_clear_access_spec_list (XASL_NODE * xasl_p, THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * list,
 					 int final);
@@ -1569,24 +1569,21 @@ qexec_clear_db_val_list (QPROC_DB_VALUE_LIST list)
 
 /*
  * qexec_clear_sort_list () - clear the sort list
- *   return: clear count
+ *   return: void
  *   xasl_p(in) : xasl
  *   list(in)   : the sort list
  *   final(in)  : true, if finalize needed
  */
-static int
+static void
 qexec_clear_sort_list (XASL_NODE * xasl_p, SORT_LIST * list, int final)
 {
   SORT_LIST *p;
-  int pg_cnt;
 
-  pg_cnt = 0;
   for (p = list; p; p = p->next)
     {
       /* restores the original domain */
       p->pos_descr.dom = p->original_value_domain;
     }
-  return pg_cnt;
 }
 
 /*
@@ -2082,8 +2079,15 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool final)
 	  pr_clear_value (xasl->ordbynum_val);
 	}
 
-      pg_cnt += qexec_clear_sort_list (xasl, xasl->after_iscan_list, final);
-      pg_cnt += qexec_clear_sort_list (xasl, xasl->orderby_list, final);
+      if (xasl->after_iscan_list)
+	{
+	  qexec_clear_sort_list (xasl, xasl->after_iscan_list, final);
+	}
+
+      if (xasl->orderby_list)
+	{
+	  qexec_clear_sort_list (xasl, xasl->orderby_list, final);
+	}
       pg_cnt += qexec_clear_pred (xasl, xasl->ordbynum_pred, final);
 
       if (xasl->orderby_limit)
@@ -2170,8 +2174,14 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool final)
 	    pg_cnt += qexec_clear_xasl (thread_p, buildlist->eptr_list, final);
 	  }
 
-	pg_cnt += qexec_clear_sort_list (xasl, buildlist->groupby_list, final);
-	pg_cnt += qexec_clear_sort_list (xasl, buildlist->after_groupby_list, final);
+	if (buildlist->groupby_list)
+	  {
+	    qexec_clear_sort_list (xasl, buildlist->groupby_list, final);
+	  }
+	if (buildlist->after_groupby_list)
+	  {
+	    qexec_clear_sort_list (xasl, buildlist->after_groupby_list, final);
+	  }
 
 	if (xasl->curr_spec)
 	  {

--- a/src/query/query_executor.h
+++ b/src/query/query_executor.h
@@ -445,9 +445,10 @@ struct access_spec_node
   ACCESS_SPEC_TYPE *next;	/* next access specification */
   PARTITION_SPEC_TYPE *parts;	/* partitions of the current spec */
   PARTITION_SPEC_TYPE *curent;	/* current partition */
-  bool pruned;			/* true if partition pruning has been performed */
   int pruning_type;		/* how pruning should be performed on this access spec performed */
   ACCESS_SPEC_FLAG flags;	/* flags from ACCESS_SPEC_FLAG enum */
+  bool pruned;			/* true if partition pruning has been performed */
+  bool clear_value_at_clone_decache;	/* true, if need to clear s_dbval at clone decache */
 };
 
 
@@ -614,6 +615,7 @@ struct update_assignment
   int att_idx;			/* index in the class attributes array */
   DB_VALUE *constant;		/* constant to be assigned to an attribute or NULL */
   REGU_VARIABLE *regu_var;	/* regu variable for rhs in assignment */
+  bool clear_value_at_clone_decache;	/* true, if need to clear constant db_value at clone decache */
 };
 
 /* type of reevaluation */
@@ -975,21 +977,21 @@ struct func_pred
   HEAP_CACHE_ATTRINFO *cache_attrinfo;
 };
 
-#define XASL_LINK_TO_REGU_VARIABLE 1	/* is linked to regu variable ? */
-#define XASL_SKIP_ORDERBY_LIST     2	/* skip sorting for orderby_list ? */
-#define XASL_ZERO_CORR_LEVEL       4	/* is zero-level uncorrelated subquery ? */
-#define XASL_TOP_MOST_XASL         8	/* this is a top most XASL */
-#define XASL_TO_BE_CACHED         16	/* the result will be cached */
-#define	XASL_HAS_NOCYCLE	  32	/* NOCYCLE is specified */
-#define	XASL_HAS_CONNECT_BY	  64	/* has CONNECT BY clause */
-#define XASL_MULTI_UPDATE_AGG	 128	/* is for multi-update with aggregate */
-#define XASL_IGNORE_CYCLES	 256	/* is for LEVEL usage in connect by clause... sometimes cycles may be ignored */
-#define	XASL_OBJFETCH_IGNORE_CLASSOID 512	/* fetch proc should ignore class oid */
-#define XASL_IS_MERGE_QUERY	      1024	/* query belongs to a merge statement */
-#define XASL_USES_MRO	      2048	/* query uses multi range optimization */
-#define XASL_KEEP_DBVAL	      4096	/* do not clear db_value */
-#define XASL_RETURN_GENERATED_KEYS	     8192	/* return generated keys */
-#define XASL_NO_FIXED_SCAN    16384	/* disable fixed scan for this proc */
+#define XASL_LINK_TO_REGU_VARIABLE	0x01	/* is linked to regu variable ? */
+#define XASL_SKIP_ORDERBY_LIST		0x02	/* skip sorting for orderby_list ? */
+#define XASL_ZERO_CORR_LEVEL		0x04	/* is zero-level uncorrelated subquery ? */
+#define XASL_TOP_MOST_XASL		0x08	/* this is a top most XASL */
+#define XASL_TO_BE_CACHED		0x10	/* the result will be cached */
+#define	XASL_HAS_NOCYCLE		0x20	/* NOCYCLE is specified */
+#define	XASL_HAS_CONNECT_BY		0x40	/* has CONNECT BY clause */
+#define XASL_MULTI_UPDATE_AGG		0x80	/* is for multi-update with aggregate */
+#define XASL_IGNORE_CYCLES	       0x100	/* is for LEVEL usage in connect by clause... sometimes cycles may be ignored */
+#define	XASL_OBJFETCH_IGNORE_CLASSOID  0x200	/* fetch proc should ignore class oid */
+#define XASL_IS_MERGE_QUERY	       0x400	/* query belongs to a merge statement */
+#define XASL_USES_MRO		       0x800	/* query uses multi range optimization */
+#define XASL_DECACHE_CLONE	      0x1000	/* decache clone */
+#define XASL_RETURN_GENERATED_KEYS    0x2000	/* return generated keys */
+#define XASL_NO_FIXED_SCAN	      0x4000	/* disable fixed scan for this proc */
 
 #define XASL_IS_FLAGED(x, f)        ((x)->flag & (int) (f))
 #define XASL_SET_FLAG(x, f)         (x)->flag |= (int) (f)
@@ -1064,8 +1066,8 @@ extern int xts_map_func_pred_to_stream (const FUNC_PRED * xasl, char **stream, i
 
 extern void xts_final (void);
 
-extern int stx_map_stream_to_xasl (THREAD_ENTRY * thread_p, XASL_NODE ** xasl_tree, char *xasl_stream,
-				   int xasl_stream_size, void **xasl_unpack_info_ptr);
+extern int stx_map_stream_to_xasl (THREAD_ENTRY * thread_p, XASL_NODE ** xasl_tree, bool use_xasl_clone,
+				   char *xasl_stream, int xasl_stream_size, void **xasl_unpack_info_ptr);
 extern int stx_map_stream_to_filter_pred (THREAD_ENTRY * thread_p, PRED_EXPR_WITH_CONTEXT ** pred_expr_tree,
 					  char *pred_stream, int pred_stream_size);
 extern int stx_map_stream_to_func_pred (THREAD_ENTRY * thread_p, FUNC_PRED ** xasl, char *xasl_stream,

--- a/src/query/query_list.h
+++ b/src/query/query_list.h
@@ -590,6 +590,7 @@ struct sort_list
   struct sort_list *local_next;	/* for latch-free freelist */
   struct sort_list *next;	/* Next sort item */
   QFILE_TUPLE_VALUE_POSITION pos_descr;	/* Value position descriptor */
+  DB_DOMAIN *original_value_domain;	/* The original value domain, used at execution in case of XASL clones */
   SORT_ORDER s_order;		/* Ascending/Descending Order */
   SORT_NULLS s_nulls;		/* NULLS as First/Last position */
 };				/* Sort item list */

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1092,7 +1092,7 @@ qmgr_process_query (THREAD_ENTRY * thread_p, XASL_NODE * xasl_tree, char *xasl_s
     }
   else
     {
-      if (stx_map_stream_to_xasl (thread_p, &xasl_p, xasl_stream, xasl_stream_size, &xasl_buf_info) != NO_ERROR)
+      if (stx_map_stream_to_xasl (thread_p, &xasl_p, false, xasl_stream, xasl_stream_size, &xasl_buf_info) != NO_ERROR)
 	{
 	  goto exit_on_error;
 	}

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -7703,14 +7703,11 @@ qdata_finalize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
   QFILE_LIST_ID *list_id_p;
   QFILE_LIST_SCAN_ID scan_id;
   SCAN_CODE scan_code;
-  QFILE_TUPLE_RECORD tuple_record = {
-    NULL, 0
-  };
+  QFILE_TUPLE_RECORD tuple_record = { NULL, 0 };
   char *tuple_p;
   PR_TYPE *pr_type_p;
   OR_BUF buf;
   double dbl;
-  int i;
 
   DB_MAKE_NULL (&sqr_val);
   DB_MAKE_NULL (&dbval);
@@ -12273,6 +12270,7 @@ qdata_calculate_aggregate_cume_dist_percent_rank (THREAD_ENTRY * thread_p, AGGRE
 	  if (save_heapid != 0)
 	    {
 	      (void) db_change_private_heap (thread_p, save_heapid);
+	      save_heapid = 0;
 	    }
 
 	  regu_var_node = regu_var_node->next;

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -109,6 +109,8 @@ struct xasl_unpack_info
   UNPACK_EXTRA_BUF *additional_buffers;
   /* 1 if additional buffers should be tracked */
   int track_allocated_bufers;
+
+  bool use_xasl_clone;		/* true, if uses xasl clone */
 };
 
 #if !defined(SERVER_MODE)
@@ -145,7 +147,9 @@ static SORT_LIST *stx_restore_sort_list (THREAD_ENTRY * thread_p, char *ptr);
 static char *stx_restore_string (THREAD_ENTRY * thread_p, char *ptr);
 static VAL_LIST *stx_restore_val_list (THREAD_ENTRY * thread_p, char *ptr);
 static DB_VALUE *stx_restore_db_value (THREAD_ENTRY * thread_p, char *ptr);
+#if defined(ENABLE_UNUSED_FUNCTION)
 static QPROC_DB_VALUE_LIST stx_restore_db_value_list (THREAD_ENTRY * thread_p, char *ptr);
+#endif
 static XASL_NODE *stx_restore_xasl_node (THREAD_ENTRY * thread_p, char *ptr);
 static PRED_EXPR_WITH_CONTEXT *stx_restore_filter_pred_node (THREAD_ENTRY * thread_p, char *ptr);
 static FUNC_PRED *stx_restore_func_pred (THREAD_ENTRY * thread_p, char *ptr);
@@ -198,7 +202,9 @@ static char *stx_build_rlist_spec_type (THREAD_ENTRY * thread_p, char *ptr, REGU
 static char *stx_build_set_spec_type (THREAD_ENTRY * thread_p, char *tmp, SET_SPEC_TYPE * ptr);
 static char *stx_build_method_spec_type (THREAD_ENTRY * thread_p, char *tmp, METHOD_SPEC_TYPE * ptr);
 static char *stx_build_val_list (THREAD_ENTRY * thread_p, char *tmp, VAL_LIST * ptr);
+#if defined(ENABLE_UNUSED_FUNCTION)
 static char *stx_build_db_value_list (THREAD_ENTRY * thread_p, char *tmp, QPROC_DB_VALUE_LIST ptr);
+#endif
 static char *stx_build_regu_variable (THREAD_ENTRY * thread_p, char *tmp, REGU_VARIABLE * ptr);
 static char *stx_unpack_regu_variable_value (THREAD_ENTRY * thread_p, char *tmp, REGU_VARIABLE * ptr);
 static char *stx_build_attr_descr (THREAD_ENTRY * thread_p, char *tmp, ATTR_DESCR * ptr);
@@ -269,6 +275,7 @@ stx_map_stream_to_xasl_node_header (THREAD_ENTRY * thread_p, XASL_NODE_HEADER * 
  *   return: if successful, return 0, otherwise non-zero error code
  *   xasl_tree(in)      : pointer to where to return the
  *                        root of the unpacked XASL tree
+ *   use_xasl_clone(in) : true, if XASL clone is used
  *   xasl_stream(in)    : pointer to xasl stream
  *   xasl_stream_size(in)       : # of bytes in xasl_stream
  *   xasl_unpack_info_ptr(in)   : pointer to where to return the pack info
@@ -279,8 +286,8 @@ stx_map_stream_to_xasl_node_header (THREAD_ENTRY * thread_p, XASL_NODE_HEADER * 
  * xasl_unpack_info_ptr. The free function is stx_free_xasl_unpack_info().
  */
 int
-stx_map_stream_to_xasl (THREAD_ENTRY * thread_p, XASL_NODE ** xasl_tree, char *xasl_stream, int xasl_stream_size,
-			void **xasl_unpack_info_ptr)
+stx_map_stream_to_xasl (THREAD_ENTRY * thread_p, XASL_NODE ** xasl_tree, bool use_xasl_clone, char *xasl_stream,
+			int xasl_stream_size, void **xasl_unpack_info_ptr)
 {
   XASL_NODE *xasl;
   char *p;
@@ -296,6 +303,7 @@ stx_map_stream_to_xasl (THREAD_ENTRY * thread_p, XASL_NODE ** xasl_tree, char *x
   stx_set_xasl_errcode (thread_p, NO_ERROR);
   stx_init_xasl_unpack_info (thread_p, xasl_stream, xasl_stream_size);
   unpack_info_p = stx_get_xasl_unpack_info_ptr (thread_p);
+  unpack_info_p->use_xasl_clone = use_xasl_clone;
   unpack_info_p->track_allocated_bufers = 1;
 
   /* calculate offset to XASL tree in the stream buffer */
@@ -331,7 +339,6 @@ stx_map_stream_to_xasl (THREAD_ENTRY * thread_p, XASL_NODE ** xasl_tree, char *x
   /* initialize the query in progress flag to FALSE.  Note that this flag is not packed/unpacked.  It is strictly a
    * server side flag. */
   xasl->query_in_progress = false;
-
 end:
   stx_free_visited_ptrs (thread_p);
 #if defined(SERVER_MODE)
@@ -372,6 +379,7 @@ stx_map_stream_to_filter_pred (THREAD_ENTRY * thread_p, PRED_EXPR_WITH_CONTEXT *
   stx_set_xasl_errcode (thread_p, NO_ERROR);
   stx_init_xasl_unpack_info (thread_p, pred_stream, pred_stream_size);
   unpack_info_p = stx_get_xasl_unpack_info_ptr (thread_p);
+  unpack_info_p->use_xasl_clone = true;
   unpack_info_p->track_allocated_bufers = 1;
 
   /* calculate offset to filter predicate in the stream buffer */
@@ -408,7 +416,7 @@ end:
 /*
  * stx_map_stream_to_func_pred () -
  *   return: if successful, return 0, otherwise non-zero error code
- *   xasl(in)      : pointer to where to return the unpacked FUNC_PRED
+ *   xasl(in)      : pointer to where to return the unpacked FUNC_PRED 
  *   xasl_stream(in)    : pointer to xasl stream
  *   xasl_stream_size(in)       : # of bytes in xasl_stream
  *   xasl_unpack_info_ptr(in)   : pointer to where to return the pack info
@@ -431,6 +439,7 @@ stx_map_stream_to_func_pred (THREAD_ENTRY * thread_p, FUNC_PRED ** xasl, char *x
   stx_set_xasl_errcode (thread_p, NO_ERROR);
   stx_init_xasl_unpack_info (thread_p, xasl_stream, xasl_stream_size);
   unpack_info_p = stx_get_xasl_unpack_info_ptr (thread_p);
+  unpack_info_p->use_xasl_clone = false;
   unpack_info_p->track_allocated_bufers = 1;
 
   /* calculate offset to expr XASL in the stream buffer */
@@ -966,6 +975,7 @@ stx_restore_db_value (THREAD_ENTRY * thread_p, char *ptr)
   return value;
 }
 
+#if defined(ENABLE_UNUSED_FUNCTION)
 static QPROC_DB_VALUE_LIST
 stx_restore_db_value_list (THREAD_ENTRY * thread_p, char *ptr)
 {
@@ -997,6 +1007,7 @@ stx_restore_db_value_list (THREAD_ENTRY * thread_p, char *ptr)
 
   return value_list;
 }
+#endif
 
 static XASL_NODE *
 stx_restore_xasl_node (THREAD_ENTRY * thread_p, char *ptr)
@@ -1464,6 +1475,7 @@ stx_restore_db_value_array_extra (THREAD_ENTRY * thread_p, char *ptr, int neleme
 	  stx_set_xasl_errcode (thread_p, ER_OUT_OF_VIRTUAL_MEMORY);
 	  return NULL;
 	}
+      assert (value_array[i]->need_clear == false);
     }
 
   for (; i < total_nelements; ++i)
@@ -1887,6 +1899,7 @@ stx_build_xasl_node (THREAD_ENTRY * thread_p, char *ptr, XASL_NODE * xasl)
 	{
 	  goto error;
 	}
+      assert (xasl->ordbynum_val->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, &offset);
@@ -2101,6 +2114,7 @@ stx_build_xasl_node (THREAD_ENTRY * thread_p, char *ptr, XASL_NODE * xasl)
 	{
 	  goto error;
 	}
+      assert (xasl->instnum_val->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, &offset);
@@ -2115,6 +2129,7 @@ stx_build_xasl_node (THREAD_ENTRY * thread_p, char *ptr, XASL_NODE * xasl)
 	{
 	  goto error;
 	}
+      assert (xasl->save_instnum_val->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, (int *) &xasl->instnum_flag);
@@ -2173,6 +2188,7 @@ stx_build_xasl_node (THREAD_ENTRY * thread_p, char *ptr, XASL_NODE * xasl)
 	{
 	  goto error;
 	}
+      assert (xasl->level_val->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, &offset);
@@ -2201,6 +2217,7 @@ stx_build_xasl_node (THREAD_ENTRY * thread_p, char *ptr, XASL_NODE * xasl)
 	{
 	  goto error;
 	}
+      assert (xasl->isleaf_val->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, &offset);
@@ -2229,6 +2246,7 @@ stx_build_xasl_node (THREAD_ENTRY * thread_p, char *ptr, XASL_NODE * xasl)
 	{
 	  goto error;
 	}
+      assert (xasl->iscycle_val->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, &offset);
@@ -2682,6 +2700,7 @@ stx_build_fetch_proc (THREAD_ENTRY * thread_p, char *ptr, FETCH_PROC_NODE * obj_
 	  stx_set_xasl_errcode (thread_p, ER_OUT_OF_VIRTUAL_MEMORY);
 	  return NULL;
 	}
+      assert (obj_set_fetch_proc->arg->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, &i);
@@ -2857,6 +2876,7 @@ stx_build_buildlist_proc (THREAD_ENTRY * thread_p, char *ptr, BUILDLIST_PROC_NOD
 	{
 	  goto error;
 	}
+      assert (stx_build_list_proc->g_grbynum_val->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, (int *) &stx_build_list_proc->g_hash_eligible);
@@ -3056,6 +3076,7 @@ stx_build_buildlist_proc (THREAD_ENTRY * thread_p, char *ptr, BUILDLIST_PROC_NOD
 	{
 	  goto error;
 	}
+      assert (stx_build_list_proc->a_instnum_val->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, (int *) &stx_build_list_proc->a_instnum_flag);
@@ -3101,6 +3122,7 @@ stx_build_buildvalue_proc (THREAD_ENTRY * thread_p, char *ptr, BUILDVALUE_PROC_N
 	  stx_set_xasl_errcode (thread_p, ER_OUT_OF_VIRTUAL_MEMORY);
 	  return NULL;
 	}
+      assert (stx_build_value_proc->grbynum_val->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, &offset);
@@ -3500,7 +3522,7 @@ static char *
 stx_build_update_assignment (THREAD_ENTRY * thread_p, char *ptr, UPDATE_ASSIGNMENT * assign)
 {
   int offset = 0;
-  XASL_UNPACK_INFO *xasl_unpack_info = stx_get_xasl_unpack_info_ptr (thread_p);
+  XASL_UNPACK_INFO *xasl_unpack_info_p = stx_get_xasl_unpack_info_ptr (thread_p);
 
   /* cls_idx */
   ptr = or_unpack_int (ptr, &assign->cls_idx);
@@ -3509,6 +3531,7 @@ stx_build_update_assignment (THREAD_ENTRY * thread_p, char *ptr, UPDATE_ASSIGNME
   ptr = or_unpack_int (ptr, &assign->att_idx);
 
   /* constant */
+  assign->clear_value_at_clone_decache = false;
   ptr = or_unpack_int (ptr, &offset);
   if (offset == 0)
     {
@@ -3516,7 +3539,15 @@ stx_build_update_assignment (THREAD_ENTRY * thread_p, char *ptr, UPDATE_ASSIGNME
     }
   else
     {
-      assign->constant = stx_restore_db_value (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+      assign->constant = stx_restore_db_value (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
+      if (assign->constant == NULL)
+	{
+	  return NULL;
+	}
+      if (xasl_unpack_info_p->use_xasl_clone && !db_value_is_null (assign->constant))
+	{
+	  assign->clear_value_at_clone_decache = true;
+	}
     }
 
   /* regu_var */
@@ -3527,7 +3558,7 @@ stx_build_update_assignment (THREAD_ENTRY * thread_p, char *ptr, UPDATE_ASSIGNME
     }
   else
     {
-      assign->regu_var = stx_restore_regu_variable (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+      assign->regu_var = stx_restore_regu_variable (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
       if (assign->regu_var == NULL)
 	{
 	  return NULL;
@@ -3909,6 +3940,7 @@ stx_build_insert_proc (THREAD_ENTRY * thread_p, char *ptr, INSERT_PROC_NODE * in
 	{
 	  return NULL;
 	}
+      assert (insert_info->obj_oid->need_clear == false);
     }
 
   return ptr;
@@ -4521,6 +4553,7 @@ stx_build_access_spec_type (THREAD_ENTRY * thread_p, char *ptr, ACCESS_SPEC_TYPE
   access_spec->curent = NULL;
   access_spec->pruned = false;
 
+  access_spec->clear_value_at_clone_decache = false;
   ptr = or_unpack_int (ptr, &offset);
   if (offset == 0)
     {
@@ -4532,6 +4565,10 @@ stx_build_access_spec_type (THREAD_ENTRY * thread_p, char *ptr, ACCESS_SPEC_TYPE
       if (access_spec->s_dbval == NULL)
 	{
 	  goto error;
+	}
+      if (xasl_unpack_info->use_xasl_clone && !db_value_is_null (access_spec->s_dbval))
+	{
+	  access_spec->clear_value_at_clone_decache = true;
 	}
     }
 
@@ -5193,6 +5230,7 @@ stx_build_val_list (THREAD_ENTRY * thread_p, char *ptr, VAL_LIST * val_list)
 	      stx_set_xasl_errcode (thread_p, ER_OUT_OF_VIRTUAL_MEMORY);
 	      return NULL;
 	    }
+	  assert (value_list[i].val->need_clear == false);
 	}
 
       if (i < val_list->val_cnt - 1)
@@ -5210,6 +5248,7 @@ stx_build_val_list (THREAD_ENTRY * thread_p, char *ptr, VAL_LIST * val_list)
   return ptr;
 }
 
+#if defined(ENABLE_UNUSED_FUNCTION)
 static char *
 stx_build_db_value_list (THREAD_ENTRY * thread_p, char *ptr, QPROC_DB_VALUE_LIST value_list)
 {
@@ -5248,6 +5287,7 @@ stx_build_db_value_list (THREAD_ENTRY * thread_p, char *ptr, QPROC_DB_VALUE_LIST
 
   return ptr;
 }
+#endif
 
 static char *
 stx_build_regu_variable (THREAD_ENTRY * thread_p, char *ptr, REGU_VARIABLE * regu_var)
@@ -5257,6 +5297,8 @@ stx_build_regu_variable (THREAD_ENTRY * thread_p, char *ptr, REGU_VARIABLE * reg
   XASL_UNPACK_INFO *xasl_unpack_info = stx_get_xasl_unpack_info_ptr (thread_p);
 
   ptr = or_unpack_domain (ptr, &regu_var->domain, NULL);
+  /* save the original domain */
+  regu_var->original_domain = regu_var->domain;
 
   ptr = or_unpack_int (ptr, &tmp);
   regu_var->type = (REGU_DATATYPE) tmp;
@@ -5308,7 +5350,7 @@ stx_unpack_regu_variable_value (THREAD_ENTRY * thread_p, char *ptr, REGU_VARIABL
   REGU_VALUE_LIST *regu_list;
   REGU_VARIABLE_LIST regu_var_list = NULL;
   int offset;
-  XASL_UNPACK_INFO *xasl_unpack_info = stx_get_xasl_unpack_info_ptr (thread_p);
+  XASL_UNPACK_INFO *xasl_unpack_info_p = stx_get_xasl_unpack_info_ptr (thread_p);
 
   assert (ptr != NULL && regu_var != NULL);
 
@@ -5342,6 +5384,10 @@ stx_unpack_regu_variable_value (THREAD_ENTRY * thread_p, char *ptr, REGU_VARIABL
 
     case TYPE_DBVAL:
       ptr = stx_build_db_value (thread_p, ptr, &regu_var->value.dbval);
+      if (xasl_unpack_info_p->use_xasl_clone && !db_value_is_null (&regu_var->value.dbval))
+	{
+	  REGU_VARIABLE_SET_FLAG (regu_var, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE);
+	}
       break;
 
     case TYPE_CONSTANT:
@@ -5353,10 +5399,14 @@ stx_unpack_regu_variable_value (THREAD_ENTRY * thread_p, char *ptr, REGU_VARIABL
 	}
       else
 	{
-	  regu_var->value.dbvalptr = stx_restore_db_value (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+	  regu_var->value.dbvalptr = stx_restore_db_value (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
 	  if (regu_var->value.dbvalptr == NULL)
 	    {
 	      goto error;
+	    }
+	  if (xasl_unpack_info_p->use_xasl_clone && regu_var->value.dbvalptr->need_clear)
+	    {
+	      REGU_VARIABLE_SET_FLAG (regu_var, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE);
 	    }
 	}
       break;
@@ -5370,7 +5420,7 @@ stx_unpack_regu_variable_value (THREAD_ENTRY * thread_p, char *ptr, REGU_VARIABL
 	}
       else
 	{
-	  regu_var->value.arithptr = stx_restore_arith_type (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+	  regu_var->value.arithptr = stx_restore_arith_type (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
 	  if (regu_var->value.arithptr == NULL)
 	    {
 	      goto error;
@@ -5386,7 +5436,7 @@ stx_unpack_regu_variable_value (THREAD_ENTRY * thread_p, char *ptr, REGU_VARIABL
 	}
       else
 	{
-	  regu_var->value.funcp = stx_restore_function_type (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+	  regu_var->value.funcp = stx_restore_function_type (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
 	  if (regu_var->value.funcp == NULL)
 	    {
 	      goto error;
@@ -5408,7 +5458,7 @@ stx_unpack_regu_variable_value (THREAD_ENTRY * thread_p, char *ptr, REGU_VARIABL
 	}
       else
 	{
-	  regu_var->value.srlist_id = stx_restore_srlist_id (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+	  regu_var->value.srlist_id = stx_restore_srlist_id (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
 	  if (regu_var->value.srlist_id == NULL)
 	    {
 	      goto error;
@@ -5496,6 +5546,8 @@ stx_build_arith_type (THREAD_ENTRY * thread_p, char *ptr, ARITH_TYPE * arith_typ
   XASL_UNPACK_INFO *xasl_unpack_info = stx_get_xasl_unpack_info_ptr (thread_p);
 
   ptr = or_unpack_domain (ptr, &arith_type->domain, NULL);
+  /* save the original domain */
+  arith_type->original_domain = arith_type->domain;
 
   ptr = or_unpack_int (ptr, &offset);
   if (offset == 0)
@@ -5509,6 +5561,7 @@ stx_build_arith_type (THREAD_ENTRY * thread_p, char *ptr, ARITH_TYPE * arith_typ
 	{
 	  goto error;
 	}
+      assert (arith_type->value->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, &tmp);
@@ -5610,7 +5663,7 @@ stx_build_aggregate_type (THREAD_ENTRY * thread_p, char *ptr, AGGREGATE_TYPE * a
 {
   int offset;
   int tmp;
-  XASL_UNPACK_INFO *xasl_unpack_info = stx_get_xasl_unpack_info_ptr (thread_p);
+  XASL_UNPACK_INFO *xasl_unpack_info_p = stx_get_xasl_unpack_info_ptr (thread_p);
 
   assert (ptr != NULL && aggregate != NULL);
 
@@ -5618,6 +5671,7 @@ stx_build_aggregate_type (THREAD_ENTRY * thread_p, char *ptr, AGGREGATE_TYPE * a
   ptr = or_unpack_domain (ptr, &aggregate->domain, NULL);
 
   /* accumulator */
+  aggregate->accumulator.clear_value_at_clone_decache = false;
   ptr = or_unpack_int (ptr, &offset);
   if (offset == 0)
     {
@@ -5625,13 +5679,18 @@ stx_build_aggregate_type (THREAD_ENTRY * thread_p, char *ptr, AGGREGATE_TYPE * a
     }
   else
     {
-      aggregate->accumulator.value = stx_restore_db_value (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+      aggregate->accumulator.value = stx_restore_db_value (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
       if (aggregate->accumulator.value == NULL)
 	{
 	  goto error;
 	}
+      if (xasl_unpack_info_p->use_xasl_clone && !db_value_is_null (aggregate->accumulator.value))
+	{
+	  aggregate->accumulator.clear_value_at_clone_decache = true;
+	}
     }
 
+  aggregate->accumulator.clear_value2_at_clone_decache = false;
   ptr = or_unpack_int (ptr, &offset);
   if (offset == 0)
     {
@@ -5639,10 +5698,14 @@ stx_build_aggregate_type (THREAD_ENTRY * thread_p, char *ptr, AGGREGATE_TYPE * a
     }
   else
     {
-      aggregate->accumulator.value2 = stx_restore_db_value (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+      aggregate->accumulator.value2 = stx_restore_db_value (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
       if (aggregate->accumulator.value2 == NULL)
 	{
 	  goto error;
+	}
+      if (xasl_unpack_info_p->use_xasl_clone && !db_value_is_null (aggregate->accumulator.value2))
+	{
+	  aggregate->accumulator.clear_value2_at_clone_decache = true;
 	}
     }
 
@@ -5656,7 +5719,7 @@ stx_build_aggregate_type (THREAD_ENTRY * thread_p, char *ptr, AGGREGATE_TYPE * a
     }
   else
     {
-      aggregate->next = stx_restore_aggregate_type (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+      aggregate->next = stx_restore_aggregate_type (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
       if (aggregate->next == NULL)
 	{
 	  goto error;
@@ -5690,7 +5753,7 @@ stx_build_aggregate_type (THREAD_ENTRY * thread_p, char *ptr, AGGREGATE_TYPE * a
     }
   else
     {
-      aggregate->list_id = stx_restore_list_id (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+      aggregate->list_id = stx_restore_list_id (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
       if (aggregate->list_id == NULL)
 	{
 	  goto error;
@@ -5711,7 +5774,7 @@ stx_build_aggregate_type (THREAD_ENTRY * thread_p, char *ptr, AGGREGATE_TYPE * a
     }
   else
     {
-      aggregate->sort_list = stx_restore_sort_list (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+      aggregate->sort_list = stx_restore_sort_list (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
       if (aggregate->sort_list == NULL)
 	{
 	  goto error;
@@ -5725,7 +5788,7 @@ stx_build_aggregate_type (THREAD_ENTRY * thread_p, char *ptr, AGGREGATE_TYPE * a
       if (offset > 0)
 	{
 	  aggregate->info.percentile.percentile_reguvar =
-	    stx_restore_regu_variable (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+	    stx_restore_regu_variable (thread_p, &xasl_unpack_info_p->packed_xasl[offset]);
 	  if (aggregate->info.percentile.percentile_reguvar == NULL)
 	    {
 	      goto error;
@@ -5772,6 +5835,7 @@ stx_build_function_type (THREAD_ENTRY * thread_p, char *ptr, FUNCTION_TYPE * fun
 	  stx_set_xasl_errcode (thread_p, ER_OUT_OF_VIRTUAL_MEMORY);
 	  return NULL;
 	}
+      assert (function->value->need_clear == false);
     }
 
   ptr = or_unpack_int (ptr, &tmp);
@@ -5820,6 +5884,7 @@ stx_build_analytic_type (THREAD_ENTRY * thread_p, char *ptr, ANALYTIC_TYPE * ana
 	{
 	  goto error;
 	}
+      assert (analytic->value->need_clear == false);
     }
 
   /* value2 */
@@ -5835,6 +5900,7 @@ stx_build_analytic_type (THREAD_ENTRY * thread_p, char *ptr, ANALYTIC_TYPE * ana
 	{
 	  goto error;
 	}
+      assert (analytic->value2->need_clear == false);
     }
 
   /* out_value */
@@ -5850,6 +5916,7 @@ stx_build_analytic_type (THREAD_ENTRY * thread_p, char *ptr, ANALYTIC_TYPE * ana
 	{
 	  goto error;
 	}
+      assert (analytic->out_value->need_clear == false);
     }
 
   /* offset_idx */
@@ -6073,6 +6140,8 @@ stx_build_sort_list (THREAD_ENTRY * thread_p, char *ptr, SORT_LIST * sort_list)
     {
       return NULL;
     }
+  sort_list->original_value_domain = sort_list->pos_descr.dom;
+
   ptr = or_unpack_int (ptr, &tmp);
   sort_list->s_order = (SORT_ORDER) tmp;
 
@@ -6391,6 +6460,8 @@ stx_build_regu_value_list (THREAD_ENTRY * thread_p, char *ptr, REGU_VALUE_LIST *
       ptr = or_unpack_int (ptr, &tmp);
       regu->type = (REGU_DATATYPE) tmp;
       regu->domain = domain;
+      /* save te original domain */
+      regu->original_domain = domain;
 
       if (regu->type != TYPE_DBVAL && regu->type != TYPE_INARITH && regu->type != TYPE_POS_VALUE)
 	{

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -243,6 +243,7 @@ static void xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidat
 static bool xcache_entry_is_related_to_oid (XASL_CACHE_ENTRY * xcache_entry, void *arg);
 static XCACHE_CLEANUP_REASON xcache_need_cleanup (void);
 
+
 /*
  * xcache_initialize () - Initialize XASL cache.
  *
@@ -349,7 +350,7 @@ xcache_finalize (THREAD_ENTRY * thread_p)
       bh_destroy (thread_p, xcache_Cleanup_bh);
       xcache_Cleanup_bh = NULL;
     }
-  (void) db_change_private_heap (thread_p, 0);
+  (void) db_change_private_heap (thread_p, save_heapid);
 
   xcache_Enabled = false;
 }
@@ -800,6 +801,7 @@ xcache_find_xasl_id (THREAD_ENTRY * thread_p, const XASL_ID * xid, XASL_CACHE_EN
   HL_HEAPID save_heapid = 0;
   int oid_index;
   int lock_result;
+  bool use_xasl_clone = false;
 
   assert (xid != NULL);
   assert (xcache_entry != NULL && *xcache_entry == NULL);
@@ -883,8 +885,8 @@ xcache_find_xasl_id (THREAD_ENTRY * thread_p, const XASL_ID * xid, XASL_CACHE_EN
 	}
     }
 
-  /* Check the entry is still valid. */
-  if ((*xcache_entry)->xasl_id.cache_flag & XCACHE_ENTRY_MARK_DELETED)
+  /* Check the entry is still valid.  Uses atomic to prevent any code reordering */
+  if (ATOMIC_INC_32 (&((*xcache_entry)->xasl_id.cache_flag), 0) & XCACHE_ENTRY_MARK_DELETED)
     {
       /* Someone has marked entry as deleted. */
       xcache_log ("could not get cache entry because it was deleted until locked: \n"
@@ -898,8 +900,9 @@ xcache_find_xasl_id (THREAD_ENTRY * thread_p, const XASL_ID * xid, XASL_CACHE_EN
 
   assert ((*xcache_entry) != NULL);
 
-  if (xcache_Max_clones > 0)
+  if (xcache_uses_clones ())
     {
+      use_xasl_clone = true;
       /* Try to fetch a cached clone. */
       if ((*xcache_entry)->cache_clones == NULL)
 	{
@@ -936,7 +939,7 @@ xcache_find_xasl_id (THREAD_ENTRY * thread_p, const XASL_ID * xid, XASL_CACHE_EN
       save_heapid = db_change_private_heap (thread_p, 0);
     }
   error_code =
-    stx_map_stream_to_xasl (thread_p, &xclone->xasl, (*xcache_entry)->stream.xasl_stream,
+    stx_map_stream_to_xasl (thread_p, &xclone->xasl, use_xasl_clone, (*xcache_entry)->stream.xasl_stream,
 			    (*xcache_entry)->stream.xasl_stream_size, &xclone->xasl_buf);
   if (save_heapid != 0)
     {
@@ -1078,6 +1081,12 @@ xcache_unfix (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry)
       xcache_log ("delete entry from hash after unfix: \n"
 		  XCACHE_LOG_ENTRY_TEXT ("entry")
 		  XCACHE_LOG_TRAN_TEXT, XCACHE_LOG_ENTRY_ARGS (xcache_entry), XCACHE_LOG_TRAN_ARGS (thread_p));
+      /* No need to acquire the clone mutex, since I'm the unique user. */
+      while (xcache_entry->n_cache_clones > 0)
+	{
+	  xcache_clone_decache (thread_p, &xcache_entry->cache_clones[--xcache_entry->n_cache_clones]);
+	}
+
       error_code = lf_hash_delete (t_entry, &xcache_Ht, &xcache_entry->xasl_id, &success);
       if (error_code != NO_ERROR)
 	{
@@ -1583,7 +1592,14 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
 	      /* Mark entry as deleted. */
 	      if (xcache_entry_mark_deleted (thread_p, xcache_entry))
 		{
-		  /* Successfully marked for delete. Save it to delete after the iteration. */
+		  /* 
+		   * Successfully marked for delete. Save it to delete after the iteration.
+		   * No need to acquire the clone mutex, since I'm the unique user.
+		   */
+		  while (xcache_entry->n_cache_clones > 0)
+		    {
+		      xcache_clone_decache (thread_p, &xcache_entry->cache_clones[--xcache_entry->n_cache_clones]);
+		    }
 		  delete_xids[n_delete_xids++] = xcache_entry->xasl_id;
 		}
 	    }
@@ -1738,7 +1754,7 @@ xcache_dump (THREAD_ENTRY * thread_p, FILE * fp)
       fprintf (fp, "  cache flags = %08x \n", xcache_entry->xasl_id.cache_flag & XCACHE_ENTRY_FLAGS_MASK);
       fprintf (fp, "  reference count = %ld \n", ATOMIC_INC_64 (&xcache_entry->ref_count, 0));
       fprintf (fp, "  time second last used = %lld \n", (long long) xcache_entry->time_last_used.tv_sec);
-      if (xcache_Max_clones > 0)
+      if (xcache_uses_clones ())
 	{
 	  fprintf (fp, "  clone count = %d \n", xcache_entry->n_cache_clones);
 	}
@@ -1800,6 +1816,8 @@ static void
 xcache_clone_decache (THREAD_ENTRY * thread_p, XASL_CLONE * xclone)
 {
   HL_HEAPID save_heapid = db_change_private_heap (thread_p, 0);
+  XASL_SET_FLAG (xclone->xasl, XASL_DECACHE_CLONE);
+  qexec_clear_xasl (thread_p, xclone->xasl, true);
   stx_free_additional_buff (thread_p, xclone->xasl_buf);
   stx_free_xasl_unpack_info (xclone->xasl_buf);
   db_private_free (thread_p, xclone->xasl_buf);
@@ -1819,7 +1837,10 @@ xcache_clone_decache (THREAD_ENTRY * thread_p, XASL_CLONE * xclone)
 void
 xcache_retire_clone (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry, XASL_CLONE * xclone)
 {
-  if (xcache_Max_clones > 0)
+  /* Free XASL. Be sure that was already cleared to avoid memory leaks. */
+  assert (xclone->xasl->status == XASL_CLEARED);
+
+  if (xcache_uses_clones ())
     {
       pthread_mutex_lock (&xcache_entry->cache_clones_mutex);
       if (xcache_entry->n_cache_clones < xcache_Max_clones)
@@ -2034,7 +2055,9 @@ xcache_cleanup (THREAD_ENTRY * thread_p)
       /* Set intention to cleanup the entry. */
       candidate.xid.cache_flag = XCACHE_ENTRY_CLEANUP;
 
-      /* Try delete. */
+      /* Try delete. Would be better to decache the clones here. For simplicity, since is not an usual case,
+       * clone decache is postponed - is decached when retired list will be cleared.
+       */
       if (lf_hash_delete (t_entry, &xcache_Ht, &candidate.xid, &success) != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -2215,4 +2238,15 @@ int
 xcache_get_entry_count (void)
 {
   return xcache_Global.entry_count;
+}
+
+/*
+ * xcache_uses_clones () - Check whether XASL clones are used
+ *
+ * return : True, if XASL clones are used, false otherwise
+ */
+bool
+xcache_uses_clones (void)
+{
+  return xcache_Max_clones > 0;
 }

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -243,7 +243,6 @@ static void xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidat
 static bool xcache_entry_is_related_to_oid (XASL_CACHE_ENTRY * xcache_entry, void *arg);
 static XCACHE_CLEANUP_REASON xcache_need_cleanup (void);
 
-
 /*
  * xcache_initialize () - Initialize XASL cache.
  *

--- a/src/query/xasl_cache.h
+++ b/src/query/xasl_cache.h
@@ -123,4 +123,5 @@ extern bool xcache_can_entry_cache_list (XASL_CACHE_ENTRY * xcache_entry);
 
 extern void xcache_retire_clone (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry, XASL_CLONE * xclone);
 extern int xcache_get_entry_count (void);
+extern bool xcache_uses_clones (void);
 #endif /* _XASL_CACHE_H_ */

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -3693,21 +3693,11 @@ catcls_insert_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
       goto error;
     }
 
-#if defined(SERVER_MODE)
-  lock_unlock_object (thread_p, oid_p, class_oid_p, X_LOCK, false);
-#endif /* SERVER_MODE */
   free_and_init (record.data);
 
   return NO_ERROR;
 
 error:
-
-#if defined(SERVER_MODE)
-  if (is_lock_inited)
-    {
-      lock_unlock_object (thread_p, oid_p, class_oid_p, X_LOCK, false);
-    }
-#endif /* SERVER_MODE */
 
   if (record.data)
     {
@@ -3798,21 +3788,11 @@ catcls_delete_instance (THREAD_ENTRY * thread_p, OID * oid_p, OID * class_oid_p,
       goto error;
     }
 
-#if defined(SERVER_MODE)
-  lock_unlock_object (thread_p, oid_p, class_oid_p, X_LOCK, false);
-#endif /* SERVER_MODE */
   catcls_free_or_value (value_p);
 
   return NO_ERROR;
 
 error:
-
-#if defined(SERVER_MODE)
-  if (is_lock_inited)
-    {
-      lock_unlock_object (thread_p, oid_p, class_oid_p, X_LOCK, false);
-    }
-#endif /* SERVER_MODE */
 
   if (value_p)
     {
@@ -3957,9 +3937,6 @@ catcls_update_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
       free_and_init (record.data);
     }
 
-#if defined(SERVER_MODE)
-  lock_unlock_object (thread_p, oid_p, class_oid_p, X_LOCK, false);
-#endif /* SERVER_MODE */
   catcls_free_or_value (old_value_p);
 
   return NO_ERROR;

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -61,8 +61,6 @@
 /* Define structures, globals, and macro's                              */
 /************************************************************************/
 
-#define DISK_VOLHEADER_PAGE      0	/* Page of the volume header */
-
 /* DON'T USE sizeof on this structure.. size if variable */
 typedef struct disk_volume_header DISK_VOLUME_HEADER;
 struct disk_volume_header

--- a/src/storage/disk_manager.h
+++ b/src/storage/disk_manager.h
@@ -33,6 +33,8 @@
 #include "storage_common.h"
 #include "recovery.h"
 
+#define DISK_VOLHEADER_PAGE      0	/* Page of the volume header */
+
 /*
  * Disk sectors
  */

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -131,11 +131,26 @@ struct file_header
    * page of user page table. Newly allocated page is appended here. */
   VPID vpid_last_user_page_ftab;
 
+  /* cache last file_numerable_find_nth page and index of its entry. used as an optimization for external sort files.
+   * the extensible hash case is not interesting for this optimization (because they are usually small files and because
+   * the access pattern is less predictable.
+   * the usual pattern external sort files is find nth, find nth+1, find nth+2 and so on. so we can cache the page and
+   * index of its first entry from last search to predict where the next file_numerable_find_nth will land.
+   *
+   * how it works:
+   * cache last search location for file_numerable_find_nth by saving user page table page VPID and index of first entry
+   * in page. next search will probably land in the same page (and it will just need to get to the right offset).
+   * if a page is deallocated, the cached location is reset (this is just a safe-guard since external sort does not
+   * deallocate pages currently.
+   * if a page is allocated, since it is appended at the end, will not affect the cached search location. current thread
+   * is actually the only one accessing the file so it can change it safely without promoting to write latch. to avoid
+   * safe-guards, we won't set the page dirty (it is hot anyway and likely to remain in memory).
+   */
+  VPID vpid_find_nth_last;
+  int first_index_find_nth_last;
+
   /* reserved area for future extension */
   INT32 reserved0;
-  INT32 reserved1;
-  INT32 reserved2;
-  INT32 reserved3;
 };
 
 /* Disk size of file header. */
@@ -147,6 +162,9 @@ struct file_header
 
 #define FILE_IS_NUMERABLE(fh) (((fh)->file_flags & FILE_FLAG_NUMERABLE) != 0)
 #define FILE_IS_TEMPORARY(fh) (((fh)->file_flags & FILE_FLAG_TEMPORARY) != 0)
+
+#define FILE_CACHE_LAST_FIND_NTH(fh) \
+  (FILE_IS_NUMERABLE (fh) && FILE_IS_TEMPORARY (fh) && (fh)->type == FILE_TEMP)
 
 /* Numerable file types. Currently, we used this property for extensible hashes and sort files. */
 #define FILE_TYPE_CAN_BE_NUMERABLE(ftype) ((ftype) == FILE_EXTENDIBLE_HASH \
@@ -320,7 +338,8 @@ static bool file_Logging = false;
   "\t\ttable offsets: partial = %d, full = %d, user page = %d \n" \
   "\t\tvpid_sticky_first = %d|%d \n" \
   "\t\tvpid_last_temp_alloc = %d|%d, offset_to_last_temp_alloc=%d \n" \
-  "\t\tvpid_last_user_page_ftab = %d|%d \n"
+  "\t\tvpid_last_user_page_ftab = %d|%d \n" \
+  "\t\tvpid_find_nth_last = %d|%d, first_index_find_nth_last = %d \n"
 #define FILE_HEAD_FULL_AS_ARGS(fhead) \
   FILE_HEAD_ALLOC_AS_ARGS (fhead), \
   VFID_AS_ARGS (&(fhead)->self), (long long int) fhead->time_creation, file_type_to_string ((fhead)->type), \
@@ -328,7 +347,8 @@ static bool file_Logging = false;
   (fhead)->offset_to_partial_ftab, (fhead)->offset_to_full_ftab, (fhead)->offset_to_user_page_ftab, \
   VPID_AS_ARGS (&(fhead)->vpid_sticky_first), \
   VPID_AS_ARGS (&(fhead)->vpid_last_temp_alloc), (fhead)->offset_to_last_temp_alloc, \
-  VPID_AS_ARGS (&(fhead)->vpid_last_user_page_ftab)
+  VPID_AS_ARGS (&(fhead)->vpid_last_user_page_ftab), \
+  VPID_AS_ARGS (&(fhead)->vpid_find_nth_last), (fhead)->first_index_find_nth_last
 
 #define FILE_EXTDATA_MSG(name) \
   "\t" name ": { vpid_next = %d|%d, max_size = %d, item_size = %d, n_items = %d } \n"
@@ -413,6 +433,7 @@ struct file_find_nth_context
 {
   VPID *vpid_nth;
   int nth;
+  int first_index;
 };
 
 /************************************************************************/
@@ -829,6 +850,8 @@ file_header_init (FILE_HEADER * fhead)
   VPID_SET_NULL (&fhead->vpid_last_temp_alloc);
   fhead->offset_to_last_temp_alloc = NULL_OFFSET;
   VPID_SET_NULL (&fhead->vpid_last_user_page_ftab);
+  VPID_SET_NULL (&fhead->vpid_find_nth_last);
+  fhead->first_index_find_nth_last = 0;
   VPID_SET_NULL (&fhead->vpid_sticky_first);
 
   fhead->n_page_total = 0;
@@ -845,7 +868,7 @@ file_header_init (FILE_HEADER * fhead)
   fhead->offset_to_full_ftab = NULL_OFFSET;
   fhead->offset_to_user_page_ftab = NULL_OFFSET;
 
-  fhead->reserved0 = fhead->reserved1 = fhead->reserved2 = fhead->reserved3 = 0;
+  fhead->reserved0 = 0;
 }
 
 /*
@@ -3220,6 +3243,8 @@ file_create (THREAD_ENTRY * thread_p, FILE_TYPE file_type,
   VPID_SET_NULL (&fhead->vpid_last_temp_alloc);
   fhead->offset_to_last_temp_alloc = NULL_OFFSET;
   VPID_SET_NULL (&fhead->vpid_last_user_page_ftab);
+  VPID_SET_NULL (&fhead->vpid_find_nth_last);
+  fhead->first_index_find_nth_last = 0;
   VPID_SET_NULL (&fhead->vpid_sticky_first);
 
   fhead->n_page_total = 0;
@@ -3237,7 +3262,7 @@ file_create (THREAD_ENTRY * thread_p, FILE_TYPE file_type,
   fhead->offset_to_full_ftab = NULL_OFFSET;
   fhead->offset_to_user_page_ftab = NULL_OFFSET;
 
-  fhead->reserved0 = fhead->reserved1 = fhead->reserved2 = fhead->reserved3 = 0;
+  fhead->reserved0 = 0;
 
   /* start with a negative empty sector (because we have allocated header). */
   fhead->n_sector_empty--;
@@ -3495,6 +3520,7 @@ file_create (THREAD_ENTRY * thread_p, FILE_TYPE file_type,
     {
       /* set last user page table VPID to header */
       fhead->vpid_last_user_page_ftab = vpid_fhead;
+      fhead->vpid_find_nth_last = vpid_fhead;
     }
 
   /* set all stats */
@@ -5416,6 +5442,13 @@ file_dealloc (THREAD_ENTRY * thread_p, const VFID * vfid, const VPID * vpid, FIL
 
   file_log ("file_dealloc", "file %d|%d marked vpid %|%d as deleted", VFID_AS_ARGS (vfid), VPID_AS_ARGS (vpid));
 
+  if (FILE_CACHE_LAST_FIND_NTH (fhead))
+    {
+      /* reset cached search location */
+      VPID_SET_NULL (&fhead->vpid_find_nth_last);
+      fhead->first_index_find_nth_last = 0;
+    }
+
   /* done */
   assert (error_code != NO_ERROR);
 
@@ -7286,6 +7319,7 @@ file_extdata_find_nth_vpid (THREAD_ENTRY * thread_p, const FILE_EXTENSIBLE_DATA 
     {
       /* not in this extensible data. continue searching. */
       find_nth_context->nth -= count_vpid;
+      find_nth_context->first_index += count_vpid;
     }
   else
     {
@@ -7357,6 +7391,8 @@ file_numerable_find_nth (THREAD_ENTRY * thread_p, const VFID * vfid, int nth, bo
   PAGE_PTR page_fhead = NULL;
   FILE_HEADER *fhead = NULL;
   FILE_EXTENSIBLE_DATA *extdata_user_page_ftab = NULL;
+  PAGE_PTR page_ftab_start = NULL;
+  PAGE_PTR page_ftab_nth_location = NULL;
   FILE_FIND_NTH_CONTEXT find_nth_context;
   int error_code = NO_ERROR;
 
@@ -7382,6 +7418,7 @@ file_numerable_find_nth (THREAD_ENTRY * thread_p, const VFID * vfid, int nth, bo
     }
   fhead = (FILE_HEADER *) page_fhead;
   file_header_sanity_check (fhead);
+  assert (FILE_IS_NUMERABLE (fhead));
   assert (nth < fhead->n_page_user || (auto_alloc && nth == fhead->n_page_user));
 
   if (auto_alloc && nth == (fhead->n_page_user - fhead->n_page_mark_delete))
@@ -7451,13 +7488,51 @@ file_numerable_find_nth (THREAD_ENTRY * thread_p, const VFID * vfid, int nth, bo
     }
   else
     {
+      if (FILE_CACHE_LAST_FIND_NTH (fhead) && !VPID_ISNULL (&fhead->vpid_find_nth_last)
+	  && !VPID_EQ (&vpid_fhead, &fhead->vpid_find_nth_last) && nth >= fhead->first_index_find_nth_last)
+	{
+	  /* start searching from last search location */
+	  page_ftab_start =
+	    pgbuf_fix (thread_p, &fhead->vpid_find_nth_last, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
+	  if (page_ftab_start == NULL)
+	    {
+	      ASSERT_ERROR_AND_SET (error_code);
+	      goto exit;
+	    }
+	  extdata_user_page_ftab = (FILE_EXTENSIBLE_DATA *) page_ftab_start;
+	  find_nth_context.first_index = fhead->first_index_find_nth_last;
+	  find_nth_context.nth -= fhead->first_index_find_nth_last;
+	}
+      else
+	{
+	  /* no last search location or it could not be used. start searching from the beginning. */
+	  find_nth_context.first_index = 0;
+	}
       /* we can go directly to the right VPID. */
       error_code = file_extdata_apply_funcs (thread_p, extdata_user_page_ftab, file_extdata_find_nth_vpid,
-					     &find_nth_context, NULL, NULL, false, NULL, NULL);
+					     &find_nth_context, NULL, NULL, false, NULL, &page_ftab_nth_location);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
 	  goto exit;
+	}
+
+      if (FILE_CACHE_LAST_FIND_NTH (fhead))
+	{
+	  /* note that we consider this file cannot be accessed concurrently. therefore we do not promote to write latch
+	   * and we do not set page dirty to update the cached search location. */
+	  if (page_ftab_nth_location == NULL)
+	    {
+	      /* it was found in the starting page */
+	      page_ftab_nth_location = page_ftab_start != NULL ? page_ftab_start : page_fhead;
+	    }
+	  pgbuf_get_vpid (page_ftab_nth_location, &fhead->vpid_find_nth_last);
+	  fhead->first_index_find_nth_last = find_nth_context.first_index;
+
+	  file_log ("file_numerable_find_nth", "update fhead.fist_index_find_nth_last to %d "
+		    "and fhead->vpid_find_nth_last to %d|%d while searching nth=%d in file %d|%d",
+		    fhead->first_index_find_nth_last, VPID_AS_ARGS (&fhead->vpid_find_nth_last), nth,
+		    VFID_AS_ARGS (vfid));
 	}
     }
 
@@ -7472,6 +7547,15 @@ file_numerable_find_nth (THREAD_ENTRY * thread_p, const VFID * vfid, int nth, bo
   assert (error_code == NO_ERROR);
 
 exit:
+  if (page_ftab_nth_location != NULL && page_ftab_nth_location != page_ftab_start
+      && page_ftab_nth_location != page_fhead)
+    {
+      pgbuf_unfix (thread_p, page_ftab_nth_location);
+    }
+  if (page_ftab_start != NULL)
+    {
+      pgbuf_unfix (thread_p, page_ftab_start);
+    }
   if (page_fhead != NULL)
     {
       pgbuf_unfix (thread_p, page_fhead);
@@ -8070,6 +8154,8 @@ file_temp_reset_user_pages (THREAD_ENTRY * thread_p, const VFID * vfid)
       VPID_SET_NULL (&extdata_user_page_ftab->vpid_next);
       extdata_user_page_ftab->n_items = 0;
       fhead->vpid_last_user_page_ftab = vpid_fhead;
+      fhead->vpid_find_nth_last = vpid_fhead;
+      fhead->first_index_find_nth_last = 0;
     }
 
   /* collect table pages */

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -10496,21 +10496,23 @@ file_tracker_check (THREAD_ENTRY * thread_p)
       disk_map_clone_free (&disk_map_clone);
       return allvalid == DISK_VALID ? DISK_ERROR : allvalid;
     }
-
-  /* check all sectors have been cleared */
-  valid = disk_map_clone_check_leaks (disk_map_clone);
-  if (valid == DISK_INVALID)
+  else
     {
-      assert_release (false);
-      allvalid = DISK_INVALID;
-    }
-  else if (valid == DISK_ERROR)
-    {
-      ASSERT_ERROR ();
-      allvalid = allvalid == DISK_VALID ? DISK_ERROR : allvalid;
+      /* check all sectors have been cleared */
+      valid = disk_map_clone_check_leaks (disk_map_clone);
+      if (valid == DISK_INVALID)
+	{
+	  assert_release (false);
+	  allvalid = DISK_INVALID;
+	}
+      else if (valid == DISK_ERROR)
+	{
+	  ASSERT_ERROR ();
+	  allvalid = allvalid == DISK_VALID ? DISK_ERROR : allvalid;
+	}
+      disk_map_clone_free (&disk_map_clone);
     }
 
-  disk_map_clone_free (&disk_map_clone);
 #endif /* SA_MODE */
 
   return allvalid;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7022,30 +7022,12 @@ static int
 heap_scancache_end_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, bool scan_state)
 {
   int ret = NO_ERROR;
-  HEAP_SCANCACHE_NODE_LIST *p = NULL;
 
   if (scan_cache->debug_initpattern != HEAP_DEBUG_SCANCACHE_INITPATTERN)
     {
       er_log_debug (ARG_FILE_LINE, "heap_scancache_end_internal: Your scancache is not initialized");
       return ER_FAILED;
     }
-
-  if (!OID_ISNULL (&scan_cache->node.class_oid))
-    {
-      lock_unlock_scan (thread_p, &scan_cache->node.class_oid, scan_state);
-    }
-
-  p = scan_cache->partition_list;
-  while (p != NULL)
-    {
-      if (!OID_EQ (&p->node.class_oid, &scan_cache->node.class_oid))
-	{
-	  lock_unlock_scan (thread_p, &p->node.class_oid, scan_state);
-	}
-      p = p->next;
-    }
-
-  OID_SET_NULL (&scan_cache->node.class_oid);
 
   ret = heap_scancache_quick_end (thread_p, scan_cache);
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -17294,7 +17294,7 @@ heap_eval_function_index (THREAD_ENTRY * thread_p, FUNCTION_INDEX_INFO * func_in
       /* insert case, read the values */
       if (func_pred == NULL)
 	{
-	  if (stx_map_stream_to_func_pred (NULL, (FUNC_PRED **) (&func_pred), expr_stream, expr_stream_size,
+	  if (stx_map_stream_to_func_pred (thread_p, (FUNC_PRED **) (&func_pred), expr_stream, expr_stream_size,
 					   &unpack_info))
 	    {
 	      error = ER_FAILED;
@@ -17429,8 +17429,8 @@ heap_init_func_pred_unpack_info (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * 
 		}
 	    }
 
-	  if (stx_map_stream_to_func_pred (thread_p, (FUNC_PRED **) (&(fi_preds[i].func_pred)), fi_info->expr_stream,
-					   fi_info->expr_stream_size, &(fi_preds[i].unpack_info)))
+	  if (stx_map_stream_to_func_pred (thread_p, (FUNC_PRED **) (&(fi_preds[i].func_pred)),
+					   fi_info->expr_stream, fi_info->expr_stream_size, &(fi_preds[i].unpack_info)))
 	    {
 	      error_status = ER_FAILED;
 	      goto error;

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -165,7 +165,7 @@ struct log_lsa
 #define VOL_MAX_NSECTS(page_size)  (VOL_MAX_NPAGES(page_size) / DISK_SECTOR_NPAGES)
 
 #define SECTOR_FIRST_PAGEID(sid) ((sid) * DISK_SECTOR_NPAGES)
-#define SECTOR_LAST_PAGEID(sid) ((sid) * (DISK_SECTOR_NPAGES + 1) - 1)
+#define SECTOR_LAST_PAGEID(sid) ((((sid) + 1) * DISK_SECTOR_NPAGES) - 1)
 #define SECTOR_FROM_PAGEID(pageid) ((pageid) / DISK_SECTOR_NPAGES)
 
 #define VSID_FROM_VPID(vsid, vpid) (vsid)->volid = (vpid)->volid; (vsid)->sectid = SECTOR_FROM_PAGEID ((vpid)->pageid)

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2068,9 +2068,6 @@ xlocator_assign_oid (THREAD_ENTRY * thread_p, const HFID * hfid, OID * perm_oid,
       assert (error_code == NO_ERROR);
     }
 
-  /* Release the lock which was set in heap_assign_address_with_class_oid according to isolation level */
-  lock_unlock_object (thread_p, perm_oid, class_oid, X_LOCK, false);
-
   return error_code;
 }
 
@@ -5287,21 +5284,12 @@ locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
     }
 #endif
 
-  /* Unlock the object according to isolation level */
-  /* locked by heap_insert */
-  /* manual duration */
-  lock_unlock_object (thread_p, &null_oid, &real_class_oid, X_LOCK, false);
-
   *force_count = 1;
 
 error1:
   /* update the OID of the class with the actual partition in which the object was inserted */
   COPY_OID (class_oid, &real_class_oid);
   HFID_COPY (hfid, &real_hfid);
-  if (error_code != NO_ERROR)
-    {
-      lock_unlock_object (thread_p, oid, class_oid, X_LOCK, false);
-    }
 
 error2:
   if (cache_attr_copyarea != NULL)
@@ -9263,10 +9251,6 @@ xlocator_notify_isolation_incons (THREAD_ENTRY * thread_p, LC_COPYAREA ** synch_
   else if (recdes.area_size >= SSIZEOF (*obj))
     {
       more_synch = true;
-    }
-  else
-    {
-      lock_unlock_by_isolation_level (thread_p);
     }
 
   return more_synch;

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -105,29 +105,6 @@ extern int lock_Comp[11][11];
 #define LK_MSG_LOCK_DEMOTE(entry) \
   LK_MSG_LOCK_HELPER(entry, MSGCAT_LK_OID_LOCK_DEMOTE)
 
-#define RECORD_LOCK_ACQUISITION_HISTORY(entry_ptr, history, lock) \
-  do \
-    { \
-      (history)->req_mode = (lock); \
-      (history)->next = NULL; \
-      (history)->prev = (entry_ptr)->recent; \
-      /* append it to end of list */ \
-      if ((entry_ptr)->recent == NULL) \
-        { \
-          (entry_ptr)->history = (history); \
-          (entry_ptr)->recent = (history); \
-        } \
-      else \
-        { \
-          (entry_ptr)->recent->next = (history); \
-          (entry_ptr)->recent = (history); \
-        } \
-    } \
-  while (0)
-
-#define NEED_LOCK_ACQUISITION_HISTORY(isolation, entry_ptr) \
-  ((isolation) == TRAN_READ_COMMITTED)
-
 #define EXPAND_WAIT_FOR_ARRAY_IF_NEEDED() \
   do \
     { \
@@ -495,12 +472,15 @@ static bool lock_check_escalate (THREAD_ENTRY * thread_p, LK_ENTRY * class_entry
 static int lock_escalate_if_needed (THREAD_ENTRY * thread_p, LK_ENTRY * class_entry, int tran_index);
 static int lock_internal_hold_lock_object_instant (int tran_index, const OID * oid, const OID * class_oid, LOCK lock);
 static int lock_internal_perform_lock_object (THREAD_ENTRY * thread_p, int tran_index, const OID * oid,
-					      const OID * class_oid, const BTID * btid, LOCK lock, int wait_msecs,
+					      const OID * class_oid, LOCK lock, int wait_msecs,
 					      LK_ENTRY ** entry_addr_ptr, LK_ENTRY * class_entry);
 static void lock_internal_perform_unlock_object (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr, int release_flag,
 						 int move_to_non2pl);
+static void lock_unlock_object_by_isolation (THREAD_ENTRY * thread_p, int tran_index, TRAN_ISOLATION isolation,
+					     const OID * class_oid, const OID * oid);
+static void lock_unlock_inst_locks_of_class_by_isolation (THREAD_ENTRY * thread_p, int tran_index,
+							  TRAN_ISOLATION isolation, const OID * class_oid);
 static int lock_internal_demote_shared_class_lock (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr);
-static void lock_demote_shared_class_lock (THREAD_ENTRY * thread_p, int tran_index, const OID * class_oid);
 static void lock_demote_all_shared_class_locks (THREAD_ENTRY * thread_p, int tran_index);
 static void lock_unlock_shared_inst_lock (THREAD_ENTRY * thread_p, int tran_index, const OID * inst_oid);
 static void lock_remove_all_class_locks (THREAD_ENTRY * thread_p, int tran_index, LOCK lock);
@@ -528,7 +508,7 @@ static void lock_event_log_blocking_locks (THREAD_ENTRY * thread_p, FILE * log_f
 static void lock_event_log_lock_info (THREAD_ENTRY * thread_p, FILE * log_fp, LK_ENTRY * entry);
 static void lock_event_set_tran_wait_entry (int tran_index, LK_ENTRY * entry);
 static void lock_event_set_xasl_id_to_entry (int tran_index, LK_ENTRY * entry);
-static LK_RES_KEY lock_create_search_key (OID * oid, OID * class_oid, BTID * btid);
+static LK_RES_KEY lock_create_search_key (OID * oid, OID * class_oid);
 #if defined (SERVER_MODE)
 static bool lock_is_safe_lock_with_page (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr);
 #endif /* SERVER_MODE */
@@ -592,7 +572,7 @@ LF_ENTRY_DESCRIPTOR obj_lock_res_desc = {
 #if defined(SERVER_MODE)
 
 static LK_RES_KEY
-lock_create_search_key (OID * oid, OID * class_oid, BTID * btid)
+lock_create_search_key (OID * oid, OID * class_oid)
 {
   LK_RES_KEY search_key;
 
@@ -613,15 +593,6 @@ lock_create_search_key (OID * oid, OID * class_oid, BTID * btid)
   else
     {
       OID_SET_NULL (&search_key.class_oid);
-    }
-
-  if (btid != NULL)
-    {
-      search_key.btid = *btid;
-    }
-  else
-    {
-      BTID_SET_NULL (&search_key.btid);
     }
 
   /* set correct type */
@@ -677,7 +648,6 @@ static int
 lock_uninit_entry (void *entry)
 {
   LK_ENTRY *entry_ptr = (LK_ENTRY *) entry;
-  LK_ACQUISITION_HISTORY *history, *next;
 
   if (entry_ptr == NULL)
     {
@@ -686,15 +656,6 @@ lock_uninit_entry (void *entry)
 
   entry_ptr->tran_index = -1;
   entry_ptr->thrd_entry = NULL;
-  history = entry_ptr->history;
-  while (history)
-    {
-      next = history->next;
-      free_and_init (history);
-      history = next;
-    }
-  entry_ptr->history = NULL;
-  entry_ptr->recent = NULL;
 
   return NO_ERROR;
 }
@@ -781,7 +742,6 @@ lock_res_key_copy (void *src, void *dest)
   switch (src_k->type)
     {
     case LOCK_RESOURCE_INSTANCE:
-      dest_k->btid = src_k->btid;
       COPY_OID (&dest_k->oid, &src_k->oid);
       COPY_OID (&dest_k->class_oid, &src_k->class_oid);
       break;
@@ -790,7 +750,6 @@ lock_res_key_copy (void *src, void *dest)
     case LOCK_RESOURCE_ROOT_CLASS:
       COPY_OID (&dest_k->oid, &src_k->oid);
       OID_SET_NULL (&dest_k->class_oid);
-      BTID_SET_NULL (&(dest_k->btid));
       break;
 
     case LOCK_RESOURCE_OBJECT:
@@ -875,8 +834,6 @@ lock_initialize_entry (LK_ENTRY * entry_ptr)
   entry_ptr->tran_prev = NULL;
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
-  entry_ptr->history = NULL;
-  entry_ptr->recent = NULL;
   entry_ptr->instant_lock_count = 0;
   entry_ptr->bind_index_in_tran = -1;
   XASL_ID_SET_NULL (&entry_ptr->xasl_id);
@@ -897,8 +854,6 @@ lock_initialize_entry_as_granted (LK_ENTRY * entry_ptr, int tran_index, LK_RES *
   entry_ptr->tran_prev = NULL;
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
-  entry_ptr->history = NULL;
-  entry_ptr->recent = NULL;
   entry_ptr->instant_lock_count = 0;
 
   lock_event_set_xasl_id_to_entry (tran_index, entry_ptr);
@@ -920,8 +875,6 @@ lock_initialize_entry_as_blocked (LK_ENTRY * entry_ptr, THREAD_ENTRY * thread_p,
   entry_ptr->tran_prev = NULL;
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
-  entry_ptr->history = NULL;
-  entry_ptr->recent = NULL;
   entry_ptr->instant_lock_count = 0;
 
   lock_event_set_xasl_id_to_entry (tran_index, entry_ptr);
@@ -942,8 +895,6 @@ lock_initialize_entry_as_non2pl (LK_ENTRY * entry_ptr, int tran_index, LK_RES * 
   entry_ptr->tran_prev = NULL;
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
-  entry_ptr->history = NULL;
-  entry_ptr->recent = NULL;
   entry_ptr->instant_lock_count = 0;
 }
 
@@ -955,7 +906,6 @@ lock_initialize_resource (LK_RES * res_ptr)
   res_ptr->key.type = LOCK_RESOURCE_OBJECT;
   OID_SET_NULL (&(res_ptr->key.oid));
   OID_SET_NULL (&(res_ptr->key.class_oid));
-  BTID_SET_NULL (&(res_ptr->key.btid));
   res_ptr->total_holders_mode = NULL_LOCK;
   res_ptr->total_waiters_mode = NULL_LOCK;
   res_ptr->holder = NULL;
@@ -3022,9 +2972,8 @@ lock_escalate_if_needed (THREAD_ENTRY * thread_p, LK_ENTRY * class_entry, int tr
        * 1. hold a lock on the class with the escalated lock mode
        */
       wait_msecs = LK_FORCE_ZERO_WAIT;	/* Conditional Locking */
-      granted =
-	lock_internal_perform_lock_object (thread_p, tran_index, &class_entry->res_head->key.oid, NULL, NULL,
-					   max_class_lock, wait_msecs, &class_entry, NULL);
+      granted = lock_internal_perform_lock_object (thread_p, tran_index, &class_entry->res_head->key.oid, NULL,
+						   max_class_lock, wait_msecs, &class_entry, NULL);
       if (granted != LK_GRANTED)
 	{
 	  /* The reason of the lock request failure: 1. interrupt 2. shortage of lock resource entries 3. shortage of
@@ -3107,7 +3056,7 @@ lock_internal_hold_lock_object_instant (int tran_index, const OID * oid, const O
     }
 
   /* search hash table */
-  search_key = lock_create_search_key ((OID *) oid, (OID *) class_oid, NULL);
+  search_key = lock_create_search_key ((OID *) oid, (OID *) class_oid);
   rv = lf_hash_find (t_entry, &lk_Gl.obj_hash_table, (void *) &search_key, (void **) &res_ptr);
   if (rv != NO_ERROR)
     {
@@ -3223,8 +3172,7 @@ lock_internal_hold_lock_object_instant (int tran_index, const OID * oid, const O
  */
 static int
 lock_internal_perform_lock_object (THREAD_ENTRY * thread_p, int tran_index, const OID * oid, const OID * class_oid,
-				   const BTID * btid, LOCK lock, int wait_msecs, LK_ENTRY ** entry_addr_ptr,
-				   LK_ENTRY * class_entry)
+				   LOCK lock, int wait_msecs, LK_ENTRY ** entry_addr_ptr, LK_ENTRY * class_entry)
 {
   LF_TRAN_ENTRY *t_entry_res = thread_get_tran_entry (thread_p, THREAD_TS_OBJ_LOCK_RES);
   LF_TRAN_ENTRY *t_entry_ent = thread_get_tran_entry (thread_p, THREAD_TS_OBJ_LOCK_ENT);
@@ -3239,7 +3187,6 @@ lock_internal_perform_lock_object (THREAD_ENTRY * thread_p, int tran_index, cons
   bool lock_conversion = false;
   THREAD_ENTRY *thrd_entry;
   int rv;
-  LK_ACQUISITION_HISTORY *history;
   LK_TRAN_LOCK *tran_lock;
   bool is_instant_duration;
   int compat1, compat2;
@@ -3351,7 +3298,7 @@ start:
     }
 
   /* find or add the lockable object in the lock table */
-  search_key = lock_create_search_key ((OID *) oid, (OID *) class_oid, (BTID *) btid);
+  search_key = lock_create_search_key ((OID *) oid, (OID *) class_oid);
   rv = lf_hash_find_or_insert (t_entry_res, &lk_Gl.obj_hash_table, (void *) &search_key, (void **) &res_ptr, NULL);
   if (rv != NO_ERROR)
     {
@@ -3407,22 +3354,6 @@ start:
 #if defined(LK_TRACE_OBJECT)
       LK_MSG_LOCK_ACQUIRED (entry_ptr);
 #endif /* LK_TRACE_OBJECT */
-
-      if (NEED_LOCK_ACQUISITION_HISTORY (isolation, entry_ptr))
-	{
-	  history = (LK_ACQUISITION_HISTORY *) malloc (sizeof (LK_ACQUISITION_HISTORY));
-	  if (history == NULL)
-	    {
-	      assert (is_res_mutex_locked);
-	      pthread_mutex_unlock (&res_ptr->res_mutex);
-
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_ALLOC_RESOURCE, 1, "history");
-	      ret_val = LK_NOTGRANTED_DUE_ERROR;
-	      goto end;
-	    }
-
-	  RECORD_LOCK_ACQUISITION_HISTORY (entry_ptr, history, lock);
-	}
 
       /* release all mutexes */
       assert (is_res_mutex_locked);
@@ -3500,22 +3431,6 @@ start:
 #if defined(LK_TRACE_OBJECT)
 	  LK_MSG_LOCK_ACQUIRED (entry_ptr);
 #endif /* LK_TRACE_OBJECT */
-
-	  if (NEED_LOCK_ACQUISITION_HISTORY (isolation, entry_ptr))
-	    {
-	      history = (LK_ACQUISITION_HISTORY *) malloc (sizeof (LK_ACQUISITION_HISTORY));
-	      if (history == NULL)
-		{
-		  assert (is_res_mutex_locked);
-		  pthread_mutex_unlock (&res_ptr->res_mutex);
-
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_ALLOC_RESOURCE, 1, "history");
-		  ret_val = LK_NOTGRANTED_DUE_ERROR;
-		  goto end;
-		}
-
-	      RECORD_LOCK_ACQUISITION_HISTORY (entry_ptr, history, lock);
-	    }
 
 	  assert (is_res_mutex_locked);
 	  pthread_mutex_unlock (&res_ptr->res_mutex);
@@ -3697,23 +3612,6 @@ lock_tran_lk_entry:
 	    }
 	}
 
-      if (NEED_LOCK_ACQUISITION_HISTORY (isolation, entry_ptr))
-	{
-	  history = (LK_ACQUISITION_HISTORY *) malloc (sizeof (LK_ACQUISITION_HISTORY));
-	  if (history == NULL)
-	    {
-	      if (is_res_mutex_locked)
-		{
-		  pthread_mutex_unlock (&res_ptr->res_mutex);
-		}
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_ALLOC_RESOURCE, 1, "history");
-	      ret_val = LK_NOTGRANTED_DUE_ERROR;
-	      goto end;
-	    }
-
-	  RECORD_LOCK_ACQUISITION_HISTORY (entry_ptr, history, lock);
-	}
-
       if (is_res_mutex_locked)
 	{
 	  pthread_mutex_unlock (&res_ptr->res_mutex);
@@ -3750,22 +3648,6 @@ lock_tran_lk_entry:
 
   if (compat1 == true)
     {
-      if (NEED_LOCK_ACQUISITION_HISTORY (isolation, entry_ptr))
-	{
-	  history = (LK_ACQUISITION_HISTORY *) malloc (sizeof (LK_ACQUISITION_HISTORY));
-	  if (history == NULL)
-	    {
-	      assert (is_res_mutex_locked);
-	      pthread_mutex_unlock (&res_ptr->res_mutex);
-
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_ALLOC_RESOURCE, 1, "history");
-	      ret_val = LK_NOTGRANTED_DUE_ERROR;
-	      goto end;
-	    }
-
-	  RECORD_LOCK_ACQUISITION_HISTORY (entry_ptr, history, lock);
-	}
-
       entry_ptr->granted_mode = new_mode;
       entry_ptr->count += 1;
       if (is_instant_duration)
@@ -3947,19 +3829,6 @@ blocked:
 	}
     }
 
-  if (NEED_LOCK_ACQUISITION_HISTORY (isolation, entry_ptr))
-    {
-      history = (LK_ACQUISITION_HISTORY *) malloc (sizeof (LK_ACQUISITION_HISTORY));
-      if (history == NULL)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_ALLOC_RESOURCE, 1, "history");
-	  ret_val = LK_NOTGRANTED_DUE_ERROR;
-	  goto end;
-	}
-
-      RECORD_LOCK_ACQUISITION_HISTORY (entry_ptr, history, lock);
-    }
-
   /* The transaction now got the lock on the object */
 lock_conversion_treatement:
 
@@ -3969,15 +3838,14 @@ lock_conversion_treatement:
       switch (old_mode)
 	{
 	case IS_LOCK:
-	  if (IS_WRITE_EXCLUSIVE_LOCK (new_mode)
-	      || ((new_mode == S_LOCK || new_mode == SIX_LOCK) && isolation == TRAN_READ_COMMITTED))
+	  if (IS_WRITE_EXCLUSIVE_LOCK (new_mode) || new_mode == S_LOCK || new_mode == SIX_LOCK)
 	    {
 	      lock_remove_all_inst_locks (thread_p, tran_index, oid, S_LOCK);
 	    }
 	  break;
 
 	case IX_LOCK:
-	  if (new_mode == SIX_LOCK && isolation == TRAN_READ_COMMITTED)
+	  if (new_mode == SIX_LOCK)
 	    {
 	      lock_remove_all_inst_locks (thread_p, tran_index, oid, S_LOCK);
 	    }
@@ -4249,7 +4117,6 @@ lock_internal_perform_unlock_object (THREAD_ENTRY * thread_p, LK_ENTRY * entry_p
  *  Private Functions Group: demote, unlock and remove locks
  *
  *   - lock_internal_demote_shared_class_lock()
- *   - lock_demote_shared_class_lock()
  *   - lock_demote_all_shared_class_locks()
  *   - lock_unlock_shared_inst_lock()
  *   - lock_remove_all_class_locks()
@@ -4358,130 +4225,22 @@ lock_internal_demote_shared_class_lock (THREAD_ENTRY * thread_p, LK_ENTRY * entr
 
 #if defined(SERVER_MODE)
 /*
- * lock_demote_shared_class_lock -  Demote one shared class lock
+ * lock_demote_read_class_lock_for_checksumdb -  Demote one shared class lock to intention shared only for checksumdb
  *
  * return:
  *
  *   tran_index(in):
  *   class_oid(in):
  *
- * Note:This function finds the lock entry whose lock object id is same
- *     with the given class_oid in the transaction lock hold list. And then,
- *     demote the class lock if the class lock is shared mode.
- */
-static void
-lock_demote_shared_class_lock (THREAD_ENTRY * thread_p, int tran_index, const OID * class_oid)
-{
-  LK_ENTRY *entry_ptr;
-  enum
-  { SKIP, DEMOTE, DECREMENT_COUNT };
-  int demote = SKIP;
-  LK_ACQUISITION_HISTORY *prev, *last, *p;
-
-  /* The caller is not holding any mutex */
-
-  /* demote only one class lock */
-  entry_ptr = lock_find_tran_hold_entry (tran_index, class_oid, true);
-
-  if (entry_ptr != NULL)
-    {
-      /* I think there's no need to acquire the mutex here. */
-      if (entry_ptr->history)
-	{
-	  last = entry_ptr->recent;
-	  prev = last->prev;
-
-	  if ((last->req_mode == S_LOCK || last->req_mode == SIX_LOCK)
-	      && (entry_ptr->granted_mode == S_LOCK || entry_ptr->granted_mode == SIX_LOCK))
-	    {
-	      p = entry_ptr->history;
-	      while (p != last)
-		{
-		  if (p->req_mode == S_LOCK || p->req_mode == SIX_LOCK)
-		    {
-		      break;
-		    }
-		  p = p->next;
-		}
-
-	      if (p != last)
-		{
-		  /* do not demote shared class lock */
-		}
-	      else
-		{
-		  demote = DEMOTE;
-		}
-	    }
-	  else if ((entry_ptr->granted_mode == IS_LOCK || entry_ptr->granted_mode == SCH_S_LOCK)
-		   && ((last->req_mode == IS_LOCK || last->req_mode == SCH_S_LOCK) && entry_ptr->history != last))
-	    {
-	      /* has > 1 IS_LOCK */
-	      demote = DECREMENT_COUNT;
-	    }
-
-	  /* free the last node */
-	  if (prev == NULL)
-	    {
-	      entry_ptr->history = NULL;
-	      entry_ptr->recent = NULL;
-	    }
-	  else
-	    {
-	      prev->next = NULL;
-	      entry_ptr->recent = prev;
-	    }
-	  free_and_init (last);
-	}
-      else
-	{
-	  if (entry_ptr->granted_mode == S_LOCK || entry_ptr->granted_mode == SIX_LOCK)
-	    {
-	      demote = DEMOTE;
-	    }
-	}
-
-      if (demote == DEMOTE)
-	{
-	  (void) lock_internal_demote_shared_class_lock (thread_p, entry_ptr);
-	}
-      else if (demote == DECREMENT_COUNT || entry_ptr->granted_mode == S_LOCK || entry_ptr->granted_mode == SIX_LOCK)
-	{
-	  entry_ptr->count--;
-
-	  if (lock_is_instant_lock_mode (tran_index))
-	    {
-	      entry_ptr->instant_lock_count--;
-	      assert (entry_ptr->instant_lock_count >= 0);
-	    }
-	}
-    }
-}
-
-/*
- * lock_demote_read_class_lock_for_checksumdb -  Demote one shared class lock
- *                                    to intention shared only for checksumdb
+ * Note: This is exported ONLY for checksumdb. NEVER consider to use this function for any other clients/threads.
  *
- * return:
- *
- *   tran_index(in):
- *   class_oid(in):
- *
- * Note: This is exported ONLY for checksumdb. NEVER consider to use this function
- *       for any other clients/threads.
- *
- * Note:This function finds the lock entry whose lock object id is same
- *     with the given class_oid in the transaction lock hold list. And then,
- *     demote the class lock if the class lock is shared mode.
+ * Note:This function finds the lock entry whose lock object id is same with the given class_oid in the transaction
+ *	lock hold list. And then, demote the class lock if the class lock is shared mode.
  */
 void
 lock_demote_read_class_lock_for_checksumdb (THREAD_ENTRY * thread_p, int tran_index, const OID * class_oid)
 {
   LK_ENTRY *entry_ptr;
-  enum
-  { SKIP, DEMOTE, DECREMENT_COUNT };
-  int demote = SKIP;
-  LK_ACQUISITION_HISTORY *prev, *last, *p;
 
   /* The caller is not holding any mutex */
 
@@ -4493,62 +4252,7 @@ lock_demote_read_class_lock_for_checksumdb (THREAD_ENTRY * thread_p, int tran_in
       return;
     }
 
-  /* I think there's no need to acquire the mutex here. */
-  if (entry_ptr->history)
-    {
-      last = entry_ptr->recent;
-      prev = last->prev;
-
-      if (last->req_mode == S_LOCK && entry_ptr->granted_mode == S_LOCK)
-	{
-	  p = entry_ptr->history;
-	  while (p != last)
-	    {
-	      if (p->req_mode == S_LOCK)
-		{
-		  break;
-		}
-	      p = p->next;
-	    }
-
-	  if (p != last)
-	    {
-	      /* do not demote shared class lock */
-	      assert (p == last);
-	    }
-	  else
-	    {
-	      demote = DEMOTE;
-	    }
-	}
-      else
-	{
-	  /* unexpected lock entry */
-	  assert (0);
-	}
-
-      /* free the last node */
-      if (prev == NULL)
-	{
-	  entry_ptr->history = NULL;
-	  entry_ptr->recent = NULL;
-	}
-      else
-	{
-	  prev->next = NULL;
-	  entry_ptr->recent = prev;
-	}
-      free_and_init (last);
-    }
-  else
-    {
-      if (entry_ptr->granted_mode == S_LOCK)
-	{
-	  demote = DEMOTE;
-	}
-    }
-
-  if (demote == DEMOTE)
+  if (entry_ptr->granted_mode == S_LOCK)
     {
       (void) lock_internal_demote_shared_class_lock (thread_p, entry_ptr);
     }
@@ -4635,16 +4339,14 @@ lock_unlock_shared_inst_lock (THREAD_ENTRY * thread_p, int tran_index, const OID
 
 #if defined(SERVER_MODE)
 /*
- * lock_remove_all_class_locks - Remove class locks whose lock mode is lower
- *                        than the given lock mode
+ * lock_remove_all_class_locks - Remove class locks whose lock mode is lower than the given lock mode
  *
  * return:
  *
  *   tran_index(in):
  *   lock(in):
  *
- * Note:This function removes class locks whose lock mode is lower than
- *     the given lock mode.
+ * Note:This function removes class locks whose lock mode is lower than the given lock mode.
  */
 static void
 lock_remove_all_class_locks (THREAD_ENTRY * thread_p, int tran_index, LOCK lock)
@@ -4688,8 +4390,7 @@ lock_remove_all_class_locks (THREAD_ENTRY * thread_p, int tran_index, LOCK lock)
 
 #if defined(SERVER_MODE)
 /*
- * lock_remove_all_inst_locks - Remove instance locks whose lock mode is lower
- *                        than the given lock mode
+ * lock_remove_all_inst_locks - Remove instance locks whose lock mode is lower than the given lock mode
  *
  * return:
  *
@@ -4697,8 +4398,7 @@ lock_remove_all_class_locks (THREAD_ENTRY * thread_p, int tran_index, LOCK lock)
  *   class_oid(in):
  *   lock(in):
  *
- * Note:This function removes instance locks whose lock mode is lower than
- *     the given lock mode.
+ * Note:This function removes instance locks whose lock mode is lower than the given lock mode.
  */
 void
 lock_remove_all_inst_locks (THREAD_ENTRY * thread_p, int tran_index, const OID * class_oid, LOCK lock)
@@ -5611,25 +5311,6 @@ lock_dump_resource (THREAD_ENTRY * thread_p, FILE * outfp, LK_RES * res_ptr)
 		  return;
 		}
 	    }
-	  else if (!BTID_IS_NULL (&res_ptr->key.btid))
-	    {
-	      char *btname = NULL;
-
-	      fprintf (outfp, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_LOCK, MSGCAT_LK_RES_INDEX_KEY_TYPE),
-		       res_ptr->key.class_oid.volid, res_ptr->key.class_oid.pageid, res_ptr->key.class_oid.slotid,
-		       classname);
-	      free_and_init (classname);
-
-	      if (heap_get_indexinfo_of_btid (thread_p, &res_ptr->key.class_oid, &res_ptr->key.btid, NULL, NULL, NULL,
-					      NULL, &btname, NULL) == NO_ERROR)
-		{
-		  fprintf (outfp, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_LOCK, MSGCAT_LK_INDEXNAME), btname);
-		}
-	      if (btname != NULL)
-		{
-		  free_and_init (btname);
-		}
-	    }
 	  else
 	    {
 	      fprintf (outfp, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_LOCK, MSGCAT_LK_RES_INSTANCE_TYPE),
@@ -6277,7 +5958,7 @@ lock_hold_object_instant (THREAD_ENTRY * thread_p, const OID * oid, const OID * 
 }
 
 /*
- * lock_object_with_btid - Lock an object
+ * lock_object - Lock an object
  *
  * return: one of following values)
  *     LK_GRANTED
@@ -6287,14 +5968,12 @@ lock_hold_object_instant (THREAD_ENTRY * thread_p, const OID * oid, const OID * 
  *
  *   oid(in): Identifier of object(instance, class, root class) to lock
  *   class_oid(in): Identifier of the class instance of the given object
- *   btid(in) :
  *   lock(in): Requested lock mode
  *   cond_flag(in):
  *
  */
 int
-lock_object_with_btid (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, const BTID * btid, LOCK lock,
-		       int cond_flag)
+lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag)
 {
 #if !defined (SERVER_MODE)
   LK_SET_STANDALONE_XLOCK (lock);
@@ -6354,10 +6033,8 @@ lock_object_with_btid (THREAD_ENTRY * thread_p, const OID * oid, const OID * cla
     {
       /* case 1 : resource type is LOCK_RESOURCE_ROOT_CLASS acquire a lock on the root class oid. NOTE that in case of
        * acquiring a lock on a class object, the higher lock granule of the class object must not be given. */
-      granted =
-	lock_internal_perform_lock_object (thread_p, tran_index, oid, NULL, btid, lock, wait_msecs, &root_class_entry,
-					   NULL);
-
+      granted = lock_internal_perform_lock_object (thread_p, tran_index, oid, NULL, lock, wait_msecs,
+						   &root_class_entry, NULL);
       goto end;
     }
 
@@ -6380,9 +6057,8 @@ lock_object_with_btid (THREAD_ENTRY * thread_p, const OID * oid, const OID * cla
     {
       if (old_class_lock < new_class_lock)
 	{
-	  granted =
-	    lock_internal_perform_lock_object (thread_p, tran_index, class_oid, NULL, btid, new_class_lock, wait_msecs,
-					       &root_class_entry, NULL);
+	  granted = lock_internal_perform_lock_object (thread_p, tran_index, class_oid, NULL, new_class_lock,
+						       wait_msecs, &root_class_entry, NULL);
 	  if (granted != LK_GRANTED)
 	    {
 	      goto end;
@@ -6393,9 +6069,8 @@ lock_object_with_btid (THREAD_ENTRY * thread_p, const OID * oid, const OID * cla
 
       /* NOTE that in case of acquiring a lock on a class object, the higher lock granule of the class object must not
        * be given. */
-      granted =
-	lock_internal_perform_lock_object (thread_p, tran_index, oid, NULL, btid, lock, wait_msecs, &class_entry,
-					   root_class_entry);
+      granted = lock_internal_perform_lock_object (thread_p, tran_index, oid, NULL, lock, wait_msecs, &class_entry,
+						   root_class_entry);
       goto end;
     }
   else
@@ -6414,7 +6089,7 @@ lock_object_with_btid (THREAD_ENTRY * thread_p, const OID * oid, const OID * cla
 	    }
 
 	  granted =
-	    lock_internal_perform_lock_object (thread_p, tran_index, class_oid, NULL, btid, new_class_lock, wait_msecs,
+	    lock_internal_perform_lock_object (thread_p, tran_index, class_oid, NULL, new_class_lock, wait_msecs,
 					       &class_entry, superclass_entry);
 	  if (granted != LK_GRANTED)
 	    {
@@ -6434,10 +6109,8 @@ lock_object_with_btid (THREAD_ENTRY * thread_p, const OID * oid, const OID * cla
 
       /* NOTE that in case of acquiring a lock on an instance object, the class oid of the instance object must be
        * given. */
-      granted =
-	lock_internal_perform_lock_object (thread_p, tran_index, oid, class_oid, btid, lock, wait_msecs, &inst_entry,
-					   class_entry);
-
+      granted = lock_internal_perform_lock_object (thread_p, tran_index, oid, class_oid, lock, wait_msecs, &inst_entry,
+						   class_entry);
       goto end;
     }
 
@@ -6458,27 +6131,6 @@ end:
 
   return granted;
 #endif /* !SERVER_MODE */
-}
-
-/*
- * lock_object - Lock an object with NULL btid
- *
- * return: one of following values)
- *     LK_GRANTED
- *     LK_NOTGRANTED_DUE_ABORTED
- *     LK_NOTGRANTED_DUE_TIMEOUT
- *     LK_NOTGRANTED_DUE_ERROR
- *
- *   oid(in): Identifier of object(instance, class, root class) to lock
- *   class_oid(in): Identifier of the class instance of the given object
- *   lock(in): Requested lock mode
- *   cond_flag(in):
- *
- */
-int
-lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag)
-{
-  return lock_object_with_btid (thread_p, oid, class_oid, NULL, lock, cond_flag);
 }
 
 /*
@@ -6567,9 +6219,8 @@ lock_subclass (THREAD_ENTRY * thread_p, const OID * subclass_oid, const OID * su
   if (old_superclass_lock < new_superclass_lock)
     {
       /* superclass is already locked, just promote to the new lock */
-      granted =
-	lock_internal_perform_lock_object (thread_p, tran_index, superclass_oid, NULL, NULL, new_superclass_lock,
-					   wait_msecs, &superclass_entry, NULL);
+      granted = lock_internal_perform_lock_object (thread_p, tran_index, superclass_oid, NULL, new_superclass_lock,
+						   wait_msecs, &superclass_entry, NULL);
       if (granted != LK_GRANTED)
 	{
 	  goto end;
@@ -6581,9 +6232,8 @@ lock_subclass (THREAD_ENTRY * thread_p, const OID * subclass_oid, const OID * su
   /* NOTE that in case of acquiring a lock on a class object, the higher lock granule of the class object must not be
    * given. */
 
-  granted =
-    lock_internal_perform_lock_object (thread_p, tran_index, subclass_oid, NULL, NULL, lock, wait_msecs,
-				       &subclass_entry, superclass_entry);
+  granted = lock_internal_perform_lock_object (thread_p, tran_index, subclass_oid, NULL, lock, wait_msecs,
+					       &subclass_entry, superclass_entry);
 end:
 #if defined (EnableThreadMonitoring)
   if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
@@ -6694,9 +6344,8 @@ lock_scan (THREAD_ENTRY * thread_p, const OID * class_oid, int cond_flag, LOCK c
   /* acquire the lock on the class */
   /* NOTE that in case of acquiring a lock on a class object, the higher lock granule of the class object is not given. */
   root_class_entry = lock_get_class_lock (oid_Root_class_oid, tran_index);
-  granted =
-    lock_internal_perform_lock_object (thread_p, tran_index, class_oid, NULL, NULL, class_lock, wait_msecs,
-				       &class_entry, root_class_entry);
+  granted = lock_internal_perform_lock_object (thread_p, tran_index, class_oid, NULL, class_lock, wait_msecs,
+					       &class_entry, root_class_entry);
   assert (granted == LK_GRANTED || cond_flag == LK_COND_LOCK || er_errid () != NO_ERROR);
 
 #if defined (EnableThreadMonitoring)
@@ -6825,9 +6474,8 @@ lock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint)
 	  root_lock = lockhint->classes[i].lock;
 
 	  /* hold an explicit lock on the root class */
-	  granted =
-	    lock_internal_perform_lock_object (thread_p, tran_index, root_oidp, NULL, NULL, root_lock, wait_msecs,
-					       &root_class_entry, NULL);
+	  granted = lock_internal_perform_lock_object (thread_p, tran_index, root_oidp, NULL, root_lock, wait_msecs,
+						       &root_class_entry, NULL);
 	  if (granted != LK_GRANTED)
 	    {
 	      if (lockhint->quit_on_errors == true || granted != LK_NOTGRANTED_DUE_TIMEOUT)
@@ -6875,9 +6523,8 @@ lock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint)
 
       if (root_class_entry == NULL || root_class_entry->granted_mode < intention_mode)
 	{
-	  granted =
-	    lock_internal_perform_lock_object (thread_p, tran_index, oid_Root_class_oid, NULL, NULL, intention_mode,
-					       wait_msecs, &root_class_entry, NULL);
+	  granted = lock_internal_perform_lock_object (thread_p, tran_index, oid_Root_class_oid, NULL, intention_mode,
+						       wait_msecs, &root_class_entry, NULL);
 	  if (granted != LK_GRANTED)
 	    {
 	      if (lockhint->quit_on_errors == false && granted == LK_NOTGRANTED_DUE_TIMEOUT)
@@ -6890,9 +6537,8 @@ lock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint)
 	}
 
       /* hold the lock on the given class. */
-      granted =
-	lock_internal_perform_lock_object (thread_p, tran_index, &cls_lockinfo[i].oid, NULL, NULL, cls_lockinfo[i].lock,
-					   wait_msecs, &class_entry, root_class_entry);
+      granted = lock_internal_perform_lock_object (thread_p, tran_index, &cls_lockinfo[i].oid, NULL,
+						   cls_lockinfo[i].lock, wait_msecs, &class_entry, root_class_entry);
 
       if (granted != LK_GRANTED)
 	{
@@ -7028,40 +6674,52 @@ lock_unlock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_
   /* get transaction table index */
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 
-#if defined(ENABLE_SYSTEMTAP)
-  CUBRID_LOCK_RELEASE_START (oid, class_oid, lock);
-#endif /* ENABLE_SYSTEMTAP */
-
   if (force == true)
     {
+#if defined(ENABLE_SYSTEMTAP)
+      CUBRID_LOCK_RELEASE_START (oid, class_oid, lock);
+#endif /* ENABLE_SYSTEMTAP */
+
       entry_ptr = lock_find_tran_hold_entry (tran_index, oid, is_class);
 
       if (entry_ptr != NULL)
 	{
 	  lock_internal_perform_unlock_object (thread_p, entry_ptr, false, true);
 	}
-      goto end;
+
+#if defined(ENABLE_SYSTEMTAP)
+      CUBRID_LOCK_RELEASE_END (oid, class_oid, lock);
+#endif /* ENABLE_SYSTEMTAP */
+
+      return;
     }
 
   /* force != true */
+  if (lock != S_LOCK)
+    {
+      assert (lock != NULL_LOCK);
+      /* These will not be released. */
+      return;
+    }
+
   isolation = logtb_find_isolation (tran_index);
   switch (isolation)
     {
     case TRAN_SERIALIZABLE:
     case TRAN_REPEATABLE_READ:
-      break;			/* nothing to do */
+      return;			/* nothing to do */
 
     case TRAN_READ_COMMITTED:
-      /* demote shared class lock or unlock shared instance lock */
-      /* The intentional lock on the higher lock granule must be kept */
-      if (OID_IS_ROOTOID (oid) || OID_IS_ROOTOID (class_oid))
-	{
-	  lock_demote_shared_class_lock (thread_p, tran_index, oid);
-	}
-      else			/* instance object */
-	{
-	  lock_unlock_shared_inst_lock (thread_p, tran_index, oid);
-	}
+#if defined(ENABLE_SYSTEMTAP)
+      CUBRID_LOCK_RELEASE_START (oid, class_oid, lock);
+#endif /* ENABLE_SYSTEMTAP */
+
+      /* The intentional lock on the higher lock granule must be kept. */
+      lock_unlock_object_by_isolation (thread_p, tran_index, isolation, class_oid, oid);
+
+#if defined(ENABLE_SYSTEMTAP)
+      CUBRID_LOCK_RELEASE_END (oid, class_oid, lock);
+#endif /* ENABLE_SYSTEMTAP */
       break;
 
     default:			/* TRAN_UNKNOWN_ISOLATION */
@@ -7069,12 +6727,7 @@ lock_unlock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_
       break;
     }
 
-end:
-#if defined(ENABLE_SYSTEMTAP)
-  CUBRID_LOCK_RELEASE_END (oid, class_oid, lock);
-#endif /* ENABLE_SYSTEMTAP */
   return;
-
 #endif /* !SERVER_MODE */
 }
 
@@ -7095,7 +6748,6 @@ lock_unlock_objects_lock_set (THREAD_ENTRY * thread_p, LC_LOCKSET * lockset)
   int tran_index;		/* transaction table index */
   TRAN_ISOLATION isolation;	/* transaction isolation level */
   LOCK reqobj_class_unlock;
-  LOCK reqobj_inst_unlock;
   OID *oid, *class_oid;
   int i;
 
@@ -7113,17 +6765,19 @@ lock_unlock_objects_lock_set (THREAD_ENTRY * thread_p, LC_LOCKSET * lockset)
     {
       return;			/* Nothing to release */
     }
+  else if (isolation != TRAN_READ_COMMITTED)
+    {
+      assert (0);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_UNKNOWN_ISOLATION, 2, isolation, tran_index);
+      return;
+    }
+
+  assert (isolation == TRAN_READ_COMMITTED);
 
   reqobj_class_unlock = lockset->reqobj_class_lock;
   if (reqobj_class_unlock == X_LOCK)
     {
-      reqobj_class_unlock = NULL_LOCK;	/* Don't release the lock */
-    }
-  reqobj_inst_unlock = lockset->reqobj_inst_lock;
-
-  if (reqobj_inst_unlock == NULL_LOCK && reqobj_class_unlock == NULL_LOCK)
-    {
-      return;
+      return;			/* Don't release the lock */
     }
 
   for (i = 0; i < lockset->num_reqobjs_processed; i++)
@@ -7136,100 +6790,11 @@ lock_unlock_objects_lock_set (THREAD_ENTRY * thread_p, LC_LOCKSET * lockset)
 
       class_oid = &lockset->classes[lockset->objects[i].class_index].oid;
 
-      if (OID_IS_ROOTOID (class_oid))
-	{			/* class object */
-	  if (reqobj_class_unlock == NULL_LOCK)
-	    {
-	      continue;
-	    }
-	}
-      else
-	{			/* instance object */
-	  if (reqobj_inst_unlock == NULL_LOCK)
-	    {
-	      continue;
-	    }
-	}
-
-      switch (isolation)
-	{
-	case TRAN_READ_COMMITTED:
-	  /* demote shared class lock or unlock shared instance lock. */
-	  /* The intentional lock on the higher lock granule must be kept. */
-	  if (OID_IS_ROOTOID (class_oid))
-	    {
-	      /* Don't release locks on classes. READ COMMITTED isolation is only applied on instances, classes must
-	       * have at least REPEATABLE READ isolation. */
-	    }
-	  else if (mvcc_is_mvcc_disabled_class (class_oid))
-	    {
-	      /* Release S_LOCK after reading object. */
-	      lock_unlock_shared_inst_lock (thread_p, tran_index, oid);
-	    }
-	  else
-	    {
-	      /* MVCC is not disabled for class. READ COMMITTED isolation uses snapshot instead of locks. We don't have 
-	       * to release anything here. */
-	    }
-	  break;
-
-	default:		/* TRAN_UNKNOWN_ISOLATION */
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_UNKNOWN_ISOLATION, 2, isolation, tran_index);
-	  break;
-	}
+      /* The intentional lock on the higher lock granule must be kept. */
+      lock_unlock_object_by_isolation (thread_p, tran_index, isolation, class_oid, oid);
     }
 #endif /* !SERVER_MODE */
 }
-
-/*
- * lock_unlock_scan - Unlock scanning according to isolation level
- *
- * return: nothing..
- *
- *   class_oid(in): Class of the instance that were scanned
- *   scan_state(in):
- *
- * Note:Unlock the given "class_oid" scan according to the transaction
- *     isolation level. That is, the lock may not be released at this
- *     moment if the transaction isolation level does not allow it.
- */
-void
-lock_unlock_scan (THREAD_ENTRY * thread_p, const OID * class_oid, bool scan_state)
-{
-#if !defined (SERVER_MODE)
-  return;
-#else /* !SERVER_MODE */
-  int tran_index;		/* transaction table index */
-  TRAN_ISOLATION isolation;	/* transaction isolation level */
-
-  /* TODO: Should we remove this function? */
-
-  if (class_oid == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_BAD_ARGUMENT, 2, "lk_unlock_scan", "NULL ClassOID pointer");
-      return;
-    }
-
-  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  isolation = logtb_find_isolation (tran_index);
-
-  switch (isolation)
-    {
-    case TRAN_SERIALIZABLE:
-      break;			/* nothing to do */
-    case TRAN_REPEATABLE_READ:
-      break;			/* nothing to do */
-
-    case TRAN_READ_COMMITTED:
-      break;
-
-    default:			/* TRAN_UNKNOWN_ISOLATION */
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_UNKNOWN_ISOLATION, 2, isolation, tran_index);
-      break;
-    }
-#endif /* !SERVER_MODE */
-}
-
 
 /*
  * lock_unlock_classes_lock_hint - Unlock many hinted classes according to
@@ -7273,14 +6838,13 @@ lock_unlock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint)
       return;			/* nothing to do */
 
     case TRAN_READ_COMMITTED:
-      /* class: demote shared class locks */
       for (i = 0; i < lockhint->num_classes; i++)
 	{
 	  if (OID_ISNULL (&lockhint->classes[i].oid) || lockhint->classes[i].lock == NULL_LOCK)
 	    {
 	      continue;
 	    }
-	  lock_demote_shared_class_lock (thread_p, tran_index, &lockhint->classes[i].oid);
+	  lock_unlock_inst_locks_of_class_by_isolation (thread_p, tran_index, isolation, &lockhint->classes[i].oid);
 	}
       return;
 
@@ -7368,46 +6932,6 @@ lock_unlock_all (THREAD_ENTRY * thread_p)
 #endif /* !SERVER_MODE */
 }
 
-/*
- * lock_unlock_by_isolation_level - Release some of the locks of the current
- *                              transaction according to its isolation  level
- *
- * return: nothing
- *
- * Note:Release some of the locks acquired by the current transaction
- *     according to its isolation level.
- */
-void
-lock_unlock_by_isolation_level (THREAD_ENTRY * thread_p)
-{
-#if !defined (SERVER_MODE)
-  return;
-#else /* !SERVER_MODE */
-  int tran_index;		/* transaction table index */
-  TRAN_ISOLATION isolation;	/* transaction isolation level */
-
-  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  isolation = logtb_find_isolation (tran_index);
-
-  switch (isolation)
-    {
-    case TRAN_SERIALIZABLE:
-    case TRAN_REPEATABLE_READ:
-      return;			/* Nothing to release */
-
-    case TRAN_READ_COMMITTED:
-      /* remove all shared instance locks, demote all shared class locks */
-      lock_remove_all_inst_locks (thread_p, tran_index, NULL, S_LOCK);
-      lock_demote_all_shared_class_locks (thread_p, tran_index);
-      return;
-
-    default:			/* TRAN_UNKNOWN_ISOLATION */
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_UNKNOWN_ISOLATION, 2, isolation, tran_index);
-      return;
-    }
-#endif /* !SERVER_MODE */
-}
-
 static LK_ENTRY *
 lock_find_tran_hold_entry (int tran_index, const OID * oid, bool is_class)
 {
@@ -7426,7 +6950,7 @@ lock_find_tran_hold_entry (int tran_index, const OID * oid, bool is_class)
     }
 
   /* search hash */
-  search_key = lock_create_search_key ((OID *) oid, NULL, NULL);
+  search_key = lock_create_search_key ((OID *) oid, NULL);
   if (search_key.type != LOCK_RESOURCE_ROOT_CLASS)
     {
       /* override type; we don't insert here, so class_oid is neither passed to us nor needed for the search */
@@ -8796,9 +8320,8 @@ lock_reacquire_crash_locks (THREAD_ENTRY * thread_p, LK_ACQUIRED_LOCKS * acqlock
        * lock wait duration       : LK_INFINITE_WAIT
        * conditional lock request : false
        */
-      r =
-	lock_internal_perform_lock_object (thread_p, tran_index, &acqlocks->obj[i].oid, &acqlocks->obj[i].class_oid,
-					   NULL, acqlocks->obj[i].lock, LK_INFINITE_WAIT, &dummy_ptr, NULL);
+      r = lock_internal_perform_lock_object (thread_p, tran_index, &acqlocks->obj[i].oid, &acqlocks->obj[i].class_oid,
+					     acqlocks->obj[i].lock, LK_INFINITE_WAIT, &dummy_ptr, NULL);
       if (r != LK_GRANTED)
 	{
 	  er_log_debug (ARG_FILE_LINE, "lk_reacquire_crash_locks: The lock cannot be reacquired...");
@@ -9215,7 +8738,7 @@ lock_add_composite_lock (THREAD_ENTRY * thread_p, LK_COMPOSITE_LOCK * comp_lock,
 
       /* initialize lockcomp_class */
       COPY_OID (&lockcomp_class->class_oid, class_oid);
-      if (lock_internal_perform_lock_object (thread_p, lockcomp->tran_index, class_oid, NULL, NULL, IX_LOCK,
+      if (lock_internal_perform_lock_object (thread_p, lockcomp->tran_index, class_oid, NULL, IX_LOCK,
 					     lockcomp->wait_msecs, &lockcomp_class->class_lock_ptr,
 					     lockcomp->root_class_ptr) != LK_GRANTED)
 	{
@@ -9342,9 +8865,8 @@ lock_finalize_composite_lock (THREAD_ENTRY * thread_p, LK_COMPOSITE_LOCK * comp_
 	  || lockcomp_class->num_inst_oids == prm_get_integer_value (PRM_ID_LK_ESCALATION_AT))
 	{
 	  /* hold X_LOCK on the class object */
-	  value =
-	    lock_internal_perform_lock_object (thread_p, lockcomp->tran_index, &lockcomp_class->class_oid, NULL, NULL,
-					       X_LOCK, lockcomp->wait_msecs, &dummy, lockcomp->root_class_ptr);
+	  value = lock_internal_perform_lock_object (thread_p, lockcomp->tran_index, &lockcomp_class->class_oid, NULL,
+						     X_LOCK, lockcomp->wait_msecs, &dummy, lockcomp->root_class_ptr);
 	  if (value != LK_GRANTED)
 	    {
 	      break;
@@ -9355,10 +8877,10 @@ lock_finalize_composite_lock (THREAD_ENTRY * thread_p, LK_COMPOSITE_LOCK * comp_
 	  /* hold X_LOCKs on the instance objects */
 	  for (i = 0; i < lockcomp_class->num_inst_oids; i++)
 	    {
-	      value =
-		lock_internal_perform_lock_object (thread_p, lockcomp->tran_index, &lockcomp_class->inst_oid_space[i],
-						   &lockcomp_class->class_oid, NULL, X_LOCK, lockcomp->wait_msecs,
-						   &dummy, lockcomp_class->class_lock_ptr);
+	      value = lock_internal_perform_lock_object (thread_p, lockcomp->tran_index,
+							 &lockcomp_class->inst_oid_space[i],
+							 &lockcomp_class->class_oid, X_LOCK, lockcomp->wait_msecs,
+							 &dummy, lockcomp_class->class_lock_ptr);
 	      if (value != LK_GRANTED)
 		{
 		  break;
@@ -9706,7 +9228,7 @@ lock_get_total_holders_mode (const OID * oid, const OID * class_oid)
   is_class = OID_EQ (oid, oid_Root_class_oid) || class_oid == NULL || OID_EQ (class_oid, oid_Root_class_oid);
 
   /* search hash */
-  search_key = lock_create_search_key ((OID *) oid, (OID *) class_oid, NULL);
+  search_key = lock_create_search_key ((OID *) oid, (OID *) class_oid);
   rv = lf_hash_find (t_entry, &lk_Gl.obj_hash_table, (void *) &search_key, (void **) &res_ptr);
   if (rv != NO_ERROR)
     {
@@ -9765,7 +9287,7 @@ lock_get_all_except_transaction (const OID * oid, const OID * class_oid, int tra
   is_class = OID_EQ (oid, oid_Root_class_oid) || class_oid == NULL || OID_EQ (class_oid, oid_Root_class_oid);
 
   /* search hash */
-  search_key = lock_create_search_key ((OID *) oid, (OID *) class_oid, NULL);
+  search_key = lock_create_search_key ((OID *) oid, (OID *) class_oid);
   rv = lf_hash_find (t_entry, &lk_Gl.obj_hash_table, (void *) &search_key, (void **) &res_ptr);
   if (rv != NO_ERROR)
     {
@@ -10264,16 +9786,6 @@ lock_event_log_lock_info (THREAD_ENTRY * thread_p, FILE * log_fp, LK_ENTRY * ent
 	      free_and_init (classname);
 	    }
 	}
-
-      if (!BTID_IS_NULL (&res_ptr->key.btid))
-	{
-	  if (heap_get_indexinfo_of_btid (thread_p, &res_ptr->key.class_oid, &res_ptr->key.btid, NULL, NULL, NULL,
-					  NULL, &btname, NULL) == NO_ERROR)
-	    {
-	      fprintf (log_fp, ", index=%s", btname);
-	      free_and_init (btname);
-	    }
-	}
       break;
 
     default:
@@ -10374,7 +9886,7 @@ lock_rep_read_tran (THREAD_ENTRY * thread_p, LOCK lock, int cond_flag)
       wait_msecs = logtb_find_wait_msecs (tran_index);
     }
 
-  if (lock_internal_perform_lock_object (thread_p, tran_index, rep_read_oid, NULL, NULL, lock, wait_msecs, &entry_addr,
+  if (lock_internal_perform_lock_object (thread_p, tran_index, rep_read_oid, NULL, lock, wait_msecs, &entry_addr,
 					 NULL) != LK_GRANTED)
     {
       return ER_FAILED;
@@ -10471,3 +9983,75 @@ lock_free_entry (int tran_index, LF_TRAN_ENTRY * tran_entry, LF_FREELIST * freel
     }
 }
 #endif
+
+#if defined (SERVER_MODE)
+/*
+ * lock_unlock_object_by_isolation - No lock is unlocked/demoted for MVCC tables. 
+ *			             Shared instance lock on non-MVCC table is unlocked for TRAN_READ_COMMITTED.
+ *
+ * return : nothing
+ * tran_index(in): Transaction index.
+ * class_oid(in): class oid.
+ * oid(in): instance oid.
+ */
+static void
+lock_unlock_object_by_isolation (THREAD_ENTRY * thread_p, int tran_index, TRAN_ISOLATION isolation,
+				 const OID * class_oid, const OID * oid)
+{
+  assert (class_oid != NULL && oid != NULL);
+  assert (!OID_ISNULL (class_oid) && !OID_ISNULL (oid));
+
+  if (isolation != TRAN_READ_COMMITTED)
+    {
+      return;			/* do nothing */
+    }
+
+  /* The intentional lock on the higher lock granule must be kept. */
+  if (OID_IS_ROOTOID (oid) || OID_IS_ROOTOID (class_oid))
+    {
+      /* Don't release locks on classes. READ COMMITTED isolation is only applied on instances, classes must
+       * have at least REPEATABLE READ isolation. */
+    }
+  else if (mvcc_is_mvcc_disabled_class (class_oid))
+    {
+      /* Release S_LOCK after reading object. */
+      lock_unlock_shared_inst_lock (thread_p, tran_index, oid);
+    }
+  else
+    {
+      /* MVCC table. READ COMMITTED isolation uses snapshot instead of locks. We don't have to release anything here. */
+    }
+}
+
+/*
+ * lock_unlock_inst_locks_of_class_by_isolation - No lock is unlocked/demoted for MVCC tables. 
+ *						  Shared instance locks on non-MVCC table is unlocked for 
+ *						  TRAN_READ_COMMITTED.
+ *
+ * return : nothing
+ * tran_index(in): Transaction index.
+ * class_oid(in): class oid.
+ */
+static void
+lock_unlock_inst_locks_of_class_by_isolation (THREAD_ENTRY * thread_p, int tran_index, TRAN_ISOLATION isolation,
+					      const OID * class_oid)
+{
+  assert (class_oid != NULL);
+  assert (!OID_ISNULL (class_oid));
+
+  if (isolation != TRAN_READ_COMMITTED)
+    {
+      return;			/* do nothing */
+    }
+
+  if (mvcc_is_mvcc_disabled_class (class_oid))
+    {
+      /* Release S_LOCKs of non-MVCC tables. */
+      lock_remove_all_inst_locks (thread_p, tran_index, class_oid, S_LOCK);
+    }
+  else
+    {
+      /* MVCC table. READ COMMITTED isolation uses snapshot instead of locks. We don't have to release anything here. */
+    }
+}
+#endif /* SERVER_MODE */

--- a/src/transaction/lock_manager.h
+++ b/src/transaction/lock_manager.h
@@ -75,14 +75,6 @@ typedef enum
   KEY_LOCK_ESCALATED = 2
 } KEY_LOCK_ESCALATION;
 
-typedef struct lk_acquisition_history LK_ACQUISITION_HISTORY;
-struct lk_acquisition_history
-{
-  LOCK req_mode;
-  LK_ACQUISITION_HISTORY *next;
-  LK_ACQUISITION_HISTORY *prev;
-};
-
 /*****************************/
 /* Lock Heap Entry Structure */
 /*****************************/
@@ -102,8 +94,6 @@ struct lk_entry
   LK_ENTRY *tran_next;		/* list of locks that trans. holds */
   LK_ENTRY *tran_prev;		/* list of locks that trans. holds */
   LK_ENTRY *class_entry;	/* ptr. to class lk_entry */
-  LK_ACQUISITION_HISTORY *history;	/* lock acquisition history */
-  LK_ACQUISITION_HISTORY *recent;	/* last node of history list */
   int ngranules;		/* number of finer granules */
   int instant_lock_count;	/* number of instant lock requests */
   int bind_index_in_tran;
@@ -179,7 +169,6 @@ struct lk_res_key
   LOCK_RESOURCE_TYPE type;	/* type of resource: class,instance */
   OID oid;
   OID class_oid;
-  BTID btid;
 };
 
 /*
@@ -220,10 +209,8 @@ extern void lock_unlock_object_donot_move_to_non2pl (THREAD_ENTRY * thread_p, co
 						     LOCK lock);
 extern void lock_unlock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int force);
 extern void lock_unlock_objects_lock_set (THREAD_ENTRY * thread_p, LC_LOCKSET * lockset);
-extern void lock_unlock_scan (THREAD_ENTRY * thread_p, const OID * class_oid, bool scan_state);
 extern void lock_unlock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint);
 extern void lock_unlock_all (THREAD_ENTRY * thread_p);
-extern void lock_unlock_by_isolation_level (THREAD_ENTRY * thread_p);
 extern LOCK lock_get_object_lock (const OID * oid, const OID * class_oid, int tran_index);
 extern bool lock_has_xlock (THREAD_ENTRY * thread_p);
 #if defined (ENABLE_UNUSED_FUNCTION)

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10060,6 +10060,8 @@ log_read_sysop_start_postpone (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_P
   /* skip log record header */
   LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_RECORD_HEADER), log_lsa, log_page);
 
+  /* read sysop_start_postpone */
+  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_SYSOP_START_POSTPONE), log_lsa, log_page);
   *sysop_start_postpone = *(LOG_REC_SYSOP_START_POSTPONE *) (log_page->area + log_lsa->offset);
   if (!with_undo_data
       || (sysop_start_postpone->sysop_end.type != LOG_SYSOP_END_LOGICAL_UNDO

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -3009,17 +3009,15 @@ logtb_find_log_records_count (int tran_index)
  *                         TRAN_SERIALIZABLE
  *                         TRAN_REPEATABLE_READ
  *                         TRAN_READ_COMMITTED
- *   unlock_by_isolation(in): unlock by isolation during reset
  *
- * Note:Reset the default isolation level for the current transaction
- *              index (client).
+ * Note:Reset the default isolation level for the current transaction index (client).
  *
  * Note/Warning: This function must be called when the current transaction has
  *               not been done any work (i.e, just after restart, commit, or
  *               abort), otherwise, its isolation behaviour will be undefined.
  */
 int
-xlogtb_reset_isolation (THREAD_ENTRY * thread_p, TRAN_ISOLATION isolation, bool unlock_by_isolation)
+xlogtb_reset_isolation (THREAD_ENTRY * thread_p, TRAN_ISOLATION isolation)
 {
   TRAN_ISOLATION old_isolation;
   int error_code = NO_ERROR;
@@ -3033,10 +3031,6 @@ xlogtb_reset_isolation (THREAD_ENTRY * thread_p, TRAN_ISOLATION isolation, bool 
     {
       old_isolation = tdes->isolation;
       tdes->isolation = isolation;
-      if (unlock_by_isolation == true)
-	{
-	  lock_unlock_by_isolation_level (thread_p);
-	}
     }
   else
     {

--- a/src/transaction/transaction_cl.c
+++ b/src/transaction/transaction_cl.c
@@ -206,7 +206,7 @@ tran_reset_isolation (TRAN_ISOLATION isolation, bool async_ws)
 
   if (tm_Tran_isolation != isolation)
     {
-      error_code = log_reset_isolation (isolation, true);
+      error_code = log_reset_isolation (isolation);
       if (error_code == NO_ERROR)
 	{
 	  tm_Tran_isolation = isolation;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20416

The issue is caused by the memory allocation/deallocation. Thus, some db_values are allocated with global heap and deallocated with private heap or in reverse way. For consistency, the unpacked db_values from XASL clone must be allocated/deallocated with global heap. That's because the XASL clone can be reused by other transaction. The db_values allocated during query execution must be allocated/deallocated with private heap, for performance reasons.