### PR TITLE
[CBRD-20699] vacuum_heap_page: error handling for release mode

### DIFF
--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -4830,7 +4830,7 @@ spage_get_slot (PAGE_PTR page_p, PGSLOTID slot_id)
 /*
  * spage_vacuum_slot () - Vacuum the slot of an invisible object version.
  *
- * return	     : Error code.
+ * return	     : void.
  * thread_p (in)     : Thread entry.
  * page_p (in)	     : Page pointer.
  * slotid (in)	     : Record slot id.
@@ -4846,7 +4846,7 @@ spage_get_slot (PAGE_PTR page_p, PGSLOTID slot_id)
  *	    slot and this version is invisible, there is no point in keeping
  *	    links to newer versions.
  */
-int
+void
 spage_vacuum_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slotid, bool reusable)
 {
   SPAGE_HEADER *page_header_p = (SPAGE_HEADER *) page_p;
@@ -4864,7 +4864,6 @@ spage_vacuum_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slotid, bo
       /* Vacuum error log */
       vacuum_er_log (VACUUM_ER_LOG_ERROR, "VACUUM: Object (%d, %d, %d) was already vacuumed",
 		     pgbuf_get_vpid_ptr (page_p)->volid, pgbuf_get_vpid_ptr (page_p)->pageid, slotid);
-      return NO_ERROR;
     }
 
   /* Slot is deleted */
@@ -4887,8 +4886,6 @@ spage_vacuum_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slotid, bo
 #ifdef SPAGE_DEBUG
   spage_check (thread_p, page_p);
 #endif
-
-  return NO_ERROR;
 }
 
 /*

--- a/src/storage/slotted_page.h
+++ b/src/storage/slotted_page.h
@@ -212,6 +212,6 @@ extern SCAN_CODE spage_slots_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_
 					void *ctx);
 extern int spage_slots_end_scan (THREAD_ENTRY * thread_p, void **ctx);
 
-extern int spage_vacuum_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slotid, bool reusable);
+extern void spage_vacuum_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slotid, bool reusable);
 extern bool spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p);
 #endif /* _SLOTTED_PAGE_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20699

The issue was caused by accessing an unfixed page (home page was unfixed while trying to fix forward page which failed).

Abort vacuum when the case happens. Other minor changes in vacuum_heap_page.