### PR TITLE
[CBRD-21940] Fix reloading error manager for broker/cas

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1301,7 +1301,7 @@ net_server_start (const char *server_name)
   // this call looks unnecessary.
   // we can either remove this completely, or we can add an er_update to check if parameters are changed and do
   // whatever is necessary
-  if (er_init (prm_get_string_value (PRM_ID_ER_LOG_FILE), prm_get_integer_value (PRM_ID_ER_EXIT_ASK)) != NO_ERROR)
+  if (er_init (NULL, prm_get_integer_value (PRM_ID_ER_EXIT_ASK)) != NO_ERROR)
     {
       PRINT_AND_LOG_ERR_MSG ("Failed to initialize error manager\n");
       status = -1;

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -838,19 +838,11 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
       goto error;
     }
 
-  if (!er_is_initialized ())
+  // reload with update file name
+  if (er_init (prm_get_string_value (PRM_ID_ER_LOG_FILE), prm_get_integer_value (PRM_ID_ER_EXIT_ASK)) != NO_ERROR)
     {
-      // we really need to load error manager
-      // todo: this is kind of late; see an er_set few lines above.
-      //       on the other hand, this when we load the client parameters for this database and have the configured
-      //       for error log file path; however, sometimes we don't want to override the error log file, e.g. csql.err.
-      //       I am confused about what we are supposed to do here.
-      // assert (false);
-      if (er_init (prm_get_string_value (PRM_ID_ER_LOG_FILE), prm_get_integer_value (PRM_ID_ER_EXIT_ASK)) != NO_ERROR)
-	{
-	  assert_release (false);
-	  goto error;
-	}
+      assert_release (false);
+      goto error;
     }
 
   pr_Enable_string_compression = prm_get_bool_value (PRM_ID_ENABLE_STRING_COMPRESSION);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21940

Quick fix reloading error manager in boot_restart_client for broker/cas case.

Make "sticky" error manager initialization. If a specific file is given (name string is not NULL), the error manager initialization is considered sticky. A new er_init call is skipped.

This way, csql and utilities will keep their initial file as error log file, while broker/cas will be set in boot_restart_client.