### PR TITLE
[CBRD-21807] Fix retrieving records with desc property and NULL field…

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -8499,7 +8499,16 @@ pr_midxkey_compare (DB_MIDXKEY * mul1, DB_MIDXKEY * mul2, int do_coercion, int t
 	      /* val 1 bound, val 2 unbound */
 	      if (mul2->min_max_val.position == i)
 		{
-		  c = mul2->min_max_val.type == MIN_COLUMN ? DB_GT : DB_LT;
+		  /* safeguard */
+		  assert (mul2->min_max_val.type == MIN_COLUMN || mul2->min_max_val.type == MAX_COLUMN);
+		  if (mul2->min_max_val.type == MIN_COLUMN)
+		    {
+		      c = DB_GT;
+		    }
+		  else
+		    {
+		      c = DB_LT;
+		    }
 		}
 	      else
 		{
@@ -8511,7 +8520,16 @@ pr_midxkey_compare (DB_MIDXKEY * mul1, DB_MIDXKEY * mul2, int do_coercion, int t
 	      /* val 1 unbound, val 2 bound */
 	      if (mul1->min_max_val.position == i)
 		{
-		  c = mul1->min_max_val.type == MIN_COLUMN ? DB_LT : DB_GT;
+		  /* safeguard */
+		  assert (mul1->min_max_val.type == MIN_COLUMN || mul1->min_max_val.type == MAX_COLUMN);
+		  if (mul1->min_max_val.type == MIN_COLUMN)
+		    {
+		      c = DB_LT;
+		    }
+		  else
+		    {
+		      c = DB_GT;
+		    }
 		}
 	      else
 		{
@@ -8543,12 +8561,28 @@ pr_midxkey_compare (DB_MIDXKEY * mul1, DB_MIDXKEY * mul2, int do_coercion, int t
 		    }
 		  else
 		    {
-		      c = DB_GT;
+		      assert (mul1->min_max_val.type == MIN_COLUMN || mul1->min_max_val.type == MAX_COLUMN);
+		      if (mul1->min_max_val.type == MIN_COLUMN)
+			{
+			  c = DB_LT;
+			}
+		      else
+			{
+			  c = DB_GT;
+			}
 		    }
 		}
 	      else if (mul2->min_max_val.position == i)
 		{
-		  c = DB_LT;
+		  assert (mul2->min_max_val.type == MIN_COLUMN || mul2->min_max_val.type == MAX_COLUMN);
+		  if (mul2->min_max_val.type == MIN_COLUMN)
+		    {
+		      c = DB_GT;
+		    }
+		  else
+		    {
+		      c = DB_LT;
+		    }
 		}
 	      else
 		{

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -14766,7 +14766,7 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
 		    {		/* CASE 1, 2 */
 		      if (dp->is_desc != true)
 			{	/* CASE 1 */
-			  ;	/* nop */
+			  minmax = BTREE_COERCE_KEY_WITH_MIN_VALUE;
 			}
 		      else
 			{	/* CASE 2 */
@@ -14781,7 +14781,7 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
 			}
 		      else
 			{	/* CASE 4 */
-			  ;	/* nop */
+			  minmax = BTREE_COERCE_KEY_WITH_MIN_VALUE;
 			}
 		    }
 		}
@@ -14791,7 +14791,7 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
 		    {		/* CASE 1, 2 */
 		      if (dp->is_desc != true)
 			{	/* CASE 1 */
-			  ;	/* nop */
+			  minmax = BTREE_COERCE_KEY_WITH_MAX_VALUE;
 			}
 		      else
 			{	/* CASE 2 */
@@ -14806,18 +14806,15 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
 			}
 		      else
 			{	/* CASE 4 */
-			  ;	/* nop */
+			  minmax = BTREE_COERCE_KEY_WITH_MAX_VALUE;
 			}
 		    }
 		}
 
 	      if (minmax == BTREE_COERCE_KEY_WITH_MIN_VALUE)
 		{
-		  if (dsize < keysize)
-		    {
-		      midxkey->min_max_val.position = dsize;
-		      midxkey->min_max_val.type = MIN_COLUMN;
-		    }
+		  midxkey->min_max_val.position = dsize;
+		  midxkey->min_max_val.type = MIN_COLUMN;
 		}
 	      else if (minmax == BTREE_COERCE_KEY_WITH_MAX_VALUE)
 		{


### PR DESCRIPTION
…s (#948)

http://jira.cubrid.org/browse/CBRD-21807

This will implement proper usage of a MIN_VALUE column type in a MIDXKEY. It will also do the correct comparison of two midxkeys, since the last implementation would fail to correctly handle the case when a NULL value will be compared against a respective value from the other MIDXKEY, which had its corresponding column set to MIN_VALUE.