### PR TITLE
[CBRD-22035] Remove GCC 4.4.7 compatibility code - string buffer

### DIFF
--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -191,23 +191,4 @@ namespace mem
 
 } // namespace mem
 
-#if !defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
-#include "memory_alloc.h"
-
-namespace mem
-{
-  inline void private_realloc (block &b, size_t len)
-  {
-    b.ptr = (char *) db_private_realloc (NULL, b.ptr, b.dim + len);
-    b.dim += len;
-  }
-
-  inline void private_dealloc (block &b)
-  {
-    db_private_free (NULL, b.ptr);
-    b = {};
-  }
-} // namespace mem
-#endif
-
 #endif // _MEM_BLOCK_HPP_

--- a/src/base/string_buffer.hpp
+++ b/src/base/string_buffer.hpp
@@ -47,7 +47,14 @@ class string_buffer
     : public mem::block_ext
 {
   public:
-    string_buffer () = default; //default ctor
+#if 0//defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
+    string_buffer () = default;
+#else
+    string_buffer ()
+      : mem::block_ext ()
+      , m_len (0)
+    {}
+#endif
 
     ~string_buffer ()
     {

--- a/src/base/string_buffer.hpp
+++ b/src/base/string_buffer.hpp
@@ -44,17 +44,14 @@
 #include <functional>
 
 class string_buffer
-    : public mem::block_ext
+  : public mem::block_ext
 {
   public:
-#if 0//defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
-    string_buffer () = default;
-#else
     string_buffer ()
       : mem::block_ext ()
       , m_len (0)
-    {}
-#endif
+    {
+    }
 
     ~string_buffer ()
     {

--- a/src/base/string_buffer.hpp
+++ b/src/base/string_buffer.hpp
@@ -43,17 +43,11 @@
 #include <stdio.h>
 #include <functional>
 
-class string_buffer: public mem::block_ext //collect formatted text (printf-like syntax)
+class string_buffer
+    : public mem::block_ext
 {
   public:
-#if defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
-    string_buffer () = default;                                    //default ctor
-#else
-    string_buffer ()
-      : mem::block_ext ()
-      , m_len (0)
-    {}
-#endif
+    string_buffer () = default; //default ctor
 
     ~string_buffer ()
     {

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -10460,7 +10460,7 @@ char *
 pr_valstring (THREAD_ENTRY * threade, DB_VALUE * val)
 {
 /* *INDENT-OFF* */
-#if defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
+#if 1//defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
   string_buffer sb {
     [&threade] (mem::block &block, size_t len)
     {
@@ -10473,7 +10473,7 @@ pr_valstring (THREAD_ENTRY * threade, DB_VALUE * val)
       block = {};
     }
   };
-#else
+  #else
   string_buffer sb {&mem::private_realloc, &mem::private_dealloc};
 #endif
 /* *INDENT-ON* */

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -10460,7 +10460,6 @@ char *
 pr_valstring (THREAD_ENTRY * threade, DB_VALUE * val)
 {
 /* *INDENT-OFF* */
-#if 1//defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
   string_buffer sb {
     [&threade] (mem::block &block, size_t len)
     {
@@ -10473,9 +10472,6 @@ pr_valstring (THREAD_ENTRY * threade, DB_VALUE * val)
       block = {};
     }
   };
-  #else
-  string_buffer sb {&mem::private_realloc, &mem::private_dealloc};
-#endif
 /* *INDENT-ON* */
 
   if (val == NULL)

--- a/src/object/object_print.c
+++ b/src/object/object_print.c
@@ -743,7 +743,7 @@ help_fprint_value (THREAD_ENTRY * thread_p, FILE * fp, const DB_VALUE * value)
 /* *INDENT-OFF* */
   db_private_allocator<char> private_allocator{thread_p};
 
-#if defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
+#if 1 //defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
   string_buffer sb{
     [&private_allocator] (mem::block& block, size_t len)
     {

--- a/src/object/object_print.c
+++ b/src/object/object_print.c
@@ -742,8 +742,6 @@ help_fprint_value (THREAD_ENTRY * thread_p, FILE * fp, const DB_VALUE * value)
 {
 /* *INDENT-OFF* */
   db_private_allocator<char> private_allocator{thread_p};
-
-#if 1 //defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
   string_buffer sb{
     [&private_allocator] (mem::block& block, size_t len)
     {
@@ -758,9 +756,6 @@ help_fprint_value (THREAD_ENTRY * thread_p, FILE * fp, const DB_VALUE * value)
       block = {};
     }
   };
-#else
-  string_buffer sb{&mem::private_realloc, &mem::private_dealloc};
-#endif
 /* *INDENT-ON* */
 
   db_value_printer printer (sb);

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2524,21 +2524,17 @@ pt_print_db_value (PARSER_CONTEXT * parser, const struct db_value * val)
   unsigned int save_custom = parser->custom_print;
 
 /* *INDENT-OFF* */
-#if 1 //defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
   string_buffer sb{
     [&parser] (mem::block& block, size_t len)
     {
       size_t dim = block.dim ? block.dim : 1;
-      for (; dim < block.dim + len; dim *= 2); //calc next power of 2 >= b.dim
-        mem::block b{dim, (char*) parser_alloc (parser, block.dim + len)};
+      for (; dim < block.dim + len; dim *= 2); //calc next power of 2 >= b.dim+len
+      mem::block b{dim, (char*) parser_alloc (parser, dim)};
       memcpy (b.ptr, block.ptr, block.dim);
       block = std::move (b);
     },
     [](mem::block& block){} //no need to deallocate for parser_context
   };
-#else
-  string_buffer sb;
-#endif
 /* *INDENT-ON* */
 
   db_value_printer printer (sb);

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2523,19 +2523,24 @@ pt_print_db_value (PARSER_CONTEXT * parser, const struct db_value * val)
   int error = NO_ERROR;
   unsigned int save_custom = parser->custom_print;
 
-/* *INDENT-OFF* */
-  string_buffer sb{
-    [&parser] (mem::block& block, size_t len)
+  /* *INDENT-OFF* */
+  string_buffer sb
+  {
+    [&parser] (mem::block &block, size_t len)
     {
       size_t dim = block.dim ? block.dim : 1;
-      for (; dim < block.dim + len; dim *= 2); //calc next power of 2 >= b.dim+len
-      mem::block b{dim, (char*) parser_alloc (parser, dim)};
+
+      for (; dim < block.dim + len; dim *= 2)	//calc next power of 2 >= b.dim+len
+	 ;
+
+      mem::block b { dim, (char *) parser_alloc (parser, dim) };
       memcpy (b.ptr, block.ptr, block.dim);
       block = std::move (b);
-    },
-    [](mem::block& block){} //no need to deallocate for parser_context
+    }, [](mem::block &block)
+    {
+    }				//no need to deallocate for parser_context
   };
-/* *INDENT-ON* */
+  /* *INDENT-ON* */
 
   db_value_printer printer (sb);
   if (val == NULL)

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2524,7 +2524,7 @@ pt_print_db_value (PARSER_CONTEXT * parser, const struct db_value * val)
   unsigned int save_custom = parser->custom_print;
 
 /* *INDENT-OFF* */
-#if defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
+#if 1 //defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
   string_buffer sb{
     [&parser] (mem::block& block, size_t len)
     {

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -9087,19 +9087,24 @@ pt_make_query_show_create_table (PARSER_CONTEXT * parser, PT_NODE * table_name)
   assert (table_name != NULL);
   assert (table_name->node_type == PT_NAME);
 
-/* *INDENT-OFF* */
+  /* *INDENT-OFF* */
   string_buffer strbuf {
-    [&parser] (mem::block& block, size_t len)
+    [&parser] (mem::block &block, size_t len)
     {
       size_t dim = block.dim ? block.dim : 1;
-      for (; dim < block.dim + len; dim *= 2); // calc next power of 2 >= b.dim+len
-      mem::block b{dim, (char *) parser_alloc (parser, dim)};
+
+      for (; dim < block.dim + len; dim *= 2) // calc next power of 2 >= b.dim+len
+	;
+
+      mem::block b{ dim, (char *) parser_alloc (parser, dim) };
       memcpy (b.ptr, block.ptr, block.dim); // copy old content
       block = std::move (b);
     },
-    [](mem::block& block){} //no need to deallocate for parser_context
+    [](mem::block &block) //no need to deallocate for parser_context
+    {
+    }
   };
-/* *INDENT-ON* */
+  /* *INDENT-ON* */
 
   pt_help_show_create_table (parser, table_name, strbuf);
   if (strbuf.len () == 0)

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -9088,7 +9088,7 @@ pt_make_query_show_create_table (PARSER_CONTEXT * parser, PT_NODE * table_name)
   assert (table_name->node_type == PT_NAME);
 
 /* *INDENT-OFF* */
-#if defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
+#if 1 //defined(NO_GCC_44) //temporary until evolve above gcc 4.4.7
   string_buffer strbuf {
     [&parser] (mem::block& block, size_t len)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22035

New compiler version allows now the use of lambdas => string_buffer instances  can use context specific allocator/deallocator instead global/generic ones:
- parser allocator 
- private allocator