### PR TITLE
[CBRD-21636] deletedb which follows a crash of copydb crashes

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1298,7 +1298,7 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
     {
       if (init_emergency == true && log_Gl.hdr.is_shutdown == false)
 	{
-	  if (LSA_GT (&log_Gl.hdr.append_lsa, &log_Gl.hdr.eof_lsa))
+	  if (!LSA_ISNULL (&log_Gl.hdr.eof_lsa) && LSA_GT (&log_Gl.hdr.append_lsa, &log_Gl.hdr.eof_lsa))
 	    {
 	      /* We cannot believe in append_lsa for this case. It points to an unflushed log page. Since we are
 	       * going to skip recovery for emergency startup, just replace it with eof_lsa. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21636

copydb resets append_lsa as (0,0) and eof_lsa as (-1, -1).
When deletedb tries to mount a database that was not shutdown (e.g, a crash), it reset append_lsa as null_lsa.
Fix never allows to reset it as null_lsa.

It is a legacy issue with small probability of reproduction.