### PR TITLE
[CBRD-21617] vacuum_heap_page: fix interrupted case

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1194,21 +1194,6 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	  pgbuf_unfix_and_init (thread_p, helper.home_page);
 	  return NO_ERROR;
 	}
-      /* page still could be reused as new heap page in same file. in this case the slot may be invalid or it may hold
-       * another record (but that won't bother us, because we always check the record header).
-       * stop if slot no longer exists. */
-      if (spage_number_of_slots (helper.home_page) <= heap_objects[0].oid.slotid)
-	{
-	  /* slot does not exist */
-	  /* Safe guard: this was possible if there was only one object to be vacuumed. */
-	  assert (n_heap_objects == 1);
-
-	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP, "Heap page %d|%d was deallocated during previous run and reused as"
-				 " new heap page\n", VPID_AS_ARGS (&helper.home_vpid));
-
-	  pgbuf_unfix_and_init (thread_p, helper.home_page);
-	  return NO_ERROR;
-	}
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21617

Fixed code that tries to handle interrupted vacuum jobs and deallocated heap pages. One of the cases it used to consider a heap page was deallocated is when the number of slots is less that what it expected.

However, that is not always true. Another possible case is undoing a series of inserts. The number of slots are incremented while inserting (and vacuum is logged for each insert), but on rollback the number of slots are decremented (this doesn't always happen, only when the deleted slot happens to be last).

The crash was caused by a safe-guard that was supposed to be true in case page was really deleted. Since the page was not deleted, the safe-guard failed.

Heap pages are no longer assumed deleted and usual checks are executed on each record.