### PR TITLE
[CBRD-21551] (re)enable log applier log print

### DIFF
--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -7001,7 +7001,6 @@ la_shutdown (void)
   return;
 }
 
-#if 0
 /*
  * la_print_log_header () -
  */
@@ -7084,7 +7083,6 @@ la_print_log_arv_header (const char *database_name, LOG_ARV_HEADER * hdr, bool v
     }
   printf ("%-30s : %d\n", "Archive number", hdr->arv_num);
 }
-#endif /* 0 */
 
 /*
  * la_log_page_check() - test the transaction log

--- a/src/transaction/log_applier.h
+++ b/src/transaction/log_applier.h
@@ -55,11 +55,8 @@ int la_log_page_check (const char *database_name, const char *log_path, INT64 pa
 		       bool check_copied_info, bool check_replica_info, bool verbose, LOG_LSA * copied_eof_lsa,
 		       LOG_LSA * copied_append_lsa, LOG_LSA * applied_final_lsa);
 int la_apply_log_file (const char *database_name, const char *log_path, const int max_mem_size);
-#if 0
-/* fixme(rem) - I cannot include log_impl.h */
 void la_print_log_header (const char *database_name, LOG_HEADER * hdr, bool verbose);
 void la_print_log_arv_header (const char *database_name, LOG_ARV_HEADER * hdr, bool verbose);
-#endif /* 0 */
 void la_print_delay_info (LOG_LSA working_lsa, LOG_LSA target_lsa, float process_rate);
 
 extern int lp_prefetch_log_file (const char *database_name, const char *log_path);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21551

Enable back la_print_log_header and la_print_log_arv_header. They were disabled to avoid exposing log_impl.h to client, but it has been exposed anyway.

log_repl_data_dump depends on printing DB_VALUE and must be solved with CBRD-21538.