### PR TITLE
[CBRD-21253] Sync after flushing log

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3861,6 +3861,13 @@ logpb_append_next_record (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * node)
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "logpb_append_next_record");
     }
 
+  /* forcing flush in the middle of log record append is a complicated business. try to avoid it if possible. */
+  if (log_Gl.flush_info.num_toflush + 1 >= log_Gl.flush_info.max_toflush)	/* flush will be forced on next page */
+    {
+      /* flush early to avoid complicated case */
+      logpb_flush_all_append_pages (thread_p);
+    }
+
   logpb_start_append (thread_p, &node->log_header);
 
   if (node->data_header != NULL)
@@ -4488,6 +4495,13 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	  goto error;
 	}
       ++flush_page_count;
+
+      /* we need to also sync again */
+      if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active) == NULL_VOLDES)
+	{
+	  error_code = ER_FAILED;
+	  goto error;
+	}
 
       /* now we can set the nxio_lsa to append_lsa */
       logpb_set_nxio_lsa (&log_Gl.hdr.append_lsa);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21253

This issue was a very particular case hard to reproduce. Sometimes flush is forced while a log record is partially appended, and the case is handled like this:

  1. Replace log record header with end of log record.
  2. Flush all pages & synchronize active log file.
  3. Finish appending log record.
  4. Flush all pages & synchronize active log file.
  5. Restore log record header and flush page again.

You may notice that after restoring log header, active log file was not synchronized. This patch fixes it.

Our suspicion in this JIRA issue is that the interrupted log record is undo of RVDK_FORMAT. Log is flushed & synchronized without RVDK_FORMAT log header, and then flushed with RVDK_FORMAT but without synchronizing.

Then new volume is created (which is also created and disk without calling synchronize) and test case randomly kills process. The new empty volume survives after recovery.

Since this case is complicated and has an additional expensive sync call, I try to avoid it by forcing log flush one page early at the start of a new log record rather than risking flushing partial log record.