### PR TITLE
[CBRD-21094] SA_MODE clears client error when enter into server

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -67,6 +67,7 @@
   do \
     { \
       db_on_server++; \
+      er_clear (); \
       if (private_heap_id == 0) \
         { \
 	  assert (db_on_server == 1); \


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21094

Forget client error to enter server.