### PR TITLE
[CBRD-21914] deregister worker in case of an early out from execute

### DIFF
--- a/contrib/gdb_debugging_scripts/thread_tran.gdb
+++ b/contrib/gdb_debugging_scripts/thread_tran.gdb
@@ -3,6 +3,30 @@
 #
 
 
+# thread_find_by_index
+# $arg0 (in)  : THREAD_INDEX
+# $arg1 (out) : THREAD_ENTRY *
+#
+# Get THREAD_ENTRY with THREAD_INDEX
+#
+define thread_find_by_index
+  set $arg1 = 0
+  set $thread_index = $arg0
+  set $num_total_threads = thread_Manager.num_total + cubthread::Manager->m_max_threads + 1
+
+  if $thread_index >= 0 && $thread_index < $num_total_threads
+    if $thread_index == 0
+      set $arg1 = (THREAD_ENTRY *) cubthread::Main_entry_p
+    else
+      if $thread_index <= thread_Manager.num_total
+        set $arg1 = (THREAD_ENTRY *) &thread_Manager.thread_array[$thread_index - 1]
+      else
+        set $arg1 = (THREAD_ENTRY *) &cubthread::Manager->m_all_entries[$thread_index - thread_Manager.num_total - 1]
+      end
+    end
+  end
+end
+
 # thread_find_by_tran_index
 # $arg0 (in)  : TRAN_INDEX
 # $arg1 (out) : THREAD_ENTRY *
@@ -12,31 +36,38 @@
 define thread_find_by_tran_index
   set $i = 0
   set $arg1 = 0
-  set $found = 0
-  while $i < thread_Manager.num_total && $found == 0
-    if thread_Manager.thread_array[$i]->tran_index == $arg0
-      set $arg1 = thread_Manager.thread_array[$i]
+  set $num_total_threads = thread_Manager.num_total + cubthread::Manager->m_max_threads + 1
+
+  while $i < $num_total_threads
+    thread_find_by_index $i $thread_entry
+
+    if $thread_entry->tran_index == $arg0
+      set $arg1 = $thread_entry
       loop_break
     end
-    set $i=$i+1
+    set $i = $i + 1
   end
 end
 
 # thread_find_by_tid
-# $arg0 (in)  : TID
+# $arg0 (in)  : THREAD_ID
 # $arg1 (out) : THREAD_ENTRY *
 #
-# Get THREAD_ENTRY with TID.
+# Get THREAD_ENTRY with THREAD_ID.
 #
-define thread_find_by_tid
+define thread_find_by_id
   set $i = 0
   set $arg1 = 0
-  while $i < thread_Manager.num_total
-    if thread_Manager.thread_array[$i]->m_id._M_thread == $arg0
-      set $arg1 = thread_Manager.thread_array[$i]
+  set $num_total_threads = thread_Manager.num_total + cubthread::Manager->m_max_threads + 1
+
+  while $i < $num_total_threads
+    thread_find_by_index $i $thread_entry
+
+    if $thread_entry->m_id._M_thread == $arg0
+      set $arg1 = $thread_entry
       loop_break
-	end
-  set $i=$i+1
+    end
+  set $i = $i + 1
   end
 end
 

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -390,6 +390,9 @@ namespace cubthread
       {
 	// task must not be executed if it was pushed for execution after worker pool was stopped
 	task_arg->retire();
+
+	// deregister worker
+	pool.deregister_worker (thread_arg);
 	return;
       }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21914

In case when worker pool is stopped and a task was pushed for execution, worker needs to be unregistered so it can be stopped as well.
Plus a fix for gdb thread scripts for finding thread by index,transaction index and thread id