### PR TITLE
[CBRD-20953] Fix show create view when the value of param plus_as_concat = no

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -9192,9 +9192,9 @@ pt_make_query_show_create_view (PARSER_CONTEXT * parser, PT_NODE * view_identifi
 
     if_true_node = pt_make_dotted_identifier (parser, "VC.vclass_def");
 
-    lhs = pt_make_pred_name_string_val (parser, PT_PLUS, "VC.vclass_def", " comment='");
-    rhs = pt_make_pred_name_string_val (parser, PT_PLUS, "VC.comment", "'");
-    if_false_node = parser_make_expression (parser, PT_PLUS, lhs, rhs, NULL);
+    lhs = pt_make_pred_name_string_val (parser, PT_CONCAT, "VC.vclass_def", " comment='");
+    rhs = pt_make_pred_name_string_val (parser, PT_CONCAT, "VC.comment", "'");
+    if_false_node = parser_make_expression (parser, PT_CONCAT, lhs, rhs, NULL);
 
     comment_node = pt_make_dotted_identifier (parser, "VC.comment");
     lhs = parser_make_expression (parser, PT_IS_NULL, comment_node, NULL, NULL);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20953

* Fix bug for 'show create view' when the value of sys. param 'plus_as_concat=no'
* This modification is quite simple, query for show create view contains '+' symbol
   since 10.x. Hence, when the CUBRID param for 'plus_as_concat' is set to 'no'
   Query processor may try arithmetic plus operation instead of 'concatenate',
   which is intended.
* Change query for 'show create view' from PT_PLUS to PT_CONCAT
* QA passed for SQL/Medium
* I'm not sure for TC modification for this case, please advise.