### PR TITLE
[CBRD-21431] Fix prepared statements on multi-column indexes with like clause

### DIFF
--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -634,8 +634,6 @@ db_value_domain_max (DB_VALUE * value, const DB_TYPE type, const int precision, 
 	value->domain.general_info.is_null = 0;
       }
       break;
-      /* TODO: The string "\377" (one character of code 255) is not a perfect representation of the maximum value of a
-       * string's domain. We should find a better way to do this. */
     case DB_TYPE_BIT:
     case DB_TYPE_VARBIT:
       value->data.ch.info.style = MEDIUM_STRING;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1645,6 +1645,10 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
     }
 
   /* calculate midxkey's size & make a new setdomain if need */
+  /* NOTICE that this will stop the iteration on MAX_COLUMN value if exists.
+   * Remaining key values including MAX_COLUMN position will be filled as NULL
+   * by btree_coerce_key at the end of this function.
+   */
   for (operand = func->value.funcp->operand, idx_dom = idx_setdomain, natts = 0;
        operand != NULL && idx_dom != NULL
        && (midxkey.min_max_val.position == -1 || natts < midxkey.min_max_val.position);

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1585,9 +1585,10 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	      /* oops, we found max. */
 	      midxkey.min_max_val.position = i;
 	      midxkey.min_max_val.type = MAX_COLUMN;
+
+	      /* just stop here */
+	      break;
 	    }
-	  /* just stop here */
-	  break;
 	}
 
       if (TP_DOMAIN_TYPE (idx_dom) != val_type_id)
@@ -1799,7 +1800,6 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
       OR_ENABLE_BOUND_BIT (nullmap_ptr, i);
     }
 
-  //assert (operand == NULL);
   assert (buf_size == CAST_BUFLEN (buf.ptr - midxkey.buf));
 
   /* Make midxkey DB_VALUE */

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1577,6 +1577,19 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	}
 
       val_type_id = DB_VALUE_DOMAIN_TYPE (val);
+      if (TP_IS_STRING_TYPE (val_type_id))
+	{
+	  /* we need to check for maxes */
+	  if (val->data.ch.medium.is_max_string)
+	    {
+	      /* oops, we found max. */
+	      midxkey.min_max_val.position = i;
+	      midxkey.min_max_val.type = MAX_COLUMN;
+	    }
+	  /* just stop here */
+	  break;
+	}
+
       if (TP_DOMAIN_TYPE (idx_dom) != val_type_id)
 	{
 	  /* allocate DB_VALUE array to store coerced values. */
@@ -1631,7 +1644,9 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
     }
 
   /* calculate midxkey's size & make a new setdomain if need */
-  for (operand = func->value.funcp->operand, idx_dom = idx_setdomain, natts = 0; operand != NULL && idx_dom != NULL;
+  for (operand = func->value.funcp->operand, idx_dom = idx_setdomain, natts = 0;
+       operand != NULL && idx_dom != NULL && (midxkey.min_max_val.position == -1
+					      || natts < midxkey.min_max_val.position);
        operand = operand->next, idx_dom = idx_dom->next, natts++)
     {
       /* If there is coerced value, we will use it regardless of whether a new setdomain is required or not. */
@@ -1784,7 +1799,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
       OR_ENABLE_BOUND_BIT (nullmap_ptr, i);
     }
 
-  assert (operand == NULL);
+  //assert (operand == NULL);
   assert (buf_size == CAST_BUFLEN (buf.ptr - midxkey.buf));
 
   /* Make midxkey DB_VALUE */
@@ -1805,9 +1820,6 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
     {
       midxkey.domain = btree_domainp;
     }
-
-  midxkey.min_max_val.position = -1;
-  midxkey.min_max_val.type = MIN_COLUMN;
 
   ret = db_make_midxkey (retval, &midxkey);
   if (ret != NO_ERROR)

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1646,8 +1646,8 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 
   /* calculate midxkey's size & make a new setdomain if need */
   for (operand = func->value.funcp->operand, idx_dom = idx_setdomain, natts = 0;
-       operand != NULL && idx_dom != NULL && (midxkey.min_max_val.position == -1
-					      || natts < midxkey.min_max_val.position);
+       operand != NULL && idx_dom != NULL
+       && (midxkey.min_max_val.position == -1 || natts < midxkey.min_max_val.position);
        operand = operand->next, idx_dom = idx_dom->next, natts++)
     {
       /* If there is coerced value, we will use it regardless of whether a new setdomain is required or not. */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -14822,9 +14822,7 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
 		{
 		  err = ER_FAILED;
 		}
-
 	    }
-
 
 	  num_dbvals = 0;
 	  partial_dom = dp;
@@ -14841,7 +14839,6 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
 
 	  db_private_free_and_init (NULL, dbvals);
 	}
-
     }
   else if (
 	    /* check if they are string or bit type */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -14816,7 +14816,7 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
 	      else if (minmax == BTREE_COERCE_KEY_WITH_MAX_VALUE)
 		{
 		  midxkey->min_max_val.position = dsize;
-		  midxkey->min_max_val.type = MIN_COLUMN;
+		  midxkey->min_max_val.type = MAX_COLUMN;
 		}
 	      else
 		{

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -14750,77 +14750,81 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
 	      ;
 	    }
 
-	  minmax = key_minmax;	/* init */
-	  if (minmax == BTREE_COERCE_KEY_WITH_MIN_VALUE)
+	  if (midxkey->min_max_val.position == -1)
 	    {
-	      if (!part_key_desc)
-		{		/* CASE 1, 2 */
-		  if (dp->is_desc != true)
-		    {		/* CASE 1 */
-		      ;		/* nop */
+	      /* If min_max_val was not set, set it here. */
+	      minmax = key_minmax;	/* init */
+	      if (minmax == BTREE_COERCE_KEY_WITH_MIN_VALUE)
+		{
+		  if (!part_key_desc)
+		    {		/* CASE 1, 2 */
+		      if (dp->is_desc != true)
+			{	/* CASE 1 */
+			  ;	/* nop */
+			}
+		      else
+			{	/* CASE 2 */
+			  minmax = BTREE_COERCE_KEY_WITH_MAX_VALUE;
+			}
 		    }
 		  else
-		    {		/* CASE 2 */
-		      minmax = BTREE_COERCE_KEY_WITH_MAX_VALUE;
+		    {		/* CASE 3, 4 */
+		      if (dp->is_desc != true)
+			{	/* CASE 3 */
+			  minmax = BTREE_COERCE_KEY_WITH_MAX_VALUE;
+			}
+		      else
+			{	/* CASE 4 */
+			  ;	/* nop */
+			}
 		    }
 		}
-	      else
-		{		/* CASE 3, 4 */
-		  if (dp->is_desc != true)
-		    {		/* CASE 3 */
-		      minmax = BTREE_COERCE_KEY_WITH_MAX_VALUE;
+	      else if (minmax == BTREE_COERCE_KEY_WITH_MAX_VALUE)
+		{
+		  if (!part_key_desc)
+		    {		/* CASE 1, 2 */
+		      if (dp->is_desc != true)
+			{	/* CASE 1 */
+			  ;	/* nop */
+			}
+		      else
+			{	/* CASE 2 */
+			  minmax = BTREE_COERCE_KEY_WITH_MIN_VALUE;
+			}
 		    }
 		  else
-		    {		/* CASE 4 */
-		      ;		/* nop */
+		    {		/* CASE 3, 4 */
+		      if (dp->is_desc != true)
+			{	/* CASE 3 */
+			  minmax = BTREE_COERCE_KEY_WITH_MIN_VALUE;
+			}
+		      else
+			{	/* CASE 4 */
+			  ;	/* nop */
+			}
 		    }
 		}
-	    }
-	  else if (minmax == BTREE_COERCE_KEY_WITH_MAX_VALUE)
-	    {
-	      if (!part_key_desc)
-		{		/* CASE 1, 2 */
-		  if (dp->is_desc != true)
-		    {		/* CASE 1 */
-		      ;		/* nop */
-		    }
-		  else
-		    {		/* CASE 2 */
-		      minmax = BTREE_COERCE_KEY_WITH_MIN_VALUE;
-		    }
-		}
-	      else
-		{		/* CASE 3, 4 */
-		  if (dp->is_desc != true)
-		    {		/* CASE 3 */
-		      minmax = BTREE_COERCE_KEY_WITH_MIN_VALUE;
-		    }
-		  else
-		    {		/* CASE 4 */
-		      ;		/* nop */
-		    }
-		}
-	    }
 
-	  if (minmax == BTREE_COERCE_KEY_WITH_MIN_VALUE)
-	    {
-	      if (dsize < keysize)
+	      if (minmax == BTREE_COERCE_KEY_WITH_MIN_VALUE)
+		{
+		  if (dsize < keysize)
+		    {
+		      midxkey->min_max_val.position = dsize;
+		      midxkey->min_max_val.type = MIN_COLUMN;
+		    }
+		}
+	      else if (minmax == BTREE_COERCE_KEY_WITH_MAX_VALUE)
 		{
 		  midxkey->min_max_val.position = dsize;
-		  /* This needs to be checked!! */
-		  //midxkey->min_max_val.type = MIN_COLUMN;
+		  midxkey->min_max_val.type = MIN_COLUMN;
 		}
+	      else
+		{
+		  err = ER_FAILED;
+		}
+
 	    }
-	  else if (minmax == BTREE_COERCE_KEY_WITH_MAX_VALUE)
-	    {
-	      midxkey->min_max_val.position = dsize;
-	      /* This needs to be checked!! */
-	      //midxkey->min_max_val.type = MIN_COLUMN;
-	    }
-	  else
-	    {
-	      err = ER_FAILED;
-	    }
+
 
 	  num_dbvals = 0;
 	  partial_dom = dp;

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -14807,11 +14807,15 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
 	      if (dsize < keysize)
 		{
 		  midxkey->min_max_val.position = dsize;
+		  /* This needs to be checked!! */
+		  //midxkey->min_max_val.type = MIN_COLUMN;
 		}
 	    }
 	  else if (minmax == BTREE_COERCE_KEY_WITH_MAX_VALUE)
 	    {
 	      midxkey->min_max_val.position = dsize;
+	      /* This needs to be checked!! */
+	      //midxkey->min_max_val.type = MIN_COLUMN;
 	    }
 	  else
 	    {

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -14807,13 +14807,11 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
 	      if (dsize < keysize)
 		{
 		  midxkey->min_max_val.position = dsize;
-		  midxkey->min_max_val.type = MIN_COLUMN;
 		}
 	    }
 	  else if (minmax == BTREE_COERCE_KEY_WITH_MAX_VALUE)
 	    {
 	      midxkey->min_max_val.position = dsize;
-	      midxkey->min_max_val.type = MAX_COLUMN;
 	    }
 	  else
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21431

Once a `MAX_STRING` type of `DB_VALUE` would be required to be inserted in a `MIDXKEY`, since the MAX_STRING info is held into the `is_max_string` field, it would not be added into the `MIDXKEY`. Therefore, the `MIDXKEY` would reside no information that it should hold a `MAX_STRING` type of value. We decided to try a workaround by correctly setting the `MAX_COLUMN` value into the `min_max_val` field of the `MIDXKEY`.