### PR TITLE
[CBRD-21101] pgbuf_lru_boost_bcb: remove unreliable safe-guard

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -9132,7 +9132,6 @@ pgbuf_lru_boost_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bcb)
    */
 
   assert (zone != PGBUF_LRU_1_ZONE);
-  assert (zone != PGBUF_LRU_2_ZONE || PGBUF_IS_BCB_OLD_ENOUGH (bcb, lru_list));
 
   /* we'll boost. collect stats */
   if (zone == PGBUF_LRU_2_ZONE)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21101

```c
if (is_old (bcb, lru))
  pgbuf_lru_boost_bcb ()

pgbuf_lru_boost_bcb
  assert (is_old (bcb, lru));
  lock (lru);
```

The safe-guard is not reliable. The initial condition can match just on the edge. Since lru list is not locked, it can change (e.g. zone 1 can be adjusted), increasing the size of zone 2. That affect the is_old condition and from true it can become false.

Fix by removing the unreliable safe-guard.
