### PR TITLE
[CBRD-22325] setFetchSize throws an exception when zero size is given

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
@@ -383,7 +383,7 @@ public class CUBRIDStatement implements Statement {
 
 	public synchronized void setFetchSize(int rows) throws SQLException {
 		checkIsOpen();
-		if (rows <= 0) {
+		if (rows < 0) {
 			throw new IllegalArgumentException();
 		}
 		fetch_size = rows;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22325

Statement.setFetchSize(0) should work. but it throws illegalArgumentException.