### PR TITLE
[CBRD-22181] Enable CTEs for client-side queries

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -16771,7 +16771,7 @@ parser_generate_xasl_proc (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * qu
 	  if (query->info.query.xasl && query->info.query.id == node->info.query.id)
 	    {
 	      // claim it's never used
-	      assert_release (false);
+	      assert (false);
 
 	      /* found cached query xasl */
 	      node->info.query.xasl = query->info.query.xasl;
@@ -17388,29 +17388,8 @@ pt_make_aptr_parent_node (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * wit
 		  namelist = pt_get_select_list (parser, node);
 		}
 
-	      /* append aptr after cte procs */
-	      if (cte != NULL)
-		{
-		  XASL_NODE *cte_xasl = (XASL_NODE *) cte->info.cte.xasl;
-		  XASL_NODE *last_aptr = cte_xasl;
-		  xasl->aptr_list = cte_xasl;
-
-		  cte = cte->next;
-		  while (cte != NULL)
-		    {
-		      cte_xasl = (XASL_NODE *) cte->info.cte.xasl;
-		      last_aptr->next = cte_xasl;
-		      cte = cte->next;
-		      last_aptr = last_aptr->next;
-		    }
-
-		  last_aptr->next = aptr;
-		}
-	      else
-		{
-		  xasl->aptr_list = aptr;
-		}
 	      aptr->next = NULL;
+              xasl->aptr_list = aptr;
 
 	      xasl->val_list = pt_make_val_list (parser, namelist);
 	      if (xasl->val_list != NULL)
@@ -19054,18 +19033,8 @@ pt_to_upd_del_query (PARSER_CONTEXT * parser, PT_NODE * select_names, PT_NODE * 
   statement = parser_new_node (parser, PT_SELECT);
   if (statement != NULL)
     {
-      if (server_op)
-	{
-	  if (with != NULL)
-	    {
-	      pt_to_with_clause_xasl (parser, with);
-	    }
-	}
-      else
-	{
-	  statement->info.query.with = with;
-	}
-
+      statement->info.query.with = with;
+      
       /* this is an internally built query */
       PT_SELECT_INFO_SET_FLAG (statement, PT_SELECT_INFO_IS_UPD_DEL_QUERY);
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -16770,6 +16770,9 @@ parser_generate_xasl_proc (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * qu
 	{
 	  if (query->info.query.xasl && query->info.query.id == node->info.query.id)
 	    {
+	      // claim it's never used
+	      assert (false);
+
 	      /* found cached query xasl */
 	      node->info.query.xasl = query->info.query.xasl;
 	      node->info.query.correlation_level = query->info.query.correlation_level;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -18993,7 +18993,6 @@ pt_mark_spec_list_for_update_clause (PARSER_CONTEXT * parser, PT_NODE * statemen
  *
  *   parser(in): context
  *   with(in): with-clause containing ctes
- *   spec_flag(in): spec flag: PT_SPEC_FLAG_UPDATE or PT_SPEC_FLAG_DELETE
  */
 void
 pt_to_with_clause_xasl (PARSER_CONTEXT * parser, PT_NODE * with)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -16771,7 +16771,7 @@ parser_generate_xasl_proc (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * qu
 	  if (query->info.query.xasl && query->info.query.id == node->info.query.id)
 	    {
 	      // claim it's never used
-	      assert (false);
+	      assert_release (false);
 
 	      /* found cached query xasl */
 	      node->info.query.xasl = query->info.query.xasl;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -18987,10 +18987,9 @@ pt_mark_spec_list_for_update_clause (PARSER_CONTEXT * parser, PT_NODE * statemen
 
 /*
  * pt_to_with_clause_xasl () - Creates xasl for ctes nodes of the with clause
- *                    
- *   return:
+ *
  *   parser(in): context
- *   statement(in): select parse tree
+ *   with(in): with-clause containing ctes
  *   spec_flag(in): spec flag: PT_SPEC_FLAG_UPDATE or PT_SPEC_FLAG_DELETE
  */
 void
@@ -19053,7 +19052,17 @@ pt_to_upd_del_query (PARSER_CONTEXT * parser, PT_NODE * select_names, PT_NODE * 
   statement = parser_new_node (parser, PT_SELECT);
   if (statement != NULL)
     {
-      pt_to_with_clause_xasl (parser, with);
+      if (server_op)
+	{
+	  if (with != NULL)
+	    {
+	      pt_to_with_clause_xasl (parser, with);
+	    }
+	}
+      else
+	{
+	  statement->info.query.with = with;
+	}
 
       /* this is an internally built query */
       PT_SELECT_INFO_SET_FLAG (statement, PT_SELECT_INFO_IS_UPD_DEL_QUERY);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -10347,8 +10347,6 @@ do_prepare_delete (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * paren
 
 	  delete_info = &statement->info.delete_;
 
-	  assert (delete_info->with == NULL);
-
 	  select_statement =
 	    pt_to_upd_del_query (parser, NULL, NULL, delete_info->spec, delete_info->with, delete_info->class_specs,
 				 delete_info->search_cond, delete_info->using_index, NULL, NULL, 0, S_DELETE);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -13439,8 +13439,6 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
       goto cleanup;
     }
 
-  // force Client-side
-  statement->info.insert.server_allowed = SERVER_INSERT_IS_NOT_ALLOWED;
   if (statement->info.insert.server_allowed != SERVER_INSERT_IS_ALLOWED)
     {
       goto cleanup;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -9040,13 +9040,6 @@ do_prepare_update (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  PT_NODE *assigns = statement->info.update.assignment;
 	  PT_NODE *from = statement->info.update.spec;
 
-	  if (statement->info.update.with != NULL)
-	    {
-	      /* client-side updates with CTEs are not supported for now */
-	      PT_INTERNAL_ERROR (parser, "update");
-	      break;
-	    }
-
 	  err = pt_append_omitted_on_update_expr_assignments (parser, assigns, from);
 	  if (err != NO_ERROR)
 	    {
@@ -13448,6 +13441,8 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
       goto cleanup;
     }
 
+  // force Client-side
+  statement->info.insert.server_allowed = SERVER_INSERT_IS_NOT_ALLOWED;
   if (statement->info.insert.server_allowed != SERVER_INSERT_IS_ALLOWED)
     {
       goto cleanup;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -8668,14 +8668,6 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 
   /* lock classes which this query will update */
   aptr = xasl->aptr_list;
-  if (aptr != NULL)
-    {
-      for (XASL_NODE * crt = aptr->next; crt; aptr = aptr->next, crt = crt->next)
-	{
-	  // assert there is never the situation that a CTE_PROC is after another type of PROC
-	  assert (!(aptr->type != CTE_PROC && crt->type == CTE_PROC));
-	}
-    }
   error = qexec_set_class_locks (thread_p, aptr, update->classes, update->num_classes, internal_classes);
   if (error != NO_ERROR)
     {
@@ -8702,13 +8694,9 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
       p_class_instance_lock_info = &class_instance_lock_info;
     }
 
-  aptr = xasl->aptr_list;
-  for (XASL_NODE * crt = aptr; crt != NULL && error == NO_ERROR; crt = crt->next)
+  if (qexec_execute_mainblock (thread_p, aptr, xasl_state, p_class_instance_lock_info) != NO_ERROR)
     {
-      if (qexec_execute_mainblock (thread_p, crt, xasl_state, p_class_instance_lock_info) != NO_ERROR)
-	{
-	  GOTO_EXIT_ON_ERROR;
-	}
+      GOTO_EXIT_ON_ERROR;
     }
 
   if (p_class_instance_lock_info && p_class_instance_lock_info->instances_locked)
@@ -9617,13 +9605,6 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 
   /* lock classes from which this query will delete */
   aptr = xasl->aptr_list;
-  if (aptr != NULL)
-    {
-      for (XASL_NODE * crt = aptr->next; crt; aptr = aptr->next, crt = crt->next)
-	{
-	  assert (!(aptr->type != CTE_PROC && crt->type == CTE_PROC));
-	}
-    }
   error = qexec_set_class_locks (thread_p, aptr, delete_->classes, delete_->num_classes, internal_classes);
   if (error != NO_ERROR)
     {
@@ -9649,13 +9630,9 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
       p_class_instance_lock_info = &class_instance_lock_info;
     }
 
-  aptr = xasl->aptr_list;
-  for (XASL_NODE * crt = aptr; crt != NULL; crt = crt->next)
+  if (qexec_execute_mainblock (thread_p, aptr, xasl_state, p_class_instance_lock_info) != NO_ERROR)
     {
-      if (qexec_execute_mainblock (thread_p, crt, xasl_state, p_class_instance_lock_info) != NO_ERROR)
-	{
-	  GOTO_EXIT_ON_ERROR;
-	}
+      GOTO_EXIT_ON_ERROR;
     }
 
   if (p_class_instance_lock_info && p_class_instance_lock_info->instances_locked)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1108,7 +1108,8 @@ qexec_end_one_iteration (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE *
 	  XASL_NODE *aptr = xasl->aptr_list;
 	  if (aptr)
 	    {
-	      for (XASL_NODE * crt = aptr->next; crt; crt = crt->next, aptr = aptr->next);
+	      for (XASL_NODE * crt = aptr->next; crt; crt = crt->next, aptr = aptr->next)
+		;
 	    }
 	  if (aptr && aptr->type == BUILDLIST_PROC && aptr->proc.buildlist.push_list_id)
 	    {

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -993,7 +993,7 @@ struct xasl_node
   ACCESS_SPEC_TYPE *merge_spec;	/* merge spec. node */
   VAL_LIST *val_list;		/* output-value list */
   VAL_LIST *merge_val_list;	/* value list for the merge spec */
-  XASL_NODE *aptr_list;		/* CTEs and uncorrelated subquery; CTEs are guaranteed always before the subqueries */
+  XASL_NODE *aptr_list;		/* CTEs and uncorrelated subquery. CTEs are guaranteed always before the subqueries */
   XASL_NODE *bptr_list;		/* OBJFETCH_PROC list */
   XASL_NODE *dptr_list;		/* corr. subquery list */
   PRED_EXPR *after_join_pred;	/* after-join predicate */

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -993,7 +993,7 @@ struct xasl_node
   ACCESS_SPEC_TYPE *merge_spec;	/* merge spec. node */
   VAL_LIST *val_list;		/* output-value list */
   VAL_LIST *merge_val_list;	/* value list for the merge spec */
-  XASL_NODE *aptr_list;		/* first uncorrelated subquery */
+  XASL_NODE *aptr_list;		/* CTEs and uncorrelated subquery; CTEs are guaranteed always before the subqueries */
   XASL_NODE *bptr_list;		/* OBJFETCH_PROC list */
   XASL_NODE *dptr_list;		/* corr. subquery list */
   PRED_EXPR *after_join_pred;	/* after-join predicate */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22181

Changed to pass the with clause of the update/delete down to the generated server-run select query. CTE proc is being generated for the select query, making cte list file results available when executing the client-side queries.