### PR TITLE
[CBRD-20932] logtb_is_interrupted_tdes: allow vacuum interrupt during recovery

### DIFF
--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -3184,8 +3184,8 @@ logtb_is_interrupted_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool clear,
   struct timeval tv;
 
 #else /* SERVER_MODE */
-  /* vacuum threads should not be interruptible */
-  assert (!VACUUM_IS_THREAD_VACUUM (thread_p));
+  /* vacuum threads should not be interruptible (unless this is still recovery). */
+  assert (!BO_IS_SERVER_RESTARTED () || !VACUUM_IS_THREAD_VACUUM (thread_p));
 #endif /* SERVER_MODE */
 
   interrupt = tdes->interrupt;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20932

Loosen-up safe-guard. During recovery, we can allow interrupts even if thread is vacuum worker.

Note that the thread is not actually a vacuum worker. It is hacked into thinking it is a vacuum worker while recovering the work of the vacuum worker. This is beyond the scope of initial safe-guard, which only tries to ensure a good control on errors during vacuum job execution.