### PR TITLE
[CBRD-22145] fix number of server request workers

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1376,6 +1376,9 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
   // initialize worker pool for server requests
   const std::size_t MAX_WORKERS = css_get_max_conn () + 1;	// = css_Num_max_conn in connection_sr.c
   const std::size_t MAX_TASK_COUNT = 2 * MAX_WORKERS;	// not that it matters...
+  const std::size_t MAX_CONNECTIONS = css_get_max_conn ();
+
+  // create request worker pool
   css_Server_request_worker_pool = cubthread::get_manager ()->create_worker_pool (MAX_WORKERS, MAX_TASK_COUNT, NULL,
 										  cubthread::system_core_count (),
 										  false);
@@ -1387,7 +1390,7 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
       goto shutdown;
     }
 
-  const std::size_t MAX_CONNECTIONS = css_get_max_conn ();
+  // create connection worker pool
   css_Connection_worker_pool =
     cubthread::get_manager ()->create_worker_pool (MAX_CONNECTIONS, MAX_CONNECTIONS, NULL, 1, false);
   if (css_Connection_worker_pool == NULL)

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1374,9 +1374,8 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 #endif /* WINDOWS */
 
   // initialize worker pool for server requests
-  const std::size_t MAX_WORKERS = NUM_NON_SYSTEM_TRANS;
-  const std::size_t MAX_TASK_COUNT = 2 * NUM_NON_SYSTEM_TRANS;	// not that it matters...
-
+  const std::size_t MAX_WORKERS = css_get_max_conn () + 1;	// = css_Num_max_conn in connection_sr.c
+  const std::size_t MAX_TASK_COUNT = 2 * MAX_WORKERS;	// not that it matters...
   css_Server_request_worker_pool = cubthread::get_manager ()->create_worker_pool (MAX_WORKERS, MAX_TASK_COUNT, NULL,
 										  cubthread::system_core_count (),
 										  false);
@@ -1388,7 +1387,9 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
       goto shutdown;
     }
 
-  css_Connection_worker_pool = cubthread::get_manager ()->create_worker_pool (MAX_WORKERS, MAX_WORKERS, NULL, 1, false);
+  const std::size_t MAX_CONNECTIONS = css_get_max_conn ();
+  css_Connection_worker_pool =
+    cubthread::get_manager ()->create_worker_pool (MAX_CONNECTIONS, MAX_CONNECTIONS, NULL, 1, false);
   if (css_Connection_worker_pool == NULL)
     {
       assert (false);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22145

The issue is caused by a miss-match between the actual number of maximum connections and the number expected by server request worker pool.

The worker pool used to allocate `css_get_max_conn ()` workers, which is the maximum number of connections that can push task at any time. However, there is also the master connection which, even though it cannot push a tasks on worker pool, interferes with the algorithm of dispatching workers on cores.

In our case, master connection has index 0, which would be normally assigned to core 0. However, the connection with index equal to `css_get_max_conn ()` was not considered. Since master connection can be re-established and a new connection may be assigned to it, with a different index, we cannot be sure which connections do actually push tasks.

The safest fix is to allocated one additional worker from the beginning, so their number can be equal to css_Num_max_conn (`= css_get_max_conn () + 1`). No matter which connection is used by master, all connections should immediately find an available worker.