### PR TITLE
[CBRD-22344] Json_Table error message correction

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -4815,14 +4815,14 @@ original_table_spec
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
-        | json_table_rule AS identifier
+	| JSON_TABLE json_table_rule AS identifier
 		{{
 			PT_NODE *ent = parser_new_node (this_parser, PT_SPEC);
 			if (ent)
 			  {
-			    ent->info.spec.derived_table = $1;  // json_table_rule
+			    ent->info.spec.derived_table = $2;  // json_table_rule
 			    ent->info.spec.derived_table_type = PT_DERIVED_JSON_TABLE;
-			    ent->info.spec.range_var = $3;      // identifier
+			    ent->info.spec.range_var = $4;      // identifier
 			  }
 			$$ = ent;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -24302,13 +24302,11 @@ json_table_rule
     : {{
 	    json_table_column_count = 0;
       DBG_PRINT}} 
-	JSON_TABLE '(' expression_ ',' json_table_node_rule ')'
+	'(' expression_ ',' json_table_node_rule ')'
       {{
-        // $3 = expression_
-        // $5 = json_table_node_rule
         PT_NODE *jt = parser_new_node (this_parser, PT_JSON_TABLE);
-        jt->info.json_table_info.expr = $4;
-        jt->info.json_table_info.tree = $6;
+        jt->info.json_table_info.expr = $3;
+        jt->info.json_table_info.tree = $5;
 
         $$ = jt;
       DBG_PRINT}}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22344

Fixed by placing the JSON_TABLE token on the same level as other sibling's tokens. The issue was that during state transitions the parser was trying to find from remaining buffer _测试表__P__P0_ a token matching the regex: **([a-zA-Z_#]|([\xc0-\xfe]))([a-zA-Z_#0-9]|([\x80-\xfe]))***. It tried then with GLR parsing to traverse down _original_table_spec -> json_table_rule_, and saved the expected token as _"JSON_TABLE"_.