### PR TITLE
[CBRD-21020] disk_reserve_sectors: fix double sector free from cache

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -3942,6 +3942,16 @@ disk_reserve_sectors (THREAD_ENTRY * thread_p, DB_VOLPURPOSE purpose, VOLID voli
 
   csect_exit (thread_p, CSECT_DISK_CHECK);
 
+#if 0
+  if (purpose == DB_TEMPORARY_DATA_PURPOSE)
+    {
+      if (disk_check (thread_p, false) == DISK_INVALID)
+	{
+	  assert (false);
+	}
+    }
+#endif
+
   return NO_ERROR;
 
 error:
@@ -3973,6 +3983,14 @@ error:
   disk_cache_free_reserved (&context);
 
   csect_exit (thread_p, CSECT_DISK_CHECK);
+
+  if (purpose == DB_TEMPORARY_DATA_PURPOSE)
+    {
+      if (disk_check (thread_p, false) == DISK_INVALID)
+	{
+	  assert (false);
+	}
+    }
 
   return error_code;
 }

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -3967,7 +3967,7 @@ error:
 
 	  /* we'll need to remove reservations for the rest of sectors (that were not allocated from disk). but first,
 	   * let's avoid removing the reservations for the ones we allocated from disk and rollbacked (they have been
-	   * removed from cache too */
+	   * removed from cache too) */
 	  for (iter_vsid = 0; iter_vsid < nreserved; iter_vsid++)
 	    {
 	      /* search vsid in volumes */

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -3942,16 +3942,6 @@ disk_reserve_sectors (THREAD_ENTRY * thread_p, DB_VOLPURPOSE purpose, VOLID voli
 
   csect_exit (thread_p, CSECT_DISK_CHECK);
 
-#if 0
-  if (purpose == DB_TEMPORARY_DATA_PURPOSE)
-    {
-      if (disk_check (thread_p, false) == DISK_INVALID)
-	{
-	  assert (false);
-	}
-    }
-#endif
-
   return NO_ERROR;
 
 error:
@@ -4002,16 +3992,6 @@ error:
   disk_cache_free_reserved (&context);
 
   csect_exit (thread_p, CSECT_DISK_CHECK);
-
-  if (purpose == DB_TEMPORARY_DATA_PURPOSE)
-    {
-      bool save = thread_set_check_interrupt (thread_p, false);
-      if (disk_check (thread_p, false) == DISK_INVALID)
-	{
-	  assert (false);
-	}
-      (void) thread_set_check_interrupt (thread_p, save);
-    }
 
   return error_code;
 }
@@ -4284,16 +4264,6 @@ disk_unreserve_ordered_sectors (THREAD_ENTRY * thread_p, DB_VOLPURPOSE purpose, 
     }
 
   csect_exit (thread_p, CSECT_DISK_CHECK);
-
-  if (purpose == DB_TEMPORARY_DATA_PURPOSE)
-    {
-      bool save = thread_set_check_interrupt (thread_p, false);
-      if (disk_check (thread_p, false) == DISK_INVALID)
-	{
-	  assert (false);
-	}
-      (void) thread_set_check_interrupt (thread_p, save);
-    }
   return error_code;
 }
 

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -3986,10 +3986,12 @@ error:
 
   if (purpose == DB_TEMPORARY_DATA_PURPOSE)
     {
+      bool save = thread_set_check_interrupt (thread_p, false);
       if (disk_check (thread_p, false) == DISK_INVALID)
 	{
 	  assert (false);
 	}
+      (void) thread_set_check_interrupt (thread_p, save);
     }
 
   return error_code;
@@ -4263,6 +4265,16 @@ disk_unreserve_ordered_sectors (THREAD_ENTRY * thread_p, DB_VOLPURPOSE purpose, 
     }
 
   csect_exit (thread_p, CSECT_DISK_CHECK);
+
+  if (purpose == DB_TEMPORARY_DATA_PURPOSE)
+    {
+      bool save = thread_set_check_interrupt (thread_p, false);
+      if (disk_check (thread_p, false) == DISK_INVALID)
+	{
+	  assert (false);
+	}
+      (void) thread_set_check_interrupt (thread_p, save);
+    }
   return error_code;
 }
 

--- a/src/storage/extendible_hash.c
+++ b/src/storage/extendible_hash.c
@@ -1154,12 +1154,10 @@ exit_on_error:
     {
       if (is_tmp)
 	{
-	  bool save_check_interrupt = thread_set_check_interrupt (thread_p, false);
 	  if (file_destroy (thread_p, &bucket_vfid, is_tmp) != NO_ERROR)
 	    {
 	      assert_release (false);
 	    }
-	  (void) thread_set_check_interrupt (thread_p, save_check_interrupt);
 	}
       else
 	{
@@ -1170,12 +1168,10 @@ exit_on_error:
     {
       if (is_tmp)
 	{
-	  bool save_check_interrupt = thread_set_check_interrupt (thread_p, false);
 	  if (file_destroy (thread_p, &dir_vfid, is_tmp) != NO_ERROR)
 	    {
 	      assert_release (false);
 	    }
-	  (void) thread_set_check_interrupt (thread_p, save_check_interrupt);
 	}
       else
 	{
@@ -1280,7 +1276,6 @@ xehash_destroy (THREAD_ENTRY * thread_p, EHID * ehid_p)
     }
 
   log_sysop_start (thread_p);
-  save_check_interrupt = thread_set_check_interrupt (thread_p, false);
 
   dir_header_p = (EHASH_DIR_HEADER *) dir_page_p;
 
@@ -1294,7 +1289,6 @@ xehash_destroy (THREAD_ENTRY * thread_p, EHID * ehid_p)
       assert_release (false);
     }
 
-  (void) thread_set_check_interrupt (thread_p, save_check_interrupt);
   log_sysop_commit (thread_p);
 
   return NO_ERROR;

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -4226,8 +4226,6 @@ file_temp_retire_internal (THREAD_ENTRY * thread_p, const VFID * vfid, bool was_
   bool save_interrupt;
   int error_code = NO_ERROR;
 
-  save_interrupt = thread_set_check_interrupt (thread_p, false);
-
   if (was_preserved)
     {
       file_tempcache_lock ();
@@ -4256,7 +4254,6 @@ file_temp_retire_internal (THREAD_ENTRY * thread_p, const VFID * vfid, bool was_
   if (entry != NULL && file_tempcache_put (thread_p, entry))
     {
       /* cached */
-      (void) thread_set_check_interrupt (thread_p, save_interrupt);
       return NO_ERROR;
     }
 
@@ -4273,8 +4270,6 @@ file_temp_retire_internal (THREAD_ENTRY * thread_p, const VFID * vfid, bool was_
     {
       file_tempcache_retire_entry (entry);
     }
-
-  (void) thread_set_check_interrupt (thread_p, save_interrupt);
   return error_code;
 }
 
@@ -8912,7 +8907,6 @@ file_tempcache_cache_or_drop_entries (THREAD_ENTRY * thread_p, FILE_TEMPCACHE_EN
 {
   FILE_TEMPCACHE_ENTRY *temp_file;
   FILE_TEMPCACHE_ENTRY *next = NULL;
-  bool save_interrupt = thread_set_check_interrupt (thread_p, false);
 
   for (temp_file = *entries; temp_file != NULL; temp_file = next)
     {
@@ -8934,8 +8928,6 @@ file_tempcache_cache_or_drop_entries (THREAD_ENTRY * thread_p, FILE_TEMPCACHE_EN
 	}
     }
   *entries = NULL;
-
-  (void) thread_set_check_interrupt (thread_p, save_interrupt);
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21020

On interruption, if thread managed to allocate sector bits from disk, it used to "free" them from cache twice. Once while clearing bit from disk and once in disk_cache_free_reserved.

Fixed by removing from context given as argument to disk_cache_free_reserved the sectors freed by disk_unreserve_ordered_sectors_without_csect.