### PR TITLE
[CBRD-21454] error was not propagated

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -7561,7 +7561,8 @@ btree_check_tree (THREAD_ENTRY * thread_p, const OID * class_oid_p, BTID * btid,
     }
 
   btid_int.sys_btid = btid;
-  if (btree_glean_root_header_info (thread_p, root_header, &btid_int) != NO_ERROR)
+  valid = btree_glean_root_header_info (thread_p, root_header, &btid_int);
+  if (valid != NO_ERROR)
     {
       goto error;
     }
@@ -7841,6 +7842,7 @@ retry_repair:
       header = btree_get_node_header (thread_p, current_pgptr);
       if (header == NULL)
 	{
+	  valid = DISK_ERROR;
 	  goto exit_repair;
 	}
 
@@ -7884,6 +7886,7 @@ retry_repair:
       header = btree_get_node_header (thread_p, next_pgptr);
       if (header == NULL)
 	{
+	  valid = DISK_ERROR;
 	  goto exit_repair;
 	}
 
@@ -10684,6 +10687,7 @@ btree_key_append_object_as_new_overflow (THREAD_ENTRY * thread_p, BTID_INT * bti
   if (spage_update (thread_p, leaf_page, search_key->slotid, leaf_rec) != SP_SUCCESS)
     {
       assert_release (false);
+      ret = ER_FAILED;
       goto error;
     }
 
@@ -12610,6 +12614,7 @@ btree_split_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
   if (qheader == NULL)
     {
       assert_release (false);
+      ret = ER_FAILED;
       goto exit_on_error;
     }
 
@@ -12746,6 +12751,7 @@ btree_split_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
       assert (j > 0);
       if (spage_insert_at (thread_p, R, j++, &rec) != SP_SUCCESS)
 	{
+	  ret = ER_FAILED;
 	  goto exit_on_error;
 	}
     }
@@ -21091,6 +21097,7 @@ btree_insert_mvcc_delid_into_page (THREAD_ENTRY * thread_p, BTID_INT * btid, PAG
   if (spage_update (thread_p, page_ptr, slot_id, rec) != SP_SUCCESS)
     {
       assert_release (false);
+      ret = ER_FAILED;
       goto exit_on_error;
     }
 
@@ -26599,6 +26606,7 @@ btree_split_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 	      pgbuf_unfix_and_init (thread_p, new_page2);
 
 	      /* Error */
+	      error_code = ER_FAILED;
 	      goto error;
 	    }
 	  assert (*crt_page != NULL);
@@ -26609,6 +26617,7 @@ btree_split_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 	    {
 	      /* Unexpected. */
 	      assert (false);
+	      error_code = ER_FAILED;
 	      goto error;
 	    }
 

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -131,7 +131,7 @@ struct load_args
   VPID vpid_first_leaf;
 };
 
-static bool btree_save_last_leafrec (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args);
+static int btree_save_last_leafrec (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args);
 static PAGE_PTR btree_connect_page (THREAD_ENTRY * thread_p, DB_VALUE * key, int max_key_len, VPID * pageid,
 				    LOAD_ARGS * load_args, int node_level);
 static int btree_build_nleafs (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args, int n_nulls, int n_oids, int n_keys);
@@ -1129,7 +1129,7 @@ error:
  * Then it saves the last leaf page (and the last overflow page,
  * if there is one) to the disk.
  */
-static bool
+static int
 btree_save_last_leafrec (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args)
 {
   INT16 slotid;

--- a/src/storage/external_sort.c
+++ b/src/storage/external_sort.c
@@ -1852,7 +1852,7 @@ px_sort_myself (THREAD_ENTRY * thread_p, PX_TREE_NODE * px_node)
       long left_vector_size, right_vector_size;
       char **left_vector, **right_vector;
       PX_TREE_NODE *left_px_node, *right_px_node;
-      int i, j, k;		// Used in the merge logic
+      int i, j, k;		/* Used in the merge logic */
 
       assert_release (child_right > 0);
 
@@ -1863,11 +1863,8 @@ px_sort_myself (THREAD_ENTRY * thread_p, PX_TREE_NODE * px_node)
 
       /* do new child first */
       right_vector = vector + left_vector_size;
-      right_px_node = px_sort_assign (thread_p, sort_param, px_node->px_id + child_right, buff + left_vector_size, right_vector, right_vector_size, child_height, 0	/* px_myself: 
-																					 * set 
-																					 * as 
-																					 * root 
-																					 */ );
+      right_px_node = px_sort_assign (thread_p, sort_param, px_node->px_id + child_right, buff + left_vector_size,
+				      right_vector, right_vector_size, child_height, 0 /* px_myself: set as root */ );
       if (right_px_node == NULL)
 	{
 	  goto exit_on_error;
@@ -2257,7 +2254,6 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
       switch (status)
 	{
 	case SORT_ERROR_OCCURRED:
-	  assert (er_errid () != NO_ERROR);
 	  error = er_errid ();
 	  assert (error != NO_ERROR);
 	  goto exit_on_error;
@@ -2285,17 +2281,16 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
 		  pthread_mutex_unlock (&(sort_param->px_mtx));
 #endif /* SERVER_MODE */
 
-		  px_node = px_sort_assign (thread_p, sort_param, 0, index_buff, index_area, numrecs, sort_param->px_height_max, 0	/* px_myself: 
-																	 * set 
-																	 * as 
-																	 * root 
-																	 */ );
+		  px_node = px_sort_assign (thread_p, sort_param, 0, index_buff, index_area, numrecs,
+					    sort_param->px_height_max, 0 /* px_myself: set as root */ );
 		  if (px_node == NULL)
 		    {
+		      error = ER_FAILED;
 		      goto exit_on_error;
 		    }
 
-		  if (px_sort_myself (thread_p, px_node) != NO_ERROR)
+		  error = px_sort_myself (thread_p, px_node);
+		  if (error != NO_ERROR)
 		    {
 		      goto exit_on_error;
 		    }
@@ -2313,6 +2308,7 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
 
 	      if (index_area == NULL || numrecs < 0)
 		{
+		  error = ER_FAILED;
 		  goto exit_on_error;
 		}
 
@@ -2421,7 +2417,7 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
 		    }
 		  else
 		    {
-		      assert (er_errid () != NO_ERROR);
+		      ASSERT_ERROR ();
 		      error = er_errid ();
 		    }
 
@@ -2533,11 +2529,13 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
 				    0 /* px_myself: set as root */ );
 	  if (px_node == NULL)
 	    {
+	      error = ER_FAILED;
 	      goto exit_on_error;
 	    }
 
 	  if (px_sort_myself (thread_p, px_node) != NO_ERROR)
 	    {
+	      error = ER_FAILED;
 	      goto exit_on_error;
 	    }
 
@@ -2553,6 +2551,7 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
 
       if (index_area == NULL || numrecs < 0)
 	{
+	  error = ER_FAILED;
 	  goto exit_on_error;
 	}
 
@@ -2633,9 +2632,8 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
 	      || sort_retrieve_longrec (thread_p, &temp_recdes, &long_recdes) == NULL
 	      || (*sort_param->put_fn) (thread_p, &long_recdes, sort_param->put_arg) != NO_ERROR)
 	    {
-	      assert (er_errid () != NO_ERROR);
+	      ASSERT_ERROR ();
 	      error = er_errid ();
-	      assert (error != NO_ERROR);
 	      goto exit_on_error;
 	    }
 	}
@@ -3128,9 +3126,8 @@ sort_exphase_merge_elim_dup (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 		{
 		  if (sort_retrieve_longrec (thread_p, &smallest_elem_ptr[i], &long_recdes[i]) == NULL)
 		    {
-		      assert (er_errid () != NO_ERROR);
+		      ASSERT_ERROR ();
 		      error = er_errid ();
-		      assert (error != NO_ERROR);
 		      goto bailout;
 		    }
 		}
@@ -3154,11 +3151,11 @@ sort_exphase_merge_elim_dup (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 	      for (p = s->next; p; p = p->next)
 		{
 		  /* compare s, p */
-		  data1 = (smallest_elem_ptr[s->rec_pos].type == REC_BIGONE)
-		    ? &(long_recdes[s->rec_pos].data) : &(smallest_elem_ptr[s->rec_pos].data);
+		  data1 = ((smallest_elem_ptr[s->rec_pos].type == REC_BIGONE)
+			   ? &(long_recdes[s->rec_pos].data) : &(smallest_elem_ptr[s->rec_pos].data));
 
-		  data2 = (smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
-		    ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data);
+		  data2 = ((smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
+			   ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data));
 
 		  cmp = (*compare) (data1, data2, compare_arg);
 		  if (cmp > 0)
@@ -3176,11 +3173,11 @@ sort_exphase_merge_elim_dup (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 	    {
 	      p = s->next;
 
-	      data1 = (smallest_elem_ptr[s->rec_pos].type == REC_BIGONE)
-		? &(long_recdes[s->rec_pos].data) : &(smallest_elem_ptr[s->rec_pos].data);
+	      data1 = ((smallest_elem_ptr[s->rec_pos].type == REC_BIGONE)
+		       ? &(long_recdes[s->rec_pos].data) : &(smallest_elem_ptr[s->rec_pos].data));
 
-	      data2 = (smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
-		? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data);
+	      data2 = ((smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
+		       ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data));
 
 	      cmp = (*compare) (data1, data2, compare_arg);
 	      if (cmp == 0)
@@ -3212,18 +3209,17 @@ sort_exphase_merge_elim_dup (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 		{
 		  if (sort_retrieve_longrec (thread_p, &last_elem_ptr, &last_long_recdes) == NULL)
 		    {
-		      assert (er_errid () != NO_ERROR);
+		      ASSERT_ERROR ();
 		      error = er_errid ();
-		      assert (error != NO_ERROR);
 		      goto bailout;
 		    }
 		}
 
 	      /* STEP 2: compare last, p */
-	      data1 = (last_elem_ptr.type == REC_BIGONE) ? &(last_long_recdes.data) : &(last_elem_ptr.data);
+	      data1 = ((last_elem_ptr.type == REC_BIGONE) ? &(last_long_recdes.data) : &(last_elem_ptr.data));
 
-	      data2 = (smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
-		? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data);
+	      data2 = ((smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
+		       ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data));
 
 	      last_elem_cmp = (*compare) (data1, data2, compare_arg);
 	    }
@@ -3432,9 +3428,8 @@ sort_exphase_merge_elim_dup (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 		{
 		  if (sort_retrieve_longrec (thread_p, &smallest_elem_ptr[min], &long_recdes[min]) == NULL)
 		    {
-		      assert (er_errid () != NO_ERROR);
+		      ASSERT_ERROR ();
 		      error = er_errid ();
-		      assert (error != NO_ERROR);
 		      goto bailout;
 		    }
 		}
@@ -3467,11 +3462,11 @@ sort_exphase_merge_elim_dup (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 			}
 
 		      /* compare s, p */
-		      data1 = (smallest_elem_ptr[s->rec_pos].type == REC_BIGONE)
-			? &(long_recdes[s->rec_pos].data) : &(smallest_elem_ptr[s->rec_pos].data);
+		      data1 = ((smallest_elem_ptr[s->rec_pos].type == REC_BIGONE)
+			       ? &(long_recdes[s->rec_pos].data) : &(smallest_elem_ptr[s->rec_pos].data));
 
-		      data2 = (smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
-			? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data);
+		      data2 = ((smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
+			       ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data));
 
 		      cmp = (*compare) (data1, data2, compare_arg);
 		      if (cmp > 0)
@@ -3519,18 +3514,18 @@ sort_exphase_merge_elim_dup (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 			    {
 			      if (sort_retrieve_longrec (thread_p, &last_elem_ptr, &last_long_recdes) == NULL)
 				{
-				  assert (er_errid () != NO_ERROR);
+				  ASSERT_ERROR ();
 				  error = er_errid ();
-				  assert (error != NO_ERROR);
 				  goto bailout;
 				}
 			    }
 
 			  /* STEP 2: compare last, p */
-			  data1 = (last_elem_ptr.type == REC_BIGONE) ? &(last_long_recdes.data) : &(last_elem_ptr.data);
+			  data1 = ((last_elem_ptr.type == REC_BIGONE)
+				   ? &(last_long_recdes.data) : &(last_elem_ptr.data));
 
-			  data2 = (smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
-			    ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data);
+			  data2 = ((smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
+				   ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data));
 
 			  last_elem_cmp = (*compare) (data1, data2, compare_arg);
 			}
@@ -3909,9 +3904,8 @@ sort_exphase_merge (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 		{
 		  if (sort_retrieve_longrec (thread_p, &smallest_elem_ptr[i], &long_recdes[i]) == NULL)
 		    {
-		      assert (er_errid () != NO_ERROR);
+		      ASSERT_ERROR ();
 		      error = er_errid ();
-		      assert (error != NO_ERROR);
 		      goto bailout;
 		    }
 		}
@@ -3931,11 +3925,11 @@ sort_exphase_merge (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 		{
 		  do_swap = false;
 
-		  data1 = (smallest_elem_ptr[s->rec_pos].type == REC_BIGONE)
-		    ? &(long_recdes[s->rec_pos].data) : &(smallest_elem_ptr[s->rec_pos].data);
+		  data1 = ((smallest_elem_ptr[s->rec_pos].type == REC_BIGONE)
+			   ? &(long_recdes[s->rec_pos].data) : &(smallest_elem_ptr[s->rec_pos].data));
 
-		  data2 = (smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
-		    ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data);
+		  data2 = ((smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
+			   ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data));
 
 		  cmp = (*compare) (data1, data2, compare_arg);
 		  if (cmp > 0)
@@ -3975,18 +3969,17 @@ sort_exphase_merge (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 		{
 		  if (sort_retrieve_longrec (thread_p, &last_elem_ptr, &last_long_recdes) == NULL)
 		    {
-		      assert (er_errid () != NO_ERROR);
+		      ASSERT_ERROR ();
 		      error = er_errid ();
-		      assert (error != NO_ERROR);
 		      goto bailout;
 		    }
 		}
 
 	      /* STEP 2: compare last, p */
-	      data1 = (last_elem_ptr.type == REC_BIGONE) ? &(last_long_recdes.data) : &(last_elem_ptr.data);
+	      data1 = ((last_elem_ptr.type == REC_BIGONE) ? &(last_long_recdes.data) : &(last_elem_ptr.data));
 
-	      data2 = (smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
-		? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data);
+	      data2 = ((smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
+		       ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data));
 
 	      cmp = (*compare) (data1, data2, compare_arg);
 	      if (cmp <= 0)
@@ -4190,9 +4183,8 @@ sort_exphase_merge (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 		{
 		  if (sort_retrieve_longrec (thread_p, &smallest_elem_ptr[min], &long_recdes[min]) == NULL)
 		    {
-		      assert (er_errid () != NO_ERROR);
+		      ASSERT_ERROR ();
 		      error = er_errid ();
-		      assert (error != NO_ERROR);
 		      goto bailout;
 		    }
 		}
@@ -4216,11 +4208,11 @@ sort_exphase_merge (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 
 		      do_swap = false;
 
-		      data1 = (smallest_elem_ptr[s->rec_pos].type == REC_BIGONE)
-			? &(long_recdes[s->rec_pos].data) : &(smallest_elem_ptr[s->rec_pos].data);
+		      data1 = ((smallest_elem_ptr[s->rec_pos].type == REC_BIGONE)
+			       ? &(long_recdes[s->rec_pos].data) : &(smallest_elem_ptr[s->rec_pos].data));
 
-		      data2 = (smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
-			? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data);
+		      data2 = ((smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
+			       ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data));
 
 		      cmp = (*compare) (data1, data2, compare_arg);
 		      if (cmp > 0)
@@ -4263,18 +4255,18 @@ sort_exphase_merge (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 			    {
 			      if (sort_retrieve_longrec (thread_p, &last_elem_ptr, &last_long_recdes) == NULL)
 				{
-				  assert (er_errid () != NO_ERROR);
+				  ASSERT_ERROR ();
 				  error = er_errid ();
-				  assert (error != NO_ERROR);
 				  goto bailout;
 				}
 			    }
 
 			  /* STEP 2: compare last, p */
-			  data1 = (last_elem_ptr.type == REC_BIGONE) ? &(last_long_recdes.data) : &(last_elem_ptr.data);
+			  data1 =
+			    ((last_elem_ptr.type == REC_BIGONE) ? &(last_long_recdes.data) : &(last_elem_ptr.data));
 
-			  data2 = (smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
-			    ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data);
+			  data2 = ((smallest_elem_ptr[p->rec_pos].type == REC_BIGONE)
+				   ? &(long_recdes[p->rec_pos].data) : &(smallest_elem_ptr[p->rec_pos].data));
 
 			  cmp = (*compare) (data1, data2, compare_arg);
 			  if (cmp <= 0)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -5151,6 +5151,7 @@ heap_create_internal (THREAD_ENTRY * thread_p, HFID * hfid, const OID * class_oi
     {
       /* something went wrong, destroy the file, and return */
       assert_release (false);
+      error_code = ER_FAILED;
       goto error;
     }
 
@@ -17558,7 +17559,7 @@ heap_header_capacity_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALU
   ctx = (HEAP_SHOW_SCAN_CTX *) db_private_alloc (thread_p, sizeof (HEAP_SHOW_SCAN_CTX));
   if (ctx == NULL)
     {
-      assert (er_errid () != NO_ERROR);
+      ASSERT_ERROR ();
       error = er_errid ();
       goto cleanup;
     }
@@ -17585,7 +17586,7 @@ heap_header_capacity_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALU
       ctx->hfids = (HFID *) db_private_alloc (thread_p, parts_count * sizeof (HFID));
       if (ctx->hfids == NULL)
 	{
-	  assert (er_errid () != NO_ERROR);
+	  ASSERT_ERROR ();
 	  error = er_errid ();
 	  goto cleanup;
 	}
@@ -17602,7 +17603,7 @@ heap_header_capacity_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALU
       ctx->hfids = (HFID *) db_private_alloc (thread_p, sizeof (HFID));
       if (ctx->hfids == NULL)
 	{
-	  assert (er_errid () != NO_ERROR);
+	  ASSERT_ERROR ();
 	  error = er_errid ();
 	  goto cleanup;
 	}
@@ -17682,7 +17683,7 @@ heap_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
   pgptr = heap_scan_pb_lock_and_fetch (thread_p, &vpid, OLD_PAGE, S_LOCK, NULL, NULL);
   if (pgptr == NULL)
     {
-      assert (er_errid () != NO_ERROR);
+      ASSERT_ERROR ();
       error = er_errid ();
       goto cleanup;
     }

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -5476,7 +5476,8 @@ catalog_get_cardinality (THREAD_ENTRY * thread_p, OID * class_oid, DISK_REPR * r
 
 	  catalog_access_info.class_oid = &partitions[i];
 	  catalog_access_info.dir_oid = &dir_oid;
-	  if (catalog_start_access_with_dir_oid (thread_p, &catalog_access_info, S_LOCK) != NO_ERROR)
+	  error = catalog_start_access_with_dir_oid (thread_p, &catalog_access_info, S_LOCK);
+	  if (error != NO_ERROR)
 	    {
 	      goto exit_cleanup;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21454

The reproduction shows error from `catcls_update_subset` was not propagated to caller.
There were same slips that did not properly return error.