### PR TITLE
[CBRD-21839] fixes bound read of parsing timezone offset

### DIFF
--- a/src/base/tz_support.c
+++ b/src/base/tz_support.c
@@ -2425,6 +2425,7 @@ tz_str_read_time (const char *str, const char *str_end, bool need_minutes, bool 
   *hour = *min = *sec = 0;
   str_cursor = str;
 
+  /* read hour part */
   if (tz_str_read_number (str_cursor, str_end, true, false, &val_read, str_next) != NO_ERROR)
     {
       return ER_FAILED;
@@ -2445,7 +2446,10 @@ tz_str_read_time (const char *str, const char *str_end, bool need_minutes, bool 
       /* invalid text representation for time */
       return ER_FAILED;
     }
-  str_cursor++;
+
+  str_cursor++;			/* skip colon between hour and minute part */
+
+  /* read minute part */
   if (str_cursor >= str_end || IS_EMPTY_STR (str_cursor))
     {
       /* missing minute token */
@@ -2461,7 +2465,18 @@ tz_str_read_time (const char *str, const char *str_end, bool need_minutes, bool 
     }
   *min = val_read;
 
+  /* read second part if exists */
   str_cursor = *str_next;
+
+  assert (str_cursor <= str_end);
+  if (str_cursor == str_end)
+    {
+      /* reaches end of the given string. This means it does not have second part */
+      assert (*sec == 0);
+      return NO_ERROR;
+    }
+
+  assert (str_cursor < str_end);
   if (*str_cursor == ':')
     {
       /* if there is a token for seconds, read it */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21839

It is a legacy bound read bug to parse a timezone offset which does not have a second.