### PR TITLE
[CBRD-21679] 10.1p1: fix vacuum last_blockid after restoredb (#879)

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6979,8 +6979,11 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	  log_Gl.hdr.last_deleted_arv_num = last_arv_num_to_delete;
 
 #if defined (SA_MODE)
-	  /* Update the last_blockid needed for vacuum. Get the first page_id of the previously logged archive */
-	  log_Gl.hdr.vacuum_last_blockid = logpb_last_complete_blockid ();
+	  if (LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa))
+	    {
+	      /* Update the last_blockid needed for vacuum. Get the first page_id of the previously logged archive */
+	      log_Gl.hdr.vacuum_last_blockid = logpb_last_complete_blockid ();
+	    }
 #endif /* SA_MODE */
 	  logpb_flush_header (thread_p);	/* to get rid of archives */
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21679

During restoredb it is not safe to update log_Gl.hdr.vacuum_last_blockid based on append_lsa, because vacuum was not executed.

The used a hack, comparing log_Gl.hdr.mvcc_op_log_lsa to NULL_LSA, to detect the case.