### PR TITLE
[CBRD-21631] fix conversion of unicode code point to UTF-8

### DIFF
--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -3619,14 +3619,14 @@ intl_cp_to_utf8 (const unsigned int codepoint, unsigned char *utf8_seq)
       *utf8_seq = (unsigned char) codepoint;
       return 1;
     }
-  if (codepoint <= 0x7ff)
+  else if (codepoint >= 0x80 && codepoint <= 0x7FF)
     {
       /* 2 bytes */
       *utf8_seq++ = (unsigned char) (0xc0 | (codepoint >> 6));
       *utf8_seq = (unsigned char) (0x80 | (codepoint & 0x3f));
       return 2;
     }
-  if (codepoint <= 0xffff)
+  else if ((codepoint >= 0x800 && codepoint <= 0xd7ff) || (codepoint >= 0xe000 && codepoint <= 0xffff))
     {
       /* 3 bytes */
       *utf8_seq++ = (unsigned char) (0xe0 | (codepoint >> 12));
@@ -3634,7 +3634,7 @@ intl_cp_to_utf8 (const unsigned int codepoint, unsigned char *utf8_seq)
       *utf8_seq = (unsigned char) (0x80 | (codepoint & 0x3f));
       return 3;
     }
-  if (codepoint <= 0x10ffff)
+  else
     {
       /* 4 bytes */
       *utf8_seq++ = (unsigned char) (0xf0 | (codepoint >> 18));

--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -3643,10 +3643,6 @@ intl_cp_to_utf8 (const unsigned int codepoint, unsigned char *utf8_seq)
       *utf8_seq = (unsigned char) (0x80 | (codepoint & 0x3f));
       return 4;
     }
-
-  assert (false);
-  *utf8_seq = '?';
-  return 1;
 }
 
 /*

--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -3619,7 +3619,7 @@ intl_cp_to_utf8 (const unsigned int codepoint, unsigned char *utf8_seq)
       *utf8_seq = (unsigned char) codepoint;
       return 1;
     }
-  else if (codepoint >= 0x80 && codepoint <= 0x7FF)
+  else if (codepoint >= 0x80 && codepoint <= 0x7ff)
     {
       /* 2 bytes */
       *utf8_seq++ = (unsigned char) (0xc0 | (codepoint >> 6));


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21631


Change Unicode code point conversion to UTF-8 according to http://scripts.sil.org/iws-appendixa
Given a Unicode scalar value U, then the UTF-8 byte sequence can be calculated as follows:
```
If U <= U+007F, then
    C1 = U
Else if U+0080 <= U <= U+07FF, then
    C1 = U 64 + 192
    C2 = U mod 64 + 128
Else if U+0800 <= U <= U+D7FF, or if U+E000 <= U <= U+FFFF, then
    C1 = U 4096 + 224
    C2 = (U mod 4096) 64 + 128
    C3 = U mod 64 + 128
Else
    C1 = U 262144 + 240
    C2 = (U mod 262144) 4096 + 128
    C3 = (U mod 4096) 64 + 128
    C4 = U mod 64 + 128
End if
```