### PR TITLE
[CBRD-21558] inline functions for string compression

### DIFF
--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -1519,7 +1519,8 @@ extern char *or_pack_sha1 (char *ptr, const SHA1Hash * sha1);
 extern char *or_unpack_sha1 (char *ptr, SHA1Hash * sha1);
 
 /* Get the compressed and the decompressed lengths of a string stored in buffer */
-extern int or_get_varchar_compression_lengths (OR_BUF * buf, int *compressed_size, int *decompressed_size);
+STATIC_INLINE int or_get_varchar_compression_lengths (OR_BUF * buf, int *compressed_size, int *decompressed_size)
+  __attribute__ ((ALWAYS_INLINE));
 
 extern int or_packed_spacedb_size (const SPACEDB_ALL * all, const SPACEDB_ONEVOL * vols, const SPACEDB_FILES * files);
 extern char *or_pack_spacedb (char *ptr, const SPACEDB_ALL * all, const SPACEDB_ONEVOL * vols,
@@ -1530,5 +1531,80 @@ extern char *or_unpack_spacedb (char *ptr, SPACEDB_ALL * all, SPACEDB_ONEVOL ** 
 extern int classobj_decompose_property_oid (const char *buffer, int *volid, int *fileid, int *pageid);
 extern void classobj_initialize_default_expr (DB_DEFAULT_EXPR * default_expr);
 extern int classobj_get_prop (DB_SEQ * properties, const char *name, DB_VALUE * pvalue);
+
+/* Because of the VARNCHAR and STRING encoding, this one could not be changed for over 255, just lower. */
+#define OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION 255
+
+#define OR_GET_STRING_SIZE_BYTE(buf, size_prefix, error) \
+  do \
+    { \
+      if (((buf)->ptr + OR_BYTE_SIZE) > (buf)->endptr) \
+        { \
+          (size_prefix) = 0; \
+          (error) = or_underflow ((buf)); \
+        } \
+      else \
+        { \
+          (size_prefix) = OR_GET_BYTE ((buf)->ptr); \
+          (buf)->ptr += OR_BYTE_SIZE; \
+          (error) = NO_ERROR; \
+        } \
+    } \
+  while (0)
+
+/* or_get_varchar_compression_lengths() - Function to get the compressed length and the uncompressed length of 
+ *					  a compressed string.
+ * 
+ * return                 : NO_ERROR or error_code.
+ * buf(in)                : The buffer where the string is stored.
+ * compressed_size(out)   : The compressed size of the string. Set to 0 if the string was not compressed.
+ * decompressed_size(out) : The uncompressed size of the string.
+ */
+STATIC_INLINE int
+or_get_varchar_compression_lengths (OR_BUF * buf, int *compressed_size, int *decompressed_size)
+{
+  int compressed_length = 0, decompressed_length = 0, rc = NO_ERROR, net_charlen = 0;
+  int size_prefix = 0;
+
+  /* Check if the string is compressed */
+  OR_GET_STRING_SIZE_BYTE (buf, size_prefix, rc);
+  if (rc != NO_ERROR)
+    {
+      assert (size_prefix == 0);
+      return rc;
+    }
+
+  if (size_prefix == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+    {
+      /* String was compressed */
+      /* Get the compressed size */
+      rc = or_get_data (buf, (char *) &net_charlen, OR_INT_SIZE);
+      compressed_length = OR_GET_INT ((char *) &net_charlen);
+      if (rc != NO_ERROR)
+	{
+	  return rc;
+	}
+      *compressed_size = compressed_length;
+
+      net_charlen = 0;
+
+      /* Get the decompressed size */
+      rc = or_get_data (buf, (char *) &net_charlen, OR_INT_SIZE);
+      decompressed_length = OR_GET_INT ((char *) &net_charlen);
+      if (rc != NO_ERROR)
+	{
+	  return rc;
+	}
+      *decompressed_size = decompressed_length;
+    }
+  else
+    {
+      /* String was not compressed so we set compressed_size to 0 to know that no compression happened. */
+      *compressed_size = 0;
+      *decompressed_size = size_prefix;
+    }
+
+  return rc;
+}
 
 #endif /* _OBJECT_REPRESENTATION_H_ */

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -6789,53 +6789,6 @@ db_set_connect_status (int status)
 }
 
 /*
- *  db_set_compressed_string()	    :- Sets the compressed string, its size and its need for clear in the DB_VALUE
- *
- *  value(in/out)		    :- The DB_VALUE
- *  compressed_string(in)	    :-
- *  compressed_size(in)		    :-
- *  compressed_need_clear(in)	    :-
- */
-void
-db_set_compressed_string (DB_VALUE * value, char *compressed_string, int compressed_size, bool compressed_need_clear)
-{
-  DB_TYPE type;
-
-  if (value == NULL || DB_IS_NULL (value))
-    {
-      return;
-    }
-  type = DB_VALUE_DOMAIN_TYPE (value);
-
-  /* Preliminary check */
-  assert (type == DB_TYPE_VARCHAR || type == DB_TYPE_VARNCHAR);
-
-  value->data.ch.medium.compressed_buf = compressed_string;
-  value->data.ch.medium.compressed_size = compressed_size;
-  value->data.ch.info.compressed_need_clear = compressed_need_clear;
-
-  return;
-}
-
-int
-db_get_compressed_size (DB_VALUE * value)
-{
-  DB_TYPE type;
-
-  if (value == NULL || DB_IS_NULL (value))
-    {
-      return 0;
-    }
-
-  type = DB_VALUE_DOMAIN_TYPE (value);
-
-  /* Preliminary check */
-  assert (type == DB_TYPE_VARCHAR || type == DB_TYPE_VARNCHAR);
-
-  return value->data.ch.medium.compressed_size;
-}
-
-/*
  * db_default_expression_string() - 
  * return : string opcode of default expression
  * default_expr_type(in):

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -363,9 +363,6 @@ extern int pr_data_compress_string (char *string, int str_length, char *compress
 extern int pr_clear_compressed_string (DB_VALUE * value);
 extern int pr_do_db_value_string_compression (DB_VALUE * value);
 
-/* Because of the VARNCHAR and STRING encoding, this one could not be changed for over 255, just lower. */
-#define PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION 255
-
 #define PRIM_TEMPORARY_DISK_SIZE 256
 #define PRIM_COMPRESSION_LENGTH_OFFSET 4
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -18004,20 +18004,19 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
   /* generally, data is short enough */
   str_length1 = OR_GET_BYTE (str1);
   str_length2 = OR_GET_BYTE (str2);
-  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
-      && str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length1 < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION && str_length2 < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       str1 += OR_BYTE_SIZE;
       str2 += OR_BYTE_SIZE;
       return bf2df_str_compare ((unsigned char *) str1, str_length1, (unsigned char *) str2, str_length2);
     }
 
-  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
-	  || str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (str_length1 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
+	  || str_length2 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* String 1 */
   or_init (&buf1, str1, 0);
-  if (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length1 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf1, &str1_compressed_length, &str1_decompressed_length);
       if (rc != NO_ERROR)
@@ -18058,7 +18057,7 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
 
   /* String 2 */
   or_init (&buf2, str2, 0);
-  if (str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length2 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf2, &str2_compressed_length, &str2_decompressed_length);
       if (rc != NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21558

Profile shows overhead of retrieving strings.
Patch inlines or_get_varchar_compression_lengths, db_set_compressed_string and db_get_compressed_size functions.

