### PR TITLE
[CBRD-21126] fix disk cache recovery

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -626,8 +626,14 @@ disk_format (THREAD_ENTRY * thread_p, const char *dbname, VOLID volid, DBDEF_VOL
       /* Even though the volume header page is not completed at this moment, to write REDO log for the header page is
        * crucial for redo recovery since disk_map_init and disk_set_link will write their redo logs. These functions
        * will access the header page during restart recovery. Another REDO log for RVDK_FORMAT will be written to
-       * completely log the header page including the volume link. */
-      addr.offset = 0;		/* Header is located at position zero */
+       * completely log the header page including the volume link.
+       *
+       * TODO: I think this log entry and comment are obsolete. In fact disk_stab_init and disk_set_link will not access
+       *       this volume header page during recovery. However, I don't like to change this without a thorough
+       *       examination, although it does bring a lot of pain. I will just use the addr.offset field to make each
+       *       RVDK_FORMAT calls recovery detectable.
+       */
+      addr.offset = -1;		/* First call is marked with offset -1. */
       log_append_redo_data (thread_p, RVDK_FORMAT, &addr, sizeof (*vhdr) + disk_vhdr_length_of_varfields (vhdr), vhdr);
     }
 
@@ -1153,7 +1159,38 @@ disk_rv_undo_format (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 
   if (volid == disk_Cache->nvols_perm - 1)
     {
+      VPID vpid_volheader;
+      PAGE_PTR page_volheader = NULL;
+      DKNSECTS total = 0, max = 0;
+      DKNSECTS free = 0;
+
+      /* we need page to remove total/max from disk cache. however, it must be allocated. */
+      vpid_volheader.volid = volid;
+      vpid_volheader.pageid = DISK_VOLHEADER_PAGE;
+      ret = pgbuf_fix_if_not_deallocated (thread_p, &vpid_volheader, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH,
+					  &page_volheader);
+      if (ret != NO_ERROR)
+	{
+	  assert_release (false);
+	}
+      else if (page_volheader == NULL)
+	{
+	  /* why was it added to cache?? */
+	  assert_release (false);
+	  ret = ER_FAILED;
+	}
+      else
+	{
+	  /* get total/max from header */
+	  DISK_VOLUME_HEADER *volheader = (DISK_VOLUME_HEADER *) page_volheader;
+	  total = volheader->nsect_total;
+	  max = volheader->nsect_max;
+
+	  pgbuf_unfix (thread_p, page_volheader);
+	}
+
       /* volume was added to cache. now remove it */
+      free = disk_Cache->vols[volid].nsect_free;
       disk_cache_lock_reserve_for_purpose (disk_Cache->vols[volid].purpose);
       disk_cache_update_vol_free (volid, -disk_Cache->vols[volid].nsect_free);
       disk_cache_unlock_reserve_for_purpose (disk_Cache->vols[volid].purpose);
@@ -1161,6 +1198,12 @@ disk_rv_undo_format (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
       assert (disk_Cache->vols[volid].nsect_free == 0);
       disk_Cache->nvols_perm--;
       disk_Cache->vols[volid].purpose = DISK_UNKNOWN_PURPOSE;
+
+      disk_Cache->perm_purpose_info.extend_info.nsect_total -= total;
+      disk_Cache->perm_purpose_info.extend_info.nsect_max -= max;
+
+      disk_log ("disk_rv_undo_format", "remove volume %d from cache (free = %d, total = %d, max = %d).",
+		volid, free, total, max);
     }
   else
     {
@@ -1168,9 +1211,11 @@ disk_rv_undo_format (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
       assert (disk_Cache->nvols_perm <= volid);
       assert (disk_Cache->vols[volid].purpose == DISK_UNKNOWN_PURPOSE);
       assert (disk_Cache->vols[volid].nsect_free == 0);
+
+      disk_log ("disk_rv_undo_format", "remove volume %d", volid);
     }
 
-  return NO_ERROR;
+  return ret;
 }
 
 /*
@@ -1183,7 +1228,11 @@ disk_rv_redo_format (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 {
   int error_code = NO_ERROR;
   DISK_VOLUME_HEADER *volheader;
+  bool is_first_call = rcv->offset == -1;
+  int nsect_free;
+  int nsect_diff;
 
+  rcv->offset = 0;
   (void) pgbuf_set_page_ptype (thread_p, rcv->pgptr, PAGE_VOLHEADER);
   error_code = log_rv_copy_char (thread_p, rcv);
   assert (error_code == NO_ERROR);
@@ -1191,25 +1240,59 @@ disk_rv_redo_format (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   disk_verify_volume_header (thread_p, rcv->pgptr);
   volheader = (DISK_VOLUME_HEADER *) rcv->pgptr;
 
+  if (is_first_call)
+    {
+      /* don't update disk cache. if the volume is successfully created, another disk_rv_redo_format call will follow,
+       * and we can update disk cache then. */
+
+      disk_log ("disk_rv_redo_format", "first call for volume %d at lsa %lld|%d", volheader->volid,
+		PGBUF_PAGE_LSA_AS_ARGS (rcv->pgptr));
+      return NO_ERROR;
+    }
+
+  /* this is the second call of disk_rv_redo_format. we need to update disk cache too.
+   * you may be tempted to think that this is a new volume and that all of it must be empty. oh well, even though you
+   * are right most of the time, we can have this beautiful case:
+   * 1. volume is successfully created.
+   * 2. some sectors are reserved.
+   * 3. some (or all) sector table pages are flushed to disk, but not the volume header page.
+   * 4. other sectors are reserved.
+   * 5. server crashes.
+   *
+   * while we are here, the sectors reserved in step #2 are already found in sector table pages, so the assumption that
+   * whole volume is empty is wrong. we need to count the sectors to make sure we are not wrong. */
+
   if (disk_Cache->nvols_perm == volheader->volid)
     {
       /* add to disk cache */
       disk_Cache->nvols_perm++;
       disk_Cache->vols[volheader->volid].purpose = volheader->purpose;
       disk_Cache->vols[volheader->volid].nsect_free = 0;
-      disk_cache_lock_reserve_for_purpose (volheader->purpose);
-      disk_cache_update_vol_free (volheader->volid,
-				  volheader->nsect_total - SECTOR_FROM_PAGEID (volheader->sys_lastpage) - 1);
-      disk_cache_unlock_reserve_for_purpose (volheader->purpose);
+
+      disk_Cache->perm_purpose_info.extend_info.nsect_total += volheader->nsect_total;
+      disk_Cache->perm_purpose_info.extend_info.nsect_max += volheader->nsect_max;
     }
-  else
+
+  /* fix cache... */
+  error_code = disk_stab_iterate_units_all (thread_p, volheader, PGBUF_LATCH_READ, disk_stab_count_free, &nsect_free);
+  if (error_code != NO_ERROR)
     {
-      /* disk_rv_redo_format is called twice. it must be already added. */
-      assert (disk_Cache->nvols_perm == volheader->volid + 1);
-      assert (disk_Cache->vols[volheader->volid].purpose == volheader->purpose);
-      assert (disk_Cache->vols[volheader->volid].nsect_free
-	      == volheader->nsect_total - SECTOR_FROM_PAGEID (volheader->sys_lastpage) - 1);
+      assert_release (false);
+      return error_code;
     }
+  nsect_diff = disk_Cache->vols[volheader->volid].nsect_free - nsect_free;
+  if (nsect_diff != 0)
+    {
+      disk_cache_lock_reserve_for_purpose (volheader->purpose);
+      disk_cache_update_vol_free (volheader->volid, nsect_diff);
+      disk_cache_unlock_reserve_for_purpose (volheader->purpose);
+
+      /* there, I fixed it */
+    }
+
+  disk_log ("disk_rv_redo_format", "second call for volume %d at lsa %lld|%d, free = %d, total = %d, max = %d",
+	    volheader->volid, PGBUF_PAGE_LSA_AS_ARGS (rcv->pgptr), nsect_free, volheader->nsect_total,
+	    volheader->nsect_max);
 
   return error_code;
 }
@@ -1789,6 +1872,10 @@ disk_rv_volhead_extend_redo (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 {
   DISK_VOLUME_HEADER *volheader = (DISK_VOLUME_HEADER *) rcv->pgptr;
   DKNSECTS nsect_extend = *(DKNSECTS *) rcv->data;
+  DISK_STAB_CURSOR start_cursor;
+  DISK_STAB_CURSOR end_cursor;
+  int nfree = 0;
+  int error_code = NO_ERROR;
 
   assert (rcv->length == sizeof (nsect_extend));
   assert (volheader->type == DB_PERMANENT_VOLTYPE);
@@ -1798,10 +1885,35 @@ disk_rv_volhead_extend_redo (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   volheader->nsect_total += nsect_extend;
   disk_verify_volume_header (thread_p, rcv->pgptr);
 
+  /* we may think that all these are new sectors, free to reserve, but that may not always be true:
+   * 1. volume is extended.
+   * 2. some of the sectors in the extended sectors are reserved.
+   * 3. sector table pages are flushed to disk.
+   * 4. other sectors are reserved.
+   * 5. server crashes.
+   *
+   * at this point, sectors reserved in step #2 are already set and they cannot be considered free. */
+
+  disk_stab_cursor_set_at_sectid (volheader, volheader->nsect_total - nsect_extend, &start_cursor);
+  disk_stab_cursor_set_at_end (volheader, &end_cursor);
+
+  error_code =
+    disk_stab_iterate_units (thread_p, volheader, PGBUF_LATCH_READ, &start_cursor, &end_cursor, disk_stab_count_free,
+			     &nfree);
+  if (error_code != NO_ERROR)
+    {
+      assert_release (false);
+      return error_code;
+    }
+  assert (nfree <= nsect_extend);
+
   disk_Cache->perm_purpose_info.extend_info.nsect_total += nsect_extend;
   disk_cache_lock_reserve_for_purpose (DB_PERMANENT_DATA_PURPOSE);
-  disk_cache_update_vol_free (volheader->volid, nsect_extend);
+  disk_cache_update_vol_free (volheader->volid, nfree);
   disk_cache_unlock_reserve_for_purpose (DB_PERMANENT_DATA_PURPOSE);
+
+  disk_log ("disk_rv_volhead_extend_redo", "extended volume %d total sectors %d (out of which %d were free). "
+	    "volume header lsa %lld|%d", volheader->volid, nsect_extend, nfree, PGBUF_PAGE_LSA_AS_ARGS (rcv->pgptr));
 
   pgbuf_set_dirty (thread_p, rcv->pgptr, DONT_FREE);
   return NO_ERROR;
@@ -1855,6 +1967,12 @@ disk_add_volume (THREAD_ENTRY * thread_p, DBDEF_VOL_EXT_INFO * extinfo, VOLID * 
   /* make sure the total and max size are rounded */
   extinfo->nsect_max = DISK_SECTS_ROUND_UP (extinfo->nsect_max);
   extinfo->nsect_total = DISK_SECTS_ROUND_UP (extinfo->nsect_total);
+
+  disk_log ("disk_add_volume", "add new %s volume with purpose %s:\n" "\tname=%s\n" "\tcomments=%s\n" "\tpath=%s\n"
+	    "\tfullname = %s\n" "\ttotal sectors = %d\n" "\tmax sectors = %d", disk_type_to_string (extinfo->voltype),
+	    disk_purpose_to_string (extinfo->purpose), extinfo->name ? extinfo->name : "(UNKNOWN)",
+	    extinfo->comments ? extinfo->comments : "(UNKNOWN)", extinfo->path ? extinfo->path : "(UNKNOWN)",
+	    fullname ? fullname : "(UNKNOWN)", extinfo->nsect_total, extinfo->nsect_max);
 
 #if !defined (WINDOWS)
   {
@@ -3560,6 +3678,10 @@ disk_rv_reserve_sectors (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   disk_cache_update_vol_free (volid, -nsect);
   disk_cache_unlock_reserve_for_purpose (purpose);
 
+  disk_log ("disk_rv_reserve_sectors", "reserved %d sectors in " PGBUF_PAGE_STATE_MSG ("sector table page")
+	    "\n\tstab_unit = " BIT64_HEXA_PRINT_FORMAT "\n\trv_unit = " BIT64_HEXA_PRINT_FORMAT,
+	    nsect, PGBUF_PAGE_STATE_ARGS (rcv->pgptr), *stab_unit, rv_unit);
+
   csect_exit (thread_p, CSECT_DISK_CHECK);
   return NO_ERROR;
 }
@@ -3636,6 +3758,10 @@ disk_rv_unreserve_sectors (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   disk_cache_lock_reserve_for_purpose (purpose);
   disk_cache_update_vol_free (volid, nsect);
   disk_cache_unlock_reserve_for_purpose (purpose);
+
+  disk_log ("disk_rv_unreserve_sectors", "unreserved %d sectors in " PGBUF_PAGE_STATE_MSG ("sector table page")
+	    "\n\tstab_unit = " BIT64_HEXA_PRINT_FORMAT "\n\trv_unit = " BIT64_HEXA_PRINT_FORMAT,
+	    nsect, PGBUF_PAGE_STATE_ARGS (rcv->pgptr), *stab_unit, rv_unit);
 
   csect_exit (thread_p, CSECT_DISK_CHECK);
   return NO_ERROR;
@@ -3886,6 +4012,7 @@ disk_reserve_sectors (THREAD_ENTRY * thread_p, DB_VOLPURPOSE purpose, VOLID voli
   int iter;
   DISK_RESERVE_CONTEXT context;
   int nreserved;
+  bool retried = false;
   int error_code = NO_ERROR;
 
   assert (purpose == DB_PERMANENT_DATA_PURPOSE || purpose == DB_TEMPORARY_DATA_PURPOSE);
@@ -3904,6 +4031,7 @@ disk_reserve_sectors (THREAD_ENTRY * thread_p, DB_VOLPURPOSE purpose, VOLID voli
       return ER_FAILED;
     }
 
+retry:
   disk_log ("disk_reserve_sectors", "reserve %d sectors for %s.", n_sectors, disk_purpose_to_string (purpose));
 
   log_sysop_start (thread_p);
@@ -3995,6 +4123,37 @@ error:
   /* abort any changes */
   log_sysop_abort (thread_p);
 
+  if (error_code == ER_INTERRUPTED	/* interrupted error */
+      || error_code == ER_IO_MOUNT_FAIL || error_code == ER_IO_FORMAT_OUT_OF_SPACE || error_code == ER_IO_WRITE
+      || error_code == ER_BO_CANNOT_CREATE_VOL /* IO errors */ )
+    {
+      /* this is expected. */
+      return error_code;
+    }
+  /* this is not. */
+  assert_release (false);
+
+  /* let's try to do something about this. */
+
+  if (retried)
+    {
+      /* already tried... this is not a good sign */
+      _er_log_debug (ARG_FILE_LINE, "disk_reserve_sectors retried and failed! error_code = %d \n", error_code);
+      return error_code;
+    }
+
+  /* disk_check should fix any cache inconsistencies */
+  if (disk_check (thread_p, true) == DISK_INVALID)
+    {
+      /* oh, it was bad */
+      error_code = NO_ERROR;
+      er_clear ();
+      retried = true;
+      goto retry;
+    }
+
+  /* it was not disk cache... */
+  _er_log_debug (ARG_FILE_LINE, "disk_reserve_sectors failed unexpectedly! error_code = %d \n", error_code);
   return error_code;
 }
 

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -1154,9 +1154,6 @@ disk_rv_undo_format (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   VOLID volid = (VOLID) rcv->offset;
   int ret = NO_ERROR;
 
-  ret = disk_unformat (thread_p, (char *) rcv->data);
-  log_append_dboutside_redo (thread_p, RVLOG_OUTSIDE_LOGICAL_REDO_NOOP, 0, NULL);
-
   if (volid == disk_Cache->nvols_perm - 1)
     {
       VPID vpid_volheader;
@@ -1214,6 +1211,9 @@ disk_rv_undo_format (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 
       disk_log ("disk_rv_undo_format", "remove volume %d", volid);
     }
+
+  ret = disk_unformat (thread_p, (char *) rcv->data);
+  log_append_dboutside_redo (thread_p, RVLOG_OUTSIDE_LOGICAL_REDO_NOOP, 0, NULL);
 
   return ret;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21126

Fix the recovery of disk cache when sector table pages (but not volume header) are flushed to disk before server crash. This used to generate some inconsistencies from format/extend (which wrongfully assumed all added sectors are free).

Also added more disk logging and a plan B for disk_reserve_sectors release version (assuming it fails due to incorrect cache).