### PR TITLE
[CBRD-20857] introduce max_print_len of parser for pt_short_print

### DIFF
--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -675,6 +675,11 @@ pt_append_bytes_for (const PARSER_CONTEXT * parser, PARSER_VARCHAR * old_string,
   PARSER_STRING_BLOCK *string;
   char *s;
 
+  if (parser->max_print_len > 0 && parser->max_print_len < old_string->length)
+    {
+      return old_string;
+    }
+
   /* here, you know you have two non-NULL pointers */
   string = pt_find_string_block (parser, (char *) old_string);
 
@@ -1191,6 +1196,7 @@ parser_create_parser (void)
   parser->return_generated_keys = 0;
   parser->is_system_generated_stmt = 0;
   parser->has_internal_error = 0;
+  parser->max_print_len = 0;
 
   return parser;
 }

--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -675,7 +675,7 @@ pt_append_bytes_for (const PARSER_CONTEXT * parser, PARSER_VARCHAR * old_string,
   PARSER_STRING_BLOCK *string;
   char *s;
 
-  if (parser->max_print_len > 0 && parser->max_print_len < old_string->length)
+  if (0 < parser->max_print_len && parser->max_print_len < old_string->length)
     {
       return old_string;
     }

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3620,6 +3620,8 @@ struct parser_context
   int num_plan_trace;
   PT_PLAN_TRACE_INFO plan_trace[MAX_NUM_PLAN_TRACE];
 
+  int max_print_len;		/* for pt_short_print */
+
   unsigned has_internal_error:1;	/* 0 or 1 */
   unsigned abort:1;		/* this flag is for aborting a transaction */
   /* if deadlock occurs during query execution */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2277,6 +2277,11 @@ pt_print_bytes_l (PARSER_CONTEXT * parser, const PT_NODE * p)
 	  strcat_with_realloc (&sb, r->bytes);
 	  prev = r;
 	}
+      if (0 < parser->max_print_len && parser->max_print_len < sb.length)
+	{
+	  /* to help early break */
+	  break;
+	}
     }
 
   if (sb.length > 0)
@@ -2746,17 +2751,23 @@ char *
 pt_short_print (PARSER_CONTEXT * parser, const PT_NODE * node)
 {
   char *str;
+  const int max_print_len = 64;
+
+  parser->max_print_len = max_print_len;
+
   str = parser_print_tree (parser, node);
   if (str == NULL)
     {
-      return NULL;
+      goto end;
     }
 
-  if (strlen (str) > 64)
+  if (strlen (str) > max_print_len)
     {
       strcpy (str + 60, "...");
     }
 
+end:
+  parser->max_print_len = 0;
   return str;
 }
 
@@ -2771,17 +2782,23 @@ char *
 pt_short_print_l (PARSER_CONTEXT * parser, const PT_NODE * node)
 {
   char *str;
+  const int max_print_len = 64;
+
+  parser->max_print_len = max_print_len;
+
   str = parser_print_tree_list (parser, node);
   if (str == NULL)
     {
-      return NULL;
+      goto end;
     }
 
-  if (strlen (str) > 64)
+  if (strlen (str) > max_print_len)
     {
       strcpy (str + 60, "...");
     }
 
+end:
+  parser->max_print_len = 0;	/* restore */
   return str;
 }
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2767,7 +2767,7 @@ pt_short_print (PARSER_CONTEXT * parser, const PT_NODE * node)
     }
 
 end:
-  parser->max_print_len = 0;
+  parser->max_print_len = 0;	/* restore */
   return str;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20857

This is a quick fix for `pt_short_print`. 
`pt_short_print` printed the entire text of PT_NODE and truncated it as 60. It may use huge amount of string buffer. 
