### PR TITLE
[CBRD-20830] Removed PT_LIST_WALK from pt_resolve_spec_to_cte

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -8006,7 +8006,6 @@ pt_resolve_spec_to_cte (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int 
 	  node->info.spec.cte_pointer->info.pointer.do_walk = false;
 	  node->info.spec.as_attr_list = cte->info.cte.as_attr_list;
 	  match_count++;
-	  *continue_walk = PT_LIST_WALK;
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20830

Continue resolving CTE specs in tree after one was found. PT_LIST_WALK was used as an optimization, but it is not correct.