### PR TITLE
[CBRD-21362] fixes double free of heap_classrepr_free

### DIFF
--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -3555,164 +3555,166 @@ or_free_classrep (OR_CLASSREP * rep)
   OR_INDEX *index;
   OR_FOREIGN_KEY *fk, *fk_next;
 
-  if (rep != NULL)
+  if (rep == NULL)
     {
-      if (rep->attributes != NULL)
-	{
-	  for (i = 0, att = rep->attributes; i < rep->n_attributes; i++, att++)
-	    {
-	      if (att->default_value.value != NULL)
-		{
-		  free_and_init (att->default_value.value);
-		}
-
-	      if (att->default_value.default_expr.default_expr_format != NULL)
-		{
-		  free_and_init (att->default_value.default_expr.default_expr_format);
-		}
-
-	      if (att->current_default_value.value != NULL)
-		{
-		  free_and_init (att->current_default_value.value);
-		}
-
-	      if (att->current_default_value.default_expr.default_expr_format != NULL)
-		{
-		  free_and_init (att->current_default_value.default_expr.default_expr_format);
-		}
-
-	      if (att->btids != NULL && att->btids != att->btid_pack)
-		{
-		  free_and_init (att->btids);
-		}
-	    }
-	  free_and_init (rep->attributes);
-	}
-
-      if (rep->shared_attrs != NULL)
-	{
-	  for (i = 0, att = rep->shared_attrs; i < rep->n_shared_attrs; i++, att++)
-	    {
-	      if (att->default_value.value != NULL)
-		{
-		  free_and_init (att->default_value.value);
-		}
-
-	      if (att->default_value.default_expr.default_expr_format != NULL)
-		{
-		  free_and_init (att->default_value.default_expr.default_expr_format);
-		}
-
-	      if (att->current_default_value.value != NULL)
-		{
-		  free_and_init (att->current_default_value.value);
-		}
-
-	      if (att->current_default_value.default_expr.default_expr_format != NULL)
-		{
-		  free_and_init (att->current_default_value.default_expr.default_expr_format);
-		}
-
-	      if (att->btids != NULL && att->btids != att->btid_pack)
-		{
-		  free_and_init (att->btids);
-		}
-	    }
-	  free_and_init (rep->shared_attrs);
-	}
-
-      if (rep->class_attrs != NULL)
-	{
-	  for (i = 0, att = rep->class_attrs; i < rep->n_class_attrs; i++, att++)
-	    {
-	      if (att->default_value.value != NULL)
-		{
-		  free_and_init (att->default_value.value);
-		}
-
-	      if (att->current_default_value.value != NULL)
-		{
-		  free_and_init (att->current_default_value.value);
-		}
-
-	      if (att->btids != NULL && att->btids != att->btid_pack)
-		{
-		  free_and_init (att->btids);
-		}
-	    }
-	  free_and_init (rep->class_attrs);
-	}
-
-      if (rep->indexes != NULL)
-	{
-	  for (i = 0, index = rep->indexes; i < rep->n_indexes; i++, index++)
-	    {
-	      if (index->atts != NULL)
-		{
-		  free_and_init (index->atts);
-		}
-
-	      if (index->btname != NULL)
-		{
-		  free_and_init (index->btname);
-		}
-
-	      if (index->filter_predicate)
-		{
-		  if (index->filter_predicate->pred_string)
-		    {
-		      free_and_init (index->filter_predicate->pred_string);
-		    }
-
-		  if (index->filter_predicate->pred_stream)
-		    {
-		      free_and_init (index->filter_predicate->pred_stream);
-		    }
-
-		  free_and_init (index->filter_predicate);
-		}
-
-	      if (index->asc_desc != NULL)
-		{
-		  free_and_init (index->asc_desc);
-		}
-
-	      if (index->attrs_prefix_length != NULL)
-		{
-		  free_and_init (index->attrs_prefix_length);
-		}
-
-	      if (index->fk)
-		{
-		  for (fk = index->fk; fk; fk = fk_next)
-		    {
-		      fk_next = fk->next;
-		      if (fk->fkname)
-			{
-			  free_and_init (fk->fkname);
-			}
-		      free_and_init (fk);
-		    }
-		}
-	      if (index->func_index_info)
-		{
-		  if (index->func_index_info->expr_string)
-		    {
-		      free_and_init (index->func_index_info->expr_string);
-		    }
-		  if (index->func_index_info->expr_stream)
-		    {
-		      free_and_init (index->func_index_info->expr_stream);
-		    }
-		  free_and_init (index->func_index_info);
-		}
-	    }
-
-	  free_and_init (rep->indexes);
-	}
-
-      free_and_init (rep);
+      return;
     }
+
+  if (rep->attributes != NULL)
+    {
+      for (i = 0, att = rep->attributes; i < rep->n_attributes; i++, att++)
+	{
+	  if (att->default_value.value != NULL)
+	    {
+	      free_and_init (att->default_value.value);
+	    }
+
+	  if (att->default_value.default_expr.default_expr_format != NULL)
+	    {
+	      free_and_init (att->default_value.default_expr.default_expr_format);
+	    }
+
+	  if (att->current_default_value.value != NULL)
+	    {
+	      free_and_init (att->current_default_value.value);
+	    }
+
+	  if (att->current_default_value.default_expr.default_expr_format != NULL)
+	    {
+	      free_and_init (att->current_default_value.default_expr.default_expr_format);
+	    }
+
+	  if (att->btids != NULL && att->btids != att->btid_pack)
+	    {
+	      free_and_init (att->btids);
+	    }
+	}
+      free_and_init (rep->attributes);
+    }
+
+  if (rep->shared_attrs != NULL)
+    {
+      for (i = 0, att = rep->shared_attrs; i < rep->n_shared_attrs; i++, att++)
+	{
+	  if (att->default_value.value != NULL)
+	    {
+	      free_and_init (att->default_value.value);
+	    }
+
+	  if (att->default_value.default_expr.default_expr_format != NULL)
+	    {
+	      free_and_init (att->default_value.default_expr.default_expr_format);
+	    }
+
+	  if (att->current_default_value.value != NULL)
+	    {
+	      free_and_init (att->current_default_value.value);
+	    }
+
+	  if (att->current_default_value.default_expr.default_expr_format != NULL)
+	    {
+	      free_and_init (att->current_default_value.default_expr.default_expr_format);
+	    }
+
+	  if (att->btids != NULL && att->btids != att->btid_pack)
+	    {
+	      free_and_init (att->btids);
+	    }
+	}
+      free_and_init (rep->shared_attrs);
+    }
+
+  if (rep->class_attrs != NULL)
+    {
+      for (i = 0, att = rep->class_attrs; i < rep->n_class_attrs; i++, att++)
+	{
+	  if (att->default_value.value != NULL)
+	    {
+	      free_and_init (att->default_value.value);
+	    }
+
+	  if (att->current_default_value.value != NULL)
+	    {
+	      free_and_init (att->current_default_value.value);
+	    }
+
+	  if (att->btids != NULL && att->btids != att->btid_pack)
+	    {
+	      free_and_init (att->btids);
+	    }
+	}
+      free_and_init (rep->class_attrs);
+    }
+
+  if (rep->indexes != NULL)
+    {
+      for (i = 0, index = rep->indexes; i < rep->n_indexes; i++, index++)
+	{
+	  if (index->atts != NULL)
+	    {
+	      free_and_init (index->atts);
+	    }
+
+	  if (index->btname != NULL)
+	    {
+	      free_and_init (index->btname);
+	    }
+
+	  if (index->filter_predicate)
+	    {
+	      if (index->filter_predicate->pred_string)
+		{
+		  free_and_init (index->filter_predicate->pred_string);
+		}
+
+	      if (index->filter_predicate->pred_stream)
+		{
+		  free_and_init (index->filter_predicate->pred_stream);
+		}
+
+	      free_and_init (index->filter_predicate);
+	    }
+
+	  if (index->asc_desc != NULL)
+	    {
+	      free_and_init (index->asc_desc);
+	    }
+
+	  if (index->attrs_prefix_length != NULL)
+	    {
+	      free_and_init (index->attrs_prefix_length);
+	    }
+
+	  if (index->fk)
+	    {
+	      for (fk = index->fk; fk; fk = fk_next)
+		{
+		  fk_next = fk->next;
+		  if (fk->fkname)
+		    {
+		      free_and_init (fk->fkname);
+		    }
+		  free_and_init (fk);
+		}
+	    }
+	  if (index->func_index_info)
+	    {
+	      if (index->func_index_info->expr_string)
+		{
+		  free_and_init (index->func_index_info->expr_string);
+		}
+	      if (index->func_index_info->expr_stream)
+		{
+		  free_and_init (index->func_index_info->expr_stream);
+		}
+	      free_and_init (index->func_index_info);
+	    }
+	}
+
+      free_and_init (rep->indexes);
+    }
+
+  free_and_init (rep);
 }
 
 /*

--- a/src/query/partition.c
+++ b/src/query/partition.c
@@ -3399,7 +3399,7 @@ cleanup:
     }
   if (classrepr != NULL)
     {
-      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
     }
   if (error != NO_ERROR)
     {

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -21874,7 +21874,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
   free_and_init (attr_ids);
   free_and_init (attr_names);
 
-  catalog_free_representation (disk_repr_p);
+  catalog_free_representation_and_init (disk_repr_p);
   heap_classrepr_free_and_init (rep, &idx_incache);
   if (heap_scancache_end (thread_p, &scan) != NO_ERROR)
     {
@@ -21941,7 +21941,7 @@ exit_on_error:
 
   if (disk_repr_p)
     {
-      catalog_free_representation (disk_repr_p);
+      catalog_free_representation_and_init (disk_repr_p);
     }
 
   if (rep)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -21875,7 +21875,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
   free_and_init (attr_names);
 
   catalog_free_representation (disk_repr_p);
-  (void) heap_classrepr_free (rep, &idx_incache);
+  heap_classrepr_free_and_init (rep, &idx_incache);
   if (heap_scancache_end (thread_p, &scan) != NO_ERROR)
     {
       GOTO_EXIT_ON_ERROR;
@@ -21946,7 +21946,7 @@ exit_on_error:
 
   if (rep)
     {
-      (void) heap_classrepr_free (rep, &idx_incache);
+      heap_classrepr_free_and_init (rep, &idx_incache);
     }
 
   heap_scancache_end (thread_p, &scan);
@@ -22809,7 +22809,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 
   free_and_init (out_values);
 
-  (void) heap_classrepr_free (rep, &idx_incache);
+  heap_classrepr_free_and_init (rep, &idx_incache);
   if (heap_scancache_end (thread_p, &scan) != NO_ERROR)
     {
       GOTO_EXIT_ON_ERROR;
@@ -22847,7 +22847,7 @@ exit_on_error:
 
   if (rep)
     {
-      (void) heap_classrepr_free (rep, &idx_incache);
+      heap_classrepr_free_and_init (rep, &idx_incache);
     }
 
   heap_scancache_end (thread_p, &scan);

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -2189,7 +2189,7 @@ xcache_check_recompilation_threshold (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY 
       if (HFID_IS_NULL (&cls_info_p->ci_hfid))
 	{
 	  /* Is this expected?? */
-	  catalog_free_class_info (cls_info_p);
+	  catalog_free_class_info_and_init (cls_info_p);
 	  continue;
 	}
       assert (!VFID_ISNULL (&cls_info_p->ci_hfid.vfid));
@@ -2213,7 +2213,7 @@ xcache_check_recompilation_threshold (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY 
 	      recompile = true;
 	    }
 	}
-      catalog_free_class_info (cls_info_p);
+      catalog_free_class_info_and_init (cls_info_p);
     }
   return recompile;
 }

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -7635,7 +7635,7 @@ exit_on_end:
 int
 btree_get_pkey_btid (THREAD_ENTRY * thread_p, OID * cls_oid, BTID * pkey_btid)
 {
-  OR_CLASSREP *cls_repr;
+  OR_CLASSREP *cls_repr = NULL;
   OR_INDEX *curr_idx;
   int cache_idx = -1;
   int i;
@@ -7672,7 +7672,7 @@ btree_get_pkey_btid (THREAD_ENTRY * thread_p, OID * cls_oid, BTID * pkey_btid)
 
   if (cls_repr != NULL)
     {
-      heap_classrepr_free (cls_repr, &cache_idx);
+      heap_classrepr_free_and_init (cls_repr, &cache_idx);
     }
 
   return error;
@@ -7687,7 +7687,7 @@ btree_get_pkey_btid (THREAD_ENTRY * thread_p, OID * cls_oid, BTID * pkey_btid)
 DISK_ISVALID
 btree_check_by_class_oid (THREAD_ENTRY * thread_p, OID * cls_oid, BTID * idx_btid)
 {
-  OR_CLASSREP *cls_repr;
+  OR_CLASSREP *cls_repr = NULL;
   OR_INDEX *curr;
   BTID btid;
   int i;
@@ -7735,7 +7735,7 @@ btree_check_by_class_oid (THREAD_ENTRY * thread_p, OID * cls_oid, BTID * idx_bti
 
   if (cls_repr)
     {
-      heap_classrepr_free (cls_repr, &cache_idx);
+      heap_classrepr_free_and_init (cls_repr, &cache_idx);
     }
 
   return rv;
@@ -7949,7 +7949,7 @@ exit_repair:
 static DISK_ISVALID
 btree_repair_prev_link_by_class_oid (THREAD_ENTRY * thread_p, OID * oid, BTID * index_btid, bool repair)
 {
-  OR_CLASSREP *cls_repr;
+  OR_CLASSREP *cls_repr = NULL;
   OR_INDEX *curr;
   int i;
   int cache_idx = -1;
@@ -7987,7 +7987,7 @@ btree_repair_prev_link_by_class_oid (THREAD_ENTRY * thread_p, OID * oid, BTID * 
   lock_unlock_object (thread_p, oid, oid_Root_class_oid, IS_LOCK, true);
   if (cls_repr)
     {
-      heap_classrepr_free (cls_repr, &cache_idx);
+      heap_classrepr_free_and_init (cls_repr, &cache_idx);
     }
 
   return valid;
@@ -20353,7 +20353,7 @@ btree_index_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_
   int i, error = NO_ERROR;
   OID oid;
   OR_CLASSREP *classrep = NULL;
-  int idx_in_cache;
+  int idx_in_cache = -1;
   SHOW_INDEX_SCAN_CTX *ctx = NULL;
   LC_FIND_CLASSNAME status;
   OR_PARTITION *parts = NULL;
@@ -20456,7 +20456,7 @@ cleanup:
 
   if (classrep != NULL)
     {
-      heap_classrepr_free (classrep, &idx_in_cache);
+      heap_classrepr_free_and_init (classrep, &idx_in_cache);
     }
 
   if (parts != NULL)
@@ -20500,7 +20500,7 @@ btree_index_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
   OR_CLASSREP *classrep = NULL;
   SHOW_INDEX_SCAN_CTX *ctx = NULL;
   OID *class_oid_p = NULL;
-  int idx_in_cache;
+  int idx_in_cache = -1;
   int selected_index = 0;
   int i, index_idx, oid_idx;
   char columns[256] = { 0 };
@@ -20575,7 +20575,7 @@ cleanup:
 
   if (classrep != NULL)
     {
-      heap_classrepr_free (classrep, &idx_in_cache);
+      heap_classrepr_free_and_init (classrep, &idx_in_cache);
     }
 
   if (class_name != NULL)

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -2937,7 +2937,7 @@ btree_check_foreign_key (THREAD_ENTRY * thread_p, OID * cls_oid, HFID * hfid, OI
     }
   if (classrepr != NULL)
     {
-      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
     }
 
   return ret;
@@ -2950,7 +2950,7 @@ exit_on_error:
     }
   if (classrepr != NULL)
     {
-      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
     }
   return (ret == NO_ERROR && (ret = er_errid ()) == NO_ERROR) ? ER_FAILED : ret;
 }

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -679,14 +679,14 @@ catcls_find_btid_of_class_name (THREAD_ENTRY * thread_p, BTID * btid_p)
       BTID_COPY (btid_p, &(att_repr_p->bt_stats->btid));
     }
 
-  catalog_free_representation (repr_p);
+  catalog_free_representation_and_init (repr_p);
   return NO_ERROR;
 
 error:
 
   if (repr_p)
     {
-      catalog_free_representation (repr_p);
+      catalog_free_representation_and_init (repr_p);
     }
 
   return error;
@@ -2862,7 +2862,7 @@ catcls_reorder_attributes_by_repr (THREAD_ENTRY * thread_p, OR_VALUE * value_p)
 	    }
 	}
     }
-  catalog_free_representation (repr_p);
+  catalog_free_representation_and_init (repr_p);
 
   return NO_ERROR;
 
@@ -2870,7 +2870,7 @@ error:
 
   if (repr_p)
     {
-      catalog_free_representation (repr_p);
+      catalog_free_representation_and_init (repr_p);
     }
 
   return error;
@@ -3334,12 +3334,12 @@ catcls_put_or_value_into_record (THREAD_ENTRY * thread_p, OR_VALUE * value_p, in
   error = catcls_put_or_value_into_buffer (value_p, chn, buf_p, class_oid_p, repr_p);
   if (error != NO_ERROR)
     {
-      catalog_free_representation (repr_p);
+      catalog_free_representation_and_init (repr_p);
       return error;
     }
 
   record_p->length = (int) (buf_p->ptr - buf_p->buffer);
-  catalog_free_representation (repr_p);
+  catalog_free_representation_and_init (repr_p);
 
   return NO_ERROR;
 }
@@ -3425,7 +3425,7 @@ catcls_get_or_value_from_record (THREAD_ENTRY * thread_p, RECDES * record_p, OID
       goto error;
     }
 
-  catalog_free_representation (repr_p);
+  catalog_free_representation_and_init (repr_p);
   return value_p;
 
 error:
@@ -3437,7 +3437,7 @@ error:
 
   if (repr_p)
     {
-      catalog_free_representation (repr_p);
+      catalog_free_representation_and_init (repr_p);
     }
 
   return NULL;

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -3519,7 +3519,7 @@ catcls_insert_subset (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * root_oi
   db_make_sequence (&value_p->value, oid_set_p);
 
   heap_scancache_end_modify (thread_p, &scan);
-  catalog_free_class_info (cls_info_p);
+  catalog_free_class_info_and_init (cls_info_p);
 
   return NO_ERROR;
 
@@ -3537,7 +3537,7 @@ error:
 
   if (cls_info_p)
     {
-      catalog_free_class_info (cls_info_p);
+      catalog_free_class_info_and_init (cls_info_p);
     }
 
   return error;
@@ -3609,7 +3609,7 @@ catcls_delete_subset (THREAD_ENTRY * thread_p, OR_VALUE * value_p)
     }
 
   heap_scancache_end_modify (thread_p, &scan);
-  catalog_free_class_info (cls_info_p);
+  catalog_free_class_info_and_init (cls_info_p);
 
   return NO_ERROR;
 
@@ -3622,7 +3622,7 @@ error:
 
   if (cls_info_p)
     {
-      catalog_free_class_info (cls_info_p);
+      catalog_free_class_info_and_init (cls_info_p);
     }
 
   return error;
@@ -4056,7 +4056,7 @@ catcls_insert_catalog_classes (THREAD_ENTRY * thread_p, RECDES * record_p)
     }
 
   heap_scancache_end_modify (thread_p, &scan);
-  catalog_free_class_info (cls_info_p);
+  catalog_free_class_info_and_init (cls_info_p);
   catcls_free_or_value (value_p);
 
   return NO_ERROR;
@@ -4070,7 +4070,7 @@ error:
 
   if (cls_info_p)
     {
-      catalog_free_class_info (cls_info_p);
+      catalog_free_class_info_and_init (cls_info_p);
     }
 
   if (value_p)
@@ -4142,7 +4142,7 @@ catcls_delete_catalog_classes (THREAD_ENTRY * thread_p, const char *name_p, OID 
   csect_exit (thread_p, CSECT_CT_OID_TABLE);
 
   heap_scancache_end_modify (thread_p, &scan);
-  catalog_free_class_info (cls_info_p);
+  catalog_free_class_info_and_init (cls_info_p);
 
   return NO_ERROR;
 
@@ -4155,7 +4155,7 @@ error:
 
   if (cls_info_p)
     {
-      catalog_free_class_info (cls_info_p);
+      catalog_free_class_info_and_init (cls_info_p);
     }
 
   return ER_FAILED;
@@ -4221,7 +4221,7 @@ catcls_update_catalog_classes (THREAD_ENTRY * thread_p, const char *name_p, RECD
     }
 
   heap_scancache_end_modify (thread_p, &scan);
-  catalog_free_class_info (cls_info_p);
+  catalog_free_class_info_and_init (cls_info_p);
   catcls_free_or_value (value_p);
 
   return NO_ERROR;
@@ -4235,7 +4235,7 @@ error:
 
   if (cls_info_p)
     {
-      catalog_free_class_info (cls_info_p);
+      catalog_free_class_info_and_init (cls_info_p);
     }
 
   if (value_p)
@@ -4785,7 +4785,7 @@ catcls_update_subset (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OR_VALUE * ol
     }
 
   heap_scancache_end_modify (thread_p, &scan);
-  catalog_free_class_info (cls_info_p);
+  catalog_free_class_info_and_init (cls_info_p);
 
   return NO_ERROR;
 
@@ -4802,7 +4802,7 @@ error:
 
   if (cls_info_p)
     {
-      catalog_free_class_info (cls_info_p);
+      catalog_free_class_info_and_init (cls_info_p);
     }
 
   return error;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -1848,6 +1848,8 @@ heap_classrepr_decache (THREAD_ENTRY * thread_p, const OID * class_oid)
  * replacement when the fix count is zero (no one is using it).
  * If the class representatin was not part of the cache, it is
  * freed.
+ *
+ * NOTE: consider to use heap_classrepr_free_and_init.
  */
 int
 heap_classrepr_free (OR_CLASSREP * classrep, int *idx_incache)
@@ -6755,7 +6757,7 @@ heap_scancache_start_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cach
 	  if (scan_cache->index_stat_info == NULL)
 	    {
 	      ret = ER_OUT_OF_VIRTUAL_MEMORY;
-	      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+	      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
 	      goto exit_on_error;
 	    }
 	  /* initialize the structure */
@@ -6769,11 +6771,7 @@ heap_scancache_start_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cach
 	}
 
       /* free class representation */
-      ret = heap_classrepr_free (classrepr, &classrepr_cacheindex);
-      if (ret != NO_ERROR)
-	{
-	  goto exit_on_error;
-	}
+      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
     }
 
   /* In case of SINGLE_ROW_INSERT, SINGLE_ROW_UPDATE, SINGLE_ROW_DELETE, or SINGLE_ROW_MODIFY, the 'num_btids' and
@@ -9793,11 +9791,7 @@ heap_attrinfo_recache (THREAD_ENTRY * thread_p, REPR_ID reprid, HEAP_CACHE_ATTRI
        */
       if (attr_info->read_classrepr != attr_info->last_classrepr)
 	{
-	  ret = heap_classrepr_free (attr_info->read_classrepr, &attr_info->read_cacheindex);
-	  if (ret != NO_ERROR)
-	    {
-	      goto exit_on_error;
-	    }
+	  heap_classrepr_free_and_init (attr_info->read_classrepr, &attr_info->read_cacheindex);
 	}
       attr_info->read_classrepr = NULL;
     }
@@ -9845,8 +9839,7 @@ heap_attrinfo_recache (THREAD_ENTRY * thread_p, REPR_ID reprid, HEAP_CACHE_ATTRI
 
   if (heap_attrinfo_recache_attrepr (attr_info, false) != NO_ERROR)
     {
-      (void) heap_classrepr_free (attr_info->read_classrepr, &attr_info->read_cacheindex);
-      attr_info->read_classrepr = NULL;
+      heap_classrepr_free_and_init (attr_info->read_classrepr, &attr_info->read_cacheindex);
 
       goto exit_on_error;
     }
@@ -9885,8 +9878,7 @@ heap_attrinfo_end (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info)
 
   if (attr_info->last_classrepr != NULL)
     {
-      ret = heap_classrepr_free (attr_info->last_classrepr, &attr_info->last_cacheindex);
-      attr_info->last_classrepr = NULL;
+      heap_classrepr_free_and_init (attr_info->last_classrepr, &attr_info->last_cacheindex);
     }
 
   if (attr_info->values)
@@ -11816,7 +11808,7 @@ heap_attrinfo_start_refoids (THREAD_ENTRY * thread_p, OID * class_oid, HEAP_CACH
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
 		  classrepr->n_attributes * sizeof (ATTR_ID));
-	  (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+	  heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
     }
@@ -11841,14 +11833,7 @@ heap_attrinfo_start_refoids (THREAD_ENTRY * thread_p, OID * class_oid, HEAP_CACH
       free_and_init (set_attrids);
     }
 
-  if (ret == NO_ERROR)
-    {
-      ret = heap_classrepr_free (classrepr, &classrepr_cacheindex);
-    }
-  else
-    {
-      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
-    }
+  heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
 
   return ret;
 }
@@ -11898,7 +11883,7 @@ heap_attrinfo_start_with_index (THREAD_ENTRY * thread_p, OID * class_oid, RECDES
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
 		  classrepr->n_attributes * sizeof (ATTR_ID));
-	  (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+	  heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
     }
@@ -11966,7 +11951,7 @@ heap_attrinfo_start_with_index (THREAD_ENTRY * thread_p, OID * class_oid, RECDES
       attr_info->num_values = -1;
 
       /* free the class representation */
-      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
     }
   else
     {				/* num_found_attrs > 0 */
@@ -11991,7 +11976,7 @@ heap_attrinfo_start_with_index (THREAD_ENTRY * thread_p, OID * class_oid, RECDES
 	  if (attr_info->values == NULL)
 	    {
 	      /* free the class representation */
-	      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+	      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
 	      attr_info->num_values = -1;
 	      goto error;
 	    }
@@ -12161,8 +12146,7 @@ heap_attrinfo_start_with_btid (THREAD_ENTRY * thread_p, OID * class_oid, BTID * 
       set_attrids[i] = classrepr->indexes[index_id].atts[i]->id;
     }
 
-  (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
-  classrepr = NULL;
+  heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
 
   /* 
    *  Get the attribute information for the collected ID's
@@ -12190,7 +12174,7 @@ error:
 
   if (classrepr)
     {
-      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
     }
 
   if (set_attrids != guess_attrids)
@@ -12979,8 +12963,9 @@ heap_get_index_with_name (THREAD_ENTRY * thread_p, OID * class_oid, const char *
     }
   if (classrep != NULL)
     {
-      error = heap_classrepr_free (classrep, &idx_in_cache);
+      heap_classrepr_free_and_init (classrep, &idx_in_cache);
     }
+
   return error;
 }
 
@@ -13107,11 +13092,7 @@ heap_get_indexinfo_of_btid (THREAD_ENTRY * thread_p, const OID * class_oid, cons
     }
 
   /* free the class representation */
-  ret = heap_classrepr_free (classrepp, &idx_in_cache);
-  if (ret != NO_ERROR)
-    {
-      goto exit_on_error;
-    }
+  heap_classrepr_free_and_init (classrepp, &idx_in_cache);
 
   return ret;
 
@@ -13138,7 +13119,7 @@ exit_on_error:
 
   if (classrepp)
     {
-      (void) heap_classrepr_free (classrepp, &idx_in_cache);
+      heap_classrepr_free_and_init (classrepp, &idx_in_cache);
     }
 
   return (ret == NO_ERROR && (ret = er_errid ()) == NO_ERROR) ? ER_FAILED : ret;
@@ -16330,7 +16311,7 @@ xheap_has_instance (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 REPR_ID
 heap_get_class_repr_id (THREAD_ENTRY * thread_p, OID * class_oid)
 {
-  OR_CLASSREP *rep;
+  OR_CLASSREP *rep = NULL;
   REPR_ID id;
   int idx_incache = -1;
 
@@ -16346,7 +16327,7 @@ heap_get_class_repr_id (THREAD_ENTRY * thread_p, OID * class_oid)
     }
 
   id = rep->id;
-  (void) heap_classrepr_free (rep, &idx_incache);
+  heap_classrepr_free_and_init (rep, &idx_incache);
 
   return id;
 }
@@ -16480,11 +16461,7 @@ heap_set_autoincrement_value (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * att
 		  search_result =
 		    xbtree_find_unique (thread_p, &serial_btid, S_SELECT, &key_val, &serial_class_oid, &serial_oid,
 					false);
-		  if (heap_classrepr_free (classrep, &idx_in_cache) != NO_ERROR)
-		    {
-		      ret = ER_FAILED;
-		      goto exit_on_error;
-		    }
+		  heap_classrepr_free_and_init (classrep, &idx_in_cache);
 		  if (search_result != BTREE_KEY_FOUND)
 		    {
 		      ret = ER_FAILED;
@@ -16497,7 +16474,7 @@ heap_set_autoincrement_value (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * att
 		}
 	      else
 		{
-		  (void) heap_classrepr_free (classrep, &idx_in_cache);
+		  heap_classrepr_free_and_init (classrep, &idx_in_cache);
 		  ret = ER_FAILED;
 		  goto exit_on_error;
 		}
@@ -16862,7 +16839,7 @@ heap_get_btid_from_index_name (THREAD_ENTRY * thread_p, const OID * p_class_oid,
 exit_cleanup:
   if (classrepr)
     {
-      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
     }
 
 exit:

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -85,6 +85,17 @@
     } \
   while (0)
 
+#define heap_classrepr_free_and_init(class_repr, idxp) \
+  do \
+    { \
+      if ((class_repr) != NULL) \
+        { \
+          heap_classrepr_free ((class_repr), (idxp)); \
+          (class_repr) = NULL; \
+        } \
+    } \
+  while (0)
+
 /*
  * Heap scan structures
  */

--- a/src/storage/statistics_sr.c
+++ b/src/storage/statistics_sr.c
@@ -324,7 +324,7 @@ end:
 
   if (disk_repr_p)
     {
-      catalog_free_representation (disk_repr_p);
+      catalog_free_representation_and_init (disk_repr_p);
     }
 
   if (cls_info_p)
@@ -791,7 +791,7 @@ xstats_get_statistics_from_server (THREAD_ENTRY * thread_p, OID * class_id_p, un
   OR_PUT_INT (buf_p, max_unique_keys);
   buf_p += OR_INT_SIZE;
 
-  catalog_free_representation (disk_repr_p);
+  catalog_free_representation_and_init (disk_repr_p);
   catalog_free_class_info_and_init (cls_info_p);
 
   *length_p = CAST_STRLEN (buf_p - start_p);
@@ -814,7 +814,7 @@ exit_on_error:
 
   if (disk_repr_p)
     {
-      catalog_free_representation (disk_repr_p);
+      catalog_free_representation_and_init (disk_repr_p);
     }
   if (cls_info_p)
     {
@@ -1430,8 +1430,7 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 	}
       if (subcls_disk_rep != NULL)
 	{
-	  catalog_free_representation (subcls_disk_rep);
-	  subcls_disk_rep = NULL;
+	  catalog_free_representation_and_init (subcls_disk_rep);
 	}
       if (subcls_rep != NULL)
 	{
@@ -1569,8 +1568,7 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
       /* clean subclass loaded in previous iteration */
       if (subcls_disk_rep != NULL)
 	{
-	  catalog_free_representation (subcls_disk_rep);
-	  subcls_disk_rep = NULL;
+	  catalog_free_representation_and_init (subcls_disk_rep);
 	}
       if (subcls_rep != NULL)
 	{
@@ -1774,10 +1772,10 @@ cleanup:
 	{
 	  if (mean[i].pkeys != NULL)
 	    {
-	      db_private_free (thread_p, mean[i].pkeys);
+	      db_private_free_and_init (thread_p, mean[i].pkeys);
 	    }
 	}
-      db_private_free (thread_p, mean);
+      db_private_free_and_init (thread_p, mean);
     }
   if (stddev != NULL)
     {
@@ -1796,7 +1794,7 @@ cleanup:
     }
   if (subcls_disk_rep != NULL)
     {
-      catalog_free_representation (subcls_disk_rep);
+      catalog_free_representation_and_init (subcls_disk_rep);
     }
   if (cls_info_p != NULL)
     {
@@ -1804,7 +1802,7 @@ cleanup:
     }
   if (disk_repr_p != NULL)
     {
-      catalog_free_representation (disk_repr_p);
+      catalog_free_representation_and_init (disk_repr_p);
     }
 
   return error;

--- a/src/storage/statistics_sr.c
+++ b/src/storage/statistics_sr.c
@@ -214,8 +214,7 @@ xstats_update_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, bool with_f
     {
       /* Update statistics for all partitions and the partitioned class */
       assert (partitions != NULL);
-      catalog_free_class_info (cls_info_p);
-      cls_info_p = NULL;
+      catalog_free_class_info_and_init (cls_info_p);
       error_code = stats_update_partitioned_statistics (thread_p, class_id_p, partitions, count, with_fullscan);
       db_private_free (thread_p, partitions);
       if (error_code != NO_ERROR)
@@ -330,7 +329,7 @@ end:
 
   if (cls_info_p)
     {
-      catalog_free_class_info (cls_info_p);
+      catalog_free_class_info_and_init (cls_info_p);
     }
 
   er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_FINISHED_TO_UPDATE_STATISTICS, 5,
@@ -793,7 +792,7 @@ xstats_get_statistics_from_server (THREAD_ENTRY * thread_p, OID * class_id_p, un
   buf_p += OR_INT_SIZE;
 
   catalog_free_representation (disk_repr_p);
-  catalog_free_class_info (cls_info_p);
+  catalog_free_class_info_and_init (cls_info_p);
 
   *length_p = CAST_STRLEN (buf_p - start_p);
 
@@ -819,7 +818,7 @@ exit_on_error:
     }
   if (cls_info_p)
     {
-      catalog_free_class_info (cls_info_p);
+      catalog_free_class_info_and_init (cls_info_p);
     }
 
 #if !defined(NDEBUG)
@@ -1427,8 +1426,7 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
       /* clean subclass loaded in previous iteration */
       if (subcls_info != NULL)
 	{
-	  catalog_free_class_info (subcls_info);
-	  subcls_info = NULL;
+	  catalog_free_class_info_and_init (subcls_info);
 	}
       if (subcls_disk_rep != NULL)
 	{
@@ -1794,7 +1792,7 @@ cleanup:
     }
   if (subcls_info)
     {
-      catalog_free_class_info (subcls_info);
+      catalog_free_class_info_and_init (subcls_info);
     }
   if (subcls_disk_rep != NULL)
     {
@@ -1802,7 +1800,7 @@ cleanup:
     }
   if (cls_info_p != NULL)
     {
-      catalog_free_class_info (cls_info_p);
+      catalog_free_class_info_and_init (cls_info_p);
     }
   if (disk_repr_p != NULL)
     {

--- a/src/storage/statistics_sr.c
+++ b/src/storage/statistics_sr.c
@@ -1437,8 +1437,7 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 	}
       if (subcls_rep != NULL)
 	{
-	  heap_classrepr_free (subcls_rep, &subcls_idx_cache);
-	  subcls_rep = NULL;
+	  heap_classrepr_free_and_init (subcls_rep, &subcls_idx_cache);
 	}
 
       if (catalog_get_dir_oid_from_cache (thread_p, &partitions[i], &part_dir_oid) != NO_ERROR)
@@ -1577,8 +1576,7 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 	}
       if (subcls_rep != NULL)
 	{
-	  heap_classrepr_free (subcls_rep, &subcls_idx_cache);
-	  subcls_rep = NULL;
+	  heap_classrepr_free_and_init (subcls_rep, &subcls_idx_cache);
 	}
 
       if (catalog_get_dir_oid_from_cache (thread_p, &partitions[i], &part_dir_oid) != NO_ERROR)
@@ -1766,11 +1764,11 @@ cleanup:
 
   if (cls_rep != NULL)
     {
-      heap_classrepr_free (cls_rep, &cls_idx_cache);
+      heap_classrepr_free_and_init (cls_rep, &cls_idx_cache);
     }
   if (subcls_rep != NULL)
     {
-      heap_classrepr_free (subcls_rep, &subcls_idx_cache);
+      heap_classrepr_free_and_init (subcls_rep, &subcls_idx_cache);
     }
   if (mean != NULL)
     {

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -3937,8 +3937,7 @@ catalog_get_representation (THREAD_ENTRY * thread_p, OID * class_id_p, REPR_ID r
     {
       if (disk_repr_p)
 	{
-	  catalog_free_representation (disk_repr_p);
-	  disk_repr_p = NULL;
+	  catalog_free_representation_and_init (disk_repr_p);
 	}
 
       if (catalog_record.page_p)
@@ -4038,8 +4037,7 @@ exit_on_error:
   error = ER_FAILED;
   if (disk_repr_p)
     {
-      catalog_free_representation (disk_repr_p);
-      disk_repr_p = NULL;
+      catalog_free_representation_and_init (disk_repr_p);
     }
 
   goto exit_on_end;
@@ -4484,7 +4482,7 @@ catalog_update (THREAD_ENTRY * thread_p, RECDES * record_p, OID * class_oid_p)
 	  catalog_copy_disk_attributes (disk_repr_p->variable, disk_repr_p->n_variable, old_repr_p->variable,
 					old_repr_p->n_variable);
 
-	  catalog_free_representation (old_repr_p);
+	  catalog_free_representation_and_init (old_repr_p);
 	  catalog_drop (thread_p, class_oid_p, current_repr_id);
 	}
     }
@@ -5083,7 +5081,7 @@ catalog_dump (THREAD_ENTRY * thread_p, FILE * fp, int dump_flag)
 	    }
 
 	  catalog_dump_representation (disk_repr_p);
-	  catalog_free_representation (disk_repr_p);
+	  catalog_free_representation_and_init (disk_repr_p);
 	}
 
       if (repr_id_set != NULL)
@@ -5458,8 +5456,7 @@ catalog_get_cardinality (THREAD_ENTRY * thread_p, OID * class_oid, DISK_REPR * r
 	    }
 	  if (subcls_disk_rep != NULL)
 	    {
-	      catalog_free_representation (subcls_disk_rep);
-	      subcls_disk_rep = NULL;
+	      catalog_free_representation_and_init (subcls_disk_rep);
 	    }
 	  if (subcls_rep != NULL)
 	    {
@@ -5553,7 +5550,7 @@ catalog_get_cardinality (THREAD_ENTRY * thread_p, OID * class_oid, DISK_REPR * r
 exit_cleanup:
   if (free_disk_rep)
     {
-      catalog_free_representation (disk_repr_p);
+      catalog_free_representation_and_init (disk_repr_p);
     }
   if (free_cls_rep)
     {
@@ -5565,8 +5562,7 @@ exit_cleanup:
     }
   if (subcls_disk_rep != NULL)
     {
-      catalog_free_representation (subcls_disk_rep);
-      subcls_disk_rep = NULL;
+      catalog_free_representation_and_init (subcls_disk_rep);
     }
   if (subcls_rep != NULL)
     {

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -5062,7 +5062,7 @@ catalog_dump (THREAD_ENTRY * thread_p, FILE * fp, int dump_flag)
 	  fprintf (fp, " Representation directory OID: { %d , %d , %d } \n", class_info_p->ci_rep_dir.volid,
 		   class_info_p->ci_rep_dir.pageid, class_info_p->ci_rep_dir.slotid);
 
-	  catalog_free_class_info (class_info_p);
+	  catalog_free_class_info_and_init (class_info_p);
 	}
 
       fprintf (fp, "\n");
@@ -5454,8 +5454,7 @@ catalog_get_cardinality (THREAD_ENTRY * thread_p, OID * class_oid, DISK_REPR * r
 	  /* clean subclass loaded in previous iteration */
 	  if (subcls_info != NULL)
 	    {
-	      catalog_free_class_info (subcls_info);
-	      subcls_info = NULL;
+	      catalog_free_class_info_and_init (subcls_info);
 	    }
 	  if (subcls_disk_rep != NULL)
 	    {
@@ -5562,8 +5561,7 @@ exit_cleanup:
     }
   if (subcls_info != NULL)
     {
-      catalog_free_class_info (subcls_info);
-      subcls_info = NULL;
+      catalog_free_class_info_and_init (subcls_info);
     }
   if (subcls_disk_rep != NULL)
     {
@@ -5581,7 +5579,6 @@ exit_cleanup:
 exit:
   catalog_end_access_with_dir_oid (thread_p, &catalog_access_info, error);
   return error;
-
 }
 
 /*

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -5464,8 +5464,7 @@ catalog_get_cardinality (THREAD_ENTRY * thread_p, OID * class_oid, DISK_REPR * r
 	    }
 	  if (subcls_rep != NULL)
 	    {
-	      heap_classrepr_free (subcls_rep, &subcls_idx_cache);
-	      subcls_rep = NULL;
+	      heap_classrepr_free_and_init (subcls_rep, &subcls_idx_cache);
 	    }
 
 	  if (catalog_get_dir_oid_from_cache (thread_p, &partitions[i], &dir_oid) != NO_ERROR)
@@ -5559,7 +5558,7 @@ exit_cleanup:
     }
   if (free_cls_rep)
     {
-      heap_classrepr_free (cls_rep, &idx_cache);
+      heap_classrepr_free_and_init (cls_rep, &idx_cache);
     }
   if (subcls_info != NULL)
     {
@@ -5573,8 +5572,7 @@ exit_cleanup:
     }
   if (subcls_rep != NULL)
     {
-      heap_classrepr_free (subcls_rep, &subcls_idx_cache);
-      subcls_rep = NULL;
+      heap_classrepr_free_and_init (subcls_rep, &subcls_idx_cache);
     }
   if (partitions != NULL)
     {

--- a/src/storage/system_catalog.h
+++ b/src/storage/system_catalog.h
@@ -131,11 +131,22 @@ struct catalog_access_info
 #define CLS_INFO_INITIALIZER \
   { HFID_INITIALIZER, 0, 0, 0, { NULL_PAGEID, NULL_SLOTID, NULL_VOLID } }
 
+#define catalog_free_class_info_and_init(class_info_p) \
+  do \
+    { \
+      if ((class_info_p) != NULL) \
+        { \
+          catalog_free_class_info ((class_info_p)); \
+          (class_info_p) = NULL; \
+        } \
+    } \
+  while (0)
+
 extern CTID catalog_Id;		/* global catalog identifier */
 
 extern void catalog_free_disk_attribute (DISK_ATTR * atr);
 extern void catalog_free_representation (DISK_REPR * dr);
-extern void catalog_free_class_info (CLS_INFO * Cls_Info);
+extern void catalog_free_class_info (CLS_INFO * class_info_p);
 extern void catalog_initialize (CTID * catid);
 extern void catalog_finalize (void);
 

--- a/src/storage/system_catalog.h
+++ b/src/storage/system_catalog.h
@@ -155,7 +155,6 @@ struct catalog_access_info
 
 extern CTID catalog_Id;		/* global catalog identifier */
 
-extern void catalog_free_disk_attribute (DISK_ATTR * atr);
 extern void catalog_free_representation (DISK_REPR * repr_p);
 extern void catalog_free_class_info (CLS_INFO * class_info_p);
 extern void catalog_initialize (CTID * catid);

--- a/src/storage/system_catalog.h
+++ b/src/storage/system_catalog.h
@@ -142,10 +142,21 @@ struct catalog_access_info
     } \
   while (0)
 
+#define catalog_free_representation_and_init(repr_p) \
+  do \
+    { \
+      if ((repr_p) != NULL) \
+        { \
+          catalog_free_representation ((repr_p)); \
+          (repr_p) = NULL; \
+        } \
+    } \
+  while (0)
+
 extern CTID catalog_Id;		/* global catalog identifier */
 
 extern void catalog_free_disk_attribute (DISK_ATTR * atr);
-extern void catalog_free_representation (DISK_REPR * dr);
+extern void catalog_free_representation (DISK_REPR * repr_p);
 extern void catalog_free_class_info (CLS_INFO * class_info_p);
 extern void catalog_initialize (CTID * catid);
 extern void catalog_finalize (void);

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -11545,7 +11545,7 @@ locator_increase_catalog_count (THREAD_ENTRY * thread_p, OID * cls_oid)
   /* NOTE that tot_objects may not be correct because changes are NOT logged. */
   (void) catalog_update_class_info (thread_p, cls_oid, cls_infop, true);
 
-  catalog_free_class_info (cls_infop);
+  catalog_free_class_info_and_init (cls_infop);
 }
 
 /*
@@ -11588,7 +11588,7 @@ locator_decrease_catalog_count (THREAD_ENTRY * thread_p, OID * cls_oid)
   /* NOTE that tot_objects may not be correct because changes are NOT logged. */
   (void) catalog_update_class_info (thread_p, cls_oid, cls_infop, true);
 
-  catalog_free_class_info (cls_infop);
+  catalog_free_class_info_and_init (cls_infop);
 }
 #endif /* ENABLE_UNUSED_FUNCTION */
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4184,7 +4184,7 @@ error:
     }
   if (classrepr != NULL)
     {
-      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
     }
   heap_attrinfo_end (thread_p, &index_attrinfo);
   return error_code;

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4104,7 +4104,7 @@ cleanup:
     }
   if (classrepr != NULL)
     {
-      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
     }
 
   return error_code;
@@ -5566,18 +5566,14 @@ logtb_create_unique_stats_from_repr (THREAD_ENTRY * thread_p, OID * class_oid)
     }
 
   /* free class representation */
-  error_code = heap_classrepr_free (classrepr, &classrepr_cacheindex);
-  if (error_code != NO_ERROR)
-    {
-      goto exit_on_error;
-    }
+  heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
 
   return NO_ERROR;
 
 exit_on_error:
   if (classrepr != NULL)
     {
-      (void) heap_classrepr_free (classrepr, &classrepr_cacheindex);
+      heap_classrepr_free_and_init (classrepr, &classrepr_cacheindex);
     }
 
   return (error_code == NO_ERROR && (error_code = er_errid ()) == NO_ERROR) ? ER_FAILED : error_code;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21362

Replace `heap_classrepr_free` with `heap_classrepr_free_and_init` macro to avoid double free.
Error handler of `qexec_execute_build_indexes` and `qexec_execute_build_columns` had a chance to free class representation twice. 

`qexec_execute_build_indexes` also had a potential to double free of disk representation.