### PR TITLE
[CBRD-21513] fix OR_GET_MONETARY/OR_PUT_MONETARY

### DIFF
--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -359,7 +359,7 @@
 
 #define OR_GET_MONETARY(ptr, value) \
   do { \
-    double pack_value; \
+    UINT64 pack_value; \
     (value)->type = (DB_CURRENCY) OR_GET_INT (((char *) (ptr)) + OR_MONETARY_TYPE); \
     memcpy ((char *) (&pack_value), ((char *) (ptr)) + OR_MONETARY_AMOUNT, OR_DOUBLE_SIZE); \
     OR_GET_DOUBLE (&pack_value, &(value)->amount); \
@@ -370,7 +370,7 @@
 
 #define OR_PUT_MONETARY(ptr, value) \
   do { \
-    double pack_value; \
+    UINT64 pack_value; \
     OR_PUT_INT (((char *) (ptr)) + OR_MONETARY_TYPE, (int) (value)->type); \
     OR_PUT_DOUBLE (&pack_value, &((value)->amount)); \
     memcpy (((char *) (ptr)) + OR_MONETARY_AMOUNT, &pack_value, OR_DOUBLE_SIZE); \

--- a/src/jsp/jsp_cl.c
+++ b/src/jsp/jsp_cl.c
@@ -2226,7 +2226,8 @@ jsp_unpack_float_value (char *buffer, DB_VALUE * retval)
 static char *
 jsp_unpack_double_value (char *buffer, DB_VALUE * retval)
 {
-  double val, result;
+  UINT64 val;
+  double result;
 
   memcpy ((char *) (&val), buffer, OR_DOUBLE_SIZE);
   OR_GET_DOUBLE (&val, &result);
@@ -2535,7 +2536,8 @@ jsp_unpack_object_value (char *buffer, DB_VALUE * retval)
 static char *
 jsp_unpack_monetary_value (char *buffer, DB_VALUE * retval)
 {
-  double val, result;
+  UINT64 val;
+  double result;
   char *ptr;
 
   ptr = buffer;


### PR DESCRIPTION
[CBRD-21513](http://jira.cubrid.org/browse/CBRD-21513)

fixed using UINT64 argument for OR_GET_DOUBLE/OR_PUT_DOUBLE. GET/PUT monetary was broken.

TODO: the macros are not safe. we should replace with inlined functions that can check type correctness.