### PR TITLE
[CBRD-21743] [Regression] fail to alter table add FOREIGN KEY constraint

### DIFF
--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -3838,22 +3838,11 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
   while (true)
     {
       ret = btree_advance_to_next_slot_and_fix_page (thread_p, sort_args->btid, &vpid, &curr_fk_pageptr, &fk_slot_id,
-						     &fk_key, is_fk_scan_desc, &fk_node_key_cnt, &fk_node_header, NULL);
+						     &fk_key, is_fk_scan_desc, &fk_node_key_cnt, &fk_node_header,
+                                                     &mvcc_snapshot_dirty);
       if (ret != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
-	  break;
-	}
-
-      /* Check if the foreign key has any items visible. If not, early out. */
-      ret = btree_has_any_visible (thread_p, sort_args->btid, curr_fk_pageptr, &mvcc_snapshot_dirty, &fk_has_visible);
-      if (ret != NO_ERROR)
-	{
-	  break;
-	}
-
-      if (!fk_has_visible)
-	{
 	  break;
 	}
 

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -182,8 +182,8 @@ static int btree_advance_to_next_slot_and_fix_page (THREAD_ENTRY * thread_p, BTI
 						    int *key_cnt, BTREE_NODE_HEADER ** header, MVCC_SNAPSHOT * mvcc);
 static int btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args_local,
 				const SORT_ARGS * sort_args_local);
-static int btree_has_any_visible (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pg_ptr,
-				  MVCC_SNAPSHOT * mvcc_snapshot, bool * has_visible);
+static int btree_is_slot_visible (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pg_ptr,
+				  MVCC_SNAPSHOT * mvcc_snapshot, int slot_id, bool * has_visible);
 
 /*
  * btree_get_node_header () -
@@ -3729,7 +3729,7 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
   INDX_SCAN_ID pk_isid;
   BTREE_SCAN pk_bt_scan;
   INT16 fk_slot_id = -1;
-  bool found = false, pk_has_visible = false, fk_has_visible = false;
+  bool found = false, pk_has_slot_visible = false, fk_has_visible = false;
   char *val_print = NULL;
   bool is_fk_scan_desc = false;
   MVCC_SNAPSHOT mvcc_snapshot_dirty;
@@ -3839,7 +3839,7 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
     {
       ret = btree_advance_to_next_slot_and_fix_page (thread_p, sort_args->btid, &vpid, &curr_fk_pageptr, &fk_slot_id,
 						     &fk_key, is_fk_scan_desc, &fk_node_key_cnt, &fk_node_header,
-                                                     &mvcc_snapshot_dirty);
+						     &mvcc_snapshot_dirty);
       if (ret != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -3974,14 +3974,14 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
 		}
 
 	      /* Make sure there is at least one visible object. */
-	      ret = btree_has_any_visible (thread_p, &pk_bt_scan.btid_int, pk_bt_scan.C_page, &mvcc_snapshot_dirty,
-					   &pk_has_visible);
+	      ret = btree_is_slot_visible (thread_p, &pk_bt_scan.btid_int, pk_bt_scan.C_page, &mvcc_snapshot_dirty,
+					   pk_bt_scan.slot_id, &pk_has_slot_visible);
 	      if (ret != NO_ERROR)
 		{
 		  break;
 		}
 
-	      if (!pk_has_visible)
+	      if (!pk_has_slot_visible)
 		{
 		  /* No visible object in current page, but the key was located here. Should not happen often. */
 		  val_print = pr_valstring (&fk_key);
@@ -4188,7 +4188,7 @@ btree_advance_to_next_slot_and_fix_page (THREAD_ENTRY * thread_p, BTID_INT * bti
   VPID next_vpid;
   PAGE_PTR page = *pg_ptr;
   BTREE_NODE_HEADER *local_header = *header;
-  bool has_visible = false;
+  bool is_slot_visible = false;
   PAGE_PTR old_page = NULL;
 
   /* Clear current key, if any. */
@@ -4272,19 +4272,19 @@ btree_advance_to_next_slot_and_fix_page (THREAD_ENTRY * thread_p, BTID_INT * bti
 
       if (mvcc != NULL)
 	{
-	  ret = btree_has_any_visible (thread_p, btid, page, mvcc, &has_visible);
+	  ret = btree_is_slot_visible (thread_p, btid, page, mvcc, *slot_id, &is_slot_visible);
 	  if (ret != NO_ERROR)
 	    {
 	      return ret;
 	    }
 
-	  if (!has_visible)
+	  if (!is_slot_visible)
 	    {
 	      continue;
 	    }
 	}
 
-      /* We have visible items. Fall through and get the key. */
+      /* The slot is visible. Fall through and get the key. */
       break;
     }
 
@@ -4300,19 +4300,20 @@ btree_advance_to_next_slot_and_fix_page (THREAD_ENTRY * thread_p, BTID_INT * bti
 }
 
 /*
- *  btree_has_any_visible(): States if the page has any visible oids.
+ *  btree_is_slot_visible(): States if current slot is visible or not.
  *
  *  thread_p(in): Thread entry.
  *  btid(in): B-tree info.
  *  pg_ptr(in):	Page pointer.
  *  mvcc_snapshot(in): The MVCC snapshot.
- *  has_visible(out): True or False
+ *  slot_id(in) : Slot id to be looked for.
+ *  is_visible(out): True or False
  *
  *  return: error code if any error occurs.
  */
 static int
-btree_has_any_visible (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pg_ptr, MVCC_SNAPSHOT * mvcc_snapshot,
-		       bool * has_visible)
+btree_is_slot_visible (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pg_ptr, MVCC_SNAPSHOT * mvcc_snapshot,
+		       int slot_id, bool * is_visible)
 {
   RECDES record;
   LEAF_REC leaf;
@@ -4321,17 +4322,17 @@ btree_has_any_visible (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pg_ptr
   int ret = NO_ERROR;
   bool dummy_clear_key;
 
-  *has_visible = false;
+  *is_visible = false;
 
   if (mvcc_snapshot == NULL)
     {
       /* Early out. */
-      *has_visible = true;
+      *is_visible = true;
       return ret;
     }
 
   /* Get the record. */
-  if (spage_get_record (thread_p, pg_ptr, 1, &record, PEEK) != S_SUCCESS)
+  if (spage_get_record (thread_p, pg_ptr, slot_id, &record, PEEK) != S_SUCCESS)
     {
       assert_release (false);
       ret = ER_FAILED;
@@ -4357,7 +4358,7 @@ btree_has_any_visible (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pg_ptr
 
   if (num_visible > 0)
     {
-      *has_visible = true;
+      *is_visible = true;
     }
 
   return ret;

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -183,7 +183,7 @@ static int btree_advance_to_next_slot_and_fix_page (THREAD_ENTRY * thread_p, BTI
 static int btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args_local,
 				const SORT_ARGS * sort_args_local);
 static int btree_is_slot_visible (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pg_ptr,
-				  MVCC_SNAPSHOT * mvcc_snapshot, int slot_id, bool * has_visible);
+				  MVCC_SNAPSHOT * mvcc_snapshot, int slot_id, bool * is_slot_visible);
 
 /*
  * btree_get_node_header () -

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -3779,12 +3779,6 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
       goto end;
     }
 
-  if (ret != NO_ERROR)
-    {
-      ASSERT_ERROR ();
-      goto end;
-    }
-
   /* Set the order. */
   is_fk_scan_desc = (sort_args->key_type->is_desc != pk_bt_scan.btid_int.key_type->is_desc);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21743

This is a slip of checking the visibility of keys in their respective btree. Before, it would check if the first record had any visible keys. It is now chaged, by checking if the record has any visible key regarding to the respective `slot_id`.