### PR TITLE
[CBRD-21311] uses quoted identifier for system genereated trigger sta…

### DIFF
--- a/src/parser/compile.c
+++ b/src/parser/compile.c
@@ -1084,8 +1084,9 @@ pt_compile_trigger_stmt (PARSER_CONTEXT * parser, const char *trigger_stmt, DB_O
       stmt_str = pt_append_string (parser, stmt_str, " FROM ON ");
       if (name1)
 	{
+	  stmt_str = pt_append_string (parser, stmt_str, " [");
 	  stmt_str = pt_append_string (parser, stmt_str, class_name);
-	  stmt_str = pt_append_string (parser, stmt_str, " ");
+	  stmt_str = pt_append_string (parser, stmt_str, "] ");
 	  stmt_str = pt_append_string (parser, stmt_str, name1);
 	}
 
@@ -1095,9 +1096,9 @@ pt_compile_trigger_stmt (PARSER_CONTEXT * parser, const char *trigger_stmt, DB_O
 	    {
 	      return (PT_NODE *) 0;
 	    }
-	  stmt_str = pt_append_string (parser, stmt_str, ", ");
+	  stmt_str = pt_append_string (parser, stmt_str, ", [");
 	  stmt_str = pt_append_string (parser, stmt_str, class_name);
-	  stmt_str = pt_append_string (parser, stmt_str, " ");
+	  stmt_str = pt_append_string (parser, stmt_str, "] ");
 	  stmt_str = pt_append_string (parser, stmt_str, name2);
 	}
     }


### PR DESCRIPTION
…tement

http://jira.cubrid.org/browse/CBRD-21311

uses quoted identifier.
