### PR TITLE
[CBRD-21558] 10.1p1: inline functions for string compression (#839)

### DIFF
--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -1519,12 +1519,99 @@ extern int or_mvcc_set_log_lsa_to_record (RECDES * record, LOG_LSA * lsa);
 extern char *or_pack_sha1 (char *ptr, const SHA1Hash * sha1);
 extern char *or_unpack_sha1 (char *ptr, SHA1Hash * sha1);
 
+STATIC_INLINE int or_get_string_size_byte (OR_BUF * buf, int *error) __attribute__ ((ALWAYS_INLINE));
 /* Get the compressed and the decompressed lengths of a string stored in buffer */
-extern int or_get_varchar_compression_lengths (OR_BUF * buf, int *compressed_size, int *decompressed_size);
+STATIC_INLINE int or_get_varchar_compression_lengths (OR_BUF * buf, int *compressed_size, int *decompressed_size)
+  __attribute__ ((ALWAYS_INLINE));
 
 extern int or_packed_spacedb_size (const SPACEDB_ALL * all, const SPACEDB_ONEVOL * vols, const SPACEDB_FILES * files);
 extern char *or_pack_spacedb (char *ptr, const SPACEDB_ALL * all, const SPACEDB_ONEVOL * vols,
 			      const SPACEDB_FILES * files);
 extern char *or_unpack_spacedb (char *ptr, SPACEDB_ALL * all, SPACEDB_ONEVOL ** vols, SPACEDB_FILES * files);
+
+/* Because of the VARNCHAR and STRING encoding, this one could not be changed for over 255, just lower. */
+#define OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION 255
+
+/*
+ * or_get_string_size_byte - read string size byte value from or buffer
+ *    return: byte value read
+ *    buf(in/out): or buffer
+ *    error(out): NO_ERROR or error code
+ *
+ * NOTE that it is really same as or_get_byte function. It is duplicated to inline the function for performance.
+ */
+STATIC_INLINE int
+or_get_string_size_byte (OR_BUF * buf, int *error)
+{
+  int size_prefix;
+
+  if ((buf->ptr + OR_BYTE_SIZE) > buf->endptr)
+    {
+      *error = or_underflow (buf);
+      size_prefix = 0;
+    }
+  else
+    {
+      size_prefix = OR_GET_BYTE (buf->ptr);
+      buf->ptr += OR_BYTE_SIZE;
+      *error = NO_ERROR;
+    }
+  return size_prefix;
+}
+
+/* or_get_varchar_compression_lengths() - Function to get the compressed length and the uncompressed length of 
+ *					  a compressed string.
+ * 
+ * return                 : NO_ERROR or error_code.
+ * buf(in)                : The buffer where the string is stored.
+ * compressed_size(out)   : The compressed size of the string. Set to 0 if the string was not compressed.
+ * decompressed_size(out) : The uncompressed size of the string.
+ */
+STATIC_INLINE int
+or_get_varchar_compression_lengths (OR_BUF * buf, int *compressed_size, int *decompressed_size)
+{
+  int compressed_length = 0, decompressed_length = 0, rc = NO_ERROR, net_charlen = 0;
+  int size_prefix = 0;
+
+  /* Check if the string is compressed */
+  size_prefix = or_get_string_size_byte (buf, &rc);
+  if (rc != NO_ERROR)
+    {
+      assert (size_prefix == 0);
+      return rc;
+    }
+
+  if (size_prefix == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+    {
+      /* String was compressed */
+      /* Get the compressed size */
+      rc = or_get_data (buf, (char *) &net_charlen, OR_INT_SIZE);
+      compressed_length = OR_GET_INT ((char *) &net_charlen);
+      if (rc != NO_ERROR)
+	{
+	  return rc;
+	}
+      *compressed_size = compressed_length;
+
+      net_charlen = 0;
+
+      /* Get the decompressed size */
+      rc = or_get_data (buf, (char *) &net_charlen, OR_INT_SIZE);
+      decompressed_length = OR_GET_INT ((char *) &net_charlen);
+      if (rc != NO_ERROR)
+	{
+	  return rc;
+	}
+      *decompressed_size = decompressed_length;
+    }
+  else
+    {
+      /* String was not compressed so we set compressed_size to 0 to know that no compression happened. */
+      *compressed_size = 0;
+      *decompressed_size = size_prefix;
+    }
+
+  return rc;
+}
 
 #endif /* _OBJECT_REPRESENTATION_H_ */

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -6779,53 +6779,6 @@ db_set_connect_status (int status)
 }
 
 /*
- *  db_set_compressed_string()	    :- Sets the compressed string, its size and its need for clear in the DB_VALUE
- *
- *  value(in/out)		    :- The DB_VALUE
- *  compressed_string(in)	    :-
- *  compressed_size(in)		    :-
- *  compressed_need_clear(in)	    :-
- */
-void
-db_set_compressed_string (DB_VALUE * value, char *compressed_string, int compressed_size, bool compressed_need_clear)
-{
-  DB_TYPE type;
-
-  if (value == NULL || DB_IS_NULL (value))
-    {
-      return;
-    }
-  type = DB_VALUE_DOMAIN_TYPE (value);
-
-  /* Preliminary check */
-  assert (type == DB_TYPE_VARCHAR || type == DB_TYPE_VARNCHAR);
-
-  value->data.ch.medium.compressed_buf = compressed_string;
-  value->data.ch.medium.compressed_size = compressed_size;
-  value->data.ch.info.compressed_need_clear = compressed_need_clear;
-
-  return;
-}
-
-int
-db_get_compressed_size (DB_VALUE * value)
-{
-  DB_TYPE type;
-
-  if (value == NULL || DB_IS_NULL (value))
-    {
-      return 0;
-    }
-
-  type = DB_VALUE_DOMAIN_TYPE (value);
-
-  /* Preliminary check */
-  assert (type == DB_TYPE_VARCHAR || type == DB_TYPE_VARNCHAR);
-
-  return value->data.ch.medium.compressed_size;
-}
-
-/*
  * db_default_expression_string() - 
  * return : string opcode of default expression
  * default_expr_type(in):

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -31,6 +31,9 @@
 
 #include "config.h"
 
+#include <assert.h>
+
+#include "porting.h"
 #include "dbdef.h"
 
 /*
@@ -181,7 +184,7 @@
 #define DB_MAX_PARTITION_EXPR_LENGTH 2048
 
 /* Defines the state of a value as not being compressable due to its bad compression size or 
- * its uncompressed size being lower than PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
+ * its uncompressed size being lower than OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
  */
 #define DB_UNCOMPRESSABLE -1
 
@@ -1175,8 +1178,56 @@ extern int valcnv_convert_value_to_string (DB_VALUE * value);
 extern int db_get_enum_codeset (const DB_VALUE * value);
 extern int db_get_enum_collation (const DB_VALUE * value);
 
-extern int db_get_compressed_size (DB_VALUE * value);
-extern void db_set_compressed_string (DB_VALUE * value, char *compressed_string,
-				      int compressed_size, bool compressed_need_clear);
+STATIC_INLINE int db_get_compressed_size (DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void db_set_compressed_string (DB_VALUE * value, char *compressed_string,
+					     int compressed_size, bool compressed_need_clear)
+  __attribute__ ((ALWAYS_INLINE));
+
+int
+db_get_compressed_size (DB_VALUE * value)
+{
+  DB_TYPE type;
+
+  if (value == NULL || DB_IS_NULL (value))
+    {
+      return 0;
+    }
+
+  type = DB_VALUE_DOMAIN_TYPE (value);
+
+  /* Preliminary check */
+  assert (type == DB_TYPE_VARCHAR || type == DB_TYPE_VARNCHAR);
+
+  return value->data.ch.medium.compressed_size;
+}
+
+/*
+ *  db_set_compressed_string() - Sets the compressed string, its size and its need for clear in the DB_VALUE
+ *
+ *  value(in/out)             : The DB_VALUE
+ *  compressed_string(in)     :
+ *  compressed_size(in)       :
+ *  compressed_need_clear(in) :
+ */
+STATIC_INLINE void
+db_set_compressed_string (DB_VALUE * value, char *compressed_string, int compressed_size, bool compressed_need_clear)
+{
+  DB_TYPE type;
+
+  if (value == NULL || DB_IS_NULL (value))
+    {
+      return;
+    }
+  type = DB_VALUE_DOMAIN_TYPE (value);
+
+  /* Preliminary check */
+  assert (type == DB_TYPE_VARCHAR || type == DB_TYPE_VARNCHAR);
+
+  value->data.ch.medium.compressed_buf = compressed_string;
+  value->data.ch.medium.compressed_size = compressed_size;
+  value->data.ch.info.compressed_need_clear = compressed_need_clear;
+
+  return;
+}
 
 #endif /* _DBTYPE_H_ */

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2094,7 +2094,7 @@ pr_clear_value (DB_VALUE * value)
 		  db_private_free_and_init (NULL, data);
 		}
 	    }
-	  DB_SET_COMPRESSED_STRING (value, NULL, 0, false);
+	  db_set_compressed_string (value, NULL, 0, false);
 	}
       else if (db_type == DB_TYPE_CHAR || db_type == DB_TYPE_NCHAR)
 	{
@@ -10901,7 +10901,7 @@ mr_data_lengthmem_string (void *memptr, TP_DOMAIN * domain, int disk)
       if (cur != NULL)
 	{
 	  len = *(int *) cur;
-	  if (len >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+	  if (len >= OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	    {
 	      /* Skip the length of the string */
 	      len = pr_get_compression_length ((cur + sizeof (int)), len) + PRIM_TEMPORARY_DISK_SIZE;
@@ -10926,12 +10926,12 @@ mr_index_lengthmem_string (void *memptr, TP_DOMAIN * domain)
 
   /* generally, index key-value is short enough */
   charlen = OR_GET_BYTE (memptr);
-  if (charlen < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (charlen < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       return or_varchar_length (charlen);
     }
 
-  assert (charlen == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (charlen == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   or_init (&buf, memptr, -1);
 
@@ -11284,7 +11284,7 @@ mr_lengthval_string_internal (DB_VALUE * value, int disk, int align)
 	  len = value->data.ch.medium.size;
 	}
 
-      if (len >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION && is_temporary_data == false)
+      if (len >= OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION && is_temporary_data == false)
 	{
 	  /* The compression failed but the size of the string calls for the new encoding. */
 	  len += PRIM_TEMPORARY_DISK_SIZE;
@@ -11345,7 +11345,7 @@ mr_writeval_string_internal (OR_BUF * buf, DB_VALUE * value, int align)
       compressed_size = DB_GET_COMPRESSED_SIZE (value);
       compressed_string = DB_GET_COMPRESSED_STRING (value);
 
-      if (compressed_size == DB_UNCOMPRESSABLE && src_length < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+      if (compressed_size == DB_UNCOMPRESSABLE && src_length < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
 	  rc = pr_write_uncompressed_string_to_buffer (buf, str, src_length, align);
 	}
@@ -11469,7 +11469,7 @@ mr_readval_string_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, 
 	      memcpy (compressed_string, start, compressed_size);
 	      compressed_string[compressed_size] = '\0';
 
-	      DB_SET_COMPRESSED_STRING (value, compressed_string, compressed_size, true);
+	      db_set_compressed_string (value, compressed_string, compressed_size, true);
 	    }
 	  else
 	    {
@@ -11479,7 +11479,7 @@ mr_readval_string_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, 
 	      db_make_varchar (value, precision, buf->ptr, decompressed_size, TP_DOMAIN_CODESET (domain),
 			       TP_DOMAIN_COLLATION (domain));
 	      value->need_clear = false;
-	      DB_SET_COMPRESSED_STRING (value, NULL, DB_UNCOMPRESSABLE, false);
+	      db_set_compressed_string (value, NULL, DB_UNCOMPRESSABLE, false);
 	    }
 
 	  or_skip_varchar_remainder (buf, str_length, align);
@@ -11645,7 +11645,7 @@ mr_readval_string_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, 
 		      compressed_need_clear = false;
 		    }
 
-		  DB_SET_COMPRESSED_STRING (value, compressed_string, compressed_size, compressed_need_clear);
+		  db_set_compressed_string (value, compressed_string, compressed_size, compressed_need_clear);
 
 		  if (size == -1)
 		    {
@@ -11715,8 +11715,7 @@ mr_data_cmpdisk_string (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
   /* generally, data is short enough */
   str_length1 = OR_GET_BYTE (str1);
   str_length2 = OR_GET_BYTE (str2);
-  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
-      && str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length1 < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION && str_length2 < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       str1 += OR_BYTE_SIZE;
       str2 += OR_BYTE_SIZE;
@@ -11725,12 +11724,12 @@ mr_data_cmpdisk_string (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
       return c;
     }
 
-  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
-	  || str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (str_length1 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
+	  || str_length2 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* String 1 */
   or_init (&buf1, str1, 0);
-  if (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length1 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf1, &str1_compressed_length, &str1_decompressed_length);
       if (rc != NO_ERROR)
@@ -11773,7 +11772,7 @@ mr_data_cmpdisk_string (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
 
   or_init (&buf2, str2, 0);
 
-  if (str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length2 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf2, &str2_compressed_length, &str2_decompressed_length);
       if (rc != NO_ERROR)
@@ -14071,7 +14070,7 @@ mr_lengthval_varnchar_internal (DB_VALUE * value, int disk, int align)
 	  len = src_size;
 	}
 
-      if (len >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION && is_temporary_data == false)
+      if (len >= OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION && is_temporary_data == false)
 	{
 	  /* The compression failed but the size of the string calls for the new encoding. */
 	  len += PRIM_TEMPORARY_DISK_SIZE;
@@ -14177,7 +14176,7 @@ mr_writeval_varnchar_internal (OR_BUF * buf, DB_VALUE * value, int align)
       compressed_size = DB_GET_COMPRESSED_SIZE (value);
       compressed_string = DB_GET_COMPRESSED_STRING (value);
 
-      if (compressed_size == DB_UNCOMPRESSABLE && src_size < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+      if (compressed_size == DB_UNCOMPRESSABLE && src_size < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
 	{
 	  rc = pr_write_uncompressed_string_to_buffer (buf, str, src_size, align);
 	}
@@ -14325,7 +14324,7 @@ mr_readval_varnchar_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain
 	      compressed_size = DB_UNCOMPRESSABLE;
 	    }
 
-	  DB_SET_COMPRESSED_STRING (value, compressed_string, compressed_size, compressed_need_clear);
+	  db_set_compressed_string (value, compressed_string, compressed_size, compressed_need_clear);
 
 	  or_skip_varchar_remainder (buf, str_length, align);
 	}
@@ -14492,7 +14491,7 @@ mr_readval_varnchar_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain
 		      compressed_need_clear = false;
 		    }
 
-		  DB_SET_COMPRESSED_STRING (value, compressed_string, compressed_size, compressed_need_clear);
+		  db_set_compressed_string (value, compressed_string, compressed_size, compressed_need_clear);
 
 		  if (size == -1)
 		    {
@@ -14588,8 +14587,7 @@ mr_data_cmpdisk_varnchar (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
   /* generally, data is short enough */
   str_length1 = OR_GET_BYTE (str1);
   str_length2 = OR_GET_BYTE (str2);
-  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
-      && str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length1 < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION && str_length2 < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       str1 += OR_BYTE_SIZE;
       str2 += OR_BYTE_SIZE;
@@ -14599,12 +14597,12 @@ mr_data_cmpdisk_varnchar (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
       return c;
     }
 
-  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
-	  || str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (str_length1 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
+	  || str_length2 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* String 1 */
   or_init (&buf1, str1, 0);
-  if (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length1 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf1, &str1_compressed_length, &str1_decompressed_length);
       if (rc != NO_ERROR)
@@ -14644,7 +14642,7 @@ mr_data_cmpdisk_varnchar (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
 
   /* String 2 */
   or_init (&buf2, str2, 0);
-  if (str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length2 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf2, &str2_compressed_length, &str2_decompressed_length);
       if (rc != NO_ERROR)
@@ -16643,7 +16641,7 @@ pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * va
 
   /* Checks to be sure that we have the correct input */
   assert (DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_VARNCHAR || DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_STRING);
-  assert (DB_GET_STRING_SIZE (value) >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (DB_GET_STRING_SIZE (value) >= OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   save_error_abort = buf->error_abort;
   buf->error_abort = 0;
@@ -16789,7 +16787,7 @@ pr_write_compressed_string_to_buffer (OR_BUF * buf, char *compressed_string, int
   int storage_length = 0;
   int rc = NO_ERROR;
 
-  assert (decompressed_length >= PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (decompressed_length >= OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* store the size prefix */
   rc = or_put_byte (buf, 0xFF);
@@ -16849,7 +16847,7 @@ pr_write_compressed_string_to_buffer (OR_BUF * buf, char *compressed_string, int
 
 /*
  * pr_write_uncompressed_string_to_buffer()   :-  Writes a string with a size less than
- *						  PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION to buffer.
+ *						  OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION to buffer.
  * 
  * return				      :- NO_ERROR or error code.
  * buf(in/out)				      :- Buffer to be written to.
@@ -16863,7 +16861,7 @@ pr_write_uncompressed_string_to_buffer (OR_BUF * buf, char *string, int size, in
 {
   int rc = NO_ERROR;
 
-  assert (size < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (size < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* Store the size prefix */
   rc = or_put_byte (buf, size);
@@ -16916,7 +16914,7 @@ pr_data_compress_string (char *string, int str_length, char *compressed_string, 
 
   *compressed_length = 0;
 
-  if (str_length < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       return rc;
     }
@@ -17019,7 +17017,7 @@ pr_clear_compressed_string (DB_VALUE * value)
       db_private_free_and_init (NULL, data);
     }
 
-  DB_SET_COMPRESSED_STRING (value, NULL, 0, false);
+  db_set_compressed_string (value, NULL, 0, false);
 
   return NO_ERROR;
 }
@@ -17062,7 +17060,7 @@ pr_do_db_value_string_compression (DB_VALUE * value)
   string = db_get_string (value);
   src_size = db_get_string_size (value);
 
-  if (!pr_Enable_string_compression || src_size < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (!pr_Enable_string_compression || src_size < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       /* Either compression was disabled or the source size is less than the compression threshold. */
       value->data.ch.medium.compressed_buf = NULL;
@@ -17090,13 +17088,13 @@ pr_do_db_value_string_compression (DB_VALUE * value)
   if (compressed_size > 0)
     {
       /* Compression successful */
-      DB_SET_COMPRESSED_STRING (value, compressed_string, compressed_size, true);
+      db_set_compressed_string (value, compressed_string, compressed_size, true);
       return rc;
     }
   else
     {
       /* Compression failed */
-      DB_SET_COMPRESSED_STRING (value, NULL, -1, false);
+      db_set_compressed_string (value, NULL, -1, false);
       goto error;
     }
 

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -361,9 +361,6 @@ extern int pr_data_compress_string (char *string, int str_length, char *compress
 extern int pr_clear_compressed_string (DB_VALUE * value);
 extern int pr_do_db_value_string_compression (DB_VALUE * value);
 
-/* Because of the VARNCHAR and STRING encoding, this one could not be changed for over 255, just lower. */
-#define PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION 255
-
 #define PRIM_TEMPORARY_DISK_SIZE 256
 #define PRIM_COMPRESSION_LENGTH_OFFSET 4
 

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -1273,7 +1273,7 @@ or_varchar_length_internal (int charlen, int align)
 {
   int len;
 
-  if (charlen < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (charlen < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       len = OR_BYTE_SIZE + charlen;
     }
@@ -1343,13 +1343,13 @@ or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align)
   buf->error_abort = 0;
 
   /* store the size prefix */
-  if (charlen < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (charlen < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_put_byte (buf, charlen);
     }
   else
     {
-      rc = or_put_byte (buf, PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+      rc = or_put_byte (buf, OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
       compressable = true;
     }
 
@@ -8385,62 +8385,6 @@ htond (double from)
 #endif /* ! OR_HAVE_HTOND */
 
 #endif /* OR_BYTE_ORDER == OR_LITTLE_ENDIAN */
-
-/* or_get_varchar_comp_lengths()  :   Function to get the compressed length
- *				      and the uncompressed length of a compressed string.
- *
- * return			  :   NO_ERROR or error_code.
- * buf(in)			  :   The buffer where the string is stored.
- * compressed_size(out)		  :   The compressed size of the string. Set to 0 if the string was not compressed.
- * decompressed_size(out)	  :   The uncompressed size of the string.
- */
-
-int
-or_get_varchar_compression_lengths (OR_BUF * buf, int *compressed_size, int *decompressed_size)
-{
-  int compressed_length = 0, decompressed_length = 0, rc = NO_ERROR, net_charlen = 0;
-  int size_prefix = 0;
-
-  /* Check if the string is compressed */
-  size_prefix = or_get_byte (buf, &rc);
-  if (rc != NO_ERROR)
-    {
-      assert (size_prefix == 0);
-      return rc;
-    }
-
-  if (size_prefix == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
-    {
-      /* String was compressed */
-      /* Get the compressed size */
-      rc = or_get_data (buf, (char *) &net_charlen, OR_INT_SIZE);
-      compressed_length = OR_GET_INT ((char *) &net_charlen);
-      if (rc != NO_ERROR)
-	{
-	  return rc;
-	}
-      *compressed_size = compressed_length;
-
-      net_charlen = 0;
-
-      /* Get the decompressed size */
-      rc = or_get_data (buf, (char *) &net_charlen, OR_INT_SIZE);
-      decompressed_length = OR_GET_INT ((char *) &net_charlen);
-      if (rc != NO_ERROR)
-	{
-	  return rc;
-	}
-      *decompressed_size = decompressed_length;
-    }
-  else
-    {
-      /* String was not compressed so we set compressed_size to 0 to know that no compression happened. */
-      *compressed_size = 0;
-      *decompressed_size = size_prefix;
-    }
-
-  return rc;
-}
 
 /*
  * or_packed_spacedb_size () - compute the size required to pack all space info

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -17992,8 +17992,7 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
   /* generally, data is short enough */
   str_length1 = OR_GET_BYTE (str1);
   str_length2 = OR_GET_BYTE (str2);
-  if (str_length1 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
-      && str_length2 < PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length1 < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION && str_length2 < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       str1 += OR_BYTE_SIZE;
       str2 += OR_BYTE_SIZE;
@@ -18001,12 +18000,12 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
       return c;
     }
 
-  assert (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
-	  || str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (str_length1 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION
+	  || str_length2 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   /* String 1 */
   or_init (&buf1, str1, 0);
-  if (str_length1 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length1 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf1, &str1_compressed_length, &str1_decompressed_length);
       if (rc != NO_ERROR)
@@ -18047,7 +18046,7 @@ bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, 
 
   /* String 2 */
   or_init (&buf2, str2, 0);
-  if (str_length2 == PRIM_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
+  if (str_length2 == OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
     {
       rc = or_get_varchar_compression_lengths (&buf2, &str2_compressed_length, &str2_decompressed_length);
       if (rc != NO_ERROR)


### PR DESCRIPTION
* inline or_get_varchar_compression_lengths, db_set_compressed_string and db_get_compressed_size

* change OR_GET_STRING_SIZE_BYTE as or_get_string_size_byte