### PR TITLE
[CBRD-21214] fixes to show usages of gen_tz where dbname is omitted f…

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -3922,13 +3922,17 @@ gen_tz (UTIL_FUNCTION_ARG * arg)
       tz_gen_type = TZ_GEN_TYPE_EXTEND;
 
       db_name = utility_get_option_string_value (arg_map, OPTION_STRING_TABLE, 0);
+
+#if !defined (WINDOWS)
       /* workaround for Linux: gen_tz process should be restarted after each database migration, since globals variables
        * from shared libcubrid.so are not properly reset at db_shutdown */
-#if defined (WINDOWS)
+      if (db_name == NULL)
+	{
+	  goto print_gen_tz_usage;
+	}
+#endif /* !WINDOWS */
+
       if (db_name != NULL && check_database_name (db_name) != NO_ERROR)
-#else
-      if (db_name == NULL || check_database_name (db_name) != NO_ERROR)
-#endif
 	{
 	  exit_status = EXIT_FAILURE;
 	  goto exit;
@@ -4042,7 +4046,10 @@ exit:
 
   if (exit_status != EXIT_SUCCESS)
     {
-      fprintf (stderr, "%s\n", db_error_string (3));
+      if (er_inited == true)
+	{
+	  fprintf (stderr, "%s\n", db_error_string (3));
+	}
 
       if (need_db_shutdown == true)
 	{


### PR DESCRIPTION
…or linux

http://jira.cubrid.org/browse/CBRD-21214

error manager is unavailable for the case. 
To show usages for the case.
