### PR TITLE
[CBRD-20835] Extend condition to differentiate entity specs from derived table/cte

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1988,6 +1988,7 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 			  if (PT_SPEC_IS_ENTITY (spec))
 			    {
 			      /* entity spec */
+			      assert (!PT_SPEC_IS_DERIVED (spec) || !PT_SPEC_IS_CTE (spec));
 			      flat = spec->info.spec.flat_entity_list;
 
 			      if (pt_str_compare (attr->info.name.original, flat->info.name.resolved, CASE_INSENSITIVE)

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1808,7 +1808,7 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
   PT_EXTRA_SPECS_FRAME spec_frame;
   PT_NODE *prev_attr = NULL, *attr = NULL, *next_attr = NULL, *as_attr = NULL;
   PT_NODE *resolved_attrs = NULL, *spec = NULL;
-  PT_NODE *derived_table = NULL, *flat = NULL, *range_var = NULL;
+  PT_NODE *flat = NULL, *range_var = NULL;
   bool do_resolve = true;
   PT_NODE *seq = NULL;
   PT_NODE *cnf = NULL, *prev = NULL, *next = NULL, *last = NULL, *save = NULL;
@@ -1985,9 +1985,9 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 		      /* STEP 2-2-1) assign spec_id into PT_NAME */
 		      for (spec = node->info.query.q.select.from; spec; spec = spec->next)
 			{
-			  derived_table = spec->info.spec.derived_table;
-			  if (derived_table == NULL && spec->info.spec.flat_entity_list)
+			  if (PT_SPEC_IS_ENTITY (spec))
 			    {
+			      /* entity spec */
 			      flat = spec->info.spec.flat_entity_list;
 
 			      if (pt_str_compare (attr->info.name.original, flat->info.name.resolved, CASE_INSENSITIVE)
@@ -1999,7 +1999,9 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 				}
 			    }
 			  else
-			    {	/* derived table */
+			    {
+			      /* derived table or cte */
+			      assert (PT_SPEC_IS_DERIVED (spec) || PT_SPEC_IS_CTE (spec));
 			      range_var = spec->info.spec.range_var;
 			      if (pt_str_compare (attr->info.name.original, range_var->info.name.original,
 						  CASE_INSENSITIVE) == 0)
@@ -2018,7 +2020,7 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 		      else
 			{
 			  /* STEP 2-2-2) recreate select_list */
-			  if (derived_table == NULL && spec->info.spec.flat_entity_list)
+			  if (PT_SPEC_IS_ENTITY (spec))
 			    {
 			      resolved_attrs =
 				parser_append_node (attr->next,

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1986,7 +1986,7 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 		      for (spec = node->info.query.q.select.from; spec; spec = spec->next)
 			{
 			  derived_table = spec->info.spec.derived_table;
-			  if (derived_table == NULL)
+			  if (derived_table == NULL && spec->info.spec.flat_entity_list)
 			    {
 			      flat = spec->info.spec.flat_entity_list;
 
@@ -2018,7 +2018,7 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 		      else
 			{
 			  /* STEP 2-2-2) recreate select_list */
-			  if (derived_table == NULL)
+			  if (derived_table == NULL && spec->info.spec.flat_entity_list)
 			    {
 			      resolved_attrs =
 				parser_append_node (attr->next,

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -739,6 +739,19 @@
 #define PT_SHOULD_BIND_RESERVED_NAME(spec_)				\
   (PT_SPEC_GET_RESERVED_NAME_TYPE (spec_) != RESERVED_NAME_INVALID)
 
+/* PT_SPEC node contains a derived table */
+#define PT_SPEC_IS_DERIVED(spec_) \
+  (spec_->info.spec.derived_table != NULL)
+
+/* PT_SPEC node contains a CTE pointer */
+#define PT_SPEC_IS_CTE(spec_) \
+  (spec_->info.spec.cte_pointer != NULL)
+
+/* PT_SPEC node contains an entity spec */
+#define PT_SPEC_IS_ENTITY(spec_) \
+  (spec_->info.spec.entity_name != NULL)
+
+
 /*
  Enumerated types of parse tree statements
   WARNING ------ WARNING ----- WARNING


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20835

CTE spec attributes were resolved as for an entity spec. Extending condition should handle CTE specs correctly. 