### PR TITLE
[APIS-771] Wrap a thrown UnsupportedOperationException in a SQLExceptio…

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDBlob.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDBlob.java
@@ -168,11 +168,11 @@ public class CUBRIDBlob implements Blob {
 	}
 
 	public long position(byte[] pattern, long start) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public long position(Blob pattern, long start) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public int setBytes(long pos, byte[] bytes) throws SQLException {
@@ -244,7 +244,7 @@ public class CUBRIDBlob implements Blob {
 	}
 
 	public void truncate(long len) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDCallableStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDCallableStatement.java
@@ -290,11 +290,11 @@ public class CUBRIDCallableStatement extends CUBRIDPreparedStatement implements
 	}
 
 	public BigDecimal getBigDecimal(int index, int scale) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public Ref getRef(int i) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public Blob getBlob(int index) throws SQLException {
@@ -326,7 +326,7 @@ public class CUBRIDCallableStatement extends CUBRIDPreparedStatement implements
 	}
 
 	public Array getArray(int i) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public Date getDate(int index, Calendar cal) throws SQLException {
@@ -342,229 +342,229 @@ public class CUBRIDCallableStatement extends CUBRIDPreparedStatement implements
 	}
 
 	public URL getURL(int index) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public void setURL(String pName, URL val) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setNull(String pName, int sqlType) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setBoolean(String pName, boolean x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setByte(String pName, byte x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setShort(String pName, short x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setInt(String pName, int x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setLong(String pName, long x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setFloat(String pName, float x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setDouble(String pName, double x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setBigDecimal(String pName, BigDecimal x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setString(String pName, String x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setBytes(String pName, byte[] x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setDate(String pName, Date x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setTime(String pName, Time x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setTimetz(String pName, CUBRIDTimetz x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setTimestamp(String pName, Timestamp x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setTimestamptz(String pName, CUBRIDTimestamptz x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setAsciiStream(String pName, InputStream x, int length)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setBinaryStream(String pName, InputStream x, int length)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setObject(String pName, Object x, int targetSqlType, int scale)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setObject(String pName, Object x, int targetSqlType)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setObject(String pName, Object x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setCharacterStream(String pName, Reader reader, int length)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setDate(String pName, Date x, Calendar cal) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setTime(String pName, Time x, Calendar cal) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setTimetz(String pName, CUBRIDTimetz x, Calendar cal)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setTimestamp(String pName, Timestamp x, Calendar cal)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setTimestamptz(String pName, CUBRIDTimestamptz x, Calendar cal)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setNull(String pName, int sqlType, String typeName)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public String getString(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public boolean getBoolean(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public byte getByte(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public short getShort(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public int getInt(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public long getLong(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public float getFloat(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public double getDouble(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public byte[] getBytes(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Date getDate(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Time getTime(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Timestamp getTimestamp(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Object getObject(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Object getObject(int i, Map<String, Class<?>> map) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Object getObject(String pName, Map<String, Class<?>> map) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public BigDecimal getBigDecimal(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Ref getRef(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Blob getBlob(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Clob getClob(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Array getArray(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Date getDate(String pName, Calendar cal) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Time getTime(String pName, Calendar cal) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Timestamp getTimestamp(String pName, Calendar cal)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public URL getURL(String pName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void registerOutParameter(int index, int sqlType)
@@ -584,25 +584,25 @@ public class CUBRIDCallableStatement extends CUBRIDPreparedStatement implements
 
 	public void registerOutParameter(String pName, int sqlType)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void registerOutParameter(String pName, int sqlType, int scale)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void registerOutParameter(String pName, int sqlType, String typeName)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public int[] executeBatch() throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void addBatch() throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	/*
@@ -654,200 +654,200 @@ public class CUBRIDCallableStatement extends CUBRIDPreparedStatement implements
 
 	/* JDK 1.6 */
 	public Reader getCharacterStream(int parameterIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public Reader getCharacterStream(String parameterName) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public Reader getNCharacterStream(int parameterIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public Reader getNCharacterStream(String parameterName) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public NClob getNClob(int parameterIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public NClob getNClob(String parameterName) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public String getNString(int parameterIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public String getNString(String parameterName) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public RowId getRowId(int parameterIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public RowId getRowId(String parameterName) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public SQLXML getSQLXML(int parameterIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public SQLXML getSQLXML(String parameterName) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setAsciiStream(String parameterName, InputStream x)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setAsciiStream(String parameterName, InputStream x, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setBinaryStream(String parameterName, InputStream x)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setBinaryStream(String parameterName, InputStream x, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setBlob(String parameterName, Blob x) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setBlob(String parameterName, InputStream inputStream)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setBlob(String parameterName, InputStream inputStream,
 			long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setCharacterStream(String parameterName, Reader reader)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setCharacterStream(String parameterName, Reader reader,
 			long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setClob(String parameterName, Clob x) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setClob(String parameterName, Reader reader)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setClob(String parameterName, Reader reader, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNCharacterStream(String parameterName, Reader value)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNCharacterStream(String parameterName, Reader value,
 			long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNClob(String parameterName, NClob value) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNClob(String parameterName, Reader reader)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNClob(String parameterName, Reader reader, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNString(String parameterName, String value)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setRowId(String parameterName, RowId x) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setSQLXML(String parameterName, SQLXML xmlObject)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public void closeOnCompletion() throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public boolean isCloseOnCompletion() throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public <T> T getObject(int parameterIndex, Class<T> type)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public <T> T getObject(String parameterName, Class<T> type)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
@@ -180,11 +180,11 @@ public class CUBRIDClob implements Clob {
 	}
 
 	public long position(String searchstr, long start) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public long position(Clob searchClob, long start) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public synchronized int setString(long pos, String str) throws SQLException {
@@ -293,7 +293,7 @@ public class CUBRIDClob implements Clob {
 	}
 
 	public void truncate(long len) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
@@ -175,7 +175,7 @@ public class CUBRIDConnection implements Connection {
 	}
 
 	public String nativeSQL(String sql) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized void setAutoCommit(boolean autoCommit)
@@ -418,11 +418,11 @@ public class CUBRIDConnection implements Connection {
 	}
 
 	public Map<String, Class<?>> getTypeMap() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	// 3.0 api
@@ -432,7 +432,7 @@ public class CUBRIDConnection implements Connection {
 		if (holdable == ResultSet.HOLD_CURSORS_OVER_COMMIT) {
 			if (type == ResultSet.TYPE_SCROLL_SENSITIVE
 					|| concur == ResultSet.CONCUR_UPDATABLE) {
-				throw new java.lang.UnsupportedOperationException();
+				throw new SQLException(new java.lang.UnsupportedOperationException());
 			}
 		}
 		Statement stmt = new CUBRIDStatement(this, type, concur, holdable);
@@ -472,7 +472,7 @@ public class CUBRIDConnection implements Connection {
 		if (holdable == ResultSet.HOLD_CURSORS_OVER_COMMIT) {
 			if (type == ResultSet.TYPE_SCROLL_SENSITIVE
 					|| concur == ResultSet.CONCUR_UPDATABLE) {
-				throw new java.lang.UnsupportedOperationException();
+				throw new SQLException(new java.lang.UnsupportedOperationException());
 			}
 		}
 		return prepare(sql, type, concur, holdable, Statement.NO_GENERATED_KEYS);
@@ -492,7 +492,7 @@ public class CUBRIDConnection implements Connection {
 
 	public synchronized void releaseSavepoint(Savepoint savepoint)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 		/*
 		 * 3.0 checkIsOpen(); boolean flag=true;
 		 * 
@@ -506,7 +506,7 @@ public class CUBRIDConnection implements Connection {
 	}
 
 	public synchronized void rollback(Savepoint savepoint) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 		/*
 		 * 3.0 checkIsOpen();
 		 * 
@@ -530,7 +530,7 @@ public class CUBRIDConnection implements Connection {
 	}
 
 	public synchronized Savepoint setSavepoint() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 		/*
 		 * 3.0 checkIsOpen();
 		 * 
@@ -551,7 +551,7 @@ public class CUBRIDConnection implements Connection {
 	}
 
 	public synchronized Savepoint setSavepoint(String name) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 		/*
 		 * 3.0 checkIsOpen(); sv_name = name;
 		 * 
@@ -959,84 +959,88 @@ public class CUBRIDConnection implements Connection {
 
 	/* JDK 1.6 */
 	public NClob createNClob() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public Array createArrayOf(String arg0, Object[] arg1) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public SQLXML createSQLXML() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public Struct createStruct(String arg0, Object[] arg1) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public Properties getClientInfo() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public String getClientInfo(String arg0) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public boolean isValid(int arg0) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setClientInfo(Properties arg0) throws SQLClientInfoException {
-		throw new java.lang.UnsupportedOperationException();
+		SQLClientInfoException clientEx = new SQLClientInfoException();
+		clientEx.initCause(new java.lang.UnsupportedOperationException());
+		throw clientEx;
 	}
 
 	/* JDK 1.6 */
 	public void setClientInfo(String arg0, String arg1)
 			throws SQLClientInfoException {
-		throw new java.lang.UnsupportedOperationException();
+		SQLClientInfoException clientEx = new SQLClientInfoException();
+		clientEx.initCause(new java.lang.UnsupportedOperationException());
+		throw clientEx;
 	}
 
 	/* JDK 1.6 */
 	public boolean isWrapperFor(Class<?> arg0) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public <T> T unwrap(Class<T> arg0) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public void setSchema(String schema) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public String getSchema() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public void abort(Executor executor) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public void setNetworkTimeout(Executor executor, int milliseconds)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public int getNetworkTimeout() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDataSource.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDataSource.java
@@ -136,12 +136,12 @@ public class CUBRIDDataSource extends CUBRIDDataSourceBase implements
 
 	/* JDK 1.6 */
 	public boolean isWrapperFor(Class<?> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public <T> T unwrap(Class<T> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDatabaseMetaData.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDatabaseMetaData.java
@@ -2156,7 +2156,7 @@ public class CUBRIDDatabaseMetaData implements DatabaseMetaData {
 
 	public synchronized ResultSet getUDTs(String catalog, String schemaPattern,
 			String typeNamePattern, int[] types) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized Connection getConnection() throws SQLException {
@@ -2421,63 +2421,63 @@ public class CUBRIDDatabaseMetaData implements DatabaseMetaData {
 
 	/* JDK 1.6 */
 	public boolean autoCommitFailureClosesAllResultSets() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public ResultSet getClientInfoProperties() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public ResultSet getFunctionColumns(String catalog, String schemaPattern,
 			String functionNamePattern, String columnNamePattern)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public ResultSet getFunctions(String catalog, String schemaPattern,
 			String functionNamePattern) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public RowIdLifetime getRowIdLifetime() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public ResultSet getSchemas(String catalog, String schemaPattern)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public boolean supportsStoredFunctionsUsingCallSyntax() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public boolean isWrapperFor(Class<?> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public <T> T unwrap(Class<T> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public ResultSet getPseudoColumns(String catalog, String schemaPattern,
 			String tableNamePattern, String columnNamePattern)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public boolean generatedKeyAlwaysReturned() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
@@ -365,7 +365,7 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements
 
 	public void setUnicodeStream(int parameterIndex, InputStream x, int length)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized void setBinaryStream(int parameterIndex, InputStream x,
@@ -592,7 +592,7 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements
 	}
 
 	public void setRef(int i, Ref x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public void setBlob(int parameterIndex, Blob x) throws SQLException {
@@ -696,7 +696,7 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements
 	}
 
 	public void setArray(int i, Array x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized ResultSetMetaData getMetaData() throws SQLException {
@@ -832,7 +832,7 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements
 	// 3.0
 	public synchronized ParameterMetaData getParameterMetaData()
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 		/*
 		 * checkIsOpen();
 		 * 
@@ -849,7 +849,7 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements
 	}
 
 	public synchronized void setURL(int index, URL x) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	// 3.0
@@ -998,7 +998,7 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements
 			throws SQLException {
 		// TODO: How to solve it? host variable bind problem
 		// setBlob(parameterIndex, x);
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
@@ -1006,7 +1006,7 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements
 			throws SQLException {
 		// TODO: How to solve it? host variable bind problem
 		// setBlob(parameterIndex, x, length);
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
@@ -1014,7 +1014,7 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements
 			throws SQLException {
 		// TODO: How to solve it? host variable bind problem
 		// setClob(parameterIndex, x);
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
@@ -1022,7 +1022,7 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements
 			throws SQLException {
 		// TODO: How to solve it? host variable bind problem
 		// setClob(parameterIndex, x, length);
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
@@ -1030,7 +1030,7 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements
 			throws SQLException {
 		// TODO: How to solve it? host variable bind problem
 		// setClob(parameterIndex, reader);
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
@@ -1038,52 +1038,52 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements
 			long length) throws SQLException {
 		// TODO: How to solve it? host variable bind problem
 		// setClob(parameterIndex, reader, length);
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNCharacterStream(int parameterIndex, Reader value)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNCharacterStream(int parameterIndex, Reader value,
 			long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNClob(int parameterIndex, NClob value) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNClob(int parameterIndex, Reader reader) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNClob(int parameterIndex, Reader reader, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setNString(int parameterIndex, String value)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setRowId(int parameterIndex, RowId x) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setSQLXML(int parameterIndex, SQLXML xmlObject)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -436,7 +436,7 @@ public class CUBRIDResultSet implements ResultSet {
 
 	public BigDecimal getBigDecimal(int columnIndex, int scale)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public synchronized byte[] getBytes(int columnIndex) throws SQLException {
@@ -546,7 +546,7 @@ public class CUBRIDResultSet implements ResultSet {
 	}
 
 	public InputStream getUnicodeStream(int columnIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public synchronized InputStream getBinaryStream(int columnIndex)
@@ -618,7 +618,7 @@ public class CUBRIDResultSet implements ResultSet {
 
 	public BigDecimal getBigDecimal(String columnName, int scale)
 	        throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized byte[] getBytes(String columnName) throws SQLException {
@@ -644,7 +644,7 @@ public class CUBRIDResultSet implements ResultSet {
 	}
 
 	public InputStream getUnicodeStream(String columnName) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public synchronized InputStream getBinaryStream(String columnName)
@@ -1475,11 +1475,11 @@ public class CUBRIDResultSet implements ResultSet {
 
 	public Object getObject(int i, Map<String, Class<?>> map)
 	        throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Ref getRef(int i) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized Blob getBlob(int columnIndex) throws SQLException {
@@ -1511,16 +1511,16 @@ public class CUBRIDResultSet implements ResultSet {
 	}
 
 	public Array getArray(int i) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Object getObject(String colName, Map<String, Class<?>> map)
 	        throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Ref getRef(String colName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public Blob getBlob(String colName) throws SQLException {
@@ -1532,7 +1532,7 @@ public class CUBRIDResultSet implements ResultSet {
 	}
 
 	public Array getArray(String colName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized Date getDate(int columnIndex, Calendar cal)
@@ -1567,21 +1567,21 @@ public class CUBRIDResultSet implements ResultSet {
 
 	// 3.0
 	public synchronized URL getURL(int columnIndex) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized URL getURL(String columnName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized void updateArray(int columnIndex, Array x)
 	        throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized void updateArray(String columnName, Array x)
 	        throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized void updateBlob(int columnIndex, Blob x)
@@ -1606,12 +1606,12 @@ public class CUBRIDResultSet implements ResultSet {
 
 	public synchronized void updateRef(int columnIndex, Ref x)
 	        throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized void updateRef(String columnName, Ref x)
 	        throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	// 3.0
@@ -1928,288 +1928,288 @@ public class CUBRIDResultSet implements ResultSet {
 
 	/* JDK 1.6 */
 	public Reader getNCharacterStream(int columnIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public Reader getNCharacterStream(String columnLabel) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public NClob getNClob(int columnIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public NClob getNClob(String columnLabel) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public String getNString(int columnIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public String getNString(String columnLabel) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public RowId getRowId(int columnIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public RowId getRowId(String columnLabel) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public SQLXML getSQLXML(int columnIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public SQLXML getSQLXML(String columnLabel) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public boolean isClosed() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateAsciiStream(int columnIndex, InputStream x)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateAsciiStream(String columnLabel, InputStream x)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateAsciiStream(int columnIndex, InputStream x, long length)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateAsciiStream(String columnLabel, InputStream x, long length)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateBinaryStream(int columnIndex, InputStream x)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateBinaryStream(String columnLabel, InputStream x)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateBinaryStream(int columnIndex, InputStream x, long length)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateBinaryStream(String columnLabel, InputStream x,
 	        long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateBlob(int columnIndex, InputStream inputStream)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateBlob(String columnLabel, InputStream inputStream)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateBlob(int columnIndex, InputStream inputStream, long length)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateBlob(String columnLabel, InputStream inputStream,
 	        long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateCharacterStream(int columnIndex, Reader x)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateCharacterStream(String columnLabel, Reader reader)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateCharacterStream(int columnIndex, Reader x, long length)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateCharacterStream(String columnLabel, Reader reader,
 	        long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateClob(int columnIndex, Reader reader) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateClob(String columnLabel, Reader reader)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateClob(int columnIndex, Reader reader, long length)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateClob(String columnLabel, Reader reader, long length)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNCharacterStream(int columnIndex, Reader x)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNCharacterStream(String columnLabel, Reader reader)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNCharacterStream(int columnIndex, Reader x, long length)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNCharacterStream(String columnLabel, Reader reader,
 	        long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(int columnIndex, NClob clob) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(String columnLabel, NClob clob) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(int columnIndex, Reader reader) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(String columnLabel, Reader reader)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(int columnIndex, Reader reader, long length)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(String columnLabel, Reader reader, long length)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNString(int columnIndex, String string)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNString(String columnLabel, String string)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateRowId(int columnIndex, RowId x) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateRowId(String columnLabel, RowId x) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateSQLXML(int columnIndex, SQLXML xmlObject)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateSQLXML(String columnLabel, SQLXML xmlObject)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public boolean isWrapperFor(Class<?> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public <T> T unwrap(Class<T> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public <T> T getObject(String columnLabel, Class<T> type)
 	        throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetMetaData.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetMetaData.java
@@ -770,12 +770,12 @@ public class CUBRIDResultSetMetaData implements ResultSetMetaData {
 
 	/* JDK 1.6 */
 	public boolean isWrapperFor(Class<?> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public <T> T unwrap(Class<T> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	private void checkColumnIndex(int column) throws SQLException {

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetWithoutQuery.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetWithoutQuery.java
@@ -240,7 +240,7 @@ class CUBRIDResultSetWithoutQuery implements ResultSet {
 
 	public BigDecimal getBigDecimal(int columnIndex, int scale)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized byte[] getBytes(int columnIndex) throws SQLException {
@@ -304,7 +304,7 @@ class CUBRIDResultSetWithoutQuery implements ResultSet {
 	}
 
 	public InputStream getUnicodeStream(int columnIndex) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized InputStream getBinaryStream(int columnIndex)
@@ -353,7 +353,7 @@ class CUBRIDResultSetWithoutQuery implements ResultSet {
 
 	public BigDecimal getBigDecimal(String columnName, int scale)
 			throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized byte[] getBytes(String columnName) throws SQLException {
@@ -379,7 +379,7 @@ class CUBRIDResultSetWithoutQuery implements ResultSet {
 	}
 
 	public InputStream getUnicodeStream(String columnName) throws SQLException {
-		throw new UnsupportedOperationException();
+		throw new SQLException(new UnsupportedOperationException());
 	}
 
 	public synchronized InputStream getBinaryStream(String columnName)
@@ -1026,307 +1026,307 @@ class CUBRIDResultSetWithoutQuery implements ResultSet {
 
 	/* JDK 1.6 */
 	public int getHoldability() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public Reader getNCharacterStream(int columnIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public Reader getNCharacterStream(String columnLabel) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public NClob getNClob(int columnIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public NClob getNClob(String columnLabel) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public String getNString(int columnIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public String getNString(String columnLabel) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public RowId getRowId(int columnIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public RowId getRowId(String columnLabel) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public SQLXML getSQLXML(int columnIndex) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public SQLXML getSQLXML(String columnLabel) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public boolean isClosed() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateAsciiStream(int columnIndex, InputStream x)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateAsciiStream(String columnLabel, InputStream x)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateAsciiStream(int columnIndex, InputStream x, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateAsciiStream(String columnLabel, InputStream x, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateBinaryStream(int columnIndex, InputStream x)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateBinaryStream(String columnLabel, InputStream x)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateBinaryStream(int columnIndex, InputStream x, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateBinaryStream(String columnLabel, InputStream x,
 			long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateBlob(int columnIndex, InputStream inputStream)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateBlob(String columnLabel, InputStream inputStream)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateBlob(int columnIndex, InputStream inputStream, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateBlob(String columnLabel, InputStream inputStream,
 			long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateCharacterStream(int columnIndex, Reader x)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateCharacterStream(String columnLabel, Reader reader)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateCharacterStream(int columnIndex, Reader x, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 
 	}
 
 	/* JDK 1.6 */
 	public void updateCharacterStream(String columnLabel, Reader reader,
 			long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateClob(int columnIndex, Reader reader) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateClob(String columnLabel, Reader reader)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateClob(int columnIndex, Reader reader, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateClob(String columnLabel, Reader reader, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNCharacterStream(int columnIndex, Reader x)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNCharacterStream(String columnLabel, Reader reader)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNCharacterStream(int columnIndex, Reader x, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNCharacterStream(String columnLabel, Reader reader,
 			long length) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(int columnIndex, NClob clob) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(String columnLabel, NClob clob) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(int columnIndex, Reader reader) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(String columnLabel, Reader reader)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(int columnIndex, Reader reader, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNClob(String columnLabel, Reader reader, long length)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNString(int columnIndex, String string)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateNString(String columnLabel, String string)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateRowId(int columnIndex, RowId x) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateRowId(String columnLabel, RowId x) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateSQLXML(int columnIndex, SQLXML xmlObject)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void updateSQLXML(String columnLabel, SQLXML xmlObject)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public boolean isWrapperFor(Class<?> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public <T> T unwrap(Class<T> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public <T> T getObject(String columnLabel, Class<T> type)
 			throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
@@ -646,7 +646,7 @@ public class CUBRIDStatement implements Statement {
 		 * e) { throw new CUBRIDException(CUBRIDJDBCErrorCode.statement_closed);
 		 * }
 		 */
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	int getHoldability() {
@@ -780,27 +780,27 @@ public class CUBRIDStatement implements Statement {
 
 	/* JDK 1.6 */
 	public boolean isClosed() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public boolean isPoolable() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public void setPoolable(boolean poolable) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public boolean isWrapperFor(Class<?> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.6 */
 	public <T> T unwrap(Class<T> iface) throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	protected CUBRIDOID executeInsertCore() throws SQLException {
@@ -1039,12 +1039,12 @@ public class CUBRIDStatement implements Statement {
 
 	/* JDK 1.7 */
 	public void closeOnCompletion() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	/* JDK 1.7 */
 	public boolean isCloseOnCompletion() throws SQLException {
-		throw new java.lang.UnsupportedOperationException();
+		throw new SQLException(new java.lang.UnsupportedOperationException());
 	}
 
 	public void setCurrentTransaction (boolean is_from_current_transaction) {

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
@@ -780,7 +780,7 @@ public class CUBRIDStatement implements Statement {
 
 	/* JDK 1.6 */
 	public boolean isClosed() throws SQLException {
-		throw new SQLException(new java.lang.UnsupportedOperationException());
+		return is_closed;
 	}
 
 	/* JDK 1.6 */


### PR DESCRIPTION
See http://jira.cubrid.org/browse/APIS-771

Wrap a thrown UnsupportedOperationException in a SQLException.  Third party tools and libraries commonly expect SQLException, and have code to deal with them.  Such tools and libraries are not expecting UnsupportedOperationException, resulting in applications experiencing exceptions that the tool or lib provider attempted to prevent.