### PR TITLE
[CBRD-21776] devtoolset-6: multiplication overflow is not detected

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -16834,42 +16834,64 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 	    case DB_TYPE_INTEGER:
 	      {
-		int i1, i2, itmp;
+		/* NOTE that we need volatile to prevent optimizer from generating division expression as 
+		 * multiplication.
+		 */
+		volatile int i1, i2, itmp;
 
 		i1 = DB_GET_INT (arg1);
 		i2 = DB_GET_INT (arg2);
 		itmp = i1 * i2;
 		if (OR_CHECK_MULT_OVERFLOW (i1, i2, itmp))
-		  goto overflow;
+		  {
+		    goto overflow;
+		  }
 		else
-		  db_make_int (result, itmp);
+		  {
+		    db_make_int (result, itmp);
+		  }
 		break;
 	      }
 
 	    case DB_TYPE_BIGINT:
 	      {
-		DB_BIGINT bi1, bi2, bitmp;
+		/* NOTE that we need volatile to prevent optimizer from generating division expression as 
+		 * multiplication.
+		 */
+		volatile DB_BIGINT bi1, bi2, bitmp;
+
 		bi1 = DB_GET_BIGINT (arg1);
 		bi2 = DB_GET_BIGINT (arg2);
 		bitmp = bi1 * bi2;
 		if (OR_CHECK_MULT_OVERFLOW (bi1, bi2, bitmp))
-		  goto overflow;
+		  {
+		    goto overflow;
+		  }
 		else
-		  db_make_bigint (result, bitmp);
+		  {
+		    db_make_bigint (result, bitmp);
+		  }
 		break;
 	      }
 
 	    case DB_TYPE_SHORT:
 	      {
-		short s1, s2, stmp;
+		/* NOTE that we need volatile to prevent optimizer from generating division expression as 
+		 * multiplication.
+		 */
+		volatile short s1, s2, stmp;
 
 		s1 = DB_GET_SHORT (arg1);
 		s2 = DB_GET_SHORT (arg2);
 		stmp = s1 * s2;
 		if (OR_CHECK_MULT_OVERFLOW (s1, s2, stmp))
-		  goto overflow;
+		  {
+		    goto overflow;
+		  }
 		else
-		  db_make_short (result, stmp);
+		  {
+		    db_make_short (result, stmp);
+		  }
 		break;
 	      }
 
@@ -16879,9 +16901,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		ftmp = DB_GET_FLOAT (arg1) * DB_GET_FLOAT (arg2);
 		if (OR_CHECK_FLOAT_OVERFLOW (ftmp))
-		  goto overflow;
+		  {
+		    goto overflow;
+		  }
 		else
-		  db_make_float (result, ftmp);
+		  {
+		    db_make_float (result, ftmp);
+		  }
 		break;
 	      }
 
@@ -16891,9 +16917,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		dtmp = DB_GET_DOUBLE (arg1) * DB_GET_DOUBLE (arg2);
 		if (OR_CHECK_DOUBLE_OVERFLOW (dtmp))
-		  goto overflow;
+		  {
+		    goto overflow;
+		  }
 		else
-		  db_make_double (result, dtmp);
+		  {
+		    db_make_double (result, dtmp);
+		  }
 		break;
 	      }
 
@@ -16922,9 +16952,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		dtmp = DB_GET_MONETARY (arg1)->amount * DB_GET_MONETARY (arg2)->amount;
 		if (OR_CHECK_DOUBLE_OVERFLOW (dtmp))
-		  goto overflow;
+		  {
+		    goto overflow;
+		  }
 		else
-		  DB_MAKE_MONETARY (result, dtmp);
+		  {
+		    DB_MAKE_MONETARY (result, dtmp);
+		  }
 		break;
 	      }
 	      break;

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -5217,7 +5217,8 @@ qdata_subtract_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * resul
 static int
 qdata_multiply_short (DB_VALUE * short_val_p, short s2, DB_VALUE * result_p)
 {
-  short s1, stmp;
+  /* NOTE that we need volatile to prevent optimizer from generating division expression as multiplication */
+  volatile short s1, stmp;
 
   s1 = DB_GET_SHORT (short_val_p);
   stmp = s1 * s2;
@@ -5236,7 +5237,8 @@ qdata_multiply_short (DB_VALUE * short_val_p, short s2, DB_VALUE * result_p)
 static int
 qdata_multiply_int (DB_VALUE * int_val_p, int i2, DB_VALUE * result_p)
 {
-  int i1, itmp;
+  /* NOTE that we need volatile to prevent optimizer from generating division expression as multiplication */
+  volatile int i1, itmp;
 
   i1 = DB_GET_INT (int_val_p);
   itmp = i1 * i2;
@@ -5254,7 +5256,8 @@ qdata_multiply_int (DB_VALUE * int_val_p, int i2, DB_VALUE * result_p)
 static int
 qdata_multiply_bigint (DB_VALUE * bigint_val_p, DB_BIGINT bi2, DB_VALUE * result_p)
 {
-  DB_BIGINT bi1, bitmp;
+  /* NOTE that we need volatile to prevent optimizer from generating division expression as multiplication */
+  volatile DB_BIGINT bi1, bitmp;
 
   bi1 = DB_GET_BIGINT (bigint_val_p);
   bitmp = bi1 * bi2;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21776

multiplication overflow is detected as follows:
```
x = a * b
x / b != a
```

devtoolset-6 optimizer does not actually do division operation and overflow is not detected.
