### PR TITLE
[CBRD-21980] [Regression] [HA] tables can't be replicated to slave node

### DIFF
--- a/src/thread/thread_entry_task.cpp
+++ b/src/thread/thread_entry_task.cpp
@@ -69,6 +69,7 @@ namespace cubthread
     context.check_interrupt = true;
 #if defined (SERVER_MODE)
     context.status = TS_FREE;
+    context.resume_status = THREAD_RESUME_NONE;
 #endif // SERVER_MODE
 
     get_manager ()->retire_entry (context);
@@ -80,7 +81,9 @@ namespace cubthread
     er_clear ();    // clear errors
     std::memset (&context.event_stats, 0, sizeof (context.event_stats));  // clear even stats
     context.tran_index = -1;    // clear transaction ID
-
+#if defined (SERVER_MODE)
+    context.resume_status = THREAD_RESUME_NONE;
+#endif // SERVER_MODE
     on_recycle (context);
   }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21980

The resume_status member variable of a thread context wasn't reset when recycling or retiring a context,
so the if (thread_p->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT) at log_writer.c:xlogwr_get_log_pages would execute and would make the entry's eof_lsa not null. The whole logic in xlogwr_get_log_pages relies on the fact that entry's eof_lsa is null, so this was generating
a replication bug.