### PR TITLE
[CBRD-20567] Allow Expression in LIMIT/KEYLIMIT Clause

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -1005,6 +1005,9 @@ int g_original_buffer_len;
 %type <node> cte_definition_list
 %type <node> cte_definition
 %type <node> cte_query_list
+%type <node> opt_limit_expr
+%type <node> limit_clause_times
+%type <node> limit_clause_term
 /*}}}*/
 
 /* define rule type (cptr) */
@@ -13224,7 +13227,7 @@ index_name_list
 	;
 	
 index_name_keylimit
-	: index_name KEYLIMIT opt_uint_or_host_input
+	: index_name KEYLIMIT opt_limit_expr
 		{{
 		
 			PT_NODE *node = $1;
@@ -13250,7 +13253,7 @@ index_name_keylimit
 			$$ = node;
 			
 		DBG_PRINT}}
-	| index_name KEYLIMIT opt_uint_or_host_input ',' opt_uint_or_host_input
+	| index_name KEYLIMIT opt_limit_expr ',' opt_limit_expr
 		{{
 		
 			PT_NODE *node = $1;
@@ -13754,6 +13757,75 @@ opt_uint_or_host_input
 		DBG_PRINT}}
 	;
 
+opt_limit_expr
+        : opt_limit_expr '+' limit_clause_times
+                {{
+                        $$ = parser_make_expression (this_parser, PT_PLUS, $1, $3, NULL);
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+
+                DBG_PRINT}}
+        | opt_limit_expr '-' limit_clause_times
+                {{
+                        $$ = parser_make_expression (this_parser, PT_MINUS, $1, $3, NULL);
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+
+                DBG_PRINT}}
+        | limit_clause_times
+                {{
+                        $$ = $1;
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+
+                DBG_PRINT}}
+        ;
+
+limit_clause_times
+        : limit_clause_times '*' limit_clause_term
+                {{
+                        $$ = parser_make_expression (this_parser, PT_TIMES, $1, $3, NULL);
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+
+                DBG_PRINT}}
+        | limit_clause_times '/' limit_clause_term
+                {{
+                        $$ = parser_make_expression (this_parser, PT_DIVIDE, $1, $3, NULL);
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+
+                DBG_PRINT}}
+        | limit_clause_term
+                {{
+                        $$ = $1;
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+
+                DBG_PRINT}}
+          ;
+
+
+
+limit_clause_term
+        : host_param_input
+                {{
+
+                        $$ = $1;
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+
+                DBG_PRINT}}
+        | unsigned_integer
+                {{
+
+                        $$ = $1;
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+
+                DBG_PRINT}}
+
+        | '(' opt_limit_expr ')'
+                {{
+
+                        $$ = $2;
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+
+                DBG_PRINT}}
+        ;              
+
 opt_select_limit_clause
 	: /* empty */
 	| LIMIT limit_options
@@ -13826,58 +13898,58 @@ opt_select_limit_clause
 	;
 
 limit_options
-	: opt_uint_or_host_input
-		{{
+        : opt_limit_expr
+                {{
 
-			PT_NODE *node = parser_top_orderby_node ();
-			if (node)
-			  {
-			    node->info.query.limit = $1;
-			    node->info.query.rewrite_limit = 1;
-			  }
-			$$ = node;
-			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+                        PT_NODE *node = parser_top_orderby_node ();
+                        if (node)
+                          {
+                            node->info.query.limit = $1;
+                            node->info.query.rewrite_limit = 1;
+                          }
+                        $$ = node;
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
-	| opt_uint_or_host_input ',' opt_uint_or_host_input
-		{{
+                DBG_PRINT}}
+        | opt_limit_expr ',' opt_limit_expr
+                {{
 
-			PT_NODE *node = parser_top_orderby_node ();
-			if (node)
-			  {
-			    PT_NODE *limit1 = $1;
-			    PT_NODE *limit2 = $3;
-			    if (limit1)
-			      {
-				limit1->next = limit2;
-			      }
-			    node->info.query.limit = limit1;
-			    node->info.query.rewrite_limit = 1;
-			  }
-			$$ = node;
-			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+                        PT_NODE *node = parser_top_orderby_node ();
+                        if (node)
+                          {
+                            PT_NODE *limit1 = $1;
+                            PT_NODE *limit2 = $3;
+                            if (limit1)
+                              {
+                                limit1->next = limit2;
+                              }
+                            node->info.query.limit = limit1;
+                            node->info.query.rewrite_limit = 1;
+                          }
+                        $$ = node;
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
-	| opt_uint_or_host_input OFFSET opt_uint_or_host_input
-		{{
+                DBG_PRINT}}
+        | opt_limit_expr OFFSET opt_limit_expr
+                {{
 
-			PT_NODE *node = parser_top_orderby_node ();
-			if (node)
-			  {
-			    PT_NODE *limit1 = $3;
-			    PT_NODE *limit2 = $1;
-			    if (limit1)
-			      {
-				limit1->next = limit2;
-			      }
-			    node->info.query.limit = limit1;
-			    node->info.query.rewrite_limit = 1;
-			  }
-			$$ = node;
-			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+                        PT_NODE *node = parser_top_orderby_node ();
+                        if (node)
+                          {
+                            PT_NODE *limit1 = $3;
+                            PT_NODE *limit2 = $1;
+                            if (limit1)
+                              {
+                                limit1->next = limit2;
+                              }
+                            node->info.query.limit = limit1;
+                            node->info.query.rewrite_limit = 1;
+                          }
+                        $$ = node;
+                        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
-	;
+                DBG_PRINT}}
+        ;
 
 opt_upd_del_limit_clause
 	: /* empty */


### PR DESCRIPTION
- Allow following type of expression in both LIMIT/KEYLIMIT Clause

1. 4 fundamental arithmetic operations(+,-,*,/)
2. use of parenthesis to express priority
3. Do not allow use of unary minus

- Some TCs should be modified/Some TCs should be newly written
  (will be done within couple of weeks)