### PR TITLE
[CBRD-21583] sa_mode_partial_block may be interrupted

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3062,7 +3062,10 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
   /* Initialize stored heap objects. */
   worker->n_heap_objects = 0;
 
-  was_interrupted = VACUUM_BLOCK_IS_INTERRUPTED (data->blockid);
+  /* set was_interrupted flag to tell vacuum_heap_page that some safe-guard have to behave differently. interruptions
+   * are usually marked in blockid, however sa_mode_partial_block can also be interrupted and will no flag is set in
+   * blockid. */
+  was_interrupted = VACUUM_BLOCK_IS_INTERRUPTED (data->blockid) || sa_mode_partial_block;
 
   /* Follow the linked records starting with start_lsa */
   for (LSA_COPY (&log_lsa, &data->start_lsa); !LSA_ISNULL (&log_lsa) && log_lsa.pageid >= first_block_pageid;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21583

This seems to be just a safe-guard issue. We usually mark in vacuum data when jobs are started and when they are finished, so we can adjust safe-guards after restart (expecting already vacuumed heap pages).

However, stand-alone mode vacuuming partial blocks can be interrupted and will not be flagged in any way. Therefore, it is better to consider that job was interrupted when sa_mode_partial_block is true.

I've set the milestone to 10.1 Patch 1, but since it is just a bad safeguard in an exceptional case, we can change it to cherry.