### PR TITLE
[CBRD-21039] Fix tracking processing & unregister

### DIFF
--- a/src/base/release_string.c
+++ b/src/base/release_string.c
@@ -101,7 +101,9 @@ static REL_COMPATIBILITY rel_get_compatible_internal (const char *base_rel_str, 
  * Disk (database image) Version Compatibility
  */
 /* TODO: when disk_compatibility_level is incremented, also search for VACUUM_DATA_COMPATIBILITY and remove the backward
- *       compatibility code. And remove this comment too. */
+ *       compatibility code. And remove this comment too.
+ * TODO: do the same thing for FILE_MANAGER_COMPATIBILITY.
+ */
 static float disk_compatibility_level = 10.06f;
 
 /*

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1875,6 +1875,8 @@ btree_create_overflow_key_file (THREAD_ENTRY * thread_p, BTID_INT * btid)
 
   /* initialize description of overflow heap file */
   btdes_ovf.btid = *btid->sys_btid;	/* structure copy */
+  btdes_ovf.class_oid = btid->topclass_oid;
+  assert (!OID_ISNULL (&btdes_ovf.class_oid));
   /* create file with at least 3 pages */
   return file_create_with_npages (thread_p, FILE_BTREE_OVERFLOW_KEY, 3, (FILE_DESCRIPTORS *) (&btdes_ovf),
 				  &btid->ovfid);

--- a/src/storage/extendible_hash.c
+++ b/src/storage/extendible_hash.c
@@ -1155,7 +1155,7 @@ exit_on_error:
       if (is_tmp)
 	{
 	  bool save_check_interrupt = thread_set_check_interrupt (thread_p, false);
-	  if (file_destroy (thread_p, &bucket_vfid) != NO_ERROR)
+	  if (file_destroy (thread_p, &bucket_vfid, is_tmp) != NO_ERROR)
 	    {
 	      assert_release (false);
 	    }
@@ -1171,7 +1171,7 @@ exit_on_error:
       if (is_tmp)
 	{
 	  bool save_check_interrupt = thread_set_check_interrupt (thread_p, false);
-	  if (file_destroy (thread_p, &dir_vfid) != NO_ERROR)
+	  if (file_destroy (thread_p, &dir_vfid, is_tmp) != NO_ERROR)
 	    {
 	      assert_release (false);
 	    }
@@ -1253,13 +1253,13 @@ ehash_fix_nth_page (THREAD_ENTRY * thread_p, const VFID * vfid_p, int offset, PG
 }
 
 /*
- * xehash_destroy () - Destroy the given extendible hashing instance
- *   return: NO_ERROR, or ER_FAILED
- *   ehid(in): extendible hashing structure to destroy
+ * xehash_destroy () - destroy the extensible hash table
  *
- * Note: Destroys the specified extendible hashing structure. All of
- * bucket and directory pages of this structure are deallocated
- * by this function.
+ * return        : error code
+ * thread_p (in) : thread entry
+ * ehid_p (in)   : extensible hash identifier
+ *
+ * note: only temporary extensible hash tables can be destroyed.
  */
 int
 xehash_destroy (THREAD_ENTRY * thread_p, EHID * ehid_p)
@@ -1284,12 +1284,12 @@ xehash_destroy (THREAD_ENTRY * thread_p, EHID * ehid_p)
 
   dir_header_p = (EHASH_DIR_HEADER *) dir_page_p;
 
-  if (file_destroy (thread_p, &(dir_header_p->bucket_file)) != NO_ERROR)
+  if (file_destroy (thread_p, &(dir_header_p->bucket_file), true) != NO_ERROR)
     {
       assert_release (false);
     }
   pgbuf_unfix (thread_p, dir_page_p);
-  if (file_destroy (thread_p, &ehid_p->vfid) != NO_ERROR)
+  if (file_destroy (thread_p, &ehid_p->vfid, true) != NO_ERROR)
     {
       assert_release (false);
     }

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -10065,6 +10065,15 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
     }
   pgbuf_unfix (thread_p, page_fhead);
 
+  /* TODO FILE_MANAGER_COMPATIBILITY: ===> */
+  if (class_oid->pageid == 0 && class_oid->volid == 0 && class_oid->slotid == 0)
+    {
+      /* for older databases, the class_oid for FILE_MULTIPAGE_OBJECT_HEAP and FILE_BTREE_OVERFLOW_KEY is 0|0|0. */
+      *stop = true;
+      return NO_ERROR;
+    }
+  /* TODO FILE_MANAGER_COMPATIBILITY: <=== */
+
   if (OID_ISNULL (class_oid))
     {
       /* this must be boot_Db_parm file; cannot be deleted so we don't need lock. */

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -3980,9 +3980,9 @@ file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid, bool is_temp)
 
   assert (vfid != NULL && !VFID_ISNULL (vfid));
 
-  if (is_temp)
+  if (!is_temp)
     {
-      /* first remove from tracker */
+      /* permanent files are first removed from tracker */
       error_code = file_tracker_unregister (thread_p, vfid);
       if (error_code != NO_ERROR)
 	{

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -9315,9 +9315,6 @@ file_tracker_unregister (THREAD_ENTRY * thread_p, const VFID * vfid)
   assert (vfid != NULL && !VFID_ISNULL (vfid));
   assert (log_check_system_op_is_started (thread_p));
 
-  /* we still need to start a system op. */
-  log_sysop_start (thread_p);
-
   page_track_head = pgbuf_fix (thread_p, &file_Tracker_vpid, OLD_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
   if (page_track_head == NULL)
     {
@@ -9325,6 +9322,9 @@ file_tracker_unregister (THREAD_ENTRY * thread_p, const VFID * vfid)
       return error_code;
     }
   extdata = (FILE_EXTENSIBLE_DATA *) page_track_head;
+
+  /* we still need to start a system op. */
+  log_sysop_start (thread_p);
 
   item_inout.volid = vfid->volid;
   item_inout.fileid = vfid->fileid;

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -768,6 +768,8 @@ STATIC_INLINE void file_tempcache_dump (FILE * fp) __attribute__ ((ALWAYS_INLINE
 static int file_tracker_init_page (THREAD_ENTRY * thread_p, PAGE_PTR page, void *args);
 static int file_tracker_register (THREAD_ENTRY * thread_p, const VFID * vfid, FILE_TYPE ftype,
 				  FILE_TRACK_METADATA * metadata);
+static int file_tracker_register_internal (THREAD_ENTRY * thread_p, PAGE_PTR page_track_head,
+					   const FILE_TRACK_ITEM * item);
 static int file_tracker_unregister (THREAD_ENTRY * thread_p, const VFID * vfid);
 static int file_tracker_apply_to_file (THREAD_ENTRY * thread_p, const VFID * vfid, PGBUF_LATCH_MODE mode,
 				       FILE_TRACK_ITEM_FUNC func, void *args);
@@ -3962,9 +3964,11 @@ file_sector_map_dealloc (THREAD_ENTRY * thread_p, const void *data, int index, b
  * return	 : Error code
  * thread_p (in) : Thread entry
  * vfid (in)	 : File identifier
+ * is_temp (in)  : True for temporary, false otherwise. Caller must know. It relevant information before fixing the file
+ *                 header page, whe, if not temporary, we need to remove from file tracker.
  */
 int
-file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid)
+file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid, bool is_temp)
 {
   VPID vpid_fhead;
   PAGE_PTR page_fhead;
@@ -3975,6 +3979,17 @@ file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid)
   int error_code = NO_ERROR;
 
   assert (vfid != NULL && !VFID_ISNULL (vfid));
+
+  if (is_temp)
+    {
+      /* first remove from tracker */
+      error_code = file_tracker_unregister (thread_p, vfid);
+      if (error_code != NO_ERROR)
+	{
+	  assert_release (false);
+	  goto exit;
+	}
+    }
 
   vsid_collector.vsids = NULL;
   ftab_collector.partsect_ftab = NULL;
@@ -3990,6 +4005,7 @@ file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid)
 
   fhead = (FILE_HEADER *) page_fhead;
 
+  assert (is_temp == FILE_IS_TEMPORARY (fhead));
   assert (FILE_IS_TEMPORARY (fhead) || log_check_system_op_is_started (thread_p));
 
   error_code = file_table_collect_all_vsids (thread_p, page_fhead, &vsid_collector);
@@ -4083,17 +4099,6 @@ file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid)
       pgbuf_unfix_and_init (thread_p, page_fhead);
     }
 
-  if (volpurpose == DB_PERMANENT_DATA_PURPOSE)
-    {
-      /* first remove from tracker */
-      error_code = file_tracker_unregister (thread_p, vfid);
-      if (error_code != NO_ERROR)
-	{
-	  assert_release (false);
-	  goto exit;
-	}
-    }
-
   /* release occupied sectors on disk */
   error_code = disk_unreserve_ordered_sectors (thread_p, volpurpose, vsid_collector.n_vsids, vsid_collector.vsids);
   if (error_code != NO_ERROR)
@@ -4143,7 +4148,7 @@ file_rv_destroy (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 
   assert (log_check_system_op_is_started (thread_p));
 
-  error_code = file_destroy (thread_p, vfid);
+  error_code = file_destroy (thread_p, vfid, false);
   if (error_code != NO_ERROR)
     {
       /* Not acceptable. */
@@ -4268,7 +4273,7 @@ file_temp_retire_internal (THREAD_ENTRY * thread_p, const VFID * vfid, bool was_
   /* was not cached. destroy */
   /* don't allow interrupt to avoid file leak */
   save_interrupt = thread_set_check_interrupt (thread_p, false);
-  error_code = file_destroy (thread_p, vfid);
+  error_code = file_destroy (thread_p, vfid, true);
   thread_set_check_interrupt (thread_p, save_interrupt);
   if (error_code != NO_ERROR)
     {
@@ -8896,7 +8901,7 @@ file_tempcache_cache_or_drop_entries (THREAD_ENTRY * thread_p, FILE_TEMPCACHE_EN
 	  /* was not cached. destroy the file */
 	  file_log ("file_tempcache_cache_or_drop_entries",
 		    "drop entry " FILE_TEMPCACHE_ENTRY_MSG, FILE_TEMPCACHE_ENTRY_AS_ARGS (temp_file));
-	  if (file_destroy (thread_p, &temp_file->vfid) != NO_ERROR)
+	  if (file_destroy (thread_p, &temp_file->vfid, true) != NO_ERROR)
 	    {
 	      /* file is leaked */
 	      assert_release (false);
@@ -9149,13 +9154,7 @@ static int
 file_tracker_register (THREAD_ENTRY * thread_p, const VFID * vfid, FILE_TYPE ftype, FILE_TRACK_METADATA * metadata)
 {
   FILE_TRACK_ITEM item;
-  FILE_EXTENSIBLE_DATA *extdata = NULL;
   PAGE_PTR page_track_head = NULL;
-  PAGE_PTR page_track_other = NULL;
-  PAGE_PTR page_extdata = NULL;
-  bool found;
-  int pos;
-  LOG_LSA save_lsa;
   int error_code = NO_ERROR;
 
   assert (vfid != NULL);
@@ -9184,8 +9183,44 @@ file_tracker_register (THREAD_ENTRY * thread_p, const VFID * vfid, FILE_TYPE fty
       ASSERT_ERROR_AND_SET (error_code);
       return error_code;
     }
-  extdata = (FILE_EXTENSIBLE_DATA *) page_track_head;
 
+  error_code = file_tracker_register_internal (thread_p, page_track_head, &item);
+  if (error_code != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+    }
+
+  /* unfix head */
+  pgbuf_unfix (thread_p, page_track_head);
+
+  /* return error code */
+  return error_code;
+}
+
+/*
+ * file_tracker_register_internal () - register new file in file tracker internal function. called by register and
+ *                                     unregister undo.
+ *
+ * return               : error code
+ * thread_p (in)        : thread entry
+ * page_track_head (in) : tracker header page
+ * item (in)            : item (with file data)
+ */
+static int
+file_tracker_register_internal (THREAD_ENTRY * thread_p, PAGE_PTR page_track_head, const FILE_TRACK_ITEM * item)
+{
+  FILE_EXTENSIBLE_DATA *extdata = NULL;
+  PAGE_PTR page_track_other = NULL;
+  PAGE_PTR page_extdata = NULL;
+  bool found;
+  int pos;
+  LOG_LSA save_lsa;
+  int error_code = NO_ERROR;
+
+  assert (log_check_system_op_is_started (thread_p));
+
+  /* find a space to add new item */
+  extdata = (FILE_EXTENSIBLE_DATA *) page_track_head;
   error_code = file_extdata_find_not_full (thread_p, &extdata, &page_track_other, &found);
   if (error_code != NO_ERROR)
     {
@@ -9235,7 +9270,7 @@ file_tracker_register (THREAD_ENTRY * thread_p, const VFID * vfid, FILE_TYPE fty
   assert (extdata == (FILE_EXTENSIBLE_DATA *) page_extdata);
   assert (!file_extdata_is_full (extdata));
 
-  file_extdata_find_ordered (extdata, &item, file_compare_track_items, &found, &pos);
+  file_extdata_find_ordered (extdata, item, file_compare_track_items, &found, &pos);
   if (found)
     {
       /* impossible */
@@ -9245,28 +9280,19 @@ file_tracker_register (THREAD_ENTRY * thread_p, const VFID * vfid, FILE_TYPE fty
     }
 
   save_lsa = *pgbuf_get_lsa (page_extdata);
-  file_extdata_insert_at (extdata, pos, 1, &item);
-  file_log_extdata_add (thread_p, extdata, page_extdata, pos, 1, &item);
+  file_extdata_insert_at (extdata, pos, 1, item);
+  file_log_extdata_add (thread_p, extdata, page_extdata, pos, 1, item);
   pgbuf_set_dirty (thread_p, page_extdata, DONT_FREE);
 
-  file_log ("file_tracker_register", "added " FILE_TRACK_ITEM_MSG ", to page %d|%d, prev_lsa = %lld|%d, "
-	    "crt_lsa = %lld|%d, at pos %d ", FILE_TRACK_ITEM_AS_ARGS (&item),
+  file_log ("file_tracker_register_internal", "added " FILE_TRACK_ITEM_MSG ", to page %d|%d, prev_lsa = %lld|%d, "
+	    "crt_lsa = %lld|%d, at pos %d ", FILE_TRACK_ITEM_AS_ARGS (item),
 	    PGBUF_PAGE_MODIFY_ARGS (page_extdata, &save_lsa), pos);
-
-  /* success */
-  assert (error_code == NO_ERROR);
 
 exit:
   if (page_track_other != NULL)
     {
       pgbuf_unfix (thread_p, page_track_other);
     }
-
-  if (page_track_head != NULL)
-    {
-      pgbuf_unfix (thread_p, page_track_head);
-    }
-
   return error_code;
 }
 
@@ -9282,12 +9308,15 @@ file_tracker_unregister (THREAD_ENTRY * thread_p, const VFID * vfid)
 {
   PAGE_PTR page_track_head = NULL;
   FILE_EXTENSIBLE_DATA *extdata = NULL;
-  FILE_TRACK_ITEM item_search;
+  FILE_TRACK_ITEM item_inout;
   VPID vpid_merged = VPID_INITIALIZER;
   int error_code = NO_ERROR;
 
   assert (vfid != NULL && !VFID_ISNULL (vfid));
   assert (log_check_system_op_is_started (thread_p));
+
+  /* we still need to start a system op. */
+  log_sysop_start (thread_p);
 
   page_track_head = pgbuf_fix (thread_p, &file_Tracker_vpid, OLD_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
   if (page_track_head == NULL)
@@ -9297,11 +9326,11 @@ file_tracker_unregister (THREAD_ENTRY * thread_p, const VFID * vfid)
     }
   extdata = (FILE_EXTENSIBLE_DATA *) page_track_head;
 
-  item_search.volid = vfid->volid;
-  item_search.fileid = vfid->fileid;
+  item_inout.volid = vfid->volid;
+  item_inout.fileid = vfid->fileid;
 
-  error_code = file_extdata_find_and_remove_item (thread_p, extdata, page_track_head, &item_search,
-						  file_compare_track_items, true, NULL, &vpid_merged);
+  error_code = file_extdata_find_and_remove_item (thread_p, extdata, page_track_head, &item_inout,
+						  file_compare_track_items, true, &item_inout, &vpid_merged);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -9325,10 +9354,64 @@ file_tracker_unregister (THREAD_ENTRY * thread_p, const VFID * vfid)
   assert (error_code == NO_ERROR);
 
 exit:
+  if (error_code != NO_ERROR)
+    {
+      log_sysop_abort (thread_p);
+    }
+  else
+    {
+      log_sysop_end_logical_undo (thread_p, RVFL_TRACKER_UNREGISTER, NULL, sizeof (item_inout), (char *) &item_inout);
+    }
   if (page_track_head != NULL)
     {
       pgbuf_unfix (thread_p, page_track_head);
     }
+  return error_code;
+}
+
+/*
+ * file_rv_tracker_unregister_undo () - undo the unregister of file. may happen if file_destroy is only partially
+ *                                      executed. since data inside tracker moved from page to page, the unregister
+ *                                      operation is logged using system ops with logical undo/compensate.
+ *
+ * return        : error code
+ * thread_p (in) : thread entry
+ * rcv (in)      : recovery data
+ */
+int
+file_rv_tracker_unregister_undo (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
+{
+  PAGE_PTR page_track_head;
+  int error_code = NO_ERROR;
+
+  assert (rcv->length == sizeof (FILE_TRACK_ITEM));
+
+  page_track_head = pgbuf_fix (thread_p, &file_Tracker_vpid, OLD_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
+  if (page_track_head == NULL)
+    {
+      assert (false);
+      return ER_FAILED;
+    }
+
+  log_sysop_start (thread_p);
+
+  /* undo unregister => register the logged item */
+  error_code = file_tracker_register_internal (thread_p, page_track_head, (FILE_TRACK_ITEM *) rcv->data);
+  if (error_code != NO_ERROR)
+    {
+      /* not expected */
+      assert (false);
+
+      log_sysop_abort (thread_p);
+    }
+  else
+    {
+      /* need to finish system op while holding latch on header */
+      log_sysop_end_logical_compensate (thread_p, &rcv->reference_lsa);
+    }
+
+  pgbuf_unfix_and_init (thread_p, page_track_head);
+
   return error_code;
 }
 
@@ -9759,7 +9842,7 @@ file_tracker_reclaim_marked_deleted (THREAD_ENTRY * thread_p)
 	      /* destroy file */
 	      vfid.volid = item->volid;
 	      vfid.fileid = item->fileid;
-	      error_code = file_destroy (thread_p, &vfid);
+	      error_code = file_destroy (thread_p, &vfid, false);
 	      if (error_code != NO_ERROR)
 		{
 		  ASSERT_ERROR ();

--- a/src/storage/file_manager.h
+++ b/src/storage/file_manager.h
@@ -90,6 +90,7 @@ typedef struct file_ovf_heap_des FILE_OVF_HEAP_DES;
 struct file_ovf_heap_des
 {
   HFID hfid;
+  OID class_oid;
 };
 
 /* Btree file descriptor */
@@ -105,6 +106,7 @@ typedef struct file_ovf_btree_des FILE_OVF_BTREE_DES;
 struct file_ovf_btree_des
 {
   BTID btid;
+  OID class_oid;
 };
 
 /* Extensible Hash file descriptor */

--- a/src/storage/file_manager.h
+++ b/src/storage/file_manager.h
@@ -168,7 +168,7 @@ extern int file_create_ehash_dir (THREAD_ENTRY * thread_p, int npages, bool is_t
 				  VFID * vfid);
 
 extern void file_postpone_destroy (THREAD_ENTRY * thread_p, const VFID * vfid);
-extern int file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid);
+extern int file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid, bool is_temp);
 extern int file_temp_retire (THREAD_ENTRY * thread_p, const VFID * vfid);
 extern int file_temp_retire_preserved (THREAD_ENTRY * thread_p, const VFID * vfid);
 
@@ -242,6 +242,7 @@ extern int file_rv_dealloc_on_undo (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int file_rv_dealloc_on_postpone (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int file_rv_header_update_mark_deleted (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int file_rv_fhead_sticky_page (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
+extern int file_rv_tracker_unregister_undo (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int file_rv_tracker_mark_heap_deleted (THREAD_ENTRY * thread_p, LOG_RCV * rcv, bool is_undo);
 extern int file_rv_tracker_mark_heap_deleted_compensate_or_run_postpone (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int file_rv_tracker_reuse_heap (THREAD_ENTRY * thread_p, LOG_RCV * rcv);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -6250,7 +6250,6 @@ heap_ovf_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFID * ovf_vfid,
 	  /* Initialize description of overflow heap file */
 	  HFID_COPY (&hfdes_ovf.hfid, hfid);
 	  hfdes_ovf.class_oid = heap_hdr->class_oid;
-	  assert (!OID_ISNULL (&hfdes_ovf.class_oid));
 	  if (file_create_with_npages (thread_p, FILE_MULTIPAGE_OBJECT_HEAP, 1, (FILE_DESCRIPTORS *) (&hfdes_ovf),
 				       ovf_vfid) == NO_ERROR)
 	    {

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -6249,6 +6249,8 @@ heap_ovf_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFID * ovf_vfid,
 
 	  /* Initialize description of overflow heap file */
 	  HFID_COPY (&hfdes_ovf.hfid, hfid);
+	  hfdes_ovf.class_oid = heap_hdr->class_oid;
+	  assert (!OID_ISNULL (&hfdes_ovf.class_oid));
 	  if (file_create_with_npages (thread_p, FILE_MULTIPAGE_OBJECT_HEAP, 1, (FILE_DESCRIPTORS *) (&hfdes_ovf),
 				       ovf_vfid) == NO_ERROR)
 	    {

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -4723,6 +4723,7 @@ catalog_check_consistency (THREAD_ENTRY * thread_p)
 	  er_log_debug (ARG_FILE_LINE,
 			"Skipping checking catalog for class %d|%d|%d because conditional lock failed. \n",
 			OID_AS_ARGS (&class_oid));
+	  continue;
 	}
       /* check catalog consistency */
       ct_valid = catalog_check_class_consistency (thread_p, &class_oid);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2695,7 +2695,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   /* If there is an existing query area, delete it. */
   if (boot_Db_parm->query_vfid.volid != NULL_VOLID)
     {
-      (void) file_destroy (thread_p, &boot_Db_parm->query_vfid);
+      (void) file_destroy (thread_p, &boot_Db_parm->query_vfid, true);
       boot_Db_parm->query_vfid.fileid = NULL_FILEID;
       boot_Db_parm->query_vfid.volid = NULL_VOLID;
 

--- a/src/transaction/recovery.c
+++ b/src/transaction/recovery.c
@@ -803,6 +803,13 @@ struct rvfun RV_fun[] = {
    NULL,
    NULL,
    NULL},
+
+  {RVFL_TRACKER_UNREGISTER,
+   "RVFL_TRACKER_UNREGISTER",
+   file_rv_tracker_unregister_undo,
+   NULL,
+   NULL,
+   NULL},
 };
 
 /*

--- a/src/transaction/recovery.h
+++ b/src/transaction/recovery.h
@@ -180,7 +180,9 @@ typedef enum
   RVPGBUF_DEALLOC = 123,
   RVPGBUF_COMPENSATE_DEALLOC = 124,
 
-  RV_LAST_LOGID = RVPGBUF_COMPENSATE_DEALLOC,
+  RVFL_TRACKER_UNREGISTER,
+
+  RV_LAST_LOGID = RVFL_TRACKER_UNREGISTER,
 
   RV_NOT_DEFINED = 999
 } LOG_RCVINDEX;
@@ -236,7 +238,8 @@ extern void rv_check_rvfuns (void);
    || (idx) == RVFL_ALLOC \
    || (idx) == RVFL_USER_PAGE_MARK_DELETE \
    || (idx) == RVPGBUF_DEALLOC \
-   || (idx) == RVFL_TRACKER_HEAP_REUSE)
+   || (idx) == RVFL_TRACKER_HEAP_REUSE \
+   || (idx) == RVFL_TRACKER_UNREGISTER)
 #define RCV_IS_LOGICAL_RUN_POSTPONE_MANUAL(idx) \
   ((idx) == RVFL_DEALLOC \
    || (idx) == RVHF_MARK_DELETED \
@@ -255,7 +258,8 @@ extern void rv_check_rvfuns (void);
    || (idx) == RVPGBUF_DEALLOC \
    || (idx) == RVES_NOTIFY_VACUUM \
    || (idx) == RVHF_MARK_DELETED \
-   || (idx) == RVFL_TRACKER_HEAP_REUSE)
+   || (idx) == RVFL_TRACKER_HEAP_REUSE \
+   || (idx) == RVFL_TRACKER_UNREGISTER)
 
 #define RCV_IS_NEW_PAGE_INIT(idx) \
   ((idx) == RVPGBUF_NEW_PAGE \


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21039

1. Fix protecting heap and b-tree key overflow files while iterating.
2. Unregister from tracker first while destoying file.
3. Fix rollbacking unregister from tracker.
4. Use SCH_S_LOCK protection while checking catalog entries for a class.
