### PR TITLE
[CBRD-22082] check stop_talk and errors on read & queue

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -983,8 +983,7 @@ css_reestablish_connection_to_master (void)
 }
 
 /*
- * css_connection_handler_thread () - Accept/process request from
- *                                    one client
+ * css_connection_handler_thread () - Accept/process request from one client
  *   return:
  *   arg(in):
  *
@@ -1039,7 +1038,7 @@ css_connection_handler_thread (THREAD_ENTRY * thread_p, CSS_CONN_ENTRY * conn)
 
       if (conn_status != CONN_OPEN)
 	{
-	  er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: " "conn->status (%d) is not CONN_OPEN.",
+	  er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: conn->status (%d) is not CONN_OPEN.",
 			conn_status);
 	  status = CONNECTION_CLOSED;
 	  break;
@@ -1064,7 +1063,7 @@ css_connection_handler_thread (THREAD_ENTRY * thread_p, CSS_CONN_ENTRY * conn)
 	    {
 	      if (css_peer_alive (fd, css_peer_alive_timeout) == false)
 		{
-		  er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: " "css_peer_alive() error\n");
+		  er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: css_peer_alive() error\n");
 		  status = CONNECTION_CLOSED;
 		  break;
 		}
@@ -1090,7 +1089,7 @@ css_connection_handler_thread (THREAD_ENTRY * thread_p, CSS_CONN_ENTRY * conn)
 	    }
 	  else
 	    {
-	      er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: " "select() error\n");
+	      er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: select() error\n");
 	      status = ERROR_ON_READ;
 	      break;
 	    }
@@ -1109,7 +1108,7 @@ css_connection_handler_thread (THREAD_ENTRY * thread_p, CSS_CONN_ENTRY * conn)
 	  status = css_read_and_queue (conn, &type);
 	  if (status != NO_ERRORS)
 	    {
-	      er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: " "css_read_and_queue() error\n");
+	      er_log_debug (ARG_FILE_LINE, "css_connection_handler_thread: css_read_and_queue() error\n");
 	      break;
 	    }
 	  else
@@ -1128,7 +1127,7 @@ css_connection_handler_thread (THREAD_ENTRY * thread_p, CSS_CONN_ENTRY * conn)
   if (status != NO_ERRORS || css_check_conn (conn) != NO_ERROR)
     {
       er_log_debug (ARG_FILE_LINE,
-		    "css_connection_handler_thread: " "status %d conn { status %d transaction_id %d "
+		    "css_connection_handler_thread: status %d conn { status %d transaction_id %d "
 		    "db_error %d stop_talk %d stop_phase %d }\n", status, conn->status, conn->transaction_id,
 		    conn->db_error, conn->stop_talk, conn->stop_phase);
       rv = pthread_mutex_lock (&thread_p->tran_index_lock);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22082

The issue is unchecked connection state and error code. Packet header is not read and then connection transaction ID is set to 0 (system transaction).

Added checks to correctly handle the case.

Note: this patch does not include safe code handling connection entry transaction ID. I may add it or open a different PR.