### PR TITLE
[CBRD-21634] Fix log_Gl.hdr.vacuum_last_blockid

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -67,6 +67,7 @@
 #include "system_parameter.h"
 #include "xserver_interface.h"
 #include "heap_file.h"
+#include "vacuum.h"
 #include "xasl_cache.h"
 
 #if defined (SERVER_MODE)

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -70,6 +70,7 @@
 #include "xserver_interface.h"
 #include "server_support.h"
 #include "utility.h"
+#include "vacuum.h"
 #if !defined(WINDOWS)
 #include "heartbeat.h"
 #endif

--- a/src/query/filter_pred_cache.c
+++ b/src/query/filter_pred_cache.c
@@ -27,6 +27,7 @@
 #include "lock_free.h"
 #include "query_executor.h"
 #include "stream_to_xasl.h"
+#include "system_parameter.h"
 
 typedef struct fpcache_ent FPCACHE_ENTRY;
 struct fpcache_ent

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4080,7 +4080,7 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
 	  /* No recovery needed. This is used for 10.1 version to keep the functionality of the database.
 	   * In this case, we are updating the last_blockid of the vacuum to the last block that was logged.
 	   */
-	  vacuum_Data.last_blockid = vacuum_get_log_blockid (log_Gl.append.prev_lsa.pageid) - 1;
+	  vacuum_Data.last_blockid = logpb_last_complete_blockid ();
 	}
       else
 	{

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -73,9 +73,6 @@
     _er_log_debug (ARG_FILE_LINE, "VACUUM WARNING " LOG_THREAD_TRAN_MSG ": " msg "\n", \
                    LOG_THREAD_TRAN_ARGS (thread_get_thread_entry_info ()), __VA_ARGS__)
 
-typedef INT64 VACUUM_LOG_BLOCKID;
-#define VACUUM_NULL_LOG_BLOCKID -1
-
 #define VACUUM_LOG_ADD_DROPPED_FILE_POSTPONE true
 #define VACUUM_LOG_ADD_DROPPED_FILE_UNDO false
 

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -46,6 +46,7 @@
 #include "db_date.h"
 #include "bit.h"
 #include "fault_injection.h"
+#include "vacuum.h"
 
 #if defined (SA_MODE)
 #include "transaction_cl.h"	/* for interrupt */

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -82,6 +82,9 @@
 #include "release_string.h"
 #include "log_impl.h"
 #include "fault_injection.h"
+#if defined (SERVER_MODE)
+#include "vacuum.h"
+#endif /* SERVER_MODE */
 
 #if defined(WINDOWS)
 #include "wintcp.h"

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -51,6 +51,7 @@
 #include "heap_file.h"
 #include "bit.h"
 #include "util_func.h"
+#include "vacuum.h"
 
 #include "critical_section.h"
 #if defined(SERVER_MODE)

--- a/src/transaction/log_comm.c
+++ b/src/transaction/log_comm.c
@@ -40,6 +40,9 @@
 #include "misc_string.h"
 #include "intl_support.h"
 #include "log_impl.h"
+#if defined (SERVER_MODE)
+#include "vacuum.h"
+#endif /* SERVER_MODE */
 #if !defined(WINDOWS)
 #if defined(CS_MODE)
 #include "db.h"

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -2387,7 +2387,7 @@ extern bool logtb_check_class_for_rr_isolation_err (const OID * class_oid);
 
 extern void logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr);
 
-extern void logpb_update_last_blockid (THREAD_ENTRY * thread_p, LOG_PAGEID page_id);
+extern VACUUM_LOG_BLOCKID logpb_last_complete_blockid (void);
 
 /************************************************************************/
 /* Inline functions:                                                    */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -48,7 +48,6 @@
 #include "critical_section.h"
 #include "thread.h"
 #include "lock_manager.h"
-#include "vacuum.h"
 #endif /* defined (SERVER_MODE) || defined (SA_MODE) */
 
 #if defined(SOLARIS)
@@ -156,6 +155,10 @@ struct log_hdr_bkup_level_info
 #define MAX_NTRANS \
   (NUM_NON_SYSTEM_TRANS + NUM_SYSTEM_TRANS)
 
+// vacuum blocks
+typedef INT64 VACUUM_LOG_BLOCKID;
+#define VACUUM_NULL_LOG_BLOCKID -1
+
 /*
  * LOG HEADER INFORMATION
  */
@@ -194,7 +197,7 @@ struct log_header
   LOG_LSA bkup_level2_lsa;	/* Lsa of backup level 2 */
   char prefix_name[MAXLOGNAME];	/* Log prefix name */
   bool has_logging_been_skipped;	/* Has logging been skipped ? */
-  INT64 vacuum_last_blockid;	/* Last processed blockid needed for vacuum. */
+  VACUUM_LOG_BLOCKID vacuum_last_blockid;	/* Last processed blockid needed for vacuum. */
   int perm_status;		/* Reserved for future expansion and permanent status indicators, e.g. to mark
 				 * RESTORE_IN_PROGRESS */
   LOG_HDR_BKUP_LEVEL_INFO bkinfo[FILEIO_BACKUP_UNDEFINED_LEVEL];

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6915,9 +6915,7 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	  log_Gl.hdr.last_deleted_arv_num = last_arv_num_to_delete;
 
 	  /* Update the last_blockid needed for vacuum. Get the first page_id of the previously logged archive */
-	  new_page_id = log_Gl.append.prev_lsa.pageid;
-	  logpb_update_last_blockid (thread_p, new_page_id);
-
+	  log_Gl.hdr.vacuum_last_blockid = logpb_last_complete_blockid ();
 	  logpb_flush_header (thread_p);	/* to get rid of archives */
 	}
 
@@ -12117,18 +12115,15 @@ logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HEADER * loghd
 }
 
 /*
- * logpb_update_last_blockid () - Updates the last_blockid needed later for vacuum.
- * 
- * return :- void
+ * logpb_last_complete_blockid () - get blockid of last completely logged block
  *
- * thread_p (in) :- Thread context.
- * page_id (in)  :- The first page id of the block that must updated to.
+ * return    : blockid
  */
-void
-logpb_update_last_blockid (THREAD_ENTRY * thread_p, LOG_PAGEID page_id)
+VACUUM_LOG_BLOCKID
+logpb_last_complete_blockid (void)
 {
-  VACUUM_LOG_BLOCKID last_blockid;
-
-  last_blockid = vacuum_get_log_blockid (page_id);
-  log_Gl.hdr.vacuum_last_blockid = last_blockid;
+  LOG_PAGEID prev_pageid = log_Gl.append.prev_lsa.pageid;
+  VACUUM_LOG_BLOCKID blockid = vacuum_get_log_blockid (prev_pageid);
+  /* the previous block is the one completed */
+  return blockid - 1;
 }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6915,8 +6915,10 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	{
 	  log_Gl.hdr.last_deleted_arv_num = last_arv_num_to_delete;
 
+#if defined (SA_MODE)
 	  /* Update the last_blockid needed for vacuum. Get the first page_id of the previously logged archive */
 	  log_Gl.hdr.vacuum_last_blockid = logpb_last_complete_blockid ();
+#endif /* SA_MODE */
 	  logpb_flush_header (thread_p);	/* to get rid of archives */
 	}
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -94,6 +94,7 @@
 #include "event_log.h"
 #include "thread.h"
 #include "tsc_timer.h"
+#include "vacuum.h"
 
 #if !defined(SERVER_MODE)
 #define pthread_mutex_init(a, b)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21634

Fix setting log_Gl.hdr.vacuum_last_blockid to last completely logged block.