### PR TITLE
[CBRD-21003] Recovery: abort sysops before finishing postpone

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -5138,8 +5138,8 @@ file_alloc (THREAD_ENTRY * thread_p, const VFID * vfid, FILE_INIT_PAGE_FUNC f_in
     }
   else
     {
-      /* start a nested system operation. we will end it with commit & undo */
-      log_sysop_start (thread_p);
+      /* start a nested system operation. we will end it with commit & undo. this must be atomic. */
+      log_sysop_start_atomic (thread_p);
       is_sysop_started = true;
 
       /* allocate page */
@@ -6000,7 +6000,7 @@ file_rv_dealloc_internal (THREAD_ENTRY * thread_p, LOG_RCV * rcv, bool compensat
 
   /* so, we do need a system operation here. the system operation will end, based on context, with commit & compensate
    * or with commit & run postpone. */
-  log_sysop_start (thread_p);
+  log_sysop_start_atomic (thread_p);
   is_sysop_started = true;
 
   /* clear page bit by calling file_perm_dealloc */

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -444,6 +444,9 @@ log_to_string (LOG_RECTYPE type)
     case LOG_REPLICATION_STATEMENT:
       return "LOG_REPLICATION_STATEMENT";
 
+    case LOG_SYSOP_ATOMIC_START:
+      return "LOG_SYSOP_ATOMIC_START";
+
     case LOG_DUMMY_HA_SERVER_STATE:
       return "LOG_DUMMY_HA_SERVER_STATE";
     case LOG_DUMMY_OVF_RECORD:
@@ -3610,6 +3613,42 @@ log_sysop_start (THREAD_ENTRY * thread_p)
   LSA_SET_NULL (&tdes->topops.stack[tdes->topops.last].posp_lsa);
 
   perfmon_inc_stat (thread_p, PSTAT_TRAN_NUM_START_TOPOPS);
+}
+
+/*
+ * log_sysop_start_atomic () - start a system operation that required to be atomic. it is aborted during recovery before
+ *                             all postpones are finished.
+ *
+ * return        : void
+ * thread_p (in) : thread entry
+ */
+void
+log_sysop_start_atomic (THREAD_ENTRY * thread_p)
+{
+  LOG_TDES *tdes = NULL;
+  int tran_index;
+
+  log_sysop_start (thread_p);
+  log_sysop_get_tran_index_and_tdes (thread_p, &tran_index, &tdes);
+  if (tdes == NULL || tdes->topops.last < 0)
+    {
+      /* not a good context. must be in a system operation */
+      assert_release (false);
+      return;
+    }
+  if (LSA_ISNULL (&tdes->rcv.atomic_sysop_start_lsa))
+    {
+      log_append_empty_record (thread_p, LOG_SYSOP_ATOMIC_START, NULL);
+    }
+  else
+    {
+      /* this must be a nested atomic system operation. If parent is atomic, we'll be atomic too. */
+      assert (tdes->topops.last > 0);
+
+      /* oh, and please tell me this is not a nested system operation during postpone of system operation nested to
+       * another atomic system operation... */
+      assert (LSA_ISNULL (&tdes->rcv.sysop_start_postpone_lsa));
+    }
 }
 
 /*
@@ -6995,11 +7034,11 @@ static void
 log_dump_checkpoint_topops (FILE * out_fp, int length, void *data)
 {
   int ntops, i;
-  LOG_INFO_CHKPT_SYSOP_START_POSTPONE *chkpt_topops;	/* Checkpoint top system operations that are in commit postpone 
-							 * mode */
-  LOG_INFO_CHKPT_SYSOP_START_POSTPONE *chkpt_topone;	/* One top system ope */
+  LOG_INFO_CHKPT_SYSOP *chkpt_topops;	/* Checkpoint top system operations that are in commit postpone 
+					 * mode */
+  LOG_INFO_CHKPT_SYSOP *chkpt_topone;	/* One top system ope */
 
-  chkpt_topops = (LOG_INFO_CHKPT_SYSOP_START_POSTPONE *) data;
+  chkpt_topops = (LOG_INFO_CHKPT_SYSOP *) data;
   ntops = length / sizeof (*chkpt_topops);
 
   /* Start dumping each checkpoint top system operation */
@@ -7029,7 +7068,7 @@ log_dump_record_checkpoint (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * lo
   fprintf (out_fp, "     Redo_LSA = %lld|%d\n", (long long int) chkpt->redo_lsa.pageid, chkpt->redo_lsa.offset);
 
   length_active_tran = sizeof (LOG_INFO_CHKPT_TRANS) * chkpt->ntrans;
-  length_topope = (sizeof (LOG_INFO_CHKPT_SYSOP_START_POSTPONE) * chkpt->ntops);
+  length_topope = (sizeof (LOG_INFO_CHKPT_SYSOP) * chkpt->ntops);
   LOG_READ_ADD_ALIGN (thread_p, sizeof (*chkpt), log_lsa, log_page_p);
   log_dump_data (thread_p, out_fp, length_active_tran, log_lsa, log_page_p, logpb_dump_checkpoint_trans, NULL);
   if (length_topope > 0)
@@ -7244,6 +7283,7 @@ log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type
     case LOG_2PC_ABORT_DECISION:
     case LOG_2PC_COMMIT_INFORM_PARTICPS:
     case LOG_2PC_ABORT_INFORM_PARTICPS:
+    case LOG_SYSOP_ATOMIC_START:
     case LOG_DUMMY_HEAD_POSTPONE:
     case LOG_DUMMY_CRASH_RECOVERY:
     case LOG_DUMMY_OVF_RECORD:
@@ -8165,6 +8205,7 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
 	    case LOG_2PC_ABORT_INFORM_PARTICPS:
 	    case LOG_REPLICATION_DATA:
 	    case LOG_REPLICATION_STATEMENT:
+	    case LOG_SYSOP_ATOMIC_START:
 	    case LOG_DUMMY_HA_SERVER_STATE:
 	    case LOG_DUMMY_OVF_RECORD:
 	    case LOG_DUMMY_GENERIC:
@@ -8581,6 +8622,7 @@ log_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postp
 		    case LOG_DUMMY_HEAD_POSTPONE:
 		    case LOG_REPLICATION_DATA:
 		    case LOG_REPLICATION_STATEMENT:
+		    case LOG_SYSOP_ATOMIC_START:
 		    case LOG_DUMMY_HA_SERVER_STATE:
 		    case LOG_DUMMY_OVF_RECORD:
 		    case LOG_DUMMY_GENERIC:

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -208,6 +208,7 @@ extern SCAN_CODE log_get_undo_record (THREAD_ENTRY * thread_p, LOG_PAGE * log_pa
 				      RECDES * recdes);
 
 extern void log_sysop_start (THREAD_ENTRY * thread_p);
+extern void log_sysop_start_atomic (THREAD_ENTRY * thread_p);
 extern void log_sysop_abort (THREAD_ENTRY * thread_p);
 extern void log_sysop_attach_to_outer (THREAD_ENTRY * thread_p);
 extern void log_sysop_commit (THREAD_ENTRY * thread_p);

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1296,7 +1296,7 @@ log_rv_analysis_sysop_start_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_
       if (logtb_realloc_topops_stack (tdes, 1) == NULL)
 	{
 	  /* Out of memory */
-	  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_recovery_analysis");
+	  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_rv_analysis_atomic_sysop_start");
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
     }

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -4059,10 +4059,16 @@ log_recovery_abort_atomic_sysop (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
       return;
     }
 
-  if (LSA_ISNULL (&tdes->rcv.atomic_sysop_start_lsa) || LSA_GE (&tdes->rcv.atomic_sysop_start_lsa, &tdes->undo_nxlsa))
+  if (LSA_ISNULL (&tdes->rcv.atomic_sysop_start_lsa))
     {
       /* no atomic system operation */
       return;
+    }
+  if (LSA_GE (&tdes->rcv.atomic_sysop_start_lsa, &tdes->undo_nxlsa))
+    {
+      /* nothing after tdes->rcv.atomic_sysop_start_lsa */
+      assert (LSA_EQ (&tdes->rcv.atomic_sysop_start_lsa, &tdes->undo_nxlsa));
+      LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
     }
   assert (tdes->topops.last <= 0);
 

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -4109,7 +4109,8 @@ log_recovery_abort_atomic_sysop (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 
   assert (tdes->topops.last <= 0);
 
-  /* this is it */
+  /* this is it. reset tdes->rcv.atomic_sysop_start_lsa and we're done. */
+  LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
 }
 
 /*

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -74,6 +74,7 @@ static int log_rv_analysis_commit_with_postpone (THREAD_ENTRY * thread_p, int tr
 						 LOG_PAGE * log_page_p);
 static int log_rv_analysis_sysop_start_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa,
 						 LOG_PAGE * log_page_p);
+static int log_rv_analysis_atomic_sysop_start (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa);
 static int log_rv_analysis_complete (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa, LOG_PAGE * log_page_p,
 				     LOG_LSA * prev_lsa, bool is_media_crash, time_t * stop_at,
 				     bool * did_incom_recovery);
@@ -101,7 +102,10 @@ static void log_recovery_analysis (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa,
 				   bool * did_incom_recovery, INT64 * num_redo_log_records);
 static void log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const LOG_LSA * end_redo_lsa,
 			       time_t * stopat);
+static void log_recovery_finish_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
 static void log_recovery_finish_all_postpone (THREAD_ENTRY * thread_p);
+static void log_recovery_abort_atomic_sysop (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
+static void log_recovery_abort_all_atomic_sysops (THREAD_ENTRY * thread_p);
 static void log_recovery_undo (THREAD_ENTRY * thread_p);
 static void log_recovery_notpartof_archives (THREAD_ENTRY * thread_p, int start_arv_num, const char *info_reason);
 static bool log_unformat_ahead_volumes (THREAD_ENTRY * thread_p, VOLID volid, VOLID * start_volid);
@@ -1317,6 +1321,42 @@ log_rv_analysis_sysop_start_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_
   LSA_COPY (&tdes->topops.stack[tdes->topops.last].lastparent_lsa, &sysop_start_posp->sysop_end.lastparent_lsa);
   LSA_COPY (&tdes->topops.stack[tdes->topops.last].posp_lsa, &sysop_start_posp->posp_lsa);
 
+  if (LSA_LT (&sysop_start_posp->sysop_end.lastparent_lsa, &tdes->rcv.atomic_sysop_start_lsa))
+    {
+      /* reset tdes->rcv.atomic_sysop_start_lsa */
+      LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
+    }
+
+  return NO_ERROR;
+}
+
+/*
+ * log_rv_analysis_atomic_sysop_start () - analyze start atomic system operation
+ *
+ * return        : error code
+ * thread_p (in) : thread entry
+ * tran_id (in)  : transaction ID
+ * log_lsa (in)  : log record LSA. will be used as marker for start system operation.
+ */
+static int
+log_rv_analysis_atomic_sysop_start (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa)
+{
+  LOG_TDES *tdes;
+
+  tdes = logtb_rv_find_allocate_tran_index (thread_p, tran_id, log_lsa);
+  if (tdes == NULL)
+    {
+      logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_rv_analysis_sysop_start_postpone");
+      return ER_FAILED;
+    }
+
+  tdes->tail_lsa = *log_lsa;
+  tdes->undo_nxlsa = tdes->tail_lsa;
+
+  /* this is a marker for system operations that need to be atomic. they will be rollbacked before postpone is finished.
+   */
+  tdes->rcv.atomic_sysop_start_lsa = *log_lsa;
+
   return NO_ERROR;
 }
 
@@ -1579,6 +1619,12 @@ log_rv_analysis_sysop_end (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_l
       tdes->topops.last = -1;
     }
 
+  if (LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.atomic_sysop_start_lsa))
+    {
+      /* reset tdes->rcv.atomic_sysop_start_lsa */
+      LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
+    }
+
   return NO_ERROR;
 }
 
@@ -1636,8 +1682,8 @@ log_rv_analysis_end_checkpoint (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_
   LOG_REC_CHKPT chkpt;
   LOG_INFO_CHKPT_TRANS *chkpt_trans;
   LOG_INFO_CHKPT_TRANS *chkpt_one;
-  LOG_INFO_CHKPT_SYSOP_START_POSTPONE *chkpt_topops;
-  LOG_INFO_CHKPT_SYSOP_START_POSTPONE *chkpt_topone;
+  LOG_INFO_CHKPT_SYSOP *chkpt_topops;
+  LOG_INFO_CHKPT_SYSOP *chkpt_topone;
   int size;
   void *area;
   int i;
@@ -1770,10 +1816,10 @@ log_rv_analysis_end_checkpoint (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_
 
   if (chkpt.ntops > 0)
     {
-      size = sizeof (LOG_INFO_CHKPT_SYSOP_START_POSTPONE) * chkpt.ntops;
+      size = sizeof (LOG_INFO_CHKPT_SYSOP) * chkpt.ntops;
       if (log_lsa->offset + size < (int) LOGAREA_SIZE)
 	{
-	  chkpt_topops = ((LOG_INFO_CHKPT_SYSOP_START_POSTPONE *) ((char *) log_page_p->area + log_lsa->offset));
+	  chkpt_topops = ((LOG_INFO_CHKPT_SYSOP *) ((char *) log_page_p->area + log_lsa->offset));
 	  log_lsa->offset += size;
 	}
       else
@@ -1787,7 +1833,7 @@ log_rv_analysis_end_checkpoint (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_
 	    }
 	  /* Copy the data */
 	  logpb_copy_from_log (thread_p, (char *) area, size, log_lsa, log_page_p);
-	  chkpt_topops = (LOG_INFO_CHKPT_SYSOP_START_POSTPONE *) area;
+	  chkpt_topops = (LOG_INFO_CHKPT_SYSOP *) area;
 	}
 
       /* Add the top system operations to the transactions */
@@ -1823,6 +1869,7 @@ log_rv_analysis_end_checkpoint (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_
 
 	  tdes->topops.last++;
 	  tdes->rcv.sysop_start_postpone_lsa = chkpt_topone->sysop_start_postpone_lsa;
+	  tdes->rcv.atomic_sysop_start_lsa = chkpt_topone->atomic_sysop_start_lsa;
 	  log_lsa_local = chkpt_topone->sysop_start_postpone_lsa;
 	  error_code =
 	    log_read_sysop_start_postpone (thread_p, &log_lsa_local, log_page_local, false, &sysop_start_postpone,
@@ -2262,6 +2309,10 @@ log_rv_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE log_type, int tran_
 
     case LOG_END_OF_LOG:
       (void) log_rv_analysis_log_end (tran_id, log_lsa);
+      break;
+
+    case LOG_SYSOP_ATOMIC_START:
+      (void) log_rv_analysis_atomic_sysop_start (thread_p, tran_id, log_lsa);
       break;
 
     case LOG_DUMMY_CRASH_RECOVERY:
@@ -3626,6 +3677,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 	    case LOG_DUMMY_OVF_RECORD:
 	    case LOG_DUMMY_GENERIC:
 	    case LOG_END_OF_LOG:
+	    case LOG_SYSOP_ATOMIC_START:
 	      break;
 
 	    case LOG_SMALLER_LOGREC_TYPE:
@@ -3660,6 +3712,9 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 
   logtb_reset_bit_area_start_mvccid ();
 
+  /* Abort all atomic system operations that were open when server crashed */
+  log_recovery_abort_all_atomic_sysops (thread_p);
+
   /* Now finish all postpone operations */
   log_recovery_finish_all_postpone (thread_p);
 
@@ -3676,23 +3731,16 @@ exit:
 }
 
 /*
- * log_recovery_finish_postpone () - Finish postpone during recovery for one
- *				     transaction descriptor.
+ * log_recovery_finish_sysop_postpone () - Finish postpone during recovery for one system operation.
  *
- * return	 : Void.
- * thread_p (in) : Thread entry.
- * tdes (in)	 : Transaction descriptor.
+ * return        : void
+ * thread_p (in) : thread entry
+ * tdes (in)     : transaction descriptor
  */
 static void
-log_recovery_finish_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
+log_recovery_finish_sysop_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 {
   LOG_LSA first_postpone_to_apply;
-
-  if (tdes == NULL || tdes->trid == NULL_TRANID)
-    {
-      /* Nothing to do */
-      return;
-    }
 
   if (tdes->state == TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE)
     {
@@ -3798,8 +3846,29 @@ log_recovery_finish_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 	}
     }
   assert (tdes->state != TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE);
+}
 
-  LSA_SET_NULL (&first_postpone_to_apply);
+/*
+ * log_recovery_finish_postpone () - Finish postpone during recovery for one
+ *				     transaction descriptor.
+ *
+ * return	 : Void.
+ * thread_p (in) : Thread entry.
+ * tdes (in)	 : Transaction descriptor.
+ */
+static void
+log_recovery_finish_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
+{
+  LOG_LSA first_postpone_to_apply;
+
+  if (tdes == NULL || tdes->trid == NULL_TRANID)
+    {
+      /* Nothing to do */
+      return;
+    }
+
+  /* first finish system op postpone (if the case). */
+  log_recovery_finish_sysop_postpone (thread_p, tdes);
 
   if (tdes->state == TRAN_UNACTIVE_WILL_COMMIT || tdes->state == TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE)
     {
@@ -3916,6 +3985,131 @@ log_recovery_finish_all_postpone (THREAD_ENTRY * thread_p)
       /* Restore thread */
       VACUUM_RESTORE_THREAD (thread_p, save_thread_type);
     }
+}
+
+/*
+ * log_recovery_abort_all_atomic_sysops () - abort all atomic system operation opened at the moment of the crash
+ *
+ * return        : void
+ * thread_p (in) : thread entry
+ */
+static void
+log_recovery_abort_all_atomic_sysops (THREAD_ENTRY * thread_p)
+{
+  int i;
+  int save_tran_index;
+  int save_thread_type = 0;
+  TRANID trid;
+  LOG_TDES *tdes = NULL;	/* Transaction descriptor */
+  VACUUM_WORKER *worker = NULL;
+
+  /* Finish committing transactions with unfinished postpone actions */
+  thread_p = thread_p != NULL ? thread_p : thread_get_thread_entry_info ();
+
+  save_tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+
+  for (i = 0; i < log_Gl.trantable.num_total_indices; i++)
+    {
+      tdes = LOG_FIND_TDES (i);
+      if (tdes == NULL || tdes->trid == NULL_TRANID)
+	{
+	  continue;
+	}
+      LOG_SET_CURRENT_TRAN_INDEX (thread_p, i);
+      log_recovery_abort_atomic_sysop (thread_p, tdes);
+      LOG_SET_CURRENT_TRAN_INDEX (thread_p, save_tran_index);
+    }
+  for (trid = LOG_FIRST_VACUUM_WORKER_TRANID; trid <= LOG_VACUUM_MASTER_TRANID; trid++)
+    {
+      /* Convert thread to vacuum worker */
+      worker = vacuum_rv_get_worker_by_trid (thread_p, trid);
+      if (worker->state != VACUUM_WORKER_STATE_RECOVERY)
+	{
+	  /* Nothing to do */
+	  continue;
+	}
+      VACUUM_CONVERT_THREAD_TO_VACUUM (thread_p, worker, save_thread_type);
+      tdes = worker->tdes;
+
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+		     "VACUUM: Finish postpone for tdes: tdes->trid=%d, tdes->state=%d, tdes->topops.last=%d.",
+		     tdes->trid, tdes->state, tdes->topops.last);
+
+      log_recovery_abort_atomic_sysop (thread_p, tdes);
+
+      /* Restore thread */
+      VACUUM_RESTORE_THREAD (thread_p, save_thread_type);
+    }
+}
+
+/*
+ * log_recovery_abort_atomic_sysop () - abort all changes down to tdes->rcv.atomic_sysop_start_lsa (where atomic system
+ *                                      operation starts).
+ *
+ * return        : void
+ * thread_p (in) : thread entry
+ * tdes (in)     : transaction descriptor
+ */
+static void
+log_recovery_abort_atomic_sysop (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
+{
+  if (tdes == NULL || tdes->trid == NULL_TRANID)
+    {
+      /* Nothing to do */
+      return;
+    }
+
+  if (LSA_ISNULL (&tdes->rcv.atomic_sysop_start_lsa) || LSA_GE (&tdes->rcv.atomic_sysop_start_lsa, &tdes->undo_nxlsa))
+    {
+      /* no atomic system operation */
+      return;
+    }
+  assert (tdes->topops.last <= 0);
+
+  if (tdes->state == TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE
+      && LSA_GT (&tdes->rcv.sysop_start_postpone_lsa, &tdes->rcv.atomic_sysop_start_lsa))
+    {
+      /* we have (maybe) the next case: 
+       *
+       * 1. atomic operation was started.
+       * 2. nested system operation is started.
+       * 3. nested operation has postpones.
+       * 4. nested operation is committed with postpone.
+       * 5. crash
+       *
+       * I am not sure this really happens. It might, and it might be risky to allow it. However, I assume this nested
+       * operation will not do other complicated operations to mess with other logical operations. I hope at least. */
+      /* finish postpone of nested system op. */
+      er_log_debug (ARG_FILE_LINE, "Nested sysop start pospone (%lld|%d) inside atomic sysop (%lld|%d). \n",
+		    LSA_AS_ARGS (&tdes->rcv.sysop_start_postpone_lsa), LSA_AS_ARGS (&tdes->rcv.atomic_sysop_start_lsa));
+      log_recovery_finish_sysop_postpone (thread_p, tdes);
+    }
+  else if (tdes->state == TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE)
+    {
+      /* this would be also a nested case, but the other way around:
+       *
+       * 1. system op starts.
+       * 2. system op end with postpone.
+       * 3. nested atomic system op starts.
+       * 4. crash.
+       *
+       * we first have to abort atomic system op. postpone will be finished later. */
+      er_log_debug (ARG_FILE_LINE, "Nested atomic sysop  (%lld|%d) after sysop start postpone (%lld|%d). \n",
+		    LSA_AS_ARGS (&tdes->rcv.sysop_start_postpone_lsa), LSA_AS_ARGS (&tdes->rcv.atomic_sysop_start_lsa));
+    }
+
+  /* rollback. simulate a new system op */
+  log_sysop_start (thread_p);
+
+  /* hack last parent to stop at tdes->rcv.atomic_sysop_start_lsa */
+  tdes->topops.stack[tdes->topops.last].lastparent_lsa = tdes->rcv.atomic_sysop_start_lsa;
+
+  /* rollback */
+  log_sysop_abort (thread_p);
+
+  assert (tdes->topops.last <= 0);
+
+  /* this is it */
 }
 
 /*
@@ -4206,6 +4400,7 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		case LOG_DUMMY_HA_SERVER_STATE:
 		case LOG_DUMMY_OVF_RECORD:
 		case LOG_DUMMY_GENERIC:
+		case LOG_SYSOP_ATOMIC_START:
 		  /* Not for UNDO ... */
 		  /* Break switch to go to previous record */
 		  break;
@@ -5100,7 +5295,7 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
       LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_CHKPT), &log_lsa, log_pgptr);
       chkpt = (LOG_REC_CHKPT *) ((char *) log_pgptr->area + log_lsa.offset);
       undo_length = sizeof (LOG_INFO_CHKPT_TRANS) * chkpt->ntrans;
-      redo_length = sizeof (LOG_INFO_CHKPT_SYSOP_START_POSTPONE) * chkpt->ntops;
+      redo_length = sizeof (LOG_INFO_CHKPT_SYSOP) * chkpt->ntops;
 
       LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_CHKPT), &log_lsa, log_pgptr);
       LOG_READ_ADD_ALIGN (thread_p, undo_length, &log_lsa, log_pgptr);
@@ -5168,6 +5363,7 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
     case LOG_DUMMY_OVF_RECORD:
     case LOG_DUMMY_GENERIC:
     case LOG_END_OF_LOG:
+    case LOG_SYSOP_ATOMIC_START:
       break;
 
     case LOG_REPLICATION_DATA:

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1950,6 +1950,7 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 
   LSA_SET_NULL (&tdes->rcv.tran_start_postpone_lsa);
   LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
+  LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
 }
 
 /*
@@ -2045,6 +2046,7 @@ logtb_initialize_tdes (LOG_TDES * tdes, int tran_index)
 
   LSA_SET_NULL (&tdes->rcv.tran_start_postpone_lsa);
   LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
+  LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21003

The issue is caused by finishing postpone of file dealloc meddling with another file alloc or dealloc operation interrupted by crash. The correct order is to first abort interrupted system operations and then finishing postpones.

But of course, this is easier said than done. Because we have to abort only interrupted system operations and not entire transactions. But we have no way of determining where a system operation has started during recovery. This is the first problem.
The second problem is caused by nested system operations. We can have one atomic system operation that has another nested system operation using postpones and that can be running postpone during crash. In this case, we first have to finish postpone of nested system operation and then abort the parent system operation.
You want to ask what about nesting another atomic system operation during the run postpone of another sytem operation nested to yet another atomic operation? I'll answer "God, I hope not" and I'll tell you that I have a safe-guard checking it never happens.

So the solution I found was to use a marker for starting atomic system operation. This is some kind of dummy log record (it only has a header, no data). I am sorry I had to add another log record, I wish I could use the existing ones, but there are so many cases of first log records in file_alloc and file_rv_dealloc_internal. I had do some ugly and complicated checks in both prior_lsa_next_record_internal and log_rv_analysis_undo_redo (which does not even have access to log record data). So I chose the easier way for me, by adding a new log record type with a clear meaning. The pro for this is that it may be easily extended to other situations.

So the complete rules for atomic system operations:
1. Atomic system operations can be nested by other atomic system operations.
2. Atomic system operations can occur during the postpone of other system operation.
3. Atomic system operation is considered completed when ending a system operation having lastparent_lsa preceding its start LSA.
4. I mentioned earlier the one case where atomic system operations are not allowed: inside a postpone phase of a system operation nested to another atomic system operation.

How it works:
1. Call log_sysop_start_atomic. Besides starting a system operation, it will also add a LOG_SYSOP_ATOMIC_START log record.
2. prior_lsa_next_record_internal, while under log_Gl.prior_info.prior_lsa_mutex, will set tdes->rcv.atomic_sysop_start_lsa to its start_lsa.
3. If checkpoint ends before system operation is completed, tdes->rcv.atomic_sysop_start_lsa is logged.
4. When atomic system operation is ended in either way (abord, commit, commit with postpone and so on), reset tdes->rcv.atomic_sysop_start_lsa. To make sure a nested system operation does not reset it, we compare the LSA to lastparent_lsa.
5. During analysis phase, we track LOG_SYSOP_ATOMIC_START to set tdes->rcv.atomic_sysop_start_lsa. We can also copy it from checkpoint data. We can reset it on system op end or start postpone (same condition using lastparent_lsa).
6. We'll call log_recovery_abort_all_atomic_sysops before calling log_recovery_finish_all_postpone.
7. For each transaction with interrupted atomic operations, log_recovery_abort_atomic_sysop gets called. We also check if we should do a log_recovery_finish_sysop_postpone first (if tdes->rcv.sysop_start_postpone_lsa is greated than tdes->rcv.atomic_sysop_start_lsa).
8. Redo, undo, rollback, run postpone recovery operations ignore the LOG_SYSOP_ATOMIC_START log record.