### PR TITLE
[CBRD-21477] Fix disk format rollback (not recovery)

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -6004,7 +6004,7 @@ disk_check_volume (THREAD_ENTRY * thread_p, INT16 volid, bool repair)
     }
 
   /* permanent volume is un-maxed if and only if it is the auto-extend volume */
-  if (volheader->purpose == DB_PERMANENT_DATA_PURPOSE && volheader->nsect_max < volheader->nsect_total
+  if (volheader->purpose == DB_PERMANENT_DATA_PURPOSE && volheader->nsect_max > volheader->nsect_total
       && disk_Cache->perm_purpose_info.extend_info.volid_extend != volid)
     {
       /* inconsistent! */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21477

bug in disk format online rollback. although the volume count says volume is in cache, actually nothing else is added to cache. "removing" from cache was wrongfully forced, and cache was corrupted.

fix by correctly handling disk_rv_undo_format. there are three cases:
  1. rollback, not recovery. volume is not in cache.
  2. recovery, volume is not in cache (volume count is less or equal to volid)
  3. recovery, volume is in cache (volume count is volid + 1).

First two cases will not touch cache (the volume count in first case is decremented by disk_add_volume).
Third case has to completely remove volume data from cache.

Other changes:
  * debug disk check after volume extensions.
  * do not interrupt disk_add_volume.