### PR TITLE
[CBRD-22268] remove duplicate b-tree root page initialization

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -4845,7 +4845,7 @@ btree_get_new_page (THREAD_ENTRY * thread_p, BTID_INT * btid, VPID * vpid, VPID 
  * return        : NO_ERROR
  * thread_p (in) : thread entry
  * page (in)     : new b-tree page
- * args (in)     : ignored
+ * args (in)     : true or nil for undoredo logging; false for redo
  */
 int
 btree_initialize_new_page (THREAD_ENTRY * thread_p, PAGE_PTR page, void *args)
@@ -5413,7 +5413,6 @@ xbtree_add_index (THREAD_ENTRY * thread_p, BTID * btid, TP_DOMAIN * key_type, OI
   BTREE_ROOT_HEADER root_header_info, *root_header = NULL;
   VPID root_vpid;
   PAGE_PTR page_ptr = NULL;
-  unsigned short alignment;
 
   root_header = &root_header_info;
 
@@ -5439,13 +5438,6 @@ xbtree_add_index (THREAD_ENTRY * thread_p, BTID * btid, TP_DOMAIN * key_type, OI
       goto error;
     }
   pgbuf_check_page_ptype (thread_p, page_ptr, PAGE_BTREE);
-
-  alignment = BTREE_MAX_ALIGN;
-  if (btree_initialize_new_page (thread_p, page_ptr, (void *) &alignment) != NO_ERROR)
-    {
-      ASSERT_ERROR ();
-      goto error;
-    }
 
   /* form the root header information */
   root_header->node.split_info.pivot = 0.0f;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22268

b-tree page initialization is logged with undoredo. on undo, page type is set to deallocated/unknown. xbtree_add_index initialized root page twice; which lead to inconsistent state during rollback.

remove duplicate b-tree root page initialization.