### PR TITLE
[CBRD-21994] do not interrupt reflect unique statistics

### DIFF
--- a/src/session/session.c
+++ b/src/session/session.c
@@ -943,6 +943,7 @@ session_remove_expired_sessions ()
 	  if (session_check_timeout (state, &active_sessions, &is_expired) != NO_ERROR)
 	    {
 	      pthread_mutex_unlock (&state->mutex);
+	      lf_tran_end_with_mb (t_entry);
 	      err = ER_FAILED;
 	      goto exit_on_end;
 	    }

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -6749,6 +6749,10 @@ logtb_reflect_global_unique_stats_to_btree (THREAD_ENTRY * thread_p)
     {
       return NO_ERROR;
     }
+
+  // reflecting stats should not be interrupted
+  bool save_check_interrupt = thread_set_check_interrupt (thread_p, false);
+
   lf_hash_create_iterator (&it, t_entry, &log_Gl.unique_stats_table.unique_stats_hash);
   for (stats = (GLOBAL_UNIQUE_STATS *) lf_hash_iterate (&it); stats != NULL;
        stats = (GLOBAL_UNIQUE_STATS *) lf_hash_iterate (&it))
@@ -6759,13 +6763,22 @@ logtb_reflect_global_unique_stats_to_btree (THREAD_ENTRY * thread_p)
 	  error = btree_reflect_global_unique_statistics (thread_p, stats, false);
 	  if (error != NO_ERROR)
 	    {
-	      return error;
+	      ASSERT_ERROR ();
+
+	      // must unlock entry
+	      pthread_mutex_unlock (&stats->mutex);
+
+	      // finish transaction
+	      lf_tran_end_with_mb (t_entry);
+	      break;
 	    }
 	  LSA_SET_NULL (&stats->last_log_lsa);
 	}
     }
 
-  return NO_ERROR;
+  (void) thread_set_check_interrupt (thread_p, save_check_interrupt);
+
+  return error;
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21994

The issue is caused by system transaction being interrupted and reflect unique statistics handling the case in a wrong manner.

This patch addresses second issue by:

  1. if reflecting statistics of one entry fails, unlock entry before aborting.
  2. do not interrupt reflect unique statistics

Should be enough to fix the issue, I will tackle first issue in a separate patch.