### PR TITLE
[CBRD-20731] fixed memory leak issue

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1280,7 +1280,7 @@ static int prm_xasl_cache_max_entries_default = 1000;
 static unsigned int prm_xasl_cache_max_entries_flag = 0;
 
 int PRM_XASL_CACHE_MAX_CLONES = 1000;
-static int prm_xasl_cache_max_clones_default = 0;
+static int prm_xasl_cache_max_clones_default = 1000;
 static int prm_xasl_cache_max_clones_lower = 0;
 static int prm_xasl_cache_max_clones_upper = 2000;
 static unsigned int prm_xasl_cache_max_clones_flag = 0;

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1280,7 +1280,7 @@ static int prm_xasl_cache_max_entries_default = 1000;
 static unsigned int prm_xasl_cache_max_entries_flag = 0;
 
 int PRM_XASL_CACHE_MAX_CLONES = 1000;
-static int prm_xasl_cache_max_clones_default = 1000;
+static int prm_xasl_cache_max_clones_default = 0;
 static int prm_xasl_cache_max_clones_lower = 0;
 static int prm_xasl_cache_max_clones_upper = 2000;
 static unsigned int prm_xasl_cache_max_clones_flag = 0;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20731
Set decache flag to XASL members of the clone. This is needed to avoid memory leak when clears the clone.