### PR TITLE
[CBRD-21022] CAS down for executeBatch with CLOB/BLOB columns

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -20381,12 +20381,12 @@ parser_generate_xasl_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, in
   switch (node->node_type)
     {
     case PT_SELECT:
-    if (!node->info.query.xasl)
-    	  {
-    	  	(void) pt_query_set_reference (parser, node);
-    	  }
-    	  pt_push_symbol_info (parser, node);
-    	  break;
+      if (!node->info.query.xasl)
+	{
+	  (void) pt_query_set_reference (parser, node);
+	}
+      pt_push_symbol_info (parser, node);
+      break;
 
 #if defined(CUBRID_DEBUG)
       PT_NODE_PRINT_TO_ALIAS (parser, node, PT_CONVERT_RANGE);

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -20381,6 +20381,13 @@ parser_generate_xasl_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, in
   switch (node->node_type)
     {
     case PT_SELECT:
+    if (!node->info.query.xasl)
+    	  {
+    	  	(void) pt_query_set_reference (parser, node);
+    	  }
+    	  pt_push_symbol_info (parser, node);
+    	  break;
+
 #if defined(CUBRID_DEBUG)
       PT_NODE_PRINT_TO_ALIAS (parser, node, PT_CONVERT_RANGE);
 #endif /* CUBRID_DEBUG */


### PR DESCRIPTION
* CAS down for Addbatch with CLOB/BLOB columns could be minor bug.
* However, it couldn't be treated as other minor bugs.
* As you can see in comments [#CBRD-21022], two solutions are suggested.
* Both modifies 'src/parser/xasl_generation.c' as follow

1. Modify function 'parser_generate_xasl_pre()'
This, in some sense of meaning, could  be a protection code. Because nobody think the value 'node->info.query.xasl' is NULL when node->node_type is PT_SELECT. However, this happened as you can see in description of [#CBRD-21022].

2. Modify function 'pt_to_insert_xasl()'
This, check and force the value node->node_type to NULL before  parser_generate_xasl_pre() is called. It is limited solution than previously suggested.

* In this PR, solution 1 is suggested because it could be more safe & simple and could be protection code. (parser_generate_xasl_pre() & parser_generate_xasl_post() are combined. And if 1st function is called, then always 2nd function will be called.)
* And, parser_generate_xasl_post() always calls 'pt_pop_symbol_info()' when the node_type is PT_SELECT.
* And, if 'pt_push_symbol_info()' was not executed before, it could be trouble.
* QA for SQL/jdbc for this modification was performed, and '4,000 continuous executeBatch were performed each contains 100 addBatch respectively with CLOB column.

* If you disagree with this suggestion or different idea on it, please reverts this PR and give me a comment on it.