### PR TITLE
[CBRD-20850] Remove order by from range expression argument

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -15781,3 +15781,48 @@ pt_coerce_partition_value_with_data_type (PARSER_CONTEXT * parser, PT_NODE * val
 
   return error;
 }
+
+/*
+ * pt_try_remove_order_by - verify and remove order_by clause after it has been decided it is unnecessary
+ *  return: void
+ *  parser(in): Parser context
+ *  query(in/out): Processed query
+ */
+void
+pt_try_remove_order_by (PARSER_CONTEXT * parser, PT_NODE * query)
+{
+  assert (PT_IS_QUERY_NODE_TYPE (query->node_type));
+
+  /* if select list has orderby_num(), can not remove ORDER BY clause for example:
+   * (i, j) = (select i, orderby_num() from t order by i) 
+   */
+  if (query->info.query.orderby_for == NULL && query->info.query.order_by)
+    {
+      PT_NODE *col, *next;
+      for (col = pt_get_select_list (parser, query); col; col = col->next)
+	{
+	  if (col->node_type == PT_EXPR && col->info.expr.op == PT_ORDERBY_NUM)
+	    {
+	      break;		/* can not remove ORDER BY clause */
+	    }
+	}
+
+      if (!col)
+	{
+	  parser_free_tree (parser, query->info.query.order_by);
+	  query->info.query.order_by = NULL;
+	  query->info.query.order_siblings = 0;
+
+	  for (col = pt_get_select_list (parser, query); col && col->next; col = next)
+	    {
+	      next = col->next;
+	      if (next->is_hidden_column)
+		{
+		  parser_free_tree (parser, next);
+		  col->next = NULL;
+		  break;
+		}
+	    }
+	}
+    }
+}

--- a/src/parser/semantic_check.h
+++ b/src/parser/semantic_check.h
@@ -61,4 +61,6 @@ extern PT_NODE *pt_check_odku_assignments (PARSER_CONTEXT * parser, PT_NODE * in
 extern int pt_attr_check_default_cs_coll (PARSER_CONTEXT * parser, PT_NODE * attr, int default_cs, int default_coll);
 extern PT_NODE *pt_check_cyclic_reference_in_view_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg,
 							int *continue_walk);
+extern void pt_try_remove_order_by (PARSER_CONTEXT * parser, PT_NODE * query);
+
 #endif /* _SEMANTIC_CHECK_H_ */

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5624,7 +5624,9 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
        * from the select list */
       PT_NODE *arg2_list = NULL;
 
+      /* duplicates are not relevant; order by is not relevant; */
       expr->info.expr.arg2->info.query.all_distinct = PT_DISTINCT;
+      pt_try_remove_order_by (parser, arg2);
 
       arg2_list = pt_get_select_list (parser, arg2);
       if (PT_IS_COLLECTION_TYPE (arg2_list->type_enum) && arg2_list->node_type == PT_FUNCTION)

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -8191,36 +8191,8 @@ mq_make_derived_spec (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * subquer
 {
   PT_NODE *range, *spec, *as_attr_list, *col, *next, *tmp;
 
-  /* remove unnecessary ORDER BY clause. if select list has orderby_num(), can not remove ORDER BY clause for example:
-   * (i, j) = (select i, orderby_num() from t order by i) */
-  if (subquery->info.query.orderby_for == NULL && subquery->info.query.order_by)
-    {
-      for (col = pt_get_select_list (parser, subquery); col; col = col->next)
-	{
-	  if (col->node_type == PT_EXPR && col->info.expr.op == PT_ORDERBY_NUM)
-	    {
-	      break;		/* can not remove ORDER BY clause */
-	    }
-	}
-
-      if (!col)
-	{
-	  parser_free_tree (parser, subquery->info.query.order_by);
-	  subquery->info.query.order_by = NULL;
-	  subquery->info.query.order_siblings = 0;
-
-	  for (col = pt_get_select_list (parser, subquery); col && col->next; col = next)
-	    {
-	      next = col->next;
-	      if (next->is_hidden_column)
-		{
-		  parser_free_tree (parser, next);
-		  col->next = NULL;
-		  break;
-		}
-	    }
-	}
-    }
+  /* remove unnecessary ORDER BY clause. */
+  pt_try_remove_order_by (parser, subquery);
 
   /* set line number to range name */
   range = pt_name (parser, "av1861");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20850

The order_by clause should be also removed when the query is marked with `PT_DISTINCT`. 
Without CTE, the order_by was removed mq_make_derived_spec and the semantic was checked afterwards.

I am not sure if `pt_try_remove_order_by `function belongs to **semantic_check.c** Let me know if you have suggestions.