### PR TITLE
[CBRD-22375] Core dumped in cubbase::restrack_assert

### DIFF
--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -6986,8 +6986,8 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 		  /* we might get a NULL count if aggregating with hash table and group has only one tuple; correct that */
 		  db_make_int (accumulator->value, 0);
 		}
-              pr_clear_value_vector (db_values);
-              continue;
+	      pr_clear_value_vector (db_values);
+	      continue;
 	    }
 	}
 

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -6986,7 +6986,8 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 		  /* we might get a NULL count if aggregating with hash table and group has only one tuple; correct that */
 		  db_make_int (accumulator->value, 0);
 		}
-	      continue;
+              pr_clear_value_vector (db_values);
+              continue;
 	    }
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22375

Vector's db_vals are not cleared before its destruction 