### PR TITLE
[CBRD-20734] fixes file_create to properly return error code

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -3334,7 +3334,7 @@ file_create (THREAD_ENTRY * thread_p, FILE_TYPE file_type,
   page_fhead = pgbuf_fix (thread_p, &vpid_fhead, NEW_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
   if (page_fhead == NULL)
     {
-      ASSERT_ERROR ();
+      ASSERT_ERROR_AND_SET (error_code);
       goto exit;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20734

Thread was interrupted while creating a new file but error was not propagated. 
