### PR TITLE
[CBRD-21503] allow archive purging in SA_MODE

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5448,8 +5448,16 @@ vacuum_min_log_pageid_to_keep (THREAD_ENTRY * thread_p)
   /* Return first pageid from first block in vacuum data table */
   if (prm_get_bool_value (PRM_ID_DISABLE_VACUUM))
     {
+      /* this is for debug, suppress log archive purging. */
+      return 0;
+    }
+#if defined (SA_MODE)
+  if (vacuum_Data.is_vacuum_complete)
+    {
+      /* no log archives are needed for vacuum any longer. */
       return NULL_PAGEID;
     }
+#endif /* defined (SA_MODE) */
   return vacuum_Data.keep_from_log_pageid;
 }
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6857,10 +6857,6 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 
   /* Get first log pageid needed for vacuum before locking LOG_CS. */
   vacuum_first_pageid = vacuum_min_log_pageid_to_keep (thread_p);
-  if (vacuum_first_pageid == NULL_PAGEID)
-    {
-      return 0;			/* none is deleted */
-    }
 
   LOG_CS_ENTER (thread_p);
 


### PR DESCRIPTION
Merge #798 for `10.1 Patch 1`.

http://jira.cubrid.org/browse/CBRD-21503

In SA_MODE, vacuum_Data.keep_from_log_pageid is never updated and it prevents log archive purger from removing log archives. But after xvacuum, it is safe to remove any archives, since new MVCC ops are not logged and vacuum is not required.