### PR TITLE
[CBRD-20669] heap_remove_page_on_vacuum: allow checkpoint thread waiter

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -4629,7 +4629,19 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
 		     "VACUUM: Candidate heap page %d|%d to remove has waiters.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
-  assert (pgbuf_has_any_waiters (crt_watcher.pgptr) == false);
+
+  /* if we are here, the page should not be accessed by any active or vacuum workers. Active workers are prevented
+   * from accessing it through heap scan, and direct references should not exist.
+   * the function would not be called if any other vacuum workers would try to access the page.
+   * however, we have another thread that could try to latch the page: checkpoint thread. this is the only case we
+   * expect. */
+  if (pgbuf_has_any_non_checkpoint_waiters (crt_watcher.pgptr))
+    {
+      assert (false);
+      vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_ERROR, "VACUUM: Unexpected page waiters \n");
+      goto error;
+    }
+  /* all good, we can deallocate the page */
 
   /* Start changes under the protection of system operation. */
   log_sysop_start (thread_p);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -11773,6 +11773,39 @@ pgbuf_has_any_non_vacuum_waiters (PAGE_PTR pgptr)
 }
 
 /*
+ * pgbuf_has_any_non_checkpoint_waiters () - true if page has any non-checkpoint waiters
+ *
+ * return     : true/false
+ * pgptr (in) : page
+ */
+bool
+pgbuf_has_any_non_checkpoint_waiters (PAGE_PTR pgptr)
+{
+#if defined (SERVER_MODE)
+  PGBUF_BCB *bufptr = NULL;
+  THREAD_ENTRY *thread_entry_p;
+
+  assert (pgptr != NULL);
+  CAST_PGPTR_TO_BFPTR (bufptr, pgptr);
+
+  if (bufptr->next_wait_thrd == NULL)
+    {
+      /* no waiters at all */
+      return false;
+    }
+  if (bufptr->next_wait_thrd->next_wait_thrd != NULL)
+    {
+      /* more than one waiter, there can be only one checkpoint thread! */
+      return true;
+    }
+  /* is the single waiter checkpoint thread? */
+  return thread_is_checkpoint_thread (bufptr->next_wait_thrd);
+#else
+  return false;
+#endif
+}
+
+/*
  * pgbuf_has_prevent_dealloc () - Quick check if page has any scanners.
  *
  * return     : True if page has any waiters, false otherwise.

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -450,6 +450,7 @@ extern void pgbuf_attach_watcher (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGBUF
 
 extern bool pgbuf_has_any_waiters (PAGE_PTR pgptr);
 extern bool pgbuf_has_any_non_vacuum_waiters (PAGE_PTR pgptr);
+extern bool pgbuf_has_any_non_checkpoint_waiters (PAGE_PTR pgptr);
 extern bool pgbuf_has_prevent_dealloc (PAGE_PTR pgptr);
 extern void pgbuf_peek_stats (UINT64 * fixed_cnt, UINT64 * dirty_cnt, UINT64 * lru1_cnt, UINT64 * lru2_cnt,
 			      UINT64 * aint_cnt, UINT64 * avoid_dealloc_cnt, UINT64 * avoid_victim_cnt,

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -2965,6 +2965,18 @@ thread_wakeup_checkpoint_thread (void)
 }
 
 /*
+ * thread_is_checkpoint_thread () - is this the checkpoint thread?
+ *
+ * return        : true/false
+ * thread_p (in) : thread entry
+ */
+bool
+thread_is_checkpoint_thread (THREAD_ENTRY * thread_p)
+{
+  return thread_p != NULL && thread_p->index == thread_Checkpoint_thread.thread_index;
+}
+
+/*
  * thread_purge_archive_logs_thread() -
  *   return:
  *   arg_p(in):

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -107,8 +107,6 @@ typedef int (*CSS_THREAD_FN) (THREAD_ENTRY * thrd, CSS_THREAD_ARG);
 
 #else /* !SERVER_MODE */
 
-#define THREAD_VACUUM_WORKERS_COUNT 10
-
 #define THREAD_GET_CURRENT_ENTRY_INDEX(thrd) \
   ((thrd) ? (thrd)->index : thread_get_current_entry_index())
 
@@ -439,6 +437,11 @@ extern void thread_wakeup_check_ha_delay_info_thread (void);
 extern struct css_conn_entry *thread_get_current_conn_entry (void);
 extern int thread_has_threads (THREAD_ENTRY * caller, int tran_index, int client_id);
 extern bool thread_set_check_interrupt (THREAD_ENTRY * thread_p, bool flag);
+
+/* is thread functions */
+extern bool thread_is_checkpoint_thread (THREAD_ENTRY * thread_p);
+
+/* wakeup functions */
 extern void thread_wakeup_deadlock_detect_thread (void);
 extern void thread_wakeup_log_flush_thread (void);
 extern void thread_wakeup_page_flush_thread (void);
@@ -450,8 +453,10 @@ extern void thread_wakeup_auto_volume_expansion_thread (void);
 extern void thread_wakeup_vacuum_master_thread (void);
 extern void thread_wakeup_vacuum_worker_threads (int n_workers);
 
+/* is available functions */
 extern bool thread_is_page_flush_thread_available (void);
 
+/* is running tunfions */
 extern bool thread_auto_volume_expansion_thread_is_running (void);
 
 extern THREAD_ENTRY *thread_find_first_lockwait_entry (int *thrd_index);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20669

The crashed safe-guard is there for a clear purpose: we tried to make sure no worker will try to access a heap page deallocated by vacuum. While this is true for all active and vacuum workers, the checkpoint thread cannot be prevented from try to latch page (and we don't to).

Change safe-guard check from is any waiter on page to is any non-checkpoint waiter on page.