### PR TITLE
[CBRD-21157] Fix to retry victimization in single threaded mode after victim flush was run.

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -15355,7 +15355,7 @@ pgbuf_lfcq_get_victim_from_shared_lru (THREAD_ENTRY * thread_p, bool multi_threa
   if (victim == NULL && multi_threaded == false && lru_list->count_vict_cand > 0)
     {
       victim = pgbuf_get_victim_from_lru_list (thread_p, lru_idx);
-      PERF (victim != NULL ? PSTAT_PB_VICTIM_SHARED_LRU_SUCCESS : PSTAT_PB_VICTIM_SHARED_LRU_FAIL);      
+      PERF (victim != NULL ? PSTAT_PB_VICTIM_SHARED_LRU_SUCCESS : PSTAT_PB_VICTIM_SHARED_LRU_FAIL);
     }
 
   if ((multi_threaded || victim != NULL) && lru_list->count_vict_cand > 0)

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -15380,6 +15380,13 @@ pgbuf_lfcq_get_victim_from_shared_lru (THREAD_ENTRY * thread_p, bool multi_threa
   victim = pgbuf_get_victim_from_lru_list (thread_p, lru_idx);
   PERF (victim != NULL ? PSTAT_PB_VICTIM_SHARED_LRU_SUCCESS : PSTAT_PB_VICTIM_SHARED_LRU_FAIL);
 
+  /* no victim found in first step, but flush thread ran and candidates can be found, try again */
+  if (victim == NULL && multi_threaded == false && lru_list->count_vict_cand > 0)
+    {
+      victim = pgbuf_get_victim_from_lru_list (thread_p, lru_idx);
+      PERF (victim != NULL ? PSTAT_PB_VICTIM_SHARED_LRU_SUCCESS : PSTAT_PB_VICTIM_SHARED_LRU_FAIL);      
+    }
+
   if ((multi_threaded || victim != NULL) && lru_list->count_vict_cand > 0)
     {
       /* add lru list back to queue */

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -3117,6 +3117,9 @@ pgbuf_get_victim_candidates_from_lru (THREAD_ENTRY * thread_p, int check_count, 
   victim_cand_count = 0;
   for (lru_idx = 0; lru_idx < PGBUF_TOTAL_LRU_COUNT; lru_idx++)
     {
+#if defined (SA_MODE)
+      int candidates_this_lru = victim_cand_count;	  
+#endif
       victim_flush_priority_this_lru = pgbuf_Pool.quota.lru_victim_flush_priority_per_lru[lru_idx];
       if (victim_flush_priority_this_lru <= 0)
 	{
@@ -3158,6 +3161,20 @@ pgbuf_get_victim_candidates_from_lru (THREAD_ENTRY * thread_p, int check_count, 
 #endif /* SERVER_MODE */
 	}
       pthread_mutex_unlock (&pgbuf_Pool.buf_LRU_list[lru_idx].mutex);
+
+#if defined (SA_MODE)
+      if ((pgbuf_Pool.buf_LRU_list[lru_idx].flags & PGBUF_LRU_VICTIM_LFCQ_FLAG) == 0
+	  && pgbuf_Pool.buf_LRU_list[lru_idx].count_vict_cand > 0)
+	{
+	  /* TODO: temporary investigation code */
+	  PGBUF_ABORT_RELEASE ();
+	}
+      /* we found no dirty pages to flush, make sure the LRU is in victimize queue */
+      if (candidates_this_lru == victim_cand_count)
+	{
+	  pgbuf_lfcq_add_lru_with_victims (&pgbuf_Pool.buf_LRU_list[lru_idx]);
+	}
+#endif
     }
 
   er_log_debug (ARG_FILE_LINE,
@@ -8530,7 +8547,7 @@ pgbuf_get_victim_from_lru_list (THREAD_ENTRY * thread_p, const int lru_idx)
 
   /* we need more victims */
   pgbuf_wakeup_flush_thread (thread_p);
-
+  
   /* failed finding victim in single-threaded, although the number of victim candidates is positive? impossible!
    * note: not really impossible. the thread may have the victimizable fixed. but bufptr_victimizable must not be
    * NULL. */
@@ -15197,6 +15214,13 @@ pgbuf_lfcq_add_lru_with_victims (PGBUF_LRU_LIST * lru_list)
   if (old_flags & PGBUF_LRU_VICTIM_LFCQ_FLAG)
     {
       /* already added. */
+#if defined (SA_MODE)
+      /* TODO: temporary investigation code */
+      if (lru_list->count_vict_cand > 0)
+	{
+	  PGBUF_ABORT_RELEASE ();
+	}
+#endif
       return false;
     }
 
@@ -15220,6 +15244,10 @@ pgbuf_lfcq_add_lru_with_victims (PGBUF_LRU_LIST * lru_list)
 	      return true;
 	    }
 	}
+#if defined (SA_MODE)
+      /* TODO: temporary investigation code */
+      PGBUF_ABORT_RELEASE ();
+#endif
       /* clear the flag */
       lru_list->flags &= ~PGBUF_LRU_VICTIM_LFCQ_FLAG;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21157