### PR TITLE
[CBRD-20146] error to connect master was not handled

### DIFF
--- a/src/connection/tcp.c
+++ b/src/connection/tcp.c
@@ -886,7 +886,7 @@ css_tcp_listen_server_datagram (SOCKET sockfd, SOCKET * newfd)
   while (true)
     {
       *newfd = accept (sockfd, (struct sockaddr *) &cli_addr, &clilen);
-      if (IS_INVALID_SOCKET (*newfd) < 0)
+      if (IS_INVALID_SOCKET (*newfd))
 	{
 	  if (errno == EINTR)
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20146

error from `accept` was not handled.
I don't think the bug was realized.