### PR TITLE
[CBRD-21645] updates keep_from_log_pageid when blocks are consumed and vacuum data was empty

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4927,6 +4927,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
   VACUUM_DATA_ENTRY *save_page_free_data = NULL;
   VACUUM_LOG_BLOCKID next_blockid;
   PAGE_TYPE ptype = PAGE_VACUUM_DATA;
+  bool was_vacuum_data_empty = false;
 
   int error_code = NO_ERROR;
 
@@ -4951,6 +4952,8 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
   data_page = vacuum_Data.last_page;
   page_free_data = data_page->data + data_page->index_free;
   save_page_free_data = page_free_data;
+
+  was_vacuum_data_empty = vacuum_is_empty ();
 
   while (lf_circular_queue_consume (vacuum_Block_data_buffer, &consumed_data))
     {
@@ -5083,6 +5086,11 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 	  page_free_data++;
 	  data_page->index_free++;
 	}
+    }
+
+  if (was_vacuum_data_empty)
+    {
+      vacuum_update_keep_from_log_pageid (thread_p);
     }
 
   assert (data_page == vacuum_Data.last_page);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21645

Bad `keep_from_log_pageid` allows archive removal although it was required for vacuum. At the time of the crash it has value -1, although there are many blocks in vacuum.

The problem was that `keep_from_log_pageid` was updated only in two places:
1. `vacuum_data_load_and_recover`.
2. `vacuum_data_mark_finished`, but only if blocks are removed from vacuum data.

After `vacuum_data_mark_finished`, if vacuum data becomes empty, `keep_from_log_pageid` is set to NULL_PAGEID, allowing archive removals. Which is what happens in our case too.

However, it is followed by a very long run that creates many new blocks but doesn't execute jobs (I guess a very long transaction prevents vacuum from executing). `vacuum_data_mark_finished` always earlies out and doesn't update `keep_from_log_pageid`; its value remain nil. Eventually, first archive is removed.

When first block finally starts executing, it tries to fetch the log pages from removed archive.

The fix is to update `keep_from_log_pageid` when blocks are consumed and vacuum data was empty.