### PR TITLE
[CBRD-21204] resets log header of copied db; it did source's not dest's

### DIFF
--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -286,7 +286,6 @@ extern void vacuum_start_new_job (THREAD_ENTRY * thread_p);
 
 extern int vacuum_create_file_for_vacuum_data (THREAD_ENTRY * thread_p, VFID * vacuum_data_vfid);
 extern int vacuum_data_load_and_recover (THREAD_ENTRY * thread_p);
-extern void vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p);
 extern VACUUM_LOG_BLOCKID vacuum_get_log_blockid (LOG_PAGEID pageid);
 extern void vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, MVCCID oldest_mvccid,
 					   MVCCID newest_mvccid);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -2348,6 +2348,8 @@ extern int logpb_prior_lsa_append_all_list (THREAD_ENTRY * thread_p);
 
 extern bool logtb_check_class_for_rr_isolation_err (const OID * class_oid);
 
+extern void logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr);
+
 /************************************************************************/
 /* Inline functions:                                                    */
 /************************************************************************/

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -323,7 +323,7 @@ static bool logpb_is_any_fix (THREAD_ENTRY * thread_p);
 static void logpb_dump_information (FILE * out_fp);
 static void logpb_dump_to_flush_page (FILE * out_fp);
 static void logpb_dump_pages (FILE * out_fp);
-static void logpb_initialize_backup_info (void);
+static void logpb_initialize_backup_info (LOG_HEADER * loghdr);
 static LOG_PAGE **logpb_writev_append_pages (THREAD_ENTRY * thread_p, LOG_PAGE ** to_flush, DKNPAGES npages);
 static int logpb_get_guess_archive_num (THREAD_ENTRY * thread_p, LOG_PAGEID pageid);
 static void logpb_set_unavailable_archive (int arv_num);
@@ -1265,16 +1265,16 @@ logpb_dump_pages (FILE * out_fp)
  * NOTE:
  */
 static void
-logpb_initialize_backup_info ()
+logpb_initialize_backup_info (LOG_HEADER * log_hdr)
 {
   int i;
 
   for (i = 0; i < FILEIO_BACKUP_UNDEFINED_LEVEL; i++)
     {
-      log_Gl.hdr.bkinfo[i].ndirty_pages_post_bkup = 0;
-      log_Gl.hdr.bkinfo[i].io_baseln_time = 0;
-      log_Gl.hdr.bkinfo[i].io_numpages = 0;
-      log_Gl.hdr.bkinfo[i].io_bkuptime = 0;
+      log_hdr->bkinfo[i].ndirty_pages_post_bkup = 0;
+      log_hdr->bkinfo[i].io_baseln_time = 0;
+      log_hdr->bkinfo[i].io_numpages = 0;
+      log_hdr->bkinfo[i].io_bkuptime = 0;
     }
 }
 
@@ -1368,16 +1368,16 @@ logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const cha
 
   for (i = 0; i < FILEIO_BACKUP_UNDEFINED_LEVEL; i++)
     {
-      log_Gl.hdr.bkinfo[i].bkup_attime = 0;
+      loghdr->bkinfo[i].bkup_attime = 0;
     }
-  logpb_initialize_backup_info ();
+  logpb_initialize_backup_info (loghdr);
 
   loghdr->ha_server_state = HA_SERVER_STATE_IDLE;
   loghdr->ha_file_status = -1;
   LSA_SET_NULL (&loghdr->eof_lsa);
   LSA_SET_NULL (&loghdr->smallest_lsa_at_last_chkpt);
 
-  vacuum_reset_log_header_cache (thread_p);
+  logpb_vacuum_reset_log_header_cache (thread_p, loghdr);
 
   return NO_ERROR;
 }
@@ -8819,7 +8819,7 @@ loop:
     }
 
   /* Clear log header information regarding previous backups */
-  logpb_initialize_backup_info ();
+  logpb_initialize_backup_info (&log_Gl.hdr);
 
   /* Save additional info and metrics from this backup */
   log_Gl.hdr.bkinfo[backup_level].bkup_attime = session.bkup.bkuphdr->start_time;
@@ -12120,4 +12120,16 @@ delete_fixed_logs:
   fileio_unformat (thread_p, log_Name_info);
 
   return NO_ERROR;
+}
+
+/*
+ * logpb_vacuum_reset_log_header_cache () - reset vacuum data cached in log global header.
+ */
+void
+logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr)
+{
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Reset vacuum info in loghdr (%p)", loghdr);
+  LSA_SET_NULL (&loghdr->mvcc_op_log_lsa);
+  loghdr->last_block_oldest_mvccid = MVCCID_NULL;
+  loghdr->last_block_newest_mvccid = MVCCID_NULL;
 }

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3147,7 +3147,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 		  LOG_LSA null_lsa = LSA_INITIALIZER;
 
 		  /* Reset log header MVCC info */
-		  vacuum_reset_log_header_cache (thread_p);
+		  logpb_vacuum_reset_log_header_cache (thread_p, &log_Gl.hdr);
 
 		  /* Reset vacuum recover LSA */
 		  vacuum_notify_server_crashed (&null_lsa);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21204

There was another defect along with #667. It reset source's log header not dest's.
Since I have not had my own reproduction, I don't know this is the last defect of copydb. I hope this resolves the case.