### PR TITLE
[CBRD-21711] 10.1p1: Fix IO expand extra page (#897)

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2567,7 +2567,7 @@ fileio_expand_to (THREAD_ENTRY * thread_p, VOLID vol_id, DKNPAGES size_npages, D
   (void) fileio_initialize_res (thread_p, &(io_page_p->prv));
 
   start_pageid = (PAGEID) (current_size / IO_PAGESIZE);
-  last_pageid = (PAGEID) (new_size / IO_PAGESIZE);
+  last_pageid = ((PAGEID) (new_size / IO_PAGESIZE) - 1);
 
   if (voltype == DB_TEMPORARY_VOLTYPE)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21711

Fix fileio_expand_to adding one extra-page.