### PR TITLE
[CBRD-22174] reset last blockid for copied database

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4140,6 +4140,14 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
 	      assert (vacuum_Data.get_last_blockid () == VACUUM_NULL_LOG_BLOCKID);
 	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY, "%s",
 			     "vacuum_data_load_and_recover: last blockid remains null");
+
+              /* and this is a hack to removed "last_blockid from vacuum data page" */
+              assert (vacuum_Data.first_page == vacuum_Data.last_page);
+              vacuum_data_initialize_new_page (thread_p, vacuum_Data.first_page);
+              vacuum_Data.first_page->data->blockid = VACUUM_NULL_LOG_BLOCKID;
+              log_append_redo_data2 (thread_p, RVVAC_DATA_INIT_NEW_PAGE, NULL, (PAGE_PTR) vacuum_Data.first_page, 0,
+                                     sizeof (vacuum_Data.first_page->data->blockid),
+                                     &vacuum_Data.first_page->data->blockid);
 	    }
 	}
       else

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4148,6 +4148,7 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
               log_append_redo_data2 (thread_p, RVVAC_DATA_INIT_NEW_PAGE, NULL, (PAGE_PTR) vacuum_Data.first_page, 0,
                                      sizeof (vacuum_Data.first_page->data->blockid),
                                      &vacuum_Data.first_page->data->blockid);
+              vacuum_set_dirty_data_page (thread_p, vacuum_Data.first_page, DONT_FREE);
 	    }
 	}
       else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22174

This is a hack to reset last_blockid of vacuum data on the first start of copied database (last_blockid is inherited from original database). It is not a proper fix and we should probably find a better one :).

The way now copydb works makes it hard to find non-hackish fix for the issue.