### PR TITLE
[CBRD-21734] or_overflow jump causes memory leaks

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -17472,12 +17472,6 @@ mr_data_writeval_json (OR_BUF * buf, DB_VALUE * value)
     {
       int estimated_length = mr_data_lengthval_json (value, true);
 
-      /* in case of string compression, buffer will hold
-       * 0xFF int int as first bytes, so we need to take them
-       * in consideration
-       */
-      estimated_length += sizeof (char) + sizeof (int) * 2;
-
       if (estimated_length > buf->endptr - buf->ptr)
 	{
 	  /* this will make string_data_writeval jump because

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -17472,7 +17472,7 @@ mr_data_writeval_json (OR_BUF * buf, DB_VALUE * value)
     {
       int estimated_length = mr_data_lengthval_json (value, true);
 
-      if (estimated_length > buf->endptr - buf->ptr)
+      if ((ptrdiff_t) estimated_length > ((ptrdiff_t) (buf->endptr - buf->ptr)))
 	{
 	  /* this will make string_data_writeval jump because
 	   * of buffer overflow, leaking memory in the process,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21734

Because of the way mr_writeval_string treats errors, I was left with memory leaks. I simply treat the error in the same function to avoid memory leaks.