### PR TITLE
[CBRD-21819] Quick fix for thread id

### DIFF
--- a/src/base/porting.c
+++ b/src/base/porting.c
@@ -1902,7 +1902,7 @@ pthread_exit (THREAD_RET_T ptr)
 pthread_t
 pthread_self ()
 {
-  return GetCurrentThread ();
+  return (pthread_t) GetCurrentThreadId ();
 }
 
 int


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21819

Critical sections were useless due to the same thread id used by several threads.