### PR TITLE
[CBRD-20659] change default password encryption algorithm as SHA2

### DIFF
--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -2542,12 +2542,10 @@ match_password (const char *user, const char *database)
  *   user(in):  user object
  *   password(in): new password
  *   encode(in): flag to enable encryption of the string in the database
- *   encrypt_prefix(in): If encode flag is 0, then we assume that the
- *                      given password have been encrypted. So, All I have
- *                      to do is add prefix(DES or SHA1) to given password.
- *                       If encode flag is 1, then we should encrypt
- *                      password with sha1 and add prefix (SHA1) to it.
- *                      So, I don't care what encrypt_prefix value is.
+ *   encrypt_prefix(in): If encode flag is 0, then we assume that the given password have been encrypted. So, All I have
+ *                       to do is add prefix(SHA2) to given password.
+ *                       If encode flag is 1, then we should encrypt password with sha2 and add prefix (SHA2) to it.
+ *                       So, I don't care what encrypt_prefix value is.
  */
 static int
 au_set_password_internal (MOP user, const char *password, int encode, char encrypt_prefix)
@@ -2594,6 +2592,7 @@ au_set_password_internal (MOP user, const char *password, int encode, char encry
 		{
 		  pass = db_get_object (&value);
 		}
+
 	      if (pass == NULL)
 		{
 		  pclass = sm_find_class (AU_PASSWORD_CLASS_NAME);
@@ -2661,7 +2660,7 @@ au_set_password_internal (MOP user, const char *password, int encode, char encry
 int
 au_set_password (MOP user, const char *password)
 {
-  return (au_set_password_internal (user, password, 1, ENCODE_PREFIX_DEFAULT));
+  return (au_set_password_internal (user, password, 1, ENCODE_PREFIX_SHA2_512));
 }
 
 /*
@@ -2748,8 +2747,7 @@ au_set_password_encoded_method (MOP user, DB_VALUE * returnval, DB_VALUE * passw
 }
 
 /*
- * au_set_password_encoded_sha1_method - Method interface for setting
- *                                      sha1 passwords.
+ * au_set_password_encoded_sha1_method - Method interface for setting sha1/2 passwords.
  *   return: none
  *   user(in): user object
  *   returnval(out): return value of this object

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -6631,9 +6631,6 @@ au_perform_login (const char *name, const char *password, bool ignore_dba_privil
   dbuser = (char *) name;
   dbpassword = (char *) password;
 
-  fprintf (stderr, "dbuser = (%s), dbpassword = (%s)\n", dbuser, dbpassword);
-  fflush (stderr);
-
   if (dbuser == NULL || strlen (dbuser) == 0)
     {
       error = ER_AU_NO_USER_LOGGED_IN;

--- a/src/object/authenticate.h
+++ b/src/object/authenticate.h
@@ -188,9 +188,6 @@ extern int au_set_user_comment (MOP user, const char *comment);
 
 extern const char *au_user_name (void);
 extern char *au_user_name_dup (void);
-#if defined(ENABLE_UNUSED_FUNCTION)
-extern int au_user_password (char *buffer);
-#endif
 
 /* grant/revoke */
 extern int au_grant (MOP user, MOP class_mop, DB_AUTH type, bool grant_option);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20659

* change default password encryption method as SHA2
* The legacy passwords are also supported. DBAs should reset legacy passwords to encrypt them by SHA2.
