### PR TITLE
[CBRD-20819] Avoid name binding lookup of group by column outside current scope, level 0

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -660,6 +660,7 @@ pt_bind_name_or_path_in_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind
   PT_NODE *temp, *entity;
   short scope_location;
   bool error_saved = false;
+  bool is_name_in_group_having = is_pt_name_in_group_having (in_node);
 
   /* skip hint argument name, index name */
   if (in_node->node_type == PT_NAME
@@ -689,6 +690,11 @@ pt_bind_name_or_path_in_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind
 	  if (node)
 	    {
 	      node = pt_expand_external_path (parser, node, &prev_entity);
+	      break;
+	    }
+	  if (is_name_in_group_having)
+	    {
+	      /* give up; this kind of name should be in level 0 scopes */
 	      break;
 	    }
 	  level++;
@@ -736,7 +742,7 @@ pt_bind_name_or_path_in_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind
   else
     {
       /* If pt_name in group by/ having, maybe it's alias. We will try to resolve it later. */
-      if (is_pt_name_in_group_having (in_node) == false)
+      if (!is_name_in_group_having)
 	{
 	  /* it may be a naked parameter or a path expression anchored by a naked parameter. Try and resolve it as
 	   * such. */

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -660,7 +660,6 @@ pt_bind_name_or_path_in_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind
   PT_NODE *temp, *entity;
   short scope_location;
   bool error_saved = false;
-  bool is_name_in_group_having = is_pt_name_in_group_having (in_node);
 
   /* skip hint argument name, index name */
   if (in_node->node_type == PT_NAME
@@ -692,7 +691,7 @@ pt_bind_name_or_path_in_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind
 	      node = pt_expand_external_path (parser, node, &prev_entity);
 	      break;
 	    }
-	  if (is_name_in_group_having)
+	  if (is_pt_name_in_group_having (in_node))
 	    {
 	      /* give up; this kind of name should be in level 0 scopes */
 	      break;
@@ -742,7 +741,7 @@ pt_bind_name_or_path_in_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind
   else
     {
       /* If pt_name in group by/ having, maybe it's alias. We will try to resolve it later. */
-      if (!is_name_in_group_having)
+      if (!is_pt_name_in_group_having (in_node))
 	{
 	  /* it may be a naked parameter or a path expression anchored by a naked parameter. Try and resolve it as
 	   * such. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20819

A group by column from the CTE was found in the CTE spec attributes. Since the CTE spec was one level higher than the query from within, it was considered a correlated query which was crashing at execution.

With the fix, group by columns will be identified only in the curent scope attributes, while executing pt_bind_names.
