### PR TITLE
[CBRD-22315] unexpected default_value in db_attribute

### DIFF
--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -1481,6 +1481,17 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	  attr_val_p->need_clear = true;
 	  default_value_len = len;
 	}
+      else
+	{
+	  /* update_default exists and default_expr is either not DB_TYPE_ENUMERATION or not existent */
+	  valcnv_convert_value_to_string (attr_val_p);
+	  db_string_truncate (attr_val_p, DB_MAX_IDENTIFIER_LENGTH);
+	  default_str_val = db_get_string (attr_val_p);
+	  if (default_str_val != NULL)
+	    {
+	      default_value_len = strlen (default_str_val);
+	    }
+	}
 
       if (classobj_get_prop (att_props, "update_default", &default_expr) > 0)
 	{

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -1483,7 +1483,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	}
       else
 	{
-	  /* update_default exists and default_expr is either not DB_TYPE_ENUMERATION or not existent */
+	  /* update_default exists and default_expr is not a DEFAULT EXPRESSION or does not exist */
 	  valcnv_convert_value_to_string (attr_val_p);
 	  db_string_truncate (attr_val_p, DB_MAX_IDENTIFIER_LENGTH);
 	  default_str_val = db_get_string (attr_val_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22315

In case default_expr is not a default expression it is left out of default_value in db_attribute. Fix is to convert the value to string and later append the on update default part to it (same way as when there is no on update expression either).