### PR TITLE
[CBRD-20957] Avoid recursive CTE optimization for analytics

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15505,7 +15505,7 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 	    {
 	      first_iteration = false;
 	      if (recursive_part->proc.buildlist.groupby_list || recursive_part->orderby_list
-		  || recursive_part->instnum_val != NULL)
+		  || recursive_part->instnum_val != NULL || recursive_part->proc.buildlist.a_eval_list != NULL)
 		{
 		  /* future specific optimizations, changes, etc */
 		}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20957

Analytic functions must be applied on each recursive level of the CTE individually.

