### PR TITLE
[CBRD-21064] vacuum_data_load_and_recover: read vacuum_Global_oldest_active_mvccid

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4115,6 +4115,9 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
 
   vacuum_Data.is_loaded = true;
 
+  /* get global oldest active MVCCID. */
+  vacuum_Global_oldest_active_mvccid = logtb_get_oldest_active_mvccid (thread_p);
+
   error_code = vacuum_recover_lost_block_data (thread_p);
   if (error_code != NO_ERROR)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21064

This is a regression of CBRD-21037. vacuum_Global_oldest_active_mvccid used to be read in vacuum_process_vacuum_data, before vacuum data was loaded. Since vacuum_data_load_and_recover is now called before master is woke, the vacuum_Global_oldest_active_mvccid remained 0.

Fixed by reading vacuum_Global_oldest_active_mvccid.