### PR TITLE
[CBRD-21832] DL in db_json_allocate_doc

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1492,14 +1492,11 @@ db_json_validate_json (const char *json_body)
 JSON_DOC *db_json_allocate_doc ()
 {
   JSON_DOC *doc = new JSON_DOC();
-  er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", doc);
-
   return doc;
 }
 
 void db_json_delete_doc (JSON_DOC *&doc)
 {
-  er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", doc);
   delete doc;
   doc = NULL;
 }

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1491,11 +1491,15 @@ db_json_validate_json (const char *json_body)
 
 JSON_DOC *db_json_allocate_doc ()
 {
-  return new JSON_DOC ();
+  JSON_DOC *doc = new JSON_DOC();
+  er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", doc);
+
+  return doc;
 }
 
 void db_json_delete_doc (JSON_DOC *&doc)
 {
+  er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", doc);
   delete doc;
   doc = NULL;
 }

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2053,6 +2053,7 @@ pr_clear_value (DB_VALUE * value)
 	    }
 	  if (value->data.json.document != NULL)
 	    {
+	      er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", &value->data.json.document);
 	      db_json_delete_doc (value->data.json.document);
 	      value->data.json.document = NULL;
 	    }

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2053,7 +2053,6 @@ pr_clear_value (DB_VALUE * value)
 	    }
 	  if (value->data.json.document != NULL)
 	    {
-	      er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", &value->data.json.document);
 	      db_json_delete_doc (value->data.json.document);
 	      value->data.json.document = NULL;
 	    }

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -3566,8 +3566,6 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 	  return (DB_VALUE *) NULL;
 	}
 
-      er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", &db_value->data.json.document);
-
       value->info.value.db_value_is_in_workspace = true;
       db_value->need_clear = true;
       if (value->info.data_type.json_schema)

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -3566,7 +3566,9 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 	  return (DB_VALUE *) NULL;
 	}
 
-      value->info.value.db_value_is_in_workspace = false;
+      er_print_callstack (ARG_FILE_LINE, "Traced pointer=%p\n", &db_value->data.json.document);
+
+      value->info.value.db_value_is_in_workspace = true;
       db_value->need_clear = true;
       if (value->info.data_type.json_schema)
 	{

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -5578,7 +5578,7 @@ mq_invert_subqueries (PARSER_CONTEXT * parser, PT_NODE * select_statements, PT_N
   PT_NODE **column_prev;
   PT_NODE *inverted;
   PT_NODE **head;
-  PT_NODE *node_to_free = NULL;
+  PT_NODE *temp = NULL;
 
   while (select_statements)
     {
@@ -5599,21 +5599,24 @@ mq_invert_subqueries (PARSER_CONTEXT * parser, PT_NODE * select_statements, PT_N
 	  // to avoid creating a new "empty" node, we better delete the column from the list
 	  if (inverted == NULL)
 	    {
-	      node_to_free = *column;
+	      temp = *column;
 
 	      if (column_prev != NULL)
 		{
 		  // link the previous node to the next node
-		  (*column_prev)->next = (*column)->next;
+		  (*column_prev)->next = column_next;
 		}
 	      else
 		{
 		  // move head to the right
-		  head = &((*column)->next);
+		  head = &column_next;
 		}
 
 	      // move forward in list
 	      column = &((*column_prev)->next);
+
+	      // avoid a mem leak
+	      parser_free_tree (parser, temp);
 	    }
 	  else
 	    {

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -5599,6 +5599,8 @@ mq_invert_subqueries (PARSER_CONTEXT * parser, PT_NODE * select_statements, PT_N
 	  // to avoid creating a new "empty" node, we better delete the column from the list
 	  if (inverted == NULL)
 	    {
+	      assert (!pt_has_error (parser));
+
 	      temp = *column;
 
 	      if (column_prev != NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21832

The function which caused the memory leak is `mq_invert_subqueries` because the parser_node was overwritten with the value returned by `mq_invert_assign`.

The fix was to free the current node before being overwritten. Instead of creating a new empty node which will be freed when the program stops the execution, I think it is better to delete the node from the select list (`select_statements->info.query.q.select.list`) instead of replacing it with an empty node.

