### PR TITLE
[CBRD-22397] Skip online index loading for shared constraints

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -16431,6 +16431,13 @@ sm_load_online_index (MOP classmop, const char *constraint_name)
   assert (con != NULL);
   assert (con->index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS);
 
+  /* We must check if the constraint isn't shared from another one. */
+  if (con->shared_cons_name != NULL)
+    {
+      /*  The BTID already exists and surely it has been loaded. Therefore we can just stop here */
+      return NO_ERROR;
+    }
+
   /* Count the attributes */
   for (i = 0, n_attrs = 0; con->attributes[i] != NULL; i++, n_attrs++)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22397

The normal behavior for shared constraints, specifically for indexes, is that they copy the `BTID` of the original constraint and they do not start another load process for the new index. Online indexes now follow the same behavior.

The issue resided in the fact that the new index will start another load process that will use the first index's `BTID`. Therefore, it will begin inserting objects into the `BTREE`, which was already loaded, and will fail asserts for already inserted objects.