### PR TITLE
[CBRD-21861] UMR of tp_atof with zero length string

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -4935,7 +4935,7 @@ tp_atof (const DB_VALUE * src, double *num_value, DB_DATA_STATUS * data_stat)
   codeset = DB_GET_STRING_CODESET (src);
   end = p + size - 1;
 
-  if (*end)
+  if (0 < size && *end)
     {
       while (p <= end && char_isspace (*p))
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21861

fixes UMR to cast zero length string to number.