### PR TITLE
[CBRD-21741] Mismatched free/delete

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -159,7 +159,7 @@ JSON_VALIDATOR::~JSON_VALIDATOR (void)
 
   if (m_schema_raw != NULL)
     {
-      delete[] m_schema_raw;
+      free (m_schema_raw);
       m_schema_raw = NULL;
     }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21741

m_schema_raw is created using strdup, so free() has to be used