### PR TITLE
[CBRD-21674] - Added support for json union

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -11810,6 +11810,11 @@ pt_common_type_op (PT_TYPE_ENUM t1, PT_OP_TYPE op, PT_TYPE_ENUM t2)
       result_type = PT_TYPE_INTEGER;
     }
 
+  if (pt_is_comp_op(op) && (PT_IS_NUMERIC_TYPE(t1) && t2 == PT_TYPE_JSON) || (t1 == PT_TYPE_JSON && PT_IS_NUMERIC_TYPE(t2)))
+  {
+    result_type = PT_TYPE_JSON;
+  }
+
   return result_type;
 }
 

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -11811,7 +11811,7 @@ pt_common_type_op (PT_TYPE_ENUM t1, PT_OP_TYPE op, PT_TYPE_ENUM t2)
     }
 
   if (pt_is_comp_op (op) && ((PT_IS_NUMERIC_TYPE (t1) && t2 == PT_TYPE_JSON)
-      || (t1 == PT_TYPE_JSON && PT_IS_NUMERIC_TYPE (t2))))
+			     || (t1 == PT_TYPE_JSON && PT_IS_NUMERIC_TYPE (t2))))
     {
       result_type = PT_TYPE_JSON;
     }

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -11810,8 +11810,8 @@ pt_common_type_op (PT_TYPE_ENUM t1, PT_OP_TYPE op, PT_TYPE_ENUM t2)
       result_type = PT_TYPE_INTEGER;
     }
 
-  if (pt_is_comp_op (op) && (PT_IS_NUMERIC_TYPE (t1) && t2 == PT_TYPE_JSON)
-      || (t1 == PT_TYPE_JSON && PT_IS_NUMERIC_TYPE (t2)))
+  if (pt_is_comp_op (op) && ((PT_IS_NUMERIC_TYPE (t1) && t2 == PT_TYPE_JSON)
+      || (t1 == PT_TYPE_JSON && PT_IS_NUMERIC_TYPE (t2))))
     {
       result_type = PT_TYPE_JSON;
     }

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -10916,11 +10916,6 @@ pt_common_type (PT_TYPE_ENUM arg1_type, PT_TYPE_ENUM arg2_type)
     {
       common_type = PT_TYPE_DOUBLE;
     }
-  else if ((PT_IS_NUMERIC_TYPE (arg1_type) && arg2_type == PT_TYPE_JSON)
-	   || (arg1_type == PT_TYPE_JSON && PT_IS_NUMERIC_TYPE (arg2_type)))
-    {
-      common_type = PT_TYPE_JSON;
-    }
   else if ((PT_IS_STRING_TYPE (arg1_type) && arg2_type == PT_TYPE_JSON)
 	   || (arg1_type == PT_TYPE_JSON && PT_IS_STRING_TYPE (arg2_type)))
     {

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -11810,10 +11810,11 @@ pt_common_type_op (PT_TYPE_ENUM t1, PT_OP_TYPE op, PT_TYPE_ENUM t2)
       result_type = PT_TYPE_INTEGER;
     }
 
-  if (pt_is_comp_op(op) && (PT_IS_NUMERIC_TYPE(t1) && t2 == PT_TYPE_JSON) || (t1 == PT_TYPE_JSON && PT_IS_NUMERIC_TYPE(t2)))
-  {
-    result_type = PT_TYPE_JSON;
-  }
+  if (pt_is_comp_op (op) && (PT_IS_NUMERIC_TYPE (t1) && t2 == PT_TYPE_JSON)
+      || (t1 == PT_TYPE_JSON && PT_IS_NUMERIC_TYPE (t2)))
+    {
+      result_type = PT_TYPE_JSON;
+    }
 
   return result_type;
 }

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -762,8 +762,8 @@ qfile_unify_types (QFILE_LIST_ID * list_id1_p, const QFILE_LIST_ID * list_id2_p)
 	{
 	  if (type2 != DB_TYPE_NULL && (list_id1_p->type_list.domp[i] != list_id2_p->type_list.domp[i]))
 	    {
-	      if (type1 == type2 && ((pr_is_string_type (type1) && pr_is_variable_type (type1))
-                || (type1 == DB_TYPE_JSON)))
+	      if (type1 == type2
+		  && ((pr_is_string_type (type1) && pr_is_variable_type (type1)) || (type1 == DB_TYPE_JSON)))
 		{
 		  /* OK for variable string types with different precision or json types */
 		}

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -762,9 +762,10 @@ qfile_unify_types (QFILE_LIST_ID * list_id1_p, const QFILE_LIST_ID * list_id2_p)
 	{
 	  if (type2 != DB_TYPE_NULL && (list_id1_p->type_list.domp[i] != list_id2_p->type_list.domp[i]))
 	    {
-	      if (type1 == type2 && pr_is_string_type (type1) && pr_is_variable_type (type1))
+	      if (type1 == type2 && ((pr_is_string_type (type1) && pr_is_variable_type (type1))
+                || (type1 == DB_TYPE_JSON)))
 		{
-		  /* OK for variable string types with different precision */
+		  /* OK for variable string types with different precision or json types */
 		}
 	      else
 		{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21674

We need a schema in order to validate a json when inserting a new value in table. In order to do that we have the **JSON_VALIDATOR** object. 

We will store in cache a **tp_domain** pointer which will be used further for the retrieval of the domain. 

When trying to unify two types ("**/src/query/list_file.c**", method: **qfile_unify_types**) we will check if the **domain pointers are the same**, but when we are dealing with json types, if the schemas are not the same, **those pointer will be different** so we need an additional check to pass that condition and to successfully make the union.