### PR TITLE
[CBRD-20828] CTE - fix recursive list id leak

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -12091,6 +12091,9 @@ pt_to_cte_table_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * ct
     {
       /* The CTE xasl is null because the recursive part xasl has not been generated yet, but this is not a problem 
        * because the recursive part should have access only to the non recursive part.
+       * This may also happen with a CTE referenced by another one. If CTE1 is referenced by CTE2, the XASL of CTE1
+       * is not completed when reaching this function from CTE2. CTE2 is reached following *next* link of CTE1 before
+       * CTE1 post function of xasl generation is executed.
        */
       PT_NODE *non_recursive_part = cte_def->info.cte.non_recursive_part;
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15515,6 +15515,11 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 	    }
 	}
 
+      /* copy all results back to non_recursive_part list id; other CTEs from the same WITH clause have access only to
+       * non_recursive_part; see how pt_to_cte_table_spec_list works for interdependent CTEs.
+       */
+      qfile_copy_list_id (non_recursive_part->list_id, xasl->list_id, true);
+
       if (save_recursive_list_id != NULL)
 	{
 	  /* restore recursive list_id */

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15443,8 +15443,6 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 	  GOTO_EXIT_ON_ERROR;
 	}
 
-      save_recursive_list_id = recursive_part->list_id;
-
       /* the recursive part XASL is executed totally (all iterations) 
        * and the results will be inserted in non_recursive_part->list_id 
        */
@@ -15517,8 +15515,11 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 	    }
 	}
 
-      qfile_copy_list_id (non_recursive_part->list_id, xasl->list_id, true);
-      recursive_part->list_id = save_recursive_list_id;
+      if (save_recursive_list_id != NULL)
+	{
+	  /* restore recursive list_id */
+	  recursive_part->list_id = save_recursive_list_id;
+	}
     }
   else if (non_recursive_part->list_id->tuple_cnt > 0
 	   && qfile_copy_list_id (xasl->list_id, non_recursive_part->list_id, true) != NO_ERROR)
@@ -15532,6 +15533,11 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
   return NO_ERROR;
 
 exit_on_error:
+  if (save_recursive_list_id != NULL)
+    {
+      /* restore recursive list_id */
+      recursive_part->list_id = save_recursive_list_id;
+    }
   xasl->status = XASL_FAILURE;
   return ER_FAILED;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20828

The recursive and non-recursive parts remained linking to the same list_id, because of the execution error. 
XASL clones kept the list_id in both parts which caused the crash at the second run.