### PR TITLE
[CBRD-21811] Quick fix for bad reinit of mutex

### DIFF
--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -548,6 +548,7 @@ extern int rand_r (unsigned int *seedp);
 extern double round (double d);
 #endif /* !_MSC_VER || _MSC_VER < 1800 */
 
+/* Maybe replace this with std::mutex */
 typedef struct
 {
   CRITICAL_SECTION cs;

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -480,12 +480,6 @@ thread_initialize_manager (size_t & total_thread_count)
   assert (daemon_index == thread_Manager.num_daemons);
 
 #if defined(WINDOWS)
-  r = pthread_mutex_init (&css_Internal_mutex_for_mutex_initialize, NULL);
-  if (r != 0)
-    {
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_INIT, 0);
-      return ER_CSS_PTHREAD_MUTEX_INIT;
-    }
   thread_initialize_sync_object ();
 #endif /* WINDOWS */
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21811

The internal mutex used for initialization of other mutexes was already initialized at the time of this call.