### PR TITLE
[CBRD-21142] Multiple choices for LZO library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@
 #
 
 cmake_minimum_required(VERSION 2.8)
+
+#also searches for modules onto cubrid/cmake
+# add other Find[LIBRARY].cmake scripts in cubrid/cmake
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -772,6 +775,23 @@ if(WITH_LIBEDIT STREQUAL "BUNDLED")
   # TODO: support system or user provided library
 endif(WITH_LIBEDIT STREQUAL "BUNDLED")
 
+# WITH_LIBLZO can have multiple values with different meanings
+# on Linux:
+# * "BUNDLED" - (default) builds lzo library from cubrid/external/lzo-2.03 and
+#               uses the library created by the build
+# * "BUNDLEDsome_name" - (e.g. BUNDLEDlzo-2.10) builds lzo library from 
+#               cubrid/external/some_name and  uses the library created by the build
+# * "" - use lzo library from the system (see cubrid/cmake/FindLZO.cmake)
+# * "/some/path" - use lzo library located in /some/path 
+#               /some/path/include/lzo should contain header files
+#               /some/path/lib should contain the library
+#               (see cubrid/cmake/FindLZO.cmake)
+# * "http://U/R/L/to/lzo.tar.gz" - downloads the library from specified URL and builds it
+# on Windows:
+# * BUNDLED - (default) uses the prebuilt library from cubrid/win/external/
+# * "" - searches for LZO library in some default system locations
+# * "/some/path" - searches for LZO library in the given path
+
 if(WITH_LIBLZO MATCHES "^BUNDLED")
   string(SUBSTRING "${WITH_LIBLZO}" 7 -1 LZO_PATH)
   
@@ -781,6 +801,7 @@ if(WITH_LIBLZO MATCHES "^BUNDLED")
   
   if(UNIX)
     set(LIBLZO_TARGET liblzo)
+    # compile LZO library from cubrid/external/${LZO_PATH}
     externalproject_add(${LIBLZO_TARGET}
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/${LZO_PATH}
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
@@ -801,6 +822,8 @@ if(WITH_LIBLZO MATCHES "^BUNDLED")
 elseif(WITH_LIBLZO MATCHES "^http")
   if(UNIX)
     set(LIBLZO_TARGET liblzo)
+    #compile LZO library given an internet url to a LZO archive
+    #e.g. http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz
     externalproject_add(${LIBLZO_TARGET}
       URL ${WITH_LIBLZO}
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
@@ -814,6 +837,8 @@ elseif(WITH_LIBLZO MATCHES "^http")
   endif(UNIX)
 else()
   set(LZO_ROOT ${WITH_LIBLZO})
+  #searches for LZO library within LZO_ROOT path and other system paths (see cubrid/cmake/FindLZO.cmake).
+  #calls cubrid/cmake/FindLZO.cmake
   find_package(LZO REQUIRED)
   if(LZO_FOUND)
     set(LIBLZO_LIBS     ${LZO_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -769,11 +769,17 @@ if(WITH_LIBEDIT STREQUAL "BUNDLED")
   # TODO: support system or user provided library
 endif(WITH_LIBEDIT STREQUAL "BUNDLED")
 
-if(WITH_LIBLZO STREQUAL "BUNDLED")
+if(WITH_LIBLZO MATCHES "^BUNDLED")
+  string(SUBSTRING ${WITH_LIBLZO} 7 -1 LZO_PATH)
+  
+  if(LZO_PATH STREQUAL "")
+    set(LZO_PATH "lzo-2.03")
+  endif()
+  
   if(UNIX)
     set(LIBLZO_TARGET liblzo)
     externalproject_add(${LIBLZO_TARGET}
-      SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/lzo-2.03
+      SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/${LZO_PATH}
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
@@ -789,8 +795,9 @@ if(WITH_LIBLZO STREQUAL "BUNDLED")
     endif(TARGET_PLATFORM_BITS EQUAL 32)
     set(LIBLZO_INCLUDES ${CMAKE_SOURCE_DIR}/win/external/include/lzo)
   endif(UNIX)
+else()
   # TODO: support system or user provided library
-endif(WITH_LIBLZO STREQUAL "BUNDLED")
+endif()
 list(APPEND EP_INCLUDES ${LIBLZO_INCLUDES})
 list(APPEND EP_LIBS ${LIBLZO_LIBS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,13 +44,16 @@ option(WITH_JDBC "Build JDBC driver" ON)
 option(WITH_CMSERVER "Build with Manager server" ON)
 
 # options for external libraries (BUNDLED or path)
-set(WITH_LIBREGEX "BUNDLED" CACHE STRING "Build with regex library (default: BUNDLED)")
-set(WITH_LIBEXPAT "BUNDLED" CACHE STRING "Build with expat library (default: BUNDLED)")
-set(WITH_LIBJANSSON "BUNDLED" CACHE STRING "Build with jansson library (default: BUNDLED)")
-set(WITH_LIBEDIT "BUNDLED" CACHE STRING "Build with editline library (default: BUNDLED)")
-set(WITH_LIBLZO "BUNDLED" CACHE STRING "Build with lzo library (default: BUNDLED)")
-set(WITH_LIBGPGERROR "BUNDLED" CACHE STRING "Build with gpg-error library (default: BUNDLED)")
-set(WITH_LIBGCRYPT "BUNDLED" CACHE STRING "Build with gcrypt library (default: BUNDLED)")
+
+set(WITH_EXTERNAL_PREFIX "BUNDLED" CACHE STRING "External library prefix (default: BUNDLED)")
+
+set(WITH_LIBREGEX     "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with regex library (default: BUNDLED)")
+set(WITH_LIBEXPAT     "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with expat library (default: BUNDLED)")
+set(WITH_LIBJANSSON   "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with jansson library (default: BUNDLED)")
+set(WITH_LIBEDIT      "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with editline library (default: BUNDLED)")
+set(WITH_LIBLZO       "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with lzo library (default: BUNDLED)")
+set(WITH_LIBGPGERROR  "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with gpg-error library (default: BUNDLED)")
+set(WITH_LIBGCRYPT    "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with gcrypt library (default: BUNDLED)")
 
 # Version info
 # TODO: remove BUILD_NUMBER file and replace with VERSION file
@@ -770,7 +773,7 @@ if(WITH_LIBEDIT STREQUAL "BUNDLED")
 endif(WITH_LIBEDIT STREQUAL "BUNDLED")
 
 if(WITH_LIBLZO MATCHES "^BUNDLED")
-  string(SUBSTRING ${WITH_LIBLZO} 7 -1 LZO_PATH)
+  string(SUBSTRING "${WITH_LIBLZO}" 7 -1 LZO_PATH)
   
   if(LZO_PATH STREQUAL "")
     set(LZO_PATH "lzo-2.03")
@@ -795,9 +798,29 @@ if(WITH_LIBLZO MATCHES "^BUNDLED")
     endif(TARGET_PLATFORM_BITS EQUAL 32)
     set(LIBLZO_INCLUDES ${CMAKE_SOURCE_DIR}/win/external/include/lzo)
   endif(UNIX)
+elseif(WITH_LIBLZO MATCHES "^http")
+  if(UNIX)
+    set(LIBLZO_TARGET liblzo)
+    externalproject_add(${LIBLZO_TARGET}
+      URL ${WITH_LIBLZO}
+      CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
+      BUILD_COMMAND make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      INSTALL_COMMAND make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      )
+    set(LIBLZO_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/liblzo2.a)
+    set(LIBLZO_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/lzo)
+    list(APPEND EP_TARGETS ${LIBLZO_TARGET})
+  else(UNIX)
+  endif(UNIX)
 else()
-  # TODO: support system or user provided library
+  set(LZO_ROOT ${WITH_LIBLZO})
+  find_package(LZO REQUIRED)
+  if(LZO_FOUND)
+    set(LIBLZO_LIBS     ${LZO_LIBRARIES})
+    set(LIBLZO_INCLUDES ${LZO_INCLUDE_DIR})
+  endif()
 endif()
+
 list(APPEND EP_INCLUDES ${LIBLZO_INCLUDES})
 list(APPEND EP_LIBS ${LIBLZO_LIBS})
 

--- a/cmake/FindLZO.cmake
+++ b/cmake/FindLZO.cmake
@@ -1,0 +1,60 @@
+# Find liblzo2
+# LZO_FOUND - system has the LZO library
+# LZO_INCLUDE_DIR - the LZO include directory
+# LZO_LIBRARIES - The libraries needed to use LZO
+
+if (LZO_INCLUDE_DIR AND LZO_LIBRARIES)
+  # in cache already
+  SET(LZO_FOUND TRUE)
+else (LZO_INCLUDE_DIR AND LZO_LIBRARIES)
+  FIND_PATH(LZO_INCLUDE_DIR lzo/lzo1x.h
+    ${LZO_ROOT}/include/
+    /usr/include/
+    /usr/local/include/
+    /sw/lib/
+    /sw/local/lib/
+    /usr/local/include/lzo/
+    /opt/lzo/include/
+    $ENV{ProgramFiles}/lzo/*/include
+    $ENV{SystemDrive}/lzo/*/include
+    $ENV{LZO_DIR}/include
+  )
+
+  if(WIN32)
+    FIND_LIBRARY(LZO_LIBRARIES NAMES lzo2.lib lzo2
+      PATHS
+      $ENV{ProgramFiles}/lzo/*/lib
+      $ENV{SystemDrive}/lzo/*/lib
+      $ENV{LZO_DIR}/lib
+      $ENV{LZO_DIR}/
+      )
+  else(WIN32)
+    FIND_LIBRARY(LZO_LIBRARIES NAMES liblzo2.a lzo2 
+      PATHS
+      ${LZO_ROOT}/lib
+      /usr/lib
+      /usr/local/lib
+      /sw/lib
+      /sw/local/lib
+      /usr/lib/lzo
+      /usr/local/lib/lzo
+      /opt/lzo/lib
+    )
+  endif(WIN32)
+
+  if (LZO_INCLUDE_DIR AND LZO_LIBRARIES)
+    set(LZO_FOUND TRUE)
+  endif (LZO_INCLUDE_DIR AND LZO_LIBRARIES)
+
+  if (LZO_FOUND)
+    if (NOT LZO_FIND_QUIETLY)
+      message(STATUS "Found LZO: ${LZO_LIBRARIES}")
+    endif (NOT LZO_FIND_QUIETLY)
+  else (LZO_FOUND)
+    if (LZO_FIND_REQUIRED)
+      message(FATAL_ERROR "Could NOT find LZO")
+    endif (LZO_FIND_REQUIRED)
+  endif (LZO_FOUND)
+
+  MARK_AS_ADVANCED(LZO_INCLUDE_DIR LZO_LIBRARIES)
+endif (LZO_INCLUDE_DIR AND LZO_LIBRARIES)

--- a/cmake/FindLZO.cmake
+++ b/cmake/FindLZO.cmake
@@ -23,6 +23,7 @@ else (LZO_INCLUDE_DIR AND LZO_LIBRARIES)
   if(WIN32)
     FIND_LIBRARY(LZO_LIBRARIES NAMES lzo2.lib lzo2
       PATHS
+      ${LZO_ROOT}/lib
       $ENV{ProgramFiles}/lzo/*/lib
       $ENV{SystemDrive}/lzo/*/lib
       $ENV{LZO_DIR}/lib


### PR DESCRIPTION
[CBRD-21142](http://jira.cubrid.org/browse/CBRD-21142)

On Fedora Linux 25, the version of LZO library from external (lzo-2.03) does not compile, so I needed a way to instruct CMake to allow using other LZO libraries.
Note that the pattern can/should be used for other external libraries CUBRID use.
Here are all options for WITH_LIBLZO on a UNIX system:
 1. cmake -DWITH_LIBLZO="BUNDLED" ../..
   (default option) build lzo from external/lzo-2.03
 2. cmake -DWITH_LIBLZO="BUNDLEDlzo-2.10"
  (lzo-2.10 is just an example, can be any path) build lzo from external/lzo-2.10
 3. cmake -DWITH_LIBLZO="" ../..
  tries to find liblzo within certain system locations - fails cmake configuration if library is not found
 4. cmake -DWITH_LIBLZO="$HOME/work/external" ../..
  same as the above but also searches into $HOME/work/external
 5. cmake -DWITH_LIBLZO="http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz" ../../
 instructs cmake to download lzo library from the given URL, build and use it.

On Windows, only 1, 3, and 4 above options work, the difference being that for the first option will use a pre-compiled version of lzo found in win/external.

Steps are made for other libraries too. One will be able to compile all cubrid external libraries into e.g. $HOME/work/cubrid_external (e.g. using a given bash/window script) and then configure the build like this:
```bash
cmake -DWITH_EXTERNAL_PREFIX=$HOME/work/cubrid_external ../..
```
so there will be no need to bundle the external libraries into the CUBRID repository.

  