### PR TITLE
[CBRD-21731] added DB_JSON_BOOL type

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -128,9 +128,10 @@ static DB_JSON_TYPE db_json_get_type_of_value (const JSON_VALUE *val);
 static bool db_json_value_has_numeric_type (const JSON_VALUE *doc);
 static int db_json_get_int_from_value (const JSON_VALUE *val);
 static double db_json_get_double_from_value (const JSON_VALUE *doc);
-static const char *db_json_get_string_from_value (const JSON_VALUE *doc, bool copy);
-static const char *db_json_get_bool_as_str_from_value (const JSON_VALUE *doc, bool copy);
-STATIC_INLINE const char *const db_json_bool_to_string (bool b);
+static const char *db_json_get_string_from_value (const JSON_VALUE *doc);
+static char *db_json_copy_string_from_value (const JSON_VALUE *doc);
+static char *db_json_get_bool_as_str_from_value (const JSON_VALUE *doc);
+STATIC_INLINE char *db_json_bool_to_string (bool b);
 static void db_json_merge_two_json_objects (JSON_DOC &obj1, const JSON_DOC *obj2);
 static void db_json_merge_two_json_arrays (JSON_DOC &array1, const JSON_DOC *array2);
 static void db_json_merge_two_json_by_array_wrapping (JSON_DOC &j1, const JSON_DOC *j2);
@@ -1077,25 +1078,19 @@ db_json_get_double_from_document (const JSON_DOC *doc)
 const char *
 db_json_get_string_from_document (const JSON_DOC *doc)
 {
-  return db_json_get_string_from_value (doc, false);
+  return db_json_get_string_from_value (doc);
 }
 
-const char *
+char *
 db_json_get_bool_as_str_from_document (const JSON_DOC *doc)
 {
-  return db_json_get_bool_as_str_from_value (doc, false);
+  return db_json_get_bool_as_str_from_value (doc);
 }
 
 char *
 db_json_copy_string_from_document (const JSON_DOC *doc)
 {
-  return const_cast <char *> (db_json_get_string_from_value (doc, true));
-}
-
-char *
-db_json_copy_bool_as_str_from_document (const JSON_DOC *doc)
-{
-  return const_cast <char *> (db_json_get_bool_as_str_from_value (doc, true));
+  return db_json_copy_string_from_value (doc);
 }
 
 int
@@ -1128,7 +1123,7 @@ db_json_get_double_from_value (const JSON_VALUE *doc)
 }
 
 const char *
-db_json_get_string_from_value (const JSON_VALUE *doc, bool copy)
+db_json_get_string_from_value (const JSON_VALUE *doc)
 {
   if (doc == NULL)
     {
@@ -1138,24 +1133,30 @@ db_json_get_string_from_value (const JSON_VALUE *doc, bool copy)
 
   assert (db_json_get_type_of_value (doc) == DB_JSON_STRING);
 
-  if (copy)
-    {
-      return db_private_strdup (NULL, doc->GetString ());
-    }
-  else
-    {
-      return doc->GetString ();
-    }
+  return doc->GetString();
 }
 
-STATIC_INLINE const char *const
+char *
+db_json_copy_string_from_value (const JSON_VALUE *doc)
+{
+  if (doc == NULL)
+    {
+      assert (false);
+      return NULL;
+    }
+
+  assert (db_json_get_type_of_value (doc) == DB_JSON_STRING);
+  return db_private_strdup (NULL, doc->GetString());
+}
+
+STATIC_INLINE char *
 db_json_bool_to_string (bool b)
 {
-  return b ? "true" : "false";
+  return b ? db_private_strdup (NULL, "true") : db_private_strdup (NULL, "false");
 }
 
-const char *
-db_json_get_bool_as_str_from_value (const JSON_VALUE *doc, bool copy)
+char *
+db_json_get_bool_as_str_from_value (const JSON_VALUE *doc)
 {
   if (doc == NULL)
     {
@@ -1164,15 +1165,7 @@ db_json_get_bool_as_str_from_value (const JSON_VALUE *doc, bool copy)
     }
 
   assert (db_json_get_type_of_value (doc) == DB_JSON_BOOL);
-
-  if (copy)
-    {
-      return db_private_strdup (NULL, db_json_bool_to_string (doc->GetBool()));
-    }
-  else
-    {
-      return db_json_bool_to_string (doc->GetBool());
-    }
+  return db_json_bool_to_string (doc->GetBool());
 }
 
 bool

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1056,13 +1056,19 @@ db_json_get_string_from_document (const JSON_DOC *doc)
 const char *
 db_json_get_bool_as_str_from_document (const JSON_DOC *doc)
 {
-  return const_cast <char *> (db_json_get_bool_as_str_from_value (doc, true));
+  return db_json_get_bool_as_str_from_value (doc, false);
 }
 
 char *
 db_json_copy_string_from_document (const JSON_DOC *doc)
 {
   return const_cast <char *> (db_json_get_string_from_value (doc, true));
+}
+
+char *
+db_json_copy_bool_as_str_from_document (const JSON_DOC *doc)
+{
+  return const_cast <char *> (db_json_get_bool_as_str_from_value (doc, true));
 }
 
 int

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -130,7 +130,7 @@ static int db_json_get_int_from_value (const JSON_VALUE *val);
 static double db_json_get_double_from_value (const JSON_VALUE *doc);
 static const char *db_json_get_string_from_value (const JSON_VALUE *doc, bool copy);
 static const char *db_json_get_bool_as_str_from_value (const JSON_VALUE *doc, bool copy);
-static inline const char *const bool_to_string (bool b);
+STATIC_INLINE const char *const db_json_bool_to_string (bool b);
 
 JSON_VALIDATOR::JSON_VALIDATOR (const char *schema_raw) : m_schema (NULL),
   m_validator (NULL),
@@ -1121,7 +1121,8 @@ db_json_get_string_from_value (const JSON_VALUE *doc, bool copy)
     }
 }
 
-inline const char *const bool_to_string (bool b)
+STATIC_INLINE const char *const
+db_json_bool_to_string (bool b)
 {
   return b ? "true" : "false";
 }
@@ -1139,11 +1140,11 @@ db_json_get_bool_as_str_from_value (const JSON_VALUE *doc, bool copy)
 
   if (copy)
     {
-      return db_private_strdup (NULL, bool_to_string (doc->GetBool()));
+      return db_private_strdup (NULL, db_json_bool_to_string (doc->GetBool()));
     }
   else
     {
-      return bool_to_string (doc->GetBool());
+      return db_json_bool_to_string (doc->GetBool());
     }
 }
 

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -52,6 +52,7 @@ enum DB_JSON_TYPE
   DB_JSON_STRING,
   DB_JSON_OBJECT,
   DB_JSON_ARRAY,
+  DB_JSON_BOOL,
 };
 
 /* C functions */
@@ -60,7 +61,7 @@ const char *db_json_get_type_as_str (const JSON_DOC *document);
 unsigned int db_json_get_length (const JSON_DOC *document);
 unsigned int db_json_get_depth (const JSON_DOC *doc);
 int db_json_extract_document_from_path (JSON_DOC *document, const char *raw_path,
-                                        JSON_DOC *&result);
+					JSON_DOC *&result);
 char *db_json_get_raw_json_body_from_document (const JSON_DOC *doc);
 JSON_DOC *db_json_get_paths_for_search_func (const JSON_DOC *doc, const char *search_str, bool all);
 
@@ -103,6 +104,8 @@ DB_JSON_TYPE db_json_get_type (const JSON_DOC *doc);
 int db_json_get_int_from_document (const JSON_DOC *doc);
 double db_json_get_double_from_document (const JSON_DOC *doc);
 const char *db_json_get_string_from_document (const JSON_DOC *doc);
+const char *db_json_get_bool_as_str_from_document (const JSON_DOC *doc);
+char *db_json_get_bool_as_str_from_document_with_copy (const JSON_DOC *doc);
 char *db_json_copy_string_from_document (const JSON_DOC *doc);
 
 void db_json_set_string_to_doc (JSON_DOC *doc, const char *str);

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -105,7 +105,7 @@ int db_json_get_int_from_document (const JSON_DOC *doc);
 double db_json_get_double_from_document (const JSON_DOC *doc);
 const char *db_json_get_string_from_document (const JSON_DOC *doc);
 const char *db_json_get_bool_as_str_from_document (const JSON_DOC *doc);
-char *db_json_get_bool_as_str_from_document_with_copy (const JSON_DOC *doc);
+char *db_json_copy_bool_as_str_from_document (const JSON_DOC *doc);
 char *db_json_copy_string_from_document (const JSON_DOC *doc);
 
 void db_json_set_string_to_doc (JSON_DOC *doc, const char *str);

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -99,8 +99,7 @@ DB_JSON_TYPE db_json_get_type (const JSON_DOC *doc);
 int db_json_get_int_from_document (const JSON_DOC *doc);
 double db_json_get_double_from_document (const JSON_DOC *doc);
 const char *db_json_get_string_from_document (const JSON_DOC *doc);
-const char *db_json_get_bool_as_str_from_document (const JSON_DOC *doc);
-char *db_json_copy_bool_as_str_from_document (const JSON_DOC *doc);
+char *db_json_get_bool_as_str_from_document (const JSON_DOC *doc);
 char *db_json_copy_string_from_document (const JSON_DOC *doc);
 
 void db_json_set_string_to_doc (JSON_DOC *doc, const char *str);

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -6949,7 +6949,7 @@ db_convert_json_into_scalar (const DB_VALUE * src, DB_VALUE * dest)
       }
     case DB_JSON_BOOL:
       {
-	const char *str = db_json_get_bool_as_str_from_document (doc);
+	char *str = db_json_get_bool_as_str_from_document (doc);
 	int error_code = DB_MAKE_STRING (dest, str);
 	if (error_code != NO_ERROR)
 	  {

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -6947,6 +6947,17 @@ db_convert_json_into_scalar (const DB_VALUE * src, DB_VALUE * dest)
 	DB_MAKE_DOUBLE (dest, val);
 	break;
       }
+    case DB_JSON_BOOL:
+      {
+	const char *str = db_json_get_bool_as_str_from_document (doc);
+	int error_code = DB_MAKE_STRING (dest, str);
+	if (error_code != NO_ERROR)
+	  {
+	    ASSERT_ERROR ();
+	    return error_code;
+	  }
+	break;
+      }
     case DB_JSON_NULL:
       DB_MAKE_NULL (dest);
       break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21731

Added DB_JSON_BOOL type because we need it for the comparison in 'order by' statement.

The bool type will be converted to string scalar for further comparison. Also, because of the copy parameter when getting the string from value we need to be careful in order to avoid a memory leak. So, I used two functions to get a const char* or char* (with copy).


