### PR TITLE
[CBRD-21522] Fix Json Regression

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -316,6 +316,8 @@ if(AT_LEAST_ONE_UNIT_TEST)
     ${EP_INCLUDES}
     )
 
+  add_dependencies(cubrid-win-lib ${EP_TARGETS})
+
   endif (WIN32)
 endif (AT_LEAST_ONE_UNIT_TEST)
 


### PR DESCRIPTION
Add dependency between cubrid-win-lib and external targets in cubrid/CMakeLists.txt to fix build failure regression