### PR TITLE
[CBRD-20733] file_tracker_reclaim_marked_deleted badly unfixed page l…

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -9700,7 +9700,7 @@ exit:
     {
       pgbuf_unfix (thread_p, page_extdata_next);
     }
-  if (page_extdata != NULL)
+  if (page_extdata != NULL && page_extdata != page_track_head)
     {
       pgbuf_unfix (thread_p, page_extdata);
     }


### PR DESCRIPTION
…atch

http://jira.cubrid.org/browse/CBRD-20733

`page_track_head` unfixed twice. 
