### PR TITLE
[CBRD-21190] locator_lock_and_get_object_with_evaluation: use latch write

### DIFF
--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -664,8 +664,7 @@ extern void heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * c
 				   int old_chn);
 extern int heap_prepare_object_page (THREAD_ENTRY * thread_p, const OID * oid, PGBUF_WATCHER * page_watcher_p,
 				     PGBUF_LATCH_MODE latch_mode);
-extern SCAN_CODE heap_prepare_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context,
-					   PGBUF_LATCH_MODE latch_mode, bool is_heap_scan,
+extern SCAN_CODE heap_prepare_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, bool is_heap_scan,
 					   NON_EXISTENT_HANDLING non_ex_handling_type);
 extern SCAN_CODE heap_get_record_data_when_all_ready (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context);
 extern SCAN_CODE heap_get_visible_version_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context,

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -12985,7 +12985,7 @@ locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT 
       lock_acquired = true;
 
       /* Prepare for getting record again. Since pages have been unlatched, others may have changed them */
-      scan = heap_prepare_get_context (thread_p, context, PGBUF_LATCH_READ, false, LOG_WARNING_IF_DELETED);
+      scan = heap_prepare_get_context (thread_p, context, false, LOG_WARNING_IF_DELETED);
       if (scan != S_SUCCESS)
 	{
 	  goto error;
@@ -13018,8 +13018,7 @@ locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT 
       if (context->recdes_p == NULL || scan == S_SUCCESS_CHN_UPTODATE)
 	{
 	  /* ensure context is prepared to get header of the record */
-	  if (heap_prepare_get_context (thread_p, context, PGBUF_LATCH_READ, false, LOG_WARNING_IF_DELETED) !=
-	      S_SUCCESS)
+	  if (heap_prepare_get_context (thread_p, context, false, LOG_WARNING_IF_DELETED) != S_SUCCESS)
 	    {
 	      scan = S_ERROR;
 	      goto error;
@@ -13161,7 +13160,7 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
   /* get class_oid if it is unknown */
   if (OID_ISNULL (class_oid))
     {
-      err = heap_prepare_object_page (thread_p, oid, &context.home_page_watcher, PGBUF_LATCH_WRITE);
+      err = heap_prepare_object_page (thread_p, oid, &context.home_page_watcher, context.latch_mode);
       if (err != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -13294,7 +13293,7 @@ locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, R
   /* get class_oid if it is unknown */
   if (OID_ISNULL (class_oid))
     {
-      err = heap_prepare_object_page (thread_p, oid, &context.home_page_watcher, PGBUF_LATCH_READ);
+      err = heap_prepare_object_page (thread_p, oid, &context.home_page_watcher, context.latch_mode);
       if (err != NO_ERROR)
 	{
 	  ASSERT_ERROR ();

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13127,13 +13127,13 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
 					     NON_EXISTENT_HANDLING non_ex_handling_type)
 {
   HEAP_GET_CONTEXT context;
-  SCAN_CODE scan;
+  SCAN_CODE scan = S_SUCCESS;
   RECDES recdes_local = RECDES_INITIALIZER;
-  MVCC_REC_HEADER mvcc_header;
-  DB_LOGICAL ev_res;		/* Re-evaluation result. */
+  MVCC_REC_HEADER mvcc_header = MVCC_REC_HEADER_INITIALIZER;
+  DB_LOGICAL ev_res = V_UNKNOWN;	/* Re-evaluation result. */
   OID class_oid_local = OID_INITIALIZER;
   LOCK lock_mode = X_LOCK;
-  int err;
+  int err = NO_ERROR;
 
   if (recdes == NULL && mvcc_reev_data != NULL)
     {
@@ -13161,7 +13161,7 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
   /* get class_oid if it is unknown */
   if (OID_ISNULL (class_oid))
     {
-      err = heap_prepare_object_page (thread_p, oid, &context.home_page_watcher, PGBUF_LATCH_READ);
+      err = heap_prepare_object_page (thread_p, oid, &context.home_page_watcher, PGBUF_LATCH_WRITE);
       if (err != NO_ERROR)
 	{
 	  ASSERT_ERROR ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21190

bug is caused by write latch over a read latched page.
when class_oid is unknown locator_lock_and_get_object_with_evaluation fixes pages using read latch to get class oid. it then is write-latched.

use write latch from the start, since the purpose of the function is to get object to update or delete it.