### PR TITLE
[CBRD-22083] safe-guard connection entry's transaction index

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1086,7 +1086,7 @@ net_server_conn_down (THREAD_ENTRY * thread_p, CSS_THREAD_ARG arg)
   local_tran_index = thread_p->tran_index;
 
   conn_p = (CSS_CONN_ENTRY *) arg;
-  tran_index = conn_p->transaction_id;
+  tran_index = conn_p->get_tran_index ();
   client_id = conn_p->client_id;
 
   thread_set_info (thread_p, client_id, 0, tran_index, NET_SERVER_SHUTDOWN);
@@ -1105,7 +1105,7 @@ loop:
 	{
 	  /* the connected client does not yet finished boot_client_register */
 	  thread_sleep (50);	/* 50 msec */
-	  tran_index = conn_p->transaction_id;
+	  tran_index = conn_p->get_tran_index ();
 	}
       if (!logtb_is_interrupted_tran (thread_p, false, &continue_check, tran_index))
 	{

--- a/src/connection/client_support.c
+++ b/src/connection/client_support.c
@@ -179,7 +179,7 @@ css_send_request_to_server (char *host, int request, char *arg_buffer, int arg_b
   entry = css_return_open_entry (host, &css_Client_anchor);
   if (entry != NULL)
     {
-      entry->conn->transaction_id = tm_Tran_index;
+      entry->conn->set_tran_index (tm_Tran_index);
       entry->conn->invalidate_snapshot = tm_Tran_invalidate_snapshot;
       css_Errno = css_send_request (entry->conn, (int) request, &rid, arg_buffer, (int) arg_buffer_size);
       if (css_Errno != NO_ERRORS)
@@ -223,7 +223,7 @@ css_send_request_to_server_with_buffer (char *host, int request, char *arg_buffe
   entry = css_return_open_entry (host, &css_Client_anchor);
   if (entry != NULL)
     {
-      entry->conn->transaction_id = tm_Tran_index;
+      entry->conn->set_tran_index (tm_Tran_index);
       entry->conn->invalidate_snapshot = tm_Tran_invalidate_snapshot;
       css_Errno =
 	css_send_request_with_data_buffer (entry->conn, request, &rid, arg_buffer, arg_buffer_size, data_buffer,
@@ -270,7 +270,7 @@ css_send_req_to_server (char *host, int request, char *arg_buffer, int arg_buffe
   entry = css_return_open_entry (host, &css_Client_anchor);
   if (entry != NULL)
     {
-      entry->conn->transaction_id = tm_Tran_index;
+      entry->conn->set_tran_index (tm_Tran_index);
       entry->conn->invalidate_snapshot = tm_Tran_invalidate_snapshot;
       css_Errno =
 	css_send_req_with_2_buffers (entry->conn, request, &rid, arg_buffer, arg_buffer_size, data_buffer,
@@ -371,7 +371,7 @@ css_send_req_to_server_2_data (char *host, int request, char *arg_buffer, int ar
   entry = css_return_open_entry (host, &css_Client_anchor);
   if (entry != NULL)
     {
-      entry->conn->transaction_id = tm_Tran_index;
+      entry->conn->set_tran_index (tm_Tran_index);
       entry->conn->invalidate_snapshot = tm_Tran_invalidate_snapshot;
       css_Errno =
 	css_send_req_with_3_buffers (entry->conn, request, &rid, arg_buffer, arg_buffer_size, data1_buffer,
@@ -410,7 +410,7 @@ css_send_req_to_server_no_reply (char *host, int request, char *arg_buffer, int 
   entry = css_return_open_entry (host, &css_Client_anchor);
   if (entry != NULL)
     {
-      entry->conn->transaction_id = tm_Tran_index;
+      entry->conn->set_tran_index (tm_Tran_index);
       entry->conn->invalidate_snapshot = tm_Tran_invalidate_snapshot;
       css_Errno = css_send_request_no_reply (entry->conn, request, &rid, arg_buffer, arg_buffer_size);
       if (css_Errno == NO_ERRORS)
@@ -483,7 +483,7 @@ css_send_error_to_server (char *host, unsigned int eid, char *buffer, int buffer
   entry = css_return_open_entry (host, &css_Client_anchor);
   if (entry != NULL)
     {
-      entry->conn->transaction_id = tm_Tran_index;
+      entry->conn->set_tran_index (tm_Tran_index);
       entry->conn->invalidate_snapshot = tm_Tran_invalidate_snapshot;
       entry->conn->db_error = er_errid ();
       css_Errno = css_send_error (entry->conn, CSS_RID_FROM_EID (eid), buffer, buffer_size);
@@ -520,7 +520,7 @@ css_send_data_to_server (char *host, unsigned int eid, char *buffer, int buffer_
   entry = css_return_open_entry (host, &css_Client_anchor);
   if (entry != NULL)
     {
-      entry->conn->transaction_id = tm_Tran_index;
+      entry->conn->set_tran_index (tm_Tran_index);
       entry->conn->invalidate_snapshot = tm_Tran_invalidate_snapshot;
       css_Errno = css_send_data (entry->conn, CSS_RID_FROM_EID (eid), buffer, buffer_size);
       if (css_Errno == NO_ERRORS)

--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -421,7 +421,6 @@ struct css_conn_entry
   SOCKET fd;
   unsigned short request_id;
   int status;			/* CONN_OPEN, CONN_CLOSED, CONN_CLOSING = 3 */
-  int transaction_id;
   int invalidate_snapshot;
   int client_id;
   int db_error;
@@ -464,6 +463,18 @@ struct css_conn_entry
 #endif
   SESSION_ID session_id;
   CSS_CONN_ENTRY *next;
+
+#if defined __cplusplus
+  // transaction ID manipulation
+  void set_tran_index (int tran_index);
+  int get_tran_index (void);
+
+private:
+  // note - I want to protect this.
+  int transaction_id;
+#else				// not c++ = c
+  int transaction_id;
+#endif				// not c++ = c
 };
 
 /*

--- a/src/connection/connection_list_cl.c
+++ b/src/connection/connection_list_cl.c
@@ -316,7 +316,7 @@ css_queue_packet (CSS_CONN_ENTRY * conn, CSS_QUEUE_ENTRY ** queue_p, unsigned sh
 {
   if (!css_is_request_aborted (conn, request_id))
     {
-      return css_add_entry_to_header (queue_p, request_id, buffer, size, rc, conn->transaction_id,
+      return css_add_entry_to_header (queue_p, request_id, buffer, size, rc, conn->get_tran_index (),
 				      conn->invalidate_snapshot, conn->db_error);
     }
 
@@ -357,7 +357,7 @@ css_recv_and_queue_packet (CSS_CONN_ENTRY * conn, unsigned short request_id, cha
     {
       if (!css_is_request_aborted (conn, request_id))
 	{
-	  css_add_entry_to_header (queue_p, request_id, buffer, size, rc, conn->transaction_id,
+	  css_add_entry_to_header (queue_p, request_id, buffer, size, rc, conn->get_tran_index (),
 				   conn->invalidate_snapshot, conn->db_error);
 	  return true;
 	}
@@ -490,7 +490,7 @@ css_queue_command_packet (CSS_CONN_ENTRY * conn, unsigned short request_id, NET_
       if (temp != NULL)
 	{
 	  memcpy ((char *) temp, (char *) header, sizeof (NET_HEADER));
-	  css_add_entry_to_header (&conn->request_queue, request_id, (char *) temp, size, 0, conn->transaction_id,
+	  css_add_entry_to_header (&conn->request_queue, request_id, (char *) temp, size, 0, conn->get_tran_index (),
 				   conn->invalidate_snapshot, conn->db_error);
 	}
     }
@@ -511,7 +511,7 @@ css_process_abort_packet (CSS_CONN_ENTRY * conn, unsigned short request_id)
 
   if (css_find_queue_entry (conn->abort_queue, request_id) == NULL)
     {
-      css_add_entry_to_header (&conn->abort_queue, request_id, NULL, 0, 0, conn->transaction_id,
+      css_add_entry_to_header (&conn->abort_queue, request_id, NULL, 0, 0, conn->get_tran_index (),
 			       conn->invalidate_snapshot, conn->db_error);
     }
 }
@@ -549,7 +549,7 @@ css_queue_unexpected_packet (int type, CSS_CONN_ENTRY * conn, unsigned short req
 {
   unsigned short flags = 0;
 
-  conn->transaction_id = ntohl (header->transaction_id);
+  conn->set_tran_index (ntohl (header->transaction_id));
   flags = ntohs (header->flags);
   conn->invalidate_snapshot = flags | NET_HEADER_FLAG_INVALIDATE_SNAPSHOT ? 1 : 0;
   conn->db_error = (int) ntohl (header->db_error);

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -66,12 +66,9 @@
 #else /* WINDOWS */
 #include "tcp.h"
 #endif /* !WINDOWS */
-
+#include "log_impl.h"
 #if defined(SERVER_MODE)
 #include "connection_sr.h"
-#if defined(WINDOWS)
-#include "log_impl.h"
-#endif
 #else
 #include "connection_list_cl.h"
 #include "connection_cl.h"
@@ -184,7 +181,7 @@ css_sprintf_conn_infoids (SOCKET fd, const char **client_user_name, const char *
 
   conn = css_find_conn_from_fd (fd);
 
-  if (conn != NULL && conn->transaction_id != -1)
+  if (conn != NULL && conn->get_tran_index () != -1)
     {
       if (getuserid (user_name, L_cuserid) == NULL)
 	{
@@ -201,7 +198,7 @@ css_sprintf_conn_infoids (SOCKET fd, const char **client_user_name, const char *
       *client_user_name = user_name;
       *client_host_name = host_name;
       *client_pid = pid;
-      tran_index = conn->transaction_id;
+      tran_index = conn->get_tran_index ();
     }
 
   return tran_index;
@@ -234,14 +231,14 @@ css_sprintf_conn_infoids (SOCKET fd, const char **client_user_name, const char *
 
   conn = css_find_conn_from_fd (fd);
 
-  if (conn != NULL && conn->transaction_id != -1)
+  if (conn != NULL && conn->get_tran_index () != -1)
     {
-      error = logtb_find_client_name_host_pid (conn->transaction_id, (char **) &client_prog_name,
+      error = logtb_find_client_name_host_pid (conn->get_tran_index (), (char **) &client_prog_name,
 					       (char **) client_user_name, (char **) client_host_name,
 					       (int *) client_pid);
       if (error == NO_ERROR)
 	{
-	  tran_index = conn->transaction_id;
+	  tran_index = conn->get_tran_index ();
 	}
     }
 
@@ -1524,7 +1521,7 @@ css_send_request_with_data_buffer (CSS_CONN_ENTRY * conn, int request, unsigned 
     }
 
   *request_id = css_get_request_id (conn);
-  css_set_net_header (&local_header, COMMAND_TYPE, request, *request_id, arg_size, conn->transaction_id,
+  css_set_net_header (&local_header, COMMAND_TYPE, request, *request_id, arg_size, conn->get_tran_index (),
 		      conn->invalidate_snapshot, conn->db_error);
 
   if (reply_buffer && (reply_size > 0))
@@ -1534,7 +1531,7 @@ css_send_request_with_data_buffer (CSS_CONN_ENTRY * conn, int request, unsigned 
 
   if (arg_size > 0 && arg_buffer != NULL)
     {
-      css_set_net_header (&data_header, DATA_TYPE, 0, *request_id, arg_size, conn->transaction_id,
+      css_set_net_header (&data_header, DATA_TYPE, 0, *request_id, arg_size, conn->get_tran_index (),
 			  conn->invalidate_snapshot, conn->db_error);
 
       return (css_net_send3 (conn, (char *) &local_header, sizeof (NET_HEADER), (char *) &data_header,
@@ -1576,10 +1573,10 @@ css_send_request_no_reply (CSS_CONN_ENTRY * conn, int request, unsigned short *r
     }
 
   *request_id = css_get_request_id (conn);
-  css_set_net_header (&req_header, COMMAND_TYPE, request, *request_id, arg_size, conn->transaction_id,
+  css_set_net_header (&req_header, COMMAND_TYPE, request, *request_id, arg_size, conn->get_tran_index (),
 		      conn->invalidate_snapshot, conn->db_error);
 
-  css_set_net_header (&data_header, DATA_TYPE, 0, *request_id, arg_size, conn->transaction_id,
+  css_set_net_header (&data_header, DATA_TYPE, 0, *request_id, arg_size, conn->get_tran_index (),
 		      conn->invalidate_snapshot, conn->db_error);
 
   return (css_net_send3 (conn, (char *) &req_header, sizeof (NET_HEADER), (char *) &data_header, sizeof (NET_HEADER),
@@ -1620,7 +1617,7 @@ css_send_req_with_2_buffers (CSS_CONN_ENTRY * conn, int request, unsigned short 
     }
 
   *request_id = css_get_request_id (conn);
-  css_set_net_header (&local_header, COMMAND_TYPE, request, *request_id, arg_size, conn->transaction_id,
+  css_set_net_header (&local_header, COMMAND_TYPE, request, *request_id, arg_size, conn->get_tran_index (),
 		      conn->invalidate_snapshot, conn->db_error);
 
   if (reply_buffer && reply_size > 0)
@@ -1628,10 +1625,10 @@ css_send_req_with_2_buffers (CSS_CONN_ENTRY * conn, int request, unsigned short 
       css_queue_user_data_buffer (conn, *request_id, reply_size, reply_buffer);
     }
 
-  css_set_net_header (&arg_header, DATA_TYPE, 0, *request_id, arg_size, conn->transaction_id, conn->invalidate_snapshot,
-		      conn->db_error);
+  css_set_net_header (&arg_header, DATA_TYPE, 0, *request_id, arg_size, conn->get_tran_index (),
+		      conn->invalidate_snapshot, conn->db_error);
 
-  css_set_net_header (&data_header, DATA_TYPE, 0, *request_id, data_size, conn->transaction_id,
+  css_set_net_header (&data_header, DATA_TYPE, 0, *request_id, data_size, conn->get_tran_index (),
 		      conn->invalidate_snapshot, conn->db_error);
 
   return (css_net_send5 (conn, (char *) &local_header, sizeof (NET_HEADER), (char *) &arg_header, sizeof (NET_HEADER),
@@ -1677,7 +1674,7 @@ css_send_req_with_3_buffers (CSS_CONN_ENTRY * conn, int request, unsigned short 
     }
 
   *request_id = css_get_request_id (conn);
-  css_set_net_header (&local_header, COMMAND_TYPE, request, *request_id, arg_size, conn->transaction_id,
+  css_set_net_header (&local_header, COMMAND_TYPE, request, *request_id, arg_size, conn->get_tran_index (),
 		      conn->invalidate_snapshot, conn->db_error);
 
   if (reply_buffer && reply_size > 0)
@@ -1685,13 +1682,13 @@ css_send_req_with_3_buffers (CSS_CONN_ENTRY * conn, int request, unsigned short 
       css_queue_user_data_buffer (conn, *request_id, reply_size, reply_buffer);
     }
 
-  css_set_net_header (&arg_header, DATA_TYPE, 0, *request_id, arg_size, conn->transaction_id, conn->invalidate_snapshot,
-		      conn->db_error);
-
-  css_set_net_header (&data1_header, DATA_TYPE, 0, *request_id, data1_size, conn->transaction_id,
+  css_set_net_header (&arg_header, DATA_TYPE, 0, *request_id, arg_size, conn->get_tran_index (),
 		      conn->invalidate_snapshot, conn->db_error);
 
-  css_set_net_header (&data2_header, DATA_TYPE, 0, *request_id, data2_size, conn->transaction_id,
+  css_set_net_header (&data1_header, DATA_TYPE, 0, *request_id, data1_size, conn->get_tran_index (),
+		      conn->invalidate_snapshot, conn->db_error);
+
+  css_set_net_header (&data2_header, DATA_TYPE, 0, *request_id, data2_size, conn->get_tran_index (),
 		      conn->invalidate_snapshot, conn->db_error);
 
   return (css_net_send7 (conn, (char *) &local_header, sizeof (NET_HEADER), (char *) &arg_header, sizeof (NET_HEADER),
@@ -1736,7 +1733,7 @@ css_send_req_with_large_buffer (CSS_CONN_ENTRY * conn, int request, unsigned sho
     }
 
   *request_id = css_get_request_id (conn);
-  css_set_net_header (&local_header, COMMAND_TYPE, request, *request_id, arg_size, conn->transaction_id,
+  css_set_net_header (&local_header, COMMAND_TYPE, request, *request_id, arg_size, conn->get_tran_index (),
 		      conn->invalidate_snapshot, conn->db_error);
 
   if (reply_buffer && reply_size > 0)
@@ -1759,8 +1756,8 @@ css_send_req_with_large_buffer (CSS_CONN_ENTRY * conn, int request, unsigned sho
       return CANT_ALLOC_BUFFER;
     }
 
-  css_set_net_header (&headers[0], DATA_TYPE, 0, *request_id, arg_size, conn->transaction_id, conn->invalidate_snapshot,
-		      conn->db_error);
+  css_set_net_header (&headers[0], DATA_TYPE, 0, *request_id, arg_size, conn->get_tran_index (),
+		      conn->invalidate_snapshot, conn->db_error);
   buffer_array[0] = arg_buffer;
 
   for (i = 1; i < num_array; i++)
@@ -1774,7 +1771,7 @@ css_send_req_with_large_buffer (CSS_CONN_ENTRY * conn, int request, unsigned sho
 	  send_data_size = (int) data_size;
 	}
 
-      css_set_net_header (&headers[i], DATA_TYPE, 0, *request_id, send_data_size, conn->transaction_id,
+      css_set_net_header (&headers[i], DATA_TYPE, 0, *request_id, send_data_size, conn->get_tran_index (),
 			  conn->invalidate_snapshot, conn->db_error);
       buffer_array[i] = data_buffer;
 
@@ -1866,7 +1863,7 @@ css_send_data (CSS_CONN_ENTRY * conn, unsigned short rid, const char *buffer, in
       return (CONNECTION_CLOSED);
     }
 
-  css_set_net_header (&header, DATA_TYPE, 0, rid, buffer_size, conn->transaction_id, conn->invalidate_snapshot,
+  css_set_net_header (&header, DATA_TYPE, 0, rid, buffer_size, conn->get_tran_index (), conn->invalidate_snapshot,
 		      conn->db_error);
 
   return (css_net_send2 (conn, (char *) &header, sizeof (NET_HEADER), buffer, buffer_size));
@@ -1895,10 +1892,10 @@ css_send_two_data (CSS_CONN_ENTRY * conn, unsigned short rid, const char *buffer
       return (CONNECTION_CLOSED);
     }
 
-  css_set_net_header (&header1, DATA_TYPE, 0, rid, buffer1_size, conn->transaction_id, conn->invalidate_snapshot,
+  css_set_net_header (&header1, DATA_TYPE, 0, rid, buffer1_size, conn->get_tran_index (), conn->invalidate_snapshot,
 		      conn->db_error);
 
-  css_set_net_header (&header2, DATA_TYPE, 0, rid, buffer2_size, conn->transaction_id, conn->invalidate_snapshot,
+  css_set_net_header (&header2, DATA_TYPE, 0, rid, buffer2_size, conn->get_tran_index (), conn->invalidate_snapshot,
 		      conn->db_error);
 
   return (css_net_send4 (conn, (char *) &header1, sizeof (NET_HEADER), buffer1, buffer1_size, (char *) &header2,
@@ -1930,13 +1927,13 @@ css_send_three_data (CSS_CONN_ENTRY * conn, unsigned short rid, const char *buff
       return (CONNECTION_CLOSED);
     }
 
-  css_set_net_header (&header1, DATA_TYPE, 0, rid, buffer1_size, conn->transaction_id, conn->invalidate_snapshot,
+  css_set_net_header (&header1, DATA_TYPE, 0, rid, buffer1_size, conn->get_tran_index (), conn->invalidate_snapshot,
 		      conn->db_error);
 
-  css_set_net_header (&header2, DATA_TYPE, 0, rid, buffer2_size, conn->transaction_id, conn->invalidate_snapshot,
+  css_set_net_header (&header2, DATA_TYPE, 0, rid, buffer2_size, conn->get_tran_index (), conn->invalidate_snapshot,
 		      conn->db_error);
 
-  css_set_net_header (&header3, DATA_TYPE, 0, rid, buffer3_size, conn->transaction_id, conn->invalidate_snapshot,
+  css_set_net_header (&header3, DATA_TYPE, 0, rid, buffer3_size, conn->get_tran_index (), conn->invalidate_snapshot,
 		      conn->db_error);
 
   return (css_net_send6 (conn, (char *) &header1, sizeof (NET_HEADER), buffer1, buffer1_size, (char *) &header2,
@@ -1974,16 +1971,16 @@ css_send_four_data (CSS_CONN_ENTRY * conn, unsigned short rid, const char *buffe
       return (CONNECTION_CLOSED);
     }
 
-  css_set_net_header (&header1, DATA_TYPE, 0, rid, buffer1_size, conn->transaction_id, conn->invalidate_snapshot,
+  css_set_net_header (&header1, DATA_TYPE, 0, rid, buffer1_size, conn->get_tran_index (), conn->invalidate_snapshot,
 		      conn->db_error);
 
-  css_set_net_header (&header2, DATA_TYPE, 0, rid, buffer2_size, conn->transaction_id, conn->invalidate_snapshot,
+  css_set_net_header (&header2, DATA_TYPE, 0, rid, buffer2_size, conn->get_tran_index (), conn->invalidate_snapshot,
 		      conn->db_error);
 
-  css_set_net_header (&header3, DATA_TYPE, 0, rid, buffer3_size, conn->transaction_id, conn->invalidate_snapshot,
+  css_set_net_header (&header3, DATA_TYPE, 0, rid, buffer3_size, conn->get_tran_index (), conn->invalidate_snapshot,
 		      conn->db_error);
 
-  css_set_net_header (&header4, DATA_TYPE, 0, rid, buffer4_size, conn->transaction_id, conn->invalidate_snapshot,
+  css_set_net_header (&header4, DATA_TYPE, 0, rid, buffer4_size, conn->get_tran_index (), conn->invalidate_snapshot,
 		      conn->db_error);
 
   return (css_net_send8 (conn, (char *) &header1, sizeof (NET_HEADER), buffer1, buffer1_size, (char *) &header2,
@@ -2022,7 +2019,7 @@ css_send_large_data (CSS_CONN_ENTRY * conn, unsigned short rid, const char **buf
 
   for (i = 0; i < num_buffers; i++)
     {
-      css_set_net_header (&headers[i], DATA_TYPE, 0, rid, buffers_size[i], conn->transaction_id,
+      css_set_net_header (&headers[i], DATA_TYPE, 0, rid, buffers_size[i], conn->get_tran_index (),
 			  conn->invalidate_snapshot, conn->db_error);
     }
 
@@ -2056,7 +2053,7 @@ css_send_error (CSS_CONN_ENTRY * conn, unsigned short rid, const char *buffer, i
       return (CONNECTION_CLOSED);
     }
 
-  css_set_net_header (&header, ERROR_TYPE, 0, rid, buffer_size, conn->transaction_id, conn->invalidate_snapshot,
+  css_set_net_header (&header, ERROR_TYPE, 0, rid, buffer_size, conn->get_tran_index (), conn->invalidate_snapshot,
 		      conn->db_error);
 
   return (css_net_send2 (conn, (char *) &header, sizeof (NET_HEADER), buffer, buffer_size));
@@ -2901,3 +2898,24 @@ css_platform_independent_poll (POLL_FD * fds, int num_of_fds, int timeout)
 
   return rc;
 }
+
+// *INDENT-OFF*
+void
+css_conn_entry::set_tran_index (int tran_index)
+{
+  // can never be system transaction index
+  if (tran_index == LOG_SYSTEM_TRAN_INDEX)
+    {
+      assert (false);
+      tran_index = NULL_TRAN_INDEX;
+    }
+  transaction_id = tran_index;
+}
+
+int
+css_conn_entry::get_tran_index ()
+{
+  assert (transaction_id != LOG_SYSTEM_TRAN_INDEX);
+  return transaction_id;
+}
+// *INDENT-ON*

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1071,7 +1071,7 @@ css_connection_handler_thread (THREAD_ENTRY * thread_p, CSS_CONN_ENTRY * conn)
 
 	  /* check server's HA state */
 	  if (ha_Server_state == HA_SERVER_STATE_TO_BE_STANDBY && conn->in_transaction == false
-	      && thread_has_threads (thread_p, conn->transaction_id, conn->client_id) == 0)
+	      && thread_has_threads (thread_p, conn->get_tran_index (), conn->client_id) == 0)
 	    {
 	      status = REQUEST_REFUSED;
 	      break;
@@ -1128,7 +1128,7 @@ css_connection_handler_thread (THREAD_ENTRY * thread_p, CSS_CONN_ENTRY * conn)
     {
       er_log_debug (ARG_FILE_LINE,
 		    "css_connection_handler_thread: status %d conn { status %d transaction_id %d "
-		    "db_error %d stop_talk %d stop_phase %d }\n", status, conn->status, conn->transaction_id,
+		    "db_error %d stop_talk %d stop_phase %d }\n", status, conn->status, conn->get_tran_index (),
 		    conn->db_error, conn->stop_talk, conn->stop_phase);
       rv = pthread_mutex_lock (&thread_p->tran_index_lock);
       (*css_Connection_error_handler) (thread_p, conn);
@@ -1170,7 +1170,7 @@ css_block_all_active_conn (unsigned short stop_phase)
       if (!IS_INVALID_SOCKET (conn->fd) && conn->fd != css_Pipe_to_master)
 	{
 	  conn->stop_talk = true;
-	  logtb_set_tran_index_interrupt (NULL, conn->transaction_id, 1);
+	  logtb_set_tran_index_interrupt (NULL, conn->get_tran_index (), 1);
 	}
 
       r = rmutex_unlock (NULL, &conn->rmutex);
@@ -1234,7 +1234,7 @@ css_internal_request_handler (THREAD_ENTRY & thread_ref, CSS_CONN_ENTRY & conn_r
   if (rc == NO_ERRORS)
     {
       /* 1. change thread's transaction id to this connection's */
-      thread_ref.tran_index = conn_ref.transaction_id;
+      thread_ref.tran_index = conn_ref.get_tran_index ();
 
       pthread_mutex_unlock (&thread_ref.tran_index_lock);
 
@@ -1251,7 +1251,7 @@ css_internal_request_handler (THREAD_ENTRY & thread_ref, CSS_CONN_ENTRY & conn_r
 
       eid = css_return_eid_from_conn (&conn_ref, rid);
       /* 2. change thread's client, rid, tran_index for this request */
-      thread_set_info (&thread_ref, conn_ref.client_id, eid, conn_ref.transaction_id, request);
+      thread_set_info (&thread_ref, conn_ref.client_id, eid, conn_ref.get_tran_index (), request);
 
       /* 3. Call server_request() function */
       status = css_Server_request_handler (&thread_ref, eid, request, size, buffer);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3030,7 +3030,7 @@ xboot_register_client (THREAD_ENTRY * thread_p, BOOT_CLIENT_CREDENTIAL * client_
   if (tran_index != NULL_TRAN_INDEX)
     {
 #if defined (SERVER_MODE)
-      thread_p->conn_entry->transaction_id = tran_index;
+      thread_p->conn_entry->set_tran_index (tran_index);
 #endif /* SERVER_MODE */
       server_credential->db_full_name = boot_Db_full_name;
       server_credential->host_name = boot_Host_name;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22083

Safe-guard setting/getting transaction index from connection entry. We cannot set system transaction as transaction index.

@eseokoh, if you think it is necessary, please trigger a manual test.