### PR TITLE
[CBRD-21100] Safe-guards for bcb.count_fix_and_avoid_dealloc

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -15086,8 +15086,10 @@ pgbuf_bcb_unregister_avoid_deallocation (PGBUF_BCB * bcb)
 #endif /* !NDEBUG */
     ATOMIC_INC_32 (&bcb->count_fix_and_avoid_dealloc, -1);
   assert (newval >= 0);
-  assert ((newval & PGBUF_BCB_AVOID_DEALLOC_MASK) != 0xFFFF) assert (bcb->count_fix_and_avoid_dealloc >= 0);
-assert ((bcb->count_fix_and_avoid_dealloc & PGBUF_BCB_AVOID_DEALLOC_MASK) != 0xFFFF)}
+  assert ((newval & PGBUF_BCB_AVOID_DEALLOC_MASK) != 0xFFFF);
+  assert (bcb->count_fix_and_avoid_dealloc >= 0);
+  assert ((bcb->count_fix_and_avoid_dealloc & PGBUF_BCB_AVOID_DEALLOC_MASK) != 0xFFFF);
+}
 
 /*
  * pgbuf_bcb_should_avoid_deallocation () - should avoid deallocating page?

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -7070,6 +7070,7 @@ pgbuf_delete_from_hash_chain (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr)
       curr_bufptr->hash_next = NULL;
       pthread_mutex_unlock (&hash_anchor->hash_mutex);
       VPID_SET_NULL (&(bufptr->vpid));
+      assert ((bufptr->count_fix_and_avoid_dealloc & PGBUF_BCB_AVOID_DEALLOC_MASK) == 0);
       bufptr->count_fix_and_avoid_dealloc = 0;
 
       return NO_ERROR;
@@ -7584,6 +7585,7 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
   assert (!pgbuf_bcb_avoid_victim (bufptr));
   bufptr->latch_mode = PGBUF_NO_LATCH;
   pgbuf_bcb_update_flags (thread_p, bufptr, 0, PGBUF_BCB_ASYNC_FLUSH_REQ);	/* todo: why this?? */
+  assert ((bufptr->count_fix_and_avoid_dealloc & PGBUF_BCB_AVOID_DEALLOC_MASK) == 0);
   bufptr->count_fix_and_avoid_dealloc = 0;
   LSA_SET_NULL (&bufptr->oldest_unflush_lsa);
 
@@ -8015,6 +8017,7 @@ pgbuf_put_bcb_into_invalid_list (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr)
   bufptr->latch_mode = PGBUF_LATCH_INVALID;
   assert ((bufptr->flags & PGBUF_BCB_FLAGS_MASK) == 0);
   pgbuf_bcb_change_zone (thread_p, bufptr, 0, PGBUF_INVALID_ZONE);
+  assert ((bufptr->count_fix_and_avoid_dealloc & PGBUF_BCB_AVOID_DEALLOC_MASK) == 0);
   bufptr->count_fix_and_avoid_dealloc = 0;
 
   rv = pthread_mutex_lock (&pgbuf_Pool.buf_invalid_list.invalid_mutex);
@@ -15059,7 +15062,12 @@ pgbuf_bcb_get_pool_index (const PGBUF_BCB * bcb)
 STATIC_INLINE void
 pgbuf_bcb_register_avoid_deallocation (PGBUF_BCB * bcb)
 {
-  (void) ATOMIC_INC_32 (&bcb->count_fix_and_avoid_dealloc, 1);
+#if !defined (NDEBUG)
+  int newval =
+#endif /* !NDEBUG */
+    ATOMIC_INC_32 (&bcb->count_fix_and_avoid_dealloc, 1);
+  assert (newval > 0);
+  assert ((newval & PGBUF_BCB_AVOID_DEALLOC_MASK) > 0);
   assert (bcb->count_fix_and_avoid_dealloc > 0);
   assert ((bcb->count_fix_and_avoid_dealloc & PGBUF_BCB_AVOID_DEALLOC_MASK) > 0);
 }
@@ -15073,9 +15081,13 @@ pgbuf_bcb_register_avoid_deallocation (PGBUF_BCB * bcb)
 STATIC_INLINE void
 pgbuf_bcb_unregister_avoid_deallocation (PGBUF_BCB * bcb)
 {
-  (void) ATOMIC_INC_32 (&bcb->count_fix_and_avoid_dealloc, -1);
-  assert (bcb->count_fix_and_avoid_dealloc >= 0);
-}
+#if !defined (NDEBUG)
+  int newval =
+#endif /* !NDEBUG */
+    ATOMIC_INC_32 (&bcb->count_fix_and_avoid_dealloc, -1);
+  assert (newval >= 0);
+  assert ((newval & PGBUF_BCB_AVOID_DEALLOC_MASK) != 0xFFFF) assert (bcb->count_fix_and_avoid_dealloc >= 0);
+assert ((bcb->count_fix_and_avoid_dealloc & PGBUF_BCB_AVOID_DEALLOC_MASK) != 0xFFFF)}
 
 /*
  * pgbuf_bcb_should_avoid_deallocation () - should avoid deallocating page?
@@ -15102,7 +15114,11 @@ pgbuf_bcb_register_fix (PGBUF_BCB * bcb)
   /* note: we only register to detect hot pages. once we hit the threshold, we are no longer required to fix it. */
   if (bcb->count_fix_and_avoid_dealloc < (PGBUF_FIX_COUNT_THRESHOLD << PGBUF_BCB_COUNT_FIX_SHIFT_BITS))
     {
-      ATOMIC_INC_32 (&bcb->count_fix_and_avoid_dealloc, 1 << PGBUF_BCB_COUNT_FIX_SHIFT_BITS);
+#if !defined (NDEBUG)
+      int newval =
+#endif /* !NDEBUG */
+	ATOMIC_INC_32 (&bcb->count_fix_and_avoid_dealloc, 1 << PGBUF_BCB_COUNT_FIX_SHIFT_BITS);
+      assert (newval >= (1 << PGBUF_BCB_COUNT_FIX_SHIFT_BITS));
       assert (bcb->count_fix_and_avoid_dealloc >= (1 << PGBUF_BCB_COUNT_FIX_SHIFT_BITS));
     }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21100

This is not an actual fix, but just more safe-guards to hopefully catch the issue earlier (or at least rule out some cases).