### PR TITLE
[CBRD-21189] activate heap_check_all_pages

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -13674,12 +13674,6 @@ heap_check_all_pages (THREAD_ENTRY * thread_p, HFID * hfid)
   int file_numpages;
 #endif /* SA_MODE */
 
-  /* todo: update for new design */
-  if (true)
-    {
-      return DISK_VALID;
-    }
-
   valid_pg = heap_chkreloc_start (chk_objs);
   if (valid_pg != DISK_VALID)
     {

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -13674,6 +13674,12 @@ heap_check_all_pages (THREAD_ENTRY * thread_p, HFID * hfid)
   int file_numpages;
 #endif /* SA_MODE */
 
+  /* todo: update for new design */
+  if (true)
+    {
+      return DISK_VALID;
+    }
+
   valid_pg = heap_chkreloc_start (chk_objs);
   if (valid_pg != DISK_VALID)
     {
@@ -13695,6 +13701,7 @@ heap_check_all_pages (THREAD_ENTRY * thread_p, HFID * hfid)
     }
   if (file_numpages != -1 && file_numpages != npages)
     {
+      assert (false);
       if (chk_objs != NULL)
 	{
 	  chk_objs->verify = false;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21189

heap_check_all_pages was disabled during file manager redesign. it should have been enabled back.

also crash during debug if file_numpages != npages.

the patch does not fix CBRD-21189.