### PR TITLE
[CBRD-22108] Grammar for update default

### DIFF
--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -2489,7 +2489,7 @@ or_get_current_representation (RECDES * record, int do_indexes)
 
       /* get the default expression. */
       classobj_initialize_default_expr (&att->current_default_value.default_expr);
-      classobj_initialize_default_expr (&att->on_update);
+      att->on_update_expr = DB_DEFAULT_NONE;
       if (properties_val_len > 0)
 	{
 	  db_make_null (&properties_val);
@@ -2582,7 +2582,7 @@ or_get_current_representation (RECDES * record, int do_indexes)
 	    {
 	      /* simple expressions like SYS_DATE */
 	      assert (DB_VALUE_TYPE (&def_expr) == DB_TYPE_INTEGER);
-	      att->on_update.default_expr_type = (DB_DEFAULT_EXPR_TYPE) db_get_int (&def_expr);
+	      att->on_update_expr = (DB_DEFAULT_EXPR_TYPE) db_get_int (&def_expr);
 	    }
 
 	  pr_clear_value (&def_expr);
@@ -2626,7 +2626,7 @@ or_get_current_representation (RECDES * record, int do_indexes)
       att->current_default_value.val_length = 0;
       att->current_default_value.value = NULL;
       classobj_initialize_default_expr (&att->current_default_value.default_expr);
-      classobj_initialize_default_expr (&att->on_update);
+      att->on_update_expr = DB_DEFAULT_NONE;
 
       OR_GET_OID (ptr + ORC_ATT_CLASS_OFFSET, &oid);
       att->classoid = oid;	/* structure copy */
@@ -2702,7 +2702,7 @@ or_get_current_representation (RECDES * record, int do_indexes)
       att->default_value.val_length = 0;
       att->default_value.value = NULL;
       classobj_initialize_default_expr (&att->default_value.default_expr);
-      classobj_initialize_default_expr (&att->on_update);
+      att->on_update_expr = DB_DEFAULT_NONE;
       att->current_default_value.val_length = 0;
       att->current_default_value.value = NULL;
       classobj_initialize_default_expr (&att->current_default_value.default_expr);
@@ -3568,11 +3568,6 @@ or_free_classrep (OR_CLASSREP * rep)
 	      free_and_init (att->default_value.default_expr.default_expr_format);
 	    }
 
-	  if (att->on_update.default_expr_format != NULL)
-	    {
-	      free_and_init (att->on_update.default_expr_format);
-	    }
-
 	  if (att->current_default_value.value != NULL)
 	    {
 	      free_and_init (att->current_default_value.value);
@@ -3603,11 +3598,6 @@ or_free_classrep (OR_CLASSREP * rep)
 	  if (att->default_value.default_expr.default_expr_format != NULL)
 	    {
 	      free_and_init (att->default_value.default_expr.default_expr_format);
-	    }
-
-	  if (att->on_update.default_expr_format != NULL)
-	    {
-	      free_and_init (att->on_update.default_expr_format);
 	    }
 
 	  if (att->current_default_value.value != NULL)

--- a/src/base/object_representation_sr.h
+++ b/src/base/object_representation_sr.h
@@ -67,7 +67,7 @@ struct or_attribute
   int position;			/* storage position (list index) */
   OID classoid;			/* source class object id */
 
-  DB_DEFAULT_EXPR on_update;
+  DB_DEFAULT_EXPR_TYPE on_update_expr;	/* on update default expr type */
   OR_DEFAULT_VALUE default_value;	/* default value */
   OR_DEFAULT_VALUE current_default_value;	/* default value */
   BTID *btids;			/* B-tree ID's for indexes and constraints */

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -2361,13 +2361,13 @@ emit_attribute_def (DB_ATTRIBUTE * attribute, ATTRIBUTE_QUALIFIER qualifier)
 	}
     }
 
-  if (attribute->on_update_default_expr.default_expr_type != DB_DEFAULT_NONE)
+  if (attribute->on_update_default_expr != DB_DEFAULT_NONE)
     {
       const char *default_expr_type_str;
 
       fprintf (output_file, " ON UPDATE ");
 
-      default_expr_type_str = db_default_expression_string (attribute->on_update_default_expr.default_expr_type);
+      default_expr_type_str = db_default_expression_string (attribute->on_update_default_expr);
       if (default_expr_type_str != NULL)
 	{
 	  fprintf (output_file, default_expr_type_str);

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4698,7 +4698,7 @@ classobj_make_attribute (const char *name, PR_TYPE * type, SM_NAME_SPACE name_sp
   db_make_null (&att->default_value.original_value);
   db_make_null (&att->default_value.value);
   classobj_initialize_default_expr (&att->default_value.default_expr);
-  classobj_initialize_default_expr (&att->on_update_default_expr);
+  att->on_update_default_expr = DB_DEFAULT_NONE;
 
   att->constraints = NULL;
   att->order_link = NULL;
@@ -4762,7 +4762,7 @@ classobj_initialize_attributes (SM_ATTRIBUTE * attributes)
       db_value_put_null (&attr->default_value.value);
       db_value_put_null (&attr->default_value.original_value);
       classobj_initialize_default_expr (&attr->default_value.default_expr);
-      classobj_initialize_default_expr (&attr->on_update_default_expr);
+      attr->on_update_default_expr = DB_DEFAULT_NONE;
     }
 }
 
@@ -4824,7 +4824,7 @@ classobj_init_attribute (SM_ATTRIBUTE * src, SM_ATTRIBUTE * dest, int copy)
   dest->properties = NULL;
   dest->auto_increment = src->auto_increment;
   classobj_copy_default_expr (&dest->default_value.default_expr, &src->default_value.default_expr);
-  classobj_copy_default_expr (&dest->on_update_default_expr, &src->on_update_default_expr);
+  dest->on_update_default_expr = src->on_update_default_expr;
   dest->comment = NULL;
 
   if (copy)
@@ -5125,12 +5125,6 @@ classobj_clear_attribute (SM_ATTRIBUTE * att)
     {
       ws_free_string (att->default_value.default_expr.default_expr_format);
       att->default_value.default_expr.default_expr_format = NULL;
-    }
-
-  if (att->on_update_default_expr.default_expr_format)
-    {
-      ws_free_string (att->on_update_default_expr.default_expr_format);
-      att->on_update_default_expr.default_expr_format = NULL;
     }
 
   att->header.name = NULL;

--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -445,7 +445,7 @@ struct sm_attribute
   int offset;			/* memory offset */
 
   SM_DEFAULT_VALUE default_value;	/* default value */
-  DB_DEFAULT_EXPR on_update_default_expr;	/* default on_update expr */
+  DB_DEFAULT_EXPR_TYPE on_update_default_expr;
 
   SM_CONSTRAINT *constraints;	/* cached constraint list */
 

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -549,20 +549,14 @@ void object_printer::describe_attribute (const struct db_object &cls, const sm_a
 	      m_buf (")");
 	    }
 	}
-      if (attribute.on_update_default_expr.default_expr_type != DB_DEFAULT_NONE)
+
+      if (attribute.on_update_default_expr != DB_DEFAULT_NONE)
 	{
 	  const char *default_expr_type_str;
 
 	  m_buf (" ON UPDATE ");
-	  default_expr_type_str = db_default_expression_string (attribute.on_update_default_expr.default_expr_type);
-	  if (attribute.on_update_default_expr.default_expr_type != NULL)
-	    {
-	      m_buf ("%s", default_expr_type_str);
-	    }
-	  else
-	    {
-	      assert (attribute.on_update_default_expr.default_expr_op == NULL_DEFAULT_EXPRESSION_OPERATOR);
-	    }
+	  default_expr_type_str = db_default_expression_string (attribute.on_update_default_expr);
+	  m_buf ("%s", default_expr_type_str);
 	}
     }
   else if (attribute.header.name_space == ID_CLASS_ATTRIBUTE)

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5418,13 +5418,13 @@ sm_att_auto_increment (MOP classop, const char *name)
 
 int
 sm_att_default_value (MOP classop, const char *name, DB_VALUE * value, DB_DEFAULT_EXPR ** default_expr,
-		      DB_DEFAULT_EXPR ** on_update_expr)
+		      DB_DEFAULT_EXPR_TYPE ** on_update_expr)
 {
   SM_CLASS *class_ = NULL;
   SM_ATTRIBUTE *att = NULL;
   int error = NO_ERROR;
 
-  assert (value != NULL && default_expr != NULL && on_update_expr != NULL);
+  assert (value != NULL && default_expr != NULL && on_update_expr != NULL && on_update_expr != NULL);
 
   error = db_value_clear (value);
   if (error != NO_ERROR)

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5413,6 +5413,7 @@ sm_att_auto_increment (MOP classop, const char *name)
  *   name(in): attribute
  *   value(out): the default value of the specified attribute
  *   default_expr(out): default expression
+ *   on_update_expr(out): on_update default expression
  */
 
 int

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5424,7 +5424,7 @@ sm_att_default_value (MOP classop, const char *name, DB_VALUE * value, DB_DEFAUL
   SM_ATTRIBUTE *att = NULL;
   int error = NO_ERROR;
 
-  assert (value != NULL && default_expr != NULL && on_update_expr != NULL && on_update_expr != NULL);
+  assert (value != NULL && default_expr != NULL && on_update_expr != NULL);
 
   error = db_value_clear (value);
   if (error != NO_ERROR)

--- a/src/object/schema_manager.h
+++ b/src/object/schema_manager.h
@@ -224,7 +224,7 @@ extern int sm_att_info (MOP classop, const char *name, int *idp, TP_DOMAIN ** do
 extern int sm_att_constrained (MOP classop, const char *name, SM_ATTRIBUTE_FLAG cons);
 extern bool sm_att_auto_increment (MOP classop, const char *name);
 extern int sm_att_default_value (MOP classop, const char *name, DB_VALUE * value, DB_DEFAULT_EXPR ** default_expr,
-				 DB_DEFAULT_EXPR ** on_update_expr);
+				 DB_DEFAULT_EXPR_TYPE ** on_update_expr);
 
 extern int sm_class_check_uniques (MOP classop);
 extern BTID *sm_find_index (MOP classop, char **att_names, int num_atts, bool unique_index_only,

--- a/src/object/schema_template.c
+++ b/src/object/schema_template.c
@@ -956,6 +956,7 @@ smt_quit (SM_TEMPLATE * template_)
  *                            list after the attribute with the given name
  *   default_expr(in): default expression
  *   on_update(in): on_update default expression
+ *   comment(in): attribute comment
  */
 int
 smt_add_attribute_w_dflt_w_order (DB_CTMPL * def, const char *name, const char *domain_string, DB_DOMAIN * domain,
@@ -989,6 +990,7 @@ smt_add_attribute_w_dflt_w_order (DB_CTMPL * def, const char *name, const char *
  *   default_value(in):
  *   name_space(in): attribute name_space (class, instance, or shared)
  *   default_expr(in): default expression
+ *   on_update(in): on_update default expression
  *   comment(in): attribute comment
  */
 int
@@ -1467,20 +1469,21 @@ smt_set_attribute_orig_default_value (SM_ATTRIBUTE * att, DB_VALUE * new_orig_va
 }
 
 /*
-* smt_set_attribute_on_update() - Sets the on update default expr of an attribute.
-*				  No domain checking is performed.
-*   return: NO_ERROR on success, non-zero for ERROR
-*   template(in/out): schema template
-*   name(in): attribute name
-*   class_attribute(in): non-zero if looking at class attributes
-*   on_update(in): on update default expression
-*/
+ * smt_set_attribute_on_update() - Sets the on update default expr of an attribute.
+ *				   No domain checking is performed.
+ *   return: NO_ERROR on success, non-zero for ERROR
+ *   template(in/out): schema template
+ *   name(in): attribute name
+ *   class_attribute(in): non-zero if looking at class attributes
+ *   on_update(in): on update default expression
+ */
 int
 smt_set_attribute_on_update (SM_TEMPLATE * template_, const char *name, int class_attribute,
 			     DB_DEFAULT_EXPR * on_update)
 {
   int error = NO_ERROR;
   SM_ATTRIBUTE *att;
+
   error = smt_find_attribute (template_, name, class_attribute, &att);
   if (error == NO_ERROR)
     {
@@ -1493,16 +1496,17 @@ smt_set_attribute_on_update (SM_TEMPLATE * template_, const char *name, int clas
 	  classobj_copy_default_expr (&att->on_update_default_expr, on_update);
 	}
     }
+
   return error;
 }
 
 /*
-* smt_set_attribute_on_update_expr() - Sets the on update default expr of an attribute.
-*				       No domain checking is performed.
-*   return: NO_ERROR on success, non-zero for ERROR
-*   att(in/out): attribute
-*   on_update(in): on update default expression
-*/
+ * smt_set_attribute_on_update_expr() - Sets the on update default expr of an attribute.
+ *				        No domain checking is performed.
+ *   return: NO_ERROR on success, non-zero for ERROR
+ *   att(in/out): attribute
+ *   on_update(in): on update default expression
+ */
 static int
 smt_set_attribute_on_update_expr (SM_ATTRIBUTE * att, DB_DEFAULT_EXPR * on_update)
 {
@@ -1511,6 +1515,7 @@ smt_set_attribute_on_update_expr (SM_ATTRIBUTE * att, DB_DEFAULT_EXPR * on_updat
       classobj_initialize_default_expr (&att->on_update_default_expr);
       return NO_ERROR;
     }
+
   return classobj_copy_default_expr (&att->on_update_default_expr, on_update);
 }
 
@@ -4395,12 +4400,10 @@ error_exit:
  *   name_space(in): class, shared or normal attribute
  *   new_default_value(in): default value
  *   new_default_expr(in): default expression
- *   new_on_update_expr(in): on update default expression
- *   change_first(in): the attribute should be added at the beginning of the
- *                  attributes list
- *   change_after_attribute(in): the attribute should be added in the
- *                               attributes list after the attribute with the
- *                               given name
+ *   new_on_update_expr(in): on_update default expression
+ *   change_first(in): the attribute should be added at the beginning of the attributes list
+ *   change_after_attribute(in): the attribute should be added in the attributes list
+ *                               after the attribute with the given name
  *   found_att(out) : the new attribute if successfully changed
  */
 int
@@ -4417,9 +4420,8 @@ smt_change_attribute_w_dflt_w_order (DB_CTMPL * def, const char *name, const cha
   TP_DOMAIN_STATUS status;
 
   *found_att = NULL;
-  error =
-    smt_change_attribute (def, name, new_name, new_domain_string, new_domain, name_space, change_first,
-			  change_after_attribute, found_att);
+  error = smt_change_attribute (def, name, new_name, new_domain_string, new_domain, name_space, change_first,
+				change_after_attribute, found_att);
   if (error != NO_ERROR)
     {
       return error;
@@ -4434,18 +4436,17 @@ smt_change_attribute_w_dflt_w_order (DB_CTMPL * def, const char *name, const cha
   if (new_default_value != NULL || (new_default_expr != NULL && new_default_expr->default_expr_type != DB_DEFAULT_NONE))
     {
       assert (((*found_att)->flags & SM_ATTFLAG_NEW) == 0);
-      error =
-	smt_set_attribute_default (def, ((new_name != NULL) ? new_name : name),
-				   name_space == (ID_CLASS_ATTRIBUTE) ? 1 : 0, new_default_value, new_default_expr);
+      error = smt_set_attribute_default (def, ((new_name != NULL) ? new_name : name),
+					 name_space == (ID_CLASS_ATTRIBUTE) ? 1 : 0, new_default_value,
+					 new_default_expr);
       if (error != NO_ERROR)
 	{
 	  return error;
 	}
     }
 
-  error =
-    smt_set_attribute_on_update (def, ((new_name != NULL) ? new_name : name),
-				 name_space == (ID_CLASS_ATTRIBUTE) ? 1 : 0, new_on_update_expr);
+  error = smt_set_attribute_on_update (def, ((new_name != NULL) ? new_name : name),
+				       name_space == (ID_CLASS_ATTRIBUTE) ? 1 : 0, new_on_update_expr);
   if (error != NO_ERROR)
     {
       return error;

--- a/src/object/schema_template.h
+++ b/src/object/schema_template.h
@@ -51,13 +51,14 @@ extern SM_CLASS_TYPE smt_get_class_type (SM_TEMPLATE * template_);
 /* Attribute definition */
 extern int smt_add_attribute_w_dflt (DB_CTMPL * def, const char *name, const char *domain_string, DB_DOMAIN * domain,
 				     DB_VALUE * default_value, const SM_NAME_SPACE name_space,
-				     DB_DEFAULT_EXPR * default_expr, DB_DEFAULT_EXPR * on_update, const char *comment);
+				     DB_DEFAULT_EXPR * default_expr, DB_DEFAULT_EXPR_TYPE * on_update,
+				     const char *comment);
 
 extern int smt_add_attribute_w_dflt_w_order (DB_CTMPL * def, const char *name, const char *domain_string,
 					     DB_DOMAIN * domain, DB_VALUE * default_value,
 					     const SM_NAME_SPACE name_space, const bool add_first,
 					     const char *add_after_attribute, DB_DEFAULT_EXPR * default_expr,
-					     DB_DEFAULT_EXPR * on_update, const char *comment);
+					     DB_DEFAULT_EXPR_TYPE * on_update, const char *comment);
 
 extern int smt_add_attribute_any (SM_TEMPLATE * template_, const char *name, const char *domain_string,
 				  DB_DOMAIN * domain, const SM_NAME_SPACE name_space, const bool add_first,
@@ -77,7 +78,7 @@ extern int smt_set_attribute_default (SM_TEMPLATE * template_, const char *name,
 				      DB_DEFAULT_EXPR * default_expr);
 
 extern int smt_set_attribute_on_update (SM_TEMPLATE * template_, const char *name, int class_attribute,
-					DB_DEFAULT_EXPR * on_update);
+					DB_DEFAULT_EXPR_TYPE on_update);
 
 extern int smt_add_constraint (SM_TEMPLATE * template_, DB_CONSTRAINT_TYPE constraint_type, const char *constraint_name,
 			       const char **att_names, const int *asc_desc, int class_attribute,
@@ -157,7 +158,7 @@ extern int smt_change_query_spec (SM_TEMPLATE * def, const char *query, const in
 extern int smt_change_attribute_w_dflt_w_order (DB_CTMPL * def, const char *name, const char *new_name,
 						const char *new_domain_string, DB_DOMAIN * new_domain,
 						const SM_NAME_SPACE name_space, DB_VALUE * new_default_value,
-						DB_DEFAULT_EXPR * new_def_expr, DB_DEFAULT_EXPR * new_on_update_expr,
+						DB_DEFAULT_EXPR * new_def_expr, DB_DEFAULT_EXPR_TYPE new_on_update_expr,
 						const bool change_first, const char *change_after_attribute,
 						SM_ATTRIBUTE ** found_att);
 

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -3033,12 +3033,12 @@ disk_to_attribute (OR_BUF * buf, SM_ATTRIBUTE * att)
       att->properties = get_property_list (buf, vars[ORC_ATT_PROPERTIES_INDEX].length);
 
       classobj_initialize_default_expr (&att->default_value.default_expr);
-      classobj_initialize_default_expr (&att->on_update_default_expr);
+      att->on_update_default_expr = DB_DEFAULT_NONE;
       if (att->properties)
 	{
 	  if (classobj_get_prop (att->properties, "update_default", &value) > 0)
 	    {
-	      att->on_update_default_expr.default_expr_type = (DB_DEFAULT_EXPR_TYPE) db_get_int (&value);
+	      att->on_update_default_expr = (DB_DEFAULT_EXPR_TYPE) db_get_int (&value);
 	    }
 
 	  if (classobj_get_prop (att->properties, "default_expr", &value) > 0)
@@ -4639,13 +4639,11 @@ tf_attribute_default_expr_to_property (SM_ATTRIBUTE * attr_list)
 	  classobj_drop_prop (attr->properties, "default_expr");
 	}
 
-      DB_DEFAULT_EXPR *update_default = &attr->on_update_default_expr;
-      if (update_default->default_expr_type != DB_DEFAULT_NONE)
+      DB_DEFAULT_EXPR_TYPE update_default = attr->on_update_default_expr;
+      if (update_default != DB_DEFAULT_NONE)
 	{
-	  /* attr has default expression as default value */
 	  if (attr->properties == NULL)
 	    {
-	      /* allocate new property sequence */
 	      attr->properties = classobj_make_prop ();
 
 	      if (attr->properties == NULL)
@@ -4655,16 +4653,8 @@ tf_attribute_default_expr_to_property (SM_ATTRIBUTE * attr_list)
 		}
 	    }
 
-	  if (update_default->default_expr_op == NULL_DEFAULT_EXPRESSION_OPERATOR)
-	    {
-	      /* add update_default property to sequence */
-	      db_make_int (&default_expr_value, update_default->default_expr_type);
-	      classobj_put_prop (attr->properties, "update_default", &default_expr_value);
-	    }
-	  else
-	    {
-	      assert (false);
-	    }
+	  db_make_int (&default_expr_value, update_default);
+	  classobj_put_prop (attr->properties, "update_default", &default_expr_value);
 	}
       else if (attr->properties != NULL)
 	{

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -4657,7 +4657,7 @@ tf_attribute_default_expr_to_property (SM_ATTRIBUTE * attr_list)
 
 	  if (update_default->default_expr_op == NULL_DEFAULT_EXPRESSION_OPERATOR)
 	    {
-	      /* add default_expr property to sequence */
+	      /* add update_default property to sequence */
 	      db_make_int (&default_expr_value, update_default->default_expr_type);
 	      classobj_put_prop (attr->properties, "update_default", &default_expr_value);
 	    }

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -10129,58 +10129,50 @@ column_shared_constraint_def
 column_on_update_def
 	: ON_ UPDATE expression_
 		{{
-			PT_NODE *attr_node;
-			PT_NODE *node = parser_new_node (this_parser, PT_ON_UPDATE);
+			DB_DEFAULT_EXPR_TYPE default_expr_type = DB_DEFAULT_NONE;
+			PT_NODE *attr_node = parser_get_attr_def_one ();
+			PT_NODE *on_update_default_value = $3;
+			PARSER_SAVE_ERR_CONTEXT (attr_node, @3.buffer_pos)
 
-			if (node)
+			if (on_update_default_value && on_update_default_value->node_type == PT_EXPR)
 			  {
-			    PT_NODE *def;
-
-			    node->info.on_update.default_value = $3;
-			    PARSER_SAVE_ERR_CONTEXT (node, @3.buffer_pos)
-
-			    def = node->info.on_update.default_value;
-			    if (def && def->node_type == PT_EXPR)
-			      {						
-				switch (def->info.expr.op)
-				  {
-				  case PT_CURRENT_TIMESTAMP:
-				    node->info.on_update.default_expr_type = DB_DEFAULT_CURRENTTIMESTAMP;
-				    break;
-				  case PT_CURRENT_DATE:
-				    node->info.on_update.default_expr_type = DB_DEFAULT_CURRENTDATE;
-				    break;
-				  case PT_CURRENT_DATETIME:
-				    node->info.on_update.default_expr_type = DB_DEFAULT_CURRENTDATETIME;
-				    break;
-				  case PT_SYS_TIMESTAMP:
-				    node->info.on_update.default_expr_type = DB_DEFAULT_SYSTIMESTAMP;
-				    break;
-				  case PT_UNIX_TIMESTAMP:
-				    node->info.on_update.default_expr_type = DB_DEFAULT_UNIX_TIMESTAMP;
-				    break;
-				  case PT_SYS_DATE:
-				    node->info.on_update.default_expr_type = DB_DEFAULT_SYSDATE;
-				    break;
-				  case PT_SYS_DATETIME:
-				    node->info.on_update.default_expr_type = DB_DEFAULT_SYSDATETIME;
-				    break;
-				  case PT_SYS_TIME:
-				    node->info.on_update.default_expr_type = DB_DEFAULT_SYSTIME;
-				    break;
-				  default:
-				    node->info.on_update.default_expr_type = DB_DEFAULT_NONE;
-				    break;
-				  }
-			      }
-			    else
-			      {
-				PT_ERROR (this_parser, node, "on update must be an expression");
-			      }
+			switch (on_update_default_value->info.expr.op)
+			  {
+			  case PT_CURRENT_TIMESTAMP:
+			    default_expr_type = DB_DEFAULT_CURRENTTIMESTAMP;
+			    break;
+			  case PT_CURRENT_DATE:
+			    default_expr_type = DB_DEFAULT_CURRENTDATE;
+			    break;
+			  case PT_CURRENT_DATETIME:
+			    default_expr_type = DB_DEFAULT_CURRENTDATETIME;
+			    break;
+			  case PT_SYS_TIMESTAMP:
+			    default_expr_type = DB_DEFAULT_SYSTIMESTAMP;
+			    break;
+			  case PT_UNIX_TIMESTAMP:
+			    default_expr_type = DB_DEFAULT_UNIX_TIMESTAMP;
+			    break;
+			  case PT_SYS_DATE:
+			    default_expr_type = DB_DEFAULT_SYSDATE;
+			    break;
+			  case PT_SYS_DATETIME:
+			    default_expr_type = DB_DEFAULT_SYSDATETIME;
+			    break;
+			  case PT_SYS_TIME:
+			    default_expr_type = DB_DEFAULT_SYSTIME;
+			    break;
+			  default:
+			    PT_ERROR (this_parser, attr_node, "invalid expression type");
+			    break;
 			  }
-
-			attr_node = parser_get_attr_def_one ();
-			attr_node->info.attr_def.on_update = node;
+			  }
+			else
+			  {
+			PT_ERROR (this_parser, attr_node, "on update must be an expression");
+			  }
+			
+			attr_node->info.attr_def.on_update = default_expr_type;
 
 		DBG_PRINT}}
 	;

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -10134,48 +10134,49 @@ column_on_update_def
 
 			if (node)
 			  {
-				PT_NODE *def;
+			    PT_NODE *def;
+
 			    node->info.on_update.default_value = $3;
 			    PARSER_SAVE_ERR_CONTEXT (node, @3.buffer_pos)
 
-				def = node->info.on_update.default_value;
+			    def = node->info.on_update.default_value;
 			    if (def && def->node_type == PT_EXPR)
 			      {						
-					switch (def->info.expr.op)
-					  {
-					  case PT_CURRENT_TIMESTAMP:
-						node->info.on_update.default_expr_type = DB_DEFAULT_CURRENTTIMESTAMP;
-						break;
-					  case PT_CURRENT_DATE:
-						node->info.on_update.default_expr_type = DB_DEFAULT_CURRENTDATE;
-						break;
-					  case PT_CURRENT_DATETIME:
-						node->info.on_update.default_expr_type = DB_DEFAULT_CURRENTDATETIME;
-						break;
-					  case PT_SYS_TIMESTAMP:
-						node->info.on_update.default_expr_type = DB_DEFAULT_SYSTIMESTAMP;
-						break;
-					  case PT_UNIX_TIMESTAMP:
-						node->info.on_update.default_expr_type = DB_DEFAULT_UNIX_TIMESTAMP;
-						break;
-					  case PT_SYS_DATE:
-						node->info.on_update.default_expr_type = DB_DEFAULT_SYSDATE;
-						break;
-					  case PT_SYS_DATETIME:
-					    node->info.on_update.default_expr_type = DB_DEFAULT_SYSDATETIME;
-						break;
-					  case PT_SYS_TIME:
-					    node->info.on_update.default_expr_type = DB_DEFAULT_SYSTIMESTAMP;
-						break;						
-					  default:
-					    node->info.on_update.default_expr_type = DB_DEFAULT_NONE;
-						break;
-					  }
-				  }
-				else
+				switch (def->info.expr.op)
 				  {
-					PT_ERROR (this_parser, node, "on update must be a expression");
+				  case PT_CURRENT_TIMESTAMP:
+				    node->info.on_update.default_expr_type = DB_DEFAULT_CURRENTTIMESTAMP;
+				    break;
+				  case PT_CURRENT_DATE:
+				    node->info.on_update.default_expr_type = DB_DEFAULT_CURRENTDATE;
+				    break;
+				  case PT_CURRENT_DATETIME:
+				    node->info.on_update.default_expr_type = DB_DEFAULT_CURRENTDATETIME;
+				    break;
+				  case PT_SYS_TIMESTAMP:
+				    node->info.on_update.default_expr_type = DB_DEFAULT_SYSTIMESTAMP;
+				    break;
+				  case PT_UNIX_TIMESTAMP:
+				    node->info.on_update.default_expr_type = DB_DEFAULT_UNIX_TIMESTAMP;
+				    break;
+				  case PT_SYS_DATE:
+				    node->info.on_update.default_expr_type = DB_DEFAULT_SYSDATE;
+				    break;
+				  case PT_SYS_DATETIME:
+				    node->info.on_update.default_expr_type = DB_DEFAULT_SYSDATETIME;
+				    break;
+				  case PT_SYS_TIME:
+				    node->info.on_update.default_expr_type = DB_DEFAULT_SYSTIME;
+				    break;
+				  default:
+				    node->info.on_update.default_expr_type = DB_DEFAULT_NONE;
+				    break;
 				  }
+			      }
+			    else
+			      {
+				PT_ERROR (this_parser, node, "on update must be an expression");
+			      }
 			  }
 
 			attr_node = parser_get_attr_def_one ();

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -10136,40 +10136,40 @@ column_on_update_def
 
 			if (on_update_default_value && on_update_default_value->node_type == PT_EXPR)
 			  {
-			switch (on_update_default_value->info.expr.op)
-			  {
-			  case PT_CURRENT_TIMESTAMP:
-			    default_expr_type = DB_DEFAULT_CURRENTTIMESTAMP;
-			    break;
-			  case PT_CURRENT_DATE:
-			    default_expr_type = DB_DEFAULT_CURRENTDATE;
-			    break;
-			  case PT_CURRENT_DATETIME:
-			    default_expr_type = DB_DEFAULT_CURRENTDATETIME;
-			    break;
-			  case PT_SYS_TIMESTAMP:
-			    default_expr_type = DB_DEFAULT_SYSTIMESTAMP;
-			    break;
-			  case PT_UNIX_TIMESTAMP:
-			    default_expr_type = DB_DEFAULT_UNIX_TIMESTAMP;
-			    break;
-			  case PT_SYS_DATE:
-			    default_expr_type = DB_DEFAULT_SYSDATE;
-			    break;
-			  case PT_SYS_DATETIME:
-			    default_expr_type = DB_DEFAULT_SYSDATETIME;
-			    break;
-			  case PT_SYS_TIME:
-			    default_expr_type = DB_DEFAULT_SYSTIME;
-			    break;
-			  default:
-			    PT_ERROR (this_parser, attr_node, "invalid expression type");
-			    break;
-			  }
+			    switch (on_update_default_value->info.expr.op)
+			      {
+			      case PT_CURRENT_TIMESTAMP:
+			        default_expr_type = DB_DEFAULT_CURRENTTIMESTAMP;
+			        break;
+			      case PT_CURRENT_DATE:
+			        default_expr_type = DB_DEFAULT_CURRENTDATE;
+			        break;
+			      case PT_CURRENT_DATETIME:
+			        default_expr_type = DB_DEFAULT_CURRENTDATETIME;
+			        break;
+			      case PT_SYS_TIMESTAMP:
+			        default_expr_type = DB_DEFAULT_SYSTIMESTAMP;
+			        break;
+			      case PT_UNIX_TIMESTAMP:
+			        default_expr_type = DB_DEFAULT_UNIX_TIMESTAMP;
+			        break;
+			      case PT_SYS_DATE:
+			        default_expr_type = DB_DEFAULT_SYSDATE;
+			        break;
+			      case PT_SYS_DATETIME:
+			        default_expr_type = DB_DEFAULT_SYSDATETIME;
+			        break;
+			      case PT_SYS_TIME:
+			        default_expr_type = DB_DEFAULT_SYSTIME;
+			        break;
+			      default:
+			        PT_ERROR (this_parser, attr_node, "invalid expression type");
+			        break;
+			      }
 			  }
 			else
 			  {
-			PT_ERROR (this_parser, attr_node, "on update must be an expression");
+			    PT_ERROR (this_parser, attr_node, "on update must be an expression");
 			  }
 			
 			attr_node->info.attr_def.on_update = default_expr_type;

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -49,7 +49,7 @@
 #define pt_cat_error(parser, node, setNo, msgNo, ...) \
     pt_frob_error(parser, node, msgcat_message(MSGCAT_CATALOG_CUBRID, setNo, msgNo), ##__VA_ARGS__)
 
-#if 1 //not necessary anymore thanks to new pt_cat_error() and existing pt_frob_error()
+#if 1				//not necessary anymore thanks to new pt_cat_error() and existing pt_frob_error()
 #define PT_ERROR(parser, node, msg) pt_frob_error(parser, node, msg)
 #define PT_ERRORc(parser, node, msg) pt_frob_error( parser, node, "%s", msg)
 
@@ -71,7 +71,7 @@
 #define pt_cat_warning(parser, node, setNo, msgNo, ...) \
     pt_frob_warning(parser, node, msgcat_message(MSGCAT_CATALOG_CUBRID, setNo, msgNo), ##__VA_ARGS__)
 
-#if 1 //not necessary anymore thanks to pt_cat_warning() and existing pt_frob_warning()
+#if 1				//not necessary anymore thanks to pt_cat_warning() and existing pt_frob_warning()
 #define PT_WARNING( parser, node, msg ) pt_frob_warning(parser, node, msg)
 #define PT_WARNINGm(parser, node, setNo, msgNo) pt_cat_warning(parser, node, setNo, msgNo)
 #define PT_WARNINGc( parser, node, msg ) pt_frob_warning(parser, node, msg)
@@ -1885,7 +1885,7 @@ struct pt_attr_def_info
 {
   PT_NODE *attr_name;		/* PT_NAME */
   PT_NODE *data_default;	/* PT_DATA_DEFAULT */
-  PT_NODE *on_update;
+  DB_DEFAULT_EXPR_TYPE on_update;
   PT_NODE *auto_increment;	/* PT_AUTO_INCREMENT */
   PT_NODE *ordering_info;	/* PT_ATTR_ORDERING */
   PT_NODE *comment;		/* PT_VALUE */

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -868,7 +868,6 @@ enum pt_node_type
   PT_CONSTRAINT,
   PT_CTE,
   PT_DATA_DEFAULT,
-  PT_ON_UPDATE,
   PT_DATA_TYPE,
   PT_DOT_,
   PT_EVENT_OBJECT,
@@ -1595,7 +1594,6 @@ typedef struct pt_cte_info PT_CTE_INFO;
 typedef struct pt_serial_info PT_SERIAL_INFO;
 typedef struct pt_data_default_info PT_DATA_DEFAULT_INFO;
 typedef struct pt_auto_increment_info PT_AUTO_INCREMENT_INFO;
-typedef struct pt_data_on_update_info PT_ON_UPDATE_INFO;
 typedef struct pt_partition_info PT_PARTITION_INFO;
 typedef struct pt_parts_info PT_PARTS_INFO;
 typedef struct pt_data_type_info PT_DATA_TYPE_INFO;
@@ -2029,12 +2027,6 @@ struct pt_data_default_info
 {
   PT_NODE *default_value;	/* PT_VALUE (list) */
   PT_MISC_TYPE shared;		/* will PT_SHARED or PT_DEFAULT */
-  DB_DEFAULT_EXPR_TYPE default_expr_type;	/* if it is a pseudocolumn, do not evaluate expr */
-};
-
-struct pt_data_on_update_info
-{
-  PT_NODE *default_value;
   DB_DEFAULT_EXPR_TYPE default_expr_type;	/* if it is a pseudocolumn, do not evaluate expr */
 };
 
@@ -3319,7 +3311,6 @@ union pt_statement_info
   PT_NAME_INFO name;
   PT_NAMED_ARG_INFO named_arg;
   PT_NODE_LIST_INFO node_list;
-  PT_ON_UPDATE_INFO on_update;
   PT_PARTITION_INFO partition;
   PT_PARTS_INFO parts;
   PT_PREPARE_INFO prepare;

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -6611,7 +6611,6 @@ pt_apply_attr_def (PARSER_CONTEXT * parser, PT_NODE * p, PT_NODE_FUNCTION g, voi
 {
   p->info.attr_def.attr_name = g (parser, p->info.attr_def.attr_name, arg);
   p->info.attr_def.data_default = g (parser, p->info.attr_def.data_default, arg);
-  p->info.attr_def.on_update = g (parser, p->info.attr_def.on_update, arg);
   p->info.attr_def.auto_increment = g (parser, p->info.attr_def.auto_increment, arg);
   p->info.attr_def.ordering_info = g (parser, p->info.attr_def.ordering_info, arg);
   return p;

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -297,7 +297,6 @@ static PT_NODE *pt_init_create_index (PT_NODE * p);
 static PT_NODE *pt_init_create_user (PT_NODE * p);
 static PT_NODE *pt_init_data_default (PT_NODE * p);
 static PT_NODE *pt_init_datatype (PT_NODE * p);
-static PT_NODE *pt_init_on_update (PT_NODE * p);
 static PT_NODE *pt_init_delete (PT_NODE * p);
 static PT_NODE *pt_init_difference (PT_NODE * p);
 static PT_NODE *pt_init_dot (PT_NODE * p);
@@ -374,7 +373,6 @@ static PARSER_VARCHAR *pt_print_create_stored_procedure (PARSER_CONTEXT * parser
 static PARSER_VARCHAR *pt_print_create_trigger (PARSER_CONTEXT * parser, PT_NODE * p);
 static PARSER_VARCHAR *pt_print_create_user (PARSER_CONTEXT * parser, PT_NODE * p);
 static PARSER_VARCHAR *pt_print_data_default (PARSER_CONTEXT * parser, PT_NODE * p);
-static PARSER_VARCHAR *pt_print_on_update (PARSER_CONTEXT * parser, PT_NODE * p);
 static PARSER_VARCHAR *pt_print_datatype (PARSER_CONTEXT * parser, PT_NODE * p);
 static PARSER_VARCHAR *pt_print_delete (PARSER_CONTEXT * parser, PT_NODE * p);
 static PARSER_VARCHAR *pt_print_difference (PARSER_CONTEXT * parser, PT_NODE * p);

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -6782,7 +6782,7 @@ pt_print_attr_def (PARSER_CONTEXT * parser, PT_NODE * p)
   if (p->info.attr_def.on_update != DB_DEFAULT_NONE)
     {
       const char *c = db_default_expression_string (p->info.attr_def.on_update);
-      q = pt_append_nulstring (parser, q, " ");
+      q = pt_append_nulstring (parser, q, " on update ");
       q = pt_append_nulstring (parser, q, c);
       q = pt_append_nulstring (parser, q, " ");
     }

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -643,7 +643,8 @@ extern "C"
 						  int *continue_walk);
   extern void pt_get_default_expression_from_data_default_node (PARSER_CONTEXT * parser, PT_NODE * data_default_node,
 								DB_DEFAULT_EXPR * default_expr);
-  extern void pt_get_default_expression_from_on_update_node (PARSER_CONTEXT * parser, PT_NODE * data_default_node,
+  extern void pt_get_default_expression_from_on_update_node (PARSER_CONTEXT * parser,
+							     DB_DEFAULT_EXPR_TYPE data_default_node,
 							     DB_DEFAULT_EXPR * default_expr);
 #ifdef __cplusplus
 }

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -643,9 +643,6 @@ extern "C"
 						  int *continue_walk);
   extern void pt_get_default_expression_from_data_default_node (PARSER_CONTEXT * parser, PT_NODE * data_default_node,
 								DB_DEFAULT_EXPR * default_expr);
-  extern void pt_get_default_expression_from_on_update_node (PARSER_CONTEXT * parser,
-							     DB_DEFAULT_EXPR_TYPE data_default_node,
-							     DB_DEFAULT_EXPR * default_expr);
 #ifdef __cplusplus
 }
 #endif

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12065,15 +12065,11 @@ pt_get_default_expression_from_data_default_node (PARSER_CONTEXT * parser, PT_NO
  * default_expr (out)	  : default expression
  */
 void
-pt_get_default_expression_from_on_update_node (PARSER_CONTEXT * parser, PT_NODE * on_update_node,
+pt_get_default_expression_from_on_update_node (PARSER_CONTEXT * parser, DB_DEFAULT_EXPR_TYPE on_update_node,
 					       DB_DEFAULT_EXPR * default_expr)
 {
   assert (parser != NULL && default_expr != NULL);
 
   classobj_initialize_default_expr (default_expr);
-  if (on_update_node != NULL)
-    {
-      assert (on_update_node->node_type == PT_ON_UPDATE);
-      default_expr->default_expr_type = on_update_node->info.on_update.default_expr_type;
-    }
+  default_expr->default_expr_type = on_update_node;
 }

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12057,13 +12057,13 @@ pt_get_default_expression_from_data_default_node (PARSER_CONTEXT * parser, PT_NO
 }
 
 /*
-* pt_get_default_expression_from_on_update_node () - get default expression from on_update node
-* return : error code or NO_ERROR
-*
-* parser (in)		  : parser context
-* on_update_node (in)     : attribute node
-* default_expr (out)	  : default expression
-*/
+ * pt_get_default_expression_from_on_update_node () - get default expression from on_update node
+ * return : error code or NO_ERROR
+ *
+ * parser (in)		  : parser context
+ * on_update_node (in)    : attribute node
+ * default_expr (out)	  : default expression
+ */
 void
 pt_get_default_expression_from_on_update_node (PARSER_CONTEXT * parser, PT_NODE * on_update_node,
 					       DB_DEFAULT_EXPR * default_expr)

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12055,21 +12055,3 @@ pt_get_default_expression_from_data_default_node (PARSER_CONTEXT * parser, PT_NO
 	}
     }
 }
-
-/*
- * pt_get_default_expression_from_on_update_node () - get default expression from on_update node
- * return : error code or NO_ERROR
- *
- * parser (in)		  : parser context
- * on_update_node (in)    : attribute node
- * default_expr (out)	  : default expression
- */
-void
-pt_get_default_expression_from_on_update_node (PARSER_CONTEXT * parser, DB_DEFAULT_EXPR_TYPE on_update_node,
-					       DB_DEFAULT_EXPR * default_expr)
-{
-  assert (parser != NULL && default_expr != NULL);
-
-  classobj_initialize_default_expr (default_expr);
-  default_expr->default_expr_type = on_update_node;
-}

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7740,36 +7740,38 @@ pt_check_default_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_N
   int flag = 0;
   bool has_user_format;
 
-  /* Import default value and on update default expr from referenced table for those attributes in the the view that don't have them. */
+  /* Import default value and on update default expr from referenced table 
+   * for those attributes in the the view that don't have them. */
   for (attr = attrs, col = columns; attr && col; attr = attr->next, col = col->next)
     {
-      if (!attr->info.attr_def.data_default || attr->info.attr_def.on_update == DB_DEFAULT_NONE)
+      if (attr->info.attr_def.data_default != NULL && attr->info.attr_def.on_update != DB_DEFAULT_NONE)
 	{
-	  if (col->node_type != PT_NAME)
-	    {
-	      continue;
-	    }
-	  /* found matching column */
-	  if (col->info.name.spec_id == 0)
-	    {
-	      continue;
-	    }
-	  spec = (PT_NODE *) col->info.name.spec_id;
-	  entity_name = spec->info.spec.entity_name;
-	  if (entity_name == NULL || !PT_IS_NAME_NODE (entity_name))
-	    {
-	      continue;
-	    }
-	  obj = entity_name->info.name.db_object;
-	  if (!obj)
-	    {
-	      continue;
-	    }
-	  col_attr = db_get_attribute_force (obj, col->info.name.original);
-	  if (!col_attr)
-	    {
-	      continue;
-	    }
+	  /* default values are overwritten */
+	  continue;
+	}
+      if (col->node_type != PT_NAME)
+	{
+	  continue;
+	}
+      if (col->info.name.spec_id == 0)
+	{
+	  continue;
+	}
+      spec = (PT_NODE *) col->info.name.spec_id;
+      entity_name = spec->info.spec.entity_name;
+      if (entity_name == NULL || !PT_IS_NAME_NODE (entity_name))
+	{
+	  continue;
+	}
+      obj = entity_name->info.name.db_object;
+      if (!obj)
+	{
+	  continue;
+	}
+      col_attr = db_get_attribute_force (obj, col->info.name.original);
+      if (!col_attr)
+	{
+	  continue;
 	}
 
       if (attr->info.attr_def.on_update == DB_DEFAULT_NONE)

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7719,12 +7719,9 @@ pt_type_cast_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_NODE 
  * copy the default values from the original table
  *
  * NOTE: there are two ways attrs is constructed at this point:
- *  - stmt: create view (attr_list) as select... and the attrs will be created
- * directly from the statement
- *  - stmt: create view as select... and the attrs will be created from the
- * query's select list
- * In both cases, each attribute in attrs will correspond to the column in the
- * select list at the same index
+ *  - stmt: create view (attr_list) as select... and the attrs will be created directly from the statement
+ *  - stmt: create view as select... and the attrs will be created from the query's select list
+ * In both cases, each attribute in attrs will correspond to the column in the select list at the same index
  */
 static PT_NODE *
 pt_check_default_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_NODE * attrs)
@@ -7757,19 +7754,22 @@ pt_check_default_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_N
 	{
 	  continue;
 	}
+
       spec = (PT_NODE *) col->info.name.spec_id;
       entity_name = spec->info.spec.entity_name;
       if (entity_name == NULL || !PT_IS_NAME_NODE (entity_name))
 	{
 	  continue;
 	}
+
       obj = entity_name->info.name.db_object;
-      if (!obj)
+      if (obj == NULL)
 	{
 	  continue;
 	}
+
       col_attr = db_get_attribute_force (obj, col->info.name.original);
-      if (!col_attr)
+      if (col_attr == NULL)
 	{
 	  continue;
 	}
@@ -7779,7 +7779,7 @@ pt_check_default_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_N
 	  attr->info.attr_def.on_update = col_attr->on_update_default_expr;
 	}
 
-      if (!attr->info.attr_def.data_default)
+      if (attr->info.attr_def.data_default == NULL)
 	{
 	  if (DB_IS_NULL (&col_attr->default_value.value)
 	      && (col_attr->default_value.default_expr.default_expr_type == DB_DEFAULT_NONE))
@@ -7792,14 +7792,14 @@ pt_check_default_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_N
 	  if (col_attr->default_value.default_expr.default_expr_type == DB_DEFAULT_NONE)
 	    {
 	      default_value = pt_dbval_to_value (parser, &col_attr->default_value.value);
-	      if (!default_value)
+	      if (default_value == NULL)
 		{
 		  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
 		  goto error;
 		}
 
 	      default_data = parser_new_node (parser, PT_DATA_DEFAULT);
-	      if (!default_data)
+	      if (default_data == NULL)
 		{
 		  parser_free_tree (parser, default_value);
 		  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
@@ -7812,68 +7812,69 @@ pt_check_default_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_N
 	  else
 	    {
 	      default_op_value = parser_new_node (parser, PT_EXPR);
-	      if (default_op_value != NULL)
-		{
-		  default_op_value->info.expr.op =
-		    pt_op_type_from_default_expr_type (col_attr->default_value.default_expr.default_expr_type);
-
-		  if (col_attr->default_value.default_expr.default_expr_op != T_TO_CHAR)
-		    {
-		      default_value = default_op_value;
-		    }
-		  else
-		    {
-		      PT_NODE *arg1, *arg2, *arg3;
-		      arg1 = default_op_value;
-		      has_user_format = col_attr->default_value.default_expr.default_expr_format ? 1 : 0;
-		      arg2 = pt_make_string_value (parser, col_attr->default_value.default_expr.default_expr_format);
-		      if (arg2 == NULL)
-			{
-			  parser_free_tree (parser, default_op_value);
-			  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
-			  goto error;
-			}
-
-		      arg3 = parser_new_node (parser, PT_VALUE);
-		      if (arg3 == NULL)
-			{
-			  parser_free_tree (parser, default_op_value);
-			  parser_free_tree (parser, arg2);
-			}
-		      arg3->type_enum = PT_TYPE_INTEGER;
-		      lang_str = prm_get_string_value (PRM_ID_INTL_DATE_LANG);
-		      lang_set_flag_from_lang (lang_str, has_user_format, 0, &flag);
-		      arg3->info.value.data_value.i = (long) flag;
-
-		      default_value = parser_make_expression (parser, PT_TO_CHAR, arg1, arg2, arg3);
-		      if (default_value == NULL)
-			{
-			  parser_free_tree (parser, default_op_value);
-			  parser_free_tree (parser, arg2);
-			  parser_free_tree (parser, arg3);
-			  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
-			  goto error;
-			}
-		    }
-		}
-	      else
+	      if (default_op_value == NULL)
 		{
 		  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
 		  goto error;
 		}
 
+	      default_op_value->info.expr.op =
+		pt_op_type_from_default_expr_type (col_attr->default_value.default_expr.default_expr_type);
+
+	      if (col_attr->default_value.default_expr.default_expr_op != T_TO_CHAR)
+		{
+		  default_value = default_op_value;
+		}
+	      else
+		{
+		  PT_NODE *arg1, *arg2, *arg3;
+
+		  arg1 = default_op_value;
+		  has_user_format = col_attr->default_value.default_expr.default_expr_format ? 1 : 0;
+		  arg2 = pt_make_string_value (parser, col_attr->default_value.default_expr.default_expr_format);
+		  if (arg2 == NULL)
+		    {
+		      parser_free_tree (parser, default_op_value);
+		      PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+		      goto error;
+		    }
+
+		  arg3 = parser_new_node (parser, PT_VALUE);
+		  if (arg3 == NULL)
+		    {
+		      parser_free_tree (parser, default_op_value);
+		      parser_free_tree (parser, arg2);
+		    }
+		  arg3->type_enum = PT_TYPE_INTEGER;
+		  lang_str = prm_get_string_value (PRM_ID_INTL_DATE_LANG);
+		  lang_set_flag_from_lang (lang_str, has_user_format, 0, &flag);
+		  arg3->info.value.data_value.i = (long) flag;
+
+		  default_value = parser_make_expression (parser, PT_TO_CHAR, arg1, arg2, arg3);
+		  if (default_value == NULL)
+		    {
+		      parser_free_tree (parser, default_op_value);
+		      parser_free_tree (parser, arg2);
+		      parser_free_tree (parser, arg3);
+		      PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+		      goto error;
+		    }
+		}
+
 	      default_data = parser_new_node (parser, PT_DATA_DEFAULT);
-	      if (!default_data)
+	      if (default_data == NULL)
 		{
 		  parser_free_tree (parser, default_value);
 		  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
 		  goto error;
 		}
+
 	      default_data->info.data_default.default_value = default_value;
 	      default_data->info.data_default.shared = PT_DEFAULT;
 	      default_data->info.data_default.default_expr_type =
 		col_attr->default_value.default_expr.default_expr_type;
 	    }
+
 	  attr->info.attr_def.data_default = default_data;
 	}
     }

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7733,7 +7733,6 @@ pt_check_default_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_N
   PT_NODE *columns = pt_get_select_list (parser, qry);
   PT_NODE *default_data = NULL;
   PT_NODE *default_value = NULL, *default_op_value = NULL;
-  PT_NODE *on_update_default_expr;
   PT_NODE *spec, *entity_name;
   DB_OBJECT *obj;
   DB_ATTRIBUTE *col_attr;
@@ -7867,7 +7866,7 @@ pt_check_default_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_N
 	      attr->info.attr_def.data_default = default_data;
 	    }
 	}
-      attr->info.attr_def.on_update = col_attr->on_update_default_expr.default_expr_type;
+      attr->info.attr_def.on_update = col_attr->on_update_default_expr;
     }
 
   return attrs;

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7743,9 +7743,12 @@ pt_check_default_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_N
   /* Import default value and on update default expr from referenced table for those attributes in the the view that don't have them. */
   for (attr = attrs, col = columns; attr && col; attr = attr->next, col = col->next)
     {
-      if ((!attr->info.attr_def.data_default || attr->info.attr_def.on_update == DB_DEFAULT_NONE)
-	  && col->node_type == PT_NAME)
+      if (!attr->info.attr_def.data_default || attr->info.attr_def.on_update == DB_DEFAULT_NONE)
 	{
+	  if (col->node_type != PT_NAME)
+	    {
+	      continue;
+	    }
 	  /* found matching column */
 	  if (col->info.name.spec_id == 0)
 	    {

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7743,130 +7743,134 @@ pt_check_default_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_N
   /* Import default value and on update default expr from referenced table for those attributes in the the view that don't have them. */
   for (attr = attrs, col = columns; attr && col; attr = attr->next, col = col->next)
     {
+      if ((!attr->info.attr_def.data_default || attr->info.attr_def.on_update == DB_DEFAULT_NONE)
+	  && col->node_type == PT_NAME)
+	{
+	  /* found matching column */
+	  if (col->info.name.spec_id == 0)
+	    {
+	      continue;
+	    }
+	  spec = (PT_NODE *) col->info.name.spec_id;
+	  entity_name = spec->info.spec.entity_name;
+	  if (entity_name == NULL || !PT_IS_NAME_NODE (entity_name))
+	    {
+	      continue;
+	    }
+	  obj = entity_name->info.name.db_object;
+	  if (!obj)
+	    {
+	      continue;
+	    }
+	  col_attr = db_get_attribute_force (obj, col->info.name.original);
+	  if (!col_attr)
+	    {
+	      continue;
+	    }
+	}
+
+      if (attr->info.attr_def.on_update == DB_DEFAULT_NONE)
+	{
+	  attr->info.attr_def.on_update = col_attr->on_update_default_expr;
+	}
+
       if (!attr->info.attr_def.data_default)
 	{
-	  if (col->node_type == PT_NAME)
+	  if (DB_IS_NULL (&col_attr->default_value.value)
+	      && (col_attr->default_value.default_expr.default_expr_type == DB_DEFAULT_NONE))
 	    {
-	      /* found matching column */
-	      if (col->info.name.spec_id == 0)
+	      /* don't create any default node if default value is null unless default expression type is not
+	       * DB_DEFAULT_NONE */
+	      continue;
+	    }
+
+	  if (col_attr->default_value.default_expr.default_expr_type == DB_DEFAULT_NONE)
+	    {
+	      default_value = pt_dbval_to_value (parser, &col_attr->default_value.value);
+	      if (!default_value)
 		{
-		  continue;
-		}
-	      spec = (PT_NODE *) col->info.name.spec_id;
-	      entity_name = spec->info.spec.entity_name;
-	      if (entity_name == NULL || !PT_IS_NAME_NODE (entity_name))
-		{
-		  continue;
-		}
-	      obj = entity_name->info.name.db_object;
-	      if (!obj)
-		{
-		  continue;
-		}
-	      col_attr = db_get_attribute_force (obj, col->info.name.original);
-	      if (!col_attr)
-		{
-		  continue;
+		  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+		  goto error;
 		}
 
-	      if (DB_IS_NULL (&col_attr->default_value.value)
-		  && (col_attr->default_value.default_expr.default_expr_type == DB_DEFAULT_NONE))
+	      default_data = parser_new_node (parser, PT_DATA_DEFAULT);
+	      if (!default_data)
 		{
-		  /* don't create any default node if default value is null unless default expression type is not
-		   * DB_DEFAULT_NONE */
-		  continue;
+		  parser_free_tree (parser, default_value);
+		  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+		  goto error;
 		}
-
-	      if (col_attr->default_value.default_expr.default_expr_type == DB_DEFAULT_NONE)
+	      default_data->info.data_default.default_value = default_value;
+	      default_data->info.data_default.shared = PT_DEFAULT;
+	      default_data->info.data_default.default_expr_type = DB_DEFAULT_NONE;
+	    }
+	  else
+	    {
+	      default_op_value = parser_new_node (parser, PT_EXPR);
+	      if (default_op_value != NULL)
 		{
-		  default_value = pt_dbval_to_value (parser, &col_attr->default_value.value);
-		  if (!default_value)
+		  default_op_value->info.expr.op =
+		    pt_op_type_from_default_expr_type (col_attr->default_value.default_expr.default_expr_type);
+
+		  if (col_attr->default_value.default_expr.default_expr_op != T_TO_CHAR)
 		    {
-		      PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
-		      goto error;
-		    }
-
-		  default_data = parser_new_node (parser, PT_DATA_DEFAULT);
-		  if (!default_data)
-		    {
-		      parser_free_tree (parser, default_value);
-		      PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
-		      goto error;
-		    }
-		  default_data->info.data_default.default_value = default_value;
-		  default_data->info.data_default.shared = PT_DEFAULT;
-		  default_data->info.data_default.default_expr_type = DB_DEFAULT_NONE;
-		}
-	      else
-		{
-		  default_op_value = parser_new_node (parser, PT_EXPR);
-		  if (default_op_value != NULL)
-		    {
-		      default_op_value->info.expr.op =
-			pt_op_type_from_default_expr_type (col_attr->default_value.default_expr.default_expr_type);
-
-		      if (col_attr->default_value.default_expr.default_expr_op != T_TO_CHAR)
-			{
-			  default_value = default_op_value;
-			}
-		      else
-			{
-			  PT_NODE *arg1, *arg2, *arg3;
-			  arg1 = default_op_value;
-			  has_user_format = col_attr->default_value.default_expr.default_expr_format ? 1 : 0;
-			  arg2 = pt_make_string_value (parser,
-						       col_attr->default_value.default_expr.default_expr_format);
-			  if (arg2 == NULL)
-			    {
-			      parser_free_tree (parser, default_op_value);
-			      PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
-			      goto error;
-			    }
-
-			  arg3 = parser_new_node (parser, PT_VALUE);
-			  if (arg3 == NULL)
-			    {
-			      parser_free_tree (parser, default_op_value);
-			      parser_free_tree (parser, arg2);
-			    }
-			  arg3->type_enum = PT_TYPE_INTEGER;
-			  lang_str = prm_get_string_value (PRM_ID_INTL_DATE_LANG);
-			  lang_set_flag_from_lang (lang_str, has_user_format, 0, &flag);
-			  arg3->info.value.data_value.i = (long) flag;
-
-			  default_value = parser_make_expression (parser, PT_TO_CHAR, arg1, arg2, arg3);
-			  if (default_value == NULL)
-			    {
-			      parser_free_tree (parser, default_op_value);
-			      parser_free_tree (parser, arg2);
-			      parser_free_tree (parser, arg3);
-			      PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
-			      goto error;
-			    }
-			}
+		      default_value = default_op_value;
 		    }
 		  else
 		    {
-		      PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
-		      goto error;
-		    }
+		      PT_NODE *arg1, *arg2, *arg3;
+		      arg1 = default_op_value;
+		      has_user_format = col_attr->default_value.default_expr.default_expr_format ? 1 : 0;
+		      arg2 = pt_make_string_value (parser, col_attr->default_value.default_expr.default_expr_format);
+		      if (arg2 == NULL)
+			{
+			  parser_free_tree (parser, default_op_value);
+			  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+			  goto error;
+			}
 
-		  default_data = parser_new_node (parser, PT_DATA_DEFAULT);
-		  if (!default_data)
-		    {
-		      parser_free_tree (parser, default_value);
-		      PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
-		      goto error;
+		      arg3 = parser_new_node (parser, PT_VALUE);
+		      if (arg3 == NULL)
+			{
+			  parser_free_tree (parser, default_op_value);
+			  parser_free_tree (parser, arg2);
+			}
+		      arg3->type_enum = PT_TYPE_INTEGER;
+		      lang_str = prm_get_string_value (PRM_ID_INTL_DATE_LANG);
+		      lang_set_flag_from_lang (lang_str, has_user_format, 0, &flag);
+		      arg3->info.value.data_value.i = (long) flag;
+
+		      default_value = parser_make_expression (parser, PT_TO_CHAR, arg1, arg2, arg3);
+		      if (default_value == NULL)
+			{
+			  parser_free_tree (parser, default_op_value);
+			  parser_free_tree (parser, arg2);
+			  parser_free_tree (parser, arg3);
+			  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+			  goto error;
+			}
 		    }
-		  default_data->info.data_default.default_value = default_value;
-		  default_data->info.data_default.shared = PT_DEFAULT;
-		  default_data->info.data_default.default_expr_type =
-		    col_attr->default_value.default_expr.default_expr_type;
 		}
-	      attr->info.attr_def.data_default = default_data;
+	      else
+		{
+		  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+		  goto error;
+		}
+
+	      default_data = parser_new_node (parser, PT_DATA_DEFAULT);
+	      if (!default_data)
+		{
+		  parser_free_tree (parser, default_value);
+		  PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+		  goto error;
+		}
+	      default_data->info.data_default.default_value = default_value;
+	      default_data->info.data_default.shared = PT_DEFAULT;
+	      default_data->info.data_default.default_expr_type =
+		col_attr->default_value.default_expr.default_expr_type;
 	    }
+	  attr->info.attr_def.data_default = default_data;
 	}
-      attr->info.attr_def.on_update = col_attr->on_update_default_expr;
     }
 
   return attrs;

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7867,19 +7867,7 @@ pt_check_default_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_N
 	      attr->info.attr_def.data_default = default_data;
 	    }
 	}
-
-      if (!attr->info.attr_def.on_update)
-	{
-	  on_update_default_expr = parser_new_node (parser, PT_ON_UPDATE);
-	  if (!on_update_default_expr)
-	    {
-	      parser_free_tree (parser, on_update_default_expr);
-	      PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
-	      goto error;
-	    }
-	  on_update_default_expr->info.on_update.default_expr_type = col_attr->on_update_default_expr.default_expr_type;
-	  attr->info.attr_def.on_update = on_update_default_expr;
-	}
+      attr->info.attr_def.on_update = col_attr->on_update_default_expr.default_expr_type;
     }
 
   return attrs;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -286,7 +286,7 @@ static bool is_att_prop_set (const int prop, const int value);
 
 static int get_att_order_from_def (PT_NODE * attribute, bool * ord_first, const char **ord_after_name);
 
-static int check_on_update (PARSER_CONTEXT * parser, PT_NODE * attribute);
+static int check_default_on_update_clause (PARSER_CONTEXT * parser, PT_NODE * attribute);
 
 static int get_att_default_from_def (PARSER_CONTEXT * parser, PT_NODE * attribute, DB_VALUE ** default_value,
 				     const char *classname);
@@ -7009,7 +7009,7 @@ do_add_attribute (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * attri
       goto error_exit;
     }
 
-  error = check_on_update (parser, attribute);
+  error = check_default_on_update_clause (parser, attribute);
   if (error != NO_ERROR)
     {
       goto error_exit;
@@ -10092,7 +10092,7 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
 	      || is_att_prop_set (attr_chg_prop->p[P_TYPE], ATT_CHG_TYPE_PSEUDO_UPGRADE));
     }
 
-  error = check_on_update (parser, attribute);
+  error = check_default_on_update_clause (parser, attribute);
   if (error != NO_ERROR)
     {
       goto exit;
@@ -12429,7 +12429,7 @@ get_att_order_from_def (PT_NODE * attribute, bool * ord_first, const char **ord_
 }
 
 static int
-check_on_update (PARSER_CONTEXT * parser, PT_NODE * attribute)
+check_default_on_update_clause (PARSER_CONTEXT * parser, PT_NODE * attribute)
 {
   int error = NO_ERROR;
   PT_TYPE_ENUM desired_type = attribute->type_enum;
@@ -12451,7 +12451,17 @@ check_on_update (PARSER_CONTEXT * parser, PT_NODE * attribute)
     }
 
   on_update_default_expr = pt_semantic_type (parser, on_update_default_expr, NULL);
+  if (on_update_default_expr == NULL)
+    {
+      return ER_FAILED;
+    }
+
   on_update_default_expr = pt_semantic_check (parser, on_update_default_expr);
+  if (on_update_default_expr == NULL)
+    {
+      return ER_FAILED;
+    }
+
   on_update_default_expr->buffer_pos = attribute->buffer_pos;
   on_update_default_expr->line_number = attribute->line_number;
   on_update_default_expr->column_number = attribute->column_number;
@@ -12466,7 +12476,7 @@ check_on_update (PARSER_CONTEXT * parser, PT_NODE * attribute)
       pt_report_to_ersys (parser, PT_SEMANTIC);
       error = er_errid ();
 
-      db_value_clear (&on_update_val);
+      pr_clear_value (&on_update_val);
       if (on_update_default_expr != NULL)
 	{
 	  parser_free_node (parser, on_update_default_expr);
@@ -12507,7 +12517,7 @@ check_on_update (PARSER_CONTEXT * parser, PT_NODE * attribute)
 	}
     }
 
-  db_value_clear (&on_update_val);
+  pr_clear_value (&on_update_val);
   if (temp_ptval != NULL)
     {
       parser_free_node (parser, temp_ptval);
@@ -13422,7 +13432,7 @@ check_change_attribute (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE *
       attr_chg_prop->class_has_subclass = true;
     }
 
-  error = check_on_update (parser, attribute);
+  error = check_default_on_update_clause (parser, attribute);
   if (error != NO_ERROR)
     {
       goto exit;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -6910,8 +6910,7 @@ get_attr_name (PT_NODE * attribute)
  *   ctemplate(in/out): Class template
  *   attribute(in/out): Attribute to add
  *   constraints(in/out): the constraints of the class
- *   error_on_not_normal(in): whether to flag an error on class and shared
- *                            attributes or not
+ *   error_on_not_normal(in): whether to flag an error on class and shared attributes or not
  *
  * Note : The class object is modified
  */
@@ -7030,9 +7029,8 @@ do_add_attribute (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * attri
   pt_get_default_expression_from_data_default_node (parser, attribute->info.attr_def.data_default, &default_expr);
   default_value = &stack_value;
 
-  error =
-    smt_add_attribute_w_dflt_w_order (ctemplate, attr_name, NULL, attr_db_domain, default_value, name_space, add_first,
-				      add_after_attr, &default_expr, &on_update_expr, NULL);
+  error = smt_add_attribute_w_dflt_w_order (ctemplate, attr_name, NULL, attr_db_domain, default_value, name_space,
+					    add_first, add_after_attr, &default_expr, &on_update_expr, NULL);
 
   db_value_clear (&stack_value);
 
@@ -7154,8 +7152,8 @@ do_add_attribute_from_select_column (PARSER_CONTEXT * parser, DB_CTMPL * ctempla
 	  goto error_exit;
 	}
 
-      error =
-	sm_att_default_value (class_obj, column->attr_name, &default_value, &default_expr, &on_update_default_expr);
+      error = sm_att_default_value (class_obj, column->attr_name, &default_value, &default_expr,
+				    &on_update_default_expr);
       if (error != NO_ERROR)
 	{
 	  goto error_exit;
@@ -10112,10 +10110,9 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
       goto exit;
     }
 
-  error =
-    smt_change_attribute_w_dflt_w_order (ctemplate, attr_name, new_name, NULL, attr_db_domain,
-					 attr_chg_prop->name_space, new_default, &new_default_expr, &new_on_update_expr,
-					 change_first, change_after_attr, &found_att);
+  error = smt_change_attribute_w_dflt_w_order (ctemplate, attr_name, new_name, NULL, attr_db_domain,
+					       attr_chg_prop->name_space, new_default, &new_default_expr,
+					       &new_on_update_expr, change_first, change_after_attr, &found_att);
   if (error != NO_ERROR)
     {
       goto exit;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10093,6 +10093,12 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
 	      || is_att_prop_set (attr_chg_prop->p[P_TYPE], ATT_CHG_TYPE_PSEUDO_UPGRADE));
     }
 
+  error = check_on_update (parser, attribute, NULL);
+  if (error != NO_ERROR)
+    {
+      goto exit;
+    }
+
   /* default value: for CLASS and SHARED attributes this changes the value itself of the atribute */
   error = get_att_default_from_def (parser, attribute, &default_value, NULL);
   if (error != NO_ERROR)
@@ -12010,7 +12016,6 @@ build_att_coll_change_map (TP_DOMAIN * curr_domain, TP_DOMAIN * req_domain, SM_A
 static int
 check_att_chg_allowed (const char *att_name, const PT_TYPE_ENUM t, const SM_ATTR_PROP_CHG * attr_chg_prop,
 		       SM_ATTR_CHG_SOL chg_how, bool log_error_allowed, bool * new_attempt)
-  //TODO: check on update somehow too !
 {
   int error = NO_ERROR;
 
@@ -12437,7 +12442,7 @@ check_on_update (PARSER_CONTEXT * parser, PT_NODE * attribute, const char *class
     }
 
   PT_OP_TYPE op = pt_op_type_from_default_expr_type (on_update_expr_type);
-  PT_NODE *on_update_default_expr = NULL;	// parser_make_expression(parser, op, NULL, NULL, NULL);
+  PT_NODE *on_update_default_expr = parser_make_expression (parser, op, NULL, NULL, NULL);
   if (on_update_default_expr == NULL)
     {
       PT_ERRORm (parser, attribute, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
@@ -13404,6 +13409,12 @@ check_change_attribute (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE *
   if (ctemplate->current->users != NULL && ctemplate->partition == NULL)
     {
       attr_chg_prop->class_has_subclass = true;
+    }
+
+  error = check_on_update (parser, attribute, NULL);
+  if (error != NO_ERROR)
+    {
+      goto exit;
     }
 
   error = get_att_default_from_def (parser, attribute, &ptr_def, NULL);

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -6925,6 +6925,7 @@ do_add_attribute (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * attri
   int meta, shared;
   DB_VALUE stack_value;
   DB_VALUE *default_value = &stack_value;
+  DB_DEFAULT_EXPR_TYPE on_update_expr = DB_DEFAULT_NONE;
   int error = NO_ERROR;
   TP_DOMAIN *attr_db_domain;
   MOP auto_increment_obj = NULL;
@@ -7033,7 +7034,7 @@ do_add_attribute (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * attri
       name_space = ID_ATTRIBUTE;
     }
 
-  DB_DEFAULT_EXPR_TYPE on_update_expr = attribute->info.attr_def.on_update;
+  on_update_expr = attribute->info.attr_def.on_update;
   pt_get_default_expression_from_data_default_node (parser, attribute->info.attr_def.data_default, &default_expr);
   default_value = &stack_value;
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -22787,16 +22787,20 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 
 	      /* add whitespace character if saved is not an empty string */
 	      const char *on_update_string = "ON UPDATE ";
-	      char *str_val = (char *) db_private_alloc (thread_p,
-							 len + (len ? 1 : 0) + strlen (on_update_string)
-							 + strlen (default_expr_op_string) + 1);
+	      size_t str_len = len + strlen (on_update_string) + strlen (default_expr_op_string) + 1;
+	      if (len != 0)
+		{
+		  str_len += 1;	// append space before
+		}
+	      char *str_val = (char *) db_private_alloc (thread_p, str_len);
+
 	      if (str_val == NULL)
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
 
 	      strcpy (str_val, saved);
-	      if (len)
+	      if (len != 0)
 		{
 		  strcat (str_val, " ");
 		}

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -22777,10 +22777,10 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  if (attrepr->on_update.default_expr_type != DB_DEFAULT_NONE)
 	    {
 	      char *saved = db_get_string (out_values[idx_val]);
-	      size_t len = strlen (saved);
+	      size_t len = saved ? strlen (saved) : 0;
 
 	      const char *default_expr_op_string = db_default_expression_string (attrepr->on_update.default_expr_type);
-	      if (!default_expr_op_string)
+	      if (default_expr_op_string == NULL)
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
@@ -22788,16 +22788,16 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	      /* add whitespace character if saved is not an empty string */
 	      const char *on_update_string = "ON_UPDATE ";
 	      char *str_val = (char *) db_private_alloc (thread_p,
-							 len + (len ? 1 : 0) + strlen (on_update_string) +
-							 strlen (default_expr_op_string) + 1);
-	      if (!str_val)
+							 (len + (len ? 1 : 0) + strlen (on_update_string)
+							  + strlen (default_expr_op_string) + 1));
+	      if (str_val == NULL)
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
 
-	      strcpy (str_val, saved);
-	      if (len)
+	      if (saved)
 		{
+		  strcpy (str_val, saved);
 		  strcat (str_val, " ");
 		}
 	      strcat (str_val, on_update_string);
@@ -22807,6 +22807,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 		{
 		  pr_clear_value (out_values[idx_val]);
 		  db_make_string (out_values[idx_val], str_val);
+		  out_values[idx_val]->need_clear = true;
 		}
 	    }
 	  idx_val++;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -22774,12 +22774,12 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	      db_make_string_by_const_str (out_values[idx_val], "auto_increment");
 	    }
 
-	  if (attrepr->on_update.default_expr_type != DB_DEFAULT_NONE)
+	  if (attrepr->on_update_expr != DB_DEFAULT_NONE)
 	    {
 	      char *saved = db_get_string (out_values[idx_val]);
 	      size_t len = strlen (saved);
 
-	      const char *default_expr_op_string = db_default_expression_string (attrepr->on_update.default_expr_type);
+	      const char *default_expr_op_string = db_default_expression_string (attrepr->on_update_expr);
 	      if (default_expr_op_string == NULL)
 		{
 		  GOTO_EXIT_ON_ERROR;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -22777,7 +22777,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  if (attrepr->on_update.default_expr_type != DB_DEFAULT_NONE)
 	    {
 	      char *saved = db_get_string (out_values[idx_val]);
-	      size_t len = saved ? strlen (saved) : 0;
+	      size_t len = strlen (saved);
 
 	      const char *default_expr_op_string = db_default_expression_string (attrepr->on_update.default_expr_type);
 	      if (default_expr_op_string == NULL)
@@ -22786,18 +22786,18 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 		}
 
 	      /* add whitespace character if saved is not an empty string */
-	      const char *on_update_string = "ON_UPDATE ";
+	      const char *on_update_string = "ON UPDATE ";
 	      char *str_val = (char *) db_private_alloc (thread_p,
-							 (len + (len ? 1 : 0) + strlen (on_update_string)
-							  + strlen (default_expr_op_string) + 1));
+							 len + (len ? 1 : 0) + strlen (on_update_string)
+							 + strlen (default_expr_op_string) + 1);
 	      if (str_val == NULL)
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
 
-	      if (saved)
+	      strcpy (str_val, saved);
+	      if (len)
 		{
-		  strcpy (str_val, saved);
 		  strcat (str_val, " ");
 		}
 	      strcat (str_val, on_update_string);

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -1373,6 +1373,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
     {
       size_t default_value_len = 0;
       char *default_str_val = NULL;
+
       if (classobj_get_prop (att_props, "default_expr", &default_expr) > 0)
 	{
 	  size_t len;
@@ -1407,12 +1408,10 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	      if (!db_value_is_null (&db_value_default_expr_format))
 		{
 #if !defined(NDEBUG)
-		  {
-		    DB_TYPE db_value_type_local = db_value_type (&db_value_default_expr_format);
-		    assert (db_value_type_local == DB_TYPE_NULL || db_value_type_local == DB_TYPE_CHAR
-			    || db_value_type_local == DB_TYPE_NCHAR || db_value_type_local == DB_TYPE_VARCHAR
-			    || db_value_type_local == DB_TYPE_VARNCHAR);
-		  }
+		  DB_TYPE db_value_type_local = db_value_type (&db_value_default_expr_format);
+		  assert (db_value_type_local == DB_TYPE_NULL || db_value_type_local == DB_TYPE_CHAR
+			  || db_value_type_local == DB_TYPE_NCHAR || db_value_type_local == DB_TYPE_VARCHAR
+			  || db_value_type_local == DB_TYPE_VARNCHAR);
 #endif
 		  assert (DB_VALUE_TYPE (&db_value_default_expr_format) == DB_TYPE_STRING);
 		  def_expr_format_string = db_get_string (&db_value_default_expr_format);
@@ -1440,9 +1439,9 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	      const char *default_expr_op_string = qdump_operator_type_string (T_TO_CHAR);
 	      assert (default_expr_op_string != NULL);
 
-	      len += (default_expr_op_string ? strlen (default_expr_op_string) : 0)	/* to_char */
-		+ 6		/* parenthesis, a comma, a blank and quotes */
-		+ (def_expr_format_string ? strlen (def_expr_format_string) : 0);	/* nothing or format */
+	      len += ((default_expr_op_string ? strlen (default_expr_op_string) : 0)	/* to_char */
+		      + 6	/* parenthesis, a comma, a blank and quotes */
+		      + (def_expr_format_string ? strlen (def_expr_format_string) : 0));	/* nothing or format */
 
 	      default_str_val = (char *) db_private_alloc (thread_p, len + 1);
 	      if (default_str_val == NULL)
@@ -1504,8 +1503,8 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	  /* add whitespace character if default_str_val is not an empty string */
 	  str_val =
 	    (char *) db_private_alloc (thread_p,
-				       default_value_len + (default_value_len ? 1 : 0) + len + strlen ("ON UPDATE ") +
-				       1);
+				       (default_value_len + (default_value_len ? 1 : 0) + len + strlen ("ON UPDATE ")
+					+ 1));
 	  if (str_val == NULL)
 	    {
 	      pr_clear_value (&default_expr);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22108

Update grammar to allow on update current times values in table definition statements. These values need to be saved in the table's schema, to be then retrieved when making update queries in http://jira.cubrid.org/browse/CBRD-22109.