### PR TITLE
[CBRD-21937] disable error context/message logging

### DIFF
--- a/src/base/error_context.cpp
+++ b/src/base/error_context.cpp
@@ -165,8 +165,6 @@ namespace cuberr
   {
     if (msg_area != msg_buffer)
       {
-	_er_log_debug (ARG_FILE_LINE, "clear_message_area - delete msg_area = %p, size = %d", msg_area, msg_area_size);
-
 	delete [] msg_area;
 
 	msg_area = msg_buffer;

--- a/src/base/error_context.hpp
+++ b/src/base/error_context.hpp
@@ -80,8 +80,11 @@ namespace cuberr
 
       // constructor
       // automatic_registration - if true, registration/deregistration is handled during construct/destruct
-      // logging -
-      context (bool automatic_registration = false, bool logging = true);
+      // logging - if true, extensive logging is activated.
+      //           NOTE: "nested" logging is possible and er_Log_file_mutex may be locked twice causing a hang.
+      //                 fix this if you want to use the error context logging.
+      //
+      context (bool automatic_registration = false, bool logging = false);
 
       ~context ();
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21937

The hang is caused by double error log file mutex: one in er_final and once in nested logging for error context.

The logging of error context is only for debug and should be disabled anyway. However, if we ever want to reactivate it, the mutex issue must be tackled too.