### PR TITLE
[CBRD-21089] fixes not to mount temp volumes during bootstrapping

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1183,7 +1183,12 @@ boot_find_rest_volumes (THREAD_ENTRY * thread_p, BO_RESTART_ARG * r_args, VOLID 
       return error_code;
     }
 
+#if 0
+  /* We don't want to mount temp vols during bootstrapping,
+   * since temp vols might be inaccessible for a crash case and will be removed soon.
+   */
   boot_find_rest_temp_volumes (thread_p, volid, fun, args, false, true);
+#endif
 
   return error_code;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21089

TBH, I don't figure out how it happened. To mount temp volumes is useless and risky for unlucky cases. A corrupted temp volumes might be inaccessible and even more important thing is they will be removed soon. 
