### PR TITLE
[CBRD-21657] fix ;historylist after editline update

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1387,16 +1387,11 @@ csql_do_session_cmd (char *line_read, CSQL_ARGUMENT * csql_arg)
 #if !defined(WINDOWS)
       if (csql_Is_interactive)
 	{
-	  /* rewind history */
-	  int i;
+	  HISTORY_STATE *hist_state = history_get_history_state ();
 
-	  while (next_history ())
+	  for (int i = 0; i < hist_state->length; i++)
 	    {
-	      ;
-	    }
-
-	  for (i = 0, hist_entry = current_history (); hist_entry; hist_entry = previous_history (), i++)
-	    {
+	      hist_entry = history_get (i + 1);
 	      fprintf (csql_Output_fp, "----< %d >----\n", i + 1);
 	      fprintf (csql_Output_fp, "%s\n\n", hist_entry->line);
 	    }

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1387,13 +1387,14 @@ csql_do_session_cmd (char *line_read, CSQL_ARGUMENT * csql_arg)
 #if !defined(WINDOWS)
       if (csql_Is_interactive)
 	{
-	  HISTORY_STATE *hist_state = history_get_history_state ();
-
-	  for (int i = 0; i < hist_state->length; i++)
+	  for (int i = 0; i < history_length; i++)
 	    {
 	      hist_entry = history_get (i + 1);
-	      fprintf (csql_Output_fp, "----< %d >----\n", i + 1);
-	      fprintf (csql_Output_fp, "%s\n\n", hist_entry->line);
+	      if (hist_entry != NULL && hist_entry->line != NULL)
+		{
+		  fprintf (csql_Output_fp, "----< %d >----\n", i + 1);
+		  fprintf (csql_Output_fp, "%s\n\n", hist_entry->line);
+		}
 	    }
 	}
 #else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21657

After update of libedit from version 20120601-3.0 to version 20170329-3.1, csql history does not work anymore. This patch fixes csql history using new version of libedit.