### PR TITLE
[CBRD-20697] Ordered fix: prevent unfixed page from being deallocated

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -10362,7 +10362,7 @@ pgbuf_ordered_fix_release (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAGE_
   PGBUF_HOLDER *holder, *next_holder;
   PAGE_PTR pgptr, ret_pgptr;
   int i, thrd_idx;
-  int saved_pages_cnt;
+  int saved_pages_cnt = 0;
   int curr_request_mode;
   PAGE_FETCH_MODE curr_fetch_mode;
   PGBUF_HOLDER_INFO ordered_holders_info[PGBUF_MAX_PAGE_FIXED_BY_TRAN];
@@ -10525,8 +10525,6 @@ pgbuf_ordered_fix_release (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAGE_
       /* to proceed ordered fix the pages, forget any underlying error. */
       er_status = NO_ERROR;
     }
-
-  saved_pages_cnt = 0;
 
   if (fetch_mode == OLD_PAGE_PREVENT_DEALLOC)
     {

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -11122,15 +11122,19 @@ exit:
 	    {
 	      /* oops... no longer in buffer?? */
 	      assert (false);
+	      pthread_mutex_unlock (&hash_anchor->hash_mutex);
 	      continue;
 	    }
 	  if (bufptr->avoid_dealloc_cnt == 0)
 	    {
 	      /* oops... deallocate not prevented */
 	      assert (false);
-	      continue;
 	    }
-	  ATOMIC_INC_32 (&bufptr->avoid_dealloc_cnt, -1);
+	  else
+	    {
+	      ATOMIC_INC_32 (&bufptr->avoid_dealloc_cnt, -1);
+	    }
+	  pthread_mutex_unlock (&bufptr->BCB_mutex);
 	}
     }
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -292,7 +292,7 @@ struct pgbuf_holder_info
   PGBUF_WATCHER *watcher[PGBUF_MAX_PAGE_WATCHERS];	/* pointers to all watchers to this holder */
   PGBUF_LATCH_MODE latch_mode;	/* aggregate latch mode of all watchers */
   PAGE_TYPE ptype;		/* page type (should be HEAP or OVERFLOW) */
-  bool prevent_dealloc;		/* page is prevented to be deallocated. */
+  bool prevent_dealloc;		/* page is prevented from being deallocated. */
 };
 
 typedef struct pgbuf_holder_stat PGBUF_HOLDER_STAT;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -10776,7 +10776,7 @@ pgbuf_ordered_fix_release (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAGE_
       CAST_BFPTR_TO_PGPTR (pgptr, holder->bufptr);
       assert (holder_fix_cnt > 0);
       /* prevent deallocate. */
-      ATOMIC_INC_32 (holder->bufptr->avoid_dealloc_cnt, 1);
+      ATOMIC_INC_32 (&holder->bufptr->avoid_dealloc_cnt, 1);
       ordered_holders_info[i].prevent_dealloc = true;
       while (holder_fix_cnt-- > 0)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20697

This issue is that vacuum deallocated pages unfixed by ordered fix. Active worker wants to advance during heap scan from a page to next page. Next page has higher priority, so current page must be unfixed. A vacuum worker fixes page and deallocates it before active worker fixes it again.