### PR TITLE
[CBRD-21889] Handle duplicate keys in json_keys

### DIFF
--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 Letzter Fehler
+1203 Json KEY "%1$s" is duplicate
+1204 Letzter Fehler
 $set 6 MSGCAT_SET_INTERNAL
 1 Fehler in Fehler-Subsystem (Zeile %1$d):
 2 Keine Fehlermeldung vorhanden.

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 Last Error
+1203 Json KEY "%1$s" is duplicate
+1204 Last Error
 $set 6 MSGCAT_SET_INTERNAL
 1 Error in error subsystem (line %1$d):
 2 No error message available.

--- a/msg/en_US/cubrid.msg
+++ b/msg/en_US/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 Last Error
+1203 Json KEY "%1$s" is duplicate
+1204 Last Error
 $set 6 MSGCAT_SET_INTERNAL
 1 Error in error subsystem (line %1$d):
 2 No error message available.

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 Ultimo error
+1203 Json KEY "%1$s" is duplicate
+1204 Ultimo error
 $set 6 MSGCAT_SET_INTERNAL
 1 Error en subsistema de error (linea %1$d):
 2 Ningun mensaje de error disponible.

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 Dernière erreur
+1203 Json KEY "%1$s" is duplicate
+1204 Dernière erreur
 $set 6 MSGCAT_SET_INTERNAL
 1 Erreur dans le sous-système d'erreur (ligne %1$d):
 2 Aucun message d'erreur disponible.

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 Ultimo errore
+1203 Json KEY "%1$s" is duplicate
+1204 Ultimo errore
 $set 6 MSGCAT_SET_INTERNAL
 1 Errore nel sottosistema di errore (linea %1$d):
 2 Nessun messaggio di errore disponibile.

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 ラストエラー
+1203 Json KEY "%1$s" is duplicate
+1204 ラストエラー
 $set 6 MSGCAT_SET_INTERNAL
 1 エラーサブシステムにエラー発生(ライン %1$d):
 2 エラーメッセージが使用できません。

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 Last Error
+1203 Json KEY "%1$s" is duplicate
+1204 Last Error
 $set 6 MSGCAT_SET_INTERNAL
 1 Error in error subsystem (line %1$d):
 2 No error message available.

--- a/msg/ko_KR.euckr/cubrid.msg
+++ b/msg/ko_KR.euckr/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 마지막 에러
+1203 Json KEY "%1$s" is duplicate
+1204 마지막 에러
 
 $set 6 MSGCAT_SET_INTERNAL
 1 에러 서브 시스템에 에러 발생(라인 %1$d):

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 마지막 에러
+1203 Json KEY "%1$s" is duplicate
+1204 마지막 에러
 
 $set 6 MSGCAT_SET_INTERNAL
 1 에러 서브 시스템에 에러 발생(라인 %1$d):

--- a/msg/ro_RO.utf8/cubrid.msg
+++ b/msg/ro_RO.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Cale de JSON invalida
 1201 Numele unei valori dintr-un JSON Object nu poate fi NULL.
 1202 Calea "%1$s" nu exista in %2$s
-1203 Ultima eroare
+1203 Cheia "%1$s" din json este duplicata
+1204 Ultima eroare
 $set 6 MSGCAT_SET_INTERNAL
 1 Eroare în subsistemul de erori (linia %1$d):
 2 Niciun mesaj de eroare disponibil.

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 Son Hata
+1203 Json KEY "%1$s" is duplicate
+1204 Son Hata
 $set 6 MSGCAT_SET_INTERNAL
 1 Alt Hata içinde hata (satır %1$d):
 2 Uygun hata mesajı bulunmamakta.

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 Last Error
+1203 Json KEY "%1$s" is duplicate
+1204 Last Error
 $set 6 MSGCAT_SET_INTERNAL
 1 Error in error subsystem (line %1$d):
 2 No error message available.

--- a/msg/zh_CN.utf8/cubrid.msg
+++ b/msg/zh_CN.utf8/cubrid.msg
@@ -1269,7 +1269,8 @@ $ LOADDB
 1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
-1203 最后一个错误.
+1203 Json KEY "%1$s" is duplicate
+1204 最后一个错误.
 
 $set 6 MSGCAT_SET_INTERNAL
 1 在错误子系统中错误 (line %1$d):

--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -1545,8 +1545,9 @@
 #define ER_JSON_INVALID_PATH                        -1200
 #define ER_JSON_OBJECT_NAME_IS_NULL                 -1201
 #define ER_JSON_PATH_DOES_NOT_EXIST                 -1202
+#define ER_JSON_DUPLICATE_KEY                       -1203
 
-#define ER_LAST_ERROR                               -1203
+#define ER_LAST_ERROR                               -1204
 
 /*
  * CAUTION!

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -76,6 +76,7 @@
 
 #include <algorithm>
 #include <locale>
+#include <unordered_map>
 #include <vector>
 
 #include <cctype>

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -216,12 +216,13 @@ class JSON_BASE_HANDLER
 class JSON_WALKER
 {
   public:
-    JSON_WALKER() {}
-    virtual ~JSON_WALKER() = 0;
-
     int WalkDocument (JSON_DOC &document);
 
   protected:
+    // we should not instantiate this class, but extend it
+    JSON_WALKER() {}
+    virtual ~JSON_WALKER() {}
+
     virtual int
     CallBefore (JSON_VALUE &value)
     {
@@ -239,8 +240,6 @@ class JSON_WALKER
   private:
     int WalkValue (JSON_VALUE &value);
 };
-
-JSON_WALKER::~JSON_WALKER() {}
 
 /*
 * JSON_DUPLICATE_KEYS_CHECKER - This class extends JSON_WALKER

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -72,10 +72,10 @@ int db_json_extract_document_from_path (const JSON_DOC *document, const char *ra
 char *db_json_get_raw_json_body_from_document (const JSON_DOC *doc);
 JSON_DOC *db_json_get_paths_for_search_func (const JSON_DOC *doc, const char *search_str, bool all);
 
-void db_json_add_member_to_object (JSON_DOC *doc, const char *name, const char *value);
-void db_json_add_member_to_object (JSON_DOC *doc, char *name, int value);
-void db_json_add_member_to_object (JSON_DOC *doc, char *name, double value);
-void db_json_add_member_to_object (JSON_DOC *doc, char *name, const JSON_DOC *value);
+int db_json_add_member_to_object (JSON_DOC *doc, const char *name, const char *value);
+int db_json_add_member_to_object (JSON_DOC *doc, const char *name, int value);
+int db_json_add_member_to_object (JSON_DOC *doc, const char *name, double value);
+int db_json_add_member_to_object (JSON_DOC *doc, const char *name, const JSON_DOC *value);
 
 void db_json_add_element_to_array (JSON_DOC *doc, char *value);
 void db_json_add_element_to_array (JSON_DOC *doc, int value);
@@ -88,8 +88,8 @@ JSON_DOC *db_json_get_copy_of_doc (const JSON_DOC *doc);
 int db_json_insert_func (const JSON_DOC *doc_to_be_inserted, JSON_DOC &doc_destination, const char *raw_path);
 int db_json_replace_func (const JSON_DOC *new_value, JSON_DOC &doc, const char *raw_path);
 int db_json_set_func (const JSON_DOC *value, JSON_DOC &doc, const char *raw_path);
-int db_json_keys_func (const JSON_DOC &doc, JSON_DOC &result_json, const char *raw_path);
-int db_json_keys_func (const char *json_raw, JSON_DOC &result_json, const char *raw_path);
+int db_json_keys_func (const JSON_DOC &doc, JSON_DOC *&result_json, const char *raw_path);
+int db_json_keys_func (const char *json_raw, JSON_DOC *&result_json, const char *raw_path);
 int db_json_array_append_func (const JSON_DOC *value, JSON_DOC &doc, const char *raw_path);
 int db_json_remove_func (JSON_DOC &doc, const char *raw_path);
 int db_json_merge_func (const JSON_DOC *source, JSON_DOC *&dest);

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -3032,6 +3032,7 @@ int
 db_json_object (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 {
   int i;
+  int error_code = NO_ERROR;
   JSON_DOC *new_doc = NULL;
   char *str = NULL;
 
@@ -3062,7 +3063,13 @@ db_json_object (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 
       if (DB_IS_NULL (arg[i + 1]))
 	{
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), (JSON_DOC *) NULL);
+	  error_code = db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), (JSON_DOC *) NULL);
+	  if (error_code != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	      db_json_delete_doc (new_doc);
+	      return error_code;
+	    }
 	  continue;
 	}
 
@@ -3072,15 +3079,15 @@ db_json_object (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_STRING (arg[i + 1]));
+	  error_code = db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_STRING (arg[i + 1]));
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_INT (arg[i + 1]));
+	  error_code = db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_INT (arg[i + 1]));
 	  break;
 
 	case DB_TYPE_DOUBLE:
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_DOUBLE (arg[i + 1]));
+	  error_code = db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_DOUBLE (arg[i + 1]));
 	  break;
 
 	case DB_TYPE_NUMERIC:
@@ -3088,23 +3095,30 @@ db_json_object (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	    DB_VALUE double_value;
 
 	    db_value_coerce (arg[i + 1], &double_value, db_type_to_db_domain (DB_TYPE_DOUBLE));
-	    db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_DOUBLE (&double_value));
+	    error_code = db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_DOUBLE (&double_value));
 	    pr_clear_value (&double_value);
 	  }
 	  break;
 
 	case DB_TYPE_JSON:
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), arg[i + 1]->data.json.document);
+	  error_code = db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), arg[i + 1]->data.json.document);
 	  break;
 
 	case DB_TYPE_NULL:
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), (JSON_DOC *) NULL);
+	  error_code = db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), (JSON_DOC *) NULL);
 	  break;
 
 	default:
 	  db_json_delete_doc (new_doc);
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INVALID_DATA_TYPE, 0);
 	  return ER_QSTR_INVALID_DATA_TYPE;
+	}
+
+      if (error_code != NO_ERROR)
+	{
+	  ASSERT_ERROR ();
+	  db_json_delete_doc (new_doc);
+	  return error_code;
 	}
     }
 
@@ -3434,18 +3448,16 @@ db_json_keys (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
       path = DB_GET_STRING (arg[1]);
     }
 
-  result_json = db_json_allocate_doc ();
-
   switch (DB_VALUE_DOMAIN_TYPE (arg[0]))
     {
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      error_code = db_json_keys_func (DB_GET_STRING (arg[0]), *result_json, path.c_str ());
+      error_code = db_json_keys_func (DB_GET_STRING (arg[0]), result_json, path.c_str ());
       break;
     case DB_TYPE_JSON:
-      error_code = db_json_keys_func (*(DB_GET_JSON_DOCUMENT (arg[0])), *result_json, path.c_str ());
+      error_code = db_json_keys_func (*(DB_GET_JSON_DOCUMENT (arg[0])), result_json, path.c_str ());
       break;
     case DB_TYPE_NULL:
       db_json_delete_doc (result_json);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21889

Handle duplicate keys in json_keys

When creating the result json array that will contain all the keys for a specific path, we need to add **only unique values**, so we need to keep track of already inserted keys. For that we can use an unordered_set for O(1) find operation.

Suppose the following example:
```
select json_keys('{"a":{"c":1, "d":2},"a":3, "c":2}');
+------------------------------------------------+
| json_keys('{"a":{"c":1, "d":2},"a":3, "c":2}') |
+------------------------------------------------+
| ["a", "c"]                                     |
+------------------------------------------------+
```
We have 2 keys with name "a" but only one in the result.