### PR TITLE
[CBRD-21144] initialize bcb ticks

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8858,7 +8858,8 @@ pgbuf_lru_add_bcb_to_bottom (THREAD_ENTRY * thread_p, PGBUF_BCB * bcb, PGBUF_LRU
       bcb->next_BCB = NULL;
 
       /* set tick_lru3 smaller that current bottom's */
-      bcb->tick_lru3 = lru_list->bottom->tick_lru3 - 1;
+      bcb->tick_lru3 =
+	PGBUF_IS_BCB_IN_LRU_VICTIM_ZONE (lru_list->bottom) ? lru_list->bottom->tick_lru3 - 1 : lru_list->tick_lru3 - 1;
 
       /* update bottom */
       lru_list->bottom = bcb;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -4900,6 +4900,9 @@ pgbuf_initialize_bcb_table (void)
       bufptr->hit_age = 0;
       LSA_SET_NULL (&bufptr->oldest_unflush_lsa);
 
+      bufptr->tick_lru3 = 0;
+      bufptr->tick_lru_list = 0;
+
       /* link BCB and iopage buffer */
       ioptr = PGBUF_FIND_IOPAGE_PTR (i);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21144

I don't really know why does valgrind complains of the UMR. The code is:

```c
  /* is list empty? */
  if (lru_list->bottom == NULL)
    {
      ...
      bcb->tick_lru3 = lru_list->tick_lru3 - 1;
    }
  else
    {
      ...
      bcb->tick_lru3 = lru_list->bottom->tick_lru3 - 1;
      ...
    }
  /* make sure tick_lru3 is not negative */
  if (bcb->tick_lru3 < 0)   /* <---- UMR */
    {
      bcb->tick_lru3 += DB_INT32_MAX;
    }
```

Unless compiler does a freak optimization and reverses the operations order (which I doubt), the tick should be initialized.

In any case, I also initialize both ticks in pgbuf_initialize_bcb_table .