### PR TITLE
[CBRD-20766] fixed crash caused by clear compressed string

### DIFF
--- a/src/query/cursor.c
+++ b/src/query/cursor.c
@@ -130,6 +130,7 @@ cursor_copy_list_id (QFILE_LIST_ID * dest_list_id_p, const QFILE_LIST_ID * src_l
     }
 
   dest_list_id_p->tpl_descr.f_valp = NULL;
+  dest_list_id_p->tpl_descr.clear_f_val_at_clone_decache = NULL;
   dest_list_id_p->sort_list = NULL;	/* never use sort_list in crs_ level */
 
   if (src_list_id_p->last_pgptr)
@@ -161,6 +162,10 @@ cursor_free_list_id (QFILE_LIST_ID * list_id_p, bool self)
   if (list_id_p->tpl_descr.f_valp)
     {
       free_and_init (list_id_p->tpl_descr.f_valp);
+    }
+  if (list_id_p->tpl_descr.clear_f_val_at_clone_decache)
+    {
+      free_and_init (list_id_p->tpl_descr.clear_f_val_at_clone_decache);
     }
   if (list_id_p->sort_list)
     {

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -321,6 +321,7 @@ qfile_modify_type_list (QFILE_TUPLE_VALUE_TYPE_LIST * type_list_p, QFILE_LIST_ID
     }
 
   list_id_p->tpl_descr.f_valp = NULL;
+  list_id_p->tpl_descr.clear_f_val_at_clone_decache = NULL;
   return NO_ERROR;
 }
 
@@ -442,6 +443,11 @@ qfile_clear_list_id (QFILE_LIST_ID * list_id_p)
   if (list_id_p->tpl_descr.f_valp)
     {
       free_and_init (list_id_p->tpl_descr.f_valp);
+    }
+
+  if (list_id_p->tpl_descr.clear_f_val_at_clone_decache)
+    {
+      free_and_init (list_id_p->tpl_descr.clear_f_val_at_clone_decache);
     }
 
   if (list_id_p->sort_list)
@@ -1506,7 +1512,9 @@ qfile_save_normal_tuple (QFILE_TUPLE_DESCRIPTOR * tuple_descr_p, char *tuple_p, 
 
   for (i = 0; i < tuple_descr_p->f_cnt; i++)
     {
-      if (qdata_copy_db_value_to_tuple_value (tuple_descr_p->f_valp[i], tuple_p, &tuple_value_size) != NO_ERROR)
+      if (qdata_copy_db_value_to_tuple_value (tuple_descr_p->f_valp[i],
+					      !(tuple_descr_p->clear_f_val_at_clone_decache[i]),
+					      tuple_p, &tuple_value_size) != NO_ERROR)
 	{
 	  return ER_FAILED;
 	}
@@ -2767,7 +2775,8 @@ qfile_copy_tuple_descr_to_tuple (THREAD_ENTRY * thread_p, QFILE_TUPLE_DESCRIPTOR
   /* build tuple */
   for (i = 0; i < tpl_descr->f_cnt; i++)
     {
-      if (qdata_copy_db_value_to_tuple_value (tpl_descr->f_valp[i], tuple_p, &size) != NO_ERROR)
+      if (qdata_copy_db_value_to_tuple_value (tpl_descr->f_valp[i], !(tpl_descr->clear_f_val_at_clone_decache[i]),
+					      tuple_p, &size) != NO_ERROR)
 	{
 	  /* error has already been set */
 	  db_private_free_and_init (thread_p, tplrec->tpl);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -904,6 +904,7 @@ qexec_generate_tuple_descriptor (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
 {
   QPROC_TPLDESCR_STATUS status;
   size_t size;
+  int i;
 
   status = QPROC_TPLDESCR_FAILURE;	/* init */
 
@@ -917,6 +918,19 @@ qexec_generate_tuple_descriptor (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, size);
 	  goto exit_on_error;
+	}
+
+      size = list_id->type_list.type_cnt * sizeof (bool);
+      list_id->tpl_descr.clear_f_val_at_clone_decache = (bool *) malloc (size);
+      if (list_id->tpl_descr.clear_f_val_at_clone_decache == NULL)
+	{
+	  free_and_init (list_id->tpl_descr.f_valp);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, size);
+	  goto exit_on_error;
+	}
+      for (i = 0; i < list_id->type_list.type_cnt; i++)
+	{
+	  list_id->tpl_descr.clear_f_val_at_clone_decache[i] = false;
 	}
     }
 
@@ -2784,7 +2798,7 @@ qexec_ordby_put_next (THREAD_ENTRY * thread_p, const RECDES * recdes, void *arg)
 		  for (i = 0; ordby_info && i < ordby_info->ordbynum_pos_cnt; i++)
 		    {
 		      QFILE_GET_TUPLE_VALUE_HEADER_POSITION (data, ordby_info->ordbynum_pos[i], tvalhp);
-		      (void) qdata_copy_db_value_to_tuple_value (ordby_info->ordbynum_val, tvalhp, &tval_size);
+		      (void) qdata_copy_db_value_to_tuple_value (ordby_info->ordbynum_val, true, tvalhp, &tval_size);
 		    }
 
 		  error = qfile_add_tuple_to_list (thread_p, info->output_file, data);
@@ -2806,7 +2820,8 @@ qexec_ordby_put_next (THREAD_ENTRY * thread_p, const RECDES * recdes, void *arg)
 		      for (i = 0; ordby_info && i < ordby_info->ordbynum_pos_cnt; i++)
 			{
 			  QFILE_GET_TUPLE_VALUE_HEADER_POSITION (data, ordby_info->ordbynum_pos[i], tvalhp);
-			  (void) qdata_copy_db_value_to_tuple_value (ordby_info->ordbynum_val, tvalhp, &tval_size);
+			  (void) qdata_copy_db_value_to_tuple_value (ordby_info->ordbynum_val, true, tvalhp,
+								     &tval_size);
 			}
 		      error = qfile_add_tuple_to_list (thread_p, info->output_file, data);
 		      db_private_free_and_init (thread_p, tplrec.tpl);
@@ -2837,7 +2852,7 @@ qexec_ordby_put_next (THREAD_ENTRY * thread_p, const RECDES * recdes, void *arg)
 		  for (i = 0; ordby_info && i < ordby_info->ordbynum_pos_cnt; i++)
 		    {
 		      QFILE_GET_TUPLE_VALUE_HEADER_POSITION (data, ordby_info->ordbynum_pos[i], tvalhp);
-		      (void) qdata_copy_db_value_to_tuple_value (ordby_info->ordbynum_val, tvalhp, &tval_size);
+		      (void) qdata_copy_db_value_to_tuple_value (ordby_info->ordbynum_val, true, tvalhp, &tval_size);
 		    }
 		  error = qfile_add_tuple_to_list (thread_p, info->output_file, data);
 		}
@@ -18863,6 +18878,16 @@ qexec_initialize_analytic_function_state (THREAD_ENTRY * thread_p, ANALYTIC_FUNC
   func_state->group_list_id->tpl_descr.f_valp[0] = &func_state->cgtc_dbval;
   func_state->group_list_id->tpl_descr.f_valp[1] = &func_state->cgtc_nn_dbval;
 
+  func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache = (bool *) malloc (sizeof (bool) * 2);
+  if (func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache == NULL)
+    {
+      free_and_init (func_state->group_list_id->tpl_descr.f_valp);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (bool) * 2);
+      return ER_FAILED;
+    }
+  func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache[0] =
+    func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache[1] = false;
+
   /* initialize group value listfile */
   value_type_list.type_cnt = 2;
   value_type_list.domp = (TP_DOMAIN **) db_private_alloc (thread_p, sizeof (TP_DOMAIN *) * 2);
@@ -18887,6 +18912,16 @@ qexec_initialize_analytic_function_state (THREAD_ENTRY * thread_p, ANALYTIC_FUNC
     }
   func_state->value_list_id->tpl_descr.f_valp[0] = &func_state->csktc_dbval;
   func_state->value_list_id->tpl_descr.f_valp[1] = func_p->value;
+
+  func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache = (bool *) malloc (sizeof (bool) * 2);
+  if (func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache == NULL)
+    {
+      free_and_init (func_state->group_list_id->tpl_descr.f_valp);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (bool) * 2);
+      return ER_FAILED;
+    }
+  func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache[0] =
+    func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache[1] = false;
 
   return NO_ERROR;
 }
@@ -23473,7 +23508,21 @@ qexec_topn_tuples_to_list_id (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_ST
 	  error = ER_FAILED;
 	  goto cleanup;
 	}
+
+      tpl_descr->clear_f_val_at_clone_decache = (bool *) malloc (sizeof (bool) * values_count);
+      if (tpl_descr->clear_f_val_at_clone_decache == NULL)
+	{
+	  free_and_init (tpl_descr->f_valp);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (bool) * values_count);
+	  goto cleanup;
+	}
+
+      for (i = 0; i < values_count; i++)
+	{
+	  tpl_descr->clear_f_val_at_clone_decache[i] = false;
+	}
     }
+
   varp = xasl->outptr_list->valptrp;
   for (row = 0; row < heap->element_count; row++)
     {
@@ -23923,7 +23972,7 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
   QFILE_TUPLE_VALUE_TYPE_LIST type_list;
   REGU_VARIABLE_LIST regu_list;
   AGGREGATE_TYPE *agg_list;
-  int value_count = 0, i = 0;
+  int value_count = 0, i = 0, error_code = NO_ERROR;
 
   if (!proc->g_hash_eligible)
     {
@@ -23956,7 +24005,7 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
 		  sizeof (DB_VALUE) * proc->g_func_count);
-	  return ER_FAILED;
+	  goto exit_on_error;
 	}
     }
 
@@ -23968,7 +24017,7 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
   if (proc->agg_hash_context.key_domains == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (TP_DOMAIN *) * proc->g_hkey_size);
-      return ER_FAILED;
+      goto exit_on_error;
     }
 
   regu_list = proc->g_hk_scan_regu_list;
@@ -23991,7 +24040,7 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
 		  sizeof (AGGREGATE_ACCUMULATOR_DOMAIN *) * proc->g_func_count);
-	  return ER_FAILED;
+	  goto exit_on_error;
 	}
 
       agg_list = proc->g_agg_list;
@@ -24012,7 +24061,7 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
   if (type_list.domp == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (TP_DOMAIN *) * type_list.type_cnt);
-      return ER_FAILED;
+      goto exit_on_error;
     }
 
   /* register key domains */
@@ -24049,10 +24098,42 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
   /* create tuple descriptor for partial list files */
   proc->agg_hash_context.part_list_id->tpl_descr.f_cnt = type_list.type_cnt;
   proc->agg_hash_context.part_list_id->tpl_descr.f_valp = (DB_VALUE **) malloc (sizeof (DB_VALUE) * type_list.type_cnt);
+  if (proc->agg_hash_context.part_list_id->tpl_descr.f_valp = NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DB_VALUE) * type_list.type_cnt);
+      goto exit_on_error;
+    }
+  proc->agg_hash_context.part_list_id->tpl_descr.clear_f_val_at_clone_decache =
+    (bool *) malloc (sizeof (bool) * type_list.type_cnt);
+  if (proc->agg_hash_context.part_list_id->tpl_descr.clear_f_val_at_clone_decache == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (bool) * type_list.type_cnt);
+      goto exit_on_error;
+    }
+  for (i = 0; i < type_list.type_cnt; i++)
+    {
+      proc->agg_hash_context.part_list_id->tpl_descr.clear_f_val_at_clone_decache[i] = false;
+    }
 
   proc->agg_hash_context.sorted_part_list_id->tpl_descr.f_cnt = type_list.type_cnt;
   proc->agg_hash_context.sorted_part_list_id->tpl_descr.f_valp =
     (DB_VALUE **) malloc (sizeof (DB_VALUE) * type_list.type_cnt);
+  if (proc->agg_hash_context.sorted_part_list_id->tpl_descr.f_valp == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DB_VALUE) * type_list.type_cnt);
+      goto exit_on_error;
+    }
+  proc->agg_hash_context.sorted_part_list_id->tpl_descr.clear_f_val_at_clone_decache =
+    (bool *) malloc (sizeof (bool) * type_list.type_cnt);
+  if (proc->agg_hash_context.sorted_part_list_id->tpl_descr.clear_f_val_at_clone_decache == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (bool) * type_list.type_cnt);
+      goto exit_on_error;
+    }
+  for (i = 0; i < type_list.type_cnt; i++)
+    {
+      proc->agg_hash_context.sorted_part_list_id->tpl_descr.clear_f_val_at_clone_decache[i] = false;
+    }
 
   /* initialize scan; this way we can call qfile_close_scan on an unopened scan without repercussions */
   proc->agg_hash_context.part_scan_id.status = S_CLOSED;
@@ -24067,7 +24148,7 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
     mht_create ("Hash aggregate evaluation", HASH_AGGREGATE_DEFAULT_TABLE_SIZE, qdata_hash_agg_hkey, qdata_agg_hkey_eq);
   if (proc->agg_hash_context.hash_table == NULL)
     {
-      return ER_FAILED;
+      goto exit_on_error;
     }
   else
     {
@@ -24085,7 +24166,7 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
   if (proc->agg_hash_context.temp_key == NULL || proc->agg_hash_context.temp_part_key == NULL
       || proc->agg_hash_context.curr_part_key == NULL)
     {
-      return ER_FAILED;
+      goto exit_on_error;
     }
 
   /* 
@@ -24096,7 +24177,7 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
 
   if (proc->agg_hash_context.temp_part_value == NULL || proc->agg_hash_context.curr_part_value == NULL)
     {
-      return ER_FAILED;
+      goto exit_on_error;
     }
 
   /* 
@@ -24124,6 +24205,11 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
 
   /* all ok */
   return NO_ERROR;
+
+exit_on_error:
+
+  qexec_free_agg_hash_context (thread_p, proc);
+  return (error_code == NO_ERROR && (error_code = er_errid ()) == NO_ERROR) ? ER_FAILED : error_code;
 }
 
 /*

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -924,7 +924,6 @@ qexec_generate_tuple_descriptor (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
       list_id->tpl_descr.clear_f_val_at_clone_decache = (bool *) malloc (size);
       if (list_id->tpl_descr.clear_f_val_at_clone_decache == NULL)
 	{
-	  free_and_init (list_id->tpl_descr.f_valp);
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, size);
 	  goto exit_on_error;
 	}
@@ -18881,7 +18880,6 @@ qexec_initialize_analytic_function_state (THREAD_ENTRY * thread_p, ANALYTIC_FUNC
   func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache = (bool *) malloc (sizeof (bool) * 2);
   if (func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache == NULL)
     {
-      free_and_init (func_state->group_list_id->tpl_descr.f_valp);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (bool) * 2);
       return ER_FAILED;
     }
@@ -18916,7 +18914,6 @@ qexec_initialize_analytic_function_state (THREAD_ENTRY * thread_p, ANALYTIC_FUNC
   func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache = (bool *) malloc (sizeof (bool) * 2);
   if (func_state->group_list_id->tpl_descr.clear_f_val_at_clone_decache == NULL)
     {
-      free_and_init (func_state->group_list_id->tpl_descr.f_valp);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (bool) * 2);
       return ER_FAILED;
     }
@@ -23512,7 +23509,6 @@ qexec_topn_tuples_to_list_id (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_ST
       tpl_descr->clear_f_val_at_clone_decache = (bool *) malloc (sizeof (bool) * values_count);
       if (tpl_descr->clear_f_val_at_clone_decache == NULL)
 	{
-	  free_and_init (tpl_descr->f_valp);
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (bool) * values_count);
 	  goto cleanup;
 	}

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -24098,7 +24098,7 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
   /* create tuple descriptor for partial list files */
   proc->agg_hash_context.part_list_id->tpl_descr.f_cnt = type_list.type_cnt;
   proc->agg_hash_context.part_list_id->tpl_descr.f_valp = (DB_VALUE **) malloc (sizeof (DB_VALUE) * type_list.type_cnt);
-  if (proc->agg_hash_context.part_list_id->tpl_descr.f_valp = NULL)
+  if (proc->agg_hash_context.part_list_id->tpl_descr.f_valp == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DB_VALUE) * type_list.type_cnt);
       goto exit_on_error;

--- a/src/query/query_list.h
+++ b/src/query/query_list.h
@@ -548,6 +548,7 @@ struct qfile_tuple_descriptor
   int tpl_size;			/* tuple size */
   int f_cnt;			/* number of field */
   DB_VALUE **f_valp;		/* pointer of field value pointer array */
+  bool *clear_f_val_at_clone_decache;	/* true, if need to clear value at clone decache */
 
   /* T_SORTKEY */
   void *sortkey_info;		/* casted pointer of (SORTKEY_INFO *) */
@@ -643,6 +644,7 @@ struct qfile_list_id
       (list_id)->tpl_descr.tpl_size = 0; \
       (list_id)->tpl_descr.f_cnt = 0; \
       (list_id)->tpl_descr.f_valp = NULL; \
+      (list_id)->tpl_descr.clear_f_val_at_clone_decache = NULL; \
       (list_id)->tpl_descr.sortkey_info = NULL; \
       (list_id)->tpl_descr.sort_rec = NULL; \
       (list_id)->tpl_descr.tplrec1 = NULL; \

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -368,6 +368,7 @@ qdata_copy_db_value (DB_VALUE * dest_p, DB_VALUE * src_p)
  * qdata_copy_db_value_to_tuple_value () -
  *   return: int (true on success, false on failure)
  *   dbval(in)  : Source dbval node
+ *   clear_compressed_string(in): true, if need to clear compressed string
  *   tvalp(in)  :  Tuple value
  *   tval_size(out)      : Set to the tuple value size
  *
@@ -375,7 +376,8 @@ qdata_copy_db_value (DB_VALUE * dest_p, DB_VALUE * src_p)
  * THIS ROUTINE ASSUMES THAT THE VALUE WILL FIT IN THE TPL!!!!
  */
 int
-qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, char *tuple_val_p, int *tuple_val_size)
+qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, bool clear_compressed_string, char *tuple_val_p,
+				    int *tuple_val_size)
 {
   char *val_p;
   int val_size, align, rc;
@@ -416,12 +418,15 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, char *tuple_val_p, int *
       /* Good moment to clear the compressed_string that might have been stored in the DB_VALUE */
       if (dbval_type == DB_TYPE_VARCHAR || dbval_type == DB_TYPE_VARNCHAR)
 	{
-	  rc = pr_clear_compressed_string (dbval_p);
-	  if (rc != NO_ERROR)
+	  if (clear_compressed_string)
 	    {
-	      /* This should not happen for now */
-	      assert (false);
-	      return ER_FAILED;
+	      rc = pr_clear_compressed_string (dbval_p);
+	      if (rc != NO_ERROR)
+		{
+		  /* This should not happen for now */
+		  assert (false);
+		  return ER_FAILED;
+		}
 	    }
 	}
 
@@ -461,6 +466,7 @@ qdata_copy_valptr_list_to_tuple (THREAD_ENTRY * thread_p, VALPTR_LIST * valptr_l
   char *tuple_p;
   int k, tval_size, tlen, tpl_size;
   int n_size, toffset;
+  bool clear_compressed_string = false;
 
   tpl_size = 0;
   tlen = QFILE_TUPLE_LENGTH_SIZE;
@@ -480,6 +486,15 @@ qdata_copy_valptr_list_to_tuple (THREAD_ENTRY * thread_p, VALPTR_LIST * valptr_l
 	  if (dbval_p == NULL)
 	    {
 	      return ER_FAILED;
+	    }
+
+	  if (REGU_VARIABLE_IS_FLAGED (&reg_var_p->value, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))
+	    {
+	      clear_compressed_string = false;
+	    }
+	  else
+	    {
+	      clear_compressed_string = true;
 	    }
 
 	  n_size = qdata_get_tuple_value_size_from_dbval (dbval_p);
@@ -516,7 +531,7 @@ qdata_copy_valptr_list_to_tuple (THREAD_ENTRY * thread_p, VALPTR_LIST * valptr_l
 	      tuple_p = (char *) (tuple_record_p->tpl) + toffset;
 	    }
 
-	  if (qdata_copy_db_value_to_tuple_value (dbval_p, tuple_p, &tval_size) != NO_ERROR)
+	  if (qdata_copy_db_value_to_tuple_value (dbval_p, clear_compressed_string, tuple_p, &tval_size) != NO_ERROR)
 	    {
 	      return ER_FAILED;
 	    }
@@ -576,6 +591,17 @@ qdata_generate_tuple_desc_for_valptr_list (THREAD_ENTRY * thread_p, VALPTR_LIST 
 	      goto exit_with_status;
 	    }
 
+	  /* Set clear_f_val_at_clone_decache to avoid memory issues */
+	  assert (tuple_desc_p->clear_f_val_at_clone_decache != NULL);
+	  if (REGU_VARIABLE_IS_FLAGED (&reg_var_p->value, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))
+	    {
+	      tuple_desc_p->clear_f_val_at_clone_decache[tuple_desc_p->f_cnt] = true;
+	    }
+	  else
+	    {
+	      tuple_desc_p->clear_f_val_at_clone_decache[tuple_desc_p->f_cnt] = false;
+	    }
+
 	  dbval_type = DB_VALUE_DOMAIN_TYPE (tuple_desc_p->f_valp[tuple_desc_p->f_cnt]);
 
 	  /* SET data-type cannot use tuple descriptor */
@@ -599,15 +625,10 @@ qdata_generate_tuple_desc_for_valptr_list (THREAD_ENTRY * thread_p, VALPTR_LIST 
 	  val_buffer = tuple_desc_p->f_valp[tuple_desc_p->f_cnt];
 	  if (!DB_IS_NULL (val_buffer) && (dbval_type == DB_TYPE_VARCHAR || dbval_type == DB_TYPE_VARNCHAR))
 	    {
-	      if (REGU_VARIABLE_IS_FLAGED (&reg_var_p->value, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))
+	      if (!(tuple_desc_p->clear_f_val_at_clone_decache[tuple_desc_p->f_cnt]))
 		{
-		  save_heapid = db_change_private_heap (thread_p, 0);
-		}
-	      pr_clear_compressed_string (val_buffer);
-	      if (save_heapid != 0)
-		{
-		  (void) db_change_private_heap (thread_p, save_heapid);
-		  save_heapid = 0;
+		  /* Clear compressed string since val_buffer allocated during execution. */
+		  pr_clear_compressed_string (val_buffer);
 		}
 	    }
 
@@ -651,8 +672,11 @@ qdata_set_valptr_list_unbound (THREAD_ENTRY * thread_p, VALPTR_LIST * valptr_lis
 
       if (dbval_p != NULL)
 	{
-	  /* this may be shared with another reguvariable that was already evaluated */
-	  pr_clear_value (dbval_p);
+	  if (!REGU_VARIABLE_IS_FLAGED (&reg_var_p->value, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))
+	    {
+	      /* this may be shared with another regu variable that was already evaluated */
+	      pr_clear_value (dbval_p);
+	    }
 
 	  if (db_value_domain_init (dbval_p, DB_VALUE_DOMAIN_TYPE (dbval_p), DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE) !=
 	      NO_ERROR)

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -416,9 +416,9 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, bool clear_compressed_st
 	}
 
       /* Good moment to clear the compressed_string that might have been stored in the DB_VALUE */
-      if (dbval_type == DB_TYPE_VARCHAR || dbval_type == DB_TYPE_VARNCHAR)
+      if (clear_compressed_string)
 	{
-	  if (clear_compressed_string)
+	  if (dbval_type == DB_TYPE_VARCHAR || dbval_type == DB_TYPE_VARNCHAR)
 	    {
 	      rc = pr_clear_compressed_string (dbval_p);
 	      if (rc != NO_ERROR)
@@ -627,7 +627,7 @@ qdata_generate_tuple_desc_for_valptr_list (THREAD_ENTRY * thread_p, VALPTR_LIST 
 	    {
 	      if (!(tuple_desc_p->clear_f_val_at_clone_decache[tuple_desc_p->f_cnt]))
 		{
-		  /* Clear compressed string since val_buffer allocated during execution. */
+		  /* Clear compressed string since val_buffer was allocated during XASL execution. */
 		  pr_clear_compressed_string (val_buffer);
 		}
 	    }

--- a/src/query/query_opfunc.h
+++ b/src/query/query_opfunc.h
@@ -177,7 +177,8 @@ struct hierarchy_aggregate_helper
 extern void qdata_set_value_list_to_null (VAL_LIST * val_list);
 extern int qdata_copy_db_value (DB_VALUE * dbval1, DB_VALUE * dbval2);
 
-extern int qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval, char *tvalp, int *tval_size);
+extern int qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval, bool clear_compressed_string, char *tvalp,
+					       int *tval_size);
 extern int qdata_copy_valptr_list_to_tuple (THREAD_ENTRY * thread_p, VALPTR_LIST * valptr_list, VAL_DESCR * vd,
 					    QFILE_TUPLE_RECORD * tplrec);
 extern QPROC_TPLDESCR_STATUS qdata_generate_tuple_desc_for_valptr_list (THREAD_ENTRY * thread_p,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20766

The compressed string is not cleared if the regu variable must be cleared at clone decache.
The issue occurs because the compressed string is cleared when generates the tuple descriptor. However, I'm not sure that we need to call pr_clear_compressed_string in qdata_generate_tuple_desc_for_valptr_list. 
I expect that compressed string to be cleared, together with uncompressed string, later.
Maybe we need to analyze more whether we need to clear compressed string in qdata_generate_tuple_desc_for_valptr_list.