### PR TITLE
[CBRD-21378] vacuum_process_log_block: clear lob not found error

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3256,7 +3256,14 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
 	  /* A lob file must be deleted */
 	  (void) or_unpack_string (undo_data, &es_uri);
 	  vacuum_er_log (VACUUM_ER_LOG_WORKER, "Delete lob %s based on %lld|%d", es_uri, LSA_AS_ARGS (&rcv_lsa));
-	  (void) es_delete_file (es_uri);
+	  if (es_delete_file (es_uri) != NO_ERROR)
+	    {
+	      er_clear ();
+	    }
+	  else
+	    {
+	      ASSERT_NO_ERROR ();
+	    }
 	  db_private_free_and_init (thread_p, es_uri);
 	}
       else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21378

vacuum will not always find the lob's to delete. but we don't need to leak errors when it doesn't.