### PR TITLE
[CBRD-21902] stop checkpoint daemon before log finalize enters in critical section

### DIFF
--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -2396,5 +2396,8 @@ extern void logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HE
 
 extern VACUUM_LOG_BLOCKID logpb_last_complete_blockid (void);
 
+extern void logpb_daemons_init ();
+extern void logpb_daemons_destroy ();
+
 #endif /* defined (SERVER_MODE) || defined (SA_MODE) */
 #endif /* _LOG_IMPL_H_ */

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1641,6 +1641,8 @@ log_final (THREAD_ENTRY * thread_p)
   bool anyloose_ends = false;
   int error_code = NO_ERROR;
 
+  logpb_daemons_destroy ();
+
   LOG_CS_ENTER (thread_p);
 
   /* reset log_Gl.rcv_phase */

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1641,7 +1641,9 @@ log_final (THREAD_ENTRY * thread_p)
   bool anyloose_ends = false;
   int error_code = NO_ERROR;
 
+#if defined(SERVER_MODE)
   logpb_daemons_destroy ();
+#endif /* SERVER_MODE */
 
   LOG_CS_ENTER (thread_p);
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -420,9 +420,6 @@ static cubthread::daemon *logpb_Checkpoint_daemon = NULL;
 static cubthread::daemon *logpb_Remove_log_archive_daemon = NULL;
 
 static bool logpb_Daemons_are_initialized = false;
-
-static void logpb_daemons_init ();
-static void logpb_daemons_destroy ();
 // *INDENT-ON*
 #endif /* SERVER_MODE */
 
@@ -702,10 +699,6 @@ logpb_finalize_pool (THREAD_ENTRY * thread_p)
   pthread_cond_destroy (&log_Gl.group_commit_info.gc_cond);
 
   logpb_finalize_writer_info ();
-
-#if defined(SERVER_MODE)
-  logpb_daemons_destroy ();
-#endif // SERVER_MODE
 
   if (log_zip_support)
     {

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7642,7 +7642,10 @@ logpb_remove_log_archive_daemon_init ()
 void
 logpb_daemons_init ()
 {
-  assert (!logpb_Daemons_are_initialized);
+  if (logpb_Daemons_are_initialized)
+    {
+      return;
+    }
 
   logpb_checkpoint_daemon_init ();
   logpb_remove_log_archive_daemon_init ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21902

Stop checkpoint daemon before log finalize enters in critical section.
A quick fix for a bug that was introduced by refactoring checkpoint ([CBRD-21843](http://jira.cubrid.org/browse/CBRD-21843), #997) daemon. 