### PR TITLE
[CBRD-21524] introduce astyle to format .cpp and .hpp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ x86
 *.swp
 *.bak
 *.*~
+*.*.orig
 tags
 cscope.out
 

--- a/src/base/base_flag.hpp
+++ b/src/base/base_flag.hpp
@@ -27,29 +27,29 @@
 template <typename T>
 class flag
 {
-public:
-  inline flag ();
-  inline flag (const flag<T> & other);
-  inline flag (const T& init_flags);
+  public:
+    inline flag ();
+    inline flag (const flag<T> &other);
+    inline flag (const T &init_flags);
 
-  inline flag& operator= (const flag<T> & other);
-  inline flag& operator= (const T& flags);
+    inline flag &operator= (const flag<T> &other);
+    inline flag &operator= (const T &flags);
 
-  inline void set (const T& flags);
-  inline void clear (const T& flags);
-  inline bool is_set (const T& flags);
-  inline bool is_all_set (const T& flags);
-  inline bool is_any_set (const T& flags);
-  inline T get_flags (void);
+    inline void set (const T &flags);
+    inline void clear (const T &flags);
+    inline bool is_set (const T &flags);
+    inline bool is_all_set (const T &flags);
+    inline bool is_any_set (const T &flags);
+    inline T get_flags (void);
 
-  static inline void set_flag (T & where_to_set, T & what_to_set);
-  static inline void clear_flag (T & where_to_clear, T & what_to_clear);
-  static inline bool is_flag_set (T & where_to_check, T & what_to_check);
-  static inline bool is_flag_all_set (T & where_to_check, T & what_to_check);
-  static inline bool is_flag_any_set (T & where_to_check, T & what_to_check);
+    static inline void set_flag (T &where_to_set, T &what_to_set);
+    static inline void clear_flag (T &where_to_clear, T &what_to_clear);
+    static inline bool is_flag_set (T &where_to_check, T &what_to_check);
+    static inline bool is_flag_all_set (T &where_to_check, T &what_to_check);
+    static inline bool is_flag_any_set (T &where_to_check, T &what_to_check);
 
-private:
-  T m_flags;
+  private:
+    T m_flags;
 };
 
 #endif /* _BASE_FLAG_HPP_ */
@@ -62,29 +62,29 @@ flag<T>::flag ()
 }
 
 template<typename T>
-inline flag<T>::flag (const flag & other)
+inline flag<T>::flag (const flag &other)
 {
   m_flags = other.m_flags;
 }
 
 template<typename T>
 inline
-flag<T>::flag (const T & init_flags)
+flag<T>::flag (const T &init_flags)
 {
   m_flags = init_flags;
 }
 
 template<typename T>
-inline flag&
-flag<T>::operator= (const flag& other)
+inline flag &
+flag<T>::operator= (const flag &other)
 {
   this->m_flags = other.m_flags;
   return *this;
 }
 
 template<typename T>
-inline flag&
-flag<T>::operator= (const T& flags)
+inline flag &
+flag<T>::operator= (const T &flags)
 {
   this->m_flags = flags;
   return *this;
@@ -92,34 +92,34 @@ flag<T>::operator= (const T& flags)
 
 template<typename T>
 inline void
-flag<T>::set (const T & flags)
+flag<T>::set (const T &flags)
 {
   m_flags = m_flags | flags;
 }
 
 template<typename T>
 inline void
-flag<T>::clear (const T & flags)
+flag<T>::clear (const T &flags)
 {
   m_flags = m_flags & (~flags);
 }
 
 template<typename T>
 inline bool
-flag<T>::is_set (const T & flags)
+flag<T>::is_set (const T &flags)
 {
   /* sugar syntax */
   return is_any_set (flags);
 }
 
 template<typename T>
-inline bool flag<T>::is_all_set (const T & flags)
+inline bool flag<T>::is_all_set (const T &flags)
 {
   return (m_flags & flags) == flags;
 }
 
 template<typename T>
-inline bool flag<T>::is_any_set (const T & flags)
+inline bool flag<T>::is_any_set (const T &flags)
 {
   return (m_flags & flags) != 0;
 }
@@ -133,34 +133,35 @@ flag<T>::get_flags (void)
 
 template<typename T>
 inline void
-flag<T>::set_flag (T & where_to_set, T & what_to_set)
+flag<T>::set_flag (T &where_to_set, T &what_to_set)
 {
   where_to_set = where_to_set | what_to_set;
 }
 
 template<typename T>
 inline void
-flag<T>::clear_flag (T & where_to_clear, T & what_to_clear)
+flag<T>::clear_flag (T &where_to_clear, T &what_to_clear)
 {
   where_to_clear = where_to_clear & (~what_to_clear);
 }
 
 template<typename T>
 inline bool
-flag<T>::is_flag_set (T & where_to_check, T & what_to_check)
+flag<T>::is_flag_set (T &where_to_check, T &what_to_check)
 {
   /* syntax sugar */
   return flag<T>::is_flag_any_set (where_to_check, what_to_check);
 }
 
 template<typename T>
-inline bool flag<T>::is_flag_all_set (T & where_to_check, T & what_to_check)
+inline bool flag<T>::is_flag_all_set (T &where_to_check, T &what_to_check)
 {
   return (where_to_check & what_to_check) == what_to_check;
 }
 
 template<typename T>
-inline bool flag<T>::is_flag_any_set (T & where_to_check, T & what_to_check)
+inline bool flag<T>::is_flag_any_set (T &where_to_check, T &what_to_check)
 {
   return (where_to_check & what_to_check) != 0;
 }
+

--- a/src/base/contiguous_memory_buffer.hpp
+++ b/src/base/contiguous_memory_buffer.hpp
@@ -55,29 +55,29 @@
 template <typename T, size_t Size, typename Allocator>
 class contiguous_memory_buffer
 {
-public:
+  public:
 
-  contiguous_memory_buffer (Allocator& alloc);
-  inline ~contiguous_memory_buffer ();
+    contiguous_memory_buffer (Allocator &alloc);
+    inline ~contiguous_memory_buffer ();
 
-  inline T* resize (size_t size);           // resize if size is bigger than current buffer and return updated buffer
-                                            // pointer
-  inline T* get_membuf_data (void) const;   // get current buffer pointer
+    inline T *resize (size_t size);           // resize if size is bigger than current buffer and return updated buffer
+    // pointer
+    inline T *get_membuf_data (void) const;   // get current buffer pointer
 
-private:
-  // no implicit constructor
-  contiguous_memory_buffer ();
+  private:
+    // no implicit constructor
+    contiguous_memory_buffer ();
 
-  inline size_t get_memsize (size_t count); // memory size for count T's
-  void extend (size_t size);                // extend buffer to hold count T's
-                                            // this is the only part not-inlined of contiguous_memory_buffer. it is
-                                            // supposed to be an exceptional case
+    inline size_t get_memsize (size_t count); // memory size for count T's
+    void extend (size_t size);                // extend buffer to hold count T's
+    // this is the only part not-inlined of contiguous_memory_buffer. it is
+    // supposed to be an exceptional case
 
-  Allocator &m_alloc;                       // heap allocator
-  size_t m_capacity;                        // current buffer capacity
-  T m_stack_membuf[Size];                   // stack buffer
-  T *m_heap_membuf;                         // heap buffer
-  T *m_current_membuf;                      // current buffer pointer
+    Allocator &m_alloc;                       // heap allocator
+    size_t m_capacity;                        // current buffer capacity
+    T m_stack_membuf[Size];                   // stack buffer
+    T *m_heap_membuf;                         // heap buffer
+    T *m_current_membuf;                      // current buffer pointer
 };
 
 #endif /* _CONTIGUOUS_MEMORY_BUFFER_HPP_ */
@@ -88,7 +88,7 @@ private:
 
 template<typename T, size_t Size, typename Allocator>
 inline
-contiguous_memory_buffer<T, Size, Allocator>::contiguous_memory_buffer (Allocator & alloc) :
+contiguous_memory_buffer<T, Size, Allocator>::contiguous_memory_buffer (Allocator &alloc) :
   m_alloc (alloc),
   m_capacity (Size),
   m_heap_membuf (NULL),
@@ -167,3 +167,4 @@ contiguous_memory_buffer<T, Size, Allocator>::extend (size_t size)
   // update capacity
   m_capacity = new_capacity;
 }
+

--- a/src/base/db_private_allocator.hpp
+++ b/src/base/db_private_allocator.hpp
@@ -50,58 +50,58 @@
 template <typename T>
 class db_private_allocator
 {
-public:
-  /* standard allocator type definitions */
-  typedef T value_type;
-  typedef value_type* pointer;
-  typedef const value_type* const_pointer;
-  typedef value_type& reference;
-  typedef const value_type& const_reference;
-  typedef size_t size_type;
-  typedef ptrdiff_t difference_type;
+  public:
+    /* standard allocator type definitions */
+    typedef T value_type;
+    typedef value_type *pointer;
+    typedef const value_type *const_pointer;
+    typedef value_type &reference;
+    typedef const value_type &const_reference;
+    typedef size_t size_type;
+    typedef ptrdiff_t difference_type;
 
-  /* convert an allocator<T> to allocator<U> */
-  template <typename U>
-  struct rebind
-  {
-    typedef db_private_allocator<U> other;
-  };
+    /* convert an allocator<T> to allocator<U> */
+    template <typename U>
+    struct rebind
+    {
+      typedef db_private_allocator<U> other;
+    };
 
-  inline explicit db_private_allocator (THREAD_ENTRY * thread_p);
-  inline ~db_private_allocator ();
-  inline explicit db_private_allocator (const db_private_allocator & other);
-  template <typename U>
-  inline explicit db_private_allocator (const db_private_allocator<U> & other);
+    inline explicit db_private_allocator (THREAD_ENTRY *thread_p);
+    inline ~db_private_allocator ();
+    inline explicit db_private_allocator (const db_private_allocator &other);
+    template <typename U>
+    inline explicit db_private_allocator (const db_private_allocator<U> &other);
 
-  /* address */
-  inline pointer address (reference r)
-  {
-    return &r;
-  }
-  inline const_pointer address (const_reference r)
-  {
-    return &r;
-  }
+    /* address */
+    inline pointer address (reference r)
+    {
+      return &r;
+    }
+    inline const_pointer address (const_reference r)
+    {
+      return &r;
+    }
 
-  /* memory allocation */
-  inline pointer allocate (size_type count);
-  inline void deallocate (pointer p, size_type UNUSED (ingored) = 0);
+    /* memory allocation */
+    inline pointer allocate (size_type count);
+    inline void deallocate (pointer p, size_type UNUSED (ingored) = 0);
 
-  /* maximum number of allocations */
-  size_type max_size () const;
+    /* maximum number of allocations */
+    size_type max_size () const;
 
-  /* construction/destruction */
-  inline void construct (pointer p, const_reference t);
-  inline void destroy (pointer p);
+    /* construction/destruction */
+    inline void construct (pointer p, const_reference t);
+    inline void destroy (pointer p);
 
-  /* db_private_alloc accessors */
-  THREAD_ENTRY *get_thread_entry () const;
-  HL_HEAPID get_heapid () const;
+    /* db_private_alloc accessors */
+    THREAD_ENTRY *get_thread_entry () const;
+    HL_HEAPID get_heapid () const;
 
-private:
+  private:
 
-  THREAD_ENTRY *m_thread_p;
-  HL_HEAPID m_heapid;
+    THREAD_ENTRY *m_thread_p;
+    HL_HEAPID m_heapid;
 };
 
 /* interchangeable specializations */
@@ -125,7 +125,7 @@ bool operator!= (const db_private_allocator<T> &, const db_private_allocator<U> 
 
 template<typename T>
 inline
-db_private_allocator<T>::db_private_allocator (THREAD_ENTRY * thread_p) :
+db_private_allocator<T>::db_private_allocator (THREAD_ENTRY *thread_p) :
   m_thread_p (thread_p)
 {
 #if defined (SERVER_MODE)
@@ -145,7 +145,7 @@ db_private_allocator<T>::db_private_allocator (THREAD_ENTRY * thread_p) :
 
 template<typename T>
 inline
-db_private_allocator<T>::db_private_allocator (const db_private_allocator & other)
+db_private_allocator<T>::db_private_allocator (const db_private_allocator &other)
 {
   m_thread_p = other.m_thread_p;
   m_heapid = other.m_heapid;
@@ -158,7 +158,7 @@ db_private_allocator<T>::db_private_allocator (const db_private_allocator & othe
 template<typename T>
 template<typename U>
 inline
-db_private_allocator<T>::db_private_allocator (const db_private_allocator<U>& other)
+db_private_allocator<T>::db_private_allocator (const db_private_allocator<U> &other)
 {
   m_thread_p = other.get_thread_entry ();
   m_heapid = other.get_heapid ();
@@ -260,3 +260,4 @@ db_private_allocator<T>::get_heapid () const
 {
   return m_heapid;
 }
+

--- a/src/base/extensible_array.hpp
+++ b/src/base/extensible_array.hpp
@@ -129,22 +129,22 @@
 template <typename T, size_t Size, typename Allocator = std::allocator<T> >
 class extensible_array
 {
-public:
-  extensible_array (Allocator & allocator);               // Constructing with allocator is required
-  ~extensible_array ();
+  public:
+    extensible_array (Allocator &allocator);                // Constructing with allocator is required
+    ~extensible_array ();
 
-  inline void append (const T* source, size_t length);    // append at the end of existing data
-  inline void copy (const T* source, size_t length);      // overwrite entire array
+    inline void append (const T *source, size_t length);    // append at the end of existing data
+    inline void copy (const T *source, size_t length);      // overwrite entire array
 
-  inline const T* get_array (void) const;                 // get array pointer
-  inline size_t get_size (void) const;                    // get current size
-  inline size_t get_memsize (void) const;                 // get current memory size
+    inline const T *get_array (void) const;                 // get array pointer
+    inline size_t get_size (void) const;                    // get current size
+    inline size_t get_memsize (void) const;                 // get current memory size
 
-private:
-  inline void reset (void);                               // reset array
+  private:
+    inline void reset (void);                               // reset array
 
-  contiguous_memory_buffer<T, Size, Allocator> m_membuf;  // memory handler
-  size_t m_size;                                          // current size
+    contiguous_memory_buffer<T, Size, Allocator> m_membuf;  // memory handler
+    size_t m_size;                                          // current size
 };
 
 /************************************************************************/
@@ -166,8 +166,8 @@ private:
  *    length: if 0, strlen (str) + 1 is used
  */
 template <size_t Size, typename Allocator = std::allocator<char> >
-inline int xarr_char_append_string (extensible_array<char, Size, Allocator>& buffer, const char *str,
-                                    size_t length = 0);
+inline int xarr_char_append_string (extensible_array<char, Size, Allocator> &buffer, const char *str,
+				    size_t length = 0);
 
 /* extensible_charbuf_append_object - append object data to extensible char buffer.
  *
@@ -184,7 +184,7 @@ inline int xarr_char_append_string (extensible_array<char, Size, Allocator>& buf
  *    to_append: object to append
  */
 template <class T, size_t Size, typename Allocator = std::allocator<char> >
-inline int xarr_char_append_object (extensible_array<char, Size, Allocator>& buffer, const T & to_append);
+inline int xarr_char_append_object (extensible_array<char, Size, Allocator> &buffer, const T &to_append);
 
 #endif /* !EXTENSIBLE_ARRAY_HPP_ */
 
@@ -196,7 +196,7 @@ inline int xarr_char_append_object (extensible_array<char, Size, Allocator>& buf
 #include <cstring>
 
 template<typename T, size_t Size, typename Allocator>
-inline extensible_array<T, Size, Allocator>::extensible_array (Allocator & allocator) :
+inline extensible_array<T, Size, Allocator>::extensible_array (Allocator &allocator) :
   m_membuf (allocator),
   m_size (0)
 {
@@ -213,10 +213,10 @@ inline extensible_array<T, Size, Allocator>::~extensible_array ()
 * legacy code. */
 template<typename T, size_t Size, typename Allocator>
 inline void
-extensible_array<T, Size, Allocator>::append (const T * source, size_t length)
+extensible_array<T, Size, Allocator>::append (const T *source, size_t length)
 {
   // make sure memory is enough
-  T* buffer_p = m_membuf.resize (m_size + length);
+  T *buffer_p = m_membuf.resize (m_size + length);
 
   // copy data at the end of the array
   std::memcpy (buffer_p + m_size, source, length * sizeof (T));
@@ -225,7 +225,7 @@ extensible_array<T, Size, Allocator>::append (const T * source, size_t length)
 
 template<typename T, size_t Size, typename Allocator>
 inline void
-extensible_array<T, Size, Allocator>::copy (const T * source, size_t length)
+extensible_array<T, Size, Allocator>::copy (const T *source, size_t length)
 {
   // copy = reset + append
   reset ();
@@ -266,7 +266,7 @@ inline void extensible_array<T, Size, Allocator>::reset (void)
 /************************************************************************/
 
 template <size_t Size, typename Allocator>
-inline int xarr_char_append_string (extensible_array<char, Size, Allocator> & buffer, const char *str, size_t length)
+inline int xarr_char_append_string (extensible_array<char, Size, Allocator> &buffer, const char *str, size_t length)
 {
   assert (str != NULL);
 
@@ -281,8 +281,9 @@ inline int xarr_char_append_string (extensible_array<char, Size, Allocator> & bu
 }
 
 template <class T, size_t Size, typename Allocator>
-inline int xarr_char_append_object (extensible_array<char, Size, Allocator> & buffer, const T & to_append)
+inline int xarr_char_append_object (extensible_array<char, Size, Allocator> &buffer, const T &to_append)
 {
   // append object data
   return buffer.append (reinterpret_cast<const char *> (&to_append), sizeof (to_append));
 }
+

--- a/src/base/lockfree_circular_queue.hpp
+++ b/src/base/lockfree_circular_queue.hpp
@@ -33,65 +33,65 @@
 namespace lockfree
 {
 
-template <class T>
-class circular_queue
-{
-  public:
+  template <class T>
+  class circular_queue
+  {
+    public:
 
-    circular_queue (size_t size);
-    ~circular_queue ();
+      circular_queue (size_t size);
+      ~circular_queue ();
 
-    // produce data. if successful, returns true, if full, returns false
-    inline bool produce (const T &element);
-    // consume data
-    inline bool consume (T &element);
-    inline bool is_empty () const;
-    inline bool is_full () const;
+      // produce data. if successful, returns true, if full, returns false
+      inline bool produce (const T &element);
+      // consume data
+      inline bool consume (T &element);
+      inline bool is_empty () const;
+      inline bool is_full () const;
 
-  private:
+    private:
 #if USE_STD_ATOMIC
-    // std::atomic
-    typedef unsigned long long cursor_type;
-    typedef std::atomic<cursor_type> atomic_cursor_type;
-    typedef std::atomic<T> atomic_data_type;
+      // std::atomic
+      typedef unsigned long long cursor_type;
+      typedef std::atomic<cursor_type> atomic_cursor_type;
+      typedef std::atomic<T> atomic_data_type;
 #else // not USE_STD_ATOMIC
-    typedef unsigned long long cursor_type;
-    typedef volatile cursor_type atomic_cursor_type;
-    typedef volatile T atomic_data_type;
+      typedef unsigned long long cursor_type;
+      typedef volatile cursor_type atomic_cursor_type;
+      typedef volatile T atomic_data_type;
 #endif // not USE_STD_ATOMIC
-    typedef atomic_cursor_type atomic_flag_type;
+      typedef atomic_cursor_type atomic_flag_type;
 
-    static const cursor_type BLOCK_FLAG;
+      static const cursor_type BLOCK_FLAG;
 
-    // block default and copy constructors
-    circular_queue ();
-    circular_queue (const circular_queue &);
+      // block default and copy constructors
+      circular_queue ();
+      circular_queue (const circular_queue &);
 
-    inline size_t next_pow2 (size_t size);
+      inline size_t next_pow2 (size_t size);
 
-    inline bool test_empty_cursors (cursor_type produce_cursor, cursor_type consume_cursor);
-    inline bool test_full_cursors (cursor_type produce_cursor, cursor_type consume_cursor);
+      inline bool test_empty_cursors (cursor_type produce_cursor, cursor_type consume_cursor);
+      inline bool test_full_cursors (cursor_type produce_cursor, cursor_type consume_cursor);
 
-    inline cursor_type load_cursor (atomic_cursor_type &cursor);
-    inline bool test_and_increment_cursor (atomic_cursor_type &cursor, cursor_type &crt_value);
+      inline cursor_type load_cursor (atomic_cursor_type &cursor);
+      inline bool test_and_increment_cursor (atomic_cursor_type &cursor, cursor_type &crt_value);
 
-    inline T load_data (size_t index);
-    inline void store_data (size_t index, const T &data);
-    inline size_t get_cursor_index (cursor_type cursor);
+      inline T load_data (size_t index);
+      inline void store_data (size_t index, const T &data);
+      inline size_t get_cursor_index (cursor_type cursor);
 
-    inline bool is_blocked (cursor_type cursor);
-    inline bool block (cursor_type cursor);
-    inline void unblock (cursor_type cursor);
+      inline bool is_blocked (cursor_type cursor);
+      inline bool block (cursor_type cursor);
+      inline void unblock (cursor_type cursor);
 
-    atomic_data_type *m_data;   // data storage. access is atomic
-    atomic_flag_type *m_blocked_cursors;  // is_blocked flag; when producing new data, there is a time window between
-    // cursor increment and until data is copied. block flag will tell when
-    // produce is completed.
-    atomic_cursor_type m_produce_cursor;  // cursor for produce position
-    atomic_cursor_type m_consume_cursor;  // cursor for consume position
-    size_t m_capacity;                    // queue capacity
-    size_t m_index_mask;                  // mask used to compute a cursor's index in queue
-};
+      atomic_data_type *m_data;   // data storage. access is atomic
+      atomic_flag_type *m_blocked_cursors;  // is_blocked flag; when producing new data, there is a time window between
+      // cursor increment and until data is copied. block flag will tell when
+      // produce is completed.
+      atomic_cursor_type m_produce_cursor;  // cursor for produce position
+      atomic_cursor_type m_consume_cursor;  // cursor for consume position
+      size_t m_capacity;                    // queue capacity
+      size_t m_index_mask;                  // mask used to compute a cursor's index in queue
+  };
 
 } // namespace lockfree
 
@@ -105,258 +105,258 @@ class circular_queue
 namespace lockfree
 {
 
-circular_queue::BLOCK_FLAG = (1 << (sizeof (BLOCK_FLAG) - 1)); // most significant bit
+  circular_queue::BLOCK_FLAG = (1 << (sizeof (BLOCK_FLAG) - 1)); // most significant bit
 
-template<class T>
-inline
-circular_queue<T>::circular_queue (size_t size) :
-  m_produce_cursor (0),
-  m_consume_cursor (0)
-{
-  m_capacity = next_pow2 (size);
-  m_index_mask = m_capacity - 1;
-  assert ((m_capacity & m_index_mask) == 0);
+  template<class T>
+  inline
+  circular_queue<T>::circular_queue (size_t size) :
+    m_produce_cursor (0),
+    m_consume_cursor (0)
+  {
+    m_capacity = next_pow2 (size);
+    m_index_mask = m_capacity - 1;
+    assert ((m_capacity & m_index_mask) == 0);
 
-  m_data = new atomic_data_type[m_capacity];
-  m_blocked_cursors = new atomic_flag_type[m_capacity];
-}
+    m_data = new atomic_data_type[m_capacity];
+    m_blocked_cursors = new atomic_flag_type[m_capacity];
+  }
 
-template<class T>
-inline
-circular_queue<T>::~circular_queue ()
-{
-  delete [] m_data;
-  delete [] m_blocked_cursors;
-}
+  template<class T>
+  inline
+  circular_queue<T>::~circular_queue ()
+  {
+    delete [] m_data;
+    delete [] m_blocked_cursors;
+  }
 
-template<class T>
-inline bool
-circular_queue<T>::produce (const T &element)
-{
-  cursor_type cc;
-  cursor_type pc;
-  bool did_block;
+  template<class T>
+  inline bool
+  circular_queue<T>::produce (const T &element)
+  {
+    cursor_type cc;
+    cursor_type pc;
+    bool did_block;
 
-  // how this works:
-  //
-  // in systems where concurrent producing is possible, we need to avoid synchronize them. in this lock-free circular
-  // queue, that translates to each thread saving its data in a data array unique slot.
-  //
-  //  current way of doing the synchronization is having a block flag for each slot in the array. when a produced wants
-  //  to push its data, it must first successfully block the slot to avoid racing others to write in the slot.
-  //
-  //  the produce algorithm is a loop where:
-  //  1. early out if queue is full.
-  //  2. get current produce cursor, then try block its slot, then try to increment cursor (compare & swap);
-  //     incrementing is executed regardless of blocking success. that's because if block fails, then someone else
-  //     blocked this slot. everyone who failed should advance to next, and incrementing cursor as fast as possible
-  //     helps.
-  //  3. if block was successful, then store data to the blocked slot and unlock for next generation.
-  //
-  //  the loop can be broken in two ways:
-  //  1. the queue is full and push fails
-  //  2. the producer successfully blocks a cursor
-  //
+    // how this works:
+    //
+    // in systems where concurrent producing is possible, we need to avoid synchronize them. in this lock-free circular
+    // queue, that translates to each thread saving its data in a data array unique slot.
+    //
+    //  current way of doing the synchronization is having a block flag for each slot in the array. when a produced wants
+    //  to push its data, it must first successfully block the slot to avoid racing others to write in the slot.
+    //
+    //  the produce algorithm is a loop where:
+    //  1. early out if queue is full.
+    //  2. get current produce cursor, then try block its slot, then try to increment cursor (compare & swap);
+    //     incrementing is executed regardless of blocking success. that's because if block fails, then someone else
+    //     blocked this slot. everyone who failed should advance to next, and incrementing cursor as fast as possible
+    //     helps.
+    //  3. if block was successful, then store data to the blocked slot and unlock for next generation.
+    //
+    //  the loop can be broken in two ways:
+    //  1. the queue is full and push fails
+    //  2. the producer successfully blocks a cursor
+    //
 
-  while (true)
-    {
-      pc = m_produce_cursor.load ();
-      cc = m_consume_cursor.load ();
+    while (true)
+      {
+	pc = m_produce_cursor.load ();
+	cc = m_consume_cursor.load ();
 
-      if (test_full_cursors (pc, cc))
-	{
-	  /* cannot produce */
-	  return false;
-	}
+	if (test_full_cursors (pc, cc))
+	  {
+	    /* cannot produce */
+	    return false;
+	  }
 
-      // first block position
-      did_block = block (pc);
-      // make sure cursor is incremented whether I blocked it or not
-      if (test_and_increment_cursor (m_produce_cursor, pc))
-	{
-	  // do nothing
-	}
-      if (did_block)
-	{
-	  /* I blocked it, it is mine. I can write my data. */
-	  store_data (idx, element);
-	  unblock (pc);
-	  return true;
-	}
-    }
-}
+	// first block position
+	did_block = block (pc);
+	// make sure cursor is incremented whether I blocked it or not
+	if (test_and_increment_cursor (m_produce_cursor, pc))
+	  {
+	    // do nothing
+	  }
+	if (did_block)
+	  {
+	    /* I blocked it, it is mine. I can write my data. */
+	    store_data (idx, element);
+	    unblock (pc);
+	    return true;
+	  }
+      }
+  }
 
-template<class T>
-inline bool circular_queue<T>::consume (T &element)
-{
-  cursor_type cc;
-  cursor_type pc;
+  template<class T>
+  inline bool circular_queue<T>::consume (T &element)
+  {
+    cursor_type cc;
+    cursor_type pc;
 
-  // how consume works:
-  //
-  // condition: every produced entry must be consumed once and only once.
-  //
-  // to make sure this condition is met and consume is possible concurrently and without locks, a consume cursor is
-  // used. the entry at a certain cursor is consumed only by the thread who successfully increments the cursor by one
-  // (using compare and swap, not atomic increment). the "consumed" entry is read before the cursor update, therefore
-  // the slot is freed for further produce operations immediately after the update.
-  //
+    // how consume works:
+    //
+    // condition: every produced entry must be consumed once and only once.
+    //
+    // to make sure this condition is met and consume is possible concurrently and without locks, a consume cursor is
+    // used. the entry at a certain cursor is consumed only by the thread who successfully increments the cursor by one
+    // (using compare and swap, not atomic increment). the "consumed" entry is read before the cursor update, therefore
+    // the slot is freed for further produce operations immediately after the update.
+    //
 
-  do
-    {
-      cc = load_cursor (m_consume_cursor);
-      pc = load_cursor (m_produce_cursor);
+    do
+      {
+	cc = load_cursor (m_consume_cursor);
+	pc = load_cursor (m_produce_cursor);
 
-      if (pc <= cc)
-	{
-	  /* empty */
-	  return false;
-	}
+	if (pc <= cc)
+	  {
+	    /* empty */
+	    return false;
+	  }
 
-      if (is_blocked (cc))
-	{
-	  // first element is not yet produced. this means we can consider the queue still empty
-	  // todo: count these cases
-	  return false;
-	}
+	if (is_blocked (cc))
+	  {
+	    // first element is not yet produced. this means we can consider the queue still empty
+	    // todo: count these cases
+	    return false;
+	  }
 
-      // copy element first. however, the consume is not actually happening until cursor is successfully incremented.
-      element = load_data (idx);
-    }
-  while (!test_and_increment_cursor (m_consume_cursor, cc));
+	// copy element first. however, the consume is not actually happening until cursor is successfully incremented.
+	element = load_data (idx);
+      }
+    while (!test_and_increment_cursor (m_consume_cursor, cc));
 
-  // consume successful
-  return true;
-}
+    // consume successful
+    return true;
+  }
 
-template<class T>
-inline bool
-circular_queue<T>::is_empty () const
-{
-  return test_empty_cursors (m_produce_cursor, m_consume_cursor);
-}
+  template<class T>
+  inline bool
+  circular_queue<T>::is_empty () const
+  {
+    return test_empty_cursors (m_produce_cursor, m_consume_cursor);
+  }
 
-template<class T>
-inline bool
-circular_queue<T>::is_full () const
-{
-  return test_full_cursors (m_produce_cursor, m_consume_cursor);
-}
+  template<class T>
+  inline bool
+  circular_queue<T>::is_full () const
+  {
+    return test_full_cursors (m_produce_cursor, m_consume_cursor);
+  }
 
-template<class T>
-inline size_t circular_queue<T>::next_pow2 (size_t size)
-{
-  size_t next_pow = 1;
-  for (; size != 0; size /= 2)
-    {
-      next_pow *= 2;
-    }
-  return next_pow;
-}
+  template<class T>
+  inline size_t circular_queue<T>::next_pow2 (size_t size)
+  {
+    size_t next_pow = 1;
+    for (; size != 0; size /= 2)
+      {
+	next_pow *= 2;
+      }
+    return next_pow;
+  }
 
-template<class T>
-inline bool circular_queue<T>::test_empty_cursors (cursor_type produce_cursor, cursor_type consume_cursor)
-{
-  return produce_cursor >= consume_cursor;
-}
+  template<class T>
+  inline bool circular_queue<T>::test_empty_cursors (cursor_type produce_cursor, cursor_type consume_cursor)
+  {
+    return produce_cursor >= consume_cursor;
+  }
 
-template<class T>
-inline bool circular_queue<T>::test_full_cursors (cursor_type produce_cursor, cursor_type consume_cursor)
-{
-  return consume_cursor + m_capacity <= produce_cursor;
-}
+  template<class T>
+  inline bool circular_queue<T>::test_full_cursors (cursor_type produce_cursor, cursor_type consume_cursor)
+  {
+    return consume_cursor + m_capacity <= produce_cursor;
+  }
 
-template<class T>
-inline cursor_type circular_queue<T>::load_cursor (atomic_cursor_type &cursor)
-{
+  template<class T>
+  inline cursor_type circular_queue<T>::load_cursor (atomic_cursor_type &cursor)
+  {
 #ifdef USE_STD_ATOMIC
-  return cursor.load ();
+    return cursor.load ();
 #else
-  ATOMIC_LOAD (&cursor);
+    ATOMIC_LOAD (&cursor);
 #endif /* */
-}
+  }
 
-template<class T>
-inline bool circular_queue<T>::test_and_increment_cursor (atomic_cursor_type &cursor, cursor_type &crt_value)
-{
+  template<class T>
+  inline bool circular_queue<T>::test_and_increment_cursor (atomic_cursor_type &cursor, cursor_type &crt_value)
+  {
 #ifdef USE_STD_ATOMIC
-  // can weak be used here?
-  return cursor.compare_exchange_strong (crt_value, crt_value + 1);
+    // can weak be used here?
+    return cursor.compare_exchange_strong (crt_value, crt_value + 1);
 #else /* not USE_STD_ATOMIC */
-  return ATOMIC_CAS (&cursor, crt_value, crt_value + 1);
+    return ATOMIC_CAS (&cursor, crt_value, crt_value + 1);
 #endif /* not USE_STD_ATOMIC */
-}
+  }
 
-template<class T>
-inline void circular_queue<T>::store_data (cursor_type cursor, const T &data)
-{
+  template<class T>
+  inline void circular_queue<T>::store_data (cursor_type cursor, const T &data)
+  {
 #ifdef USE_STD_ATOMIC
-  m_data[get_cursor_index (cursor)].store (data);
+    m_data[get_cursor_index (cursor)].store (data);
 #else /* not USE_STD_ATOMIC */
-  ATOMIC_STORE (&m_data[get_cursor_index (cursor)], data);
+    ATOMIC_STORE (&m_data[get_cursor_index (cursor)], data);
 #endif /* not USE_STD_ATOMIC */
-}
+  }
 
-template<class T>
-inline T circular_queue<T>::load_data (int index)
-{
+  template<class T>
+  inline T circular_queue<T>::load_data (int index)
+  {
 #ifdef USE_STD_ATOMIC
-  return m_data[index].load ();
+    return m_data[index].load ();
 #else /* not USE_STD_ATOMIC */
-  return ATOMIC_LOAD (&m_data[index]);
+    return ATOMIC_LOAD (&m_data[index]);
 #endif /* not USE_STD_ATOMIC */
-}
+  }
 
-template<class T>
-inline size_t circular_queue<T>::get_cursor_index (cursor_type cursor)
-{
-  return cursor & m_index_mask;
-}
+  template<class T>
+  inline size_t circular_queue<T>::get_cursor_index (cursor_type cursor)
+  {
+    return cursor & m_index_mask;
+  }
 
-template<class T>
-inline bool
-circular_queue<T>::is_blocked (cursor_type cursor)
-{
+  template<class T>
+  inline bool
+  circular_queue<T>::is_blocked (cursor_type cursor)
+  {
 #ifdef USE_STD_ATOMIC
-  cursor_type block_val = m_blocked_cursors[get_cursor_index (cursor)]->load ();
+    cursor_type block_val = m_blocked_cursors[get_cursor_index (cursor)]->load ();
 #else /* not USE_STD_ATOMIC */
-  cursor_type block_val = ATOMIC_LOAD (&m_blocked_cursors[get_cursor_index (cursor)]);
+    cursor_type block_val = ATOMIC_LOAD (&m_blocked_cursors[get_cursor_index (cursor)]);
 #endif /* not USE_STD_ATOMIC */
-  return flag<cursor_type>::is_flag_set (block_val, BLOCK_FLAG);
-}
+    return flag<cursor_type>::is_flag_set (block_val, BLOCK_FLAG);
+  }
 
-template<class T>
-inline bool
-circular_queue<T>::block (cursor_type cursor)
-{
-  cursor_type block_val = flag<cursor_type> (cursor).set (BLOCK_FLAG).get_flags ();
+  template<class T>
+  inline bool
+  circular_queue<T>::block (cursor_type cursor)
+  {
+    cursor_type block_val = flag<cursor_type> (cursor).set (BLOCK_FLAG).get_flags ();
 #ifdef USE_STD_ATOMIC
-  // can weak be used here?
-  return m_blocked_cursors[get_cursor_index (cursor)].compare_exchange_strong (cursor, block_val);
+    // can weak be used here?
+    return m_blocked_cursors[get_cursor_index (cursor)].compare_exchange_strong (cursor, block_val);
 #else /* not USE_STD_ATOMIC */
-  return ATOMIC_CAS (&m_blocked_cursors[get_cursor_index (cursor)], cursor, block_val);
+    return ATOMIC_CAS (&m_blocked_cursors[get_cursor_index (cursor)], cursor, block_val);
 #endif /* not USE_STD_ATOMIC */
-}
+  }
 
-template<class T>
-inline void circular_queue<T>::unblock (cursor_type cursor)
-{
-  atomic_flag_type &ref_blocked_cursor = m_blocked_cursors[get_cursor_index (cursor)];
+  template<class T>
+  inline void circular_queue<T>::unblock (cursor_type cursor)
+  {
+    atomic_flag_type &ref_blocked_cursor = m_blocked_cursors[get_cursor_index (cursor)];
 #ifdef USE_STD_ATOMIC
-  flag<cursor_type> blocked_cursor_value = ref_blocked_cursor.load ();
+    flag<cursor_type> blocked_cursor_value = ref_blocked_cursor.load ();
 #else /* not USE_STD_ATOMIC */
-  flag<cursor_type> blocked_cursor_value = ATOMIC_LOAD (&ref_blocked_cursor);
+    flag<cursor_type> blocked_cursor_value = ATOMIC_LOAD (&ref_blocked_cursor);
 #endif /* not USE_STD_ATOMIC */
 
-  assert (blocked_cursor_value.is_set (BLOCK_FLAG));
-  cursor_type nextgen_cursor = blocked_cursor_value.clear (BLOCK_FLAG) + m_capacity;
+    assert (blocked_cursor_value.is_set (BLOCK_FLAG));
+    cursor_type nextgen_cursor = blocked_cursor_value.clear (BLOCK_FLAG) + m_capacity;
 
 #ifdef USE_STD_ATOMIC
-  ref_blocked_cursor.store (nextgen_cursor);
+    ref_blocked_cursor.store (nextgen_cursor);
 #else /* not USE_STD_ATOMIC */
-  ATOMIC_STORE (&ref_blocked_cursor, nextgen_cursor);
+    ATOMIC_STORE (&ref_blocked_cursor, nextgen_cursor);
 #endif /* not USE_STD_ATOMIC */
-}
+  }
 
 }  // namespace lockfree
 

--- a/src/cci/cci_log.cpp
+++ b/src/cci/cci_log.cpp
@@ -74,99 +74,99 @@ class _Logger;
 
 class _LogAppender
 {
-public:
-  _LogAppender(const _LoggerContext &context);
-  virtual ~_LogAppender() {}
+  public:
+    _LogAppender (const _LoggerContext &context);
+    virtual ~_LogAppender() {}
 
-  virtual void open() = 0;
-  virtual void close() = 0;
-  virtual void write(const char *msg) = 0;
-  virtual void flush() = 0;
+    virtual void open() = 0;
+    virtual void close() = 0;
+    virtual void write (const char *msg) = 0;
+    virtual void flush() = 0;
 
-protected:
-  const _LoggerContext &context;
+  protected:
+    const _LoggerContext &context;
 };
 
 class _LogAppenderBase : public _LogAppender
 {
-public:
-  _LogAppenderBase(const _LoggerContext &context);
-  virtual ~_LogAppenderBase();
+  public:
+    _LogAppenderBase (const _LoggerContext &context);
+    virtual ~_LogAppenderBase();
 
-  virtual void open();
-  virtual void close();
-  virtual void write(const char *msg);
-  virtual void flush();
+    virtual void open();
+    virtual void close();
+    virtual void write (const char *msg);
+    virtual void flush();
 
-protected:
-  virtual void roll() = 0;
-  virtual bool isRolling() = 0;
+  protected:
+    virtual void roll() = 0;
+    virtual bool isRolling() = 0;
 
-  std::string rename(const char *newPath, const char *postfix);
-  int getLogSizeKBytes();
-  std::string getCurrDate();
-  std::string getCurrDateTime();
-  void makeLogDir();
+    std::string rename (const char *newPath, const char *postfix);
+    int getLogSizeKBytes();
+    std::string getCurrDate();
+    std::string getCurrDateTime();
+    void makeLogDir();
 
-private:
-  void checkFileIsOpen();
+  private:
+    void checkFileIsOpen();
 
-protected:
-  std::ofstream out;
-  long int nextCheckTime;
+  protected:
+    std::ofstream out;
+    long int nextCheckTime;
 };
 
 class _PostFixAppender : public _LogAppenderBase
 {
-public:
-  _PostFixAppender(const _LoggerContext &context, CCI_LOG_POSTFIX postfix);
-  virtual ~_PostFixAppender() {}
+  public:
+    _PostFixAppender (const _LoggerContext &context, CCI_LOG_POSTFIX postfix);
+    virtual ~_PostFixAppender() {}
 
-  virtual void open();
+    virtual void open();
 
-protected:
-  virtual void roll();
-  virtual bool isRolling();
+  protected:
+    virtual void roll();
+    virtual bool isRolling();
 
-private:
-  void checkFileIsOpen();
-  std::string getNewPath();
+  private:
+    void checkFileIsOpen();
+    std::string getNewPath();
 
-private:
-  CCI_LOG_POSTFIX postfix;
-  int prevDate;
+  private:
+    CCI_LOG_POSTFIX postfix;
+    int prevDate;
 };
 
 class _MaxSizeLogAppender : public _LogAppenderBase
 {
-public:
-  _MaxSizeLogAppender(const _LoggerContext &context, int maxFileSizeKBytes,
-      int maxBackupCount);
-  virtual ~_MaxSizeLogAppender() {}
+  public:
+    _MaxSizeLogAppender (const _LoggerContext &context, int maxFileSizeKBytes,
+			 int maxBackupCount);
+    virtual ~_MaxSizeLogAppender() {}
 
-protected:
-  virtual void roll();
-  virtual bool isRolling();
+  protected:
+    virtual void roll();
+    virtual bool isRolling();
 
-private:
-  int maxFileSizeKBytes;
-  int maxBackupCount;
-  int currBackupCount;
-  std::list<std::string> backupList;
+  private:
+    int maxFileSizeKBytes;
+    int maxBackupCount;
+    int currBackupCount;
+    std::list<std::string> backupList;
 };
 
 class _DailyLogAppender : public _LogAppenderBase
 {
-public:
-  _DailyLogAppender(const _LoggerContext &context);
-  virtual ~_DailyLogAppender() {}
+  public:
+    _DailyLogAppender (const _LoggerContext &context);
+    virtual ~_DailyLogAppender() {}
 
-protected:
-  virtual void roll();
-  virtual bool isRolling();
+  protected:
+    virtual void roll();
+    virtual bool isRolling();
 
-private:
-  int prevDate;
+  private:
+    int prevDate;
 };
 
 struct _LoggerContext
@@ -177,45 +177,45 @@ struct _LoggerContext
 
 class _Logger
 {
-public:
-  _Logger(const char *path);
-  virtual ~_Logger();
+  public:
+    _Logger (const char *path);
+    virtual ~_Logger();
 
-  void setLogLevel(CCI_LOG_LEVEL level);
-  void setUseDefaultPrefix(bool useDefaultPrefix);
-  void setUseDefaultNewLine(bool useDefaultNewLine);
-  void setForceFlush(bool isForceFlush);
-  void log(CCI_LOG_LEVEL level, const char *msg);
-  void changeMaxFileSizeAppender(int maxFileSizeKBytes, int maxBackupCount);
-  void changePostfixAppender(CCI_LOG_POSTFIX postfix);
+    void setLogLevel (CCI_LOG_LEVEL level);
+    void setUseDefaultPrefix (bool useDefaultPrefix);
+    void setUseDefaultNewLine (bool useDefaultNewLine);
+    void setForceFlush (bool isForceFlush);
+    void log (CCI_LOG_LEVEL level, const char *msg);
+    void changeMaxFileSizeAppender (int maxFileSizeKBytes, int maxBackupCount);
+    void changePostfixAppender (CCI_LOG_POSTFIX postfix);
 
-public:
-  const char *getPath();
-  bool isWritable(CCI_LOG_LEVEL level);
+  public:
+    const char *getPath();
+    bool isWritable (CCI_LOG_LEVEL level);
 
-private:
-  void write(const char *msg);
-  void logPrefix(CCI_LOG_LEVEL level);
+  private:
+    void write (const char *msg);
+    void logPrefix (CCI_LOG_LEVEL level);
 
-private:
-  cci::_Mutex critical;
-  _LoggerContext context;
-  _LogAppender *logAppender;
-  CCI_LOG_LEVEL level;
-  bool useDefaultPrefix;
-  bool useDefaultNewLine;
-  bool isForceFlush;
-  int unflushedBytes;
-  unsigned long nextFlushTime;
+  private:
+    cci::_Mutex critical;
+    _LoggerContext context;
+    _LogAppender *logAppender;
+    CCI_LOG_LEVEL level;
+    bool useDefaultPrefix;
+    bool useDefaultNewLine;
+    bool isForceFlush;
+    int unflushedBytes;
+    unsigned long nextFlushTime;
 };
 
-_LogAppender::_LogAppender(const _LoggerContext &context) :
-  context(context)
+_LogAppender::_LogAppender (const _LoggerContext &context) :
+  context (context)
 {
 }
 
-_LogAppenderBase::_LogAppenderBase(const _LoggerContext &context) :
-  _LogAppender(context), nextCheckTime(0)
+_LogAppenderBase::_LogAppenderBase (const _LoggerContext &context) :
+  _LogAppender (context), nextCheckTime (0)
 {
   open();
 }
@@ -234,14 +234,14 @@ void _LogAppenderBase::open()
 
   makeLogDir();
 
-  out.open(context.path.c_str(), std::fstream::out | std::fstream::app);
+  out.open (context.path.c_str(), std::fstream::out | std::fstream::app);
   if (out.fail())
     {
-      out.open(context.path.c_str(), std::fstream::out | std::fstream::app);
+      out.open (context.path.c_str(), std::fstream::out | std::fstream::app);
       if (out.fail())
-        {
-          throw LOG_ER_OPEN;
-        }
+	{
+	  throw LOG_ER_OPEN;
+	}
     }
 }
 
@@ -255,21 +255,21 @@ void _LogAppenderBase::close()
   out.close();
 }
 
-void _LogAppenderBase::write(const char *msg)
+void _LogAppenderBase::write (const char *msg)
 {
   checkFileIsOpen();
 
   try
     {
       if (!out.is_open())
-        {
-          open();
-        }
+	{
+	  open();
+	}
 
       if (this->isRolling())
-        {
-          this->roll();
-        }
+	{
+	  this->roll();
+	}
 
       out << msg;
     }
@@ -288,19 +288,19 @@ void _LogAppenderBase::flush()
   out.flush();
 }
 
-std::string _LogAppenderBase::rename(const char *newPath, const char *postfix)
+std::string _LogAppenderBase::rename (const char *newPath, const char *postfix)
 {
   std::stringstream newPathStream;
   newPathStream << newPath;
 
   close();
 
-  if (access(newPath, F_OK) == 0 && postfix != NULL)
+  if (access (newPath, F_OK) == 0 && postfix != NULL)
     {
       newPathStream << postfix;
     }
 
-  int e = std::rename(context.path.c_str(), newPathStream.str().c_str());
+  int e = std::rename (context.path.c_str(), newPathStream.str().c_str());
   if (e != 0)
     {
     }
@@ -334,10 +334,10 @@ std::string _LogAppenderBase::getCurrDate()
   char buf[16];
   time_t t = context.now.tv_sec;
 
-  localtime_r(&t, &cal);
+  localtime_r (&t, &cal);
   cal.tm_year += 1900;
   cal.tm_mon += 1;
-  snprintf(buf, 16, "%d-%02d-%02d", cal.tm_year, cal.tm_mon, cal.tm_mday);
+  snprintf (buf, 16, "%d-%02d-%02d", cal.tm_year, cal.tm_mon, cal.tm_mday);
 
   return buf;
 }
@@ -348,11 +348,11 @@ std::string _LogAppenderBase::getCurrDateTime()
   char buf[16];
   time_t t = context.now.tv_sec;
 
-  localtime_r(&t, &cal);
+  localtime_r (&t, &cal);
   cal.tm_year += 1900;
   cal.tm_mon += 1;
-  snprintf(buf, 16, "%d%02d%02d%02d%02d%02d", cal.tm_year, cal.tm_mon,
-      cal.tm_mday, cal.tm_hour, cal.tm_min, cal.tm_sec);
+  snprintf (buf, 16, "%d%02d%02d%02d%02d%02d", cal.tm_year, cal.tm_mon,
+	    cal.tm_mday, cal.tm_hour, cal.tm_min, cal.tm_sec);
 
   return buf;
 }
@@ -370,9 +370,9 @@ void _LogAppenderBase::makeLogDir()
       *p++ = *q;
       *p = '\0';
       if (*q == sep[0] || *q == sep[1])
-        {
-          mkdir(dir, 0755);
-        }
+	{
+	  mkdir (dir, 0755);
+	}
       q++;
     }
 }
@@ -383,29 +383,29 @@ void _LogAppenderBase::checkFileIsOpen()
 
   if (nextCheckTime == 0 || currentTime >= nextCheckTime)
     {
-      if (access(context.path.c_str(), F_OK) != 0)
-        {
-          if (out.is_open())
-            {
-              out.close();
-            }
+      if (access (context.path.c_str(), F_OK) != 0)
+	{
+	  if (out.is_open())
+	    {
+	      out.close();
+	    }
 
-          try
-            {
-              open();
-            }
-          catch (...)
-            {
-            }
-        }
+	  try
+	    {
+	      open();
+	    }
+	  catch (...)
+	    {
+	    }
+	}
 
       nextCheckTime = currentTime + LOG_CHECK_FILE_INTERVAL_USEC;
     }
 }
 
-_PostFixAppender::_PostFixAppender(const _LoggerContext &context,
-    CCI_LOG_POSTFIX postfix) :
-  _LogAppenderBase(context), postfix(postfix), prevDate(time(NULL) / ONE_DAY)
+_PostFixAppender::_PostFixAppender (const _LoggerContext &context,
+				    CCI_LOG_POSTFIX postfix) :
+  _LogAppenderBase (context), postfix (postfix), prevDate (time (NULL) / ONE_DAY)
 {
 }
 
@@ -419,14 +419,14 @@ void _PostFixAppender::open()
   makeLogDir();
 
   std::string newPath = getNewPath();
-  out.open(newPath.c_str(), std::fstream::out | std::fstream::app);
+  out.open (newPath.c_str(), std::fstream::out | std::fstream::app);
   if (out.fail())
     {
-      out.open(newPath.c_str(), std::fstream::out | std::fstream::app);
+      out.open (newPath.c_str(), std::fstream::out | std::fstream::app);
       if (out.fail())
-        {
-          throw LOG_ER_OPEN;
-        }
+	{
+	  throw LOG_ER_OPEN;
+	}
     }
 }
 
@@ -463,21 +463,21 @@ void _PostFixAppender::checkFileIsOpen()
   if (nextCheckTime == 0 || currentTime >= nextCheckTime)
     {
       std::string newPath = getNewPath();
-      if (access(newPath.c_str(), F_OK) != 0)
-        {
-          if (out.is_open())
-            {
-              out.close();
-            }
+      if (access (newPath.c_str(), F_OK) != 0)
+	{
+	  if (out.is_open())
+	    {
+	      out.close();
+	    }
 
-          try
-            {
-              open();
-            }
-          catch (...)
-            {
-            }
-        }
+	  try
+	    {
+	      open();
+	    }
+	  catch (...)
+	    {
+	    }
+	}
 
       nextCheckTime = currentTime + LOG_CHECK_FILE_INTERVAL_USEC;
     }
@@ -496,10 +496,10 @@ std::string _PostFixAppender::getNewPath()
   return newPath.str();
 }
 
-_MaxSizeLogAppender::_MaxSizeLogAppender(const _LoggerContext &context,
+_MaxSizeLogAppender::_MaxSizeLogAppender (const _LoggerContext &context,
     int maxFileSizeKBytes, int maxBackupCount) :
-  _LogAppenderBase(context), maxFileSizeKBytes(maxFileSizeKBytes),
-  maxBackupCount(maxBackupCount), currBackupCount(0)
+  _LogAppenderBase (context), maxFileSizeKBytes (maxFileSizeKBytes),
+  maxBackupCount (maxBackupCount), currBackupCount (0)
 {
 }
 
@@ -511,20 +511,20 @@ void _MaxSizeLogAppender::roll()
   std::stringstream postfix_stream;
   postfix_stream << "(" << currBackupCount++ << ")";
 
-  std::string newPath = rename(newPath_stream.str().c_str(),
-      postfix_stream.str().c_str());
-  backupList.push_back(newPath);
+  std::string newPath = rename (newPath_stream.str().c_str(),
+				postfix_stream.str().c_str());
+  backupList.push_back (newPath);
 
   if (backupList.size() > (size_t) maxBackupCount)
     {
       std::string remove_path = backupList.front();
       backupList.pop_front();
 
-      int e = remove(remove_path.c_str());
+      int e = remove (remove_path.c_str());
       if (e != 0)
-        {
-          perror("remove");
-        }
+	{
+	  perror ("remove");
+	}
     }
 }
 
@@ -533,8 +533,8 @@ bool _MaxSizeLogAppender::isRolling()
   return getLogSizeKBytes() > maxFileSizeKBytes;
 }
 
-_DailyLogAppender::_DailyLogAppender(const _LoggerContext &context) :
-  _LogAppenderBase(context), prevDate(time(NULL) / ONE_DAY)
+_DailyLogAppender::_DailyLogAppender (const _LoggerContext &context) :
+  _LogAppenderBase (context), prevDate (time (NULL) / ONE_DAY)
 {
 }
 
@@ -545,7 +545,7 @@ void _DailyLogAppender::roll()
   std::stringstream newPathStream;
   newPathStream << context.path << "." << getCurrDate();
 
-  rename(newPathStream.str().c_str(), NULL);
+  rename (newPathStream.str().c_str(), NULL);
 }
 
 bool _DailyLogAppender::isRolling()
@@ -554,21 +554,21 @@ bool _DailyLogAppender::isRolling()
   return prevDate < nowDay;
 }
 
-_Logger::_Logger(const char *path) :
-  logAppender(NULL), level(CCI_LOG_LEVEL_INFO), useDefaultPrefix(true),
-  useDefaultNewLine(true), isForceFlush(true), unflushedBytes(0),
-  nextFlushTime(0)
+_Logger::_Logger (const char *path) :
+  logAppender (NULL), level (CCI_LOG_LEVEL_INFO), useDefaultPrefix (true),
+  useDefaultNewLine (true), isForceFlush (true), unflushedBytes (0),
+  nextFlushTime (0)
 {
   context.path = path;
-  gettimeofday(&context.now, NULL);
+  gettimeofday (&context.now, NULL);
   nextFlushTime = context.now.tv_usec + LOG_FLUSH_USEC;
 
-  logAppender = new _DailyLogAppender(context);
+  logAppender = new _DailyLogAppender (context);
 }
 
 _Logger::~_Logger()
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
   if (logAppender != NULL)
     {
@@ -576,69 +576,69 @@ _Logger::~_Logger()
     }
 }
 
-void _Logger::setLogLevel(CCI_LOG_LEVEL level)
+void _Logger::setLogLevel (CCI_LOG_LEVEL level)
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
   this->level = level;
 }
 
-void _Logger::setUseDefaultPrefix(bool useDefaultPrefix)
+void _Logger::setUseDefaultPrefix (bool useDefaultPrefix)
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
   this->useDefaultPrefix = useDefaultPrefix;
 }
 
-void _Logger::setUseDefaultNewLine(bool useDefaultNewLine)
+void _Logger::setUseDefaultNewLine (bool useDefaultNewLine)
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
   this->useDefaultNewLine = useDefaultNewLine;
 }
 
-void _Logger::setForceFlush(bool isForceFlush)
+void _Logger::setForceFlush (bool isForceFlush)
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
   this->isForceFlush = isForceFlush;
 }
 
-void _Logger::log(CCI_LOG_LEVEL level, const char *msg)
+void _Logger::log (CCI_LOG_LEVEL level, const char *msg)
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
-  gettimeofday(&context.now, NULL);
+  gettimeofday (&context.now, NULL);
 
   if (useDefaultPrefix)
     {
-      logPrefix(level);
+      logPrefix (level);
     }
 
-  write(msg);
+  write (msg);
 
   if (useDefaultNewLine)
     {
-      write("\n");
+      write ("\n");
     }
 }
 
-void _Logger::changeMaxFileSizeAppender(int maxFileSizeKBytes, int maxBackupCount)
+void _Logger::changeMaxFileSizeAppender (int maxFileSizeKBytes, int maxBackupCount)
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
   if (this->logAppender != NULL)
     {
       delete this->logAppender;
     }
 
-  this->logAppender = new _MaxSizeLogAppender(context, maxFileSizeKBytes,
+  this->logAppender = new _MaxSizeLogAppender (context, maxFileSizeKBytes,
       maxBackupCount);
 }
 
-void _Logger::changePostfixAppender(CCI_LOG_POSTFIX postfix)
+void _Logger::changePostfixAppender (CCI_LOG_POSTFIX postfix)
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
   if (this->logAppender != NULL)
     {
@@ -647,33 +647,33 @@ void _Logger::changePostfixAppender(CCI_LOG_POSTFIX postfix)
 
   if (postfix == CCI_LOG_POSTFIX_NONE)
     {
-      this->logAppender = new _DailyLogAppender(context);
+      this->logAppender = new _DailyLogAppender (context);
     }
   else
     {
-      this->logAppender = new _PostFixAppender(context, postfix);
+      this->logAppender = new _PostFixAppender (context, postfix);
     }
 }
 
 const char *_Logger::getPath()
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
   return context.path.c_str();
 }
 
-bool _Logger::isWritable(CCI_LOG_LEVEL level)
+bool _Logger::isWritable (CCI_LOG_LEVEL level)
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
   return this->level >= level;
 }
 
-void _Logger::write(const char *msg)
+void _Logger::write (const char *msg)
 {
-  logAppender->write(msg);
+  logAppender->write (msg);
 
-  unflushedBytes += strlen(msg);
+  unflushedBytes += strlen (msg);
 
   if (isForceFlush || unflushedBytes >= LOG_FLUSH_SIZE
       || nextFlushTime >= (unsigned long) context.now.tv_usec)
@@ -684,25 +684,25 @@ void _Logger::write(const char *msg)
     }
 }
 
-void _Logger::logPrefix(CCI_LOG_LEVEL level)
+void _Logger::logPrefix (CCI_LOG_LEVEL level)
 {
   struct tm cal;
   time_t t;
 
   t = context.now.tv_sec;
 
-  localtime_r((const time_t *) &t, &cal);
+  localtime_r ((const time_t *) &t, &cal);
   cal.tm_year += 1900;
   cal.tm_mon += 1;
 
   char buf[128];
   unsigned long tid = gettid();
-  snprintf(buf, 128, "%d-%02d-%02d %02d:%02d:%02d.%03d [TID:%lu] [%5s]",
-      cal.tm_year, cal.tm_mon, cal.tm_mday, cal.tm_hour, cal.tm_min,
-      cal.tm_sec, (int)(context.now.tv_usec / 1000), tid,
-      cci_log_level_string[level]);
+  snprintf (buf, 128, "%d-%02d-%02d %02d:%02d:%02d.%03d [TID:%lu] [%5s]",
+	    cal.tm_year, cal.tm_mon, cal.tm_mday, cal.tm_hour, cal.tm_min,
+	    cal.tm_sec, (int) (context.now.tv_usec / 1000), tid,
+	    cci_log_level_string[level]);
 
-  write(buf);
+  write (buf);
 }
 
 typedef std::pair<_Logger *, int> _LoggerReference;
@@ -711,36 +711,36 @@ typedef std::map<std::string, _LoggerReference> _LoggerMap;
 
 class _LoggerManager
 {
-public:
-  _LoggerManager() {}
-  virtual ~_LoggerManager() {}
+  public:
+    _LoggerManager() {}
+    virtual ~_LoggerManager() {}
 
-  _Logger *getLogger(const char *path);
-  void removeLogger(const char *path);
-  void clearLogger();
+    _Logger *getLogger (const char *path);
+    void removeLogger (const char *path);
+    void clearLogger();
 
-private:
-  cci::_Mutex critical;
-  _LoggerMap map;
+  private:
+    cci::_Mutex critical;
+    _LoggerMap map;
 };
 
-_Logger *_LoggerManager::getLogger(const char *path)
+_Logger *_LoggerManager::getLogger (const char *path)
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
-  _LoggerMap::iterator it = map.find(path);
+  _LoggerMap::iterator it = map.find (path);
   if (it == map.end())
     {
       try
-        {
-          _Logger *logger = new _Logger(path);
-          map[path] = _LoggerReference(logger, 1);
-          return logger;
-        }
+	{
+	  _Logger *logger = new _Logger (path);
+	  map[path] = _LoggerReference (logger, 1);
+	  return logger;
+	}
       catch (...)
-        {
-          return NULL;
-        }
+	{
+	  return NULL;
+	}
     }
   else
     {
@@ -750,25 +750,25 @@ _Logger *_LoggerManager::getLogger(const char *path)
   return it->second.first;
 }
 
-void _LoggerManager::removeLogger(const char *path)
+void _LoggerManager::removeLogger (const char *path)
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
-  _LoggerMap::iterator it = map.find(path);
+  _LoggerMap::iterator it = map.find (path);
   if (it != map.end())
     {
       it->second.second--;
       if (it->second.second == 0)
-        {
-          delete it->second.first;
-          map.erase(it);
-        }
+	{
+	  delete it->second.first;
+	  map.erase (it);
+	}
     }
 }
 
 void _LoggerManager::clearLogger()
 {
-  cci::_MutexAutolock lock(&critical);
+  cci::_MutexAutolock lock (&critical);
 
   _LoggerMap::iterator it = map.begin();
   for (; it != map.end(); it++)
@@ -781,22 +781,22 @@ void _LoggerManager::clearLogger()
 
 static _LoggerManager loggerManager;
 
-Logger cci_log_add(const char *path)
+Logger cci_log_add (const char *path)
 {
-  return loggerManager.getLogger(path);
+  return loggerManager.getLogger (path);
 }
 
-Logger cci_log_get(const char *path)
+Logger cci_log_get (const char *path)
 {
-  return loggerManager.getLogger(path);
+  return loggerManager.getLogger (path);
 }
 
-void cci_log_finalize(void)
+void cci_log_finalize (void)
 {
   loggerManager.clearLogger();
 }
 
-void cci_log_writef(CCI_LOG_LEVEL level, Logger logger, const char *format, ...)
+void cci_log_writef (CCI_LOG_LEVEL level, Logger logger, const char *format, ...)
 {
   _Logger *l = (_Logger *) logger;
 
@@ -808,14 +808,14 @@ void cci_log_writef(CCI_LOG_LEVEL level, Logger logger, const char *format, ...)
   char buf[LOG_BUFFER_SIZE];
   va_list vl;
 
-  va_start(vl, format);
-  vsnprintf(buf, LOG_BUFFER_SIZE, format, vl);
-  va_end(vl);
+  va_start (vl, format);
+  vsnprintf (buf, LOG_BUFFER_SIZE, format, vl);
+  va_end (vl);
 
-  l->log(level, buf);
+  l->log (level, buf);
 }
 
-void cci_log_write(CCI_LOG_LEVEL level, Logger logger, const char *log)
+void cci_log_write (CCI_LOG_LEVEL level, Logger logger, const char *log)
 {
   _Logger *l = (_Logger *) logger;
 
@@ -824,15 +824,15 @@ void cci_log_write(CCI_LOG_LEVEL level, Logger logger, const char *log)
       return;
     }
 
-  l->log(level, (char *) log);
+  l->log (level, (char *) log);
 }
 
-void cci_log_remove(const char *path)
+void cci_log_remove (const char *path)
 {
-  loggerManager.removeLogger(path);
+  loggerManager.removeLogger (path);
 }
 
-void cci_log_set_level(Logger logger, CCI_LOG_LEVEL level)
+void cci_log_set_level (Logger logger, CCI_LOG_LEVEL level)
 {
   _Logger *l = (_Logger *) logger;
 
@@ -841,10 +841,10 @@ void cci_log_set_level(Logger logger, CCI_LOG_LEVEL level)
       return;
     }
 
-  l->setLogLevel(level);
+  l->setLogLevel (level);
 }
 
-bool cci_log_is_writable(Logger logger, CCI_LOG_LEVEL level)
+bool cci_log_is_writable (Logger logger, CCI_LOG_LEVEL level)
 {
   _Logger *l = (_Logger *) logger;
 
@@ -853,10 +853,10 @@ bool cci_log_is_writable(Logger logger, CCI_LOG_LEVEL level)
       return false;
     }
 
-  return l->isWritable(level);
+  return l->isWritable (level);
 }
 
-void cci_log_set_force_flush(Logger logger, bool force_flush)
+void cci_log_set_force_flush (Logger logger, bool force_flush)
 {
   _Logger *l = (_Logger *) logger;
 
@@ -865,10 +865,10 @@ void cci_log_set_force_flush(Logger logger, bool force_flush)
       return;
     }
 
-  l->setForceFlush(force_flush);
+  l->setForceFlush (force_flush);
 }
 
-void cci_log_use_default_newline(Logger logger, bool use_default_newline)
+void cci_log_use_default_newline (Logger logger, bool use_default_newline)
 {
   _Logger *l = (_Logger *) logger;
 
@@ -877,10 +877,10 @@ void cci_log_use_default_newline(Logger logger, bool use_default_newline)
       return;
     }
 
-  l->setUseDefaultNewLine(use_default_newline);
+  l->setUseDefaultNewLine (use_default_newline);
 }
 
-void cci_log_use_default_prefix(Logger logger, bool use_default_prefix)
+void cci_log_use_default_prefix (Logger logger, bool use_default_prefix)
 {
   _Logger *l = (_Logger *) logger;
 
@@ -889,10 +889,10 @@ void cci_log_use_default_prefix(Logger logger, bool use_default_prefix)
       return;
     }
 
-  l->setUseDefaultPrefix(use_default_prefix);
+  l->setUseDefaultPrefix (use_default_prefix);
 }
 
-void cci_log_change_max_file_size_appender(Logger logger,
+void cci_log_change_max_file_size_appender (Logger logger,
     int maxFileSizeKBytes, int maxBackupCount)
 {
   _Logger *l = (_Logger *) logger;
@@ -904,14 +904,14 @@ void cci_log_change_max_file_size_appender(Logger logger,
 
   try
     {
-      l->changeMaxFileSizeAppender(maxFileSizeKBytes, maxBackupCount);
+      l->changeMaxFileSizeAppender (maxFileSizeKBytes, maxBackupCount);
     }
   catch (...)
     {
     }
 }
 
-void cci_log_set_default_postfix(Logger logger, CCI_LOG_POSTFIX postfix)
+void cci_log_set_default_postfix (Logger logger, CCI_LOG_POSTFIX postfix)
 {
   _Logger *l = (_Logger *) logger;
 
@@ -920,5 +920,6 @@ void cci_log_set_default_postfix(Logger logger, CCI_LOG_POSTFIX postfix)
       return;
     }
 
-  l->changePostfixAppender(postfix);
+  l->changePostfixAppender (postfix);
 }
+

--- a/src/cci/cci_map.cpp
+++ b/src/cci/cci_map.cpp
@@ -90,7 +90,7 @@ map_get_next_id (Map &map, Value &currValue)
 }
 
 T_CCI_ERROR_CODE map_open_otc (T_CCI_CONN connection_id,
-                               T_CCI_CONN *mapped_conn_id)
+			       T_CCI_CONN *mapped_conn_id)
 {
   T_CCI_ERROR_CODE error;
 
@@ -115,8 +115,8 @@ T_CCI_ERROR_CODE map_open_otc (T_CCI_CONN connection_id,
 }
 
 T_CCI_ERROR_CODE map_get_otc_value (T_CCI_CONN mapped_conn_id,
-                                    T_CCI_CONN *connection_id,
-                                    bool force)
+				    T_CCI_CONN *connection_id,
+				    bool force)
 {
   T_CCI_ERROR_CODE error;
 
@@ -142,7 +142,7 @@ T_CCI_ERROR_CODE map_get_otc_value (T_CCI_CONN mapped_conn_id,
 	  T_CON_HANDLE *connection;
 
 	  error = hm_get_connection_by_resolved_id (*connection_id,
-	                                            &connection);
+		  &connection);
 	  if (error == CCI_ER_NO_ERROR)
 	    {
 	      if (connection->used)
@@ -194,7 +194,7 @@ T_CCI_ERROR_CODE map_close_otc (T_CCI_CONN mapped_conn_id)
 	    }
 	}
 
-      mapConnection.erase(it);
+      mapConnection.erase (it);
       error = CCI_ER_NO_ERROR;
     }
 
@@ -205,7 +205,7 @@ T_CCI_ERROR_CODE map_close_otc (T_CCI_CONN mapped_conn_id)
 }
 
 T_CCI_ERROR_CODE map_open_ots (T_CCI_REQ statement_id,
-                               T_CCI_REQ *mapped_stmt_id)
+			       T_CCI_REQ *mapped_stmt_id)
 {
 
   if (mapped_stmt_id == NULL)
@@ -228,8 +228,8 @@ T_CCI_ERROR_CODE map_open_ots (T_CCI_REQ statement_id,
 }
 
 T_CCI_ERROR_CODE map_get_ots_value (T_CCI_REQ mapped_stmt_id,
-                                    T_CCI_REQ *statement_id,
-                                    bool force)
+				    T_CCI_REQ *statement_id,
+				    bool force)
 {
   T_CCI_ERROR_CODE error;
 
@@ -256,7 +256,7 @@ T_CCI_ERROR_CODE map_get_ots_value (T_CCI_REQ mapped_stmt_id,
 	  T_CCI_CONN connection_id = GET_CON_ID (*statement_id);
 
 	  error = hm_get_connection_by_resolved_id (connection_id,
-	                                            &connection);
+		  &connection);
 	  if (error == CCI_ER_NO_ERROR)
 	    {
 	      if (connection->used)
@@ -289,7 +289,7 @@ T_CCI_ERROR_CODE map_close_ots (T_CCI_REQ mapped_stmt_id)
     }
   else
     {
-      mapStatement.erase(it);
+      mapStatement.erase (it);
       error = CCI_ER_NO_ERROR;
     }
 
@@ -297,3 +297,4 @@ T_CCI_ERROR_CODE map_close_ots (T_CCI_REQ mapped_stmt_id)
 
   return error;
 }
+

--- a/src/heaplayers/customheaps.cpp
+++ b/src/heaplayers/customheaps.cpp
@@ -25,7 +25,7 @@ class TheFixedHeapType :
 UINTPTR
 hl_register_fixed_heap (int chunk_size)
 {
-  TheFixedHeapType * th = new TheFixedHeapType;
+  TheFixedHeapType *th = new TheFixedHeapType;
   if (th)
     {
       th->reset (chunk_size);
@@ -37,7 +37,7 @@ hl_register_fixed_heap (int chunk_size)
 void
 hl_unregister_fixed_heap (UINTPTR heap_id)
 {
-  TheFixedHeapType * th = (TheFixedHeapType *) heap_id;
+  TheFixedHeapType *th = (TheFixedHeapType *) heap_id;
   if (th)
     {
       delete th;
@@ -48,7 +48,7 @@ hl_unregister_fixed_heap (UINTPTR heap_id)
 void *
 hl_fixed_alloc (UINTPTR heap_id, size_t sz)
 {
-  TheFixedHeapType * th = (TheFixedHeapType *) heap_id;
+  TheFixedHeapType *th = (TheFixedHeapType *) heap_id;
   if (th)
     {
       return th->malloc (sz);
@@ -57,9 +57,9 @@ hl_fixed_alloc (UINTPTR heap_id, size_t sz)
 }
 
 void
-hl_fixed_free (UINTPTR heap_id, void * ptr)
+hl_fixed_free (UINTPTR heap_id, void *ptr)
 {
-  TheFixedHeapType * th = (TheFixedHeapType *) heap_id;
+  TheFixedHeapType *th = (TheFixedHeapType *) heap_id;
   if (th)
     {
       th->free (ptr);
@@ -78,10 +78,10 @@ class TheObstackHeapType :
 UINTPTR
 hl_register_ostk_heap (int chunk_size)
 {
-  TheObstackHeapType * th = new TheObstackHeapType;
+  TheObstackHeapType *th = new TheObstackHeapType;
   if (th)
     {
-      th->reset(chunk_size);
+      th->reset (chunk_size);
       return (UINTPTR) th;
     }
   return 0;
@@ -90,7 +90,7 @@ hl_register_ostk_heap (int chunk_size)
 void
 hl_clear_ostk_heap (UINTPTR heap_id)
 {
-  TheObstackHeapType * th = (TheObstackHeapType *) heap_id;
+  TheObstackHeapType *th = (TheObstackHeapType *) heap_id;
   if (th)
     {
       th->clear();
@@ -100,7 +100,7 @@ hl_clear_ostk_heap (UINTPTR heap_id)
 void
 hl_unregister_ostk_heap (UINTPTR heap_id)
 {
-  TheObstackHeapType * th = (TheObstackHeapType *) heap_id;
+  TheObstackHeapType *th = (TheObstackHeapType *) heap_id;
   if (th)
     {
       delete th;
@@ -111,7 +111,7 @@ hl_unregister_ostk_heap (UINTPTR heap_id)
 void *
 hl_ostk_alloc (UINTPTR heap_id, size_t sz)
 {
-  TheObstackHeapType * th = (TheObstackHeapType *) heap_id;
+  TheObstackHeapType *th = (TheObstackHeapType *) heap_id;
   if (th)
     {
       return th->malloc (sz);
@@ -122,10 +122,10 @@ hl_ostk_alloc (UINTPTR heap_id, size_t sz)
 void *
 hl_ostk_realloc (UINTPTR heap_id, void *ptr, size_t sz)
 {
-  TheObstackHeapType * th = (TheObstackHeapType *) heap_id;
+  TheObstackHeapType *th = (TheObstackHeapType *) heap_id;
   if (th)
     {
-      void * new_ptr = th->malloc (sz);
+      void *new_ptr = th->malloc (sz);
       size_t old_sz = th->getSize (ptr);
 
       memcpy (new_ptr, ptr, (old_sz > sz ? sz : old_sz));
@@ -138,9 +138,9 @@ hl_ostk_realloc (UINTPTR heap_id, void *ptr, size_t sz)
 }
 
 void
-hl_ostk_free (UINTPTR heap_id, void * ptr)
+hl_ostk_free (UINTPTR heap_id, void *ptr)
 {
-  TheObstackHeapType * th = (TheObstackHeapType *) heap_id;
+  TheObstackHeapType *th = (TheObstackHeapType *) heap_id;
   if (th)
     {
       th->free (ptr);
@@ -161,7 +161,7 @@ class TheKingsleyHeapType :
 UINTPTR
 hl_register_kingsley_heap (/*int chunk_size*/)
 {
-  TheKingsleyHeapType * th = new TheKingsleyHeapType;
+  TheKingsleyHeapType *th = new TheKingsleyHeapType;
   if (th)
     {
       //th->reset(chunk_size);
@@ -185,7 +185,7 @@ hl_clear_kingsley_heap (unsigned int heap_id)
 void
 hl_unregister_kingsley_heap (UINTPTR heap_id)
 {
-  TheKingsleyHeapType * th = (TheKingsleyHeapType *) heap_id;
+  TheKingsleyHeapType *th = (TheKingsleyHeapType *) heap_id;
   if (th)
     {
       delete th;
@@ -196,7 +196,7 @@ hl_unregister_kingsley_heap (UINTPTR heap_id)
 void *
 hl_kingsley_alloc (UINTPTR heap_id, size_t sz)
 {
-  TheKingsleyHeapType * th = (TheKingsleyHeapType *) heap_id;
+  TheKingsleyHeapType *th = (TheKingsleyHeapType *) heap_id;
   if (th)
     {
       return th->malloc (sz);
@@ -207,26 +207,30 @@ hl_kingsley_alloc (UINTPTR heap_id, size_t sz)
 void *
 hl_kingsley_realloc (UINTPTR heap_id, void *ptr, size_t sz)
 {
-  TheKingsleyHeapType * th = (TheKingsleyHeapType *) heap_id;
+  TheKingsleyHeapType *th = (TheKingsleyHeapType *) heap_id;
   if (th)
     {
-      void * new_ptr = th->malloc (sz);
+      void *new_ptr = th->malloc (sz);
       size_t old_sz = th->getSize (ptr);
 
       memcpy (new_ptr, ptr, (old_sz > sz ? sz : old_sz));
 
-      if (ptr) th->free (ptr);
+      if (ptr)
+	{
+	  th->free (ptr);
+	}
       return new_ptr;
     }
   return NULL;
 }
 
 void
-hl_kingsley_free (UINTPTR heap_id, void * ptr)
+hl_kingsley_free (UINTPTR heap_id, void *ptr)
 {
-  TheKingsleyHeapType * th = (TheKingsleyHeapType *) heap_id;
+  TheKingsleyHeapType *th = (TheKingsleyHeapType *) heap_id;
   if (th)
     {
       th->free (ptr);
     }
 }
+

--- a/src/heaplayers/stats.cpp
+++ b/src/heaplayers/stats.cpp
@@ -4,7 +4,8 @@
 
 #include "timer.h"
 
-struct mallinfo {
+struct mallinfo
+{
   int arena;    /* non-mmapped space allocated from system */
   int ordblks;  /* number of free chunks */
   int smblks;   /* number of fastbin blocks */
@@ -22,7 +23,7 @@ extern "C" struct mallinfo dlmallinfo (void);
 #endif
 extern "C" void mstats (void); // for Kingsley malloc.
 extern "C" void dlmalloc_stats (void); // for Doug Lea malloc.
-extern "C" void * sbrk (long);
+extern "C" void *sbrk (long);
 extern "C" void malloc_stats (void); // for Doug Lea malloc.
 
 int masMem;// FIX ME
@@ -33,50 +34,54 @@ int maxAllocated;
 int totalRequested;
 int maxRequested;
 
-class TimeItAll {
-public:
-	TimeItAll (void) {
-		totalAllocated = 0;
-		maxAllocated = 0;
-		t.start();
-		// FIX ME
-		masMem = 0;
+class TimeItAll
+{
+  public:
+    TimeItAll (void)
+    {
+      totalAllocated = 0;
+      maxAllocated = 0;
+      t.start();
+      // FIX ME
+      masMem = 0;
 #ifdef WIN32
-		initSpace = (long) sbrk(0);
-		//initSpace = CommittedSpace();
+      initSpace = (long) sbrk (0);
+      //initSpace = CommittedSpace();
 #endif
-	}
+    }
 
-	~TimeItAll (void) {
-		t.stop();
+    ~TimeItAll (void)
+    {
+      t.stop();
 #if 0
-		struct mallinfo mi = dlmallinfo();
-		printf ("Doug Lea Memory allocated = {total} %d, {non-mmapped} %d\n", mi.usmblks, mi.arena);
+      struct mallinfo mi = dlmallinfo();
+      printf ("Doug Lea Memory allocated = {total} %d, {non-mmapped} %d\n", mi.usmblks, mi.arena);
 #endif
-		double elapsed = (double) t;
-		printf ("Time elapsed = %f\n", elapsed);
-		printf ("Max allocated = %d\n", maxAllocated);
-		printf ("Max requested = %d\n", maxRequested);
-		printf ("Frag = %lf\n", (double) maxAllocated / (double) maxRequested);
+      double elapsed = (double) t;
+      printf ("Time elapsed = %f\n", elapsed);
+      printf ("Max allocated = %d\n", maxAllocated);
+      printf ("Max requested = %d\n", maxRequested);
+      printf ("Frag = %lf\n", (double) maxAllocated / (double) maxRequested);
 #ifdef WIN32
-		printf ("init space = %ld\n",  initSpace);
-		printf ("Sbrk report: %ld\n", (long) sbrk(0));
+      printf ("init space = %ld\n",  initSpace);
+      printf ("Sbrk report: %ld\n", (long) sbrk (0));
 #if 0
-		size_t diff = (size_t) wsbrk(8);
-		cout << "diff1 = " << diff << endl;
-		diff -= initSpace - 8;
-		cout << "diff = " << diff << endl;
+      size_t diff = (size_t) wsbrk (8);
+      cout << "diff1 = " << diff << endl;
+      diff -= initSpace - 8;
+      cout << "diff = " << diff << endl;
 #endif
 #endif
-		malloc_stats();
-		fflush (stdout);
+      malloc_stats();
+      fflush (stdout);
 //		dlmalloc_stats();
-	}
-private:
-	Timer t;
+    }
+  private:
+    Timer t;
 #ifdef WIN32
-	long initSpace;
+    long initSpace;
 #endif
 };
 
 TimeItAll timer;
+

--- a/src/heaplayers/wrapper.cpp
+++ b/src/heaplayers/wrapper.cpp
@@ -3,21 +3,21 @@
 /*
 
   Heap Layers: An Extensible Memory Allocation Infrastructure
-  
+
   Copyright (C) 2000-2007 by Emery Berger
   http://www.cs.umass.edu/~emery
   emery@cs.umass.edu
-  
+
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; either version 2 of the License, or
   (at your option) any later version.
-  
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
   along with this program; if not, write to the Free Software
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
@@ -93,27 +93,28 @@
 
 /***** generic malloc functions *****/
 
-extern "C" void * MYCDECL CUSTOM_MALLOC (size_t sz)
+extern "C" void *MYCDECL CUSTOM_MALLOC (size_t sz)
 {
-  TheCustomHeapType * theCustomHeap = getCustomHeap();
-  void * ptr = theCustomHeap->malloc (sz);
+  TheCustomHeapType *theCustomHeap = getCustomHeap();
+  void *ptr = theCustomHeap->malloc (sz);
   return ptr;
 }
 
-extern "C" void * MYCDECL CUSTOM_CALLOC (size_t nelem, size_t elsize)
+extern "C" void *MYCDECL CUSTOM_CALLOC (size_t nelem, size_t elsize)
 {
   size_t n = nelem * elsize;
-  void * ptr = CUSTOM_MALLOC (n);
+  void *ptr = CUSTOM_MALLOC (n);
   // Zero out the malloc'd block.
-  if (ptr != NULL) {
-    memset (ptr, 0, n);
-  }
+  if (ptr != NULL)
+    {
+      memset (ptr, 0, n);
+    }
   return ptr;
 }
 
 
 #if !defined(_WIN32)
-extern "C" void * MYCDECL CUSTOM_MEMALIGN (size_t alignment, size_t size);
+extern "C" void *MYCDECL CUSTOM_MEMALIGN (size_t alignment, size_t size);
 
 extern "C" int posix_memalign (void **memptr, size_t alignment, size_t size)
 {
@@ -123,71 +124,82 @@ extern "C" int posix_memalign (void **memptr, size_t alignment, size_t size)
     {
       return EINVAL;
     }
-  void * ptr = CUSTOM_MEMALIGN (alignment, size);
-  if (!ptr) {
-    return ENOMEM;
-  } else {
-    *memptr = ptr;
-    return 0;
-  }
+  void *ptr = CUSTOM_MEMALIGN (alignment, size);
+  if (!ptr)
+    {
+      return ENOMEM;
+    }
+  else
+    {
+      *memptr = ptr;
+      return 0;
+    }
 }
 #endif
 
 
-extern "C" void * MYCDECL CUSTOM_MEMALIGN (size_t alignment, size_t size)
+extern "C" void *MYCDECL CUSTOM_MEMALIGN (size_t alignment, size_t size)
 {
   // NOTE: This function is deprecated.
-  if (alignment == sizeof(double)) {
-    return CUSTOM_MALLOC (size);
-  } else {
-    void * ptr = CUSTOM_MALLOC (size + 2 * alignment);
-    void * alignedPtr = (void *) (((size_t) ptr + alignment - 1) & ~(alignment - 1));
-    return alignedPtr;
-  }
+  if (alignment == sizeof (double))
+    {
+      return CUSTOM_MALLOC (size);
+    }
+  else
+    {
+      void *ptr = CUSTOM_MALLOC (size + 2 * alignment);
+      void *alignedPtr = (void *) (((size_t) ptr + alignment - 1) & ~ (alignment - 1));
+      return alignedPtr;
+    }
 }
 
-extern "C" size_t MYCDECL CUSTOM_GETSIZE (void * ptr)
+extern "C" size_t MYCDECL CUSTOM_GETSIZE (void *ptr)
 {
-  TheCustomHeapType * theCustomHeap = getCustomHeap();
-  if (ptr == NULL) {
-    return 0;
-  }
-  return theCustomHeap->getSize(ptr);
+  TheCustomHeapType *theCustomHeap = getCustomHeap();
+  if (ptr == NULL)
+    {
+      return 0;
+    }
+  return theCustomHeap->getSize (ptr);
 }
 
-extern "C" void MYCDECL CUSTOM_FREE (void * ptr)
+extern "C" void MYCDECL CUSTOM_FREE (void *ptr)
 {
-  TheCustomHeapType * theCustomHeap = getCustomHeap();
+  TheCustomHeapType *theCustomHeap = getCustomHeap();
   theCustomHeap->free (ptr);
 }
 
-extern "C" void * MYCDECL CUSTOM_REALLOC (void * ptr, size_t sz)
+extern "C" void *MYCDECL CUSTOM_REALLOC (void *ptr, size_t sz)
 {
-  if (ptr == NULL) {
-    ptr = CUSTOM_MALLOC (sz);
-    return ptr;
-  }
-  if (sz == 0) {
-    CUSTOM_FREE (ptr);
-    return NULL;
-  }
+  if (ptr == NULL)
+    {
+      ptr = CUSTOM_MALLOC (sz);
+      return ptr;
+    }
+  if (sz == 0)
+    {
+      CUSTOM_FREE (ptr);
+      return NULL;
+    }
 
   size_t objSize = CUSTOM_GETSIZE (ptr);
 
-  void * buf = CUSTOM_MALLOC ((size_t) (sz));
+  void *buf = CUSTOM_MALLOC ((size_t) (sz));
 
-  if (buf != NULL) {
-    if (objSize == CUSTOM_GETSIZE(buf)) {
-      // The objects are the same actual size.
-      // Free the new object and return the original.
-      CUSTOM_FREE (buf);
-      return ptr;
+  if (buf != NULL)
+    {
+      if (objSize == CUSTOM_GETSIZE (buf))
+	{
+	  // The objects are the same actual size.
+	  // Free the new object and return the original.
+	  CUSTOM_FREE (buf);
+	  return ptr;
+	}
+      // Copy the contents of the original object
+      // up to the size of the new block.
+      size_t minSize = (objSize < sz) ? objSize : sz;
+      memcpy (buf, ptr, minSize);
     }
-    // Copy the contents of the original object
-    // up to the size of the new block.
-    size_t minSize = (objSize < sz) ? objSize : sz;
-    memcpy (buf, ptr, minSize);
-  }
 
   // Free the old block.
   CUSTOM_FREE (ptr);
@@ -197,28 +209,32 @@ extern "C" void * MYCDECL CUSTOM_REALLOC (void * ptr, size_t sz)
 }
 
 #if defined(linux)
-extern "C" char * MYCDECL CUSTOM_PREFIX(strndup) (const char * s, size_t sz)
+extern "C" char *MYCDECL CUSTOM_PREFIX (strndup) (const char *s, size_t sz)
 {
-  char * newString = NULL;
-  if (s != NULL) {
-    size_t cappedLength = strnlen (s, sz);
-    if ((newString = (char *) CUSTOM_MALLOC(cappedLength + 1))) {
-      strncpy(newString, s, cappedLength);
-      newString[cappedLength] = '\0';
+  char *newString = NULL;
+  if (s != NULL)
+    {
+      size_t cappedLength = strnlen (s, sz);
+      if ((newString = (char *) CUSTOM_MALLOC (cappedLength + 1)))
+	{
+	  strncpy (newString, s, cappedLength);
+	  newString[cappedLength] = '\0';
+	}
     }
-  }
   return newString;
 }
 #endif
 
-extern "C" char * MYCDECL CUSTOM_PREFIX(strdup) (const char * s)
+extern "C" char *MYCDECL CUSTOM_PREFIX (strdup) (const char *s)
 {
-  char * newString = NULL;
-  if (s != NULL) {
-    if ((newString = (char *) CUSTOM_MALLOC(strlen(s) + 1))) {
-      strcpy(newString, s);
+  char *newString = NULL;
+  if (s != NULL)
+    {
+      if ((newString = (char *) CUSTOM_MALLOC (strlen (s) + 1)))
+	{
+	  strcpy (newString, s);
+	}
     }
-  }
   return newString;
 }
 
@@ -231,60 +247,70 @@ extern "C" char * MYCDECL CUSTOM_PREFIX(strdup) (const char * s)
 #endif
 
 
-typedef char * getcwdFunction (char *, size_t);
+typedef char *getcwdFunction (char *, size_t);
 
-extern "C"  char * MYCDECL CUSTOM_PREFIX(getcwd) (char * buf, size_t size)
+extern "C"  char *MYCDECL CUSTOM_PREFIX (getcwd) (char *buf, size_t size)
 {
-  static getcwdFunction * real_getcwd
+  static getcwdFunction *real_getcwd
     = (getcwdFunction *) dlsym (RTLD_NEXT, "getcwd");
-  
-  if (!buf) {
-    if (size == 0) {
-      size = PATH_MAX;
+
+  if (!buf)
+    {
+      if (size == 0)
+	{
+	  size = PATH_MAX;
+	}
+      buf = (char *) CUSTOM_PREFIX (malloc) (size);
     }
-    buf = (char *) CUSTOM_PREFIX(malloc)(size);
-  }
-  return (real_getcwd)(buf, size);
+  return (real_getcwd) (buf, size);
 }
 
 #endif
 
 
-void * operator new (size_t sz)
+void *operator new (size_t sz)
 {
-  void * ptr = CUSTOM_MALLOC (sz);
-  if (ptr == NULL) {
-    throw std::bad_alloc();
-  } else {
-    return ptr;
-  }
+  void *ptr = CUSTOM_MALLOC (sz);
+  if (ptr == NULL)
+    {
+      throw std::bad_alloc();
+    }
+  else
+    {
+      return ptr;
+    }
 }
 
-void operator delete (void * ptr)
+void operator delete (void *ptr)
 {
   CUSTOM_FREE (ptr);
 }
 
 #if !defined(__SUNPRO_CC) || __SUNPRO_CC > 0x420
-void * operator new (size_t sz, const std::nothrow_t&) throw() {
-  return CUSTOM_MALLOC(sz);
-} 
-
-void * operator new[] (size_t size) 
+void *operator new (size_t sz, const std::nothrow_t &) throw()
 {
-  void * ptr = CUSTOM_MALLOC(size);
-  if (ptr == NULL) {
-    throw std::bad_alloc();
-  } else {
-    return ptr;
-  }
+  return CUSTOM_MALLOC (sz);
 }
 
-void * operator new[] (size_t sz, const std::nothrow_t&) throw() {
-  return CUSTOM_MALLOC (sz);
-} 
+void *operator new[] (size_t size)
+{
+  void *ptr = CUSTOM_MALLOC (size);
+  if (ptr == NULL)
+    {
+      throw std::bad_alloc();
+    }
+  else
+    {
+      return ptr;
+    }
+}
 
-void operator delete[] (void * ptr)
+void *operator new[] (size_t sz, const std::nothrow_t &) throw()
+{
+  return CUSTOM_MALLOC (sz);
+}
+
+void operator delete[] (void *ptr)
 {
   CUSTOM_FREE (ptr);
 }
@@ -306,15 +332,16 @@ extern "C" int MYCDECL CUSTOM_MALLOPT (int number, int value)
 
 // NOTE: for convenience, we assume page size = 8192.
 
-extern "C" void * MYCDECL CUSTOM_VALLOC (size_t sz)
+extern "C" void *MYCDECL CUSTOM_VALLOC (size_t sz)
 {
   return CUSTOM_MEMALIGN (8192, sz);
 }
 
 
-extern "C" void * MYCDECL CUSTOM_PVALLOC (size_t sz)
+extern "C" void *MYCDECL CUSTOM_PVALLOC (size_t sz)
 {
   // Rounds up to the next pagesize and then calls valloc. Hoard
   // doesn't support aligned memory requests.
   return CUSTOM_VALLOC ((sz + 8191) & ~8191);
 }
+


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21524

introduce [astyle](http://astyle.sourceforge.net/) to format .cpp and .hpp files. Since astyle does not beautifully format .c and .h files, we will use `indent` and `astyle`.
This means we use `indent` for .c and .h and `astyle` for .cpp and .hpp.

The options for `astyle` I use is 
```sh
  ~/bin/astyle --style=gnu --mode=c --indent-namespaces --indent=spaces=2 -xT8 -xt4 --add-brackets --max-code-length=120 --align-pointer=name --indent-classes --pad-header --pad-first-paren-out "$1"
```

I will also update commit hook of http://jira.cubrid.org/browse/CBRD-20385.