### PR TITLE
[CBRD-21884] Crash for json_array_append in view

### DIFF
--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -3538,7 +3538,7 @@ db_json_array_append (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 
   for (i = 1; i < num_args; i += 2)
     {
-      if (DB_IS_NULL (arg[i]))
+      if (DB_IS_NULL (arg[i]) || DB_IS_NULL (arg[i + 1]))
 	{
 	  db_json_delete_doc (new_doc);
 	  return DB_MAKE_NULL (result);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21884

If the **value** that we want to append is null then the result should be null.