### PR TITLE
[CBRD-20959] Set correlation level zero for CTEs

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -16718,7 +16718,7 @@ parser_generate_xasl_proc (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * qu
 	}
 
       /* set as zero correlation-level; this uncorrelated subquery need to be executed at most one time */
-      if (node->info.query.correlation_level == 0)
+      if ((PT_IS_QUERY (node) && node->info.query.correlation_level == 0) || node->node_type == PT_CTE)
 	{
 	  XASL_SET_FLAG (xasl, XASL_ZERO_CORR_LEVEL);
 	}

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15422,6 +15422,7 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 
   if (xasl->status == XASL_SUCCESS)
     {
+      /* early exit, CTEs should be executed only once */
       return NO_ERROR;
     }
 
@@ -15526,7 +15527,11 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
       /* copy all results back to non_recursive_part list id; other CTEs from the same WITH clause have access only to
        * non_recursive_part; see how pt_to_cte_table_spec_list works for interdependent CTEs.
        */
-      qfile_copy_list_id (non_recursive_part->list_id, xasl->list_id, true);
+      if (qfile_copy_list_id (non_recursive_part->list_id, xasl->list_id, true) != NO_ERROR)
+	{
+	  QFILE_FREE_AND_INIT_LIST_ID (non_recursive_part->list_id);
+	  GOTO_EXIT_ON_ERROR;
+	}
 
       if (save_recursive_list_id != NULL)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20959

The CTEs should be executed only once. They should be independent of the context (they may depend on other CTEs but remain independent overall).