### PR TITLE
[CBRD-21703] 10.1p1: avoid vacuums purging log archives (#902)

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -705,9 +705,6 @@ xvacuum (THREAD_ENTRY * thread_p)
   /* Process vacuum data and run vacuum . */
   vacuum_process_vacuum_data (thread_p);
 
-  /* remove archives that have been prevented from being removed up until now. */
-  logpb_remove_archive_logs_exceed_limit (thread_p, 0);
-
   VACUUM_RESTORE_THREAD (thread_p, dummy_save_type);
 
   return NO_ERROR;
@@ -5619,7 +5616,6 @@ vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p)
     {
       /* remove archives that have been blocked up to this point. */
       vacuum_Data.is_archive_removal_safe = true;
-      logpb_remove_archive_logs_exceed_limit (thread_p, 0);
     }
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21703

This is a quick fix to avoid potential regressions.