### PR TITLE
[CBRD-21402] xcache_check_recompilation_threshold: fix race

### DIFF
--- a/src/query/xasl_cache.h
+++ b/src/query/xasl_cache.h
@@ -99,7 +99,7 @@ struct xasl_cache_ent
   pthread_mutex_t cache_clones_mutex;
 
   /* RT check */
-  struct timeval time_last_rt_check;
+  INT64 time_last_rt_check;
 
   bool initialized;
 };


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21402

Use atomic operation on INT64 field instead of the varying in size timeval.tv_sec.