### PR TITLE
[CBRD-22166] [Regression] Core dumped in map_running_contexts

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -3015,9 +3015,9 @@ css_stop_log_writer (THREAD_ENTRY & thread_ref, bool & stop_mapper)
 static void
 css_find_not_stopped (THREAD_ENTRY & thread_ref, bool & stop_mapper, bool is_log_writer, bool & found)
 {
-  if (thread_ref.tran_index == -1)
+  if (thread_ref.conn_entry == NULL)
     {
-      // no transaction, no stop
+      // no conn_entry => does not need stopping
       return;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22166

Condition for finding threads to not stop in css_find_not_stopped was wrong, it was true and did the early out when it wasn't supposed to (for connection workers). This patch fixes the condition, now connection workers should also be stopped. 