### PR TITLE
[CBRD-21375] client may suffer from closed socket while closing connection

### DIFF
--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -183,7 +183,6 @@ set_server_error (int error)
     default:
       server_error = ER_NET_SERVER_CRASHED;
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, server_error, 0);
-      assert (0);
       break;
     }
 

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -183,6 +183,7 @@ set_server_error (int error)
     default:
       server_error = ER_NET_SERVER_CRASHED;
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, server_error, 0);
+      assert (0);
       break;
     }
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -3265,17 +3265,28 @@ sboot_register_client (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
 void
 sboot_notify_unregister_client (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
+  CSS_CONN_ENTRY *conn;
   int tran_index;
   int success = NO_ERROR;
+  int r;
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply = OR_ALIGNED_BUF_START (a_reply);
 
   (void) or_unpack_int (request, &tran_index);
 
+  conn = thread_p->conn_entry;
+
+  /* blah blah */
+  r = rmutex_lock (thread_p, &conn->rmutex);
+  assert (r == NO_ERROR);
+
   xboot_notify_unregister_client (thread_p, tran_index);
 
   (void) or_pack_int (reply, success);
   css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
+
+  r = rmutex_unlock (thread_p, &conn->rmutex);
+  assert (r == NO_ERROR);
 }
 
 /*

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -433,14 +433,12 @@ css_readn (SOCKET fd, char *ptr, int nbytes, int timeout)
 	    {
 	      errno = EINVAL;
 	      er_log_debug (ARG_FILE_LINE, "css_readn: %s", strerror (errno));
-	      assert (0);
 	      return -1;
 	    }
 	  if (po[0].revents & POLLHUP)
 	    {
 	      errno = EINVAL;
 	      er_log_debug (ARG_FILE_LINE, "css_readn: %s", strerror (errno));
-	      assert (0);
 	      return -1;
 	    }
 	}
@@ -579,14 +577,12 @@ css_net_recv (SOCKET fd, char *buffer, int *maxlen, int timeout)
 		{
 		  if (css_peer_alive (fd, time_unit) == false)
 		    {
-		      assert (0);
 		      return ERROR_WHEN_READING_SIZE;
 		    }
 		  if (css_check_server_alive_fn != NULL)
 		    {
 		      if (css_check_server_alive_fn (NULL, NULL) == false)
 			{
-			  assert (0);
 			  return ERROR_WHEN_READING_SIZE;
 			}
 		    }
@@ -595,7 +591,6 @@ css_net_recv (SOCKET fd, char *buffer, int *maxlen, int timeout)
 	      elapsed += time_unit;
 	      continue;
 	    }
-	  assert (0);
 	  return ERROR_WHEN_READING_SIZE;
 	}
       if (nbytes != sizeof (int))
@@ -603,7 +598,6 @@ css_net_recv (SOCKET fd, char *buffer, int *maxlen, int timeout)
 #ifdef CUBRID_DEBUG
 	  er_log_debug (ARG_FILE_LINE, "css_net_recv: returning ERROR_WHEN_READING_SIZE bytes %d \n", nbytes);
 #endif
-	  assert (0);
 	  return ERROR_WHEN_READING_SIZE;
 	}
       else
@@ -2452,7 +2446,6 @@ css_check_magic (CSS_CONN_ENTRY * conn)
   nbytes = css_readn (conn->fd, (char *) &size, sizeof (int), timeout);
   if (nbytes != sizeof (int))
     {
-      assert (0);
       return ERROR_WHEN_READING_SIZE;
     }
   size = ntohl (size);

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -409,6 +409,7 @@ css_readn (SOCKET fd, char *ptr, int nbytes, int timeout)
 	{
 	  /* 0 means it timed out and no fd is changed. */
 	  errno = ETIMEDOUT;
+	  er_log_debug (ARG_FILE_LINE, "css_readn: ETIMEDOUT");
 	  return -1;
 	}
       else if (n < 0)
@@ -423,13 +424,23 @@ css_readn (SOCKET fd, char *ptr, int nbytes, int timeout)
 #endif /* !SERVER_MODE */
 	      continue;
 	    }
+	  er_log_debug (ARG_FILE_LINE, "css_readn: %s", strerror (errno));
 	  return -1;
 	}
       else
 	{
-	  if (po[0].revents & POLLERR || po[0].revents & POLLHUP)
+	  if (po[0].revents & POLLERR)
 	    {
 	      errno = EINVAL;
+	      er_log_debug (ARG_FILE_LINE, "css_readn: %s", strerror (errno));
+	      assert (0);
+	      return -1;
+	    }
+	  if (po[0].revents & POLLHUP)
+	    {
+	      errno = EINVAL;
+	      er_log_debug (ARG_FILE_LINE, "css_readn: %s", strerror (errno));
+	      assert (0);
 	      return -1;
 	    }
 	}
@@ -472,9 +483,9 @@ css_readn (SOCKET fd, char *ptr, int nbytes, int timeout)
 #if !defined (SERVER_MODE)
 	  css_set_networking_error (fd);
 #endif /* !SERVER_MODE */
-#ifdef CUBRID_DEBUG
-	  er_log_debug (ARG_FILE_LINE, "css_readn: returning error n %d, errno %d\n", n, errno);
-#endif
+
+	  er_log_debug (ARG_FILE_LINE, "css_readn: returning error n %d, errno %s\n", n, strerror (errno));
+
 	  return n;		/* error, return < 0 */
 	}
       nleft -= n;
@@ -568,12 +579,14 @@ css_net_recv (SOCKET fd, char *buffer, int *maxlen, int timeout)
 		{
 		  if (css_peer_alive (fd, time_unit) == false)
 		    {
+		      assert (0);
 		      return ERROR_WHEN_READING_SIZE;
 		    }
 		  if (css_check_server_alive_fn != NULL)
 		    {
 		      if (css_check_server_alive_fn (NULL, NULL) == false)
 			{
+			  assert (0);
 			  return ERROR_WHEN_READING_SIZE;
 			}
 		    }
@@ -582,6 +595,7 @@ css_net_recv (SOCKET fd, char *buffer, int *maxlen, int timeout)
 	      elapsed += time_unit;
 	      continue;
 	    }
+	  assert (0);
 	  return ERROR_WHEN_READING_SIZE;
 	}
       if (nbytes != sizeof (int))
@@ -589,6 +603,7 @@ css_net_recv (SOCKET fd, char *buffer, int *maxlen, int timeout)
 #ifdef CUBRID_DEBUG
 	  er_log_debug (ARG_FILE_LINE, "css_net_recv: returning ERROR_WHEN_READING_SIZE bytes %d \n", nbytes);
 #endif
+	  assert (0);
 	  return ERROR_WHEN_READING_SIZE;
 	}
       else
@@ -915,9 +930,8 @@ css_vector_send (SOCKET fd, struct iovec *vec[], int *len, int bytes_written, in
 
   if (bytes_written > 0)
     {
-#ifdef CUBRID_DEBUG
       er_log_debug (ARG_FILE_LINE, "css_vector_send: retry called for %d\n", bytes_written);
-#endif
+
       for (i = 0; i < *len; i++)
 	{
 	  if ((*vec)[i].iov_len <= (size_t) bytes_written)
@@ -948,19 +962,29 @@ css_vector_send (SOCKET fd, struct iovec *vec[], int *len, int bytes_written, in
 	    {
 	      continue;
 	    }
+
+	  er_log_debug (ARG_FILE_LINE, "css_vector_send: EINTR %s\n", strerror (errno));
 	  return -1;
 	}
       else if (n == 0)
 	{
 	  /* 0 means it timed out and no fd is changed. */
 	  errno = ETIMEDOUT;
+	  er_log_debug (ARG_FILE_LINE, "css_vector_send: ETIMEDOUT %s\n", strerror (errno));
 	  return -1;
 	}
       else
 	{
-	  if (po[0].revents & POLLERR || po[0].revents & POLLHUP)
+	  if (po[0].revents & POLLERR)
 	    {
 	      errno = EINVAL;
+	      er_log_debug (ARG_FILE_LINE, "css_vector_send: EINVAL POLLERR %s\n", strerror (errno));
+	      return -1;
+	    }
+	  if (po[0].revents & POLLHUP)
+	    {
+	      errno = EINVAL;
+	      er_log_debug (ARG_FILE_LINE, "css_vector_send: EINVAL POLLHUP %s\n", strerror (errno));
 	      return -1;
 	    }
 	}
@@ -988,9 +1012,8 @@ css_vector_send (SOCKET fd, struct iovec *vec[], int *len, int bytes_written, in
 #if !defined (SERVER_MODE)
 	  css_set_networking_error (fd);
 #endif /* !SERVER_MODE */
-#ifdef CUBRID_DEBUG
-	  er_log_debug (ARG_FILE_LINE, "css_vector_send: returning error n %d, errno %d\n", n, errno);
-#endif
+
+	  er_log_debug (ARG_FILE_LINE, "css_vector_send: returning error n %d, errno %s\n", n, strerror (errno));
 	  return n;		/* error, return < 0 */
 	}
     }
@@ -2429,6 +2452,7 @@ css_check_magic (CSS_CONN_ENTRY * conn)
   nbytes = css_readn (conn->fd, (char *) &size, sizeof (int), timeout);
   if (nbytes != sizeof (int))
     {
+      assert (0);
       return ERROR_WHEN_READING_SIZE;
     }
   size = ntohl (size);

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -409,7 +409,6 @@ css_readn (SOCKET fd, char *ptr, int nbytes, int timeout)
 	{
 	  /* 0 means it timed out and no fd is changed. */
 	  errno = ETIMEDOUT;
-	  er_log_debug (ARG_FILE_LINE, "css_readn: ETIMEDOUT");
 	  return -1;
 	}
       else if (n < 0)
@@ -429,16 +428,11 @@ css_readn (SOCKET fd, char *ptr, int nbytes, int timeout)
 	}
       else
 	{
-	  if (po[0].revents & POLLERR)
+	  if (po[0].revents & POLLERR || po[0].revents & POLLHUP)
 	    {
 	      errno = EINVAL;
-	      er_log_debug (ARG_FILE_LINE, "css_readn: %s", strerror (errno));
-	      return -1;
-	    }
-	  if (po[0].revents & POLLHUP)
-	    {
-	      errno = EINVAL;
-	      er_log_debug (ARG_FILE_LINE, "css_readn: %s", strerror (errno));
+	      er_log_debug (ARG_FILE_LINE, "css_readn: %s %s", (po[0].revents & POLLERR ? "POLLERR" : "POLLHUP"),
+			    strerror (errno));
 	      return -1;
 	    }
 	}
@@ -964,21 +958,15 @@ css_vector_send (SOCKET fd, struct iovec *vec[], int *len, int bytes_written, in
 	{
 	  /* 0 means it timed out and no fd is changed. */
 	  errno = ETIMEDOUT;
-	  er_log_debug (ARG_FILE_LINE, "css_vector_send: ETIMEDOUT %s\n", strerror (errno));
 	  return -1;
 	}
       else
 	{
-	  if (po[0].revents & POLLERR)
+	  if (po[0].revents & POLLERR || po[0].revents & POLLHUP)
 	    {
 	      errno = EINVAL;
-	      er_log_debug (ARG_FILE_LINE, "css_vector_send: EINVAL POLLERR %s\n", strerror (errno));
-	      return -1;
-	    }
-	  if (po[0].revents & POLLHUP)
-	    {
-	      errno = EINVAL;
-	      er_log_debug (ARG_FILE_LINE, "css_vector_send: EINVAL POLLHUP %s\n", strerror (errno));
+	      er_log_debug (ARG_FILE_LINE, "css_vector_send: %s %s\n",
+			    (po[0].revents & POLLERR ? "POLLERR" : "POLLHUP"), strerror (errno));
 	      return -1;
 	    }
 	}

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1445,6 +1445,7 @@ css_connection_handler_thread (THREAD_ENTRY * thread_p, CSS_CONN_ENTRY * conn)
 {
   CSS_JOB_ENTRY *job;
   int n, type, rv, status;
+  volatile int conn_status;
   int css_peer_alive_timeout, poll_timeout;
   int max_num_loop, num_loop;
   int prefetchlogdb_max_thread_count = 0;
@@ -1474,9 +1475,21 @@ css_connection_handler_thread (THREAD_ENTRY * thread_p, CSS_CONN_ENTRY * conn)
   while (thread_p->shutdown == false && conn->stop_talk == false)
     {
       /* check the connection */
-      if (conn->status != CONN_OPEN)
+      con_status = conn->status;
+      if (conn_status == CONN_CLOSING)
 	{
-	  er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: " "conn->status is not CONN_OPEN.");
+	  /* blah blah */
+	  rmutex_lock (&conn->rmutex);
+
+	  conn_status = conn->status;
+
+	  rmutex_unlock (&conn->rmutex);
+	}
+
+      if (conn_status != CONN_OPEN)
+	{
+	  er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: " "conn->status (%) is not CONN_OPEN.",
+			conn_status);
 	  status = CONNECTION_CLOSED;
 	  break;
 	}

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1475,20 +1475,20 @@ css_connection_handler_thread (THREAD_ENTRY * thread_p, CSS_CONN_ENTRY * conn)
   while (thread_p->shutdown == false && conn->stop_talk == false)
     {
       /* check the connection */
-      con_status = conn->status;
+      conn_status = conn->status;
       if (conn_status == CONN_CLOSING)
 	{
 	  /* blah blah */
-	  rmutex_lock (&conn->rmutex);
+	  rmutex_lock (thread_p, &conn->rmutex);
 
 	  conn_status = conn->status;
 
-	  rmutex_unlock (&conn->rmutex);
+	  rmutex_unlock (thread_p, &conn->rmutex);
 	}
 
       if (conn_status != CONN_OPEN)
 	{
-	  er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: " "conn->status (%) is not CONN_OPEN.",
+	  er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: " "conn->status (%d) is not CONN_OPEN.",
 			conn_status);
 	  status = CONNECTION_CLOSED;
 	  break;

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1478,7 +1478,12 @@ css_connection_handler_thread (THREAD_ENTRY * thread_p, CSS_CONN_ENTRY * conn)
       conn_status = conn->status;
       if (conn_status == CONN_CLOSING)
 	{
-	  /* blah blah */
+	  /* There's an interesting race condition among client, worker thread and connection handler.
+	   * Please find CBRD-21375 for detail and also see sboot_notify_unregister_client.
+	   * 
+	   * We have to synchronize here with worker thread which may be in sboot_notify_unregister_client
+	   * to let it have a chance to send reply to client.
+	   */
 	  rmutex_lock (thread_p, &conn->rmutex);
 
 	  conn_status = conn->status;

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3197,18 +3197,11 @@ xboot_notify_unregister_client (THREAD_ENTRY * thread_p, int tran_index)
   LOG_TDES *tdes;
   int client_id;
 
-  if (thread_p == NULL)
-    {
-      thread_p = thread_get_thread_entry_info ();
-      if (thread_p == NULL)
-	{
-	  return;
-	}
-    }
-
   conn = thread_p->conn_entry;
 
-  /* blah blah */
+  /* sboot_notify_unregister_client should hold conn->rmutex. 
+   * Please see the comment of sboot_notify_unregister_client.
+   */
 
   client_id = conn->client_id;
   tdes = LOG_FIND_TDES (tran_index);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3196,7 +3196,6 @@ xboot_notify_unregister_client (THREAD_ENTRY * thread_p, int tran_index)
   CSS_CONN_ENTRY *conn;
   LOG_TDES *tdes;
   int client_id;
-  int r;
 
   if (thread_p == NULL)
     {
@@ -3209,8 +3208,7 @@ xboot_notify_unregister_client (THREAD_ENTRY * thread_p, int tran_index)
 
   conn = thread_p->conn_entry;
 
-  r = rmutex_lock (thread_p, &conn->rmutex);
-  assert (r == NO_ERROR);
+  /* blah blah */
 
   client_id = conn->client_id;
   tdes = LOG_FIND_TDES (tran_index);
@@ -3221,9 +3219,6 @@ xboot_notify_unregister_client (THREAD_ENTRY * thread_p, int tran_index)
 	  conn->status = CONN_CLOSING;
 	}
     }
-
-  r = rmutex_unlock (thread_p, &conn->rmutex);
-  assert (r == NO_ERROR);
 }
 #endif /* SERVER_MODE */
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21375

We had a race condition among client, worker thread and connection handler when client disconnects the connection. 
Detailed scenarios are [here](http://jira.cubrid.org/browse/CBRD-21375?focusedCommentId=4743927&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4743927).

Fix is to synchronize disconnecting worker thread and connection handler.

I think "kill statement" and "killtran utility" have the same potentials. I don't think we have to fix these case (at least for this milestone).

