### PR TITLE
[CBRD-21492] heap_classrepr_get: don't combine regular and ordered fix

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -2327,6 +2327,12 @@ search_begin:
 	      /* we cannot hold mutex */
 	      pthread_mutex_unlock (&hash_anchor->hash_mutex);
 	    }
+	  else if (spage_get_record_type (page_of_class, class_oid->slotid) != REC_HOME)
+	    {
+	      /* things get too complicated when we need to do ordered fix. */
+	      pgbuf_unfix_and_init (thread_p, page_of_class);
+	      pthread_mutex_unlock (&hash_anchor->hash_mutex);
+	    }
 	  repr_from_record = heap_classrepr_get_from_record (thread_p, &last_reprid, class_oid, class_recdes, reprid);
 	  if (repr_from_record == NULL)
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21492

this is a hack to avoid combining regular and ordered fix, but keep the optimization of latching page and not repeating search in case of REC_HOME.