### PR TITLE
[CBRD-21328] fixed memory overrun of printing default expression

### DIFF
--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -3671,7 +3671,7 @@ get_column_default_as_string (DB_ATTRIBUTE * attr, bool * alloc)
 
       default_expr_format = attr->default_value.default_expr.default_expr_format;
       len = ((default_value_expr_op_string ? strlen (default_value_expr_op_string) : 0)
-	     + 4 /* parenthesis, a comma and a blank */  + strlen (default_value_expr_type_string)
+	     + 6 /* parenthesis, a comma, a blank and quotes */  + strlen (default_value_expr_type_string)
 	     + (default_expr_format ? strlen (default_expr_format) : 0));
 
       default_value_string = (char *) malloc (len + 1);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -22666,7 +22666,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 		  default_expr_format = attrepr->default_value.default_expr.default_expr_format;
 
 		  len = ((default_expr_op_string ? strlen (default_expr_op_string) : 0)
-			 + 4 /* parenthsis, a comma and a blank */  + strlen (default_expr_type_string)
+			 + 6 /* parenthesis, a comma, a blank and quotes */  + strlen (default_expr_type_string)
 			 + (default_expr_format ? strlen (default_expr_format) : 0));
 
 		  default_value_string = (char *) malloc (len + 1);

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -1442,7 +1442,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
       default_expr_op_string = qdump_operator_type_string (default_expr_op);
 
       len = ((default_expr_op_string ? strlen (default_expr_op_string) : 0)
-	     + 4 /* parenthesis, a comma and a blank */  + strlen (default_expr_type_string)
+	     + 6 /* parenthesis, a comma, a blank and quotes */  + strlen (default_expr_type_string)
 	     + (def_expr_format_string ? strlen (def_expr_format_string) : 0));
 
       str_val = (char *) db_private_alloc (thread_p, len + 1);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21328

space for quotes were missed.

It also fixes http://jira.cubrid.org/browse/CBRD-21327