### PR TITLE
[CBRD-21115] pgbuf_flush_victim_candidates: update looping & safe-guard

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -3227,6 +3227,8 @@ pgbuf_flush_victim_candidates (THREAD_ENTRY * thread_p, float flush_ratio, PERF_
 
   PGBUF_BCB_CHECK_MUTEX_LEAKS ();
 
+  *stop = false;
+
   pgbuf_compute_lru_vict_target (&lru_sum_flush_priority);
 
   victim_cand_list = pgbuf_Pool.victim_cand_list;

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -342,7 +342,7 @@ extern int pgbuf_invalidate (THREAD_ENTRY * thread_p, PAGE_PTR pgptr);
 extern PAGE_PTR pgbuf_flush_with_wal (THREAD_ENTRY * thread_p, PAGE_PTR pgptr);
 extern void pgbuf_flush_if_requested (THREAD_ENTRY * thread_p, PAGE_PTR page);
 extern int pgbuf_flush_victim_candidates (THREAD_ENTRY * thread_p, float flush_ratio,
-					  PERF_UTIME_TRACKER * time_tracker);
+					  PERF_UTIME_TRACKER * time_tracker, bool * stop);
 extern int pgbuf_flush_checkpoint (THREAD_ENTRY * thread_p, const LOG_LSA * flush_upto_lsa,
 				   const LOG_LSA * prev_chkpt_redo_lsa, LOG_LSA * smallest_lsa, int *flushed_page_cnt);
 extern int pgbuf_flush_all (THREAD_ENTRY * thread_p, VOLID volid);

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -3325,6 +3325,7 @@ thread_page_flush_thread (void *arg_p)
   int wakeup_interval;
   PERF_UTIME_TRACKER perf_track;
   bool force_one_run = false;
+  bool stop_iteration = false;
 
   tsd_ptr = (THREAD_ENTRY *) arg_p;
   thread_daemon_start (&thread_Page_flush_thread, tsd_ptr, TT_DAEMON);
@@ -3335,8 +3336,13 @@ thread_page_flush_thread (void *arg_p)
       /* flush pages as long as necessary */
       while (!tsd_ptr->shutdown && (force_one_run || pgbuf_keep_victim_flush_thread_running ()))
 	{
-	  pgbuf_flush_victim_candidates (tsd_ptr, prm_get_float_value (PRM_ID_PB_BUFFER_FLUSH_RATIO), &perf_track);
+	  pgbuf_flush_victim_candidates (tsd_ptr, prm_get_float_value (PRM_ID_PB_BUFFER_FLUSH_RATIO), &perf_track,
+					 &stop_iteration);
 	  force_one_run = false;
+	  if (stop_iteration)
+	    {
+	      break;
+	    }
 	}
 
       /* wait */

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -445,6 +445,7 @@ extern bool thread_set_check_interrupt (THREAD_ENTRY * thread_p, bool flag);
 extern void thread_wakeup_deadlock_detect_thread (void);
 extern void thread_wakeup_log_flush_thread (void);
 extern void thread_wakeup_page_flush_thread (void);
+extern void thread_try_wakeup_page_flush_thread (void);
 extern void thread_wakeup_page_buffer_maintenance_thread (void);
 extern void thread_wakeup_page_post_flush_thread (void);
 extern void thread_wakeup_flush_control_thread (void);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21115

The issue is again a preempted direct victim waiter that puts itself into waiting list after flush thread flushes enough candidates. Moreover, it puts itself in the waiting list between searching for victims and safe-guard. Should be fixed with next changes:

1. stop looping if pgbuf_get_victim_candidates_from_lru failed to produce anything.
2. update safe-guard:
    - replace pgbuf_is_any_thread_waiting_for_direct_victim () with direct_victim_waiters which is obtained before searching victims.
    - safe-guard is passed if assigned_directly is true.