### PR TITLE
[CBRD-21841] migrate deadlock detect daemon thread to new API

### DIFF
--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -110,7 +110,7 @@ static pthread_key_t thread_Thread_key;
 static THREAD_MANAGER thread_Manager;
 
 /*
- * For special Purpose Threads: deadlock detector, checkpoint daemon
+ * For special Purpose Threads: checkpoint daemon etc.
  *    Under the win32-threads system, *_cond variables are an auto-reset event
  */
 static DAEMON_THREAD_MONITOR thread_Checkpoint_thread = DAEMON_THREAD_MONITOR_INITIALIZER;
@@ -360,9 +360,8 @@ thread_is_manager_initialized (void)
  * thread_initialize_manager() - Create and initialize all necessary threads.
  *   return: 0 if no error, or error code
  *
- * Note: It includes a main thread, service handler, a deadlock detector
- *       and a checkpoint daemon. Some other threads like signal handler
- *       might be needed later.
+ * Note: It includes a main thread, service handler and a checkpoint daemon.
+ *       Some other threads like signal handler might be needed later.
  */
 int
 thread_initialize_manager (size_t & total_thread_count)
@@ -478,7 +477,7 @@ thread_initialize_manager (size_t & total_thread_count)
   /* allocate threads */
   thread_Manager.thread_array = new THREAD_ENTRY[thread_Manager.num_total];
 
-  /* init worker/deadlock-detection/checkpoint daemon/page flush thread/log flush thread
+  /* init worker/checkpoint daemon/page flush thread/log flush thread
    * thread_mgr.thread_array[0] is used for main thread */
   for (i = 0; i < thread_Manager.num_total; i++)
     {
@@ -809,7 +808,7 @@ thread_compare_shutdown_sequence_of_daemon (const void *p1, const void *p2)
 }
 
 /*
- * thread_stop_active_daemons() - Stop deadlock detector/checkpoint threads
+ * thread_stop_active_daemons() - Stop active daemon threads
  *   return: NO_ERROR
  */
 int
@@ -2047,8 +2046,8 @@ thread_worker (void *arg_p)
 }
 
 /* Special Purpose Threads
-   deadlock detector, check point daemon */
-
+ * check point daemon
+ */
 #if defined(WINDOWS)
 /*
  * thread_initialize_sync_object() -

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -113,7 +113,6 @@ static THREAD_MANAGER thread_Manager;
  * For special Purpose Threads: deadlock detector, checkpoint daemon
  *    Under the win32-threads system, *_cond variables are an auto-reset event
  */
-static DAEMON_THREAD_MONITOR thread_Deadlock_detect_thread = DAEMON_THREAD_MONITOR_INITIALIZER;
 static DAEMON_THREAD_MONITOR thread_Checkpoint_thread = DAEMON_THREAD_MONITOR_INITIALIZER;
 static DAEMON_THREAD_MONITOR thread_Purge_archive_logs_thread = DAEMON_THREAD_MONITOR_INITIALIZER;
 static DAEMON_THREAD_MONITOR thread_Page_flush_thread = DAEMON_THREAD_MONITOR_INITIALIZER;
@@ -130,7 +129,6 @@ static void thread_stop_daemon (DAEMON_THREAD_MONITOR * daemon_monitor);
 static void thread_wakeup_daemon_thread (DAEMON_THREAD_MONITOR * daemon_monitor);
 static int thread_compare_shutdown_sequence_of_daemon (const void *p1, const void *p2);
 
-static THREAD_RET_T THREAD_CALLING_CONVENTION thread_deadlock_detect_thread (void *);
 static THREAD_RET_T THREAD_CALLING_CONVENTION thread_checkpoint_thread (void *);
 static THREAD_RET_T THREAD_CALLING_CONVENTION thread_purge_archive_logs_thread (void *);
 static THREAD_RET_T THREAD_CALLING_CONVENTION thread_page_flush_thread (void *);
@@ -146,7 +144,6 @@ static THREAD_RET_T THREAD_CALLING_CONVENTION thread_page_post_flush_thread (voi
 typedef enum
 {
   /* All the single threads */
-  THREAD_DAEMON_DEADLOCK_DETECT,
   THREAD_DAEMON_PURGE_ARCHIVE_LOGS,
   THREAD_DAEMON_CHECKPOINT,
   THREAD_DAEMON_SESSION_CONTROL,
@@ -391,12 +388,6 @@ thread_initialize_manager (size_t & total_thread_count)
   /* IMPORTANT NOTE: Daemons are shutdown in the same order as they are created here. */
   daemon_index = 0;
   shutdown_sequence = 0;
-
-  /* Initialize deadlock detect daemon */
-  thread_Daemons[daemon_index].type = THREAD_DAEMON_DEADLOCK_DETECT;
-  thread_Daemons[daemon_index].daemon_monitor = &thread_Deadlock_detect_thread;
-  thread_Daemons[daemon_index].shutdown_sequence = shutdown_sequence++;
-  thread_Daemons[daemon_index++].daemon_function = thread_deadlock_detect_thread;
 
   /* Initialize purge archive logs daemon */
   thread_Daemons[daemon_index].type = THREAD_DAEMON_PURGE_ARCHIVE_LOGS;
@@ -2089,121 +2080,6 @@ thread_initialize_sync_object (void)
   return r;
 }
 #endif /* WINDOWS */
-
-/*
- * thread_deadlock_detect_thread() -
- *   return:
- */
-static THREAD_RET_T THREAD_CALLING_CONVENTION
-thread_deadlock_detect_thread (void *arg_p)
-{
-#if !defined(HPUX)
-  THREAD_ENTRY *tsd_ptr;
-#endif /* !HPUX */
-  int rv;
-  THREAD_ENTRY *thread_p;
-  int thrd_index;
-  bool state;
-  int lockwait_count;
-
-  tsd_ptr = (THREAD_ENTRY *) arg_p;
-  /* wait until THREAD_CREATE() finish */
-  rv = pthread_mutex_lock (&tsd_ptr->th_entry_lock);
-  pthread_mutex_unlock (&tsd_ptr->th_entry_lock);
-
-  thread_set_thread_entry_info (tsd_ptr);	/* save TSD */
-  tsd_ptr->type = TT_DAEMON;
-  tsd_ptr->status = TS_RUN;	/* set thread stat as RUN */
-  tsd_ptr->register_id ();
-
-  thread_Deadlock_detect_thread.is_available = true;
-  thread_Deadlock_detect_thread.is_running = true;
-
-  thread_set_current_tran_index (tsd_ptr, LOG_SYSTEM_TRAN_INDEX);
-
-  /* during server is active */
-  while (!tsd_ptr->shutdown)
-    {
-      thread_sleep (100);	/* 100 msec */
-      if (!lock_check_local_deadlock_detection ())
-	{
-	  continue;
-	}
-
-      er_clear ();
-
-      /* check if the lock-wait thread exists */
-      thread_p = thread_find_first_lockwait_entry (&thrd_index);
-      if (thread_p == (THREAD_ENTRY *) NULL)
-	{
-	  /* none is lock-waiting */
-	  rv = pthread_mutex_lock (&thread_Deadlock_detect_thread.lock);
-	  thread_Deadlock_detect_thread.is_running = false;
-
-	  if (tsd_ptr->shutdown)
-	    {
-	      pthread_mutex_unlock (&thread_Deadlock_detect_thread.lock);
-	      break;
-	    }
-	  pthread_cond_wait (&thread_Deadlock_detect_thread.cond, &thread_Deadlock_detect_thread.lock);
-
-	  thread_Deadlock_detect_thread.is_running = true;
-
-	  pthread_mutex_unlock (&thread_Deadlock_detect_thread.lock);
-	  continue;
-	}
-
-      /* One or more threads are lock-waiting */
-      lockwait_count = 0;
-      while (thread_p != (THREAD_ENTRY *) NULL)
-	{
-	  /* 
-	   * The transaction, for which the current thread is working,
-	   * might be interrupted. The interrupt checking is also performed
-	   * within lock_force_timeout_expired_wait_transactions().
-	   */
-	  state = lock_force_timeout_expired_wait_transactions (thread_p);
-	  if (state == false)
-	    {
-	      lockwait_count++;
-	    }
-	  thread_p = thread_find_next_lockwait_entry (&thrd_index);
-	}
-
-      if (lockwait_count >= 2)
-	{
-	  (void) lock_detect_local_deadlock (tsd_ptr);
-	}
-    }
-
-  rv = pthread_mutex_lock (&thread_Deadlock_detect_thread.lock);
-  thread_Deadlock_detect_thread.is_running = false;
-  thread_Deadlock_detect_thread.is_available = false;
-  pthread_mutex_unlock (&thread_Deadlock_detect_thread.lock);
-
-  er_final (ER_THREAD_FINAL);
-  tsd_ptr->status = TS_DEAD;
-  tsd_ptr->unregister_id ();
-
-  return (THREAD_RET_T) 0;
-}
-
-/*
- * thread_wakeup_deadlock_detect_thread() -
- *   return:
- */
-void
-thread_wakeup_deadlock_detect_thread (void)
-{
-  int rv;
-
-  rv = pthread_mutex_lock (&thread_Deadlock_detect_thread.lock);
-  if (thread_Deadlock_detect_thread.is_running == false)
-    {
-      pthread_cond_signal (&thread_Deadlock_detect_thread.cond);
-    }
-  pthread_mutex_unlock (&thread_Deadlock_detect_thread.lock);
-}
 
 static THREAD_RET_T THREAD_CALLING_CONVENTION
 thread_session_control_thread (void *arg_p)

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -316,7 +316,6 @@ extern int thread_has_threads (THREAD_ENTRY * caller, int tran_index, int client
 extern bool thread_set_check_interrupt (THREAD_ENTRY * thread_p, bool flag);
 
 /* wakeup functions */
-extern void thread_wakeup_deadlock_detect_thread (void);
 extern void thread_wakeup_log_flush_thread (void);
 extern void thread_wakeup_page_flush_thread (void);
 extern void thread_try_wakeup_page_flush_thread (void);

--- a/src/thread/thread_entry_task.cpp
+++ b/src/thread/thread_entry_task.cpp
@@ -24,6 +24,7 @@
 #include "thread_entry_task.hpp"
 
 #include "error_manager.h"
+#include "log_impl.h"
 #include "porting.h"
 #if defined (SERVER_MODE)
 #include "thread.h"
@@ -41,8 +42,6 @@ namespace cubthread
     // for backward compatibility
     context.register_id ();
     context.type = TT_WORKER;
-
-    // TODO: daemon type
 
     on_create (context);
     return context;
@@ -77,5 +76,26 @@ namespace cubthread
     on_recycle (context);
   }
 
+  void
+  daemon_entry_manager::on_create (entry &context)
+  {
+#if defined (SERVER_MODE)
+    context.status = TS_RUN;
+#endif // SERVER_MODE
+    context.type = TT_DAEMON;
+    context.tran_index = LOG_SYSTEM_TRAN_INDEX;
+
+    on_daemon_create (context);
+  }
+
+  void
+  daemon_entry_manager::on_retire (entry &context)
+  {
+#if defined (SERVER_MODE)
+    context.status = TS_DEAD;
+#endif // SERVER_MODE
+
+    on_daemon_retire (context);
+  }
 
 } // namespace cubthread

--- a/src/thread/thread_entry_task.hpp
+++ b/src/thread/thread_entry_task.hpp
@@ -76,7 +76,7 @@ namespace cubthread
   //
   //  how to use:
   //    create a context manager derived from entry manager and override on_create, on_retire and on_recycle functions.
-  //    create worker pools or daemons using derived context manager
+  //    create worker pools using derived context manager
   //
   class entry_manager : public context_manager<entry>
   {
@@ -100,6 +100,44 @@ namespace cubthread
       virtual void on_recycle (entry &)   // manipulate entry between execution cycles
       {
 	// does nothing by default
+      }
+  };
+
+  // cubthread::daemon_entry_manager
+  //
+  //  description:
+  //    daemon_entry_manager is derived from entry_manager and adds extra logic specific for deamon threads
+  //    initialization and destruction. for more details see entry_manager description.
+  //
+  //  how to use:
+  //    create a demon_entry_manager derived from entry_manager and override on_daemon_create and on on_daemon_retire
+  //    functions if daemon require custom logic on initialization or destruction.
+  //    create deamon threads using daemon_entry_manager class
+  //
+  class daemon_entry_manager : public entry_manager
+  {
+    public:
+      daemon_entry_manager () = default;
+      ~daemon_entry_manager () = default;
+
+    protected:
+      virtual void on_daemon_create (entry &)
+      {
+	// does nothing by default
+      }
+
+      void on_create (entry &) final;
+
+      virtual void on_daemon_retire (entry &)
+      {
+	// does nothing by default
+      }
+
+      void on_retire (entry &) final;
+
+      void on_recycle (entry &) final
+      {
+	// daemon threads are not recycled
       }
   };
 

--- a/src/thread/thread_entry_task.hpp
+++ b/src/thread/thread_entry_task.hpp
@@ -106,13 +106,13 @@ namespace cubthread
   // cubthread::daemon_entry_manager
   //
   //  description:
-  //    daemon_entry_manager is derived from entry_manager and adds extra logic specific for deamon threads
+  //    daemon_entry_manager is derived from entry_manager and adds extra logic specific for daemon threads
   //    initialization and destruction. for more details see entry_manager description.
   //
   //  how to use:
-  //    create a demon_entry_manager derived from entry_manager and override on_daemon_create and on on_daemon_retire
+  //    create a daemon_entry_manager derived from entry_manager and override on_daemon_create and on on_daemon_retire
   //    functions if daemon require custom logic on initialization or destruction.
-  //    create deamon threads using daemon_entry_manager class
+  //    create daemon threads using daemon_entry_manager class
   //
   class daemon_entry_manager : public entry_manager
   {

--- a/src/thread/thread_looper.hpp
+++ b/src/thread/thread_looper.hpp
@@ -87,7 +87,7 @@ namespace cubthread
       //
       // the sleep time is increased according to periods for each sleep that times out
       // sleep timer is reset when sleep doesn't time out
-      template<class Rep, class Period, size_t Count>
+      template<class Rep, class Period, std::size_t Count>
       looper (const std::array<std::chrono::duration<Rep, Period>, Count> periods);
 
       // copy other loop pattern
@@ -116,7 +116,7 @@ namespace cubthread
 	INFINITE_WAITS,               // always infinite waits
       };
 
-      static const size_t MAX_PERIODS = 3; // for increasing period pattern
+      static constexpr std::size_t const &MAX_PERIODS = 3; // for increasing period pattern
 
       wait_pattern m_wait_pattern;          // wait pattern type
       std::size_t m_periods_count;          // the period count
@@ -148,7 +148,7 @@ namespace cubthread
 #endif
   }
 
-  template<class Rep, class Period, size_t Count>
+  template<class Rep, class Period, std::size_t Count>
   looper::looper (const std::array<std::chrono::duration<Rep, Period>, Count> periods)
     : m_wait_pattern (wait_pattern::INCREASING_PERIODS)
     , m_periods_count (Count)
@@ -160,7 +160,7 @@ namespace cubthread
     m_periods_count = std::min (Count, MAX_PERIODS);
 
     // wait increasing period on timeouts
-    for (size_t i = 0; i < m_periods_count; i++)
+    for (std::size_t i = 0; i < m_periods_count; i++)
       {
 	m_periods[i] = periods[i];
 	// check increasing periods

--- a/src/thread/thread_looper.hpp
+++ b/src/thread/thread_looper.hpp
@@ -64,6 +64,8 @@
 //    // loop is stopped calling looper_shared_variable->stop ();
 //
 
+#define MAX_PERIODS 3 // for increasing period pattern
+
 namespace cubthread
 {
 
@@ -116,8 +118,6 @@ namespace cubthread
 	INFINITE_WAITS,               // always infinite waits
       };
 
-      static const std::size_t MAX_PERIODS = 3; // for increasing period pattern
-
       wait_pattern m_wait_pattern;          // wait pattern type
       std::size_t m_periods_count;          // the period count
       delta_time m_periods[MAX_PERIODS];    // period array
@@ -157,7 +157,7 @@ namespace cubthread
     , m_stop (false)
   {
     static_assert (Count <= MAX_PERIODS, "Count template cannot exceed MAX_PERIODS=3");
-    m_periods_count = std::min (Count, MAX_PERIODS);
+    m_periods_count = std::min (Count, (std::size_t) MAX_PERIODS);
 
     // wait increasing period on timeouts
     for (std::size_t i = 0; i < m_periods_count; i++)

--- a/src/thread/thread_looper.hpp
+++ b/src/thread/thread_looper.hpp
@@ -116,7 +116,7 @@ namespace cubthread
 	INFINITE_WAITS,               // always infinite waits
       };
 
-      static constexpr std::size_t const &MAX_PERIODS = 3; // for increasing period pattern
+      static const std::size_t MAX_PERIODS = 3; // for increasing period pattern
 
       wait_pattern m_wait_pattern;          // wait pattern type
       std::size_t m_periods_count;          // the period count

--- a/src/thread/thread_looper.hpp
+++ b/src/thread/thread_looper.hpp
@@ -31,6 +31,8 @@
 #include <cassert>
 #include <cstdint>
 
+#define MAX_PERIODS 3 // for increasing period pattern
+
 // cubthread::looper
 //
 // description
@@ -63,8 +65,6 @@
 //      }
 //    // loop is stopped calling looper_shared_variable->stop ();
 //
-
-#define MAX_PERIODS 3 // for increasing period pattern
 
 namespace cubthread
 {

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -58,6 +58,7 @@ namespace cubthread
     , m_entry_dispatcher (NULL)
     , m_available_entries_count (max_threads)
     , m_entry_manager (NULL)
+    , m_daemon_entry_manager (NULL)
   {
     if (m_max_threads > 0)
       {
@@ -66,6 +67,7 @@ namespace cubthread
       }
 
     m_entry_manager = new entry_manager ();
+    m_daemon_entry_manager = new daemon_entry_manager();
   }
 
   manager::~manager ()
@@ -79,6 +81,7 @@ namespace cubthread
     delete m_entry_dispatcher;
     delete [] m_all_entries;
     delete m_entry_manager;
+    delete m_daemon_entry_manager;
   }
 
   template<typename Res>
@@ -151,7 +154,7 @@ namespace cubthread
       {
 	if (context_manager == NULL)
 	  {
-	    context_manager = m_entry_manager;
+	    context_manager = m_daemon_entry_manager;
 	  }
 	return create_and_track_resource (m_daemons, 1, looper_arg, context_manager, exec_p);
       }

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -45,6 +45,7 @@ namespace cubthread
   class entry;
   class entry_task;
   class entry_manager;
+  class daemon_entry_manager;
 
   // alias for worker_pool<entry>
   using entry_workpool = worker_pool<entry>;
@@ -205,6 +206,7 @@ namespace cubthread
       // available entries count
       std::size_t m_available_entries_count;
       entry_manager *m_entry_manager;
+      daemon_entry_manager *m_daemon_entry_manager;
   };
 
   //////////////////////////////////////////////////////////////////////////

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -243,7 +243,7 @@ boot_server_status (BOOT_SERVER_STATUS status)
 
 #if defined(SERVER_MODE)
 /*
- * bo_shutdown_server_atexit () - make sure that the server is shutdown at exit
+ * bo_shutdown_server_at_exit () - make sure that the server is shutdown at exit
  *
  * return : nothing
  *

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -5920,7 +5920,7 @@ public:
     int lock_wait_count = 0;
 
     /* One or more threads are lock-waiting */
-    while (lock_wait_entry != NULL)
+    while (lock_wait_entry != NULL && lock_wait_count < 2)
       {
 	/*
 	 * The transaction, for which the current thread is working,

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -25,41 +25,45 @@
 
 #include "config.h"
 
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
+#include <array>
 #include <assert.h>
 #if defined(SOLARIS)
 #include <netdb.h>
 #endif /* SOLARIS */
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
 
-#include "porting.h"
-#include "xserver_interface.h"
-#include "lock_manager.h"
-#include "system_parameter.h"
-#include "memory_alloc.h"
-#include "oid.h"
-#include "storage_common.h"
-#include "log_manager.h"
-#include "transaction_sr.h"
-#include "wait_for_graph.h"
+#include "boot_sr.h"
 #include "critical_section.h"
-#include "memory_hash.h"
-#include "locator.h"
-#include "perf_monitor.h"
-#include "page_buffer.h"
-#include "message_catalog.h"
 #include "environment_variable.h"
+#include "event_log.h"
+#include "locator.h"
+#include "lock_free.h"
+#include "lock_manager.h"
 #include "log_impl.h"
-#include "thread.h"
-#include "query_manager.h"
+#include "log_manager.h"
+#include "memory_alloc.h"
+#include "memory_hash.h"
+#include "message_catalog.h"
+#include "oid.h"
+#include "page_buffer.h"
+#include "perf_monitor.h"
+#include "porting.h"
 #if defined(ENABLE_SYSTEMTAP)
 #include "probes.h"
 #endif /* ENABLE_SYSTEMTAP */
-#include "event_log.h"
+#include "query_manager.h"
+#include "storage_common.h"
+#include "system_parameter.h"
+#include "thread.h"
+#include "thread_daemon.hpp"
+#include "thread_entry_task.hpp"
+#include "thread_manager.hpp"
+#include "transaction_sr.h"
 #include "tsc_timer.h"
-#include "lock_free.h"
-
+#include "wait_for_graph.h"
+#include "xserver_interface.h"
 
 extern LOCK_COMPATIBILITY lock_Comp[11][11];
 
@@ -513,6 +517,14 @@ static bool lock_is_safe_lock_with_page (THREAD_ENTRY * thread_p, LK_ENTRY * ent
 
 static LK_ENTRY *lock_get_new_entry (int tran_index, LF_TRAN_ENTRY * tran_entry, LF_FREELIST * freelist);
 static void lock_free_entry (int tran_index, LF_TRAN_ENTRY * tran_entry, LF_FREELIST * freelist, LK_ENTRY * lock_entry);
+
+// *INDENT-OFF*
+static bool lock_Deadlock_detect_daemon_is_initialized = false;
+static cubthread::daemon *lock_Deadlock_detect_daemon = NULL;
+
+static void lock_deadlock_detect_daemon_init ();
+static void lock_deadlock_detect_daemon_destroy ();
+// *INDENT-ON*
 
 /* object lock entry */
 static void *lock_alloc_entry (void);
@@ -1176,7 +1188,7 @@ lock_remove_resource (LK_RES * res_ptr)
   rc = lf_hash_delete_already_locked (t_entry, &lk_Gl.obj_hash_table, (void *) &res_ptr->key, res_ptr, &success);
   if (!success)
     {
-      /* this should not happen, as the hash entry is mutex protected and no clear operations are performed on the hash 
+      /* this should not happen, as the hash entry is mutex protected and no clear operations are performed on the hash
        * table */
       pthread_mutex_unlock (&res_ptr->res_mutex);
       assert_release (false);
@@ -2137,7 +2149,7 @@ lock_suspend (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr, int wait_msecs)
   lk_Gl.TWFG_node[entry_ptr->tran_index].thrd_wait_stime = entry_ptr->thrd_entry->lockwait_stime;
 
   /* wakeup the dealock detect thread */
-  thread_wakeup_deadlock_detect_thread ();
+  lock_Deadlock_detect_daemon->wakeup ();
 
   tdes = LOG_FIND_CURRENT_TDES (thread_p);
 
@@ -2192,8 +2204,8 @@ lock_suspend (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr, int wait_msecs)
   thread_unlock_entry (entry_ptr->thrd_entry);
 
   /* The thread has been awaken Before waking up the thread, the waker cleared the lockwait field of the thread entry
-   * and set lockwait_state field of it to the resumed state while holding the thread entry mutex. After the wakeup, no 
-   * one can update the lockwait releated fields of the thread entry. Therefore, waken-up thread can read the values of 
+   * and set lockwait_state field of it to the resumed state while holding the thread entry mutex. After the wakeup, no
+   * one can update the lockwait releated fields of the thread entry. Therefore, waken-up thread can read the values of
    * lockwait related fields of its own thread entry without holding thread entry mutex. */
 
   switch ((LOCK_WAIT_STATE) (entry_ptr->thrd_entry->lockwait_state))
@@ -2808,7 +2820,7 @@ lock_grant_blocked_waiter_partial (THREAD_ENTRY * thread_p, LK_RES * res_ptr, LK
 		      check->thrd_entry->tran_index);
 	    }
 	  /* The thread is not waiting on the lock. That is, the thread has already been waken up by lock timeout,
-	   * deadlock victim or interrupt. In this case, we have nothing to do since the thread itself will remove this 
+	   * deadlock victim or interrupt. In this case, we have nothing to do since the thread itself will remove this
 	   * lock entry. */
 	  (void) thread_unlock_entry (check->thrd_entry);
 
@@ -2975,7 +2987,7 @@ lock_escalate_if_needed (THREAD_ENTRY * thread_p, LK_ENTRY * class_entry, int tr
 
   if (max_class_lock != NULL_LOCK)
     {
-      /* 
+      /*
        * lock escalation is performed
        * 1. hold a lock on the class with the escalated lock mode
        */
@@ -3610,7 +3622,7 @@ lock_tran_lk_entry:
 	  if ((lock >= IX_LOCK && (entry_ptr->instant_lock_count == 0 && entry_ptr->granted_mode >= IX_LOCK))
 	      && compat1 != LOCK_COMPAT_YES)
 	    {
-	      /* if the lock is already acquired with incompatible mode by current transaction, remove instant instance 
+	      /* if the lock is already acquired with incompatible mode by current transaction, remove instant instance
 	       * locks */
 	      lock_stop_instant_lock_mode (thread_p, tran_index, false);
 	    }
@@ -4462,7 +4474,7 @@ lock_remove_non2pl (LK_ENTRY * non2pl, int tran_index)
   LK_ENTRY *prev, *curr;
   int rv;
 
-  /* The given non2pl entry has already been removed from the transaction non2pl list. Therefore, This function removes 
+  /* The given non2pl entry has already been removed from the transaction non2pl list. Therefore, This function removes
    * the given non2pl entry from the resource non2pl list and then frees the entry. */
 
   res_ptr = non2pl->res_head;
@@ -4662,7 +4674,7 @@ lock_add_WFG_edge (int from_tran_index, int to_tran_index, int holder_flag, INT6
     }
 
   /* NOTE the following description.. According to the above code, whenever it is identified that a transaction has
-   * been terminated during deadlock detection, the transaction is checked again as a new transaction. And, the current 
+   * been terminated during deadlock detection, the transaction is checked again as a new transaction. And, the current
    * edge is based on the current active transactions. */
 
   if (lk_Gl.TWFG_free_edge_idx == -1)
@@ -4770,7 +4782,7 @@ lock_select_deadlock_victim (THREAD_ENTRY * thread_p, int s, int t)
   TWFG_node = lk_Gl.TWFG_node;
   TWFG_edge = lk_Gl.TWFG_edge;
 
-  /* 
+  /*
    * check if current deadlock cycle is false deadlock cycle
    */
   tot_WFG_nodes = 0;
@@ -4857,7 +4869,7 @@ lock_select_deadlock_victim (THREAD_ENTRY * thread_p, int s, int t)
       return;
     }
 
-  /* 
+  /*
    * Victim Selection Strategy 1) Must be lock holder. 2) Must be active transaction. 3) Prefer a transaction does not
    * have victim priority. 4) Prefer a transaction has written less log records. 5) Prefer a transaction with a closer
    * timeout. 6) Prefer the youngest transaction. */
@@ -5008,7 +5020,7 @@ lock_select_deadlock_victim (THREAD_ENTRY * thread_p, int s, int t)
 		    }
 		  else
 		    {
-		      /* 
+		      /*
 		       *  Prefer a transaction with a closer timeout.
 		       *  Prefer the youngest transaction.
 		       */
@@ -5863,6 +5875,8 @@ lock_initialize (void)
     }
 #endif /* LK_DUMP */
 
+  lock_deadlock_detect_daemon_init ();
+
   return error_code;
 
 error:
@@ -5870,6 +5884,95 @@ error:
   return error_code;
 #endif /* !SERVER_MODE */
 }
+
+// *INDENT-OFF*
+#if defined(SERVER_MODE)
+// class deadlock_detect_task
+//
+//  description:
+//    deadlock detect daemon task
+//
+class deadlock_detect_task : public cubthread::entry_task
+{
+public:
+  void execute (cubthread::entry & thread_ref) override
+  {
+    if (!BO_IS_SERVER_RESTARTED ())
+      {
+	// wait for boot to finish
+	return;
+      }
+
+    if (!lock_check_local_deadlock_detection ())
+      {
+	return;
+      }
+
+    /* check if the lock-wait thread exists */
+    int thread_index;
+    THREAD_ENTRY *lock_wait_entry = thread_find_first_lockwait_entry (&thread_index);
+
+    if (lock_wait_entry == NULL)
+    {
+      return;
+    }
+
+    int lock_wait_count = 0;
+
+    /* One or more threads are lock-waiting */
+    while (lock_wait_entry != NULL)
+      {
+	/*
+	 * The transaction, for which the current thread is working,
+	 * might be interrupted. The interrupt checking is also performed
+	 * within lock_force_timeout_expired_wait_transactions().
+	 */
+	bool state = lock_force_timeout_expired_wait_transactions (lock_wait_entry);
+	if (!state)
+	  {
+	    lock_wait_count++;
+	  }
+	lock_wait_entry = thread_find_next_lockwait_entry (&thread_index);
+      }
+
+    if (lock_wait_count >= 2)
+      {
+	lock_detect_local_deadlock (&thread_ref);
+      }
+  }
+};
+#endif /* SERVER_MODE */
+
+#if defined(SERVER_MODE)
+void
+lock_deadlock_detect_daemon_init ()
+{
+  assert (!lock_Deadlock_detect_daemon_is_initialized);
+
+  // create deadlock detect daemon thread
+  std::array<std::chrono::milliseconds, 1> interval_time = {{ std::chrono::milliseconds (100) }};
+  lock_Deadlock_detect_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (interval_time),
+				new deadlock_detect_task ());
+
+  lock_Deadlock_detect_daemon_is_initialized = true;
+}
+#endif /* SERVER_MODE */
+
+#if defined(SERVER_MODE)
+void
+lock_deadlock_detect_daemon_destroy ()
+{
+  if (!lock_Deadlock_detect_daemon_is_initialized)
+    {
+      return;
+    }
+
+  cubthread::get_manager ()->destroy_daemon (lock_Deadlock_detect_daemon);
+
+  lock_Deadlock_detect_daemon_is_initialized = false;
+}
+#endif /* SERVER_MODE */
+// *INDENT-ON*
 
 /*
  * lock_finalize - Finalize the lock manager
@@ -5926,6 +6029,8 @@ lock_finalize (void)
   lf_hash_destroy (&lk_Gl.obj_hash_table);
   lf_freelist_destroy (&lk_Gl.obj_free_entry_list);
   lf_freelist_destroy (&lk_Gl.obj_free_res_list);
+
+  lock_deadlock_detect_daemon_destroy ();
 #endif /* !SERVER_MODE */
 }
 
@@ -7042,7 +7147,7 @@ lock_get_object_lock (const OID * oid, const OID * class_oid, int tran_index)
   /* get a pointer to transaction lock info entry */
   tran_lock = &lk_Gl.tran_lock_table[tran_index];
 
-  /* 
+  /*
    * case 1: root class lock
    */
   /* get the granted lock mode acquired on the root class oid */
@@ -7057,7 +7162,7 @@ lock_get_object_lock (const OID * oid, const OID * class_oid, int tran_index)
       return lock_mode;		/* might be NULL_LOCK */
     }
 
-  /* 
+  /*
    * case 2: general class lock
    */
   /* get the granted lock mode acquired on the given class oid */
@@ -7145,7 +7250,7 @@ lock_has_lock_on_object (const OID * oid, const OID * class_oid, int tran_index,
   /* get a pointer to transaction lock info entry */
   tran_lock = &lk_Gl.tran_lock_table[tran_index];
 
-  /* 
+  /*
    * case 1: root class lock
    */
   /* get the granted lock mode acquired on the root class oid */
@@ -7160,7 +7265,7 @@ lock_has_lock_on_object (const OID * oid, const OID * class_oid, int tran_index,
       return (lock_Conv[lock][granted_lock_mode] == granted_lock_mode);
     }
 
-  /* 
+  /*
    * case 2: general class lock
    */
   /* get the granted lock mode acquired on the given class oid */
@@ -7184,7 +7289,7 @@ lock_has_lock_on_object (const OID * oid, const OID * class_oid, int tran_index,
 	}
     }
 
-  /* 
+  /*
    * case 3: object lock
    */
   /* get the granted lock mode acquired on the given instance/pseudo oid */
@@ -7219,9 +7324,9 @@ lock_has_xlock (THREAD_ENTRY * thread_p)
   LK_ENTRY *entry_ptr;
   int rv;
 
-  /* 
+  /*
    * Exclusive locks in this context mean IX_LOCK, SIX_LOCK, X_LOCK and
-   * SCH_M_LOCK. NOTE that U_LOCK are excluded from exclusive locks. 
+   * SCH_M_LOCK. NOTE that U_LOCK are excluded from exclusive locks.
    * Because U_LOCK is currently for reading the object.
    */
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
@@ -7716,7 +7821,7 @@ lock_check_local_deadlock_detection (void)
  *     First, allocate heaps for WFG table from local memory.
  *     Check whether deadlock(s) have been occurred or not.
  *
- *     Deadlock detection is peformed via exhaustive loop construction
+ *     Deadlock detection is performed via exhaustive loop construction
  *     which indicates the wait-for-relationship.
  *     If deadlock is detected,
  *     the first transaction which enables a cycle
@@ -7746,7 +7851,7 @@ lock_detect_local_deadlock (THREAD_ENTRY * thread_p)
 
   /* initialize deadlock detection related structures */
 
-  /* initialize transaction WFG node table.. The current transaction might be old deadlock victim. And, the transaction 
+  /* initialize transaction WFG node table.. The current transaction might be old deadlock victim. And, the transaction
    * may have not been aborted, until now. Even if the transaction(old deadlock victim) has not been aborted, set
    * checked_by_deadlock_detector of the transaction to true. */
   for (i = 1; i < lk_Gl.num_trans; i++)
@@ -7893,7 +7998,7 @@ lock_detect_local_deadlock (THREAD_ENTRY * thread_p)
   TWFG_node = lk_Gl.TWFG_node;
   TWFG_edge = lk_Gl.TWFG_edge;
 
-  /* 
+  /*
    * deadlock detection and victim selection
    */
 
@@ -8192,7 +8297,7 @@ lk_global_deadlock_detection (void)
 		       * process), select the new candidate as the victim. */
 		      ok = 0;
 
-		      /* 
+		      /*
 		       * never consider the unactive one as a victim
 		       */
 		      if (logtb_is_active (tranid) == false)
@@ -8333,7 +8438,7 @@ lock_reacquire_crash_locks (THREAD_ENTRY * thread_p, LK_ACQUIRED_LOCKS * acqlock
   /* reacquire given exclusive locks on behalf of the transaction */
   for (i = 0; i < acqlocks->nobj_locks; i++)
     {
-      /* 
+      /*
        * lock wait duration       : LK_INFINITE_WAIT
        * conditional lock request : false
        */
@@ -8826,7 +8931,7 @@ lock_add_composite_lock (THREAD_ENTRY * thread_p, LK_COMPOSITE_LOCK * comp_lock,
 	  COPY_OID (&lockcomp_class->inst_oid_space[lockcomp_class->num_inst_oids], oid);
 	  lockcomp_class->num_inst_oids++;
 	}
-      /* else, lockcomp_class->max_inst_oids equals PRM_LK_ESCALATION_AT. lock escalation will be performed. so no more 
+      /* else, lockcomp_class->max_inst_oids equals PRM_LK_ESCALATION_AT. lock escalation will be performed. so no more
        * instance OID is stored. */
     }
 
@@ -9511,7 +9616,7 @@ lock_get_lock_holder_tran_index (THREAD_ENTRY * thread_p, char **out_buf, int wa
 }
 
 /*
- * lock_wait_state_to_string () - Translate lock wait state into string 
+ * lock_wait_state_to_string () - Translate lock wait state into string
  *                                representation
  *   return:
  *   state(in): lock wait state
@@ -10014,7 +10119,7 @@ lock_free_entry (int tran_index, LF_TRAN_ENTRY * tran_entry, LF_FREELIST * freel
 
 #if defined (SERVER_MODE)
 /*
- * lock_unlock_object_by_isolation - No lock is unlocked/demoted for MVCC tables. 
+ * lock_unlock_object_by_isolation - No lock is unlocked/demoted for MVCC tables.
  *			             Shared instance lock on non-MVCC table is unlocked for TRAN_READ_COMMITTED.
  *
  * return : nothing
@@ -10052,8 +10157,8 @@ lock_unlock_object_by_isolation (THREAD_ENTRY * thread_p, int tran_index, TRAN_I
 }
 
 /*
- * lock_unlock_inst_locks_of_class_by_isolation - No lock is unlocked/demoted for MVCC tables. 
- *						  Shared instance locks on non-MVCC table is unlocked for 
+ * lock_unlock_inst_locks_of_class_by_isolation - No lock is unlocked/demoted for MVCC tables.
+ *						  Shared instance locks on non-MVCC table is unlocked for
  *						  TRAN_READ_COMMITTED.
  *
  * return : nothing

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -5944,6 +5944,9 @@ public:
 #endif /* SERVER_MODE */
 
 #if defined(SERVER_MODE)
+/*
+ * lock_deadlock_detect_daemon_init () - initialize deadlock detect daemon thread
+ */
 void
 lock_deadlock_detect_daemon_init ()
 {
@@ -5959,6 +5962,9 @@ lock_deadlock_detect_daemon_init ()
 #endif /* SERVER_MODE */
 
 #if defined(SERVER_MODE)
+/*
+ * lock_deadlock_detect_daemon_destroy () - destroy deadlock detect daemon thread
+ */
 void
 lock_deadlock_detect_daemon_destroy ()
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21841

Refactor deadlock detect daemon thread using new thread API, also a daemon_entry_manager class was added which will serve as daemon manager for creating and retiring a daemon thread entry, later this new class will be used for other daemon threads migration