### PR TITLE
[CBRD-21871] to keep inserted object template for getGeneratedKeys

### DIFF
--- a/src/object/object_template.c
+++ b/src/object/object_template.c
@@ -126,7 +126,6 @@ static int check_constraints (SM_ATTRIBUTE * att, DB_VALUE * value, unsigned for
 static int quick_validate (SM_VALIDATION * valid, DB_VALUE * value);
 static void cache_validation (SM_VALIDATION * valid, DB_VALUE * value);
 static void begin_template_traversal (void);
-static void reset_template (OBJ_TEMPLATE * template_ptr);
 static OBJ_TEMPLATE *make_template (MOP object, MOP classobj);
 static int validate_template (OBJ_TEMPLATE * temp);
 static OBJ_TEMPASSIGN *obt_make_assignment (OBJ_TEMPLATE * template_ptr, SM_ATTRIBUTE * att);
@@ -730,39 +729,6 @@ begin_template_traversal (void)
     {
       obj_Template_traversal++;
     }
-}
-
-
-/*
- * reset_template -
- *    return: none
- *    template(in):
- *
- */
-
-static void
-reset_template (OBJ_TEMPLATE * template_ptr)
-{
-  template_ptr->object = NULL;
-  template_ptr->base_object = NULL;
-  template_ptr->traversal = 0;
-  template_ptr->traversed = 0;
-  template_ptr->is_old_template = 0;
-  if (TM_TRAN_ISOLATION () >= TRAN_REPEATABLE_READ)
-    {
-      template_ptr->check_serializable_conflict = 1;
-    }
-  else
-    {
-      template_ptr->check_serializable_conflict = 0;
-    }
-  template_ptr->uniques_were_modified = 0;
-  template_ptr->shared_was_modified = 0;
-  template_ptr->fkeys_were_modified = 0;
-  template_ptr->force_flush = 0;
-  template_ptr->force_check_not_null = 0;
-  template_ptr->function_key_modified = 0;
-  template_ptr->is_autoincrement_set = 0;
 }
 
 /*
@@ -2869,7 +2835,6 @@ obt_reset_force_flush (OBJ_TEMPLATE * template_ptr)
   template_ptr->force_flush = 0;
 }
 
-#if defined(ENABLE_UNUSED_FUNCTION)
 /*
  * obt_retain_after_finish
  *    return: none
@@ -2879,12 +2844,10 @@ obt_reset_force_flush (OBJ_TEMPLATE * template_ptr)
 void
 obt_retain_after_finish (OBJ_TEMPLATE * template_ptr)
 {
-  if (template_ptr)
-    {
-      template_ptr->discard_on_finish = 0;
-    }
+  assert (template_ptr != NULL);
+
+  template_ptr->discard_on_finish = 0;
 }
-#endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
  * obt_update_internal
@@ -2894,7 +2857,6 @@ obt_retain_after_finish (OBJ_TEMPLATE * template_ptr)
  *    check_non_null(in): set if this is an internally defined template
  *
  */
-
 int
 obt_update_internal (OBJ_TEMPLATE * template_ptr, MOP * newobj, int check_non_null)
 {
@@ -2952,13 +2914,10 @@ obt_update_internal (OBJ_TEMPLATE * template_ptr, MOP * newobj, int check_non_nu
 		      *newobj = template_ptr->object;
 		    }
 
+		  /* When discard_on_finish is false, caller should explictly free template */
 		  if (template_ptr->discard_on_finish)
 		    {
 		      obt_free_template (template_ptr);
-		    }
-		  else
-		    {
-		      reset_template (template_ptr);
 		    }
 		}
 	    }

--- a/src/object/object_template.h
+++ b/src/object/object_template.h
@@ -242,8 +242,6 @@ extern int obt_find_attribute (OBJ_TEMPLATE * template_ptr, int use_base_class, 
 extern int obt_desc_set (OBJ_TEMPLATE * template_ptr, SM_DESCRIPTOR * desc, DB_VALUE * value);
 extern int obt_check_missing_assignments (OBJ_TEMPLATE * template_ptr);
 extern int obt_populate_known_arguments (OBJ_TEMPLATE * template_ptr);
-#if defined(ENABLE_UNUSED_FUNCTION)
 extern void obt_retain_after_finish (OBJ_TEMPLATE * template_ptr);
-#endif
 extern void obt_begin_insert_values (void);
 #endif /* _OBJECT_TEMPLATE_H_ */

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -12242,22 +12242,25 @@ do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * st
 
 	  if (*otemplate != NULL)
 	    {
-	      bool wants_obj;
-
-	      wants_obj = (parser->return_generated_keys && (*otemplate)->is_autoincrement_set);
+	      obt_retain_after_finish (*otemplate);
 
 	      obj = dbt_finish_object (*otemplate);
 	      if (obj == NULL)
 		{
-		  assert (er_errid () != NO_ERROR);
-		  error = er_errid ();
-		  /* On error, the template must be freed. */
+		  ASSERT_ERROR_AND_SET (error);
+
 		  dbt_abort_object (*otemplate);
 		  *otemplate = NULL;
 		}
 	      else
 		{
-		  if (wants_obj == true)
+		  bool include_new_obj;
+
+		  include_new_obj = (parser->return_generated_keys && (*otemplate)->is_autoincrement_set);
+
+		  obt_quit (*otemplate);	/* free template */
+
+		  if (include_new_obj == true)
 		    {
 		      db_make_object (&db_value, obj);
 		      error = set_put_element (seq, obj_count, &db_value);
@@ -12719,9 +12722,17 @@ insert_subquery_results (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE *
 		  if (otemplate != NULL)
 		    {
 		      /* apply the object template */
-		      obj = dbt_finish_object (otemplate);
+		      bool include_new_obj;
 
-		      if (obj && parser->return_generated_keys && otemplate->is_autoincrement_set > 0)
+		      obt_retain_after_finish (otemplate);
+
+		      obj = dbt_finish_object (otemplate);	/* flush template */
+
+		      include_new_obj = (obj && parser->return_generated_keys && otemplate->is_autoincrement_set);
+
+		      obt_quit (otemplate);	/* free template */
+
+		      if (include_new_obj == true)
 			{
 			  db_make_object (&db_value, obj);
 			  error = set_put_element (seq, obj_count, &db_value);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21871

It is a regression of #984 
Before #984, it accessed freed object template. It worked as a hack.

To access inserted object template, client insert routines request to template manager to keep it by resetting `discard_on_finish`. Since the flag was not used, fix changes its behavior. Caller who wants to keep the template after flush should explicitly free it. 