### PR TITLE
[CBRD-22091] protocol mismatches when zero size buffer is delivered

### DIFF
--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -65,10 +65,6 @@
  * the function.
  */
 
-#define SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS(err, rc, num_packets) \
-  set_alloc_err_and_read_expected_packets((err), (rc), (num_packets), \
-					  __FILE__, __LINE__)
-
 #define COMPARE_SIZE_AND_BUFFER(replysize, size, replybuf, buf)       \
   compare_size_and_buffer((replysize), (size), (replybuf), (buf),     \
 			  __FILE__, __LINE__)
@@ -116,15 +112,12 @@ static void return_error_to_server (char *host, unsigned int eid);
 static int client_capabilities (void);
 static int check_server_capabilities (int server_cap, int client_type, int rel_compare,
 				      REL_COMPATIBILITY * compatibility, const char *server_host, int opt_cap);
-static void set_alloc_err_and_read_expected_packets (int *err, int rc, int num_packets, const char *file,
-						     const int line);
+static int net_set_alloc_err_if_not_set (int err, const char *file, const int line);
+static void net_consume_expected_packets (int rc, int num_packets);
 static int compare_size_and_buffer (int *replysize, int size, char **replybuf, char *buf, const char *file,
 				    const int line);
 static int net_client_request_internal (int request, char *argbuf, int argsize, char *replybuf, int replysize,
 					char *databuf, int datasize, char *replydata, int replydatasize);
-#if defined(ENABLE_UNUSED_FUNCTION)
-static int net_client_request_buffer (unsigned int rc, char **buf_ptr, int expected_size);
-#endif
 static int set_server_error (int error);
 
 static void net_histo_setup_names (void);
@@ -376,36 +369,37 @@ check_server_capabilities (int server_cap, int client_type, int rel_compare, REL
 }
 
 /*
- * set_alloc_err_and_read_expected_packets -
+ * net_set_alloc_err_if_not_set
  *
  * return:
  *
  *   err(in):
- *   rc(in):
- *   num_packets(in):
  *   file(in):
  *   line(in):
  *
- * Note:
- *    Allocation failures are recorded and any outstanding data packets
- *    will try to be read.  Called by macro of the same name.
  */
+static int
+net_set_alloc_err_if_not_set (int err, const char *file, const int line)
+{
+  /* don't set error if there already is one */
+  if (err == NO_ERROR)
+    {
+      err = ER_NET_CANT_ALLOC_BUFFER;
+      er_set (ER_ERROR_SEVERITY, file, line, err, 0);
+    }
+
+  return err;
+}
+
 static void
-set_alloc_err_and_read_expected_packets (int *err, int rc, int num_packets, const char *file, const int line)
+net_consume_expected_packets (int rc, int num_packets)
 {
   char *reply = NULL;
   int i, size = 0;
 
-  /* don't set error if there already is one */
-  if (!(*err))
+  for (i = 0; i < num_packets; i++)
     {
-      *err = ER_NET_CANT_ALLOC_BUFFER;
-      er_set (ER_ERROR_SEVERITY, file, line, *err, 0);
-    }
-
-  for (i = 0; i < (num_packets); i++)
-    {
-      css_receive_data_from_server ((rc), &reply, &size);
+      css_receive_data_from_server (rc, &reply, &size);
       if (reply != NULL)
 	{
 	  free_and_init (reply);
@@ -1344,7 +1338,9 @@ net_client_request2 (int request, char *argbuf, int argsize, char *replybuf, int
 	}
       else
 	{
-	  SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, 1);
+	  error = net_set_alloc_err_if_not_set (error, ARG_FILE_LINE);
+
+	  net_consume_expected_packets (rc, 1);
 	}
     }
 
@@ -1602,13 +1598,13 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 				  char **replydata_plan, int *replydatasize_plan)
 {
   unsigned int rc;
-  int size;
-  int reply_datasize_listid, reply_datasize_page, reply_datasize_plan, error;
+  int size, error;
+  int reply_datasize_listid, reply_datasize_page, reply_datasize_plan, remaining_size;
   char *reply = NULL, *replydata, *ptr;
   QUERY_SERVER_REQUEST server_request;
   int server_request_num;
 
-  error = 0;
+  error = NO_ERROR;
   *replydata_listid = NULL;
   *replydata_page = NULL;
   if (replydata_plan != NULL)
@@ -1672,11 +1668,17 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 	      ptr = or_unpack_int (ptr, &reply_datasize_plan);
 	      COMPARE_AND_FREE_BUFFER (replybuf, reply);
 
-	      if (reply_datasize_listid + reply_datasize_page + reply_datasize_plan)
+	      remaining_size = reply_datasize_listid + reply_datasize_page + reply_datasize_plan;
+
+	      // 1. Read list_id
+	      if (0 < remaining_size)
 		{
+		  assert (0 < reply_datasize_listid);
+
 		  if ((error == NO_ERROR) && (replydata = (char *) malloc (reply_datasize_listid)) != NULL)
 		    {
 		      css_queue_receive_data_buffer (rc, replydata, reply_datasize_listid);
+
 		      error = css_receive_data_from_server (rc, &reply, &size);
 		      if (error != NO_ERROR)
 			{
@@ -1684,52 +1686,77 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 			  free_and_init (replydata);
 			  return set_server_error (error);
 			}
-		      else
-			{
-			  error = COMPARE_SIZE_AND_BUFFER (&reply_datasize_listid, size, &replydata, reply);
-			}
+
+		      error = COMPARE_SIZE_AND_BUFFER (&reply_datasize_listid, size, &replydata, reply);
 
 		      *replydata_listid = reply;
 		      *replydatasize_listid = size;
+
 		      reply = NULL;
 		    }
 		  else
 		    {
-		      SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, 1);
+		      error = net_set_alloc_err_if_not_set (error, ARG_FILE_LINE);
+
+		      net_consume_expected_packets (rc, 1);
 		    }
+
+		  remaining_size -= reply_datasize_listid;
 		}
 
-	      if (reply_datasize_page + reply_datasize_plan)
+	      // 2. Read page if exists
+	      //
+	      // Note that not all list files have a page. list file for insert may not have one.
+	      if (0 < remaining_size)
 		{
-		  if ((error == NO_ERROR) && (replydata = (char *) malloc (DB_PAGESIZE)) != NULL)
+		  if (0 < reply_datasize_page)
 		    {
-		      css_queue_receive_data_buffer (rc, replydata, reply_datasize_page);
-		      error = css_receive_data_from_server (rc, &reply, &size);
-		      if (error != NO_ERROR)
+		      if ((error == NO_ERROR) && (replydata = (char *) malloc (DB_PAGESIZE)) != NULL)
 			{
-			  COMPARE_AND_FREE_BUFFER (replydata, reply);
-			  free_and_init (replydata);
-			  return set_server_error (error);
+			  css_queue_receive_data_buffer (rc, replydata, reply_datasize_page);
+
+			  error = css_receive_data_from_server (rc, &reply, &size);
+			  if (error != NO_ERROR)
+			    {
+			      COMPARE_AND_FREE_BUFFER (replydata, reply);
+			      free_and_init (replydata);
+			      return set_server_error (error);
+			    }
+
+			  error = COMPARE_SIZE_AND_BUFFER (&reply_datasize_page, size, &replydata, reply);
+
+			  *replydata_page = reply;
+			  *replydatasize_page = size;
+
+			  reply = NULL;
 			}
 		      else
 			{
-			  error = COMPARE_SIZE_AND_BUFFER (&reply_datasize_page, size, &replydata, reply);
+			  error = net_set_alloc_err_if_not_set (error, ARG_FILE_LINE);
+
+			  net_consume_expected_packets (rc, 1);
 			}
-		      *replydata_page = reply;
-		      *replydatasize_page = size;
-		      reply = NULL;
+
 		    }
 		  else
 		    {
-		      SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, 1);
+		      // Even though its size is 0, it should also be consumed.
+		      assert (reply_datasize_page == 0);
+		      net_consume_expected_packets (rc, 1);
 		    }
+
+		  remaining_size -= reply_datasize_page;
 		}
 
-	      if (reply_datasize_plan)
+	      // 3. Read plan if exists
+	      if (0 < remaining_size)
 		{
+		  assert (0 < reply_datasize_plan);
+
 		  if ((error == NO_ERROR) && (replydata = (char *) malloc (reply_datasize_plan + 1)) != NULL)
 		    {
 		      css_queue_receive_data_buffer (rc, replydata, reply_datasize_plan);
+
 		      error = css_receive_data_from_server (rc, &reply, &size);
 		      if (error != NO_ERROR)
 			{
@@ -1737,10 +1764,8 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 			  free_and_init (replydata);
 			  return set_server_error (error);
 			}
-		      else
-			{
-			  error = COMPARE_SIZE_AND_BUFFER (&reply_datasize_plan, size, &replydata, reply);
-			}
+
+		      error = COMPARE_SIZE_AND_BUFFER (&reply_datasize_plan, size, &replydata, reply);
 
 		      if (replydata_plan != NULL)
 			{
@@ -1756,7 +1781,9 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 		    }
 		  else
 		    {
-		      SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, 1);
+		      error = net_set_alloc_err_if_not_set (error, ARG_FILE_LINE);
+
+		      net_consume_expected_packets (rc, 1);
 		    }
 		}
 	      break;
@@ -1833,7 +1860,9 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 		  }
 		else
 		  {
-		    SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, 1);
+		    error = net_set_alloc_err_if_not_set (error, ARG_FILE_LINE);
+
+		    net_consume_expected_packets (rc, 1);
 		  }
 
 		if (error != NO_ERROR)
@@ -2073,7 +2102,9 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 		else
 		  {
 		    /* send back some kind of error to server */
-		    SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, 1);
+		    error = net_set_alloc_err_if_not_set (error, ARG_FILE_LINE);
+
+		    net_consume_expected_packets (rc, 1);
 
 		    /* Do we need to tell the server? */
 		    server_request = END_CALLBACK;	/* force a stop */
@@ -2501,178 +2532,6 @@ net_client_get_next_log_pages (int rc, char *replybuf, int replysize, int length
   return error;
 }
 
-#if defined(ENABLE_UNUSED_FUNCTION)
-/*
- * net_client_request_buffer -
- *
- * return: error status
- *
- *   rc(in): pre-allocated data buffer
- *   buf_ptr(in): pre-allocated data buffer
- *   expected_size(in): size of data buffer
- *
- * Note: This is used to read an expected network buffer.
- *    Returns non-zero if an error condition was detected.
- *
- *    the other two client request functions should use this, re-write after
- *    1.1 release
- */
-static int
-net_client_request_buffer (unsigned int rc, char **buf_ptr, int expected_size)
-{
-  int error;
-  int reply_size;
-  char *buffer, *reply = NULL;
-
-  error = 0;
-  *buf_ptr = NULL;
-
-  buffer = (char *) malloc (expected_size);
-  if (buffer != NULL)
-    {
-      css_queue_receive_data_buffer (rc, buffer, expected_size);
-      error = css_receive_data_from_server (rc, &reply, &reply_size);
-      if (error != NO_ERROR)
-	{
-	  COMPARE_AND_FREE_BUFFER (buffer, reply);
-	  free_and_init (buffer);
-	  return set_server_error (error);
-	}
-      else
-	{
-	  error = COMPARE_SIZE_AND_BUFFER (&expected_size, reply_size, &buffer, reply);
-	}
-
-      if (error)
-	{
-	  free_and_init (buffer);
-	}
-      else
-	{
-	  *buf_ptr = buffer;
-	}
-    }
-  else
-    {
-      SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, 1);
-    }
-
-  return error;
-}
-
-/*
- * net_client_request3 -
- *
- * return: error status
- *
- *   request(in): request id
- *   argbuf(in): request argument buffer
- *   argsize(in): request argument buffer size
- *   replybuf(in): reply argument buffer
- *   replysize(in): reply argument buffer size
- *   databuf(in): send data buffer
- *   datasize(in): send data buffer size
- *   replydata_ptr(in): returned data buffer pointer
- *   replydatasize_ptr(in): returned data buffer size
- *   replydata_ptr2(in): second reply data buffer pointer
- *   replydatasize_ptr2(in): second reply buffer size
- *
- * Note: Like net_client_request2 but expectes two reply data buffers.
- *    Need to generalize this.
- */
-int
-net_client_request3 (int request, char *argbuf, int argsize, char *replybuf, int replysize, char *databuf, int datasize,
-		     char **replydata_ptr, int *replydatasize_ptr, char **replydata_ptr2, int *replydatasize_ptr2)
-{
-  unsigned int rc;
-  int size;
-  int reply_datasize, reply_datasize2, error;
-  char *reply = NULL, *replydata, *replydata2;
-  char *ptr;
-
-  error = 0;
-  *replydata_ptr = NULL;
-  *replydata_ptr2 = NULL;
-  *replydatasize_ptr = 0;
-  *replydatasize_ptr2 = 0;
-
-  if (net_Server_name[0] == '\0')
-    {
-      /* need to have a more appropriate "unexpected disconnect" message */
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_SERVER_CRASHED, 0);
-      error = -1;
-    }
-  else
-    {
-#if defined(HISTO)
-      if (net_Histo_setup)
-	{
-	  net_histo_add_entry (request, argsize + datasize);
-	}
-#endif /* HISTO */
-      rc = css_send_req_to_server (net_Server_host, request, argbuf, argsize, databuf, datasize, replybuf, replysize);
-      if (rc == 0)
-	{
-	  return set_server_error (css_Errno);
-	}
-
-      error = css_receive_data_from_server (rc, &reply, &size);
-      if (error != NO_ERROR || reply == NULL)
-	{
-	  COMPARE_AND_FREE_BUFFER (replybuf, reply);
-	  return set_server_error (error);
-	}
-      else
-	{
-	  error = COMPARE_SIZE_AND_BUFFER (&replysize, size, &replybuf, reply);
-	}
-
-      /* here we assume that the first two integers in the reply are the lengths of the following data blocks */
-      ptr = or_unpack_int (reply, &reply_datasize);
-      (void) or_unpack_int (ptr, &reply_datasize2);
-
-      replydata = NULL;
-      replydata2 = NULL;
-
-      if (reply_datasize)
-	{
-	  error = net_client_request_buffer (rc, &replydata, reply_datasize);
-	}
-
-      if ((error == NO_ERROR) && reply_datasize2)
-	{
-	  error = net_client_request_buffer (rc, &replydata2, reply_datasize2);
-	}
-
-      if (error)
-	{
-	  if (replydata != NULL)
-	    {
-	      free_and_init (replydata);
-	      replydata = NULL;
-	    }
-	  if (replydata2)
-	    {
-	      free_and_init (replydata2);
-	      replydata2 = NULL;
-	    }
-	}
-
-      *replydata_ptr = replydata;
-      *replydatasize_ptr = reply_datasize;
-      *replydata_ptr2 = replydata2;
-      *replydatasize_ptr2 = reply_datasize2;
-#if defined(HISTO)
-      if (net_Histo_setup)
-	{
-	  net_histo_request_finished (request, replysize + *replydatasize_ptr + *replydatasize_ptr2);
-	}
-#endif /* HISTO */
-    }
-  return error;
-}
-#endif /* ENABLE_UNUSED_FUNCTION */
-
 /*
  * net_client_request_recv_copyarea -
  *
@@ -2706,145 +2565,152 @@ net_client_request_recv_copyarea (int request, char *argbuf, int argsize, char *
     {
       /* need to have a more appropriate "unexpected disconnect" message */
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_SERVER_CRASHED, 0);
-      error = -1;
+      return ER_FAILED;
     }
-  else
-    {
+
 #if defined(HISTO)
-      if (net_Histo_setup)
-	{
-	  net_histo_add_entry (request, argsize);
-	}
+  if (net_Histo_setup)
+    {
+      net_histo_add_entry (request, argsize);
+    }
 #endif /* HISTO */
 
-      rc = css_send_req_to_server (net_Server_host, request, argbuf, argsize, NULL, 0, replybuf, replysize);
-      if (rc == 0)
+  rc = css_send_req_to_server (net_Server_host, request, argbuf, argsize, NULL, 0, replybuf, replysize);
+  if (rc == 0)
+    {
+      return set_server_error (css_Errno);
+    }
+
+  /* 
+   * Receive replybuf
+   */
+
+  error = css_receive_data_from_server (rc, &reply, &size);
+  if (error != NO_ERROR || reply == NULL)
+    {
+      COMPARE_AND_FREE_BUFFER (replybuf, reply);
+      return set_server_error (error);
+    }
+
+  error = COMPARE_SIZE_AND_BUFFER (&replysize, size, &replybuf, reply);
+
+  /* 
+   * Receive copyarea
+   * Here assume that the next two integers in the reply are the lengths of
+   * the copy descriptor and content descriptor
+   */
+
+  reply = or_unpack_int (reply, &num_objs);
+  reply = or_unpack_int (reply, &packed_desc_size);
+  reply = or_unpack_int (reply, &content_size);
+
+  if (packed_desc_size == 0 && content_size == 0)
+    {
+      return error;
+    }
+
+  if (error == NO_ERROR && reply_copy_area != NULL)
+    {
+      *reply_copy_area = locator_recv_allocate_copyarea (num_objs, &packed_desc, packed_desc_size, &content_ptr,
+							 content_size);
+      if (*reply_copy_area != NULL)
 	{
-	  return set_server_error (css_Errno);
-	}
-
-      /* 
-       * Receive replybuf
-       */
-
-      error = css_receive_data_from_server (rc, &reply, &size);
-      if (error != NO_ERROR || reply == NULL)
-	{
-	  COMPARE_AND_FREE_BUFFER (replybuf, reply);
-	  return set_server_error (error);
-	}
-      else
-	{
-	  error = COMPARE_SIZE_AND_BUFFER (&replysize, size, &replybuf, reply);
-	}
-
-      /* 
-       * Receive copyarea
-       * Here assume that the next two integers in the reply are the lengths of
-       * the copy descriptor and content descriptor
-       */
-
-      reply = or_unpack_int (reply, &num_objs);
-      reply = or_unpack_int (reply, &packed_desc_size);
-      reply = or_unpack_int (reply, &content_size);
-
-      if (packed_desc_size != 0 || content_size != 0)
-	{
-	  if (error == NO_ERROR && reply_copy_area != NULL)
+	  if (packed_desc != NULL && packed_desc_size > 0)
 	    {
-	      *reply_copy_area = locator_recv_allocate_copyarea (num_objs, &packed_desc, packed_desc_size, &content_ptr,
-								 content_size);
-	      if (*reply_copy_area != NULL)
+	      css_queue_receive_data_buffer (rc, packed_desc, packed_desc_size);
+	      error = css_receive_data_from_server (rc, &reply, &size);
+	      if (error != NO_ERROR)
 		{
-		  if (packed_desc != NULL && packed_desc_size > 0)
-		    {
-		      css_queue_receive_data_buffer (rc, packed_desc, packed_desc_size);
-		      error = css_receive_data_from_server (rc, &reply, &size);
-		      if (error != NO_ERROR)
-			{
-			  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
-			  free_and_init (packed_desc);
-			  locator_free_copy_area (*reply_copy_area);
-			  *reply_copy_area = NULL;
-			  return set_server_error (error);
-			}
-		      else
-			{
-			  locator_unpack_copy_area_descriptor (num_objs, *reply_copy_area, packed_desc);
-			  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
-			  free_and_init (packed_desc);
-			}
-		    }
-
-		  if (content_size > 0)
-		    {
-		      error = css_queue_receive_data_buffer (rc, content_ptr, content_size);
-		      if (error != NO_ERROR)
-			{
-			  SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, 1);
-			}
-		      else
-			{
-			  error = css_receive_data_from_server (rc, &reply, &size);
-			}
-
-		      COMPARE_AND_FREE_BUFFER (content_ptr, reply);
-
-		      if (error != NO_ERROR)
-			{
-			  if (packed_desc != NULL)
-			    {
-			      free_and_init (packed_desc);
-			    }
-			  locator_free_copy_area (*reply_copy_area);
-			  *reply_copy_area = NULL;
-			  return set_server_error (error);
-			}
-		    }
+		  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
+		  free_and_init (packed_desc);
+		  locator_free_copy_area (*reply_copy_area);
+		  *reply_copy_area = NULL;
+		  return set_server_error (error);
 		}
 	      else
 		{
-		  int num_packets = 0;
-
-		  if (packed_desc_size > 0)
-		    {
-		      num_packets++;
-		    }
-		  if (content_size > 0)
-		    {
-		      num_packets++;
-		    }
-		  SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, num_packets);
-		}
-
-	      if (packed_desc != NULL)
-		{
+		  locator_unpack_copy_area_descriptor (num_objs, *reply_copy_area, packed_desc);
+		  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
 		  free_and_init (packed_desc);
 		}
 	    }
-	  else
+
+	  if (content_size > 0)
 	    {
-	      int num_packets = 0;
-
-	      if (packed_desc_size > 0)
+	      error = css_queue_receive_data_buffer (rc, content_ptr, content_size);
+	      if (error != NO_ERROR)
 		{
-		  num_packets++;
+		  net_consume_expected_packets (rc, 1);
 		}
-	      if (content_size > 0)
+	      else
 		{
-		  num_packets++;
+		  error = css_receive_data_from_server (rc, &reply, &size);
 		}
-	      SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, num_packets);
 
+	      COMPARE_AND_FREE_BUFFER (content_ptr, reply);
+
+	      if (error != NO_ERROR)
+		{
+		  if (packed_desc != NULL)
+		    {
+		      free_and_init (packed_desc);
+		    }
+		  locator_free_copy_area (*reply_copy_area);
+		  *reply_copy_area = NULL;
+		  return set_server_error (error);
+		}
 	    }
 	}
-#if defined(HISTO)
-      if (net_Histo_setup)
+      else
 	{
-	  net_histo_request_finished (request, replysize + content_size + packed_desc_size);
+	  int num_packets = 0;
+
+	  ASSERT_ERROR_AND_SET (error);
+
+	  if (packed_desc_size > 0)
+	    {
+	      num_packets++;
+	    }
+	  if (content_size > 0)
+	    {
+	      num_packets++;
+	    }
+	  net_consume_expected_packets (rc, num_packets);
 	}
-#endif /* HISTO */
+
+      if (packed_desc != NULL)
+	{
+	  free_and_init (packed_desc);
+	}
     }
+  else
+    {
+      int num_packets = 0;
+
+      if (error == NO_ERROR)
+	{
+	  error = ER_FAILED;
+	}
+
+      if (packed_desc_size > 0)
+	{
+	  num_packets++;
+	}
+      if (content_size > 0)
+	{
+	  num_packets++;
+	}
+      net_consume_expected_packets (rc, num_packets);
+    }
+
+exit:
+#if defined(HISTO)
+  if (net_Histo_setup)
+    {
+      net_histo_request_finished (request, replysize + content_size + packed_desc_size);
+    }
+#endif /* HISTO */
+
   return error;
 }
 
@@ -2882,14 +2748,14 @@ net_client_request_2recv_copyarea (int request, char *argbuf, int argsize, char 
   char *packed_desc = NULL;
   int packed_desc_size;
 
-  error = 0;
+  error = NO_ERROR;
   if (net_Server_name[0] == '\0')
     {
       /* need to have a more appropriate "unexpected disconnect" message */
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_SERVER_CRASHED, 0);
-      error = -1;
-      return error;
+      return ER_FAILED;
     }
+
 #if defined(HISTO)
   if (net_Histo_setup)
     {
@@ -2991,70 +2857,55 @@ net_client_request_2recv_copyarea (int request, char *argbuf, int argsize, char 
 
   /* allocate the copyarea */
   *reply_copy_area = NULL;
-  if (packed_desc_size != 0 || content_size != 0)
+  if (packed_desc_size == 0 && content_size == 0)
     {
-      if (error == NO_ERROR)
+      return error;
+    }
+
+  if (error == NO_ERROR)
+    {
+      *reply_copy_area = locator_recv_allocate_copyarea (num_objs, &packed_desc, packed_desc_size, &content_ptr,
+							 content_size);
+      if (*reply_copy_area != NULL)
 	{
-	  *reply_copy_area = locator_recv_allocate_copyarea (num_objs, &packed_desc, packed_desc_size, &content_ptr,
-							     content_size);
-	  if (*reply_copy_area != NULL)
+	  if (packed_desc != NULL && packed_desc_size > 0)
 	    {
-	      if (packed_desc != NULL && packed_desc_size > 0)
+	      css_queue_receive_data_buffer (rc, packed_desc, packed_desc_size);
+	      error = css_receive_data_from_server (rc, &reply, &size);
+	      if (error != NO_ERROR)
 		{
-		  css_queue_receive_data_buffer (rc, packed_desc, packed_desc_size);
-		  error = css_receive_data_from_server (rc, &reply, &size);
-		  if (error != NO_ERROR)
-		    {
-		      COMPARE_AND_FREE_BUFFER (packed_desc, reply);
-		      free_and_init (packed_desc);
-		      return set_server_error (error);
-		    }
-		  else
-		    {
-		      locator_unpack_copy_area_descriptor (num_objs, *reply_copy_area, packed_desc);
-		      COMPARE_AND_FREE_BUFFER (packed_desc, reply);
-		      free_and_init (packed_desc);
-		    }
+		  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
+		  free_and_init (packed_desc);
+		  return set_server_error (error);
 		}
-
-	      if (content_size > 0)
+	      else
 		{
-		  css_queue_receive_data_buffer (rc, content_ptr, content_size);
-		  error = css_receive_data_from_server (rc, &reply, &size);
-		  COMPARE_AND_FREE_BUFFER (content_ptr, reply);
-		  if (error != NO_ERROR)
-		    {
-		      if (packed_desc != NULL)
-			{
-			  free_and_init (packed_desc);
-			}
-		      return set_server_error (error);
-		    }
+		  locator_unpack_copy_area_descriptor (num_objs, *reply_copy_area, packed_desc);
+		  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
+		  free_and_init (packed_desc);
 		}
 	    }
-	  else
-	    {
-	      int num_packets = 0;
 
-	      if (packed_desc_size > 0)
-		{
-		  num_packets++;
-		}
-	      if (content_size > 0)
-		{
-		  num_packets++;
-		}
-	      SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, num_packets);
-	    }
-
-	  if (packed_desc != NULL)
+	  if (content_size > 0)
 	    {
-	      free_and_init (packed_desc);
+	      css_queue_receive_data_buffer (rc, content_ptr, content_size);
+	      error = css_receive_data_from_server (rc, &reply, &size);
+	      COMPARE_AND_FREE_BUFFER (content_ptr, reply);
+	      if (error != NO_ERROR)
+		{
+		  if (packed_desc != NULL)
+		    {
+		      free_and_init (packed_desc);
+		    }
+		  return set_server_error (error);
+		}
 	    }
 	}
       else
 	{
 	  int num_packets = 0;
+
+	  ASSERT_ERROR_AND_SET (error);
 
 	  if (packed_desc_size > 0)
 	    {
@@ -3064,9 +2915,29 @@ net_client_request_2recv_copyarea (int request, char *argbuf, int argsize, char 
 	    {
 	      num_packets++;
 	    }
-	  SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, num_packets);
-
+	  net_consume_expected_packets (rc, num_packets);
 	}
+
+      if (packed_desc != NULL)
+	{
+	  free_and_init (packed_desc);
+	}
+    }
+  else
+    {
+      int num_packets = 0;
+
+      assert (error != NO_ERROR);
+
+      if (packed_desc_size > 0)
+	{
+	  num_packets++;
+	}
+      if (content_size > 0)
+	{
+	  num_packets++;
+	}
+      net_consume_expected_packets (rc, num_packets);
     }
 
 #if defined(HISTO)
@@ -3075,6 +2946,7 @@ net_client_request_2recv_copyarea (int request, char *argbuf, int argsize, char 
       net_histo_request_finished (request, replysize + recvbuffer_size + content_size + packed_desc_size);
     }
 #endif /* HISTO */
+
   return error;
 }
 
@@ -3113,14 +2985,14 @@ net_client_request_3_data_recv_copyarea (int request, char *argbuf, int argsize,
   // test code
   int success;
 
-  error = 0;
+  error = NO_ERROR;
   if (net_Server_name[0] == '\0')
     {
       /* need to have a more appropriate "unexpected disconnect" message */
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_SERVER_CRASHED, 0);
-      error = -1;
-      return error;
+      return ER_FAILED;
     }
+
 #if defined(HISTO)
   if (net_Histo_setup)
     {
@@ -3153,70 +3025,55 @@ net_client_request_3_data_recv_copyarea (int request, char *argbuf, int argsize,
   replybuf = or_unpack_int (replybuf, &success);
 
   *reply_copy_area = NULL;
-  if (packed_desc_size != 0 || content_size != 0)
+  if (packed_desc_size == 0 && content_size == 0)
     {
-      if (error == NO_ERROR)
+      return error;
+    }
+
+  if (error == NO_ERROR)
+    {
+      *reply_copy_area = locator_recv_allocate_copyarea (num_objs, &packed_desc, packed_desc_size, &content_ptr,
+							 content_size);
+      if (*reply_copy_area != NULL)
 	{
-	  *reply_copy_area = locator_recv_allocate_copyarea (num_objs, &packed_desc, packed_desc_size, &content_ptr,
-							     content_size);
-	  if (*reply_copy_area != NULL)
+	  if (packed_desc != NULL && packed_desc_size > 0)
 	    {
-	      if (packed_desc != NULL && packed_desc_size > 0)
+	      css_queue_receive_data_buffer (rid, packed_desc, packed_desc_size);
+	      error = css_receive_data_from_server (rid, &reply, &size);
+	      if (error != NO_ERROR)
 		{
-		  css_queue_receive_data_buffer (rid, packed_desc, packed_desc_size);
-		  error = css_receive_data_from_server (rid, &reply, &size);
-		  if (error != NO_ERROR)
-		    {
-		      COMPARE_AND_FREE_BUFFER (packed_desc, reply);
-		      free_and_init (packed_desc);
-		      return set_server_error (error);
-		    }
-		  else
-		    {
-		      locator_unpack_copy_area_descriptor (num_objs, *reply_copy_area, packed_desc);
-		      COMPARE_AND_FREE_BUFFER (packed_desc, reply);
-		      free_and_init (packed_desc);
-		    }
+		  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
+		  free_and_init (packed_desc);
+		  return set_server_error (error);
 		}
-
-	      if (content_size > 0)
+	      else
 		{
-		  css_queue_receive_data_buffer (rid, content_ptr, content_size);
-		  error = css_receive_data_from_server (rid, &reply, &size);
-		  COMPARE_AND_FREE_BUFFER (content_ptr, reply);
-		  if (error != NO_ERROR)
-		    {
-		      if (packed_desc != NULL)
-			{
-			  free_and_init (packed_desc);
-			}
-		      return set_server_error (error);
-		    }
+		  locator_unpack_copy_area_descriptor (num_objs, *reply_copy_area, packed_desc);
+		  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
+		  free_and_init (packed_desc);
 		}
 	    }
-	  else
-	    {
-	      int num_packets = 0;
 
-	      if (packed_desc_size > 0)
-		{
-		  num_packets++;
-		}
-	      if (content_size > 0)
-		{
-		  num_packets++;
-		}
-	      SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rid, num_packets);
-	    }
-
-	  if (packed_desc != NULL)
+	  if (content_size > 0)
 	    {
-	      free_and_init (packed_desc);
+	      css_queue_receive_data_buffer (rid, content_ptr, content_size);
+	      error = css_receive_data_from_server (rid, &reply, &size);
+	      COMPARE_AND_FREE_BUFFER (content_ptr, reply);
+	      if (error != NO_ERROR)
+		{
+		  if (packed_desc != NULL)
+		    {
+		      free_and_init (packed_desc);
+		    }
+		  return set_server_error (error);
+		}
 	    }
 	}
       else
 	{
 	  int num_packets = 0;
+
+	  ASSERT_ERROR_AND_SET (error);
 
 	  if (packed_desc_size > 0)
 	    {
@@ -3226,9 +3083,29 @@ net_client_request_3_data_recv_copyarea (int request, char *argbuf, int argsize,
 	    {
 	      num_packets++;
 	    }
-	  SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rid, num_packets);
-
+	  net_consume_expected_packets (rid, num_packets);
 	}
+
+      if (packed_desc != NULL)
+	{
+	  free_and_init (packed_desc);
+	}
+    }
+  else
+    {
+      int num_packets = 0;
+
+      assert (error != NO_ERROR);
+
+      if (packed_desc_size > 0)
+	{
+	  num_packets++;
+	}
+      if (content_size > 0)
+	{
+	  num_packets++;
+	}
+      net_consume_expected_packets (rid, num_packets);
     }
 
 #if defined(HISTO)
@@ -3237,6 +3114,7 @@ net_client_request_3_data_recv_copyarea (int request, char *argbuf, int argsize,
       net_histo_request_finished (request, replysize + recvbuffer_size + content_size + packed_desc_size);
     }
 #endif /* HISTO */
+
   return error;
 }
 
@@ -3268,14 +3146,14 @@ net_client_recv_copyarea (int request, char *replybuf, int replysize, char *recv
   char *packed_desc = NULL;
   int packed_desc_size;
 
-  error = 0;
+  error = NO_ERROR;
   if (net_Server_name[0] == '\0')
     {
       /* need to have a more appropriate "unexpected disconnect" message */
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_SERVER_CRASHED, 0);
-      error = -1;
-      return error;
+      return ER_FAILED;
     }
+
 #if defined(HISTO)
   if (net_Histo_setup)
     {
@@ -3327,32 +3205,31 @@ net_client_recv_copyarea (int request, char *replybuf, int replysize, char *recv
       else
 	{
 	  css_queue_receive_data_buffer (rc, recvbuffer, p_size);
+
 	  error = css_receive_data_from_server (rc, &reply, &size);
 	  if (error != NO_ERROR)
 	    {
 	      COMPARE_AND_FREE_BUFFER (recvbuffer, reply);
 	      return set_server_error (error);
 	    }
+
+	  if (recvbuffer_size < size)
+	    {
+	      /* we expect that the sizes won't match, but we must be sure that the we can accomodate the data in
+	       * our buffer. So, don't use COMPARE_SIZE_AND_BUFFER() here. */
+	      error = ER_NET_DATASIZE_MISMATCH;
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 2, recvbuffer_size, size);
+	    }
 	  else
 	    {
-	      if (recvbuffer_size < size)
-		{
-		  /* we expect that the sizes won't match, but we must be sure that the we can accomodate the data in
-		   * our buffer. So, don't use COMPARE_SIZE_AND_BUFFER() here. */
-		  error = ER_NET_DATASIZE_MISMATCH;
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 2, recvbuffer_size, size);
-		}
-	      else
-		{
-		  recvbuffer_size = size;
-		}
+	      recvbuffer_size = size;
+	    }
 
-	      if (reply != recvbuffer)
-		{
-		  error = ER_NET_UNUSED_BUFFER;
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
-		  free_and_init (reply);
-		}
+	  if (reply != recvbuffer)
+	    {
+	      error = ER_NET_UNUSED_BUFFER;
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
+	      free_and_init (reply);
 	    }
 	}
     }
@@ -3369,70 +3246,54 @@ net_client_recv_copyarea (int request, char *replybuf, int replysize, char *recv
 
   /* allocate the copyarea */
   *reply_copy_area = NULL;
-  if (packed_desc_size != 0 || content_size != 0)
+  if (packed_desc_size == 0 && content_size == 0)
     {
-      if (error == NO_ERROR)
+      return error;
+    }
+
+  if (error == NO_ERROR)
+    {
+      *reply_copy_area =
+	locator_recv_allocate_copyarea (num_objs, &packed_desc, packed_desc_size, &content_ptr, content_size);
+      if (*reply_copy_area != NULL)
 	{
-	  *reply_copy_area =
-	    locator_recv_allocate_copyarea (num_objs, &packed_desc, packed_desc_size, &content_ptr, content_size);
-	  if (*reply_copy_area != NULL)
+	  if (packed_desc != NULL && packed_desc_size > 0)
 	    {
-	      if (packed_desc != NULL && packed_desc_size > 0)
+	      css_queue_receive_data_buffer (rc, packed_desc, packed_desc_size);
+
+	      error = css_receive_data_from_server (rc, &reply, &size);
+	      if (error != NO_ERROR)
 		{
-		  css_queue_receive_data_buffer (rc, packed_desc, packed_desc_size);
-		  error = css_receive_data_from_server (rc, &reply, &size);
-		  if (error != NO_ERROR)
-		    {
-		      COMPARE_AND_FREE_BUFFER (packed_desc, reply);
-		      free_and_init (packed_desc);
-		      return set_server_error (error);
-		    }
-		  else
-		    {
-		      locator_unpack_copy_area_descriptor (num_objs, *reply_copy_area, packed_desc);
-		      COMPARE_AND_FREE_BUFFER (packed_desc, reply);
-		      free_and_init (packed_desc);
-		    }
+		  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
+		  free_and_init (packed_desc);
+		  return set_server_error (error);
 		}
 
-	      if (content_size > 0)
-		{
-		  css_queue_receive_data_buffer (rc, content_ptr, content_size);
-		  error = css_receive_data_from_server (rc, &reply, &size);
-		  COMPARE_AND_FREE_BUFFER (content_ptr, reply);
-		  if (error != NO_ERROR)
-		    {
-		      if (packed_desc != NULL)
-			{
-			  free_and_init (packed_desc);
-			}
-		      return set_server_error (error);
-		    }
-		}
-	    }
-	  else
-	    {
-	      int num_packets = 0;
-
-	      if (packed_desc_size > 0)
-		{
-		  num_packets++;
-		}
-	      if (content_size > 0)
-		{
-		  num_packets++;
-		}
-	      SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, num_packets);
-	    }
-
-	  if (packed_desc != NULL)
-	    {
+	      locator_unpack_copy_area_descriptor (num_objs, *reply_copy_area, packed_desc);
+	      COMPARE_AND_FREE_BUFFER (packed_desc, reply);
 	      free_and_init (packed_desc);
+	    }
+
+	  if (content_size > 0)
+	    {
+	      css_queue_receive_data_buffer (rc, content_ptr, content_size);
+	      error = css_receive_data_from_server (rc, &reply, &size);
+	      COMPARE_AND_FREE_BUFFER (content_ptr, reply);
+	      if (error != NO_ERROR)
+		{
+		  if (packed_desc != NULL)
+		    {
+		      free_and_init (packed_desc);
+		    }
+		  return set_server_error (error);
+		}
 	    }
 	}
       else
 	{
 	  int num_packets = 0;
+
+	  ASSERT_ERROR_AND_SET (error);
 
 	  if (packed_desc_size > 0)
 	    {
@@ -3442,8 +3303,29 @@ net_client_recv_copyarea (int request, char *replybuf, int replysize, char *recv
 	    {
 	      num_packets++;
 	    }
-	  SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, num_packets);
+	  net_consume_expected_packets (rc, num_packets);
 	}
+
+      if (packed_desc != NULL)
+	{
+	  free_and_init (packed_desc);
+	}
+    }
+  else
+    {
+      int num_packets = 0;
+
+      assert (error != NO_ERROR);
+
+      if (packed_desc_size > 0)
+	{
+	  num_packets++;
+	}
+      if (content_size > 0)
+	{
+	  num_packets++;
+	}
+      net_consume_expected_packets (rc, num_packets);
     }
 
 #if defined(HISTO)
@@ -3489,7 +3371,7 @@ net_client_request_3recv_copyarea (int request, char *argbuf, int argsize, char 
   char *packed_desc = NULL;
   int packed_desc_size;
 
-  error = 0;
+  error = NO_ERROR;
   *recvbuffer = NULL;
   *recvbuffer_size = 0;
 
@@ -3497,9 +3379,9 @@ net_client_request_3recv_copyarea (int request, char *argbuf, int argsize, char 
     {
       /* need to have a more appropriate "unexpected disconnect" message */
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_SERVER_CRASHED, 0);
-      error = -1;
-      return error;
+      return ER_FAILED;
     }
+
 #if defined(HISTO)
   if (net_Histo_setup)
     {
@@ -3559,7 +3441,10 @@ net_client_request_3recv_copyarea (int request, char *argbuf, int argsize, char 
       else
 	{
 	  *recvbuffer_size = 0;
-	  SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, 1);
+
+	  error = net_set_alloc_err_if_not_set (error, ARG_FILE_LINE);
+
+	  net_consume_expected_packets (rc, 1);
 	}
     }
 
@@ -3575,69 +3460,70 @@ net_client_request_3recv_copyarea (int request, char *argbuf, int argsize, char 
 
   /* allocate the copyarea */
   *reply_copy_area = NULL;
-  if (packed_desc_size != 0 || content_size != 0)
+  if (packed_desc_size == 0 && content_size == 0)
     {
-      if ((error == NO_ERROR)
-	  &&
-	  ((*reply_copy_area =
-	    locator_recv_allocate_copyarea (num_objs, &packed_desc, packed_desc_size, &content_ptr,
-					    content_size)) != NULL))
-	{
-	  if (packed_desc != NULL && packed_desc_size > 0)
-	    {
-	      css_queue_receive_data_buffer (rc, packed_desc, packed_desc_size);
-	      error = css_receive_data_from_server (rc, &reply, &size);
-	      if (error != NO_ERROR)
-		{
-		  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
-		  free_and_init (packed_desc);
-		  return set_server_error (error);
-		}
-	      else
-		{
-		  locator_unpack_copy_area_descriptor (num_objs, *reply_copy_area, packed_desc);
-		  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
-		  free_and_init (packed_desc);
-		}
-	    }
-
-	  if (content_size > 0)
-	    {
-	      css_queue_receive_data_buffer (rc, content_ptr, content_size);
-	      error = css_receive_data_from_server (rc, &reply, &size);
-	      COMPARE_AND_FREE_BUFFER (content_ptr, reply);
-	      if (error != NO_ERROR)
-		{
-		  if (packed_desc != NULL)
-		    {
-		      free_and_init (packed_desc);
-		    }
-		  return set_server_error (error);
-		}
-	    }
-
-	  if (packed_desc != NULL)
-	    {
-	      free_and_init (packed_desc);
-	    }
-	}
-      else
-	{
-	  int num_packets = 0;
-
-	  if (packed_desc_size > 0)
-	    {
-	      num_packets++;
-	    }
-	  if (content_size > 0)
-	    {
-	      num_packets++;
-	    }
-	  SET_ALLOC_ERR_AND_READ_EXPECTED_PACKETS (&error, rc, num_packets);
-
-	}
+      return error;
     }
 
+  if ((error == NO_ERROR)
+      && ((*reply_copy_area = locator_recv_allocate_copyarea (num_objs, &packed_desc, packed_desc_size, &content_ptr,
+							      content_size)) != NULL))
+    {
+      if (packed_desc != NULL && packed_desc_size > 0)
+	{
+	  css_queue_receive_data_buffer (rc, packed_desc, packed_desc_size);
+	  error = css_receive_data_from_server (rc, &reply, &size);
+	  if (error != NO_ERROR)
+	    {
+	      COMPARE_AND_FREE_BUFFER (packed_desc, reply);
+	      free_and_init (packed_desc);
+	      return set_server_error (error);
+	    }
+
+	  locator_unpack_copy_area_descriptor (num_objs, *reply_copy_area, packed_desc);
+	  COMPARE_AND_FREE_BUFFER (packed_desc, reply);
+	  free_and_init (packed_desc);
+	}
+
+      if (content_size > 0)
+	{
+	  css_queue_receive_data_buffer (rc, content_ptr, content_size);
+	  error = css_receive_data_from_server (rc, &reply, &size);
+	  COMPARE_AND_FREE_BUFFER (content_ptr, reply);
+	  if (error != NO_ERROR)
+	    {
+	      if (packed_desc != NULL)
+		{
+		  free_and_init (packed_desc);
+		}
+	      return set_server_error (error);
+	    }
+	}
+
+      if (packed_desc != NULL)
+	{
+	  free_and_init (packed_desc);
+	}
+    }
+  else
+    {
+      int num_packets = 0;
+
+      if (error == NO_ERROR)
+	{
+	  ASSERT_ERROR_AND_SET (error);
+	}
+
+      if (packed_desc_size > 0)
+	{
+	  num_packets++;
+	}
+      if (content_size > 0)
+	{
+	  num_packets++;
+	}
+      net_consume_expected_packets (rc, num_packets);
+    }
 
 #if defined(HISTO)
   if (net_Histo_setup)
@@ -3734,68 +3620,65 @@ net_client_request_recv_stream (int request, char *argbuf, int argsize, char *re
       error = set_server_error (css_Errno);
       goto end;
     }
+
+  error = css_receive_data_from_server (rc, &reply, &size);
+  if (error != NO_ERROR)
+    {
+      COMPARE_AND_FREE_BUFFER (recv_replybuf, reply);
+      error = set_server_error (error);
+      goto end;
+    }
   else
     {
+      error = COMPARE_SIZE_AND_BUFFER (&recv_replybuf_size, size, &recv_replybuf, reply);
+    }
+
+  /* Get total size of file to transfered */
+  or_unpack_int (recv_replybuf, &file_size);
+
+  if (replybuf)
+    {
+      memcpy (replybuf, recv_replybuf + OR_INT_SIZE, recv_replybuf_size - OR_INT_SIZE);
+    }
+
+#if defined(HISTO)
+  if (net_Histo_setup)
+    {
+      net_histo_request_finished (request, recv_replybuf_size + file_size);
+    }
+#endif /* HISTO */
+
+  while (file_size > 0)
+    {
+      css_queue_receive_data_buffer (rc, reply_streamdata, reply_streamdata_size);
+
       error = css_receive_data_from_server (rc, &reply, &size);
       if (error != NO_ERROR)
 	{
-	  COMPARE_AND_FREE_BUFFER (recv_replybuf, reply);
+	  COMPARE_AND_FREE_BUFFER (reply_streamdata, reply);
 	  error = set_server_error (error);
 	  goto end;
 	}
-      else
+
+      if (reply != reply_streamdata)
 	{
-	  error = COMPARE_SIZE_AND_BUFFER (&recv_replybuf_size, size, &recv_replybuf, reply);
+	  error = ER_NET_UNUSED_BUFFER;
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
+	  COMPARE_AND_FREE_BUFFER (reply_streamdata, reply);
+	  break;
+	}
+      if (size > reply_streamdata_size)
+	{
+	  error = ER_NET_DATASIZE_MISMATCH;
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 2, reply_streamdata_size, size);
+	  break;
 	}
 
-      /* Get total size of file to transfered */
-      or_unpack_int (recv_replybuf, &file_size);
-
-      if (replybuf)
-	{
-	  memcpy (replybuf, recv_replybuf + OR_INT_SIZE, recv_replybuf_size - OR_INT_SIZE);
-	}
-
-#if defined(HISTO)
-      if (net_Histo_setup)
-	{
-	  net_histo_request_finished (request, recv_replybuf_size + file_size);
-	}
-#endif /* HISTO */
-
-      while (file_size > 0)
-	{
-	  css_queue_receive_data_buffer (rc, reply_streamdata, reply_streamdata_size);
-	  error = css_receive_data_from_server (rc, &reply, &size);
-	  if (error != NO_ERROR)
-	    {
-	      COMPARE_AND_FREE_BUFFER (reply_streamdata, reply);
-	      error = set_server_error (error);
-	      goto end;
-	    }
-	  else
-	    {
-	      if (reply != reply_streamdata)
-		{
-		  error = ER_NET_UNUSED_BUFFER;
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
-		  COMPARE_AND_FREE_BUFFER (reply_streamdata, reply);
-		  break;
-		}
-	      if (size > reply_streamdata_size)
-		{
-		  error = ER_NET_DATASIZE_MISMATCH;
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 2, reply_streamdata_size, size);
-		  break;
-		}
-	      file_size -= size;
-	      fwrite (reply_streamdata, 1, size, outfp);
-	    }
-	}
+      file_size -= size;
+      fwrite (reply_streamdata, 1, size, outfp);
     }
 
 end:
-
   free_and_init (send_argbuffer);
   free_and_init (recv_replybuf);
 
@@ -4131,34 +4014,33 @@ net_client_receive_action (int rc, int *action)
     {
       /* need to have a more appropriate "unexpected disconnect" message */
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_SERVER_CRASHED, 0);
-      error = ER_NET_SERVER_CRASHED;
+      return ER_NET_SERVER_CRASHED;
     }
-  else
-    {
-      error = css_receive_data_from_server (rc, &reply, &size);
-      if (error != NO_ERROR || reply == NULL)
-	{
-	  if (reply != NULL)
-	    {
-	      free_and_init (reply);
-	    }
-	  return set_server_error (error);
-	}
 
-      if (size != replysize)
+  error = css_receive_data_from_server (rc, &reply, &size);
+  if (error != NO_ERROR || reply == NULL)
+    {
+      if (reply != NULL)
 	{
-	  error = ER_NET_DATASIZE_MISMATCH;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 2, replysize, size);
-	  replysize = size;
-	  if (reply != NULL)
-	    {
-	      free_and_init (reply);
-	    }
-	  return set_server_error (error);
+	  free_and_init (reply);
 	}
-      or_unpack_int (reply, action);
-      free_and_init (reply);
+      return set_server_error (error);
     }
+
+  if (size != replysize)
+    {
+      error = ER_NET_DATASIZE_MISMATCH;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 2, replysize, size);
+      replysize = size;
+      if (reply != NULL)
+	{
+	  free_and_init (reply);
+	}
+      return set_server_error (error);
+    }
+
+  or_unpack_int (reply, action);
+  free_and_init (reply);
 
   return error;
 }

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -1736,7 +1736,6 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 
 			  net_consume_expected_packets (rc, 1);
 			}
-
 		    }
 		  else
 		    {
@@ -2560,7 +2559,7 @@ net_client_request_recv_copyarea (int request, char *argbuf, int argsize, char *
   char *packed_desc = NULL;
   int packed_desc_size;
 
-  error = 0;
+  error = NO_ERROR;
   if (net_Server_name[0] == '\0')
     {
       /* need to have a more appropriate "unexpected disconnect" message */
@@ -2703,7 +2702,6 @@ net_client_request_recv_copyarea (int request, char *argbuf, int argsize, char *
       net_consume_expected_packets (rc, num_packets);
     }
 
-exit:
 #if defined(HISTO)
   if (net_Histo_setup)
     {

--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -507,13 +507,16 @@ begin:
       return rc;
     }
 
+  assert (header_size == sizeof (NET_HEADER));	// to make it sure.
+
   rid = ntohl (header.request_id);
-  conn->set_tran_index (ntohl (header.transaction_id));
   conn->db_error = (int) ntohl (header.db_error);
 
   type = ntohl (header.type);
   if (type == DATA_TYPE)
     {
+      conn->set_tran_index (ntohl (header.transaction_id));
+
       buf_size = ntohl (header.buffer_size);
 
       if (rid == req_id)

--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -630,14 +630,16 @@ begin:
     {
       return rc;
     }
+  assert (header_size == sizeof (NET_HEADER));
 
   rid = ntohl (header.request_id);
-  conn->set_tran_index (ntohl (header.transaction_id));
   conn->db_error = (int) ntohl (header.db_error);
 
   type = ntohl (header.type);
   if (type == ERROR_TYPE)
     {
+      conn->set_tran_index (ntohl (header.transaction_id));
+
       buf_size = ntohl (header.buffer_size);
       if (buf_size != 0)
 	{

--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -84,7 +84,7 @@
         do {                       \
           er_log_debug(ARG_FILE_LINE, string, arg1);  \
         }                          \
-        while (0);
+        while (0)
 #else /* PACKET_TRACE */
 #define TRACE(string, arg1)
 #endif /* PACKET_TRACE */
@@ -297,7 +297,7 @@ css_get_request_id (CSS_CONN_ENTRY * conn)
     }
 
   er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ERR_CSS_REQUEST_ID_FAILURE, 0);
-  return (0);
+  return 0;
 }
 
 /*
@@ -383,7 +383,7 @@ css_read_header (CSS_CONN_ENTRY * conn, NET_HEADER * local_header)
   conn->invalidate_snapshot = flags | NET_HEADER_FLAG_INVALIDATE_SNAPSHOT ? 1 : 0;
   conn->db_error = (int) ntohl (local_header->db_error);
 
-  return (rc);
+  return rc;
 }
 
 /*
@@ -460,7 +460,7 @@ css_receive_request (CSS_CONN_ENTRY * conn, unsigned short *rid, int *request, i
 
   TRACE ("in css_receive_request, received request: %d\n", *request);
 
-  return (rc);
+  return rc;
 }
 
 /*
@@ -502,82 +502,89 @@ css_receive_data (CSS_CONN_ENTRY * conn, unsigned short req_id, char **buffer, i
 begin:
   header_size = sizeof (NET_HEADER);
   rc = css_net_read_header (conn->fd, (char *) &header, &header_size, timeout);
-  if (rc == NO_ERRORS)
+  if (rc != NO_ERRORS)
     {
-      rid = ntohl (header.request_id);
-      conn->set_tran_index (ntohl (header.transaction_id));
-      conn->db_error = (int) ntohl (header.db_error);
-      type = ntohl (header.type);
+      return rc;
+    }
 
-      if (type == DATA_TYPE)
+  rid = ntohl (header.request_id);
+  conn->set_tran_index (ntohl (header.transaction_id));
+  conn->db_error = (int) ntohl (header.db_error);
+
+  type = ntohl (header.type);
+  if (type == DATA_TYPE)
+    {
+      buf_size = ntohl (header.buffer_size);
+
+      if (rid == req_id)
 	{
-	  buf_size = ntohl (header.buffer_size);
-
-	  if (rid == req_id)
-	    {
-	      buf = (char *) css_return_data_buffer (conn, rid, &buf_size);
-	    }
-	  else
-	    {
-	      buf = (char *) css_return_data_buffer (conn, 0, &buf_size);
-	    }
-
-	  if (buf != NULL)
-	    {
-	      rc = css_net_recv (conn->fd, buf, &buf_size, timeout);
-	      if (rc == NO_ERRORS || rc == RECORD_TRUNCATED)
-		{
-		  if (req_id != rid)
-		    {
-		      /* We have some data for a different request id */
-		      css_queue_unexpected_data_packet (conn, rid, buf, buf_size, rc);
-		      goto begin;
-		    }
-		}
-	    }
-	  else
-	    {
-	      if (buf_size > 0)
-		{
-		  /* 
-		   * allocation error, buffer == NULL
-		   * cleanup received message and set error
-		   */
-		  css_read_remaining_bytes (conn->fd, sizeof (int) + buf_size);
-		  rc = CANT_ALLOC_BUFFER;
-		  if (req_id != rid)
-		    {
-		      css_queue_unexpected_data_packet (conn, rid, NULL, 0, rc);
-		      goto begin;
-		    }
-		}
-	    }
-
-	  *buffer = buf;
-	  *buffer_size = buf_size;
+	  buf = (char *) css_return_data_buffer (conn, rid, &buf_size);
 	}
       else
 	{
-#if defined(CS_MODE)
-	  if (type == ABORT_TYPE)
-	    {
-	      /* 
-	       * if the user registered a buffer, we should return the buffer
-	       */
-	      *buffer_size = ntohl (header.buffer_size);
-	      *buffer = css_return_data_buffer (conn, req_id, buffer_size);
-	      assert (*buffer_size == 0);
-
-	      return SERVER_ABORTED;
-	    }
-#endif /* CS_MODE */
-
-	  css_queue_unexpected_packet (type, conn, rid, &header, ntohl (header.buffer_size));
-	  goto begin;
+	  buf = (char *) css_return_data_buffer (conn, 0, &buf_size);
 	}
+
+      if (buf != NULL)
+	{
+	  rc = css_net_recv (conn->fd, buf, &buf_size, timeout);
+	  if (rc == NO_ERRORS || rc == RECORD_TRUNCATED)
+	    {
+	      if (req_id != rid)
+		{
+		  /* We have some data for a different request id */
+		  css_queue_unexpected_data_packet (conn, rid, buf, buf_size, rc);
+		  goto begin;
+		}
+	    }
+	}
+      else if (0 <= buf_size)
+	{
+	  // Two cases here:
+	  // 1. allocation failure: (buf == NULL && buf_size > 0)
+	  // 2. receives size 0 buffer: (buf == NULL && buf_size == 0)
+	  //    - sender sent size 0 for nil buffer and receiver should consume its size.
+
+	  css_read_remaining_bytes (conn->fd, sizeof (int) + buf_size);
+
+	  if (0 < buf_size)
+	    {
+	      rc = CANT_ALLOC_BUFFER;
+	    }
+
+	  if (req_id != rid)
+	    {
+	      css_queue_unexpected_data_packet (conn, rid, NULL, 0, rc);
+	      goto begin;
+	    }
+	}
+
+      *buffer = buf;
+      *buffer_size = buf_size;
+
+      return rc;
+    }
+#if defined(CS_MODE)
+  else if (type == ABORT_TYPE)
+    {
+      /* 
+       * if the user registered a buffer, we should return the buffer
+       */
+      *buffer_size = ntohl (header.buffer_size);
+      *buffer = css_return_data_buffer (conn, req_id, buffer_size);
+      assert (*buffer_size == 0);
+
+      return SERVER_ABORTED;
+    }
+#endif /* CS_MODE */
+  else
+    {
+      css_queue_unexpected_packet (type, conn, rid, &header, ntohl (header.buffer_size));
+      goto begin;
     }
 
-  return rc;
+  // unreachable
+  assert (0);
 }
 
 /*
@@ -616,67 +623,76 @@ css_receive_error (CSS_CONN_ENTRY * conn, unsigned short req_id, char **buffer, 
 begin:
   header_size = sizeof (NET_HEADER);
   rc = css_net_read_header (conn->fd, (char *) &header, &header_size, -1);
-  if (rc == NO_ERRORS)
+  if (rc != NO_ERRORS)
     {
-      rid = ntohl (header.request_id);
-      conn->set_tran_index (ntohl (header.transaction_id));
-      conn->db_error = (int) ntohl (header.db_error);
-      type = ntohl (header.type);
-      if (ERROR_TYPE == type)
+      return rc;
+    }
+
+  rid = ntohl (header.request_id);
+  conn->set_tran_index (ntohl (header.transaction_id));
+  conn->db_error = (int) ntohl (header.db_error);
+
+  type = ntohl (header.type);
+  if (type == ERROR_TYPE)
+    {
+      buf_size = ntohl (header.buffer_size);
+      if (buf_size != 0)
 	{
-	  buf_size = ntohl (header.buffer_size);
-	  if (buf_size != 0)
+	  buf = (char *) css_return_data_buffer (conn, rid, &buf_size);
+	  if (buf != NULL)
 	    {
-	      buf = (char *) css_return_data_buffer (conn, rid, &buf_size);
-	      if (buf != NULL)
+	      rc = css_net_recv (conn->fd, buf, &buf_size, -1);
+	      if (rc == NO_ERRORS || rc == RECORD_TRUNCATED)
 		{
-		  rc = css_net_recv (conn->fd, buf, &buf_size, -1);
-		  if (rc == NO_ERRORS || rc == RECORD_TRUNCATED)
-		    {
-		      if (req_id != rid)
-			{
-			  /* We have some data for a different request id */
-			  css_queue_unexpected_error_packet (conn, rid, buf, buf_size, rc);
-			  goto begin;
-			}
-		    }
-		}
-	      else
-		{
-		  /* 
-		   * allocation error, buffer == NULL
-		   * cleanup received message and set error
-		   */
-		  css_read_remaining_bytes (conn->fd, sizeof (int) + buf_size);
-		  rc = CANT_ALLOC_BUFFER;
 		  if (req_id != rid)
 		    {
-		      css_queue_unexpected_error_packet (conn, rid, NULL, 0, rc);
+		      /* We have some data for a different request id */
+		      css_queue_unexpected_error_packet (conn, rid, buf, buf_size, rc);
 		      goto begin;
 		    }
 		}
-	      *buffer = buf;
-	      *buffer_size = buf_size;
 	    }
 	  else
 	    {
 	      /* 
-	       * This is the case where data length is zero, but if the
-	       * user registered a buffer, we should return the buffer
+	       * allocation error, buffer == NULL
+	       * cleanup received message and set error
 	       */
-	      *buffer_size = ntohl (header.buffer_size);
-	      *buffer = css_return_data_buffer (conn, req_id, buffer_size);
-	      assert (*buffer_size == 0);
+	      css_read_remaining_bytes (conn->fd, sizeof (int) + buf_size);
+	      rc = CANT_ALLOC_BUFFER;
+	      if (req_id != rid)
+		{
+		  css_queue_unexpected_error_packet (conn, rid, NULL, 0, rc);
+		  goto begin;
+		}
 	    }
+
+	  *buffer = buf;
+	  *buffer_size = buf_size;
+
+	  return rc;
 	}
       else
 	{
-	  css_queue_unexpected_packet (type, conn, rid, &header, ntohl (header.buffer_size));
-	  goto begin;
+	  /* 
+	   * This is the case where data length is zero, but if the
+	   * user registered a buffer, we should return the buffer
+	   */
+	  *buffer_size = ntohl (header.buffer_size);
+	  *buffer = css_return_data_buffer (conn, req_id, buffer_size);
+	  assert (*buffer_size == 0);
+
+	  return rc;
 	}
     }
+  else
+    {
+      css_queue_unexpected_packet (type, conn, rid, &header, ntohl (header.buffer_size));
+      goto begin;
+    }
 
-  return rc;
+  // unreachable
+  assert (0);
 }
 
 /*
@@ -699,13 +715,18 @@ css_common_connect (const char *host_name, CSS_CONN_ENTRY * conn, int connect_ty
 
 #if !defined (WINDOWS)
   if (timeout > 0)
-    /* timeout in milli-seconds in css_tcp_client_open_with_timeout() */
-    fd = css_tcp_client_open_with_timeout (host_name, port, timeout * 1000);
+    {
+      /* timeout in milli-seconds in css_tcp_client_open_with_timeout() */
+      fd = css_tcp_client_open_with_timeout (host_name, port, timeout * 1000);
+    }
   else
-    fd = css_tcp_client_open_with_retry (host_name, port, true);
+    {
+      fd = css_tcp_client_open_with_retry (host_name, port, true);
+    }
 #else /* !WINDOWS */
   fd = css_tcp_client_open_with_retry (host_name, port, true);
 #endif /* WINDOWS */
+
   if (!IS_INVALID_SOCKET (fd))
     {
       conn->fd = fd;
@@ -788,28 +809,30 @@ css_server_connect_part_two (char *host_name, CSS_CONN_ENTRY * conn, int port_id
    */
 
   /* timeout in second in css_common_connect() */
-  if (css_common_connect (host_name, conn, DATA_REQUEST, NULL, 0, port_id, timeout, rid, false) != NULL)
+  if (css_common_connect (host_name, conn, DATA_REQUEST, NULL, 0, port_id, timeout, rid, false) == NULL)
     {
-      /* now ask for a reply from the server */
-      css_queue_user_data_buffer (conn, *rid, sizeof (int), (char *) &reason);
-      if (css_receive_data (conn, *rid, &buffer, &buffer_size, timeout * 1000) == NO_ERRORS)
+      return NULL;
+    }
+
+  /* now ask for a reply from the server */
+  css_queue_user_data_buffer (conn, *rid, sizeof (int), (char *) &reason);
+  if (css_receive_data (conn, *rid, &buffer, &buffer_size, timeout * 1000) == NO_ERRORS)
+    {
+      if (buffer_size == sizeof (int) && buffer == (char *) &reason)
 	{
-	  if (buffer_size == sizeof (int) && buffer == (char *) &reason)
+	  reason = ntohl (reason);
+	  if (reason == SERVER_CONNECTED)
 	    {
-	      reason = ntohl (reason);
-	      if (reason == SERVER_CONNECTED)
-		{
-		  return_status = conn;
-		}
-
-	      /* we shouldn't have to deal with SERVER_STARTED responses here ? */
+	      return_status = conn;
 	    }
-	}
 
-      if (buffer != NULL && buffer != (char *) &reason)
-	{
-	  free_and_init (buffer);
+	  /* we shouldn't have to deal with SERVER_STARTED responses here ? */
 	}
+    }
+
+  if (buffer != NULL && buffer != (char *) &reason)
+    {
+      free_and_init (buffer);
     }
 
   return return_status;
@@ -840,132 +863,127 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 #endif
 
   css_Service_id = master_port_id;
-  if (GETHOSTNAME (hname, MAXHOSTNAMELEN) == 0)
+  if (GETHOSTNAME (hname, MAXHOSTNAMELEN) != 0)
     {
-      conn = css_make_conn (0);
-      if (conn == NULL)
+      return NULL;
+    }
+
+  conn = css_make_conn (0);
+  if (conn == NULL)
+    {
+      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
+      return NULL;
+    }
+
+  /* select the connection protocol, for PC's this will always be new */
+  connection_protocol = ((css_Server_use_new_connection_protocol) ? SERVER_REQUEST_NEW : SERVER_REQUEST);
+
+  if (css_common_connect (hname, conn, connection_protocol, server_name, name_length, master_port_id, 0, &rid, true)
+      == NULL)
+    {
+      goto fail_end;
+    }
+
+  if (css_readn (conn->fd, (char *) &response_buff, sizeof (int), -1) != sizeof (int))
+    {
+      goto fail_end;
+    }
+
+  response = ntohl (response_buff);
+
+  TRACE ("connect_to_master received %d as response from master\n", response);
+
+  switch (response)
+    {
+    case SERVER_ALREADY_EXISTS:
+#if defined(CS_MODE)
+      if (IS_MASTER_CONN_NAME_HA_COPYLOG (server_name))
 	{
-	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
-	  return NULL;
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_COPYLOG_ALREADY_EXISTS, 1,
+		  GET_REAL_MASTER_CONN_NAME (server_name));
+	}
+      else if (IS_MASTER_CONN_NAME_HA_APPLYLOG (server_name))
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_APPLYLOG_ALREADY_EXISTS, 1,
+		  GET_REAL_MASTER_CONN_NAME (server_name));
+	}
+      else if (IS_MASTER_CONN_NAME_HA_SERVER (server_name))
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_SERVER_ALREADY_EXISTS, 1,
+		  GET_REAL_MASTER_CONN_NAME (server_name));
+	}
+      else
+#endif /* CS_MODE */
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_SERVER_ALREADY_EXISTS, 1, server_name);
 	}
 
-      /* select the connection protocol, for PC's this will always be new */
-      connection_protocol = ((css_Server_use_new_connection_protocol) ? SERVER_REQUEST_NEW : SERVER_REQUEST);
+      goto fail_end;
 
-      if (css_common_connect (hname, conn, connection_protocol, server_name, name_length, master_port_id, 0, &rid, true)
-	  == NULL)
+    case SERVER_REQUEST_ACCEPTED_NEW:
+      /* 
+       * Master requests a new-style connect, must go get our port id and set up our connection socket.
+       * For drivers, we don't need a connection socket and we don't want to allocate a bunch of them.  
+       * Let a flag variable control whether or not we actually create one of these.
+       */
+      if (css_Server_inhibit_connection_socket)
 	{
-	  css_free_conn (conn);
-	  return NULL;
+	  server_port_id = -1;
 	}
       else
 	{
-	  if (css_readn (conn->fd, (char *) &response_buff, sizeof (int), -1) == sizeof (int))
-	    {
-	      response = ntohl (response_buff);
+	  server_port_id = css_open_server_connection_socket ();
+	}
 
-	      TRACE ("connect_to_master received %d as response from master\n", response);
+      response = htonl (server_port_id);
+      css_net_send (conn, (char *) &response, sizeof (int), -1);
 
-	      switch (response)
-		{
-		case SERVER_ALREADY_EXISTS:
-		  css_free_conn (conn);
+      /* this connection remains our only contact with the master */
+      return conn;
 
-#if defined(CS_MODE)
-		  if (IS_MASTER_CONN_NAME_HA_COPYLOG (server_name))
-		    {
-		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_COPYLOG_ALREADY_EXISTS, 1,
-			      GET_REAL_MASTER_CONN_NAME (server_name));
-		    }
-		  else if (IS_MASTER_CONN_NAME_HA_APPLYLOG (server_name))
-		    {
-		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_APPLYLOG_ALREADY_EXISTS, 1,
-			      GET_REAL_MASTER_CONN_NAME (server_name));
-		    }
-		  else if (IS_MASTER_CONN_NAME_HA_SERVER (server_name))
-		    {
-		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_SERVER_ALREADY_EXISTS, 1,
-			      GET_REAL_MASTER_CONN_NAME (server_name));
-		    }
-		  else
-#endif /* CS_MODE */
-		    {
-		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_SERVER_ALREADY_EXISTS, 1, server_name);
-		    }
-		  return NULL;
-
-		case SERVER_REQUEST_ACCEPTED_NEW:
-		  /* 
-		   * Master requests a new-style connect, must go get
-		   * our port id and set up our connection socket.
-		   * For drivers, we don't need a connection socket and we
-		   * don't want to allocate a bunch of them.  Let a flag variable
-		   * control whether or not we actually create one of these.
-		   */
-		  if (css_Server_inhibit_connection_socket)
-		    {
-		      server_port_id = -1;
-		    }
-		  else
-		    {
-		      server_port_id = css_open_server_connection_socket ();
-		    }
-
-		  response = htonl (server_port_id);
-		  css_net_send (conn, (char *) &response, sizeof (int), -1);
-
-		  /* this connection remains our only contact with the master */
-		  return conn;
-
-		case SERVER_REQUEST_ACCEPTED:
+    case SERVER_REQUEST_ACCEPTED:
 #if defined(WINDOWS)
-		  /* Windows can't handle this style of connection at all */
-		  css_free_conn (conn);
+      /* Windows can't handle this style of connection at all */
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
 
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
-		  return NULL;
+      goto fail_end;
 #else /* WINDOWS */
-		  /* send the "pathname" for the datagram */
-		  /* be sure to open the datagram first.  */
-		  pname = tempnam (NULL, "csql");
-		  if (pname)
-		    {
-		      if (css_tcp_setup_server_datagram (pname, &socket_fd)
-			  && css_send_data (conn, rid, pname, strlen (pname) + 1) == NO_ERRORS
-			  && css_tcp_listen_server_datagram (socket_fd, &datagram_fd))
-			{
-			  (void) unlink (pname);
-			  /* don't use free_and_init on pname since it came from tempnam() */
-			  free (pname);
-			  css_free_conn (conn);
-			  close (socket_fd);
-			  return (css_make_conn (datagram_fd));
-			}
-		      else
-			{
-			  /* don't use free_and_init on pname since it came from tempnam() */
-			  free (pname);
-			  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1,
-					       server_name);
-			  css_free_conn (conn);
-			  return NULL;
-			}
-		    }
-		  else
-		    {
-		      /* Could not create the temporary file */
-		      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1,
-					   server_name);
-		      css_free_conn (conn);
-		      return NULL;
-		    }
-#endif /* WINDOWS */
-		}
+      /* send the "pathname" for the datagram */
+      /* be sure to open the datagram first.  */
+      pname = tempnam (NULL, "csql");
+      if (pname)
+	{
+	  if (css_tcp_setup_server_datagram (pname, &socket_fd)
+	      && css_send_data (conn, rid, pname, strlen (pname) + 1) == NO_ERRORS
+	      && css_tcp_listen_server_datagram (socket_fd, &datagram_fd))
+	    {
+	      (void) unlink (pname);
+	      /* don't use free_and_init on pname since it came from tempnam() */
+	      free (pname);
+	      css_free_conn (conn);
+	      close (socket_fd);
+	      return (css_make_conn (datagram_fd));
+	    }
+	  else
+	    {
+	      /* don't use free_and_init on pname since it came from tempnam() */
+	      free (pname);
+	      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1,
+				   server_name);
+	      goto fail_end;
 	    }
 	}
-      css_free_conn (conn);
+      else
+	{
+	  /* Could not create the temporary file */
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
+	  goto fail_end;
+	}
+#endif /* WINDOWS */
     }
 
+fail_end:
+  css_free_conn (conn);
   return NULL;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22091

#1092 revealed this old legacy bug.

There was a protocol mismatch between client and server.
Not all list files have a page. One for insert may be empty. Server sends nil buffer as size 0 for the case. 
Client tried to receive data from server only when its non-zero sized receiving buffer is given. Size 0 remains in the packet and the next packet read accidentally read it. The badly read packet is thrashed and client continues to read. This is the way the old legacies worked.

The major changes are
* `css_receive_data` of connection_cl.c // to properly read size 0 buffer
* `net_client_request_with_callback` // to fix potential leak
* `sqmgr_execute_query` // to consider an empty list file page

The other changes are to remove ugly nested blocks for readability. 