### PR TITLE
[CBRD-20857] to support query trace for CTE

### DIFF
--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -2768,6 +2768,12 @@ qdump_print_xasl (XASL_NODE * xasl_p)
 	}
       break;
 
+    case CTE_PROC:
+      fprintf (foutput, "non_recursive_part xasl:%p\n", xasl_p->proc.cte.non_recursive_part);
+      fprintf (foutput, "recursive_part xasl:%p\n", xasl_p->proc.cte.recursive_part);
+      /* TODO - dump anchor and recursive part of CTE when we need */
+      break;
+
     default:
       return false;
     }
@@ -2851,6 +2857,8 @@ qdump_xasl_type_string (XASL_NODE * xasl_p)
       return "SCHEMA";
     case DO_PROC:
       return "DO";
+    case CTE_PROC:
+      return "CTE";
     default:
       assert (false);
       return "";
@@ -2991,6 +2999,7 @@ qdump_print_stats_json (XASL_NODE * xasl_p, json_t * parent)
   json_t *proc, *scan = NULL;
   json_t *subquery, *groupby, *orderby;
   json_t *left, *right, *outer, *inner;
+  json_t *cte_non_recursive_part, *cte_recursive_part;
 
   if (xasl_p == NULL || parent == NULL)
     {
@@ -3032,7 +3041,6 @@ qdump_print_stats_json (XASL_NODE * xasl_p, json_t * parent)
 
       json_object_set_new (proc, "left", left);
       json_object_set_new (proc, "right", right);
-
       break;
 
     case MERGELIST_PROC:
@@ -3044,7 +3052,6 @@ qdump_print_stats_json (XASL_NODE * xasl_p, json_t * parent)
 
       json_object_set_new (proc, "outer", outer);
       json_object_set_new (proc, "inner", inner);
-
       break;
 
     case MERGE_PROC:
@@ -3056,7 +3063,19 @@ qdump_print_stats_json (XASL_NODE * xasl_p, json_t * parent)
 
       json_object_set_new (proc, "update", inner);
       json_object_set_new (proc, "insert", outer);
+      break;
 
+    case CTE_PROC:
+      cte_non_recursive_part = json_object ();
+      qdump_print_stats_json (xasl_p->proc.cte.non_recursive_part, cte_non_recursive_part);
+      json_object_set_new (proc, "non_recursive_part", cte_non_recursive_part);
+
+      if (xasl_p->proc.cte.recursive_part != NULL)
+	{
+	  cte_recursive_part = json_object ();
+	  qdump_print_stats_json (xasl_p->proc.cte.recursive_part, cte_recursive_part);
+	  json_object_set_new (proc, "recursive_part", cte_recursive_part);
+	}
       break;
 
     case SCAN_PROC:
@@ -3329,6 +3348,17 @@ qdump_print_stats_text (FILE * fp, XASL_NODE * xasl_p, int indent)
       fprintf (fp, "MERGE\n");
       qdump_print_stats_text (fp, xasl_p->proc.merge.update_xasl, indent);
       qdump_print_stats_text (fp, xasl_p->proc.merge.insert_xasl, indent);
+      break;
+
+    case CTE_PROC:
+      fprintf (fp, "CTE (non_recursive_part)\n");
+      qdump_print_stats_text (fp, xasl_p->proc.cte.non_recursive_part, indent);
+      if (xasl_p->proc.cte.recursive_part != NULL)
+	{
+	  fprintf (fp, "%*c", indent, ' ');
+	  fprintf (fp, "CTE (recursive_part)\n");
+	  qdump_print_stats_text (fp, xasl_p->proc.cte.recursive_part, indent);
+	}
       break;
 
     case SCAN_PROC:

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -12555,9 +12555,8 @@ qexec_start_mainblock_iterations (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 
 	    QFILE_SET_FLAG (ls_flag, QFILE_FLAG_ALL);
 	    if (XASL_IS_FLAGED (xasl, XASL_TOP_MOST_XASL) && XASL_IS_FLAGED (xasl, XASL_TO_BE_CACHED)
-		&& buildlist->groupby_list == NULL && buildlist->a_eval_list == NULL && (xasl->orderby_list == NULL
-											 || XASL_IS_FLAGED (xasl,
-													    XASL_SKIP_ORDERBY_LIST))
+		&& buildlist->groupby_list == NULL && buildlist->a_eval_list == NULL
+		&& (xasl->orderby_list == NULL || XASL_IS_FLAGED (xasl, XASL_SKIP_ORDERBY_LIST))
 		&& xasl->option != Q_DISTINCT)
 	      {
 		QFILE_SET_FLAG (ls_flag, QFILE_FLAG_RESULT_FILE);
@@ -12669,9 +12668,7 @@ qexec_start_mainblock_iterations (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
     case UNION_PROC:
     case DIFFERENCE_PROC:
     case INTERSECTION_PROC:	/* start SET block iterations */
-      {
-	break;
-      }
+      break;
 
     case CTE_PROC:
       break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20857

Query trace for CTE were missed as well as XASL dump.

You can see a sample query trace result of both json and text format from [here](http://jira.cubrid.org/browse/CBRD-20857?focusedCommentId=4740718&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4740718). 
I just leave dumping details of XASL for CTE as a TODO task. 
