### PR TITLE
[CBRD-20074] add stats back temporarily

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -175,6 +175,11 @@ PSTAT_METADATA pstat_Metadata[] = {
   PSTAT_METADATA_INIT_SINGLE_ACC (PSTAT_PB_NUM_DIRTIES, "Num_data_page_dirties"),
   PSTAT_METADATA_INIT_SINGLE_ACC (PSTAT_PB_NUM_IOREADS, "Num_data_page_ioreads"),
   PSTAT_METADATA_INIT_SINGLE_ACC (PSTAT_PB_NUM_IOWRITES, "Num_data_page_iowrites"),
+  /* TODO: Temporary dummy stats to make build work. Revert when CM server can fetch last develop version */
+  /* ===> */
+  PSTAT_METADATA_INIT_SINGLE_ACC (PSTAT_PB_NUM_VICTIMS, "Num_data_page_victims"),
+  PSTAT_METADATA_INIT_SINGLE_ACC (PSTAT_PB_NUM_REPLACEMENTS, "Num_data_page_iowrites_for_replacement"),
+  /* <=== */
   PSTAT_METADATA_INIT_SINGLE_ACC (PSTAT_PB_NUM_FLUSHED, "Num_data_page_flushed"),
   /* peeked stats */
   PSTAT_METADATA_INIT_SINGLE_PEEK (PSTAT_PB_PRIVATE_QUOTA, "Num_data_page_private_quota"),

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -289,6 +289,11 @@ typedef enum
   PSTAT_PB_NUM_DIRTIES,
   PSTAT_PB_NUM_IOREADS,
   PSTAT_PB_NUM_IOWRITES,
+  /* TODO: Temporary dummy stats to make build work. Revert when CM server can fetch last develop version */
+  /* ===> */
+  PSTAT_PB_NUM_VICTIMS,
+  PSTAT_PB_NUM_REPLACEMENTS,
+  /* <=== */
   PSTAT_PB_NUM_FLUSHED,
   /* peeked stats */
   PSTAT_PB_PRIVATE_QUOTA,

--- a/src/cm_common/cm_mem_cpu_stat.c
+++ b/src/cm_common/cm_mem_cpu_stat.c
@@ -1055,6 +1055,11 @@ static STATDUMP_PROP statdump_offset[] = {
   {"Num_data_page_dirties", offsetof (T_CM_DB_EXEC_STAT, pb_num_dirties)},
   {"Num_data_page_ioreads", offsetof (T_CM_DB_EXEC_STAT, pb_num_ioreads)},
   {"Num_data_page_iowrites", offsetof (T_CM_DB_EXEC_STAT, pb_num_iowrites)},
+  /* TODO: Temporary dummy stats to make build work. Revert when CM server can fetch last develop version */
+  /* ===> */
+  {"Num_data_page_victims", offsetof (T_CM_DB_EXEC_STAT, pb_num_victims)},
+  {"Num_data_page_iowrites_for_replacement", offsetof (T_CM_DB_EXEC_STAT, pb_num_replacements)},
+  /* <=== */
   {"Num_data_page_hash_anchor_waits", offsetof (T_CM_DB_EXEC_STAT, pb_num_hash_anchor_waits)},
   {"Time_data_page_hash_anchor_wait", offsetof (T_CM_DB_EXEC_STAT, pb_time_hash_anchor_wait)},
   {"Num_data_page_fixed", offsetof (T_CM_DB_EXEC_STAT, pb_fixed_cnt)},

--- a/src/cm_common/cm_stat.h
+++ b/src/cm_common/cm_stat.h
@@ -270,6 +270,11 @@ extern "C"
     unsigned int pb_num_dirties;
     unsigned int pb_num_ioreads;
     unsigned int pb_num_iowrites;
+    /* TODO: Temporary dummy stats to make build work. Revert when CM server can fetch last develop version */
+    /* ===> */
+    unsigned int pb_num_victims;
+    unsigned int pb_num_replacements;
+    /* <=== */
     unsigned int pb_num_hash_anchor_waits;
     unsigned int pb_time_hash_anchor_wait;
     /* peeked stats */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20074

quick fix cm server compatibility issue in daily build. should be reverted when the daily build is fixed to fetch develop head revision instead of master.