### PR TITLE
[CBRD-20825] fixed type resolution of DAYOFYEAR (and other functions)

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -1396,8 +1396,8 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
       def->overloads[num++] = sig;
 
       /* arg1 */
-      sig.arg1_type.is_generic = false;
-      sig.arg1_type.val.type = PT_TYPE_DATE;
+      sig.arg1_type.is_generic = true;
+      sig.arg1_type.val.type = PT_GENERIC_TYPE_DATE;
       /* return type */
       sig.return_type.is_generic = false;
       sig.return_type.val.type = PT_TYPE_INTEGER;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20825

In fact, it is not a CTE but a type resolution issue. 

These functions:
```c
    case PT_YEARF:
    case PT_DAYF:
    case PT_MONTHF:
    case PT_DAYOFMONTH:
    case PT_DAYOFWEEK: 
    case PT_DAYOFYEAR:
    case PT_QUARTERF:
    case PT_TODAYS:
    case PT_WEEKDAY:
```
accepted two types of argument: `string` and `date` type.

`Timestamp` and `Datetime` types were accepted as `string`. 
