### PR TITLE
[CBRD-20719] fixed incr on partition

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1280,7 +1280,7 @@ static int prm_xasl_cache_max_entries_default = 1000;
 static unsigned int prm_xasl_cache_max_entries_flag = 0;
 
 int PRM_XASL_CACHE_MAX_CLONES = 1000;
-static int prm_xasl_cache_max_clones_default = 0;
+static int prm_xasl_cache_max_clones_default = 1000;
 static int prm_xasl_cache_max_clones_lower = 0;
 static int prm_xasl_cache_max_clones_upper = 2000;
 static unsigned int prm_xasl_cache_max_clones_flag = 0;

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1280,7 +1280,7 @@ static int prm_xasl_cache_max_entries_default = 1000;
 static unsigned int prm_xasl_cache_max_entries_flag = 0;
 
 int PRM_XASL_CACHE_MAX_CLONES = 1000;
-static int prm_xasl_cache_max_clones_default = 1000;
+static int prm_xasl_cache_max_clones_default = 0;
 static int prm_xasl_cache_max_clones_lower = 0;
 static int prm_xasl_cache_max_clones_upper = 2000;
 static unsigned int prm_xasl_cache_max_clones_flag = 0;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1722,6 +1722,7 @@ qexec_clear_access_spec_list (XASL_NODE * xasl_p, THREAD_ENTRY * thread_p, ACCES
 	  db_private_free (thread_p, p->parts);
 	  p->parts = NULL;
 	  p->curent = NULL;
+	  p->pruned = false;
 	}
 
       if (XASL_IS_FLAGED (xasl_p, XASL_DECACHE_CLONE))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20719
Set partition pruning as false when clear access spec type. This is needed to perform partition pruning, next time when reuse the clone.