### PR TITLE
[CBRD-20906] fix vacuum recovery of log_Gl.hdr

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2910,9 +2910,7 @@ restart:
   vacuum_cleanup_dropped_files (thread_p);
 
   /* Reset log header information saved for vacuum. */
-  LSA_SET_NULL (&log_Gl.hdr.mvcc_op_log_lsa);
-  log_Gl.hdr.last_block_oldest_mvccid = MVCCID_NULL;
-  log_Gl.hdr.last_block_newest_mvccid = MVCCID_NULL;
+  vacuum_reset_log_header_cache ();
 
   er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_STAND_ALONE_VACUUM_END, 0);
   er_log_debug (ARG_FILE_LINE, "Stand-alone vacuum end.\n");
@@ -2946,9 +2944,7 @@ vacuum_rv_redo_vacuum_complete (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   vacuum_Data.oldest_unvacuumed_mvccid = oldest_newest_mvccid;
 
   /* Reset log header information saved for vacuum. */
-  LSA_SET_NULL (&log_Gl.hdr.mvcc_op_log_lsa);
-  log_Gl.hdr.last_block_oldest_mvccid = MVCCID_NULL;
-  log_Gl.hdr.last_block_newest_mvccid = MVCCID_NULL;
+  vacuum_reset_log_header_cache ();
 
   pgbuf_set_dirty (thread_p, rcv->pgptr, DONT_FREE);
 
@@ -4821,7 +4817,7 @@ vacuum_rv_undoredo_first_data_page_dump (FILE * fp, int length, void *data)
 int
 vacuum_rv_redo_data_finished (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 {
-  char *rcv_data_ptr = (void *) rcv->data;
+  const char *rcv_data_ptr = rcv->data;
   VACUUM_LOG_BLOCKID blockid;
   VACUUM_LOG_BLOCKID blockid_with_flags;
   VACUUM_LOG_BLOCKID page_unvacuumed_blockid;
@@ -4891,7 +4887,7 @@ vacuum_rv_redo_data_finished (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 void
 vacuum_rv_redo_data_finished_dump (FILE * fp, int length, void *data)
 {
-  char *rcv_data_ptr = data;
+  const char *rcv_data_ptr = (const char *) data;
   VACUUM_LOG_BLOCKID blockid;
   VACUUM_LOG_BLOCKID blockid_with_flags;
 
@@ -5243,6 +5239,8 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   LOG_LSA mvcc_op_log_lsa = LSA_INITIALIZER;
   bool is_last_block = false;
 
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+		 "VACUUM: vacuum_recover_lost_block_data, lsa = %lld|%d n", LSA_AS_ARGS (&vacuum_Data.recovery_lsa));
   if (LSA_ISNULL (&vacuum_Data.recovery_lsa))
     {
       /* No recovery was done. */
@@ -5258,6 +5256,9 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   if (LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa))
     {
       /* We need to search for an MVCC op log record to start recovering lost blocks. */
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+		     "VACUUM: vacuum_recover_lost_block_data, log_Gl.hdr.mvcc_op_log_lsa is null \n");
+
       LSA_COPY (&log_lsa, &vacuum_Data.recovery_lsa);
       /* Stop search if search reaches blocks already in vacuum data. */
       stop_at_pageid = VACUUM_LAST_LOG_PAGEID_IN_BLOCK (vacuum_Data.last_blockid);
@@ -5279,6 +5280,9 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	      || log_rec_header.type == LOG_MVCC_DIFF_UNDOREDO_DATA)
 	    {
 	      LSA_COPY (&mvcc_op_log_lsa, &log_lsa);
+	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+			     "VACUUM: vacuum_recover_lost_block_data, found mvcc op at lsa = %lld|%d \n",
+			     LSA_AS_ARGS (&mvcc_op_log_lsa));
 	      break;
 	    }
 	  else if (log_rec_header.type == LOG_REDO_DATA)
@@ -5293,6 +5297,8 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	      if (redo->data.rcvindex == RVVAC_COMPLETE)
 		{
 		  /* stop looking */
+		  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+				 "VACUUM: vacuum_recover_lost_block_data, complete vacuum \n");
 		  break;
 		}
 	    }
@@ -5302,13 +5308,19 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
       if (LSA_ISNULL (&mvcc_op_log_lsa))
 	{
 	  /* Vacuum data was reached, so there is nothing to recover. */
+	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+			 "VACUUM: vacuum_recover_lost_block_data, nothing to recovery \n");
 	  return NO_ERROR;
 	}
     }
   else if (vacuum_get_log_blockid (log_Gl.hdr.mvcc_op_log_lsa.pageid) <= vacuum_Data.last_blockid)
     {
       /* Already in vacuum data. */
-      LSA_SET_NULL (&log_Gl.hdr.mvcc_op_log_lsa);
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+		     "VACUUM: vacuum_recover_lost_block_data, mvcc_op_log_lsa %lld|%d is already in vacuum data "
+		     "(last blockid = %lld) \n", LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa),
+		     (long long int) vacuum_Data.last_blockid);
+      vacuum_reset_log_header_cache ();
       return NO_ERROR;
     }
   else
@@ -5316,6 +5328,10 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
       LSA_COPY (&mvcc_op_log_lsa, &log_Gl.hdr.mvcc_op_log_lsa);
     }
   assert (!LSA_ISNULL (&mvcc_op_log_lsa));
+
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+		 "VACUUM: vacuum_recover_lost_block_data, start recovering from %lld|%d \n",
+		 LSA_AS_ARGS (&mvcc_op_log_lsa));
 
   /* Start recovering blocks. */
   is_last_block = true;
@@ -5370,6 +5386,13 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	  log_Gl.hdr.last_block_newest_mvccid = data.newest_mvccid;
 	  LSA_COPY (&log_Gl.hdr.mvcc_op_log_lsa, &data.start_lsa);
 	  is_last_block = false;
+
+	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+			 "VACUUM: Restore log global cached info: \n\t mvcc_op_log_lsa = %lld|%d \n"
+			 "\t last_block_oldest_mvccid = %llu \n\t last_block_newest_mvccid = %llu \n",
+			 LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa),
+			 (unsigned long long int) log_Gl.hdr.last_block_oldest_mvccid,
+			 (unsigned long long int) log_Gl.hdr.last_block_newest_mvccid);
 	}
       else
 	{
@@ -5387,6 +5410,18 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 
   lf_circular_queue_async_reset (vacuum_Block_data_buffer);
   return NO_ERROR;
+}
+
+/*
+ * vacuum_reset_log_header_cache () - reset vacuum data cached in log global header.
+ */
+void
+vacuum_reset_log_header_cache (void)
+{
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Reset vacuum info in log_Gl.hdr \n");
+  LSA_SET_NULL (&log_Gl.hdr.mvcc_op_log_lsa);
+  log_Gl.hdr.last_block_oldest_mvccid = MVCCID_NULL;
+  log_Gl.hdr.last_block_newest_mvccid = MVCCID_NULL;
 }
 
 /*
@@ -5520,7 +5555,7 @@ vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p)
   vacuum_Data.keep_from_log_pageid = VACUUM_FIRST_LOG_PAGEID_IN_BLOCK (keep_from_blockid);
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
-		 "VACUUM: Update keep_from_log_pageid to %lld", (long long int) vacuum_Data.keep_from_log_pageid);
+		 "VACUUM: Update keep_from_log_pageid to %lld \n", (long long int) vacuum_Data.keep_from_log_pageid);
 }
 
 /*

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -281,6 +281,7 @@ extern void vacuum_start_new_job (THREAD_ENTRY * thread_p);
 
 extern int vacuum_create_file_for_vacuum_data (THREAD_ENTRY * thread_p, VFID * vacuum_data_vfid);
 extern int vacuum_load_data_from_disk (THREAD_ENTRY * thread_p);
+extern void vacuum_reset_log_header_cache (void);
 extern VACUUM_LOG_BLOCKID vacuum_get_log_blockid (LOG_PAGEID pageid);
 extern void vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, MVCCID oldest_mvccid,
 					   MVCCID newest_mvccid);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1377,9 +1377,7 @@ logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const cha
   LSA_SET_NULL (&loghdr->eof_lsa);
   LSA_SET_NULL (&loghdr->smallest_lsa_at_last_chkpt);
 
-  LSA_SET_NULL (&loghdr->mvcc_op_log_lsa);
-  loghdr->last_block_newest_mvccid = MVCCID_NULL;
-  loghdr->last_block_oldest_mvccid = MVCCID_NULL;
+  vacuum_reset_log_header_cache ();
 
   return NO_ERROR;
 }

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3082,9 +3082,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 		  LOG_LSA null_lsa = LSA_INITIALIZER;
 
 		  /* Reset log header MVCC info */
-		  LSA_SET_NULL (&log_Gl.hdr.mvcc_op_log_lsa);
-		  log_Gl.hdr.last_block_oldest_mvccid = MVCCID_NULL;
-		  log_Gl.hdr.last_block_newest_mvccid = MVCCID_NULL;
+		  vacuum_reset_log_header_cache ();
 
 		  /* Reset vacuum recover LSA */
 		  vacuum_notify_server_crashed (&null_lsa);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20906

The bug is generated by a mistake in vacuum_recover_lost_block_data code. When we need to recovery vacuum data (that is not logged), we may have two cases:

1. mvcc_op_log_lsa is not in vacuum data blocks. we go backward and process mvcc log records until we rebuild lost blocks (and update cached data in log global header).
2. mvcc_op_log_lsa is in vacuum data blocks, which means it was already added and we do not need to process it. It is reset, but the mistake was that last_block_oldest_mvccid and last_block_newest_mvccid fields were left untouched.

On the next mvcc op the code:
```c
      /* Check if the block of log data is changed */
      if (!LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa)
	  && (vacuum_get_log_blockid (log_Gl.hdr.mvcc_op_log_lsa.pageid) != vacuum_get_log_blockid (start_lsa.pageid)))
	{
	  /* Notify vacuum of a new block */
	  vacuum_produce_log_block_data (thread_p, &log_Gl.hdr.mvcc_op_log_lsa, log_Gl.hdr.last_block_oldest_mvccid,
					 log_Gl.hdr.last_block_newest_mvccid);
	  assert (log_Gl.hdr.last_block_oldest_mvccid <= vacuum_get_global_oldest_active_mvccid ());
	  log_Gl.hdr.last_block_oldest_mvccid = vacuum_get_global_oldest_active_mvccid ();
	  log_Gl.hdr.last_block_newest_mvccid = mvccid;
	  assert (!MVCC_ID_PRECEDES (mvccid, log_Gl.hdr.last_block_oldest_mvccid));
	}
      else
	{
	  /* Same block, update the oldest and the newest met MVCCID's */
	  if (log_Gl.hdr.last_block_newest_mvccid == MVCCID_NULL
	      || MVCC_ID_PRECEDES (log_Gl.hdr.last_block_newest_mvccid, mvccid))
	    {
	      /* A newer MVCCID was found */
	      log_Gl.hdr.last_block_newest_mvccid = mvccid;
	    }
	  if (log_Gl.hdr.last_block_oldest_mvccid == MVCCID_NULL)
	    {
	      log_Gl.hdr.last_block_oldest_mvccid = vacuum_get_global_oldest_active_mvccid ();
	    }
	  assert (!MVCC_ID_PRECEDES (mvccid, log_Gl.hdr.last_block_oldest_mvccid));
	}
```
goes to else branch. last_block_oldest_mvccid for next block remains the last_block_oldest_mvccid flushed to disk before server crashed (which was very old).

when vacuum_consume_buffer_log_blocks is called, the vacuum_Save_log_hdr_oldest_mvccid is also set to the old value.

then vacuum_update_oldest_unvacuumed_mvccid is called several times, each time taking the oldest mvccid value in the first vacuum data entry (which is newer than log_Gl.hdr.last_block_oldest_mvccid), until finally the entire vacuum data is processed & executed and remains empty. When vacuum data is empty, oldest mvccid takes the value of vacuum_Save_log_hdr_oldest_mvccid , which is incorrect (much older than in reality).

The fix is simple: whenever mvcc_op_log_lsa is reset, we should also reset last_block_oldest_mvccid and last_block_newest_mvccid. In our scenario, vacuum_Save_log_hdr_oldest_mvccid will then point to the real oldest MVCCID in block cached in log global header and updating oldest MVCCID to a smaller value would not happen.