### PR TITLE
[CBRD-21142] Fix build on windows VS2015 and newer

### DIFF
--- a/src/jsp/jsp_sr.c
+++ b/src/jsp/jsp_sr.c
@@ -27,6 +27,7 @@
 
 #if defined(WINDOWS)
 #include <windows.h>
+#define DELAYIMP_INSECURE_WRITABLE_HOOKS
 #include <Delayimp.h>
 #pragma comment(lib, "delayimp")
 #pragma comment(lib, "jvm")


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21142

On Windows, starting with VS2015 rev 3, __pfnDliNotifyHook2 and __pfnDliFailureHook2 external pointers, defined in Delayimp.h are const and, thus cannot be modified. This leads to a compilation error because jsp_sr.c needs to modify those pointers.
In order to make the above pointers writable, one needs to
#define DELAYIMP_INSECURE_WRITABLE_HOOKS
before
#include <Delayimp.h>
