### PR TITLE
[CBRD-20805] keep PK disk image to LA_ITEM for sql_logging and error …

### DIFF
--- a/src/object/work_space.c
+++ b/src/object/work_space.c
@@ -5415,8 +5415,15 @@ ws_add_to_repl_obj_list (OID * class_oid, char *packed_pkey_value, int packed_pk
 
   COPY_OID (&repl_obj->class_oid, class_oid);
 
-  repl_obj->packed_pkey_value = packed_pkey_value;	/* hand over the disk image of pk value. see la_repl_add_object */
   repl_obj->packed_pkey_value_length = packed_pkey_value_length;
+  repl_obj->packed_pkey_value = (char *) malloc (packed_pkey_value_length);
+  if (repl_obj->packed_pkey_value == NULL)
+    {
+      free (repl_obj);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (WS_REPL_OBJ));
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+  memcpy (repl_obj->packed_pkey_value, packed_pkey_value, packed_pkey_value_length);
 
   repl_obj->recdes = recdes;
   repl_obj->has_index = has_index;

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -4932,10 +4932,6 @@ la_repl_add_object (MOP classop, LA_ITEM * item, RECDES * recdes)
 
   error = ws_add_to_repl_obj_list (class_oid, item->packed_key_value, item->packed_key_value_length, recdes,
 				   operation, has_index);
-
-  item->packed_key_value = NULL;	/* to prevent double free. see ws_add_to_repl_obj_list */
-  item->packed_key_value_length = 0;
-
   return error;
 }
 


### PR DESCRIPTION
…reporting.

http://jira.cubrid.org/browse/CBRD-20805

This is a slip of #420.
PK disk image is required for sql_logging and error reporting. 
