### PR TITLE
[CBRD-21897] fix to avoid deadlock of "show indexes"

### DIFF
--- a/src/storage/statistics_sr.c
+++ b/src/storage/statistics_sr.c
@@ -1230,8 +1230,7 @@ stats_dump_class_statistics (CLASS_STATS * class_stats, FILE * fpp)
 #endif /* CUBRID_DEBUG */
 
 /*
- * stats_update_partitioned_statistics () - compute statistics for a
- *						  partitioned class
+ * stats_update_partitioned_statistics () - compute statistics for a partitioned class
  * return : error code or NO_ERROR
  * thread_p (in) :
  * class_id_p (in) : oid of the partitioned class
@@ -1466,8 +1465,8 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 	  goto cleanup;
 	}
 
-      subcls_disk_rep =
-	catalog_get_representation (thread_p, &partitions[i], subcls_repr_id, &part_catalog_access_info);
+      subcls_disk_rep = catalog_get_representation (thread_p, &partitions[i], subcls_repr_id,
+						    &part_catalog_access_info);
       if (subcls_disk_rep == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error);
@@ -1511,9 +1510,10 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 
 	  for (k = 0, btree_stats_p = disk_attr_p->bt_stats; k < disk_attr_p->n_btstats; k++, btree_stats_p++)
 	    {
-	      const BTREE_STATS *subcls_stats = stats_find_inherited_index_stats (cls_rep, subcls_rep,
-										  subcls_attr_p,
-										  &btree_stats_p->btid);
+	      const BTREE_STATS *subcls_stats;
+
+	      subcls_stats = stats_find_inherited_index_stats (cls_rep, subcls_rep, subcls_attr_p,
+							       &btree_stats_p->btid);
 	      if (subcls_stats == NULL)
 		{
 		  error = ER_FAILED;
@@ -1592,8 +1592,8 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 	  goto cleanup;
 	}
 
-      subcls_disk_rep =
-	catalog_get_representation (thread_p, &partitions[i], subcls_repr_id, &part_catalog_access_info);
+      subcls_disk_rep = catalog_get_representation (thread_p, &partitions[i], subcls_repr_id,
+						    &part_catalog_access_info);
       if (subcls_disk_rep == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error);
@@ -1636,9 +1636,10 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 
 	  for (k = 0, btree_stats_p = disk_attr_p->bt_stats; k < disk_attr_p->n_btstats; k++, btree_stats_p++)
 	    {
-	      const BTREE_STATS *subcls_stats = stats_find_inherited_index_stats (cls_rep, subcls_rep,
-										  subcls_attr_p,
-										  &btree_stats_p->btid);
+	      const BTREE_STATS *subcls_stats;
+
+	      subcls_stats = stats_find_inherited_index_stats (cls_rep, subcls_rep, subcls_attr_p,
+							       &btree_stats_p->btid);
 	      if (subcls_stats == NULL)
 		{
 		  error = ER_FAILED;
@@ -1738,9 +1739,8 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 
   /* replace the current disk representation structure/information in the catalog with the newly computed statistics */
   assert (!OID_ISNULL (&(cls_info_p->ci_rep_dir)));
-  error =
-    catalog_add_representation (thread_p, class_id_p, repr_id, disk_repr_p, &(cls_info_p->ci_rep_dir),
-				&catalog_access_info);
+  error = catalog_add_representation (thread_p, class_id_p, repr_id, disk_repr_p, &(cls_info_p->ci_rep_dir),
+				      &catalog_access_info);
   if (error != NO_ERROR)
     {
       goto cleanup;
@@ -1805,9 +1805,7 @@ cleanup:
 }
 
 /*
- * stats_find_inherited_index_stats () - find the btree statistics
- *					 corresponding to an index in a
- *					 subclass
+ * stats_find_inherited_index_stats () - find the btree statistics corresponding to an index in a subclass
  * return : btree statistics
  * cls_rep (in)	   : superclass representation
  * subcls_rep (in) : subclass representation

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -5709,8 +5709,7 @@ catalog_rv_ovf_page_logical_insert_undo (THREAD_ENTRY * thread_p, LOG_RCV * recv
 }
 
 /*
- * catalog_get_dir_oid_from_cache () - Get directory OID from cache
- *				       or class record
+ * catalog_get_dir_oid_from_cache () - Get directory OID from cache or class record
  *   return: error status
  *   class_id_p(in): Class identifier
  *   dir_oid_p(out): directory OID
@@ -5802,8 +5801,7 @@ catalog_get_dir_oid_from_cache (THREAD_ENTRY * thread_p, const OID * class_id_p,
 }
 
 /*
- * catalog_start_access_with_dir_oid () - starts an access on catalog using
- *					  directory OID for locking purpose
+ * catalog_start_access_with_dir_oid () - starts an access on catalog using directory OID for locking purpose
  *   return: error code
  *   catalog_access_info(in/out): catalog access helper structure
  *   lock_mode(in): should be X_LOCK for update on catalog and S_LOCK for read
@@ -5910,8 +5908,7 @@ error:
 }
 
 /*
- * catalog_end_access_with_dir_oid () - ends access on catalog using directory
- *					OID
+ * catalog_end_access_with_dir_oid () - ends access on catalog using directory OID
  *   return: error code
  *   catalog_access_info(in/out): catalog access helper structure
  *   error(in): error code


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21897

This is a legacy issue.
Dead-lock/latch between `qexec_execute_build_indexes` and `xstats_get_statistics_from_server`.
The latter acquires lock and then fixes a page latch to access class representation, while the former did into reverse. This caused deadlock chances.

Fix is to make `show indexes` to follow the same order of query execution.