### PR TITLE
[CBRD-21758] JSON - cub_server crashed in thread_rc_track_meter_check

### DIFF
--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -6956,6 +6956,7 @@ db_convert_json_into_scalar (const DB_VALUE * src, DB_VALUE * dest)
 	    ASSERT_ERROR ();
 	    return error_code;
 	  }
+	dest->need_clear = true;
 	break;
       }
     case DB_JSON_NULL:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21758

The function **db_json_bool_to_string** allocates memory when converting a bool to string.

Right now **db_make_string** expects a const char* and the need_clear flag is **false**, but in the future it will require a char*. After making the DB_VALUE from string we need to set need_clear flag to **true** in order to avoid memory leak.