### PR TITLE
[CBRD-21987] stop checkpoint on shutdown

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -3682,11 +3682,9 @@ pgbuf_flush_checkpoint (THREAD_ENTRY * thread_p, const LOG_LSA * flush_upto_lsa,
       collected_bcbs++;
 
 #if defined(SERVER_MODE)
-      if (thread_p && thread_p->shutdown == true)
+      if (thread_p != NULL && thread_p->shutdown == true)
 	{
-#if defined (SERVER_MODE)
 	  pgbuf_Pool.is_checkpoint = false;
-#endif
 	  return ER_FAILED;
 	}
 #endif
@@ -3765,6 +3763,12 @@ pgbuf_flush_chkpt_seq_list (THREAD_ENTRY * thread_p, PGBUF_SEQ_FLUSHER * seq_flu
   while (seq_flusher->flush_idx < seq_flusher->flush_cnt)
     {
 #if defined (SERVER_MODE)
+      if (thread_p != NULL && thread_p->shutdown)
+	{
+	  // stop
+	  return ER_FAILED;
+	}
+
       gettimeofday (&cur_time, NULL);
 
       /* compute time limit for allowed flush interval */

--- a/src/thread/thread_daemon.cpp
+++ b/src/thread/thread_daemon.cpp
@@ -50,6 +50,12 @@ namespace cubthread
 	return;
       }
 
+    if (m_func_on_stop)
+      {
+	// to interrupt execution context
+	m_func_on_stop ();
+      }
+
     // make sure thread will wakeup
     wakeup ();
 

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -75,6 +75,7 @@ namespace cubthread
   class daemon
   {
     public:
+
       //  daemon constructor needs:
       //    loop_pattern_arg    : loop pattern for task execution
       //    context_manager_arg : context manager to create and retire thread execution context
@@ -116,6 +117,8 @@ namespace cubthread
 
       waiter m_waiter;        // thread waiter
       looper m_looper;        // thread looper
+      std::function<void (void)> m_func_on_stop;  // callback function to interrupt execution on stop request
+
       std::thread m_thread;   // the actual daemon thread
 
       // stats
@@ -135,12 +138,14 @@ namespace cubthread
 		  task<Context> *exec)
     : m_waiter ()
     , m_looper (loop_pattern_arg)
-    , m_thread (daemon::loop<Context>, this, context_manager_arg, exec)
+    , m_func_on_stop ()
+    , m_thread ()
     , m_loop_count (0)
     , m_execute_time (0)
     , m_pause_time (0)
   {
     // starts a thread to execute daemon::loop
+    m_thread = std::thread (daemon::loop<Context>, this, context_manager_arg, exec);
   }
 
   template <typename Context>
@@ -149,6 +154,9 @@ namespace cubthread
   {
     // create execution context
     Context &context = context_manager_arg->create_context ();
+
+    // now that we have access to context we can set the callback function on stop
+    daemon_arg->m_func_on_stop = std::bind (&Context::interrupt_execution, std::ref (context));
 
     // loop until stopped
     using clock_type = std::chrono::high_resolution_clock;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21987

Two changes were required to stop checkpoint thread on shutdown:

  1. a way to tell thread context when daemon is stopped. In order to avoid storing the context in daemon (and would have forced us to make daemon template based on Context), I bind the stop function at runtime (calling context.interrupt_execution). As a result, thread_p.shutdown is set to true.
  2. pgbuf_flush_chkpt_seq_list check thread_p->shutdown regularly.

