### PR TITLE
[CBRD-21952] flush pages directly on server stop

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4744,7 +4744,7 @@ logpb_flush_pages (THREAD_ENTRY * thread_p, LOG_LSA * flush_lsa)
 
   assert (flush_lsa != NULL && !LSA_ISNULL (flush_lsa));
 
-  if (!LOG_ISRESTARTED () || flush_lsa == NULL || LSA_ISNULL (flush_lsa))
+  if (!BO_IS_SERVER_RESTARTED () || flush_lsa == NULL || LSA_ISNULL (flush_lsa))
     {
       LOG_CS_ENTER (thread_p);
       logpb_flush_pages_direct (thread_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21952

When server is down and log flush daemon is not yet stopped, a worker thread needs to flush pages directly not through daemon.