### PR TITLE
[CBRD-21645] restore uses the current log files if exists

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -5591,7 +5591,7 @@ fileio_make_log_active_name (char *log_active_name_p, const char *log_path_p, co
 }
 
 /*
- * fileio_make_log_active_temp_name () - Build the name of volumes
+ * fileio_make_temp_log_files_from_backup () - Build the name of volumes
  *   return: void
  *   logactive_name(out):
  *   level(in):
@@ -5602,9 +5602,23 @@ fileio_make_log_active_name (char *log_active_name_p, const char *log_path_p, co
  *       DB_MAX_PATH_LENGTH length.
  */
 void
-fileio_make_log_active_temp_name (char *log_active_name_p, FILEIO_BACKUP_LEVEL level, const char *active_name_p)
+fileio_make_temp_log_files_from_backup (char *temp_log_name, VOLID to_volid, FILEIO_BACKUP_LEVEL level,
+					const char *base_log_name)
 {
-  sprintf (log_active_name_p, "%s_%03d_tmp", active_name_p, level);
+  switch (to_volid)
+    {
+    case LOG_DBLOG_ACTIVE_VOLID:
+      sprintf (temp_log_name, "%s_%03d_tmp", base_log_name, level);
+      break;
+    case LOG_DBLOG_INFO_VOLID:
+      sprintf (temp_log_name, "%s_%03d_tmp", base_log_name, level);
+      break;
+    case LOG_DBLOG_ARCHIVE_VOLID:
+      sprintf (temp_log_name, "%s_%03d_tmp", base_log_name, level);
+      break;
+    default:
+      break;
+    }
 }
 
 /*

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -456,8 +456,8 @@ extern void fileio_make_volume_ext_given_name (char *volext_fullname, const char
 extern void fileio_make_volume_temp_name (char *voltmp_fullname, const char *tmp_path, const char *tmp_name,
 					  VOLID volid);
 extern void fileio_make_log_active_name (char *logactive_name, const char *log_path, const char *dbname);
-extern void fileio_make_log_active_temp_name (char *logactive_tmpname, FILEIO_BACKUP_LEVEL level,
-					      const char *active_name);
+extern void fileio_make_temp_log_files_from_backup (char *temp_log_name, VOLID volid, FILEIO_BACKUP_LEVEL level,
+						    const char *base_log_name);
 extern void fileio_make_log_archive_name (char *logarchive_name, const char *log_path, const char *dbname, int arvnum);
 extern void fileio_make_removed_log_archive_name (char *logarchive_name, const char *log_path, const char *dbname);
 extern void fileio_make_log_archive_temp_name (char *log_archive_temp_name_p, const char *log_path_p,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21645

Restore uses the current log files (active/archive logs and log info) if exists. Otherwise, does them from backup volume.
The current files are more recent ones than those from backup volume. 