### PR TITLE
[CBRD-21497] assigns an idle query id

### DIFF
--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -313,9 +313,10 @@ qmgr_allocate_query_entry (THREAD_ENTRY * thread_p, QMGR_TRAN_ENTRY * tran_entry
 	}
       query_p->query_id = ++tran_entry_p->query_id_generator;
 
-      usable = session_is_queryid_available (thread_p, query_p->query_id, &hint_query_id);
+      usable = session_is_queryid_idle (thread_p, query_p->query_id, &hint_query_id);
       if (usable == true)
 	{
+	  /* it is usable */
 	  break;
 	}
 

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -272,6 +272,11 @@ static QMGR_QUERY_ENTRY *
 qmgr_allocate_query_entry (THREAD_ENTRY * thread_p, QMGR_TRAN_ENTRY * tran_entry_p)
 {
   QMGR_QUERY_ENTRY *query_p;
+  QUERY_ID hint_query_id;
+  int i;
+  bool usable = false;
+
+  static_assert (QMGR_MAX_QUERY_ENTRY_PER_TRAN < SHRT_MAX, "Bad query entry count");
 
   query_p = tran_entry_p->free_query_entry_list_p;
 
@@ -281,6 +286,7 @@ qmgr_allocate_query_entry (THREAD_ENTRY * thread_p, QMGR_TRAN_ENTRY * tran_entry
     }
   else if (QMGR_MAX_QUERY_ENTRY_PER_TRAN < tran_entry_p->num_query_entries)
     {
+      assert (QMGR_MAX_QUERY_ENTRY_PER_TRAN >= tran_entry_p->num_query_entries);
       return NULL;
     }
   else
@@ -298,11 +304,31 @@ qmgr_allocate_query_entry (THREAD_ENTRY * thread_p, QMGR_TRAN_ENTRY * tran_entry
     }
 
   /* assign query id */
-  if (tran_entry_p->query_id_generator >= SHRT_MAX - 2)	/* overflow happened */
+  hint_query_id = 0;
+  for (i = 0; i < QMGR_MAX_QUERY_ENTRY_PER_TRAN; i++)
     {
-      tran_entry_p->query_id_generator = 0;
+      if (tran_entry_p->query_id_generator >= SHRT_MAX - 2)	/* overflow happened */
+	{
+	  tran_entry_p->query_id_generator = 0;
+	}
+      query_p->query_id = ++tran_entry_p->query_id_generator;
+
+      usable = session_is_queryid_available (thread_p, query_p->query_id, &hint_query_id);
+      if (usable == true)
+	{
+	  break;
+	}
+
+      if (i == 0)
+	{
+	  /* optimization: The second try uses the current max query_id as hint. 
+	   * This may help us to quickly locate an available id.
+	   */
+	  assert (hint_query_id != 0);
+	  tran_entry_p->query_id_generator = hint_query_id;
+	}
     }
-  query_p->query_id = ++tran_entry_p->query_id_generator;
+  assert (usable == true);
 
   /* initialize per query temp file VFID structure */
   query_p->next = NULL;
@@ -318,6 +344,15 @@ qmgr_allocate_query_entry (THREAD_ENTRY * thread_p, QMGR_TRAN_ENTRY * tran_entry
   query_p->query_flag = 0;
   query_p->is_holdable = false;
   query_p->is_preserved = false;
+
+#if defined (NDEBUG)
+  /* just a safe guard for a release build. I don't expect it will be hit. */
+  if (usable == false)
+    {
+      qmgr_free_query_entry (thread_p, tran_entry_p, query_p);
+      return NULL;
+    }
+#endif /* NDEBUG */
 
   return query_p;
 }

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -2621,14 +2621,14 @@ session_clear_query_entry_info (THREAD_ENTRY * thread_p, const QUERY_ID query_id
 }
 
 /*
- * session_is_queryid_available () - search for a query entry
- * return : true if the given query_id is inactive, false otherwise
+ * session_is_queryid_idle () - search for a idle query entry among the holable results
+ * return : true if the given query_id is idle, false otherwise
  * thread_p (in) :
  * query_id (in) : query id
  * max_query_id_uses (out): max query id among the active ones. caller may use it as a hint
  */
 bool
-session_is_queryid_available (THREAD_ENTRY * thread_p, const QUERY_ID query_id, QUERY_ID * max_query_id_uses)
+session_is_queryid_idle (THREAD_ENTRY * thread_p, const QUERY_ID query_id, QUERY_ID * max_query_id_uses)
 {
   SESSION_STATE *state_p = NULL;
   SESSION_QUERY_ENTRY *sentry_p = NULL;

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -2531,8 +2531,7 @@ session_load_query_entry_info (THREAD_ENTRY * thread_p, QMGR_QUERY_ENTRY * qentr
 }
 
 /*
- * session_remove_query_entry_info () - remove a query entry from the holdable
- *					queries list
+ * session_remove_query_entry_info () - remove a query entry from the holdable queries list
  * return : error code or NO_ERROR
  * thread_p (in) : active thread
  * query_id (in) : query id
@@ -2542,6 +2541,7 @@ session_remove_query_entry_info (THREAD_ENTRY * thread_p, const QUERY_ID query_i
 {
   SESSION_STATE *state_p = NULL;
   SESSION_QUERY_ENTRY *sentry_p = NULL, *prev = NULL;
+
   state_p = session_get_session_state (thread_p);
   if (state_p == NULL)
     {
@@ -2575,9 +2575,8 @@ session_remove_query_entry_info (THREAD_ENTRY * thread_p, const QUERY_ID query_i
 }
 
 /*
- * session_remove_query_entry_info () - remove a query entry from the holdable
- *					queries list but do not close the
- *					associated list files
+ * session_clear_query_entry_info () - remove a query entry from the holdable queries list but do not close the
+ *				       associated list files
  * return : error code or NO_ERROR
  * thread_p (in) : active thread
  * query_id (in) : query id
@@ -2619,6 +2618,43 @@ session_clear_query_entry_info (THREAD_ENTRY * thread_p, const QUERY_ID query_id
     }
 
   return NO_ERROR;
+}
+
+/*
+ * session_is_queryid_available () - search for a query entry
+ * return : true if the given query_id is inactive, false otherwise
+ * thread_p (in) :
+ * query_id (in) : query id
+ * max_query_id_uses (out): max query id among the active ones. caller may use it as a hint
+ */
+bool
+session_is_queryid_available (THREAD_ENTRY * thread_p, const QUERY_ID query_id, QUERY_ID * max_query_id_uses)
+{
+  SESSION_STATE *state_p = NULL;
+  SESSION_QUERY_ENTRY *sentry_p = NULL;
+
+  *max_query_id_uses = 0;
+
+  state_p = session_get_session_state (thread_p);
+  if (state_p == NULL)
+    {
+      return true;
+    }
+
+  for (sentry_p = state_p->queries; sentry_p != NULL; sentry_p = sentry_p->next)
+    {
+      if (*max_query_id_uses < sentry_p->query_id)
+	{
+	  *max_query_id_uses = sentry_p->query_id;
+	}
+
+      if (sentry_p->query_id == query_id)
+	{
+	  return false;
+	}
+    }
+
+  return true;
 }
 
 /*

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -65,8 +65,7 @@ extern void session_store_query_entry_info (THREAD_ENTRY * thread_p, QMGR_QUERY_
 extern int session_load_query_entry_info (THREAD_ENTRY * thread_p, QMGR_QUERY_ENTRY * qentry_p);
 extern int session_remove_query_entry_info (THREAD_ENTRY * thread_p, const QUERY_ID query_id);
 extern int session_clear_query_entry_info (THREAD_ENTRY * thread_p, const QUERY_ID query_id);
-extern bool session_is_queryid_available (THREAD_ENTRY * thread_p, const QUERY_ID query_id,
-					  QUERY_ID * max_query_id_uses);
+extern bool session_is_queryid_idle (THREAD_ENTRY * thread_p, const QUERY_ID query_id, QUERY_ID * max_query_id_uses);
 
 extern int session_get_exec_stats_and_clear (THREAD_ENTRY * thread_p, const DB_VALUE * name, DB_VALUE * result);
 extern SESSION_PARAM *session_get_session_parameter (THREAD_ENTRY * thread_p, PARAM_ID id);

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -65,6 +65,8 @@ extern void session_store_query_entry_info (THREAD_ENTRY * thread_p, QMGR_QUERY_
 extern int session_load_query_entry_info (THREAD_ENTRY * thread_p, QMGR_QUERY_ENTRY * qentry_p);
 extern int session_remove_query_entry_info (THREAD_ENTRY * thread_p, const QUERY_ID query_id);
 extern int session_clear_query_entry_info (THREAD_ENTRY * thread_p, const QUERY_ID query_id);
+extern bool session_is_queryid_available (THREAD_ENTRY * thread_p, const QUERY_ID query_id,
+					  QUERY_ID * max_query_id_uses);
 
 extern int session_get_exec_stats_and_clear (THREAD_ENTRY * thread_p, const DB_VALUE * name, DB_VALUE * result);
 extern SESSION_PARAM *session_get_session_parameter (THREAD_ENTRY * thread_p, PARAM_ID id);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21497

Recycling query id may allocates a query id which is for a holdable cursor. It causes unexpected close of the existing holdable cursor.
