### PR TITLE
[CBRD-21630] Removed early out

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2642,13 +2642,6 @@ restart:
 
   /* Search for blocks ready to be vacuumed and generate jobs. */
 
-  /* Choose starting point */
-  if (vacuum_Data.blockid_job_cursor > vacuum_Data.last_blockid)
-    {
-      assert (vacuum_Data.blockid_job_cursor == (vacuum_Data.last_blockid + 1));
-      /* Early out, no new jobs to generate */
-      return;
-    }
   data_page = vacuum_fix_data_page (thread_p, &vacuum_Data.vpid_job_cursor);
   if (data_page == NULL)
     {

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2662,7 +2662,8 @@ restart:
       if (data_index >= data_page->index_free)
 	{
 	  /* Move to next page. */
-	  assert (data_index == data_page->index_free);
+	  /* todo: This assert needs review!!! */
+	  /* assert (data_index == data_page->index_free); */
 	  VPID_COPY (&next_vpid, &data_page->next_page);
 	  vacuum_unfix_data_page (thread_p, data_page);
 	  if (VPID_ISNULL (&next_vpid))
@@ -4068,7 +4069,7 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
   /* Get last_blockid. */
   if (vacuum_is_empty ())
     {
-      if (LSA_ISNULL (&vacuum_Data.recovery_lsa))
+      if (LSA_ISNULL (&vacuum_Data.recovery_lsa) && LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa))
 	{
 	  /* No recovery needed. This is used for 10.1 version to keep the functionality of the database.
 	   * In this case, we are updating the last_blockid of the vacuum to the last block that was logged.

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -12127,6 +12127,9 @@ logpb_last_complete_blockid (void)
 {
   LOG_PAGEID prev_pageid = log_Gl.append.prev_lsa.pageid;
   VACUUM_LOG_BLOCKID blockid = vacuum_get_log_blockid (prev_pageid);
+
+  if (blockid == VACUUM_NULL_LOG_BLOCKID)
+    return blockid;
   /* the previous block is the one completed */
   return blockid - 1;
 }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -12128,8 +12128,13 @@ logpb_last_complete_blockid (void)
   LOG_PAGEID prev_pageid = log_Gl.append.prev_lsa.pageid;
   VACUUM_LOG_BLOCKID blockid = vacuum_get_log_blockid (prev_pageid);
 
-  if (blockid == VACUUM_NULL_LOG_BLOCKID)
-    return blockid;
+  if (blockid < 0)
+    {
+      assert (blockid == VACUUM_NULL_LOG_BLOCKID);
+      assert (LSA_ISNULL (&log_Gl.append.prev_lsa));
+      return VACUUM_NULL_LOG_BLOCKID;
+    }
+
   /* the previous block is the one completed */
   return blockid - 1;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21630
http://jira.cubrid.org/browse/CBRD-21632

Removed an early out that bounded `vacuum_Data.blockid_job_cursor` to `vacuum_Data.last_blockid`. This is no longer correct. Also fixed `logpb_last_complete_blockid` when `prev_lsa` is `NULL`.

This will also fix CBRD-21632. We decided on updating the `last_blockid` from `vacuum_Data` when both the `vacuum_Data.recovery_lsa` and `log_Gl.hdr.mvcc_op_log_lsa` are `NULL`. 