### PR TITLE
[CBRD-22232] [JSON]Cannot coerce value of domain "national character" to domain "json"

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -2435,12 +2435,12 @@ db_json_keys_func (const JSON_DOC &doc, JSON_DOC *&result_json, const char *raw_
 }
 
 int
-db_json_keys_func (const char *json_raw, JSON_DOC *&result_json, const char *raw_path)
+db_json_keys_func (const char *json_raw, JSON_DOC *&result_json, const char *raw_path, size_t json_raw_length)
 {
   JSON_DOC doc;
   int error_code = NO_ERROR;
 
-  error_code = db_json_get_json_from_str (json_raw, doc);
+  error_code = db_json_get_json_from_str (json_raw, doc, json_raw_length);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR();

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1063,22 +1063,12 @@ static int
 db_json_get_json_from_str (const char *json_raw, JSON_DOC &doc, size_t json_raw_length)
 {
   int error_code = NO_ERROR;
-  const rapidjson::GenericDocument <JSON_ENCODING, JSON_PRIVATE_MEMPOOL> *result_doc = NULL;
   if (json_raw == NULL)
     {
       return NO_ERROR;
     }
-
-  if (json_raw_length == 0)
-    {
-      result_doc = &doc.Parse(json_raw);
-    }
-  else
-    {
-      result_doc = &doc.Parse(json_raw, json_raw_length);
-    }
   
-  if (result_doc->HasParseError ())
+  if (doc.Parse (json_raw, json_raw_length).HasParseError ())
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_JSON_INVALID_JSON, 2,
 	      rapidjson::GetParseError_En (doc.GetParseError ()), doc.GetErrorOffset ());

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -430,7 +430,7 @@ static int db_json_keys_func (const JSON_DOC &doc, JSON_DOC &result_json, const 
 
 STATIC_INLINE JSON_VALUE &db_json_doc_to_value (JSON_DOC &doc) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE const JSON_VALUE &db_json_doc_to_value (const JSON_DOC &doc) __attribute__ ((ALWAYS_INLINE));
-static int db_json_get_json_from_str (const char *json_raw, JSON_DOC &doc, size_t json_raw_length = 0);
+static int db_json_get_json_from_str (const char *json_raw, JSON_DOC &doc, size_t json_raw_length);
 static int db_json_add_json_value_to_object (JSON_DOC &doc, const char *name, JSON_VALUE &value);
 
 static int db_json_deserialize_doc_internal (OR_BUF *buf, JSON_VALUE &value, JSON_PRIVATE_MEMPOOL &doc_allocator);
@@ -1067,7 +1067,7 @@ db_json_get_json_from_str (const char *json_raw, JSON_DOC &doc, size_t json_raw_
     {
       return NO_ERROR;
     }
-  
+
   if (doc.Parse (json_raw, json_raw_length).HasParseError ())
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_JSON_INVALID_JSON, 2,

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -430,7 +430,7 @@ static int db_json_keys_func (const JSON_DOC &doc, JSON_DOC &result_json, const 
 
 STATIC_INLINE JSON_VALUE &db_json_doc_to_value (JSON_DOC &doc) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE const JSON_VALUE &db_json_doc_to_value (const JSON_DOC &doc) __attribute__ ((ALWAYS_INLINE));
-static int db_json_get_json_from_str (const char *json_raw, JSON_DOC &doc);
+static int db_json_get_json_from_str (const char *json_raw, JSON_DOC &doc, size_t json_raw_length = 0);
 static int db_json_add_json_value_to_object (JSON_DOC &doc, const char *name, JSON_VALUE &value);
 
 static int db_json_deserialize_doc_internal (OR_BUF *buf, JSON_VALUE &value, JSON_PRIVATE_MEMPOOL &doc_allocator);
@@ -1060,15 +1060,25 @@ db_json_contains_duplicate_keys (JSON_DOC &doc)
 }
 
 static int
-db_json_get_json_from_str (const char *json_raw, JSON_DOC &doc)
+db_json_get_json_from_str (const char *json_raw, JSON_DOC &doc, size_t json_raw_length)
 {
   int error_code = NO_ERROR;
+  const rapidjson::GenericDocument <JSON_ENCODING, JSON_PRIVATE_MEMPOOL> *result_doc = NULL;
   if (json_raw == NULL)
     {
       return NO_ERROR;
     }
 
-  if (doc.Parse (json_raw).HasParseError ())
+  if (json_raw_length == 0)
+    {
+      result_doc = &doc.Parse(json_raw);
+    }
+  else
+    {
+      result_doc = &doc.Parse(json_raw, json_raw_length);
+    }
+  
+  if (result_doc->HasParseError ())
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_JSON_INVALID_JSON, 2,
 	      rapidjson::GetParseError_En (doc.GetParseError ()), doc.GetErrorOffset ());
@@ -1086,7 +1096,7 @@ db_json_get_json_from_str (const char *json_raw, JSON_DOC &doc)
 }
 
 int
-db_json_get_json_from_str (const char *json_raw, JSON_DOC *&doc)
+db_json_get_json_from_str (const char *json_raw, JSON_DOC *&doc, size_t json_raw_length)
 {
   int err;
 
@@ -1094,7 +1104,7 @@ db_json_get_json_from_str (const char *json_raw, JSON_DOC *&doc)
 
   doc = db_json_allocate_doc ();
 
-  err = db_json_get_json_from_str (json_raw, *doc);
+  err = db_json_get_json_from_str (json_raw, *doc, json_raw_length);
   if (err != NO_ERROR)
     {
       delete doc;

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -84,7 +84,7 @@ void db_json_add_element_to_array (JSON_DOC *doc, int value);
 void db_json_add_element_to_array (JSON_DOC *doc, double value);
 void db_json_add_element_to_array (JSON_DOC *doc, const JSON_DOC *value);
 
-int db_json_get_json_from_str (const char *json_raw, JSON_DOC *&doc);
+int db_json_get_json_from_str (const char *json_raw, JSON_DOC *&doc, size_t json_raw_length = 0);
 JSON_DOC *db_json_get_copy_of_doc (const JSON_DOC *doc);
 
 int db_json_serialize (const JSON_DOC &doc, OR_BUF &buffer);

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -95,7 +95,7 @@ int db_json_insert_func (const JSON_DOC *doc_to_be_inserted, JSON_DOC &doc_desti
 int db_json_replace_func (const JSON_DOC *new_value, JSON_DOC &doc, const char *raw_path);
 int db_json_set_func (const JSON_DOC *value, JSON_DOC &doc, const char *raw_path);
 int db_json_keys_func (const JSON_DOC &doc, JSON_DOC *&result_json, const char *raw_path);
-int db_json_keys_func (const char *json_raw, JSON_DOC *&result_json, const char *raw_path);
+int db_json_keys_func (const char *json_raw, JSON_DOC *&result_json, const char *raw_path, size_t json_raw_length);
 int db_json_array_append_func (const JSON_DOC *value, JSON_DOC &doc, const char *raw_path);
 int db_json_remove_func (JSON_DOC &doc, const char *raw_path);
 int db_json_merge_func (const JSON_DOC *source, JSON_DOC *&dest);

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -84,7 +84,7 @@ void db_json_add_element_to_array (JSON_DOC *doc, int value);
 void db_json_add_element_to_array (JSON_DOC *doc, double value);
 void db_json_add_element_to_array (JSON_DOC *doc, const JSON_DOC *value);
 
-int db_json_get_json_from_str (const char *json_raw, JSON_DOC *&doc, size_t json_raw_length = 0);
+int db_json_get_json_from_str (const char *json_raw, JSON_DOC *&doc, size_t json_raw_length);
 JSON_DOC *db_json_get_copy_of_doc (const JSON_DOC *doc);
 
 int db_json_serialize (const JSON_DOC &doc, OR_BUF &buffer);
@@ -134,12 +134,12 @@ bool db_json_doc_is_uncomparable (const JSON_DOC *doc);
 
 template <typename Fn, typename... Args>
 inline int
-db_json_convert_string_and_call (const char *json_raw, Fn &&func, Args &&... args)
+db_json_convert_string_and_call (const char *json_raw, size_t json_raw_length, Fn &&func, Args &&... args)
 {
   JSON_DOC *doc = NULL;
   int error_code;
 
-  error_code = db_json_get_json_from_str (json_raw, doc);
+  error_code = db_json_get_json_from_str (json_raw, doc, json_raw_length);
   if (error_code != NO_ERROR)
     {
       return error_code;

--- a/src/executables/loader.c
+++ b/src/executables/loader.c
@@ -6361,7 +6361,7 @@ ldr_json_elem (LDR_CONTEXT * context, const char *str, int len, DB_VALUE * val)
   char *json_body = NULL;
   int error_code = NO_ERROR;
 
-  error_code = db_json_get_json_from_str (str, document);
+  error_code = db_json_get_json_from_str (str, document, len);
   if (error_code != NO_ERROR)
     {
       assert (document == NULL);

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -9974,7 +9974,9 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	      assert (str_size >= 0);	/* if this isn't correct, we cannot rely on strlen */
 
-	      error_code = db_json_get_json_from_str (original_str, doc);
+              std::string str_with_size(original_str, str_size);
+
+	      error_code = db_json_get_json_from_str (str_with_size.c_str(), doc);
 	      if (error_code != NO_ERROR)
 		{
 		  assert (doc == NULL);

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -9974,7 +9974,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	      assert (str_size >= 0);	/* if this isn't correct, we cannot rely on strlen */
 
-              std::string str_with_size(original_str, str_size);
+            std::string str_with_size(original_str, str_size);
 
 	      error_code = db_json_get_json_from_str (str_with_size.c_str(), doc);
 	      if (error_code != NO_ERROR)

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -9973,7 +9973,6 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      int error_code;
 
 	      assert (str_size >= 0);	/* if this isn't correct, we cannot rely on strlen */
-              
 	      error_code = db_json_get_json_from_str (original_str, doc, str_size);
 	      if (error_code != NO_ERROR)
 		{

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -9973,10 +9973,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      int error_code;
 
 	      assert (str_size >= 0);	/* if this isn't correct, we cannot rely on strlen */
-
-            std::string str_with_size(original_str, str_size);
-
-	      error_code = db_json_get_json_from_str (str_with_size.c_str(), doc);
+              
+	      error_code = db_json_get_json_from_str (original_str, doc, str_size);
 	      if (error_code != NO_ERROR)
 		{
 		  assert (doc == NULL);

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -3495,8 +3495,9 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
     case PT_TYPE_JSON:
       db_value->domain.general_info.type = DB_TYPE_JSON;
       db_value->domain.general_info.is_null = 0;
-      json_body = (const char *) value->info.value.data_value.str->bytes;
-      if (db_json_get_json_from_str (json_body, db_value->data.json.document) != NO_ERROR)
+      json_body = (const char *) value->info.value.data_value.str->bytes; 
+      if (db_json_get_json_from_str (json_body, db_value->data.json.document, 
+        value->info.value.data_value.str->length) != NO_ERROR)
 	{
 	  PT_ERRORmf (parser, value, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_INVALID_JSON,
 		      value->info.value.data_value.str->bytes);

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -3497,7 +3497,7 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
       db_value->domain.general_info.is_null = 0;
       json_body = (const char *) value->info.value.data_value.str->bytes;
       if (db_json_get_json_from_str (json_body, db_value->data.json.document,
-          value->info.value.data_value.str->length) != NO_ERROR)
+				     value->info.value.data_value.str->length) != NO_ERROR)
 	{
 	  PT_ERRORmf (parser, value, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_INVALID_JSON,
 		      value->info.value.data_value.str->bytes);

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -3495,9 +3495,9 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
     case PT_TYPE_JSON:
       db_value->domain.general_info.type = DB_TYPE_JSON;
       db_value->domain.general_info.is_null = 0;
-      json_body = (const char *) value->info.value.data_value.str->bytes; 
-      if (db_json_get_json_from_str (json_body, db_value->data.json.document, 
-        value->info.value.data_value.str->length) != NO_ERROR)
+      json_body = (const char *) value->info.value.data_value.str->bytes;
+      if (db_json_get_json_from_str (json_body, db_value->data.json.document,
+          value->info.value.data_value.str->length) != NO_ERROR)
 	{
 	  PT_ERRORmf (parser, value, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_INVALID_JSON,
 		      value->info.value.data_value.str->bytes);

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -3447,8 +3447,7 @@ db_json_keys (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      error_code = db_json_keys_func (db_get_string (arg[0]), result_json, path.c_str (),
-                                      db_get_string_size (arg[0]));
+      error_code = db_json_keys_func (db_get_string (arg[0]), result_json, path.c_str (), db_get_string_size (arg[0]));
       break;
     case DB_TYPE_JSON:
       error_code = db_json_keys_func (*(db_get_json_document (arg[0])), result_json, path.c_str ());
@@ -3633,7 +3632,7 @@ db_json_merge (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
 	  error_code = db_json_convert_string_and_call (db_get_string (arg[i]), db_get_string_size (arg[i]),
-                                                        db_json_merge_func, accumulator);
+							db_json_merge_func, accumulator);
 	  break;
 
 	case DB_TYPE_NULL:
@@ -28398,8 +28397,7 @@ db_value_to_json_doc (const DB_VALUE & value, REFPTR (JSON_DOC, json))
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      error_code = db_json_get_json_from_str (db_get_string (&value), json,
-                                              db_get_string_size (&value));
+      error_code = db_json_get_json_from_str (db_get_string (&value), json, db_get_string_size (&value));
       if (error_code != NO_ERROR)
 	{
 	  assert (json == NULL);

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -3447,7 +3447,7 @@ db_json_keys (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      error_code = db_json_keys_func (db_get_string (arg[0]), result_json, path.c_str ());
+      error_code = db_json_keys_func (db_get_string (arg[0]), result_json, path.c_str (), db_get_string_size(arg[0]));
       break;
     case DB_TYPE_JSON:
       error_code = db_json_keys_func (*(db_get_json_document (arg[0])), result_json, path.c_str ());
@@ -28396,7 +28396,7 @@ db_value_to_json_doc (const DB_VALUE & value, REFPTR (JSON_DOC, json))
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      error_code = db_json_get_json_from_str (db_get_string (&value), json);
+      error_code = db_json_get_json_from_str (db_get_string (&value), json, db_get_string_size(&value));
       if (error_code != NO_ERROR)
 	{
 	  assert (json == NULL);

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -3239,7 +3239,7 @@ db_json_insert (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
-	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]),
+	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]), db_get_string_size (arg[i + 1]),
 							db_json_insert_func, *new_doc, db_get_string (arg[i]));
 	  break;
 
@@ -3310,7 +3310,7 @@ db_json_replace (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
-	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]),
+	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]), db_get_string_size (arg[i + 1]),
 							db_json_replace_func, *new_doc, db_get_string (arg[i]));
 	  break;
 
@@ -3380,7 +3380,7 @@ db_json_set (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
-	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]),
+	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]), db_get_string_size (arg[i + 1]),
 							db_json_set_func, *new_doc, db_get_string (arg[i]));
 	  break;
 
@@ -3447,7 +3447,8 @@ db_json_keys (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      error_code = db_json_keys_func (db_get_string (arg[0]), result_json, path.c_str (), db_get_string_size(arg[0]));
+      error_code = db_json_keys_func (db_get_string (arg[0]), result_json, path.c_str (),
+                                      db_get_string_size (arg[0]));
       break;
     case DB_TYPE_JSON:
       error_code = db_json_keys_func (*(db_get_json_document (arg[0])), result_json, path.c_str ());
@@ -3560,7 +3561,7 @@ db_json_array_append (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
       switch (DB_VALUE_DOMAIN_TYPE (arg[i + 1]))
 	{
 	case DB_TYPE_CHAR:
-	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]),
+	  error_code = db_json_convert_string_and_call (db_get_string (arg[i + 1]), db_get_string_size (arg[i + 1]),
 							db_json_array_append_func, *new_doc, db_get_string (arg[i]));
 	  break;
 
@@ -3631,7 +3632,8 @@ db_json_merge (DB_VALUE * result, DB_VALUE * arg[], int const num_args)
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
-	  error_code = db_json_convert_string_and_call (db_get_string (arg[i]), db_json_merge_func, accumulator);
+	  error_code = db_json_convert_string_and_call (db_get_string (arg[i]), db_get_string_size (arg[i]),
+                                                        db_json_merge_func, accumulator);
 	  break;
 
 	case DB_TYPE_NULL:
@@ -28396,7 +28398,8 @@ db_value_to_json_doc (const DB_VALUE & value, REFPTR (JSON_DOC, json))
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      error_code = db_json_get_json_from_str (db_get_string (&value), json, db_get_string_size(&value));
+      error_code = db_json_get_json_from_str (db_get_string (&value), json,
+                                              db_get_string_size (&value));
       if (error_code != NO_ERROR)
 	{
 	  assert (json == NULL);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22232

The implementation of `db_json_get_json_from_str` does `doc.Parse(str)`. Because the string is not null terminated, it will go until reaches `'\0'` so this is why we will have a parse error. 

Modified the header of `db_get_json_from_str` to send a string with a specific length.
