### PR TITLE
[CBRD-21023] Clob's length() returns -1 when empty string

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
@@ -126,6 +126,9 @@ public class CUBRIDClob implements Clob {
 		if (lobHandle == null) {
 			throw conn.createCUBRIDException(CUBRIDJDBCErrorCode.invalid_value, null);
 		}
+		if (lobHandle.getLobSize() == 0) {
+			return 0;
+		}
 		if (clobCharLength < 0) {
 			readClobPartially(Long.MAX_VALUE, 1);
 		}


### PR DESCRIPTION
This issue related to [CBRD-21023](http://jira.cubrid.org/browse/CBRD-21023).

I added checking condition for empty string or value in `CUBRIDClob.length()`.
