### PR TITLE
[CBRD-20909] fixes memory leak of select_btree_node_info scan

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1020,7 +1020,7 @@ qexec_upddel_add_unique_oid_to_ehid (THREAD_ENTRY * thread_p, XASL_NODE * xasl, 
 
 	  if (typ != DB_TYPE_OID)
 	    {
-	      db_value_clear (dbval);
+	      pr_clear_value (dbval);
 	      GOTO_EXIT_ON_ERROR;
 	    }
 
@@ -1031,7 +1031,7 @@ qexec_upddel_add_unique_oid_to_ehid (THREAD_ENTRY * thread_p, XASL_NODE * xasl, 
 	    {
 	    case EH_KEY_FOUND:
 	      /* Make it null because it was already processed */
-	      db_value_clear (orig_dbval);
+	      pr_clear_value (orig_dbval);
 	      rem_cnt++;
 	      break;
 	    case EH_KEY_NOTFOUND:
@@ -1812,7 +1812,7 @@ qexec_clear_access_spec_list (XASL_NODE * xasl_p, THREAD_ENTRY * thread_p, ACCES
 		{
 		  for (i = 0; i < HEAP_RECORD_INFO_COUNT; i++)
 		    {
-		      db_value_clear (hsidp->cache_recordinfo[i]);
+		      pr_clear_value (hsidp->cache_recordinfo[i]);
 		    }
 		}
 	      hsidp->caches_inited = false;
@@ -1825,7 +1825,7 @@ qexec_clear_access_spec_list (XASL_NODE * xasl_p, THREAD_ENTRY * thread_p, ACCES
 	      int i;
 	      for (i = 0; i < HEAP_PAGE_INFO_COUNT; i++)
 		{
-		  db_value_clear (hpsidp->cache_page_info[i]);
+		  pr_clear_value (hpsidp->cache_page_info[i]);
 		}
 	    }
 	  break;
@@ -1868,7 +1868,7 @@ qexec_clear_access_spec_list (XASL_NODE * xasl_p, THREAD_ENTRY * thread_p, ACCES
 	      int i;
 	      for (i = 0; i < BTREE_KEY_INFO_COUNT; i++)
 		{
-		  db_value_clear (isidp->key_info_values[i]);
+		  pr_clear_value (isidp->key_info_values[i]);
 		}
 	      isidp->caches_inited = false;
 	    }
@@ -1881,7 +1881,7 @@ qexec_clear_access_spec_list (XASL_NODE * xasl_p, THREAD_ENTRY * thread_p, ACCES
 	      int i;
 	      for (i = 0; i < BTREE_NODE_INFO_COUNT; i++)
 		{
-		  db_value_clear (insidp->node_info_values[i]);
+		  pr_clear_value (insidp->node_info_values[i]);
 		}
 	      insidp->caches_inited = false;
 	    }
@@ -7472,7 +7472,7 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec)
 	    {
 	      for (i = 0; i < HEAP_RECORD_INFO_COUNT; i++)
 		{
-		  db_value_clear (hsidp->cache_recordinfo[i]);
+		  pr_clear_value (hsidp->cache_recordinfo[i]);
 		}
 	    }
 	  hsidp->caches_inited = false;
@@ -7498,7 +7498,7 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec)
 	{
 	  for (i = 0; i < HEAP_PAGE_INFO_COUNT; i++)
 	    {
-	      db_value_clear (hpsidp->cache_page_info[i]);
+	      pr_clear_value (hpsidp->cache_page_info[i]);
 	    }
 	}
       error =
@@ -18526,10 +18526,10 @@ qexec_groupby_index (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xas
 		  all_cols_equal = false;
 		}
 
-	      db_value_clear (&list_dbvals[i]);
+	      pr_clear_value (&list_dbvals[i]);
 	    }
 
-	  db_value_clone (&val, &list_dbvals[i]);
+	  pr_clone_value (&val, &list_dbvals[i]);
 
 	  if (DB_NEED_CLEAR (&val))
 	    {
@@ -21783,7 +21783,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
       db_make_string (&braket, ")");
       db_make_string (&enum_, "ENUM(");
 
-      db_value_clone (&enum_, penum_result);
+      pr_clone_value (&enum_, penum_result);
       for (i = 0; i < enum_elements_count; i++)
 	{
 	  penum_temp = penum_arg1;
@@ -21792,10 +21792,10 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 	  if ((db_string_concatenate (penum_arg1, &quote, penum_result, &data_stat) != NO_ERROR)
 	      || (data_stat != DATA_STATUS_OK))
 	    {
-	      db_value_clear (penum_arg1);
+	      pr_clear_value (penum_arg1);
 	      goto exit_on_error;
 	    }
-	  db_value_clear (penum_arg1);
+	  pr_clear_value (penum_arg1);
 
 	  penum_temp = penum_arg1;
 	  penum_arg1 = penum_result;
@@ -21805,10 +21805,10 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 	  if ((db_string_concatenate (penum_arg1, penum_arg2, penum_result, &data_stat) != NO_ERROR)
 	      || (data_stat != DATA_STATUS_OK))
 	    {
-	      db_value_clear (penum_arg1);
+	      pr_clear_value (penum_arg1);
 	      goto exit_on_error;
 	    }
-	  db_value_clear (penum_arg1);
+	  pr_clear_value (penum_arg1);
 
 	  penum_temp = penum_arg1;
 	  penum_arg1 = penum_result;
@@ -21818,7 +21818,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 	      if ((db_string_concatenate (penum_arg1, &quote_comma_space, penum_result, &data_stat) != NO_ERROR)
 		  || (data_stat != DATA_STATUS_OK))
 		{
-		  db_value_clear (penum_arg1);
+		  pr_clear_value (penum_arg1);
 		  goto exit_on_error;
 		}
 	    }
@@ -21827,11 +21827,11 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 	      if ((db_string_concatenate (penum_arg1, &quote, penum_result, &data_stat) != NO_ERROR)
 		  || (data_stat != DATA_STATUS_OK))
 		{
-		  db_value_clear (penum_arg1);
+		  pr_clear_value (penum_arg1);
 		  goto exit_on_error;
 		}
 	    }
-	  db_value_clear (penum_arg1);
+	  pr_clear_value (penum_arg1);
 	}
 
       penum_temp = penum_arg1;
@@ -21842,9 +21842,9 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 	{
 	  goto exit_on_error;
 	}
-      db_value_clear (penum_arg1);
-      db_value_clone (penum_result, result);
-      db_value_clear (penum_result);
+      pr_clear_value (penum_arg1);
+      pr_clone_value (penum_result, result);
+      pr_clear_value (penum_result);
 
       return NO_ERROR;
     }
@@ -21903,7 +21903,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
       db_make_string (&comma, ",");
       db_make_string (&set_of, set_of_string);
 
-      db_value_clone (&set_of, pset_result);
+      pr_clone_value (&set_of, pset_result);
       for (setdomain = domain->setdomain, i = 0; setdomain; setdomain = setdomain->next, i++)
 	{
 	  pset_temp = pset_arg1;
@@ -21914,10 +21914,10 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 	      || (data_stat != DATA_STATUS_OK))
 	    {
 	      free_and_init (ordered_names);
-	      db_value_clear (pset_arg1);
+	      pr_clear_value (pset_arg1);
 	      goto exit_on_error;
 	    }
-	  db_value_clear (pset_arg1);
+	  pr_clear_value (pset_arg1);
 
 	  if (setdomain->next != NULL)
 	    {
@@ -21928,15 +21928,15 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 		  || (data_stat != DATA_STATUS_OK))
 		{
 		  free_and_init (ordered_names);
-		  db_value_clear (pset_arg1);
+		  pr_clear_value (pset_arg1);
 		  goto exit_on_error;
 		}
-	      db_value_clear (pset_arg1);
+	      pr_clear_value (pset_arg1);
 	    }
 	}
 
-      db_value_clone (pset_result, result);
-      db_value_clear (pset_result);
+      pr_clone_value (pset_result, result);
+      pr_clear_value (pset_result);
       free_and_init (ordered_names);
       return NO_ERROR;
     }
@@ -21962,14 +21962,14 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
       db_make_string (&bracket2, ")");
       db_make_string (&db_name, name);
 
-      db_value_clone (&db_name, pprec_scale_arg1);
+      pr_clone_value (&db_name, pprec_scale_arg1);
       if ((db_string_concatenate (pprec_scale_arg1, &bracket1, pprec_scale_result, &data_stat) != NO_ERROR)
 	  || (data_stat != DATA_STATUS_OK))
 	{
-	  db_value_clear (pprec_scale_arg1);
+	  pr_clear_value (pprec_scale_arg1);
 	  goto exit_on_error;
 	}
-      db_value_clear (pprec_scale_arg1);
+      pr_clear_value (pprec_scale_arg1);
 
       pprec_scale_temp = pprec_scale_arg1;
       pprec_scale_arg1 = pprec_scale_result;
@@ -21977,11 +21977,11 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
       if ((db_string_concatenate (pprec_scale_arg1, &db_str_precision, pprec_scale_result, &data_stat) != NO_ERROR)
 	  || (data_stat != DATA_STATUS_OK))
 	{
-	  db_value_clear (pprec_scale_arg1);
+	  pr_clear_value (pprec_scale_arg1);
 	  goto exit_on_error;
 	}
-      db_value_clear (&db_str_precision);
-      db_value_clear (pprec_scale_arg1);
+      pr_clear_value (&db_str_precision);
+      pr_clear_value (pprec_scale_arg1);
 
       if (scale >= 0)
 	{
@@ -21989,7 +21989,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 	  DB_MAKE_NULL (&db_str_scale);
 	  if (tp_value_cast (&db_int_scale, &db_str_scale, &tp_String_domain, false) != DOMAIN_COMPATIBLE)
 	    {
-	      db_value_clear (pprec_scale_result);
+	      pr_clear_value (pprec_scale_result);
 	      goto exit_on_error;
 	    }
 
@@ -21999,10 +21999,10 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 	  if ((db_string_concatenate (pprec_scale_arg1, &comma, pprec_scale_result, &data_stat) != NO_ERROR)
 	      || (data_stat != DATA_STATUS_OK))
 	    {
-	      db_value_clear (pprec_scale_arg1);
+	      pr_clear_value (pprec_scale_arg1);
 	      goto exit_on_error;
 	    }
-	  db_value_clear (pprec_scale_arg1);
+	  pr_clear_value (pprec_scale_arg1);
 
 	  pprec_scale_temp = pprec_scale_arg1;
 	  pprec_scale_arg1 = pprec_scale_result;
@@ -22010,11 +22010,11 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 	  if ((db_string_concatenate (pprec_scale_arg1, &db_str_scale, pprec_scale_result, &data_stat) != NO_ERROR)
 	      || (data_stat != DATA_STATUS_OK))
 	    {
-	      db_value_clear (pprec_scale_arg1);
+	      pr_clear_value (pprec_scale_arg1);
 	      goto exit_on_error;
 	    }
-	  db_value_clear (&db_str_scale);
-	  db_value_clear (pprec_scale_arg1);
+	  pr_clear_value (&db_str_scale);
+	  pr_clear_value (pprec_scale_arg1);
 	}
 
       pprec_scale_temp = pprec_scale_arg1;
@@ -22023,13 +22023,13 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
       if ((db_string_concatenate (pprec_scale_arg1, &bracket2, pprec_scale_result, &data_stat) != NO_ERROR)
 	  || (data_stat != DATA_STATUS_OK))
 	{
-	  db_value_clear (pprec_scale_arg1);
+	  pr_clear_value (pprec_scale_arg1);
 	  goto exit_on_error;
 	}
-      db_value_clear (pprec_scale_arg1);
+      pr_clear_value (pprec_scale_arg1);
 
-      db_value_clone (pprec_scale_result, result);
-      db_value_clear (pprec_scale_result);
+      pr_clone_value (pprec_scale_result, result);
+      pr_clear_value (pprec_scale_result);
 
       return NO_ERROR;
     }
@@ -22037,7 +22037,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
   {
     DB_VALUE db_name;
     db_make_string (&db_name, name);
-    db_value_clone (&db_name, result);
+    pr_clone_value (&db_name, result);
   }
 
   return NO_ERROR;
@@ -22403,10 +22403,10 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 
 	  for (j = 1; j < size_values; j++)
 	    {
-	      db_value_clear (out_values[j]);
+	      pr_clear_value (out_values[j]);
 	    }
 	}
-      db_value_clear (out_values[0]);
+      pr_clear_value (out_values[0]);
     }
 
   free_and_init (out_values);
@@ -22441,7 +22441,7 @@ exit_on_error:
     {
       for (i = 0; i < size_values; i++)
 	{
-	  db_value_clear (out_values[i]);
+	  pr_clear_value (out_values[i]);
 	}
 
       free_and_init (out_values);

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1518,7 +1518,7 @@ end:
     {
       for (i = 0, dbval = dbvals_p; i < dbval_count; i++, dbval++)
 	{
-	  db_value_clear (dbval);
+	  pr_clear_value (dbval);
 	}
       db_private_free_and_init (thread_p, dbvals_p);
     }
@@ -1795,7 +1795,7 @@ end:
     {
       for (i = 0, dbval = dbvals_p; i < dbval_count; i++, dbval++)
 	{
-	  db_value_clear (dbval);
+	  pr_clear_value (dbval);
 	}
       db_private_free_and_init (thread_p, dbvals_p);
     }

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -7422,7 +7422,7 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 		    }
 
 		  pr_clear_value (agg_p->accumulator.value);
-		  error = db_value_clone (&dbval, agg_p->accumulator.value);
+		  error = pr_clone_value (&dbval, agg_p->accumulator.value);
 		  if (error != NO_ERROR)
 		    {
 		      pr_clear_value (&dbval);
@@ -9108,7 +9108,7 @@ qdata_evaluate_connect_by_root (THREAD_ENTRY * thread_p, void *xasl_p, REGU_VARI
       /* TYPE_CONSTANT but not in val_list, check if it is inst_num() (orderby_num() is not allowed) */
       if (regu_p->value.dbvalptr == xasl->instnum_val)
 	{
-	  if (db_value_clone (xasl->instnum_val, result_val_p) != NO_ERROR)
+	  if (pr_clone_value (xasl->instnum_val, result_val_p) != NO_ERROR)
 	    {
 	      return false;
 	    }
@@ -9529,7 +9529,7 @@ qdata_evaluate_sys_connect_by_path (THREAD_ENTRY * thread_p, void *xasl_p, REGU_
 		{
 		  goto error2;
 		}
-	      if (db_value_clone (save_values[i], valp->val) != NO_ERROR)
+	      if (pr_clone_value (save_values[i], valp->val) != NO_ERROR)
 		{
 		  goto error2;
 		}
@@ -9539,7 +9539,7 @@ qdata_evaluate_sys_connect_by_path (THREAD_ENTRY * thread_p, void *xasl_p, REGU_
 	    {
 	      if (save_values[i])
 		{
-		  if (db_value_free (save_values[i]) != NO_ERROR)
+		  if (pr_free_ext_value (save_values[i]) != NO_ERROR)
 		    {
 		      goto error2;
 		    }
@@ -9571,7 +9571,7 @@ error:
 	{
 	  if (save_values[i])
 	    {
-	      db_value_free (save_values[i]);
+	      pr_free_ext_value (save_values[i]);
 	    }
 	}
       db_private_free_and_init (thread_p, save_values);
@@ -10443,7 +10443,7 @@ qdata_elt (THREAD_ENTRY * thread_p, FUNCTION_TYPE * function_p, VAL_DESCR * val_
    * operand should already be cast to the right type (CHAR
    * or NCHAR VARYING)
    */
-  error_status = db_value_clone (operand_value, function_p->value);
+  error_status = pr_clone_value (operand_value, function_p->value);
 
 fast_exit:
   return error_status;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -2270,7 +2270,7 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
 	{
 	  if (iscan_id->multi_range_opt.top_n_items[i] != NULL)
 	    {
-	      db_value_clear (&(iscan_id->multi_range_opt.top_n_items[i]->index_value));
+	      pr_clear_value (&(iscan_id->multi_range_opt.top_n_items[i]->index_value));
 	      db_private_free_and_init (thread_p, iscan_id->multi_range_opt.top_n_items[i]);
 	    }
 	}
@@ -4607,7 +4607,7 @@ scan_close_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	    {
 	      if (isidp->multi_range_opt.top_n_items[i] != NULL)
 		{
-		  db_value_clear (&(isidp->multi_range_opt.top_n_items[i]->index_value));
+		  pr_clear_value (&(isidp->multi_range_opt.top_n_items[i]->index_value));
 		  db_private_free_and_init (thread_p, isidp->multi_range_opt.top_n_items[i]);
 		}
 	    }

--- a/src/query/show_scan.c
+++ b/src/query/show_scan.c
@@ -361,7 +361,7 @@ showstmt_free_array_context (THREAD_ENTRY * thread_p, SHOWSTMT_ARRAY_CONTEXT * c
       vals = ctx->tuples[i];
       for (j = 0; j < ctx->num_cols; j++)
 	{
-	  db_value_clear (&vals[j]);
+	  pr_clear_value (&vals[j]);
 	}
 
       db_private_free (thread_p, vals);
@@ -440,7 +440,7 @@ showstmt_array_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_v
 
   for (i = 0; i < ctx->num_cols; i++)
     {
-      db_value_clone (&vals[i], out_values[i]);
+      pr_clone_value (&vals[i], out_values[i]);
     }
 
   return S_SUCCESS;

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -11182,7 +11182,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
       goto error;
     }
 
-  db_value_clear (&new_time_value);
+  pr_clear_value (&new_time_value);
 
   /* 2. Compute the value for each format specifier */
   if (mi < 0)
@@ -11403,7 +11403,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
   return error_status;
 
 error:
-  db_value_clear (&new_time_value);
+  pr_clear_value (&new_time_value);
 
   if (res != NULL)
     {

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1971,7 +1971,7 @@ btree_store_overflow_key (THREAD_ENTRY * thread_p, BTID_INT * btid, DB_VALUE * k
 
   if (key_ptr != key)
     {
-      db_value_clear (key_ptr);
+      pr_clear_value (key_ptr);
     }
 
   return ret;
@@ -1985,7 +1985,7 @@ exit_on_error:
 
   if (key_ptr != key)
     {
-      db_value_clear (key_ptr);
+      pr_clear_value (key_ptr);
     }
 
   return (ret == NO_ERROR && (ret = er_errid ()) == NO_ERROR) ? ER_FAILED : ret;
@@ -16043,14 +16043,14 @@ btree_get_next_key_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_SCAN * bts,
   DB_MAKE_INT (key_info[BTREE_KEY_INFO_SLOTID], bts->slot_id);
 
   /* Get key */
-  db_value_clear (key_info[BTREE_KEY_INFO_KEY]);
-  db_value_clone (&bts->cur_key, key_info[BTREE_KEY_INFO_KEY]);
+  pr_clear_value (key_info[BTREE_KEY_INFO_KEY]);
+  pr_clone_value (&bts->cur_key, key_info[BTREE_KEY_INFO_KEY]);
 
   /* Get overflow key and overflow oids */
-  db_value_clear (key_info[BTREE_KEY_INFO_OVERFLOW_KEY]);
+  pr_clear_value (key_info[BTREE_KEY_INFO_OVERFLOW_KEY]);
   DB_MAKE_STRING (key_info[BTREE_KEY_INFO_OVERFLOW_KEY],
 		  btree_leaf_is_flaged (&bts->key_record, BTREE_LEAF_RECORD_OVERFLOW_KEY) ? "true" : "false");
-  db_value_clear (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS]);
+  pr_clear_value (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS]);
   DB_MAKE_STRING (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS],
 		  btree_leaf_is_flaged (&bts->key_record, BTREE_LEAF_RECORD_OVERFLOW_OIDS) ? "true" : "false");
 
@@ -18699,8 +18699,8 @@ btree_range_opt_check_add_index_key (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, 
 	}
 
       /* overwrite the last item with the new key and OIDs */
-      db_value_clear (&(last_item->index_value));
-      db_value_clone (&(bts->cur_key), &(last_item->index_value));
+      pr_clear_value (&(last_item->index_value));
+      pr_clone_value (&(bts->cur_key), &(last_item->index_value));
       COPY_OID (&(last_item->inst_oid), p_new_oid);
     }
   else
@@ -18717,7 +18717,7 @@ btree_range_opt_check_add_index_key (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, 
 	}
 
       multi_range_opt->top_n_items[multi_range_opt->cnt] = curr_item;
-      db_value_clone (&(bts->cur_key), &(curr_item->index_value));
+      pr_clone_value (&(bts->cur_key), &(curr_item->index_value));
 
       COPY_OID (&(curr_item->inst_oid), p_new_oid);
 
@@ -19962,7 +19962,7 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
   DB_MAKE_INT (node_info[BTREE_NODE_INFO_PAGEID], btns->crt_vpid.pageid);
 
   /* Get node type */
-  db_value_clear (node_info[BTREE_NODE_INFO_NODE_TYPE]);
+  pr_clear_value (node_info[BTREE_NODE_INFO_NODE_TYPE]);
   DB_MAKE_STRING (node_info[BTREE_NODE_INFO_NODE_TYPE], (node_type == BTREE_NON_LEAF_NODE) ? "non-leaf" : "leaf");
 
   /* Get key count */
@@ -19980,7 +19980,7 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
 	{
 	  goto error;
 	}
-      db_value_clear (node_info[BTREE_NODE_INFO_FIRST_KEY]);
+      pr_clear_value (node_info[BTREE_NODE_INFO_FIRST_KEY]);
       *node_info[BTREE_NODE_INFO_FIRST_KEY] = key_value;	/* just copy. it will be cleared later */
 
       /* Get last key */
@@ -19993,16 +19993,16 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
 	{
 	  goto error;
 	}
-      db_value_clear (node_info[BTREE_NODE_INFO_LAST_KEY]);
+      pr_clear_value (node_info[BTREE_NODE_INFO_LAST_KEY]);
       *node_info[BTREE_NODE_INFO_LAST_KEY] = key_value;	/* just copy. it will be cleared later */
     }
   else
     {
       /* Empty node */
-      db_value_clear (node_info[BTREE_NODE_INFO_FIRST_KEY]);
+      pr_clear_value (node_info[BTREE_NODE_INFO_FIRST_KEY]);
       DB_MAKE_NULL (node_info[BTREE_NODE_INFO_FIRST_KEY]);
 
-      db_value_clear (node_info[BTREE_NODE_INFO_LAST_KEY]);
+      pr_clear_value (node_info[BTREE_NODE_INFO_LAST_KEY]);
       DB_MAKE_NULL (node_info[BTREE_NODE_INFO_LAST_KEY]);
     }
 
@@ -21681,7 +21681,7 @@ btree_check_valid_record (THREAD_ENTRY * thread_p, BTID_INT * btid, RECDES * rec
 		   * fence for compare */
 		  /* For now, do nothing */
 		}
-	      db_value_clear (&rec_key_value);
+	      pr_clear_value (&rec_key_value);
 	    }
 	  else
 	    {

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -19981,7 +19981,7 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
 	  goto error;
 	}
       db_value_clear (node_info[BTREE_NODE_INFO_FIRST_KEY]);
-      db_value_clone (&key_value, node_info[BTREE_NODE_INFO_FIRST_KEY]);
+      *node_info[BTREE_NODE_INFO_FIRST_KEY] = key_value;	/* just copy. it will be cleared later */
 
       /* Get last key */
       if (spage_get_record (btns->crt_page, key_cnt, &rec, PEEK) != S_SUCCESS)
@@ -19994,7 +19994,7 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
 	  goto error;
 	}
       db_value_clear (node_info[BTREE_NODE_INFO_LAST_KEY]);
-      db_value_clone (&key_value, node_info[BTREE_NODE_INFO_LAST_KEY]);
+      *node_info[BTREE_NODE_INFO_LAST_KEY] = key_value;	/* just copy. it will be cleared later */
     }
   else
     {

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -2502,7 +2502,7 @@ catcls_get_or_value_from_indexes (DB_SEQ * seq_p, OR_VALUE * values, int is_uniq
       pr_clear_value (&keys);
       if (pvalue)
 	{
-	  db_value_free (pvalue);
+	  pr_free_ext_value (pvalue);
 	  pvalue = NULL;
 	}
 
@@ -2529,7 +2529,7 @@ error:
   pr_clear_value (&avalue);
   if (pvalue)
     {
-      db_value_free (pvalue);
+      pr_free_ext_value (pvalue);
     }
   return error;
 }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -11245,7 +11245,7 @@ heap_attrinfo_set_uninitialized (THREAD_ENTRY * thread_p, OID * inst_oid, RECDES
 	{
 	  DB_VALUE *save;
 	  save = db_value_copy (&value->dbvalue);
-	  db_value_clear (&value->dbvalue);
+	  pr_clear_value (&value->dbvalue);
 
 	  /* read and delete old value */
 	  ret = heap_attrvalue_read (recdes, value, attr_info);
@@ -11264,7 +11264,7 @@ heap_attrinfo_set_uninitialized (THREAD_ENTRY * thread_p, OID * inst_oid, RECDES
 		{
 		  ret = db_elo_delete (elo);
 		}
-	      db_value_clear (&value->dbvalue);
+	      pr_clear_value (&value->dbvalue);
 	      ret = (ret >= 0 ? NO_ERROR : ret);
 	      if (ret != NO_ERROR)
 		{
@@ -11272,8 +11272,8 @@ heap_attrinfo_set_uninitialized (THREAD_ENTRY * thread_p, OID * inst_oid, RECDES
 		}
 	    }
 	  value->state = HEAP_WRITTEN_ATTRVALUE;
-	  db_value_clone (save, &value->dbvalue);
-	  db_value_free (save);
+	  pr_clone_value (save, &value->dbvalue);
+	  pr_free_ext_value (save);
 	}
     }
 
@@ -11676,7 +11676,7 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 		      error = (error >= 0 ? NO_ERROR : error);
 		      if (error == NO_ERROR)
 			{
-			  db_value_clear (dbvalue);
+			  pr_clear_value (dbvalue);
 			  db_make_elo (dbvalue, pr_type->id, &dest_elo);
 			  dbvalue->need_clear = true;
 			}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20909

6d8aa6a fixes memory leak. 
It also changes avoid compat APIs from server. 