### PR TITLE
[CBRD-21739] Treat null case from readmem json

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1292,7 +1292,10 @@ bool db_json_are_docs_equal (const JSON_DOC *doc1, const JSON_DOC *doc2)
 void
 db_json_make_document_null (JSON_DOC *doc)
 {
-  doc->SetNull ();
+  if (doc != NULL)
+    {
+      doc->SetNull ();
+    }
 }
 
 bool db_json_doc_has_numeric_type (const JSON_DOC *doc)

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -17300,17 +17300,24 @@ mr_data_readmem_json (OR_BUF * buf, void *memptr, TP_DOMAIN * domain, int size)
   DB_MAKE_NULL (&schema_raw);
   json = (DB_JSON *) memptr;
 
-  if (size <= 0)
-    {
-      return;
-    }
-
   if (json == NULL)
     {
       if (size)
 	{
 	  or_advance (buf, size);
 	}
+      return;
+    }
+
+  if (size < 0)
+    {
+      assert (false);
+      return;
+    }
+
+  if (size == 0)
+    {
+      mr_initmem_json (memptr, domain);
       return;
     }
 

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -17300,6 +17300,11 @@ mr_data_readmem_json (OR_BUF * buf, void *memptr, TP_DOMAIN * domain, int size)
   DB_MAKE_NULL (&schema_raw);
   json = (DB_JSON *) memptr;
 
+  if (size <= 0)
+    {
+      return;
+    }
+
   if (json == NULL)
     {
       if (size)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21739

The case where a null JSON is read (size = 0 from the offset table) was not treated, this generating a buffer underflow.