### PR TITLE
[CBRD-21995] fix calling stop log writer

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -3537,7 +3537,7 @@ css_stop_all_workers (THREAD_ENTRY &thread_ref, thread_stop_type stop_phase)
       // tell all to stop
       if (stop_phase == THREAD_STOP_LOGWR)
         {
-          css_Server_request_worker_pool->map_running_contexts (css_stop_log_writer, thread_ref);
+          css_Server_request_worker_pool->map_running_contexts (css_stop_log_writer);
         }
       else
         {

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -3535,7 +3535,14 @@ css_stop_all_workers (THREAD_ENTRY &thread_ref, thread_stop_type stop_phase)
   while (true)
     {
       // tell all to stop
-      css_Server_request_worker_pool->map_running_contexts (css_stop_non_log_writer, thread_ref);
+      if (stop_phase == THREAD_STOP_LOGWR)
+        {
+          css_Server_request_worker_pool->map_running_contexts (css_stop_log_writer, thread_ref);
+        }
+      else
+        {
+          css_Server_request_worker_pool->map_running_contexts (css_stop_non_log_writer, thread_ref);
+        }
 
       // make sure none is blocked in lock waits
       lock_force_timeout_lock_wait_transactions (stop_phase);
@@ -3565,16 +3572,6 @@ css_stop_all_workers (THREAD_ENTRY &thread_ref, thread_stop_type stop_phase)
       // todo: temporary disabled.
       // thread_stop_active_workers will call it. activate when connections are merged to new thread manager
       // css_block_all_active_conn (stop_phase);
-    }
-}
-
-static void
-css_stop_all_log_writer (THREAD_ENTRY &thread_ref)
-{
-  if (css_Server_request_worker_pool == NULL)
-    {
-      // nothing to stop
-      return;
     }
 }
 

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -3473,7 +3473,7 @@ css_stop_log_writer (THREAD_ENTRY &thread_ref)
       // this is not log writer
       return;
     }
-  if (thread_ref.tran_index != -1)
+  if (thread_ref.tran_index == -1)
     {
       // no transaction, no stop
       return;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21995

Map css_stop_log_writer on all thread entries when css_stop_all_workers is called with THREAD_STOP_LOGWR.