### PR TITLE
[CBRD-21280] don't try to flush from empty zone 3

### DIFF
--- a/contrib/gdb_debugging_scripts/page_buffer.gdb
+++ b/contrib/gdb_debugging_scripts/page_buffer.gdb
@@ -630,7 +630,7 @@ end
 # 
 # Print counters on each LRU related to count of LRU3 and count of dirties in each LRU3
 #
-define pgbuf_show_lru_dirties
+define pgbuf_show_all_lru_dirties
   set $i = 0
   while $i < pgbuf_Pool.num_LRU_list + pgbuf_Pool.quota.num_private_LRU_list
     pgbuf_show_lru_dirties $i

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -3174,11 +3174,6 @@ pgbuf_get_victim_candidates_from_lru (THREAD_ENTRY * thread_p, int check_count, 
 }
 
 /*
- * pgbuf_flush_victim_candidates () - Flush victim candidates
- *   return: NO_ERROR, or ER_code
- *
- */
-/*
  * pgbuf_flush_victim_candidates () - collect & flush victim candidates
  *
  * return                : error code
@@ -13108,6 +13103,7 @@ pgbuf_compute_lru_vict_target (float *lru_sum_flush_priority)
        * shared are right below minimum desired size... and flush will not find anything.
        */
       this_prv_target = PGBUF_LRU_LIST_COUNT (lru_list) - (int) (lru_list->quota * 0.9);
+      this_prv_target = MIN (this_prv_target, lru_list->count_lru3);
       if (this_prv_target > 0)
 	{
 	  total_prv_target += this_prv_target;
@@ -13170,6 +13166,7 @@ pgbuf_compute_lru_vict_target (float *lru_sum_flush_priority)
 		{
 		  /* use bcb's over 90% of quota as flush target */
 		  this_prv_target = PGBUF_LRU_LIST_COUNT (lru_list) - (int) (lru_list->quota * 0.9);
+		  this_prv_target = MIN (this_prv_target, lru_list->count_lru3);
 		}
 	      if (this_prv_target > 0)
 		{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21280

Some private lists were assigned a target for flush although they had no possible candidates. Each list had only on bcb in zone 1 and quota 0, which means they are considered over-quota. Flush thread sets a flush target bigger than 0 for these lists although there is no victimizable bcb.

The hit assert checks there are more victims than target when flush finds nothing, which was not true for these lists.

Fix by setting the flush target on private lists to MIN (over_quota_bcb's, zone_3_bcb_count).