### PR TITLE
[CBRD-22171] DL in db_json_allocate_doc

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -20416,6 +20416,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 		  parser_free_tree (parser, result);
 		}
 	    }
+	  expr->next = expr_next;
 	  return expr;
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22171

In the beginning of the function `pt_fold_const_expr` we set `expr->next = NULL` which in case of error will produce a memory leak if the next pointer is not null. 

The quick fix for this issue is to reestablish the link to `expr_next` when we return the `expr` node. I saw that in majority cases when we encounter an error we return the node unmodified, but because the next is set to null we will lose this link.

I think a better fix will be to refactor this method because is confusing the return part: we either `return` in all cases or use the `goto end` label.  Also I think that when the `result` node is `NULL` we will also have a memory leak which will be triggered by other cases.
