### PR TITLE
[CBRD-21574] Use of 32 bits time_t in WIN32 build for CMS

### DIFF
--- a/src/cm_common/cm_broker_admin.c
+++ b/src/cm_common/cm_broker_admin.c
@@ -24,6 +24,10 @@
 
 #ident "$Id$"
 
+#if defined (WIN32) && !defined (_WIN64) && !defined (_USE_32BIT_TIME_T)
+#define _USE_32BIT_TIME_T
+#endif
+
 #include "cm_stat.h"
 #include "cm_errmsg.h"
 #include "cm_portable.h"


### PR DESCRIPTION
* Because of the lifetime of this code is limited to 10.1 Windows 32, we PR this code to 'release/10.1' as the base branch.
* In windows 64 bits environments, CBRD-21574 is not a problem.
* WIN32 CUBRID Engine will not be supported from Cherry, so PR of this code to develop branch is not   necessary.