### PR TITLE
[CBRD-21982] assign private LRU list to vacuum workers

### DIFF
--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -144,6 +144,9 @@ struct vacuum_worker
   char *undo_data_buffer;	/* Buffer to save log undo data */
   int undo_data_buffer_capacity;	/* Capacity of log undo data buffer */
 
+  // page buffer private lru list
+  int private_lru_index;
+
   /* Caches postpones to avoid reading them from log after commit top operation with postpone. Otherwise, log critical
    * section may be required which will slow the access on merged index nodes. */
   VACUUM_CACHE_POSTPONE_STATUS postpone_cache_status;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21982

When vacuum worker contexts are created, they are also assigned a private LRU list. When a thread entry is claimed for vacuum job, it inherits the private list.

This is a regression of thread manager refactoring.