### PR TITLE
[CBRD-22081] remove incorrect file_expand_to safe-guard

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2540,8 +2540,10 @@ fileio_expand_to (THREAD_ENTRY * thread_p, VOLID vol_id, DKNPAGES size_npages, D
 
   if (new_size <= current_size)
     {
-      /* this must be recovery. */
-      assert (!LOG_ISRESTARTED ());
+      /* this is possible in limited cases. we cannot link file expand to a page, so sometimes we may expand but volume
+       * header does not reflect this change. also, once expanded, we don't undo the expansion.
+       * however next time volume wants to expand (this case), it just notices file is already expanded and all is
+       * good. */
       er_log_debug (ARG_FILE_LINE, "skip extending volume %d with current size %zu to new size %zu\n",
 		    vol_id, current_size, new_size);
       return NO_ERROR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22081

Removed safe-guard. The case is possible even if it is not during recovery. Sometimes file gets extended, but volume header changes are rollbacked. There is no easy way to ensure exact synchronization.

Is is best to just accept file bigger than expected while expanding. If file is big enough, early out.