### PR TITLE
[CBRD-20978] Return error for cte.* usage in count function

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -4312,7 +4312,8 @@ pt_resolve_correlation (PARSER_CONTEXT * parser, PT_NODE * in_node, PT_NODE * sc
     {
       /* the exposed name of a derived table may not be used alone, ie, "select e from (select a from c) e" is
        * disallowed. */
-      if (col_name && exposed_spec->info.spec.derived_table && exposed_spec->info.spec.range_var != in_node)
+      if (col_name && (PT_SPEC_IS_DERIVED (exposed_spec) || PT_SPEC_IS_CTE (exposed_spec))
+	  && exposed_spec->info.spec.range_var != in_node)
 	{
 	  if (PT_NAME_INFO_IS_FLAGED (in_node, PT_NAME_FOR_UPDATE))
 	    {

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -4310,8 +4310,8 @@ pt_resolve_correlation (PARSER_CONTEXT * parser, PT_NODE * in_node, PT_NODE * sc
   /* If so, name resolves to scope's flat list of entities */
   if (exposed_spec)
     {
-      /* the exposed name of a derived table may not be used alone, ie, "select e from (select a from c) e" is
-       * disallowed. */
+      /* the exposed name of a derived table or a CTE may not be used alone, ie, "select e from (select a from c) e" 
+       * is disallowed. */
       if (col_name && (PT_SPEC_IS_DERIVED (exposed_spec) || PT_SPEC_IS_CTE (exposed_spec))
 	  && exposed_spec->info.spec.range_var != in_node)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20978

According to the comment "the exposed name of a derived table may not be used alone" queries like SELECT count(cte.*) FROM cte should also throw error. 

In this way there will be the same behaviour with CTEs as it is with derived tables.

The only incosistency will appear when the derived table is considered a dummy select and it is folded. Dummy CTEs can not be folded and will return error.

```sql
select count(x.*) from (select * from t1) x;
``` 
-> 
```sql
select count(x.*) from t1 x; --success
```

```sql
with tmp as (select * from t1)select count(tmp.*) from tmp;
```
->
```
ERROR: Class instance reference tmp.* to a derived table name is not allowed.
```