### PR TITLE
[CBRD-21645] 10.1p1: keep archive when empty data and mvcc_op_log_lsa not nul…

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5591,8 +5591,18 @@ vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p)
 
   if (vacuum_is_empty ())
     {
-      keep_from_blockid = VACUUM_NULL_LOG_BLOCKID;
-      vacuum_Data.keep_from_log_pageid = NULL_PAGEID;
+      if (LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa))
+	{
+	  /* safe to remove all archives */
+	  keep_from_blockid = VACUUM_NULL_LOG_BLOCKID;
+	  vacuum_Data.keep_from_log_pageid = NULL_PAGEID;
+	}
+      else
+	{
+	  /* keep block of log_Gl.hdr.mvcc_op_log_lsa */
+	  keep_from_blockid = vacuum_get_log_blockid (log_Gl.hdr.mvcc_op_log_lsa.pageid);
+	  vacuum_Data.keep_from_log_pageid = VACUUM_FIRST_LOG_PAGEID_IN_BLOCK (keep_from_blockid);
+	}
     }
   else
     {


### PR DESCRIPTION
…l (#888)

http://jira.cubrid.org/browse/CBRD-21645

vacuum_update_keep_from_log_pageid - if vacuum data is empty we considered safe to remove archives. we were almost right, except that we did not consider partially logged block still in log_Gl.hdr;

One design flaw that causes us trouble is the condition to produce a log block - first mvcc operation in a different block. This sometimes leaves us with a very old block cached in header for a long time; one such case is very long undo recovery (that appends non-mvcc log records). I think the condition may be changed to first any log record in a different block.