### PR TITLE
[CBRD-20722] Fixed crash caused by null list_id when executes analytic

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -18838,7 +18838,6 @@ exit_on_error:
 	    {
 	      qfile_close_list (thread_p, func_p->list_id);
 	      qfile_destroy_list (thread_p, func_p->list_id);
-	      func_p->list_id = NULL;
 	    }
 	}
     }

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -11297,7 +11297,6 @@ qdata_finalize_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, b
 	{
 	  qfile_close_list (thread_p, func_p->list_id);
 	  qfile_destroy_list (thread_p, func_p->list_id);
-	  func_p->list_id = NULL;
 	}
 
       if (!list_id_p)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20722

The list_id should not be set to null, since is reused. I suppose that this is the source of the issue, but I don't have a simple scenario.