### PR TITLE
[CBRD-20839] handle vacuum interruption

### DIFF
--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -2351,6 +2351,7 @@ thread_set_check_interrupt (THREAD_ENTRY * thread_p, bool flag)
 	  thread_p = thread_get_thread_entry_info ();
 	}
 
+      assert (!VACUUM_IS_THREAD_VACUUM (thread_p));
       old_val = thread_p->check_interrupt;
       thread_p->check_interrupt = flag;
     }
@@ -2648,6 +2649,8 @@ thread_vacuum_master_thread (void *arg_p)
   tsd_ptr->type = TT_VACUUM_MASTER;
   tsd_ptr->status = TS_RUN;	/* set thread stat as RUN */
   thread_Vacuum_master_thread.is_available = true;
+  /* vacuum master cannot be interrupted */
+  tsd_ptr->check_interrupt = false;
 
   thread_set_current_tran_index (tsd_ptr, LOG_SYSTEM_TRAN_INDEX);
 
@@ -2739,6 +2742,8 @@ thread_vacuum_worker_thread (void *arg_p)
   thread_set_thread_entry_info (tsd_ptr);	/* save TSD */
   tsd_ptr->type = TT_VACUUM_WORKER;
   tsd_ptr->status = TS_RUN;	/* set thread stat as RUN */
+  /* vacuum workers cannot be interrupted */
+  tsd_ptr->check_interrupt = false;
 
   /* Assign one vacuum worker daemon monitor to current thread based on thread index. The workers in thread array must
    * be in the same order as their daemons. */

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -2351,7 +2351,8 @@ thread_set_check_interrupt (THREAD_ENTRY * thread_p, bool flag)
 	  thread_p = thread_get_thread_entry_info ();
 	}
 
-      assert (!VACUUM_IS_THREAD_VACUUM (thread_p));
+      /* safe guard: vacuum workers should not check for interrupt */
+      assert (flag == false || !VACUUM_IS_THREAD_VACUUM (thread_p));
       old_val = thread_p->check_interrupt;
       thread_p->check_interrupt = flag;
     }

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -3182,7 +3182,11 @@ logtb_is_interrupted_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool clear,
   INT64 now;
 #if !defined(SERVER_MODE)
   struct timeval tv;
-#endif /* !SERVER_MODE */
+
+#else /* SERVER_MODE */
+  /* vacuum threads should not be interruptible */
+  assert (!VACUUM_IS_THREAD_VACUUM (thread_p));
+#endif /* SERVER_MODE */
 
   interrupt = tdes->interrupt;
   if (!LOG_ISTRAN_ACTIVE (tdes))
@@ -3254,16 +3258,12 @@ logtb_is_interrupted_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool clear,
  *                        interrupts to check or to false if there are not
  *                        more interrupts.
  *
- * Note: Find if the current execution must be stopped due to an
- *              interrupt (^C). If clear is true, the interruption flag is
- *              cleared; This is the expected case, once someone is notified,
- *              we do not have to keep the flag on.
+ * Note: Find if the current execution must be stopped due to an interrupt (^C). If clear is true, the interruption flag
+ *       is cleared; This is the expected case, once someone is notified, we do not have to keep the flag on.
  *
- *       If the transaction is not active, false is returned. For
- *              example, in the middle of an undo action, the transaction will
- *              not be interrupted. The recovery manager will interrupt the
- *              transaction at the end of the undo action...int this case the
- *              transaction will be partially aborted.
+ *       If the transaction is not active, false is returned. For example, in the middle of an undo action, the
+ *       transaction will not be interrupted. The recovery manager will interrupt the transaction at the end of the undo
+ *       action... in this case the transaction will be partially aborted.
  */
 bool
 logtb_is_interrupted (THREAD_ENTRY * thread_p, bool clear, bool * continue_checking)
@@ -3297,13 +3297,11 @@ logtb_is_interrupted (THREAD_ENTRY * thread_p, bool clear, bool * continue_check
  *                        more interrupts.
  *   tran_index(in):
  *
- * Note: Find if the execution o fthe given transaction must be stopped
- *              due to an interrupt (^C). If clear is true, the
- *              interruption flag is cleared; This is the expected case, once
- *              someone is notified, we do not have to keep the flag on.
- *       This function is called to see if a transaction that is
- *              waiting (e.g., suspended wiating on a lock) on an event must
- *              be interrupted.
+ * Note: Find if the execution of the given transaction must be stopped due to an interrupt (^C). If clear is true, the
+ *       interruption flag is cleared; This is the expected case, once someone is notified, we do not have to keep the
+ *       flag on.
+ *       This function is called to see if a transaction that is waiting (e.g., suspended on a lock) on an event must
+ *       be interrupted.
  */
 bool
 logtb_is_interrupted_tran (THREAD_ENTRY * thread_p, bool clear, bool * continue_checking, int tran_index)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20839

Bug is caused by server shutdown and incorrect interrupt handling. When shutdown is executed, all transactions (including system transaction) are notified to interrupt their current tasks. System transaction is also shared by vacuum workers and one of them may check the interrupt flag, clear it and set interrupted error. The server then crashes because errors are not accepted during vacuum execution.

Actually, vacuum workers (and master) and never meant to be interrupted during a server run. They can be interrupted by shutdown. Checking for interrupted flag is redundant considering thread entry shut_down flag is also checked.

For stand-alone mode (CSQL and utilities), vacuum is executed serially and we no longer have daemon threads (that are not handled by users). We have only one thread and user may want to interrupt it. Therefore, we need to check periodically for interrupts and stop.