### PR TITLE
[CBRD-21191] fixes to unlock lockset; class oid might be null oid

### DIFF
--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -6804,6 +6804,10 @@ lock_unlock_objects_lock_set (THREAD_ENTRY * thread_p, LC_LOCKSET * lockset)
 	}
 
       class_oid = &lockset->classes[lockset->objects[i].class_index].oid;
+      if (OID_ISNULL (class_oid))
+	{
+	  continue;
+	}
 
       /* The intentional lock on the higher lock granule must be kept. */
       lock_unlock_object_by_isolation (thread_p, tran_index, isolation, class_oid, oid);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21191

The thread was interrupted while fetching class oid of the requested oid of lockset.
Since lockset->quit_on_errors is 0, it continued to fetch remaining requested objects.
It tried to unlock the locked objects and hit the assertion of not null class oid.