### PR TITLE
[CBRD-20735] fixes btree_load_new_page to propagate error

### DIFF
--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -1953,8 +1953,7 @@ end:
       log_sysop_commit (thread_p);
     }
 
-  /* success */
-  return NO_ERROR;
+  return error_code;
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20735

`btree_load_new_page` returned NO_ERROR for error cases.