### PR TITLE
[CBRD-21974] fix pt_make_val_list type missmatch

### DIFF
--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -145,7 +145,6 @@ db_value_put_null (DB_VALUE * value)
  *  scale(in)     : Scale.
  *
  */
-
 int
 db_value_domain_init (DB_VALUE * value, const DB_TYPE type, const int precision, const int scale)
 {
@@ -383,6 +382,18 @@ db_value_domain_init (DB_VALUE * value, const DB_TYPE type, const int precision,
     }
 
   return error;
+}
+
+// db_value_domain_init_default - default value initialization
+//
+// value - db_value to init
+// type - desired type of value
+//
+void
+db_value_domain_init_default (DB_VALUE * value, const DB_TYPE type)
+{
+  // default initialization should not fail
+  (void) db_value_domain_init (value, type, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 }
 
 /*

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -177,6 +177,7 @@ extern "C"
   extern int db_value_equal (const DB_VALUE * value1, const DB_VALUE * value2);
   extern int db_value_compare (const DB_VALUE * value1, const DB_VALUE * value2);
   extern int db_value_domain_init (DB_VALUE * value, DB_TYPE type, const int precision, const int scale);
+  extern void db_value_domain_init_default (DB_VALUE * value, const DB_TYPE type);
   extern int db_value_domain_min (DB_VALUE * value, DB_TYPE type, const int precision, const int scale,
 				  const int codeset, const int collation_id, const DB_ENUMERATION * enumeration);
   extern int db_value_domain_max (DB_VALUE * value, DB_TYPE type, const int precision, const int scale,

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -1292,9 +1292,11 @@ pt_data_type_init_value (const PT_NODE * node, DB_VALUE * value_out)
 
   if (node->data_type == NULL)
     {
-      // nothing to init
+      // init as node->type_enum
+      db_value_domain_init_default (value_out, pt_type_enum_to_db (node->type_enum));
       return;
     }
+  // node->data_type is not null
 
   // get data type
   PT_NODE *node_data_type = node->data_type;

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -1325,7 +1325,7 @@ pt_data_type_init_value (const PT_NODE * node, DB_VALUE * value_out)
       value_out->domain.numeric_info.scale = node_data_type->info.data_type.dec_precision;
       break;
     case DB_TYPE_JSON:
-      // we should really move json_schema from value
+      // we should really move json_schema from value.data
       if (node_data_type->info.data_type.json_schema != NULL)
 	{
 	  value_out->data.json.schema_raw =

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -1276,6 +1276,71 @@ pt_value_to_db (PARSER_CONTEXT * parser, PT_NODE * value)
   return (db_value);
 }
 
+// pt_data_type_init_value - initialize value according to node data type
+//
+// node      : PT_NODE for which value_out is initialized
+// value_out : DB_VALUE initialized according to node data type
+//
+void
+pt_data_type_init_value (const PT_NODE * node, DB_VALUE * value_out)
+{
+  // init as null
+  db_make_null (value_out);
+
+  // make sure we get rid of pointer
+  CAST_POINTER_TO_NODE (node);
+
+  if (node->data_type == NULL)
+    {
+      // nothing to init
+      return;
+    }
+
+  // get data type
+  PT_NODE *node_data_type = node->data_type;
+  DB_TYPE node_db_type = pt_type_enum_to_db (node_data_type->type_enum);
+
+  if (node_db_type == DB_TYPE_OBJECT && node->data_type->info.data_type.virt_object != NULL)
+    {
+      // virtual object
+      node_db_type = DB_TYPE_VOBJ;
+    }
+
+  db_value_domain_init_default (value_out, node_db_type);
+  switch (node_db_type)
+    {
+    case DB_TYPE_VARCHAR:
+    case DB_TYPE_CHAR:
+    case DB_TYPE_NCHAR:
+    case DB_TYPE_VARNCHAR:
+    case DB_TYPE_BIT:
+    case DB_TYPE_VARBIT:
+      value_out->domain.char_info.length = node_data_type->info.data_type.precision;
+      break;
+
+    case DB_TYPE_NUMERIC:
+      value_out->domain.numeric_info.precision = node_data_type->info.data_type.precision;
+      value_out->domain.numeric_info.scale = node_data_type->info.data_type.dec_precision;
+      break;
+    case DB_TYPE_JSON:
+      // we should really move json_schema from value
+      if (node_data_type->info.data_type.json_schema != NULL)
+	{
+	  value_out->data.json.schema_raw =
+	    db_private_strdup (NULL, (const char *) node_data_type->info.data_type.json_schema->bytes);
+	  value_out->need_clear = true;
+	}
+      else
+	{
+	  value_out->data.json.schema_raw = NULL;
+	}
+      break;
+
+    default:
+      ;				/* Do nothing. This suppresses compiler's warnings. */
+    }
+}
+
 /*
  * pt_string_to_db_domain() - returns DB_DOMAIN * that matches the string
  *   return:  a DB_DOMAIN

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -219,6 +219,7 @@ extern "C"
   extern DB_DOMAIN *pt_string_to_db_domain (const char *s, const char *class_name);
 
   extern DB_VALUE *pt_value_to_db (PARSER_CONTEXT * parser, PT_NODE * value);
+  extern void pt_data_type_init_value (const PT_NODE * node, DB_VALUE * value_out);
 
   extern int pt_coerce_value (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE_ENUM desired_type,
 			      PT_NODE * elem_type_list);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21974

This is momentarily a test PR. I'd like to see regression results and then discuss the fix.

@cristighr1995 found an issue while investigating crash on #1039.

Scenario can easily reproduce:
```sql
  create table t (i int, [json] json );
  update t set [json]='111' where [json]='"a"' order by [json];
```

The problem was ultimately generated by unsafe ```pt_init_precision_and_scale```. It wants to set precision and scale in value according to node data type, but does no check if data types match. Therefore, it may modify wrong fields in wrong type of domain/data.

With JSON, since its schema is stored in ```value.data```, it overwrites the ```value.data.ch.medium``` when value is char type. Before Cristi's changes, the overwrite was harmless because it "missed" vital fields. Now that ```value.data.json``` structure is changed, it overwrites ```value.data.ch.codeset```.

However, same issue can be observed with any types. I changed the type from JSON to integer and same issue happens. However, it is mostly harmless because it doesn't override vital fields when type is not correct.

This patch tries a proper fix, however I am afraid of side effects. Let's see regression results.

EDIT:
The fix seems to generate no sql/medium regressions.