### PR TITLE
[CBRD-20748] fix freeing query temporary files considering holdable/preserved

### DIFF
--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -323,6 +323,7 @@ qmgr_allocate_query_entry (THREAD_ENTRY * thread_p, QMGR_TRAN_ENTRY * tran_entry
   query_p->er_msg = NULL;
   query_p->query_flag = 0;
   query_p->is_holdable = false;
+  query_p->is_preserved = false;
 
   return query_p;
 }
@@ -2790,7 +2791,7 @@ qmgr_free_query_temp_file_helper (THREAD_ENTRY * thread_p, QMGR_QUERY_ENTRY * qu
       tfile_vfid_p = query_p->temp_vfid;
       tfile_vfid_p->prev->next = NULL;
 
-      rc = qmgr_free_temp_file_list (thread_p, tfile_vfid_p, query_p->query_id, is_error, query_p->is_holdable);
+      rc = qmgr_free_temp_file_list (thread_p, tfile_vfid_p, query_p->query_id, is_error, query_p->is_preserved);
 
       query_p->temp_vfid = NULL;
     }

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -2790,7 +2790,7 @@ qmgr_free_query_temp_file_helper (THREAD_ENTRY * thread_p, QMGR_QUERY_ENTRY * qu
       tfile_vfid_p = query_p->temp_vfid;
       tfile_vfid_p->prev->next = NULL;
 
-      rc = qmgr_free_temp_file_list (thread_p, tfile_vfid_p, query_p->query_id, is_error, false);
+      rc = qmgr_free_temp_file_list (thread_p, tfile_vfid_p, query_p->query_id, is_error, query_p->is_holdable);
 
       query_p->temp_vfid = NULL;
     }

--- a/src/query/query_manager.h
+++ b/src/query/query_manager.h
@@ -126,6 +126,7 @@ struct qmgr_query_entry
   QMGR_QUERY_STATUS query_status;
   QUERY_FLAG query_flag;
   bool is_holdable;		/* true if this query should be available */
+  bool is_preserved;		/* true if query was preserved in session, false otherwise. */
 };
 
 extern QMGR_QUERY_ENTRY *qmgr_get_query_entry (THREAD_ENTRY * thread_p, QUERY_ID query_id, int trans_ind);

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -2386,22 +2386,6 @@ sentry_to_qentry (const SESSION_QUERY_ENTRY * sentry_p, QMGR_QUERY_ENTRY * qentr
   qentry_p->xasl_ent = NULL;
   qentry_p->er_msg = NULL;
   qentry_p->is_holdable = true;
-
-  if (qentry_p->temp_vfid)
-    {
-      /* when files were preserved, they were removed from transaction list of temporary files. we need to add them
-       * back to make sure they are never leaked. */
-      QMGR_TEMP_FILE *iter_temp_file;
-      THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
-
-      for (iter_temp_file = qentry_p->temp_vfid; iter_temp_file != NULL; iter_temp_file = iter_temp_file->next)
-	{
-	  if (!VFID_ISNULL (&iter_temp_file->temp_vfid))
-	    {
-	      (void) file_temp_save_tran_file (thread_p, &iter_temp_file->temp_vfid, iter_temp_file->temp_file_type);
-	    }
-	}
-    }
 }
 
 /*

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -2386,6 +2386,7 @@ sentry_to_qentry (const SESSION_QUERY_ENTRY * sentry_p, QMGR_QUERY_ENTRY * qentr
   qentry_p->xasl_ent = NULL;
   qentry_p->er_msg = NULL;
   qentry_p->is_holdable = true;
+  qentry_p->is_preserved = true;
 }
 
 /*

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -8810,40 +8810,6 @@ file_tempcache_push_tran_file (THREAD_ENTRY * thread_p, FILE_TEMPCACHE_ENTRY * e
 }
 
 /*
- * file_temp_save_tran_file () - cache temporary file in transaction list
- *
- * return         : error code
- * thread_p (in)  : thread entry
- * vfid (in)      : file identifier
- * file_type (in) : file type
- */
-int
-file_temp_save_tran_file (THREAD_ENTRY * thread_p, const VFID * vfid, FILE_TYPE file_type)
-{
-  FILE_TEMPCACHE_ENTRY *entry = NULL;
-  int error_code = NO_ERROR;
-
-  assert (vfid != NULL && !VFID_ISNULL (vfid));
-  file_tempcache_lock ();
-  error_code = file_tempcache_alloc_entry (&entry);
-  file_tempcache_unlock ();
-  if (error_code != NO_ERROR)
-    {
-      ASSERT_ERROR ();
-      return error_code;
-    }
-  if (entry == NULL)
-    {
-      assert_release (false);
-      return ER_FAILED;
-    }
-  entry->vfid = *vfid;
-  entry->ftype = file_type;
-  file_tempcache_push_tran_file (thread_p, entry);
-  return NO_ERROR;
-}
-
-/*
  * file_get_tran_num_temp_files () - returns the number of temp file entries of the given transaction
  *
  * return        : the number of temp files of the given transaction

--- a/src/storage/file_manager.h
+++ b/src/storage/file_manager.h
@@ -183,7 +183,6 @@ extern int file_numerable_truncate (THREAD_ENTRY * thread_p, const VFID * vfid, 
 extern void file_tempcache_drop_tran_temp_files (THREAD_ENTRY * thread_p);
 
 extern void file_temp_preserve (THREAD_ENTRY * thread_p, const VFID * vfid);
-extern int file_temp_save_tran_file (THREAD_ENTRY * thread_p, const VFID * vfid, FILE_TYPE file_type);
 extern int file_get_tran_num_temp_files (THREAD_ENTRY * thread_p);
 
 extern int file_tracker_create (THREAD_ENTRY * thread_p, VFID * vfid_tracker_out);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20748

Remove file_temp_save_tran_file, it was incorrectly used.

When calling qmgr_free_query_temp_file_helper, we should consider that holdable queries were preserved.