### PR TITLE
[CBRD-21470] fixes to hold directory lock until the end of system ope…

### DIFF
--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -5941,14 +5941,6 @@ catalog_end_access_with_dir_oid (THREAD_ENTRY * thread_p, CATALOG_ACCESS_INFO * 
 
   assert (BO_IS_SERVER_RESTARTED () == true);
 
-  OID_GET_VIRTUAL_CLASS_OF_DIR_OID (catalog_access_info->class_oid, &virtual_class_dir_oid);
-  if (catalog_access_info->need_unlock == true)
-    {
-      current_lock = catalog_access_info->is_update ? X_LOCK : S_LOCK;
-      lock_unlock_object_donot_move_to_non2pl (thread_p, catalog_access_info->dir_oid, &virtual_class_dir_oid,
-					       current_lock);
-    }
-
   if (catalog_access_info->is_update == true)
     {
       if (error != NO_ERROR)
@@ -5983,6 +5975,14 @@ catalog_end_access_with_dir_oid (THREAD_ENTRY * thread_p, CATALOG_ACCESS_INFO * 
 #if !defined (NDEBUG)
   assert (catalog_access_info->is_systemop_started == false);
 #endif
+
+  OID_GET_VIRTUAL_CLASS_OF_DIR_OID (catalog_access_info->class_oid, &virtual_class_dir_oid);
+  if (catalog_access_info->need_unlock == true)
+    {
+      current_lock = catalog_access_info->is_update ? X_LOCK : S_LOCK;
+      lock_unlock_object_donot_move_to_non2pl (thread_p, catalog_access_info->dir_oid, &virtual_class_dir_oid,
+					       current_lock);
+    }
 
   catalog_access_info->access_started = false;
   catalog_access_info->is_update = false;


### PR DESCRIPTION
…ration

http://jira.cubrid.org/browse/CBRD-21470

Two (or more) update statistics to a table might cause the trouble.
Consequences are

1. Tr 1 adds an entry
2. Tr 1 unlocks directory lock
3. Tr 2 deletes the entry inserted by Tr 1.
4. Tr 2 commits its sysop
5. Tr 1 aborts its sysop