### PR TITLE
[CBRD-20846] Handling of CTE pointers in parse tree copy 

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -769,21 +769,6 @@ copy_node_in_tree_pre (PARSER_CONTEXT * parser, PT_NODE * old_node, void *arg, i
 
   new_node->parser_id = parser->id;
 
-  /* handle CTE copy so that the CTE pointers will be updated to point to new_node */
-  if (old_node->node_type == PT_CTE)
-    {
-      /* the address of the new CTE node is kept in old_node->etc */
-      old_node->etc = new_node;
-    }
-  else if (new_node->node_type == PT_SPEC && PT_SPEC_IS_CTE (new_node))
-    {
-      /* the new cte_pointer must point to the new_cte; new_cte address was previously set in old_node->etc */
-      PT_NODE *cte_pointer = new_node->info.spec.cte_pointer;
-
-      assert (cte_pointer->info.pointer.node->node_type == PT_CTE && cte_pointer->info.pointer.node->etc != NULL);
-      cte_pointer->info.pointer.node = (PT_NODE *) cte_pointer->info.pointer.node->etc;
-    }
-
   return new_node;
 }
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -838,7 +838,7 @@ copy_node_in_tree_post (PARSER_CONTEXT * parser, PT_NODE * new_node, void *arg, 
 	      break;
 	    }
 	}
-      if (cte_info_it != NULL)
+      if (cte_info_it == NULL)
 	{
 	  assert (false);
 	  PT_INTERNAL_ERROR (parser, "incorrect CTE pointer");

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -838,6 +838,12 @@ copy_node_in_tree_post (PARSER_CONTEXT * parser, PT_NODE * new_node, void *arg, 
 	      break;
 	    }
 	}
+      if (cte_info_it != NULL)
+      {
+	  assert (false);
+	  PT_INTERNAL_ERROR (parser, "incorrect CTE pointer");
+	  return NULL;
+      }
       cte_pointer->info.pointer.node = cte_info_it->new_cte_node;
     }
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -769,6 +769,21 @@ copy_node_in_tree_pre (PARSER_CONTEXT * parser, PT_NODE * old_node, void *arg, i
 
   new_node->parser_id = parser->id;
 
+  /* handle CTE copy so that the CTE pointers will be updated to point to new_node */
+  if (old_node->node_type == PT_CTE)
+    {
+      /* the address of the new CTE node is kept in old_node->etc */
+      old_node->etc = new_node;
+    }
+  else if (new_node->node_type == PT_SPEC && PT_SPEC_IS_CTE (new_node))
+    {
+      /* the new cte_pointer must point to the new_cte; new_cte address was previously set in old_node->etc */
+      PT_NODE *cte_pointer = new_node->info.spec.cte_pointer;
+
+      assert (cte_pointer->info.pointer.node->node_type == PT_CTE && cte_pointer->info.pointer.node->etc != NULL);
+      cte_pointer->info.pointer.node = (PT_NODE *) cte_pointer->info.pointer.node->etc;
+    }
+
   return new_node;
 }
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -839,11 +839,11 @@ copy_node_in_tree_post (PARSER_CONTEXT * parser, PT_NODE * new_node, void *arg, 
 	    }
 	}
       if (cte_info_it != NULL)
-      {
+	{
 	  assert (false);
 	  PT_INTERNAL_ERROR (parser, "incorrect CTE pointer");
 	  return NULL;
-      }
+	}
       cte_pointer->info.pointer.node = cte_info_it->new_cte_node;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20846

The CTE pointers have to be handled separately in parse tree copy, otherwise they will remain pointing to the CTEs from the old tree.

PT_TREE_COPY_INFO was created to keep a list of cloned CTE nodes in new/old pairs. This list will be used for each CTE pointer to identify the updated CTE node address.