### PR TITLE
[CBRD-21371] btree_set_error: clear error if index name could not be obtained

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -18211,6 +18211,7 @@ btree_set_error (THREAD_ENTRY * thread_p, DB_VALUE * key, OID * obj_oid, OID * c
     {
       if (heap_get_indexinfo_of_btid (thread_p, class_oid, btid, NULL, NULL, NULL, NULL, &index_name, NULL) != NO_ERROR)
 	{
+	  er_clear ();
 	  index_name = NULL;
 	}
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21371

clear error if index name could not be obtained.