### PR TITLE
[CBRD-21875] Expected json path will be parsed correctly

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1625,8 +1625,8 @@ db_json_sql_path_is_valid (std::string &sql_path)
 	      // expecting a valid index
 	      return false;
 	    }
-	  // move after ']'
-	  i = end_bracket_offset + 1;
+	  // move to ']'. i will be incremented.
+	  i = end_bracket_offset;
 	}
 	break;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21875

Expected json path will be parsed correctly

When parsing the sql path, if we have an array index like ```$.[123]``` we need to move the index of the iteration **i** to the index of the last ending bracket. This way the index will be auto incremented in the for loop.

This PR should fix the parsing of numeric index in sql path.