### PR TITLE
[CBRD-20696] Correct disk space from createdb message

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -417,7 +417,7 @@ createdb (UTIL_FUNCTION_ARG * arg)
       db_volume_pages = (int) (db_volume_size / db_page_size);
     }
   /* determine volume number of sectors */
-  db_volume_sect = disk_sectors_to_hold_npages (db_volume_pages);
+  db_volume_sect = disk_sectors_to_extend_npages (db_volume_pages);
   /* adjust the number of pages according to the number of sectors */
   db_volume_pages = DISK_SECTOR_NPAGES * db_volume_sect;
 

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -417,7 +417,7 @@ createdb (UTIL_FUNCTION_ARG * arg)
       db_volume_pages = (int) (db_volume_size / db_page_size);
     }
   /* determine volume number of sectors */
-  db_volume_sect = MAX (CEIL_PTVDIV (db_volume_pages, DISK_SECTOR_NPAGES), BOOT_VOLUME_MINSECTS);
+  db_volume_sect = disk_sectors_to_hold_npages (db_volume_pages);
   /* adjust the number of pages according to the number of sectors */
   db_volume_pages = DISK_SECTOR_NPAGES * db_volume_sect;
 

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -316,6 +316,7 @@ createdb (UTIL_FUNCTION_ARG * arg)
   const char *user_define_file_name;
   const char *cubrid_charset;
 
+  int db_volume_sect;
   int db_volume_pages;
   int db_page_size;
   UINT64 db_volume_size;
@@ -415,6 +416,11 @@ createdb (UTIL_FUNCTION_ARG * arg)
     {
       db_volume_pages = (int) (db_volume_size / db_page_size);
     }
+  /* determine volume number of sectors */
+  db_volume_sect = MAX (CEIL_PTVDIV (db_volume_pages, DISK_SECTOR_NPAGES), BOOT_VOLUME_MINSECTS);
+  /* adjust the number of pages according to the number of sectors */
+  db_volume_pages = DISK_SECTOR_NPAGES * db_volume_sect;
+
   db_volume_size = (UINT64) db_volume_pages *(UINT64) db_page_size;
 
   log_page_str = utility_get_option_string_value (arg_map, CREATE_LOG_PAGE_SIZE_S, 0);

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2009,8 +2009,7 @@ disk_add_volume_extension (THREAD_ENTRY * thread_p, DB_VOLPURPOSE purpose, DKNPA
   ext_info.overwrite = overwrite;
 
   /* compute total/max sectors. we always keep a rounded number of sectors. */
-  ext_info.nsect_total = CEIL_PTVDIV (npages, DISK_SECTOR_NPAGES);
-  ext_info.nsect_total = DISK_SECTS_ROUND_UP (ext_info.nsect_total);
+  ext_info.nsect_total = disk_sectors_to_hold_npages ((const) npages);
   ext_info.nsect_max = ext_info.nsect_total;
   ext_info.max_npages = npages;	/* this is obsolete. I set it just to see it if a crash occurs. */
 
@@ -4502,8 +4501,7 @@ disk_format_first_volume (THREAD_ENTRY * thread_p, const char *full_dbname, cons
 
   ext_info.name = full_dbname;
   ext_info.comments = dbcomments;
-  ext_info.nsect_total = CEIL_PTVDIV (npages, DISK_SECTOR_NPAGES);
-  ext_info.nsect_total = DISK_SECTS_ROUND_UP (ext_info.nsect_total);
+  ext_info.nsect_total = disk_sectors_to_hold_npages (npages);
   ext_info.nsect_max = ext_info.nsect_total;
   ext_info.max_writesize_in_sec = 0;
   ext_info.overwrite = false;
@@ -5925,6 +5923,18 @@ disk_volheader_check_magic (THREAD_ENTRY * thread_p, const PAGE_PTR page_volhead
   assert (strncmp (volheader->magic, CUBRID_MAGIC_DATABASE_VOLUME, CUBRID_MAGIC_MAX_LENGTH) == 0);
 }
 #endif /* !NDEBUG */
+
+/*
+ * disk_sectors_to_hold_npages () - compute the number of sectors necessary to hold a number of pages 
+ *
+ * return	  : The number of sectors 
+ * num_pages (in) : required number of pages
+ **/
+int
+disk_sectors_to_hold_npages (const int num_pages)
+{
+  return DISK_SECTS_ROUND_UP (DISK_PAGES_TO_SECTS (num_pages));
+}
 
 /************************************************************************/
 /* End of file                                                          */

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2009,7 +2009,7 @@ disk_add_volume_extension (THREAD_ENTRY * thread_p, DB_VOLPURPOSE purpose, DKNPA
   ext_info.overwrite = overwrite;
 
   /* compute total/max sectors. we always keep a rounded number of sectors. */
-  ext_info.nsect_total = disk_sectors_to_hold_npages ((const) npages);
+  ext_info.nsect_total = disk_sectors_to_extend_npages ((const) npages);
   ext_info.nsect_max = ext_info.nsect_total;
   ext_info.max_npages = npages;	/* this is obsolete. I set it just to see it if a crash occurs. */
 
@@ -4501,7 +4501,7 @@ disk_format_first_volume (THREAD_ENTRY * thread_p, const char *full_dbname, cons
 
   ext_info.name = full_dbname;
   ext_info.comments = dbcomments;
-  ext_info.nsect_total = disk_sectors_to_hold_npages (npages);
+  ext_info.nsect_total = disk_sectors_to_extend_npages (npages);
   ext_info.nsect_max = ext_info.nsect_total;
   ext_info.max_writesize_in_sec = 0;
   ext_info.overwrite = false;
@@ -5925,13 +5925,13 @@ disk_volheader_check_magic (THREAD_ENTRY * thread_p, const PAGE_PTR page_volhead
 #endif /* !NDEBUG */
 
 /*
- * disk_sectors_to_hold_npages () - compute the number of sectors necessary to hold a number of pages 
+ * disk_sectors_to_extend_npages () - compute the rounded number of sectors necessary to extend a number of pages 
  *
  * return	  : The number of sectors 
  * num_pages (in) : required number of pages
  **/
 int
-disk_sectors_to_hold_npages (const int num_pages)
+disk_sectors_to_extend_npages (const int num_pages)
 {
   return DISK_SECTS_ROUND_UP (DISK_PAGES_TO_SECTS (num_pages));
 }

--- a/src/storage/disk_manager.h
+++ b/src/storage/disk_manager.h
@@ -233,6 +233,6 @@ extern int disk_rv_volhead_extend_redo (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern void disk_volheader_check_magic (THREAD_ENTRY * thread_p, const PAGE_PTR page_volheader);
 #endif /* !NDEBUG */
 
-extern int disk_sectors_to_hold_npages (const int num_pages);
+extern int disk_sectors_to_extend_npages (const int num_pages);
 
 #endif /* _DISK_MANAGER_H_ */

--- a/src/storage/disk_manager.h
+++ b/src/storage/disk_manager.h
@@ -145,6 +145,7 @@ struct vol_space_info
 
 #define DISK_SECTS_SIZE(nsects)  ((INT64) nsects * IO_SECTORSIZE)
 #define DISK_SECTS_NPAGES(nsects) (nsects * DISK_SECTOR_NPAGES)
+#define DISK_PAGES_TO_SECTS(npages) (CEIL_PTVDIV (npages, DISK_SECTOR_NPAGES))
 
 /* structure used to clone disk sector bitmaps to cross check against file tables */
 typedef struct disk_volmap_clone DISK_VOLMAP_CLONE;
@@ -231,5 +232,7 @@ extern int disk_rv_volhead_extend_redo (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 #if !defined (NDEBUG)
 extern void disk_volheader_check_magic (THREAD_ENTRY * thread_p, const PAGE_PTR page_volheader);
 #endif /* !NDEBUG */
+
+extern int disk_sectors_to_hold_npages (const int num_pages);
 
 #endif /* _DISK_MANAGER_H_ */

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -157,6 +157,7 @@ struct log_lsa
 /*
  * Sector
  */
+#define BOOT_VOLUME_MINSECTS 64
 /* Number of pages in a sector. Careful about changing this size. The whole file manager depends on this size. */
 #define DISK_SECTOR_NPAGES 64
 #define IO_SECTORSIZE           (DISK_SECTOR_NPAGES * IO_PAGESIZE)

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -157,7 +157,6 @@ struct log_lsa
 /*
  * Sector
  */
-#define BOOT_VOLUME_MINSECTS 64
 /* Number of pages in a sector. Careful about changing this size. The whole file manager depends on this size. */
 #define DISK_SECTOR_NPAGES 64
 #define IO_SECTORSIZE           (DISK_SECTOR_NPAGES * IO_PAGESIZE)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -511,31 +511,6 @@ boot_get_lob_path (void)
 }
 
 /*
- * bo_maxpages_for_newvol () - find max pages that can be used to define a new
- *                             volume at given location
- *
- * return : max pages
- *
- * Note: Find the maximum number of pages that are accepted to safetly
- *       automatically create a volume extension or a temporary volume
- *       at the given location.
- */
-DKNPAGES
-boot_max_pages_new_volume (void)
-{
-  int nfree_pages;
-
-  nfree_pages = (fileio_get_number_of_partition_free_pages (boot_Db_full_name, IO_PAGESIZE)
-		 - BOOT_LEAVE_SAFE_OSDISK_PARTITION_FREE_SPACE);
-  if (nfree_pages < 0)
-    {
-      nfree_pages = 0;
-    }
-
-  return (DKNPAGES) nfree_pages;
-}
-
-/*
  * boot_remove_temp_volume () - remove a volume from the database
  *
  * return : NO_ERROR if all OK, ER_ status otherwise
@@ -1173,55 +1148,6 @@ boot_remove_unknown_temp_volumes (THREAD_ENTRY * thread_p)
     {
       free_and_init (alloc_tempath);
     }
-}
-
-/*
- * boot_max_pages_for_new_auto_volume_extension () - find max pages that can
- *                                                   be allocated for an
- *                                                   automatic volume extension
- *
- * return : max pages
- *
- * Note: Find the maximum number of pages that are accepted to safetly
- *       automatically create a volume extension.
- */
-DKNPAGES
-boot_max_pages_for_new_auto_volume_extension (void)
-{
-  char vol_fullname[PATH_MAX];
-  const char *ext_path;
-  const char *ext_name;
-  char *alloc_extpath = NULL;
-  DKNPAGES npages;
-
-  /* 
-   * Get the name of the extension: ext_path|dbname|"ext"|volid
-   */
-
-  /* Use the directory where the primary volume is located */
-  alloc_extpath = (char *) malloc (strlen (boot_Db_full_name) + 1);
-  if (alloc_extpath == NULL)
-    {
-      return 0;
-    }
-  ext_path = fileio_get_directory_path (alloc_extpath, boot_Db_full_name);
-  if (ext_path == NULL)
-    {
-      alloc_extpath[0] = '\0';
-      ext_path = alloc_extpath;
-    }
-
-  ext_name = fileio_get_base_file_name (boot_Db_full_name);
-  fileio_make_volume_ext_name (vol_fullname, ext_path, ext_name, 1);
-
-  npages = fileio_get_number_of_partition_free_pages (vol_fullname, IO_PAGESIZE);
-
-  if (alloc_extpath)
-    {
-      free_and_init (alloc_extpath);
-    }
-
-  return npages;
 }
 
 /*

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1038,24 +1038,6 @@ boot_parse_add_volume_extensions (THREAD_ENTRY * thread_p, const char *filename_
 }
 
 /*
- * boot_get_temp_temp_vol_max_npages
- *   a default temp temp volume grows up to 20G
- *   when prm_get_integer_value (PRM_ID_BOSR_MAXTMP_PAGES) is not specified.
- */
-DKNPAGES
-boot_get_temp_temp_vol_max_npages (void)
-{
-  if (prm_get_integer_value (PRM_ID_BOSR_MAXTMP_PAGES) < 0)
-    {
-      return (DKNPAGES) (((20LL * 1024LL * 1024LL * 1024LL) / IO_PAGESIZE));
-    }
-  else
-    {
-      return prm_get_integer_value (PRM_ID_BOSR_MAXTMP_PAGES);
-    }
-}
-
-/*
  * boot_remove_all_temp_volumes () - remove all temporary volumes from the database
  *
  * return :NO_ERROR if all OK, ER_ status otherwise

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -115,7 +115,6 @@
   (1250 * (IO_DEFAULT_PAGE_SIZE / IO_PAGESIZE))	/* 5 Mbytes */
 
 static const int BOOT_VOLUME_MINPAGES = 50;
-static const int BOOT_VOLUME_MINSECTS = 64;	/* find a common place to set this */
 #define BOOT_FORMAT_MAX_LENGTH	500
 #define BOOTSR_MAX_LINE	 500
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -114,7 +114,6 @@
 #define BOOT_LEAVE_SAFE_OSDISK_PARTITION_FREE_SPACE  \
   (1250 * (IO_DEFAULT_PAGE_SIZE / IO_PAGESIZE))	/* 5 Mbytes */
 
-static const int BOOT_VOLUME_MINPAGES = 50;
 #define BOOT_FORMAT_MAX_LENGTH	500
 #define BOOTSR_MAX_LINE	 500
 
@@ -1238,79 +1237,6 @@ boot_max_pages_for_new_auto_volume_extension (void)
   if (alloc_extpath)
     {
       free_and_init (alloc_extpath);
-    }
-
-  return npages;
-}
-
-/*
- * boot_max_pages_for_new_temp_volume () - find max pages that can be allocated for a
- *                                  temporary volume
- *
- * return : max pages
- *
- * NOTGE: Find the maximum number of pages that are accepted to safetly
- *              automatically create a temporary volume.
- */
-DKNPAGES
-boot_max_pages_for_new_temp_volume (void)
-{
-  char temp_vol_fullname[PATH_MAX];
-  const char *temp_path;
-  const char *temp_name;
-  char *alloc_tempath = NULL;
-  DKNPAGES npages;
-
-  if (boot_Temp_volumes_max_sects == -2)
-    {
-      /* 
-       * Get the maximum number of temporary pages that can be allocated for
-       * all temporary volumes
-       */
-      boot_Temp_volumes_max_sects = prm_get_integer_value (PRM_ID_BOSR_MAXTMP_PAGES);
-      if (boot_Temp_volumes_max_sects < 0)
-	{
-	  boot_Temp_volumes_max_sects = -1;	/* Infinite, until out of disk space */
-	}
-      else
-	{
-	  if (boot_Temp_volumes_max_sects < BOOT_VOLUME_MINPAGES)
-	    {
-	      boot_Temp_volumes_max_sects = 0;	/* Don't allocate any temp space */
-	    }
-	}
-    }
-
-  /* 
-   * Get the name of the extension: ext_path|dbname|"ext"|volid
-   */
-
-  /* Use the directory where the primary volume is located */
-  alloc_tempath = (char *) malloc (strlen (boot_Db_full_name) + 1);
-  if (alloc_tempath == NULL)
-    {
-      return NULL_VOLID;
-    }
-  temp_path = fileio_get_directory_path (alloc_tempath, boot_Db_full_name);
-  if (temp_path == NULL)
-    {
-      alloc_tempath[0] = '\0';
-      temp_path = alloc_tempath;
-    }
-
-  temp_name = fileio_get_base_file_name (boot_Db_full_name);
-  fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, LOG_MAX_DBVOLID);
-
-  npages = fileio_get_number_of_partition_free_pages (temp_vol_fullname, IO_PAGESIZE);
-
-  if (boot_Temp_volumes_max_sects >= 0 && npages > (boot_Temp_volumes_max_sects - boot_Temp_volumes_tpgs))
-    {
-      npages = boot_Temp_volumes_max_sects - boot_Temp_volumes_tpgs;
-    }
-
-  if (alloc_tempath)
-    {
-      free_and_init (alloc_tempath);
     }
 
   return npages;

--- a/src/transaction/boot_sr.h
+++ b/src/transaction/boot_sr.h
@@ -103,7 +103,6 @@ extern VOLID boot_find_next_permanent_volid (THREAD_ENTRY * thread_p);
 extern int boot_reset_db_parm (THREAD_ENTRY * thread_p);
 extern DKNPAGES boot_max_pages_new_volume (void);
 extern DKNPAGES boot_max_pages_for_new_auto_volume_extension (void);
-extern DKNPAGES boot_max_pages_for_new_temp_volume (void);
 extern DKNPAGES boot_get_temp_temp_vol_max_npages (void);	/* todo: remove me */
 
 extern int boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db_name, bool from_backup,

--- a/src/transaction/boot_sr.h
+++ b/src/transaction/boot_sr.h
@@ -103,7 +103,6 @@ extern VOLID boot_find_next_permanent_volid (THREAD_ENTRY * thread_p);
 extern int boot_reset_db_parm (THREAD_ENTRY * thread_p);
 extern DKNPAGES boot_max_pages_new_volume (void);
 extern DKNPAGES boot_max_pages_for_new_auto_volume_extension (void);
-extern DKNPAGES boot_get_temp_temp_vol_max_npages (void);	/* todo: remove me */
 
 extern int boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db_name, bool from_backup,
 				CHECK_ARGS * check_coll_and_timezone, BO_RESTART_ARG * r_args);

--- a/src/transaction/boot_sr.h
+++ b/src/transaction/boot_sr.h
@@ -101,8 +101,6 @@ int boot_find_root_heap (HFID * root_hfid_p);
 
 extern VOLID boot_find_next_permanent_volid (THREAD_ENTRY * thread_p);
 extern int boot_reset_db_parm (THREAD_ENTRY * thread_p);
-extern DKNPAGES boot_max_pages_new_volume (void);
-extern DKNPAGES boot_max_pages_for_new_auto_volume_extension (void);
 
 extern int boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db_name, bool from_backup,
 				CHECK_ARGS * check_coll_and_timezone, BO_RESTART_ARG * r_args);


### PR DESCRIPTION
The database volume size from createdb mesage was set to its real value, according to the minimum number of sectors and the number of  pages  per sector.