### PR TITLE
[CBRD-21727] Use of 32bit time_t for Win32 build (_USE_32BIT_TIME_T)

### DIFF
--- a/cm_common/CMakeLists.txt
+++ b/cm_common/CMakeLists.txt
@@ -39,6 +39,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
 elseif(WIN32)
   set_target_properties(cmstat PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_SOURCE_DIR}/win/cmstat/cmstat.def\"")
   target_link_libraries(cmstat LINK_PRIVATE ws2_32 psapi cubridcs)
+  if(TARGET_PLATFORM_BITS EQUAL 32)
+    target_compile_definitions(cmstat PRIVATE _USE_32BIT_TIME_T)
+  endif(TARGET_PLATFORM_BITS EQUAL 32)
 endif()
 
 
@@ -58,6 +61,9 @@ target_link_libraries(cmdep LINK_PRIVATE cubridcs)
 if(WIN32)
   set_target_properties(cmdep PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_SOURCE_DIR}/win/cmdep/cmdep.def\"")
   target_link_libraries(cmdep LINK_PRIVATE ws2_32)
+  if(TARGET_PLATFORM_BITS EQUAL 32)
+    target_compile_definitions(cmdep PRIVATE _USE_32BIT_TIME_T)
+  endif(TARGET_PLATFORM_BITS EQUAL 32)
 endif()
 
 


### PR DESCRIPTION
http://www.jira.cubrid.org/browse/CBRD-21727

* Changed cm_common/CMakeLists.txt to use 32bit time_t in Win32 Build
* We did QA inside our organization for CMS behavior & passed (Win32 build only)