### PR TITLE
[CBRD-21352] log_final: reset log_GL.rcv_phase

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -3731,7 +3731,6 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
   master_host_name = utility_get_option_string_value (arg_map, RESTORESLAVE_MASTER_HOST_NAME_S, 0);
   source_state = utility_get_option_string_value (arg_map, RESTORESLAVE_SOURCE_STATE_S, 0);
 
-#if 0				/* temporary disables */
   if (master_host_name == NULL || source_state == NULL)
     {
       goto print_restoreslave_usage;
@@ -3752,7 +3751,6 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
 	       source_state);
       goto error_exit;
     }
-#endif /* temporary disables */
 
   restart_arg.restore_slave = true;
   restart_arg.printtoc = utility_get_option_bool_value (arg_map, RESTORESLAVE_LIST_S);
@@ -3769,7 +3767,6 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
       goto print_restoreslave_usage;
     }
 
-#if 0				/* temporary disables */
   if (check_ha_db_and_node_list (database_name, master_host_name) == false)
     {
       fprintf (stderr,
@@ -3794,7 +3791,6 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
 
       return EXIT_SUCCESS;
     }
-#endif /* temporary disables */
 
   sysprm_set_force (prm_get_name (PRM_ID_JAVA_STORED_PROCEDURE), "no");
 
@@ -3826,7 +3822,6 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
       return EXIT_FAILURE;
     }
 
-#if 0				/* temporary disables */
   if (init_ha_catalog)
     {
       error_code = delete_all_ha_apply_info ();
@@ -3870,7 +3865,6 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
 	}
 
     }
-#endif /* temporary disables */
   db_commit_transaction ();
   db_shutdown ();
 

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -3731,7 +3731,7 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
   master_host_name = utility_get_option_string_value (arg_map, RESTORESLAVE_MASTER_HOST_NAME_S, 0);
   source_state = utility_get_option_string_value (arg_map, RESTORESLAVE_SOURCE_STATE_S, 0);
 
-#if defined 0			/* temporary disables */
+#if 0				/* temporary disables */
   if (master_host_name == NULL || source_state == NULL)
     {
       goto print_restoreslave_usage;
@@ -3769,7 +3769,7 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
       goto print_restoreslave_usage;
     }
 
-#if defined 0			/* temporary disables */
+#if 0				/* temporary disables */
   if (check_ha_db_and_node_list (database_name, master_host_name) == false)
     {
       fprintf (stderr,
@@ -3826,7 +3826,7 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
       return EXIT_FAILURE;
     }
 
-#if defined 0			/* temporary disables */
+#if 0				/* temporary disables */
   if (init_ha_catalog)
     {
       error_code = delete_all_ha_apply_info ();

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -3731,6 +3731,7 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
   master_host_name = utility_get_option_string_value (arg_map, RESTORESLAVE_MASTER_HOST_NAME_S, 0);
   source_state = utility_get_option_string_value (arg_map, RESTORESLAVE_SOURCE_STATE_S, 0);
 
+#if defined 0			/* temporary disables */
   if (master_host_name == NULL || source_state == NULL)
     {
       goto print_restoreslave_usage;
@@ -3751,6 +3752,7 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
 	       source_state);
       goto error_exit;
     }
+#endif /* temporary disables */
 
   restart_arg.restore_slave = true;
   restart_arg.printtoc = utility_get_option_bool_value (arg_map, RESTORESLAVE_LIST_S);
@@ -3767,6 +3769,7 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
       goto print_restoreslave_usage;
     }
 
+#if defined 0			/* temporary disables */
   if (check_ha_db_and_node_list (database_name, master_host_name) == false)
     {
       fprintf (stderr,
@@ -3791,6 +3794,7 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
 
       return EXIT_SUCCESS;
     }
+#endif /* temporary disables */
 
   sysprm_set_force (prm_get_name (PRM_ID_JAVA_STORED_PROCEDURE), "no");
 
@@ -3822,6 +3826,7 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
       return EXIT_FAILURE;
     }
 
+#if defined 0			/* temporary disables */
   if (init_ha_catalog)
     {
       error_code = delete_all_ha_apply_info ();
@@ -3865,6 +3870,7 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
 	}
 
     }
+#endif /* temporary disables */
   db_commit_transaction ();
   db_shutdown ();
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1649,6 +1649,9 @@ log_final (THREAD_ENTRY * thread_p)
 
   LOG_CS_ENTER (thread_p);
 
+  /* reset log_Gl.rcv_phase */
+  log_Gl.rcv_phase = LOG_RECOVERY_ANALYSIS_PHASE;
+
   if (log_Gl.trantable.area == NULL)
     {
       LOG_CS_EXIT (thread_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21352

The issue is caused by shutdown/restart server in the same execution instance. Global variables are not always properly reset.

This case was caused by log_GL.rcv_phase. We supress **pgbuf_is_temporary_volume** check when server is not yet restarted. This may be called before disk cache is loaded, which is problematic and a safe-guard is hit.

In our case, restoreslave first calls **boot_restart_from_backup**, shuts it down and then **db_restart** to apply HA logs. Since log_GL.rcv_phase was not properly reset during shutdown, when volumes are booted, it crashes calling pgbuf_is_temporary_volume (debug mode).

This fixes log_GL.rcv_phase, which proved to be enough for the case described in issue. However, I doubt this is the only issue we face because globals are not properly reset.