### PR TITLE
[CBRD-20975] truncate problem,  whose table name is a reserved word of the CUBRID

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -15107,18 +15107,13 @@ sm_truncate_using_delete (MOP class_mop)
   /* We will run a DELETE statement with triggers disabled. */
   save_tr_state = tr_set_execution_state (false);
 
-  if (pt_is_reserved_word (class_name))
-    {
-      /*
-       * If the table name to tuncate belongs to reserved words of the CUBRID
-       * add [ ] explicitly outside the table name.
-       */
-      (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE */ FROM [%s];", class_name);
-    }
-  else
-    {
-      (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE */ FROM %s;", class_name);
-    }
+  /*
+   * When the 'class_nams' is one of the CUBRID reserved word,
+   * it should be called like '[class_name]' not 'class_name' in DELETE Query.
+   * So, we build query like 'DELETE FROM [class_name];', 
+   * whatever the 'class_name' belongs to the CUBRID reserved words or not
+   */
+  (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE */ FROM [%s];", class_name);
 
   session = db_open_buffer (delete_query);
   if (session == NULL)

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -15106,7 +15106,19 @@ sm_truncate_using_delete (MOP class_mop)
 
   /* We will run a DELETE statement with triggers disabled. */
   save_tr_state = tr_set_execution_state (false);
-  (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE */ FROM %s;", class_name);
+ 
+  if (pt_is_reserved_word(class_name))
+    {
+      /*
+       * If the table name to tuncate belongs to reserved words of the CUBRID
+       * add [ ] explicitly outside the table name.
+       */
+      (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE */ FROM [%s];", class_name);
+    }
+  else
+    {
+      (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE */ FROM %s;", class_name);
+    }
 
   session = db_open_buffer (delete_query);
   if (session == NULL)

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -15106,8 +15106,8 @@ sm_truncate_using_delete (MOP class_mop)
 
   /* We will run a DELETE statement with triggers disabled. */
   save_tr_state = tr_set_execution_state (false);
- 
-  if (pt_is_reserved_word(class_name))
+
+  if (pt_is_reserved_word (class_name))
     {
       /*
        * If the table name to tuncate belongs to reserved words of the CUBRID


### PR DESCRIPTION
* Fix truncate tables whose table name is a reserved word of the CUBRID, such as 'create', 'convert'
* Test Case for this PR can be found in [CBRD-20975]