### PR TITLE
[CBRD-21970] fix lfcq & vacuum

### DIFF
--- a/src/base/lockfree_circular_queue.hpp
+++ b/src/base/lockfree_circular_queue.hpp
@@ -47,10 +47,10 @@ namespace lockfree
   class circular_queue
   {
     public:
-      typedef std::uint64_t cursor_type;
-      typedef std::atomic<cursor_type> atomic_cursor_type;
-      typedef std::atomic<T> atomic_data_type;
-      typedef atomic_cursor_type atomic_flag_type;
+      using cursor_type = std::uint64_t;
+      using atomic_cursor_type = std::atomic<cursor_type>;
+      using data_type = T;
+      using atomic_flag_type = atomic_cursor_type;
 
       circular_queue (std::size_t size);
       ~circular_queue ();
@@ -98,7 +98,7 @@ namespace lockfree
       inline void unblock (cursor_type cursor);
       inline void init_blocked_cursors (void);
 
-      atomic_data_type *m_data;   // data storage. access is atomic
+      data_type *m_data;   // data storage. access is atomic
       atomic_flag_type *m_blocked_cursors;  // is_blocked flag; when producing new data, there is a time window between
       // cursor increment and until data is copied. block flag will tell when
       // produce is completed.
@@ -211,7 +211,7 @@ namespace lockfree
     m_index_mask = m_capacity - 1;
     assert ((m_capacity & m_index_mask) == 0);
 
-    m_data = new atomic_data_type[m_capacity];
+    m_data = new data_type[m_capacity];
     init_blocked_cursors ();
   }
 
@@ -445,14 +445,14 @@ namespace lockfree
   inline void
   circular_queue<T>::store_data (cursor_type cursor, const T &data)
   {
-    m_data[get_cursor_index (cursor)].store (data);
+    m_data[get_cursor_index (cursor)] = data;
   }
 
   template<class T>
   inline T
   circular_queue<T>::load_data (cursor_type consume_cursor) const
   {
-    return m_data[get_cursor_index (consume_cursor)].load ();
+    return m_data[get_cursor_index (consume_cursor)];
   }
 
   template<class T>

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -374,7 +374,7 @@ struct vacuum_job_entry
  * added directly to vacuum data.
  */
 /* *INDENT-OFF* */
-lockfree::circular_queue<VACUUM_DATA_ENTRY *> *vacuum_Block_data_buffer = NULL;
+lockfree::circular_queue<vacuum_data_entry> *vacuum_Block_data_buffer = NULL;
 /* *INDENT-ON* */
 #define VACUUM_BLOCK_DATA_BUFFER_CAPACITY 1024
 
@@ -949,7 +949,7 @@ vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npages, VFID * 
 
   /* Initialize the log block data buffer */
   /* *INDENT-OFF* */
-  vacuum_Block_data_buffer = new lockfree::circular_queue<VACUUM_DATA_ENTRY *> (VACUUM_BLOCK_DATA_BUFFER_CAPACITY);
+  vacuum_Block_data_buffer = new lockfree::circular_queue<vacuum_data_entry> (VACUUM_BLOCK_DATA_BUFFER_CAPACITY);
   /* *INDENT-ON* */
   if (vacuum_Block_data_buffer == NULL)
     {
@@ -2736,7 +2736,7 @@ vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, MVC
 		 (unsigned long long int) block_data.oldest_mvccid, (unsigned long long int) block_data.newest_mvccid);
 
   /* Push new block into block data buffer */
-  if (!vacuum_Block_data_buffer->produce (&block_data))
+  if (!vacuum_Block_data_buffer->produce (block_data))
     {
       /* Push failed, the buffer must be full */
       /* TODO: Set a new message error for full block data buffer */
@@ -5017,7 +5017,6 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 {
 #define MAX_PAGE_MAX_DATA_ENTRIES (IO_MAX_PAGE_SIZE / sizeof (VACUUM_DATA_ENTRY))
   VACUUM_DATA_ENTRY consumed_data;
-  VACUUM_DATA_ENTRY *consumed_data_ptr = &consumed_data;
   VACUUM_DATA_PAGE *data_page = NULL;
   VACUUM_DATA_ENTRY *page_free_data = NULL;
   VACUUM_DATA_ENTRY *save_page_free_data = NULL;
@@ -5063,7 +5062,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 
   was_vacuum_data_empty = vacuum_is_empty ();
 
-  while (vacuum_Block_data_buffer->consume (consumed_data_ptr))
+  while (vacuum_Block_data_buffer->consume (consumed_data))
     {
       assert (vacuum_Data.last_blockid < consumed_data.blockid);
 
@@ -5541,7 +5540,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   /* Produce recovered blocks. */
   while (!vacuum_block_data_buffer_stack.empty ())
     {
-      vacuum_Block_data_buffer->produce (&vacuum_block_data_buffer_stack.top ());
+      vacuum_Block_data_buffer->produce (vacuum_block_data_buffer_stack.top ());
       vacuum_block_data_buffer_stack.pop ();
     }
 

--- a/unit_tests/lockfree/test_cqueue_functional.cpp
+++ b/unit_tests/lockfree/test_cqueue_functional.cpp
@@ -275,6 +275,8 @@ namespace test_lockfree
     /* queue size */
     size_t one_k_cqueue_size = 1024;
 
+    auto start_time = std::chrono::high_resolution_clock::now ();
+
 #if 0
     /* test for hangs */
     test_cqueue_no_hang (one_thread_count, core_count, one_mil_op_count, one_k_cqueue_size);
@@ -292,6 +294,10 @@ namespace test_lockfree
     test_cqueue_values_match (core_count_x2, one_mil_op_count, one_k_cqueue_size);
 
     std::cout << std::endl;
+
+    std::chrono::nanoseconds nanos = std::chrono::high_resolution_clock::now () - start_time;
+    std::uint64_t milli_count = nanos.count () / 1000000;
+    std::cout << milli_count << std::endl;
 
     return 0;
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21970

Fix producing/consuming block data buffers. Current version that produces and consumes pointers to data is broken.

Side effect of fix is that lock-free circular queue data type is no longer limited to atomic types. I don't think the restrictions was so useful anyway. Simple copy instructions should be enough, with the note that more complex structure may suffer performance penalties.

Should also fix [CBRD-21971](http://jira.cubrid.org/browse/CBRD-21971), [CBRD-21972](http://jira.cubrid.org/browse/CBRD-21972) and [CBRD-21973](http://jira.cubrid.org/browse/CBRD-21973)