### PR TITLE
[CBRD-21782] memory leak of JSON

### DIFF
--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -897,7 +897,10 @@ parser_free_node (const PARSER_CONTEXT * parser, PT_NODE * node)
     {
       db_value_clear (&node->info.value.db_value);
     }
-
+   if (node->node_type == PT_INSERT_VALUE && node->info.insert_value.is_evaluated) 
+   { 
+     db_value_clear (&node->info.insert_value.value); 
+   }
   /* 
    * Always set the node type to maximum.  This may
    * keep us from doing bad things to the free list if we try to free

--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -897,10 +897,10 @@ parser_free_node (const PARSER_CONTEXT * parser, PT_NODE * node)
     {
       db_value_clear (&node->info.value.db_value);
     }
-   if (node->node_type == PT_INSERT_VALUE && node->info.insert_value.is_evaluated) 
-   { 
-     db_value_clear (&node->info.insert_value.value); 
-   }
+  if (node->node_type == PT_INSERT_VALUE && node->info.insert_value.is_evaluated)
+    {
+      db_value_clear (&node->info.insert_value.value);
+    }
   /* 
    * Always set the node type to maximum.  This may
    * keep us from doing bad things to the free list if we try to free

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -16627,7 +16627,6 @@ end_error:
   pr_clear_value (&eval_value);
   if (temp != NULL && free_temp)
     {
-      /* free temp */
       parser_free_tree (parser, temp);
     }
   if (er_errid () != NO_ERROR)

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -16596,6 +16596,7 @@ do_evaluate_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement)
 		      PT_ERRORmf (parser, val, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME__CAN_NOT_EVALUATE,
 				  pt_short_print (parser, val));
 		    }
+		  parser_free_tree (parser, result);
 		  val->next = save_next;
 		  goto end_error;
 		}
@@ -16623,6 +16624,7 @@ do_evaluate_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement)
   return NO_ERROR;
 
 end_error:
+  pr_clear_value (&eval_value);
   if (temp != NULL && free_temp)
     {
       /* free temp */
@@ -16632,7 +16634,6 @@ end_error:
     {
       return er_errid ();
     }
-  pr_clear_value (&eval_value);
   return ER_FAILED;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21782

`parser_free_node()`:
- clear db_value for node type PT_INSERT_VALUE 

Already fixed in previous PRs:
- mem::default_realloc()
- db_json_contains_dbval()

I could reproduce only one memory leak related to `db_json_allocate_doc()` with
`sql/_31_cherry/issue_21522_json/cases/json_remove_and_dml.sql`

Waiting instructions how to reproduce memory leaks other than the above one