### PR TITLE
[CBRD-21600] fix getopt compilation error on GCC 7.2.0

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -69,7 +69,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/error_manager.c
   ${BASE_DIR}/fault_injection.c
   ${BASE_DIR}/fixed_alloc.c
-  ${BASE_DIR}/getopt_long.c
+  ${BASE_DIR}/cubrid_getopt_long.c
   ${BASE_DIR}/ini_parser.c
   ${BASE_DIR}/intl_support.c
   ${BASE_DIR}/language_support.c

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -185,14 +185,14 @@ set(SESSION_SOURCES
   )
 
 if(UNIX)
-  list(APPEND BASE_SOURCES ${BASE_DIR}/getopt_long.c)
+  list(APPEND BASE_SOURCES ${BASE_DIR}/cubrid_getopt_long.c)
   list(APPEND BASE_SOURCES ${BASE_DIR}/variable_string.c)
   list(APPEND CONNECTION_SOURCES ${CONNECTION_DIR}/tcp.c)
   list(APPEND CONNECTION_SOURCES ${CONNECTION_DIR}/heartbeat.c)
   list(APPEND STORAGE_SOURCES ${STORAGE_DIR}/es_owfs.c)
 else(UNIX)
   list(APPEND CONNECTION_SOURCES ${CONNECTION_DIR}/wintcp.c)
-  list(APPEND BASE_SOURCES ${BASE_DIR}/getopt_long.c)
+  list(APPEND BASE_SOURCES ${BASE_DIR}/cubrid_getopt_long.c)
   list(APPEND BASE_SOURCES ${BASE_DIR}/rand.c)
 endif(UNIX)
 

--- a/include/system.h
+++ b/include/system.h
@@ -32,192 +32,188 @@
 
 #include <stdio.h>
 #ifdef HAVE_SYS_TYPES_H
-# include <sys/types.h>
+#include <sys/types.h>
 #endif
 #ifdef HAVE_SYS_STAT_H
-# include <sys/stat.h>
+#include <sys/stat.h>
 #endif
 #ifdef STDC_HEADERS
-# include <stdlib.h>
-# include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
 #else
-# ifdef HAVE_STDLIB_H
-#  include <stdlib.h>
-# endif
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
 #endif
 #ifdef HAVE_STRING_H
-# if !defined STDC_HEADERS && defined HAVE_MEMORY_H
-#  include <memory.h>
-# endif
-# include <string.h>
+#if !defined STDC_HEADERS && defined HAVE_MEMORY_H
+#include <memory.h>
+#endif
+#include <string.h>
 #endif
 #ifdef HAVE_STRINGS_H
-# include <strings.h>
+#include <strings.h>
 #endif
 #ifdef HAVE_INTTYPES_H
-# include <inttypes.h>
+#include <inttypes.h>
 #endif
 #ifdef HAVE_STDINT_H
-# include <stdint.h>
+#include <stdint.h>
 #endif
 #ifdef HAVE_UNISTD_H
-# include <unistd.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_TIME_H
-# include <sys/time.h>
+#include <sys/time.h>
 #else
-# include <time.h>
+#include <time.h>
 #endif
 #ifdef HAVE_LIMITS_H
-# include <limits.h>
+#include <limits.h>
 #endif
 #ifdef HAVE_SYS_PARAM_H
-# include <sys/param.h>
+#include <sys/param.h>
 #endif
 #ifdef HAVE_REGEX_H
-# include <regex.h>
+#include <regex.h>
 #endif
-#ifdef HAVE_GETOPT_H
-# include <getopt.h>
-#else
-# include "getopt.h"
-#endif
+#include "cubrid_getopt.h"
 #ifdef HAVE_LIBGEN_H
-# include <libgen.h>
+#include <libgen.h>
 #endif
 #ifdef HAVE_STDBOOL_H
-# include <stdbool.h>
+#include <stdbool.h>
 #else
-# ifndef HAVE__BOOL
-#  ifdef __cplusplus
+#ifndef HAVE__BOOL
+#ifdef __cplusplus
 typedef bool _Bool;
-#  else
-#   define bool char
-#  endif
-# endif
-# define false 0
-# define true 1
-# define __bool_true_false_are_defined 1
+#else
+#define bool char
+#endif
+#endif
+#define false 0
+#define true 1
+#define __bool_true_false_are_defined 1
 #endif
 
 /* need more consideration for the system which is not LP64 model */
 #if SIZEOF_VOID_P < 4
-# error "Error: sizeof(void *) < 4"
+#error "Error: sizeof(void *) < 4"
 #endif
 #if SIZEOF_INT < 4
-# error "Error: sizeo(int) < 4"
+#error "Error: sizeo(int) < 4"
 #endif
 
 #ifdef HAVE_BYTE_T
 typedef byte_t BYTE;
 #else
-# if SIZEOF_CHAR == 1
+#if SIZEOF_CHAR == 1
 typedef unsigned char BYTE;
-# else
-#  error "Error: BYTE"
-# endif
+#else
+#error "Error: BYTE"
+#endif
 #endif
 #ifdef HAVE_INT8_T
 typedef int8_t INT8;
 #else
-# if SIZEOF_CHAR == 1
+#if SIZEOF_CHAR == 1
 #if !defined(WINDOWS)
 typedef char INT8;		/* TODO: check to exist redefined macro INT8 */
 #endif
-# else
-#  error "Error: INT8"
-# endif
+#else
+#error "Error: INT8"
+#endif
 #endif
 #ifdef HAVE_INT16_T
 typedef int16_t INT16;
 #else
-# if SIZEOF_SHORT == 2
+#if SIZEOF_SHORT == 2
 typedef short INT16;
-# else
-#  error "Error: INT16"
-# endif
+#else
+#error "Error: INT16"
+#endif
 #endif
 #ifdef HAVE_INT32_T
 typedef int32_t INT32;
 #else
-# if SIZEOF_INT == 4
+#if SIZEOF_INT == 4
 typedef int INT32;
-# else
-#  error "Error: INT32"
-# endif
+#else
+#error "Error: INT32"
+#endif
 #endif
 #ifdef HAVE_INT64_T
 typedef int64_t INT64;
 #else
-# if SIZEOF_LONG == 8
+#if SIZEOF_LONG == 8
 typedef long INT64;
-# elif SIZEOF_LONG_LONG == 8
+#elif SIZEOF_LONG_LONG == 8
 typedef long long INT64;
-# else
-#  error "Error: INT64"
-# endif
+#else
+#error "Error: INT64"
+#endif
 #endif
 #ifdef HAVE_INTPTR_T
 typedef intptr_t INTPTR;
 #else
-# if SIZEOF_VOID_P == SIZEOF_INT
+#if SIZEOF_VOID_P == SIZEOF_INT
 typedef int INTPTR;
-# elif SIZEOF_VOID_P == SIZEOF_LONG
+#elif SIZEOF_VOID_P == SIZEOF_LONG
 typedef long INTPTR;
-# elif SIZEOF_VOID_P == SIZEOF_LONG_LONG
+#elif SIZEOF_VOID_P == SIZEOF_LONG_LONG
 typedef long long INTPTR;
-# else
-#  error "Error: UINTPTR"
-# endif
+#else
+#error "Error: UINTPTR"
+#endif
 #endif
 #ifdef HAVE_UINT8_T
 typedef uint8_t UINT8;
 #else
-# if SIZEOF_CHAR == 1
+#if SIZEOF_CHAR == 1
 typedef unsigned char UNINT8;
-# else
-#  error "Error: UINT18"
-# endif
+#else
+#error "Error: UINT18"
+#endif
 #endif
 #ifdef HAVE_UINT16_T
 typedef uint16_t UINT16;
 #else
-# if SIZEOF_SHORT == 2
+#if SIZEOF_SHORT == 2
 typedef unsigned short UINT16;
-# else
-#  error "Error: UINT16"
-# endif
+#else
+#error "Error: UINT16"
+#endif
 #endif
 #ifdef HAVE_UINT32_T
 typedef uint32_t UINT32;
 #else
-# if SIZEOF_INT == 4
+#if SIZEOF_INT == 4
 typedef unsigned int UINT32;
-# else
-#  error "Error: UINT32"
-# endif
+#else
+#error "Error: UINT32"
+#endif
 #endif
 #ifdef HAVE_UINT64_T
 typedef uint64_t UINT64;
 #else
-# if SIZEOF_LONG == 8
+#if SIZEOF_LONG == 8
 typedef unsigned long UINT64;
-# elif SIZEOF_LONG_LONG == 8
+#elif SIZEOF_LONG_LONG == 8
 typedef unsigned long long UINT64;
-# endif
+#endif
 #endif
 #ifdef HAVE_UINTPTR_T
 typedef uintptr_t UINTPTR;
 #else
-# if SIZEOF_VOID_P == SIZEOF_INT
+#if SIZEOF_VOID_P == SIZEOF_INT
 typedef unsigned int UINTPTR;
-# elif SIZEOF_VOID_P == SIZEOF_LONG
+#elif SIZEOF_VOID_P == SIZEOF_LONG
 typedef unsigned long UINTPTR;
-# elif SIZEOF_VOID_P == SIZEOF_LONG_LONG
+#elif SIZEOF_VOID_P == SIZEOF_LONG_LONG
 typedef unsigned long long UINTPTR;
-# else
-#  error "Error: UINTPTR"
-# endif
+#else
+#error "Error: UINTPTR"
+#endif
 #endif
 
 #if defined(WINDOWS)
@@ -274,7 +270,7 @@ typedef UINTPTR QUERY_ID;
 #endif
 
 #if defined(_POWER)
-# define __powerpc__
+#define __powerpc__
 #endif
 
 #endif /* _SYSTEM_H_ */

--- a/include/system.h
+++ b/include/system.h
@@ -77,7 +77,6 @@
 #ifdef HAVE_REGEX_H
 #include <regex.h>
 #endif
-#include "cubrid_getopt.h"
 #ifdef HAVE_LIBGEN_H
 #include <libgen.h>
 #endif

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -16,7 +16,7 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
 
-message(WARNING "Flex loader outputs: ${FLEX_loader_lexer_OUTPUTS}")
+message(STATUS "Flex loader outputs: ${FLEX_loader_lexer_OUTPUTS}")
 
 set(EXECUTABLE_SOURCES
   ${BISON_loader_grammar_OUTPUTS}
@@ -95,7 +95,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/environment_variable.c
   ${BASE_DIR}/misc_string.c
   ${BASE_DIR}/variable_string.c
-  ${BASE_DIR}/getopt_long.c
+  ${BASE_DIR}/cubrid_getopt_long.c
   ${BASE_DIR}/binaryheap.c
   ${BASE_DIR}/tsc_timer.c
   ${BASE_DIR}/perf.c

--- a/src/base/cubrid_getopt.h
+++ b/src/base/cubrid_getopt.h
@@ -85,6 +85,6 @@ extern "C"
 #endif
 #endif
 
-#endif				/* !_CUBRID_GETOPT_H_ */
-
 typedef struct option GETOPT_LONG;
+
+#endif /* !_CUBRID_GETOPT_H_ */

--- a/src/base/cubrid_getopt.h
+++ b/src/base/cubrid_getopt.h
@@ -33,7 +33,8 @@
 #include "config.h"
 
 #ifdef HAVE_GETOPT_H
-#include <getopt.h>
+#include <getopt.h>		/* for getopt_long */
+#include <unistd.h>		/* for getopt */
 #else
 #if !defined(WINDOWS)
 #include <sys/cdefs.h>

--- a/src/base/cubrid_getopt.h
+++ b/src/base/cubrid_getopt.h
@@ -27,9 +27,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ___GETOPT_H___
-#define ___GETOPT_H___
+#ifndef _CUBRID_GETOPT_H_
+#define _CUBRID_GETOPT_H_
 
+#include "config.h"
+
+#ifdef HAVE_GETOPT_H
+#include <getopt.h>
+#else
 #if !defined(WINDOWS)
 #include <sys/cdefs.h>
 #define DllImport
@@ -48,7 +53,7 @@ struct option
 {
   /* name of long option */
   const char *name;
-  /* 
+  /*
    * one of no_argument, required_argument, and optional_argument:
    * whether option takes an argument
    */
@@ -77,5 +82,8 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+#endif
 
-#endif				/* !_GETOPT_H_ */
+#endif				/* !_CUBRID_GETOPT_H_ */
+
+typedef struct option GETOPT_LONG;

--- a/src/base/cubrid_getopt_long.c
+++ b/src/base/cubrid_getopt_long.c
@@ -36,7 +36,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "getopt.h"
+#include "cubrid_getopt.h"
 
 #define REPLACE_GETOPT
 
@@ -169,7 +169,7 @@ permute_args (int nonopt_start, int nonopt_end, int opt_end, char *const *nargv)
  *  Returns -2 if -- is found (can be long option or end of options marker).
  */
 static int
-getopt_internal (int nargc, char *const * nargv, const char *options)
+getopt_internal (int nargc, char *const *nargv, const char *options)
 {
   char *oli;			/* option letter list index */
   int optchar;
@@ -254,7 +254,7 @@ start:
 	  return -2;
 	}
     }
-  if ((optchar = (int) *place++) == (int) ':' || (oli = (char*) strchr (options + (IGNORE_FIRST ? 1 : 0), optchar))
+  if ((optchar = (int) *place++) == (int) ':' || (oli = (char *) strchr (options + (IGNORE_FIRST ? 1 : 0), optchar))
       == NULL)
     {
       /* option letter unknown or ':' */
@@ -358,7 +358,7 @@ getopt (int nargc, char *const *nargv, const char *options)
  *	Parse argc/argv argument vector.
  */
 int
-getopt_long (int nargc, char *const * nargv, const char *options, const struct option *long_options, int *idx)
+getopt_long (int nargc, char *const *nargv, const char *options, const struct option *long_options, int *idx)
 {
   int retval;
 

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -44,7 +44,6 @@
 #include <process.h>
 #include <io.h>
 #else /* WINDOWS */
-#include <unistd.h>
 #include <sys/time.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -73,6 +72,7 @@
 #include "cas_sql_log2.h"
 #include "broker_acl.h"
 #include "chartype.h"
+#include "cubrid_getopt.h"
 
 #if !defined(CAS_FOR_ORACLE) && !defined(CAS_FOR_MYSQL)
 #include "dbdef.h"

--- a/src/broker/broker_log_converter.c
+++ b/src/broker/broker_log_converter.c
@@ -30,12 +30,8 @@
 #if !defined(WINDOWS)
 #include <unistd.h>
 #endif
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#else
-#include "getopt.h"
-#endif
 
+#include "cubrid_getopt.h"
 #include "cas_common.h"
 #include "cas_cci.h"
 #include "broker_log_util.h"

--- a/src/broker/broker_log_replay.c
+++ b/src/broker/broker_log_replay.c
@@ -32,13 +32,9 @@
 #else /* WINDOWS */
 #include <unistd.h>
 #endif /* !WINDOWS */
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#else
-#include "getopt.h"
-#endif
 #include <assert.h>
 
+#include "cubrid_getopt.h"
 #include "cas_common.h"
 #include "cas_cci.h"
 #include "broker_log_util.h"

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -32,16 +32,12 @@
 #if !defined(WINDOWS)
 #include <unistd.h>
 #endif
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#else
-#include "getopt.h"
-#endif
 
 #ifdef MT_MODE
 #include <pthread.h>
 #endif
 
+#include "cubrid_getopt.h"
 #include "cas_common.h"
 #include "cas_query_info.h"
 #include "broker_log_time.h"

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -29,8 +29,6 @@
 #include <inttypes.h>
 #endif
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
@@ -38,11 +36,6 @@
 #include <string.h>
 #include <stdarg.h>
 #include <assert.h>
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#else
-#include "getopt.h"
-#endif
 
 #if defined(WINDOWS)
 #include <winsock2.h>
@@ -65,6 +58,7 @@
 #include <sys/time.h>
 #endif
 
+#include "cubrid_getopt.h"
 #include "porting.h"
 #include "cas_common.h"
 #include "broker_config.h"
@@ -96,7 +90,7 @@
 #define         UNUSABLE_DATABASES_FLAG_MASK 0x20
 
 #if defined(WINDOWS) && !defined(PRId64)
-# define PRId64 "lld"
+#define PRId64 "lld"
 #endif
 
 typedef enum

--- a/src/broker/broker_tester.c
+++ b/src/broker/broker_tester.c
@@ -45,7 +45,7 @@
 #include "broker_filename.h"
 #include "cas_protocol.h"
 #include "cas_common.h"
-
+#include "cubrid_getopt.h"
 #include "cas_cci.h"
 
 #if defined(WINDOWS)

--- a/src/broker/cas_runner.c
+++ b/src/broker/cas_runner.c
@@ -39,12 +39,8 @@
 #include <pthread.h>
 #include <unistd.h>
 #endif
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#else
-#include "getopt.h"
-#endif
 
+#include "cubrid_getopt.h"
 #include "cas_common.h"
 #include "porting.h"
 #include "cas_cci.h"

--- a/src/executables/commdb.c
+++ b/src/executables/commdb.c
@@ -23,18 +23,11 @@
 
 #ident "$Id$"
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>
 #include <assert.h>
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#else
-#include "getopt.h"
-#endif
 
 #if defined(WINDOWS)
 #include <winsock2.h>
@@ -61,6 +54,7 @@
 #include "utility.h"
 #include "util_support.h"
 #include "porting.h"
+#include "cubrid_getopt.h"
 
 #define COMMDB_CMD_ALLOWED_ON_REMOTE() \
   ((commdb_Arg_deact_stop_all == true) \

--- a/src/executables/csql.h
+++ b/src/executables/csql.h
@@ -27,8 +27,6 @@
 
 #ident "$Id$"
 
-#include "config.h"
-
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -23,15 +23,8 @@
 
 #ident "$Id$"
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdarg.h>
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#else
-#include "getopt.h"
-#endif
 
 #include "csql.h"
 #include "message_catalog.h"
@@ -39,6 +32,7 @@
 #include "intl_support.h"
 #include "utility.h"
 #include "util_support.h"
+#include "cubrid_getopt.h"
 
 typedef const char *(*CSQL_GET_MESSAGE) (int message_index);
 typedef int (*CSQL) (const char *argv0, CSQL_ARGUMENT * csql_arg);

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include "config.h"
 #ifdef HAVE_GETOPT_H
 #include <getopt.h>
 #else

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -23,9 +23,10 @@
 
 #ident "$Id$"
 
+#include "config.h"
+
 #include <stdio.h>
 #include <stdarg.h>
-#include "config.h"
 #ifdef HAVE_GETOPT_H
 #include <getopt.h>
 #else

--- a/src/executables/esql_grammar.y
+++ b/src/executables/esql_grammar.y
@@ -299,12 +299,7 @@ extern int esql_yylineno;
 #include <fcntl.h>
 #include <errno.h>
 
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#else
-#include "getopt.h"
-#endif
-
+#include "cubrid_getopt.h"
 #include "language_support.h"
 #include "message_catalog.h"
 #include "variable_string.h"

--- a/src/executables/gencat.c
+++ b/src/executables/gencat.c
@@ -98,11 +98,6 @@ up-to-date.  Many thanks.
 #if !defined(WINDOWS)
 #include <unistd.h>
 #endif
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#else
-#include "getopt.h"
-#endif
 
 #if defined(WINDOWS)
 #include <io.h>
@@ -117,6 +112,7 @@ typedef int int32_t;
 #endif /* WINDOWS */
 
 #include "porting.h"
+#include "cubrid_getopt.h"
 
 #ifndef NL_SETMAX
 #define NL_SETMAX 255

--- a/src/executables/loadjava.c
+++ b/src/executables/loadjava.c
@@ -30,12 +30,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
-#ifdef HAVA_GETOPT_H
-#include <getopt.h>
-#else
-#include "getopt.h"
-#endif
 
+#include "cubrid_getopt.h"
 #include "error_code.h"
 #include "message_catalog.h"
 #include "utility.h"

--- a/src/executables/util_admin.c
+++ b/src/executables/util_admin.c
@@ -25,12 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "config.h"
-#ifdef HAVE_GETOPT_H
-#include <getopt.h>
-#else
-#include "getopt.h"
-#endif
+#include "cubrid_getopt.h"
 #include "utility.h"
 #include "error_code.h"
 #include "util_support.h"

--- a/src/executables/util_support.c
+++ b/src/executables/util_support.c
@@ -23,16 +23,14 @@
 
 #ident "$Id$"
 
-#include "config.h"
-
 #include <stdio.h>
 #include <string.h>
-#include <getopt.h>
 #include <errno.h>
 #if !defined(WINDOWS)
-#include <unistd.h>
 #include <dlfcn.h>
 #endif
+
+#include "cubrid_getopt.h"
 #include "error_code.h"
 #include "util_support.h"
 #include "utility.h"

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -26,8 +26,10 @@
 #ifndef _UTILITY_H_
 #define _UTILITY_H_
 
-#include <config.h>
 #include <stdio.h>
+
+#include "config.h"
+#include "cubrid_getopt.h"
 #include "util_func.h"
 #include "dynamic_array.h"
 
@@ -752,8 +754,6 @@ typedef enum
   ARG_BOOLEAN,
   ARG_BIGINT
 } UTIL_ARG_TYPE;
-
-typedef struct option GETOPT_LONG;
 
 typedef struct
 {

--- a/src/tools/cci_applier.c
+++ b/src/tools/cci_applier.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
-#include <unistd.h>
 #include <stdbool.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -10,7 +9,8 @@
 #include <ctype.h>
 #include <assert.h>
 #include <libgen.h>
-#include <getopt.h>
+
+#include "cubrid_getopt.h"
 #include "cas_cci.h"
 #include "cci_applier.h"
 #include "log_applier.h"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -19,7 +19,7 @@
 if(UNIX)
   set(CCI_APPLIER_SOURCES
     ${TOOLS_DIR}/cci_applier.c
-    ${BASE_DIR}/getopt_long.c
+    ${BASE_DIR}/cubrid_getopt_long.c
     )
   SET_SOURCE_FILES_PROPERTIES(
     ${CCI_APPLIER_SOURCES}

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -44,7 +44,7 @@ set(CSQL_SOURCES
   ${EXECUTABLES_DIR}/csql_launcher.c
   ${EXECUTABLES_DIR}/util_support.c
   ${BASE_DIR}/porting.c
-  ${BASE_DIR}/getopt_long.c
+  ${BASE_DIR}/cubrid_getopt_long.c
   )
 
 SET_SOURCE_FILES_PROPERTIES(
@@ -127,9 +127,9 @@ SET_SOURCE_FILES_PROPERTIES(
   PROPERTIES LANGUAGE CXX
   )
 if(WIN32)
-  list(APPEND CUBRID_SOURCES ${BASE_DIR}/getopt_long.c)
+  list(APPEND CUBRID_SOURCES ${BASE_DIR}/cubrid_getopt_long.c)
   SET_SOURCE_FILES_PROPERTIES(
-    ${BASE_DIR}/getopt_long.c
+    ${BASE_DIR}/cubrid_getopt_long.c
     PROPERTIES LANGUAGE CXX
   )
   list(APPEND CUBRID_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
@@ -202,7 +202,7 @@ endif(UNIX)
 set(CUB_ADMIN_SOURCES
   ${EXECUTABLES_DIR}/util_admin.c
   ${EXECUTABLES_DIR}/util_support.c
-  ${BASE_DIR}/getopt_long.c
+  ${BASE_DIR}/cubrid_getopt_long.c
   ${BASE_DIR}/porting.c
   )
   
@@ -271,7 +271,7 @@ set(GENCAT_SOURCES
   ${EXECUTABLES_DIR}/gencat.c
   )
 if(WIN32)
-  list(APPEND GENCAT_SOURCES ${BASE_DIR}/getopt_long.c)
+  list(APPEND GENCAT_SOURCES ${BASE_DIR}/cubrid_getopt_long.c)
   list(APPEND GENCAT_SOURCES ${CMAKE_BINARY_DIR}/version.rc)
 endif(WIN32)
 add_executable(gencat ${GENCAT_SOURCES})


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21600

getopt compilation error on GCC 7.2.0:
```
Building CXX object util/CMakeFiles/csql.dir/__/src/executables/csql_launcher.c.o
In file included from /usr/include/bits/getopt_posix.h:27:0,
                 from /usr/include/unistd.h:872,
                 from /home/valeri/cubrid/include/system.h:64,
                 from /home/valeri/cubrid/build_x86_64_debug/config.h:94,
                 from /home/valeri/cubrid/src/executables/csql.h:30,
                 from /home/valeri/cubrid/src/executables/csql_launcher.c:34:
/usr/include/bits/getopt_core.h:91:12: error: declaration of ‘int getopt(int, char const, const char*) throw ()’ has a different exception specifier
 extern int getopt (int ___argc, char const ___argv, const char *__shortopts)
            ^~~~~~
In file included from /home/valeri/cubrid/src/executables/csql_launcher.c:31:0:
/home/valeri/cubrid/src/base/getopt.h:67:7: note: from previous declaration ‘int getopt(int, char const, const char*)’
   int getopt (int, char const , const char *);
       ^~~~~~
```