### PR TITLE
[CBRD-21696] remove safe-guard of unfixing page latch: There might be…

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -6011,7 +6011,6 @@ pgbuf_unlatch_bcb_upon_unfix (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, int h
        * performance. */
       if (pgbuf_bcb_should_be_moved_to_bottom_lru (bufptr))
 	{
-	  assert (!pgbuf_is_exist_blocked_reader_writer (bufptr));
 	  pgbuf_move_bcb_to_bottom_lru (thread_p, bufptr);
 	}
       else if (pgbuf_is_exist_blocked_reader_writer (bufptr) == false)


### PR DESCRIPTION
… a blocked waiter to a deallocated page

http://jira.cubrid.org/browse/CBRD-21696

`btree_key_lock_object` unfixes the leaf page and refixes it to lock the oid. 
In the meantime, vacuum merges the page and is deallocating it.
A waiter for to be deallocated page is unexpected and hits the assertion. 
This might not be true for the case. 

Release builds including 10.1 work.
