### PR TITLE
[CBRD-21353] btree_range_scan_resume: expect not found from empty pages

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -24054,7 +24054,7 @@ btree_range_scan_resume (THREAD_ENTRY * thread_p, BTREE_SCAN * bts)
 		      ASSERT_ERROR ();
 		      return error_code;
 		    }
-		  assert (search_key.result != BTREE_KEY_FOUND);
+		  assert (search_key.result != BTREE_KEY_NOTFOUND);
 		}
 	      switch (search_key.result)
 		{

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -24054,6 +24054,7 @@ btree_range_scan_resume (THREAD_ENTRY * thread_p, BTREE_SCAN * bts)
 		      ASSERT_ERROR ();
 		      return error_code;
 		    }
+		  assert (search_key.result != BTREE_KEY_FOUND);
 		}
 	      switch (search_key.result)
 		{
@@ -24081,6 +24082,7 @@ btree_range_scan_resume (THREAD_ENTRY * thread_p, BTREE_SCAN * bts)
 
 		case BTREE_KEY_SMALLER:
 		case BTREE_KEY_BIGGER:
+		case BTREE_KEY_NOTFOUND:
 		  /* Key is no longer in this leaf node. Locate key by advancing from root. */
 		  /* Fall through. */
 		  break;
@@ -30095,7 +30097,8 @@ btree_merge_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
       /* Fix right page. */
       VPID_COPY (&right_vpid, &non_leaf_rec_info.pnt);
 #if defined (SERVER_MODE)
-      if (pgbuf_is_io_stressful () && spage_get_free_space (thread_p, child_page) < (int) (DB_PAGESIZE * 0.75f))
+      if (pgbuf_is_io_stressful () && spage_get_free_space (thread_p, child_page) < (int) (DB_PAGESIZE * 0.75f)
+	  && spage_number_of_slots (child_page) > 2)
 	{
 	  /* avoid fetching "cold" neighbor pages, that are not in page buffer. at the same time, we should avoid doing
 	   * zero merges. so if we have a strong indicator that merge is possible (e.g. current page is almost empty)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21353

The page b-tree scan was interrupted at has become empty in the meantime. Vacuum cleaned its last entry. In btree_range_scan_resume, btree_leaf_is_key_between_min_max returns BTREE_KEY_NOTFOUND, btree_search_leaf_page call is suppressed, and then crash happens. I added BTREE_KEY_NOTFOUND to accepted cases that need to restart search from the top.

Why is page empty and not merged with next page? I can only guess that the next page was full (or we have a bug, I don't know). The page was pretty empty (its last record being only 24-byte long).

I also added an extra condition in btree_merge_node_and_advance to force loading right child node from disk when advance to child node has only one record. (in case the only existing record, that is going to be removed is around 1/4 of current page).