### PR TITLE
[CBRD-22215] ON UPDATE does not apply to ODKU 

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -17935,10 +17935,16 @@ pt_to_odku_info (PARSER_CONTEXT * parser, PT_NODE * insert, XASL_NODE * xasl)
       select_specs = NULL;
     }
 
-  odku->num_assigns = 0;
   assignments = insert->info.insert.odku_assignments;
+  error = pt_append_omitted_on_update_expr_assignments (parser, assignments, insert_spec);
+  if (error != NO_ERROR)
+    {
+      PT_INTERNAL_ERROR (parser, "odku on update insert error");
+      goto exit_on_error;
+    }
 
   /* init update attribute ids */
+  odku->num_assigns = 0;
   pt_init_assignments_helper (parser, &assignments_helper, assignments);
   while (pt_get_next_assignment (&assignments_helper) != NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22215

On xasl generation of the On duplicate key update the appending of the on update defaults was left out.