### PR TITLE
[CBRD-22123] Broker failed to connect to database server when insert data with multi-threads

### DIFF
--- a/src/connection/tcp.c
+++ b/src/connection/tcp.c
@@ -89,7 +89,7 @@ static pthread_mutex_t gethostbyname_lock = PTHREAD_MUTEX_INITIALIZER;
 #define INADDR_NONE 0xffffffff
 #endif /* !INADDR_NONE */
 
-static const int css_Maximum_server_count = 50;
+static const int css_Maximum_server_count = 1000;
 
 #if !defined (WINDOWS)
 #define SET_NONBLOCKING(fd) { \

--- a/src/connection/wintcp.c
+++ b/src/connection/wintcp.c
@@ -53,7 +53,7 @@
 #define HOST_ID_ARRAY_SIZE 8
 
 static const int css_Tcp_max_connect_tries = 3;
-static const int css_Maximum_server_count = 50;
+static const int css_Maximum_server_count = 1000;
 
 /* containing the last WSA error */
 static int css_Wsa_error = CSS_ER_WINSOCK_NOERROR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22123

This bug appears because cub_master gets blocked when delegating the connection to cub_server because the socket send is blocking and cub_server spawns receiving threads instead of pooling them, which has overhead. Because cub_master has a backlog of only 50, clients quickly saturate this value and they get rejected.

We decided, for the time being, to simply increase the cub_master backlog to 1K in order to fix the regression. We conveyed that pooling threads on the cub_server side it's not worth it and we may, in the future, separate connections to threads on cub_master's side.