### PR TITLE
[CBRD-21827] Fix worker pool stop & concurrent tasks

### DIFF
--- a/src/base/error_manager.h
+++ b/src/base/error_manager.h
@@ -291,12 +291,7 @@ extern "C"
   extern bool er_has_error (void);
   extern void er_print_callstack (const char *file_name, const int line_no, const char *fmt, ...);
 
-#define ER_LOG(...) _er_log_debug (ARG_FILE_LINE, __VA_ARGS__)
-
 #ifdef __cplusplus
-
-// c++ only
-#define ER_LOG_FUNC(msg, ...) _er_log_debug (ARG_FILE_LINE, __FUNCTION__ ": " msg "\n", __VA_ARGS__)
 }
 #endif
 #endif				/* _ERROR_MANAGER_H_ */

--- a/src/base/error_manager.h
+++ b/src/base/error_manager.h
@@ -291,7 +291,12 @@ extern "C"
   extern bool er_has_error (void);
   extern void er_print_callstack (const char *file_name, const int line_no, const char *fmt, ...);
 
+#define ER_LOG(...) _er_log_debug (ARG_FILE_LINE, __VA_ARGS__)
+
 #ifdef __cplusplus
+
+// c++ only
+#define ER_LOG_FUNC(msg, ...) _er_log_debug (ARG_FILE_LINE, __FUNCTION__ ": " msg "\n", __VA_ARGS__)
 }
 #endif
 #endif				/* _ERROR_MANAGER_H_ */

--- a/src/base/resource_shared_pool.hpp
+++ b/src/base/resource_shared_pool.hpp
@@ -30,30 +30,32 @@ template <class T>
 class resource_shared_pool
 {
 public:
-  resource_shared_pool (size_t size)
+  resource_shared_pool (size_t size, allow_claimed_on_destruction = false)
     : m_size (size)
     , m_free_stack_size (size)
     , m_mutex ()
+    , m_allow_claimed_on_destruction (allow_claimed_on_destruction)
   {
     m_resources = new T [size];
     m_own_resources = m_resources;
     populate_free_stack ();
   }
 
-  resource_shared_pool (T * resources, size_t size)
+  resource_shared_pool (T * resources, size_t size, allow_claimed_on_destruction = false)
     : m_size (size)
     , m_free_stack_size (size)
     , m_mutex ()
     , m_resources (resources)
     , m_own_resources (NULL)
     , m_free_stack (NULL)
+    , m_allow_claimed_on_destruction (allow_claimed_on_destruction)
   {
     populate_free_stack ();
   }
 
   ~resource_shared_pool ()
   {
-    assert (m_free_stack_size == m_size);
+    assert (m_allow_claimed_on_destruction || m_free_stack_size == m_size);
     delete [] m_free_stack;
     delete [] m_own_resources;
   }
@@ -100,6 +102,8 @@ private:
   T * m_resources;
   T * m_own_resources;
   T ** m_free_stack;
+
+  bool m_allow_claimed_on_destruction;
 };
 
 #endif // _RESOURCE_SHARED_POOL_HPP_

--- a/src/base/resource_shared_pool.hpp
+++ b/src/base/resource_shared_pool.hpp
@@ -30,7 +30,7 @@ template <class T>
 class resource_shared_pool
 {
 public:
-  resource_shared_pool (size_t size, allow_claimed_on_destruction = false)
+  resource_shared_pool (size_t size, bool allow_claimed_on_destruction = false)
     : m_size (size)
     , m_free_stack_size (size)
     , m_mutex ()
@@ -41,7 +41,7 @@ public:
     populate_free_stack ();
   }
 
-  resource_shared_pool (T * resources, size_t size, allow_claimed_on_destruction = false)
+  resource_shared_pool (T * resources, size_t size, bool allow_claimed_on_destruction = false)
     : m_size (size)
     , m_free_stack_size (size)
     , m_mutex ()

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -632,6 +632,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_CONNECTION_LOGGING "connection_logging"
 
+#define PRM_NAME_THREAD_LOGGING_FLAG "thread_logging_flag"
+
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
 #define PRM_VALUE_MIN "MIN"
@@ -2106,6 +2108,10 @@ static unsigned int prm_json_log_allocations_flag = 0;
 bool PRM_CONNECTION_LOGGING = false;
 static bool prm_connection_logging_default = false;
 static unsigned int prm_connection_logging_flag = 0;
+
+int PRM_THREAD_LOGGING_FLAG = 0;
+static int prm_thread_logging_flag_default = 0;
+static unsigned int prm_thread_logging_flag_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5332,6 +5338,17 @@ static SYSPRM_PARAM prm_Def[] = {
    &prm_connection_logging_flag,
    (void *) &prm_connection_logging_default,
    (void *) &PRM_CONNECTION_LOGGING,
+   (void *) NULL, (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_THREAD_LOGGING_FLAG,
+   PRM_NAME_THREAD_LOGGING_FLAG,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_INTEGER,
+   &prm_thread_logging_flag_flag,
+   (void *) &prm_thread_logging_flag_default,
+   (void *) &PRM_THREAD_LOGGING_FLAG,
    (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -405,8 +405,10 @@ enum param_id
 
   PRM_ID_CONNECTION_LOGGING,
 
+  PRM_ID_THREAD_LOGGING_FLAG,
+
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_CONNECTION_LOGGING
+  PRM_LAST_ID = PRM_ID_THREAD_LOGGING_FLAG
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1119,8 +1119,7 @@ vacuum_boot (THREAD_ENTRY * thread_p)
   vacuum_Worker_threads =
     thread_manager->create_worker_pool (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT),
 					VACUUM_JOB_QUEUE_CAPACITY,
-                                        vacuum_Worker_context_manager,
-                                        log_vacuum_worker_pool);
+					vacuum_Worker_context_manager, log_vacuum_worker_pool);
   assert (vacuum_Worker_threads != NULL);
 
   // create vacuum master thread

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -7948,7 +7948,7 @@ vacuum_convert_thread_to_worker (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker
   save_type = thread_p->type;
   thread_p->type = TT_VACUUM_WORKER;
   thread_p->vacuum_worker = worker;
-  if (vacuum_worker_allocate_resources (thread_p, thread_p->vacuum_worker) != NULL)
+  if (vacuum_worker_allocate_resources (thread_p, thread_p->vacuum_worker) != NO_ERROR)
     {
       assert_release (false);
     }

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1108,7 +1108,9 @@ vacuum_boot (THREAD_ENTRY * thread_p)
   // create thread pool
   vacuum_Worker_threads =
     thread_manager->create_worker_pool (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT),
-					VACUUM_JOB_QUEUE_CAPACITY, vacuum_Worker_context_manager);
+					VACUUM_JOB_QUEUE_CAPACITY,
+                                        vacuum_Worker_context_manager,
+                                        true);
   assert (vacuum_Worker_threads != NULL);
 
   // create vacuum master thread

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -271,26 +271,31 @@ struct vacuum_data
 #if defined (SA_MODE)
   bool is_vacuum_complete;
 #endif				/* SA_MODE */
-};
-static VACUUM_DATA vacuum_Data = {
-  VFID_INITIALIZER,		/* vacuum_data_file */
-  VACUUM_NULL_LOG_BLOCKID,	/* last_blockid */
-  NULL_PAGEID,			/* keep_from_log_pageid */
-  MVCCID_NULL,			/* oldest_unvacuumed_mvccid */
-  NULL,				/* first_page */
-  NULL,				/* last_page */
-  0,				/* page_data_max_count */
-  0,				/* log_block_npages */
-  false,			/* is_loaded */
-  false,			/* shutdown_requested */
-  false,			/* is_archive_removal_safe */
-  VPID_INITIALIZER,		/* vpid_job_cursor */
-  0,				/* blockid_job_cursor */
-  LSA_INITIALIZER		/* recovery_lsa */
+
+  /* *INDENT-OFF* */
+  vacuum_data ()
+    : vacuum_data_file (VFID_INITIALIZER)
+    , last_blockid (VACUUM_NULL_LOG_BLOCKID)
+    , keep_from_log_pageid (NULL_PAGEID)
+    , oldest_unvacuumed_mvccid (MVCCID_NULL)
+    , first_page (NULL)
+    , last_page (NULL)
+    , page_data_max_count (0)
+    , log_block_npages (0)
+    , is_loaded (false)
+    , shutdown_requested (false)
+    , is_archive_removal_safe (false)
+    , vpid_job_cursor (VPID_INITIALIZER)
+    , blockid_job_cursor (0)
+    , recovery_lsa (LSA_INITIALIZER)
 #if defined (SA_MODE)
-    , false			/* is_vacuum_complete. */
-#endif /* SA_MODE */
+    , is_vacuum_complete (false)
+#endif // SA_MODE
+  {
+  }
+  /* *INDENT-ON* */
 };
+static VACUUM_DATA vacuum_Data;
 
 /* vacuum data load */
 typedef struct vacuum_data_load VACUUM_DATA_LOAD;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -23,6 +23,7 @@
  */
 #include "vacuum.h"
 
+#include "base_flag.hpp"
 #include "boot_sr.h"
 #include "btree.h"
 #include "dbtype.h"
@@ -1105,12 +1106,17 @@ vacuum_boot (THREAD_ENTRY * thread_p)
   // get thread manager
   auto thread_manager = cubthread::get_manager ();
 
+  // get logging flag for vacuum worker pool
+  bool log_vacuum_worker_pool =
+    flag<int>::is_flag_set (prm_get_integer_value (PRM_ID_THREAD_LOGGING_FLAG), THREAD_LOG_WORKER_POOL_VACUUM)
+    || flag<int>::is_flag_set (prm_get_integer_value (PRM_ID_ER_LOG_VACUUM), VACUUM_ER_LOG_WORKER);
+
   // create thread pool
   vacuum_Worker_threads =
     thread_manager->create_worker_pool (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT),
 					VACUUM_JOB_QUEUE_CAPACITY,
                                         vacuum_Worker_context_manager,
-                                        true);
+                                        log_vacuum_worker_pool);
   assert (vacuum_Worker_threads != NULL);
 
   // create vacuum master thread

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -257,8 +257,10 @@ struct vacuum_data
   int log_block_npages;		/* The number of pages in a log block. */
 
   bool is_loaded;		/* True if vacuum data is loaded. */
+  /* *INDENT-OFF*/
   std::atomic<bool> shutdown_requested;	/* Set to true when shutdown is requested. It stops vacuum from generating or
                                          * executing new jobs. */
+  /* INDENT-ON* */
   bool is_archive_removal_safe;	/* Set to true after keep_from_log_pageid is updated. */
 
   /* Job cursor for vacuum master to avoid going again through jobs already generated */
@@ -1107,9 +1109,11 @@ vacuum_boot (THREAD_ENTRY * thread_p)
   auto thread_manager = cubthread::get_manager ();
 
   // get logging flag for vacuum worker pool
+  /* *INDENT-OFF* */
   bool log_vacuum_worker_pool =
     flag<int>::is_flag_set (prm_get_integer_value (PRM_ID_THREAD_LOGGING_FLAG), THREAD_LOG_WORKER_POOL_VACUUM)
     || flag<int>::is_flag_set (prm_get_integer_value (PRM_ID_ER_LOG_VACUUM), VACUUM_ER_LOG_WORKER);
+  /* *INDENT-ON* */
 
   // create thread pool
   vacuum_Worker_threads =

--- a/src/thread/thread_compat.hpp
+++ b/src/thread/thread_compat.hpp
@@ -28,7 +28,7 @@
 #define _THREAD_COMPAT_HPP_
 
 // forward definition for THREAD_ENTRY
-#if defined (SERVER_MODE)
+#if defined (SERVER_MODE) || (defined (SA_MODE) && defined (__cplusplus))
 #ifndef _THREAD_ENTRY_HPP_
 namespace cubthread
 {
@@ -36,24 +36,6 @@ namespace cubthread
 } // namespace cubthread
 typedef cubthread::entry THREAD_ENTRY;
 #endif // _THREAD_ENTRY_HPP_
-#elif defined (SA_MODE)
-#if defined (__cplusplus)
-// we have the grammar module on stand-alone that is compiled with C and cannot comprehend namespaces. since it doesn't
-// really use thread module, should fall to #else case
-#ifndef _THREAD_ENTRY_HPP_
-// forward definition for THREAD_ENTRY
-namespace cubthread
-{
-  class entry;
-} // namespace cubthread
-typedef cubthread::entry THREAD_ENTRY;
-#endif // _THREAD_ENTRY_HPP_
-#else // not C++
-typedef void THREAD_ENTRY;
-#endif // not C++
-#else // not SERVER_MODE and not SA_MODE
-typedef void THREAD_ENTRY;
-#endif // not SERVER_MODE and not SA_MODE
 
 // system parameter flags for thread logging
 // manager flags
@@ -65,5 +47,10 @@ const int THREAD_LOG_WORKER_POOL_ALL = 0xFF00;    // reserved for thread worker 
 
 const int THREAD_LOG_DAEMON_VACUUM = 0x10000;
 const int THREAD_LOG_DAEMON_ALL = 0xFFFF0000;     // reserved for thread daemons
+
+#else // not SERVER_MODE and not SA_MODE-C++
+// client or SA_MODE annoying grammars
+typedef void THREAD_ENTRY;
+#endif // not SERVER_MODE and not SA_MODE
 
 #endif // _THREAD_COMPAT_HPP_

--- a/src/thread/thread_compat.hpp
+++ b/src/thread/thread_compat.hpp
@@ -55,4 +55,15 @@ typedef void THREAD_ENTRY;
 typedef void THREAD_ENTRY;
 #endif // not SERVER_MODE and not SA_MODE
 
+// system parameter flags for thread logging
+// manager flags
+const int THREAD_LOG_MANAGER = 0x1;
+const int THREAD_LOG_MANAGER_ALL = 0xFF;          // reserved for thread manager
+
+const int THREAD_LOG_WORKER_POOL_VACUUM = 0x100;
+const int THREAD_LOG_WORKER_POOL_ALL = 0xFF00;    // reserved for thread worker pool
+
+const int THREAD_LOG_DAEMON_VACUUM = 0x10000;
+const int THREAD_LOG_DAEMON_ALL = 0xFFFF0000;     // reserved for thread daemons
+
 #endif // _THREAD_COMPAT_HPP_

--- a/src/thread/thread_daemon.cpp
+++ b/src/thread/thread_daemon.cpp
@@ -30,7 +30,7 @@ namespace cubthread
   daemon::~daemon ()
   {
     // thread must be stopped
-    stop ();
+    stop_execution ();
   }
 
   void
@@ -40,20 +40,19 @@ namespace cubthread
   }
 
   void
-  daemon::stop (void)
+  daemon::stop_execution (void)
   {
     // note: this must not be called concurrently
 
-    if (m_looper.is_stopped ())
+    if (m_looper.stop ())
       {
 	// already stopped
 	return;
       }
 
-    // first signal stop
-    m_looper.stop ();
     // make sure thread will wakeup
     wakeup ();
+
     // then wait for thread to finish
     m_thread.join ();
   }

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -90,8 +90,6 @@ namespace cubthread
       // note: this must not be called concurrently
 
     private:
-      using context_stop_func_type = void (*) (void);
-
       template <typename Context>
       static void loop (daemon *daemon_arg, context_manager<Context> *context_manager_arg,
 			task<Context> *exec_arg);     // daemon thread loop function

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -86,10 +86,11 @@ namespace cubthread
       ~daemon();
 
       void wakeup (void);     // wakeup daemon thread
-      void stop (void);       // stop daemon thread from looping and join it
+      void stop_execution (void);       // stop_execution daemon thread from looping and join it
       // note: this must not be called concurrently
 
     private:
+      using context_stop_func_type = void (*) (void);
 
       template <typename Context>
       static void loop (daemon *daemon_arg, context_manager<Context> *context_manager_arg,
@@ -100,6 +101,8 @@ namespace cubthread
       waiter m_waiter;        // thread waiter
       looper m_looper;        // thread looper
       std::thread m_thread;   // the actual daemon thread
+
+      // todo: m_log
   };
 
   /************************************************************************/

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -153,6 +153,14 @@ namespace cubthread
   }
 
   void
+  entry::interrupt_execution (void)
+  {
+    shutdown = true;
+
+    // migrate thread code here
+  }
+
+  void
   entry::request_lock_free_transactions (void)
   {
 #if defined (SERVER_MODE)

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -131,6 +131,9 @@ namespace cubthread
 
       // public functions
 
+      // Context template requirement
+      void interrupt_execution (void);
+
       void request_lock_free_transactions (void);   // todo: lock-free refactoring
 
       // The rules of thumbs is to always use private members. Until a complete refactoring, these members will remain

--- a/src/thread/thread_looper.cpp
+++ b/src/thread/thread_looper.cpp
@@ -93,10 +93,10 @@ namespace cubthread
     m_period_index = 0;
   }
 
-  void
+  bool
   looper::stop (void)
   {
-    m_stop = true;
+    return m_stop.exchange (true);
   }
 
   bool

--- a/src/thread/thread_looper.hpp
+++ b/src/thread/thread_looper.hpp
@@ -25,6 +25,7 @@
 #define _THREAD_LOOPER_HPP_
 
 #include <array>
+#include <atomic>
 #include <chrono>
 
 #include <cassert>
@@ -99,7 +100,7 @@ namespace cubthread
       void reset (void);
 
       // stop looping; no waits after this
-      void stop (void);
+      bool stop (void);
 
       // is looper stopped
       bool is_stopped (void) const;
@@ -122,7 +123,7 @@ namespace cubthread
       delta_time m_periods[MAX_PERIODS];    // period array
 
       std::size_t m_period_index;           // current period index
-      bool m_stop;                          // when true, loop is stopped; no waits
+      std::atomic<bool> m_stop;             // when true, loop is stopped; no waits
   };
 
   /************************************************************************/

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -85,7 +85,7 @@ namespace cubthread
 #if defined (SERVER_MODE)
     for (auto iter = tracker.begin (); iter != tracker.end (); iter = tracker.erase (iter))
       {
-	(*iter)->stop ();
+	(*iter)->stop_execution ();
 	delete *iter;
       }
 #endif // SERVER_MODE
@@ -172,7 +172,7 @@ namespace cubthread
 	    (void) tracker.erase (iter);
 
 	    // stop resource and delete
-	    res->stop ();
+	    res->stop_execution ();
 	    delete res;
 	    res = NULL;
 

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -112,7 +112,8 @@ namespace cubthread
   }
 
   entry_workpool *
-  manager::create_worker_pool (size_t pool_size, size_t work_queue_size, entry_manager *context_manager)
+  manager::create_worker_pool (size_t pool_size, size_t work_queue_size, entry_manager *context_manager,
+                               bool debug_logging)
   {
 #if defined (SERVER_MODE)
     if (is_single_thread ())
@@ -125,7 +126,8 @@ namespace cubthread
 	  {
 	    context_manager = m_entry_manager;
 	  }
-	return create_and_track_resource (m_worker_pools, pool_size, pool_size, work_queue_size, context_manager);
+	return create_and_track_resource (m_worker_pools, pool_size, pool_size, work_queue_size, context_manager,
+                                          debug_logging);
       }
 #else // not SERVER_MODE = SA_MODE
     return NULL;

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -104,7 +104,7 @@ namespace cubthread
       // create a entry_workpool with pool_size number of threads
       // note: if there are not pool_size number of entries available, worker pool is not created and NULL is returned
       entry_workpool *create_worker_pool (size_t pool_size, size_t work_queue_size,
-					  entry_manager *context_manager = NULL);
+					  entry_manager *context_manager = NULL, bool debug_logging = false);
 
       // destroy worker pool
       void destroy_worker_pool (entry_workpool *&worker_pool_arg);

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -57,6 +57,9 @@ namespace cubthread
   //              task_p->retire (); // this will delete task_p
   //            }
   //
+  // NOTE: to use tasks with worker pools, Context should have interrupt_execution () method defined.
+  //       For long execution tasks, it is recommended to check the interrupt condition regularly.
+  //
   template <typename Context>
   class task
   {

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -167,7 +167,7 @@ namespace cubthread
 /* Template implementation                                              */
 /************************************************************************/
 
-#define THREAD_WP_LOG(func, msg, ...) if (m_log) _er_log_debug (func ": " msg "\n", __VA_ARGS__)
+#define THREAD_WP_LOG(func, msg, ...) if (m_log) _er_log_debug (ARG_FILE_LINE, func ": " msg "\n", __VA_ARGS__)
 
 namespace cubthread
 {

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -320,7 +320,7 @@ namespace cubthread
   void
   worker_pool<Context>::run (worker_pool<Context> &pool, std::thread &thread_arg, task_type *task_arg)
   {
-#define THREAD_WP_STATIC_LOG(msg, ...) if (pool.m_log) ER_LOG_FUNC ("run: " msg, __VA_ARGS__)
+#define THREAD_WP_STATIC_LOG(msg, ...) if (pool.m_log) er_log_debug (ARG_FILE_LINE, "run: " msg, __VA_ARGS__)
 
     // create context for task execution
     Context &context = pool.m_context_manager.create_context ();

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -186,7 +186,7 @@ namespace cubthread
     , m_work_queue (work_queue_size)
     , m_context_manager (*context_mgr)
     , m_threads (new std::thread[m_max_workers])
-    , m_thread_dispatcher (m_threads, m_max_workers)
+    , m_thread_dispatcher (m_threads, m_max_workers, true)
     , m_context_pointers (NULL)
     , m_stopped (false)
     , m_log (debug_log)

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -30,6 +30,7 @@
 #include "thread_task.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <mutex>
 #include <thread>
 
@@ -75,14 +76,13 @@ namespace cubthread
   //    // on destroy, worker pools stops execution (jobs in queue are not executed) and joins any running threads
   //
   //  todo:
-  //    [Optional] Specialize worker_pool with thread context.
-  //
   //    [Optional] Define a way to stop worker pool, but to finish executing everything it has in queue.
   //
   template <typename Context>
   class worker_pool
   {
     public:
+      using context_type = Context;
       using task_type = task<Context>;
       using context_manager_type = context_manager<Context>;
 
@@ -98,7 +98,7 @@ namespace cubthread
 
       // stop worker pool; stop all running threads and join
       // note: do not call concurrently
-      void stop (void);
+      void stop_execution (void);
 
       // is_running = is not stopped; when created, a worker pool starts running
       bool is_running (void) const;
@@ -115,6 +115,7 @@ namespace cubthread
       std::size_t get_max_count (void) const;
 
     private:
+      using atomic_context_ptr = std::atomic<context_type*>;
 
       // function executed by worker; executes first task and then continues with any task it finds in queue
       static void run (worker_pool<Context> &pool, std::thread &thread_arg, task_type *work_arg);
@@ -128,8 +129,10 @@ namespace cubthread
       // deregister worker when it stops running
       inline void deregister_worker (std::thread &thread_arg);
 
-      // for debug logging - thread index
+      // thread index
       inline size_t get_thread_index (std::thread &thread_arg);
+
+      void stop_all_contexts (void);
 
       // maximum number of concurrent workers
       const std::size_t m_max_workers;
@@ -152,6 +155,9 @@ namespace cubthread
 
       // thread "dispatcher" - a pool of threads
       resource_shared_pool<std::thread> m_thread_dispatcher;
+
+      // contexts being used, one for each thread. thread <-> context matching based on index
+      atomic_context_ptr* m_context_pointers;
 
       // set to true when stopped
       std::atomic<bool> m_stopped;
@@ -181,10 +187,18 @@ namespace cubthread
     , m_context_manager (*context_mgr)
     , m_threads (new std::thread[m_max_workers])
     , m_thread_dispatcher (m_threads, m_max_workers)
+    , m_context_pointers (NULL)
     , m_stopped (false)
     , m_log (debug_log)
   {
     // new pool with worker count and work queue size
+
+    // m_running_context array => all nulls
+    m_context_pointers = new atomic_context_ptr [m_max_workers];
+    for (std::size_t i = 0; i < m_max_workers; ++i)
+      {
+        m_context_pointers[i] = NULL;
+      }
   }
 
   template <typename Context>
@@ -193,14 +207,18 @@ namespace cubthread
     // not safe to destroy running pools
     assert (m_stopped);
     assert (m_work_queue.is_empty ());
-    delete[] m_threads;
+    delete [] m_threads;
+    delete [] m_context_pointers;
   }
 
   template <typename Context>
   bool
   worker_pool<Context>::try_execute (task_type *work_arg)
   {
-    assert (!m_stopped);
+    if (m_stopped)
+      {
+        return false;
+      }
     std::thread *thread_p = register_worker ();
     if (thread_p != NULL)
       {
@@ -217,11 +235,17 @@ namespace cubthread
   void
   worker_pool<Context>::execute (task_type *work_arg)
   {
-    assert (!m_stopped);
     std::thread *thread_p = register_worker ();
     if (thread_p != NULL)
       {
 	push_execute (*thread_p, work_arg);
+      }
+    else if (m_stopped)
+      {
+        // do not accept other new requests
+        assert (false);
+        work_arg->retire ();
+        return;
       }
     else if (!m_work_queue.produce (work_arg))
       {
@@ -245,7 +269,23 @@ namespace cubthread
 
   template <typename Context>
   void
-  worker_pool<Context>::stop (void)
+  worker_pool<Context>::stop_all_contexts (void)
+  {
+    context_type* context_p = NULL;
+    for (std::size_t i = 0; i < m_max_workers; ++i)
+      {
+        context_p = m_context_pointers[i];
+        if (context_p != NULL)
+          {
+            // indicate execution context to stop
+            context_p->interrupt_execution ();
+          }
+      }
+  }
+
+  template <typename Context>
+  void
+  worker_pool<Context>::stop_execution (void)
   {
     if (m_stopped.exchange (true))
       {
@@ -259,21 +299,45 @@ namespace cubthread
 	// I am responsible with stopping threads
       }
 
-    // join all threads
-    for (std::size_t i = 0; i < m_max_workers; i++)
+    const std::chrono::seconds time_wait_to_thread_stop (30);   // timeout duration = 30 secs
+    const std::chrono::milliseconds time_spin_sleep (10);       // slip between spins for 10 milliseconds
+
+    // stop all thread execution
+    stop_all_contexts ();
+
+    // we need to register all workers to be sure all threads are stopped and nothing new starts
+    auto timeout = std::chrono::system_clock::now () + time_wait_to_thread_stop; // timeout time
+
+    // spin until all threads are registered.
+    std::thread* thread_p;
+    std::size_t stop_count = 0;
+    while (stop_count < m_max_workers && std::chrono::system_clock::now () < timeout)
       {
-	if (m_threads[i].joinable ())
-	  {
-	    m_threads[i].join ();
-            THREAD_WP_LOG ("stop", "joined thread = %zu", i);
-	  }
+        thread_p = register_worker ();
+        if (thread_p == NULL)
+          {
+            // in case new threads have started, tell them to stop
+            stop_all_contexts ();
+
+            // sleep for 10 milliseconds to give running threads a chance to finish
+            std::this_thread::sleep_for (time_spin_sleep);
+          }
         else
           {
-            THREAD_WP_LOG ("stop", "not joinable thread = %zu", i);
+            ++stop_count;
           }
       }
 
-    // retire all tasks that have not been executed
+    if (stop_count < m_max_workers)
+      {
+        assert (false);
+      }
+    else
+      {
+        // all threads are joined
+      }
+
+    // retire all tasks that have not been executed; at this point, no new tasks are produced
     task_type *task = NULL;
     while (m_work_queue.consume (task))
       {
@@ -323,15 +387,21 @@ namespace cubthread
 #define THREAD_WP_STATIC_LOG(msg, ...) if (pool.m_log) _er_log_debug (ARG_FILE_LINE, "run: " msg, __VA_ARGS__)
 
     // create context for task execution
+    std::size_t thread_index = pool.get_thread_index (thread_arg);
     Context &context = pool.m_context_manager.create_context ();
     bool first_loop = true;
+
+    // save to pool contexts too
+    pool.m_context_pointers[thread_index] = &context;
+
+    // this thread should not start after pool is stopped
+    assert (pool.is_running ());
 
     // loop as long as pool is running and there are tasks in queue
     task_type *task_p = task_arg;
     do
       {
-        THREAD_WP_STATIC_LOG ("loop on thread = %zu, context = %p, task = %p", pool.get_thread_index (thread_arg),
-                              &context, task_p);
+        THREAD_WP_STATIC_LOG ("loop on thread = %zu, context = %p, task = %p", thread_index, &context, task_p);
 
 	if (!first_loop)
 	  {
@@ -348,9 +418,10 @@ namespace cubthread
       }
     while (pool.is_running() && pool.m_work_queue.consume (task_p));
 
-    THREAD_WP_STATIC_LOG ("stop on thread = %zu, context = %p", pool.get_thread_index (thread_arg), &context);
+    THREAD_WP_STATIC_LOG ("stop on thread = %zu, context = %p", thread_index, &context);
 
-    // retire thread context
+    // remove context from pool and retire
+    pool.m_context_pointers[thread_index] = NULL;
     pool.m_context_manager.retire_context (context);
 
     // end of run; deregister worker

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -250,12 +250,12 @@ namespace cubthread
     if (m_stopped.exchange (true))
       {
 	// already stopped
-        THREAD_WP_LOG ("stop", "already stopped");
+        THREAD_WP_LOG ("stop", "stop was %s", "true");
 	return;
       }
     else
       {
-        THREAD_WP_LOG ("stop", "stopping");
+        THREAD_WP_LOG ("stop", "stop was %s", "false");
 	// I am responsible with stopping threads
       }
 
@@ -269,7 +269,7 @@ namespace cubthread
 	  }
         else
           {
-            THREAD_WP_LOG ("stop", "not joinable thread = %zu", i)
+            THREAD_WP_LOG ("stop", "not joinable thread = %zu", i);
           }
       }
 
@@ -320,7 +320,7 @@ namespace cubthread
   void
   worker_pool<Context>::run (worker_pool<Context> &pool, std::thread &thread_arg, task_type *task_arg)
   {
-#define THREAD_WP_STATIC_LOG(msg, ...) if (pool.m_log) er_log_debug (ARG_FILE_LINE, "run: " msg, __VA_ARGS__)
+#define THREAD_WP_STATIC_LOG(msg, ...) if (pool.m_log) _er_log_debug (ARG_FILE_LINE, "run: " msg, __VA_ARGS__)
 
     // create context for task execution
     Context &context = pool.m_context_manager.create_context ();
@@ -330,8 +330,8 @@ namespace cubthread
     task_type *task_p = task_arg;
     do
       {
-        THREAD_WP_STATIC_LOG ("loop on thread = %zu, context = %p, task = %p", get_thread_index (thread_arg), &context,
-                              task_p);
+        THREAD_WP_STATIC_LOG ("loop on thread = %zu, context = %p, task = %p", pool.get_thread_index (thread_arg),
+                              &context, task_p);
 
 	if (!first_loop)
 	  {
@@ -348,7 +348,7 @@ namespace cubthread
       }
     while (pool.is_running() && pool.m_work_queue.consume (task_p));
 
-    THREAD_WP_STATIC_LOG ("stop on thread = %zu, context = %p", get_thread_index (thread_arg), &context);
+    THREAD_WP_STATIC_LOG ("stop on thread = %zu, context = %p", pool.get_thread_index (thread_arg), &context);
 
     // retire thread context
     pool.m_context_manager.retire_context (context);
@@ -370,7 +370,7 @@ namespace cubthread
     if (thread_p == NULL)
       {
 	// no threads available
-        THREAD_WP_LOG ("register_worker", "no threads available");
+        THREAD_WP_LOG ("register_worker", "thread_p = %p", NULL);
 	return NULL;
       }
 
@@ -394,7 +394,8 @@ namespace cubthread
   inline void
   worker_pool<Context>::deregister_worker (std::thread &thread_arg)
   {
-    THREAD_WP_LOG ("deregister_worker", "thread = %zu", get_thread_index (thread_arg));
+    // THREAD_WP_LOG ("deregister_worker", "thread = %zu", get_thread_index (thread_arg));
+    // no logging here; no thread & error context
     m_thread_dispatcher.retire (thread_arg);
 #if defined (NO_GCC_44)
     --m_worker_count;

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -320,6 +320,8 @@ namespace cubthread
   void
   worker_pool<Context>::run (worker_pool<Context> &pool, std::thread &thread_arg, task_type *task_arg)
   {
+#define THREAD_WP_STATIC_LOG(msg, ...) if (pool.m_log) ER_LOG_FUNC (msg, __VA_ARGS__)
+
     // create context for task execution
     Context &context = pool.m_context_manager.create_context ();
     bool first_loop = true;
@@ -328,8 +330,8 @@ namespace cubthread
     task_type *task_p = task_arg;
     do
       {
-        THREAD_WP_LOG ("loop on thread = %zu, context = %p, task = %p", get_thread_index (thread_arg), &context,
-                       task_p);
+        THREAD_WP_STATIC_LOG ("loop on thread = %zu, context = %p, task = %p", get_thread_index (thread_arg), &context,
+                              task_p);
 
 	if (!first_loop)
 	  {
@@ -346,13 +348,15 @@ namespace cubthread
       }
     while (pool.is_running() && pool.m_work_queue.consume (task_p));
 
-    THREAD_WP_LOG ("stop on thread = %zu, context = %p", get_thread_index (thread_arg), &context);
+    THREAD_WP_STATIC_LOG ("stop on thread = %zu, context = %p", get_thread_index (thread_arg), &context);
 
     // retire thread context
     pool.m_context_manager.retire_context (context);
 
     // end of run; deregister worker
     pool.deregister_worker (thread_arg);
+
+#undef THREAD_WP_STATIC_LOG
   }
 
   template <typename Context>
@@ -407,5 +411,7 @@ namespace cubthread
     assert (index >= 0 && index < m_max_workers);
     return index;
   }
+
+#undef THREAD_WP_LOG
 
 } // namespace cubthread


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21827

Make worker pool execution stop robust in regard with concurrent task execution.

The bug context - vacuum stop and three thread involved: master thread (calls vacuum_stop), vacuum master thread (is executing vacuum_process_vacuum_data) and vacuum worker. The order of calls:

  1. Vacuum master thread starts pushing task, but is preempted somewhere inside worker_pool->execute
  2. Master thread notifies vacuum to shutdown and stops worker pool.
  3. Vacuum master regains focus, registers thread (or has already registered one) and starts new execution.
  4. Worker pool is destroyed, threads are deleted, but one thread is joinable (crash).

The fix requires worker pool to register all threads in order to stop execution. This prevents any further thread executions from occurring.

Side effects:

  1. Added thread logging flag system parameter.
  2. Allow resource_shared_pool destruction with claimed resources.
  3. Vacuum master checks shutdown request more often.
  4. Interrupt execution: worker pool context template requires interrupt_execution function; worker pool tracks contexts for running threads.
  5. worker pool logging.