### PR TITLE
[CBRD-20743] xlocator_fetch: set warning instead of error for non-existent objects

### DIFF
--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -4396,36 +4396,16 @@ tr_drop_trigger_internal (TR_TRIGGER * trigger, int rollback, bool need_savepoin
 	       */
 	      db_drop (trigger->object);
 
-	      /* check whether successfully dropped as follow: - flush, decache, fetch again */
+	      /* 
+	       * flush, decache object; no need to check if the object was indeed deleted;
+	       * it is supposed that the last version of the object was locked and deleted
+	       * because only the last version can be locked; previous versions are in the log 
+	       */
 	      error = locator_flush_instance (trigger->object);
 	      if (error == NO_ERROR)
 		{
 		  ws_decache (trigger->object);
 		  ws_clear_hints (trigger->object, false);
-
-		  /* check temp object is not needed */
-		  if (!OID_ISTEMP (ws_oid (trigger->object)))
-		    {
-		      /* need to fetch dirty version, since the object was previously locked by current transaction. */
-		      error = au_fetch_instance_force (trigger->object, NULL, AU_FETCH_WRITE, LC_FETCH_DIRTY_VERSION);
-		      if (error == NO_ERROR)
-			{
-			  /* 
-			   * The object was not deleted in fact. This is possible when we start delete from intermediary version
-			   * (not the last one). This may happen when another concurrent transaction has updated the trigger before me.
-			   * The current solution may be expensive, but drop trigger is rarely used.
-			   * A better solution would be to get & lock the last version from beginning, not the visible one.
-			   */
-			  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TR_TRIGGER_NOT_FOUND, 1, trigger->name);
-			  error = ER_TR_TRIGGER_NOT_FOUND;
-			}
-		      else if (error == ER_HEAP_UNKNOWN_OBJECT)
-			{
-			  /* clear the error - the object was successfully dropped */
-			  er_clear ();
-			  error = NO_ERROR;
-			}
-		    }
 		}
 	    }
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2470,8 +2470,8 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 	  error_code = ER_HEAP_UNKNOWN_OBJECT;
 	  if (er_errid () != error_code)
 	    {
-	      /* error has not been previously set */
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 3, oid->volid, oid->pageid, oid->slotid);
+	      /* error was not previously set; set error in order to have it returned to client */
+	      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error_code, 3, oid->volid, oid->pageid, oid->slotid);
 	    }
 	  return error_code;
 	}
@@ -2575,9 +2575,8 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 	  error_code = ER_HEAP_UNKNOWN_OBJECT;
 	  if (er_errid () != error_code)
 	    {
-	      /* error was not previously set */
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, oid->volid, oid->pageid,
-		      oid->slotid);
+	      /* error was not previously set; set error in order to have it returned to client */
+	      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error_code, 3, oid->volid, oid->pageid, oid->slotid);
 	    }
 	  goto error;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20743

In this scenario, the error was reached because of the mechanism from **tr_drop_trigger_internal**(). It is supposed to always recheck the existence of the trigger after it is dropped.