### PR TITLE
[CBRD-20928] parser_copy_tree: allow CTE node pointers copy without u…

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -826,7 +826,8 @@ copy_node_in_tree_post (PARSER_CONTEXT * parser, PT_NODE * new_node, void *arg, 
 
   if (new_node->node_type == PT_SPEC && PT_SPEC_IS_CTE (new_node))
     {
-      /* the new cte_pointer must point to the new_cte; new_cte address should be found in tree_copy_info->cte_structures_list */
+      /* the new cte_pointer may have to point to a new cte; it depends if the copied tree includes the CTE too
+       * (should be in cte_structures_list) */
       PT_NODE *cte_pointer = new_node->info.spec.cte_pointer;
       PT_CTE_COPY_INFO *cte_info_it;
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -838,13 +838,11 @@ copy_node_in_tree_post (PARSER_CONTEXT * parser, PT_NODE * new_node, void *arg, 
 	      break;
 	    }
 	}
-      if (cte_info_it == NULL)
+      if (cte_info_it != NULL)
 	{
-	  assert (false);
-	  PT_INTERNAL_ERROR (parser, "incorrect CTE pointer");
-	  return NULL;
+	  /* the old value of the pointer was found in the list; update the pointer to the new cte address */
+	  cte_pointer->info.pointer.node = cte_info_it->new_cte_node;
 	}
-      cte_pointer->info.pointer.node = cte_info_it->new_cte_node;
     }
 
   return new_node;


### PR DESCRIPTION
…pdating the address
http://jira.cubrid.org/browse/CBRD-20928

It is possible to use parser_copy_tree for a subtree of the statement where there are CTE pointers, without copying the actual CTEs also. 

This happens for example when copying only the FROM node of a statement with CTEs. 
WITH cte AS (SELECT 1 x)
SELECT x FROM cte;
The cte pointer (FROM cte) have to remain pointing to the old CTE. 

