### PR TITLE
[CBRD-21512] quick fix LOCK_COMPATIBILITY issue

### DIFF
--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -492,9 +492,9 @@ typedef int TRANID;		/* Transaction identifier */
 
 typedef enum
 {
-  LOCK_COMPAT_UNKNOWN,
+  LOCK_COMPAT_NO = 0,
   LOCK_COMPAT_YES,
-  LOCK_COMPAT_NO,
+  LOCK_COMPAT_UNKNOWN,
 } LOCK_COMPATIBILITY;
 
 typedef enum


### PR DESCRIPTION
[CBRD-21512](http://jira.cubrid.org/browse/CBRD-21512)

Fix values for lock_no, lock_yes and lock_unknown to match previous values.

TODO: use LOCK_COMPATIBILITY everywhere lock compatibility is checked.

Also fixes [CBRD-21510](http://jira.cubrid.org/browse/CBRD-21510) and [CBRD-21511](http://jira.cubrid.org/browse/CBRD-21511).