### PR TITLE
[CBRD-20808] Do not interrupt temp ehash destroy

### DIFF
--- a/src/storage/extendible_hash.c
+++ b/src/storage/extendible_hash.c
@@ -1262,6 +1262,7 @@ xehash_destroy (THREAD_ENTRY * thread_p, EHID * ehid_p)
 {
   EHASH_DIR_HEADER *dir_header_p;
   PAGE_PTR dir_page_p;
+  bool save_check_interrupt;
 
   if (ehid_p == NULL)
     {
@@ -1275,6 +1276,7 @@ xehash_destroy (THREAD_ENTRY * thread_p, EHID * ehid_p)
     }
 
   log_sysop_start (thread_p);
+  save_check_interrupt = thread_set_check_interrupt (thread_p, false);
 
   dir_header_p = (EHASH_DIR_HEADER *) dir_page_p;
 
@@ -1288,6 +1290,7 @@ xehash_destroy (THREAD_ENTRY * thread_p, EHID * ehid_p)
       assert_release (false);
     }
 
+  (void) thread_set_check_interrupt (thread_p, save_check_interrupt);
   log_sysop_commit (thread_p);
 
   return NO_ERROR;

--- a/src/storage/extendible_hash.c
+++ b/src/storage/extendible_hash.c
@@ -1150,7 +1150,12 @@ exit_on_error:
     {
       if (is_tmp)
 	{
-	  (void) file_destroy (thread_p, &bucket_vfid);
+	  bool save_check_interrupt = thread_set_check_interrupt (thread_p, false);
+	  if (file_destroy (thread_p, &bucket_vfid) != NO_ERROR)
+	    {
+	      assert_release (false);
+	    }
+	  (void) thread_set_check_interrupt (thread_p, save_check_interrupt);
 	}
       else
 	{
@@ -1161,7 +1166,12 @@ exit_on_error:
     {
       if (is_tmp)
 	{
-	  (void) file_destroy (thread_p, &dir_vfid);
+	  bool save_check_interrupt = thread_set_check_interrupt (thread_p, false);
+	  if (file_destroy (thread_p, &dir_vfid) != NO_ERROR)
+	    {
+	      assert_release (false);
+	    }
+	  (void) thread_set_check_interrupt (thread_p, save_check_interrupt);
 	}
       else
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20808

we need to destroy temporary extensible hashes, or they'd get leaked. so don't mind interruptions.