### PR TITLE
[CBRD-21116] fix abort atomic sysop inside sysop run postpone

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -4013,6 +4013,7 @@ log_recovery_abort_all_atomic_sysops (THREAD_ENTRY * thread_p)
 		     tdes->trid, tdes->state, tdes->topops.last);
 
       log_recovery_abort_atomic_sysop (thread_p, tdes);
+      worker->state = VACUUM_WORKER_STATE_RECOVERY;
 
       /* Restore thread */
       VACUUM_RESTORE_THREAD (thread_p, save_thread_type);
@@ -4063,7 +4064,8 @@ log_recovery_abort_atomic_sysop (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
        * I am not sure this really happens. It might, and it might be risky to allow it. However, I assume this nested
        * operation will not do other complicated operations to mess with other logical operations. I hope at least. */
       /* finish postpone of nested system op. */
-      er_log_debug (ARG_FILE_LINE, "Nested sysop start pospone (%lld|%d) inside atomic sysop (%lld|%d). \n",
+      er_log_debug (ARG_FILE_LINE,
+		    "(trid = %d) Nested sysop start pospone (%lld|%d) inside atomic sysop (%lld|%d). \n", tdes->trid,
 		    LSA_AS_ARGS (&tdes->rcv.sysop_start_postpone_lsa), LSA_AS_ARGS (&tdes->rcv.atomic_sysop_start_lsa));
       log_recovery_finish_sysop_postpone (thread_p, tdes);
     }
@@ -4077,7 +4079,8 @@ log_recovery_abort_atomic_sysop (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
        * 4. crash.
        *
        * we first have to abort atomic system op. postpone will be finished later. */
-      er_log_debug (ARG_FILE_LINE, "Nested atomic sysop  (%lld|%d) after sysop start postpone (%lld|%d). \n",
+      er_log_debug (ARG_FILE_LINE,
+		    "(trid = %d) Nested atomic sysop  (%lld|%d) after sysop start postpone (%lld|%d). \n", tdes->trid,
 		    LSA_AS_ARGS (&tdes->rcv.sysop_start_postpone_lsa), LSA_AS_ARGS (&tdes->rcv.atomic_sysop_start_lsa));
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21116

We had two issues:
  1. log_sysop_start changes vacuum worker state to VACUUM_WORKER_STATE_TOPOP. the state is changed  back to VACUUM_WORKER_STATE_RECOVERY only when last system op is ended. Finish postpone has an early out to skip vacuum transactions when state is not VACUUM_WORKER_STATE_RECOVERY.
  2. tdes->rcv.sysop_start_postpone_lsa was reset by any system op end. However, we can have nested system ops inside run postpone phase.

Fixed both issues.