### PR TITLE
[CBRD-21931] Remove DB_GET and DB_MAKE usages of macros

### DIFF
--- a/src/base/memory_hash.c
+++ b/src/base/memory_hash.c
@@ -624,7 +624,7 @@ mht_valhash (const void *key, const unsigned int ht_size)
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_VARNCHAR:
-	  hash = mht_1str_pseudo_key (db_get_string (val), DB_GET_STRING_SIZE (val));
+	  hash = mht_1str_pseudo_key (db_get_string (val), db_get_string_size (val));
 	  break;
 	case DB_TYPE_BIT:
 	case DB_TYPE_VARBIT:
@@ -2185,7 +2185,7 @@ mht_get_hash_number (const int ht_size, const DB_VALUE * val)
 	  {
 	    char *json_body = NULL;
 
-	    json_body = DB_GET_JSON_RAW_BODY (val);
+	    json_body = db_get_json_raw_body (val);
 
 	    if (json_body == NULL)
 	      {

--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -1522,10 +1522,10 @@ or_install_btids_foreign_key (const char *fkname, DB_SEQ * fk_seq, OR_INDEX * in
   index->fk->ref_class_pk_btid.vfid.fileid = (FILEID) fileid;
 
   set_get_element_nocopy (fk_seq, 2, &val);
-  index->fk->del_action = DB_GET_INT (&val);
+  index->fk->del_action = db_get_int (&val);
 
   set_get_element_nocopy (fk_seq, 3, &val);
-  index->fk->upd_action = DB_GET_INT (&val);
+  index->fk->upd_action = db_get_int (&val);
 }
 
 /*
@@ -1553,7 +1553,7 @@ or_install_btids_foreign_key_ref (DB_SEQ * fk_container, OR_INDEX * index)
 	  return;
 	}
 
-      fk_seq = DB_GET_SEQUENCE (&fkval);
+      fk_seq = db_get_set (&fkval);
 
       fk = (OR_FOREIGN_KEY *) malloc (sizeof (OR_FOREIGN_KEY));
       if (fk == NULL)
@@ -1605,14 +1605,14 @@ or_install_btids_foreign_key_ref (DB_SEQ * fk_container, OR_INDEX * index)
 	  free_and_init (fk);
 	  return;
 	}
-      fk->del_action = DB_GET_INT (&val);
+      fk->del_action = db_get_int (&val);
 
       if (set_get_element_nocopy (fk_seq, 3, &val) != NO_ERROR)
 	{
 	  free_and_init (fk);
 	  return;
 	}
-      fk->upd_action = DB_GET_INT (&val);
+      fk->upd_action = db_get_int (&val);
 
       if (set_get_element_nocopy (fk_seq, 4, &val) != NO_ERROR)
 	{
@@ -1672,7 +1672,7 @@ or_install_btids_prefix_length (DB_SEQ * prefix_seq, OR_INDEX * index, int num_a
 	  return;
 	}
 
-      index->attrs_prefix_length[i] = DB_GET_INT (&val);
+      index->attrs_prefix_length[i] = db_get_int (&val);
     }
 }
 
@@ -1755,7 +1755,7 @@ or_install_btids_filter_pred (DB_SEQ * pred_seq, OR_INDEX * index)
     }
 
   buffer = db_get_string (&val2);
-  buffer_len = DB_GET_STRING_SIZE (&val2);
+  buffer_len = db_get_string_size (&val2);
   filter_predicate->pred_stream = (char *) malloc (buffer_len * sizeof (char));
   if (filter_predicate->pred_stream == NULL)
     {
@@ -1877,7 +1877,7 @@ or_install_btids_class (OR_CLASSREP * rep, BTID * id, DB_SEQ * constraint_seq, i
 	      break;
 	    }
 
-	  att_id = DB_GET_INTEGER (&att_val);
+	  att_id = db_get_int (&att_val);
 
 	  for (j = 0, att = rep->attributes, ptr = NULL; j < rep->n_attributes && ptr == NULL; j++, att++)
 	    {
@@ -1894,7 +1894,7 @@ or_install_btids_class (OR_CLASSREP * rep, BTID * id, DB_SEQ * constraint_seq, i
       /* asc_desc info */
       if (set_get_element_nocopy (constraint_seq, e++, &att_val) == NO_ERROR)
 	{
-	  index->asc_desc[i] = DB_GET_INTEGER (&att_val);
+	  index->asc_desc[i] = db_get_int (&att_val);
 	}
     }
   index->btname = strdup (cons_name);
@@ -1903,7 +1903,7 @@ or_install_btids_class (OR_CLASSREP * rep, BTID * id, DB_SEQ * constraint_seq, i
     {
       if (set_get_element_nocopy (constraint_seq, seq_size - 2, &att_val) == NO_ERROR)
 	{
-	  or_install_btids_foreign_key (cons_name, DB_GET_SEQUENCE (&att_val), index);
+	  or_install_btids_foreign_key (cons_name, db_get_set (&att_val), index);
 	}
     }
   else if (type == BTREE_PRIMARY_KEY)
@@ -1912,7 +1912,7 @@ or_install_btids_class (OR_CLASSREP * rep, BTID * id, DB_SEQ * constraint_seq, i
 	{
 	  if (DB_VALUE_TYPE (&att_val) == DB_TYPE_SEQUENCE)
 	    {
-	      or_install_btids_foreign_key_ref (DB_GET_SEQUENCE (&att_val), index);
+	      or_install_btids_foreign_key_ref (db_get_set (&att_val), index);
 	    }
 	}
     }
@@ -1922,19 +1922,19 @@ or_install_btids_class (OR_CLASSREP * rep, BTID * id, DB_SEQ * constraint_seq, i
 	{
 	  if (DB_VALUE_TYPE (&att_val) == DB_TYPE_SEQUENCE)
 	    {
-	      DB_SEQ *seq = DB_GET_SEQUENCE (&att_val);
+	      DB_SEQ *seq = db_get_set (&att_val);
 	      DB_VALUE val;
 
 	      if (set_get_element_nocopy (seq, 0, &val) == NO_ERROR)
 		{
 		  if (DB_VALUE_TYPE (&val) == DB_TYPE_INTEGER)
 		    {
-		      or_install_btids_prefix_length (DB_GET_SEQUENCE (&att_val), index, att_cnt);
+		      or_install_btids_prefix_length (db_get_set (&att_val), index, att_cnt);
 		    }
 		  else if (DB_VALUE_TYPE (&val) == DB_TYPE_SEQUENCE)
 		    {
 		      DB_VALUE avalue;
-		      DB_SET *child_seq = DB_GET_SEQUENCE (&val);
+		      DB_SET *child_seq = db_get_set (&val);
 		      int seq_size = set_size (seq);
 		      int flag;
 
@@ -1978,15 +1978,15 @@ or_install_btids_class (OR_CLASSREP * rep, BTID * id, DB_SEQ * constraint_seq, i
 			  switch (flag)
 			    {
 			    case 0x01:
-			      or_install_btids_filter_pred (DB_GET_SEQUENCE (&avalue), index);
+			      or_install_btids_filter_pred (db_get_set (&avalue), index);
 			      break;
 
 			    case 0x02:
-			      or_install_btids_function_info (DB_GET_SEQUENCE (&avalue), index);
+			      or_install_btids_function_info (db_get_set (&avalue), index);
 			      break;
 
 			    case 0x03:
-			      or_install_btids_prefix_length (DB_GET_SEQUENCE (&avalue), index, att_cnt);
+			      or_install_btids_prefix_length (db_get_set (&avalue), index, att_cnt);
 			      break;
 
 			    default:
@@ -2010,7 +2010,7 @@ or_install_btids_class (OR_CLASSREP * rep, BTID * id, DB_SEQ * constraint_seq, i
 			      continue;
 			    }
 
-			  child_seq = DB_GET_SEQUENCE (&val);
+			  child_seq = db_get_set (&val);
 			}
 
 		      if (index->func_index_info)
@@ -2176,7 +2176,7 @@ or_install_btids_constraint (OR_CLASSREP * rep, DB_SEQ * constraint_seq, BTREE_T
   if (set_get_element_nocopy (constraint_seq, i, &att_val) == NO_ERROR)
     {
       assert (DB_VALUE_TYPE (&att_val) == DB_TYPE_INTEGER);
-      att_id = DB_GET_INTEGER (&att_val);	/* The first attrID */
+      att_id = db_get_int (&att_val);	/* The first attrID */
       (void) or_install_btids_attribute (rep, att_id, &id);
     }
 
@@ -2223,7 +2223,7 @@ or_install_btids (OR_CLASSREP * rep, DB_SEQ * props)
 	{
 	  if (DB_VALUE_TYPE (&vals[i]) == DB_TYPE_SEQUENCE)
 	    {
-	      property_vars[i].seq = DB_GET_SEQUENCE (&vals[i]);
+	      property_vars[i].seq = db_get_set (&vals[i]);
 	    }
 
 	  if (property_vars[i].seq)
@@ -2272,7 +2272,7 @@ or_install_btids (OR_CLASSREP * rep, DB_SEQ * props)
 		{
 		  if (DB_VALUE_TYPE (&ids_val) == DB_TYPE_SEQUENCE)
 		    {
-		      ids_seq = DB_GET_SEQUENCE (&ids_val);
+		      ids_seq = db_get_set (&ids_val);
 		      or_install_btids_constraint (rep, ids_seq, property_vars[i].type, cons_name);
 		    }
 		}
@@ -2497,7 +2497,7 @@ or_get_current_representation (RECDES * record, int do_indexes)
 	  db_make_null (&def_expr_format);
 
 	  or_get_value (&buf, &properties_val, tp_domain_resolve_default (DB_TYPE_SEQUENCE), properties_val_len, true);
-	  att_props = DB_GET_SEQUENCE (&properties_val);
+	  att_props = db_get_set (&properties_val);
 
 	  if (att_props != NULL && classobj_get_prop (att_props, "default_expr", &def_expr) > 0)
 	    {
@@ -2514,9 +2514,9 @@ or_get_current_representation (RECDES * record, int do_indexes)
 		   */
 
 		  /* Currently, we allow only (T_TO_CHAR(int), default_expr(int), default_expr_format(string)) */
-		  assert (set_size (DB_GET_SEQUENCE (&def_expr)) == 3);
+		  assert (set_size (db_get_set (&def_expr)) == 3);
 
-		  def_expr_set = DB_GET_SEQUENCE (&def_expr);
+		  def_expr_set = db_get_set (&def_expr);
 
 		  /* get and cache default expression operator - op of expr */
 		  if (set_get_element_nocopy (def_expr_set, 0, &def_expr_op) != NO_ERROR)
@@ -2527,9 +2527,9 @@ or_get_current_representation (RECDES * record, int do_indexes)
 		      goto error_cleanup;
 		    }
 		  assert (DB_VALUE_TYPE (&def_expr_op) == DB_TYPE_INTEGER
-			  && DB_GET_INT (&def_expr_op) == (int) T_TO_CHAR);
-		  att->default_value.default_expr.default_expr_op = DB_GET_INT (&def_expr_op);
-		  att->current_default_value.default_expr.default_expr_op = DB_GET_INT (&def_expr_op);
+			  && db_get_int (&def_expr_op) == (int) T_TO_CHAR);
+		  att->default_value.default_expr.default_expr_op = db_get_int (&def_expr_op);
+		  att->current_default_value.default_expr.default_expr_op = db_get_int (&def_expr_op);
 
 		  /* get and cache default expression type - arg1 of expr */
 		  if (set_get_element_nocopy (def_expr_set, 1, &def_expr_type) != NO_ERROR)
@@ -2541,9 +2541,9 @@ or_get_current_representation (RECDES * record, int do_indexes)
 		    }
 		  assert (DB_VALUE_TYPE (&def_expr_type) == DB_TYPE_INTEGER);
 		  att->default_value.default_expr.default_expr_type =
-		    (DB_DEFAULT_EXPR_TYPE) DB_GET_INT (&def_expr_type);
+		    (DB_DEFAULT_EXPR_TYPE) db_get_int (&def_expr_type);
 		  att->current_default_value.default_expr.default_expr_type =
-		    (DB_DEFAULT_EXPR_TYPE) DB_GET_INT (&def_expr_type);
+		    (DB_DEFAULT_EXPR_TYPE) db_get_int (&def_expr_type);
 
 		  /* get and cache default expression format - arg2 of expr */
 		  if (set_get_element_nocopy (def_expr_set, 2, &def_expr_format) != NO_ERROR)
@@ -2570,9 +2570,9 @@ or_get_current_representation (RECDES * record, int do_indexes)
 		  /* simple expressions like SYS_DATE */
 		  assert (DB_VALUE_TYPE (&def_expr) == DB_TYPE_INTEGER);
 
-		  att->default_value.default_expr.default_expr_type = (DB_DEFAULT_EXPR_TYPE) DB_GET_INT (&def_expr);
+		  att->default_value.default_expr.default_expr_type = (DB_DEFAULT_EXPR_TYPE) db_get_int (&def_expr);
 		  att->current_default_value.default_expr.default_expr_type =
-		    (DB_DEFAULT_EXPR_TYPE) DB_GET_INT (&def_expr);
+		    (DB_DEFAULT_EXPR_TYPE) db_get_int (&def_expr);
 		}
 	    }
 
@@ -3369,7 +3369,7 @@ or_class_get_partition_info (RECDES * record, OR_PARTITION * partition_info, REP
     {
       return ER_FAILED;
     }
-  partition_info->values = db_seq_copy (DB_GET_SEQUENCE (&val));
+  partition_info->values = db_seq_copy (db_get_set (&val));
   if (partition_info->values == NULL)
     {
       pr_clear_value (&val);
@@ -3454,7 +3454,7 @@ or_get_constraint_comment (RECDES * record, const char *constraint_name)
       /* this sequence is an alternating pair of constraint name & info sequence, as by: { name, { BTID, [att_name,
        * asc_dsc], {fk_info | pk_info | prefix_length}, filter_predicate, comment}, name, { BTID, [att_name, asc_dsc],
        * {fk_info | pk_info | prefix_length}, filter_predicate, comment}, ... } */
-      props = DB_GET_SEQUENCE (&value);
+      props = db_get_set (&value);
       len = set_size (props);
       for (j = 0; j < len; j += 2)
 	{
@@ -3480,7 +3480,7 @@ or_get_constraint_comment (RECDES * record, const char *constraint_name)
 	      goto error_exit;
 	    }
 
-	  info = DB_GET_SEQUENCE (&uvalue);
+	  info = db_get_set (&uvalue);
 	  info_len = set_size (info);
 
 	  if (set_get_element_nocopy (info, info_len - 1, &cvalue) || DB_IS_NULL (&cvalue))
@@ -4003,7 +4003,7 @@ or_install_btids_function_info (DB_SEQ * fi_seq, OR_INDEX * index)
     }
 
   buffer = db_get_string (&val);
-  fi_info->expr_stream_size = DB_GET_STRING_SIZE (&val);
+  fi_info->expr_stream_size = db_get_string_size (&val);
   fi_info->expr_stream = (char *) malloc (fi_info->expr_stream_size);
   if (fi_info->expr_stream == NULL)
     {
@@ -4017,14 +4017,14 @@ or_install_btids_function_info (DB_SEQ * fi_seq, OR_INDEX * index)
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SM_INVALID_PROPERTY, 0);
       goto error;
     }
-  fi_info->col_id = DB_GET_INT (&val);
+  fi_info->col_id = db_get_int (&val);
 
   if (set_get_element_nocopy (fi_seq, 3, &val) != NO_ERROR)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SM_INVALID_PROPERTY, 0);
       goto error;
     }
-  fi_info->attr_index_start = DB_GET_INT (&val);
+  fi_info->attr_index_start = db_get_int (&val);
 
   index->func_index_info = fi_info;
   return;

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -1083,7 +1083,7 @@ ux_get_last_insert_id (T_NET_BUF * net_buf)
   int err = NO_ERROR;
   DB_VALUE lid;
 
-  DB_MAKE_NULL (&lid);
+  db_make_null (&lid);
 
   err = db_get_last_insert_id (&lid);
   if (err != NO_ERROR)
@@ -3739,8 +3739,8 @@ get_column_default_as_string (DB_ATTRIBUTE * attr, bool * alloc)
     case DB_TYPE_VARCHAR:
     case DB_TYPE_VARNCHAR:
       {
-	int def_size = DB_GET_STRING_SIZE (def);
-	char *def_str_p = DB_GET_STRING (def);
+	int def_size = db_get_string_size (def);
+	char *def_str_p = db_get_string (def);
 	if (def_str_p)
 	  {
 	    default_value_string = (char *) malloc (def_size + 3);
@@ -3763,8 +3763,8 @@ get_column_default_as_string (DB_ATTRIBUTE * attr, bool * alloc)
 	err = db_value_coerce (def, &tmp_val, db_type_to_db_domain (DB_TYPE_VARCHAR));
 	if (err == NO_ERROR)
 	  {
-	    int def_size = DB_GET_STRING_SIZE (&tmp_val);
-	    char *def_str_p = DB_GET_STRING (&tmp_val);
+	    int def_size = db_get_string_size (&tmp_val);
+	    char *def_str_p = db_get_string (&tmp_val);
 
 	    default_value_string = (char *) malloc (def_size + 1);
 	    if (default_value_string != NULL)
@@ -4506,13 +4506,13 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
 	bool need_decomp = false;
 
 	str = db_get_char (val, &dummy);
-	bytes_size = DB_GET_STRING_SIZE (val);
+	bytes_size = db_get_string_size (val);
 	if (max_col_size > 0)
 	  {
 	    bytes_size = MIN (bytes_size, max_col_size);
 	  }
 
-	if (DB_GET_STRING_CODESET (val) == INTL_CODESET_UTF8)
+	if (db_get_string_codeset (val) == INTL_CODESET_UTF8)
 	  {
 	    need_decomp =
 	      unicode_string_need_decompose (str, bytes_size, &decomp_size, lang_get_generic_unicode_norm ());
@@ -4537,7 +4537,7 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
 	      }
 	  }
 
-	add_res_data_string (net_buf, str, bytes_size, ext_col_type, DB_GET_STRING_CODESET (val), &data_size);
+	add_res_data_string (net_buf, str, bytes_size, ext_col_type, db_get_string_codeset (val), &data_size);
 
 	if (decomposed != NULL)
 	  {
@@ -4557,13 +4557,13 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
 	bool need_decomp = false;
 
 	nchar = db_get_nchar (val, &dummy);
-	bytes_size = DB_GET_STRING_SIZE (val);
+	bytes_size = db_get_string_size (val);
 	if (max_col_size > 0)
 	  {
 	    bytes_size = MIN (bytes_size, max_col_size);
 	  }
 
-	if (DB_GET_STRING_CODESET (val) == INTL_CODESET_UTF8)
+	if (db_get_string_codeset (val) == INTL_CODESET_UTF8)
 	  {
 	    need_decomp =
 	      unicode_string_need_decompose (nchar, bytes_size, &decomp_size, lang_get_generic_unicode_norm ());
@@ -4588,7 +4588,7 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
 	      }
 	  }
 
-	add_res_data_string (net_buf, nchar, bytes_size, ext_col_type, DB_GET_STRING_CODESET (val), &data_size);
+	add_res_data_string (net_buf, nchar, bytes_size, ext_col_type, db_get_string_codeset (val), &data_size);
 
 	if (decomposed != NULL)
 	  {
@@ -4636,7 +4636,7 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
 	      }
 	  }
 
-	add_res_data_string (net_buf, str, bytes_size, ext_col_type, DB_GET_ENUM_CODESET (val), &data_size);
+	add_res_data_string (net_buf, str, bytes_size, ext_col_type, db_get_enum_codeset (val), &data_size);
 
 	if (decomposed != NULL)
 	  {
@@ -7338,7 +7338,7 @@ execute_info_set (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_buf, T_BROKER_VERSI
 		    {
 		      /* result of a GET_GENERATED_KEYS request, client insert */
 		      DB_VALUE value;
-		      DB_SEQ *seq = DB_GET_SEQUENCE (&val);
+		      DB_SEQ *seq = db_get_set (&val);
 
 		      if (seq != NULL && db_col_size (seq) == 1)
 			{
@@ -9363,7 +9363,7 @@ ux_get_generated_keys_client_insert (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_
 
   if (DB_VALUE_DOMAIN_TYPE (qres->res.c.val_ptr) == DB_TYPE_SEQUENCE)
     {
-      seq = DB_GET_SEQUENCE (qres->res.c.val_ptr);
+      seq = db_get_set (qres->res.c.val_ptr);
       if (seq == NULL)
 	{
 	  err_code = ERROR_INFO_SET (err_code, DBMS_ERROR_INDICATOR);
@@ -9376,7 +9376,7 @@ ux_get_generated_keys_client_insert (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_
     {
       /* the default result, when the generated keys have not been requested */
       tuple_count = 1;
-      db_make_object (&oid_val, DB_GET_OBJECT (qres->res.c.val_ptr));
+      db_make_object (&oid_val, db_get_object (qres->res.c.val_ptr));
     }
   else
     {

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -2468,7 +2468,7 @@ _op_get_set_value (DB_VALUE * val)
       snprintf (result, result_size, "%s%s%s", "time '", return_result, "'");
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       snprintf (result, result_size, "%s%s%s", "timestamp '", return_result, "'");
       break;
 

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -4395,7 +4395,7 @@ csession_get_last_insert_id (DB_VALUE * value, bool update_last_insert_id)
   char *data_reply = NULL;
   int data_size = 0;
 
-  DB_MAKE_NULL (value);
+  db_make_null (value);
 
   reply = OR_ALIGNED_BUF_START (a_reply);
 
@@ -4407,7 +4407,7 @@ csession_get_last_insert_id (DB_VALUE * value, bool update_last_insert_id)
 			 OR_ALIGNED_BUF_SIZE (a_reply), NULL, 0, &data_reply, &data_size);
   if (req_error != NO_ERROR)
     {
-      DB_MAKE_NULL (value);
+      db_make_null (value);
       req_error = ER_FAILED;
       goto cleanup;
     }
@@ -5076,7 +5076,7 @@ cleanup:
     }
   else
     {
-      DB_MAKE_NULL (value);
+      db_make_null (value);
     }
   return err;
 #endif
@@ -6464,7 +6464,7 @@ qmgr_execute_query (const XASL_ID * xasl_id, QUERY_ID * query_idp, int dbval_cnt
 	}
       for (i = 0; i < dbval_cnt; i++)
 	{
-	  DB_MAKE_NULL (&server_db_values[i]);
+	  db_make_null (&server_db_values[i]);
 	}
       for (i = 0; i < dbval_cnt; i++)
 	{
@@ -6472,10 +6472,10 @@ qmgr_execute_query (const XASL_ID * xasl_id, QUERY_ID * query_idp, int dbval_cnt
 	    {
 	    case DB_TYPE_OBJECT:
 	      /* server cannot handle objects, convert to OID instead */
-	      oid = ws_identifier (DB_GET_OBJECT (&dbvals[i]));
+	      oid = ws_identifier (db_get_object (&dbvals[i]));
 	      if (oid != NULL)
 		{
-		  DB_MAKE_OID (&server_db_values[i], oid);
+		  db_make_oid (&server_db_values[i], oid);
 		}
 	      break;
 
@@ -7865,7 +7865,7 @@ db_local_transaction_id (DB_VALUE * result_trid)
       ptr = or_unpack_int (ptr, &trid);
     }
 
-  DB_MAKE_INTEGER (result_trid, trid);
+  db_make_int (result_trid, trid);
   return success;
 #else /* CS_MODE */
   int success;

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -5584,7 +5584,7 @@ sqp_get_sys_timestamp (THREAD_ENTRY * thread_p, unsigned int rid, char *request_
   DB_VALUE sys_timestamp;
 
   db_sys_timestamp (&sys_timestamp);
-  (void) or_pack_utime (reply, *(DB_TIMESTAMP *) DB_GET_TIMESTAMP (&sys_timestamp));
+  (void) or_pack_utime (reply, *(DB_TIMESTAMP *) db_get_timestamp (&sys_timestamp));
   css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
 #endif /* ENABLE_UNUSED_FUNCTION */
 }
@@ -7382,7 +7382,7 @@ stran_get_local_transaction_id (THREAD_ENTRY * thread_p, unsigned int rid, char 
   int success, trid;
 
   success = (xtran_get_local_transaction_id (thread_p, &val) == NO_ERROR) ? NO_ERROR : ER_FAILED;
-  trid = DB_GET_INTEGER (&val);
+  trid = db_get_int (&val);
   ptr = or_pack_int (reply, success);
   ptr = or_pack_int (ptr, trid);
   css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
@@ -8857,8 +8857,8 @@ ssession_get_session_variable (THREAD_ENTRY * thread_p, unsigned int rid, char *
   DB_VALUE result, name;
   int size = 0;
 
-  DB_MAKE_NULL (&result);
-  DB_MAKE_NULL (&name);
+  db_make_null (&result);
+  db_make_null (&name);
 
   reply = OR_ALIGNED_BUF_START (a_reply);
 

--- a/src/compat/cnv.c
+++ b/src/compat/cnv.c
@@ -5949,7 +5949,7 @@ bfmt_print (BIT_STRING_FORMAT * bfmt, const DB_VALUE * the_db_bit, char *string,
   };
 
   /* Get the buffer and the length from the_db_bit */
-  bstring = DB_GET_BIT (the_db_bit, &length);
+  bstring = db_get_bit (the_db_bit, &length);
 
   switch (*bfmt)
     {
@@ -6608,7 +6608,7 @@ db_string_value (const char *string, int str_size, const char *format, DB_VALUE 
 	    {
 	      return NULL;
 	    }
-	  next = db_string_monetary (string, format, DB_GET_MONETARY (value));
+	  next = db_string_monetary (string, format, db_get_monetary (value));
 	  csect_exit (NULL, CSECT_CNV_FMT_LEXER);
 	  break;
 
@@ -6835,7 +6835,7 @@ db_value_string (const DB_VALUE * value, const char *format, char *string, int m
   switch (DB_VALUE_TYPE (value))
     {
     case DB_TYPE_DATE:
-      error = db_date_string (DB_GET_DATE (value), format, string, max_size);
+      error = db_date_string (db_get_date (value), format, string, max_size);
       break;
 
     case DB_TYPE_NUMERIC:
@@ -6843,22 +6843,22 @@ db_value_string (const DB_VALUE * value, const char *format, char *string, int m
       break;
 
     case DB_TYPE_DOUBLE:
-      error = db_double_string (DB_GET_DOUBLE (value), format, string, max_size);
+      error = db_double_string (db_get_double (value), format, string, max_size);
       break;
 
     case DB_TYPE_FLOAT:
-      error = db_float_string (DB_GET_FLOAT (value), format, string, max_size);
+      error = db_float_string (db_get_float (value), format, string, max_size);
       break;
 
     case DB_TYPE_INTEGER:
-      error = db_integer_string (DB_GET_INTEGER (value), format, string, max_size);
+      error = db_integer_string (db_get_int (value), format, string, max_size);
       break;
     case DB_TYPE_BIGINT:
-      error = db_bigint_string (DB_GET_BIGINT (value), format, string, max_size);
+      error = db_bigint_string (db_get_bigint (value), format, string, max_size);
       break;
 
     case DB_TYPE_MONETARY:
-      error = db_monetary_string (DB_GET_MONETARY (value), format, string, max_size);
+      error = db_monetary_string (db_get_monetary (value), format, string, max_size);
       break;
 
     case DB_TYPE_NULL:
@@ -6866,7 +6866,7 @@ db_value_string (const DB_VALUE * value, const char *format, char *string, int m
       break;
 
     case DB_TYPE_SHORT:
-      error = db_short_string (DB_GET_SHORT (value), format, string, max_size);
+      error = db_short_string (db_get_short (value), format, string, max_size);
       break;
 
     case DB_TYPE_VARCHAR:
@@ -6891,7 +6891,7 @@ db_value_string (const DB_VALUE * value, const char *format, char *string, int m
 
     case DB_TYPE_VARNCHAR:
     case DB_TYPE_NCHAR:
-      p = DB_GET_NCHAR (value, &dummy);
+      p = db_get_nchar (value, &dummy);
       if (p != NULL)
 	{
 	  if ((int) strlen (p) + 1 > max_size)
@@ -6907,15 +6907,15 @@ db_value_string (const DB_VALUE * value, const char *format, char *string, int m
       break;
 
     case DB_TYPE_TIME:
-      error = db_time_string (DB_GET_TIME (value), format, string, max_size);
+      error = db_time_string (db_get_time (value), format, string, max_size);
       break;
 
     case DB_TYPE_TIMESTAMP:
-      error = db_timestamp_string (DB_GET_TIMESTAMP (value), format, string, max_size);
+      error = db_timestamp_string (db_get_timestamp (value), format, string, max_size);
       break;
 
     case DB_TYPE_DATETIME:
-      error = db_datetime_string (DB_GET_DATETIME (value), format, string, max_size);
+      error = db_datetime_string (db_get_datetime (value), format, string, max_size);
       break;
     case DB_TYPE_VARBIT:
     case DB_TYPE_BIT:

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -2327,9 +2327,9 @@ fetch_set_internal (DB_SET * set, DB_FETCH_MODE purpose, int quit_on_error)
 	  error = set_get_element (set, i, &value);
 	  if (error == NO_ERROR)
 	    {
-	      if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && DB_GET_OBJECT (&value) != NULL)
+	      if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && db_get_object (&value) != NULL)
 		{
-		  mops[cnt] = DB_GET_OBJECT (&value);
+		  mops[cnt] = db_get_object (&value);
 		  cnt++;
 		}
 	      db_value_clear (&value);

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -1726,7 +1726,7 @@ db_type_to_db_domain (const DB_TYPE type)
     case DB_TYPE_TIME:
     case DB_TYPE_TIMETZ:
     case DB_TYPE_TIMELTZ:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPTZ:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_DATETIME:

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -977,10 +977,10 @@ db_string_truncate (DB_VALUE * value, const int precision)
   switch (DB_VALUE_TYPE (value))
     {
     case DB_TYPE_STRING:
-      val_str = DB_GET_STRING (value);
-      if (val_str != NULL && DB_GET_STRING_LENGTH (value) > precision)
+      val_str = db_get_string (value);
+      if (val_str != NULL && db_get_string_length (value) > precision)
 	{
-	  intl_char_size ((unsigned char *) val_str, precision, DB_GET_STRING_CODESET (value), &byte_size);
+	  intl_char_size ((unsigned char *) val_str, precision, db_get_string_codeset (value), &byte_size);
 	  string = (char *) db_private_alloc (NULL, byte_size + 1);
 	  if (string == NULL)
 	    {
@@ -988,11 +988,11 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	      break;
 	    }
 
-	  assert (byte_size < DB_GET_STRING_SIZE (value));
+	  assert (byte_size < db_get_string_size (value));
 	  strncpy (string, val_str, byte_size);
 	  string[byte_size] = '\0';
 	  db_make_varchar (&src_value, precision, string, byte_size,
-			   DB_GET_STRING_CODESET (value), DB_GET_STRING_COLLATION (value));
+			   db_get_string_codeset (value), db_get_string_collation (value));
 
 	  pr_clear_value (value);
 	  (*(tp_String.setval)) (value, &src_value, true);
@@ -1002,10 +1002,10 @@ db_string_truncate (DB_VALUE * value, const int precision)
       break;
 
     case DB_TYPE_CHAR:
-      val_str = DB_GET_CHAR (value, &length);
+      val_str = db_get_char (value, &length);
       if (val_str != NULL && length > precision)
 	{
-	  intl_char_size ((unsigned char *) val_str, precision, DB_GET_STRING_CODESET (value), &byte_size);
+	  intl_char_size ((unsigned char *) val_str, precision, db_get_string_codeset (value), &byte_size);
 	  string = (char *) db_private_alloc (NULL, byte_size + 1);
 	  if (string == NULL)
 	    {
@@ -1013,11 +1013,11 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	      break;
 	    }
 
-	  assert (byte_size < DB_GET_STRING_SIZE (value));
+	  assert (byte_size < db_get_string_size (value));
 	  strncpy (string, val_str, byte_size);
 	  string[byte_size] = '\0';
 	  db_make_char (&src_value, precision, string, byte_size,
-			DB_GET_STRING_CODESET (value), DB_GET_STRING_COLLATION (value));
+			db_get_string_codeset (value), db_get_string_collation (value));
 
 	  pr_clear_value (value);
 	  (*(tp_Char.setval)) (value, &src_value, true);
@@ -1028,10 +1028,10 @@ db_string_truncate (DB_VALUE * value, const int precision)
       break;
 
     case DB_TYPE_VARNCHAR:
-      val_str = DB_GET_NCHAR (value, &length);
+      val_str = db_get_nchar (value, &length);
       if (val_str != NULL && length > precision)
 	{
-	  intl_char_size ((unsigned char *) val_str, precision, DB_GET_STRING_CODESET (value), &byte_size);
+	  intl_char_size ((unsigned char *) val_str, precision, db_get_string_codeset (value), &byte_size);
 	  string = (char *) db_private_alloc (NULL, byte_size + 1);
 	  if (string == NULL)
 	    {
@@ -1039,11 +1039,11 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	      break;
 	    }
 
-	  assert (byte_size < DB_GET_STRING_SIZE (value));
+	  assert (byte_size < db_get_string_size (value));
 	  strncpy (string, val_str, byte_size);
 	  string[byte_size] = '\0';
 	  db_make_varnchar (&src_value, precision, string, byte_size,
-			    DB_GET_STRING_CODESET (value), DB_GET_STRING_COLLATION (value));
+			    db_get_string_codeset (value), db_get_string_collation (value));
 
 	  pr_clear_value (value);
 	  (*(tp_VarNChar.setval)) (value, &src_value, true);
@@ -1053,10 +1053,10 @@ db_string_truncate (DB_VALUE * value, const int precision)
       break;
 
     case DB_TYPE_NCHAR:
-      val_str = DB_GET_NCHAR (value, &length);
+      val_str = db_get_nchar (value, &length);
       if (val_str != NULL && length > precision)
 	{
-	  intl_char_size ((unsigned char *) val_str, precision, DB_GET_STRING_CODESET (value), &byte_size);
+	  intl_char_size ((unsigned char *) val_str, precision, db_get_string_codeset (value), &byte_size);
 	  string = (char *) db_private_alloc (NULL, byte_size + 1);
 	  if (string == NULL)
 	    {
@@ -1064,11 +1064,11 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	      break;
 	    }
 
-	  assert (byte_size < DB_GET_STRING_SIZE (value));
+	  assert (byte_size < db_get_string_size (value));
 	  strncpy (string, val_str, byte_size);
 	  string[byte_size] = '\0';
 	  db_make_nchar (&src_value, precision, string, byte_size,
-			 DB_GET_STRING_CODESET (value), DB_GET_STRING_COLLATION (value));
+			 db_get_string_codeset (value), db_get_string_collation (value));
 
 	  pr_clear_value (value);
 	  (*(tp_NChar.setval)) (value, &src_value, true);
@@ -1079,7 +1079,7 @@ db_string_truncate (DB_VALUE * value, const int precision)
       break;
 
     case DB_TYPE_BIT:
-      val_str = DB_GET_BIT (value, &length);
+      val_str = db_get_bit (value, &length);
       length = (length + 7) >> 3;
       if (val_str != NULL && length > precision)
 	{
@@ -1101,7 +1101,7 @@ db_string_truncate (DB_VALUE * value, const int precision)
       break;
 
     case DB_TYPE_VARBIT:
-      val_str = DB_GET_BIT (value, &length);
+      val_str = db_get_bit (value, &length);
       length = (length >> 3) + ((length & 7) ? 1 : 0);
       if (val_str != NULL && length > precision)
 	{
@@ -1176,9 +1176,9 @@ db_value_eh_key (DB_VALUE * value)
   switch (value->domain.general_info.type)
     {
     case DB_TYPE_STRING:
-      return DB_GET_STRING (value);
+      return db_get_string (value);
     case DB_TYPE_OBJECT:
-      obj = DB_GET_OBJECT (value);
+      obj = db_get_object (value);
       if (obj == NULL)
 	{
 	  return NULL;
@@ -2002,19 +2002,19 @@ transfer_bit_string (char *buf, int *xflen, int *outlen, const int buflen, const
   error_code = db_bit_string_coerce (src, &tmp_value, &data_status);
   if (error_code == NO_ERROR)
     {
-      *xflen = DB_GET_STRING_LENGTH (&tmp_value);
+      *xflen = db_get_string_length (&tmp_value);
       if (data_status == DATA_STATUS_TRUNCATED)
 	{
 	  if (outlen != NULL)
 	    {
-	      *outlen = DB_GET_STRING_LENGTH (src);
+	      *outlen = db_get_string_length (src);
 	    }
 	}
 
-      tmp_val_str = DB_GET_STRING (&tmp_value);
+      tmp_val_str = db_get_string (&tmp_value);
       if (tmp_val_str != NULL)
 	{
-	  memcpy (buf, tmp_val_str, DB_GET_STRING_SIZE (&tmp_value));
+	  memcpy (buf, tmp_val_str, db_get_string_size (&tmp_value));
 	}
 
       error_code = db_value_clear (&tmp_value);
@@ -2138,7 +2138,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
     {
     case DB_TYPE_INTEGER:
       {
-	int i = DB_GET_INT (value);
+	int i = db_get_int (value);
 
 	switch (c_type)
 	  {
@@ -2188,7 +2188,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 
     case DB_TYPE_SMALLINT:
       {
-	short s = DB_GET_SMALLINT (value);
+	short s = db_get_short (value);
 
 	switch (c_type)
 	  {
@@ -2248,7 +2248,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 
     case DB_TYPE_BIGINT:
       {
-	DB_BIGINT bigint = DB_GET_BIGINT (value);
+	DB_BIGINT bigint = db_get_bigint (value);
 
 	switch (c_type)
 	  {
@@ -2302,7 +2302,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 
     case DB_TYPE_FLOAT:
       {
-	float f = DB_GET_FLOAT (value);
+	float f = db_get_float (value);
 
 	switch (c_type)
 	  {
@@ -2362,7 +2362,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 
     case DB_TYPE_DOUBLE:
       {
-	double d = DB_GET_DOUBLE (value);
+	double d = db_get_double (value);
 
 	switch (c_type)
 	  {
@@ -2422,7 +2422,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 
     case DB_TYPE_MONETARY:
       {
-	DB_MONETARY *money = DB_GET_MONETARY (value);
+	DB_MONETARY *money = db_get_monetary (value);
 	double d = money->amount;
 
 	switch (c_type)
@@ -2497,8 +2497,8 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
     case DB_TYPE_VARNCHAR:
     case DB_TYPE_NCHAR:
       {
-	const char *s = DB_GET_STRING (value);
-	int n = DB_GET_STRING_SIZE (value);
+	const char *s = db_get_string (value);
+	int n = db_get_string_size (value);
 
 	if (s == NULL)
 	  {
@@ -2598,7 +2598,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	  {
 	  case DB_TYPE_C_OBJECT:
 	    {
-	      *(DB_OBJECT **) buf = (DB_OBJECT *) DB_GET_OBJECT (value);
+	      *(DB_OBJECT **) buf = (DB_OBJECT *) db_get_object (value);
 	      *xflen = sizeof (DB_OBJECT *);
 	    }
 	    break;
@@ -2616,7 +2616,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	  {
 	  case DB_TYPE_C_SET:
 	    {
-	      *(DB_SET **) buf = (DB_SET *) DB_GET_SET (value);
+	      *(DB_SET **) buf = (DB_SET *) db_get_set (value);
 	      *xflen = sizeof (DB_SET *);
 	    }
 	    break;
@@ -2632,7 +2632,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	  {
 	  case DB_TYPE_C_TIME:
 	    {
-	      *(DB_TIME *) buf = *(DB_GET_TIME (value));
+	      *(DB_TIME *) buf = *(db_get_time (value));
 	      *xflen = sizeof (DB_TIME);
 	    }
 	    break;
@@ -2641,7 +2641,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	    {
 	      int n;
 	      char tmp[TIME_BUF_SIZE];
-	      n = db_time_to_string (tmp, sizeof (tmp), DB_GET_TIME (value));
+	      n = db_time_to_string (tmp, sizeof (tmp), db_get_time (value));
 	      if (n < 0)
 		{
 		  goto invalid_args;
@@ -2655,7 +2655,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	    {
 	      int n;
 	      char tmp[TIME_BUF_SIZE];
-	      n = db_time_to_string (tmp, sizeof (tmp), DB_GET_TIME (value));
+	      n = db_time_to_string (tmp, sizeof (tmp), db_get_time (value));
 	      if (n < 0)
 		{
 		  goto invalid_args;
@@ -2676,7 +2676,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	  {
 	  case DB_TYPE_C_TIMESTAMP:
 	    {
-	      *(DB_TIMESTAMP *) buf = *(DB_GET_TIMESTAMP (value));
+	      *(DB_TIMESTAMP *) buf = *(db_get_timestamp (value));
 	      *xflen = sizeof (DB_TIMESTAMP);
 	    }
 	    break;
@@ -2685,7 +2685,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	    {
 	      int n;
 	      char tmp[TIMESTAMP_BUF_SIZE];
-	      n = db_timestamp_to_string (tmp, sizeof (tmp), DB_GET_TIMESTAMP (value));
+	      n = db_timestamp_to_string (tmp, sizeof (tmp), db_get_timestamp (value));
 	      if (n < 0)
 		{
 		  goto invalid_args;
@@ -2700,7 +2700,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	    {
 	      int n;
 	      char tmp[TIMESTAMP_BUF_SIZE];
-	      n = db_timestamp_to_string (tmp, sizeof (tmp), DB_GET_TIMESTAMP (value));
+	      n = db_timestamp_to_string (tmp, sizeof (tmp), db_get_timestamp (value));
 	      if (n < 0)
 		{
 		  goto invalid_args;
@@ -2721,7 +2721,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	  {
 	  case DB_TYPE_C_DATETIME:
 	    {
-	      *(DB_DATETIME *) buf = *(DB_GET_DATETIME (value));
+	      *(DB_DATETIME *) buf = *(db_get_datetime (value));
 	      *xflen = sizeof (DB_DATETIME);
 	    }
 	    break;
@@ -2730,7 +2730,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	    {
 	      int n;
 	      char tmp[DATETIME_BUF_SIZE];
-	      n = db_datetime_to_string (tmp, sizeof (tmp), DB_GET_DATETIME (value));
+	      n = db_datetime_to_string (tmp, sizeof (tmp), db_get_datetime (value));
 	      if (n < 0)
 		{
 		  goto invalid_args;
@@ -2745,7 +2745,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	    {
 	      int n;
 	      char tmp[DATETIME_BUF_SIZE];
-	      n = db_datetime_to_string (tmp, sizeof (tmp), DB_GET_DATETIME (value));
+	      n = db_datetime_to_string (tmp, sizeof (tmp), db_get_datetime (value));
 	      if (n < 0)
 		{
 		  goto invalid_args;
@@ -2765,7 +2765,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	  {
 	  case DB_TYPE_C_DATE:
 	    {
-	      *(DB_DATE *) buf = *(DB_GET_DATE (value));
+	      *(DB_DATE *) buf = *(db_get_date (value));
 	      *xflen = sizeof (DB_DATE);
 	    }
 	    break;
@@ -2774,7 +2774,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	    {
 	      int n;
 	      char tmp[DATE_BUF_SIZE];
-	      n = db_date_to_string (tmp, sizeof (tmp), DB_GET_DATE (value));
+	      n = db_date_to_string (tmp, sizeof (tmp), db_get_date (value));
 	      if (n < 0)
 		{
 		  goto invalid_args;
@@ -2788,7 +2788,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	    {
 	      int n;
 	      char tmp[DATE_BUF_SIZE];
-	      n = db_date_to_string (tmp, sizeof (tmp), DB_GET_DATE (value));
+	      n = db_date_to_string (tmp, sizeof (tmp), db_get_date (value));
 	      if (n < 0)
 		{
 		  goto invalid_args;
@@ -2879,7 +2879,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	    {
 	      int truncated;
 	      qstr_bit_to_hex_coerce ((char *) buf, buflen,
-				      DB_GET_STRING (value), DB_GET_STRING_LENGTH (value), true, xflen, &truncated);
+				      db_get_string (value), db_get_string_length (value), true, xflen, &truncated);
 	      if (truncated > 0)
 		{
 		  if (outlen)
@@ -2899,7 +2899,7 @@ db_value_get (DB_VALUE * value, const DB_TYPE_C c_type, void *buf, const int buf
 	    {
 	      int truncated;
 	      qstr_bit_to_hex_coerce ((char *) buf, buflen,
-				      DB_GET_STRING (value), DB_GET_STRING_LENGTH (value), false, xflen, &truncated);
+				      db_get_string (value), db_get_string_length (value), false, xflen, &truncated);
 	      if (truncated > 0)
 		{
 		  if (outlen)
@@ -3084,7 +3084,7 @@ coerce_char_to_dbvalue (DB_VALUE * value, char *buf, const int buflen)
 	     */
 	    if (DB_VALUE_PRECISION (value) == TP_FLOATING_PRECISION_VALUE)
 	      {
-		db_value_domain_init (value, db_type, DB_GET_STRING_LENGTH (&tmp_value), DB_DEFAULT_SCALE);
+		db_value_domain_init (value, db_type, db_get_string_length (&tmp_value), DB_DEFAULT_SCALE);
 	      }
 
 	    (void) db_bit_string_coerce (&tmp_value, value, &data_status);
@@ -3642,7 +3642,7 @@ coerce_date_to_dbvalue (DB_VALUE * value, char *buf)
 		length = 1;
 	      }
 
-	    DB_MAKE_NULL (&tmp_value);
+	    db_make_null (&tmp_value);
 	    qstr_make_typed_string (db_type, &tmp_value, length, tmp, length, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 
 	    /* 
@@ -3723,7 +3723,7 @@ coerce_time_to_dbvalue (DB_VALUE * value, char *buf)
 		length = 1;
 	      }
 
-	    DB_MAKE_NULL (&tmp_value);
+	    db_make_null (&tmp_value);
 	    qstr_make_typed_string (db_type, &tmp_value, length, tmp, length, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 
 	    /* 
@@ -3802,7 +3802,7 @@ coerce_timestamp_to_dbvalue (DB_VALUE * value, char *buf)
 		length = 1;
 	      }
 
-	    DB_MAKE_NULL (&tmp_value);
+	    db_make_null (&tmp_value);
 	    qstr_make_typed_string (db_type, &tmp_value, length, tmp, length, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 
 	    /* 
@@ -3907,7 +3907,7 @@ coerce_datetime_to_dbvalue (DB_VALUE * value, char *buf)
 		length = 1;
 	      }
 
-	    DB_MAKE_NULL (&tmp_value);
+	    db_make_null (&tmp_value);
 	    qstr_make_typed_string (db_type, &tmp_value, length, tmp, length, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 
 	    /* 
@@ -4357,8 +4357,8 @@ valcnv_convert_bit_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_p
   int nibble_len, nibbles, count;
   char tbuf[10];
 
-  bit_string_p = (unsigned char *) DB_GET_STRING (value_p);
-  nibble_len = (DB_GET_STRING_LENGTH (value_p) + 3) / 4;
+  bit_string_p = (unsigned char *) db_get_string (value_p);
+  nibble_len = (db_get_string_length (value_p) + 3) / 4;
 
   for (nibbles = 0, count = 0; nibbles < nibble_len - 1; count++, nibbles += 2)
     {
@@ -4521,26 +4521,26 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
       switch (DB_VALUE_TYPE (value_p))
 	{
 	case DB_TYPE_INTEGER:
-	  sprintf (line, "%d", DB_GET_INTEGER (value_p));
+	  sprintf (line, "%d", db_get_int (value_p));
 	  buffer_p = valcnv_append_string (buffer_p, line);
 	  break;
 
 	case DB_TYPE_BIGINT:
-	  sprintf (line, "%lld", (long long) DB_GET_BIGINT (value_p));
+	  sprintf (line, "%lld", (long long) db_get_bigint (value_p));
 	  buffer_p = valcnv_append_string (buffer_p, line);
 	  break;
 
 	case DB_TYPE_SHORT:
-	  sprintf (line, "%d", (int) DB_GET_SHORT (value_p));
+	  sprintf (line, "%d", (int) db_get_short (value_p));
 	  buffer_p = valcnv_append_string (buffer_p, line);
 	  break;
 
 	case DB_TYPE_FLOAT:
-	  buffer_p = valcnv_convert_float_to_string (buffer_p, DB_GET_FLOAT (value_p));
+	  buffer_p = valcnv_convert_float_to_string (buffer_p, db_get_float (value_p));
 	  break;
 
 	case DB_TYPE_DOUBLE:
-	  buffer_p = valcnv_convert_double_to_string (buffer_p, DB_GET_DOUBLE (value_p));
+	  buffer_p = valcnv_convert_double_to_string (buffer_p, db_get_double (value_p));
 	  break;
 
 	case DB_TYPE_NUMERIC:
@@ -4556,15 +4556,15 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_VARNCHAR:
-	  src_p = DB_GET_STRING (value_p);
+	  src_p = db_get_string (value_p);
 
-	  if (src_p != NULL && DB_GET_STRING_SIZE (value_p) == 0)
+	  if (src_p != NULL && db_get_string_size (value_p) == 0)
 	    {
 	      buffer_p = valcnv_append_string (buffer_p, "");
 	      return buffer_p;
 	    }
 
-	  end_p = src_p + DB_GET_STRING_SIZE (value_p);
+	  end_p = src_p + db_get_string_size (value_p);
 	  while (src_p < end_p)
 	    {
 	      for (p = src_p; p < end_p && *p != '\''; p++)
@@ -4655,7 +4655,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 
 	case DB_TYPE_BLOB:
 	case DB_TYPE_CLOB:
-	  elo_p = DB_GET_ELO (value_p);
+	  elo_p = db_get_elo (value_p);
 	  if (elo_p == NULL)
 	    {
 	      buffer_p = valcnv_append_string (buffer_p, "NULL");
@@ -4676,7 +4676,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	  break;
 
 	case DB_TYPE_TIME:
-	  cnt = db_time_to_string (line, VALCNV_TOO_BIG_TO_MATTER, DB_GET_TIME (value_p));
+	  cnt = db_time_to_string (line, VALCNV_TOO_BIG_TO_MATTER, db_get_time (value_p));
 	  if (cnt == 0)
 	    {
 	      return NULL;
@@ -4688,7 +4688,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	  {
 	    DB_TIMETZ *time_tz;
 
-	    time_tz = DB_GET_TIMETZ (value_p);
+	    time_tz = db_get_timetz (value_p);
 	    cnt = db_timetz_to_string (line, VALCNV_TOO_BIG_TO_MATTER, &time_tz->time, &time_tz->tz_id);
 	    if (cnt == 0)
 	      {
@@ -4703,7 +4703,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	    TZ_ID tz_id;
 	    DB_TIME *time;
 
-	    time = DB_GET_TIME (value_p);
+	    time = db_get_time (value_p);
 	    if (tz_create_session_tzid_for_time (time, true, &tz_id) != NO_ERROR)
 	      {
 		return NULL;
@@ -4718,7 +4718,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	  }
 
 	case DB_TYPE_TIMESTAMP:
-	  cnt = db_timestamp_to_string (line, VALCNV_TOO_BIG_TO_MATTER, DB_GET_TIMESTAMP (value_p));
+	  cnt = db_timestamp_to_string (line, VALCNV_TOO_BIG_TO_MATTER, db_get_timestamp (value_p));
 	  if (cnt == 0)
 	    {
 	      return NULL;
@@ -4728,7 +4728,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 
 	case DB_TYPE_TIMESTAMPTZ:
 	  {
-	    DB_TIMESTAMPTZ *ts_tz = DB_GET_TIMESTAMPTZ (value_p);
+	    DB_TIMESTAMPTZ *ts_tz = db_get_timestamptz (value_p);
 
 	    cnt = db_timestamptz_to_string (line, VALCNV_TOO_BIG_TO_MATTER, &(ts_tz->timestamp), &(ts_tz->tz_id));
 	    if (cnt == 0)
@@ -4744,7 +4744,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	    TZ_ID tz_id;
 	    DB_TIMESTAMP *utime;
 
-	    utime = DB_GET_TIMESTAMP (value_p);
+	    utime = db_get_timestamp (value_p);
 	    if (tz_create_session_tzid_for_timestamp (utime, &tz_id) != NO_ERROR)
 	      {
 		return NULL;
@@ -4759,7 +4759,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	  break;
 
 	case DB_TYPE_DATETIME:
-	  cnt = db_datetime_to_string (line, VALCNV_TOO_BIG_TO_MATTER, DB_GET_DATETIME (value_p));
+	  cnt = db_datetime_to_string (line, VALCNV_TOO_BIG_TO_MATTER, db_get_datetime (value_p));
 	  if (cnt == 0)
 	    {
 	      return NULL;
@@ -4770,7 +4770,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 
 	case DB_TYPE_DATETIMETZ:
 	  {
-	    DB_DATETIMETZ *dt_tz = DB_GET_DATETIMETZ (value_p);
+	    DB_DATETIMETZ *dt_tz = db_get_datetimetz (value_p);
 
 	    cnt = db_datetimetz_to_string (line, VALCNV_TOO_BIG_TO_MATTER, &(dt_tz->datetime), &(dt_tz->tz_id));
 	    if (cnt == 0)
@@ -4787,7 +4787,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	    TZ_ID tz_id;
 	    DB_DATETIME *dt;
 
-	    dt = DB_GET_DATETIME (value_p);
+	    dt = db_get_datetime (value_p);
 	    if (tz_create_session_tzid_for_datetime (dt, true, &tz_id) != NO_ERROR)
 	      {
 		return NULL;
@@ -4804,7 +4804,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	  break;
 
 	case DB_TYPE_DATE:
-	  cnt = db_date_to_string (line, VALCNV_TOO_BIG_TO_MATTER, DB_GET_DATE (value_p));
+	  cnt = db_date_to_string (line, VALCNV_TOO_BIG_TO_MATTER, db_get_date (value_p));
 	  if (cnt == 0)
 	    {
 	      return NULL;
@@ -4813,7 +4813,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	  break;
 
 	case DB_TYPE_MONETARY:
-	  money_p = DB_GET_MONETARY (value_p);
+	  money_p = db_get_monetary (value_p);
 	  OR_MOVE_DOUBLE (&money_p->amount, &amount);
 	  money_string_p = valcnv_convert_money_to_string (amount);
 	  if (money_string_p == NULL)
@@ -4841,7 +4841,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	    }
 	  else if (db_get_enum_string_size (value_p) > 0)
 	    {
-	      DB_MAKE_STRING (&dbval, db_get_enum_string (value_p));
+	      db_make_string (&dbval, db_get_enum_string (value_p));
 
 	      buffer_p = valcnv_convert_data_to_string (buffer_p, &dbval);
 	    }
@@ -4965,7 +4965,7 @@ valcnv_convert_value_to_string (DB_VALUE * value_p)
 	  return ER_FAILED;
 	}
 
-      DB_MAKE_VARCHAR (&src_value, DB_MAX_STRING_LENGTH,
+      db_make_varchar (&src_value, DB_MAX_STRING_LENGTH,
 		       (char *) buf_p->bytes, CAST_STRLEN (buf_p->length), LANG_SYS_CODESET, LANG_SYS_COLLATION);
 
       pr_clear_value (value_p);
@@ -5033,7 +5033,7 @@ int
 db_convert_json_into_scalar (const DB_VALUE * src, DB_VALUE * dest)
 {
   CHECK_2ARGS_ERROR (src, dest);
-  JSON_DOC *doc = DB_GET_JSON_DOCUMENT (src);
+  JSON_DOC *doc = db_get_json_document (src);
 
   assert (doc != NULL);
 
@@ -5042,7 +5042,7 @@ db_convert_json_into_scalar (const DB_VALUE * src, DB_VALUE * dest)
     case DB_JSON_STRING:
       {
 	const char *str = db_json_get_string_from_document (doc);
-	int error_code = DB_MAKE_STRING (dest, str);
+	int error_code = db_make_string (dest, str);
 	if (error_code != NO_ERROR)
 	  {
 	    ASSERT_ERROR ();
@@ -5053,19 +5053,19 @@ db_convert_json_into_scalar (const DB_VALUE * src, DB_VALUE * dest)
     case DB_JSON_INT:
       {
 	int val = db_json_get_int_from_document (doc);
-	DB_MAKE_INTEGER (dest, val);
+	db_make_int (dest, val);
 	break;
       }
     case DB_JSON_DOUBLE:
       {
 	double val = db_json_get_double_from_document (doc);
-	DB_MAKE_DOUBLE (dest, val);
+	db_make_double (dest, val);
 	break;
       }
     case DB_JSON_BOOL:
       {
 	char *str = db_json_get_bool_as_str_from_document (doc);
-	int error_code = DB_MAKE_STRING (dest, str);
+	int error_code = db_make_string (dest, str);
 	if (error_code != NO_ERROR)
 	  {
 	    ASSERT_ERROR ();
@@ -5075,7 +5075,7 @@ db_convert_json_into_scalar (const DB_VALUE * src, DB_VALUE * dest)
 	break;
       }
     case DB_JSON_NULL:
-      DB_MAKE_NULL (dest);
+      db_make_null (dest);
       break;
     default:
       assert (false);

--- a/src/compat/db_obj.c
+++ b/src/compat/db_obj.c
@@ -677,7 +677,7 @@ dbt_put_internal (DB_OTMPL * def, const char *name, DB_VALUE * value)
 
   if ((value != NULL) && (DB_VALUE_TYPE (value) == DB_TYPE_POINTER))
     {
-      error = obt_set_obt (def, name, (OBJ_TEMPLATE *) DB_GET_POINTER (value));
+      error = obt_set_obt (def, name, (OBJ_TEMPLATE *) db_get_pointer (value));
     }
   else
     {

--- a/src/compat/db_set.c
+++ b/src/compat/db_set.c
@@ -1145,7 +1145,7 @@ db_col_drop_nulls (DB_COLLECTION * col)
       CHECK_MODIFICATION_ERROR ();
     }
 
-  DB_MAKE_NULL (&value);
+  db_make_null (&value);
 
   error = set_drop_element (col, &value, true);
 

--- a/src/compat/db_value_printer.cpp
+++ b/src/compat/db_value_printer.cpp
@@ -212,7 +212,7 @@ void db_value_printer::describe_value (const db_value *value)
 	  describe_data (value);
 	  m_buf += '\'';
 	  break;
-	case DB_TYPE_UTIME:
+	case DB_TYPE_TIMESTAMP:
 	  m_buf ("timestamp '");
 	  describe_data (value);
 	  m_buf += '\'';
@@ -475,12 +475,12 @@ void db_value_printer::describe_data (const db_value *value)
     }
     break;
 
-    case DB_TYPE_UTIME:
-      (void) db_utime_to_string (line, TOO_BIG_TO_MATTER, db_get_utime (value));
+    case DB_TYPE_TIMESTAMP:
+      (void) db_utime_to_string (line, TOO_BIG_TO_MATTER, db_get_timestamp (value));
       m_buf (line);
       break;
     case DB_TYPE_TIMESTAMPLTZ:
-      (void) db_timestampltz_to_string (line, TOO_BIG_TO_MATTER, db_get_utime (value));
+      (void) db_timestampltz_to_string (line, TOO_BIG_TO_MATTER, db_get_timestamp (value));
       m_buf (line);
       break;
 

--- a/src/compat/db_value_printer.cpp
+++ b/src/compat/db_value_printer.cpp
@@ -128,7 +128,7 @@ void db_value_printer::describe_value (const db_value *value)
 	{
 	case DB_TYPE_CHAR:
 	case DB_TYPE_VARCHAR:
-	  codeset = DB_GET_STRING_CODESET (value);
+	  codeset = db_get_string_codeset (value);
 	  if (codeset != LANG_SYS_CODESET)
 	    {
 	      m_buf ("%s", lang_charset_introducer (codeset));
@@ -139,17 +139,17 @@ void db_value_printer::describe_value (const db_value *value)
 	  break;
 
 	case DB_TYPE_ENUMERATION:
-	  if (DB_GET_ENUM_STRING (value) == NULL && DB_GET_ENUM_SHORT (value) != 0)
+	  if (db_get_enum_string (value) == NULL && db_get_enum_short (value) != 0)
 	    {
 #if defined(SERVER_MODE)
 	      /* to print enum index as int */
-	      m_buf ("%d", (int)DB_GET_ENUM_SHORT (value));
+	      m_buf ("%d", (int)db_get_enum_short (value));
 	      break;
 #elif defined(SA_MODE)
 	      if (db_on_server)
 		{
 		  /* to print enum index as int */
-		  m_buf ("%d", (int)DB_GET_ENUM_SHORT (value));
+		  m_buf ("%d", (int)db_get_enum_short (value));
 		  break;
 		}
 	      else
@@ -171,7 +171,7 @@ void db_value_printer::describe_value (const db_value *value)
 	      /* print enumerations as strings */
 	      if (tp_enumeration_to_varchar (value, &varchar_val) == NO_ERROR)
 		{
-		  codeset = (INTL_CODESET) DB_GET_ENUM_CODESET (value);
+		  codeset = (INTL_CODESET) db_get_enum_codeset (value);
 		  if (codeset != LANG_SYS_CODESET)
 		    {
 		      m_buf ("%s", lang_charset_introducer (codeset));
@@ -415,7 +415,7 @@ void db_value_printer::describe_data (const db_value *value)
       m_buf ("%s", value->data.json.json_body);
       break;
     case DB_TYPE_MIDXKEY:
-      midxkey = DB_GET_MIDXKEY (value);
+      midxkey = db_get_midxkey (value);
       if (midxkey != NULL)
 	{
 	  describe_midxkey (midxkey);
@@ -469,18 +469,18 @@ void db_value_printer::describe_data (const db_value *value)
     {
       DB_TIMETZ *time_tz;
 
-      time_tz = DB_GET_TIMETZ (value);
+      time_tz = db_get_timetz (value);
       (void) db_timetz_to_string (line, TOO_BIG_TO_MATTER, &time_tz->time, &time_tz->tz_id);
       m_buf (line);
     }
     break;
 
     case DB_TYPE_UTIME:
-      (void) db_utime_to_string (line, TOO_BIG_TO_MATTER, DB_GET_UTIME (value));
+      (void) db_utime_to_string (line, TOO_BIG_TO_MATTER, db_get_utime (value));
       m_buf (line);
       break;
     case DB_TYPE_TIMESTAMPLTZ:
-      (void) db_timestampltz_to_string (line, TOO_BIG_TO_MATTER, DB_GET_UTIME (value));
+      (void) db_timestampltz_to_string (line, TOO_BIG_TO_MATTER, db_get_utime (value));
       m_buf (line);
       break;
 
@@ -488,18 +488,18 @@ void db_value_printer::describe_data (const db_value *value)
     {
       DB_TIMESTAMPTZ *ts_tz;
 
-      ts_tz = DB_GET_TIMESTAMPTZ (value);
+      ts_tz = db_get_timestamptz (value);
       (void) db_timestamptz_to_string (line, TOO_BIG_TO_MATTER, & (ts_tz->timestamp), & (ts_tz->tz_id));
       m_buf (line);
     }
     break;
 
     case DB_TYPE_DATETIME:
-      (void) db_datetime_to_string (line, TOO_BIG_TO_MATTER, DB_GET_DATETIME (value));
+      (void) db_datetime_to_string (line, TOO_BIG_TO_MATTER, db_get_datetime (value));
       m_buf (line);
       break;
     case DB_TYPE_DATETIMELTZ:
-      (void) db_datetimeltz_to_string (line, TOO_BIG_TO_MATTER, DB_GET_DATETIME (value));
+      (void) db_datetimeltz_to_string (line, TOO_BIG_TO_MATTER, db_get_datetime (value));
       m_buf (line);
       break;
 
@@ -507,7 +507,7 @@ void db_value_printer::describe_data (const db_value *value)
     {
       DB_DATETIMETZ *dt_tz;
 
-      dt_tz = DB_GET_DATETIMETZ (value);
+      dt_tz = db_get_datetimetz (value);
       (void) db_datetimetz_to_string (line, TOO_BIG_TO_MATTER, & (dt_tz->datetime), & (dt_tz->tz_id));
       m_buf (line);
     }

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -458,8 +458,8 @@ db_calculate_current_server_time (PARSER_CONTEXT * parser)
 			      c_time_struct->tm_year + 1900, c_time_struct->tm_hour, c_time_struct->tm_min,
 			      c_time_struct->tm_sec, curr_server_timeb.millitm);
 
-	  DB_MAKE_DATETIME (&parser->sys_datetime, &datetime);
-	  DB_MAKE_TIMESTAMP (&parser->sys_epochtime, (DB_TIMESTAMP) curr_server_timeb.time);
+	  db_make_datetime (&parser->sys_datetime, &datetime);
+	  db_make_timestamp (&parser->sys_epochtime, (DB_TIMESTAMP) curr_server_timeb.time);
 	}
     }
 }
@@ -2075,7 +2075,7 @@ values_list_to_values_array (PARSER_CONTEXT * parser, PT_NODE * values_list, DB_
 	  assert (current_value->info.expr.arg1->node_type == PT_VALUE);
 
 	  name = pt_value_to_db (parser, current_value->info.expr.arg1);
-	  DB_MAKE_NULL (&val);
+	  db_make_null (&val);
 	  if (db_get_variable (name, &val) != NO_ERROR)
 	    {
 	      assert (er_errid () != NO_ERROR);

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -49,8 +49,6 @@
 
 #define db_make_utime db_make_timestamp
 
-#define DB_MAKE_NULL(value) db_make_null(value)
-
 #define DB_VALUE_CLONE_AS_NULL(src_value, dest_value)                   \
   do {                                                                  \
     if ((db_value_domain_init(dest_value,                               \
@@ -61,141 +59,6 @@
       (void)db_value_put_null(dest_value);                              \
   } while (0)
 
-#define DB_MAKE_INTEGER(value, num) db_make_int(value, num)
-
-#define DB_MAKE_INT DB_MAKE_INTEGER
-
-#define DB_MAKE_BIGINT(value, num) db_make_bigint(value, num)
-
-#define DB_MAKE_BIGINTEGER DB_MAKE_BIGINT
-
-#define DB_MAKE_FLOAT(value, num) db_make_float(value, num)
-
-#define DB_MAKE_DOUBLE(value, num) db_make_double(value, num)
-
-#define DB_MAKE_OBJECT(value, obj) db_make_object(value, obj)
-
-#define DB_MAKE_OBJ DB_MAKE_OBJECT
-
-#define DB_MAKE_SET(value, set) db_make_set(value, set)
-
-#define DB_MAKE_MULTISET(value, set) db_make_multiset(value, set)
-
-/* obsolete */
-#define DB_MAKE_MULTI_SET DB_MAKE_MULTISET
-
-#define DB_MAKE_SEQUENCE(value, set) db_make_sequence(value, set)
-
-#define DB_MAKE_LIST DB_MAKE_SEQUENCE
-
-/* obsolete */
-#define DB_MAKE_SEQ DB_MAKE_SEQUENCE
-
-/* new preferred interface */
-#define DB_MAKE_OID(value, oid)	\
-      (((oid) == NULL) ? ((value)->domain.general_info.is_null = 1, NO_ERROR) : \
-          db_make_oid((value), (oid)))
-
-#define DB_GET_OID(value)		(db_get_oid(value))
-#define DB_MAKE_COLLECTION(value, col) db_make_collection(value, col)
-
-#define DB_MAKE_MIDXKEY(value, midxkey) db_make_midxkey(value, midxkey)
-
-#define DB_MAKE_ELO(value, type, elo) db_make_elo(value, type, elo)
-
-#define DB_MAKE_TIME(value, hour, minute, second) \
-    db_make_time(value, hour, minute, second)
-
-#define DB_MAKE_TIMETZ(value, timetz_value) \
-    db_make_timetz(value, timetz_value)
-
-#define DB_MAKE_TIMELTZ(value, time_value) \
-    db_make_timeltz(value, time_value)
-
-#define DB_MAKE_ENCODED_TIME(value, time_value) \
-    db_value_put_encoded_time(value, time_value)
-
-#define DB_MAKE_DATE(value, month, day, year) \
-    db_make_date(value, month, day, year)
-
-#define DB_MAKE_ENCODED_DATE(value, date_value) \
-    db_value_put_encoded_date(value, date_value)
-
-#define DB_MAKE_TIMESTAMP(value, timeval) \
-    db_make_timestamp(value, timeval)
-
-#define DB_MAKE_UTIME DB_MAKE_TIMESTAMP
-
-#define DB_MAKE_TIMESTAMPTZ(value, ts_tz) \
-    db_make_timestamptz(value, ts_tz)
-
-#define DB_MAKE_TIMESTAMPLTZ(value, timeval) \
-    db_make_timestampltz(value, timeval)
-
-#define DB_MAKE_MONETARY_AMOUNT(value, amount) \
-    db_make_monetary(value, DB_CURRENCY_DEFAULT, amount)
-
-#define DB_MAKE_DATETIME(value, datetime_value) \
-    db_make_datetime(value, datetime_value)
-
-#define DB_MAKE_DATETIMETZ(value, datetimetz_value) \
-    db_make_datetimetz(value, datetimetz_value)
-
-#define DB_MAKE_DATETIMELTZ(value, datetime_value) \
-    db_make_datetimeltz(value, datetime_value)
-
-#define DB_MAKE_MONETARY DB_MAKE_MONETARY_AMOUNT
-
-#define DB_MAKE_MONETARY_TYPE_AMOUNT(value, type, amount) \
-    db_make_monetary(value, type, amount)
-
-#define DB_MAKE_POINTER(value, ptr) db_make_pointer(value, ptr)
-
-#define DB_MAKE_ERROR(value, errcode) db_make_error(value, errcode)
-
-#define DB_MAKE_METHOD_ERROR(value, errcode, errmsg) \
-           db_make_method_error(value, errcode, errmsg)
-
-#define DB_MAKE_SMALLINT(value, num) db_make_short(value, num)
-
-#define DB_MAKE_SHORT DB_MAKE_SMALLINT
-
-#define DB_MAKE_NUMERIC(value, num, precision, scale) \
-        db_make_numeric(value, num, precision, scale)
-
-#define DB_MAKE_BIT(value, bit_length, bit_str, bit_str_bit_size) \
-        db_make_bit(value, bit_length, bit_str, bit_str_bit_size)
-
-#define DB_MAKE_VARBIT(value, max_bit_length, bit_str, bit_str_bit_size)\
-        db_make_varbit(value, max_bit_length, bit_str, bit_str_bit_size)
-
-#define DB_MAKE_CHAR(value, char_length, str, char_str_byte_size, \
-		     codeset, collation) \
-        db_make_char(value, char_length, str, char_str_byte_size, \
-		     codeset, collation)
-
-#define DB_MAKE_VARCHAR(value, max_char_length, str, char_str_byte_size, \
-		        codeset, collation) \
-        db_make_varchar(value, max_char_length, str, char_str_byte_size, \
-			codeset, collation)
-
-#define DB_MAKE_STRING(value, str) db_make_string(value, str)
-
-#define DB_MAKE_NCHAR(value, nchar_length, str, nchar_str_byte_size, \
-		      codeset, collation) \
-        db_make_nchar(value, nchar_length, str, nchar_str_byte_size, \
-		      codeset, collation)
-
-#define DB_MAKE_VARNCHAR(value, max_nchar_length, str, nchar_str_byte_size, \
-			 codeset, collation)\
-        db_make_varnchar(value, max_nchar_length, str, nchar_str_byte_size, \
-			 codeset, collation)
-
-#define DB_MAKE_ENUMERATION(value, index, str, size, codeset, collation) \
-	db_make_enumeration(value, index, str, size, codeset, collation)
-
-#define DB_MAKE_RESULTSET(value, handle) db_make_resultset(value, handle)
-
 #define db_get_collection db_get_set
 #define db_get_utime db_get_timestamp
 
@@ -203,66 +66,14 @@
 
 #define DB_VALUE_DOMAIN_TYPE(value)     db_value_domain_type(value)
 
-/* New preferred interface for DB_GET macros. */
-#define DB_GET_INT(v) db_get_int(v)
-#define DB_GET_SHORT(v) db_get_short(v)
-#define DB_GET_BIGINT(v) db_get_bigint(v)
-#define DB_GET_FLOAT(v) db_get_float(v)
-#define DB_GET_STRING(v) db_get_string(v)
-#define DB_GET_STRING_LENGTH(v) db_get_string_length(v)
-#define DB_GET_DOUBLE(v) db_get_double(v)
-#define DB_GET_OBJECT(v) db_get_object(v)
-#define DB_GET_SET(v) db_get_set(v)
-#define DB_GET_MIDXKEY(v) db_get_midxkey(v)
-#define DB_GET_POINTER(v) db_get_pointer(v)
-#define DB_GET_TIME(v) db_get_time(v)
-#define DB_GET_TIMETZ(v) db_get_timetz(v)
-#define DB_GET_TIMESTAMP(v) db_get_timestamp(v)
-#define DB_GET_TIMESTAMPTZ(v) db_get_timestamptz(v)
-#define DB_GET_DATETIME(v) db_get_datetime(v)
-#define DB_GET_DATETIMETZ(v) db_get_datetimetz(v)
-#define DB_GET_DATE(v) db_get_date(v)
-#define DB_GET_MONETARY(v) db_get_monetary(v)
-#define DB_GET_ERROR(v) db_get_error(v)
-#define DB_GET_ELO(v) db_get_elo(v)
-#define DB_GET_NUMERIC(v) db_get_numeric(v)
-#define DB_GET_BIT(v, l) db_get_bit(v, l)
-#define DB_GET_CHAR(v, l) db_get_char(v, l)
-#define DB_GET_NCHAR(v, l) db_get_nchar(v, l)
-#define DB_GET_STRING_SIZE(v) db_get_string_size(v)
-#define DB_GET_ENUM_SHORT(v) db_get_enum_short(v)
-#define DB_GET_ENUM_STRING(v) db_get_enum_string(v)
-#define DB_GET_ENUM_STRING_SIZE(v) db_get_enum_string_size(v)
-#define DB_GET_METHOD_ERROR_MSG() db_get_method_error_msg()
-#define DB_GET_RESULTSET(v) db_get_resultset(v)
-#define DB_GET_STRING_CODESET(v) ((INTL_CODESET) db_get_string_codeset(v))
-#define DB_GET_STRING_COLLATION(v) db_get_string_collation(v)
-#define DB_GET_ENUM_CODESET(v) db_get_enum_codeset(v)
-#define DB_GET_ENUM_COLLATION(v) db_get_enum_collation(v)
 #define DB_VALUE_TYPE(value) db_value_type(value)
 #define DB_VALUE_PRECISION(value) db_value_precision(value)
 #define DB_VALUE_SCALE(value) db_value_scale(value)
 
-#define DB_GET_INTEGER(value)           db_get_int(value)
-#define DB_GET_BIGINTEGER               DB_GET_BIGINT
-#define DB_GET_OBJ DB_GET_OBJECT
-#define DB_GET_MULTISET(value)          db_get_set(value)
-#define DB_GET_LIST(value)              db_get_set(value)
-#define DB_GET_SEQUENCE DB_GET_LIST
-#define DB_GET_COLLECTION(value)        db_get_set(value)
-#define DB_GET_UTIME DB_GET_TIMESTAMP
-#define DB_GET_SMALLINT(value)          db_get_short(value)
-
-#define DB_GET_COMPRESSED_SIZE(value) db_get_compressed_size(value)
-
-#define DB_GET_JSON_DOCUMENT(value) db_get_json_document(value)
-
-#define DB_GET_SEQ DB_GET_SEQUENCE
-
 #define DB_SET_COMPRESSED_STRING(value, compressed_string, compressed_size, compressed_need_clear) \
 	db_set_compressed_string(value, compressed_string, compressed_size, compressed_need_clear)
 
-#define DB_TRIED_COMPRESSION(value) (DB_GET_COMPRESSED_SIZE(value) != DB_NOT_YET_COMPRESSED)
+#define DB_TRIED_COMPRESSION(value) (db_get_compressed_size(value) != DB_NOT_YET_COMPRESSED)
 
   /* Macros from dbval.h */
 
@@ -332,7 +143,6 @@
 	((v)->data.json.schema_raw)
 
 #define db_get_json_schema(v) DB_GET_JSON_SCHEMA(v)
-#define DB_GET_JSON_RAW_BODY(v) db_get_json_raw_body(v)
 
 #ifdef __cplusplus
 extern "C"

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -76,7 +76,7 @@ STATIC_INLINE DB_C_CHAR db_get_enum_string (const DB_VALUE * value) __attribute_
 STATIC_INLINE int db_get_enum_string_size (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_C_CHAR db_get_method_error_msg (void) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_RESULTSET db_get_resultset (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_get_string_codeset (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE INTL_CODESET db_get_string_codeset (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_get_string_collation (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_get_enum_codeset (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_get_enum_collation (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
@@ -814,14 +814,14 @@ db_get_resultset (const DB_VALUE * value)
  * return :
  * value(in):
  */
-int
+INTL_CODESET
 db_get_string_codeset (const DB_VALUE * value)
 {
 #if defined (API_ACTIVE_CHECKS)
   CHECK_1ARG_ZERO_WITH_TYPE (value, INTL_CODESET);
 #endif
 
-  return (int) value->data.ch.info.codeset;
+  return (INTL_CODESET) value->data.ch.info.codeset;
 }
 
 /*
@@ -1888,6 +1888,12 @@ db_make_oid (DB_VALUE * value, const OID * oid)
 #if defined (API_ACTIVE_CHECKS)
   CHECK_2ARGS_ERROR (value, oid);
 #endif
+
+  if (oid == NULL)
+    {
+      value->domain.general_info.is_null = 1;
+      return NO_ERROR;
+    }
 
   value->domain.general_info.type = DB_TYPE_OID;
   value->data.oid.pageid = oid->pageid;

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -943,7 +943,7 @@ db_value_precision (const DB_VALUE * value)
     case DB_TYPE_FLOAT:
     case DB_TYPE_DOUBLE:
     case DB_TYPE_TIME:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPTZ:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_DATE:

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2706,7 +2706,7 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
 	    {
 	      if (heap_value->attrid == attr_idx)
 		{
-		  user_name = DB_GET_STRING (&heap_value->dbvalue);
+		  user_name = db_get_string (&heap_value->dbvalue);
 		}
 	    }
 	}

--- a/src/executables/checksumdb.c
+++ b/src/executables/checksumdb.c
@@ -248,7 +248,7 @@ chksum_report_schema_diff (FILE * fp)
 	    }
 	  else
 	    {
-	      db_datetime_to_string (time_buf, sizeof (time_buf), DB_GET_DATETIME (&out_value));
+	      db_datetime_to_string (time_buf, sizeof (time_buf), db_get_datetime (&out_value));
 	    }
 	  db_value_clear (&out_value);
 
@@ -360,7 +360,7 @@ chksum_report_diff (FILE * fp)
 	      db_query_end (query_result);
 	      return error;
 	    }
-	  CHKSUM_PRINT_AND_LOG (fp, "%-15d ", DB_GET_INT (&out_value));
+	  CHKSUM_PRINT_AND_LOG (fp, "%-15d ", db_get_int (&out_value));
 	  db_value_clear (&out_value);
 
 	  /* lower bound */
@@ -444,7 +444,7 @@ chksum_report_summary (FILE * fp)
 	      db_query_end (query_result);
 	      return error;
 	    }
-	  num_chunks = DB_GET_INT (&out_value);
+	  num_chunks = db_get_int (&out_value);
 	  CHKSUM_PRINT_AND_LOG (fp, "%-23d ", num_chunks);
 	  db_value_clear (&out_value);
 
@@ -455,7 +455,7 @@ chksum_report_summary (FILE * fp)
 	      db_query_end (query_result);
 	      return error;
 	    }
-	  CHKSUM_PRINT_AND_LOG (fp, "%-23d ", DB_GET_INT (&out_value));
+	  CHKSUM_PRINT_AND_LOG (fp, "%-23d ", db_get_int (&out_value));
 	  db_value_clear (&out_value);
 
 	  /* total elapsed time */
@@ -466,7 +466,7 @@ chksum_report_summary (FILE * fp)
 	      return error;
 	    }
 
-	  CHKSUM_PRINT_AND_LOG (fp, "%d / %d ", DB_GET_INT (&out_value), DB_GET_INT (&out_value) / num_chunks);
+	  CHKSUM_PRINT_AND_LOG (fp, "%d / %d ", db_get_int (&out_value), db_get_int (&out_value) / num_chunks);
 	  db_value_clear (&out_value);
 
 	  /* min elapsed time */
@@ -477,7 +477,7 @@ chksum_report_summary (FILE * fp)
 	      return error;
 	    }
 
-	  CHKSUM_PRINT_AND_LOG (fp, "/ %d ", DB_GET_INT (&out_value));
+	  CHKSUM_PRINT_AND_LOG (fp, "/ %d ", db_get_int (&out_value));
 	  db_value_clear (&out_value);
 
 	  /* max elapsed time */
@@ -488,7 +488,7 @@ chksum_report_summary (FILE * fp)
 	      return error;
 	    }
 
-	  CHKSUM_PRINT_AND_LOG (fp, "/ %d (ms)\n", DB_GET_INT (&out_value));
+	  CHKSUM_PRINT_AND_LOG (fp, "/ %d (ms)\n", db_get_int (&out_value));
 	  db_value_clear (&out_value);
 
 	  pos = db_query_next_tuple (query_result);
@@ -863,7 +863,7 @@ chksum_get_prev_checksum_results (void)
 	      return error;
 	    }
 
-	  checksum_result->last_chunk_id = DB_GET_INT (&value);
+	  checksum_result->last_chunk_id = db_get_int (&value);
 	  db_value_clear (&value);
 
 	  /* chunk_lower_bound */
@@ -889,7 +889,7 @@ chksum_get_prev_checksum_results (void)
 	      return error;
 	    }
 
-	  checksum_result->last_chunk_cnt = DB_GET_INT (&value);
+	  checksum_result->last_chunk_cnt = db_get_int (&value);
 	  db_value_clear (&value);
 
 	  checksum_result->next = chksum_Prev_results;
@@ -1512,7 +1512,7 @@ chksum_update_master_checksum (PARSER_CONTEXT * parser, const char *table_name, 
 	      break;
 	    }
 
-	  master_checksum = DB_GET_INT (&value);
+	  master_checksum = db_get_int (&value);
 	  db_value_clear (&value);
 	  break;
 	case DB_CURSOR_END:

--- a/src/executables/compactdb.c
+++ b/src/executables/compactdb.c
@@ -492,7 +492,7 @@ process_value (DB_VALUE * value)
     case DB_TYPE_MULTISET:
     case DB_TYPE_SEQUENCE:
       {
-	return_value = process_set (DB_GET_SET (value));
+	return_value = process_set (db_get_set (value));
 	break;
       }
 

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -503,7 +503,7 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
   DB_QUERY_RESULT *result = result_info->query_result;
   int num_attrs = result_info->num_attrs;
 
-  DB_MAKE_NULL (&db_value);
+  db_make_null (&db_value);
 
   val = (char **) malloc (sizeof (char *) * num_attrs);
   if (val == NULL)
@@ -574,7 +574,7 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
 	      csql_Error_code = CSQL_ERR_NO_MORE_MEMORY;
 	      goto error;
 	    }
-	  sprintf (val[i], "pointer value (%p)", (void *) DB_GET_POINTER (&db_value));
+	  sprintf (val[i], "pointer value (%p)", (void *) db_get_pointer (&db_value));
 	  break;
 
 	case DB_TYPE_ERROR:	/* error type */
@@ -584,7 +584,7 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
 	      csql_Error_code = CSQL_ERR_NO_MORE_MEMORY;
 	      goto error;
 	    }
-	  sprintf (val[i], "error code (%d)", DB_GET_ERROR (&db_value));
+	  sprintf (val[i], "error code (%d)", db_get_error (&db_value));
 	  break;
 
 	default:		/* other types */
@@ -598,8 +598,8 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
 	    {
 	      int async_ws, iso_lvl;
 
-	      async_ws = DB_GET_INTEGER (&db_value) & TRAN_ASYNC_WS_BIT;
-	      iso_lvl = DB_GET_INTEGER (&db_value) & TRAN_ISO_LVL_BITS;
+	      async_ws = db_get_int (&db_value) & TRAN_ASYNC_WS_BIT;
+	      iso_lvl = db_get_int (&db_value) & TRAN_ISO_LVL_BITS;
 
 	      val[i] = (char *) malloc (128);
 	      if (val[i] == NULL)
@@ -616,7 +616,7 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
 
 	      sprintf (val[i], "%s%s", csql_Isolation_level_string[iso_lvl], (async_ws ? ", ASYNC WORKSPACE" : ""));
 	    }
-	  else if ((stmt_type == CUBRID_STMT_GET_TIMEOUT) && (DB_GET_FLOAT (&db_value) == -1.0))
+	  else if ((stmt_type == CUBRID_STMT_GET_TIMEOUT) && (db_get_float (&db_value) == -1.0))
 	    {
 	      val[i] = (char *) malloc (9);
 	      if (val[i] == NULL)

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -316,7 +316,7 @@ csql_results (const CSQL_ARGUMENT * csql_arg, DB_QUERY_RESULT * result, DB_QUERY
 	case DB_TYPE_TIMELTZ:
 	  attr_lengths[i] = -MAX (MAX_TIMETZ_DISPLAY_LENGTH, attr_name_lengths[i]);
 	  break;
-	case DB_TYPE_UTIME:
+	case DB_TYPE_TIMESTAMP:
 	  attr_lengths[i] = -MAX (MAX_UTIME_DISPLAY_LENGTH, attr_name_lengths[i]);
 	  break;
 	case DB_TYPE_TIMESTAMPTZ:

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -1551,16 +1551,18 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
 	      }
 	  }
 
-	result =
-	  (db_get_monetary (value) == NULL) ? NULL : double_to_string (monetary_val->amount,
-								       default_monetary_profile.fieldwidth,
-								       default_monetary_profile.decimalplaces,
-								       default_monetary_profile.leadingsign,
-								       leading_str, trailing_str,
-								       default_monetary_profile.leadingzeros,
-								       default_monetary_profile.trailingzeros,
-								       default_monetary_profile.commas,
-								       DOUBLE_FORMAT_DECIMAL);
+	if (db_get_monetary (value) == NULL)
+	  {
+	    result = NULL;
+	  }
+	else
+	  {
+	    result = double_to_string (monetary_val->amount, default_monetary_profile.fieldwidth,
+				       default_monetary_profile.decimalplaces, default_monetary_profile.leadingsign,
+				       leading_str, trailing_str, default_monetary_profile.leadingzeros,
+				       default_monetary_profile.trailingzeros, default_monetary_profile.commas,
+				       DOUBLE_FORMAT_DECIMAL);
+	  }
 
 	if (result)
 	  {
@@ -1576,10 +1578,10 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
 	  len = strlen (result);
 	}
       break;
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       {
 	char buf[TIMESTAMP_BUF_SIZE];
-	if (db_utime_to_string (buf, sizeof (buf), db_get_utime (value)))
+	if (db_utime_to_string (buf, sizeof (buf), db_get_timestamp (value)))
 	  {
 	    result = duplicate_string (buf);
 	  }
@@ -1609,7 +1611,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       {
 	char buf[TIMESTAMPTZ_BUF_SIZE];
 
-	if (db_timestampltz_to_string (buf, sizeof (buf), db_get_utime (value)))
+	if (db_timestampltz_to_string (buf, sizeof (buf), db_get_timestamp (value)))
 	  {
 	    result = duplicate_string (buf);
 	  }

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -989,7 +989,7 @@ set_to_string (DB_VALUE * value, char begin_notation, char end_notation, int max
   int set_error;
   DB_SET *set;
 
-  set = DB_GET_SET (value);
+  set = db_get_set (value);
   if (set == NULL)
     {
       return (NULL);
@@ -1304,7 +1304,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
     {
     case DB_TYPE_BIGINT:
       result =
-	bigint_to_string (DB_GET_BIGINT (value), default_bigint_profile.fieldwidth, default_bigint_profile.leadingzeros,
+	bigint_to_string (db_get_bigint (value), default_bigint_profile.fieldwidth, default_bigint_profile.leadingzeros,
 			  default_bigint_profile.leadingsymbol, default_bigint_profile.commas,
 			  default_bigint_profile.format);
       if (result)
@@ -1314,7 +1314,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       break;
     case DB_TYPE_INTEGER:
       result =
-	bigint_to_string (DB_GET_INTEGER (value), default_int_profile.fieldwidth, default_int_profile.leadingzeros,
+	bigint_to_string (db_get_int (value), default_int_profile.fieldwidth, default_int_profile.leadingzeros,
 			  default_int_profile.leadingsymbol, default_int_profile.commas, default_int_profile.format);
       if (result)
 	{
@@ -1323,7 +1323,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       break;
     case DB_TYPE_SHORT:
       result =
-	bigint_to_string (SHORT_TO_INT (DB_GET_SHORT (value)), default_short_profile.fieldwidth,
+	bigint_to_string (SHORT_TO_INT (db_get_short (value)), default_short_profile.fieldwidth,
 			  default_short_profile.leadingzeros, default_short_profile.leadingsymbol,
 			  default_short_profile.commas, default_short_profile.format);
       if (result)
@@ -1333,7 +1333,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       break;
     case DB_TYPE_FLOAT:
       result =
-	double_to_string ((double) DB_GET_FLOAT (value), default_float_profile.fieldwidth,
+	double_to_string ((double) db_get_float (value), default_float_profile.fieldwidth,
 			  default_float_profile.precision, default_float_profile.leadingsign, NULL, NULL,
 			  default_float_profile.leadingzeros, default_float_profile.trailingzeros,
 			  default_float_profile.commas, default_float_profile.format);
@@ -1344,7 +1344,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       break;
     case DB_TYPE_DOUBLE:
       result =
-	double_to_string (DB_GET_DOUBLE (value), default_double_profile.fieldwidth, default_double_profile.precision,
+	double_to_string (db_get_double (value), default_double_profile.fieldwidth, default_double_profile.precision,
 			  default_double_profile.leadingsign, NULL, NULL, default_double_profile.leadingzeros,
 			  default_double_profile.trailingzeros, default_double_profile.commas,
 			  default_double_profile.format);
@@ -1370,7 +1370,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
 
 	str = db_get_char (value, &dummy);
 	bytes_size = db_get_string_size (value);
-	if (bytes_size > 0 && DB_GET_STRING_CODESET (value) == INTL_CODESET_UTF8)
+	if (bytes_size > 0 && db_get_string_codeset (value) == INTL_CODESET_UTF8)
 	  {
 	    need_decomp =
 	      unicode_string_need_decompose (str, bytes_size, &decomp_size, lang_get_generic_unicode_norm ());
@@ -1411,7 +1411,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
 
 	str = db_get_char (value, &dummy);
 	bytes_size = db_get_string_size (value);
-	if (bytes_size > 0 && DB_GET_STRING_CODESET (value) == INTL_CODESET_UTF8)
+	if (bytes_size > 0 && db_get_string_codeset (value) == INTL_CODESET_UTF8)
 	  {
 	    need_decomp =
 	      unicode_string_need_decompose (str, bytes_size, &decomp_size, lang_get_generic_unicode_norm ());
@@ -1450,7 +1450,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
 	}
       break;
     case DB_TYPE_OBJECT:
-      result = object_to_string (DB_GET_OBJECT (value), get_object_print_format ());
+      result = object_to_string (db_get_object (value), get_object_print_format ());
       if (result == NULL)
 	{
 	  result = duplicate_string ("NULL");
@@ -1461,7 +1461,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
 	}
       break;
     case DB_TYPE_VOBJ:
-      result = object_to_string (DB_GET_OBJECT (value), get_object_print_format ());
+      result = object_to_string (db_get_object (value), get_object_print_format ());
       if (result == NULL)
 	{
 	  result = duplicate_string ("NULL");
@@ -1492,7 +1492,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
     case DB_TYPE_TIME:
       {
 	char buf[TIME_BUF_SIZE];
-	if (db_time_to_string (buf, sizeof (buf), DB_GET_TIME (value)))
+	if (db_time_to_string (buf, sizeof (buf), db_get_time (value)))
 	  {
 	    result = duplicate_string (buf);
 	  }
@@ -1505,7 +1505,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
     case DB_TYPE_TIMETZ:
       {
 	char buf[TIMETZ_BUF_SIZE];
-	DB_TIMETZ *time_tz = DB_GET_TIMETZ (value);
+	DB_TIMETZ *time_tz = db_get_timetz (value);
 	if (db_timetz_to_string (buf, sizeof (buf), &(time_tz->time), &time_tz->tz_id))
 	  {
 	    result = duplicate_string (buf);
@@ -1521,7 +1521,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       {
 	char buf[TIMETZ_BUF_SIZE];
 
-	if (db_timeltz_to_string (buf, sizeof (buf), DB_GET_TIME (value)))
+	if (db_timeltz_to_string (buf, sizeof (buf), db_get_time (value)))
 	  {
 	    result = duplicate_string (buf);
 	  }
@@ -1536,7 +1536,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       {
 	char *leading_str = NULL;
 	char *trailing_str = NULL;
-	DB_MONETARY *monetary_val = DB_GET_MONETARY (value);
+	DB_MONETARY *monetary_val = db_get_monetary (value);
 	DB_CURRENCY currency = monetary_val->type;
 
 	if (default_monetary_profile.currency_symbol)
@@ -1552,7 +1552,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
 	  }
 
 	result =
-	  (DB_GET_MONETARY (value) == NULL) ? NULL : double_to_string (monetary_val->amount,
+	  (db_get_monetary (value) == NULL) ? NULL : double_to_string (monetary_val->amount,
 								       default_monetary_profile.fieldwidth,
 								       default_monetary_profile.decimalplaces,
 								       default_monetary_profile.leadingsign,
@@ -1570,7 +1570,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       break;
     case DB_TYPE_DATE:
       /* default format for all locales */
-      result = date_as_string (DB_GET_DATE (value), default_date_profile.format);
+      result = date_as_string (db_get_date (value), default_date_profile.format);
       if (result)
 	{
 	  len = strlen (result);
@@ -1579,7 +1579,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
     case DB_TYPE_UTIME:
       {
 	char buf[TIMESTAMP_BUF_SIZE];
-	if (db_utime_to_string (buf, sizeof (buf), DB_GET_UTIME (value)))
+	if (db_utime_to_string (buf, sizeof (buf), db_get_utime (value)))
 	  {
 	    result = duplicate_string (buf);
 	  }
@@ -1593,7 +1593,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
     case DB_TYPE_TIMESTAMPTZ:
       {
 	char buf[TIMESTAMPTZ_BUF_SIZE];
-	DB_TIMESTAMPTZ *ts_tz = DB_GET_TIMESTAMPTZ (value);
+	DB_TIMESTAMPTZ *ts_tz = db_get_timestamptz (value);
 	if (db_timestamptz_to_string (buf, sizeof (buf), &(ts_tz->timestamp), &(ts_tz->tz_id)))
 	  {
 	    result = duplicate_string (buf);
@@ -1609,7 +1609,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       {
 	char buf[TIMESTAMPTZ_BUF_SIZE];
 
-	if (db_timestampltz_to_string (buf, sizeof (buf), DB_GET_UTIME (value)))
+	if (db_timestampltz_to_string (buf, sizeof (buf), db_get_utime (value)))
 	  {
 	    result = duplicate_string (buf);
 	  }
@@ -1623,7 +1623,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
     case DB_TYPE_DATETIME:
       {
 	char buf[DATETIME_BUF_SIZE];
-	if (db_datetime_to_string (buf, sizeof (buf), DB_GET_DATETIME (value)))
+	if (db_datetime_to_string (buf, sizeof (buf), db_get_datetime (value)))
 	  {
 	    result = duplicate_string (buf);
 	  }
@@ -1637,7 +1637,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
     case DB_TYPE_DATETIMETZ:
       {
 	char buf[DATETIMETZ_BUF_SIZE];
-	DB_DATETIMETZ *dt_tz = DB_GET_DATETIMETZ (value);
+	DB_DATETIMETZ *dt_tz = db_get_datetimetz (value);
 	if (db_datetimetz_to_string (buf, sizeof (buf), &(dt_tz->datetime), &(dt_tz->tz_id)))
 	  {
 	    result = duplicate_string (buf);
@@ -1653,7 +1653,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       {
 	char buf[DATETIMETZ_BUF_SIZE];
 
-	if (db_datetimeltz_to_string (buf, sizeof (buf), DB_GET_DATETIME (value)))
+	if (db_datetimeltz_to_string (buf, sizeof (buf), db_get_datetime (value)))
 	  {
 	    result = duplicate_string (buf);
 	  }
@@ -1675,7 +1675,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
     case DB_TYPE_BLOB:
     case DB_TYPE_CLOB:
       {
-	DB_ELO *elo = DB_GET_ELO (value);
+	DB_ELO *elo = db_get_elo (value);
 
 	if (elo != NULL)
 	  {

--- a/src/executables/esql_cli.c
+++ b/src/executables/esql_cli.c
@@ -1197,7 +1197,7 @@ uci_delete_cs (int cs_no)
   e = db_query_get_tuple_oid (cs->result, &oid);
   CHECK_DBI (e < 0, return);
 
-  e = db_drop (DB_GET_OBJECT (&oid));
+  e = db_drop (db_get_object (&oid));
   CHECK_DBI (e < 0, return);
 }
 

--- a/src/executables/load_object.c
+++ b/src/executables/load_object.c
@@ -127,7 +127,7 @@ make_desc_obj (SM_CLASS * class_)
 	}
       for (i = 0, att = class_->attributes; i < class_->att_count; i++, att = (SM_ATTRIBUTE *) att->header.next)
 	{
-	  DB_MAKE_NULL (&obj->values[i]);
+	  db_make_null (&obj->values[i]);
 	  obj->atts[i] = att;
 	}
     }
@@ -1138,7 +1138,7 @@ bfmt_print (int bfmt, const DB_VALUE * the_db_bit, char *string, int max_size)
   };
 
   /* Get the buffer and the length from the_db_bit */
-  bstring = DB_GET_BIT (the_db_bit, &length);
+  bstring = db_get_bit (the_db_bit, &length);
 
   switch (bfmt)
     {
@@ -1396,7 +1396,7 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
 	  /* flush remaining buffer */
 	  CHECK_PRINT_ERROR (text_print_flush (tout));
 	}
-      CHECK_PRINT_ERROR (itoa_print (tout, DB_GET_BIGINT (value), 10 /* base */ ));
+      CHECK_PRINT_ERROR (itoa_print (tout, db_get_bigint (value), 10 /* base */ ));
       break;
     case DB_TYPE_INTEGER:
       if (tout->iosize - tout->count < INTERNAL_BUFFER_SIZE)
@@ -1404,7 +1404,7 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
 	  /* flush remaining buffer */
 	  CHECK_PRINT_ERROR (text_print_flush (tout));
 	}
-      CHECK_PRINT_ERROR (itoa_print (tout, DB_GET_INTEGER (value), 10 /* base */ ));
+      CHECK_PRINT_ERROR (itoa_print (tout, db_get_int (value), 10 /* base */ ));
       break;
     case DB_TYPE_SMALLINT:
       if (tout->iosize - tout->count < INTERNAL_BUFFER_SIZE)
@@ -1412,7 +1412,7 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
 	  /* flush remaining buffer */
 	  CHECK_PRINT_ERROR (text_print_flush (tout));
 	}
-      CHECK_PRINT_ERROR (itoa_print (tout, DB_GET_SMALLINT (value), 10 /* base */ ));
+      CHECK_PRINT_ERROR (itoa_print (tout, db_get_short (value), 10 /* base */ ));
       break;
 
     case DB_TYPE_FLOAT:
@@ -1423,7 +1423,7 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
 	pos = tout->ptr;
 	CHECK_PRINT_ERROR (text_print
 			   (tout, NULL, 0, "%.*g", (type == DB_TYPE_FLOAT) ? 10 : 17,
-			    (type == DB_TYPE_FLOAT) ? DB_GET_FLOAT (value) : DB_GET_DOUBLE (value)));
+			    (type == DB_TYPE_FLOAT) ? db_get_float (value) : db_get_double (value)));
 
 	/* if tout flushed, then this float/double should be the first content */
 	if ((pos < tout->ptr && !strchr (pos, '.')) || (pos > tout->ptr && !strchr (tout->buffer, '.')))
@@ -1439,58 +1439,58 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
 	  /* flush remaining buffer */
 	  CHECK_PRINT_ERROR (text_print_flush (tout));
 	}
-      CHECK_PRINT_ERROR (itoa_print (tout, DB_GET_ENUM_SHORT (value), 10 /* base */ ));
+      CHECK_PRINT_ERROR (itoa_print (tout, db_get_enum_short (value), 10 /* base */ ));
       break;
 
     case DB_TYPE_DATE:
-      db_date_to_string (buf, MAX_DISPLAY_COLUMN, DB_GET_DATE (value));
+      db_date_to_string (buf, MAX_DISPLAY_COLUMN, db_get_date (value));
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "date '%s'", buf));
       break;
 
     case DB_TYPE_TIME:
-      db_time_to_string (buf, MAX_DISPLAY_COLUMN, DB_GET_TIME (value));
+      db_time_to_string (buf, MAX_DISPLAY_COLUMN, db_get_time (value));
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "time '%s'", buf));
       break;
 
     case DB_TYPE_TIMELTZ:
-      db_timeltz_to_string (buf, MAX_DISPLAY_COLUMN, DB_GET_TIME (value));
+      db_timeltz_to_string (buf, MAX_DISPLAY_COLUMN, db_get_time (value));
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "timeltz '%s'", buf));
       break;
 
     case DB_TYPE_TIMETZ:
-      time_tz = DB_GET_TIMETZ (value);
+      time_tz = db_get_timetz (value);
       db_timetz_to_string (buf, MAX_DISPLAY_COLUMN, &time_tz->time, &time_tz->tz_id);
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "timetz '%s'", buf));
       break;
 
     case DB_TYPE_TIMESTAMP:
-      db_timestamp_to_string (buf, MAX_DISPLAY_COLUMN, DB_GET_UTIME (value));
+      db_timestamp_to_string (buf, MAX_DISPLAY_COLUMN, db_get_utime (value));
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "timestamp '%s'", buf));
       break;
 
     case DB_TYPE_TIMESTAMPLTZ:
-      db_timestampltz_to_string (buf, MAX_DISPLAY_COLUMN, DB_GET_UTIME (value));
+      db_timestampltz_to_string (buf, MAX_DISPLAY_COLUMN, db_get_utime (value));
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "timestampltz '%s'", buf));
       break;
 
     case DB_TYPE_TIMESTAMPTZ:
-      ts_tz = DB_GET_TIMESTAMPTZ (value);
+      ts_tz = db_get_timestamptz (value);
       db_timestamptz_to_string (buf, MAX_DISPLAY_COLUMN, &ts_tz->timestamp, &ts_tz->tz_id);
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "timestamptz '%s'", buf));
       break;
 
     case DB_TYPE_DATETIME:
-      db_datetime_to_string (buf, MAX_DISPLAY_COLUMN, DB_GET_DATETIME (value));
+      db_datetime_to_string (buf, MAX_DISPLAY_COLUMN, db_get_datetime (value));
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "datetime '%s'", buf));
       break;
 
     case DB_TYPE_DATETIMELTZ:
-      db_datetimeltz_to_string (buf, MAX_DISPLAY_COLUMN, DB_GET_DATETIME (value));
+      db_datetimeltz_to_string (buf, MAX_DISPLAY_COLUMN, db_get_datetime (value));
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "datetimeltz '%s'", buf));
       break;
 
     case DB_TYPE_DATETIMETZ:
-      dt_tz = DB_GET_DATETIMETZ (value);
+      dt_tz = db_get_datetimetz (value);
       db_datetimetz_to_string (buf, MAX_DISPLAY_COLUMN, &dt_tz->datetime, &dt_tz->tz_id);
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "datetimetz '%s'", buf));
       break;
@@ -1499,8 +1499,8 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
       /* Always print symbol before value, even if for turkish lira the user format is after value :
        * intl_get_currency_symbol_position */
       CHECK_PRINT_ERROR (text_print
-			 (tout, NULL, 0, "%s%.*f", intl_get_money_esc_ISO_symbol (DB_GET_MONETARY (value)->type), 2,
-			  DB_GET_MONETARY (value)->amount));
+			 (tout, NULL, 0, "%s%.*f", intl_get_money_esc_ISO_symbol (db_get_monetary (value)->type), 2,
+			  db_get_monetary (value)->amount));
       break;
 
     case DB_TYPE_NCHAR:
@@ -1560,15 +1560,15 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
 
       /* other stubs */
     case DB_TYPE_ERROR:
-      CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "%d", DB_GET_ERROR (value)));
+      CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "%d", db_get_error (value)));
       break;
 
     case DB_TYPE_POINTER:
-      CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "%p", DB_GET_POINTER (value)));
+      CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "%p", db_get_pointer (value)));
       break;
 
     case DB_TYPE_JSON:
-      CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "'%s'", DB_GET_JSON_RAW_BODY (value)));	//, strlen (DB_GET_JSON_RAW_BODY (value)), NULL));
+      CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "'%s'", db_get_json_raw_body (value)));	//, strlen (db_get_json_raw_body (value)), NULL));
       break;
 
     default:
@@ -1604,7 +1604,7 @@ desc_value_special_fprint (TEXT_OUTPUT * tout, DB_VALUE * value)
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
     case DB_TYPE_SEQUENCE:
-      CHECK_PRINT_ERROR (fprint_special_set (tout, DB_GET_SET (value)));
+      CHECK_PRINT_ERROR (fprint_special_set (tout, db_get_set (value)));
       break;
 
     case DB_TYPE_BLOB:
@@ -1644,7 +1644,7 @@ desc_value_fprint (FILE * fp, DB_VALUE * value)
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
     case DB_TYPE_SEQUENCE:
-      fprint_set (fp, DB_GET_SET (value));
+      fprint_set (fp, db_get_set (value));
       break;
 
     case DB_TYPE_BLOB:

--- a/src/executables/load_object.c
+++ b/src/executables/load_object.c
@@ -1464,12 +1464,12 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
       break;
 
     case DB_TYPE_TIMESTAMP:
-      db_timestamp_to_string (buf, MAX_DISPLAY_COLUMN, db_get_utime (value));
+      db_timestamp_to_string (buf, MAX_DISPLAY_COLUMN, db_get_timestamp (value));
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "timestamp '%s'", buf));
       break;
 
     case DB_TYPE_TIMESTAMPLTZ:
-      db_timestampltz_to_string (buf, MAX_DISPLAY_COLUMN, db_get_utime (value));
+      db_timestampltz_to_string (buf, MAX_DISPLAY_COLUMN, db_get_timestamp (value));
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "timestampltz '%s'", buf));
       break;
 
@@ -1498,9 +1498,9 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
     case DB_TYPE_MONETARY:
       /* Always print symbol before value, even if for turkish lira the user format is after value :
        * intl_get_currency_symbol_position */
-      CHECK_PRINT_ERROR (text_print
-			 (tout, NULL, 0, "%s%.*f", intl_get_money_esc_ISO_symbol (db_get_monetary (value)->type), 2,
-			  db_get_monetary (value)->amount));
+      CHECK_PRINT_ERROR (text_print (tout, NULL, 0, "%s%.*f",
+				     intl_get_money_esc_ISO_symbol (db_get_monetary (value)->type), 2,
+				     db_get_monetary (value)->amount));
       break;
 
     case DB_TYPE_NCHAR:

--- a/src/executables/loader.c
+++ b/src/executables/loader.c
@@ -1703,7 +1703,7 @@ error_exit:
 static int
 ldr_null_elem (LDR_CONTEXT * context, const char *str, int len, DB_VALUE * val)
 {
-  DB_MAKE_NULL (val);
+  db_make_null (val);
   return NO_ERROR;
 }
 
@@ -2177,7 +2177,7 @@ error_exit:
 static int
 ldr_str_elem (LDR_CONTEXT * context, const char *str, int len, DB_VALUE * val)
 {
-  DB_MAKE_STRING (val, str);
+  db_make_string (val, str);
   return NO_ERROR;
 }
 
@@ -2337,7 +2337,7 @@ ldr_str_db_generic (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUT
 {
   DB_VALUE val;
 
-  DB_MAKE_STRING (&val, str);
+  db_make_string (&val, str);
   return ldr_generic (context, &val);
 }
 
@@ -2370,7 +2370,7 @@ ldr_bstr_elem (LDR_CONTEXT * context, const char *str, int len, DB_VALUE * val)
       CHECK_PARSE_ERR (err, ER_OBJ_DOMAIN_CONFLICT, context, DB_TYPE_BIT, str);
     }
 
-  DB_MAKE_VARBIT (&temp, TP_FLOATING_PRECISION_VALUE, bstring, len);
+  db_make_varbit (&temp, TP_FLOATING_PRECISION_VALUE, bstring, len);
   temp.need_clear = true;
 
   GET_DOMAIN (context, domain);
@@ -2439,7 +2439,7 @@ ldr_xstr_elem (LDR_CONTEXT * context, const char *str, int len, DB_VALUE * val)
   DB_VALUE temp;
   TP_DOMAIN *domain_ptr, temp_domain;
 
-  DB_MAKE_NULL (&temp);
+  db_make_null (&temp);
 
   dest_size = (len + 1) / 2;
 
@@ -2451,7 +2451,7 @@ ldr_xstr_elem (LDR_CONTEXT * context, const char *str, int len, DB_VALUE * val)
       CHECK_PARSE_ERR (err, ER_OBJ_DOMAIN_CONFLICT, context, DB_TYPE_BIT, str);
     }
 
-  DB_MAKE_VARBIT (&temp, TP_FLOATING_PRECISION_VALUE, bstring, len * 4);
+  db_make_varbit (&temp, TP_FLOATING_PRECISION_VALUE, bstring, len * 4);
   temp.need_clear = true;
 
   /* temp takes ownership of this piece of memory */
@@ -2521,7 +2521,7 @@ static int
 ldr_nstr_elem (LDR_CONTEXT * context, const char *str, int len, DB_VALUE * val)
 {
 
-  DB_MAKE_VARNCHAR (val, TP_FLOATING_PRECISION_VALUE, (const DB_C_NCHAR) (str), len, LANG_SYS_CODESET,
+  db_make_varnchar (val, TP_FLOATING_PRECISION_VALUE, (const DB_C_NCHAR) (str), len, LANG_SYS_CODESET,
 		    LANG_SYS_COLLATION);
   return NO_ERROR;
 }
@@ -3907,7 +3907,7 @@ ldr_class_oid_elem (LDR_CONTEXT * context, const char *str, int len, DB_VALUE * 
     }
 
   CHECK_ERR (err, check_class_domain (context));
-  DB_MAKE_OBJECT (val, context->attrs[context->next_attr].ref_class);
+  db_make_object (val, context->attrs[context->next_attr].ref_class);
 
 error_exit:
   return err;
@@ -3973,7 +3973,7 @@ ldr_oid_elem (LDR_CONTEXT * context, const char *str, int len, DB_VALUE * val)
   err = find_instance (context, actual_class, &oid, context->attrs[context->next_attr].instance_id);
   if (err == ER_LDR_INTERNAL_REFERENCE)
     {
-      DB_MAKE_NULL (val);
+      db_make_null (val);
     }
   else
     {
@@ -3989,7 +3989,7 @@ ldr_oid_elem (LDR_CONTEXT * context, const char *str, int len, DB_VALUE * val)
 	  CHECK_ERR (err, err);
 	}
 
-      DB_MAKE_OBJECT (val, mop);
+      db_make_object (val, mop);
     }
 
 error_exit:
@@ -4165,7 +4165,7 @@ ldr_collection_db_collection (LDR_CONTEXT * context, const char *str, int len, S
        */
       DB_VALUE tmp;
 
-      DB_MAKE_COLLECTION (&tmp, context->collection);
+      db_make_collection (&tmp, context->collection);
 
       context->collection = NULL;
       context->set_domain = NULL;
@@ -5368,7 +5368,7 @@ construct_instance (LDR_CONTEXT * context)
 
   if (!err && DB_VALUE_TYPE (&retval) == DB_TYPE_OBJECT)
     {
-      obj = DB_GET_OBJECT (&retval);
+      obj = db_get_object (&retval);
       context->obj = obj;
       err = au_fetch_instance (context->obj, &context->mobj, AU_FETCH_UPDATE, LC_FETCH_MVCC_VERSION, AU_UPDATE);
       if (err == NO_ERROR)

--- a/src/executables/unload_object.c
+++ b/src/executables/unload_object.c
@@ -1537,7 +1537,7 @@ process_value (DB_VALUE * value)
 
 	if (DB_VALUE_TYPE (value) == DB_TYPE_OID)
 	  {
-	    ref_oid = DB_GET_OID (value);
+	    ref_oid = db_get_oid (value);
 	  }
 	else
 	  {
@@ -1669,7 +1669,7 @@ process_value (DB_VALUE * value)
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
     case DB_TYPE_SEQUENCE:
-      CHECK_PRINT_ERROR (process_set (DB_GET_SET (value)));
+      CHECK_PRINT_ERROR (process_set (db_get_set (value)));
       break;
 
     case DB_TYPE_BLOB:

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -587,10 +587,10 @@ emit_class_owner (FILE * fp, MOP class_)
 	{
 	  if (db_get (owner, "name", &value) == NO_ERROR)
 	    {
-	      if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && DB_GET_STRING (&value) != NULL)
+	      if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && db_get_string (&value) != NULL)
 		{
 		  fprintf (fp, "call [change_owner]('%s', '%s') on class [db_root];\n", classname,
-			   DB_GET_STRING (&value));
+			   db_get_string (&value));
 		}
 	      db_value_clear (&value);
 	    }
@@ -622,8 +622,8 @@ export_serial (FILE * outfp)
     "select [name], [owner].[name], " "[current_val], " "[increment_val], " "[max_val], " "[min_val], " "[cyclic], "
     "[started], " "[cached_num], " "[comment] " "from [db_serial] where [class_name] is null and [att_name] is null";
 
-  DB_MAKE_NULL (&diff_value);
-  DB_MAKE_NULL (&answer_value);
+  db_make_null (&diff_value);
+  db_make_null (&answer_value);
 
   error = db_compile_and_execute_local (query, &query_result, &query_error);
   if (error < 0)
@@ -715,7 +715,7 @@ export_serial (FILE * outfp)
 	    }
 	}
 
-      if (DB_GET_INTEGER (&values[SERIAL_STARTED]) == 1)
+      if (db_get_int (&values[SERIAL_STARTED]) == 1)
 	{
 	  /* Calculate next value of serial */
 	  error = numeric_db_value_sub (&values[SERIAL_MAX_VAL], &values[SERIAL_CURRENT_VAL], &diff_value);
@@ -730,10 +730,10 @@ export_serial (FILE * outfp)
 	      goto err;
 	    }
 	  /* increment > diff */
-	  if (DB_GET_INTEGER (&answer_value) > 0)
+	  if (db_get_int (&answer_value) > 0)
 	    {
 	      /* no cyclic case */
-	      if (DB_GET_INTEGER (&values[SERIAL_CYCLIC]) == 0)
+	      if (db_get_int (&values[SERIAL_CYCLIC]) == 0)
 		{
 		  domain = tp_domain_resolve_default (DB_TYPE_NUMERIC);
 		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IT_DATA_OVERFLOW, 1,
@@ -766,15 +766,15 @@ export_serial (FILE * outfp)
       fprintf (outfp, "\t increment by %s\n", numeric_db_value_print (&values[SERIAL_INCREMENT_VAL], str_buf));
       fprintf (outfp, "\t minvalue %s\n", numeric_db_value_print (&values[SERIAL_MIN_VAL], str_buf));
       fprintf (outfp, "\t maxvalue %s\n", numeric_db_value_print (&values[SERIAL_MAX_VAL], str_buf));
-      fprintf (outfp, "\t %scycle\n", (DB_GET_INTEGER (&values[SERIAL_CYCLIC]) == 0 ? "no" : ""));
-      if (DB_GET_INTEGER (&values[SERIAL_CACHED_NUM]) <= 1)
+      fprintf (outfp, "\t %scycle\n", (db_get_int (&values[SERIAL_CYCLIC]) == 0 ? "no" : ""));
+      if (db_get_int (&values[SERIAL_CACHED_NUM]) <= 1)
 	{
 	  fprintf (outfp, "\t nocache\n");
 
 	}
       else
 	{
-	  fprintf (outfp, "\t cache %d\n", DB_GET_INTEGER (&values[SERIAL_CACHED_NUM]));
+	  fprintf (outfp, "\t cache %d\n", db_get_int (&values[SERIAL_CACHED_NUM]));
 
 	}
       if (DB_IS_NULL (&values[SERIAL_COMMENT]) == false)
@@ -1854,12 +1854,12 @@ emit_instance_attributes (DB_OBJECT * class_, const char *class_type, int *has_i
 	    {
 	      int sr_error = NO_ERROR;
 
-	      DB_MAKE_NULL (&sr_name);
-	      DB_MAKE_NULL (&cur_val);
-	      DB_MAKE_NULL (&started_val);
-	      DB_MAKE_NULL (&min_val);
-	      DB_MAKE_NULL (&max_val);
-	      DB_MAKE_NULL (&inc_val);
+	      db_make_null (&sr_name);
+	      db_make_null (&cur_val);
+	      db_make_null (&started_val);
+	      db_make_null (&min_val);
+	      db_make_null (&max_val);
+	      db_make_null (&inc_val);
 
 	      sr_error = db_get (a->auto_increment, "name", &sr_name);
 	      if (sr_error < 0)
@@ -1902,7 +1902,7 @@ emit_instance_attributes (DB_OBJECT * class_, const char *class_type, int *has_i
 		  continue;
 		}
 
-	      if (DB_GET_INTEGER (&started_val) == 1)
+	      if (db_get_int (&started_val) == 1)
 		{
 		  DB_VALUE diff_val, answer_val;
 
@@ -1919,7 +1919,7 @@ emit_instance_attributes (DB_OBJECT * class_, const char *class_type, int *has_i
 		      continue;
 		    }
 		  /* auto_increment is always non-cyclic */
-		  if (DB_GET_INTEGER (&answer_val) > 0)
+		  if (db_get_int (&answer_val) > 0)
 		    {
 		      pr_clear_value (&sr_name);
 		      continue;
@@ -2225,11 +2225,11 @@ ex_contains_object_reference (DB_VALUE * value)
     {
       if (DB_VALUE_TYPE (value) == DB_TYPE_OBJECT)
 	{
-	  has_object = DB_GET_OBJECT (value) != NULL;
+	  has_object = db_get_object (value) != NULL;
 	}
       else if (TP_IS_SET_TYPE (DB_VALUE_TYPE (value)))
 	{
-	  set = DB_GET_SET (value);
+	  set = db_get_set (value);
 	  size = db_set_size (set);
 	  type = db_set_type (set);
 
@@ -2820,8 +2820,8 @@ emit_autoincrement_def (DB_ATTRIBUTE * attribute)
 
   if (attribute->auto_increment != NULL)
     {
-      DB_MAKE_NULL (&min_val);
-      DB_MAKE_NULL (&inc_val);
+      db_make_null (&min_val);
+      db_make_null (&inc_val);
 
       error = db_get (attribute->auto_increment, "min_val", &min_val);
       if (error < 0)
@@ -3119,7 +3119,7 @@ emit_stored_procedure_args (int arg_cnt, DB_SET * arg_set)
 	  continue;
 	}
 
-      arg = DB_GET_OBJECT (&arg_val);
+      arg = db_get_object (&arg_val);
 
       if ((err = db_get (arg, SP_ATTR_ARG_NAME, &arg_name_val)) != NO_ERROR
 	  || (err = db_get (arg, SP_ATTR_MODE, &arg_mode_val)) != NO_ERROR
@@ -3132,10 +3132,10 @@ emit_stored_procedure_args (int arg_cnt, DB_SET * arg_set)
 
       fprintf (output_file, "%s%s%s ", PRINT_IDENTIFIER (db_get_string (&arg_name_val)));
 
-      arg_mode = DB_GET_INT (&arg_mode_val);
+      arg_mode = db_get_int (&arg_mode_val);
       fprintf (output_file, "%s ", arg_mode == SP_MODE_IN ? "IN" : arg_mode == SP_MODE_OUT ? "OUT" : "INOUT");
 
-      arg_type = DB_GET_INT (&arg_type_val);
+      arg_type = db_get_int (&arg_type_val);
 
       if (arg_type == DB_TYPE_RESULTSET)
 	{
@@ -3207,13 +3207,13 @@ emit_stored_procedure (void)
 	  continue;
 	}
 
-      sp_type = DB_GET_INT (&sp_type_val);
+      sp_type = db_get_int (&sp_type_val);
       fprintf (output_file, "\nCREATE %s", sp_type == SP_TYPE_PROCEDURE ? "PROCEDURE" : "FUNCTION");
 
       fprintf (output_file, " %s%s%s (", PRINT_IDENTIFIER (db_get_string (&sp_name_val)));
 
-      arg_cnt = DB_GET_INT (&arg_cnt_val);
-      arg_set = DB_GET_SET (&args_val);
+      arg_cnt = db_get_int (&arg_cnt_val);
+      arg_set = db_get_set (&args_val);
       if (emit_stored_procedure_args (arg_cnt, arg_set) > 0)
 	{
 	  err_count++;
@@ -3224,7 +3224,7 @@ emit_stored_procedure (void)
 
       if (sp_type == SP_TYPE_FUNCTION)
 	{
-	  rtn_type = DB_GET_INT (&rtn_type_val);
+	  rtn_type = db_get_int (&rtn_type_val);
 
 	  if (rtn_type == DB_TYPE_RESULTSET)
 	    {
@@ -3236,7 +3236,7 @@ emit_stored_procedure (void)
 	    }
 	}
 
-      fprintf (output_file, "AS LANGUAGE JAVA NAME '%s'", DB_GET_STRING (&method_val));
+      fprintf (output_file, "AS LANGUAGE JAVA NAME '%s'", db_get_string (&method_val));
 
       if (!DB_IS_NULL (&comment_val))
 	{
@@ -3246,7 +3246,7 @@ emit_stored_procedure (void)
 
       fprintf (output_file, ";\n");
 
-      owner = DB_GET_OBJECT (&owner_val);
+      owner = db_get_object (&owner_val);
       err = db_get (owner, "name", &owner_name_val);
       if (err != NO_ERROR)
 	{
@@ -3254,8 +3254,8 @@ emit_stored_procedure (void)
 	  continue;
 	}
 
-      fprintf (output_file, "call [change_sp_owner]('%s', '%s') on class [db_root];\n", DB_GET_STRING (&sp_name_val),
-	       DB_GET_STRING (&owner_name_val));
+      fprintf (output_file, "call [change_sp_owner]('%s', '%s') on class [db_root];\n", db_get_string (&sp_name_val),
+	       db_get_string (&owner_name_val));
 
       db_value_clear (&owner_name_val);
     }

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -2849,15 +2849,15 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 		  assert (DB_VALUE_TYPE (&class_name) == DB_TYPE_STRING);
 		  assert (DB_VALUE_TYPE (&ct) == DB_TYPE_INTEGER);
 
-		  if (DB_GET_INTEGER (&ct) != 0)
+		  if (db_get_int (&ct) != 0)
 		    {
 		      continue;
 		    }
-		  fprintf (stdout, "%s\n", DB_GET_STRING (&class_name));
+		  fprintf (stdout, "%s\n", db_get_string (&class_name));
 
 		  /* output query to fix schema */
 		  snprintf (query, sizeof (query) - 1, "ALTER TABLE [%s] " "COLLATE utf8_bin;",
-			    DB_GET_STRING (&class_name));
+			    db_get_string (&class_name));
 		  fprintf (f_stmt, "%s\n", query);
 		  need_manual_sync = true;
 		}
@@ -2910,9 +2910,9 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 		    }
 		  assert (DB_VALUE_TYPE (&class_name) == DB_TYPE_STRING);
 		  assert (DB_VALUE_TYPE (&index_name) == DB_TYPE_STRING);
-		  fprintf (stdout, "%s | %s\n", DB_GET_STRING (&class_name), DB_GET_STRING (&index_name));
+		  fprintf (stdout, "%s | %s\n", db_get_string (&class_name), db_get_string (&index_name));
 		  snprintf (query, sizeof (query) - 1, "ALTER TABLE [%s] DROP FOREIGN KEY [%s];",
-			    DB_GET_STRING (&class_name), DB_GET_STRING (&index_name));
+			    db_get_string (&class_name), db_get_string (&index_name));
 		  fprintf (f_stmt, "%s\n", query);
 		  need_manual_sync = true;
 		}
@@ -2985,26 +2985,26 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 		  assert (DB_VALUE_TYPE (&attr_data_type) == DB_TYPE_STRING);
 		  assert (DB_VALUE_TYPE (&has_part) == DB_TYPE_INTEGER);
 
-		  fprintf (stdout, "%s | %s %s\n", DB_GET_STRING (&class_name), DB_GET_STRING (&attr),
-			   DB_GET_STRING (&attr_data_type));
+		  fprintf (stdout, "%s | %s %s\n", db_get_string (&class_name), db_get_string (&attr),
+			   db_get_string (&attr_data_type));
 
 		  /* output query to fix schema */
-		  if (DB_GET_INTEGER (&ct) == 0)
+		  if (db_get_int (&ct) == 0)
 		    {
-		      if (DB_GET_INTEGER (&has_part) == 1)
+		      if (db_get_int (&has_part) == 1)
 			{
 			  /* class is partitioned, remove partition; we cannot change the collation of an attribute
 			   * having partitions */
-			  fprintf (f_stmt, "ALTER TABLE [%s] REMOVE PARTITIONING;\n", DB_GET_STRING (&class_name));
+			  fprintf (f_stmt, "ALTER TABLE [%s] REMOVE PARTITIONING;\n", db_get_string (&class_name));
 			  add_to_part_tables = true;
 			}
 
 		      snprintf (query, sizeof (query) - 1, "ALTER TABLE [%s] " "MODIFY [%s] %s COLLATE utf8_bin;",
-				DB_GET_STRING (&class_name), DB_GET_STRING (&attr), DB_GET_STRING (&attr_data_type));
+				db_get_string (&class_name), db_get_string (&attr), db_get_string (&attr_data_type));
 		    }
 		  else
 		    {
-		      snprintf (query, sizeof (query) - 1, "DROP VIEW [%s];", DB_GET_STRING (&class_name));
+		      snprintf (query, sizeof (query) - 1, "DROP VIEW [%s];", db_get_string (&class_name));
 
 		      if (vclass_names == NULL || vclass_names_alloced <= vclass_names_used)
 			{
@@ -3022,9 +3022,9 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 			  vclass_names_alloced *= 2;
 			}
 
-		      memcpy (vclass_names + vclass_names_used, DB_GET_STRING (&class_name),
-			      DB_GET_STRING_SIZE (&class_name));
-		      vclass_names_used += DB_GET_STRING_SIZE (&class_name);
+		      memcpy (vclass_names + vclass_names_used, db_get_string (&class_name),
+			      db_get_string_size (&class_name));
+		      vclass_names_used += db_get_string_size (&class_name);
 		      memcpy (vclass_names + vclass_names_used, "\0", 1);
 		      vclass_names_used += 1;
 		    }
@@ -3049,9 +3049,9 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 			  part_tables_alloced *= 2;
 			}
 
-		      memcpy (part_tables + part_tables_used, DB_GET_STRING (&class_name),
-			      DB_GET_STRING_SIZE (&class_name));
-		      part_tables_used += DB_GET_STRING_SIZE (&class_name);
+		      memcpy (part_tables + part_tables_used, db_get_string (&class_name),
+			      db_get_string_size (&class_name));
+		      part_tables_used += db_get_string_size (&class_name);
 		      memcpy (part_tables + part_tables_used, "\0", 1);
 		      part_tables_used += 1;
 		    }
@@ -3123,18 +3123,18 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 		  assert (DB_VALUE_TYPE (&view) == DB_TYPE_STRING);
 		  assert (DB_VALUE_TYPE (&query_spec) == DB_TYPE_STRING);
 
-		  fprintf (stdout, "%s | %s\n", DB_GET_STRING (&view), DB_GET_STRING (&query_spec));
+		  fprintf (stdout, "%s | %s\n", db_get_string (&view), db_get_string (&query_spec));
 
 		  /* output query to fix schema */
 		  if (vclass_names != NULL)
 		    {
 		      char *search = vclass_names;
-		      int view_name_size = DB_GET_STRING_SIZE (&view);
+		      int view_name_size = db_get_string_size (&view);
 
 		      /* search if the view was already put in .SQL file */
 		      while (search + view_name_size < vclass_names + vclass_names_used)
 			{
-			  if (memcmp (search, DB_GET_STRING (&view), view_name_size) == 0
+			  if (memcmp (search, db_get_string (&view), view_name_size) == 0
 			      && *(search + view_name_size) == '\0')
 			    {
 			      already_dropped = true;
@@ -3150,7 +3150,7 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 
 		  if (!already_dropped)
 		    {
-		      snprintf (query, sizeof (query) - 1, "DROP VIEW [%s];", DB_GET_STRING (&view));
+		      snprintf (query, sizeof (query) - 1, "DROP VIEW [%s];", db_get_string (&view));
 		      fprintf (f_stmt, "%s\n", query);
 		    }
 		  need_manual_sync = true;
@@ -3199,10 +3199,10 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 		  assert (DB_VALUE_TYPE (&trig_name) == DB_TYPE_STRING);
 		  assert (DB_VALUE_TYPE (&trig_cond) == DB_TYPE_STRING);
 
-		  fprintf (stdout, "%s | %s\n", DB_GET_STRING (&trig_name), DB_GET_STRING (&trig_cond));
+		  fprintf (stdout, "%s | %s\n", db_get_string (&trig_name), db_get_string (&trig_cond));
 
 		  /* output query to fix schema */
-		  snprintf (query, sizeof (query) - 1, "DROP TRIGGER [%s];", DB_GET_STRING (&trig_name));
+		  snprintf (query, sizeof (query) - 1, "DROP TRIGGER [%s];", db_get_string (&trig_name));
 		  fprintf (f_stmt, "%s\n", query);
 		  need_manual_sync = true;
 		}
@@ -3258,12 +3258,12 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 		  assert (DB_VALUE_TYPE (&func_expr) == DB_TYPE_STRING);
 		  assert (DB_VALUE_TYPE (&class_name) == DB_TYPE_STRING);
 
-		  fprintf (stdout, "%s | %s | %s\n", DB_GET_STRING (&class_name), DB_GET_STRING (&index_name),
-			   DB_GET_STRING (&func_expr));
+		  fprintf (stdout, "%s | %s | %s\n", db_get_string (&class_name), db_get_string (&index_name),
+			   db_get_string (&func_expr));
 
 		  /* output query to fix schema */
 		  snprintf (query, sizeof (query) - 1, "ALTER TABLE [%s] " "DROP INDEX [%s];",
-			    DB_GET_STRING (&class_name), DB_GET_STRING (&index_name));
+			    db_get_string (&class_name), db_get_string (&index_name));
 		  fprintf (f_stmt, "%s\n", query);
 		  need_manual_sync = true;
 		}

--- a/src/jsp/jsp_cl.c
+++ b/src/jsp/jsp_cl.c
@@ -679,7 +679,7 @@ jsp_alter_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * statement)
       goto error;
     }
 
-  real_type = (SP_TYPE_ENUM) DB_GET_INT (&sp_type_val);
+  real_type = (SP_TYPE_ENUM) db_get_int (&sp_type_val);
   if (real_type != jsp_map_pt_misc_to_sp_type (type))
     {
       err = ER_SP_INVALID_TYPE;
@@ -1180,7 +1180,7 @@ drop_stored_procedure (const char *name, PT_MISC_TYPE expected_type)
     {
       goto error;
     }
-  owner = DB_GET_OBJECT (&owner_val);
+  owner = db_get_object (&owner_val);
 
   if (!ws_is_same_object (owner, Au_user) && !au_is_dba_group_member (Au_user))
     {
@@ -1195,7 +1195,7 @@ drop_stored_procedure (const char *name, PT_MISC_TYPE expected_type)
       goto error;
     }
 
-  real_type = (SP_TYPE_ENUM) DB_GET_INT (&sp_type_val);
+  real_type = (SP_TYPE_ENUM) db_get_int (&sp_type_val);
   if (real_type != jsp_map_pt_misc_to_sp_type (expected_type))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_INVALID_TYPE, 2, name,
@@ -1211,7 +1211,7 @@ drop_stored_procedure (const char *name, PT_MISC_TYPE expected_type)
       goto error;
     }
 
-  arg_cnt = DB_GET_INT (&arg_cnt_val);
+  arg_cnt = db_get_int (&arg_cnt_val);
 
   err = db_get (sp_mop, SP_ATTR_ARGS, &args_val);
   if (err != NO_ERROR)
@@ -1219,12 +1219,12 @@ drop_stored_procedure (const char *name, PT_MISC_TYPE expected_type)
       goto error;
     }
 
-  arg_set_p = DB_GET_SET (&args_val);
+  arg_set_p = db_get_set (&args_val);
 
   for (i = 0; i < arg_cnt; i++)
     {
       set_get_element (arg_set_p, i, &temp);
-      arg_mop = DB_GET_OBJECT (&temp);
+      arg_mop = db_get_object (&temp);
       err = obj_delete (arg_mop);
       pr_clear_value (&temp);
       if (err != NO_ERROR)
@@ -1468,7 +1468,7 @@ jsp_get_value_size (DB_VALUE * value)
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
     case DB_TYPE_STRING:
-      size = or_packed_string_length (DB_GET_STRING (value), NULL);
+      size = or_packed_string_length (db_get_string (value), NULL);
       break;
 
     case DB_TYPE_BIT:
@@ -1497,7 +1497,7 @@ jsp_get_value_size (DB_VALUE * value)
 	int ncol, i;
 	DB_VALUE v;
 
-	set = DB_GET_SET (value);
+	set = db_get_set (value);
 	ncol = set_size (set);
 	size += 4;		/* set size */
 
@@ -1562,7 +1562,7 @@ jsp_pack_int_argument (char *buffer, DB_VALUE * value)
 
   ptr = buffer;
   ptr = or_pack_int (ptr, sizeof (int));
-  v = DB_GET_INT (value);
+  v = db_get_int (value);
   ptr = or_pack_int (ptr, v);
 
   return ptr;
@@ -1583,7 +1583,7 @@ jsp_pack_bigint_argument (char *buffer, DB_VALUE * value)
   char *ptr;
 
   ptr = or_pack_int (buffer, sizeof (DB_BIGINT));
-  tmp_value = DB_GET_BIGINT (value);
+  tmp_value = db_get_bigint (value);
   OR_PUT_BIGINT (ptr, &tmp_value);
 
   return ptr + OR_BIGINT_SIZE;
@@ -1606,7 +1606,7 @@ jsp_pack_short_argument (char *buffer, DB_VALUE * value)
 
   ptr = buffer;
   ptr = or_pack_int (ptr, sizeof (int));
-  v = DB_GET_SHORT (value);
+  v = db_get_short (value);
   ptr = or_pack_short (ptr, v);
 
   return ptr;
@@ -1629,7 +1629,7 @@ jsp_pack_float_argument (char *buffer, DB_VALUE * value)
 
   ptr = buffer;
   ptr = or_pack_int (ptr, sizeof (float));
-  v = DB_GET_FLOAT (value);
+  v = db_get_float (value);
   ptr = or_pack_float (ptr, v);
 
   return ptr;
@@ -1651,7 +1651,7 @@ jsp_pack_double_argument (char *buffer, DB_VALUE * value)
   char *ptr;
 
   ptr = or_pack_int (buffer, sizeof (double));
-  v = DB_GET_DOUBLE (value);
+  v = db_get_double (value);
   OR_PUT_DOUBLE (&pack_value, &v);
   memcpy (ptr, (char *) (&pack_value), OR_DOUBLE_SIZE);
 
@@ -1700,10 +1700,10 @@ jsp_pack_string_argument (char *buffer, DB_VALUE * value)
 
 
   ptr = buffer;
-  v = DB_GET_STRING (value);
+  v = db_get_string (value);
   v_size = (v != NULL) ? strlen (v) : 0;
 
-  if (v_size > 0 && DB_GET_STRING_CODESET (value) == INTL_CODESET_UTF8
+  if (v_size > 0 && db_get_string_codeset (value) == INTL_CODESET_UTF8
       && unicode_string_need_decompose (v, v_size, &decomp_size, lang_get_generic_unicode_norm ()))
     {
       char *decomposed;
@@ -1754,7 +1754,7 @@ jsp_pack_date_argument (char *buffer, DB_VALUE * value)
   char *ptr;
 
   ptr = buffer;
-  date = DB_GET_DATE (value);
+  date = db_get_date (value);
   db_date_decode (date, &month, &day, &year);
 
   ptr = or_pack_int (ptr, sizeof (int) * 3);
@@ -1782,7 +1782,7 @@ jsp_pack_time_argument (char *buffer, DB_VALUE * value)
   char *ptr;
 
   ptr = buffer;
-  time = DB_GET_TIME (value);
+  time = db_get_time (value);
   db_time_decode (time, &hour, &min, &sec);
 
   ptr = or_pack_int (ptr, sizeof (int) * 3);
@@ -1812,7 +1812,7 @@ jsp_pack_timestamp_argument (char *buffer, DB_VALUE * value)
   char *ptr;
 
   ptr = buffer;
-  timestamp = DB_GET_TIMESTAMP (value);
+  timestamp = db_get_timestamp (value);
   (void) db_timestamp_decode_ses (timestamp, &date, &time);
   db_date_decode (&date, &mon, &day, &year);
   db_time_decode (&time, &hour, &min, &sec);
@@ -1845,7 +1845,7 @@ jsp_pack_datetime_argument (char *buffer, DB_VALUE * value)
   char *ptr;
 
   ptr = buffer;
-  datetime = DB_GET_DATETIME (value);
+  datetime = db_get_datetime (value);
   db_datetime_decode (datetime, &mon, &day, &year, &hour, &min, &sec, &msec);
 
   ptr = or_pack_int (ptr, sizeof (int) * 7);
@@ -1878,7 +1878,7 @@ jsp_pack_set_argument (char *buffer, DB_VALUE * value)
   char *ptr;
 
   ptr = buffer;
-  set = DB_GET_SET (value);
+  set = db_get_set (value);
   ncol = set_size (set);
 
   ptr = or_pack_int (ptr, sizeof (int));
@@ -1915,7 +1915,7 @@ jsp_pack_object_argument (char *buffer, DB_VALUE * value)
   MOP mop;
 
   ptr = buffer;
-  mop = DB_GET_OBJECT (value);
+  mop = db_get_object (value);
   if (mop != NULL)
     {
       oid = WS_OID (mop);
@@ -1950,7 +1950,7 @@ jsp_pack_monetary_argument (char *buffer, DB_VALUE * value)
   char *ptr;
 
   ptr = or_pack_int (buffer, sizeof (double));
-  v = DB_GET_MONETARY (value);
+  v = db_get_monetary (value);
   OR_PUT_DOUBLE (&pack_value, &v->amount);
   memcpy (ptr, (char *) (&pack_value), OR_DOUBLE_SIZE);
 
@@ -2445,7 +2445,7 @@ jsp_unpack_datetime_value (char *buffer, DB_VALUE * retval)
     }
   else
     {
-      DB_MAKE_DATETIME (retval, &datetime);
+      db_make_datetime (retval, &datetime);
     }
 
   return ptr;
@@ -2795,7 +2795,7 @@ redo:
 	  goto error;
 	}
 
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, DB_GET_STRING (&error_msg));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, db_get_string (&error_msg));
       error_code = er_errid ();
       db_value_clear (&error_msg);
     }
@@ -3026,7 +3026,7 @@ jsp_do_call_stored_procedure (DB_VALUE * returnval, DB_ARG_LIST * args, const ch
       goto error;
     }
 
-  sp_args.name = DB_GET_STRING (&method);
+  sp_args.name = db_get_string (&method);
   if (!sp_args.name)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_INVAILD_JAVA_METHOD, 0);
@@ -3042,7 +3042,7 @@ jsp_do_call_stored_procedure (DB_VALUE * returnval, DB_ARG_LIST * args, const ch
       goto error;
     }
 
-  param_cnt = DB_GET_INT (&param_cnt_val);
+  param_cnt = db_get_int (&param_cnt_val);
   arg_cnt = jsp_get_argument_count (&sp_args);
   if (param_cnt != arg_cnt)
     {
@@ -3058,12 +3058,12 @@ jsp_do_call_stored_procedure (DB_VALUE * returnval, DB_ARG_LIST * args, const ch
       goto error;
     }
 
-  param_set = DB_GET_SET (&param);
+  param_set = db_get_set (&param);
 
   for (i = 0; i < arg_cnt; i++)
     {
       set_get_element (param_set, i, &temp);
-      arg_mop_p = DB_GET_OBJECT (&temp);
+      arg_mop_p = db_get_object (&temp);
 
       err = db_get (arg_mop_p, SP_ATTR_MODE, &mode);
       if (err != NO_ERROR)
@@ -3072,7 +3072,7 @@ jsp_do_call_stored_procedure (DB_VALUE * returnval, DB_ARG_LIST * args, const ch
 	  goto error;
 	}
 
-      sp_args.arg_mode[i] = DB_GET_INT (&mode);
+      sp_args.arg_mode[i] = db_get_int (&mode);
 
       err = db_get (arg_mop_p, SP_ATTR_DATA_TYPE, &arg_type);
       if (err != NO_ERROR)
@@ -3081,7 +3081,7 @@ jsp_do_call_stored_procedure (DB_VALUE * returnval, DB_ARG_LIST * args, const ch
 	  goto error;
 	}
 
-      sp_args.arg_type[i] = DB_GET_INT (&arg_type);
+      sp_args.arg_type[i] = db_get_int (&arg_type);
       pr_clear_value (&temp);
 
       if (sp_args.arg_type[i] == DB_TYPE_RESULTSET && !is_prepare_call[call_cnt])
@@ -3098,7 +3098,7 @@ jsp_do_call_stored_procedure (DB_VALUE * returnval, DB_ARG_LIST * args, const ch
       goto error;
     }
 
-  sp_args.return_type = DB_GET_INT (&return_type);
+  sp_args.return_type = db_get_int (&return_type);
 
   if (sp_args.return_type == DB_TYPE_RESULTSET && !is_prepare_call[call_cnt])
     {

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -8670,7 +8670,7 @@ au_check_serial_authorization (MOP serial_object)
       return ret_val;
     }
 
-  creator = DB_GET_OBJECT (&creator_val);
+  creator = db_get_object (&creator_val);
 
   ret_val = ER_QPROC_CANNOT_UPDATE_SERIAL;
 

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -3851,8 +3851,7 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 			      switch (flag)
 				{
 				case 0x01:
-				  new_->filter_predicate =
-				    classobj_make_index_filter_pred_info (db_get_set (&avalue));
+				  new_->filter_predicate = classobj_make_index_filter_pred_info (db_get_set (&avalue));
 				  break;
 
 				case 0x02:

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -333,7 +333,7 @@ classobj_put_prop (DB_SEQ * properties, const char *name, DB_VALUE * pvalue)
 	  continue;
 	}
 
-      if (DB_VALUE_TYPE (&value) != DB_TYPE_STRING || (val_str = DB_GET_STRING (&value)) == NULL)
+      if (DB_VALUE_TYPE (&value) != DB_TYPE_STRING || (val_str = db_get_string (&value)) == NULL)
 	{
 	  error = ER_SM_INVALID_PROPERTY;
 	}
@@ -413,7 +413,7 @@ classobj_drop_prop (DB_SEQ * properties, const char *name)
 	  continue;
 	}
 
-      if (DB_VALUE_TYPE (&value) != DB_TYPE_STRING || (val_str = DB_GET_STRING (&value)) == NULL)
+      if (DB_VALUE_TYPE (&value) != DB_TYPE_STRING || (val_str = db_get_string (&value)) == NULL)
 	{
 	  error = ER_SM_INVALID_PROPERTY;
 	}
@@ -957,7 +957,7 @@ classobj_put_index (DB_SEQ ** properties, SM_CONSTRAINT_TYPE type, const char *c
 
   if (found)
     {
-      unique_property = DB_GET_SEQUENCE (&pvalue);
+      unique_property = db_get_set (&pvalue);
     }
   else
     {
@@ -1379,7 +1379,7 @@ classobj_put_index_id (DB_SEQ ** properties, SM_CONSTRAINT_TYPE type, const char
   found = classobj_get_prop (*properties, prop_name, &pvalue);
   if (found)
     {
-      unique_property = DB_GET_SEQUENCE (&pvalue);
+      unique_property = db_get_set (&pvalue);
     }
   else
     {
@@ -1855,14 +1855,14 @@ classobj_put_foreign_key_ref (DB_SEQ ** properties, SM_FOREIGN_KEY_INFO * fk_inf
       return er_errid ();
     }
 
-  pk_property = DB_GET_SEQUENCE (&prop_val);
+  pk_property = db_get_set (&prop_val);
   err = set_get_element (pk_property, 1, &pk_val);
   if (err != NO_ERROR)
     {
       goto end;
     }
 
-  pk_seq = DB_GET_SEQUENCE (&pk_val);
+  pk_seq = db_get_set (&pk_val);
   size = set_size (pk_seq);
 
   err = set_get_element (pk_seq, size - 2, &fk_container_val);
@@ -1873,7 +1873,7 @@ classobj_put_foreign_key_ref (DB_SEQ ** properties, SM_FOREIGN_KEY_INFO * fk_inf
 
   if (DB_VALUE_TYPE (&fk_container_val) == DB_TYPE_SEQUENCE)
     {
-      fk_container = DB_GET_SEQUENCE (&fk_container_val);
+      fk_container = db_get_set (&fk_container_val);
       fk_container_pos = set_size (fk_container);
       pk_seq_pos = size - 2;
     }
@@ -2001,14 +2001,14 @@ classobj_rename_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const 
       return err;
     }
 
-  pk_property = DB_GET_SEQUENCE (&prop_val);
+  pk_property = db_get_set (&prop_val);
   err = set_get_element (pk_property, 1, &pk_val);
   if (err != NO_ERROR)
     {
       goto end;
     }
 
-  pk_seq = DB_GET_SEQUENCE (&pk_val);
+  pk_seq = db_get_set (&pk_val);
   size = set_size (pk_seq);
 
   err = set_get_element (pk_seq, size - 2, &fk_container_val);
@@ -2019,7 +2019,7 @@ classobj_rename_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const 
 
   if (DB_VALUE_TYPE (&fk_container_val) == DB_TYPE_SEQUENCE)
     {
-      fk_container = DB_GET_SEQUENCE (&fk_container_val);
+      fk_container = db_get_set (&fk_container_val);
       fk_container_len = set_size (fk_container);
       pk_seq_pos = size - 2;
 
@@ -2035,7 +2035,7 @@ classobj_rename_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const 
 	      goto end;
 	    }
 
-	  fk_seq = DB_GET_SEQUENCE (&fk_val);
+	  fk_seq = db_get_set (&fk_val);
 
 	  /* A shallow copy for btid_val is enough. So, no need pr_clear_val(&btid_val). */
 	  err = set_get_element_nocopy (fk_seq, 1, &btid_val);
@@ -2044,7 +2044,7 @@ classobj_rename_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const 
 	      goto end;
 	    }
 
-	  if (classobj_decompose_property_oid (DB_GET_STRING (&btid_val), &volid, &fileid, &pageid) != 3)
+	  if (classobj_decompose_property_oid (db_get_string (&btid_val), &volid, &fileid, &pageid) != 3)
 	    {
 	      err = ER_SM_INVALID_PROPERTY;
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, err, 0);
@@ -2065,7 +2065,7 @@ classobj_rename_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const 
 	      goto end;
 	    }
 
-	  name = DB_GET_STRING (&name_val);
+	  name = db_get_string (&name_val);
 
 	  if (btid->vfid.volid == volid && btid->vfid.fileid == fileid && btid->root_pageid == pageid
 	      && old_name != NULL && name != NULL && SM_COMPARE_NAMES (old_name, name) == 0)
@@ -2169,14 +2169,14 @@ classobj_drop_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const ch
       return er_errid ();
     }
 
-  pk_property = DB_GET_SEQUENCE (&prop_val);
+  pk_property = db_get_set (&prop_val);
   err = set_get_element (pk_property, 1, &pk_val);
   if (err != NO_ERROR)
     {
       goto end;
     }
 
-  pk_seq = DB_GET_SEQUENCE (&pk_val);
+  pk_seq = db_get_set (&pk_val);
   fk_container_pos = set_size (pk_seq) - 2;
 
   err = set_get_element (pk_seq, fk_container_pos, &fk_container_val);
@@ -2192,7 +2192,7 @@ classobj_drop_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const ch
       goto end;
     }
 
-  fk_container = DB_GET_SEQUENCE (&fk_container_val);
+  fk_container = db_get_set (&fk_container_val);
   fk_count = set_size (fk_container);
 
   for (i = 0; i < fk_count; i++)
@@ -2203,7 +2203,7 @@ classobj_drop_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const ch
 	  goto end;
 	}
 
-      fk_seq = DB_GET_SEQUENCE (&fk_val);
+      fk_seq = db_get_set (&fk_val);
 
       err = set_get_element (fk_seq, 1, &btid_val);
       if (err != NO_ERROR)
@@ -2211,7 +2211,7 @@ classobj_drop_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const ch
 	  goto end;
 	}
 
-      if (classobj_decompose_property_oid (DB_GET_STRING (&btid_val), &volid, &fileid, &pageid) != 3)
+      if (classobj_decompose_property_oid (db_get_string (&btid_val), &volid, &fileid, &pageid) != 3)
 	{
 	  err = ER_SM_INVALID_PROPERTY;
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, err, 0);
@@ -2232,7 +2232,7 @@ classobj_drop_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const ch
 	  goto end;
 	}
 
-      cons_name = DB_GET_STRING (&cons_name_val);
+      cons_name = db_get_string (&cons_name_val);
 
       if (btid->vfid.volid == volid && btid->vfid.fileid == fileid && btid->root_pageid == pageid && name != NULL
 	  && cons_name != NULL && SM_COMPARE_NAMES (name, cons_name) == 0)
@@ -2311,7 +2311,7 @@ classobj_find_prop_constraint (DB_SEQ * properties, const char *prop_name, const
   db_make_null (&prop_val);
   if (classobj_get_prop (properties, prop_name, &prop_val) > 0)
     {
-      prop_seq = DB_GET_SEQ (&prop_val);
+      prop_seq = db_get_set (&prop_val);
       found = classobj_get_prop (prop_seq, cnstr_name, cnstr_val);
     }
 
@@ -2350,7 +2350,7 @@ classobj_rename_constraint (DB_SEQ * properties, const char *prop_name, const ch
       goto end;
     }
 
-  prop_seq = DB_GET_SEQ (&prop_val);
+  prop_seq = db_get_set (&prop_val);
   found = classobj_get_prop (prop_seq, old_name, &cnstr_val);
   if (found == 0)
     {
@@ -2416,7 +2416,7 @@ classobj_change_constraint_comment (DB_SEQ * properties, const char *prop_type, 
       goto end;
     }
 
-  prop_seq = DB_GET_SEQ (&prop_val);
+  prop_seq = db_get_set (&prop_val);
   found = classobj_get_prop (prop_seq, index_name, &cnstr_val);
   if (found == 0)
     {
@@ -2425,7 +2425,7 @@ classobj_change_constraint_comment (DB_SEQ * properties, const char *prop_type, 
       goto end;
     }
 
-  idx_seq = DB_GET_SEQ (&cnstr_val);
+  idx_seq = db_get_set (&cnstr_val);
   len = set_size (idx_seq);
 
   /* comment stands at the end of the seq */
@@ -2493,7 +2493,7 @@ classobj_btid_from_property_value (DB_VALUE * value, BTID * btid, char **shared_
       goto structure_error;
     }
 
-  btid_string = DB_GET_STRING (value);
+  btid_string = db_get_string (value);
   if (btid_string == NULL)
     {
       goto structure_error;
@@ -2547,7 +2547,7 @@ classobj_oid_from_property_value (DB_VALUE * value, OID * oid)
       goto structure_error;
     }
 
-  oid_string = DB_GET_STRING (value);
+  oid_string = db_get_string (value);
   if (oid_string == NULL)
     {
       goto structure_error;
@@ -2815,13 +2815,13 @@ classobj_cache_constraint_entry (const char *name, DB_SEQ * constraint_seq, SM_C
       if (error == NO_ERROR)
 	{
 	  att = NULL;
-	  if (DB_VALUE_TYPE (&att_val) == DB_TYPE_STRING && DB_GET_STRING (&att_val) != NULL)
+	  if (DB_VALUE_TYPE (&att_val) == DB_TYPE_STRING && db_get_string (&att_val) != NULL)
 	    {
 	      att = classobj_find_attribute (class_, db_get_string (&att_val), 0);
 	    }
 	  else if (DB_VALUE_TYPE (&att_val) == DB_TYPE_INTEGER)
 	    {
-	      att = classobj_find_attribute_id (class_, DB_GET_INTEGER (&att_val), 0);
+	      att = classobj_find_attribute_id (class_, db_get_int (&att_val), 0);
 	    }
 	  if (att != NULL)
 	    {
@@ -2918,8 +2918,8 @@ classobj_cache_constraint_list (DB_SEQ * seq, SM_CLASS * class_, SM_CONSTRAINT_T
 	{
 	  if (DB_VALUE_TYPE (&ids_val) == DB_TYPE_SEQUENCE)
 	    {
-	      ids_seq = DB_GET_SEQUENCE (&ids_val);
-	      ok = classobj_cache_constraint_entry (DB_GET_STRING (&name_val), ids_seq, class_, constraint_type);
+	      ids_seq = db_get_set (&ids_val);
+	      ok = classobj_cache_constraint_entry (db_get_string (&name_val), ids_seq, class_, constraint_type);
 	    }
 	  pr_clear_value (&ids_val);
 	}
@@ -2984,7 +2984,7 @@ classobj_cache_constraints (SM_CLASS * class_)
 	{
 	  if (DB_VALUE_TYPE (&un_value) == DB_TYPE_SEQUENCE)
 	    {
-	      un_seq = DB_GET_SEQUENCE (&un_value);
+	      un_seq = db_get_set (&un_value);
 	      ok = classobj_cache_constraint_list (un_seq, class_, Constraint_types[i]);
 	    }
 	  pr_clear_value (&un_value);
@@ -3191,13 +3191,13 @@ classobj_make_foreign_key_info (DB_SEQ * fk_seq, const char *cons_name, SM_ATTRI
     {
       goto error;
     }
-  fk_info->delete_action = (SM_FOREIGN_KEY_ACTION) DB_GET_INT (&fvalue);
+  fk_info->delete_action = (SM_FOREIGN_KEY_ACTION) db_get_int (&fvalue);
 
   if (set_get_element (fk_seq, 3, &fvalue))
     {
       goto error;
     }
-  fk_info->update_action = (SM_FOREIGN_KEY_ACTION) DB_GET_INT (&fvalue);
+  fk_info->update_action = (SM_FOREIGN_KEY_ACTION) db_get_int (&fvalue);
 
 
   fk_info->name = (char *) cons_name;
@@ -3262,19 +3262,19 @@ classobj_make_foreign_key_ref (DB_SEQ * fk_seq)
     {
       goto error;
     }
-  fk_info->delete_action = (SM_FOREIGN_KEY_ACTION) DB_GET_INT (&fvalue);
+  fk_info->delete_action = (SM_FOREIGN_KEY_ACTION) db_get_int (&fvalue);
 
   if (set_get_element (fk_seq, 3, &fvalue))
     {
       goto error;
     }
-  fk_info->update_action = (SM_FOREIGN_KEY_ACTION) DB_GET_INT (&fvalue);
+  fk_info->update_action = (SM_FOREIGN_KEY_ACTION) db_get_int (&fvalue);
 
   if (set_get_element (fk_seq, 4, &fvalue))
     {
       goto error;
     }
-  val_str = DB_GET_STRING (&fvalue);
+  val_str = db_get_string (&fvalue);
   if (val_str == NULL)
     {
       goto error;
@@ -3318,7 +3318,7 @@ classobj_make_foreign_key_ref_list (DB_SEQ * fk_container)
 	  goto error;
 	}
 
-      fk_seq = DB_GET_SEQUENCE (&fkvalue);
+      fk_seq = db_get_set (&fkvalue);
 
       fk_info = classobj_make_foreign_key_ref (fk_seq);
       if (fk_info == NULL)
@@ -3381,7 +3381,7 @@ classobj_make_index_prefix_info (DB_SEQ * prefix_seq, int num_attrs)
 	  return NULL;
 	}
 
-      prefix_length[i] = DB_GET_INT (&v);
+      prefix_length[i] = db_get_int (&v);
     }
 
   return prefix_length;
@@ -3426,8 +3426,8 @@ classobj_make_index_filter_pred_info (DB_SEQ * pred_seq)
       goto error;
     }
 
-  val_str = DB_GET_STRING (&fvalue);
-  val_str_len = DB_GET_STRING_SIZE (&fvalue);
+  val_str = db_get_string (&fvalue);
+  val_str_len = db_get_string_size (&fvalue);
   assert (val_str != NULL);
 
   filter_predicate = (SM_PREDICATE_INFO *) db_ws_alloc (sizeof (SM_PREDICATE_INFO));
@@ -3459,8 +3459,8 @@ classobj_make_index_filter_pred_info (DB_SEQ * pred_seq)
       goto error;
     }
 
-  buffer = DB_GET_STRING (&fvalue);
-  buffer_len = DB_GET_STRING_SIZE (&fvalue);
+  buffer = db_get_string (&fvalue);
+  buffer_len = db_get_string_size (&fvalue);
   filter_predicate->pred_stream = (char *) db_ws_alloc (buffer_len * sizeof (char));
   if (filter_predicate->pred_stream == NULL)
     {
@@ -3482,7 +3482,7 @@ classobj_make_index_filter_pred_info (DB_SEQ * pred_seq)
       goto error;
     }
 
-  att_seq = DB_GET_SEQUENCE (&avalue);
+  att_seq = db_get_set (&avalue);
   filter_predicate->num_attrs = att_seq_size = set_size (att_seq);
   if (att_seq_size == 0)
     {
@@ -3504,7 +3504,7 @@ classobj_make_index_filter_pred_info (DB_SEQ * pred_seq)
 	      goto error;
 	    }
 
-	  filter_predicate->att_ids[i] = DB_GET_INT (&v);
+	  filter_predicate->att_ids[i] = db_get_int (&v);
 	}
     }
 
@@ -3586,7 +3586,7 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 	    {
 	      goto structure_error;
 	    }
-	  props = DB_GET_SEQUENCE (&pvalue);
+	  props = db_get_set (&pvalue);
 	  len = set_size (props);
 
 	  /* this sequence is an alternating pair of constraint name & info sequence, as by: { name, { BTID,
@@ -3607,7 +3607,7 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 
 	      /* make a new constraint list node, the string in uvalue will become owned by the constraint so we don't
 	       * have to free it. */
-	      new_ = classobj_make_class_constraint (DB_GET_STRING (&uvalue), Constraint_types[k]);
+	      new_ = classobj_make_class_constraint (db_get_string (&uvalue), Constraint_types[k]);
 	      if (new_ == NULL)
 		{
 		  goto memory_error;
@@ -3633,7 +3633,7 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 		  goto structure_error;
 		}
 
-	      info = DB_GET_SEQUENCE (&uvalue);
+	      info = db_get_set (&uvalue);
 	      info_len = set_size (info);
 
 	      att_cnt = (info_len - 2) / 2;	/* excludes BTID and comment */
@@ -3686,11 +3686,11 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 
 		  if (DB_VALUE_TYPE (&avalue) == DB_TYPE_STRING)
 		    {
-		      att = classobj_find_attribute_list (attributes, DB_GET_STRING (&avalue), -1);
+		      att = classobj_find_attribute_list (attributes, db_get_string (&avalue), -1);
 		    }
 		  else if (DB_VALUE_TYPE (&avalue) == DB_TYPE_INTEGER)
 		    {
-		      att = classobj_find_attribute_list (attributes, NULL, DB_GET_INTEGER (&avalue));
+		      att = classobj_find_attribute_list (attributes, NULL, db_get_int (&avalue));
 		    }
 		  else
 		    {
@@ -3717,7 +3717,7 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 
 		  if (DB_VALUE_TYPE (&avalue) == DB_TYPE_INTEGER)
 		    {
-		      asc_desc[j] = DB_GET_INTEGER (&avalue);
+		      asc_desc[j] = db_get_int (&avalue);
 		      if (Constraint_types[k] == SM_CONSTRAINT_REVERSE_UNIQUE
 			  || Constraint_types[k] == SM_CONSTRAINT_REVERSE_INDEX)
 			{
@@ -3751,7 +3751,7 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 		    {
 		      goto structure_error;
 		    }
-		  fk = DB_GET_SEQUENCE (&bvalue);
+		  fk = db_get_set (&bvalue);
 
 		  new_->fk_info = classobj_make_foreign_key_info (fk, new_->name, attributes);
 		  if (new_->fk_info == NULL)
@@ -3770,7 +3770,7 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 
 		  if (DB_VALUE_TYPE (&bvalue) == DB_TYPE_SEQUENCE)
 		    {
-		      new_->fk_info = classobj_make_foreign_key_ref_list (DB_GET_SEQUENCE (&bvalue));
+		      new_->fk_info = classobj_make_foreign_key_ref_list (db_get_set (&bvalue));
 		      if (new_->fk_info == NULL)
 			{
 			  goto structure_error;
@@ -3788,7 +3788,7 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 
 		  if (DB_VALUE_TYPE (&bvalue) == DB_TYPE_SEQUENCE)
 		    {
-		      DB_SEQ *seq = DB_GET_SEQUENCE (&bvalue);
+		      DB_SEQ *seq = db_get_set (&bvalue);
 		      if (set_get_element (seq, 0, &fvalue))
 			{
 			  pr_clear_value (&bvalue);
@@ -3804,8 +3804,8 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 			}
 		      else if (DB_VALUE_TYPE (&fvalue) == DB_TYPE_SEQUENCE)
 			{
-			  DB_SET *seq = DB_GET_SEQUENCE (&bvalue);
-			  DB_SET *child_seq = DB_GET_SEQUENCE (&fvalue);
+			  DB_SET *seq = db_get_set (&bvalue);
+			  DB_SET *child_seq = db_get_set (&fvalue);
 			  int seq_size = set_size (seq);
 			  int flag;
 
@@ -3852,16 +3852,16 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 				{
 				case 0x01:
 				  new_->filter_predicate =
-				    classobj_make_index_filter_pred_info (DB_GET_SEQUENCE (&avalue));
+				    classobj_make_index_filter_pred_info (db_get_set (&avalue));
 				  break;
 
 				case 0x02:
-				  new_->func_index_info = classobj_make_function_index_info (DB_GET_SEQUENCE (&avalue));
+				  new_->func_index_info = classobj_make_function_index_info (db_get_set (&avalue));
 				  break;
 
 				case 0x03:
 				  new_->attrs_prefix_length =
-				    classobj_make_index_prefix_info (DB_GET_SEQUENCE (&avalue), att_cnt);
+				    classobj_make_index_prefix_info (db_get_set (&avalue), att_cnt);
 				  break;
 
 				default:
@@ -3887,7 +3887,7 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 				  goto structure_error;
 				}
 
-			      child_seq = DB_GET_SEQUENCE (&fvalue);
+			      child_seq = db_get_set (&fvalue);
 			    }
 
 			  if (new_->func_index_info)
@@ -3926,7 +3926,7 @@ classobj_make_class_constraints (DB_SET * class_props, SM_ATTRIBUTE * attributes
 	      else if (DB_IS_NULL (&cvalue) || DB_VALUE_TYPE (&cvalue) == DB_TYPE_STRING)
 		{
 		  /* take "cvalue == null" case into account */
-		  new_->comment = DB_GET_STRING (&cvalue);
+		  new_->comment = db_get_string (&cvalue);
 		}
 	      else
 		{
@@ -5049,7 +5049,7 @@ classobj_clear_attribute_value (DB_VALUE * value)
   if (!DB_IS_NULL (value) && TP_IS_SET_TYPE (DB_VALUE_TYPE (value)))
     {
       /* get directly to the set */
-      ref = DB_GET_SET (value);
+      ref = db_get_set (value);
       if (ref != NULL)
 	{
 	  set = ref->set;
@@ -8524,8 +8524,8 @@ classobj_make_function_index_info (DB_SEQ * func_seq)
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SM_INVALID_PROPERTY, 0);
       goto error;
     }
-  buffer = DB_GET_STRING (&val);
-  size = DB_GET_STRING_SIZE (&val);
+  buffer = db_get_string (&val);
+  size = db_get_string_size (&val);
   fi_info->expr_str = (char *) db_ws_alloc (size + 1);
   if (fi_info->expr_str == NULL)
     {
@@ -8540,8 +8540,8 @@ classobj_make_function_index_info (DB_SEQ * func_seq)
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SM_INVALID_PROPERTY, 0);
       goto error;
     }
-  buffer = DB_GET_STRING (&val);
-  fi_info->expr_stream_size = DB_GET_STRING_SIZE (&val);
+  buffer = db_get_string (&val);
+  fi_info->expr_stream_size = db_get_string_size (&val);
   fi_info->expr_stream = (char *) db_ws_alloc (fi_info->expr_stream_size);
   if (fi_info->expr_stream == NULL)
     {
@@ -8554,21 +8554,21 @@ classobj_make_function_index_info (DB_SEQ * func_seq)
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SM_INVALID_PROPERTY, 0);
       goto error;
     }
-  fi_info->col_id = DB_GET_INT (&val);
+  fi_info->col_id = db_get_int (&val);
 
   if (set_get_element_nocopy (func_seq, 3, &val) != NO_ERROR)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SM_INVALID_PROPERTY, 0);
       goto error;
     }
-  fi_info->attr_index_start = DB_GET_INT (&val);
+  fi_info->attr_index_start = db_get_int (&val);
 
   if (set_get_element_nocopy (func_seq, 4, &val) != NO_ERROR)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SM_INVALID_PROPERTY, 0);
       goto error;
     }
-  buffer = DB_GET_STRING (&val);
+  buffer = db_get_string (&val);
   ptr = buffer;
   ptr = or_unpack_domain (ptr, &(fi_info->fi_domain), NULL);
 
@@ -8686,7 +8686,7 @@ classobj_check_function_constraint_info (DB_SEQ * constraint_seq, bool * has_fun
 
   if (DB_VALUE_TYPE (&bvalue) == DB_TYPE_SEQUENCE)
     {
-      DB_SEQ *seq = DB_GET_SEQUENCE (&bvalue);
+      DB_SEQ *seq = db_get_set (&bvalue);
       if (set_get_element (seq, 0, &fvalue) != NO_ERROR)
 	{
 	  pr_clear_value (&bvalue);
@@ -8698,7 +8698,7 @@ classobj_check_function_constraint_info (DB_SEQ * constraint_seq, bool * has_fun
 	}
       else if (DB_VALUE_TYPE (&fvalue) == DB_TYPE_SEQUENCE)
 	{
-	  DB_SET *child_seq = DB_GET_SEQUENCE (&fvalue);
+	  DB_SET *child_seq = db_get_set (&fvalue);
 	  int seq_size = set_size (seq);
 
 	  j = 0;
@@ -8740,7 +8740,7 @@ classobj_check_function_constraint_info (DB_SEQ * constraint_seq, bool * has_fun
 		  goto structure_error;
 		}
 
-	      child_seq = DB_GET_SEQUENCE (&fvalue);
+	      child_seq = db_get_set (&fvalue);
 	    }
 	}
       else

--- a/src/object/object_accessor.c
+++ b/src/object/object_accessor.c
@@ -554,15 +554,15 @@ assign_set_value (MOP op, SM_ATTRIBUTE * att, char *mem, SETREF * setref)
 	    {
 	    case DB_TYPE_SET:
 	    default:
-	      DB_MAKE_SET (&val, new_set);
+	      db_make_set (&val, new_set);
 	      break;
 
 	    case DB_TYPE_MULTISET:
-	      DB_MAKE_MULTISET (&val, new_set);
+	      db_make_multiset (&val, new_set);
 	      break;
 
 	    case DB_TYPE_SEQUENCE:
-	      DB_MAKE_SEQUENCE (&val, new_set);
+	      db_make_sequence (&val, new_set);
 	      break;
 	    }
 
@@ -583,7 +583,7 @@ assign_set_value (MOP op, SM_ATTRIBUTE * att, char *mem, SETREF * setref)
 	   * remove ownership information in the current set,
 	   * need to be able to free this !!!
 	   */
-	  current_set = DB_GET_SET (&att->default_value.value);
+	  current_set = db_get_set (&att->default_value.value);
 	  if (current_set != NULL)
 	    {
 	      error = set_disconnect (current_set);
@@ -599,21 +599,21 @@ assign_set_value (MOP op, SM_ATTRIBUTE * att, char *mem, SETREF * setref)
 		    {
 		    case DB_TYPE_SET:
 		    default:
-		      DB_MAKE_SET (&att->default_value.value, new_set);
+		      db_make_set (&att->default_value.value, new_set);
 		      break;
 
 		    case DB_TYPE_MULTISET:
-		      DB_MAKE_MULTISET (&att->default_value.value, new_set);
+		      db_make_multiset (&att->default_value.value, new_set);
 		      break;
 
 		    case DB_TYPE_SEQUENCE:
-		      DB_MAKE_SEQUENCE (&att->default_value.value, new_set);
+		      db_make_sequence (&att->default_value.value, new_set);
 		      break;
 		    }
 		}
 	      else
 		{
-		  DB_MAKE_NULL (&att->default_value.value);
+		  db_make_null (&att->default_value.value);
 		}
 
 	      if (new_set != NULL)
@@ -662,11 +662,11 @@ obj_assign_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * value)
     {
       if (TP_IS_SET_TYPE (TP_DOMAIN_TYPE (att->domain)))
 	{
-	  error = assign_set_value (op, att, mem, DB_GET_SET (value));
+	  error = assign_set_value (op, att, mem, db_get_set (value));
 	}
       else
 	{
-	  if (att->domain->type == tp_Type_object && !op->is_vid && (mop = DB_GET_OBJECT (value))
+	  if (att->domain->type == tp_Type_object && !op->is_vid && (mop = db_get_object (value))
 	      && WS_MOP_IS_NULL (mop))
 	    {
 	      error = assign_null_value (op, att, mem);
@@ -732,7 +732,7 @@ obj_set_att (MOP op, SM_CLASS * class_, SM_ATTRIBUTE * att, DB_VALUE * value, SM
   MOBJ obj, ref_obj;
   MOP class_mop = NULL;
 
-  DB_MAKE_NULL (&base_value);
+  db_make_null (&base_value);
 
   if (op->is_temp)
     {
@@ -1085,17 +1085,17 @@ get_object_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * source, DB_V
   current = NULL;
   if (mem != NULL)
     {
-      DB_MAKE_OBJECT (&curval, NULL);
+      db_make_object (&curval, NULL);
       if (PRIM_GETMEM (att->domain->type, att->domain, mem, &curval))
 	{
 	  ASSERT_ERROR_AND_SET (rc);
 	  return rc;
 	}
-      current = DB_GET_OBJECT (&curval);
+      current = db_get_object (&curval);
     }
   else if (TP_DOMAIN_TYPE (att->domain) == DB_VALUE_TYPE (source))
     {
-      current = DB_GET_OBJECT (source);
+      current = db_get_object (source);
     }
 
   /* check for existence of the object this is expensive so only do this if enabled by a parameter. */
@@ -1134,7 +1134,7 @@ get_object_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * source, DB_V
   if (current != NULL && WS_IS_DELETED (current))
     {
       /* convert deleted MOPs to NULL values */
-      DB_MAKE_NULL (dest);
+      db_make_null (dest);
 
       /* 
        * set the attribute value so we don't hit this condition again,
@@ -1155,7 +1155,7 @@ get_object_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * source, DB_V
 	    }
 	  else
 	    {
-	      DB_MAKE_NULL (source);
+	      db_make_null (source);
 	    }
 	}
     }
@@ -1163,11 +1163,11 @@ get_object_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * source, DB_V
     {
       if (current != NULL)
 	{
-	  DB_MAKE_OBJECT (dest, current);
+	  db_make_object (dest, current);
 	}
       else
 	{
-	  DB_MAKE_NULL (dest);
+	  db_make_null (dest);
 	}
     }
 
@@ -1221,7 +1221,7 @@ get_set_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * source, DB_VALU
 	  assert (er_errid () != NO_ERROR);
 	  return er_errid ();
 	}
-      set = DB_GET_SET (&setval);
+      set = db_get_set (&setval);
       db_value_put_null (&setval);
     }
   else
@@ -1239,7 +1239,7 @@ get_set_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * source, DB_VALU
 	}
       if (TP_DOMAIN_TYPE (att->domain) == DB_VALUE_TYPE (source))
 	{
-	  set = DB_GET_SET (source);
+	  set = db_get_set (source);
 	  /* KLUDGE: shouldn't be doing this at this level */
 	  if (set != NULL)
 	    {
@@ -1264,7 +1264,7 @@ get_set_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * source, DB_VALU
   /* convert NULL sets to DB_TYPE_NULL */
   if (set == NULL)
     {
-      DB_MAKE_NULL (dest);
+      db_make_null (dest);
     }
   else
     {
@@ -1272,15 +1272,15 @@ get_set_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * source, DB_VALU
 	{
 	case DB_TYPE_SET:
 	default:
-	  DB_MAKE_SET (dest, set);
+	  db_make_set (dest, set);
 	  break;
 
 	case DB_TYPE_MULTISET:
-	  DB_MAKE_MULTISET (dest, set);
+	  db_make_multiset (dest, set);
 	  break;
 
 	case DB_TYPE_SEQUENCE:
-	  DB_MAKE_SEQUENCE (dest, set);
+	  db_make_sequence (dest, set);
 	  break;
 	}
     }
@@ -1330,7 +1330,7 @@ obj_get_value (MOP op, SM_ATTRIBUTE * att, void *mem, DB_VALUE * source, DB_VALU
   /* first check the bound bits */
   if (!att->domain->type->variable_p && mem != NULL && OBJ_GET_BOUND_BIT (object, att->storage_order) == 0)
     {
-      DB_MAKE_NULL (dest);
+      db_make_null (dest);
     }
   else
     {
@@ -1597,7 +1597,7 @@ obj_get_path (DB_OBJECT * object, const char *attpath, DB_VALUE * value)
   error = NO_ERROR;
   (void) strcpy (&buf[0], attpath);
   delimiter = '.';		/* start with implicit dot */
-  DB_MAKE_OBJECT (&temp_value, object);
+  db_make_object (&temp_value, object);
   for (token = &buf[0]; char_isspace (*token) && *token != '\0'; token++);
   end = token;
 
@@ -1631,7 +1631,7 @@ obj_get_path (DB_OBJECT * object, const char *attpath, DB_VALUE * value)
 		}
 	      else
 		{
-		  error = obj_get (DB_GET_OBJECT (&temp_value), token, &temp_value);
+		  error = obj_get (db_get_object (&temp_value), token, &temp_value);
 		}
 	    }
 	}
@@ -1660,11 +1660,11 @@ obj_get_path (DB_OBJECT * object, const char *attpath, DB_VALUE * value)
 		  index = atoi (token);
 		  if (temp_type == DB_TYPE_SEQUENCE)
 		    {
-		      error = db_seq_get (DB_GET_SET (&temp_value), index, &temp_value);
+		      error = db_seq_get (db_get_set (&temp_value), index, &temp_value);
 		    }
 		  else
 		    {
-		      error = db_set_get (DB_GET_SET (&temp_value), index, &temp_value);
+		      error = db_set_get (db_get_set (&temp_value), index, &temp_value);
 		    }
 
 		  if (error == NO_ERROR)
@@ -1780,7 +1780,7 @@ obj_get_temp (DB_OBJECT * obj, SM_CLASS * class_, SM_ATTRIBUTE * att, DB_VALUE *
 	       * there was no base object so we must be performing an insertion,
 	       * in this case, the value is considered to be NULL
 	       */
-	      DB_MAKE_NULL (value);
+	      db_make_null (value);
 	    }
 	}
     }
@@ -1990,7 +1990,7 @@ obj_copy (MOP op)
   DB_VALUE value;
 
   new_mop = NULL;
-  DB_MAKE_NULL (&value);
+  db_make_null (&value);
 
   /* op must be an object */
   if (op != NULL)
@@ -2431,7 +2431,7 @@ call_method (METHOD_FUNCTION method, MOP obj, DB_VALUE * returnval, int nargs, D
     }
 
   if (!forge_flag_pat)
-    DB_MAKE_NULL (returnval);
+    db_make_null (returnval);
   switch (nargs)
     {
     case 0:
@@ -2613,7 +2613,7 @@ call_method (METHOD_FUNCTION method, MOP obj, DB_VALUE * returnval, int nargs, D
   if (!forge_flag_pat)
     if (DB_VALUE_TYPE (returnval) == DB_TYPE_ERROR)
       {
-	error = DB_GET_ERROR (returnval);
+	error = db_get_error (returnval);
 	if (error >= 0)
 	  {
 	    /* it's not a system error, it's a user error */
@@ -3494,7 +3494,7 @@ flush_temporary_OID (MOP classop, DB_VALUE * key)
 {
   MOP mop;
 
-  mop = DB_GET_OBJECT (key);
+  mop = db_get_object (key);
   if (mop == NULL || WS_ISVID (mop))
     {
       /* if this is a virtual object, we don't support that */
@@ -3649,7 +3649,7 @@ obj_make_key_value (DB_VALUE * key, const DB_VALUE * values[], int size)
 	  return NULL;
 	}
 
-      DB_MAKE_SEQUENCE (key, mc_seq);
+      db_make_sequence (key, mc_seq);
     }
 
   return key;
@@ -3684,7 +3684,7 @@ obj_find_multi_attr (MOP op, int size, const char *attr_names[], const DB_VALUE 
       return NULL;
     }
 
-  DB_MAKE_NULL (&key);
+  db_make_null (&key);
   if (obj_make_key_value (&key, values, size) == NULL)
     {
       return NULL;
@@ -3771,7 +3771,7 @@ obj_find_multi_desc (MOP op, int size, const SM_DESCRIPTOR * desc[], const DB_VA
       return NULL;
     }
 
-  DB_MAKE_NULL (&key);
+  db_make_null (&key);
   if (obj_make_key_value (&key, values, size) == NULL)
     {
       return NULL;
@@ -3925,7 +3925,7 @@ obj_find_object_by_cons_and_key (MOP classop, SM_CLASS_CONSTRAINT * cons, DB_VAL
   else
     {
       /* multi column */
-      keyset = DB_GET_SEQUENCE (key);
+      keyset = db_get_set (key);
       if (keyset == NULL)
 	return NULL;
 
@@ -4046,7 +4046,7 @@ obj_find_primary_key (MOP op, const DB_VALUE ** values, int size, AU_FETCHMODE f
 	      goto notfound;
 	    }
 	}
-      DB_MAKE_SEQUENCE (&tmp, mc_seq);
+      db_make_sequence (&tmp, mc_seq);
       key = &tmp;
     }
 
@@ -4123,7 +4123,7 @@ obj_find_object_by_pkey (MOP classop, DB_VALUE * key, AU_FETCHMODE fetchmode)
     }
   else if (value_type == DB_TYPE_OBJECT)
     {
-      mop = DB_GET_OBJECT (key);
+      mop = db_get_object (key);
       if (mop == NULL || WS_ISVID (mop))
 	{
 	  /* if this is a virtual object, we don't support that */

--- a/src/object/object_accessor.c
+++ b/src/object/object_accessor.c
@@ -2292,7 +2292,8 @@ argstate_from_list (ARGSTATE * state, DB_VALUE_LIST * arglist)
   state->overflow = arg;
   state->free_overflow = 0;
   state->save_overflow = NULL;
-  for (i = 0; arg != NULL; arg = arg->next, i++);
+  for (i = 0; arg != NULL; arg = arg->next, i++)
+    ;
   state->noverflow = i;
 }
 
@@ -2327,7 +2328,8 @@ argstate_from_array (ARGSTATE * state, DB_VALUE ** argarray)
 	}
       state->nargs = i;
       /* need to handle overflow arguments ! */
-      for (j = 0; argarray[i] != NULL; i++, j++);
+      for (j = 0; argarray[i] != NULL; i++, j++)
+	;
       state->noverflow = j;
     }
 }
@@ -2431,7 +2433,10 @@ call_method (METHOD_FUNCTION method, MOP obj, DB_VALUE * returnval, int nargs, D
     }
 
   if (!forge_flag_pat)
-    db_make_null (returnval);
+    {
+      db_make_null (returnval);
+    }
+
   switch (nargs)
     {
     case 0:

--- a/src/object/object_accessor.c
+++ b/src/object/object_accessor.c
@@ -1347,17 +1347,17 @@ obj_get_value (MOP op, SM_ATTRIBUTE * att, void *mem, DB_VALUE * source, DB_VALU
 	  if (mem != NULL)
 	    {
 	      error = PRIM_GETMEM (att->domain->type, att->domain, mem, dest);
-	      if (!error)
-		{
-		  OBJ_FORCE_SIMPLE_NULL_TO_UNBOUND (dest);
-		}
 	    }
 	  else
 	    {
 	      error = pr_clone_value (source, dest);
-	      if (!error)
+	    }
+
+	  if (error == NO_ERROR)
+	    {
+	      if (DB_VALUE_TYPE (dest) == DB_TYPE_STRING && db_get_string (dest) == NULL)
 		{
-		  OBJ_FORCE_SIMPLE_NULL_TO_UNBOUND (dest);
+		  db_make_null (dest);
 		}
 	    }
 	}

--- a/src/object/object_accessor.h
+++ b/src/object/object_accessor.h
@@ -50,25 +50,25 @@
 
 #define OBJ_FORCE_NULL_TO_UNBOUND(dbvalue) \
   if ((DB_VALUE_TYPE(dbvalue) == DB_TYPE_STRING && \
-       DB_GET_STRING(dbvalue) == NULL) || \
+       db_get_string(dbvalue) == NULL) || \
       (TP_IS_SET_TYPE (DB_VALUE_TYPE(dbvalue)) && \
-       DB_GET_SET(dbvalue) == NULL) || \
+       db_get_set(dbvalue) == NULL) || \
       (DB_VALUE_TYPE(dbvalue) == DB_TYPE_OBJECT && \
-       DB_GET_OBJECT(dbvalue) == NULL) || \
+       db_get_object(dbvalue) == NULL) || \
       (DB_VALUE_TYPE(dbvalue) == DB_TYPE_BLOB && \
-       DB_GET_ELO(dbvalue) == NULL) || \
+       db_get_elo(dbvalue) == NULL) || \
       (DB_VALUE_TYPE(dbvalue) == DB_TYPE_CLOB && \
-       DB_GET_ELO(dbvalue) == NULL) || \
+       db_get_elo(dbvalue) == NULL) || \
       (DB_VALUE_TYPE(dbvalue) == DB_TYPE_ELO && \
-       DB_GET_ELO(dbvalue) == NULL)) \
-  DB_MAKE_NULL(dbvalue);
+       db_get_elo(dbvalue) == NULL)) \
+  db_make_null(dbvalue);
 
 
 
 #define OBJ_FORCE_SIMPLE_NULL_TO_UNBOUND(dbvalue) \
   if ((DB_VALUE_TYPE(dbvalue) == DB_TYPE_STRING) && \
-      (DB_GET_STRING(dbvalue) == NULL)) \
-  DB_MAKE_NULL(dbvalue);
+      (db_get_string(dbvalue) == NULL)) \
+  db_make_null(dbvalue);
 
 
 /*

--- a/src/object/object_accessor.h
+++ b/src/object/object_accessor.h
@@ -40,38 +40,6 @@
 #include "authenticate.h"
 
 /*
- * OBJ_FORCE_NULL_TO_UNBOUND
- *
- * Note:
- *    Macro to convert a DB_VALUE structure that contains a logical NULL
- *    value into one with DB_TYPE_NULL.
- *
- */
-
-#define OBJ_FORCE_NULL_TO_UNBOUND(dbvalue) \
-  if ((DB_VALUE_TYPE(dbvalue) == DB_TYPE_STRING && \
-       db_get_string(dbvalue) == NULL) || \
-      (TP_IS_SET_TYPE (DB_VALUE_TYPE(dbvalue)) && \
-       db_get_set(dbvalue) == NULL) || \
-      (DB_VALUE_TYPE(dbvalue) == DB_TYPE_OBJECT && \
-       db_get_object(dbvalue) == NULL) || \
-      (DB_VALUE_TYPE(dbvalue) == DB_TYPE_BLOB && \
-       db_get_elo(dbvalue) == NULL) || \
-      (DB_VALUE_TYPE(dbvalue) == DB_TYPE_CLOB && \
-       db_get_elo(dbvalue) == NULL) || \
-      (DB_VALUE_TYPE(dbvalue) == DB_TYPE_ELO && \
-       db_get_elo(dbvalue) == NULL)) \
-  db_make_null(dbvalue);
-
-
-
-#define OBJ_FORCE_SIMPLE_NULL_TO_UNBOUND(dbvalue) \
-  if ((DB_VALUE_TYPE(dbvalue) == DB_TYPE_STRING) && \
-      (db_get_string(dbvalue) == NULL)) \
-  db_make_null(dbvalue);
-
-
-/*
  *
  *       		      OBJECT HEADER FIELDS
  *

--- a/src/object/object_description.cpp
+++ b/src/object/object_description.cpp
@@ -84,10 +84,10 @@ int object_description::init (struct db_object *op)
   string_buffer sb;
   db_value_printer printer (sb);
 
-  DB_MAKE_OBJECT (&value, op);
+  db_make_object (&value, op);
   printer.describe_data (&value);
   db_value_clear (&value);
-  DB_MAKE_NULL (&value);
+  db_make_null (&value);
 
   this->oid = sb.move_ptr ();
 

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -8075,7 +8075,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	}
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       switch (original_type)
 	{
 	case DB_TYPE_VARCHAR:
@@ -8468,7 +8468,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 
-	case DB_TYPE_UTIME:
+	case DB_TYPE_TIMESTAMP:
 	case DB_TYPE_TIMESTAMPLTZ:
 	  v_utime = *db_get_timestamp (src);
 	  if (db_timestamp_decode_ses (&v_utime, &v_date, &v_time) != NO_ERROR)
@@ -8565,7 +8565,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 
-	case DB_TYPE_UTIME:
+	case DB_TYPE_TIMESTAMP:
 	case DB_TYPE_TIMESTAMPLTZ:
 	  v_utime = *db_get_timestamp (src);
 
@@ -8653,7 +8653,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 
-	case DB_TYPE_UTIME:
+	case DB_TYPE_TIMESTAMP:
 	case DB_TYPE_TIMESTAMPLTZ:
 	  {
 	    v_utime = *db_get_timestamp (src);
@@ -8758,9 +8758,9 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 
-	case DB_TYPE_UTIME:
+	case DB_TYPE_TIMESTAMP:
 	case DB_TYPE_TIMESTAMPLTZ:
-	  (void) db_timestamp_decode_ses (db_get_utime (src), &v_date, NULL);
+	  (void) db_timestamp_decode_ses (db_get_timestamp (src), &v_date, NULL);
 	  db_date_decode (&v_date, &month, &day, &year);
 	  db_make_date (target, month, day, year);
 	  break;
@@ -8854,9 +8854,9 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	  break;
 
-	case DB_TYPE_UTIME:
+	case DB_TYPE_TIMESTAMP:
 	case DB_TYPE_TIMESTAMPLTZ:
-	  if (db_timestamp_decode_ses (db_get_utime (src), NULL, &v_time) != NO_ERROR)
+	  if (db_timestamp_decode_ses (db_get_timestamp (src), NULL, &v_time) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
 	      break;
@@ -9028,12 +9028,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  /* copy time value (UTC) */
 	  db_make_timeltz (target, &v_timetz.time);
 	  break;
-	case DB_TYPE_UTIME:
-	  db_timestamp_decode_utc (db_get_utime (src), NULL, &v_time);
+	case DB_TYPE_TIMESTAMP:
+	  db_timestamp_decode_utc (db_get_timestamp (src), NULL, &v_time);
 	  db_make_timeltz (target, &v_time);
 	  break;
 	case DB_TYPE_TIMESTAMPLTZ:
-	  db_timestamp_decode_utc (db_get_utime (src), NULL, &v_time);
+	  db_timestamp_decode_utc (db_get_timestamp (src), NULL, &v_time);
 	  db_make_timeltz (target, &v_time);
 	  break;
 	case DB_TYPE_TIMESTAMPTZ:
@@ -9151,10 +9151,10 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  tz_tzid_convert_region_to_offset (&v_timetz.tz_id);
 	  db_make_timetz (target, &v_timetz);
 	  break;
-	case DB_TYPE_UTIME:
+	case DB_TYPE_TIMESTAMP:
 	case DB_TYPE_TIMESTAMPLTZ:
 	  {
-	    db_timestamp_decode_utc (db_get_utime (src), NULL, &v_time);
+	    db_timestamp_decode_utc (db_get_timestamp (src), NULL, &v_time);
 	    if (tz_create_session_tzid_for_time (&v_time, true, &v_timetz.tz_id) != NO_ERROR)
 	      {
 		status = DOMAIN_ERROR;
@@ -10213,7 +10213,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		val_idx = (unsigned short) floor (v_money->amount);
 	      }
 	    break;
-	  case DB_TYPE_UTIME:
+	  case DB_TYPE_TIMESTAMP:
 	  case DB_TYPE_TIMESTAMPLTZ:
 	  case DB_TYPE_TIMESTAMPTZ:
 	  case DB_TYPE_DATETIME:

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -4280,7 +4280,7 @@ tp_domain_select (const TP_DOMAIN * domain_list, const DB_VALUE * value, int all
       int val_idx, dom_size, val_size;
       char *dom_str = NULL, *val_str = NULL;
 
-      if ((db_get_enum_short (value) == 0 && db_get_enum_string (value) != NULL))
+      if (db_get_enum_short (value) == 0 && db_get_enum_string (value) != NULL)
 	{
 	  /* An enumeration should be NULL or should at least have an index */
 	  assert (false);
@@ -8177,7 +8177,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  if (status == DOMAIN_COMPATIBLE)
 	    {
 	      int tmpint;
-	      if ((tmpint = db_get_int (target)) >= 0)
+	      tmpint = db_get_int (target);
+	      if (tmpint >= 0)
 		{
 		  db_make_timestamp (target, (DB_UTIME) tmpint);
 		}
@@ -8425,7 +8426,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  if (status == DOMAIN_COMPATIBLE)
 	    {
 	      int tmpint;
-	      if ((tmpint = db_get_int (target)) >= 0)
+	      tmpint = db_get_int (target);
+	      if (tmpint >= 0)
 		{
 		  db_make_timestampltz (target, (DB_UTIME) tmpint);
 		}

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -3221,7 +3221,7 @@ tp_domain_resolve_value (DB_VALUE * val, TP_DOMAIN * dbuf)
       DB_MIDXKEY *midxkey;
 
       /* For midxkey type, return the domain attached to the value */
-      midxkey = DB_GET_MIDXKEY (val);
+      midxkey = db_get_midxkey (val);
       if (midxkey != NULL)
 	{
 	  domain = midxkey->domain;
@@ -4241,7 +4241,7 @@ tp_domain_select (const TP_DOMAIN * domain_list, const DB_VALUE * value, int all
        */
       DB_OTMPL *val_tmpl;
 
-      val_tmpl = (DB_OTMPL *) DB_GET_POINTER (value);
+      val_tmpl = (DB_OTMPL *) db_get_pointer (value);
       if (val_tmpl)
 	{
 	  for (d = (TP_DOMAIN *) domain_list; d != NULL && best == NULL; d = d->next)
@@ -4280,7 +4280,7 @@ tp_domain_select (const TP_DOMAIN * domain_list, const DB_VALUE * value, int all
       int val_idx, dom_size, val_size;
       char *dom_str = NULL, *val_str = NULL;
 
-      if ((DB_GET_ENUM_SHORT (value) == 0 && DB_GET_ENUM_STRING (value) != NULL))
+      if ((db_get_enum_short (value) == 0 && db_get_enum_string (value) != NULL))
 	{
 	  /* An enumeration should be NULL or should at least have an index */
 	  assert (false);
@@ -4288,10 +4288,10 @@ tp_domain_select (const TP_DOMAIN * domain_list, const DB_VALUE * value, int all
 	  return NULL;
 	}
 
-      val_idx = DB_GET_ENUM_SHORT (value);
+      val_idx = db_get_enum_short (value);
 
-      val_str = DB_GET_ENUM_STRING (value);
-      val_size = DB_GET_ENUM_STRING_SIZE (value);
+      val_str = db_get_enum_string (value);
+      val_size = db_get_enum_string_size (value);
 
       for (d = (TP_DOMAIN *) domain_list; d != NULL && best == NULL; d = d->next)
 	{
@@ -4325,7 +4325,7 @@ tp_domain_select (const TP_DOMAIN * domain_list, const DB_VALUE * value, int all
 	      break;
 	    }
 
-	  if (DB_GET_ENUM_COLLATION (value) != d->collation_id)
+	  if (db_get_enum_collation (value) != d->collation_id)
 	    {
 	      continue;
 	    }
@@ -4576,8 +4576,8 @@ tp_can_steal_string (const DB_VALUE * val, const DB_DOMAIN * desired_domain)
       return 0;
     }
 
-  original_length = DB_GET_STRING_LENGTH (val);
-  original_size = DB_GET_STRING_SIZE (val);
+  original_length = db_get_string_length (val);
+  original_size = db_get_string_size (val);
   desired_type = TP_DOMAIN_TYPE (desired_domain);
   desired_precision = desired_domain->precision;
 
@@ -4591,14 +4591,14 @@ tp_can_steal_string (const DB_VALUE * val, const DB_DOMAIN * desired_domain)
   if (TP_IS_CHAR_TYPE (original_type) && TP_IS_CHAR_TYPE (TP_DOMAIN_TYPE (desired_domain)))
     {
       if (desired_domain->collation_flag != TP_DOMAIN_COLL_LEAVE
-	  && DB_GET_STRING_COLLATION (val) != TP_DOMAIN_COLLATION (desired_domain)
-	  && !LANG_IS_COERCIBLE_COLL (DB_GET_STRING_COLLATION (val)))
+	  && db_get_string_collation (val) != TP_DOMAIN_COLLATION (desired_domain)
+	  && !LANG_IS_COERCIBLE_COLL (db_get_string_collation (val)))
 	{
 	  return 0;
 	}
 
       if (desired_domain->collation_flag != TP_DOMAIN_COLL_LEAVE
-	  && !INTL_CAN_STEAL_CS (DB_GET_STRING_CODESET (val), TP_DOMAIN_CODESET (desired_domain)))
+	  && !INTL_CAN_STEAL_CS (db_get_string_codeset (val), TP_DOMAIN_CODESET (desired_domain)))
 	{
 	  return 0;
 	}
@@ -4660,13 +4660,13 @@ tp_null_terminate (const DB_VALUE * src, char **strp, int str_len, bool * do_all
 
   *do_alloc = false;		/* init */
 
-  str = DB_GET_STRING (src);
+  str = db_get_string (src);
   if (str == NULL)
     {
       return ER_FAILED;
     }
 
-  str_size = DB_GET_STRING_SIZE (src);
+  str_size = db_get_string_size (src);
 
   if (str[str_size] == '\0')
     {
@@ -4708,8 +4708,8 @@ static int
 tp_atotime (const DB_VALUE * src, DB_TIME * temp)
 {
   int milisec;
-  char *strp = DB_GET_STRING (src);
-  int str_len = DB_GET_STRING_SIZE (src);
+  char *strp = db_get_string (src);
+  int str_len = db_get_string_size (src);
   int status = NO_ERROR;
 
   if (db_date_parse_time (strp, str_len, temp, &milisec) != NO_ERROR)
@@ -4735,8 +4735,8 @@ tp_atotime (const DB_VALUE * src, DB_TIME * temp)
 static int
 tp_atotimetz (const DB_VALUE * src, DB_TIMETZ * temp, bool to_timeltz)
 {
-  char *strp = DB_GET_STRING (src);
-  int str_len = DB_GET_STRING_SIZE (src);
+  char *strp = db_get_string (src);
+  int str_len = db_get_string_size (src);
   int status = NO_ERROR;
   bool dummy_has_zone;
 
@@ -4760,8 +4760,8 @@ tp_atotimetz (const DB_VALUE * src, DB_TIMETZ * temp, bool to_timeltz)
 static int
 tp_atodate (const DB_VALUE * src, DB_DATE * temp)
 {
-  char *strp = DB_GET_STRING (src);
-  int str_len = DB_GET_STRING_SIZE (src);
+  char *strp = db_get_string (src);
+  int str_len = db_get_string_size (src);
   int status = NO_ERROR;
 
   if (db_date_parse_date (strp, str_len, temp) != NO_ERROR)
@@ -4784,8 +4784,8 @@ tp_atodate (const DB_VALUE * src, DB_DATE * temp)
 static int
 tp_atoutime (const DB_VALUE * src, DB_UTIME * temp)
 {
-  char *strp = DB_GET_STRING (src);
-  int str_len = DB_GET_STRING_SIZE (src);
+  char *strp = db_get_string (src);
+  int str_len = db_get_string_size (src);
   int status = NO_ERROR;
 
   if (db_date_parse_utime (strp, str_len, temp) != NO_ERROR)
@@ -4808,8 +4808,8 @@ tp_atoutime (const DB_VALUE * src, DB_UTIME * temp)
 static int
 tp_atotimestamptz (const DB_VALUE * src, DB_TIMESTAMPTZ * temp)
 {
-  char *strp = DB_GET_STRING (src);
-  int str_len = DB_GET_STRING_SIZE (src);
+  char *strp = db_get_string (src);
+  int str_len = db_get_string_size (src);
   int status = NO_ERROR;
   bool dummy_has_zone;
 
@@ -4833,8 +4833,8 @@ tp_atotimestamptz (const DB_VALUE * src, DB_TIMESTAMPTZ * temp)
 static int
 tp_atoudatetime (const DB_VALUE * src, DB_DATETIME * temp)
 {
-  char *strp = DB_GET_STRING (src);
-  int str_len = DB_GET_STRING_SIZE (src);
+  char *strp = db_get_string (src);
+  int str_len = db_get_string_size (src);
   int status = NO_ERROR;
 
   if (db_date_parse_datetime (strp, str_len, temp) != NO_ERROR)
@@ -4857,8 +4857,8 @@ tp_atoudatetime (const DB_VALUE * src, DB_DATETIME * temp)
 static int
 tp_atodatetimetz (const DB_VALUE * src, DB_DATETIMETZ * temp)
 {
-  char *strp = DB_GET_STRING (src);
-  int str_len = DB_GET_STRING_SIZE (src);
+  char *strp = db_get_string (src);
+  int str_len = db_get_string_size (src);
   int status = NO_ERROR;
   bool dummy_has_zone;
 
@@ -4892,9 +4892,9 @@ tp_atonumeric (const DB_VALUE * src, DB_VALUE * temp)
       return ER_FAILED;
     }
 
-  str_len = DB_GET_STRING_SIZE (src);
+  str_len = db_get_string_size (src);
 
-  if (numeric_coerce_string_to_num (strp, str_len, DB_GET_STRING_CODESET (src), temp) != NO_ERROR)
+  if (numeric_coerce_string_to_num (strp, str_len, db_get_string_codeset (src), temp) != NO_ERROR)
     {
       status = ER_FAILED;
     }
@@ -4929,9 +4929,9 @@ tp_atof (const DB_VALUE * src, double *num_value, DB_DATA_STATUS * data_stat)
 
   *data_stat = DATA_STATUS_OK;
 
-  p = DB_GET_STRING (src);
-  size = DB_GET_STRING_SIZE (src);
-  codeset = DB_GET_STRING_CODESET (src);
+  p = db_get_string (src);
+  size = db_get_string_size (src);
+  codeset = db_get_string_codeset (src);
   end = p + size - 1;
 
   if (0 < size && *end)
@@ -5015,12 +5015,12 @@ tp_atof (const DB_VALUE * src, double *num_value, DB_DATA_STATUS * data_stat)
 static int
 tp_atobi (const DB_VALUE * src, DB_BIGINT * num_value, DB_DATA_STATUS * data_stat)
 {
-  char *strp = DB_GET_STRING (src);
+  char *strp = db_get_string (src);
   char *stre = NULL;
   char *p = NULL, *old_p = NULL;
   int status = NO_ERROR;
   bool is_negative = false;
-  INTL_CODESET codeset = DB_GET_STRING_CODESET (src);
+  INTL_CODESET codeset = db_get_string_codeset (src);
   bool is_hex = false, is_scientific = false;
   bool has_leading_zero = false;
 
@@ -5029,7 +5029,7 @@ tp_atobi (const DB_VALUE * src, DB_BIGINT * num_value, DB_DATA_STATUS * data_sta
       return ER_FAILED;
     }
 
-  stre = strp + DB_GET_STRING_SIZE (src);
+  stre = strp + db_get_string_size (src);
 
   /* skip leading spaces */
   while (strp != stre && char_isspace (*strp))
@@ -5472,12 +5472,12 @@ tp_ftoa (DB_VALUE const *src, DB_VALUE * result)
   rve = str_float = (char *) db_private_alloc (NULL, TP_FLOAT_AS_CHAR_LENGTH + 1);
   if (str_float == NULL)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return;
     }
 
   /* _dtoa just returns the digits sequence and the exponent as for a number in the form 0.4321344e+14 */
-  _dtoa (DB_GET_FLOAT (src), 0, ndigits, &decpt, &sign, &rve, str_float, 1);
+  _dtoa (db_get_float (src), 0, ndigits, &decpt, &sign, &rve, str_float, 1);
 
   /* rounding should also be performed here */
   str_float[ndigits] = '\0';	/* _dtoa() disregards ndigits */
@@ -5487,26 +5487,26 @@ tp_ftoa (DB_VALUE const *src, DB_VALUE * result)
   switch (DB_VALUE_DOMAIN_TYPE (result))
     {
     case DB_TYPE_CHAR:
-      DB_MAKE_CHAR (result, DB_VALUE_PRECISION (result), str_float, strlen (str_float), DB_GET_STRING_CODESET (result),
-		    DB_GET_STRING_COLLATION (result));
+      db_make_char (result, DB_VALUE_PRECISION (result), str_float, strlen (str_float), db_get_string_codeset (result),
+		    db_get_string_collation (result));
       result->need_clear = true;
       break;
 
     case DB_TYPE_NCHAR:
-      DB_MAKE_NCHAR (result, DB_VALUE_PRECISION (result), str_float, strlen (str_float), DB_GET_STRING_CODESET (result),
-		     DB_GET_STRING_COLLATION (result));
+      db_make_nchar (result, DB_VALUE_PRECISION (result), str_float, strlen (str_float), db_get_string_codeset (result),
+		     db_get_string_collation (result));
       result->need_clear = true;
       break;
 
     case DB_TYPE_VARCHAR:
-      DB_MAKE_VARCHAR (result, DB_VALUE_PRECISION (result), str_float, strlen (str_float),
-		       DB_GET_STRING_CODESET (result), DB_GET_STRING_COLLATION (result));
+      db_make_varchar (result, DB_VALUE_PRECISION (result), str_float, strlen (str_float),
+		       db_get_string_codeset (result), db_get_string_collation (result));
       result->need_clear = true;
       break;
 
     case DB_TYPE_VARNCHAR:
-      DB_MAKE_VARNCHAR (result, DB_VALUE_PRECISION (result), str_float, strlen (str_float),
-			DB_GET_STRING_CODESET (result), DB_GET_STRING_COLLATION (result));
+      db_make_varnchar (result, DB_VALUE_PRECISION (result), str_float, strlen (str_float),
+			db_get_string_codeset (result), db_get_string_collation (result));
       result->need_clear = true;
       break;
 
@@ -5514,7 +5514,7 @@ tp_ftoa (DB_VALUE const *src, DB_VALUE * result)
       db_private_free_and_init (NULL, str_float);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2, pr_type_name (DB_VALUE_DOMAIN_TYPE (src)),
 	      pr_type_name (DB_VALUE_DOMAIN_TYPE (result)));
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       break;
     }
 }
@@ -5543,11 +5543,11 @@ tp_dtoa (DB_VALUE const *src, DB_VALUE * result)
   rve = str_double = (char *) db_private_alloc (NULL, TP_DOUBLE_AS_CHAR_LENGTH + 1);
   if (str_double == NULL)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return;
     }
 
-  _dtoa (DB_GET_DOUBLE (src), 0, ndigits, &decpt, &sign, &rve, str_double, 0);
+  _dtoa (db_get_double (src), 0, ndigits, &decpt, &sign, &rve, str_double, 0);
   /* rounding should also be performed here */
   str_double[ndigits] = '\0';	/* _dtoa() disregards ndigits */
 
@@ -5556,26 +5556,26 @@ tp_dtoa (DB_VALUE const *src, DB_VALUE * result)
   switch (DB_VALUE_DOMAIN_TYPE (result))
     {
     case DB_TYPE_CHAR:
-      DB_MAKE_CHAR (result, DB_VALUE_PRECISION (result), str_double, strlen (str_double),
-		    DB_GET_STRING_CODESET (result), DB_GET_STRING_COLLATION (result));
+      db_make_char (result, DB_VALUE_PRECISION (result), str_double, strlen (str_double),
+		    db_get_string_codeset (result), db_get_string_collation (result));
       result->need_clear = true;
       break;
 
     case DB_TYPE_NCHAR:
-      DB_MAKE_NCHAR (result, DB_VALUE_PRECISION (result), str_double, strlen (str_double),
-		     DB_GET_STRING_CODESET (result), DB_GET_STRING_COLLATION (result));
+      db_make_nchar (result, DB_VALUE_PRECISION (result), str_double, strlen (str_double),
+		     db_get_string_codeset (result), db_get_string_collation (result));
       result->need_clear = true;
       break;
 
     case DB_TYPE_VARCHAR:
-      DB_MAKE_VARCHAR (result, DB_VALUE_PRECISION (result), str_double, strlen (str_double),
-		       DB_GET_STRING_CODESET (result), DB_GET_STRING_COLLATION (result));
+      db_make_varchar (result, DB_VALUE_PRECISION (result), str_double, strlen (str_double),
+		       db_get_string_codeset (result), db_get_string_collation (result));
       result->need_clear = true;
       break;
 
     case DB_TYPE_VARNCHAR:
-      DB_MAKE_VARNCHAR (result, DB_VALUE_PRECISION (result), str_double, strlen (str_double),
-			DB_GET_STRING_CODESET (result), DB_GET_STRING_COLLATION (result));
+      db_make_varnchar (result, DB_VALUE_PRECISION (result), str_double, strlen (str_double),
+			db_get_string_codeset (result), db_get_string_collation (result));
       result->need_clear = true;
       break;
 
@@ -5583,7 +5583,7 @@ tp_dtoa (DB_VALUE const *src, DB_VALUE * result)
       db_private_free_and_init (NULL, str_double);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2, pr_type_name (DB_VALUE_DOMAIN_TYPE (src)),
 	      pr_type_name (DB_VALUE_DOMAIN_TYPE (result)));
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       break;
     }
 }
@@ -5608,14 +5608,14 @@ tp_enumeration_to_varchar (const DB_VALUE * src, DB_VALUE * result)
       return ER_FAILED;
     }
 
-  if (DB_GET_ENUM_STRING (src) == NULL)
+  if (db_get_enum_string (src) == NULL)
     {
-      db_make_varchar (result, DB_DEFAULT_PRECISION, "", 0, DB_GET_ENUM_CODESET (src), DB_GET_ENUM_COLLATION (src));
+      db_make_varchar (result, DB_DEFAULT_PRECISION, "", 0, db_get_enum_codeset (src), db_get_enum_collation (src));
     }
   else
     {
-      db_make_varchar (result, DB_DEFAULT_PRECISION, DB_GET_ENUM_STRING (src), DB_GET_ENUM_STRING_SIZE (src),
-		       DB_GET_ENUM_CODESET (src), DB_GET_ENUM_COLLATION (src));
+      db_make_varchar (result, DB_DEFAULT_PRECISION, db_get_enum_string (src), db_get_enum_string_size (src),
+		       db_get_enum_codeset (src), db_get_enum_collation (src));
     }
 
   return error;
@@ -5652,7 +5652,7 @@ bfmt_print (int bfmt, const DB_VALUE * the_db_bit, char *string, int max_size)
   };
 
   /* Get the buffer and the length from the_db_bit */
-  bstring = DB_GET_BIT (the_db_bit, &length);
+  bstring = db_get_bit (the_db_bit, &length);
 
   switch (bfmt)
     {
@@ -5745,18 +5745,18 @@ tp_value_string_to_double (const DB_VALUE * value, DB_VALUE * result)
 
   if (!TP_IS_CHAR_STRING (type))
     {
-      DB_MAKE_DOUBLE (result, 0);
+      db_make_double (result, 0);
       return ER_FAILED;
     }
 
   ret = tp_atof (value, &dbl, &data_stat);
   if (ret != NO_ERROR)
     {
-      DB_MAKE_DOUBLE (result, 0);
+      db_make_double (result, 0);
     }
   else
     {
-      DB_MAKE_DOUBLE (result, dbl);
+      db_make_double (result, dbl);
     }
 
   return ret;
@@ -5892,7 +5892,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_MONETARY:
 	  {
 	    double i = 0;
-	    const double val = DB_GET_MONETARY (src)->amount;
+	    const double val = db_get_monetary (src)->amount;
 	    if (OR_CHECK_SHORT_OVERFLOW (val))
 	      {
 		err = ER_FAILED;
@@ -5907,25 +5907,25 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 	case DB_TYPE_INTEGER:
-	  if (OR_CHECK_SHORT_OVERFLOW (DB_GET_INT (src)))
+	  if (OR_CHECK_SHORT_OVERFLOW (db_get_int (src)))
 	    {
 	      err = ER_FAILED;
 	      break;
 	    }
-	  db_make_short (target, (short) DB_GET_INT (src));
+	  db_make_short (target, (short) db_get_int (src));
 	  break;
 	case DB_TYPE_BIGINT:
-	  if (OR_CHECK_SHORT_OVERFLOW (DB_GET_BIGINT (src)))
+	  if (OR_CHECK_SHORT_OVERFLOW (db_get_bigint (src)))
 	    {
 	      err = ER_FAILED;
 	      break;
 	    }
-	  db_make_short (target, (short) DB_GET_BIGINT (src));
+	  db_make_short (target, (short) db_get_bigint (src));
 	  break;
 	case DB_TYPE_FLOAT:
 	  {
 	    float i = 0;
-	    const float val = DB_GET_FLOAT (src);
+	    const float val = db_get_float (src);
 	    if (OR_CHECK_SHORT_OVERFLOW (val))
 	      {
 		err = ER_FAILED;
@@ -5942,7 +5942,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DOUBLE:
 	  {
 	    double i = 0;
-	    const double val = DB_GET_DOUBLE (src);
+	    const double val = db_get_double (src);
 	    if (OR_CHECK_SHORT_OVERFLOW (val))
 	      {
 		err = ER_FAILED;
@@ -5994,13 +5994,13 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_SHORT:
-	  db_make_int (target, (int) DB_GET_SHORT (src));
+	  db_make_int (target, (int) db_get_short (src));
 	  err = NO_ERROR;
 	  break;
 	case DB_TYPE_MONETARY:
 	  {
 	    double i = 0;
-	    const double val = DB_GET_MONETARY (src)->amount;
+	    const double val = db_get_monetary (src)->amount;
 	    if (OR_CHECK_INT_OVERFLOW (val))
 	      {
 		err = ER_FAILED;
@@ -6015,17 +6015,17 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 	case DB_TYPE_BIGINT:
-	  if (OR_CHECK_INT_OVERFLOW (DB_GET_BIGINT (src)))
+	  if (OR_CHECK_INT_OVERFLOW (db_get_bigint (src)))
 	    {
 	      err = ER_FAILED;
 	      break;
 	    }
-	  db_make_int (target, (int) DB_GET_BIGINT (src));
+	  db_make_int (target, (int) db_get_bigint (src));
 	  break;
 	case DB_TYPE_FLOAT:
 	  {
 	    float i = 0;
-	    const float val = DB_GET_FLOAT (src);
+	    const float val = db_get_float (src);
 	    if (OR_CHECK_INT_OVERFLOW (val))
 	      {
 		err = ER_FAILED;
@@ -6042,7 +6042,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DOUBLE:
 	  {
 	    double i = 0;
-	    const double val = DB_GET_DOUBLE (src);
+	    const double val = db_get_double (src);
 	    if (OR_CHECK_INT_OVERFLOW (val))
 	      {
 		err = ER_FAILED;
@@ -6094,15 +6094,15 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_SHORT:
-	  db_make_bigint (target, DB_GET_SHORT (src));
+	  db_make_bigint (target, db_get_short (src));
 	  break;
 	case DB_TYPE_INTEGER:
-	  db_make_bigint (target, DB_GET_INT (src));
+	  db_make_bigint (target, db_get_int (src));
 	  break;
 	case DB_TYPE_MONETARY:
 	  {
 	    double i = 0;
-	    const double val = DB_GET_MONETARY (src)->amount;
+	    const double val = db_get_monetary (src)->amount;
 	    if (OR_CHECK_BIGINT_OVERFLOW (val))
 	      {
 		err = ER_FAILED;
@@ -6120,7 +6120,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_FLOAT:
 	  {
 	    float i = 0;
-	    const float val = DB_GET_FLOAT (src);
+	    const float val = db_get_float (src);
 	    if (OR_CHECK_BIGINT_OVERFLOW (val))
 	      {
 		err = ER_FAILED;
@@ -6137,7 +6137,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DOUBLE:
 	  {
 	    double i = 0;
-	    const double val = DB_GET_DOUBLE (src);
+	    const double val = db_get_double (src);
 	    if (OR_CHECK_BIGINT_OVERFLOW (val))
 	      {
 		err = ER_FAILED;
@@ -6189,13 +6189,13 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_SHORT:
-	  db_make_float (target, (float) DB_GET_SHORT (src));
+	  db_make_float (target, (float) db_get_short (src));
 	  break;
 	case DB_TYPE_INTEGER:
-	  db_make_float (target, (float) DB_GET_INT (src));
+	  db_make_float (target, (float) db_get_int (src));
 	  break;
 	case DB_TYPE_BIGINT:
-	  db_make_float (target, (float) DB_GET_BIGINT (src));
+	  db_make_float (target, (float) db_get_bigint (src));
 	  break;
 	case DB_TYPE_NUMERIC:
 	  err = numeric_db_value_coerce_from_num_strict ((DB_VALUE *) src, target);
@@ -6232,19 +6232,19 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_SHORT:
-	  db_make_double (target, (double) DB_GET_SHORT (src));
+	  db_make_double (target, (double) db_get_short (src));
 	  break;
 	case DB_TYPE_INTEGER:
-	  db_make_double (target, (double) DB_GET_INT (src));
+	  db_make_double (target, (double) db_get_int (src));
 	  break;
 	case DB_TYPE_BIGINT:
-	  db_make_double (target, (double) DB_GET_BIGINT (src));
+	  db_make_double (target, (double) db_get_bigint (src));
 	  break;
 	case DB_TYPE_FLOAT:
-	  db_make_double (target, (double) DB_GET_FLOAT (src));
+	  db_make_double (target, (double) db_get_float (src));
 	  break;
 	case DB_TYPE_MONETARY:
-	  db_make_double (target, DB_GET_MONETARY (src)->amount);
+	  db_make_double (target, db_get_monetary (src)->amount);
 	  break;
 	case DB_TYPE_NUMERIC:
 	  err = numeric_db_value_coerce_from_num_strict ((DB_VALUE *) src, target);
@@ -6313,19 +6313,19 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_SHORT:
-	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) DB_GET_SHORT (src));
+	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) db_get_short (src));
 	  break;
 	case DB_TYPE_INTEGER:
-	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) DB_GET_INT (src));
+	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) db_get_int (src));
 	  break;
 	case DB_TYPE_BIGINT:
-	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) DB_GET_BIGINT (src));
+	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) db_get_bigint (src));
 	  break;
 	case DB_TYPE_FLOAT:
-	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) DB_GET_FLOAT (src));
+	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) db_get_float (src));
 	  break;
 	case DB_TYPE_DOUBLE:
-	  db_make_monetary (target, DB_CURRENCY_DEFAULT, DB_GET_DOUBLE (src));
+	  db_make_monetary (target, DB_CURRENCY_DEFAULT, db_get_double (src));
 	  break;
 	case DB_TYPE_NUMERIC:
 	  err = numeric_db_value_coerce_from_num_strict ((DB_VALUE *) src, target);
@@ -6375,13 +6375,13 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_TIMETZ:
 	  {
-	    DB_TIMETZ *time_tz = DB_GET_TIMETZ (src);
+	    DB_TIMETZ *time_tz = db_get_timetz (src);
 	    db_value_put_encoded_time (target, &time_tz->time);
 	    break;
 	  }
 	case DB_TYPE_TIMELTZ:
 	  {
-	    DB_TIME *time = DB_GET_TIME (src);
+	    DB_TIME *time = db_get_time (src);
 	    db_value_put_encoded_time (target, time);
 	    break;
 	  }
@@ -6413,7 +6413,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_TIMELTZ:
 	  {
 	    DB_TIMETZ time_tz = { 0, 0 };
-	    DB_TIME *time = DB_GET_TIME (src);
+	    DB_TIME *time = db_get_time (src);
 	    bool time_is_utc = (original_type == DB_TYPE_TIMELTZ) ? true : false;
 
 	    time_tz.time = *time;
@@ -6454,7 +6454,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_TIMETZ:
 	  {
-	    DB_TIMETZ *time_tz = DB_GET_TIMETZ (src);
+	    DB_TIMETZ *time_tz = db_get_timetz (src);
 
 	    assert (tz_check_geographic_tz (&time_tz->tz_id) == NO_ERROR);
 
@@ -6464,7 +6464,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_TIME:
 	  {
-	    DB_TIME *time = DB_GET_TIME (src);
+	    DB_TIME *time = db_get_time (src);
 	    DB_TIMETZ time_tz;
 
 	    if (tz_check_session_has_geographic_tz () != NO_ERROR)
@@ -6510,7 +6510,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  {
 	    DB_DATETIME *src_dt = NULL;
 
-	    src_dt = DB_GET_DATETIME (src);
+	    src_dt = db_get_datetime (src);
 	    if (src_dt->time != 0)
 	      {
 		/* only "downcast" if time is 0 */
@@ -6531,7 +6531,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    /* DATETIMELTZ and DATETIMETZ store in UTC, convert to session */
 	    if (original_type == DB_TYPE_DATETIMELTZ)
 	      {
-		utc_dt_p = DB_GET_DATETIME (src);
+		utc_dt_p = db_get_datetime (src);
 		if (tz_create_session_tzid_for_datetime (utc_dt_p, true, &tz_id) != NO_ERROR)
 		  {
 		    err = ER_FAILED;
@@ -6540,7 +6540,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      }
 	    else
 	      {
-		dt_tz_p = DB_GET_DATETIMETZ (src);
+		dt_tz_p = db_get_datetimetz (src);
 		utc_dt_p = &dt_tz_p->datetime;
 		tz_id = dt_tz_p->tz_id;
 	      }
@@ -6568,7 +6568,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    DB_TIME time = 0;
 	    DB_TIMESTAMP *ts = NULL;
 
-	    ts = DB_GET_TIMESTAMP (src);
+	    ts = db_get_timestamp (src);
 	    (void) db_timestamp_decode_ses (ts, &date, &time);
 	    if (time != 0)
 	      {
@@ -6585,7 +6585,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    DB_TIME time = 0;
 	    DB_TIMESTAMPTZ *ts_tz = NULL;
 
-	    ts_tz = DB_GET_TIMESTAMPTZ (src);
+	    ts_tz = db_get_timestamptz (src);
 	    err = db_timestamp_decode_w_tz_id (&ts_tz->timestamp, &ts_tz->tz_id, &date, &time);
 	    if (err != NO_ERROR || time != 0)
 	      {
@@ -6608,20 +6608,20 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DATE:
 	  {
 	    DB_DATETIME datetime = { 0, 0 };
-	    datetime.date = *DB_GET_DATE (src);
+	    datetime.date = *db_get_date (src);
 	    datetime.time = 0;
 	    db_make_datetime (target, &datetime);
 	    break;
 	  }
 	case DB_TYPE_DATETIMETZ:
 	  {
-	    DB_DATETIMETZ *dt_tz = DB_GET_DATETIMETZ (src);
+	    DB_DATETIMETZ *dt_tz = db_get_datetimetz (src);
 	    db_make_datetime (target, &dt_tz->datetime);
 	    break;
 	  }
 	case DB_TYPE_DATETIMELTZ:
 	  {
-	    DB_DATETIME *dt = DB_GET_DATETIME (src);
+	    DB_DATETIME *dt = db_get_datetime (src);
 	    db_make_datetime (target, dt);
 	    break;
 	  }
@@ -6643,7 +6643,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_TIMESTAMPLTZ:
 	  {
 	    DB_DATETIME datetime = { 0, 0 };
-	    DB_TIMESTAMP *utime = DB_GET_TIMESTAMP (src);
+	    DB_TIMESTAMP *utime = db_get_timestamp (src);
 	    DB_DATE date;
 	    DB_TIME time;
 
@@ -6662,7 +6662,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    DB_DATETIME datetime = { 0, 0 };
 	    DB_DATE date;
 	    DB_TIME time;
-	    DB_TIMESTAMPTZ *ts_tz = DB_GET_TIMESTAMPTZ (src);
+	    DB_TIMESTAMPTZ *ts_tz = db_get_timestamptz (src);
 
 	    if (db_timestamp_decode_w_tz_id (&ts_tz->timestamp, &ts_tz->tz_id, &date, &time) != NO_ERROR)
 	      {
@@ -6691,12 +6691,12 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	    if (original_type == DB_TYPE_DATE)
 	      {
-		dt_tz.datetime.date = *DB_GET_DATE (src);
+		dt_tz.datetime.date = *db_get_date (src);
 		dt_tz.datetime.time = 0;
 	      }
 	    else
 	      {
-		dt_tz.datetime = *DB_GET_DATETIME (src);
+		dt_tz.datetime = *db_get_datetime (src);
 	      }
 
 	    err = tz_create_datetimetz_from_ses (&(dt_tz.datetime), &dt_tz);
@@ -6710,7 +6710,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DATETIMELTZ:
 	  {
 	    DB_DATETIMETZ dt_tz = DB_DATETIMETZ_INITIALIZER;
-	    DB_DATETIME *dt = DB_GET_DATETIME (src);
+	    DB_DATETIME *dt = db_get_datetime (src);
 
 	    dt_tz.datetime = *dt;
 	    err = tz_create_session_tzid_for_datetime (dt, false, &dt_tz.tz_id);
@@ -6740,7 +6740,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_TIMESTAMPLTZ:
 	  {
 	    DB_DATETIMETZ dt_tz = DB_DATETIMETZ_INITIALIZER;
-	    DB_TIMESTAMP *utime = DB_GET_TIMESTAMP (src);
+	    DB_TIMESTAMP *utime = db_get_timestamp (src);
 	    DB_DATE date;
 	    DB_TIME time;
 
@@ -6758,7 +6758,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_TIMESTAMPTZ:
 	  {
 	    DB_DATETIMETZ dt_tz = DB_DATETIMETZ_INITIALIZER;
-	    DB_TIMESTAMPTZ *ts_tz = DB_GET_TIMESTAMPTZ (src);
+	    DB_TIMESTAMPTZ *ts_tz = db_get_timestamptz (src);
 	    DB_DATE date;
 	    DB_TIME time;
 
@@ -6786,12 +6786,12 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	    if (original_type == DB_TYPE_DATE)
 	      {
-		datetime.date = *DB_GET_DATE (src);
+		datetime.date = *db_get_date (src);
 		datetime.time = 0;
 	      }
 	    else
 	      {
-		datetime = *DB_GET_DATETIME (src);
+		datetime = *db_get_datetime (src);
 	      }
 
 	    err = tz_create_datetimetz_from_ses (&datetime, &dt_tz);
@@ -6806,7 +6806,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_DATETIMETZ:
 	  {
-	    DB_DATETIMETZ *dt_tz = DB_GET_DATETIMETZ (src);
+	    DB_DATETIMETZ *dt_tz = db_get_datetimetz (src);
 
 	    /* copy datetime (UTC) */
 	    db_make_datetimeltz (target, &dt_tz->datetime);
@@ -6831,7 +6831,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_TIMESTAMPLTZ:
 	  {
 	    DB_DATETIME datetime = { 0, 0 };
-	    DB_TIMESTAMP *utime = DB_GET_TIMESTAMP (src);
+	    DB_TIMESTAMP *utime = db_get_timestamp (src);
 	    DB_DATE date;
 	    DB_TIME time;
 
@@ -6844,7 +6844,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_TIMESTAMPTZ:
 	  {
 	    DB_DATETIME datetime = { 0, 0 };
-	    DB_TIMESTAMPTZ *ts_tz = DB_GET_TIMESTAMPTZ (src);
+	    DB_TIMESTAMPTZ *ts_tz = db_get_timestamptz (src);
 	    DB_DATE date;
 	    DB_TIME time;
 
@@ -6880,7 +6880,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_DATETIME:
 	  {
-	    DB_DATETIME dt = *DB_GET_DATETIME (src);
+	    DB_DATETIME dt = *db_get_datetime (src);
 	    DB_DATE date = dt.date;
 	    DB_TIME time = dt.time / 1000;
 	    DB_TIMESTAMP ts = 0;
@@ -6895,7 +6895,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_DATETIMELTZ:
 	  {
-	    DB_DATETIME dt = *DB_GET_DATETIME (src);
+	    DB_DATETIME dt = *db_get_datetime (src);
 	    DB_DATE date = dt.date;
 	    DB_TIME time = dt.time / 1000;
 	    DB_TIMESTAMP ts = 0;
@@ -6911,7 +6911,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_DATETIMETZ:
 	  {
-	    DB_DATETIMETZ *dt_tz = DB_GET_DATETIMETZ (src);
+	    DB_DATETIMETZ *dt_tz = db_get_datetimetz (src);
 	    DB_DATE date = dt_tz->datetime.date;
 	    DB_TIME time = dt_tz->datetime.time / 1000;
 	    DB_TIMESTAMP ts = 0;
@@ -6928,7 +6928,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DATE:
 	  {
 	    DB_TIME tm = 0;
-	    DB_DATE date = *DB_GET_DATE (src);
+	    DB_DATE date = *db_get_date (src);
 	    DB_TIMESTAMP ts = 0;
 
 	    db_time_encode (&tm, 0, 0, 0);
@@ -6943,7 +6943,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_TIMESTAMPTZ:
 	  {
-	    DB_TIMESTAMPTZ *ts_tz = DB_GET_TIMESTAMPTZ (src);
+	    DB_TIMESTAMPTZ *ts_tz = db_get_timestamptz (src);
 
 	    /* copy timestamp value (UTC) */
 	    db_make_timestamp (target, ts_tz->timestamp);
@@ -6952,7 +6952,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_TIMESTAMPLTZ:
 	  {
-	    DB_TIMESTAMP *ts = DB_GET_TIMESTAMP (src);
+	    DB_TIMESTAMP *ts = db_get_timestamp (src);
 
 	    /* copy timestamp value (UTC) */
 	    db_make_timestamp (target, *ts);
@@ -6985,7 +6985,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_DATETIME:
 	  {
-	    DB_DATETIME dt = *DB_GET_DATETIME (src);
+	    DB_DATETIME dt = *db_get_datetime (src);
 	    DB_DATE date = dt.date;
 	    DB_TIME time = dt.time / 1000;
 	    DB_TIMESTAMP ts = 0;
@@ -7000,7 +7000,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_DATETIMELTZ:
 	  {
-	    DB_DATETIME dt = *DB_GET_DATETIME (src);
+	    DB_DATETIME dt = *db_get_datetime (src);
 	    DB_DATE date = dt.date;
 	    DB_TIME time = dt.time / 1000;
 	    DB_TIMESTAMP ts = 0;
@@ -7016,7 +7016,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_DATETIMETZ:
 	  {
-	    DB_DATETIMETZ *dt_tz = DB_GET_DATETIMETZ (src);
+	    DB_DATETIMETZ *dt_tz = db_get_datetimetz (src);
 	    DB_DATE date = dt_tz->datetime.date;
 	    DB_TIME time = dt_tz->datetime.time / 1000;
 	    DB_TIMESTAMP ts = 0;
@@ -7033,7 +7033,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DATE:
 	  {
 	    DB_TIME tm = 0;
-	    DB_DATE date = *DB_GET_DATE (src);
+	    DB_DATE date = *db_get_date (src);
 	    DB_TIMESTAMP ts = 0;
 
 	    db_time_encode (&tm, 0, 0, 0);
@@ -7048,7 +7048,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_TIMESTAMP:
 	  {
-	    DB_TIMESTAMP *ts = DB_GET_TIMESTAMP (src);
+	    DB_TIMESTAMP *ts = db_get_timestamp (src);
 
 	    /* copy val timestamp value (UTC) */
 	    db_make_timestampltz (target, *ts);
@@ -7057,7 +7057,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_TIMESTAMPTZ:
 	  {
-	    DB_TIMESTAMPTZ *ts_tz = DB_GET_TIMESTAMPTZ (src);
+	    DB_TIMESTAMPTZ *ts_tz = db_get_timestamptz (src);
 
 	    /* copy val timestamp value (UTC) */
 	    db_make_timestampltz (target, ts_tz->timestamp);
@@ -7091,7 +7091,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DATETIME:
 	  {
 	    DB_TIMESTAMPTZ ts_tz = { 0, 0 };
-	    DB_DATETIME dt = *DB_GET_DATETIME (src);
+	    DB_DATETIME dt = *db_get_datetime (src);
 	    DB_DATE date = dt.date;
 	    DB_TIME time = dt.time / 1000;
 
@@ -7107,7 +7107,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DATETIMELTZ:
 	  {
 	    DB_TIMESTAMPTZ ts_tz = { 0, 0 };
-	    DB_DATETIME dt = *DB_GET_DATETIME (src);
+	    DB_DATETIME dt = *db_get_datetime (src);
 	    DB_DATE date = dt.date;
 	    DB_TIME time = dt.time / 1000;
 
@@ -7124,7 +7124,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DATETIMETZ:
 	  {
 	    DB_TIMESTAMPTZ ts_tz = { 0, 0 };
-	    DB_DATETIMETZ *dt_tz = DB_GET_DATETIMETZ (src);
+	    DB_DATETIMETZ *dt_tz = db_get_datetimetz (src);
 	    DB_DATE date = dt_tz->datetime.date;
 	    DB_TIME time = dt_tz->datetime.time / 1000;
 
@@ -7142,7 +7142,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  {
 	    DB_TIMESTAMPTZ ts_tz = { 0, 0 };
 	    DB_TIME tm = 0;
-	    DB_DATE date = *DB_GET_DATE (src);
+	    DB_DATE date = *db_get_date (src);
 
 	    db_time_encode (&tm, 0, 0, 0);
 	    if (db_timestamp_encode_ses (&date, &tm, &ts_tz.timestamp, &ts_tz.tz_id) != NO_ERROR)
@@ -7159,7 +7159,7 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  {
 	    DB_TIMESTAMPTZ ts_tz = { 0, 0 };
 
-	    ts_tz.timestamp = *DB_GET_TIMESTAMP (src);
+	    ts_tz.timestamp = *db_get_timestamp (src);
 
 	    err = tz_create_session_tzid_for_timestamp (&(ts_tz.timestamp), &(ts_tz.tz_id));
 
@@ -7271,8 +7271,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       /* TODO this is very hackish,
        * we really need to split this function up
        */
-      DB_JSON_TYPE json_type = db_json_get_type (DB_GET_JSON_DOCUMENT (src));
-      JSON_DOC *src_doc = DB_GET_JSON_DOCUMENT (src);
+      DB_JSON_TYPE json_type = db_json_get_type (db_get_json_document (src));
+      JSON_DOC *src_doc = db_get_json_document (src);
 
       switch (json_type)
 	{
@@ -7471,7 +7471,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  assert (desired_domain->collation_flag == TP_DOMAIN_COLL_LEAVE);
 	  if (TP_IS_CHAR_TYPE (original_type))
 	    {
-	      db_string_put_cs_and_collation (target, DB_GET_STRING_CODESET (src), DB_GET_STRING_COLLATION (src));
+	      db_string_put_cs_and_collation (target, db_get_string_codeset (src), db_get_string_collation (src));
 	    }
 	}
     }
@@ -7482,7 +7482,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_MONETARY:
-	  v_money = DB_GET_MONETARY (src);
+	  v_money = db_get_monetary (src);
 	  if (OR_CHECK_SHORT_OVERFLOW (v_money->amount))
 	    {
 	      status = DOMAIN_OVERFLOW;
@@ -7493,43 +7493,43 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    }
 	  break;
 	case DB_TYPE_INTEGER:
-	  if (OR_CHECK_SHORT_OVERFLOW (DB_GET_INT (src)))
+	  if (OR_CHECK_SHORT_OVERFLOW (db_get_int (src)))
 	    {
 	      status = DOMAIN_OVERFLOW;
 	    }
 	  else
 	    {
-	      db_make_short (target, DB_GET_INT (src));
+	      db_make_short (target, db_get_int (src));
 	    }
 	  break;
 	case DB_TYPE_BIGINT:
-	  if (OR_CHECK_SHORT_OVERFLOW (DB_GET_BIGINT (src)))
+	  if (OR_CHECK_SHORT_OVERFLOW (db_get_bigint (src)))
 	    {
 	      status = DOMAIN_OVERFLOW;
 	    }
 	  else
 	    {
-	      db_make_short (target, (short) DB_GET_BIGINT (src));
+	      db_make_short (target, (short) db_get_bigint (src));
 	    }
 	  break;
 	case DB_TYPE_FLOAT:
-	  if (OR_CHECK_SHORT_OVERFLOW (DB_GET_FLOAT (src)))
+	  if (OR_CHECK_SHORT_OVERFLOW (db_get_float (src)))
 	    {
 	      status = DOMAIN_OVERFLOW;
 	    }
 	  else
 	    {
-	      db_make_short (target, (short) ROUND (DB_GET_FLOAT (src)));
+	      db_make_short (target, (short) ROUND (db_get_float (src)));
 	    }
 	  break;
 	case DB_TYPE_DOUBLE:
-	  if (OR_CHECK_SHORT_OVERFLOW (DB_GET_DOUBLE (src)))
+	  if (OR_CHECK_SHORT_OVERFLOW (db_get_double (src)))
 	    {
 	      status = DOMAIN_OVERFLOW;
 	    }
 	  else
 	    {
-	      db_make_short (target, (short) ROUND (DB_GET_DOUBLE (src)));
+	      db_make_short (target, (short) ROUND (db_get_double (src)));
 	    }
 	  break;
 	case DB_TYPE_NUMERIC:
@@ -7567,7 +7567,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 	case DB_TYPE_ENUMERATION:
-	  db_make_short (target, DB_GET_ENUM_SHORT (src));
+	  db_make_short (target, db_get_enum_short (src));
 	  break;
 	default:
 	  status = DOMAIN_INCOMPATIBLE;
@@ -7579,20 +7579,20 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_SHORT:
-	  db_make_int (target, DB_GET_SHORT (src));
+	  db_make_int (target, db_get_short (src));
 	  break;
 	case DB_TYPE_BIGINT:
-	  if (OR_CHECK_INT_OVERFLOW (DB_GET_BIGINT (src)))
+	  if (OR_CHECK_INT_OVERFLOW (db_get_bigint (src)))
 	    {
 	      status = DOMAIN_OVERFLOW;
 	    }
 	  else
 	    {
-	      db_make_int (target, (int) DB_GET_BIGINT (src));
+	      db_make_int (target, (int) db_get_bigint (src));
 	    }
 	  break;
 	case DB_TYPE_MONETARY:
-	  v_money = DB_GET_MONETARY (src);
+	  v_money = db_get_monetary (src);
 	  if (OR_CHECK_INT_OVERFLOW (v_money->amount))
 	    {
 	      status = DOMAIN_OVERFLOW;
@@ -7607,13 +7607,13 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    int tmp_int;
 	    float tmp_float;
 
-	    if (OR_CHECK_INT_OVERFLOW (DB_GET_FLOAT (src)))
+	    if (OR_CHECK_INT_OVERFLOW (db_get_float (src)))
 	      {
 		status = DOMAIN_OVERFLOW;
 	      }
 	    else
 	      {
-		tmp_float = DB_GET_FLOAT (src);
+		tmp_float = db_get_float (src);
 		tmp_int = (int) ROUND (tmp_float);
 
 #if defined(AIX)
@@ -7636,13 +7636,13 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	  break;
 	case DB_TYPE_DOUBLE:
-	  if (OR_CHECK_INT_OVERFLOW (DB_GET_DOUBLE (src)))
+	  if (OR_CHECK_INT_OVERFLOW (db_get_double (src)))
 	    {
 	      status = DOMAIN_OVERFLOW;
 	    }
 	  else
 	    {
-	      db_make_int (target, (int) ROUND (DB_GET_DOUBLE (src)));
+	      db_make_int (target, (int) ROUND (db_get_double (src)));
 	    }
 	  break;
 	case DB_TYPE_NUMERIC:
@@ -7680,7 +7680,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 	case DB_TYPE_ENUMERATION:
-	  db_make_int (target, DB_GET_ENUM_SHORT (src));
+	  db_make_int (target, db_get_enum_short (src));
 	  break;
 	default:
 	  status = DOMAIN_INCOMPATIBLE;
@@ -7692,16 +7692,16 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_SHORT:
-	  db_make_bigint (target, DB_GET_SHORT (src));
+	  db_make_bigint (target, db_get_short (src));
 	  break;
 	case DB_TYPE_INTEGER:
-	  db_make_bigint (target, DB_GET_INT (src));
+	  db_make_bigint (target, db_get_int (src));
 	  break;
 	case DB_TYPE_MONETARY:
 	  {
 	    DB_BIGINT tmp_bi;
 
-	    v_money = DB_GET_MONETARY (src);
+	    v_money = db_get_monetary (src);
 	    if (OR_CHECK_BIGINT_OVERFLOW (v_money->amount))
 	      {
 		status = DOMAIN_OVERFLOW;
@@ -7725,13 +7725,13 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    float tmp_float;
 	    DB_BIGINT tmp_bi;
 
-	    if (OR_CHECK_BIGINT_OVERFLOW (DB_GET_FLOAT (src)))
+	    if (OR_CHECK_BIGINT_OVERFLOW (db_get_float (src)))
 	      {
 		status = DOMAIN_OVERFLOW;
 	      }
 	    else
 	      {
-		tmp_float = DB_GET_FLOAT (src);
+		tmp_float = db_get_float (src);
 		tmp_bi = (DB_BIGINT) ROUND (tmp_float);
 
 #if defined(AIX)
@@ -7757,13 +7757,13 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    double tmp_double;
 	    DB_BIGINT tmp_bi;
 
-	    if (OR_CHECK_BIGINT_OVERFLOW (DB_GET_DOUBLE (src)))
+	    if (OR_CHECK_BIGINT_OVERFLOW (db_get_double (src)))
 	      {
 		status = DOMAIN_OVERFLOW;
 	      }
 	    else
 	      {
-		tmp_double = DB_GET_DOUBLE (src);
+		tmp_double = db_get_double (src);
 		tmp_bi = (DB_BIGINT) ROUND (tmp_double);
 
 #if defined(AIX)
@@ -7817,7 +7817,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 	case DB_TYPE_ENUMERATION:
-	  db_make_bigint (target, DB_GET_ENUM_SHORT (src));
+	  db_make_bigint (target, db_get_enum_short (src));
 	  break;
 	default:
 	  status = DOMAIN_INCOMPATIBLE;
@@ -7829,26 +7829,26 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_SHORT:
-	  db_make_float (target, (float) DB_GET_SHORT (src));
+	  db_make_float (target, (float) db_get_short (src));
 	  break;
 	case DB_TYPE_INTEGER:
-	  db_make_float (target, (float) DB_GET_INT (src));
+	  db_make_float (target, (float) db_get_int (src));
 	  break;
 	case DB_TYPE_BIGINT:
-	  db_make_float (target, (float) DB_GET_BIGINT (src));
+	  db_make_float (target, (float) db_get_bigint (src));
 	  break;
 	case DB_TYPE_DOUBLE:
-	  if (OR_CHECK_FLOAT_OVERFLOW (DB_GET_DOUBLE (src)))
+	  if (OR_CHECK_FLOAT_OVERFLOW (db_get_double (src)))
 	    {
 	      status = DOMAIN_OVERFLOW;
 	    }
 	  else
 	    {
-	      db_make_float (target, (float) DB_GET_DOUBLE (src));
+	      db_make_float (target, (float) db_get_double (src));
 	    }
 	  break;
 	case DB_TYPE_MONETARY:
-	  v_money = DB_GET_MONETARY (src);
+	  v_money = db_get_monetary (src);
 	  if (OR_CHECK_FLOAT_OVERFLOW (v_money->amount))
 	    {
 	      status = DOMAIN_OVERFLOW;
@@ -7893,7 +7893,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 	case DB_TYPE_ENUMERATION:
-	  db_make_float (target, (float) DB_GET_ENUM_SHORT (src));
+	  db_make_float (target, (float) db_get_enum_short (src));
 	  break;
 	default:
 	  status = DOMAIN_INCOMPATIBLE;
@@ -7905,19 +7905,19 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_SHORT:
-	  db_make_double (target, (double) DB_GET_SHORT (src));
+	  db_make_double (target, (double) db_get_short (src));
 	  break;
 	case DB_TYPE_INTEGER:
-	  db_make_double (target, (double) DB_GET_INT (src));
+	  db_make_double (target, (double) db_get_int (src));
 	  break;
 	case DB_TYPE_BIGINT:
-	  db_make_double (target, (double) DB_GET_BIGINT (src));
+	  db_make_double (target, (double) db_get_bigint (src));
 	  break;
 	case DB_TYPE_FLOAT:
-	  db_make_double (target, (double) DB_GET_FLOAT (src));
+	  db_make_double (target, (double) db_get_float (src));
 	  break;
 	case DB_TYPE_MONETARY:
-	  v_money = DB_GET_MONETARY (src);
+	  v_money = db_get_monetary (src);
 	  db_make_double (target, (double) v_money->amount);
 	  break;
 	case DB_TYPE_NUMERIC:
@@ -7956,7 +7956,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 	case DB_TYPE_ENUMERATION:
-	  db_make_double (target, (double) DB_GET_ENUM_SHORT (src));
+	  db_make_double (target, (double) db_get_enum_short (src));
 	  break;
 	default:
 	  status = DOMAIN_INCOMPATIBLE;
@@ -8018,19 +8018,19 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_SHORT:
-	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) DB_GET_SHORT (src));
+	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) db_get_short (src));
 	  break;
 	case DB_TYPE_INTEGER:
-	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) DB_GET_INT (src));
+	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) db_get_int (src));
 	  break;
 	case DB_TYPE_BIGINT:
-	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) DB_GET_BIGINT (src));
+	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) db_get_bigint (src));
 	  break;
 	case DB_TYPE_FLOAT:
-	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) DB_GET_FLOAT (src));
+	  db_make_monetary (target, DB_CURRENCY_DEFAULT, (double) db_get_float (src));
 	  break;
 	case DB_TYPE_DOUBLE:
-	  db_make_monetary (target, DB_CURRENCY_DEFAULT, DB_GET_DOUBLE (src));
+	  db_make_monetary (target, DB_CURRENCY_DEFAULT, db_get_double (src));
 	  break;
 	case DB_TYPE_NUMERIC:
 	  status = (TP_DOMAIN_STATUS) numeric_db_value_coerce_from_num ((DB_VALUE *) src, target, &data_stat);
@@ -8067,7 +8067,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 	case DB_TYPE_ENUMERATION:
-	  db_make_monetary (target, DB_CURRENCY_DEFAULT, DB_GET_ENUM_SHORT (src));
+	  db_make_monetary (target, DB_CURRENCY_DEFAULT, db_get_enum_short (src));
 	  break;
 	default:
 	  status = DOMAIN_INCOMPATIBLE;
@@ -8110,12 +8110,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  {
 	    if (original_type == DB_TYPE_DATE)
 	      {
-		v_date = *DB_GET_DATE (src);
+		v_date = *db_get_date (src);
 		db_time_encode (&v_time, 0, 0, 0);
 	      }
 	    else
 	      {
-		v_datetime = *DB_GET_DATETIME (src);
+		v_datetime = *db_get_datetime (src);
 		v_date = v_datetime.date;
 		v_time = v_datetime.time / 1000;
 	      }
@@ -8132,7 +8132,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 
 	case DB_TYPE_DATETIMELTZ:
-	  v_datetime = *DB_GET_DATETIME (src);
+	  v_datetime = *db_get_datetime (src);
 	  v_date = v_datetime.date;
 	  v_time = v_datetime.time / 1000;
 
@@ -8147,7 +8147,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 
 	case DB_TYPE_DATETIMETZ:
-	  v_datetimetz = *DB_GET_DATETIMETZ (src);
+	  v_datetimetz = *db_get_datetimetz (src);
 	  v_date = v_datetimetz.datetime.date;
 	  v_time = v_datetimetz.datetime.time / 1000;
 
@@ -8163,11 +8163,11 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_TIMESTAMPLTZ:
 	  /* copy timestamp (UTC) */
-	  db_make_timestamp (target, *DB_GET_TIMESTAMP (src));
+	  db_make_timestamp (target, *db_get_timestamp (src));
 	  break;
 
 	case DB_TYPE_TIMESTAMPTZ:
-	  v_timestamptz = *DB_GET_TIMESTAMPTZ (src);
+	  v_timestamptz = *db_get_timestamptz (src);
 	  /* copy timestamp (UTC) */
 	  db_make_timestamp (target, v_timestamptz.timestamp);
 	  break;
@@ -8177,7 +8177,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  if (status == DOMAIN_COMPATIBLE)
 	    {
 	      int tmpint;
-	      if ((tmpint = DB_GET_INT (target)) >= 0)
+	      if ((tmpint = db_get_int (target)) >= 0)
 		{
 		  db_make_timestamp (target, (DB_UTIME) tmpint);
 		}
@@ -8225,14 +8225,14 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  /* convert from session to UTC */
 	  if (original_type == DB_TYPE_DATETIME)
 	    {
-	      v_datetime = *DB_GET_DATETIME (src);
+	      v_datetime = *db_get_datetime (src);
 	      v_date = v_datetime.date;
 	      v_time = v_datetime.time / 1000;
 	    }
 	  else
 	    {
 	      assert (original_type == DB_TYPE_DATE);
-	      v_date = *DB_GET_DATE (src);
+	      v_date = *db_get_date (src);
 	      v_time = 0;
 	    }
 
@@ -8247,7 +8247,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 
 	case DB_TYPE_DATETIMELTZ:
-	  v_datetime = *DB_GET_DATETIME (src);
+	  v_datetime = *db_get_datetime (src);
 	  v_date = v_datetime.date;
 	  v_time = v_datetime.time / 1000;
 
@@ -8268,7 +8268,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 
 	case DB_TYPE_DATETIMETZ:
-	  v_datetimetz = *DB_GET_DATETIMETZ (src);
+	  v_datetimetz = *db_get_datetimetz (src);
 	  v_date = v_datetimetz.datetime.date;
 	  v_time = v_datetimetz.datetime.time / 1000;
 
@@ -8287,7 +8287,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_TIMESTAMP:
 	case DB_TYPE_TIMESTAMPLTZ:
 	  /* copy TS value and create TZ_ID for system TZ */
-	  v_timestamptz.timestamp = *DB_GET_TIMESTAMP (src);
+	  v_timestamptz.timestamp = *db_get_timestamp (src);
 
 	  if (tz_create_session_tzid_for_timestamp (&v_timestamptz.timestamp, &(v_timestamptz.tz_id)) != NO_ERROR)
 	    {
@@ -8304,7 +8304,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    {
 	      int tmpint;
 
-	      tmpint = DB_GET_INT (target);
+	      tmpint = db_get_int (target);
 	      if (tmpint < 0)
 		{
 		  status = DOMAIN_INCOMPATIBLE;
@@ -8361,14 +8361,14 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  {
 	    if (original_type == DB_TYPE_DATETIME)
 	      {
-		v_datetime = *DB_GET_DATETIME (src);
+		v_datetime = *db_get_datetime (src);
 		v_date = v_datetime.date;
 		v_time = v_datetime.time / 1000;
 	      }
 	    else
 	      {
 		assert (original_type == DB_TYPE_DATE);
-		v_date = *DB_GET_DATE (src);
+		v_date = *db_get_date (src);
 		v_time = 0;
 	      }
 
@@ -8386,14 +8386,14 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DATETIMETZ:
 	  if (original_type == DB_TYPE_DATETIMELTZ)
 	    {
-	      v_datetime = *DB_GET_DATETIME (src);
+	      v_datetime = *db_get_datetime (src);
 	      v_date = v_datetime.date;
 	      v_time = v_datetime.time / 1000;
 	    }
 	  else
 	    {
 	      assert (original_type == DB_TYPE_DATETIMETZ);
-	      v_datetimetz = *DB_GET_DATETIMETZ (src);
+	      v_datetimetz = *db_get_datetimetz (src);
 	      v_date = v_datetimetz.datetime.date;
 	      v_time = v_datetimetz.datetime.time / 1000;
 	    }
@@ -8411,11 +8411,11 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_TIMESTAMP:
 	  /* original value stored in UTC, copy it */
-	  db_make_timestampltz (target, *DB_GET_TIMESTAMP (src));
+	  db_make_timestampltz (target, *db_get_timestamp (src));
 	  break;
 
 	case DB_TYPE_TIMESTAMPTZ:
-	  v_timestamptz = *DB_GET_TIMESTAMPTZ (src);
+	  v_timestamptz = *db_get_timestamptz (src);
 	  /* original value stored in UTC, copy it */
 	  db_make_timestampltz (target, v_timestamptz.timestamp);
 	  break;
@@ -8425,7 +8425,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  if (status == DOMAIN_COMPATIBLE)
 	    {
 	      int tmpint;
-	      if ((tmpint = DB_GET_INT (target)) >= 0)
+	      if ((tmpint = db_get_int (target)) >= 0)
 		{
 		  db_make_timestampltz (target, (DB_UTIME) tmpint);
 		}
@@ -8470,7 +8470,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_UTIME:
 	case DB_TYPE_TIMESTAMPLTZ:
-	  v_utime = *DB_GET_TIMESTAMP (src);
+	  v_utime = *db_get_timestamp (src);
 	  if (db_timestamp_decode_ses (&v_utime, &v_date, &v_time) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
@@ -8482,7 +8482,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 
 	case DB_TYPE_TIMESTAMPTZ:
-	  v_timestamptz = *DB_GET_TIMESTAMPTZ (src);
+	  v_timestamptz = *db_get_timestamptz (src);
 	  if (db_timestamp_decode_w_tz_id (&v_timestamptz.timestamp, &v_timestamptz.tz_id, &v_date, &v_time) !=
 	      NO_ERROR)
 	    {
@@ -8495,7 +8495,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 
 	case DB_TYPE_DATE:
-	  v_datetime.date = *DB_GET_DATE (src);
+	  v_datetime.date = *db_get_date (src);
 	  v_datetime.time = 0;
 	  db_make_datetime (target, &v_datetime);
 	  break;
@@ -8505,7 +8505,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    DB_DATETIME utc_dt;
 
 	    /* DATETIMELTZ store in UTC, DATETIME in session TZ */
-	    utc_dt = *DB_GET_DATETIME (src);
+	    utc_dt = *db_get_datetime (src);
 	    if (tz_datetimeltz_to_local (&utc_dt, &v_datetime) != NO_ERROR)
 	      {
 		status = DOMAIN_ERROR;
@@ -8518,7 +8518,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_DATETIMETZ:
 	  /* DATETIMETZ store in UTC, DATETIME in session TZ */
-	  v_datetimetz = *DB_GET_DATETIMETZ (src);
+	  v_datetimetz = *db_get_datetimetz (src);
 	  if (tz_utc_datetimetz_to_local (&v_datetimetz.datetime, &v_datetimetz.tz_id, &v_datetime) == NO_ERROR)
 	    {
 	      db_make_datetime (target, &v_datetime);
@@ -8567,7 +8567,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_UTIME:
 	case DB_TYPE_TIMESTAMPLTZ:
-	  v_utime = *DB_GET_TIMESTAMP (src);
+	  v_utime = *db_get_timestamp (src);
 
 	  (void) db_timestamp_decode_utc (&v_utime, &v_date, &v_time);
 	  v_datetime.time = v_time * 1000;
@@ -8576,7 +8576,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 
 	case DB_TYPE_TIMESTAMPTZ:
-	  v_timestamptz = *DB_GET_TIMESTAMPTZ (src);
+	  v_timestamptz = *db_get_timestamptz (src);
 	  (void) db_timestamp_decode_utc (&v_timestamptz.timestamp, &v_date, &v_time);
 	  v_datetime.time = v_time * 1000;
 	  v_datetime.date = v_date;
@@ -8587,12 +8587,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_DATETIME:
 	  if (original_type == DB_TYPE_DATE)
 	    {
-	      v_datetime.date = *DB_GET_DATE (src);
+	      v_datetime.date = *db_get_date (src);
 	      v_datetime.time = 0;
 	    }
 	  else
 	    {
-	      v_datetime = *DB_GET_DATETIME (src);
+	      v_datetime = *db_get_datetime (src);
 	    }
 
 	  if (tz_create_datetimetz_from_ses (&v_datetime, &v_datetimetz) != NO_ERROR)
@@ -8605,7 +8605,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_DATETIMETZ:
 	  /* copy (UTC) */
-	  v_datetimetz = *DB_GET_DATETIMETZ (src);
+	  v_datetimetz = *db_get_datetimetz (src);
 	  db_make_datetimeltz (target, &v_datetimetz.datetime);
 	  break;
 
@@ -8656,7 +8656,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_UTIME:
 	case DB_TYPE_TIMESTAMPLTZ:
 	  {
-	    v_utime = *DB_GET_TIMESTAMP (src);
+	    v_utime = *db_get_timestamp (src);
 	    db_timestamp_decode_utc (&v_utime, &v_date, &v_time);
 	    v_datetimetz.datetime.time = v_time * 1000;
 	    v_datetimetz.datetime.date = v_date;
@@ -8672,7 +8672,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 
 	case DB_TYPE_TIMESTAMPTZ:
-	  v_timestamptz = *DB_GET_TIMESTAMPTZ (src);
+	  v_timestamptz = *db_get_timestamptz (src);
 	  (void) db_timestamp_decode_utc (&v_timestamptz.timestamp, &v_date, &v_time);
 	  v_datetimetz.datetime.time = v_time * 1000;
 	  v_datetimetz.datetime.date = v_date;
@@ -8681,7 +8681,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 
 	case DB_TYPE_DATE:
-	  v_datetime.date = *DB_GET_DATE (src);
+	  v_datetime.date = *db_get_date (src);
 	  v_datetime.time = 0;
 
 	  if (tz_create_datetimetz_from_ses (&v_datetime, &v_datetimetz) != NO_ERROR)
@@ -8693,7 +8693,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 
 	case DB_TYPE_DATETIME:
-	  if (tz_create_datetimetz_from_ses (DB_GET_DATETIME (src), &v_datetimetz) != NO_ERROR)
+	  if (tz_create_datetimetz_from_ses (db_get_datetime (src), &v_datetimetz) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
 	      break;
@@ -8702,7 +8702,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 
 	case DB_TYPE_DATETIMELTZ:
-	  v_datetimetz.datetime = *DB_GET_DATETIME (src);
+	  v_datetimetz.datetime = *db_get_datetime (src);
 	  if (tz_create_session_tzid_for_datetime (&v_datetimetz.datetime, true, &v_datetimetz.tz_id) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
@@ -8760,13 +8760,13 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_UTIME:
 	case DB_TYPE_TIMESTAMPLTZ:
-	  (void) db_timestamp_decode_ses (DB_GET_UTIME (src), &v_date, NULL);
+	  (void) db_timestamp_decode_ses (db_get_utime (src), &v_date, NULL);
 	  db_date_decode (&v_date, &month, &day, &year);
 	  db_make_date (target, month, day, year);
 	  break;
 
 	case DB_TYPE_TIMESTAMPTZ:
-	  v_timestamptz = *DB_GET_TIMESTAMPTZ (src);
+	  v_timestamptz = *db_get_timestamptz (src);
 	  if (db_timestamp_decode_w_tz_id (&v_timestamptz.timestamp, &v_timestamptz.tz_id, &v_date, NULL) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
@@ -8777,7 +8777,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 
 	case DB_TYPE_DATETIME:
-	  db_datetime_decode ((DB_DATETIME *) DB_GET_DATETIME (src), &month, &day, &year, &hour, &minute, &second,
+	  db_datetime_decode ((DB_DATETIME *) db_get_datetime (src), &month, &day, &year, &hour, &minute, &second,
 			      &millisecond);
 	  db_make_date (target, month, day, year);
 	  break;
@@ -8792,7 +8792,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    /* DATETIMELTZ and DATETIMETZ store in UTC, convert to session */
 	    if (original_type == DB_TYPE_DATETIMELTZ)
 	      {
-		utc_dt_p = DB_GET_DATETIME (src);
+		utc_dt_p = db_get_datetime (src);
 		if (tz_create_session_tzid_for_datetime (utc_dt_p, true, &tz_id) != NO_ERROR)
 		  {
 		    status = DOMAIN_ERROR;
@@ -8801,7 +8801,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      }
 	    else
 	      {
-		dt_tz_p = DB_GET_DATETIMETZ (src);
+		dt_tz_p = db_get_datetimetz (src);
 		utc_dt_p = &dt_tz_p->datetime;
 		tz_id = dt_tz_p->tz_id;
 	      }
@@ -8830,7 +8830,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_TIMELTZ:
 	  {
 	    DB_TIME *time_utc_p;
-	    time_utc_p = DB_GET_TIME (src);
+	    time_utc_p = db_get_time (src);
 
 	    if (tz_timeltz_to_local (time_utc_p, &v_time) != NO_ERROR)
 	      {
@@ -8842,7 +8842,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 	case DB_TYPE_TIMETZ:
 	  {
-	    DB_TIMETZ *time_tz_p = DB_GET_TIMETZ (src);
+	    DB_TIMETZ *time_tz_p = db_get_timetz (src);
 
 	    if (tz_utc_timetz_to_local (&time_tz_p->time, &time_tz_p->tz_id, &v_time) != NO_ERROR)
 	      {
@@ -8856,7 +8856,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_UTIME:
 	case DB_TYPE_TIMESTAMPLTZ:
-	  if (db_timestamp_decode_ses (DB_GET_UTIME (src), NULL, &v_time) != NO_ERROR)
+	  if (db_timestamp_decode_ses (db_get_utime (src), NULL, &v_time) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
 	      break;
@@ -8866,7 +8866,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	case DB_TYPE_TIMESTAMPTZ:
 	  /* convert TS from UTC to value TZ */
-	  v_timestamptz = *DB_GET_TIMESTAMPTZ (src);
+	  v_timestamptz = *db_get_timestamptz (src);
 	  if (db_timestamp_decode_w_tz_id (&v_timestamptz.timestamp, &v_timestamptz.tz_id, NULL, &v_time) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
@@ -8875,7 +8875,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  db_value_put_encoded_time (target, &v_time);
 	  break;
 	case DB_TYPE_DATETIME:
-	  db_datetime_decode ((DB_DATETIME *) DB_GET_DATETIME (src), &month, &day, &year, &hour, &minute, &second,
+	  db_datetime_decode ((DB_DATETIME *) db_get_datetime (src), &month, &day, &year, &hour, &minute, &second,
 			      &millisecond);
 	  db_make_time (target, hour, minute, second);
 	  break;
@@ -8883,7 +8883,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  {
 	    DB_DATETIME dt_local;
 
-	    v_datetime = *DB_GET_DATETIME (src);
+	    v_datetime = *db_get_datetime (src);
 
 	    if (tz_datetimeltz_to_local (&v_datetime, &dt_local) != NO_ERROR)
 	      {
@@ -8899,7 +8899,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  {
 	    DB_DATETIME dt_local;
 
-	    v_datetimetz = *DB_GET_DATETIMETZ (src);
+	    v_datetimetz = *db_get_datetimetz (src);
 	    if (tz_utc_datetimetz_to_local (&v_datetimetz.datetime, &v_datetimetz.tz_id, &dt_local) != NO_ERROR)
 	      {
 		status = DOMAIN_ERROR;
@@ -8910,22 +8910,22 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 	case DB_TYPE_SHORT:
-	  v_time = DB_GET_SHORT (src) % SECONDS_IN_A_DAY;
+	  v_time = db_get_short (src) % SECONDS_IN_A_DAY;
 	  db_time_decode (&v_time, &hour, &minute, &second);
 	  db_make_time (target, hour, minute, second);
 	  break;
 	case DB_TYPE_INTEGER:
-	  v_time = DB_GET_INT (src) % SECONDS_IN_A_DAY;
+	  v_time = db_get_int (src) % SECONDS_IN_A_DAY;
 	  db_time_decode (&v_time, &hour, &minute, &second);
 	  db_make_time (target, hour, minute, second);
 	  break;
 	case DB_TYPE_BIGINT:
-	  v_time = DB_GET_BIGINT (src) % SECONDS_IN_A_DAY;
+	  v_time = db_get_bigint (src) % SECONDS_IN_A_DAY;
 	  db_time_decode (&v_time, &hour, &minute, &second);
 	  db_make_time (target, hour, minute, second);
 	  break;
 	case DB_TYPE_MONETARY:
-	  v_money = DB_GET_MONETARY (src);
+	  v_money = db_get_monetary (src);
 	  if (OR_CHECK_INT_OVERFLOW (v_money->amount))
 	    {
 	      status = DOMAIN_OVERFLOW;
@@ -8939,7 +8939,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 	case DB_TYPE_FLOAT:
 	  {
-	    float ftmp = DB_GET_FLOAT (src);
+	    float ftmp = db_get_float (src);
 	    if (OR_CHECK_INT_OVERFLOW (ftmp))
 	      {
 		status = DOMAIN_OVERFLOW;
@@ -8954,7 +8954,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_DOUBLE:
 	  {
-	    double dtmp = DB_GET_DOUBLE (src);
+	    double dtmp = db_get_double (src);
 	    if (OR_CHECK_INT_OVERFLOW (dtmp))
 	      {
 		status = DOMAIN_OVERFLOW;
@@ -9007,7 +9007,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_TIME:
-	  v_time = *(DB_GET_TIME (src));
+	  v_time = *(db_get_time (src));
 
 	  if (tz_check_session_has_geographic_tz () != NO_ERROR)
 	    {
@@ -9015,7 +9015,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      break;
 	    }
 
-	  if (tz_create_timetz_from_ses (DB_GET_TIME (src), &v_timetz) != NO_ERROR)
+	  if (tz_create_timetz_from_ses (db_get_time (src), &v_timetz) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
 	      break;
@@ -9023,27 +9023,27 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  db_make_timeltz (target, &v_timetz.time);
 	  break;
 	case DB_TYPE_TIMETZ:
-	  v_timetz = *(DB_GET_TIMETZ (src));
+	  v_timetz = *(db_get_timetz (src));
 	  assert (tz_check_geographic_tz (&v_timetz.tz_id) == NO_ERROR);
 	  /* copy time value (UTC) */
 	  db_make_timeltz (target, &v_timetz.time);
 	  break;
 	case DB_TYPE_UTIME:
-	  db_timestamp_decode_utc (DB_GET_UTIME (src), NULL, &v_time);
+	  db_timestamp_decode_utc (db_get_utime (src), NULL, &v_time);
 	  db_make_timeltz (target, &v_time);
 	  break;
 	case DB_TYPE_TIMESTAMPLTZ:
-	  db_timestamp_decode_utc (DB_GET_UTIME (src), NULL, &v_time);
+	  db_timestamp_decode_utc (db_get_utime (src), NULL, &v_time);
 	  db_make_timeltz (target, &v_time);
 	  break;
 	case DB_TYPE_TIMESTAMPTZ:
-	  v_timestamptz = *DB_GET_TIMESTAMPTZ (src);
+	  v_timestamptz = *db_get_timestamptz (src);
 	  db_timestamp_decode_utc (&v_timestamptz.timestamp, NULL, &v_time);
 	  db_make_timeltz (target, &v_time);
 	  break;
 	case DB_TYPE_DATETIME:
 	  /* convert to UTC */
-	  if (tz_create_datetimetz_from_ses (DB_GET_DATETIME (src), &v_datetimetz) != NO_ERROR)
+	  if (tz_create_datetimetz_from_ses (db_get_datetime (src), &v_datetimetz) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
 	      break;
@@ -9053,14 +9053,14 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  db_make_timeltz (target, &v_time);
 	  break;
 	case DB_TYPE_DATETIMELTZ:
-	  db_datetime_decode ((DB_DATETIME *) DB_GET_DATETIME (src), &month, &day, &year, &hour, &minute, &second,
+	  db_datetime_decode ((DB_DATETIME *) db_get_datetime (src), &month, &day, &year, &hour, &minute, &second,
 			      &millisecond);
 	  db_time_encode (&v_time, hour, minute, second);
 	  db_make_timeltz (target, &v_time);
 	  break;
 	case DB_TYPE_DATETIMETZ:
 	  /* copy time part (UTC) */
-	  v_datetimetz = *DB_GET_DATETIMETZ (src);
+	  v_datetimetz = *db_get_datetimetz (src);
 	  db_datetime_decode (&v_datetimetz.datetime, &month, &day, &year, &hour, &minute, &second, &millisecond);
 	  db_time_encode (&v_time, hour, minute, second);
 	  db_make_timeltz (target, &v_time);
@@ -9086,7 +9086,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      status = DOMAIN_ERROR;
 	      break;
 	    }
-	  if (tz_create_timetz_from_ses (DB_GET_TIME (&temp), &v_timetz) != NO_ERROR)
+	  if (tz_create_timetz_from_ses (db_get_time (&temp), &v_timetz) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
 	      break;
@@ -9130,7 +9130,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       switch (original_type)
 	{
 	case DB_TYPE_TIME:
-	  if (tz_create_timetz_from_ses (DB_GET_TIME (src), &v_timetz) != NO_ERROR)
+	  if (tz_create_timetz_from_ses (db_get_time (src), &v_timetz) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
 	      break;
@@ -9140,7 +9140,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 	case DB_TYPE_TIMELTZ:
 	  /* copy time value and store TZ of session */
-	  v_timetz.time = *(DB_GET_TIME (src));
+	  v_timetz.time = *(db_get_time (src));
 	  if (tz_create_session_tzid_for_time (&(v_timetz.time), true, &(v_timetz.tz_id)) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
@@ -9154,7 +9154,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_UTIME:
 	case DB_TYPE_TIMESTAMPLTZ:
 	  {
-	    db_timestamp_decode_utc (DB_GET_UTIME (src), NULL, &v_time);
+	    db_timestamp_decode_utc (db_get_utime (src), NULL, &v_time);
 	    if (tz_create_session_tzid_for_time (&v_time, true, &v_timetz.tz_id) != NO_ERROR)
 	      {
 		status = DOMAIN_ERROR;
@@ -9169,7 +9169,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_TIMESTAMPTZ:
 	  {
-	    v_timestamptz = *DB_GET_TIMESTAMPTZ (src);
+	    v_timestamptz = *db_get_timestamptz (src);
 
 	    db_timestamp_decode_utc (&v_timestamptz.timestamp, NULL, &v_time);
 	    v_timetz.time = v_time;
@@ -9182,7 +9182,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_DATETIME:
 	  {
-	    if (tz_create_datetimetz_from_ses (DB_GET_DATETIME (src), &v_datetimetz) != NO_ERROR)
+	    if (tz_create_datetimetz_from_ses (db_get_datetime (src), &v_datetimetz) != NO_ERROR)
 	      {
 		status = DOMAIN_ERROR;
 		break;
@@ -9200,7 +9200,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_DATETIMELTZ:
 	  {
-	    db_datetime_decode ((DB_DATETIME *) DB_GET_DATETIME (src), &month, &day, &year, &hour, &minute, &second,
+	    db_datetime_decode ((DB_DATETIME *) db_get_datetime (src), &month, &day, &year, &hour, &minute, &second,
 				&millisecond);
 	    db_time_encode (&v_time, hour, minute, second);
 	    if (tz_create_session_tzid_for_time (&v_time, true, &v_timetz.tz_id) != NO_ERROR)
@@ -9217,7 +9217,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	case DB_TYPE_DATETIMETZ:
 	  {
-	    v_datetimetz = *DB_GET_DATETIMETZ (src);
+	    v_datetimetz = *db_get_datetimetz (src);
 	    db_datetime_decode (&v_datetimetz.datetime, &month, &day, &year, &hour, &minute, &second, &millisecond);
 	    db_time_encode (&v_time, hour, minute, second);
 	    v_timetz.time = v_time;
@@ -9244,7 +9244,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	  assert (DB_VALUE_TYPE (&temp) == DB_TYPE_TIME);
 
-	  if (tz_create_timetz_from_ses (DB_GET_TIME (&temp), &v_timetz) != NO_ERROR)
+	  if (tz_create_timetz_from_ses (db_get_time (&temp), &v_timetz) != NO_ERROR)
 	    {
 	      status = DOMAIN_ERROR;
 	      break;
@@ -9292,17 +9292,17 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	switch (original_type)
 	  {
 	  case DB_TYPE_OBJECT:
-	    if (!sm_coerce_object_domain ((TP_DOMAIN *) desired_domain, DB_GET_OBJECT (src), &v_obj))
+	    if (!sm_coerce_object_domain ((TP_DOMAIN *) desired_domain, db_get_object (src), &v_obj))
 	      {
 		status = DOMAIN_INCOMPATIBLE;
 	      }
 	    break;
 	  case DB_TYPE_POINTER:
-	    if (!sm_check_class_domain ((TP_DOMAIN *) desired_domain, ((DB_OTMPL *) DB_GET_POINTER (src))->classobj))
+	    if (!sm_check_class_domain ((TP_DOMAIN *) desired_domain, ((DB_OTMPL *) db_get_pointer (src))->classobj))
 	      {
 		status = DOMAIN_INCOMPATIBLE;
 	      }
-	    db_make_pointer (target, DB_GET_POINTER (src));
+	    db_make_pointer (target, db_get_pointer (src));
 	    break;
 	  case DB_TYPE_OID:
 	    vid_oid_to_object (src, &v_obj);
@@ -9487,7 +9487,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 #if !defined (SERVER_MODE)
       if (original_type == DB_TYPE_OBJECT)
 	{
-	  if (vid_object_to_vobj (DB_GET_OBJECT (src), target) < 0)
+	  if (vid_object_to_vobj (db_get_object (src), target) < 0)
 	    {
 	      status = DOMAIN_INCOMPATIBLE;
 	    }
@@ -9508,8 +9508,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  DB_SEQ *seq;
 
 	  OID_SET_NULL (&nulloid);
-	  DB_MAKE_OID (&class_oid, &nulloid);
-	  DB_MAKE_OID (&view_oid, &nulloid);
+	  db_make_oid (&class_oid, &nulloid);
+	  db_make_oid (&view_oid, &nulloid);
 	  seq = db_seq_create (NULL, NULL, 3);
 	  keys = *src;
 
@@ -9552,13 +9552,13 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  {
 	    DB_VALUE temp;
 	    char *bit_char_string;
-	    int src_size = DB_GET_STRING_SIZE (src);
+	    int src_size = db_get_string_size (src);
 	    int dst_size = (src_size + 1) / 2;
 
 	    bit_char_string = (char *) db_private_alloc (NULL, dst_size + 1);
 	    if (bit_char_string)
 	      {
-		if (qstr_hex_to_bin (bit_char_string, dst_size, DB_GET_STRING (src), src_size) != src_size)
+		if (qstr_hex_to_bin (bit_char_string, dst_size, db_get_string (src), src_size) != src_size)
 		  {
 		    status = DOMAIN_ERROR;
 		    db_private_free_and_init (NULL, bit_char_string);
@@ -9608,7 +9608,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  {
 	    DB_VALUE tmpval;
 
-	    DB_MAKE_NULL (&tmpval);
+	    db_make_null (&tmpval);
 
 	    err = db_blob_to_bit (src, NULL, &tmpval);
 	    if (err == NO_ERROR)
@@ -9720,15 +9720,15 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	    if (original_type == DB_TYPE_BIGINT)
 	      {
-		num = DB_GET_BIGINT (src);
+		num = db_get_bigint (src);
 	      }
 	    else if (original_type == DB_TYPE_INTEGER)
 	      {
-		num = (DB_BIGINT) DB_GET_INT (src);
+		num = (DB_BIGINT) db_get_int (src);
 	      }
 	    else		/* DB_TYPE_SHORT */
 	      {
-		num = (DB_BIGINT) DB_GET_SHORT (src);
+		num = (DB_BIGINT) db_get_short (src);
 	      }
 
 	    if (tp_ltoa (num, new_string, 10))
@@ -9778,7 +9778,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		  }
 	      }
 	    else if (DB_VALUE_PRECISION (target) != TP_FLOATING_PRECISION_VALUE
-		     && (DB_GET_STRING_LENGTH (target) > DB_VALUE_PRECISION (target)))
+		     && (db_get_string_length (target) > DB_VALUE_PRECISION (target)))
 	      {
 		status = DOMAIN_OVERFLOW;
 		pr_clear_value (target);
@@ -9829,8 +9829,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		return DOMAIN_ERROR;
 	      }
 
-	    snprintf (new_string, max_size - 1, "%s%.*f", lang_currency_symbol (DB_GET_MONETARY (src)->type), 2,
-		      DB_GET_MONETARY (src)->amount);
+	    snprintf (new_string, max_size - 1, "%s%.*f", lang_currency_symbol (db_get_monetary (src)->type), 2,
+		      db_get_monetary (src)->amount);
 	    new_string[max_size - 1] = '\0';
 
 	    p = new_string + strlen (new_string);
@@ -9881,17 +9881,17 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    switch (original_type)
 	      {
 	      case DB_TYPE_DATE:
-		db_date_to_string (new_string, max_size, (DB_DATE *) DB_GET_DATE (src));
+		db_date_to_string (new_string, max_size, (DB_DATE *) db_get_date (src));
 		break;
 	      case DB_TYPE_TIME:
-		db_time_to_string (new_string, max_size, (DB_TIME *) DB_GET_TIME (src));
+		db_time_to_string (new_string, max_size, (DB_TIME *) db_get_time (src));
 		break;
 	      case DB_TYPE_TIMETZ:
-		v_timetz = *DB_GET_TIMETZ (src);
+		v_timetz = *db_get_timetz (src);
 		db_timetz_to_string (new_string, max_size, &v_timetz.time, &v_timetz.tz_id);
 		break;
 	      case DB_TYPE_TIMELTZ:
-		v_time = *DB_GET_TIME (src);
+		v_time = *db_get_time (src);
 		err = tz_create_session_tzid_for_time (&v_time, true, &ses_tz_id);
 		if (err != NO_ERROR)
 		  {
@@ -9901,10 +9901,10 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		db_timetz_to_string (new_string, max_size, &v_time, &ses_tz_id);
 		break;
 	      case DB_TYPE_TIMESTAMP:
-		db_timestamp_to_string (new_string, max_size, (DB_TIMESTAMP *) DB_GET_TIMESTAMP (src));
+		db_timestamp_to_string (new_string, max_size, (DB_TIMESTAMP *) db_get_timestamp (src));
 		break;
 	      case DB_TYPE_TIMESTAMPLTZ:
-		v_utime = *DB_GET_TIMESTAMP (src);
+		v_utime = *db_get_timestamp (src);
 		err = tz_create_session_tzid_for_timestamp (&v_utime, &ses_tz_id);
 		if (err != NO_ERROR)
 		  {
@@ -9913,11 +9913,11 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		db_timestamptz_to_string (new_string, max_size, &v_utime, &ses_tz_id);
 		break;
 	      case DB_TYPE_TIMESTAMPTZ:
-		v_timestamptz = *DB_GET_TIMESTAMPTZ (src);
+		v_timestamptz = *db_get_timestamptz (src);
 		db_timestamptz_to_string (new_string, max_size, &v_timestamptz.timestamp, &v_timestamptz.tz_id);
 		break;
 	      case DB_TYPE_DATETIMELTZ:
-		v_datetime = *DB_GET_DATETIME (src);
+		v_datetime = *db_get_datetime (src);
 		err = tz_create_session_tzid_for_datetime (&v_datetime, true, &ses_tz_id);
 		if (err != NO_ERROR)
 		  {
@@ -9926,12 +9926,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		db_datetimetz_to_string (new_string, max_size, &v_datetime, &ses_tz_id);
 		break;
 	      case DB_TYPE_DATETIMETZ:
-		v_datetimetz = *DB_GET_DATETIMETZ (src);
+		v_datetimetz = *db_get_datetimetz (src);
 		db_datetimetz_to_string (new_string, max_size, &v_datetimetz.datetime, &v_datetimetz.tz_id);
 		break;
 	      case DB_TYPE_DATETIME:
 	      default:
-		db_datetime_to_string (new_string, max_size, (DB_DATETIME *) DB_GET_DATETIME (src));
+		db_datetime_to_string (new_string, max_size, (DB_DATETIME *) db_get_datetime (src));
 		break;
 	      }
 
@@ -10010,9 +10010,9 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		DB_VALUE tmpval;
 		DB_VALUE cs;
 
-		DB_MAKE_NULL (&tmpval);
+		db_make_null (&tmpval);
 		/* convert directly from CLOB into charset of desired domain string */
-		DB_MAKE_INTEGER (&cs, desired_domain->codeset);
+		db_make_int (&cs, desired_domain->codeset);
 		err = db_clob_to_char (src, &cs, &tmpval);
 		if (err == NO_ERROR)
 		  {
@@ -10031,7 +10031,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    char *json_str;
 	    int len;
 
-	    json_str = db_json_get_raw_json_body_from_document (DB_GET_JSON_DOCUMENT (src));
+	    json_str = db_json_get_raw_json_body_from_document (db_get_json_document (src));
 	    len = strlen (json_str);
 
 	    if (db_value_precision (target) != TP_FLOATING_PRECISION_VALUE && db_value_precision (target) < len)
@@ -10124,7 +10124,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	bool exit = false, alloc_string = true;
 	DB_VALUE conv_val;
 
-	DB_MAKE_NULL (&conv_val);
+	db_make_null (&conv_val);
 
 	if (src->domain.general_info.is_null)
 	  {
@@ -10135,46 +10135,46 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	switch (original_type)
 	  {
 	  case DB_TYPE_SHORT:
-	    val_idx = (unsigned short) DB_GET_SHORT (src);
+	    val_idx = (unsigned short) db_get_short (src);
 	    break;
 	  case DB_TYPE_INTEGER:
-	    if (OR_CHECK_USHRT_OVERFLOW (DB_GET_INT (src)))
+	    if (OR_CHECK_USHRT_OVERFLOW (db_get_int (src)))
 	      {
 		status = DOMAIN_INCOMPATIBLE;
 	      }
 	    else
 	      {
-		val_idx = (unsigned short) DB_GET_INT (src);
+		val_idx = (unsigned short) db_get_int (src);
 	      }
 	    break;
 	  case DB_TYPE_BIGINT:
-	    if (OR_CHECK_USHRT_OVERFLOW (DB_GET_BIGINT (src)))
+	    if (OR_CHECK_USHRT_OVERFLOW (db_get_bigint (src)))
 	      {
 		status = DOMAIN_INCOMPATIBLE;
 	      }
 	    else
 	      {
-		val_idx = (unsigned short) DB_GET_BIGINT (src);
+		val_idx = (unsigned short) db_get_bigint (src);
 	      }
 	    break;
 	  case DB_TYPE_FLOAT:
-	    if (OR_CHECK_USHRT_OVERFLOW (floor (DB_GET_FLOAT (src))))
+	    if (OR_CHECK_USHRT_OVERFLOW (floor (db_get_float (src))))
 	      {
 		status = DOMAIN_INCOMPATIBLE;
 	      }
 	    else
 	      {
-		val_idx = (unsigned short) floor (DB_GET_FLOAT (src));
+		val_idx = (unsigned short) floor (db_get_float (src));
 	      }
 	    break;
 	  case DB_TYPE_DOUBLE:
-	    if (OR_CHECK_USHRT_OVERFLOW (floor (DB_GET_DOUBLE (src))))
+	    if (OR_CHECK_USHRT_OVERFLOW (floor (db_get_double (src))))
 	      {
 		status = DOMAIN_INCOMPATIBLE;
 	      }
 	    else
 	      {
-		val_idx = (unsigned short) floor (DB_GET_DOUBLE (src));
+		val_idx = (unsigned short) floor (db_get_double (src));
 	      }
 	    break;
 	  case DB_TYPE_NUMERIC:
@@ -10183,7 +10183,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      DB_DATA_STATUS stat = DATA_STATUS_OK;
 	      int err = NO_ERROR;
 
-	      DB_MAKE_DOUBLE (&val, 0);
+	      db_make_double (&val, 0);
 	      err = numeric_db_value_coerce_from_num ((DB_VALUE *) src, &val, &stat);
 	      if (err != NO_ERROR)
 		{
@@ -10191,19 +10191,19 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		}
 	      else
 		{
-		  if (OR_CHECK_USHRT_OVERFLOW (floor (DB_GET_DOUBLE (&val))))
+		  if (OR_CHECK_USHRT_OVERFLOW (floor (db_get_double (&val))))
 		    {
 		      status = DOMAIN_INCOMPATIBLE;
 		    }
 		  else
 		    {
-		      val_idx = (unsigned short) floor (DB_GET_DOUBLE (&val));
+		      val_idx = (unsigned short) floor (db_get_double (&val));
 		    }
 		}
 	      break;
 	    }
 	  case DB_TYPE_MONETARY:
-	    v_money = DB_GET_MONETARY (src);
+	    v_money = db_get_monetary (src);
 	    if (OR_CHECK_USHRT_OVERFLOW (floor (v_money->amount)))
 	      {
 		status = DOMAIN_INCOMPATIBLE;
@@ -10233,21 +10233,21 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 					do_domain_select, false);
 	      if (status == DOMAIN_COMPATIBLE)
 		{
-		  val_str = DB_GET_STRING (&conv_val);
-		  val_str_size = DB_GET_STRING_SIZE (&conv_val);
+		  val_str = db_get_string (&conv_val);
+		  val_str_size = db_get_string_size (&conv_val);
 		}
 	    }
 	    break;
 	  case DB_TYPE_CHAR:
 	  case DB_TYPE_VARCHAR:
-	    if (DB_GET_STRING_CODESET (src) != TP_DOMAIN_CODESET (desired_domain))
+	    if (db_get_string_codeset (src) != TP_DOMAIN_CODESET (desired_domain))
 	      {
 		DB_DATA_STATUS data_status = DATA_STATUS_OK;
 
 		if (TP_DOMAIN_CODESET (desired_domain) == INTL_CODESET_RAW_BYTES)
 		  {
 		    /* avoid data truncation when converting to binary charset */
-		    db_value_domain_init (&conv_val, DB_VALUE_TYPE (src), DB_GET_STRING_SIZE (src), 0);
+		    db_value_domain_init (&conv_val, DB_VALUE_TYPE (src), db_get_string_size (src), 0);
 		  }
 		else
 		  {
@@ -10264,14 +10264,14 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		  }
 		else
 		  {
-		    val_str = DB_GET_STRING (&conv_val);
-		    val_str_size = DB_GET_STRING_SIZE (&conv_val);
+		    val_str = db_get_string (&conv_val);
+		    val_str_size = db_get_string_size (&conv_val);
 		  }
 	      }
 	    else
 	      {
-		val_str = DB_GET_STRING (src);
-		val_str_size = DB_GET_STRING_SIZE (src);
+		val_str = db_get_string (src);
+		val_str_size = db_get_string_size (src);
 	      }
 	    break;
 	  case DB_TYPE_ENUMERATION:
@@ -10281,17 +10281,17 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		exit = true;
 		break;
 	      }
-	    val_str = DB_GET_ENUM_STRING (src);
-	    val_str_size = DB_GET_ENUM_STRING_SIZE (src);
+	    val_str = db_get_enum_string (src);
+	    val_str_size = db_get_enum_string_size (src);
 	    if (val_str == NULL)
 	      {
 		/* src has a short value or a string value or both. We prefer to use the string value when matching
 		 * against the desired domain but, if this is not set, we will use the value index */
-		val_idx = DB_GET_ENUM_SHORT (src);
+		val_idx = db_get_enum_short (src);
 	      }
 	    else
 	      {
-		if (DB_GET_ENUM_CODESET (src) != TP_DOMAIN_CODESET (desired_domain))
+		if (db_get_enum_codeset (src) != TP_DOMAIN_CODESET (desired_domain))
 		  {
 		    /* first convert charset of the original value to charset of destination domain */
 		    DB_VALUE tmp;
@@ -10299,8 +10299,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 		    /* charset conversion can handle only CHAR/VARCHAR DB_VALUEs, create a STRING value with max
 		     * precision (so that no truncation occurs) from the ENUM source string */
-		    DB_MAKE_VARCHAR (&tmp, DB_MAX_STRING_LENGTH, val_str, val_str_size, DB_GET_ENUM_CODESET (src),
-				     DB_GET_ENUM_COLLATION (src));
+		    db_make_varchar (&tmp, DB_MAX_STRING_LENGTH, val_str, val_str_size, db_get_enum_codeset (src),
+				     db_get_enum_collation (src));
 
 		    /* initialize destination value of conversion */
 		    db_value_domain_init (&conv_val, DB_TYPE_STRING, DB_MAX_STRING_LENGTH, 0);
@@ -10317,8 +10317,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		      }
 		    else
 		      {
-			val_str = DB_GET_STRING (&conv_val);
-			val_str_size = DB_GET_STRING_SIZE (&conv_val);
+			val_str = db_get_string (&conv_val);
+			val_str_size = db_get_string_size (&conv_val);
 		      }
 		    pr_clear_value (&tmp);
 		  }
@@ -10363,7 +10363,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		      {
 			/* The source value is string with length 0 and can be matched with enum "special error value"
 			 * if it's not a valid ENUM value */
-			DB_MAKE_ENUMERATION (target, 0, NULL, 0, TP_DOMAIN_CODESET (desired_domain),
+			db_make_enumeration (target, 0, NULL, 0, TP_DOMAIN_CODESET (desired_domain),
 					     TP_DOMAIN_COLLATION (desired_domain));
 			break;
 		      }
@@ -10383,7 +10383,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		else if (val_idx == 0)
 		  {
 		    /* ENUM Special error value */
-		    DB_MAKE_ENUMERATION (target, 0, NULL, 0, TP_DOMAIN_CODESET (desired_domain),
+		    db_make_enumeration (target, 0, NULL, 0, TP_DOMAIN_CODESET (desired_domain),
 					 TP_DOMAIN_COLLATION (desired_domain));
 		    break;
 		  }
@@ -10426,7 +10426,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		  {
 		    enum_str = val_str;
 		  }
-		DB_MAKE_ENUMERATION (target, val_idx, enum_str, val_str_size, TP_DOMAIN_CODESET (desired_domain),
+		db_make_enumeration (target, val_idx, enum_str, val_str_size, TP_DOMAIN_CODESET (desired_domain),
 				     TP_DOMAIN_COLLATION (desired_domain));
 		target->need_clear = true;
 	      }
@@ -10446,8 +10446,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  case DB_TYPE_NCHAR:
 	  case DB_TYPE_VARNCHAR:
 	    {
-	      unsigned int str_size = DB_GET_STRING_SIZE (src);
-	      const char *original_str = DB_GET_STRING (src);
+	      unsigned int str_size = db_get_string_size (src);
+	      const char *original_str = db_get_string (src);
 	      int error_code;
 
 	      assert (str_size >= 0);	/* if this isn't correct, we cannot rely on strlen */
@@ -10484,11 +10484,11 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  case DB_TYPE_INTEGER:
 	    doc = db_json_allocate_doc ();
-	    db_json_set_int_to_doc (doc, DB_GET_INT (src));
+	    db_json_set_int_to_doc (doc, db_get_int (src));
 	    break;
 	  case DB_TYPE_DOUBLE:
 	    doc = db_json_allocate_doc ();
-	    db_json_set_double_to_doc (doc, DB_GET_DOUBLE (src));
+	    db_json_set_double_to_doc (doc, db_get_double (src));
 	    break;
 	  case DB_TYPE_NUMERIC:
 	    {
@@ -10496,7 +10496,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	      doc = db_json_allocate_doc ();
 	      db_value_coerce (src, &double_value, db_type_to_db_domain (DB_TYPE_DOUBLE));
-	      db_json_set_double_to_doc (doc, DB_GET_DOUBLE (&double_value));
+	      db_json_set_double_to_doc (doc, db_get_double (&double_value));
 	      pr_clear_value (&double_value);
 	    }
 	    break;
@@ -10643,7 +10643,7 @@ tp_value_change_coll_and_codeset (DB_VALUE * src, DB_VALUE * dest, int coll_id, 
   assert (src != NULL && dest != NULL);
   assert (TP_IS_STRING_TYPE (DB_VALUE_TYPE (src)));
 
-  if (DB_GET_STRING_COLLATION (src) == coll_id && DB_GET_STRING_CODESET (src) == codeset)
+  if (db_get_string_collation (src) == coll_id && db_get_string_codeset (src) == codeset)
     {
       /* early exit scenario */
       return DOMAIN_COMPATIBLE;
@@ -10822,7 +10822,7 @@ tp_set_compare (const DB_VALUE * value1, const DB_VALUE * value2, int do_coercio
 	    }
 	  else
 	    {
-	      DB_MAKE_NULL (&temp);
+	      db_make_null (&temp);
 	      coercion = 1;
 	      if (tp_more_general_type (vtype1, vtype2) > 0)
 		{
@@ -11039,8 +11039,8 @@ tp_value_compare_with_error (const DB_VALUE * value1, const DB_VALUE * value2, i
 	   */
 	  if (do_coercion && !ARE_COMPARABLE (vtype1, vtype2))
 	    {
-	      DB_MAKE_NULL (&temp1);
-	      DB_MAKE_NULL (&temp2);
+	      db_make_null (&temp1);
+	      db_make_null (&temp2);
 	      coercion = 1;
 
 	      if (TP_IS_CHAR_TYPE (vtype1) && TP_IS_NUMERIC_TYPE (vtype2))
@@ -11119,16 +11119,16 @@ tp_value_compare_with_error (const DB_VALUE * value1, const DB_VALUE * value2, i
 		      if (TP_IS_CHAR_TYPE (vtype2))
 			{
 			  /* keep the codeset and collation from original value v2 */
-			  d1->codeset = DB_GET_STRING_CODESET (v2);
-			  d1->collation_id = DB_GET_STRING_COLLATION (v2);
+			  d1->codeset = db_get_string_codeset (v2);
+			  d1->collation_id = db_get_string_collation (v2);
 			}
 		      else
 			{
 			  /* v2 is ENUM, and is coerced to string this should happend when the other operand is a HV;
 			   * in this case we remember to use collation and charset from ENUM (v2) */
 			  use_collation_of_v2 = true;
-			  d1->codeset = DB_GET_ENUM_CODESET (v2);
-			  d1->collation_id = DB_GET_ENUM_COLLATION (v2);
+			  d1->codeset = db_get_enum_codeset (v2);
+			  d1->collation_id = db_get_enum_collation (v2);
 			  common_coll = d1->collation_id;
 			}
 
@@ -11162,16 +11162,16 @@ tp_value_compare_with_error (const DB_VALUE * value1, const DB_VALUE * value2, i
 		      if (TP_IS_CHAR_TYPE (vtype1))
 			{
 			  /* keep the codeset and collation from original value v1 */
-			  d2->codeset = DB_GET_STRING_CODESET (v1);
-			  d2->collation_id = DB_GET_STRING_COLLATION (v1);
+			  d2->codeset = db_get_string_codeset (v1);
+			  d2->collation_id = db_get_string_collation (v1);
 			}
 		      else
 			{
 			  /* v1 is ENUM, and is coerced to string this should happend when the other operand is a HV;
 			   * in this case we remember to use collation and charset from ENUM (v1) */
 			  use_collation_of_v1 = true;
-			  d2->codeset = DB_GET_ENUM_CODESET (v1);
-			  d2->collation_id = DB_GET_ENUM_COLLATION (v1);
+			  d2->codeset = db_get_enum_codeset (v1);
+			  d2->collation_id = db_get_enum_collation (v1);
 			  common_coll = d2->collation_id;
 			}
 
@@ -11238,9 +11238,9 @@ tp_value_compare_with_error (const DB_VALUE * value1, const DB_VALUE * value2, i
 		{
 		  common_coll = 0;
 		}
-	      else if (DB_GET_STRING_COLLATION (v1) == DB_GET_STRING_COLLATION (v2))
+	      else if (db_get_string_collation (v1) == db_get_string_collation (v2))
 		{
-		  common_coll = DB_GET_STRING_COLLATION (v1);
+		  common_coll = db_get_string_collation (v1);
 		}
 	      else if (TP_IS_CHAR_TYPE (vtype1) && (use_collation_of_v1 || use_collation_of_v2))
 		{
@@ -11248,23 +11248,23 @@ tp_value_compare_with_error (const DB_VALUE * value1, const DB_VALUE * value2, i
 		  DB_DATA_STATUS data_status;
 		  int error_status;
 
-		  DB_MAKE_NULL (&tmp_char_conv);
+		  db_make_null (&tmp_char_conv);
 		  char_conv = 1;
 
 		  if (use_collation_of_v1)
 		    {
 		      assert (!use_collation_of_v2);
-		      common_coll = DB_GET_STRING_COLLATION (v1);
+		      common_coll = db_get_string_collation (v1);
 		    }
 		  else
 		    {
 		      assert (use_collation_of_v2 == true);
-		      common_coll = DB_GET_STRING_COLLATION (v2);
+		      common_coll = db_get_string_collation (v2);
 		    }
 
 		  codeset = lang_get_collation (common_coll)->codeset;
 
-		  if (DB_GET_STRING_CODESET (v1) != codeset)
+		  if (db_get_string_codeset (v1) != codeset)
 		    {
 		      db_value_domain_init (&tmp_char_conv, vtype1, DB_VALUE_PRECISION (v1), 0);
 
@@ -11286,7 +11286,7 @@ tp_value_compare_with_error (const DB_VALUE * value1, const DB_VALUE * value2, i
 
 		      v1 = &tmp_char_conv;
 		    }
-		  else if (DB_GET_STRING_CODESET (v2) != codeset)
+		  else if (db_get_string_codeset (v2) != codeset)
 		    {
 		      db_value_domain_init (&tmp_char_conv, vtype2, DB_VALUE_PRECISION (v2), 0);
 
@@ -11309,9 +11309,9 @@ tp_value_compare_with_error (const DB_VALUE * value1, const DB_VALUE * value2, i
 		      v2 = &tmp_char_conv;
 		    }
 		}
-	      else if (TP_IS_CHAR_TYPE (vtype1) && DB_GET_STRING_CODESET (v1) == DB_GET_STRING_CODESET (v2))
+	      else if (TP_IS_CHAR_TYPE (vtype1) && db_get_string_codeset (v1) == db_get_string_codeset (v2))
 		{
-		  LANG_RT_COMMON_COLL (DB_GET_STRING_COLLATION (v1), DB_GET_STRING_COLLATION (v2), common_coll);
+		  LANG_RT_COMMON_COLL (db_get_string_collation (v1), db_get_string_collation (v2), common_coll);
 		}
 
 	      if (common_coll == -1)
@@ -11541,7 +11541,7 @@ tp_check_value_size (TP_DOMAIN * domain, DB_VALUE * value)
 	   * A floating precision is determined by the length of the string
 	   * value.
 	   */
-	  src = DB_GET_STRING (value);
+	  src = db_get_string (value);
 	  if (src != NULL)
 	    {
 	      src_precision = db_value_precision (value);
@@ -11575,7 +11575,7 @@ tp_check_value_size (TP_DOMAIN * domain, DB_VALUE * value)
 	   * The compatibility of the value is always determined by the
 	   * actual length of the value, not the destination precision.
 	   */
-	  src = DB_GET_STRING (value);
+	  src = db_get_string (value);
 	  if (src != NULL)
 	    {
 	      if (!TP_IS_BIT_TYPE (dbtype))
@@ -11869,7 +11869,7 @@ tp_value_auto_cast (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN * des
 	{
 	  status = DOMAIN_COMPATIBLE;
 	  pr_clear_value (dest);
-	  DB_MAKE_NULL (dest);
+	  db_make_null (dest);
 	  er_clear ();
 	}
     }
@@ -11901,7 +11901,7 @@ tp_value_str_auto_cast_to_number (DB_VALUE * src, DB_VALUE * dest, DB_TYPE * val
   assert (TP_IS_CHAR_TYPE (*val_type));
   assert (src != dest);
 
-  DB_MAKE_NULL (dest);
+  db_make_null (dest);
 
   /* cast string to DOUBLE */
   cast_dom = tp_domain_resolve_default (DB_TYPE_DOUBLE);

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -1160,7 +1160,7 @@ PR_TYPE tp_Timeltz = {
 PR_TYPE *tp_Type_timeltz = &tp_Timeltz;
 
 PR_TYPE tp_Utime = {
-  "timestamp", DB_TYPE_UTIME, 0, sizeof (DB_UTIME), OR_UTIME_SIZE, 4,
+  "timestamp", DB_TYPE_TIMESTAMP, 0, sizeof (DB_UTIME), OR_UTIME_SIZE, 4,
   help_fprint_value,
   help_sprint_value,
   mr_initmem_utime,
@@ -4049,7 +4049,7 @@ mr_setmem_utime (void *mem, TP_DOMAIN * domain, DB_VALUE * value)
   if (value == NULL)
     mr_initmem_utime (mem, domain);
   else
-    *(DB_UTIME *) mem = *db_get_utime (value);
+    *(DB_UTIME *) mem = *db_get_timestamp (value);
 
   return NO_ERROR;
 }
@@ -4114,11 +4114,11 @@ mr_setval_utime (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 
   if (DB_IS_NULL (src))
     {
-      error = db_value_domain_init (dest, DB_TYPE_UTIME, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
+      error = db_value_domain_init (dest, DB_TYPE_TIMESTAMP, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
     }
   else
     {
-      error = db_make_utime (dest, *db_get_utime (src));
+      error = db_make_utime (dest, *db_get_timestamp (src));
     }
   return error;
 }
@@ -4134,7 +4134,7 @@ mr_setval_timestampltz (DB_VALUE * dest, const DB_VALUE * src, bool copy)
     }
   else
     {
-      error = db_make_timestampltz (dest, *db_get_utime (src));
+      error = db_make_timestampltz (dest, *db_get_timestamp (src));
     }
   return error;
 }
@@ -4142,7 +4142,7 @@ mr_setval_timestampltz (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 static int
 mr_data_writeval_utime (OR_BUF * buf, DB_VALUE * value)
 {
-  return or_put_utime (buf, db_get_utime (value));
+  return or_put_utime (buf, db_get_timestamp (value));
 }
 
 static int
@@ -4193,7 +4193,7 @@ mr_index_writeval_utime (OR_BUF * buf, DB_VALUE * value)
 {
   DB_UTIME *utm;
 
-  utm = db_get_utime (value);
+  utm = db_get_timestamp (value);
 
   return or_put_data (buf, (char *) utm, tp_Utime.disksize);
 }
@@ -4277,8 +4277,8 @@ mr_cmpval_utime (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
 {
   const DB_TIMESTAMP *ts1, *ts2;
 
-  ts1 = db_get_utime (value1);
-  ts2 = db_get_utime (value2);
+  ts1 = db_get_timestamp (value1);
+  ts2 = db_get_timestamp (value2);
 
   return MR_CMP (*ts1, *ts2);
 }

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2158,13 +2158,13 @@ pr_clear_value (DB_VALUE * value)
     case DB_TYPE_ENUMERATION:
       if (value->need_clear)
 	{
-	  char *temp = DB_GET_ENUM_STRING (value);
+	  char *temp = db_get_enum_string (value);
 	  if (temp != NULL)
 	    {
 	      db_private_free_and_init (NULL, temp);
 	    }
 	}
-      db_make_enumeration (value, 0, NULL, 0, DB_GET_ENUM_CODESET (value), DB_GET_ENUM_COLLATION (value));
+      db_make_enumeration (value, 0, NULL, 0, db_get_enum_codeset (value), db_get_enum_collation (value));
       break;
 
     default:
@@ -2706,8 +2706,8 @@ mr_cmpval_int (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total_
 {
   int i1, i2;
 
-  i1 = DB_GET_INT (value1);
-  i2 = DB_GET_INT (value2);
+  i1 = db_get_int (value1);
+  i2 = db_get_int (value2);
 
   return MR_CMP (i1, i2);
 }
@@ -2879,8 +2879,8 @@ mr_cmpval_short (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
 {
   short s1, s2;
 
-  s1 = DB_GET_SHORT (value1);
-  s2 = DB_GET_SHORT (value2);
+  s1 = db_get_short (value1);
+  s2 = db_get_short (value2);
 
   return MR_CMP (s1, s2);
 }
@@ -3051,8 +3051,8 @@ mr_cmpval_bigint (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
 {
   DB_BIGINT i1, i2;
 
-  i1 = DB_GET_BIGINT (value1);
-  i2 = DB_GET_BIGINT (value2);
+  i1 = db_get_bigint (value1);
+  i2 = db_get_bigint (value2);
 
   return MR_CMP (i1, i2);
 }
@@ -3225,8 +3225,8 @@ mr_cmpval_float (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
 {
   float f1, f2;
 
-  f1 = DB_GET_FLOAT (value1);
-  f2 = DB_GET_FLOAT (value2);
+  f1 = db_get_float (value1);
+  f2 = db_get_float (value2);
 
   return MR_CMP (f1, f2);
 }
@@ -3417,8 +3417,8 @@ mr_cmpval_double (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
 {
   double d1, d2;
 
-  d1 = DB_GET_DOUBLE (value1);
-  d2 = DB_GET_DOUBLE (value2);
+  d1 = db_get_double (value1);
+  d2 = db_get_double (value2);
 
   return MR_CMP (d1, d2);
 }
@@ -3730,8 +3730,8 @@ mr_cmpval_timeltz (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int to
   DB_TIME t1_local, t2_local;
   int error = NO_ERROR;
 
-  t1 = DB_GET_TIME (value1);
-  t2 = DB_GET_TIME (value2);
+  t1 = db_get_time (value1);
+  t2 = db_get_time (value2);
 
   error = tz_create_session_tzid_for_time (t1, true, &ses_tz_id1);
   if (error != NO_ERROR)
@@ -3791,8 +3791,8 @@ mr_cmpval_time (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
 {
   const DB_TIME *t1, *t2;
 
-  t1 = DB_GET_TIME (value1);
-  t2 = DB_GET_TIME (value2);
+  t1 = db_get_time (value1);
+  t2 = db_get_time (value2);
 
   return MR_CMP (*t1, *t2);
 }
@@ -4007,8 +4007,8 @@ mr_cmpval_timetz (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
   DB_VALUE_COMPARE_RESULT ret_cmp;
   int day1, day2;
 
-  t1 = DB_GET_TIMETZ (value1);
-  t2 = DB_GET_TIMETZ (value2);
+  t1 = db_get_timetz (value1);
+  t2 = db_get_timetz (value2);
 
   /* TIME with TZ compares as what point in time comes first relative to the current day */
 
@@ -4277,8 +4277,8 @@ mr_cmpval_utime (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
 {
   const DB_TIMESTAMP *ts1, *ts2;
 
-  ts1 = DB_GET_UTIME (value1);
-  ts2 = DB_GET_UTIME (value2);
+  ts1 = db_get_utime (value1);
+  ts2 = db_get_utime (value2);
 
   return MR_CMP (*ts1, *ts2);
 }
@@ -4474,8 +4474,8 @@ mr_cmpval_timestamptz (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, in
 
   /* TIMESTAMP with TZ compares the same as TIMESTAMP (zone is not taken into account); the first component of
    * TIMESTAMPTZ is a TIMESTAMP, it is safe to use the TIMESTAMP part of DB_DATA union to read it */
-  ts_tz1 = DB_GET_TIMESTAMPTZ (value1);
-  ts_tz2 = DB_GET_TIMESTAMPTZ (value2);
+  ts_tz1 = db_get_timestamptz (value1);
+  ts_tz2 = db_get_timestamptz (value2);
 
 #if defined (SA_MODE)
   if (tz_Compare_timestamptz_tz_id == true && ts_tz1->tz_id != ts_tz2->tz_id)
@@ -4824,8 +4824,8 @@ mr_cmpval_datetime (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int t
   const DB_DATETIME *dt1, *dt2;
   DB_VALUE_COMPARE_RESULT c;
 
-  dt1 = DB_GET_DATETIME (value1);
-  dt2 = DB_GET_DATETIME (value2);
+  dt1 = db_get_datetime (value1);
+  dt2 = db_get_datetime (value2);
 
   if (dt1->date < dt2->date)
     {
@@ -5041,8 +5041,8 @@ mr_cmpval_datetimetz (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int
   const DB_DATETIME *dt1, *dt2;
   DB_VALUE_COMPARE_RESULT c;
 
-  dt_tz1 = DB_GET_DATETIMETZ (value1);
-  dt_tz2 = DB_GET_DATETIMETZ (value2);
+  dt_tz1 = db_get_datetimetz (value1);
+  dt_tz2 = db_get_datetimetz (value2);
 
   dt1 = &(dt_tz1->datetime);
   dt2 = &(dt_tz2->datetime);
@@ -5283,8 +5283,8 @@ mr_cmpval_money (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
 {
   const DB_MONETARY *m1, *m2;
 
-  m1 = DB_GET_MONETARY (value1);
-  m2 = DB_GET_MONETARY (value2);
+  m1 = db_get_monetary (value1);
+  m2 = db_get_monetary (value2);
 
   return MR_CMP (m1->amount, m2->amount);
 }
@@ -5454,8 +5454,8 @@ mr_cmpval_date (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
 {
   const DB_DATE *d1, *d2;
 
-  d1 = DB_GET_DATE (value1);
-  d2 = DB_GET_DATE (value2);
+  d1 = db_get_date (value1);
+  d2 = db_get_date (value2);
 
   return MR_CMP (*d1, *d2);
 }
@@ -6718,8 +6718,8 @@ mr_cmpval_elo (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total_
 {
   DB_ELO *elo1, *elo2;
 
-  elo1 = DB_GET_ELO (value1);
-  elo2 = DB_GET_ELO (value2);
+  elo1 = db_get_elo (value1);
+  elo2 = db_get_elo (value2);
 
   /* use address for collating sequence */
   return MR_CMP ((UINTPTR) elo1, (UINTPTR) elo2);
@@ -7007,8 +7007,8 @@ mr_cmpval_ptr (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total_
 {
   void *p1, *p2;
 
-  p1 = DB_GET_POINTER (value1);
-  p2 = DB_GET_POINTER (value2);
+  p1 = db_get_pointer (value1);
+  p2 = db_get_pointer (value2);
 
   /* use address for collating sequence */
   return MR_CMP ((UINTPTR) p1, (UINTPTR) p2);
@@ -7140,8 +7140,8 @@ mr_cmpval_error (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
 {
   int e1, e2;
 
-  e1 = DB_GET_ERROR (value1);
-  e2 = DB_GET_ERROR (value2);
+  e1 = db_get_error (value1);
+  e2 = db_get_error (value2);
 
   return MR_CMP (e1, e2);
 }
@@ -7393,8 +7393,8 @@ mr_cmpval_oid (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total_
   OID *oid1, *oid2;
   int oidc;
 
-  oid1 = DB_GET_OID (value1);
-  oid2 = DB_GET_OID (value2);
+  oid1 = db_get_oid (value1);
+  oid2 = db_get_oid (value2);
 
   if (oid1 == NULL || oid2 == NULL)
     {
@@ -8149,7 +8149,7 @@ mr_setval_midxkey (DB_VALUE * dest, const DB_VALUE * src, bool copy)
     }
 
   /* Get information from the value. */
-  src_idx = DB_GET_MIDXKEY (src);
+  src_idx = db_get_midxkey (src);
   src_precision = db_value_precision (src);
   if (src_idx == NULL)
     {
@@ -8211,7 +8211,7 @@ mr_index_writeval_midxkey (OR_BUF * buf, DB_VALUE * value)
   DB_MIDXKEY *midxkey;
   int rc;
 
-  midxkey = DB_GET_MIDXKEY (value);
+  midxkey = db_get_midxkey (value);
   if (midxkey == NULL)
     {
       return ER_FAILED;
@@ -8339,8 +8339,8 @@ pr_midxkey_compare_element (char *mem1, char *mem2, TP_DOMAIN * dom1, TP_DOMAIN 
   OR_BUF_INIT (buf_val1, mem1, -1);
   OR_BUF_INIT (buf_val2, mem2, -1);
 
-  DB_MAKE_NULL (&val1);
-  DB_MAKE_NULL (&val2);
+  db_make_null (&val1);
+  db_make_null (&val2);
 
   if ((*(dom1->type->index_readval)) (&buf_val1, &val1, dom1, -1, false, NULL, 0) != NO_ERROR)
     {
@@ -8690,8 +8690,8 @@ mr_cmpval_midxkey (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int to
   int dummy_size1, dummy_size2, dummy_diff_column;
   bool dummy_dom_is_desc, dummy_next_dom_is_desc;
 
-  midxkey1 = DB_GET_MIDXKEY (value1);
-  midxkey2 = DB_GET_MIDXKEY (value2);
+  midxkey1 = db_get_midxkey (value1);
+  midxkey2 = db_get_midxkey (value2);
 
   if (midxkey1 == NULL || midxkey2 == NULL)
     {
@@ -8987,7 +8987,7 @@ mr_setmem_numeric (void *mem, TP_DOMAIN * domain, DB_VALUE * value)
     }
   else
     {
-      src_num = DB_GET_NUMERIC (value);
+      src_num = db_get_numeric (value);
 
       src_precision = db_value_precision (value);
       src_scale = db_value_scale (value);
@@ -9110,7 +9110,7 @@ mr_setval_numeric (DB_VALUE * dest, const DB_VALUE * src, bool copy)
     {
       src_precision = db_value_precision (src);
       src_scale = db_value_scale (src);
-      src_numeric = (DB_C_NUMERIC) DB_GET_NUMERIC (src);
+      src_numeric = (DB_C_NUMERIC) db_get_numeric (src);
 
       if (DB_IS_NULL (src) || src_numeric == NULL)
 	{
@@ -9172,7 +9172,7 @@ mr_data_writeval_numeric (OR_BUF * buf, DB_VALUE * value)
 
   if (value != NULL)
     {
-      numeric = DB_GET_NUMERIC (value);
+      numeric = db_get_numeric (value);
       if (numeric != NULL)
 	{
 	  precision = db_value_precision (value);
@@ -9275,7 +9275,7 @@ mr_data_cmpdisk_numeric (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coer
       return DB_UNK;
     }
 
-  c = MR_CMP_RETURN_CODE (DB_GET_INT (&answer));
+  c = MR_CMP_RETURN_CODE (db_get_int (&answer));
 
   return c;
 }
@@ -9292,13 +9292,13 @@ mr_cmpval_numeric (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int to
       return DB_UNK;
     }
 
-  if (DB_GET_INT (&answer) < 0)
+  if (db_get_int (&answer) < 0)
     {
       c = DB_LT;
     }
   else
     {
-      if (DB_GET_INT (&answer) > 0)
+      if (db_get_int (&answer) > 0)
 	{
 	  c = DB_GT;
 	}
@@ -9859,7 +9859,7 @@ pr_midxkey_add_prefix (DB_VALUE * result, DB_VALUE * prefix, DB_VALUE * postfix,
 
   midx_result.min_max_val.position = -1;
   midx_result.min_max_val.type = MIN_COLUMN;
-  DB_MAKE_MIDXKEY (result, &midx_result);
+  db_make_midxkey (result, &midx_result);
   result->need_clear = true;
 
   return NO_ERROR;
@@ -9992,7 +9992,7 @@ pr_midxkey_get_element_internal (const DB_MIDXKEY * midxkey, int index, DB_VALUE
 
   if (OR_MULTI_ATT_IS_UNBOUND (bitptr, index))
     {
-      DB_MAKE_NULL (value);
+      db_make_null (value);
     }
   else
     {
@@ -10169,7 +10169,7 @@ pr_midxkey_unique_prefix (const DB_VALUE * db_midxkey1, const DB_VALUE * db_midx
 
       result_midxkey.min_max_val.position = -1;
       result_midxkey.min_max_val.type = MIN_COLUMN;
-      DB_MAKE_MIDXKEY (db_result, &result_midxkey);
+      db_make_midxkey (db_result, &result_midxkey);
 
       db_result->need_clear = true;
 
@@ -10266,7 +10266,7 @@ pr_midxkey_add_elements (DB_VALUE * keyval, DB_VALUE * dbvals, int num_dbvals, T
   OR_BUF buf;
 
   /* phase 1: find old */
-  midxkey = DB_GET_MIDXKEY (keyval);
+  midxkey = db_get_midxkey (keyval);
   if (midxkey == NULL)
     {
       return ER_FAILED;
@@ -10530,9 +10530,9 @@ pr_complete_enum_value (DB_VALUE * value, TP_DOMAIN * domain)
       return ER_FAILED;
     }
 
-  short_val = DB_GET_ENUM_SHORT (value);
-  str_val = DB_GET_ENUM_STRING (value);
-  str_val_size = DB_GET_ENUM_STRING_SIZE (value);
+  short_val = db_get_enum_short (value);
+  str_val = db_get_enum_string (value);
+  str_val_size = db_get_enum_string_size (value);
   enum_count = DOM_GET_ENUM_ELEMS_COUNT (domain);
   if (short_val > enum_count)
     {
@@ -10545,8 +10545,8 @@ pr_complete_enum_value (DB_VALUE * value, TP_DOMAIN * domain)
       if (str_val != NULL && DB_GET_ENUM_ELEM_STRING_SIZE (db_elem) == str_val_size
 	  && !memcmp (str_val, DB_GET_ENUM_ELEM_STRING (db_elem), str_val_size))
 	{
-	  DB_MAKE_ENUMERATION (value, short_val, str_val, str_val_size, DB_GET_ENUM_ELEM_CODESET (db_elem),
-			       DB_GET_ENUM_COLLATION (value));
+	  db_make_enumeration (value, short_val, str_val, str_val_size, DB_GET_ENUM_ELEM_CODESET (db_elem),
+			       db_get_enum_collation (value));
 	  return NO_ERROR;
 	}
       pr_clear_value (value);
@@ -10559,8 +10559,8 @@ pr_complete_enum_value (DB_VALUE * value, TP_DOMAIN * domain)
 	}
       memcpy (str_val, DB_GET_ENUM_ELEM_STRING (db_elem), str_val_size);
       str_val[str_val_size] = 0;
-      DB_MAKE_ENUMERATION (value, short_val, str_val, str_val_size, DB_GET_ENUM_ELEM_CODESET (db_elem),
-			   DB_GET_ENUM_COLLATION (value));
+      db_make_enumeration (value, short_val, str_val, str_val_size, DB_GET_ENUM_ELEM_CODESET (db_elem),
+			   db_get_enum_collation (value));
       value->need_clear = true;
 
       return NO_ERROR;
@@ -10577,8 +10577,8 @@ pr_complete_enum_value (DB_VALUE * value, TP_DOMAIN * domain)
       if (DB_GET_ENUM_ELEM_STRING_SIZE (db_elem) == str_val_size
 	  && !memcmp (DB_GET_ENUM_ELEM_STRING (db_elem), str_val, str_val_size))
 	{
-	  DB_MAKE_ENUMERATION (value, DB_GET_ENUM_ELEM_SHORT (db_elem), str_val, str_val_size,
-			       DB_GET_ENUM_ELEM_CODESET (db_elem), DB_GET_ENUM_COLLATION (value));
+	  db_make_enumeration (value, DB_GET_ENUM_ELEM_SHORT (db_elem), str_val, str_val_size,
+			       DB_GET_ENUM_ELEM_CODESET (db_elem), db_get_enum_collation (value));
 	  break;
 	}
     }
@@ -10706,8 +10706,8 @@ mr_cmpval_resultset (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int 
 {
   int i1, i2;
 
-  i1 = DB_GET_RESULTSET (value1);
-  i2 = DB_GET_RESULTSET (value2);
+  i1 = db_get_resultset (value1);
+  i2 = db_get_resultset (value2);
 
   return MR_CMP (i1, i2);
 }
@@ -10740,7 +10740,7 @@ mr_setmem_string (void *memptr, TP_DOMAIN * domain, DB_VALUE * value)
   mem = (char **) memptr;
   cur = *mem;
 
-  if (value == NULL || (src = DB_GET_STRING (value)) == NULL)
+  if (value == NULL || (src = db_get_string (value)) == NULL)
     {
       /* remove the current value */
       if (cur != NULL)
@@ -10757,7 +10757,7 @@ mr_setmem_string (void *memptr, TP_DOMAIN * domain, DB_VALUE * value)
        * Whether or not the value "fits" should have been checked by now.
        */
       src_precision = DB_GET_STRING_PRECISION (value);
-      src_length = DB_GET_STRING_SIZE (value);	/* size in bytes */
+      src_length = db_get_string_size (value);	/* size in bytes */
 
       if (src_length < 0)
 	{
@@ -11094,9 +11094,9 @@ mr_setval_string (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 	{
 	  dest->data.ch.info.is_max_string = true;
 	  dest->domain.general_info.is_null = 0;
-	  dest->domain.char_info.collation_id = DB_GET_STRING_COLLATION (src);
+	  dest->domain.char_info.collation_id = db_get_string_collation (src);
 	  dest->data.ch.medium.compressed_buf = NULL;
-	  dest->data.ch.medium.codeset = DB_GET_STRING_CODESET (src);
+	  dest->data.ch.medium.codeset = db_get_string_codeset (src);
 	  dest->data.ch.medium.compressed_size = DB_UNCOMPRESSABLE;
 	  dest->data.ch.info.compressed_need_clear = false;
 	}
@@ -11115,8 +11115,8 @@ mr_setval_string (DB_VALUE * dest, const DB_VALUE * src, bool copy)
       if (!copy)
 	{
 	  error =
-	    db_make_varchar (dest, src_precision, src_str, src_length, DB_GET_STRING_CODESET (src),
-			     DB_GET_STRING_COLLATION (src));
+	    db_make_varchar (dest, src_precision, src_str, src_length, db_get_string_codeset (src),
+			     db_get_string_collation (src));
 	  dest->data.ch.medium.compressed_buf = src->data.ch.medium.compressed_buf;
 	  dest->data.ch.info.compressed_need_clear = false;
 	}
@@ -11133,8 +11133,8 @@ mr_setval_string (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 	    {
 	      memcpy (new_, src_str, src_length);
 	      new_[src_length] = '\0';
-	      db_make_varchar (dest, src_precision, new_, src_length, DB_GET_STRING_CODESET (src),
-			       DB_GET_STRING_COLLATION (src));
+	      db_make_varchar (dest, src_precision, new_, src_length, db_get_string_codeset (src),
+			       db_get_string_collation (src));
 	      dest->need_clear = true;
 	    }
 
@@ -11247,7 +11247,7 @@ mr_lengthval_string_internal (DB_VALUE * value, int disk, int align)
 	  rc = pr_do_db_value_string_compression (value);
 	}
       /* We are now sure that the value has been through the process of compression */
-      compressed_size = DB_GET_COMPRESSED_SIZE (value);
+      compressed_size = db_get_compressed_size (value);
 
       /* If the compression was successful, then we use the compression size value */
       if (compressed_size > 0)
@@ -11319,7 +11319,7 @@ mr_writeval_string_internal (OR_BUF * buf, DB_VALUE * value, int align)
 	  return rc;
 	}
 
-      compressed_size = DB_GET_COMPRESSED_SIZE (value);
+      compressed_size = db_get_compressed_size (value);
       compressed_string = DB_GET_COMPRESSED_STRING (value);
 
       if (compressed_size == DB_UNCOMPRESSABLE && src_length < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
@@ -11832,8 +11832,8 @@ mr_cmpval_string (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
   int size1, size2;
   int strc;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
 
   /*
@@ -11860,13 +11860,13 @@ mr_cmpval_string (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
 	}
     }
 
-  if (string1 == NULL || string2 == NULL || DB_GET_STRING_CODESET (value1) != DB_GET_STRING_CODESET (value1))
+  if (string1 == NULL || string2 == NULL || db_get_string_codeset (value1) != db_get_string_codeset (value1))
     {
       return DB_UNK;
     }
 
-  size1 = (int) DB_GET_STRING_SIZE (value1);
-  size2 = (int) DB_GET_STRING_SIZE (value2);
+  size1 = (int) db_get_string_size (value1);
+  size2 = (int) db_get_string_size (value2);
 
   if (size1 < 0)
     {
@@ -11898,17 +11898,17 @@ mr_cmpval_string2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coer
   unsigned char *string1, *string2;
   int len1, len2, string_size;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
   if (string1 == NULL || string2 == NULL)
     {
       return DB_UNK;
     }
 
-  string_size = (int) DB_GET_STRING_SIZE (value1);
+  string_size = (int) db_get_string_size (value1);
   len1 = MIN (string_size, length);
-  string_size = (int) DB_GET_STRING_SIZE (value2);
+  string_size = (int) db_get_string_size (value2);
   len2 = MIN (string_size, length);
 
   c = QSTR_COMPARE (string1, len1, string2, len2);
@@ -11992,9 +11992,9 @@ mr_setmem_char (void *memptr, TP_DOMAIN * domain, DB_VALUE * value)
     }
 
   /* Get information from the value */
-  src = DB_GET_STRING (value);
+  src = db_get_string (value);
   src_precision = DB_GET_STRING_PRECISION (value);
-  src_length = DB_GET_STRING_SIZE (value);	/* size in bytes */
+  src_length = db_get_string_size (value);	/* size in bytes */
 
   if (src == NULL)
     {
@@ -12223,16 +12223,16 @@ mr_setval_char (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 	}
       DB_DOMAIN_INIT_CHAR (dest, src_precision);
       /* Get information from the value */
-      src_string = DB_GET_STRING (src);
-      src_length = DB_GET_STRING_SIZE (src);	/* size in bytes */
+      src_string = db_get_string (src);
+      src_length = db_get_string_size (src);	/* size in bytes */
 
       /* shouldn't see a NULL string at this point, treat as NULL */
       if (src_string != NULL)
 	{
 	  if (!copy)
 	    {
-	      db_make_char (dest, src_precision, src_string, src_length, DB_GET_STRING_CODESET (src),
-			    DB_GET_STRING_COLLATION (src));
+	      db_make_char (dest, src_precision, src_string, src_length, db_get_string_codeset (src),
+			    db_get_string_collation (src));
 	    }
 	  else
 	    {
@@ -12253,8 +12253,8 @@ mr_setval_char (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 		{
 		  memcpy (new_, src_string, src_length);
 		  new_[src_length] = '\0';
-		  db_make_char (dest, src_precision, new_, src_length, DB_GET_STRING_CODESET (src),
-				DB_GET_STRING_COLLATION (src));
+		  db_make_char (dest, src_precision, new_, src_length, db_get_string_codeset (src),
+				db_get_string_collation (src));
 		  dest->need_clear = true;
 		}
 	    }
@@ -12287,7 +12287,7 @@ mr_data_lengthval_char (DB_VALUE * value, int disk)
   src_precision = db_value_precision (value);
   if (!IS_FLOATING_PRECISION (src_precision))
     {
-      packed_length = STR_SIZE (src_precision, DB_GET_STRING_CODESET (value));
+      packed_length = STR_SIZE (src_precision, db_get_string_codeset (value));
     }
   else
     {
@@ -12358,7 +12358,7 @@ mr_writeval_char_internal (OR_BUF * buf, DB_VALUE * value, int align)
 	  src_length = strlen (src);
 	}
 
-      packed_length = STR_SIZE (src_precision, DB_GET_STRING_CODESET (value));
+      packed_length = STR_SIZE (src_precision, db_get_string_codeset (value));
 
       if (packed_length < src_length)
 	{
@@ -12683,8 +12683,8 @@ mr_cmpval_char (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
   unsigned char *string1, *string2;
   int strc;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
   /*
    *  Check if the is_max_string flag set for each DB_VALUE.
@@ -12710,7 +12710,7 @@ mr_cmpval_char (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
 	}
     }
 
-  if (string1 == NULL || string2 == NULL || DB_GET_STRING_CODESET (value1) != DB_GET_STRING_CODESET (value1))
+  if (string1 == NULL || string2 == NULL || db_get_string_codeset (value1) != db_get_string_codeset (value1))
     {
       return DB_UNK;
     }
@@ -12721,8 +12721,8 @@ mr_cmpval_char (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
       return DB_UNK;
     }
 
-  strc = QSTR_CHAR_COMPARE (collation, string1, (int) DB_GET_STRING_SIZE (value1), string2,
-			    (int) DB_GET_STRING_SIZE (value2));
+  strc = QSTR_CHAR_COMPARE (collation, string1, (int) db_get_string_size (value1), string2,
+			    (int) db_get_string_size (value2));
   c = MR_CMP_RETURN_CODE (strc);
 
   return c;
@@ -12736,17 +12736,17 @@ mr_cmpval_char2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coerci
   unsigned char *string1, *string2;
   int len1, len2, string_size;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
   if (string1 == NULL || string2 == NULL)
     {
       return DB_UNK;
     }
 
-  string_size = (int) DB_GET_STRING_SIZE (value1);
+  string_size = (int) db_get_string_size (value1);
   len1 = MIN (string_size, length);
-  string_size = (int) DB_GET_STRING_SIZE (value2);
+  string_size = (int) db_get_string_size (value2);
   len2 = MIN (string_size, length);
 
   c = QSTR_CHAR_COMPARE (string1, len1, string2, len2);
@@ -13070,8 +13070,8 @@ mr_setval_nchar (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 	{
 	  if (!copy)
 	    {
-	      db_make_nchar (dest, src_precision, src_string, src_length, DB_GET_STRING_CODESET (src),
-			     DB_GET_STRING_COLLATION (src));
+	      db_make_nchar (dest, src_precision, src_string, src_length, db_get_string_codeset (src),
+			     db_get_string_collation (src));
 	    }
 	  else
 	    {
@@ -13092,8 +13092,8 @@ mr_setval_nchar (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 		{
 		  memcpy (new_, src_string, src_length);
 		  new_[src_length] = '\0';
-		  db_make_nchar (dest, src_precision, new_, src_length, DB_GET_STRING_CODESET (src),
-				 DB_GET_STRING_COLLATION (src));
+		  db_make_nchar (dest, src_precision, new_, src_length, db_get_string_codeset (src),
+				 db_get_string_collation (src));
 		  dest->need_clear = true;
 		}
 	    }
@@ -13602,10 +13602,10 @@ mr_cmpval_nchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
   unsigned char *string1, *string2;
   int strc;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
-  if (string1 == NULL || string2 == NULL || DB_GET_STRING_CODESET (value1) != DB_GET_STRING_CODESET (value2))
+  if (string1 == NULL || string2 == NULL || db_get_string_codeset (value1) != db_get_string_codeset (value2))
     {
       return DB_UNK;
     }
@@ -13616,8 +13616,8 @@ mr_cmpval_nchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
       return DB_UNK;
     }
 
-  strc = QSTR_NCHAR_COMPARE (collation, string1, (int) DB_GET_STRING_SIZE (value1), string2,
-			     (int) DB_GET_STRING_SIZE (value2), DB_GET_STRING_CODESET (value2));
+  strc = QSTR_NCHAR_COMPARE (collation, string1, (int) db_get_string_size (value1), string2,
+			     (int) db_get_string_size (value2), db_get_string_codeset (value2));
   c = MR_CMP_RETURN_CODE (strc);
 
   return c;
@@ -13631,20 +13631,20 @@ mr_cmpval_nchar2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coerc
   unsigned char *string1, *string2;
   int len1, len2, string_size;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
   if (string1 == NULL || string2 == NULL)
     {
       return DB_UNK;
     }
 
-  string_size = (int) DB_GET_STRING_SIZE (value1);
+  string_size = (int) db_get_string_size (value1);
   len1 = MIN (string_size, length);
-  string_size = (int) DB_GET_STRING_SIZE (value2);
+  string_size = (int) db_get_string_size (value2);
   len2 = MIN (string_size, length);
 
-  c = nchar_compare (string1, len1, string2, len2, DB_GET_STRING_CODESET (value2));
+  c = nchar_compare (string1, len1, string2, len2, db_get_string_codeset (value2));
   c = MR_CMP_RETURN_CODE (c);
 
   return c;
@@ -13942,8 +13942,8 @@ mr_setval_varnchar (DB_VALUE * dest, const DB_VALUE * src, bool copy)
       /* should we be paying attention to this? it is extremely dangerous */
       if (!copy)
 	{
-	  error = db_make_varnchar (dest, src_precision, src_str, src_length, DB_GET_STRING_CODESET (src),
-				    DB_GET_STRING_COLLATION (src));
+	  error = db_make_varnchar (dest, src_precision, src_str, src_length, db_get_string_codeset (src),
+				    db_get_string_collation (src));
 	}
       else
 	{
@@ -13958,8 +13958,8 @@ mr_setval_varnchar (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 	    {
 	      memcpy (new_, src_str, src_length);
 	      new_[src_length] = '\0';
-	      db_make_varnchar (dest, src_precision, new_, src_length, DB_GET_STRING_CODESET (src),
-				DB_GET_STRING_COLLATION (src));
+	      db_make_varnchar (dest, src_precision, new_, src_length, db_get_string_codeset (src),
+				db_get_string_collation (src));
 	      dest->need_clear = true;
 	    }
 	}
@@ -14038,7 +14038,7 @@ mr_lengthval_varnchar_internal (DB_VALUE * value, int disk, int align)
 	  rc = pr_do_db_value_string_compression (value);
 	}
       /* We are now sure that the value has been through the process of compression */
-      compressed_size = DB_GET_COMPRESSED_SIZE (value);
+      compressed_size = db_get_compressed_size (value);
       /* If the compression was successful, then we use the compression size value */
       if (compressed_size > 0)
 	{
@@ -14155,7 +14155,7 @@ mr_writeval_varnchar_internal (OR_BUF * buf, DB_VALUE * value, int align)
 	  return rc;
 	}
 
-      compressed_size = DB_GET_COMPRESSED_SIZE (value);
+      compressed_size = db_get_compressed_size (value);
       compressed_string = DB_GET_COMPRESSED_STRING (value);
 
       if (compressed_size == DB_UNCOMPRESSABLE && src_size < OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION)
@@ -14701,10 +14701,10 @@ mr_cmpval_varnchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int t
   unsigned char *string1, *string2;
   int strc;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
-  if (string1 == NULL || string2 == NULL || DB_GET_STRING_CODESET (value1) != DB_GET_STRING_CODESET (value1))
+  if (string1 == NULL || string2 == NULL || db_get_string_codeset (value1) != db_get_string_codeset (value1))
     {
       return DB_UNK;
     }
@@ -14715,8 +14715,8 @@ mr_cmpval_varnchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int t
       return DB_UNK;
     }
 
-  strc = QSTR_NCHAR_COMPARE (collation, string1, (int) DB_GET_STRING_SIZE (value1), string2,
-			     (int) DB_GET_STRING_SIZE (value2), DB_GET_STRING_CODESET (value2));
+  strc = QSTR_NCHAR_COMPARE (collation, string1, (int) db_get_string_size (value1), string2,
+			     (int) db_get_string_size (value2), db_get_string_codeset (value2));
   c = MR_CMP_RETURN_CODE (strc);
 
   return c;
@@ -14731,20 +14731,20 @@ mr_cmpval_varnchar2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_co
   unsigned char *string1, *string2;
   int len1, len2, string_size;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
   if (string1 == NULL || string2 == NULL)
     {
       return DB_UNK;
     }
 
-  string_size = (int) DB_GET_STRING_SIZE (value1);
+  string_size = (int) db_get_string_size (value1);
   len1 = MIN (string_size, length);
-  string_size = (int) DB_GET_STRING_SIZE (value2);
+  string_size = (int) db_get_string_size (value2);
   len2 = MIN (string_size, length);
 
-  c = varnchar_compare (string1, len1, string2, len2, DB_GET_STRING_CODESET (value2));
+  c = varnchar_compare (string1, len1, string2, len2, db_get_string_codeset (value2));
   c = MR_CMP_RETURN_CODE (c);
 
   return c;
@@ -15444,15 +15444,15 @@ mr_cmpval_bit (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total_
   unsigned char *string1, *string2;
   int bitc;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
   if (string1 == NULL || string2 == NULL)
     {
       return DB_UNK;
     }
 
-  bitc = bit_compare (string1, (int) DB_GET_STRING_SIZE (value1), string2, (int) DB_GET_STRING_SIZE (value2));
+  bitc = bit_compare (string1, (int) db_get_string_size (value1), string2, (int) db_get_string_size (value2));
   c = MR_CMP_RETURN_CODE (bitc);
 
   return c;
@@ -15466,17 +15466,17 @@ mr_cmpval_bit2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coercio
   int len1, len2, string_size;
   int bitc;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
   if (string1 == NULL || string2 == NULL)
     {
       return DB_UNK;
     }
 
-  string_size = (int) DB_GET_STRING_SIZE (value1);
+  string_size = (int) db_get_string_size (value1);
   len1 = MIN (string_size, length);
-  string_size = (int) DB_GET_STRING_SIZE (value2);
+  string_size = (int) db_get_string_size (value2);
   len2 = MIN (string_size, length);
 
   bitc = bit_compare (string1, len1, string2, len2);
@@ -16138,15 +16138,15 @@ mr_cmpval_varbit (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
   unsigned char *string1, *string2;
   int bitc;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
   if (string1 == NULL || string2 == NULL)
     {
       return DB_UNK;
     }
 
-  bitc = varbit_compare (string1, (int) DB_GET_STRING_SIZE (value1), string2, (int) DB_GET_STRING_SIZE (value2));
+  bitc = varbit_compare (string1, (int) db_get_string_size (value1), string2, (int) db_get_string_size (value2));
   c = MR_CMP_RETURN_CODE (bitc);
 
   return c;
@@ -16160,17 +16160,17 @@ mr_cmpval_varbit2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coer
   int len1, len2, string_size;
   int bitc;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
   if (string1 == NULL || string2 == NULL)
     {
       return DB_UNK;
     }
 
-  string_size = (int) DB_GET_STRING_SIZE (value1);
+  string_size = (int) db_get_string_size (value1);
   len1 = MIN (string_size, length);
-  string_size = (int) DB_GET_STRING_SIZE (value2);
+  string_size = (int) db_get_string_size (value2);
   len2 = MIN (string_size, length);
 
   bitc = varbit_compare (string1, len1, string2, len2);
@@ -16230,7 +16230,7 @@ mr_setmem_enumeration (void *mem, TP_DOMAIN * domain, DB_VALUE * value)
     }
   else
     {
-      *(unsigned short *) mem = DB_GET_ENUM_SHORT (value);
+      *(unsigned short *) mem = db_get_enum_short (value);
     }
 
   return NO_ERROR;
@@ -16257,29 +16257,29 @@ mr_setval_enumeration (DB_VALUE * dest, const DB_VALUE * src, bool copy)
       return db_value_domain_init (dest, DB_TYPE_ENUMERATION, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
     }
 
-  if (DB_GET_ENUM_STRING (src) != NULL)
+  if (db_get_enum_string (src) != NULL)
     {
       if (copy)
 	{
-	  str = (char *) db_private_alloc (NULL, DB_GET_ENUM_STRING_SIZE (src) + 1);
+	  str = (char *) db_private_alloc (NULL, db_get_enum_string_size (src) + 1);
 	  if (str == NULL)
 	    {
 	      assert (er_errid () != NO_ERROR);
 	      return er_errid ();
 	    }
-	  memcpy (str, DB_GET_ENUM_STRING (src), DB_GET_ENUM_STRING_SIZE (src));
-	  str[DB_GET_ENUM_STRING_SIZE (src)] = 0;
+	  memcpy (str, db_get_enum_string (src), db_get_enum_string_size (src));
+	  str[db_get_enum_string_size (src)] = 0;
 	  need_clear = true;
 	}
       else
 	{
-	  str = DB_GET_ENUM_STRING (src);
+	  str = db_get_enum_string (src);
 	}
     }
 
   /* get proper codeset from src */
-  db_make_enumeration (dest, DB_GET_ENUM_SHORT (src), str, DB_GET_ENUM_STRING_SIZE (src), DB_GET_ENUM_CODESET (src),
-		       DB_GET_ENUM_COLLATION (src));
+  db_make_enumeration (dest, db_get_enum_short (src), str, db_get_enum_string_size (src), db_get_enum_codeset (src),
+		       db_get_enum_collation (src));
   dest->need_clear = need_clear;
 
   return NO_ERROR;
@@ -16399,13 +16399,13 @@ mr_data_readval_enumeration (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain,
 static int
 mr_data_writeval_enumeration (OR_BUF * buf, DB_VALUE * value)
 {
-  return or_put_short (buf, DB_GET_ENUM_SHORT (value));
+  return or_put_short (buf, db_get_enum_short (value));
 }
 
 static int
 mr_index_writeval_enumeration (OR_BUF * buf, DB_VALUE * value)
 {
-  unsigned short s = DB_GET_ENUM_SHORT (value);
+  unsigned short s = db_get_enum_short (value);
 
   return or_put_data (buf, (char *) (&s), tp_Enumeration.disksize);
 }
@@ -16466,8 +16466,8 @@ mr_cmpval_enumeration (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, in
 {
   unsigned short s1, s2;
 
-  s1 = DB_GET_ENUM_SHORT (value1);
-  s2 = DB_GET_ENUM_SHORT (value2);
+  s1 = db_get_enum_short (value1);
+  s2 = db_get_enum_short (value2);
 
   return MR_CMP (s1, s2);
 }
@@ -16628,13 +16628,13 @@ pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * va
 
   /* Checks to be sure that we have the correct input */
   assert (DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_VARNCHAR || DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_STRING);
-  assert (DB_GET_STRING_SIZE (value) >= OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
+  assert (db_get_string_size (value) >= OR_MINIMUM_STRING_LENGTH_FOR_COMPRESSION);
 
   save_error_abort = buf->error_abort;
   buf->error_abort = 0;
 
-  string = DB_GET_STRING (value);
-  str_length = DB_GET_STRING_SIZE (value);
+  string = db_get_string (value);
+  str_length = db_get_string_size (value);
   *val_size = 0;
 
   if (!pr_Enable_string_compression)	/* compression is not set */
@@ -17154,7 +17154,7 @@ mr_setmem_json (void *memptr, TP_DOMAIN * domain, DB_VALUE * value)
       assert (false);
     }
 
-  if (value != NULL && (DB_GET_JSON_RAW_BODY (value) != NULL) && (DB_GET_JSON_DOCUMENT (value) != NULL))
+  if (value != NULL && (db_get_json_raw_body (value) != NULL) && (db_get_json_document (value) != NULL))
     {
       error = db_get_deep_copy_of_json (&value->data.json, json);
       if (error != NO_ERROR)
@@ -17179,7 +17179,7 @@ mr_getmem_json (void *memptr, TP_DOMAIN * domain, DB_VALUE * value, bool copy)
 
   if (json == NULL)
     {
-      DB_MAKE_NULL (value);
+      db_make_null (value);
       db_value_domain_init (value, DB_TYPE_JSON, domain->precision, 0);
       value->need_clear = false;
       return NO_ERROR;
@@ -17298,8 +17298,8 @@ mr_data_readmem_json (OR_BUF * buf, void *memptr, TP_DOMAIN * domain, int size)
   DB_JSON *json;
   int rc;
 
-  DB_MAKE_NULL (&json_body);
-  DB_MAKE_NULL (&schema_raw);
+  db_make_null (&json_body);
+  db_make_null (&schema_raw);
   json = (DB_JSON *) memptr;
 
   if (json == NULL)
@@ -17326,8 +17326,8 @@ mr_data_readmem_json (OR_BUF * buf, void *memptr, TP_DOMAIN * domain, int size)
   (*(tp_String.data_readval)) (buf, &json_body, NULL, -1, false, NULL, 0);
   (*(tp_String.data_readval)) (buf, &schema_raw, NULL, -1, false, NULL, 0);
 
-  json_body_length = DB_GET_STRING_SIZE (&json_body);
-  schema_length = DB_GET_STRING_SIZE (&schema_raw);
+  json_body_length = db_get_string_size (&json_body);
+  schema_length = db_get_string_size (&schema_raw);
 
   if (json_body_length <= 0)
     {
@@ -17537,9 +17537,9 @@ mr_data_readval_json (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int si
   const char *json_raw = NULL;
   char *json_raw_copy = NULL;
 
-  DB_MAKE_NULL (value);
-  DB_MAKE_NULL (&json_body);
-  DB_MAKE_NULL (&schema_raw);
+  db_make_null (value);
+  db_make_null (&json_body);
+  db_make_null (&schema_raw);
 
   if (size == 0)
     {
@@ -17572,7 +17572,7 @@ mr_data_readval_json (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int si
   json_raw_copy = db_private_strdup (NULL, json_raw);
   db_make_json (value, json_raw_copy, doc, true);
 
-  if (DB_GET_STRING_SIZE (&schema_raw) > 0)
+  if (db_get_string_size (&schema_raw) > 0)
     {
       value->data.json.schema_raw = db_private_strdup (NULL, db_get_string (&schema_raw));
     }
@@ -17667,8 +17667,8 @@ mr_cmpval_json (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
   bool is_value1_null = true, is_value2_null = true;
   int error_code;
 
-  doc1 = DB_GET_JSON_DOCUMENT (value1);
-  doc2 = DB_GET_JSON_DOCUMENT (value2);
+  doc1 = db_get_json_document (value1);
+  doc2 = db_get_json_document (value2);
 
   is_value1_null = DB_IS_NULL (value1) || ((type1 = db_json_get_type (doc1)) == DB_JSON_NULL);
   is_value2_null = DB_IS_NULL (value2) || ((type2 = db_json_get_type (doc2)) == DB_JSON_NULL);
@@ -17691,8 +17691,8 @@ mr_cmpval_json (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
   /* db_json_get_type shouldn't return DB_JSON_UNKNOWN, this represents a bug */
   assert (type1 != DB_JSON_UNKNOWN && type2 != DB_JSON_UNKNOWN);
 
-  DB_MAKE_NULL (&scalar_value1);
-  DB_MAKE_NULL (&scalar_value2);
+  db_make_null (&scalar_value1);
+  db_make_null (&scalar_value2);
 
   if (db_json_doc_is_uncomparable (doc1) || db_json_doc_is_uncomparable (doc2))
     {
@@ -17702,8 +17702,8 @@ mr_cmpval_json (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
       str1 = db_json_get_raw_json_body_from_document (doc1);
       str2 = db_json_get_raw_json_body_from_document (doc2);
 
-      DB_MAKE_STRING (&scalar_value1, str1);
-      DB_MAKE_STRING (&scalar_value2, str2);
+      db_make_string (&scalar_value1, str1);
+      db_make_string (&scalar_value2, str2);
       scalar_value1.need_clear = true;
       scalar_value2.need_clear = true;
     }

--- a/src/object/object_print.c
+++ b/src/object/object_print.c
@@ -412,7 +412,7 @@ help_class_names (const char *qualifier)
 		  buffer[0] = '\0';
 		  if (!requested_owner && db_get (owner, "name", &owner_name) >= 0)
 		    {
-		      tmp = DB_GET_STRING (&owner_name);
+		      tmp = db_get_string (&owner_name);
 		      if (tmp)
 			{
 			  snprintf (buffer, sizeof (buffer) - 1, "%s.%s", tmp, cname);

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -48,8 +48,8 @@ void object_printer::describe_comment (const char *comment)
 
   assert (comment != NULL);
 
-  DB_MAKE_NULL (&comment_value);
-  DB_MAKE_STRING (&comment_value, comment);
+  db_make_null (&comment_value);
+  db_make_string (&comment_value, comment);
 
   m_buf ("COMMENT ");
   if (comment != NULL && comment[0] != '\0')
@@ -72,7 +72,7 @@ void object_printer::describe_partition_parts (const sm_partition &parts, class_
   int setsize, i;
   db_value_printer obj_print (m_buf);
 
-  DB_MAKE_NULL (&ele);
+  db_make_null (&ele);
 
   m_buf ("PARTITION ");
   describe_identifier (parts.pname, prt_type);
@@ -493,8 +493,8 @@ void object_printer::describe_attribute (const struct db_object &cls, const sm_a
 
 	      assert (attribute.auto_increment != NULL);
 
-	      DB_MAKE_NULL (&min_val);
-	      DB_MAKE_NULL (&inc_val);
+	      db_make_null (&min_val);
+	      db_make_null (&inc_val);
 
 	      if (db_get (attribute.auto_increment, "min_val", &min_val) != NO_ERROR)
 		{
@@ -1121,8 +1121,8 @@ void object_printer::describe_class (struct db_object *class_op)
   if (class_descr.comment != NULL && class_descr.comment[0] != '\0')
     {
       DB_VALUE comment_value;
-      DB_MAKE_NULL (&comment_value);
-      DB_MAKE_STRING (&comment_value, class_descr.comment);
+      db_make_null (&comment_value);
+      db_make_string (&comment_value, class_descr.comment);
 
       m_buf (" COMMENT=");
 
@@ -1181,7 +1181,7 @@ void object_printer::describe_partition_info (const sm_partition &partinfo)
     {
       if (set_get_element (partinfo.values, 1, &ele) == NO_ERROR)
 	{
-	  m_buf ("PARTITIONS %d", DB_GET_INTEGER (&ele));
+	  m_buf ("PARTITIONS %d", db_get_int (&ele));
 	}
     }
 }

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -189,7 +189,7 @@ void object_printer::describe_domain (/*const*/tp_domain &domain, class_descript
 	case DB_TYPE_TIME:
 	case DB_TYPE_TIMETZ:
 	case DB_TYPE_TIMELTZ:
-	case DB_TYPE_UTIME:
+	case DB_TYPE_TIMESTAMP:
 	case DB_TYPE_TIMESTAMPTZ:
 	case DB_TYPE_TIMESTAMPLTZ:
 	case DB_TYPE_DATETIME:

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -156,13 +156,13 @@ classobj_get_prop (DB_SEQ * properties, const char *name, DB_VALUE * pvalue)
 	  continue;
 	}
 
-      if (DB_VALUE_TYPE (&value) != DB_TYPE_STRING || DB_GET_STRING (&value) == NULL)
+      if (DB_VALUE_TYPE (&value) != DB_TYPE_STRING || db_get_string (&value) == NULL)
 	{
 	  error = ER_SM_INVALID_PROPERTY;
 	}
       else
 	{
-	  tmp_str = DB_GET_STRING (&value);
+	  tmp_str = db_get_string (&value);
 	  if (tmp_str && strcmp (name, tmp_str) == 0)
 	    {
 	      if ((i + 1) >= max)
@@ -7682,7 +7682,7 @@ or_get_enumeration (OR_BUF * buf, DB_ENUMERATION * enumeration)
   int str_size = 0;
   LANG_COLLATION *lc;
 
-  DB_MAKE_NULL (&value);
+  db_make_null (&value);
 
   if (enumeration == NULL)
     {
@@ -8725,7 +8725,7 @@ or_get_json_schema (OR_BUF * buf, REFPTR (char, schema))
       return rc;
     }
 
-  if (DB_GET_STRING_SIZE (&schema_value) == 0)
+  if (db_get_string_size (&schema_value) == 0)
     {
       schema = NULL;
     }

--- a/src/object/object_template.c
+++ b/src/object/object_template.c
@@ -391,7 +391,7 @@ check_constraints (SM_ATTRIBUTE * att, DB_VALUE * value, unsigned force_check_no
 
   /* check NOT NULL constraint */
   if (value == NULL || DB_IS_NULL (value)
-      || (att->domain->type == tp_Type_object && (mop = DB_GET_OBJECT (value)) && WS_MOP_IS_NULL (mop)))
+      || (att->domain->type == tp_Type_object && (mop = db_get_object (value)) && WS_MOP_IS_NULL (mop)))
     {
       if (att->flags & SM_ATTFLAG_NON_NULL)
 	{
@@ -1024,10 +1024,10 @@ obt_free_assignment (OBJ_TEMPASSIGN * assign)
 	  av_type = DB_VALUE_TYPE (assign->variable);
 	  if (av_type == DB_TYPE_POINTER)
 	    {
-	      obt_free_template ((OBJ_TEMPLATE *) DB_GET_POINTER (assign->variable));
-	      DB_MAKE_POINTER (assign->variable, NULL);
+	      obt_free_template ((OBJ_TEMPLATE *) db_get_pointer (assign->variable));
+	      db_make_pointer (assign->variable, NULL);
 	    }
-	  else if (TP_IS_SET_TYPE (av_type) && DB_GET_SET (assign->variable) != NULL)
+	  else if (TP_IS_SET_TYPE (av_type) && db_get_set (assign->variable) != NULL)
 	    {
 	      /* must go through and free any elements that may be template pointers */
 	      setref = db_get_set (assign->variable);
@@ -1039,8 +1039,8 @@ obt_free_assignment (OBJ_TEMPASSIGN * assign)
 		      setobj_get_element_ptr (setref->set, i, &value);
 		      if (value != NULL && DB_VALUE_TYPE (value) == DB_TYPE_POINTER)
 			{
-			  obt_free_template ((OBJ_TEMPLATE *) DB_GET_POINTER (value));
-			  DB_MAKE_POINTER (value, NULL);
+			  obt_free_template ((OBJ_TEMPLATE *) db_get_pointer (value));
+			  db_make_pointer (value, NULL);
 			}
 		    }
 		}
@@ -1205,7 +1205,7 @@ populate_auto_increment (OBJ_TEMPLATE * template_ptr)
 	  goto auto_increment_error;
 	}
 
-      DB_MAKE_NULL (&val);
+      db_make_null (&val);
       /* Do not update LAST_INSERT_ID during executing a trigger. */
       if (do_Trigger_involved == true || obt_Last_insert_id_generated == true)
 	{
@@ -1271,7 +1271,7 @@ populate_defaults (OBJ_TEMPLATE * template_ptr)
   DB_VALUE base_value;
   const char *base_name;
 
-  DB_MAKE_NULL (&base_value);
+  db_make_null (&base_value);
 
   if (!template_ptr->is_class_update)
     {
@@ -1529,7 +1529,7 @@ obt_assign (OBJ_TEMPLATE * template_ptr, SM_ATTRIBUTE * att, int base_assignment
   DB_AUTH auth;
   DB_OBJECT *object;
 
-  DB_MAKE_NULL (&base_value);
+  db_make_null (&base_value);
 
   if ((template_ptr == NULL) || (att == NULL) || (value == NULL))
     {
@@ -1673,8 +1673,8 @@ obt_assign_obt (OBJ_TEMPLATE * template_ptr, SM_ATTRIBUTE * att, int base_assign
   const char *base_name;
   DB_AUTH auth;
 
-  DB_MAKE_NULL (&base_value);
-  DB_MAKE_NULL (&dummy_value);
+  db_make_null (&base_value);
+  db_make_null (&dummy_value);
 
   if (value == NULL)
     {
@@ -1789,7 +1789,7 @@ obt_set (OBJ_TEMPLATE * template_ptr, const char *attname, DB_VALUE * value)
 
       if (DB_VALUE_TYPE (value) == DB_TYPE_POINTER)
 	{
-	  error = obt_assign_obt (template_ptr, att, 0, (OBJ_TEMPLATE *) DB_GET_POINTER (value));
+	  error = obt_assign_obt (template_ptr, att, 0, (OBJ_TEMPLATE *) db_get_pointer (value));
 	}
       else
 	{
@@ -1814,7 +1814,7 @@ obt_set_obt (OBJ_TEMPLATE * template_ptr, const char *attname, OBJ_TEMPLATE * va
 {
   DB_VALUE v;
 
-  DB_MAKE_POINTER (&v, value);
+  db_make_pointer (&v, value);
 
   return (obt_set (template_ptr, attname, &v));
 }
@@ -1861,7 +1861,7 @@ obt_desc_set (OBJ_TEMPLATE * template_ptr, SM_DESCRIPTOR * desc, DB_VALUE * valu
 
       if (DB_VALUE_TYPE (value) == DB_TYPE_POINTER)
 	{
-	  error = obt_assign_obt (template_ptr, att, 0, (OBJ_TEMPLATE *) DB_GET_POINTER (value));
+	  error = obt_assign_obt (template_ptr, att, 0, (OBJ_TEMPLATE *) db_get_pointer (value));
 	}
       else
 	{
@@ -1930,7 +1930,7 @@ create_template_object (OBJ_TEMPLATE * template_ptr)
       /* set the label if one is defined */
       if (template_ptr->label != NULL)
 	{
-	  DB_MAKE_OBJECT (template_ptr->label, mop);
+	  db_make_object (template_ptr->label, mop);
 	}
 
       /* if this is a virtual instance insert, cache the base instance too */
@@ -2079,12 +2079,12 @@ obt_convert_set_templates (SETREF * setref, int check_uniques)
 	      if (value != NULL && DB_VALUE_TYPE (value) == DB_TYPE_POINTER)
 		{
 		  /* apply the template for this element */
-		  template_ptr = (OBJ_TEMPLATE *) DB_GET_POINTER (value);
+		  template_ptr = (OBJ_TEMPLATE *) db_get_pointer (value);
 		  error = obt_apply_assignments (template_ptr, check_uniques, 1);
 		  /* 1 means do eager flushing of (set-nested) proxy objects */
 		  if (error == NO_ERROR && template_ptr != NULL)
 		    {
-		      DB_MAKE_OBJECT (value, template_ptr->object);
+		      db_make_object (value, template_ptr->object);
 		      obt_free_template (template_ptr);
 		    }
 		}
@@ -2129,7 +2129,7 @@ obt_final_check_set (SETREF * setref, int *has_uniques)
 	      setobj_get_element_ptr (set, i, &value);
 	      if (value != NULL && DB_VALUE_TYPE (value) == DB_TYPE_POINTER)
 		{
-		  template_ptr = (OBJ_TEMPLATE *) DB_GET_POINTER (value);
+		  template_ptr = (OBJ_TEMPLATE *) db_get_pointer (value);
 		  error = obt_final_check (template_ptr, 1, has_uniques);
 		}
 	    }
@@ -2285,7 +2285,7 @@ obt_final_check (OBJ_TEMPLATE * template_ptr, int check_non_null, int *has_uniqu
 	      av_type = DB_VALUE_TYPE (a->variable);
 	      if (TP_IS_SET_TYPE (av_type))
 		{
-		  error = obt_final_check_set (DB_GET_SET (a->variable), has_uniques);
+		  error = obt_final_check_set (db_get_set (a->variable), has_uniques);
 		}
 	    }
 	}
@@ -2329,7 +2329,7 @@ obt_apply_assignment (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * value, i
   else
     {
       /* for sets, first apply any templates in the set */
-      error = obt_convert_set_templates (DB_GET_SET (value), check_uniques);
+      error = obt_convert_set_templates (db_get_set (value), check_uniques);
       if (error == NO_ERROR)
 	{
 
@@ -2620,7 +2620,7 @@ obt_apply_assignments (OBJ_TEMPLATE * template_ptr, int check_uniques, int level
 	      error = obt_apply_assignments (a->obj, check_uniques, level + 1);
 	      if (error == NO_ERROR)
 		{
-		  DB_MAKE_OBJECT (&val, a->obj->object);
+		  db_make_object (&val, a->obj->object);
 		  error = obt_apply_assignment (object, a->att, mem, &val, check_uniques);
 		}
 	    }

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -2681,7 +2681,7 @@ sm_rename_class (MOP op, const char *new_name)
 			  break;
 			}
 
-		      class_name = DB_GET_STRING (&name_val);
+		      class_name = db_get_string (&name_val);
 		      if (class_name != NULL && (strcmp (current, class_name) == 0))
 			{
 			  int save;
@@ -3127,7 +3127,7 @@ sm_partitioned_class_type (DB_OBJECT * classop, int *partition_type, char *keyat
 	  char *p = NULL;
 
 	  keyattr[0] = 0;
-	  if (DB_IS_NULL (&attrname) || (p = DB_GET_STRING (&attrname)) == NULL)
+	  if (DB_IS_NULL (&attrname) || (p = db_get_string (&attrname)) == NULL)
 	    {
 	      goto partition_failed;
 	    }
@@ -9041,7 +9041,7 @@ flatten_properties (SM_TEMPLATE * def, SM_TEMPLATE * flat)
 		      int cnstr_exists = 0;
 
 		      /* Does the constraint exist in the subclass ? */
-		      DB_MAKE_NULL (&cnstr_val);
+		      db_make_null (&cnstr_val);
 		      cnstr_exists =
 			classobj_find_prop_constraint (flat->properties, classobj_map_constraint_to_property (c->type),
 						       c->name, &cnstr_val);
@@ -9053,8 +9053,8 @@ flatten_properties (SM_TEMPLATE * def, SM_TEMPLATE * flat)
 			  int is_global_index = 0;
 
 			  /* Get the BTID from the local constraint */
-			  DB_MAKE_NULL (&btid_val);
-			  local_property = DB_GET_SEQ (&cnstr_val);
+			  db_make_null (&btid_val);
+			  local_property = db_get_set (&cnstr_val);
 			  if (set_get_element (local_property, 0, &btid_val))
 			    {
 			      pr_clear_value (&cnstr_val);
@@ -13054,7 +13054,7 @@ sm_delete_class_mop (MOP op, bool is_cascade_constraints)
 	  error = db_get (att->auto_increment, "class_name", &name_val);
 	  if (error == NO_ERROR)
 	    {
-	      class_name = DB_GET_STRING (&name_val);
+	      class_name = db_get_string (&name_val);
 	      if (class_name != NULL && (strcmp (sm_ch_name ((MOBJ) class_), class_name) == 0))
 		{
 		  int save;
@@ -15551,8 +15551,8 @@ filter_local_constraints (SM_TEMPLATE * template_, SM_CLASS * super_class)
       return NO_ERROR;
     }
 
-  DB_MAKE_NULL (&oldval);
-  DB_MAKE_NULL (&newval);
+  db_make_null (&oldval);
+  db_make_null (&newval);
 
   /* get old constraints */
   error = classobj_make_class_constraints (super_class->properties, super_class->attributes, &old_constraints);
@@ -15604,7 +15604,7 @@ filter_local_constraints (SM_TEMPLATE * template_, SM_CLASS * super_class)
 	      goto cleanup;
 	    }
 
-	  seq = DB_GET_SEQ (&oldval);
+	  seq = db_get_set (&oldval);
 	  found = classobj_drop_prop (seq, c->name);
 	  if (found == 0)
 	    {
@@ -15615,7 +15615,7 @@ filter_local_constraints (SM_TEMPLATE * template_, SM_CLASS * super_class)
 		}
 	    }
 
-	  DB_MAKE_SEQ (&newval, seq);
+	  db_make_sequence (&newval, seq);
 
 	  classobj_put_prop (template_->properties, classobj_map_constraint_to_property (c->type), &newval);
 

--- a/src/object/schema_template.c
+++ b/src/object/schema_template.c
@@ -1481,21 +1481,21 @@ smt_drop_constraint_from_property (SM_TEMPLATE * template_, const char *constrai
       return NO_ERROR;
     }
 
-  DB_MAKE_NULL (&oldval);
-  DB_MAKE_NULL (&newval);
+  db_make_null (&oldval);
+  db_make_null (&newval);
 
   prop_type = SM_MAP_CONSTRAINT_ATTFAG_TO_PROPERTY (constraint);
 
   if (classobj_get_prop (template_->properties, prop_type, &oldval) > 0)
     {
-      seq = DB_GET_SEQ (&oldval);
+      seq = db_get_set (&oldval);
 
       if (!classobj_drop_prop (seq, constraint_name))
 	{
 	  ERROR1 (error, ER_SM_CONSTRAINT_NOT_FOUND, constraint_name);
 	}
 
-      DB_MAKE_SEQUENCE (&newval, seq);
+      db_make_sequence (&newval, seq);
       classobj_put_prop (template_->properties, prop_type, &newval);
     }
   else
@@ -1535,7 +1535,7 @@ smt_add_constraint_to_property (SM_TEMPLATE * template_, SM_CONSTRAINT_TYPE type
   DB_VALUE cnstr_val;
   const char *constraint = classobj_map_constraint_to_property (type);
 
-  DB_MAKE_NULL (&cnstr_val);
+  db_make_null (&cnstr_val);
 
   /* 
    *  Check if the constraint already exists

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -1156,7 +1156,7 @@ col_find (COL * col, long *found, DB_VALUE * val, int do_coerce)
 	  if (col->sorted && col->coltype != DB_TYPE_SEQUENCE && DB_VALUE_TYPE (val) == DB_TYPE_OBJECT)
 	    {
 
-	      DB_OBJECT *obj = DB_GET_OBJECT (val);
+	      DB_OBJECT *obj = db_get_object (val);
 	      if (obj != NULL && OBJECT_HAS_TEMP_OID (obj))
 		{
 		  /* we're inserting a temp OID, must force the collection to become unsorted */
@@ -1304,7 +1304,7 @@ col_put (COL * col, long colindex, DB_VALUE * val)
 	  assert_release (false);
 	  return ER_FAILED;
 #else /* !defined (SERVER_MODE) */
-	  DB_OBJECT *obj = DB_GET_OBJECT (val);
+	  DB_OBJECT *obj = db_get_object (val);
 	  if (obj != NULL && OBJECT_HAS_TEMP_OID (obj))
 	    {
 	      col->may_have_temporary_oids = 1;
@@ -1444,7 +1444,7 @@ col_insert (COL * col, long colindex, DB_VALUE * val)
 	  assert_release (false);
 	  return ER_FAILED;
 #else /* !defined (SERVER_MODE) */
-	  DB_OBJECT *obj = DB_GET_OBJECT (val);
+	  DB_OBJECT *obj = db_get_object (val);
 	  if (obj != NULL && OBJECT_HAS_TEMP_OID (obj))
 	    {
 	      col->may_have_temporary_oids = 1;
@@ -1801,7 +1801,7 @@ col_permanent_oids (COL * col)
 
 	      if (DB_VALUE_DOMAIN_TYPE (val) == DB_TYPE_OBJECT)
 		{
-		  obj = DB_GET_OBJECT (val);
+		  obj = db_get_object (val);
 		  if (obj != NULL && OBJECT_HAS_TEMP_OID (obj))
 		    {
 		      tcount++;
@@ -1816,7 +1816,7 @@ col_permanent_oids (COL * col)
 	      else if (DB_VALUE_DOMAIN_TYPE (val) == DB_TYPE_SET || DB_VALUE_DOMAIN_TYPE (val) == DB_TYPE_MULTISET)
 		{
 		  /* recurse and make sure any nested set is also assigned permanent oids and sorted */
-		  set_optimize (DB_GET_SET (val));
+		  set_optimize (db_get_set (val));
 		}
 	    }
 
@@ -4491,7 +4491,7 @@ setobj_find_temporary_oids (SETOBJ * col, LC_OIDSET * oidset)
 	  type = DB_VALUE_TYPE (val);
 	  if (type == DB_TYPE_OBJECT)
 	    {
-	      obj = DB_GET_OBJECT (val);
+	      obj = db_get_object (val);
 	      if (obj != NULL && OBJECT_HAS_TEMP_OID (obj))
 		{
 		  tempoids++;
@@ -4506,7 +4506,7 @@ setobj_find_temporary_oids (SETOBJ * col, LC_OIDSET * oidset)
 	    {
 	      /* its a nested set, recurse, since we must already be pinned don't have to worry about pinning the
 	       * nested set. */
-	      ref = DB_GET_SET (val);
+	      ref = db_get_set (val);
 	      if (ref && ref->set != NULL)
 		{
 		  error = setobj_find_temporary_oids (ref->set, oidset);
@@ -4680,7 +4680,7 @@ swizzle_value (DB_VALUE * val, int input)
 	  DB_OBJECT *mop;
 	  mop = ws_mop (oid, NULL);
 	  db_value_domain_init (val, DB_TYPE_OBJECT, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
-	  DB_MAKE_OBJECT (val, mop);
+	  db_make_object (val, mop);
 	}
 #endif /* !SERVER_MODE */
     }
@@ -4801,7 +4801,7 @@ check_set_object (DB_VALUE * var, int *removed_ptr)
     {
       goto end;
     }
-  mop = DB_GET_OBJECT (var);
+  mop = db_get_object (var);
   if (mop == NULL)
     {
       goto end;
@@ -4833,7 +4833,7 @@ check_set_object (DB_VALUE * var, int *removed_ptr)
     }
 
   removed = 1;
-  DB_MAKE_NULL (var);
+  db_make_null (var);
 
 end:
 #endif /* !SERVER_MODE */
@@ -5666,13 +5666,13 @@ setobj_convert_oids_to_objects (COL * col)
 	    {
 	      pr_clear_value (var);
 	      db_value_domain_init (var, DB_TYPE_OBJECT, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
-	      DB_MAKE_OBJECT (var, mop);
+	      db_make_object (var, mop);
 	    }
 	  break;
 	case DB_TYPE_SET:
 	case DB_TYPE_MULTISET:
 	case DB_TYPE_SEQUENCE:
-	  error = set_convert_oids_to_objects (DB_GET_SET (var));
+	  error = set_convert_oids_to_objects (db_get_set (var));
 	  break;
 	default:
 	  break;
@@ -5736,7 +5736,7 @@ setobj_get_element (COL * set, int index, DB_VALUE * value)
   DB_VALUE *element;
 
   /* should this be pr_clear_value instead? */
-  DB_MAKE_NULL (value);
+  db_make_null (value);
 
   error = setobj_get_element_ptr (set, index, &element);
 
@@ -5770,7 +5770,7 @@ setobj_add_element (COL * col, DB_VALUE * value)
   DB_VALUE temp;
   int error = NO_ERROR;
 
-  DB_MAKE_NULL (&temp);
+  db_make_null (&temp);
   CHECKNULL_ERR (col);
   CHECKNULL_ERR (value);
 
@@ -5812,7 +5812,7 @@ setobj_put_element (COL * col, int index, DB_VALUE * value)
   int error = NO_ERROR;
   DB_VALUE temp;
 
-  DB_MAKE_NULL (&temp);
+  db_make_null (&temp);
   CHECKNULL_ERR (col);
   CHECKNULL_ERR (value);
 

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -5734,6 +5734,7 @@ setobj_get_element (COL * set, int index, DB_VALUE * value)
 {
   int error = NO_ERROR;
   DB_VALUE *element;
+  DB_TYPE db_type;
 
   /* should this be pr_clear_value instead? */
   db_make_null (value);
@@ -5745,7 +5746,17 @@ setobj_get_element (COL * set, int index, DB_VALUE * value)
       swizzle_value (element, 0);
       error = pr_clone_value (element, value);
       /* kludge, should be part of pr_ level */
-      SET_FIX_VALUE (value);
+
+      db_type = DB_VALUE_TYPE (value);
+      if (db_type == DB_TYPE_STRING && db_get_string (value) == NULL
+	  || TP_IS_SET_TYPE (db_type) && db_get_set (value) == NULL
+	  || db_type == DB_TYPE_OBJECT && db_get_object (value) == NULL
+	  || db_type == DB_TYPE_BLOB && db_get_elo (value) == NULL
+	  || db_type == DB_TYPE_CLOB && db_get_elo (value) == NULL
+	  || db_type == DB_TYPE_ELO && db_get_elo (value) == NULL)
+	{
+	  db_make_null (value);
+	}
     }
 
   return error;

--- a/src/object/set_object.h
+++ b/src/object/set_object.h
@@ -44,25 +44,6 @@
 #define SET_DUPLICATE_VALUE (1)
 #define IMPLICIT (1)
 
-/* Quick set argument check */
-
-/* this needs to go into the pr_ level */
-
-#define SET_FIX_VALUE(value) \
-  if ((DB_VALUE_TYPE(value) == DB_TYPE_STRING && \
-       db_get_string(value) == NULL) || \
-      (TP_IS_SET_TYPE (DB_VALUE_TYPE(value)) && \
-       db_get_set(value) == NULL) || \
-      (DB_VALUE_TYPE(value) == DB_TYPE_OBJECT && \
-       db_get_object(value) == NULL) || \
-      (DB_VALUE_TYPE(value) == DB_TYPE_BLOB && \
-       db_get_elo(value) == NULL) || \
-      (DB_VALUE_TYPE(value) == DB_TYPE_CLOB && \
-       db_get_elo(value) == NULL) || \
-      (DB_VALUE_TYPE(value) == DB_TYPE_ELO && \
-       db_get_elo(value) == NULL)) \
-    db_make_null(value);
-
 #define COL_BLOCK_SIZE (64)
 
 /* Is there some compelling reason to keep the value array larger than necessary?

--- a/src/object/set_object.h
+++ b/src/object/set_object.h
@@ -50,18 +50,18 @@
 
 #define SET_FIX_VALUE(value) \
   if ((DB_VALUE_TYPE(value) == DB_TYPE_STRING && \
-       DB_GET_STRING(value) == NULL) || \
+       db_get_string(value) == NULL) || \
       (TP_IS_SET_TYPE (DB_VALUE_TYPE(value)) && \
-       DB_GET_SET(value) == NULL) || \
+       db_get_set(value) == NULL) || \
       (DB_VALUE_TYPE(value) == DB_TYPE_OBJECT && \
-       DB_GET_OBJECT(value) == NULL) || \
+       db_get_object(value) == NULL) || \
       (DB_VALUE_TYPE(value) == DB_TYPE_BLOB && \
-       DB_GET_ELO(value) == NULL) || \
+       db_get_elo(value) == NULL) || \
       (DB_VALUE_TYPE(value) == DB_TYPE_CLOB && \
-       DB_GET_ELO(value) == NULL) || \
+       db_get_elo(value) == NULL) || \
       (DB_VALUE_TYPE(value) == DB_TYPE_ELO && \
-       DB_GET_ELO(value) == NULL)) \
-    DB_MAKE_NULL(value);
+       db_get_elo(value) == NULL)) \
+    db_make_null(value);
 
 #define COL_BLOCK_SIZE (64)
 

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -3044,9 +3044,9 @@ disk_to_attribute (OR_BUF * buf, SM_ATTRIBUTE * att)
 		  DB_VALUE def_expr_op, def_expr_type, def_expr_format;
 		  char *def_expr_format_str;
 
-		  assert (set_size (DB_GET_SEQUENCE (&value)) == 3);
+		  assert (set_size (db_get_set (&value)) == 3);
 
-		  def_expr_seq = DB_GET_SEQUENCE (&value);
+		  def_expr_seq = db_get_set (&value);
 
 		  /* get default expression operator (op of expr) */
 		  if (set_get_element_nocopy (def_expr_seq, 0, &def_expr_op) != NO_ERROR)
@@ -3054,8 +3054,8 @@ disk_to_attribute (OR_BUF * buf, SM_ATTRIBUTE * att)
 		      assert (false);
 		    }
 		  assert (DB_VALUE_TYPE (&def_expr_op) == DB_TYPE_INTEGER
-			  && DB_GET_INT (&def_expr_op) == (int) T_TO_CHAR);
-		  att->default_value.default_expr.default_expr_op = DB_GET_INT (&def_expr_op);
+			  && db_get_int (&def_expr_op) == (int) T_TO_CHAR);
+		  att->default_value.default_expr.default_expr_op = db_get_int (&def_expr_op);
 
 		  /* get default expression type (arg1 of expr) */
 		  if (set_get_element_nocopy (def_expr_seq, 1, &def_expr_type) != NO_ERROR)
@@ -3064,7 +3064,7 @@ disk_to_attribute (OR_BUF * buf, SM_ATTRIBUTE * att)
 		    }
 		  assert (DB_VALUE_TYPE (&def_expr_type) == DB_TYPE_INTEGER);
 		  att->default_value.default_expr.default_expr_type =
-		    (DB_DEFAULT_EXPR_TYPE) DB_GET_INT (&def_expr_type);
+		    (DB_DEFAULT_EXPR_TYPE) db_get_int (&def_expr_type);
 
 		  /* get default expression format (arg2 of expr) */
 		  if (set_get_element_nocopy (def_expr_seq, 2, &def_expr_format) != NO_ERROR)
@@ -3080,7 +3080,7 @@ disk_to_attribute (OR_BUF * buf, SM_ATTRIBUTE * att)
 #endif
 		  if (!db_value_is_null (&def_expr_format))
 		    {
-		      def_expr_format_str = DB_GET_STRING (&def_expr_format);
+		      def_expr_format_str = db_get_string (&def_expr_format);
 		      att->default_value.default_expr.default_expr_format = ws_copy_string (def_expr_format_str);
 		      if (att->default_value.default_expr.default_expr_format == NULL)
 			{
@@ -3090,7 +3090,7 @@ disk_to_attribute (OR_BUF * buf, SM_ATTRIBUTE * att)
 		}
 	      else
 		{
-		  att->default_value.default_expr.default_expr_type = (DB_DEFAULT_EXPR_TYPE) DB_GET_INT (&value);
+		  att->default_value.default_expr.default_expr_type = (DB_DEFAULT_EXPR_TYPE) db_get_int (&value);
 		}
 
 	      pr_clear_value (&value);
@@ -4880,7 +4880,7 @@ disk_to_partition_info (OR_BUF * buf)
 	  classobj_free_partition_info (partition_info);
 	  return NULL;
 	}
-      partition_info->values = db_seq_copy (DB_GET_SEQUENCE (&val));
+      partition_info->values = db_seq_copy (db_get_set (&val));
       if (partition_info->values == NULL)
 	{
 	  free_var_table (vars);

--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -4549,9 +4549,9 @@ value_as_boolean (DB_VALUE * value)
 	status = (time_tz->time == 0) ? false : true;
       }
       break;
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
-      status = (*db_get_utime (value) == 0) ? false : true;
+      status = (*db_get_timestamp (value) == 0) ? false : true;
       break;
     case DB_TYPE_TIMESTAMPTZ:
       {

--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -1216,7 +1216,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 	}
       else
 	{
-	  trigger->owner = DB_GET_OBJECT (&value);
+	  trigger->owner = db_get_object (&value);
 	}
     }
 
@@ -1228,7 +1228,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 
   if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && !DB_IS_NULL (&value))
     {
-      tmp = DB_GET_STRING (&value);
+      tmp = db_get_string (&value);
       if (tmp)
 	{
 	  trigger->name = strdup (tmp);
@@ -1244,7 +1244,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 
   if (DB_VALUE_TYPE (&value) == DB_TYPE_INTEGER)
     {
-      trigger->status = (DB_TRIGGER_STATUS) DB_GET_INTEGER (&value);
+      trigger->status = (DB_TRIGGER_STATUS) db_get_int (&value);
     }
 
   /* PRIORITY */
@@ -1255,7 +1255,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 
   if (DB_VALUE_TYPE (&value) == DB_TYPE_DOUBLE)
     {
-      trigger->priority = DB_GET_DOUBLE (&value);
+      trigger->priority = db_get_double (&value);
     }
 
   /* EVENT */
@@ -1266,7 +1266,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 
   if (DB_VALUE_TYPE (&value) == DB_TYPE_INTEGER)
     {
-      trigger->event = (DB_TRIGGER_EVENT) DB_GET_INTEGER (&value);
+      trigger->event = (DB_TRIGGER_EVENT) db_get_int (&value);
     }
 
   /* CLASS */
@@ -1283,7 +1283,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 	}
       else
 	{
-	  trigger->class_mop = DB_GET_OBJECT (&value);
+	  trigger->class_mop = db_get_object (&value);
 	}
       /* 
        * Check to make sure the class is still available.  It is possible
@@ -1307,7 +1307,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 
   if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && !DB_IS_NULL (&value))
     {
-      tmp = DB_GET_STRING (&value);
+      tmp = db_get_string (&value);
       if (tmp)
 	{
 	  trigger->attribute = strdup (tmp);
@@ -1324,7 +1324,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 
   if (DB_VALUE_TYPE (&value) == DB_TYPE_INTEGER)
     {
-      trigger->class_attribute = DB_GET_INTEGER (&value);
+      trigger->class_attribute = db_get_int (&value);
     }
 
   /* CONDITION TYPE */
@@ -1341,7 +1341,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 	  goto error;
 	}
 
-      trigger->condition->type = (DB_TRIGGER_ACTION) DB_GET_INTEGER (&value);
+      trigger->condition->type = (DB_TRIGGER_ACTION) db_get_int (&value);
 
       /* CONDITION TIME */
       if (db_get (object, TR_ATT_CONDITION_TIME, &value))
@@ -1351,7 +1351,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 
       if (DB_VALUE_TYPE (&value) == DB_TYPE_INTEGER)
 	{
-	  trigger->condition->time = (DB_TRIGGER_TIME) DB_GET_INTEGER (&value);
+	  trigger->condition->time = (DB_TRIGGER_TIME) db_get_int (&value);
 	}
 
       /* CONDITION SOURCE */
@@ -1362,7 +1362,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 
       if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && !DB_IS_NULL (&value))
 	{
-	  tmp = DB_GET_STRING (&value);
+	  tmp = db_get_string (&value);
 	  if (tmp)
 	    {
 	      trigger->condition->source = strdup (tmp);
@@ -1385,7 +1385,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 	  goto error;
 	}
 
-      trigger->action->type = (DB_TRIGGER_ACTION) DB_GET_INTEGER (&value);
+      trigger->action->type = (DB_TRIGGER_ACTION) db_get_int (&value);
 
       /* ACTION TIME */
       if (db_get (object, TR_ATT_ACTION_TIME, &value))
@@ -1395,7 +1395,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 
       if (DB_VALUE_TYPE (&value) == DB_TYPE_INTEGER)
 	{
-	  trigger->action->time = (DB_TRIGGER_TIME) DB_GET_INTEGER (&value);
+	  trigger->action->time = (DB_TRIGGER_TIME) db_get_int (&value);
 	}
 
       /* ACTION SOURCE */
@@ -1410,7 +1410,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 
       if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && !DB_IS_NULL (&value))
 	{
-	  tmp = DB_GET_STRING (&value);
+	  tmp = db_get_string (&value);
 	  if (tmp)
 	    {
 	      trigger->action->source = strdup (tmp);
@@ -1427,7 +1427,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
 
   if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && !DB_IS_NULL (&value))
     {
-      tmp = DB_GET_STRING (&value);
+      tmp = db_get_string (&value);
       if (tmp != NULL)
 	{
 	  trigger->comment = strdup (tmp);
@@ -1933,7 +1933,7 @@ register_user_trigger (DB_OBJECT * object)
 	}
       else
 	{
-	  table = DB_GET_SET (&value);
+	  table = db_get_set (&value);
 	}
 
       if (table == NULL)
@@ -1953,7 +1953,7 @@ register_user_trigger (DB_OBJECT * object)
 	    }
 	  else
 	    {
-	      table = DB_GET_SET (&value);
+	      table = db_get_set (&value);
 	    }
 	}
 
@@ -2014,7 +2014,7 @@ unregister_user_trigger (TR_TRIGGER * trigger, int rollback)
 	}
       else
 	{
-	  table = DB_GET_SET (&value);
+	  table = db_get_set (&value);
 	}
 
       if (table != NULL)
@@ -2075,7 +2075,7 @@ get_user_trigger_objects (DB_TRIGGER_EVENT event, bool active_filter, DB_OBJLIST
     }
   else
     {
-      table = DB_GET_SET (&value);
+      table = db_get_set (&value);
     }
 
   if (table != NULL)
@@ -2088,10 +2088,10 @@ get_user_trigger_objects (DB_TRIGGER_EVENT event, bool active_filter, DB_OBJLIST
 	  error = set_get_element (table, i, &value);
 	  if (error == NO_ERROR)
 	    {
-	      if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && !DB_IS_NULL (&value) && DB_GET_OBJECT (&value) != NULL)
+	      if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && !DB_IS_NULL (&value) && db_get_object (&value) != NULL)
 		{
 		  /* deleted objects should have been filtered by now */
-		  trigger = tr_map_trigger (DB_GET_OBJECT (&value), 1);
+		  trigger = tr_map_trigger (db_get_object (&value), 1);
 		  if (trigger == NULL)
 		    {
 		      ASSERT_ERROR_AND_SET (error);
@@ -2103,17 +2103,17 @@ get_user_trigger_objects (DB_TRIGGER_EVENT event, bool active_filter, DB_OBJLIST
 			  if (event == TR_EVENT_NULL)
 			    {
 			      /* unconditionally collect all the trigger objects */
-			      error = ml_ext_add (trigger_list, DB_GET_OBJECT (&value), NULL);
+			      error = ml_ext_add (trigger_list, db_get_object (&value), NULL);
 			    }
 			  else
 			    {
 			      /* must check for a specific event */
-			      error = tr_trigger_event (DB_GET_OBJECT (&value), &e);
+			      error = tr_trigger_event (db_get_object (&value), &e);
 			      if (error == NO_ERROR)
 				{
 				  if (e == event)
 				    {
-				      error = ml_ext_add (trigger_list, DB_GET_OBJECT (&value), NULL);
+				      error = ml_ext_add (trigger_list, db_get_object (&value), NULL);
 				    }
 				}
 			    }
@@ -2167,7 +2167,7 @@ tr_update_user_cache (void)
 	}
       else
 	{
-	  table = DB_GET_SET (&value);
+	  table = db_get_set (&value);
 	}
 
       if (table != NULL)
@@ -2181,10 +2181,10 @@ tr_update_user_cache (void)
 	      if (error == NO_ERROR)
 		{
 		  if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && !DB_IS_NULL (&value)
-		      && DB_GET_OBJECT (&value) != NULL)
+		      && db_get_object (&value) != NULL)
 		    {
 		      /* deleted objects will have been filtered by now */
-		      trigger = tr_map_trigger (DB_GET_OBJECT (&value), 1);
+		      trigger = tr_map_trigger (db_get_object (&value), 1);
 		      if (trigger == NULL)
 			{
 			  assert (er_errid () != NO_ERROR);
@@ -3024,7 +3024,7 @@ trigger_table_add (const char *name, DB_OBJECT * trigger)
     }
   else
     {
-      table = DB_GET_SET (&value);
+      table = db_get_set (&value);
     }
 
   if (table == NULL)
@@ -3074,7 +3074,7 @@ trigger_table_add (const char *name, DB_OBJECT * trigger)
 	}
       else
 	{
-	  table = DB_GET_SET (&value);
+	  table = db_get_set (&value);
 	}
     }
   max = set_size (table);
@@ -3143,7 +3143,7 @@ trigger_table_find (const char *name, DB_OBJECT ** trigger_p)
     }
   else
     {
-      table = DB_GET_SET (&value);
+      table = db_get_set (&value);
     }
 
   if (table == NULL)
@@ -3160,7 +3160,7 @@ trigger_table_find (const char *name, DB_OBJECT ** trigger_p)
       error = set_get_element (table, i, &value);
       if (error == NO_ERROR)
 	{
-	  if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && !DB_IS_NULL (&value) && DB_GET_STRING (&value) != NULL
+	  if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && !DB_IS_NULL (&value) && db_get_string (&value) != NULL
 	      && COMPARE_TRIGGER_NAMES (db_get_string (&value), name) == 0)
 	    {
 	      found = i;
@@ -3182,7 +3182,7 @@ trigger_table_find (const char *name, DB_OBJECT ** trigger_p)
 		}
 	      else
 		{
-		  *trigger_p = DB_GET_OBJECT (&value);
+		  *trigger_p = db_get_object (&value);
 		}
 	    }
 	  pr_clear_value (&value);
@@ -3252,7 +3252,7 @@ trigger_table_rename (DB_OBJECT * trigger_object, const char *newname)
     }
   else
     {
-      table = DB_GET_SET (&value);
+      table = db_get_set (&value);
     }
 
   if (table == NULL)
@@ -3270,7 +3270,7 @@ trigger_table_rename (DB_OBJECT * trigger_object, const char *newname)
       error = set_get_element (table, i, &value);
       if (error == NO_ERROR)
 	{
-	  if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && DB_GET_OBJECT (&value) == trigger_object)
+	  if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && db_get_object (&value) == trigger_object)
 	    {
 	      found = i;
 	    }
@@ -3336,7 +3336,7 @@ trigger_table_drop (const char *name)
     }
   else
     {
-      table = DB_GET_SET (&value);
+      table = db_get_set (&value);
     }
 
   if (table == NULL)
@@ -3353,7 +3353,7 @@ trigger_table_drop (const char *name)
       error = set_get_element (table, i, &value);
       if (error == NO_ERROR)
 	{
-	  if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && !DB_IS_NULL (&value) && DB_GET_STRING (&value) != NULL
+	  if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && !DB_IS_NULL (&value) && db_get_string (&value) != NULL
 	      && COMPARE_TRIGGER_NAMES (db_get_string (&value), name) == 0)
 	    {
 	      found = i;
@@ -3494,7 +3494,7 @@ find_all_triggers (bool active_filter, bool alter_filter, DB_OBJLIST ** list)
     }
   else
     {
-      table = DB_GET_SET (&value);
+      table = db_get_set (&value);
     }
 
   if (table == NULL)
@@ -3509,10 +3509,10 @@ find_all_triggers (bool active_filter, bool alter_filter, DB_OBJLIST ** list)
       error = set_get_element (table, i, &value);
       if (error == NO_ERROR)
 	{
-	  if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && !DB_IS_NULL (&value) && DB_GET_OBJECT (&value) != NULL)
+	  if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && !DB_IS_NULL (&value) && db_get_object (&value) != NULL)
 	    {
 	      /* think about possibly avoiding this, especially if we're going to turn around and delete it */
-	      trigger = tr_map_trigger (DB_GET_OBJECT (&value), 1);
+	      trigger = tr_map_trigger (db_get_object (&value), 1);
 	      if (trigger == NULL)
 		{
 		  ASSERT_ERROR_AND_SET (error);
@@ -3522,7 +3522,7 @@ find_all_triggers (bool active_filter, bool alter_filter, DB_OBJLIST ** list)
 		  if ((!active_filter || trigger->status == TR_STATUS_ACTIVE)
 		      && check_authorization (trigger, alter_filter))
 		    {
-		      error = ml_ext_add (list, DB_GET_OBJECT (&value), NULL);
+		      error = ml_ext_add (list, db_get_object (&value), NULL);
 		    }
 		}
 	    }
@@ -4524,58 +4524,58 @@ value_as_boolean (DB_VALUE * value)
       status = false;
       break;
     case DB_TYPE_SHORT:
-      status = (DB_GET_SHORT (value) == 0) ? false : true;
+      status = (db_get_short (value) == 0) ? false : true;
       break;
     case DB_TYPE_INTEGER:
-      status = (DB_GET_INT (value) == 0) ? false : true;
+      status = (db_get_int (value) == 0) ? false : true;
       break;
     case DB_TYPE_BIGINT:
-      status = (DB_GET_BIGINT (value) == 0) ? false : true;
+      status = (db_get_bigint (value) == 0) ? false : true;
       break;
     case DB_TYPE_FLOAT:
-      status = (DB_GET_FLOAT (value) == 0) ? false : true;
+      status = (db_get_float (value) == 0) ? false : true;
       break;
     case DB_TYPE_DOUBLE:
-      status = (DB_GET_DOUBLE (value) == 0) ? false : true;
+      status = (db_get_double (value) == 0) ? false : true;
       break;
     case DB_TYPE_TIME:
     case DB_TYPE_TIMELTZ:
-      status = (*DB_GET_TIME (value) == 0) ? false : true;
+      status = (*db_get_time (value) == 0) ? false : true;
       break;
     case DB_TYPE_TIMETZ:
       {
-	DB_TIMETZ *time_tz = DB_GET_TIMETZ (value);
+	DB_TIMETZ *time_tz = db_get_timetz (value);
 
 	status = (time_tz->time == 0) ? false : true;
       }
       break;
     case DB_TYPE_UTIME:
     case DB_TYPE_TIMESTAMPLTZ:
-      status = (*DB_GET_UTIME (value) == 0) ? false : true;
+      status = (*db_get_utime (value) == 0) ? false : true;
       break;
     case DB_TYPE_TIMESTAMPTZ:
       {
-	DB_TIMESTAMPTZ *ts_tz = DB_GET_TIMESTAMPTZ (value);
+	DB_TIMESTAMPTZ *ts_tz = db_get_timestamptz (value);
 
 	status = (ts_tz->timestamp == 0) ? false : true;
       }
       break;
     case DB_TYPE_DATETIME:
     case DB_TYPE_DATETIMELTZ:
-      status = (DB_GET_DATETIME (value)->date == 0 && DB_GET_DATETIME (value)->time == 0) ? false : true;
+      status = (db_get_datetime (value)->date == 0 && db_get_datetime (value)->time == 0) ? false : true;
       break;
     case DB_TYPE_DATETIMETZ:
       {
-	DB_DATETIMETZ *dt_tz = DB_GET_DATETIMETZ (value);
+	DB_DATETIMETZ *dt_tz = db_get_datetimetz (value);
 
 	status = (dt_tz->datetime.date == 0 && dt_tz->datetime.time == 0) ? false : true;
       }
       break;
     case DB_TYPE_DATE:
-      status = (*DB_GET_DATE (value) == 0) ? false : true;
+      status = (*db_get_date (value) == 0) ? false : true;
       break;
     case DB_TYPE_MONETARY:
-      status = (DB_GET_MONETARY (value)->amount == 0) ? false : true;
+      status = (db_get_monetary (value)->amount == 0) ? false : true;
       break;
 
     default:
@@ -6771,13 +6771,13 @@ get_user_name (DB_OBJECT * user)
       return namebuf;
     }
 
-  if (DB_VALUE_TYPE (&value) != DB_TYPE_STRING || DB_IS_NULL (&value) || DB_GET_STRING (&value) == NULL)
+  if (DB_VALUE_TYPE (&value) != DB_TYPE_STRING || DB_IS_NULL (&value) || db_get_string (&value) == NULL)
     {
       strcpy (namebuf, "???");
     }
   else
     {
-      tmp = DB_GET_STRING (&value);
+      tmp = db_get_string (&value);
       if (tmp)
 	{
 	  strncpy (namebuf, tmp, sizeof (namebuf) - 1);
@@ -6823,7 +6823,7 @@ tr_dump_all_triggers (FILE * fp, bool quoted_id_flag)
 	}
       else
 	{
-	  table = DB_GET_SET (&value);
+	  table = db_get_set (&value);
 	}
       if (table != NULL)
 	{
@@ -6834,9 +6834,9 @@ tr_dump_all_triggers (FILE * fp, bool quoted_id_flag)
 	      if ((error = set_get_element (table, i, &value)) == NO_ERROR)
 		{
 		  if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && !DB_IS_NULL (&value)
-		      && DB_GET_OBJECT (&value) != NULL)
+		      && db_get_object (&value) != NULL)
 		    {
-		      trigger_object = DB_GET_OBJECT (&value);
+		      trigger_object = db_get_object (&value);
 		      trigger = tr_map_trigger (trigger_object, 1);
 		      if (trigger == NULL)
 			{
@@ -6924,7 +6924,7 @@ tr_dump_selective_triggers (FILE * fp, DB_OBJLIST * classes)
     }
   else
     {
-      table = DB_GET_SET (&value);
+      table = db_get_set (&value);
     }
 
   if (table == NULL)
@@ -6939,9 +6939,9 @@ tr_dump_selective_triggers (FILE * fp, DB_OBJLIST * classes)
       error = set_get_element (table, i, &value);
       if (error == NO_ERROR)
 	{
-	  if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && !DB_IS_NULL (&value) && DB_GET_OBJECT (&value) != NULL)
+	  if (DB_VALUE_TYPE (&value) == DB_TYPE_OBJECT && !DB_IS_NULL (&value) && db_get_object (&value) != NULL)
 	    {
-	      trigger_object = DB_GET_OBJECT (&value);
+	      trigger_object = db_get_object (&value);
 	      trigger = tr_map_trigger (trigger_object, 1);
 	      if (trigger == NULL)
 		{
@@ -7692,7 +7692,7 @@ tr_downcase_all_trigger_info (void)
 
       if (!DB_IS_NULL (&value))
 	{
-	  attribute = DB_GET_STRING (&value);
+	  attribute = db_get_string (&value);
 	  sm_downcase_name (attribute, attribute, SM_MAX_IDENTIFIER_LENGTH);
 	  if (obj_set (obj, "target_attribute", &value) != NO_ERROR)
 	    break;

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -296,7 +296,7 @@ vid_convert_object_attr_value (SM_ATTRIBUTE * attribute_p, DB_VALUE * source_val
     case DB_TYPE_OBJECT:
       {
 	db_value_domain_init (destination_value, DB_TYPE_STRING, DB_DEFAULT_PRECISION, 0);
-	temp_object = DB_GET_OBJECT (source_value);
+	temp_object = db_get_object (source_value);
 	if (temp_object != NULL)
 	  {
 	    ref_vid_info = temp_object->oid_info.vid_info;
@@ -325,9 +325,9 @@ vid_convert_object_attr_value (SM_ATTRIBUTE * attribute_p, DB_VALUE * source_val
 	  {
 	    DB_VALUE setval;
 
-	    set = DB_GET_SET (source_value);
+	    set = db_get_set (source_value);
 	    (void) db_seq_get (set, 1, &setval);
-	    proxy_class_mop = DB_GET_OBJECT (&setval);
+	    proxy_class_mop = db_get_object (&setval);
 
 	    if (proxy_class_mop == NULL)
 	      {
@@ -347,8 +347,8 @@ vid_convert_object_attr_value (SM_ATTRIBUTE * attribute_p, DB_VALUE * source_val
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
       {
-	set = DB_GET_SET (source_value);
-	new_set = DB_GET_SET (destination_value);
+	set = db_get_set (source_value);
+	new_set = db_get_set (destination_value);
 	set_size = db_set_cardinality (set);
 	for (set_index = 0; set_index < set_size; ++set_index)
 	  {
@@ -370,8 +370,8 @@ vid_convert_object_attr_value (SM_ATTRIBUTE * attribute_p, DB_VALUE * source_val
 
     case DB_TYPE_SEQUENCE:
       {
-	set = DB_GET_SET (source_value);
-	new_set = DB_GET_SET (destination_value);
+	set = db_get_set (source_value);
+	new_set = db_get_set (destination_value);
 	set_size = db_seq_size (set);
 	for (set_index = 0; set_index < set_size; ++set_index)
 	  {
@@ -542,7 +542,7 @@ vid_flush_and_rehash_lbl (DB_VALUE * value)
       return value;
     }
 
-  mop = DB_GET_OBJECT (value);
+  mop = db_get_object (value);
 
   /* if val has anything other than a new dirty proxy object then do nothing */
   if (mop == NULL || !vid_is_new_pobj (mop))
@@ -689,7 +689,7 @@ vid_get_referenced_mop (MOP mop)
 
   if (DB_VALUE_TYPE (&mop_vid_info->keys) == DB_TYPE_OBJECT)
     {
-      return DB_GET_OBJECT (&mop_vid_info->keys);
+      return db_get_object (&mop_vid_info->keys);
     }
 
 end:
@@ -960,8 +960,8 @@ vid_compare_non_updatable_objects (MOP mop1, MOP mop2)
 	  db_value_domain_init (&val2, att1->type->id, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	  PRIM_GETMEM (att1->type, att1->domain, mem1, &val1);
 	  PRIM_GETMEM (att2->type, att2->domain, mem2, &val2);
-	  set1 = DB_GET_SET (&val1);
-	  set2 = DB_GET_SET (&val2);
+	  set1 = db_get_set (&val1);
+	  set2 = db_get_set (&val2);
 	  db_value_put_null (&val1);
 	  db_value_put_null (&val2);
 	  if ((set1 != NULL) && (set2 != NULL))
@@ -982,8 +982,8 @@ vid_compare_non_updatable_objects (MOP mop1, MOP mop2)
 	  db_value_domain_init (&val2, DB_TYPE_OBJECT, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	  PRIM_GETMEM (att1->type, att1->domain, mem1, &val1);
 	  PRIM_GETMEM (att2->type, att2->domain, mem2, &val2);
-	  attobj1 = DB_GET_OBJECT (&val1);
-	  attobj2 = DB_GET_OBJECT (&val2);
+	  attobj1 = db_get_object (&val1);
+	  attobj2 = db_get_object (&val2);
 	  db_value_put_null (&val1);
 	  db_value_put_null (&val2);
 	  if (attobj1 != NULL && WS_IS_DELETED (attobj1))
@@ -1135,7 +1135,7 @@ vid_build_non_upd_object (MOP mop, DB_VALUE * seq)
     }
 
   mop->object = inst;
-  col = DB_GET_SET (seq);
+  col = db_get_set (seq);
   for (attribute_p = class_p->attributes; attribute_p != NULL; attribute_p = (SM_ATTRIBUTE *) attribute_p->header.next)
     {
       error = db_seq_get (col, attribute_p->order, &val);
@@ -1160,7 +1160,7 @@ vid_build_non_upd_object (MOP mop, DB_VALUE * seq)
 	case DB_TYPE_MULTISET:
 	case DB_TYPE_SEQUENCE:
 	  {
-	    error = set_convert_oids_to_objects (DB_GET_SET (&val));
+	    error = set_convert_oids_to_objects (db_get_set (&val));
 	  }
 	  break;
 	default:
@@ -1344,7 +1344,7 @@ vid_getall_mops (MOP class_mop, SM_CLASS * class_p, DB_FETCH_MODE purpose)
 	}
 
       /* save instance mop into objlist */
-      new1->op = mop = DB_GET_OBJECT (&value);
+      new1->op = mop = db_get_object (&value);
       new1->next = objlst;
       objlst = new1;
     }
@@ -1401,7 +1401,7 @@ vid_vobj_to_object (const DB_VALUE * vobj, DB_OBJECT ** mop)
   MOBJ inst;
 
   /* make sure we have a good input argument */
-  if (!vobj || !mop || DB_VALUE_TYPE (vobj) != DB_TYPE_VOBJ || (seq = DB_GET_SEQUENCE (vobj)) == NULL
+  if (!vobj || !mop || DB_VALUE_TYPE (vobj) != DB_TYPE_VOBJ || (seq = db_get_set (vobj)) == NULL
       || (size = db_set_size (seq)) != 3)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DL_ESYS, 1, "virtual object inconsistent");
@@ -1503,7 +1503,7 @@ vid_vobj_to_object (const DB_VALUE * vobj, DB_OBJECT ** mop)
 	   * The vclass refers to a class, but we left
 	   * the class oid feild empty in the vobj.
 	   */
-	  obj = DB_GET_OBJECT (&keys);
+	  obj = db_get_object (&keys);
 	}
       else if (keys.domain.general_info.type == DB_TYPE_VOBJ)
 	{
@@ -1594,7 +1594,7 @@ vid_oid_to_object (const DB_VALUE * value, DB_OBJECT ** mop)
   switch (DB_VALUE_TYPE (value))
     {
     case DB_TYPE_OID:
-      oid = (OID *) DB_GET_OID (value);
+      oid = (OID *) db_get_oid (value);
       if (oid != NULL && !OID_ISNULL (oid))
 	{
 	  *mop = ws_mop (oid, NULL);
@@ -1604,7 +1604,7 @@ vid_oid_to_object (const DB_VALUE * value, DB_OBJECT ** mop)
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
     case DB_TYPE_SEQUENCE:
-      return set_convert_oids_to_objects (DB_GET_SET (value));
+      return set_convert_oids_to_objects (db_get_set (value));
 
     default:
       break;
@@ -2108,7 +2108,7 @@ vid_decode_object (const char *string, DB_OBJECT ** object)
 	}
       else
 	{
-	  *object = DB_GET_OBJECT (&val);
+	  *object = db_get_object (&val);
 	}
       break;
     default:

--- a/src/object/work_space.c
+++ b/src/object/work_space.c
@@ -961,16 +961,16 @@ ws_rehash_vmop (MOP mop, MOBJ classobj, DB_VALUE * newkey)
 	{
 	  if ((att->flags & SM_ATTFLAG_VID) && (classobj_get_prop (att->properties, SM_PROPERTY_VID_KEY, &val)))
 	    {
-	      att_seq_val = DB_GET_INTEGER (&val);
+	      att_seq_val = db_get_int (&val);
 	      if (att_seq_val == key_index)
 		{
 		  /* Sets won't work as key components */
 		  mem = inst + att->offset;
 		  db_value_domain_init (&val, att->type->id, att->domain->precision, att->domain->scale);
 		  PRIM_GETMEM (att->type, att->domain, mem, &val);
-		  if ((DB_VALUE_TYPE (value) == DB_TYPE_STRING) && (DB_GET_STRING (value) == NULL))
+		  if ((DB_VALUE_TYPE (value) == DB_TYPE_STRING) && (db_get_string (value) == NULL))
 		    {
-		      DB_MAKE_NULL (value);
+		      db_make_null (value);
 		    }
 
 		  if (no_keys > 1)

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -5478,7 +5478,7 @@ qo_data_compare (DB_DATA * data1, DB_DATA * data2, DB_TYPE type)
       break;
 
     case DB_TYPE_TIMESTAMPLTZ:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       result = ((data1->utime < data2->utime) ? -1 : ((data1->utime > data2->utime) ? 1 : 0));
       break;
     case DB_TYPE_TIMESTAMPTZ:

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -5612,7 +5612,7 @@ qo_env_new (PARSER_CONTEXT * parser, PT_NODE * query)
   env->dump_enable = prm_get_bool_value (PRM_ID_QO_DUMP);
   bitset_init (&(env->fake_terms), env);
   bitset_init (&QO_ENV_SORT_LIMIT_NODES (env), env);
-  DB_MAKE_NULL (&QO_ENV_LIMIT_VALUE (env));
+  db_make_null (&QO_ENV_LIMIT_VALUE (env));
 
   assert (query->node_type == PT_SELECT);
   if (PT_SELECT_INFO_IS_FLAGED (query, PT_SELECT_INFO_COLS_SCHEMA)
@@ -8487,7 +8487,7 @@ qo_discover_sort_limit_nodes (QO_ENV * env)
       goto abandon_stop_limit;
     }
 
-  if ((DB_BIGINT) limit_max_count < DB_GET_BIGINT (&QO_ENV_LIMIT_VALUE (env)))
+  if ((DB_BIGINT) limit_max_count < db_get_bigint (&QO_ENV_LIMIT_VALUE (env)))
     {
       /* Limit too large to apply this optimization. Mark it as candidate but do not generate SORT-LIMIT plans at this
        * time. 

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -3057,7 +3057,7 @@ qo_nljoin_cost (QO_PLAN * planp)
   if (outer->plan_type == QO_PLANTYPE_SORT && outer->plan_un.sort.sort_type == SORT_LIMIT)
     {
       /* cardinality of a SORT_LIMIT plan is given by the value of the query limit */
-      guessed_result_cardinality = (double) DB_GET_BIGINT (&QO_ENV_LIMIT_VALUE (outer->info->env));
+      guessed_result_cardinality = (double) db_get_bigint (&QO_ENV_LIMIT_VALUE (outer->info->env));
     }
   else
     {
@@ -3234,7 +3234,7 @@ qo_mjoin_cost (QO_PLAN * planp)
   env = outer->info->env;
   if (outer->has_sort_limit)
     {
-      outer_cardinality = (double) DB_GET_BIGINT (&QO_ENV_LIMIT_VALUE (env));
+      outer_cardinality = (double) db_get_bigint (&QO_ENV_LIMIT_VALUE (env));
     }
   else
     {
@@ -3243,7 +3243,7 @@ qo_mjoin_cost (QO_PLAN * planp)
 
   if (inner->has_sort_limit)
     {
-      inner_cardinality = (double) DB_GET_BIGINT (&QO_ENV_LIMIT_VALUE (env));
+      inner_cardinality = (double) db_get_bigint (&QO_ENV_LIMIT_VALUE (env));
     }
   else
     {
@@ -4847,12 +4847,12 @@ qo_set_cost (DB_OBJECT * target, DB_VALUE * result, DB_VALUE * plan, DB_VALUE * 
    */
   if ((plan_string = qo_plan_set_cost_fn (plan_string, cost_string[0])) != NULL)
     {
-      DB_MAKE_STRING (result, plan_string);
+      db_make_string (result, plan_string);
     }
   else
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-      DB_MAKE_ERROR (result, ER_GENERIC_ERROR);
+      db_make_error (result, ER_GENERIC_ERROR);
     }
 }
 

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -392,7 +392,7 @@ unsigned char qo_type_qualifiers[] = {
   0,				/* DB_TYPE_SEQUENCE */
   0,				/* DB_TYPE_ELO */
   _INT + _NUM,			/* DB_TYPE_TIME */
-  _INT + _NUM,			/* DB_TYPE_UTIME */
+  _INT + _NUM,			/* DB_TYPE_TIMESTAMP */
   _INT + _NUM,			/* DB_TYPE_DATE */
   _NUM,				/* DB_TYPE_MONETARY */
   0,				/* DB_TYPE_VARIABLE */

--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -1607,7 +1607,7 @@ qo_reduce_equality_terms (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE ** wh
 		      *wherep = save_where_next;
 		      continue;	/* give up */
 		    }
-		  DB_MAKE_NULL (&dbval_res);
+		  db_make_null (&dbval_res);
 		  if (tp_value_cast (dbval, &dbval_res, dom, false) != DOMAIN_COMPATIBLE)
 		    {
 		      PT_ERRORmf2 (parser, arg2, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CANT_COERCE_TO,
@@ -2672,7 +2672,7 @@ qo_fold_is_and_not_null (PARSER_CONTEXT * parser, PT_NODE ** wherep)
 	      truefalse = (node->info.expr.op == PT_IS_NOT_NULL);
 	    }
 
-	  DB_MAKE_INTEGER (&value, truefalse);
+	  db_make_int (&value, truefalse);
 	  fold = pt_dbval_to_value (parser, &value);
 	  if (fold == NULL)
 	    {
@@ -3038,7 +3038,7 @@ qo_find_like_rewrite_bound (PARSER_CONTEXT * const parser, PT_NODE * const patte
   PT_NODE *bound;
   DB_VALUE tmp_result;
 
-  DB_MAKE_NULL (&tmp_result);
+  db_make_null (&tmp_result);
 
   assert (parser != NULL);
   if (parser == NULL)
@@ -3070,15 +3070,15 @@ qo_find_like_rewrite_bound (PARSER_CONTEXT * const parser, PT_NODE * const patte
       bound->data_type = parser_copy_tree (parser, pattern->data_type);
     }
   bound->info.value.data_value.str =
-    pt_append_bytes (parser, NULL, DB_GET_STRING (&tmp_result), DB_GET_STRING_SIZE (&tmp_result));
+    pt_append_bytes (parser, NULL, db_get_string (&tmp_result), db_get_string_size (&tmp_result));
   PT_NODE_PRINT_VALUE_TO_TEXT (parser, bound);
   (void) pt_value_to_db (parser, bound);
 
   assert (bound->info.value.db_value_is_initialized);
   assert (PT_HAS_COLLATION (pattern->type_enum));
 
-  db_string_put_cs_and_collation (&(bound->info.value.db_value), DB_GET_STRING_CODESET (&tmp_result),
-				  DB_GET_STRING_COLLATION (&tmp_result));
+  db_string_put_cs_and_collation (&(bound->info.value.db_value), db_get_string_codeset (&tmp_result),
+				  db_get_string_collation (&tmp_result));
 
   db_value_clear (&tmp_result);
   return bound;
@@ -3134,7 +3134,7 @@ qo_rewrite_one_like_term (PARSER_CONTEXT * const parser, PT_NODE * const like, P
   int collation_id;
   INTL_CODESET codeset;
 
-  DB_MAKE_NULL (&compressed_pattern);
+  db_make_null (&compressed_pattern);
 
   *perform_generic_rewrite = false;
 
@@ -3146,8 +3146,8 @@ qo_rewrite_one_like_term (PARSER_CONTEXT * const parser, PT_NODE * const like, P
 
   assert (TP_IS_CHAR_TYPE (DB_VALUE_DOMAIN_TYPE (&pattern->info.value.db_value)));
 
-  collation_id = DB_GET_STRING_COLLATION (&pattern->info.value.db_value);
-  codeset = DB_GET_STRING_CODESET (&pattern->info.value.db_value);
+  collation_id = db_get_string_collation (&pattern->info.value.db_value);
+  codeset = db_get_string_codeset (&pattern->info.value.db_value);
 
   if (escape != NULL)
     {
@@ -3195,7 +3195,7 @@ qo_rewrite_one_like_term (PARSER_CONTEXT * const parser, PT_NODE * const like, P
     }
 
   pattern->info.value.data_value.str =
-    pt_append_bytes (parser, NULL, DB_GET_STRING (&compressed_pattern), DB_GET_STRING_SIZE (&compressed_pattern));
+    pt_append_bytes (parser, NULL, db_get_string (&compressed_pattern), db_get_string_size (&compressed_pattern));
   pattern_str = (char *) pattern->info.value.data_value.str->bytes;
   pattern_size = pattern->info.value.data_value.str->length;
   intl_char_count ((unsigned char *) pattern_str, pattern_size, codeset, &pattern_length);
@@ -4718,7 +4718,7 @@ qo_convert_to_range (PARSER_CONTEXT * parser, PT_NODE ** wherep)
 		      DB_VALUE db_zero;
 		      parser_free_tree (parser, dnf_node->info.expr.arg1);
 		      parser_free_tree (parser, dnf_node->info.expr.arg2);
-		      DB_MAKE_INT (&db_zero, 0);
+		      db_make_int (&db_zero, 0);
 
 		      dnf_node->info.expr.arg1 = pt_dbval_to_value (parser, &db_zero);
 		      dnf_node->info.expr.arg2 = pt_dbval_to_value (parser, &db_zero);

--- a/src/parser/method_transform.c
+++ b/src/parser/method_transform.c
@@ -629,7 +629,7 @@ meth_translate_spec (PARSER_CONTEXT * parser, PT_NODE * spec, void *void_arg, in
       PT_NODE *arg, *set;
 
       /* not derived-table spec and not meta class spec */
-      DB_MAKE_INTEGER (&val, true);
+      db_make_int (&val, true);
       arg = pt_dbval_to_value (parser, &val);
 
       set = parser_new_node (parser, PT_FUNCTION);

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -378,7 +378,7 @@ pt_eval_value_path (PARSER_CONTEXT * parser, PT_NODE * path)
   DB_VALUE val;
   PT_NODE *tmp;
 
-  DB_MAKE_NULL (&val);
+  db_make_null (&val);
 
   if (pt_eval_path_expr (parser, path, &val))
     {
@@ -453,7 +453,7 @@ pt_bind_parameter (PARSER_CONTEXT * parser, PT_NODE * parameter)
        */
       if (DB_VALUE_TYPE (db_val) == DB_TYPE_OBJECT)
 	{
-	  MOP mop = DB_GET_OBJECT (db_val);
+	  MOP mop = db_get_object (db_val);
 	  int does_exist = locator_does_exist_object (mop, DB_FETCH_READ);
 	  if (does_exist == LC_ERROR || does_exist == LC_DOESNOT_EXIST)
 	    {
@@ -8646,7 +8646,7 @@ pt_resolve_object (PARSER_CONTEXT * parser, PT_NODE * node)
       PT_ERRORm (parser, obj_param, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_ARG_IS_NOT_AN_OBJECT);
       return;
     }
-  node->info.update.object = DB_GET_OBJECT (val);
+  node->info.update.object = db_get_object (val);
   class_op = db_get_class (node->info.update.object);
   if (class_op == NULL)
     {

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -798,8 +798,8 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	  }
       }
       break;
-    case DB_TYPE_UTIME:
-      if (db_utime_to_string (buf, sizeof (buf), db_get_utime (val)) == 0)
+    case DB_TYPE_TIMESTAMP:
+      if (db_utime_to_string (buf, sizeof (buf), db_get_timestamp (val)) == 0)
 	{
 	  SET_PARSER_ERROR_AND_FREE_NODE (parser, result, MSGCAT_RUNTIME_UNDEFINED_CONVERSION);
 	}
@@ -809,7 +809,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	}
       break;
     case DB_TYPE_TIMESTAMPLTZ:
-      if (db_timestampltz_to_string (buf, sizeof (buf), db_get_utime (val)) == 0)
+      if (db_timestampltz_to_string (buf, sizeof (buf), db_get_timestamp (val)) == 0)
 	{
 	  SET_PARSER_ERROR_AND_FREE_NODE (parser, result, MSGCAT_RUNTIME_UNDEFINED_CONVERSION);
 	}
@@ -1541,7 +1541,7 @@ pt_type_enum_to_db_domain (const PT_TYPE_ENUM t)
       retval = tp_domain_construct (domain_type, NULL, DB_DATE_PRECISION, 0, NULL);
       break;
     case DB_TYPE_TIMESTAMPLTZ:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       retval = tp_domain_construct (domain_type, NULL, DB_TIMESTAMP_PRECISION, 0, NULL);
       break;
     case DB_TYPE_TIMESTAMPTZ:
@@ -1794,7 +1794,7 @@ pt_data_type_to_db_domain (PARSER_CONTEXT * parser, PT_NODE * dt, const char *cl
     case DB_TYPE_TIME:
     case DB_TYPE_TIMETZ:
     case DB_TYPE_TIMELTZ:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPTZ:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_DATETIME:
@@ -2024,7 +2024,7 @@ pt_node_data_type_to_db_domain (PARSER_CONTEXT * parser, PT_NODE * dt, PT_TYPE_E
     case DB_TYPE_TIME:
     case DB_TYPE_TIMETZ:
     case DB_TYPE_TIMELTZ:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPTZ:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_DATETIME:
@@ -2319,7 +2319,7 @@ pt_type_enum_to_db (const PT_TYPE_ENUM t)
       db_type = DB_TYPE_TIMELTZ;
       break;
     case PT_TYPE_TIMESTAMP:
-      db_type = DB_TYPE_UTIME;
+      db_type = DB_TYPE_TIMESTAMP;
       break;
     case PT_TYPE_TIMESTAMPTZ:
       db_type = DB_TYPE_TIMESTAMPTZ;
@@ -2610,7 +2610,7 @@ pt_db_to_type_enum (const DB_TYPE t)
     case DB_TYPE_TIMELTZ:
       pt_type = PT_TYPE_TIMELTZ;
       break;
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       pt_type = PT_TYPE_TIMESTAMP;
       break;
     case DB_TYPE_TIMESTAMPTZ:
@@ -2824,7 +2824,7 @@ pt_bind_helper (PARSER_CONTEXT * parser, PT_NODE * node, DB_VALUE * val, int *da
     case DB_TYPE_TIME:
     case DB_TYPE_TIMETZ:
     case DB_TYPE_TIMELTZ:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPTZ:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_DATE:

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -616,16 +616,16 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
       break;
 
     case DB_TYPE_INTEGER:
-      result->info.value.data_value.i = DB_GET_INT (val);
+      result->info.value.data_value.i = db_get_int (val);
       break;
     case DB_TYPE_BIGINT:
-      result->info.value.data_value.bigint = DB_GET_BIGINT (val);
+      result->info.value.data_value.bigint = db_get_bigint (val);
       break;
     case DB_TYPE_FLOAT:
-      result->info.value.data_value.f = DB_GET_FLOAT (val);
+      result->info.value.data_value.f = db_get_float (val);
       break;
     case DB_TYPE_DOUBLE:
-      result->info.value.data_value.d = DB_GET_DOUBLE (val);
+      result->info.value.data_value.d = db_get_double (val);
       break;
     case DB_TYPE_JSON:
       result->data_type = parser_new_node (parser, PT_DATA_TYPE);
@@ -638,7 +638,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	{
 	  result->data_type->type_enum = result->type_enum;
 	  result->info.value.data_value.str =
-	    pt_append_nulstring (parser, (PARSER_VARCHAR *) NULL, DB_GET_JSON_RAW_BODY (val));
+	    pt_append_nulstring (parser, (PARSER_VARCHAR *) NULL, db_get_json_raw_body (val));
 	  if (db_get_json_schema (val) != NULL)
 	    {
 	      /* check valid schema */
@@ -712,7 +712,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	char *printed_bit = NULL;
 
 	size = 0;
-	bytes = DB_GET_BIT (val, &size);
+	bytes = db_get_bit (val, &size);
 	max_length = ((size + 3) / 4) + 4;
 	printed_bit = (char *) db_private_alloc (NULL, max_length);
 	if (printed_bit == NULL)
@@ -757,7 +757,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	break;
       }
     case DB_TYPE_OBJECT:
-      result->info.value.data_value.op = DB_GET_OBJECT (val);
+      result->info.value.data_value.op = db_get_object (val);
       result->data_type = pt_get_object_data_type (parser, val);
       if (result->data_type == NULL)
 	{
@@ -766,7 +766,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	}
       break;
     case DB_TYPE_TIME:
-      if (db_time_to_string (buf, sizeof (buf), DB_GET_TIME (val)) == 0)
+      if (db_time_to_string (buf, sizeof (buf), db_get_time (val)) == 0)
 	{
 	  SET_PARSER_ERROR_AND_FREE_NODE (parser, result, MSGCAT_RUNTIME_UNDEFINED_CONVERSION);
 	}
@@ -776,7 +776,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	}
       break;
     case DB_TYPE_TIMELTZ:
-      if (db_timeltz_to_string (buf, sizeof (buf), DB_GET_TIME (val)) == 0)
+      if (db_timeltz_to_string (buf, sizeof (buf), db_get_time (val)) == 0)
 	{
 	  SET_PARSER_ERROR_AND_FREE_NODE (parser, result, MSGCAT_RUNTIME_UNDEFINED_CONVERSION);
 	}
@@ -787,7 +787,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
       break;
     case DB_TYPE_TIMETZ:
       {
-	DB_TIMETZ *time_tz = DB_GET_TIMETZ (val);
+	DB_TIMETZ *time_tz = db_get_timetz (val);
 	if (db_timetz_to_string (buf, sizeof (buf), &time_tz->time, &time_tz->tz_id) == 0)
 	  {
 	    SET_PARSER_ERROR_AND_FREE_NODE (parser, result, MSGCAT_RUNTIME_UNDEFINED_CONVERSION);
@@ -799,7 +799,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
       }
       break;
     case DB_TYPE_UTIME:
-      if (db_utime_to_string (buf, sizeof (buf), DB_GET_UTIME (val)) == 0)
+      if (db_utime_to_string (buf, sizeof (buf), db_get_utime (val)) == 0)
 	{
 	  SET_PARSER_ERROR_AND_FREE_NODE (parser, result, MSGCAT_RUNTIME_UNDEFINED_CONVERSION);
 	}
@@ -809,7 +809,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	}
       break;
     case DB_TYPE_TIMESTAMPLTZ:
-      if (db_timestampltz_to_string (buf, sizeof (buf), DB_GET_UTIME (val)) == 0)
+      if (db_timestampltz_to_string (buf, sizeof (buf), db_get_utime (val)) == 0)
 	{
 	  SET_PARSER_ERROR_AND_FREE_NODE (parser, result, MSGCAT_RUNTIME_UNDEFINED_CONVERSION);
 	}
@@ -820,7 +820,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
       break;
     case DB_TYPE_TIMESTAMPTZ:
       {
-	DB_TIMESTAMPTZ *ts_tz = DB_GET_TIMESTAMPTZ (val);
+	DB_TIMESTAMPTZ *ts_tz = db_get_timestamptz (val);
 
 	if (db_timestamptz_to_string (buf, sizeof (buf), &ts_tz->timestamp, &ts_tz->tz_id) == 0)
 	  {
@@ -833,7 +833,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
       }
       break;
     case DB_TYPE_DATETIME:
-      if (db_datetime_to_string (buf, sizeof (buf), DB_GET_DATETIME (val)) == 0)
+      if (db_datetime_to_string (buf, sizeof (buf), db_get_datetime (val)) == 0)
 	{
 	  SET_PARSER_ERROR_AND_FREE_NODE (parser, result, MSGCAT_RUNTIME_UNDEFINED_CONVERSION);
 	}
@@ -843,7 +843,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	}
       break;
     case DB_TYPE_DATETIMELTZ:
-      if (db_datetimeltz_to_string (buf, sizeof (buf), DB_GET_DATETIME (val)) == 0)
+      if (db_datetimeltz_to_string (buf, sizeof (buf), db_get_datetime (val)) == 0)
 	{
 	  SET_PARSER_ERROR_AND_FREE_NODE (parser, result, MSGCAT_RUNTIME_UNDEFINED_CONVERSION);
 	}
@@ -854,7 +854,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
       break;
     case DB_TYPE_DATETIMETZ:
       {
-	DB_DATETIMETZ *dt_tz = DB_GET_DATETIMETZ (val);
+	DB_DATETIMETZ *dt_tz = db_get_datetimetz (val);
 
 	if (db_datetimetz_to_string (buf, sizeof (buf), &dt_tz->datetime, &(dt_tz->tz_id)) == 0)
 	  {
@@ -867,7 +867,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
       }
       break;
     case DB_TYPE_DATE:
-      if (db_date_to_string (buf, sizeof (buf), DB_GET_DATE (val)) == 0)
+      if (db_date_to_string (buf, sizeof (buf), db_get_date (val)) == 0)
 	{
 	  SET_PARSER_ERROR_AND_FREE_NODE (parser, result, MSGCAT_RUNTIME_UNDEFINED_CONVERSION);
 	}
@@ -877,8 +877,8 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	}
       break;
     case DB_TYPE_MONETARY:
-      result->info.value.data_value.money.type = (PT_CURRENCY) DB_GET_MONETARY (val)->type;
-      result->info.value.data_value.money.amount = DB_GET_MONETARY (val)->amount;
+      result->info.value.data_value.money.type = (PT_CURRENCY) db_get_monetary (val)->type;
+      result->info.value.data_value.money.amount = db_get_monetary (val)->amount;
       result->data_type = parser_new_node (parser, PT_DATA_TYPE);
       if (result->data_type == NULL)
 	{
@@ -892,7 +892,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	}
       break;
     case DB_TYPE_SHORT:
-      result->info.value.data_value.i = DB_GET_SHORT (val);
+      result->info.value.data_value.i = db_get_short (val);
       break;
 
     case DB_TYPE_VOBJ:
@@ -953,10 +953,10 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
       break;
 
     case DB_TYPE_ENUMERATION:
-      bytes = DB_GET_ENUM_STRING (val);
-      size = DB_GET_ENUM_STRING_SIZE (val);
-      result->info.value.data_value.enumeration.short_val = DB_GET_ENUM_SHORT (val);
-      if (DB_GET_ENUM_SHORT (val) != 0)
+      bytes = db_get_enum_string (val);
+      size = db_get_enum_string_size (val);
+      result->info.value.data_value.enumeration.short_val = db_get_enum_short (val);
+      if (db_get_enum_short (val) != 0)
 	{
 	  result->info.value.data_value.enumeration.str_val = pt_append_bytes (parser, NULL, bytes, size);
 	  result->info.value.text = (const char *) result->info.value.data_value.enumeration.str_val->bytes;
@@ -1011,7 +1011,7 @@ pt_seq_value_to_db (PARSER_CONTEXT * parser, PT_NODE * values, DB_VALUE * db_val
       pt_evaluate_tree (parser, element, &e_val, 1);
       if (!pt_has_error (parser))
 	{
-	  if (db_seq_put (DB_GET_SEQUENCE (db_value), indx, &e_val) != NO_ERROR)
+	  if (db_seq_put (db_get_set (db_value), indx, &e_val) != NO_ERROR)
 	    {
 	      PT_ERRORc (parser, element, db_error_string (3));
 	      pr_clear_value (&e_val);
@@ -1070,7 +1070,7 @@ pt_set_value_to_db (PARSER_CONTEXT * parser, PT_NODE ** values, DB_VALUE * db_va
 
 	      if (DB_VALUE_TYPE (&e_val) == DB_TYPE_POINTER)
 		{
-		  obt_quit ((OBJ_TEMPLATE *) DB_GET_POINTER (&e_val));
+		  obt_quit ((OBJ_TEMPLATE *) db_get_pointer (&e_val));
 		}
 	      return NULL;
 	    }
@@ -2973,7 +2973,7 @@ pt_bind_set_type (PARSER_CONTEXT * parser, PT_NODE * node, DB_VALUE * val, int *
 
   assert (node != NULL && val != NULL);
 
-  iterator = set_iterate (DB_GET_SET (val));
+  iterator = set_iterate (db_get_set (val));
   if (iterator == NULL)
     {
       goto error;
@@ -3390,7 +3390,7 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 
     case PT_TYPE_MONETARY:
       /* 
-       * Don't use DB_MAKE_MONETARY here, since it doesn't preserve the
+       * Don't use db_make_monetary here, since it doesn't preserve the
        * currency info.
        */
       db_make_monetary (db_value, (DB_CURRENCY) value->info.value.data_value.money.type,

--- a/src/parser/parse_evaluate.c
+++ b/src/parser/parse_evaluate.c
@@ -271,7 +271,7 @@ pt_eval_path_expr (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * val)
   int is_class = 0;
 
   assert (parser != NULL);
-  DB_MAKE_NULL (&val1);
+  db_make_null (&val1);
 
   if (tree == NULL || val == NULL)
     {
@@ -294,7 +294,7 @@ pt_eval_path_expr (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * val)
 	    {
 	      result = true;
 	    }
-	  else if (DB_VALUE_TYPE (&val1) == DB_TYPE_OBJECT && (obj1 = DB_GET_OBJECT (&val1)) != NULL)
+	  else if (DB_VALUE_TYPE (&val1) == DB_TYPE_OBJECT && (obj1 = db_get_object (&val1)) != NULL)
 	    {
 	      int error;
 
@@ -633,7 +633,7 @@ pt_is_reference_to_reusable_oid (DB_VALUE * val)
 
   if (vtype == DB_TYPE_OBJECT)
     {
-      DB_OBJECT *obj = DB_GET_OBJECT (val);
+      DB_OBJECT *obj = db_get_object (val);
       int is_class = 0;
 
       if (obj == NULL)
@@ -659,7 +659,7 @@ pt_is_reference_to_reusable_oid (DB_VALUE * val)
     }
   else if (vtype == DB_TYPE_POINTER)
     {
-      DB_OTMPL *obj_tmpl = (DB_OTMPL *) DB_GET_POINTER (val);
+      DB_OTMPL *obj_tmpl = (DB_OTMPL *) db_get_pointer (val);
 
       if (obj_tmpl == NULL)
 	{
@@ -1100,7 +1100,7 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 			  int num_alloc;
 
 			  val = pt_value_to_db (parser, arg2);
-			  num_alloc = DB_GET_INTEGER (val);
+			  num_alloc = db_get_int (val);
 			  if (num_alloc < 1)
 			    {
 			      PT_ERRORm (parser, tree, MSGCAT_SET_PARSER_SEMANTIC,
@@ -1170,8 +1170,8 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 	    }
 	  else
 	    {
-	      INTL_CODESET opd1_cs = DB_IS_NULL (&opd1) ? LANG_SYS_CODESET : DB_GET_STRING_CODESET (&opd1);
-	      int opd1_coll = DB_IS_NULL (&opd1) ? LANG_SYS_COLLATION : DB_GET_STRING_COLLATION (&opd1);
+	      INTL_CODESET opd1_cs = DB_IS_NULL (&opd1) ? LANG_SYS_CODESET : db_get_string_codeset (&opd1);
+	      int opd1_coll = DB_IS_NULL (&opd1) ? LANG_SYS_COLLATION : db_get_string_collation (&opd1);
 
 	      switch (op)
 		{
@@ -1205,8 +1205,8 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 	    }
 	  else
 	    {
-	      INTL_CODESET opd1_cs = DB_IS_NULL (&opd1) ? LANG_SYS_CODESET : DB_GET_STRING_CODESET (&opd1);
-	      int opd1_coll = DB_IS_NULL (&opd1) ? LANG_SYS_COLLATION : DB_GET_STRING_COLLATION (&opd1);
+	      INTL_CODESET opd1_cs = DB_IS_NULL (&opd1) ? LANG_SYS_CODESET : db_get_string_codeset (&opd1);
+	      int opd1_coll = DB_IS_NULL (&opd1) ? LANG_SYS_COLLATION : db_get_string_collation (&opd1);
 
 	      switch (op)
 		{

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2601,7 +2601,7 @@ pt_print_db_value (PARSER_CONTEXT * parser, const struct db_value * val)
       printer.describe_value (val);
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPTZ:
     case DB_TYPE_TIMESTAMPLTZ:
       /* everyone else gets csql's utime format */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2580,7 +2580,7 @@ pt_print_db_value (PARSER_CONTEXT * parser, const struct db_value * val)
 
     case DB_TYPE_MONETARY:
       /* This is handled explicitly because describe_value will add a currency symbol, and it isn't needed here. */
-      printer.describe_money (DB_GET_MONETARY ((DB_VALUE *) val));
+      printer.describe_money (db_get_monetary ((DB_VALUE *) val));
       break;
 
     case DB_TYPE_BIT:
@@ -17454,7 +17454,7 @@ static PT_NODE *
 pt_init_insert_value (PT_NODE * p)
 {
   p->info.insert_value.original_node = NULL;
-  DB_MAKE_NULL (&p->info.insert_value.value);
+  db_make_null (&p->info.insert_value.value);
   p->info.insert_value.is_evaluated = false;
   p->info.insert_value.replace_names = false;
 

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -6124,7 +6124,7 @@ pt_limit_to_numbering_expr (PARSER_CONTEXT * parser, PT_NODE * limit, PT_OP_TYPE
   PT_NODE *lhs, *sum, *part1, *part2, *node;
   DB_VALUE sum_val;
 
-  DB_MAKE_NULL (&sum_val);
+  db_make_null (&sum_val);
 
   if (limit == NULL)
     {
@@ -6407,7 +6407,7 @@ pt_rewrite_to_auto_param (PARSER_CONTEXT * parser, PT_NODE * value)
 	}
       else
 	{
-	  DB_MAKE_NULL (host_var_val);
+	  db_make_null (host_var_val);
 	}
     }
   parser_free_tree (parser, value);
@@ -11212,7 +11212,7 @@ pt_get_query_limit_from_limit (PARSER_CONTEXT * parser, PT_NODE * limit, DB_VALU
   TP_DOMAIN *domainp = NULL;
   int error = NO_ERROR;
 
-  DB_MAKE_NULL (limit_val);
+  db_make_null (limit_val);
 
   if (limit == NULL)
     {
@@ -11249,7 +11249,7 @@ pt_get_query_limit_from_limit (PARSER_CONTEXT * parser, PT_NODE * limit, DB_VALU
     {
       DB_VALUE range;
 
-      DB_MAKE_NULL (&range);
+      db_make_null (&range);
 
       /* LIMIT :offset, :row_count => return :offset + :row_count */
       assert (limit->next->node_type == PT_VALUE || limit->next->node_type == PT_HOST_VAR
@@ -11275,14 +11275,14 @@ pt_get_query_limit_from_limit (PARSER_CONTEXT * parser, PT_NODE * limit, DB_VALU
 	}
 
       /* add range to current limit */
-      DB_MAKE_BIGINT (limit_val, DB_GET_BIGINT (limit_val) + DB_GET_BIGINT (&range));
+      db_make_bigint (limit_val, db_get_bigint (limit_val) + db_get_bigint (&range));
     }
 
 cleanup:
   if (error != NO_ERROR)
     {
       pr_clear_value (limit_val);
-      DB_MAKE_NULL (limit_val);
+      db_make_null (limit_val);
     }
 
   parser->set_host_var = save_set_host_var;
@@ -11301,7 +11301,7 @@ pt_get_query_limit_value (PARSER_CONTEXT * parser, PT_NODE * query, DB_VALUE * l
 {
   assert_release (limit_val != NULL);
 
-  DB_MAKE_NULL (limit_val);
+  db_make_null (limit_val);
 
   if (query == NULL || !PT_IS_QUERY (query))
     {
@@ -11363,7 +11363,7 @@ pt_check_ordby_num_for_multi_range_opt (PARSER_CONTEXT * parser, PT_NODE * query
       return false;
     }
 
-  DB_MAKE_NULL (&limit_val);
+  db_make_null (&limit_val);
 
   save_set_host_var = parser->set_host_var;
   parser->set_host_var = 1;
@@ -11383,7 +11383,7 @@ pt_check_ordby_num_for_multi_range_opt (PARSER_CONTEXT * parser, PT_NODE * query
       /* upper limit was successfully evaluated */
       *cannot_eval = false;
     }
-  if (DB_GET_BIGINT (&limit_val) > prm_get_integer_value (PRM_ID_MULTI_RANGE_OPT_LIMIT))
+  if (db_get_bigint (&limit_val) > prm_get_integer_value (PRM_ID_MULTI_RANGE_OPT_LIMIT))
     {
       goto end_mro_candidate;
     }
@@ -11559,7 +11559,7 @@ pt_get_query_limit_from_orderby_for (PARSER_CONTEXT * parser, PT_NODE * orderby_
     }
 
   /* evaluate the rhs expression */
-  DB_MAKE_NULL (&limit);
+  db_make_null (&limit);
   if (PT_IS_CONST (rhs) || PT_IS_CAST_CONST_INPUT_HOSTVAR (rhs))
     {
       pt_evaluate_tree_having_serial (parser, rhs, &limit, 1);
@@ -11577,9 +11577,9 @@ pt_get_query_limit_from_orderby_for (PARSER_CONTEXT * parser, PT_NODE * orderby_
   if (lt)
     {
       /* ORDERBY_NUM () < n => ORDERBY_NUM <= n - 1 */
-      DB_MAKE_BIGINT (&limit, (DB_GET_BIGINT (&limit) - 1));
+      db_make_bigint (&limit, (db_get_bigint (&limit) - 1));
     }
-  if (DB_IS_NULL (upper_limit) || (DB_GET_BIGINT (upper_limit) > DB_GET_BIGINT (&limit)))
+  if (DB_IS_NULL (upper_limit) || (db_get_bigint (upper_limit) > db_get_bigint (&limit)))
     {
       /* update upper limit */
       if (pr_clone_value (&limit, upper_limit) != NO_ERROR)
@@ -11871,7 +11871,7 @@ pt_recompile_for_limit_optimizations (PARSER_CONTEXT * parser, PT_NODE * stateme
     }
   else
     {
-      val = DB_GET_BIGINT (&limit_val);
+      val = db_get_bigint (&limit_val);
     }
 
   /* verify MRO */
@@ -12039,7 +12039,7 @@ pt_get_default_expression_from_data_default_node (PARSER_CONTEXT * parser, PT_NO
 	      if (PT_IS_CHAR_STRING_TYPE (pt_default_expr->info.expr.arg2->type_enum))
 		{
 		  db_value_default_expr_format = pt_value_to_db (parser, pt_default_expr->info.expr.arg2);
-		  default_expr->default_expr_format = DB_GET_STRING (db_value_default_expr_format);
+		  default_expr->default_expr_format = db_get_string (db_value_default_expr_format);
 		}
 	    }
 	}

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -4147,7 +4147,7 @@ pt_attr_check_default_cs_coll (PARSER_CONTEXT * parser, PT_NODE * attr, int defa
 		    }
 		  else if (elem->info.value.db_value_is_initialized)
 		    {
-		      dt->info.data_type.precision = DB_GET_STRING_SIZE (&(elem->info.value.db_value));
+		      dt->info.data_type.precision = db_get_string_size (&(elem->info.value.db_value));
 		    }
 		}
 
@@ -6102,7 +6102,7 @@ partition_range_min_max (DB_VALUE ** dest, DB_VALUE * inval, int min_max)
 
   if (inval == NULL)
     {
-      DB_MAKE_NULL (&nullval);
+      db_make_null (&nullval);
       inval = &nullval;
     }
 
@@ -6172,7 +6172,7 @@ db_value_list_add (DB_VALUE_PLIST ** ptail, DB_VALUE * val)
 
   if (val == NULL)
     {
-      DB_MAKE_NULL (&nullval);
+      db_make_null (&nullval);
       chkval = &nullval;
     }
   else
@@ -6221,7 +6221,7 @@ db_value_list_find (const DB_VALUE_PLIST * phead, const DB_VALUE * val)
 
   if (val == NULL)
     {
-      DB_MAKE_NULL (&nullval);
+      db_make_null (&nullval);
       chkval = &nullval;
     }
   else
@@ -6259,7 +6259,7 @@ db_value_list_finddel (DB_VALUE_PLIST ** phead, DB_VALUE * val)
 
   if (val == NULL)
     {
-      DB_MAKE_NULL (&nullval);
+      db_make_null (&nullval);
       chkval = &nullval;
     }
   else
@@ -6337,9 +6337,9 @@ pt_check_alter_partition (PARSER_CONTEXT * parser, PT_NODE * stmt, MOP dbobj)
       return;
     }
 
-  DB_MAKE_NULL (&minele);
-  DB_MAKE_NULL (&maxele);
-  DB_MAKE_NULL (&null_val);
+  db_make_null (&minele);
+  db_make_null (&maxele);
+  db_make_null (&null_val);
 
   class_name = (char *) stmt->info.alter.entity_name->info.name.original;
   cmd = stmt->info.alter.code;
@@ -6517,7 +6517,7 @@ pt_check_alter_partition (PARSER_CONTEXT * parser, PT_NODE * stmt, MOP dbobj)
       goto check_end;
     }
 
-  DB_MAKE_NULL (&null_val);
+  db_make_null (&null_val);
   for (objs = smclass->users; objs; objs = objs->next)
     {
       if (au_fetch_class (objs->op, &subcls, AU_FETCH_READ, AU_SELECT) != NO_ERROR)
@@ -6533,8 +6533,8 @@ pt_check_alter_partition (PARSER_CONTEXT * parser, PT_NODE * stmt, MOP dbobj)
 
       orig_cnt++;
 
-      DB_MAKE_NULL (&minele);
-      DB_MAKE_NULL (&maxele);
+      db_make_null (&minele);
+      db_make_null (&maxele);
 
       if (psize == NULL)
 	{			/* RANGE or LIST */
@@ -8936,7 +8936,7 @@ pt_check_method (PARSER_CONTEXT * parser, PT_NODE * node)
 
   assert (node != NULL && node->info.method_call.method_name != NULL);
 
-  DB_MAKE_NULL (&val);
+  db_make_null (&val);
 
   /* check if call has a target */
   target = node->info.method_call.on_call_target;
@@ -8993,7 +8993,7 @@ pt_check_method (PARSER_CONTEXT * parser, PT_NODE * node)
 	   * if we are not already doing this. Also we probably shouldn't get PT_VALUES here now that parameters are
 	   * not bound until runtime (but we'll guard against them anyway). */
 	  if (((target->node_type != PT_NAME) || (target->info.name.meta_class != PT_PARAMETER)
-	       || !pt_eval_path_expr (parser, target, &val) || db_is_instance (DB_GET_OBJECT (&val)) <= 0)
+	       || !pt_eval_path_expr (parser, target, &val) || db_is_instance (db_get_object (&val)) <= 0)
 	      && target->node_type != PT_VALUE
 	      && (target->data_type->info.data_type.entity->info.name.meta_class != PT_META_CLASS))
 	    {
@@ -9009,7 +9009,7 @@ pt_check_method (PARSER_CONTEXT * parser, PT_NODE * node)
        * if we are not already doing this. Also we probably shouldn't get PT_VALUES here now that parameters are not
        * bound until runtime (but we'll guard against them anyway). */
       if (((target->node_type != PT_NAME) || (target->info.name.meta_class != PT_PARAMETER)
-	   || !pt_eval_path_expr (parser, target, &val) || db_is_instance (DB_GET_OBJECT (&val)) <= 0)
+	   || !pt_eval_path_expr (parser, target, &val) || db_is_instance (db_get_object (&val)) <= 0)
 	  && target->node_type != PT_VALUE
 	  && (target->data_type->info.data_type.entity->info.name.meta_class != PT_CLASS))
 	{
@@ -15210,7 +15210,7 @@ pt_check_filter_index_expr_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *a
 	{
 	  if (node->info.value.db_value_is_initialized && DB_VALUE_TYPE (&node->info.value.db_value) == DB_TYPE_INTEGER)
 	    {
-	      if (DB_GET_INT (&node->info.value.db_value) == 0)
+	      if (db_get_int (&node->info.value.db_value) == 0)
 		{
 		  info->is_valid_expr = false;
 		}
@@ -15650,7 +15650,7 @@ pt_check_range_partition_strict_increasing (PARSER_CONTEXT * parser, PT_NODE * s
 		      || (pt_val1->data_type->info.data_type.collation_id ==
 			  column_dt->info.data_type.collation_id)))));
 
-  DB_MAKE_NULL (&null_val);
+  db_make_null (&null_val);
 
   /* next value */
   if (part_next != NULL)

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -15928,21 +15928,21 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      }
 	      break;
 
-	    case DB_TYPE_UTIME:
+	    case DB_TYPE_TIMESTAMP:
 	    case DB_TYPE_TIMESTAMPLTZ:
 	      {
 		DB_UTIME *utime, result_utime;
 		DB_VALUE *other;
 		DB_BIGINT bi;
 
-		if (DB_VALUE_TYPE (arg1) == DB_TYPE_UTIME || DB_VALUE_TYPE (arg1) == DB_TYPE_TIMESTAMPLTZ)
+		if (DB_VALUE_TYPE (arg1) == DB_TYPE_TIMESTAMP || DB_VALUE_TYPE (arg1) == DB_TYPE_TIMESTAMPLTZ)
 		  {
-		    utime = db_get_utime (arg1);
+		    utime = db_get_timestamp (arg1);
 		    other = arg2;
 		  }
 		else
 		  {
-		    utime = db_get_utime (arg2);
+		    utime = db_get_timestamp (arg2);
 		    other = arg1;
 		  }
 
@@ -16665,7 +16665,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      }
 	      break;
 
-	    case DB_TYPE_UTIME:
+	    case DB_TYPE_TIMESTAMP:
 	    case DB_TYPE_TIMESTAMPLTZ:
 	    case DB_TYPE_TIMESTAMPTZ:
 	      {
@@ -16697,7 +16697,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		  }
 		else
 		  {
-		    utime = *db_get_utime (arg1);
+		    utime = *db_get_timestamp (arg1);
 		  }
 
 		if (utime == 0)

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -12639,13 +12639,13 @@ pt_check_and_coerce_to_time (PARSER_CONTEXT * parser, PT_NODE * src)
       return ER_TIME_CONVERSION;
     }
 
-  if (DB_GET_STRING (db_src) == NULL)
+  if (db_get_string (db_src) == NULL)
     {
       return ER_TIME_CONVERSION;
     }
 
-  cp = DB_GET_STRING (db_src);
-  cp_len = DB_GET_STRING_SIZE (db_src);
+  cp = db_get_string (db_src);
+  cp_len = db_get_string_size (db_src);
   if (db_string_check_explicit_time (cp, cp_len) == false)
     {
       return ER_TIME_CONVERSION;
@@ -12681,13 +12681,13 @@ pt_check_and_coerce_to_date (PARSER_CONTEXT * parser, PT_NODE * src)
       return ER_DATE_CONVERSION;
     }
 
-  if (DB_GET_STRING (db_src) == NULL)
+  if (db_get_string (db_src) == NULL)
     {
       return ER_DATE_CONVERSION;
     }
 
-  str = DB_GET_STRING (db_src);
-  str_len = DB_GET_STRING_SIZE (db_src);
+  str = db_get_string (db_src);
+  str_len = db_get_string_size (db_src);
   if (!db_string_check_explicit_date (str, str_len))
     {
       return ER_DATE_CONVERSION;
@@ -14449,7 +14449,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	{
 	  db_make_null (result);	/* not NULL = NULL */
 	}
-      else if (DB_GET_INTEGER (arg1))
+      else if (db_get_int (arg1))
 	{
 	  db_make_int (result, false);	/* not true = false */
 	}
@@ -14479,15 +14479,15 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  db_make_bigint (result, ~((DB_BIGINT) DB_GET_INTEGER (arg1)));
+	  db_make_bigint (result, ~((DB_BIGINT) db_get_int (arg1)));
 	  break;
 
 	case DB_TYPE_BIGINT:
-	  db_make_bigint (result, ~DB_GET_BIGINT (arg1));
+	  db_make_bigint (result, ~db_get_bigint (arg1));
 	  break;
 
 	case DB_TYPE_SHORT:
-	  db_make_bigint (result, ~((DB_BIGINT) DB_GET_SHORT (arg1)));
+	  db_make_bigint (result, ~((DB_BIGINT) db_get_short (arg1)));
 	  break;
 
 	default:
@@ -14516,15 +14516,15 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		break;
 
 	      case DB_TYPE_INTEGER:
-		bi[i] = (DB_BIGINT) DB_GET_INTEGER (dbval[i]);
+		bi[i] = (DB_BIGINT) db_get_int (dbval[i]);
 		break;
 
 	      case DB_TYPE_BIGINT:
-		bi[i] = DB_GET_BIGINT (dbval[i]);
+		bi[i] = db_get_bigint (dbval[i]);
 		break;
 
 	      case DB_TYPE_SHORT:
-		bi[i] = (DB_BIGINT) DB_GET_SHORT (dbval[i]);
+		bi[i] = (DB_BIGINT) db_get_short (dbval[i]);
 		break;
 
 	      default:
@@ -14560,15 +14560,15 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		break;
 
 	      case DB_TYPE_INTEGER:
-		bi[i] = (DB_BIGINT) DB_GET_INTEGER (dbval[i]);
+		bi[i] = (DB_BIGINT) db_get_int (dbval[i]);
 		break;
 
 	      case DB_TYPE_BIGINT:
-		bi[i] = DB_GET_BIGINT (dbval[i]);
+		bi[i] = db_get_bigint (dbval[i]);
 		break;
 
 	      case DB_TYPE_SHORT:
-		bi[i] = (DB_BIGINT) DB_GET_SHORT (dbval[i]);
+		bi[i] = (DB_BIGINT) db_get_short (dbval[i]);
 		break;
 
 	      default:
@@ -14604,15 +14604,15 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		break;
 
 	      case DB_TYPE_INTEGER:
-		bi[i] = (DB_BIGINT) DB_GET_INTEGER (dbval[i]);
+		bi[i] = (DB_BIGINT) db_get_int (dbval[i]);
 		break;
 
 	      case DB_TYPE_BIGINT:
-		bi[i] = DB_GET_BIGINT (dbval[i]);
+		bi[i] = db_get_bigint (dbval[i]);
 		break;
 
 	      case DB_TYPE_SHORT:
-		bi[i] = (DB_BIGINT) DB_GET_SHORT (dbval[i]);
+		bi[i] = (DB_BIGINT) db_get_short (dbval[i]);
 		break;
 
 	      default:
@@ -14649,15 +14649,15 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		break;
 
 	      case DB_TYPE_INTEGER:
-		bi[i] = (DB_BIGINT) DB_GET_INTEGER (dbval[i]);
+		bi[i] = (DB_BIGINT) db_get_int (dbval[i]);
 		break;
 
 	      case DB_TYPE_BIGINT:
-		bi[i] = DB_GET_BIGINT (dbval[i]);
+		bi[i] = db_get_bigint (dbval[i]);
 		break;
 
 	      case DB_TYPE_SHORT:
-		bi[i] = (DB_BIGINT) DB_GET_SHORT (dbval[i]);
+		bi[i] = (DB_BIGINT) db_get_short (dbval[i]);
 		break;
 
 	      default:
@@ -14708,15 +14708,15 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		break;
 
 	      case DB_TYPE_INTEGER:
-		bi[i] = (DB_BIGINT) DB_GET_INTEGER (dbval[i]);
+		bi[i] = (DB_BIGINT) db_get_int (dbval[i]);
 		break;
 
 	      case DB_TYPE_BIGINT:
-		bi[i] = DB_GET_BIGINT (dbval[i]);
+		bi[i] = db_get_bigint (dbval[i]);
 		break;
 
 	      case DB_TYPE_SHORT:
-		bi[i] = (DB_BIGINT) DB_GET_SHORT (dbval[i]);
+		bi[i] = (DB_BIGINT) db_get_short (dbval[i]);
 		break;
 
 	      default:
@@ -14791,7 +14791,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	  }
 	else
 	  {
-	    if (DB_GET_INTEGER (arg1))
+	    if (db_get_int (arg1))
 	      {
 		if (db_value_clone (arg2, result) != NO_ERROR)
 		  {
@@ -14918,44 +14918,44 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  if (DB_GET_INTEGER (arg1) == DB_INT32_MIN)
+	  if (db_get_int (arg1) == DB_INT32_MIN)
 	    {
 	      goto overflow;
 	    }
 	  else
 	    {
-	      db_make_int (result, -DB_GET_INTEGER (arg1));
+	      db_make_int (result, -db_get_int (arg1));
 	    }
 	  break;
 
 	case DB_TYPE_BIGINT:
-	  if (DB_GET_BIGINT (arg1) == DB_BIGINT_MIN)
+	  if (db_get_bigint (arg1) == DB_BIGINT_MIN)
 	    {
 	      goto overflow;
 	    }
 	  else
 	    {
-	      db_make_bigint (result, -DB_GET_BIGINT (arg1));
+	      db_make_bigint (result, -db_get_bigint (arg1));
 	    }
 	  break;
 
 	case DB_TYPE_SHORT:
-	  if (DB_GET_SHORT (arg1) == DB_INT16_MIN)
+	  if (db_get_short (arg1) == DB_INT16_MIN)
 	    {
 	      goto overflow;
 	    }
 	  else
 	    {
-	      db_make_short (result, -DB_GET_SHORT (arg1));
+	      db_make_short (result, -db_get_short (arg1));
 	    }
 	  break;
 
 	case DB_TYPE_FLOAT:
-	  db_make_float (result, -DB_GET_FLOAT (arg1));
+	  db_make_float (result, -db_get_float (arg1));
 	  break;
 
 	case DB_TYPE_DOUBLE:
-	  db_make_double (result, -DB_GET_DOUBLE (arg1));
+	  db_make_double (result, -db_get_double (arg1));
 	  break;
 
 	case DB_TYPE_NUMERIC:
@@ -14965,11 +14965,11 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      return 0;
 	    }
 
-	  db_make_numeric (result, DB_GET_NUMERIC (arg1), DB_VALUE_PRECISION (arg1), DB_VALUE_SCALE (arg1));
+	  db_make_numeric (result, db_get_numeric (arg1), DB_VALUE_PRECISION (arg1), DB_VALUE_SCALE (arg1));
 	  break;
 
 	case DB_TYPE_MONETARY:
-	  DB_MAKE_MONETARY (result, -DB_GET_MONETARY (arg1)->amount);
+	  db_make_monetary (result, DB_CURRENCY_DEFAULT, -db_get_monetary (arg1)->amount);
 	  break;
 
 	case DB_TYPE_CHAR:
@@ -14998,7 +14998,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	    {
 	      pr_clear_value (arg1);
 	      *arg1 = tmp_val;
-	      db_make_double (result, -DB_GET_DOUBLE (arg1));
+	      db_make_double (result, -db_get_double (arg1));
 	    }
 	  break;
 
@@ -15060,7 +15060,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      }
 	    else
 	      {
-		if (DB_GET_INTEGER (arg1) == DB_GET_INTEGER (arg2))
+		if (db_get_int (arg1) == db_get_int (arg2))
 		  {
 		    db_make_int (result, _true);
 		  }
@@ -15569,12 +15569,12 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
       break;
 
     case PT_AND:
-      if ((typ1 == DB_TYPE_NULL && typ2 == DB_TYPE_NULL) || (typ1 == DB_TYPE_NULL && DB_GET_INTEGER (arg2))
-	  || (typ2 == DB_TYPE_NULL && DB_GET_INTEGER (arg1)))
+      if ((typ1 == DB_TYPE_NULL && typ2 == DB_TYPE_NULL) || (typ1 == DB_TYPE_NULL && db_get_int (arg2))
+	  || (typ2 == DB_TYPE_NULL && db_get_int (arg1)))
 	{
 	  db_make_null (result);
 	}
-      else if (typ1 != DB_TYPE_NULL && DB_GET_INTEGER (arg1) && typ2 != DB_TYPE_NULL && DB_GET_INTEGER (arg2))
+      else if (typ1 != DB_TYPE_NULL && db_get_int (arg1) && typ2 != DB_TYPE_NULL && db_get_int (arg2))
 	{
 	  db_make_int (result, true);
 	}
@@ -15585,12 +15585,12 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
       break;
 
     case PT_OR:
-      if ((typ1 == DB_TYPE_NULL && typ2 == DB_TYPE_NULL) || (typ1 == DB_TYPE_NULL && !DB_GET_INTEGER (arg2))
-	  || (typ2 == DB_TYPE_NULL && !DB_GET_INTEGER (arg1)))
+      if ((typ1 == DB_TYPE_NULL && typ2 == DB_TYPE_NULL) || (typ1 == DB_TYPE_NULL && !db_get_int (arg2))
+	  || (typ2 == DB_TYPE_NULL && !db_get_int (arg1)))
 	{
 	  db_make_null (result);
 	}
-      else if (typ1 != DB_TYPE_NULL && !DB_GET_INTEGER (arg1) && typ2 != DB_TYPE_NULL && !DB_GET_INTEGER (arg2))
+      else if (typ1 != DB_TYPE_NULL && !db_get_int (arg1) && typ2 != DB_TYPE_NULL && !db_get_int (arg2))
 	{
 	  db_make_int (result, false);
 	}
@@ -15605,7 +15605,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	{
 	  db_make_null (result);
 	}
-      else if ((!DB_GET_INTEGER (arg1) && !DB_GET_INTEGER (arg2)) || (DB_GET_INTEGER (arg1) && DB_GET_INTEGER (arg2)))
+      else if ((!db_get_int (arg1) && !db_get_int (arg2)) || (db_get_int (arg1) && db_get_int (arg2)))
 	{
 	  db_make_int (result, false);
 	}
@@ -15724,8 +15724,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		int i1, i2, itmp;
 
-		i1 = DB_GET_INT (arg1);
-		i2 = DB_GET_INT (arg2);
+		i1 = db_get_int (arg1);
+		i2 = db_get_int (arg2);
 		itmp = i1 + i2;
 		if (OR_CHECK_ADD_OVERFLOW (i1, i2, itmp))
 		  goto overflow;
@@ -15738,8 +15738,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		DB_BIGINT bi1, bi2, bitmp;
 
-		bi1 = DB_GET_BIGINT (arg1);
-		bi2 = DB_GET_BIGINT (arg2);
+		bi1 = db_get_bigint (arg1);
+		bi2 = db_get_bigint (arg2);
 		bitmp = bi1 + bi2;
 		if (OR_CHECK_ADD_OVERFLOW (bi1, bi2, bitmp))
 		  goto overflow;
@@ -15752,8 +15752,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		short s1, s2, stmp;
 
-		s1 = DB_GET_SHORT (arg1);
-		s2 = DB_GET_SHORT (arg2);
+		s1 = db_get_short (arg1);
+		s2 = db_get_short (arg2);
 		stmp = s1 + s2;
 		if (OR_CHECK_ADD_OVERFLOW (s1, s2, stmp))
 		  goto overflow;
@@ -15766,7 +15766,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		float ftmp;
 
-		ftmp = DB_GET_FLOAT (arg1) + DB_GET_FLOAT (arg2);
+		ftmp = db_get_float (arg1) + db_get_float (arg2);
 		if (OR_CHECK_FLOAT_OVERFLOW (ftmp))
 		  goto overflow;
 		else
@@ -15778,7 +15778,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		double dtmp;
 
-		dtmp = DB_GET_DOUBLE (arg1) + DB_GET_DOUBLE (arg2);
+		dtmp = db_get_double (arg1) + db_get_double (arg2);
 		if (OR_CHECK_DOUBLE_OVERFLOW (dtmp))
 		  goto overflow;
 		else
@@ -15805,11 +15805,11 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		double dtmp;
 
-		dtmp = (DB_GET_MONETARY (arg1)->amount + DB_GET_MONETARY (arg2)->amount);
+		dtmp = (db_get_monetary (arg1)->amount + db_get_monetary (arg2)->amount);
 		if (OR_CHECK_DOUBLE_OVERFLOW (dtmp))
 		  goto overflow;
 		else
-		  DB_MAKE_MONETARY (result, dtmp);
+		  db_make_monetary (result, DB_CURRENCY_DEFAULT, dtmp);
 		break;
 	      }
 
@@ -15823,25 +15823,25 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		if (DB_VALUE_TYPE (arg1) == DB_TYPE_TIME || DB_VALUE_TYPE (arg1) == DB_TYPE_TIMELTZ)
 		  {
-		    time = *DB_GET_TIME (arg1);
+		    time = *db_get_time (arg1);
 		    other = arg2;
 		  }
 		else
 		  {
-		    time = *DB_GET_TIME (arg2);
+		    time = *db_get_time (arg2);
 		    other = arg1;
 		  }
 
 		switch (DB_VALUE_TYPE (other))
 		  {
 		  case DB_TYPE_INTEGER:
-		    itmp = DB_GET_INTEGER (other);	/* SECONDS_OF_ONE_DAY */
+		    itmp = db_get_int (other);	/* SECONDS_OF_ONE_DAY */
 		    break;
 		  case DB_TYPE_SMALLINT:
-		    itmp = DB_GET_SHORT (other);	/* SECONDS_OF_ONE_DAY */
+		    itmp = db_get_short (other);	/* SECONDS_OF_ONE_DAY */
 		    break;
 		  case DB_TYPE_BIGINT:
-		    itmp = DB_GET_BIGINT (other);	/* SECONDS_OF_ONE_DAY */
+		    itmp = db_get_bigint (other);	/* SECONDS_OF_ONE_DAY */
 		    break;
 		  default:
 		    return 0;
@@ -15880,25 +15880,25 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		if (DB_VALUE_TYPE (arg1) == DB_TYPE_TIMETZ)
 		  {
-		    time_tz_p = DB_GET_TIMETZ (arg1);
+		    time_tz_p = db_get_timetz (arg1);
 		    other = arg2;
 		  }
 		else
 		  {
-		    time_tz_p = DB_GET_TIMETZ (arg2);
+		    time_tz_p = db_get_timetz (arg2);
 		    other = arg1;
 		  }
 
 		switch (DB_VALUE_TYPE (other))
 		  {
 		  case DB_TYPE_INTEGER:
-		    itmp = DB_GET_INTEGER (other);	/* SECONDS_OF_ONE_DAY */
+		    itmp = db_get_int (other);	/* SECONDS_OF_ONE_DAY */
 		    break;
 		  case DB_TYPE_SMALLINT:
-		    itmp = DB_GET_SHORT (other);	/* SECONDS_OF_ONE_DAY */
+		    itmp = db_get_short (other);	/* SECONDS_OF_ONE_DAY */
 		    break;
 		  case DB_TYPE_BIGINT:
-		    itmp = DB_GET_BIGINT (other);	/* SECONDS_OF_ONE_DAY */
+		    itmp = db_get_bigint (other);	/* SECONDS_OF_ONE_DAY */
 		    break;
 		  default:
 		    return 0;
@@ -15937,19 +15937,19 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		if (DB_VALUE_TYPE (arg1) == DB_TYPE_UTIME || DB_VALUE_TYPE (arg1) == DB_TYPE_TIMESTAMPLTZ)
 		  {
-		    utime = DB_GET_UTIME (arg1);
+		    utime = db_get_utime (arg1);
 		    other = arg2;
 		  }
 		else
 		  {
-		    utime = DB_GET_UTIME (arg2);
+		    utime = db_get_utime (arg2);
 		    other = arg1;
 		  }
 
 		if (*utime == 0)
 		  {
 		    /* operation with zero date returns null */
-		    DB_MAKE_NULL (result);
+		    db_make_null (result);
 		    if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 		      {
 			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ATTEMPT_TO_USE_ZERODATE, 0);
@@ -15961,13 +15961,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		switch (DB_VALUE_TYPE (other))
 		  {
 		  case DB_TYPE_INTEGER:
-		    bi = DB_GET_INTEGER (other);
+		    bi = db_get_int (other);
 		    break;
 		  case DB_TYPE_SMALLINT:
-		    bi = DB_GET_SHORT (other);
+		    bi = db_get_short (other);
 		    break;
 		  case DB_TYPE_BIGINT:
-		    bi = DB_GET_BIGINT (other);
+		    bi = db_get_bigint (other);
 		    break;
 		  default:
 		    return 0;
@@ -16022,12 +16022,12 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		if (DB_VALUE_TYPE (arg1) == DB_TYPE_TIMESTAMPTZ)
 		  {
-		    ts_tz_p = DB_GET_TIMESTAMPTZ (arg1);
+		    ts_tz_p = db_get_timestamptz (arg1);
 		    other = arg2;
 		  }
 		else
 		  {
-		    ts_tz_p = DB_GET_TIMESTAMPTZ (arg2);
+		    ts_tz_p = db_get_timestamptz (arg2);
 		    other = arg1;
 		  }
 
@@ -16036,7 +16036,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		if (utime == 0)
 		  {
 		    /* operation with zero date returns null */
-		    DB_MAKE_NULL (result);
+		    db_make_null (result);
 		    if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 		      {
 			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ATTEMPT_TO_USE_ZERODATE, 0);
@@ -16048,13 +16048,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		switch (DB_VALUE_TYPE (other))
 		  {
 		  case DB_TYPE_INTEGER:
-		    bi = DB_GET_INTEGER (other);
+		    bi = db_get_int (other);
 		    break;
 		  case DB_TYPE_SMALLINT:
-		    bi = DB_GET_SHORT (other);
+		    bi = db_get_short (other);
 		    break;
 		  case DB_TYPE_BIGINT:
-		    bi = DB_GET_BIGINT (other);
+		    bi = db_get_bigint (other);
 		    break;
 		  default:
 		    return 0;
@@ -16110,19 +16110,19 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		if (DB_VALUE_TYPE (arg1) == DB_TYPE_DATETIME || DB_VALUE_TYPE (arg1) == DB_TYPE_DATETIMELTZ)
 		  {
-		    datetime = DB_GET_DATETIME (arg1);
+		    datetime = db_get_datetime (arg1);
 		    other = arg2;
 		  }
 		else
 		  {
-		    datetime = DB_GET_DATETIME (arg2);
+		    datetime = db_get_datetime (arg2);
 		    other = arg1;
 		  }
 
 		if (datetime->date == 0 && datetime->time == 0)
 		  {
 		    /* operation with zero date returns null */
-		    DB_MAKE_NULL (result);
+		    db_make_null (result);
 		    if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 		      {
 			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ATTEMPT_TO_USE_ZERODATE, 0);
@@ -16134,13 +16134,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		switch (DB_VALUE_TYPE (other))
 		  {
 		  case DB_TYPE_SMALLINT:
-		    bi2 = (DB_BIGINT) DB_GET_SHORT (other);
+		    bi2 = (DB_BIGINT) db_get_short (other);
 		    break;
 		  case DB_TYPE_INTEGER:
-		    bi2 = (DB_BIGINT) DB_GET_INTEGER (other);
+		    bi2 = (DB_BIGINT) db_get_int (other);
 		    break;
 		  default:
-		    bi2 = (DB_BIGINT) DB_GET_BIGINT (other);
+		    bi2 = (DB_BIGINT) db_get_bigint (other);
 		    break;
 		  }
 
@@ -16195,12 +16195,12 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		if (DB_VALUE_TYPE (arg1) == DB_TYPE_DATETIMETZ)
 		  {
-		    dt_tz_p = DB_GET_DATETIMETZ (arg1);
+		    dt_tz_p = db_get_datetimetz (arg1);
 		    other = arg2;
 		  }
 		else
 		  {
-		    dt_tz_p = DB_GET_DATETIMETZ (arg2);
+		    dt_tz_p = db_get_datetimetz (arg2);
 		    other = arg1;
 		  }
 
@@ -16209,7 +16209,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		if (datetime.date == 0 && datetime.time == 0)
 		  {
 		    /* operation with zero date returns null */
-		    DB_MAKE_NULL (result);
+		    db_make_null (result);
 		    if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 		      {
 			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ATTEMPT_TO_USE_ZERODATE, 0);
@@ -16221,13 +16221,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		switch (DB_VALUE_TYPE (other))
 		  {
 		  case DB_TYPE_SMALLINT:
-		    bi2 = (DB_BIGINT) DB_GET_SHORT (other);
+		    bi2 = (DB_BIGINT) db_get_short (other);
 		    break;
 		  case DB_TYPE_INTEGER:
-		    bi2 = (DB_BIGINT) DB_GET_INTEGER (other);
+		    bi2 = (DB_BIGINT) db_get_int (other);
 		    break;
 		  default:
-		    bi2 = (DB_BIGINT) DB_GET_BIGINT (other);
+		    bi2 = (DB_BIGINT) db_get_bigint (other);
 		    break;
 		  }
 
@@ -16280,19 +16280,19 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		if (DB_VALUE_TYPE (arg1) == DB_TYPE_DATE)
 		  {
-		    date = DB_GET_DATE (arg1);
+		    date = db_get_date (arg1);
 		    other = arg2;
 		  }
 		else
 		  {
-		    date = DB_GET_DATE (arg2);
+		    date = db_get_date (arg2);
 		    other = arg1;
 		  }
 
 		if (*date == 0)
 		  {
 		    /* operation with zero date returns null */
-		    DB_MAKE_NULL (result);
+		    db_make_null (result);
 		    if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 		      {
 			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ATTEMPT_TO_USE_ZERODATE, 0);
@@ -16304,13 +16304,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		switch (DB_VALUE_TYPE (other))
 		  {
 		  case DB_TYPE_INTEGER:
-		    bi = DB_GET_INTEGER (other);
+		    bi = db_get_int (other);
 		    break;
 		  case DB_TYPE_SMALLINT:
-		    bi = DB_GET_SHORT (other);
+		    bi = db_get_short (other);
 		    break;
 		  case DB_TYPE_BIGINT:
-		    bi = DB_GET_BIGINT (other);
+		    bi = db_get_bigint (other);
 		    break;
 		  default:
 		    return 0;
@@ -16364,8 +16364,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		int i1, i2, itmp;
 
-		i1 = DB_GET_INT (arg1);
-		i2 = DB_GET_INT (arg2);
+		i1 = db_get_int (arg1);
+		i2 = db_get_int (arg2);
 		itmp = i1 - i2;
 		if (OR_CHECK_SUB_UNDERFLOW (i1, i2, itmp))
 		  goto overflow;
@@ -16383,7 +16383,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		  {
 		    assert (false);
 
-		    DB_MAKE_NULL (result);
+		    db_make_null (result);
 		    break;
 		  }
 
@@ -16391,8 +16391,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		  {
 		    DB_DATETIME *dt1, *dt2;
 
-		    dt1 = DB_GET_DATETIME (arg1);
-		    dt2 = DB_GET_DATETIME (arg2);
+		    dt1 = db_get_datetime (arg1);
+		    dt2 = db_get_datetime (arg2);
 
 		    bi1 = (((DB_BIGINT) dt1->date) * MILLISECONDS_OF_ONE_DAY + dt1->time);
 		    bi2 = (((DB_BIGINT) dt2->date) * MILLISECONDS_OF_ONE_DAY + dt2->time);
@@ -16401,8 +16401,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		  {
 		    DB_DATETIMETZ *dt_tz1, *dt_tz2;
 
-		    dt_tz1 = DB_GET_DATETIMETZ (arg1);
-		    dt_tz2 = DB_GET_DATETIMETZ (arg2);
+		    dt_tz1 = db_get_datetimetz (arg1);
+		    dt_tz2 = db_get_datetimetz (arg2);
 
 		    bi1 = (((DB_BIGINT) dt_tz1->datetime.date) * MILLISECONDS_OF_ONE_DAY + dt_tz1->datetime.time);
 		    bi2 = (((DB_BIGINT) dt_tz2->datetime.date) * MILLISECONDS_OF_ONE_DAY + dt_tz2->datetime.time);
@@ -16411,8 +16411,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		  {
 		    DB_DATE *d1, *d2;
 
-		    d1 = DB_GET_DATE (arg1);
-		    d2 = DB_GET_DATE (arg2);
+		    d1 = db_get_date (arg1);
+		    d2 = db_get_date (arg2);
 
 		    bi1 = (DB_BIGINT) (*d1);
 		    bi2 = (DB_BIGINT) (*d2);
@@ -16421,8 +16421,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		  {
 		    DB_TIME *t1, *t2;
 
-		    t1 = DB_GET_TIME (arg1);
-		    t2 = DB_GET_TIME (arg2);
+		    t1 = db_get_time (arg1);
+		    t2 = db_get_time (arg2);
 
 		    if (typ1 == DB_TYPE_TIMELTZ)
 		      {
@@ -16467,8 +16467,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		    DB_TIMETZ *t_tz1, *t_tz2;
 		    int day1, day2;
 
-		    t_tz1 = DB_GET_TIMETZ (arg1);
-		    t_tz2 = DB_GET_TIMETZ (arg2);
+		    t_tz1 = db_get_timetz (arg1);
+		    t_tz2 = db_get_timetz (arg2);
 
 		    day1 = get_day_from_timetz (t_tz1);
 		    day2 = get_day_from_timetz (t_tz2);
@@ -16480,8 +16480,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		  {
 		    DB_TIMESTAMP *ts1, *ts2;
 
-		    ts1 = DB_GET_TIMESTAMP (arg1);
-		    ts2 = DB_GET_TIMESTAMP (arg2);
+		    ts1 = db_get_timestamp (arg1);
+		    ts2 = db_get_timestamp (arg2);
 
 		    bi1 = (DB_BIGINT) (*ts1);
 		    bi2 = (DB_BIGINT) (*ts2);
@@ -16490,29 +16490,29 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		  {
 		    DB_TIMESTAMPTZ *ts_tz1, *ts_tz2;
 
-		    ts_tz1 = DB_GET_TIMESTAMPTZ (arg1);
-		    ts_tz2 = DB_GET_TIMESTAMPTZ (arg2);
+		    ts_tz1 = db_get_timestamptz (arg1);
+		    ts_tz2 = db_get_timestamptz (arg2);
 
 		    bi1 = (DB_BIGINT) (ts_tz1->timestamp);
 		    bi2 = (DB_BIGINT) (ts_tz2->timestamp);
 		  }
 		else if (typ1 == DB_TYPE_BIGINT)
 		  {
-		    bi1 = DB_GET_BIGINT (arg1);
-		    bi2 = DB_GET_BIGINT (arg2);
+		    bi1 = db_get_bigint (arg1);
+		    bi2 = db_get_bigint (arg2);
 		  }
 		else
 		  {
 		    assert (false);
 
-		    DB_MAKE_NULL (result);
+		    db_make_null (result);
 		    break;
 		  }
 
 		if ((TP_IS_DATE_TYPE (typ1) && bi1 == 0) || (TP_IS_DATE_TYPE (typ2) && bi2 == 0))
 		  {
 		    /* operation with zero date returns null */
-		    DB_MAKE_NULL (result);
+		    db_make_null (result);
 		    if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 		      {
 			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ATTEMPT_TO_USE_ZERODATE, 0);
@@ -16537,8 +16537,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		short s1, s2, stmp;
 
-		s1 = DB_GET_SHORT (arg1);
-		s2 = DB_GET_SHORT (arg2);
+		s1 = db_get_short (arg1);
+		s2 = db_get_short (arg2);
 		stmp = s1 - s2;
 		if (OR_CHECK_SUB_UNDERFLOW (s1, s2, stmp))
 		  goto overflow;
@@ -16551,7 +16551,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		float ftmp;
 
-		ftmp = DB_GET_FLOAT (arg1) - DB_GET_FLOAT (arg2);
+		ftmp = db_get_float (arg1) - db_get_float (arg2);
 		if (OR_CHECK_FLOAT_OVERFLOW (ftmp))
 		  goto overflow;
 		else
@@ -16563,7 +16563,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		double dtmp;
 
-		dtmp = DB_GET_DOUBLE (arg1) - DB_GET_DOUBLE (arg2);
+		dtmp = db_get_double (arg1) - db_get_double (arg2);
 		if (OR_CHECK_DOUBLE_OVERFLOW (dtmp))
 		  goto overflow;
 		else
@@ -16589,11 +16589,11 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		double dtmp;
 
-		dtmp = DB_GET_MONETARY (arg1)->amount - DB_GET_MONETARY (arg2)->amount;
+		dtmp = db_get_monetary (arg1)->amount - db_get_monetary (arg2)->amount;
 		if (OR_CHECK_DOUBLE_OVERFLOW (dtmp))
 		  goto overflow;
 		else
-		  DB_MAKE_MONETARY (result, dtmp);
+		  db_make_monetary (result, DB_CURRENCY_DEFAULT, dtmp);
 		break;
 	      }
 
@@ -16609,13 +16609,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		switch (DB_VALUE_TYPE (arg2))
 		  {
 		  case DB_TYPE_SHORT:
-		    bi = DB_GET_SHORT (arg2);
+		    bi = db_get_short (arg2);
 		    break;
 		  case DB_TYPE_INTEGER:
-		    bi = DB_GET_INT (arg2);
+		    bi = db_get_int (arg2);
 		    break;
 		  case DB_TYPE_BIGINT:
-		    bi = DB_GET_BIGINT (arg2);
+		    bi = db_get_bigint (arg2);
 		    break;
 		  default:
 		    assert (false);
@@ -16627,12 +16627,12 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		if (typ == DB_TYPE_TIMETZ)
 		  {
-		    time_tz = *DB_GET_TIMETZ (arg1);
+		    time_tz = *db_get_timetz (arg1);
 		    time = time_tz.time;
 		  }
 		else
 		  {
-		    time = *DB_GET_TIME (arg1);
+		    time = *db_get_time (arg1);
 		  }
 
 		if (time < (DB_TIME) (ubi % 86400))
@@ -16676,13 +16676,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		switch (DB_VALUE_TYPE (arg2))
 		  {
 		  case DB_TYPE_SHORT:
-		    bi = DB_GET_SHORT (arg2);
+		    bi = db_get_short (arg2);
 		    break;
 		  case DB_TYPE_INTEGER:
-		    bi = DB_GET_INT (arg2);
+		    bi = db_get_int (arg2);
 		    break;
 		  case DB_TYPE_BIGINT:
-		    bi = DB_GET_BIGINT (arg2);
+		    bi = db_get_bigint (arg2);
 		    break;
 		  default:
 		    assert (false);
@@ -16692,18 +16692,18 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		assert (typ == DB_VALUE_TYPE (arg1));
 		if (typ == DB_TYPE_TIMESTAMPTZ)
 		  {
-		    ts_tz = *DB_GET_TIMESTAMPTZ (arg1);
+		    ts_tz = *db_get_timestamptz (arg1);
 		    utime = ts_tz.timestamp;
 		  }
 		else
 		  {
-		    utime = *DB_GET_UTIME (arg1);
+		    utime = *db_get_utime (arg1);
 		  }
 
 		if (utime == 0)
 		  {
 		    /* operation with zero date returns null */
-		    DB_MAKE_NULL (result);
+		    db_make_null (result);
 		    if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 		      {
 			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ATTEMPT_TO_USE_ZERODATE, 0);
@@ -16761,13 +16761,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		switch (DB_VALUE_TYPE (arg2))
 		  {
 		  case DB_TYPE_SHORT:
-		    bi = DB_GET_SHORT (arg2);
+		    bi = db_get_short (arg2);
 		    break;
 		  case DB_TYPE_INTEGER:
-		    bi = DB_GET_INT (arg2);
+		    bi = db_get_int (arg2);
 		    break;
 		  case DB_TYPE_BIGINT:
-		    bi = DB_GET_BIGINT (arg2);
+		    bi = db_get_bigint (arg2);
 		    break;
 		  default:
 		    assert (false);
@@ -16776,18 +16776,18 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 		if (typ == DB_TYPE_DATETIMETZ)
 		  {
-		    dt_tz = *DB_GET_DATETIMETZ (arg1);
+		    dt_tz = *db_get_datetimetz (arg1);
 		    datetime = dt_tz.datetime;
 		  }
 		else
 		  {
-		    datetime = *DB_GET_DATETIME (arg1);
+		    datetime = *db_get_datetime (arg1);
 		  }
 
 		if (datetime.date == 0 && datetime.time == 0)
 		  {
 		    /* operation with zero date returns null */
-		    DB_MAKE_NULL (result);
+		    db_make_null (result);
 		    if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 		      {
 			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ATTEMPT_TO_USE_ZERODATE, 0);
@@ -16832,24 +16832,24 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		switch (DB_VALUE_TYPE (arg2))
 		  {
 		  case DB_TYPE_SHORT:
-		    bi = DB_GET_SHORT (arg2);
+		    bi = db_get_short (arg2);
 		    break;
 		  case DB_TYPE_INTEGER:
-		    bi = DB_GET_INT (arg2);
+		    bi = db_get_int (arg2);
 		    break;
 		  case DB_TYPE_BIGINT:
-		    bi = DB_GET_BIGINT (arg2);
+		    bi = db_get_bigint (arg2);
 		    break;
 		  default:
 		    assert (false);
 		    break;
 		  }
-		date = DB_GET_DATE (arg1);
+		date = db_get_date (arg1);
 
 		if (*date == 0)
 		  {
 		    /* operation with zero date returns null */
-		    DB_MAKE_NULL (result);
+		    db_make_null (result);
 		    if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 		      {
 			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ATTEMPT_TO_USE_ZERODATE, 0);
@@ -16905,8 +16905,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		 */
 		volatile int i1, i2, itmp;
 
-		i1 = DB_GET_INT (arg1);
-		i2 = DB_GET_INT (arg2);
+		i1 = db_get_int (arg1);
+		i2 = db_get_int (arg2);
 		itmp = i1 * i2;
 		if (OR_CHECK_MULT_OVERFLOW (i1, i2, itmp))
 		  {
@@ -16926,8 +16926,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		 */
 		volatile DB_BIGINT bi1, bi2, bitmp;
 
-		bi1 = DB_GET_BIGINT (arg1);
-		bi2 = DB_GET_BIGINT (arg2);
+		bi1 = db_get_bigint (arg1);
+		bi2 = db_get_bigint (arg2);
 		bitmp = bi1 * bi2;
 		if (OR_CHECK_MULT_OVERFLOW (bi1, bi2, bitmp))
 		  {
@@ -16947,8 +16947,8 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		 */
 		volatile short s1, s2, stmp;
 
-		s1 = DB_GET_SHORT (arg1);
-		s2 = DB_GET_SHORT (arg2);
+		s1 = db_get_short (arg1);
+		s2 = db_get_short (arg2);
 		stmp = s1 * s2;
 		if (OR_CHECK_MULT_OVERFLOW (s1, s2, stmp))
 		  {
@@ -16965,7 +16965,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		float ftmp;
 
-		ftmp = DB_GET_FLOAT (arg1) * DB_GET_FLOAT (arg2);
+		ftmp = db_get_float (arg1) * db_get_float (arg2);
 		if (OR_CHECK_FLOAT_OVERFLOW (ftmp))
 		  {
 		    goto overflow;
@@ -16981,7 +16981,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		double dtmp;
 
-		dtmp = DB_GET_DOUBLE (arg1) * DB_GET_DOUBLE (arg2);
+		dtmp = db_get_double (arg1) * db_get_double (arg2);
 		if (OR_CHECK_DOUBLE_OVERFLOW (dtmp))
 		  {
 		    goto overflow;
@@ -17016,14 +17016,14 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 		double dtmp;
 
-		dtmp = DB_GET_MONETARY (arg1)->amount * DB_GET_MONETARY (arg2)->amount;
+		dtmp = db_get_monetary (arg1)->amount * db_get_monetary (arg2)->amount;
 		if (OR_CHECK_DOUBLE_OVERFLOW (dtmp))
 		  {
 		    goto overflow;
 		  }
 		else
 		  {
-		    DB_MAKE_MONETARY (result, dtmp);
+		    db_make_monetary (result, DB_CURRENCY_DEFAULT, dtmp);
 		  }
 		break;
 	      }
@@ -17038,33 +17038,33 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	  switch (typ)
 	    {
 	    case DB_TYPE_SHORT:
-	      if (DB_GET_SHORT (arg2) != 0)
+	      if (db_get_short (arg2) != 0)
 		{
-		  db_make_short (result, DB_GET_SHORT (arg1) / DB_GET_SHORT (arg2));
+		  db_make_short (result, db_get_short (arg1) / db_get_short (arg2));
 		  return 1;
 		}
 	      break;
 
 	    case DB_TYPE_INTEGER:
-	      if (DB_GET_INTEGER (arg2) != 0)
+	      if (db_get_int (arg2) != 0)
 		{
-		  db_make_int (result, (DB_GET_INTEGER (arg1) / DB_GET_INTEGER (arg2)));
+		  db_make_int (result, (db_get_int (arg1) / db_get_int (arg2)));
 		  return 1;
 		}
 	      break;
 	    case DB_TYPE_BIGINT:
-	      if (DB_GET_BIGINT (arg2) != 0)
+	      if (db_get_bigint (arg2) != 0)
 		{
-		  db_make_bigint (result, (DB_GET_BIGINT (arg1) / DB_GET_BIGINT (arg2)));
+		  db_make_bigint (result, (db_get_bigint (arg1) / db_get_bigint (arg2)));
 		  return 1;
 		}
 	      break;
 	    case DB_TYPE_FLOAT:
-	      if (fabs (DB_GET_FLOAT (arg2)) > FLT_EPSILON)
+	      if (fabs (db_get_float (arg2)) > FLT_EPSILON)
 		{
 		  float ftmp;
 
-		  ftmp = DB_GET_FLOAT (arg1) / DB_GET_FLOAT (arg2);
+		  ftmp = db_get_float (arg1) / db_get_float (arg2);
 		  if (OR_CHECK_FLOAT_OVERFLOW (ftmp))
 		    {
 		      goto overflow;
@@ -17078,11 +17078,11 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      break;
 
 	    case DB_TYPE_DOUBLE:
-	      if (fabs (DB_GET_DOUBLE (arg2)) > DBL_EPSILON)
+	      if (fabs (db_get_double (arg2)) > DBL_EPSILON)
 		{
 		  double dtmp;
 
-		  dtmp = DB_GET_DOUBLE (arg1) / DB_GET_DOUBLE (arg2);
+		  dtmp = db_get_double (arg1) / db_get_double (arg2);
 		  if (OR_CHECK_DOUBLE_OVERFLOW (dtmp))
 		    {
 		      goto overflow;
@@ -17121,18 +17121,18 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      break;
 
 	    case DB_TYPE_MONETARY:
-	      if (fabs (DB_GET_MONETARY (arg2)->amount) > DBL_EPSILON)
+	      if (fabs (db_get_monetary (arg2)->amount) > DBL_EPSILON)
 		{
 		  double dtmp;
 
-		  dtmp = DB_GET_MONETARY (arg1)->amount / DB_GET_MONETARY (arg2)->amount;
+		  dtmp = db_get_monetary (arg1)->amount / db_get_monetary (arg2)->amount;
 		  if (OR_CHECK_DOUBLE_OVERFLOW (dtmp))
 		    {
 		      goto overflow;
 		    }
 		  else
 		    {
-		      DB_MAKE_MONETARY (result, dtmp);
+		      db_make_monetary (result, DB_CURRENCY_DEFAULT, dtmp);
 		      return 1;	/* success */
 		    }
 		}
@@ -17212,7 +17212,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	}
       else
 	{
-	  srand48 (DB_GET_INT (arg1));
+	  srand48 (db_get_int (arg1));
 	  db_make_int (result, lrand48 ());
 	}
       break;
@@ -17224,7 +17224,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	}
       else
 	{
-	  srand48 (DB_GET_INT (arg1));
+	  srand48 (db_get_int (arg1));
 	  db_make_double (result, drand48 ());
 	}
       break;
@@ -17241,7 +17241,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	}
       else
 	{
-	  srand48 (DB_GET_INT (arg1));
+	  srand48 (db_get_int (arg1));
 	}
       db_make_int (result, lrand48 ());
       break;
@@ -17255,7 +17255,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	}
       else
 	{
-	  srand48 (DB_GET_INT (arg1));
+	  srand48 (db_get_int (arg1));
 	}
       db_make_double (result, drand48 ());
       break;
@@ -17621,7 +17621,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
     case PT_SUBSTRING:
       if (DB_IS_NULL (arg1) || DB_IS_NULL (arg2) || (o3 && DB_IS_NULL (arg3)))
 	{
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	  return 1;
 	}
 
@@ -17737,7 +17737,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
       if (PT_IS_CHAR_STRING_TYPE (o1->type_enum))
 	{
-	  db_make_int (result, 8 * DB_GET_STRING_SIZE (arg1));
+	  db_make_int (result, 8 * db_get_string_size (arg1));
 	}
       else
 	{
@@ -17759,7 +17759,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	{
 	  return 0;
 	}
-      db_make_int (result, DB_GET_STRING_LENGTH (arg1));
+      db_make_int (result, db_get_string_length (arg1));
       return 1;
 
     case PT_LOWER:
@@ -18485,7 +18485,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	timestamp = db_get_timestamp (&parser->sys_epochtime);
 	tz_timestamp_decode_no_leap_sec (*timestamp, &year, &month, &day, &hour, &minute, &second);
 	date = julian_encode (month + 1, day, year);
-	DB_MAKE_ENCODED_DATE (result, &date);
+	db_value_put_encoded_date (result, &date);
 	return 1;
       }
 
@@ -18518,7 +18518,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 	tmp_datetime = db_get_timestamp (&parser->sys_epochtime);
 	db_time = (DB_TIME) (*tmp_datetime % SECONDS_OF_ONE_DAY);
-	DB_MAKE_ENCODED_TIME (result, &db_time);
+	db_value_put_encoded_time (result, &db_time);
 	return 1;
       }
 
@@ -18933,7 +18933,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
     case PT_DECODE:
       /* If arg3 = NULL, then arg2 = NULL and arg1 != NULL.  For this case, we've already finished checking
        * case_search_condition. */
-      if (arg3 && (DB_VALUE_TYPE (arg3) == DB_TYPE_INTEGER && DB_GET_INT (arg3) != 0))
+      if (arg3 && (DB_VALUE_TYPE (arg3) == DB_TYPE_INTEGER && db_get_int (arg3) != 0))
 	{
 	  if (tp_value_coerce (arg1, result, domain) != DOMAIN_COMPATIBLE)
 	    {
@@ -19201,19 +19201,19 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 	    if (prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) == false && DB_IS_NULL (esc_char))
 	      {
-		INTL_CODESET arg1_cs = DB_IS_NULL (arg1) ? LANG_SYS_CODESET : DB_GET_STRING_CODESET (arg1);
-		int arg1_coll = DB_IS_NULL (arg1) ? LANG_SYS_COLLATION : DB_GET_STRING_COLLATION (arg1);
+		INTL_CODESET arg1_cs = DB_IS_NULL (arg1) ? LANG_SYS_CODESET : db_get_string_codeset (arg1);
+		int arg1_coll = DB_IS_NULL (arg1) ? LANG_SYS_COLLATION : db_get_string_collation (arg1);
 		/* when compat_mode=mysql, the slash '\\' is an escape character for LIKE pattern, unless user
 		 * explicitly specifies otherwise. */
 		esc_char = &slash_char;
 		if (arg1->domain.general_info.type == DB_TYPE_NCHAR
 		    || arg1->domain.general_info.type == DB_TYPE_VARNCHAR)
 		  {
-		    DB_MAKE_NCHAR (esc_char, 1, (const DB_C_NCHAR) slash_str, 1, arg1_cs, arg1_coll);
+		    db_make_nchar (esc_char, 1, (const DB_C_NCHAR) slash_str, 1, arg1_cs, arg1_coll);
 		  }
 		else
 		  {
-		    DB_MAKE_CHAR (esc_char, 1, (const DB_C_CHAR) slash_str, 1, arg1_cs, arg1_coll);
+		    db_make_char (esc_char, 1, (const DB_C_CHAR) slash_str, 1, arg1_cs, arg1_coll);
 		  }
 
 		esc_char->need_clear = false;
@@ -19366,7 +19366,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	  }
 	else
 	  {
-	    if (DB_GET_ENUM_SHORT (result) == DB_ENUM_OVERFLOW_VAL)
+	    if (db_get_enum_short (result) == DB_ENUM_OVERFLOW_VAL)
 	      {
 		/* To avoid coercing result to enumeration type later on, we consider that this expression cannot be
 		 * folded */
@@ -19499,7 +19499,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 	tmp_datetime = db_get_datetime (&parser->sys_datetime);
 	db_sys_timezone (&timezone);
-	timezone_milis = DB_GET_INT (&timezone) * 60000;
+	timezone_milis = db_get_int (&timezone) * 60000;
 	db_add_int_to_datetime (tmp_datetime, timezone_milis, &utc_datetime);
 
 	if (DB_IS_NULL (arg1))
@@ -19581,7 +19581,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	date = julian_encode (month + 1, day, year);
 	db_time_encode (&time, hour, minute, second);
 	db_timestamp_encode_ses (&date, &time, &timestamp, NULL);
-	DB_MAKE_TIMESTAMP (result, timestamp);
+	db_make_timestamp (result, timestamp);
 	return 1;
       }
 
@@ -19789,7 +19789,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	  db_get_row_count (&row_count);
 	  db_update_row_count_cache (row_count);
 	}
-      DB_MAKE_INT (&dbval_res, row_count);
+      db_make_int (&dbval_res, row_count);
       result = pt_dbval_to_value (parser, &dbval_res);
       goto end;
     }
@@ -19802,11 +19802,11 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	  if (coll_infer.coerc_level >= PT_COLLATION_L2_COERC && coll_infer.coerc_level <= PT_COLLATION_L2_BIN_COERC
 	      && coll_infer.can_force_cs == true)
 	    {
-	      DB_MAKE_INT (&dbval_res, -1);
+	      db_make_int (&dbval_res, -1);
 	    }
 	  else
 	    {
-	      DB_MAKE_INT (&dbval_res, (int) (coll_infer.coerc_level));
+	      db_make_int (&dbval_res, (int) (coll_infer.coerc_level));
 	    }
 	}
       else
@@ -19814,7 +19814,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	  if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	    {
 	      er_clear ();
-	      DB_MAKE_NULL (&dbval_res);
+	      db_make_null (&dbval_res);
 	    }
 	  else
 	    {
@@ -19939,7 +19939,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
        * () and qo_optimize_queries () */
       tmp_value->type_enum = PT_TYPE_OBJECT;
       OID_SET_NULL (&null_oid);
-      DB_MAKE_OID (&tmp_value->info.value.db_value, &null_oid);
+      db_make_oid (&tmp_value->info.value.db_value, &null_oid);
       tmp_value->info.value.db_value_is_initialized = true;
       tmp_value->data_type = parser_copy_tree (parser, expr->data_type);
       if (tmp_value->data_type == NULL)
@@ -20219,7 +20219,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
    * a possible call of pt_evaluate_db_val_expr. */
   if ((op == PT_CASE || op == PT_DECODE) && opd3 && opd3->node_type == PT_VALUE)
     {
-      if (arg3 && (DB_VALUE_TYPE (arg3) == DB_TYPE_INTEGER && DB_GET_INT (arg3)))
+      if (arg3 && (DB_VALUE_TYPE (arg3) == DB_TYPE_INTEGER && db_get_int (arg3)))
 	{
 	  opd2 = NULL;
 	}
@@ -20341,7 +20341,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	    {
 	      result = val;
 	    }
-	  else if (db_value && DB_GET_INTEGER (db_value) == 1)
+	  else if (db_value && db_get_int (db_value) == 1)
 	    {
 	      result = other;
 	    }
@@ -20356,7 +20356,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	    {
 	      result = other;
 	    }
-	  else if (db_value && DB_GET_INTEGER (db_value) == 1)
+	  else if (db_value && db_get_int (db_value) == 1)
 	    {
 	      result = val;
 	    }
@@ -20446,7 +20446,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 		{
 		  result = other;
 		}
-	      else if (db_value && DB_VALUE_TYPE (db_value) == DB_TYPE_INTEGER && DB_GET_INTEGER (db_value) == 1)
+	      else if (db_value && DB_VALUE_TYPE (db_value) == DB_TYPE_INTEGER && db_get_int (db_value) == 1)
 		{
 		  parser_free_tree (parser, result->or_next);
 		  result->or_next = NULL;
@@ -20486,7 +20486,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	    {
 	      result = other;
 	    }
-	  else if (db_value && DB_VALUE_TYPE (db_value) == DB_TYPE_INTEGER && DB_GET_INTEGER (db_value) == 1)
+	  else if (db_value && DB_VALUE_TYPE (db_value) == DB_TYPE_INTEGER && db_get_int (db_value) == 1)
 	    {
 	      parser_free_tree (parser, result->or_next);
 	      result->or_next = NULL;
@@ -20529,7 +20529,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	  if ((op == PT_GT && rvalue <= 0) || (op == PT_GE && rvalue <= 1))
 	    {
 	      /* always true */
-	      DB_MAKE_INTEGER (&dbval_res, 1);
+	      db_make_int (&dbval_res, 1);
 	      result = pt_dbval_to_value (parser, &dbval_res);
 	    }
 	}
@@ -21594,28 +21594,28 @@ pt_compare_bounds_to_value (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE 
       switch (rhs_type)
 	{
 	case PT_TYPE_INTEGER:
-	  if (DB_GET_INTEGER (rhs_val) > DB_INT16_MAX)
+	  if (db_get_int (rhs_val) > DB_INT16_MAX)
 	    lhs_less = true;
-	  else if (DB_GET_INTEGER (rhs_val) < DB_INT16_MIN)
+	  else if (db_get_int (rhs_val) < DB_INT16_MIN)
 	    lhs_greater = true;
 	  break;
 	case PT_TYPE_BIGINT:
-	  if (DB_GET_BIGINT (rhs_val) > DB_INT16_MAX)
+	  if (db_get_bigint (rhs_val) > DB_INT16_MAX)
 	    lhs_less = true;
-	  else if (DB_GET_BIGINT (rhs_val) < DB_INT16_MIN)
+	  else if (db_get_bigint (rhs_val) < DB_INT16_MIN)
 	    lhs_greater = true;
 	  break;
 	case PT_TYPE_FLOAT:
-	  if (DB_GET_FLOAT (rhs_val) > DB_INT16_MAX)
+	  if (db_get_float (rhs_val) > DB_INT16_MAX)
 	    lhs_less = true;
-	  else if (DB_GET_FLOAT (rhs_val) < DB_INT16_MIN)
+	  else if (db_get_float (rhs_val) < DB_INT16_MIN)
 	    lhs_greater = true;
 	  break;
 
 	case PT_TYPE_DOUBLE:
-	  if (DB_GET_DOUBLE (rhs_val) > DB_INT16_MAX)
+	  if (db_get_double (rhs_val) > DB_INT16_MAX)
 	    lhs_less = true;
-	  else if (DB_GET_DOUBLE (rhs_val) < DB_INT16_MIN)
+	  else if (db_get_double (rhs_val) < DB_INT16_MIN)
 	    lhs_greater = true;
 	  break;
 
@@ -21628,7 +21628,7 @@ pt_compare_bounds_to_value (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE 
 	  break;
 
 	case PT_TYPE_MONETARY:
-	  dtmp = (DB_GET_MONETARY (rhs_val))->amount;
+	  dtmp = (db_get_monetary (rhs_val))->amount;
 	  if (dtmp > DB_INT16_MAX)
 	    lhs_less = true;
 	  else if (dtmp < DB_INT16_MIN)
@@ -21644,22 +21644,22 @@ pt_compare_bounds_to_value (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE 
       switch (rhs_type)
 	{
 	case PT_TYPE_BIGINT:
-	  if (DB_GET_BIGINT (rhs_val) > DB_INT32_MAX)
+	  if (db_get_bigint (rhs_val) > DB_INT32_MAX)
 	    lhs_less = true;
-	  else if (DB_GET_BIGINT (rhs_val) < DB_INT32_MIN)
+	  else if (db_get_bigint (rhs_val) < DB_INT32_MIN)
 	    lhs_greater = true;
 	  break;
 	case PT_TYPE_FLOAT:
-	  if (DB_GET_FLOAT (rhs_val) > DB_INT32_MAX)
+	  if (db_get_float (rhs_val) > DB_INT32_MAX)
 	    lhs_less = true;
-	  else if (DB_GET_FLOAT (rhs_val) < DB_INT32_MIN)
+	  else if (db_get_float (rhs_val) < DB_INT32_MIN)
 	    lhs_greater = true;
 	  break;
 
 	case PT_TYPE_DOUBLE:
-	  if (DB_GET_DOUBLE (rhs_val) > DB_INT32_MAX)
+	  if (db_get_double (rhs_val) > DB_INT32_MAX)
 	    lhs_less = true;
-	  else if (DB_GET_DOUBLE (rhs_val) < DB_INT32_MIN)
+	  else if (db_get_double (rhs_val) < DB_INT32_MIN)
 	    lhs_greater = true;
 	  break;
 
@@ -21672,7 +21672,7 @@ pt_compare_bounds_to_value (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE 
 	  break;
 
 	case PT_TYPE_MONETARY:
-	  dtmp = (DB_GET_MONETARY (rhs_val))->amount;
+	  dtmp = (db_get_monetary (rhs_val))->amount;
 	  if (dtmp > DB_INT32_MAX)
 	    lhs_less = true;
 	  else if (dtmp < DB_INT32_MIN)
@@ -21687,15 +21687,15 @@ pt_compare_bounds_to_value (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE 
       switch (rhs_type)
 	{
 	case PT_TYPE_FLOAT:
-	  if (DB_GET_FLOAT (rhs_val) > DB_BIGINT_MAX)
+	  if (db_get_float (rhs_val) > DB_BIGINT_MAX)
 	    lhs_less = true;
-	  else if (DB_GET_FLOAT (rhs_val) < DB_BIGINT_MIN)
+	  else if (db_get_float (rhs_val) < DB_BIGINT_MIN)
 	    lhs_greater = true;
 	  break;
 	case PT_TYPE_DOUBLE:
-	  if (DB_GET_DOUBLE (rhs_val) > DB_BIGINT_MAX)
+	  if (db_get_double (rhs_val) > DB_BIGINT_MAX)
 	    lhs_less = true;
-	  else if (DB_GET_DOUBLE (rhs_val) < DB_BIGINT_MIN)
+	  else if (db_get_double (rhs_val) < DB_BIGINT_MIN)
 	    lhs_greater = true;
 	  break;
 	case PT_TYPE_NUMERIC:
@@ -21706,7 +21706,7 @@ pt_compare_bounds_to_value (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE 
 	    lhs_greater = true;
 	  break;
 	case PT_TYPE_MONETARY:
-	  dtmp = (DB_GET_MONETARY (rhs_val))->amount;
+	  dtmp = (db_get_monetary (rhs_val))->amount;
 	  if (dtmp > DB_BIGINT_MAX)
 	    lhs_less = true;
 	  else if (dtmp < DB_BIGINT_MIN)
@@ -21721,9 +21721,9 @@ pt_compare_bounds_to_value (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE 
       switch (rhs_type)
 	{
 	case PT_TYPE_DOUBLE:
-	  if (DB_GET_DOUBLE (rhs_val) > FLT_MAX)
+	  if (db_get_double (rhs_val) > FLT_MAX)
 	    lhs_less = true;
-	  else if (DB_GET_DOUBLE (rhs_val) < -(FLT_MAX))
+	  else if (db_get_double (rhs_val) < -(FLT_MAX))
 	    lhs_greater = true;
 	  break;
 
@@ -21736,7 +21736,7 @@ pt_compare_bounds_to_value (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE 
 	  break;
 
 	case PT_TYPE_MONETARY:
-	  dtmp = (DB_GET_MONETARY (rhs_val))->amount;
+	  dtmp = (db_get_monetary (rhs_val))->amount;
 	  if (dtmp > FLT_MAX)
 	    lhs_less = true;
 	  else if (dtmp < -(FLT_MAX))
@@ -22267,7 +22267,7 @@ pt_check_const_fold_op_w_args (PT_OP_TYPE op, DB_VALUE * arg1, DB_VALUE * arg2, 
     case PT_SPACE:
       if (DB_VALUE_DOMAIN_TYPE (arg1) == DB_TYPE_INTEGER)
 	{
-	  int count_i = DB_GET_INTEGER (arg1);
+	  int count_i = db_get_int (arg1);
 	  if (count_i > MAX_RESULT_SIZE_ON_CONST_FOLDING)
 	    {
 	      return false;
@@ -22275,7 +22275,7 @@ pt_check_const_fold_op_w_args (PT_OP_TYPE op, DB_VALUE * arg1, DB_VALUE * arg2, 
 	}
       else if (DB_VALUE_DOMAIN_TYPE (arg1) == DB_TYPE_SHORT)
 	{
-	  short count_sh = DB_GET_SHORT (arg1);
+	  short count_sh = db_get_short (arg1);
 	  if (count_sh > MAX_RESULT_SIZE_ON_CONST_FOLDING)
 	    {
 	      return false;
@@ -22283,7 +22283,7 @@ pt_check_const_fold_op_w_args (PT_OP_TYPE op, DB_VALUE * arg1, DB_VALUE * arg2, 
 	}
       else if (DB_VALUE_DOMAIN_TYPE (arg1) == DB_TYPE_BIGINT)
 	{
-	  DB_BIGINT count_b = DB_GET_BIGINT (arg1);
+	  DB_BIGINT count_b = db_get_bigint (arg1);
 	  if (count_b > MAX_RESULT_SIZE_ON_CONST_FOLDING)
 	    {
 	      return false;
@@ -22294,10 +22294,10 @@ pt_check_const_fold_op_w_args (PT_OP_TYPE op, DB_VALUE * arg1, DB_VALUE * arg2, 
     case PT_REPEAT:
       if (DB_VALUE_DOMAIN_TYPE (arg2) == DB_TYPE_INTEGER)
 	{
-	  int count_i = DB_GET_INTEGER (arg2);
+	  int count_i = db_get_int (arg2);
 	  if (QSTR_IS_ANY_CHAR (DB_VALUE_DOMAIN_TYPE (arg1)))
 	    {
-	      int arg1_len = DB_GET_STRING_SIZE (arg1);
+	      int arg1_len = db_get_string_size (arg1);
 
 	      if (arg1_len * count_i > MAX_RESULT_SIZE_ON_CONST_FOLDING)
 		{
@@ -22312,10 +22312,10 @@ pt_check_const_fold_op_w_args (PT_OP_TYPE op, DB_VALUE * arg1, DB_VALUE * arg2, 
       /* check if constant folding is OK */
       if (DB_VALUE_DOMAIN_TYPE (arg2) == DB_TYPE_INTEGER)
 	{
-	  int count_i = DB_GET_INTEGER (arg2);
+	  int count_i = db_get_int (arg2);
 	  if (arg3 != NULL && QSTR_IS_ANY_CHAR (DB_VALUE_DOMAIN_TYPE (arg3)))
 	    {
-	      int arg3_len = DB_GET_STRING_SIZE (arg3);
+	      int arg3_len = db_get_string_size (arg3);
 
 	      if (arg3_len * count_i > MAX_RESULT_SIZE_ON_CONST_FOLDING)
 		{
@@ -23369,7 +23369,7 @@ pt_coerce_node_collation (PARSER_CONTEXT * parser, PT_NODE * node, const int col
 		    }
 		  else if (node->info.value.db_value_is_initialized)
 		    {
-		      wrap_dt->info.data_type.precision = DB_GET_STRING_SIZE (&(node->info.value.db_value));
+		      wrap_dt->info.data_type.precision = db_get_string_size (&(node->info.value.db_value));
 		    }
 		}
 
@@ -24920,8 +24920,8 @@ pt_fix_enumeration_comparison (PARSER_CONTEXT * parser, PT_NODE * expr)
 	      return NULL;
 	    }
 	  if (dbval != NULL
-	      && ((DB_GET_ENUM_STRING (dbval) == NULL && DB_GET_ENUM_SHORT (dbval) == 0)
-		  || ((DB_GET_ENUM_STRING (dbval) != NULL && DB_GET_ENUM_SHORT (dbval) > 0)
+	      && ((db_get_enum_string (dbval) == NULL && db_get_enum_short (dbval) == 0)
+		  || ((db_get_enum_string (dbval) != NULL && db_get_enum_short (dbval) > 0)
 		      && tp_domain_select (domain, dbval, 0, TP_EXACT_MATCH) != NULL)))
 	    {
 	      return expr;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -4096,12 +4096,12 @@ mq_replace_virtual_oid_with_real_oid (PARSER_CONTEXT * parser, PT_NODE * node, v
 		  PT_ERRORc (parser, node, er_msg ());
 		  return node;
 		}
-	      DB_MAKE_OBJECT (&db_val, obj);
+	      db_make_object (&db_val, obj);
 	    }
 	  else if (DB_VALUE_TYPE (&db_val) == DB_TYPE_OBJECT)
 	    {
-	      obj = db_real_instance (DB_GET_OBJECT (&db_val));
-	      DB_MAKE_OBJECT (&db_val, obj);
+	      obj = db_real_instance (db_get_object (&db_val));
+	      db_make_object (&db_val, obj);
 	    }
 	  else
 	    {
@@ -5635,7 +5635,7 @@ mq_set_non_updatable_oid (PARSER_CONTEXT * parser, PT_NODE * stmt, PT_NODE * vir
 	  select_list->type_enum = PT_TYPE_OBJECT;
 
 	  /* set vclass_name as literal string */
-	  DB_MAKE_STRING (&vid, db_get_class_name (virt_entity->info.name.db_object));
+	  db_make_string (&vid, db_get_class_name (virt_entity->info.name.db_object));
 	  select_list->info.function.arg_list = pt_dbval_to_value (parser, &vid);
 	  select_list->info.function.function_type = F_SEQUENCE;
 
@@ -9529,7 +9529,7 @@ mq_translate_value (PARSER_CONTEXT * parser, PT_NODE * value)
 	  db_value = pt_value_to_db (parser, value);
 	  if (db_value)
 	    {
-	      DB_MAKE_OBJECT (db_value, value->info.value.data_value.op);
+	      db_make_object (db_value, value->info.value.data_value.op);
 	    }
 
 	}
@@ -10561,7 +10561,7 @@ mq_update_attribute (DB_OBJECT * vclass_object, const char *attr_name, DB_OBJECT
 	  value_holder->info.value.db_value_is_initialized = true;
 	  pt_evaluate_tree (parser, expr->info.expr.arg2, real_value, 1);
 	  parser_free_tree (parser, value);
-	  DB_MAKE_NULL (&value_holder->info.value.db_value);
+	  db_make_null (&value_holder->info.value.db_value);
 	  value_holder->info.value.db_value_is_initialized = false;
 	  /* 
 	   * This is a bit of a kludge since there is no way to clean up
@@ -10920,7 +10920,7 @@ mq_evaluate_check_option (PARSER_CONTEXT * parser, PT_NODE * check_where, DB_OBJ
   DB_VALUE bool_val;
   int error;
 
-  DB_MAKE_NULL (&bool_val);
+  db_make_null (&bool_val);
 
   /* evaluate check option */
   if (check_where != NULL)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -3697,7 +3697,7 @@ pt_to_aggregate_node (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *c
 		    }
 		  else
 		    {
-		      DB_MAKE_NULL (aggregate_list->accumulator.value2);
+		      db_make_null (aggregate_list->accumulator.value2);
 		    }
 		}
 	    }
@@ -5224,7 +5224,7 @@ regu_make_constant_vid (DB_VALUE * val, DB_VALUE ** dbvalptr)
   assert (val != NULL);
 
   /* make sure we got a virtual MOP and a db_value */
-  if (DB_VALUE_TYPE (val) != DB_TYPE_OBJECT || !(vmop = DB_GET_OBJECT (val)) || !WS_ISVID (vmop))
+  if (DB_VALUE_TYPE (val) != DB_TYPE_OBJECT || !(vmop = db_get_object (val)) || !WS_ISVID (vmop))
     {
       return ER_GENERIC_ERROR;
     }
@@ -5273,8 +5273,8 @@ regu_make_constant_vid (DB_VALUE * val, DB_VALUE ** dbvalptr)
 	}
     }
 
-  DB_MAKE_OID (virt_val, &virt_oid);
-  DB_MAKE_OID (proxy_val, &proxy_oid);
+  db_make_oid (virt_val, &virt_oid);
+  db_make_oid (proxy_val, &proxy_oid);
 
   /* the DB_VALUE form of a VMOP is given a type of DB_TYPE_VOBJ and takes the form of a 3-element sequence: virt,
    * proxy, keys (Oh what joy to find out the secret encoding of a virtual object!) */
@@ -5396,7 +5396,7 @@ setof_mop_to_setof_vobj (PARSER_CONTEXT * parser, DB_SET * seq, DB_VALUE * new_v
 	    }
 	  db_value_domain_init (new_elem, DB_TYPE_OBJECT, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	}
-      else if (DB_VALUE_DOMAIN_TYPE (&elem) != DB_TYPE_OBJECT || (obj = DB_GET_OBJECT (&elem)) == NULL)
+      else if (DB_VALUE_DOMAIN_TYPE (&elem) != DB_TYPE_OBJECT || (obj = db_get_object (&elem)) == NULL)
 	{
 	  /* the set has mixed object and non-object types. */
 	  new_elem = &elem;
@@ -5533,8 +5533,8 @@ pt_make_regu_hostvar (PARSER_CONTEXT * parser, const PT_NODE * node)
 	      regu->domain = tp_domain_copy (domain, false);
 	      if (regu->domain != NULL)
 		{
-		  regu->domain->codeset = DB_GET_STRING_CODESET (val);
-		  regu->domain->collation_id = DB_GET_STRING_COLLATION (val);
+		  regu->domain->codeset = db_get_string_codeset (val);
+		  regu->domain->collation_id = db_get_string_collation (val);
 		  regu->domain = tp_domain_cache (regu->domain);
 		  if (regu->domain == NULL)
 		    {
@@ -5585,7 +5585,7 @@ pt_make_regu_hostvar (PARSER_CONTEXT * parser, const PT_NODE * node)
 	    }
 	  else if (typ != exptyp
 		   || (TP_TYPE_HAS_COLLATION (typ) && TP_TYPE_HAS_COLLATION (exptyp)
-		       && (DB_GET_STRING_COLLATION (val) != TP_DOMAIN_COLLATION (regu->domain))))
+		       && (db_get_string_collation (val) != TP_DOMAIN_COLLATION (regu->domain))))
 	    {
 	      if (tp_value_cast (val, val, regu->domain, false) != DOMAIN_COMPATIBLE)
 		{
@@ -5732,7 +5732,7 @@ pt_make_regu_constant (PARSER_CONTEXT * parser, DB_VALUE * db_value, const DB_TY
 		{
 		  OID *oid;
 
-		  oid = db_identifier (DB_GET_OBJECT (db_value));
+		  oid = db_identifier (db_get_object (db_value));
 		  if (oid == NULL)
 		    {
 		      db_value_put_null (db_value);
@@ -5927,8 +5927,8 @@ pt_make_vid (PARSER_CONTEXT * parser, const PT_NODE * data_type, const REGU_VARI
       return NULL;
     }
 
-  DB_MAKE_OID (value1, &virt_oid);
-  DB_MAKE_OID (value2, &proxy_oid);
+  db_make_oid (value1, &virt_oid);
+  db_make_oid (value2, &proxy_oid);
 
   regu1 = pt_make_regu_constant (parser, value1, DB_TYPE_OID, NULL);
   regu2 = pt_make_regu_constant (parser, value2, DB_TYPE_OID, NULL);
@@ -7185,7 +7185,7 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 		  val = regu_dbval_alloc ();
 		  if (val)
 		    {
-		      DB_MAKE_INT (val, node->info.expr.arg3->info.expr.qualifier);
+		      db_make_int (val, node->info.expr.arg3->info.expr.qualifier);
 		      r3 = pt_make_regu_constant (parser, val, DB_TYPE_INTEGER, NULL);
 		    }
 
@@ -8334,7 +8334,7 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 			    return NULL;
 			  }
 
-			DB_MAKE_INTEGER (&dbval, cached_num);
+			db_make_int (&dbval, cached_num);
 			cached_num_node_p = pt_dbval_to_value (parser, &dbval);
 			if (cached_num_node_p == NULL)
 			  {
@@ -9525,7 +9525,7 @@ pt_create_iss_range (INDX_INFO * indx_infop, TP_DOMAIN * domain)
 
   v1->domain = domain;
   v1->flags = 0;
-  DB_MAKE_NULL (&v1->value.dbval);
+  db_make_null (&v1->value.dbval);
 
   v1->vfetch_to = NULL;
 
@@ -12978,7 +12978,7 @@ pt_to_outlist (PARSER_CONTEXT * parser, PT_NODE * node_list, SELUPD_LIST ** selu
 
 		  /* initialize result of regu expr */
 		  OID_SET_NULL (&nulloid);
-		  DB_MAKE_OID (regu->value.arithptr->value, &nulloid);
+		  db_make_oid (regu->value.arithptr->value, &nulloid);
 
 		  (*selupd_list_ptr) = pt_link_regu_to_selupd_list (parser, *regulist, (*selupd_list_ptr), upd_dom_cls);
 		  if ((*selupd_list_ptr) == NULL)
@@ -22504,7 +22504,7 @@ pt_to_analytic_node (PARSER_CONTEXT * parser, PT_NODE * tree, ANALYTIC_INFO * an
       analytic->opr_dbtype = DB_TYPE_NULL;
       analytic->operand.type = TYPE_DBVAL;
       analytic->operand.domain = &tp_Null_domain;
-      DB_MAKE_NULL (&analytic->operand.value.dbval);
+      db_make_null (&analytic->operand.value.dbval);
 
       goto unlink_and_exit;
     }

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -92,23 +92,23 @@ db_floor_dbval (DB_VALUE * result, DB_VALUE * value)
   switch (res_type)
     {
     case DB_TYPE_SHORT:
-      DB_MAKE_SHORT (result, DB_GET_SHORT (value));
+      db_make_short (result, db_get_short (value));
       break;
     case DB_TYPE_INTEGER:
-      DB_MAKE_INT (result, DB_GET_INT (value));
+      db_make_int (result, db_get_int (value));
       break;
     case DB_TYPE_BIGINT:
-      DB_MAKE_BIGINT (result, DB_GET_BIGINT (value));
+      db_make_bigint (result, db_get_bigint (value));
       break;
     case DB_TYPE_FLOAT:
-      dtmp = floor (DB_GET_FLOAT (value));
-      DB_MAKE_FLOAT (result, (float) dtmp);
+      dtmp = floor (db_get_float (value));
+      db_make_float (result, (float) dtmp);
       break;
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      DB_MAKE_NULL (&cast_value);
+      db_make_null (&cast_value);
       er_status = tp_value_str_auto_cast_to_number (value, &cast_value, &res_type);
       if (er_status != NO_ERROR
 	  || (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true && res_type != DB_TYPE_DOUBLE))
@@ -123,8 +123,8 @@ db_floor_dbval (DB_VALUE * result, DB_VALUE * value)
       /* fall through */
 
     case DB_TYPE_DOUBLE:
-      dtmp = floor (DB_GET_DOUBLE (value));
-      DB_MAKE_DOUBLE (result, (double) dtmp);
+      dtmp = floor (db_get_double (value));
+      db_make_double (result, (double) dtmp);
       break;
     case DB_TYPE_NUMERIC:
       {
@@ -202,27 +202,27 @@ db_floor_dbval (DB_VALUE * result, DB_VALUE * value)
 		  }
 
 		numeric_coerce_dec_str_to_num (num_str_p, num);
-		DB_MAKE_NUMERIC (result, num, p, s);
+		db_make_numeric (result, num, p, s);
 	      }
 	    else
 	      {
 		/* given numeric is positive or already rounded */
 		numeric_coerce_dec_str_to_num (num_str + 1, num);
-		DB_MAKE_NUMERIC (result, num, p, s);
+		db_make_numeric (result, num, p, s);
 	      }
 	  }
 	else
 	  {
 	    /* given numeric number is already of integral type */
-	    DB_MAKE_NUMERIC (result, db_get_numeric (value), p, 0);
+	    db_make_numeric (result, db_get_numeric (value), p, 0);
 	  }
 
 	break;
       }
     case DB_TYPE_MONETARY:
-      dtmp = (DB_GET_MONETARY (value))->amount;
+      dtmp = (db_get_monetary (value))->amount;
       dtmp = floor (dtmp);
-      DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value))->type, dtmp);
+      db_make_monetary (result, (db_get_monetary (value))->type, dtmp);
       break;
     default:
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == false)
@@ -259,23 +259,23 @@ db_ceil_dbval (DB_VALUE * result, DB_VALUE * value)
   switch (res_type)
     {
     case DB_TYPE_SHORT:
-      DB_MAKE_SHORT (result, DB_GET_SHORT (value));
+      db_make_short (result, db_get_short (value));
       break;
     case DB_TYPE_INTEGER:
-      DB_MAKE_INT (result, DB_GET_INT (value));
+      db_make_int (result, db_get_int (value));
       break;
     case DB_TYPE_BIGINT:
-      DB_MAKE_BIGINT (result, DB_GET_BIGINT (value));
+      db_make_bigint (result, db_get_bigint (value));
       break;
     case DB_TYPE_FLOAT:
-      dtmp = ceil (DB_GET_FLOAT (value));
-      DB_MAKE_FLOAT (result, (float) dtmp);
+      dtmp = ceil (db_get_float (value));
+      db_make_float (result, (float) dtmp);
       break;
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      DB_MAKE_NULL (&cast_value);
+      db_make_null (&cast_value);
       er_status = tp_value_str_auto_cast_to_number (value, &cast_value, &res_type);
       if (er_status != NO_ERROR
 	  || (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true && res_type != DB_TYPE_DOUBLE))
@@ -290,8 +290,8 @@ db_ceil_dbval (DB_VALUE * result, DB_VALUE * value)
       /* fall through */
 
     case DB_TYPE_DOUBLE:
-      dtmp = ceil (DB_GET_DOUBLE (value));
-      DB_MAKE_DOUBLE (result, (double) dtmp);
+      dtmp = ceil (db_get_double (value));
+      db_make_double (result, (double) dtmp);
       break;
     case DB_TYPE_NUMERIC:
       {
@@ -332,7 +332,7 @@ db_ceil_dbval (DB_VALUE * result, DB_VALUE * value)
 		  {
 		    /* CEIL(-3.1) is -3.0, as opposed to CEIL(+3.1) which is 4 */
 		    numeric_coerce_dec_str_to_num (num_str + 1, num);
-		    DB_MAKE_NUMERIC (result, num, p, s);
+		    db_make_numeric (result, num, p, s);
 		  }
 		else
 		  {
@@ -377,27 +377,27 @@ db_ceil_dbval (DB_VALUE * result, DB_VALUE * value)
 		      }
 
 		    numeric_coerce_dec_str_to_num (num_str_p, num);
-		    DB_MAKE_NUMERIC (result, num, p, s);
+		    db_make_numeric (result, num, p, s);
 		  }
 	      }
 	    else
 	      {
 		/* the given numeric value is already an integer */
-		DB_MAKE_NUMERIC (result, db_locate_numeric (value), p, s);
+		db_make_numeric (result, db_locate_numeric (value), p, s);
 	      }
 	  }
 	else
 	  {
 	    /* the given numeric value has a scale of 0 */
-	    DB_MAKE_NUMERIC (result, db_locate_numeric (value), p, 0);
+	    db_make_numeric (result, db_locate_numeric (value), p, 0);
 	  }
 
 	break;
       }
     case DB_TYPE_MONETARY:
-      dtmp = (DB_GET_MONETARY (value))->amount;
+      dtmp = (db_get_monetary (value))->amount;
       dtmp = ceil (dtmp);
-      DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value))->type, dtmp);
+      db_make_monetary (result, (db_get_monetary (value))->type, dtmp);
       break;
     default:
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == false)
@@ -436,108 +436,108 @@ db_sign_dbval (DB_VALUE * result, DB_VALUE * value)
   switch (res_type)
     {
     case DB_TYPE_SHORT:
-      itmp = DB_GET_SHORT (value);
+      itmp = db_get_short (value);
       if (itmp == 0)
 	{
-	  DB_MAKE_INT (result, 0);
+	  db_make_int (result, 0);
 	}
       else if (itmp < 0)
 	{
-	  DB_MAKE_INT (result, -1);
+	  db_make_int (result, -1);
 	}
       else
 	{
-	  DB_MAKE_INT (result, 1);
+	  db_make_int (result, 1);
 	}
       break;
     case DB_TYPE_INTEGER:
-      itmp = DB_GET_INTEGER (value);
+      itmp = db_get_int (value);
       if (itmp == 0)
 	{
-	  DB_MAKE_INT (result, 0);
+	  db_make_int (result, 0);
 	}
       else if (itmp < 0)
 	{
-	  DB_MAKE_INT (result, -1);
+	  db_make_int (result, -1);
 	}
       else
 	{
-	  DB_MAKE_INT (result, 1);
+	  db_make_int (result, 1);
 	}
       break;
     case DB_TYPE_BIGINT:
-      bitmp = DB_GET_BIGINT (value);
+      bitmp = db_get_bigint (value);
       if (bitmp == 0)
 	{
-	  DB_MAKE_INT (result, 0);
+	  db_make_int (result, 0);
 	}
       else if (bitmp < 0)
 	{
-	  DB_MAKE_INT (result, -1);
+	  db_make_int (result, -1);
 	}
       else
 	{
-	  DB_MAKE_INT (result, 1);
+	  db_make_int (result, 1);
 	}
       break;
     case DB_TYPE_FLOAT:
-      dtmp = DB_GET_FLOAT (value);
+      dtmp = db_get_float (value);
       if (dtmp == 0)
 	{
-	  DB_MAKE_INT (result, 0);
+	  db_make_int (result, 0);
 	}
       else if (dtmp < 0)
 	{
-	  DB_MAKE_INT (result, -1);
+	  db_make_int (result, -1);
 	}
       else
 	{
-	  DB_MAKE_INT (result, 1);
+	  db_make_int (result, 1);
 	}
       break;
     case DB_TYPE_DOUBLE:
-      dtmp = DB_GET_DOUBLE (value);
+      dtmp = db_get_double (value);
       if (dtmp == 0)
 	{
-	  DB_MAKE_INT (result, 0);
+	  db_make_int (result, 0);
 	}
       else if (dtmp < 0)
 	{
-	  DB_MAKE_INT (result, -1);
+	  db_make_int (result, -1);
 	}
       else
 	{
-	  DB_MAKE_INT (result, 1);
+	  db_make_int (result, 1);
 	}
       break;
     case DB_TYPE_NUMERIC:
       numeric_coerce_num_to_double (db_locate_numeric (value), DB_VALUE_SCALE (value), &dtmp);
       if (dtmp == 0)
 	{
-	  DB_MAKE_INT (result, 0);
+	  db_make_int (result, 0);
 	}
       else if (dtmp < 0)
 	{
-	  DB_MAKE_INT (result, -1);
+	  db_make_int (result, -1);
 	}
       else
 	{
-	  DB_MAKE_INT (result, 1);
+	  db_make_int (result, 1);
 	}
       break;
     case DB_TYPE_MONETARY:
-      dtmp = (DB_GET_MONETARY (value))->amount;
+      dtmp = (db_get_monetary (value))->amount;
       if (dtmp == 0)
 	{
-	  DB_MAKE_INT (result, 0);
+	  db_make_int (result, 0);
 	}
       else if (dtmp < 0)
 	{
-	  DB_MAKE_INT (result, -1);
+	  db_make_int (result, -1);
 	}
       else
 	{
-	  DB_MAKE_INT (result, 1);
+	  db_make_int (result, 1);
 	}
       break;
     default:
@@ -573,31 +573,31 @@ db_abs_dbval (DB_VALUE * result, DB_VALUE * value)
   switch (res_type)
     {
     case DB_TYPE_SHORT:
-      stmp = DB_GET_SHORT (value);
+      stmp = db_get_short (value);
       stmp = abs (stmp);
-      DB_MAKE_SHORT (result, stmp);
+      db_make_short (result, stmp);
       break;
     case DB_TYPE_INTEGER:
-      itmp = DB_GET_INT (value);
+      itmp = db_get_int (value);
       itmp = abs (itmp);
-      DB_MAKE_INT (result, itmp);
+      db_make_int (result, itmp);
       break;
     case DB_TYPE_BIGINT:
-      bitmp = DB_GET_BIGINT (value);
+      bitmp = db_get_bigint (value);
       bitmp = llabs (bitmp);
-      DB_MAKE_BIGINT (result, bitmp);
+      db_make_bigint (result, bitmp);
       break;
     case DB_TYPE_FLOAT:
-      dtmp = DB_GET_FLOAT (value);
+      dtmp = db_get_float (value);
       dtmp = fabs (dtmp);
-      DB_MAKE_FLOAT (result, (float) dtmp);
+      db_make_float (result, (float) dtmp);
       break;
 
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      DB_MAKE_NULL (&cast_value);
+      db_make_null (&cast_value);
       er_status = tp_value_str_auto_cast_to_number (value, &cast_value, &res_type);
       if (er_status != NO_ERROR
 	  || (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true && res_type != DB_TYPE_DOUBLE))
@@ -612,22 +612,22 @@ db_abs_dbval (DB_VALUE * result, DB_VALUE * value)
       /* fall through */
 
     case DB_TYPE_DOUBLE:
-      dtmp = DB_GET_DOUBLE (value);
+      dtmp = db_get_double (value);
       dtmp = fabs (dtmp);
-      DB_MAKE_DOUBLE (result, (double) dtmp);
+      db_make_double (result, (double) dtmp);
       break;
     case DB_TYPE_NUMERIC:
       {
 	unsigned char num[DB_NUMERIC_BUF_SIZE];
 
 	numeric_db_value_abs (db_locate_numeric (value), num);
-	DB_MAKE_NUMERIC (result, num, DB_VALUE_PRECISION (value), DB_VALUE_SCALE (value));
+	db_make_numeric (result, num, DB_VALUE_PRECISION (value), DB_VALUE_SCALE (value));
 	break;
       }
     case DB_TYPE_MONETARY:
-      dtmp = (DB_GET_MONETARY (value))->amount;
+      dtmp = (db_get_monetary (value))->amount;
       dtmp = fabs (dtmp);
-      DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value))->type, dtmp);
+      db_make_monetary (result, (db_get_monetary (value))->type, dtmp);
       break;
     default:
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == false)
@@ -668,23 +668,23 @@ db_exp_dbval (DB_VALUE * result, DB_VALUE * value)
   switch (type)
     {
     case DB_TYPE_SHORT:
-      s = DB_GET_SHORT (value);
+      s = db_get_short (value);
       dtmp = exp ((double) s);
       break;
     case DB_TYPE_INTEGER:
-      i = DB_GET_INT (value);
+      i = db_get_int (value);
       dtmp = exp ((double) i);
       break;
     case DB_TYPE_BIGINT:
-      bi = DB_GET_BIGINT (value);
+      bi = db_get_bigint (value);
       dtmp = exp ((double) bi);
       break;
     case DB_TYPE_FLOAT:
-      f = DB_GET_FLOAT (value);
+      f = db_get_float (value);
       dtmp = exp (f);
       break;
     case DB_TYPE_DOUBLE:
-      d = DB_GET_DOUBLE (value);
+      d = db_get_double (value);
       dtmp = exp (d);
       break;
     case DB_TYPE_NUMERIC:
@@ -692,7 +692,7 @@ db_exp_dbval (DB_VALUE * result, DB_VALUE * value)
       dtmp = exp (d);
       break;
     case DB_TYPE_MONETARY:
-      d = (DB_GET_MONETARY (value))->amount;
+      d = (db_get_monetary (value))->amount;
       dtmp = exp (d);
       break;
     default:
@@ -705,7 +705,7 @@ db_exp_dbval (DB_VALUE * result, DB_VALUE * value)
       goto exp_overflow;
     }
 
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
   return NO_ERROR;
 
 exp_overflow:
@@ -740,7 +740,7 @@ db_sqrt_dbval (DB_VALUE * result, DB_VALUE * value)
   switch (type)
     {
     case DB_TYPE_SHORT:
-      s = DB_GET_SHORT (value);
+      s = db_get_short (value);
       if (s < 0)
 	{
 	  goto sqrt_error;
@@ -748,7 +748,7 @@ db_sqrt_dbval (DB_VALUE * result, DB_VALUE * value)
       dtmp = sqrt ((double) s);
       break;
     case DB_TYPE_INTEGER:
-      i = DB_GET_INT (value);
+      i = db_get_int (value);
       if (i < 0)
 	{
 	  goto sqrt_error;
@@ -756,7 +756,7 @@ db_sqrt_dbval (DB_VALUE * result, DB_VALUE * value)
       dtmp = sqrt ((double) i);
       break;
     case DB_TYPE_BIGINT:
-      bi = DB_GET_BIGINT (value);
+      bi = db_get_bigint (value);
       if (bi < 0)
 	{
 	  goto sqrt_error;
@@ -764,7 +764,7 @@ db_sqrt_dbval (DB_VALUE * result, DB_VALUE * value)
       dtmp = sqrt ((double) bi);
       break;
     case DB_TYPE_FLOAT:
-      f = DB_GET_FLOAT (value);
+      f = db_get_float (value);
       if (f < 0)
 	{
 	  goto sqrt_error;
@@ -772,7 +772,7 @@ db_sqrt_dbval (DB_VALUE * result, DB_VALUE * value)
       dtmp = sqrt (f);
       break;
     case DB_TYPE_DOUBLE:
-      d = DB_GET_DOUBLE (value);
+      d = db_get_double (value);
       if (d < 0)
 	{
 	  goto sqrt_error;
@@ -788,7 +788,7 @@ db_sqrt_dbval (DB_VALUE * result, DB_VALUE * value)
       dtmp = sqrt (d);
       break;
     case DB_TYPE_MONETARY:
-      d = (DB_GET_MONETARY (value))->amount;
+      d = (db_get_monetary (value))->amount;
       if (d < 0)
 	{
 	  goto sqrt_error;
@@ -801,13 +801,13 @@ db_sqrt_dbval (DB_VALUE * result, DB_VALUE * value)
       break;
     }
 
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
   return NO_ERROR;
 
 sqrt_error:
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) == COMPAT_MYSQL)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
   else
@@ -833,7 +833,7 @@ db_power_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
   if (DB_IS_NULL (value1) || DB_IS_NULL (value2))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -860,14 +860,14 @@ db_power_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       goto pow_overflow;
     }
 
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
 
   return NO_ERROR;
 
 pow_overflow:
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) == COMPAT_MYSQL)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
   else
@@ -879,7 +879,7 @@ pow_overflow:
 pow_error:
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) == COMPAT_MYSQL)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
   else
@@ -916,60 +916,60 @@ db_mod_short (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
   assert (result != NULL && value1 != NULL && value2 != NULL);
 
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value2);
 
 #if !defined(NDEBUG)
   type1 = DB_VALUE_DOMAIN_TYPE (value1);
   assert (type1 == DB_TYPE_SHORT);
 #endif
 
-  s1 = DB_GET_SHORT (value1);
+  s1 = db_get_short (value1);
 
   type2 = DB_VALUE_DOMAIN_TYPE (value2);
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      s2 = DB_GET_SHORT (value2);
+      s2 = db_get_short (value2);
       if (s2 == 0)
 	{
-	  DB_MAKE_SHORT (result, s1);
+	  db_make_short (result, s1);
 	}
       else
 	{
-	  DB_MAKE_SHORT (result, (short) (s1 % s2));
+	  db_make_short (result, (short) (s1 % s2));
 	}
       break;
     case DB_TYPE_INTEGER:
-      i2 = DB_GET_INT (value2);
+      i2 = db_get_int (value2);
       if (i2 == 0)
 	{
-	  DB_MAKE_INT (result, s1);
+	  db_make_int (result, s1);
 	}
       else
 	{
-	  DB_MAKE_INT (result, (int) (s1 % i2));
+	  db_make_int (result, (int) (s1 % i2));
 	}
       break;
     case DB_TYPE_BIGINT:
-      bi2 = DB_GET_BIGINT (value2);
+      bi2 = db_get_bigint (value2);
       if (bi2 == 0)
 	{
-	  DB_MAKE_BIGINT (result, s1);
+	  db_make_bigint (result, s1);
 	}
       else
 	{
-	  DB_MAKE_BIGINT (result, (DB_BIGINT) (s1 % bi2));
+	  db_make_bigint (result, (DB_BIGINT) (s1 % bi2));
 	}
       break;
     case DB_TYPE_FLOAT:
-      f2 = DB_GET_FLOAT (value2);
+      f2 = db_get_float (value2);
       if (f2 == 0)
 	{
-	  DB_MAKE_FLOAT (result, s1);
+	  db_make_float (result, s1);
 	}
       else
 	{
-	  DB_MAKE_FLOAT (result, (float) fmod ((float) s1, f2));
+	  db_make_float (result, (float) fmod ((float) s1, f2));
 	}
       break;
     case DB_TYPE_CHAR:
@@ -990,14 +990,14 @@ db_mod_short (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       /* fall through */
 
     case DB_TYPE_DOUBLE:
-      d2 = DB_GET_DOUBLE (value2);
+      d2 = db_get_double (value2);
       if (d2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, s1);
+	  db_make_double (result, s1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, (double) fmod ((double) s1, d2));
+	  db_make_double (result, (double) fmod ((double) s1, d2));
 	}
       break;
     case DB_TYPE_NUMERIC:
@@ -1010,18 +1010,18 @@ db_mod_short (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	{
 	  dtmp = fmod ((double) s1, d2);
 	  (void) numeric_internal_double_to_num (dtmp, DB_VALUE_SCALE (value2), num, &p, &s);
-	  DB_MAKE_NUMERIC (result, num, p, s);
+	  db_make_numeric (result, num, p, s);
 	}
       break;
     case DB_TYPE_MONETARY:
-      d2 = (DB_GET_MONETARY (value2))->amount;
+      d2 = (db_get_monetary (value2))->amount;
       if (d2 == 0)
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, s1);
+	  db_make_monetary (result, (db_get_monetary (value2))->type, s1);
 	}
       else
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, (double) fmod (s1, d2));
+	  db_make_monetary (result, (db_get_monetary (value2))->type, (double) fmod (s1, d2));
 	}
       break;
     default:
@@ -1065,60 +1065,60 @@ db_mod_int (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
   assert (result != NULL && value1 != NULL && value2 != NULL);
 
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value2);
 
 #if !defined(NDEBUG)
   type1 = DB_VALUE_DOMAIN_TYPE (value1);
   assert (type1 == DB_TYPE_INTEGER);
 #endif
 
-  i1 = DB_GET_INT (value1);
+  i1 = db_get_int (value1);
 
   type2 = DB_VALUE_DOMAIN_TYPE (value2);
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      s2 = DB_GET_SHORT (value2);
+      s2 = db_get_short (value2);
       if (s2 == 0)
 	{
-	  DB_MAKE_INT (result, i1);
+	  db_make_int (result, i1);
 	}
       else
 	{
-	  DB_MAKE_INT (result, (int) (i1 % s2));
+	  db_make_int (result, (int) (i1 % s2));
 	}
       break;
     case DB_TYPE_INTEGER:
-      i2 = DB_GET_INT (value2);
+      i2 = db_get_int (value2);
       if (i2 == 0)
 	{
-	  DB_MAKE_INT (result, i1);
+	  db_make_int (result, i1);
 	}
       else
 	{
-	  DB_MAKE_INT (result, (int) (i1 % i2));
+	  db_make_int (result, (int) (i1 % i2));
 	}
       break;
     case DB_TYPE_BIGINT:
-      bi2 = DB_GET_BIGINT (value2);
+      bi2 = db_get_bigint (value2);
       if (bi2 == 0)
 	{
-	  DB_MAKE_BIGINT (result, i1);
+	  db_make_bigint (result, i1);
 	}
       else
 	{
-	  DB_MAKE_BIGINT (result, (DB_BIGINT) (i1 % bi2));
+	  db_make_bigint (result, (DB_BIGINT) (i1 % bi2));
 	}
       break;
     case DB_TYPE_FLOAT:
-      f2 = DB_GET_FLOAT (value2);
+      f2 = db_get_float (value2);
       if (f2 == 0)
 	{
-	  DB_MAKE_FLOAT (result, (float) i1);
+	  db_make_float (result, (float) i1);
 	}
       else
 	{
-	  DB_MAKE_FLOAT (result, (float) fmod ((float) i1, f2));
+	  db_make_float (result, (float) fmod ((float) i1, f2));
 	}
       break;
     case DB_TYPE_CHAR:
@@ -1139,14 +1139,14 @@ db_mod_int (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       /* fall through */
 
     case DB_TYPE_DOUBLE:
-      d2 = DB_GET_DOUBLE (value2);
+      d2 = db_get_double (value2);
       if (d2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, i1);
+	  db_make_double (result, i1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, (double) fmod ((double) i1, d2));
+	  db_make_double (result, (double) fmod ((double) i1, d2));
 	}
       break;
     case DB_TYPE_NUMERIC:
@@ -1159,18 +1159,18 @@ db_mod_int (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	{
 	  dtmp = fmod ((double) i1, d2);
 	  (void) numeric_internal_double_to_num (dtmp, DB_VALUE_SCALE (value2), num, &p, &s);
-	  DB_MAKE_NUMERIC (result, num, p, s);
+	  db_make_numeric (result, num, p, s);
 	}
       break;
     case DB_TYPE_MONETARY:
-      d2 = (DB_GET_MONETARY (value2))->amount;
+      d2 = (db_get_monetary (value2))->amount;
       if (d2 == 0)
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, i1);
+	  db_make_monetary (result, (db_get_monetary (value2))->type, i1);
 	}
       else
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, (double) fmod ((double) i1, d2));
+	  db_make_monetary (result, (db_get_monetary (value2))->type, (double) fmod ((double) i1, d2));
 	}
       break;
     default:
@@ -1214,60 +1214,60 @@ db_mod_bigint (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
   assert (result != NULL && value1 != NULL && value2 != NULL);
 
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value2);
 
 #if !defined(NDEBUG)
   type1 = DB_VALUE_DOMAIN_TYPE (value1);
   assert (type1 == DB_TYPE_BIGINT);
 #endif
 
-  bi1 = DB_GET_BIGINT (value1);
+  bi1 = db_get_bigint (value1);
 
   type2 = DB_VALUE_DOMAIN_TYPE (value2);
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      s2 = DB_GET_SHORT (value2);
+      s2 = db_get_short (value2);
       if (s2 == 0)
 	{
-	  DB_MAKE_BIGINT (result, bi1);
+	  db_make_bigint (result, bi1);
 	}
       else
 	{
-	  DB_MAKE_BIGINT (result, (DB_BIGINT) (bi1 % s2));
+	  db_make_bigint (result, (DB_BIGINT) (bi1 % s2));
 	}
       break;
     case DB_TYPE_INTEGER:
-      i2 = DB_GET_INT (value2);
+      i2 = db_get_int (value2);
       if (i2 == 0)
 	{
-	  DB_MAKE_BIGINT (result, bi1);
+	  db_make_bigint (result, bi1);
 	}
       else
 	{
-	  DB_MAKE_BIGINT (result, (DB_BIGINT) (bi1 % i2));
+	  db_make_bigint (result, (DB_BIGINT) (bi1 % i2));
 	}
       break;
     case DB_TYPE_BIGINT:
-      bi2 = DB_GET_BIGINT (value2);
+      bi2 = db_get_bigint (value2);
       if (bi2 == 0)
 	{
-	  DB_MAKE_BIGINT (result, bi1);
+	  db_make_bigint (result, bi1);
 	}
       else
 	{
-	  DB_MAKE_BIGINT (result, (DB_BIGINT) (bi1 % bi2));
+	  db_make_bigint (result, (DB_BIGINT) (bi1 % bi2));
 	}
       break;
     case DB_TYPE_FLOAT:
-      f2 = DB_GET_FLOAT (value2);
+      f2 = db_get_float (value2);
       if (f2 == 0)
 	{
-	  DB_MAKE_FLOAT (result, (float) bi1);
+	  db_make_float (result, (float) bi1);
 	}
       else
 	{
-	  DB_MAKE_FLOAT (result, (float) fmod ((double) bi1, (double) f2));
+	  db_make_float (result, (float) fmod ((double) bi1, (double) f2));
 	}
       break;
     case DB_TYPE_CHAR:
@@ -1288,14 +1288,14 @@ db_mod_bigint (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       /* fall through */
 
     case DB_TYPE_DOUBLE:
-      d2 = DB_GET_DOUBLE (value2);
+      d2 = db_get_double (value2);
       if (d2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, (double) bi1);
+	  db_make_double (result, (double) bi1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, (double) fmod ((double) bi1, d2));
+	  db_make_double (result, (double) fmod ((double) bi1, d2));
 	}
       break;
     case DB_TYPE_NUMERIC:
@@ -1308,18 +1308,18 @@ db_mod_bigint (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	{
 	  dtmp = fmod ((double) bi1, d2);
 	  (void) numeric_internal_double_to_num (dtmp, DB_VALUE_SCALE (value2), num, &p, &s);
-	  DB_MAKE_NUMERIC (result, num, p, s);
+	  db_make_numeric (result, num, p, s);
 	}
       break;
     case DB_TYPE_MONETARY:
-      d2 = (DB_GET_MONETARY (value2))->amount;
+      d2 = (db_get_monetary (value2))->amount;
       if (d2 == 0)
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, (double) bi1);
+	  db_make_monetary (result, (db_get_monetary (value2))->type, (double) bi1);
 	}
       else
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, (double) fmod ((double) bi1, d2));
+	  db_make_monetary (result, (db_get_monetary (value2))->type, (double) fmod ((double) bi1, d2));
 	}
       break;
     default:
@@ -1359,60 +1359,60 @@ db_mod_float (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
   assert (result != NULL && value1 != NULL && value2 != NULL);
 
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value2);
 
 #if !defined(NDEBUG)
   type1 = DB_VALUE_DOMAIN_TYPE (value1);
   assert (type1 == DB_TYPE_FLOAT);
 #endif
 
-  f1 = DB_GET_FLOAT (value1);
+  f1 = db_get_float (value1);
 
   type2 = DB_VALUE_DOMAIN_TYPE (value2);
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      s2 = DB_GET_SHORT (value2);
+      s2 = db_get_short (value2);
       if (s2 == 0)
 	{
-	  DB_MAKE_FLOAT (result, f1);
+	  db_make_float (result, f1);
 	}
       else
 	{
-	  DB_MAKE_FLOAT (result, (float) fmod (f1, (float) s2));
+	  db_make_float (result, (float) fmod (f1, (float) s2));
 	}
       break;
     case DB_TYPE_INTEGER:
-      i2 = DB_GET_INT (value2);
+      i2 = db_get_int (value2);
       if (i2 == 0)
 	{
-	  DB_MAKE_FLOAT (result, f1);
+	  db_make_float (result, f1);
 	}
       else
 	{
-	  DB_MAKE_FLOAT (result, (float) fmod (f1, (float) i2));
+	  db_make_float (result, (float) fmod (f1, (float) i2));
 	}
       break;
     case DB_TYPE_BIGINT:
-      bi2 = DB_GET_BIGINT (value2);
+      bi2 = db_get_bigint (value2);
       if (bi2 == 0)
 	{
-	  DB_MAKE_FLOAT (result, f1);
+	  db_make_float (result, f1);
 	}
       else
 	{
-	  DB_MAKE_FLOAT (result, (float) fmod ((double) f1, (double) bi2));
+	  db_make_float (result, (float) fmod ((double) f1, (double) bi2));
 	}
       break;
     case DB_TYPE_FLOAT:
-      f2 = DB_GET_FLOAT (value2);
+      f2 = db_get_float (value2);
       if (f2 == 0)
 	{
-	  DB_MAKE_FLOAT (result, f1);
+	  db_make_float (result, f1);
 	}
       else
 	{
-	  DB_MAKE_FLOAT (result, (float) fmod (f1, f2));
+	  db_make_float (result, (float) fmod (f1, f2));
 	}
       break;
     case DB_TYPE_CHAR:
@@ -1433,14 +1433,14 @@ db_mod_float (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       /* fall through */
 
     case DB_TYPE_DOUBLE:
-      d2 = DB_GET_DOUBLE (value2);
+      d2 = db_get_double (value2);
       if (d2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, f1);
+	  db_make_double (result, f1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, (double) fmod ((double) f1, d2));
+	  db_make_double (result, (double) fmod ((double) f1, d2));
 	}
       break;
     case DB_TYPE_NUMERIC:
@@ -1448,22 +1448,22 @@ db_mod_float (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       /* common type of float and numeric is double. */
       if (d2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, f1);
+	  db_make_double (result, f1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, fmod ((double) f1, d2));
+	  db_make_double (result, fmod ((double) f1, d2));
 	}
       break;
     case DB_TYPE_MONETARY:
-      d2 = (DB_GET_MONETARY (value2))->amount;
+      d2 = (db_get_monetary (value2))->amount;
       if (d2 == 0)
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, f1);
+	  db_make_monetary (result, (db_get_monetary (value2))->type, f1);
 	}
       else
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, (double) fmod ((double) f1, d2));
+	  db_make_monetary (result, (db_get_monetary (value2))->type, (double) fmod ((double) f1, d2));
 	}
       break;
     default:
@@ -1503,60 +1503,60 @@ db_mod_double (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
   assert (result != NULL && value1 != NULL && value2 != NULL);
 
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value2);
 
 #if !defined(NDEBUG)
   type1 = DB_VALUE_DOMAIN_TYPE (value1);
   assert (type1 == DB_TYPE_DOUBLE);
 #endif
 
-  d1 = DB_GET_DOUBLE (value1);
+  d1 = db_get_double (value1);
 
   type2 = DB_VALUE_DOMAIN_TYPE (value2);
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      s2 = DB_GET_SHORT (value2);
+      s2 = db_get_short (value2);
       if (s2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, d1);
+	  db_make_double (result, d1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, (double) fmod (d1, (double) s2));
+	  db_make_double (result, (double) fmod (d1, (double) s2));
 	}
       break;
     case DB_TYPE_INTEGER:
-      i2 = DB_GET_INT (value2);
+      i2 = db_get_int (value2);
       if (i2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, d1);
+	  db_make_double (result, d1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, (double) fmod (d1, (double) i2));
+	  db_make_double (result, (double) fmod (d1, (double) i2));
 	}
       break;
     case DB_TYPE_BIGINT:
-      bi2 = DB_GET_BIGINT (value2);
+      bi2 = db_get_bigint (value2);
       if (bi2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, d1);
+	  db_make_double (result, d1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, (double) fmod (d1, (double) bi2));
+	  db_make_double (result, (double) fmod (d1, (double) bi2));
 	}
       break;
     case DB_TYPE_FLOAT:
-      f2 = DB_GET_FLOAT (value2);
+      f2 = db_get_float (value2);
       if (f2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, d1);
+	  db_make_double (result, d1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, (double) fmod (d1, (double) f2));
+	  db_make_double (result, (double) fmod (d1, (double) f2));
 	}
       break;
     case DB_TYPE_CHAR:
@@ -1577,36 +1577,36 @@ db_mod_double (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       /* fall through */
 
     case DB_TYPE_DOUBLE:
-      d2 = DB_GET_DOUBLE (value2);
+      d2 = db_get_double (value2);
       if (d2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, d1);
+	  db_make_double (result, d1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, (double) fmod (d1, d2));
+	  db_make_double (result, (double) fmod (d1, d2));
 	}
       break;
     case DB_TYPE_NUMERIC:
       numeric_coerce_num_to_double (db_locate_numeric (value2), DB_VALUE_SCALE (value2), &d2);
       if (d2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, d1);
+	  db_make_double (result, d1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, (double) fmod (d1, d2));
+	  db_make_double (result, (double) fmod (d1, d2));
 	}
       break;
     case DB_TYPE_MONETARY:
-      d2 = (DB_GET_MONETARY (value2))->amount;
+      d2 = (db_get_monetary (value2))->amount;
       if (d2 == 0)
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, d1);
+	  db_make_monetary (result, (db_get_monetary (value2))->type, d1);
 	}
       else
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, (double) fmod (d1, d2));
+	  db_make_monetary (result, (db_get_monetary (value2))->type, (double) fmod (d1, d2));
 	}
       break;
     default:
@@ -1638,7 +1638,7 @@ db_mod_string (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
   assert (result != NULL && value1 != NULL && value2 != NULL);
 
-  DB_MAKE_NULL (&cast_value1);
+  db_make_null (&cast_value1);
 
 #if !defined(NDEBUG)
   type1 = DB_VALUE_DOMAIN_TYPE (value1);
@@ -1687,7 +1687,7 @@ db_mod_numeric (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
   assert (result != NULL && value1 != NULL && value2 != NULL);
 
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value2);
 
 #if !defined(NDEBUG)
   type1 = DB_VALUE_DOMAIN_TYPE (value1);
@@ -1700,7 +1700,7 @@ db_mod_numeric (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      s2 = DB_GET_SHORT (value2);
+      s2 = db_get_short (value2);
       if (s2 == 0)
 	{
 	  (void) numeric_db_value_coerce_to_num (value1, result, &data_stat);
@@ -1709,11 +1709,11 @@ db_mod_numeric (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	{
 	  dtmp = fmod (d1, (double) s2);
 	  (void) numeric_internal_double_to_num (dtmp, DB_VALUE_SCALE (value1), num, &p, &s);
-	  DB_MAKE_NUMERIC (result, num, p, s);
+	  db_make_numeric (result, num, p, s);
 	}
       break;
     case DB_TYPE_INTEGER:
-      i2 = DB_GET_INT (value2);
+      i2 = db_get_int (value2);
       if (i2 == 0)
 	{
 	  (void) numeric_db_value_coerce_to_num (value1, result, &data_stat);
@@ -1722,11 +1722,11 @@ db_mod_numeric (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	{
 	  dtmp = fmod (d1, (double) i2);
 	  (void) numeric_internal_double_to_num (dtmp, DB_VALUE_SCALE (value1), num, &p, &s);
-	  DB_MAKE_NUMERIC (result, num, p, s);
+	  db_make_numeric (result, num, p, s);
 	}
       break;
     case DB_TYPE_BIGINT:
-      bi2 = DB_GET_BIGINT (value2);
+      bi2 = db_get_bigint (value2);
       if (bi2 == 0)
 	{
 	  (void) numeric_db_value_coerce_to_num (value1, result, &data_stat);
@@ -1735,19 +1735,19 @@ db_mod_numeric (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	{
 	  dtmp = fmod (d1, (double) bi2);
 	  (void) numeric_internal_double_to_num (dtmp, DB_VALUE_SCALE (value1), num, &p, &s);
-	  DB_MAKE_NUMERIC (result, num, p, s);
+	  db_make_numeric (result, num, p, s);
 	}
       break;
     case DB_TYPE_FLOAT:
-      f2 = DB_GET_FLOAT (value2);
+      f2 = db_get_float (value2);
       /* common type of float and numeric is double */
       if (f2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, d1);
+	  db_make_double (result, d1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, fmod (d1, (double) f2));
+	  db_make_double (result, fmod (d1, (double) f2));
 	}
       break;
     case DB_TYPE_CHAR:
@@ -1768,14 +1768,14 @@ db_mod_numeric (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       /* fall through */
 
     case DB_TYPE_DOUBLE:
-      d2 = DB_GET_DOUBLE (value2);
+      d2 = db_get_double (value2);
       if (d2 == 0)
 	{
-	  DB_MAKE_DOUBLE (result, d1);
+	  db_make_double (result, d1);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (result, (double) fmod (d1, d2));
+	  db_make_double (result, (double) fmod (d1, d2));
 	}
       break;
     case DB_TYPE_NUMERIC:
@@ -1789,18 +1789,18 @@ db_mod_numeric (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = fmod (d1, d2);
 	  (void) numeric_internal_double_to_num (dtmp, MAX (DB_VALUE_SCALE (value1), DB_VALUE_SCALE (value2)), num, &p,
 						 &s);
-	  DB_MAKE_NUMERIC (result, num, p, s);
+	  db_make_numeric (result, num, p, s);
 	}
       break;
     case DB_TYPE_MONETARY:
-      d2 = (DB_GET_MONETARY (value2))->amount;
+      d2 = (db_get_monetary (value2))->amount;
       if (d2 == 0)
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, d1);
+	  db_make_monetary (result, (db_get_monetary (value2))->type, d1);
 	}
       else
 	{
-	  DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value2))->type, (double) fmod (d1, d2));
+	  db_make_monetary (result, (db_get_monetary (value2))->type, (double) fmod (d1, d2));
 	}
       break;
     default:
@@ -1836,30 +1836,30 @@ db_mod_monetary (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
   assert (result != NULL && value1 != NULL && value2 != NULL);
 
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value2);
 
 #if !defined(NDEBUG)
   type1 = DB_VALUE_DOMAIN_TYPE (value1);
   assert (type1 == DB_TYPE_MONETARY);
 #endif
 
-  d1 = (DB_GET_MONETARY (value1))->amount;
+  d1 = (db_get_monetary (value1))->amount;
   d2 = 0;
 
   type2 = DB_VALUE_DOMAIN_TYPE (value2);
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      d2 = DB_GET_SHORT (value2);
+      d2 = db_get_short (value2);
       break;
     case DB_TYPE_INTEGER:
-      d2 = DB_GET_INT (value2);
+      d2 = db_get_int (value2);
       break;
     case DB_TYPE_BIGINT:
-      d2 = (double) DB_GET_BIGINT (value2);
+      d2 = (double) db_get_bigint (value2);
       break;
     case DB_TYPE_FLOAT:
-      d2 = DB_GET_FLOAT (value2);
+      d2 = db_get_float (value2);
       break;
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
@@ -1879,13 +1879,13 @@ db_mod_monetary (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       /* fall through */
 
     case DB_TYPE_DOUBLE:
-      d2 = DB_GET_DOUBLE (value2);
+      d2 = db_get_double (value2);
       break;
     case DB_TYPE_NUMERIC:
       numeric_coerce_num_to_double (db_locate_numeric (value2), DB_VALUE_SCALE (value2), &d2);
       break;
     case DB_TYPE_MONETARY:
-      d2 = (DB_GET_MONETARY (value2))->amount;
+      d2 = (db_get_monetary (value2))->amount;
       break;
     default:
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == false)
@@ -1898,11 +1898,11 @@ db_mod_monetary (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
   if (d2 == 0)
     {
-      DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value1))->type, d1);
+      db_make_monetary (result, (db_get_monetary (value1))->type, d1);
     }
   else
     {
-      DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value1))->type, (double) fmod (d1, d2));
+      db_make_monetary (result, (db_get_monetary (value1))->type, (double) fmod (d1, d2));
     }
 
 exit:
@@ -2289,13 +2289,13 @@ round_date (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
     }
 
   /* re-create new date */
-  error = DB_MAKE_DATE (result, month, day, year);
+  error = db_make_date (result, month, day, year);
 
 end:
   if (error != NO_ERROR && prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       error = NO_ERROR;
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       er_clear ();
     }
 
@@ -2329,8 +2329,8 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
   int er_status = NO_ERROR;
   TP_DOMAIN *domain = NULL;
 
-  DB_MAKE_NULL (&cast_value);
-  DB_MAKE_NULL (&cast_format);
+  db_make_null (&cast_value);
+  db_make_null (&cast_format);
 
   if (DB_IS_NULL (value1) || DB_IS_NULL (value2))
     {
@@ -2347,7 +2347,7 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
     {				/* round date */
       if (QSTR_IS_ANY_CHAR (type2) && strcasecmp (DB_GET_STRING_SAFE (value2), "default") == 0)
 	{
-	  DB_MAKE_STRING (&cast_format, "dd");
+	  db_make_string (&cast_format, "dd");
 	  value2 = &cast_format;
 	}
       return round_date (result, value1, value2);
@@ -2379,25 +2379,25 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
   /* get value2 */
   if (type2 == DB_TYPE_INTEGER)
     {
-      d2 = (double) DB_GET_INT (value2);
+      d2 = (double) db_get_int (value2);
     }
   else if (type2 == DB_TYPE_BIGINT)
     {
-      d2 = (double) DB_GET_BIGINT (value2);
+      d2 = (double) db_get_bigint (value2);
     }
   else if (type2 == DB_TYPE_SHORT)
     {
-      d2 = (double) DB_GET_SHORT (value2);
+      d2 = (double) db_get_short (value2);
     }
   else if (type2 == DB_TYPE_DOUBLE)
     {
-      d2 = DB_GET_DOUBLE (value2);
+      d2 = db_get_double (value2);
     }
   else				/* cast to INTEGER */
     {
       if (QSTR_IS_ANY_CHAR (type2) && strcasecmp (DB_GET_STRING_SAFE (value2), "default") == 0)
 	{
-	  DB_MAKE_INT (&cast_format, 0);
+	  db_make_int (&cast_format, 0);
 	  value2 = &cast_format;
 	  type2 = DB_TYPE_INTEGER;
 	  d2 = 0;
@@ -2422,7 +2422,7 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	    }
 	  type2 = DB_TYPE_INTEGER;
 	  value2 = &cast_format;
-	  d2 = DB_GET_INTEGER (value2);
+	  d2 = db_get_int (value2);
 	}
     }
 
@@ -2430,17 +2430,17 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
   switch (type1)
     {
     case DB_TYPE_SHORT:
-      s1 = DB_GET_SHORT (value1);
+      s1 = db_get_short (value1);
       dtmp = round_double (s1, d2);
-      DB_MAKE_SHORT (result, (short) dtmp);
+      db_make_short (result, (short) dtmp);
       break;
     case DB_TYPE_INTEGER:
-      i1 = DB_GET_INT (value1);
+      i1 = db_get_int (value1);
       dtmp = round_double (i1, d2);
-      DB_MAKE_INT (result, (int) dtmp);
+      db_make_int (result, (int) dtmp);
       break;
     case DB_TYPE_BIGINT:
-      bi1 = DB_GET_BIGINT (value1);
+      bi1 = db_get_bigint (value1);
       dtmp = round_double ((double) bi1, d2);
       bi_tmp = (DB_BIGINT) dtmp;
 #if defined(AIX)
@@ -2450,18 +2450,18 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  bi_tmp = DB_BIGINT_MIN;
 	}
 #endif
-      DB_MAKE_BIGINT (result, bi_tmp);
+      db_make_bigint (result, bi_tmp);
       break;
     case DB_TYPE_FLOAT:
-      f1 = DB_GET_FLOAT (value1);
+      f1 = db_get_float (value1);
       dtmp = round_double (f1, d2);
-      DB_MAKE_FLOAT (result, (float) dtmp);
+      db_make_float (result, (float) dtmp);
       break;
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      DB_MAKE_NULL (&cast_value);
+      db_make_null (&cast_value);
       er_status = tp_value_str_auto_cast_to_number (value1, &cast_value, &type1);
       if (er_status != NO_ERROR
 	  || (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true && type1 != DB_TYPE_DOUBLE))
@@ -2474,9 +2474,9 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
       /* fall through */
     case DB_TYPE_DOUBLE:
-      d1 = DB_GET_DOUBLE (value1);
+      d1 = db_get_double (value1);
       dtmp = round_double (d1, d2);
-      DB_MAKE_DOUBLE (result, (double) dtmp);
+      db_make_double (result, (double) dtmp);
       break;
     case DB_TYPE_NUMERIC:
       memset (num_string, 0, sizeof (num_string));
@@ -2487,19 +2487,19 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
       if (type2 == DB_TYPE_BIGINT)
 	{
-	  bi2 = DB_GET_BIGINT (value2);
+	  bi2 = db_get_bigint (value2);
 	}
       else if (type2 == DB_TYPE_INTEGER)
 	{
-	  bi2 = DB_GET_INT (value2);
+	  bi2 = db_get_int (value2);
 	}
       else if (type2 == DB_TYPE_SHORT)
 	{
-	  bi2 = DB_GET_SHORT (value2);
+	  bi2 = db_get_short (value2);
 	}
       else			/* double */
 	{
-	  bi2 = (DB_BIGINT) DB_GET_DOUBLE (value2);
+	  bi2 = (DB_BIGINT) db_get_double (value2);
 	}
       ptr = end - s + bi2;
 
@@ -2567,12 +2567,12 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	}
 
       numeric_coerce_dec_str_to_num (num_string, num);
-      DB_MAKE_NUMERIC (result, num, p, s);
+      db_make_numeric (result, num, p, s);
       break;
     case DB_TYPE_MONETARY:
-      d1 = (DB_GET_MONETARY (value1))->amount;
+      d1 = (db_get_monetary (value1))->amount;
       dtmp = round_double (d1, d2);
-      DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value1))->type, dtmp);
+      db_make_monetary (result, (db_get_monetary (value1))->type, dtmp);
       break;
     default:
       if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
@@ -2586,7 +2586,7 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
   if (er_errid () != NO_ERROR && prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       er_clear ();
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
 
   return er_errid ();
@@ -2621,7 +2621,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
   switch (type1)
     {
     case DB_TYPE_SHORT:
-      s1 = DB_GET_SHORT (value1);
+      s1 = db_get_short (value1);
       if (s1 <= 1)
 	{
 	  goto log_error;
@@ -2630,7 +2630,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       switch (type2)
 	{
 	case DB_TYPE_SHORT:
-	  s2 = DB_GET_SHORT (value2);
+	  s2 = db_get_short (value2);
 	  if (s2 <= 0)
 	    {
 	      goto log_error;
@@ -2638,7 +2638,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) s2) / log10 ((double) s1);
 	  break;
 	case DB_TYPE_INTEGER:
-	  i2 = DB_GET_INT (value2);
+	  i2 = db_get_int (value2);
 	  if (i2 <= 0)
 	    {
 	      goto log_error;
@@ -2646,7 +2646,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) i2) / log10 ((double) s1);
 	  break;
 	case DB_TYPE_BIGINT:
-	  bi2 = DB_GET_BIGINT (value2);
+	  bi2 = db_get_bigint (value2);
 	  if (bi2 <= 0)
 	    {
 	      goto log_error;
@@ -2654,7 +2654,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) bi2) / log10 ((double) s1);
 	  break;
 	case DB_TYPE_FLOAT:
-	  f2 = DB_GET_FLOAT (value2);
+	  f2 = db_get_float (value2);
 	  if (f2 <= 0)
 	    {
 	      goto log_error;
@@ -2662,7 +2662,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) f2) / log10 ((double) s1);
 	  break;
 	case DB_TYPE_DOUBLE:
-	  d2 = DB_GET_DOUBLE (value2);
+	  d2 = db_get_double (value2);
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -2678,7 +2678,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) d2) / log10 ((double) s1);
 	  break;
 	case DB_TYPE_MONETARY:
-	  d2 = (DB_GET_MONETARY (value2))->amount;
+	  d2 = (db_get_monetary (value2))->amount;
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -2692,7 +2692,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       break;
 
     case DB_TYPE_BIGINT:
-      bi1 = DB_GET_BIGINT (value1);
+      bi1 = db_get_bigint (value1);
       if (bi1 <= 1)
 	{
 	  goto log_error;
@@ -2701,7 +2701,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       switch (type2)
 	{
 	case DB_TYPE_SHORT:
-	  s2 = DB_GET_SHORT (value2);
+	  s2 = db_get_short (value2);
 	  if (s2 <= 0)
 	    {
 	      goto log_error;
@@ -2709,7 +2709,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) s2) / log10 ((double) bi1);
 	  break;
 	case DB_TYPE_INTEGER:
-	  i2 = DB_GET_INT (value2);
+	  i2 = db_get_int (value2);
 	  if (i2 <= 0)
 	    {
 	      goto log_error;
@@ -2717,7 +2717,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) i2) / log10 ((double) bi1);
 	  break;
 	case DB_TYPE_BIGINT:
-	  bi2 = DB_GET_BIGINT (value2);
+	  bi2 = db_get_bigint (value2);
 	  if (bi2 <= 0)
 	    {
 	      goto log_error;
@@ -2725,7 +2725,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) bi2) / log10 ((double) bi1);
 	  break;
 	case DB_TYPE_FLOAT:
-	  f2 = DB_GET_FLOAT (value2);
+	  f2 = db_get_float (value2);
 	  if (f2 <= 0)
 	    {
 	      goto log_error;
@@ -2733,7 +2733,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) f2) / log10 ((double) bi1);
 	  break;
 	case DB_TYPE_DOUBLE:
-	  d2 = DB_GET_DOUBLE (value2);
+	  d2 = db_get_double (value2);
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -2749,7 +2749,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) d2) / log10 ((double) bi1);
 	  break;
 	case DB_TYPE_MONETARY:
-	  d2 = (DB_GET_MONETARY (value2))->amount;
+	  d2 = (db_get_monetary (value2))->amount;
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -2763,7 +2763,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       break;
 
     case DB_TYPE_INTEGER:
-      i1 = DB_GET_INT (value1);
+      i1 = db_get_int (value1);
       if (i1 <= 1)
 	{
 	  goto log_error;
@@ -2772,7 +2772,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       switch (type2)
 	{
 	case DB_TYPE_SHORT:
-	  s2 = DB_GET_SHORT (value2);
+	  s2 = db_get_short (value2);
 	  if (s2 <= 0)
 	    {
 	      goto log_error;
@@ -2780,7 +2780,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) s2) / log10 ((double) i1);
 	  break;
 	case DB_TYPE_INTEGER:
-	  i2 = DB_GET_INT (value2);
+	  i2 = db_get_int (value2);
 	  if (i2 <= 0)
 	    {
 	      goto log_error;
@@ -2788,7 +2788,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) i2) / log10 ((double) i1);
 	  break;
 	case DB_TYPE_BIGINT:
-	  bi2 = DB_GET_BIGINT (value2);
+	  bi2 = db_get_bigint (value2);
 	  if (bi2 <= 0)
 	    {
 	      goto log_error;
@@ -2796,7 +2796,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) bi2) / log10 ((double) i1);
 	  break;
 	case DB_TYPE_FLOAT:
-	  f2 = DB_GET_FLOAT (value2);
+	  f2 = db_get_float (value2);
 	  if (f2 <= 0)
 	    {
 	      goto log_error;
@@ -2804,7 +2804,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) f2) / log10 ((double) i1);
 	  break;
 	case DB_TYPE_DOUBLE:
-	  d2 = DB_GET_DOUBLE (value2);
+	  d2 = db_get_double (value2);
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -2820,7 +2820,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 (d2) / log10 ((double) i1);
 	  break;
 	case DB_TYPE_MONETARY:
-	  d2 = (DB_GET_MONETARY (value2))->amount;
+	  d2 = (db_get_monetary (value2))->amount;
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -2834,7 +2834,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       break;
 
     case DB_TYPE_FLOAT:
-      f1 = DB_GET_FLOAT (value1);
+      f1 = db_get_float (value1);
       if (f1 <= 1)
 	{
 	  goto log_error;
@@ -2843,7 +2843,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       switch (type2)
 	{
 	case DB_TYPE_SHORT:
-	  s2 = DB_GET_SHORT (value2);
+	  s2 = db_get_short (value2);
 	  if (s2 <= 0)
 	    {
 	      goto log_error;
@@ -2851,7 +2851,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) s2) / log10 ((double) f1);
 	  break;
 	case DB_TYPE_INTEGER:
-	  i2 = DB_GET_INT (value2);
+	  i2 = db_get_int (value2);
 	  if (i2 <= 0)
 	    {
 	      goto log_error;
@@ -2859,7 +2859,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) i2) / log10 ((double) f1);
 	  break;
 	case DB_TYPE_BIGINT:
-	  bi2 = DB_GET_BIGINT (value2);
+	  bi2 = db_get_bigint (value2);
 	  if (bi2 <= 0)
 	    {
 	      goto log_error;
@@ -2867,7 +2867,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) bi2) / log10 ((double) f1);
 	  break;
 	case DB_TYPE_FLOAT:
-	  f2 = DB_GET_FLOAT (value2);
+	  f2 = db_get_float (value2);
 	  if (f2 <= 0)
 	    {
 	      goto log_error;
@@ -2875,7 +2875,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) f2) / log10 ((double) f1);
 	  break;
 	case DB_TYPE_DOUBLE:
-	  d2 = DB_GET_DOUBLE (value2);
+	  d2 = db_get_double (value2);
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -2891,7 +2891,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 (d2) / log10 (f1);
 	  break;
 	case DB_TYPE_MONETARY:
-	  d2 = (DB_GET_MONETARY (value2))->amount;
+	  d2 = (db_get_monetary (value2))->amount;
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -2905,7 +2905,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       break;
 
     case DB_TYPE_DOUBLE:
-      d1 = DB_GET_DOUBLE (value1);
+      d1 = db_get_double (value1);
       if (d1 <= 1)
 	{
 	  goto log_error;
@@ -2914,7 +2914,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       switch (type2)
 	{
 	case DB_TYPE_SHORT:
-	  s2 = DB_GET_SHORT (value2);
+	  s2 = db_get_short (value2);
 	  if (s2 <= 0)
 	    {
 	      goto log_error;
@@ -2922,7 +2922,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) s2) / log10 (d1);
 	  break;
 	case DB_TYPE_INTEGER:
-	  i2 = DB_GET_INT (value2);
+	  i2 = db_get_int (value2);
 	  if (i2 <= 0)
 	    {
 	      goto log_error;
@@ -2930,7 +2930,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) i2) / log10 (d1);
 	  break;
 	case DB_TYPE_BIGINT:
-	  bi2 = DB_GET_BIGINT (value2);
+	  bi2 = db_get_bigint (value2);
 	  if (bi2 <= 0)
 	    {
 	      goto log_error;
@@ -2938,7 +2938,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) bi2) / log10 (d1);
 	  break;
 	case DB_TYPE_FLOAT:
-	  f2 = DB_GET_FLOAT (value2);
+	  f2 = db_get_float (value2);
 	  if (f2 <= 0)
 	    {
 	      goto log_error;
@@ -2946,7 +2946,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) f2) / log10 (d1);
 	  break;
 	case DB_TYPE_DOUBLE:
-	  d2 = DB_GET_DOUBLE (value2);
+	  d2 = db_get_double (value2);
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -2962,7 +2962,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 (d2) / log10 (d1);
 	  break;
 	case DB_TYPE_MONETARY:
-	  d2 = (DB_GET_MONETARY (value2))->amount;
+	  d2 = (db_get_monetary (value2))->amount;
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -2985,7 +2985,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       switch (type2)
 	{
 	case DB_TYPE_SHORT:
-	  s2 = DB_GET_SHORT (value2);
+	  s2 = db_get_short (value2);
 	  if (s2 <= 0)
 	    {
 	      goto log_error;
@@ -2993,7 +2993,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) s2) / log10 (d1);
 	  break;
 	case DB_TYPE_INTEGER:
-	  i2 = DB_GET_INT (value2);
+	  i2 = db_get_int (value2);
 	  if (i2 <= 0)
 	    {
 	      goto log_error;
@@ -3001,7 +3001,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) i2) / log10 (d1);
 	  break;
 	case DB_TYPE_BIGINT:
-	  bi2 = DB_GET_BIGINT (value2);
+	  bi2 = db_get_bigint (value2);
 	  if (bi2 <= 0)
 	    {
 	      goto log_error;
@@ -3009,7 +3009,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) bi2) / log10 (d1);
 	  break;
 	case DB_TYPE_FLOAT:
-	  f2 = DB_GET_FLOAT (value2);
+	  f2 = db_get_float (value2);
 	  if (f2 <= 0)
 	    {
 	      goto log_error;
@@ -3017,7 +3017,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) f2) / log10 (d1);
 	  break;
 	case DB_TYPE_DOUBLE:
-	  d2 = DB_GET_DOUBLE (value2);
+	  d2 = db_get_double (value2);
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -3033,7 +3033,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 (d2) / log10 (d1);
 	  break;
 	case DB_TYPE_MONETARY:
-	  d2 = (DB_GET_MONETARY (value2))->amount;
+	  d2 = (db_get_monetary (value2))->amount;
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -3047,7 +3047,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       break;
 
     case DB_TYPE_MONETARY:
-      d1 = (DB_GET_MONETARY (value1))->amount;
+      d1 = (db_get_monetary (value1))->amount;
       if (d1 <= 1)
 	{
 	  goto log_error;
@@ -3056,7 +3056,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       switch (type2)
 	{
 	case DB_TYPE_SHORT:
-	  s2 = DB_GET_SHORT (value2);
+	  s2 = db_get_short (value2);
 	  if (s2 <= 0)
 	    {
 	      goto log_error;
@@ -3064,7 +3064,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) s2) / log10 (d1);
 	  break;
 	case DB_TYPE_INTEGER:
-	  i2 = DB_GET_INT (value2);
+	  i2 = db_get_int (value2);
 	  if (i2 <= 0)
 	    {
 	      goto log_error;
@@ -3072,7 +3072,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) i2) / log10 (d1);
 	  break;
 	case DB_TYPE_BIGINT:
-	  bi2 = DB_GET_BIGINT (value2);
+	  bi2 = db_get_bigint (value2);
 	  if (bi2 <= 0)
 	    {
 	      goto log_error;
@@ -3080,7 +3080,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) bi2) / log10 (d1);
 	  break;
 	case DB_TYPE_FLOAT:
-	  f2 = DB_GET_FLOAT (value2);
+	  f2 = db_get_float (value2);
 	  if (f2 <= 0)
 	    {
 	      goto log_error;
@@ -3088,7 +3088,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 ((double) f2) / log10 (d1);
 	  break;
 	case DB_TYPE_DOUBLE:
-	  d2 = DB_GET_DOUBLE (value2);
+	  d2 = db_get_double (value2);
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -3104,7 +3104,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  dtmp = log10 (d2) / log10 (d1);
 	  break;
 	case DB_TYPE_MONETARY:
-	  d2 = (DB_GET_MONETARY (value2))->amount;
+	  d2 = (db_get_monetary (value2))->amount;
 	  if (d2 <= 0)
 	    {
 	      goto log_error;
@@ -3122,7 +3122,7 @@ db_log_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       return ER_FAILED;
     }
 
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
   return NO_ERROR;
 
 log_error:
@@ -3319,8 +3319,8 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
   TP_DOMAIN *domain;
   TP_DOMAIN_STATUS cast_status;
 
-  DB_MAKE_NULL (&cast_value);
-  DB_MAKE_NULL (&cast_format);
+  db_make_null (&cast_value);
+  db_make_null (&cast_format);
 
   if (DB_IS_NULL (value1) || DB_IS_NULL (value2))
     {
@@ -3360,7 +3360,7 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       type1 = DB_TYPE_UNKNOWN;
 
       /* try type double */
-      DB_MAKE_NULL (&cast_value);
+      db_make_null (&cast_value);
       domain = tp_domain_resolve_default (DB_TYPE_DOUBLE);
       cast_status = tp_value_coerce (value1, &cast_value, domain);
       if (cast_status == DOMAIN_COMPATIBLE)
@@ -3374,7 +3374,7 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	{
 	  if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true)
 	    {
-	      DB_MAKE_NULL (result);
+	      db_make_null (result);
 	      er_clear ();
 	      er_status = NO_ERROR;
 	    }
@@ -3393,11 +3393,11 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
     {
       if (TP_IS_DATE_TYPE (type1))
 	{
-	  DB_MAKE_STRING (&cast_format, "dd");
+	  db_make_string (&cast_format, "dd");
 	}
       else
 	{
-	  DB_MAKE_INT (&cast_format, 0);
+	  db_make_int (&cast_format, 0);
 	  type2 = DB_TYPE_INTEGER;
 	}
 
@@ -3406,15 +3406,15 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
   if (type2 == DB_TYPE_INTEGER)
     {
-      bi2 = DB_GET_INT (value2);
+      bi2 = db_get_int (value2);
     }
   else if (type2 == DB_TYPE_BIGINT)
     {
-      bi2 = DB_GET_BIGINT (value2);
+      bi2 = db_get_bigint (value2);
     }
   else if (type2 == DB_TYPE_SHORT)
     {
-      bi2 = DB_GET_SHORT (value2);
+      bi2 = db_get_short (value2);
     }
   else if (type1 != DB_TYPE_DATE && type1 != DB_TYPE_DATETIME && type1 != DB_TYPE_DATETIMELTZ
 	   && type1 != DB_TYPE_DATETIMETZ && type1 != DB_TYPE_TIMESTAMP && type1 != DB_TYPE_TIMESTAMPLTZ
@@ -3426,7 +3426,7 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	{
 	  if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true)
 	    {
-	      DB_MAKE_NULL (result);
+	      db_make_null (result);
 	      er_clear ();
 	      er_status = NO_ERROR;
 	    }
@@ -3439,7 +3439,7 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  goto end;
 	}
 
-      bi2 = DB_GET_BIGINT (&cast_format);
+      bi2 = db_get_bigint (&cast_format);
     }
   else
     {
@@ -3452,36 +3452,36 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       {
 	short s1;
 
-	s1 = DB_GET_SHORT (value1);
+	s1 = db_get_short (value1);
 	dtmp = truncate_double (s1, (double) bi2);
-	DB_MAKE_SHORT (result, (short) dtmp);
+	db_make_short (result, (short) dtmp);
       }
       break;
     case DB_TYPE_INTEGER:
       {
 	int i1;
 
-	i1 = DB_GET_INT (value1);
+	i1 = db_get_int (value1);
 	dtmp = truncate_double (i1, (double) bi2);
-	DB_MAKE_INT (result, (int) dtmp);
+	db_make_int (result, (int) dtmp);
       }
       break;
     case DB_TYPE_BIGINT:
       {
 	DB_BIGINT bi1;
 
-	bi1 = DB_GET_BIGINT (value1);
+	bi1 = db_get_bigint (value1);
 	bi1 = truncate_bigint (bi1, bi2);
-	DB_MAKE_BIGINT (result, bi1);
+	db_make_bigint (result, bi1);
       }
       break;
     case DB_TYPE_FLOAT:
       {
 	float f1;
 
-	f1 = DB_GET_FLOAT (value1);
+	f1 = db_get_float (value1);
 	dtmp = truncate_double (f1, (double) bi2);
-	DB_MAKE_FLOAT (result, (float) dtmp);
+	db_make_float (result, (float) dtmp);
       }
       break;
 
@@ -3489,9 +3489,9 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       {
 	double d1;
 
-	d1 = DB_GET_DOUBLE (value1);
+	d1 = db_get_double (value1);
 	dtmp = truncate_double (d1, (double) bi2);
-	DB_MAKE_DOUBLE (result, (double) dtmp);
+	db_make_double (result, (double) dtmp);
       }
       break;
     case DB_TYPE_NUMERIC:
@@ -3527,16 +3527,16 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	      }
 	  }
 	numeric_coerce_dec_str_to_num (num_string, num);
-	DB_MAKE_NUMERIC (result, num, p, s);
+	db_make_numeric (result, num, p, s);
       }
       break;
     case DB_TYPE_MONETARY:
       {
 	double d1;
 
-	d1 = (DB_GET_MONETARY (value1))->amount;
+	d1 = (db_get_monetary (value1))->amount;
 	dtmp = truncate_double (d1, (double) bi2);
-	DB_MAKE_MONETARY_TYPE_AMOUNT (result, (DB_GET_MONETARY (value1))->type, dtmp);
+	db_make_monetary (result, (db_get_monetary (value1))->type, dtmp);
       }
       break;
     case DB_TYPE_DATE:
@@ -3548,17 +3548,17 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
     case DB_TYPE_TIMESTAMPTZ:
       if (type1 == DB_TYPE_DATE)
 	{
-	  date = *(DB_GET_DATE (value1));
+	  date = *(db_get_date (value1));
 	}
       else if (type1 == DB_TYPE_DATETIME)
 	{
-	  date = DB_GET_DATETIME (value1)->date;
+	  date = db_get_datetime (value1)->date;
 	}
       else if (type1 == DB_TYPE_DATETIMELTZ)
 	{
 	  DB_DATETIME local_dt, *p_dt;
 
-	  p_dt = DB_GET_DATETIME (value1);
+	  p_dt = db_get_datetime (value1);
 
 	  er_status = tz_datetimeltz_to_local (p_dt, &local_dt);
 	  if (er_status != NO_ERROR)
@@ -3566,7 +3566,7 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	      if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true)
 		{
 		  er_clear ();
-		  DB_MAKE_NULL (result);
+		  db_make_null (result);
 		  er_status = NO_ERROR;
 		}
 	      goto end;
@@ -3579,7 +3579,7 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	  DB_DATETIME local_dt;
 	  DB_DATETIMETZ *p_dt_tz;
 
-	  p_dt_tz = DB_GET_DATETIMETZ (value1);
+	  p_dt_tz = db_get_datetimetz (value1);
 
 	  er_status = tz_utc_datetimetz_to_local (&p_dt_tz->datetime, &p_dt_tz->tz_id, &local_dt);
 
@@ -3588,7 +3588,7 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	      if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true)
 		{
 		  er_clear ();
-		  DB_MAKE_NULL (result);
+		  db_make_null (result);
 		  er_status = NO_ERROR;
 		}
 	      goto end;
@@ -3607,7 +3607,7 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 	      if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true)
 		{
 		  er_clear ();
-		  DB_MAKE_NULL (result);
+		  db_make_null (result);
 		  er_status = NO_ERROR;
 		}
 	      goto end;
@@ -3616,7 +3616,7 @@ db_trunc_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       else
 	{
 	  assert (type1 == DB_TYPE_TIMESTAMP || type1 == DB_TYPE_TIMESTAMPLTZ);
-	  (void) db_timestamp_decode_ses (DB_GET_TIMESTAMP (value1), &date, NULL);
+	  (void) db_timestamp_decode_ses (db_get_timestamp (value1), &date, NULL);
 	}
 
       er_status = truncate_date (&date, value2);
@@ -3658,7 +3658,7 @@ end:
 int
 db_random_dbval (DB_VALUE * result)
 {
-  DB_MAKE_INTEGER (result, lrand48 ());
+  db_make_int (result, lrand48 ());
 
   return NO_ERROR;
 }
@@ -3671,7 +3671,7 @@ db_random_dbval (DB_VALUE * result)
 int
 db_drandom_dbval (DB_VALUE * result)
 {
-  DB_MAKE_DOUBLE (result, drand48 ());
+  db_make_double (result, drand48 ());
 
   return NO_ERROR;
 }
@@ -3694,29 +3694,29 @@ get_number_dbval_as_double (double *d, const DB_VALUE * value)
   switch (DB_VALUE_DOMAIN_TYPE (value))
     {
     case DB_TYPE_SHORT:
-      s = DB_GET_SHORT (value);
+      s = db_get_short (value);
       dtmp = (double) s;
       break;
     case DB_TYPE_INTEGER:
-      i = DB_GET_INT (value);
+      i = db_get_int (value);
       dtmp = (double) i;
       break;
     case DB_TYPE_BIGINT:
-      bi = DB_GET_BIGINT (value);
+      bi = db_get_bigint (value);
       dtmp = (double) bi;
       break;
     case DB_TYPE_FLOAT:
-      f = DB_GET_FLOAT (value);
+      f = db_get_float (value);
       dtmp = (double) f;
       break;
     case DB_TYPE_DOUBLE:
-      dtmp = DB_GET_DOUBLE (value);
+      dtmp = db_get_double (value);
       break;
     case DB_TYPE_NUMERIC:
       numeric_coerce_num_to_double ((DB_C_NUMERIC) db_locate_numeric (value), DB_VALUE_SCALE (value), &dtmp);
       break;
     case DB_TYPE_MONETARY:
-      dtmp = (DB_GET_MONETARY (value))->amount;
+      dtmp = (db_get_monetary (value))->amount;
       break;
     default:
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
@@ -3743,7 +3743,7 @@ db_cos_dbval (DB_VALUE * result, DB_VALUE * value)
   type = DB_VALUE_DOMAIN_TYPE (value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -3755,7 +3755,7 @@ db_cos_dbval (DB_VALUE * result, DB_VALUE * value)
 
   dtmp = cos (dtmp);
 
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
   return NO_ERROR;
 }
 
@@ -3775,7 +3775,7 @@ db_sin_dbval (DB_VALUE * result, DB_VALUE * value)
   type = DB_VALUE_DOMAIN_TYPE (value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -3787,7 +3787,7 @@ db_sin_dbval (DB_VALUE * result, DB_VALUE * value)
 
   dtmp = sin (dtmp);
 
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
   return NO_ERROR;
 }
 
@@ -3807,7 +3807,7 @@ db_tan_dbval (DB_VALUE * result, DB_VALUE * value)
   type = DB_VALUE_DOMAIN_TYPE (value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -3819,7 +3819,7 @@ db_tan_dbval (DB_VALUE * result, DB_VALUE * value)
 
   dtmp = tan (dtmp);
 
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
   return NO_ERROR;
 }
 
@@ -3839,7 +3839,7 @@ db_cot_dbval (DB_VALUE * result, DB_VALUE * value)
   type = DB_VALUE_DOMAIN_TYPE (value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -3851,12 +3851,12 @@ db_cot_dbval (DB_VALUE * result, DB_VALUE * value)
 
   if (dtmp == 0)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
   else
     {
       dtmp = 1 / tan (dtmp);
-      DB_MAKE_DOUBLE (result, dtmp);
+      db_make_double (result, dtmp);
     }
 
   return NO_ERROR;
@@ -3878,7 +3878,7 @@ db_acos_dbval (DB_VALUE * result, DB_VALUE * value)
   type = DB_VALUE_DOMAIN_TYPE (value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -3895,13 +3895,13 @@ db_acos_dbval (DB_VALUE * result, DB_VALUE * value)
 
   dtmp = acos (dtmp);
 
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
   return NO_ERROR;
 
 error:
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) == COMPAT_MYSQL)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
   else
@@ -3927,7 +3927,7 @@ db_asin_dbval (DB_VALUE * result, DB_VALUE * value)
   type = DB_VALUE_DOMAIN_TYPE (value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -3944,13 +3944,13 @@ db_asin_dbval (DB_VALUE * result, DB_VALUE * value)
 
   dtmp = asin (dtmp);
 
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
   return NO_ERROR;
 
 error:
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) == COMPAT_MYSQL)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
   else
@@ -3976,7 +3976,7 @@ db_atan_dbval (DB_VALUE * result, DB_VALUE * value)
   type = DB_VALUE_DOMAIN_TYPE (value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -3988,7 +3988,7 @@ db_atan_dbval (DB_VALUE * result, DB_VALUE * value)
 
   dtmp = atan (dtmp);
 
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
   return NO_ERROR;
 }
 
@@ -4013,7 +4013,7 @@ db_atan2_dbval (DB_VALUE * result, DB_VALUE * value, DB_VALUE * value2)
   type = DB_VALUE_DOMAIN_TYPE (value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -4027,7 +4027,7 @@ db_atan2_dbval (DB_VALUE * result, DB_VALUE * value, DB_VALUE * value2)
   type2 = DB_VALUE_DOMAIN_TYPE (value2);
   if (type2 == DB_TYPE_NULL || DB_IS_NULL (value2))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -4040,7 +4040,7 @@ db_atan2_dbval (DB_VALUE * result, DB_VALUE * value, DB_VALUE * value2)
   /* function call, all is double type */
   dtmp = atan2 (d, d2);
 
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
   return NO_ERROR;
 }
 
@@ -4060,7 +4060,7 @@ db_degrees_dbval (DB_VALUE * result, DB_VALUE * value)
   type = DB_VALUE_DOMAIN_TYPE (value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -4071,7 +4071,7 @@ db_degrees_dbval (DB_VALUE * result, DB_VALUE * value)
     }
 
   dtmp = dtmp * (double) 57.295779513082320876798154814105;	/* 180 / PI */
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
 
   return NO_ERROR;
 }
@@ -4092,7 +4092,7 @@ db_radians_dbval (DB_VALUE * result, DB_VALUE * value)
   type = DB_VALUE_DOMAIN_TYPE (value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -4103,7 +4103,7 @@ db_radians_dbval (DB_VALUE * result, DB_VALUE * value)
     }
 
   dtmp = dtmp * (double) 0.017453292519943295769236907684886;	/* PI / 180 */
-  DB_MAKE_DOUBLE (result, dtmp);
+  db_make_double (result, dtmp);
 
   return NO_ERROR;
 }
@@ -4125,7 +4125,7 @@ db_log_generic_dbval (DB_VALUE * result, DB_VALUE * value, long b)
   type = DB_VALUE_DOMAIN_TYPE (value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -4138,7 +4138,7 @@ db_log_generic_dbval (DB_VALUE * result, DB_VALUE * value, long b)
   if (dtmp > 0)
     {
       dtmp = log10 (dtmp) / log10 (base);
-      DB_MAKE_DOUBLE (result, dtmp);
+      db_make_double (result, dtmp);
     }
   else
     {
@@ -4195,14 +4195,14 @@ db_bit_count_dbval (DB_VALUE * result, DB_VALUE * value)
 
   if (DB_IS_NULL (value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
   else
     {
       switch (type)
 	{
 	case DB_TYPE_SHORT:
-	  s = DB_GET_SHORT (value);
+	  s = db_get_short (value);
 	  for (c = 0; s; c++)
 	    {
 	      s &= s - 1;
@@ -4210,7 +4210,7 @@ db_bit_count_dbval (DB_VALUE * result, DB_VALUE * value)
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  i = DB_GET_INTEGER (value);
+	  i = db_get_int (value);
 	  for (c = 0; i; c++)
 	    {
 	      i &= i - 1;
@@ -4218,7 +4218,7 @@ db_bit_count_dbval (DB_VALUE * result, DB_VALUE * value)
 	  break;
 
 	case DB_TYPE_BIGINT:
-	  bi = DB_GET_BIGINT (value);
+	  bi = db_get_bigint (value);
 	  for (c = 0; bi; c++)
 	    {
 	      bi &= bi - 1;
@@ -4226,7 +4226,7 @@ db_bit_count_dbval (DB_VALUE * result, DB_VALUE * value)
 	  break;
 
 	case DB_TYPE_FLOAT:
-	  f = DB_GET_FLOAT (value);
+	  f = db_get_float (value);
 	  if (f < 0)
 	    {
 	      i = (int) (f - 0.5f);
@@ -4242,7 +4242,7 @@ db_bit_count_dbval (DB_VALUE * result, DB_VALUE * value)
 	  break;
 
 	case DB_TYPE_MONETARY:
-	  d = (DB_GET_MONETARY (value))->amount;
+	  d = (db_get_monetary (value))->amount;
 	  if (d < 0)
 	    {
 	      bi = (DB_BIGINT) (d - 0.5f);
@@ -4266,7 +4266,7 @@ db_bit_count_dbval (DB_VALUE * result, DB_VALUE * value)
 	  tmpval_p = &tmpval;
 	  /* no break here */
 	case DB_TYPE_DOUBLE:
-	  d = DB_GET_DOUBLE (tmpval_p);
+	  d = db_get_double (tmpval_p);
 	  if (d < 0)
 	    {
 	      bi = (DB_BIGINT) (d - 0.5f);
@@ -4286,7 +4286,7 @@ db_bit_count_dbval (DB_VALUE * result, DB_VALUE * value)
 	  return ER_QPROC_INVALID_DATATYPE;
 	}
 
-      DB_MAKE_INT (result, c);
+      db_make_int (result, c);
     }
 
   return NO_ERROR;
@@ -4370,27 +4370,27 @@ get_number_dbval_as_long_double (long double *ld, const DB_VALUE * value)
   switch (DB_VALUE_DOMAIN_TYPE (value))
     {
     case DB_TYPE_SHORT:
-      s = DB_GET_SHORT (value);
+      s = db_get_short (value);
       dtmp = (long double) s;
       break;
 
     case DB_TYPE_INTEGER:
-      i = DB_GET_INT (value);
+      i = db_get_int (value);
       dtmp = (long double) i;
       break;
 
     case DB_TYPE_BIGINT:
-      bi = DB_GET_BIGINT (value);
+      bi = db_get_bigint (value);
       dtmp = (long double) bi;
       break;
 
     case DB_TYPE_FLOAT:
-      f = DB_GET_FLOAT (value);
+      f = db_get_float (value);
       dtmp = (long double) f;
       break;
 
     case DB_TYPE_DOUBLE:
-      dtmp = (long double) DB_GET_DOUBLE (value);
+      dtmp = (long double) db_get_double (value);
       break;
 
     case DB_TYPE_NUMERIC:
@@ -4403,7 +4403,7 @@ get_number_dbval_as_long_double (long double *ld, const DB_VALUE * value)
       break;
 
     case DB_TYPE_MONETARY:
-      dtmp = (long double) (DB_GET_MONETARY (value))->amount;
+      dtmp = (long double) (db_get_monetary (value))->amount;
       break;
 
     default:
@@ -4436,11 +4436,11 @@ db_width_bucket_calculate_numeric (double *result, const DB_VALUE * value1, cons
   assert (DB_VALUE_TYPE (value1) == DB_TYPE_NUMERIC && DB_VALUE_TYPE (value2) == DB_TYPE_NUMERIC
 	  && DB_VALUE_TYPE (value3) == DB_TYPE_NUMERIC && DB_VALUE_TYPE (value4) == DB_TYPE_NUMERIC);
 
-  DB_MAKE_NULL (&cmp_result);
-  DB_MAKE_NULL (&n1);
-  DB_MAKE_NULL (&n2);
-  DB_MAKE_NULL (&n3);
-  DB_MAKE_NULL (&n4);
+  db_make_null (&cmp_result);
+  db_make_null (&n1);
+  db_make_null (&n2);
+  db_make_null (&n3);
+  db_make_null (&n4);
 
   er_status = numeric_db_value_compare (value2, value3, &cmp_result);
   if (er_status != NO_ERROR)
@@ -4448,7 +4448,7 @@ db_width_bucket_calculate_numeric (double *result, const DB_VALUE * value1, cons
       return er_status;
     }
 
-  c = DB_GET_INTEGER (&cmp_result);
+  c = db_get_int (&cmp_result);
   if (c == 0 || c == -1)
     {
       /* value2 <= value3 */
@@ -4459,7 +4459,7 @@ db_width_bucket_calculate_numeric (double *result, const DB_VALUE * value1, cons
 	  return er_status;
 	}
 
-      if (DB_GET_INTEGER (&cmp_result) < 0)
+      if (db_get_int (&cmp_result) < 0)
 	{
 	  res = 0.0;
 	}
@@ -4471,9 +4471,9 @@ db_width_bucket_calculate_numeric (double *result, const DB_VALUE * value1, cons
 	      return er_status;
 	    }
 
-	  if (DB_GET_INTEGER (&cmp_result) < 1)
+	  if (db_get_int (&cmp_result) < 1)
 	    {
-	      numeric_coerce_num_to_double ((DB_C_NUMERIC) DB_GET_NUMERIC (value4), DB_VALUE_SCALE (value4), &res);
+	      numeric_coerce_num_to_double ((DB_C_NUMERIC) db_get_numeric (value4), DB_VALUE_SCALE (value4), &res);
 	      res += 1.0;
 	    }
 	  else
@@ -4503,7 +4503,7 @@ db_width_bucket_calculate_numeric (double *result, const DB_VALUE * value1, cons
 		  return er_status;
 		}
 
-	      numeric_coerce_num_to_double (DB_GET_NUMERIC (&n4), DB_VALUE_SCALE (&n4), &res);
+	      numeric_coerce_num_to_double (db_get_numeric (&n4), DB_VALUE_SCALE (&n4), &res);
 	      if (OR_CHECK_DOUBLE_OVERFLOW (res))
 		{
 		  return ER_IT_DATA_OVERFLOW;
@@ -4524,7 +4524,7 @@ db_width_bucket_calculate_numeric (double *result, const DB_VALUE * value1, cons
 	  return er_status;
 	}
 
-      if (DB_GET_INTEGER (&cmp_result) < 0)
+      if (db_get_int (&cmp_result) < 0)
 	{
 	  res = 0.0;
 	}
@@ -4536,9 +4536,9 @@ db_width_bucket_calculate_numeric (double *result, const DB_VALUE * value1, cons
 	      return er_status;
 	    }
 
-	  if (DB_GET_INTEGER (&cmp_result) < 1)
+	  if (db_get_int (&cmp_result) < 1)
 	    {
-	      numeric_coerce_num_to_double ((DB_C_NUMERIC) DB_GET_NUMERIC (value4), DB_VALUE_SCALE (value4), &res);
+	      numeric_coerce_num_to_double ((DB_C_NUMERIC) db_get_numeric (value4), DB_VALUE_SCALE (value4), &res);
 	      res += 1.0;
 	    }
 	  else
@@ -4568,7 +4568,7 @@ db_width_bucket_calculate_numeric (double *result, const DB_VALUE * value1, cons
 		  return er_status;
 		}
 
-	      numeric_coerce_num_to_double (DB_GET_NUMERIC (&n4), DB_VALUE_SCALE (&n4), &res);
+	      numeric_coerce_num_to_double (db_get_numeric (&n4), DB_VALUE_SCALE (&n4), &res);
 	      if (OR_CHECK_DOUBLE_OVERFLOW (res))
 		{
 		  return ER_IT_DATA_OVERFLOW;
@@ -4603,7 +4603,7 @@ db_width_bucket (DB_VALUE * result, const DB_VALUE * value1, const DB_VALUE * va
     { \
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true) \
 	{ \
-	  DB_MAKE_NULL (result); \
+	  db_make_null (result); \
 	  er_clear (); \
 	  return NO_ERROR; \
 	} \
@@ -4620,7 +4620,7 @@ db_width_bucket (DB_VALUE * result, const DB_VALUE * value1, const DB_VALUE * va
     { \
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true) \
         { \
-          DB_MAKE_NULL (result); \
+          db_make_null (result); \
           er_clear (); \
           return NO_ERROR; \
         } \
@@ -4648,19 +4648,19 @@ db_width_bucket (DB_VALUE * result, const DB_VALUE * value1, const DB_VALUE * va
 
   assert (result != NULL && value1 != NULL && value2 != NULL && value3 != NULL && value4 != NULL);
 
-  DB_MAKE_NULL (&cast_value1);
-  DB_MAKE_NULL (&cast_value2);
-  DB_MAKE_NULL (&cast_value3);
-  DB_MAKE_NULL (&cast_value4);
+  db_make_null (&cast_value1);
+  db_make_null (&cast_value2);
+  db_make_null (&cast_value3);
+  db_make_null (&cast_value4);
 
   if (DB_VALUE_TYPE (value1) == DB_TYPE_NULL || DB_VALUE_TYPE (value2) == DB_TYPE_NULL
       || DB_VALUE_TYPE (value3) == DB_TYPE_NULL || DB_VALUE_TYPE (value4) == DB_TYPE_NULL)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
-  d4 = DB_GET_DOUBLE (value4);
+  d4 = db_get_double (value4);
   if (d4 < 1 || d4 >= DB_INT32_MAX)
     {
       RETURN_ERROR (ER_PROC_WIDTH_BUCKET_COUNT);
@@ -4747,61 +4747,61 @@ db_width_bucket (DB_VALUE * result, const DB_VALUE * value1, const DB_VALUE * va
   switch (type)
     {
     case DB_TYPE_DATE:
-      d1 = (double) *DB_GET_DATE (value1);
-      d2 = (double) *DB_GET_DATE (value2);
-      d3 = (double) *DB_GET_DATE (value3);
+      d1 = (double) *db_get_date (value1);
+      d2 = (double) *db_get_date (value2);
+      d3 = (double) *db_get_date (value3);
       break;
 
     case DB_TYPE_DATETIME:
     case DB_TYPE_DATETIMELTZ:
       /* double can hold datetime type */
-      d1 = ((double) DB_GET_DATETIME (value1)->date) * MILLISECONDS_OF_ONE_DAY + DB_GET_DATETIME (value1)->time;
-      d2 = ((double) DB_GET_DATETIME (value2)->date) * MILLISECONDS_OF_ONE_DAY + DB_GET_DATETIME (value2)->time;
-      d3 = ((double) DB_GET_DATETIME (value3)->date) * MILLISECONDS_OF_ONE_DAY + DB_GET_DATETIME (value3)->time;
+      d1 = ((double) db_get_datetime (value1)->date) * MILLISECONDS_OF_ONE_DAY + db_get_datetime (value1)->time;
+      d2 = ((double) db_get_datetime (value2)->date) * MILLISECONDS_OF_ONE_DAY + db_get_datetime (value2)->time;
+      d3 = ((double) db_get_datetime (value3)->date) * MILLISECONDS_OF_ONE_DAY + db_get_datetime (value3)->time;
       break;
 
     case DB_TYPE_DATETIMETZ:
       /* double can hold datetime type */
-      d1 = (((double) DB_GET_DATETIMETZ (value1)->datetime.date) * MILLISECONDS_OF_ONE_DAY
-	    + DB_GET_DATETIMETZ (value1)->datetime.time);
-      d2 = (((double) DB_GET_DATETIMETZ (value2)->datetime.date) * MILLISECONDS_OF_ONE_DAY
-	    + DB_GET_DATETIMETZ (value2)->datetime.time);
-      d3 = (((double) DB_GET_DATETIMETZ (value3)->datetime.date) * MILLISECONDS_OF_ONE_DAY
-	    + DB_GET_DATETIMETZ (value3)->datetime.time);
+      d1 = (((double) db_get_datetimetz (value1)->datetime.date) * MILLISECONDS_OF_ONE_DAY
+	    + db_get_datetimetz (value1)->datetime.time);
+      d2 = (((double) db_get_datetimetz (value2)->datetime.date) * MILLISECONDS_OF_ONE_DAY
+	    + db_get_datetimetz (value2)->datetime.time);
+      d3 = (((double) db_get_datetimetz (value3)->datetime.date) * MILLISECONDS_OF_ONE_DAY
+	    + db_get_datetimetz (value3)->datetime.time);
       break;
 
     case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
-      d1 = (double) *DB_GET_TIMESTAMP (value1);
-      d2 = (double) *DB_GET_TIMESTAMP (value2);
-      d3 = (double) *DB_GET_TIMESTAMP (value3);
+      d1 = (double) *db_get_timestamp (value1);
+      d2 = (double) *db_get_timestamp (value2);
+      d3 = (double) *db_get_timestamp (value3);
       break;
 
     case DB_TYPE_TIMESTAMPTZ:
-      d1 = (double) (DB_GET_TIMESTAMPTZ (value1)->timestamp);
-      d2 = (double) (DB_GET_TIMESTAMPTZ (value2)->timestamp);
-      d3 = (double) (DB_GET_TIMESTAMPTZ (value3)->timestamp);
+      d1 = (double) (db_get_timestamptz (value1)->timestamp);
+      d2 = (double) (db_get_timestamptz (value2)->timestamp);
+      d3 = (double) (db_get_timestamptz (value3)->timestamp);
       break;
 
 
     case DB_TYPE_TIME:
-      d1 = (double) *DB_GET_TIME (value1);
-      d2 = (double) *DB_GET_TIME (value2);
-      d3 = (double) *DB_GET_TIME (value3);
+      d1 = (double) *db_get_time (value1);
+      d2 = (double) *db_get_time (value2);
+      d3 = (double) *db_get_time (value3);
       break;
 
     case DB_TYPE_TIMELTZ:
-      er_status = tz_timeltz_to_local (DB_GET_TIME (value1), &time_local);
+      er_status = tz_timeltz_to_local (db_get_time (value1), &time_local);
       if (er_status == NO_ERROR)
 	{
 	  d1 = (double) time_local;
-	  er_status = tz_timeltz_to_local (DB_GET_TIME (value2), &time_local);
+	  er_status = tz_timeltz_to_local (db_get_time (value2), &time_local);
 	}
 
       if (er_status == NO_ERROR)
 	{
 	  d2 = (double) time_local;
-	  er_status = tz_timeltz_to_local (DB_GET_TIME (value3), &time_local);
+	  er_status = tz_timeltz_to_local (db_get_time (value3), &time_local);
 	}
 
       if (er_status == NO_ERROR)
@@ -4815,19 +4815,19 @@ db_width_bucket (DB_VALUE * result, const DB_VALUE * value1, const DB_VALUE * va
       break;
 
     case DB_TYPE_TIMETZ:
-      er_status = tz_utc_timetz_to_local (&DB_GET_TIMETZ (value1)->time, &DB_GET_TIMETZ (value1)->tz_id, &time_local);
+      er_status = tz_utc_timetz_to_local (&db_get_timetz (value1)->time, &db_get_timetz (value1)->tz_id, &time_local);
       if (er_status == NO_ERROR)
 	{
 	  d1 = (double) time_local;
 	  er_status =
-	    tz_utc_timetz_to_local (&DB_GET_TIMETZ (value2)->time, &DB_GET_TIMETZ (value2)->tz_id, &time_local);
+	    tz_utc_timetz_to_local (&db_get_timetz (value2)->time, &db_get_timetz (value2)->tz_id, &time_local);
 	}
 
       if (er_status == NO_ERROR)
 	{
 	  d2 = (double) time_local;
 	  er_status =
-	    tz_utc_timetz_to_local (&DB_GET_TIMETZ (value3)->time, &DB_GET_TIMETZ (value3)->tz_id, &time_local);
+	    tz_utc_timetz_to_local (&db_get_timetz (value3)->time, &db_get_timetz (value3)->tz_id, &time_local);
 	}
 
       if (er_status == NO_ERROR)
@@ -4920,7 +4920,7 @@ db_width_bucket (DB_VALUE * result, const DB_VALUE * value1, const DB_VALUE * va
 	  value3 = &cast_value3;
 	}
 
-      DB_MAKE_INT (&cast_value4, ((int) d4));
+      db_make_int (&cast_value4, ((int) d4));
       cast_domain->precision = DB_INTEGER_PRECISION;
       cast_domain->scale = 0;
       cast_status = tp_value_coerce (&cast_value4, &cast_value4, cast_domain);
@@ -5008,7 +5008,7 @@ db_width_bucket (DB_VALUE * result, const DB_VALUE * value1, const DB_VALUE * va
       RETURN_ERROR (ER_QPROC_OVERFLOW_ADDITION);
     }
 
-  DB_MAKE_INT (result, ((int) d_ret));
+  db_make_int (result, ((int) d_ret));
 
   return er_status;
 
@@ -5031,9 +5031,9 @@ db_sleep (DB_VALUE * result, DB_VALUE * value)
   assert (result != NULL && value != NULL);
   assert (DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_NULL || DB_VALUE_DOMAIN_TYPE (value) == DB_TYPE_DOUBLE);
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
-  if (DB_IS_NULL (value) || DB_GET_DOUBLE (value) < 0.0)
+  if (DB_IS_NULL (value) || db_get_double (value) < 0.0)
     {
       error = ER_OBJ_INVALID_ARGUMENTS;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
@@ -5041,16 +5041,16 @@ db_sleep (DB_VALUE * result, DB_VALUE * value)
       goto end;
     }
 
-  million_sec = (long) (DB_GET_DOUBLE (value) * 1000L);
+  million_sec = (long) (db_get_double (value) * 1000L);
 
   error = msleep (million_sec);
   if (error == NO_ERROR)
     {
-      DB_MAKE_INT (result, 0);
+      db_make_int (result, 0);
     }
   else
     {
-      DB_MAKE_INT (result, 1);
+      db_make_int (result, 1);
 
       error = NO_ERROR;
     }
@@ -5086,13 +5086,13 @@ db_crc32_dbval (DB_VALUE * result, DB_VALUE * value)
 
       if (QSTR_IS_ANY_CHAR (type))
 	{
-	  error_status = crypt_crc32 (NULL, db_get_string (value), DB_GET_STRING_SIZE (value), &hash_result);
+	  error_status = crypt_crc32 (NULL, db_get_string (value), db_get_string_size (value), &hash_result);
 	  if (error_status != NO_ERROR)
 	    {
 	      goto error;
 	    }
 
-	  DB_MAKE_INT (result, hash_result);
+	  db_make_int (result, hash_result);
 	}
       else
 	{
@@ -5130,10 +5130,10 @@ db_json_contains_dbval (const DB_VALUE * json, const DB_VALUE * value, const DB_
 
   if (DB_IS_NULL (json) || DB_IS_NULL (value) || (path != NULL && DB_IS_NULL (path)))
     {
-      return DB_MAKE_NULL (result);
+      return db_make_null (result);
     }
 
-  this_doc = DB_GET_JSON_DOCUMENT (json);
+  this_doc = db_get_json_document (json);
 
   if (path != NULL)
     {
@@ -5149,7 +5149,7 @@ db_json_contains_dbval (const DB_VALUE * json, const DB_VALUE * value, const DB_
     }
   else
     {
-      result_doc = DB_GET_JSON_DOCUMENT (json);
+      result_doc = db_get_json_document (json);
     }
 
   if (result_doc != NULL)
@@ -5159,7 +5159,7 @@ db_json_contains_dbval (const DB_VALUE * json, const DB_VALUE * value, const DB_
 
       assert (value->domain.general_info.type == DB_TYPE_JSON);
 
-      error_code = db_json_value_is_contained_in_doc (result_doc, DB_GET_JSON_DOCUMENT (value), has_member);
+      error_code = db_json_value_is_contained_in_doc (result_doc, db_get_json_document (value), has_member);
       if (doc_needs_clear)
 	{
 	  db_json_delete_doc (result_doc);
@@ -5168,11 +5168,11 @@ db_json_contains_dbval (const DB_VALUE * json, const DB_VALUE * value, const DB_
 	{
 	  return error_code;
 	}
-      return DB_MAKE_INT (result, has_member ? 1 : 0);
+      return db_make_int (result, has_member ? 1 : 0);
     }
   else
     {
-      return DB_MAKE_NULL (result);
+      return db_make_null (result);
     }
 }
 
@@ -5181,19 +5181,19 @@ db_json_type_dbval (const DB_VALUE * json, DB_VALUE * type_res)
 {
   if (DB_IS_NULL (json))
     {
-      return DB_MAKE_NULL (type_res);
+      return db_make_null (type_res);
     }
   else
     {
       const char *type;
       unsigned int length;
 
-      assert (DB_GET_JSON_RAW_BODY (json) != NULL);
+      assert (db_get_json_raw_body (json) != NULL);
 
-      type = db_json_get_type_as_str (DB_GET_JSON_DOCUMENT (json));
+      type = db_json_get_type_as_str (db_get_json_document (json));
       length = strlen (type);
 
-      return DB_MAKE_CHAR (type_res, length, (DB_C_CHAR) type, length, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
+      return db_make_char (type_res, length, (DB_C_CHAR) type, length, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
     }
 }
 
@@ -5202,13 +5202,13 @@ db_json_valid_dbval (const DB_VALUE * json, DB_VALUE * type_res)
 {
   if (DB_IS_NULL (json))
     {
-      return DB_MAKE_NULL (type_res);
+      return db_make_null (type_res);
     }
   else
     {
       bool valid = db_json_is_valid (db_get_string (json));
 
-      return DB_MAKE_INT (type_res, (int) valid);
+      return db_make_int (type_res, (int) valid);
     }
 }
 
@@ -5221,7 +5221,7 @@ db_json_length_dbval (const DB_VALUE * json, const DB_VALUE * path, DB_VALUE * r
 
   if (DB_IS_NULL (json) || (path != NULL && DB_IS_NULL (path)))
     {
-      return DB_MAKE_NULL (res);
+      return db_make_null (res);
     }
   else
     {
@@ -5231,7 +5231,7 @@ db_json_length_dbval (const DB_VALUE * json, const DB_VALUE * path, DB_VALUE * r
 	{
 	  const char *raw_path = db_get_string (path);
 
-	  error_code = db_json_extract_document_from_path (DB_GET_JSON_DOCUMENT (json), raw_path, this_doc);
+	  error_code = db_json_extract_document_from_path (db_get_json_document (json), raw_path, this_doc);
 	  if (error_code != NO_ERROR)
 	    {
 	      assert (this_doc == NULL);
@@ -5241,7 +5241,7 @@ db_json_length_dbval (const DB_VALUE * json, const DB_VALUE * path, DB_VALUE * r
 	}
       else
 	{
-	  this_doc = DB_GET_JSON_DOCUMENT (json);
+	  this_doc = db_get_json_document (json);
 	}
 
       if (this_doc != NULL)
@@ -5252,11 +5252,11 @@ db_json_length_dbval (const DB_VALUE * json, const DB_VALUE * path, DB_VALUE * r
 	    {
 	      db_json_delete_doc (this_doc);
 	    }
-	  return DB_MAKE_INT (res, length);
+	  return db_make_int (res, length);
 	}
       else
 	{
-	  return DB_MAKE_NULL (res);
+	  return db_make_null (res);
 	}
     }
 }
@@ -5266,13 +5266,13 @@ db_json_depth_dbval (DB_VALUE * json, DB_VALUE * res)
 {
   if (DB_IS_NULL (json))
     {
-      return DB_MAKE_NULL (res);
+      return db_make_null (res);
     }
   else
     {
-      unsigned int depth = db_json_get_depth (DB_GET_JSON_DOCUMENT (json));
+      unsigned int depth = db_json_get_depth (db_get_json_document (json));
 
-      return DB_MAKE_INT (res, depth);
+      return db_make_int (res, depth);
     }
 }
 
@@ -5287,10 +5287,10 @@ db_json_extract_dbval (const DB_VALUE * json, const DB_VALUE * path, DB_VALUE * 
 
   if (DB_IS_NULL (json) || DB_IS_NULL (path))
     {
-      return DB_MAKE_NULL (json_res);
+      return db_make_null (json_res);
     }
 
-  this_doc = DB_GET_JSON_DOCUMENT (json);
+  this_doc = db_get_json_document (json);
   raw_path = db_get_string (path);
 
   error_code = db_json_extract_document_from_path (this_doc, raw_path, result_doc);
@@ -5307,7 +5307,7 @@ db_json_extract_dbval (const DB_VALUE * json, const DB_VALUE * path, DB_VALUE * 
     }
   else
     {
-      DB_MAKE_NULL (json_res);
+      db_make_null (json_res);
     }
 
   return NO_ERROR;

--- a/src/query/cursor.c
+++ b/src/query/cursor.c
@@ -230,7 +230,7 @@ cursor_fixup_set_vobjs (DB_VALUE * value_p)
       return ER_FAILED;
     }
 
-  set = DB_GET_SET (value_p);
+  set = db_get_set (value_p);
   size = db_set_size (set);
 
   if (cursor_has_set_vobjs (set) == false)
@@ -289,13 +289,13 @@ cursor_fixup_set_vobjs (DB_VALUE * value_p)
   switch (type)
     {
     case DB_TYPE_SET:
-      DB_MAKE_SET (value_p, new_set);
+      db_make_set (value_p, new_set);
       break;
     case DB_TYPE_MULTISET:
-      DB_MAKE_MULTISET (value_p, new_set);
+      db_make_multiset (value_p, new_set);
       break;
     case DB_TYPE_SEQUENCE:
-      DB_MAKE_SEQUENCE (value_p, new_set);
+      db_make_sequence (value_p, new_set);
       break;
     default:
       db_set_free (new_set);
@@ -323,7 +323,7 @@ cursor_fixup_vobjs (DB_VALUE * value_p)
     {
     case DB_TYPE_OID:
       rc = vid_oid_to_object (value_p, &obj);
-      DB_MAKE_OBJECT (value_p, obj);
+      db_make_object (value_p, obj);
       break;
 
     case DB_TYPE_VOBJ:
@@ -337,7 +337,7 @@ cursor_fixup_vobjs (DB_VALUE * value_p)
 	{
 	  rc = vid_vobj_to_object (value_p, &obj);
 	  pr_clear_value (value_p);
-	  DB_MAKE_OBJECT (value_p, obj);
+	  db_make_object (value_p, obj);
 	}
       break;
 
@@ -389,7 +389,7 @@ cursor_copy_vobj_to_dbvalue (OR_BUF * buffer_p, DB_VALUE * value_p)
 
   /* convert the vobj into a vmop */
   rc = vid_vobj_to_object (&vobj_dbval, &object_p);
-  DB_MAKE_OBJECT (value_p, object_p);
+  db_make_object (value_p, object_p);
   pr_clear_value (&vobj_dbval);
 
   return rc;
@@ -632,11 +632,11 @@ cursor_get_oid_from_vobj (OID * current_oid_p, int length)
   vobject_p = (char *) current_oid_p;
   current_oid_p = NULL;
   or_init (&buffer, vobject_p, length);
-  DB_MAKE_NULL (&value);
+  db_make_null (&value);
 
   if (cursor_copy_vobj_to_dbvalue (&buffer, &value) == NO_ERROR)
     {
-      tmp_object_p = DB_GET_OBJECT (&value);
+      tmp_object_p = db_get_object (&value);
 
       if (vid_is_updatable (tmp_object_p) == true)
 	{
@@ -1147,7 +1147,7 @@ cursor_print_list (QUERY_ID query_id, QFILE_LIST_ID * list_id_p)
 
 	  if (TP_IS_SET_TYPE (DB_VALUE_TYPE (value_p)) || DB_VALUE_TYPE (value_p) == DB_TYPE_VOBJ)
 	    {
-	      db_set_print (DB_GET_SET (value_p));
+	      db_set_print (db_get_set (value_p));
 	    }
 	  else
 	    {

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -4379,7 +4379,7 @@ do_is_partitioned_subclass (int *is_partitioned, const char *classname, char *ke
 	  keyattr[0] = 0;
 
 	  if (set_get_element_nocopy (smclass->partition->values, 0, &attrname) == NO_ERROR && !DB_IS_NULL (&attrname)
-	      && (p = DB_GET_STRING (&attrname)))
+	      && (p = db_get_string (&attrname)))
 	    {
 	      strncpy (keyattr, p, DB_MAX_IDENTIFIER_LENGTH);
 	      if (strlen (p) < DB_MAX_IDENTIFIER_LENGTH)
@@ -6934,7 +6934,7 @@ do_add_attribute (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * attri
   DB_DEFAULT_EXPR default_expr;
   PARSER_VARCHAR *comment_str = NULL;
 
-  DB_MAKE_NULL (&stack_value);
+  db_make_null (&stack_value);
   attr_name = get_attr_name (attribute);
 
   meta = (attribute->info.attr_def.attr_type == PT_META_ATTR);
@@ -7109,7 +7109,7 @@ do_add_attribute_from_select_column (PARSER_CONTEXT * parser, DB_CTMPL * ctempla
   MOP class_obj = NULL;
   DB_DEFAULT_EXPR *default_expr = NULL;
 
-  DB_MAKE_NULL (&default_value);
+  db_make_null (&default_value);
 
   if (column == NULL || column->domain == NULL)
     {
@@ -9715,7 +9715,7 @@ do_alter_change_owner (PARSER_CONTEXT * const parser, PT_NODE * const alter)
 
   if (DB_VALUE_TYPE (&returnval) == DB_TYPE_ERROR)
     {
-      error = DB_GET_ERROR (&returnval);
+      error = db_get_error (&returnval);
     }
 
   return error;
@@ -10021,7 +10021,7 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
 
   assert (attribute->node_type == PT_ATTR_DEF);
 
-  DB_MAKE_NULL (&stack_value);
+  db_make_null (&stack_value);
 
   attr_name = get_attr_name (attribute);
 
@@ -12523,7 +12523,7 @@ get_att_default_from_def (PARSER_CONTEXT * parser, PT_NODE * attribute, DB_VALUE
 	  DB_VALUE src;
 	  PT_NODE *temp_val;
 
-	  DB_MAKE_NULL (&src);
+	  db_make_null (&src);
 
 	  def_val = pt_semantic_type (parser, def_val, NULL);
 	  if (pt_has_error (parser) || def_val == NULL)
@@ -13276,7 +13276,7 @@ check_change_attribute (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE *
 
   *change_mode = SM_ATTR_CHG_ONLY_SCHEMA;
 
-  DB_MAKE_NULL (&def_value);
+  db_make_null (&def_value);
 
   attr_name = get_attr_name (attribute);
 
@@ -13695,7 +13695,7 @@ do_check_rows_for_null (MOP class_mop, const char *att_name, bool * has_nulls)
   assert (has_nulls != NULL);
 
   *has_nulls = false;
-  DB_MAKE_NULL (&count);
+  db_make_null (&count);
 
   class_name = db_get_class_name (class_mop);
   if (class_name == NULL)
@@ -13775,7 +13775,7 @@ do_check_rows_for_null (MOP class_mop, const char *att_name, bool * has_nulls)
   assert (!DB_IS_NULL (&count));
   assert (DB_VALUE_DOMAIN_TYPE (&count) == DB_TYPE_INTEGER);
 
-  if (DB_GET_INTEGER (&count) > 0)
+  if (db_get_int (&count) > 0)
     {
       *has_nulls = true;
     }

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -226,7 +226,7 @@ check_serial_invariants (SERIAL_INVARIANT * invariants, int num_invariants, int 
 	  return error;
 	}
 
-      c = DB_GET_INT (&cmp_result);
+      c = db_get_int (&cmp_result);
       switch (invariants[i].cmp_op)
 	{
 	case PT_GT:
@@ -433,7 +433,7 @@ do_evaluate_default_expr (PARSER_CONTEXT * parser, PT_NODE * class_name)
 		}
 	      else
 		{
-		  db_datetime_decode ((DB_DATETIME *) DB_GET_DATETIME (&parser->sys_datetime), &month, &day, &year,
+		  db_datetime_decode ((DB_DATETIME *) db_get_datetime (&parser->sys_datetime), &month, &day, &year,
 				      &hour, &minute, &second, &millisecond);
 		  db_make_time (&default_value, hour, minute, second);
 		}
@@ -449,13 +449,13 @@ do_evaluate_default_expr (PARSER_CONTEXT * parser, PT_NODE * class_name)
 		  const char *t_source, *t_dest;
 		  DB_DATETIME *datetime;
 
-		  datetime = DB_GET_DATETIME (&parser->sys_datetime);
+		  datetime = db_get_datetime (&parser->sys_datetime);
 		  t_source = tz_get_system_timezone ();
 		  t_dest = tz_get_session_local_timezone ();
 		  db_time = datetime->time / 1000;
 		  error = tz_conv_tz_time_w_zone_name (&db_time, t_source, strlen (t_source), t_dest,
 						       strlen (t_dest), &cur_time);
-		  DB_MAKE_ENCODED_TIME (&default_value, &cur_time);
+		  db_value_put_encoded_time (&default_value, &cur_time);
 		}
 	      break;
 	    case DB_DEFAULT_SYSDATE:
@@ -465,7 +465,7 @@ do_evaluate_default_expr (PARSER_CONTEXT * parser, PT_NODE * class_name)
 		}
 	      else
 		{
-		  datetime = DB_GET_DATETIME (&parser->sys_datetime);
+		  datetime = db_get_datetime (&parser->sys_datetime);
 		  error = db_value_put_encoded_date (&default_value, &datetime->date);
 		}
 	      break;
@@ -485,7 +485,7 @@ do_evaluate_default_expr (PARSER_CONTEXT * parser, PT_NODE * class_name)
 	      break;
 	    case DB_DEFAULT_CURR_USER:
 	      user_name = db_get_user_name ();
-	      error = DB_MAKE_STRING (&default_value, user_name);
+	      error = db_make_string (&default_value, user_name);
 	      default_value.need_clear = true;
 	      break;
 	    case DB_DEFAULT_CURRENTDATE:
@@ -500,18 +500,18 @@ do_evaluate_default_expr (PARSER_CONTEXT * parser, PT_NODE * class_name)
 		  DB_DATETIME dest_dt;
 		  DB_DATETIME *src_dt;
 
-		  src_dt = DB_GET_DATETIME (&parser->sys_datetime);
+		  src_dt = db_get_datetime (&parser->sys_datetime);
 		  tz_get_system_tz_region (&system_tz_region);
 		  tz_get_session_tz_region (&session_tz_region);
 		  error =
 		    tz_conv_tz_datetime_w_region (src_dt, &system_tz_region, &session_tz_region, &dest_dt, NULL, NULL);
 		  if (att->default_value.default_expr.default_expr_type == DB_DEFAULT_CURRENTDATE)
 		    {
-		      DB_MAKE_ENCODED_DATE (&default_value, &dest_dt.date);
+		      db_value_put_encoded_date (&default_value, &dest_dt.date);
 		    }
 		  else
 		    {
-		      DB_MAKE_DATETIME (&default_value, &dest_dt);
+		      db_make_datetime (&default_value, &dest_dt);
 		    }
 		}
 	      break;
@@ -527,7 +527,7 @@ do_evaluate_default_expr (PARSER_CONTEXT * parser, PT_NODE * class_name)
 		  DB_TIMESTAMP tmp_timestamp;
 		  DB_DATETIME *sys_datetime;
 
-		  sys_datetime = DB_GET_DATETIME (&parser->sys_datetime);
+		  sys_datetime = db_get_datetime (&parser->sys_datetime);
 		  tmp_date = sys_datetime->date;
 		  tmp_time = sys_datetime->time / 1000;
 		  db_timestamp_encode_sys (&tmp_date, &tmp_time, &tmp_timestamp, NULL);
@@ -760,7 +760,7 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
   /* cached num */
   if (cached_num > 0)
     {
-      DB_MAKE_INT (&value, cached_num);
+      db_make_int (&value, cached_num);
       error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_CACHED_NUM, &value);
       pr_clear_value (&value);
       if (error < 0)
@@ -1082,7 +1082,7 @@ do_change_auto_increment_serial (PARSER_CONTEXT * const parser, MOP serial_obj, 
       goto error_exit;
     }
 
-  cmp = DB_GET_INT (&cmp_result);
+  cmp = db_get_int (&cmp_result);
   if (cmp >= 0)
     {
       error_code = ER_AUTO_INCREMENT_NEWVAL_MUST_LT_MAXVAL;
@@ -1250,7 +1250,7 @@ do_get_serial_cached_num (int *cached_num, MOP serial_obj)
 
   assert (DB_VALUE_TYPE (&cached_num_val) == DB_TYPE_INTEGER);
 
-  *cached_num = DB_GET_INT (&cached_num_val);
+  *cached_num = db_get_int (&cached_num_val);
 
   return NO_ERROR;
 }
@@ -1390,7 +1390,7 @@ do_create_serial (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  goto end;
 	}
 
-      inc_val_flag = DB_GET_INT (&cmp_result);
+      inc_val_flag = db_get_int (&cmp_result);
       if (inc_val_flag == 0)
 	{
 	  error = ER_INVALID_SERIAL_VALUE;
@@ -1669,7 +1669,7 @@ do_create_serial (PARSER_CONTEXT * parser, PT_NODE * statement)
       pr_clear_value (&tmp_val2);
 
       numeric_coerce_int_to_num (cached_num, num);
-      DB_MAKE_NUMERIC (&cached_num_val, num, DB_MAX_NUMERIC_PRECISION, 0);
+      db_make_numeric (&cached_num_val, num, DB_MAX_NUMERIC_PRECISION, 0);
 
       /* 
        * must holds: cached_num_val <= result_val
@@ -1867,7 +1867,7 @@ do_create_auto_increment_serial (PARSER_CONTEXT * parser, MOP * serial_object, c
 	  goto end;
 	}
 
-      if (DB_GET_INT (&cmp_result) <= 0)
+      if (db_get_int (&cmp_result) <= 0)
 	{
 	  error = ER_INCREMENT_VALUE_CANNOT_BE_ZERO;
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
@@ -2366,7 +2366,7 @@ do_alter_serial (PARSER_CONTEXT * parser, PT_NODE * statement)
     }
   else
     {
-      cached_num = DB_GET_INT (&old_cached_num);
+      cached_num = db_get_int (&old_cached_num);
     }
 
   /* Now, get new values from node */
@@ -2403,7 +2403,7 @@ do_alter_serial (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  goto end;
 	}
 
-      new_inc_val_flag = DB_GET_INT (&cmp_result);
+      new_inc_val_flag = db_get_int (&cmp_result);
       /* new_inc_val == 0 */
       if (new_inc_val_flag == 0)
 	{
@@ -2423,7 +2423,7 @@ do_alter_serial (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  goto end;
 	}
 
-      new_inc_val_flag = DB_GET_INT (&cmp_result);
+      new_inc_val_flag = db_get_int (&cmp_result);
     }
 
   /* start_val */
@@ -2643,7 +2643,7 @@ do_alter_serial (PARSER_CONTEXT * parser, PT_NODE * statement)
       pr_clear_value (&tmp_val2);
 
       numeric_coerce_int_to_num (cached_num, num);
-      DB_MAKE_NUMERIC (&cached_num_val, num, DB_MAX_NUMERIC_PRECISION, 0);
+      db_make_numeric (&cached_num_val, num, DB_MAX_NUMERIC_PRECISION, 0);
 
       /* 
        * must holds: cached_num_val <= result_val
@@ -2697,7 +2697,7 @@ do_alter_serial (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  goto end;
 	}
       /* reset started flag because current_val changed */
-      DB_MAKE_INT (&value, 0);
+      db_make_int (&value, 0);
       error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_STARTED, &value);
       if (error < 0)
 	{
@@ -2765,7 +2765,7 @@ do_alter_serial (PARSER_CONTEXT * parser, PT_NODE * statement)
 
 	}
 
-      DB_MAKE_INT (&value, cached_num);
+      db_make_int (&value, cached_num);
       error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_CACHED_NUM, &value);
       if (error < 0)
 	{
@@ -4309,7 +4309,7 @@ do_get_stats (PARSER_CONTEXT * parser, PT_NODE * statement)
   DB_VALUE *ret_val, db_val;
   int error;
 
-  DB_MAKE_NULL (&db_val);
+  db_make_null (&db_val);
 
   cls = statement->info.get_stats.class_;
   arg = statement->info.get_stats.args;
@@ -4445,7 +4445,7 @@ do_rollback (PARSER_CONTEXT * parser, PT_NODE * statement)
   PT_NODE *name;
   DB_VALUE val;
 
-  DB_MAKE_NULL (&val);
+  db_make_null (&val);
 
   name = statement->info.rollback_work.save_name;
   if (name == NULL)
@@ -4497,7 +4497,7 @@ do_savepoint (PARSER_CONTEXT * parser, PT_NODE * statement)
   PT_NODE *name;
   DB_VALUE val;
 
-  DB_MAKE_NULL (&val);
+  db_make_null (&val);
 
   name = statement->info.savepoint.save_name;
   if (name == NULL)
@@ -4661,7 +4661,7 @@ do_set_xaction (PARSER_CONTEXT * parser, PT_NODE * statement)
   bool async_ws;
   float wait_secs;
 
-  DB_MAKE_NULL (&val);
+  db_make_null (&val);
 
   while ((error == NO_ERROR) && (mode != NULL))
     {
@@ -4710,7 +4710,7 @@ do_set_xaction (PARSER_CONTEXT * parser, PT_NODE * statement)
 	    }
 	  else
 	    {
-	      wait_secs = DB_GET_FLOAT (&val);
+	      wait_secs = db_get_float (&val);
 	      if (wait_secs > 0)
 		{
 		  wait_secs *= 1000;
@@ -4766,7 +4766,7 @@ do_get_optimization_param (PARSER_CONTEXT * parser, PT_NODE * statement)
       {
 	DB_VALUE plan;
 
-	DB_MAKE_NULL (&plan);
+	db_make_null (&plan);
 
 	pt_evaluate_tree (parser, statement->info.get_opt_lvl.args, &plan, 1);
 	if (pt_has_error (parser))
@@ -4782,7 +4782,7 @@ do_get_optimization_param (PARSER_CONTEXT * parser, PT_NODE * statement)
 	    return ER_OUT_OF_VIRTUAL_MEMORY;
 	  }
 
-	qo_get_optimization_param (cost, QO_PARAM_COST, DB_GET_STRING (&plan));
+	qo_get_optimization_param (cost, QO_PARAM_COST, db_get_string (&plan));
 	pr_clear_value (&plan);
 	db_make_string (val, cost);
 	val->need_clear = true;
@@ -4843,10 +4843,10 @@ do_set_optimization_param (PARSER_CONTEXT * parser, PT_NODE * statement)
   switch (statement->info.set_opt_lvl.option)
     {
     case PT_OPT_LVL:
-      qo_set_optimization_param (NULL, QO_PARAM_LEVEL, (int) DB_GET_INTEGER (&val1));
+      qo_set_optimization_param (NULL, QO_PARAM_LEVEL, (int) db_get_int (&val1));
       break;
     case PT_OPT_COST:
-      plan = DB_GET_STRING (&val1);
+      plan = db_get_string (&val1);
       p2 = p1->next;
       pt_evaluate_tree (parser, p2, &val2, 1);
       if (pt_has_error (parser))
@@ -4858,7 +4858,7 @@ do_set_optimization_param (PARSER_CONTEXT * parser, PT_NODE * statement)
       switch (DB_VALUE_TYPE (&val2))
 	{
 	case DB_TYPE_INTEGER:
-	  qo_set_optimization_param (NULL, QO_PARAM_COST, plan, DB_GET_INT (&val2));
+	  qo_set_optimization_param (NULL, QO_PARAM_COST, plan, db_get_int (&val2));
 	  break;
 	case DB_TYPE_CHAR:
 	case DB_TYPE_NCHAR:
@@ -4901,7 +4901,7 @@ do_set_sys_params (PARSER_CONTEXT * parser, PT_NODE * statement)
   DB_VALUE db_val;
   int error = NO_ERROR;
 
-  DB_MAKE_NULL (&db_val);
+  db_make_null (&db_val);
 
   val = statement->info.set_sys_params.val;
   if (val == NULL)
@@ -4920,7 +4920,7 @@ do_set_sys_params (PARSER_CONTEXT * parser, PT_NODE * statement)
 	}
       else
 	{
-	  error = db_set_system_parameters (DB_GET_STRING (&db_val));
+	  error = db_set_system_parameters (db_get_string (&db_val));
 	}
 
       pr_clear_value (&db_val);
@@ -5012,8 +5012,8 @@ set_iso_level (PARSER_CONTEXT * parser, DB_TRAN_ISOLATION * tran_isolation, bool
 	       const DB_VALUE * level)
 {
   int error = NO_ERROR;
-  int isolvl = DB_GET_INTEGER (level) & 0x0F;
-  *async_ws = (DB_GET_INTEGER (level) & 0xF0) ? true : false;
+  int isolvl = db_get_int (level) & 0x0F;
+  *async_ws = (db_get_int (level) & 0xF0) ? true : false;
 
   /* translate to the enumerated type */
   switch (isolvl)
@@ -5078,7 +5078,7 @@ check_timeout_value (PARSER_CONTEXT * parser, PT_NODE * statement, DB_VALUE * va
 
   if (db_value_coerce (val, val, &tp_Float_domain) == DOMAIN_COMPATIBLE)
     {
-      timeout = DB_GET_FLOAT (val);
+      timeout = db_get_float (val);
       if ((timeout == -1) || (timeout >= 0))
 	{
 	  return NO_ERROR;
@@ -5488,7 +5488,7 @@ get_priority (PARSER_CONTEXT * parser, PT_NODE * node)
   src = pt_value_to_db (parser, node);
   if (src != NULL && (tp_value_coerce (src, &value, &tp_Double_domain) == DOMAIN_COMPATIBLE))
     {
-      priority = DB_GET_DOUBLE (&value);
+      priority = db_get_double (&value);
     }
   /* else, should be setting some kind of error */
 
@@ -6473,7 +6473,7 @@ do_alter_trigger (PARSER_CONTEXT * parser, PT_NODE * statement)
 
 		  if (DB_VALUE_TYPE (&returnval) == DB_TYPE_ERROR)
 		    {
-		      error = DB_GET_ERROR (&returnval);
+		      error = db_get_error (&returnval);
 		      break;
 		    }
 
@@ -6640,8 +6640,8 @@ do_set_trigger (PARSER_CONTEXT * parser, PT_NODE * statement)
   DB_VALUE src, dst;
   TP_DOMAIN_STATUS dom_status;
 
-  DB_MAKE_NULL (&src);
-  DB_MAKE_NULL (&dst);
+  db_make_null (&src);
+  db_make_null (&dst);
 
   pt_evaluate_tree (parser, statement->info.set_trigger.val, &src, 1);
   if (pt_has_error (parser))
@@ -6673,7 +6673,7 @@ do_set_trigger (PARSER_CONTEXT * parser, PT_NODE * statement)
       int v;
 
       option = statement->info.set_trigger.option;
-      v = DB_GET_INT (&dst);
+      v = db_get_int (&dst);
 
       if (option == PT_TRIGGER_TRACE)
 	{
@@ -6964,7 +6964,7 @@ update_object_tuple (PARSER_CONTEXT * parser, CLIENT_UPDATE_INFO * assigns, int 
 	  continue;
 	}
 
-      object = DB_GET_OBJECT (cls_info->oid);
+      object = db_get_object (cls_info->oid);
       error = db_is_deleted (object);
       if (error < 0)
 	{
@@ -7214,7 +7214,7 @@ update_object_by_oid (PARSER_CONTEXT * parser, PT_NODE * statement, UPDATE_TYPE 
 
       if (error == NO_ERROR)
 	{
-	  DB_MAKE_OBJECT (&dbvals[0], oid);
+	  db_make_object (&dbvals[0], oid);
 
 	  /* iterate through assignments and evaluate right side of each assignment */
 	  i = 0;
@@ -7496,7 +7496,7 @@ init_update_data (PARSER_CONTEXT * parser, PT_NODE * statement, CLIENT_UPDATE_IN
 
   for (i = 0; i < assign_cnt + upd_cls_cnt + has_delete; i++)
     {
-      DB_MAKE_NULL (&dbvals[i]);
+      db_make_null (&dbvals[i]);
     }
 
   /* initialize classes info array */
@@ -7784,7 +7784,7 @@ update_objs_for_list_file (PARSER_CONTEXT * parser, QFILE_LIST_ID * list_id, PT_
 	    }
 	  else
 	    {
-	      should_delete = DB_GET_INT (&dbvals[upd_cls_cnt]);
+	      should_delete = db_get_int (&dbvals[upd_cls_cnt]);
 	    }
 	}
 
@@ -9532,7 +9532,7 @@ delete_list_by_oids (PARSER_CONTEXT * parser, PT_NODE * statement, QFILE_LIST_ID
 	      continue;
 	    }
 
-	  mop = DB_GET_OBJECT (&oids[idx]);
+	  mop = db_get_object (&oids[idx]);
 
 	  error = db_is_deleted (mop);
 	  if (error < 0)
@@ -11624,7 +11624,7 @@ do_find_unique_constraint_violations (DB_OTMPL * tmpl, bool for_update, OID ** o
 	  continue;
 	}
       BTID_COPY (&unique_btids[key_cnt], &constraint->index_btid);
-      DB_MAKE_NULL (&unique_keys[key_cnt]);
+      db_make_null (&unique_keys[key_cnt]);
       attr_count = 0;
       for (attr = constraint->attributes; *attr != NULL; attr++)
 	{
@@ -11959,7 +11959,7 @@ do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * st
 	  error = er_errid ();
 	  goto cleanup;
 	}
-      DB_MAKE_OBJECT (ins_val, (DB_OBJECT *) NULL);
+      db_make_object (ins_val, (DB_OBJECT *) NULL);
     }
 
   if (TM_TRAN_ISOLATION () >= TRAN_REP_READ && statement->info.insert.server_allowed != SERVER_INSERT_IS_ALLOWED)
@@ -12004,7 +12004,7 @@ do_insert_template (PARSER_CONTEXT * parser, DB_OTMPL ** otemplate, PT_NODE * st
 	      val = (DB_VALUE *) statement->etc;
 	      if (val != NULL)
 		{
-		  DB_MAKE_OBJECT (ins_val, DB_GET_OBJECT (val));
+		  db_make_object (ins_val, db_get_object (val));
 		}
 	      if (into_label != NULL)
 		{
@@ -12405,7 +12405,7 @@ cleanup:
 
       if (db_val != NULL)
 	{
-	  DB_MAKE_OBJECT (db_val, (DB_OBJECT *) NULL);
+	  db_make_object (db_val, (DB_OBJECT *) NULL);
 	}
     }
 
@@ -12567,7 +12567,7 @@ insert_subquery_results (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE *
 
 	  for (i = 0; i < degree; i++)
 	    {
-	      DB_MAKE_NULL (&vals[i]);
+	      db_make_null (&vals[i]);
 	    }
 
 	  /* allocate attribute descriptor array */
@@ -12947,7 +12947,7 @@ make_vmops (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_wa
       val = pt_find_value_of_label (into_label);
       if (val != NULL)
 	{
-	  obj = DB_GET_OBJECT (val);
+	  obj = db_get_object (val);
 	  *vobj = vid_build_virtual_mop (obj, vclass_mop);
 	  /* change the label to point to the newly created vmop, we don't need to call pt_associate_label_with_value
 	   * here because we've directly modified the value that has been installed in the table. */
@@ -13490,7 +13490,7 @@ call_method (PARSER_CONTEXT * parser, PT_NODE * statement)
     {
       if (DB_VALUE_TYPE (&target_value) == DB_TYPE_OBJECT)
 	{
-	  obj = DB_GET_OBJECT ((&target_value));
+	  obj = db_get_object ((&target_value));
 	}
 
       if (obj == NULL || pt_has_error (parser))
@@ -14813,7 +14813,7 @@ do_set_session_variables (PARSER_CONTEXT * parser, PT_NODE * statement)
   /* initialize variables in case we need to exit with error */
   for (i = 0; i < count * 2; i++)
     {
-      DB_MAKE_NULL (&variables[i]);
+      db_make_null (&variables[i]);
     }
 
   for (i = 0, assignment = statement->info.set_variables.assignments; assignment; i += 2, assignment = assignment->next)
@@ -16467,7 +16467,7 @@ do_evaluate_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement)
   eval.replace_names = false;
   eval.crt_attr_index = 0;
 
-  DB_MAKE_NULL (&eval_value);
+  db_make_null (&eval_value);
 
   /* evaluate lists of values */
   for (value_list = value_clause; value_list != NULL; value_list = value_list->next)
@@ -16701,7 +16701,7 @@ do_clear_insert_values (PARSER_CONTEXT * parser, PT_NODE * insert_statement)
 	      /* prepare node for reevaluation */
 	      value->info.insert_value.is_evaluated = false;
 	      db_value_clear (&value->info.insert_value.value);
-	      DB_MAKE_NULL (&value->info.insert_value.value);
+	      db_make_null (&value->info.insert_value.value);
 	    }
 	}
     }
@@ -16858,7 +16858,7 @@ do_replace_names_for_insert_values_pre (PARSER_CONTEXT * parser, PT_NODE * node,
 			      pt_short_print (parser, node));
 		  return node;
 		}
-	      DB_MAKE_OBJECT (&db_value, obj);
+	      db_make_object (&db_value, obj);
 	      break;
 	    case PT_PARAMETER:
 	      pt_evaluate_tree_having_serial (parser, node, &db_value, 1);
@@ -16870,13 +16870,13 @@ do_replace_names_for_insert_values_pre (PARSER_CONTEXT * parser, PT_NODE * node,
 		      PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME__CAN_NOT_EVALUATE,
 				  pt_short_print (parser, node));
 		    }
-		  DB_MAKE_OBJECT (&db_value, obj);
+		  db_make_object (&db_value, obj);
 		}
 	      else if (DB_VALUE_TYPE (&db_value) == DB_TYPE_OBJECT)
 		{
-		  obj = DB_GET_OBJECT (&db_value);
+		  obj = db_get_object (&db_value);
 		  obj = db_real_instance (obj);
-		  DB_MAKE_OBJECT (&db_value, obj);
+		  db_make_object (&db_value, obj);
 		}
 	      break;
 	    default:
@@ -17221,8 +17221,8 @@ do_send_plan_trace_to_session (PARSER_CONTEXT * parser)
 
   if (plan_str != NULL)
     {
-      DB_MAKE_CHAR (&var[0], 10, "trace_plan", 10, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
-      DB_MAKE_STRING (&var[1], plan_str);
+      db_make_char (&var[0], 10, "trace_plan", 10, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
+      db_make_string (&var[1], plan_str);
 
       csession_set_session_variables (var, 2);
       free_and_init (plan_str);

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -1270,7 +1270,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       else
 	{
 	  /* must be a char string type */
-	  db_make_int (arithptr->value, 8 * DB_GET_STRING_SIZE (peek_right));
+	  db_make_int (arithptr->value, 8 * db_get_string_size (peek_right));
 	}
       break;
 
@@ -1281,7 +1281,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       else
 	{
-	  db_make_int (arithptr->value, DB_GET_STRING_LENGTH (peek_right));
+	  db_make_int (arithptr->value, db_get_string_length (peek_right));
 	}
       break;
 
@@ -1447,8 +1447,8 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  && !DB_IS_NULL (peek_right))
 	{
 	  TP_DOMAIN_STATUS status = tp_value_change_coll_and_codeset (peek_right, peek_right,
-								      DB_GET_STRING_COLLATION (peek_left),
-								      DB_GET_STRING_CODESET (peek_left));
+								      db_get_string_collation (peek_left),
+								      db_get_string_codeset (peek_left));
 
 	  if (status != DOMAIN_COMPATIBLE)
 	    {
@@ -1472,8 +1472,8 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  && !DB_IS_NULL (peek_right))
 	{
 	  TP_DOMAIN_STATUS status = tp_value_change_coll_and_codeset (peek_right, peek_right,
-								      DB_GET_STRING_COLLATION (peek_left),
-								      DB_GET_STRING_CODESET (peek_left));
+								      db_get_string_collation (peek_left),
+								      db_get_string_codeset (peek_left));
 
 	  if (status != DOMAIN_COMPATIBLE)
 	    {
@@ -1497,8 +1497,8 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  && !DB_IS_NULL (peek_right))
 	{
 	  TP_DOMAIN_STATUS status = tp_value_change_coll_and_codeset (peek_right, peek_right,
-								      DB_GET_STRING_COLLATION (peek_left),
-								      DB_GET_STRING_CODESET (peek_left));
+								      db_get_string_collation (peek_left),
+								      db_get_string_codeset (peek_left));
 
 	  if (status != DOMAIN_COMPATIBLE)
 	    {
@@ -1533,8 +1533,8 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  && !DB_IS_NULL (peek_third))
 	{
 	  TP_DOMAIN_STATUS status = tp_value_change_coll_and_codeset (peek_third, peek_third,
-								      DB_GET_STRING_COLLATION (peek_left),
-								      DB_GET_STRING_CODESET (peek_left));
+								      db_get_string_collation (peek_left),
+								      db_get_string_codeset (peek_left));
 
 	  if (status != DOMAIN_COMPATIBLE)
 	    {
@@ -1558,8 +1558,8 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  && !DB_IS_NULL (peek_third))
 	{
 	  TP_DOMAIN_STATUS status = tp_value_change_coll_and_codeset (peek_third, peek_third,
-								      DB_GET_STRING_COLLATION (peek_left),
-								      DB_GET_STRING_CODESET (peek_left));
+								      db_get_string_collation (peek_left),
+								      db_get_string_codeset (peek_left));
 
 	  if (status != DOMAIN_COMPATIBLE)
 	    {
@@ -1583,8 +1583,8 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  && !DB_IS_NULL (peek_third))
 	{
 	  TP_DOMAIN_STATUS status = tp_value_change_coll_and_codeset (peek_third, peek_third,
-								      DB_GET_STRING_COLLATION (peek_left),
-								      DB_GET_STRING_CODESET (peek_left));
+								      db_get_string_collation (peek_left),
+								      db_get_string_codeset (peek_left));
 
 	  if (status != DOMAIN_COMPATIBLE)
 	    {
@@ -1607,8 +1607,8 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       if (REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_INFER_COLLATION) && !DB_IS_NULL (peek_left))
 	{
 	  TP_DOMAIN_STATUS status = tp_value_change_coll_and_codeset (peek_third, peek_third,
-								      DB_GET_STRING_COLLATION (peek_left),
-								      DB_GET_STRING_CODESET (peek_left));
+								      db_get_string_collation (peek_left),
+								      db_get_string_codeset (peek_left));
 
 	  if (status != DOMAIN_COMPATIBLE)
 	    {
@@ -2033,7 +2033,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       break;
 
     case T_SYS_DATE:
-      DB_MAKE_ENCODED_DATE (arithptr->value, &vd->sys_datetime.date);
+      db_value_put_encoded_date (arithptr->value, &vd->sys_datetime.date);
       break;
 
     case T_SYS_TIME:
@@ -2041,13 +2041,13 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	DB_TIME db_time;
 
 	db_time = vd->sys_datetime.time / 1000;
-	DB_MAKE_ENCODED_TIME (arithptr->value, &db_time);
+	db_value_put_encoded_time (arithptr->value, &db_time);
 	break;
       }
 
     case T_SYS_DATETIME:
       {
-	DB_MAKE_DATETIME (arithptr->value, &vd->sys_datetime);
+	db_make_datetime (arithptr->value, &vd->sys_datetime);
       }
       break;
 
@@ -2078,7 +2078,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  {
 	    return err_status;
 	  }
-	DB_MAKE_ENCODED_DATE (arithptr->value, &dest_dt.date);
+	db_value_put_encoded_date (arithptr->value, &dest_dt.date);
 	break;
       }
 
@@ -2099,7 +2099,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  {
 	    return err_status;
 	  }
-	DB_MAKE_ENCODED_TIME (arithptr->value, &cur_time);
+	db_value_put_encoded_time (arithptr->value, &cur_time);
 	break;
       }
 
@@ -2130,7 +2130,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  {
 	    return err_status;
 	  }
-	DB_MAKE_DATETIME (arithptr->value, &dest_dt);
+	db_make_datetime (arithptr->value, &dest_dt);
       }
       break;
 
@@ -2138,7 +2138,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       {
 	DB_TIME db_time;
 	db_time = (DB_TIME) (vd->sys_epochtime % SECONDS_OF_ONE_DAY);
-	DB_MAKE_ENCODED_TIME (arithptr->value, &db_time);
+	db_value_put_encoded_time (arithptr->value, &db_time);
 	break;
       }
 
@@ -2149,7 +2149,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 
 	tz_timestamp_decode_no_leap_sec (vd->sys_epochtime, &year, &month, &day, &hour, &minute, &second);
 	date = julian_encode (month + 1, day, year);
-	DB_MAKE_ENCODED_DATE (arithptr->value, &date);
+	db_value_put_encoded_date (arithptr->value, &date);
 	break;
       }
 
@@ -2323,8 +2323,8 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  OID *serial_oid;
 	  int cached_num;
 
-	  serial_oid = DB_GET_OID (peek_left);
-	  cached_num = DB_GET_INTEGER (peek_right);
+	  serial_oid = db_get_oid (peek_left);
+	  cached_num = db_get_int (peek_right);
 
 	  if (xserial_get_current_value (thread_p, arithptr->value, serial_oid, cached_num) != NO_ERROR)
 	    {
@@ -2347,9 +2347,9 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  int cached_num;
 	  int num_alloc;
 
-	  serial_oid = DB_GET_OID (peek_left);
-	  cached_num = DB_GET_INTEGER (peek_right);
-	  num_alloc = DB_GET_INTEGER (peek_third);
+	  serial_oid = db_get_oid (peek_left);
+	  cached_num = db_get_int (peek_right);
+	  num_alloc = db_get_int (peek_third);
 
 	  if (xserial_get_next_value (thread_p, arithptr->value, serial_oid, cached_num, num_alloc, GENERATE_SERIAL,
 				      false) != NO_ERROR)
@@ -2369,7 +2369,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	      if (!DB_IS_NULL (arithptr->value))
 		{
 		  assert (TP_IS_CHAR_TYPE (DB_VALUE_TYPE (arithptr->value)));
-		  assert (regu_var->domain->codeset == DB_GET_STRING_CODESET (arithptr->value));
+		  assert (regu_var->domain->codeset == db_get_string_codeset (arithptr->value));
 		}
 	      db_string_put_cs_and_collation (arithptr->value, regu_var->domain->codeset,
 					      regu_var->domain->collation_id);
@@ -2381,7 +2381,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	      if (!DB_IS_NULL (arithptr->value))
 		{
 		  assert (DB_VALUE_DOMAIN_TYPE (arithptr->value) == DB_TYPE_ENUMERATION);
-		  assert (regu_var->domain->codeset == DB_GET_ENUM_CODESET (arithptr->value));
+		  assert (regu_var->domain->codeset == db_get_enum_codeset (arithptr->value));
 		}
 	      db_enum_put_cs_and_collation (arithptr->value, regu_var->domain->codeset, regu_var->domain->collation_id);
 
@@ -2408,7 +2408,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	      if (!DB_IS_NULL (arithptr->value))
 		{
 		  assert (TP_IS_CHAR_TYPE (DB_VALUE_TYPE (arithptr->value)));
-		  assert (regu_var->domain->codeset == DB_GET_STRING_CODESET (arithptr->value));
+		  assert (regu_var->domain->codeset == db_get_string_codeset (arithptr->value));
 		}
 	      db_string_put_cs_and_collation (arithptr->value, regu_var->domain->codeset,
 					      regu_var->domain->collation_id);
@@ -2420,7 +2420,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	      if (!DB_IS_NULL (arithptr->value))
 		{
 		  assert (DB_VALUE_DOMAIN_TYPE (arithptr->value) == DB_TYPE_ENUMERATION);
-		  assert (regu_var->domain->codeset == DB_GET_ENUM_CODESET (arithptr->value));
+		  assert (regu_var->domain->codeset == db_get_enum_codeset (arithptr->value));
 		}
 	      db_enum_put_cs_and_collation (arithptr->value, regu_var->domain->codeset, regu_var->domain->collation_id);
 
@@ -2484,13 +2484,13 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       switch (eval_pred (thread_p, arithptr->pred, vd, obj_oid))
 	{
 	case V_UNKNOWN:
-	  DB_MAKE_NULL (peek_left);
+	  db_make_null (peek_left);
 	  break;
 	case V_FALSE:
-	  DB_MAKE_INT (peek_left, 0);
+	  db_make_int (peek_left, 0);
 	  break;
 	case V_TRUE:
-	  DB_MAKE_INT (peek_left, 1);
+	  db_make_int (peek_left, 1);
 	  break;
 	default:
 	  goto error;
@@ -2625,11 +2625,11 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ISNULL:
       if (DB_IS_NULL (peek_right))
 	{
-	  DB_MAKE_INTEGER (arithptr->value, 1);
+	  db_make_int (arithptr->value, 1);
 	}
       else
 	{
-	  DB_MAKE_INTEGER (arithptr->value, 0);
+	  db_make_int (arithptr->value, 0);
 	}
       break;
 
@@ -2730,7 +2730,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	    {
 	      DB_VALUE tmp_val;
 
-	      DB_MAKE_NULL (&tmp_val);
+	      db_make_null (&tmp_val);
 	      if (qdata_strcat_dbval (peek_left, peek_third, &tmp_val, regu_var->domain) != NO_ERROR)
 		{
 		  goto error;
@@ -2954,7 +2954,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	      DB_VALUE tmp_len, tmp_val, tmp_arg3;
 	      int tmp;
 
-	      DB_MAKE_NULL (&tmp_val);
+	      db_make_null (&tmp_val);
 
 	      tmp = db_get_int (peek_third);
 	      if (tmp < 1)
@@ -3274,7 +3274,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  {
 	    goto error;
 	  }
-	DB_MAKE_INTEGER (arithptr->value, row_count);
+	db_make_int (arithptr->value, row_count);
       }
       break;
 
@@ -3575,7 +3575,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  {
 	    goto error;
 	  }
-	timezone_milis = DB_GET_INT (&timezone) * 60000;
+	timezone_milis = db_get_int (&timezone) * 60000;
 	tmp_datetime = vd->sys_datetime;
 	db_add_int_to_datetime (&tmp_datetime, timezone_milis, &utc_datetime);
 
@@ -3679,7 +3679,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	date = julian_encode (month + 1, day, year);
 	db_time_encode (&time, hour, minute, second);
 	db_timestamp_encode_ses (&date, &time, &timestamp, NULL);
-	DB_MAKE_TIMESTAMP (arithptr->value, timestamp);
+	db_make_timestamp (arithptr->value, timestamp);
 	break;
       }
 
@@ -3900,14 +3900,14 @@ fetch_peek_dbval (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       REGU_VARIABLE_SET_FLAG (regu_var, REGU_VARIABLE_FETCH_ALL_CONST);
       assert (!REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_NOT_CONST));
       *peek_dbval = &regu_var->value.dbval;
-      DB_MAKE_OID (*peek_dbval, obj_oid);
+      db_make_oid (*peek_dbval, obj_oid);
       break;
 
     case TYPE_CLASSOID:	/* fetch class identifier value */
       REGU_VARIABLE_SET_FLAG (regu_var, REGU_VARIABLE_FETCH_ALL_CONST);
       assert (!REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_NOT_CONST));
       *peek_dbval = &regu_var->value.dbval;
-      DB_MAKE_OID (*peek_dbval, class_oid);
+      db_make_oid (*peek_dbval, class_oid);
       break;
 
     case TYPE_POSITION:	/* fetch list file tuple value */
@@ -4137,13 +4137,13 @@ fetch_peek_dbval (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 		    switch (index_type)
 		      {
 		      case DB_TYPE_SMALLINT:
-			idx = DB_GET_SMALLINT (index);
+			idx = db_get_short (index);
 			break;
 		      case DB_TYPE_INTEGER:
-			idx = DB_GET_INTEGER (index);
+			idx = db_get_int (index);
 			break;
 		      case DB_TYPE_BIGINT:
-			idx = DB_GET_BIGINT (index);
+			idx = db_get_bigint (index);
 			break;
 		      case DB_TYPE_NULL:
 			is_null_elt = true;
@@ -4273,7 +4273,7 @@ fetch_peek_dbval (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  if (!DB_IS_NULL (*peek_dbval))
 	    {
 	      assert (TP_IS_CHAR_TYPE (DB_VALUE_TYPE (*peek_dbval)));
-	      assert (regu_var->domain->codeset == DB_GET_STRING_CODESET (*peek_dbval));
+	      assert (regu_var->domain->codeset == db_get_string_codeset (*peek_dbval));
 	    }
 	  db_string_put_cs_and_collation (*peek_dbval, regu_var->domain->codeset, regu_var->domain->collation_id);
 	}
@@ -4284,7 +4284,7 @@ fetch_peek_dbval (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  if (!DB_IS_NULL (*peek_dbval))
 	    {
 	      assert (DB_VALUE_DOMAIN_TYPE (*peek_dbval) == DB_TYPE_ENUMERATION);
-	      assert (regu_var->domain->codeset == DB_GET_ENUM_CODESET (*peek_dbval));
+	      assert (regu_var->domain->codeset == db_get_enum_codeset (*peek_dbval));
 	    }
 	  db_enum_put_cs_and_collation (*peek_dbval, regu_var->domain->codeset, regu_var->domain->collation_id);
 
@@ -4721,7 +4721,7 @@ get_hour_minute_or_second (const DB_VALUE * datetime, OPERATOR_TYPE op_type, DB_
     {
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true)
 	{
-	  DB_MAKE_NULL (db_value);
+	  db_make_null (db_value);
 	}
       else
 	{
@@ -4736,7 +4736,7 @@ get_hour_minute_or_second (const DB_VALUE * datetime, OPERATOR_TYPE op_type, DB_
     {
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == true)
 	{
-	  DB_MAKE_NULL (db_value);
+	  db_make_null (db_value);
 	  error = NO_ERROR;
 	}
       else
@@ -4749,17 +4749,17 @@ get_hour_minute_or_second (const DB_VALUE * datetime, OPERATOR_TYPE op_type, DB_
   switch (op_type)
     {
     case T_HOUR:
-      DB_MAKE_INT (db_value, hour);
+      db_make_int (db_value, hour);
       break;
     case T_MINUTE:
-      DB_MAKE_INT (db_value, minute);
+      db_make_int (db_value, minute);
       break;
     case T_SECOND:
-      DB_MAKE_INT (db_value, second);
+      db_make_int (db_value, second);
       break;
     default:
       assert (false);
-      DB_MAKE_NULL (db_value);
+      db_make_null (db_value);
       error = ER_FAILED;
       break;
     }
@@ -4786,7 +4786,7 @@ get_year_month_or_day (const DB_VALUE * src_date, OPERATOR_TYPE op, DB_VALUE * r
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -4796,7 +4796,7 @@ get_year_month_or_day (const DB_VALUE * src_date, OPERATOR_TYPE op, DB_VALUE * r
       /* This function should return NULL if src_date is an invalid parameter. Clear the error generated by the
        * function call and return null. */
       er_clear ();
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  return NO_ERROR;
@@ -4809,17 +4809,17 @@ get_year_month_or_day (const DB_VALUE * src_date, OPERATOR_TYPE op, DB_VALUE * r
   switch (op)
     {
     case T_YEAR:
-      DB_MAKE_INT (result, year);
+      db_make_int (result, year);
       break;
     case T_MONTH:
-      DB_MAKE_INT (result, month);
+      db_make_int (result, month);
       break;
     case T_DAY:
-      DB_MAKE_INT (result, day);
+      db_make_int (result, day);
       break;
     default:
       assert (false);
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return ER_FAILED;
     }
 
@@ -4837,7 +4837,7 @@ get_date_weekday (const DB_VALUE * src_date, OPERATOR_TYPE op, DB_VALUE * result
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -4870,18 +4870,18 @@ get_date_weekday (const DB_VALUE * src_date, OPERATOR_TYPE op, DB_VALUE * result
 	{
 	  day_of_week--;
 	}
-      DB_MAKE_INT (result, day_of_week);
+      db_make_int (result, day_of_week);
       break;
 
     case T_DAYOFWEEK:
       /* 1 = Sunday, 2 = Monday, ..., 7 = Saturday */
       day_of_week++;
-      DB_MAKE_INT (result, day_of_week);
+      db_make_int (result, day_of_week);
       break;
 
     default:
       assert (false);
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       break;
     }
 
@@ -4891,7 +4891,7 @@ error_exit:
   /* This function should return NULL if src_date is an invalid parameter or zero date. Clear the error generated by
    * the function call and return null. */
   er_clear ();
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       return NO_ERROR;

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -6660,8 +6660,8 @@ qfile_compare_with_interpolation_domain (char *fp0, char *fp1, SUBKEY_INFO * sub
 
   assert (fp0 != NULL && fp1 != NULL && subkey != NULL && key_info != NULL);
 
-  DB_MAKE_NULL (&val0);
-  DB_MAKE_NULL (&val1);
+  db_make_null (&val0);
+  db_make_null (&val1);
 
   d0 = fp0 + QFILE_TUPLE_VALUE_HEADER_LENGTH;
   d1 = fp1 + QFILE_TUPLE_VALUE_HEADER_LENGTH;

--- a/src/query/method_scan.c
+++ b/src/query/method_scan.c
@@ -301,7 +301,7 @@ method_invoke_from_stand_alone (METHOD_SCAN_BUFFER * scan_buffer_p)
    */
   for (i = 0; i < val_cnt; i++)
     {
-      DB_MAKE_NULL (&scan_buffer_p->vallist[i]);
+      db_make_null (&scan_buffer_p->vallist[i]);
     }
 
   scan_buffer_p->valptrs = (DB_VALUE **) malloc (sizeof (DB_VALUE *) * (val_cnt + 1));
@@ -383,7 +383,7 @@ method_receive_results_for_server (THREAD_ENTRY * thread_p, METHOD_SCAN_BUFFER *
 	}
       else
 	{
-	  DB_MAKE_NULL (dbval_p);
+	  db_make_null (dbval_p);
 	  result = method_receive_value (thread_p, dbval_p, scan_buffer_p->vacomm_buffer);
 	}
 
@@ -470,7 +470,7 @@ method_receive_results_for_stand_alone (METHOD_SCAN_BUFFER * scan_buffer_p)
 	    }
 
 	  scan_buffer_p->valptrs[num_args] = NULL;
-	  DB_MAKE_NULL (&val);
+	  db_make_null (&val);
 
 	  if (meth_sig->class_name != NULL)
 	    {
@@ -478,10 +478,10 @@ method_receive_results_for_stand_alone (METHOD_SCAN_BUFFER * scan_buffer_p)
 	       * NULL. */
 	      if (!DB_IS_NULL (scan_buffer_p->valptrs[0]))
 		{
-		  error = db_is_any_class (DB_GET_OBJECT (scan_buffer_p->valptrs[0]));
+		  error = db_is_any_class (db_get_object (scan_buffer_p->valptrs[0]));
 		  if (error == 0)
 		    {
-		      error = db_is_instance (DB_GET_OBJECT (scan_buffer_p->valptrs[0]));
+		      error = db_is_instance (db_get_object (scan_buffer_p->valptrs[0]));
 		    }
 		}
 	      if (error == ER_HEAP_UNKNOWN_OBJECT)
@@ -495,7 +495,7 @@ method_receive_results_for_stand_alone (METHOD_SCAN_BUFFER * scan_buffer_p)
 		  AU_ENABLE (turn_on_auth);
 		  db_disable_modification ();
 		  ++method_Num_method_jsp_calls;
-		  error = obj_send_array (DB_GET_OBJECT (scan_buffer_p->valptrs[0]), meth_sig->method_name, &val,
+		  error = obj_send_array (db_get_object (scan_buffer_p->valptrs[0]), meth_sig->method_name, &val,
 					  &scan_buffer_p->valptrs[1]);
 		  --method_Num_method_jsp_calls;
 		  db_enable_modification ();
@@ -546,7 +546,7 @@ method_receive_results_for_stand_alone (METHOD_SCAN_BUFFER * scan_buffer_p)
 	  /* Don't forget to translate any OBJECTS to OIDs. */
 	  if (DB_VALUE_DOMAIN_TYPE (&val) == DB_TYPE_OBJECT)
 	    {
-	      DB_MAKE_OID (dbval_list->val, ws_oid (DB_GET_OBJECT (&val)));
+	      db_make_oid (dbval_list->val, ws_oid (db_get_object (&val)));
 	    }
 	  else if (db_value_clone (&val, dbval_list->val) != NO_ERROR)
 	    {

--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -1370,8 +1370,8 @@ numeric_common_prec_scale (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALU
   if (scale1 == scale2)
     {
       cprec = MAX (prec1, prec2);
-      DB_MAKE_NUMERIC (dbv1_common, db_locate_numeric (dbv1), cprec, scale1);
-      DB_MAKE_NUMERIC (dbv2_common, db_locate_numeric (dbv2), cprec, scale2);
+      db_make_numeric (dbv1_common, db_locate_numeric (dbv1), cprec, scale1);
+      db_make_numeric (dbv2_common, db_locate_numeric (dbv2), cprec, scale2);
     }
 
   /* Otherwise scale and reset the numbers */
@@ -1387,8 +1387,8 @@ numeric_common_prec_scale (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALU
 	}
       numeric_scale_dec (db_locate_numeric (dbv1), scale_diff, temp);
       cprec = MAX (prec1, prec2);
-      DB_MAKE_NUMERIC (dbv1_common, temp, cprec, scale2);
-      DB_MAKE_NUMERIC (dbv2_common, db_locate_numeric (dbv2), cprec, scale2);
+      db_make_numeric (dbv1_common, temp, cprec, scale2);
+      db_make_numeric (dbv2_common, db_locate_numeric (dbv2), cprec, scale2);
     }
   else
     {
@@ -1402,8 +1402,8 @@ numeric_common_prec_scale (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALU
 	}
       numeric_scale_dec (db_locate_numeric (dbv2), scale_diff, temp);
       cprec = MAX (prec1, prec2);
-      DB_MAKE_NUMERIC (dbv2_common, temp, cprec, scale1);
-      DB_MAKE_NUMERIC (dbv1_common, db_locate_numeric (dbv1), cprec, scale1);
+      db_make_numeric (dbv2_common, temp, cprec, scale1);
+      db_make_numeric (dbv1_common, db_locate_numeric (dbv1), cprec, scale1);
     }
 
   return NO_ERROR;
@@ -1443,14 +1443,14 @@ numeric_prec_scale_when_overflow (const DB_VALUE * dbv1, const DB_VALUE * dbv2, 
     {
       return ret;
     }
-  DB_MAKE_NUMERIC (dbv1_common, temp, prec, scale);
+  db_make_numeric (dbv1_common, temp, prec, scale);
 
   ret = numeric_coerce_num_to_num (num2, prec2, scale2, prec, scale, temp);
   if (ret != NO_ERROR)
     {
       return ret;
     }
-  DB_MAKE_NUMERIC (dbv2_common, temp, prec, scale);
+  db_make_numeric (dbv2_common, temp, prec, scale);
 
   return ret;
 }
@@ -1605,12 +1605,12 @@ numeric_db_value_add (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE * a
     }
   if (dbv1 == NULL || DB_VALUE_TYPE (dbv1) != DB_TYPE_NUMERIC)
     {
-      DB_MAKE_NULL (answer);
+      db_make_null (answer);
       return ER_OBJ_INVALID_ARGUMENTS;
     }
   if (dbv2 == NULL || DB_VALUE_TYPE (dbv2) != DB_TYPE_NUMERIC)
     {
-      DB_MAKE_NULL (answer);
+      db_make_null (answer);
       return ER_OBJ_INVALID_ARGUMENTS;
     }
 
@@ -1657,7 +1657,7 @@ numeric_db_value_add (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE * a
 	  goto exit_on_error;
 	}
     }
-  DB_MAKE_NUMERIC (answer, temp, prec, DB_VALUE_SCALE (&dbv1_common));
+  db_make_numeric (answer, temp, prec, DB_VALUE_SCALE (&dbv1_common));
 
   return ret;
 
@@ -1701,12 +1701,12 @@ numeric_db_value_sub (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE * a
     }
   if (dbv1 == NULL || DB_VALUE_TYPE (dbv1) != DB_TYPE_NUMERIC)
     {
-      DB_MAKE_NULL (answer);
+      db_make_null (answer);
       return ER_OBJ_INVALID_ARGUMENTS;
     }
   if (dbv2 == NULL || DB_VALUE_TYPE (dbv2) != DB_TYPE_NUMERIC)
     {
-      DB_MAKE_NULL (answer);
+      db_make_null (answer);
       return ER_OBJ_INVALID_ARGUMENTS;
     }
 
@@ -1753,7 +1753,7 @@ numeric_db_value_sub (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE * a
 	  goto exit_on_error;
 	}
     }
-  DB_MAKE_NUMERIC (answer, temp, prec, DB_VALUE_SCALE (&dbv1_common));
+  db_make_numeric (answer, temp, prec, DB_VALUE_SCALE (&dbv1_common));
 
   return ret;
 
@@ -1799,12 +1799,12 @@ numeric_db_value_mul (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE * a
     }
   if (dbv1 == NULL || DB_VALUE_TYPE (dbv1) != DB_TYPE_NUMERIC)
     {
-      DB_MAKE_NULL (answer);
+      db_make_null (answer);
       return ER_OBJ_INVALID_ARGUMENTS;
     }
   if (dbv2 == NULL || DB_VALUE_TYPE (dbv2) != DB_TYPE_NUMERIC)
     {
-      DB_MAKE_NULL (answer);
+      db_make_null (answer);
       return ER_OBJ_INVALID_ARGUMENTS;
     }
 
@@ -1831,7 +1831,7 @@ numeric_db_value_mul (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE * a
     {
       numeric_negate (result);
     }
-  DB_MAKE_NUMERIC (answer, result, prec, scale);
+  db_make_numeric (answer, result, prec, scale);
 
   return ret;
 
@@ -1883,12 +1883,12 @@ numeric_db_value_div (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE * a
     }
   if (dbv1 == NULL || DB_VALUE_TYPE (dbv1) != DB_TYPE_NUMERIC)
     {
-      DB_MAKE_NULL (answer);
+      db_make_null (answer);
       return ER_OBJ_INVALID_ARGUMENTS;
     }
   if (dbv2 == NULL || DB_VALUE_TYPE (dbv2) != DB_TYPE_NUMERIC)
     {
-      DB_MAKE_NULL (answer);
+      db_make_null (answer);
       return ER_OBJ_INVALID_ARGUMENTS;
     }
 
@@ -2013,7 +2013,7 @@ numeric_db_value_div (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE * a
 	}
     }
 
-  DB_MAKE_NUMERIC (answer, temp_quo, prec, scale);
+  db_make_numeric (answer, temp_quo, prec, scale);
 
   return ret;
 
@@ -2124,12 +2124,12 @@ numeric_db_value_compare (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE
     }
   if (dbv1 == NULL || DB_VALUE_TYPE (dbv1) != DB_TYPE_NUMERIC)
     {
-      DB_MAKE_NULL (answer);
+      db_make_null (answer);
       return ER_OBJ_INVALID_ARGUMENTS;
     }
   if (dbv2 == NULL || DB_VALUE_TYPE (dbv2) != DB_TYPE_NUMERIC)
     {
-      DB_MAKE_NULL (answer);
+      db_make_null (answer);
       return ER_OBJ_INVALID_ARGUMENTS;
     }
 
@@ -2149,7 +2149,7 @@ numeric_db_value_compare (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE
     {
       /* Simple case. Just compare two numbers. */
       cmp_rez = numeric_compare (db_locate_numeric (dbv1), db_locate_numeric (dbv2));
-      DB_MAKE_INTEGER (answer, cmp_rez);
+      db_make_int (answer, cmp_rez);
       return NO_ERROR;
     }
   else
@@ -2161,7 +2161,7 @@ numeric_db_value_compare (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE
       if (ret == NO_ERROR)
 	{
 	  cmp_rez = numeric_compare (db_locate_numeric (&dbv1_common), db_locate_numeric (&dbv2_common));
-	  DB_MAKE_INTEGER (answer, cmp_rez);
+	  db_make_int (answer, cmp_rez);
 	  return NO_ERROR;
 	}
       else if (ret == ER_IT_DATA_OVERFLOW)
@@ -2201,7 +2201,7 @@ numeric_db_value_compare (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE
 	  if (cmp_rez != 0)
 	    {
 	      /* if the integral parts differ, we don't need to compare fractional parts */
-	      DB_MAKE_INT (answer, cmp_rez);
+	      db_make_int (answer, cmp_rez);
 	      return NO_ERROR;
 	    }
 
@@ -2211,11 +2211,11 @@ numeric_db_value_compare (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE
 
 	  /* compare fractional parts and return the result */
 	  cmp_rez = numeric_compare (num1_frac, num2_frac);
-	  DB_MAKE_INT (answer, cmp_rez);
+	  db_make_int (answer, cmp_rez);
 	}
       else
 	{
-	  DB_MAKE_NULL (answer);
+	  db_make_null (answer);
 	  return ER_FAILED;
 	}
     }
@@ -3197,7 +3197,7 @@ numeric_coerce_string_to_num (const char *astring, int astring_length, INTL_CODE
     {
       numeric_negate (num);
     }
-  DB_MAKE_NUMERIC (result, num, prec, scale);
+  db_make_numeric (result, num, prec, scale);
 
   return ret;
 
@@ -3386,14 +3386,14 @@ numeric_db_value_coerce_to_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATUS 
     {
     case DB_TYPE_DOUBLE:
       {
-	double adouble = DB_GET_DOUBLE (src);
+	double adouble = db_get_double (src);
 	ret = numeric_internal_double_to_num (adouble, desired_scale, num, &precision, &scale);
 	break;
       }
 
     case DB_TYPE_FLOAT:
       {
-	float adouble = (float) DB_GET_FLOAT (src);
+	float adouble = (float) db_get_float (src);
 	ret = numeric_internal_float_to_num (adouble, desired_scale, num, &precision, &scale);
 	break;
       }
@@ -3407,7 +3407,7 @@ numeric_db_value_coerce_to_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATUS 
 
     case DB_TYPE_INTEGER:
       {
-	int anint = DB_GET_INT (src);
+	int anint = db_get_int (src);
 
 	numeric_coerce_int_to_num (anint, num);
 	precision = get_significant_digit (anint);
@@ -3417,7 +3417,7 @@ numeric_db_value_coerce_to_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATUS 
 
     case DB_TYPE_SMALLINT:
       {
-	int anint = (int) DB_GET_SMALLINT (src);
+	int anint = (int) db_get_short (src);
 
 	numeric_coerce_int_to_num (anint, num);
 	precision = get_significant_digit (anint);
@@ -3427,7 +3427,7 @@ numeric_db_value_coerce_to_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATUS 
 
     case DB_TYPE_BIGINT:
       {
-	DB_BIGINT bigint = DB_GET_BIGINT (src);
+	DB_BIGINT bigint = db_get_bigint (src);
 
 	numeric_coerce_bigint_to_num (bigint, num);
 	precision = get_significant_digit (bigint);
@@ -3446,7 +3446,7 @@ numeric_db_value_coerce_to_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATUS 
 
     case DB_TYPE_ENUMERATION:
       {
-	int anint = DB_GET_ENUM_SHORT (src);
+	int anint = db_get_enum_short (src);
 	numeric_coerce_int_to_num (anint, num);
 	precision = 5;
 	scale = 0;
@@ -3462,7 +3462,7 @@ numeric_db_value_coerce_to_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATUS 
   if (ret == NO_ERROR)
     {
       /* Make the intermediate value */
-      DB_MAKE_NUMERIC (dest, num, precision, scale);
+      db_make_numeric (dest, num, precision, scale);
       ret =
 	numeric_coerce_num_to_num (db_locate_numeric (dest), DB_VALUE_PRECISION (dest), DB_VALUE_SCALE (dest),
 				   desired_precision, desired_scale, num);
@@ -3471,7 +3471,7 @@ numeric_db_value_coerce_to_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATUS 
 	  goto exit_on_error;
 	}
 
-      DB_MAKE_NUMERIC (dest, num, desired_precision, desired_scale);
+      db_make_numeric (dest, num, desired_precision, desired_scale);
     }
 
   if (ret == ER_IT_DATA_OVERFLOW)
@@ -3520,7 +3520,7 @@ numeric_db_value_coerce_from_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATU
 	    ret = ER_IT_DATA_OVERFLOW;
 	    goto exit_on_error;
 	  }
-	DB_MAKE_DOUBLE (dest, adouble);
+	db_make_double (dest, adouble);
 	break;
       }
 
@@ -3533,7 +3533,7 @@ numeric_db_value_coerce_from_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATU
 	    ret = ER_IT_DATA_OVERFLOW;
 	    goto exit_on_error;
 	  }
-	DB_MAKE_FLOAT (dest, (float) adouble);
+	db_make_float (dest, (float) adouble);
 	break;
       }
 
@@ -3541,7 +3541,7 @@ numeric_db_value_coerce_from_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATU
       {
 	double adouble;
 	numeric_coerce_num_to_double (db_locate_numeric (src), DB_VALUE_SCALE (src), &adouble);
-	DB_MAKE_MONETARY_AMOUNT (dest, adouble);
+	db_make_monetary (dest, DB_CURRENCY_DEFAULT, adouble);
 	break;
       }
 
@@ -3554,7 +3554,7 @@ numeric_db_value_coerce_from_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATU
 	    ret = ER_IT_DATA_OVERFLOW;
 	    goto exit_on_error;
 	  }
-	DB_MAKE_INTEGER (dest, (int) ROUND (adouble));
+	db_make_int (dest, (int) ROUND (adouble));
 	break;
       }
 
@@ -3568,7 +3568,7 @@ numeric_db_value_coerce_from_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATU
 	    goto exit_on_error;
 	  }
 
-	DB_MAKE_BIGINT (dest, bint);
+	db_make_bigint (dest, bint);
 	break;
       }
 
@@ -3581,7 +3581,7 @@ numeric_db_value_coerce_from_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATU
 	    ret = ER_IT_DATA_OVERFLOW;
 	    goto exit_on_error;
 	  }
-	DB_MAKE_SMALLINT (dest, (DB_C_SHORT) ROUND (adouble));
+	db_make_short (dest, (DB_C_SHORT) ROUND (adouble));
 	break;
       }
 
@@ -3614,19 +3614,19 @@ numeric_db_value_coerce_from_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATU
 	type = DB_VALUE_DOMAIN_TYPE (dest);
 	if (type == DB_TYPE_CHAR)
 	  {
-	    DB_MAKE_CHAR (dest, size, return_string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_char (dest, size, return_string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	  }
 	else if (type == DB_TYPE_VARCHAR)
 	  {
-	    DB_MAKE_VARCHAR (dest, size, return_string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_varchar (dest, size, return_string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	  }
 	else if (type == DB_TYPE_NCHAR)
 	  {
-	    DB_MAKE_NCHAR (dest, size, return_string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_nchar (dest, size, return_string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	  }
 	else if (type == DB_TYPE_VARNCHAR)
 	  {
-	    DB_MAKE_VARNCHAR (dest, size, return_string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_varnchar (dest, size, return_string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	  }
 	dest->need_clear = true;
 	break;
@@ -3641,7 +3641,7 @@ numeric_db_value_coerce_from_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATU
 	numeric_coerce_num_to_double (db_locate_numeric (src), DB_VALUE_SCALE (src), &adouble);
 	v_time = (int) (adouble + 0.5) % SECONDS_IN_A_DAY;
 	db_time_decode (&v_time, &hour, &minute, &second);
-	DB_MAKE_TIME (dest, hour, minute, second);
+	db_make_time (dest, hour, minute, second);
 	break;
       }
 
@@ -3654,7 +3654,7 @@ numeric_db_value_coerce_from_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATU
 	numeric_coerce_num_to_double (db_locate_numeric (src), DB_VALUE_SCALE (src), &adouble);
 	v_date = (DB_DATE) (adouble);
 	db_date_decode (&v_date, &month, &day, &year);
-	DB_MAKE_DATE (dest, month, day, year);
+	db_make_date (dest, month, day, year);
 	break;
       }
 
@@ -3665,7 +3665,7 @@ numeric_db_value_coerce_from_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATU
 
 	numeric_coerce_num_to_double (db_locate_numeric (src), DB_VALUE_SCALE (src), &adouble);
 	v_timestamp = (DB_TIMESTAMP) (adouble);
-	DB_MAKE_TIMESTAMP (dest, v_timestamp);
+	db_make_timestamp (dest, v_timestamp);
 	break;
       }
 
@@ -3727,7 +3727,7 @@ numeric_db_value_coerce_from_num_strict (DB_VALUE * src, DB_VALUE * dest)
 	  {
 	    return ER_FAILED;
 	  }
-	DB_MAKE_DOUBLE (dest, adouble);
+	db_make_double (dest, adouble);
 	break;
       }
 
@@ -3739,7 +3739,7 @@ numeric_db_value_coerce_from_num_strict (DB_VALUE * src, DB_VALUE * dest)
 	  {
 	    return ER_FAILED;
 	  }
-	DB_MAKE_FLOAT (dest, (float) adouble);
+	db_make_float (dest, (float) adouble);
 	break;
       }
 
@@ -3751,7 +3751,7 @@ numeric_db_value_coerce_from_num_strict (DB_VALUE * src, DB_VALUE * dest)
 	  {
 	    return ER_FAILED;
 	  }
-	DB_MAKE_MONETARY_AMOUNT (dest, adouble);
+	db_make_monetary (dest, DB_CURRENCY_DEFAULT, adouble);
 	break;
       }
 
@@ -3767,7 +3767,7 @@ numeric_db_value_coerce_from_num_strict (DB_VALUE * src, DB_VALUE * dest)
 	  {
 	    return ER_FAILED;
 	  }
-	DB_MAKE_INTEGER (dest, (int) (adouble));
+	db_make_int (dest, (int) (adouble));
 	break;
       }
 
@@ -3785,7 +3785,7 @@ numeric_db_value_coerce_from_num_strict (DB_VALUE * src, DB_VALUE * dest)
 	  {
 	    return ER_FAILED;
 	  }
-	DB_MAKE_BIGINT (dest, bint);
+	db_make_bigint (dest, bint);
 	break;
       }
 
@@ -3801,7 +3801,7 @@ numeric_db_value_coerce_from_num_strict (DB_VALUE * src, DB_VALUE * dest)
 	  {
 	    return ER_FAILED;
 	  }
-	DB_MAKE_SMALLINT (dest, (DB_C_SHORT) ROUND (adouble));
+	db_make_short (dest, (DB_C_SHORT) ROUND (adouble));
 	break;
       }
 

--- a/src/query/partition.c
+++ b/src/query/partition.c
@@ -1100,7 +1100,7 @@ partition_prune_list (PRUNING_CONTEXT * pinfo, const DB_VALUE * val, const PRUNI
 		return MATCH_NOT_FOUND;
 	      }
 
-	    val_collection = DB_GET_COLLECTION (val);
+	    val_collection = db_get_set (val);
 	    for (j = 0; j < size; j++)
 	      {
 		db_set_get (part_collection, j, &col);
@@ -1135,7 +1135,7 @@ partition_prune_list (PRUNING_CONTEXT * pinfo, const DB_VALUE * val, const PRUNI
 		status = MATCH_NOT_FOUND;
 	      }
 
-	    val_collection = DB_GET_COLLECTION (val);
+	    val_collection = db_get_set (val);
 	    for (j = 0; j < size; j++)
 	      {
 		db_set_get (part_collection, j, &col);
@@ -1210,7 +1210,7 @@ partition_prune_hash (PRUNING_CONTEXT * pinfo, const DB_VALUE * val_p, const PRU
   DB_VALUE val;
   MATCH_STATUS status = MATCH_NOT_FOUND;
 
-  DB_MAKE_NULL (&val);
+  db_make_null (&val);
 
   col_domain = pinfo->partition_pred->func_regu->domain;
   switch (op)
@@ -1254,7 +1254,7 @@ partition_prune_hash (PRUNING_CONTEXT * pinfo, const DB_VALUE * val_p, const PRU
 	    goto cleanup;
 	  }
 
-	values = DB_GET_COLLECTION (val_p);
+	values = db_get_set (val_p);
 	size = db_set_size (values);
 	if (size < 0)
 	  {
@@ -1330,8 +1330,8 @@ partition_prune_range (PRUNING_CONTEXT * pinfo, const DB_VALUE * val, const PRUN
   int rmin = DB_UNK, rmax = DB_UNK;
   MATCH_STATUS status;
 
-  DB_MAKE_NULL (&min);
-  DB_MAKE_NULL (&max);
+  db_make_null (&min);
+  db_make_null (&max);
 
   for (i = 0; i < PARTITIONS_COUNT (pinfo); i++)
     {
@@ -1518,7 +1518,7 @@ partition_prune (PRUNING_CONTEXT * pinfo, const REGU_VARIABLE * arg, const PRUNI
 
   if (op == PO_IS_NULL)
     {
-      DB_MAKE_NULL (&val);
+      db_make_null (&val);
       is_value = true;
     }
   else if (partition_get_value_from_regu_var (pinfo, arg, &val, &is_value) != NO_ERROR)
@@ -1586,7 +1586,7 @@ partition_get_value_from_regu_var (PRUNING_CONTEXT * pinfo, const REGU_VARIABLE 
 	if (regu->value.funcp->ftype != F_MIDXKEY)
 	  {
 	    *is_value = false;
-	    DB_MAKE_NULL (value_p);
+	    db_make_null (value_p);
 	    return NO_ERROR;
 	  }
 	if (partition_get_value_from_key (pinfo, regu, value_p, is_value) != NO_ERROR)
@@ -1607,7 +1607,7 @@ partition_get_value_from_regu_var (PRUNING_CONTEXT * pinfo, const REGU_VARIABLE 
       break;
 
     default:
-      DB_MAKE_NULL (value_p);
+      db_make_null (value_p);
       *is_value = false;
       return NO_ERROR;
     }
@@ -1615,7 +1615,7 @@ partition_get_value_from_regu_var (PRUNING_CONTEXT * pinfo, const REGU_VARIABLE 
   return NO_ERROR;
 
 error:
-  DB_MAKE_NULL (value_p);
+  db_make_null (value_p);
   *is_value = false;
 
   return ER_FAILED;
@@ -1724,7 +1724,7 @@ partition_get_value_from_key (PRUNING_CONTEXT * pinfo, const REGU_VARIABLE * key
 
 	if (regu_list == NULL)
 	  {
-	    DB_MAKE_NULL (attr_key);
+	    db_make_null (attr_key);
 	    error = NO_ERROR;
 
 	    *is_present = false;
@@ -1743,7 +1743,7 @@ partition_get_value_from_key (PRUNING_CONTEXT * pinfo, const REGU_VARIABLE * key
     case TYPE_CONSTANT:
       /* TYPE_CONSTANT comes from an index join. Since we haven't actually scanned anything yet, this value is not set
        * so we cannot use it here */
-      DB_MAKE_NULL (attr_key);
+      db_make_null (attr_key);
       error = NO_ERROR;
       *is_present = false;
       break;
@@ -1751,7 +1751,7 @@ partition_get_value_from_key (PRUNING_CONTEXT * pinfo, const REGU_VARIABLE * key
     default:
       assert (false);
 
-      DB_MAKE_NULL (attr_key);
+      db_make_null (attr_key);
 
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       error = ER_FAILED;
@@ -1785,7 +1785,7 @@ partition_get_value_from_inarith (PRUNING_CONTEXT * pinfo, const REGU_VARIABLE *
   assert_release (src->type == TYPE_INARITH);
 
   *is_value = false;
-  DB_MAKE_NULL (value_p);
+  db_make_null (value_p);
 
   if (!partition_is_reguvar_const (src))
     {
@@ -2443,7 +2443,7 @@ partition_load_partition_predicate (PRUNING_CONTEXT * pinfo, OR_PARTITION * mast
 
   assert (DB_VALUE_TYPE (&val) == DB_TYPE_CHAR);
   expr_stream = db_get_string (&val);
-  stream_len = DB_GET_STRING_SIZE (&val);
+  stream_len = db_get_string_size (&val);
 
   /* unpack partition expression */
   error =

--- a/src/query/query_evaluator.c
+++ b/src/query/query_evaluator.c
@@ -1589,7 +1589,7 @@ eval_set_list_cmp (THREAD_ENTRY * thread_p, COMP_EVAL_TERM * et_comp, VAL_DESCR 
       else
 	{
 	  /* compare list file and set */
-	  return eval_sort_list_to_multi_set (thread_p, lhs_srlist_id->list_id, DB_GET_SET (dbval2), et_comp->rel_op);
+	  return eval_sort_list_to_multi_set (thread_p, lhs_srlist_id->list_id, db_get_set (dbval2), et_comp->rel_op);
 	}
     }
   else if (et_comp->rhs->type == TYPE_LIST_ID)
@@ -1620,7 +1620,7 @@ eval_set_list_cmp (THREAD_ENTRY * thread_p, COMP_EVAL_TERM * et_comp, VAL_DESCR 
 	}
 
       /* lhs must be a set value, compare set and list */
-      return eval_multi_set_to_sort_list (thread_p, DB_GET_SET (dbval1), rhs_srlist_id->list_id, et_comp->rel_op);
+      return eval_multi_set_to_sort_list (thread_p, db_get_set (dbval1), rhs_srlist_id->list_id, et_comp->rel_op);
     }
 
   return V_UNKNOWN;
@@ -1856,7 +1856,7 @@ eval_pred (THREAD_ENTRY * thread_p, PRED_EXPR * pr, VAL_DESCR * vd, OID * obj_oi
 		      goto exit;
 		    }
 
-		  result = ((db_set_size (DB_GET_SET (peek_val1)) > 0) ? V_TRUE : V_FALSE);
+		  result = ((db_set_size (db_get_set (peek_val1)) > 0) ? V_TRUE : V_FALSE);
 		}
 	      break;
 	    }
@@ -1941,7 +1941,7 @@ eval_pred (THREAD_ENTRY * thread_p, PRED_EXPR * pr, VAL_DESCR * vd, OID * obj_oi
 
 		rhs_type = DB_VALUE_TYPE (peek_val2);
 		rhs_is_set = TP_IS_SET_TYPE (rhs_type);
-		if (rhs_is_set && set_size (DB_GET_SET (peek_val2)) == 0)
+		if (rhs_is_set && set_size (db_get_set (peek_val2)) == 0)
 		  {
 		    /* empty set */
 		    result = (et_alsm->eq_flag == F_ALL) ? V_TRUE : V_FALSE;
@@ -1999,11 +1999,11 @@ eval_pred (THREAD_ENTRY * thread_p, PRED_EXPR * pr, VAL_DESCR * vd, OID * obj_oi
 		/* rhs value is a set, use set evaluation routines */
 		if (et_alsm->eq_flag == F_ALL)
 		  {
-		    result = eval_all_eval (peek_val1, DB_GET_SET (peek_val2), et_alsm->rel_op);
+		    result = eval_all_eval (peek_val1, db_get_set (peek_val2), et_alsm->rel_op);
 		  }
 		else
 		  {
-		    result = eval_some_eval (peek_val1, DB_GET_SET (peek_val2), et_alsm->rel_op);
+		    result = eval_some_eval (peek_val1, db_get_set (peek_val2), et_alsm->rel_op);
 		  }
 	      }
 	    else
@@ -2225,7 +2225,7 @@ eval_pred_comp2 (THREAD_ENTRY * thread_p, PRED_EXPR * pr, VAL_DESCR * vd, OID * 
 	  return V_ERROR;
 	}
 
-      return (set_size (DB_GET_SET (peek_val1)) > 0) ? V_TRUE : V_FALSE;
+      return (set_size (db_get_set (peek_val1)) > 0) ? V_TRUE : V_FALSE;
     }
 }
 
@@ -2326,7 +2326,7 @@ eval_pred_alsm4 (THREAD_ENTRY * thread_p, PRED_EXPR * pr, VAL_DESCR * vd, OID * 
       return V_ERROR;
     }
 
-  if (set_size (DB_GET_SET (peek_val2)) == 0)
+  if (set_size (db_get_set (peek_val2)) == 0)
     {
       /* empty set */
       return ((et_alsm->eq_flag == F_ALL) ? V_TRUE : V_FALSE);
@@ -2345,11 +2345,11 @@ eval_pred_alsm4 (THREAD_ENTRY * thread_p, PRED_EXPR * pr, VAL_DESCR * vd, OID * 
   /* rhs value is a set, use set evaluation routines */
   if (et_alsm->eq_flag == F_ALL)
     {
-      return eval_all_eval (peek_val1, DB_GET_SET (peek_val2), et_alsm->rel_op);
+      return eval_all_eval (peek_val1, db_get_set (peek_val2), et_alsm->rel_op);
     }
   else
     {
-      return eval_some_eval (peek_val1, DB_GET_SET (peek_val2), et_alsm->rel_op);
+      return eval_some_eval (peek_val1, db_get_set (peek_val2), et_alsm->rel_op);
     }
 }
 
@@ -2860,7 +2860,7 @@ eval_key_filter (THREAD_ENTRY * thread_p, DB_VALUE * value, FILTER_INFO * filter
     {
       if (DB_VALUE_TYPE (value) == DB_TYPE_MIDXKEY)
 	{
-	  midxkey = DB_GET_MIDXKEY (value);
+	  midxkey = db_get_midxkey (value);
 
 	  if (filterp->btree_num_attrs <= 0 || !filterp->btree_attr_ids || !midxkey)
 	    {
@@ -2940,7 +2940,7 @@ eval_key_filter (THREAD_ENTRY * thread_p, DB_VALUE * value, FILTER_INFO * filter
 		   */
 		  DB_VALUE null;
 
-		  DB_MAKE_NULL (&null);
+		  db_make_null (&null);
 		  if (heap_attrinfo_set (NULL, scan_attrsp->attr_ids[i], &null, scan_attrsp->attr_cache) != NO_ERROR)
 		    {
 		      return V_ERROR;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -811,7 +811,7 @@ qexec_add_composite_lock (THREAD_ENTRY * thread_p, REGU_VARIABLE_LIST reg_var_li
 	  if (typ == DB_TYPE_VOBJ)
 	    {
 	      /* grab the real oid */
-	      ret = db_seq_get (DB_GET_SEQUENCE (dbval), 2, &element);
+	      ret = db_seq_get (db_get_set (dbval), 2, &element);
 	      if (ret != NO_ERROR)
 		{
 		  GOTO_EXIT_ON_ERROR;
@@ -825,7 +825,7 @@ qexec_add_composite_lock (THREAD_ENTRY * thread_p, REGU_VARIABLE_LIST reg_var_li
 	      GOTO_EXIT_ON_ERROR;
 	    }
 
-	  SAFE_COPY_OID (&instance_oid, DB_GET_OID (dbval));
+	  SAFE_COPY_OID (&instance_oid, db_get_oid (dbval));
 
 	  if (default_cls_oid != NULL)
 	    {
@@ -843,7 +843,7 @@ qexec_add_composite_lock (THREAD_ENTRY * thread_p, REGU_VARIABLE_LIST reg_var_li
 	      if (typ == DB_TYPE_VOBJ)
 		{
 		  /* grab the real oid */
-		  ret = db_seq_get (DB_GET_SEQUENCE (dbval), 2, &element);
+		  ret = db_seq_get (db_get_set (dbval), 2, &element);
 		  if (ret != NO_ERROR)
 		    {
 		      GOTO_EXIT_ON_ERROR;
@@ -857,7 +857,7 @@ qexec_add_composite_lock (THREAD_ENTRY * thread_p, REGU_VARIABLE_LIST reg_var_li
 		  GOTO_EXIT_ON_ERROR;
 		}
 
-	      SAFE_COPY_OID (&class_oid, DB_GET_OID (dbval));
+	      SAFE_COPY_OID (&class_oid, db_get_oid (dbval));
 	    }
 
 	  ret = lock_add_composite_lock (thread_p, composite_lock, &instance_oid, &class_oid);
@@ -1000,7 +1000,7 @@ qexec_upddel_add_unique_oid_to_ehid (THREAD_ENTRY * thread_p, XASL_NODE * xasl, 
 	  if (typ == DB_TYPE_VOBJ)
 	    {
 	      /* grab the real oid */
-	      ret = db_seq_get (DB_GET_SEQUENCE (dbval), 2, &element);
+	      ret = db_seq_get (db_get_set (dbval), 2, &element);
 	      if (ret != NO_ERROR)
 		{
 		  GOTO_EXIT_ON_ERROR;
@@ -1018,7 +1018,7 @@ qexec_upddel_add_unique_oid_to_ehid (THREAD_ENTRY * thread_p, XASL_NODE * xasl, 
 	  /* Get the appropriate hash file and check if the OID exists in the file */
 	  ehid = &xasl->proc.buildlist.upddel_oid_locator_ehids[idx];
 
-	  SAFE_COPY_OID (&key_oid, DB_GET_OID (dbval));
+	  SAFE_COPY_OID (&key_oid, db_get_oid (dbval));
 
 	  eh_search = ehash_search (thread_p, ehid, &key_oid, &oid);
 	  switch (eh_search)
@@ -2829,7 +2829,7 @@ qexec_ordby_put_next (THREAD_ENTRY * thread_p, const RECDES * recdes, void *arg)
 	  if (ordby_info->ordbynum_flag & XASL_ORDBYNUM_FLAG_SCAN_STOP)
 	    {
 	      /* reset ordbynum_val for next use */
-	      DB_MAKE_BIGINT (ordby_info->ordbynum_val, 0);
+	      db_make_bigint (ordby_info->ordbynum_val, 0);
 	      /* setting SORT_PUT_STOP will make 'sr_in_sort()' stop processing; the caller, 'qexec_gby_put_next()',
 	       * returns 'gbstate->state' */
 	      return SORT_PUT_STOP;
@@ -3036,7 +3036,7 @@ qexec_fill_sort_limit (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * x
 	}
     }
 
-  *limit_ptr = DB_GET_INTEGER (dbvalp);
+  *limit_ptr = db_get_int (dbvalp);
   if (*limit_ptr < 0)
     {
       /* If the limit is below 0, set it to 0 and still return success. */
@@ -4347,7 +4347,7 @@ qexec_groupby (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_stat
   /* initialize groupby_num() value */
   if (buildlist->g_grbynum_val && DB_IS_NULL (buildlist->g_grbynum_val))
     {
-      DB_MAKE_BIGINT (buildlist->g_grbynum_val, 0);
+      db_make_bigint (buildlist->g_grbynum_val, 0);
     }
 
   /* clear group by limit flags when skip group by is not used */
@@ -8789,7 +8789,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 		}
 	      else
 		{
-		  should_delete = DB_GET_INT (valp);
+		  should_delete = db_get_int (valp);
 		}
 
 	      if (should_delete)
@@ -8834,7 +8834,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 		  internal_class->oid = NULL;
 		  continue;
 		}
-	      internal_class->oid = DB_GET_OID (valp);
+	      internal_class->oid = db_get_oid (valp);
 	      if (mvcc_reev_class != NULL)
 		{
 		  mvcc_reev_class->inst_oid = internal_class->oid;
@@ -8850,7 +8850,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 		{
 		  continue;
 		}
-	      class_oid = DB_GET_OID (valp);
+	      class_oid = db_get_oid (valp);
 
 	      /* class has changed to a new subclass */
 	      if (class_oid
@@ -9006,7 +9006,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
-	      /* FIXME: Function version of DB_GET_OID returns (probably) NULL_OID when the value is NULL,
+	      /* FIXME: Function version of db_get_oid returns (probably) NULL_OID when the value is NULL,
 	       * while macro version returns NULL pointer. This may cause different behavior.
 	       * As a quick fix, I'm going to add DB_IS_NULL block to keep the existing behavior.
 	       * We need to investigate and get rid of differences of two implementation.
@@ -9018,7 +9018,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 		}
 	      else
 		{
-		  mvcc_reev_class->inst_oid = DB_GET_OID (valp);
+		  mvcc_reev_class->inst_oid = db_get_oid (valp);
 		}
 
 	      /* class OID */
@@ -9035,7 +9035,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 		}
 	      else
 		{
-		  class_oid = DB_GET_OID (valp);
+		  class_oid = db_get_oid (valp);
 		}
 
 	      /* class has changed to a new subclass */
@@ -9697,7 +9697,7 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		    }
 		  continue;
 		}
-	      oid = DB_GET_OID (valp);
+	      oid = db_get_oid (valp);
 
 	      /* class OID */
 	      valp = val_list->next->val;
@@ -9713,7 +9713,7 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		    }
 		  continue;
 		}
-	      class_oid = DB_GET_OID (valp);
+	      class_oid = db_get_oid (valp);
 
 	      if (class_oid_idx < class_oid_cnt)
 		{
@@ -10185,7 +10185,7 @@ qexec_remove_duplicates_for_replace (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * s
 
   *removed_count = 0;
 
-  DB_MAKE_NULL (&dbvalue);
+  db_make_null (&dbvalue);
 
   if (heap_attrinfo_clear_dbvalues (index_attr_info) != NO_ERROR)
     {
@@ -10409,7 +10409,7 @@ qexec_oid_of_duplicate_key_update (THREAD_ENTRY * thread_p, HEAP_SCANCACHE ** pr
 
   assert (pruned_partition_scan_cache != NULL);
 
-  DB_MAKE_NULL (&dbvalue);
+  db_make_null (&dbvalue);
   OID_SET_NULL (unique_oid_p);
   OID_SET_NULL (&unique_oid);
 
@@ -10893,7 +10893,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
       num_default_expr = 0;
     }
 
-  DB_MAKE_NULL (&insert_val);
+  db_make_null (&insert_val);
   for (k = 0; k < num_default_expr; k++)
     {
       OR_ATTRIBUTE *attr;
@@ -10911,7 +10911,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	{
 	  GOTO_EXIT_ON_ERROR;
 	}
-      DB_MAKE_NULL (new_val);
+      db_make_null (new_val);
       insert->vals[k] = new_val;
 
       switch (attr->current_default_value.default_expr.default_expr_type)
@@ -10933,7 +10933,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	    len_dest = (int) strlen (t_dest);
 	    db_time = xasl_state->vd.sys_datetime.time / 1000;
 	    error = tz_conv_tz_time_w_zone_name (&db_time, t_source, len_source, t_dest, len_dest, &cur_time);
-	    DB_MAKE_ENCODED_TIME (&insert_val, &cur_time);
+	    db_value_put_encoded_time (&insert_val, &cur_time);
 	  }
 	  break;
 
@@ -10952,16 +10952,16 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	    error =
 	      tz_conv_tz_datetime_w_region (&xasl_state->vd.sys_datetime, &system_tz_region, &session_tz_region,
 					    &dest_dt, NULL, NULL);
-	    DB_MAKE_ENCODED_DATE (&insert_val, &dest_dt.date);
+	    db_value_put_encoded_date (&insert_val, &dest_dt.date);
 	  }
 	  break;
 
 	case DB_DEFAULT_SYSDATETIME:
-	  DB_MAKE_DATETIME (&insert_val, &xasl_state->vd.sys_datetime);
+	  db_make_datetime (&insert_val, &xasl_state->vd.sys_datetime);
 	  break;
 
 	case DB_DEFAULT_SYSTIMESTAMP:
-	  DB_MAKE_DATETIME (&insert_val, &xasl_state->vd.sys_datetime);
+	  db_make_datetime (&insert_val, &xasl_state->vd.sys_datetime);
 	  error = db_datetime_to_timestamp (&insert_val, &insert_val);
 	  break;
 
@@ -10975,7 +10975,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	    error =
 	      tz_conv_tz_datetime_w_region (&xasl_state->vd.sys_datetime, &system_tz_region, &session_tz_region,
 					    &dest_dt, NULL, NULL);
-	    DB_MAKE_DATETIME (&insert_val, &dest_dt);
+	    db_make_datetime (&insert_val, &dest_dt);
 	  }
 	  break;
 
@@ -10993,7 +10993,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	  break;
 
 	case DB_DEFAULT_UNIX_TIMESTAMP:
-	  DB_MAKE_DATETIME (&insert_val, &xasl_state->vd.sys_datetime);
+	  db_make_datetime (&insert_val, &xasl_state->vd.sys_datetime);
 	  error = db_unix_timestamp (&insert_val, &insert_val);
 	  break;
 
@@ -11021,7 +11021,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		  }
 	      }
 
-	    DB_MAKE_STRING (&insert_val, temp);
+	    db_make_string (&insert_val, temp);
 	    insert_val.need_clear = true;
 	  }
 	  break;
@@ -11037,7 +11037,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	      {
 		temp = tdes->client.db_user;
 	      }
-	    DB_MAKE_STRING (&insert_val, temp);
+	    db_make_string (&insert_val, temp);
 	  }
 	  break;
 
@@ -11718,20 +11718,20 @@ qexec_execute_obj_fetch (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE *
       /* check for virtual objects */
       if (DB_VALUE_DOMAIN_TYPE (fetch->arg) != DB_TYPE_VOBJ)
 	{
-	  SAFE_COPY_OID (&dbvaloid, DB_GET_OID (fetch->arg));
+	  SAFE_COPY_OID (&dbvaloid, db_get_oid (fetch->arg));
 	}
       else
 	{
-	  DB_SET *setp = DB_GET_SET (fetch->arg);
+	  DB_SET *setp = db_get_set (fetch->arg);
 	  DB_VALUE dbval, dbval1;
 
 	  if ((db_set_size (setp) == 3) && (db_set_get (setp, 1, &dbval) == NO_ERROR)
 	      && (db_set_get (setp, 2, &dbval1) == NO_ERROR)
 	      && (DB_IS_NULL (&dbval)
-		  || ((DB_VALUE_DOMAIN_TYPE (&dbval) == DB_TYPE_OID) && OID_ISNULL (DB_GET_OID (&dbval))))
+		  || ((DB_VALUE_DOMAIN_TYPE (&dbval) == DB_TYPE_OID) && OID_ISNULL (db_get_oid (&dbval))))
 	      && (DB_VALUE_DOMAIN_TYPE (&dbval1) == DB_TYPE_OID))
 	    {
-	      SAFE_COPY_OID (&dbvaloid, DB_GET_OID (&dbval1));
+	      SAFE_COPY_OID (&dbvaloid, db_get_oid (&dbval1));
 	    }
 	  else
 	    {
@@ -12347,7 +12347,7 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 	  /* get oid and attrid to be fetched last at scan */
 	  rightvalp = varptr->value.arithptr->value;
 
-	  oid = DB_GET_OID (rightvalp);
+	  oid = db_get_oid (rightvalp);
 	  if (oid == NULL)
 	    {
 	      /* Probably this would be INCR(NULL). When the source value is NULL, INCR/DECR expression is also NULL. */
@@ -12370,7 +12370,7 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 	    {
 	      goto exit_on_error;
 	    }
-	  attrid = DB_GET_INTEGER (thirdvalp);
+	  attrid = db_get_int (thirdvalp);
 
 	  n_increment = (varptr->value.arithptr->opcode == T_INCR ? 1 : -1);
 
@@ -12639,11 +12639,11 @@ qexec_init_instnum_val (XASL_NODE * xasl, THREAD_ENTRY * thread_p, XASL_STATE * 
   TP_DOMAIN_STATUS dom_status;
 
   assert (xasl && xasl->instnum_val);
-  DB_MAKE_BIGINT (xasl->instnum_val, 0);
+  db_make_bigint (xasl->instnum_val, 0);
 
   if (xasl->save_instnum_val)
     {
-      DB_MAKE_BIGINT (xasl->save_instnum_val, 0);
+      db_make_bigint (xasl->save_instnum_val, 0);
     }
 
   /* Single table, index scan, with keylimit that has lower value */
@@ -12779,7 +12779,7 @@ qexec_start_mainblock_iterations (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 	/* initialize groupby_num() value for BUILDLIST_PROC */
 	if (buildlist->g_grbynum_val)
 	  {
-	    DB_MAKE_BIGINT (buildlist->g_grbynum_val, 0);
+	    db_make_bigint (buildlist->g_grbynum_val, 0);
 	  }
 
 	if (xasl->list_id->type_list.type_cnt == 0)
@@ -12894,7 +12894,7 @@ qexec_start_mainblock_iterations (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 	/* set groupby_num() value as 1 for BUILDVALUE_PROC */
 	if (buildvalue->grbynum_val)
 	  {
-	    DB_MAKE_BIGINT (buildvalue->grbynum_val, 1);
+	    db_make_bigint (buildvalue->grbynum_val, 1);
 	  }
 
 	/* initialize aggregation list */
@@ -12928,7 +12928,7 @@ qexec_start_mainblock_iterations (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
   /* initialize orderby_num() value */
   if (xasl->ordbynum_val)
     {
-      DB_MAKE_BIGINT (xasl->ordbynum_val, 0);
+      db_make_bigint (xasl->ordbynum_val, 0);
     }
 
   if (XASL_IS_FLAGED (xasl, XASL_HAS_CONNECT_BY))
@@ -12936,17 +12936,17 @@ qexec_start_mainblock_iterations (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
       /* initialize level_val value */
       if (xasl->level_val)
 	{
-	  DB_MAKE_INT (xasl->level_val, 0);
+	  db_make_int (xasl->level_val, 0);
 	}
       /* initialize isleaf_val value */
       if (xasl->isleaf_val)
 	{
-	  DB_MAKE_INT (xasl->isleaf_val, 0);
+	  db_make_int (xasl->isleaf_val, 0);
 	}
       /* initialize iscycle_val value */
       if (xasl->iscycle_val)
 	{
-	  DB_MAKE_INT (xasl->iscycle_val, 0);
+	  db_make_int (xasl->iscycle_val, 0);
 	}
     }
 
@@ -13376,7 +13376,7 @@ qexec_check_limit_clause (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
   /* init output */
   *empty_result = false;
 
-  DB_MAKE_INT (&zero_val, 0);
+  db_make_int (&zero_val, 0);
 
   if (xasl->limit_offset != NULL)
     {
@@ -15042,7 +15042,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 
       /* calculate LEVEL pseudocolumn value */
       level_value++;
-      DB_MAKE_INT (level_valp, level_value);
+      db_make_int (level_valp, level_value);
 
       /* start parents list scanner */
       if (qfile_open_list_scan (listfile1, &lfscan_id) != NO_ERROR)
@@ -15064,7 +15064,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	  parent_tuple_added = false;
 
 	  /* reset parent tuple position pseudocolumn value */
-	  DB_MAKE_BIT (parent_pos_valp, DB_DEFAULT_PRECISION, NULL, 8);
+	  db_make_bit (parent_pos_valp, DB_DEFAULT_PRECISION, NULL, 8);
 
 	  /* fetch regu_variable values from parent tuple; obs: prior_regu_list was split into pred and rest for
 	   * possible future optimizations. */
@@ -15177,7 +15177,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 		  if (xasl->level_val)
 		    {
 		      /* set level_val to children's level */
-		      DB_MAKE_INT (xasl->level_val, level_value + 1);
+		      db_make_int (xasl->level_val, level_value + 1);
 		    }
 		  ev_res = eval_pred (thread_p, xasl->if_pred, &xasl_state->vd, NULL);
 		  if (ev_res == V_ERROR)
@@ -15227,12 +15227,12 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 			    }
 
 			  /* set index string pseudocolumn value to tuples from START WITH list */
-			  DB_MAKE_STRING (index_valp, father_index);
+			  db_make_string (index_valp, father_index);
 			}
 
 		      /* set CONNECT_BY_ISLEAF pseudocolumn value; this is only for completion, we don't know its final
 		       * value yet */
-		      DB_MAKE_INT (isleaf_valp, isleaf_value);
+		      db_make_int (isleaf_valp, isleaf_value);
 
 		      /* preserve the parent position pseudocolumn value */
 		      if (qexec_get_tuple_column_value (tuple_rec.tpl,
@@ -15258,7 +15258,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 			}
 
 		      /* set parent tuple position pseudocolumn value */
-		      DB_MAKE_BIT (parent_pos_valp, DB_DEFAULT_PRECISION, (const DB_C_BIT) (&parent_pos),
+		      db_make_bit (parent_pos_valp, DB_DEFAULT_PRECISION, (const DB_C_BIT) (&parent_pos),
 				   sizeof (parent_pos) * 8);
 
 		      parent_tuple_added = true;
@@ -15290,7 +15290,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 			      pr_clear_value (index_valp);
 			    }
 
-			  DB_MAKE_STRING (index_valp, son_index);
+			  db_make_string (index_valp, son_index);
 
 			  if (qexec_insert_tuple_into_list (thread_p, listfile2, xasl->outptr_list, &xasl_state->vd,
 							    tplrec) != NO_ERROR)
@@ -15344,10 +15344,10 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 		      pr_clear_value (index_valp);
 		    }
 
-		  DB_MAKE_STRING (index_valp, father_index);
+		  db_make_string (index_valp, father_index);
 		}
 
-	      DB_MAKE_INT (isleaf_valp, isleaf_value);
+	      db_make_int (isleaf_valp, isleaf_value);
 
 	      if (qexec_get_tuple_column_value (tuple_rec.tpl,
 						(xasl->outptr_list->valptr_cnt - PCOL_PARENTPOS_TUPLE_OFFSET),
@@ -15371,7 +15371,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	    }
 
 	  /* set CONNECT_BY_ISCYCLE pseudocolumn value */
-	  DB_MAKE_INT (iscycle_valp, iscycle_value);
+	  db_make_int (iscycle_valp, iscycle_value);
 	  /* it is fixed size data, so we can set it in this fashion */
 	  if (qfile_set_tuple_column_value (thread_p, listfile0, NULL, &parent_pos.vpid, parent_pos.tpl,
 					    (xasl->outptr_list->valptr_cnt - PCOL_ISCYCLE_TUPLE_OFFSET), iscycle_valp,
@@ -15381,7 +15381,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	    }
 
 	  /* set CONNECT_BY_ISLEAF pseudocolumn value */
-	  DB_MAKE_INT (isleaf_valp, isleaf_value);
+	  db_make_int (isleaf_valp, isleaf_value);
 	  if (qfile_set_tuple_column_value (thread_p, listfile0, NULL, &parent_pos.vpid, parent_pos.tpl,
 					    (xasl->outptr_list->valptr_cnt - PCOL_ISLEAF_TUPLE_OFFSET), isleaf_valp,
 					    &tp_Integer_domain) != NO_ERROR)
@@ -15425,7 +15425,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 		      pr_clear_value (index_valp);
 		    }
 
-		  DB_MAKE_STRING (index_valp, son_index);
+		  db_make_string (index_valp, son_index);
 
 		  if (fetch_val_list (thread_p, connect_by->prior_regu_list_pred, &xasl_state->vd, NULL, NULL,
 				      tpl_lst2tmp.tpl, PEEK) != NO_ERROR)
@@ -16188,7 +16188,7 @@ qexec_get_tuple_column_value (QFILE_TUPLE tpl, int index, DB_VALUE * valp, TP_DO
     }
   else
     {
-      DB_MAKE_NULL (valp);
+      db_make_null (valp);
     }
 
   return NO_ERROR;
@@ -16244,7 +16244,7 @@ qexec_check_for_cycle (THREAD_ENTRY * thread_p, OUTPTR_LIST * outptr_list, QFILE
 	  return ER_FAILED;
 	}
 
-      bitval = (QFILE_TUPLE_POSITION *) DB_GET_BIT (&p_pos_dbval, &length);
+      bitval = (QFILE_TUPLE_POSITION *) db_get_bit (&p_pos_dbval, &length);
 
       if (bitval)
 	{
@@ -16608,17 +16608,17 @@ qexec_set_pseudocolumns_val_pointers (XASL_NODE * xasl, DB_VALUE ** level_valp, 
       if (i == n - PCOL_ISLEAF_TUPLE_OFFSET)
 	{
 	  *isleaf_valp = regulist->value.value.dbvalptr;
-	  DB_MAKE_INT (*isleaf_valp, 0);
+	  db_make_int (*isleaf_valp, 0);
 	}
       if (i == n - PCOL_ISCYCLE_TUPLE_OFFSET)
 	{
 	  *iscycle_valp = regulist->value.value.dbvalptr;
-	  DB_MAKE_INT (*iscycle_valp, 0);
+	  db_make_int (*iscycle_valp, 0);
 	}
       if (i == n - PCOL_INDEX_STRING_TUPLE_OFFSET)
 	{
 	  *index_valp = regulist->value.value.dbvalptr;
-	  DB_MAKE_INT (*index_valp, 0);
+	  db_make_int (*index_valp, 0);
 	}
       regulist = regulist->next;
       i++;
@@ -16790,7 +16790,7 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 	  goto exit_on_error;
 	}
 
-      level = DB_GET_INTEGER (&level_dbval);
+      level = db_get_int (&level_dbval);
 
       if (level == prev_level)
 	{
@@ -16804,7 +16804,7 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 	  if (level > 1)
 	    {
 	      /* set parent position pseudocolumn value */
-	      DB_MAKE_BIT (&parent_pos_dbval, DB_DEFAULT_PRECISION, (const DB_C_BIT) &pos_info_p->tpl_pos,
+	      db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, (const DB_C_BIT) &pos_info_p->tpl_pos,
 			   sizeof (pos_info_p->tpl_pos) * 8);
 
 	      if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
@@ -16835,7 +16835,7 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 
 	  qfile_save_current_scan_tuple_position (&prev_s_id, &pos_info_p->tpl_pos);
 
-	  DB_MAKE_BIT (&parent_pos_dbval, DB_DEFAULT_PRECISION, (const DB_C_BIT) &pos_info_p->tpl_pos,
+	  db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, (const DB_C_BIT) &pos_info_p->tpl_pos,
 		       sizeof (pos_info_p->tpl_pos) * 8);
 
 	  if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
@@ -16870,7 +16870,7 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 
 	  if (level > 1)
 	    {
-	      DB_MAKE_BIT (&parent_pos_dbval, DB_DEFAULT_PRECISION, (const DB_C_BIT) &pos_info_p->tpl_pos,
+	      db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, (const DB_C_BIT) &pos_info_p->tpl_pos,
 			   sizeof (pos_info_p->tpl_pos) * 8);
 
 	      if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
@@ -17290,7 +17290,7 @@ qexec_gby_finalize_group_val_list (THREAD_ENTRY * thread_p, GROUPBY_STATE * gbst
 	  if (i >= N - 1)
 	    {
 	      (void) pr_clear_value (gby_vallist->val);
-	      DB_MAKE_NULL (gby_vallist->val);
+	      db_make_null (gby_vallist->val);
 	    }
 	  i++;
 	  gby_vallist = gby_vallist->next;
@@ -17445,7 +17445,7 @@ qexec_gby_finalize_group (THREAD_ENTRY * thread_p, GROUPBY_STATE * gbstate, int 
 		{
 		  pr_clear_value (g_outp->accumulator.value);
 		  *g_outp->accumulator.value = *d_aggp->accumulator.value;
-		  /* Don't use DB_MAKE_NULL here to preserve the type information. */
+		  /* Don't use db_make_null here to preserve the type information. */
 
 		  PRIM_SET_NULL (d_aggp->accumulator.value);
 		}
@@ -17508,7 +17508,7 @@ qexec_gby_finalize_group (THREAD_ENTRY * thread_p, GROUPBY_STATE * gbstate, int 
       if (gbstate->grbynum_flag & XASL_G_GRBYNUM_FLAG_SCAN_STOP)
 	{
 	  /* reset grbynum_val for next use */
-	  DB_MAKE_BIGINT (gbstate->grbynum_val, 0);
+	  db_make_bigint (gbstate->grbynum_val, 0);
 	  /* setting SORT_PUT_STOP will make 'sr_in_sort()' stop processing; the caller, 'qexec_gby_put_next()',
 	   * returns 'gbstate->state' */
 	  gbstate->state = SORT_PUT_STOP;
@@ -18088,15 +18088,15 @@ bf2df_str_cmpval (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
 {
   unsigned char *string1, *string2;
 
-  string1 = (unsigned char *) DB_GET_STRING (value1);
-  string2 = (unsigned char *) DB_GET_STRING (value2);
+  string1 = (unsigned char *) db_get_string (value1);
+  string2 = (unsigned char *) db_get_string (value2);
 
   if (string1 == NULL || string2 == NULL)
     {
       return DB_UNK;
     }
 
-  return bf2df_str_compare (string1, (int) DB_GET_STRING_SIZE (value1), string2, (int) DB_GET_STRING_SIZE (value2));
+  return bf2df_str_compare (string1, (int) db_get_string_size (value1), string2, (int) db_get_string_size (value2));
 }
 
 /*
@@ -18706,7 +18706,7 @@ qexec_groupby_index (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xas
   TSC_TICKS start_tick, end_tick;
   TSCTIMEVAL tv_diff;
 
-  DB_MAKE_NULL (&val);
+  db_make_null (&val);
 
   if (buildlist->groupby_list == NULL)
     {
@@ -19424,9 +19424,9 @@ qexec_initialize_analytic_function_state (THREAD_ENTRY * thread_p, ANALYTIC_FUNC
   func_state->value_tplrec.tpl = NULL;
 
   /* initialize dbvals */
-  DB_MAKE_NULL (&func_state->csktc_dbval);
-  DB_MAKE_NULL (&func_state->cgtc_dbval);
-  DB_MAKE_NULL (&func_state->cgtc_nn_dbval);
+  db_make_null (&func_state->csktc_dbval);
+  db_make_null (&func_state->cgtc_dbval);
+  db_make_null (&func_state->cgtc_nn_dbval);
 
   /* initialize group header listfile */
   group_type_list.type_cnt = 2;
@@ -20045,9 +20045,9 @@ qexec_analytic_finalize_group (THREAD_ENTRY * thread_p, XASL_STATE * xasl_state,
     }
 
   /* write current counts to dbvalues */
-  DB_MAKE_INT (&func_state->cgtc_dbval, func_state->curr_group_tuple_count);
-  DB_MAKE_INT (&func_state->cgtc_nn_dbval, func_state->curr_group_tuple_count_nn);
-  DB_MAKE_INT (&func_state->csktc_dbval, func_state->curr_sort_key_tuple_count);
+  db_make_int (&func_state->cgtc_dbval, func_state->curr_group_tuple_count);
+  db_make_int (&func_state->cgtc_nn_dbval, func_state->curr_group_tuple_count_nn);
+  db_make_int (&func_state->csktc_dbval, func_state->curr_sort_key_tuple_count);
 
   /* dump group */
   if (!is_same_group)
@@ -20269,12 +20269,12 @@ qexec_analytic_evaluate_ntile_function (THREAD_ENTRY * thread_p, ANALYTIC_FUNCTI
       if (recs_in_bucket == 0)
 	{
 	  /* more buckets than tuples, this is identity */
-	  DB_MAKE_INT (func_state->func_p->value, func_state->group_tuple_position + 1);
+	  db_make_int (func_state->func_p->value, func_state->group_tuple_position + 1);
 	}
       else if (compensate == 0)
 	{
 	  /* perfect division, straightforward */
-	  DB_MAKE_INT (func_state->func_p->value, func_state->group_tuple_position / recs_in_bucket + 1);
+	  db_make_int (func_state->func_p->value, func_state->group_tuple_position / recs_in_bucket + 1);
 	}
       else
 	{
@@ -20283,11 +20283,11 @@ qexec_analytic_evaluate_ntile_function (THREAD_ENTRY * thread_p, ANALYTIC_FUNCTI
 	  /* account for remainder */
 	  if (func_state->group_tuple_position < xcount)
 	    {
-	      DB_MAKE_INT (func_state->func_p->value, func_state->group_tuple_position / (recs_in_bucket + 1) + 1);
+	      db_make_int (func_state->func_p->value, func_state->group_tuple_position / (recs_in_bucket + 1) + 1);
 	    }
 	  else
 	    {
-	      DB_MAKE_INT (func_state->func_p->value,
+	      db_make_int (func_state->func_p->value,
 			   (func_state->group_tuple_position - compensate) / recs_in_bucket + 1);
 	    }
 	}
@@ -20295,7 +20295,7 @@ qexec_analytic_evaluate_ntile_function (THREAD_ENTRY * thread_p, ANALYTIC_FUNCTI
   else
     {
       /* null output */
-      DB_MAKE_NULL (func_state->func_p->value);
+      db_make_null (func_state->func_p->value);
     }
 
   /* all ok */
@@ -20426,7 +20426,7 @@ qexec_analytic_evaluate_offset_function (THREAD_ENTRY * thread_p, ANALYTIC_FUNCT
 	  return ER_FAILED;
 	}
 
-      nth_idx = DB_GET_DOUBLE (&offset_val);
+      nth_idx = db_get_double (&offset_val);
 
       if (nth_idx < 1.0 || nth_idx > DB_INT32_MAX)
 	{
@@ -20541,17 +20541,17 @@ qexec_analytic_evaluate_cume_dist_percent_rank_function (THREAD_ENTRY * thread_p
   switch (func_state->func_p->function)
     {
     case PT_CUME_DIST:
-      DB_MAKE_DOUBLE (func_state->func_p->value, (double) end_of_group / func_state->curr_group_tuple_count);
+      db_make_double (func_state->func_p->value, (double) end_of_group / func_state->curr_group_tuple_count);
       break;
 
     case PT_PERCENT_RANK:
       if (func_state->curr_group_tuple_count <= 1)
 	{
-	  DB_MAKE_DOUBLE (func_state->func_p->value, 0.0f);
+	  db_make_double (func_state->func_p->value, 0.0f);
 	}
       else
 	{
-	  DB_MAKE_DOUBLE (func_state->func_p->value,
+	  db_make_double (func_state->func_p->value,
 			  (double) start_of_group / (func_state->curr_group_tuple_count - 1));
 	}
       break;
@@ -20621,7 +20621,7 @@ qexec_analytic_evaluate_interpolation_function (THREAD_ENTRY * thread_p, ANALYTI
 
       assert (DB_VALUE_TYPE (peek_value_p) == DB_TYPE_DOUBLE);
 
-      percentile_d = DB_GET_DOUBLE (peek_value_p);
+      percentile_d = db_get_double (peek_value_p);
 
       if (func_p->function == PT_PERCENTILE_DISC)
 	{
@@ -20662,8 +20662,8 @@ qexec_analytic_evaluate_interpolation_function (THREAD_ENTRY * thread_p, ANALYTI
   else
     {
       DB_VALUE c_value, f_value;
-      DB_MAKE_NULL (&c_value);
-      DB_MAKE_NULL (&f_value);
+      db_make_null (&c_value);
+      db_make_null (&f_value);
 
       if (qexec_analytic_value_lookup (thread_p, func_state, (int) f_row_num_d, true) != NO_ERROR)
 	{
@@ -20789,7 +20789,7 @@ qexec_analytic_sort_key_header_load (ANALYTIC_FUNCTION_STATE * func_state, bool 
     }
   else
     {
-      DB_MAKE_NULL (func_state->func_p->value);
+      db_make_null (func_state->func_p->value);
     }
 
   /* all ok */
@@ -22359,7 +22359,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
       DB_DATA_STATUS data_stat;
 
       db_make_int (&db_int_precision, precision);
-      DB_MAKE_NULL (&db_str_precision);
+      db_make_null (&db_str_precision);
       if (tp_value_cast (&db_int_precision, &db_str_precision, &tp_String_domain, false) != DOMAIN_COMPATIBLE)
 	{
 	  goto exit_on_error;
@@ -22395,7 +22395,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
       if (scale >= 0)
 	{
 	  db_make_int (&db_int_scale, scale);
-	  DB_MAKE_NULL (&db_str_scale);
+	  db_make_null (&db_str_scale);
 	  if (tp_value_cast (&db_int_scale, &db_str_scale, &tp_String_domain, false) != DOMAIN_COMPATIBLE)
 	    {
 	      pr_clear_value (pprec_scale_result);
@@ -23799,7 +23799,7 @@ qexec_setup_topn_proc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, VAL_DESCR * vd
       return NO_ERROR;
     }
 
-  DB_MAKE_NULL (&ubound_val);
+  db_make_null (&ubound_val);
   error = qexec_get_orderbynum_upper_bound (thread_p, xasl->ordbynum_pred, vd, &ubound_val);
   if (error != NO_ERROR)
     {
@@ -23820,7 +23820,7 @@ qexec_setup_topn_proc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, VAL_DESCR * vd
 	}
     }
 
-  ubound = DB_GET_INT (&ubound_val);
+  ubound = db_get_int (&ubound_val);
   pr_clear_value (&ubound_val);
 
   if (ubound == 0)
@@ -24161,7 +24161,7 @@ qexec_topn_tuples_to_list_id (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_ST
   ordby_info.ordbynum_flag = xasl->ordbynum_flag;
   ordby_info.ordbynum_pos_cnt = 0;
   ordby_info.ordbynum_val = xasl->ordbynum_val;
-  DB_MAKE_BIGINT (ordby_info.ordbynum_val, 0);
+  db_make_bigint (ordby_info.ordbynum_val, 0);
 
   list_id = xasl->list_id;
   topn = xasl->topn_items;
@@ -24302,7 +24302,7 @@ cleanup:
     {
       /* reset ORDERBY_NUM value */
       assert (DB_VALUE_TYPE (xasl->ordbynum_val) == DB_TYPE_BIGINT);
-      DB_MAKE_BIGINT (xasl->ordbynum_val, 0);
+      db_make_bigint (xasl->ordbynum_val, 0);
     }
   return error;
 }
@@ -24356,9 +24356,9 @@ qexec_get_orderbynum_upper_bound (THREAD_ENTRY * thread_p, PRED_EXPR * pred, VAL
   assert_release (pred != NULL);
   assert_release (ubound != NULL);
 
-  DB_MAKE_NULL (ubound);
-  DB_MAKE_NULL (&left_bound);
-  DB_MAKE_NULL (&right_bound);
+  db_make_null (ubound);
+  db_make_null (&left_bound);
+  db_make_null (&right_bound);
 
   if (pred->type == T_PRED && pred->pe.pred.bool_op == B_AND)
     {
@@ -24458,7 +24458,7 @@ qexec_get_orderbynum_upper_bound (THREAD_ENTRY * thread_p, PRED_EXPR * pred, VAL
 	{
 	  /* add 1 so we can use R_LE */
 	  DB_VALUE one_val;
-	  DB_MAKE_INT (&one_val, 1);
+	  db_make_int (&one_val, 1);
 	  error = qdata_subtract_dbval (val, &one_val, ubound, rhs->domain);
 	}
       else
@@ -24476,7 +24476,7 @@ qexec_get_orderbynum_upper_bound (THREAD_ENTRY * thread_p, PRED_EXPR * pred, VAL
   return error;
 
 error_return:
-  DB_MAKE_NULL (ubound);
+  db_make_null (ubound);
 
 cleanup:
   pr_clear_value (&left_bound);

--- a/src/query/query_method.c
+++ b/src/query/query_method.c
@@ -285,7 +285,7 @@ method_invoke_for_server (unsigned int rc, char *host_p, char *server_name_p, QF
   int count;
   DB_VALUE *value_p;
 
-  DB_MAKE_NULL (&value);
+  db_make_null (&value);
 
   if (method_initialize_vacomm_buffer (&vacomm_buffer, rc, host_p, server_name_p) != NO_ERROR)
     {
@@ -316,7 +316,7 @@ method_invoke_for_server (unsigned int rc, char *host_p, char *server_name_p, QF
 
   for (count = 0, value_p = val_list_p; count < value_count; count++, value_p++)
     {
-      DB_MAKE_NULL (value_p);
+      db_make_null (value_p);
     }
 
   values_p = (DB_VALUE **) malloc (sizeof (DB_VALUE *) * (value_count + 1));
@@ -386,7 +386,7 @@ method_invoke_for_server (unsigned int rc, char *host_p, char *server_name_p, QF
 	    }
 
 	  values_p[num_args] = (DB_VALUE *) 0;
-	  DB_MAKE_NULL (&value);
+	  db_make_null (&value);
 
 	  if (meth_sig_p->class_name != NULL)
 	    {
@@ -394,10 +394,10 @@ method_invoke_for_server (unsigned int rc, char *host_p, char *server_name_p, QF
 	       * NULL. */
 	      if (!DB_IS_NULL (values_p[0]))
 		{
-		  error = db_is_any_class (DB_GET_OBJECT (values_p[0]));
+		  error = db_is_any_class (db_get_object (values_p[0]));
 		  if (error == 0)
 		    {
-		      error = db_is_instance (DB_GET_OBJECT (values_p[0]));
+		      error = db_is_instance (db_get_object (values_p[0]));
 		    }
 		}
 	      if (error == ER_HEAP_UNKNOWN_OBJECT)
@@ -410,7 +410,7 @@ method_invoke_for_server (unsigned int rc, char *host_p, char *server_name_p, QF
 		  turn_on_auth = 0;
 		  AU_ENABLE (turn_on_auth);
 		  db_disable_modification ();
-		  error = obj_send_array (DB_GET_OBJECT (values_p[0]), meth_sig_p->method_name, &value, &values_p[1]);
+		  error = obj_send_array (db_get_object (values_p[0]), meth_sig_p->method_name, &value, &values_p[1]);
 		  db_enable_modification ();
 		  AU_DISABLE (turn_on_auth);
 		}

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -283,7 +283,7 @@ static int qdata_evaluate_interpolation_function (THREAD_ENTRY * thread_p, void 
 static int
 qdata_dummy (THREAD_ENTRY * thread_p, DB_VALUE * result_p, int num_args, DB_VALUE ** args)
 {
-  DB_MAKE_NULL (result_p);
+  db_make_null (result_p);
   return ER_FAILED;
 }
 
@@ -309,20 +309,20 @@ qdata_is_zero_value_date (DB_VALUE * dbval_p)
 	{
 	case DB_TYPE_UTIME:
 	case DB_TYPE_TIMESTAMPLTZ:
-	  utime = DB_GET_UTIME (dbval_p);
+	  utime = db_get_utime (dbval_p);
 	  return (*utime == 0);
 	case DB_TYPE_TIMESTAMPTZ:
-	  ts_tz = DB_GET_TIMESTAMPTZ (dbval_p);
+	  ts_tz = db_get_timestamptz (dbval_p);
 	  return (ts_tz->timestamp == 0);
 	case DB_TYPE_DATETIME:
 	case DB_TYPE_DATETIMELTZ:
-	  datetime = DB_GET_DATETIME (dbval_p);
+	  datetime = db_get_datetime (dbval_p);
 	  return (datetime->date == 0 && datetime->time == 0);
 	case DB_TYPE_DATETIMETZ:
-	  dt_tz = DB_GET_DATETIMETZ (dbval_p);
+	  dt_tz = db_get_datetimetz (dbval_p);
 	  return (dt_tz->datetime.date == 0 && dt_tz->datetime.time == 0);
 	case DB_TYPE_DATE:
-	  date = DB_GET_DATE (dbval_p);
+	  date = db_get_date (dbval_p);
 	  return (*date == 0);
 	default:
 	  break;
@@ -723,7 +723,7 @@ qdata_add_short (short s, DB_VALUE * dbval_p, DB_VALUE * result_p)
 {
   short result, tmp;
 
-  tmp = DB_GET_SHORT (dbval_p);
+  tmp = db_get_short (dbval_p);
   result = s + tmp;
 
   if (OR_CHECK_ADD_OVERFLOW (s, tmp, result))
@@ -732,7 +732,7 @@ qdata_add_short (short s, DB_VALUE * dbval_p, DB_VALUE * result_p)
       return ER_QPROC_OVERFLOW_ADDITION;
     }
 
-  DB_MAKE_SHORT (result_p, result);
+  db_make_short (result_p, result);
   return NO_ERROR;
 }
 
@@ -749,7 +749,7 @@ qdata_add_int (int i1, int i2, DB_VALUE * result_p)
       return ER_QPROC_OVERFLOW_ADDITION;
     }
 
-  DB_MAKE_INT (result_p, result);
+  db_make_int (result_p, result);
   return NO_ERROR;
 }
 
@@ -766,7 +766,7 @@ qdata_add_bigint (DB_BIGINT bi1, DB_BIGINT bi2, DB_VALUE * result_p)
       return ER_QPROC_OVERFLOW_ADDITION;
     }
 
-  DB_MAKE_BIGINT (result_p, result);
+  db_make_bigint (result_p, result);
   return NO_ERROR;
 }
 
@@ -783,7 +783,7 @@ qdata_add_float (float f1, float f2, DB_VALUE * result_p)
       return ER_QPROC_OVERFLOW_ADDITION;
     }
 
-  DB_MAKE_FLOAT (result_p, result);
+  db_make_float (result_p, result);
   return NO_ERROR;
 }
 
@@ -800,7 +800,7 @@ qdata_add_double (double d1, double d2, DB_VALUE * result_p)
       return ER_QPROC_OVERFLOW_ADDITION;
     }
 
-  DB_MAKE_DOUBLE (result_p, result);
+  db_make_double (result_p, result);
   return NO_ERROR;
 }
 
@@ -813,7 +813,7 @@ qdata_coerce_numeric_to_double (DB_VALUE * numeric_val_p)
   db_value_domain_init (&dbval_tmp, DB_TYPE_DOUBLE, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
   (void) numeric_db_value_coerce_from_num (numeric_val_p, &dbval_tmp, &data_stat);
 
-  return DB_GET_DOUBLE (&dbval_tmp);
+  return db_get_double (&dbval_tmp);
 }
 
 static void
@@ -847,11 +847,11 @@ qdata_add_numeric_to_monetary (DB_VALUE * numeric_val_p, DB_VALUE * monetary_val
   double d1, d2, dtmp;
 
   d1 = qdata_coerce_numeric_to_double (numeric_val_p);
-  d2 = (DB_GET_MONETARY (monetary_val_p))->amount;
+  d2 = (db_get_monetary (monetary_val_p))->amount;
 
   dtmp = d1 + d2;
 
-  DB_MAKE_MONETARY_TYPE_AMOUNT (result_p, (DB_GET_MONETARY (monetary_val_p))->type, dtmp);
+  db_make_monetary (result_p, (db_get_monetary (monetary_val_p))->type, dtmp);
 
   return NO_ERROR;
 }
@@ -869,7 +869,7 @@ qdata_add_monetary (double d1, double d2, DB_CURRENCY type, DB_VALUE * result_p)
       return ER_QPROC_OVERFLOW_ADDITION;
     }
 
-  DB_MAKE_MONETARY_TYPE_AMOUNT (result_p, type, result);
+  db_make_monetary (result_p, type, result);
   return NO_ERROR;
 }
 
@@ -881,7 +881,7 @@ qdata_add_int_to_time (DB_VALUE * time_val_p, unsigned int add_time, DB_VALUE * 
   DB_TIME *time;
   int hour, minute, second;
 
-  time = DB_GET_TIME (time_val_p);
+  time = db_get_time (time_val_p);
   utime = (unsigned int) *time % SECONDS_OF_ONE_DAY;
 
   result = (utime + add_time) % SECONDS_OF_ONE_DAY;
@@ -890,7 +890,7 @@ qdata_add_int_to_time (DB_VALUE * time_val_p, unsigned int add_time, DB_VALUE * 
 
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) != COMPAT_MYSQL)
     {
-      DB_MAKE_TIME (result_p, hour, minute, second);
+      db_make_time (result_p, hour, minute, second);
     }
   else
     {
@@ -899,15 +899,15 @@ qdata_add_int_to_time (DB_VALUE * time_val_p, unsigned int add_time, DB_VALUE * 
       switch (type)
 	{
 	case DB_TYPE_INTEGER:
-	  DB_MAKE_INT (result_p, (hour * 100 + minute) * 100 + second);
+	  db_make_int (result_p, (hour * 100 + minute) * 100 + second);
 	  break;
 
 	case DB_TYPE_SHORT:
-	  DB_MAKE_SHORT (result_p, (hour * 100 + minute) * 100 + second);
+	  db_make_short (result_p, (hour * 100 + minute) * 100 + second);
 	  break;
 
 	default:
-	  DB_MAKE_TIME (result_p, hour, minute, second);
+	  db_make_time (result_p, hour, minute, second);
 	  break;
 	}
     }
@@ -923,7 +923,7 @@ qdata_add_bigint_to_time (DB_VALUE * time_val_p, DB_BIGINT add_time, DB_VALUE * 
   int hour, minute, second;
   int error = NO_ERROR;
 
-  utime = *(DB_GET_TIME (time_val_p)) % SECONDS_OF_ONE_DAY;
+  utime = *(db_get_time (time_val_p)) % SECONDS_OF_ONE_DAY;
   add_time = add_time % SECONDS_OF_ONE_DAY;
   if (add_time < 0)
     {
@@ -935,7 +935,7 @@ qdata_add_bigint_to_time (DB_VALUE * time_val_p, DB_BIGINT add_time, DB_VALUE * 
 
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) != COMPAT_MYSQL)
     {
-      error = DB_MAKE_TIME (result_p, hour, minute, second);
+      error = db_make_time (result_p, hour, minute, second);
     }
   else
     {
@@ -944,15 +944,15 @@ qdata_add_bigint_to_time (DB_VALUE * time_val_p, DB_BIGINT add_time, DB_VALUE * 
       switch (type)
 	{
 	case DB_TYPE_BIGINT:
-	  error = DB_MAKE_BIGINT (result_p, (hour * 100 + minute) * 100 + second);
+	  error = db_make_bigint (result_p, (hour * 100 + minute) * 100 + second);
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  error = DB_MAKE_INTEGER (result_p, (hour * 100 + minute) * 100 + second);
+	  error = db_make_int (result_p, (hour * 100 + minute) * 100 + second);
 	  break;
 
 	default:
-	  error = DB_MAKE_TIME (result_p, hour, minute, second);
+	  error = db_make_time (result_p, hour, minute, second);
 	  break;
 	}
     }
@@ -969,7 +969,7 @@ qdata_add_bigint_to_timetz (DB_VALUE * time_tz_val_p, DB_BIGINT add_time, DB_VAL
   int error = NO_ERROR;
   DB_VALUE time_val_res;
 
-  time_tz_p = DB_GET_TIMETZ (time_tz_val_p);
+  time_tz_p = db_get_timetz (time_tz_val_p);
   utime = (time_tz_p->time) % SECONDS_OF_ONE_DAY;
   add_time = add_time % SECONDS_OF_ONE_DAY;
   if (add_time < 0)
@@ -980,7 +980,7 @@ qdata_add_bigint_to_timetz (DB_VALUE * time_tz_val_p, DB_BIGINT add_time, DB_VAL
 	  goto exit;
 	}
       assert (DB_VALUE_TYPE (&time_val_res) == DB_TYPE_TIME);
-      time_res = *DB_GET_TIME (&time_val_res);
+      time_res = *db_get_time (&time_val_res);
       goto return_time_tz;
     }
 
@@ -1010,11 +1010,11 @@ qdata_add_bigint_to_timetz (DB_VALUE * time_tz_val_p, DB_BIGINT add_time, DB_VAL
 
 	  if (type == DB_TYPE_BIGINT)
 	    {
-	      error = DB_MAKE_BIGINT (result_p, (hour * 100 + minute) * 100 + second);
+	      error = db_make_bigint (result_p, (hour * 100 + minute) * 100 + second);
 	    }
 	  else
 	    {
-	      error = DB_MAKE_INTEGER (result_p, (hour * 100 + minute) * 100 + second);
+	      error = db_make_int (result_p, (hour * 100 + minute) * 100 + second);
 	    }
 	  break;
 
@@ -1033,7 +1033,7 @@ return_time_tz:
     {
       return error;
     }
-  DB_MAKE_TIMETZ (result_p, &time_tz_fixed);
+  db_make_timetz (result_p, &time_tz_fixed);
 
 exit:
   return error;
@@ -1057,7 +1057,7 @@ qdata_add_short_to_utime_asymmetry (DB_VALUE * utime_val_p, short s, unsigned in
       s++;
     }
 
-  DB_MAKE_SHORT (&tmp, -(s));
+  db_make_short (&tmp, -(s));
   return (qdata_subtract_dbval (utime_val_p, &tmp, result_p, domain_p));
 }
 
@@ -1079,7 +1079,7 @@ qdata_add_int_to_utime_asymmetry (DB_VALUE * utime_val_p, int i, unsigned int *u
       i++;
     }
 
-  DB_MAKE_INT (&tmp, -i);
+  db_make_int (&tmp, -i);
   return (qdata_subtract_dbval (utime_val_p, &tmp, result_p, domain_p));
 }
 
@@ -1101,7 +1101,7 @@ qdata_add_bigint_to_utime_asymmetry (DB_VALUE * utime_val_p, DB_BIGINT bi, unsig
       bi++;
     }
 
-  DB_MAKE_BIGINT (&tmp, -bi);
+  db_make_bigint (&tmp, -bi);
   return (qdata_subtract_dbval (utime_val_p, &tmp, result_p, domain_p));
 }
 
@@ -1116,7 +1116,7 @@ qdata_add_short_to_utime (DB_VALUE * utime_val_p, short s, DB_VALUE * result_p, 
   DB_BIGINT bigint = 0;
   int d, m, y, h, mi, sec;
 
-  utime = DB_GET_UTIME (utime_val_p);
+  utime = db_get_utime (utime_val_p);
 
   if (s < 0)
     {
@@ -1135,7 +1135,7 @@ qdata_add_short_to_utime (DB_VALUE * utime_val_p, short s, DB_VALUE * result_p, 
 
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) != COMPAT_MYSQL)
     {
-      DB_MAKE_UTIME (result_p, utmp);
+      db_make_timestamp (result_p, utmp);
     }
   else
     {
@@ -1149,11 +1149,11 @@ qdata_add_short_to_utime (DB_VALUE * utime_val_p, short s, DB_VALUE * result_p, 
 	  db_time_decode (&time, &h, &mi, &sec);
 	  bigint = (y * 100 + m) * 100 + d;
 	  bigint = ((bigint * 100 + h) * 100 + mi) * 100 + sec;
-	  DB_MAKE_BIGINT (result_p, bigint);
+	  db_make_bigint (result_p, bigint);
 	  break;
 
 	default:
-	  DB_MAKE_UTIME (result_p, utmp);
+	  db_make_timestamp (result_p, utmp);
 	  break;
 	}
     }
@@ -1172,7 +1172,7 @@ qdata_add_int_to_utime (DB_VALUE * utime_val_p, int i, DB_VALUE * result_p, TP_D
   DB_BIGINT bigint;
   int d, m, y, h, mi, s;
 
-  utime = DB_GET_UTIME (utime_val_p);
+  utime = db_get_utime (utime_val_p);
 
   if (i < 0)
     {
@@ -1191,7 +1191,7 @@ qdata_add_int_to_utime (DB_VALUE * utime_val_p, int i, DB_VALUE * result_p, TP_D
 
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) != COMPAT_MYSQL)
     {
-      DB_MAKE_UTIME (result_p, utmp);
+      db_make_timestamp (result_p, utmp);
     }
   else
     {
@@ -1205,11 +1205,11 @@ qdata_add_int_to_utime (DB_VALUE * utime_val_p, int i, DB_VALUE * result_p, TP_D
 	  db_time_decode (&time, &h, &mi, &s);
 	  bigint = (y * 100 + m) * 100 + d;
 	  bigint = ((bigint * 100 + h) * 100 + mi) * 100 + s;
-	  DB_MAKE_BIGINT (result_p, bigint);
+	  db_make_bigint (result_p, bigint);
 	  break;
 
 	default:
-	  DB_MAKE_UTIME (result_p, utmp);
+	  db_make_timestamp (result_p, utmp);
 	  break;
 	}
     }
@@ -1228,7 +1228,7 @@ qdata_add_bigint_to_utime (DB_VALUE * utime_val_p, DB_BIGINT bi, DB_VALUE * resu
   DB_BIGINT bigint;
   int d, m, y, h, mi, s;
 
-  utime = DB_GET_UTIME (utime_val_p);
+  utime = db_get_utime (utime_val_p);
 
   if (bi < 0)
     {
@@ -1246,7 +1246,7 @@ qdata_add_bigint_to_utime (DB_VALUE * utime_val_p, DB_BIGINT bi, DB_VALUE * resu
     }
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) != COMPAT_MYSQL)
     {
-      DB_MAKE_UTIME (result_p, (unsigned int) utmp);	/* truncate to 4bytes time_t */
+      db_make_timestamp (result_p, (unsigned int) utmp);	/* truncate to 4bytes time_t */
     }
   else
     {
@@ -1262,12 +1262,12 @@ qdata_add_bigint_to_utime (DB_VALUE * utime_val_p, DB_BIGINT bi, DB_VALUE * resu
 	    db_time_decode (&time, &h, &mi, &s);
 	    bigint = (y * 100 + m) * 100 + d;
 	    bigint = ((bigint * 100 + h) * 100 + mi) * 100 + s;
-	    DB_MAKE_BIGINT (result_p, bigint);
+	    db_make_bigint (result_p, bigint);
 	  }
 	  break;
 
 	default:
-	  DB_MAKE_UTIME (result_p, (unsigned int) utmp);
+	  db_make_timestamp (result_p, (unsigned int) utmp);
 	  break;
 	}
     }
@@ -1290,12 +1290,12 @@ qdata_add_short_to_timestamptz (DB_VALUE * ts_tz_val_p, short s, DB_VALUE * resu
   int d, m, y, h, mi, sec;
   DB_VALUE tmp_utime_val, tmp_utime_val_res;
 
-  ts_tz_p = DB_GET_TIMESTAMPTZ (ts_tz_val_p);
+  ts_tz_p = db_get_timestamptz (ts_tz_val_p);
   utime = ts_tz_p->timestamp;
 
   if (s < 0)
     {
-      DB_MAKE_UTIME (&tmp_utime_val, utime);
+      db_make_timestamp (&tmp_utime_val, utime);
       err =
 	qdata_add_short_to_utime_asymmetry (&tmp_utime_val, s, &utime, &tmp_utime_val_res,
 					    tp_domain_resolve_default (DB_TYPE_UTIME));
@@ -1305,7 +1305,7 @@ qdata_add_short_to_timestamptz (DB_VALUE * ts_tz_val_p, short s, DB_VALUE * resu
 	}
 
       assert (DB_VALUE_TYPE (&tmp_utime_val_res) == DB_TYPE_UTIME);
-      utmp = *DB_GET_UTIME (&tmp_utime_val_res);
+      utmp = *db_get_utime (&tmp_utime_val_res);
 
       goto return_timestamp_tz;
     }
@@ -1348,7 +1348,7 @@ qdata_add_short_to_timestamptz (DB_VALUE * ts_tz_val_p, short s, DB_VALUE * resu
 	  db_time_decode (&time, &h, &mi, &sec);
 	  bigint = (y * 100 + m) * 100 + d;
 	  bigint = ((bigint * 100 + h) * 100 + mi) * 100 + sec;
-	  DB_MAKE_BIGINT (result_p, bigint);
+	  db_make_bigint (result_p, bigint);
 	  break;
 
 	default:
@@ -1365,7 +1365,7 @@ return_timestamp_tz:
     {
       return err;
     }
-  DB_MAKE_TIMESTAMPTZ (result_p, &ts_tz_fixed);
+  db_make_timestamptz (result_p, &ts_tz_fixed);
 
 exit:
   return err;
@@ -1386,12 +1386,12 @@ qdata_add_int_to_timestamptz (DB_VALUE * ts_tz_val_p, int i, DB_VALUE * result_p
   int d, m, y, h, mi, sec;
   DB_VALUE tmp_utime_val, tmp_utime_val_res;
 
-  ts_tz_p = DB_GET_TIMESTAMPTZ (ts_tz_val_p);
+  ts_tz_p = db_get_timestamptz (ts_tz_val_p);
   utime = ts_tz_p->timestamp;
 
   if (i < 0)
     {
-      DB_MAKE_UTIME (&tmp_utime_val, utime);
+      db_make_timestamp (&tmp_utime_val, utime);
       err =
 	qdata_add_int_to_utime_asymmetry (&tmp_utime_val, i, &utime, &tmp_utime_val_res,
 					  tp_domain_resolve_default (DB_TYPE_UTIME));
@@ -1401,7 +1401,7 @@ qdata_add_int_to_timestamptz (DB_VALUE * ts_tz_val_p, int i, DB_VALUE * result_p
 	}
 
       assert (DB_VALUE_TYPE (&tmp_utime_val_res) == DB_TYPE_UTIME);
-      utmp = *DB_GET_UTIME (&tmp_utime_val_res);
+      utmp = *db_get_utime (&tmp_utime_val_res);
 
       goto return_timestamp_tz;
     }
@@ -1444,7 +1444,7 @@ qdata_add_int_to_timestamptz (DB_VALUE * ts_tz_val_p, int i, DB_VALUE * result_p
 	  db_time_decode (&time, &h, &mi, &sec);
 	  bigint = (y * 100 + m) * 100 + d;
 	  bigint = ((bigint * 100 + h) * 100 + mi) * 100 + sec;
-	  DB_MAKE_BIGINT (result_p, bigint);
+	  db_make_bigint (result_p, bigint);
 	  break;
 
 	default:
@@ -1461,7 +1461,7 @@ return_timestamp_tz:
     {
       return err;
     }
-  DB_MAKE_TIMESTAMPTZ (result_p, &ts_tz_fixed);
+  db_make_timestamptz (result_p, &ts_tz_fixed);
 
 exit:
   return err;
@@ -1481,12 +1481,12 @@ qdata_add_bigint_to_timestamptz (DB_VALUE * ts_tz_val_p, DB_BIGINT bi, DB_VALUE 
   int d, m, y, h, mi, sec;
   DB_VALUE tmp_utime_val, tmp_utime_val_res;
 
-  ts_tz_p = DB_GET_TIMESTAMPTZ (ts_tz_val_p);
+  ts_tz_p = db_get_timestamptz (ts_tz_val_p);
   utime = ts_tz_p->timestamp;
 
   if (bi < 0)
     {
-      DB_MAKE_UTIME (&tmp_utime_val, utime);
+      db_make_timestamp (&tmp_utime_val, utime);
       err =
 	qdata_add_bigint_to_utime_asymmetry (&tmp_utime_val, bi, &utime, &tmp_utime_val_res,
 					     tp_domain_resolve_default (DB_TYPE_UTIME));
@@ -1496,7 +1496,7 @@ qdata_add_bigint_to_timestamptz (DB_VALUE * ts_tz_val_p, DB_BIGINT bi, DB_VALUE 
 	}
 
       assert (DB_VALUE_TYPE (&tmp_utime_val_res) == DB_TYPE_UTIME);
-      utmp = *DB_GET_UTIME (&tmp_utime_val_res);
+      utmp = *db_get_utime (&tmp_utime_val_res);
 
       goto return_timestamp_tz;
     }
@@ -1540,7 +1540,7 @@ qdata_add_bigint_to_timestamptz (DB_VALUE * ts_tz_val_p, DB_BIGINT bi, DB_VALUE 
 	  db_time_decode (&time, &h, &mi, &sec);
 	  bigint = (y * 100 + m) * 100 + d;
 	  bigint = ((bigint * 100 + h) * 100 + mi) * 100 + sec;
-	  DB_MAKE_BIGINT (result_p, bigint);
+	  db_make_bigint (result_p, bigint);
 	  break;
 
 	default:
@@ -1558,7 +1558,7 @@ return_timestamp_tz:
     {
       return err;
     }
-  DB_MAKE_TIMESTAMPTZ (result_p, &ts_tz_fixed);
+  db_make_timestamptz (result_p, &ts_tz_fixed);
 
 exit:
   return err;
@@ -1571,12 +1571,12 @@ qdata_add_short_to_datetime (DB_VALUE * datetime_val_p, short s, DB_VALUE * resu
   DB_DATETIME tmp;
   int error = NO_ERROR;
 
-  datetime = DB_GET_DATETIME (datetime_val_p);
+  datetime = db_get_datetime (datetime_val_p);
 
   error = db_add_int_to_datetime (datetime, s, &tmp);
   if (error == NO_ERROR)
     {
-      DB_MAKE_DATETIME (result_p, &tmp);
+      db_make_datetime (result_p, &tmp);
     }
   return error;
 }
@@ -1588,12 +1588,12 @@ qdata_add_int_to_datetime (DB_VALUE * datetime_val_p, int i, DB_VALUE * result_p
   DB_DATETIME tmp;
   int error = NO_ERROR;
 
-  datetime = DB_GET_DATETIME (datetime_val_p);
+  datetime = db_get_datetime (datetime_val_p);
 
   error = db_add_int_to_datetime (datetime, i, &tmp);
   if (error == NO_ERROR)
     {
-      DB_MAKE_DATETIME (result_p, &tmp);
+      db_make_datetime (result_p, &tmp);
     }
   return error;
 }
@@ -1605,12 +1605,12 @@ qdata_add_bigint_to_datetime (DB_VALUE * datetime_val_p, DB_BIGINT bi, DB_VALUE 
   DB_DATETIME tmp;
   int error = NO_ERROR;
 
-  datetime = DB_GET_DATETIME (datetime_val_p);
+  datetime = db_get_datetime (datetime_val_p);
 
   error = db_add_int_to_datetime (datetime, bi, &tmp);
   if (error == NO_ERROR)
     {
-      DB_MAKE_DATETIME (result_p, &tmp);
+      db_make_datetime (result_p, &tmp);
     }
   return error;
 }
@@ -1622,7 +1622,7 @@ qdata_add_short_to_date (DB_VALUE * date_val_p, short s, DB_VALUE * result_p, TP
   unsigned int utmp, u1, u2;
   int day, month, year;
 
-  date = DB_GET_DATE (date_val_p);
+  date = db_get_date (date_val_p);
   if (s < 0)
     {
       return qdata_add_short_to_utime_asymmetry (date_val_p, s, date, result_p, domain_p);
@@ -1642,7 +1642,7 @@ qdata_add_short_to_date (DB_VALUE * date_val_p, short s, DB_VALUE * result_p, TP
 
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) != COMPAT_MYSQL)
     {
-      DB_MAKE_DATE (result_p, month, day, year);
+      db_make_date (result_p, month, day, year);
     }
   else
     {
@@ -1651,11 +1651,11 @@ qdata_add_short_to_date (DB_VALUE * date_val_p, short s, DB_VALUE * result_p, TP
       switch (type)
 	{
 	case DB_TYPE_SHORT:
-	  DB_MAKE_SHORT (result_p, (year * 100 + month) * 100 + day);
+	  db_make_short (result_p, (year * 100 + month) * 100 + day);
 	  break;
 
 	default:
-	  DB_MAKE_DATE (result_p, month, day, year);
+	  db_make_date (result_p, month, day, year);
 	  break;
 	}
     }
@@ -1670,7 +1670,7 @@ qdata_add_int_to_date (DB_VALUE * date_val_p, int i, DB_VALUE * result_p, TP_DOM
   unsigned int utmp, u1, u2;
   int day, month, year;
 
-  date = DB_GET_DATE (date_val_p);
+  date = db_get_date (date_val_p);
 
   if (i < 0)
     {
@@ -1690,7 +1690,7 @@ qdata_add_int_to_date (DB_VALUE * date_val_p, int i, DB_VALUE * result_p, TP_DOM
   db_date_decode (&utmp, &month, &day, &year);
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) != COMPAT_MYSQL)
     {
-      DB_MAKE_DATE (result_p, month, day, year);
+      db_make_date (result_p, month, day, year);
     }
   else
     {
@@ -1699,11 +1699,11 @@ qdata_add_int_to_date (DB_VALUE * date_val_p, int i, DB_VALUE * result_p, TP_DOM
       switch (type)
 	{
 	case DB_TYPE_INTEGER:
-	  DB_MAKE_INT (result_p, (year * 100 + month) * 100 + day);
+	  db_make_int (result_p, (year * 100 + month) * 100 + day);
 	  break;
 
 	default:
-	  DB_MAKE_DATE (result_p, month, day, year);
+	  db_make_date (result_p, month, day, year);
 	  break;
 	}
     }
@@ -1719,7 +1719,7 @@ qdata_add_bigint_to_date (DB_VALUE * date_val_p, DB_BIGINT bi, DB_VALUE * result
   DB_DATE tmp_date;
   int day, month, year;
 
-  date = DB_GET_DATE (date_val_p);
+  date = db_get_date (date_val_p);
 
   if (bi < 0)
     {
@@ -1740,7 +1740,7 @@ qdata_add_bigint_to_date (DB_VALUE * date_val_p, DB_BIGINT bi, DB_VALUE * result
   db_date_decode (&tmp_date, &month, &day, &year);
   if (prm_get_integer_value (PRM_ID_COMPAT_MODE) == COMPAT_MYSQL)
     {
-      DB_MAKE_DATE (result_p, month, day, year);
+      db_make_date (result_p, month, day, year);
     }
   else
     {
@@ -1749,11 +1749,11 @@ qdata_add_bigint_to_date (DB_VALUE * date_val_p, DB_BIGINT bi, DB_VALUE * result
       switch (type)
 	{
 	case DB_TYPE_BIGINT:
-	  DB_MAKE_BIGINT (result_p, (year * 100 + month) * 100 + day);
+	  db_make_bigint (result_p, (year * 100 + month) * 100 + day);
 	  break;
 
 	default:
-	  DB_MAKE_DATE (result_p, month, day, year);
+	  db_make_date (result_p, month, day, year);
 	  break;
 	}
     }
@@ -1769,7 +1769,7 @@ qdata_add_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VALUE *
   short s;
   DB_TYPE type;
 
-  s = DB_GET_SHORT (short_val_p);
+  s = db_get_short (short_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
@@ -1778,22 +1778,22 @@ qdata_add_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VALUE *
       return qdata_add_short (s, dbval_p, result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_int (s, DB_GET_INT (dbval_p), result_p);
+      return qdata_add_int (s, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_bigint (s, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_add_bigint (s, db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_add_float (s, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_add_float (s, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_add_double (s, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_add_double (s, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_add_numeric (dbval_p, short_val_p, result_p);
 
     case DB_TYPE_MONETARY:
-      return qdata_add_monetary (s, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type, result_p);
+      return qdata_add_monetary (s, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type, result_p);
 
     case DB_TYPE_TIME:
       return qdata_add_bigint_to_time (dbval_p, (DB_BIGINT) s, result_p);
@@ -1801,14 +1801,14 @@ qdata_add_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VALUE *
     case DB_TYPE_TIMELTZ:
       {
 	DB_TIMETZ time_tz;
-	time_tz.time = *DB_GET_TIME (dbval_p);
+	time_tz.time = *db_get_time (dbval_p);
 
 	err = tz_create_session_tzid_for_time (&time_tz.time, true, &time_tz.tz_id);
 	if (err != NO_ERROR)
 	  {
 	    break;
 	  }
-	DB_MAKE_TIMETZ (&tmp_val, &time_tz);
+	db_make_timetz (&tmp_val, &time_tz);
 
 	err = qdata_add_bigint_to_timetz (&tmp_val, (DB_BIGINT) s, result_p);
 	if (err != NO_ERROR)
@@ -1817,8 +1817,8 @@ qdata_add_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VALUE *
 	  }
 	if (DB_VALUE_TYPE (result_p) == DB_TYPE_TIMETZ)
 	  {
-	    time_tz = *DB_GET_TIMETZ (result_p);
-	    DB_MAKE_TIMELTZ (result_p, &time_tz.time);
+	    time_tz = *db_get_timetz (result_p);
+	    db_make_timeltz (result_p, &time_tz.time);
 	  }
 	break;
       }
@@ -1832,14 +1832,14 @@ qdata_add_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VALUE *
     case DB_TYPE_TIMESTAMPLTZ:
       {
 	DB_TIMESTAMPTZ ts_tz;
-	ts_tz.timestamp = *DB_GET_UTIME (dbval_p);
+	ts_tz.timestamp = *db_get_utime (dbval_p);
 
 	err = tz_create_session_tzid_for_timestamp (&ts_tz.timestamp, &ts_tz.tz_id);
 	if (err != NO_ERROR)
 	  {
 	    break;
 	  }
-	DB_MAKE_TIMESTAMPTZ (&tmp_val, &ts_tz);
+	db_make_timestamptz (&tmp_val, &ts_tz);
 
 	err = qdata_add_short_to_timestamptz (&tmp_val, (DB_BIGINT) s, result_p, domain_p);
 	if (err != NO_ERROR)
@@ -1848,8 +1848,8 @@ qdata_add_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VALUE *
 	  }
 	if (DB_VALUE_TYPE (result_p) == DB_TYPE_TIMESTAMPTZ)
 	  {
-	    ts_tz = *DB_GET_TIMESTAMPTZ (result_p);
-	    DB_MAKE_TIMESTAMPLTZ (result_p, ts_tz.timestamp);
+	    ts_tz = *db_get_timestamptz (result_p);
+	    db_make_timestampltz (result_p, ts_tz.timestamp);
 	  }
 	break;
       }
@@ -1862,12 +1862,12 @@ qdata_add_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VALUE *
       err = qdata_add_short_to_datetime (dbval_p, s, &tmp_val, domain_p);
       if (err == NO_ERROR && type == DB_TYPE_DATETIMELTZ)
 	{
-	  DB_MAKE_DATETIMELTZ (result_p, DB_GET_DATETIME (&tmp_val));
+	  db_make_datetimeltz (result_p, db_get_datetime (&tmp_val));
 	}
       return err;
 
     case DB_TYPE_DATETIMETZ:
-      DB_MAKE_SHORT (&tmp_val, s);
+      db_make_short (&tmp_val, s);
       return qdata_add_datetimetz_to_dbval (dbval_p, &tmp_val, result_p);
 
     case DB_TYPE_DATE:
@@ -1888,32 +1888,32 @@ qdata_add_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE * res
   DB_TYPE type;
   DB_VALUE tmp_val;
 
-  i = DB_GET_INT (int_val_p);
+  i = db_get_int (int_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_add_int (i, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_add_int (i, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_int (i, DB_GET_INT (dbval_p), result_p);
+      return qdata_add_int (i, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_bigint (i, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_add_bigint (i, db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_add_float ((float) i, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_add_float ((float) i, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_add_double (i, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_add_double (i, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_add_numeric (dbval_p, int_val_p, result_p);
       break;
 
     case DB_TYPE_MONETARY:
-      return qdata_add_monetary (i, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type, result_p);
+      return qdata_add_monetary (i, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type, result_p);
 
     case DB_TYPE_TIME:
       return qdata_add_bigint_to_time (dbval_p, (DB_BIGINT) i, result_p);
@@ -1921,14 +1921,14 @@ qdata_add_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE * res
     case DB_TYPE_TIMELTZ:
       {
 	DB_TIMETZ time_tz;
-	time_tz.time = *DB_GET_TIME (dbval_p);
+	time_tz.time = *db_get_time (dbval_p);
 
 	err = tz_create_session_tzid_for_time (&time_tz.time, true, &time_tz.tz_id);
 	if (err != NO_ERROR)
 	  {
 	    break;
 	  }
-	DB_MAKE_TIMETZ (&tmp_val, &time_tz);
+	db_make_timetz (&tmp_val, &time_tz);
 
 	err = qdata_add_bigint_to_timetz (&tmp_val, (DB_BIGINT) i, result_p);
 	if (err != NO_ERROR)
@@ -1937,8 +1937,8 @@ qdata_add_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE * res
 	  }
 	if (DB_VALUE_TYPE (result_p) == DB_TYPE_TIMETZ)
 	  {
-	    time_tz = *DB_GET_TIMETZ (result_p);
-	    DB_MAKE_TIMELTZ (result_p, &time_tz.time);
+	    time_tz = *db_get_timetz (result_p);
+	    db_make_timeltz (result_p, &time_tz.time);
 	  }
 	break;
       }
@@ -1952,14 +1952,14 @@ qdata_add_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE * res
     case DB_TYPE_TIMESTAMPLTZ:
       {
 	DB_TIMESTAMPTZ ts_tz;
-	ts_tz.timestamp = *DB_GET_UTIME (dbval_p);
+	ts_tz.timestamp = *db_get_utime (dbval_p);
 
 	err = tz_create_session_tzid_for_timestamp (&ts_tz.timestamp, &ts_tz.tz_id);
 	if (err != NO_ERROR)
 	  {
 	    break;
 	  }
-	DB_MAKE_TIMESTAMPTZ (&tmp_val, &ts_tz);
+	db_make_timestamptz (&tmp_val, &ts_tz);
 
 	err = qdata_add_int_to_timestamptz (&tmp_val, (DB_BIGINT) i, result_p, domain_p);
 	if (err != NO_ERROR)
@@ -1968,8 +1968,8 @@ qdata_add_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE * res
 	  }
 	if (DB_VALUE_TYPE (result_p) == DB_TYPE_TIMESTAMPTZ)
 	  {
-	    ts_tz = *DB_GET_TIMESTAMPTZ (result_p);
-	    DB_MAKE_TIMESTAMPLTZ (result_p, ts_tz.timestamp);
+	    ts_tz = *db_get_timestamptz (result_p);
+	    db_make_timestampltz (result_p, ts_tz.timestamp);
 	  }
 	break;
       }
@@ -1982,12 +1982,12 @@ qdata_add_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE * res
       err = qdata_add_int_to_datetime (dbval_p, i, &tmp_val, domain_p);
       if (err == NO_ERROR && type == DB_TYPE_DATETIMELTZ)
 	{
-	  DB_MAKE_DATETIMELTZ (result_p, DB_GET_DATETIME (&tmp_val));
+	  db_make_datetimeltz (result_p, db_get_datetime (&tmp_val));
 	}
       return err;
 
     case DB_TYPE_DATETIMETZ:
-      DB_MAKE_INT (&tmp_val, i);
+      db_make_int (&tmp_val, i);
       return qdata_add_datetimetz_to_dbval (dbval_p, &tmp_val, result_p);
 
     case DB_TYPE_DATE:
@@ -2008,32 +2008,32 @@ qdata_add_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_VALUE
   DB_TYPE type;
   DB_VALUE tmp_val;
 
-  bi = DB_GET_BIGINT (bigint_val_p);
+  bi = db_get_bigint (bigint_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_add_bigint (bi, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_add_bigint (bi, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_bigint (bi, DB_GET_INT (dbval_p), result_p);
+      return qdata_add_bigint (bi, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_bigint (bi, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_add_bigint (bi, db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_add_float ((float) bi, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_add_float ((float) bi, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_add_double ((double) bi, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_add_double ((double) bi, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_add_numeric (dbval_p, bigint_val_p, result_p);
       break;
 
     case DB_TYPE_MONETARY:
-      return qdata_add_monetary ((double) bi, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type,
+      return qdata_add_monetary ((double) bi, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type,
 				 result_p);
 
     case DB_TYPE_TIME:
@@ -2042,14 +2042,14 @@ qdata_add_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_VALUE
     case DB_TYPE_TIMELTZ:
       {
 	DB_TIMETZ time_tz;
-	time_tz.time = *DB_GET_TIME (dbval_p);
+	time_tz.time = *db_get_time (dbval_p);
 
 	err = tz_create_session_tzid_for_time (&time_tz.time, true, &time_tz.tz_id);
 	if (err != NO_ERROR)
 	  {
 	    break;
 	  }
-	DB_MAKE_TIMETZ (&tmp_val, &time_tz);
+	db_make_timetz (&tmp_val, &time_tz);
 
 	err = qdata_add_bigint_to_timetz (&tmp_val, bi, result_p);
 	if (err != NO_ERROR)
@@ -2058,8 +2058,8 @@ qdata_add_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_VALUE
 	  }
 	if (DB_VALUE_TYPE (result_p) == DB_TYPE_TIMETZ)
 	  {
-	    time_tz = *DB_GET_TIMETZ (result_p);
-	    DB_MAKE_TIMELTZ (result_p, &time_tz.time);
+	    time_tz = *db_get_timetz (result_p);
+	    db_make_timeltz (result_p, &time_tz.time);
 	  }
 	break;
       }
@@ -2073,14 +2073,14 @@ qdata_add_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_VALUE
     case DB_TYPE_TIMESTAMPLTZ:
       {
 	DB_TIMESTAMPTZ ts_tz;
-	ts_tz.timestamp = *DB_GET_UTIME (dbval_p);
+	ts_tz.timestamp = *db_get_utime (dbval_p);
 
 	err = tz_create_session_tzid_for_timestamp (&ts_tz.timestamp, &ts_tz.tz_id);
 	if (err != NO_ERROR)
 	  {
 	    break;
 	  }
-	DB_MAKE_TIMESTAMPTZ (&tmp_val, &ts_tz);
+	db_make_timestamptz (&tmp_val, &ts_tz);
 
 	err = qdata_add_bigint_to_timestamptz (&tmp_val, bi, result_p, domain_p);
 	if (err != NO_ERROR)
@@ -2089,8 +2089,8 @@ qdata_add_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_VALUE
 	  }
 	if (DB_VALUE_TYPE (result_p) == DB_TYPE_TIMESTAMPTZ)
 	  {
-	    ts_tz = *DB_GET_TIMESTAMPTZ (result_p);
-	    DB_MAKE_TIMESTAMPLTZ (result_p, ts_tz.timestamp);
+	    ts_tz = *db_get_timestamptz (result_p);
+	    db_make_timestampltz (result_p, ts_tz.timestamp);
 	  }
 	break;
       }
@@ -2108,12 +2108,12 @@ qdata_add_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_VALUE
       err = qdata_add_bigint_to_datetime (dbval_p, bi, &tmp_val, domain_p);
       if (err == NO_ERROR && type == DB_TYPE_DATETIMELTZ)
 	{
-	  DB_MAKE_DATETIMELTZ (result_p, DB_GET_DATETIME (&tmp_val));
+	  db_make_datetimeltz (result_p, db_get_datetime (&tmp_val));
 	}
       return err;
 
     case DB_TYPE_DATETIMETZ:
-      DB_MAKE_BIGINT (&tmp_val, bi);
+      db_make_bigint (&tmp_val, bi);
       return qdata_add_datetimetz_to_dbval (dbval_p, &tmp_val, result_p);
 
     default:
@@ -2129,31 +2129,31 @@ qdata_add_float_to_dbval (DB_VALUE * float_val_p, DB_VALUE * dbval_p, DB_VALUE *
   float f1;
   DB_TYPE type;
 
-  f1 = DB_GET_FLOAT (float_val_p);
+  f1 = db_get_float (float_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_add_float (f1, (float) DB_GET_SHORT (dbval_p), result_p);
+      return qdata_add_float (f1, (float) db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_float (f1, (float) DB_GET_INT (dbval_p), result_p);
+      return qdata_add_float (f1, (float) db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_double (f1, (double) DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_add_double (f1, (double) db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_add_float (f1, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_add_float (f1, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_add_double (f1, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_add_double (f1, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_add_double (f1, qdata_coerce_numeric_to_double (dbval_p), result_p);
 
     case DB_TYPE_MONETARY:
-      return qdata_add_monetary (f1, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type, result_p);
+      return qdata_add_monetary (f1, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type, result_p);
 
     default:
       break;
@@ -2168,31 +2168,31 @@ qdata_add_double_to_dbval (DB_VALUE * double_val_p, DB_VALUE * dbval_p, DB_VALUE
   double d1;
   DB_TYPE type;
 
-  d1 = DB_GET_DOUBLE (double_val_p);
+  d1 = db_get_double (double_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_add_double (d1, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_add_double (d1, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_double (d1, DB_GET_INT (dbval_p), result_p);
+      return qdata_add_double (d1, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_double (d1, (double) DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_add_double (d1, (double) db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_add_double (d1, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_add_double (d1, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_add_double (d1, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_add_double (d1, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_add_double (d1, qdata_coerce_numeric_to_double (dbval_p), result_p);
 
     case DB_TYPE_MONETARY:
-      return qdata_add_monetary (d1, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type, result_p);
+      return qdata_add_monetary (d1, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type, result_p);
 
     default:
       break;
@@ -2224,10 +2224,10 @@ qdata_add_numeric_to_dbval (DB_VALUE * numeric_val_p, DB_VALUE * dbval_p, DB_VAL
       break;
 
     case DB_TYPE_FLOAT:
-      return qdata_add_double (qdata_coerce_numeric_to_double (numeric_val_p), DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_add_double (qdata_coerce_numeric_to_double (numeric_val_p), db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_add_double (qdata_coerce_numeric_to_double (numeric_val_p), DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_add_double (qdata_coerce_numeric_to_double (numeric_val_p), db_get_double (dbval_p), result_p);
 
     case DB_TYPE_MONETARY:
       return qdata_add_numeric_to_monetary (numeric_val_p, dbval_p, result_p);
@@ -2246,34 +2246,34 @@ qdata_add_monetary_to_dbval (DB_VALUE * monetary_val_p, DB_VALUE * dbval_p, DB_V
   double d1;
   DB_CURRENCY currency;
 
-  d1 = (DB_GET_MONETARY (monetary_val_p))->amount;
-  currency = (DB_GET_MONETARY (monetary_val_p))->type;
+  d1 = (db_get_monetary (monetary_val_p))->amount;
+  currency = (db_get_monetary (monetary_val_p))->type;
 
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_add_monetary (d1, DB_GET_SHORT (dbval_p), currency, result_p);
+      return qdata_add_monetary (d1, db_get_short (dbval_p), currency, result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_monetary (d1, DB_GET_INT (dbval_p), currency, result_p);
+      return qdata_add_monetary (d1, db_get_int (dbval_p), currency, result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_monetary (d1, (double) DB_GET_BIGINT (dbval_p), currency, result_p);
+      return qdata_add_monetary (d1, (double) db_get_bigint (dbval_p), currency, result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_add_monetary (d1, DB_GET_FLOAT (dbval_p), currency, result_p);
+      return qdata_add_monetary (d1, db_get_float (dbval_p), currency, result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_add_monetary (d1, DB_GET_DOUBLE (dbval_p), currency, result_p);
+      return qdata_add_monetary (d1, db_get_double (dbval_p), currency, result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_add_numeric_to_monetary (dbval_p, monetary_val_p, result_p);
 
     case DB_TYPE_MONETARY:
       /* Note: we probably should return an error if the two monetaries have different monetary types. */
-      return qdata_add_monetary (d1, (DB_GET_MONETARY (dbval_p))->amount, currency, result_p);
+      return qdata_add_monetary (d1, (db_get_monetary (dbval_p))->amount, currency, result_p);
 
     default:
       break;
@@ -2319,7 +2319,7 @@ qdata_add_sequence_to_dbval (DB_VALUE * seq_val_p, DB_VALUE * dbval_p, DB_VALUE 
       return ER_FAILED;
     }
 
-  DB_MAKE_NULL (&dbval_tmp);
+  db_make_null (&dbval_tmp);
 
   if (TP_DOMAIN_TYPE (domain_p) == DB_TYPE_SEQUENCE)
     {
@@ -2328,9 +2328,9 @@ qdata_add_sequence_to_dbval (DB_VALUE * seq_val_p, DB_VALUE * dbval_p, DB_VALUE 
 	  return ER_FAILED;
 	}
 
-      seq_tmp = DB_GET_SEQUENCE (dbval_p);
+      seq_tmp = db_get_set (dbval_p);
       card = db_seq_size (seq_tmp);
-      seq_tmp1 = DB_GET_SEQUENCE (result_p);
+      seq_tmp1 = db_get_set (result_p);
       card1 = db_seq_size (seq_tmp1);
 
       for (i = 0; i < card; i++)
@@ -2352,7 +2352,7 @@ qdata_add_sequence_to_dbval (DB_VALUE * seq_val_p, DB_VALUE * dbval_p, DB_VALUE 
   else
     {
       /* set or multiset */
-      if (set_union (DB_GET_SET (seq_val_p), DB_GET_SET (dbval_p), &set_tmp, domain_p) < 0)
+      if (set_union (db_get_set (seq_val_p), db_get_set (dbval_p), &set_tmp, domain_p) < 0)
 	{
 	  return ER_FAILED;
 	}
@@ -2374,13 +2374,13 @@ qdata_add_time_to_dbval (DB_VALUE * time_val_p, DB_VALUE * dbval_p, DB_VALUE * r
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_add_bigint_to_time (time_val_p, (DB_BIGINT) DB_GET_SHORT (dbval_p), result_p);
+      return qdata_add_bigint_to_time (time_val_p, (DB_BIGINT) db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_bigint_to_time (time_val_p, (DB_BIGINT) DB_GET_INT (dbval_p), result_p);
+      return qdata_add_bigint_to_time (time_val_p, (DB_BIGINT) db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_bigint_to_time (time_val_p, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_add_bigint_to_time (time_val_p, db_get_bigint (dbval_p), result_p);
 
     default:
       break;
@@ -2399,13 +2399,13 @@ qdata_add_timetz_to_dbval (DB_VALUE * time_tz_val_p, DB_VALUE * dbval_p, DB_VALU
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_add_bigint_to_timetz (time_tz_val_p, (DB_BIGINT) DB_GET_SHORT (dbval_p), result_p);
+      return qdata_add_bigint_to_timetz (time_tz_val_p, (DB_BIGINT) db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_bigint_to_timetz (time_tz_val_p, (DB_BIGINT) DB_GET_INT (dbval_p), result_p);
+      return qdata_add_bigint_to_timetz (time_tz_val_p, (DB_BIGINT) db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_bigint_to_timetz (time_tz_val_p, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_add_bigint_to_timetz (time_tz_val_p, db_get_bigint (dbval_p), result_p);
 
     default:
       break;
@@ -2424,13 +2424,13 @@ qdata_add_utime_to_dbval (DB_VALUE * utime_val_p, DB_VALUE * dbval_p, DB_VALUE *
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_add_short_to_utime (utime_val_p, DB_GET_SHORT (dbval_p), result_p, domain_p);
+      return qdata_add_short_to_utime (utime_val_p, db_get_short (dbval_p), result_p, domain_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_int_to_utime (utime_val_p, DB_GET_INT (dbval_p), result_p, domain_p);
+      return qdata_add_int_to_utime (utime_val_p, db_get_int (dbval_p), result_p, domain_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_bigint_to_utime (utime_val_p, DB_GET_BIGINT (dbval_p), result_p, domain_p);
+      return qdata_add_bigint_to_utime (utime_val_p, db_get_bigint (dbval_p), result_p, domain_p);
 
     default:
       break;
@@ -2452,13 +2452,13 @@ qdata_add_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p, DB_V
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_add_short_to_timestamptz (ts_tz_val_p, DB_GET_SHORT (dbval_p), result_p, domain_p);
+      return qdata_add_short_to_timestamptz (ts_tz_val_p, db_get_short (dbval_p), result_p, domain_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_int_to_timestamptz (ts_tz_val_p, DB_GET_INT (dbval_p), result_p, domain_p);
+      return qdata_add_int_to_timestamptz (ts_tz_val_p, db_get_int (dbval_p), result_p, domain_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_bigint_to_timestamptz (ts_tz_val_p, DB_GET_BIGINT (dbval_p), result_p, domain_p);
+      return qdata_add_bigint_to_timestamptz (ts_tz_val_p, db_get_bigint (dbval_p), result_p, domain_p);
 
     default:
       break;
@@ -2477,13 +2477,13 @@ qdata_add_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p, DB_V
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_add_short_to_datetime (datetime_val_p, DB_GET_SHORT (dbval_p), result_p, domain_p);
+      return qdata_add_short_to_datetime (datetime_val_p, db_get_short (dbval_p), result_p, domain_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_int_to_datetime (datetime_val_p, DB_GET_INT (dbval_p), result_p, domain_p);
+      return qdata_add_int_to_datetime (datetime_val_p, db_get_int (dbval_p), result_p, domain_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_bigint_to_datetime (datetime_val_p, DB_GET_BIGINT (dbval_p), result_p, domain_p);
+      return qdata_add_bigint_to_datetime (datetime_val_p, db_get_bigint (dbval_p), result_p, domain_p);
 
     default:
       break;
@@ -2497,17 +2497,17 @@ qdata_add_datetimetz_to_dbval (DB_VALUE * datetimetz_val_p, DB_VALUE * dbval_p, 
 {
   int error = NO_ERROR;
   DB_VALUE dt_val, dt_val_res;
-  DB_DATETIMETZ *dt_tz_p = DB_GET_DATETIMETZ (datetimetz_val_p);
+  DB_DATETIMETZ *dt_tz_p = db_get_datetimetz (datetimetz_val_p);
   DB_DATETIMETZ dt_tz_res, dt_tz_fixed;
 
-  DB_MAKE_DATETIME (&dt_val, &dt_tz_p->datetime);
+  db_make_datetime (&dt_val, &dt_tz_p->datetime);
   error = qdata_add_datetime_to_dbval (&dt_val, dbval_p, &dt_val_res, tp_domain_resolve_default (DB_TYPE_DATETIME));
   if (error != NO_ERROR)
     {
       return error;
     }
 
-  dt_tz_res.datetime = *DB_GET_DATETIME (&dt_val_res);
+  dt_tz_res.datetime = *db_get_datetime (&dt_val_res);
   dt_tz_res.tz_id = dt_tz_p->tz_id;
 
   error = tz_datetimetz_fix_zone (&dt_tz_res, &dt_tz_fixed);
@@ -2516,7 +2516,7 @@ qdata_add_datetimetz_to_dbval (DB_VALUE * datetimetz_val_p, DB_VALUE * dbval_p, 
       return error;
     }
 
-  DB_MAKE_DATETIMETZ (result_p, &dt_tz_fixed);
+  db_make_datetimetz (result_p, &dt_tz_fixed);
   return NO_ERROR;
 }
 
@@ -2530,13 +2530,13 @@ qdata_add_date_to_dbval (DB_VALUE * date_val_p, DB_VALUE * dbval_p, DB_VALUE * r
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_add_short_to_date (date_val_p, DB_GET_SHORT (dbval_p), result_p, domain_p);
+      return qdata_add_short_to_date (date_val_p, db_get_short (dbval_p), result_p, domain_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_add_int_to_date (date_val_p, DB_GET_INT (dbval_p), result_p, domain_p);
+      return qdata_add_int_to_date (date_val_p, db_get_int (dbval_p), result_p, domain_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_add_bigint_to_date (date_val_p, DB_GET_BIGINT (dbval_p), result_p, domain_p);
+      return qdata_add_bigint_to_date (date_val_p, db_get_bigint (dbval_p), result_p, domain_p);
 
     default:
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS) == false)
@@ -2682,8 +2682,8 @@ qdata_add_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_p, 
       return NO_ERROR;
     }
 
-  DB_MAKE_NULL (&cast_value1);
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value1);
+  db_make_null (&cast_value2);
 
   /* not all pairs of operands types can be handled; for some of these pairs, reverse the order of operands to match
    * the handled case */
@@ -2755,7 +2755,7 @@ qdata_add_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_p, 
   if (qdata_is_zero_value_date (dbval1_p) || qdata_is_zero_value_date (dbval2_p))
     {
       /* add operation with zero date returns null */
-      DB_MAKE_NULL (result_p);
+      db_make_null (result_p);
       if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ATTEMPT_TO_USE_ZERODATE, 0);
@@ -2833,7 +2833,7 @@ qdata_add_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_p, 
       error = qdata_add_time_to_dbval (dbval1_p, dbval2_p, result_p);
       if (error == NO_ERROR && type1 == DB_TYPE_TIMELTZ)
 	{
-	  DB_MAKE_TIMELTZ (result_p, DB_GET_TIME (result_p));
+	  db_make_timeltz (result_p, db_get_time (result_p));
 	}
       break;
 
@@ -2850,7 +2850,7 @@ qdata_add_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_p, 
 	DB_TIMESTAMPTZ ts_tz, *ts_tz_p;
 	DB_VALUE ts_tz_val, tmp_val_res;
 
-	ts_tz.timestamp = *DB_GET_UTIME (dbval1_p);
+	ts_tz.timestamp = *db_get_utime (dbval1_p);
 
 	error = tz_create_session_tzid_for_timestamp (&ts_tz.timestamp, &ts_tz.tz_id);
 	if (error != NO_ERROR)
@@ -2858,7 +2858,7 @@ qdata_add_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_p, 
 	    break;
 	  }
 
-	DB_MAKE_TIMESTAMPTZ (&ts_tz_val, &ts_tz);
+	db_make_timestamptz (&ts_tz_val, &ts_tz);
 
 	error = qdata_add_timestamptz_to_dbval (&ts_tz_val, dbval2_p, &tmp_val_res);
 	if (error != NO_ERROR)
@@ -2867,8 +2867,8 @@ qdata_add_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_p, 
 	  }
 	if (DB_VALUE_TYPE (&tmp_val_res) == DB_TYPE_TIMESTAMPTZ)
 	  {
-	    ts_tz_p = DB_GET_TIMESTAMPTZ (&tmp_val_res);
-	    DB_MAKE_TIMESTAMPLTZ (result_p, ts_tz_p->timestamp);
+	    ts_tz_p = db_get_timestamptz (&tmp_val_res);
+	    db_make_timestampltz (result_p, ts_tz_p->timestamp);
 	  }
 	else
 	  {
@@ -2888,7 +2888,7 @@ qdata_add_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_p, 
       error = qdata_add_datetime_to_dbval (dbval1_p, dbval2_p, result_p, domain_p);
       if (error == NO_ERROR && type1 == DB_TYPE_DATETIMELTZ)
 	{
-	  DB_MAKE_DATETIMELTZ (result_p, DB_GET_DATETIME (result_p));
+	  db_make_datetimeltz (result_p, db_get_datetime (result_p));
 	}
       break;
 
@@ -2957,10 +2957,10 @@ qdata_concatenate_dbval (THREAD_ENTRY * thread_p, DB_VALUE * dbval1_p, DB_VALUE 
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
       return ER_QPROC_INVALID_DATATYPE;
     }
-  DB_MAKE_NULL (&arg_val);
-  DB_MAKE_NULL (&db_temp);
+  db_make_null (&arg_val);
+  db_make_null (&db_temp);
 
-  res_size = DB_GET_STRING_SIZE (dbval1_p);
+  res_size = db_get_string_size (dbval1_p);
 
   switch (type2)
     {
@@ -2970,7 +2970,7 @@ qdata_concatenate_dbval (THREAD_ENTRY * thread_p, DB_VALUE * dbval1_p, DB_VALUE 
     case DB_TYPE_VARNCHAR:
     case DB_TYPE_BIT:
     case DB_TYPE_VARBIT:
-      val_size = DB_GET_STRING_SIZE (dbval2_p);
+      val_size = db_get_string_size (dbval2_p);
       if (res_size >= max_allowed_size)
 	{
 	  assert (warning_size_exceeded == false);
@@ -2995,8 +2995,8 @@ qdata_concatenate_dbval (THREAD_ENTRY * thread_p, DB_VALUE * dbval1_p, DB_VALUE 
 	       * aggregate. */
 	      save_need_clear = result_p->need_clear;
 	      qstr_make_typed_string (DB_VALUE_DOMAIN_TYPE (result_p), result_p, DB_VALUE_PRECISION (result_p),
-				      db_get_string (result_p), DB_GET_STRING_SIZE (result_p) + spare_bytes,
-				      DB_GET_STRING_CODESET (dbval1_p), DB_GET_STRING_COLLATION (dbval1_p));
+				      db_get_string (result_p), db_get_string_size (result_p) + spare_bytes,
+				      db_get_string_codeset (dbval1_p), db_get_string_collation (dbval1_p));
 	      result_p->need_clear = save_need_clear;
 	    }
 	}
@@ -3029,7 +3029,7 @@ qdata_concatenate_dbval (THREAD_ENTRY * thread_p, DB_VALUE * dbval1_p, DB_VALUE 
 
 	if (err_dom == DOMAIN_COMPATIBLE)
 	  {
-	    val_size = DB_GET_STRING_SIZE (&arg_val);
+	    val_size = db_get_string_size (&arg_val);
 
 	    if (res_size >= max_allowed_size)
 	      {
@@ -3051,8 +3051,8 @@ qdata_concatenate_dbval (THREAD_ENTRY * thread_p, DB_VALUE * dbval1_p, DB_VALUE 
 		  {
 		    save_need_clear = result_p->need_clear;
 		    qstr_make_typed_string (DB_VALUE_DOMAIN_TYPE (result_p), result_p, DB_VALUE_PRECISION (result_p),
-					    db_get_string (result_p), DB_GET_STRING_SIZE (result_p) + spare_bytes,
-					    DB_GET_STRING_CODESET (dbval1_p), DB_GET_STRING_COLLATION (dbval1_p));
+					    db_get_string (result_p), db_get_string_size (result_p) + spare_bytes,
+					    db_get_string_codeset (dbval1_p), db_get_string_collation (dbval1_p));
 		    result_p->need_clear = save_need_clear;
 		  }
 	      }
@@ -3107,7 +3107,7 @@ qdata_increment_dbval (DB_VALUE * dbval_p, DB_VALUE * result_p, int inc_val)
   switch (type1)
     {
     case DB_TYPE_SHORT:
-      s1 = DB_GET_SHORT (dbval_p);
+      s1 = db_get_short (dbval_p);
       stmp = s1 + inc_val;
       if ((inc_val > 0 && OR_CHECK_ADD_OVERFLOW (s1, inc_val, stmp))
 	  || (inc_val < 0 && OR_CHECK_SUB_UNDERFLOW (s1, -inc_val, stmp)))
@@ -3115,11 +3115,11 @@ qdata_increment_dbval (DB_VALUE * dbval_p, DB_VALUE * result_p, int inc_val)
 	  stmp = 0;
 	}
 
-      DB_MAKE_SHORT (result_p, stmp);
+      db_make_short (result_p, stmp);
       break;
 
     case DB_TYPE_INTEGER:
-      i1 = DB_GET_INT (dbval_p);
+      i1 = db_get_int (dbval_p);
       itmp = i1 + inc_val;
       if ((inc_val > 0 && OR_CHECK_ADD_OVERFLOW (i1, inc_val, itmp))
 	  || (inc_val < 0 && OR_CHECK_SUB_UNDERFLOW (i1, -inc_val, itmp)))
@@ -3127,11 +3127,11 @@ qdata_increment_dbval (DB_VALUE * dbval_p, DB_VALUE * result_p, int inc_val)
 	  itmp = 0;
 	}
 
-      DB_MAKE_INT (result_p, itmp);
+      db_make_int (result_p, itmp);
       break;
 
     case DB_TYPE_BIGINT:
-      bi1 = DB_GET_BIGINT (dbval_p);
+      bi1 = db_get_bigint (dbval_p);
       bitmp = bi1 + inc_val;
       if ((inc_val > 0 && OR_CHECK_ADD_OVERFLOW (bi1, inc_val, bitmp))
 	  || (inc_val < 0 && OR_CHECK_SUB_UNDERFLOW (bi1, -inc_val, bitmp)))
@@ -3139,7 +3139,7 @@ qdata_increment_dbval (DB_VALUE * dbval_p, DB_VALUE * result_p, int inc_val)
 	  bitmp = 0;
 	}
 
-      DB_MAKE_BIGINT (result_p, bitmp);
+      db_make_bigint (result_p, bitmp);
       break;
 
     default:
@@ -3163,7 +3163,7 @@ qdata_subtract_short (short s1, short s2, DB_VALUE * result_p)
       return ER_FAILED;
     }
 
-  DB_MAKE_SHORT (result_p, stmp);
+  db_make_short (result_p, stmp);
   return NO_ERROR;
 }
 
@@ -3180,7 +3180,7 @@ qdata_subtract_int (int i1, int i2, DB_VALUE * result_p)
       return ER_FAILED;
     }
 
-  DB_MAKE_INT (result_p, itmp);
+  db_make_int (result_p, itmp);
   return NO_ERROR;
 }
 
@@ -3197,7 +3197,7 @@ qdata_subtract_bigint (DB_BIGINT bi1, DB_BIGINT bi2, DB_VALUE * result_p)
       return ER_FAILED;
     }
 
-  DB_MAKE_BIGINT (result_p, bitmp);
+  db_make_bigint (result_p, bitmp);
   return NO_ERROR;
 }
 
@@ -3214,7 +3214,7 @@ qdata_subtract_float (float f1, float f2, DB_VALUE * result_p)
       return ER_FAILED;
     }
 
-  DB_MAKE_FLOAT (result_p, ftmp);
+  db_make_float (result_p, ftmp);
   return NO_ERROR;
 }
 
@@ -3231,7 +3231,7 @@ qdata_subtract_double (double d1, double d2, DB_VALUE * result_p)
       return ER_FAILED;
     }
 
-  DB_MAKE_DOUBLE (result_p, dtmp);
+  db_make_double (result_p, dtmp);
   return NO_ERROR;
 }
 
@@ -3248,7 +3248,7 @@ qdata_subtract_monetary (double d1, double d2, DB_CURRENCY currency, DB_VALUE * 
       return ER_FAILED;
     }
 
-  DB_MAKE_MONETARY_TYPE_AMOUNT (result_p, currency, dtmp);
+  db_make_monetary (result_p, currency, dtmp);
   return NO_ERROR;
 }
 
@@ -3265,7 +3265,7 @@ qdata_subtract_time (DB_TIME u1, DB_TIME u2, DB_VALUE * result_p)
 
   utmp = u1 - u2;
   db_time_decode (&utmp, &hour, &minute, &second);
-  DB_MAKE_TIME (result_p, hour, minute, second);
+  db_make_time (result_p, hour, minute, second);
 
   return NO_ERROR;
 }
@@ -3282,7 +3282,7 @@ qdata_subtract_utime (DB_UTIME u1, DB_UTIME u2, DB_VALUE * result_p)
       return ER_FAILED;
     }
 
-  DB_MAKE_UTIME (result_p, utmp);
+  db_make_timestamp (result_p, utmp);
   return NO_ERROR;
 }
 
@@ -3305,7 +3305,7 @@ qdata_subtract_utime_to_short_asymmetry (DB_VALUE * utime_val_p, short s, unsign
       s++;
     }
 
-  DB_MAKE_SHORT (&tmp, -(s));
+  db_make_short (&tmp, -(s));
   error = qdata_add_dbval (utime_val_p, &tmp, result_p, domain_p);
 
   return error;
@@ -3330,7 +3330,7 @@ qdata_subtract_utime_to_int_asymmetry (DB_VALUE * utime_val_p, int i, unsigned i
       i++;
     }
 
-  DB_MAKE_INT (&tmp, -(i));
+  db_make_int (&tmp, -(i));
   error = qdata_add_dbval (utime_val_p, &tmp, result_p, domain_p);
 
   return error;
@@ -3355,7 +3355,7 @@ qdata_subtract_utime_to_bigint_asymmetry (DB_VALUE * utime_val_p, DB_BIGINT bi, 
       bi++;
     }
 
-  DB_MAKE_BIGINT (&tmp, -(bi));
+  db_make_bigint (&tmp, -(bi));
   error = qdata_add_dbval (utime_val_p, &tmp, result_p, domain_p);
 
   return error;
@@ -3373,7 +3373,7 @@ qdata_subtract_datetime_to_int (DB_DATETIME * dt1, DB_BIGINT i2, DB_VALUE * resu
       return error;
     }
 
-  DB_MAKE_DATETIME (result_p, &datetime_tmp);
+  db_make_datetime (result_p, &datetime_tmp);
   return NO_ERROR;
 }
 
@@ -3392,7 +3392,7 @@ qdata_subtract_datetime (DB_DATETIME * dt1, DB_DATETIME * dt2, DB_VALUE * result
       return ER_FAILED;
     }
 
-  DB_MAKE_BIGINT (result_p, tmp);
+  db_make_bigint (result_p, tmp);
   return NO_ERROR;
 }
 
@@ -3415,7 +3415,7 @@ qdata_subtract_datetime_to_int_asymmetry (DB_VALUE * datetime_val_p, DB_BIGINT i
       i++;
     }
 
-  DB_MAKE_BIGINT (&tmp, -(i));
+  db_make_bigint (&tmp, -(i));
   error = qdata_add_dbval (datetime_val_p, &tmp, result_p, domain_p);
 
   return error;
@@ -3434,25 +3434,25 @@ qdata_subtract_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VA
   int err = NO_ERROR;
   DB_VALUE tmp_val;
 
-  s = DB_GET_SHORT (short_val_p);
+  s = db_get_short (short_val_p);
   type2 = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      return qdata_subtract_short (s, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_subtract_short (s, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_subtract_int (s, DB_GET_INT (dbval_p), result_p);
+      return qdata_subtract_int (s, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_subtract_bigint (s, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_subtract_bigint (s, db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_subtract_float (s, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_subtract_float (s, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_subtract_double (s, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_subtract_double (s, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       qdata_coerce_dbval_to_numeric (short_val_p, &dbval_tmp);
@@ -3465,7 +3465,7 @@ qdata_subtract_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VA
       break;
 
     case DB_TYPE_MONETARY:
-      return qdata_subtract_monetary (s, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type,
+      return qdata_subtract_monetary (s, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type,
 				      result_p);
 
     case DB_TYPE_TIME:
@@ -3484,48 +3484,48 @@ qdata_subtract_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VA
 	{
 	  DB_TIMETZ *timetz_p;
 
-	  timetz_p = DB_GET_TIMETZ (dbval_p);
+	  timetz_p = db_get_timetz (dbval_p);
 	  timeval = &timetz_p->time;
 	}
       else
 	{
-	  timeval = DB_GET_TIME (dbval_p);
+	  timeval = db_get_time (dbval_p);
 	}
 
       err = qdata_subtract_time (timetmp, (DB_TIME) (*timeval % SECONDS_OF_ONE_DAY), result_p);
       if (err == NO_ERROR && type2 == DB_TYPE_TIMELTZ)
 	{
-	  DB_MAKE_TIMELTZ (result_p, DB_GET_TIME (result_p));
+	  db_make_timeltz (result_p, db_get_time (result_p));
 	}
       else if (err == NO_ERROR && type2 == DB_TYPE_TIMETZ)
 	{
 	  DB_TIMETZ time_tz, time_tz_fixed;
 
-	  time_tz = *DB_GET_TIMETZ (dbval_p);
-	  time_tz.time = *DB_GET_TIME (result_p);
+	  time_tz = *db_get_timetz (dbval_p);
+	  time_tz.time = *db_get_time (result_p);
 	  err = tz_timetz_fix_zone (&time_tz, &time_tz_fixed);
 	  if (err != NO_ERROR)
 	    {
 	      break;
 	    }
-	  DB_MAKE_TIMETZ (result_p, &time_tz_fixed);
+	  db_make_timetz (result_p, &time_tz_fixed);
 	}
       return err;
 
     case DB_TYPE_UTIME:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_TIMESTAMPTZ:
-      DB_MAKE_BIGINT (&tmp_val, (DB_BIGINT) s);
+      db_make_bigint (&tmp_val, (DB_BIGINT) s);
       return qdata_subtract_bigint_to_dbval (&tmp_val, dbval_p, result_p);
 
     case DB_TYPE_DATETIME:
     case DB_TYPE_DATETIMELTZ:
     case DB_TYPE_DATETIMETZ:
-      DB_MAKE_INT (&tmp_val, (int) s);
+      db_make_int (&tmp_val, (int) s);
       return qdata_subtract_int_to_dbval (&tmp_val, dbval_p, result_p);
 
     case DB_TYPE_DATE:
-      date = DB_GET_DATE (dbval_p);
+      date = db_get_date (dbval_p);
 
       u1 = (unsigned int) s;
       u2 = (unsigned int) *date;
@@ -3538,7 +3538,7 @@ qdata_subtract_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VA
 	}
 
       db_time_decode (&utmp, &hour, &minute, &second);
-      DB_MAKE_TIME (result_p, hour, minute, second);
+      db_make_time (result_p, hour, minute, second);
       break;
 
     default:
@@ -3561,25 +3561,25 @@ qdata_subtract_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE 
   DB_VALUE tmp_val;
   int err = NO_ERROR;
 
-  i = DB_GET_INT (int_val_p);
+  i = db_get_int (int_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_subtract_int (i, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_subtract_int (i, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_subtract_int (i, DB_GET_INT (dbval_p), result_p);
+      return qdata_subtract_int (i, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_subtract_bigint (i, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_subtract_bigint (i, db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_subtract_float ((float) i, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_subtract_float ((float) i, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_subtract_double (i, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_subtract_double (i, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       qdata_coerce_dbval_to_numeric (int_val_p, &dbval_tmp);
@@ -3592,7 +3592,7 @@ qdata_subtract_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE 
       break;
 
     case DB_TYPE_MONETARY:
-      return qdata_subtract_monetary (i, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type,
+      return qdata_subtract_monetary (i, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type,
 				      result_p);
 
     case DB_TYPE_TIME:
@@ -3601,11 +3601,11 @@ qdata_subtract_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE 
     case DB_TYPE_UTIME:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_TIMESTAMPTZ:
-      DB_MAKE_BIGINT (&tmp_val, (DB_BIGINT) i);
+      db_make_bigint (&tmp_val, (DB_BIGINT) i);
       return qdata_subtract_bigint_to_dbval (&tmp_val, dbval_p, result_p);
 
     case DB_TYPE_DATETIME:
-      datetime = DB_GET_DATETIME (dbval_p);
+      datetime = db_get_datetime (dbval_p);
 
       datetime_tmp.date = i / MILLISECONDS_OF_ONE_DAY;
       datetime_tmp.time = i % MILLISECONDS_OF_ONE_DAY;
@@ -3616,7 +3616,7 @@ qdata_subtract_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE 
       {
 	DB_DATETIME dt_local;
 
-	datetime = DB_GET_DATETIME (dbval_p);
+	datetime = db_get_datetime (dbval_p);
 	err = tz_datetimeltz_to_local (datetime, &dt_local);
 	if (err != NO_ERROR)
 	  {
@@ -3634,7 +3634,7 @@ qdata_subtract_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE 
 	DB_DATETIMETZ dt_tz;
 	DB_DATETIME dt_local;
 
-	dt_tz = *DB_GET_DATETIMETZ (dbval_p);
+	dt_tz = *db_get_datetimetz (dbval_p);
 
 	err = tz_utc_datetimetz_to_local (&dt_tz.datetime, &dt_tz.tz_id, &dt_local);
 	if (err != NO_ERROR)
@@ -3649,7 +3649,7 @@ qdata_subtract_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE 
       }
 
     case DB_TYPE_DATE:
-      date = DB_GET_DATE (dbval_p);
+      date = db_get_date (dbval_p);
 
       u1 = (unsigned int) i;
       u2 = (unsigned int) *date;
@@ -3662,7 +3662,7 @@ qdata_subtract_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE 
 	}
 
       db_date_decode (&utmp, &month, &day, &year);
-      DB_MAKE_DATE (result_p, month, day, year);
+      db_make_date (result_p, month, day, year);
       break;
 
     default:
@@ -3685,25 +3685,25 @@ qdata_subtract_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_
   int day, month, year;
   int err = NO_ERROR;
 
-  bi = DB_GET_BIGINT (bigint_val_p);
+  bi = db_get_bigint (bigint_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_subtract_bigint (bi, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_subtract_bigint (bi, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_subtract_bigint (bi, DB_GET_INT (dbval_p), result_p);
+      return qdata_subtract_bigint (bi, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_subtract_bigint (bi, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_subtract_bigint (bi, db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_subtract_float ((float) bi, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_subtract_float ((float) bi, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_subtract_double ((double) bi, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_subtract_double ((double) bi, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       qdata_coerce_dbval_to_numeric (bigint_val_p, &dbval_tmp);
@@ -3716,8 +3716,8 @@ qdata_subtract_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_
       break;
 
     case DB_TYPE_MONETARY:
-      return qdata_subtract_monetary ((double) bi, (DB_GET_MONETARY (dbval_p))->amount,
-				      (DB_GET_MONETARY (dbval_p))->type, result_p);
+      return qdata_subtract_monetary ((double) bi, (db_get_monetary (dbval_p))->amount,
+				      (db_get_monetary (dbval_p))->type, result_p);
 
     case DB_TYPE_TIME:
       if (bi < 0)
@@ -3733,35 +3733,35 @@ qdata_subtract_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_
 	{
 	  DB_TIMETZ *timetz_p;
 
-	  timetz_p = DB_GET_TIMETZ (dbval_p);
+	  timetz_p = db_get_timetz (dbval_p);
 	  timeval = &timetz_p->time;
 	}
       else
 	{
-	  timeval = DB_GET_TIME (dbval_p);
+	  timeval = db_get_time (dbval_p);
 	}
       err = qdata_subtract_time ((DB_TIME) bi, (DB_TIME) (*timeval % SECONDS_OF_ONE_DAY), result_p);
       if (err == NO_ERROR && type == DB_TYPE_TIMELTZ)
 	{
-	  DB_MAKE_TIMELTZ (result_p, DB_GET_TIME (result_p));
+	  db_make_timeltz (result_p, db_get_time (result_p));
 	}
       else if (err == NO_ERROR && type == DB_TYPE_TIMETZ)
 	{
 	  DB_TIMETZ time_tz, time_tz_fixed;
 
-	  time_tz = *DB_GET_TIMETZ (dbval_p);
-	  time_tz.time = *DB_GET_TIME (result_p);
+	  time_tz = *db_get_timetz (dbval_p);
+	  time_tz.time = *db_get_time (result_p);
 	  err = tz_timetz_fix_zone (&time_tz, &time_tz_fixed);
 	  if (err != NO_ERROR)
 	    {
 	      break;
 	    }
-	  DB_MAKE_TIMETZ (result_p, &time_tz_fixed);
+	  db_make_timetz (result_p, &time_tz_fixed);
 	}
       return err;
     case DB_TYPE_UTIME:
     case DB_TYPE_TIMESTAMPLTZ:
-      utime = DB_GET_UTIME (dbval_p);
+      utime = db_get_utime (dbval_p);
       err = qdata_subtract_utime ((DB_UTIME) bi, *utime, result_p);
       if (err != NO_ERROR)
 	{
@@ -3769,7 +3769,7 @@ qdata_subtract_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_
 	}
       if (err == NO_ERROR && type == DB_TYPE_TIMESTAMPLTZ)
 	{
-	  DB_MAKE_TIMESTAMPLTZ (result_p, *DB_GET_UTIME (result_p));
+	  db_make_timestampltz (result_p, *db_get_utime (result_p));
 	}
       return err;
 
@@ -3777,26 +3777,26 @@ qdata_subtract_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_
       {
 	DB_TIMESTAMPTZ ts_tz_res, ts_tz_fixed, *ts_tz_p;
 
-	ts_tz_p = DB_GET_TIMESTAMPTZ (dbval_p);
+	ts_tz_p = db_get_timestamptz (dbval_p);
 	utime = &ts_tz_p->timestamp;
 	err = qdata_subtract_utime ((DB_UTIME) bi, *utime, result_p);
 	if (err != NO_ERROR)
 	  {
 	    break;
 	  }
-	ts_tz_res.timestamp = *DB_GET_UTIME (result_p);
+	ts_tz_res.timestamp = *db_get_utime (result_p);
 	ts_tz_res.tz_id = ts_tz_p->tz_id;
 	err = tz_timestamptz_fix_zone (&ts_tz_res, &ts_tz_fixed);
 	if (err != NO_ERROR)
 	  {
 	    break;
 	  }
-	DB_MAKE_TIMESTAMPTZ (result_p, &ts_tz_fixed);
+	db_make_timestamptz (result_p, &ts_tz_fixed);
 	return err;
       }
 
     case DB_TYPE_DATE:
-      date = DB_GET_DATE (dbval_p);
+      date = db_get_date (dbval_p);
 
       u1 = (unsigned int) bi;
       u2 = (unsigned int) *date;
@@ -3809,7 +3809,7 @@ qdata_subtract_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_
 	}
 
       db_date_decode (&utmp, &month, &day, &year);
-      DB_MAKE_DATE (result_p, month, day, year);
+      db_make_date (result_p, month, day, year);
       break;
 
     default:
@@ -3825,31 +3825,31 @@ qdata_subtract_float_to_dbval (DB_VALUE * float_val_p, DB_VALUE * dbval_p, DB_VA
   float f;
   DB_TYPE type;
 
-  f = DB_GET_FLOAT (float_val_p);
+  f = db_get_float (float_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_subtract_float (f, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_subtract_float (f, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_subtract_float (f, (float) DB_GET_INT (dbval_p), result_p);
+      return qdata_subtract_float (f, (float) db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_subtract_float (f, (float) DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_subtract_float (f, (float) db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_subtract_float (f, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_subtract_float (f, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_subtract_double (f, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_subtract_double (f, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_subtract_double (f, qdata_coerce_numeric_to_double (dbval_p), result_p);
 
     case DB_TYPE_MONETARY:
-      return qdata_subtract_monetary (f, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type,
+      return qdata_subtract_monetary (f, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type,
 				      result_p);
 
     default:
@@ -3865,31 +3865,31 @@ qdata_subtract_double_to_dbval (DB_VALUE * double_val_p, DB_VALUE * dbval_p, DB_
   double d;
   DB_TYPE type;
 
-  d = DB_GET_DOUBLE (double_val_p);
+  d = db_get_double (double_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_subtract_double (d, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_subtract_double (d, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_subtract_double (d, DB_GET_INT (dbval_p), result_p);
+      return qdata_subtract_double (d, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_subtract_double (d, (double) DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_subtract_double (d, (double) db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_subtract_double (d, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_subtract_double (d, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_subtract_double (d, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_subtract_double (d, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_subtract_double (d, qdata_coerce_numeric_to_double (dbval_p), result_p);
 
     case DB_TYPE_MONETARY:
-      return qdata_subtract_monetary (d, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type,
+      return qdata_subtract_monetary (d, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type,
 				      result_p);
 
     default:
@@ -3930,16 +3930,16 @@ qdata_subtract_numeric_to_dbval (DB_VALUE * numeric_val_p, DB_VALUE * dbval_p, D
       break;
 
     case DB_TYPE_FLOAT:
-      return qdata_subtract_double (qdata_coerce_numeric_to_double (numeric_val_p), DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_subtract_double (qdata_coerce_numeric_to_double (numeric_val_p), db_get_float (dbval_p), result_p);
       break;
 
     case DB_TYPE_DOUBLE:
-      return qdata_subtract_double (qdata_coerce_numeric_to_double (numeric_val_p), DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_subtract_double (qdata_coerce_numeric_to_double (numeric_val_p), db_get_double (dbval_p), result_p);
       break;
 
     case DB_TYPE_MONETARY:
       return qdata_subtract_monetary (qdata_coerce_numeric_to_double (numeric_val_p),
-				      (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type, result_p);
+				      (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type, result_p);
       break;
 
     default:
@@ -3956,33 +3956,33 @@ qdata_subtract_monetary_to_dbval (DB_VALUE * monetary_val_p, DB_VALUE * dbval_p,
   DB_CURRENCY currency;
   DB_TYPE type;
 
-  d = (DB_GET_MONETARY (monetary_val_p))->amount;
-  currency = (DB_GET_MONETARY (monetary_val_p))->type;
+  d = (db_get_monetary (monetary_val_p))->amount;
+  currency = (db_get_monetary (monetary_val_p))->type;
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return qdata_subtract_monetary (d, DB_GET_SHORT (dbval_p), currency, result_p);
+      return qdata_subtract_monetary (d, db_get_short (dbval_p), currency, result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_subtract_monetary (d, DB_GET_INT (dbval_p), currency, result_p);
+      return qdata_subtract_monetary (d, db_get_int (dbval_p), currency, result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_subtract_monetary (d, (double) DB_GET_BIGINT (dbval_p), currency, result_p);
+      return qdata_subtract_monetary (d, (double) db_get_bigint (dbval_p), currency, result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_subtract_monetary (d, DB_GET_FLOAT (dbval_p), currency, result_p);
+      return qdata_subtract_monetary (d, db_get_float (dbval_p), currency, result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_subtract_monetary (d, DB_GET_DOUBLE (dbval_p), currency, result_p);
+      return qdata_subtract_monetary (d, db_get_double (dbval_p), currency, result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_subtract_monetary (d, qdata_coerce_numeric_to_double (dbval_p), currency, result_p);
 
     case DB_TYPE_MONETARY:
       /* Note: we probably should return an error if the two monetaries have different monetary types. */
-      return qdata_subtract_monetary (d, (DB_GET_MONETARY (dbval_p))->amount, currency, result_p);
+      return qdata_subtract_monetary (d, (db_get_monetary (dbval_p))->amount, currency, result_p);
 
     default:
       break;
@@ -4012,7 +4012,7 @@ qdata_subtract_sequence_to_dbval (DB_VALUE * seq_val_p, DB_VALUE * dbval_p, DB_V
       return ER_FAILED;
     }
 
-  if (set_difference (DB_GET_SET (seq_val_p), DB_GET_SET (dbval_p), &set_tmp, domain_p) < 0)
+  if (set_difference (db_get_set (seq_val_p), db_get_set (dbval_p), &set_tmp, domain_p) < 0)
     {
       return ER_FAILED;
     }
@@ -4029,13 +4029,13 @@ qdata_subtract_time_to_dbval (DB_VALUE * time_val_p, DB_VALUE * dbval_p, DB_VALU
   int subval;
   int err = NO_ERROR;
 
-  timeval = DB_GET_TIME (time_val_p);
+  timeval = db_get_time (time_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
-      subval = (int) DB_GET_SHORT (dbval_p);
+      subval = (int) db_get_short (dbval_p);
       if (subval < 0)
 	{
 	  return qdata_add_bigint_to_time (time_val_p, (DB_BIGINT) (-subval), result_p);
@@ -4043,7 +4043,7 @@ qdata_subtract_time_to_dbval (DB_VALUE * time_val_p, DB_VALUE * dbval_p, DB_VALU
       return qdata_subtract_time ((DB_TIME) (*timeval % SECONDS_OF_ONE_DAY), (DB_TIME) subval, result_p);
 
     case DB_TYPE_INTEGER:
-      subval = (int) (DB_GET_INT (dbval_p) % SECONDS_OF_ONE_DAY);
+      subval = (int) (db_get_int (dbval_p) % SECONDS_OF_ONE_DAY);
       if (subval < 0)
 	{
 	  return qdata_add_bigint_to_time (time_val_p, (DB_BIGINT) (-subval), result_p);
@@ -4051,7 +4051,7 @@ qdata_subtract_time_to_dbval (DB_VALUE * time_val_p, DB_VALUE * dbval_p, DB_VALU
       return qdata_subtract_time ((DB_TIME) (*timeval % SECONDS_OF_ONE_DAY), (DB_TIME) subval, result_p);
 
     case DB_TYPE_BIGINT:
-      subval = (int) (DB_GET_BIGINT (dbval_p) % SECONDS_OF_ONE_DAY);
+      subval = (int) (db_get_bigint (dbval_p) % SECONDS_OF_ONE_DAY);
       if (subval < 0)
 	{
 	  return qdata_add_bigint_to_time (time_val_p, (DB_BIGINT) (-subval), result_p);
@@ -4059,8 +4059,8 @@ qdata_subtract_time_to_dbval (DB_VALUE * time_val_p, DB_VALUE * dbval_p, DB_VALU
       return qdata_subtract_time ((DB_TIME) (*timeval % SECONDS_OF_ONE_DAY), (DB_TIME) subval, result_p);
 
     case DB_TYPE_TIME:
-      timeval1 = DB_GET_TIME (dbval_p);
-      DB_MAKE_INT (result_p, ((int) *timeval - (int) *timeval1));
+      timeval1 = db_get_time (dbval_p);
+      db_make_int (result_p, ((int) *timeval - (int) *timeval1));
       break;
 
     case DB_TYPE_TIMELTZ:
@@ -4070,7 +4070,7 @@ qdata_subtract_time_to_dbval (DB_VALUE * time_val_p, DB_VALUE * dbval_p, DB_VALU
 	  break;
 	}
       assert (DB_VALUE_TYPE (result_p) == DB_TYPE_INTEGER);
-      DB_MAKE_INT (result_p, -(DB_GET_INTEGER (result_p)));
+      db_make_int (result_p, -(db_get_int (result_p)));
       break;
     case DB_TYPE_TIMETZ:
       err = qdata_subtract_timetz_to_dbval (dbval_p, time_val_p, result_p);
@@ -4079,7 +4079,7 @@ qdata_subtract_time_to_dbval (DB_VALUE * time_val_p, DB_VALUE * dbval_p, DB_VALU
 	  break;
 	}
       assert (DB_VALUE_TYPE (result_p) == DB_TYPE_INTEGER);
-      DB_MAKE_INT (result_p, -(DB_GET_INTEGER (result_p)));
+      db_make_int (result_p, -(db_get_int (result_p)));
       break;
 
     default:
@@ -4096,7 +4096,7 @@ qdata_subtract_timetz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB_
   DB_TYPE type;
   DB_TIMETZ *time_tz_p;
 
-  time_tz_p = DB_GET_TIMETZ (timetz_val_p);
+  time_tz_p = db_get_timetz (timetz_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
@@ -4108,14 +4108,14 @@ qdata_subtract_timetz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB_
 	DB_VALUE time_val, time_val_res;
 	DB_TIMETZ time_tz_res, time_tz_fixed;
 
-	DB_MAKE_ENCODED_TIME (&time_val, &time_tz_p->time);
+	db_value_put_encoded_time (&time_val, &time_tz_p->time);
 
 	err = qdata_subtract_time_to_dbval (&time_val, dbval_p, &time_val_res);
 	if (err != NO_ERROR)
 	  {
 	    break;
 	  }
-	time_tz_res.time = *DB_GET_TIME (&time_val_res);
+	time_tz_res.time = *db_get_time (&time_val_res);
 	time_tz_res.tz_id = time_tz_p->tz_id;
 
 	err = tz_timetz_fix_zone (&time_tz_res, &time_tz_fixed);
@@ -4124,7 +4124,7 @@ qdata_subtract_timetz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB_
 	    break;
 	  }
 
-	DB_MAKE_TIMETZ (result_p, &time_tz_fixed);
+	db_make_timetz (result_p, &time_tz_fixed);
 	break;
       }
 
@@ -4133,7 +4133,7 @@ qdata_subtract_timetz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB_
 	DB_TIME *time_2_p;
 	DB_TIMETZ timetz_2;
 
-	time_2_p = DB_GET_TIME (dbval_p);
+	time_2_p = db_get_time (dbval_p);
 
 	err = tz_create_timetz_from_ses (time_2_p, &timetz_2);
 	if (err != NO_ERROR)
@@ -4141,7 +4141,7 @@ qdata_subtract_timetz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB_
 	    break;
 	  }
 
-	DB_MAKE_INT (result_p, ((int) time_tz_p->time - (int) timetz_2.time));
+	db_make_int (result_p, ((int) time_tz_p->time - (int) timetz_2.time));
 	break;
       }
 
@@ -4149,8 +4149,8 @@ qdata_subtract_timetz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB_
       {
 	DB_TIME *time_2_p;
 
-	time_2_p = DB_GET_TIME (dbval_p);
-	DB_MAKE_INT (result_p, ((int) time_tz_p->time - (int) *time_2_p));
+	time_2_p = db_get_time (dbval_p);
+	db_make_int (result_p, ((int) time_tz_p->time - (int) *time_2_p));
 	break;
       }
     case DB_TYPE_TIMETZ:
@@ -4158,11 +4158,11 @@ qdata_subtract_timetz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB_
 	DB_TIMETZ *time_tz_2_p;
 	int day1, day2;
 
-	time_tz_2_p = DB_GET_TIMETZ (dbval_p);
+	time_tz_2_p = db_get_timetz (dbval_p);
 	day1 = get_day_from_timetz (time_tz_p);
 	day2 = get_day_from_timetz (time_tz_2_p);
 
-	DB_MAKE_INT (result_p,
+	db_make_int (result_p,
 		     ((int) time_tz_p->time + day1 * SECONDS_OF_ONE_DAY - (int) time_tz_2_p->time -
 		      day2 * SECONDS_OF_ONE_DAY));
 	break;
@@ -4182,7 +4182,7 @@ qdata_subtract_timeltz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB
   DB_TYPE type;
   DB_TIME *time_p;
 
-  time_p = DB_GET_TIME (timetz_val_p);
+  time_p = db_get_time (timetz_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
@@ -4194,13 +4194,13 @@ qdata_subtract_timeltz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB
 	DB_VALUE time_val, time_val_res;
 
 	/* create a simple TIME value and perform the operation with it */
-	DB_MAKE_ENCODED_TIME (&time_val, time_p);
+	db_value_put_encoded_time (&time_val, time_p);
 	err = qdata_subtract_time_to_dbval (&time_val, dbval_p, &time_val_res);
 	if (err != NO_ERROR)
 	  {
 	    break;
 	  }
-	DB_MAKE_TIMELTZ (result_p, DB_GET_TIME (&time_val_res));
+	db_make_timeltz (result_p, db_get_time (&time_val_res));
 	break;
       }
 
@@ -4218,7 +4218,7 @@ qdata_subtract_timeltz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB
 	  {
 	    break;
 	  }
-	DB_MAKE_TIMETZ (&timetz_val, &timetz);
+	db_make_timetz (&timetz_val, &timetz);
 
 	err = qdata_subtract_timetz_to_dbval (&timetz_val, dbval_p, result_p);
 	break;
@@ -4228,7 +4228,7 @@ qdata_subtract_timeltz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB
 	TZ_ID ses_tz_id1, ses_tz_id2;
 	DB_TIME *t2_utc, t1_local, t2_local;
 
-	t2_utc = DB_GET_TIME (dbval_p);
+	t2_utc = db_get_time (dbval_p);
 	err = tz_create_session_tzid_for_time (time_p, true, &ses_tz_id1);
 	if (err != NO_ERROR)
 	  {
@@ -4253,7 +4253,7 @@ qdata_subtract_timeltz_to_dbval (DB_VALUE * timetz_val_p, DB_VALUE * dbval_p, DB
 	    break;
 	  }
 
-	DB_MAKE_INT (result_p, t1_local - t2_local);
+	db_make_int (result_p, t1_local - t2_local);
 	break;
       }
 
@@ -4278,14 +4278,14 @@ qdata_subtract_utime_to_dbval (DB_VALUE * utime_val_p, DB_VALUE * dbval_p, DB_VA
   int i2;
   DB_BIGINT bi2;
 
-  utime = DB_GET_UTIME (utime_val_p);
+  utime = db_get_utime (utime_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
       u1 = (unsigned int) *utime;
-      s2 = DB_GET_SHORT (dbval_p);
+      s2 = db_get_short (dbval_p);
       if (s2 < 0)
 	{
 	  /* We're really adding.  */
@@ -4296,7 +4296,7 @@ qdata_subtract_utime_to_dbval (DB_VALUE * utime_val_p, DB_VALUE * dbval_p, DB_VA
 
     case DB_TYPE_INTEGER:
       u1 = (unsigned int) *utime;
-      i2 = DB_GET_INT (dbval_p);
+      i2 = db_get_int (dbval_p);
       if (i2 < 0)
 	{
 	  /* We're really adding.  */
@@ -4307,7 +4307,7 @@ qdata_subtract_utime_to_dbval (DB_VALUE * utime_val_p, DB_VALUE * dbval_p, DB_VA
 
     case DB_TYPE_BIGINT:
       u1 = (unsigned int) *utime;
-      bi2 = DB_GET_BIGINT (dbval_p);
+      bi2 = db_get_bigint (dbval_p);
       if (bi2 < 0)
 	{
 	  /* We're really adding. */
@@ -4318,30 +4318,30 @@ qdata_subtract_utime_to_dbval (DB_VALUE * utime_val_p, DB_VALUE * dbval_p, DB_VA
 
     case DB_TYPE_UTIME:
     case DB_TYPE_TIMESTAMPLTZ:
-      utime1 = DB_GET_UTIME (dbval_p);
-      DB_MAKE_INT (result_p, ((int) *utime - (int) *utime1));
+      utime1 = db_get_utime (dbval_p);
+      db_make_int (result_p, ((int) *utime - (int) *utime1));
       break;
 
     case DB_TYPE_TIMESTAMPTZ:
-      ts_tz1 = DB_GET_TIMESTAMPTZ (dbval_p);
-      DB_MAKE_INT (result_p, ((int) *utime - (int) ts_tz1->timestamp));
+      ts_tz1 = db_get_timestamptz (dbval_p);
+      db_make_int (result_p, ((int) *utime - (int) ts_tz1->timestamp));
       break;
 
     case DB_TYPE_DATETIME:
-      datetime = DB_GET_DATETIME (dbval_p);
+      datetime = db_get_datetime (dbval_p);
 
       (void) db_timestamp_decode_ses (utime, &tmp_datetime.date, &tmp_datetime.time);
 
       return qdata_subtract_datetime (&tmp_datetime, datetime, result_p);
 
     case DB_TYPE_DATETIMELTZ:
-      datetime = DB_GET_DATETIME (dbval_p);
+      datetime = db_get_datetime (dbval_p);
       (void) db_timestamp_decode_utc (utime, &tmp_datetime.date, &tmp_datetime.time);
 
       return qdata_subtract_datetime (&tmp_datetime, datetime, result_p);
 
     case DB_TYPE_DATETIMETZ:
-      datetime_tz_1 = *DB_GET_DATETIMETZ (dbval_p);
+      datetime_tz_1 = *db_get_datetimetz (dbval_p);
       (void) db_timestamp_decode_utc (utime, &tmp_datetime.date, &tmp_datetime.time);
 
       return qdata_subtract_datetime (&tmp_datetime, &datetime_tz_1.datetime, result_p);
@@ -4362,7 +4362,7 @@ qdata_subtract_timestampltz_to_dbval (DB_VALUE * ts_ltz_val_p, DB_VALUE * dbval_
   DB_VALUE utime_val, tmp_val_res;
   int err = NO_ERROR;
 
-  utime_p = DB_GET_UTIME (ts_ltz_val_p);
+  utime_p = db_get_utime (ts_ltz_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
@@ -4377,7 +4377,7 @@ qdata_subtract_timestampltz_to_dbval (DB_VALUE * ts_ltz_val_p, DB_VALUE * dbval_
     case DB_TYPE_DATETIMELTZ:
     case DB_TYPE_DATETIMETZ:
       /* perform operation as simple UTIME */
-      DB_MAKE_UTIME (&utime_val, *utime_p);
+      db_make_timestamp (&utime_val, *utime_p);
       err =
 	qdata_subtract_utime_to_dbval (&utime_val, dbval_p, &tmp_val_res, tp_domain_resolve_default (DB_TYPE_UTIME));
       if (err != NO_ERROR)
@@ -4387,7 +4387,7 @@ qdata_subtract_timestampltz_to_dbval (DB_VALUE * ts_ltz_val_p, DB_VALUE * dbval_
 
       if (DB_VALUE_TYPE (&tmp_val_res) == DB_TYPE_UTIME)
 	{
-	  DB_MAKE_TIMESTAMPLTZ (result_p, *DB_GET_UTIME (&tmp_val_res));
+	  db_make_timestampltz (result_p, *db_get_utime (&tmp_val_res));
 	}
       else
 	{
@@ -4421,7 +4421,7 @@ qdata_subtract_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p,
   DB_BIGINT bi2;
   DB_VALUE tmp_val_res;
 
-  ts_tz1_p = DB_GET_TIMESTAMPTZ (ts_tz_val_p);
+  ts_tz1_p = db_get_timestamptz (ts_tz_val_p);
   utime1 = &ts_tz1_p->timestamp;
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
@@ -4429,7 +4429,7 @@ qdata_subtract_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p,
     {
     case DB_TYPE_SHORT:
       u1 = (unsigned int) *utime1;
-      s2 = DB_GET_SHORT (dbval_p);
+      s2 = db_get_short (dbval_p);
       if (s2 < 0)
 	{
 	  /* We're really adding.  */
@@ -4441,7 +4441,7 @@ qdata_subtract_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p,
 
     case DB_TYPE_INTEGER:
       u1 = (unsigned int) *utime1;
-      i2 = DB_GET_INT (dbval_p);
+      i2 = db_get_int (dbval_p);
       if (i2 < 0)
 	{
 	  /* We're really adding.  */
@@ -4453,7 +4453,7 @@ qdata_subtract_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p,
 
     case DB_TYPE_BIGINT:
       u1 = (unsigned int) *utime1;
-      bi2 = DB_GET_BIGINT (dbval_p);
+      bi2 = db_get_bigint (dbval_p);
       if (bi2 < 0)
 	{
 	  /* We're really adding. */
@@ -4465,17 +4465,17 @@ qdata_subtract_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p,
 
     case DB_TYPE_UTIME:
     case DB_TYPE_TIMESTAMPLTZ:
-      utime2 = DB_GET_UTIME (dbval_p);
-      DB_MAKE_INT (result_p, ((int) *utime1 - (int) *utime2));
+      utime2 = db_get_utime (dbval_p);
+      db_make_int (result_p, ((int) *utime1 - (int) *utime2));
       return err;
 
     case DB_TYPE_TIMESTAMPTZ:
-      ts_tz2_p = DB_GET_TIMESTAMPTZ (dbval_p);
-      DB_MAKE_INT (result_p, ((int) *utime1 - (int) ts_tz2_p->timestamp));
+      ts_tz2_p = db_get_timestamptz (dbval_p);
+      db_make_int (result_p, ((int) *utime1 - (int) ts_tz2_p->timestamp));
       return err;
 
     case DB_TYPE_DATETIME:
-      datetime = DB_GET_DATETIME (dbval_p);
+      datetime = db_get_datetime (dbval_p);
 
       err = db_timestamp_decode_w_tz_id (utime1, &ts_tz1_p->tz_id, &date, &time);
       if (err != NO_ERROR)
@@ -4489,7 +4489,7 @@ qdata_subtract_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p,
       return qdata_subtract_datetime (&tmp_datetime, datetime, result_p);
 
     case DB_TYPE_DATETIMELTZ:
-      datetime = DB_GET_DATETIME (dbval_p);
+      datetime = db_get_datetime (dbval_p);
       db_timestamp_decode_utc (utime1, &date, &time);
 
       tmp_datetime.date = date;
@@ -4498,7 +4498,7 @@ qdata_subtract_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p,
       return qdata_subtract_datetime (&tmp_datetime, datetime, result_p);
 
     case DB_TYPE_DATETIMETZ:
-      datetime_tz_1 = *DB_GET_DATETIMETZ (dbval_p);
+      datetime_tz_1 = *db_get_datetimetz (dbval_p);
       db_timestamp_decode_utc (utime1, &date, &time);
 
       if (err != NO_ERROR)
@@ -4519,7 +4519,7 @@ qdata_subtract_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p,
     {
       assert (DB_VALUE_TYPE (&tmp_val_res) == DB_TYPE_UTIME);
       /* create TIMESTAMPTZ from result UTIME by adjusting TZ_ID */
-      ts_tz_res.timestamp = *DB_GET_UTIME (&tmp_val_res);
+      ts_tz_res.timestamp = *db_get_utime (&tmp_val_res);
       ts_tz_res.tz_id = ts_tz1_p->tz_id;
       err = tz_timestamptz_fix_zone (&ts_tz_res, &ts_tz_res_fixed);
       if (err != NO_ERROR)
@@ -4527,7 +4527,7 @@ qdata_subtract_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p,
 	  return err;
 	}
 
-      DB_MAKE_TIMESTAMPTZ (result_p, &ts_tz_res_fixed);
+      db_make_timestamptz (result_p, &ts_tz_res_fixed);
     }
   return err;
 }
@@ -4539,7 +4539,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
   DB_TYPE type;
   DB_DATETIME *datetime1_p;
 
-  datetime1_p = DB_GET_DATETIME (datetime_val_p);
+  datetime1_p = db_get_datetime (datetime_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
@@ -4547,7 +4547,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
     case DB_TYPE_SHORT:
       {
 	short s2;
-	s2 = DB_GET_SHORT (dbval_p);
+	s2 = db_get_short (dbval_p);
 	if (s2 < 0)
 	  {
 	    /* We're really adding.  */
@@ -4560,7 +4560,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
     case DB_TYPE_INTEGER:
       {
 	int i2;
-	i2 = DB_GET_INT (dbval_p);
+	i2 = db_get_int (dbval_p);
 	if (i2 < 0)
 	  {
 	    /* We're really adding.  */
@@ -4574,7 +4574,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
       {
 	DB_BIGINT bi2;
 
-	bi2 = DB_GET_BIGINT (dbval_p);
+	bi2 = db_get_bigint (dbval_p);
 	if (bi2 < 0)
 	  {
 	    /* We're really adding.  */
@@ -4589,7 +4589,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
 	DB_BIGINT u1, u2;
 	DB_DATETIME datetime2;
 
-	(void) db_timestamp_decode_ses (DB_GET_UTIME (dbval_p), &datetime2.date, &datetime2.time);
+	(void) db_timestamp_decode_ses (db_get_utime (dbval_p), &datetime2.date, &datetime2.time);
 
 	u1 = ((DB_BIGINT) datetime1_p->date) * MILLISECONDS_OF_ONE_DAY + datetime1_p->time;
 	u2 = ((DB_BIGINT) datetime2.date) * MILLISECONDS_OF_ONE_DAY + datetime2.time;
@@ -4602,7 +4602,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
 	DB_BIGINT u1, u2;
 	DB_DATETIME datetime2;
 
-	(void) db_timestamp_decode_ses (DB_GET_UTIME (dbval_p), &datetime2.date, &datetime2.time);
+	(void) db_timestamp_decode_ses (db_get_utime (dbval_p), &datetime2.date, &datetime2.time);
 
 	u1 = ((DB_BIGINT) datetime1_p->date) * MILLISECONDS_OF_ONE_DAY + datetime1_p->time;
 	u2 = ((DB_BIGINT) datetime2.date) * MILLISECONDS_OF_ONE_DAY + datetime2.time;
@@ -4616,7 +4616,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
 	DB_DATETIME datetime2;
 	DB_TIMESTAMPTZ ts_tz2;
 
-	ts_tz2 = *DB_GET_TIMESTAMPTZ (dbval_p);
+	ts_tz2 = *db_get_timestamptz (dbval_p);
 
 	(void) db_timestamp_decode_ses (&ts_tz2.timestamp, &datetime2.date, &datetime2.time);
 
@@ -4631,7 +4631,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
 	DB_BIGINT u1, u2;
 	DB_DATETIME *datetime2_p;
 
-	datetime2_p = DB_GET_DATETIME (dbval_p);
+	datetime2_p = db_get_datetime (dbval_p);
 
 	u1 = ((DB_BIGINT) datetime1_p->date) * MILLISECONDS_OF_ONE_DAY + datetime1_p->time;
 	u2 = ((DB_BIGINT) datetime2_p->date) * MILLISECONDS_OF_ONE_DAY + datetime2_p->time;
@@ -4652,7 +4652,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
 	    return err;
 	  }
 
-	dt_utc2_p = DB_GET_DATETIME (dbval_p);
+	dt_utc2_p = db_get_datetime (dbval_p);
 
 	u1 = ((DB_BIGINT) dt_tz1.datetime.date) * MILLISECONDS_OF_ONE_DAY + dt_tz1.datetime.time;
 	u2 = ((DB_BIGINT) dt_utc2_p->date) * MILLISECONDS_OF_ONE_DAY + dt_utc2_p->time;
@@ -4667,7 +4667,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
 	DB_DATETIME datetime2;
 	int err;
 
-	datetimetz2_p = DB_GET_DATETIMETZ (dbval_p);
+	datetimetz2_p = db_get_datetimetz (dbval_p);
 	err = tz_utc_datetimetz_to_local (&datetimetz2_p->datetime, &datetimetz2_p->tz_id, &datetime2);
 
 	if (err != NO_ERROR)
@@ -4686,7 +4686,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
 	DB_BIGINT u1, u2;
 
 	u1 = ((DB_BIGINT) datetime1_p->date) * MILLISECONDS_OF_ONE_DAY + datetime1_p->time;
-	u2 = ((DB_BIGINT) * DB_GET_DATE (dbval_p)) * MILLISECONDS_OF_ONE_DAY;
+	u2 = ((DB_BIGINT) * db_get_date (dbval_p)) * MILLISECONDS_OF_ONE_DAY;
 
 	return db_make_bigint (result_p, u1 - u2);
       }
@@ -4707,7 +4707,7 @@ qdata_subtract_datetimetz_to_dbval (DB_VALUE * dt_tz_val_p, DB_VALUE * dbval_p, 
   DB_DATETIMETZ *dt_tz1_p;
   DB_DATETIME *datetime1_p;
 
-  dt_tz1_p = DB_GET_DATETIMETZ (dt_tz_val_p);
+  dt_tz1_p = db_get_datetimetz (dt_tz_val_p);
   datetime1_p = &(dt_tz1_p->datetime);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
@@ -4720,7 +4720,7 @@ qdata_subtract_datetimetz_to_dbval (DB_VALUE * dt_tz_val_p, DB_VALUE * dbval_p, 
 	DB_VALUE dt_val, dt_val_res;
 	DB_DATETIMETZ dt_tz, dt_tz_fixed;
 
-	DB_MAKE_DATETIME (&dt_val, datetime1_p);
+	db_make_datetime (&dt_val, datetime1_p);
 
 	err =
 	  qdata_subtract_datetime_to_dbval (&dt_val, dbval_p, &dt_val_res,
@@ -4730,7 +4730,7 @@ qdata_subtract_datetimetz_to_dbval (DB_VALUE * dt_tz_val_p, DB_VALUE * dbval_p, 
 	    break;
 	  }
 
-	dt_tz.datetime = *DB_GET_DATETIME (&dt_val_res);
+	dt_tz.datetime = *db_get_datetime (&dt_val_res);
 	dt_tz.tz_id = dt_tz1_p->tz_id;
 
 	err = tz_datetimetz_fix_zone (&dt_tz, &dt_tz_fixed);
@@ -4739,7 +4739,7 @@ qdata_subtract_datetimetz_to_dbval (DB_VALUE * dt_tz_val_p, DB_VALUE * dbval_p, 
 	    break;
 	  }
 
-	DB_MAKE_DATETIMETZ (result_p, &dt_tz_fixed);
+	db_make_datetimetz (result_p, &dt_tz_fixed);
 	break;
       }
 
@@ -4756,12 +4756,12 @@ qdata_subtract_datetimetz_to_dbval (DB_VALUE * dt_tz_val_p, DB_VALUE * dbval_p, 
 	  {
 	    DB_TIMESTAMPTZ *ts_tz2_p;
 
-	    ts_tz2_p = DB_GET_TIMESTAMPTZ (dbval_p);
+	    ts_tz2_p = db_get_timestamptz (dbval_p);
 	    utime2_p = &(ts_tz2_p->timestamp);
 	  }
 	else
 	  {
-	    utime2_p = DB_GET_UTIME (dbval_p);
+	    utime2_p = db_get_utime (dbval_p);
 	  }
 	(void) db_timestamp_decode_utc (utime2_p, &datetime2.date, &datetime2.time);
 
@@ -4778,7 +4778,7 @@ qdata_subtract_datetimetz_to_dbval (DB_VALUE * dt_tz_val_p, DB_VALUE * dbval_p, 
 	DB_DATETIME datetime1;
 
 	/* from DT with TZ to local */
-	datetime2_p = DB_GET_DATETIME (dbval_p);
+	datetime2_p = db_get_datetime (dbval_p);
 
 	err = tz_utc_datetimetz_to_local (&dt_tz1_p->datetime, &dt_tz1_p->tz_id, &datetime1);
 	if (err != NO_ERROR)
@@ -4802,12 +4802,12 @@ qdata_subtract_datetimetz_to_dbval (DB_VALUE * dt_tz_val_p, DB_VALUE * dbval_p, 
 	/* both datetimes are in UTC, no need to consider timezones */
 	if (type == DB_TYPE_DATETIMETZ)
 	  {
-	    dt_tz2_p = DB_GET_DATETIMETZ (dbval_p);
+	    dt_tz2_p = db_get_datetimetz (dbval_p);
 	    datetime2_p = &(dt_tz2_p->datetime);
 	  }
 	else
 	  {
-	    datetime2_p = DB_GET_DATETIME (dbval_p);
+	    datetime2_p = db_get_datetime (dbval_p);
 	  }
 
 	u1 = ((DB_BIGINT) datetime1_p->date) * MILLISECONDS_OF_ONE_DAY + datetime1_p->time;
@@ -4823,7 +4823,7 @@ qdata_subtract_datetimetz_to_dbval (DB_VALUE * dt_tz_val_p, DB_VALUE * dbval_p, 
 	DB_DATETIME datetime1;
 
 	/* from DT with TZ to local */
-	datetime2_p = DB_GET_DATETIME (dbval_p);
+	datetime2_p = db_get_datetime (dbval_p);
 
 	err = tz_utc_datetimetz_to_local (&dt_tz1_p->datetime, &dt_tz1_p->tz_id, &datetime1);
 	if (err != NO_ERROR)
@@ -4832,7 +4832,7 @@ qdata_subtract_datetimetz_to_dbval (DB_VALUE * dt_tz_val_p, DB_VALUE * dbval_p, 
 	  }
 
 	u1 = ((DB_BIGINT) datetime1.date) * MILLISECONDS_OF_ONE_DAY + datetime1.time;
-	u2 = ((DB_BIGINT) * DB_GET_DATE (dbval_p)) * MILLISECONDS_OF_ONE_DAY;
+	u2 = ((DB_BIGINT) * db_get_date (dbval_p)) * MILLISECONDS_OF_ONE_DAY;
 
 	return db_make_bigint (result_p, u1 - u2);
       }
@@ -4855,14 +4855,14 @@ qdata_subtract_date_to_dbval (DB_VALUE * date_val_p, DB_VALUE * dbval_p, DB_VALU
   DB_BIGINT bi1, bi2, bitmp;
   int day, month, year;
 
-  date = DB_GET_DATE (date_val_p);
+  date = db_get_date (date_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
     {
     case DB_TYPE_SHORT:
       u1 = (unsigned int) *date;
-      s2 = DB_GET_SHORT (dbval_p);
+      s2 = db_get_short (dbval_p);
 
       if (s2 < 0)
 	{
@@ -4879,12 +4879,12 @@ qdata_subtract_date_to_dbval (DB_VALUE * date_val_p, DB_VALUE * dbval_p, DB_VALU
 	}
 
       db_date_decode (&utmp, &month, &day, &year);
-      DB_MAKE_DATE (result_p, month, day, year);
+      db_make_date (result_p, month, day, year);
       break;
 
     case DB_TYPE_BIGINT:
       bi1 = (DB_BIGINT) * date;
-      bi2 = DB_GET_BIGINT (dbval_p);
+      bi2 = db_get_bigint (dbval_p);
 
       if (bi2 < 0)
 	{
@@ -4901,12 +4901,12 @@ qdata_subtract_date_to_dbval (DB_VALUE * date_val_p, DB_VALUE * dbval_p, DB_VALU
 
       utmp = (unsigned int) bitmp;
       db_date_decode (&utmp, &month, &day, &year);
-      DB_MAKE_DATE (result_p, month, day, year);
+      db_make_date (result_p, month, day, year);
       break;
 
     case DB_TYPE_INTEGER:
       u1 = (unsigned int) *date;
-      i2 = DB_GET_INT (dbval_p);
+      i2 = db_get_int (dbval_p);
 
       if (i2 < 0)
 	{
@@ -4923,12 +4923,12 @@ qdata_subtract_date_to_dbval (DB_VALUE * date_val_p, DB_VALUE * dbval_p, DB_VALU
 	}
 
       db_date_decode (&utmp, &month, &day, &year);
-      DB_MAKE_DATE (result_p, month, day, year);
+      db_make_date (result_p, month, day, year);
       break;
 
     case DB_TYPE_DATE:
-      date1 = DB_GET_DATE (dbval_p);
-      DB_MAKE_INT (result_p, (int) *date - (int) *date1);
+      date1 = db_get_date (dbval_p);
+      db_make_int (result_p, (int) *date - (int) *date1);
       break;
 
     default:
@@ -4972,8 +4972,8 @@ qdata_subtract_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * resul
       return NO_ERROR;
     }
 
-  DB_MAKE_NULL (&cast_value1);
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value1);
+  db_make_null (&cast_value2);
 
   type1 = DB_VALUE_DOMAIN_TYPE (dbval1_p);
   type2 = DB_VALUE_DOMAIN_TYPE (dbval2_p);
@@ -5103,7 +5103,7 @@ qdata_subtract_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * resul
   if (qdata_is_zero_value_date (dbval1_p) || qdata_is_zero_value_date (dbval2_p))
     {
       /* subtract operation with zero date returns null */
-      DB_MAKE_NULL (result_p);
+      db_make_null (result_p);
       if (!prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ATTEMPT_TO_USE_ZERODATE, 0);
@@ -5200,14 +5200,14 @@ qdata_subtract_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * resul
 	DB_VALUE tmp_val;
 	DB_DATETIMETZ dt_tz1;
 
-	dt_tz1.datetime = *DB_GET_DATETIME (dbval1_p);
+	dt_tz1.datetime = *db_get_datetime (dbval1_p);
 	error = tz_create_session_tzid_for_datetime (&dt_tz1.datetime, true, &dt_tz1.tz_id);
 	if (error != NO_ERROR)
 	  {
 	    break;
 	  }
 
-	DB_MAKE_DATETIMETZ (&tmp_val, &dt_tz1);
+	db_make_datetimetz (&tmp_val, &dt_tz1);
 
 	error = qdata_subtract_datetimetz_to_dbval (&tmp_val, dbval2_p, result_p, domain_p);
       }
@@ -5244,7 +5244,7 @@ qdata_multiply_short (DB_VALUE * short_val_p, short s2, DB_VALUE * result_p)
   /* NOTE that we need volatile to prevent optimizer from generating division expression as multiplication */
   volatile short s1, stmp;
 
-  s1 = DB_GET_SHORT (short_val_p);
+  s1 = db_get_short (short_val_p);
   stmp = s1 * s2;
 
   if (OR_CHECK_MULT_OVERFLOW (s1, s2, stmp))
@@ -5253,7 +5253,7 @@ qdata_multiply_short (DB_VALUE * short_val_p, short s2, DB_VALUE * result_p)
       return ER_FAILED;
     }
 
-  DB_MAKE_SHORT (result_p, stmp);
+  db_make_short (result_p, stmp);
 
   return NO_ERROR;
 }
@@ -5264,7 +5264,7 @@ qdata_multiply_int (DB_VALUE * int_val_p, int i2, DB_VALUE * result_p)
   /* NOTE that we need volatile to prevent optimizer from generating division expression as multiplication */
   volatile int i1, itmp;
 
-  i1 = DB_GET_INT (int_val_p);
+  i1 = db_get_int (int_val_p);
   itmp = i1 * i2;
 
   if (OR_CHECK_MULT_OVERFLOW (i1, i2, itmp))
@@ -5273,7 +5273,7 @@ qdata_multiply_int (DB_VALUE * int_val_p, int i2, DB_VALUE * result_p)
       return ER_FAILED;
     }
 
-  DB_MAKE_INT (result_p, itmp);
+  db_make_int (result_p, itmp);
   return NO_ERROR;
 }
 
@@ -5283,7 +5283,7 @@ qdata_multiply_bigint (DB_VALUE * bigint_val_p, DB_BIGINT bi2, DB_VALUE * result
   /* NOTE that we need volatile to prevent optimizer from generating division expression as multiplication */
   volatile DB_BIGINT bi1, bitmp;
 
-  bi1 = DB_GET_BIGINT (bigint_val_p);
+  bi1 = db_get_bigint (bigint_val_p);
   bitmp = bi1 * bi2;
 
   if (OR_CHECK_MULT_OVERFLOW (bi1, bi2, bitmp))
@@ -5292,7 +5292,7 @@ qdata_multiply_bigint (DB_VALUE * bigint_val_p, DB_BIGINT bi2, DB_VALUE * result
       return ER_FAILED;
     }
 
-  DB_MAKE_BIGINT (result_p, bitmp);
+  db_make_bigint (result_p, bitmp);
   return NO_ERROR;
 }
 
@@ -5301,7 +5301,7 @@ qdata_multiply_float (DB_VALUE * float_val_p, float f2, DB_VALUE * result_p)
 {
   float f1, ftmp;
 
-  f1 = DB_GET_FLOAT (float_val_p);
+  f1 = db_get_float (float_val_p);
   ftmp = f1 * f2;
 
   if (OR_CHECK_FLOAT_OVERFLOW (ftmp))
@@ -5310,7 +5310,7 @@ qdata_multiply_float (DB_VALUE * float_val_p, float f2, DB_VALUE * result_p)
       return ER_FAILED;
     }
 
-  DB_MAKE_FLOAT (result_p, ftmp);
+  db_make_float (result_p, ftmp);
   return NO_ERROR;
 }
 
@@ -5327,7 +5327,7 @@ qdata_multiply_double (double d1, double d2, DB_VALUE * result_p)
       return ER_FAILED;
     }
 
-  DB_MAKE_DOUBLE (result_p, dtmp);
+  db_make_double (result_p, dtmp);
   return NO_ERROR;
 }
 
@@ -5352,7 +5352,7 @@ qdata_multiply_monetary (DB_VALUE * monetary_val_p, double d, DB_VALUE * result_
 {
   double dtmp;
 
-  dtmp = (DB_GET_MONETARY (monetary_val_p))->amount * d;
+  dtmp = (db_get_monetary (monetary_val_p))->amount * d;
 
   if (OR_CHECK_DOUBLE_OVERFLOW (dtmp))
     {
@@ -5360,7 +5360,7 @@ qdata_multiply_monetary (DB_VALUE * monetary_val_p, double d, DB_VALUE * result_
       return ER_FAILED;
     }
 
-  DB_MAKE_MONETARY_TYPE_AMOUNT (result_p, (DB_GET_MONETARY (monetary_val_p))->type, dtmp);
+  db_make_monetary (result_p, (db_get_monetary (monetary_val_p))->type, dtmp);
 
   return NO_ERROR;
 }
@@ -5371,7 +5371,7 @@ qdata_multiply_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VA
   short s;
   DB_TYPE type2;
 
-  s = DB_GET_SHORT (short_val_p);
+  s = db_get_short (short_val_p);
   type2 = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type2)
@@ -5389,7 +5389,7 @@ qdata_multiply_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VA
       return qdata_multiply_float (dbval_p, s, result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_multiply_double (DB_GET_DOUBLE (dbval_p), s, result_p);
+      return qdata_multiply_double (db_get_double (dbval_p), s, result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_multiply_numeric (dbval_p, short_val_p, result_p);
@@ -5414,25 +5414,25 @@ qdata_multiply_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE 
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      return qdata_multiply_int (int_val_p, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_multiply_int (int_val_p, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_multiply_int (int_val_p, DB_GET_INT (dbval_p), result_p);
+      return qdata_multiply_int (int_val_p, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_multiply_bigint (dbval_p, DB_GET_INT (int_val_p), result_p);
+      return qdata_multiply_bigint (dbval_p, db_get_int (int_val_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_multiply_float (dbval_p, (float) DB_GET_INT (int_val_p), result_p);
+      return qdata_multiply_float (dbval_p, (float) db_get_int (int_val_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_multiply_double (DB_GET_DOUBLE (dbval_p), DB_GET_INT (int_val_p), result_p);
+      return qdata_multiply_double (db_get_double (dbval_p), db_get_int (int_val_p), result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_multiply_numeric (dbval_p, int_val_p, result_p);
 
     case DB_TYPE_MONETARY:
-      return qdata_multiply_monetary (dbval_p, DB_GET_INT (int_val_p), result_p);
+      return qdata_multiply_monetary (dbval_p, db_get_int (int_val_p), result_p);
 
     default:
       break;
@@ -5451,25 +5451,25 @@ qdata_multiply_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      return qdata_multiply_bigint (bigint_val_p, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_multiply_bigint (bigint_val_p, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_multiply_bigint (bigint_val_p, DB_GET_INT (dbval_p), result_p);
+      return qdata_multiply_bigint (bigint_val_p, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_multiply_bigint (bigint_val_p, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_multiply_bigint (bigint_val_p, db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_multiply_float (dbval_p, (float) DB_GET_BIGINT (bigint_val_p), result_p);
+      return qdata_multiply_float (dbval_p, (float) db_get_bigint (bigint_val_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_multiply_double (DB_GET_DOUBLE (dbval_p), (double) DB_GET_BIGINT (bigint_val_p), result_p);
+      return qdata_multiply_double (db_get_double (dbval_p), (double) db_get_bigint (bigint_val_p), result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_multiply_numeric (dbval_p, bigint_val_p, result_p);
 
     case DB_TYPE_MONETARY:
-      return qdata_multiply_monetary (dbval_p, (double) DB_GET_BIGINT (bigint_val_p), result_p);
+      return qdata_multiply_monetary (dbval_p, (double) db_get_bigint (bigint_val_p), result_p);
 
     default:
       break;
@@ -5488,25 +5488,25 @@ qdata_multiply_float_to_dbval (DB_VALUE * float_val_p, DB_VALUE * dbval_p, DB_VA
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      return qdata_multiply_float (float_val_p, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_multiply_float (float_val_p, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_multiply_float (float_val_p, (float) DB_GET_INT (dbval_p), result_p);
+      return qdata_multiply_float (float_val_p, (float) db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_multiply_float (float_val_p, (float) DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_multiply_float (float_val_p, (float) db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_multiply_float (float_val_p, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_multiply_float (float_val_p, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_multiply_double (DB_GET_FLOAT (float_val_p), DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_multiply_double (db_get_float (float_val_p), db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
-      return qdata_multiply_double (DB_GET_FLOAT (float_val_p), qdata_coerce_numeric_to_double (dbval_p), result_p);
+      return qdata_multiply_double (db_get_float (float_val_p), qdata_coerce_numeric_to_double (dbval_p), result_p);
 
     case DB_TYPE_MONETARY:
-      return qdata_multiply_monetary (dbval_p, DB_GET_FLOAT (float_val_p), result_p);
+      return qdata_multiply_monetary (dbval_p, db_get_float (float_val_p), result_p);
 
     default:
       break;
@@ -5521,26 +5521,26 @@ qdata_multiply_double_to_dbval (DB_VALUE * double_val_p, DB_VALUE * dbval_p, DB_
   double d;
   DB_TYPE type2;
 
-  d = DB_GET_DOUBLE (double_val_p);
+  d = db_get_double (double_val_p);
   type2 = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type2)
 
     {
     case DB_TYPE_SHORT:
-      return qdata_multiply_double (d, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_multiply_double (d, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_multiply_double (d, DB_GET_INT (dbval_p), result_p);
+      return qdata_multiply_double (d, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_multiply_double (d, (double) DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_multiply_double (d, (double) db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_multiply_double (d, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_multiply_double (d, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_multiply_double (d, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_multiply_double (d, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_multiply_double (d, qdata_coerce_numeric_to_double (dbval_p), result_p);
@@ -5578,10 +5578,10 @@ qdata_multiply_numeric_to_dbval (DB_VALUE * numeric_val_p, DB_VALUE * dbval_p, D
       break;
 
     case DB_TYPE_FLOAT:
-      return qdata_multiply_double (qdata_coerce_numeric_to_double (numeric_val_p), DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_multiply_double (qdata_coerce_numeric_to_double (numeric_val_p), db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_multiply_double (qdata_coerce_numeric_to_double (numeric_val_p), DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_multiply_double (qdata_coerce_numeric_to_double (numeric_val_p), db_get_double (dbval_p), result_p);
 
     case DB_TYPE_MONETARY:
       return qdata_multiply_monetary (dbval_p, qdata_coerce_numeric_to_double (numeric_val_p), result_p);
@@ -5603,26 +5603,26 @@ qdata_multiply_monetary_to_dbval (DB_VALUE * monetary_val_p, DB_VALUE * dbval_p,
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      return qdata_multiply_monetary (monetary_val_p, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_multiply_monetary (monetary_val_p, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_multiply_monetary (monetary_val_p, DB_GET_INT (dbval_p), result_p);
+      return qdata_multiply_monetary (monetary_val_p, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_multiply_monetary (monetary_val_p, (double) DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_multiply_monetary (monetary_val_p, (double) db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_multiply_monetary (monetary_val_p, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_multiply_monetary (monetary_val_p, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_multiply_monetary (monetary_val_p, DB_GET_DOUBLE (dbval_p), result_p);
+      return qdata_multiply_monetary (monetary_val_p, db_get_double (dbval_p), result_p);
 
     case DB_TYPE_NUMERIC:
       return qdata_multiply_monetary (monetary_val_p, qdata_coerce_numeric_to_double (dbval_p), result_p);
 
     case DB_TYPE_MONETARY:
       /* Note: we probably should return an error if the two monetaries have different montetary types. */
-      return qdata_multiply_monetary (monetary_val_p, (DB_GET_MONETARY (dbval_p))->amount, result_p);
+      return qdata_multiply_monetary (monetary_val_p, (db_get_monetary (dbval_p))->amount, result_p);
 
     default:
       break;
@@ -5647,7 +5647,7 @@ qdata_multiply_sequence_to_dbval (DB_VALUE * seq_val_p, DB_VALUE * dbval_p, DB_V
   assert (TP_IS_SET_TYPE (type2));
 #endif
 
-  if (set_intersection (DB_GET_SET (seq_val_p), DB_GET_SET (dbval_p), &set_tmp, domain_p) < 0)
+  if (set_intersection (db_get_set (seq_val_p), db_get_set (dbval_p), &set_tmp, domain_p) < 0)
     {
       return ER_FAILED;
     }
@@ -5686,8 +5686,8 @@ qdata_multiply_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * resul
   type1 = DB_VALUE_DOMAIN_TYPE (dbval1_p);
   type2 = DB_VALUE_DOMAIN_TYPE (dbval2_p);
 
-  DB_MAKE_NULL (&cast_value1);
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value1);
+  db_make_null (&cast_value2);
 
   /* number * string : cast string to DOUBLE, multiply as number * DOUBLE */
   if (TP_IS_NUMERIC_TYPE (type1) && TP_IS_CHAR_TYPE (type2))
@@ -5830,22 +5830,22 @@ qdata_is_divided_zero (DB_VALUE * dbval_p)
   switch (type)
     {
     case DB_TYPE_SHORT:
-      return DB_GET_SHORT (dbval_p) == 0;
+      return db_get_short (dbval_p) == 0;
 
     case DB_TYPE_INTEGER:
-      return DB_GET_INT (dbval_p) == 0;
+      return db_get_int (dbval_p) == 0;
 
     case DB_TYPE_BIGINT:
-      return DB_GET_BIGINT (dbval_p) == 0;
+      return db_get_bigint (dbval_p) == 0;
 
     case DB_TYPE_FLOAT:
-      return fabs ((double) DB_GET_FLOAT (dbval_p)) <= DBL_EPSILON;
+      return fabs ((double) db_get_float (dbval_p)) <= DBL_EPSILON;
 
     case DB_TYPE_DOUBLE:
-      return fabs (DB_GET_DOUBLE (dbval_p)) <= DBL_EPSILON;
+      return fabs (db_get_double (dbval_p)) <= DBL_EPSILON;
 
     case DB_TYPE_MONETARY:
-      return DB_GET_MONETARY (dbval_p)->amount <= DBL_EPSILON;
+      return db_get_monetary (dbval_p)->amount <= DBL_EPSILON;
 
     case DB_TYPE_NUMERIC:
       return numeric_db_value_is_zero (dbval_p);
@@ -5863,7 +5863,7 @@ qdata_divide_short (short s1, short s2, DB_VALUE * result_p)
   short stmp;
 
   stmp = s1 / s2;
-  DB_MAKE_SHORT (result_p, stmp);
+  db_make_short (result_p, stmp);
 
   return NO_ERROR;
 }
@@ -5874,7 +5874,7 @@ qdata_divide_int (int i1, int i2, DB_VALUE * result_p)
   int itmp;
 
   itmp = i1 / i2;
-  DB_MAKE_INT (result_p, itmp);
+  db_make_int (result_p, itmp);
 
   return NO_ERROR;
 }
@@ -5885,7 +5885,7 @@ qdata_divide_bigint (DB_BIGINT bi1, DB_BIGINT bi2, DB_VALUE * result_p)
   DB_BIGINT bitmp;
 
   bitmp = bi1 / bi2;
-  DB_MAKE_BIGINT (result_p, bitmp);
+  db_make_bigint (result_p, bitmp);
 
   return NO_ERROR;
 }
@@ -5903,7 +5903,7 @@ qdata_divide_float (float f1, float f2, DB_VALUE * result_p)
       return ER_FAILED;
     }
 
-  DB_MAKE_FLOAT (result_p, ftmp);
+  db_make_float (result_p, ftmp);
   return NO_ERROR;
 }
 
@@ -5920,7 +5920,7 @@ qdata_divide_double (double d1, double d2, DB_VALUE * result_p, bool is_check_ov
       return ER_FAILED;
     }
 
-  DB_MAKE_DOUBLE (result_p, dtmp);
+  db_make_double (result_p, dtmp);
   return NO_ERROR;
 }
 
@@ -5937,7 +5937,7 @@ qdata_divide_monetary (double d1, double d2, DB_CURRENCY currency, DB_VALUE * re
       return ER_FAILED;
     }
 
-  DB_MAKE_MONETARY_TYPE_AMOUNT (result_p, currency, dtmp);
+  db_make_monetary (result_p, currency, dtmp);
   return NO_ERROR;
 }
 
@@ -5948,25 +5948,25 @@ qdata_divide_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VALU
   DB_TYPE type2;
   DB_VALUE dbval_tmp;
 
-  s = DB_GET_SHORT (short_val_p);
+  s = db_get_short (short_val_p);
   type2 = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      return qdata_divide_short (s, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_divide_short (s, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_divide_int (s, DB_GET_INT (dbval_p), result_p);
+      return qdata_divide_int (s, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_divide_bigint (s, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_divide_bigint (s, db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_divide_float (s, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_divide_float (s, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_divide_double (s, DB_GET_DOUBLE (dbval_p), result_p, true);
+      return qdata_divide_double (s, db_get_double (dbval_p), result_p, true);
 
     case DB_TYPE_NUMERIC:
       qdata_coerce_dbval_to_numeric (short_val_p, &dbval_tmp);
@@ -5978,7 +5978,7 @@ qdata_divide_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VALU
       break;
 
     case DB_TYPE_MONETARY:
-      return qdata_divide_monetary (s, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type, result_p,
+      return qdata_divide_monetary (s, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type, result_p,
 				    true);
 
     default:
@@ -5995,25 +5995,25 @@ qdata_divide_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE * 
   DB_TYPE type2;
   DB_VALUE dbval_tmp;
 
-  i = DB_GET_INT (int_val_p);
+  i = db_get_int (int_val_p);
   type2 = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      return qdata_divide_int (i, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_divide_int (i, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_divide_int (i, DB_GET_INT (dbval_p), result_p);
+      return qdata_divide_int (i, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_divide_bigint (i, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_divide_bigint (i, db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_divide_float ((float) i, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_divide_float ((float) i, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_divide_double (i, DB_GET_DOUBLE (dbval_p), result_p, true);
+      return qdata_divide_double (i, db_get_double (dbval_p), result_p, true);
 
     case DB_TYPE_NUMERIC:
       qdata_coerce_dbval_to_numeric (int_val_p, &dbval_tmp);
@@ -6025,7 +6025,7 @@ qdata_divide_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE * 
       break;
 
     case DB_TYPE_MONETARY:
-      return qdata_divide_monetary (i, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type, result_p,
+      return qdata_divide_monetary (i, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type, result_p,
 				    true);
 
     default:
@@ -6042,25 +6042,25 @@ qdata_divide_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_VA
   DB_TYPE type2;
   DB_VALUE dbval_tmp;
 
-  bi = DB_GET_BIGINT (bigint_val_p);
+  bi = db_get_bigint (bigint_val_p);
   type2 = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      return qdata_divide_bigint (bi, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_divide_bigint (bi, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_divide_bigint (bi, DB_GET_INT (dbval_p), result_p);
+      return qdata_divide_bigint (bi, db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_divide_bigint (bi, DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_divide_bigint (bi, db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_divide_float ((float) bi, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_divide_float ((float) bi, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_divide_double ((double) bi, DB_GET_DOUBLE (dbval_p), result_p, true);
+      return qdata_divide_double ((double) bi, db_get_double (dbval_p), result_p, true);
 
     case DB_TYPE_NUMERIC:
       qdata_coerce_dbval_to_numeric (bigint_val_p, &dbval_tmp);
@@ -6072,7 +6072,7 @@ qdata_divide_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_VA
       break;
 
     case DB_TYPE_MONETARY:
-      return qdata_divide_monetary ((double) bi, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type,
+      return qdata_divide_monetary ((double) bi, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type,
 				    result_p, true);
 
     default:
@@ -6088,31 +6088,31 @@ qdata_divide_float_to_dbval (DB_VALUE * float_val_p, DB_VALUE * dbval_p, DB_VALU
   float f;
   DB_TYPE type2;
 
-  f = DB_GET_FLOAT (float_val_p);
+  f = db_get_float (float_val_p);
   type2 = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      return qdata_divide_float (f, DB_GET_SHORT (dbval_p), result_p);
+      return qdata_divide_float (f, db_get_short (dbval_p), result_p);
 
     case DB_TYPE_INTEGER:
-      return qdata_divide_float (f, (float) DB_GET_INT (dbval_p), result_p);
+      return qdata_divide_float (f, (float) db_get_int (dbval_p), result_p);
 
     case DB_TYPE_BIGINT:
-      return qdata_divide_float (f, (float) DB_GET_BIGINT (dbval_p), result_p);
+      return qdata_divide_float (f, (float) db_get_bigint (dbval_p), result_p);
 
     case DB_TYPE_FLOAT:
-      return qdata_divide_float (f, DB_GET_FLOAT (dbval_p), result_p);
+      return qdata_divide_float (f, db_get_float (dbval_p), result_p);
 
     case DB_TYPE_DOUBLE:
-      return qdata_divide_double (f, DB_GET_DOUBLE (dbval_p), result_p, true);
+      return qdata_divide_double (f, db_get_double (dbval_p), result_p, true);
 
     case DB_TYPE_NUMERIC:
       return qdata_divide_double (f, qdata_coerce_numeric_to_double (dbval_p), result_p, false);
 
     case DB_TYPE_MONETARY:
-      return qdata_divide_monetary (f, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type, result_p,
+      return qdata_divide_monetary (f, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type, result_p,
 				    true);
 
     default:
@@ -6128,31 +6128,31 @@ qdata_divide_double_to_dbval (DB_VALUE * double_val_p, DB_VALUE * dbval_p, DB_VA
   double d;
   DB_TYPE type2;
 
-  d = DB_GET_DOUBLE (double_val_p);
+  d = db_get_double (double_val_p);
   type2 = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      return qdata_divide_double (d, DB_GET_SHORT (dbval_p), result_p, false);
+      return qdata_divide_double (d, db_get_short (dbval_p), result_p, false);
 
     case DB_TYPE_INTEGER:
-      return qdata_divide_double (d, DB_GET_INT (dbval_p), result_p, false);
+      return qdata_divide_double (d, db_get_int (dbval_p), result_p, false);
 
     case DB_TYPE_BIGINT:
-      return qdata_divide_double (d, (double) DB_GET_BIGINT (dbval_p), result_p, false);
+      return qdata_divide_double (d, (double) db_get_bigint (dbval_p), result_p, false);
 
     case DB_TYPE_FLOAT:
-      return qdata_divide_double (d, DB_GET_FLOAT (dbval_p), result_p, true);
+      return qdata_divide_double (d, db_get_float (dbval_p), result_p, true);
 
     case DB_TYPE_DOUBLE:
-      return qdata_divide_double (d, DB_GET_DOUBLE (dbval_p), result_p, true);
+      return qdata_divide_double (d, db_get_double (dbval_p), result_p, true);
 
     case DB_TYPE_NUMERIC:
       return qdata_divide_double (d, qdata_coerce_numeric_to_double (dbval_p), result_p, false);
 
     case DB_TYPE_MONETARY:
-      return qdata_divide_monetary (d, (DB_GET_MONETARY (dbval_p))->amount, (DB_GET_MONETARY (dbval_p))->type, result_p,
+      return qdata_divide_monetary (d, (db_get_monetary (dbval_p))->amount, (db_get_monetary (dbval_p))->type, result_p,
 				    true);
 
     default:
@@ -6192,16 +6192,16 @@ qdata_divide_numeric_to_dbval (DB_VALUE * numeric_val_p, DB_VALUE * dbval_p, DB_
       break;
 
     case DB_TYPE_FLOAT:
-      return qdata_divide_double (qdata_coerce_numeric_to_double (numeric_val_p), DB_GET_FLOAT (dbval_p), result_p,
+      return qdata_divide_double (qdata_coerce_numeric_to_double (numeric_val_p), db_get_float (dbval_p), result_p,
 				  false);
 
     case DB_TYPE_DOUBLE:
-      return qdata_divide_double (qdata_coerce_numeric_to_double (numeric_val_p), DB_GET_DOUBLE (dbval_p), result_p,
+      return qdata_divide_double (qdata_coerce_numeric_to_double (numeric_val_p), db_get_double (dbval_p), result_p,
 				  true);
 
     case DB_TYPE_MONETARY:
-      return qdata_divide_monetary (qdata_coerce_numeric_to_double (numeric_val_p), (DB_GET_MONETARY (dbval_p))->amount,
-				    (DB_GET_MONETARY (dbval_p))->type, result_p, true);
+      return qdata_divide_monetary (qdata_coerce_numeric_to_double (numeric_val_p), (db_get_monetary (dbval_p))->amount,
+				    (db_get_monetary (dbval_p))->type, result_p, true);
 
     default:
       break;
@@ -6217,33 +6217,33 @@ qdata_divide_monetary_to_dbval (DB_VALUE * monetary_val_p, DB_VALUE * dbval_p, D
   DB_CURRENCY currency;
   DB_TYPE type2;
 
-  d = (DB_GET_MONETARY (monetary_val_p))->amount;
-  currency = (DB_GET_MONETARY (monetary_val_p))->type;
+  d = (db_get_monetary (monetary_val_p))->amount;
+  currency = (db_get_monetary (monetary_val_p))->type;
   type2 = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type2)
     {
     case DB_TYPE_SHORT:
-      return qdata_divide_monetary (d, DB_GET_SHORT (dbval_p), currency, result_p, false);
+      return qdata_divide_monetary (d, db_get_short (dbval_p), currency, result_p, false);
 
     case DB_TYPE_INTEGER:
-      return qdata_divide_monetary (d, DB_GET_INT (dbval_p), currency, result_p, false);
+      return qdata_divide_monetary (d, db_get_int (dbval_p), currency, result_p, false);
 
     case DB_TYPE_BIGINT:
-      return qdata_divide_monetary (d, (double) DB_GET_BIGINT (dbval_p), currency, result_p, false);
+      return qdata_divide_monetary (d, (double) db_get_bigint (dbval_p), currency, result_p, false);
 
     case DB_TYPE_FLOAT:
-      return qdata_divide_monetary (d, DB_GET_FLOAT (dbval_p), currency, result_p, true);
+      return qdata_divide_monetary (d, db_get_float (dbval_p), currency, result_p, true);
 
     case DB_TYPE_DOUBLE:
-      return qdata_divide_monetary (d, DB_GET_DOUBLE (dbval_p), currency, result_p, true);
+      return qdata_divide_monetary (d, db_get_double (dbval_p), currency, result_p, true);
 
     case DB_TYPE_NUMERIC:
       return qdata_divide_monetary (d, qdata_coerce_numeric_to_double (dbval_p), currency, result_p, true);
 
     case DB_TYPE_MONETARY:
       /* Note: we probably should return an error if the two monetaries have different montetary types. */
-      return qdata_divide_monetary (d, (DB_GET_MONETARY (dbval_p))->amount, currency, result_p, true);
+      return qdata_divide_monetary (d, (db_get_monetary (dbval_p))->amount, currency, result_p, true);
 
     default:
       break;
@@ -6292,8 +6292,8 @@ qdata_divide_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_
   type1 = DB_VALUE_DOMAIN_TYPE (dbval1_p);
   type2 = DB_VALUE_DOMAIN_TYPE (dbval2_p);
 
-  DB_MAKE_NULL (&cast_value1);
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value1);
+  db_make_null (&cast_value2);
 
   /* number / string : cast string to DOUBLE, divide as number / DOUBLE */
   if (TP_IS_NUMERIC_TYPE (type1) && TP_IS_CHAR_TYPE (type2))
@@ -6439,27 +6439,27 @@ qdata_unary_minus_dbval (DB_VALUE * result_p, DB_VALUE * dbval_p)
   switch (res_type)
     {
     case DB_TYPE_INTEGER:
-      itmp = DB_GET_INT (dbval_p);
+      itmp = db_get_int (dbval_p);
       if (itmp == INT_MIN)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_OVERFLOW_UMINUS, 0);
 	  return ER_QPROC_OVERFLOW_UMINUS;
 	}
-      DB_MAKE_INT (result_p, (-1) * itmp);
+      db_make_int (result_p, (-1) * itmp);
       break;
 
     case DB_TYPE_BIGINT:
-      bitmp = DB_GET_BIGINT (dbval_p);
+      bitmp = db_get_bigint (dbval_p);
       if (bitmp == DB_BIGINT_MIN)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_OVERFLOW_UMINUS, 0);
 	  return ER_QPROC_OVERFLOW_UMINUS;
 	}
-      DB_MAKE_BIGINT (result_p, (-1) * bitmp);
+      db_make_bigint (result_p, (-1) * bitmp);
       break;
 
     case DB_TYPE_FLOAT:
-      DB_MAKE_FLOAT (result_p, (-1) * DB_GET_FLOAT (dbval_p));
+      db_make_float (result_p, (-1) * db_get_float (dbval_p));
       break;
 
     case DB_TYPE_CHAR:
@@ -6480,11 +6480,11 @@ qdata_unary_minus_dbval (DB_VALUE * result_p, DB_VALUE * dbval_p)
       /* fall through */
 
     case DB_TYPE_DOUBLE:
-      DB_MAKE_DOUBLE (result_p, (-1) * DB_GET_DOUBLE (dbval_p));
+      db_make_double (result_p, (-1) * db_get_double (dbval_p));
       break;
 
     case DB_TYPE_NUMERIC:
-      DB_MAKE_NUMERIC (result_p, DB_GET_NUMERIC (dbval_p), DB_VALUE_PRECISION (dbval_p), DB_VALUE_SCALE (dbval_p));
+      db_make_numeric (result_p, db_get_numeric (dbval_p), DB_VALUE_PRECISION (dbval_p), DB_VALUE_SCALE (dbval_p));
       if (numeric_db_value_negate (result_p) != NO_ERROR)
 	{
 	  return ER_FAILED;
@@ -6492,18 +6492,18 @@ qdata_unary_minus_dbval (DB_VALUE * result_p, DB_VALUE * dbval_p)
       break;
 
     case DB_TYPE_MONETARY:
-      dtmp = (-1) * (DB_GET_MONETARY (dbval_p))->amount;
-      DB_MAKE_MONETARY_TYPE_AMOUNT (result_p, (DB_GET_MONETARY (dbval_p))->type, dtmp);
+      dtmp = (-1) * (db_get_monetary (dbval_p))->amount;
+      db_make_monetary (result_p, (db_get_monetary (dbval_p))->type, dtmp);
       break;
 
     case DB_TYPE_SHORT:
-      stmp = DB_GET_SHORT (dbval_p);
+      stmp = db_get_short (dbval_p);
       if (stmp == SHRT_MIN)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_OVERFLOW_UMINUS, 0);
 	  return ER_QPROC_OVERFLOW_UMINUS;
 	}
-      DB_MAKE_SHORT (result_p, (-1) * stmp);
+      db_make_short (result_p, (-1) * stmp);
       break;
 
     default:
@@ -6634,8 +6634,8 @@ qdata_strcat_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_
       cast_dom1 = tp_domain_resolve_value (dbval2_p, NULL);
     }
 
-  DB_MAKE_NULL (&cast_value1);
-  DB_MAKE_NULL (&cast_value2);
+  db_make_null (&cast_value1);
+  db_make_null (&cast_value2);
 
   if (cast_dom1 != NULL)
     {
@@ -6748,7 +6748,7 @@ qdata_strcat_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_
       error = qdata_add_time_to_dbval (dbval1_p, dbval2_p, result_p);
       if (error != NO_ERROR && type1 == DB_TYPE_TIMELTZ)
 	{
-	  DB_MAKE_TIMELTZ (result_p, DB_GET_TIME (result_p));
+	  db_make_timeltz (result_p, db_get_time (result_p));
 	}
       break;
 
@@ -6761,7 +6761,7 @@ qdata_strcat_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_
       error = qdata_add_utime_to_dbval (dbval1_p, dbval2_p, result_p, domain_p);
       if (error == NO_ERROR && type1 == DB_TYPE_TIMESTAMPLTZ)
 	{
-	  DB_MAKE_TIMESTAMPLTZ (result_p, *DB_GET_UTIME (result_p));
+	  db_make_timestampltz (result_p, *db_get_utime (result_p));
 	}
       break;
 
@@ -6774,7 +6774,7 @@ qdata_strcat_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_
       error = qdata_add_datetime_to_dbval (dbval1_p, dbval2_p, result_p, domain_p);
       if (error != NO_ERROR && type1 == DB_TYPE_DATETIMELTZ)
 	{
-	  DB_MAKE_DATETIMELTZ (result_p, DB_GET_DATETIME (result_p));
+	  db_make_datetimeltz (result_p, db_get_datetime (result_p));
 	}
       break;
 
@@ -6900,7 +6900,7 @@ qdata_initialize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_l
       /* This set is made, because if class is empty, aggregate results should return NULL, except count(*) and count */
       if (agg_p->function == PT_COUNT_STAR || agg_p->function == PT_COUNT)
 	{
-	  DB_MAKE_INT (agg_p->accumulator.value, 0);
+	  db_make_int (agg_p->accumulator.value, 0);
 	}
 
       /* create temporary list file to handle distincts */
@@ -7080,12 +7080,12 @@ qdata_aggregate_value_to_accumulator (THREAD_ENTRY * thread_p, AGGREGATE_ACCUMUL
       if (acc->curr_cnt < 1)
 	{
 	  /* first value */
-	  DB_MAKE_INT (acc->value, 1);
+	  db_make_int (acc->value, 1);
 	}
       else
 	{
 	  /* increment */
-	  DB_MAKE_INT (acc->value, DB_GET_INT (acc->value) + 1);
+	  db_make_int (acc->value, db_get_int (acc->value) + 1);
 	}
       break;
 
@@ -7095,7 +7095,7 @@ qdata_aggregate_value_to_accumulator (THREAD_ENTRY * thread_p, AGGREGATE_ACCUMUL
       {
 	int error;
 	DB_VALUE tmp_val;
-	DB_MAKE_BIGINT (&tmp_val, (DB_BIGINT) 0);
+	db_make_bigint (&tmp_val, (DB_BIGINT) 0);
 
 	if (acc->curr_cnt < 1)
 	  {
@@ -7274,7 +7274,7 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
   int dbval_size, i, error;
   AGGREGATE_PERCENTILE_INFO *percentile = NULL;
 
-  DB_MAKE_NULL (&dbval);
+  db_make_null (&dbval);
 
   for (agg_p = agg_list_p, i = 0; agg_p != NULL; agg_p = agg_p->next, i++)
     {
@@ -7330,7 +7330,7 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 	  if ((agg_p->function == PT_COUNT || agg_p->function == PT_COUNT_STAR) && DB_IS_NULL (accumulator->value))
 	    {
 	      /* we might get a NULL count if aggregating with hash table and group has only one tuple; correct that */
-	      DB_MAKE_INT (accumulator->value, 0);
+	      db_make_int (accumulator->value, 0);
 	    }
 	  continue;
 	}
@@ -7431,7 +7431,7 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 		      return ER_FAILED;
 		    }
 
-		  percentile->cur_group_percentile = DB_GET_DOUBLE (percentile_val);
+		  percentile->cur_group_percentile = db_get_double (percentile_val);
 		  if (percentile->cur_group_percentile < 0 || percentile->cur_group_percentile > 1)
 		    {
 		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_PERCENTILE_FUNC_INVALID_PERCENTILE_RANGE, 1,
@@ -7520,7 +7520,7 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 	  if (agg_p->function == PT_PERCENTILE_CONT || agg_p->function == PT_PERCENTILE_DISC)
 	    {
 	      if (DB_VALUE_TYPE (percentile_val) != DB_TYPE_DOUBLE
-		  || DB_GET_DOUBLE (percentile_val) != percentile->cur_group_percentile)
+		  || db_get_double (percentile_val) != percentile->cur_group_percentile)
 		{
 		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_PERCENTILE_FUNC_PERCENTILE_CHANGED_IN_GROUP, 0);
 		  return ER_FAILED;
@@ -7626,11 +7626,11 @@ qdata_evaluate_aggregate_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg
     case PT_COUNT:
       if (agg_p->option == Q_ALL)
 	{
-	  DB_MAKE_INT (agg_p->accumulator.value, oid_count - null_count);
+	  db_make_int (agg_p->accumulator.value, oid_count - null_count);
 	}
       else
 	{
-	  DB_MAKE_INT (agg_p->accumulator.value, key_count);
+	  db_make_int (agg_p->accumulator.value, key_count);
 	}
       break;
 
@@ -7687,7 +7687,7 @@ qdata_evaluate_aggregate_hierarchy (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
       return error;
     }
 
-  DB_MAKE_NULL (&result);
+  db_make_null (&result);
   error = pr_clone_value (agg_p->accumulator.value, &result);
   if (error != NO_ERROR)
     {
@@ -7823,14 +7823,14 @@ qdata_finalize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
   OR_BUF buf;
   double dbl;
 
-  DB_MAKE_NULL (&sqr_val);
-  DB_MAKE_NULL (&dbval);
-  DB_MAKE_NULL (&xavgval);
-  DB_MAKE_NULL (&xavg_1val);
-  DB_MAKE_NULL (&x2avgval);
-  DB_MAKE_NULL (&xavg2val);
-  DB_MAKE_NULL (&varval);
-  DB_MAKE_NULL (&dval);
+  db_make_null (&sqr_val);
+  db_make_null (&dbval);
+  db_make_null (&xavgval);
+  db_make_null (&xavg_1val);
+  db_make_null (&x2avgval);
+  db_make_null (&xavg2val);
+  db_make_null (&varval);
+  db_make_null (&dval);
 
   for (agg_p = agg_list_p; agg_p != NULL; agg_p = agg_p->next)
     {
@@ -7845,7 +7845,7 @@ qdata_finalize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
       /* set count-star aggregate values */
       if (agg_p->function == PT_COUNT_STAR)
 	{
-	  DB_MAKE_INT (agg_p->accumulator.value, agg_p->accumulator.curr_cnt);
+	  db_make_int (agg_p->accumulator.value, agg_p->accumulator.curr_cnt);
 	}
 
       /* the value of groupby_num() remains unchanged; it will be changed while evaluating groupby_num predicates
@@ -7861,7 +7861,7 @@ qdata_finalize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 	  /* calculate the result for CUME_DIST */
 	  dbl = (double) (agg_p->info.dist_percent.nlargers + 1) / (agg_p->accumulator.curr_cnt + 1);
 	  assert (dbl <= 1.0 && dbl > 0.0);
-	  DB_MAKE_DOUBLE (agg_p->accumulator.value, dbl);
+	  db_make_double (agg_p->accumulator.value, dbl);
 
 	  /* free const_array */
 	  if (agg_p->info.dist_percent.const_array != NULL)
@@ -7883,7 +7883,7 @@ qdata_finalize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 	      dbl = (double) (agg_p->info.dist_percent.nlargers) / agg_p->accumulator.curr_cnt;
 	    }
 	  assert (dbl <= 1.0 && dbl >= 0.0);
-	  DB_MAKE_DOUBLE (agg_p->accumulator.value, dbl);
+	  db_make_double (agg_p->accumulator.value, dbl);
 
 	  /* free const_array */
 	  if (agg_p->info.dist_percent.const_array != NULL)
@@ -7936,7 +7936,7 @@ qdata_finalize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 
 	      if (agg_p->function == PT_COUNT)
 		{
-		  DB_MAKE_INT (agg_p->accumulator.value, list_id_p->tuple_cnt);
+		  db_make_int (agg_p->accumulator.value, list_id_p->tuple_cnt);
 		}
 	      else
 		{
@@ -8165,7 +8165,7 @@ qdata_finalize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 	  TP_DOMAIN *double_domain_ptr = tp_domain_resolve_default (DB_TYPE_DOUBLE);
 
 	  /* compute AVG(X) = SUM(X)/COUNT(X) */
-	  DB_MAKE_DOUBLE (&dbval, agg_p->accumulator.curr_cnt);
+	  db_make_double (&dbval, agg_p->accumulator.curr_cnt);
 	  error = qdata_divide_dbval (agg_p->accumulator.value, &dbval, &xavgval, double_domain_ptr);
 	  if (error != NO_ERROR)
 	    {
@@ -8188,12 +8188,12 @@ qdata_finalize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 	      /* compute SUM(X^2) / (n-1) */
 	      if (agg_p->accumulator.curr_cnt > 1)
 		{
-		  DB_MAKE_DOUBLE (&dbval, agg_p->accumulator.curr_cnt - 1);
+		  db_make_double (&dbval, agg_p->accumulator.curr_cnt - 1);
 		}
 	      else
 		{
 		  /* when not enough samples, return NULL */
-		  DB_MAKE_NULL (agg_p->accumulator.value);
+		  db_make_null (agg_p->accumulator.value);
 		  continue;
 		}
 	    }
@@ -8202,7 +8202,7 @@ qdata_finalize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 	      assert (agg_p->function == PT_STDDEV || agg_p->function == PT_STDDEV_POP || agg_p->function == PT_VARIANCE
 		      || agg_p->function == PT_VAR_POP);
 	      /* compute SUM(X^2) / n */
-	      DB_MAKE_DOUBLE (&dbval, agg_p->accumulator.curr_cnt);
+	      db_make_double (&dbval, agg_p->accumulator.curr_cnt);
 	    }
 
 	  error = qdata_divide_dbval (agg_p->accumulator.value2, &dbval, &x2avgval, double_domain_ptr);
@@ -8253,14 +8253,14 @@ qdata_finalize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 		  goto exit;
 		}
 
-	      dtmp = DB_GET_DOUBLE (&dval);
+	      dtmp = db_get_double (&dval);
 
 	      /* mathematically, dtmp should be zero or positive; however, due to some precision errors, in some cases
 	       * it can be a very small negative number of which we cannot extract the square root */
 	      dtmp = (dtmp < 0.0f ? 0.0f : dtmp);
 
 	      dtmp = sqrt (dtmp);
-	      DB_MAKE_DOUBLE (&dval, dtmp);
+	      db_make_double (&dval, dtmp);
 
 	      pr_clone_value (&dval, agg_p->accumulator.value);
 	    }
@@ -8324,7 +8324,7 @@ qdata_get_tuple_value_size_from_dbval (DB_VALUE * dbval_p)
 	      if (pr_is_string_type (dbval_type))
 		{
 		  int precision = DB_VALUE_PRECISION (dbval_p);
-		  int string_length = DB_GET_STRING_LENGTH (dbval_p);
+		  int string_length = db_get_string_length (dbval_p);
 
 		  if (precision == TP_FLOATING_PRECISION_VALUE)
 		    {
@@ -8626,7 +8626,7 @@ qdata_convert_dbvals_to_set (THREAD_ENTRY * thread_p, DB_TYPE stype, REGU_VARIAB
   result_p = regu_func_p->value.funcp->value;
   operand = regu_func_p->value.funcp->operand;
   domain_p = regu_func_p->domain;
-  DB_MAKE_NULL (&dbval);
+  db_make_null (&dbval);
 
   if (stype == DB_TYPE_SET)
     {
@@ -8757,7 +8757,7 @@ qdata_evaluate_generic_function (THREAD_ENTRY * thread_p, FUNCTION_TYPE * functi
       goto error;
     }
 
-  offset = DB_GET_INTEGER (offset_dbval_p);
+  offset = db_get_int (offset_dbval_p);
   if (offset >= (SSIZEOF (generic_func_ptrs) / SSIZEOF (generic_func_ptrs[0])))
     {
       goto error;
@@ -8832,7 +8832,7 @@ qdata_get_class_of_function (THREAD_ENTRY * thread_p, FUNCTION_TYPE * function_p
 
   if (DB_IS_NULL (val_p))
     {
-      DB_MAKE_NULL (function_p->value);
+      db_make_null (function_p->value);
       return NO_ERROR;
     }
 
@@ -8840,7 +8840,7 @@ qdata_get_class_of_function (THREAD_ENTRY * thread_p, FUNCTION_TYPE * function_p
   if (type == DB_TYPE_VOBJ)
     {
       /* grab the real oid */
-      if (db_seq_get (DB_GET_SEQUENCE (val_p), 2, &element) != NO_ERROR)
+      if (db_seq_get (db_get_set (val_p), 2, &element) != NO_ERROR)
 	{
 	  return ER_FAILED;
 	}
@@ -8862,7 +8862,7 @@ qdata_get_class_of_function (THREAD_ENTRY * thread_p, FUNCTION_TYPE * function_p
       return err;
     }
 
-  DB_MAKE_OID (function_p->value, &class_oid);
+  db_make_oid (function_p->value, &class_oid);
 
   return NO_ERROR;
 }
@@ -9004,7 +9004,7 @@ qdata_convert_table_to_set (THREAD_ENTRY * thread_p, DB_TYPE stype, REGU_VARIABL
 
   domain_p = function_p->domain;
   list_id_p = operand->value.value.srlist_id->list_id;
-  DB_MAKE_NULL (&dbval);
+  db_make_null (&dbval);
 
   if (stype == DB_TYPE_SET)
     {
@@ -9174,7 +9174,7 @@ qdata_evaluate_connect_by_root (THREAD_ENTRY * thread_p, void *xasl_p, REGU_VARI
 	  return false;
 	}
 
-      bitval = (QFILE_TUPLE_POSITION *) DB_GET_BIT (&p_pos_dbval, &length);
+      bitval = (QFILE_TUPLE_POSITION *) db_get_bit (&p_pos_dbval, &length);
 
       if (bitval)
 	{
@@ -9291,7 +9291,7 @@ qdata_evaluate_qprior (THREAD_ENTRY * thread_p, void *xasl_p, REGU_VARIABLE * re
       return false;
     }
 
-  bitval = (QFILE_TUPLE_POSITION *) DB_GET_BIT (&p_pos_dbval, &length);
+  bitval = (QFILE_TUPLE_POSITION *) db_get_bit (&p_pos_dbval, &length);
 
   if (bitval)
     {
@@ -9341,7 +9341,7 @@ qdata_evaluate_qprior (THREAD_ENTRY * thread_p, void *xasl_p, REGU_VARIABLE * re
     }
   else
     {
-      DB_MAKE_NULL (result_val_p);
+      db_make_null (result_val_p);
     }
 
   return true;
@@ -9429,7 +9429,7 @@ qdata_evaluate_sys_connect_by_path (THREAD_ENTRY * thread_p, void *xasl_p, REGU_
   else
     {
       arg_dbval_p = &arg_dbval;
-      DB_MAKE_NULL (arg_dbval_p);
+      db_make_null (arg_dbval_p);
     }
 
   /* character */
@@ -9547,7 +9547,7 @@ qdata_evaluate_sys_connect_by_path (THREAD_ENTRY * thread_p, void *xasl_p, REGU_
 
       if (DB_IS_NULL (arg_dbval_p))
 	{
-	  DB_MAKE_NULL (&cast_value);
+	  db_make_null (&cast_value);
 	}
       else
 	{
@@ -9564,7 +9564,7 @@ qdata_evaluate_sys_connect_by_path (THREAD_ENTRY * thread_p, void *xasl_p, REGU_
 	    }
 	}
 
-      len = (strlen (sep) + (DB_IS_NULL (&cast_value) ? 0 : DB_GET_STRING_SIZE (&cast_value))
+      len = (strlen (sep) + (DB_IS_NULL (&cast_value) ? 0 : db_get_string_size (&cast_value))
 	     + strlen (result_path) + 1);
       if (len > len_tmp || path_tmp == NULL)
 	{
@@ -9614,7 +9614,7 @@ qdata_evaluate_sys_connect_by_path (THREAD_ENTRY * thread_p, void *xasl_p, REGU_
 	  goto error;
 	}
 
-      bitval = (QFILE_TUPLE_POSITION *) DB_GET_BIT (&p_pos_dbval, &length);
+      bitval = (QFILE_TUPLE_POSITION *) db_get_bit (&p_pos_dbval, &length);
 
       if (bitval)
 	{
@@ -9635,7 +9635,7 @@ qdata_evaluate_sys_connect_by_path (THREAD_ENTRY * thread_p, void *xasl_p, REGU_
 
   qfile_close_scan (thread_p, &s_id);
 
-  DB_MAKE_STRING (result_p, result_path);
+  db_make_string (result_p, result_path);
   result_p->need_clear = true;
 
   if (use_extended)
@@ -9754,15 +9754,15 @@ qdata_bit_not_dbval (DB_VALUE * dbval_p, DB_VALUE * result_p, TP_DOMAIN * domain
       break;
 
     case DB_TYPE_INTEGER:
-      db_make_bigint (result_p, ~((INT64) DB_GET_INTEGER (dbval_p)));
+      db_make_bigint (result_p, ~((INT64) db_get_int (dbval_p)));
       break;
 
     case DB_TYPE_BIGINT:
-      db_make_bigint (result_p, ~DB_GET_BIGINT (dbval_p));
+      db_make_bigint (result_p, ~db_get_bigint (dbval_p));
       break;
 
     case DB_TYPE_SHORT:
-      db_make_bigint (result_p, ~((INT64) DB_GET_SHORT (dbval_p)));
+      db_make_bigint (result_p, ~((INT64) db_get_short (dbval_p)));
       break;
 
     default:
@@ -9810,15 +9810,15 @@ qdata_bit_and_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  bi[i] = (DB_BIGINT) DB_GET_INTEGER (dbval[i]);
+	  bi[i] = (DB_BIGINT) db_get_int (dbval[i]);
 	  break;
 
 	case DB_TYPE_BIGINT:
-	  bi[i] = DB_GET_BIGINT (dbval[i]);
+	  bi[i] = db_get_bigint (dbval[i]);
 	  break;
 
 	case DB_TYPE_SHORT:
-	  bi[i] = (DB_BIGINT) DB_GET_SHORT (dbval[i]);
+	  bi[i] = (DB_BIGINT) db_get_short (dbval[i]);
 	  break;
 
 	default:
@@ -9872,15 +9872,15 @@ qdata_bit_or_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  bi[i] = (DB_BIGINT) DB_GET_INTEGER (dbval[i]);
+	  bi[i] = (DB_BIGINT) db_get_int (dbval[i]);
 	  break;
 
 	case DB_TYPE_BIGINT:
-	  bi[i] = DB_GET_BIGINT (dbval[i]);
+	  bi[i] = db_get_bigint (dbval[i]);
 	  break;
 
 	case DB_TYPE_SHORT:
-	  bi[i] = (DB_BIGINT) DB_GET_SHORT (dbval[i]);
+	  bi[i] = (DB_BIGINT) db_get_short (dbval[i]);
 	  break;
 
 	default:
@@ -9934,15 +9934,15 @@ qdata_bit_xor_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  bi[i] = (DB_BIGINT) DB_GET_INTEGER (dbval[i]);
+	  bi[i] = (DB_BIGINT) db_get_int (dbval[i]);
 	  break;
 
 	case DB_TYPE_BIGINT:
-	  bi[i] = DB_GET_BIGINT (dbval[i]);
+	  bi[i] = db_get_bigint (dbval[i]);
 	  break;
 
 	case DB_TYPE_SHORT:
-	  bi[i] = (DB_BIGINT) DB_GET_SHORT (dbval[i]);
+	  bi[i] = (DB_BIGINT) db_get_short (dbval[i]);
 	  break;
 
 	default:
@@ -9997,15 +9997,15 @@ qdata_bit_shift_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, OPERATOR_TYPE o
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  bi[i] = (DB_BIGINT) DB_GET_INTEGER (dbval[i]);
+	  bi[i] = (DB_BIGINT) db_get_int (dbval[i]);
 	  break;
 
 	case DB_TYPE_BIGINT:
-	  bi[i] = DB_GET_BIGINT (dbval[i]);
+	  bi[i] = db_get_bigint (dbval[i]);
 	  break;
 
 	case DB_TYPE_SHORT:
-	  bi[i] = (DB_BIGINT) DB_GET_SHORT (dbval[i]);
+	  bi[i] = (DB_BIGINT) db_get_short (dbval[i]);
 	  break;
 
 	default:
@@ -10074,15 +10074,15 @@ qdata_divmod_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, OPERATOR_TYPE op, 
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  bi[i] = (DB_BIGINT) DB_GET_INTEGER (dbval[i]);
+	  bi[i] = (DB_BIGINT) db_get_int (dbval[i]);
 	  break;
 
 	case DB_TYPE_BIGINT:
-	  bi[i] = DB_GET_BIGINT (dbval[i]);
+	  bi[i] = db_get_bigint (dbval[i]);
 	  break;
 
 	case DB_TYPE_SHORT:
-	  bi[i] = (DB_BIGINT) DB_GET_SHORT (dbval[i]);
+	  bi[i] = (DB_BIGINT) db_get_short (dbval[i]);
 	  break;
 
 	default:
@@ -10260,7 +10260,7 @@ qdata_group_concat_first_value (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_p,
   int max_allowed_size;
   DB_VALUE tmp_val;
 
-  DB_MAKE_NULL (&tmp_val);
+  db_make_null (&tmp_val);
 
   agg_type = DB_VALUE_DOMAIN_TYPE (agg_p->accumulator.value);
   /* init the aggregate value domain */
@@ -10321,7 +10321,7 @@ qdata_group_concat_value (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_p, DB_VA
   int max_allowed_size;
   DB_VALUE tmp_val;
 
-  DB_MAKE_NULL (&tmp_val);
+  db_make_null (&tmp_val);
 
   agg_type = DB_VALUE_DOMAIN_TYPE (agg_p->accumulator.value);
 
@@ -10520,16 +10520,16 @@ qdata_elt (THREAD_ENTRY * thread_p, FUNCTION_TYPE * function_p, VAL_DESCR * val_
   switch (index_type)
     {
     case DB_TYPE_SMALLINT:
-      idx = DB_GET_SMALLINT (index);
+      idx = db_get_short (index);
       break;
     case DB_TYPE_INTEGER:
-      idx = DB_GET_INTEGER (index);
+      idx = db_get_int (index);
       break;
     case DB_TYPE_BIGINT:
-      idx = DB_GET_BIGINT (index);
+      idx = db_get_bigint (index);
       break;
     case DB_TYPE_NULL:
-      DB_MAKE_NULL (function_p->value);
+      db_make_null (function_p->value);
       goto fast_exit;
     default:
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
@@ -10540,7 +10540,7 @@ qdata_elt (THREAD_ENTRY * thread_p, FUNCTION_TYPE * function_p, VAL_DESCR * val_
   if (idx <= 0)
     {
       /* index is 0 or is negative */
-      DB_MAKE_NULL (function_p->value);
+      db_make_null (function_p->value);
       goto fast_exit;
     }
 
@@ -10556,7 +10556,7 @@ qdata_elt (THREAD_ENTRY * thread_p, FUNCTION_TYPE * function_p, VAL_DESCR * val_
   if (operand == NULL)
     {
       /* index greater than number of arguments */
-      DB_MAKE_NULL (function_p->value);
+      db_make_null (function_p->value);
       goto fast_exit;
     }
 
@@ -10731,7 +10731,7 @@ qdata_get_cardinality (THREAD_ENTRY * thread_p, DB_VALUE * db_class_name, DB_VAL
   int str_class_name_len;
   int str_index_name_len;
 
-  DB_MAKE_NULL (result_p);
+  db_make_null (result_p);
 
   cl_name_arg_type = DB_VALUE_DOMAIN_TYPE (db_class_name);
   idx_name_arg_type = DB_VALUE_DOMAIN_TYPE (db_index_name);
@@ -10749,26 +10749,26 @@ qdata_get_cardinality (THREAD_ENTRY * thread_p, DB_VALUE * db_class_name, DB_VAL
       goto exit;
     }
 
-  str_class_name_len = MIN (SM_MAX_IDENTIFIER_LENGTH - 1, DB_GET_STRING_SIZE (db_class_name));
+  str_class_name_len = MIN (SM_MAX_IDENTIFIER_LENGTH - 1, db_get_string_size (db_class_name));
   strncpy (class_name, db_get_string (db_class_name), str_class_name_len);
   class_name[str_class_name_len] = '\0';
 
-  str_index_name_len = MIN (SM_MAX_IDENTIFIER_LENGTH - 1, DB_GET_STRING_SIZE (db_index_name));
+  str_index_name_len = MIN (SM_MAX_IDENTIFIER_LENGTH - 1, db_get_string_size (db_index_name));
   strncpy (index_name, db_get_string (db_index_name), str_index_name_len);
   index_name[str_index_name_len] = '\0';
 
-  key_pos = DB_GET_INT (db_key_position);
+  key_pos = db_get_int (db_key_position);
 
   error = catalog_get_cardinality_by_name (thread_p, class_name, index_name, key_pos, &cardinality);
   if (error == NO_ERROR)
     {
       if (cardinality < 0)
 	{
-	  DB_MAKE_NULL (result_p);
+	  db_make_null (result_p);
 	}
       else
 	{
-	  DB_MAKE_INT (result_p, cardinality);
+	  db_make_int (result_p, cardinality);
 	}
     }
 
@@ -10796,10 +10796,10 @@ qdata_initialize_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p,
   if (func_p->function == PT_COUNT_STAR || func_p->function == PT_COUNT || func_p->function == PT_ROW_NUMBER
       || func_p->function == PT_RANK || func_p->function == PT_DENSE_RANK)
     {
-      DB_MAKE_INT (func_p->value, 0);
+      db_make_int (func_p->value, 0);
     }
 
-  DB_MAKE_NULL (&func_p->part_value);
+  db_make_null (&func_p->part_value);
 
   /* create temporary list file to handle distincts */
   if (func_p->option == Q_DISTINCT)
@@ -10862,8 +10862,8 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
   ANALYTIC_PERCENTILE_FUNCTION_INFO *percentile_info_p = NULL;
   DB_VALUE *peek_value_p = NULL;
 
-  DB_MAKE_NULL (&dbval);
-  DB_MAKE_NULL (&sqr_val);
+  db_make_null (&dbval);
+  db_make_null (&sqr_val);
 
   /* fetch operand value, analytic regulator variable should only contain constants */
   if (fetch_copy_dbval (thread_p, &func_p->operand, val_desc_p, NULL, NULL, NULL, &dbval) != NO_ERROR)
@@ -11003,7 +11003,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 
     case PT_NTILE:
       /* output value is not required now */
-      DB_MAKE_NULL (func_p->value);
+      db_make_null (func_p->value);
 
       if (func_p->curr_cnt < 1)
 	{
@@ -11018,7 +11018,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 	      goto exit;
 	    }
 
-	  ntile_bucket = DB_GET_DOUBLE (&dbval);
+	  ntile_bucket = db_get_double (&dbval);
 
 	  /* boundary check */
 	  if (ntile_bucket < 1.0 || ntile_bucket > DB_INT32_MAX)
@@ -11126,24 +11126,24 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
       break;
 
     case PT_ROW_NUMBER:
-      DB_MAKE_INT (func_p->out_value, func_p->curr_cnt + 1);
+      db_make_int (func_p->out_value, func_p->curr_cnt + 1);
       break;
 
     case PT_COUNT:
       if (func_p->curr_cnt < 1)
 	{
-	  DB_MAKE_INT (func_p->value, 1);
+	  db_make_int (func_p->value, 1);
 	}
       else
 	{
-	  DB_MAKE_INT (func_p->value, DB_GET_INT (func_p->value) + 1);
+	  db_make_int (func_p->value, db_get_int (func_p->value) + 1);
 	}
       break;
 
     case PT_RANK:
       if (func_p->curr_cnt < 1)
 	{
-	  DB_MAKE_INT (func_p->value, 1);
+	  db_make_int (func_p->value, 1);
 	}
       else
 	{
@@ -11153,7 +11153,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 	    }
 	  else
 	    {
-	      DB_MAKE_INT (func_p->value, func_p->curr_cnt + 1);
+	      db_make_int (func_p->value, func_p->curr_cnt + 1);
 	    }
 	}
       break;
@@ -11161,7 +11161,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
     case PT_DENSE_RANK:
       if (func_p->curr_cnt < 1)
 	{
-	  DB_MAKE_INT (func_p->value, 1);
+	  db_make_int (func_p->value, 1);
 	}
       else
 	{
@@ -11171,7 +11171,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 	    }
 	  else
 	    {
-	      DB_MAKE_INT (func_p->value, DB_GET_INT (func_p->value) + 1);
+	      db_make_int (func_p->value, db_get_int (func_p->value) + 1);
 	    }
 	}
       break;
@@ -11285,7 +11285,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 		  goto exit;
 		}
 
-	      percentile_info_p->cur_group_percentile = DB_GET_DOUBLE (peek_value_p);
+	      percentile_info_p->cur_group_percentile = db_get_double (peek_value_p);
 	      if ((percentile_info_p->cur_group_percentile < 0) || (percentile_info_p->cur_group_percentile > 1))
 		{
 		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_PERCENTILE_FUNC_INVALID_PERCENTILE_RANGE, 1,
@@ -11448,7 +11448,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 	    }
 
 	  if ((peek_value_p == NULL) || (DB_VALUE_TYPE (peek_value_p) != DB_TYPE_DOUBLE)
-	      || (DB_GET_DOUBLE (peek_value_p) != func_p->info.percentile.cur_group_percentile))
+	      || (db_get_double (peek_value_p) != func_p->info.percentile.cur_group_percentile))
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_PERCENTILE_FUNC_PERCENTILE_CHANGED_IN_GROUP, 0);
 	      error = ER_PERCENTILE_FUNC_PERCENTILE_CHANGED_IN_GROUP;
@@ -11518,14 +11518,14 @@ qdata_finalize_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, b
   TP_DOMAIN *tmp_domain_ptr = NULL;
   int err = NO_ERROR;
 
-  DB_MAKE_NULL (&sqr_val);
-  DB_MAKE_NULL (&dbval);
-  DB_MAKE_NULL (&xavgval);
-  DB_MAKE_NULL (&xavg_1val);
-  DB_MAKE_NULL (&x2avgval);
-  DB_MAKE_NULL (&xavg2val);
-  DB_MAKE_NULL (&varval);
-  DB_MAKE_NULL (&dval);
+  db_make_null (&sqr_val);
+  db_make_null (&dbval);
+  db_make_null (&xavgval);
+  db_make_null (&xavg_1val);
+  db_make_null (&x2avgval);
+  db_make_null (&xavg2val);
+  db_make_null (&varval);
+  db_make_null (&dval);
 
   if (func_p->function == PT_VARIANCE || func_p->function == PT_VAR_POP || func_p->function == PT_VAR_SAMP
       || func_p->function == PT_STDDEV || func_p->function == PT_STDDEV_POP || func_p->function == PT_STDDEV_SAMP)
@@ -11536,7 +11536,7 @@ qdata_finalize_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, b
   /* set count-star aggregate values */
   if (func_p->function == PT_COUNT_STAR)
     {
-      DB_MAKE_INT (func_p->value, func_p->curr_cnt);
+      db_make_int (func_p->value, func_p->curr_cnt);
     }
 
   /* process list file for distinct */
@@ -11562,7 +11562,7 @@ qdata_finalize_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, b
 
       if (func_p->function == PT_COUNT)
 	{
-	  DB_MAKE_INT (func_p->value, list_id_p->tuple_cnt);
+	  db_make_int (func_p->value, list_id_p->tuple_cnt);
 	}
       else
 	{
@@ -11578,7 +11578,7 @@ qdata_finalize_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, b
 
 	  (void) pr_clear_value (func_p->value);
 
-	  DB_MAKE_NULL (func_p->value);
+	  db_make_null (func_p->value);
 
 	  /* median and percentile funcs don't need to read all rows */
 	  if (list_id_p->tuple_cnt > 0 && QPROC_IS_INTERPOLATION_FUNC (func_p))
@@ -11738,7 +11738,7 @@ qdata_finalize_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, b
       double_domain_ptr = tp_domain_resolve_default (DB_TYPE_DOUBLE);
 
       /* compute AVG(X) = SUM(X)/COUNT(X) */
-      DB_MAKE_DOUBLE (&dbval, func_p->curr_cnt);
+      db_make_double (&dbval, func_p->curr_cnt);
       if (qdata_divide_dbval (func_p->value, &dbval, &xavgval, double_domain_ptr) != NO_ERROR)
 	{
 	  goto error;
@@ -11760,13 +11760,13 @@ qdata_finalize_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, b
 	  /* compute SUM(X^2) / (n-1) */
 	  if (func_p->curr_cnt > 1)
 	    {
-	      DB_MAKE_DOUBLE (&dbval, func_p->curr_cnt - 1);
+	      db_make_double (&dbval, func_p->curr_cnt - 1);
 	    }
 	  else
 	    {
 	      /* when not enough samples, return NULL */
 	      (void) pr_clear_value (func_p->value);
-	      DB_MAKE_NULL (func_p->value);
+	      db_make_null (func_p->value);
 	      goto exit;
 	    }
 	}
@@ -11775,7 +11775,7 @@ qdata_finalize_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, b
 	  assert (func_p->function == PT_STDDEV || func_p->function == PT_STDDEV_POP || func_p->function == PT_VARIANCE
 		  || func_p->function == PT_VAR_POP);
 	  /* compute SUM(X^2) / n */
-	  DB_MAKE_DOUBLE (&dbval, func_p->curr_cnt);
+	  db_make_double (&dbval, func_p->curr_cnt);
 	}
 
       if (qdata_divide_dbval (func_p->value2, &dbval, &x2avgval, double_domain_ptr) != NO_ERROR)
@@ -11817,14 +11817,14 @@ qdata_finalize_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, b
 	      goto error;
 	    }
 
-	  dtmp = DB_GET_DOUBLE (&dval);
+	  dtmp = db_get_double (&dval);
 
 	  /* mathematically, dtmp should be zero or positive; however, due to some precision errors, in some cases it
 	   * can be a very small negative number of which we cannot extract the square root */
 	  dtmp = (dtmp < 0.0f ? 0.0f : dtmp);
 
 	  dtmp = sqrt (dtmp);
-	  DB_MAKE_DOUBLE (&dval, dtmp);
+	  db_make_double (&dval, dtmp);
 
 	  pr_clone_value (&dval, func_p->value);
 	}
@@ -11934,34 +11934,34 @@ qdata_apply_interpolation_function_coercion (DB_VALUE * f_value, TP_DOMAIN ** re
 	{
 	  if (type == DB_TYPE_SHORT)
 	    {
-	      d_result = (double) DB_GET_SHORT (f_value);
+	      d_result = (double) db_get_short (f_value);
 	    }
 	  else if (type == DB_TYPE_INTEGER)
 	    {
-	      d_result = (double) DB_GET_INT (f_value);
+	      d_result = (double) db_get_int (f_value);
 	    }
 	  else if (type == DB_TYPE_BIGINT)
 	    {
-	      d_result = (double) DB_GET_BIGINT (f_value);
+	      d_result = (double) db_get_bigint (f_value);
 	    }
 	  else if (type == DB_TYPE_FLOAT)
 	    {
-	      d_result = (double) DB_GET_FLOAT (f_value);
+	      d_result = (double) db_get_float (f_value);
 	    }
 	  else if (type == DB_TYPE_DOUBLE)
 	    {
-	      d_result = (double) DB_GET_DOUBLE (f_value);
+	      d_result = (double) db_get_double (f_value);
 	    }
 	  else if (type == DB_TYPE_MONETARY)
 	    {
-	      d_result = (DB_GET_MONETARY (f_value))->amount;
+	      d_result = (db_get_monetary (f_value))->amount;
 	    }
 	  else if (type == DB_TYPE_NUMERIC)
 	    {
 	      numeric_coerce_num_to_double (db_locate_numeric (f_value), DB_VALUE_SCALE (f_value), &d_result);
 	    }
 
-	  DB_MAKE_DOUBLE (result, d_result);
+	  db_make_double (result, d_result);
 	}
       else
 	{
@@ -12086,68 +12086,68 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
   switch (type)
     {
     case DB_TYPE_SHORT:
-      d1 = (double) DB_GET_SHORT (f_value);
-      d2 = (double) DB_GET_SHORT (c_value);
+      d1 = (double) db_get_short (f_value);
+      d2 = (double) db_get_short (c_value);
 
       /* calculate */
       d_result = (c_row_num_d - row_num_d) * d1 + (row_num_d - f_row_num_d) * d2;
 
-      DB_MAKE_DOUBLE (result, d_result);
+      db_make_double (result, d_result);
 
       break;
 
     case DB_TYPE_INTEGER:
-      d1 = (double) DB_GET_INT (f_value);
-      d2 = (double) DB_GET_INT (c_value);
+      d1 = (double) db_get_int (f_value);
+      d2 = (double) db_get_int (c_value);
 
       /* calculate */
       d_result = (c_row_num_d - row_num_d) * d1 + (row_num_d - f_row_num_d) * d2;
 
-      DB_MAKE_DOUBLE (result, d_result);
+      db_make_double (result, d_result);
 
       break;
 
     case DB_TYPE_BIGINT:
-      d1 = (double) DB_GET_BIGINT (f_value);
-      d2 = (double) DB_GET_BIGINT (c_value);
+      d1 = (double) db_get_bigint (f_value);
+      d2 = (double) db_get_bigint (c_value);
 
       /* calculate */
       d_result = (c_row_num_d - row_num_d) * d1 + (row_num_d - f_row_num_d) * d2;
 
-      DB_MAKE_DOUBLE (result, d_result);
+      db_make_double (result, d_result);
 
       break;
 
     case DB_TYPE_FLOAT:
-      d1 = (double) DB_GET_FLOAT (f_value);
-      d2 = (double) DB_GET_FLOAT (c_value);
+      d1 = (double) db_get_float (f_value);
+      d2 = (double) db_get_float (c_value);
 
       /* calculate */
       d_result = (c_row_num_d - row_num_d) * d1 + (row_num_d - f_row_num_d) * d2;
 
-      DB_MAKE_DOUBLE (result, d_result);
+      db_make_double (result, d_result);
 
       break;
 
     case DB_TYPE_DOUBLE:
-      d1 = DB_GET_DOUBLE (f_value);
-      d2 = DB_GET_DOUBLE (c_value);
+      d1 = db_get_double (f_value);
+      d2 = db_get_double (c_value);
 
       /* calculate */
       d_result = (c_row_num_d - row_num_d) * d1 + (row_num_d - f_row_num_d) * d2;
 
-      DB_MAKE_DOUBLE (result, d_result);
+      db_make_double (result, d_result);
 
       break;
 
     case DB_TYPE_MONETARY:
-      d1 = (DB_GET_MONETARY (f_value))->amount;
-      d2 = (DB_GET_MONETARY (c_value))->amount;
+      d1 = (db_get_monetary (f_value))->amount;
+      d2 = (db_get_monetary (c_value))->amount;
 
       /* calculate */
       d_result = (c_row_num_d - row_num_d) * d1 + (row_num_d - f_row_num_d) * d2;
 
-      DB_MAKE_DOUBLE (result, d_result);
+      db_make_double (result, d_result);
 
       break;
 
@@ -12158,13 +12158,13 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
       /* calculate */
       d_result = (c_row_num_d - row_num_d) * d1 + (row_num_d - f_row_num_d) * d2;
 
-      DB_MAKE_DOUBLE (result, d_result);
+      db_make_double (result, d_result);
 
       break;
 
     case DB_TYPE_DATE:
-      d1 = (double) *(DB_GET_DATE (f_value));
-      d2 = (double) *(DB_GET_DATE (c_value));
+      d1 = (double) *(db_get_date (f_value));
+      d2 = (double) *(db_get_date (c_value));
       d_result = (c_row_num_d - row_num_d) * d1 + (row_num_d - f_row_num_d) * d2;
 
       date = (DB_DATE) floor (d_result);
@@ -12178,22 +12178,22 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
     case DB_TYPE_DATETIMETZ:
       if (type == DB_TYPE_DATETIMETZ)
 	{
-	  datetime = DB_GET_DATETIMETZ (f_value)->datetime;
+	  datetime = db_get_datetimetz (f_value)->datetime;
 	}
       else
 	{
-	  datetime = *(DB_GET_DATETIME (f_value));
+	  datetime = *(db_get_datetime (f_value));
 	}
 
       d1 = ((double) datetime.date) * MILLISECONDS_OF_ONE_DAY + datetime.time;
 
       if (type == DB_TYPE_DATETIMETZ)
 	{
-	  datetime = DB_GET_DATETIMETZ (c_value)->datetime;
+	  datetime = db_get_datetimetz (c_value)->datetime;
 	}
       else
 	{
-	  datetime = *(DB_GET_DATETIME (c_value));
+	  datetime = *(db_get_datetime (c_value));
 	}
 
       d2 = ((double) datetime.date) * MILLISECONDS_OF_ONE_DAY + datetime.time;
@@ -12205,11 +12205,11 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
 
       if (type == DB_TYPE_DATETIME)
 	{
-	  DB_MAKE_DATETIME (result, &datetime);
+	  db_make_datetime (result, &datetime);
 	}
       else if (type == DB_TYPE_DATETIMELTZ)
 	{
-	  DB_MAKE_DATETIMELTZ (result, &datetime);
+	  db_make_datetimeltz (result, &datetime);
 	}
       else
 	{
@@ -12217,7 +12217,7 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
 
 	  /* if the two timezones are different, we use the first timezone */
 	  dttz1.datetime = datetime;
-	  dttz1.tz_id = DB_GET_DATETIMETZ (f_value)->tz_id;
+	  dttz1.tz_id = db_get_datetimetz (f_value)->tz_id;
 
 	  error = tz_datetimetz_fix_zone (&dttz1, &dttz2);
 	  if (error != NO_ERROR)
@@ -12226,7 +12226,7 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
 	      goto end;
 	    }
 
-	  DB_MAKE_DATETIMETZ (result, &dttz2);
+	  db_make_datetimetz (result, &dttz2);
 	}
 
       break;
@@ -12236,22 +12236,22 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
     case DB_TYPE_TIMESTAMPTZ:
       if (type == DB_TYPE_TIMESTAMPTZ)
 	{
-	  db_timestamp_decode_utc (&DB_GET_TIMESTAMPTZ (f_value)->timestamp, &date, &time);
+	  db_timestamp_decode_utc (&db_get_timestamptz (f_value)->timestamp, &date, &time);
 	}
       else
 	{
-	  db_timestamp_decode_utc (DB_GET_TIMESTAMP (f_value), &date, &time);
+	  db_timestamp_decode_utc (db_get_timestamp (f_value), &date, &time);
 	}
 
       d1 = ((double) date) * MILLISECONDS_OF_ONE_DAY + time * 1000;
 
       if (type == DB_TYPE_TIMESTAMPTZ)
 	{
-	  db_timestamp_decode_utc (&DB_GET_TIMESTAMPTZ (c_value)->timestamp, &date, &time);
+	  db_timestamp_decode_utc (&db_get_timestamptz (c_value)->timestamp, &date, &time);
 	}
       else
 	{
-	  db_timestamp_decode_utc (DB_GET_TIMESTAMP (c_value), &date, &time);
+	  db_timestamp_decode_utc (db_get_timestamp (c_value), &date, &time);
 	}
 
       d2 = ((double) date) * MILLISECONDS_OF_ONE_DAY + time * 1000;
@@ -12271,11 +12271,11 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
 
       if (type == DB_TYPE_TIMESTAMP)
 	{
-	  DB_MAKE_TIMESTAMP (result, utime);
+	  db_make_timestamp (result, utime);
 	}
       else if (type == DB_TYPE_TIMESTAMPLTZ)
 	{
-	  DB_MAKE_TIMESTAMPLTZ (result, utime);
+	  db_make_timestampltz (result, utime);
 	}
       else
 	{
@@ -12283,7 +12283,7 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
 
 	  /* if the two timezones are different, we use the first timezone */
 	  tstz1.timestamp = utime;
-	  tstz1.tz_id = DB_GET_TIMESTAMPTZ (f_value)->tz_id;
+	  tstz1.tz_id = db_get_timestamptz (f_value)->tz_id;
 
 	  error = tz_timestamptz_fix_zone (&tstz1, &tstz2);
 	  if (error != NO_ERROR)
@@ -12292,7 +12292,7 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
 	      goto end;
 	    }
 
-	  DB_MAKE_TIMESTAMPTZ (result, &tstz2);
+	  db_make_timestamptz (result, &tstz2);
 	}
 
       break;
@@ -12302,13 +12302,13 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
     case DB_TYPE_TIMETZ:
       if (type == DB_TYPE_TIMETZ)
 	{
-	  d1 = (double) (DB_GET_TIMETZ (f_value)->time);
-	  d2 = (double) (DB_GET_TIMETZ (c_value)->time);
+	  d1 = (double) (db_get_timetz (f_value)->time);
+	  d2 = (double) (db_get_timetz (c_value)->time);
 	}
       else
 	{
-	  d1 = (double) (*DB_GET_TIME (f_value));
-	  d2 = (double) (*DB_GET_TIME (c_value));
+	  d1 = (double) (*db_get_time (f_value));
+	  d2 = (double) (*db_get_time (c_value));
 	}
 
       d_result = floor ((c_row_num_d - row_num_d) * d1 + (row_num_d - f_row_num_d) * d2);
@@ -12321,7 +12321,7 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
 	}
       else if (type == DB_TYPE_TIMELTZ)
 	{
-	  DB_MAKE_TIMELTZ (result, &time);
+	  db_make_timeltz (result, &time);
 	}
       else
 	{
@@ -12329,7 +12329,7 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
 
 	  /* if the two timezones are different, we use the first timezone */
 	  ttz1.time = time;
-	  ttz1.tz_id = DB_GET_TIMETZ (f_value)->tz_id;
+	  ttz1.tz_id = db_get_timetz (f_value)->tz_id;
 
 	  error = tz_timetz_fix_zone (&ttz1, &ttz2);
 	  if (error != NO_ERROR)
@@ -12338,7 +12338,7 @@ qdata_interpolation_function_values (DB_VALUE * f_value, DB_VALUE * c_value, dou
 	      goto end;
 	    }
 
-	  DB_MAKE_TIMETZ (result, &ttz2);
+	  db_make_timetz (result, &ttz2);
 	}
 
       break;
@@ -12380,8 +12380,8 @@ qdata_get_interpolation_function_result (THREAD_ENTRY * thread_p, QFILE_LIST_SCA
 
   assert (scan_id != NULL && domain != NULL && result != NULL && result_dom != NULL);
 
-  DB_MAKE_NULL (&f_fetch_value);
-  DB_MAKE_NULL (&c_fetch_value);
+  db_make_null (&f_fetch_value);
+  db_make_null (&c_fetch_value);
 
   /* overflow check */
   if (OR_CHECK_BIGINT_OVERFLOW (f_row_num_d))
@@ -13156,7 +13156,7 @@ qdata_save_agg_hentry_to_list (THREAD_ENTRY * thread_p, AGGREGATE_HASH_KEY * key
       list_id->tpl_descr.f_valp[col++] = value->accumulators[i].value;
       list_id->tpl_descr.f_valp[col++] = value->accumulators[i].value2;
 
-      DB_MAKE_INT (&temp_dbval_array[i], value->accumulators[i].curr_cnt);
+      db_make_int (&temp_dbval_array[i], value->accumulators[i].curr_cnt);
       list_id->tpl_descr.f_valp[col++] = &temp_dbval_array[i];
 
       tuple_size += qdata_get_tuple_value_size_from_dbval (value->accumulators[i].value);
@@ -13164,7 +13164,7 @@ qdata_save_agg_hentry_to_list (THREAD_ENTRY * thread_p, AGGREGATE_HASH_KEY * key
       tuple_size += qdata_get_tuple_value_size_from_dbval (&temp_dbval_array[i]);
     }
 
-  DB_MAKE_INT (&tuple_count, value->tuple_count);
+  db_make_int (&tuple_count, value->tuple_count);
   list_id->tpl_descr.f_valp[col++] = &tuple_count;
   tuple_size += qdata_get_tuple_value_size_from_dbval (&tuple_count);
 
@@ -13198,7 +13198,7 @@ qdata_load_agg_hentry_from_tuple (THREAD_ENTRY * thread_p, QFILE_TUPLE tuple, AG
   int i, rc;
 
   /* initialize buffer */
-  DB_MAKE_INT (&int_val, 0);
+  db_make_int (&int_val, 0);
   OR_BUF_INIT (iterator, tuple, QFILE_GET_TUPLE_LENGTH (tuple));
   rc = or_advance (&iterator, QFILE_TUPLE_LENGTH_SIZE);
   if (rc != NO_ERROR)
@@ -13222,7 +13222,7 @@ qdata_load_agg_hentry_from_tuple (THREAD_ENTRY * thread_p, QFILE_TUPLE tuple, AG
 	}
       else
 	{
-	  DB_MAKE_NULL (key->values[i]);
+	  db_make_null (key->values[i]);
 	}
     }
 
@@ -13244,7 +13244,7 @@ qdata_load_agg_hentry_from_tuple (THREAD_ENTRY * thread_p, QFILE_TUPLE tuple, AG
 	}
       else
 	{
-	  DB_MAKE_NULL (value->accumulators[i].value);
+	  db_make_null (value->accumulators[i].value);
 	}
 
       /* read value2 */
@@ -13262,7 +13262,7 @@ qdata_load_agg_hentry_from_tuple (THREAD_ENTRY * thread_p, QFILE_TUPLE tuple, AG
 	}
       else
 	{
-	  DB_MAKE_NULL (value->accumulators[i].value2);
+	  db_make_null (value->accumulators[i].value2);
 	}
 
       /* read tuple count */

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -307,9 +307,9 @@ qdata_is_zero_value_date (DB_VALUE * dbval_p)
     {
       switch (type)
 	{
-	case DB_TYPE_UTIME:
+	case DB_TYPE_TIMESTAMP:
 	case DB_TYPE_TIMESTAMPLTZ:
-	  utime = db_get_utime (dbval_p);
+	  utime = db_get_timestamp (dbval_p);
 	  return (*utime == 0);
 	case DB_TYPE_TIMESTAMPTZ:
 	  ts_tz = db_get_timestamptz (dbval_p);
@@ -1116,7 +1116,7 @@ qdata_add_short_to_utime (DB_VALUE * utime_val_p, short s, DB_VALUE * result_p, 
   DB_BIGINT bigint = 0;
   int d, m, y, h, mi, sec;
 
-  utime = db_get_utime (utime_val_p);
+  utime = db_get_timestamp (utime_val_p);
 
   if (s < 0)
     {
@@ -1172,7 +1172,7 @@ qdata_add_int_to_utime (DB_VALUE * utime_val_p, int i, DB_VALUE * result_p, TP_D
   DB_BIGINT bigint;
   int d, m, y, h, mi, s;
 
-  utime = db_get_utime (utime_val_p);
+  utime = db_get_timestamp (utime_val_p);
 
   if (i < 0)
     {
@@ -1228,7 +1228,7 @@ qdata_add_bigint_to_utime (DB_VALUE * utime_val_p, DB_BIGINT bi, DB_VALUE * resu
   DB_BIGINT bigint;
   int d, m, y, h, mi, s;
 
-  utime = db_get_utime (utime_val_p);
+  utime = db_get_timestamp (utime_val_p);
 
   if (bi < 0)
     {
@@ -1298,14 +1298,14 @@ qdata_add_short_to_timestamptz (DB_VALUE * ts_tz_val_p, short s, DB_VALUE * resu
       db_make_timestamp (&tmp_utime_val, utime);
       err =
 	qdata_add_short_to_utime_asymmetry (&tmp_utime_val, s, &utime, &tmp_utime_val_res,
-					    tp_domain_resolve_default (DB_TYPE_UTIME));
+					    tp_domain_resolve_default (DB_TYPE_TIMESTAMP));
       if (err != NO_ERROR)
 	{
 	  goto exit;
 	}
 
-      assert (DB_VALUE_TYPE (&tmp_utime_val_res) == DB_TYPE_UTIME);
-      utmp = *db_get_utime (&tmp_utime_val_res);
+      assert (DB_VALUE_TYPE (&tmp_utime_val_res) == DB_TYPE_TIMESTAMP);
+      utmp = *db_get_timestamp (&tmp_utime_val_res);
 
       goto return_timestamp_tz;
     }
@@ -1394,14 +1394,14 @@ qdata_add_int_to_timestamptz (DB_VALUE * ts_tz_val_p, int i, DB_VALUE * result_p
       db_make_timestamp (&tmp_utime_val, utime);
       err =
 	qdata_add_int_to_utime_asymmetry (&tmp_utime_val, i, &utime, &tmp_utime_val_res,
-					  tp_domain_resolve_default (DB_TYPE_UTIME));
+					  tp_domain_resolve_default (DB_TYPE_TIMESTAMP));
       if (err != NO_ERROR)
 	{
 	  goto exit;
 	}
 
-      assert (DB_VALUE_TYPE (&tmp_utime_val_res) == DB_TYPE_UTIME);
-      utmp = *db_get_utime (&tmp_utime_val_res);
+      assert (DB_VALUE_TYPE (&tmp_utime_val_res) == DB_TYPE_TIMESTAMP);
+      utmp = *db_get_timestamp (&tmp_utime_val_res);
 
       goto return_timestamp_tz;
     }
@@ -1489,14 +1489,14 @@ qdata_add_bigint_to_timestamptz (DB_VALUE * ts_tz_val_p, DB_BIGINT bi, DB_VALUE 
       db_make_timestamp (&tmp_utime_val, utime);
       err =
 	qdata_add_bigint_to_utime_asymmetry (&tmp_utime_val, bi, &utime, &tmp_utime_val_res,
-					     tp_domain_resolve_default (DB_TYPE_UTIME));
+					     tp_domain_resolve_default (DB_TYPE_TIMESTAMP));
       if (err != NO_ERROR)
 	{
 	  goto exit;
 	}
 
-      assert (DB_VALUE_TYPE (&tmp_utime_val_res) == DB_TYPE_UTIME);
-      utmp = *db_get_utime (&tmp_utime_val_res);
+      assert (DB_VALUE_TYPE (&tmp_utime_val_res) == DB_TYPE_TIMESTAMP);
+      utmp = *db_get_timestamp (&tmp_utime_val_res);
 
       goto return_timestamp_tz;
     }
@@ -1826,13 +1826,13 @@ qdata_add_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VALUE *
     case DB_TYPE_TIMETZ:
       return qdata_add_bigint_to_timetz (dbval_p, (DB_BIGINT) s, result_p);
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       return qdata_add_short_to_utime (dbval_p, s, result_p, domain_p);
 
     case DB_TYPE_TIMESTAMPLTZ:
       {
 	DB_TIMESTAMPTZ ts_tz;
-	ts_tz.timestamp = *db_get_utime (dbval_p);
+	ts_tz.timestamp = *db_get_timestamp (dbval_p);
 
 	err = tz_create_session_tzid_for_timestamp (&ts_tz.timestamp, &ts_tz.tz_id);
 	if (err != NO_ERROR)
@@ -1946,13 +1946,13 @@ qdata_add_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE * res
     case DB_TYPE_TIMETZ:
       return qdata_add_bigint_to_timetz (dbval_p, (DB_BIGINT) i, result_p);
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       return qdata_add_int_to_utime (dbval_p, i, result_p, domain_p);
 
     case DB_TYPE_TIMESTAMPLTZ:
       {
 	DB_TIMESTAMPTZ ts_tz;
-	ts_tz.timestamp = *db_get_utime (dbval_p);
+	ts_tz.timestamp = *db_get_timestamp (dbval_p);
 
 	err = tz_create_session_tzid_for_timestamp (&ts_tz.timestamp, &ts_tz.tz_id);
 	if (err != NO_ERROR)
@@ -2067,13 +2067,13 @@ qdata_add_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_VALUE
     case DB_TYPE_TIMETZ:
       return qdata_add_bigint_to_timetz (dbval_p, bi, result_p);
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       return qdata_add_bigint_to_utime (dbval_p, bi, result_p, domain_p);
 
     case DB_TYPE_TIMESTAMPLTZ:
       {
 	DB_TIMESTAMPTZ ts_tz;
-	ts_tz.timestamp = *db_get_utime (dbval_p);
+	ts_tz.timestamp = *db_get_timestamp (dbval_p);
 
 	err = tz_create_session_tzid_for_timestamp (&ts_tz.timestamp, &ts_tz.tz_id);
 	if (err != NO_ERROR)
@@ -2841,7 +2841,7 @@ qdata_add_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_p, 
       error = qdata_add_timetz_to_dbval (dbval1_p, dbval2_p, result_p);
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       error = qdata_add_utime_to_dbval (dbval1_p, dbval2_p, result_p, domain_p);
       break;
 
@@ -2850,7 +2850,7 @@ qdata_add_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_p, 
 	DB_TIMESTAMPTZ ts_tz, *ts_tz_p;
 	DB_VALUE ts_tz_val, tmp_val_res;
 
-	ts_tz.timestamp = *db_get_utime (dbval1_p);
+	ts_tz.timestamp = *db_get_timestamp (dbval1_p);
 
 	error = tz_create_session_tzid_for_timestamp (&ts_tz.timestamp, &ts_tz.tz_id);
 	if (error != NO_ERROR)
@@ -3019,7 +3019,7 @@ qdata_concatenate_dbval (THREAD_ENTRY * thread_p, DB_VALUE * dbval1_p, DB_VALUE 
     case DB_TYPE_DATETIME:
     case DB_TYPE_DATETIMELTZ:
     case DB_TYPE_DATETIMETZ:
-    case DB_TYPE_TIMESTAMP:	/* == DB_TYPE_UTIME */
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_TIMESTAMPTZ:
     case DB_TYPE_ENUMERATION:
@@ -3512,7 +3512,7 @@ qdata_subtract_short_to_dbval (DB_VALUE * short_val_p, DB_VALUE * dbval_p, DB_VA
 	}
       return err;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_TIMESTAMPTZ:
       db_make_bigint (&tmp_val, (DB_BIGINT) s);
@@ -3598,7 +3598,7 @@ qdata_subtract_int_to_dbval (DB_VALUE * int_val_p, DB_VALUE * dbval_p, DB_VALUE 
     case DB_TYPE_TIME:
     case DB_TYPE_TIMELTZ:
     case DB_TYPE_TIMETZ:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_TIMESTAMPTZ:
       db_make_bigint (&tmp_val, (DB_BIGINT) i);
@@ -3759,9 +3759,9 @@ qdata_subtract_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_
 	  db_make_timetz (result_p, &time_tz_fixed);
 	}
       return err;
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
-      utime = db_get_utime (dbval_p);
+      utime = db_get_timestamp (dbval_p);
       err = qdata_subtract_utime ((DB_UTIME) bi, *utime, result_p);
       if (err != NO_ERROR)
 	{
@@ -3769,7 +3769,7 @@ qdata_subtract_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_
 	}
       if (err == NO_ERROR && type == DB_TYPE_TIMESTAMPLTZ)
 	{
-	  db_make_timestampltz (result_p, *db_get_utime (result_p));
+	  db_make_timestampltz (result_p, *db_get_timestamp (result_p));
 	}
       return err;
 
@@ -3784,7 +3784,7 @@ qdata_subtract_bigint_to_dbval (DB_VALUE * bigint_val_p, DB_VALUE * dbval_p, DB_
 	  {
 	    break;
 	  }
-	ts_tz_res.timestamp = *db_get_utime (result_p);
+	ts_tz_res.timestamp = *db_get_timestamp (result_p);
 	ts_tz_res.tz_id = ts_tz_p->tz_id;
 	err = tz_timestamptz_fix_zone (&ts_tz_res, &ts_tz_fixed);
 	if (err != NO_ERROR)
@@ -4278,7 +4278,7 @@ qdata_subtract_utime_to_dbval (DB_VALUE * utime_val_p, DB_VALUE * dbval_p, DB_VA
   int i2;
   DB_BIGINT bi2;
 
-  utime = db_get_utime (utime_val_p);
+  utime = db_get_timestamp (utime_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
@@ -4316,9 +4316,9 @@ qdata_subtract_utime_to_dbval (DB_VALUE * utime_val_p, DB_VALUE * dbval_p, DB_VA
 
       return qdata_subtract_utime (*utime, (DB_UTIME) bi2, result_p);
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
-      utime1 = db_get_utime (dbval_p);
+      utime1 = db_get_timestamp (dbval_p);
       db_make_int (result_p, ((int) *utime - (int) *utime1));
       break;
 
@@ -4362,7 +4362,7 @@ qdata_subtract_timestampltz_to_dbval (DB_VALUE * ts_ltz_val_p, DB_VALUE * dbval_
   DB_VALUE utime_val, tmp_val_res;
   int err = NO_ERROR;
 
-  utime_p = db_get_utime (ts_ltz_val_p);
+  utime_p = db_get_timestamp (ts_ltz_val_p);
   type = DB_VALUE_DOMAIN_TYPE (dbval_p);
 
   switch (type)
@@ -4370,7 +4370,7 @@ qdata_subtract_timestampltz_to_dbval (DB_VALUE * ts_ltz_val_p, DB_VALUE * dbval_
     case DB_TYPE_SHORT:
     case DB_TYPE_INTEGER:
     case DB_TYPE_BIGINT:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_TIMESTAMPTZ:
     case DB_TYPE_DATETIME:
@@ -4379,15 +4379,16 @@ qdata_subtract_timestampltz_to_dbval (DB_VALUE * ts_ltz_val_p, DB_VALUE * dbval_
       /* perform operation as simple UTIME */
       db_make_timestamp (&utime_val, *utime_p);
       err =
-	qdata_subtract_utime_to_dbval (&utime_val, dbval_p, &tmp_val_res, tp_domain_resolve_default (DB_TYPE_UTIME));
+	qdata_subtract_utime_to_dbval (&utime_val, dbval_p, &tmp_val_res,
+				       tp_domain_resolve_default (DB_TYPE_TIMESTAMP));
       if (err != NO_ERROR)
 	{
 	  break;
 	}
 
-      if (DB_VALUE_TYPE (&tmp_val_res) == DB_TYPE_UTIME)
+      if (DB_VALUE_TYPE (&tmp_val_res) == DB_TYPE_TIMESTAMP)
 	{
-	  db_make_timestampltz (result_p, *db_get_utime (&tmp_val_res));
+	  db_make_timestampltz (result_p, *db_get_timestamp (&tmp_val_res));
 	}
       else
 	{
@@ -4463,9 +4464,9 @@ qdata_subtract_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p,
       err = qdata_subtract_utime (*utime1, (DB_UTIME) bi2, &tmp_val_res);
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
-      utime2 = db_get_utime (dbval_p);
+      utime2 = db_get_timestamp (dbval_p);
       db_make_int (result_p, ((int) *utime1 - (int) *utime2));
       return err;
 
@@ -4517,9 +4518,9 @@ qdata_subtract_timestamptz_to_dbval (DB_VALUE * ts_tz_val_p, DB_VALUE * dbval_p,
 
   if (err == NO_ERROR)
     {
-      assert (DB_VALUE_TYPE (&tmp_val_res) == DB_TYPE_UTIME);
+      assert (DB_VALUE_TYPE (&tmp_val_res) == DB_TYPE_TIMESTAMP);
       /* create TIMESTAMPTZ from result UTIME by adjusting TZ_ID */
-      ts_tz_res.timestamp = *db_get_utime (&tmp_val_res);
+      ts_tz_res.timestamp = *db_get_timestamp (&tmp_val_res);
       ts_tz_res.tz_id = ts_tz1_p->tz_id;
       err = tz_timestamptz_fix_zone (&ts_tz_res, &ts_tz_res_fixed);
       if (err != NO_ERROR)
@@ -4584,12 +4585,12 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
 	return qdata_subtract_datetime_to_int (datetime1_p, bi2, result_p);
       }
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       {
 	DB_BIGINT u1, u2;
 	DB_DATETIME datetime2;
 
-	(void) db_timestamp_decode_ses (db_get_utime (dbval_p), &datetime2.date, &datetime2.time);
+	(void) db_timestamp_decode_ses (db_get_timestamp (dbval_p), &datetime2.date, &datetime2.time);
 
 	u1 = ((DB_BIGINT) datetime1_p->date) * MILLISECONDS_OF_ONE_DAY + datetime1_p->time;
 	u2 = ((DB_BIGINT) datetime2.date) * MILLISECONDS_OF_ONE_DAY + datetime2.time;
@@ -4602,7 +4603,7 @@ qdata_subtract_datetime_to_dbval (DB_VALUE * datetime_val_p, DB_VALUE * dbval_p,
 	DB_BIGINT u1, u2;
 	DB_DATETIME datetime2;
 
-	(void) db_timestamp_decode_ses (db_get_utime (dbval_p), &datetime2.date, &datetime2.time);
+	(void) db_timestamp_decode_ses (db_get_timestamp (dbval_p), &datetime2.date, &datetime2.time);
 
 	u1 = ((DB_BIGINT) datetime1_p->date) * MILLISECONDS_OF_ONE_DAY + datetime1_p->time;
 	u2 = ((DB_BIGINT) datetime2.date) * MILLISECONDS_OF_ONE_DAY + datetime2.time;
@@ -4743,7 +4744,7 @@ qdata_subtract_datetimetz_to_dbval (DB_VALUE * dt_tz_val_p, DB_VALUE * dbval_p, 
 	break;
       }
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_TIMESTAMPTZ:
       {
@@ -4761,7 +4762,7 @@ qdata_subtract_datetimetz_to_dbval (DB_VALUE * dt_tz_val_p, DB_VALUE * dbval_p, 
 	  }
 	else
 	  {
-	    utime2_p = db_get_utime (dbval_p);
+	    utime2_p = db_get_timestamp (dbval_p);
 	  }
 	(void) db_timestamp_decode_utc (utime2_p, &datetime2.date, &datetime2.time);
 
@@ -5178,7 +5179,7 @@ qdata_subtract_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * resul
       error = qdata_subtract_timetz_to_dbval (dbval1_p, dbval2_p, result_p);
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       error = qdata_subtract_utime_to_dbval (dbval1_p, dbval2_p, result_p, domain_p);
       break;
 
@@ -5796,7 +5797,7 @@ qdata_multiply_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * resul
     case DB_TYPE_TIME:
     case DB_TYPE_TIMELTZ:
     case DB_TYPE_TIMETZ:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_TIMESTAMPTZ:
     case DB_TYPE_DATE:
@@ -6387,7 +6388,7 @@ qdata_divide_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_
     case DB_TYPE_TIME:
     case DB_TYPE_TIMELTZ:
     case DB_TYPE_TIMETZ:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
     case DB_TYPE_TIMESTAMPTZ:
     case DB_TYPE_DATETIME:
@@ -6756,12 +6757,12 @@ qdata_strcat_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_
       error = qdata_add_timetz_to_dbval (dbval1_p, dbval2_p, result_p);
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
       error = qdata_add_utime_to_dbval (dbval1_p, dbval2_p, result_p, domain_p);
       if (error == NO_ERROR && type1 == DB_TYPE_TIMESTAMPLTZ)
 	{
-	  db_make_timestampltz (result_p, *db_get_utime (result_p));
+	  db_make_timestampltz (result_p, *db_get_timestamp (result_p));
 	}
       break;
 

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -253,7 +253,7 @@ scan_init_iss (INDX_SCAN_ID * isidp)
   if (!DB_IS_NULL (last_key))
     {
       pr_clear_value (last_key);
-      DB_MAKE_NULL (last_key);
+      db_make_null (last_key);
     }
 
   return NO_ERROR;
@@ -449,7 +449,7 @@ scan_get_next_iss_value (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, INDX_SCAN_I
 	  if (DB_IS_NULL (last_key))
 	    {
 	      pr_clear_value (last_key);
-	      DB_MAKE_NULL (last_key);
+	      db_make_null (last_key);
 
 	      return S_END;
 	    }
@@ -831,7 +831,7 @@ scan_init_index_key_limit (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, KEY_IN
 	}
       else
 	{
-	  isidp->key_limit_lower = DB_GET_BIGINT (dbvalp);
+	  isidp->key_limit_lower = db_get_bigint (dbvalp);
 	}
 
       if (isidp->key_limit_lower < 0)
@@ -882,7 +882,7 @@ scan_init_index_key_limit (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, KEY_IN
 	}
       else
 	{
-	  isidp->key_limit_upper = DB_GET_BIGINT (dbvalp);
+	  isidp->key_limit_upper = db_get_bigint (dbvalp);
 	}
 
       if (isidp->key_limit_upper < 0)
@@ -1165,7 +1165,7 @@ scan_key_compare (DB_VALUE * val1, DB_VALUE * val2, int num_index_term)
       if (key_type == DB_TYPE_MIDXKEY)
 	{
 	  rc =
-	    pr_midxkey_compare (DB_GET_MIDXKEY (val1), DB_GET_MIDXKEY (val2), 1, 1, num_index_term, NULL, &dummy_size1,
+	    pr_midxkey_compare (db_get_midxkey (val1), db_get_midxkey (val2), 1, 1, num_index_term, NULL, &dummy_size1,
 				&dummy_size2, &dummy_diff_column, &dummy_dom_is_desc, &dummy_next_dom_is_desc);
 	}
       else
@@ -1398,7 +1398,7 @@ merge_key_ranges (KEY_VAL_RANGE * key_vals, int key_cnt)
 	    {
 	      pr_clear_value (&curp->key1);
 	      curp->key1 = nextp->key1;	/* bitwise copy */
-	      DB_MAKE_NULL (&nextp->key1);
+	      db_make_null (&nextp->key1);
 	      cur_op1 = next_op1;
 	    }
 	  else
@@ -1411,7 +1411,7 @@ merge_key_ranges (KEY_VAL_RANGE * key_vals, int key_cnt)
 	    {
 	      pr_clear_value (&curp->key2);
 	      curp->key2 = nextp->key2;	/* bitwise copy */
-	      DB_MAKE_NULL (&nextp->key2);
+	      db_make_null (&nextp->key2);
 	      cur_op2 = next_op2;
 	    }
 	  else
@@ -2216,8 +2216,8 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
 	{
 	  /* initialize DB_VALUE first for error case */
 	  key_vals[i].range = NA_NA;
-	  DB_MAKE_NULL (&key_vals[i].key1);
-	  DB_MAKE_NULL (&key_vals[i].key2);
+	  db_make_null (&key_vals[i].key1);
+	  db_make_null (&key_vals[i].key2);
 	  key_vals[i].is_truncated = false;
 	  key_vals[i].num_index_term = 0;
 	}
@@ -3949,7 +3949,7 @@ scan_start_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	      /* initialize cache_recordinfo values */
 	      for (i = 0; i < HEAP_RECORD_INFO_COUNT; i++)
 		{
-		  DB_MAKE_NULL (hsidp->cache_recordinfo[i]);
+		  db_make_null (hsidp->cache_recordinfo[i]);
 		}
 	    }
 	  hsidp->caches_inited = true;
@@ -4081,7 +4081,7 @@ scan_start_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	{
 	  for (i = 0; i < BTREE_KEY_INFO_COUNT; i++)
 	    {
-	      DB_MAKE_NULL (isidp->key_info_values[i]);
+	      db_make_null (isidp->key_info_values[i]);
 	    }
 	}
       isidp->caches_inited = true;
@@ -4097,7 +4097,7 @@ scan_start_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	{
 	  for (i = 0; i < BTREE_NODE_INFO_COUNT; i++)
 	    {
-	      DB_MAKE_NULL (insidp->node_info_values[i]);
+	      db_make_null (insidp->node_info_values[i]);
 	    }
 	  insidp->caches_inited = true;
 	}
@@ -4140,7 +4140,7 @@ scan_start_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
     case S_SET_SCAN:
       ssidp = &scan_id->s.ssid;
-      DB_MAKE_NULL (&ssidp->set);
+      db_make_null (&ssidp->set);
       break;
 
     case S_METHOD_SCAN:

--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -422,7 +422,7 @@ serial_get_next_cached_value (THREAD_ENTRY * thread_p, SERIAL_CACHE_ENTRY * entr
 	{
 	  return error;
 	}
-      if (DB_GET_INT (&cmp_result) == 0)
+      if (db_get_int (&cmp_result) == 0)
 	{
 	  /* entry is cached to number of cached_num */
 	  exhausted = true;
@@ -440,7 +440,7 @@ serial_get_next_cached_value (THREAD_ENTRY * thread_p, SERIAL_CACHE_ENTRY * entr
 	  return error;
 	}
 
-      if (DB_GET_INT (&cmp_result) >= 0)
+      if (db_get_int (&cmp_result) >= 0)
 	{
 	  exhausted = true;
 	}
@@ -505,7 +505,7 @@ serial_update_cur_val_of_serial (THREAD_ENTRY * thread_p, SERIAL_CACHE_ENTRY * e
   ATTR_ID attrid;
   OID serial_class_oid;
 
-  DB_MAKE_NULL (&key_val);
+  db_make_null (&key_val);
 
   CHECK_MODIFICATION_NO_RETURN (thread_p, ret);
   if (ret != NO_ERROR)
@@ -619,7 +619,7 @@ xserial_get_next_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_num,
   ATTR_ID attrid;
   OID serial_class_oid;
 
-  DB_MAKE_NULL (&key_val);
+  db_make_null (&key_val);
 
   oid_get_serial_oid (&serial_class_oid);
   heap_scancache_quick_start_modify_with_class_oid (thread_p, &scan_cache, &serial_class_oid);
@@ -658,7 +658,7 @@ xserial_get_next_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_num,
   else
     {
       val = heap_attrinfo_access (attrid, attr_info_p);
-      cached_num = DB_GET_INT (val);
+      cached_num = db_get_int (val);
     }
 
   attrid = serial_get_attrid (thread_p, SERIAL_ATTR_NAME_INDEX);
@@ -696,12 +696,12 @@ xserial_get_next_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_num,
   val = heap_attrinfo_access (attrid, attr_info_p);
   PR_SHARE_VALUE (val, &started);
 
-  DB_MAKE_NULL (&last_val);
+  db_make_null (&last_val);
 
-  if (DB_GET_INT (&started) == 0)
+  if (db_get_int (&started) == 0)
     {
       /* This is the first time to generate the serial value. */
-      DB_MAKE_INT (&started, 1);
+      db_make_int (&started, 1);
       attrid = serial_get_attrid (thread_p, SERIAL_ATTR_STARTED_INDEX);
       assert (attrid != NOT_FOUND);
       ret = heap_attrinfo_set (serial_oidp, attrid, &started, attr_info_p);
@@ -953,7 +953,7 @@ serial_get_nth_value (DB_VALUE * inc_val, DB_VALUE * cur_val, DB_VALUE * min_val
   if (nth > 1)
     {
       numeric_coerce_int_to_num (nth, num);
-      DB_MAKE_NUMERIC (&tmp_val, num, DB_MAX_NUMERIC_PRECISION, 0);
+      db_make_numeric (&tmp_val, num, DB_MAX_NUMERIC_PRECISION, 0);
       numeric_db_value_mul (inc_val, &tmp_val, &add_val);
     }
   else
@@ -976,9 +976,9 @@ serial_get_nth_value (DB_VALUE * inc_val, DB_VALUE * cur_val, DB_VALUE * min_val
 	}
 
       /* cur_val + inc_val * cached_num > max_val */
-      if (DB_GET_INT (&cmp_result) > 0)
+      if (db_get_int (&cmp_result) > 0)
 	{
-	  if (DB_GET_INT (cyclic))
+	  if (db_get_int (cyclic))
 	    {
 	      PR_SHARE_VALUE (min_val, result_val);
 	    }
@@ -1007,9 +1007,9 @@ serial_get_nth_value (DB_VALUE * inc_val, DB_VALUE * cur_val, DB_VALUE * min_val
 	}
 
       /* cur_val + inc_val * cached_num < min_val */
-      if (DB_GET_INT (&cmp_result) < 0)
+      if (db_get_int (&cmp_result) < 0)
 	{
-	  if (DB_GET_INT (cyclic))
+	  if (db_get_int (cyclic))
 	    {
 	      PR_SHARE_VALUE (max_val, result_val);
 	    }

--- a/src/query/set_scan.c
+++ b/src/query/set_scan.c
@@ -103,7 +103,7 @@ qproc_next_set_scan (THREAD_ENTRY * thread_p, SCAN_ID * s_id)
 	{
 	  return S_END;
 	}
-      setp = DB_GET_SET (&set_id->set);
+      setp = db_get_set (&set_id->set);
       if (!setp)
 	{
 	  return S_END;

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -6925,7 +6925,7 @@ stx_init_analytic_type_unserialized_fields (ANALYTIC_TYPE * analytic)
   analytic->is_first_exec_time = true;
 
   /* part_value */
-  DB_MAKE_NULL (&analytic->part_value);
+  db_make_null (&analytic->part_value);
 
   /* curr_cnt */
   analytic->curr_cnt = 0;

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -67,7 +67,7 @@
 #define BYTE_SIZE               (8)
 #define QSTR_VALUE_PRECISION(value)                                       \
             ((DB_VALUE_PRECISION(value) == TP_FLOATING_PRECISION_VALUE)  \
-                     ?      DB_GET_STRING_LENGTH(value)       :          \
+                     ?      db_get_string_length(value)       :          \
                             DB_VALUE_PRECISION(value))
 
 #define QSTR_MAX_PRECISION(str_type)                                         \
@@ -380,7 +380,7 @@ db_string_compare (const DB_VALUE * string1, const DB_VALUE * string2, DB_VALUE 
     {
       cmp_result = 0;
     }
-  else if (DB_GET_STRING_CODESET (string1) != DB_GET_STRING_CODESET (string2))
+  else if (db_get_string_codeset (string1) != db_get_string_codeset (string2))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INCOMPATIBLE_CODE_SETS, 0);
       return ER_QSTR_INCOMPATIBLE_CODE_SETS;
@@ -394,9 +394,9 @@ db_string_compare (const DB_VALUE * string1, const DB_VALUE * string2, DB_VALUE 
 	case QSTR_CHAR:
 	case QSTR_NATIONAL_CHAR:
 
-	  assert (DB_GET_STRING_CODESET (string1) == DB_GET_STRING_CODESET (string2));
+	  assert (db_get_string_codeset (string1) == db_get_string_codeset (string2));
 
-	  LANG_RT_COMMON_COLL (DB_GET_STRING_COLLATION (string1), DB_GET_STRING_COLLATION (string2), coll_id);
+	  LANG_RT_COMMON_COLL (db_get_string_collation (string1), db_get_string_collation (string2), coll_id);
 
 	  if (coll_id == -1)
 	    {
@@ -404,17 +404,17 @@ db_string_compare (const DB_VALUE * string1, const DB_VALUE * string2, DB_VALUE 
 	      return ER_QSTR_INCOMPATIBLE_COLLATIONS;
 	    }
 
-	  coll_id = DB_GET_STRING_COLLATION (string1);
-	  assert (DB_GET_STRING_COLLATION (string1) == DB_GET_STRING_COLLATION (string2));
+	  coll_id = db_get_string_collation (string1);
+	  assert (db_get_string_collation (string1) == db_get_string_collation (string2));
 
 	  cmp_result =
-	    QSTR_COMPARE (coll_id, (unsigned char *) DB_GET_STRING (string1), (int) DB_GET_STRING_SIZE (string1),
-			  (unsigned char *) DB_GET_STRING (string2), (int) DB_GET_STRING_SIZE (string2));
+	    QSTR_COMPARE (coll_id, (unsigned char *) db_get_string (string1), (int) db_get_string_size (string1),
+			  (unsigned char *) db_get_string (string2), (int) db_get_string_size (string2));
 	  break;
 	case QSTR_BIT:
 	  cmp_result =
-	    varbit_compare ((unsigned char *) DB_GET_STRING (string1), (int) DB_GET_STRING_SIZE (string1),
-			    (unsigned char *) DB_GET_STRING (string2), (int) DB_GET_STRING_SIZE (string2));
+	    varbit_compare ((unsigned char *) db_get_string (string1), (int) db_get_string_size (string1),
+			    (unsigned char *) db_get_string (string2), (int) db_get_string_size (string2));
 	  break;
 	default:		/* QSTR_UNKNOWN */
 	  break;
@@ -429,7 +429,7 @@ db_string_compare (const DB_VALUE * string1, const DB_VALUE * string2, DB_VALUE 
     {
       cmp_result = 1;
     }
-  DB_MAKE_INTEGER (result, cmp_result);
+  db_make_int (result, cmp_result);
 
   return NO_ERROR;
 }
@@ -484,9 +484,9 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
 
   error_status = db_string_compare (db_string1, db_string2, &tmp_result);
   if ((error_status != NO_ERROR)
-      || ((c = DB_GET_INTEGER (&tmp_result)) && ((!key_domain->is_desc && c > 0) || (key_domain->is_desc && c < 0))))
+      || ((c = db_get_int (&tmp_result)) && ((!key_domain->is_desc && c > 0) || (key_domain->is_desc && c < 0))))
     {
-      DB_MAKE_NULL (db_result);
+      db_make_null (db_result);
 #if defined(CUBRID_DEBUG)
       if (error_status == ER_QSTR_INVALID_DATA_TYPE)
 	{
@@ -498,10 +498,10 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
 	  printf ("db_string_unique_prefix(): incompatible types: %s and %s\n",
 		  pr_type_name (DB_VALUE_DOMAIN_TYPE (db_string1)), pr_type_name (DB_VALUE_DOMAIN_TYPE (db_string2)));
 	}
-      if (DB_GET_INTEGER (&tmp_result) > 0)
+      if (db_get_int (&tmp_result) > 0)
 	{
-	  printf ("db_string_unique_prefix(): string1 %s, greater than string2 %s\n", DB_GET_STRING (db_string1),
-		  DB_GET_STRING (db_string2));
+	  printf ("db_string_unique_prefix(): string1 %s, greater than string2 %s\n", db_get_string (db_string1),
+		  db_get_string (db_string2));
 	}
 #endif
       return ER_GENERIC_ERROR;
@@ -524,7 +524,7 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
     }
   else
     {
-      DB_MAKE_NULL (db_result);
+      db_make_null (db_result);
 #if defined(CUBRID_DEBUG)
       printf ("db_string_unique_prefix(): non-string type: %s and %s\n",
 	      pr_type_name (DB_VALUE_DOMAIN_TYPE (db_string1)), pr_type_name (DB_VALUE_DOMAIN_TYPE (db_string2)));
@@ -549,14 +549,14 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
       int collation_id;
       bool bit_use_str2_size = false;
 
-      string1 = (unsigned char *) DB_GET_STRING (db_string1);
-      size1 = (int) DB_GET_STRING_SIZE (db_string1);
-      string2 = (unsigned char *) DB_GET_STRING (db_string2);
-      size2 = (int) DB_GET_STRING_SIZE (db_string2);
-      codeset = DB_GET_STRING_CODESET (db_string1);
-      collation_id = DB_GET_STRING_COLLATION (db_string1);
+      string1 = (unsigned char *) db_get_string (db_string1);
+      size1 = (int) db_get_string_size (db_string1);
+      string2 = (unsigned char *) db_get_string (db_string2);
+      size2 = (int) db_get_string_size (db_string2);
+      codeset = db_get_string_codeset (db_string1);
+      collation_id = db_get_string_collation (db_string1);
 
-      assert (collation_id == DB_GET_STRING_COLLATION (db_string2));
+      assert (collation_id == db_get_string_collation (db_string2));
 
       if (result_type == DB_TYPE_VARBIT)
 	{
@@ -706,12 +706,12 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
       err_status2 = db_string_compare (db_string1, db_result, &tmp_result);
       if (err_status2 == NO_ERROR)
 	{
-	  c1 = DB_GET_INTEGER (&tmp_result);
+	  c1 = db_get_int (&tmp_result);
 	}
       err_status2 = db_string_compare (db_result, db_string2, &tmp_result);
       if (err_status2 == NO_ERROR)
 	{
-	  c2 = DB_GET_INTEGER (&tmp_result);
+	  c2 = db_get_int (&tmp_result);
 	}
 
       if (!key_domain->is_desc)
@@ -760,7 +760,7 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
   else
     {
       result_type = DB_TYPE_NULL;
-      DB_MAKE_NULL (db_result);
+      db_make_null (db_result);
 #if defined(CUBRID_DEBUG)
       printf ("db_string_unique_prefix called with non-string type: %s\n", pr_type_name (string_type));
 #endif
@@ -782,14 +782,14 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
    */
   else
     {
-      int string1_size = DB_GET_STRING_SIZE (db_string1);
-      int string2_size = DB_GET_STRING_SIZE (db_string2);
-      const unsigned char *string1 = (const unsigned char *) DB_GET_STRING (db_string1);
-      const unsigned char *string2 = (const unsigned char *) DB_GET_STRING (db_string2);
+      int string1_size = db_get_string_size (db_string1);
+      int string2_size = db_get_string_size (db_string2);
+      const unsigned char *string1 = (const unsigned char *) db_get_string (db_string1);
+      const unsigned char *string2 = (const unsigned char *) db_get_string (db_string2);
       unsigned char *result;
       const unsigned char *key;
       int result_size;
-      INTL_CODESET codeset = DB_GET_STRING_CODESET ((DB_VALUE *) db_string1);
+      INTL_CODESET codeset = db_get_string_codeset ((DB_VALUE *) db_string1);
 
       /* We need to implicitly trim both strings since we don't want padding for the result (its of varying type) and
        * since padding can mask the logical end of both of the strings.  We need to be careful how the trimming is
@@ -1104,9 +1104,9 @@ db_string_concatenate (const DB_VALUE * string1, const DB_VALUE * string2, DB_VA
 	  int result_domain_length;
 
 	  error_status =
-	    qstr_bit_concatenate ((unsigned char *) DB_GET_STRING (string1), (int) DB_GET_STRING_LENGTH (string1),
+	    qstr_bit_concatenate ((unsigned char *) db_get_string (string1), (int) db_get_string_length (string1),
 				  (int) QSTR_VALUE_PRECISION (string1), DB_VALUE_DOMAIN_TYPE (string1),
-				  (unsigned char *) DB_GET_STRING (string2), (int) DB_GET_STRING_LENGTH (string2),
+				  (unsigned char *) db_get_string (string2), (int) db_get_string_length (string2),
 				  (int) QSTR_VALUE_PRECISION (string2), DB_VALUE_DOMAIN_TYPE (string2), &r, &r_length,
 				  &r_size, &r_type, data_status);
 
@@ -1124,7 +1124,7 @@ db_string_concatenate (const DB_VALUE * string1, const DB_VALUE * string2, DB_VA
 		}
 
 	      qstr_make_typed_string (r_type, result, result_domain_length, (char *) r, r_length,
-				      DB_GET_STRING_CODESET (string1), DB_GET_STRING_COLLATION (string1));
+				      db_get_string_codeset (string1), db_get_string_collation (string1));
 	      result->need_clear = true;
 	    }
 	}
@@ -1133,24 +1133,24 @@ db_string_concatenate (const DB_VALUE * string1, const DB_VALUE * string2, DB_VA
 	  DB_VALUE temp;
 	  int result_domain_length;
 	  int common_coll;
-	  INTL_CODESET codeset = DB_GET_STRING_CODESET (string1);
+	  INTL_CODESET codeset = db_get_string_codeset (string1);
 
-	  DB_MAKE_NULL (&temp);
+	  db_make_null (&temp);
 
-	  LANG_RT_COMMON_COLL (DB_GET_STRING_COLLATION (string1), DB_GET_STRING_COLLATION (string2), common_coll);
+	  LANG_RT_COMMON_COLL (db_get_string_collation (string1), db_get_string_collation (string2), common_coll);
 	  if (common_coll == -1)
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INCOMPATIBLE_COLLATIONS, 0);
 	      return ER_QSTR_INCOMPATIBLE_COLLATIONS;
 	    }
 
-	  if (DB_GET_STRING_CODESET (string1) != DB_GET_STRING_CODESET (string2))
+	  if (db_get_string_codeset (string1) != db_get_string_codeset (string2))
 	    {
 	      DB_DATA_STATUS data_status;
 
 	      codeset = lang_get_collation (common_coll)->codeset;
 
-	      if (DB_GET_STRING_CODESET (string1) != codeset)
+	      if (db_get_string_codeset (string1) != codeset)
 		{
 		  db_value_domain_init (&temp, string_type1, (int) QSTR_VALUE_PRECISION (string1), 0);
 
@@ -1169,7 +1169,7 @@ db_string_concatenate (const DB_VALUE * string1, const DB_VALUE * string2, DB_VA
 		}
 	      else
 		{
-		  assert (DB_GET_STRING_CODESET (string2) != codeset);
+		  assert (db_get_string_codeset (string2) != codeset);
 
 		  db_value_domain_init (&temp, string_type2, (int) QSTR_VALUE_PRECISION (string2), 0);
 
@@ -1189,9 +1189,9 @@ db_string_concatenate (const DB_VALUE * string1, const DB_VALUE * string2, DB_VA
 	    }
 
 	  error_status =
-	    qstr_concatenate ((unsigned char *) DB_GET_STRING (string1), (int) DB_GET_STRING_LENGTH (string1),
+	    qstr_concatenate ((unsigned char *) db_get_string (string1), (int) db_get_string_length (string1),
 			      (int) QSTR_VALUE_PRECISION (string1), DB_VALUE_DOMAIN_TYPE (string1),
-			      (unsigned char *) DB_GET_STRING (string2), (int) DB_GET_STRING_LENGTH (string2),
+			      (unsigned char *) db_get_string (string2), (int) db_get_string_length (string2),
 			      (int) QSTR_VALUE_PRECISION (string2), DB_VALUE_DOMAIN_TYPE (string2), codeset, &r,
 			      &r_length, &r_size, &r_type, data_status);
 
@@ -1263,7 +1263,7 @@ db_string_chr (DB_VALUE * res, DB_VALUE * dbval1, DB_VALUE * dbval2)
 
   assert (DB_VALUE_DOMAIN_TYPE (dbval2) == DB_TYPE_INTEGER);
 
-  codeset = DB_GET_INTEGER (dbval2);
+  codeset = db_get_int (dbval2);
   if (codeset != INTL_CODESET_UTF8 && codeset != INTL_CODESET_ISO88591 && codeset != INTL_CODESET_KSC5601_EUC
       && codeset != INTL_CODESET_BINARY)
     {
@@ -1276,25 +1276,25 @@ db_string_chr (DB_VALUE * res, DB_VALUE * dbval1, DB_VALUE * dbval2)
   switch (arg_type)
     {
     case DB_TYPE_SHORT:
-      itmp = DB_GET_SHORT (dbval1);
+      itmp = db_get_short (dbval1);
       break;
     case DB_TYPE_INTEGER:
-      itmp = DB_GET_INTEGER (dbval1);
+      itmp = db_get_int (dbval1);
       break;
     case DB_TYPE_BIGINT:
-      bi = DB_GET_BIGINT (dbval1);
+      bi = db_get_bigint (dbval1);
       break;
     case DB_TYPE_FLOAT:
-      dtmp = DB_GET_FLOAT (dbval1);
+      dtmp = db_get_float (dbval1);
       break;
     case DB_TYPE_DOUBLE:
-      dtmp = DB_GET_DOUBLE (dbval1);
+      dtmp = db_get_double (dbval1);
       break;
     case DB_TYPE_NUMERIC:
       numeric_coerce_num_to_double (db_locate_numeric (dbval1), DB_VALUE_SCALE (dbval1), &dtmp);
       break;
     case DB_TYPE_MONETARY:
-      dtmp = (DB_GET_MONETARY (dbval1))->amount;
+      dtmp = (db_get_monetary (dbval1))->amount;
       break;
     default:
       assert (false);
@@ -1351,7 +1351,7 @@ db_string_chr (DB_VALUE * res, DB_VALUE * dbval1, DB_VALUE * dbval2)
       || (codeset == INTL_CODESET_KSC5601_EUC
 	  && intl_check_euckr ((const unsigned char *) num_as_bytes, num_byte_count, &invalid_pos) != INTL_UTF8_VALID))
     {
-      DB_MAKE_NULL (res);
+      db_make_null (res);
       db_private_free (NULL, num_as_bytes);
 
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
@@ -1423,7 +1423,7 @@ db_string_instr (const DB_VALUE * src_string, const DB_VALUE * sub_string, const
 
   if (DB_IS_NULL (src_string) || DB_IS_NULL (sub_string) || DB_IS_NULL (start_pos))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
   else
     {
@@ -1437,7 +1437,7 @@ db_string_instr (const DB_VALUE * src_string, const DB_VALUE * sub_string, const
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
 	}
       else if (qstr_get_category (src_string) != qstr_get_category (sub_string)
-	       || (DB_GET_STRING_CODESET (src_string) != DB_GET_STRING_CODESET (sub_string)))
+	       || (db_get_string_codeset (src_string) != db_get_string_codeset (sub_string)))
 	{
 	  error_status = ER_QSTR_INCOMPATIBLE_CODE_SETS;
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -1447,31 +1447,31 @@ db_string_instr (const DB_VALUE * src_string, const DB_VALUE * sub_string, const
 	  int position = 0;
 	  int src_str_len;
 	  int sub_str_len;
-	  int offset = DB_GET_INT (start_pos);
-	  INTL_CODESET codeset = (INTL_CODESET) DB_GET_STRING_CODESET (src_string);
+	  int offset = db_get_int (start_pos);
+	  INTL_CODESET codeset = (INTL_CODESET) db_get_string_codeset (src_string);
 	  char *search_from, *src_buf, *sub_str;
 	  int coll_id;
-	  int sub_str_size = DB_GET_STRING_SIZE (sub_string);
+	  int sub_str_size = db_get_string_size (sub_string);
 	  int from_byte_offset;
-	  int src_size = DB_GET_STRING_SIZE (src_string);
+	  int src_size = db_get_string_size (src_string);
 
-	  LANG_RT_COMMON_COLL (DB_GET_STRING_COLLATION (src_string), DB_GET_STRING_COLLATION (sub_string), coll_id);
+	  LANG_RT_COMMON_COLL (db_get_string_collation (src_string), db_get_string_collation (sub_string), coll_id);
 	  if (coll_id == -1)
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INCOMPATIBLE_COLLATIONS, 0);
 	      return ER_QSTR_INCOMPATIBLE_COLLATIONS;
 	    }
 
-	  src_str_len = DB_GET_STRING_LENGTH (src_string);
-	  sub_str_len = DB_GET_STRING_LENGTH (sub_string);
+	  src_str_len = db_get_string_length (src_string);
+	  sub_str_len = db_get_string_length (sub_string);
 
-	  src_buf = DB_GET_STRING (src_string);
+	  src_buf = db_get_string (src_string);
 	  if (src_size < 0)
 	    {
 	      src_size = strlen (src_buf);
 	    }
 
-	  sub_str = DB_GET_STRING (sub_string);
+	  sub_str = db_get_string (sub_string);
 	  if (sub_str_size < 0)
 	    {
 	      sub_str_size = strlen (sub_str);
@@ -1534,7 +1534,7 @@ db_string_instr (const DB_VALUE * src_string, const DB_VALUE * sub_string, const
 
 	  if (error_status == NO_ERROR)
 	    {
-	      DB_MAKE_INTEGER (result, position);
+	      db_make_int (result, position);
 	    }
 	}
     }
@@ -1565,7 +1565,7 @@ db_string_space (DB_VALUE const *count, DB_VALUE * result)
 
   if (DB_IS_NULL (count))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
   else
@@ -1576,13 +1576,13 @@ db_string_space (DB_VALUE const *count, DB_VALUE * result)
       switch (DB_VALUE_DOMAIN_TYPE (count))
 	{
 	case DB_TYPE_SMALLINT:
-	  len = DB_GET_SMALLINT (count);
+	  len = db_get_short (count);
 	  break;
 	case DB_TYPE_INTEGER:
-	  len = DB_GET_INTEGER (count);
+	  len = db_get_int (count);
 	  break;
 	case DB_TYPE_BIGINT:
-	  len = (int) DB_GET_BIGINT (count);
+	  len = (int) db_get_bigint (count);
 	  break;
 	default:
 	  return ER_QSTR_INVALID_DATA_TYPE;
@@ -1597,7 +1597,7 @@ db_string_space (DB_VALUE const *count, DB_VALUE * result)
 	{
 	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_QPROC_STRING_SIZE_TOO_BIG, 2, len,
 		  (int) prm_get_bigint_value (PRM_ID_STRING_MAX_SIZE_BYTES));
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	  return NO_ERROR;
 	}
 
@@ -1676,7 +1676,7 @@ db_string_position (const DB_VALUE * sub_string, const DB_VALUE * src_string, DB
 
   if (DB_IS_NULL (sub_string) || DB_IS_NULL (src_string))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
   else if (!QSTR_IS_ANY_CHAR_OR_BIT (str1_type) || !QSTR_IS_ANY_CHAR_OR_BIT (str2_type))
     {
@@ -1684,7 +1684,7 @@ db_string_position (const DB_VALUE * sub_string, const DB_VALUE * src_string, DB
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
     }
   else if ((qstr_get_category (sub_string) != qstr_get_category (src_string))
-	   || (DB_GET_STRING_CODESET (src_string) != DB_GET_STRING_CODESET (sub_string)))
+	   || (db_get_string_codeset (src_string) != db_get_string_codeset (sub_string)))
     {
       error_status = ER_QSTR_INCOMPATIBLE_CODE_SETS;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -1696,13 +1696,13 @@ db_string_position (const DB_VALUE * sub_string, const DB_VALUE * src_string, DB
 
       if (QSTR_IS_CHAR (src_type) || QSTR_IS_NATIONAL_CHAR (src_type))
 	{
-	  char *src_str = DB_GET_STRING (src_string);
-	  int src_size = DB_GET_STRING_SIZE (src_string);
-	  char *sub_str = DB_GET_STRING (sub_string);
-	  int sub_size = DB_GET_STRING_SIZE (sub_string);
+	  char *src_str = db_get_string (src_string);
+	  int src_size = db_get_string_size (src_string);
+	  char *sub_str = db_get_string (sub_string);
+	  int sub_size = db_get_string_size (sub_string);
 	  int coll_id;
 
-	  LANG_RT_COMMON_COLL (DB_GET_STRING_COLLATION (src_string), DB_GET_STRING_COLLATION (sub_string), coll_id);
+	  LANG_RT_COMMON_COLL (db_get_string_collation (src_string), db_get_string_collation (sub_string), coll_id);
 	  if (coll_id == -1)
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INCOMPATIBLE_COLLATIONS, 0);
@@ -1720,20 +1720,20 @@ db_string_position (const DB_VALUE * sub_string, const DB_VALUE * src_string, DB
 	    }
 
 	  error_status =
-	    qstr_position (sub_str, sub_size, DB_GET_STRING_LENGTH (sub_string), src_str, src_str + src_size,
-			   src_str + src_size, DB_GET_STRING_LENGTH (src_string), coll_id, true, &position);
+	    qstr_position (sub_str, sub_size, db_get_string_length (sub_string), src_str, src_str + src_size,
+			   src_str + src_size, db_get_string_length (src_string), coll_id, true, &position);
 	}
       else
 	{
 	  error_status =
-	    qstr_bit_position ((unsigned char *) DB_GET_STRING (sub_string), DB_GET_STRING_LENGTH (sub_string),
-			       (unsigned char *) DB_GET_STRING (src_string), DB_GET_STRING_LENGTH (src_string),
+	    qstr_bit_position ((unsigned char *) db_get_string (sub_string), db_get_string_length (sub_string),
+			       (unsigned char *) db_get_string (src_string), db_get_string_length (src_string),
 			       &position);
 	}
 
       if (error_status == NO_ERROR)
 	{
-	  DB_MAKE_INTEGER (result, position);
+	  db_make_int (result, position);
 	}
     }
 
@@ -1802,7 +1802,7 @@ db_string_substring (const MISC_OPERAND substr_operand, const DB_VALUE * src_str
 #if defined(SERVER_MODE)
       assert (DB_IS_NULL (sub_string));
 #endif
-      DB_MAKE_NULL (sub_string);
+      db_make_null (sub_string);
     }
   else
     {
@@ -1821,7 +1821,7 @@ db_string_substring (const MISC_OPERAND substr_operand, const DB_VALUE * src_str
 
 	  if (!extraction_length_is_null)
 	    {
-	      extract_nchars = (int) DB_GET_INTEGER (extraction_length);
+	      extract_nchars = (int) db_get_int (extraction_length);
 	    }
 
 	  /* Initialize the memory manager of the substring */
@@ -1829,9 +1829,9 @@ db_string_substring (const MISC_OPERAND substr_operand, const DB_VALUE * src_str
 	    {
 	      int sub_size = 0;
 
-	      unsigned char *string = (unsigned char *) DB_GET_STRING (src_string);
-	      int start_offset = DB_GET_INTEGER (start_position);
-	      int string_len = DB_GET_STRING_LENGTH (src_string);
+	      unsigned char *string = (unsigned char *) db_get_string (src_string);
+	      int start_offset = db_get_int (start_position);
+	      int string_len = db_get_string_length (src_string);
 
 	      if (extraction_length_is_null)
 		{
@@ -1848,7 +1848,7 @@ db_string_substring (const MISC_OPERAND substr_operand, const DB_VALUE * src_str
 		  if (start_offset < 0)
 		    {
 		      int byte_pos;
-		      (void) intl_char_size (string, string_len + start_offset, DB_GET_STRING_CODESET (src_string),
+		      (void) intl_char_size (string, string_len + start_offset, db_get_string_codeset (src_string),
 					     &byte_pos);
 		      string += byte_pos;
 		      string_len = -start_offset;
@@ -1856,13 +1856,13 @@ db_string_substring (const MISC_OPERAND substr_operand, const DB_VALUE * src_str
 		}
 
 	      error_status =
-		qstr_substring (string, string_len, start_offset, extract_nchars, DB_GET_STRING_CODESET (src_string),
+		qstr_substring (string, string_len, start_offset, extract_nchars, db_get_string_codeset (src_string),
 				&sub, &sub_length, &sub_size);
 	      if (error_status == NO_ERROR && sub != NULL)
 		{
 		  qstr_make_typed_string (result_type, sub_string, DB_VALUE_PRECISION (src_string), (char *) sub,
-					  sub_size, DB_GET_STRING_CODESET (src_string),
-					  DB_GET_STRING_COLLATION (src_string));
+					  sub_size, db_get_string_codeset (src_string),
+					  db_get_string_collation (src_string));
 		  sub[sub_size] = 0;
 		  sub_string->need_clear = true;
 		}
@@ -1870,14 +1870,14 @@ db_string_substring (const MISC_OPERAND substr_operand, const DB_VALUE * src_str
 	  else
 	    {
 	      error_status =
-		qstr_bit_substring ((unsigned char *) DB_GET_STRING (src_string),
-				    (int) DB_GET_STRING_LENGTH (src_string), (int) DB_GET_INTEGER (start_position),
+		qstr_bit_substring ((unsigned char *) db_get_string (src_string),
+				    (int) db_get_string_length (src_string), (int) db_get_int (start_position),
 				    extract_nchars, &sub, &sub_length);
 	      if (error_status == NO_ERROR)
 		{
 		  qstr_make_typed_string (result_type, sub_string, DB_VALUE_PRECISION (src_string), (char *) sub,
-					  sub_length, DB_GET_STRING_CODESET (src_string),
-					  DB_GET_STRING_COLLATION (src_string));
+					  sub_length, db_get_string_codeset (src_string),
+					  db_get_string_collation (src_string));
 		  sub_string->need_clear = true;
 		}
 	    }
@@ -1923,9 +1923,9 @@ db_string_repeat (const DB_VALUE * src_string, const DB_VALUE * count, DB_VALUE 
   assert (!DB_IS_NULL (src_string) && !DB_IS_NULL (count));
 
   src_type = DB_VALUE_DOMAIN_TYPE (src_string);
-  src_length = (int) DB_GET_STRING_LENGTH (src_string);
-  count_i = DB_GET_INTEGER (count);
-  codeset = DB_GET_STRING_CODESET (src_string);
+  src_length = (int) db_get_string_length (src_string);
+  count_i = db_get_int (count);
+  codeset = db_get_string_codeset (src_string);
 
   if (QSTR_IS_CHAR (src_type))
     {
@@ -1936,10 +1936,10 @@ db_string_repeat (const DB_VALUE * src_string, const DB_VALUE * count, DB_VALUE 
       result_type = DB_TYPE_VARNCHAR;
     }
 
-  src_size = DB_GET_STRING_SIZE (src_string);
+  src_size = db_get_string_size (src_string);
   if (src_size < 0)
     {
-      intl_char_size ((unsigned char *) DB_GET_STRING (result), src_length, codeset, &src_size);
+      intl_char_size ((unsigned char *) db_get_string (result), src_length, codeset, &src_size);
     }
 
   if (!QSTR_IS_ANY_CHAR (src_type) || !is_integer (count))
@@ -1950,8 +1950,8 @@ db_string_repeat (const DB_VALUE * src_string, const DB_VALUE * count, DB_VALUE 
   else if (count_i <= 0 || src_length <= 0)
     {
       error_status =
-	db_string_make_empty_typed_string (result, result_type, src_length, DB_GET_STRING_CODESET (src_string),
-					   DB_GET_STRING_COLLATION (src_string));
+	db_string_make_empty_typed_string (result, result_type, src_length, db_get_string_codeset (src_string),
+					   db_get_string_collation (src_string));
       if (error_status != NO_ERROR)
 	{
 	  return error_status;
@@ -1964,7 +1964,7 @@ db_string_repeat (const DB_VALUE * src_string, const DB_VALUE * count, DB_VALUE 
       DB_BIGINT new_length, expected_size;
 
       /* init dummy */
-      DB_MAKE_NULL (&dummy);
+      db_make_null (&dummy);
       /* create an empy string for result */
 
       new_length = (DB_BIGINT) src_length *count_i;
@@ -1976,7 +1976,7 @@ db_string_repeat (const DB_VALUE * src_string, const DB_VALUE * count, DB_VALUE 
 
       error_status =
 	db_string_make_empty_typed_string (&dummy, result_type, (int) new_length,
-					   DB_GET_STRING_CODESET (src_string), DB_GET_STRING_COLLATION (src_string));
+					   db_get_string_codeset (src_string), db_get_string_collation (src_string));
       if (error_status != NO_ERROR)
 	{
 	  return error_status;
@@ -2012,8 +2012,8 @@ db_string_repeat (const DB_VALUE * src_string, const DB_VALUE * count, DB_VALUE 
 
       pr_clear_value (&dummy);
 
-      res_ptr = (unsigned char *) DB_GET_STRING (result);
-      src_ptr = (unsigned char *) DB_GET_STRING (src_string);
+      res_ptr = (unsigned char *) db_get_string (result);
+      src_ptr = (unsigned char *) db_get_string (src_string);
 
       while (count_i--)
 	{
@@ -2022,9 +2022,9 @@ db_string_repeat (const DB_VALUE * src_string, const DB_VALUE * count, DB_VALUE 
 	}
 
       /* update size of string */
-      qstr_make_typed_string (result_type, result, DB_VALUE_PRECISION (result), DB_GET_STRING (result),
-			      (const int) expected_size, DB_GET_STRING_CODESET (src_string),
-			      DB_GET_STRING_COLLATION (src_string));
+      qstr_make_typed_string (result_type, result, DB_VALUE_PRECISION (result), db_get_string (result),
+			      (const int) expected_size, db_get_string_codeset (src_string),
+			      db_get_string_collation (src_string));
       result->need_clear = true;
 
     }
@@ -2066,9 +2066,9 @@ db_string_substring_index (DB_VALUE * src_string, DB_VALUE * delim_string, const
   /* 
    *  Initialize status value
    */
-  DB_MAKE_NULL (result);
-  DB_MAKE_NULL (&empty_string1);
-  DB_MAKE_NULL (&empty_string2);
+  db_make_null (result);
+  db_make_null (&empty_string1);
+  db_make_null (&empty_string2);
 
   /* 
    *  Assert that DB_VALUE structures have been allocated.
@@ -2080,11 +2080,11 @@ db_string_substring_index (DB_VALUE * src_string, DB_VALUE * delim_string, const
 
   if (DB_IS_NULL (count))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
 
       return NO_ERROR;
     }
-  count_i = DB_GET_INT (count);
+  count_i = db_get_int (count);
 
   /* 
    *  Categorize the parameters into respective code sets.
@@ -2097,11 +2097,11 @@ db_string_substring_index (DB_VALUE * src_string, DB_VALUE * delim_string, const
   src_type = DB_VALUE_DOMAIN_TYPE (src_string);
   delim_type = DB_VALUE_DOMAIN_TYPE (delim_string);
 
-  src_cs = DB_IS_NULL (src_string) ? LANG_SYS_CODESET : DB_GET_STRING_CODESET (src_string);
-  src_coll = DB_IS_NULL (src_string) ? LANG_SYS_COLLATION : DB_GET_STRING_COLLATION (src_string);
+  src_cs = DB_IS_NULL (src_string) ? LANG_SYS_CODESET : db_get_string_codeset (src_string);
+  src_coll = DB_IS_NULL (src_string) ? LANG_SYS_COLLATION : db_get_string_collation (src_string);
 
-  delim_cs = DB_IS_NULL (delim_string) ? LANG_SYS_CODESET : DB_GET_STRING_CODESET (delim_string);
-  delim_coll = DB_IS_NULL (delim_string) ? LANG_SYS_COLLATION : DB_GET_STRING_COLLATION (delim_string);
+  delim_cs = DB_IS_NULL (delim_string) ? LANG_SYS_CODESET : db_get_string_codeset (delim_string);
+  delim_coll = DB_IS_NULL (delim_string) ? LANG_SYS_COLLATION : db_get_string_collation (delim_string);
 
   if (prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING) == true)
     {
@@ -2181,10 +2181,10 @@ db_string_substring_index (DB_VALUE * src_string, DB_VALUE * delim_string, const
       DB_VALUE offset_val, interm_pos;
       int offset = 1, initial_count = 0;
       bool count_from_start;
-      const int src_length = DB_GET_STRING_LENGTH (src_string);
-      const int delim_length = DB_GET_STRING_LENGTH (delim_string);
+      const int src_length = db_get_string_length (src_string);
+      const int delim_length = db_get_string_length (delim_string);
 
-      DB_MAKE_NULL (&interm_pos);
+      db_make_null (&interm_pos);
       initial_count = count_i;
       count_from_start = (count_i > 0) ? true : false;
       count_i = abs (count_i);
@@ -2195,17 +2195,17 @@ db_string_substring_index (DB_VALUE * src_string, DB_VALUE * delim_string, const
 	{
 	  while (count_i > 0)
 	    {
-	      DB_MAKE_INTEGER (&offset_val, offset);
+	      db_make_int (&offset_val, offset);
 	      error_status = db_string_instr (src_string, delim_string, &offset_val, &interm_pos);
 	      if (error_status < 0)
 		{
 		  goto exit;
 		}
-	      offset = DB_GET_INT (&interm_pos);
+	      offset = db_get_int (&interm_pos);
 	      if (offset != 0)
 		{
 		  offset += delim_length;
-		  DB_MAKE_INTEGER (&offset_val, offset);
+		  db_make_int (&offset_val, offset);
 		}
 	      else
 		{
@@ -2220,18 +2220,18 @@ db_string_substring_index (DB_VALUE * src_string, DB_VALUE * delim_string, const
 	  while (count_i > 0)
 	    {
 	      /* search from end */
-	      DB_MAKE_INTEGER (&offset_val, -offset);
+	      db_make_int (&offset_val, -offset);
 	      error_status = db_string_instr (src_string, delim_string, &offset_val, &interm_pos);
 	      if (error_status < 0)
 		{
 		  goto exit;
 		}
-	      offset = DB_GET_INT (&interm_pos);
+	      offset = db_get_int (&interm_pos);
 	      if (offset != 0)
 		{
 		  /* adjust offset to indicate position relative to end */
 		  offset = src_length - offset + 2;
-		  DB_MAKE_INTEGER (&offset_val, offset);
+		  db_make_int (&offset_val, offset);
 		}
 	      else
 		{
@@ -2267,8 +2267,8 @@ db_string_substring_index (DB_VALUE * src_string, DB_VALUE * delim_string, const
 	    }
 	  else
 	    {
-	      DB_MAKE_INTEGER (&start_val, start_pos);
-	      DB_MAKE_INTEGER (&len_val, end_pos - start_pos + 1);
+	      db_make_int (&start_val, start_pos);
+	      db_make_int (&len_val, end_pos - start_pos + 1);
 
 	      error_status = db_string_substring (SUBSTRING, src_string, &start_val, &len_val, result);
 
@@ -2290,7 +2290,7 @@ db_string_substring_index (DB_VALUE * src_string, DB_VALUE * delim_string, const
 	    {
 	      /* convert CHARACTER(N) to CHARACTER VARYING(N) */
 	      qstr_make_typed_string ((src_type == DB_TYPE_NCHAR ? DB_TYPE_VARNCHAR : DB_TYPE_VARCHAR), result,
-				      DB_VALUE_PRECISION (result), DB_GET_STRING (result), DB_GET_STRING_SIZE (result),
+				      DB_VALUE_PRECISION (result), db_get_string (result), db_get_string_size (result),
 				      src_cs, src_coll);
 	      result->need_clear = true;
 	    }
@@ -2349,7 +2349,7 @@ db_string_sha_one (DB_VALUE const *src, DB_VALUE * result)
 
   if (DB_IS_NULL (src))
     {
-      DB_MAKE_NULL (result);	/* SH1(NULL) returns NULL */
+      db_make_null (result);	/* SH1(NULL) returns NULL */
       return error_status;
     }
   else
@@ -2358,14 +2358,14 @@ db_string_sha_one (DB_VALUE const *src, DB_VALUE * result)
 
       if (QSTR_IS_ANY_CHAR (val_type))
 	{
-	  error_status = crypt_sha_one (NULL, DB_GET_STRING (src), DB_GET_STRING_SIZE (src), &result_strp, &result_len);
+	  error_status = crypt_sha_one (NULL, db_get_string (src), db_get_string_size (src), &result_strp, &result_len);
 	  if (error_status != NO_ERROR)
 	    {
 	      goto error;
 	    }
 
 	  qstr_make_typed_string (DB_TYPE_CHAR, result, result_len, result_strp, result_len,
-				  DB_GET_STRING_CODESET (src), DB_GET_STRING_COLLATION (src));
+				  db_get_string_codeset (src), db_get_string_collation (src));
 	  result->need_clear = true;
 	}
       else
@@ -2378,7 +2378,7 @@ db_string_sha_one (DB_VALUE const *src, DB_VALUE * result)
   return error_status;
 
 error:
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       er_clear ();
@@ -2419,20 +2419,20 @@ db_string_sha_two (DB_VALUE const *src, DB_VALUE const *hash_len, DB_VALUE * res
 
   if (DB_IS_NULL (src) || DB_IS_NULL (hash_len))
     {
-      DB_MAKE_NULL (result);	/* sha2(NULL, ...) or sha2(..., NULL) returns NULL */
+      db_make_null (result);	/* sha2(NULL, ...) or sha2(..., NULL) returns NULL */
       return error_status;
     }
 
   switch (hash_len_type)
     {
     case DB_TYPE_SHORT:
-      len = DB_GET_SHORT (hash_len);
+      len = db_get_short (hash_len);
       break;
     case DB_TYPE_INTEGER:
-      len = DB_GET_INT (hash_len);
+      len = db_get_int (hash_len);
       break;
     case DB_TYPE_BIGINT:
-      len = (int) DB_GET_BIGINT (hash_len);
+      len = (int) db_get_bigint (hash_len);
       break;
     default:
       return ER_QSTR_INVALID_DATA_TYPE;
@@ -2441,7 +2441,7 @@ db_string_sha_two (DB_VALUE const *src, DB_VALUE const *hash_len, DB_VALUE * res
   if (QSTR_IS_ANY_CHAR (src_type))
     {
       error_status =
-	crypt_sha_two (NULL, DB_GET_STRING (src), DB_GET_STRING_LENGTH (src), len, &result_strp, &result_len);
+	crypt_sha_two (NULL, db_get_string (src), db_get_string_length (src), len, &result_strp, &result_len);
       if (error_status != NO_ERROR)
 	{
 	  goto error;
@@ -2450,12 +2450,12 @@ db_string_sha_two (DB_VALUE const *src, DB_VALUE const *hash_len, DB_VALUE * res
       /* It means that the hash_len is wrong. */
       if (result_strp == NULL)
 	{
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	  return error_status;
 	}
 
-      qstr_make_typed_string (DB_TYPE_VARCHAR, result, result_len, result_strp, result_len, DB_GET_STRING_CODESET (src),
-			      DB_GET_STRING_COLLATION (src));
+      qstr_make_typed_string (DB_TYPE_VARCHAR, result, result_len, result_strp, result_len, db_get_string_codeset (src),
+			      db_get_string_collation (src));
       result->need_clear = true;
     }
   else
@@ -2467,7 +2467,7 @@ db_string_sha_two (DB_VALUE const *src, DB_VALUE const *hash_len, DB_VALUE * res
   return error_status;
 
 error:
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       er_clear ();
@@ -2508,22 +2508,22 @@ db_string_aes_encrypt (DB_VALUE const *src, DB_VALUE const *key, DB_VALUE * resu
   if (DB_IS_NULL (src) || DB_IS_NULL (key))
     {
       /* aes_encypt(NULL, ...) or aes_encypt(..., NULL) returns NULL */
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return error_status;
     }
 
   if (QSTR_IS_ANY_CHAR (src_type) && QSTR_IS_ANY_CHAR (key_type))
     {
       error_status =
-	crypt_aes_default_encrypt (NULL, DB_GET_STRING (src), DB_GET_STRING_LENGTH (src), DB_GET_STRING (key),
-				   DB_GET_STRING_LENGTH (key), &result_strp, &result_len);
+	crypt_aes_default_encrypt (NULL, db_get_string (src), db_get_string_length (src), db_get_string (key),
+				   db_get_string_length (key), &result_strp, &result_len);
       if (error_status != NO_ERROR)
 	{
 	  goto error;
 	}
 
-      qstr_make_typed_string (DB_TYPE_VARCHAR, result, result_len, result_strp, result_len, DB_GET_STRING_CODESET (src),
-			      DB_GET_STRING_COLLATION (src));
+      qstr_make_typed_string (DB_TYPE_VARCHAR, result, result_len, result_strp, result_len, db_get_string_codeset (src),
+			      db_get_string_collation (src));
       result->need_clear = true;
     }
   else
@@ -2535,7 +2535,7 @@ db_string_aes_encrypt (DB_VALUE const *src, DB_VALUE const *key, DB_VALUE * resu
   return error_status;
 
 error:
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       er_clear ();
@@ -2576,15 +2576,15 @@ db_string_aes_decrypt (DB_VALUE const *src, DB_VALUE const *key, DB_VALUE * resu
   if (DB_IS_NULL (src) || DB_IS_NULL (key))
     {
       /* aes_decypt(NULL, ...) or aes_decypt(..., NULL) returns NULL */
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return error_status;
     }
 
   if (QSTR_IS_ANY_CHAR (src_type) && QSTR_IS_ANY_CHAR (key_type))
     {
       error_status =
-	crypt_aes_default_decrypt (NULL, DB_GET_STRING (src), DB_GET_STRING_LENGTH (src), DB_GET_STRING (key),
-				   DB_GET_STRING_LENGTH (key), &result_strp, &result_len);
+	crypt_aes_default_decrypt (NULL, db_get_string (src), db_get_string_length (src), db_get_string (key),
+				   db_get_string_length (key), &result_strp, &result_len);
       if (error_status != NO_ERROR)
 	{
 	  goto error;
@@ -2593,12 +2593,12 @@ db_string_aes_decrypt (DB_VALUE const *src, DB_VALUE const *key, DB_VALUE * resu
       if (result_strp == NULL)
 	{
 	  /* it means the src isn't aes_encrypted string, we return NULL like mysql */
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	  return error_status;
 	}
 
-      qstr_make_typed_string (DB_TYPE_VARCHAR, result, result_len, result_strp, result_len, DB_GET_STRING_CODESET (src),
-			      DB_GET_STRING_COLLATION (src));
+      qstr_make_typed_string (DB_TYPE_VARCHAR, result, result_len, result_strp, result_len, db_get_string_codeset (src),
+			      db_get_string_collation (src));
       result->need_clear = true;
     }
   else
@@ -2610,7 +2610,7 @@ db_string_aes_decrypt (DB_VALUE const *src, DB_VALUE const *key, DB_VALUE * resu
   return error_status;
 
 error:
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       er_clear ();
@@ -2643,7 +2643,7 @@ db_string_md5 (DB_VALUE const *val, DB_VALUE * result)
 
   if (DB_IS_NULL (val))
     {
-      DB_MAKE_NULL (result);	/* MD5(NULL) returns NULL */
+      db_make_null (result);	/* MD5(NULL) returns NULL */
       return error_status;
     }
   else
@@ -2657,15 +2657,15 @@ db_string_md5 (DB_VALUE const *val, DB_VALUE * result)
 
 	  DB_VALUE hash_string;
 
-	  DB_MAKE_NULL (&hash_string);
+	  db_make_null (&hash_string);
 
-	  md5_buffer (DB_GET_STRING (val), DB_GET_STRING_LENGTH (val), hashString);
+	  md5_buffer (db_get_string (val), db_get_string_length (val), hashString);
 
 	  md5_hash_to_hex (hashString, hashString);
 
 	  /* dump result as hex string */
-	  qstr_make_typed_string (DB_TYPE_CHAR, &hash_string, 32, hashString, 32, DB_GET_STRING_CODESET (val),
-				  DB_GET_STRING_COLLATION (val));
+	  qstr_make_typed_string (DB_TYPE_CHAR, &hash_string, 32, hashString, 32, db_get_string_codeset (val),
+				  db_get_string_collation (val));
 	  hash_string.need_clear = false;
 	  pr_clone_value (&hash_string, result);
 	}
@@ -2728,12 +2728,12 @@ db_string_insert_substring (DB_VALUE * src_string, const DB_VALUE * position, co
   /* 
    *  Initialize values
    */
-  DB_MAKE_NULL (result);
-  DB_MAKE_NULL (&string1);
-  DB_MAKE_NULL (&string2);
-  DB_MAKE_NULL (&empty_string1);
-  DB_MAKE_NULL (&empty_string2);
-  DB_MAKE_NULL (&partial_result);
+  db_make_null (result);
+  db_make_null (&string1);
+  db_make_null (&string2);
+  db_make_null (&empty_string1);
+  db_make_null (&empty_string2);
+  db_make_null (&partial_result);
 
   /* 
    *  Categorize the parameters into respective code sets.
@@ -2746,11 +2746,11 @@ db_string_insert_substring (DB_VALUE * src_string, const DB_VALUE * position, co
   src_type = DB_VALUE_DOMAIN_TYPE (src_string);
   substr_type = DB_VALUE_DOMAIN_TYPE (sub_string);
 
-  src_cs = DB_IS_NULL (src_string) ? LANG_SYS_CODESET : DB_GET_STRING_CODESET (src_string);
-  src_coll = DB_IS_NULL (src_string) ? LANG_SYS_COLLATION : DB_GET_STRING_COLLATION (src_string);
+  src_cs = DB_IS_NULL (src_string) ? LANG_SYS_CODESET : db_get_string_codeset (src_string);
+  src_coll = DB_IS_NULL (src_string) ? LANG_SYS_COLLATION : db_get_string_collation (src_string);
 
-  substr_cs = DB_IS_NULL (sub_string) ? LANG_SYS_CODESET : DB_GET_STRING_CODESET (sub_string);
-  substr_coll = DB_IS_NULL (sub_string) ? LANG_SYS_COLLATION : DB_GET_STRING_COLLATION (sub_string);
+  substr_cs = DB_IS_NULL (sub_string) ? LANG_SYS_CODESET : db_get_string_codeset (sub_string);
+  substr_coll = DB_IS_NULL (sub_string) ? LANG_SYS_COLLATION : db_get_string_collation (sub_string);
 
   if (prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING) == true)
     {
@@ -2831,15 +2831,15 @@ db_string_insert_substring (DB_VALUE * src_string, const DB_VALUE * position, co
       goto exit;
     }
 
-  position_i = DB_GET_INT (position);
-  length_i = DB_GET_INT (length);
-  src_length = DB_GET_STRING_LENGTH (src_string);
+  position_i = db_get_int (position);
+  length_i = db_get_int (length);
+  src_length = db_get_string_length (src_string);
 
   if (position_i <= 0 || position_i > src_length + 1)
     {
       /* return the source string */
       error_status = pr_clone_value ((DB_VALUE *) src_string, result);
-      result_size = DB_GET_STRING_SIZE (src_string);
+      result_size = db_get_string_size (src_string);
     }
   else
     {
@@ -2853,8 +2853,8 @@ db_string_insert_substring (DB_VALUE * src_string, const DB_VALUE * position, co
 	{
 	  DB_VALUE start_val, len_val;
 
-	  DB_MAKE_INTEGER (&start_val, 1);
-	  DB_MAKE_INTEGER (&len_val, position_i - 1);
+	  db_make_int (&start_val, 1);
+	  db_make_int (&len_val, position_i - 1);
 
 	  error_status = db_string_substring (SUBSTRING, src_string, &start_val, &len_val, &string1);
 	  if (error_status != NO_ERROR)
@@ -2889,8 +2889,8 @@ db_string_insert_substring (DB_VALUE * src_string, const DB_VALUE * position, co
 	{
 	  DB_VALUE start_val, len_val;
 
-	  DB_MAKE_INTEGER (&start_val, position_i + length_i);
-	  DB_MAKE_INTEGER (&len_val, src_length - (position_i + length_i) + 1);
+	  db_make_int (&start_val, position_i + length_i);
+	  db_make_int (&len_val, src_length - (position_i + length_i) + 1);
 
 	  error_status = db_string_substring (SUBSTRING, src_string, &start_val, &len_val, &string2);
 	  if (error_status != NO_ERROR)
@@ -2945,7 +2945,7 @@ db_string_insert_substring (DB_VALUE * src_string, const DB_VALUE * position, co
 	  goto exit;
 	}
 
-      result_size = DB_GET_STRING_SIZE (result);
+      result_size = db_get_string_size (result);
     }
 
   /* force type to variable string */
@@ -2953,12 +2953,12 @@ db_string_insert_substring (DB_VALUE * src_string, const DB_VALUE * position, co
     {
       /* convert CHARACTER(N) to CHARACTER VARYING(N) */
       qstr_make_typed_string ((src_type == DB_TYPE_NCHAR ? DB_TYPE_VARNCHAR : DB_TYPE_VARCHAR), result,
-			      TP_FLOATING_PRECISION_VALUE, DB_GET_STRING (result), result_size, src_cs, src_coll);
+			      TP_FLOATING_PRECISION_VALUE, db_get_string (result), result_size, src_cs, src_coll);
     }
   else if (src_type == DB_TYPE_BIT)
     {
       /* convert BIT to BIT VARYING */
-      qstr_make_typed_string (DB_TYPE_VARBIT, result, TP_FLOATING_PRECISION_VALUE, DB_GET_STRING (result), result_size,
+      qstr_make_typed_string (DB_TYPE_VARBIT, result, TP_FLOATING_PRECISION_VALUE, db_get_string (result), result_size,
 			      src_cs, src_coll);
     }
 
@@ -2990,26 +2990,26 @@ db_string_elt (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 
   if (num_args <= 0)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
   if (DB_IS_NULL (arg[0]))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
   switch (index_type)
     {
     case DB_TYPE_BIGINT:
-      index = DB_GET_BIGINT (arg[0]);
+      index = db_get_bigint (arg[0]);
       break;
     case DB_TYPE_INTEGER:
-      index = DB_GET_INTEGER (arg[0]);
+      index = db_get_int (arg[0]);
       break;
     case DB_TYPE_SMALLINT:
-      index = DB_GET_SMALLINT (arg[0]);
+      index = db_get_short (arg[0]);
       break;
     default:
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INVALID_DATA_TYPE, 0);
@@ -3022,7 +3022,7 @@ db_string_elt (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
     }
   else
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
 
   return NO_ERROR;
@@ -3035,7 +3035,7 @@ db_json_object (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
   JSON_DOC *new_doc = NULL;
   char *str = NULL;
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (num_args <= 0)
     {
@@ -3062,7 +3062,7 @@ db_json_object (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 
       if (DB_IS_NULL (arg[i + 1]))
 	{
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), (JSON_DOC *) NULL);
+	  db_json_add_member_to_object (new_doc, db_get_string (arg[i]), (JSON_DOC *) NULL);
 	  continue;
 	}
 
@@ -3072,15 +3072,15 @@ db_json_object (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_STRING (arg[i + 1]));
+	  db_json_add_member_to_object (new_doc, db_get_string (arg[i]), db_get_string (arg[i + 1]));
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_INT (arg[i + 1]));
+	  db_json_add_member_to_object (new_doc, db_get_string (arg[i]), db_get_int (arg[i + 1]));
 	  break;
 
 	case DB_TYPE_DOUBLE:
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_DOUBLE (arg[i + 1]));
+	  db_json_add_member_to_object (new_doc, db_get_string (arg[i]), db_get_double (arg[i + 1]));
 	  break;
 
 	case DB_TYPE_NUMERIC:
@@ -3088,17 +3088,17 @@ db_json_object (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	    DB_VALUE double_value;
 
 	    db_value_coerce (arg[i + 1], &double_value, db_type_to_db_domain (DB_TYPE_DOUBLE));
-	    db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), DB_GET_DOUBLE (&double_value));
+	    db_json_add_member_to_object (new_doc, db_get_string (arg[i]), db_get_double (&double_value));
 	    pr_clear_value (&double_value);
 	  }
 	  break;
 
 	case DB_TYPE_JSON:
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), arg[i + 1]->data.json.document);
+	  db_json_add_member_to_object (new_doc, db_get_string (arg[i]), arg[i + 1]->data.json.document);
 	  break;
 
 	case DB_TYPE_NULL:
-	  db_json_add_member_to_object (new_doc, DB_GET_STRING (arg[i]), (JSON_DOC *) NULL);
+	  db_json_add_member_to_object (new_doc, db_get_string (arg[i]), (JSON_DOC *) NULL);
 	  break;
 
 	default:
@@ -3120,7 +3120,7 @@ db_json_array (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
   JSON_DOC *new_doc = NULL;
   char *str = NULL;
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (num_args <= 0)
     {
@@ -3144,15 +3144,15 @@ db_json_array (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
-	  db_json_add_element_to_array (new_doc, DB_GET_STRING (arg[i]));
+	  db_json_add_element_to_array (new_doc, db_get_string (arg[i]));
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  db_json_add_element_to_array (new_doc, DB_GET_INT (arg[i]));
+	  db_json_add_element_to_array (new_doc, db_get_int (arg[i]));
 	  break;
 
 	case DB_TYPE_DOUBLE:
-	  db_json_add_element_to_array (new_doc, DB_GET_DOUBLE (arg[i]));
+	  db_json_add_element_to_array (new_doc, db_get_double (arg[i]));
 	  break;
 
 	case DB_TYPE_NUMERIC:
@@ -3160,7 +3160,7 @@ db_json_array (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	    DB_VALUE double_value;
 
 	    db_value_coerce (arg[i], &double_value, db_type_to_db_domain (DB_TYPE_DOUBLE));
-	    db_json_add_element_to_array (new_doc, DB_GET_DOUBLE (&double_value));
+	    db_json_add_element_to_array (new_doc, db_get_double (&double_value));
 	    pr_clear_value (&double_value);
 	  }
 	  break;
@@ -3193,7 +3193,7 @@ db_json_insert (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
   JSON_DOC *new_doc = NULL;
   char *str = NULL;
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (num_args < 3 || num_args % 2 == 0)
     {
@@ -3203,7 +3203,7 @@ db_json_insert (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 
   if (DB_IS_NULL (arg[0]))
     {
-      return DB_MAKE_NULL (result);
+      return db_make_null (result);
     }
 
   error_code = db_value_to_json_doc (*arg[0], new_doc);
@@ -3218,7 +3218,7 @@ db_json_insert (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
       if (DB_IS_NULL (arg[i]))
 	{
 	  db_json_delete_doc (new_doc);
-	  return DB_MAKE_NULL (result);
+	  return db_make_null (result);
 	}
 
       switch (DB_VALUE_DOMAIN_TYPE (arg[i + 1]))
@@ -3227,17 +3227,17 @@ db_json_insert (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
-	  error_code = db_json_convert_string_and_call (DB_GET_STRING (arg[i + 1]),
-							db_json_insert_func, *new_doc, DB_GET_STRING (arg[i]));
+	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]),
+							db_json_insert_func, *new_doc, db_get_string (arg[i]));
 	  break;
 
 	case DB_TYPE_JSON:
-	  error_code = db_json_insert_func (arg[i + 1]->data.json.document, *new_doc, DB_GET_STRING (arg[i]));
+	  error_code = db_json_insert_func (arg[i + 1]->data.json.document, *new_doc, db_get_string (arg[i]));
 	  break;
 
 	case DB_TYPE_NULL:
 	  db_json_delete_doc (new_doc);
-	  return DB_MAKE_NULL (result);
+	  return db_make_null (result);
 
 	default:
 	  db_json_delete_doc (new_doc);
@@ -3266,7 +3266,7 @@ db_json_replace (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
   JSON_DOC *new_doc = NULL;
   char *str;
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (num_args < 3 || num_args % 2 == 0)
     {
@@ -3291,7 +3291,7 @@ db_json_replace (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
       if (DB_IS_NULL (arg[i]))
 	{
 	  db_json_delete_doc (new_doc);
-	  return DB_MAKE_NULL (result);
+	  return db_make_null (result);
 	}
 
       switch (DB_VALUE_DOMAIN_TYPE (arg[i + 1]))
@@ -3300,17 +3300,17 @@ db_json_replace (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
-	  error_code = db_json_convert_string_and_call (DB_GET_STRING (arg[i + 1]),
-							db_json_replace_func, *new_doc, DB_GET_STRING (arg[i]));
+	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]),
+							db_json_replace_func, *new_doc, db_get_string (arg[i]));
 	  break;
 
 	case DB_TYPE_JSON:
-	  error_code = db_json_replace_func (arg[i + 1]->data.json.document, *new_doc, DB_GET_STRING (arg[i]));
+	  error_code = db_json_replace_func (arg[i + 1]->data.json.document, *new_doc, db_get_string (arg[i]));
 	  break;
 
 	case DB_TYPE_NULL:
 	  db_json_delete_doc (new_doc);
-	  return DB_MAKE_NULL (result);
+	  return db_make_null (result);
 
 	default:
 	  db_json_delete_doc (new_doc);
@@ -3338,7 +3338,7 @@ db_json_set (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
   JSON_DOC *new_doc = NULL;
   char *str;
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (num_args < 3 || num_args % 2 == 0)
     {
@@ -3363,7 +3363,7 @@ db_json_set (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
       if (DB_IS_NULL (arg[i]))
 	{
 	  db_json_delete_doc (new_doc);
-	  return DB_MAKE_NULL (result);
+	  return db_make_null (result);
 	}
 
       switch (DB_VALUE_DOMAIN_TYPE (arg[i + 1]))
@@ -3372,17 +3372,17 @@ db_json_set (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
-	  error_code = db_json_convert_string_and_call (DB_GET_STRING (arg[i + 1]),
-							db_json_set_func, *new_doc, DB_GET_STRING (arg[i]));
+	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]),
+							db_json_set_func, *new_doc, db_get_string (arg[i]));
 	  break;
 
 	case DB_TYPE_JSON:
-	  error_code = db_json_set_func (arg[i + 1]->data.json.document, *new_doc, DB_GET_STRING (arg[i]));
+	  error_code = db_json_set_func (arg[i + 1]->data.json.document, *new_doc, db_get_string (arg[i]));
 	  break;
 
 	case DB_TYPE_NULL:
 	  db_json_delete_doc (new_doc);
-	  return DB_MAKE_NULL (result);
+	  return db_make_null (result);
 
 	default:
 	  db_json_delete_doc (new_doc);
@@ -3412,7 +3412,7 @@ db_json_keys (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
   std::string path;
   char *str = NULL;
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (num_args > 2)
     {
@@ -3431,7 +3431,7 @@ db_json_keys (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
     }
   else
     {
-      path = DB_GET_STRING (arg[1]);
+      path = db_get_string (arg[1]);
     }
 
   result_json = db_json_allocate_doc ();
@@ -3442,14 +3442,14 @@ db_json_keys (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      error_code = db_json_keys_func (DB_GET_STRING (arg[0]), *result_json, path.c_str ());
+      error_code = db_json_keys_func (db_get_string (arg[0]), *result_json, path.c_str ());
       break;
     case DB_TYPE_JSON:
-      error_code = db_json_keys_func (*(DB_GET_JSON_DOCUMENT (arg[0])), *result_json, path.c_str ());
+      error_code = db_json_keys_func (*(db_get_json_document (arg[0])), *result_json, path.c_str ());
       break;
     case DB_TYPE_NULL:
       db_json_delete_doc (result_json);
-      return DB_MAKE_NULL (result);
+      return db_make_null (result);
 
     default:
       db_json_delete_doc (result_json);
@@ -3477,7 +3477,7 @@ db_json_remove (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
   JSON_DOC *new_doc = NULL;
   char *str;
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (num_args < 2)
     {
@@ -3502,10 +3502,10 @@ db_json_remove (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
       if (DB_IS_NULL (arg[i]))
 	{
 	  db_json_delete_doc (new_doc);
-	  return DB_MAKE_NULL (result);
+	  return db_make_null (result);
 	}
 
-      error_code = db_json_remove_func (*new_doc, DB_GET_STRING (arg[i]));
+      error_code = db_json_remove_func (*new_doc, db_get_string (arg[i]));
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -3527,7 +3527,7 @@ db_json_array_append (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
   JSON_DOC *new_doc = NULL;
   char *str = NULL;
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (num_args < 3 || num_args % 2 == 0)
     {
@@ -3552,23 +3552,23 @@ db_json_array_append (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
       if (DB_IS_NULL (arg[i]) || DB_IS_NULL (arg[i + 1]))
 	{
 	  db_json_delete_doc (new_doc);
-	  return DB_MAKE_NULL (result);
+	  return db_make_null (result);
 	}
 
       switch (DB_VALUE_DOMAIN_TYPE (arg[i + 1]))
 	{
 	case DB_TYPE_CHAR:
-	  error_code = db_json_convert_string_and_call (DB_GET_STRING (arg[i + 1]),
-							db_json_array_append_func, *new_doc, DB_GET_STRING (arg[i]));
+	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]),
+							db_json_array_append_func, *new_doc, db_get_string (arg[i]));
 	  break;
 
 	case DB_TYPE_JSON:
-	  error_code = db_json_array_append_func (arg[i + 1]->data.json.document, *new_doc, DB_GET_STRING (arg[i]));
+	  error_code = db_json_array_append_func (arg[i + 1]->data.json.document, *new_doc, db_get_string (arg[i]));
 	  break;
 
 	case DB_TYPE_NULL:
 	  db_json_delete_doc (new_doc);
-	  return DB_MAKE_NULL (result);
+	  return db_make_null (result);
 
 	default:
 	  db_json_delete_doc (new_doc);
@@ -3609,7 +3609,7 @@ db_json_merge (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 
   if (num_args < 2)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -3618,7 +3618,7 @@ db_json_merge (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
       if (DB_IS_NULL (arg[i]))
 	{
 	  db_json_delete_doc (accumulator);
-	  return DB_MAKE_NULL (result);
+	  return db_make_null (result);
 	}
 
       switch (DB_VALUE_TYPE (arg[i]))
@@ -3631,7 +3631,7 @@ db_json_merge (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
-	  error_code = db_json_convert_string_and_call (DB_GET_STRING (arg[i]), db_json_merge_func, accumulator);
+	  error_code = db_json_convert_string_and_call (db_get_string (arg[i]), db_json_merge_func, accumulator);
 	  break;
 
 	case DB_TYPE_NULL:
@@ -3666,7 +3666,7 @@ db_json_get_all_paths (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
   JSON_DOC *result_json = NULL;
   char *str = NULL;
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (num_args != 1)
     {
@@ -3757,7 +3757,7 @@ db_string_byte_length (const DB_VALUE * string, DB_VALUE * byte_count)
     }
   else
     {
-      DB_MAKE_INTEGER (byte_count, DB_GET_STRING_SIZE (string));
+      db_make_int (byte_count, db_get_string_size (string));
     }
 
   return error_status;
@@ -3824,11 +3824,11 @@ db_string_bit_length (const DB_VALUE * string, DB_VALUE * bit_count)
     {
       if (qstr_get_category (string) == QSTR_BIT)
 	{
-	  DB_MAKE_INTEGER (bit_count, DB_GET_STRING_LENGTH (string));
+	  db_make_int (bit_count, db_get_string_length (string));
 	}
       else
 	{
-	  DB_MAKE_INTEGER (bit_count, (DB_GET_STRING_SIZE (string) * BYTE_SIZE));
+	  db_make_int (bit_count, (db_get_string_size (string) * BYTE_SIZE));
 	}
     }
 
@@ -3891,7 +3891,7 @@ db_string_char_length (const DB_VALUE * string, DB_VALUE * char_count)
     }
   else
     {
-      DB_MAKE_INTEGER (char_count, DB_GET_STRING_LENGTH (string));
+      db_make_int (char_count, db_get_string_length (string));
     }
 
   return error_status;
@@ -3919,7 +3919,7 @@ db_string_char_length (const DB_VALUE * string, DB_VALUE * char_count)
  *
  *   The <lower_string> value structure will be cloned from <string>.
  *   <lower_string> should be cleared with pr_clone_value() if it has
- *   already been initialized or DB_MAKE_NULL if it has not been
+ *   already been initialized or db_make_null if it has not been
  *   previously used by the system.
  *
  * Assert:
@@ -3949,7 +3949,7 @@ db_string_lower (const DB_VALUE * string, DB_VALUE * lower_string)
   str_type = DB_VALUE_DOMAIN_TYPE (string);
   if (DB_IS_NULL (string))
     {
-      DB_MAKE_NULL (lower_string);
+      db_make_null (lower_string);
     }
   else if (!QSTR_IS_ANY_CHAR (str_type))
     {
@@ -3964,11 +3964,11 @@ db_string_lower (const DB_VALUE * string, DB_VALUE * lower_string)
       unsigned char *lower_str;
       int lower_size;
       int src_length;
-      const ALPHABET_DATA *alphabet = lang_user_alphabet_w_coll (DB_GET_STRING_COLLATION (string));
+      const ALPHABET_DATA *alphabet = lang_user_alphabet_w_coll (db_get_string_collation (string));
 
-      src_length = DB_GET_STRING_LENGTH (string);
+      src_length = db_get_string_length (string);
       lower_size =
-	intl_lower_string_size (alphabet, (unsigned char *) DB_GET_STRING (string), DB_GET_STRING_SIZE (string),
+	intl_lower_string_size (alphabet, (unsigned char *) db_get_string (string), db_get_string_size (string),
 				src_length);
 
       lower_str = (unsigned char *) db_private_alloc (NULL, lower_size + 1);
@@ -3979,15 +3979,15 @@ db_string_lower (const DB_VALUE * string, DB_VALUE * lower_string)
       else
 	{
 	  int lower_length = TP_FLOATING_PRECISION_VALUE;
-	  intl_lower_string (alphabet, (unsigned char *) DB_GET_STRING (string), lower_str, src_length);
+	  intl_lower_string (alphabet, (unsigned char *) db_get_string (string), lower_str, src_length);
 	  lower_str[lower_size] = 0;
 
 	  if (db_value_precision (string) != TP_FLOATING_PRECISION_VALUE)
 	    {
-	      intl_char_count (lower_str, lower_size, DB_GET_STRING_CODESET (string), &lower_length);
+	      intl_char_count (lower_str, lower_size, db_get_string_codeset (string), &lower_length);
 	    }
 	  qstr_make_typed_string (str_type, lower_string, lower_length, (char *) lower_str, lower_size,
-				  DB_GET_STRING_CODESET (string), DB_GET_STRING_COLLATION (string));
+				  db_get_string_codeset (string), db_get_string_collation (string));
 	  lower_string->need_clear = true;
 	}
     }
@@ -4018,7 +4018,7 @@ db_string_lower (const DB_VALUE * string, DB_VALUE * lower_string)
  *
  *   The <upper_string> value structure will be cloned from <string>.
  *   <upper_string> should be cleared with pr_clone_value() if it has
- *   already been initialized or DB_MAKE_NULL if it has not been
+ *   already been initialized or db_make_null if it has not been
  *   previously used by the system.
  *
  * Assert:
@@ -4048,7 +4048,7 @@ db_string_upper (const DB_VALUE * string, DB_VALUE * upper_string)
   str_type = DB_VALUE_DOMAIN_TYPE (string);
   if (DB_IS_NULL (string))
     {
-      DB_MAKE_NULL (upper_string);
+      db_make_null (upper_string);
     }
   else if (!QSTR_IS_ANY_CHAR (str_type))
     {
@@ -4062,11 +4062,11 @@ db_string_upper (const DB_VALUE * string, DB_VALUE * upper_string)
     {
       unsigned char *upper_str;
       int upper_size, src_length;
-      const ALPHABET_DATA *alphabet = lang_user_alphabet_w_coll (DB_GET_STRING_COLLATION (string));
+      const ALPHABET_DATA *alphabet = lang_user_alphabet_w_coll (db_get_string_collation (string));
 
-      src_length = DB_GET_STRING_LENGTH (string);
+      src_length = db_get_string_length (string);
       upper_size =
-	intl_upper_string_size (alphabet, (unsigned char *) DB_GET_STRING (string), DB_GET_STRING_SIZE (string),
+	intl_upper_string_size (alphabet, (unsigned char *) db_get_string (string), db_get_string_size (string),
 				src_length);
 
       upper_str = (unsigned char *) db_private_alloc (NULL, upper_size + 1);
@@ -4077,15 +4077,15 @@ db_string_upper (const DB_VALUE * string, DB_VALUE * upper_string)
       else
 	{
 	  int upper_length = TP_FLOATING_PRECISION_VALUE;
-	  intl_upper_string (alphabet, (unsigned char *) DB_GET_STRING (string), upper_str, src_length);
+	  intl_upper_string (alphabet, (unsigned char *) db_get_string (string), upper_str, src_length);
 
 	  upper_str[upper_size] = 0;
 	  if (db_value_precision (string) != TP_FLOATING_PRECISION_VALUE)
 	    {
-	      intl_char_count (upper_str, upper_size, DB_GET_STRING_CODESET (string), &upper_length);
+	      intl_char_count (upper_str, upper_size, db_get_string_codeset (string), &upper_length);
 	    }
 	  qstr_make_typed_string (str_type, upper_string, upper_length, (char *) upper_str, upper_size,
-				  DB_GET_STRING_CODESET (string), DB_GET_STRING_COLLATION (string));
+				  db_get_string_codeset (string), db_get_string_collation (string));
 	  upper_string->need_clear = true;
 	}
     }
@@ -4190,7 +4190,7 @@ db_string_trim (const MISC_OPERAND tr_operand, const DB_VALUE * trim_charset, co
 
   if (!is_trim_charset_omitted
       && (qstr_get_category (src_string) != qstr_get_category (trim_charset)
-	  || DB_GET_STRING_CODESET (src_string) != DB_GET_STRING_CODESET (trim_charset)))
+	  || db_get_string_codeset (src_string) != db_get_string_codeset (trim_charset)))
     {
       error_status = ER_QSTR_INCOMPATIBLE_CODE_SETS;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INCOMPATIBLE_CODE_SETS, 0);
@@ -4202,22 +4202,22 @@ db_string_trim (const MISC_OPERAND tr_operand, const DB_VALUE * trim_charset, co
    */
   if (!is_trim_charset_omitted)
     {
-      trim_charset_ptr = (unsigned char *) DB_GET_STRING (trim_charset);
-      trim_charset_length = DB_GET_STRING_LENGTH (trim_charset);
-      trim_charset_size = DB_GET_STRING_SIZE (trim_charset);
+      trim_charset_ptr = (unsigned char *) db_get_string (trim_charset);
+      trim_charset_length = db_get_string_length (trim_charset);
+      trim_charset_size = db_get_string_size (trim_charset);
     }
 
   error_status =
     qstr_trim (tr_operand, trim_charset_ptr, trim_charset_length, trim_charset_size,
-	       (unsigned char *) DB_GET_STRING (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
-	       DB_GET_STRING_LENGTH (src_string), DB_GET_STRING_SIZE (src_string), DB_GET_STRING_CODESET (src_string),
+	       (unsigned char *) db_get_string (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
+	       db_get_string_length (src_string), db_get_string_size (src_string), db_get_string_codeset (src_string),
 	       &result, &result_type, &result_length, &result_size);
 
   if (error_status == NO_ERROR && result != NULL)
     {
       result_domain_length = MIN (QSTR_MAX_PRECISION (result_type), DB_VALUE_PRECISION (src_string));
       qstr_make_typed_string (result_type, trimmed_string, result_domain_length, (char *) result, result_size,
-			      DB_GET_STRING_CODESET (src_string), DB_GET_STRING_COLLATION (src_string));
+			      db_get_string_codeset (src_string), db_get_string_collation (src_string));
       result[result_size] = 0;
       trimmed_string->need_clear = true;
     }
@@ -4513,7 +4513,7 @@ db_string_pad (const MISC_OPERAND pad_operand, const DB_VALUE * src_string, cons
       return error_status;
     }
 
-  if (DB_IS_NULL (pad_length) || (total_length = DB_GET_INTEGER (pad_length)) <= 0)
+  if (DB_IS_NULL (pad_length) || (total_length = db_get_int (pad_length)) <= 0)
     {
       /* error_status = ER_QPROC_INVALID_PARAMETER; */
       if (QSTR_IS_CHAR (DB_VALUE_DOMAIN_TYPE (src_string)))
@@ -4537,7 +4537,7 @@ db_string_pad (const MISC_OPERAND pad_operand, const DB_VALUE * src_string, cons
 
   if (!is_pad_charset_omitted
       && (qstr_get_category (src_string) != qstr_get_category (pad_charset)
-	  || DB_GET_STRING_CODESET (src_string) != DB_GET_STRING_CODESET (pad_charset)))
+	  || db_get_string_codeset (src_string) != db_get_string_codeset (pad_charset)))
     {
       error_status = ER_QSTR_INCOMPATIBLE_CODE_SETS;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INCOMPATIBLE_CODE_SETS, 0);
@@ -4546,21 +4546,21 @@ db_string_pad (const MISC_OPERAND pad_operand, const DB_VALUE * src_string, cons
 
   if (!is_pad_charset_omitted)
     {
-      pad_charset_ptr = (unsigned char *) DB_GET_STRING (pad_charset);
-      pad_charset_length = DB_GET_STRING_LENGTH (pad_charset);
-      pad_charset_size = DB_GET_STRING_SIZE (pad_charset);
+      pad_charset_ptr = (unsigned char *) db_get_string (pad_charset);
+      pad_charset_length = db_get_string_length (pad_charset);
+      pad_charset_size = db_get_string_size (pad_charset);
     }
 
   error_status =
     qstr_pad (pad_operand, total_length, pad_charset_ptr, pad_charset_length, pad_charset_size,
-	      (unsigned char *) DB_GET_STRING (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
-	      DB_GET_STRING_LENGTH (src_string), DB_GET_STRING_SIZE (src_string), DB_GET_STRING_CODESET (src_string),
+	      (unsigned char *) db_get_string (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
+	      db_get_string_length (src_string), db_get_string_size (src_string), db_get_string_codeset (src_string),
 	      &result, &result_type, &result_length, &result_size);
 
   if (error_status == NO_ERROR && result != NULL)
     {
       qstr_make_typed_string (result_type, padded_string, result_length, (char *) result, result_size,
-			      DB_GET_STRING_CODESET (src_string), DB_GET_STRING_COLLATION (src_string));
+			      db_get_string_codeset (src_string), db_get_string_collation (src_string));
 
       result[result_size] = 0;
       padded_string->need_clear = true;
@@ -4761,7 +4761,7 @@ db_string_like (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB_
       return error_status;
     }
 
-  if (src_category != pattern_category || (DB_GET_STRING_CODESET (src_string) != DB_GET_STRING_CODESET (pattern)))
+  if (src_category != pattern_category || (db_get_string_codeset (src_string) != db_get_string_codeset (pattern)))
     {
       error_status = ER_QSTR_INCOMPATIBLE_CODE_SETS;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -4781,7 +4781,7 @@ db_string_like (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB_
       return error_status;
     }
 
-  LANG_RT_COMMON_COLL (DB_GET_STRING_COLLATION (src_string), DB_GET_STRING_COLLATION (pattern), coll_id);
+  LANG_RT_COMMON_COLL (db_get_string_collation (src_string), db_get_string_collation (pattern), coll_id);
   if (coll_id == -1)
     {
       error_status = ER_QSTR_INCOMPATIBLE_COLLATIONS;
@@ -4807,10 +4807,10 @@ db_string_like (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB_
 	    {
 	      if (src_category == esc_category)
 		{
-		  esc_char_p = DB_GET_STRING (esc_char);
-		  esc_char_size = DB_GET_STRING_SIZE (esc_char);
+		  esc_char_p = db_get_string (esc_char);
+		  esc_char_size = db_get_string_size (esc_char);
 
-		  intl_char_count ((unsigned char *) esc_char_p, esc_char_size, DB_GET_STRING_CODESET (esc_char),
+		  intl_char_count ((unsigned char *) esc_char_p, esc_char_size, db_get_string_codeset (esc_char),
 				   &esc_char_len);
 
 		  assert (esc_char_p != NULL);
@@ -4840,15 +4840,15 @@ db_string_like (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB_
 	}
     }
 
-  src_char_string_p = DB_GET_STRING (src_string);
-  src_length = DB_GET_STRING_SIZE (src_string);
+  src_char_string_p = db_get_string (src_string);
+  src_length = db_get_string_size (src_string);
 
-  pattern_char_string_p = DB_GET_STRING (pattern);
-  pattern_length = DB_GET_STRING_SIZE (pattern);
+  pattern_char_string_p = db_get_string (pattern);
+  pattern_length = db_get_string_size (pattern);
 
   *result =
     qstr_eval_like (src_char_string_p, src_length, pattern_char_string_p, pattern_length,
-		    (esc_char ? esc_char_p : NULL), DB_GET_STRING_CODESET (src_string), coll_id);
+		    (esc_char ? esc_char_p : NULL), db_get_string_codeset (src_string), coll_id);
 
   if (*result == V_ERROR)
     {
@@ -4961,11 +4961,11 @@ db_string_rlike (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB
       goto cleanup;
     }
 
-  src_char_string_p = DB_GET_STRING (src_string);
-  src_length = DB_GET_STRING_SIZE (src_string);
+  src_char_string_p = db_get_string (src_string);
+  src_length = db_get_string_size (src_string);
 
-  pattern_char_string_p = DB_GET_STRING (pattern);
-  pattern_length = DB_GET_STRING_SIZE (pattern);
+  pattern_char_string_p = db_get_string (pattern);
+  pattern_length = db_get_string_size (pattern);
 
   /* initialize regex library memory allocator */
   cub_regset_malloc ((CUB_REG_MALLOC) db_private_alloc_external);
@@ -5149,7 +5149,7 @@ db_string_limit_size_string (DB_VALUE * src_string, DB_VALUE * result, const int
       return ER_QSTR_INVALID_DATA_TYPE;
     }
 
-  src_size = DB_GET_STRING_SIZE (src_string);
+  src_size = db_get_string_size (src_string);
   src_domain_precision = DB_VALUE_PRECISION (src_string);
 
   if (new_size < 0)
@@ -5175,9 +5175,9 @@ db_string_limit_size_string (DB_VALUE * src_string, DB_VALUE * result, const int
     }
   else
     {
-      intl_char_count ((unsigned char *) DB_GET_STRING (src_string), result_size, DB_GET_STRING_CODESET (src_string),
+      intl_char_count ((unsigned char *) db_get_string (src_string), result_size, db_get_string_codeset (src_string),
 		       &char_count);
-      intl_char_size ((unsigned char *) DB_GET_STRING (src_string), char_count, DB_GET_STRING_CODESET (src_string),
+      intl_char_size ((unsigned char *) db_get_string (src_string), char_count, db_get_string_codeset (src_string),
 		      &adj_char_size);
     }
 
@@ -5193,7 +5193,7 @@ db_string_limit_size_string (DB_VALUE * src_string, DB_VALUE * result, const int
 
   if (adj_char_size > 0)
     {
-      memcpy ((char *) r, (char *) DB_GET_STRING (src_string), adj_char_size);
+      memcpy ((char *) r, (char *) db_get_string (src_string), adj_char_size);
     }
   /* adjust also domain precision in case of fixed length types */
   if (QSTR_IS_FIXED_LENGTH (src_type))
@@ -5201,7 +5201,7 @@ db_string_limit_size_string (DB_VALUE * src_string, DB_VALUE * result, const int
       src_domain_precision = MIN (src_domain_precision, char_count);
     }
   qstr_make_typed_string (src_type, result, src_domain_precision, (char *) r, adj_char_size,
-			  DB_GET_STRING_CODESET (src_string), DB_GET_STRING_COLLATION (src_string));
+			  db_get_string_codeset (src_string), db_get_string_collation (src_string));
   result->need_clear = true;
 
   *spare_bytes = result_size - adj_char_size;
@@ -5254,14 +5254,14 @@ db_string_fix_string_size (DB_VALUE * src_string)
       return ER_QSTR_INVALID_DATA_TYPE;
     }
 
-  val_size = DB_GET_STRING_SIZE (src_string);
+  val_size = db_get_string_size (src_string);
   /* this is a system generated string; it must have the null terminator */
-  string_size = strlen (DB_GET_STRING (src_string));
+  string_size = strlen (db_get_string (src_string));
   assert (val_size >= string_size);
 
   save_need_clear = src_string->need_clear;
-  qstr_make_typed_string (src_type, src_string, DB_VALUE_PRECISION (src_string), DB_GET_STRING (src_string),
-			  string_size, DB_GET_STRING_CODESET (src_string), DB_GET_STRING_COLLATION (src_string));
+  qstr_make_typed_string (src_type, src_string, DB_VALUE_PRECISION (src_string), db_get_string (src_string),
+			  string_size, db_get_string_codeset (src_string), db_get_string_collation (src_string));
   src_string->need_clear = save_need_clear;
 
   return error_status;
@@ -5617,7 +5617,7 @@ db_string_replace (const DB_VALUE * src_string, const DB_VALUE * srch_string, co
   assert (src_string != (DB_VALUE *) NULL);
   assert (replaced_string != (DB_VALUE *) NULL);
 
-  DB_MAKE_NULL (&dummy_string);
+  db_make_null (&dummy_string);
 
   if (repl_string == NULL)
     {
@@ -5632,8 +5632,8 @@ db_string_replace (const DB_VALUE * src_string, const DB_VALUE * srch_string, co
 	{
 	  error_status =
 	    db_string_make_empty_typed_string (&dummy_string, DB_VALUE_DOMAIN_TYPE (src_string),
-					       TP_FLOATING_PRECISION_VALUE, DB_GET_STRING_CODESET (src_string),
-					       DB_GET_STRING_COLLATION (src_string));
+					       TP_FLOATING_PRECISION_VALUE, db_get_string_codeset (src_string),
+					       db_get_string_collation (src_string));
 	  if (error_status != NO_ERROR)
 	    {
 	      goto exit;
@@ -5675,15 +5675,15 @@ db_string_replace (const DB_VALUE * src_string, const DB_VALUE * srch_string, co
   if ((qstr_get_category (src_string) != qstr_get_category (srch_string))
       || (!is_repl_string_omitted && (qstr_get_category (src_string) != qstr_get_category (repl_string)))
       || (!is_repl_string_omitted && (qstr_get_category (srch_string) != qstr_get_category (repl_string)))
-      || ((DB_GET_STRING_CODESET (src_string) != DB_GET_STRING_CODESET (srch_string)))
-      || (!is_repl_string_omitted && (DB_GET_STRING_CODESET (src_string) != DB_GET_STRING_CODESET (repl_string))))
+      || ((db_get_string_codeset (src_string) != db_get_string_codeset (srch_string)))
+      || (!is_repl_string_omitted && (db_get_string_codeset (src_string) != db_get_string_codeset (repl_string))))
     {
       error_status = ER_QSTR_INCOMPATIBLE_CODE_SETS;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INCOMPATIBLE_CODE_SETS, 0);
       goto exit;
     }
 
-  LANG_RT_COMMON_COLL (DB_GET_STRING_COLLATION (src_string), DB_GET_STRING_COLLATION (srch_string), coll_id_tmp);
+  LANG_RT_COMMON_COLL (db_get_string_collation (src_string), db_get_string_collation (srch_string), coll_id_tmp);
   if (coll_id_tmp == -1)
     {
       error_status = ER_QSTR_INCOMPATIBLE_COLLATIONS;
@@ -5693,7 +5693,7 @@ db_string_replace (const DB_VALUE * src_string, const DB_VALUE * srch_string, co
 
   if (!is_repl_string_omitted)
     {
-      LANG_RT_COMMON_COLL (coll_id_tmp, DB_GET_STRING_COLLATION (repl_string), coll_id);
+      LANG_RT_COMMON_COLL (coll_id_tmp, db_get_string_collation (repl_string), coll_id);
       if (coll_id == -1)
 	{
 	  error_status = ER_QSTR_INCOMPATIBLE_COLLATIONS;
@@ -5710,13 +5710,13 @@ db_string_replace (const DB_VALUE * src_string, const DB_VALUE * srch_string, co
 
   if (!is_repl_string_omitted)
     {
-      repl_string_ptr = (unsigned char *) DB_GET_STRING (repl_string);
-      repl_string_size = DB_GET_STRING_SIZE (repl_string);
+      repl_string_ptr = (unsigned char *) db_get_string (repl_string);
+      repl_string_size = db_get_string_size (repl_string);
     }
   error_status =
-    qstr_replace ((unsigned char *) DB_GET_STRING (src_string), DB_GET_STRING_LENGTH (src_string),
-		  DB_GET_STRING_SIZE (src_string), DB_GET_STRING_CODESET (src_string), coll_id,
-		  (unsigned char *) DB_GET_STRING (srch_string), DB_GET_STRING_SIZE (srch_string), repl_string_ptr,
+    qstr_replace ((unsigned char *) db_get_string (src_string), db_get_string_length (src_string),
+		  db_get_string_size (src_string), db_get_string_codeset (src_string), coll_id,
+		  (unsigned char *) db_get_string (srch_string), db_get_string_size (srch_string), repl_string_ptr,
 		  repl_string_size, &result_ptr, &result_length, &result_size);
 
   if (error_status == NO_ERROR && result_ptr != NULL)
@@ -5724,13 +5724,13 @@ db_string_replace (const DB_VALUE * src_string, const DB_VALUE * srch_string, co
       if (result_length == 0)
 	{
 	  qstr_make_typed_string (result_type, replaced_string,
-				  (DB_GET_STRING_LENGTH (src_string) == 0) ? 1 : DB_GET_STRING_LENGTH (src_string),
-				  (char *) result_ptr, result_size, DB_GET_STRING_CODESET (src_string), coll_id);
+				  (db_get_string_length (src_string) == 0) ? 1 : db_get_string_length (src_string),
+				  (char *) result_ptr, result_size, db_get_string_codeset (src_string), coll_id);
 	}
       else
 	{
 	  qstr_make_typed_string (result_type, replaced_string, result_length, (char *) result_ptr, result_size,
-				  DB_GET_STRING_CODESET (src_string), coll_id);
+				  db_get_string_codeset (src_string), coll_id);
 	}
       result_ptr[result_size] = 0;
       replaced_string->need_clear = true;
@@ -5927,8 +5927,8 @@ db_string_translate (const DB_VALUE * src_string, const DB_VALUE * from_string, 
   if ((qstr_get_category (src_string) != qstr_get_category (from_string))
       || (qstr_get_category (src_string) != qstr_get_category (to_string))
       || (qstr_get_category (from_string) != qstr_get_category (to_string))
-      || (DB_GET_STRING_CODESET (src_string) != DB_GET_STRING_CODESET (from_string))
-      || (DB_GET_STRING_CODESET (src_string) != DB_GET_STRING_CODESET (to_string)))
+      || (db_get_string_codeset (src_string) != db_get_string_codeset (from_string))
+      || (db_get_string_codeset (src_string) != db_get_string_codeset (to_string)))
     {
       error_status = ER_QSTR_INCOMPATIBLE_CODE_SETS;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -5936,10 +5936,10 @@ db_string_translate (const DB_VALUE * src_string, const DB_VALUE * from_string, 
     }
 
   error_status =
-    qstr_translate ((unsigned char *) DB_GET_STRING (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
-		    DB_GET_STRING_SIZE (src_string), DB_GET_STRING_CODESET (src_string),
-		    (unsigned char *) DB_GET_STRING (from_string), DB_GET_STRING_SIZE (from_string),
-		    (unsigned char *) DB_GET_STRING (to_string), DB_GET_STRING_SIZE (to_string), &result_ptr,
+    qstr_translate ((unsigned char *) db_get_string (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
+		    db_get_string_size (src_string), db_get_string_codeset (src_string),
+		    (unsigned char *) db_get_string (from_string), db_get_string_size (from_string),
+		    (unsigned char *) db_get_string (to_string), db_get_string_size (to_string), &result_ptr,
 		    &result_type, &result_length, &result_size);
 
   if (error_status == NO_ERROR && result_ptr != NULL)
@@ -5947,14 +5947,14 @@ db_string_translate (const DB_VALUE * src_string, const DB_VALUE * from_string, 
       if (result_length == 0)
 	{
 	  qstr_make_typed_string (result_type, transed_string,
-				  (DB_GET_STRING_LENGTH (src_string) == 0) ? 1 : DB_GET_STRING_LENGTH (src_string),
-				  (char *) result_ptr, result_size, DB_GET_STRING_CODESET (src_string),
-				  DB_GET_STRING_COLLATION (src_string));
+				  (db_get_string_length (src_string) == 0) ? 1 : db_get_string_length (src_string),
+				  (char *) result_ptr, result_size, db_get_string_codeset (src_string),
+				  db_get_string_collation (src_string));
 	}
       else
 	{
 	  qstr_make_typed_string (result_type, transed_string, result_length, (char *) result_ptr, result_size,
-				  DB_GET_STRING_CODESET (src_string), DB_GET_STRING_COLLATION (src_string));
+				  db_get_string_codeset (src_string), db_get_string_collation (src_string));
 	}
       result_ptr[result_size] = 0;
       transed_string->need_clear = true;
@@ -6161,7 +6161,7 @@ db_bit_string_coerce (const DB_VALUE * src_string, DB_VALUE * dest_string, DB_DA
 
       if (DB_VALUE_PRECISION (dest_string) == TP_FLOATING_PRECISION_VALUE)
 	{
-	  dest_prec = DB_GET_STRING_LENGTH (src_string);
+	  dest_prec = db_get_string_length (src_string);
 	}
       else
 	{
@@ -6169,7 +6169,7 @@ db_bit_string_coerce (const DB_VALUE * src_string, DB_VALUE * dest_string, DB_DA
 	}
 
       error_status =
-	qstr_bit_coerce ((unsigned char *) DB_GET_STRING (src_string), DB_GET_STRING_LENGTH (src_string),
+	qstr_bit_coerce ((unsigned char *) db_get_string (src_string), db_get_string_length (src_string),
 			 QSTR_VALUE_PRECISION (src_string), src_type, &dest, &dest_length, dest_prec, dest_type,
 			 data_status);
 
@@ -6260,8 +6260,8 @@ db_char_string_coerce (const DB_VALUE * src_string, DB_VALUE * dest_string, DB_D
       int dest_prec;
       int dest_length;
       int dest_size;
-      INTL_CODESET src_codeset = DB_GET_STRING_CODESET (src_string);
-      INTL_CODESET dest_codeset = DB_GET_STRING_CODESET (dest_string);
+      INTL_CODESET src_codeset = db_get_string_codeset (src_string);
+      INTL_CODESET dest_codeset = db_get_string_codeset (dest_string);
 
       if (!INTL_CAN_COERCE_CS (src_codeset, dest_codeset))
 	{
@@ -6273,7 +6273,7 @@ db_char_string_coerce (const DB_VALUE * src_string, DB_VALUE * dest_string, DB_D
       /* Initialize the memory manager of the destination */
       if (DB_VALUE_PRECISION (dest_string) == TP_FLOATING_PRECISION_VALUE)
 	{
-	  dest_prec = DB_GET_STRING_LENGTH (src_string);
+	  dest_prec = db_get_string_length (src_string);
 	}
       else
 	{
@@ -6281,15 +6281,15 @@ db_char_string_coerce (const DB_VALUE * src_string, DB_VALUE * dest_string, DB_D
 	}
 
       error_status =
-	qstr_coerce ((unsigned char *) DB_GET_STRING (src_string), DB_GET_STRING_LENGTH (src_string),
+	qstr_coerce ((unsigned char *) db_get_string (src_string), db_get_string_length (src_string),
 		     QSTR_VALUE_PRECISION (src_string), DB_VALUE_DOMAIN_TYPE (src_string), src_codeset, dest_codeset,
 		     &dest, &dest_length, &dest_size, dest_prec, DB_VALUE_DOMAIN_TYPE (dest_string), data_status);
 
       if (error_status == NO_ERROR && dest != NULL)
 	{
 	  qstr_make_typed_string (DB_VALUE_DOMAIN_TYPE (dest_string), dest_string, DB_VALUE_PRECISION (dest_string),
-				  (char *) dest, dest_size, DB_GET_STRING_CODESET (dest_string),
-				  DB_GET_STRING_COLLATION (dest_string));
+				  (char *) dest, dest_size, db_get_string_codeset (dest_string),
+				  db_get_string_collation (dest_string));
 	  dest[dest_size] = 0;
 	  dest_string->need_clear = true;
 	}
@@ -6382,7 +6382,7 @@ db_find_string_in_in_set (const DB_VALUE * needle, const DB_VALUE * stack, DB_VA
 
   if (DB_IS_NULL (needle) || DB_IS_NULL (stack))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -6403,14 +6403,14 @@ db_find_string_in_in_set (const DB_VALUE * needle, const DB_VALUE * stack, DB_VA
     }
 
   if (qstr_get_category (needle) != qstr_get_category (stack)
-      || DB_GET_STRING_CODESET (needle) != DB_GET_STRING_CODESET (stack))
+      || db_get_string_codeset (needle) != db_get_string_codeset (stack))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INCOMPATIBLE_CODE_SETS, 0);
       err = ER_QSTR_INCOMPATIBLE_CODE_SETS;
       goto error_return;
     }
 
-  LANG_RT_COMMON_COLL (DB_GET_STRING_COLLATION (stack), DB_GET_STRING_COLLATION (needle), coll_id);
+  LANG_RT_COMMON_COLL (db_get_string_collation (stack), db_get_string_collation (needle), coll_id);
   if (coll_id == -1)
     {
       err = ER_QSTR_INCOMPATIBLE_COLLATIONS;
@@ -6418,10 +6418,10 @@ db_find_string_in_in_set (const DB_VALUE * needle, const DB_VALUE * stack, DB_VA
       goto error_return;
     }
 
-  stack_str = DB_GET_STRING (stack);
-  stack_size = DB_GET_STRING_SIZE (stack);
-  needle_str = DB_GET_STRING (needle);
-  needle_size = DB_GET_STRING_SIZE (needle);
+  stack_str = db_get_string (stack);
+  stack_size = db_get_string_size (stack);
+  needle_str = db_get_string (needle);
+  needle_size = db_get_string_size (needle);
 
   if (stack_size == 0 && needle_size == 0)
     {
@@ -6441,7 +6441,7 @@ db_find_string_in_in_set (const DB_VALUE * needle, const DB_VALUE * stack, DB_VA
 	    {
 	      if (needle_size == 0)
 		{
-		  DB_MAKE_INT (result, position);
+		  db_make_int (result, position);
 		  return NO_ERROR;
 		}
 	    }
@@ -6456,7 +6456,7 @@ db_find_string_in_in_set (const DB_VALUE * needle, const DB_VALUE * stack, DB_VA
 				(const unsigned char *) needle_str, needle_size, NULL, false, &matched_stack_size);
 		  if (cmp == 0 && matched_stack_size == CAST_BUFLEN (stack_ptr - elem_start))
 		    {
-		      DB_MAKE_INT (result, position);
+		      db_make_int (result, position);
 		      return NO_ERROR;
 		    }
 		}
@@ -6478,11 +6478,11 @@ db_find_string_in_in_set (const DB_VALUE * needle, const DB_VALUE * stack, DB_VA
 
 match_not_found:
   /* if we didn't find it in the loop above, then there is no match */
-  DB_MAKE_INTEGER (result, 0);
+  db_make_int (result, 0);
   return NO_ERROR;
 
 error_return:
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       er_clear ();
@@ -6509,7 +6509,7 @@ db_bigint_to_binary_string (const DB_VALUE * src_bigint, DB_VALUE * result)
 
   if (DB_IS_NULL (src_bigint))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -6521,7 +6521,7 @@ db_bigint_to_binary_string (const DB_VALUE * src_bigint, DB_VALUE * result)
       goto error_return;
     }
 
-  bigint_val = DB_GET_BIGINT (src_bigint);
+  bigint_val = db_get_bigint (src_bigint);
 
   /* count the number of digits in bigint_val */
   if (bigint_val < (DB_BIGINT) 0)
@@ -6557,7 +6557,7 @@ db_bigint_to_binary_string (const DB_VALUE * src_bigint, DB_VALUE * result)
       binary_form[digits_count - i - 1] = ((DB_BIGINT) 1 << i) & bigint_val ? '1' : '0';
     }
 
-  DB_MAKE_VARCHAR (result, digits_count, binary_form, digits_count, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
+  db_make_varchar (result, digits_count, binary_form, digits_count, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
   result->need_clear = true;
   return error;
 
@@ -6567,7 +6567,7 @@ error_return:
       db_private_free (NULL, binary_form);
     }
   pr_clear_value (result);
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       er_clear ();
@@ -6606,7 +6606,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 
   if (DB_IS_NULL (left) || DB_IS_NULL (right))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -6620,7 +6620,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	bool has_zone = false;
 	bool is_explicit_time = false;
 
-	error = db_string_to_datetimetz (DB_GET_STRING (left), &ldatetimetz, &has_zone);
+	error = db_string_to_datetimetz (db_get_string (left), &ldatetimetz, &has_zone);
 	if (error == NO_ERROR && has_zone == true)
 	  {
 	    tz_id = ldatetimetz.tz_id;
@@ -6630,12 +6630,12 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	    break;
 	  }
 
-	error = db_date_parse_time (DB_GET_STRING (left), DB_GET_STRING_SIZE (left), &ltime, &lms);
+	error = db_date_parse_time (db_get_string (left), db_get_string_size (left), &ltime, &lms);
 	if (error != NO_ERROR)
 	  {
 	    /* left may be a date string, try it here */
 	    error =
-	      db_date_parse_datetime_parts (DB_GET_STRING (left), DB_GET_STRING_SIZE (left), &ldatetime,
+	      db_date_parse_datetime_parts (db_get_string (left), db_get_string_size (left), &ldatetime,
 					    &is_explicit_time, NULL, NULL, NULL);
 	    if (error != NO_ERROR)
 	      {
@@ -6660,7 +6660,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	is_time_decoded = true;
 
 	error =
-	  db_date_parse_datetime_parts (DB_GET_STRING (left), DB_GET_STRING_SIZE (left), &ldatetime, &is_explicit_time,
+	  db_date_parse_datetime_parts (db_get_string (left), db_get_string_size (left), &ldatetime, &is_explicit_time,
 					NULL, NULL, NULL);
 	if (error != NO_ERROR || !is_explicit_time)
 	  {
@@ -6686,7 +6686,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 
     case DB_TYPE_DATETIME:
     case DB_TYPE_DATETIMELTZ:
-      ldatetime = *(DB_GET_DATETIME (left));
+      ldatetime = *(db_get_datetime (left));
       left_is_datetime = true;
 
       if (DB_VALUE_TYPE (left) == DB_TYPE_DATETIME)
@@ -6703,7 +6703,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
       {
 	DB_DATETIMETZ *dt_tz_p;
 
-	dt_tz_p = DB_GET_DATETIMETZ (left);
+	dt_tz_p = db_get_datetimetz (left);
 	ldatetime = dt_tz_p->datetime;
 	tz_id = dt_tz_p->tz_id;
 	left_is_datetime = true;
@@ -6712,7 +6712,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
       }
     case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
-      db_timestamp_decode_utc (DB_GET_TIMESTAMP (left), &ldatetime.date, &ltime);
+      db_timestamp_decode_utc (db_get_timestamp (left), &ldatetime.date, &ltime);
       ldatetime.time = ltime * 1000;
       left_is_datetime = true;
       if (DB_VALUE_TYPE (left) == DB_TYPE_TIMESTAMP)
@@ -6729,7 +6729,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
       {
 	DB_TIMESTAMPTZ *ts_tz_p;
 
-	ts_tz_p = DB_GET_TIMESTAMPTZ (left);
+	ts_tz_p = db_get_timestamptz (left);
 	db_timestamp_decode_utc (&ts_tz_p->timestamp, &ldatetime.date, &ltime);
 
 	ldatetime.time = ltime * 1000;
@@ -6740,19 +6740,19 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
       }
 
     case DB_TYPE_DATE:
-      ldatetime.date = *(DB_GET_DATE (left));
+      ldatetime.date = *(db_get_date (left));
       left_is_datetime = true;
       result_type = DB_TYPE_DATETIME;
       break;
 
     case DB_TYPE_TIME:
-      ltime = *(DB_GET_TIME (left));
+      ltime = *(db_get_time (left));
       left_is_datetime = false;
       result_type = DB_TYPE_TIME;
       break;
 
     case DB_TYPE_TIMELTZ:
-      error = tz_timeltz_to_local (DB_GET_TIME (left), &ltime);
+      error = tz_timeltz_to_local (db_get_time (left), &ltime);
       if (error != NO_ERROR)
 	{
 	  goto error_return;
@@ -6763,7 +6763,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 
     case DB_TYPE_TIMETZ:
       {
-	DB_TIMETZ *time_tz_p = DB_GET_TIMETZ (left);
+	DB_TIMETZ *time_tz_p = db_get_timetz (left);
 	error = tz_utc_timetz_to_local (&time_tz_p->time, &time_tz_p->tz_id, &ltime);
 	if (error != NO_ERROR)
 	  {
@@ -6853,7 +6853,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	{
 	  /* the result type can be DATETIME only if the first argument is a DATE or a DATETIME */
 	  assert (false);
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	}
 
       if (DB_VALUE_TYPE (left) == DB_TYPE_TIMESTAMP)
@@ -6868,7 +6868,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	  result_datetime = dt_local;
 	}
 
-      DB_MAKE_DATETIME (result, &result_datetime);
+      db_make_datetime (result, &result_datetime);
       break;
 
     case DB_TYPE_DATETIMELTZ:
@@ -6877,10 +6877,10 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	  {
 	    /* the result type can be DATETIME only if the first argument is a DATE or a DATETIME */
 	    assert (false);
-	    DB_MAKE_NULL (result);
+	    db_make_null (result);
 	  }
 
-	DB_MAKE_DATETIMELTZ (result, &result_datetime);
+	db_make_datetimeltz (result, &result_datetime);
 	break;
       }
 
@@ -6892,7 +6892,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	  {
 	    /* the result type can be DATETIME only if the first argument is a DATE or a DATETIME */
 	    assert (false);
-	    DB_MAKE_NULL (result);
+	    db_make_null (result);
 	  }
 
 	error = tz_create_datetimetz_from_parts (month, day, year, lhour, lminute, lsecond, lms, &tz_id, &dt_tz);
@@ -6900,7 +6900,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	  {
 	    goto error_return;
 	  }
-	DB_MAKE_DATETIMETZ (result, &dt_tz);
+	db_make_datetimetz (result, &dt_tz);
 	break;
       }
 
@@ -6909,9 +6909,9 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	{
 	  /* the result type can be DATETIME only if the first argument is a TIME */
 	  assert (false);
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	}
-      DB_MAKE_TIME (result, rhour, rminute, rsecond);
+      db_make_time (result, rhour, rminute, rsecond);
       break;
 
     case DB_TYPE_TIMELTZ:
@@ -6922,7 +6922,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	  {
 	    /* the result type can be DATETIME only if the first argument is a TIME */
 	    assert (false);
-	    DB_MAKE_NULL (result);
+	    db_make_null (result);
 	  }
 
 	(void) db_time_encode (&time_res, rhour, rminute, rsecond);
@@ -6931,7 +6931,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	  {
 	    goto error_return;
 	  }
-	DB_MAKE_TIMELTZ (result, &time_tz.time);
+	db_make_timeltz (result, &time_tz.time);
 	break;
       }
 
@@ -6945,7 +6945,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	  {
 	    /* the result type can be DATETIME only if the first argument is a TIME */
 	    assert (false);
-	    DB_MAKE_NULL (result);
+	    db_make_null (result);
 	  }
 
 	(void) db_time_encode (&time_res, rhour, rminute, rsecond);
@@ -6955,7 +6955,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	  {
 	    goto error_return;
 	  }
-	DB_MAKE_TIMETZ (result, &time_tz);
+	db_make_timetz (result, &time_tz);
 	break;
       }
 
@@ -6973,7 +6973,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	    }
 
 	  db_datetime_to_string (res_s, QSTR_DATETIME_LENGTH + 1, &result_datetime);
-	  DB_MAKE_VARCHAR (result, strlen (res_s), res_s, strlen (res_s), codeset, collation_id);
+	  db_make_varchar (result, strlen (res_s), res_s, strlen (res_s), codeset, collation_id);
 	}
       else
 	{
@@ -6985,13 +6985,13 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	    }
 	  db_time_encode (&rtime, rhour, rminute, rsecond);
 	  db_time_to_string (res_s, QSTR_TIME_LENGTH + 1, &rtime);
-	  DB_MAKE_VARCHAR (result, strlen (res_s), res_s, strlen (res_s), codeset, collation_id);
+	  db_make_varchar (result, strlen (res_s), res_s, strlen (res_s), codeset, collation_id);
 	}
       result->need_clear = true;
       break;
     default:
       assert (false);
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       break;
     }
 
@@ -7002,7 +7002,7 @@ error_return:
     {
       db_private_free (NULL, res_s);
     }
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       /* clear error and return NULL */
@@ -7087,11 +7087,11 @@ db_string_convert (const DB_VALUE * src_string, DB_VALUE * dest_string)
       int num_unconverted, cnv_size;
 
 
-      src = (unsigned char *) DB_GET_NCHAR (src_string, &src_length);
+      src = (unsigned char *) db_get_nchar (src_string, &src_length);
       src_precision = QSTR_VALUE_PRECISION (src_string);
 
-      src_codeset = DB_GET_STRING_CODESET (src_string);
-      dest_codeset = DB_GET_STRING_CODESET (dest_string);
+      src_codeset = db_get_string_codeset (src_string);
+      dest_codeset = db_get_string_codeset (dest_string);
 
       /* Fixed-length strings */
 
@@ -7114,7 +7114,7 @@ db_string_convert (const DB_VALUE * src_string, DB_VALUE * dest_string)
 	      qstr_pad_string ((unsigned char *) &dest[cnv_size], (src_precision - src_length + num_unconverted),
 			       dest_codeset);
 	      dest[src_precision] = 0;
-	      DB_MAKE_NCHAR (dest_string, src_precision, (char *) dest, src_precision);
+	      db_make_nchar (dest_string, src_precision, (char *) dest, src_precision);
 	      dest_string->need_clear = true;
 	    }
 	  else
@@ -7139,7 +7139,7 @@ db_string_convert (const DB_VALUE * src_string, DB_VALUE * dest_string)
 	  if (convert_status == NO_ERROR)
 	    {
 	      dest[src_length - num_unconverted] = 0;
-	      DB_MAKE_VARNCHAR (dest_string, src_precision, (char *) dest, (src_length - num_unconverted));
+	      db_make_varnchar (dest_string, src_precision, (char *) dest, (src_length - num_unconverted));
 	      dest_string->need_clear = true;
 	    }
 	  else
@@ -7590,32 +7590,32 @@ qstr_make_typed_string (const DB_TYPE db_type, DB_VALUE * value, const int preci
   switch (db_type)
     {
     case DB_TYPE_CHAR:
-      DB_MAKE_CHAR (value, precision, src, s_unit, codeset, collation_id);
+      db_make_char (value, precision, src, s_unit, codeset, collation_id);
       break;
 
     case DB_TYPE_VARCHAR:
-      DB_MAKE_VARCHAR (value, precision, src, s_unit, codeset, collation_id);
+      db_make_varchar (value, precision, src, s_unit, codeset, collation_id);
       break;
 
     case DB_TYPE_NCHAR:
-      DB_MAKE_NCHAR (value, precision, src, s_unit, codeset, collation_id);
+      db_make_nchar (value, precision, src, s_unit, codeset, collation_id);
       break;
 
     case DB_TYPE_VARNCHAR:
-      DB_MAKE_VARNCHAR (value, precision, src, s_unit, codeset, collation_id);
+      db_make_varnchar (value, precision, src, s_unit, codeset, collation_id);
       break;
 
     case DB_TYPE_BIT:
-      DB_MAKE_BIT (value, precision, src, s_unit);
+      db_make_bit (value, precision, src, s_unit);
       break;
 
     case DB_TYPE_VARBIT:
-      DB_MAKE_VARBIT (value, precision, src, s_unit);
+      db_make_varbit (value, precision, src, s_unit);
       break;
 
     default:
       assert (false);
-      DB_MAKE_NULL (value);
+      db_make_null (value);
       break;
     }
 }
@@ -8301,7 +8301,7 @@ qstr_grow_string (DB_VALUE * src_string, DB_VALUE * result, int new_size)
   assert (result != (DB_VALUE *) NULL);
 
   src_type = DB_VALUE_DOMAIN_TYPE (src_string);
-  src_length = (int) DB_GET_STRING_LENGTH (src_string);
+  src_length = (int) db_get_string_length (src_string);
   result_domain_length = DB_VALUE_PRECISION (src_string);
 
   if (!QSTR_IS_ANY_CHAR (src_type) || DB_IS_NULL (src_string))
@@ -8317,11 +8317,11 @@ qstr_grow_string (DB_VALUE * src_string, DB_VALUE * result, int new_size)
       result_type = DB_TYPE_CHAR;
     }
 
-  codeset = DB_GET_STRING_CODESET (src_string);
+  codeset = db_get_string_codeset (src_string);
 
   result_size = src_length * INTL_CODESET_MULT (codeset);
 
-  src_size = DB_GET_STRING_SIZE (src_string);
+  src_size = db_get_string_size (src_string);
 
   assert (new_size >= result_size);
   assert (new_size >= src_size);
@@ -8334,7 +8334,7 @@ qstr_grow_string (DB_VALUE * src_string, DB_VALUE * result, int new_size)
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_QPROC_STRING_SIZE_TOO_BIG, 2, result_size,
 	      (int) prm_get_bigint_value (PRM_ID_STRING_MAX_SIZE_BYTES));
 
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
   /* Allocate storage for the result string */
@@ -8348,10 +8348,10 @@ qstr_grow_string (DB_VALUE * src_string, DB_VALUE * result, int new_size)
 
   if (src_size > 0)
     {
-      memcpy ((char *) r, (char *) DB_GET_STRING (src_string), src_size);
+      memcpy ((char *) r, (char *) db_get_string (src_string), src_size);
     }
   qstr_make_typed_string (result_type, result, result_domain_length, (char *) r, (int) MIN (result_size, src_size),
-			  codeset, DB_GET_STRING_COLLATION (src_string));
+			  codeset, db_get_string_collation (src_string));
 
   if (prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING) == true && DB_IS_NULL (result)
       && QSTR_IS_ANY_CHAR_OR_BIT (DB_VALUE_DOMAIN_TYPE (result)))
@@ -10365,7 +10365,7 @@ db_unix_timestamp (const DB_VALUE * src_date, DB_VALUE * result_timestamp)
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result_timestamp);
+      db_make_null (result_timestamp);
       return error_status;
     }
 
@@ -10410,7 +10410,7 @@ db_unix_timestamp (const DB_VALUE * src_date, DB_VALUE * result_timestamp)
 		  {
 		    error_status = ER_OBJ_INVALID_ARGUMENTS;
 		    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
-		    DB_MAKE_NULL (result_timestamp);
+		    db_make_null (result_timestamp);
 		    return ER_FAILED;
 		  }
 	      }
@@ -10428,19 +10428,19 @@ db_unix_timestamp (const DB_VALUE * src_date, DB_VALUE * result_timestamp)
 	  {
 	    DB_DATETIMETZ *datetimetz;
 
-	    datetimetz = DB_GET_DATETIMETZ (dt_tz_p);
+	    datetimetz = db_get_datetimetz (dt_tz_p);
 	    datetime = datetimetz->datetime;
 	    datetime.time /= 1000;
 	  }
 	else if (type == DB_TYPE_DATETIME)
 	  {
-	    datetime = *DB_GET_DATETIME (dt_tz_p);
+	    datetime = *db_get_datetime (dt_tz_p);
 	    datetime.time /= 1000;
 	  }
 	else
 	  {
 	    assert (type == DB_TYPE_DATE);
-	    date = *DB_GET_DATE (dt_tz_p);
+	    date = *db_get_date (dt_tz_p);
 	    datetime.date = date;
 	    datetime.time = 0;
 	  }
@@ -10463,7 +10463,7 @@ db_unix_timestamp (const DB_VALUE * src_date, DB_VALUE * result_timestamp)
 	      }
 	  }
 
-	DB_MAKE_INT (result_timestamp, timestamp);
+	db_make_int (result_timestamp, timestamp);
 	return NO_ERROR;
       }
 
@@ -10476,12 +10476,12 @@ db_unix_timestamp (const DB_VALUE * src_date, DB_VALUE * result_timestamp)
 
 	if (type == DB_TYPE_DATETIMETZ)
 	  {
-	    datetimetz = DB_GET_DATETIMETZ (src_date);
+	    datetimetz = db_get_datetimetz (src_date);
 	    datetime = datetimetz->datetime;
 	  }
 	else
 	  {
-	    datetime = *DB_GET_DATETIME (src_date);
+	    datetime = *db_get_datetime (src_date);
 	  }
 
 	datetime.time /= 1000;
@@ -10490,7 +10490,7 @@ db_unix_timestamp (const DB_VALUE * src_date, DB_VALUE * result_timestamp)
 	  {
 	    return error_status;
 	  }
-	DB_MAKE_INT (result_timestamp, timestamp);
+	db_make_int (result_timestamp, timestamp);
 
 	return NO_ERROR;
       }
@@ -10499,27 +10499,27 @@ db_unix_timestamp (const DB_VALUE * src_date, DB_VALUE * result_timestamp)
     case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
       /* The supported timestamp range is '1970-01-01 00:00:01' UTC to '2038-01-19 03:14:07' UTC */
-      ts = *DB_GET_TIMESTAMP (src_date);
+      ts = *db_get_timestamp (src_date);
       /* supplementary conversion from long to int will be needed on 64 bit platforms.  */
-      DB_MAKE_INT (result_timestamp, (int) ts);
+      db_make_int (result_timestamp, (int) ts);
       return NO_ERROR;
 
     case DB_TYPE_TIMESTAMPTZ:
       {
 	DB_TIMESTAMPTZ *timestamp_tz;
-	timestamp_tz = DB_GET_TIMESTAMPTZ (src_date);
+	timestamp_tz = db_get_timestamptz (src_date);
 	ts = timestamp_tz->timestamp;
-	DB_MAKE_INT (result_timestamp, (int) ts);
+	db_make_int (result_timestamp, (int) ts);
 	return NO_ERROR;
       }
 
     default:
-      DB_MAKE_NULL (result_timestamp);
+      db_make_null (result_timestamp);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
       return ER_FAILED;
     }
 
-  DB_MAKE_NULL (result_timestamp);
+  db_make_null (result_timestamp);
   er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
   return ER_FAILED;
 }
@@ -10608,7 +10608,7 @@ db_get_date_dayofyear (const DB_VALUE * src_date, DB_VALUE * result)
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -10627,7 +10627,7 @@ db_get_date_dayofyear (const DB_VALUE * src_date, DB_VALUE * result)
     }
 
   day_of_year = db_get_day_of_year (year, month, day);
-  DB_MAKE_INT (result, day_of_year);
+  db_make_int (result, day_of_year);
 
   return NO_ERROR;
 
@@ -10635,7 +10635,7 @@ error_exit:
   /* This function should return NULL if src_date is an invalid parameter or Zero date. Clear the error generated by
    * the function call and return null. */
   er_clear ();
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       return NO_ERROR;
@@ -10668,7 +10668,7 @@ db_get_date_weekday (const DB_VALUE * src_date, const int mode, DB_VALUE * resul
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -10701,18 +10701,18 @@ db_get_date_weekday (const DB_VALUE * src_date, const int mode, DB_VALUE * resul
 	{
 	  day_of_week--;
 	}
-      DB_MAKE_INT (result, day_of_week);
+      db_make_int (result, day_of_week);
       break;
 
     case PT_DAYOFWEEK:
       /* 1 = Sunday, 2 = Monday, ..., 7 = Saturday */
       day_of_week++;
-      DB_MAKE_INT (result, day_of_week);
+      db_make_int (result, day_of_week);
       break;
 
     default:
       assert (false);
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       break;
     }
 
@@ -10722,7 +10722,7 @@ error_exit:
   /* This function should return NULL if src_date is an invalid parameter or zero date. Clear the error generated by
    * the function call and return null. */
   er_clear ();
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       return NO_ERROR;
@@ -10752,7 +10752,7 @@ db_get_date_quarter (const DB_VALUE * src_date, DB_VALUE * result)
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
   /* get the date/time information from src_date */
@@ -10760,7 +10760,7 @@ db_get_date_quarter (const DB_VALUE * src_date, DB_VALUE * result)
   if (retval != NO_ERROR || (endp && *endp && !char_isspace (*endp)))
     {
       er_clear ();
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  return NO_ERROR;
@@ -10772,23 +10772,23 @@ db_get_date_quarter (const DB_VALUE * src_date, DB_VALUE * result)
   if (year == 0 && month == 0 && day == 0 && hour == 0 && minute == 0 && second == 0 && ms == 0)
     {
       /* This function should return 0 if src_date is zero date */
-      DB_MAKE_INT (result, 0);
+      db_make_int (result, 0);
     }
   /* db_datetime_decode returned NO_ERROR so we can calculate the quarter */
   else if (month == 0)
     {
       assert (false);
-      DB_MAKE_INT (result, 0);
+      db_make_int (result, 0);
     }
   else if (month < 0 || month > 12)
     {
       assert (false);
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
   else
     {
       const int quarter = (month - 1) / 3 + 1;
-      DB_MAKE_INT (result, quarter);
+      db_make_int (result, quarter);
     }
 
   return NO_ERROR;
@@ -10814,7 +10814,7 @@ db_get_date_totaldays (const DB_VALUE * src_date, DB_VALUE * result)
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -10835,13 +10835,13 @@ db_get_date_totaldays (const DB_VALUE * src_date, DB_VALUE * result)
   leap_years = count_leap_years_up_to (year - 1);
   days_this_year = db_get_day_of_year (year, month, day);
   total_days = year * 365 + leap_years + days_this_year;
-  DB_MAKE_INT (result, total_days);
+  db_make_int (result, total_days);
 
   return NO_ERROR;
 
 error_exit:
   er_clear ();
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       return NO_ERROR;
@@ -10872,7 +10872,7 @@ db_get_date_from_days (const DB_VALUE * src, DB_VALUE * result)
 
   if (DB_IS_NULL (src))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -10885,7 +10885,7 @@ db_get_date_from_days (const DB_VALUE * src, DB_VALUE * result)
    * 0000-00-00 for less than 366 days */
   if (int_value < 366)
     {
-      DB_MAKE_DATE (result, 0, 0, 0);
+      db_make_date (result, 0, 0, 0);
       return NO_ERROR;
     }
 
@@ -10898,11 +10898,11 @@ db_get_date_from_days (const DB_VALUE * src, DB_VALUE * result)
 
   if (year > 9999)
     {
-      DB_MAKE_DATE (result, 0, 0, 0);
+      db_make_date (result, 0, 0, 0);
       return NO_ERROR;
     }
 
-  DB_MAKE_DATE (result, month, day, year);
+  db_make_date (result, month, day, year);
   return NO_ERROR;
 }
 
@@ -10926,7 +10926,7 @@ db_add_days_to_year (const DB_VALUE * src_year, const DB_VALUE * src_days, DB_VA
 
   if (DB_IS_NULL (src_year) || DB_IS_NULL (src_days))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -10966,11 +10966,11 @@ db_add_days_to_year (const DB_VALUE * src_year, const DB_VALUE * src_days, DB_VA
       goto error;
     }
 
-  DB_MAKE_DATE (result, month, day, year);
+  db_make_date (result, month, day, year);
   return NO_ERROR;
 
 error:
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
@@ -11001,7 +11001,7 @@ db_convert_to_time (const DB_VALUE * src_hour, const DB_VALUE * src_minute, cons
 
   if (DB_IS_NULL (src_hour) || DB_IS_NULL (src_minute) || DB_IS_NULL (src_second))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -11016,11 +11016,11 @@ db_convert_to_time (const DB_VALUE * src_hour, const DB_VALUE * src_minute, cons
       goto error;
     }
 
-  DB_MAKE_TIME (result, hour, minute, second);
+  db_make_time (result, hour, minute, second);
   return NO_ERROR;
 
 error:
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
@@ -11059,7 +11059,7 @@ db_convert_sec_to_time (const DB_VALUE * src, DB_VALUE * result)
 
   if (DB_IS_NULL (src))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -11083,11 +11083,11 @@ db_convert_sec_to_time (const DB_VALUE * src, DB_VALUE * result)
       goto error;
     }
 
-  DB_MAKE_TIME (result, hours, minutes, seconds);
+  db_make_time (result, hours, minutes, seconds);
   return NO_ERROR;
 
 error:
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
@@ -11117,7 +11117,7 @@ db_convert_time_to_sec (const DB_VALUE * src_date, DB_VALUE * result)
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -11125,7 +11125,7 @@ db_convert_time_to_sec (const DB_VALUE * src_date, DB_VALUE * result)
   if (error_status != NO_ERROR)
     {
       er_clear ();
-      DB_MAKE_NULL (result);
+      db_make_null (result);
 
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
@@ -11136,7 +11136,7 @@ db_convert_time_to_sec (const DB_VALUE * src_date, DB_VALUE * result)
     }
 
   total_seconds = hour * 3600 + minute * 60 + second;
-  DB_MAKE_INT (result, total_seconds);
+  db_make_int (result, total_seconds);
 
   return NO_ERROR;
 }
@@ -11159,23 +11159,23 @@ db_round_dbvalue_to_int (const DB_VALUE * src, int *result)
   switch (src_type)
     {
     case DB_TYPE_SMALLINT:
-      *result = DB_GET_SMALLINT (src);
+      *result = db_get_short (src);
       return NO_ERROR;
 
     case DB_TYPE_INTEGER:
-      *result = DB_GET_INT (src);
+      *result = db_get_int (src);
       return NO_ERROR;
 
     case DB_TYPE_FLOAT:
       {
-	float x = DB_GET_FLOAT (src);
+	float x = db_get_float (src);
 	*result = (int) ((x) > 0 ? ((x) + .5) : ((x) - .5));
 	return NO_ERROR;
       }
 
     case DB_TYPE_DOUBLE:
       {
-	double x = DB_GET_DOUBLE (src);
+	double x = db_get_double (src);
 	*result = (int) ((x) > 0 ? ((x) + .5) : ((x) - .5));
 	return NO_ERROR;
       }
@@ -11189,12 +11189,12 @@ db_round_dbvalue_to_int (const DB_VALUE * src, int *result)
       }
 
     case DB_TYPE_BIGINT:
-      *result = (int) DB_GET_BIGINT (src);
+      *result = (int) db_get_bigint (src);
       return NO_ERROR;
 
     case DB_TYPE_MONETARY:
       {
-	double x = (DB_GET_MONETARY (src))->amount;
+	double x = (db_get_monetary (src))->amount;
 	*result = (int) ((x) > 0 ? ((x) + .5) : ((x) - .5));
 	return NO_ERROR;
       }
@@ -11213,7 +11213,7 @@ db_round_dbvalue_to_int (const DB_VALUE * src, int *result)
 	    return error_status;
 	  }
 
-	x = DB_GET_DOUBLE (&val);
+	x = db_get_double (&val);
 	*result = (int) ((x) > 0 ? ((x) + .5) : ((x) - .5));
 	return NO_ERROR;
       }
@@ -11296,7 +11296,7 @@ db_get_date_week (const DB_VALUE * src_date, const DB_VALUE * mode, DB_VALUE * r
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -11336,12 +11336,12 @@ db_get_date_week (const DB_VALUE * src_date, const DB_VALUE * mode, DB_VALUE * r
 
   week_number = db_get_week_of_year (year, month, day, calc_mode);
 
-  DB_MAKE_INT (result, week_number);
+  db_make_int (result, week_number);
   return NO_ERROR;
 
 error_exit:
   er_clear ();
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       return NO_ERROR;
@@ -11370,7 +11370,7 @@ db_get_date_item (const DB_VALUE * src_date, const int item_type, DB_VALUE * res
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -11380,7 +11380,7 @@ db_get_date_item (const DB_VALUE * src_date, const int item_type, DB_VALUE * res
       /* This function should return NULL if src_date is an invalid parameter. Clear the error generated by the
        * function call and return null. */
       er_clear ();
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  return NO_ERROR;
@@ -11393,17 +11393,17 @@ db_get_date_item (const DB_VALUE * src_date, const int item_type, DB_VALUE * res
   switch (item_type)
     {
     case PT_YEARF:
-      DB_MAKE_INT (result, year);
+      db_make_int (result, year);
       break;
     case PT_MONTHF:
-      DB_MAKE_INT (result, month);
+      db_make_int (result, month);
       break;
     case PT_DAYF:
-      DB_MAKE_INT (result, day);
+      db_make_int (result, day);
       break;
     default:
       assert (false);
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       break;
     }
 
@@ -11426,14 +11426,14 @@ db_get_time_item (const DB_VALUE * src_date, const int item_type, DB_VALUE * res
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
   if (db_get_time_from_dbvalue (src_date, &hour, &minute, &second, &millisecond) != NO_ERROR)
     {
       er_clear ();
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  return NO_ERROR;
@@ -11445,17 +11445,17 @@ db_get_time_item (const DB_VALUE * src_date, const int item_type, DB_VALUE * res
   switch (item_type)
     {
     case PT_HOURF:
-      DB_MAKE_INT (result, hour);
+      db_make_int (result, hour);
       break;
     case PT_MINUTEF:
-      DB_MAKE_INT (result, minute);
+      db_make_int (result, minute);
       break;
     case PT_SECONDF:
-      DB_MAKE_INT (result, second);
+      db_make_int (result, second);
       break;
     default:
       assert (false);
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       break;
     }
 
@@ -11522,16 +11522,16 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
   res = NULL;
   res2 = NULL;
 
-  DB_MAKE_NULL (&new_time_value);
+  db_make_null (&new_time_value);
 
   if (time_value == NULL || format == NULL || DB_IS_NULL (time_value) || DB_IS_NULL (format))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       goto error;
     }
 
   assert (DB_VALUE_TYPE (date_lang) == DB_TYPE_INTEGER);
-  date_lang_id = lang_get_lang_id_from_flag (DB_GET_INT (date_lang), &dummy, &dummy);
+  date_lang_id = lang_get_lang_id_from_flag (db_get_int (date_lang), &dummy, &dummy);
   if (domain != NULL && domain->collation_flag != TP_DOMAIN_COLL_LEAVE)
     {
       codeset = TP_DOMAIN_CODESET (domain);
@@ -11539,8 +11539,8 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
     }
   else
     {
-      codeset = DB_GET_STRING_CODESET (format);
-      res_collation = DB_GET_STRING_COLLATION (format);
+      codeset = db_get_string_codeset (format);
+      res_collation = db_get_string_collation (format);
     }
 
   lld = lang_get_specific_locale (date_lang_id, codeset);
@@ -11575,7 +11575,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
       {
 	TZ_ID tz_id;
 
-	ts_p = DB_GET_TIMESTAMP (time_value);
+	ts_p = db_get_timestamp (time_value);
 	error_status = tz_create_session_tzid_for_timestamp (ts_p, &tz_id);
 	if (error_status != NO_ERROR)
 	  {
@@ -11600,7 +11600,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
 	DB_DATE date;
 	DB_TIME time;
 
-	tsmp_tz = DB_GET_TIMESTAMPTZ (time_value);
+	tsmp_tz = db_get_timestamptz (time_value);
 	error_status = db_timestamp_decode_w_tz_id (&tsmp_tz->timestamp, &tsmp_tz->tz_id, &date, &time);
 	if (error_status != NO_ERROR)
 	  {
@@ -11624,7 +11624,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
 	DB_TIME time;
 	TZ_ID tz_id;
 
-	tsmp = DB_GET_TIMESTAMP (time_value);
+	tsmp = db_get_timestamp (time_value);
 	error_status = tz_create_session_tzid_for_timestamp (tsmp, &tz_id);
 
 	if (error_status != NO_ERROR)
@@ -11651,7 +11651,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
       {
 	TZ_ID tz_id;
 
-	dt_p = DB_GET_DATETIME (time_value);
+	dt_p = db_get_datetime (time_value);
 	error_status = tz_create_session_tzid_for_datetime (dt_p, true, &tz_id);
 	if (error_status != NO_ERROR)
 	  {
@@ -11672,7 +11672,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
 	DB_DATETIME dt_local;
 	DB_DATETIMETZ *dt_tz;
 
-	dt_tz = DB_GET_DATETIMETZ (time_value);
+	dt_tz = db_get_datetimetz (time_value);
 	error_status = tz_utc_datetimetz_to_local (&dt_tz->datetime, &dt_tz->tz_id, &dt_local);
 	if (error_status != NO_ERROR)
 	  {
@@ -11694,7 +11694,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
 	DB_DATETIME *dt, dt_local;
 	TZ_ID tz_id;
 
-	dt = DB_GET_DATETIME (time_value);
+	dt = db_get_datetime (time_value);
 	error_status = tz_create_session_tzid_for_datetime (dt, true, &tz_id);
 	if (error_status != NO_ERROR)
 	  {
@@ -11723,7 +11723,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
       {
 	TZ_ID tz_id;
 
-	t_p = DB_GET_TIME (time_value);
+	t_p = db_get_time (time_value);
 
 	error_status = tz_create_session_tzid_for_time (t_p, true, &tz_id);
 	if (error_status != NO_ERROR)
@@ -11746,7 +11746,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
 	DB_TIMETZ *time_tz;
 	DB_TIME time_local;
 
-	time_tz = DB_GET_TIMETZ (time_value);
+	time_tz = db_get_timetz (time_value);
 
 	error_status = tz_utc_timetz_to_local (&time_tz->time, &time_tz->tz_id, &time_local);
 	if (error_status != NO_ERROR)
@@ -11769,7 +11769,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
 	TZ_ID tz_id;
 	DB_TIME time_local;
 
-	t_p = DB_GET_TIME (time_value);
+	t_p = db_get_time (time_value);
 
 	error_status = tz_create_session_tzid_for_time (t_p, true, &tz_id);
 	if (error_status != NO_ERROR)
@@ -11805,7 +11805,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
 
 	if (tp_value_cast (time_value, &tm, tp_time, false) == DOMAIN_COMPATIBLE)
 	  {
-	    db_time_decode (DB_GET_TIME (&tm), &h, &mi, &s);
+	    db_time_decode (db_get_time (&tm), &h, &mi, &s);
 	    is_time = true;
 	  }
 
@@ -11814,7 +11814,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
 	    DB_TIMETZ time_tz;
 	    DB_TIME time_local;
 
-	    time_tz = *DB_GET_TIMETZ (&tm);
+	    time_tz = *db_get_timetz (&tm);
 	    if (tz_explain_tz_id (&time_tz.tz_id, tzr, TZR_SIZE + 1, tzd, TZ_DS_STRING_SIZE + 1, &tzh, &tzm) ==
 		NO_ERROR)
 	      {
@@ -11917,8 +11917,8 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
     case DB_TYPE_VARNCHAR:
     case DB_TYPE_CHAR:
     case DB_TYPE_NCHAR:
-      format_s = DB_GET_STRING (format);
-      format_s_len = DB_GET_STRING_SIZE (format);
+      format_s = db_get_string (format);
+      format_s_len = db_get_string_size (format);
       break;
 
     default:
@@ -12058,7 +12058,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
 
   /* 4. */
 
-  DB_MAKE_STRING (result, res);
+  db_make_string (result, res);
   db_string_put_cs_and_collation (result, codeset, res_collation);
 
   result->need_clear = true;
@@ -12123,7 +12123,7 @@ db_timestamp (const DB_VALUE * src_datetime1, const DB_VALUE * src_time2, DB_VAL
    * 0. */
   if (DB_IS_NULL (src_datetime1) || (src_time2 && DB_IS_NULL (src_time2)))
     {
-      DB_MAKE_NULL (result_datetime);
+      db_make_null (result_datetime);
       return NO_ERROR;
     }
 
@@ -12146,32 +12146,32 @@ db_timestamp (const DB_VALUE * src_datetime1, const DB_VALUE * src_time2, DB_VAL
     {
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
-      parse_time_string ((const char *) DB_GET_STRING (src_time2), DB_GET_STRING_SIZE (src_time2), &sign, &h, &mi, &s,
+      parse_time_string ((const char *) db_get_string (src_time2), db_get_string_size (src_time2), &sign, &h, &mi, &s,
 			 &ms);
       break;
 
     case DB_TYPE_TIME:
-      db_time_decode (DB_GET_TIME (src_time2), &h, &mi, &s);
+      db_time_decode (db_get_time (src_time2), &h, &mi, &s);
       break;
 
     case DB_TYPE_SMALLINT:
-      amount = (DB_BIGINT) DB_GET_SMALLINT (src_time2);
+      amount = (DB_BIGINT) db_get_short (src_time2);
       break;
 
     case DB_TYPE_INTEGER:
-      amount = (DB_BIGINT) DB_GET_INTEGER (src_time2);
+      amount = (DB_BIGINT) db_get_int (src_time2);
       break;
 
     case DB_TYPE_BIGINT:
-      amount = DB_GET_BIGINT (src_time2);
+      amount = db_get_bigint (src_time2);
       break;
 
     case DB_TYPE_FLOAT:
-      amount_d = DB_GET_FLOAT (src_time2);
+      amount_d = db_get_float (src_time2);
       break;
 
     case DB_TYPE_DOUBLE:
-      amount_d = DB_GET_DOUBLE (src_time2);
+      amount_d = db_get_double (src_time2);
       break;
 
     case DB_TYPE_MONETARY:
@@ -12267,15 +12267,15 @@ db_add_months (const DB_VALUE * src_date, const DB_VALUE * nmonth, DB_VALUE * re
 
   if (DB_IS_NULL (src_date) || DB_IS_NULL (nmonth))
     {
-      DB_MAKE_NULL (result_date);
+      db_make_null (result_date);
       return error_status;
     }
 
   assert (DB_VALUE_TYPE (nmonth) == DB_TYPE_INTEGER);
-  n = DB_GET_INTEGER (nmonth);
+  n = db_get_int (nmonth);
 
   assert (DB_VALUE_TYPE (src_date) == DB_TYPE_DATE);
-  date_p = DB_GET_DATE (src_date);
+  date_p = db_get_date (src_date);
 
   db_date_decode (date_p, &month, &day, &year);
 
@@ -12302,7 +12302,7 @@ db_add_months (const DB_VALUE * src_date, const DB_VALUE * nmonth, DB_VALUE * re
 
   if (0 < year && year < 10000)
     {
-      DB_MAKE_DATE (result_date, month, day, year);
+      db_make_date (result_date, month, day, year);
     }
   else
     {
@@ -12328,7 +12328,7 @@ db_last_day (const DB_VALUE * src_date, DB_VALUE * result_day)
 
   if (DB_IS_NULL (src_date))
     {
-      DB_MAKE_NULL (result_day);
+      db_make_null (result_day);
       return error_status;
     }
 
@@ -12336,7 +12336,7 @@ db_last_day (const DB_VALUE * src_date, DB_VALUE * result_day)
 
   if (month == 0 && day == 0 && year == 0)
     {
-      DB_MAKE_NULL (result_day);
+      db_make_null (result_day);
       er_clear ();
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
@@ -12348,7 +12348,7 @@ db_last_day (const DB_VALUE * src_date, DB_VALUE * result_day)
 
   lastday = get_last_day (month, year);
 
-  DB_MAKE_DATE (result_day, month, lastday, year);
+  db_make_date (result_day, month, lastday, year);
 
   return error_status;
 }
@@ -12373,15 +12373,15 @@ db_months_between (const DB_VALUE * start_mon, const DB_VALUE * end_mon, DB_VALU
 
   if (DB_IS_NULL (start_mon) || DB_IS_NULL (end_mon))
     {
-      DB_MAKE_NULL (result_mon);
+      db_make_null (result_mon);
       return error_status;
     }
 
   assert (DB_VALUE_TYPE (start_mon) == DB_TYPE_DATE);
   assert (DB_VALUE_TYPE (end_mon) == DB_TYPE_DATE);
 
-  start_date = DB_GET_DATE (start_mon);
-  end_date = DB_GET_DATE (end_mon);
+  start_date = db_get_date (start_mon);
+  end_date = db_get_date (end_mon);
 
   db_date_decode (start_date, &start_month, &start_day, &start_year);
   db_date_decode (end_date, &end_month, &end_day, &end_year);
@@ -12398,7 +12398,7 @@ db_months_between (const DB_VALUE * start_mon, const DB_VALUE * end_mon, DB_VALU
 	(double) ((start_day - end_day) / 31.0);
     }
 
-  DB_MAKE_DOUBLE (result_mon, result_double);
+  db_make_double (result_mon, result_double);
 
   return error_status;
 }
@@ -12435,7 +12435,7 @@ db_sys_date (DB_VALUE * result_date)
       return error_status;
     }
 
-  DB_MAKE_DATE (result_date, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900);
+  db_make_date (result_date, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900);
 
   return error_status;
 }
@@ -12471,7 +12471,7 @@ db_sys_time (DB_VALUE * result_time)
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
-  DB_MAKE_TIME (result_time, c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec);
+  db_make_time (result_time, c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec);
 
   return error_status;
 }
@@ -12497,7 +12497,7 @@ db_sys_timestamp (DB_VALUE * result_timestamp)
       return error_status;
     }
 
-  DB_MAKE_TIMESTAMP (result_timestamp, (DB_TIMESTAMP) tloc);
+  db_make_timestamp (result_timestamp, (DB_TIMESTAMP) tloc);
 
   return error_status;
 }
@@ -12536,7 +12536,7 @@ db_sys_datetime (DB_VALUE * result_datetime)
 
   db_datetime_encode (&datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900,
 		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, tloc.millitm);
-  DB_MAKE_DATETIME (result_datetime, &datetime);
+  db_make_datetime (result_datetime, &datetime);
 
   return error_status;
 }
@@ -12580,8 +12580,8 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
   db_datetime_encode (&datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900,
 		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, tloc.millitm);
 
-  DB_MAKE_DATETIME (dt_dbval, &datetime);
-  DB_MAKE_TIMESTAMP (ts_dbval, (DB_TIMESTAMP) tloc.time);
+  db_make_datetime (dt_dbval, &datetime);
+  db_make_timestamp (ts_dbval, (DB_TIMESTAMP) tloc.time);
 
   return error_status;
 }
@@ -12610,7 +12610,7 @@ db_sys_timezone (DB_VALUE * result_timezone)
       return error_status;
     }
 
-  DB_MAKE_INTEGER (result_timezone, tloc.timezone);
+  db_make_int (result_timezone, tloc.timezone);
   return NO_ERROR;
 }
 
@@ -13128,16 +13128,16 @@ db_to_date (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
   assert (result_date != (DB_VALUE *) NULL);
   assert (date_lang != (DB_VALUE *) NULL);
 
-  DB_MAKE_NULL (&default_format);
+  db_make_null (&default_format);
 
   if (DB_IS_NULL (src_str))
     {
-      DB_MAKE_NULL (result_date);
+      db_make_null (result_date);
       return error_status;
     }
 
   assert (DB_VALUE_TYPE (date_lang) == DB_TYPE_INTEGER);
-  date_lang_id = lang_get_lang_id_from_flag (DB_GET_INT (date_lang), &has_user_format, &dummy);
+  date_lang_id = lang_get_lang_id_from_flag (db_get_int (date_lang), &has_user_format, &dummy);
 
   if (false == is_char_string (src_str))
     {
@@ -13146,21 +13146,21 @@ db_to_date (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
       return error_status;
     }
 
-  if (DB_GET_STRING_SIZE (src_str) == 0)
+  if (db_get_string_size (src_str) == 0)
     {
       error_status = ER_QSTR_EMPTY_STRING;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  if (DB_GET_STRING_SIZE (src_str) > MAX_TOKEN_SIZE)
+  if (db_get_string_size (src_str) > MAX_TOKEN_SIZE)
     {
       error_status = ER_QSTR_SRC_TOO_LONG;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  codeset = DB_GET_STRING_CODESET (src_str);
+  codeset = db_get_string_codeset (src_str);
   if (lang_get_specific_locale (date_lang_id, codeset) == NULL)
     {
       error_status = ER_LANG_CODESET_NOT_AVAILABLE;
@@ -13193,7 +13193,7 @@ db_to_date (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
       /* try default CUBRID format first */
       if (NO_ERROR == db_string_to_date_ex ((char *) cs, CAST_BUFLEN (last_src - cs), &date_tmp))
 	{
-	  DB_MAKE_ENCODED_DATE (result_date, &date_tmp);
+	  db_value_put_encoded_date (result_date, &date_tmp);
 	  goto exit;
 	}
 
@@ -13206,14 +13206,14 @@ db_to_date (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 	  goto exit;
 	}
 
-      DB_MAKE_CHAR (&default_format, strlen (default_format_str), (const DB_C_CHAR) (default_format_str),
+      db_make_char (&default_format, strlen (default_format_str), (const DB_C_CHAR) (default_format_str),
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
 
   if (DB_IS_NULL (format_str))
     {
-      DB_MAKE_NULL (result_date);
+      db_make_null (result_date);
       goto exit;
     }
 
@@ -13224,21 +13224,21 @@ db_to_date (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
       goto exit;
     }
 
-  if (DB_GET_STRING_SIZE (format_str) > MAX_TOKEN_SIZE)
+  if (db_get_string_size (format_str) > MAX_TOKEN_SIZE)
     {
       error_status = ER_QSTR_FORMAT_TOO_LONG;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       goto exit;
     }
 
-  if (DB_GET_STRING_SIZE (format_str) == 0)
+  if (db_get_string_size (format_str) == 0)
     {
       error_status = ER_QSTR_EMPTY_STRING;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       goto exit;
     }
 
-  frmt_codeset = DB_GET_STRING_CODESET (format_str);
+  frmt_codeset = db_get_string_codeset (format_str);
 
   error_status =
     db_check_or_create_null_term_string (format_str, stack_buf_format, sizeof (stack_buf_format), true, true,
@@ -13632,9 +13632,9 @@ db_to_date (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
       goto exit;
     }
 
-  DB_MAKE_DATE (result_date, month, day, year);
+  db_make_date (result_date, month, day, year);
 
-  if (*(DB_GET_DATE (result_date)) == 0)
+  if (*(db_get_date (result_date)) == 0)
     {
       error_status = ER_DATE_CONVERSION;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -13702,12 +13702,12 @@ db_to_time (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 
   if (DB_IS_NULL (src_str))
     {
-      DB_MAKE_NULL (result_time);
+      db_make_null (result_time);
       return error_status;
     }
 
   assert (DB_VALUE_TYPE (date_lang) == DB_TYPE_INTEGER);
-  date_lang_id = lang_get_lang_id_from_flag (DB_GET_INT (date_lang), &has_user_format, &dummy);
+  date_lang_id = lang_get_lang_id_from_flag (db_get_int (date_lang), &has_user_format, &dummy);
 
   /* now return null */
   if (false == is_char_string (src_str))
@@ -13717,21 +13717,21 @@ db_to_time (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
       return error_status;
     }
 
-  if (DB_GET_STRING_SIZE (src_str) == 0)
+  if (db_get_string_size (src_str) == 0)
     {
       error_status = ER_QSTR_EMPTY_STRING;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  if (DB_GET_STRING_SIZE (src_str) > MAX_TOKEN_SIZE)
+  if (db_get_string_size (src_str) > MAX_TOKEN_SIZE)
     {
       error_status = ER_QSTR_SRC_TOO_LONG;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  codeset = DB_GET_STRING_CODESET (src_str);
+  codeset = db_get_string_codeset (src_str);
   if (lang_get_specific_locale (date_lang_id, codeset) == NULL)
     {
       error_status = ER_LANG_CODESET_NOT_AVAILABLE;
@@ -13766,7 +13766,7 @@ db_to_time (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 	{
 	  if (NO_ERROR == db_string_to_time_ex ((const char *) cs, CAST_BUFLEN (last_src - cs), &time_tmp))
 	    {
-	      DB_MAKE_ENCODED_TIME (result_time, &time_tmp);
+	      db_value_put_encoded_time (result_time, &time_tmp);
 	      goto exit;
 	    }
 	}
@@ -13777,7 +13777,7 @@ db_to_time (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 	  if (db_string_to_timetz_ex ((const char *) cs, CAST_BUFLEN (last_src - cs), false, &timetz_tmp, &has_zone)
 	      == NO_ERROR)
 	    {
-	      DB_MAKE_TIMETZ (result_time, &timetz_tmp);
+	      db_make_timetz (result_time, &timetz_tmp);
 	      goto exit;
 	    }
 	}
@@ -13790,14 +13790,14 @@ db_to_time (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
 	  goto exit;
 	}
-      DB_MAKE_CHAR (&default_format, strlen (default_format_str), (const DB_C_CHAR) (default_format_str),
+      db_make_char (&default_format, strlen (default_format_str), (const DB_C_CHAR) (default_format_str),
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
 
   if (DB_IS_NULL (format_str))
     {
-      DB_MAKE_NULL (result_time);
+      db_make_null (result_time);
       goto exit;
     }
 
@@ -13808,21 +13808,21 @@ db_to_time (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
       goto exit;
     }
 
-  if (DB_GET_STRING_SIZE (format_str) > MAX_TOKEN_SIZE)
+  if (db_get_string_size (format_str) > MAX_TOKEN_SIZE)
     {
       error_status = ER_QSTR_FORMAT_TOO_LONG;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       goto exit;
     }
 
-  if (DB_GET_STRING_SIZE (format_str) == 0)
+  if (db_get_string_size (format_str) == 0)
     {
       error_status = ER_QSTR_EMPTY_STRING;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       goto exit;
     }
 
-  frmt_codeset = DB_GET_STRING_CODESET (format_str);
+  frmt_codeset = db_get_string_codeset (format_str);
 
   error_status =
     db_check_or_create_null_term_string (format_str, stack_buf_format, sizeof (stack_buf_format), true, true,
@@ -14215,7 +14215,7 @@ db_to_time (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 
   if (type == DB_TYPE_TIME)
     {
-      DB_MAKE_TIME (result_time, hour, minute, second);
+      db_make_time (result_time, hour, minute, second);
     }
   else
     {
@@ -14251,7 +14251,7 @@ db_to_time (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 	      goto exit;
 	    }
 	}
-      DB_MAKE_TIMETZ (result_time, &db_timetz);
+      db_make_timetz (result_time, &db_timetz);
     }
 
 exit:
@@ -14321,16 +14321,16 @@ db_to_timestamp (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB
   assert (date_lang != (DB_VALUE *) NULL);
   assert (type == DB_TYPE_TIMESTAMP || type == DB_TYPE_TIMESTAMPTZ);
 
-  DB_MAKE_NULL (&default_format);
+  db_make_null (&default_format);
 
   if (DB_IS_NULL (src_str))
     {
-      DB_MAKE_NULL (result_timestamp);
+      db_make_null (result_timestamp);
       return error_status;
     }
 
   assert (DB_VALUE_TYPE (date_lang) == DB_TYPE_INTEGER);
-  date_lang_id = lang_get_lang_id_from_flag (DB_GET_INT (date_lang), &has_user_format, &dummy);
+  date_lang_id = lang_get_lang_id_from_flag (db_get_int (date_lang), &has_user_format, &dummy);
 
   if (false == is_char_string (src_str))
     {
@@ -14339,21 +14339,21 @@ db_to_timestamp (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB
       return error_status;
     }
 
-  if (DB_GET_STRING_SIZE (src_str) == 0)
+  if (db_get_string_size (src_str) == 0)
     {
       error_status = ER_QSTR_EMPTY_STRING;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  if (DB_GET_STRING_SIZE (src_str) > MAX_TOKEN_SIZE)
+  if (db_get_string_size (src_str) > MAX_TOKEN_SIZE)
     {
       error_status = ER_QSTR_SRC_TOO_LONG;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  codeset = DB_GET_STRING_CODESET (src_str);
+  codeset = db_get_string_codeset (src_str);
   if (lang_get_specific_locale (date_lang_id, codeset) == NULL)
     {
       error_status = ER_LANG_CODESET_NOT_AVAILABLE;
@@ -14389,7 +14389,7 @@ db_to_timestamp (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB
 	{
 	  if (db_string_to_timestamp_ex ((const char *) cs, CAST_BUFLEN (last_src - cs), &timestamp_tmp) == NO_ERROR)
 	    {
-	      DB_MAKE_TIMESTAMP (result_timestamp, timestamp_tmp);
+	      db_make_timestamp (result_timestamp, timestamp_tmp);
 	      goto exit;
 	    }
 	}
@@ -14399,7 +14399,7 @@ db_to_timestamp (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB
 	  if (db_string_to_timestamptz_ex ((const char *) cs, CAST_BUFLEN (last_src - cs), &timestamptz_tmp, &has_zone,
 					   false) == NO_ERROR)
 	    {
-	      DB_MAKE_TIMESTAMPTZ (result_timestamp, &timestamptz_tmp);
+	      db_make_timestamptz (result_timestamp, &timestamptz_tmp);
 	      goto exit;
 	    }
 	}
@@ -14412,14 +14412,14 @@ db_to_timestamp (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB
 	  goto exit;
 	}
 
-      DB_MAKE_CHAR (&default_format, strlen (default_format_str), (const DB_C_CHAR) (default_format_str),
+      db_make_char (&default_format, strlen (default_format_str), (const DB_C_CHAR) (default_format_str),
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
 
   if (DB_IS_NULL (format_str))
     {
-      DB_MAKE_NULL (result_timestamp);
+      db_make_null (result_timestamp);
       goto exit;
     }
 
@@ -14430,21 +14430,21 @@ db_to_timestamp (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB
       goto exit;
     }
 
-  if (DB_GET_STRING_SIZE (format_str) > MAX_TOKEN_SIZE)
+  if (db_get_string_size (format_str) > MAX_TOKEN_SIZE)
     {
       error_status = ER_QSTR_FORMAT_TOO_LONG;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       goto exit;
     }
 
-  if (DB_GET_STRING_SIZE (format_str) == 0)
+  if (db_get_string_size (format_str) == 0)
     {
       error_status = ER_QSTR_EMPTY_STRING;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       goto exit;
     }
 
-  frmt_codeset = DB_GET_STRING_CODESET (format_str);
+  frmt_codeset = db_get_string_codeset (format_str);
 
   error_status =
     db_check_or_create_null_term_string (format_str, stack_buf_format, sizeof (stack_buf_format), true, true,
@@ -15128,7 +15128,7 @@ db_to_timestamp (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
 	  goto exit;
 	}
-      DB_MAKE_TIMESTAMP (result_timestamp, tmp_timestamp);
+      db_make_timestamp (result_timestamp, tmp_timestamp);
     }
   else
     {
@@ -15164,7 +15164,7 @@ db_to_timestamp (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB
 	      goto exit;
 	    }
 	}
-      DB_MAKE_TIMESTAMPTZ (result_timestamp, &db_timestamptz);
+      db_make_timestamptz (result_timestamp, &db_timestamptz);
     }
 
 exit:
@@ -15232,16 +15232,16 @@ db_to_datetime (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_
   assert (result_datetime != (DB_VALUE *) NULL);
   assert (type == DB_TYPE_DATETIME || type == DB_TYPE_DATETIMETZ);
 
-  DB_MAKE_NULL (&default_format);
+  db_make_null (&default_format);
 
   if (DB_IS_NULL (src_str))
     {
-      DB_MAKE_NULL (result_datetime);
+      db_make_null (result_datetime);
       return error_status;
     }
 
   assert (DB_VALUE_TYPE (date_lang) == DB_TYPE_INTEGER);
-  date_lang_id = lang_get_lang_id_from_flag (DB_GET_INT (date_lang), &has_user_format, &dummy);
+  date_lang_id = lang_get_lang_id_from_flag (db_get_int (date_lang), &has_user_format, &dummy);
 
   if (false == is_char_string (src_str))
     {
@@ -15250,21 +15250,21 @@ db_to_datetime (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_
       return error_status;
     }
 
-  if (DB_GET_STRING_SIZE (src_str) == 0)
+  if (db_get_string_size (src_str) == 0)
     {
       error_status = ER_QSTR_EMPTY_STRING;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  if (DB_GET_STRING_SIZE (src_str) > MAX_TOKEN_SIZE)
+  if (db_get_string_size (src_str) > MAX_TOKEN_SIZE)
     {
       error_status = ER_QSTR_SRC_TOO_LONG;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  codeset = DB_GET_STRING_CODESET (src_str);
+  codeset = db_get_string_codeset (src_str);
   if (lang_get_specific_locale (date_lang_id, codeset) == NULL)
     {
       error_status = ER_LANG_CODESET_NOT_AVAILABLE;
@@ -15300,7 +15300,7 @@ db_to_datetime (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_
 	{
 	  if (db_string_to_datetime_ex ((const char *) cs, CAST_BUFLEN (last_src - cs), &datetime_tmp) == NO_ERROR)
 	    {
-	      DB_MAKE_DATETIME (result_datetime, &datetime_tmp);
+	      db_make_datetime (result_datetime, &datetime_tmp);
 	      goto exit;
 	    }
 	}
@@ -15310,7 +15310,7 @@ db_to_datetime (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_
 	  if (db_string_to_datetimetz_ex ((const char *) cs, CAST_BUFLEN (last_src - cs), &datetimetz_tmp, &has_zone)
 	      == NO_ERROR)
 	    {
-	      DB_MAKE_DATETIMETZ (result_datetime, &datetimetz_tmp);
+	      db_make_datetimetz (result_datetime, &datetimetz_tmp);
 	      goto exit;
 	    }
 	}
@@ -15323,13 +15323,13 @@ db_to_datetime (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_
 	  goto exit;
 	}
 
-      DB_MAKE_CHAR (&default_format, strlen (default_format_str), (const DB_C_CHAR) (default_format_str),
+      db_make_char (&default_format, strlen (default_format_str), (const DB_C_CHAR) (default_format_str),
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
   if (DB_IS_NULL (format_str))
     {
-      DB_MAKE_NULL (result_datetime);
+      db_make_null (result_datetime);
       goto exit;
     }
 
@@ -15340,21 +15340,21 @@ db_to_datetime (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_
       goto exit;
     }
 
-  if (DB_GET_STRING_SIZE (format_str) > MAX_TOKEN_SIZE)
+  if (db_get_string_size (format_str) > MAX_TOKEN_SIZE)
     {
       error_status = ER_QSTR_FORMAT_TOO_LONG;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       goto exit;
     }
 
-  if (DB_GET_STRING_SIZE (format_str) == 0)
+  if (db_get_string_size (format_str) == 0)
     {
       error_status = ER_QSTR_EMPTY_STRING;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       goto exit;
     }
 
-  frmt_codeset = DB_GET_STRING_CODESET (format_str);
+  frmt_codeset = db_get_string_codeset (format_str);
 
   error_status =
     db_check_or_create_null_term_string (format_str, stack_buf_format, sizeof (stack_buf_format), true, true,
@@ -16079,7 +16079,7 @@ db_to_datetime (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_
 
   if (type == DB_TYPE_DATETIME)
     {
-      if (DB_MAKE_DATETIME (result_datetime, &tmp_datetime) != NO_ERROR)
+      if (db_make_datetime (result_datetime, &tmp_datetime) != NO_ERROR)
 	{
 	  error_status = ER_DATE_CONVERSION;
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -16120,7 +16120,7 @@ db_to_datetime (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_
 	      goto exit;
 	    }
 	}
-      DB_MAKE_DATETIMETZ (result_datetime, &db_datetimetz);
+      db_make_datetimetz (result_datetime, &db_datetimetz);
     }
 
 exit:
@@ -16331,7 +16331,7 @@ db_to_number (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VA
 
   if (DB_IS_NULL (src_str))
     {
-      DB_MAKE_NULL (result_num);
+      db_make_null (result_num);
       return error_status;
     }
 
@@ -16342,14 +16342,14 @@ db_to_number (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VA
       return error_status;
     }
 
-  if (DB_GET_STRING_SIZE (src_str) == 0)
+  if (db_get_string_size (src_str) == 0)
     {
       error_status = ER_QSTR_EMPTY_STRING;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  if (DB_GET_STRING_SIZE (src_str) > MAX_TOKEN_SIZE)
+  if (db_get_string_size (src_str) > MAX_TOKEN_SIZE)
     {
       error_status = ER_QSTR_SRC_TOO_LONG;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -16357,7 +16357,7 @@ db_to_number (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VA
     }
 
   assert (DB_VALUE_TYPE (number_lang) == DB_TYPE_INTEGER);
-  number_lang_id = lang_get_lang_id_from_flag (DB_GET_INT (number_lang), &has_user_format, &dummy);
+  number_lang_id = lang_get_lang_id_from_flag (db_get_int (number_lang), &has_user_format, &dummy);
   digit_grouping_symbol = lang_digit_grouping_symbol (number_lang_id);
   fraction_symbol = lang_digit_fractional_symbol (number_lang_id);
 
@@ -16383,7 +16383,7 @@ db_to_number (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VA
       /* Format string type checking */
       if (is_char_string (format_str))
 	{
-	  if (DB_GET_STRING_SIZE (format_str) > MAX_TOKEN_SIZE)
+	  if (db_get_string_size (format_str) > MAX_TOKEN_SIZE)
 	    {
 	      error_status = ER_QSTR_FORMAT_TOO_LONG;
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -16400,7 +16400,7 @@ db_to_number (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VA
 	    }
 	  format_str_ptr = initial_buf_format;
 	  last_format = format_str_ptr + strlen (format_str_ptr);
-	  format_codeset = DB_GET_STRING_CODESET (format_str);
+	  format_codeset = db_get_string_codeset (format_str);
 	}
       else
 	{
@@ -16409,7 +16409,7 @@ db_to_number (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VA
 	  goto exit;
 	}
 
-      if (DB_GET_STRING_SIZE (format_str) == 0)
+      if (db_get_string_size (format_str) == 0)
 	{
 	  error_status = ER_QSTR_EMPTY_STRING;
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -16417,7 +16417,7 @@ db_to_number (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VA
 	}
     }
 
-  last_cs = (char *) intl_backskip_spaces (cs, last_cs - 1, DB_GET_STRING_CODESET (src_str));
+  last_cs = (char *) intl_backskip_spaces (cs, last_cs - 1, db_get_string_codeset (src_str));
   last_cs = last_cs + 1;
 
   /* Skip space, tab, CR */
@@ -16500,7 +16500,7 @@ db_to_number (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VA
 	    }
 
 	  error_status =
-	    make_number (cs, last_cs, DB_GET_STRING_CODESET (src_str), format_str_ptr, &token_length, result_num,
+	    make_number (cs, last_cs, db_get_string_codeset (src_str), format_str_ptr, &token_length, result_num,
 			 precision, scale, number_lang_id);
 	  if (error_status == NO_ERROR)
 	    {
@@ -16672,7 +16672,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 
   if (DB_IS_NULL (src_value))
     {
-      DB_MAKE_NULL (result_str);
+      db_make_null (result_str);
       return error_status;
     }
 
@@ -16693,7 +16693,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
     }
 
   assert (DB_VALUE_TYPE (date_lang) == DB_TYPE_INTEGER);
-  date_lang_id = lang_get_lang_id_from_flag (DB_GET_INT (date_lang), &has_user_format, &dummy);
+  date_lang_id = lang_get_lang_id_from_flag (db_get_int (date_lang), &has_user_format, &dummy);
 
   no_user_format = (format_str == NULL) || (!has_user_format);
 
@@ -16711,7 +16711,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	      return error_status;
 	    }
 	  result_len = QSTR_DATE_LENGTH;
-	  retval = db_date_to_string (result_buf, QSTR_DATE_LENGTH + 1, DB_GET_DATE (src_value));
+	  retval = db_date_to_string (result_buf, QSTR_DATE_LENGTH + 1, db_get_date (src_value));
 	  break;
 
 	case DB_TYPE_TIME:
@@ -16722,7 +16722,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	      return error_status;
 	    }
 	  result_len = QSTR_TIME_LENGTH;
-	  retval = db_time_to_string (result_buf, QSTR_TIME_LENGTH + 1, DB_GET_TIME (src_value));
+	  retval = db_time_to_string (result_buf, QSTR_TIME_LENGTH + 1, db_get_time (src_value));
 	  break;
 
 	case DB_TYPE_TIMESTAMP:
@@ -16733,7 +16733,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	      return error_status;
 	    }
 	  result_len = QSTR_TIME_STAMPLENGTH;
-	  retval = db_timestamp_to_string (result_buf, QSTR_TIME_STAMPLENGTH + 1, DB_GET_TIMESTAMP (src_value));
+	  retval = db_timestamp_to_string (result_buf, QSTR_TIME_STAMPLENGTH + 1, db_get_timestamp (src_value));
 	  break;
 
 	case DB_TYPE_DATETIME:
@@ -16744,7 +16744,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	      return error_status;
 	    }
 	  result_len = QSTR_DATETIME_LENGTH;
-	  retval = db_datetime_to_string (result_buf, QSTR_DATETIME_LENGTH + 1, DB_GET_DATETIME (src_value));
+	  retval = db_datetime_to_string (result_buf, QSTR_DATETIME_LENGTH + 1, db_get_datetime (src_value));
 	  break;
 
 	case DB_TYPE_DATETIMETZ:
@@ -16756,7 +16756,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 		error_status = ER_OUT_OF_VIRTUAL_MEMORY;
 		return error_status;
 	      }
-	    dtz = *DB_GET_DATETIMETZ (src_value);
+	    dtz = *db_get_datetimetz (src_value);
 	    retval = db_datetimetz_to_string (result_buf, DATETIMETZ_BUF_SIZE, &dtz.datetime, &dtz.tz_id);
 	    result_len = retval;
 	  }
@@ -16769,7 +16769,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	      error_status = ER_OUT_OF_VIRTUAL_MEMORY;
 	      return error_status;
 	    }
-	  retval = db_datetimeltz_to_string (result_buf, DATETIMETZ_BUF_SIZE, DB_GET_DATETIME (src_value));
+	  retval = db_datetimeltz_to_string (result_buf, DATETIMETZ_BUF_SIZE, db_get_datetime (src_value));
 	  result_len = retval;
 	  break;
 
@@ -16782,7 +16782,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 		error_status = ER_OUT_OF_VIRTUAL_MEMORY;
 		return error_status;
 	      }
-	    tm_tz = *DB_GET_TIMETZ (src_value);
+	    tm_tz = *db_get_timetz (src_value);
 	    retval = db_timetz_to_string (result_buf, TIMETZ_BUF_SIZE, &tm_tz.time, &tm_tz.tz_id);
 	    result_len = retval;
 	  }
@@ -16795,7 +16795,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	      error_status = ER_OUT_OF_VIRTUAL_MEMORY;
 	      return error_status;
 	    }
-	  retval = db_timeltz_to_string (result_buf, TIMETZ_BUF_SIZE, DB_GET_TIME (src_value));
+	  retval = db_timeltz_to_string (result_buf, TIMETZ_BUF_SIZE, db_get_time (src_value));
 	  result_len = retval;
 	  break;
 
@@ -16809,7 +16809,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 		error_status = ER_OUT_OF_VIRTUAL_MEMORY;
 		return error_status;
 	      }
-	    tsmp_tz = *DB_GET_TIMESTAMPTZ (src_value);
+	    tsmp_tz = *db_get_timestamptz (src_value);
 	    retval = db_timestamptz_to_string (result_buf, TIMESTAMPTZ_BUF_SIZE, &tsmp_tz.timestamp, &tsmp_tz.tz_id);
 	    result_len = retval;
 	  }
@@ -16823,7 +16823,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	      error_status = ER_OUT_OF_VIRTUAL_MEMORY;
 	      return error_status;
 	    }
-	  retval = db_timestampltz_to_string (result_buf, TIMESTAMPTZ_BUF_SIZE, DB_GET_TIMESTAMP (src_value));
+	  retval = db_timestampltz_to_string (result_buf, TIMESTAMPTZ_BUF_SIZE, db_get_timestamp (src_value));
 	  result_len = retval;
 	  break;
 
@@ -16839,7 +16839,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	  return error_status;
 	}
 
-      DB_MAKE_VARCHAR (result_str, result_len, result_buf, result_len, codeset, collation_id);
+      db_make_varchar (result_str, result_len, result_buf, result_len, codeset, collation_id);
     }
   else
     {
@@ -16857,21 +16857,21 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 
       if (DB_IS_NULL (format_str))
 	{
-	  DB_MAKE_NULL (result_str);
+	  db_make_null (result_str);
 	  goto exit;
 	}
 
       /* compute allocation size : trade-off exact size (and small mem usage) vs speed */
-      result_len = (DB_GET_STRING_LENGTH (format_str) * QSTR_TO_CHAR_LEN_MULTIPLIER_RATIO);
+      result_len = (db_get_string_length (format_str) * QSTR_TO_CHAR_LEN_MULTIPLIER_RATIO);
 
-      if (DB_GET_STRING_SIZE (format_str) == 0)
+      if (db_get_string_size (format_str) == 0)
 	{
 	  error_status = ER_QSTR_EMPTY_STRING;
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
 	  goto exit;
 	}
 
-      frmt_codeset = DB_GET_STRING_CODESET (format_str);
+      frmt_codeset = db_get_string_codeset (format_str);
 
       error_status =
 	db_check_or_create_null_term_string (format_str, stack_buf_format, sizeof (stack_buf_format), true, false,
@@ -16927,13 +16927,13 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
       switch (src_type)
 	{
 	case DB_TYPE_DATE:
-	  db_date_decode (DB_GET_DATE (src_value), &month, &day, &year);
+	  db_date_decode (db_get_date (src_value), &month, &day, &year);
 	  break;
 	case DB_TYPE_TIME:
 	  {
 	    DB_TIME *tm;
 
-	    tm = DB_GET_TIME (src_value);
+	    tm = db_get_time (src_value);
 	    if (ntzr != 0 || ntzd != 0 || has_tzh == true || has_tzm == true)
 	      {
 		error_status = tz_create_session_tzid_for_time (tm, true, &tz_id);
@@ -16949,7 +16949,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	  {
 	    DB_TIMESTAMP *tsmp;
 
-	    tsmp = DB_GET_TIMESTAMP (src_value);
+	    tsmp = db_get_timestamp (src_value);
 	    if (ntzr != 0 || ntzd != 0 || has_tzh == true || has_tzm == true)
 	      {
 		error_status = tz_create_session_tzid_for_timestamp (tsmp, &tz_id);
@@ -16967,7 +16967,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	  {
 	    DB_DATETIME *dt;
 
-	    dt = DB_GET_DATETIME (src_value);
+	    dt = db_get_datetime (src_value);
 	    if (ntzr != 0 || ntzd != 0 || has_tzh == true || has_tzm == true)
 	      {
 		error_status = tz_create_session_tzid_for_datetime (dt, true, &tz_id);
@@ -16984,7 +16984,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	    DB_DATETIMETZ dtz;
 	    DB_DATETIME dt_local;
 
-	    dtz = *DB_GET_DATETIMETZ (src_value);
+	    dtz = *db_get_datetimetz (src_value);
 	    tz_id = dtz.tz_id;
 	    error_status = tz_utc_datetimetz_to_local (&dtz.datetime, &dtz.tz_id, &dt_local);
 	    if (error_status != NO_ERROR)
@@ -16998,7 +16998,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	  {
 	    DB_DATETIME *dt, dt_local;
 
-	    dt = DB_GET_DATETIME (src_value);
+	    dt = db_get_datetime (src_value);
 	    error_status = tz_create_session_tzid_for_datetime (dt, true, &tz_id);
 	    if (error_status != NO_ERROR)
 	      {
@@ -17018,7 +17018,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	    DB_TIMETZ tm_tz;
 	    DB_TIME tm_local;
 
-	    tm_tz = *DB_GET_TIMETZ (src_value);
+	    tm_tz = *db_get_timetz (src_value);
 	    tz_id = tm_tz.tz_id;
 	    error_status = tz_utc_timetz_to_local (&tm_tz.time, &tm_tz.tz_id, &tm_local);
 	    if (error_status != NO_ERROR)
@@ -17032,7 +17032,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	  {
 	    DB_TIME *tm, tm_local;
 
-	    tm = DB_GET_TIME (src_value);
+	    tm = db_get_time (src_value);
 	    error_status = tz_create_session_tzid_for_time (tm, true, &tz_id);
 
 	    if (error_status != NO_ERROR)
@@ -17053,7 +17053,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	    DB_DATE date;
 	    DB_TIME time;
 
-	    tsmp_tz = *DB_GET_TIMESTAMPTZ (src_value);
+	    tsmp_tz = *db_get_timestamptz (src_value);
 	    tz_id = tsmp_tz.tz_id;
 	    error_status = db_timestamp_decode_w_tz_id (&tsmp_tz.timestamp, &tsmp_tz.tz_id, &date, &time);
 	    if (error_status != NO_ERROR)
@@ -17070,7 +17070,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	    DB_DATE date;
 	    DB_TIME time;
 
-	    tsmp = DB_GET_TIMESTAMP (src_value);
+	    tsmp = db_get_timestamp (src_value);
 	    error_status = tz_create_session_tzid_for_timestamp (tsmp, &tz_id);
 	    if (error_status != NO_ERROR)
 	      {
@@ -17092,7 +17092,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 
       if (ntzr != 0 || ntzd != 0 || has_tzh == true || has_tzm == true)
 	{
-	  int len = DB_GET_STRING_LENGTH (format_str);
+	  int len = db_get_string_length (format_str);
 	  int left;
 
 	  error_status = tz_explain_tz_id (&tz_id, tzr, TZR_SIZE + 1, tzd, TZ_DS_STRING_SIZE + 1, &tzh, &tzm);
@@ -17495,7 +17495,7 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 	    }
 	}
 
-      DB_MAKE_VARCHAR (result_str, result_len, result_buf, i, codeset, collation_id);
+      db_make_varchar (result_str, result_len, result_buf, i, codeset, collation_id);
     }
 
   result_str->need_clear = true;
@@ -17513,7 +17513,7 @@ zerodate_exit:
     {
       db_private_free_and_init (NULL, result_buf);
     }
-  DB_MAKE_NULL (result_str);
+  db_make_null (result_str);
   goto exit;
 }
 
@@ -17563,11 +17563,11 @@ number_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const D
   /* now return null */
   if (DB_IS_NULL (src_value))
     {
-      DB_MAKE_NULL (result_str);
+      db_make_null (result_str);
       return error_status;
     }
 
-  number_lang_id = lang_get_lang_id_from_flag (DB_GET_INT (number_lang), &has_user_format, &dummy);
+  number_lang_id = lang_get_lang_id_from_flag (db_get_int (number_lang), &has_user_format, &dummy);
   fraction_symbol = lang_digit_fractional_symbol (number_lang_id);
   digit_grouping_symbol = lang_digit_grouping_symbol (number_lang_id);
   currency = lang_locale_currency (lang_get_lang_name_from_id (number_lang_id));
@@ -17590,7 +17590,7 @@ number_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const D
       break;
 
     case DB_TYPE_INTEGER:
-      sprintf (tmp_str, "%d", DB_GET_INTEGER (src_value));
+      sprintf (tmp_str, "%d", db_get_int (src_value));
       cs = (char *) db_private_alloc (NULL, strlen (tmp_str) + 1);
       if (cs == NULL)
 	{
@@ -17601,7 +17601,7 @@ number_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const D
       break;
 
     case DB_TYPE_BIGINT:
-      sprintf (tmp_str, "%lld", (long long) DB_GET_BIGINT (src_value));
+      sprintf (tmp_str, "%lld", (long long) db_get_bigint (src_value));
       cs = (char *) db_private_alloc (NULL, strlen (tmp_str) + 1);
       if (cs == NULL)
 	{
@@ -17612,7 +17612,7 @@ number_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const D
       break;
 
     case DB_TYPE_SMALLINT:
-      sprintf (tmp_str, "%d", DB_GET_SMALLINT (src_value));
+      sprintf (tmp_str, "%d", db_get_short (src_value));
       cs = (char *) db_private_alloc (NULL, strlen (tmp_str) + 1);
       if (cs == NULL)
 	{
@@ -17623,7 +17623,7 @@ number_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const D
       break;
 
     case DB_TYPE_FLOAT:
-      sprintf (tmp_str, "%.6e", DB_GET_FLOAT (src_value));
+      sprintf (tmp_str, "%.6e", db_get_float (src_value));
       if (number_lang_id != INTL_LANG_ENGLISH)
 	{
 	  convert_locale_number (tmp_str, strlen (tmp_str), INTL_LANG_ENGLISH, number_lang_id);
@@ -17636,7 +17636,7 @@ number_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const D
       break;
 
     case DB_TYPE_DOUBLE:
-      sprintf (tmp_str, "%.15e", DB_GET_DOUBLE (src_value));
+      sprintf (tmp_str, "%.15e", db_get_double (src_value));
       if (number_lang_id != INTL_LANG_ENGLISH)
 	{
 	  convert_locale_number (tmp_str, strlen (tmp_str), INTL_LANG_ENGLISH, number_lang_id);
@@ -17649,8 +17649,8 @@ number_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const D
       break;
 
     case DB_TYPE_MONETARY:
-      currency = (DB_GET_MONETARY (src_value))->type;
-      sprintf (tmp_str, "%.15e", (DB_GET_MONETARY (src_value))->amount);
+      currency = (db_get_monetary (src_value))->type;
+      sprintf (tmp_str, "%.15e", (db_get_monetary (src_value))->amount);
       if (number_lang_id != INTL_LANG_ENGLISH)
 	{
 	  convert_locale_number (tmp_str, strlen (tmp_str), INTL_LANG_ENGLISH, number_lang_id);
@@ -17697,7 +17697,7 @@ number_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const D
   if (format_str == NULL || !has_user_format)
     {
       /* Caution: VARCHAR's Size */
-      DB_MAKE_VARCHAR (result_str, (ssize_t) strlen (cs), cs, strlen (cs), codeset, collation_id);
+      db_make_varchar (result_str, (ssize_t) strlen (cs), cs, strlen (cs), codeset, collation_id);
       result_str->need_clear = true;
       return error_status;
     }
@@ -17706,14 +17706,14 @@ number_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const D
       if (DB_IS_NULL (format_str))
 	{
 	  db_private_free_and_init (NULL, cs);
-	  DB_MAKE_NULL (result_str);
+	  db_make_null (result_str);
 	  return error_status;
 	}
 
       /* Format string type checking */
       if (is_char_string (format_str))
 	{
-	  if (DB_GET_STRING_SIZE (format_str) > MAX_TOKEN_SIZE)
+	  if (db_get_string_size (format_str) > MAX_TOKEN_SIZE)
 	    {
 	      error_status = ER_QSTR_FORMAT_TOO_LONG;
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -17741,7 +17741,7 @@ number_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const D
 	  return error_status;
 	}
 
-      if (DB_GET_STRING_SIZE (format_str) == 0)
+      if (db_get_string_size (format_str) == 0)
 	{
 	  error_status = ER_QSTR_EMPTY_STRING;
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -17864,7 +17864,7 @@ number_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const D
       goto exit;
     }
 
-  DB_MAKE_VARCHAR (result_str, (ssize_t) strlen (res_string), res_string, strlen (res_string), codeset, collation_id);
+  db_make_varchar (result_str, (ssize_t) strlen (res_string), res_string, strlen (res_string), codeset, collation_id);
   result_str->need_clear = true;
   db_private_free_and_init (NULL, cs);
 
@@ -17899,7 +17899,7 @@ lob_to_bit_char (const DB_VALUE * src_value, DB_VALUE * result_value, DB_TYPE lo
 	  if (er_errid () == ER_ES_GENERAL)
 	    {
 	      /* by the spec, some lob handling functions treats the read error as a NULL value */
-	      DB_MAKE_NULL (result_value);
+	      db_make_null (result_value);
 	      /* clear the error set before */
 	      er_clear ();
 	      return NO_ERROR;
@@ -17933,7 +17933,7 @@ lob_to_bit_char (const DB_VALUE * src_value, DB_VALUE * result_value, DB_TYPE lo
 	  if (error_status == ER_ES_GENERAL)
 	    {
 	      /* by the spec, some lob handling functions treats the read error as a NULL value */
-	      DB_MAKE_NULL (result_value);
+	      db_make_null (result_value);
 	      db_private_free_and_init (NULL, cs);
 
 	      /* clear the error set before */
@@ -17952,17 +17952,17 @@ lob_to_bit_char (const DB_VALUE * src_value, DB_VALUE * result_value, DB_TYPE lo
 	{
 	  /* convert the converted max_length to number of bits */
 	  max_length *= 8;
-	  DB_MAKE_VARBIT (result_value, max_length, cs, max_length);
+	  db_make_varbit (result_value, max_length, cs, max_length);
 	}
       else
 	{
-	  DB_MAKE_VARCHAR (result_value, max_length, cs, max_length, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
+	  db_make_varchar (result_value, max_length, cs, max_length, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
 	}
       result_value->need_clear = true;
     }
   else
     {
-      DB_MAKE_NULL (result_value);
+      db_make_null (result_value);
     }
   return error_status;
 }
@@ -17988,7 +17988,7 @@ lob_from_file (const char *path, const DB_VALUE * src_value, DB_VALUE * lob_valu
   if (size < 0)
     {
       error_status = ER_ES_INVALID_PATH;
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 1, DB_GET_STRING (src_value));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 1, db_get_string (src_value));
       return error_status;
     }
 
@@ -18047,7 +18047,7 @@ lob_length (const DB_VALUE * src_value, DB_VALUE * result_value)
 	  if (er_errid () == ER_ES_GENERAL)
 	    {
 	      /* by the spec, some lob handling functions treats the read error as a NULL value */
-	      DB_MAKE_NULL (result_value);
+	      db_make_null (result_value);
 	      /* clear the error set before */
 	      er_clear ();
 	      return NO_ERROR;
@@ -18061,7 +18061,7 @@ lob_length (const DB_VALUE * src_value, DB_VALUE * result_value)
     }
   else
     {
-      DB_MAKE_NULL (result_value);
+      db_make_null (result_value);
     }
   return error_status;
 }
@@ -19359,7 +19359,7 @@ make_number (char *src, char *last_src, INTL_CODESET codeset, char *token, int *
 	  /* patch for to_number('-1.23e+03','9.99eeee') */
 	  return ER_QSTR_MISMATCHING_ARGUMENTS;
 	}
-      /* old comment DB_MAKE_NUMERIC(r,num,precision,scale); */
+      /* old comment db_make_numeric(r,num,precision,scale); */
     }
   else
     {
@@ -19887,29 +19887,29 @@ db_format (const DB_VALUE * value, const DB_VALUE * decimals, const DB_VALUE * n
 
   if (arg1_type == DB_TYPE_NULL || DB_IS_NULL (value) || arg2_type == DB_TYPE_NULL || DB_IS_NULL (decimals))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
   assert (DB_VALUE_TYPE (number_lang) == DB_TYPE_INTEGER);
-  number_lang_id = lang_get_lang_id_from_flag (DB_GET_INT (number_lang), &dummy, &dummy);
+  number_lang_id = lang_get_lang_id_from_flag (db_get_int (number_lang), &dummy, &dummy);
   fraction_symbol = lang_digit_fractional_symbol (number_lang_id);
   digit_grouping_symbol = lang_digit_grouping_symbol (number_lang_id);
 
-  DB_MAKE_NULL (&formatted_val);
-  DB_MAKE_NULL (&trimmed_val);
+  db_make_null (&formatted_val);
+  db_make_null (&trimmed_val);
 
   if (arg2_type == DB_TYPE_INTEGER)
     {
-      ndec = DB_GET_INT (decimals);
+      ndec = db_get_int (decimals);
     }
   else if (arg2_type == DB_TYPE_SHORT)
     {
-      ndec = DB_GET_SHORT (decimals);
+      ndec = db_get_short (decimals);
     }
   else if (arg2_type == DB_TYPE_BIGINT)
     {
-      DB_BIGINT bi = DB_GET_BIGINT (decimals);
+      DB_BIGINT bi = db_get_bigint (decimals);
       if (bi > INT_MAX || bi < 0)
 	{
 	  goto invalid_argument_error;
@@ -19948,7 +19948,7 @@ db_format (const DB_VALUE * value, const DB_VALUE * decimals, const DB_VALUE * n
 	    return error;
 	  }
 
-	c = DB_GET_STRING (&trimmed_val);
+	c = db_get_string (&trimmed_val);
 	if (c == NULL)
 	  {
 	    goto invalid_argument_error;
@@ -19978,7 +19978,7 @@ db_format (const DB_VALUE * value, const DB_VALUE * decimals, const DB_VALUE * n
 	    convert_locale_number (c, len, number_lang_id, INTL_LANG_ENGLISH);
 	  }
 
-	error = numeric_coerce_string_to_num (c, len, DB_GET_STRING_CODESET (&trimmed_val), &numeric_val);
+	error = numeric_coerce_string_to_num (c, len, db_get_string_codeset (&trimmed_val), &numeric_val);
 	if (error != NO_ERROR)
 	  {
 	    pr_clear_value (&trimmed_val);
@@ -20083,7 +20083,7 @@ db_string_reverse (const DB_VALUE * src_str, DB_VALUE * result_str)
   str_type = DB_VALUE_DOMAIN_TYPE (src_str);
   if (DB_IS_NULL (src_str))
     {
-      DB_MAKE_NULL (result_str);
+      db_make_null (result_str);
     }
   else if (!QSTR_IS_ANY_CHAR (str_type))
     {
@@ -20095,7 +20095,7 @@ db_string_reverse (const DB_VALUE * src_str, DB_VALUE * result_str)
    */
   else
     {
-      res = (char *) db_private_alloc (NULL, DB_GET_STRING_SIZE (src_str) + 1);
+      res = (char *) db_private_alloc (NULL, db_get_string_size (src_str) + 1);
       if (res == NULL)
 	{
 	  error_status = ER_OUT_OF_VIRTUAL_MEMORY;
@@ -20103,19 +20103,19 @@ db_string_reverse (const DB_VALUE * src_str, DB_VALUE * result_str)
 
       if (error_status == NO_ERROR)
 	{
-	  memset (res, 0, DB_GET_STRING_SIZE (src_str) + 1);
-	  intl_reverse_string ((unsigned char *) DB_GET_STRING (src_str), (unsigned char *) res,
-			       DB_GET_STRING_LENGTH (src_str), DB_GET_STRING_SIZE (src_str),
-			       DB_GET_STRING_CODESET (src_str));
+	  memset (res, 0, db_get_string_size (src_str) + 1);
+	  intl_reverse_string ((unsigned char *) db_get_string (src_str), (unsigned char *) res,
+			       db_get_string_length (src_str), db_get_string_size (src_str),
+			       db_get_string_codeset (src_str));
 	  if (QSTR_IS_CHAR (str_type))
 	    {
-	      DB_MAKE_VARCHAR (result_str, DB_GET_STRING_PRECISION (src_str), res, DB_GET_STRING_SIZE (src_str),
-			       DB_GET_STRING_CODESET (src_str), DB_GET_STRING_COLLATION (src_str));
+	      db_make_varchar (result_str, DB_GET_STRING_PRECISION (src_str), res, db_get_string_size (src_str),
+			       db_get_string_codeset (src_str), db_get_string_collation (src_str));
 	    }
 	  else
 	    {
-	      DB_MAKE_VARNCHAR (result_str, DB_GET_STRING_PRECISION (src_str), res, DB_GET_STRING_SIZE (src_str),
-				DB_GET_STRING_CODESET (src_str), DB_GET_STRING_COLLATION (src_str));
+	      db_make_varnchar (result_str, DB_GET_STRING_PRECISION (src_str), res, db_get_string_size (src_str),
+				db_get_string_codeset (src_str), db_get_string_collation (src_str));
 	    }
 	  result_str->need_clear = true;
 	}
@@ -20515,19 +20515,19 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
   res_type = DB_VALUE_DOMAIN_TYPE (date);
   if (res_type == DB_TYPE_NULL || DB_IS_NULL (date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
   if (DB_VALUE_DOMAIN_TYPE (db_days) == DB_TYPE_NULL || DB_IS_NULL (db_days))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
   /* simple case, where just a number of days is added to date */
 
-  days = DB_GET_INT (db_days);
+  days = db_get_int (db_days);
 
   switch (res_type)
     {
@@ -20537,8 +20537,8 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
     case DB_TYPE_NCHAR:
       {
 	bool has_explicit_time = false;
-	int str_len = DB_GET_STRING_SIZE (date);
-	date_s = DB_GET_STRING (date);
+	int str_len = db_get_string_size (date);
+	date_s = db_get_string (date);
 
 	/* try to figure out the string format */
 	if (db_date_parse_datetime_parts (date_s, str_len, &db_datetime, &has_explicit_time, NULL, NULL, NULL))
@@ -20593,13 +20593,13 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
 
     case DB_TYPE_DATE:
       is_d = 1;
-      d_p = DB_GET_DATE (date);
+      d_p = db_get_date (date);
       break;
 
     case DB_TYPE_DATETIMELTZ:
     case DB_TYPE_DATETIME:
       is_dt = 1;
-      dt_p = DB_GET_DATETIME (date);
+      dt_p = db_get_datetime (date);
       if (res_type == DB_TYPE_DATETIMELTZ)
 	{
 	  is_local_timezone = 1;
@@ -20610,7 +20610,7 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
       {
 	DB_DATETIMETZ *dt_tz_p;
 
-	dt_tz_p = DB_GET_DATETIMETZ (date);
+	dt_tz_p = db_get_datetimetz (date);
 	dt_p = &dt_tz_p->datetime;
 	tz_id = dt_tz_p->tz_id;
 	is_dt = 1;
@@ -20621,7 +20621,7 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
     case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
       is_timest = 1;
-      ts_p = DB_GET_TIMESTAMP (date);
+      ts_p = db_get_timestamp (date);
       if (res_type == DB_TYPE_TIMESTAMPLTZ)
 	{
 	  is_local_timezone = 1;
@@ -20632,7 +20632,7 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
       {
 	DB_TIMESTAMPTZ *ts_tz_p;
 
-	ts_tz_p = DB_GET_TIMESTAMPTZ (date);
+	ts_tz_p = db_get_timestamptz (date);
 	ts_p = &ts_tz_p->timestamp;
 	tz_id = ts_tz_p->tz_id;
 	is_timest = 1;
@@ -20660,7 +20660,7 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
 
       if (m == 0 && d == 0 && y == 0)
 	{
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	  er_clear ();
 	  if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	    {
@@ -20714,12 +20714,12 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
 	      goto error;
 	    }
 	  strcpy (res_final, res_s);
-	  DB_MAKE_STRING (result, res_final);
+	  db_make_string (result, res_final);
 	  result->need_clear = true;
 	}
       else
 	{
-	  DB_MAKE_DATE (result, m, d, y);
+	  db_make_date (result, m, d, y);
 	}
     }
   else if (is_dt >= 0)
@@ -20731,7 +20731,7 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
 
       if (m == 0 && d == 0 && y == 0 && h == 0 && mi == 0 && s == 0 && ms == 0)
 	{
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	  er_clear ();
 	  if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	    {
@@ -20803,22 +20803,22 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
 	      goto error;
 	    }
 	  strcpy (res_final, res_s);
-	  DB_MAKE_STRING (result, res_final);
+	  db_make_string (result, res_final);
 	  result->need_clear = true;
 	}
       else
 	{
 	  if (is_timezone > 0)
 	    {
-	      DB_MAKE_DATETIMETZ (result, &dt_tz);
+	      db_make_datetimetz (result, &dt_tz);
 	    }
 	  else if (is_local_timezone > 0)
 	    {
-	      DB_MAKE_DATETIMELTZ (result, &db_datetime);
+	      db_make_datetimeltz (result, &db_datetime);
 	    }
 	  else
 	    {
-	      DB_MAKE_DATETIME (result, &db_datetime);
+	      db_make_datetime (result, &db_datetime);
 	    }
 	}
     }
@@ -20834,7 +20834,7 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
 
       if (m == 0 && d == 0 && y == 0 && h == 0 && mi == 0 && s == 0)
 	{
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	  er_clear ();
 	  if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	    {
@@ -20916,18 +20916,18 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
 	      goto error;
 	    }
 	  strcpy (res_final, res_s);
-	  DB_MAKE_STRING (result, res_final);
+	  db_make_string (result, res_final);
 	  result->need_clear = true;
 	}
       else
 	{
 	  if (is_timezone > 0)
 	    {
-	      DB_MAKE_DATETIMETZ (result, &dt_tz);
+	      db_make_datetimetz (result, &dt_tz);
 	    }
 	  else if (is_local_timezone > 0)
 	    {
-	      DB_MAKE_DATETIMELTZ (result, &db_datetime);
+	      db_make_datetimeltz (result, &db_datetime);
 	    }
 	  else
 	    {
@@ -20938,7 +20938,7 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
 		{
 		  goto error;
 		}
-	      DB_MAKE_DATETIME (result, &dt_local);
+	      db_make_datetime (result, &dt_local);
 	    }
 	}
     }
@@ -21140,18 +21140,18 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
   res_type = DB_VALUE_DOMAIN_TYPE (date);
   if (res_type == DB_TYPE_NULL || DB_IS_NULL (date))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
   expr_type = DB_VALUE_DOMAIN_TYPE (expr);
   if (expr_type == DB_TYPE_NULL || DB_IS_NULL (expr))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
-  DB_MAKE_NULL (&trimed_expr);
+  db_make_null (&trimed_expr);
   unit_int_val = 0;
   expr_s = NULL;
 
@@ -21178,7 +21178,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 	}
 
       /* db_string_trim builds a NULL terminated string, expr_s is NULL terminated */
-      expr_s = DB_GET_STRING (&trimed_expr);
+      expr_s = db_get_string (&trimed_expr);
       if (expr_s == NULL)
 	{
 	  error_status = ER_OBJ_INVALID_ARGUMENTS;
@@ -21188,23 +21188,23 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
       break;
 
     case DB_TYPE_SHORT:
-      unit_int_val = DB_GET_SHORT (expr);
+      unit_int_val = db_get_short (expr);
       break;
 
     case DB_TYPE_INTEGER:
-      unit_int_val = DB_GET_INTEGER (expr);
+      unit_int_val = db_get_int (expr);
       break;
 
     case DB_TYPE_BIGINT:
-      unit_int_val = DB_GET_BIGINT (expr);
+      unit_int_val = db_get_bigint (expr);
       break;
 
     case DB_TYPE_FLOAT:
-      unit_int_val = (DB_BIGINT) round (DB_GET_FLOAT (expr));
+      unit_int_val = (DB_BIGINT) round (db_get_float (expr));
       break;
 
     case DB_TYPE_DOUBLE:
-      unit_int_val = (DB_BIGINT) round (DB_GET_DOUBLE (expr));
+      unit_int_val = (DB_BIGINT) round (db_get_double (expr));
       break;
 
     case DB_TYPE_NUMERIC:
@@ -21543,8 +21543,8 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
       {
 	bool has_explicit_time = false;
 	bool has_zone = false;
-	int str_len = DB_GET_STRING_SIZE (date);
-	date_s = DB_GET_STRING (date);
+	int str_len = db_get_string_size (date);
+	date_s = db_get_string (date);
 
 	if (db_string_to_datetimetz_ex (date_s, str_len, &dt_tz, &has_zone) == NO_ERROR && has_zone == true)
 	  {
@@ -21605,13 +21605,13 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 
     case DB_TYPE_DATE:
       is_d = 1;
-      d_p = DB_GET_DATE (date);
+      d_p = db_get_date (date);
       break;
 
     case DB_TYPE_DATETIME:
     case DB_TYPE_DATETIMELTZ:
       is_dt = 1;
-      dt_p = DB_GET_DATETIME (date);
+      dt_p = db_get_datetime (date);
       if (res_type == DB_TYPE_DATETIMELTZ)
 	{
 	  is_local_timezone = 1;
@@ -21622,7 +21622,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
       {
 	DB_DATETIMETZ *dt_tz_p;
 
-	dt_tz_p = DB_GET_DATETIMETZ (date);
+	dt_tz_p = db_get_datetimetz (date);
 
 	dt_p = &dt_tz_p->datetime;
 	tz_id = dt_tz_p->tz_id;
@@ -21634,7 +21634,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
     case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
       is_timest = 1;
-      ts_p = DB_GET_TIMESTAMP (date);
+      ts_p = db_get_timestamp (date);
       if (res_type == DB_TYPE_TIMESTAMPLTZ)
 	{
 	  is_local_timezone = 1;
@@ -21645,7 +21645,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
       {
 	DB_TIMESTAMPTZ *ts_tz_p;
 
-	ts_tz_p = DB_GET_TIMESTAMPTZ (date);
+	ts_tz_p = db_get_timestamptz (date);
 	ts_p = &ts_tz_p->timestamp;
 	tz_id = ts_tz_p->tz_id;
 	is_timest = 1;
@@ -21675,7 +21675,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
       if (m == 0 && d == 0 && y == 0)
 	{
 	  pr_clear_value (&trimed_expr);
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	  er_clear ();
 	  if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	    {
@@ -21713,7 +21713,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 	  if (m == 0 && d == 0 && y == 0)
 	    {
 	      pr_clear_value (&trimed_expr);
-	      DB_MAKE_NULL (result);
+	      db_make_null (result);
 	      er_clear ();
 	      if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 		{
@@ -21734,12 +21734,12 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 		  goto error;
 		}
 	      strcpy (res_final, res_s);
-	      DB_MAKE_STRING (result, res_final);
+	      db_make_string (result, res_final);
 	      result->need_clear = true;
 	    }
 	  else
 	    {
-	      DB_MAKE_DATE (result, m, d, y);
+	      db_make_date (result, m, d, y);
 	    }
 	}
       else if (type & 1)
@@ -21750,7 +21750,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 	  if (m == 0 && d == 0 && y == 0 && h == 0 && mi == 0 && s == 0 && ms == 0)
 	    {
 	      pr_clear_value (&trimed_expr);
-	      DB_MAKE_NULL (result);
+	      db_make_null (result);
 	      er_clear ();
 	      if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 		{
@@ -21771,7 +21771,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 		  goto error;
 		}
 	      strcpy (res_final, res_s);
-	      DB_MAKE_STRING (result, res_final);
+	      db_make_string (result, res_final);
 	      result->need_clear = true;
 	    }
 	  else
@@ -21783,7 +21783,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 		    {
 		      goto error;
 		    }
-		  DB_MAKE_DATETIMELTZ (result, &dt_tz.datetime);
+		  db_make_datetimeltz (result, &dt_tz.datetime);
 		}
 	      else if (is_timezone > 0)
 		{
@@ -21795,11 +21795,11 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 		    {
 		      goto error;
 		    }
-		  DB_MAKE_DATETIMETZ (result, &dt_tz);
+		  db_make_datetimetz (result, &dt_tz);
 		}
 	      else
 		{
-		  DB_MAKE_DATETIME (result, &db_datetime);
+		  db_make_datetime (result, &db_datetime);
 		}
 	    }
 	}
@@ -21814,7 +21814,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
       if (m == 0 && d == 0 && y == 0 && h == 0 && mi == 0 && s == 0 && ms == 0)
 	{
 	  pr_clear_value (&trimed_expr);
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	  er_clear ();
 	  if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	    {
@@ -21877,7 +21877,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 	      goto error;
 	    }
 	  strcpy (res_final, res_s);
-	  DB_MAKE_STRING (result, res_final);
+	  db_make_string (result, res_final);
 	  result->need_clear = true;
 	}
       else
@@ -21885,15 +21885,15 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 	  /* datetime, date + time units, timestamp => return datetime */
 	  if (is_local_timezone > 0)
 	    {
-	      DB_MAKE_DATETIMELTZ (result, &db_datetime);
+	      db_make_datetimeltz (result, &db_datetime);
 	    }
 	  else if (is_timezone > 0)
 	    {
-	      DB_MAKE_DATETIMETZ (result, &dt_tz);
+	      db_make_datetimetz (result, &dt_tz);
 	    }
 	  else
 	    {
-	      DB_MAKE_DATETIME (result, &db_datetime);
+	      db_make_datetime (result, &db_datetime);
 	    }
 	}
     }
@@ -21910,7 +21910,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
       if (m == 0 && d == 0 && y == 0 && h == 0 && mi == 0 && s == 0)
 	{
 	  pr_clear_value (&trimed_expr);
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	  er_clear ();
 	  if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	    {
@@ -21983,7 +21983,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 	      goto error;
 	    }
 	  strcpy (res_final, res_s);
-	  DB_MAKE_STRING (result, res_final);
+	  db_make_string (result, res_final);
 	  result->need_clear = true;
 	}
       else
@@ -21991,11 +21991,11 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 	  /* datetime, date + time units, timestamp => return datetime */
 	  if (is_local_timezone > 0)
 	    {
-	      DB_MAKE_DATETIMELTZ (result, &db_datetime);
+	      db_make_datetimeltz (result, &db_datetime);
 	    }
 	  else if (is_timezone > 0)
 	    {
-	      DB_MAKE_DATETIMETZ (result, &dt_tz);
+	      db_make_datetimetz (result, &dt_tz);
 	    }
 	  else
 	    {
@@ -22006,7 +22006,7 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
 		{
 		  goto error;
 		}
-	      DB_MAKE_DATETIME (result, &dt_local);
+	      db_make_datetime (result, &dt_local);
 	    }
 	}
     }
@@ -22114,7 +22114,7 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
 
   if (date_value == NULL || format == NULL || DB_IS_NULL (date_value) || DB_IS_NULL (format))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       goto error;
     }
 
@@ -22126,7 +22126,7 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
     }
 
   assert (DB_VALUE_TYPE (date_lang) == DB_TYPE_INTEGER);
-  date_lang_id = lang_get_lang_id_from_flag (DB_GET_INT (date_lang), &dummy, &dummy);
+  date_lang_id = lang_get_lang_id_from_flag (db_get_int (date_lang), &dummy, &dummy);
   if (domain != NULL && domain->collation_flag != TP_DOMAIN_COLL_LEAVE)
     {
       codeset = TP_DOMAIN_CODESET (domain);
@@ -22134,8 +22134,8 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
     }
   else
     {
-      codeset = DB_GET_STRING_CODESET (format);
-      res_collation = DB_GET_STRING_COLLATION (format);
+      codeset = db_get_string_codeset (format);
+      res_collation = db_get_string_collation (format);
     }
 
   lld = lang_get_specific_locale (date_lang_id, codeset);
@@ -22156,7 +22156,7 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
       {
 	TZ_ID tz_id;
 
-	dt_p = DB_GET_DATETIME (date_value);
+	dt_p = db_get_datetime (date_value);
 	error_status = tz_create_session_tzid_for_datetime (dt_p, true, &tz_id);
 	if (error_status != NO_ERROR)
 	  {
@@ -22174,14 +22174,14 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
       break;
 
     case DB_TYPE_DATE:
-      d_p = DB_GET_DATE (date_value);
+      d_p = db_get_date (date_value);
       db_date_decode (d_p, &m, &d, &y);
       break;
 
     case DB_TYPE_TIMESTAMP:
       {
 	TZ_ID tz_id;
-	ts_p = DB_GET_TIMESTAMP (date_value);
+	ts_p = db_get_timestamp (date_value);
 	error_status = tz_create_session_tzid_for_timestamp (ts_p, &tz_id);
 	if (error_status != NO_ERROR)
 	  {
@@ -22205,7 +22205,7 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
       {
 	DB_DATETIME dt_local;
 	DB_DATETIMETZ *dt_tz;
-	dt_tz = DB_GET_DATETIMETZ (date_value);
+	dt_tz = db_get_datetimetz (date_value);
 	error_status = tz_utc_datetimetz_to_local (&dt_tz->datetime, &dt_tz->tz_id, &dt_local);
 	if (error_status != NO_ERROR)
 	  {
@@ -22227,7 +22227,7 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
 	DB_DATETIME *dt, dt_local;
 	TZ_ID tz_id;
 
-	dt = DB_GET_DATETIME (date_value);
+	dt = db_get_datetime (date_value);
 	error_status = tz_create_session_tzid_for_datetime (dt, true, &tz_id);
 	if (error_status != NO_ERROR)
 	  {
@@ -22256,7 +22256,7 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
 	DB_DATE date;
 	DB_TIME time;
 
-	tsmp_tz = DB_GET_TIMESTAMPTZ (date_value);
+	tsmp_tz = db_get_timestamptz (date_value);
 	error_status = db_timestamp_decode_w_tz_id (&tsmp_tz->timestamp, &tsmp_tz->tz_id, &date, &time);
 	if (error_status != NO_ERROR)
 	  {
@@ -22282,7 +22282,7 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
 	DB_TIME time;
 	TZ_ID tz_id;
 
-	tsmp = DB_GET_TIMESTAMP (date_value);
+	tsmp = db_get_timestamp (date_value);
 	error_status = tz_create_session_tzid_for_timestamp (tsmp, &tz_id);
 
 	if (error_status != NO_ERROR)
@@ -22323,13 +22323,13 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
 	    goto error;
 	  }
 
-	db_datetime_decode (DB_GET_DATETIME (&dt), &m, &d, &y, &h, &mi, &s, &ms);
+	db_datetime_decode (db_get_datetime (&dt), &m, &d, &y, &h, &mi, &s, &ms);
 
 	if (tp_value_cast (date_value, &dt, tp_datetimetz, false) == DOMAIN_COMPATIBLE)
 	  {
 	    DB_DATETIMETZ dt_tz;
 
-	    dt_tz = *DB_GET_DATETIMETZ (&dt);
+	    dt_tz = *db_get_datetimetz (&dt);
 	    if (tz_explain_tz_id (&dt_tz.tz_id, tzr, TZR_SIZE + 1, tzd, TZ_DS_STRING_SIZE + 1, &tzh, &tzm) == NO_ERROR)
 	      {
 		is_valid_tz = true;
@@ -22545,8 +22545,8 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
     case DB_TYPE_VARNCHAR:
     case DB_TYPE_CHAR:
     case DB_TYPE_NCHAR:
-      format_s = DB_GET_STRING (format);
-      format_s_len = DB_GET_STRING_SIZE (format);
+      format_s = db_get_string (format);
+      format_s_len = db_get_string_size (format);
       break;
 
     default:
@@ -22684,7 +22684,7 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
 
   /* 4. */
 
-  DB_MAKE_STRING (result, res);
+  db_make_string (result, res);
 
   db_string_put_cs_and_collation (result, codeset, res_collation);
 
@@ -22810,16 +22810,16 @@ db_str_to_date (const DB_VALUE * str, const DB_VALUE * format, const DB_VALUE * 
       goto error;
     }
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   if (DB_IS_NULL (str) || DB_IS_NULL (format))
     {
       return NO_ERROR;
     }
 
-  codeset = DB_GET_STRING_CODESET (str);
+  codeset = db_get_string_codeset (str);
   assert (DB_VALUE_TYPE (date_lang) == DB_TYPE_INTEGER);
-  date_lang_id = lang_get_lang_id_from_flag (DB_GET_INT (date_lang), &dummy, &dummy);
+  date_lang_id = lang_get_lang_id_from_flag (db_get_int (date_lang), &dummy, &dummy);
   if (lang_get_specific_locale (date_lang_id, codeset) == NULL)
     {
       error_status = ER_LANG_CODESET_NOT_AVAILABLE;
@@ -22843,8 +22843,8 @@ db_str_to_date (const DB_VALUE * str, const DB_VALUE * format, const DB_VALUE * 
 
   sstr = initial_buf_str;
 
-  format2_s = DB_GET_STRING (format);
-  len2 = DB_GET_STRING_SIZE (format);
+  format2_s = db_get_string (format);
+  len2 = db_get_string_size (format);
   len2 = (len2 < 0) ? strlen (format2_s) : len2;
 
   format_s = (char *) db_private_alloc (NULL, len2 + 1);
@@ -23844,11 +23844,11 @@ write_results:
 
   if (res_type == DB_TYPE_DATE)
     {
-      DB_MAKE_DATE (result, m, d, y);
+      db_make_date (result, m, d, y);
     }
   else if (res_type == DB_TYPE_TIME)
     {
-      DB_MAKE_TIME (result, h, mi, s);
+      db_make_time (result, h, mi, s);
     }
   else if (res_type == DB_TYPE_DATETIME)
     {
@@ -23856,7 +23856,7 @@ write_results:
 
       db_datetime_encode (&db_datetime, m, d, y, h, mi, s, ms);
 
-      DB_MAKE_DATETIME (result, &db_datetime);
+      db_make_datetime (result, &db_datetime);
     }
   else if (res_type == DB_TYPE_DATETIMETZ || res_type == DB_TYPE_TIMETZ)
     {
@@ -23919,11 +23919,11 @@ write_results:
 	}
       if (res_type == DB_TYPE_DATETIMETZ)
 	{
-	  DB_MAKE_DATETIMETZ (result, &db_datetimetz);
+	  db_make_datetimetz (result, &db_datetimetz);
 	}
       else
 	{
-	  DB_MAKE_TIMETZ (result, &db_timetz);
+	  db_make_timetz (result, &db_timetz);
 	}
     }
 
@@ -23961,7 +23961,7 @@ conversion_error:
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
     }
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   return error_status;
 }
 
@@ -23982,7 +23982,7 @@ db_time_dbval (DB_VALUE * result, const DB_VALUE * datetime_value, const TP_DOMA
 
   if (DB_IS_NULL (datetime_value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -23990,7 +23990,7 @@ db_time_dbval (DB_VALUE * result, const DB_VALUE * datetime_value, const TP_DOMA
 
   if (db_get_time_from_dbvalue (datetime_value, &hour, &min, &sec, &milisec) != NO_ERROR)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  er_clear ();
@@ -24028,18 +24028,18 @@ db_time_dbval (DB_VALUE * result, const DB_VALUE * datetime_value, const TP_DOMA
     {
     case DB_TYPE_VARNCHAR:
     case DB_TYPE_NCHAR:
-      DB_MAKE_VARNCHAR (result, TP_FLOATING_PRECISION_VALUE, res_s, strlen (res_s),
-			DB_GET_STRING_CODESET (datetime_value), DB_GET_STRING_COLLATION (datetime_value));
+      db_make_varnchar (result, TP_FLOATING_PRECISION_VALUE, res_s, strlen (res_s),
+			db_get_string_codeset (datetime_value), db_get_string_collation (datetime_value));
       break;
 
     case DB_TYPE_VARCHAR:
     case DB_TYPE_CHAR:
-      DB_MAKE_VARCHAR (result, TP_FLOATING_PRECISION_VALUE, res_s, strlen (res_s),
-		       DB_GET_STRING_CODESET (datetime_value), DB_GET_STRING_COLLATION (datetime_value));
+      db_make_varchar (result, TP_FLOATING_PRECISION_VALUE, res_s, strlen (res_s),
+		       db_get_string_codeset (datetime_value), db_get_string_collation (datetime_value));
       break;
 
     default:
-      DB_MAKE_STRING (result, res_s);
+      db_make_string (result, res_s);
       break;
     }
 
@@ -24082,13 +24082,13 @@ db_date_dbval (DB_VALUE * result, const DB_VALUE * date_value, const TP_DOMAIN *
   type = DB_VALUE_DOMAIN_TYPE (date_value);
   if (type == DB_TYPE_NULL || DB_IS_NULL (date_value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
   if (db_get_datetime_from_dbvalue (date_value, &y, &m, &d, &hour, &min, &sec, &ms, NULL) != NO_ERROR)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  er_clear ();
@@ -24113,8 +24113,8 @@ db_date_dbval (DB_VALUE * result, const DB_VALUE * date_value, const TP_DOMAIN *
     }
   else if (TP_IS_STRING_TYPE (DB_VALUE_TYPE (date_value)))
     {
-      codeset = DB_GET_STRING_CODESET (date_value);
-      collation_id = DB_GET_STRING_COLLATION (date_value);
+      codeset = db_get_string_codeset (date_value);
+      collation_id = db_get_string_collation (date_value);
     }
   else
     {
@@ -24124,11 +24124,11 @@ db_date_dbval (DB_VALUE * result, const DB_VALUE * date_value, const TP_DOMAIN *
 
   if (QSTR_IS_NATIONAL_CHAR (type))
     {
-      DB_MAKE_VARNCHAR (result, 10, res_s, 10, codeset, collation_id);
+      db_make_varnchar (result, 10, res_s, 10, codeset, collation_id);
     }
   else
     {
-      DB_MAKE_STRING (result, res_s);
+      db_make_string (result, res_s);
       db_string_put_cs_and_collation (result, codeset, collation_id);
     }
 
@@ -24188,14 +24188,14 @@ db_date_diff (const DB_VALUE * date_value1, const DB_VALUE * date_value2, DB_VAL
   type1 = DB_VALUE_DOMAIN_TYPE (date_value1);
   if (type1 == DB_TYPE_NULL || DB_IS_NULL (date_value1))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       goto error;
     }
 
   type2 = DB_VALUE_DOMAIN_TYPE (date_value2);
   if (type2 == DB_TYPE_NULL || DB_IS_NULL (date_value2))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       goto error;
     }
 
@@ -24203,7 +24203,7 @@ db_date_diff (const DB_VALUE * date_value1, const DB_VALUE * date_value2, DB_VAL
   if (retval != NO_ERROR)
     {
       error_status = ER_DATE_CONVERSION;
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       goto error;
     }
 
@@ -24211,7 +24211,7 @@ db_date_diff (const DB_VALUE * date_value1, const DB_VALUE * date_value2, DB_VAL
   if (retval != NO_ERROR)
     {
       error_status = ER_DATE_CONVERSION;
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       goto error;
     }
 
@@ -24219,7 +24219,7 @@ db_date_diff (const DB_VALUE * date_value1, const DB_VALUE * date_value2, DB_VAL
       || (y2 == 0 && m2 == 0 && d2 == 0 && hour == 0 && min == 0 && sec == 0 && ms == 0))
     {
       er_clear ();
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  return NO_ERROR;
@@ -24252,7 +24252,7 @@ db_date_diff (const DB_VALUE * date_value1, const DB_VALUE * date_value2, DB_VAL
   cd2 = cdpy2 + cdpm2 + d2;
   diff = cd1 - cd2;
 
-  DB_MAKE_INTEGER (result, diff);
+  db_make_int (result, diff);
 
 error:
   return error_status;
@@ -24270,7 +24270,7 @@ db_from_unixtime (const DB_VALUE * src_value, const DB_VALUE * format, const DB_
 
   if (DB_IS_NULL (src_value))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
   if (DB_VALUE_TYPE (src_value) != DB_TYPE_INTEGER)
@@ -24278,7 +24278,7 @@ db_from_unixtime (const DB_VALUE * src_value, const DB_VALUE * format, const DB_
       error_status = ER_TIMESTAMP_CONVERSION;
       goto error;
     }
-  unix_timestamp = DB_GET_INT (src_value);
+  unix_timestamp = db_get_int (src_value);
   if (unix_timestamp < 0)
     {
       error_status = ER_TIMESTAMP_CONVERSION;
@@ -24288,13 +24288,13 @@ db_from_unixtime (const DB_VALUE * src_value, const DB_VALUE * format, const DB_
   if (format == NULL)
     {
       /* if unix_timestamp is called without a format argument, return the timestamp */
-      DB_MAKE_TIMESTAMP (result, (DB_TIMESTAMP) unix_timestamp);
+      db_make_timestamp (result, (DB_TIMESTAMP) unix_timestamp);
       return NO_ERROR;
     }
 
   if (DB_IS_NULL (format))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -24309,11 +24309,11 @@ db_from_unixtime (const DB_VALUE * src_value, const DB_VALUE * format, const DB_
 	DB_VALUE ts_val;
 	DB_VALUE default_date_lang;
 
-	DB_MAKE_TIMESTAMP (&ts_val, (DB_TIMESTAMP) unix_timestamp);
+	db_make_timestamp (&ts_val, (DB_TIMESTAMP) unix_timestamp);
 	if (date_lang == NULL || DB_IS_NULL (date_lang))
 	  {
 	    /* use date_lang for en_US */
-	    DB_MAKE_INTEGER (&default_date_lang, 0);
+	    db_make_int (&default_date_lang, 0);
 	    date_lang = &default_date_lang;
 	  }
 
@@ -24331,7 +24331,7 @@ db_from_unixtime (const DB_VALUE * src_value, const DB_VALUE * format, const DB_
     }
 
 error:
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       er_clear ();
@@ -24371,7 +24371,7 @@ db_time_diff (const DB_VALUE * val1, const DB_VALUE * val2, DB_VALUE * result)
 
   if (DB_IS_NULL (val1) || DB_IS_NULL (val2))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -24486,8 +24486,8 @@ db_time_diff (const DB_VALUE * val1, const DB_VALUE * val2, DB_VALUE * result)
   min_res = (date_diff % 3600) / 60;
   sec_res = date_diff - 3600 * hour_res - 60 * min_res;
 
-  DB_MAKE_TIME (result, hour_res, min_res, sec_res);
-  ret_int = (int) *(DB_GET_TIME (result));
+  db_make_time (result, hour_res, min_res, sec_res);
+  ret_int = (int) *(db_get_time (result));
 
   /* check time overflow on result */
   if (ret_int < 0)
@@ -24498,7 +24498,7 @@ db_time_diff (const DB_VALUE * val1, const DB_VALUE * val2, DB_VALUE * result)
   return NO_ERROR;
 
 error:
-  DB_MAKE_NULL (result);
+  db_make_null (result);
   er_clear ();
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
@@ -24670,7 +24670,7 @@ db_bit_to_blob (const DB_VALUE * src_value, DB_VALUE * result_value)
   src_type = DB_VALUE_DOMAIN_TYPE (src_value);
   if (src_type == DB_TYPE_NULL)
     {
-      DB_MAKE_NULL (result_value);
+      db_make_null (result_value);
       return NO_ERROR;
     }
   else if (QSTR_IS_BIT (src_type))
@@ -24715,7 +24715,7 @@ db_char_to_blob (const DB_VALUE * src_value, DB_VALUE * result_value)
   src_type = DB_VALUE_DOMAIN_TYPE (src_value);
   if (src_type == DB_TYPE_NULL)
     {
-      DB_MAKE_NULL (result_value);
+      db_make_null (result_value);
       return NO_ERROR;
     }
 
@@ -24726,7 +24726,7 @@ db_char_to_blob (const DB_VALUE * src_value, DB_VALUE * result_value)
 	{
 	  elo = db_get_elo (result_value);
 	  src_str = db_get_string (src_value);
-	  src_size = DB_GET_STRING_SIZE (src_value);
+	  src_size = db_get_string_size (src_value);
 	  if (src_size > 0)
 	    {
 	      error_status = db_elo_write (elo, 0, src_str, src_size, NULL);
@@ -24771,7 +24771,7 @@ db_blob_to_bit (const DB_VALUE * src_value, const DB_VALUE * length_value, DB_VA
     }
   if (src_type == DB_TYPE_NULL)
     {
-      DB_MAKE_NULL (result_value);
+      db_make_null (result_value);
       return NO_ERROR;
     }
 
@@ -24808,32 +24808,32 @@ db_blob_from_file (const DB_VALUE * src_value, DB_VALUE * result_value)
   src_type = DB_VALUE_DOMAIN_TYPE (src_value);
   if (src_type == DB_TYPE_NULL)
     {
-      DB_MAKE_NULL (result_value);
+      db_make_null (result_value);
       return NO_ERROR;
     }
 
   if (QSTR_IS_CHAR (src_type))
     {
       int path_buf_len = 0;
-      int src_size = DB_GET_STRING_SIZE (src_value);
+      int src_size = db_get_string_size (src_value);
 
-      src_size = (src_size < 0) ? strlen (DB_GET_STRING (src_value)) : src_size;
+      src_size = (src_size < 0) ? strlen (db_get_string (src_value)) : src_size;
 
-      if (DB_GET_STRING_SIZE (src_value) == 0)
+      if (db_get_string_size (src_value) == 0)
 	{
 	  error_status = ER_QSTR_EMPTY_STRING;
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
 	  return error_status;
 	}
 
-      if (es_get_type (DB_GET_STRING (src_value)) == ES_NONE)
+      if (es_get_type (db_get_string (src_value)) == ES_NONE)
 	{
 	  /* Set default prefix, if no valid prefix was set. */
 	  strcpy (path_buf, default_prefix);
 	  path_buf_len = strlen (path_buf);
 	}
 
-      strncat (path_buf, DB_GET_STRING (src_value), MIN (src_size, PATH_MAX - path_buf_len));
+      strncat (path_buf, db_get_string (src_value), MIN (src_size, PATH_MAX - path_buf_len));
       path_buf[path_buf_len + MIN (src_size, PATH_MAX - path_buf_len)] = '\0';
 
       error_status = lob_from_file (path_buf, src_value, result_value, DB_TYPE_BLOB);
@@ -24864,7 +24864,7 @@ db_blob_length (const DB_VALUE * src_value, DB_VALUE * result_value)
   src_type = DB_VALUE_DOMAIN_TYPE (src_value);
   if (src_type == DB_TYPE_NULL)
     {
-      DB_MAKE_NULL (result_value);
+      db_make_null (result_value);
       return NO_ERROR;
     }
 
@@ -24901,7 +24901,7 @@ db_char_to_clob (const DB_VALUE * src_value, DB_VALUE * result_value)
   src_type = DB_VALUE_DOMAIN_TYPE (src_value);
   if (src_type == DB_TYPE_NULL)
     {
-      DB_MAKE_NULL (result_value);
+      db_make_null (result_value);
       return NO_ERROR;
     }
 
@@ -24912,7 +24912,7 @@ db_char_to_clob (const DB_VALUE * src_value, DB_VALUE * result_value)
 	{
 	  elo = db_get_elo (result_value);
 	  src_str = db_get_string (src_value);
-	  src_size = DB_GET_STRING_SIZE (src_value);
+	  src_size = db_get_string_size (src_value);
 	  if (src_size > 0)
 	    {
 	      error_status = db_elo_write (elo, 0, src_str, src_size, NULL);
@@ -24949,7 +24949,7 @@ db_clob_to_char (const DB_VALUE * src_value, const DB_VALUE * codeset_value, DB_
     {
       assert (DB_VALUE_DOMAIN_TYPE (codeset_value) == DB_TYPE_INTEGER);
 
-      cs = DB_GET_INTEGER (codeset_value);
+      cs = db_get_int (codeset_value);
       if (cs != INTL_CODESET_UTF8 && cs != INTL_CODESET_ISO88591 && cs != INTL_CODESET_KSC5601_EUC)
 	{
 	  error_status = ER_OBJ_INVALID_ARGUMENTS;
@@ -24963,7 +24963,7 @@ db_clob_to_char (const DB_VALUE * src_value, const DB_VALUE * codeset_value, DB_
 
   if (src_type == DB_TYPE_NULL)
     {
-      DB_MAKE_NULL (result_value);
+      db_make_null (result_value);
       return NO_ERROR;
     }
 
@@ -25005,32 +25005,32 @@ db_clob_from_file (const DB_VALUE * src_value, DB_VALUE * result_value)
   src_type = DB_VALUE_DOMAIN_TYPE (src_value);
   if (src_type == DB_TYPE_NULL)
     {
-      DB_MAKE_NULL (result_value);
+      db_make_null (result_value);
       return NO_ERROR;
     }
 
   if (QSTR_IS_CHAR (src_type))
     {
       int path_buf_len = 0;
-      int src_size = DB_GET_STRING_SIZE (src_value);
+      int src_size = db_get_string_size (src_value);
 
-      src_size = (src_size < 0) ? strlen (DB_GET_STRING (src_value)) : src_size;
+      src_size = (src_size < 0) ? strlen (db_get_string (src_value)) : src_size;
 
-      if (DB_GET_STRING_SIZE (src_value) == 0)
+      if (db_get_string_size (src_value) == 0)
 	{
 	  error_status = ER_QSTR_EMPTY_STRING;
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
 	  return error_status;
 	}
 
-      if (es_get_type (DB_GET_STRING (src_value)) == ES_NONE)
+      if (es_get_type (db_get_string (src_value)) == ES_NONE)
 	{
 	  /* Set default prefix, if no valid prefix was set. */
 	  strcpy (path_buf, default_prefix);
 	  path_buf_len = strlen (path_buf);
 	}
 
-      strncat (path_buf, DB_GET_STRING (src_value), MIN (src_size, PATH_MAX - path_buf_len));
+      strncat (path_buf, db_get_string (src_value), MIN (src_size, PATH_MAX - path_buf_len));
       path_buf[path_buf_len + MIN (src_size, PATH_MAX - path_buf_len)] = '\0';
 
       error_status = lob_from_file (path_buf, src_value, result_value, DB_TYPE_CLOB);
@@ -25061,7 +25061,7 @@ db_clob_length (const DB_VALUE * src_value, DB_VALUE * result_value)
   src_type = DB_VALUE_DOMAIN_TYPE (src_value);
   if (src_type == DB_TYPE_NULL)
     {
-      DB_MAKE_NULL (result_value);
+      db_make_null (result_value);
       return NO_ERROR;
     }
 
@@ -25119,8 +25119,8 @@ db_get_datetime_from_dbvalue (const DB_VALUE * src_date, int *year, int *month, 
 	int str_len;
 	char *strp;
 
-	strp = DB_GET_STRING (src_date);
-	str_len = DB_GET_STRING_SIZE (src_date);
+	strp = db_get_string (src_date);
+	str_len = db_get_string_size (src_date);
 	if (db_date_parse_datetime_parts (strp, str_len, &db_datetime, NULL, NULL, NULL, endp) != NO_ERROR)
 	  {
 	    return ER_FAILED;
@@ -25135,7 +25135,7 @@ db_get_datetime_from_dbvalue (const DB_VALUE * src_date, int *year, int *month, 
 	*minute = 0;
 	*second = 0;
 	*millisecond = 0;
-	db_date_decode (DB_GET_DATE (src_date), month, day, year);
+	db_date_decode (db_get_date (src_date), month, day, year);
 
 	return NO_ERROR;
       }
@@ -25150,7 +25150,7 @@ db_get_datetime_from_dbvalue (const DB_VALUE * src_date, int *year, int *month, 
 
 	if (arg_type == DB_TYPE_DATETIMELTZ)
 	  {
-	    dt_p = DB_GET_DATETIME (src_date);
+	    dt_p = db_get_datetime (src_date);
 	    if (tz_datetimeltz_to_local (dt_p, &dt_local) != NO_ERROR)
 	      {
 		er_clear ();
@@ -25160,7 +25160,7 @@ db_get_datetime_from_dbvalue (const DB_VALUE * src_date, int *year, int *month, 
 	  }
 	else if (arg_type == DB_TYPE_DATETIMETZ)
 	  {
-	    dt_tz_p = DB_GET_DATETIMETZ (src_date);
+	    dt_tz_p = db_get_datetimetz (src_date);
 	    if (tz_utc_datetimetz_to_local (&dt_tz_p->datetime, &dt_tz_p->tz_id, &dt_local) != NO_ERROR)
 	      {
 		er_clear ();
@@ -25170,7 +25170,7 @@ db_get_datetime_from_dbvalue (const DB_VALUE * src_date, int *year, int *month, 
 	  }
 	else
 	  {
-	    dt_p = DB_GET_DATETIME (src_date);
+	    dt_p = db_get_datetime (src_date);
 	  }
 
 	return db_datetime_decode (dt_p, month, day, year, hour, minute, second, millisecond);
@@ -25187,7 +25187,7 @@ db_get_datetime_from_dbvalue (const DB_VALUE * src_date, int *year, int *month, 
 
 	if (arg_type == DB_TYPE_TIMESTAMPTZ)
 	  {
-	    ts_tz_p = DB_GET_TIMESTAMPTZ (src_date);
+	    ts_tz_p = db_get_timestamptz (src_date);
 	    if (db_timestamp_decode_w_tz_id (&ts_tz_p->timestamp, &ts_tz_p->tz_id, &db_date, &db_time) != NO_ERROR)
 	      {
 		er_clear ();
@@ -25196,7 +25196,7 @@ db_get_datetime_from_dbvalue (const DB_VALUE * src_date, int *year, int *month, 
 	  }
 	else
 	  {
-	    ts_p = DB_GET_TIMESTAMP (src_date);
+	    ts_p = db_get_timestamp (src_date);
 	    (void) db_timestamp_decode_ses (ts_p, &db_date, &db_time);
 	  }
 
@@ -25262,8 +25262,8 @@ db_get_time_from_dbvalue (const DB_VALUE * src_date, int *hour, int *minute, int
 	int str_len;
 	char *strp;
 
-	strp = DB_GET_STRING (src_date);
-	str_len = DB_GET_STRING_SIZE (src_date);
+	strp = db_get_string (src_date);
+	str_len = db_get_string_size (src_date);
 	if (db_date_parse_time (strp, str_len, &db_time, millisecond) != NO_ERROR)
 	  {
 	    return ER_FAILED;
@@ -25284,7 +25284,7 @@ db_get_time_from_dbvalue (const DB_VALUE * src_date, int *hour, int *minute, int
 
 	if (arg_type == DB_TYPE_DATETIMELTZ)
 	  {
-	    dt_p = DB_GET_DATETIME (src_date);
+	    dt_p = db_get_datetime (src_date);
 	    if (tz_datetimeltz_to_local (dt_p, &dt_local) != NO_ERROR)
 	      {
 		er_clear ();
@@ -25294,7 +25294,7 @@ db_get_time_from_dbvalue (const DB_VALUE * src_date, int *hour, int *minute, int
 	  }
 	else if (arg_type == DB_TYPE_DATETIMETZ)
 	  {
-	    dt_tz_p = DB_GET_DATETIMETZ (src_date);
+	    dt_tz_p = db_get_datetimetz (src_date);
 	    if (tz_utc_datetimetz_to_local (&dt_tz_p->datetime, &dt_tz_p->tz_id, &dt_local) != NO_ERROR)
 	      {
 		er_clear ();
@@ -25304,7 +25304,7 @@ db_get_time_from_dbvalue (const DB_VALUE * src_date, int *hour, int *minute, int
 	  }
 	else
 	  {
-	    dt_p = DB_GET_DATETIME (src_date);
+	    dt_p = db_get_datetime (src_date);
 	  }
 
 	return db_datetime_decode (dt_p, &month, &day, &year, hour, minute, second, millisecond);
@@ -25320,7 +25320,7 @@ db_get_time_from_dbvalue (const DB_VALUE * src_date, int *hour, int *minute, int
 
 	if (arg_type == DB_TYPE_TIMELTZ)
 	  {
-	    time_p = DB_GET_TIME (src_date);
+	    time_p = db_get_time (src_date);
 	    if (tz_timeltz_to_local (time_p, &time_local) != NO_ERROR)
 	      {
 		er_clear ();
@@ -25330,7 +25330,7 @@ db_get_time_from_dbvalue (const DB_VALUE * src_date, int *hour, int *minute, int
 	  }
 	else if (arg_type == DB_TYPE_TIMETZ)
 	  {
-	    time_tz_p = DB_GET_TIMETZ (src_date);
+	    time_tz_p = db_get_timetz (src_date);
 	    if (tz_utc_timetz_to_local (&time_tz_p->time, &time_tz_p->tz_id, &time_local) != NO_ERROR)
 	      {
 		er_clear ();
@@ -25340,7 +25340,7 @@ db_get_time_from_dbvalue (const DB_VALUE * src_date, int *hour, int *minute, int
 	  }
 	else
 	  {
-	    time_p = DB_GET_TIME (src_date);
+	    time_p = db_get_time (src_date);
 	  }
 
 	db_time_decode (time_p, hour, minute, second);
@@ -25358,7 +25358,7 @@ db_get_time_from_dbvalue (const DB_VALUE * src_date, int *hour, int *minute, int
 
 	if (arg_type == DB_TYPE_TIMESTAMPTZ)
 	  {
-	    ts_tz_p = DB_GET_TIMESTAMPTZ (src_date);
+	    ts_tz_p = db_get_timestamptz (src_date);
 	    if (db_timestamp_decode_w_tz_id (&ts_tz_p->timestamp, &ts_tz_p->tz_id, &db_date, &db_time) != NO_ERROR)
 	      {
 		er_clear ();
@@ -25367,7 +25367,7 @@ db_get_time_from_dbvalue (const DB_VALUE * src_date, int *hour, int *minute, int
 	  }
 	else
 	  {
-	    ts_p = DB_GET_TIMESTAMP (src_date);
+	    ts_p = db_get_timestamp (src_date);
 	    (void) db_timestamp_decode_ses (ts_p, &db_date, &db_time);
 	  }
 
@@ -25406,7 +25406,7 @@ db_null_terminate_string (const DB_VALUE * src_value, char **strp)
       return ER_FAILED;
     }
 
-  src_size = DB_GET_STRING_SIZE (src_value);
+  src_size = db_get_string_size (src_value);
   src_type = DB_VALUE_DOMAIN_TYPE (src_value);
 
   if (src_type != DB_TYPE_CHAR && src_type != DB_TYPE_NCHAR)
@@ -25420,7 +25420,7 @@ db_null_terminate_string (const DB_VALUE * src_value, char **strp)
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
-  memcpy (*strp, DB_GET_STRING (src_value), src_size);
+  memcpy (*strp, db_get_string (src_value), src_size);
   (*strp)[src_size] = '\0';
 
   return NO_ERROR;
@@ -25640,8 +25640,8 @@ db_get_info_for_like_optimization (const DB_VALUE * const pattern, const bool ha
   *last_safe_logical_pos = -22;
   *num_match_many = 0;
   *num_match_one = 0;
-  pattern_str = DB_GET_STRING (pattern);
-  pattern_size = DB_GET_STRING_SIZE (pattern);
+  pattern_str = db_get_string (pattern);
+  pattern_size = db_get_string_size (pattern);
 
   for (i = 0; i < pattern_size;)
     {
@@ -25649,7 +25649,7 @@ db_get_info_for_like_optimization (const DB_VALUE * const pattern, const bool ha
       bool is_escaped = false;
 
       error_code =
-	db_get_next_like_pattern_character (pattern_str, pattern_size, DB_GET_STRING_CODESET (pattern), has_escape_char,
+	db_get_next_like_pattern_character (pattern_str, pattern_size, db_get_string_codeset (pattern), has_escape_char,
 					    escape_str, &i, &crt_char_p, &is_escaped);
       if (error_code != NO_ERROR)
 	{
@@ -25669,7 +25669,7 @@ db_get_info_for_like_optimization (const DB_VALUE * const pattern, const bool ha
 	}
 
       if (*num_match_many == 0
-	  && is_safe_last_char_for_like_optimization (crt_char_p, is_escaped, DB_GET_STRING_CODESET (pattern)))
+	  && is_safe_last_char_for_like_optimization (crt_char_p, is_escaped, db_get_string_codeset (pattern)))
 	{
 	  *last_safe_logical_pos = *num_logical_chars;
 	}
@@ -25739,12 +25739,12 @@ db_get_like_optimization_bounds (const DB_VALUE * const pattern, DB_VALUE * boun
 
   if (DB_IS_NULL (pattern))
     {
-      DB_MAKE_NULL (bound);
+      db_make_null (bound);
       goto fast_exit;
     }
 
-  codeset = DB_GET_STRING_CODESET (pattern);
-  collation_id = DB_GET_STRING_COLLATION (pattern);
+  codeset = db_get_string_codeset (pattern);
+  collation_id = db_get_string_collation (pattern);
 
   if (!QSTR_IS_CHAR (DB_VALUE_DOMAIN_TYPE (pattern)))
     {
@@ -25779,8 +25779,8 @@ db_get_like_optimization_bounds (const DB_VALUE * const pattern, DB_VALUE * boun
       goto fast_exit;
     }
 
-  original = DB_GET_STRING (pattern);
-  original_size = DB_GET_STRING_SIZE (pattern);
+  original = db_get_string (pattern);
+  original_size = db_get_string_size (pattern);
 
   /* assume worst case scenario : all characters in output bound string are stored on the maximum character size */
   intl_char_count ((unsigned char *) original, original_size, codeset, &char_count);
@@ -25919,7 +25919,7 @@ db_compress_like_pattern (const DB_VALUE * const pattern, DB_VALUE * compressed_
 
   if (DB_IS_NULL (pattern))
     {
-      DB_MAKE_NULL (compressed_pattern);
+      db_make_null (compressed_pattern);
       goto fast_exit;
     }
 
@@ -25930,9 +25930,9 @@ db_compress_like_pattern (const DB_VALUE * const pattern, DB_VALUE * compressed_
       goto error_exit;
     }
 
-  codeset = DB_GET_STRING_CODESET (pattern);
-  original = DB_GET_STRING (pattern);
-  original_size = DB_GET_STRING_SIZE (pattern);
+  codeset = db_get_string_codeset (pattern);
+  original = db_get_string (pattern);
+  original_size = db_get_string_size (pattern);
 
   if (has_escape_char)
     {
@@ -26011,8 +26011,8 @@ db_compress_like_pattern (const DB_VALUE * const pattern, DB_VALUE * compressed_
 
   assert (result_length <= alloc_size);
   result[result_size] = 0;
-  DB_MAKE_VARCHAR (compressed_pattern, TP_FLOATING_PRECISION_VALUE, result, result_size, codeset,
-		   DB_GET_STRING_COLLATION (pattern));
+  db_make_varchar (compressed_pattern, TP_FLOATING_PRECISION_VALUE, result, result_size, codeset,
+		   db_get_string_collation (pattern));
   compressed_pattern->need_clear = true;
 
 fast_exit:
@@ -26053,7 +26053,7 @@ db_like_bound (const DB_VALUE * const src_pattern, const DB_VALUE * const src_es
   int num_match_one = 0;
   const char *escape_str = NULL;
 
-  DB_MAKE_NULL (&compressed_pattern);
+  db_make_null (&compressed_pattern);
 
   if (src_pattern == NULL || result_bound == NULL)
     {
@@ -26064,7 +26064,7 @@ db_like_bound (const DB_VALUE * const src_pattern, const DB_VALUE * const src_es
 
   if (DB_IS_NULL (src_pattern))
     {
-      DB_MAKE_NULL (result_bound);
+      db_make_null (result_bound);
       goto fast_exit;
     }
 
@@ -26096,9 +26096,9 @@ db_like_bound (const DB_VALUE * const src_pattern, const DB_VALUE * const src_es
 	      goto error_exit;
 	    }
 
-	  escape_str = DB_GET_STRING (src_escape);
+	  escape_str = db_get_string (src_escape);
 
-	  if (DB_GET_STRING_LENGTH (src_escape) != 1 || escape_str[0] == 0)
+	  if (db_get_string_length (src_escape) != 1 || escape_str[0] == 0)
 	    {
 	      error_code = ER_QSTR_INVALID_ESCAPE_CHARACTER;
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
@@ -26176,13 +26176,13 @@ db_check_or_create_null_term_string (const DB_VALUE * str_val, char *pre_alloc_b
 
   *do_alloc = false;
 
-  val_buf = DB_GET_STRING (str_val);
+  val_buf = db_get_string (str_val);
   if (val_buf == NULL)
     {
       *str_out = NULL;
       return NO_ERROR;
     }
-  val_size = DB_GET_STRING_SIZE (str_val);
+  val_size = db_get_string_size (str_val);
 
   /* size < 0 assumes a null terminated string */
   if (val_size < 0)
@@ -26632,7 +26632,7 @@ db_hex (const DB_VALUE * param, DB_VALUE * result)
 
   if (DB_IS_NULL (param))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -26644,15 +26644,15 @@ db_hex (const DB_VALUE * param, DB_VALUE * result)
       if (TP_IS_CHAR_TYPE (param_type))
 	{
 	  /* retrieve source string */
-	  str = DB_GET_STRING (param);
-	  str_size = DB_GET_STRING_SIZE (param);
+	  str = db_get_string (param);
+	  str_size = db_get_string_size (param);
 
 	  /* remove padding from end of string */
 	  if (param_type == DB_TYPE_CHAR || param_type == DB_TYPE_NCHAR)
 	    {
 	      unsigned char pad_char[2];
 	      int pad_char_size;
-	      intl_pad_char (DB_GET_STRING_CODESET (param), pad_char, &pad_char_size);
+	      intl_pad_char (db_get_string_codeset (param), pad_char, &pad_char_size);
 
 	      while (str_size >= pad_char_size
 		     && memcmp (&(str[str_size - pad_char_size]), pad_char, pad_char_size) == 0)
@@ -26664,7 +26664,7 @@ db_hex (const DB_VALUE * param, DB_VALUE * result)
       else
 	{
 	  /* get bytes of bitfield */
-	  str = DB_GET_BIT (param, &str_size);
+	  str = db_get_bit (param, &str_size);
 	  str_size = QSTR_NUM_BYTES (str_size);
 	}
 
@@ -26686,7 +26686,7 @@ db_hex (const DB_VALUE * param, DB_VALUE * result)
 	}
 
       /* set return string */
-      DB_MAKE_STRING (result, hexval);
+      db_make_string (result, hexval);
       result->need_clear = true;
     }
   else if (TP_IS_NUMERIC_TYPE (param_type))
@@ -26707,7 +26707,7 @@ db_hex (const DB_VALUE * param, DB_VALUE * result)
 	}
       else
 	{
-	  param_bigint = (UINT64) DB_GET_BIGINT (&param_db_bigint);
+	  param_bigint = (UINT64) db_get_bigint (&param_db_bigint);
 	}
 
       /* compute hex representation length */
@@ -26734,7 +26734,7 @@ db_hex (const DB_VALUE * param, DB_VALUE * result)
 	}
 
       /* set return string */
-      DB_MAKE_STRING (result, hexval);
+      db_make_string (result, hexval);
       result->need_clear = true;
     }
   else
@@ -26749,7 +26749,7 @@ db_hex (const DB_VALUE * param, DB_VALUE * result)
 error:
   if (result)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
@@ -26787,7 +26787,7 @@ db_guid (THREAD_ENTRY * thread_p, DB_VALUE * result)
       goto error;
     }
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   /* Generate random bytes */
   error_code = crypt_generate_random_bytes (thread_p, guid_bytes, GUID_STANDARD_BYTES_LENGTH);
@@ -26823,7 +26823,7 @@ db_guid (THREAD_ENTRY * thread_p, DB_VALUE * result)
       guid_hex[i * 2 + 1] = hex_digit[(guid_bytes[i] & 0xF)];
     }
 
-  DB_MAKE_STRING (result, guid_hex);
+  db_make_string (result, guid_hex);
   result->need_clear = true;
 
   return NO_ERROR;
@@ -26866,7 +26866,7 @@ db_ascii (const DB_VALUE * param, DB_VALUE * result)
 
   if (DB_IS_NULL (param))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -26876,15 +26876,15 @@ db_ascii (const DB_VALUE * param, DB_VALUE * result)
   if (TP_IS_CHAR_TYPE (param_type))
     {
       /* get string and length */
-      str = DB_GET_STRING (param);
-      str_size = DB_GET_STRING_SIZE (param);
+      str = db_get_string (param);
+      str_size = db_get_string_size (param);
 
       /* remove padding from end of string */
       if (param_type == DB_TYPE_CHAR || param_type == DB_TYPE_NCHAR)
 	{
 	  unsigned char pad_char[2];
 	  int pad_char_size;
-	  intl_pad_char (DB_GET_STRING_CODESET (param), pad_char, &pad_char_size);
+	  intl_pad_char (db_get_string_codeset (param), pad_char, &pad_char_size);
 
 	  while (str_size >= pad_char_size && memcmp (&(str[str_size - pad_char_size]), pad_char, pad_char_size) == 0)
 	    {
@@ -26895,26 +26895,26 @@ db_ascii (const DB_VALUE * param, DB_VALUE * result)
       /* return first character */
       if (str_size > 0)
 	{
-	  DB_MAKE_SMALLINT (result, (unsigned char) str[0]);
+	  db_make_short (result, (unsigned char) str[0]);
 	}
       else
 	{
-	  DB_MAKE_SMALLINT (result, 0);
+	  db_make_short (result, 0);
 	}
     }
   else if (TP_IS_BIT_TYPE (param_type))
     {
       /* get bitfield as char array */
-      str = DB_GET_BIT (param, &str_size);
+      str = db_get_bit (param, &str_size);
 
       /* return first byte */
       if (str_size > 0)
 	{
-	  DB_MAKE_SMALLINT (result, (unsigned char) str[0]);
+	  db_make_short (result, (unsigned char) str[0]);
 	}
       else
 	{
-	  DB_MAKE_SMALLINT (result, 0);
+	  db_make_short (result, 0);
 	}
     }
   else
@@ -26929,7 +26929,7 @@ db_ascii (const DB_VALUE * param, DB_VALUE * result)
 error:
   if (result)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
   er_clear ();
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
@@ -26994,7 +26994,7 @@ db_conv (const DB_VALUE * num, const DB_VALUE * from_base, const DB_VALUE * to_b
 
   if (DB_IS_NULL (num) || DB_IS_NULL (from_base) || DB_IS_NULL (to_base))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -27010,8 +27010,8 @@ db_conv (const DB_VALUE * num, const DB_VALUE * from_base, const DB_VALUE * to_b
     }
 
   /* from_base and to_base bounds checking */
-  from_base_int = DB_GET_SMALLINT (from_base);
-  to_base_int = DB_GET_SMALLINT (to_base);
+  from_base_int = db_get_short (from_base);
+  to_base_int = db_get_short (to_base);
   num_is_signed = (from_base_int < 0);
   res_is_signed = (to_base_int < 0);
   from_base_int = ABS (from_base_int);
@@ -27019,7 +27019,7 @@ db_conv (const DB_VALUE * num, const DB_VALUE * from_base, const DB_VALUE * to_b
 
   if (from_base_int < 2 || from_base_int > 36 || to_base_int < 2 || to_base_int > 36)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -27030,15 +27030,15 @@ db_conv (const DB_VALUE * num, const DB_VALUE * from_base, const DB_VALUE * to_b
       switch (num_type)
 	{
 	case DB_TYPE_SMALLINT:
-	  snprintf (num_p_str, UINT64_MAX_BIN_DIGITS + 1, "%d", DB_GET_SMALLINT (num));
+	  snprintf (num_p_str, UINT64_MAX_BIN_DIGITS + 1, "%d", db_get_short (num));
 	  break;
 
 	case DB_TYPE_INTEGER:
-	  snprintf (num_p_str, UINT64_MAX_BIN_DIGITS + 1, "%d", DB_GET_INT (num));
+	  snprintf (num_p_str, UINT64_MAX_BIN_DIGITS + 1, "%d", db_get_int (num));
 	  break;
 
 	case DB_TYPE_BIGINT:
-	  snprintf (num_p_str, UINT64_MAX_BIN_DIGITS + 1, "%lld", (long long int) DB_GET_BIGINT (num));
+	  snprintf (num_p_str, UINT64_MAX_BIN_DIGITS + 1, "%lld", (long long int) db_get_bigint (num));
 	  break;
 
 	case DB_TYPE_NUMERIC:
@@ -27056,11 +27056,11 @@ db_conv (const DB_VALUE * num, const DB_VALUE * from_base, const DB_VALUE * to_b
 	  break;
 
 	case DB_TYPE_FLOAT:
-	  snprintf (num_p_str, UINT64_MAX_BIN_DIGITS + 1, "%.0f", DB_GET_FLOAT (num));
+	  snprintf (num_p_str, UINT64_MAX_BIN_DIGITS + 1, "%.0f", db_get_float (num));
 	  break;
 
 	case DB_TYPE_DOUBLE:
-	  snprintf (num_p_str, UINT64_MAX_BIN_DIGITS + 1, "%.0f", DB_GET_DOUBLE (num));
+	  snprintf (num_p_str, UINT64_MAX_BIN_DIGITS + 1, "%.0f", db_get_double (num));
 	  break;
 
 	case DB_TYPE_MONETARY:
@@ -27068,15 +27068,15 @@ db_conv (const DB_VALUE * num, const DB_VALUE * from_base, const DB_VALUE * to_b
 	  break;
 
 	default:
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	  return NO_ERROR;
 	}
     }
   else if (TP_IS_CHAR_TYPE (num_type))
     {
       /* copy into a null-terminated string */
-      int str_size = DB_GET_STRING_SIZE (num);
-      INTL_CODESET codeset = DB_GET_STRING_CODESET (num);
+      int str_size = db_get_string_size (num);
+      INTL_CODESET codeset = db_get_string_codeset (num);
       int prev_char_length = 0;
       char *str_start = NULL, *str_end = NULL;
       char *prev_char = NULL;
@@ -27084,7 +27084,7 @@ db_conv (const DB_VALUE * num, const DB_VALUE * from_base, const DB_VALUE * to_b
       if (str_size >= 0)
 	{
 	  str_size = MIN (str_size, sizeof (num_str) - 1);
-	  strncpy (num_str, DB_GET_STRING (num), str_size);
+	  strncpy (num_str, db_get_string (num), str_size);
 	  str_start = num_str;
 	  str_end = num_str + str_size;
 
@@ -27127,7 +27127,7 @@ db_conv (const DB_VALUE * num, const DB_VALUE * from_base, const DB_VALUE * to_b
   else if (TP_IS_BIT_TYPE (num_type))
     {
       /* get raw bytes */
-      num_p_str = DB_GET_BIT (num, &num_size);
+      num_p_str = db_get_bit (num, &num_size);
       num_size = QSTR_NUM_BYTES (num_size);
 
       /* convert to hex; NOTE: qstr_bin_to_hex returns number of converted bytes, not the size of the hex string; also, 
@@ -27220,7 +27220,7 @@ db_conv (const DB_VALUE * num, const DB_VALUE * from_base, const DB_VALUE * to_b
       goto error;
     }
   memcpy (res_p_str, res_str, res_size + 1);
-  DB_MAKE_STRING (result, res_p_str);
+  db_make_string (result, res_p_str);
   result->need_clear = true;
 
   /* all ok */
@@ -27229,7 +27229,7 @@ db_conv (const DB_VALUE * num, const DB_VALUE * from_base, const DB_VALUE * to_b
 error:
   if (result)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
@@ -27438,7 +27438,7 @@ db_value_to_enumeration_value (const DB_VALUE * src, DB_VALUE * result, const TP
       return ER_FAILED;
     }
 
-  DB_MAKE_NULL (result);
+  db_make_null (result);
 
   status = tp_value_cast (src, result, enum_domain, false);
   if (status != DOMAIN_COMPATIBLE)
@@ -27447,7 +27447,7 @@ db_value_to_enumeration_value (const DB_VALUE * src, DB_VALUE * result, const TP
 	{
 	  return ER_FAILED;
 	}
-      DB_MAKE_ENUMERATION (result, DB_ENUM_OVERFLOW_VAL, NULL, 0, TP_DOMAIN_CODESET (enum_domain),
+      db_make_enumeration (result, DB_ENUM_OVERFLOW_VAL, NULL, 0, TP_DOMAIN_CODESET (enum_domain),
 			   TP_DOMAIN_COLLATION (enum_domain));
       er_clear ();
       /* continue, no error */
@@ -27501,7 +27501,7 @@ db_inet_aton (DB_VALUE * result_numbered_ip, const DB_VALUE * string)
 
   if (DB_IS_NULL (string))
     {
-      DB_MAKE_NULL (result_numbered_ip);
+      db_make_null (result_numbered_ip);
       return NO_ERROR;
     }
 
@@ -27511,8 +27511,8 @@ db_inet_aton (DB_VALUE * result_numbered_ip, const DB_VALUE * string)
       goto error;
     }
 
-  /* there is no need to check DB_GET_STRING_LENGTH or DB_GET_STRING_SIZE or cnt, we control ip format by ourselves */
-  ip_string = DB_GET_CHAR (string, &cnt);
+  /* there is no need to check db_get_string_length or db_get_string_size or cnt, we control ip format by ourselves */
+  ip_string = db_get_char (string, &cnt);
   local_ipstring = (char *) db_private_alloc (NULL, cnt + 1);
   if (local_ipstring == NULL)
     {
@@ -27558,7 +27558,7 @@ db_inet_aton (DB_VALUE * result_numbered_ip, const DB_VALUE * string)
     }
 
   db_private_free (NULL, local_ipstring);
-  DB_MAKE_BIGINT (result_numbered_ip, numbered_ip);
+  db_make_bigint (result_numbered_ip, numbered_ip);
   return NO_ERROR;
 
 error:
@@ -27566,7 +27566,7 @@ error:
     {
       db_private_free (NULL, local_ipstring);
     }
-  DB_MAKE_NULL (result_numbered_ip);
+  db_make_null (result_numbered_ip);
 
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
@@ -27630,7 +27630,7 @@ db_inet_ntoa (DB_VALUE * result_ip_string, const DB_VALUE * number)
       goto error;
     }
 
-  ip_number = DB_GET_BIGINT (number);
+  ip_number = db_get_bigint (number);
   if (ip_number > ipmax || ip_number < 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OPFUNC_INET_NTOA_ARG, 1, (long long int) ip_number);
@@ -27659,13 +27659,13 @@ db_inet_ntoa (DB_VALUE * result_ip_string, const DB_VALUE * number)
       goto error;
     }
   memcpy (res_p_str, ip_string, ret_string_len + 1);
-  DB_MAKE_STRING (result_ip_string, res_p_str);
+  db_make_string (result_ip_string, res_p_str);
   result_ip_string->need_clear = true;
 
   return NO_ERROR;
 
 error:
-  DB_MAKE_NULL (result_ip_string);
+  db_make_null (result_ip_string);
 
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
@@ -27777,7 +27777,7 @@ db_get_date_format (const DB_VALUE * format_str, TIMESTAMP_FORMAT * format)
       goto end;
     }
 
-  if (DB_GET_STRING_SIZE (format_str) == 0)
+  if (db_get_string_size (format_str) == 0)
     {
       error = ER_QSTR_EMPTY_STRING;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
@@ -27785,7 +27785,7 @@ db_get_date_format (const DB_VALUE * format_str, TIMESTAMP_FORMAT * format)
       goto end;
     }
 
-  if (DB_GET_STRING_SIZE (format_str) > MAX_TOKEN_SIZE)
+  if (db_get_string_size (format_str) > MAX_TOKEN_SIZE)
     {
       error = ER_QSTR_SRC_TOO_LONG;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
@@ -27793,7 +27793,7 @@ db_get_date_format (const DB_VALUE * format_str, TIMESTAMP_FORMAT * format)
       goto end;
     }
 
-  codeset = DB_GET_STRING_CODESET (format_str);
+  codeset = db_get_string_codeset (format_str);
 
   error =
     db_check_or_create_null_term_string (format_str, stack_buf_format, sizeof (stack_buf_format), true, true,
@@ -27852,14 +27852,14 @@ db_get_cs_coll_info (DB_VALUE * result, const DB_VALUE * val, const int mode)
 
   if (DB_IS_NULL (val))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
   else if (!TP_TYPE_HAS_COLLATION (DB_VALUE_TYPE (val)))
     {
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  er_clear ();
-	  DB_MAKE_NULL (result);
+	  db_make_null (result);
 	}
       else
 	{
@@ -27873,24 +27873,24 @@ db_get_cs_coll_info (DB_VALUE * result, const DB_VALUE * val, const int mode)
 
       if (TP_IS_CHAR_TYPE (DB_VALUE_TYPE (val)))
 	{
-	  cs = DB_GET_STRING_CODESET (val);
-	  coll = DB_GET_STRING_COLLATION (val);
+	  cs = db_get_string_codeset (val);
+	  coll = db_get_string_collation (val);
 	}
       else
 	{
 	  assert (DB_VALUE_TYPE (val) == DB_TYPE_ENUMERATION);
-	  cs = DB_GET_ENUM_CODESET (val);
-	  coll = DB_GET_ENUM_COLLATION (val);
+	  cs = db_get_enum_codeset (val);
+	  coll = db_get_enum_collation (val);
 	}
 
       if (mode == 0)
 	{
-	  DB_MAKE_STRING (result, lang_charset_cubrid_name ((INTL_CODESET) cs));
+	  db_make_string (result, lang_charset_cubrid_name ((INTL_CODESET) cs));
 	}
       else
 	{
 	  assert (mode == 1);
-	  DB_MAKE_STRING (result, lang_get_collation_name (coll));
+	  db_make_string (result, lang_get_collation_name (coll));
 	}
     }
 
@@ -27939,7 +27939,7 @@ db_string_index_prefix (const DB_VALUE * string1, const DB_VALUE * string2, cons
     }
 
   if ((qstr_get_category (string1) != qstr_get_category (string2))
-      || (DB_GET_STRING_CODESET (string1) != DB_GET_STRING_CODESET (string2)))
+      || (db_get_string_codeset (string1) != db_get_string_codeset (string2)))
     {
       error_status = ER_QSTR_INCOMPATIBLE_CODE_SETS;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -27947,7 +27947,7 @@ db_string_index_prefix (const DB_VALUE * string1, const DB_VALUE * string2, cons
     }
 
   key_domain.is_desc = false;
-  if (strncasecmp (DB_GET_STRING (index_type), "d", 1) == 0)
+  if (strncasecmp (db_get_string (index_type), "d", 1) == 0)
     {
       key_domain.is_desc = true;
     }
@@ -27957,7 +27957,7 @@ db_string_index_prefix (const DB_VALUE * string1, const DB_VALUE * string2, cons
     {
       return error_status;
     }
-  cmp_res = DB_GET_INT (&db_cmp_res);
+  cmp_res = db_get_int (&db_cmp_res);
   if ((key_domain.is_desc && cmp_res <= 0) || (!key_domain.is_desc && cmp_res >= 0))
     {
       error_status = ER_OBJ_INVALID_ARGUMENTS;
@@ -27995,14 +27995,14 @@ db_string_to_base64 (DB_VALUE const *src, DB_VALUE * result)
 
   if (DB_IS_NULL (src))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return error_status;
     }
 
-  src_buf = (const unsigned char *) DB_GET_STRING (src);
+  src_buf = (const unsigned char *) db_get_string (src);
 
   /* length in bytes */
-  src_len = DB_GET_STRING_SIZE (src);
+  src_len = db_get_string_size (src);
 
   assert (src_len >= 0);
 
@@ -28010,8 +28010,8 @@ db_string_to_base64 (DB_VALUE const *src, DB_VALUE * result)
   if (src_len == 0)
     {
       error_status =
-	db_string_make_empty_typed_string (result, DB_TYPE_VARCHAR, 0, DB_GET_STRING_CODESET (src),
-					   DB_GET_STRING_COLLATION (src));
+	db_string_make_empty_typed_string (result, DB_TYPE_VARCHAR, 0, db_get_string_codeset (src),
+					   db_get_string_collation (src));
       if (error_status != NO_ERROR)
 	{
 	  assert_release (false);
@@ -28029,7 +28029,7 @@ db_string_to_base64 (DB_VALUE const *src, DB_VALUE * result)
       if (error_status == NO_ERROR)
 	{
 	  qstr_make_typed_string (DB_TYPE_VARCHAR, result, encode_len, (char *) encode_buf, encode_len,
-				  DB_GET_STRING_CODESET (src), DB_GET_STRING_COLLATION (src));
+				  db_get_string_codeset (src), db_get_string_collation (src));
 
 	  result->need_clear = true;
 
@@ -28044,7 +28044,7 @@ db_string_to_base64 (DB_VALUE const *src, DB_VALUE * result)
 
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       er_clear ();		/* forget previous error */
       return NO_ERROR;
     }
@@ -28086,14 +28086,14 @@ db_string_from_base64 (DB_VALUE const *src, DB_VALUE * result)
   /* source is NULL */
   if (DB_IS_NULL (src))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
-  src_buf = (const unsigned char *) DB_GET_STRING (src);
+  src_buf = (const unsigned char *) db_get_string (src);
 
   /* length in bytes */
-  src_len = DB_GET_STRING_SIZE (src);
+  src_len = db_get_string_size (src);
 
   assert (src_len >= 0);
 
@@ -28101,8 +28101,8 @@ db_string_from_base64 (DB_VALUE const *src, DB_VALUE * result)
   if (src_len == 0)
     {
       error_status =
-	db_string_make_empty_typed_string (result, DB_TYPE_VARCHAR, 0, DB_GET_STRING_CODESET (src),
-					   DB_GET_STRING_COLLATION (src));
+	db_string_make_empty_typed_string (result, DB_TYPE_VARCHAR, 0, db_get_string_codeset (src),
+					   db_get_string_collation (src));
       if (error_status != NO_ERROR)
 	{
 	  assert_release (false);
@@ -28121,8 +28121,8 @@ db_string_from_base64 (DB_VALUE const *src, DB_VALUE * result)
 	{
 	case BASE64_EMPTY_INPUT:
 	  error_status =
-	    db_string_make_empty_typed_string (result, DB_TYPE_VARCHAR, 0, DB_GET_STRING_CODESET (src),
-					       DB_GET_STRING_COLLATION (src));
+	    db_string_make_empty_typed_string (result, DB_TYPE_VARCHAR, 0, db_get_string_codeset (src),
+					       db_get_string_collation (src));
 	  if (error_status != NO_ERROR)
 	    {
 	      assert_release (false);
@@ -28132,7 +28132,7 @@ db_string_from_base64 (DB_VALUE const *src, DB_VALUE * result)
 
 	case NO_ERROR:
 	  qstr_make_typed_string (DB_TYPE_VARCHAR, result, decode_len, (char *) decode_buf, decode_len,
-				  DB_GET_STRING_CODESET (src), DB_GET_STRING_COLLATION (src));
+				  db_get_string_codeset (src), db_get_string_collation (src));
 	  result->need_clear = true;
 	  break;
 
@@ -28161,7 +28161,7 @@ error_handling:
 
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       er_clear ();		/* forget previous error */
       return NO_ERROR;
     }
@@ -28204,12 +28204,12 @@ db_string_extract_dbval (const MISC_OPERAND extr_operand, DB_VALUE * dbval_p, DB
   switch (dbval_type)
     {
     case DB_TYPE_TIME:
-      time = *DB_GET_TIME (dbval_p);
+      time = *db_get_time (dbval_p);
       db_time_decode (&time, &extvar[HOUR], &extvar[MINUTE], &extvar[SECOND]);
       break;
 
     case DB_TYPE_TIMELTZ:
-      time_p = DB_GET_TIME (dbval_p);
+      time_p = db_get_time (dbval_p);
       err = tz_timeltz_to_local (time_p, &time);
       if (err != NO_ERROR)
 	{
@@ -28220,7 +28220,7 @@ db_string_extract_dbval (const MISC_OPERAND extr_operand, DB_VALUE * dbval_p, DB
       break;
 
     case DB_TYPE_TIMETZ:
-      time_tz_p = DB_GET_TIMETZ (dbval_p);
+      time_tz_p = db_get_timetz (dbval_p);
       err = tz_utc_timetz_to_local (&time_tz_p->time, &time_tz_p->tz_id, &time);
       if (err != NO_ERROR)
 	{
@@ -28230,13 +28230,13 @@ db_string_extract_dbval (const MISC_OPERAND extr_operand, DB_VALUE * dbval_p, DB
       break;
 
     case DB_TYPE_DATE:
-      date = *DB_GET_DATE (dbval_p);
+      date = *db_get_date (dbval_p);
       db_date_decode (&date, &extvar[MONTH], &extvar[DAY], &extvar[YEAR]);
       break;
 
     case DB_TYPE_UTIME:
     case DB_TYPE_TIMESTAMPLTZ:
-      utime = DB_GET_UTIME (dbval_p);
+      utime = db_get_utime (dbval_p);
       (void) db_timestamp_decode_ses (utime, &date, &time);
 
       if (extr_operand == YEAR || extr_operand == MONTH || extr_operand == DAY)
@@ -28250,7 +28250,7 @@ db_string_extract_dbval (const MISC_OPERAND extr_operand, DB_VALUE * dbval_p, DB
       break;
 
     case DB_TYPE_TIMESTAMPTZ:
-      ts_tz_p = DB_GET_TIMESTAMPTZ (dbval_p);
+      ts_tz_p = db_get_timestamptz (dbval_p);
       err = db_timestamp_decode_w_tz_id (&ts_tz_p->timestamp, &ts_tz_p->tz_id, &date, &time);
       if (err != NO_ERROR)
 	{
@@ -28268,13 +28268,13 @@ db_string_extract_dbval (const MISC_OPERAND extr_operand, DB_VALUE * dbval_p, DB
       break;
 
     case DB_TYPE_DATETIME:
-      datetime_p = DB_GET_DATETIME (dbval_p);
+      datetime_p = db_get_datetime (dbval_p);
       db_datetime_decode (datetime_p, &extvar[MONTH], &extvar[DAY], &extvar[YEAR], &extvar[HOUR], &extvar[MINUTE],
 			  &extvar[SECOND], &extvar[MILLISECOND]);
       break;
 
     case DB_TYPE_DATETIMELTZ:
-      datetime_p = DB_GET_DATETIME (dbval_p);
+      datetime_p = db_get_datetime (dbval_p);
       err = tz_datetimeltz_to_local (datetime_p, &datetime);
       if (err != NO_ERROR)
 	{
@@ -28286,7 +28286,7 @@ db_string_extract_dbval (const MISC_OPERAND extr_operand, DB_VALUE * dbval_p, DB
       break;
 
     case DB_TYPE_DATETIMETZ:
-      dt_tz_p = DB_GET_DATETIMETZ (dbval_p);
+      dt_tz_p = db_get_datetimetz (dbval_p);
       err = tz_utc_datetimetz_to_local (&dt_tz_p->datetime, &dt_tz_p->tz_id, &datetime);
       if (err != NO_ERROR)
 	{
@@ -28302,8 +28302,8 @@ db_string_extract_dbval (const MISC_OPERAND extr_operand, DB_VALUE * dbval_p, DB
       {
 	DB_UTIME utime_s;
 	DB_DATETIME datetime_s;
-	char *str_date = DB_GET_STRING (dbval_p);
-	int str_date_len = DB_GET_STRING_SIZE (dbval_p);
+	char *str_date = db_get_string (dbval_p);
+	int str_date_len = db_get_string_size (dbval_p);
 
 	switch (extr_operand)
 	  {
@@ -28371,7 +28371,7 @@ db_string_extract_dbval (const MISC_OPERAND extr_operand, DB_VALUE * dbval_p, DB
 
   if (err == NO_ERROR)
     {
-      DB_MAKE_INT (result_p, extvar[extr_operand]);
+      db_make_int (result_p, extvar[extr_operand]);
     }
   return err;
 }
@@ -28404,15 +28404,15 @@ db_new_time (DB_VALUE * time_val, DB_VALUE * tz_source, DB_VALUE * tz_dest, DB_V
 
   if (DB_IS_NULL (time_val) || DB_IS_NULL (tz_source) || DB_IS_NULL (tz_dest))
     {
-      DB_MAKE_NULL (result_time);
+      db_make_null (result_time);
       return NO_ERROR;
     }
 
-  t_source = DB_GET_STRING (tz_source);
-  t_dest = DB_GET_STRING (tz_dest);
+  t_source = db_get_string (tz_source);
+  t_dest = db_get_string (tz_dest);
 
-  len_source = DB_GET_STRING_SIZE (tz_source);
-  len_dest = DB_GET_STRING_SIZE (tz_dest);
+  len_source = db_get_string_size (tz_source);
+  len_dest = db_get_string_size (tz_dest);
 
   if (len_source < 0)
     {
@@ -28430,7 +28430,7 @@ db_new_time (DB_VALUE * time_val, DB_VALUE * tz_source, DB_VALUE * tz_dest, DB_V
 	DB_DATETIME result;
 	int month, day, year, julian_date;
 
-	datetime = DB_GET_DATETIME (time_val);
+	datetime = db_get_datetime (time_val);
 	db_date_decode (&(datetime->date), &month, &day, &year);
 	julian_date = julian_encode (month, day, year);
 	datetime->date = julian_date;
@@ -28441,7 +28441,7 @@ db_new_time (DB_VALUE * time_val, DB_VALUE * tz_source, DB_VALUE * tz_dest, DB_V
 	  {
 	    return error;
 	  }
-	DB_MAKE_DATETIME (result_time, &result);
+	db_make_datetime (result_time, &result);
       }
       break;
 
@@ -28450,14 +28450,14 @@ db_new_time (DB_VALUE * time_val, DB_VALUE * tz_source, DB_VALUE * tz_dest, DB_V
 	DB_TIME time_res;
 	int hour, min, sec;
 
-	time = DB_GET_TIME (time_val);
+	time = db_get_time (time_val);
 	error = tz_conv_tz_time_w_zone_name (time, t_source, len_source, t_dest, len_dest, &time_res);
 	if (error != NO_ERROR)
 	  {
 	    return error;
 	  }
 	db_time_decode (&time_res, &hour, &min, &sec);
-	DB_MAKE_TIME (result_time, hour, min, sec);
+	db_make_time (result_time, hour, min, sec);
       }
       break;
 
@@ -28500,7 +28500,7 @@ db_tz_offset (const DB_VALUE * src_str, DB_VALUE * result_str, DB_DATETIME * dat
   str_type = DB_VALUE_DOMAIN_TYPE (src_str);
   if (DB_IS_NULL (src_str))
     {
-      DB_MAKE_NULL (result_str);
+      db_make_null (result_str);
     }
   else if (!QSTR_IS_CHAR (str_type))
     {
@@ -28513,10 +28513,10 @@ db_tz_offset (const DB_VALUE * src_str, DB_VALUE * result_str, DB_DATETIME * dat
    */
   else
     {
-      int len = DB_GET_STRING_SIZE (src_str);
+      int len = db_get_string_size (src_str);
       if (len < 0)
 	{
-	  len = strlen (DB_GET_STRING (src_str));
+	  len = strlen (db_get_string (src_str));
 	}
 
       res = (char *) db_private_alloc (NULL, MAX_LEN_OFFSET);
@@ -28527,10 +28527,10 @@ db_tz_offset (const DB_VALUE * src_str, DB_VALUE * result_str, DB_DATETIME * dat
 	  return error_status;
 	}
 
-      error_status = tz_get_timezone_offset (DB_GET_STRING (src_str), len, res, datetime);
+      error_status = tz_get_timezone_offset (db_get_string (src_str), len, res, datetime);
       if (error_status == NO_ERROR)
 	{
-	  DB_MAKE_VARCHAR (result_str, TP_FLOATING_PRECISION_VALUE, res, strlen (res), LANG_SYS_CODESET,
+	  db_make_varchar (result_str, TP_FLOATING_PRECISION_VALUE, res, strlen (res), LANG_SYS_CODESET,
 			   LANG_SYS_COLLATION);
 	  result_str->need_clear = true;
 	}
@@ -28567,12 +28567,12 @@ db_from_tz (DB_VALUE * time_val, DB_VALUE * tz, DB_VALUE * time_val_with_tz)
 
   if (DB_IS_NULL (time_val) || DB_IS_NULL (tz))
     {
-      DB_MAKE_NULL (time_val_with_tz);
+      db_make_null (time_val_with_tz);
       return NO_ERROR;
     }
 
-  timezone = DB_GET_STRING (tz);
-  len_timezone = DB_GET_STRING_SIZE (tz);
+  timezone = db_get_string (tz);
+  len_timezone = db_get_string_size (tz);
 
   if (len_timezone < 0)
     {
@@ -28586,7 +28586,7 @@ db_from_tz (DB_VALUE * time_val, DB_VALUE * tz, DB_VALUE * time_val_with_tz)
 	DB_DATETIMETZ result;
 	TZ_REGION region;
 
-	datetime = DB_GET_DATETIME (time_val);
+	datetime = db_get_datetime (time_val);
 	error = tz_str_to_region (timezone, len_timezone, &region);
 	if (error != NO_ERROR)
 	  {
@@ -28597,7 +28597,7 @@ db_from_tz (DB_VALUE * time_val, DB_VALUE * tz, DB_VALUE * time_val_with_tz)
 	  {
 	    return error;
 	  }
-	DB_MAKE_DATETIMETZ (time_val_with_tz, &result);
+	db_make_datetimetz (time_val_with_tz, &result);
       }
       break;
 
@@ -28664,7 +28664,7 @@ db_conv_tz (DB_VALUE * time_val, DB_VALUE * result_time)
 
   if (DB_IS_NULL (time_val))
     {
-      DB_MAKE_NULL (result_time);
+      db_make_null (result_time);
       return NO_ERROR;
     }
 
@@ -28674,14 +28674,14 @@ db_conv_tz (DB_VALUE * time_val, DB_VALUE * result_time)
       {
 	DB_DATETIMETZ datetimetz_out;
 
-	datetimetz = DB_GET_DATETIMETZ (time_val);
+	datetimetz = db_get_datetimetz (time_val);
 
 	error = conv_tz (&datetimetz_out, datetimetz, DB_TYPE_DATETIMETZ);
 	if (error != NO_ERROR)
 	  {
 	    return error;
 	  }
-	DB_MAKE_DATETIMETZ (result_time, &datetimetz_out);
+	db_make_datetimetz (result_time, &datetimetz_out);
       }
       break;
 
@@ -28689,14 +28689,14 @@ db_conv_tz (DB_VALUE * time_val, DB_VALUE * result_time)
       {
 	DB_DATETIME datetime_out;
 
-	datetime = DB_GET_DATETIME (time_val);
+	datetime = db_get_datetime (time_val);
 
 	error = conv_tz (&datetime_out, datetime, DB_TYPE_DATETIMELTZ);
 	if (error != NO_ERROR)
 	  {
 	    return error;
 	  }
-	DB_MAKE_DATETIMELTZ (result_time, &datetime_out);
+	db_make_datetimeltz (result_time, &datetime_out);
       }
       break;
 
@@ -28704,14 +28704,14 @@ db_conv_tz (DB_VALUE * time_val, DB_VALUE * result_time)
       {
 	DB_TIMESTAMPTZ timestamptz_out;
 
-	timestamptz = DB_GET_TIMESTAMPTZ (time_val);
+	timestamptz = db_get_timestamptz (time_val);
 
 	error = conv_tz (&timestamptz_out, timestamptz, DB_TYPE_TIMESTAMPTZ);
 	if (error != NO_ERROR)
 	  {
 	    return error;
 	  }
-	DB_MAKE_TIMESTAMPTZ (result_time, &timestamptz_out);
+	db_make_timestamptz (result_time, &timestamptz_out);
       }
       break;
 
@@ -28719,14 +28719,14 @@ db_conv_tz (DB_VALUE * time_val, DB_VALUE * result_time)
       {
 	DB_TIMESTAMP timestamp_out;
 
-	timestamp = DB_GET_TIMESTAMP (time_val);
+	timestamp = db_get_timestamp (time_val);
 
 	error = conv_tz (&timestamp_out, timestamp, DB_TYPE_TIMESTAMPLTZ);
 	if (error != NO_ERROR)
 	  {
 	    return error;
 	  }
-	DB_MAKE_TIMESTAMPLTZ (result_time, timestamp_out);
+	db_make_timestampltz (result_time, timestamp_out);
       }
       break;
 
@@ -28757,7 +28757,7 @@ db_value_to_json_doc (const DB_VALUE & value, REFPTR (JSON_DOC, json))
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      error_code = db_json_get_json_from_str (DB_GET_STRING (&value), json);
+      error_code = db_json_get_json_from_str (db_get_string (&value), json);
       if (error_code != NO_ERROR)
 	{
 	  assert (json == NULL);

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -28234,9 +28234,9 @@ db_string_extract_dbval (const MISC_OPERAND extr_operand, DB_VALUE * dbval_p, DB
       db_date_decode (&date, &extvar[MONTH], &extvar[DAY], &extvar[YEAR]);
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
-      utime = db_get_utime (dbval_p);
+      utime = db_get_timestamp (dbval_p);
       (void) db_timestamp_decode_ses (utime, &date, &time);
 
       if (extr_operand == YEAR || extr_operand == MONTH || extr_operand == DAY)

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -266,8 +266,8 @@ session_state_init (void *st)
     }
 
   /* initialize fields */
-  DB_MAKE_NULL (&session_p->cur_insert_id);
-  DB_MAKE_NULL (&session_p->last_insert_id);
+  db_make_null (&session_p->cur_insert_id);
+  db_make_null (&session_p->last_insert_id);
   session_p->is_trigger_involved = false;
   session_p->is_last_insert_id_generated = false;
   session_p->row_count = -1;
@@ -1105,20 +1105,20 @@ session_add_variable (SESSION_STATE * state_p, const DB_VALUE * name, DB_VALUE *
 
   assert (DB_VALUE_DOMAIN_TYPE (name) == DB_TYPE_CHAR);
 
-  name_str = DB_GET_STRING (name);
+  name_str = db_get_string (name);
 
   assert (name_str != NULL);
 
-  len = DB_GET_STRING_SIZE (name);
+  len = db_get_string_size (name);
   len = MAX (len, strlen ("collect_exec_stats"));
 
   if (strncasecmp (name_str, "collect_exec_stats", len) == 0)
     {
-      if (DB_GET_INT (value) == 1)
+      if (db_get_int (value) == 1)
 	{
 	  perfmon_start_watch (NULL);
 	}
-      else if (DB_GET_INT (value) == 0)
+      else if (db_get_int (value) == 0)
 	{
 	  perfmon_stop_watch (NULL);
 	}
@@ -1130,7 +1130,7 @@ session_add_variable (SESSION_STATE * state_p, const DB_VALUE * name, DB_VALUE *
 	  free_and_init (state_p->plan_string);
 	}
 
-      state_p->plan_string = strdup (DB_GET_STRING (value));
+      state_p->plan_string = strdup (db_get_string (value));
     }
 
   current = state_p->session_variables;
@@ -1163,7 +1163,7 @@ session_add_variable (SESSION_STATE * state_p, const DB_VALUE * name, DB_VALUE *
       return ER_FAILED;
     }
 
-  len = DB_GET_STRING_SIZE (name);
+  len = db_get_string_size (name);
   var->name = (char *) malloc (len + 1);
   if (var->name == NULL)
     {
@@ -1223,7 +1223,7 @@ db_value_alloc_and_copy (const DB_VALUE * src)
   src_dbtype = DB_VALUE_DOMAIN_TYPE (src);
   if (DB_IS_NULL (src))
     {
-      DB_MAKE_NULL (dest);
+      db_make_null (dest);
       return dest;
     }
 
@@ -1236,13 +1236,13 @@ db_value_alloc_and_copy (const DB_VALUE * src)
   if (!QSTR_IS_ANY_CHAR_OR_BIT (src_dbtype))
     {
       /* attempt to convert to varchar */
-      DB_MAKE_NULL (&conv);
+      db_make_null (&conv);
       domain = db_type_to_db_domain (DB_TYPE_VARCHAR);
       domain->precision = TP_FLOATING_PRECISION_VALUE;
 
       if (tp_value_cast (src, &conv, domain, false) != DOMAIN_COMPATIBLE)
 	{
-	  DB_MAKE_NULL (dest);
+	  db_make_null (dest);
 	  return dest;
 	}
 
@@ -1254,7 +1254,7 @@ db_value_alloc_and_copy (const DB_VALUE * src)
       return dest;
     }
 
-  length = DB_GET_STRING_SIZE (src);
+  length = db_get_string_size (src);
   scale = 0;
   str = (char *) malloc (length + 1);
   if (str == NULL)
@@ -1263,7 +1263,7 @@ db_value_alloc_and_copy (const DB_VALUE * src)
       return NULL;
     }
 
-  src_str = DB_GET_STRING (src);
+  src_str = db_get_string (src);
   if (src_str != NULL)
     {
       memcpy (str, src_str, length);
@@ -1275,22 +1275,22 @@ db_value_alloc_and_copy (const DB_VALUE * src)
   switch (src_dbtype)
     {
     case DB_TYPE_CHAR:
-      DB_MAKE_CHAR (dest, precision, str, length, DB_GET_STRING_CODESET (src), DB_GET_STRING_COLLATION (src));
+      db_make_char (dest, precision, str, length, db_get_string_codeset (src), db_get_string_collation (src));
       break;
     case DB_TYPE_NCHAR:
-      DB_MAKE_NCHAR (dest, precision, str, length, DB_GET_STRING_CODESET (src), DB_GET_STRING_COLLATION (src));
+      db_make_nchar (dest, precision, str, length, db_get_string_codeset (src), db_get_string_collation (src));
       break;
     case DB_TYPE_VARCHAR:
-      DB_MAKE_VARCHAR (dest, precision, str, length, DB_GET_STRING_CODESET (src), DB_GET_STRING_COLLATION (src));
+      db_make_varchar (dest, precision, str, length, db_get_string_codeset (src), db_get_string_collation (src));
       break;
     case DB_TYPE_VARNCHAR:
-      DB_MAKE_VARNCHAR (dest, precision, str, length, DB_GET_STRING_CODESET (src), DB_GET_STRING_COLLATION (src));
+      db_make_varnchar (dest, precision, str, length, db_get_string_codeset (src), db_get_string_collation (src));
       break;
     case DB_TYPE_BIT:
-      DB_MAKE_BIT (dest, precision, str, length);
+      db_make_bit (dest, precision, str, length);
       break;
     case DB_TYPE_VARBIT:
-      DB_MAKE_VARBIT (dest, precision, str, length);
+      db_make_varbit (dest, precision, str, length);
       break;
     default:
       assert (false);
@@ -1340,7 +1340,7 @@ session_drop_variable (SESSION_STATE * state_p, const DB_VALUE * name)
     }
 
   assert (DB_VALUE_DOMAIN_TYPE (name) == DB_TYPE_CHAR);
-  name_str = DB_GET_STRING (name);
+  name_str = db_get_string (name);
 
   assert (name_str != NULL);
 
@@ -2020,7 +2020,7 @@ session_define_variable (THREAD_ENTRY * thread_p, DB_VALUE * name, DB_VALUE * va
     }
   else
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
 
   return err;
@@ -2042,7 +2042,7 @@ session_get_variable (THREAD_ENTRY * thread_p, const DB_VALUE * name, DB_VALUE *
 
   assert (DB_VALUE_DOMAIN_TYPE (name) == DB_TYPE_CHAR);
 
-  name_str = DB_GET_STRING (name);
+  name_str = db_get_string (name);
   assert (name_str != NULL);
   state_p = session_get_session_state (thread_p);
   if (state_p == NULL)
@@ -2120,7 +2120,7 @@ session_get_variable_no_copy (THREAD_ENTRY * thread_p, const DB_VALUE * name, DB
   assert (DB_VALUE_DOMAIN_TYPE (name) == DB_TYPE_CHAR);
   assert (result != NULL);
 
-  name_str = DB_GET_STRING (name);
+  name_str = db_get_string (name);
   name_len = (name_str != NULL) ? strlen (name_str) : 0;
 
   if (session_get_session_id (thread_p, &id) != NO_ERROR)
@@ -2231,10 +2231,10 @@ session_get_exec_stats_and_clear (THREAD_ENTRY * thread_p, const DB_VALUE * name
 
   assert (DB_VALUE_DOMAIN_TYPE (name) == DB_TYPE_CHAR);
 
-  name_str = DB_GET_STRING (name);
+  name_str = db_get_string (name);
 
   stat_val = perfmon_get_stats_and_clear (thread_p, name_str);
-  DB_MAKE_BIGINT (result, stat_val);
+  db_make_bigint (result, stat_val);
 
   return NO_ERROR;
 }
@@ -2284,7 +2284,7 @@ session_dump_session (SESSION_STATE * session)
   fprintf (stdout, "SESSION ID = %d\n", session->id);
 
   db_value_coerce (&session->last_insert_id, &v, db_type_to_db_domain (DB_TYPE_VARCHAR));
-  fprintf (stdout, "\tLAST_INSERT_ID = %s\n", DB_GET_STRING (&v));
+  fprintf (stdout, "\tLAST_INSERT_ID = %s\n", db_get_string (&v));
   db_value_clear (&v);
 
   fprintf (stdout, "\tROW_COUNT = %d\n", session->row_count);
@@ -2334,7 +2334,7 @@ session_dump_variable (SESSION_VARIABLE * var)
   if (var->value != NULL)
     {
       db_value_coerce (var->value, &v, db_type_to_db_domain (DB_TYPE_VARCHAR));
-      fprintf (stdout, "%s\n", DB_GET_STRING (&v));
+      fprintf (stdout, "%s\n", db_get_string (&v));
       db_value_clear (&v);
     }
 }
@@ -2859,7 +2859,7 @@ session_get_trace_stats (THREAD_ENTRY * thread_p, DB_VALUE * result)
 
   if (state_p->plan_string == NULL && state_p->trace_stats == NULL)
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -2911,13 +2911,13 @@ session_get_trace_stats (THREAD_ENTRY * thread_p, DB_VALUE * result)
 
   if (trace_str != NULL)
     {
-      DB_MAKE_STRING (&temp_result, trace_str);
+      db_make_string (&temp_result, trace_str);
       pr_clone_value (&temp_result, result);
       free_and_init (trace_str);
     }
   else
     {
-      DB_MAKE_NULL (result);
+      db_make_null (result);
     }
 
   thread_set_clear_trace (thread_p, true);

--- a/src/session/session_sr.c
+++ b/src/session/session_sr.c
@@ -130,7 +130,7 @@ xsession_get_last_insert_id (THREAD_ENTRY * thread_p, DB_VALUE * value, bool upd
   err = session_get_last_insert_id (thread_p, value, update_last_insert_id);
   if (err != NO_ERROR)
     {
-      DB_MAKE_NULL (value);
+      db_make_null (value);
     }
   return err;
 }

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -5066,7 +5066,7 @@ btree_leaf_is_key_between_min_max (THREAD_ENTRY * thread_p, BTID_INT * btid_int,
    * Compare with first key in page.
    */
   /* Read record and get key. */
-  DB_MAKE_NULL (&border_key);
+  db_make_null (&border_key);
 
   if (spage_get_record (thread_p, leaf, 1, &border_record, PEEK) != S_SUCCESS)
     {
@@ -6182,7 +6182,7 @@ btree_get_subtree_stats (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page
 				     &offset, PEEK_KEY_VALUE, NULL);
 
 		  /* extract the sequence of the key-value */
-		  midxkey = DB_GET_MIDXKEY (&key);
+		  midxkey = db_get_midxkey (&key);
 		  if (midxkey == NULL)
 		    {
 		      goto exit_on_error;
@@ -6439,7 +6439,7 @@ count_keys:
 	  assert (!DB_IS_NULL (&key_value));
 
 	  /* get pkeys info */
-	  ret = btree_get_stats_midxkey (thread_p, env, DB_GET_MIDXKEY (&key_value));
+	  ret = btree_get_stats_midxkey (thread_p, env, db_get_midxkey (&key_value));
 	  if (ret != NO_ERROR)
 	    {
 	      goto exit_on_error;
@@ -6483,7 +6483,7 @@ count_keys:
 	}
 
       /* get pkeys info */
-      ret = btree_get_stats_midxkey (thread_p, env, DB_GET_MIDXKEY (&key_value));
+      ret = btree_get_stats_midxkey (thread_p, env, db_get_midxkey (&key_value));
       if (ret != NO_ERROR)
 	{
 	  goto exit_on_error;
@@ -6844,7 +6844,7 @@ btree_get_stats (THREAD_ENTRY * thread_p, BTREE_STATS * stat_info_p, bool with_f
   assert (env->pkeys_val_num <= BTREE_STATS_PKEYS_NUM);
   for (i = 0; i < env->pkeys_val_num; i++)
     {
-      DB_MAKE_NULL (&(env->pkeys_val[i]));
+      db_make_null (&(env->pkeys_val[i]));
     }
 
   root_vpid.pageid = env->stat_info->btid.root_pageid;	/* read root page */
@@ -7054,8 +7054,8 @@ btree_check_page_key (THREAD_ENTRY * thread_p, const OID * class_oid_p, BTID_INT
   nleaf_pnt.key_len = 0;
   VPID_SET_NULL (&nleaf_pnt.pnt);
 
-  DB_MAKE_NULL (&key1);
-  DB_MAKE_NULL (&key2);
+  db_make_null (&key1);
+  db_make_null (&key2);
 
   key_cnt = btree_node_number_of_keys (thread_p, page_ptr);
 
@@ -9971,8 +9971,8 @@ btree_merge_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
   right_header = btree_get_node_header (thread_p, right_pg);
   assert (left_header != NULL && right_header != NULL);
 
-  DB_MAKE_NULL (&left_fence_key);
-  DB_MAKE_NULL (&right_fence_key);
+  db_make_null (&left_fence_key);
+  db_make_null (&right_fence_key);
 
   left_used = btree_node_size_uncompressed (thread_p, btid, left_pg);
   if (left_used < 0)
@@ -10432,7 +10432,7 @@ btree_node_size_uncompressed (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR
       assert (btree_leaf_is_flaged (&rec, BTREE_LEAF_RECORD_FENCE));
       assert (DB_VALUE_TYPE (&key) == DB_TYPE_MIDXKEY);
 
-      midx_key = DB_GET_MIDXKEY (&key);
+      midx_key = db_get_midxkey (&key);
 
       btree_clear_key_value (&clear_key, &key);
 
@@ -12361,7 +12361,7 @@ btree_recompress_record (THREAD_ENTRY * thread_p, BTID_INT * btid_int, RECDES * 
   old_key_len = DB_ALIGN (old_key_len, INT_ALIGNMENT);
 
   /* Uncompress. */
-  DB_MAKE_NULL (&recompress_key);
+  db_make_null (&recompress_key);
   if (old_prefix > 0)
     {
       pr_midxkey_add_prefix (&recompress_key, fence_key, &key, old_prefix);
@@ -14698,7 +14698,7 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
        * sequence) of B+tree key domain. */
 
       /* get number of elements of sequence type of the 'src_key' */
-      midxkey = DB_GET_MIDXKEY (keyp);
+      midxkey = db_get_midxkey (keyp);
       ssize = midxkey->ncolumns;
 
       /* count number of elements of sequence type of the B+tree key domain */
@@ -14828,7 +14828,7 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
 	  partial_dom = dp;
 	  for (err = NO_ERROR; dp && err == NO_ERROR; dp = dp->next, dsize++)
 	    {
-	      DB_MAKE_NULL (&dbvals[num_dbvals]);
+	      db_make_null (&dbvals[num_dbvals]);
 	      num_dbvals++;
 	    }
 
@@ -14863,7 +14863,7 @@ btree_coerce_key (DB_VALUE * keyp, int keysize, TP_DOMAIN * btree_domainp, int k
     {
       DB_VALUE temp_val;
 
-      DB_MAKE_NULL (&temp_val);
+      db_make_null (&temp_val);
 
       if (tp_more_general_type (dtype, stype) > 0)
 	{
@@ -14953,8 +14953,8 @@ btree_prepare_bts (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, BTID * btid, INDX_
   if (key_val_range == NULL)
     {
       /* NULL key_val_range argument means a full range scan */
-      DB_MAKE_NULL (&inf_key_val_range.key1);
-      DB_MAKE_NULL (&inf_key_val_range.key2);
+      db_make_null (&inf_key_val_range.key1);
+      db_make_null (&inf_key_val_range.key2);
       inf_key_val_range.range = INF_INF;
       inf_key_val_range.num_index_term = 0;
       inf_key_val_range.is_truncated = false;
@@ -14998,7 +14998,7 @@ btree_prepare_bts (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, BTID * btid, INDX_
        */
       if (DB_VALUE_TYPE (&key_val_range->key1) == DB_TYPE_MIDXKEY)
 	{
-	  midxkey = DB_GET_MIDXKEY (&key_val_range->key1);
+	  midxkey = db_get_midxkey (&key_val_range->key1);
 	  if (midxkey->domain == NULL || LOG_CHECK_LOG_APPLIER (thread_p))
 	    {
 	      /* 
@@ -15015,7 +15015,7 @@ btree_prepare_bts (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, BTID * btid, INDX_
 	}
       if (DB_VALUE_TYPE (&key_val_range->key2) == DB_TYPE_MIDXKEY)
 	{
-	  midxkey = DB_GET_MIDXKEY (&key_val_range->key2);
+	  midxkey = db_get_midxkey (&key_val_range->key2);
 	  if (midxkey->domain == NULL || LOG_CHECK_LOG_APPLIER (thread_p))
 	    {
 	      if (midxkey->domain)
@@ -15110,12 +15110,12 @@ btree_prepare_bts (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, BTID * btid, INDX_
 #if !defined(NDEBUG)
   if (DB_VALUE_TYPE (&key_val_range->key1) == DB_TYPE_MIDXKEY)
     {
-      midxkey = DB_GET_MIDXKEY (&key_val_range->key1);
+      midxkey = db_get_midxkey (&key_val_range->key1);
       assert (midxkey->ncolumns == midxkey->domain->precision);
     }
   if (DB_VALUE_TYPE (&key_val_range->key2) == DB_TYPE_MIDXKEY)
     {
-      midxkey = DB_GET_MIDXKEY (&key_val_range->key2);
+      midxkey = db_get_midxkey (&key_val_range->key2);
       assert (midxkey->ncolumns == midxkey->domain->precision);
     }
 #endif
@@ -15261,12 +15261,12 @@ btree_scan_update_range (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, KEY_VAL_RANG
 #if !defined(NDEBUG)
   if (DB_VALUE_TYPE (&key_val_range->key1) == DB_TYPE_MIDXKEY)
     {
-      midxkey = DB_GET_MIDXKEY (&key_val_range->key1);
+      midxkey = db_get_midxkey (&key_val_range->key1);
       assert (midxkey->ncolumns == midxkey->domain->precision);
     }
   if (DB_VALUE_TYPE (&key_val_range->key2) == DB_TYPE_MIDXKEY)
     {
-      midxkey = DB_GET_MIDXKEY (&key_val_range->key2);
+      midxkey = db_get_midxkey (&key_val_range->key2);
       assert (midxkey->ncolumns == midxkey->domain->precision);
     }
 #endif
@@ -15711,7 +15711,7 @@ btree_apply_key_range_and_filter (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, boo
       if (need_to_check_null && DB_VALUE_DOMAIN_TYPE (&bts->cur_key) == DB_TYPE_MIDXKEY
 	  && bts->key_range.num_index_term > 0)
 	{
-	  mkey = DB_GET_MIDXKEY (&(bts->cur_key));
+	  mkey = db_get_midxkey (&(bts->cur_key));
 	  /* get the last element from key range elements */
 	  ret = pr_midxkey_get_element_nocopy (mkey, bts->key_range.num_index_term - 1, &ep, NULL, NULL);
 	  if (ret != NO_ERROR)
@@ -15882,7 +15882,7 @@ btree_attrinfo_read_dbvalues (THREAD_ENTRY * thread_p, DB_VALUE * curr_key, int 
 		  j++;
 		}
 	    }
-	  if (pr_midxkey_get_element_nocopy (DB_GET_MIDXKEY (curr_key), j, &(attr_value->dbvalue), NULL, NULL) !=
+	  if (pr_midxkey_get_element_nocopy (db_get_midxkey (curr_key), j, &(attr_value->dbvalue), NULL, NULL) !=
 	      NO_ERROR)
 	    {
 	      error = ER_FAILED;
@@ -16070,9 +16070,9 @@ btree_get_next_key_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_SCAN * bts,
   /* TODO: Do we have to get all oids or should we just count them ? Or maybe select only the first OID? Or a maximum
    * number of OIDs... */
 
-  DB_MAKE_INT (key_info[BTREE_KEY_INFO_VOLUMEID], bts->C_vpid.volid);
-  DB_MAKE_INT (key_info[BTREE_KEY_INFO_PAGEID], bts->C_vpid.pageid);
-  DB_MAKE_INT (key_info[BTREE_KEY_INFO_SLOTID], bts->slot_id);
+  db_make_int (key_info[BTREE_KEY_INFO_VOLUMEID], bts->C_vpid.volid);
+  db_make_int (key_info[BTREE_KEY_INFO_PAGEID], bts->C_vpid.pageid);
+  db_make_int (key_info[BTREE_KEY_INFO_SLOTID], bts->slot_id);
 
   /* Get key */
   pr_clear_value (key_info[BTREE_KEY_INFO_KEY]);
@@ -16080,14 +16080,14 @@ btree_get_next_key_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_SCAN * bts,
 
   /* Get overflow key and overflow oids */
   pr_clear_value (key_info[BTREE_KEY_INFO_OVERFLOW_KEY]);
-  DB_MAKE_STRING (key_info[BTREE_KEY_INFO_OVERFLOW_KEY],
+  db_make_string (key_info[BTREE_KEY_INFO_OVERFLOW_KEY],
 		  btree_leaf_is_flaged (&bts->key_record, BTREE_LEAF_RECORD_OVERFLOW_KEY) ? "true" : "false");
   pr_clear_value (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS]);
-  DB_MAKE_STRING (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS],
+  db_make_string (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS],
 		  btree_leaf_is_flaged (&bts->key_record, BTREE_LEAF_RECORD_OVERFLOW_OIDS) ? "true" : "false");
 
   /* Get OIDs count -> For now ignore the overflow OIDs */
-  DB_MAKE_INT (key_info[BTREE_KEY_INFO_OID_COUNT],
+  db_make_int (key_info[BTREE_KEY_INFO_OID_COUNT],
 	       btree_record_get_num_oids (thread_p, &bts->btid_int, &bts->key_record, bts->offset, BTREE_LEAF_NODE));
 
   /* Get OIDs -> For now just the first OID */
@@ -16112,7 +16112,7 @@ btree_get_next_key_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_SCAN * bts,
 	  OID_SET_NULL (&oid);
 	}
     }
-  DB_MAKE_OID (key_info[BTREE_KEY_INFO_FIRST_OID], &oid);
+  db_make_oid (key_info[BTREE_KEY_INFO_FIRST_OID], &oid);
 
   /* Key was consumed. */
   bts->key_status = BTS_KEY_IS_CONSUMED;
@@ -16177,7 +16177,7 @@ btree_find_min_or_max_key (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key,
       return NO_ERROR;
     }
 
-  DB_MAKE_NULL (key);
+  db_make_null (key);
 
   BTS = &btree_scan;
   BTREE_INIT_SCAN (BTS);
@@ -17926,7 +17926,7 @@ btree_multicol_key_is_null (DB_VALUE * key)
     {
       assert (!DB_IS_NULL (key));
 
-      midxkey = DB_GET_MIDXKEY (key);
+      midxkey = db_get_midxkey (key);
       assert (midxkey != NULL);
 
       /* ncolumns == -1 means already constructing step */
@@ -17971,7 +17971,7 @@ btree_multicol_key_has_null (DB_VALUE * key)
     {
       assert (!DB_IS_NULL (key));
 
-      midxkey = DB_GET_MIDXKEY (key);
+      midxkey = db_get_midxkey (key);
       assert (midxkey != NULL);
 
       /* ncolumns == -1 means already constructing step */
@@ -18574,7 +18574,7 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
 	  return DB_UNK;
 	}
 
-      c = pr_midxkey_compare (DB_GET_MIDXKEY (key1), DB_GET_MIDXKEY (key2), do_coercion, total_order, -1, start_colp,
+      c = pr_midxkey_compare (db_get_midxkey (key1), db_get_midxkey (key2), do_coercion, total_order, -1, start_colp,
 			      &dummy_size1, &dummy_size2, &dummy_diff_column, &dom_is_desc, &dummy_next_dom_is_desc);
       assert_release (c == DB_UNK || (DB_LT <= c && c <= DB_GT));
 
@@ -18727,7 +18727,7 @@ btree_range_opt_check_add_index_key (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, 
       return ER_FAILED;
     }
 
-  new_mkey = DB_GET_MIDXKEY (&(bts->cur_key));
+  new_mkey = db_get_midxkey (&(bts->cur_key));
   new_key_value = (DB_VALUE *) db_private_alloc (thread_p, multi_range_opt->num_attrs * sizeof (DB_VALUE));
   if (new_key_value == NULL)
     {
@@ -18738,7 +18738,7 @@ btree_range_opt_check_add_index_key (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, 
 
   for (i = 0; i < multi_range_opt->num_attrs; i++)
     {
-      DB_MAKE_NULL (&new_key_value[i]);
+      db_make_null (&new_key_value[i]);
     }
 
   for (i = 0; i < multi_range_opt->num_attrs; i++)
@@ -18801,13 +18801,13 @@ btree_range_opt_check_add_index_key (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, 
       last_item = multi_range_opt->top_n_items[multi_range_opt->size - 1];
       assert (last_item != NULL);
 
-      comp_mkey = DB_GET_MIDXKEY (&(last_item->index_value));
+      comp_mkey = db_get_midxkey (&(last_item->index_value));
 
       /* if all keys are equal, the new element is rejected */
       reject_new_elem = true;
       for (i = 0; i < multi_range_opt->num_attrs; i++)
 	{
-	  DB_MAKE_NULL (&comp_key_value);
+	  db_make_null (&comp_key_value);
 	  error = pr_midxkey_get_element_nocopy (comp_mkey, multi_range_opt->sort_att_idx[i], &comp_key_value, NULL,
 						 NULL);
 	  if (error != NO_ERROR)
@@ -18959,11 +18959,11 @@ btree_top_n_items_binary_search (RANGE_OPT_ITEM ** top_n_items, int *att_idxs, T
 	{
 	  /* need to check if the new key is smaller than the first */
 	  comp_item = top_n_items[0];
-	  comp_mkey = DB_GET_MIDXKEY (&(comp_item->index_value));
+	  comp_mkey = db_get_midxkey (&(comp_item->index_value));
 
 	  for (i = 0; i < num_keys; i++)
 	    {
-	      DB_MAKE_NULL (&comp_key_value);
+	      db_make_null (&comp_key_value);
 	      error = pr_midxkey_get_element_nocopy (comp_mkey, att_idxs[i], &comp_key_value, NULL, NULL);
 	      if (error != NO_ERROR)
 		{
@@ -18998,11 +18998,11 @@ btree_top_n_items_binary_search (RANGE_OPT_ITEM ** top_n_items, int *att_idxs, T
   /* compare new value with the value in the middle of the current range */
   middle = (last + first) / 2;
   comp_item = top_n_items[middle];
-  comp_mkey = DB_GET_MIDXKEY (&(comp_item->index_value));
+  comp_mkey = db_get_midxkey (&(comp_item->index_value));
 
   for (i = 0; i < num_keys; i++)
     {
-      DB_MAKE_NULL (&comp_key_value);
+      db_make_null (&comp_key_value);
       error = pr_midxkey_get_element_nocopy (comp_mkey, att_idxs[i], &comp_key_value, NULL, NULL);
       if (error != NO_ERROR)
 	{
@@ -19554,10 +19554,10 @@ btree_verify_leaf_node (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PAGE_PTR p
   prev_vpid = header->prev_vpid;
   next_vpid = header->next_vpid;
 
-  DB_MAKE_NULL (&curr_key);
-  DB_MAKE_NULL (&prev_key);
-  DB_MAKE_NULL (&lower_fence_key);
-  DB_MAKE_NULL (&uncompressed_value);
+  db_make_null (&curr_key);
+  db_make_null (&prev_key);
+  db_make_null (&lower_fence_key);
+  db_make_null (&uncompressed_value);
 
   common_prefix = btree_node_common_prefix (thread_p, btid_int, page_ptr);
   if (common_prefix > 0)
@@ -19958,7 +19958,7 @@ btree_ils_adjust_range (THREAD_ENTRY * thread_p, BTREE_SCAN * bts)
 
   for (i = prefix_len; i < curr_key->data.midxkey.ncolumns; i++)
     {
-      DB_MAKE_NULL (&new_key_dbvals[i]);
+      db_make_null (&new_key_dbvals[i]);
     }
 
   /* build midxkey */
@@ -20103,15 +20103,15 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
   /* Get b-tree page info */
 
   /* Get volume id and page id */
-  DB_MAKE_INT (node_info[BTREE_NODE_INFO_VOLUMEID], btns->crt_vpid.volid);
-  DB_MAKE_INT (node_info[BTREE_NODE_INFO_PAGEID], btns->crt_vpid.pageid);
+  db_make_int (node_info[BTREE_NODE_INFO_VOLUMEID], btns->crt_vpid.volid);
+  db_make_int (node_info[BTREE_NODE_INFO_PAGEID], btns->crt_vpid.pageid);
 
   /* Get node type */
   pr_clear_value (node_info[BTREE_NODE_INFO_NODE_TYPE]);
-  DB_MAKE_STRING (node_info[BTREE_NODE_INFO_NODE_TYPE], (node_type == BTREE_NON_LEAF_NODE) ? "non-leaf" : "leaf");
+  db_make_string (node_info[BTREE_NODE_INFO_NODE_TYPE], (node_type == BTREE_NON_LEAF_NODE) ? "non-leaf" : "leaf");
 
   /* Get key count */
-  DB_MAKE_INT (node_info[BTREE_NODE_INFO_KEY_COUNT], key_cnt);
+  db_make_int (node_info[BTREE_NODE_INFO_KEY_COUNT], key_cnt);
 
   if (key_cnt > 0)
     {
@@ -20145,10 +20145,10 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
     {
       /* Empty node */
       pr_clear_value (node_info[BTREE_NODE_INFO_FIRST_KEY]);
-      DB_MAKE_NULL (node_info[BTREE_NODE_INFO_FIRST_KEY]);
+      db_make_null (node_info[BTREE_NODE_INFO_FIRST_KEY]);
 
       pr_clear_value (node_info[BTREE_NODE_INFO_LAST_KEY]);
-      DB_MAKE_NULL (node_info[BTREE_NODE_INFO_LAST_KEY]);
+      db_make_null (node_info[BTREE_NODE_INFO_LAST_KEY]);
     }
 
   result = S_SUCCESS;
@@ -21810,7 +21810,7 @@ btree_check_valid_record (THREAD_ENTRY * thread_p, BTID_INT * btid, RECDES * rec
 	      TP_DOMAIN *key_domain = NULL;
 	      PR_TYPE *pr_type = NULL;
 
-	      DB_MAKE_NULL (&rec_key_value);
+	      db_make_null (&rec_key_value);
 	      key_domain = btid->key_type;
 	      pr_type = key_domain->type;
 	      if ((*(pr_type->index_readval)) (&buffer, &rec_key_value, key_domain, -1, true, NULL, 0) != NO_ERROR)
@@ -21873,7 +21873,7 @@ btree_check_foreign_key (THREAD_ENTRY * thread_p, OID * cls_oid, HFID * hfid, OI
   int classrepr_cacheindex = -1;
   BTREE_SEARCH ret_search;
 
-  DB_MAKE_NULL (&val);
+  db_make_null (&val);
   OID_SET_NULL (&unique_oid);
 
   /* SQL standard defines as follows:
@@ -25475,7 +25475,7 @@ btree_select_visible_object_for_range_scan (THREAD_ENTRY * thread_p, BTID_INT * 
 	      ASSERT_ERROR ();
 	      return error_code;
 	    }
-	  DB_MAKE_NULL (&bts->cur_key);
+	  db_make_null (&bts->cur_key);
 	}
       else
 	{
@@ -27285,7 +27285,7 @@ btree_key_insert_new_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_VALUE
 #endif /* SERVER_MODE */
 
   /* Insert new key. */
-  DB_MAKE_NULL (&local_key);
+  db_make_null (&local_key);
 
   key_len = btree_get_disk_size_of_key (key);
   if (key_len >= BTREE_MAX_KEYLEN_INPAGE)
@@ -29003,7 +29003,7 @@ btree_rv_record_modify_internal (THREAD_ENTRY * thread_p, LOG_RCV * rcv, bool is
 		  bool clear_key;
 		  char *printed_key = NULL;
 
-		  DB_MAKE_NULL (&key);
+		  db_make_null (&key);
 		  (void) btree_read_record (thread_p, &btid_int_for_debug, rcv->pgptr, &update_record, &key,
 					    &leaf_rec_info, node_type, &clear_key, &offset_after_key, PEEK_KEY_VALUE,
 					    NULL);
@@ -29107,7 +29107,7 @@ btree_rv_record_modify_internal (THREAD_ENTRY * thread_p, LOG_RCV * rcv, bool is
 	   * crash). */
 	  if (node_type == BTREE_LEAF_NODE && !btree_leaf_is_flaged (&update_record, BTREE_LEAF_RECORD_OVERFLOW_KEY))
 	    {
-	      DB_MAKE_NULL (&key);
+	      db_make_null (&key);
 	      (void) btree_read_record (thread_p, &btid_int_for_debug, rcv->pgptr, &update_record, &key, &leaf_rec_info,
 					node_type, &clear_key, &offset_after_key, PEEK_KEY_VALUE, NULL);
 	      printed_key = pr_valstring (thread_p, &key);
@@ -29564,7 +29564,7 @@ btree_delete_internal (THREAD_ENTRY * thread_p, BTID * btid, OID * oid, OID * cl
       /* Key will be unpacked after fixing root and getting key type. */
       delete_helper.buffered_key = buffered_key;
       key = &local_key;
-      DB_MAKE_NULL (key);
+      db_make_null (key);
     }
 
   /* Log b-tree operations? For debugging. */

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -255,7 +255,7 @@ struct btree_scan
     (bts)->oid_pos = 0;					\
     (bts)->restart_scan = 0;                    	\
     (bts)->common_prefix = COMMON_PREFIX_UNKNOWN;	\
-    DB_MAKE_NULL (&(bts)->cur_key);			\
+    db_make_null (&(bts)->cur_key);			\
     (bts)->clear_cur_key = false;			\
     (bts)->is_btid_int_valid = false;			\
     (bts)->read_uncommitted = false;			\
@@ -302,7 +302,7 @@ struct btree_scan
     (bts)->restart_scan = 0;                    	\
     (bts)->common_prefix = COMMON_PREFIX_UNKNOWN;	\
     pr_clear_value (&(bts)->cur_key);			\
-    DB_MAKE_NULL (&(bts)->cur_key);			\
+    db_make_null (&(bts)->cur_key);			\
     (bts)->clear_cur_key = false;			\
     (bts)->is_scan_started = false;			\
   } while (0)

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -830,7 +830,7 @@ xbtree_load_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_name, TP
   /** Initialize the fields of loading argument structures **/
   load_args->btid = &btid_int;
   load_args->bt_name = bt_name;
-  DB_MAKE_NULL (&load_args->current_key);
+  db_make_null (&load_args->current_key);
   VPID_SET_NULL (&load_args->nleaf.vpid);
   load_args->nleaf.pgptr = NULL;
   VPID_SET_NULL (&load_args->leaf.vpid);
@@ -1425,9 +1425,9 @@ btree_build_nleafs (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args, int n_nulls,
   rec.area_size = DB_PAGESIZE;
   rec.data = PTR_ALIGN (rec_buf, BTREE_MAX_ALIGN);
 
-  DB_MAKE_NULL (&last_key);
-  DB_MAKE_NULL (&first_key);
-  DB_MAKE_NULL (&prefix_key);
+  db_make_null (&last_key);
+  db_make_null (&first_key);
+  db_make_null (&prefix_key);
 
   temp_data = (char *) os_malloc (DB_PAGESIZE);
   if (temp_data == NULL)
@@ -1462,7 +1462,7 @@ btree_build_nleafs (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args, int n_nulls,
   load_args->push_list = NULL;
   load_args->pop_list = NULL;
 
-  DB_MAKE_NULL (&last_key);
+  db_make_null (&last_key);
 
   /* While there are some leaf pages do */
   load_args->leaf.vpid = load_args->vpid_first_leaf;
@@ -2909,7 +2909,7 @@ btree_sort_get_next (THREAD_ENTRY * thread_p, RECDES * temp_recdes, void *arg)
   MVCC_SNAPSHOT mvcc_snapshot_dirty;
   MVCC_SATISFIES_SNAPSHOT_RESULT snapshot_dirty_satisfied;
 
-  DB_MAKE_NULL (&dbvalue);
+  db_make_null (&dbvalue);
 
   aligned_midxkey_buf = PTR_ALIGN (midxkey_buf, MAX_ALIGNMENT);
 
@@ -3746,8 +3746,8 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
   BTREE_SCAN_PART partitions[MAX_PARTITIONS];
   bool has_nulls = false;
 
-  DB_MAKE_NULL (&fk_key);
-  DB_MAKE_NULL (&pk_key);
+  db_make_null (&fk_key);
+  db_make_null (&pk_key);
 
   mvcc_snapshot_dirty.snapshot_fnc = mvcc_satisfies_dirty;
 

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -736,7 +736,7 @@ catcls_convert_class_oid_to_oid (THREAD_ENTRY * thread_p, DB_VALUE * oid_val_p)
       return NO_ERROR;
     }
 
-  class_oid_p = DB_GET_OID (oid_val_p);
+  class_oid_p = db_get_oid (oid_val_p);
 
   if (csect_enter_as_reader (thread_p, CSECT_CT_OID_TABLE, INF_WAIT) != NO_ERROR)
     {
@@ -874,12 +874,12 @@ catcls_convert_attr_id_to_name (THREAD_ENTRY * thread_p, OR_BUF * orbuf_p, OR_VA
 
 	  if (!DB_IS_NULL (&key_atts[1].value))
 	    {
-	      id = DB_GET_INT (&key_atts[1].value);
+	      id = db_get_int (&key_atts[1].value);
 
 	      for (ids = id_val_p->sub.value, k = 0; k < id_val_p->sub.count; k++)
 		{
 		  id_atts = ids[k].sub.value;
-		  if (!DB_IS_NULL (&id_atts[0].value) && id == DB_GET_INT (&id_atts[0].value))
+		  if (!DB_IS_NULL (&id_atts[0].value) && id == db_get_int (&id_atts[0].value))
 		    {
 		      pr_clear_value (&key_atts[1].value);
 		      pr_clone_value (&id_atts[1].value, &key_atts[1].value);
@@ -964,8 +964,8 @@ catcls_apply_resolutions (OR_VALUE * value_p, OR_VALUE * resolution_p)
 	  /* compare component name & name space */
 	  if (tp_value_compare (&attrs[1].value, &res_attrs[1].value, 1, 0) == DB_EQ)
 	    {
-	      attr_name_space = catcls_resolution_space (DB_GET_INT (&attrs[2].value));
-	      if (attr_name_space == DB_GET_INT (&res_attrs[2].value))
+	      attr_name_space = catcls_resolution_space (db_get_int (&attrs[2].value));
+	      if (attr_name_space == db_get_int (&res_attrs[2].value))
 		{
 		  /* set the value as 'from_xxx_name' */
 		  pr_clear_value (&attrs[3].value);
@@ -1055,7 +1055,7 @@ catcls_get_or_value_from_class (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VALU
   db_string_truncate (attr_val_p, DB_MAX_IDENTIFIER_LENGTH);
 
   /* (class_of) */
-  if (catcls_find_class_oid_by_class_name (thread_p, DB_GET_STRING (&attrs[10].value), &class_oid) != NO_ERROR)
+  if (catcls_find_class_oid_by_class_name (thread_p, db_get_string (&attrs[10].value), &class_oid) != NO_ERROR)
     {
       assert (er_errid () != NO_ERROR);
       error = er_errid ();
@@ -1295,7 +1295,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
   (*(tp_Integer.data_readval)) (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
 
   /* for 'is_nullable', reverse NON_NULL flag */
-  db_make_int (attr_val_p, (DB_GET_INT (attr_val_p) & SM_ATTFLAG_NON_NULL) ? false : true);
+  db_make_int (attr_val_p, (db_get_int (attr_val_p) & SM_ATTFLAG_NON_NULL) ? false : true);
 
   /* index_file_id */
   or_advance (buf_p, OR_INT_SIZE);
@@ -1347,20 +1347,20 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	}
       or_val = &or_val[7];
       if (!TP_IS_SET_TYPE (DB_VALUE_TYPE (&or_val->value))
-	  || DB_GET_ENUM_SHORT (attr_val_p) > or_val->value.data.set->set->size)
+	  || db_get_enum_short (attr_val_p) > or_val->value.data.set->set->size)
 	{
 	  error = ER_FAILED;
 	  goto error;
 	}
-      error = set_get_element (DB_GET_SET (&or_val->value), DB_GET_ENUM_SHORT (attr_val_p) - 1, &val);
+      error = set_get_element (db_get_set (&or_val->value), db_get_enum_short (attr_val_p) - 1, &val);
       if (error != NO_ERROR)
 	{
 	  goto error;
 	}
 
       val.need_clear = false;
-      DB_MAKE_ENUMERATION (attr_val_p, DB_GET_ENUM_SHORT (attr_val_p), DB_GET_STRING (&val), DB_GET_STRING_SIZE (&val),
-			   DB_GET_ENUM_CODESET (attr_val_p), DB_GET_ENUM_COLLATION (attr_val_p));
+      db_make_enumeration (attr_val_p, db_get_enum_short (attr_val_p), db_get_string (&val), db_get_string_size (&val),
+			   db_get_enum_codeset (attr_val_p), db_get_enum_collation (attr_val_p));
       attr_val_p->need_clear = true;
     }
   /* triggers - advance only */
@@ -1368,7 +1368,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 
   /* properties */
   or_get_value (buf_p, &val, tp_domain_resolve_default (DB_TYPE_SEQUENCE), vars[ORC_ATT_PROPERTIES_INDEX].length, true);
-  att_props = DB_GET_SEQUENCE (&val);
+  att_props = db_get_set (&val);
   attr_val_p = &attrs[8].value;
   db_make_null (&default_expr);
   if (att_props != NULL && classobj_get_prop (att_props, "default_expr", &default_expr) > 0)
@@ -1378,8 +1378,8 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 
       if (DB_VALUE_TYPE (&default_expr) == DB_TYPE_SEQUENCE)
 	{
-	  assert (set_size (DB_GET_SEQUENCE (&default_expr)) == 3);
-	  def_expr_seq = DB_GET_SEQUENCE (&default_expr);
+	  assert (set_size (db_get_set (&default_expr)) == 3);
+	  def_expr_seq = db_get_set (&default_expr);
 
 	  error = set_get_element_nocopy (def_expr_seq, 0, &db_value_default_expr_op);
 	  if (error != NO_ERROR)
@@ -1387,7 +1387,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	      goto error;
 	    }
 	  assert (DB_VALUE_TYPE (&db_value_default_expr_op) == DB_TYPE_INTEGER
-		  && DB_GET_INT (&db_value_default_expr_op) == (int) T_TO_CHAR);
+		  && db_get_int (&db_value_default_expr_op) == (int) T_TO_CHAR);
 	  with_to_char = true;
 
 	  error = set_get_element_nocopy (def_expr_seq, 1, &db_value_default_expr_type);
@@ -1395,7 +1395,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	    {
 	      goto error;
 	    }
-	  default_expr_type = (DB_DEFAULT_EXPR_TYPE) DB_GET_INT (&db_value_default_expr_type);
+	  default_expr_type = (DB_DEFAULT_EXPR_TYPE) db_get_int (&db_value_default_expr_type);
 
 	  error = set_get_element_nocopy (def_expr_seq, 2, &db_value_default_expr_format);
 	  if (error != NO_ERROR)
@@ -1414,12 +1414,12 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	      }
 #endif
 	      assert (DB_VALUE_TYPE (&db_value_default_expr_format) == DB_TYPE_STRING);
-	      def_expr_format_string = DB_GET_STRING (&db_value_default_expr_format);
+	      def_expr_format_string = db_get_string (&db_value_default_expr_format);
 	    }
 	}
       else
 	{
-	  default_expr_type = (DB_DEFAULT_EXPR_TYPE) DB_GET_INT (&default_expr);
+	  default_expr_type = (DB_DEFAULT_EXPR_TYPE) db_get_int (&default_expr);
 	}
 
       default_expr_type_string = db_default_expression_string (default_expr_type);
@@ -1477,7 +1477,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	}
 
       pr_clear_value (attr_val_p);	/* clean old default value */
-      DB_MAKE_STRING (attr_val_p, str_val);
+      db_make_string (attr_val_p, str_val);
       attr_val_p->need_clear = true;
     }
   else
@@ -1698,7 +1698,7 @@ catcls_get_or_value_from_domain (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VAL
     }
   else
     {
-      DB_MAKE_NULL (&attrs[9].value);
+      db_make_null (&attrs[9].value);
     }
 
   if (error != NO_ERROR)
@@ -2216,7 +2216,7 @@ catcls_get_or_value_from_indexes (DB_SEQ * seq_p, OR_VALUE * values, int is_uniq
 
       if (DB_VALUE_TYPE (&keys) == DB_TYPE_SEQUENCE)
 	{
-	  key_seq_p = DB_GET_SEQUENCE (&keys);
+	  key_seq_p = db_get_set (&keys);
 	}
       else
 	{
@@ -2255,7 +2255,7 @@ catcls_get_or_value_from_indexes (DB_SEQ * seq_p, OR_VALUE * values, int is_uniq
 	      goto error;
 	    }
 
-	  seq = DB_GET_SEQUENCE (&svalue);
+	  seq = db_get_set (&svalue);
 	  error = set_get_element (seq, 0, &val);
 	  if (error != NO_ERROR)
 	    {
@@ -2269,7 +2269,7 @@ catcls_get_or_value_from_indexes (DB_SEQ * seq_p, OR_VALUE * values, int is_uniq
 	    }
 	  else if (DB_VALUE_TYPE (&val) == DB_TYPE_SEQUENCE)
 	    {
-	      DB_SET *child_seq = DB_GET_SEQUENCE (&val);
+	      DB_SET *child_seq = db_get_set (&val);
 	      int seq_size = set_size (seq);
 	      int flag, l = 0;
 	      DB_VALUE temp;
@@ -2294,15 +2294,15 @@ catcls_get_or_value_from_indexes (DB_SEQ * seq_p, OR_VALUE * values, int is_uniq
 		      goto error;
 		    }
 
-		  if (!intl_identifier_casecmp (DB_GET_STRING (&avalue), SM_FILTER_INDEX_ID))
+		  if (!intl_identifier_casecmp (db_get_string (&avalue), SM_FILTER_INDEX_ID))
 		    {
 		      flag = 0x01;
 		    }
-		  else if (!intl_identifier_casecmp (DB_GET_STRING (&avalue), SM_FUNCTION_INDEX_ID))
+		  else if (!intl_identifier_casecmp (db_get_string (&avalue), SM_FUNCTION_INDEX_ID))
 		    {
 		      flag = 0x02;
 		    }
-		  else if (!intl_identifier_casecmp (DB_GET_STRING (&avalue), SM_PREFIX_INDEX_ID))
+		  else if (!intl_identifier_casecmp (db_get_string (&avalue), SM_PREFIX_INDEX_ID))
 		    {
 		      flag = 0x03;
 		    }
@@ -2325,7 +2325,7 @@ catcls_get_or_value_from_indexes (DB_SEQ * seq_p, OR_VALUE * values, int is_uniq
 		  switch (flag)
 		    {
 		    case 0x01:
-		      pred_seq = DB_GET_SEQUENCE (&avalue);
+		      pred_seq = db_get_set (&avalue);
 		      attr_val_p = &attrs[8].value;
 		      error = set_get_element (pred_seq, 0, attr_val_p);
 		      if (error != NO_ERROR)
@@ -2336,7 +2336,7 @@ catcls_get_or_value_from_indexes (DB_SEQ * seq_p, OR_VALUE * values, int is_uniq
 
 		    case 0x02:
 		      has_function_index = 1;
-		      pred_seq = DB_GET_SEQUENCE (&avalue);
+		      pred_seq = db_get_set (&avalue);
 
 		      error = set_get_element_nocopy (pred_seq, 2, &temp);
 		      if (error != NO_ERROR)
@@ -2419,7 +2419,7 @@ catcls_get_or_value_from_indexes (DB_SEQ * seq_p, OR_VALUE * values, int is_uniq
 				  goto error;
 				}
 
-			      buffer = DB_GET_STRING (&temp);
+			      buffer = db_get_string (&temp);
 			      ptr = buffer;
 			      ptr = or_unpack_domain (ptr, &fi_domain, NULL);
 
@@ -2443,7 +2443,7 @@ catcls_get_or_value_from_indexes (DB_SEQ * seq_p, OR_VALUE * values, int is_uniq
 
 		    case 0x03:
 		      pvalue = db_value_copy (&avalue);
-		      prefix_seq = DB_GET_SEQUENCE (pvalue);
+		      prefix_seq = db_get_set (pvalue);
 		      break;
 
 		    default:
@@ -2470,7 +2470,7 @@ catcls_get_or_value_from_indexes (DB_SEQ * seq_p, OR_VALUE * values, int is_uniq
 		      goto error;
 		    }
 
-		  child_seq = DB_GET_SEQUENCE (&val);
+		  child_seq = db_get_set (&val);
 		}
 	    }
 	  else
@@ -2730,7 +2730,7 @@ catcls_get_property_set (THREAD_ENTRY * thread_p, OR_BUF * buf_p, int expected_s
     }
 
   (*(tp_Sequence.data_readval)) (buf_p, &prop_val, NULL, expected_size, true, NULL, 0);
-  prop_seq_p = DB_GET_SEQUENCE (&prop_val);
+  prop_seq_p = db_get_set (&prop_val);
 
   for (i = 0; i < SM_PROPERTY_NUM_INDEX_FAMILY; i++)
     {
@@ -2739,7 +2739,7 @@ catcls_get_property_set (THREAD_ENTRY * thread_p, OR_BUF * buf_p, int expected_s
 
 	  if (DB_VALUE_TYPE (&vals[i]) == DB_TYPE_SEQUENCE)
 	    {
-	      property_vars[i].seq = DB_GET_SEQUENCE (&vals[i]);
+	      property_vars[i].seq = db_get_set (&vals[i]);
 	    }
 
 	  if (property_vars[i].seq != NULL)
@@ -2976,14 +2976,14 @@ catcls_expand_or_value_by_subset (THREAD_ENTRY * thread_p, OR_VALUE * value_p)
       return NO_ERROR;
     }
 
-  set_p = DB_GET_SET (&value_p->value);
+  set_p = db_get_set (&value_p->value);
   size = set_size (set_p);
   if (size > 0)
     {
       set_get_element_nocopy (set_p, 0, &element);
       if (DB_VALUE_TYPE (&element) == DB_TYPE_OID)
 	{
-	  oid_p = DB_GET_OID (&element);
+	  oid_p = db_get_oid (&element);
 
 	  scan_code = heap_get_class_oid (thread_p, oid_p, &class_oid);
 	  if (er_errid () == ER_HEAP_UNKNOWN_OBJECT)
@@ -3592,7 +3592,7 @@ catcls_delete_subset (THREAD_ENTRY * thread_p, OR_VALUE * value_p)
       return NO_ERROR;
     }
 
-  oid_set_p = DB_GET_SET (&value_p->value);
+  oid_set_p = db_get_set (&value_p->value);
   class_oid_p = &subset_p[0].id.classoid;
 
   cls_info_p = catalog_get_class_info (thread_p, class_oid_p, NULL);
@@ -3621,7 +3621,7 @@ catcls_delete_subset (THREAD_ENTRY * thread_p, OR_VALUE * value_p)
 	  goto error;
 	}
 
-      oid_p = DB_GET_OID (&oid_val);
+      oid_p = db_get_oid (&oid_val);
       error = catcls_delete_instance (thread_p, oid_p, class_oid_p, hfid_p, &scan);
       if (error != NO_ERROR)
 	{
@@ -3707,7 +3707,7 @@ catcls_insert_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
 		    {
 		      if (DB_VALUE_TYPE (&attr_p[k].value) == DB_TYPE_OID)
 			{
-			  if (OID_EQ (oid_p, DB_GET_OID (&attr_p[k].value)))
+			  if (OID_EQ (oid_p, db_get_oid (&attr_p[k].value)))
 			    {
 			      db_value_put_null (&attr_p[k].value);
 			    }
@@ -3948,7 +3948,7 @@ catcls_update_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
 		    {
 		      if (DB_VALUE_TYPE (&attr_p[k].value) == DB_TYPE_OID)
 			{
-			  if (OID_EQ (oid_p, DB_GET_OID (&attr_p[k].value)))
+			  if (OID_EQ (oid_p, db_get_oid (&attr_p[k].value)))
 			    {
 			      db_value_put_null (&attr_p[k].value);
 			    }
@@ -4554,7 +4554,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
 		}
 	      assert (DB_VALUE_DOMAIN_TYPE (&(heap_value->dbvalue)) == DB_TYPE_INTEGER);
 
-	      *charset_id_p = (INTL_CODESET) DB_GET_INTEGER (&heap_value->dbvalue);
+	      *charset_id_p = (INTL_CODESET) db_get_int (&heap_value->dbvalue);
 	    }
 	  else if (heap_value->attrid == lang_att_id)
 	    {
@@ -4570,7 +4570,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
 
 	      assert (DB_VALUE_DOMAIN_TYPE (&(heap_value->dbvalue)) == DB_TYPE_STRING);
 
-	      lang_str = DB_GET_STRING (&heap_value->dbvalue);
+	      lang_str = db_get_string (&heap_value->dbvalue);
 	      lang_str_len = (lang_str != NULL) ? strlen (lang_str) : 0;
 
 	      assert (lang_str_len < lang_buf_size);
@@ -4597,7 +4597,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
 
 	      assert (DB_VALUE_DOMAIN_TYPE (&(heap_value->dbvalue)) == DB_TYPE_STRING);
 
-	      checksum = DB_GET_STRING (&heap_value->dbvalue);
+	      checksum = db_get_string (&heap_value->dbvalue);
 	      checksum_len = (checksum != NULL) ? strlen (checksum) : 0;
 
 	      assert (checksum_len <= CHECKSUM_SIZE);
@@ -4697,13 +4697,13 @@ catcls_update_subset (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OR_VALUE * ol
 	}
       else
 	{
-	  oid_set_p = DB_GET_SET (&value_p->value);
+	  oid_set_p = db_get_set (&value_p->value);
 	}
     }
 
   if (n_old_subset > 0)
     {
-      old_oid_set_p = DB_GET_SET (&old_value_p->value);
+      old_oid_set_p = db_get_set (&old_value_p->value);
     }
 
   cls_info_p = catalog_get_class_info (thread_p, class_oid_p, NULL);
@@ -4738,7 +4738,7 @@ catcls_update_subset (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OR_VALUE * ol
 	  goto error;
 	}
 
-      oid_p = DB_GET_OID (&oid_val);
+      oid_p = db_get_oid (&oid_val);
       error = catcls_update_instance (thread_p, &subset_p[i], oid_p, class_oid_p, hfid_p, &scan, force_in_place);
       if (error != NO_ERROR)
 	{
@@ -4772,7 +4772,7 @@ catcls_update_subset (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OR_VALUE * ol
 	    }
 
 	  /* logical deletion - keep OID in sequence */
-	  oid_p = DB_GET_OID (&oid_val);
+	  oid_p = db_get_oid (&oid_val);
 	  error = catcls_delete_instance (thread_p, oid_p, class_oid_p, hfid_p, &scan);
 	  if (error != NO_ERROR)
 	    {
@@ -5017,7 +5017,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
 	    {
 	      assert (DB_VALUE_DOMAIN_TYPE (&(heap_value->dbvalue)) == DB_TYPE_INTEGER);
 
-	      curr_coll->coll_id = DB_GET_INTEGER (&heap_value->dbvalue);
+	      curr_coll->coll_id = db_get_int (&heap_value->dbvalue);
 	    }
 	  else if (heap_value->attrid == coll_name_att_id)
 	    {
@@ -5026,7 +5026,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
 
 	      assert (DB_VALUE_DOMAIN_TYPE (&(heap_value->dbvalue)) == DB_TYPE_STRING);
 
-	      lang_str = DB_GET_STRING (&heap_value->dbvalue);
+	      lang_str = db_get_string (&heap_value->dbvalue);
 	      lang_str_len = (lang_str != NULL) ? strlen (lang_str) : 0;
 	      lang_str_len = MIN (lang_str_len, sizeof (curr_coll->coll_name));
 
@@ -5037,7 +5037,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
 	    {
 	      assert (DB_VALUE_DOMAIN_TYPE (&(heap_value->dbvalue)) == DB_TYPE_INTEGER);
 
-	      curr_coll->codeset = (INTL_CODESET) DB_GET_INTEGER (&heap_value->dbvalue);
+	      curr_coll->codeset = (INTL_CODESET) db_get_int (&heap_value->dbvalue);
 	    }
 	  else if (heap_value->attrid == checksum_att_id)
 	    {
@@ -5046,7 +5046,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
 
 	      assert (DB_VALUE_DOMAIN_TYPE (&(heap_value->dbvalue)) == DB_TYPE_STRING);
 
-	      checksum_str = DB_GET_STRING (&heap_value->dbvalue);
+	      checksum_str = db_get_string (&heap_value->dbvalue);
 	      str_len = (checksum_str != NULL) ? strlen (checksum_str) : 0;
 
 	      assert (str_len == 32);
@@ -5213,7 +5213,7 @@ catcls_get_apply_info_log_record_time (THREAD_ENTRY * thread_p, time_t * log_rec
 	      tmp_log_record_time = 0;
 	      if (!DB_IS_NULL (&heap_value->dbvalue))
 		{
-		  tmp_datetime = *(DB_GET_DATETIME (&heap_value->dbvalue));
+		  tmp_datetime = *(db_get_datetime (&heap_value->dbvalue));
 		  tmp_datetime.time /= 1000;
 
 		  tmp_log_record_time = db_mktime (&tmp_datetime.date, &tmp_datetime.time);
@@ -5330,7 +5330,7 @@ catcls_get_or_value_from_partition (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
   /* expr */
   attr_val_p = &attrs[3].value;
   (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_PARTITION_EXPR_INDEX].length, true, NULL, 0);
-  assert (DB_IS_NULL (attr_val_p) || DB_GET_STRING_LENGTH (attr_val_p) <= DB_MAX_PARTITION_EXPR_LENGTH);
+  assert (DB_IS_NULL (attr_val_p) || db_get_string_length (attr_val_p) <= DB_MAX_PARTITION_EXPR_LENGTH);
 
   /* values */
   attr_val_p = &attrs[4].value;

--- a/src/storage/compactdb_sr.c
+++ b/src/storage/compactdb_sr.c
@@ -94,7 +94,7 @@ process_value (THREAD_ENTRY * thread_p, DB_VALUE * value)
 	OID ref_class_oid;
 	HEAP_SCANCACHE scan_cache;
 
-	ref_oid = DB_GET_OID (value);
+	ref_oid = db_get_oid (value);
 
 	if (OID_ISNULL (ref_oid))
 	  {
@@ -136,7 +136,7 @@ process_value (THREAD_ENTRY * thread_p, DB_VALUE * value)
     case DB_TYPE_MULTISET:
     case DB_TYPE_SEQUENCE:
       {
-	return_value = process_set (thread_p, DB_GET_SET (value));
+	return_value = process_set (thread_p, db_get_set (value));
 	break;
       }
 

--- a/src/storage/extendible_hash.c
+++ b/src/storage/extendible_hash.c
@@ -799,7 +799,7 @@ eh_dump_key (DB_TYPE key_type, void *key, OID * value_ptr)
       fprintf (stdout, "key:%d", ((DB_TIMETZ *) key)->time, ((DB_TIMETZ *) key)->tz_id);
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
       fprintf (stdout, "key:%d", *(DB_UTIME *) key);
       break;
@@ -925,7 +925,7 @@ ehash_get_key_size (DB_TYPE key_type)
       key_size = sizeof (DB_TIME);
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       key_size = sizeof (DB_UTIME);
       break;
 
@@ -2123,7 +2123,7 @@ ehash_write_key_to_record (RECDES * recdes_p, DB_TYPE key_type, void *key_p, sho
       *(DB_TIME *) record_p = *(DB_TIME *) key_p;
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       *(DB_UTIME *) record_p = *(DB_UTIME *) key_p;
       break;
 
@@ -2339,7 +2339,7 @@ ehash_compare_key (THREAD_ENTRY * thread_p, char *bucket_record_p, DB_TYPE key_t
       compare_result = *(DB_TIME *) key_p - *(DB_TIME *) bucket_record_p;
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       compare_result = *(DB_UTIME *) key_p - *(DB_UTIME *) bucket_record_p;
       break;
 
@@ -4362,7 +4362,7 @@ ehash_hash (void *original_key_p, DB_TYPE key_type)
     case DB_TYPE_FLOAT:
     case DB_TYPE_DATE:
     case DB_TYPE_TIME:
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_DATETIME:
     case DB_TYPE_INTEGER:
       hash_key = ehash_hash_four_bytes_type (key);
@@ -4729,7 +4729,7 @@ ehash_apply_each (THREAD_ENTRY * thread_p, EHID * ehid_p, RECDES * recdes_p, DB_
       *((DB_TIME *) (&next_key)) = *(DB_TIME *) bucket_record_p;
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       *((DB_UTIME *) (&next_key)) = *(DB_UTIME *) bucket_record_p;
       break;
 
@@ -4946,7 +4946,7 @@ ehash_dump (THREAD_ENTRY * thread_p, EHID * ehid_p)
       printf (" time                                   *\n");
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
       printf (" utime                                  *\n");
       break;
 
@@ -5224,7 +5224,7 @@ ehash_dump_bucket (THREAD_ENTRY * thread_p, PAGE_PTR bucket_page_p, DB_TYPE key_
 	  fprintf (stdout, "      %2d:%2d:%2d               ", hour, minute, second);
 	  break;
 
-	case DB_TYPE_UTIME:
+	case DB_TYPE_TIMESTAMP:
 	  {
 	    DB_DATE tmp_date;
 	    DB_TIME tmp_time;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -11161,7 +11161,7 @@ heap_attrinfo_set (const OID * inst_oid, ATTR_ID attrid, DB_VALUE * attr_val, HE
 	  ret = tp_domain_status_er_set (dom_status, ARG_FILE_LINE, attr_val, value->last_attrepr->domain);
 	  assert (er_errid () != NO_ERROR);
 
-	  DB_MAKE_NULL (&value->dbvalue);
+	  db_make_null (&value->dbvalue);
 	}
     }
 
@@ -12583,7 +12583,7 @@ heap_attrinfo_generate_key (THREAD_ENTRY * thread_p, int n_atts, int *att_ids, i
 
       (void) pr_clear_value (db_valuep);
 
-      DB_MAKE_MIDXKEY (db_valuep, &midxkey);
+      db_make_midxkey (db_valuep, &midxkey);
 
       if (midxkey_size > DBVAL_BUFSIZE)
 	{
@@ -12746,7 +12746,7 @@ heap_attrvalue_get_key (THREAD_ENTRY * thread_p, int btid_index, HEAP_CACHE_ATTR
 
       (void) pr_clear_value (db_value);
 
-      DB_MAKE_MIDXKEY (db_value, &midxkey);
+      db_make_midxkey (db_value, &midxkey);
 
       if (midxkey_size > DBVAL_BUFSIZE)
 	{
@@ -16874,7 +16874,7 @@ heap_object_upgrade_domain (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scanca
   ATTR_ID atts_id[1] = { 0 };
   DB_VALUE orig_value;
 
-  DB_MAKE_NULL (&orig_value);
+  db_make_null (&orig_value);
 
   if (upd_scancache == NULL || attr_info == NULL || oid == NULL)
     {
@@ -16902,17 +16902,17 @@ heap_object_upgrade_domain (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scanca
 
       if (QSTR_IS_BIT (src_type))
 	{
-	  curr_prec = DB_GET_STRING_LENGTH (&(value->dbvalue));
+	  curr_prec = db_get_string_length (&(value->dbvalue));
 	}
       else if (QSTR_IS_ANY_CHAR (src_type))
 	{
 	  if (TP_DOMAIN_CODESET (dest_dom) == INTL_CODESET_RAW_BYTES)
 	    {
-	      curr_prec = DB_GET_STRING_SIZE (&(value->dbvalue));
+	      curr_prec = db_get_string_size (&(value->dbvalue));
 	    }
 	  else if (!DB_IS_NULL (&(value->dbvalue)))
 	    {
-	      curr_prec = DB_GET_STRING_LENGTH (&(value->dbvalue));
+	      curr_prec = db_get_string_length (&(value->dbvalue));
 	    }
 	  else
 	    {
@@ -17001,25 +17001,25 @@ heap_object_upgrade_domain (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scanca
 	      switch (src_type)
 		{
 		case DB_TYPE_INTEGER:
-		  is_positive = ((DB_GET_INTEGER (&value->dbvalue) >= 0) ? 1 : 0);
+		  is_positive = ((db_get_int (&value->dbvalue) >= 0) ? 1 : 0);
 		  break;
 		case DB_TYPE_SMALLINT:
-		  is_positive = ((DB_GET_SHORT (&value->dbvalue) >= 0) ? 1 : 0);
+		  is_positive = ((db_get_short (&value->dbvalue) >= 0) ? 1 : 0);
 		  break;
 		case DB_TYPE_BIGINT:
-		  is_positive = ((DB_GET_BIGINT (&value->dbvalue) >= 0) ? 1 : 0);
+		  is_positive = ((db_get_bigint (&value->dbvalue) >= 0) ? 1 : 0);
 		  break;
 		case DB_TYPE_FLOAT:
-		  is_positive = ((DB_GET_FLOAT (&value->dbvalue) >= 0) ? 1 : 0);
+		  is_positive = ((db_get_float (&value->dbvalue) >= 0) ? 1 : 0);
 		  break;
 		case DB_TYPE_DOUBLE:
-		  is_positive = ((DB_GET_DOUBLE (&value->dbvalue) >= 0) ? 1 : 0);
+		  is_positive = ((db_get_double (&value->dbvalue) >= 0) ? 1 : 0);
 		  break;
 		case DB_TYPE_NUMERIC:
 		  is_positive = numeric_db_value_is_positive (&value->dbvalue);
 		  break;
 		case DB_TYPE_MONETARY:
-		  is_positive = ((DB_GET_MONETARY (&value->dbvalue)->amount >= 0) ? 1 : 0);
+		  is_positive = ((db_get_monetary (&value->dbvalue)->amount >= 0) ? 1 : 0);
 		  break;
 
 		case DB_TYPE_CHAR:
@@ -17027,8 +17027,8 @@ heap_object_upgrade_domain (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scanca
 		case DB_TYPE_NCHAR:
 		case DB_TYPE_VARNCHAR:
 		  {
-		    char *str = DB_GET_STRING (&(value->dbvalue));
-		    char *str_end = str + DB_GET_STRING_LENGTH (&(value->dbvalue));
+		    char *str = db_get_string (&(value->dbvalue));
+		    char *str_end = str + db_get_string_length (&(value->dbvalue));
 		    char *p = NULL;
 
 		    /* get the sign in the source string; look directly into the buffer string, no copy */
@@ -18120,19 +18120,19 @@ heap_get_page_info (THREAD_ENTRY * thread_p, const OID * cls_oid, const HFID * h
       return S_ERROR;
     }
 
-  DB_MAKE_OID (page_info[HEAP_PAGE_INFO_CLASS_OID], cls_oid);
+  db_make_oid (page_info[HEAP_PAGE_INFO_CLASS_OID], cls_oid);
 
   if (hfid->hpgid == vpid->pageid && hfid->vfid.volid == vpid->volid)
     {
       HEAP_HDR_STATS *hdr_stats = (HEAP_HDR_STATS *) recdes.data;
-      DB_MAKE_NULL (page_info[HEAP_PAGE_INFO_PREV_PAGE]);
-      DB_MAKE_INT (page_info[HEAP_PAGE_INFO_NEXT_PAGE], hdr_stats->next_vpid.pageid);
+      db_make_null (page_info[HEAP_PAGE_INFO_PREV_PAGE]);
+      db_make_int (page_info[HEAP_PAGE_INFO_NEXT_PAGE], hdr_stats->next_vpid.pageid);
     }
   else
     {
       HEAP_CHAIN *chain = (HEAP_CHAIN *) recdes.data;
-      DB_MAKE_INT (page_info[HEAP_PAGE_INFO_PREV_PAGE], chain->prev_vpid.pageid);
-      DB_MAKE_INT (page_info[HEAP_PAGE_INFO_NEXT_PAGE], chain->next_vpid.pageid);
+      db_make_int (page_info[HEAP_PAGE_INFO_PREV_PAGE], chain->prev_vpid.pageid);
+      db_make_int (page_info[HEAP_PAGE_INFO_NEXT_PAGE], chain->next_vpid.pageid);
     }
 
   /* Obtain information from spage header */
@@ -18305,9 +18305,9 @@ heap_get_record_info (THREAD_ENTRY * thread_p, const OID oid, RECDES * recdes, R
   assert (recdes != NULL);
 
   /* careful adding values in the right order */
-  DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_VOLUMEID], oid.volid);
-  DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_PAGEID], oid.pageid);
-  DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_SLOTID], oid.slotid);
+  db_make_int (record_info[HEAP_RECORD_INFO_T_VOLUMEID], oid.volid);
+  db_make_int (record_info[HEAP_RECORD_INFO_T_PAGEID], oid.pageid);
+  db_make_int (record_info[HEAP_RECORD_INFO_T_SLOTID], oid.slotid);
 
   /* get slot info */
   slot_p = spage_get_slot (page_watcher->pgptr, oid.slotid);
@@ -18315,9 +18315,9 @@ heap_get_record_info (THREAD_ENTRY * thread_p, const OID oid, RECDES * recdes, R
     {
       assert (0);
     }
-  DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_OFFSET], slot_p->offset_to_record);
-  DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_LENGTH], slot_p->record_length);
-  DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_REC_TYPE], slot_p->record_type);
+  db_make_int (record_info[HEAP_RECORD_INFO_T_OFFSET], slot_p->offset_to_record);
+  db_make_int (record_info[HEAP_RECORD_INFO_T_LENGTH], slot_p->record_length);
+  db_make_int (record_info[HEAP_RECORD_INFO_T_REC_TYPE], slot_p->record_type);
 
   /* get record info */
   switch (slot_p->record_type)
@@ -18354,27 +18354,27 @@ heap_get_record_info (THREAD_ENTRY * thread_p, const OID oid, RECDES * recdes, R
 	  scan = spage_get_record (thread_p, page_watcher->pgptr, oid.slotid, recdes, COPY);
 	  pgbuf_ordered_unfix (thread_p, page_watcher);
 	}
-      DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_REPRID], or_rep_id (recdes));
-      DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_REPRID], or_chn (recdes));
+      db_make_int (record_info[HEAP_RECORD_INFO_T_REPRID], or_rep_id (recdes));
+      db_make_int (record_info[HEAP_RECORD_INFO_T_REPRID], or_chn (recdes));
       or_mvcc_get_header (recdes, &mvcc_header);
-      DB_MAKE_BIGINT (record_info[HEAP_RECORD_INFO_T_MVCC_INSID], MVCC_GET_INSID (&mvcc_header));
+      db_make_bigint (record_info[HEAP_RECORD_INFO_T_MVCC_INSID], MVCC_GET_INSID (&mvcc_header));
       if (MVCC_IS_HEADER_DELID_VALID (&mvcc_header))
 	{
-	  DB_MAKE_BIGINT (record_info[HEAP_RECORD_INFO_T_MVCC_DELID], MVCC_GET_DELID (&mvcc_header));
+	  db_make_bigint (record_info[HEAP_RECORD_INFO_T_MVCC_DELID], MVCC_GET_DELID (&mvcc_header));
 	}
       else
 	{
-	  DB_MAKE_NULL (record_info[HEAP_RECORD_INFO_T_MVCC_DELID]);
+	  db_make_null (record_info[HEAP_RECORD_INFO_T_MVCC_DELID]);
 	}
-      DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_CHN], OR_GET_MVCC_CHN (&mvcc_header));
-      DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_MVCC_FLAGS], MVCC_GET_FLAG (&mvcc_header));
+      db_make_int (record_info[HEAP_RECORD_INFO_T_CHN], OR_GET_MVCC_CHN (&mvcc_header));
+      db_make_int (record_info[HEAP_RECORD_INFO_T_MVCC_FLAGS], MVCC_GET_FLAG (&mvcc_header));
       if (MVCC_IS_FLAG_SET (&mvcc_header, OR_MVCC_FLAG_VALID_PREV_VERSION))
 	{
-	  DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_MVCC_PREV_VERSION], 1);
+	  db_make_int (record_info[HEAP_RECORD_INFO_T_MVCC_PREV_VERSION], 1);
 	}
       else
 	{
-	  DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_MVCC_PREV_VERSION], 0);
+	  db_make_int (record_info[HEAP_RECORD_INFO_T_MVCC_PREV_VERSION], 0);
 	}
       break;
 
@@ -18430,28 +18430,28 @@ heap_get_record_info (THREAD_ENTRY * thread_p, const OID oid, RECDES * recdes, R
 	{
 	  return S_ERROR;
 	}
-      DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_REPRID], or_rep_id (recdes));
-      DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_REPRID], or_chn (recdes));
+      db_make_int (record_info[HEAP_RECORD_INFO_T_REPRID], or_rep_id (recdes));
+      db_make_int (record_info[HEAP_RECORD_INFO_T_REPRID], or_chn (recdes));
 
       or_mvcc_get_header (recdes, &mvcc_header);
-      DB_MAKE_BIGINT (record_info[HEAP_RECORD_INFO_T_MVCC_INSID], MVCC_GET_INSID (&mvcc_header));
+      db_make_bigint (record_info[HEAP_RECORD_INFO_T_MVCC_INSID], MVCC_GET_INSID (&mvcc_header));
       if (MVCC_IS_HEADER_DELID_VALID (&mvcc_header))
 	{
-	  DB_MAKE_BIGINT (record_info[HEAP_RECORD_INFO_T_MVCC_DELID], MVCC_GET_DELID (&mvcc_header));
+	  db_make_bigint (record_info[HEAP_RECORD_INFO_T_MVCC_DELID], MVCC_GET_DELID (&mvcc_header));
 	}
       else
 	{
-	  DB_MAKE_NULL (record_info[HEAP_RECORD_INFO_T_MVCC_DELID]);
+	  db_make_null (record_info[HEAP_RECORD_INFO_T_MVCC_DELID]);
 	}
-      DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_CHN], OR_GET_MVCC_CHN (&mvcc_header));
-      DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_MVCC_FLAGS], MVCC_GET_FLAG (&mvcc_header));
+      db_make_int (record_info[HEAP_RECORD_INFO_T_CHN], OR_GET_MVCC_CHN (&mvcc_header));
+      db_make_int (record_info[HEAP_RECORD_INFO_T_MVCC_FLAGS], MVCC_GET_FLAG (&mvcc_header));
       if (MVCC_IS_FLAG_SET (&mvcc_header, OR_MVCC_FLAG_VALID_PREV_VERSION))
 	{
-	  DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_MVCC_PREV_VERSION], 1);
+	  db_make_int (record_info[HEAP_RECORD_INFO_T_MVCC_PREV_VERSION], 1);
 	}
       else
 	{
-	  DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_MVCC_PREV_VERSION], 0);
+	  db_make_int (record_info[HEAP_RECORD_INFO_T_MVCC_PREV_VERSION], 0);
 	}
       break;
     case REC_RELOCATION:
@@ -18460,13 +18460,13 @@ heap_get_record_info (THREAD_ENTRY * thread_p, const OID oid, RECDES * recdes, R
     case REC_ASSIGN_ADDRESS:
     case REC_UNKNOWN:
     default:
-      DB_MAKE_NULL (record_info[HEAP_RECORD_INFO_T_REPRID]);
-      DB_MAKE_NULL (record_info[HEAP_RECORD_INFO_T_CHN]);
-      DB_MAKE_NULL (record_info[HEAP_RECORD_INFO_T_MVCC_INSID]);
-      DB_MAKE_NULL (record_info[HEAP_RECORD_INFO_T_MVCC_DELID]);
-      DB_MAKE_NULL (record_info[HEAP_RECORD_INFO_T_MVCC_FLAGS]);
+      db_make_null (record_info[HEAP_RECORD_INFO_T_REPRID]);
+      db_make_null (record_info[HEAP_RECORD_INFO_T_CHN]);
+      db_make_null (record_info[HEAP_RECORD_INFO_T_MVCC_INSID]);
+      db_make_null (record_info[HEAP_RECORD_INFO_T_MVCC_DELID]);
+      db_make_null (record_info[HEAP_RECORD_INFO_T_MVCC_FLAGS]);
 
-      DB_MAKE_INT (record_info[HEAP_RECORD_INFO_T_MVCC_PREV_VERSION], 0);
+      db_make_int (record_info[HEAP_RECORD_INFO_T_MVCC_PREV_VERSION], 0);
 
       recdes->area_size = -1;
       recdes->data = NULL;

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -4759,15 +4759,15 @@ spage_get_page_header_info (PAGE_PTR page_p, DB_VALUE ** page_header_info)
   page_header_p = (SPAGE_HEADER *) page_p;
   SPAGE_VERIFY_HEADER (page_header_p);
 
-  DB_MAKE_INT (page_header_info[HEAP_PAGE_INFO_NUM_SLOTS], page_header_p->num_slots);
-  DB_MAKE_INT (page_header_info[HEAP_PAGE_INFO_NUM_RECORDS], page_header_p->num_records);
-  DB_MAKE_INT (page_header_info[HEAP_PAGE_INFO_ANCHOR_TYPE], page_header_p->anchor_type);
-  DB_MAKE_INT (page_header_info[HEAP_PAGE_INFO_ALIGNMENT], page_header_p->alignment);
-  DB_MAKE_INT (page_header_info[HEAP_PAGE_INFO_TOTAL_FREE], page_header_p->total_free);
-  DB_MAKE_INT (page_header_info[HEAP_PAGE_INFO_CONT_FREE], page_header_p->cont_free);
-  DB_MAKE_INT (page_header_info[HEAP_PAGE_INFO_OFFSET_TO_FREE_AREA], page_header_p->offset_to_free_area);
-  DB_MAKE_INT (page_header_info[HEAP_PAGE_INFO_IS_SAVING], page_header_p->is_saving);
-  DB_MAKE_INT (page_header_info[HEAP_PAGE_INFO_UPDATE_BEST], page_header_p->need_update_best_hint);
+  db_make_int (page_header_info[HEAP_PAGE_INFO_NUM_SLOTS], page_header_p->num_slots);
+  db_make_int (page_header_info[HEAP_PAGE_INFO_NUM_RECORDS], page_header_p->num_records);
+  db_make_int (page_header_info[HEAP_PAGE_INFO_ANCHOR_TYPE], page_header_p->anchor_type);
+  db_make_int (page_header_info[HEAP_PAGE_INFO_ALIGNMENT], page_header_p->alignment);
+  db_make_int (page_header_info[HEAP_PAGE_INFO_TOTAL_FREE], page_header_p->total_free);
+  db_make_int (page_header_info[HEAP_PAGE_INFO_CONT_FREE], page_header_p->cont_free);
+  db_make_int (page_header_info[HEAP_PAGE_INFO_OFFSET_TO_FREE_AREA], page_header_p->offset_to_free_area);
+  db_make_int (page_header_info[HEAP_PAGE_INFO_IS_SAVING], page_header_p->is_saving);
+  db_make_int (page_header_info[HEAP_PAGE_INFO_UPDATE_BEST], page_header_p->need_update_best_hint);
 
   return S_SUCCESS;
 }

--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -391,8 +391,8 @@ stats_dump (const char *class_name_p, FILE * file_p)
 	  fprintf (file_p, "DB_TYPE_TIMETZ\n");
 	  break;
 
-	case DB_TYPE_UTIME:
-	  fprintf (file_p, "DB_TYPE_UTIME\n");
+	case DB_TYPE_TIMESTAMP:
+	  fprintf (file_p, "DB_TYPE_TIMESTAMP\n");
 	  break;
 
 	case DB_TYPE_TIMESTAMPLTZ:

--- a/src/storage/statistics_sr.c
+++ b/src/storage/statistics_sr.c
@@ -985,7 +985,7 @@ stats_compare_data (DB_DATA * data1_p, DB_DATA * data2_p, DB_TYPE type)
       status = stats_compare_time (&data1_p->timetz.time, &data2_p->timetz.time);
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
       status = stats_compare_utime (&data1_p->utime, &data2_p->utime);
       break;
@@ -1118,8 +1118,8 @@ stats_dump_class_statistics (CLASS_STATS * class_stats, FILE * fpp)
 	  fprintf (fpp, "DB_TYPE_TIMETZ \n");
 	  break;
 
-	case DB_TYPE_UTIME:
-	  fprintf (fpp, "DB_TYPE_UTIME \n");
+	case DB_TYPE_TIMESTAMP:
+	  fprintf (fpp, "DB_TYPE_TIMESTAMP \n");
 	  break;
 
 	case DB_TYPE_TIMESTAMPLTZ:

--- a/src/storage/storage_common.c
+++ b/src/storage/storage_common.c
@@ -238,7 +238,7 @@ db_print_data (DB_TYPE type, DB_DATA * data, FILE * fd)
       fprintf (fd, "%d:%d:%d Z:%X", hour, minute, second, data->timetz.tz_id);
       break;
 
-    case DB_TYPE_UTIME:
+    case DB_TYPE_TIMESTAMP:
     case DB_TYPE_TIMESTAMPLTZ:
       fprintf (fd, "%d", data->utime);
       break;

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -2743,7 +2743,7 @@ boot_define_index_key (MOP class_mop)
       return error_code;
     }
 
-  DB_MAKE_INTEGER (&prefix_default, -1);
+  db_make_int (&prefix_default, -1);
 
   error_code = smt_set_attribute_default (def, "key_prefix_length", 0, &prefix_default, NULL);
   if (error_code != NO_ERROR)
@@ -2981,10 +2981,10 @@ boot_add_data_type (MOP class_mop)
 	      return er_errid ();
 	    }
 
-	  DB_MAKE_INTEGER (&val, i + 1);
+	  db_make_int (&val, i + 1);
 	  db_put_internal (obj, "type_id", &val);
 
-	  DB_MAKE_VARCHAR (&val, 16, (char *) names[i], strlen (names[i]), LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	  db_make_varchar (&val, 16, (char *) names[i], strlen (names[i]), LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	  db_put_internal (obj, "type_name", &val);
 	}
     }
@@ -3260,7 +3260,7 @@ boot_define_serial (MOP class_mop)
 
   sprintf (domain_string, "numeric(%d,0)", DB_MAX_NUMERIC_PRECISION);
   numeric_coerce_int_to_num (1, num);
-  DB_MAKE_NUMERIC (&default_value, num, DB_MAX_NUMERIC_PRECISION, 0);
+  db_make_numeric (&default_value, num, DB_MAX_NUMERIC_PRECISION, 0);
 
   error_code = smt_add_attribute (def, "current_val", domain_string, NULL);
   if (error_code != NO_ERROR)
@@ -3296,7 +3296,7 @@ boot_define_serial (MOP class_mop)
       return error_code;
     }
 
-  DB_MAKE_INTEGER (&default_value, 0);
+  db_make_int (&default_value, 0);
 
   error_code = smt_add_attribute (def, "cyclic", "integer", NULL);
   if (error_code != NO_ERROR)
@@ -3698,30 +3698,30 @@ boot_add_collations (MOP class_mop)
 
       assert (lang_coll->coll.coll_id == i);
 
-      DB_MAKE_INTEGER (&val, i);
+      db_make_int (&val, i);
       db_put_internal (obj, CT_DBCOLL_COLL_ID_COLUMN, &val);
 
-      DB_MAKE_VARCHAR (&val, 32, lang_coll->coll.coll_name, strlen (lang_coll->coll.coll_name), LANG_SYS_CODESET,
+      db_make_varchar (&val, 32, lang_coll->coll.coll_name, strlen (lang_coll->coll.coll_name), LANG_SYS_CODESET,
 		       LANG_SYS_COLLATION);
       db_put_internal (obj, CT_DBCOLL_COLL_NAME_COLUMN, &val);
 
-      DB_MAKE_INTEGER (&val, (int) (lang_coll->codeset));
+      db_make_int (&val, (int) (lang_coll->codeset));
       db_put_internal (obj, CT_DBCOLL_CHARSET_ID_COLUMN, &val);
 
-      DB_MAKE_INTEGER (&val, lang_coll->built_in);
+      db_make_int (&val, lang_coll->built_in);
       db_put_internal (obj, CT_DBCOLL_BUILT_IN_COLUMN, &val);
 
-      DB_MAKE_INTEGER (&val, lang_coll->coll.uca_opt.sett_expansions ? 1 : 0);
+      db_make_int (&val, lang_coll->coll.uca_opt.sett_expansions ? 1 : 0);
       db_put_internal (obj, CT_DBCOLL_EXPANSIONS_COLUMN, &val);
 
-      DB_MAKE_INTEGER (&val, lang_coll->coll.count_contr);
+      db_make_int (&val, lang_coll->coll.count_contr);
       db_put_internal (obj, CT_DBCOLL_CONTRACTIONS_COLUMN, &val);
 
-      DB_MAKE_INTEGER (&val, (int) (lang_coll->coll.uca_opt.sett_strength));
+      db_make_int (&val, (int) (lang_coll->coll.uca_opt.sett_strength));
       db_put_internal (obj, CT_DBCOLL_UCA_STRENGTH, &val);
 
       assert (strlen (lang_coll->coll.checksum) == 32);
-      DB_MAKE_VARCHAR (&val, 32, lang_coll->coll.checksum, 32, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+      db_make_varchar (&val, 32, lang_coll->coll.checksum, 32, LANG_SYS_CODESET, LANG_SYS_COLLATION);
       db_put_internal (obj, CT_DBCOLL_CHECKSUM_COLUMN, &val);
     }
 
@@ -3856,7 +3856,7 @@ boot_add_charsets (MOP class_mop)
 	  return er_errid ();
 	}
 
-      DB_MAKE_INTEGER (&val, i);
+      db_make_int (&val, i);
       db_put_internal (obj, CT_DBCHARSET_CHARSET_ID, &val);
 
       charset_name = (char *) lang_charset_cubrid_name ((INTL_CODESET) i);
@@ -3865,13 +3865,13 @@ boot_add_charsets (MOP class_mop)
 	  return ER_LANG_CODESET_NOT_AVAILABLE;
 	}
 
-      DB_MAKE_VARCHAR (&val, 32, charset_name, strlen (charset_name), LANG_SYS_CODESET, LANG_SYS_COLLATION);
+      db_make_varchar (&val, 32, charset_name, strlen (charset_name), LANG_SYS_CODESET, LANG_SYS_COLLATION);
       db_put_internal (obj, CT_DBCHARSET_CHARSET_NAME, &val);
 
-      DB_MAKE_INTEGER (&val, LANG_GET_BINARY_COLLATION (i));
+      db_make_int (&val, LANG_GET_BINARY_COLLATION (i));
       db_put_internal (obj, CT_DBCHARSET_DEFAULT_COLLATION, &val);
 
-      DB_MAKE_INTEGER (&val, INTL_CODESET_MULT (i));
+      db_make_int (&val, INTL_CODESET_MULT (i));
       db_put_internal (obj, CT_DBCHARSET_CHAR_SIZE, &val);
     }
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4029,7 +4029,7 @@ locator_check_foreign_key (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid
   int classrepr_cacheindex = -1;
   BTREE_SEARCH ret;
 
-  DB_MAKE_NULL (&dbvalue);
+  db_make_null (&dbvalue);
 
   aligned_buf = PTR_ALIGN (buf, MAX_ALIGNMENT);
 
@@ -7670,7 +7670,7 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
   assert_release (!OID_ISNULL (class_oid));
 
   key_dbvalue = NULL;
-  DB_MAKE_NULL (&dbvalue);
+  db_make_null (&dbvalue);
 
   aligned_buf = PTR_ALIGN (buf, MAX_ALIGNMENT);
 
@@ -8196,8 +8196,8 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 
   LSA_SET_NULL (&preserved_repl_lsa);
 
-  DB_MAKE_NULL (&new_dbvalue);
-  DB_MAKE_NULL (&old_dbvalue);
+  db_make_null (&new_dbvalue);
+  db_make_null (&old_dbvalue);
 
   aligned_newbuf = PTR_ALIGN (newbuf, MAX_ALIGNMENT);
   aligned_oldbuf = PTR_ALIGN (oldbuf, MAX_ALIGNMENT);
@@ -8795,7 +8795,7 @@ xlocator_remove_class_from_index (THREAD_ENTRY * thread_p, OID * class_oid, BTID
 	}
     }
 
-  DB_MAKE_NULL (&dbvalue);
+  db_make_null (&dbvalue);
 
   aligned_buf = PTR_ALIGN (buf, MAX_ALIGNMENT);
 
@@ -9250,7 +9250,7 @@ locator_check_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, HFID * hfid, 
     {
       return DISK_ERROR;
     }
-  DB_MAKE_NULL (&dbvalue);
+  db_make_null (&dbvalue);
 
   aligned_buf = PTR_ALIGN (buf, MAX_ALIGNMENT);
 
@@ -9674,7 +9674,7 @@ locator_check_unique_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, OID * 
     {
       return DISK_ERROR;
     }
-  DB_MAKE_NULL (&dbvalue);
+  db_make_null (&dbvalue);
 
   aligned_buf = PTR_ALIGN (buf, MAX_ALIGNMENT);
 
@@ -11640,7 +11640,7 @@ xlocator_check_fk_validity (THREAD_ENTRY * thread_p, OID * cls_oid, HFID * hfid,
       return (error_code == NO_ERROR ? ER_FAILED : error_code);
     }
 
-  DB_MAKE_NULL (&tmpval);
+  db_make_null (&tmpval);
 
   aligned_midxkey_buf = PTR_ALIGN (midxkey_buf, MAX_ALIGNMENT);
 

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -1538,7 +1538,7 @@ la_get_ha_apply_info (const char *log_path, const char *prefix_name, LA_HA_APPLY
 	  strncpy (ha_apply_info->copied_log_path, log_path, sizeof (ha_apply_info->copied_log_path) - 1);
 
 	  /* 2. creation time */
-	  db_time = DB_GET_DATETIME (&out_value[out_value_idx++]);
+	  db_time = db_get_datetime (&out_value[out_value_idx++]);
 	  ha_apply_info->creation_time.date = db_time->date;
 	  ha_apply_info->creation_time.time = db_time->time;
 
@@ -1550,8 +1550,8 @@ la_get_ha_apply_info (const char *log_path, const char *prefix_name, LA_HA_APPLY
 	    }
 	  else
 	    {
-	      ha_apply_info->committed_lsa.pageid = DB_GET_BIGINT (&out_value[out_value_idx++]);
-	      ha_apply_info->committed_lsa.offset = DB_GET_INTEGER (&out_value[out_value_idx++]);
+	      ha_apply_info->committed_lsa.pageid = db_get_bigint (&out_value[out_value_idx++]);
+	      ha_apply_info->committed_lsa.offset = db_get_int (&out_value[out_value_idx++]);
 	    }
 
 	  /* 6 ~ 7. committed_rep_lsa */
@@ -1562,17 +1562,17 @@ la_get_ha_apply_info (const char *log_path, const char *prefix_name, LA_HA_APPLY
 	    }
 	  else
 	    {
-	      ha_apply_info->committed_rep_lsa.pageid = DB_GET_BIGINT (&out_value[out_value_idx++]);
-	      ha_apply_info->committed_rep_lsa.offset = DB_GET_INTEGER (&out_value[out_value_idx++]);
+	      ha_apply_info->committed_rep_lsa.pageid = db_get_bigint (&out_value[out_value_idx++]);
+	      ha_apply_info->committed_rep_lsa.offset = db_get_int (&out_value[out_value_idx++]);
 	    }
 
 	  /* 8 ~ 9. append_lsa */
-	  ha_apply_info->append_lsa.pageid = DB_GET_BIGINT (&out_value[out_value_idx++]);
-	  ha_apply_info->append_lsa.offset = DB_GET_INTEGER (&out_value[out_value_idx++]);
+	  ha_apply_info->append_lsa.pageid = db_get_bigint (&out_value[out_value_idx++]);
+	  ha_apply_info->append_lsa.offset = db_get_int (&out_value[out_value_idx++]);
 
 	  /* 10 ~ 11. eof_lsa */
-	  ha_apply_info->eof_lsa.pageid = DB_GET_BIGINT (&out_value[out_value_idx++]);
-	  ha_apply_info->eof_lsa.offset = DB_GET_INTEGER (&out_value[out_value_idx++]);
+	  ha_apply_info->eof_lsa.pageid = db_get_bigint (&out_value[out_value_idx++]);
+	  ha_apply_info->eof_lsa.offset = db_get_int (&out_value[out_value_idx++]);
 
 	  /* 12 ~ 13. final_lsa */
 	  if (DB_IS_NULL (&out_value[out_value_idx]) || DB_IS_NULL (&out_value[out_value_idx + 1]))
@@ -1582,8 +1582,8 @@ la_get_ha_apply_info (const char *log_path, const char *prefix_name, LA_HA_APPLY
 	    }
 	  else
 	    {
-	      ha_apply_info->final_lsa.pageid = DB_GET_BIGINT (&out_value[out_value_idx++]);
-	      ha_apply_info->final_lsa.offset = DB_GET_INTEGER (&out_value[out_value_idx++]);
+	      ha_apply_info->final_lsa.pageid = db_get_bigint (&out_value[out_value_idx++]);
+	      ha_apply_info->final_lsa.offset = db_get_int (&out_value[out_value_idx++]);
 	    }
 
 	  /* 14 ~ 15. required_lsa */
@@ -1594,22 +1594,22 @@ la_get_ha_apply_info (const char *log_path, const char *prefix_name, LA_HA_APPLY
 	    }
 	  else
 	    {
-	      ha_apply_info->required_lsa.pageid = DB_GET_BIGINT (&out_value[out_value_idx++]);
-	      ha_apply_info->required_lsa.offset = DB_GET_INTEGER (&out_value[out_value_idx++]);
+	      ha_apply_info->required_lsa.pageid = db_get_bigint (&out_value[out_value_idx++]);
+	      ha_apply_info->required_lsa.offset = db_get_int (&out_value[out_value_idx++]);
 	    }
 
 	  /* 16. log_record_time */
-	  db_time = DB_GET_DATETIME (&out_value[out_value_idx++]);
+	  db_time = db_get_datetime (&out_value[out_value_idx++]);
 	  ha_apply_info->log_record_time.date = db_time->date;
 	  ha_apply_info->log_record_time.time = db_time->time;
 
 	  /* 17. log_commit_time */
-	  db_time = DB_GET_DATETIME (&out_value[out_value_idx++]);
+	  db_time = db_get_datetime (&out_value[out_value_idx++]);
 	  ha_apply_info->log_commit_time.date = db_time->date;
 	  ha_apply_info->log_commit_time.time = db_time->time;
 
 	  /* 18. last_access_time */
-	  db_time = DB_GET_DATETIME (&out_value[out_value_idx++]);
+	  db_time = db_get_datetime (&out_value[out_value_idx++]);
 	  ha_apply_info->last_access_time.date = db_time->date;
 	  ha_apply_info->last_access_time.time = db_time->time;
 
@@ -1617,15 +1617,15 @@ la_get_ha_apply_info (const char *log_path, const char *prefix_name, LA_HA_APPLY
 	  ha_apply_info->status = LA_STATUS_IDLE;
 
 	  /* 19 ~ 24. statistics */
-	  ha_apply_info->insert_counter = DB_GET_BIGINT (&out_value[out_value_idx++]);
-	  ha_apply_info->update_counter = DB_GET_BIGINT (&out_value[out_value_idx++]);
-	  ha_apply_info->delete_counter = DB_GET_BIGINT (&out_value[out_value_idx++]);
-	  ha_apply_info->schema_counter = DB_GET_BIGINT (&out_value[out_value_idx++]);
-	  ha_apply_info->commit_counter = DB_GET_BIGINT (&out_value[out_value_idx++]);
-	  ha_apply_info->fail_counter = DB_GET_BIGINT (&out_value[out_value_idx++]);
+	  ha_apply_info->insert_counter = db_get_bigint (&out_value[out_value_idx++]);
+	  ha_apply_info->update_counter = db_get_bigint (&out_value[out_value_idx++]);
+	  ha_apply_info->delete_counter = db_get_bigint (&out_value[out_value_idx++]);
+	  ha_apply_info->schema_counter = db_get_bigint (&out_value[out_value_idx++]);
+	  ha_apply_info->commit_counter = db_get_bigint (&out_value[out_value_idx++]);
+	  ha_apply_info->fail_counter = db_get_bigint (&out_value[out_value_idx++]);
 
 	  /* 25. start_time */
-	  db_time = DB_GET_DATETIME (&out_value[out_value_idx++]);
+	  db_time = db_get_datetime (&out_value[out_value_idx++]);
 	  ha_apply_info->start_time.date = db_time->date;
 	  ha_apply_info->start_time.time = db_time->time;
 
@@ -2963,7 +2963,7 @@ la_new_repl_item (LOG_LSA * lsa, LOG_LSA * target_lsa)
   LSA_COPY (&item->lsa, lsa);
   LSA_COPY (&item->target_lsa, target_lsa);
 
-  DB_MAKE_NULL (&item->key);
+  db_make_null (&item->key);
   item->packed_key_value_length = 0;
   item->packed_key_value = NULL;
 

--- a/src/transaction/transaction_sr.c
+++ b/src/transaction/transaction_sr.c
@@ -671,7 +671,7 @@ xtran_get_local_transaction_id (THREAD_ENTRY * thread_p, DB_VALUE * trid)
   error_code = db_value_domain_init (trid, DB_TYPE_INTEGER, 0, 0);
   if (error_code == NO_ERROR)
     {
-      DB_MAKE_INTEGER (trid, logtb_find_current_tranid (thread_p));
+      db_make_int (trid, logtb_find_current_tranid (thread_p));
     }
 
   return error_code;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21931

We have decided to get rid of the macros used for the `db_get_*` and `db_make_*` families of functions to avoid any confusion in the future. I think we still have to keep them, though, for the API, so they remained, for now, in `dbtype_function.h`. When JIRA gets back up I will also make an issue there to correspond to this PR.