### PR TITLE
[CBRD-20725] fix postpone recovery

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3790,7 +3790,8 @@ log_sysop_commit_internal (THREAD_ENTRY * thread_p, LOG_REC_SYSOP_END * log_reco
 		  || tdes->state == TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE);
 
 	  /* this is relevant for proper recovery */
-	  log_record->run_postpone.is_sysop_postpone = (tdes->state == TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE);
+	  log_record->run_postpone.is_sysop_postpone =
+	    (tdes->state == TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE && !is_rv_finish_postpone);
 	}
       else if (log_record->type == LOG_SYSOP_END_LOGICAL_COMPENSATE)
 	{

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1263,10 +1263,25 @@ log_rv_analysis_sysop_start_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_
       /* no undo */
       LSA_SET_NULL (&tdes->undo_nxlsa);
     }
+  else if (sysop_start_posp->sysop_end.type == LOG_SYSOP_END_LOGICAL_RUN_POSTPONE)
+    {
+      if (sysop_start_posp->sysop_end.run_postpone.is_sysop_postpone)
+	{
+	  /* system op postpone inside system op postpone. not a valid situation */
+	  assert (false);
+	}
+      else
+	{
+	  /* no undo. it is possible that the transaction state is TRAN_UNACTIVE_UNILATERALLY_ABORTED because this might
+	   * be the first log record discovered for current transaction. it will be set correctly when the system op end
+	   * is found or executed.
+	   */
+	  LSA_SET_NULL (&tdes->undo_nxlsa);
+	}
+    }
   else
     {
-      assert (sysop_start_posp->sysop_end.type == LOG_SYSOP_END_COMMIT
-	      || sysop_start_posp->sysop_end.type == LOG_SYSOP_END_LOGICAL_COMPENSATE);
+      assert (sysop_start_posp->sysop_end.type != LOG_SYSOP_END_ABORT);
     }
 
   /* update state */
@@ -3744,15 +3759,26 @@ log_recovery_finish_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 
       if (sysop_start_postpone.sysop_end.type == LOG_SYSOP_END_LOGICAL_RUN_POSTPONE)
 	{
-	  tdes->state = TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE;
-	  LSA_SET_NULL (&tdes->undo_nxlsa);
+	  if (sysop_start_postpone.sysop_end.run_postpone.is_sysop_postpone)
+	    {
+	      /* this is a system op postpone during system op postpone? should not happen! */
+	      assert (false);
+	      tdes->state = TRAN_UNACTIVE_UNILATERALLY_ABORTED;
+	      tdes->undo_nxlsa = tdes->tail_lsa;
+	    }
+	  else
+	    {
+	      /* logical run postpone during transaction postpone. */
+	      tdes->state = TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE;
+	      LSA_SET_NULL (&tdes->undo_nxlsa);
+
+	      /* we just finished the run postpone. update tdes->posp_nxlsa */
+	      tdes->posp_nxlsa = sysop_start_postpone.sysop_end.run_postpone.postpone_lsa;
+	    }
 	}
       else
 	{
-	  assert (sysop_start_postpone.sysop_end.type == LOG_SYSOP_END_COMMIT
-		  || sysop_start_postpone.sysop_end.type == LOG_SYSOP_END_LOGICAL_COMPENSATE
-		  || sysop_start_postpone.sysop_end.type == LOG_SYSOP_END_LOGICAL_UNDO
-		  || sysop_start_postpone.sysop_end.type == LOG_SYSOP_END_LOGICAL_MVCC_UNDO);
+	  assert (sysop_start_postpone.sysop_end.type != LOG_SYSOP_END_ABORT);
 	  tdes->state = TRAN_UNACTIVE_UNILATERALLY_ABORTED;
 	  tdes->undo_nxlsa = tdes->tail_lsa;
 	}

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3750,6 +3750,10 @@ log_recovery_finish_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 	  assert_release (false);
 	  return;
 	}
+      /* check this is not a system op postpone during system op postpone */
+      assert (sysop_start_postpone.sysop_end.type == LOG_SYSOP_END_LOGICAL_RUN_POSTPONE
+	      || !sysop_start_postpone.sysop_end.run_postpone.is_sysop_postpone);
+
       log_sysop_end_recovery_postpone (thread_p, &sysop_start_postpone.sysop_end, undo_data_size, undo_data);
       if (undo_buffer != NULL)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20725

* fix updating tdes.posp_nxlsa when postpone of logical run postpone is recovered.
* do not set log_record->run_postpone.is_sysop_postpone when log_sysop_end_recovery_postpone is called.
* fix log_rv_analysis_sysop_start_postpone  when state is not the expected one.
* fix checking for system op postpone inside system op postpone
