### PR TITLE
[CBRD-21080] pgbuf_flush_victim_candidates: fix hitting safe-guard

### DIFF
--- a/contrib/gdb_debugging_scripts/page_buffer.gdb
+++ b/contrib/gdb_debugging_scripts/page_buffer.gdb
@@ -544,3 +544,38 @@ define pgbuf_flush_select_victims
     printf "total victims = %d \n", $total_vict_cand
   set pagination on
   end
+
+# pgbuf_flush_show_all
+# No arguments
+# 
+# Print all information relevant to the safe guard in pgbuf_flush_victim_candidates. Function is designed to be called in pgbuf_flush_victim_candidates.
+#
+# Prerequisite:
+# pgbuf_lru_print_victim_status
+# pgbuf_flush_select_victims
+#
+define pgbuf_flush_show_all
+  set $lfcq = pgbuf_Pool.direct_victims.waiter_threads_high_priority
+  set $i = $lfcq->consume_cursor
+  set $thrar = (THREAD_ENTRY **) $lfcq->data
+  while $i < $lfcq->produce_cursor
+    printf "thread %d \n", $thrar[$i % $lfcq->capacity]->index
+    set $plru = $thrar[$i % $lfcq->capacity]->private_lru_index
+    pgbuf_lru_print $plru
+    set $i = $i + 1
+    end
+    
+  set $lfcq = pgbuf_Pool.direct_victims.waiter_threads_low_priority
+  set $i = $lfcq->consume_cursor
+  set $thrar = (THREAD_ENTRY **) $lfcq->data
+  while $i < $lfcq->produce_cursor
+    printf "thread %d \n", $thrar[$i % $lfcq->capacity]->index
+    set $plru = $thrar[$i % $lfcq->capacity]->private_lru_index
+    pgbuf_lru_print $plru
+    set $i = $i + 1
+    end
+  
+  pgbuf_lru_print_victim_status
+  pgbuf_flush_select_victims
+  end
+  

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8328,6 +8328,12 @@ pgbuf_get_victim_from_lru_list (THREAD_ENTRY * thread_p, const int lru_idx)
       return NULL;
     }
 
+  if (!pgbuf_bcb_is_dirty (lru_list->bottom) && lru_list->victim_hint != lru_list->bottom)
+    {
+      /* update hint to bottom. sometimes it may be out of sync. */
+      (void) ATOMIC_TAS_ADDR (&lru_list->victim_hint, lru_list->bottom);
+    }
+
   /* we will search */
   found_victim_cnt = 0;
   bufptr_victimizable = NULL;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -756,7 +756,6 @@ struct pgbuf_buffer_pool
   int num_LRU_list;		/* number of shared LRU lists */
   float ratio_lru1;		/* ratio for lru 1 zone */
   float ratio_lru2;		/* ratio for lru 2 zone */
-  int last_flushed_LRU_list_idx;	/* index of the last flushed LRU list */
   PGBUF_LRU_LIST *buf_LRU_list;	/* LRU lists. When Page quota is enabled, first 'num_LRU_list' store shared pages;
 				 * the next 'num_garbage_LRU_list' lists store shared garbage pages;
 				 * the last 'num_private_LRU_list' are private lists.
@@ -1002,7 +1001,7 @@ static PGBUF_BCB *pgbuf_get_bcb_from_invalid_list (THREAD_ENTRY * thread_p);
 static int pgbuf_put_bcb_into_invalid_list (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr);
 
 STATIC_INLINE int pgbuf_get_shared_lru_index_for_add (void) __attribute__ ((ALWAYS_INLINE));
-static int pgbuf_get_victim_candidates_from_lru (THREAD_ENTRY * thread_p, int check_count, int victim_count,
+static int pgbuf_get_victim_candidates_from_lru (THREAD_ENTRY * thread_p, int check_count,
 						 float lru_sum_flush_priority);
 static PGBUF_BCB *pgbuf_get_victim (THREAD_ENTRY * thread_p);
 STATIC_INLINE PGBUF_BCB *pgbuf_get_victim_from_lru_list (THREAD_ENTRY * thread_p, const int lru_idx)
@@ -3097,49 +3096,35 @@ pgbuf_compare_victim_list (const void *p1, const void *p2)
  * return : number of victims found
  * thread_p (in)     : thread entry
  * check_count (in)  : number of items to verify before abandoning search
- * victim_count (in) : number of victims already selected
  * flush_ratio (in)  : flush ratio
  */
 static int
-pgbuf_get_victim_candidates_from_lru (THREAD_ENTRY * thread_p, int check_count, int victim_count,
-				      float lru_sum_flush_priority)
+pgbuf_get_victim_candidates_from_lru (THREAD_ENTRY * thread_p, int check_count, float lru_sum_flush_priority)
 {
-#if defined(SERVER_MODE)
-  int rv;
-#endif
-  PGBUF_VICTIM_CANDIDATE_LIST *victim_cand_list = NULL;
-  int lru_idx, start_lru_idx, victim_cand_count, i;
+  int lru_idx, victim_cand_count, i;
   PGBUF_BCB *bufptr;
-  int cand_found_in_this_lru;
   int check_count_this_lru;
   float victim_flush_priority_this_lru;
+  int count_checked_lists = 0;
 
   /* init */
-  lru_idx = ((pgbuf_Pool.last_flushed_LRU_list_idx + 1) % PGBUF_TOTAL_LRU_COUNT);
-  start_lru_idx = lru_idx;
-  victim_cand_count = victim_count;
-  victim_cand_list = pgbuf_Pool.victim_cand_list;
-
-  do
+  victim_cand_count = 0;
+  for (lru_idx = 0; lru_idx < PGBUF_TOTAL_LRU_COUNT; lru_idx++)
     {
       victim_flush_priority_this_lru = pgbuf_Pool.quota.lru_victim_flush_priority_per_lru[lru_idx];
-
-      /* do not flush from this LRU when there are no victim requests, or no pages in list or all victim requests were
-       * quickly served from bottom LRU (vict_searches_this_lru == 0) */
       if (victim_flush_priority_this_lru <= 0)
 	{
-	  pgbuf_Pool.last_flushed_LRU_list_idx = lru_idx;
-	  lru_idx = (lru_idx + 1) % PGBUF_TOTAL_LRU_COUNT;
+	  /* no target for this list. */
 	  continue;
 	}
+      ++count_checked_lists;
 
       check_count_this_lru = (int) (victim_flush_priority_this_lru * (float) check_count / lru_sum_flush_priority);
       check_count_this_lru = MAX (check_count_this_lru, 1);
 
-      cand_found_in_this_lru = 0;
       i = check_count_this_lru;
 
-      rv = pthread_mutex_lock (&pgbuf_Pool.buf_LRU_list[lru_idx].mutex);
+      (void) pthread_mutex_lock (&pgbuf_Pool.buf_LRU_list[lru_idx].mutex);
 
       for (bufptr = pgbuf_Pool.buf_LRU_list[lru_idx].bottom;
 	   bufptr != NULL && PGBUF_IS_BCB_IN_LRU_VICTIM_ZONE (bufptr) && i > 0; bufptr = bufptr->prev_BCB, i--)
@@ -3147,27 +3132,19 @@ pgbuf_get_victim_candidates_from_lru (THREAD_ENTRY * thread_p, int check_count, 
 	  if (pgbuf_bcb_is_dirty (bufptr))
 	    {
 	      /* save victim candidate information temporarily. */
-	      victim_cand_list[victim_cand_count].bufptr = bufptr;
-	      victim_cand_list[victim_cand_count].vpid = bufptr->vpid;
+	      pgbuf_Pool.victim_cand_list[victim_cand_count].bufptr = bufptr;
+	      pgbuf_Pool.victim_cand_list[victim_cand_count].vpid = bufptr->vpid;
 	      victim_cand_count++;
-	      cand_found_in_this_lru++;
 	    }
 	}
       pthread_mutex_unlock (&pgbuf_Pool.buf_LRU_list[lru_idx].mutex);
-
-      /* Note that we don't hold the mutex, however it will not be an issue.
-       * Also note that we are updating the last_flushed_LRU_list_idx whether the list has flushed or not.
-       */
-      pgbuf_Pool.last_flushed_LRU_list_idx = lru_idx;
-
-      lru_idx = (lru_idx + 1) % PGBUF_TOTAL_LRU_COUNT;
     }
-  while (lru_idx != start_lru_idx);	/* check if we've visited all of the lists */
 
-  er_log_debug (ARG_FILE_LINE, "pgbuf_flush_victim_candidates: pgbuf_get_victim_candidates_from_lru %d \n",
-		victim_cand_count - victim_count);
+  er_log_debug (ARG_FILE_LINE,
+		"pgbuf_flush_victim_candidates: pgbuf_get_victim_candidates_from_lru %d candidates in %d lists \n",
+		victim_cand_count, count_checked_lists);
 
-  return victim_cand_count - victim_count;
+  return victim_cand_count;
 }
 
 /*
@@ -3223,9 +3200,6 @@ pgbuf_flush_victim_candidates (THREAD_ENTRY * thread_p, float flush_ratio, PERF_
 
   victim_cand_list = pgbuf_Pool.victim_cand_list;
 
-  lru_idx = ((pgbuf_Pool.last_flushed_LRU_list_idx + 1) % PGBUF_TOTAL_LRU_COUNT);
-  start_lru_idx = lru_idx;
-
   victim_count = 0;
   total_flushed_count = 0;
   check_count_lru = 0;
@@ -3271,7 +3245,7 @@ pgbuf_flush_victim_candidates (THREAD_ENTRY * thread_p, float flush_ratio, PERF_
 
   if (check_count_lru > 0 && lru_sum_flush_priority > 0)
     {
-      victim_count = pgbuf_get_victim_candidates_from_lru (thread_p, check_count_lru, 0, lru_sum_flush_priority);
+      victim_count = pgbuf_get_victim_candidates_from_lru (thread_p, check_count_lru, lru_sum_flush_priority);
     }
   if (victim_count == 0)
     {
@@ -3440,9 +3414,8 @@ end:
 	  || count_need_wal > 0);
 #endif /* SERVER_MODE */
 
-  er_log_debug (ARG_FILE_LINE, "pgbuf_flush_victim_candidates: flush %d pages from (%d) to (%d) list. Found LRU:%d/%d",
-		total_flushed_count, start_lru_idx, pgbuf_Pool.last_flushed_LRU_list_idx, victim_count,
-		check_count_lru);
+  er_log_debug (ARG_FILE_LINE, "pgbuf_flush_victim_candidates: flush %d pages from lru lists. Found LRU:%d/%d",
+		total_flushed_count, victim_count, check_count_lru);
   er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_FLUSH_VICTIM_FINISHED, 1, total_flushed_count);
 
   perfmon_add_stat (thread_p, PSTAT_PB_NUM_FLUSHED, total_flushed_count);
@@ -4934,7 +4907,6 @@ pgbuf_initialize_lru_list (void)
   int i;
 
   /* set the number of LRU lists */
-  pgbuf_Pool.last_flushed_LRU_list_idx = -1;
   pgbuf_Pool.num_LRU_list = prm_get_integer_value (PRM_ID_PB_NUM_LRU_CHAINS);
   if (pgbuf_Pool.num_LRU_list == 0)
     {

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -6430,3 +6430,27 @@ thread_daemon_wakeup_onereq (DAEMON_THREAD_MONITOR * daemon)
     }
   pthread_mutex_unlock (&daemon->lock);
 }
+
+#if !defined (NDEBUG)
+/*
+ * thread_iterate () - thread iterator
+ *
+ * return        : next thread entry
+ * thread_p (in) : current thread entry
+ */
+THREAD_ENTRY *
+thread_iterate (THREAD_ENTRY * thread_p)
+{
+  int index = 0;
+  if (thread_p != NULL)
+    {
+      index = thread_p->index + 1;
+    }
+  if (index >= thread_Manager.num_total)
+    {
+      assert (index == thread_Manager.num_total);
+      return NULL;
+    }
+  return thread_Manager.thread_array + index;
+}
+#endif /* !NDEBUG */

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -531,6 +531,9 @@ extern int thread_first_vacuum_worker_thread_index (void);
 
 extern bool thread_is_auto_volume_expansion_thread_available (void);
 
+#if !defined (NDEBUG)
+extern THREAD_ENTRY *thread_iterate (THREAD_ENTRY * thread_p);
+#endif /* !NDEBUG */
 #endif /* SERVER_MODE */
 
 #endif /* _THREAD_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21080

Four cases when safe-guard is hit:
- two of them are acceptable scenarios. I updated the safe-guard so it would not be hit in these cases. The waiters have no candidates and under-quota private lists, while other lists have enough victim candidates.
- one scenario when thread does not find a victim in his private lists although there are more than 4k victim candidates. I suspect the victim hint was bad and I tried to quick fix it by changing the hint to bottom when bottom is not dirty.
- one scenario when flush thread should have found victim candidates in list, but it didn't. I still don't understand why and how it happened. However, I changed the looping pgbuf_get_victim_candidates_from_lru in order to make sure all lists are processed exactly once (in the old loop, starting lru could be processed twice if previous list was empty).

I have added helpful scripts for gdb specially designed for this safe-guard.