### PR TITLE
[CBRD-22413] use different name nodes for spec.as_attr_list and json table columns

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -4412,7 +4412,7 @@ pt_get_all_json_table_attributes_and_types (PARSER_CONTEXT * parser, PT_NODE * j
       // we need copies of the actual names
       copy_node = pt_name (parser, attr->info.name.original);
       copy_node->type_enum = attr->type_enum;
-      copy_node->info.name.resolved == json_table_alias;
+      copy_node->info.name.resolved = json_table_alias;
       if (attr->data_type != NULL)
 	{
 	  copy_node->data_type = parser_copy_tree (parser, attr->data_type);

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -19182,6 +19182,7 @@ pt_init_json_table_column (PT_NODE * p)
 static PT_NODE *
 pt_apply_json_table_column (PARSER_CONTEXT * parser, PT_NODE * p, PT_NODE_FUNCTION g, void *arg)
 {
+  p->info.json_table_column_info.name = g (parser, p->info.json_table_column_info.name, arg);
   return p;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22413

Fix consists of multiple changes in how json table column names are handled.

  1. We have to include json table name in "apply" of walker (fix copy tree and free one of the copies).
  2. Use different nodes in spec's as_attr_list (again, duplicate pointers may lead to complications).
  3. Fix resolving json table column info's name (pt_bind_name_to_spec workaround).