### PR TITLE
[CBRD-21645] restore uses the current log files if exists (#929)

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -5582,7 +5582,7 @@ fileio_make_log_active_name (char *log_active_name_p, const char *log_path_p, co
 }
 
 /*
- * fileio_make_log_active_temp_name () - Build the name of volumes
+ * fileio_make_temp_log_files_from_backup () - Build the name of volumes
  *   return: void
  *   logactive_name(out):
  *   level(in):
@@ -5593,9 +5593,23 @@ fileio_make_log_active_name (char *log_active_name_p, const char *log_path_p, co
  *       DB_MAX_PATH_LENGTH length.
  */
 void
-fileio_make_log_active_temp_name (char *log_active_name_p, FILEIO_BACKUP_LEVEL level, const char *active_name_p)
+fileio_make_temp_log_files_from_backup (char *temp_log_name, VOLID to_volid, FILEIO_BACKUP_LEVEL level,
+					const char *base_log_name)
 {
-  sprintf (log_active_name_p, "%s_%03d_tmp", active_name_p, level);
+  switch (to_volid)
+    {
+    case LOG_DBLOG_ACTIVE_VOLID:
+      sprintf (temp_log_name, "%s_%03d_tmp", base_log_name, level);
+      break;
+    case LOG_DBLOG_INFO_VOLID:
+      sprintf (temp_log_name, "%s_%03d_tmp", base_log_name, level);
+      break;
+    case LOG_DBLOG_ARCHIVE_VOLID:
+      sprintf (temp_log_name, "%s_%03d_tmp", base_log_name, level);
+      break;
+    default:
+      break;
+    }
 }
 
 /*

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -454,8 +454,8 @@ extern void fileio_make_volume_ext_given_name (char *volext_fullname, const char
 extern void fileio_make_volume_temp_name (char *voltmp_fullname, const char *tmp_path, const char *tmp_name,
 					  VOLID volid);
 extern void fileio_make_log_active_name (char *logactive_name, const char *log_path, const char *dbname);
-extern void fileio_make_log_active_temp_name (char *logactive_tmpname, FILEIO_BACKUP_LEVEL level,
-					      const char *active_name);
+extern void fileio_make_temp_log_files_from_backup (char *temp_log_name, VOLID volid, FILEIO_BACKUP_LEVEL level,
+						    const char *base_log_name);
 extern void fileio_make_log_archive_name (char *logarchive_name, const char *log_path, const char *dbname, int arvnum);
 extern void fileio_make_removed_log_archive_name (char *logarchive_name, const char *log_path, const char *dbname);
 extern void fileio_make_log_archive_temp_name (char *log_archive_temp_name_p, const char *log_path_p,

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -9044,7 +9044,8 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
   time_t restore_start_time, restore_end_time;
   char time_val[CTIME_MAX];
   int loop_cnt = 0;
-  char lgat_tmpname[PATH_MAX];	/* active log temp name */
+  char tmp_logfiles_from_backup[PATH_MAX];
+  char *volume_name_p;
   struct stat stat_buf;
   int error_code = NO_ERROR, success = NO_ERROR;
   bool printtoc;
@@ -9054,9 +9055,10 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
 
   try_level = (FILEIO_BACKUP_LEVEL) r_args->level;
   start_level = try_level;
+
   memset (&session_storage, 0, sizeof (FILEIO_BACKUP_SESSION));
   memset (verbose_to_volname, 0, PATH_MAX);
-  memset (lgat_tmpname, 0, PATH_MAX);
+  memset (tmp_logfiles_from_backup, 0, PATH_MAX);
 
   LOG_CS_ENTER (thread_p);
 
@@ -9258,11 +9260,17 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
 		  strcpy (verbose_to_volname, to_volname);
 		}
 
-	      if (to_volid == LOG_DBLOG_ACTIVE_VOLID)
+	      if (to_volid == LOG_DBLOG_ACTIVE_VOLID || to_volid == LOG_DBLOG_INFO_VOLID
+		  || to_volid == LOG_DBLOG_ARCHIVE_VOLID)
 		{
 		  /* rename _lgat to _lgat_tmp name */
-		  fileio_make_log_active_temp_name (lgat_tmpname, (FILEIO_BACKUP_LEVEL) r_args->level, to_volname);
-		  strcpy (to_volname, lgat_tmpname);
+		  fileio_make_temp_log_files_from_backup (tmp_logfiles_from_backup, to_volid,
+							  (FILEIO_BACKUP_LEVEL) r_args->level, to_volname);
+		  volume_name_p = tmp_logfiles_from_backup;
+		}
+	      else
+		{
+		  volume_name_p = to_volname;
 		}
 
 	      restore_in_progress = true;
@@ -9334,8 +9342,36 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
 		}
 
 	      success =
-		fileio_restore_volume (thread_p, session, to_volname, verbose_to_volname, prev_volname, page_bitmap,
+		fileio_restore_volume (thread_p, session, volume_name_p, verbose_to_volname, prev_volname, page_bitmap,
 				       remember_pages);
+
+	      if (success != NO_ERROR)
+		{
+		  break;
+		}
+
+	      if (volume_name_p == tmp_logfiles_from_backup)
+		{
+		  /* rename temp logfiles if the current file does not exist */
+		  if (stat (to_volname, &stat_buf) != 0 && stat (tmp_logfiles_from_backup, &stat_buf) == 0)
+		    {
+		      if (to_volid == LOG_DBLOG_ACTIVE_VOLID && lgat_vdes != NULL_VOLDES)
+			{
+			  fileio_dismount (thread_p, lgat_vdes);
+			  lgat_vdes = NULL_VOLDES;
+			}
+
+		      os_rename_file (tmp_logfiles_from_backup, to_volname);
+		    }
+		  else
+		    {
+		      unlink (tmp_logfiles_from_backup);
+		    }
+
+		  tmp_logfiles_from_backup[0] = '\0';
+		}
+
+	      volume_name_p = NULL;
 	    }
 	  else if (another_vol == 0)
 	    {
@@ -9386,20 +9422,6 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
       fileio_write_backup_info_entries (backup_volinfo_fp, FILEIO_SECOND_BACKUP_VOL_INFO);
       fclose (backup_volinfo_fp);
     }
-
-  /* rename logactive tmp to logactive */
-  if (stat (log_Name_active, &stat_buf) != 0 && lgat_tmpname[0] != '\0' && stat (lgat_tmpname, &stat_buf) == 0)
-    {
-      if (lgat_vdes != NULL_VOLDES)
-	{
-	  fileio_dismount (thread_p, lgat_vdes);
-	  lgat_vdes = NULL_VOLDES;
-	}
-
-      os_rename_file (lgat_tmpname, log_Name_active);
-    }
-
-  unlink (lgat_tmpname);
 
   if (session != NULL)
     {
@@ -9476,9 +9498,9 @@ error:
       logpb_fatal_error (thread_p, false, ARG_FILE_LINE, "logpb_restore");
     }
 
-  if (lgat_tmpname[0] != '\0')
+  if (tmp_logfiles_from_backup[0] != '\0')
     {
-      unlink (lgat_tmpname);
+      unlink (tmp_logfiles_from_backup);
     }
 
   return error_code;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21645

Restore uses the current log files (active/archive logs and log info) if exists. Otherwise, does them from backup volume.
The current files are more recent ones than those from backup volume.