### PR TITLE
[CBRD-21545] ha_mode param should also be a client param as well as s…

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -3439,7 +3439,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_HA_MODE,
    PRM_NAME_HA_MODE,
-   (PRM_FOR_SERVER | PRM_FOR_HA | PRM_FORCE_SERVER),
+   (PRM_FOR_SERVER | PRM_FOR_CLIENT | PRM_FOR_HA | PRM_FORCE_SERVER),
    PRM_KEYWORD,
    &prm_ha_mode_flag,
    (void *) &prm_ha_mode_default,


### PR DESCRIPTION
…erver

http://jira.cubrid.org/browse/CBRD-21545

`master` and other clients should be allowed to access it.
