### PR TITLE
[CBRD-21212] Fix vacuum recovery on restore

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2449,9 +2449,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 
   log_initialize (thread_p, boot_Db_full_name, log_path, log_prefix, from_backup, r_args);
 
-  /* restore from backup should be prevented from other changes of the database (includes vacuum) */
-  if ((r_args == NULL || r_args->is_restore_from_backup == false)
-      && prm_get_bool_value (PRM_ID_DISABLE_VACUUM) == false)
+  if (prm_get_bool_value (PRM_ID_DISABLE_VACUUM) == false)
     {
       /* load and recovery vacuum data and dropped files */
       error_code = vacuum_data_load_and_recover (thread_p);

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3148,9 +3148,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 
 		  /* Reset log header MVCC info */
 		  logpb_vacuum_reset_log_header_cache (thread_p, &log_Gl.hdr);
-
-		  /* Reset vacuum recover LSA */
-		  vacuum_notify_server_crashed (&null_lsa);
 		}
 
 	      /* 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21212

Fix two issues:
1. Call vacuum_data_load_and_recover after restore.
    vacuum_data_load_and_recover addes new log records. And we thought initially that restore can be called iteratively (-l0, then -l1, then -l2). Restore does not expect pages with LSA's higher than their end_redo_lsa (which happened in this case). However, that proved wrong, and restore should be called with -l2 directly.
2. Do not reset vacuum_Data.recovery_lsa when finding RVVAC_COMPLETE on redo.
    Resetting vacuum's recovery_lsa was a minor optimization for recovery (to skip trying to recover vacuum data). But it only considered recovery case and not restore. For recovery, to find RVVAC_COMPLETE after checkpoint, means no other MVCC operations are possible afterwards (since last run must have been stand-alone mode). However, when starting before last checkpoint (which restoredb usually does), the assumption is no longer true (we can find multiple RVVAC_COMPLETE and MVCC ops can follow).