### PR TITLE
[CBRD-22121] fix stopping execution on shutdown

### DIFF
--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -172,7 +172,8 @@ namespace cubthread
     Context &context = context_manager_arg->create_context ();
 
     // now that we have access to context we can set the callback function on stop
-    daemon_arg->m_func_on_stop = std::bind (&Context::interrupt_execution, std::ref (context));
+    daemon_arg->m_func_on_stop = std::bind (&context_manager<Context>::stop_execution, std::ref (*context_manager_arg),
+					    std::ref (context));
 
     daemon_arg->register_stat_start ();
 

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -193,33 +193,6 @@ namespace cubthread
   }
 
   void
-  entry::interrupt_execution (void)
-  {
-    shutdown = true;
-
-    // wakeup if waiting
-    if (m_status != status::TS_WAIT)
-      {
-	// not waiting
-	return;
-      }
-
-    lock ();
-    // check again
-    if (m_status != status::TS_WAIT)
-      {
-	// not waiting
-	unlock ();
-	return;
-      }
-
-    // interrupt & force wakeup
-    interrupted = true;
-    thread_wakeup_already_had_mutex (this, THREAD_RESUME_DUE_TO_INTERRUPT);
-    unlock ();
-  }
-
-  void
   entry::request_lock_free_transactions (void)
   {
     /* lock-free transaction entries */

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -190,10 +190,6 @@ namespace cubthread
       };
 
       // public functions
-
-      // Context template requirement
-      void interrupt_execution (void);
-
       void request_lock_free_transactions (void);   // todo: lock-free refactoring
 
       // The rules of thumbs is to always use private members. Until a complete refactoring, these members will remain

--- a/src/thread/thread_entry_task.cpp
+++ b/src/thread/thread_entry_task.cpp
@@ -88,6 +88,12 @@ namespace cubthread
   }
 
   void
+  entry_manager::stop_execution (entry &context)
+  {
+    context.shutdown = true;
+  }
+
+  void
   daemon_entry_manager::on_create (entry &context)
   {
     context.type = TT_DAEMON;

--- a/src/thread/thread_entry_task.hpp
+++ b/src/thread/thread_entry_task.hpp
@@ -86,6 +86,7 @@ namespace cubthread
       entry &create_context (void) final;
       void retire_context (entry &context) final;
       void recycle_context (entry &context) final;
+      void stop_execution (entry &context) override;
 
     protected:
 

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -57,9 +57,6 @@ namespace cubthread
   //              task_p->retire (); // this will delete task_p
   //            }
   //
-  // NOTE: to use tasks with worker pools & daemons, Context should have interrupt_execution () method defined.
-  //       For long execution tasks, it is recommended to check the interrupt condition regularly.
-  //
   template <typename Context>
   class task
   {
@@ -126,6 +123,11 @@ namespace cubthread
   //
   //          context_mgr.retire_context (context_ref);
   //
+  //    [optional]
+  //    4. if task execution can take a very long time and you need to force stop it, you can use stop_execution:
+  //        4.1. implement context_manager::stop_execution; should notify context to stop.
+  //        4.2. you have to check stop notifications in custom_task::execute
+  //        4.3. call context_mgr.stop_execution (context_ref).
   //
   template <typename Context>
   class context_manager
@@ -139,6 +141,10 @@ namespace cubthread
       virtual context_type &create_context (void) = 0;      // create a new thread context; cannot fail
       virtual void retire_context (context_type &) = 0;     // retire the thread context
       virtual void recycle_context (context_type &)         // recycle context before reuse
+      {
+	// usage and implementation is optional
+      }
+      virtual void stop_execution (context_type &)          // notify context to stop execution
       {
 	// usage and implementation is optional
       }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22121

JIRA issue is due to dropped files page being fix being interrupted on shutdown. It was not expected and fatal error is set.

Fixed by accepting and propagating the error until vacuum worker is stopped.

Another potential undiscovered issue is interrupting the vacuum master. Its current behavior relies on no interruptions. As a consequence I've made a change on how threads are stopped, by moving stop/interrupt functionality from context (entry) to context manager. From thread design point of view is even better, since this is an outside interaction with context too (like create, retire, recycle context). It allows better tuning on how to stop your workers/daemons.