### PR TITLE
[CBRD-21998] do not kill system transaction

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -3091,7 +3091,8 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
 
 	  /* try to kill transaction. */
 	  TR_TABLE_CS_ENTER (thread_p);
-	  for (i = 0; i < log_Gl.trantable.num_total_indices; i++)
+	  // start from transaction index i = 1; system transaction cannot be killed
+	  for (i = 1; i < log_Gl.trantable.num_total_indices; i++)
 	    {
 	      tdes = log_Gl.trantable.all_tdes[i];
 	      if (tdes != NULL && tdes->trid != NULL_TRANID)

--- a/src/query/show_scan.c
+++ b/src/query/show_scan.c
@@ -513,7 +513,7 @@ thread_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, in
       return error;
     }
 
-  for (i = 0; i < thread_num_total_threads (); i++)
+  for (i = 1; i < thread_num_total_threads (); i++)
     {
       thrd = thread_find_entry_by_index (i);
 

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -1681,6 +1681,13 @@ xthread_kill_tran_index (THREAD_ENTRY * thread_p, int kill_tran_index, char *kil
       return ER_CSS_KILL_BAD_INTERFACE;
     }
 
+  if (kill_tran_index == LOG_SYSTEM_TRAN_INDEX)
+    {
+      // cannot kill system transaction; not even if this is dba
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_KILL_TR_NOT_ALLOWED, 1, kill_tran_index);
+      return ER_KILL_TR_NOT_ALLOWED;
+    }
+
   signaled = false;
   for (i = 0; i < THREAD_RETRY_MAX_SLAM_TIMES && error_code == NO_ERROR && !killed; i++)
     {
@@ -1745,6 +1752,13 @@ xthread_kill_or_interrupt_tran (THREAD_ENTRY * thread_p, int tran_index, bool is
   bool interrupt, has_authorization;
   bool is_trx_exists;
   KILLSTMT_TYPE kill_type;
+
+  if (tran_index == LOG_SYSTEM_TRAN_INDEX)
+    {
+      // cannot kill system transaction; not even if this is dba
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_KILL_TR_NOT_ALLOWED, 1, tran_index);
+      return ER_KILL_TR_NOT_ALLOWED;
+    }
 
   if (!is_dba_group_member)
     {

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -1881,7 +1881,9 @@ thread_find_entry_by_index (int thread_index)
   THREAD_ENTRY *thread_p;
   if (thread_index == 0)
     {
-      thread_p = cubthread::get_main_entry ();
+      // this is the index of main thread entry. we don't want to expose it by thread_find_entry_by_index
+      assert (false);
+      return NULL;
     }
   else if (thread_index <= thread_Manager.num_total)
     {
@@ -3604,7 +3606,7 @@ thread_clear_recursion_depth (THREAD_ENTRY * thread_p)
 THREAD_ENTRY *
 thread_iterate (THREAD_ENTRY * thread_p)
 {
-  int index = 0;
+  int index = 1;		// iteration starts with thread index = 1
 
   if (!thread_Manager.initialized)
     {

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -3081,6 +3081,12 @@ logtb_set_tran_index_interrupt (THREAD_ENTRY * thread_p, int tran_index, bool se
 {
   LOG_TDES *tdes;		/* Transaction descriptor */
 
+  if (tran_index == LOG_SYSTEM_TRAN_INDEX)
+    {
+      assert (false);
+      return false;
+    }
+
   if (log_Gl.trantable.area != NULL)
     {
       tdes = LOG_FIND_TDES (tran_index);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21998

System transaction is only for internal usage. We cannot allow it to be interrupted.

There are two ways it can be interrupted:

  1. By client request. In this case an error is returned.
  2. Automatically by internal code. This case should crash on debug. On release it will ignore the request.

@eseokoh 
The patch may cause regressions. I think it is better to run some manual tests first.