### PR TITLE
[CBRD-21809] Fix thread_has_threads false match

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -630,6 +630,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_JSON_LOG_ALLOCATIONS "json_log_allocations"
 
+#define PRM_NAME_CONNECTION_LOGGING "connection_logging"
+
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
 #define PRM_VALUE_MIN "MIN"
@@ -2100,6 +2102,10 @@ static unsigned int prm_cte_max_recursions_flag = 0;
 bool PRM_JSON_LOG_ALLOCATIONS = false;
 static bool prm_json_log_allocations_default = false;
 static unsigned int prm_json_log_allocations_flag = 0;
+
+bool PRM_CONNECTION_LOGGING = false;
+static bool prm_connection_logging_default = false;
+static unsigned int prm_connection_logging_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5318,7 +5324,18 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
-   (DUP_PRM_FUNC) NULL}
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_CONNECTION_LOGGING,
+   PRM_NAME_CONNECTION_LOGGING,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   &prm_connection_logging_flag,
+   (void *) &prm_connection_logging_default,
+   (void *) &PRM_CONNECTION_LOGGING,
+   (void *) NULL, (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
 };
 
 #define NUM_PRM ((int)(sizeof(prm_Def)/sizeof(prm_Def[0])))

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -403,8 +403,10 @@ enum param_id
 
   PRM_ID_JSON_LOG_ALLOCATIONS,
 
+  PRM_ID_CONNECTION_LOGGING,
+
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_JSON_LOG_ALLOCATIONS
+  PRM_LAST_ID = PRM_ID_CONNECTION_LOGGING
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/connection/connection_sr.h
+++ b/src/connection/connection_sr.h
@@ -134,6 +134,11 @@ extern int (*css_Connect_handler) (CSS_CONN_ENTRY *);
 extern CSS_THREAD_FN css_Request_handler;
 extern CSS_THREAD_FN css_Connection_error_handler;
 
+#define CSS_LOG(msg_arg, ...) \
+  if (prm_get_bool_value (PRM_ID_CONNECTION_LOGGING)) _er_log_debug (ARG_FILE_LINE, msg_arg "\n", __VA_ARGS__)
+#define CSS_LOG_STACK(msg_arg, ...) \
+  if (prm_get_bool_value (PRM_ID_CONNECTION_LOGGING)) er_print_callstack (ARG_FILE_LINE, msg_arg "\n", __VA_ARGS__)
+
 extern int css_initialize_conn (CSS_CONN_ENTRY * conn, SOCKET fd);
 extern void css_shutdown_conn (CSS_CONN_ENTRY * conn);
 extern int css_init_conn_list (void);

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -1704,7 +1704,7 @@ thread_has_threads (THREAD_ENTRY * caller, int tran_index, int client_id)
 {
   int n = 0;
 
-  for (thread_p = thread_Manager.thread_array;
+  for (THREAD_ENTRY * thread_p = thread_Manager.thread_array;
        thread_p < thread_Manager.thread_array + thread_Manager.num_workers; thread_p++)
     {
       if (thread_p == caller)

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -1675,13 +1675,15 @@ thread_belongs_to (THREAD_ENTRY * thread_p, int tran_index, int client_id)
       && thread_p->status != TS_CHECK)
     {
       conn_p = thread_p->conn_entry;
-      if (tran_index == NULL_TRAN_INDEX && (conn_p != NULL && conn_p->client_id == client_id))
+      if (tran_index == NULL_TRAN_INDEX)
 	{
-	  does_belong = true;
+	  // exact match client ID is required
+	  does_belong = conn_p != NULL && conn_p->client_id == client_id;
 	}
-      else if (tran_index == thread_p->tran_index && (conn_p == NULL || conn_p->client_id == client_id))
+      else if (tran_index == thread_p->tran_index)
 	{
-	  does_belong = true;
+	  // match client ID or null connection
+	  does_belong = conn_p == NULL || conn_p->client_id == client_id;
 	}
     }
   pthread_mutex_unlock (&thread_p->tran_index_lock);
@@ -1702,7 +1704,8 @@ thread_has_threads (THREAD_ENTRY * caller, int tran_index, int client_id)
 {
   int n = 0;
 
-  for (THREAD_ENTRY * thread_p = thread_iterate (NULL); thread_p != NULL; thread_p = thread_iterate (thread_p))
+  for (thread_p = thread_Manager.thread_array;
+       thread_p < thread_Manager.thread_array + thread_Manager.num_workers; thread_p++)
     {
       if (thread_p == caller)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21809

Fix thread_has_threads regressions:
1. Fix thread_belongs_to to avoid matching thread entries with both tran_index and conn_entry NULL.
2. Fix thread_has_threads to search only workers, not all threads.
Any one of two changes was enough, however I think the logic is more clear now.

I also added some connection logging while trying to investigate the connection issue.

As consequence of thread_has_threads bug, net_server_conn_down looped infinitely and connections were never closed and connection entry pool was completely depleted. Paired with bad handling of new clients, it leaves admin connection with no conn_entry, hence the issue.

@paulgheorghecristian @razvanradulescu 
While working on HA connection, please consider changing css_process_new_client. I think it is better to know the client type (normal or admin) from the very beginning. Admin connections should not use same connection pool as normal connections.