### PR TITLE
[CBRD-21199] vacuum_heap_page: interrupted vacuum job can find file table page

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1165,6 +1165,9 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	  /* deallocated */
 	  /* Safe guard: this was possible if there was only one object to be vacuumed. */
 	  assert (n_heap_objects == 1);
+
+	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP, "Heap page %d|%d was deallocated during previous run\n",
+				 VPID_AS_ARGS (&helper.home_vpid));
 	  return NO_ERROR;
 	}
       ptype = pgbuf_get_page_ptype (thread_p, helper.home_page);
@@ -1174,6 +1177,9 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	  assert (ptype == PAGE_FTAB);
 	  /* Safe guard: this was possible if there was only one object to be vacuumed. */
 	  assert (n_heap_objects == 1);
+
+	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP, "Heap page %d|%d was deallocated during previous run and reused as"
+				 " file table page\n", VPID_AS_ARGS (&helper.home_vpid));
 
 	  pgbuf_unfix_and_init (thread_p, helper.home_page);
 	  return NO_ERROR;
@@ -1186,6 +1192,9 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	  /* slot does not exist */
 	  /* Safe guard: this was possible if there was only one object to be vacuumed. */
 	  assert (n_heap_objects == 1);
+
+	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP, "Heap page %d|%d was deallocated during previous run and reused as"
+				 " new heap page\n", VPID_AS_ARGS (&helper.home_vpid));
 
 	  pgbuf_unfix_and_init (thread_p, helper.home_page);
 	  return NO_ERROR;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1150,6 +1150,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
   /* Fix heap page. */
   if (was_interrupted)
     {
+      PAGE_TYPE ptype;
       error_code =
 	pgbuf_fix_if_not_deallocated (thread_p, &helper.home_vpid, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH,
 				      &helper.home_page);
@@ -1164,6 +1165,29 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	  /* deallocated */
 	  /* Safe guard: this was possible if there was only one object to be vacuumed. */
 	  assert (n_heap_objects == 1);
+	  return NO_ERROR;
+	}
+      ptype = pgbuf_get_page_ptype (thread_p, helper.home_page);
+      if (ptype != PAGE_HEAP)
+	{
+	  /* page was deallocated and reused as file table. */
+	  assert (ptype == PAGE_FTAB);
+	  /* Safe guard: this was possible if there was only one object to be vacuumed. */
+	  assert (n_heap_objects == 1);
+
+	  pgbuf_unfix_and_init (thread_p, helper.home_page);
+	  return NO_ERROR;
+	}
+      /* page still could be reused as new heap page in same file. in this case the slot may be invalid or it may hold
+       * another record (but that won't bother us, because we always check the record header).
+       * stop if slot no longer exists. */
+      if (spage_number_of_slots (helper.home_page) <= heap_objects[0].oid.slotid)
+	{
+	  /* slot does not exist */
+	  /* Safe guard: this was possible if there was only one object to be vacuumed. */
+	  assert (n_heap_objects == 1);
+
+	  pgbuf_unfix_and_init (thread_p, helper.home_page);
 	  return NO_ERROR;
 	}
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21199

During server run, vacuum thread vacuumed objects, deallocated its page and continued. In the meantime, someone else reused page as file table. Server crashed and restarted for checkdb.

During restart, vacuum tries to clean same object again and finds a file table page (unexpectedly). Fixed by changing expectations and allowing file table pages when job is interrupted.