### PR TITLE
[CBRD-20765] Allow Re-creation of foreign key having one or more NULL values for foreign keys

### DIFF
--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4018,6 +4018,11 @@ locator_end_force_scan_cache (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cac
 
 
 /*
+ * Following function, locator_check_primary_key_upddel(), is not referenced from anywhere.
+ */
+
+#if 0
+/*
  * locator_check_primary_key_upddel () -
  *
  * return: NO_ERROR if all OK, ER_ status otherwise
@@ -4123,6 +4128,7 @@ error:
   heap_attrinfo_end (thread_p, &index_attrinfo);
   return error_code;
 }
+#endif
 
 /*
  * locator_check_foreign_key () -


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20765

- allow rebuild foreign key using 'alter table .. add constraint...' on the table which is not empty
- allow one or more NULL values for foreign key like [CBRD-20523]
- found used function is defined: (locator_check_primary_key_upddel(...))
  in the file src/transaction/locator_sr.c:4020 linw, 
  a function 'static int locator_check_primary_key_upddel()'  was defined 
  but nobody references that function. (marked '#if 0  #endif' compiler directive)