### PR TITLE
[CBRD-20937] Recursive CTE optimization restriction

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15509,10 +15509,12 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 		{
 		  /* future specific optimizations, changes, etc */
 		}
-	      else
+	      else if (recursive_part->spec_list->s.list_node.xasl_node == non_recursive_part)
 		{
 		  /* optimization: use non-recursive list id for both reading and writing
 		   * the recursive xasl will iterate through this list id while appending new results at its end 
+		   * note: this works only if the cte(actually the non_recursive_part link) is the first spec used
+		   * for scanning during recursive iterations
 		   */
 		  save_recursive_list_id = recursive_part->list_id;
 		  recursive_part->list_id = non_recursive_part->list_id;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20937

The optimization with using the same list_id for both reading and writing results for recursive query can work only if the CTE is the first in FROM specs. After every advance of the CTE scan, all the other scans involved in the recursive query must be restarted. This is the only mechanism that accepts writing in the same list_id. Otherwise there will be more separate scans on the CTE and the number of resulted tuples will be different since it is continously added new tuples.


This will affect a lot the performance of recursive CTEs, but the results will be correct.

The best solution would be to reorder the FROM specs in such a way that the self reference of the CTE would be the first node. This approach require more investigation. 