### PR TITLE
[CBRD-21738] Fix memory leak in XASL node

### DIFF
--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -6885,17 +6885,8 @@ or_get_value (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int expected, 
 	    }
 	  else if (TP_DOMAIN_TYPE (domain) == DB_TYPE_JSON)
 	    {
-	      if (domain->json_validator == NULL)
-		{
-		  value->data.json.schema_raw = NULL;
-		}
-	      else
-		{
-		  const char *s;
-
-		  s = db_json_get_schema_raw_from_validator (domain->json_validator);
-		  value->data.json.schema_raw = s;
-		}
+	      /* TODO find if schema_raw set here is ever used */
+	      value->data.json.schema_raw = NULL;
 	    }
 	}
       else

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -6891,9 +6891,9 @@ or_get_value (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int expected, 
 		}
 	      else
 		{
-		  char *s;
+		  const char *s;
 
-		  s = db_private_strdup (NULL, db_json_get_schema_raw_from_validator (domain->json_validator));
+		  s = db_json_get_schema_raw_from_validator (domain->json_validator);
 		  value->data.json.schema_raw = s;
 		}
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21738

It isn't expected that the value from stx_build_val_list->stx_restore_db_value will be deleted, so cloning it results in a mem leak. We now simply make the pointer of the schema_raw null because it is not used when only creating a temporary container for the next dbvalue.