### PR TITLE
[CBRD-22064] force thread entry wakeup on shutdown

### DIFF
--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -159,7 +159,7 @@ namespace cubthread
   {
     shutdown = true;
 
-    // migrate thread code here
+    thread_wakeup (this, THREAD_RESUME_DUE_TO_SHUTDOWN);
   }
 
   void

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -159,7 +159,25 @@ namespace cubthread
   {
     shutdown = true;
 
-    thread_wakeup (this, THREAD_RESUME_DUE_TO_SHUTDOWN);
+    // wakeup if waiting
+    if (m_status != status::TS_WAIT)
+      {
+	// not waiting
+	return;
+      }
+
+    lock ();
+    // check again
+    if (m_status != status::TS_WAIT)
+      {
+	// not waiting
+	unlock ();
+	return;
+      }
+
+    // force wakeup
+    thread_wakeup_already_had_mutex (this, THREAD_RESUME_DUE_TO_SHUTDOWN);
+    unlock ();
   }
 
   void


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22064

During shutdown, interrupt_execution is called on all thread entries of all running threads (daemon, active workers, vacuum workers). However, it used to only set shutdown flag. If thread is waiting on a latch, it would remain waiting.

Fix by forcing wakeup when thread is waiting.