### PR TITLE
[CBRD-21990] lock waiter managed to timedout or interrupted at deadlo…

### DIFF
--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -461,6 +461,7 @@ static int lock_delete_from_tran_hold_list (LK_ENTRY * entry_ptr, int owner_tran
 static void lock_insert_into_tran_non2pl_list (LK_ENTRY * non2pl, int owner_tran_index);
 static int lock_delete_from_tran_non2pl_list (LK_ENTRY * non2pl, int owner_tran_index);
 static LK_ENTRY *lock_find_tran_hold_entry (int tran_index, const OID * oid, bool is_class);
+static bool lock_force_timeout_expired_wait_transactions (void *thrd_entry);
 static bool lock_is_local_deadlock_detection_interval_up (void);
 static void lock_detect_local_deadlock (THREAD_ENTRY * thread_p);
 static bool lock_is_class_lock_escalated (LOCK class_lock, LOCK lock_escalation);
@@ -5897,6 +5898,11 @@ error:
 //
 //  description:
 //    deadlock detect daemon task
+//    It does
+//      (1) to resume an interrupted lock waiter
+//      (2) to resume a timedout lock waiter
+//      (3) to detect and resolve a deadlock.
+//    It operates (1) and (2) for every 100ms and does (3) for every PRM_ID_LK_RUN_DEADLOCK_INTERVAL.
 //
 class deadlock_detect_task : public cubthread::entry_task
 {
@@ -5906,12 +5912,6 @@ class deadlock_detect_task : public cubthread::entry_task
       if (!BO_IS_SERVER_RESTARTED ())
 	{
 	  // wait for boot to finish
-	  return;
-	}
-
-      if (!lock_is_local_deadlock_detection_interval_up ())
-	{
-	  // forced to wait until PRM_ID_LK_RUN_DEADLOCK_INTERVAL
 	  return;
 	}
 
@@ -5948,7 +5948,7 @@ class deadlock_detect_task : public cubthread::entry_task
 	  lock_wait_entry = thread_find_next_lockwait_entry (&thread_index);
 	}
 
-      if (lock_wait_count >= 2)
+      if (lock_is_local_deadlock_detection_interval_up () && lock_wait_count >= 2)
 	{
 	  lock_detect_local_deadlock (&thread_ref);
 	}
@@ -7528,8 +7528,7 @@ lock_get_class_lock (const OID * class_oid, int tran_index)
 }
 
 /*
- * lock_force_timeout_lock_wait_transactions - All lock-wait transactions
- *                               are forced to timeout
+ * lock_force_timeout_lock_wait_transactions - All lock-wait transactions are forced to timeout
  *
  * return: nothing
  *
@@ -7568,7 +7567,8 @@ lock_force_timeout_lock_wait_transactions (unsigned short stop_phase)
 	  if (thrd->lockwait != NULL || thrd->lockwait_state == (int) LOCK_SUSPENDED)
 	    {
 	      /* some strange lock wait state.. */
-	      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_LK_STRANGE_LOCK_WAIT, 5, thrd->lockwait,
+	      assert (false);
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_STRANGE_LOCK_WAIT, 5, thrd->lockwait,
 		      thrd->lockwait_state, thrd->index, thrd->get_posix_id (), thrd->tran_index);
 	    }
 	  /* release the thread entry mutex */
@@ -7584,16 +7584,16 @@ lock_force_timeout_lock_wait_transactions (unsigned short stop_phase)
  *                           expired or it is interrupted
  *
  * return: true if the thread was timed out or
- *                       false if the thread was not timed out.
+ *         false if the thread was not timed out.
  *
- *   thrd_entry(in): thread entry pointer
+ * thrd_entry(in): thread entry pointer
  *
  * Note:If the given thread is waiting on a lock to be granted, and
  *     either its expiration time has expired or it is interrupted,
  *     the thread is timed-out.
  *     If NULL is given, it applies to all threads.
  */
-bool
+static bool
 lock_force_timeout_expired_wait_transactions (void *thrd_entry)
 {
 #if !defined (SERVER_MODE)
@@ -7603,85 +7603,51 @@ lock_force_timeout_expired_wait_transactions (void *thrd_entry)
   bool ignore;
   THREAD_ENTRY *thrd;
 
-  if (thrd_entry != NULL)
+  assert (thrd_entry != NULL);
+
+  thrd = (THREAD_ENTRY *) thrd_entry;
+
+  (void) thread_lock_entry (thrd);
+  if (LK_IS_LOCKWAIT_THREAD (thrd))
     {
-      thrd = (THREAD_ENTRY *) thrd_entry;
-      (void) thread_lock_entry (thrd);
-      if (LK_IS_LOCKWAIT_THREAD (thrd))
+      if (logtb_is_interrupted_tran (NULL, true, &ignore, thrd->tran_index))
+	{
+	  /* wake up the thread */
+	  lock_resume ((LK_ENTRY *) thrd->lockwait, LOCK_RESUMED_INTERRUPT);
+	  return true;
+	}
+      else if (LK_CAN_TIMEOUT (thrd->lockwait_msecs))
 	{
 	  struct timeval tv;
 	  INT64 etime;
+
 	  (void) gettimeofday (&tv, NULL);
 	  etime = (tv.tv_sec * 1000000LL + tv.tv_usec) / 1000LL;
-	  if (LK_CAN_TIMEOUT (thrd->lockwait_msecs) && etime - thrd->lockwait_stime > thrd->lockwait_msecs)
+	  if (etime - thrd->lockwait_stime > thrd->lockwait_msecs)
 	    {
 	      /* wake up the thread */
 	      lock_resume ((LK_ENTRY *) thrd->lockwait, LOCK_RESUMED_TIMEOUT);
 	      return true;
 	    }
-	  else if (logtb_is_interrupted_tran (NULL, true, &ignore, thrd->tran_index))
-	    {
-	      /* wake up the thread */
-	      lock_resume ((LK_ENTRY *) thrd->lockwait, LOCK_RESUMED_INTERRUPT);
-	      return true;
-	    }
-	  else
-	    {
-	      /* release the thread entry mutex */
-	      (void) thread_unlock_entry (thrd);
-	      return false;
-	    }
 	}
-      else
-	{
-	  if (thrd->lockwait != NULL || thrd->lockwait_state == (int) LOCK_SUSPENDED)
-	    {
-	      /* some strange lock wait state.. */
-	      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_LK_STRANGE_LOCK_WAIT, 5, thrd->lockwait,
-		      thrd->lockwait_state, thrd->index, thrd->get_posix_id (), thrd->tran_index);
-	    }
-	  /* release the thread entry mutex */
-	  (void) thread_unlock_entry (thrd);
-	  return false;
-	}
+
+      /* release the thread entry mutex */
+      (void) thread_unlock_entry (thrd);
+      return false;
     }
   else
     {
-      for (i = 1; i < thread_num_total_threads (); i++)
+      if (thrd->lockwait != NULL || thrd->lockwait_state == (int) LOCK_SUSPENDED)
 	{
-	  thrd = thread_find_entry_by_index (i);
-	  (void) thread_lock_entry (thrd);
-	  if (LK_IS_LOCKWAIT_THREAD (thrd))
-	    {
-	      struct timeval tv;
-	      INT64 etime;
-	      (void) gettimeofday (&tv, NULL);
-	      etime = (tv.tv_sec * 1000000LL + tv.tv_usec) / 1000LL;
-	      if ((LK_CAN_TIMEOUT (thrd->lockwait_msecs) && etime - thrd->lockwait_stime > thrd->lockwait_msecs)
-		  || logtb_is_interrupted_tran (NULL, true, &ignore, thrd->tran_index))
-		{
-		  /* wake up the thread */
-		  lock_resume ((LK_ENTRY *) thrd->lockwait, LOCK_RESUMED_TIMEOUT);
-		}
-	      else
-		{
-		  /* release the thread entry mutex */
-		  (void) thread_unlock_entry (thrd);
-		}
-	    }
-	  else
-	    {
-	      if (thrd->lockwait != NULL || thrd->lockwait_state == (int) LOCK_SUSPENDED)
-		{
-		  /* some strange lock wait state.. */
-		  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_LK_STRANGE_LOCK_WAIT, 5, thrd->lockwait,
-			  thrd->lockwait_state, thrd->index, thrd->get_posix_id (), thrd->tran_index);
-		}
-	      /* release the thread entry mutex */
-	      (void) thread_unlock_entry (thrd);
-	    }
+	  /* some strange lock wait state.. */
+	  assert (false);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_STRANGE_LOCK_WAIT, 5, thrd->lockwait,
+		  thrd->lockwait_state, thrd->index, thrd->get_posix_id (), thrd->tran_index);
 	}
-      return true;
+
+      /* release the thread entry mutex */
+      (void) thread_unlock_entry (thrd);
+      return false;
     }
 #endif /* !SERVER_MODE */
 }

--- a/src/transaction/lock_manager.h
+++ b/src/transaction/lock_manager.h
@@ -217,7 +217,6 @@ extern bool lock_has_lock_transaction (int tran_index);
 extern bool lock_is_waiting_transaction (int tran_index);
 extern LK_ENTRY *lock_get_class_lock (const OID * class_oid, int tran_index);
 extern void lock_force_timeout_lock_wait_transactions (unsigned short stop_phase);
-extern bool lock_force_timeout_expired_wait_transactions (void *thrd_entry);
 extern void lock_notify_isolation_incons (THREAD_ENTRY * thread_p,
 					  bool (*fun) (const OID * class_oid, const OID * oid, void *args), void *args);
 extern int lock_reacquire_crash_locks (THREAD_ENTRY * thread_p, LK_ACQUIRED_LOCKS * acqlocks, int tran_index);


### PR DESCRIPTION
…ck detection interval

http://jira.cubrid.org/browse/CBRD-21990

It fixes a slip of #1054.
Deadlock detector checks lock waters were timeout or interrupted at every 100ms and a deadlock at every deadlock detection interval.
