### PR TITLE
[CBRD-22169] Core dumped in free_node_in_tree_pre

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -5602,6 +5602,7 @@ mq_invert_subqueries (PARSER_CONTEXT * parser, PT_NODE * select_statements, PT_N
 	      assert (!pt_has_error (parser));
 
 	      temp = *column;
+	      temp->next = NULL;
 
 	      if (column_prev != NULL)
 		{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22169

The new functionality of `mq_invert_subqueries` is when we can not invert the current node from list (calling `pt_invert (parser, *column, attr)`) we better delete the node and free it. 

Because free is called recursively on all of its next links, we need to assign `NULL` to the next pointer in order to free just the current node.

Maybe this will resolve also this issue: http://jira.cubrid.org/browse/CBRD-22170 