### PR TITLE
[CBRD-21958] set upper limit for checkpoint sleep parameter

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -998,6 +998,7 @@ static unsigned int prm_log_checkpoint_interval_secs_flag = 0;
 
 int PRM_LOG_CHECKPOINT_SLEEP_MSECS = 1;
 static int prm_log_checkpoint_sleep_msecs_default = 1;
+static int prm_log_checkpoint_sleep_msecs_upper = 100;
 static int prm_log_checkpoint_sleep_msecs_lower = 0;
 static unsigned int prm_log_checkpoint_sleep_msecs_flag = 0;
 
@@ -2533,7 +2534,8 @@ static SYSPRM_PARAM prm_Def[] = {
    &prm_log_checkpoint_sleep_msecs_flag,
    (void *) &prm_log_checkpoint_sleep_msecs_default,
    (void *) &PRM_LOG_CHECKPOINT_SLEEP_MSECS,
-   (void *) NULL, (void *) &prm_log_checkpoint_sleep_msecs_lower,
+   (void *) &prm_log_checkpoint_sleep_msecs_upper,
+   (void *) &prm_log_checkpoint_sleep_msecs_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -3731,7 +3731,7 @@ pgbuf_flush_chkpt_seq_list (THREAD_ENTRY * thread_p, PGBUF_SEQ_FLUSHER * seq_flu
   sleep_msecs = prm_get_integer_value (PRM_ID_LOG_CHECKPOINT_SLEEP_MSECS);
   if (sleep_msecs > 0)
     {
-      chkpt_flush_rate = 1000.0f / (float) sleep_msecs;
+      chkpt_flush_rate = sleep_msecs / 1000.0f;
     }
   else
     {

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -3731,7 +3731,7 @@ pgbuf_flush_chkpt_seq_list (THREAD_ENTRY * thread_p, PGBUF_SEQ_FLUSHER * seq_flu
   sleep_msecs = prm_get_integer_value (PRM_ID_LOG_CHECKPOINT_SLEEP_MSECS);
   if (sleep_msecs > 0)
     {
-      chkpt_flush_rate = sleep_msecs / 1000.0f;
+      chkpt_flush_rate = 1000.0f / (float) sleep_msecs;
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21958

Set upper limit for checkpoint_sleep_msecs system parameter to 100 milli seconds.