### PR TITLE
[CBRD-22326]  raise an error when using index clause refers to an invisible index

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -7402,7 +7402,6 @@ qo_discover_indexes (QO_ENV * env)
   /* iterate over all nodes and find indexes for each node */
   for (i = 0; i < env->nnodes; i++)
     {
-
       nodep = QO_ENV_NODE (env, i);
       if (nodep->info)
 	{
@@ -7414,23 +7413,20 @@ qo_discover_indexes (QO_ENV * env)
 				    (PT_SPEC_FLAG_RECORD_INFO_SCAN | PT_SPEC_FLAG_PAGE_INFO_SCAN)))
 	    {
 	      qo_find_node_indexes (env, nodep);
-	      /* collect statistic information on discovered indexes */
-	      qo_get_index_info (env, nodep);
+	      if (0 < QO_NODE_INFO_N (nodep) && QO_NODE_INDEXES (nodep) != NULL)
+		{
+		  /* collect statistics if discovers an usable index */
+		  qo_get_index_info (env, nodep);
+		  continue;
+		}
+	      /* fall through */
 	    }
-	  else
-	    {
-	      QO_NODE_INDEXES (nodep) = NULL;
-	    }
-	}
-      else
-	{
-	  /* If the 'info' of node is NULL, then this is probably a derived table. Without the info, we don't have
-	   * class information to work with so we really can't do much so just skip the node. 
-	   */
-	  QO_NODE_INDEXES (nodep) = NULL;	/* this node will not use a index */
+	  /* fall through */
 	}
 
-    }				/* for (n = 0; n < env->nnodes; n++) */
+      /* this node will not use an index */
+      QO_NODE_INDEXES (nodep) = NULL;
+    }
 
   /* for each terms, look indexed segements and filter out the segments which don't actually contain any indexes */
   for (i = 0; i < env->nterms; i++)

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -6865,14 +6865,11 @@ pt_resolve_using_index (PARSER_CONTEXT * parser, PT_NODE * index, PT_NODE * from
 				  pt_short_print (parser, index));
 		      return NULL;
 		    }
-		  else if (cons->index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS)
+		  else if (cons->index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS
+			   || cons->index_status == SM_INVISIBLE_INDEX)
 		    {
-		      // TODO: raise an error?
-		      return NULL;	// unusable index
-		    }
-		  else if (cons->index_status == SM_INVISIBLE_INDEX)
-		    {
-		      // TODO: raise an error?
+		      PT_ERRORmf (parser, index, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_USING_INDEX_ERR_1,
+				  pt_short_print (parser, index));
 		      return NULL;	// unusable index
 		    }
 		}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22326

It is an inherited vulnerability might crash.

I've pushed another patch to raise an error when using index clause refers to an invisible index.
I believe this will also fix the other client crashes.
