### PR TITLE
[CBRD-21415] fix recovery for file_tracker_unregister crash

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3864,7 +3864,8 @@ log_sysop_commit_internal (THREAD_ENTRY * thread_p, LOG_REC_SYSOP_END * log_reco
 	{
 	  /* we should be doing rollback or undo recovery */
 	  assert (tdes->state == TRAN_UNACTIVE_ABORTED || tdes->state == TRAN_UNACTIVE_UNILATERALLY_ABORTED
-		  || (tdes->state == TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE && is_rv_finish_postpone));
+		  || (is_rv_finish_postpone && (tdes->state == TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE
+						|| tdes->state == TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE)));
 	}
       else if (log_record->type == LOG_SYSOP_END_LOGICAL_UNDO || log_record->type == LOG_SYSOP_END_LOGICAL_MVCC_UNDO)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21415

This is a complicated case.

1. file_destroy (during postpone)
2. file_tracker_unregister (file_dealloc).
3. sysop with logical undo starts postpone
4. crash!

We have a sysop postpone phase inside a logical undo, inside a logical run during transaction postpone phase. The recovery code was not adept to handle the case, so it had a safe-guard to ban the case.

This is a hack/quick fix that should work in this case. We allow a sysop start postpone in this context and try to correct the transaction state changes. However, it may not work in other complicated cases (if they exist or if they will be added). A correct way to manage nested system operations is log more information (e.g. previous transaction state).