### PR TITLE
[CBRD-21414] corrects error handling of checking dropped file to crea…

### DIFF
--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -319,7 +319,7 @@ extern int vacuum_rv_redo_vacuum_heap_record (THREAD_ENTRY * thread_p, LOG_RCV *
 
 extern int vacuum_create_file_for_dropped_files (THREAD_ENTRY * thread_p, VFID * dropped_files_vfid);
 extern int vacuum_load_dropped_files_from_disk (THREAD_ENTRY * thread_p);
-extern bool vacuum_is_file_dropped (THREAD_ENTRY * thread_p, VFID * vfid, MVCCID mvccid);
+extern int vacuum_is_file_dropped (THREAD_ENTRY * thread_p, bool * is_file_dropped, VFID * vfid, MVCCID mvccid);
 extern int vacuum_rv_notify_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern void vacuum_log_add_dropped_file (THREAD_ENTRY * thread_p, const VFID * vfid, const OID * class_oid,
 					 bool postpone_or_undo);


### PR DESCRIPTION
…te a new file

http://jira.cubrid.org/browse/CBRD-21414

worker thread was interrupted while checking the file id is in dropped file list and ignored it. 
At the end of creation, it complained an error was set.

Fix is to correctly propagate an error. 
