### PR TITLE
[CBRD-22174]  first boot after copydb

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4136,19 +4136,8 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
 	    }
 	  else
 	    {
-	      /* this is likely the first restart after database copy */
-	      assert (vacuum_Data.get_last_blockid () == VACUUM_NULL_LOG_BLOCKID);
-	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY, "%s",
-			     "vacuum_data_load_and_recover: last blockid remains null");
-
-              /* and this is a hack to removed "last_blockid from vacuum data page" */
-              assert (vacuum_Data.first_page == vacuum_Data.last_page);
-              vacuum_data_initialize_new_page (thread_p, vacuum_Data.first_page);
-              vacuum_Data.first_page->data->blockid = VACUUM_NULL_LOG_BLOCKID;
-              log_append_redo_data2 (thread_p, RVVAC_DATA_INIT_NEW_PAGE, NULL, (PAGE_PTR) vacuum_Data.first_page, 0,
-                                     sizeof (vacuum_Data.first_page->data->blockid),
-                                     &vacuum_Data.first_page->data->blockid);
-              vacuum_set_dirty_data_page (thread_p, vacuum_Data.first_page, DONT_FREE);
+	      // we should just not be here...
+	      assert (false);
 	    }
 	}
       else
@@ -8075,6 +8064,53 @@ vacuum_check_shutdown_interruption (const THREAD_ENTRY * thread_p, int error_cod
 {
   ASSERT_ERROR ();
   assert (thread_p->shutdown && error_code == ER_INTERRUPTED);
+}
+
+//
+// vacuum_reset_data_after_copydb () - reset vacuum data after copydb. since complete vacuum is run on copied database
+//                                     there should be no actual data; however, last_blockid remains set in first
+//                                     data entry
+//
+int
+vacuum_reset_data_after_copydb (THREAD_ENTRY * thread_p)
+{
+  assert (vacuum_Data.first_page == NULL && vacuum_Data.last_page == NULL);
+  assert (!VFID_ISNULL (&vacuum_Data.vacuum_data_file));
+
+  int error_code = NO_ERROR;
+  FILE_DESCRIPTORS fdes;
+
+  error_code = file_descriptor_get (thread_p, &vacuum_Data.vacuum_data_file, &fdes);
+  if (error_code != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      return error_code;
+    }
+  assert (!VPID_ISNULL (&fdes.vacuum_data.vpid_first));
+
+  vacuum_Data.first_page = vacuum_fix_data_page (thread_p, &fdes.vacuum_data.vpid_first);
+  if (vacuum_Data.first_page == NULL)
+    {
+      ASSERT_ERROR_AND_SET (error_code);
+      return error_code;
+    }
+
+  // there should be no data
+  assert (VPID_ISNULL (&vacuum_Data.first_page->next_page));
+  assert (vacuum_Data.first_page->index_free == 0);
+
+  vacuum_data_initialize_new_page (thread_p, vacuum_Data.first_page);
+  vacuum_Data.first_page->data->blockid = VACUUM_NULL_LOG_BLOCKID;
+  log_append_redo_data2 (thread_p, RVVAC_DATA_INIT_NEW_PAGE, NULL, (PAGE_PTR) vacuum_Data.first_page, 0,
+			 sizeof (vacuum_Data.first_page->data->blockid), &vacuum_Data.first_page->data->blockid);
+  vacuum_set_dirty_data_page (thread_p, vacuum_Data.first_page, DONT_FREE);
+
+  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Reset vacuum data page %d|%d, lsa %lld|%d, after copydb",
+		 PGBUF_PAGE_STATE_ARGS ((PAGE_PTR) vacuum_Data.first_page));
+
+  vacuum_unfix_first_and_last_data_page (thread_p);
+
+  return NO_ERROR;
 }
 
 // *INDENT-OFF*

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4136,8 +4136,10 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
 	    }
 	  else
 	    {
-	      // we should just not be here...
-	      assert (false);
+	      // we can be here if log has not yet passed first block. one case may be soon after copydb.
+	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
+			     "vacuum_data_load_and_recover: do not update last_blockid; prev_lsa = %lld|%d",
+			     LSA_AS_ARGS (&log_Gl.append.prev_lsa));
 	    }
 	}
       else

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -346,4 +346,6 @@ extern int vacuum_rv_es_nop (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 #if defined (SERVER_MODE)
 extern void vacuum_notify_es_deleted (THREAD_ENTRY * thread_p, const char *uri);
 #endif /* SERVER_MODE */
+
+extern int vacuum_reset_data_after_copydb (THREAD_ENTRY * thread_p);
 #endif /* _VACUUM_H_ */

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -199,6 +199,8 @@ static INTL_CODESET boot_get_db_charset_from_header (THREAD_ENTRY * thread_p, co
 						     const char *log_prefix);
 STATIC_INLINE int boot_db_parm_update_heap (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
 
+static int boot_after_copydb (THREAD_ENTRY * thread_p);
+
 /*
  * bo_server) -set server's status, UP or DOWN
  *   return: void
@@ -2434,6 +2436,13 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
    */
 
   log_initialize (thread_p, boot_Db_full_name, log_path, log_prefix, from_backup, r_args);
+
+  error_code = boot_after_copydb (thread_p);	// only does something if this is first boot after copydb
+  if (error_code != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      goto error;
+    }
 
 #if defined(SERVER_MODE)
   pgbuf_daemons_init ();
@@ -5915,4 +5924,40 @@ boot_db_parm_update_heap (THREAD_ENTRY * thread_p)
     }
   heap_scancache_end (thread_p, &scan_cache);
   return error_code;
+}
+
+//
+// boot_after_copydb - do whatever checks and changes necessary on first boot of copied database.
+//                     copydb is quite rudimentary; it will just copy page by page as is, and then reset the LSA's.
+//                     some of database stuff may be contextual (e.g. stuff that depend on log like vacuum), and
+//                     here that stuff must be handled
+//
+static int
+boot_after_copydb (THREAD_ENTRY * thread_p)
+{
+  if (!log_Gl.hdr.was_copied)
+    {
+      // this is not after copydb
+      return NO_ERROR;
+    }
+
+  int error_code = vacuum_reset_data_after_copydb (thread_p);
+  if (error_code != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      return error_code;
+    }
+
+  // finished booting after copydb
+  log_Gl.hdr.was_copied = false;
+
+  // flush log and header to disk to make sure everything is saved
+  LOG_CS_ENTER (thread_p);
+  logpb_flush_pages_direct (thread_p);
+  logpb_flush_header (thread_p);
+  LOG_CS_EXIT (thread_p);
+
+  _er_log_debug (ARG_FILE_LINE, "Complete boot_after_copydb \n");
+
+  return NO_ERROR;
 }

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -5957,7 +5957,7 @@ boot_after_copydb (THREAD_ENTRY * thread_p)
   logpb_flush_header (thread_p);
   LOG_CS_EXIT (thread_p);
 
-  _er_log_debug (ARG_FILE_LINE, "Complete boot_after_copydb \n");
+  er_log_debug (ARG_FILE_LINE, "Complete boot_after_copydb \n");
 
   return NO_ERROR;
 }

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -195,8 +195,8 @@ struct log_header
   int avg_nlocks;		/* Average number of object locks */
   DKNPAGES npages;		/* Number of pages in the active log portion. Does not include the log header page. */
   INT8 db_charset;
-  INT8 dummy2;			/* Dummy fields for 8byte align */
-  INT8 dummy3;
+  bool was_copied;		/* set to true for copied database; should be reset on first server start */
+  INT8 dummy3;			/* Dummy fields for 8byte align */
   INT8 dummy4;
   LOG_PAGEID fpageid;		/* Logical pageid at physical location 1 in active log */
   LOG_LSA append_lsa;		/* Current append location */
@@ -250,7 +250,12 @@ struct log_header
      0, 0, 0,					 \
      /* db_charset */				 \
      0,						 \
-     0, 0, 0, 0,				 \
+     /* was_copied */                            \
+     false,                                      \
+     /* dummy INT8 for align */                  \
+     0, 0,                                       \
+     /* fpageid */                               \
+     0,				                 \
      /* append_lsa */                            \
      {NULL_PAGEID, NULL_OFFSET},                 \
      /* chkpt_lsa */                             \

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -314,7 +314,12 @@ struct log_header
      0, 0, 0,					 \
      /* db_charset */				 \
      0,						 \
-     0, 0, 0, 0,				 \
+     /* was_copied */                            \
+     false,                                      \
+     /* dummy INT8 for align */                  \
+     0, 0,                                       \
+     /* fpageid */                               \
+     0,				                 \
      /* append_lsa */                            \
      {NULL_PAGEID, NULL_OFFSET},                 \
      /* chkpt_lsa */                             \

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1418,6 +1418,8 @@ logpb_copy_log_header (THREAD_ENTRY * thread_p, LOG_HEADER * to_hdr, const LOG_H
   assert (to_hdr != NULL);
   assert (from_hdr != NULL);
 
+  to_hdr->was_copied = true;	// should be reset on first restart
+
   to_hdr->mvcc_next_id = from_hdr->mvcc_next_id;
 
   /* Add other attributes that need to be copied */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22174

Add a routine to handle first boot after copydb. Log header is extended for this purpose, but it should be backward compatible.

Properly handle the case when log_blockid is `NULL`. It may happen on both branches of condition:
`if (LSA_ISNULL (&vacuum_Data.recovery_lsa) && LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa))`