### PR TITLE
[CBRD-22409] fix walking/copying union parser node

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -15683,6 +15683,10 @@ pt_apply_union_stmt (PARSER_CONTEXT * parser, PT_NODE * p, PT_NODE_FUNCTION g, v
   p->info.query.into_list = g (parser, p->info.query.into_list, arg);
   p->info.query.order_by = g (parser, p->info.query.order_by, arg);
   p->info.query.orderby_for = g (parser, p->info.query.orderby_for, arg);
+  p->info.query.limit = g (parser, p->info.query.orderby_for, arg);
+  // todo - there is a lot less stuff here than on pt_apply_select. I am not sure this is safe.
+  //        e.g. this is used for parser_copy_tree too. which should deep copy entire tree! otherwise we may have some
+  //        unpleasant effects.
   return p;
 }
 
@@ -19329,4 +19333,12 @@ pt_print_json_table_columns (PARSER_CONTEXT * parser, PT_NODE * p)
   pstr = pt_print_json_table_column_info (parser, p_it, pstr);
 
   return pstr;
+}
+
+// pt_move_node - move PT_NODE pointer from source to destination. useful to automatically assign and unlink
+void
+pt_move_node (REFPTR (PT_NODE, destp), REFPTR (PT_NODE, srcp))
+{
+  destp = srcp;
+  srcp = NULL;
 }

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -650,4 +650,8 @@ extern "C"
 }
 #endif
 
-#endif				/* _PARSER_H_ */
+#if defined __cplusplus
+extern void pt_move_node (REFPTR (PT_NODE, destp), REFPTR (PT_NODE, srcp));
+#endif // c++
+
+#endif /* _PARSER_H_ */

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -15914,15 +15914,12 @@ pt_check_union_is_foldable (PARSER_CONTEXT * parser, PT_NODE * union_node)
 PT_NODE *
 pt_fold_union (PARSER_CONTEXT * parser, PT_NODE * union_node, STATEMENT_SET_FOLD fold_as)
 {
-  PT_NODE *arg1, *arg2, *new_node, *next;
+  PT_NODE *new_node, *next;
   int line, column;
   const char *alias_print;
 
   assert (union_node->node_type == PT_UNION || union_node->node_type == PT_INTERSECTION
 	  || union_node->node_type == PT_DIFFERENCE);
-
-  arg1 = union_node->info.query.q.union_.arg1;
-  arg2 = union_node->info.query.q.union_.arg2;
 
   line = union_node->line_number;
   column = union_node->column_number;
@@ -15945,19 +15942,19 @@ pt_fold_union (PARSER_CONTEXT * parser, PT_NODE * union_node, STATEMENT_SET_FOLD
 
       if (fold_as == STATEMENT_SET_FOLD_AS_ARG1)
 	{
-	  active = arg1;
+	  pt_move_node (active, union_node->info.query.q.union_.arg1);
 	}
       else
 	{
-	  active = arg2;
+	  pt_move_node (active, union_node->info.query.q.union_.arg2);
 	}
 
       /* to save union's orderby or limit clause to arg1 or arg2 */
-      union_orderby = union_node->info.query.order_by;
-      union_orderby_for = union_node->info.query.orderby_for;
-      union_limit = union_node->info.query.limit;
+      pt_move_node (union_orderby, union_node->info.query.order_by);
+      pt_move_node (union_orderby_for, union_node->info.query.orderby_for);
+      pt_move_node (union_limit, union_node->info.query.limit);
       union_rewrite_limit = union_node->info.query.rewrite_limit;
-      union_with_clause = union_node->info.query.with;
+      pt_move_node (union_with_clause, union_node->info.query.with);
 
       /* When active node has a limit or orderby_for clause and union node has a limit or ORDERBY clause, need a
        * derived table to keep both conflicting clauses. When a subquery has orderby clause without
@@ -15981,20 +15978,7 @@ pt_fold_union (PARSER_CONTEXT * parser, PT_NODE * union_node, STATEMENT_SET_FOLD
 	  new_node = active;
 	}
 
-      /* unlink and free union node */
-      union_node->info.query.order_by = NULL;
-      union_node->info.query.orderby_for = NULL;
-      union_node->info.query.limit = NULL;
-      if (fold_as == STATEMENT_SET_FOLD_AS_ARG1)
-	{
-	  union_node->info.query.q.union_.arg1 = NULL;	/* to save arg1 to fold */
-	}
-      else
-	{
-	  union_node->info.query.q.union_.arg2 = NULL;	/* to save arg2 to fold */
-	}
-      union_node->info.query.with = NULL;
-
+      /* free union node */
       parser_free_tree (parser, union_node);
 
       /* to fold the query with remaining parts */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22409

pt_apply_union_node misses walking over info.query.limit node. As a consequence, when tree is copied, limit node is not deep-copied.

1. A temporary copy of create_select tree is created.
2. Union is folder as select query due to false-where statement and converted in a PT_SELECT node, and limit node is copied.
3. Temporary tree is freed recursively. This time limit node is accessed by pt_apply_select and is freed!
4. Node is reused, corrupting create_select tree.
5. Safe-guard finds unexpected limit node type PT_NAME.

Fixed by including limit node in pt_apply_union_node.