### PR TITLE
[CBRD-21815] Separate thread context of thread task

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -32,6 +32,7 @@ set(THREAD_SOURCES
   ${THREAD_DIR}/critical_section.c
   ${THREAD_DIR}/thread_daemon.cpp
   ${THREAD_DIR}/thread_entry.cpp
+  ${THREAD_DIR}/thread_entry_task.cpp
   ${THREAD_DIR}/thread_looper.cpp
   ${THREAD_DIR}/thread_manager.cpp
   ${THREAD_DIR}/thread_waiter.cpp

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -218,6 +218,7 @@ set(JSP_SOURCES
 
 set(THREAD_SOURCES
   ${THREAD_DIR}/thread_entry.cpp
+  ${THREAD_DIR}/thread_entry_task.cpp
   ${THREAD_DIR}/thread_manager.cpp
   )
 set(THREAD_HEADERS

--- a/src/base/lockfree_circular_queue.hpp
+++ b/src/base/lockfree_circular_queue.hpp
@@ -65,6 +65,9 @@ namespace lockfree
       inline bool is_full () const;               // is query full?
 
       inline bool consume (T &element);               // consume one element from queue; returns false on fail
+      // IMPORTANT!
+      //   Element argument may change even if consume fails.
+      //   Using its value after failed consumption is not safe.
       inline bool produce (const T &element);         // produce an element to queue; returns false on fail
       inline void force_produce (const T &element);   // force produce (loop until successful)
       // note:

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -771,7 +771,7 @@ public:
   
 private:
 #if defined (SA_MODE)
-  // find a proper way to do this
+  // find a proper way to do this; SA_MODE claim vacuum worker
   friend void vacuum_push_task (THREAD_ENTRY * thread_p, const VACUUM_DATA_ENTRY & data_entry,
                                 const BLOCK_LOG_BUFFER & log_buffer, bool is_partial_block);
 #endif // SA_MODE

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2743,7 +2743,7 @@ vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, MVC
   perfmon_add_stat (thread_p, PSTAT_VAC_NUM_TO_VACUUM_LOG_PAGES, vacuum_Data.log_block_npages);
 }
 
-static void
+void
 vacuum_push_task (THREAD_ENTRY * thread_p, const VACUUM_DATA_ENTRY & data_entry, const BLOCK_LOG_BUFFER & log_buffer,
 		  bool is_partial_block = false)
 {

--- a/src/thread/thread_daemon.cpp
+++ b/src/thread/thread_daemon.cpp
@@ -27,15 +27,6 @@
 
 namespace cubthread
 {
-
-  daemon::daemon (const looper &loop_pattern, task *exec)
-    : m_waiter ()
-    , m_looper (loop_pattern)
-    , m_thread (daemon::loop, this, exec)
-  {
-    // starts a thread to execute daemon::loop
-  }
-
   daemon::~daemon ()
   {
     // thread must be stopped
@@ -65,23 +56,6 @@ namespace cubthread
     wakeup ();
     // then wait for thread to finish
     m_thread.join ();
-  }
-
-  void
-  daemon::loop (daemon *daemon_arg, task *exec)
-  {
-    // loop until stopped
-    while (!daemon_arg->m_looper.is_stopped ())
-      {
-	// execute task
-	exec->execute ();
-
-	// take a break
-	daemon_arg->pause ();
-      }
-
-    // retire task
-    exec->retire ();
   }
 
   void daemon::pause (void)

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -25,6 +25,7 @@
 #define _THREAD_DAEMON_HPP_
 
 #include "thread_looper.hpp"
+#include "thread_task.hpp"
 #include "thread_waiter.hpp"
 
 #include <thread>
@@ -36,41 +37,63 @@
 //    task is executed in a loop; wait times are defined by looper
 //
 //  how to use
-//    // define your task
-//    class custom_task : public task
+//    // define your custom task
+//    class custom_task : public cubthread::task<custom_thread_context>
 //    {
-//      void execute () override { ... }
+//      void execute (custom_thread_context & context) override { ... }
+//    }
+//
+//    // define your custom context manager
+//    class custom_thread_context_manager : public cubthread::context_manager<custom_thread_context>
+//    {
+//      custom_thread_context & create_context (void) override { ... }
+//      void retire_context(custom_thread_context & context) override { ... }
 //    }
 //
 //    // declare a looper
 //    cubthread::looper loop_pattern;   // by default sleep until wakeup
-//    cubthread::daemon my_daemon (loop_pattern, new custom_task ());    // daemon starts, executes task and sleeps
+//
+//    // context manager is required
+//    custom_thread_context_manager thr_ctxt_mgr;
+//
+//    // and finally looping task
+//    custom_task *task = new_custom_task ();
+//
+//    cubthread::daemon my_daemon (loop_pattern, thr_ctxt_mgr, *task);    // daemon starts, executes task and sleeps
 //
 //    std::chrono::sleep_for (std::chrono::seconds (1));
 //    my_daemon.wakeup ();    // daemon executes task again
 //    std::chrono::sleep_for (std::chrono::seconds (1));
 //
 //    // when daemon is destroyed, its execution is stopped and thread is joined
+//    // daemon will handle task deletion
 //
 namespace cubthread
 {
-
-// forward definition
-  class task;
-
   class daemon
   {
     public:
-      daemon (const looper &loop_pattern, task *exec);
+      //  daemon constructor needs:
+      //    loop_pattern_arg    : loop pattern for task execution
+      //    context_manager_arg : context manager to create and retire thread execution context
+      //    exec                : task to execute
+      //
+      //  NOTE: it is recommended to use dynamic allocation for execution tasks
+      //
+      template <typename Context>
+      daemon (const looper &loop_pattern_arg, context_manager<Context> *context_manager_arg,
+	      task<Context> *exec);
       ~daemon();
 
       void wakeup (void);     // wakeup daemon thread
       void stop (void);       // stop daemon thread from looping and join it
-                              // note: this must not be called concurrently
+      // note: this must not be called concurrently
 
     private:
 
-      static void loop (daemon *daemon_arg, task *exec);    // daemon thread loop function
+      template <typename Context>
+      static void loop (daemon *daemon_arg, context_manager<Context> *context_manager_arg,
+			task<Context> *exec_arg);     // daemon thread loop function
 
       void pause (void);                                    // pause between tasks
 
@@ -78,6 +101,44 @@ namespace cubthread
       looper m_looper;        // thread looper
       std::thread m_thread;   // the actual daemon thread
   };
+
+  /************************************************************************/
+  /* Inline/template Implementation                                       */
+  /************************************************************************/
+
+  template <typename Context>
+  daemon::daemon (const looper &loop_pattern_arg, context_manager<Context> *context_manager_arg,
+		  task<Context> *exec)
+    : m_waiter ()
+    , m_looper (loop_pattern_arg)
+    , m_thread (daemon::loop<Context>, this, context_manager_arg, exec)
+  {
+    // starts a thread to execute daemon::loop
+  }
+
+  template <typename Context>
+  void
+  daemon::loop (daemon *daemon_arg, context_manager<Context> *context_manager_arg, task<Context> *exec_arg)
+  {
+    // create execution context
+    Context &context = context_manager_arg->create_context ();
+
+    // loop until stopped
+    while (!daemon_arg->m_looper.is_stopped ())
+      {
+	// execute task
+	exec_arg->execute (context);
+
+	// take a break
+	daemon_arg->pause ();
+      }
+
+    // retire execution context
+    context_manager_arg->retire_context (context);
+
+    // retire task
+    exec_arg->retire ();
+  }
 
 } // namespace cubthread
 

--- a/src/thread/thread_entry_task.cpp
+++ b/src/thread/thread_entry_task.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * thread_entry_task.cpp - implementation of entry_task and entry_manager
+ */
+
+#include "thread_entry_task.hpp"
+
+#include "error_manager.h"
+#include "porting.h"
+#if defined (SERVER_MODE)
+#include "thread.h"
+#endif // SERVER_MODE
+#include "thread_entry.hpp"
+#include "thread_manager.hpp"
+
+namespace cubthread
+{
+
+  entry &
+  entry_manager::create_context (void)
+  {
+    entry &context = *get_manager ()->claim_entry ();
+    // for backward compatibility
+    context.tid = pthread_self ();
+    context.type = TT_WORKER;
+
+    // TODO: daemon type
+
+    on_create (context);
+    return context;
+  }
+
+  void
+  entry_manager::retire_context (entry &context)
+  {
+    on_retire (context);
+
+    // clear error messages
+    er_clear ();
+
+    // for backward compatibility
+    context.tid = (pthread_t) 0;
+
+    // todo: here we should do more operations to clear thread entry before being reused
+    context.tran_index = -1;
+    context.check_interrupt = true;
+#if defined (SERVER_MODE)
+    context.status = TS_FREE;
+#endif // SERVER_MODE
+
+    get_manager ()->retire_entry (context);
+  }
+
+  void
+  entry_manager::recycle_context (entry &context)
+  {
+    er_clear ();
+
+    on_recycle (context);
+  }
+
+
+} // namespace cubthread

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -57,7 +57,6 @@ namespace cubthread
     , m_all_entries (NULL)
     , m_entry_dispatcher (NULL)
     , m_available_entries_count (max_threads)
-    , m_entry_manager (new entry_manager (*this))
   {
     if (m_max_threads > 0)
       {
@@ -113,7 +112,7 @@ namespace cubthread
   }
 
   entry_workpool *
-  manager::create_worker_pool (size_t pool_size, size_t work_queue_size)
+  manager::create_worker_pool (size_t pool_size, size_t work_queue_size, entry_manager *context_manager)
   {
 #if defined (SERVER_MODE)
     if (is_single_thread ())
@@ -122,7 +121,11 @@ namespace cubthread
       }
     else
       {
-	return create_and_track_resource (m_worker_pools, pool_size, pool_size, work_queue_size);
+	if (context_manager == NULL)
+	  {
+	    context_manager = m_entry_manager;
+	  }
+	return create_and_track_resource (m_worker_pools, pool_size, pool_size, work_queue_size, context_manager);
       }
 #else // not SERVER_MODE = SA_MODE
     return NULL;
@@ -130,7 +133,7 @@ namespace cubthread
   }
 
   daemon *
-  manager::create_daemon (const looper &looper_arg, entry_task *exec_p)
+  manager::create_daemon (const looper &looper_arg, entry_task *exec_p, entry_manager *context_manager)
   {
 #if defined (SERVER_MODE)
     if (is_single_thread ())
@@ -140,8 +143,11 @@ namespace cubthread
       }
     else
       {
-	exec_p->set_manager (this);
-	return create_and_track_resource (m_daemons, 1, looper_arg, m_entry_manager, exec_p);
+	if (context_manager == NULL)
+	  {
+	    context_manager = m_entry_manager;
+	  }
+	return create_and_track_resource (m_daemons, 1, looper_arg, context_manager, exec_p);
       }
 #else // not SERVER_MODE = SA_MODE
     assert (false);
@@ -221,7 +227,6 @@ namespace cubthread
       {
 #if defined (SERVER_MODE)
 	check_not_single_thread ();
-	exec_p->set_manager (this);
 	worker_pool_arg->execute (exec_p);
 #else // not SERVER_MODE = SA_MODE
 	assert (false);
@@ -246,7 +251,6 @@ namespace cubthread
       {
 #if defined (SERVER_MODE)
 	check_not_single_thread ();
-	exec_p->set_manager (this);
 	return worker_pool_arg->try_execute (exec_p);
 #else // not SERVER_MODE = SA_MODE
 	assert (false);
@@ -295,12 +299,6 @@ namespace cubthread
   {
     tl_Entry_p = m_entry_dispatcher->claim ();
 
-    // for backward compatibility
-    tl_Entry_p->tid = pthread_self ();
-    tl_Entry_p->type = TT_WORKER;
-
-    // TODO: daemon type
-
     return tl_Entry_p;
   }
 
@@ -308,16 +306,6 @@ namespace cubthread
   manager::retire_entry (entry &entry_p)
   {
     assert (tl_Entry_p == &entry_p);
-
-    // for backward compatibility
-    entry_p.tid = (pthread_t) 0;
-
-    // todo: here we should do more operations to clear thread entry before being reused
-    entry_p.tran_index = -1;
-    entry_p.check_interrupt = true;
-#if defined (SERVER_MODE)
-    entry_p.status = TS_FREE;
-#endif // SERVER_MODE
 
     tl_Entry_p = NULL;
     m_entry_dispatcher->retire (entry_p);

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -57,6 +57,7 @@ namespace cubthread
     , m_all_entries (NULL)
     , m_entry_dispatcher (NULL)
     , m_available_entries_count (max_threads)
+    , m_entry_manager (new entry_manager (*this))
   {
     if (m_max_threads > 0)
       {
@@ -140,7 +141,7 @@ namespace cubthread
     else
       {
 	exec_p->set_manager (this);
-	return create_and_track_resource (m_daemons, 1, looper_arg, exec_p);
+	return create_and_track_resource (m_daemons, 1, looper_arg, m_entry_manager, exec_p);
       }
 #else // not SERVER_MODE = SA_MODE
     assert (false);

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -103,7 +103,8 @@ namespace cubthread
 
       // create a entry_workpool with pool_size number of threads
       // note: if there are not pool_size number of entries available, worker pool is not created and NULL is returned
-      entry_workpool *create_worker_pool (size_t pool_size, size_t work_queue_size);
+      entry_workpool *create_worker_pool (size_t pool_size, size_t work_queue_size,
+					  entry_manager *context_manager = NULL);
 
       // destroy worker pool
       void destroy_worker_pool (entry_workpool *&worker_pool_arg);
@@ -131,7 +132,8 @@ namespace cubthread
       //////////////////////////////////////////////////////////////////////////
 
       // create daemon thread
-      daemon *create_daemon (const looper &looper_arg, entry_task *exec_p);
+      daemon *create_daemon (const looper &looper_arg, entry_task *exec_p,
+			     entry_manager *context_manager = NULL);
 
       // destroy daemon thread
       void destroy_daemon (daemon *&daemon_arg);
@@ -165,7 +167,6 @@ namespace cubthread
     private:
 
       // define friend classes/functions to access claim_entry/retire_entry functions
-      friend class entry_task;
       friend class entry_manager;
       friend void initialize (entry *&my_entry);
       friend void finalize (void);

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -44,9 +44,10 @@ namespace cubthread
   class daemon;
   class entry;
   class entry_task;
+  class entry_manager;
 
   // alias for worker_pool<entry>
-  typedef worker_pool<entry> entry_workpool;
+  using entry_workpool = worker_pool<entry>;
 
   // cubthread::manager
   //
@@ -165,11 +166,12 @@ namespace cubthread
 
       // define friend classes/functions to access claim_entry/retire_entry functions
       friend class entry_task;
+      friend class entry_manager;
       friend void initialize (entry *&my_entry);
       friend void finalize (void);
 
       // private type aliases
-      typedef resource_shared_pool<entry> entry_dispatcher;
+      using entry_dispatcher = resource_shared_pool<entry>;
 
       // claim/retire entries
       entry *claim_entry (void);
@@ -201,6 +203,7 @@ namespace cubthread
       entry_dispatcher *m_entry_dispatcher;
       // available entries count
       std::size_t m_available_entries_count;
+      entry_manager *m_entry_manager;
   };
 
   //////////////////////////////////////////////////////////////////////////

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -37,44 +37,25 @@ namespace cubthread
   //    abstract class for thread tasks
   //
   //  templates:
-  //    Context - thread execution context, a helper/cache structure that can be passed to multiple tasks
+  //    Context - thread execution context, a helper/cache structure that can be passed to multiple tasks.
   //
   //  how to use:
   //     1. specialize task with Context
   //        e.g. in CUBRID we have entry_task which uses entry as context; see thread_entry_task.hpp
   //
-  //     2. extend specialized contextual_task and override virtual functions
+  //     2. extend specialized task<custom_context> and override virtual functions
   //        override execute (Context &) to define task execution
-  //        [optional] override create_context and retire_context; as a recommendation, always call create_context from
-  //        parent class before doing your own context initialization; also call parent retire_context at the end of
-  //        own retire_context.
-  //        [optional] override retire function
+  //        [optional] override retire function; by default it deletes task
   //
   //     3. execute multiple tasks using same context:
-  //          custom_context & context_ref;
-  //          custom_task * task_p;
+  //          custom_context context;       // this is a dummy example
+  //          custom_task* task_p = NULL;   // using custom_task = task<custom_context>
   //
-  //          task_p = first_task ();
-  //          context_ref = task_p->create_context ();
-  //
-  //          do
+  //          for (task_p = get_task (); task_p != NULL; task_p = get_task ())
   //            {
-  //              if (task_p != last_task ())
-  //                {
-  //                  task_p->retire ();
-  //                }
-  //              task_p->execute (context_ref);
+  //              task_p->execute (context);
+  //              task_p->retire (); // this will delete task_p
   //            }
-  //          while (task_p != last_task ());
-  //
-  //          task_p->retire_context ();
-  //          task_p->retire ();
-  //
-  //        see thread_worker_pool.hpp implementation for task.
-  //
-  //  todo:
-  //    find a better design for claiming/retiring context; I wanted to make them static, but static and virtual don't
-  //    go together.
   //
   template <typename Context>
   class task
@@ -82,44 +63,50 @@ namespace cubthread
     public:
       using context_type = Context;
 
+      task () = default;
+
       // abstract class requires virtual destructor
       virtual ~task () = default;
 
       // virtual functions to be implemented by inheritors
       virtual void execute (context_type &) = 0;
-      virtual context_type &create_context (void) = 0;
-      virtual void retire_context (context_type &) = 0;
 
       // implementation of task's retire function.
       virtual void retire (void)
       {
-	if (m_own_context != NULL)
-	  {
-	    retire_context (*m_own_context);
-	  }
 	delete this;
       }
-
-      // create own context
-      void create_own_context (void)
-      {
-	assert (m_own_context == NULL);
-	m_own_context = & (create_context ());
-      }
-
-      context_type *get_own_context (void)
-      {
-	return m_own_context;
-      }
-
-    private:
-      context_type *m_own_context;
   };
 
   // context_manager
   //
-  //    abstract class for thread context managers. used to pool, create and retire thread contexts to be passed to
-  //    tasks in various execution patterns. (see thread worker pools & thread daemons)
+  //  description:
+  //    complex tasks may require bulky context that can take a long time to construct/destruct.
+  //    context_manager abstract class is designed to pool context and hand them quickly on demand.
+  //
+  //  templates:
+  //    Context - thread execution context, a helper/cache structure that can be passed to multiple tasks
+  //
+  //  how to use:
+  //    1. specialize context_manager with custom context
+  //       e.g. see CUBRID implementation for entry_manager.
+  //
+  //    2. override create_context, retire_context and recycle_context functions
+  //
+  //    3. execute multiple tasks using same context:
+  //          custom_context_manager context_mgr; // using custom_context_manager = context_manager<custom_context>
+  //          custom_context& context_ref = context_mgr.create_context ();
+  //          custom_task* task_p = NULL;   // using custom_task = task<custom_context>
+  //
+  //          for (task_p = get_task (); task_p != NULL; task_p = get_task ())
+  //            {
+  //              task_p->execute (context_ref);
+  //              task_p->retire (); // this will delete task_p
+  //              // context_mgr.recycle_context ();    // optional operation before reusing context
+  //            }
+  //
+  //          context_mgr.retire_context (context_ref);
+  //
   //
   template <typename Context>
   class context_manager
@@ -130,8 +117,12 @@ namespace cubthread
       // abstract class requires virtual destructor
       virtual ~context_manager () = default;
 
-      virtual context_type &create_context (void) = 0;
-      virtual void retire_context (context_type &) = 0;
+      virtual context_type &create_context (void) = 0;      // create a new thread context; cannot fail
+      virtual void retire_context (context_type &) = 0;     // retire the thread context
+      virtual void recycle_context (context_type &)         // recycle context before reuse
+      {
+	// usage and implementation is optional
+      }
   };
 
 } // namespace cubthread

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -97,6 +97,7 @@ namespace cubthread
 	  {
 	    retire_context (*m_own_context);
 	  }
+	delete this;
       }
 
       // create own context

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -31,42 +31,16 @@
 
 namespace cubthread
 {
-
   // cubthread::task
   //
   //  description:
-  //    abstract class for thread tasks; it has two virtual methods: execute and retire
-  //
-  //  how to use:
-  //    extend task
-  //    override execute to define task execution
-  //    [optional] override retire to manage task object when no longer required; it is deleted by default
-  //    provide tasks to daemon threads; see thread_daemon.hpp
-  //
-  class task
-  {
-    public:
-      virtual void execute () = 0;       // function to execute
-      virtual void retire ()                  // what happens with task instance when task is executed; default is delete
-      {
-	delete this;
-      }
-      virtual ~task ()                        // virtual destructor
-      {
-      }
-  };
-
-  // cubthread::contextual_task
-  //
-  //  description:
-  //    extension of task class that can handle thread context
-  //    the context can be shared by multiple tasks
+  //    abstract class for thread tasks
   //
   //  templates:
-  //    Context - thread context
+  //    Context - thread execution context, a helper/cache structure that can be passed to multiple tasks
   //
   //  how to use:
-  //     1. specialize contextual_task with Context
+  //     1. specialize task with Context
   //        e.g. in CUBRID we have entry_task which uses entry as context; see thread_entry_task.hpp
   //
   //     2. extend specialized contextual_task and override virtual functions
@@ -85,7 +59,7 @@ namespace cubthread
   //
   //          do
   //            {
-  //              if (task_p != first_task ())
+  //              if (task_p != last_task ())
   //                {
   //                  task_p->retire ();
   //                }
@@ -96,36 +70,26 @@ namespace cubthread
   //          task_p->retire_context ();
   //          task_p->retire ();
   //
-  //        see thread_worker_pool.hpp implementation for contextual_task.
+  //        see thread_worker_pool.hpp implementation for task.
   //
   //  todo:
   //    find a better design for claiming/retiring context; I wanted to make them static, but static and virtual don't
   //    go together.
   //
   template <typename Context>
-  class contextual_task : public task
+  class task
   {
     public:
+      using context_type = Context;
 
-      contextual_task ()
-	: m_own_context (NULL)
-      {
-      }
+      // abstract class requires virtual destructor
+      virtual ~task () = default;
 
       // virtual functions to be implemented by inheritors
-      virtual void execute (Context &) = 0;
-      virtual Context &create_context (void) = 0;
-      virtual void retire_context (Context &) = 0;
+      virtual void execute (context_type &) = 0;
+      virtual context_type &create_context (void) = 0;
+      virtual void retire_context (context_type &) = 0;
 
-      // implementation of task's execute function. creates own context
-      void execute (void)
-      {
-	if (m_own_context == NULL)
-	  {
-	    create_own_context ();
-	  }
-	execute (*m_own_context);
-      }
       // implementation of task's retire function.
       virtual void retire (void)
       {
@@ -141,7 +105,7 @@ namespace cubthread
 	m_own_context = & (create_context ());
       }
 
-      Context *get_own_context (void)
+      context_type *get_own_context (void)
       {
 	return m_own_context;
       }
@@ -155,7 +119,25 @@ namespace cubthread
       }
 
     private:
-      Context *m_own_context;
+      context_type *m_own_context;
+  };
+
+  // context_manager
+  //
+  //    abstract class for thread context managers. used to pool, create and retire thread contexts to be passed to
+  //    tasks in various execution patterns. (see thread worker pools & thread daemons)
+  //
+  template <typename Context>
+  class context_manager
+  {
+    public:
+      using context_type = Context;
+
+      // abstract class requires virtual destructor
+      virtual ~context_manager () = default;
+
+      virtual context_type &create_context (void) = 0;
+      virtual void retire_context (context_type &) = 0;
   };
 
 } // namespace cubthread

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -35,9 +35,8 @@ namespace cubthread
 {
 
   // forward definition
-  class task;
   template <typename Context>
-  class contextual_task;
+  class task;
 
   // cubtread::worker_pool<Context>
   //
@@ -57,8 +56,8 @@ namespace cubthread
   //    // define the thread context; for CUBRID, that is usually cubthread::entry
   //    class custom_context { ... };
   //
-  //    // then define the contextual_task
-  //    class custom_task : public contextual_task<custom_context>
+  //    // then define the task
+  //    class custom_task : public task<custom_context>
   //    {
   //      void execute (Context &) override { ... }
   //      void create_context (void) override { ... }
@@ -87,7 +86,7 @@ namespace cubthread
   class worker_pool
   {
     public:
-      typedef contextual_task<Context> task_type;
+      typedef task<Context> task_type;
 
       worker_pool (std::size_t pool_size, std::size_t work_queue_size);
       ~worker_pool ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21815

The bug surfaced by memory leak fix in thread_worker_pool::run was corrupted pointer used after circular_queue->consume failed.

circular_queue->consume does not guarantee argument element is not changed when consume fails. It is an intended optimization of the underlying implementation and caller should consider it.

This bug was also a flaw of initial thread manager design. Creating/retiring context was part of thread task implementation. I fixed by separating context manager into a different class context_manager.

Daemons/worker pools will also receive the context manager as argument during construction.

Several thread files and vacuum had to be changed because of design change.