### PR TITLE
[CBRD-20691] Revise Lock Manager for MVCC

### DIFF
--- a/src/base/xserver_interface.h
+++ b/src/base/xserver_interface.h
@@ -148,7 +148,7 @@ extern void xlogtb_set_interrupt (THREAD_ENTRY * thread_p, int set);
 extern void xlogtb_set_suppress_repl_on_transaction (THREAD_ENTRY * thread_p, int set);
 
 extern int xlogtb_reset_wait_msecs (THREAD_ENTRY * thread_p, int wait_msecs);
-extern int xlogtb_reset_isolation (THREAD_ENTRY * thread_p, TRAN_ISOLATION isolation, bool unlock_by_isolation);
+extern int xlogtb_reset_isolation (THREAD_ENTRY * thread_p, TRAN_ISOLATION isolation);
 
 extern LOG_LSA *log_get_final_restored_lsa (void);
 extern float log_get_db_compatibility (void);

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -2200,11 +2200,11 @@ log_reset_wait_msecs (int wait_msecs)
  * NOTE:
  */
 int
-log_reset_isolation (TRAN_ISOLATION isolation, bool unlock_by_isolation)
+log_reset_isolation (TRAN_ISOLATION isolation)
 {
 #if defined(CS_MODE)
   int req_error, error_code = ER_NET_CLIENT_DATA_RECEIVE;
-  OR_ALIGNED_BUF (OR_INT_SIZE * 2) a_request;
+  OR_ALIGNED_BUF (OR_INT_SIZE) a_request;
   char *request, *ptr;
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply;
@@ -2213,7 +2213,6 @@ log_reset_isolation (TRAN_ISOLATION isolation, bool unlock_by_isolation)
   reply = OR_ALIGNED_BUF_START (a_reply);
 
   ptr = or_pack_int (request, (int) isolation);
-  ptr = or_pack_int (ptr, (int) unlock_by_isolation);
 
   req_error =
     net_client_request (NET_SERVER_LOG_RESET_ISOLATION, request, OR_ALIGNED_BUF_SIZE (a_request), reply,
@@ -2229,7 +2228,7 @@ log_reset_isolation (TRAN_ISOLATION isolation, bool unlock_by_isolation)
 
   ENTER_SERVER ();
 
-  error_code = xlogtb_reset_isolation (NULL, isolation, unlock_by_isolation);
+  error_code = xlogtb_reset_isolation (NULL, isolation);
 
   EXIT_SERVER ();
 

--- a/src/communication/network_interface_cl.h
+++ b/src/communication/network_interface_cl.h
@@ -116,7 +116,7 @@ extern int disk_get_purpose_and_space_info (VOLID volid, DISK_VOLPURPOSE * vol_p
 extern char *disk_get_fullname (VOLID volid, char *vol_fullname);
 extern bool disk_is_volume_exist (VOLID volid);
 extern int log_reset_wait_msecs (int wait_msecs);
-extern int log_reset_isolation (TRAN_ISOLATION isolation, bool unlock_by_isolation);
+extern int log_reset_isolation (TRAN_ISOLATION isolation);
 extern void log_set_interrupt (int set);
 extern int log_checkpoint (void);
 extern void log_dump_stat (FILE * outfp);

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -1757,15 +1757,14 @@ slogtb_reset_wait_msecs (THREAD_ENTRY * thread_p, unsigned int rid, char *reques
 void
 slogtb_reset_isolation (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  int isolation, unlock_by_isolation, error_code;
+  int isolation, error_code;
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply = OR_ALIGNED_BUF_START (a_reply);
   char *ptr;
 
   ptr = or_unpack_int (request, &isolation);
-  ptr = or_unpack_int (ptr, &unlock_by_isolation);
 
-  error_code = (int) xlogtb_reset_isolation (thread_p, (TRAN_ISOLATION) isolation, (bool) unlock_by_isolation);
+  error_code = (int) xlogtb_reset_isolation (thread_p, (TRAN_ISOLATION) isolation);
 
   if (error_code != NO_ERROR)
     {

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -3693,21 +3693,11 @@ catcls_insert_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
       goto error;
     }
 
-#if defined(SERVER_MODE)
-  lock_unlock_object (thread_p, oid_p, class_oid_p, X_LOCK, false);
-#endif /* SERVER_MODE */
   free_and_init (record.data);
 
   return NO_ERROR;
 
 error:
-
-#if defined(SERVER_MODE)
-  if (is_lock_inited)
-    {
-      lock_unlock_object (thread_p, oid_p, class_oid_p, X_LOCK, false);
-    }
-#endif /* SERVER_MODE */
 
   if (record.data)
     {
@@ -3798,21 +3788,11 @@ catcls_delete_instance (THREAD_ENTRY * thread_p, OID * oid_p, OID * class_oid_p,
       goto error;
     }
 
-#if defined(SERVER_MODE)
-  lock_unlock_object (thread_p, oid_p, class_oid_p, X_LOCK, false);
-#endif /* SERVER_MODE */
   catcls_free_or_value (value_p);
 
   return NO_ERROR;
 
 error:
-
-#if defined(SERVER_MODE)
-  if (is_lock_inited)
-    {
-      lock_unlock_object (thread_p, oid_p, class_oid_p, X_LOCK, false);
-    }
-#endif /* SERVER_MODE */
 
   if (value_p)
     {
@@ -3957,9 +3937,6 @@ catcls_update_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
       free_and_init (record.data);
     }
 
-#if defined(SERVER_MODE)
-  lock_unlock_object (thread_p, oid_p, class_oid_p, X_LOCK, false);
-#endif /* SERVER_MODE */
   catcls_free_or_value (old_value_p);
 
   return NO_ERROR;

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -131,11 +131,26 @@ struct file_header
    * page of user page table. Newly allocated page is appended here. */
   VPID vpid_last_user_page_ftab;
 
+  /* cache last file_numerable_find_nth page and index of its entry. used as an optimization for external sort files.
+   * the extensible hash case is not interesting for this optimization (because they are usually small files and because
+   * the access pattern is less predictable.
+   * the usual pattern external sort files is find nth, find nth+1, find nth+2 and so on. so we can cache the page and
+   * index of its first entry from last search to predict where the next file_numerable_find_nth will land.
+   *
+   * how it works:
+   * cache last search location for file_numerable_find_nth by saving user page table page VPID and index of first entry
+   * in page. next search will probably land in the same page (and it will just need to get to the right offset).
+   * if a page is deallocated, the cached location is reset (this is just a safe-guard since external sort does not
+   * deallocate pages currently.
+   * if a page is allocated, since it is appended at the end, will not affect the cached search location. current thread
+   * is actually the only one accessing the file so it can change it safely without promoting to write latch. to avoid
+   * safe-guards, we won't set the page dirty (it is hot anyway and likely to remain in memory).
+   */
+  VPID vpid_find_nth_last;
+  int first_index_find_nth_last;
+
   /* reserved area for future extension */
   INT32 reserved0;
-  INT32 reserved1;
-  INT32 reserved2;
-  INT32 reserved3;
 };
 
 /* Disk size of file header. */
@@ -147,6 +162,9 @@ struct file_header
 
 #define FILE_IS_NUMERABLE(fh) (((fh)->file_flags & FILE_FLAG_NUMERABLE) != 0)
 #define FILE_IS_TEMPORARY(fh) (((fh)->file_flags & FILE_FLAG_TEMPORARY) != 0)
+
+#define FILE_CACHE_LAST_FIND_NTH(fh) \
+  (FILE_IS_NUMERABLE (fh) && FILE_IS_TEMPORARY (fh) && (fh)->type == FILE_TEMP)
 
 /* Numerable file types. Currently, we used this property for extensible hashes and sort files. */
 #define FILE_TYPE_CAN_BE_NUMERABLE(ftype) ((ftype) == FILE_EXTENDIBLE_HASH \
@@ -320,7 +338,8 @@ static bool file_Logging = false;
   "\t\ttable offsets: partial = %d, full = %d, user page = %d \n" \
   "\t\tvpid_sticky_first = %d|%d \n" \
   "\t\tvpid_last_temp_alloc = %d|%d, offset_to_last_temp_alloc=%d \n" \
-  "\t\tvpid_last_user_page_ftab = %d|%d \n"
+  "\t\tvpid_last_user_page_ftab = %d|%d \n" \
+  "\t\tvpid_find_nth_last = %d|%d, first_index_find_nth_last = %d \n"
 #define FILE_HEAD_FULL_AS_ARGS(fhead) \
   FILE_HEAD_ALLOC_AS_ARGS (fhead), \
   VFID_AS_ARGS (&(fhead)->self), (long long int) fhead->time_creation, file_type_to_string ((fhead)->type), \
@@ -328,7 +347,8 @@ static bool file_Logging = false;
   (fhead)->offset_to_partial_ftab, (fhead)->offset_to_full_ftab, (fhead)->offset_to_user_page_ftab, \
   VPID_AS_ARGS (&(fhead)->vpid_sticky_first), \
   VPID_AS_ARGS (&(fhead)->vpid_last_temp_alloc), (fhead)->offset_to_last_temp_alloc, \
-  VPID_AS_ARGS (&(fhead)->vpid_last_user_page_ftab)
+  VPID_AS_ARGS (&(fhead)->vpid_last_user_page_ftab), \
+  VPID_AS_ARGS (&(fhead)->vpid_find_nth_last), (fhead)->first_index_find_nth_last
 
 #define FILE_EXTDATA_MSG(name) \
   "\t" name ": { vpid_next = %d|%d, max_size = %d, item_size = %d, n_items = %d } \n"
@@ -413,6 +433,7 @@ struct file_find_nth_context
 {
   VPID *vpid_nth;
   int nth;
+  int first_index;
 };
 
 /************************************************************************/
@@ -829,6 +850,8 @@ file_header_init (FILE_HEADER * fhead)
   VPID_SET_NULL (&fhead->vpid_last_temp_alloc);
   fhead->offset_to_last_temp_alloc = NULL_OFFSET;
   VPID_SET_NULL (&fhead->vpid_last_user_page_ftab);
+  VPID_SET_NULL (&fhead->vpid_find_nth_last);
+  fhead->first_index_find_nth_last = 0;
   VPID_SET_NULL (&fhead->vpid_sticky_first);
 
   fhead->n_page_total = 0;
@@ -845,7 +868,7 @@ file_header_init (FILE_HEADER * fhead)
   fhead->offset_to_full_ftab = NULL_OFFSET;
   fhead->offset_to_user_page_ftab = NULL_OFFSET;
 
-  fhead->reserved0 = fhead->reserved1 = fhead->reserved2 = fhead->reserved3 = 0;
+  fhead->reserved0 = 0;
 }
 
 /*
@@ -3220,6 +3243,8 @@ file_create (THREAD_ENTRY * thread_p, FILE_TYPE file_type,
   VPID_SET_NULL (&fhead->vpid_last_temp_alloc);
   fhead->offset_to_last_temp_alloc = NULL_OFFSET;
   VPID_SET_NULL (&fhead->vpid_last_user_page_ftab);
+  VPID_SET_NULL (&fhead->vpid_find_nth_last);
+  fhead->first_index_find_nth_last = 0;
   VPID_SET_NULL (&fhead->vpid_sticky_first);
 
   fhead->n_page_total = 0;
@@ -3237,7 +3262,7 @@ file_create (THREAD_ENTRY * thread_p, FILE_TYPE file_type,
   fhead->offset_to_full_ftab = NULL_OFFSET;
   fhead->offset_to_user_page_ftab = NULL_OFFSET;
 
-  fhead->reserved0 = fhead->reserved1 = fhead->reserved2 = fhead->reserved3 = 0;
+  fhead->reserved0 = 0;
 
   /* start with a negative empty sector (because we have allocated header). */
   fhead->n_sector_empty--;
@@ -3495,6 +3520,7 @@ file_create (THREAD_ENTRY * thread_p, FILE_TYPE file_type,
     {
       /* set last user page table VPID to header */
       fhead->vpid_last_user_page_ftab = vpid_fhead;
+      fhead->vpid_find_nth_last = vpid_fhead;
     }
 
   /* set all stats */
@@ -5416,6 +5442,13 @@ file_dealloc (THREAD_ENTRY * thread_p, const VFID * vfid, const VPID * vpid, FIL
 
   file_log ("file_dealloc", "file %d|%d marked vpid %|%d as deleted", VFID_AS_ARGS (vfid), VPID_AS_ARGS (vpid));
 
+  if (FILE_CACHE_LAST_FIND_NTH (fhead))
+    {
+      /* reset cached search location */
+      VPID_SET_NULL (&fhead->vpid_find_nth_last);
+      fhead->first_index_find_nth_last = 0;
+    }
+
   /* done */
   assert (error_code != NO_ERROR);
 
@@ -7286,6 +7319,7 @@ file_extdata_find_nth_vpid (THREAD_ENTRY * thread_p, const FILE_EXTENSIBLE_DATA 
     {
       /* not in this extensible data. continue searching. */
       find_nth_context->nth -= count_vpid;
+      find_nth_context->first_index += count_vpid;
     }
   else
     {
@@ -7357,6 +7391,8 @@ file_numerable_find_nth (THREAD_ENTRY * thread_p, const VFID * vfid, int nth, bo
   PAGE_PTR page_fhead = NULL;
   FILE_HEADER *fhead = NULL;
   FILE_EXTENSIBLE_DATA *extdata_user_page_ftab = NULL;
+  PAGE_PTR page_ftab_start = NULL;
+  PAGE_PTR page_ftab_nth_location = NULL;
   FILE_FIND_NTH_CONTEXT find_nth_context;
   int error_code = NO_ERROR;
 
@@ -7382,6 +7418,7 @@ file_numerable_find_nth (THREAD_ENTRY * thread_p, const VFID * vfid, int nth, bo
     }
   fhead = (FILE_HEADER *) page_fhead;
   file_header_sanity_check (fhead);
+  assert (FILE_IS_NUMERABLE (fhead));
   assert (nth < fhead->n_page_user || (auto_alloc && nth == fhead->n_page_user));
 
   if (auto_alloc && nth == (fhead->n_page_user - fhead->n_page_mark_delete))
@@ -7451,13 +7488,51 @@ file_numerable_find_nth (THREAD_ENTRY * thread_p, const VFID * vfid, int nth, bo
     }
   else
     {
+      if (FILE_CACHE_LAST_FIND_NTH (fhead) && !VPID_ISNULL (&fhead->vpid_find_nth_last)
+	  && !VPID_EQ (&vpid_fhead, &fhead->vpid_find_nth_last) && nth >= fhead->first_index_find_nth_last)
+	{
+	  /* start searching from last search location */
+	  page_ftab_start =
+	    pgbuf_fix (thread_p, &fhead->vpid_find_nth_last, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
+	  if (page_ftab_start == NULL)
+	    {
+	      ASSERT_ERROR_AND_SET (error_code);
+	      goto exit;
+	    }
+	  extdata_user_page_ftab = (FILE_EXTENSIBLE_DATA *) page_ftab_start;
+	  find_nth_context.first_index = fhead->first_index_find_nth_last;
+	  find_nth_context.nth -= fhead->first_index_find_nth_last;
+	}
+      else
+	{
+	  /* no last search location or it could not be used. start searching from the beginning. */
+	  find_nth_context.first_index = 0;
+	}
       /* we can go directly to the right VPID. */
       error_code = file_extdata_apply_funcs (thread_p, extdata_user_page_ftab, file_extdata_find_nth_vpid,
-					     &find_nth_context, NULL, NULL, false, NULL, NULL);
+					     &find_nth_context, NULL, NULL, false, NULL, &page_ftab_nth_location);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
 	  goto exit;
+	}
+
+      if (FILE_CACHE_LAST_FIND_NTH (fhead))
+	{
+	  /* note that we consider this file cannot be accessed concurrently. therefore we do not promote to write latch
+	   * and we do not set page dirty to update the cached search location. */
+	  if (page_ftab_nth_location == NULL)
+	    {
+	      /* it was found in the starting page */
+	      page_ftab_nth_location = page_ftab_start != NULL ? page_ftab_start : page_fhead;
+	    }
+	  pgbuf_get_vpid (page_ftab_nth_location, &fhead->vpid_find_nth_last);
+	  fhead->first_index_find_nth_last = find_nth_context.first_index;
+
+	  file_log ("file_numerable_find_nth", "update fhead.fist_index_find_nth_last to %d "
+		    "and fhead->vpid_find_nth_last to %d|%d while searching nth=%d in file %d|%d",
+		    fhead->first_index_find_nth_last, VPID_AS_ARGS (&fhead->vpid_find_nth_last), nth,
+		    VFID_AS_ARGS (vfid));
 	}
     }
 
@@ -7472,6 +7547,15 @@ file_numerable_find_nth (THREAD_ENTRY * thread_p, const VFID * vfid, int nth, bo
   assert (error_code == NO_ERROR);
 
 exit:
+  if (page_ftab_nth_location != NULL && page_ftab_nth_location != page_ftab_start
+      && page_ftab_nth_location != page_fhead)
+    {
+      pgbuf_unfix (thread_p, page_ftab_nth_location);
+    }
+  if (page_ftab_start != NULL)
+    {
+      pgbuf_unfix (thread_p, page_ftab_start);
+    }
   if (page_fhead != NULL)
     {
       pgbuf_unfix (thread_p, page_fhead);
@@ -8070,6 +8154,8 @@ file_temp_reset_user_pages (THREAD_ENTRY * thread_p, const VFID * vfid)
       VPID_SET_NULL (&extdata_user_page_ftab->vpid_next);
       extdata_user_page_ftab->n_items = 0;
       fhead->vpid_last_user_page_ftab = vpid_fhead;
+      fhead->vpid_find_nth_last = vpid_fhead;
+      fhead->first_index_find_nth_last = 0;
     }
 
   /* collect table pages */

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -10496,21 +10496,23 @@ file_tracker_check (THREAD_ENTRY * thread_p)
       disk_map_clone_free (&disk_map_clone);
       return allvalid == DISK_VALID ? DISK_ERROR : allvalid;
     }
-
-  /* check all sectors have been cleared */
-  valid = disk_map_clone_check_leaks (disk_map_clone);
-  if (valid == DISK_INVALID)
+  else
     {
-      assert_release (false);
-      allvalid = DISK_INVALID;
-    }
-  else if (valid == DISK_ERROR)
-    {
-      ASSERT_ERROR ();
-      allvalid = allvalid == DISK_VALID ? DISK_ERROR : allvalid;
+      /* check all sectors have been cleared */
+      valid = disk_map_clone_check_leaks (disk_map_clone);
+      if (valid == DISK_INVALID)
+	{
+	  assert_release (false);
+	  allvalid = DISK_INVALID;
+	}
+      else if (valid == DISK_ERROR)
+	{
+	  ASSERT_ERROR ();
+	  allvalid = allvalid == DISK_VALID ? DISK_ERROR : allvalid;
+	}
+      disk_map_clone_free (&disk_map_clone);
     }
 
-  disk_map_clone_free (&disk_map_clone);
 #endif /* SA_MODE */
 
   return allvalid;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7022,30 +7022,12 @@ static int
 heap_scancache_end_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, bool scan_state)
 {
   int ret = NO_ERROR;
-  HEAP_SCANCACHE_NODE_LIST *p = NULL;
 
   if (scan_cache->debug_initpattern != HEAP_DEBUG_SCANCACHE_INITPATTERN)
     {
       er_log_debug (ARG_FILE_LINE, "heap_scancache_end_internal: Your scancache is not initialized");
       return ER_FAILED;
     }
-
-  if (!OID_ISNULL (&scan_cache->node.class_oid))
-    {
-      lock_unlock_scan (thread_p, &scan_cache->node.class_oid, scan_state);
-    }
-
-  p = scan_cache->partition_list;
-  while (p != NULL)
-    {
-      if (!OID_EQ (&p->node.class_oid, &scan_cache->node.class_oid))
-	{
-	  lock_unlock_scan (thread_p, &p->node.class_oid, scan_state);
-	}
-      p = p->next;
-    }
-
-  OID_SET_NULL (&scan_cache->node.class_oid);
 
   ret = heap_scancache_quick_end (thread_p, scan_cache);
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2068,9 +2068,6 @@ xlocator_assign_oid (THREAD_ENTRY * thread_p, const HFID * hfid, OID * perm_oid,
       assert (error_code == NO_ERROR);
     }
 
-  /* Release the lock which was set in heap_assign_address_with_class_oid according to isolation level */
-  lock_unlock_object (thread_p, perm_oid, class_oid, X_LOCK, false);
-
   return error_code;
 }
 
@@ -5287,21 +5284,12 @@ locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
     }
 #endif
 
-  /* Unlock the object according to isolation level */
-  /* locked by heap_insert */
-  /* manual duration */
-  lock_unlock_object (thread_p, &null_oid, &real_class_oid, X_LOCK, false);
-
   *force_count = 1;
 
 error1:
   /* update the OID of the class with the actual partition in which the object was inserted */
   COPY_OID (class_oid, &real_class_oid);
   HFID_COPY (hfid, &real_hfid);
-  if (error_code != NO_ERROR)
-    {
-      lock_unlock_object (thread_p, oid, class_oid, X_LOCK, false);
-    }
 
 error2:
   if (cache_attr_copyarea != NULL)
@@ -9263,10 +9251,6 @@ xlocator_notify_isolation_incons (THREAD_ENTRY * thread_p, LC_COPYAREA ** synch_
   else if (recdes.area_size >= SSIZEOF (*obj))
     {
       more_synch = true;
-    }
-  else
-    {
-      lock_unlock_by_isolation_level (thread_p);
     }
 
   return more_synch;

--- a/src/transaction/lock_manager.h
+++ b/src/transaction/lock_manager.h
@@ -169,7 +169,6 @@ struct lk_res_key
   LOCK_RESOURCE_TYPE type;	/* type of resource: class,instance */
   OID oid;
   OID class_oid;
-  BTID btid;
 };
 
 /*

--- a/src/transaction/lock_manager.h
+++ b/src/transaction/lock_manager.h
@@ -75,14 +75,6 @@ typedef enum
   KEY_LOCK_ESCALATED = 2
 } KEY_LOCK_ESCALATION;
 
-typedef struct lk_acquisition_history LK_ACQUISITION_HISTORY;
-struct lk_acquisition_history
-{
-  LOCK req_mode;
-  LK_ACQUISITION_HISTORY *next;
-  LK_ACQUISITION_HISTORY *prev;
-};
-
 /*****************************/
 /* Lock Heap Entry Structure */
 /*****************************/
@@ -102,8 +94,6 @@ struct lk_entry
   LK_ENTRY *tran_next;		/* list of locks that trans. holds */
   LK_ENTRY *tran_prev;		/* list of locks that trans. holds */
   LK_ENTRY *class_entry;	/* ptr. to class lk_entry */
-  LK_ACQUISITION_HISTORY *history;	/* lock acquisition history */
-  LK_ACQUISITION_HISTORY *recent;	/* last node of history list */
   int ngranules;		/* number of finer granules */
   int instant_lock_count;	/* number of instant lock requests */
   int bind_index_in_tran;
@@ -220,10 +210,8 @@ extern void lock_unlock_object_donot_move_to_non2pl (THREAD_ENTRY * thread_p, co
 						     LOCK lock);
 extern void lock_unlock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int force);
 extern void lock_unlock_objects_lock_set (THREAD_ENTRY * thread_p, LC_LOCKSET * lockset);
-extern void lock_unlock_scan (THREAD_ENTRY * thread_p, const OID * class_oid, bool scan_state);
 extern void lock_unlock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint);
 extern void lock_unlock_all (THREAD_ENTRY * thread_p);
-extern void lock_unlock_by_isolation_level (THREAD_ENTRY * thread_p);
 extern LOCK lock_get_object_lock (const OID * oid, const OID * class_oid, int tran_index);
 extern bool lock_has_xlock (THREAD_ENTRY * thread_p);
 #if defined (ENABLE_UNUSED_FUNCTION)

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10060,6 +10060,8 @@ log_read_sysop_start_postpone (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_P
   /* skip log record header */
   LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_RECORD_HEADER), log_lsa, log_page);
 
+  /* read sysop_start_postpone */
+  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_SYSOP_START_POSTPONE), log_lsa, log_page);
   *sysop_start_postpone = *(LOG_REC_SYSOP_START_POSTPONE *) (log_page->area + log_lsa->offset);
   if (!with_undo_data
       || (sysop_start_postpone->sysop_end.type != LOG_SYSOP_END_LOGICAL_UNDO

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -3009,17 +3009,15 @@ logtb_find_log_records_count (int tran_index)
  *                         TRAN_SERIALIZABLE
  *                         TRAN_REPEATABLE_READ
  *                         TRAN_READ_COMMITTED
- *   unlock_by_isolation(in): unlock by isolation during reset
  *
- * Note:Reset the default isolation level for the current transaction
- *              index (client).
+ * Note:Reset the default isolation level for the current transaction index (client).
  *
  * Note/Warning: This function must be called when the current transaction has
  *               not been done any work (i.e, just after restart, commit, or
  *               abort), otherwise, its isolation behaviour will be undefined.
  */
 int
-xlogtb_reset_isolation (THREAD_ENTRY * thread_p, TRAN_ISOLATION isolation, bool unlock_by_isolation)
+xlogtb_reset_isolation (THREAD_ENTRY * thread_p, TRAN_ISOLATION isolation)
 {
   TRAN_ISOLATION old_isolation;
   int error_code = NO_ERROR;
@@ -3033,10 +3031,6 @@ xlogtb_reset_isolation (THREAD_ENTRY * thread_p, TRAN_ISOLATION isolation, bool 
     {
       old_isolation = tdes->isolation;
       tdes->isolation = isolation;
-      if (unlock_by_isolation == true)
-	{
-	  lock_unlock_by_isolation_level (thread_p);
-	}
     }
   else
     {

--- a/src/transaction/transaction_cl.c
+++ b/src/transaction/transaction_cl.c
@@ -206,7 +206,7 @@ tran_reset_isolation (TRAN_ISOLATION isolation, bool async_ws)
 
   if (tm_Tran_isolation != isolation)
     {
-      error_code = log_reset_isolation (isolation, true);
+      error_code = log_reset_isolation (isolation);
       if (error_code == NO_ERROR)
 	{
 	  tm_Tran_isolation = isolation;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20691

Lock Manager changes:
* Do not unlock the current locks when reset isolation to `TRAN_READ_COMMITTED`
* Removing `lock_unlock_object (..., X_LOCK, false);` because it does nothing.
* Removing `lock_unlock_scan (...);` No effect.
* Removing `LK_ACQUISITION_HISTORY`. This consumed huge amount of main memory.
* To release instance locks to escalate to class lock for entire isolation levels. It did only for `TRAN_READ_COMMITTED`.
* Removing `lock_demote_shared_class_lock`
* Changing `lock_remove_all_inst_locks`: `TRAN_READ_COMMITTED` releases only shared locks of non-MVCC tables. 
* Changing `lock_unlock_objects_lock_set`: same as above
* Changing `lock_unlock_classes_lock_hint`: same as above
* Introduces `lock_unlock_object_by_isolation`
* Introduces `lock_unlock_inst_locks_of_class_by_isolation`
* Removing `BTID` from `LK_RES_KEY`
* Removing unused `lock_object_with_btid`
