### PR TITLE
[CBRD-20983] do not deallocate compressed string when generate tuple descriptor

### DIFF
--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -569,7 +569,6 @@ qdata_generate_tuple_desc_for_valptr_list (THREAD_ENTRY * thread_p, VALPTR_LIST 
   int i;
   int value_size;
   QPROC_TPLDESCR_STATUS status = QPROC_TPLDESCR_SUCCESS;
-  DB_VALUE *val_buffer;
   DB_TYPE dbval_type;
   HL_HEAPID save_heapid = 0;
 
@@ -619,18 +618,7 @@ qdata_generate_tuple_desc_for_valptr_list (THREAD_ENTRY * thread_p, VALPTR_LIST 
 	      goto exit_with_status;
 	    }
 
-	  /* The value has been peeked so it does not require any clear, but we still might have the compressed_string
-	   * alloced so we need to clear it.
-	   */
-	  val_buffer = tuple_desc_p->f_valp[tuple_desc_p->f_cnt];
-	  if (!DB_IS_NULL (val_buffer) && (dbval_type == DB_TYPE_VARCHAR || dbval_type == DB_TYPE_VARNCHAR))
-	    {
-	      if (!(tuple_desc_p->clear_f_val_at_clone_decache[tuple_desc_p->f_cnt]))
-		{
-		  /* Clear compressed string since val_buffer was allocated during XASL execution. */
-		  pr_clear_compressed_string (val_buffer);
-		}
-	    }
+	  /* The compressed string will be deallocated later, after copying db_value into tuple. */
 
 	  tuple_desc_p->tpl_size += value_size;
 	  tuple_desc_p->f_cnt += 1;	/* increase field number */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20983