### PR TITLE
[CBRD-21883] Tokenize an SQL path string that's surrounded by double quotes

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1579,6 +1579,8 @@ db_json_split_path_by_delimiters (const std::string &path, const std::string &de
 	  if (index_of_closing_quote == std::string::npos)
 	    {
 	      assert (false);
+	      tokens.clear ();
+	      return tokens;
 	      /* this should have been catched earlier */
 	    }
 	  else

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1573,8 +1573,23 @@ db_json_split_path_by_delimiters (const std::string &path, const std::string &de
 
   while (end != std::string::npos)
     {
+      if (path[end] == '"')
+	{
+	  std::size_t index_of_closing_quote = path.find_first_of ("\"", end+1);
+	  if (index_of_closing_quote == std::string::npos)
+	    {
+	      assert (false);
+	      /* this should have been catched earlier */
+	    }
+	  else
+	    {
+	      tokens.push_back (path.substr (end + 1, index_of_closing_quote - end - 1));
+	      end = index_of_closing_quote;
+	      start = end + 1;
+	    }
+	}
       // do not tokenize on escaped quotes
-      if (path[end] != '"' || path[end - 1] != '\\')
+      else if (path[end] != '"' || ((end >= 1) && path[end - 1] != '\\'))
 	{
 	  const std::string &substring = path.substr (start, end - start);
 	  if (!substring.empty ())


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21883

I left cristi's logic unchanged and I added the case when the string is surrounded by double quotes. If I find a double quote, I look immediately for the closing one, ignoring all other tokens.