### PR TITLE
[CBRD-21567] Copy class and columns comments for CREATE TABLE LIKE

### DIFF
--- a/src/compat/db_class.c
+++ b/src/compat/db_class.c
@@ -200,7 +200,7 @@ db_add_attribute_internal (MOP class_, const char *name, const char *domain, DB_
     }
   else
     {
-      error = smt_add_attribute_any (def, name, domain, (DB_DOMAIN *) 0, name_space, false, NULL);
+      error = smt_add_attribute_any (def, name, domain, (DB_DOMAIN *) 0, name_space, false, NULL, NULL);
       if (error)
 	{
 	  smt_quit (def);

--- a/src/compat/db_temp.c
+++ b/src/compat/db_temp.c
@@ -277,7 +277,7 @@ dbt_add_attribute (DB_CTMPL * def, const char *name, const char *domain, DB_VALU
   CHECK_3ARGS_ERROR (def, name, domain);
   CHECK_MODIFICATION_ERROR ();
 
-  error = smt_add_attribute_w_dflt (def, name, domain, (DB_DOMAIN *) 0, default_value, ID_ATTRIBUTE, NULL);
+  error = smt_add_attribute_w_dflt (def, name, domain, (DB_DOMAIN *) 0, default_value, ID_ATTRIBUTE, NULL, NULL);
 
   return (error);
 }
@@ -299,7 +299,7 @@ dbt_add_shared_attribute (DB_CTMPL * def, const char *name, const char *domain, 
   CHECK_3ARGS_ERROR (def, name, domain);
   CHECK_MODIFICATION_ERROR ();
 
-  error = smt_add_attribute_w_dflt (def, name, domain, (DB_DOMAIN *) 0, default_value, ID_SHARED_ATTRIBUTE, NULL);
+  error = smt_add_attribute_w_dflt (def, name, domain, (DB_DOMAIN *) 0, default_value, ID_SHARED_ATTRIBUTE, NULL, NULL);
 
   return (error);
 }
@@ -321,7 +321,7 @@ dbt_add_class_attribute (DB_CTMPL * def, const char *name, const char *domain, D
   CHECK_3ARGS_ERROR (def, name, domain);
   CHECK_MODIFICATION_ERROR ();
 
-  error = smt_add_attribute_w_dflt (def, name, domain, (DB_DOMAIN *) 0, default_value, ID_CLASS_ATTRIBUTE, NULL);
+  error = smt_add_attribute_w_dflt (def, name, domain, (DB_DOMAIN *) 0, default_value, ID_CLASS_ATTRIBUTE, NULL, NULL);
 
   return (error);
 }

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -6732,7 +6732,7 @@ classobj_copy_attribute_like (DB_CTMPL * ctemplate, SM_ATTRIBUTE * attribute, co
   error =
     smt_add_attribute_w_dflt (ctemplate, attribute->header.name, NULL, attribute->domain,
 			      &attribute->default_value.value, attribute->header.name_space,
-			      &attribute->default_value.default_expr);
+			      &attribute->default_value.default_expr, attribute->comment);
   if (error != NO_ERROR)
     {
       return error;

--- a/src/object/schema_template.c
+++ b/src/object/schema_template.c
@@ -957,11 +957,11 @@ smt_quit (SM_TEMPLATE * template_)
 int
 smt_add_attribute_w_dflt_w_order (DB_CTMPL * def, const char *name, const char *domain_string, DB_DOMAIN * domain,
 				  DB_VALUE * default_value, const SM_NAME_SPACE name_space, const bool add_first,
-				  const char *add_after_attribute, DB_DEFAULT_EXPR * default_expr)
+				  const char *add_after_attribute, DB_DEFAULT_EXPR * default_expr, const char *comment)
 {
   int error = NO_ERROR;
 
-  error = smt_add_attribute_any (def, name, domain_string, domain, name_space, add_first, add_after_attribute);
+  error = smt_add_attribute_any (def, name, domain_string, domain, name_space, add_first, add_after_attribute, comment);
   if (error == NO_ERROR && default_value != NULL)
     {
       error =
@@ -981,13 +981,15 @@ smt_add_attribute_w_dflt_w_order (DB_CTMPL * def, const char *name, const char *
  *   default_value(in):
  *   name_space(in): attribute name_space (class, instance, or shared)
  *   default_expr(in): default expression
+ *   comment(in): attribute comment
  */
 int
 smt_add_attribute_w_dflt (DB_CTMPL * def, const char *name, const char *domain_string, DB_DOMAIN * domain,
-			  DB_VALUE * default_value, const SM_NAME_SPACE name_space, DB_DEFAULT_EXPR * default_expr)
+			  DB_VALUE * default_value, const SM_NAME_SPACE name_space, DB_DEFAULT_EXPR * default_expr,
+			  const char *comment)
 {
   return smt_add_attribute_w_dflt_w_order (def, name, domain_string, domain, default_value, name_space, false, NULL,
-					   default_expr);
+					   default_expr, comment);
 }
 
 /*
@@ -1011,7 +1013,8 @@ smt_add_attribute_w_dflt (DB_CTMPL * def, const char *name, const char *domain_s
 
 int
 smt_add_attribute_any (SM_TEMPLATE * template_, const char *name, const char *domain_string, DB_DOMAIN * domain,
-		       const SM_NAME_SPACE name_space, const bool add_first, const char *add_after_attribute)
+		       const SM_NAME_SPACE name_space, const bool add_first, const char *add_after_attribute,
+		       const char *comment)
 {
   int error_code = NO_ERROR;
   SM_ATTRIBUTE *att = NULL;
@@ -1092,6 +1095,7 @@ smt_add_attribute_any (SM_TEMPLATE * template_, const char *name, const char *do
       error_code = er_errid ();
       goto error_exit;
     }
+  att->comment = ws_copy_string (comment);
 
   /* Flag this attribute as new so that we can initialize the original_value properly.  Make sure this isn't saved on
    * disk ! */
@@ -1189,7 +1193,7 @@ error_exit:
 int
 smt_add_attribute (SM_TEMPLATE * template_, const char *name, const char *domain_string, DB_DOMAIN * domain)
 {
-  return (smt_add_attribute_any (template_, name, domain_string, domain, ID_ATTRIBUTE, false, NULL));
+  return (smt_add_attribute_any (template_, name, domain_string, domain, ID_ATTRIBUTE, false, NULL, NULL));
 }
 
 /*

--- a/src/object/schema_template.h
+++ b/src/object/schema_template.h
@@ -51,16 +51,17 @@ extern SM_CLASS_TYPE smt_get_class_type (SM_TEMPLATE * template_);
 /* Attribute definition */
 extern int smt_add_attribute_w_dflt (DB_CTMPL * def, const char *name, const char *domain_string, DB_DOMAIN * domain,
 				     DB_VALUE * default_value, const SM_NAME_SPACE name_space,
-				     DB_DEFAULT_EXPR * default_expr);
+				     DB_DEFAULT_EXPR * default_expr, const char *comment);
 
 extern int smt_add_attribute_w_dflt_w_order (DB_CTMPL * def, const char *name, const char *domain_string,
 					     DB_DOMAIN * domain, DB_VALUE * default_value,
 					     const SM_NAME_SPACE name_space, const bool add_first,
-					     const char *add_after_attribute, DB_DEFAULT_EXPR * default_expr);
+					     const char *add_after_attribute, DB_DEFAULT_EXPR * default_expr,
+					     const char *comment);
 
 extern int smt_add_attribute_any (SM_TEMPLATE * template_, const char *name, const char *domain_string,
 				  DB_DOMAIN * domain, const SM_NAME_SPACE name_space, const bool add_first,
-				  const char *add_after_attribute);
+				  const char *add_after_attribute, const char *comment);
 
 extern int smt_add_attribute (SM_TEMPLATE * template_, const char *name, const char *domain_string, DB_DOMAIN * domain);
 

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -7160,9 +7160,8 @@ do_add_attribute_from_select_column (PARSER_CONTEXT * parser, DB_CTMPL * ctempla
 	}
     }
 
-  error =
-    smt_add_attribute_w_dflt (ctemplate, attr_name, NULL, column->domain, &default_value, ID_ATTRIBUTE, default_expr,
-			      NULL);
+  error = smt_add_attribute_w_dflt (ctemplate, attr_name, NULL, column->domain, &default_value, ID_ATTRIBUTE,
+				    default_expr, NULL);
   if (error != NO_ERROR)
     {
       goto error_exit;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -7032,7 +7032,7 @@ do_add_attribute (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * attri
 
   error =
     smt_add_attribute_w_dflt_w_order (ctemplate, attr_name, NULL, attr_db_domain, default_value, name_space, add_first,
-				      add_after_attr, &default_expr);
+				      add_after_attr, &default_expr, NULL);
 
   db_value_clear (&stack_value);
 
@@ -7161,7 +7161,8 @@ do_add_attribute_from_select_column (PARSER_CONTEXT * parser, DB_CTMPL * ctempla
     }
 
   error =
-    smt_add_attribute_w_dflt (ctemplate, attr_name, NULL, column->domain, &default_value, ID_ATTRIBUTE, default_expr);
+    smt_add_attribute_w_dflt (ctemplate, attr_name, NULL, column->domain, &default_value, ID_ATTRIBUTE, default_expr,
+			      NULL);
   if (error != NO_ERROR)
     {
       goto error_exit;
@@ -8739,6 +8740,14 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	  if (!reuse_oid && (source_class->flags & SM_CLASSFLAG_REUSE_OID))
 	    {
 	      reuse_oid = true;
+	    }
+	  if (source_class->comment)
+	    {
+	      error = sm_set_class_comment (class_obj, source_class->comment);
+	      if (error != NO_ERROR)
+		{
+		  break;
+		}
 	    }
 	}
       if (locator_create_heap_if_needed (class_obj, reuse_oid) == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21567 "The comment does not be copied when creating table using "create table ... like" statement."

Both table and columns comments were ignored during CREATE TABLE Like ...
