### PR TITLE
[CBRD-22343] reset sysop LSA's

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1606,14 +1606,14 @@ log_rv_analysis_sysop_end (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_l
       tdes->topops.last = -1;
     }
 
-  if (LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.atomic_sysop_start_lsa))
+  if (LSA_LE (&sysop_end->lastparent_lsa, &tdes->rcv.atomic_sysop_start_lsa))
     {
       /* reset tdes->rcv.atomic_sysop_start_lsa */
       LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
     }
-  if (LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.sysop_start_postpone_lsa))
+  if (LSA_LE (&sysop_end->lastparent_lsa, &tdes->rcv.sysop_start_postpone_lsa))
     {
-      /* reset tdes->rcv.atomic_sysop_start_lsa */
+      /* reset tdes->rcv.sysop_start_postpone_lsa */
       LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22343

log_rv_analysis_sysop_end: reset `tdes->rcv.atomic_sysop_start_lsa` and `tdes->rcv.sysop_start_postpone_lsa` if they are equal to sysop_end->lastparent_lsa.

Fix is explained in JIRA issue.