### PR TITLE
[CBRD-22179] Fix replication unit test for Windows

### DIFF
--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2484,13 +2484,19 @@ css_send_magic_with_socket (SOCKET & socket)
 int
 css_check_magic (CSS_CONN_ENTRY * conn)
 {
+  return css_check_magic_with_socket (conn->fd);
+}
+
+int
+css_check_magic_with_socket (SOCKET fd)
+{
   int size, nbytes;
   unsigned int i;
   NET_HEADER header;
   char *p;
   int timeout = prm_get_integer_value (PRM_ID_TCP_CONNECTION_TIMEOUT) * 1000;
 
-  nbytes = css_readn (conn->fd, (char *) &size, sizeof (int), timeout);
+  nbytes = css_readn (fd, (char *) &size, sizeof (int), timeout);
   if (nbytes != sizeof (int))
     {
       return ERROR_WHEN_READING_SIZE;
@@ -2502,7 +2508,7 @@ css_check_magic (CSS_CONN_ENTRY * conn)
     }
 
   p = (char *) &header;
-  nbytes = css_readn (conn->fd, p, size, timeout);
+  nbytes = css_readn (fd, p, size, timeout);
   if (nbytes != size)
     {
       return ERROR_ON_READ;

--- a/src/connection/connection_support.h
+++ b/src/connection/connection_support.h
@@ -114,6 +114,8 @@ extern void css_register_check_server_alive_fn (CSS_CHECK_SERVER_ALIVE_FN callba
 extern int css_send_magic (CSS_CONN_ENTRY * conn);
 extern int css_check_magic (CSS_CONN_ENTRY * conn);
 
+extern int css_check_magic_with_socket (SOCKET fd);
+
 extern int css_user_access_status_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int arg_cnt,
 					      void **ptr);
 extern int css_platform_independent_poll (POLL_FD * fds, int num_of_fds, int timeout);

--- a/unit_tests/replication_channels/CMakeLists.txt
+++ b/unit_tests/replication_channels/CMakeLists.txt
@@ -51,21 +51,12 @@ target_link_libraries(test_replication_channels PRIVATE
   test_common
   )
 if(UNIX)
-	# the order should be 1.cubrid 2.cubridcs because
-	# they have common named functions and we need to
-	# use the ones in cubrid.so 
   target_link_libraries(test_replication_channels PRIVATE
     cubrid
-    )
-  target_link_libraries(test_replication_channels PRIVATE
-    cubridcs
     )
 elseif(WIN32)
 	target_link_libraries(test_replication_channels PRIVATE
     cubrid-win-lib
-    )
-  target_link_libraries(test_replication_channels PRIVATE
-    cubridcs
     )
 else()
   message( SEND_ERROR "Replication channel unit testing is for unix/windows")

--- a/unit_tests/replication_channels/cub_master_mock.cpp
+++ b/unit_tests/replication_channels/cub_master_mock.cpp
@@ -15,8 +15,6 @@
 #endif
 #include "connection_cl.h"
 
-#include <netinet/in.h>
-
 namespace cub_master_mock
 {
 

--- a/unit_tests/replication_channels/cub_master_mock.cpp
+++ b/unit_tests/replication_channels/cub_master_mock.cpp
@@ -8,8 +8,10 @@
 #include "thread_looper.hpp"
 #if !defined (WINDOWS)
 #include "tcp.h"
+#include <netinet/in.h>
 #else
 #include "wintcp.h"
+#include <Winsock2.h>
 #endif
 #include "connection_cl.h"
 

--- a/unit_tests/replication_channels/cub_master_mock.cpp
+++ b/unit_tests/replication_channels/cub_master_mock.cpp
@@ -81,7 +81,7 @@ namespace cub_master_mock
 
 	    if (css_check_magic (conn) != NO_ERRORS)
 	      {
-		css_free_conn (conn);
+		free_conn_entry_fp (conn);
 		return;
 	      }
 
@@ -93,7 +93,7 @@ namespace cub_master_mock
 
 	    if (function_code != SERVER_REQUEST_CONNECT_NEW_SLAVE)
 	      {
-		css_free_conn (conn);
+		free_conn_entry_fp (conn);
 		assert (false);
 		return;
 	      }

--- a/unit_tests/replication_channels/master_replication_channel_mock.cpp
+++ b/unit_tests/replication_channels/master_replication_channel_mock.cpp
@@ -2,13 +2,13 @@
 
 #define SERVER_MODE
 #include "replication_master_senders_manager.hpp"
-#if defined (WINDOWS)
+#if !defined (WINDOWS)
 #include "tcp.h"
+#include <sys/poll.h>
 #else
 #include "wintcp.h"
 #endif
 #include "error_code.h"
-#include <sys/poll.h>
 #include "thread_manager.hpp"
 #include <assert.h>
 #include "test_output.hpp"
@@ -39,3 +39,4 @@ namespace master
   }
 
 } /* namespace master */
+

--- a/unit_tests/replication_channels/test_main.cpp
+++ b/unit_tests/replication_channels/test_main.cpp
@@ -65,8 +65,9 @@ static int init_thread_system ()
 static int init ()
 {
   int error_code = NO_ERROR;
+#if !defined (WINDOWS)
   signal (SIGPIPE, SIG_IGN);
-
+#endif
   error_code = er_init ("replication_channels.log", ER_EXIT_DONT_ASK);
   if (error_code != NO_ERROR)
     {
@@ -191,3 +192,4 @@ int main (int argc, char **argv)
 
   return 0;
 }
+


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22179

Made changes for Windows side in order to prevent replication unit test from crashing. The libraries have different behaviors for Linux and Windows, so I made the unit test conscious of the differences.