### PR TITLE
[CBRD-21406] deletes a bad assertion: locator_update_force

### DIFF
--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -5516,7 +5516,6 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		  if (error_code == ER_FAILED)
 		    {
 		      ASSERT_ERROR_AND_SET (error_code);
-		      assert (false);
 		    }
 		  else
 		    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21406

It was interrupted while updating the class.
`heap_mark_class_as_modified` might return `ER_FAILED`.