### PR TITLE
[CBRD-20964] pt_eval_type: Remove recursive part of CTEs with false w…

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -9911,17 +9911,6 @@ pt_semantic_check_local (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int
 	}
       break;
 
-    case PT_CTE:
-      if (node->info.cte.recursive_part != NULL
-	  && (pt_false_where (parser, node->info.cte.recursive_part)
-	      || pt_false_where (parser, node->info.cte.non_recursive_part)))
-	{
-	  /* the recursive_part can be removed if one of the parts has false_where */
-	  parser_free_tree (parser, node->info.cte.recursive_part);
-	  node->info.cte.recursive_part = NULL;
-	}
-      break;
-
     default:			/* other node types */
       break;
     }

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -8249,11 +8249,17 @@ pt_eval_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_
       else
 	{
 	  /* check that signatures are compatible */
-
 	  if (node->node_type == PT_CTE)
 	    {
 	      arg1 = node->info.cte.non_recursive_part;
 	      arg2 = node->info.cte.recursive_part;
+	      if (arg2 != NULL && (pt_false_where (parser, arg1) || pt_false_where (parser, arg2)))
+	      {
+		  /* the recursive_part can be removed if one of the parts has false_where */
+		  parser_free_tree (parser, node->info.cte.recursive_part);
+		  arg2 = node->info.cte.recursive_part = NULL;
+	      }
+
 	      if (arg2 == NULL)
 		{
 		  /* then the CTE is not recursive (just one part) */

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -8254,11 +8254,11 @@ pt_eval_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_
 	      arg1 = node->info.cte.non_recursive_part;
 	      arg2 = node->info.cte.recursive_part;
 	      if (arg2 != NULL && (pt_false_where (parser, arg1) || pt_false_where (parser, arg2)))
-	      {
+		{
 		  /* the recursive_part can be removed if one of the parts has false_where */
 		  parser_free_tree (parser, node->info.cte.recursive_part);
 		  arg2 = node->info.cte.recursive_part = NULL;
-	      }
+		}
 
 	      if (arg2 == NULL)
 		{


### PR DESCRIPTION
…here
http://jira.cubrid.org/browse/CBRD-20964

Moved the handling of false where CTEs from semantic_check_local to pt_eval_type.