### PR TITLE
[CBRD-21976][Regression] make locale failed on Windows

### DIFF
--- a/locales/make_locale_x64.bat
+++ b/locales/make_locale_x64.bat
@@ -99,10 +99,10 @@ if defined VS150COMCOMNTOOLS (
 @echo checking Visual Studio 2017 v140... VS140COMNTOOLS = "%VS140COMNTOOLS%"
 if defined VS140COMNTOOLS (
     @echo. Found installation for Visual Studio 2017 v140: "%VS140COMNTOOLS%"
-    @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\ToolsVsDevCmd.bat"
-    if exist "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\ToolsVsDevCmd.bat" (
+    @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat"
+    if exist "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat" (
         echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Community.
-        call "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\ToolsVsDevCmd.bat" -arch=amd64
+        call "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64
         goto :BUILD
     )
     @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat"

--- a/locales/make_locale_x64.bat
+++ b/locales/make_locale_x64.bat
@@ -17,6 +17,7 @@ REM  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 US
 
 
 set APP_NAME=%0
+echo %APP_NAME%
 
 set BUILD_TARGET=x64
 set BUILD_MODE=.
@@ -81,7 +82,7 @@ if NOT "%VS150COMCOMNTOOLS%"=="" (
         goto :BUILD
     )
     @rem it should be done similar for Professional and Enterprise editions (like for VS2017v140) but I have access to none of them to be sure about the paths
-    goto :ENV_ERROR
+    @rem configuration for this VS version didn't work, try older VS versions...
 )
 @echo checking Visual Studio 2017 v140... VS140COMNTOOLS = "%VS140COMNTOOLS%"
 if NOT "%VS140COMNTOOLS%"=="" (
@@ -105,7 +106,7 @@ if NOT "%VS140COMNTOOLS%"=="" (
         call "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat" %VS2017_ARCH%
         goto :BUILD
     )
-    goto :ENV_ERROR
+    @rem configuration for this VS version didn't work, try older VS versions...
 )
 @echo checking Visual Studio 2010... VS100COMNTOOLS = "%VS100COMNTOOLS%"
 if NOT "%VS100COMNTOOLS%"=="" (
@@ -116,7 +117,7 @@ if NOT "%VS100COMNTOOLS%"=="" (
         call "%VS100COMNTOOLS%..\..\VC\%VCVARS%"
         goto :BUILD
     )
-    goto :ENV_ERROR
+    @rem configuration for this VS version didn't work, try older VS versions...
 )
 @echo checking Visual Studio 2008... VS90COMNTOOLS = "%VS90COMNTOOLS%"
 if NOT "%VS90COMNTOOLS%"=="" (
@@ -127,7 +128,7 @@ if NOT "%VS90COMNTOOLS%"=="" (
         call "%VS90COMNTOOLS%..\..\VC\%VCVARS%"
         goto :BUILD
     )
-    goto :ENV_ERROR
+    @rem configuration for this VS version didn't work, try older VS versions...
 )
 @echo checking Visual Studio 2005... VS80COMNTOOLS = "%VS80COMNTOOLS%"
 if NOT "%VS80COMNTOOLS%"=="" (
@@ -138,9 +139,9 @@ if NOT "%VS80COMNTOOLS%"=="" (
         call "%VS80COMNTOOLS%..\..\VC\%VCVARS%"
         goto :BUILD
     )
-    goto :ENV_ERROR
+    @rem configuration for this VS version didn't work, try older VS versions...
 )
-@echo. ERROR: no Visual Studio installation found
+@echo. ERROR: no valid Visual Studio installation found
 goto :ENV_ERROR
 
 @rem 2. build

--- a/locales/make_locale_x64.bat
+++ b/locales/make_locale_x64.bat
@@ -72,7 +72,7 @@ if "%BUILD_MODE%" == "." set BUILD_MODE=release
 @echo. Searching for Visual Studio installs...
 
 @rem 1. search Visual Studio installation (from newest to oldest)
-@echo checking Visual Studio 2017 v150... VS150COMNTOOLS = "%VS150COMNTOOLS%"
+@echo checking Visual Studio 2017 v150... VS150COMNTOOLS = "%VS150COMCOMNTOOLS%"
 if defined VS150COMNTOOLS (
     @echo. Found installation for Visual Studio 2017 150: "%VS150COMNTOOLS%"
     if exist "%VS150COMNTOOLS%VsDevCmd.bat" (
@@ -99,24 +99,24 @@ if defined VS150COMCOMNTOOLS (
 @echo checking Visual Studio 2017 v140... VS140COMNTOOLS = "%VS140COMNTOOLS%"
 if defined VS140COMNTOOLS (
     @echo. Found installation for Visual Studio 2017 v140: "%VS140COMNTOOLS%"
-    @echo checking "%VS140COMNTOOLS%VsDevCmd.bat"
-    if exist "%VS140COMNTOOLS%VsDevCmd.bat" (
+    @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\ToolsVsDevCmd.bat"
+    if exist "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\ToolsVsDevCmd.bat" (
         echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Community.
-        call "%VS140COMNTOOLS%VsDevCmd.bat" -arch=amd64
+        call "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\ToolsVsDevCmd.bat" -arch=amd64
         goto :BUILD
     )
-    @echo checking "%VS140COMNTOOLS%VsDevCmd.bat"
-    if exist "%VS140COMNTOOLS%VsDevCmd.bat" (
+    @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat"
+    if exist "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat" (
         echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Professional.
-        @echo call "%VS140COMNTOOLS%VsDevCmd.bat" -arch=amd64
-        call "%VS140COMNTOOLS%VsDevCmd.bat" -arch=amd64
+        @echo call "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat" -arch=amd64
+        call "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat" -arch=amd64
         goto :BUILD
     )
-    @echo checking "%VS140COMNTOOLS%VsDevCmd.bat"
-    if exist "%VS140COMNTOOLS%VsDevCmd.bat" (
+    @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
+    if exist "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat" (
         echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Enterprise.
-        @echo call "%VS140COMNTOOLS%VsDevCmd.bat" -arch=amd64
-        call "%VS140COMNTOOLS%VsDevCmd.bat" -arch=amd64
+        @echo call "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64
+        call "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64
         goto :BUILD
     )
     @rem configuration for this VS version didn't work, try older VS versions...

--- a/locales/make_locale_x64.bat
+++ b/locales/make_locale_x64.bat
@@ -70,72 +70,80 @@ if "%BUILD_MODE%" == "." set BUILD_MODE=release
 
 @echo. Searching for Visual Studio installs...
 
-if NOT "%VS80COMNTOOLS%"=="" (
-@echo. Found installation for Visual Studio 2005
-)
-if NOT "%VS90COMNTOOLS%"=="" (
-@echo. Found installation for Visual Studio 2008
-)
-if NOT "%VS100COMNTOOLS%"=="" (
-@echo. Found installation for Visual Studio 2010
-)
+@rem 1. search Visual Studio installation (from newest to oldest)
+@echo checking Visual Studio 2017 v150... VS150COMCOMNTOOLS = "%VS150COMCOMNTOOLS%"
 if NOT "%VS150COMCOMNTOOLS%"=="" (
-    @echo. Found installation for Visual Studio 2017_150 ("%VS150COMCOMNTOOLS%")
+    @echo. Found installation for Visual Studio 2017 150: "%VS150COMCOMNTOOLS%"
     set VS2017_ARCH=-arch=amd64
-    goto :VS2017_150
+    if exist "%VS150COMCOMNTOOLS%VsDevCmd.bat" (
+        echo Found %BUILD_TARGET% configuration in Visual Studio 2017_150 Community.
+        call "%VS150COMCOMNTOOLS%VsDevCmd.bat" %VS2017_ARCH%
+        goto :BUILD
+    )
+    @rem it should be done similar for Professional and Enterprise editions (like for VS2017v140) but I have access to none of them to be sure about the paths
+    goto :ENV_ERROR
 )
+@echo checking Visual Studio 2017 v140... VS140COMNTOOLS = "%VS140COMNTOOLS%"
 if NOT "%VS140COMNTOOLS%"=="" (
-@echo. Found installation for Visual Studio 2017
-set VS2017_ARCH=-arch=amd64
+    @echo. Found installation for Visual Studio 2017 v140: "%VS140COMNTOOLS%"
+    set VS2017_ARCH=-arch=amd64
+    @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat"
+    if exist "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat" (
+        echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Community.
+        call "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat" %VS2017_ARCH%
+        goto :BUILD
+    )
+    @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat"
+    if exist "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat" (
+        echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Professional.
+        call "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat" %VS2017_ARCH%
+        goto :BUILD
+    )
+    @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
+    if exist "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat" (
+        echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Enterprise.
+        call "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat" %VS2017_ARCH%
+        goto :BUILD
+    )
+    goto :ENV_ERROR
 )
-
-@echo. Checking for %BUILD_TARGET% configuration...
-
-if exist "%VS90COMNTOOLS%..\..\VC\%VCVARS%" (
-@echo. Found %BUILD_TARGET% configuration in Visual Studio 2008.
-call "%VS90COMNTOOLS%..\..\VC\%VCVARS%"
-goto :BUILD
+@echo checking Visual Studio 2010... VS100COMNTOOLS = "%VS100COMNTOOLS%"
+if NOT "%VS100COMNTOOLS%"=="" (
+    @echo. Found installation for Visual Studio 2010
+    @echo checking "%VS100COMNTOOLS%..\..\VC\%VCVARS%"
+    if exist "%VS100COMNTOOLS%..\..\VC\%VCVARS%" (
+        echo Found %BUILD_TARGET% configuration in Visual Studio 2010.
+        call "%VS100COMNTOOLS%..\..\VC\%VCVARS%"
+        goto :BUILD
+    )
+    goto :ENV_ERROR
 )
-
-if exist "%VS80COMNTOOLS%..\..\VC\%VCVARS%" (
-echo Found %BUILD_TARGET% configuration in Visual Studio 2005.
-call "%VS80COMNTOOLS%..\..\VC\%VCVARS%"
-goto :BUILD
+@echo checking Visual Studio 2008... VS90COMNTOOLS = "%VS90COMNTOOLS%"
+if NOT "%VS90COMNTOOLS%"=="" (
+    @echo. Found installation for Visual Studio 2008
+    @echo checking "%VS90COMNTOOLS%..\..\VC\%VCVARS%"
+    if exist "%VS90COMNTOOLS%..\..\VC\%VCVARS%" (
+        @echo. Found %BUILD_TARGET% configuration in Visual Studio 2008.
+        call "%VS90COMNTOOLS%..\..\VC\%VCVARS%"
+        goto :BUILD
+    )
+    goto :ENV_ERROR
 )
-
-if exist "%VS100COMNTOOLS%..\..\VC\%VCVARS%" (
-echo Found %BUILD_TARGET% configuration in Visual Studio 2010.
-call "%VS100COMNTOOLS%..\..\VC\%VCVARS%"
-goto :BUILD
+@echo checking Visual Studio 2005... VS80COMNTOOLS = "%VS80COMNTOOLS%"
+if NOT "%VS80COMNTOOLS%"=="" (
+    @echo. Found installation for Visual Studio 2005
+    @echo checking "%VS80COMNTOOLS%..\..\VC\%VCVARS%"
+    if exist "%VS80COMNTOOLS%..\..\VC\%VCVARS%" (
+        echo Found %BUILD_TARGET% configuration in Visual Studio 2005.
+        call "%VS80COMNTOOLS%..\..\VC\%VCVARS%"
+        goto :BUILD
+    )
+    goto :ENV_ERROR
 )
-
-if exist "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat" (
-echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Community.
-call "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat" %VS2017_ARCH%
-goto :BUILD
-)
-
-if exist "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat" (
-echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Professional.
-call "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat" %VS2017_ARCH%
-goto :BUILD
-)
-
-if exist "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat" (
-echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Enterprise.
-call "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat" %VS2017_ARCH%
-goto :BUILD
-)
-
-:VS2017_150
-if exist "%VS150COMCOMNTOOLS%VsDevCmd.bat" (
-    echo Found %BUILD_TARGET% configuration in Visual Studio 2017_150 Community.
-    call "%VS150COMCOMNTOOLS%VsDevCmd.bat" %VS2017_ARCH%
-    goto :BUILD
-)
-
+@echo. ERROR: no Visual Studio installation found
 goto :ENV_ERROR
 
+@rem 2. build
 :BUILD
 @echo. Running %APP_NAME% with parameters:
 @echo.         BUILD_TARGET = %BUILD_TARGET%
@@ -219,10 +227,10 @@ goto :GENERIC_ERROR
 
 :GENERIC_ERROR
 if exist %CUBRID%\locales\loclib\Output (
-rmdir /S /Q %CUBRID%\locales\loclib\Output
+    rmdir /S /Q %CUBRID%\locales\loclib\Output
 )
 if exist %CUBRID%\locales\loclib\locale.c (
-del /Q %CUBRID%\locales\loclib\locale.c
+    del /Q %CUBRID%\locales\loclib\locale.c
 )
 
 :eof

--- a/locales/make_locale_x64.bat
+++ b/locales/make_locale_x64.bat
@@ -72,13 +72,25 @@ if "%BUILD_MODE%" == "." set BUILD_MODE=release
 @echo. Searching for Visual Studio installs...
 
 @rem 1. search Visual Studio installation (from newest to oldest)
+@echo checking Visual Studio 2017 v150... VS150COMNTOOLS = "%VS150COMNTOOLS%"
+if defined VS150COMNTOOLS (
+    @echo. Found installation for Visual Studio 2017 150: "%VS150COMNTOOLS%"
+    if exist "%VS150COMNTOOLS%VsDevCmd.bat" (
+        echo Found %BUILD_TARGET% configuration in Visual Studio 2017_150 Community.
+        @echo call "%VS150COMNTOOLS%VsDevCmd.bat" -arch=amd64
+        call "%VS150COMNTOOLS%VsDevCmd.bat" -arch=amd64
+        goto :BUILD
+    )
+    @rem it should be done similar for Professional and Enterprise editions (like for VS2017v140) but I have access to none of them to be sure about the paths
+    @rem configuration for this VS version didn't work, try older VS versions...
+)
 @echo checking Visual Studio 2017 v150... VS150COMCOMNTOOLS = "%VS150COMCOMNTOOLS%"
 if defined VS150COMCOMNTOOLS (
     @echo. Found installation for Visual Studio 2017 150: "%VS150COMCOMNTOOLS%"
-    set VS2017_ARCH=-arch=amd64
     if exist "%VS150COMCOMNTOOLS%VsDevCmd.bat" (
         echo Found %BUILD_TARGET% configuration in Visual Studio 2017_150 Community.
-        call "%VS150COMCOMNTOOLS%VsDevCmd.bat" %VS2017_ARCH%
+        @echo call "%VS150COMCOMNTOOLS%VsDevCmd.bat" -arch=amd64
+        call "%VS150COMCOMNTOOLS%VsDevCmd.bat" -arch=amd64
         goto :BUILD
     )
     @rem it should be done similar for Professional and Enterprise editions (like for VS2017v140) but I have access to none of them to be sure about the paths
@@ -87,23 +99,24 @@ if defined VS150COMCOMNTOOLS (
 @echo checking Visual Studio 2017 v140... VS140COMNTOOLS = "%VS140COMNTOOLS%"
 if defined VS140COMNTOOLS (
     @echo. Found installation for Visual Studio 2017 v140: "%VS140COMNTOOLS%"
-    set VS2017_ARCH=-arch=amd64
-    @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat"
-    if exist "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat" (
+    @echo checking "%VS140COMNTOOLS%VsDevCmd.bat"
+    if exist "%VS140COMNTOOLS%VsDevCmd.bat" (
         echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Community.
-        call "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat" %VS2017_ARCH%
+        call "%VS140COMNTOOLS%VsDevCmd.bat" -arch=amd64
         goto :BUILD
     )
-    @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat"
-    if exist "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat" (
+    @echo checking "%VS140COMNTOOLS%VsDevCmd.bat"
+    if exist "%VS140COMNTOOLS%VsDevCmd.bat" (
         echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Professional.
-        call "%VS140COMNTOOLS%..\..\..\..\2017\Professional\Common7\Tools\VsDevCmd.bat" %VS2017_ARCH%
+        @echo call "%VS140COMNTOOLS%VsDevCmd.bat" -arch=amd64
+        call "%VS140COMNTOOLS%VsDevCmd.bat" -arch=amd64
         goto :BUILD
     )
-    @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
-    if exist "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat" (
+    @echo checking "%VS140COMNTOOLS%VsDevCmd.bat"
+    if exist "%VS140COMNTOOLS%VsDevCmd.bat" (
         echo Found %BUILD_TARGET% configuration in Visual Studio 2017 Enterprise.
-        call "%VS140COMNTOOLS%..\..\..\..\2017\Enterprise\Common7\Tools\VsDevCmd.bat" %VS2017_ARCH%
+        @echo call "%VS140COMNTOOLS%VsDevCmd.bat" -arch=amd64
+        call "%VS140COMNTOOLS%VsDevCmd.bat" -arch=amd64
         goto :BUILD
     )
     @rem configuration for this VS version didn't work, try older VS versions...
@@ -114,6 +127,7 @@ if defined VS100COMNTOOLS (
     @echo checking "%VS100COMNTOOLS%..\..\VC\%VCVARS%"
     if exist "%VS100COMNTOOLS%..\..\VC\%VCVARS%" (
         echo Found %BUILD_TARGET% configuration in Visual Studio 2010.
+        @echo call "%VS100COMNTOOLS%..\..\VC\%VCVARS%"
         call "%VS100COMNTOOLS%..\..\VC\%VCVARS%"
         goto :BUILD
     )
@@ -125,6 +139,7 @@ if defined VS90COMNTOOLS (
     @echo checking "%VS90COMNTOOLS%..\..\VC\%VCVARS%"
     if exist "%VS90COMNTOOLS%..\..\VC\%VCVARS%" (
         @echo. Found %BUILD_TARGET% configuration in Visual Studio 2008.
+        @echo call "%VS90COMNTOOLS%..\..\VC\%VCVARS%"
         call "%VS90COMNTOOLS%..\..\VC\%VCVARS%"
         goto :BUILD
     )
@@ -136,6 +151,7 @@ if defined VS80COMNTOOLS (
     @echo checking "%VS80COMNTOOLS%..\..\VC\%VCVARS%"
     if exist "%VS80COMNTOOLS%..\..\VC\%VCVARS%" (
         echo Found %BUILD_TARGET% configuration in Visual Studio 2005.
+        @echo call "%VS80COMNTOOLS%..\..\VC\%VCVARS%"
         call "%VS80COMNTOOLS%..\..\VC\%VCVARS%"
         goto :BUILD
     )
@@ -153,15 +169,19 @@ goto :ENV_ERROR
 @echo. 
 
 @echo. Generating locale C file for %SELECTED_LOCALE% ...
+@echo cubrid genlocale %LOCALE_PARAM%
 cubrid genlocale %LOCALE_PARAM%
 
 if %ERRORLEVEL% NEQ 0 goto :ERROR_GENLOCALE
 
-echo Compiling locale library ...
+echo Compiling locale library ... using:
+@where cl.exe
+@where link.exe
 
 mkdir %CUBRID%\locales\loclib\Output
 set CURRENT_DIR=%CD%
 cd /D %CUBRID%\locales\loclib
+@echo nmake -f makefile %BUILD_MODE%
 nmake -f makefile %BUILD_MODE%
 echo Done.
 cd /D %CURRENT_DIR%

--- a/locales/make_locale_x64.bat
+++ b/locales/make_locale_x64.bat
@@ -72,7 +72,7 @@ if "%BUILD_MODE%" == "." set BUILD_MODE=release
 @echo. Searching for Visual Studio installs...
 
 @rem 1. search Visual Studio installation (from newest to oldest)
-@echo checking Visual Studio 2017 v150... VS150COMNTOOLS = "%VS150COMCOMNTOOLS%"
+@echo checking Visual Studio 2017 v150... VS150COMNTOOLS = "%VS150COMNTOOLS%"
 if defined VS150COMNTOOLS (
     @echo. Found installation for Visual Studio 2017 150: "%VS150COMNTOOLS%"
     if exist "%VS150COMNTOOLS%VsDevCmd.bat" (

--- a/locales/make_locale_x64.bat
+++ b/locales/make_locale_x64.bat
@@ -73,7 +73,7 @@ if "%BUILD_MODE%" == "." set BUILD_MODE=release
 
 @rem 1. search Visual Studio installation (from newest to oldest)
 @echo checking Visual Studio 2017 v150... VS150COMCOMNTOOLS = "%VS150COMCOMNTOOLS%"
-if NOT "%VS150COMCOMNTOOLS%"=="" (
+if defined VS150COMCOMNTOOLS (
     @echo. Found installation for Visual Studio 2017 150: "%VS150COMCOMNTOOLS%"
     set VS2017_ARCH=-arch=amd64
     if exist "%VS150COMCOMNTOOLS%VsDevCmd.bat" (
@@ -85,7 +85,7 @@ if NOT "%VS150COMCOMNTOOLS%"=="" (
     @rem configuration for this VS version didn't work, try older VS versions...
 )
 @echo checking Visual Studio 2017 v140... VS140COMNTOOLS = "%VS140COMNTOOLS%"
-if NOT "%VS140COMNTOOLS%"=="" (
+if defined VS140COMNTOOLS (
     @echo. Found installation for Visual Studio 2017 v140: "%VS140COMNTOOLS%"
     set VS2017_ARCH=-arch=amd64
     @echo checking "%VS140COMNTOOLS%..\..\..\..\2017\Community\Common7\Tools\VsDevCmd.bat"
@@ -109,7 +109,7 @@ if NOT "%VS140COMNTOOLS%"=="" (
     @rem configuration for this VS version didn't work, try older VS versions...
 )
 @echo checking Visual Studio 2010... VS100COMNTOOLS = "%VS100COMNTOOLS%"
-if NOT "%VS100COMNTOOLS%"=="" (
+if defined VS100COMNTOOLS (
     @echo. Found installation for Visual Studio 2010
     @echo checking "%VS100COMNTOOLS%..\..\VC\%VCVARS%"
     if exist "%VS100COMNTOOLS%..\..\VC\%VCVARS%" (
@@ -120,7 +120,7 @@ if NOT "%VS100COMNTOOLS%"=="" (
     @rem configuration for this VS version didn't work, try older VS versions...
 )
 @echo checking Visual Studio 2008... VS90COMNTOOLS = "%VS90COMNTOOLS%"
-if NOT "%VS90COMNTOOLS%"=="" (
+if defined VS90COMNTOOLS (
     @echo. Found installation for Visual Studio 2008
     @echo checking "%VS90COMNTOOLS%..\..\VC\%VCVARS%"
     if exist "%VS90COMNTOOLS%..\..\VC\%VCVARS%" (
@@ -131,7 +131,7 @@ if NOT "%VS90COMNTOOLS%"=="" (
     @rem configuration for this VS version didn't work, try older VS versions...
 )
 @echo checking Visual Studio 2005... VS80COMNTOOLS = "%VS80COMNTOOLS%"
-if NOT "%VS80COMNTOOLS%"=="" (
+if defined VS80COMNTOOLS (
     @echo. Found installation for Visual Studio 2005
     @echo checking "%VS80COMNTOOLS%..\..\VC\%VCVARS%"
     if exist "%VS80COMNTOOLS%..\..\VC\%VCVARS%" (

--- a/locales/make_locale_x64.bat
+++ b/locales/make_locale_x64.bat
@@ -84,7 +84,6 @@ if defined VS150COMNTOOLS (
         call "%VS150COMNTOOLS%VsDevCmd.bat" -arch=amd64
         goto :BUILD
     )
-    @rem it should be done similar for Professional and Enterprise editions (like for VS2017v140) but I have access to none of them to be sure about the paths
     @rem configuration for this VS version didn't work, try older VS versions...
 )
 @echo checking Visual Studio 2017 v150... VS150COMCOMNTOOLS = "%VS150COMCOMNTOOLS%"
@@ -96,7 +95,6 @@ if defined VS150COMCOMNTOOLS (
         call "%VS150COMCOMNTOOLS%VsDevCmd.bat" -arch=amd64
         goto :BUILD
     )
-    @rem it should be done similar for Professional and Enterprise editions (like for VS2017v140) but I have access to none of them to be sure about the paths
     @rem configuration for this VS version didn't work, try older VS versions...
 )
 @echo checking Visual Studio 2017 v140... VS140COMNTOOLS = "%VS140COMNTOOLS%"

--- a/locales/make_locale_x64.bat
+++ b/locales/make_locale_x64.bat
@@ -15,7 +15,6 @@ REM  You should have received a copy of the GNU General Public License
 REM  along with this program; if not, write to the Free Software 
 REM  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-
 set APP_NAME=%0
 echo %APP_NAME%
 
@@ -30,16 +29,20 @@ set VCVARS=bin\amd64\vcvarsamd64.bat
 if "%1." == "." (GOTO :CHECK_ENV)
 
 if "%1" == "/debug" (
-if "%BUILD_MODE%" == "." (
-set BUILD_MODE=debug
-GOTO :DO_SHIFT
-) else (GOTO :ERROR_BUILD_MODE)
+    if "%BUILD_MODE%" == "." (
+        set BUILD_MODE=debug
+        GOTO :DO_SHIFT
+    ) else (
+        GOTO :ERROR_BUILD_MODE
+    )
 )
 if "%1" == "/release" (
-if "%BUILD_MODE%" == "." (
-set BUILD_MODE=release
-GOTO :DO_SHIFT
-) else (GOTO :ERROR_BUILD_MODE)
+    if "%BUILD_MODE%" == "." (
+        set BUILD_MODE=release
+        GOTO :DO_SHIFT
+    ) else (
+        GOTO :ERROR_BUILD_MODE
+    )
 )
 
 if "%1" == "/h"            (GOTO :SHOW_USAGE)
@@ -47,8 +50,8 @@ if "%1" == "/?"            (GOTO :SHOW_USAGE)
 if "%1" == "/help"         (GOTO :SHOW_USAGE)
 if NOT "%2" == "" (GOTO :ERROR)
 if "%SELECTED_LOCALE%" == "." (
-set SELECTED_LOCALE=%1
-GOTO :CHECK_ENV
+    set SELECTED_LOCALE=%1
+    GOTO :CHECK_ENV
 )
 
 GOTO :ERROR
@@ -59,10 +62,10 @@ GOTO :CHECK_OPTION
 
 :CHECK_ENV
 if "%SELECTED_LOCALE%" == "." (
-set SELECTED_LOCALE=all_locales
+    set SELECTED_LOCALE=all_locales
 ) else (
-if "%SELECTED_LOCALE:~0,1%" == "-" goto :ERROR
-set LOCALE_PARAM=%SELECTED_LOCALE%
+    if "%SELECTED_LOCALE:~0,1%" == "-" goto :ERROR
+    set LOCALE_PARAM=%SELECTED_LOCALE%
 ) 
 
 if "%BUILD_MODE%" == "." set BUILD_MODE=release


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21976

- search for Visual Studio installations in reverse order of the versions (from newest to oldest) and fall back to an older version if one doesn't exists or it is invalid
- display more messages for trace and better information about Visual Studio version & tools, compiler & linker

NOTE: just for testing it is not necessary to re-generate the whole project, it is enough to use the last build and replace the content of
`<cubrid_install_path>/bin/make_locale.bat`
with the content of the file from this PR
`make_locale_x64.bat`
and call it for at least one locale, e.g.:
`make_locale.bat ro_RO`

TODO: test with VS2017 v150 Professional & Enterprise
