### PR TITLE
[CBRD-21848] [CBRD-21849] [CBRD-21850] [CBRD-21851] page flush daemons migration

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -44,6 +44,9 @@
 #include "perf_monitor.h"
 #include "environment_variable.h"
 #include "thread.h"
+#include "thread_daemon.hpp"
+#include "thread_entry_task.hpp"
+#include "thread_manager.hpp"
 #include "list_file.h"
 #include "tsc_timer.h"
 #include "query_manager.h"
@@ -1094,7 +1097,7 @@ STATIC_INLINE int pgbuf_wakeup_uncond (THREAD_ENTRY * thread_p) __attribute__ ((
 STATIC_INLINE void pgbuf_set_dirty_buffer_ptr (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr)
   __attribute__ ((ALWAYS_INLINE));
 static int pgbuf_compare_victim_list (const void *p1, const void *p2);
-static void pgbuf_wakeup_flush_thread (THREAD_ENTRY * thread_p);
+static void pgbuf_wakeup_page_flush_daemon (THREAD_ENTRY * thread_p);
 STATIC_INLINE bool pgbuf_check_page_ptype_internal (PAGE_PTR pgptr, PAGE_TYPE ptype, bool no_error)
   __attribute__ ((ALWAYS_INLINE));
 #if defined (SERVER_MODE)
@@ -1203,6 +1206,20 @@ static void pgbuf_lru_sanity_check (const PGBUF_LRU_LIST * lru);
 
 // TODO: find a better place for this, but not log_impl.h
 STATIC_INLINE int pgbuf_find_current_wait_msecs (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
+
+#if defined (SERVER_MODE)
+// *INDENT-OFF*
+static cubthread::daemon *pgbuf_Page_maintenance_daemon = NULL;
+static cubthread::daemon *pgbuf_Page_flush_daemon = NULL;
+static cubthread::daemon *pgbuf_Page_post_flush_daemon = NULL;
+static cubthread::daemon *pgbuf_Flush_control_daemon = NULL;
+// *INDENT-ON*
+
+static void pgbuf_daemons_init ();
+static void pgbuf_daemons_destroy ();
+#endif /* SERVER_MODE */
+
+static bool pgbuf_is_page_flush_daemon_available ();
 
 /*
  * pgbuf_hash_func_mirror () - Hash VPID into hash anchor
@@ -1469,6 +1486,10 @@ pgbuf_initialize (void)
       goto error;
     }
 
+#if defined (SERVER_MODE)
+  pgbuf_daemons_init ();
+#endif /* SERVER_MODE */
+
   return NO_ERROR;
 
 error:
@@ -1491,6 +1512,10 @@ pgbuf_finalize (void)
   PGBUF_HOLDER_SET *holder_set;
   int i;
   size_t hash_size, j;
+
+#if defined (SERVER_MODE)
+  pgbuf_daemons_destroy ();
+#endif /* SERVER_MODE */
 
 #if defined(CUBRID_DEBUG)
   pgbuf_dump_if_any_fixed ();
@@ -3217,7 +3242,7 @@ pgbuf_flush_victim_candidates (THREAD_ENTRY * thread_p, float flush_ratio, PERF_
   er_log_debug (ARG_FILE_LINE, "pgbuf_flush_victim_candidates: start flush victim candidates\n");
 
 #if !defined(NDEBUG) && defined(SERVER_MODE)
-  if (thread_is_page_flush_thread_available ())
+  if (pgbuf_is_page_flush_daemon_available ())
     {
       if (page_flush_thread == NULL)
 	{
@@ -7390,7 +7415,7 @@ pgbuf_allocate_bcb (THREAD_ENTRY * thread_p, const VPID * src_vpid)
     }
 
 #if defined (SERVER_MODE)
-  if (thread_is_page_flush_thread_available ())
+  if (pgbuf_is_page_flush_daemon_available ())
     {
     retry:
       high_priority = high_priority || VACUUM_IS_THREAD_VACUUM (thread_p) || pgbuf_is_thread_high_priority (thread_p);
@@ -7447,7 +7472,8 @@ pgbuf_allocate_bcb (THREAD_ENTRY * thread_p, const VPID * src_vpid)
 	}
 
       /* make sure at least flush will feed us with bcb's. */
-      thread_try_wakeup_page_flush_thread ();
+      // before migration of the page_flush_daemon it was a try_wakeup, check if still needed
+      pgbuf_wakeup_page_flush_daemon (thread_p);
 
       r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_ALLOC_BCB_SUSPENDED);
 
@@ -7498,7 +7524,7 @@ pgbuf_allocate_bcb (THREAD_ENTRY * thread_p, const VPID * src_vpid)
   else
     {
       /* flush */
-      pgbuf_wakeup_flush_thread (thread_p);
+      pgbuf_wakeup_page_flush_daemon (thread_p);
 
       /* search lru lists again */
       bufptr = pgbuf_get_victim (thread_p);
@@ -8151,7 +8177,7 @@ pgbuf_get_victim (THREAD_ENTRY * thread_p)
 
   PGBUF_BCB *victim = NULL;
   bool detailed_perf = perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_PB_VICTIMIZATION);
-  bool has_flush_thread = thread_is_page_flush_thread_available ();
+  bool has_flush_thread = pgbuf_is_page_flush_daemon_available ();
   int nloops = 0;		/* used as safe-guard against infinite loops */
   int private_lru_idx;
   PGBUF_LRU_LIST *lru_list = NULL;
@@ -8493,10 +8519,10 @@ pgbuf_get_victim_from_lru_list (THREAD_ENTRY * thread_p, const int lru_idx)
 #endif /* SERVER_MODE */
 
 	      if (lru_list->bottom != NULL && pgbuf_bcb_is_dirty (lru_list->bottom)
-		  && thread_is_page_flush_thread_available ())
+		  && pgbuf_is_page_flush_daemon_available ())
 		{
 		  /* new bottom is dirty... make sure that flush will wake up */
-		  pgbuf_wakeup_flush_thread (thread_p);
+		  pgbuf_wakeup_page_flush_daemon (thread_p);
 		}
 	      pthread_mutex_unlock (&lru_list->mutex);
 
@@ -8512,7 +8538,7 @@ pgbuf_get_victim_from_lru_list (THREAD_ENTRY * thread_p, const int lru_idx)
       else
 	{
 	  /* failed try lock in single-threaded? impossible */
-	  assert (thread_is_page_flush_thread_available ());
+	  assert (pgbuf_is_page_flush_daemon_available ());
 
 	  /* save the avoid victim bufptr. maybe it will be reset until we finish the search */
 	  if (bufptr_victimizable == NULL)
@@ -8556,11 +8582,11 @@ pgbuf_get_victim_from_lru_list (THREAD_ENTRY * thread_p, const int lru_idx)
   pthread_mutex_unlock (&lru_list->mutex);
 
   /* we need more victims */
-  pgbuf_wakeup_flush_thread (thread_p);
+  pgbuf_wakeup_page_flush_daemon (thread_p);
   /* failed finding victim in single-threaded, although the number of victim candidates is positive? impossible!
    * note: not really impossible. the thread may have the victimizable fixed. but bufptr_victimizable must not be
    * NULL. */
-  assert (thread_is_page_flush_thread_available () || bufptr_victimizable != NULL || search_cnt == MAX_DEPTH);
+  assert (pgbuf_is_page_flush_daemon_available () || (bufptr_victimizable != NULL) || (search_cnt == MAX_DEPTH));
   return NULL;
 
 #undef PERF
@@ -9887,12 +9913,12 @@ pgbuf_bcb_flush_with_wal (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, bool is_p
 
 #if defined (SERVER_MODE)
   /* if the flush thread is under pressure, we'll move some of the workload to post-flush thread. */
-  if (is_page_flush_thread && thread_is_page_post_flush_thread_available ()
+  if (is_page_flush_thread && (pgbuf_Page_post_flush_daemon != NULL)
       && pgbuf_is_any_thread_waiting_for_direct_victim ()
       && lf_circular_queue_produce (pgbuf_Pool.flushed_bcbs, &bufptr))
     {
       /* page buffer maintenance thread will try to assign this bcb directly as victim. */
-      thread_wakeup_page_post_flush_thread ();
+      pgbuf_Page_post_flush_daemon->wakeup ();
       if (perfmon_is_perf_tracking_and_active (PERFMON_ACTIVE_PB_VICTIMIZATION))
 	{
 	  perfmon_inc_stat (thread_p, PSTAT_PB_FLUSH_SEND_DIRTY_TO_POST_FLUSH);
@@ -10980,24 +11006,24 @@ pgbuf_set_dirty_buffer_ptr (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr)
 }
 
 /*
- * pgbuf_wakeup_flush_thread () - Wakeup the flushing thread to flush some
+ * pgbuf_wakeup_page_flush_daemon () - Wakeup the flushing daemon thread to flush some
  *				  of the dirty pages in buffer pool to disk
  * return : void
  * thread_p (in) :
  */
 static void
-pgbuf_wakeup_flush_thread (THREAD_ENTRY * thread_p)
+pgbuf_wakeup_page_flush_daemon (THREAD_ENTRY * thread_p)
 {
-  PERF_UTIME_TRACKER dummy_time_tracker;
-  bool stop = false;
-
-#if defined(SERVER_MODE)
-  if (thread_is_page_flush_thread_available ())
+#if defined (SERVER_MODE)
+  if (pgbuf_is_page_flush_daemon_available ())
     {
-      thread_wakeup_page_flush_thread ();
+      pgbuf_Page_flush_daemon->wakeup ();
       return;
     }
 #endif
+
+  PERF_UTIME_TRACKER dummy_time_tracker;
+  bool stop = false;
 
   /* single-threaded environment. do flush on our own. */
   dummy_time_tracker.is_perf_tracking = false;
@@ -15838,4 +15864,307 @@ pgbuf_find_current_wait_msecs (THREAD_ENTRY * thread_p)
     {
       return 0;
     }
+}
+
+// *INDENT-OFF*
+#if defined (SERVER_MODE)
+// class pgbuf_page_maintenance_daemon_task
+//
+//  description:
+//    page maintenance daemon task
+//
+class pgbuf_page_maintenance_daemon_task : public cubthread::entry_task
+{
+  public:
+    void execute (cubthread::entry & thread_ref) override
+    {
+      if (!BO_IS_SERVER_RESTARTED ())
+	{
+	  // wait for boot to finish
+	  return;
+	}
+
+      /* page buffer maintenance thread adjust quota's based on thread activity. */
+      pgbuf_adjust_quotas (&thread_ref);
+
+      /* search lists and assign victims directly */
+      pgbuf_direct_victims_maintenance (&thread_ref);
+    }
+};
+#endif /* SERVER_MODE */
+
+#if defined (SERVER_MODE)
+// class pgbuf_page_flush_daemon_task
+//
+//  description:
+//    page flush daemon task
+//
+class pgbuf_page_flush_daemon_task : public cubthread::entry_task
+{
+  private:
+    bool m_force_one_run;
+    bool m_stop_iteration;
+    PERF_UTIME_TRACKER m_perf_track;
+
+  public:
+    pgbuf_page_flush_daemon_task ()
+      : m_force_one_run (false)
+      , m_stop_iteration (false)
+    {
+      PERF_UTIME_TRACKER_START (NULL, &m_perf_track);
+    }
+
+    void execute (cubthread::entry & thread_ref) override
+    {
+      if (!BO_IS_SERVER_RESTARTED ())
+	{
+	  // wait for boot to finish
+	  return;
+	}
+
+      /* flush pages as long as necessary */
+      while (m_force_one_run || pgbuf_keep_victim_flush_thread_running ())
+	{
+	  pgbuf_flush_victim_candidates (&thread_ref, prm_get_float_value (PRM_ID_PB_BUFFER_FLUSH_RATIO), &m_perf_track,
+					 &m_stop_iteration);
+	  m_force_one_run = false;
+	  if (m_stop_iteration)
+	    {
+	      break;
+	    }
+	}
+
+      /* did not timeout, someone requested flush... run at least once */
+      m_force_one_run = pgbuf_Page_flush_daemon->woke_up ();
+
+      /* performance tracking */
+      if (m_perf_track.is_perf_tracking)
+	{
+	  /* register sleep time. */
+	  PERF_UTIME_TRACKER_TIME_AND_RESTART (&thread_ref, &m_perf_track, PSTAT_PB_FLUSH_SLEEP);
+
+	  /* update is_perf_tracking */
+	  m_perf_track.is_perf_tracking = perfmon_is_perf_tracking ();
+	}
+      else
+	{
+	  /* update is_perf_tracking and start timer if it became true */
+	  PERF_UTIME_TRACKER_START (&thread_ref, &m_perf_track);
+	}
+    }
+};
+#endif /* SERVER_MODE */
+
+#if defined (SERVER_MODE)
+// class pgbuf_page_post_flush_daemon_task
+//
+//  description:
+//    page post flush daemon task
+//
+class pgbuf_page_post_flush_daemon_task : public cubthread::entry_task
+{
+  public:
+    void execute (cubthread::entry & thread_ref) override
+    {
+      if (!BO_IS_SERVER_RESTARTED ())
+	{
+	  // wait for boot to finish
+	  return;
+	}
+
+      /* assign flushed pages */
+      if (pgbuf_assign_flushed_pages (&thread_ref))
+	{
+	  /* reset daemon looper and be prepared to start over */
+	  pgbuf_Page_post_flush_daemon->reset_looper ();
+	}
+    }
+};
+#endif /* SERVER_MODE */
+
+#if defined (SERVER_MODE)
+// class pgbuf_flush_control_daemon_task
+//
+//  description:
+//    flush control daemon task
+//
+class pgbuf_flush_control_daemon_task : public cubthread::entry_task
+{
+  private:
+    struct timeval m_end;
+    bool m_first_run;
+
+  public:
+    pgbuf_flush_control_daemon_task ()
+      : m_end ({0, 0})
+      , m_first_run (true)
+    {
+    }
+
+    int initialize ()
+    {
+      return fileio_flush_control_initialize ();
+    }
+
+    void execute (cubthread::entry & thread_ref) override
+    {
+      if (!BO_IS_SERVER_RESTARTED ())
+	{
+	  // wait for boot to finish
+	  return;
+	}
+
+      if (m_first_run)
+	{
+	  gettimeofday (&m_end, NULL);
+	  m_first_run = false;
+	  return;
+	}
+      else
+	{
+	  struct timeval begin, diff;
+	  int token_gen, token_consumed;
+
+	  gettimeofday (&begin, NULL);
+	  DIFF_TIMEVAL (m_end, begin, diff);
+
+	  int64_t diff_usec = diff.tv_sec * 1000000LL + diff.tv_usec;
+
+	  fileio_flush_control_add_tokens (&thread_ref, diff_usec, &token_gen, &token_consumed);
+
+	  gettimeofday (&m_end, NULL);
+	}
+    }
+
+    void retire (void) override
+    {
+      fileio_flush_control_finalize ();
+      delete this;
+    }
+};
+#endif /* SERVER_MODE */
+
+#if defined (SERVER_MODE)
+/*
+ * pgbuf_page_maintenance_daemon_init () - initialize page maintenance daemon thread
+ */
+void
+pgbuf_page_maintenance_daemon_init ()
+{
+  assert (pgbuf_Page_maintenance_daemon == NULL);
+
+  auto looper_interval = std::chrono::milliseconds (100);
+  pgbuf_Page_maintenance_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (looper_interval),
+				  new pgbuf_page_maintenance_daemon_task ());
+}
+#endif /* SERVER_MODE */
+
+#if defined (SERVER_MODE)
+/*
+ * pgbuf_page_flush_daemon_init () - initialize page flush daemon thread
+ */
+void
+pgbuf_page_flush_daemon_init ()
+{
+  assert (pgbuf_Page_flush_daemon == NULL);
+
+  int page_bg_flush_interval_msecs = prm_get_integer_value (PRM_ID_PAGE_BG_FLUSH_INTERVAL_MSECS);
+
+  if (page_bg_flush_interval_msecs > 0)
+    {
+      auto looper_interval = std::chrono::milliseconds (page_bg_flush_interval_msecs);
+      pgbuf_Page_flush_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (looper_interval),
+				new pgbuf_page_flush_daemon_task ());
+    }
+  else
+    {
+      pgbuf_Page_flush_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (),
+				new pgbuf_page_flush_daemon_task ());
+    }
+}
+#endif /* SERVER_MODE */
+
+#if defined (SERVER_MODE)
+/*
+ * pgbuf_page_post_flush_daemon_init () - initialize page post flush daemon thread
+ */
+void
+pgbuf_page_post_flush_daemon_init ()
+{
+  assert (pgbuf_Page_post_flush_daemon == NULL);
+
+  std::array<std::chrono::milliseconds, 3> looper_interval {{
+      std::chrono::milliseconds (1),
+      std::chrono::milliseconds (10),
+      std::chrono::milliseconds (100)
+    }};
+
+  pgbuf_Page_post_flush_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (looper_interval),
+				  new pgbuf_page_post_flush_daemon_task ());
+}
+#endif /* SERVER_MODE */
+
+#if defined (SERVER_MODE)
+/*
+ * pgbuf_flush_control_daemon_init () - initialize flush control daemon thread
+ */
+void
+pgbuf_flush_control_daemon_init ()
+{
+  assert (pgbuf_Flush_control_daemon == NULL);
+
+  auto daemon_task = new pgbuf_flush_control_daemon_task ();
+
+  if (daemon_task->initialize () != NO_ERROR)
+    {
+      delete daemon_task;
+      return;
+    }
+
+  auto looper_interval = std::chrono::milliseconds (50);
+  pgbuf_Flush_control_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (looper_interval), daemon_task);
+}
+#endif /* SERVER_MODE */
+
+#if defined (SERVER_MODE)
+/*
+ * pgbuf_daemons_init () - initialize page buffer daemon threads
+ */
+static void
+pgbuf_daemons_init ()
+{
+  pgbuf_page_maintenance_daemon_init ();
+  pgbuf_page_flush_daemon_init ();
+  pgbuf_page_post_flush_daemon_init ();
+  pgbuf_flush_control_daemon_init ();
+}
+#endif /* SERVER_MODE */
+
+#if defined (SERVER_MODE)
+/*
+ * pgbuf_daemons_destroy () - destroy page buffer daemon threads
+ */
+static void
+pgbuf_daemons_destroy ()
+{
+  cubthread::get_manager ()->destroy_daemon (pgbuf_Page_maintenance_daemon);
+  cubthread::get_manager ()->destroy_daemon (pgbuf_Page_flush_daemon);
+  cubthread::get_manager ()->destroy_daemon (pgbuf_Page_post_flush_daemon);
+  cubthread::get_manager ()->destroy_daemon (pgbuf_Flush_control_daemon);
+}
+#endif /* SERVER_MODE */
+// *INDENT-OFF*
+
+/*
+ * pgbuf_is_page_flush_daemon_available () - check if page flush daemon is available
+ * return: true if page flush daemon is available, false otherwise
+ */
+static bool
+pgbuf_is_page_flush_daemon_available ()
+{
+#if defined (SERVER_MODE)
+  return pgbuf_Page_flush_daemon != NULL;
+#else
+  return false;
+#endif
 }

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -438,4 +438,10 @@ extern bool pgbuf_assign_flushed_pages (THREAD_ENTRY * thread_p);
 
 extern void pgbuf_notify_vacuum_follows (THREAD_ENTRY * thread_p, PAGE_PTR page);
 extern bool pgbuf_is_io_stressful (void);
+
+#if defined (SERVER_MODE)
+extern void pgbuf_daemons_init ();
+extern void pgbuf_daemons_destroy ();
+#endif /* SERVER_MODE */
+
 #endif /* _PAGE_BUFFER_H_ */

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -132,8 +132,6 @@ thread_get_thread_entry_info (void)
 
 #define thread_get_tran_entry(thread_p, entry_idx)  (&thread_ts_decoy_entries[entry_idx])
 
-#define thread_is_page_flush_thread_available()	(false)
-
 #else /* !SERVER_MODE */
 
 #define THREAD_GET_CURRENT_ENTRY_INDEX(thrd) \
@@ -304,17 +302,7 @@ extern struct css_conn_entry *thread_get_current_conn_entry (void);
 extern int thread_has_threads (THREAD_ENTRY * caller, int tran_index, int client_id);
 extern bool thread_set_check_interrupt (THREAD_ENTRY * thread_p, bool flag);
 
-/* wakeup functions */
 extern void thread_wakeup_log_flush_thread (void);
-extern void thread_wakeup_page_flush_thread (void);
-extern void thread_try_wakeup_page_flush_thread (void);
-extern void thread_wakeup_page_buffer_maintenance_thread (void);
-extern void thread_wakeup_page_post_flush_thread (void);
-extern void thread_wakeup_flush_control_thread (void);
-
-/* is available functions */
-extern bool thread_is_page_flush_thread_available (void);
-extern bool thread_is_page_post_flush_thread_available (void);
 extern bool thread_is_log_flush_thread_available (void);
 
 extern THREAD_ENTRY *thread_find_first_lockwait_entry (int *thrd_index);
@@ -323,12 +311,9 @@ extern THREAD_ENTRY *thread_find_entry_by_index (int thrd_index);
 extern THREAD_ENTRY *thread_find_entry_by_tid (thread_id_t thrd_id);
 extern int thread_get_lockwait_entry (int tran_index, THREAD_ENTRY ** array);
 
-
 extern int thread_suspend_with_other_mutex (THREAD_ENTRY * p, pthread_mutex_t * mutexp, int timeout,
 					    struct timespec *to, int suspended_reason);
-extern void thread_print_entry_info (THREAD_ENTRY * p);
 extern int thread_return_all_transactions_entries (void);
-extern void thread_dump_threads (void);
 extern bool thread_get_check_interrupt (THREAD_ENTRY * thread_p);
 
 extern int xthread_kill_tran_index (THREAD_ENTRY * thread_p, int kill_tran_index, char *kill_user, char *kill_host,

--- a/src/thread/thread_daemon.cpp
+++ b/src/thread/thread_daemon.cpp
@@ -63,9 +63,9 @@ namespace cubthread
   }
 
   bool
-  daemon::woke_up (void)
+  daemon::was_woken_up (void)
   {
-    return m_looper.woke_up ();
+    return m_looper.was_woken_up ();
   }
 
   void

--- a/src/thread/thread_daemon.cpp
+++ b/src/thread/thread_daemon.cpp
@@ -62,4 +62,16 @@ namespace cubthread
     m_looper.put_to_sleep (m_waiter);
   }
 
+  bool
+  daemon::woke_up (void)
+  {
+    return m_looper.woke_up ();
+  }
+
+  void
+  daemon::reset_looper (void)
+  {
+    m_looper.reset ();
+  }
+
 } // namespace cubthread

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -85,9 +85,14 @@ namespace cubthread
 	      task<Context> *exec);
       ~daemon();
 
-      void wakeup (void);     // wakeup daemon thread
-      void stop_execution (void);       // stop_execution daemon thread from looping and join it
+      void wakeup (void);         // wakeup daemon thread
+      void stop_execution (void); // stop_execution daemon thread from looping and join it
       // note: this must not be called concurrently
+
+      bool woke_up (void);        // return true if daemon woke up before time out
+
+      void reset_looper (void);   // reset looper
+      // note: this applies only if looper wait pattern is of type INCREASING_PERIODS
 
     private:
       template <typename Context>

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -89,7 +89,7 @@ namespace cubthread
       void stop_execution (void); // stop_execution daemon thread from looping and join it
       // note: this must not be called concurrently
 
-      bool woke_up (void);        // return true if daemon woke up before time out
+      bool was_woken_up (void);   // return true if daemon was woken up before timeout
 
       void reset_looper (void);   // reset looper
       // note: this applies only if looper wait pattern is of type INCREASING_PERIODS

--- a/src/thread/thread_looper.cpp
+++ b/src/thread/thread_looper.cpp
@@ -35,6 +35,7 @@ namespace cubthread
     , m_periods_count (0)
     , m_period_index (0)
     , m_stop (false)
+    , m_woke_up (false)
   {
     // infinite waits
   }
@@ -45,14 +46,18 @@ namespace cubthread
     , m_periods ()
     , m_period_index (0)
     , m_stop (false)
+    , m_woke_up (false)
   {
-    *this->m_periods = *other.m_periods;
+    for (std::size_t i = 0; i < m_periods_count; i++)
+      {
+	this->m_periods[i] = other.m_periods[i];
+      }
   }
 
   void
   looper::put_to_sleep (waiter &waiter_arg)
   {
-    bool timeout = false;
+    m_woke_up = false;
 
     if (is_stopped ())
       {
@@ -64,17 +69,18 @@ namespace cubthread
       {
 	assert (m_period_index == m_periods_count);
 	waiter_arg.wait_inf ();
+	m_woke_up = true;
       }
     else
       {
-	timeout = !waiter_arg.wait_for (m_periods[m_period_index]);
+	m_woke_up = waiter_arg.wait_for (m_periods[m_period_index]);
       }
     if (m_wait_pattern == wait_pattern::FIXED_PERIODS || m_wait_pattern == wait_pattern::INFINITE_WAITS)
       {
 	assert (m_period_index == 0);
 	return;
       }
-    if (timeout)
+    if (!m_woke_up)
       {
 	/* increment */
 	++m_period_index;
@@ -103,6 +109,12 @@ namespace cubthread
   looper::is_stopped (void) const
   {
     return m_stop;
+  }
+
+  bool
+  looper::woke_up (void) const
+  {
+    return m_woke_up;
   }
 
 } // namespace cubthread

--- a/src/thread/thread_looper.cpp
+++ b/src/thread/thread_looper.cpp
@@ -35,7 +35,7 @@ namespace cubthread
     , m_periods_count (0)
     , m_period_index (0)
     , m_stop (false)
-    , m_woke_up (false)
+    , m_was_woken_up (false)
   {
     // infinite waits
   }
@@ -46,7 +46,7 @@ namespace cubthread
     , m_periods ()
     , m_period_index (0)
     , m_stop (false)
-    , m_woke_up (false)
+    , m_was_woken_up (false)
   {
     for (std::size_t i = 0; i < m_periods_count; i++)
       {
@@ -57,8 +57,6 @@ namespace cubthread
   void
   looper::put_to_sleep (waiter &waiter_arg)
   {
-    m_woke_up = false;
-
     if (is_stopped ())
       {
 	// stopped; don't put to sleep
@@ -69,18 +67,18 @@ namespace cubthread
       {
 	assert (m_period_index == m_periods_count);
 	waiter_arg.wait_inf ();
-	m_woke_up = true;
+	m_was_woken_up = true;
       }
     else
       {
-	m_woke_up = waiter_arg.wait_for (m_periods[m_period_index]);
+	m_was_woken_up = waiter_arg.wait_for (m_periods[m_period_index]);
       }
     if (m_wait_pattern == wait_pattern::FIXED_PERIODS || m_wait_pattern == wait_pattern::INFINITE_WAITS)
       {
 	assert (m_period_index == 0);
 	return;
       }
-    if (!m_woke_up)
+    if (!m_was_woken_up)
       {
 	/* increment */
 	++m_period_index;
@@ -112,9 +110,9 @@ namespace cubthread
   }
 
   bool
-  looper::woke_up (void) const
+  looper::was_woken_up (void) const
   {
-    return m_woke_up;
+    return m_was_woken_up;
   }
 
 } // namespace cubthread

--- a/src/thread/thread_looper.hpp
+++ b/src/thread/thread_looper.hpp
@@ -108,6 +108,9 @@ namespace cubthread
       // is looper stopped
       bool is_stopped (void) const;
 
+      // return true if woke up before time out
+      bool woke_up (void) const;
+
     private:
 
       // definitions
@@ -125,6 +128,7 @@ namespace cubthread
 
       std::size_t m_period_index;           // current period index
       std::atomic<bool> m_stop;             // when true, loop is stopped; no waits
+      std::atomic<bool> m_woke_up;
   };
 
   /************************************************************************/
@@ -142,6 +146,7 @@ namespace cubthread
 #endif
     , m_period_index (0)
     , m_stop (false)
+    , m_woke_up (false)
   {
     // fixed period waits
 #if !defined (NO_GCC_44)
@@ -156,6 +161,7 @@ namespace cubthread
     , m_periods {}
     , m_period_index (0)
     , m_stop (false)
+    , m_woke_up (false)
   {
     static_assert (Count <= MAX_LOOPER_PERIODS, "Count template cannot exceed MAX_LOOPER_PERIODS=3");
     m_periods_count = std::min (Count, MAX_LOOPER_PERIODS);

--- a/src/thread/thread_looper.hpp
+++ b/src/thread/thread_looper.hpp
@@ -108,8 +108,8 @@ namespace cubthread
       // is looper stopped
       bool is_stopped (void) const;
 
-      // return true if woke up before time out
-      bool woke_up (void) const;
+      // return true if waiter was woken up before timeout, for more details see put_to_sleep (waiter &)
+      bool was_woken_up (void) const;
 
     private:
 
@@ -126,9 +126,9 @@ namespace cubthread
       std::size_t m_periods_count;              // the period count
       delta_time m_periods[MAX_LOOPER_PERIODS]; // period array
 
-      std::size_t m_period_index;           // current period index
-      std::atomic<bool> m_stop;             // when true, loop is stopped; no waits
-      std::atomic<bool> m_woke_up;
+      std::atomic<std::size_t> m_period_index;  // current period index
+      std::atomic<bool> m_stop;                 // when true, loop is stopped; no waits
+      std::atomic<bool> m_was_woken_up;         // when true, waiter was woken up before timeout
   };
 
   /************************************************************************/
@@ -146,7 +146,7 @@ namespace cubthread
 #endif
     , m_period_index (0)
     , m_stop (false)
-    , m_woke_up (false)
+    , m_was_woken_up (false)
   {
     // fixed period waits
 #if !defined (NO_GCC_44)
@@ -161,7 +161,7 @@ namespace cubthread
     , m_periods {}
     , m_period_index (0)
     , m_stop (false)
-    , m_woke_up (false)
+    , m_was_woken_up (false)
   {
     static_assert (Count <= MAX_LOOPER_PERIODS, "Count template cannot exceed MAX_LOOPER_PERIODS=3");
     m_periods_count = std::min (Count, MAX_LOOPER_PERIODS);

--- a/src/thread/thread_waiter.hpp
+++ b/src/thread/thread_waiter.hpp
@@ -66,8 +66,7 @@ namespace cubthread
       // returns true if woke up before timeout
       template< class Clock, class Duration >
       bool wait_until (std::chrono::time_point<Clock, Duration> &timeout_time); // wait until time or until wakeup
-      // returns true if woke up before
-      // timeout
+      // returns true if woke up before timeout
 
     private:
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2439,6 +2439,10 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 
   log_initialize (thread_p, boot_Db_full_name, log_path, log_prefix, from_backup, r_args);
 
+#if defined(SERVER_MODE)
+  pgbuf_daemons_init ();
+#endif /* SERVER_MODE */
+
   // after recovery we can boot vacuum
   error_code = vacuum_boot (thread_p);
   if (error_code != NO_ERROR)
@@ -2751,6 +2755,11 @@ error:
   logtb_finalize_global_unique_stats_table (thread_p);
 
   vacuum_stop (thread_p);
+
+#if defined(SERVER_MODE)
+  pgbuf_daemons_destroy ();
+#endif
+
   log_final (thread_p);
   fpcache_finalize (thread_p);
   qfile_finalize_list_cache (thread_p);
@@ -2890,6 +2899,7 @@ xboot_shutdown_server (THREAD_ENTRY * thread_p, ER_FINAL_CODE is_er_final)
       (void) boot_remove_all_temp_volumes (thread_p, REMOVE_TEMP_VOL_DEFAULT_ACTION);
 
 #if defined(SERVER_MODE)
+      pgbuf_daemons_destroy ();
       thread_stop_active_daemons ();
 #endif
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10283,12 +10283,12 @@ log_wakeup_checkpoint_daemon ()
 
 // *INDENT-OFF*
 #if defined(SERVER_MODE)
-// class checkpoint_daemon_task
+// class log_checkpoint_daemon_task
 //
 //  description:
-//    checkpoint daemon task
+//    log checkpoint daemon task
 //
-class checkpoint_daemon_task : public cubthread::entry_task
+class log_checkpoint_daemon_task : public cubthread::entry_task
 {
   public:
     void execute (cubthread::entry & thread_ref) override
@@ -10305,22 +10305,22 @@ class checkpoint_daemon_task : public cubthread::entry_task
 #endif /* SERVER_MODE */
 
 #if defined(SERVER_MODE)
-// class remove_log_archive_daemon_task
+// class log_remove_log_archive_daemon_task
 //
 //  constructor args:
 //    archive_logs_to_delete : represents number of how many archive logs should be deleted by daemon task,
 //                             which must be dependent of PRM_ID_REMOVE_LOG_ARCHIVES_INTERVAL param value
 //
 //  description:
-//    purge archive logs daemon task
+//    remove archive logs daemon task
 //
-class remove_log_archive_daemon_task : public cubthread::entry_task
+class log_remove_log_archive_daemon_task : public cubthread::entry_task
 {
   private:
     int m_archive_logs_to_delete;
 
   public:
-    explicit remove_log_archive_daemon_task (int archive_logs_to_delete)
+    explicit log_remove_log_archive_daemon_task (int archive_logs_to_delete)
     {
       this->m_archive_logs_to_delete = archive_logs_to_delete;
     }
@@ -10469,7 +10469,7 @@ log_checkpoint_daemon_init ()
   // create checkpoint daemon thread
   auto looper_interval = std::chrono::seconds (prm_get_integer_value (PRM_ID_LOG_CHECKPOINT_INTERVAL_SECS));
   log_Checkpoint_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (looper_interval),
-			  new checkpoint_daemon_task ());
+			  new log_checkpoint_daemon_task ());
 }
 #endif /* SERVER_MODE */
 
@@ -10491,13 +10491,13 @@ log_remove_log_archive_daemon_init ()
       // if interval is greater than 0 (zero) then on every loop remove one log archive
       log_Remove_log_archive_daemon = cubthread::get_manager ()->create_daemon (
 					      cubthread::looper (std::chrono::seconds (remove_log_archive_interval)),
-					      new remove_log_archive_daemon_task (1));
+					      new log_remove_log_archive_daemon_task (1));
     }
   else
     {
       // if interval is equal to 0 (zero) then on wakeup remove all log archive records
       log_Remove_log_archive_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (),
-				      new remove_log_archive_daemon_task (0));
+				      new log_remove_log_archive_daemon_task (0));
     }
 }
 #endif /* SERVER_MODE */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21848
http://jira.cubrid.org/browse/CBRD-21849
http://jira.cubrid.org/browse/CBRD-21850
http://jira.cubrid.org/browse/CBRD-21851

This patch includes migration of:
- [CBRD-21848](http://jira.cubrid.org/browse/CBRD-21848) page buffer maintenance daemon
- [CBRD-21849](http://jira.cubrid.org/browse/CBRD-21849) page flush daemon
- [CBRD-21850](http://jira.cubrid.org/browse/CBRD-21850) page post flush daemon
- [CBRD-21851](http://jira.cubrid.org/browse/CBRD-21851) flush control daemon