### PR TITLE
[CBRD-22104] use interrupt reason on shutdown threads

### DIFF
--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -175,8 +175,9 @@ namespace cubthread
 	return;
       }
 
-    // force wakeup
-    thread_wakeup_already_had_mutex (this, THREAD_RESUME_DUE_TO_SHUTDOWN);
+    // interrupt & force wakeup
+    interrupted = true;
+    thread_wakeup_already_had_mutex (this, THREAD_RESUME_DUE_TO_INTERRUPT);
     unlock ();
   }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22104

Set interrupt as resume status instead of shutdown.