### PR TITLE
[CBRD-21176] fixes catalog_Max_space_lock leak

### DIFF
--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -815,6 +815,7 @@ catalog_find_optimal_page (THREAD_ENTRY * thread_p, int size, VPID * page_id_p)
   if (page_p == NULL)
     {
       ASSERT_ERROR ();
+      pthread_mutex_unlock (&catalog_Max_space_lock);
       return NULL;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21176

server hung due to mutex leak