### PR TITLE
[CBRD-21732] Solve memory leak from early out

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -7285,11 +7285,10 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 	case DB_JSON_STRING:
 	  {
-	    char *json_string_copy = NULL;
+	    const char *json_string = NULL;
 
-	    json_string_copy = db_json_copy_string_from_document (src_doc);
-	    db_make_string (&src_replacement, json_string_copy);
-	    src_replacement.need_clear = true;
+	    json_string = db_json_get_string_from_document (src_doc);
+	    db_make_string (&src_replacement, json_string);
 	  }
 	  break;
 	default:
@@ -10522,8 +10521,6 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       status = DOMAIN_INCOMPATIBLE;
       break;
     }
-
-  pr_clear_value (&src_replacement);
 
   if (err < 0)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21732

There are some early outs that prevent the deletion of memory, so I simply don't perform the copy, but rather use the already allocated pointer which gets dealt with later. Not sure why I performed the copy in the first place.

There is one test, json_set_variables.sql, that will fail, but it will be resolved after merging https://github.com/CUBRID/cubrid/pull/919