### PR TITLE
[CBRD-21658] Merge log archive and vacuum fixes to 10.1 patch1

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -69,6 +69,7 @@
 #include "system_parameter.h"
 #include "xserver_interface.h"
 #include "heap_file.h"
+#include "vacuum.h"
 #include "xasl_cache.h"
 
 #if defined (SERVER_MODE)

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -70,6 +70,7 @@
 #include "xserver_interface.h"
 #include "server_support.h"
 #include "utility.h"
+#include "vacuum.h"
 #if !defined(WINDOWS)
 #include "heartbeat.h"
 #endif

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4927,6 +4927,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
   VACUUM_DATA_ENTRY *save_page_free_data = NULL;
   VACUUM_LOG_BLOCKID next_blockid;
   PAGE_TYPE ptype = PAGE_VACUUM_DATA;
+  bool was_vacuum_data_empty = false;
 
   int error_code = NO_ERROR;
 
@@ -4951,6 +4952,8 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
   data_page = vacuum_Data.last_page;
   page_free_data = data_page->data + data_page->index_free;
   save_page_free_data = page_free_data;
+
+  was_vacuum_data_empty = vacuum_is_empty ();
 
   while (lf_circular_queue_consume (vacuum_Block_data_buffer, &consumed_data))
     {
@@ -5083,6 +5086,11 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 	  page_free_data++;
 	  data_page->index_free++;
 	}
+    }
+
+  if (was_vacuum_data_empty)
+    {
+      vacuum_update_keep_from_log_pageid (thread_p);
     }
 
   assert (data_page == vacuum_Data.last_page);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5538,10 +5538,16 @@ vacuum_update_oldest_unvacuumed_mvccid (THREAD_ENTRY * thread_p)
     }
   else
     {
+#if defined (SERVER_MODE)
       /* If page is empty and has next page, it should have been removed. */
       assert (VPID_ISNULL (&vacuum_Data.first_page->next_page));
       /* Use vacuum_Save_log_hdr_oldest_mvccid (see its description). */
       oldest_mvccid = vacuum_Save_log_hdr_oldest_mvccid;
+#else /* not SERVER_MODE = SA_MODE */
+      /* if vacuum data is empty in SA_MODE, then everything has been vacuumed! set oldest not vacuumed to
+       * log_Gl.hdr.mvcc_next_id */
+      oldest_mvccid = log_Gl.hdr.mvcc_next_id;
+#endif /* SA_MODE */
     }
 
   if (oldest_mvccid != vacuum_Data.oldest_unvacuumed_mvccid)

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1190,21 +1190,6 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	  pgbuf_unfix_and_init (thread_p, helper.home_page);
 	  return NO_ERROR;
 	}
-      /* page still could be reused as new heap page in same file. in this case the slot may be invalid or it may hold
-       * another record (but that won't bother us, because we always check the record header).
-       * stop if slot no longer exists. */
-      if (spage_number_of_slots (helper.home_page) <= heap_objects[0].oid.slotid)
-	{
-	  /* slot does not exist */
-	  /* Safe guard: this was possible if there was only one object to be vacuumed. */
-	  assert (n_heap_objects == 1);
-
-	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP, "Heap page %d|%d was deallocated during previous run and reused as"
-				 " new heap page\n", VPID_AS_ARGS (&helper.home_vpid));
-
-	  pgbuf_unfix_and_init (thread_p, helper.home_page);
-	  return NO_ERROR;
-	}
     }
   else
     {

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3058,7 +3058,10 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, BLO
   /* Initialize stored heap objects. */
   worker->n_heap_objects = 0;
 
-  was_interrupted = VACUUM_BLOCK_IS_INTERRUPTED (data->blockid);
+  /* set was_interrupted flag to tell vacuum_heap_page that some safe-guard have to behave differently. interruptions
+   * are usually marked in blockid, however sa_mode_partial_block can also be interrupted and will no flag is set in
+   * blockid. */
+  was_interrupted = VACUUM_BLOCK_IS_INTERRUPTED (data->blockid) || sa_mode_partial_block;
 
   /* Follow the linked records starting with start_lsa */
   for (LSA_COPY (&log_lsa, &data->start_lsa); !LSA_ISNULL (&log_lsa) && log_lsa.pageid >= first_block_pageid;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -248,6 +248,7 @@ struct vacuum_data
   bool shutdown_requested;	/* Set to true when shutdown is requested. It stops vacuum from generating or executing
 				 * new jobs.
 				 */
+  bool is_archive_removal_safe;	/* Set to true after keep_from_log_pageid is updated. */
 
   /* Job cursor for vacuum master to avoid going again through jobs already generated */
   VPID vpid_job_cursor;
@@ -272,6 +273,7 @@ static VACUUM_DATA vacuum_Data = {
   0,				/* log_block_npages */
   false,			/* is_loaded */
   false,			/* shutdown_requested */
+  false,			/* is_archive_removal_safe */
   VPID_INITIALIZER,		/* vpid_job_cursor */
   0,				/* blockid_job_cursor */
   LSA_INITIALIZER		/* recovery_lsa */
@@ -700,6 +702,9 @@ xvacuum (THREAD_ENTRY * thread_p)
 
   /* Process vacuum data and run vacuum . */
   vacuum_process_vacuum_data (thread_p);
+
+  /* remove archives that have been prevented from being removed up until now. */
+  logpb_remove_archive_logs_exceed_limit (thread_p, 0);
 
   VACUUM_RESTORE_THREAD (thread_p, dummy_save_type);
 
@@ -5465,6 +5470,18 @@ vacuum_min_log_pageid_to_keep (THREAD_ENTRY * thread_p)
 }
 
 /*
+ * vacuum_is_safe_to_remove_archives () - Is safe to remove archives? Not until keep_from_log_pageid has been updated
+ *                                        at least once.
+ *
+ * return    : is safe?
+ */
+bool
+vacuum_is_safe_to_remove_archives (void)
+{
+  return vacuum_Data.is_archive_removal_safe;
+}
+
+/*
  * vacuum_rv_redo_start_job () - Redo start vacuum job.
  *
  * return	 : Error code.
@@ -5565,6 +5582,13 @@ vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p)
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
 		 "Update keep_from_log_pageid to %lld ", (long long int) vacuum_Data.keep_from_log_pageid);
+
+  if (!vacuum_Data.is_archive_removal_safe)
+    {
+      /* remove archives that have been blocked up to this point. */
+      vacuum_Data.is_archive_removal_safe = true;
+      logpb_remove_archive_logs_exceed_limit (thread_p, 0);
+    }
 }
 
 /*

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4079,7 +4079,7 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
 	  /* No recovery needed. This is used for 10.1 version to keep the functionality of the database.
 	   * In this case, we are updating the last_blockid of the vacuum to the last block that was logged.
 	   */
-	  vacuum_Data.last_blockid = vacuum_get_log_blockid (log_Gl.append.prev_lsa.pageid) - 1;
+	  vacuum_Data.last_blockid = logpb_last_complete_blockid ();
 	}
       else
 	{

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2637,13 +2637,6 @@ restart:
 
   /* Search for blocks ready to be vacuumed and generate jobs. */
 
-  /* Choose starting point */
-  if (vacuum_Data.blockid_job_cursor > vacuum_Data.last_blockid)
-    {
-      assert (vacuum_Data.blockid_job_cursor == (vacuum_Data.last_blockid + 1));
-      /* Early out, no new jobs to generate */
-      return;
-    }
   data_page = vacuum_fix_data_page (thread_p, &vacuum_Data.vpid_job_cursor);
   if (data_page == NULL)
     {
@@ -2664,7 +2657,8 @@ restart:
       if (data_index >= data_page->index_free)
 	{
 	  /* Move to next page. */
-	  assert (data_index == data_page->index_free);
+	  /* todo: This assert needs review!!! */
+	  /* assert (data_index == data_page->index_free); */
 	  VPID_COPY (&next_vpid, &data_page->next_page);
 	  vacuum_unfix_data_page (thread_p, data_page);
 	  if (VPID_ISNULL (&next_vpid))
@@ -4074,7 +4068,7 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
   /* Get last_blockid. */
   if (vacuum_is_empty ())
     {
-      if (LSA_ISNULL (&vacuum_Data.recovery_lsa))
+      if (LSA_ISNULL (&vacuum_Data.recovery_lsa) && LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa))
 	{
 	  /* No recovery needed. This is used for 10.1 version to keep the functionality of the database.
 	   * In this case, we are updating the last_blockid of the vacuum to the last block that was logged.

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -337,4 +337,5 @@ extern DISK_ISVALID vacuum_check_not_vacuumed_rec_header (THREAD_ENTRY * thread_
 extern bool vacuum_is_mvccid_vacuumed (MVCCID id);
 extern int vacuum_rv_check_at_undo (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slotid, INT16 rec_type);
 
+extern void vacuum_log_last_blockid (THREAD_ENTRY * thread_p);
 #endif /* _VACUUM_H_ */

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -67,9 +67,6 @@
     _er_log_debug (ARG_FILE_LINE, "VACUUM WARNING " LOG_THREAD_TRAN_MSG ": " msg "\n", \
                    LOG_THREAD_TRAN_ARGS (thread_get_thread_entry_info ()), __VA_ARGS__)
 
-typedef INT64 VACUUM_LOG_BLOCKID;
-#define VACUUM_NULL_LOG_BLOCKID -1
-
 #define VACUUM_LOG_ADD_DROPPED_FILE_POSTPONE true
 #define VACUUM_LOG_ADD_DROPPED_FILE_UNDO false
 

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -291,6 +291,7 @@ extern void vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * st
 					   MVCCID newest_mvccid);
 extern int vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p);
 extern LOG_PAGEID vacuum_min_log_pageid_to_keep (THREAD_ENTRY * thread_p);
+extern bool vacuum_is_safe_to_remove_archives (void);
 extern void vacuum_notify_server_crashed (LOG_LSA * recovery_lsa);
 extern void vacuum_notify_server_shutdown (void);
 extern int vacuum_rv_redo_vacuum_complete (THREAD_ENTRY * thread_p, LOG_RCV * rcv);

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -51,6 +51,7 @@
 #include "heap_file.h"
 #include "bit.h"
 #include "util_func.h"
+#include "vacuum.h"
 
 #include "critical_section.h"
 #if defined(SERVER_MODE)

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -778,6 +778,13 @@ struct spacedb_files
   DKNPAGES npage_reserved;
 };
 
+/* vacuum blocks */
+/*
+ * Note that develop branch has these definitions in log_impl.h
+ */
+typedef INT64 VACUUM_LOG_BLOCKID;
+#define VACUUM_NULL_LOG_BLOCKID -1
+
 extern INT16 db_page_size (void);
 extern INT16 db_io_page_size (void);
 extern INT16 db_log_page_size (void);

--- a/src/transaction/log_comm.c
+++ b/src/transaction/log_comm.c
@@ -40,6 +40,9 @@
 #include "misc_string.h"
 #include "intl_support.h"
 #include "log_impl.h"
+#if defined (SERVER_MODE)
+#include "vacuum.h"
+#endif /* SERVER_MODE */
 #if !defined(WINDOWS)
 #if defined(CS_MODE)
 #include "db.h"

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -954,7 +954,7 @@ struct log_header
   LOG_LSA bkup_level2_lsa;	/* Lsa of backup level 2 */
   char prefix_name[MAXLOGNAME];	/* Log prefix name */
   bool has_logging_been_skipped;	/* Has logging been skipped ? */
-  int reserved_int_1;		/* for backward compatibility - previously used for lowest_arv_num_for_backup */
+  INT64 vacuum_last_blockid;	/* Last processed blockid needed for vacuum. */
   int reserved_int_2;		/* for backward compatibility - previously used for highest_arv_num_for_backup */
   int perm_status;		/* Reserved for future expansion and permanent status indicators, e.g. to mark
 				 * RESTORE_IN_PROGRESS */
@@ -1013,7 +1013,7 @@ struct log_header
      {'0'},                                      \
      /* has_logging_been_skipped */              \
      false,                                      \
-     0, 0, 0,                                    \
+     0, 0,                                       \
      /* bkinfo */                                \
      {{0, 0, 0, 0, 0}},                          \
      0, 0,                                       \
@@ -1072,7 +1072,7 @@ struct log_header
      {'0'},                                      \
      /* has_logging_been_skipped */              \
      false,                                      \
-     0, 0, 0,                                    \
+     0, 0,                                       \
      /* bkinfo */                                \
      {{0, 0, 0, 0, 0}},                          \
      0, 0,                                       \
@@ -2341,6 +2341,8 @@ extern int logpb_prior_lsa_append_all_list (THREAD_ENTRY * thread_p);
 extern bool logtb_check_class_for_rr_isolation_err (const OID * class_oid);
 
 extern void logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr);
+
+extern void logpb_update_last_blockid (THREAD_ENTRY * thread_p, LOG_PAGEID page_id);
 
 /************************************************************************/
 /* Inline functions:                                                    */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -954,8 +954,7 @@ struct log_header
   LOG_LSA bkup_level2_lsa;	/* Lsa of backup level 2 */
   char prefix_name[MAXLOGNAME];	/* Log prefix name */
   bool has_logging_been_skipped;	/* Has logging been skipped ? */
-  INT64 vacuum_last_blockid;	/* Last processed blockid needed for vacuum. */
-  int reserved_int_2;		/* for backward compatibility - previously used for highest_arv_num_for_backup */
+  VACUUM_LOG_BLOCKID vacuum_last_blockid;	/* Last processed blockid needed for vacuum. */
   int perm_status;		/* Reserved for future expansion and permanent status indicators, e.g. to mark
 				 * RESTORE_IN_PROGRESS */
   LOG_HDR_BKUP_LEVEL_INFO bkinfo[FILEIO_BACKUP_UNDEFINED_LEVEL];
@@ -2342,7 +2341,7 @@ extern bool logtb_check_class_for_rr_isolation_err (const OID * class_oid);
 
 extern void logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr);
 
-extern void logpb_update_last_blockid (THREAD_ENTRY * thread_p, LOG_PAGEID page_id);
+extern VACUUM_LOG_BLOCKID logpb_last_complete_blockid (void);
 
 /************************************************************************/
 /* Inline functions:                                                    */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -12166,6 +12166,14 @@ logpb_last_complete_blockid (void)
 {
   LOG_PAGEID prev_pageid = log_Gl.append.prev_lsa.pageid;
   VACUUM_LOG_BLOCKID blockid = vacuum_get_log_blockid (prev_pageid);
+
+  if (blockid < 0)
+    {
+      assert (blockid == VACUUM_NULL_LOG_BLOCKID);
+      assert (LSA_ISNULL (&log_Gl.append.prev_lsa));
+      return VACUUM_NULL_LOG_BLOCKID;
+    }
+
   /* the previous block is the one completed */
   return blockid - 1;
 }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -94,6 +94,7 @@
 #include "event_log.h"
 #include "thread.h"
 #include "tsc_timer.h"
+#include "vacuum.h"
 
 #if !defined(SERVER_MODE)
 #define pthread_mutex_init(a, b)
@@ -6946,10 +6947,10 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	{
 	  log_Gl.hdr.last_deleted_arv_num = last_arv_num_to_delete;
 
+#if defined (SA_MODE)
 	  /* Update the last_blockid needed for vacuum. Get the first page_id of the previously logged archive */
-	  new_page_id = log_Gl.append.prev_lsa.pageid;
-	  logpb_update_last_blockid (thread_p, new_page_id);
-
+	  log_Gl.hdr.vacuum_last_blockid = logpb_last_complete_blockid ();
+#endif /* SA_MODE */
 	  logpb_flush_header (thread_p);	/* to get rid of archives */
 	}
 
@@ -12156,18 +12157,15 @@ logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HEADER * loghd
 }
 
 /*
- * logpb_update_last_blockid () - Updates the last_blockid needed later for vacuum.
- * 
- * return :- void
+ * logpb_last_complete_blockid () - get blockid of last completely logged block
  *
- * thread_p (in) :- Thread context.
- * page_id (in)  :- The first page id of the block that must updated to.
+ * return    : blockid
  */
-void
-logpb_update_last_blockid (THREAD_ENTRY * thread_p, LOG_PAGEID page_id)
+VACUUM_LOG_BLOCKID
+logpb_last_complete_blockid (void)
 {
-  VACUUM_LOG_BLOCKID last_blockid;
-
-  last_blockid = vacuum_get_log_blockid (page_id);
-  log_Gl.hdr.vacuum_last_blockid = last_blockid;
+  LOG_PAGEID prev_pageid = log_Gl.append.prev_lsa.pageid;
+  VACUUM_LOG_BLOCKID blockid = vacuum_get_log_blockid (prev_pageid);
+  /* the previous block is the one completed */
+  return blockid - 1;
 }


### PR DESCRIPTION
Merge the recent fixes of log archive and vacuum to 10.1 patch 1.

* [CBRD-21583](http://jira.cubrid.org/browse/CBRD-21583): https://github.com/CUBRID/cubrid/pull/834
* [CBRD-21584](http://jira.cubrid.org/browse/CBRD-21584): https://github.com/CUBRID/cubrid/pull/833
* [CBRD-21595](http://jira.cubrid.org/browse/CBRD-21595): https://github.com/CUBRID/cubrid/pull/836
* [CBRD-21617](http://jira.cubrid.org/browse/CBRD-21617): https://github.com/CUBRID/cubrid/pull/847
* [CBRD-21593](http://jira.cubrid.org/browse/CBRD-21593): https://github.com/CUBRID/cubrid/pull/837
* [CBRD-21634](http://jira.cubrid.org/browse/CBRD-21634): https://github.com/CUBRID/cubrid/pull/860
* [CBRD-21630](http://jira.cubrid.org/browse/CBRD-21630): https://github.com/CUBRID/cubrid/pull/863
* [CBRD-21645](http://jira.cubrid.org/browse/CBRD-21645): https://github.com/CUBRID/cubrid/pull/869