### PR TITLE
[CBRD-22257] keep error stack safe-guard for server mode only

### DIFF
--- a/src/base/error_context.cpp
+++ b/src/base/error_context.cpp
@@ -255,7 +255,11 @@ namespace cuberr
   void
   context::deregister_thread_local (void)
   {
+#if defined (SERVER_MODE)
+    // safe-guard that stacks are not "leaked"
+    // ignore it for client (this is too late anyway)
     assert (m_stack.empty ());
+#endif // SERVER_MODE
 
     clear_all_levels ();
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22257

keep error stack safe-guard for server mode only