### PR TITLE
[CBRD-21367] fileio_find_next_perm_volume: lock disk extensions

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -6122,21 +6122,14 @@ fileio_find_next_perm_volume (THREAD_ENTRY * thread_p, VOLID volid)
 
   FILEIO_CHECK_AND_INITIALIZE_VOLUME_HEADER_CACHE (NULL_VOLID);
 
-  /* we might have a problem if a new volume is being added concurrently. to make sure we avoid any inconsistencies,
-   * we need to block or get blocked by adding new volumes. */
-  disk_lock_extend ();
-
   arg.vol_id = volid;
   vol_info_p = fileio_traverse_permanent_volume (thread_p, fileio_is_volume_id_gt, &arg);
   if (vol_info_p)
     {
       assert (fileio_get_volume_descriptor (volid) != NULL_VOLDES);
-
-      disk_unlock_extend ();
       return vol_info_p->volid;
     }
 
-  disk_unlock_extend ();
   return NULL_VOLID;
 }
 

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -6122,14 +6122,21 @@ fileio_find_next_perm_volume (THREAD_ENTRY * thread_p, VOLID volid)
 
   FILEIO_CHECK_AND_INITIALIZE_VOLUME_HEADER_CACHE (NULL_VOLID);
 
+  /* we might have a problem if a new volume is being added concurrently. to make sure we avoid any inconsistencies,
+   * we need to block or get blocked by adding new volumes. */
+  disk_lock_extend ();
+
   arg.vol_id = volid;
   vol_info_p = fileio_traverse_permanent_volume (thread_p, fileio_is_volume_id_gt, &arg);
   if (vol_info_p)
     {
       assert (fileio_get_volume_descriptor (volid) != NULL_VOLDES);
+
+      disk_unlock_extend ();
       return vol_info_p->volid;
     }
 
+  disk_unlock_extend ();
   return NULL_VOLID;
 }
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7644,6 +7644,7 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
   int i;
   const char *catmsg;
   VOLID volid;
+  VOLID curr_last_perm_volid;
   int error_code = NO_ERROR;
   LOG_PAGEID smallest_pageid;
   int first_arv_num_not_needed;
@@ -7996,16 +7997,15 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
   /* 
    * Record the checkpoint address on every volume header
    */
+  curr_last_perm_volid = xboot_find_last_permanent (thread_p);
 
-  disk_lock_extend ();
-  for (volid = LOG_DBFIRST_VOLID; volid != NULL_VOLID && volid <= xboot_peek_last_permanent (thread_p);
+  for (volid = LOG_DBFIRST_VOLID; volid != NULL_VOLID && volid <= curr_last_perm_volid;
        volid = fileio_find_next_perm_volume (thread_p, volid))
     {
       /* When volid is greater than boot_Db_parm->last_perm_volid, it means that the volume is now adding. We don't
        * need to care for the new volumes in here. */
       (void) disk_set_checkpoint (thread_p, volid, &chkpt_lsa);
     }
-  disk_unlock_extend ();
 
   /* 
    * Get the critical section again, so we can check if any archive can be

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7997,6 +7997,7 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
    * Record the checkpoint address on every volume header
    */
 
+  disk_lock_extend ();
   for (volid = LOG_DBFIRST_VOLID; volid != NULL_VOLID && volid <= xboot_peek_last_permanent (thread_p);
        volid = fileio_find_next_perm_volume (thread_p, volid))
     {
@@ -8004,6 +8005,7 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
        * need to care for the new volumes in here. */
       (void) disk_set_checkpoint (thread_p, volid, &chkpt_lsa);
     }
+  disk_unlock_extend ();
 
   /* 
    * Get the critical section again, so we can check if any archive can be
@@ -8718,7 +8720,9 @@ loop:
 	    {
 	      goto error;
 	    }
+	  disk_lock_extend ();
 	  volid = fileio_find_next_perm_volume (thread_p, volid);
+	  disk_unlock_extend ();
 	}
       else
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21367

the bug here is that logpb_backup_for_volume tries to backup a volume in progress of being added.

to discover all volumes, logpb_backup_for_volume calls fileio_find_next_perm_volume, which gets it from fileio_Vol_info_header, with no synchronization whatsoever. another thread is formatting a new volume, which is added to fileio_Vol_info_header, but is not yet initialized. backup is accessing volume first page and discovers it is deallocated, hitting safe-guard.

to fix the issue, I forced fileio_find_next_perm_volume get block on disk extensions. I thought of blocking fileio_traverse_permanent_volume, but it is dangerous, since it may be called while mutex is already blocked.

[EDIT] I have moved disk_lock_extend/disk_unlock_extend even upper. It seems file IO module doesn't have access to disk manager and I don't like to change that. logpb_checkpoint and logpb_backup are the two cases that could called the function while server is running.