### PR TITLE
[CBRD-22146]  do not force interrupt vacuum on shutdown

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1376,6 +1376,9 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
   // initialize worker pool for server requests
   const std::size_t MAX_WORKERS = css_get_max_conn () + 1;	// = css_Num_max_conn in connection_sr.c
   const std::size_t MAX_TASK_COUNT = 2 * MAX_WORKERS;	// not that it matters...
+  const std::size_t MAX_CONNECTIONS = css_get_max_conn ();
+
+  // create request worker pool
   css_Server_request_worker_pool = cubthread::get_manager ()->create_worker_pool (MAX_WORKERS, MAX_TASK_COUNT, NULL,
 										  cubthread::system_core_count (),
 										  false);
@@ -1387,7 +1390,7 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
       goto shutdown;
     }
 
-  const std::size_t MAX_CONNECTIONS = css_get_max_conn ();
+  // create connection worker pool
   css_Connection_worker_pool =
     cubthread::get_manager ()->create_worker_pool (MAX_CONNECTIONS, MAX_CONNECTIONS, NULL, 1, false);
   if (css_Connection_worker_pool == NULL)

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1374,9 +1374,8 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 #endif /* WINDOWS */
 
   // initialize worker pool for server requests
-  const std::size_t MAX_WORKERS = NUM_NON_SYSTEM_TRANS;
-  const std::size_t MAX_TASK_COUNT = 2 * NUM_NON_SYSTEM_TRANS;	// not that it matters...
-
+  const std::size_t MAX_WORKERS = css_get_max_conn () + 1;	// = css_Num_max_conn in connection_sr.c
+  const std::size_t MAX_TASK_COUNT = 2 * MAX_WORKERS;	// not that it matters...
   css_Server_request_worker_pool = cubthread::get_manager ()->create_worker_pool (MAX_WORKERS, MAX_TASK_COUNT, NULL,
 										  cubthread::system_core_count (),
 										  false);
@@ -1388,7 +1387,9 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
       goto shutdown;
     }
 
-  css_Connection_worker_pool = cubthread::get_manager ()->create_worker_pool (MAX_WORKERS, MAX_WORKERS, NULL, 1, false);
+  const std::size_t MAX_CONNECTIONS = css_get_max_conn ();
+  css_Connection_worker_pool =
+    cubthread::get_manager ()->create_worker_pool (MAX_CONNECTIONS, MAX_CONNECTIONS, NULL, 1, false);
   if (css_Connection_worker_pool == NULL)
     {
       assert (false);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -762,32 +762,6 @@ class vacuum_worker_context_manager : public cubthread::entry_manager
       context.tran_index = 0;
     }
 
-    void stop_execution (cubthread::entry & context) final
-    {
-      context.shutdown = true;
-
-      // wakeup if waiting
-      if (context.m_status != cubthread::entry::status::TS_WAIT)
-        {
-          // not waiting
-          return;
-        }
-
-      context.lock ();
-      // check again
-      if (context.m_status != cubthread::entry::status::TS_WAIT)
-        {
-          // not waiting
-          context.unlock ();
-          return;
-        }
-
-      // interrupt & force wakeup
-      context.interrupted = true;
-      thread_wakeup_already_had_mutex (&context, THREAD_RESUME_DUE_TO_INTERRUPT);
-      context.unlock ();
-    }
-
     // members
     resource_shared_pool<VACUUM_WORKER>* m_pool;
 };


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22146

This is a regression of a recent change. Vacuum workers are forced to wake up if they are waiting on a page latch. The case we tried to solve was a long queue of workers all trying to deallocate pages from overflow file.

However, there is no way we can discriminate between these cases and uninterruptible operations (like page manipulation during system operation postpone phase).

This patch removes force wakeup. As a consequence, shutdown may again take a long time.