### PR TITLE
[CBRD-21650] Fix json mem leak

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -633,6 +633,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_CTE_MAX_RECURSIONS "cte_max_recursions"
 
+#define PRM_NAME_JSON_SHOW_CALLSTACK "json_show_callstack"
+
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
 #define PRM_VALUE_MIN "MIN"
@@ -2121,6 +2123,10 @@ static int prm_cte_max_recursions_default = 2000;
 static int prm_cte_max_recursions_upper = 1000000;
 static int prm_cte_max_recursions_lower = 2;
 static unsigned int prm_cte_max_recursions_flag = 0;
+
+bool PRM_JSON_SHOW_CALLSTACK = false;
+static bool prm_json_show_callstack_default = false;
+static unsigned int prm_json_show_callstack_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5374,6 +5380,17 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) &PRM_CTE_MAX_RECURSIONS,
    (void *) &prm_cte_max_recursions_upper,
    (void *) &prm_cte_max_recursions_lower,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_JSON_SHOW_CALLSTACK,
+   PRM_NAME_JSON_SHOW_CALLSTACK,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   &prm_json_show_callstack_flag,
+   (void *) &prm_json_show_callstack_default,
+   (void *) &PRM_JSON_SHOW_CALLSTACK,
+   (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL}

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -633,7 +633,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_CTE_MAX_RECURSIONS "cte_max_recursions"
 
-#define PRM_NAME_JSON_SHOW_CALLSTACK "json_show_callstack"
+#define PRM_NAME_JSON_SHOW_CALLSTACK "log_json_allocations"
 
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -633,7 +633,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_CTE_MAX_RECURSIONS "cte_max_recursions"
 
-#define PRM_NAME_JSON_SHOW_CALLSTACK "log_json_allocations"
+#define PRM_NAME_JSON_LOG_ALLOCATIONS "json_log_allocations"
 
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
@@ -2124,9 +2124,9 @@ static int prm_cte_max_recursions_upper = 1000000;
 static int prm_cte_max_recursions_lower = 2;
 static unsigned int prm_cte_max_recursions_flag = 0;
 
-bool PRM_JSON_SHOW_CALLSTACK = false;
-static bool prm_json_show_callstack_default = false;
-static unsigned int prm_json_show_callstack_flag = 0;
+bool PRM_JSON_LOG_ALLOCATIONS = false;
+static bool prm_json_log_allocations_default = false;
+static unsigned int prm_json_log_allocations_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5383,13 +5383,13 @@ static SYSPRM_PARAM prm_Def[] = {
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},
-  {PRM_ID_JSON_SHOW_CALLSTACK,
-   PRM_NAME_JSON_SHOW_CALLSTACK,
+  {PRM_ID_JSON_LOG_ALLOCATIONS,
+   PRM_NAME_JSON_LOG_ALLOCATIONS,
    (PRM_FOR_SERVER | PRM_HIDDEN),
    PRM_BOOLEAN,
-   &prm_json_show_callstack_flag,
-   (void *) &prm_json_show_callstack_default,
-   (void *) &PRM_JSON_SHOW_CALLSTACK,
+   &prm_json_log_allocations_flag,
+   (void *) &prm_json_log_allocations_default,
+   (void *) &PRM_JSON_LOG_ALLOCATIONS,
    (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -405,10 +405,10 @@ enum param_id
 
   PRM_ID_CTE_MAX_RECURSIONS,
 
-  PRM_ID_JSON_SHOW_CALLSTACK,
+  PRM_ID_JSON_LOG_ALLOCATIONS,
 
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_JSON_SHOW_CALLSTACK
+  PRM_LAST_ID = PRM_ID_JSON_LOG_ALLOCATIONS
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -405,8 +405,10 @@ enum param_id
 
   PRM_ID_CTE_MAX_RECURSIONS,
 
+  PRM_ID_JSON_SHOW_CALLSTACK,
+
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_CTE_MAX_RECURSIONS
+  PRM_LAST_ID = PRM_ID_JSON_SHOW_CALLSTACK
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -269,7 +269,7 @@ JSON_PRIVATE_ALLOCATOR::Malloc (size_t size)
   if (size)			//  behavior of malloc(0) is implementation defined.
     {
       char *p = (char *) db_private_alloc (NULL, size);
-      if (prm_get_bool_value (PRM_ID_JSON_SHOW_CALLSTACK))
+      if (prm_get_bool_value (PRM_ID_JSON_LOG_ALLOCATIONS))
         {
           er_print_callstack (ARG_FILE_LINE, "JSON_ALLOC: Traced pointer=%p\n", p);
         }
@@ -292,7 +292,7 @@ JSON_PRIVATE_ALLOCATOR::Realloc (void *originalPtr, size_t originalSize, size_t 
       return NULL;
     }
   p = (char *) db_private_realloc (NULL, originalPtr, newSize);
-  if (prm_get_bool_value (PRM_ID_JSON_SHOW_CALLSTACK))
+  if (prm_get_bool_value (PRM_ID_JSON_LOG_ALLOCATIONS))
     {
       er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", p);
     }

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -66,6 +66,7 @@
 
 #include <vector>
 #include "memory_alloc.h"
+#include "system_parameter.h"
 
 #if defined GetObject
 /* stupid windows and their definitions; GetObject is defined as GetObjectW or GetObjectA */
@@ -267,7 +268,12 @@ JSON_PRIVATE_ALLOCATOR::Malloc (size_t size)
 {
   if (size)			//  behavior of malloc(0) is implementation defined.
     {
-      return db_private_alloc (NULL, size);
+      char *p = (char *) db_private_alloc (NULL, size);
+      if (prm_get_bool_value (PRM_ID_JSON_SHOW_CALLSTACK))
+        {
+          er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", p);
+        }
+      return p;
     }
   else
     {
@@ -279,12 +285,18 @@ void *
 JSON_PRIVATE_ALLOCATOR::Realloc (void *originalPtr, size_t originalSize, size_t newSize)
 {
   (void) originalSize;
+  char *p;
   if (newSize == 0)
     {
       db_private_free (NULL, originalPtr);
       return NULL;
     }
-  return db_private_realloc (NULL, originalPtr, newSize);
+  p = (char *) db_private_realloc (NULL, originalPtr, newSize);
+  if (prm_get_bool_value (PRM_ID_JSON_SHOW_CALLSTACK))
+    {
+      er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", p);
+    }
+  return p;
 }
 
 void

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -271,7 +271,7 @@ JSON_PRIVATE_ALLOCATOR::Malloc (size_t size)
       char *p = (char *) db_private_alloc (NULL, size);
       if (prm_get_bool_value (PRM_ID_JSON_SHOW_CALLSTACK))
         {
-          er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", p);
+          er_print_callstack (ARG_FILE_LINE, "JSON_ALLOC: Traced pointer=%p\n", p);
         }
       return p;
     }

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -10025,30 +10025,21 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_JSON:
 	  {
-	    const char *json_str;
+	    char *json_str;
 	    int len;
 
 	    json_str = db_json_get_raw_json_body_from_document (DB_GET_JSON_DOCUMENT (src));
-
 	    len = strlen (json_str);
-	    target->need_clear = true;
 
-	    err = DB_MAKE_CHAR (target, len, json_str, len, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
-	    if (err != NO_ERROR)
-	      {
-		status = DOMAIN_ERROR;
-		pr_clear_value (target);
-	      }
-	    else if (DB_IS_NULL (target))
-	      {
-		status = DOMAIN_ERROR;
-		pr_clear_value (target);
-	      }
-	    else if (DB_VALUE_PRECISION (target) != TP_FLOATING_PRECISION_VALUE
-		     && (DB_GET_STRING_LENGTH (target) > DB_VALUE_PRECISION (target)))
+	    if (db_value_precision (target) != TP_FLOATING_PRECISION_VALUE && db_value_precision (target) < len)
 	      {
 		status = DOMAIN_OVERFLOW;
-		pr_clear_value (target);
+		db_private_free_and_init (NULL, json_str);
+	      }
+	    else
+	      {
+		make_desired_string_db_value (desired_type, desired_domain, json_str, target, &status, &data_stat);
+		target->need_clear = true;
 	      }
 	  }
 	  break;


### PR DESCRIPTION
DB_MAKE_CHAR was overriding my need_clear flag to false and the memory wasn't deallocated, thus resulting in a mem leak. I suggest adding a "need_clear" parameter to DB_MAKE_CHAR.

I have also added the json_show_callstack hidden system parameter to aid in resolving future memory leak problems.