### PR TITLE
[CBRD-22277] fix worker pool stopping

### DIFF
--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -442,6 +442,10 @@ namespace cubthread
       {
 	return m_has_thread;
       }
+      void set_has_thread (void)
+      {
+	m_has_thread = true;
+      }
       void set_push_time_now (void)
       {
 	m_push_time = cubperf::clock::now ();
@@ -1046,6 +1050,7 @@ namespace cubthread
 	  {
 	    // this thread is already stopped and we can start its thread
 	    refp->set_push_time_now ();
+	    refp->set_has_thread ();
 	    refp->start_thread ();
 	  }
       }
@@ -1144,6 +1149,7 @@ namespace cubthread
       }
     else
       {
+	m_has_thread = true;
 	ulock.unlock ();
 
 	assert (m_context_p == NULL);
@@ -1231,6 +1237,9 @@ namespace cubthread
   void
   worker_pool<Context>::core::worker::init_run (void)
   {
+    // safe-guard - we have a thread
+    assert (m_has_thread);
+
     // safe-guard - threads should [no longer] be available
     m_parent_core->check_worker_not_available (*this);
 
@@ -1241,9 +1250,6 @@ namespace cubthread
     // a context is required
     m_context_p = &m_parent_core->get_context_manager ().create_context ();
     wp_worker_statset_time_and_increment (m_statistics, Wpstat_create_context);
-
-    // will be set when thread decides to stop (there's no going back after this was set to true)
-    m_has_thread = true;
   }
 
   template <typename Context>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22277

worker is marked as having thread too late (only after thread was spawned).

vacuum worker pool is stopped. all workers are notified to stop. one worker was just assigned a task, but has not started yet, and its m_has_thread flag is false. pool wrongfully assumes everyone is stopped and gets destroyed.

worker finally wakes up to init_run and finds destroyed core parent, causing the crash.

To have a safe stop, we need to set m_has_thread before actually starting the thread.