### PR TITLE
[CBRD-21960] fixed memory leak of "show columns"

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -22746,7 +22746,8 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 
 		  strcat (default_value_string, ")");
 
-		  db_make_string_by_const_str (out_values[idx_val], default_value_string);
+		  db_make_string (out_values[idx_val], default_value_string);
+		  out_values[idx_val]->need_clear = true;
 		}
 	      else
 		{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21960

There was memory leak of `default (TO_CHAR(...) )` expression.