### PR TITLE
[CBRD-20860] Fix outdated pointer of cte non recursive part

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1157,6 +1157,9 @@ pt_bind_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg)
 	    {
 	      non_recursive_cte =
 		parser_walk_tree (parser, non_recursive_cte, pt_bind_names, bind_arg, pt_bind_names_post, bind_arg);
+
+	      /* restore non recursive part; pointer may be changed during walk */
+	      cte_def->info.cte.non_recursive_part = non_recursive_cte;
 	    }
 	  else
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20860

Non recursive part pointer remained outdated, which caused the crash.