### PR TITLE
[CBRD-22288] fix update xasl's referenced oid list

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -8761,6 +8761,12 @@ pt_print_delete (PARSER_CONTEXT * parser, PT_NODE * p)
   r1 = pt_print_bytes_l (parser, p->info.delete_.target_classes);
   r2 = pt_print_bytes_spec_list (parser, p->info.delete_.spec);
 
+  if (p->info.delete_.with != NULL)
+    {
+      r1 = pt_print_bytes_l (parser, p->info.delete_.with);
+      b = pt_append_varchar (parser, b, r1);
+    }
+
   q = pt_append_nulstring (parser, q, "delete ");
   if (p->info.delete_.hint != PT_HINT_NONE)
     {
@@ -15773,6 +15779,12 @@ static PARSER_VARCHAR *
 pt_print_update (PARSER_CONTEXT * parser, PT_NODE * p)
 {
   PARSER_VARCHAR *b = NULL, *r1;
+
+  if (p->info.update.with != NULL)
+    {
+      r1 = pt_print_bytes_l (parser, p->info.update.with);
+      b = pt_append_varchar (parser, b, r1);
+    }
 
   b = pt_append_nulstring (parser, b, "update ");
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -8764,7 +8764,7 @@ pt_print_delete (PARSER_CONTEXT * parser, PT_NODE * p)
   if (p->info.delete_.with != NULL)
     {
       r1 = pt_print_bytes_l (parser, p->info.delete_.with);
-      b = pt_append_varchar (parser, b, r1);
+      q = pt_append_varchar (parser, q, r1);
     }
 
   q = pt_append_nulstring (parser, q, "delete ");

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -20450,19 +20450,27 @@ pt_to_update_xasl (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** non_
 
   if (xasl->aptr_list != NULL)
     {
-      xasl->n_oid_list = xasl->aptr_list->n_oid_list;
-      xasl->aptr_list->n_oid_list = 0;
+      XASL_NODE *last = xasl->aptr_list;
+      for (XASL_NODE * crt = xasl->aptr_list->next; crt; last = last->next, crt = crt->next)
+	{
+	  // CTE procs are before the BuildList and are empty of references
+	  assert (last->n_oid_list == 0);
+	  assert (last->dbval_cnt == 0);
+	}
 
-      xasl->class_oid_list = xasl->aptr_list->class_oid_list;
-      xasl->aptr_list->class_oid_list = NULL;
+      xasl->n_oid_list = last->n_oid_list;
+      last->n_oid_list = 0;
 
-      xasl->class_locks = xasl->aptr_list->class_locks;
-      xasl->aptr_list->class_locks = NULL;
+      xasl->class_oid_list = last->class_oid_list;
+      last->class_oid_list = NULL;
 
-      xasl->tcard_list = xasl->aptr_list->tcard_list;
-      xasl->aptr_list->tcard_list = NULL;
+      xasl->class_locks = last->class_locks;
+      last->class_locks = NULL;
 
-      xasl->dbval_cnt = xasl->aptr_list->dbval_cnt;
+      xasl->tcard_list = last->tcard_list;
+      last->tcard_list = NULL;
+
+      xasl->dbval_cnt = last->dbval_cnt;
     }
 
   xasl->query_alias = statement->alias_print;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -19616,19 +19616,27 @@ pt_to_delete_xasl (PARSER_CONTEXT * parser, PT_NODE * statement)
       /* list of class OIDs used in this XASL */
       if (xasl->aptr_list != NULL)
 	{
-	  xasl->n_oid_list = xasl->aptr_list->n_oid_list;
-	  xasl->aptr_list->n_oid_list = 0;
+	  XASL_NODE *last = xasl->aptr_list;
+	  for (XASL_NODE * crt = xasl->aptr_list->next; crt; last = last->next, crt = crt->next)
+	    {
+	      // CTE procs are before the BuildList and are empty of references
+	      assert (last->n_oid_list == 0);
+	      assert (last->dbval_cnt == 0);
+	    }
 
-	  xasl->class_oid_list = xasl->aptr_list->class_oid_list;
-	  xasl->aptr_list->class_oid_list = NULL;
+	  xasl->n_oid_list = last->n_oid_list;
+	  last->n_oid_list = 0;
 
-	  xasl->class_locks = xasl->aptr_list->class_locks;
-	  xasl->aptr_list->class_locks = NULL;
+	  xasl->class_oid_list = last->class_oid_list;
+	  last->class_oid_list = NULL;
 
-	  xasl->tcard_list = xasl->aptr_list->tcard_list;
-	  xasl->aptr_list->tcard_list = NULL;
+	  xasl->class_locks = last->class_locks;
+	  last->class_locks = NULL;
 
-	  xasl->dbval_cnt = xasl->aptr_list->dbval_cnt;
+	  xasl->tcard_list = last->tcard_list;
+	  last->tcard_list = NULL;
+
+	  xasl->dbval_cnt = last->dbval_cnt;
 	}
     }
   if (xasl)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22288

OID list of the update's XASL parent was built using the references of the BUILDLIST PROC (it's aptr) which is underneath it. To enable CTEs for Update, CTE procs were placed as aptrs before the last BUILDLIST proc. The fix was to copy the oid list from the last aptr.