### PR TITLE
[CBRD-21325] correct volume info file if disk_add_volume crashes

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -1217,6 +1217,8 @@ disk_rv_undo_format (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
     }
 
   ret = disk_unformat (thread_p, (char *) rcv->data);
+  /* we need to remove from volume info file too... the only way is to recreate it. */
+  (void) logpb_recreate_volume_info (thread_p);
   log_append_dboutside_redo (thread_p, RVLOG_OUTSIDE_LOGICAL_REDO_NOOP, 0, NULL);
 
   return ret;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -5799,6 +5799,7 @@ logpb_scan_volume_info (THREAD_ENTRY * thread_p, const char *db_fullname, VOLID 
 	{
 	  if (((*fun) (thread_p, volid, vol_fullname, args)) != NO_ERROR)
 	    {
+	      num_vols = -1;
 	      break;
 	    }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21325

The volume info file is not synchronized after crash during disk_add_volume. Find volumes during restart bug also kept things that way. During unlikely case described [here](http://jira.cubrid.org/browse/CBRD-21325?focusedCommentId=4743682&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4743682), the issue ends up with a crash in debug mode.

Fix by making sure that volume info file is correct if:
  * disk_add_volume is aborted.
  * volume found in volume info file could not be mounted.