### PR TITLE
[CBRD-21630] Fix compile from previous patch

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2429,7 +2429,7 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
   return vol_fd;
 }
 
-#if defined (SERVER_MODE)
+#if !defined (CS_MODE)
 /*
  * fileio_expand_to () -  Expand a volume to the given number of pages.
  *
@@ -2477,11 +2477,11 @@ fileio_expand_to (THREAD_ENTRY * thread_p, VOLID vol_id, DKNPAGES size_npages, D
   size_t new_size;
   size_t desired_extend_size;
   size_t max_extend_size;
-#if defined(WINDOWS)
+#if defined(WINDOWS) && defined(SERVER_MODE)
   int rv;
   pthread_mutex_t *io_mutex;
   static pthread_mutex_t io_mutex_instance = PTHREAD_MUTEX_INITIALIZER;
-#endif /* WINDOWS */
+#endif /* WINDOWS && SERVER_MODE */
 
   int error_code = NO_ERROR;
 
@@ -2503,7 +2503,7 @@ fileio_expand_to (THREAD_ENTRY * thread_p, VOLID vol_id, DKNPAGES size_npages, D
       return error_code;
     }
 
-#if defined(WINDOWS)
+#if defined(WINDOWS) && defined(SERVER_MODE)
   io_mutex = fileio_get_volume_mutex (thread_p, vol_fd);
   if (io_mutex == NULL)
     {
@@ -2516,13 +2516,13 @@ fileio_expand_to (THREAD_ENTRY * thread_p, VOLID vol_id, DKNPAGES size_npages, D
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       return ER_FAILED;
     }
-#endif /* WINDOWS */
+#endif /* WINDOWS && SERVER_MODE */
 
   /* get current size */
   current_size = lseek (vol_fd, 0, SEEK_END);
-#if defined(WINDOWS)
+#if defined(WINDOWS) && defined(SERVER_MODE)
   pthread_mutex_unlock (io_mutex);
-#endif /* WINDOWS */
+#endif /* WINDOWS && SERVER_MODE */
   /* safe-guard: current size is rounded to IO_PAGESIZE... unless it crashed during an expand */
   assert (!LOG_ISRESTARTED () || (current_size % IO_PAGESIZE) == 0);
 
@@ -2609,7 +2609,7 @@ fileio_expand_to (THREAD_ENTRY * thread_p, VOLID vol_id, DKNPAGES size_npages, D
 
   return NO_ERROR;
 }
-#endif /* SERVER_MODE */
+#endif /* not CS_MODE */
 
 #if defined(ENABLE_UNUSED_FUNCTION)
 /*

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -392,7 +392,9 @@ extern void fileio_close (int vdes);
 extern int fileio_format (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel, VOLID volid,
 			  DKNPAGES npages, bool sweep_clean, bool dolock, bool dosync, size_t page_size,
 			  int kbytes_to_be_written_per_sec, bool reuse_file);
+#if defined (SERVER_MODE)
 extern int fileio_expand_to (THREAD_ENTRY * threda_p, VOLID volid, DKNPAGES npages_toadd, DB_VOLTYPE voltype);
+#endif /* SERVER_MODE */
 extern void *fileio_initialize_pages (THREAD_ENTRY * thread_p, int vdes, void *io_pgptr, DKNPAGES start_pageid,
 				      DKNPAGES npages, size_t page_size, int kbytes_to_be_written_per_sec);
 extern void fileio_initialize_res (THREAD_ENTRY * thread_p, FILEIO_PAGE_RESERVED * prv_p);

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -392,9 +392,9 @@ extern void fileio_close (int vdes);
 extern int fileio_format (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel, VOLID volid,
 			  DKNPAGES npages, bool sweep_clean, bool dolock, bool dosync, size_t page_size,
 			  int kbytes_to_be_written_per_sec, bool reuse_file);
-#if defined (SERVER_MODE)
+#if !defined (CS_MODE)
 extern int fileio_expand_to (THREAD_ENTRY * threda_p, VOLID volid, DKNPAGES npages_toadd, DB_VOLTYPE voltype);
-#endif /* SERVER_MODE */
+#endif /* not CS_MODE */
 extern void *fileio_initialize_pages (THREAD_ENTRY * thread_p, int vdes, void *io_pgptr, DKNPAGES start_pageid,
 				      DKNPAGES npages, size_t page_size, int kbytes_to_be_written_per_sec);
 extern void fileio_initialize_res (THREAD_ENTRY * thread_p, FILEIO_PAGE_RESERVED * prv_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21630

Fix compile by wrapping entire fileio_expand_to in #if defined (SERVER_MODE)/#endif