### PR TITLE
[CBRD-20806] correct file_log_extdata_set_next arguments

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -2324,6 +2324,9 @@ file_log_extdata_set_next (THREAD_ENTRY * thread_p,
 
   addr.pgptr = page;
   addr.offset = (PGLENGTH) (((char *) extdata) - page);
+  /* extdata should belong to page */
+  assert (addr.offset >= 0 && addr.offset < DB_PAGESIZE);
+
   save_lsa = *pgbuf_get_lsa (page);
   log_append_undoredo_data (thread_p, RVFL_EXTDATA_SET_NEXT, &addr,
 			    sizeof (VPID), sizeof (VPID), &extdata->vpid_next, vpid_next);
@@ -4924,7 +4927,7 @@ file_perm_alloc (THREAD_ENTRY * thread_p, PAGE_PTR page_fhead, FILE_ALLOC_TYPE a
       /* init new table extensible data */
       extdata_new_ftab = (FILE_EXTENSIBLE_DATA *) page_ftab;
       file_extdata_init (sizeof (VSID), DB_PAGESIZE, extdata_new_ftab);
-      file_log_extdata_set_next (thread_p, extdata_new_ftab, page_fhead, &extdata_full_ftab->vpid_next);
+      file_log_extdata_set_next (thread_p, extdata_new_ftab, page_ftab, &extdata_full_ftab->vpid_next);
       VPID_COPY (&extdata_new_ftab->vpid_next, &extdata_full_ftab->vpid_next);
 
       pgbuf_log_new_page (thread_p, page_ftab, file_extdata_size (extdata_new_ftab), PAGE_FTAB);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20806

extdata_new_ftab corresponds to page_ftab. 