### PR TITLE
[CBRD-21204] fixes ABR of copydb

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -5288,11 +5288,18 @@ xdisk_get_purpose (THREAD_ENTRY * thread_p, INT16 volid)
       return DB_PERMANENT_DATA_PURPOSE;
     }
 
+  if (volid < LOG_DBFIRST_VOLID)
+    {
+      /* system volumes */
+      return DISK_UNKNOWN_PURPOSE;
+    }
+
   if (!disk_is_valid_volid (volid))
     {
       assert (false);
       return DISK_UNKNOWN_PURPOSE;
     }
+
   return disk_get_volpurpose (volid);
 }
 
@@ -5651,7 +5658,7 @@ STATIC_INLINE DB_VOLPURPOSE
 disk_get_volpurpose (VOLID volid)
 {
   assert (disk_Cache != NULL);
-  assert (disk_is_valid_volid (volid));
+  assert (LOG_DBFIRST_VOLID <= volid && disk_is_valid_volid (volid));
 
   return disk_Cache->vols[volid].purpose;
 }

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -4842,7 +4842,7 @@ pgbuf_is_temporary_volume (VOLID volid)
     {
       return false;
     }
-  return (xdisk_get_purpose (NULL, volid) == DB_TEMPORARY_DATA_PURPOSE);
+  return (LOG_DBFIRST_VOLID <= volid && xdisk_get_purpose (NULL, volid) == DB_TEMPORARY_DATA_PURPOSE);
 }
 
 /*

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -11285,7 +11285,7 @@ logpb_check_and_reset_temp_lsa (THREAD_ENTRY * thread_p, VOLID volid)
       return ER_FAILED;
     }
 
-  if (xdisk_get_purpose (thread_p, volid) == DB_TEMPORARY_DATA_PURPOSE)
+  if (LOG_DBFIRST_VOLID <= volid && xdisk_get_purpose (thread_p, volid) == DB_TEMPORARY_DATA_PURPOSE)
     {
       pgbuf_reset_temp_lsa (pgptr);
       pgbuf_set_dirty (thread_p, pgptr, FREE);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21204

`copydb` uses a special volid as `LOG_DBCOPY_VOLID`.
It caused ABR and corruption of log header. This lead to a corruption and a crash for some cases.