### PR TITLE
[CBRD-21847] fix windows linker error for es.obj

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -7995,3 +7995,64 @@ vacuum_restore_thread (THREAD_ENTRY * thread_p, THREAD_TYPE save_type)
   thread_p->type = save_type;
   thread_p->vacuum_worker = NULL;
 }
+
+/*
+ * vacuum_rv_es_nop () - Skip recovery operation for external storage.
+ *
+ * return	 : NO_ERROR.
+ * thread_p (in) : Thread entry.
+ * rcv (in)	 : Recovery data.
+ */
+int
+vacuum_rv_es_nop (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
+{
+  /* Do nothing */
+  return NO_ERROR;
+}
+
+#if defined (SERVER_MODE)
+/*
+ * vacuum_notify_es_deleted () - External storage file cannot be deleted
+ *				    when transaction is ended and MVCC is
+ *				    used. Vacuum must be notified instead and
+ *				    file is deleted when it is no longer
+ *				    visible.
+ *
+ * return	 : Void.
+ * thread_p (in) : Thread entry.
+ * uri (in)	 : File location URI.
+ */
+void
+vacuum_notify_es_deleted (THREAD_ENTRY * thread_p, const char *uri)
+{
+#define ES_NOTIFY_VACUUM_FOR_DELETE_BUFFER_SIZE \
+  (INT_ALIGNMENT +	/* Aligning buffer start */	      \
+   OR_INT_SIZE +	/* String length */		      \
+   ES_MAX_URI_LEN +	/* URI string */	  	      \
+   INT_ALIGNMENT)		/* Alignment of packed string */
+
+  LOG_DATA_ADDR addr;
+  int length;
+  char data_buf[ES_NOTIFY_VACUUM_FOR_DELETE_BUFFER_SIZE];
+  char *data = NULL;
+
+  addr.offset = -1;
+  addr.pgptr = NULL;
+  addr.vfid = NULL;
+
+  /* Compute the total length required to pack string */
+  length = or_packed_string_length (uri, NULL);
+
+  /* Check there is enough space in data buffer to pack the string */
+  assert (length <= (int) (ES_NOTIFY_VACUUM_FOR_DELETE_BUFFER_SIZE - INT_ALIGNMENT));
+
+  /* Align buffer to prepare for packing string */
+  data = PTR_ALIGN (data_buf, INT_ALIGNMENT);
+
+  /* Pack string */
+  (void) or_pack_string (data, uri);
+
+  /* This is not actually ever undone, but vacuum will process undo data of log entry. */
+  log_append_undo_data (thread_p, RVES_NOTIFY_VACUUM, &addr, length, data);
+}
+#endif /* SERVER_MODE */

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -380,4 +380,9 @@ extern void vacuum_log_last_blockid (THREAD_ENTRY * thread_p);
 
 extern void vacuum_rv_convert_thread_to_vacuum (THREAD_ENTRY * thread_p, TRANID trid, THREAD_TYPE & save_type);
 extern void vacuum_restore_thread (THREAD_ENTRY * thread_p, THREAD_TYPE save_type);
+
+extern int vacuum_rv_es_nop (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
+#if defined (SERVER_MODE)
+extern void vacuum_notify_es_deleted (THREAD_ENTRY * thread_p, const char *uri);
+#endif /* SERVER_MODE */
 #endif /* _VACUUM_H_ */

--- a/src/storage/es.h
+++ b/src/storage/es.h
@@ -46,9 +46,7 @@ extern int es_copy_file (const char *in_uri, const char *metaname, char *out_uri
 extern int es_rename_file (const char *in_uri, const char *metaname, char *out_uri);
 extern off_t es_get_file_size (const char *uri);
 
-extern int es_rv_nop (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 
-#if defined (SERVER_MODE)
-extern void es_notify_vacuum_for_delete (THREAD_ENTRY * thread_p, const char *uri);
-#endif /* SERVER_MODE */
+
+
 #endif /* _ES_H_ */

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -106,13 +106,6 @@ LOG_GLOBAL log_Gl = {
   GLOBAL_UNIQUE_STATS_TABLE_INITIALIZER
 };
 
-#if defined (SERVER_MODE)
-/* Current time in milliseconds */
-// *INDENT-OFF*
-std::atomic<INT64> log_Clock_msec = {0};
-// *INDENT-ON*
-#endif /* SERVER_MODE */
-
 /* Name of the database and logs */
 char log_Path[PATH_MAX];
 char log_Archive_path[PATH_MAX];

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -60,9 +60,6 @@
 #include <netdb.h>		/* for MAXHOSTNAMELEN */
 #endif /* SOLARIS */
 #include <signal.h>
-#if defined (SERVER_MODE)
-#include <atomic>
-#endif /* SERVER_MODE */
 
 /************************************************************************/
 /* Section shared with client... TODO: remove any code accessing log    */
@@ -2029,13 +2026,6 @@ extern int log_Tran_index;	/* Index onto transaction table for current thread of
 extern LOG_GLOBAL log_Gl;
 
 extern LOG_LOGGING_STAT log_Stat;
-
-#if defined (SERVER_MODE)
-/* Current time in milliseconds */
-// *INDENT-OFF*
-extern std::atomic<INT64> log_Clock_msec;
-// *INDENT-ON*
-#endif /* SERVER_MODE */
 
 /* Name of the database and logs */
 extern char log_Path[];

--- a/src/transaction/recovery.c
+++ b/src/transaction/recovery.c
@@ -766,8 +766,8 @@ struct rvfun RV_fun[] = {
 
   {RVES_NOTIFY_VACUUM,
    "RVES_NOTIFY_VACUUM",
-   es_rv_nop,
-   es_rv_nop,
+   vacuum_rv_es_nop,
+   vacuum_rv_es_nop,
    NULL, NULL},
 
   {RVLOC_CLASSNAME_DUMMY,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21847

We are suffering linking errors building libcubrid on Windows 10, Visual Studio 2017. This is a regression of CBRD-21847, but we cannot explain it.

All we know is that we get a series of linker errors like this:
>   es.obj : error LNK2005: "void __cdecl std::_Store_relaxed_1(unsigned char volatile *,unsigned char)" (?_Store_relaxed_1@std@@YAXPECEE@Z) already defined in vacuum.obj [C:\Work\Cubrid\Github\upstream\build\cubrid\cubrid.vcxproj]
  es.obj : error LNK2005: "void __cdecl std::_Store_release_1(unsigned char volatile *,unsigned char)" (?_Store_release_1@std@@YAXPECEE@Z) already defined in vacuum.obj [C:\Work\Cubrid\Github\upstream\build\cubrid\cubrid.vcxproj]
  es.obj : error LNK2005: "void __cdecl std::_Store_seq_cst_1(unsigned char volatile *,unsigned char)" (?_Store_seq_cst_1@std@@YAXPECEE@Z) already defined in vacuum.obj [C:\Work\Cubrid\Github\upstream\build\cubrid\cubrid.vcxproj]
  es.obj : error LNK2005: "void __cdecl std::_Atomic_store_1(unsigned char volatile *,unsigned char,enum std::memory_order)" (?_Atomic_store_1@std@@YAXPECEEW4memory_order@1@@Z) already defined in vacuum.obj [C:\Work\Cubrid\Github\upstrea
  es.obj : error LNK2005: "unsigned char __cdecl std::_Load_seq_cst_1(unsigned char volatile *)" (?_Load_seq_cst_1@std@@YAEPECE@Z) already defined in thread_looper.obj [C:\Work\Cubrid\Github\upstream\build\cubrid\cubrid.vcxproj]
  es.obj : error LNK2005: "unsigned char __cdecl std::_Load_relaxed_1(unsigned char volatile *)" (?_Load_relaxed_1@std@@YAEPECE@Z) already defined in thread_looper.obj [C:\Work\Cubrid\Github\upstream\build\cubrid\cubrid.vcxproj]
  es.obj : error LNK2005: "unsigned char __cdecl std::_Load_acquire_1(unsigned char volatile *)" (?_Load_acquire_1@std@@YAEPECE@Z) already defined in thread_looper.obj [C:\Work\Cubrid\Github\upstream\build\cubrid\cubrid.vcxproj]
...

It seems to have something to do with atomic being included in log_impl.h. The current patch fixes it, although we still can't explain what was wrong in the first place.

Current patch includes two changes:
  1. Hide log_Clock_msec in log_manager.c and don't expose it. Atomic is removed from log_impl.h.
  2. Move logging functionality from es.c to vacuum.c.

Any one change of the two above would have fix the issue. However, I think both are good changes.