### PR TITLE
[CBRD-21704] Fix log_Gl.hdr.vacuum_last_blockid

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4081,7 +4081,8 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
 	   * in the log_Gl header. After a long session in SA_MODE, the vacuum_Data.last_page->data->blockid will
 	   * be outdated. Instead, SA_MODE updates log_Gl.hdr.vacuum_last_blockid before removing old archives.
 	   */
-	  vacuum_Data.last_blockid = MAX (log_Gl.hdr.vacuum_last_blockid, vacuum_Data.last_page->data->blockid);
+	  VACUUM_LOG_BLOCKID hdr_last_blockid = logpb_hdr_get_vacuum_last_blockid ();
+	  vacuum_Data.last_blockid = MAX (hdr_last_blockid, vacuum_Data.last_page->data->blockid);
 	}
     }
   else

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -954,7 +954,8 @@ struct log_header
   LOG_LSA bkup_level2_lsa;	/* Lsa of backup level 2 */
   char prefix_name[MAXLOGNAME];	/* Log prefix name */
   bool has_logging_been_skipped;	/* Has logging been skipped ? */
-  VACUUM_LOG_BLOCKID vacuum_last_blockid;	/* Last processed blockid needed for vacuum. */
+  char vacuum_last_blockid_buf[sizeof (VACUUM_LOG_BLOCKID)];	/* Last processed blockid needed for vacuum. */
+  /* hack for 10.1 p 1 compatibility */
   int perm_status;		/* Reserved for future expansion and permanent status indicators, e.g. to mark
 				 * RESTORE_IN_PROGRESS */
   LOG_HDR_BKUP_LEVEL_INFO bkinfo[FILEIO_BACKUP_UNDEFINED_LEVEL];
@@ -2342,6 +2343,8 @@ extern bool logtb_check_class_for_rr_isolation_err (const OID * class_oid);
 extern void logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr);
 
 extern VACUUM_LOG_BLOCKID logpb_last_complete_blockid (void);
+extern VACUUM_LOG_BLOCKID logpb_hdr_get_vacuum_last_blockid (void);
+extern void logpb_hdr_set_vacuum_last_blockid (VACUUM_LOG_BLOCKID blockid);
 
 /************************************************************************/
 /* Inline functions:                                                    */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -954,6 +954,7 @@ struct log_header
   LOG_LSA bkup_level2_lsa;	/* Lsa of backup level 2 */
   char prefix_name[MAXLOGNAME];	/* Log prefix name */
   bool has_logging_been_skipped;	/* Has logging been skipped ? */
+  bool dummy_byte_1;
   char vacuum_last_blockid_buf[sizeof (VACUUM_LOG_BLOCKID)];	/* Last processed blockid needed for vacuum. */
   /* hack for 10.1 p 1 compatibility */
   int perm_status;		/* Reserved for future expansion and permanent status indicators, e.g. to mark

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1363,7 +1363,7 @@ logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const cha
     {
       loghdr->prefix_name[0] = '\0';
     }
-  loghdr->vacuum_last_blockid = 0;
+  logpb_hdr_set_vacuum_last_blockid (0);
   loghdr->perm_status = LOG_PSTAT_CLEAR;
 
   for (i = 0; i < FILEIO_BACKUP_UNDEFINED_LEVEL; i++)
@@ -6982,7 +6982,7 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	  if (LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa))
 	    {
 	      /* Update the last_blockid needed for vacuum. Get the first page_id of the previously logged archive */
-	      log_Gl.hdr.vacuum_last_blockid = logpb_last_complete_blockid ();
+	      logpb_hdr_set_vacuum_last_blockid (logpb_last_complete_blockid ());
 	    }
 #endif /* SA_MODE */
 	  logpb_flush_header (thread_p);	/* to get rid of archives */
@@ -12097,4 +12097,18 @@ logpb_last_complete_blockid (void)
 
   /* the previous block is the one completed */
   return blockid - 1;
+}
+
+VACUUM_LOG_BLOCKID
+logpb_hdr_get_vacuum_last_blockid (void)
+{
+  VACUUM_LOG_BLOCKID temp;
+  memcpy (&temp, log_Gl.hdr.vacuum_last_blockid_buf, sizeof (VACUUM_LOG_BLOCKID));
+  return temp;
+}
+
+void
+logpb_hdr_set_vacuum_last_blockid (VACUUM_LOG_BLOCKID blockid)
+{
+  memcpy (log_Gl.hdr.vacuum_last_blockid_buf, &blockid, sizeof (VACUUM_LOG_BLOCKID));
 }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1363,6 +1363,7 @@ logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const cha
     {
       loghdr->prefix_name[0] = '\0';
     }
+  loghdr->dummy_byte_1 = false;
   logpb_hdr_set_vacuum_last_blockid (0);
   loghdr->perm_status = LOG_PSTAT_CLEAR;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21704

memcopy vacuum_last_blockid to avoid alignment issues.

this is a hack for 10.1 p1 only.