### PR TITLE
[CBRD-21629] Fix ctltool broken compilation

### DIFF
--- a/src/compat/dbi_compat.h
+++ b/src/compat/dbi_compat.h
@@ -28,6 +28,10 @@
 #ifndef _DBI_COMPAT_H_
 #define _DBI_COMPAT_H_
 
+#ifndef __cplusplus
+#define bool char
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {


### PR DESCRIPTION
I re-added #define bool char in dbi_compat.h only for C compiler