### PR TITLE
[CBRD-20887] generate alias_print for constant folded expressions as …

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -19975,7 +19975,6 @@ end:
 
       if (result != expr)
 	{
-#if 0
 	  if (alias_print == NULL || (PT_IS_VALUE_NODE (result) && !result->info.value.text))
 	    {
 	      /* print expr to alias_print */
@@ -19998,7 +19997,6 @@ end:
 	    {
 	      result->info.value.is_collate_allowed = true;
 	    }
-#endif
 	  parser_free_tree (parser, expr);
 	}
 


### PR DESCRIPTION
…it did

http://jira.cubrid.org/browse/CBRD-20887

It was an experimental change and accidentally merged. 