### PR TITLE
[CBRD-20986] fix ut_trim (memmove)

### DIFF
--- a/src/broker/broker_log_util.c
+++ b/src/broker/broker_log_util.c
@@ -65,7 +65,7 @@ ut_trim (char *str)
   *++p = '\0';
 
   if (s != str)
-    memcpy (str, s, strlen (s) + 1);
+    memmove (str, s, strlen (s) + 1);
 
   return (str);
 }

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -555,7 +555,7 @@ ut_trim (char *str)
   *++p = '\0';
 
   if (s != str)
-    memcpy (str, s, strlen (s) + 1);
+    memmove (str, s, strlen (s) + 1);
 
   return (str);
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20986

memcpy function is non-deterministic when using the same memory in src and dst arguments, making the program unreliable.