### PR TITLE
[CBRD-21412] xbtree_load_index: fix for null btid

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -6842,7 +6842,7 @@ vacuum_verify_vacuum_data_debug (THREAD_ENTRY * thread_p)
       last_unvacuumed = NULL;
     }
 
-  if (in_progress_distance <= 500)
+  if (in_progress_distance > 500)
     {
       /* In progress distance is computed starting with first in progress entry found and by counting all following
        * in progress or vacuumed jobs. The goal of this count is to find potential job leaks: jobs marked as in progress

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -1019,7 +1019,7 @@ xbtree_load_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_name, TP
 
 error:
 
-  if (BTID_IS_NULL (&btid_global_stats))
+  if (!BTID_IS_NULL (&btid_global_stats))
     {
       logtb_delete_global_unique_stats (thread_p, &btid_global_stats);
     }

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -626,7 +626,8 @@ xbtree_load_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_name, TP
   FUNCTION_INDEX_INFO func_index_info;
   DB_TYPE single_node_type = DB_TYPE_NULL;
   void *func_unpack_info = NULL;
-  bool btree_id_complete = false, has_fk;
+  bool has_fk;
+  BTID btid_global_stats = BTID_INITIALIZER;
   OID *notification_class_oid;
   unsigned short alignment = BTREE_MAX_ALIGN;
 #if !defined(NDEBUG)
@@ -837,7 +838,7 @@ xbtree_load_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_name, TP
 
   /* Allocate a root page and save the page_id */
   *load_args->btid->sys_btid = *btid;
-  btree_id_complete = true;
+  btid_global_stats = *btid;
 
   if (prm_get_bool_value (PRM_ID_LOG_BTREE_OPS))
     {
@@ -1018,9 +1019,9 @@ xbtree_load_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_name, TP
 
 error:
 
-  if (btree_id_complete)
+  if (BTID_IS_NULL (&btid_global_stats))
     {
-      logtb_delete_global_unique_stats (thread_p, btid);
+      logtb_delete_global_unique_stats (thread_p, &btid_global_stats);
     }
 
   if (sort_args->scancache_inited)

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -6734,6 +6734,8 @@ logtb_delete_global_unique_stats (THREAD_ENTRY * thread_p, BTID * btid)
   LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_GLOBAL_UNIQUE_STATS);
   int error = NO_ERROR;
 
+  assert (!BTID_IS_NULL (btid));
+
 #if !defined(NDEBUG)
   {
     VPID root_vpid;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21412

xbtree_load_index: fix deleting globals stats for null btid

the patch includes minor fix in vacuum module.