### PR TITLE
[CBRD-20941] Avoid recursive CTE optimization for rownum

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15504,7 +15504,8 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 	  if (first_iteration && non_recursive_part->list_id->tuple_cnt > 0)
 	    {
 	      first_iteration = false;
-	      if (recursive_part->proc.buildlist.groupby_list || recursive_part->orderby_list)
+	      if (recursive_part->proc.buildlist.groupby_list || recursive_part->orderby_list
+		  || recursive_part->instnum_val != NULL)
 		{
 		  /* future specific optimizations, changes, etc */
 		}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20941

The rownum can not be computed correctly with the optimization, when the same list_id is used for both reading and writing.