### PR TITLE
[CBRD-20842] Fix vacuum crash on dropped file after restart

### DIFF
--- a/src/base/release_string.c
+++ b/src/base/release_string.c
@@ -100,7 +100,7 @@ static REL_COMPATIBILITY rel_get_compatible_internal (const char *base_rel_str, 
 /*
  * Disk (database image) Version Compatibility
  */
-static float disk_compatibility_level = 10.05f;
+static float disk_compatibility_level = 10.06f;
 
 /*
  * rel_copy_version_string - version string of the product

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5454,6 +5454,8 @@ vacuum_update_oldest_unvacuumed_mvccid (THREAD_ENTRY * thread_p)
       vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "VACUUM: Update oldest_unvacuumed_mvccid from %llu to %llu.\n",
 		     (unsigned long long int) vacuum_Data.oldest_unvacuumed_mvccid,
 		     (unsigned long long int) oldest_mvccid);
+
+      (void) vacuum_cleanup_dropped_files (thread_p);
     }
   /* Vacuum data oldest MVCCID cannot go backwards! */
   assert (vacuum_Data.oldest_unvacuumed_mvccid <= oldest_mvccid);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1170,7 +1170,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
   if (HFID_IS_NULL (hfid))
     {
       /* file has changed and we must get HFID and file type */
-      error_code = vacuum_heap_get_hfid_and_file_type (thread_p, &helper, &heap_objects[i].vfid);
+      error_code = vacuum_heap_get_hfid_and_file_type (thread_p, &helper, &heap_objects[0].vfid);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -816,6 +816,8 @@ file_manager_init (void)
 {
   file_Logging = prm_get_bool_value (PRM_ID_FILE_LOGGING);
 
+  assert (FILE_DESCRIPTORS_SIZE == sizeof (FILE_DESCRIPTORS));
+
   return file_tempcache_init ();
 }
 

--- a/src/storage/file_manager.h
+++ b/src/storage/file_manager.h
@@ -82,6 +82,7 @@ typedef struct file_heap_des FILE_HEAP_DES;
 struct file_heap_des
 {
   OID class_oid;
+  HFID hfid;
 };
 
 /* Overflow heap file descriptor */
@@ -123,6 +124,8 @@ struct file_tablespace
   int expand_max_size;
 };
 
+/* note: if you change file descriptors size, make sure to change disk compatibility version too! */
+#define FILE_DESCRIPTORS_SIZE 64
 typedef union file_descriptors FILE_DESCRIPTORS;
 union file_descriptors
 {
@@ -131,6 +134,7 @@ union file_descriptors
   FILE_BTREE_DES btree;
   FILE_OVF_BTREE_DES btree_key_overflow;	/* TODO: rename FILE_OVF_BTREE_DES */
   FILE_EHASH_DES ehash;
+  char dummy_align[FILE_DESCRIPTORS_SIZE];
 };
 
 typedef int (*FILE_INIT_PAGE_FUNC) (THREAD_ENTRY * thread_p, PAGE_PTR page, void *args);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -5049,6 +5049,7 @@ heap_create_internal (THREAD_ENTRY * thread_p, HFID * hfid, const OID * class_oi
       if (!VFID_ISNULL (&hfid->vfid))
 	{
 	  VPID vpid_heap_header;
+	  hfdes.hfid = *hfid;
 	  error_code = file_descriptor_update (thread_p, &hfid->vfid, &hfdes);
 	  if (error_code != NO_ERROR)
 	    {
@@ -5116,6 +5117,14 @@ heap_create_internal (THREAD_ENTRY * thread_p, HFID * hfid, const OID * class_oi
     }
 
   hfid->hpgid = vpid.pageid;
+
+  hfdes.hfid = *hfid;
+  error_code = file_descriptor_update (thread_p, &hfid->vfid, &hfdes);
+  if (error_code != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      goto error;
+    }
 
   if (heap_insert_hfid_for_class_oid (thread_p, class_oid, hfid, file_type) != NO_ERROR)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20842

Vacuum heap pages requires two pieces of information: hfid and file type. These are regularly obtain from heap cache (where key is class OID), even if class is dropped (removing the info from cache is postponed until all vacuum workers are notified of this change).

However, if class is dropped immediately after server restart, the information is not in cache. It cannot be obtained from class record either (since it is deleted by the time vacuum gets here). One place that can be accessed is file header. File type was  already there, but I had to also add HFID in the heap descriptor.

Also call cleanup dropped files when oldest MVCCID not vacuumed advances.