### PR TITLE
[CBRD-22226] [shell] Core dumped in db_json_serialize at src/compat/db_json.cpp:2945

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16732,7 +16732,7 @@ mr_data_writemem_json (OR_BUF * buf, void *memptr, TP_DOMAIN * domain)
   int rc = NO_ERROR;
 
   json = (DB_JSON *) memptr;
-  if (json == NULL)
+  if (json == NULL || json->document == NULL)
     {
       return;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22226

The `json->document` pointer was `NULL`, but dereferencing a nullptr causes undefined behavior. 

So, in order to avoid these cases, we should add a safety check before entering the function.