### PR TITLE
[CBRD-20960] Remove recursive part of CTEs with false where

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2792,7 +2792,8 @@ struct pt_query_info
 {
   int correlation_level;	/* for correlated subqueries */
   PT_MISC_TYPE all_distinct;	/* enum value is PT_ALL or PT_DISTINCT */
-  PT_MISC_TYPE is_subquery;	/* PT_IS_SUB_QUERY, PT_IS_UNION_QUERY, or 0 */
+  PT_MISC_TYPE is_subquery;	/* PT_IS_SUB_QUERY, PT_IS_UNION_QUERY, PT_IS_CTE_NON_REC_SUBQUERY, 
+				 * PT_IS_CTE_REC_SUBQUERY or 0 */
   char is_view_spec;		/* 0 - normal, 1 - view query spec */
   char oids_included;		/* DB_NO_OIDS/0 DB_ROW_OIDS/1 */
   SCAN_OPERATION_TYPE scan_op_type;	/* scan operation type */

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -9910,6 +9910,17 @@ pt_semantic_check_local (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int
 	  pt_coerce_insert_values (parser, node);
 	}
       break;
+
+    case PT_CTE:
+      if (node->info.cte.recursive_part != NULL
+	  && (pt_false_where (parser, node->info.cte.recursive_part)
+	      || pt_false_where (parser, node->info.cte.non_recursive_part)))
+	{
+	  parser_free_tree (parser, node->info.cte.recursive_part);
+	  node->info.cte.recursive_part = NULL;
+	}
+      break;
+
     default:			/* other node types */
       break;
     }

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -9916,6 +9916,7 @@ pt_semantic_check_local (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int
 	  && (pt_false_where (parser, node->info.cte.recursive_part)
 	      || pt_false_where (parser, node->info.cte.non_recursive_part)))
 	{
+	  /* the recursive_part can be removed if one of the parts has false_where */
 	  parser_free_tree (parser, node->info.cte.recursive_part);
 	  node->info.cte.recursive_part = NULL;
 	}

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -8047,6 +8047,7 @@ pt_eval_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_
   bool arg1_is_false = false;
   PT_NODE *list;
   STATEMENT_SET_FOLD do_fold;
+  PT_MISC_TYPE is_subquery;
 
   switch (node->node_type)
     {
@@ -8160,10 +8161,12 @@ pt_eval_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_
 
       node->info.query.q.select.where = pt_where_type (parser, node->info.query.q.select.where);
 
+      is_subquery = node->info.query.is_subquery;
+
       if (sc_info->donot_fold == false
-	  && (node->info.query.is_subquery == PT_IS_SUBQUERY || node->info.query.is_subquery == PT_IS_UNION_SUBQUERY
-	      || node->info.query.is_subquery == PT_IS_CTE_NON_REC_SUBQUERY
-	      || node->info.query.is_subquery == PT_IS_CTE_REC_SUBQUERY) && pt_false_where (parser, node))
+	  && (is_subquery == PT_IS_SUBQUERY || is_subquery == PT_IS_UNION_SUBQUERY
+	      || is_subquery == PT_IS_CTE_NON_REC_SUBQUERY || is_subquery == PT_IS_CTE_REC_SUBQUERY)
+	  && pt_false_where (parser, node))
 	{
 	  node = pt_to_false_subquery (parser, node);
 	}

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -8161,8 +8161,9 @@ pt_eval_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_
       node->info.query.q.select.where = pt_where_type (parser, node->info.query.q.select.where);
 
       if (sc_info->donot_fold == false
-	  && (node->info.query.is_subquery == PT_IS_SUBQUERY || node->info.query.is_subquery == PT_IS_UNION_SUBQUERY)
-	  && pt_false_where (parser, node))
+	  && (node->info.query.is_subquery == PT_IS_SUBQUERY || node->info.query.is_subquery == PT_IS_UNION_SUBQUERY
+	      || node->info.query.is_subquery == PT_IS_CTE_NON_REC_SUBQUERY
+	      || node->info.query.is_subquery == PT_IS_CTE_REC_SUBQUERY) && pt_false_where (parser, node))
 	{
 	  node = pt_to_false_subquery (parser, node);
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20960

If the CTE has false_where, the recursive_part can be removed without affecting the results.