### PR TITLE
[CBRD-20692] extend logging

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -892,7 +892,7 @@ vacuum_init_master_prefetch (THREAD_ENTRY * thread_p)
 
   size_vacuum_prefetch_log_buffer = (((long long unsigned) VACUUM_PREFETCH_LOG_PAGES) * LOG_PAGESIZE) + MAX_ALIGNMENT;
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_MASTER,
+  vacuum_er_log (VACUUM_ER_LOG_MASTER,
 		 "VACUUM INIT: prefetch pages:%d, log_page_size:%d, "
 		 "prefetch buffer size:%llu, job_queue_capacity:%d.", (int) VACUUM_PREFETCH_LOG_PAGES,
 		 (int) LOG_PAGESIZE, size_vacuum_prefetch_log_buffer, (int) VACUUM_JOB_QUEUE_CAPACITY);
@@ -1069,7 +1069,7 @@ vacuum_heap (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, MVCCID threshold_m
 	vacuum_heap_page (thread_p, page_ptr, object_count, threshold_mvccid, &hfid, &reusable, was_interrupted);
       if (error_code != NO_ERROR)
 	{
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Vacuum heap page %d|%d, error_code=%d.\n",
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Vacuum heap page %d|%d, error_code=%d.\n",
 			       page_ptr->oid.volid, page_ptr->oid.pageid);
 
 	  assert_release (false);
@@ -1147,7 +1147,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 				      &helper.home_page);
       if (error_code != NO_ERROR)
 	{
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.\n",
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.\n",
 			       helper.home_vpid.volid, helper.home_vpid.pageid);
 	  return error_code;
 	}
@@ -1166,7 +1166,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
       if (helper.home_page == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error_code);
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.\n",
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.\n",
 			       helper.home_vpid.volid, helper.home_vpid.pageid);
 	  return error_code;
 	}
@@ -1183,7 +1183,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Failed to get hfid.\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to get hfid.\n");
 	  return error_code;
 	}
       /* we need to also output to avoid checking again for other objects */
@@ -1211,7 +1211,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
       error_code = vacuum_heap_prepare_record (thread_p, &helper);
       if (error_code != NO_ERROR)
 	{
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP,
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP,
 			       "Could not prepare vacuum for object %d|%d|%d.\n",
 			       heap_objects[obj_index].oid.volid, heap_objects[obj_index].oid.pageid,
 			       heap_objects[obj_index].oid.slotid);
@@ -1256,7 +1256,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	    }
 	  if (error_code != NO_ERROR)
 	    {
-	      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP,
+	      vacuum_er_log_error (VACUUM_ER_LOG_HEAP,
 				   "Failed to vacuum object at %d|%d|%d.\n", helper.home_vpid.volid,
 				   helper.home_vpid.pageid, helper.crt_slotid);
 
@@ -1313,7 +1313,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	    {
 	      heap_page_set_vacuum_status_none (thread_p, helper.home_page);
 
-	      vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP,
+	      vacuum_er_log (VACUUM_ER_LOG_HEAP,
 			     "Changed vacuum status of heap page %d|%d, lsa=%lld|%d from once to none.\n",
 			     PGBUF_PAGE_STATE_ARGS (helper.home_page));
 
@@ -1346,7 +1346,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 		  /* Successfully removed page. */
 		  assert (helper.home_page == NULL);
 
-		  vacuum_er_log (thread_p, VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_HEAP,
+		  vacuum_er_log (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_HEAP,
 				 "Successfully removed page %d|%d from heap file (%d, %d|%d).\n",
 				 VPID_AS_ARGS (&helper.home_vpid), HFID_AS_ARGS (&helper.hfid));
 
@@ -1380,7 +1380,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	  if (helper.home_page == NULL)
 	    {
 	      assert (false);
-	      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.\n",
+	      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.\n",
 				   helper.home_vpid.volid, helper.home_vpid.pageid);
 	      goto end;
 	    }
@@ -1491,7 +1491,7 @@ retry_prepare:
 	    {
 	      /* Fix should have worked. */
 	      ASSERT_ERROR_AND_SET (error_code);
-	      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Failed to fix page (%d, %d).",
+	      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page (%d, %d).",
 				   forward_vpid.volid, forward_vpid.pageid);
 	      return error_code;
 	    }
@@ -1510,7 +1510,7 @@ retry_prepare:
 	  if (helper->forward_page == NULL)
 	    {
 	      ASSERT_ERROR_AND_SET (error_code);
-	      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Failed to fix page (%d, %d).",
+	      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page (%d, %d).",
 				   forward_vpid.volid, forward_vpid.pageid);
 	      return error_code;
 	    }
@@ -1520,7 +1520,7 @@ retry_prepare:
 	  if (helper->home_page == NULL)
 	    {
 	      ASSERT_ERROR_AND_SET (error_code);
-	      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Failed to fix page (%d, %d).",
+	      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page (%d, %d).",
 				   forward_vpid.volid, forward_vpid.pageid);
 	      return error_code;
 	    }
@@ -1583,7 +1583,7 @@ retry_prepare:
 	      if (helper->home_page == NULL)
 		{
 		  ASSERT_ERROR_AND_SET (error_code);
-		  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Failed to fix page (%d, %d).",
+		  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page (%d, %d).",
 				       helper->home_vpid.volid, helper->home_vpid.pageid);
 		  return error_code;
 		}
@@ -1614,7 +1614,7 @@ retry_prepare:
       if (helper->forward_page == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error_code);
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Failed to fix page (%d, %d).",
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page (%d, %d).",
 			       forward_vpid.volid, forward_vpid.pageid);
 	  return error_code;
 	}
@@ -1624,7 +1624,7 @@ retry_prepare:
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP,
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP,
 			       "Failed to get MVCC header from overflow page %d|%d.", forward_vpid.volid,
 			       forward_vpid.pageid);
 	  return error_code;
@@ -1768,7 +1768,7 @@ vacuum_heap_record_insid_and_prev_version (THREAD_ENTRY * thread_p, VACUUM_HEAP_
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP,
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP,
 			       "set mvcc header (flag=%d, repid=%d, chn=%d, insid=%llu, "
 			       "delid=%llu, forward object %d|%d|%d with record of type=%d and size=%d",
 			       (int) MVCC_GET_FLAG (&helper->mvcc_header), (int) MVCC_GET_REPID (&helper->mvcc_header),
@@ -2002,7 +2002,7 @@ vacuum_heap_get_hfid_and_file_type (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER 
   error_code = heap_get_class_oid_from_page (thread_p, helper->home_page, &class_oid);
   if (error_code != NO_ERROR)
     {
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log_error (VACUUM_ER_LOG_HEAP,
 			   "Failed to obtain class_oid from heap page %d|%d.\n",
 			   PGBUF_PAGE_VPID_AS_ARGS (helper->home_page));
 
@@ -2036,7 +2036,7 @@ vacuum_heap_get_hfid_and_file_type (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER 
 	    }
 	  else
 	    {
-	      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_DROPPED_FILES,
+	      vacuum_er_log_warning (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_DROPPED_FILES,
 				     "VACUUM WARNING: vacuuming heap found deleted class oid, however hfid and file type "
 				     "have been successfully loaded from file header. \n");
 	    }
@@ -2044,7 +2044,7 @@ vacuum_heap_get_hfid_and_file_type (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER 
     }
   if (error_code != NO_ERROR)
     {
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log_error (VACUUM_ER_LOG_HEAP,
 			   "Failed to obtain heap file identifier for class (%d, %d, %d)", class_oid.volid,
 			   class_oid.pageid, class_oid.slotid);
 
@@ -2053,7 +2053,7 @@ vacuum_heap_get_hfid_and_file_type (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER 
     }
   if (HFID_IS_NULL (&helper->hfid) || (ftype != FILE_HEAP && ftype != FILE_HEAP_REUSE_SLOTS))
     {
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log_error (VACUUM_ER_LOG_HEAP,
 			   "Invalid hfid (%d, %d|%d) or ftype = %s \n", HFID_AS_ARGS (&helper->hfid),
 			   file_type_to_string (ftype));
       assert_release (false);
@@ -2239,7 +2239,7 @@ vacuum_rv_redo_vacuum_heap_page (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 
   if (all_vacuumed)
     {
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
+      vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
 		     "Change vacuum status for heap page %d|%d, lsa=%lld|%d, from once to none.\n",
 		     PGBUF_PAGE_STATE_ARGS (rcv->pgptr));
     }
@@ -2284,7 +2284,7 @@ vacuum_rv_redo_vacuum_heap_page (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 	  /* Only insert MVCCID has been removed */
 	  if (spage_get_record (thread_p, rcv->pgptr, slotids[i], &peek_record, PEEK) != S_SUCCESS)
 	    {
-	      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
+	      vacuum_er_log_error (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
 				   "Failed to get record at (%d, %d, %d).",
 				   PGBUF_PAGE_VPID_AS_ARGS (rcv->pgptr), slotids[i]);
 	      assert_release (false);
@@ -2435,7 +2435,7 @@ vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, MVC
   block_data.oldest_mvccid = oldest_mvccid;
   block_data.newest_mvccid = newest_mvccid;
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_LOGGING | VACUUM_ER_LOG_VACUUM_DATA,
+  vacuum_er_log (VACUUM_ER_LOG_LOGGING | VACUUM_ER_LOG_VACUUM_DATA,
 		 "vacuum_produce_log_block_data: blockid=(%lld) start_lsa=(%lld, %d) old_mvccid=(%llu) "
 		 "new_mvccid=(%llu)\n", (long long) block_data.blockid, LSA_AS_ARGS (&block_data.start_lsa),
 		 (unsigned long long int) block_data.oldest_mvccid, (unsigned long long int) block_data.newest_mvccid);
@@ -2447,8 +2447,7 @@ vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, MVC
       /* TODO: Set a new message error for full block data buffer */
       /* TODO: Probably this case should be avoided... Make sure that we do not lose vacuum data so there has to be
        * enough space to keep it. */
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_ERROR,
-			   "Cannot produce new log block data! The buffer is already full.");
+      vacuum_er_log_error (VACUUM_ER_LOG_ERROR, "Cannot produce new log block data! The buffer is already full.");
       assert (false);
       return;
     }
@@ -2625,7 +2624,7 @@ restart:
 	   + (INT16) (vacuum_Data.blockid_job_cursor
 		      - VACUUM_BLOCKID_WITHOUT_FLAGS (data_page->data[data_page->index_unvacuumed].blockid)));
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_MASTER, "Start searching jobs in page %d|%d from index %d.\n",
+  vacuum_er_log (VACUUM_ER_LOG_MASTER, "Start searching jobs in page %d|%d from index %d.\n",
 		 vacuum_Data.vpid_job_cursor.volid, vacuum_Data.vpid_job_cursor.pageid, data_index);
 
   while (true)
@@ -2659,7 +2658,7 @@ restart:
 	  /* Already vacuumed. */
 	  data_index++;
 	  vacuum_Data.blockid_job_cursor++;
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_JOBS,
+	  vacuum_er_log (VACUUM_ER_LOG_JOBS,
 			 "Job for %lld was already executed. Skip.\n",
 			 (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (entry->blockid));
 	  continue;
@@ -2680,7 +2679,7 @@ restart:
 	   * Stop searching for other jobs.
 	   */
 	  vacuum_unfix_data_page (thread_p, data_page);
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_JOBS,
+	  vacuum_er_log (VACUUM_ER_LOG_JOBS,
 			 "Job for blockid = %lld, newest_mvccid = %llu, start_lsa = %lld cannot be generated. "
 			 "vacuum_Global_oldest_active_mvccid = %lld, log_Gl.append.prev_lsa.pageid = %d.\n",
 			 (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (entry->blockid),
@@ -2699,7 +2698,7 @@ restart:
 	  /* Continue to other blocks. */
 	  data_index++;
 	  vacuum_Data.blockid_job_cursor++;
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_JOBS,
+	  vacuum_er_log (VACUUM_ER_LOG_JOBS,
 			 "Job for blockid = %lld %s. Skip.\n",
 			 (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (entry->blockid),
 			 VACUUM_BLOCK_STATUS_IS_VACUUMED (entry->blockid) ? "was executed" : "is in progress");
@@ -2716,7 +2715,7 @@ restart:
 	  if (error_code != NO_ERROR)
 	    {
 	      assert_release (false);
-	      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_MASTER,
+	      vacuum_er_log_error (VACUUM_ER_LOG_MASTER,
 				   "Error %d while master tried to prefetch log pages for block %lld.",
 				   er_errid (), (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (entry->blockid));
 	      vacuum_unfix_data_page (thread_p, data_page);
@@ -2731,10 +2730,10 @@ restart:
       if (!lf_circular_queue_produce (vacuum_Job_queue, &vacuum_job_entry))
 	{
 	  /* Queue is full, abort creating new jobs. */
-	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_MASTER, "Could not push new job.");
+	  vacuum_er_log_warning (VACUUM_ER_LOG_MASTER, "Could not push new job.");
 	  VACUUM_BLOCK_STATUS_SET_AVAILABLE (entry->blockid);
 
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_JOBS,
+	  vacuum_er_log (VACUUM_ER_LOG_JOBS,
 			 "Could not produce job for blockid = %lld. Set it as available.\n",
 			 (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (entry->blockid));
 
@@ -2743,7 +2742,7 @@ restart:
 	}
       else
 	{
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_JOBS,
+	  vacuum_er_log (VACUUM_ER_LOG_JOBS,
 			 "Generated new job with blockid %lld, flags = %lld",
 			 (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (entry->blockid),
 			 (long long int) VACUUM_BLOCKID_GET_FLAGS (entry->blockid));
@@ -3008,7 +3007,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
   log_page_p->hdr.logical_pageid = NULL_PAGEID;
   log_page_p->hdr.offset = NULL_OFFSET;
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_JOBS,
+  vacuum_er_log (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_JOBS,
 		 "vacuum_process_log_block (): blockid(%lld) start_lsa(%lld, %d) old_mvccid(%llu) new_mvccid(%llu)\n",
 		 LSA_AS_ARGS (&data->start_lsa), (unsigned long long int) data->oldest_mvccid,
 		 (unsigned long long int) data->newest_mvccid);
@@ -3048,8 +3047,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	}
 #endif /* SERVER_MODE */
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_WORKER, "process log entry at log_lsa (%lld, %d)\n",
-		     LSA_AS_ARGS (&log_lsa));
+      vacuum_er_log (VACUUM_ER_LOG_WORKER, "process log entry at log_lsa (%lld, %d)\n", LSA_AS_ARGS (&log_lsa));
 
       worker->state = VACUUM_WORKER_STATE_PROCESS_LOG;
       PERF_UTIME_TRACKER_TIME_AND_RESTART (thread_p, &perf_tracker, PSTAT_VAC_WORKER_EXECUTE);
@@ -3084,7 +3082,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
       if (is_file_dropped)
 	{
 	  /* No need to vacuum */
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_DROPPED_FILES,
+	  vacuum_er_log (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_DROPPED_FILES,
 			 "Skip vacuuming based on (%lld, %d) in file %d|%d. Log record info: rcvindex=%d.\n",
 			 (long long int) rcv_lsa.pageid, (int) rcv_lsa.offset, log_vacuum.vfid.volid,
 			 log_vacuum.vfid.fileid, log_record_data.rcvindex);
@@ -3113,14 +3111,13 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	  if (error_code != NO_ERROR)
 	    {
 	      assert_release (false);
-	      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_HEAP,
-				   "vacuum_collect_heap_objects.\n");
+	      vacuum_er_log_error (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_HEAP, "vacuum_collect_heap_objects.\n");
 	      /* Release should not stop. */
 	      er_clear ();
 	      error_code = NO_ERROR;
 	      continue;
 	    }
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_WORKER,
+	  vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_WORKER,
 			 "collected oid %d|%d|%d, in file %d|%d, based on %lld|%d\n", OID_AS_ARGS (&heap_object_oid),
 			 VFID_AS_ARGS (&log_vacuum.vfid), LSA_AS_ARGS (&rcv_lsa));
 	}
@@ -3150,7 +3147,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	       * entire object. */
 	      if (MVCCID_IS_VALID (mvcc_info.delete_mvccid))
 		{
-		  vacuum_er_log (thread_p, VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
+		  vacuum_er_log (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 				 "vacuum from b-tree: btidp(%d, (%d %d)) oid(%d, %d, %d) "
 				 "class_oid(%d, %d, %d), purpose=rem_object, mvccid=%llu, based on %lld|%d\n",
 				 BTID_AS_ARGS (btid_int.sys_btid), OID_AS_ARGS (&oid), OID_AS_ARGS (&class_oid),
@@ -3161,7 +3158,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 		}
 	      else if (MVCCID_IS_VALID (mvcc_info.insert_mvccid) && mvcc_info.insert_mvccid != MVCCID_ALL_VISIBLE)
 		{
-		  vacuum_er_log (thread_p, VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
+		  vacuum_er_log (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 				 "vacuum from b-tree: btidp(%d, (%d %d)) oid(%d, %d, %d) class_oid(%d, %d, %d), "
 				 "purpose=rem_insid, mvccid=%llu, based on %lld|%d\n",
 				 BTID_AS_ARGS (btid_int.sys_btid), OID_AS_ARGS (&oid), OID_AS_ARGS (&class_oid),
@@ -3173,7 +3170,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	      else
 		{
 		  /* impossible case */
-		  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
+		  vacuum_er_log_error (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 				       "invalid vacuum case for RVBT_MVCC_NOTIFY_VACUUM btid(%d, (%d %d)) "
 				       "oid(%d, %d, %d) class_oid(%d, %d, %d), based on %lld|%d",
 				       BTID_AS_ARGS (btid_int.sys_btid), OID_AS_ARGS (&oid), OID_AS_ARGS (&class_oid),
@@ -3185,7 +3182,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	  else if (log_record_data.rcvindex == RVBT_MVCC_DELETE_OBJECT)
 	    {
 	      /* Object was deleted and must be completely removed. */
-	      vacuum_er_log (thread_p, VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
+	      vacuum_er_log (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 			     "vacuum from b-tree: btidp(%d, (%d %d)) oid(%d, %d, %d) "
 			     "class_oid(%d, %d, %d), purpose=rem_object, mvccid=%llu, based on %lld|%d\n",
 			     BTID_AS_ARGS (btid_int.sys_btid), OID_AS_ARGS (&oid), OID_AS_ARGS (&class_oid),
@@ -3201,7 +3198,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 		  COPY_OID (&oid, &old_version.oid);
 		  COPY_OID (&class_oid, &old_version.class_oid);
 		}
-	      vacuum_er_log (thread_p, VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
+	      vacuum_er_log (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 			     "vacuum from b-tree: btidp(%d, (%d %d)) oid(%d, %d, %d) "
 			     "class_oid(%d, %d, %d), purpose=rem_insid, mvccid=%llu, based on %lld|%d\n",
 			     BTID_AS_ARGS (btid_int.sys_btid), OID_AS_ARGS (&oid), OID_AS_ARGS (&class_oid),
@@ -3217,7 +3214,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	  if (error_code != NO_ERROR)
 	    {
 	      assert_release (false);
-	      vacuum_er_log (thread_p, VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
+	      vacuum_er_log (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 			     "Error deleting object or insert MVCCID: error_code=%d", error_code);
 	      er_clear ();
 	      error_code = NO_ERROR;
@@ -3228,8 +3225,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	{
 	  /* A lob file must be deleted */
 	  (void) or_unpack_string (undo_data, &es_uri);
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_WORKER, "Delete lob %s based on %lld|%d\n", es_uri,
-			 LSA_AS_ARGS (&rcv_lsa));
+	  vacuum_er_log (VACUUM_ER_LOG_WORKER, "Delete lob %s based on %lld|%d\n", es_uri, LSA_AS_ARGS (&rcv_lsa));
 	  (void) es_delete_file (es_uri);
 	  db_private_free_and_init (thread_p, es_uri);
 	}
@@ -3334,7 +3330,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   worker->log_zip_p = log_zip_alloc (IO_PAGESIZE, false);
   if (worker->log_zip_p == NULL)
     {
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_WORKER, "Could not allocate log zip.");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not allocate log zip.");
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_assign_worker");
       return ER_FAILED;
     }
@@ -3344,7 +3340,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   worker->heap_objects = (VACUUM_HEAP_OBJECT *) malloc (worker->heap_objects_capacity * sizeof (VACUUM_HEAP_OBJECT));
   if (worker->heap_objects == NULL)
     {
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_WORKER, "Could not allocate files and objects buffer.\n");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not allocate files and objects buffer.\n");
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_assign_worker");
       goto error;
     }
@@ -3353,7 +3349,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   worker->undo_data_buffer = (char *) malloc (IO_PAGESIZE);
   if (worker->undo_data_buffer == NULL)
     {
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_WORKER, "Could not allocate undo data buffer.");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not allocate undo data buffer.");
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_assign_worker");
       goto error;
     }
@@ -3362,7 +3358,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   worker->postpone_redo_data_buffer = (char *) malloc (IO_PAGESIZE);
   if (worker->postpone_redo_data_buffer == NULL)
     {
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_WORKER, "Could not allocate postpone_redo_data_buffer.");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not allocate postpone_redo_data_buffer.");
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_assign_worker");
       goto error;
     }
@@ -3371,7 +3367,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   /* Save worker to thread entry */
   thread_p->vacuum_worker = worker;
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_WORKER,
+  vacuum_er_log (VACUUM_ER_LOG_WORKER,
 		 "Assigned vacuum_worker %p, index %d to thread %p, index %d.\n",
 		 worker, save_assigned_workers_count, thread_p, thread_p->index);
 
@@ -3383,7 +3379,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
       worker->prefetch_log_buffer = (char *) malloc ((size_t) size_worker_prefetch_log_buffer);
       if (worker->prefetch_log_buffer == NULL)
 	{
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_WORKER, "Could not allocate prefetch buffer.");
+	  vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not allocate prefetch buffer.");
 	  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_assign_worker");
 	  goto error;
 	}
@@ -3489,7 +3485,7 @@ vacuum_rv_finish_worker_recovery (THREAD_ENTRY * thread_p, TRANID trid)
       vacuum_Master.state = VACUUM_WORKER_STATE_EXECUTE;	/* Master is always in execute state. */
       vacuum_Master.tdes->state = TRAN_ACTIVE;
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_MASTER,
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_MASTER,
 		     "Finished recovery for vacuum master.\n");
 
       return;
@@ -3502,7 +3498,7 @@ vacuum_rv_finish_worker_recovery (THREAD_ENTRY * thread_p, TRANID trid)
   /* Check this is called under recovery context. */
   assert (!LOG_ISRESTARTED ());
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_WORKER,
+  vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_WORKER,
 		 "Finished recovery for vacuum worker with tdes->trid=%d.", trid);
 
   /* Reset vacuum worker state */
@@ -3617,7 +3613,7 @@ vacuum_finished_block_vacuum (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data,
       VACUUM_BLOCK_STATUS_SET_VACUUMED (data->blockid);
       VACUUM_BLOCK_CLEAR_INTERRUPTED (data->blockid);
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
+      vacuum_er_log (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
 		     "Processing log block %lld is complete. Notify master.\n",
 		     (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (data->blockid));
     }
@@ -3647,13 +3643,13 @@ vacuum_finished_block_vacuum (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data,
       /* The only relevant information is in fact the updated start_lsa if it has changed. */
       if (error_level == VACUUM_ER_LOG_ERROR)
 	{
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
 			       "Processing log block %lld is interrupted!",
 			       VACUUM_BLOCKID_WITHOUT_FLAGS (data->blockid));
 	}
       else
 	{
-	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
+	  vacuum_er_log_warning (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
 				 "Processing log block %lld is interrupted!",
 				 VACUUM_BLOCKID_WITHOUT_FLAGS (data->blockid));
 	}
@@ -3664,7 +3660,7 @@ vacuum_finished_block_vacuum (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data,
   if (!lf_circular_queue_produce (vacuum_Finished_job_queue, &blockid))
     {
       assert_release (false);
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_JOBS, "Finished job queue is full!!!\n");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_JOBS, "Finished job queue is full!!!\n");
     }
 
 #if defined (SERVER_MODE)
@@ -3782,7 +3778,7 @@ vacuum_process_log_record (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, LOG_
       if (sysop_end->type != LOG_SYSOP_END_LOGICAL_MVCC_UNDO)
 	{
 	  assert (false);
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_LOGGING, "invalid record type!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_LOGGING, "invalid record type!\n");
 	  return ER_FAILED;
 	}
 
@@ -3831,7 +3827,7 @@ vacuum_process_log_record (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, LOG_
 	  vacuum_cleanup_collected_by_vfid (worker, &vfid);
 
 	  worker->drop_files_version = vacuum_Dropped_files_version;
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_WORKER,
+	  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_WORKER,
 			 "update min version to %d", worker->drop_files_version);
 	}
 
@@ -3876,8 +3872,7 @@ vacuum_process_log_record (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, LOG_
 	  new_undo_data_buffer = (char *) realloc (worker->undo_data_buffer, *undo_data_size);
 	  if (new_undo_data_buffer == NULL)
 	    {
-	      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_WORKER,
-				   "Could not expand undo data buffer to %d.", *undo_data_size);
+	      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not expand undo data buffer to %d.", *undo_data_size);
 	      logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_process_log_record");
 	      return ER_FAILED;
 	    }
@@ -3903,7 +3898,7 @@ vacuum_process_log_record (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, LOG_
 	}
       else
 	{
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_WORKER, "Could not unzip undo data.");
+	  vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not unzip undo data.");
 	  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_process_log_record");
 	  return ER_FAILED;
 	}
@@ -4397,7 +4392,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 	 && lf_circular_queue_consume (vacuum_Finished_job_queue, &finished_blocks[n_finished_blocks]))
     {
       /* Increment consumed finished blocks. */
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA, "Consumed from finished job queue %lld (flags %lld).\n",
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Consumed from finished job queue %lld (flags %lld).\n",
 		     (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (finished_blocks[n_finished_blocks]),
 		     VACUUM_BLOCKID_GET_FLAGS (finished_blocks[n_finished_blocks]));
       ++n_finished_blocks;
@@ -4436,7 +4431,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 	      /* Block has been vacuumed. */
 	      VACUUM_BLOCK_STATUS_SET_VACUUMED (data->blockid);
 
-	      vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
+	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
 			     "Mark block %lld as vacuumed.\n",
 			     (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (data->blockid));
 	    }
@@ -4446,7 +4441,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 	      VACUUM_BLOCK_STATUS_SET_AVAILABLE (data->blockid);
 	      VACUUM_BLOCK_SET_INTERRUPTED (data->blockid);
 
-	      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
+	      vacuum_er_log_warning (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
 				     "VACUUM WARNING: Mark block %lld as interrupted.\n",
 				     (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (data->blockid));
 	    }
@@ -4487,8 +4482,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 		  if (n_finished_blocks > index)
 		    {
 		      assert (false);
-		      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_VACUUM_DATA,
-					   "Finished blocks not found in vacuum data!!!!\n");
+		      vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "Finished blocks not found in vacuum data!!!!\n");
 		      return;
 		    }
 		  else
@@ -4555,7 +4549,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
       if (VPID_ISNULL (&data_page->next_page))
 	{
 	  assert (false);
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_VACUUM_DATA, "Finished blocks not found in vacuum data!!!!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "Finished blocks not found in vacuum data!!!!\n");
 	  vacuum_unfix_data_page (thread_p, data_page);
 	  return;
 	}
@@ -4622,7 +4616,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 			     sizeof (vacuum_Data.last_blockid), &vacuum_Data.last_blockid);
       vacuum_set_dirty_data_page (thread_p, *data_page, DONT_FREE);
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA,
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
 		     "Last page, vpid = %d|%d, is empty and was reset. %s\n",
 		     pgbuf_get_vpid_ptr ((PAGE_PTR) (*data_page))->volid,
 		     pgbuf_get_vpid_ptr ((PAGE_PTR) (*data_page))->pageid,
@@ -4649,7 +4643,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 	{
 	  /* Unexpected. */
 	  assert_release (false);
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_VACUUM_DATA, "Invalid vacuum data next_page!!!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "Invalid vacuum data next_page!!!\n");
 	  *data_page = vacuum_Data.first_page;
 	  return;
 	}
@@ -4664,7 +4658,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
       if (file_descriptor_update (thread_p, &vacuum_Data.vacuum_data_file, &fdes_update) != NO_ERROR)
 	{
 	  assert_release (false);
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_VACUUM_DATA,
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA,
 			       "Failed to update file descriptor!!!\n", save_first_vpid.volid, save_first_vpid.pageid);
 	  log_sysop_abort (thread_p);
 
@@ -4681,7 +4675,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
       if (file_dealloc (thread_p, &vacuum_Data.vacuum_data_file, &save_first_vpid, FILE_VACUUM_DATA) != NO_ERROR)
 	{
 	  assert_release (false);
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_VACUUM_DATA,
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA,
 			       "Failed to deallocate first page from vacuum data - %d|%d!!!\n",
 			       save_first_vpid.volid, save_first_vpid.pageid);
 	  log_sysop_abort (thread_p);
@@ -4697,7 +4691,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 	}
       log_sysop_commit (thread_p);
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA, "Changed first VPID from %d|%d to %d|%d.\n",
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Changed first VPID from %d|%d to %d|%d.\n",
 		     VPID_AS_ARGS (&save_first_vpid), VPID_AS_ARGS (&fdes_update.vacuum_data.vpid_first));
 
       /* If cursor was in this page, advance to next page */
@@ -4719,7 +4713,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
       if (prev_data_page == NULL)
 	{
 	  assert_release (false);
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_VACUUM_DATA, "No previous data page is unexpected!!!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "No previous data page is unexpected!!!\n");
 	  vacuum_unfix_data_page (thread_p, *data_page);
 	  return;
 	}
@@ -4736,7 +4730,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
       if (file_dealloc (thread_p, &vacuum_Data.vacuum_data_file, &save_page_vpid, FILE_VACUUM_DATA) != NO_ERROR)
 	{
 	  assert_release (false);
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_VACUUM_DATA,
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA,
 			       "Failed to deallocate page from vacuum data - %d|%d!!!\n",
 			       save_page_vpid.volid, save_page_vpid.pageid);
 	  log_sysop_abort (thread_p);
@@ -4990,8 +4984,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 	      if (error_code != NO_ERROR)
 		{
 		  /* Could not allocate new page. */
-		  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_VACUUM_DATA,
-				       "Could not allocate new page for vacuum data!!!!");
+		  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "Could not allocate new page for vacuum data!!!!");
 		  assert_release (false);
 		  log_sysop_abort (thread_p);
 		  return error_code;
@@ -5054,7 +5047,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 		}
 #endif /* !NDEBUG */
 
-	      vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA,
+	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
 			     "Add block %lld, start_lsa=%lld|%d, oldest_mvccid=%llu, newest_mvccid=%llu.\n",
 			     (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (page_free_data->blockid),
 			     (long long int) page_free_data->start_lsa.pageid, (int) page_free_data->start_lsa.offset,
@@ -5069,7 +5062,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 	      page_free_data->oldest_mvccid = MVCCID_NULL;
 	      page_free_data->newest_mvccid = MVCCID_NULL;
 
-	      vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA,
+	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
 			     "Block %lld has no MVCC ops and is skipped (marked as vacuumed).\n", next_blockid);
 	    }
 	  vacuum_Data.last_blockid = next_blockid;
@@ -5234,7 +5227,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   LOG_LSA mvcc_op_log_lsa = LSA_INITIALIZER;
   bool is_last_block = false;
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 		 "vacuum_recover_lost_block_data, lsa = %lld|%d n", LSA_AS_ARGS (&vacuum_Data.recovery_lsa));
   if (LSA_ISNULL (&vacuum_Data.recovery_lsa))
     {
@@ -5251,7 +5244,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   if (LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa))
     {
       /* We need to search for an MVCC op log record to start recovering lost blocks. */
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 		     "vacuum_recover_lost_block_data, log_Gl.hdr.mvcc_op_log_lsa is null \n");
 
       LSA_COPY (&log_lsa, &vacuum_Data.recovery_lsa);
@@ -5275,7 +5268,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	      || log_rec_header.type == LOG_MVCC_DIFF_UNDOREDO_DATA)
 	    {
 	      LSA_COPY (&mvcc_op_log_lsa, &log_lsa);
-	      vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 			     "vacuum_recover_lost_block_data, found mvcc op at lsa = %lld|%d \n",
 			     LSA_AS_ARGS (&mvcc_op_log_lsa));
 	      break;
@@ -5292,7 +5285,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	      if (redo->data.rcvindex == RVVAC_COMPLETE)
 		{
 		  /* stop looking */
-		  vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+		  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 				 "vacuum_recover_lost_block_data, complete vacuum \n");
 		  break;
 		}
@@ -5303,7 +5296,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
       if (LSA_ISNULL (&mvcc_op_log_lsa))
 	{
 	  /* Vacuum data was reached, so there is nothing to recover. */
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 			 "vacuum_recover_lost_block_data, nothing to recovery \n");
 	  return NO_ERROR;
 	}
@@ -5311,7 +5304,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   else if (vacuum_get_log_blockid (log_Gl.hdr.mvcc_op_log_lsa.pageid) <= vacuum_Data.last_blockid)
     {
       /* Already in vacuum data. */
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 		     "vacuum_recover_lost_block_data, mvcc_op_log_lsa %lld|%d is already in vacuum data "
 		     "(last blockid = %lld) \n", LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa),
 		     (long long int) vacuum_Data.last_blockid);
@@ -5324,7 +5317,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
     }
   assert (!LSA_ISNULL (&mvcc_op_log_lsa));
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 		 "vacuum_recover_lost_block_data, start recovering from %lld|%d \n", LSA_AS_ARGS (&mvcc_op_log_lsa));
 
   /* Start recovering blocks. */
@@ -5381,7 +5374,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	  LSA_COPY (&log_Gl.hdr.mvcc_op_log_lsa, &data.start_lsa);
 	  is_last_block = false;
 
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 			 "Restore log global cached info: \n\t mvcc_op_log_lsa = %lld|%d \n"
 			 "\t last_block_oldest_mvccid = %llu \n\t last_block_newest_mvccid = %llu \n",
 			 LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa),
@@ -5412,7 +5405,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 void
 vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p)
 {
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA, "Reset vacuum info in log_Gl.hdr \n");
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Reset vacuum info in log_Gl.hdr \n");
   LSA_SET_NULL (&log_Gl.hdr.mvcc_op_log_lsa);
   log_Gl.hdr.last_block_oldest_mvccid = MVCCID_NULL;
   log_Gl.hdr.last_block_newest_mvccid = MVCCID_NULL;
@@ -5514,7 +5507,7 @@ vacuum_update_oldest_unvacuumed_mvccid (THREAD_ENTRY * thread_p)
 
   if (oldest_mvccid != vacuum_Data.oldest_unvacuumed_mvccid)
     {
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA, "Update oldest_unvacuumed_mvccid from %llu to %llu.\n",
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Update oldest_unvacuumed_mvccid from %llu to %llu.\n",
 		     (unsigned long long int) vacuum_Data.oldest_unvacuumed_mvccid,
 		     (unsigned long long int) oldest_mvccid);
 
@@ -5548,7 +5541,7 @@ vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p)
   keep_from_blockid = VACUUM_BLOCKID_WITHOUT_FLAGS (keep_from_blockid);
   vacuum_Data.keep_from_log_pageid = VACUUM_FIRST_LOG_PAGEID_IN_BLOCK (keep_from_blockid);
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_VACUUM_DATA,
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
 		 "Update keep_from_log_pageid to %lld \n", (long long int) vacuum_Data.keep_from_log_pageid);
 }
 
@@ -5622,7 +5615,7 @@ vacuum_add_dropped_file (THREAD_ENTRY * thread_p, VFID * vfid, MVCCID mvccid)
 
       if (vacuum_load_dropped_files_from_disk (thread_p) != NO_ERROR)
 	{
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
+	  vacuum_er_log_error (VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
 			       "Failed to load dropped files during recovery!");
 
 	  assert_release (false);
@@ -5695,7 +5688,7 @@ vacuum_add_dropped_file (THREAD_ENTRY * thread_p, VFID * vfid, MVCCID mvccid)
 	      memcpy (&track_page->dropped_data_page, page, DB_PAGESIZE);
 	    }
 #endif
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES,
+	  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
 			 "add dropped file: found duplicate vfid(%d, %d) at position=%d, "
 			 "replace mvccid=%llu with mvccid=%llu. Page is (%d, %d) with lsa (%lld, %d)."
 			 "Page count=%d, global count=%d", VFID_AS_ARGS (&page->dropped_files[position].vfid), position,
@@ -5754,7 +5747,7 @@ vacuum_add_dropped_file (THREAD_ENTRY * thread_p, VFID * vfid, MVCCID mvccid)
 	}
 #endif
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES,
+      vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
 		     "added new dropped file(%d, %d) and mvccid=%llu at position=%d. "
 		     "Page is (%d, %d) with lsa (%lld, %d). Page count=%d, global count=%d",
 		     VFID_AS_ARGS (&page->dropped_files[position].vfid),
@@ -5829,7 +5822,7 @@ vacuum_add_dropped_file (THREAD_ENTRY * thread_p, VFID * vfid, MVCCID mvccid)
   log_append_redo_data2 (thread_p, RVPGBUF_NEW_PAGE, NULL, (PAGE_PTR) new_page, (PGLENGTH) PAGE_DROPPED_FILES,
 			 sizeof (VACUUM_DROPPED_FILES_PAGE), new_page);
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES,
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
 		 "added new dropped file(%d, %d) and mvccid=%llu to at position=%d. "
 		 "Page is (%d, %d) with lsa (%lld, %d). Page count=%d, global count=%d",
 		 VFID_AS_ARGS (&new_page->dropped_files[0].vfid),
@@ -5869,7 +5862,7 @@ vacuum_log_add_dropped_file (THREAD_ENTRY * thread_p, const VFID * vfid, const O
   LOG_DATA_ADDR addr;
   VACUUM_DROPPED_FILES_RCV_DATA rcv_data;
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES, "Append %s log from dropped file (%d, %d).",
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "Append %s log from dropped file (%d, %d).",
 		 pospone_or_undo ? "postpone" : "undo", vfid->volid, vfid->fileid);
 
   /* Initialize recovery data */
@@ -5923,7 +5916,7 @@ vacuum_rv_redo_add_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   if (position > page->n_dropped_files)
     {
       /* Error! */
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
+      vacuum_er_log_error (VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
 			   "Dropped files recovery error: Invalid position %d (only %d entries in page) while "
 			   "inserting new entry vfid=(%d, %d) mvccid=%llu. Page is (%d, %d) at lsa (%lld, %d). ",
 			   position, page->n_dropped_files, VFID_AS_ARGS (&dropped_file->vfid),
@@ -5947,7 +5940,7 @@ vacuum_rv_redo_add_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   /* Increment number of files */
   page->n_dropped_files++;
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
 		 "Dropped files redo recovery, insert new entry "
 		 "vfid=(%d, %d), mvccid=%llu at position %d. Page is (%d, %d) at lsa (%lld, %d).",
 		 VFID_AS_ARGS (&dropped_file->vfid), (unsigned long long) dropped_file->mvccid, position,
@@ -6022,7 +6015,7 @@ vacuum_rv_replace_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   if (position >= page->n_dropped_files)
     {
       /* Error! */
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
+      vacuum_er_log_error (VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
 			   "Dropped files recovery error: Invalid position %d (only %d entries in page) while "
 			   "replacing old entry with vfid=(%d, %d) mvccid=%llu. Page is (%d, %d) at lsa (%lld, %d). ",
 			   position, page->n_dropped_files, VFID_AS_ARGS (&dropped_file->vfid),
@@ -6035,7 +6028,7 @@ vacuum_rv_replace_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   if (!VFID_EQ (&dropped_file->vfid, &page->dropped_files[position].vfid))
     {
       /* Error! */
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
+      vacuum_er_log_error (VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
 			   "Dropped files recovery error: expected to "
 			   "find vfid (%d, %d) at position %d and found (%d, %d) with MVCCID=%d. "
 			   "Page is (%d, %d) at lsa (%lld, %d). ", VFID_AS_ARGS (&dropped_file->vfid), position,
@@ -6047,7 +6040,7 @@ vacuum_rv_replace_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
       return ER_FAILED;
     }
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
 		 "Dropped files redo recovery, replace MVCCID for"
 		 " file (%d, %d) with %llu (position=%d). Page is (%d, %d) at lsa (%lld, %d).",
 		 VFID_AS_ARGS (&dropped_file->vfid), (unsigned long long) dropped_file->mvccid, position,
@@ -6116,7 +6109,7 @@ vacuum_rv_notify_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
    * synchronized with the changes. It is only used to make sure that all workers have seen current change. */
   my_version = ++vacuum_Dropped_files_version;
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES,
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
 		 "Added dropped file - vfid=(%d, %d), mvccid=%llu - "
 		 "Wait for all workers to see my_version=%d", VFID_AS_ARGS (&rcv_data->vfid), mvccid, my_version);
 
@@ -6125,14 +6118,13 @@ vacuum_rv_notify_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
        workers_min_version != -1 && workers_min_version < my_version;
        workers_min_version = vacuum_get_worker_min_dropped_files_version ())
     {
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES,
+      vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
 		     "not all workers saw my changes, workers min version=%d. Sleep and retry.", workers_min_version);
 
       thread_sleep (1);
     }
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES, "All workers have been notified, min_version=%d",
-		 workers_min_version);
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "All workers have been notified, min_version=%d", workers_min_version);
 
   VFID_SET_NULL (&vacuum_Last_dropped_vfid);
   pthread_mutex_unlock (&vacuum_Dropped_files_mutex);
@@ -6171,12 +6163,12 @@ vacuum_cleanup_dropped_files (THREAD_ENTRY * thread_p)
   VACUUM_TRACK_DROPPED_FILES *track_page = (VACUUM_TRACK_DROPPED_FILES *) vacuum_Track_dropped_files;
 #endif
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES, "Start cleanup dropped files.");
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "Start cleanup dropped files.");
 
   if (!LOG_ISRESTARTED ())
     {
       /* Skip cleanup during recovery */
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_DROPPED_FILES, "Skip cleanup during recovery.");
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_DROPPED_FILES, "Skip cleanup during recovery.");
       return NO_ERROR;
     }
 
@@ -6186,7 +6178,7 @@ vacuum_cleanup_dropped_files (THREAD_ENTRY * thread_p)
   if (vacuum_Dropped_files_count == 0)
     {
       /* Nothing to clean */
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES, "Cleanup skipped, no current entries.");
+      vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "Cleanup skipped, no current entries.");
       return NO_ERROR;
     }
 
@@ -6250,7 +6242,7 @@ vacuum_cleanup_dropped_files (THREAD_ENTRY * thread_p)
 	  /* Log changes */
 	  vacuum_log_cleanup_dropped_files (thread_p, (PAGE_PTR) page, removed_entries, n_removed_entries);
 
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES,
+	  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
 			 "cleanup dropped files. Page is (%d %d) with lsa (%lld, %d). "
 			 "Page count=%d, global count=%d", PGBUF_PAGE_STATE_ARGS ((PAGE_PTR) page),
 			 page->n_dropped_files, vacuum_Dropped_files_count);
@@ -6277,7 +6269,7 @@ vacuum_cleanup_dropped_files (THREAD_ENTRY * thread_p)
   if (!VPID_ISNULL (&last_non_empty_page_vpid) && !VPID_EQ (&last_non_empty_page_vpid, &last_page_vpid))
     {
       /* Update next page link in the last non-empty page to NULL, to avoid fixing empty pages in the future. */
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES,
+      vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
 		     "Cleanup dropped files must remove pages to the of page (%d, %d)... Cut off link.",
 		     last_non_empty_page_vpid.volid, last_non_empty_page_vpid.pageid);
 
@@ -6294,7 +6286,7 @@ vacuum_cleanup_dropped_files (THREAD_ENTRY * thread_p)
       /* todo: tracker? */
     }
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES, "Finished cleanup dropped files.");
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "Finished cleanup dropped files.");
   return NO_ERROR;
 }
 
@@ -6376,7 +6368,7 @@ vacuum_find_dropped_file (THREAD_ENTRY * thread_p, VFID * vfid, MVCCID mvccid)
 	  if (MVCC_ID_PRECEDES (mvccid, dropped_file->mvccid))
 	    {
 	      /* The record must belong to the dropped file */
-	      vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES,
+	      vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
 			     "found dropped file: vfid=(%d, %d) "
 			     "mvccid=%d in page (%d, %d). Entry at position %d, vfid=(%d, %d) mvccid=%d. "
 			     "The vacuumed file is dropped.", vfid->volid, vfid->fileid, mvccid,
@@ -6389,7 +6381,7 @@ vacuum_find_dropped_file (THREAD_ENTRY * thread_p, VFID * vfid, MVCCID mvccid)
 	  else
 	    {
 	      /* The record belongs to an entry with the same identifier, but is newer. */
-	      vacuum_er_log (thread_p, VACUUM_ER_LOG_DROPPED_FILES,
+	      vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
 			     "found dropped file: vfid=(%d, %d) "
 			     "mvccid=%d in page (%d, %d). Entry at position %d, vfid=(%d, %d) mvccid=%d. "
 			     "The vacuumed file is newer.", vfid->volid, vfid->fileid, mvccid,
@@ -6402,7 +6394,7 @@ vacuum_find_dropped_file (THREAD_ENTRY * thread_p, VFID * vfid, MVCCID mvccid)
 	}
 
       /* Do not log this unless you think it is useful. It spams the log file. */
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_NONE,
+      vacuum_er_log (VACUUM_ER_LOG_NONE,
 		     "didn't find dropped file: vfid=(%d, %d) mvccid=%d in page (%d, %d).", vfid->volid,
 		     vfid->fileid, mvccid, PGBUF_PAGE_VPID_AS_ARGS ((PAGE_PTR) page));
 
@@ -6487,7 +6479,7 @@ vacuum_rv_redo_cleanup_dropped_files (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   for (i = 0; i < n_indexes; i++)
     {
       /* Remove entry at indexes[i] */
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_DROPPED_FILES,
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_DROPPED_FILES,
 		     "Recovery of dropped classes: remove file(%d, %d), mvccid=%llu at position %d.",
 		     (int) page->dropped_files[indexes[i]].vfid.volid,
 		     (int) page->dropped_files[indexes[i]].vfid.fileid, page->dropped_files[indexes[i]].mvccid,
@@ -6554,7 +6546,7 @@ vacuum_rv_set_next_page_dropped_files (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   /* Check recovery data is as expected */
   assert (rcv->length = sizeof (VPID));
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY, "Set link for dropped files from page(%d, %d) to page(%d, %d).",
+  vacuum_er_log (VACUUM_ER_LOG_RECOVERY, "Set link for dropped files from page(%d, %d) to page(%d, %d).",
 		 pgbuf_get_vpid_ptr (rcv->pgptr)->pageid, pgbuf_get_vpid_ptr (rcv->pgptr)->volid, page->next_page.volid,
 		 page->next_page.pageid);
 
@@ -6639,7 +6631,7 @@ vacuum_collect_heap_objects (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, OI
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
 		  new_capacity * sizeof (VACUUM_HEAP_OBJECT));
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_WORKER,
+	  vacuum_er_log_error (VACUUM_ER_LOG_WORKER,
 			       "Could not expact the files and objects capacity to %d.\n", new_capacity);
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
@@ -6892,7 +6884,7 @@ vacuum_log_prefetch_vacuum_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * e
       if (block_log_buffer->buffer_id < 0)
 	{
 	  assert (false);
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_MASTER, "Could not prefetch. No more free log block buffers.");
+	  vacuum_er_log_error (VACUUM_ER_LOG_MASTER, "Could not prefetch. No more free log block buffers.");
 	  return ER_FAILED;
 	}
       buffer_block_start_ptr = VACUUM_PREFETCH_LOG_BLOCK_BUFFER (block_log_buffer->buffer_id);
@@ -6914,7 +6906,7 @@ vacuum_log_prefetch_vacuum_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * e
       if (error != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
-	  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_ERROR, "cannot prefetch log page %d", log_pageid);
+	  vacuum_er_log_error (VACUUM_ER_LOG_ERROR, "cannot prefetch log page %d", log_pageid);
 	  if (vacuum_Prefetch_log_mode == VACUUM_PREFETCH_LOG_MODE_MASTER)
 	    {
 	      lf_bitmap_free_entry (&vacuum_Prefetch_free_buffers_bitmap, block_log_buffer->buffer_id);
@@ -6931,7 +6923,7 @@ vacuum_log_prefetch_vacuum_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * e
   block_log_buffer->start_page = start_log_pageid;
   block_log_buffer->last_page = start_log_pageid + i - 1;
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_MASTER, "VACUUM : prefetched %d log pages from %lld to %lld", i,
+  vacuum_er_log (VACUUM_ER_LOG_MASTER, "VACUUM : prefetched %d log pages from %lld to %lld", i,
 		 (long long int) block_log_buffer->start_page, (long long int) block_log_buffer->last_page);
 
 end:

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1183,7 +1183,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
-	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to get hfid.\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "%s", "Failed to get hfid.\n");
 	  return error_code;
 	}
       /* we need to also output to avoid checking again for other objects */
@@ -2036,7 +2036,7 @@ vacuum_heap_get_hfid_and_file_type (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER 
 	    }
 	  else
 	    {
-	      vacuum_er_log_warning (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_DROPPED_FILES,
+	      vacuum_er_log_warning (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_DROPPED_FILES, "%s",
 				     "VACUUM WARNING: vacuuming heap found deleted class oid, however hfid and file type "
 				     "have been successfully loaded from file header. \n");
 	    }
@@ -2447,7 +2447,7 @@ vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, MVC
       /* TODO: Set a new message error for full block data buffer */
       /* TODO: Probably this case should be avoided... Make sure that we do not lose vacuum data so there has to be
        * enough space to keep it. */
-      vacuum_er_log_error (VACUUM_ER_LOG_ERROR, "Cannot produce new log block data! The buffer is already full.");
+      vacuum_er_log_error (VACUUM_ER_LOG_ERROR, "%s", "Cannot produce new log block data! The buffer is already full.");
       assert (false);
       return;
     }
@@ -2730,7 +2730,7 @@ restart:
       if (!lf_circular_queue_produce (vacuum_Job_queue, &vacuum_job_entry))
 	{
 	  /* Queue is full, abort creating new jobs. */
-	  vacuum_er_log_warning (VACUUM_ER_LOG_MASTER, "Could not push new job.");
+	  vacuum_er_log_warning (VACUUM_ER_LOG_MASTER, "%s", "Could not push new job.");
 	  VACUUM_BLOCK_STATUS_SET_AVAILABLE (entry->blockid);
 
 	  vacuum_er_log (VACUUM_ER_LOG_JOBS,
@@ -3111,7 +3111,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	  if (error_code != NO_ERROR)
 	    {
 	      assert_release (false);
-	      vacuum_er_log_error (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_HEAP, "vacuum_collect_heap_objects.\n");
+	      vacuum_er_log_error (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_HEAP, "%s", "vacuum_collect_heap_objects.\n");
 	      /* Release should not stop. */
 	      er_clear ();
 	      error_code = NO_ERROR;
@@ -3330,7 +3330,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   worker->log_zip_p = log_zip_alloc (IO_PAGESIZE, false);
   if (worker->log_zip_p == NULL)
     {
-      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not allocate log zip.");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "%s", "Could not allocate log zip.");
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_assign_worker");
       return ER_FAILED;
     }
@@ -3340,7 +3340,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   worker->heap_objects = (VACUUM_HEAP_OBJECT *) malloc (worker->heap_objects_capacity * sizeof (VACUUM_HEAP_OBJECT));
   if (worker->heap_objects == NULL)
     {
-      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not allocate files and objects buffer.\n");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "%s", "Could not allocate files and objects buffer.\n");
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_assign_worker");
       goto error;
     }
@@ -3349,7 +3349,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   worker->undo_data_buffer = (char *) malloc (IO_PAGESIZE);
   if (worker->undo_data_buffer == NULL)
     {
-      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not allocate undo data buffer.");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "%s", "Could not allocate undo data buffer.");
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_assign_worker");
       goto error;
     }
@@ -3358,7 +3358,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   worker->postpone_redo_data_buffer = (char *) malloc (IO_PAGESIZE);
   if (worker->postpone_redo_data_buffer == NULL)
     {
-      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not allocate postpone_redo_data_buffer.");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "%s", "Could not allocate postpone_redo_data_buffer.");
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_assign_worker");
       goto error;
     }
@@ -3379,7 +3379,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
       worker->prefetch_log_buffer = (char *) malloc ((size_t) size_worker_prefetch_log_buffer);
       if (worker->prefetch_log_buffer == NULL)
 	{
-	  vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not allocate prefetch buffer.");
+	  vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "%s", "Could not allocate prefetch buffer.");
 	  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_assign_worker");
 	  goto error;
 	}
@@ -3485,7 +3485,7 @@ vacuum_rv_finish_worker_recovery (THREAD_ENTRY * thread_p, TRANID trid)
       vacuum_Master.state = VACUUM_WORKER_STATE_EXECUTE;	/* Master is always in execute state. */
       vacuum_Master.tdes->state = TRAN_ACTIVE;
 
-      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_MASTER,
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_MASTER, "%s",
 		     "Finished recovery for vacuum master.\n");
 
       return;
@@ -3660,7 +3660,7 @@ vacuum_finished_block_vacuum (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data,
   if (!lf_circular_queue_produce (vacuum_Finished_job_queue, &blockid))
     {
       assert_release (false);
-      vacuum_er_log_error (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_JOBS, "Finished job queue is full!!!\n");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_JOBS, "%s", "Finished job queue is full!!!\n");
     }
 
 #if defined (SERVER_MODE)
@@ -3778,7 +3778,7 @@ vacuum_process_log_record (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, LOG_
       if (sysop_end->type != LOG_SYSOP_END_LOGICAL_MVCC_UNDO)
 	{
 	  assert (false);
-	  vacuum_er_log_error (VACUUM_ER_LOG_LOGGING, "invalid record type!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_LOGGING, "%s", "invalid record type!\n");
 	  return ER_FAILED;
 	}
 
@@ -3898,7 +3898,7 @@ vacuum_process_log_record (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, LOG_
 	}
       else
 	{
-	  vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "Could not unzip undo data.");
+	  vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "%s", "Could not unzip undo data.");
 	  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_process_log_record");
 	  return ER_FAILED;
 	}
@@ -4482,7 +4482,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 		  if (n_finished_blocks > index)
 		    {
 		      assert (false);
-		      vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "Finished blocks not found in vacuum data!!!!\n");
+		      vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Finished blocks not found in vacuum data!!!!\n");
 		      return;
 		    }
 		  else
@@ -4549,7 +4549,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
       if (VPID_ISNULL (&data_page->next_page))
 	{
 	  assert (false);
-	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "Finished blocks not found in vacuum data!!!!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Finished blocks not found in vacuum data!!!!\n");
 	  vacuum_unfix_data_page (thread_p, data_page);
 	  return;
 	}
@@ -4643,7 +4643,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 	{
 	  /* Unexpected. */
 	  assert_release (false);
-	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "Invalid vacuum data next_page!!!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Invalid vacuum data next_page!!!\n");
 	  *data_page = vacuum_Data.first_page;
 	  return;
 	}
@@ -4713,7 +4713,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
       if (prev_data_page == NULL)
 	{
 	  assert_release (false);
-	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "No previous data page is unexpected!!!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "No previous data page is unexpected!!!\n");
 	  vacuum_unfix_data_page (thread_p, *data_page);
 	  return;
 	}
@@ -4984,7 +4984,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 	      if (error_code != NO_ERROR)
 		{
 		  /* Could not allocate new page. */
-		  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "Could not allocate new page for vacuum data!!!!");
+		  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Could not allocate new page for vacuum data!!!!");
 		  assert_release (false);
 		  log_sysop_abort (thread_p);
 		  return error_code;
@@ -5244,7 +5244,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   if (LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa))
     {
       /* We need to search for an MVCC op log record to start recovering lost blocks. */
-      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY, "%s",
 		     "vacuum_recover_lost_block_data, log_Gl.hdr.mvcc_op_log_lsa is null \n");
 
       LSA_COPY (&log_lsa, &vacuum_Data.recovery_lsa);
@@ -5285,7 +5285,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	      if (redo->data.rcvindex == RVVAC_COMPLETE)
 		{
 		  /* stop looking */
-		  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+		  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY, "%s",
 				 "vacuum_recover_lost_block_data, complete vacuum \n");
 		  break;
 		}
@@ -5296,7 +5296,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
       if (LSA_ISNULL (&mvcc_op_log_lsa))
 	{
 	  /* Vacuum data was reached, so there is nothing to recover. */
-	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY, "%s",
 			 "vacuum_recover_lost_block_data, nothing to recovery \n");
 	  return NO_ERROR;
 	}
@@ -5405,7 +5405,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 void
 vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p)
 {
-  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Reset vacuum info in log_Gl.hdr \n");
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Reset vacuum info in log_Gl.hdr \n");
   LSA_SET_NULL (&log_Gl.hdr.mvcc_op_log_lsa);
   log_Gl.hdr.last_block_oldest_mvccid = MVCCID_NULL;
   log_Gl.hdr.last_block_newest_mvccid = MVCCID_NULL;
@@ -5615,7 +5615,7 @@ vacuum_add_dropped_file (THREAD_ENTRY * thread_p, VFID * vfid, MVCCID mvccid)
 
       if (vacuum_load_dropped_files_from_disk (thread_p) != NO_ERROR)
 	{
-	  vacuum_er_log_error (VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY,
+	  vacuum_er_log_error (VACUUM_ER_LOG_DROPPED_FILES | VACUUM_ER_LOG_RECOVERY, "%s",
 			       "Failed to load dropped files during recovery!");
 
 	  assert_release (false);
@@ -6163,12 +6163,12 @@ vacuum_cleanup_dropped_files (THREAD_ENTRY * thread_p)
   VACUUM_TRACK_DROPPED_FILES *track_page = (VACUUM_TRACK_DROPPED_FILES *) vacuum_Track_dropped_files;
 #endif
 
-  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "Start cleanup dropped files.");
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "%s", "Start cleanup dropped files.");
 
   if (!LOG_ISRESTARTED ())
     {
       /* Skip cleanup during recovery */
-      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_DROPPED_FILES, "Skip cleanup during recovery.");
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_DROPPED_FILES, "%s", "Skip cleanup during recovery.");
       return NO_ERROR;
     }
 
@@ -6178,7 +6178,7 @@ vacuum_cleanup_dropped_files (THREAD_ENTRY * thread_p)
   if (vacuum_Dropped_files_count == 0)
     {
       /* Nothing to clean */
-      vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "Cleanup skipped, no current entries.");
+      vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "%s", "Cleanup skipped, no current entries.");
       return NO_ERROR;
     }
 
@@ -6286,7 +6286,7 @@ vacuum_cleanup_dropped_files (THREAD_ENTRY * thread_p)
       /* todo: tracker? */
     }
 
-  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "Finished cleanup dropped files.");
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "%s", "Finished cleanup dropped files.");
   return NO_ERROR;
 }
 
@@ -6884,7 +6884,7 @@ vacuum_log_prefetch_vacuum_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * e
       if (block_log_buffer->buffer_id < 0)
 	{
 	  assert (false);
-	  vacuum_er_log_error (VACUUM_ER_LOG_MASTER, "Could not prefetch. No more free log block buffers.");
+	  vacuum_er_log_error (VACUUM_ER_LOG_MASTER, "%s", "Could not prefetch. No more free log block buffers.");
 	  return ER_FAILED;
 	}
       buffer_block_start_ptr = VACUUM_PREFETCH_LOG_BLOCK_BUFFER (block_log_buffer->buffer_id);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1069,7 +1069,7 @@ vacuum_heap (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, MVCCID threshold_m
 	vacuum_heap_page (thread_p, page_ptr, object_count, threshold_mvccid, &hfid, &reusable, was_interrupted);
       if (error_code != NO_ERROR)
 	{
-	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Vacuum heap page %d|%d, error_code=%d.\n",
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Vacuum heap page %d|%d, error_code=%d.",
 			       page_ptr->oid.volid, page_ptr->oid.pageid);
 
 	  assert_release (false);
@@ -1147,7 +1147,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 				      &helper.home_page);
       if (error_code != NO_ERROR)
 	{
-	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.\n",
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.",
 			       helper.home_vpid.volid, helper.home_vpid.pageid);
 	  return error_code;
 	}
@@ -1166,7 +1166,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
       if (helper.home_page == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error_code);
-	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.\n",
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.",
 			       helper.home_vpid.volid, helper.home_vpid.pageid);
 	  return error_code;
 	}
@@ -1183,7 +1183,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
-	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "%s", "Failed to get hfid.\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "%s", "Failed to get hfid.");
 	  return error_code;
 	}
       /* we need to also output to avoid checking again for other objects */
@@ -1212,7 +1212,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
       if (error_code != NO_ERROR)
 	{
 	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP,
-			       "Could not prepare vacuum for object %d|%d|%d.\n",
+			       "Could not prepare vacuum for object %d|%d|%d.",
 			       heap_objects[obj_index].oid.volid, heap_objects[obj_index].oid.pageid,
 			       heap_objects[obj_index].oid.slotid);
 
@@ -1257,7 +1257,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	  if (error_code != NO_ERROR)
 	    {
 	      vacuum_er_log_error (VACUUM_ER_LOG_HEAP,
-				   "Failed to vacuum object at %d|%d|%d.\n", helper.home_vpid.volid,
+				   "Failed to vacuum object at %d|%d|%d.", helper.home_vpid.volid,
 				   helper.home_vpid.pageid, helper.crt_slotid);
 
 	      /* Debug should hit assert. Release should continue. */
@@ -1314,7 +1314,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	      heap_page_set_vacuum_status_none (thread_p, helper.home_page);
 
 	      vacuum_er_log (VACUUM_ER_LOG_HEAP,
-			     "Changed vacuum status of heap page %d|%d, lsa=%lld|%d from once to none.\n",
+			     "Changed vacuum status of heap page %d|%d, lsa=%lld|%d from once to none.",
 			     PGBUF_PAGE_STATE_ARGS (helper.home_page));
 
 	      VACUUM_PERF_HEAP_TRACK_EXECUTE (thread_p, &helper);
@@ -1347,7 +1347,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 		  assert (helper.home_page == NULL);
 
 		  vacuum_er_log (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_HEAP,
-				 "Successfully removed page %d|%d from heap file (%d, %d|%d).\n",
+				 "Successfully removed page %d|%d from heap file (%d, %d|%d).",
 				 VPID_AS_ARGS (&helper.home_vpid), HFID_AS_ARGS (&helper.hfid));
 
 		  VACUUM_PERF_HEAP_TRACK_EXECUTE (thread_p, &helper);
@@ -1380,7 +1380,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	  if (helper.home_page == NULL)
 	    {
 	      assert (false);
-	      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.\n",
+	      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.",
 				   helper.home_vpid.volid, helper.home_vpid.pageid);
 	      goto end;
 	    }
@@ -2003,7 +2003,7 @@ vacuum_heap_get_hfid_and_file_type (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER 
   if (error_code != NO_ERROR)
     {
       vacuum_er_log_error (VACUUM_ER_LOG_HEAP,
-			   "Failed to obtain class_oid from heap page %d|%d.\n",
+			   "Failed to obtain class_oid from heap page %d|%d.",
 			   PGBUF_PAGE_VPID_AS_ARGS (helper->home_page));
 
       assert_release (false);
@@ -2037,8 +2037,8 @@ vacuum_heap_get_hfid_and_file_type (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER 
 	  else
 	    {
 	      vacuum_er_log_warning (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_DROPPED_FILES, "%s",
-				     "VACUUM WARNING: vacuuming heap found deleted class oid, however hfid and file type "
-				     "have been successfully loaded from file header. \n");
+				     "vacuuming heap found deleted class oid, however hfid and file type "
+				     "have been successfully loaded from file header. ");
 	    }
 	}
     }
@@ -2054,7 +2054,7 @@ vacuum_heap_get_hfid_and_file_type (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER 
   if (HFID_IS_NULL (&helper->hfid) || (ftype != FILE_HEAP && ftype != FILE_HEAP_REUSE_SLOTS))
     {
       vacuum_er_log_error (VACUUM_ER_LOG_HEAP,
-			   "Invalid hfid (%d, %d|%d) or ftype = %s \n", HFID_AS_ARGS (&helper->hfid),
+			   "Invalid hfid (%d, %d|%d) or ftype = %s ", HFID_AS_ARGS (&helper->hfid),
 			   file_type_to_string (ftype));
       assert_release (false);
       return ER_FAILED;
@@ -2240,7 +2240,7 @@ vacuum_rv_redo_vacuum_heap_page (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   if (all_vacuumed)
     {
       vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
-		     "Change vacuum status for heap page %d|%d, lsa=%lld|%d, from once to none.\n",
+		     "Change vacuum status for heap page %d|%d, lsa=%lld|%d, from once to none.",
 		     PGBUF_PAGE_STATE_ARGS (rcv->pgptr));
     }
 
@@ -2437,7 +2437,7 @@ vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, MVC
 
   vacuum_er_log (VACUUM_ER_LOG_LOGGING | VACUUM_ER_LOG_VACUUM_DATA,
 		 "vacuum_produce_log_block_data: blockid=(%lld) start_lsa=(%lld, %d) old_mvccid=(%llu) "
-		 "new_mvccid=(%llu)\n", (long long) block_data.blockid, LSA_AS_ARGS (&block_data.start_lsa),
+		 "new_mvccid=(%llu)", (long long) block_data.blockid, LSA_AS_ARGS (&block_data.start_lsa),
 		 (unsigned long long int) block_data.oldest_mvccid, (unsigned long long int) block_data.newest_mvccid);
 
   /* Push new block into block data buffer */
@@ -2624,7 +2624,7 @@ restart:
 	   + (INT16) (vacuum_Data.blockid_job_cursor
 		      - VACUUM_BLOCKID_WITHOUT_FLAGS (data_page->data[data_page->index_unvacuumed].blockid)));
 
-  vacuum_er_log (VACUUM_ER_LOG_MASTER, "Start searching jobs in page %d|%d from index %d.\n",
+  vacuum_er_log (VACUUM_ER_LOG_MASTER, "Start searching jobs in page %d|%d from index %d.",
 		 vacuum_Data.vpid_job_cursor.volid, vacuum_Data.vpid_job_cursor.pageid, data_index);
 
   while (true)
@@ -2659,7 +2659,7 @@ restart:
 	  data_index++;
 	  vacuum_Data.blockid_job_cursor++;
 	  vacuum_er_log (VACUUM_ER_LOG_JOBS,
-			 "Job for %lld was already executed. Skip.\n",
+			 "Job for %lld was already executed. Skip.",
 			 (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (entry->blockid));
 	  continue;
 	}
@@ -2681,7 +2681,7 @@ restart:
 	  vacuum_unfix_data_page (thread_p, data_page);
 	  vacuum_er_log (VACUUM_ER_LOG_JOBS,
 			 "Job for blockid = %lld, newest_mvccid = %llu, start_lsa = %lld cannot be generated. "
-			 "vacuum_Global_oldest_active_mvccid = %lld, log_Gl.append.prev_lsa.pageid = %d.\n",
+			 "vacuum_Global_oldest_active_mvccid = %lld, log_Gl.append.prev_lsa.pageid = %d.",
 			 (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (entry->blockid),
 			 (unsigned long long int) entry->newest_mvccid,
 			 (long long int) entry->start_lsa.pageid, (int) entry->start_lsa.offset,
@@ -2699,7 +2699,7 @@ restart:
 	  data_index++;
 	  vacuum_Data.blockid_job_cursor++;
 	  vacuum_er_log (VACUUM_ER_LOG_JOBS,
-			 "Job for blockid = %lld %s. Skip.\n",
+			 "Job for blockid = %lld %s. Skip.",
 			 (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (entry->blockid),
 			 VACUUM_BLOCK_STATUS_IS_VACUUMED (entry->blockid) ? "was executed" : "is in progress");
 	  continue;
@@ -2734,7 +2734,7 @@ restart:
 	  VACUUM_BLOCK_STATUS_SET_AVAILABLE (entry->blockid);
 
 	  vacuum_er_log (VACUUM_ER_LOG_JOBS,
-			 "Could not produce job for blockid = %lld. Set it as available.\n",
+			 "Could not produce job for blockid = %lld. Set it as available.",
 			 (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (entry->blockid));
 
 	  vacuum_unfix_data_page (thread_p, data_page);
@@ -3008,7 +3008,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
   log_page_p->hdr.offset = NULL_OFFSET;
 
   vacuum_er_log (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_JOBS,
-		 "vacuum_process_log_block (): blockid(%lld) start_lsa(%lld, %d) old_mvccid(%llu) new_mvccid(%llu)\n",
+		 "vacuum_process_log_block (): blockid(%lld) start_lsa(%lld, %d) old_mvccid(%llu) new_mvccid(%llu)",
 		 LSA_AS_ARGS (&data->start_lsa), (unsigned long long int) data->oldest_mvccid,
 		 (unsigned long long int) data->newest_mvccid);
 
@@ -3047,7 +3047,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	}
 #endif /* SERVER_MODE */
 
-      vacuum_er_log (VACUUM_ER_LOG_WORKER, "process log entry at log_lsa (%lld, %d)\n", LSA_AS_ARGS (&log_lsa));
+      vacuum_er_log (VACUUM_ER_LOG_WORKER, "process log entry at log_lsa (%lld, %d)", LSA_AS_ARGS (&log_lsa));
 
       worker->state = VACUUM_WORKER_STATE_PROCESS_LOG;
       PERF_UTIME_TRACKER_TIME_AND_RESTART (thread_p, &perf_tracker, PSTAT_VAC_WORKER_EXECUTE);
@@ -3083,7 +3083,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	{
 	  /* No need to vacuum */
 	  vacuum_er_log (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_DROPPED_FILES,
-			 "Skip vacuuming based on (%lld, %d) in file %d|%d. Log record info: rcvindex=%d.\n",
+			 "Skip vacuuming based on (%lld, %d) in file %d|%d. Log record info: rcvindex=%d.",
 			 (long long int) rcv_lsa.pageid, (int) rcv_lsa.offset, log_vacuum.vfid.volid,
 			 log_vacuum.vfid.fileid, log_record_data.rcvindex);
 	  continue;
@@ -3111,14 +3111,14 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	  if (error_code != NO_ERROR)
 	    {
 	      assert_release (false);
-	      vacuum_er_log_error (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_HEAP, "%s", "vacuum_collect_heap_objects.\n");
+	      vacuum_er_log_error (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_HEAP, "%s", "vacuum_collect_heap_objects.");
 	      /* Release should not stop. */
 	      er_clear ();
 	      error_code = NO_ERROR;
 	      continue;
 	    }
 	  vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_WORKER,
-			 "collected oid %d|%d|%d, in file %d|%d, based on %lld|%d\n", OID_AS_ARGS (&heap_object_oid),
+			 "collected oid %d|%d|%d, in file %d|%d, based on %lld|%d", OID_AS_ARGS (&heap_object_oid),
 			 VFID_AS_ARGS (&log_vacuum.vfid), LSA_AS_ARGS (&rcv_lsa));
 	}
       else if (LOG_IS_MVCC_BTREE_OPERATION (log_record_data.rcvindex))
@@ -3149,7 +3149,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 		{
 		  vacuum_er_log (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 				 "vacuum from b-tree: btidp(%d, (%d %d)) oid(%d, %d, %d) "
-				 "class_oid(%d, %d, %d), purpose=rem_object, mvccid=%llu, based on %lld|%d\n",
+				 "class_oid(%d, %d, %d), purpose=rem_object, mvccid=%llu, based on %lld|%d",
 				 BTID_AS_ARGS (btid_int.sys_btid), OID_AS_ARGS (&oid), OID_AS_ARGS (&class_oid),
 				 (unsigned long long int) mvcc_info.delete_mvccid, LSA_AS_ARGS (&rcv_lsa));
 		  error_code =
@@ -3160,7 +3160,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 		{
 		  vacuum_er_log (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 				 "vacuum from b-tree: btidp(%d, (%d %d)) oid(%d, %d, %d) class_oid(%d, %d, %d), "
-				 "purpose=rem_insid, mvccid=%llu, based on %lld|%d\n",
+				 "purpose=rem_insid, mvccid=%llu, based on %lld|%d",
 				 BTID_AS_ARGS (btid_int.sys_btid), OID_AS_ARGS (&oid), OID_AS_ARGS (&class_oid),
 				 (unsigned long long int) mvcc_info.insert_mvccid, LSA_AS_ARGS (&rcv_lsa));
 		  error_code =
@@ -3184,7 +3184,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	      /* Object was deleted and must be completely removed. */
 	      vacuum_er_log (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 			     "vacuum from b-tree: btidp(%d, (%d %d)) oid(%d, %d, %d) "
-			     "class_oid(%d, %d, %d), purpose=rem_object, mvccid=%llu, based on %lld|%d\n",
+			     "class_oid(%d, %d, %d), purpose=rem_object, mvccid=%llu, based on %lld|%d",
 			     BTID_AS_ARGS (btid_int.sys_btid), OID_AS_ARGS (&oid), OID_AS_ARGS (&class_oid),
 			     (unsigned long long int) mvccid, LSA_AS_ARGS (&rcv_lsa));
 	      error_code = btree_vacuum_object (thread_p, btid_int.sys_btid, &key_buf, &oid, &class_oid, mvccid);
@@ -3200,7 +3200,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 		}
 	      vacuum_er_log (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 			     "vacuum from b-tree: btidp(%d, (%d %d)) oid(%d, %d, %d) "
-			     "class_oid(%d, %d, %d), purpose=rem_insid, mvccid=%llu, based on %lld|%d\n",
+			     "class_oid(%d, %d, %d), purpose=rem_insid, mvccid=%llu, based on %lld|%d",
 			     BTID_AS_ARGS (btid_int.sys_btid), OID_AS_ARGS (&oid), OID_AS_ARGS (&class_oid),
 			     (unsigned long long int) mvccid, LSA_AS_ARGS (&rcv_lsa));
 	      error_code = btree_vacuum_insert_mvccid (thread_p, btid_int.sys_btid, &key_buf, &oid, &class_oid, mvccid);
@@ -3225,7 +3225,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	{
 	  /* A lob file must be deleted */
 	  (void) or_unpack_string (undo_data, &es_uri);
-	  vacuum_er_log (VACUUM_ER_LOG_WORKER, "Delete lob %s based on %lld|%d\n", es_uri, LSA_AS_ARGS (&rcv_lsa));
+	  vacuum_er_log (VACUUM_ER_LOG_WORKER, "Delete lob %s based on %lld|%d", es_uri, LSA_AS_ARGS (&rcv_lsa));
 	  (void) es_delete_file (es_uri);
 	  db_private_free_and_init (thread_p, es_uri);
 	}
@@ -3340,7 +3340,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   worker->heap_objects = (VACUUM_HEAP_OBJECT *) malloc (worker->heap_objects_capacity * sizeof (VACUUM_HEAP_OBJECT));
   if (worker->heap_objects == NULL)
     {
-      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "%s", "Could not allocate files and objects buffer.\n");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "%s", "Could not allocate files and objects buffer.");
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_assign_worker");
       goto error;
     }
@@ -3368,7 +3368,7 @@ vacuum_assign_worker (THREAD_ENTRY * thread_p)
   thread_p->vacuum_worker = worker;
 
   vacuum_er_log (VACUUM_ER_LOG_WORKER,
-		 "Assigned vacuum_worker %p, index %d to thread %p, index %d.\n",
+		 "Assigned vacuum_worker %p, index %d to thread %p, index %d.",
 		 worker, save_assigned_workers_count, thread_p, thread_p->index);
 
   if (vacuum_Prefetch_log_mode == VACUUM_PREFETCH_LOG_MODE_WORKERS && worker->prefetch_log_buffer == NULL)
@@ -3486,7 +3486,7 @@ vacuum_rv_finish_worker_recovery (THREAD_ENTRY * thread_p, TRANID trid)
       vacuum_Master.tdes->state = TRAN_ACTIVE;
 
       vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_MASTER, "%s",
-		     "Finished recovery for vacuum master.\n");
+		     "Finished recovery for vacuum master.");
 
       return;
     }
@@ -3614,7 +3614,7 @@ vacuum_finished_block_vacuum (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data,
       VACUUM_BLOCK_CLEAR_INTERRUPTED (data->blockid);
 
       vacuum_er_log (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
-		     "Processing log block %lld is complete. Notify master.\n",
+		     "Processing log block %lld is complete. Notify master.",
 		     (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (data->blockid));
     }
   else
@@ -3660,7 +3660,7 @@ vacuum_finished_block_vacuum (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data,
   if (!lf_circular_queue_produce (vacuum_Finished_job_queue, &blockid))
     {
       assert_release (false);
-      vacuum_er_log_error (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_JOBS, "%s", "Finished job queue is full!!!\n");
+      vacuum_er_log_error (VACUUM_ER_LOG_WORKER | VACUUM_ER_LOG_JOBS, "%s", "Finished job queue is full!!!");
     }
 
 #if defined (SERVER_MODE)
@@ -3778,7 +3778,7 @@ vacuum_process_log_record (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, LOG_
       if (sysop_end->type != LOG_SYSOP_END_LOGICAL_MVCC_UNDO)
 	{
 	  assert (false);
-	  vacuum_er_log_error (VACUUM_ER_LOG_LOGGING, "%s", "invalid record type!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_LOGGING, "%s", "invalid record type!");
 	  return ER_FAILED;
 	}
 
@@ -4392,7 +4392,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 	 && lf_circular_queue_consume (vacuum_Finished_job_queue, &finished_blocks[n_finished_blocks]))
     {
       /* Increment consumed finished blocks. */
-      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Consumed from finished job queue %lld (flags %lld).\n",
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Consumed from finished job queue %lld (flags %lld).",
 		     (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (finished_blocks[n_finished_blocks]),
 		     VACUUM_BLOCKID_GET_FLAGS (finished_blocks[n_finished_blocks]));
       ++n_finished_blocks;
@@ -4432,7 +4432,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 	      VACUUM_BLOCK_STATUS_SET_VACUUMED (data->blockid);
 
 	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
-			     "Mark block %lld as vacuumed.\n",
+			     "Mark block %lld as vacuumed.",
 			     (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (data->blockid));
 	    }
 	  else
@@ -4442,7 +4442,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 	      VACUUM_BLOCK_SET_INTERRUPTED (data->blockid);
 
 	      vacuum_er_log_warning (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_JOBS,
-				     "VACUUM WARNING: Mark block %lld as interrupted.\n",
+				     "Mark block %lld as interrupted.",
 				     (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (data->blockid));
 	    }
 	  index++;
@@ -4482,7 +4482,8 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
 		  if (n_finished_blocks > index)
 		    {
 		      assert (false);
-		      vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Finished blocks not found in vacuum data!!!!\n");
+		      vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s",
+					   "Finished blocks not found in vacuum data!!!!");
 		      return;
 		    }
 		  else
@@ -4549,7 +4550,7 @@ vacuum_data_mark_finished (THREAD_ENTRY * thread_p)
       if (VPID_ISNULL (&data_page->next_page))
 	{
 	  assert (false);
-	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Finished blocks not found in vacuum data!!!!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Finished blocks not found in vacuum data!!!!");
 	  vacuum_unfix_data_page (thread_p, data_page);
 	  return;
 	}
@@ -4617,7 +4618,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
       vacuum_set_dirty_data_page (thread_p, *data_page, DONT_FREE);
 
       vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
-		     "Last page, vpid = %d|%d, is empty and was reset. %s\n",
+		     "Last page, vpid = %d|%d, is empty and was reset. %s",
 		     pgbuf_get_vpid_ptr ((PAGE_PTR) (*data_page))->volid,
 		     pgbuf_get_vpid_ptr ((PAGE_PTR) (*data_page))->pageid,
 		     vacuum_Data.first_page == vacuum_Data.last_page ?
@@ -4643,7 +4644,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 	{
 	  /* Unexpected. */
 	  assert_release (false);
-	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Invalid vacuum data next_page!!!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Invalid vacuum data next_page!!!");
 	  *data_page = vacuum_Data.first_page;
 	  return;
 	}
@@ -4659,7 +4660,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 	{
 	  assert_release (false);
 	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA,
-			       "Failed to update file descriptor!!!\n", save_first_vpid.volid, save_first_vpid.pageid);
+			       "Failed to update file descriptor!!!", save_first_vpid.volid, save_first_vpid.pageid);
 	  log_sysop_abort (thread_p);
 
 	  return;
@@ -4676,7 +4677,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 	{
 	  assert_release (false);
 	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA,
-			       "Failed to deallocate first page from vacuum data - %d|%d!!!\n",
+			       "Failed to deallocate first page from vacuum data - %d|%d!!!",
 			       save_first_vpid.volid, save_first_vpid.pageid);
 	  log_sysop_abort (thread_p);
 
@@ -4691,7 +4692,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 	}
       log_sysop_commit (thread_p);
 
-      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Changed first VPID from %d|%d to %d|%d.\n",
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Changed first VPID from %d|%d to %d|%d.",
 		     VPID_AS_ARGS (&save_first_vpid), VPID_AS_ARGS (&fdes_update.vacuum_data.vpid_first));
 
       /* If cursor was in this page, advance to next page */
@@ -4713,7 +4714,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
       if (prev_data_page == NULL)
 	{
 	  assert_release (false);
-	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "No previous data page is unexpected!!!\n");
+	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "No previous data page is unexpected!!!");
 	  vacuum_unfix_data_page (thread_p, *data_page);
 	  return;
 	}
@@ -4731,7 +4732,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 	{
 	  assert_release (false);
 	  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA,
-			       "Failed to deallocate page from vacuum data - %d|%d!!!\n",
+			       "Failed to deallocate page from vacuum data - %d|%d!!!",
 			       save_page_vpid.volid, save_page_vpid.pageid);
 	  log_sysop_abort (thread_p);
 	  return;
@@ -4791,7 +4792,7 @@ vacuum_rv_undoredo_first_data_page (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 void
 vacuum_rv_undoredo_first_data_page_dump (FILE * fp, int length, void *data)
 {
-  fprintf (fp, " Set first page vacuum data page VPID to %d|%d.\n", ((VPID *) data)->volid, ((VPID *) data)->pageid);
+  fprintf (fp, " Set first page vacuum data page VPID to %d|%d.", ((VPID *) data)->volid, ((VPID *) data)->pageid);
 }
 
 /* TODO VACUUM_DATA_COMPATIBILITY: <=== */
@@ -4984,7 +4985,8 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 	      if (error_code != NO_ERROR)
 		{
 		  /* Could not allocate new page. */
-		  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Could not allocate new page for vacuum data!!!!");
+		  vacuum_er_log_error (VACUUM_ER_LOG_VACUUM_DATA, "%s",
+				       "Could not allocate new page for vacuum data!!!!");
 		  assert_release (false);
 		  log_sysop_abort (thread_p);
 		  return error_code;
@@ -5048,7 +5050,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 #endif /* !NDEBUG */
 
 	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
-			     "Add block %lld, start_lsa=%lld|%d, oldest_mvccid=%llu, newest_mvccid=%llu.\n",
+			     "Add block %lld, start_lsa=%lld|%d, oldest_mvccid=%llu, newest_mvccid=%llu.",
 			     (long long int) VACUUM_BLOCKID_WITHOUT_FLAGS (page_free_data->blockid),
 			     (long long int) page_free_data->start_lsa.pageid, (int) page_free_data->start_lsa.offset,
 			     (unsigned long long int) page_free_data->oldest_mvccid,
@@ -5063,7 +5065,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 	      page_free_data->newest_mvccid = MVCCID_NULL;
 
 	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
-			     "Block %lld has no MVCC ops and is skipped (marked as vacuumed).\n", next_blockid);
+			     "Block %lld has no MVCC ops and is skipped (marked as vacuumed).", next_blockid);
 	    }
 	  vacuum_Data.last_blockid = next_blockid;
 
@@ -5245,7 +5247,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
     {
       /* We need to search for an MVCC op log record to start recovering lost blocks. */
       vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY, "%s",
-		     "vacuum_recover_lost_block_data, log_Gl.hdr.mvcc_op_log_lsa is null \n");
+		     "vacuum_recover_lost_block_data, log_Gl.hdr.mvcc_op_log_lsa is null ");
 
       LSA_COPY (&log_lsa, &vacuum_Data.recovery_lsa);
       /* Stop search if search reaches blocks already in vacuum data. */
@@ -5269,7 +5271,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	    {
 	      LSA_COPY (&mvcc_op_log_lsa, &log_lsa);
 	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
-			     "vacuum_recover_lost_block_data, found mvcc op at lsa = %lld|%d \n",
+			     "vacuum_recover_lost_block_data, found mvcc op at lsa = %lld|%d ",
 			     LSA_AS_ARGS (&mvcc_op_log_lsa));
 	      break;
 	    }
@@ -5286,7 +5288,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 		{
 		  /* stop looking */
 		  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY, "%s",
-				 "vacuum_recover_lost_block_data, complete vacuum \n");
+				 "vacuum_recover_lost_block_data, complete vacuum ");
 		  break;
 		}
 	    }
@@ -5297,7 +5299,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	{
 	  /* Vacuum data was reached, so there is nothing to recover. */
 	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY, "%s",
-			 "vacuum_recover_lost_block_data, nothing to recovery \n");
+			 "vacuum_recover_lost_block_data, nothing to recovery ");
 	  return NO_ERROR;
 	}
     }
@@ -5306,7 +5308,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
       /* Already in vacuum data. */
       vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 		     "vacuum_recover_lost_block_data, mvcc_op_log_lsa %lld|%d is already in vacuum data "
-		     "(last blockid = %lld) \n", LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa),
+		     "(last blockid = %lld) ", LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa),
 		     (long long int) vacuum_Data.last_blockid);
       vacuum_reset_log_header_cache (thread_p);
       return NO_ERROR;
@@ -5318,7 +5320,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   assert (!LSA_ISNULL (&mvcc_op_log_lsa));
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
-		 "vacuum_recover_lost_block_data, start recovering from %lld|%d \n", LSA_AS_ARGS (&mvcc_op_log_lsa));
+		 "vacuum_recover_lost_block_data, start recovering from %lld|%d ", LSA_AS_ARGS (&mvcc_op_log_lsa));
 
   /* Start recovering blocks. */
   is_last_block = true;
@@ -5376,7 +5378,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 
 	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 			 "Restore log global cached info: \n\t mvcc_op_log_lsa = %lld|%d \n"
-			 "\t last_block_oldest_mvccid = %llu \n\t last_block_newest_mvccid = %llu \n",
+			 "\t last_block_oldest_mvccid = %llu \n\t last_block_newest_mvccid = %llu ",
 			 LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa),
 			 (unsigned long long int) log_Gl.hdr.last_block_oldest_mvccid,
 			 (unsigned long long int) log_Gl.hdr.last_block_newest_mvccid);
@@ -5405,7 +5407,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 void
 vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p)
 {
-  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Reset vacuum info in log_Gl.hdr \n");
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "%s", "Reset vacuum info in log_Gl.hdr ");
   LSA_SET_NULL (&log_Gl.hdr.mvcc_op_log_lsa);
   log_Gl.hdr.last_block_oldest_mvccid = MVCCID_NULL;
   log_Gl.hdr.last_block_newest_mvccid = MVCCID_NULL;
@@ -5507,7 +5509,7 @@ vacuum_update_oldest_unvacuumed_mvccid (THREAD_ENTRY * thread_p)
 
   if (oldest_mvccid != vacuum_Data.oldest_unvacuumed_mvccid)
     {
-      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Update oldest_unvacuumed_mvccid from %llu to %llu.\n",
+      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Update oldest_unvacuumed_mvccid from %llu to %llu.",
 		     (unsigned long long int) vacuum_Data.oldest_unvacuumed_mvccid,
 		     (unsigned long long int) oldest_mvccid);
 
@@ -5542,7 +5544,7 @@ vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p)
   vacuum_Data.keep_from_log_pageid = VACUUM_FIRST_LOG_PAGEID_IN_BLOCK (keep_from_blockid);
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
-		 "Update keep_from_log_pageid to %lld \n", (long long int) vacuum_Data.keep_from_log_pageid);
+		 "Update keep_from_log_pageid to %lld ", (long long int) vacuum_Data.keep_from_log_pageid);
 }
 
 /*
@@ -6632,7 +6634,7 @@ vacuum_collect_heap_objects (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, OI
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
 		  new_capacity * sizeof (VACUUM_HEAP_OBJECT));
 	  vacuum_er_log_error (VACUUM_ER_LOG_WORKER,
-			       "Could not expact the files and objects capacity to %d.\n", new_capacity);
+			       "Could not expact the files and objects capacity to %d.", new_capacity);
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
       worker->heap_objects = new_buffer;

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -54,13 +54,17 @@
 #define VACUUM_IS_ER_LOG_LEVEL_SET(er_log_level) \
   ((prm_get_integer_value (PRM_ID_ER_LOG_VACUUM) & (er_log_level)) != 0)
 
-#if defined(SERVER_MODE)
-#define vacuum_er_log(er_log_level, ...) \
+#define vacuum_er_log(thread_p, er_log_level, msg, ...) \
   if (VACUUM_IS_ER_LOG_LEVEL_SET (er_log_level)) \
-    _er_log_debug (ARG_FILE_LINE, __VA_ARGS__)
-#else
-#define vacuum_er_log(er_log_level, ...)
-#endif
+    _er_log_debug (ARG_FILE_LINE, "VACUUM " LOG_THREAD_TRAN_MSG ": " msg, LOG_THREAD_TRAN_ARGS (thread_p), __VA_ARGS__)
+#define vacuum_er_log_error(thread_p, er_log_level, msg, ...) \
+  if (VACUUM_IS_ER_LOG_LEVEL_SET (VACUUM_ER_LOG_ERROR | er_log_level)) \
+    _er_log_debug (ARG_FILE_LINE, "VACUUM ERROR " LOG_THREAD_TRAN_MSG ": " msg, LOG_THREAD_TRAN_ARGS (thread_p), \
+                   __VA_ARGS__)
+#define vacuum_er_log_warning(thread_p, er_log_level, msg, ...) \
+  if (VACUUM_IS_ER_LOG_LEVEL_SET (VACUUM_ER_LOG_WARNING | er_log_level)) \
+    _er_log_debug (ARG_FILE_LINE, "VACUUM WARNING " LOG_THREAD_TRAN_MSG ": " msg, LOG_THREAD_TRAN_ARGS (thread_p), \
+                   __VA_ARGS__)
 
 typedef INT64 VACUUM_LOG_BLOCKID;
 #define VACUUM_NULL_LOG_BLOCKID -1
@@ -281,7 +285,7 @@ extern void vacuum_start_new_job (THREAD_ENTRY * thread_p);
 
 extern int vacuum_create_file_for_vacuum_data (THREAD_ENTRY * thread_p, VFID * vacuum_data_vfid);
 extern int vacuum_data_load_and_recover (THREAD_ENTRY * thread_p);
-extern void vacuum_reset_log_header_cache (void);
+extern void vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p);
 extern VACUUM_LOG_BLOCKID vacuum_get_log_blockid (LOG_PAGEID pageid);
 extern void vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, MVCCID oldest_mvccid,
 					   MVCCID newest_mvccid);

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -54,17 +54,18 @@
 #define VACUUM_IS_ER_LOG_LEVEL_SET(er_log_level) \
   ((prm_get_integer_value (PRM_ID_ER_LOG_VACUUM) & (er_log_level)) != 0)
 
-#define vacuum_er_log(thread_p, er_log_level, msg, ...) \
+#define vacuum_er_log(er_log_level, msg, ...) \
   if (VACUUM_IS_ER_LOG_LEVEL_SET (er_log_level)) \
-    _er_log_debug (ARG_FILE_LINE, "VACUUM " LOG_THREAD_TRAN_MSG ": " msg, LOG_THREAD_TRAN_ARGS (thread_p), __VA_ARGS__)
-#define vacuum_er_log_error(thread_p, er_log_level, msg, ...) \
+    _er_log_debug (ARG_FILE_LINE, "VACUUM " LOG_THREAD_TRAN_MSG ": " msg, \
+                   LOG_THREAD_TRAN_ARGS (thread_get_thread_entry_info ()), __VA_ARGS__)
+#define vacuum_er_log_error(er_log_level, msg, ...) \
   if (VACUUM_IS_ER_LOG_LEVEL_SET (VACUUM_ER_LOG_ERROR | er_log_level)) \
-    _er_log_debug (ARG_FILE_LINE, "VACUUM ERROR " LOG_THREAD_TRAN_MSG ": " msg, LOG_THREAD_TRAN_ARGS (thread_p), \
-                   __VA_ARGS__)
-#define vacuum_er_log_warning(thread_p, er_log_level, msg, ...) \
+    _er_log_debug (ARG_FILE_LINE, "VACUUM ERROR " LOG_THREAD_TRAN_MSG ": " msg, \
+                   LOG_THREAD_TRAN_ARGS (thread_get_thread_entry_info ()), __VA_ARGS__)
+#define vacuum_er_log_warning(er_log_level, msg, ...) \
   if (VACUUM_IS_ER_LOG_LEVEL_SET (VACUUM_ER_LOG_WARNING | er_log_level)) \
-    _er_log_debug (ARG_FILE_LINE, "VACUUM WARNING " LOG_THREAD_TRAN_MSG ": " msg, LOG_THREAD_TRAN_ARGS (thread_p), \
-                   __VA_ARGS__)
+    _er_log_debug (ARG_FILE_LINE, "VACUUM WARNING " LOG_THREAD_TRAN_MSG ": " msg, \
+                   LOG_THREAD_TRAN_ARGS (thread_get_thread_entry_info ()), __VA_ARGS__)
 
 typedef INT64 VACUUM_LOG_BLOCKID;
 #define VACUUM_NULL_LOG_BLOCKID -1

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -56,15 +56,15 @@
 
 #define vacuum_er_log(er_log_level, msg, ...) \
   if (VACUUM_IS_ER_LOG_LEVEL_SET (er_log_level)) \
-    _er_log_debug (ARG_FILE_LINE, "VACUUM " LOG_THREAD_TRAN_MSG ": " msg, \
+    _er_log_debug (ARG_FILE_LINE, "VACUUM " LOG_THREAD_TRAN_MSG ": " msg "\n", \
                    LOG_THREAD_TRAN_ARGS (thread_get_thread_entry_info ()), __VA_ARGS__)
 #define vacuum_er_log_error(er_log_level, msg, ...) \
   if (VACUUM_IS_ER_LOG_LEVEL_SET (VACUUM_ER_LOG_ERROR | er_log_level)) \
-    _er_log_debug (ARG_FILE_LINE, "VACUUM ERROR " LOG_THREAD_TRAN_MSG ": " msg, \
+    _er_log_debug (ARG_FILE_LINE, "VACUUM ERROR " LOG_THREAD_TRAN_MSG ": " msg "\n", \
                    LOG_THREAD_TRAN_ARGS (thread_get_thread_entry_info ()), __VA_ARGS__)
 #define vacuum_er_log_warning(er_log_level, msg, ...) \
   if (VACUUM_IS_ER_LOG_LEVEL_SET (VACUUM_ER_LOG_WARNING | er_log_level)) \
-    _er_log_debug (ARG_FILE_LINE, "VACUUM WARNING " LOG_THREAD_TRAN_MSG ": " msg, \
+    _er_log_debug (ARG_FILE_LINE, "VACUUM WARNING " LOG_THREAD_TRAN_MSG ": " msg "\n", \
                    LOG_THREAD_TRAN_ARGS (thread_get_thread_entry_info ()), __VA_ARGS__)
 
 typedef INT64 VACUUM_LOG_BLOCKID;

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -30354,11 +30354,11 @@ btree_key_delete_remove_object (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB
 	   * OID1 is vacuumed from heap and its slot can be reused. 4. OID1 is reused and is inserted in the same
 	   * overflow page. The algorithm recognizes that the old version is just not vacuumed yet and replaces it.
 	   * OID's cannot be repeated in overflow pages. 5. Vacuum will not find the old OID1 to remove. */
-	  vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
-			 "VACUUM WARNING: Could not find object %d|%d|%d in key=%s to vacuum it.",
-			 delete_helper->object_info.oid.volid, delete_helper->object_info.oid.pageid,
-			 delete_helper->object_info.oid.slotid,
-			 delete_helper->printed_key != NULL ? delete_helper->printed_key : "(unknown)");
+	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
+				 "Could not find object %d|%d|%d in key=%s to vacuum it.",
+				 delete_helper->object_info.oid.volid, delete_helper->object_info.oid.pageid,
+				 delete_helper->object_info.oid.slotid,
+				 delete_helper->printed_key != NULL ? delete_helper->printed_key : "(unknown)");
 	  btree_delete_log (delete_helper, "could not find object to vacuum \n"
 			    BTREE_DELETE_HELPER_MSG ("\t"), BTREE_DELETE_HELPER_AS_ARGS (delete_helper));
 	  goto exit;
@@ -31570,11 +31570,11 @@ btree_key_remove_insert_mvccid (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB
     {
       /* Key or object not found. */
       /* Object must have been vacuumed/removed already. */
-      vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
-		     "VACUUM WARNING: Could not find object %d|%d|%d in key=%s to vacuum it.",
-		     delete_helper->object_info.oid.volid, delete_helper->object_info.oid.pageid,
-		     delete_helper->object_info.oid.slotid,
-		     delete_helper->printed_key != NULL ? delete_helper->printed_key : "(unknown)");
+      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
+			     "Could not find object %d|%d|%d in key=%s to vacuum it.",
+			     delete_helper->object_info.oid.volid, delete_helper->object_info.oid.pageid,
+			     delete_helper->object_info.oid.slotid,
+			     delete_helper->printed_key != NULL ? delete_helper->printed_key : "(unknown)");
       btree_delete_log (delete_helper, "could not find object to vacuum its insert MVCCID \n"
 			BTREE_DELETE_HELPER_MSG ("\t"), BTREE_DELETE_HELPER_AS_ARGS (delete_helper));
       return NO_ERROR;

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -30353,7 +30353,7 @@ btree_key_delete_remove_object (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB
 	   * OID1 is vacuumed from heap and its slot can be reused. 4. OID1 is reused and is inserted in the same
 	   * overflow page. The algorithm recognizes that the old version is just not vacuumed yet and replaces it.
 	   * OID's cannot be repeated in overflow pages. 5. Vacuum will not find the old OID1 to remove. */
-	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
+	  vacuum_er_log_warning (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 				 "Could not find object %d|%d|%d in key=%s to vacuum it.",
 				 delete_helper->object_info.oid.volid, delete_helper->object_info.oid.pageid,
 				 delete_helper->object_info.oid.slotid,
@@ -31569,7 +31569,7 @@ btree_key_remove_insert_mvccid (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB
     {
       /* Key or object not found. */
       /* Object must have been vacuumed/removed already. */
-      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
+      vacuum_er_log_warning (VACUUM_ER_LOG_BTREE | VACUUM_ER_LOG_WORKER,
 			     "Could not find object %d|%d|%d in key=%s to vacuum it.",
 			     delete_helper->object_info.oid.volid, delete_helper->object_info.oid.pageid,
 			     delete_helper->object_info.oid.slotid,

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1148,13 +1148,12 @@ enum btree_rv_debug_id
 
 /* b-tree debug logging */
 #define btree_log(prefix, msg, ...) \
-  _er_log_debug (ARG_FILE_LINE, prefix " (thread=%d tran=%d): " msg "\n", \
-                 thread_get_current_entry_index (), LOG_FIND_THREAD_TRAN_INDEX (thread_get_thread_entry_info ()), \
-                 __VA_ARGS__)
+  _er_log_debug (ARG_FILE_LINE, prefix LOG_THREAD_TRAN_MSG ": " msg "\n", \
+                 LOG_THREAD_TRAN_ARGS (thread_get_thread_entry_info ()), __VA_ARGS__)
 #define btree_insert_log(helper, msg, ...) \
-  if ((helper)->log_operations) btree_log ("BTREE_INSERT", msg, __VA_ARGS__)
+  if ((helper)->log_operations) btree_log ("BTREE_INSERT ", msg, __VA_ARGS__)
 #define btree_delete_log(helper, msg, ...) \
-  if ((helper)->log_operations) btree_log ("BTREE_DELETE", msg, __VA_ARGS__)
+  if ((helper)->log_operations) btree_log ("BTREE_DELETE ", msg, __VA_ARGS__)
 
 /* logging btid */
 #define BTREE_ID_MSG "index = %d, %d|%d"

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -301,7 +301,7 @@ struct disk_reserve_context
 static bool disk_Logging = false;
 #define disk_log(func, msg, ...) \
   if (disk_Logging) \
-    _er_log_debug (ARG_FILE_LINE, "DISK " func LOG_THREAD_TRAN_MSG ": \n\t" msg "\n", \
+    _er_log_debug (ARG_FILE_LINE, "DISK " func " " LOG_THREAD_TRAN_MSG ": \n\t" msg "\n", \
                    LOG_THREAD_TRAN_ARGS (thread_get_thread_entry_info ()), __VA_ARGS__)
 
 #define DISK_RESERVE_CONTEXT_MSG \

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -301,9 +301,8 @@ struct disk_reserve_context
 static bool disk_Logging = false;
 #define disk_log(func, msg, ...) \
   if (disk_Logging) \
-    _er_log_debug (ARG_FILE_LINE, "DISK " func " (thread=%d tran=%d): \n\t" msg "\n", \
-                   thread_get_current_entry_index (), LOG_FIND_THREAD_TRAN_INDEX (thread_get_thread_entry_info ()), \
-                   __VA_ARGS__)
+    _er_log_debug (ARG_FILE_LINE, "DISK " func LOG_THREAD_TRAN_MSG ": \n\t" msg "\n", \
+                   LOG_THREAD_TRAN_ARGS (thread_get_thread_entry_info ()), __VA_ARGS__)
 
 #define DISK_RESERVE_CONTEXT_MSG \
   "\t\tcontext: \n" \

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -306,7 +306,7 @@ static bool file_Logging = false;
 
 #define file_log(func, msg, ...) \
   if (file_Logging) \
-    _er_log_debug (ARG_FILE_LINE, "FILE " func LOG_THREAD_TRAN_MSG ": " msg "\n", \
+    _er_log_debug (ARG_FILE_LINE, "FILE " func " " LOG_THREAD_TRAN_MSG ": " msg "\n", \
                    LOG_THREAD_TRAN_ARGS(thread_get_thread_entry_info ()), __VA_ARGS__)
 
 #define FILE_PERM_TEMP_STRING(is_temp) ((is_temp) ? "temporary" : "permanent")

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -306,9 +306,8 @@ static bool file_Logging = false;
 
 #define file_log(func, msg, ...) \
   if (file_Logging) \
-    _er_log_debug (ARG_FILE_LINE, "FILE " func " (thread=%d tran=%d): " msg "\n", \
-                   thread_get_current_entry_index (), LOG_FIND_THREAD_TRAN_INDEX (thread_get_thread_entry_info ()), \
-                   __VA_ARGS__)
+    _er_log_debug (ARG_FILE_LINE, "FILE " func LOG_THREAD_TRAN_MSG ": " msg "\n", \
+                   LOG_THREAD_TRAN_ARGS(thread_get_thread_entry_info ()), __VA_ARGS__)
 
 #define FILE_PERM_TEMP_STRING(is_temp) ((is_temp) ? "temporary" : "permanent")
 #define FILE_NUMERABLE_REGULAR_STRING(is_numerable) ((is_numerable) ? "numerable" : "regular")

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -4637,7 +4637,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (pgbuf_has_any_waiters (crt_watcher.pgptr))
     {
       assert (false);
-      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Unexpected page waiters \n");
+      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "%s", "Unexpected page waiters \n");
       goto error;
     }
   /* all good, we can deallocate the page */

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -4569,7 +4569,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
     {
       /* Give up. */
       vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
+			     "Could not remove candidate empty heap page %d|%d.", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
   assert (header_watcher.pgptr != NULL);
@@ -4580,7 +4580,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
     {
       /* Give up. */
       vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
+			     "Could not remove candidate empty heap page %d|%d.", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
 
@@ -4591,7 +4591,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
 	{
 	  /* Give up. */
 	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 "Could not remove candidate empty heap page %d|%d.", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
 	}
@@ -4604,7 +4604,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
 	{
 	  /* Give up. */
 	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 "Could not remove candidate empty heap page %d|%d.", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
 	}
@@ -4616,7 +4616,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
     {
       /* Current page has new data. It is no longer a candidate for removal. */
       vacuum_er_log (VACUUM_ER_LOG_HEAP,
-		     "Candidate heap page %d|%d to remove was changed and has new data.\n", page_vpid.volid,
+		     "Candidate heap page %d|%d to remove was changed and has new data.", page_vpid.volid,
 		     page_vpid.pageid);
       goto error;
     }
@@ -4627,7 +4627,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
       /* Even though we have fixed all required pages, somebody was doing a heap scan, and already reached our page. We 
        * cannot deallocate it. */
       vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-			     "Candidate heap page %d|%d to remove has waiters.\n", page_vpid.volid, page_vpid.pageid);
+			     "Candidate heap page %d|%d to remove has waiters.", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
 
@@ -4637,7 +4637,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (pgbuf_has_any_waiters (crt_watcher.pgptr))
     {
       assert (false);
-      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "%s", "Unexpected page waiters \n");
+      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "%s", "Unexpected page waiters");
       goto error;
     }
   /* all good, we can deallocate the page */
@@ -4653,7 +4653,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
     {
       assert_release (false);
       vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
+			     "Could not remove candidate empty heap page %d|%d.", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
   memcpy (&heap_hdr, copy_recdes.data, sizeof (heap_hdr));
@@ -4693,7 +4693,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
     {
       assert_release (false);
       vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
+			     "Could not remove candidate empty heap page %d|%d.", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
   log_append_undoredo_data2 (thread_p, RVHF_STATS, &hfid->vfid, header_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID,
@@ -4712,7 +4712,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
 	{
 	  assert_release (false);
 	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 "Could not remove candidate empty heap page %d|%d.", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
 	}
@@ -4724,7 +4724,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
 	{
 	  assert_release (false);
 	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 "Could not remove candidate empty heap page %d|%d.", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
 	}
@@ -4742,7 +4742,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
 	{
 	  assert_release (false);
 	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 "Could not remove candidate empty heap page %d|%d.", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
 	}
@@ -4755,7 +4755,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
 	{
 	  assert_release (false);
 	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 "Could not remove candidate empty heap page %d|%d.", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
 	}
@@ -4771,7 +4771,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
     {
       ASSERT_ERROR ();
       vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
-			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
+			     "Could not remove candidate empty heap page %d|%d.", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
 
@@ -4794,7 +4794,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   pgbuf_ordered_unfix (thread_p, &header_watcher);
 
   /* Page removed successfully. */
-  vacuum_er_log (VACUUM_ER_LOG_HEAP, "Successfully remove heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
+  vacuum_er_log (VACUUM_ER_LOG_HEAP, "Successfully remove heap page %d|%d.", page_vpid.volid, page_vpid.pageid);
   return true;
 
 error:
@@ -23471,7 +23471,7 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
       assert (MVCC_ID_PRECEDES (chain->max_mvccid, mvccid));
       HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_ONCE);
       vacuum_er_log (VACUUM_ER_LOG_HEAP,
-		     "Changed vacuum status for page %d|%d, lsa=%lld|%d from no vacuum to vacuum once.\n",
+		     "Changed vacuum status for page %d|%d, lsa=%lld|%d from no vacuum to vacuum once.",
 		     PGBUF_PAGE_STATE_ARGS (heap_page));
       break;
 
@@ -23479,7 +23479,7 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
       /* Change status to unknown number of vacuums. */
       HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_UNKNOWN);
       vacuum_er_log (VACUUM_ER_LOG_HEAP,
-		     "Changed vacuum status for page %d|%d, lsa=%lld|%d from vacuum once to unknown.\n",
+		     "Changed vacuum status for page %d|%d, lsa=%lld|%d from vacuum once to unknown.",
 		     PGBUF_PAGE_STATE_ARGS (heap_page));
       break;
 
@@ -23490,13 +23490,13 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
 	  /* Now page must be vacuumed once, due to new MVCC op. */
 	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_ONCE);
 	  vacuum_er_log (VACUUM_ER_LOG_HEAP,
-			 "Changed vacuum status for page %d|%d, lsa=%lld|%d from unknown to vacuum once.\n ",
+			 "Changed vacuum status for page %d|%d, lsa=%lld|%d from unknown to vacuum once.",
 			 PGBUF_PAGE_STATE_ARGS (heap_page));
 	}
       else
 	{
 	  /* Status remains the same. Number of vacuums needed still cannot be predicted. */
-	  vacuum_er_log (VACUUM_ER_LOG_HEAP, "Vacuum status for page %d|%d, %lld|%d remains unknown.\n ",
+	  vacuum_er_log (VACUUM_ER_LOG_HEAP, "Vacuum status for page %d|%d, %lld|%d remains unknown.",
 			 PGBUF_PAGE_STATE_ARGS (heap_page));
 	}
       break;
@@ -23508,7 +23508,7 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
   /* Update max_mvccid. */
   if (MVCC_ID_PRECEDES (chain->max_mvccid, mvccid))
     {
-      vacuum_er_log (VACUUM_ER_LOG_HEAP, "Update max MVCCID for page %d|%d from %llu to %llu.\n",
+      vacuum_er_log (VACUUM_ER_LOG_HEAP, "Update max MVCCID for page %d|%d from %llu to %llu.",
 		     PGBUF_PAGE_VPID_AS_ARGS (heap_page), (unsigned long long int) chain->max_mvccid,
 		     (unsigned long long int) mvccid);
       chain->max_mvccid = mvccid;
@@ -23559,7 +23559,7 @@ heap_page_rv_chain_update (THREAD_ENTRY * thread_p, PAGE_PTR heap_page, MVCCID m
 	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_ONCE);
 
 	  vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
-			 "Change heap page %d|%d, lsa=%lld|%d, status from %s to once.\n",
+			 "Change heap page %d|%d, lsa=%lld|%d, status from %s to once.",
 			 PGBUF_PAGE_STATE_ARGS (heap_page),
 			 vacuum_status == HEAP_PAGE_VACUUM_NONE ? "none" : "unknown");
 	  break;
@@ -23567,7 +23567,7 @@ heap_page_rv_chain_update (THREAD_ENTRY * thread_p, PAGE_PTR heap_page, MVCCID m
 	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_UNKNOWN);
 
 	  vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
-			 "Change heap page %d|%d, lsa=%lld|%d, status from once to unknown.\n",
+			 "Change heap page %d|%d, lsa=%lld|%d, status from once to unknown.",
 			 PGBUF_PAGE_STATE_ARGS (heap_page));
 	  break;
 	}
@@ -23618,7 +23618,7 @@ heap_page_set_vacuum_status_none (THREAD_ENTRY * thread_p, PAGE_PTR heap_page)
   /* Update vacuum status. */
   HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_NONE);
 
-  vacuum_er_log (VACUUM_ER_LOG_HEAP, "Changed vacuum status for page %d|%d from vacuum once to no vacuum.\n",
+  vacuum_er_log (VACUUM_ER_LOG_HEAP, "Changed vacuum status for page %d|%d from vacuum once to no vacuum.",
 		 PGBUF_PAGE_VPID_AS_ARGS (heap_page));
 }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -4568,7 +4568,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (pgbuf_ordered_fix (thread_p, &header_vpid, OLD_PAGE, PGBUF_LATCH_WRITE, &header_watcher) != NO_ERROR)
     {
       /* Give up. */
-      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
@@ -4579,7 +4579,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
       || heap_vpid_next (thread_p, hfid, *page_ptr, &next_vpid) != NO_ERROR)
     {
       /* Give up. */
-      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
@@ -4590,7 +4590,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
       if (pgbuf_ordered_fix (thread_p, &prev_vpid, OLD_PAGE, PGBUF_LATCH_WRITE, &prev_watcher) != NO_ERROR)
 	{
 	  /* Give up. */
-	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
@@ -4603,7 +4603,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
       if (pgbuf_ordered_fix (thread_p, &next_vpid, OLD_PAGE, PGBUF_LATCH_WRITE, &next_watcher) != NO_ERROR)
 	{
 	  /* Give up. */
-	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
@@ -4615,7 +4615,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (crt_watcher.page_was_unfixed && spage_number_of_records (crt_watcher.pgptr) > 1)
     {
       /* Current page has new data. It is no longer a candidate for removal. */
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log (VACUUM_ER_LOG_HEAP,
 		     "Candidate heap page %d|%d to remove was changed and has new data.\n", page_vpid.volid,
 		     page_vpid.pageid);
       goto error;
@@ -4626,7 +4626,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
     {
       /* Even though we have fixed all required pages, somebody was doing a heap scan, and already reached our page. We 
        * cannot deallocate it. */
-      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 			     "Candidate heap page %d|%d to remove has waiters.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
@@ -4637,7 +4637,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (pgbuf_has_any_waiters (crt_watcher.pgptr))
     {
       assert (false);
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Unexpected page waiters \n");
+      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Unexpected page waiters \n");
       goto error;
     }
   /* all good, we can deallocate the page */
@@ -4652,7 +4652,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (spage_get_record (thread_p, header_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID, &copy_recdes, COPY) != S_SUCCESS)
     {
       assert_release (false);
-      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
@@ -4692,7 +4692,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (spage_update (thread_p, header_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID, &update_recdes) != SP_SUCCESS)
     {
       assert_release (false);
-      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
@@ -4711,7 +4711,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
 	  S_SUCCESS)
 	{
 	  assert_release (false);
-	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
@@ -4723,7 +4723,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
       if (spage_update (thread_p, prev_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID, &update_recdes) != SP_SUCCESS)
 	{
 	  assert_release (false);
-	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
@@ -4741,7 +4741,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
 	  S_SUCCESS)
 	{
 	  assert_release (false);
-	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
@@ -4754,7 +4754,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
       if (spage_update (thread_p, next_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID, &update_recdes) != SP_SUCCESS)
 	{
 	  assert_release (false);
-	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
 				 page_vpid.pageid);
 	  goto error;
@@ -4770,7 +4770,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (file_dealloc (thread_p, &hfid->vfid, &page_vpid, FILE_HEAP) != NO_ERROR)
     {
       ASSERT_ERROR ();
-      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
@@ -4794,8 +4794,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   pgbuf_ordered_unfix (thread_p, &header_watcher);
 
   /* Page removed successfully. */
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP, "Successfully remove heap page %d|%d.\n", page_vpid.volid,
-		 page_vpid.pageid);
+  vacuum_er_log (VACUUM_ER_LOG_HEAP, "Successfully remove heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
   return true;
 
 error:
@@ -6111,7 +6110,7 @@ xheap_reclaim_addresses (THREAD_ENTRY * thread_p, const HFID * hfid)
 	    {
 	      goto exit_on_error;
 	    }
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP, "Compactdb removed page %d|%d from heap file (%d, %d|%d).\n",
+	  vacuum_er_log (VACUUM_ER_LOG_HEAP, "Compactdb removed page %d|%d from heap file (%d, %d|%d).\n",
 			 vpid.volid, vpid.pageid, hfid->hpgid, hfid->vfid.volid, hfid->vfid.fileid);
 	}
       else
@@ -23471,7 +23470,7 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
       /* Change status to one vacuum. */
       assert (MVCC_ID_PRECEDES (chain->max_mvccid, mvccid));
       HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_ONCE);
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log (VACUUM_ER_LOG_HEAP,
 		     "Changed vacuum status for page %d|%d, lsa=%lld|%d from no vacuum to vacuum once.\n",
 		     PGBUF_PAGE_STATE_ARGS (heap_page));
       break;
@@ -23479,7 +23478,7 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
     case HEAP_PAGE_VACUUM_ONCE:
       /* Change status to unknown number of vacuums. */
       HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_UNKNOWN);
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP,
+      vacuum_er_log (VACUUM_ER_LOG_HEAP,
 		     "Changed vacuum status for page %d|%d, lsa=%lld|%d from vacuum once to unknown.\n",
 		     PGBUF_PAGE_STATE_ARGS (heap_page));
       break;
@@ -23490,14 +23489,14 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
 	{
 	  /* Now page must be vacuumed once, due to new MVCC op. */
 	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_ONCE);
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP,
+	  vacuum_er_log (VACUUM_ER_LOG_HEAP,
 			 "Changed vacuum status for page %d|%d, lsa=%lld|%d from unknown to vacuum once.\n ",
 			 PGBUF_PAGE_STATE_ARGS (heap_page));
 	}
       else
 	{
 	  /* Status remains the same. Number of vacuums needed still cannot be predicted. */
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP, "Vacuum status for page %d|%d, %lld|%d remains unknown.\n ",
+	  vacuum_er_log (VACUUM_ER_LOG_HEAP, "Vacuum status for page %d|%d, %lld|%d remains unknown.\n ",
 			 PGBUF_PAGE_STATE_ARGS (heap_page));
 	}
       break;
@@ -23509,7 +23508,7 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
   /* Update max_mvccid. */
   if (MVCC_ID_PRECEDES (chain->max_mvccid, mvccid))
     {
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP, "Update max MVCCID for page %d|%d from %llu to %llu.\n",
+      vacuum_er_log (VACUUM_ER_LOG_HEAP, "Update max MVCCID for page %d|%d from %llu to %llu.\n",
 		     PGBUF_PAGE_VPID_AS_ARGS (heap_page), (unsigned long long int) chain->max_mvccid,
 		     (unsigned long long int) mvccid);
       chain->max_mvccid = mvccid;
@@ -23559,7 +23558,7 @@ heap_page_rv_chain_update (THREAD_ENTRY * thread_p, PAGE_PTR heap_page, MVCCID m
 	case HEAP_PAGE_VACUUM_UNKNOWN:
 	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_ONCE);
 
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
+	  vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
 			 "Change heap page %d|%d, lsa=%lld|%d, status from %s to once.\n",
 			 PGBUF_PAGE_STATE_ARGS (heap_page),
 			 vacuum_status == HEAP_PAGE_VACUUM_NONE ? "none" : "unknown");
@@ -23567,7 +23566,7 @@ heap_page_rv_chain_update (THREAD_ENTRY * thread_p, PAGE_PTR heap_page, MVCCID m
 	case HEAP_PAGE_VACUUM_ONCE:
 	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_UNKNOWN);
 
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
+	  vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
 			 "Change heap page %d|%d, lsa=%lld|%d, status from once to unknown.\n",
 			 PGBUF_PAGE_STATE_ARGS (heap_page));
 	  break;
@@ -23619,7 +23618,7 @@ heap_page_set_vacuum_status_none (THREAD_ENTRY * thread_p, PAGE_PTR heap_page)
   /* Update vacuum status. */
   HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_NONE);
 
-  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP, "Changed vacuum status for page %d|%d from vacuum once to no vacuum.\n",
+  vacuum_er_log (VACUUM_ER_LOG_HEAP, "Changed vacuum status for page %d|%d from vacuum once to no vacuum.\n",
 		 PGBUF_PAGE_VPID_AS_ARGS (heap_page));
 }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -4568,9 +4568,8 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (pgbuf_ordered_fix (thread_p, &header_vpid, OLD_PAGE, PGBUF_LATCH_WRITE, &header_watcher) != NO_ERROR)
     {
       /* Give up. */
-      vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_HEAP,
-		     "VACUUM WARNING: Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
-		     page_vpid.pageid);
+      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
   assert (header_watcher.pgptr != NULL);
@@ -4580,9 +4579,8 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
       || heap_vpid_next (thread_p, hfid, *page_ptr, &next_vpid) != NO_ERROR)
     {
       /* Give up. */
-      vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_HEAP,
-		     "VACUUM WARNING: Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
-		     page_vpid.pageid);
+      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
 
@@ -4592,9 +4590,9 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
       if (pgbuf_ordered_fix (thread_p, &prev_vpid, OLD_PAGE, PGBUF_LATCH_WRITE, &prev_watcher) != NO_ERROR)
 	{
 	  /* Give up. */
-	  vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_HEAP,
-			 "VACUUM WARNING: Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
-			 page_vpid.pageid);
+	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 page_vpid.pageid);
 	  goto error;
 	}
     }
@@ -4605,9 +4603,9 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
       if (pgbuf_ordered_fix (thread_p, &next_vpid, OLD_PAGE, PGBUF_LATCH_WRITE, &next_watcher) != NO_ERROR)
 	{
 	  /* Give up. */
-	  vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_HEAP,
-			 "VACUUM WARNING: Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
-			 page_vpid.pageid);
+	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 page_vpid.pageid);
 	  goto error;
 	}
     }
@@ -4617,8 +4615,8 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (crt_watcher.page_was_unfixed && spage_number_of_records (crt_watcher.pgptr) > 1)
     {
       /* Current page has new data. It is no longer a candidate for removal. */
-      vacuum_er_log (VACUUM_ER_LOG_HEAP,
-		     "VACUUM: Candidate heap page %d|%d to remove was changed and has new data.\n", page_vpid.volid,
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP,
+		     "Candidate heap page %d|%d to remove was changed and has new data.\n", page_vpid.volid,
 		     page_vpid.pageid);
       goto error;
     }
@@ -4628,8 +4626,8 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
     {
       /* Even though we have fixed all required pages, somebody was doing a heap scan, and already reached our page. We 
        * cannot deallocate it. */
-      vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_WARNING,
-		     "VACUUM: Candidate heap page %d|%d to remove has waiters.\n", page_vpid.volid, page_vpid.pageid);
+      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+			     "Candidate heap page %d|%d to remove has waiters.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
 
@@ -4639,7 +4637,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (pgbuf_has_any_waiters (crt_watcher.pgptr))
     {
       assert (false);
-      vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_ERROR, "VACUUM: Unexpected page waiters \n");
+      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_HEAP, "Unexpected page waiters \n");
       goto error;
     }
   /* all good, we can deallocate the page */
@@ -4654,9 +4652,8 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (spage_get_record (thread_p, header_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID, &copy_recdes, COPY) != S_SUCCESS)
     {
       assert_release (false);
-      vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_HEAP,
-		     "VACUUM WARNING: Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
-		     page_vpid.pageid);
+      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
   memcpy (&heap_hdr, copy_recdes.data, sizeof (heap_hdr));
@@ -4695,9 +4692,8 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (spage_update (thread_p, header_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID, &update_recdes) != SP_SUCCESS)
     {
       assert_release (false);
-      vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_HEAP,
-		     "VACUUM WARNING: Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
-		     page_vpid.pageid);
+      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
   log_append_undoredo_data2 (thread_p, RVHF_STATS, &hfid->vfid, header_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID,
@@ -4715,9 +4711,9 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
 	  S_SUCCESS)
 	{
 	  assert_release (false);
-	  vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_HEAP,
-			 "VACUUM WARNING: Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
-			 page_vpid.pageid);
+	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 page_vpid.pageid);
 	  goto error;
 	}
       memcpy (&chain, copy_recdes.data, copy_recdes.length);
@@ -4727,9 +4723,9 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
       if (spage_update (thread_p, prev_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID, &update_recdes) != SP_SUCCESS)
 	{
 	  assert_release (false);
-	  vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_HEAP,
-			 "VACUUM WARNING: Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
-			 page_vpid.pageid);
+	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 page_vpid.pageid);
 	  goto error;
 	}
       log_append_undoredo_data2 (thread_p, RVHF_CHAIN, &hfid->vfid, prev_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID,
@@ -4745,9 +4741,9 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
 	  S_SUCCESS)
 	{
 	  assert_release (false);
-	  vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_HEAP,
-			 "VACUUM WARNING: Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
-			 page_vpid.pageid);
+	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 page_vpid.pageid);
 	  goto error;
 	}
       memcpy (&chain, copy_recdes.data, sizeof (chain));
@@ -4758,9 +4754,9 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
       if (spage_update (thread_p, next_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID, &update_recdes) != SP_SUCCESS)
 	{
 	  assert_release (false);
-	  vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_HEAP,
-			 "VACUUM WARNING: Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
-			 page_vpid.pageid);
+	  vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+				 "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
+				 page_vpid.pageid);
 	  goto error;
 	}
       log_append_undoredo_data2 (thread_p, RVHF_CHAIN, &hfid->vfid, next_watcher.pgptr, HEAP_HEADER_AND_CHAIN_SLOTID,
@@ -4774,9 +4770,8 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   if (file_dealloc (thread_p, &hfid->vfid, &page_vpid, FILE_HEAP) != NO_ERROR)
     {
       ASSERT_ERROR ();
-      vacuum_er_log (VACUUM_ER_LOG_WARNING | VACUUM_ER_LOG_HEAP,
-		     "VACUUM WARNING: Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid,
-		     page_vpid.pageid);
+      vacuum_er_log_warning (thread_p, VACUUM_ER_LOG_HEAP,
+			     "Could not remove candidate empty heap page %d|%d.\n", page_vpid.volid, page_vpid.pageid);
       goto error;
     }
 
@@ -4799,7 +4794,7 @@ heap_remove_page_on_vacuum (THREAD_ENTRY * thread_p, PAGE_PTR * page_ptr, HFID *
   pgbuf_ordered_unfix (thread_p, &header_watcher);
 
   /* Page removed successfully. */
-  vacuum_er_log (VACUUM_ER_LOG_HEAP, "VACUUM: Successfully remove heap page %d|%d.\n", page_vpid.volid,
+  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP, "Successfully remove heap page %d|%d.\n", page_vpid.volid,
 		 page_vpid.pageid);
   return true;
 
@@ -6116,7 +6111,7 @@ xheap_reclaim_addresses (THREAD_ENTRY * thread_p, const HFID * hfid)
 	    {
 	      goto exit_on_error;
 	    }
-	  vacuum_er_log (VACUUM_ER_LOG_HEAP, "VACUUM: Compactdb removed page %d|%d from heap file (%d, %d|%d).\n",
+	  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP, "Compactdb removed page %d|%d from heap file (%d, %d|%d).\n",
 			 vpid.volid, vpid.pageid, hfid->hpgid, hfid->vfid.volid, hfid->vfid.fileid);
 	}
       else
@@ -23476,16 +23471,16 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
       /* Change status to one vacuum. */
       assert (MVCC_ID_PRECEDES (chain->max_mvccid, mvccid));
       HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_ONCE);
-      vacuum_er_log (VACUUM_ER_LOG_HEAP,
-		     "VACUUM: Changed vacuum status for page %d|%d, lsa=%lld|%d from no vacuum to vacuum once.\n",
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP,
+		     "Changed vacuum status for page %d|%d, lsa=%lld|%d from no vacuum to vacuum once.\n",
 		     PGBUF_PAGE_STATE_ARGS (heap_page));
       break;
 
     case HEAP_PAGE_VACUUM_ONCE:
       /* Change status to unknown number of vacuums. */
       HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_UNKNOWN);
-      vacuum_er_log (VACUUM_ER_LOG_HEAP,
-		     "VACUUM: Changed vacuum status for page %d|%d, lsa=%lld|%d from vacuum once to unknown.\n",
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP,
+		     "Changed vacuum status for page %d|%d, lsa=%lld|%d from vacuum once to unknown.\n",
 		     PGBUF_PAGE_STATE_ARGS (heap_page));
       break;
 
@@ -23495,14 +23490,14 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
 	{
 	  /* Now page must be vacuumed once, due to new MVCC op. */
 	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_ONCE);
-	  vacuum_er_log (VACUUM_ER_LOG_HEAP,
-			 "VACUUM: Changed vacuum status for page %d|%d, lsa=%lld|%d from unknown to vacuum once.\n ",
+	  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP,
+			 "Changed vacuum status for page %d|%d, lsa=%lld|%d from unknown to vacuum once.\n ",
 			 PGBUF_PAGE_STATE_ARGS (heap_page));
 	}
       else
 	{
 	  /* Status remains the same. Number of vacuums needed still cannot be predicted. */
-	  vacuum_er_log (VACUUM_ER_LOG_HEAP, "VACUUM: Vacuum status for page %d|%d, %lld|%d remains unknown.\n ",
+	  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP, "Vacuum status for page %d|%d, %lld|%d remains unknown.\n ",
 			 PGBUF_PAGE_STATE_ARGS (heap_page));
 	}
       break;
@@ -23514,7 +23509,7 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
   /* Update max_mvccid. */
   if (MVCC_ID_PRECEDES (chain->max_mvccid, mvccid))
     {
-      vacuum_er_log (VACUUM_ER_LOG_HEAP, "VACUUM: Update max MVCCID for page %d|%d from %llu to %llu.\n",
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP, "Update max MVCCID for page %d|%d from %llu to %llu.\n",
 		     PGBUF_PAGE_VPID_AS_ARGS (heap_page), (unsigned long long int) chain->max_mvccid,
 		     (unsigned long long int) mvccid);
       chain->max_mvccid = mvccid;
@@ -23564,16 +23559,16 @@ heap_page_rv_chain_update (THREAD_ENTRY * thread_p, PAGE_PTR heap_page, MVCCID m
 	case HEAP_PAGE_VACUUM_UNKNOWN:
 	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_ONCE);
 
-	  vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
-			 "VACUUM: Change heap page %d|%d, lsa=%lld|%d, status from %s to once.\n",
+	  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
+			 "Change heap page %d|%d, lsa=%lld|%d, status from %s to once.\n",
 			 PGBUF_PAGE_STATE_ARGS (heap_page),
 			 vacuum_status == HEAP_PAGE_VACUUM_NONE ? "none" : "unknown");
 	  break;
 	case HEAP_PAGE_VACUUM_ONCE:
 	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_UNKNOWN);
 
-	  vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
-			 "VACUUM: Change heap page %d|%d, lsa=%lld|%d, status from once to unknown.\n",
+	  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
+			 "Change heap page %d|%d, lsa=%lld|%d, status from once to unknown.\n",
 			 PGBUF_PAGE_STATE_ARGS (heap_page));
 	  break;
 	}
@@ -23624,7 +23619,7 @@ heap_page_set_vacuum_status_none (THREAD_ENTRY * thread_p, PAGE_PTR heap_page)
   /* Update vacuum status. */
   HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_NONE);
 
-  vacuum_er_log (VACUUM_ER_LOG_HEAP, "VACUUM: Changed vacuum status for page %d|%d from vacuum once to no vacuum.\n",
+  vacuum_er_log (thread_p, VACUUM_ER_LOG_HEAP, "Changed vacuum status for page %d|%d from vacuum once to no vacuum.\n",
 		 PGBUF_PAGE_VPID_AS_ARGS (heap_page));
 }
 

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -4862,8 +4862,8 @@ spage_vacuum_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slotid, bo
   if (slot_p->record_type == REC_MARKDELETED || slot_p->record_type == REC_DELETED_WILL_REUSE)
     {
       /* Vacuum error log */
-      vacuum_er_log (VACUUM_ER_LOG_ERROR, "VACUUM: Object (%d, %d, %d) was already vacuumed",
-		     pgbuf_get_vpid_ptr (page_p)->volid, pgbuf_get_vpid_ptr (page_p)->pageid, slotid);
+      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_ERROR, "Object (%d, %d, %d) was already vacuumed",
+			   pgbuf_get_vpid_ptr (page_p)->volid, pgbuf_get_vpid_ptr (page_p)->pageid, slotid);
     }
 
   /* Slot is deleted */

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -4862,7 +4862,7 @@ spage_vacuum_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slotid, bo
   if (slot_p->record_type == REC_MARKDELETED || slot_p->record_type == REC_DELETED_WILL_REUSE)
     {
       /* Vacuum error log */
-      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_ERROR, "Object (%d, %d, %d) was already vacuumed",
+      vacuum_er_log_error (VACUUM_ER_LOG_ERROR, "Object (%d, %d, %d) was already vacuumed",
 			   pgbuf_get_vpid_ptr (page_p)->volid, pgbuf_get_vpid_ptr (page_p)->pageid, slotid);
     }
 

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -2018,6 +2018,18 @@ extern char log_Name_removed_archive[];
 #define LOG_RV_RECORD_UPDPARTIAL_ALIGNED_SIZE(new_data_size) \
   (DB_ALIGN (new_data_size + OR_SHORT_SIZE + 2 * OR_BYTE_SIZE, INT_ALIGNMENT))
 
+/* logging */
+#if defined (SA_MODE)
+#define LOG_THREAD_TRAN_MSG "%s"
+#define LOG_THREAD_TRAN_ARGS(thread_p) "(SA_MODE)"
+#else	/* !SA_MODE */	     /* SERVER_MODE */
+#define LOG_THREAD_TRAN_MSG "(thr=%d, trid=%d)"
+#define LOG_THREAD_TRAN_ARGS(thread_p) \
+  THREAD_GET_CURRENT_ENTRY_INDEX (thread_p), \
+  VACUUM_IS_THREAD_VACUUM(thread_p) && thread_p->vacuum_worker != NULL ? \
+  VACUUM_GET_WORKER_TDES (thread_p)->trid : LOG_FIND_CURRENT_TDES (thread_p)->trid
+#endif /* SERVER_MODE */
+
 extern int logpb_initialize_pool (THREAD_ENTRY * thread_p);
 extern void logpb_finalize_pool (THREAD_ENTRY * thread_p);
 extern bool logpb_is_pool_initialized (void);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -2022,7 +2022,7 @@ extern char log_Name_removed_archive[];
 #if defined (SA_MODE)
 #define LOG_THREAD_TRAN_MSG "%s"
 #define LOG_THREAD_TRAN_ARGS(thread_p) "(SA_MODE)"
-#else	/* !SA_MODE */	     /* SERVER_MODE */
+#else	/* !SA_MODE */	       /* SERVER_MODE */
 #define LOG_THREAD_TRAN_MSG "(thr=%d, trid=%d)"
 #define LOG_THREAD_TRAN_ARGS(thread_p) \
   THREAD_GET_CURRENT_ENTRY_INDEX (thread_p), \

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -2026,7 +2026,7 @@ extern char log_Name_removed_archive[];
 #define LOG_THREAD_TRAN_MSG "(thr=%d, trid=%d)"
 #define LOG_THREAD_TRAN_ARGS(thread_p) \
   THREAD_GET_CURRENT_ENTRY_INDEX (thread_p), \
-  VACUUM_IS_THREAD_VACUUM(thread_p) && thread_p->vacuum_worker != NULL ? \
+  VACUUM_IS_THREAD_VACUUM (thread_p) && (thread_p)->vacuum_worker != NULL ? \
   VACUUM_GET_WORKER_TDES (thread_p)->trid : LOG_FIND_CURRENT_TDES (thread_p)->trid
 #endif /* SERVER_MODE */
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3552,7 +3552,7 @@ log_sysop_start (THREAD_ENTRY * thread_p)
 
       vacuum_er_log (VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_WORKER,
 		     "Start system operation. Current worker tdes: tdes->trid=%d, tdes->topops.last=%d, "
-		     "tdes->tail_lsa=(%lld, %d). Worker state=%d.\n", tdes->trid, tdes->topops.last,
+		     "tdes->tail_lsa=(%lld, %d). Worker state=%d.", tdes->trid, tdes->topops.last,
 		     (long long int) tdes->tail_lsa.pageid, (int) tdes->tail_lsa.offset,
 		     VACUUM_GET_WORKER_STATE (thread_p));
 
@@ -3770,7 +3770,7 @@ log_sysop_end_final (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 	  vacuum_er_log (VACUUM_ER_LOG_TOPOPS,
 			 "Ended all top operations. Tdes: tdes->trid=%d tdes->head_lsa=(%lld, %d), "
 			 "tdes->tail_lsa=(%lld, %d), tdes->undo_nxlsa=(%lld, %d), "
-			 "tdes->tail_topresult_lsa=(%lld, %d). Worker state=%d.\n", tdes->trid,
+			 "tdes->tail_topresult_lsa=(%lld, %d). Worker state=%d.", tdes->trid,
 			 (long long int) tdes->head_lsa.pageid, (int) tdes->head_lsa.offset,
 			 (long long int) tdes->tail_lsa.pageid, (int) tdes->tail_lsa.offset,
 			 (long long int) tdes->undo_nxlsa.pageid, (int) tdes->undo_nxlsa.offset,

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3550,8 +3550,8 @@ log_sysop_start (THREAD_ENTRY * thread_p)
       assert (VACUUM_WORKER_STATE_IS_EXECUTE (thread_p) || VACUUM_WORKER_STATE_IS_TOPOP (thread_p)
 	      || VACUUM_WORKER_STATE_IS_RECOVERY (thread_p));
 
-      vacuum_er_log (VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_WORKER,
-		     "VACUUM: Start system operation. Current worker tdes: tdes->trid=%d, tdes->topops.last=%d, "
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_WORKER,
+		     "Start system operation. Current worker tdes: tdes->trid=%d, tdes->topops.last=%d, "
 		     "tdes->tail_lsa=(%lld, %d). Worker state=%d.\n", tdes->trid, tdes->topops.last,
 		     (long long int) tdes->tail_lsa.pageid, (int) tdes->tail_lsa.offset,
 		     VACUUM_GET_WORKER_STATE (thread_p));
@@ -3767,8 +3767,8 @@ log_sysop_end_final (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 	      VACUUM_SET_WORKER_STATE (thread_p, VACUUM_WORKER_STATE_RECOVERY);
 	    }
 
-	  vacuum_er_log (VACUUM_ER_LOG_TOPOPS,
-			 "VACUUM: Ended all top operations. Tdes: tdes->trid=%d tdes->head_lsa=(%lld, %d), "
+	  vacuum_er_log (thread_p, VACUUM_ER_LOG_TOPOPS,
+			 "Ended all top operations. Tdes: tdes->trid=%d tdes->head_lsa=(%lld, %d), "
 			 "tdes->tail_lsa=(%lld, %d), tdes->undo_nxlsa=(%lld, %d), "
 			 "tdes->tail_topresult_lsa=(%lld, %d). Worker state=%d.\n", tdes->trid,
 			 (long long int) tdes->head_lsa.pageid, (int) tdes->head_lsa.offset,

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3550,7 +3550,7 @@ log_sysop_start (THREAD_ENTRY * thread_p)
       assert (VACUUM_WORKER_STATE_IS_EXECUTE (thread_p) || VACUUM_WORKER_STATE_IS_TOPOP (thread_p)
 	      || VACUUM_WORKER_STATE_IS_RECOVERY (thread_p));
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_WORKER,
+      vacuum_er_log (VACUUM_ER_LOG_TOPOPS | VACUUM_ER_LOG_WORKER,
 		     "Start system operation. Current worker tdes: tdes->trid=%d, tdes->topops.last=%d, "
 		     "tdes->tail_lsa=(%lld, %d). Worker state=%d.\n", tdes->trid, tdes->topops.last,
 		     (long long int) tdes->tail_lsa.pageid, (int) tdes->tail_lsa.offset,
@@ -3767,7 +3767,7 @@ log_sysop_end_final (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 	      VACUUM_SET_WORKER_STATE (thread_p, VACUUM_WORKER_STATE_RECOVERY);
 	    }
 
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_TOPOPS,
+	  vacuum_er_log (VACUUM_ER_LOG_TOPOPS,
 			 "Ended all top operations. Tdes: tdes->trid=%d tdes->head_lsa=(%lld, %d), "
 			 "tdes->tail_lsa=(%lld, %d), tdes->undo_nxlsa=(%lld, %d), "
 			 "tdes->tail_topresult_lsa=(%lld, %d). Worker state=%d.\n", tdes->trid,

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1841,7 +1841,7 @@ logpb_read_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_AC
 #if defined (SERVER_MODE)
 	  if (thread_p != NULL && thread_p->type == TT_VACUUM_MASTER)
 	    {
-	      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_MASTER | VACUUM_ER_LOG_ARCHIVES,
+	      vacuum_er_log_error (VACUUM_ER_LOG_MASTER | VACUUM_ER_LOG_ARCHIVES,
 				   "Failed to fetch page %lld from archives.", pageid);
 	    }
 #endif /* SERVER_MODE */
@@ -1879,7 +1879,7 @@ logpb_read_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_AC
 #if defined (SERVER_MODE)
 		      if (thread_p != NULL && thread_p->type == TT_VACUUM_MASTER)
 			{
-			  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_MASTER | VACUUM_ER_LOG_ARCHIVES,
+			  vacuum_er_log_error (VACUUM_ER_LOG_MASTER | VACUUM_ER_LOG_ARCHIVES,
 					       "Failed to fetch page %lld from archives.", pageid);
 			}
 #endif /* SERVER_MODE */
@@ -3683,7 +3683,7 @@ prior_lsa_next_record_internal (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * node, 
       /* Save previous mvcc operation log lsa to vacuum info */
       LSA_COPY (&vacuum_info->prev_mvcc_op_log_lsa, &log_Gl.hdr.mvcc_op_log_lsa);
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_LOGGING,
+      vacuum_er_log (VACUUM_ER_LOG_LOGGING,
 		     "log mvcc op at (%lld, %d) and create link with log_lsa(%lld, %d)\n",
 		     LSA_AS_ARGS (&node->start_lsa), LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa));
 
@@ -6913,11 +6913,11 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	{
 	  last_arv_num_to_delete = MIN (last_arv_num_to_delete, log_Gl.hdr.last_arv_num_for_syscrashes);
 	}
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_ARCHIVES, "First log pageid in vacuum data is %lld", vacuum_first_pageid);
+      vacuum_er_log (VACUUM_ER_LOG_ARCHIVES, "First log pageid in vacuum data is %lld", vacuum_first_pageid);
       if (vacuum_first_pageid != NULL_PAGEID && logpb_is_page_in_archive (vacuum_first_pageid))
 	{
 	  min_arv_required_for_vacuum = logpb_get_archive_number (thread_p, vacuum_first_pageid);
-	  vacuum_er_log (thread_p, VACUUM_ER_LOG_ARCHIVES, "First archive number used for vacuum is %d",
+	  vacuum_er_log (VACUUM_ER_LOG_ARCHIVES, "First archive number used for vacuum is %d",
 			 min_arv_required_for_vacuum);
 	  if (min_arv_required_for_vacuum >= 0)
 	    {
@@ -6943,7 +6943,7 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	  logpb_flush_header (thread_p);	/* to get rid of archives */
 	}
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_ARCHIVES, "last_arv_num_to_delete is %d", last_arv_num_to_delete);
+      vacuum_er_log (VACUUM_ER_LOG_ARCHIVES, "last_arv_num_to_delete is %d", last_arv_num_to_delete);
     }
 
   LOG_CS_EXIT (thread_p);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1377,7 +1377,7 @@ logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const cha
   LSA_SET_NULL (&loghdr->eof_lsa);
   LSA_SET_NULL (&loghdr->smallest_lsa_at_last_chkpt);
 
-  vacuum_reset_log_header_cache ();
+  vacuum_reset_log_header_cache (thread_p);
 
   return NO_ERROR;
 }
@@ -1841,8 +1841,8 @@ logpb_read_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_AC
 #if defined (SERVER_MODE)
 	  if (thread_p != NULL && thread_p->type == TT_VACUUM_MASTER)
 	    {
-	      vacuum_er_log (VACUUM_ER_LOG_ERROR | VACUUM_ER_LOG_MASTER | VACUUM_ER_LOG_ARCHIVES,
-			     "VACUUM ERROR: Failed to fetch page %lld from archives.", pageid);
+	      vacuum_er_log_error (thread_p, VACUUM_ER_LOG_MASTER | VACUUM_ER_LOG_ARCHIVES,
+				   "Failed to fetch page %lld from archives.", pageid);
 	    }
 #endif /* SERVER_MODE */
 	  goto error;
@@ -1879,8 +1879,8 @@ logpb_read_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_AC
 #if defined (SERVER_MODE)
 		      if (thread_p != NULL && thread_p->type == TT_VACUUM_MASTER)
 			{
-			  vacuum_er_log (VACUUM_ER_LOG_ERROR | VACUUM_ER_LOG_MASTER | VACUUM_ER_LOG_ARCHIVES,
-					 "VACUUM ERROR: Failed to fetch page %lld from archives.", pageid);
+			  vacuum_er_log_error (thread_p, VACUUM_ER_LOG_MASTER | VACUUM_ER_LOG_ARCHIVES,
+					       "Failed to fetch page %lld from archives.", pageid);
 			}
 #endif /* SERVER_MODE */
 		      goto error;
@@ -3683,11 +3683,9 @@ prior_lsa_next_record_internal (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * node, 
       /* Save previous mvcc operation log lsa to vacuum info */
       LSA_COPY (&vacuum_info->prev_mvcc_op_log_lsa, &log_Gl.hdr.mvcc_op_log_lsa);
 
-      vacuum_er_log (VACUUM_ER_LOG_LOGGING,
-		     "VACUUM: thread(%d): log mvcc op at (%lld, %d) and create link with log_lsa(%lld, %d)\n",
-		     thread_get_current_entry_index (), (long long int) node->start_lsa.pageid,
-		     (int) node->start_lsa.offset, (long long int) log_Gl.hdr.mvcc_op_log_lsa.pageid,
-		     (int) log_Gl.hdr.mvcc_op_log_lsa.offset);
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_LOGGING,
+		     "log mvcc op at (%lld, %d) and create link with log_lsa(%lld, %d)\n",
+		     LSA_AS_ARGS (&node->start_lsa), LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa));
 
       /* Check if the block of log data is changed */
       if (!LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa)
@@ -6915,11 +6913,11 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	{
 	  last_arv_num_to_delete = MIN (last_arv_num_to_delete, log_Gl.hdr.last_arv_num_for_syscrashes);
 	}
-      vacuum_er_log (VACUUM_ER_LOG_ARCHIVES, "VACUUM: First log pageid in vacuum data is %lld", vacuum_first_pageid);
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_ARCHIVES, "First log pageid in vacuum data is %lld", vacuum_first_pageid);
       if (vacuum_first_pageid != NULL_PAGEID && logpb_is_page_in_archive (vacuum_first_pageid))
 	{
 	  min_arv_required_for_vacuum = logpb_get_archive_number (thread_p, vacuum_first_pageid);
-	  vacuum_er_log (VACUUM_ER_LOG_ARCHIVES, "VACUUM: First archive number used for vacuum is %d",
+	  vacuum_er_log (thread_p, VACUUM_ER_LOG_ARCHIVES, "First archive number used for vacuum is %d",
 			 min_arv_required_for_vacuum);
 	  if (min_arv_required_for_vacuum >= 0)
 	    {
@@ -6945,7 +6943,7 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	  logpb_flush_header (thread_p);	/* to get rid of archives */
 	}
 
-      vacuum_er_log (VACUUM_ER_LOG_ARCHIVES, "VACUUM: last_arv_num_to_delete is %d", last_arv_num_to_delete);
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_ARCHIVES, "last_arv_num_to_delete is %d", last_arv_num_to_delete);
     }
 
   LOG_CS_EXIT (thread_p);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3684,7 +3684,7 @@ prior_lsa_next_record_internal (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * node, 
       LSA_COPY (&vacuum_info->prev_mvcc_op_log_lsa, &log_Gl.hdr.mvcc_op_log_lsa);
 
       vacuum_er_log (VACUUM_ER_LOG_LOGGING,
-		     "log mvcc op at (%lld, %d) and create link with log_lsa(%lld, %d)\n",
+		     "log mvcc op at (%lld, %d) and create link with log_lsa(%lld, %d)",
 		     LSA_AS_ARGS (&node->start_lsa), LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa));
 
       /* Check if the block of log data is changed */

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -178,7 +178,7 @@ log_rv_undo_record (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_PAGE * log_p
       /* Convert thread to a vacuum worker. */
       VACUUM_CONVERT_THREAD_TO_VACUUM (thread_p, vacuum_rv_get_worker_by_trid (thread_p, tdes->trid), save_thread_type);
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
 		     "Log undo (%lld, %d), rcvindex=%d for tdes: tdes->trid=%d.",
 		     (long long int) rcv_undo_lsa->pageid, (int) rcv_undo_lsa->offset, rcvindex, tdes->trid);
     }
@@ -875,7 +875,7 @@ log_rv_analysis_undo_redo (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_l
 
   if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
     {
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "Found undo_redo record. tdes->trid=%d.",
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "Found undo_redo record. tdes->trid=%d.",
 		     tdes->trid);
     }
 
@@ -958,7 +958,7 @@ log_rv_analysis_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_ls
 
   if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
     {
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "Found postpone record. tdes->trid=%d.",
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "Found postpone record. tdes->trid=%d.",
 		     tdes->trid);
     }
 
@@ -1070,7 +1070,7 @@ log_rv_analysis_run_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * lo
 
   if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
     {
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
 		     "Found postpone record. tdes->trid=%d, tdes->state=%d, ref_lsa=(%lld, %d).", tdes->trid,
 		     tdes->state, (long long int) run_posp->ref_lsa.pageid, (int) run_posp->ref_lsa.offset);
     }
@@ -1239,7 +1239,7 @@ log_rv_analysis_sysop_start_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_
 
   if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
     {
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
 		     "Found commit_topope_with_postpone. tdes->trid=%d. ", tdes->trid);
     }
 
@@ -1497,8 +1497,7 @@ log_rv_analysis_sysop_end (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_l
 
   if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
     {
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "Found commit sysop. tdes->trid=%d.",
-		     tdes->trid);
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "Found commit sysop. tdes->trid=%d.", tdes->trid);
     }
 
   LSA_COPY (&tdes->tail_lsa, log_lsa);
@@ -4053,7 +4052,7 @@ log_recovery_finish_all_postpone (THREAD_ENTRY * thread_p)
       VACUUM_CONVERT_THREAD_TO_VACUUM (thread_p, worker, save_thread_type);
       tdes = worker->tdes;
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
 		     "Finish postpone for tdes: tdes->trid=%d, tdes->state=%d, tdes->topops.last=%d.",
 		     tdes->trid, tdes->state, tdes->topops.last);
 
@@ -4108,7 +4107,7 @@ log_recovery_abort_all_atomic_sysops (THREAD_ENTRY * thread_p)
       VACUUM_CONVERT_THREAD_TO_VACUUM (thread_p, worker, save_thread_type);
       tdes = worker->tdes;
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
 		     "Finish postpone for tdes: tdes->trid=%d, tdes->state=%d, tdes->topops.last=%d.",
 		     tdes->trid, tdes->state, tdes->topops.last);
 
@@ -4665,7 +4664,7 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 
 		      if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
 			{
-			  vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+			  vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
 					 "Update undo_nxlsa=(%lld, %d) for tdes->trid=%d.",
 					 (long long int) tdes->undo_nxlsa.pageid, (int) tdes->undo_nxlsa.offset,
 					 tdes->trid);

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -178,8 +178,8 @@ log_rv_undo_record (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_PAGE * log_p
       /* Convert thread to a vacuum worker. */
       VACUUM_CONVERT_THREAD_TO_VACUUM (thread_p, vacuum_rv_get_worker_by_trid (thread_p, tdes->trid), save_thread_type);
 
-      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
-		     "VACUUM: Log undo (%lld, %d), rcvindex=%d for tdes: tdes->trid=%d.",
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+		     "Log undo (%lld, %d), rcvindex=%d for tdes: tdes->trid=%d.",
 		     (long long int) rcv_undo_lsa->pageid, (int) rcv_undo_lsa->offset, rcvindex, tdes->trid);
     }
   else
@@ -875,7 +875,7 @@ log_rv_analysis_undo_redo (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_l
 
   if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
     {
-      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "VACUUM: Found undo_redo record. tdes->trid=%d.",
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "Found undo_redo record. tdes->trid=%d.",
 		     tdes->trid);
     }
 
@@ -958,7 +958,7 @@ log_rv_analysis_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_ls
 
   if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
     {
-      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "VACUUM: Found postpone record. tdes->trid=%d.",
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "Found postpone record. tdes->trid=%d.",
 		     tdes->trid);
     }
 
@@ -1070,8 +1070,8 @@ log_rv_analysis_run_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * lo
 
   if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
     {
-      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
-		     "VACUUM: Found postpone record. tdes->trid=%d, tdes->state=%d, ref_lsa=(%lld, %d).", tdes->trid,
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+		     "Found postpone record. tdes->trid=%d, tdes->state=%d, ref_lsa=(%lld, %d).", tdes->trid,
 		     tdes->state, (long long int) run_posp->ref_lsa.pageid, (int) run_posp->ref_lsa.offset);
     }
 
@@ -1239,8 +1239,8 @@ log_rv_analysis_sysop_start_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_
 
   if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
     {
-      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
-		     "VACUUM: Found commit_topope_with_postpone. tdes->trid=%d. ", tdes->trid);
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+		     "Found commit_topope_with_postpone. tdes->trid=%d. ", tdes->trid);
     }
 
   LSA_COPY (&tdes->tail_lsa, log_lsa);
@@ -1497,7 +1497,7 @@ log_rv_analysis_sysop_end (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_l
 
   if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
     {
-      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "VACUUM: Found commit sysop. tdes->trid=%d.",
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS, "Found commit sysop. tdes->trid=%d.",
 		     tdes->trid);
     }
 
@@ -3147,7 +3147,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 		  LOG_LSA null_lsa = LSA_INITIALIZER;
 
 		  /* Reset log header MVCC info */
-		  vacuum_reset_log_header_cache ();
+		  vacuum_reset_log_header_cache (thread_p);
 
 		  /* Reset vacuum recover LSA */
 		  vacuum_notify_server_crashed (&null_lsa);
@@ -4053,8 +4053,8 @@ log_recovery_finish_all_postpone (THREAD_ENTRY * thread_p)
       VACUUM_CONVERT_THREAD_TO_VACUUM (thread_p, worker, save_thread_type);
       tdes = worker->tdes;
 
-      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
-		     "VACUUM: Finish postpone for tdes: tdes->trid=%d, tdes->state=%d, tdes->topops.last=%d.",
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+		     "Finish postpone for tdes: tdes->trid=%d, tdes->state=%d, tdes->topops.last=%d.",
 		     tdes->trid, tdes->state, tdes->topops.last);
 
       log_recovery_finish_postpone (thread_p, tdes);
@@ -4108,8 +4108,8 @@ log_recovery_abort_all_atomic_sysops (THREAD_ENTRY * thread_p)
       VACUUM_CONVERT_THREAD_TO_VACUUM (thread_p, worker, save_thread_type);
       tdes = worker->tdes;
 
-      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
-		     "VACUUM: Finish postpone for tdes: tdes->trid=%d, tdes->state=%d, tdes->topops.last=%d.",
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+		     "Finish postpone for tdes: tdes->trid=%d, tdes->state=%d, tdes->topops.last=%d.",
 		     tdes->trid, tdes->state, tdes->topops.last);
 
       log_recovery_abort_atomic_sysop (thread_p, tdes);
@@ -4665,8 +4665,8 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 
 		      if (LOG_IS_VACUUM_THREAD_TRANID (tdes->trid))
 			{
-			  vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
-					 "VACUUM: Update undo_nxlsa=(%lld, %d) for tdes->trid=%d.",
+			  vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+					 "Update undo_nxlsa=(%lld, %d) for tdes->trid=%d.",
 					 (long long int) tdes->undo_nxlsa.pageid, (int) tdes->undo_nxlsa.offset,
 					 tdes->trid);
 			}

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1359,7 +1359,7 @@ logtb_rv_find_allocate_tran_index (THREAD_ENTRY * thread_p, TRANID trid, const L
       /* Set worker state to recovery. */
       worker->state = VACUUM_WORKER_STATE_RECOVERY;
 
-      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
 		     "Log entry (%lld, %d) belongs to vacuum worker "
 		     "tdes. tdes->trid=%d, tdes->tail_lsa=(%lld, %d). ", (long long int) log_lsa->pageid,
 		     (int) log_lsa->offset, worker->tdes->trid, (long long int) worker->tdes->tail_lsa.pageid,

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1359,8 +1359,8 @@ logtb_rv_find_allocate_tran_index (THREAD_ENTRY * thread_p, TRANID trid, const L
       /* Set worker state to recovery. */
       worker->state = VACUUM_WORKER_STATE_RECOVERY;
 
-      vacuum_er_log (VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
-		     "VACUUM: Log entry (%lld, %d) belongs to vacuum worker "
+      vacuum_er_log (thread_p, VACUUM_ER_LOG_RECOVERY | VACUUM_ER_LOG_TOPOPS,
+		     "Log entry (%lld, %d) belongs to vacuum worker "
 		     "tdes. tdes->trid=%d, tdes->tail_lsa=(%lld, %d). ", (long long int) log_lsa->pageid,
 		     (int) log_lsa->offset, worker->tdes->trid, (long long int) worker->tdes->tail_lsa.pageid,
 		     (int) worker->tdes->tail_lsa.offset);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20692

The patch does not really have anything to do with the issue, other than that some of the extended logging will be used for its investigation.

  1. Log transaction ID insteand of transaction index. Much easier to identify the culprit of a change and match it with logdump transactions.
  2. Vacuum processing log block logs the LSA's of vacuum tasks. Also log thread/trid to identify the worker.
  3. Refactoring of vacuum_er_log to make it easier to be used in the future.