### PR TITLE
[CBRD-20701] log_rv_analysis_sysop_end: allocate topops stack

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1516,6 +1516,12 @@ log_rv_analysis_sysop_end (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_l
 	  /* run postpone for log record inside a system op */
 	  if (tdes->topops.last < 0 || tdes->state != TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE)
 	    {
+	      if (tdes->topops.max == 0 && logtb_realloc_topops_stack (tdes, 1) == NULL)
+		{
+		  /* Out of memory */
+		  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_recovery_analysis");
+		  return ER_OUT_OF_VIRTUAL_MEMORY;
+		}
 	      tdes->topops.last = 0;
 	      tdes->state = TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20701

log_rv_analysis_sysop_end: make sure stack is not null when setting last to 0