### PR TITLE
[CBRD-22008] no context task/daemons

### DIFF
--- a/src/communication/stream_transfer_receiver.cpp
+++ b/src/communication/stream_transfer_receiver.cpp
@@ -33,7 +33,7 @@
 namespace cubstream
 {
 
-  class transfer_receiver_task : public cubthread::task<void>
+  class transfer_receiver_task : public cubthread::task_without_context
   {
     public:
       transfer_receiver_task (cubstream::transfer_receiver &consumer_channel)
@@ -75,7 +75,7 @@ namespace cubstream
       m_last_received_position (received_from_position)
   {
     m_receiver_daemon = cubthread::get_manager ()->create_daemon_without_entry (cubthread::delta_time (0),
-			new transfer_receiver_task (*this), "transfer_receiver");
+			new transfer_receiver_task (*this), "stream_transfer_receiver");
   }
 
   transfer_receiver::~transfer_receiver ()

--- a/src/communication/stream_transfer_receiver.cpp
+++ b/src/communication/stream_transfer_receiver.cpp
@@ -33,7 +33,7 @@
 namespace cubstream
 {
 
-  class transfer_receiver_task : public cubthread::entry_task
+  class transfer_receiver_task : public cubthread::task<void>
   {
     public:
       transfer_receiver_task (cubstream::transfer_receiver &consumer_channel)
@@ -41,7 +41,7 @@ namespace cubstream
       {
       }
 
-      void execute (cubthread::entry &context) override
+      void execute () override
       {
 	int rc = 0;
 	size_t max_len = MTU;
@@ -74,13 +74,13 @@ namespace cubstream
       m_stream (stream),
       m_last_received_position (received_from_position)
   {
-    m_receiver_daemon = cubthread::get_manager ()->create_daemon (cubthread::delta_time (0),
+    m_receiver_daemon = cubthread::get_manager ()->create_daemon_without_entry (cubthread::delta_time (0),
 			new transfer_receiver_task (*this), "transfer_receiver");
   }
 
   transfer_receiver::~transfer_receiver ()
   {
-    cubthread::get_manager ()->destroy_daemon (m_receiver_daemon);
+    cubthread::get_manager ()->destroy_daemon_without_entry (m_receiver_daemon);
   }
 
   int transfer_receiver::write_action (const stream_position pos, char *ptr, const size_t byte_count)

--- a/src/communication/stream_transfer_receiver.cpp
+++ b/src/communication/stream_transfer_receiver.cpp
@@ -75,7 +75,7 @@ namespace cubstream
       m_last_received_position (received_from_position)
   {
     m_receiver_daemon = cubthread::get_manager ()->create_daemon (cubthread::delta_time (0),
-			new transfer_receiver_task (*this));
+			new transfer_receiver_task (*this), "transfer_receiver");
   }
 
   transfer_receiver::~transfer_receiver ()

--- a/src/communication/stream_transfer_sender.cpp
+++ b/src/communication/stream_transfer_sender.cpp
@@ -39,7 +39,7 @@
 namespace cubstream
 {
 
-  class transfer_sender_task : public cubthread::task<void>
+  class transfer_sender_task : public cubthread::task_without_context
   {
     public:
       transfer_sender_task (cubstream::transfer_sender &producer_channel)
@@ -82,7 +82,7 @@ namespace cubstream
     cubthread::delta_time daemon_period = std::chrono::milliseconds (10);
     m_sender_daemon = cubthread::get_manager ()->create_daemon_without_entry (daemon_period,
 		      new transfer_sender_task (*this),
-		      "transfer_sender");
+		      "stream_transfer_sender");
   }
 
   transfer_sender::~transfer_sender ()

--- a/src/communication/stream_transfer_sender.cpp
+++ b/src/communication/stream_transfer_sender.cpp
@@ -80,7 +80,8 @@ namespace cubstream
       m_last_sent_position (begin_sending_position)
   {
     cubthread::delta_time daemon_period = std::chrono::milliseconds (10);
-    m_sender_daemon = cubthread::get_manager ()->create_daemon (daemon_period, new transfer_sender_task (*this));
+    m_sender_daemon = cubthread::get_manager ()->create_daemon (daemon_period, new transfer_sender_task (*this),
+		      "transfer_sender");
   }
 
   transfer_sender::~transfer_sender ()

--- a/src/communication/stream_transfer_sender.cpp
+++ b/src/communication/stream_transfer_sender.cpp
@@ -39,7 +39,7 @@
 namespace cubstream
 {
 
-  class transfer_sender_task : public cubthread::entry_task
+  class transfer_sender_task : public cubthread::task<void>
   {
     public:
       transfer_sender_task (cubstream::transfer_sender &producer_channel)
@@ -47,7 +47,7 @@ namespace cubstream
       {
       }
 
-      void execute (cubthread::entry &context) override
+      void execute () override
       {
 	int rc = NO_ERRORS;
 	stream_position last_reported_ready_pos = this_producer_channel.m_stream.get_last_reported_ready_pos ();
@@ -80,13 +80,14 @@ namespace cubstream
       m_last_sent_position (begin_sending_position)
   {
     cubthread::delta_time daemon_period = std::chrono::milliseconds (10);
-    m_sender_daemon = cubthread::get_manager ()->create_daemon (daemon_period, new transfer_sender_task (*this),
+    m_sender_daemon = cubthread::get_manager ()->create_daemon_without_entry (daemon_period,
+		      new transfer_sender_task (*this),
 		      "transfer_sender");
   }
 
   transfer_sender::~transfer_sender ()
   {
-    cubthread::get_manager ()->destroy_daemon (m_sender_daemon);
+    cubthread::get_manager ()->destroy_daemon_without_entry (m_sender_daemon);
   }
 
   communication_channel &transfer_sender::get_communication_channel ()

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1051,7 +1051,7 @@ vacuum_boot (THREAD_ENTRY * thread_p)
 
   // create vacuum master thread
   vacuum_Master_daemon =
-    thread_manager->create_daemon (looper, new vacuum_master_task (), vacuum_Master_context_manager);
+    thread_manager->create_daemon (looper, new vacuum_master_task (), "vacuum_master", vacuum_Master_context_manager);
 #endif /* SERVER_MODE */
 
   vacuum_Is_booted = true;

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -530,7 +530,7 @@ session_control_daemon_init ()
   session_control_daemon_task *daemon_task = new session_control_daemon_task ();
 
   // create session control daemon thread
-  session_Control_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  session_Control_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "session_control");
 }
 #endif /* SERVER_MODE */
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -16078,7 +16078,8 @@ pgbuf_page_maintenance_daemon_init ()
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (100));
   pgbuf_page_maintenance_daemon_task *daemon_task = new pgbuf_page_maintenance_daemon_task ();
 
-  pgbuf_Page_maintenance_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  pgbuf_Page_maintenance_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
+                                                                            "pgbuf_page_maintenance");
 }
 #endif /* SERVER_MODE */
 
@@ -16094,7 +16095,7 @@ pgbuf_page_flush_daemon_init ()
   cubthread::looper looper = cubthread::looper (pgbuf_get_page_flush_interval);
   pgbuf_page_flush_daemon_task *daemon_task = new pgbuf_page_flush_daemon_task ();
 
-  pgbuf_Page_flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  pgbuf_Page_flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "pgbuf_page_flush");
 }
 #endif /* SERVER_MODE */
 
@@ -16116,7 +16117,8 @@ pgbuf_page_post_flush_daemon_init ()
   cubthread::looper looper = cubthread::looper (looper_interval);
   pgbuf_page_post_flush_daemon_task *daemon_task = new pgbuf_page_post_flush_daemon_task ();
 
-  pgbuf_Page_post_flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  pgbuf_Page_post_flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
+                                                                           "pgbuf_page_post_flush");
 }
 #endif /* SERVER_MODE */
 
@@ -16138,7 +16140,8 @@ pgbuf_flush_control_daemon_init ()
     }
 
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (50));
-  pgbuf_Flush_control_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  pgbuf_Flush_control_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
+                                                                         "pgbuf_flush_control");
 }
 #endif /* SERVER_MODE */
 

--- a/src/thread/thread_daemon.cpp
+++ b/src/thread/thread_daemon.cpp
@@ -49,7 +49,7 @@ namespace cubthread
   // daemon implementation
   //////////////////////////////////////////////////////////////////////////
 
-  daemon::daemon (const looper &loop_pattern_arg, task<void> *exec_arg, const char *name)
+  daemon::daemon (const looper &loop_pattern_arg, task_without_context *exec_arg, const char *name)
     : m_waiter ()
     , m_looper (loop_pattern_arg)
     , m_func_on_stop ()
@@ -194,7 +194,7 @@ namespace cubthread
   }
 
   void
-  daemon::loop_without_context (daemon *daemon_arg, task<void> *exec_arg, const char *name)
+  daemon::loop_without_context (daemon *daemon_arg, task_without_context *exec_arg, const char *name)
   {
     (void) name;  // suppress unused parameter warning
     // its purpose is to help visualize daemon thread stacks

--- a/src/thread/thread_daemon.cpp
+++ b/src/thread/thread_daemon.cpp
@@ -57,7 +57,7 @@ namespace cubthread
     , m_name (name)
     , m_stats (daemon::create_statset ())
   {
-    m_thread = std::thread (daemon::loop, this, exec_arg, m_name.c_str ());
+    m_thread = std::thread (daemon::loop_without_context, this, exec_arg, m_name.c_str ());
   }
 
   daemon::~daemon ()
@@ -194,7 +194,7 @@ namespace cubthread
   }
 
   void
-  daemon::loop (daemon *daemon_arg, task<void> *exec_arg, const char *name)
+  daemon::loop_without_context (daemon *daemon_arg, task<void> *exec_arg, const char *name)
   {
     (void) name;  // suppress unused parameter warning
     // its purpose is to help visualize daemon thread stacks

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -88,7 +88,7 @@ namespace cubthread
       //
       template <typename Context>
       daemon (const looper &loop_pattern_arg, context_manager<Context> *context_manager_arg,
-	      task<Context> *exec, const char *name = NULL);
+	      task<Context> *exec, const char *name = "");
       ~daemon();
 
       void wakeup (void);         // wakeup daemon thread
@@ -137,7 +137,7 @@ namespace cubthread
 
   template <typename Context>
   daemon::daemon (const looper &loop_pattern_arg, context_manager<Context> *context_manager_arg,
-		  task<Context> *exec, const char *name)
+		  task<Context> *exec, const char *name /* = "" */)
     : m_waiter ()
     , m_looper (loop_pattern_arg)
     , m_func_on_stop ()
@@ -152,7 +152,7 @@ namespace cubthread
   template <typename Context>
   void
   daemon::loop (daemon *daemon_arg, context_manager<Context> *context_manager_arg, task<Context> *exec_arg,
-		const char *name /* = NULL */)
+		const char *name)
   {
     (void) (name);    // parameter is never used. it is here for convenience, to be seen on thread stacks
 

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -89,7 +89,7 @@ namespace cubthread
       template <typename Context>
       daemon (const looper &loop_pattern_arg, context_manager<Context> *context_manager_arg,
 	      task<Context> *exec, const char *name);
-      daemon (const looper &loop_pattern_arg, task<void> *exec_arg, const char *name);
+      daemon (const looper &loop_pattern_arg, task_without_context *exec_arg, const char *name);
       ~daemon();
 
       void wakeup (void);         // wakeup daemon thread
@@ -119,7 +119,7 @@ namespace cubthread
 				     task<Context> *exec_arg, const char *name);
 
       // loop_without_context - just execute context-less task in a loop
-      static void loop_without_context (daemon *daemon_arg, task<void> *exec_arg, const char *name);
+      static void loop_without_context (daemon *daemon_arg, task_without_context *exec_arg, const char *name);
 
       void pause (void);                                    // pause between tasks
       // register statistics

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -86,11 +86,9 @@ namespace cubthread
       //
       //  NOTE: it is recommended to use dynamic allocation for execution tasks
       //
-      // todo: remove default value NULL from name
-      //
       template <typename Context>
       daemon (const looper &loop_pattern_arg, context_manager<Context> *context_manager_arg,
-	      task<Context> *exec, const char *name = "");
+	      task<Context> *exec, const char *name);
       daemon (const looper &loop_pattern_arg, task<void> *exec_arg, const char *name);
       ~daemon();
 

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -175,7 +175,7 @@ namespace cubthread
   }
 
   daemon *
-  manager::create_daemon (const looper &looper_arg, entry_task *exec_p, const char *daemon_name /* = NULL */,
+  manager::create_daemon (const looper &looper_arg, entry_task *exec_p, const char *daemon_name /* = "" */,
 			  entry_manager *context_manager /* = NULL */)
   {
 #if defined (SERVER_MODE)
@@ -190,7 +190,7 @@ namespace cubthread
 	  {
 	    context_manager = m_daemon_entry_manager;
 	  }
-	return create_and_track_resource (m_daemons, 1, looper_arg, context_manager, exec_p);
+	return create_and_track_resource (m_daemons, 1, looper_arg, context_manager, exec_p, daemon_name);
       }
 #else // not SERVER_MODE = SA_MODE
     assert (false);

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -201,7 +201,7 @@ namespace cubthread
   }
 
   daemon *
-  manager::create_daemon_without_entry (const looper &looper_arg, task<void> *exec_p, const char *daemon_name)
+  manager::create_daemon_without_entry (const looper &looper_arg, task_without_context *exec_p, const char *daemon_name)
   {
 #if defined (SERVER_MODE)
     if (is_single_thread ())

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -166,7 +166,7 @@ namespace cubthread
 	  {
 	    context_manager = m_entry_manager;
 	  }
-	// reserver pool_size entries and add to m_worker_pools
+	// reserve pool_size entries and add to m_worker_pools
 	return create_and_track_resource (m_worker_pools, pool_size, pool_size, task_max_count, *context_manager,
 					  core_count, debug_logging);
       }

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -175,7 +175,8 @@ namespace cubthread
   }
 
   daemon *
-  manager::create_daemon (const looper &looper_arg, entry_task *exec_p, entry_manager *context_manager)
+  manager::create_daemon (const looper &looper_arg, entry_task *exec_p, const char *daemon_name /* = NULL */,
+			  entry_manager *context_manager /* = NULL */)
   {
 #if defined (SERVER_MODE)
     if (is_single_thread ())

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -141,7 +141,7 @@ namespace cubthread
 
       // create daemon thread
       // todo: remove default daemon name
-      daemon *create_daemon (const looper &looper_arg, entry_task *exec_p, const char *daemon_name = NULL,
+      daemon *create_daemon (const looper &looper_arg, entry_task *exec_p, const char *daemon_name = "",
 			     entry_manager *context_manager = NULL);
 
       // destroy daemon thread

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -166,7 +166,8 @@ namespace cubthread
       // create & destroy daemon thread without thread entry
       //
       // note: create signature should match context-less daemon constructor
-      daemon *create_daemon_without_entry (const looper &looper_arg, task<void> *exec_p, const char *daemon_name);
+      daemon *create_daemon_without_entry (const looper &looper_arg, task_without_context *exec_p,
+					   const char *daemon_name);
       void destroy_daemon_without_entry (daemon *&daemon_arg);
 
       //////////////////////////////////////////////////////////////////////////

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -140,7 +140,8 @@ namespace cubthread
       //////////////////////////////////////////////////////////////////////////
 
       // create daemon thread
-      daemon *create_daemon (const looper &looper_arg, entry_task *exec_p,
+      // todo: remove default daemon name
+      daemon *create_daemon (const looper &looper_arg, entry_task *exec_p, const char *daemon_name = NULL,
 			     entry_manager *context_manager = NULL);
 
       // destroy daemon thread

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -28,6 +28,8 @@
 #error Wrong module
 #endif // not SERVER_MODE and not SA_MODE
 
+#include "thread_task.hpp"
+
 #include <mutex>
 #include <vector>
 
@@ -139,13 +141,33 @@ namespace cubthread
       // daemon management
       //////////////////////////////////////////////////////////////////////////
 
+      // there are two types of daemons:
+      //
+      //    1. daemons based on thread_entry context
+      //    2. daemons without context
+      //
+      // first types of daemons will also have to reserve a thread entry. there can be unlimited second type daemons
+      //
+      // create_daemon/destroy_daemon and create_daemon_without_entry/destroy_daemon_without_entry are not
+      // interchangeable. expect safe-guard failures if not used appropriately.
+      //
+
       // create daemon thread
+      //
+      // note: signature should match context-based daemon constructor. only exception is context manager which is
+      //       moved at the end to allow a default value
+      //
       // todo: remove default daemon name
       daemon *create_daemon (const looper &looper_arg, entry_task *exec_p, const char *daemon_name = "",
 			     entry_manager *context_manager = NULL);
-
       // destroy daemon thread
       void destroy_daemon (daemon *&daemon_arg);
+
+      // create & destroy daemon thread without thread entry
+      //
+      // note: create signature should match context-less daemon constructor
+      daemon *create_daemon_without_entry (const looper &looper_arg, task<void> *exec_p, const char *daemon_name);
+      void destroy_daemon_without_entry (daemon *&daemon_arg);
 
       //////////////////////////////////////////////////////////////////////////
       // other member functions
@@ -200,6 +222,8 @@ namespace cubthread
       std::vector<entry_workpool *> m_worker_pools;
       // daemons
       std::vector<daemon *> m_daemons;
+      // daemons without entries
+      std::vector<daemon *> m_daemons_without_entries;
 
       // entries
       entry *m_all_entries;

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -57,7 +57,7 @@ namespace cubthread
   //              task_p->retire (); // this will delete task_p
   //            }
   //
-  // NOTE: to use tasks with worker pools, Context should have interrupt_execution () method defined.
+  // NOTE: to use tasks with worker pools & daemons, Context should have interrupt_execution () method defined.
   //       For long execution tasks, it is recommended to check the interrupt condition regularly.
   //
   template <typename Context>
@@ -66,15 +66,30 @@ namespace cubthread
     public:
       using context_type = Context;
 
-      task () = default;
+      task (void) = default;
 
       // abstract class requires virtual destructor
-      virtual ~task () = default;
+      virtual ~task (void) = default;
 
       // virtual functions to be implemented by inheritors
       virtual void execute (context_type &) = 0;
 
       // implementation of task's retire function.
+      virtual void retire (void)
+      {
+	delete this;
+      }
+  };
+
+  // context-less task specialization. no argument for execute function
+  template<>
+  class task<void>
+  {
+    public:
+      task (void) = default;
+      virtual ~task (void);
+
+      virtual void execute (void) = 0;
       virtual void retire (void)
       {
 	delete this;

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -87,7 +87,7 @@ namespace cubthread
   {
     public:
       task (void) = default;
-      virtual ~task (void);
+      virtual ~task (void) = default;
 
       virtual void execute (void) = 0;
       virtual void retire (void)

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -95,6 +95,7 @@ namespace cubthread
 	delete this;
       }
   };
+  using task_without_context = task<void>;
 
   // context_manager
   //

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -5966,7 +5966,7 @@ lock_deadlock_detect_daemon_init ()
   deadlock_detect_task *daemon_task = new deadlock_detect_task ();
 
   // create deadlock detect daemon thread
-  lock_Deadlock_detect_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  lock_Deadlock_detect_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "lock_deadlock_detect");
 }
 #endif /* SERVER_MODE */
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10672,7 +10672,7 @@ log_checkpoint_daemon_init ()
   log_checkpoint_daemon_task *daemon_task = new log_checkpoint_daemon_task ();
 
   // create checkpoint daemon thread
-  log_Checkpoint_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  log_Checkpoint_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log_checkpoint");
 }
 #endif /* SERVER_MODE */
 
@@ -10695,7 +10695,8 @@ log_remove_log_archive_daemon_init ()
   cubthread::looper looper = cubthread::looper (setup_period_function);
 
   // create log archive remover daemon thread
-  log_Remove_log_archive_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  log_Remove_log_archive_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
+                                                                            "log_remove_log_archive");
 }
 #endif /* SERVER_MODE */
 
@@ -10709,7 +10710,7 @@ log_clock_daemon_init ()
   assert (log_Clock_daemon == NULL);
 
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (200));
-  log_Clock_daemon = cubthread::get_manager ()->create_daemon (looper, new log_clock_daemon_task ());
+  log_Clock_daemon = cubthread::get_manager ()->create_daemon (looper, new log_clock_daemon_task (), "log_clock");
 }
 #endif /* SERVER_MODE */
 
@@ -10725,7 +10726,8 @@ log_check_ha_delay_info_daemon_init ()
   cubthread::looper looper = cubthread::looper (std::chrono::seconds (1));
   log_check_ha_delay_info_daemon_task *daemon_task = new log_check_ha_delay_info_daemon_task ();
 
-  log_Check_ha_delay_info_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  log_Check_ha_delay_info_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
+                                                                             "log_check_ha_delay_info");
 }
 #endif /* SERVER_MODE */
 
@@ -10741,7 +10743,7 @@ log_flush_daemon_init ()
   cubthread::looper looper = cubthread::looper (log_get_log_group_commit_interval);
   log_flush_daemon_task *daemon_task = new log_flush_daemon_task ();
 
-  log_Flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  log_Flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log_flush");
 }
 #endif /* SERVER_MODE */
 

--- a/unit_tests/communication_channel/test_main.cpp
+++ b/unit_tests/communication_channel/test_main.cpp
@@ -1,26 +1,28 @@
 #define SERVER_MODE
 
 #include "communication_channel.hpp"
+#include "connection_sr.h"
 #include "thread_entry_task.hpp"
 #include "thread_entry.hpp"
 #include "thread_looper.hpp"
 #include "thread_task.hpp"
 #include "thread_daemon.hpp"
 #include "lock_free.h"
-#include <vector>
-#include <mutex>
-#include <iostream>
-#include <chrono>
-#include <thread>
-#include "connection_sr.h"
-#include <stdio.h>
-#include <stdlib.h>
 
 #if !defined (WINDOWS)
 #include "tcp.h"
 #else
 #include "wintcp.h"
 #endif
+
+#include <chrono>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <stdio.h>
+#include <stdlib.h>
 
 #define MAX_THREADS 16
 

--- a/unit_tests/communication_channel/test_main.cpp
+++ b/unit_tests/communication_channel/test_main.cpp
@@ -210,9 +210,9 @@ class conn_listener_daemon_task : public cubthread::task<void>
 static int init_thread_system ()
 {
   int error_code;
-  lf_initialize_transaction_systems (MAX_THREADS);
 
-  if (csect_initialize_static_critical_sections () != NO_ERROR)
+  error_code = csect_initialize_static_critical_sections ();
+  if (error_code != NO_ERROR)
     {
       assert (false);
       return error_code;
@@ -243,6 +243,7 @@ static int init ()
   error_code = init_thread_system ();
   if (error_code != NO_ERROR)
     {
+      assert (false);
       return error_code;
     }
 
@@ -298,7 +299,6 @@ static int finish ()
     }
 
   css_final_conn_list();
-  lf_destroy_transaction_systems ();
 
   er_final (ER_ALL_FINAL);
 

--- a/unit_tests/communication_channel/test_main.cpp
+++ b/unit_tests/communication_channel/test_main.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <vector>
 
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/unit_tests/communication_channel/test_main.cpp
+++ b/unit_tests/communication_channel/test_main.cpp
@@ -97,7 +97,7 @@ void master_listening_thread_func (std::vector <communication_channel> &channels
     }
 }
 
-class conn_initiator_daemon_task : public cubthread::task<void>
+class conn_initiator_daemon_task : public cubthread::task_without_context
 {
   public:
     conn_initiator_daemon_task (int &counter, communication_channel &&chn) : m_counter (counter),
@@ -143,7 +143,7 @@ class conn_initiator_daemon_task : public cubthread::task<void>
     communication_channel m_channel;
 };
 
-class conn_listener_daemon_task : public cubthread::task<void>
+class conn_listener_daemon_task : public cubthread::task_without_context
 {
   public:
     conn_listener_daemon_task (std::vector <communication_channel> &&channels) : m_channels (
@@ -248,7 +248,7 @@ static int init ()
     }
 
   std::vector <communication_channel> channels;
-  std::vector <cubthread::task<void> *> tasks;
+  std::vector <cubthread::task_without_context *> tasks;
   counters = (int *) calloc (NUM_OF_INITIATORS, sizeof (int));
 
   is_listening.store (false);

--- a/unit_tests/communication_channel/test_main.cpp
+++ b/unit_tests/communication_channel/test_main.cpp
@@ -259,11 +259,12 @@ static int init ()
     }
   listening_thread.join ();
 
-  listener_daemon = cubthread::get_manager ()->create_daemon (std::chrono::seconds (0),
+  listener_daemon = cubthread::get_manager ()->create_daemon (cubthread::delta_time (0),
 		    new conn_listener_daemon_task (std::move (channels)));
   for (unsigned int i = 0; i < NUM_OF_INITIATORS; i++)
     {
-      initiator_daemons.push_back (cubthread::get_manager ()->create_daemon (std::chrono::seconds (1), tasks[i]));
+      initiator_daemons.push_back (cubthread::get_manager ()-> create_daemon (cubthread::delta_time (std::chrono::seconds (
+					   1)), tasks[i]));
     }
 
   return NO_ERROR;

--- a/unit_tests/transfer_channel/test_main.cpp
+++ b/unit_tests/transfer_channel/test_main.cpp
@@ -156,7 +156,7 @@ void master_listening_thread_func ()
 
 static int init_thread_system ()
 {
-  error_code = csect_initialize_static_critical_sections ();
+  int error_code = csect_initialize_static_critical_sections ();
   if (error_code != NO_ERROR)
     {
       assert (false);

--- a/unit_tests/transfer_channel/test_main.cpp
+++ b/unit_tests/transfer_channel/test_main.cpp
@@ -24,6 +24,7 @@
 #include <thread>
 #include <vector>
 
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/unit_tests/transfer_channel/test_main.cpp
+++ b/unit_tests/transfer_channel/test_main.cpp
@@ -12,19 +12,20 @@
 #include "lock_free.h"
 #include "connection_sr.h"
 
-#include <vector>
-#include <mutex>
-#include <iostream>
-#include <chrono>
-#include <thread>
-#include <stdio.h>
-#include <stdlib.h>
-
 #if !defined (WINDOWS)
 #include "tcp.h"
 #else
 #include "wintcp.h"
 #endif
+
+#include <chrono>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <stdio.h>
+#include <stdlib.h>
 
 #define MAX_THREADS 16
 #define LISTENING_PORT 2222

--- a/unit_tests/transfer_channel/test_main.cpp
+++ b/unit_tests/transfer_channel/test_main.cpp
@@ -156,10 +156,8 @@ void master_listening_thread_func ()
 
 static int init_thread_system ()
 {
-  int error_code;
-  lf_initialize_transaction_systems (MAX_THREADS);
-
-  if (csect_initialize_static_critical_sections () != NO_ERROR)
+  error_code = csect_initialize_static_critical_sections ();
+  if (error_code != NO_ERROR)
     {
       assert (false);
       return error_code;
@@ -243,7 +241,6 @@ static int finish ()
     }
 
   css_final_conn_list();
-  lf_destroy_transaction_systems ();
 
   er_final (ER_ALL_FINAL);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22008

  1. extend tasks and daemons to be used without a context.
  2. thread manager tracks entry-less daemons.
  3. remove entry/dummy thread contexts from stream transfer and unit test daemons.
  4. add daemons names that show up on thread stack.
  5. minor fixes in unit tests - add missing signal.h header and remove unnecessary lock-free transactions code.