### PR TITLE
[CBRD-21081] Removed assert regarding the match of MVCC info

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -11107,14 +11107,12 @@ btree_find_oid_does_mvcc_info_match (THREAD_ENTRY * thread_p, BTREE_MVCC_INFO * 
       assert (match_mvccinfo != NULL && BTREE_MVCC_INFO_IS_DELID_VALID (match_mvccinfo));
       if (BTREE_MVCC_INFO_HAS_DELID (mvcc_info) && mvcc_info->delete_mvccid == match_mvccinfo->delete_mvccid)
 	{
-	  /* This is the object to be vacuumed. */
+	  /* This is the object to be vacuumed/deleted. */
 	  *is_match = true;
 	}
       else
 	{
 	  /* Not a match. */
-	  /* This is acceptable only for vacuum. Postpone delete expects to find an exact match. */
-	  assert (purpose == BTREE_OP_DELETE_VACUUM_OBJECT);
 	}
       return NO_ERROR;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21081

In the scenario provided, it happened to rename a table, having an auto-increment key, to a new name, then back to its original name. In this case, one key would be marked for insert, while the other would be marked for insert and delete, so therefore the MVCC info would not match, eventually failing an assert. We remove the assert since it was incorrect.