### PR TITLE
[CBRD-21852] migrate log flush daemon thread to new API

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -945,25 +945,18 @@ static void *server_shm_open (int shm_key);
 #endif /* WINDOWS */
 
 T_DIAG_OBJECT_TABLE diag_obj_list[] = {
-  {"open_page", DIAG_OBJ_TYPE_QUERY_OPEN_PAGE, diag_val_set_query_open_page}
-  , {"opened_page", DIAG_OBJ_TYPE_QUERY_OPENED_PAGE,
-     diag_val_set_query_opened_page}
-  , {"slow_query", DIAG_OBJ_TYPE_QUERY_SLOW_QUERY,
-     diag_val_set_query_slow_query}
-  , {"full_scan", DIAG_OBJ_TYPE_QUERY_FULL_SCAN, diag_val_set_query_full_scan}
-  , {"cli_request", DIAG_OBJ_TYPE_CONN_CLI_REQUEST,
-     diag_val_set_conn_cli_request}
-  , {"aborted_client", DIAG_OBJ_TYPE_CONN_ABORTED_CLIENTS,
-     diag_val_set_conn_aborted_clients}
-  , {"conn_req", DIAG_OBJ_TYPE_CONN_CONN_REQ, diag_val_set_conn_conn_req}
-  , {"conn_reject", DIAG_OBJ_TYPE_CONN_CONN_REJECT,
-     diag_val_set_conn_conn_reject}
-  , {"buffer_page_read", DIAG_OBJ_TYPE_BUFFER_PAGE_READ,
-     diag_val_set_buffer_page_read}
-  , {"buffer_page_write", DIAG_OBJ_TYPE_BUFFER_PAGE_WRITE,
-     diag_val_set_buffer_page_write}
-  , {"lock_deadlock", DIAG_OBJ_TYPE_LOCK_DEADLOCK, diag_val_set_lock_deadlock}
-  , {"lock_request", DIAG_OBJ_TYPE_LOCK_REQUEST, diag_val_set_lock_request}
+  {"open_page", DIAG_OBJ_TYPE_QUERY_OPEN_PAGE, diag_val_set_query_open_page},
+  {"opened_page", DIAG_OBJ_TYPE_QUERY_OPENED_PAGE, diag_val_set_query_opened_page},
+  {"slow_query", DIAG_OBJ_TYPE_QUERY_SLOW_QUERY, diag_val_set_query_slow_query},
+  {"full_scan", DIAG_OBJ_TYPE_QUERY_FULL_SCAN, diag_val_set_query_full_scan},
+  {"cli_request", DIAG_OBJ_TYPE_CONN_CLI_REQUEST, diag_val_set_conn_cli_request},
+  {"aborted_client", DIAG_OBJ_TYPE_CONN_ABORTED_CLIENTS, diag_val_set_conn_aborted_clients},
+  {"conn_req", DIAG_OBJ_TYPE_CONN_CONN_REQ, diag_val_set_conn_conn_req},
+  {"conn_reject", DIAG_OBJ_TYPE_CONN_CONN_REJECT, diag_val_set_conn_conn_reject},
+  {"buffer_page_read", DIAG_OBJ_TYPE_BUFFER_PAGE_READ, diag_val_set_buffer_page_read},
+  {"buffer_page_write", DIAG_OBJ_TYPE_BUFFER_PAGE_WRITE, diag_val_set_buffer_page_write},
+  {"lock_deadlock", DIAG_OBJ_TYPE_LOCK_DEADLOCK, diag_val_set_lock_deadlock},
+  {"lock_request", DIAG_OBJ_TYPE_LOCK_REQUEST, diag_val_set_lock_request}
 };
 
 /* function definition */

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -1375,7 +1375,7 @@ extern bool set_diag_value (T_DIAG_OBJ_TYPE type, int value, T_DIAG_VALUE_SETTYP
 #endif /* DIAG_DEVEL */
 
 STATIC_INLINE void
-perfmon_diff_timeval (struct timeval start, struct timeval end, struct timeval *elapsed)
+perfmon_diff_timeval (struct timeval *elapsed, struct timeval start, struct timeval end)
 {
   elapsed->tv_sec = end.tv_sec - start.tv_sec;
   elapsed->tv_usec = end.tv_usec - start.tv_usec;

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -1345,7 +1345,7 @@ struct t_diag_object_table
     do {                                                                                 \
         if (DIAG_EXEC_FLAG == true) {                                                 \
             struct timeval result = {0,0};                                               \
-            ADD_TIMEVAL(result, START_TIME, END_TIME);                                   \
+            ADD_TIMEVAL(&result, START_TIME, END_TIME);                                   \
             if (result.tv_sec >= diag_long_query_time)                                   \
                 set_diag_value(DIAG_OBJ_TYPE_QUERY_SLOW_QUERY, VALUE, SET_TYPE, ERR_BUF);\
         }                                                                                \
@@ -1374,32 +1374,33 @@ extern bool set_diag_value (T_DIAG_OBJ_TYPE type, int value, T_DIAG_VALUE_SETTYP
 #endif /* SERVER_MODE */
 #endif /* DIAG_DEVEL */
 
-#ifndef DIFF_TIMEVAL
-#define DIFF_TIMEVAL(start, end, elapsed) \
-    do { \
-      (elapsed).tv_sec = (end).tv_sec - (start).tv_sec; \
-      (elapsed).tv_usec = (end).tv_usec - (start).tv_usec; \
-      if ((elapsed).tv_usec < 0) \
-        { \
-          (elapsed).tv_sec--; \
-          (elapsed).tv_usec += 1000000; \
-        } \
-    } while (0)
-#endif
+STATIC_INLINE void
+perfmon_diff_timeval (struct timeval start, struct timeval end, struct timeval *elapsed)
+{
+  elapsed->tv_sec = end.tv_sec - start.tv_sec;
+  elapsed->tv_usec = end.tv_usec - start.tv_usec;
 
-#define ADD_TIMEVAL(total, start, end) do {     \
-  total.tv_usec +=                              \
-    (end.tv_usec - start.tv_usec) >= 0 ?        \
-      (end.tv_usec-start.tv_usec)               \
-    : (1000000 + (end.tv_usec-start.tv_usec));  \
-  total.tv_sec +=                               \
-    (end.tv_usec - start.tv_usec) >= 0 ?        \
-      (end.tv_sec-start.tv_sec)                 \
-    : (end.tv_sec-start.tv_sec-1);              \
-  total.tv_sec +=                               \
-    total.tv_usec/1000000;                      \
-  total.tv_usec %= 1000000;                     \
-} while(0)
+  if (elapsed->tv_usec < 0)
+    {
+      elapsed->tv_sec--;
+      elapsed->tv_usec += 1000000;
+    }
+}
+
+#define DIFF_TIMEVAL perfmon_diff_timeval
+
+STATIC_INLINE void
+perform_add_timeval (struct timeval *total, struct timeval start, struct timeval end)
+{
+  total->tv_usec +=
+    (end.tv_usec - start.tv_usec) >= 0 ? (end.tv_usec - start.tv_usec) : (1000000 + (end.tv_usec - start.tv_usec));
+  total->tv_sec += (end.tv_usec - start.tv_usec) >= 0 ? (end.tv_sec - start.tv_sec) : (end.tv_sec - start.tv_sec - 1);
+
+  total->tv_sec += total->tv_usec / 1000000;
+  total->tv_usec %= 1000000;
+}
+
+#define ADD_TIMEVAL perform_add_timeval
 
 #define TO_MSEC(elapsed) \
   ((int)(((elapsed).tv_sec * 1000) + (int) ((elapsed).tv_usec / 1000)))

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -816,6 +816,11 @@ STATIC_INLINE int perfmon_get_activation_flag (void) __attribute__ ((ALWAYS_INLI
 extern char *perfmon_pack_stats (char *buf, UINT64 * stats);
 extern char *perfmon_unpack_stats (char *buf, UINT64 * stats);
 
+STATIC_INLINE void perfmon_diff_timeval (struct timeval *elapsed, struct timeval *start, struct timeval *end)
+  __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void perfmon_add_timeval (struct timeval *total, struct timeval *start, struct timeval *end)
+  __attribute__ ((ALWAYS_INLINE));
+
 #ifdef __cplusplus
 /* TODO: it looks ugly now, but it should be fixed with stat tool patch */
 
@@ -1326,44 +1331,58 @@ struct t_diag_object_table
   T_DO_FUNC func;
 };
 
-/* MACRO definition */
-#define SET_DIAG_VALUE(DIAG_EXEC_FLAG, ITEM_TYPE, VALUE, SET_TYPE, ERR_BUF)          \
-    do {                                                                             \
-        if (DIAG_EXEC_FLAG == true) {                                             \
-            set_diag_value(ITEM_TYPE , VALUE, SET_TYPE, ERR_BUF);                    \
-        }                                                                            \
-    } while(0)
+STATIC_INLINE void perfmon_diag_set_value (bool diag_exec_flag, T_DIAG_OBJ_TYPE item_type, int value,
+					   T_DIAG_VALUE_SETTYPE set_type, char *err_buf)
+  __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void perfmon_diag_set_slow_query (bool diag_exec_flag, struct timeval *start_time,
+						struct timeval *end_time, char *err_buf)
+  __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void perfmon_diag_set_full_scan (bool diag_exec_flag, char *err_buf, XASL_NODE * xasl,
+					       ACCESS_SPEC_TYPE * spec) __attribute__ ((ALWAYS_INLINE));
 
-#define DIAG_GET_TIME(DIAG_EXEC_FLAG, TIMER)                                         \
-    do {                                                                             \
-        if (DIAG_EXEC_FLAG == true) {                                             \
-            gettimeofday(&TIMER, NULL);                                              \
-        }                                                                            \
-    } while(0)
+STATIC_INLINE void
+perfmon_diag_set_value (bool diag_exec_flag, T_DIAG_OBJ_TYPE item_type, int value, T_DIAG_VALUE_SETTYPE set_type,
+			char *err_buf)
+{
+  if (diag_exec_flag == false)
+    {
+      return;
+    }
 
-#define SET_DIAG_VALUE_SLOW_QUERY(DIAG_EXEC_FLAG, START_TIME, END_TIME, VALUE, SET_TYPE, ERR_BUF)\
-    do {                                                                                 \
-        if (DIAG_EXEC_FLAG == true) {                                                 \
-            struct timeval result = {0,0};                                               \
-            ADD_TIMEVAL(&result, START_TIME, END_TIME);                                   \
-            if (result.tv_sec >= diag_long_query_time)                                   \
-                set_diag_value(DIAG_OBJ_TYPE_QUERY_SLOW_QUERY, VALUE, SET_TYPE, ERR_BUF);\
-        }                                                                                \
-    } while(0)
+  set_diag_value (item_type, value, set_type, err_buf);
+}
 
-#define SET_DIAG_VALUE_FULL_SCAN(DIAG_EXEC_FLAG, VALUE, SET_TYPE, ERR_BUF, XASL, SPECP) \
-    do {                                                                                \
-        if (DIAG_EXEC_FLAG == true) {                                                \
-            if (((XASL_TYPE(XASL) == BUILDLIST_PROC) ||                                 \
-                 (XASL_TYPE(XASL) == BUILDVALUE_PROC))                                  \
-                && ACCESS_SPEC_ACCESS(SPECP) == SEQUENTIAL) {                           \
-                set_diag_value(DIAG_OBJ_TYPE_QUERY_FULL_SCAN                            \
-                        , 1                                                             \
-                        , DIAG_VAL_SETTYPE_INC                                          \
-                        , NULL);                                                        \
-            }                                                                           \
-        }                                                                               \
-    } while(0)
+STATIC_INLINE void
+perfmon_diag_set_slow_query (bool diag_exec_flag, struct timeval *start_time, struct timeval *end_time, char *err_buf)
+{
+  struct timeval result = { 0, 0 };
+
+  if (diag_exec_flag == false)
+    {
+      return;
+    }
+
+  perfmon_add_timeval (&result, start_time, end_time);
+  if (result.tv_sec >= diag_long_query_time)
+    {
+      set_diag_value (DIAG_OBJ_TYPE_QUERY_SLOW_QUERY, 1, DIAG_VAL_SETTYPE_INC, err_buf);
+    }
+}
+
+STATIC_INLINE void
+perfmon_diag_set_full_scan (bool diag_exec_flag, char *err_buf, XASL_NODE * xasl, ACCESS_SPEC_TYPE * spec)
+{
+  if (diag_exec_flag == false)
+    {
+      return;
+    }
+
+  if ((XASL_TYPE (xasl) == BUILDLIST_PROC || XASL_TYPE (xasl) == BUILDVALUE_PROC)
+      && ACCESS_SPEC_ACCESS (spec) == SEQUENTIAL)
+    {
+      set_diag_value (DIAG_OBJ_TYPE_QUERY_FULL_SCAN, 1, DIAG_VAL_SETTYPE_INC, err_buf);
+    }
+}
 
 extern int diag_long_query_time;
 extern bool diag_executediag;
@@ -1375,10 +1394,10 @@ extern bool set_diag_value (T_DIAG_OBJ_TYPE type, int value, T_DIAG_VALUE_SETTYP
 #endif /* DIAG_DEVEL */
 
 STATIC_INLINE void
-perfmon_diff_timeval (struct timeval *elapsed, struct timeval start, struct timeval end)
+perfmon_diff_timeval (struct timeval *elapsed, struct timeval *start, struct timeval *end)
 {
-  elapsed->tv_sec = end.tv_sec - start.tv_sec;
-  elapsed->tv_usec = end.tv_usec - start.tv_usec;
+  elapsed->tv_sec = end->tv_sec - start->tv_sec;
+  elapsed->tv_usec = end->tv_usec - start->tv_usec;
 
   if (elapsed->tv_usec < 0)
     {
@@ -1387,20 +1406,23 @@ perfmon_diff_timeval (struct timeval *elapsed, struct timeval start, struct time
     }
 }
 
-#define DIFF_TIMEVAL perfmon_diff_timeval
-
 STATIC_INLINE void
-perform_add_timeval (struct timeval *total, struct timeval start, struct timeval end)
+perfmon_add_timeval (struct timeval *total, struct timeval *start, struct timeval *end)
 {
-  total->tv_usec +=
-    (end.tv_usec - start.tv_usec) >= 0 ? (end.tv_usec - start.tv_usec) : (1000000 + (end.tv_usec - start.tv_usec));
-  total->tv_sec += (end.tv_usec - start.tv_usec) >= 0 ? (end.tv_sec - start.tv_sec) : (end.tv_sec - start.tv_sec - 1);
+  if (end->tv_usec - start->tv_usec >= 0)
+    {
+      total->tv_usec += end->tv_usec - start->tv_usec;
+      total->tv_sec += end->tv_sec - start->tv_sec;
+    }
+  else
+    {
+      total->tv_usec += 1000000 + (end->tv_usec - start->tv_usec);
+      total->tv_sec += end->tv_sec - start->tv_sec - 1;
+    }
 
   total->tv_sec += total->tv_usec / 1000000;
   total->tv_usec %= 1000000;
 }
-
-#define ADD_TIMEVAL perform_add_timeval
 
 #define TO_MSEC(elapsed) \
   ((int)(((elapsed).tv_sec * 1000) + (int) ((elapsed).tv_usec / 1000)))

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -3194,7 +3194,7 @@ sboot_register_client (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
   client_isolation = (TRAN_ISOLATION) xint;
 
 #if defined(DIAG_DEVEL) && defined(SERVER_MODE)
-  SET_DIAG_VALUE (diag_executediag, DIAG_OBJ_TYPE_CONN_CONN_REQ, 1, DIAG_VAL_SETTYPE_INC, NULL);
+  perfmon_diag_set_value (diag_executediag, DIAG_OBJ_TYPE_CONN_CONN_REQ, 1, DIAG_VAL_SETTYPE_INC, NULL);
 #endif
 
   tran_index = xboot_register_client (thread_p, &client_credential, client_lock_wait, client_isolation, &tran_state,
@@ -3202,7 +3202,7 @@ sboot_register_client (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
   if (tran_index == NULL_TRAN_INDEX)
     {
 #if defined(DIAG_DEVEL) && defined(SERVER_MODE)
-      SET_DIAG_VALUE (diag_executediag, DIAG_OBJ_TYPE_CONN_CONN_REJECT, 1, DIAG_VAL_SETTYPE_INC, NULL);
+      perfmon_diag_set_value (diag_executediag, DIAG_OBJ_TYPE_CONN_CONN_REJECT, 1, DIAG_VAL_SETTYPE_INC, NULL);
 #endif
       return_error_to_client (thread_p, rid);
       area = NULL;

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1055,7 +1055,7 @@ net_server_request (THREAD_ENTRY * thread_p, unsigned int rid, int request, int 
   if (net_Requests[request].action_attribute & SET_DIAGNOSTICS_INFO)
     {
       gettimeofday (&diag_end_time, NULL);
-      DIFF_TIMEVAL (diag_start_time, diag_end_time, diag_elapsed_time);
+      DIFF_TIMEVAL (diag_start_time, diag_end_time, &diag_elapsed_time);
       if (request == NET_SERVER_QM_QUERY_EXECUTE || request == NET_SERVER_QM_QUERY_PREPARE_AND_EXECUTE)
 	{
 	  SET_DIAG_VALUE_SLOW_QUERY (diag_executediag, diag_start_time, diag_end_time, 1, DIAG_VAL_SETTYPE_INC, NULL);

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1010,7 +1010,7 @@ net_server_request (THREAD_ENTRY * thread_p, unsigned int rid, int request, int 
 #if defined (DIAG_DEVEL)
   if (net_Requests[request].action_attribute & SET_DIAGNOSTICS_INFO)
     {
-      SET_DIAG_VALUE (diag_executediag, DIAG_OBJ_TYPE_CONN_CLI_REQUEST, 1, DIAG_VAL_SETTYPE_INC, NULL);
+      perfmon_diag_set_value (diag_executediag, DIAG_OBJ_TYPE_CONN_CLI_REQUEST, 1, DIAG_VAL_SETTYPE_INC, NULL);
       gettimeofday (&diag_start_time, NULL);
     }
 #endif /* DIAG_DEVEL */
@@ -1055,10 +1055,10 @@ net_server_request (THREAD_ENTRY * thread_p, unsigned int rid, int request, int 
   if (net_Requests[request].action_attribute & SET_DIAGNOSTICS_INFO)
     {
       gettimeofday (&diag_end_time, NULL);
-      perfmon_diff_timeval (&diag_elapsed_time, diag_start_time, diag_end_time);
+      perfmon_diff_timeval (&diag_elapsed_time, &diag_start_time, &diag_end_time);
       if (request == NET_SERVER_QM_QUERY_EXECUTE || request == NET_SERVER_QM_QUERY_PREPARE_AND_EXECUTE)
 	{
-	  SET_DIAG_VALUE_SLOW_QUERY (diag_executediag, diag_start_time, diag_end_time, 1, DIAG_VAL_SETTYPE_INC, NULL);
+	  perfmon_diag_set_slow_query (diag_executediag, &diag_start_time, &diag_end_time, NULL);
 	}
     }
 #endif /* DIAG_DEVEL */

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1055,7 +1055,7 @@ net_server_request (THREAD_ENTRY * thread_p, unsigned int rid, int request, int 
   if (net_Requests[request].action_attribute & SET_DIAGNOSTICS_INFO)
     {
       gettimeofday (&diag_end_time, NULL);
-      DIFF_TIMEVAL (diag_start_time, diag_end_time, &diag_elapsed_time);
+      perfmon_diff_timeval (&diag_elapsed_time, diag_start_time, diag_end_time);
       if (request == NET_SERVER_QM_QUERY_EXECUTE || request == NET_SERVER_QM_QUERY_PREPARE_AND_EXECUTE)
 	{
 	  SET_DIAG_VALUE_SLOW_QUERY (diag_executediag, diag_start_time, diag_end_time, 1, DIAG_VAL_SETTYPE_INC, NULL);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -13955,7 +13955,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 		      if (level == 0 && spec_level == 1)
 			{
 #if defined(DIAG_DEVEL) && defined(SERVER_MODE)
-			  SET_DIAG_VALUE_FULL_SCAN (diag_executediag, 1, DIAG_VAL_SETTYPE_INC, NULL, xasl, specp);
+			  perfmon_diag_set_full_scan (diag_executediag, NULL, xasl, specp);
 #if 0				/* ACTIVITY PROFILE */
 			  ADD_ACTIVITY_DATA (diag_executediag, DIAG_EVENTCLASS_TYPE_SERVER_QUERY_FULL_SCAN,
 					     xasl->sql_hash_text, "", 0);
@@ -13987,7 +13987,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 			      iscan_oid_order = false;
 			    }
 #if defined(DIAG_DEVEL) && defined(SERVER_MODE)
-			  SET_DIAG_VALUE_FULL_SCAN (diag_executediag, 1, DIAG_VAL_SETTYPE_INC, NULL, xasl, specp);
+			  perfmon_diag_set_full_scan (diag_executediag, NULL, xasl, specp);
 #if 0				/* ACTIVITY PROFILE */
 			  ADD_ACTIVITY_DATA (diag_executediag, DIAG_EVENTCLASS_TYPE_SERVER_QUERY_FULL_SCAN,
 					     xasl->sql_hash_text, "", 0);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -670,6 +670,7 @@ static void vacuum_log_cleanup_dropped_files (THREAD_ENTRY * thread_p, PAGE_PTR 
 static void vacuum_dropped_files_set_next_page (THREAD_ENTRY * thread_p, VACUUM_DROPPED_FILES_PAGE * page_p,
 						VPID * next_page);
 static int vacuum_get_first_page_dropped_files (THREAD_ENTRY * thread_p, VPID * first_page_vpid);
+static void vacuum_notify_all_workers_dropped_file (const VFID & vfid_dropped, MVCCID mvccid);
 
 static bool is_not_vacuumed_and_lost (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header);
 static void print_not_vacuumed_to_log (OID * oid, OID * class_oid, MVCC_REC_HEADER * rec_header, int btree_node_type);
@@ -6245,6 +6246,57 @@ vacuum_rv_replace_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 }
 
 /*
+ * vacuum_notify_all_workers_dropped_file () - notify all vacuum workers that given file was dropped
+ *
+ * vfid_dropped (in) : VFID of dropped file
+ * mvccid (in)       : MVCCID marker for dropped file
+ */
+static void
+vacuum_notify_all_workers_dropped_file (const VFID & vfid_dropped, MVCCID mvccid)
+{
+#if defined (SERVER_MODE)
+  if (!LOG_ISRESTARTED ())
+    {
+      // workers are not running during recovery
+      return;
+    }
+
+  INT32 my_version, workers_min_version;
+
+  /* Before notifying vacuum workers there is one last thing we have to do. Running workers must also be notified of
+   * the VFID being dropped to cleanup their collected heap object arrays. Since must done one file at a time, so a
+   * mutex is used for protection, in case there are several transactions doing file drops. */
+  pthread_mutex_lock (&vacuum_Dropped_files_mutex);
+  assert (VFID_ISNULL (&vacuum_Last_dropped_vfid));
+  VFID_COPY (&vacuum_Last_dropped_vfid, &vfid_dropped);
+
+  /* Increment dropped files version and save a version for current change. It is not important to keep the version
+   * synchronized with the changes. It is only used to make sure that all workers have seen current change. */
+  my_version = ++vacuum_Dropped_files_version;
+
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
+		 "Added dropped file - vfid=%d|%d, mvccid=%llu - "
+		 "Wait for all workers to see my_version=%d", VFID_AS_ARGS (&vfid_dropped), mvccid, my_version);
+
+  /* Wait until all workers have been notified of this change */
+  for (workers_min_version = vacuum_get_worker_min_dropped_files_version ();
+       workers_min_version != -1 && workers_min_version < my_version;
+       workers_min_version = vacuum_get_worker_min_dropped_files_version ())
+    {
+      vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
+		     "not all workers saw my changes, workers min version=%d. Sleep and retry.", workers_min_version);
+
+      thread_sleep (1);
+    }
+
+  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "All workers have been notified, min_version=%d", workers_min_version);
+
+  VFID_SET_NULL (&vacuum_Last_dropped_vfid);
+  pthread_mutex_unlock (&vacuum_Dropped_files_mutex);
+#endif // SERVER_MODE
+}
+
+/*
  * vacuum_rv_notify_dropped_file () - Add drop file used in recovery phase. Can be used in two ways: at run postpone phase
  *				   for dropped heap files and indexes (if postpone_ref_lsa in not null); or at undo
  *				   phase for created heap files and indexes.
@@ -6261,9 +6313,6 @@ vacuum_rv_notify_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   int error = NO_ERROR;
   OID *class_oid;
   MVCCID mvccid;
-#if defined (SERVER_MODE)
-  INT32 my_version, workers_min_version;
-#endif
   VACUUM_DROPPED_FILES_RCV_DATA *rcv_data;
 
   /* Copy VFID from current log recovery data but set MVCCID at this point. We will use the log_Gl.hdr.mvcc_next_id as
@@ -6282,38 +6331,8 @@ vacuum_rv_notify_dropped_file (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
       return error;
     }
 
-#if defined (SERVER_MODE)
-  /* Before notifying vacuum workers there is one last thing we have to do. Running workers must also be notified of
-   * the VFID being dropped to cleanup their collected heap object arrays. Since must done one file at a time, so a
-   * mutex is used for protection, in case there are several transactions doing file drops. */
-  pthread_mutex_lock (&vacuum_Dropped_files_mutex);
-  assert (VFID_ISNULL (&vacuum_Last_dropped_vfid));
-  VFID_COPY (&vacuum_Last_dropped_vfid, &rcv_data->vfid);
-
-  /* Increment dropped files version and save a version for current change. It is not important to keep the version
-   * synchronized with the changes. It is only used to make sure that all workers have seen current change. */
-  my_version = ++vacuum_Dropped_files_version;
-
-  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
-		 "Added dropped file - vfid=%d|%d, mvccid=%llu - "
-		 "Wait for all workers to see my_version=%d", VFID_AS_ARGS (&rcv_data->vfid), mvccid, my_version);
-
-  /* Wait until all workers have been notified of this change */
-  for (workers_min_version = vacuum_get_worker_min_dropped_files_version ();
-       workers_min_version != -1 && workers_min_version < my_version;
-       workers_min_version = vacuum_get_worker_min_dropped_files_version ())
-    {
-      vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES,
-		     "not all workers saw my changes, workers min version=%d. Sleep and retry.", workers_min_version);
-
-      thread_sleep (1);
-    }
-
-  vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "All workers have been notified, min_version=%d", workers_min_version);
-
-  VFID_SET_NULL (&vacuum_Last_dropped_vfid);
-  pthread_mutex_unlock (&vacuum_Dropped_files_mutex);
-#endif /* SERVER_MODE */
+  // make sure vacuum workers will not access dropped file
+  vacuum_notify_all_workers_dropped_file (rcv_data->vfid, mvccid);
 
   /* vacuum is notified of the file drop, it is safe to remove from cache */
   class_oid = &rcv_data->class_oid;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1100,7 +1100,7 @@ vacuum_boot (THREAD_ENTRY * thread_p)
 #if defined (SERVER_MODE)
 
   // get thread manager
-  auto thread_manager = cubthread::get_manager ();
+  cubthread::manager * thread_manager = cubthread::get_manager ();
 
   // get logging flag for vacuum worker pool
   /* *INDENT-OFF* */
@@ -1116,10 +1116,12 @@ vacuum_boot (THREAD_ENTRY * thread_p)
 					vacuum_Worker_context_manager, log_vacuum_worker_pool);
   assert (vacuum_Worker_threads != NULL);
 
+  int vacuum_master_wakeup_interval_msec = prm_get_integer_value (PRM_ID_VACUUM_MASTER_WAKEUP_INTERVAL);
+  cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (vacuum_master_wakeup_interval_msec));
+
   // create vacuum master thread
-  auto interval_time = std::chrono::milliseconds (prm_get_integer_value (PRM_ID_VACUUM_MASTER_WAKEUP_INTERVAL));
-  vacuum_Master_daemon = thread_manager->create_daemon (cubthread::looper (interval_time),
-							new vacuum_master_task (), vacuum_Master_context_manager);
+  vacuum_Master_daemon =
+    thread_manager->create_daemon (looper, new vacuum_master_task (), vacuum_Master_context_manager);
 #endif /* SERVER_MODE */
 
   vacuum_Is_booted = true;
@@ -1139,7 +1141,7 @@ vacuum_stop (THREAD_ENTRY * thread_p)
   // notify master to stop generating new jobs
   vacuum_notify_server_shutdown ();
 
-  auto thread_manager = cubthread::get_manager ();
+  cubthread::manager * thread_manager = cubthread::get_manager ();
 
   // stop work pool
   if (vacuum_Worker_threads != NULL)

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -526,10 +526,11 @@ session_control_daemon_init ()
 {
   assert (session_Control_daemon == NULL);
 
+  cubthread::looper looper = cubthread::looper (std::chrono::seconds (60));
+  session_control_daemon_task *daemon_task = new session_control_daemon_task ();
+
   // create session control daemon thread
-  std::chrono::seconds interval_time = std::chrono::seconds (60);
-  session_Control_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (interval_time),
-			   new session_control_daemon_task ());
+  session_Control_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
 }
 #endif /* SERVER_MODE */
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -16030,7 +16030,7 @@ class pgbuf_flush_control_daemon_task : public cubthread::entry_task
       int token_gen, token_consumed;
 
       gettimeofday (&begin, NULL);
-      DIFF_TIMEVAL (m_end, begin, &diff);
+      perfmon_diff_timeval (&diff, m_end, begin);
 
       int64_t diff_usec = diff.tv_sec * 1000000LL + diff.tv_usec;
       fileio_flush_control_add_tokens (&thread_ref, diff_usec, &token_gen, &token_consumed);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -7785,7 +7785,7 @@ pgbuf_victimize_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr)
   /* at this point, the caller is holding bufptr->mutex */
 
 #if defined(DIAG_DEVEL) && defined(SERVER_MODE)
-  SET_DIAG_VALUE (diag_executediag, DIAG_OBJ_TYPE_QUERY_OPENED_PAGE, 1, DIAG_VAL_SETTYPE_INC, NULL);
+  perfmon_diag_set_value (diag_executediag, DIAG_OBJ_TYPE_QUERY_OPENED_PAGE, 1, DIAG_VAL_SETTYPE_INC, NULL);
 #endif /* DIAG_DEVEL && SERVER_MODE */
 
   return NO_ERROR;
@@ -7847,7 +7847,7 @@ pgbuf_invalidate_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr)
       pgbuf_put_bcb_into_invalid_list (thread_p, bufptr);
 
 #if defined(DIAG_DEVEL) && defined(SERVER_MODE)
-      SET_DIAG_VALUE (diag_executediag, DIAG_OBJ_TYPE_QUERY_OPENED_PAGE, 1, DIAG_VAL_SETTYPE_INC, NULL);
+      perfmon_diag_set_value (diag_executediag, DIAG_OBJ_TYPE_QUERY_OPENED_PAGE, 1, DIAG_VAL_SETTYPE_INC, NULL);
 #endif /* DIAG_DEVEL && SERVER_MODE */
     }
   else
@@ -16030,7 +16030,7 @@ class pgbuf_flush_control_daemon_task : public cubthread::entry_task
       int token_gen, token_consumed;
 
       gettimeofday (&begin, NULL);
-      perfmon_diff_timeval (&diff, m_end, begin);
+      perfmon_diff_timeval (&diff, &m_end, &begin);
 
       int64_t diff_usec = diff.tv_sec * 1000000LL + diff.tv_usec;
       fileio_flush_control_add_tokens (&thread_ref, diff_usec, &token_gen, &token_consumed);

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -71,7 +71,6 @@ struct thread_manager
   THREAD_ENTRY *thread_array;	/* thread entry array */
   int num_total;
   int num_workers;
-  int num_daemons;
   bool initialized;
 };
 
@@ -84,36 +83,6 @@ static pthread_key_t thread_Thread_key;
 #endif /* HPUX */
 
 static THREAD_MANAGER thread_Manager;
-
-/*
- * For special Purpose Threads
- * Under the win32-threads system, *_cond variables are an auto-reset event
- */
-DAEMON_THREAD_MONITOR thread_Log_flush_thread = DAEMON_THREAD_MONITOR_INITIALIZER;
-
-static void thread_stop_daemon (DAEMON_THREAD_MONITOR * daemon_monitor);
-static void thread_wakeup_daemon_thread (DAEMON_THREAD_MONITOR * daemon_monitor);
-
-static THREAD_RET_T THREAD_CALLING_CONVENTION thread_log_flush_thread (void *);
-
-typedef enum
-{
-  /* All the single threads */
-  THREAD_DAEMON_LOG_FLUSH,
-
-  THREAD_DAEMON_NUM_SINGLE_THREADS
-} THREAD_DAEMON_TYPE;
-
-typedef struct thread_daemon THREAD_DAEMON;
-struct thread_daemon
-{
-  DAEMON_THREAD_MONITOR *daemon_monitor;
-  THREAD_DAEMON_TYPE type;
-  int shutdown_sequence;
-    THREAD_RET_T (THREAD_CALLING_CONVENTION * daemon_function) (void *);
-};
-
-static THREAD_DAEMON *thread_Daemons = NULL;
 
 #define THREAD_RC_TRACK_VMEM_THRESHOLD_AMOUNT	      32767
 #define THREAD_RC_TRACK_PGBUF_THRESHOLD_AMOUNT	      1024
@@ -152,9 +121,6 @@ static THREAD_DAEMON *thread_Daemons = NULL;
     } \
   while (0)
 
-#if defined(WINDOWS)
-static int thread_initialize_sync_object (void);
-#endif /* WINDOWS */
 static int thread_wakeup_internal (THREAD_ENTRY * thread_p, int resume_reason, bool had_mutex);
 
 static void thread_rc_track_clear_all (THREAD_ENTRY * thread_p);
@@ -170,10 +136,6 @@ static void thread_rc_track_dump (THREAD_ENTRY * thread_p, FILE * outfp, THREAD_
 static int thread_check_kill_tran_auth (THREAD_ENTRY * thread_p, int tran_id, bool * has_authoriation);
 static INT32 thread_rc_track_threshold_amount (int rc_idx);
 static bool thread_rc_track_is_enabled (THREAD_ENTRY * thread_p);
-
-STATIC_INLINE void thread_daemon_start (DAEMON_THREAD_MONITOR * daemon, THREAD_ENTRY * thread_p,
-					THREAD_TYPE thread_type) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE void thread_daemon_wakeup_onereq (DAEMON_THREAD_MONITOR * daemon) __attribute__ ((ALWAYS_INLINE));
 
 #if !defined(NDEBUG)
 static void thread_rc_track_meter_at (THREAD_RC_METER * meter, const char *caller_file, int caller_line, int amount,
@@ -303,40 +265,12 @@ int
 thread_initialize_manager (size_t & total_thread_count)
 {
   int i, r;
-  int daemon_index;
-  size_t size;
 
   assert (NUM_NORMAL_TRANS >= 10);
   assert (!thread_Manager.initialized);
 
-  /* Initialize daemons */
-  thread_Manager.num_daemons = THREAD_DAEMON_NUM_SINGLE_THREADS;
-  size = thread_Manager.num_daemons * sizeof (THREAD_DAEMON);
-  thread_Daemons = (THREAD_DAEMON *) malloc (size);
-  if (thread_Daemons == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, size);
-      return ER_OUT_OF_VIRTUAL_MEMORY;
-    }
-
-  /* IMPORTANT NOTE: Daemons are shutdown in the same order as they are created here. */
-  daemon_index = 0;
-
-  /* Initialize log flush daemon */
-  thread_Daemons[daemon_index].type = THREAD_DAEMON_LOG_FLUSH;
-  thread_Daemons[daemon_index].daemon_monitor = &thread_Log_flush_thread;
-  thread_Daemons[daemon_index].shutdown_sequence = INT_MAX;
-  thread_Daemons[daemon_index++].daemon_function = thread_log_flush_thread;
-
-  assert (daemon_index == thread_Manager.num_daemons);
-
-#if defined(WINDOWS)
-  thread_initialize_sync_object ();
-#endif /* WINDOWS */
-
   thread_Manager.num_workers = NUM_NON_SYSTEM_TRANS * 2;
-
-  thread_Manager.num_total = (thread_Manager.num_workers + thread_Manager.num_daemons);
+  thread_Manager.num_total = thread_Manager.num_workers;
 
   /* initialize lock-free transaction systems */
   r = lf_initialize_transaction_systems (thread_Manager.num_total + (int) cubthread::get_max_thread_count ());
@@ -443,36 +377,6 @@ thread_start_workers (void)
       /* If win32, then "thread_attr" is ignored, else "p->thread_handle". */
       pthread_t tid = 0;	// thread id is registered in thread_worker function, so do nothing with tid
       r = pthread_create (&tid, &thread_attr, thread_worker, thread_p);
-      if (r != 0)
-	{
-	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_CREATE, 0);
-	  pthread_mutex_unlock (&thread_p->th_entry_lock);
-	  return ER_CSS_PTHREAD_CREATE;
-	}
-
-      r = pthread_mutex_unlock (&thread_p->th_entry_lock);
-      if (r != 0)
-	{
-	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_UNLOCK, 0);
-	  return ER_CSS_PTHREAD_MUTEX_UNLOCK;
-	}
-    }
-
-  for (i = 0; thread_index < thread_Manager.num_total; thread_index++, i++)
-    {
-      thread_Daemons[i].daemon_monitor->thread_index = thread_index;
-      thread_p = &thread_Manager.thread_array[thread_index];
-
-      r = pthread_mutex_lock (&thread_p->th_entry_lock);
-      if (r != 0)
-	{
-	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_LOCK, 0);
-	  return ER_CSS_PTHREAD_MUTEX_LOCK;
-	}
-
-      /* If win32, then "thread_attr" is ignored, else "p->thread_handle". */
-      pthread_t tid = 0;	// thread id is registered in daemon_function, so do nothing with tid
-      r = pthread_create (&tid, &thread_attr, thread_Daemons[i].daemon_function, thread_p);
       if (r != 0)
 	{
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_CREATE, 0);
@@ -622,65 +526,6 @@ loop:
 }
 
 /*
- * thread_wakeup_daemon_thread() -
- *
- */
-static void
-thread_wakeup_daemon_thread (DAEMON_THREAD_MONITOR * daemon_monitor)
-{
-  int rv;
-
-  rv = pthread_mutex_lock (&daemon_monitor->lock);
-  pthread_cond_signal (&daemon_monitor->cond);
-  pthread_mutex_unlock (&daemon_monitor->lock);
-}
-
-/*
- * thread_stop_daemon() -
- *
- */
-static void
-thread_stop_daemon (DAEMON_THREAD_MONITOR * daemon_monitor)
-{
-  THREAD_ENTRY *thread_p;
-
-  thread_p = &thread_Manager.thread_array[daemon_monitor->thread_index];
-  thread_p->shutdown = true;
-
-  while (thread_p->status != TS_DEAD)
-    {
-      thread_wakeup_daemon_thread (daemon_monitor);
-
-      if (css_is_shutdown_timeout_expired ())
-	{
-	  er_log_debug (ARG_FILE_LINE, "thread_stop_daemon(%d): _exit(0)\n", daemon_monitor->thread_index);
-	  /* exit process after some tries */
-	  _exit (0);
-	}
-      thread_sleep (10);	/* 10 msec */
-    }
-}
-
-/*
- * thread_stop_active_daemons() - Stop active daemon threads
- *   return: NO_ERROR
- */
-int
-thread_stop_active_daemons (void)
-{
-  int i;
-
-  for (i = 0; i < thread_Manager.num_daemons; i++)
-    {
-      assert ((i == 0) || (thread_Daemons[i - 1].shutdown_sequence < thread_Daemons[i].shutdown_sequence));
-
-      thread_stop_daemon (thread_Daemons[i].daemon_monitor);
-    }
-
-  return NO_ERROR;
-}
-
-/*
  * thread_kill_all_workers() - Signal all worker threads to exit.
  *   return: 0 if no error, or error code
  */
@@ -748,8 +593,6 @@ thread_final_manager (void)
   delete [] thread_Manager.thread_array;
   thread_Manager.thread_array = NULL;
   /* *INDENT-ON* */
-
-  free_and_init (thread_Daemons);
 
   lf_destroy_transaction_systems ();
 
@@ -1791,188 +1634,6 @@ thread_worker (void *arg_p)
   tsd_ptr->unregister_id ();
 
   return (THREAD_RET_T) 0;
-}
-
-/* Special Purpose Threads
- * check point daemon
- */
-#if defined(WINDOWS)
-/*
- * thread_initialize_sync_object() -
- *   return:
- */
-static int
-thread_initialize_sync_object (void)
-{
-  int r, i;
-
-  r = NO_ERROR;
-
-  for (i = 0; i < thread_Manager.num_daemons; i++)
-    {
-      r = pthread_cond_init (&thread_Daemons[i].daemon_monitor->cond, NULL);
-      if (r != 0)
-	{
-	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_INIT, 0);
-	  return ER_CSS_PTHREAD_COND_INIT;
-	}
-      r = pthread_mutex_init (&thread_Daemons[i].daemon_monitor->lock, NULL);
-      if (r != 0)
-	{
-	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_MUTEX_INIT, 0);
-	  return ER_CSS_PTHREAD_MUTEX_INIT;
-	}
-    }
-
-  return r;
-}
-#endif /* WINDOWS */
-
-/*
- * thread_log_flush_thread() - flushed dirty log pages in background
- *   return:
- *   arg(in) : thread entry information
- *
- */
-static THREAD_RET_T THREAD_CALLING_CONVENTION
-thread_log_flush_thread (void *arg_p)
-{
-#if !defined(HPUX)
-  THREAD_ENTRY *tsd_ptr;
-#endif /* !HPUX */
-  int rv, ret;
-
-  struct timespec LFT_wakeup_time = { 0, 0 };
-  struct timeval wakeup_time = { 0, 0 };
-  struct timeval wait_time = { 0, 0 };
-  struct timeval tmp_timeval = { 0, 0 };
-
-  int working_time, remained_time, total_elapsed_time, param_refresh_remained;
-  int gc_interval, wakeup_interval;
-  int param_refresh_interval = 3000;
-  int max_wait_time = 1000;
-
-  LOG_GROUP_COMMIT_INFO *group_commit_info = &log_Gl.group_commit_info;
-
-  tsd_ptr = (THREAD_ENTRY *) arg_p;
-
-  thread_daemon_start (&thread_Log_flush_thread, tsd_ptr, TT_DAEMON);
-
-  gettimeofday (&wakeup_time, NULL);
-  total_elapsed_time = 0;
-  param_refresh_remained = param_refresh_interval;
-
-  tsd_ptr->event_stats.trace_log_flush_time = prm_get_integer_value (PRM_ID_LOG_TRACE_FLUSH_TIME_MSECS);
-
-  while (!tsd_ptr->shutdown)
-    {
-      er_clear ();
-
-      gc_interval = prm_get_integer_value (PRM_ID_LOG_GROUP_COMMIT_INTERVAL_MSECS);
-
-      wakeup_interval = max_wait_time;
-      if (gc_interval > 0)
-	{
-	  wakeup_interval = MIN (gc_interval, wakeup_interval);
-	}
-
-      gettimeofday (&wait_time, NULL);
-      working_time = (int) timeval_diff_in_msec (&wait_time, &wakeup_time);
-      total_elapsed_time += working_time;
-
-      remained_time = MAX ((int) (wakeup_interval - working_time), 0);
-      (void) timeval_add_msec (&tmp_timeval, &wait_time, remained_time);
-      (void) timeval_to_timespec (&LFT_wakeup_time, &tmp_timeval);
-
-      rv = pthread_mutex_lock (&thread_Log_flush_thread.lock);
-
-      ret = 0;
-      if (thread_Log_flush_thread.nrequestors == 0 || gc_interval > 0)
-	{
-	  thread_Log_flush_thread.is_running = false;
-	  ret = pthread_cond_timedwait (&thread_Log_flush_thread.cond, &thread_Log_flush_thread.lock, &LFT_wakeup_time);
-	  thread_Log_flush_thread.is_running = true;
-	}
-
-      rv = pthread_mutex_unlock (&thread_Log_flush_thread.lock);
-
-      gettimeofday (&wakeup_time, NULL);
-      total_elapsed_time += (int) timeval_diff_in_msec (&wakeup_time, &wait_time);
-
-      if (tsd_ptr->shutdown)
-	{
-	  break;
-	}
-
-      if (ret == ETIMEDOUT)
-	{
-	  if (total_elapsed_time < gc_interval)
-	    {
-	      continue;
-	    }
-	}
-
-      /* to prevent performance degradation */
-      param_refresh_remained -= total_elapsed_time;
-      if (param_refresh_remained < 0)
-	{
-	  tsd_ptr->event_stats.trace_log_flush_time = prm_get_integer_value (PRM_ID_LOG_TRACE_FLUSH_TIME_MSECS);
-
-	  param_refresh_remained = param_refresh_interval;
-	}
-
-      LOG_CS_ENTER (tsd_ptr);
-      logpb_flush_pages_direct (tsd_ptr);
-      LOG_CS_EXIT (tsd_ptr);
-
-      log_Stat.gc_flush_count++;
-      total_elapsed_time = 0;
-
-      rv = pthread_mutex_lock (&group_commit_info->gc_mutex);
-      pthread_cond_broadcast (&group_commit_info->gc_cond);
-      (void) ATOMIC_TAS_32 (&thread_Log_flush_thread.nrequestors, 0);
-      pthread_mutex_unlock (&group_commit_info->gc_mutex);
-
-#if defined(CUBRID_DEBUG)
-      er_log_debug (ARG_FILE_LINE, "css_log_flush_thread: [%d]send signal - waiters\n", (int) THREAD_ID ());
-#endif /* CUBRID_DEBUG */
-    }
-
-  rv = pthread_mutex_lock (&thread_Log_flush_thread.lock);
-  thread_Log_flush_thread.is_available = false;
-  thread_Log_flush_thread.is_running = false;
-  pthread_mutex_unlock (&thread_Log_flush_thread.lock);
-
-  er_final (ER_THREAD_FINAL);
-  tsd_ptr->status = TS_DEAD;
-  tsd_ptr->unregister_id ();
-
-#if defined(CUBRID_DEBUG)
-  er_log_debug (ARG_FILE_LINE, "css_log_flush_thread: [%d]end \n", (int) THREAD_ID ());
-#endif /* CUBRID_DEBUG */
-
-  return (THREAD_RET_T) 0;
-}
-
-
-/*
- * thread_wakeup_log_flush_thread() - wakeup log flush thread.
- */
-void
-thread_wakeup_log_flush_thread (void)
-{
-  thread_daemon_wakeup_onereq (&thread_Log_flush_thread);
-}
-
-/*
- * thread_is_log_flush_thread_available () - is log flush thread available?
- *
- * return : true/false
- */
-bool
-thread_is_log_flush_thread_available (void)
-{
-  return thread_Log_flush_thread.is_available;
 }
 
 /*
@@ -3915,58 +3576,6 @@ thread_clear_recursion_depth (THREAD_ENTRY * thread_p)
     }
 
   thread_p->xasl_recursion_depth = 0;
-}
-
-/*
- * thread_daemon_start () - start daemon thread
- *
- * return           : void
- * daemon (in)      : daemon thread monitor
- * thread_p (in)    : thread entry
- * thread_type (in) : thread type
- */
-STATIC_INLINE void
-thread_daemon_start (DAEMON_THREAD_MONITOR * daemon, THREAD_ENTRY * thread_p, THREAD_TYPE thread_type)
-{
-  /* wait until THREAD_CREATE() finishes */
-  pthread_mutex_lock (&thread_p->th_entry_lock);
-  pthread_mutex_unlock (&thread_p->th_entry_lock);
-
-  thread_set_thread_entry_info (thread_p);	/* save TSD */
-  thread_p->type = thread_type;	/* daemon thread */
-  thread_p->status = TS_RUN;	/* set thread stat as RUN */
-  thread_p->register_id ();
-  thread_p->get_error_context ().register_thread_local ();
-
-  daemon->is_running = true;
-  daemon->is_available = true;
-
-  thread_set_current_tran_index (thread_p, LOG_SYSTEM_TRAN_INDEX);
-}
-
-/*
- * thread_daemon_wakeup_onereq () - request daemon thread wakeup if not already requested
- *
- * return      : void
- * daemon (in) : daemon thread monitor
- */
-STATIC_INLINE void
-thread_daemon_wakeup_onereq (DAEMON_THREAD_MONITOR * daemon)
-{
-  if (daemon->nrequestors > 0)
-    {
-      /* we register only one request per wakeup */
-      return;
-    }
-  /* increment requesters */
-  ++daemon->nrequestors;
-  pthread_mutex_lock (&daemon->lock);
-  if (!daemon->is_running)
-    {
-      /* signal wakeup */
-      pthread_cond_signal (&daemon->cond);
-    }
-  pthread_mutex_unlock (&daemon->lock);
 }
 
 /*

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -238,20 +238,6 @@ struct fi_test_item;
   ((thread_p)->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT && \
    (thread_p)->interrupted == true)
 
-typedef struct daemon_thread_monitor DAEMON_THREAD_MONITOR;
-struct daemon_thread_monitor
-{
-  int thread_index;
-  bool is_available;
-  bool is_running;
-  int nrequestors;
-  pthread_mutex_t lock;
-  pthread_cond_t cond;
-};
-
-#define DAEMON_THREAD_MONITOR_INITIALIZER  \
-  {0, false, false, 0, PTHREAD_MUTEX_INITIALIZER,PTHREAD_COND_INITIALIZER}
-
 #if !defined(HPUX)
 extern int thread_set_thread_entry_info (THREAD_ENTRY * entry);
 #endif /* not HPUX */
@@ -261,7 +247,6 @@ extern THREAD_ENTRY *thread_get_thread_entry_info (void);
 extern int thread_initialize_manager (size_t & total_thread_count);
 extern int thread_start_workers (void);
 extern int thread_stop_active_workers (unsigned short stop_phase);
-extern int thread_stop_active_daemons (void);
 extern int thread_kill_all_workers (void);
 extern void thread_final_manager (void);
 extern void thread_slam_tran_index (THREAD_ENTRY * thread_p, int tran_index);
@@ -301,9 +286,6 @@ extern void thread_set_current_tran_index (THREAD_ENTRY * thread_p, int tran_ind
 extern struct css_conn_entry *thread_get_current_conn_entry (void);
 extern int thread_has_threads (THREAD_ENTRY * caller, int tran_index, int client_id);
 extern bool thread_set_check_interrupt (THREAD_ENTRY * thread_p, bool flag);
-
-extern void thread_wakeup_log_flush_thread (void);
-extern bool thread_is_log_flush_thread_available (void);
 
 extern THREAD_ENTRY *thread_find_first_lockwait_entry (int *thrd_index);
 extern THREAD_ENTRY *thread_find_next_lockwait_entry (int *thrd_index);

--- a/src/thread/thread_looper.cpp
+++ b/src/thread/thread_looper.cpp
@@ -150,6 +150,11 @@ namespace cubthread
   void
   looper::setup_increasing_waits (bool &is_timed_wait, delta_time &period)
   {
+    if (m_was_woken_up)
+      {
+	reset ();
+      }
+
     if (m_period_index < m_periods_count)
       {
 	is_timed_wait = true;

--- a/src/thread/thread_looper.cpp
+++ b/src/thread/thread_looper.cpp
@@ -163,7 +163,6 @@ namespace cubthread
     else
       {
 	is_timed_wait = false;
-	reset ();
       }
   }
 

--- a/src/thread/thread_looper.cpp
+++ b/src/thread/thread_looper.cpp
@@ -22,36 +22,44 @@
  */
 
 #include "thread_looper.hpp"
-
 #include "thread_waiter.hpp"
-
-#include <cassert>
 
 namespace cubthread
 {
 
   looper::looper ()
-    : m_wait_pattern (wait_pattern::INFINITE_WAITS)
-    , m_periods_count (0)
-    , m_period_index (0)
-    , m_stop (false)
-    , m_was_woken_up (false)
-  {
-    // infinite waits
-  }
-
-  looper::looper (const looper &other)
-    : m_wait_pattern (other.m_wait_pattern)
-    , m_periods_count (other.m_periods_count)
+    : m_periods_count (0)
     , m_periods ()
     , m_period_index (0)
     , m_stop (false)
     , m_was_woken_up (false)
+    , m_start_execution_time ()
   {
-    for (std::size_t i = 0; i < m_periods_count; i++)
-      {
-	this->m_periods[i] = other.m_periods[i];
-      }
+    // infinite waits
+    m_setup_period = std::bind (&looper::setup_infinite_wait, *this, std::placeholders::_1, std::placeholders::_2);
+  }
+
+  looper::looper (const looper &other)
+    : m_periods_count (other.m_periods_count)
+    , m_periods ()
+    , m_period_index (0)
+    , m_stop (false)
+    , m_was_woken_up (false)
+    , m_setup_period (other.m_setup_period)
+    , m_start_execution_time (other.m_start_execution_time)
+  {
+    std::copy (std::begin (other.m_periods), std::end (other.m_periods), std::begin (m_periods));
+  }
+
+  looper::looper (const period_function &setup_period_function)
+    : m_periods_count (0)
+    , m_periods ()
+    , m_period_index (0)
+    , m_stop (false)
+    , m_was_woken_up (false)
+    , m_setup_period (setup_period_function)
+    , m_start_execution_time ()
+  {
   }
 
   void
@@ -63,37 +71,44 @@ namespace cubthread
 	return;
       }
 
-    if (m_period_index >= m_periods_count)
+    assert (m_setup_period);
+
+    bool is_timed_wait = true;
+    delta_time period = delta_time (0);
+
+    m_setup_period (is_timed_wait, period);
+
+    if (is_timed_wait)
       {
-	assert (m_period_index == m_periods_count);
+	delta_time wait_time = delta_time (0);
+	delta_time execution_time = delta_time (0);
+
+	if (m_start_execution_time != std::chrono::system_clock::time_point ())
+	  {
+	    execution_time = std::chrono::system_clock::now () - m_start_execution_time;
+	  }
+
+	// compute task execution time
+	if (period > execution_time)
+	  {
+	    wait_time = period - execution_time;
+	  }
+
+	m_was_woken_up = waiter_arg.wait_for (wait_time);
+      }
+    else
+      {
 	waiter_arg.wait_inf ();
 	m_was_woken_up = true;
       }
-    else
-      {
-	m_was_woken_up = waiter_arg.wait_for (m_periods[m_period_index]);
-      }
-    if (m_wait_pattern == wait_pattern::FIXED_PERIODS || m_wait_pattern == wait_pattern::INFINITE_WAITS)
-      {
-	assert (m_period_index == 0);
-	return;
-      }
-    if (!m_was_woken_up)
-      {
-	/* increment */
-	++m_period_index;
-      }
-    else
-      {
-	/* reset */
-	m_period_index = 0;
-      }
+
+    // register start of the task execution time
+    m_start_execution_time = std::chrono::system_clock::now ();
   }
 
   void
   looper::reset (void)
   {
-    assert (m_wait_pattern == wait_pattern::INCREASING_PERIODS);
     m_period_index = 0;
   }
 
@@ -113,6 +128,38 @@ namespace cubthread
   looper::was_woken_up (void) const
   {
     return m_was_woken_up;
+  }
+
+  void
+  looper::setup_fixed_waits (bool &is_timed_wait, delta_time &period)
+  {
+    assert (m_period_index == 0);
+
+    is_timed_wait = true;
+    period = m_periods[m_period_index];
+  }
+
+  void
+  looper::setup_infinite_wait (bool &is_timed_wait, delta_time &period)
+  {
+    assert (m_period_index == 0);
+
+    is_timed_wait = false;
+  }
+
+  void
+  looper::setup_increasing_waits (bool &is_timed_wait, delta_time &period)
+  {
+    if (m_period_index < m_periods_count)
+      {
+	is_timed_wait = true;
+	period = m_periods[m_period_index++];
+      }
+    else
+      {
+	is_timed_wait = false;
+	reset ();
+      }
   }
 
 } // namespace cubthread

--- a/src/thread/thread_looper.hpp
+++ b/src/thread/thread_looper.hpp
@@ -30,6 +30,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <functional>
 
 // cubthread::looper
 //
@@ -67,6 +68,10 @@
 namespace cubthread
 {
 
+  // definitions
+  typedef std::chrono::duration<std::uint64_t, std::nano> delta_time;
+  typedef std::function<void (bool &, delta_time &)> period_function;
+
   // for increasing period pattern
   const std::size_t MAX_LOOPER_PERIODS = 3;
 
@@ -82,6 +87,12 @@ namespace cubthread
       // default looping pattern; always wait until wakeup on each loop
       looper ();
 
+      // copy other loop pattern
+      looper (const looper &other);
+
+      // loop and wait based on value provided by setup_period_function
+      looper (const period_function &setup_period_function);
+
       // loop and wait for a fixed period of time
       template<class Rep, class Period>
       looper (const std::chrono::duration<Rep, Period> &fixed_period);
@@ -92,9 +103,6 @@ namespace cubthread
       // sleep timer is reset when sleep doesn't time out
       template<class Rep, class Period, std::size_t Count>
       looper (const std::array<std::chrono::duration<Rep, Period>, Count> periods);
-
-      // copy other loop pattern
-      looper (const looper &other);
 
       // put waiter to sleep according to loop pattern
       void put_to_sleep (waiter &waiter_arg);
@@ -113,22 +121,22 @@ namespace cubthread
 
     private:
 
-      // definitions
-      typedef std::chrono::duration<std::uint64_t, std::nano> delta_time;
-      enum class wait_pattern
-      {
-	FIXED_PERIODS,                // fixed periods
-	INCREASING_PERIODS,           // increasing periods with each timeout
-	INFINITE_WAITS,               // always infinite waits
-      };
+      void setup_fixed_waits (bool &is_timed_wait, delta_time &period);
+      void setup_infinite_wait (bool &is_timed_wait, delta_time &period);
+      void setup_increasing_waits (bool &is_timed_wait, delta_time &period);
 
-      wait_pattern m_wait_pattern;              // wait pattern type
-      std::size_t m_periods_count;              // the period count
+      std::size_t m_periods_count;              // the period count, used by increasing period pattern
       delta_time m_periods[MAX_LOOPER_PERIODS]; // period array
 
       std::atomic<std::size_t> m_period_index;  // current period index
       std::atomic<bool> m_stop;                 // when true, loop is stopped; no waits
       std::atomic<bool> m_was_woken_up;         // when true, waiter was woken up before timeout
+
+      period_function m_setup_period;           // function used to refresh period on every run
+
+      // a time point that represents the start of task execution
+      // used by put_to_sleep function in order to sleep for difference between period interval and task execution time
+      std::chrono::system_clock::time_point m_start_execution_time;
   };
 
   /************************************************************************/
@@ -137,31 +145,24 @@ namespace cubthread
 
   template<class Rep, class Period>
   looper::looper (const std::chrono::duration<Rep, Period> &fixed_period)
-    : m_wait_pattern (wait_pattern::FIXED_PERIODS)
-    , m_periods_count (1)
-#if defined (NO_GCC_44)
+    : m_periods_count (0)
     , m_periods {fixed_period}
-#else
-    , m_periods ()
-#endif
     , m_period_index (0)
     , m_stop (false)
     , m_was_woken_up (false)
+    , m_start_execution_time ()
   {
-    // fixed period waits
-#if !defined (NO_GCC_44)
-    m_periods[0] = fixed_period;
-#endif
+    m_setup_period = std::bind (&looper::setup_fixed_waits, *this, std::placeholders::_1, std::placeholders::_2);
   }
 
   template<class Rep, class Period, std::size_t Count>
   looper::looper (const std::array<std::chrono::duration<Rep, Period>, Count> periods)
-    : m_wait_pattern (wait_pattern::INCREASING_PERIODS)
-    , m_periods_count (Count)
+    : m_periods_count (Count)
     , m_periods {}
     , m_period_index (0)
     , m_stop (false)
     , m_was_woken_up (false)
+    , m_start_execution_time ()
   {
     static_assert (Count <= MAX_LOOPER_PERIODS, "Count template cannot exceed MAX_LOOPER_PERIODS=3");
     m_periods_count = std::min (Count, MAX_LOOPER_PERIODS);
@@ -173,6 +174,8 @@ namespace cubthread
 	// check increasing periods
 	assert (i == 0 || m_periods[i - 1] < m_periods[i]);
       }
+
+    m_setup_period = std::bind (&looper::setup_increasing_waits, *this, std::placeholders::_1, std::placeholders::_2);
   }
 
 } // namespace cubthread

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -43,11 +43,7 @@
 namespace cubthread
 {
 
-#if defined (NO_GCC_44) || defined (WINDOWS)
   thread_local entry *tl_Entry_p = NULL;
-#else // GCC 4.4
-  __thread entry *tl_Entry_p = NULL;
-#endif // GCC 4.4
 
   manager::manager (std::size_t max_threads)
     : m_max_threads (max_threads)

--- a/src/thread/thread_waiter.cpp
+++ b/src/thread/thread_waiter.cpp
@@ -95,11 +95,7 @@ namespace cubthread
     goto_sleep ();
 
     // wait
-#if defined (NO_GCC_44)
     m_condvar.wait (lock, [this] { return m_status == AWAKENING; });
-#else
-    m_condvar.wait (lock);
-#endif
 
     run ();
 

--- a/src/thread/thread_waiter.hpp
+++ b/src/thread/thread_waiter.hpp
@@ -104,25 +104,13 @@ namespace cubthread
   {
     if (delta == std::chrono::duration<Rep, Period> (0))
       {
-#if defined (NO_GCC_44)
-	// no wait, just yield
-	std::this_thread::yield ();
-#endif // not GCC 4.4
 	return true;
       }
 
     std::unique_lock<std::mutex> lock (m_mutex);    // mutex is also locked
     goto_sleep ();
 
-#if defined (NO_GCC_44)
     bool ret = m_condvar.wait_for (lock, delta, [this] { return m_status == AWAKENING; });
-#else // NO_GCC_44
-#if !defined (WINDOWS) && __cplusplus < 201103L
-    bool ret = m_condvar.wait_for (lock, delta);
-#else
-    bool ret = (m_condvar.wait_for (lock, delta) != std::cv_status::timeout);
-#endif
-#endif // MP_GCC_44
 
     run ();
 
@@ -137,15 +125,7 @@ namespace cubthread
     std::unique_lock<std::mutex> lock (m_mutex);    // mutex is also locked
     goto_sleep ();
 
-#if defined (NO_GCC_44)
     bool ret = m_condvar.wait_until (lock, timeout_time, [this] { return m_status == AWAKENING; });
-#else // GCC 4.4
-#if __cplusplus < 201103L
-    bool ret = m_condvar.wait_until (lock, timeout_time);
-#else
-    bool ret = (m_condvar.wait_until (lock, timeout_time) != std::cv_status::timeout);
-#endif
-#endif // GCC 4.4
 
     run ();
 

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -137,12 +137,7 @@ namespace cubthread
       // maximum number of concurrent workers
       const std::size_t m_max_workers;
 
-#if defined (NO_GCC_44)
-      // current worker count
       std::atomic<std::size_t> m_worker_count;
-#else
-      volatile std::size_t m_worker_count;
-#endif
 
       // work queue to store tasks that cannot be immediately executed
       lockfree::circular_queue<task_type *> m_work_queue;
@@ -458,11 +453,7 @@ namespace cubthread
 	thread_p->join ();
       }
 
-#if defined (NO_GCC_44)
     ++m_worker_count;
-#else
-    (void) ATOMIC_INC (&m_worker_count, 1);
-#endif
 
     THREAD_WP_LOG ("register_worker", "thread = %zu", get_thread_index (*thread_p));
     return thread_p;
@@ -475,11 +466,7 @@ namespace cubthread
     // THREAD_WP_LOG ("deregister_worker", "thread = %zu", get_thread_index (thread_arg));
     // no logging here; no thread & error context
     m_thread_dispatcher.retire (thread_arg);
-#if defined (NO_GCC_44)
     --m_worker_count;
-#else
-    (void) ATOMIC_INC (&m_worker_count, -1);
-#endif
   }
 
   template<typename Context>

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2900,7 +2900,6 @@ xboot_shutdown_server (THREAD_ENTRY * thread_p, ER_FINAL_CODE is_er_final)
 
 #if defined(SERVER_MODE)
       pgbuf_daemons_destroy ();
-      thread_stop_active_daemons ();
 #endif
 
       log_final (thread_p);

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -3067,7 +3067,7 @@ lock_internal_hold_lock_object_instant (int tran_index, const OID * oid, const O
 #endif /* LK_DUMP */
 
 #if defined(SERVER_MODE) && defined(DIAG_DEVEL)
-  SET_DIAG_VALUE (diag_executediag, DIAG_OBJ_TYPE_LOCK_REQUEST, 1, DIAG_VAL_SETTYPE_INC, NULL);
+  perfmon_diag_set_value (diag_executediag, DIAG_OBJ_TYPE_LOCK_REQUEST, 1, DIAG_VAL_SETTYPE_INC, NULL);
 #endif /* SERVER_MODE && DIAG_DEVEL */
   if (class_oid != NULL && !OID_IS_ROOTOID (class_oid))
     {
@@ -3276,7 +3276,7 @@ lock_internal_perform_lock_object (THREAD_ENTRY * thread_p, int tran_index, cons
   *entry_addr_ptr = NULL;
 
 #if defined(SERVER_MODE) && defined(DIAG_DEVEL)
-  SET_DIAG_VALUE (diag_executediag, DIAG_OBJ_TYPE_LOCK_REQUEST, 1, DIAG_VAL_SETTYPE_INC, NULL);
+  perfmon_diag_set_value (diag_executediag, DIAG_OBJ_TYPE_LOCK_REQUEST, 1, DIAG_VAL_SETTYPE_INC, NULL);
 #endif /* SERVER_MODE && DIAG_DEVEL */
 
   /* get current locking phase */
@@ -8073,7 +8073,7 @@ final_:
 #if defined(SERVER_MODE) && defined(DIAG_DEVEL)
   if (victim_count > 0)
     {
-      SET_DIAG_VALUE (diag_executediag, DIAG_OBJ_TYPE_LOCK_DEADLOCK, 1, DIAG_VAL_SETTYPE_INC, NULL);
+      perfmon_diag_set_value (diag_executediag, DIAG_OBJ_TYPE_LOCK_DEADLOCK, 1, DIAG_VAL_SETTYPE_INC, NULL);
 #if 0				/* ACTIVITY PROFILE */
       ADD_ACTIVITY_DATA (diag_executediag, DIAG_EVENTCLASS_TYPE_SERVER_LOCK_DEADLOCK, "", "", victim_count);
 #endif

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -5956,10 +5956,11 @@ lock_deadlock_detect_daemon_init ()
 {
   assert (lock_Deadlock_detect_daemon == NULL);
 
+  cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (100));
+  deadlock_detect_task *daemon_task = new deadlock_detect_task ();
+
   // create deadlock detect daemon thread
-  auto interval_time = std::chrono::milliseconds (100);
-  lock_Deadlock_detect_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (interval_time),
-				new deadlock_detect_task ());
+  lock_Deadlock_detect_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
 }
 #endif /* SERVER_MODE */
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10266,14 +10266,14 @@ log_get_log_group_commit_interval (bool & is_timed_wait, cubthread::delta_time &
     }
 #endif /* SERVER_MODE */
 
-  int max_wait_time_msec = 1000;
+  const int MAX_WAIT_TIME_MSEC = 1000;
   int log_group_commit_interval_msec = prm_get_integer_value (PRM_ID_LOG_GROUP_COMMIT_INTERVAL_MSECS);
 
   assert (log_group_commit_interval_msec >= 0);
 
   if (log_group_commit_interval_msec == 0)
     {
-      period = std::chrono::milliseconds (max_wait_time_msec);
+      period = std::chrono::milliseconds (MAX_WAIT_TIME_MSEC);
     }
   else
     {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -342,6 +342,9 @@ static cubthread::daemon *log_Clock_daemon = NULL;
 static cubthread::daemon *log_Checkpoint_daemon = NULL;
 static cubthread::daemon *log_Remove_log_archive_daemon = NULL;
 static cubthread::daemon *log_Check_ha_delay_info_daemon = NULL;
+
+static cubthread::daemon *log_Flush_daemon = NULL;
+static std::atomic_bool log_Flush_has_been_requested = {false};
 // *INDENT-ON*
 
 static void log_daemons_init ();
@@ -506,7 +509,6 @@ log_is_in_crash_recovery (void)
     }
 }
 
-
 /*
  * log_get_restart_lsa - FIND RESTART LOG SEQUENCE ADDRESS
  *
@@ -563,7 +565,6 @@ log_get_append_lsa (void)
 {
   return (&log_Gl.hdr.append_lsa);
 }
-
 
 /*
  * log_get_eof_lsa -
@@ -1271,7 +1272,6 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
 	}
       strncpy (log_Gl.hdr.db_release, rel_release_string (), REL_MAX_RELEASE_LENGTH);
     }
-
 
   /* 
    * Create the transaction table and make sure that data volumes and log
@@ -7990,7 +7990,6 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
   int data_header_size = 0;
   bool is_mvcc_op = false;
 
-
   aligned_log_pgbuf = PTR_ALIGN (log_pgbuf, MAX_ALIGNMENT);
 
   /* 
@@ -9427,7 +9426,6 @@ log_simulate_crash (THREAD_ENTRY * thread_p, int flush_log, int flush_data_pages
 }
 #endif /* ENABLE_UNUSED_FUNCTION */
 
-
 /*
  * log_active_log_header_start_scan () -
  *   return: NO_ERROR, or ER_code
@@ -9983,7 +9981,6 @@ log_set_db_restore_time (THREAD_ENTRY * thread_p, INT64 db_restore_time)
   LOG_CS_EXIT (thread_p);
 }
 
-
 /*
  * log_get_undo_record () - gets undo record from log lsa adress
  *   return: S_SUCCESS or ER_code
@@ -10253,16 +10250,98 @@ log_read_sysop_start_postpone (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_P
   return NO_ERROR;
 }
 
-#if defined(SERVER_MODE)
+/*
+ * log_get_log_group_commit_interval () - setup flush daemon period based on system parameter
+ */
+void
+log_get_log_group_commit_interval (bool & is_timed_wait, cubthread::delta_time & period)
+{
+  is_timed_wait = true;
+
+#if defined (SERVER_MODE)
+  if (log_Flush_has_been_requested)
+    {
+      period = std::chrono::milliseconds (0);
+      return;
+    }
+#endif /* SERVER_MODE */
+
+  int max_wait_time_msec = 1000;
+  int log_group_commit_interval_msec = prm_get_integer_value (PRM_ID_LOG_GROUP_COMMIT_INTERVAL_MSECS);
+
+  assert (log_group_commit_interval_msec >= 0);
+
+  if (log_group_commit_interval_msec == 0)
+    {
+      period = std::chrono::milliseconds (max_wait_time_msec);
+    }
+  else
+    {
+      period = std::chrono::milliseconds (log_group_commit_interval_msec);
+    }
+}
+
+/*
+ * log_get_checkpoint_interval () - setup log checkpoint daemon period based on system parameter
+ */
+void
+log_get_checkpoint_interval (bool & is_timed_wait, cubthread::delta_time & period)
+{
+  int log_checkpoint_interval_sec = prm_get_integer_value (PRM_ID_LOG_CHECKPOINT_INTERVAL_SECS);
+
+  assert (log_checkpoint_interval_sec >= 0);
+
+  if (log_checkpoint_interval_sec > 0)
+    {
+      // if log_checkpoint_interval_sec > 0 (zero) then loop for fixed interval
+      is_timed_wait = true;
+      period = std::chrono::seconds (log_checkpoint_interval_sec);
+    }
+  else
+    {
+      // infinite wait
+      is_timed_wait = false;
+    }
+}
+
+/*
+ * log_get_remove_log_archive_interval () - setup remove log archive daemon period based on system parameter
+ */
+void
+log_get_remove_log_archive_interval (bool & is_timed_wait, cubthread::delta_time & period)
+{
+  int remove_log_archive_interval_sec = prm_get_integer_value (PRM_ID_REMOVE_LOG_ARCHIVES_INTERVAL);
+
+  assert (remove_log_archive_interval_sec >= 0);
+
+  if (remove_log_archive_interval_sec > 0)
+    {
+      // if remove_log_archive_interval_sec > 0 (zero) then loop for fixed interval
+      is_timed_wait = true;
+      period = std::chrono::seconds (remove_log_archive_interval_sec);
+    }
+  else
+    {
+      // infinite wait
+      is_timed_wait = false;
+    }
+}
+
+#if defined (SERVER_MODE)
 /*
  * log_wakeup_remove_log_archive_daemon () - wakeup remove log archive daemon
  */
 void
 log_wakeup_remove_log_archive_daemon ()
 {
-  if (log_Remove_log_archive_daemon != NULL && prm_get_integer_value (PRM_ID_REMOVE_LOG_ARCHIVES_INTERVAL) == 0)
+  bool is_timed_wait;
+  cubthread::delta_time period;
+
+  log_get_remove_log_archive_interval (is_timed_wait, period);
+
+  if (log_Remove_log_archive_daemon && !is_timed_wait)
     {
-      // If PRM_ID_REMOVE_LOG_ARCHIVES_INTERVAL is 0 (zero) it means that daemon is sleeping
+      // if is_timed_wait is false it means that daemon is sleeping
       // and on wakeup it will do his job,
       // otherwise daemon will be awakened every PRM_ID_REMOVE_LOG_ARCHIVES_INTERVAL seconds
       log_Remove_log_archive_daemon->wakeup ();
@@ -10270,7 +10349,7 @@ log_wakeup_remove_log_archive_daemon ()
 }
 #endif /* SERVER_MODE */
 
-#if defined(SERVER_MODE)
+#if defined (SERVER_MODE)
 /*
  * log_wakeup_checkpoint_daemon () - wakeup checkpoint daemon
  */
@@ -10283,6 +10362,34 @@ log_wakeup_checkpoint_daemon ()
     }
 }
 #endif /* SERVER_MODE */
+
+/*
+ * log_wakeup_log_flush_daemon () - wakeup log flush daemon
+ */
+void
+log_wakeup_log_flush_daemon ()
+{
+  if (log_is_log_flush_daemon_available ())
+    {
+#if defined (SERVER_MODE)
+      log_Flush_has_been_requested = true;
+      log_Flush_daemon->wakeup ();
+#endif /* SERVER_MODE */
+    }
+}
+
+/*
+ * log_is_log_flush_daemon_available () - check if log flush daemon is available
+ */
+bool
+log_is_log_flush_daemon_available ()
+{
+#if defined (SERVER_MODE)
+  return log_Flush_daemon != NULL;
+#else
+  return false;
+#endif
+}
 
 // *INDENT-OFF*
 #if defined(SERVER_MODE)
@@ -10319,15 +10426,7 @@ class log_checkpoint_daemon_task : public cubthread::entry_task
 //
 class log_remove_log_archive_daemon_task : public cubthread::entry_task
 {
-  private:
-    int m_archive_logs_to_delete;
-
   public:
-    explicit log_remove_log_archive_daemon_task (int archive_logs_to_delete)
-    {
-      this->m_archive_logs_to_delete = archive_logs_to_delete;
-    }
-
     void execute (cubthread::entry & thread_ref) override
     {
       if (!BO_IS_SERVER_RESTARTED ())
@@ -10336,7 +10435,16 @@ class log_remove_log_archive_daemon_task : public cubthread::entry_task
 	  return;
 	}
 
-      logpb_remove_archive_logs_exceed_limit (&thread_ref, m_archive_logs_to_delete);
+      bool is_timed_wait;
+      cubthread::delta_time period;
+
+      log_get_remove_log_archive_interval (is_timed_wait, period);
+
+      // if is_timed_wait is true then on every loop remove one log archive
+      // otherwise on wakeup remove all log archive records
+      int archive_logs_to_delete = is_timed_wait ? 1 : 0;
+
+      logpb_remove_archive_logs_exceed_limit (&thread_ref, archive_logs_to_delete);
     }
 };
 #endif /* SERVER_MODE */
@@ -10460,6 +10568,39 @@ class log_check_ha_delay_info_daemon_task : public cubthread::entry_task
 };
 #endif /* SERVER_MODE */
 
+#if defined (SERVER_MODE)
+// class log_flush_daemon_task
+//
+//  description:
+//    log flush daemon task
+//
+class log_flush_daemon_task : public cubthread::entry_task
+{
+  public:
+    void execute (cubthread::entry & thread_ref) override
+    {
+      if (!BO_IS_SERVER_RESTARTED () || !log_Flush_has_been_requested)
+	{
+	  return;
+	}
+
+      // refresh log trace flush time
+      thread_ref.event_stats.trace_log_flush_time = prm_get_integer_value (PRM_ID_LOG_TRACE_FLUSH_TIME_MSECS);
+
+      LOG_CS_ENTER (&thread_ref);
+      logpb_flush_pages_direct (&thread_ref);
+      LOG_CS_EXIT (&thread_ref);
+
+      log_Stat.gc_flush_count++;
+
+      pthread_mutex_lock (&log_Gl.group_commit_info.gc_mutex);
+      pthread_cond_broadcast (&log_Gl.group_commit_info.gc_cond);
+      log_Flush_has_been_requested = false;
+      pthread_mutex_unlock (&log_Gl.group_commit_info.gc_mutex);
+    }
+};
+#endif /* SERVER_MODE */
+
 #if defined(SERVER_MODE)
 /*
  * log_checkpoint_daemon_init () - initialize checkpoint daemon
@@ -10469,10 +10610,11 @@ log_checkpoint_daemon_init ()
 {
   assert (log_Checkpoint_daemon == NULL);
 
+  cubthread::looper looper = cubthread::looper (log_get_checkpoint_interval);
+  log_checkpoint_daemon_task *daemon_task = new log_checkpoint_daemon_task ();
+
   // create checkpoint daemon thread
-  auto looper_interval = std::chrono::seconds (prm_get_integer_value (PRM_ID_LOG_CHECKPOINT_INTERVAL_SECS));
-  log_Checkpoint_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (looper_interval),
-			  new log_checkpoint_daemon_task ());
+  log_Checkpoint_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
 }
 #endif /* SERVER_MODE */
 
@@ -10485,23 +10627,11 @@ log_remove_log_archive_daemon_init ()
 {
   assert (log_Remove_log_archive_daemon == NULL);
 
-  // get remove log archive interval in seconds system parameter
-  int remove_log_archive_interval = prm_get_integer_value (PRM_ID_REMOVE_LOG_ARCHIVES_INTERVAL);
+  cubthread::looper looper = cubthread::looper (log_get_remove_log_archive_interval);
+  log_remove_log_archive_daemon_task *daemon_task = new log_remove_log_archive_daemon_task ();
 
   // create log archive remover daemon thread
-  if (remove_log_archive_interval > 0)
-    {
-      // if interval is greater than 0 (zero) then on every loop remove one log archive
-      log_Remove_log_archive_daemon = cubthread::get_manager ()->create_daemon (
-					      cubthread::looper (std::chrono::seconds (remove_log_archive_interval)),
-					      new log_remove_log_archive_daemon_task (1));
-    }
-  else
-    {
-      // if interval is equal to 0 (zero) then on wakeup remove all log archive records
-      log_Remove_log_archive_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (),
-				      new log_remove_log_archive_daemon_task (0));
-    }
+  log_Remove_log_archive_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
 }
 #endif /* SERVER_MODE */
 
@@ -10514,9 +10644,8 @@ log_clock_daemon_init ()
 {
   assert (log_Clock_daemon == NULL);
 
-  auto looper_interval = std::chrono::milliseconds (200);
-  log_Clock_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (looper_interval),
-			 new log_clock_daemon_task ());
+  cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (200));
+  log_Clock_daemon = cubthread::get_manager ()->create_daemon (looper, new log_clock_daemon_task ());
 }
 #endif /* SERVER_MODE */
 
@@ -10529,9 +10658,26 @@ log_check_ha_delay_info_daemon_init ()
 {
   assert (log_Check_ha_delay_info_daemon == NULL);
 
-  auto looper_interval = std::chrono::seconds (1);
-  log_Check_ha_delay_info_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (looper_interval),
-				   new log_check_ha_delay_info_daemon_task ());
+  cubthread::looper looper = cubthread::looper (std::chrono::seconds (1));
+  log_check_ha_delay_info_daemon_task *daemon_task = new log_check_ha_delay_info_daemon_task ();
+
+  log_Check_ha_delay_info_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+}
+#endif /* SERVER_MODE */
+
+#if defined(SERVER_MODE)
+/*
+ * log_flush_daemon_init () - initialize log flush daemon
+ */
+void
+log_flush_daemon_init ()
+{
+  assert (log_Flush_daemon == NULL);
+
+  cubthread::looper looper = cubthread::looper (log_get_log_group_commit_interval);
+  log_flush_daemon_task *daemon_task = new log_flush_daemon_task ();
+
+  log_Flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
 }
 #endif /* SERVER_MODE */
 
@@ -10546,6 +10692,7 @@ log_daemons_init ()
   log_checkpoint_daemon_init ();
   log_check_ha_delay_info_daemon_init ();
   log_clock_daemon_init ();
+  log_flush_daemon_init ();
 }
 #endif /* SERVER_MODE */
 
@@ -10560,6 +10707,7 @@ log_daemons_destroy ()
   cubthread::get_manager ()->destroy_daemon (log_Checkpoint_daemon);
   cubthread::get_manager ()->destroy_daemon (log_Check_ha_delay_info_daemon);
   cubthread::get_manager ()->destroy_daemon (log_Clock_daemon);
+  cubthread::get_manager ()->destroy_daemon (log_Flush_daemon);
 }
 #endif /* SERVER_MODE */
 // *INDENT-ON*

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -204,5 +204,8 @@ extern INT64 log_get_clock_msec (void);
 
 extern void log_wakeup_remove_log_archive_daemon ();
 extern void log_wakeup_checkpoint_daemon ();
+extern void log_wakeup_log_flush_daemon ();
+
+extern bool log_is_log_flush_daemon_available ();
 
 #endif /* _LOG_MANAGER_H_ */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3837,7 +3837,7 @@ prior_lsa_next_record_internal (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * node, 
 #if defined(SERVER_MODE)
 	  if (!log_is_in_crash_recovery ())
 	    {
-	      thread_wakeup_log_flush_thread ();
+	      log_wakeup_log_flush_daemon ();
 
 	      thread_sleep (1);	/* 1msec */
 	    }
@@ -4754,7 +4754,7 @@ logpb_flush_pages (THREAD_ENTRY * thread_p, LOG_LSA * flush_lsa)
     }
   assert (!LOG_CS_OWN_WRITE_MODE (thread_p));
 
-  if (!thread_is_log_flush_thread_available ())
+  if (!log_is_log_flush_daemon_available ())
     {
       LOG_CS_ENTER (thread_p);
       logpb_flush_pages_direct (thread_p);
@@ -4801,7 +4801,7 @@ logpb_flush_pages (THREAD_ENTRY * thread_p, LOG_LSA * flush_lsa)
 
   if (need_wakeup_LFT == true && need_wait == false)
     {
-      thread_wakeup_log_flush_thread ();
+      log_wakeup_log_flush_daemon ();
     }
   else if (need_wait == true)
     {
@@ -4828,7 +4828,7 @@ logpb_flush_pages (THREAD_ENTRY * thread_p, LOG_LSA * flush_lsa)
 
 	  if (need_wakeup_LFT == true)
 	    {
-	      thread_wakeup_log_flush_thread ();
+	      log_wakeup_log_flush_daemon ();
 	    }
 	  (void) pthread_cond_timedwait (&group_commit_info->gc_cond, &group_commit_info->gc_mutex, &to);
 	  pthread_mutex_unlock (&group_commit_info->gc_mutex);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21852

This patch includes:
- option to provide a period function to the thread looper that will be used to refresh sleep interval on every task execution
- change of the daemon sleep strategy
from: **execute task then sleep for fixed period**
to: **execute task then sleep for `fixed period - execution time`**
- migration of log flush daemon