### PR TITLE
[CBRD-22418] correct {unique | not_null} btree index type

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -16407,6 +16407,7 @@ sm_load_online_index (MOP classmop, const char *constraint_name)
   HFID *hfids = NULL;
   int reverse;
   int unique_pk = 0;
+  int not_null;
 
   /* Fetch the class. */
   error = au_fetch_class (classmop, &class_, AU_FETCH_UPDATE, AU_ALTER);
@@ -16540,16 +16541,18 @@ sm_load_online_index (MOP classmop, const char *constraint_name)
   if (con->type == SM_CONSTRAINT_UNIQUE || con->type == SM_CONSTRAINT_REVERSE_UNIQUE)
     {
       unique_pk = BTREE_CONSTRAINT_UNIQUE;
+      not_null = 0;
     }
   else if (con->type == SM_CONSTRAINT_PRIMARY_KEY)
     {
       unique_pk = BTREE_CONSTRAINT_UNIQUE | BTREE_CONSTRAINT_PRIMARY_KEY;
+      not_null = 1;
     }
 
   if (con->func_index_info)
     {
       error = btree_load_index (&con->index_btid, constraint_name, domain, oids, n_classes, n_attrs, attr_ids,
-				(int *) con->attrs_prefix_length, hfids, unique_pk, false, NULL,
+				(int *) con->attrs_prefix_length, hfids, unique_pk, not_null, NULL,
 				NULL, NULL, SM_GET_FILTER_PRED_STREAM (con->filter_predicate),
 				SM_GET_FILTER_PRED_STREAM_SIZE (con->filter_predicate),
 				con->func_index_info->expr_stream, con->func_index_info->expr_stream_size,
@@ -16559,7 +16562,7 @@ sm_load_online_index (MOP classmop, const char *constraint_name)
   else
     {
       error = btree_load_index (&con->index_btid, constraint_name, domain, oids, n_classes, n_attrs, attr_ids,
-				(int *) con->attrs_prefix_length, hfids, unique_pk, false, NULL,
+				(int *) con->attrs_prefix_length, hfids, unique_pk, not_null, NULL,
 				NULL, NULL, SM_GET_FILTER_PRED_STREAM (con->filter_predicate),
 				SM_GET_FILTER_PRED_STREAM_SIZE (con->filter_predicate), NULL, -1, -1, -1,
 				con->index_status);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -33152,7 +33152,7 @@ btree_online_index_set_normal_state (MVCCID & state)
 //
 int
 btree_online_index_dispatcher (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key, OID * class_oid, OID * oid,
-			       int *unique, BTREE_OP_PURPOSE purpose, LOG_LSA * undo_nxlsa)
+			       int unique, BTREE_OP_PURPOSE purpose, LOG_LSA * undo_nxlsa)
 {
   int error_code = NO_ERROR;
   /* Search key helper which will point to where data should inserted. */
@@ -33178,7 +33178,7 @@ btree_online_index_dispatcher (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * 
   if (DB_IS_NULL (key) || btree_multicol_key_is_null (key))
     {
       /* We do not store NULL keys but we track them for unique indexes. */
-      if (BTREE_IS_UNIQUE (*unique))
+      if (BTREE_IS_UNIQUE (unique))
 	{
 	  /* In this scenario, we have to write log for the update of local statistics, since we do not
 	   * log the physical operation of a NULL key.
@@ -34637,7 +34637,6 @@ btree_rv_keyval_undo_online_index_tran_delete (THREAD_ENTRY * thread_p, LOG_RCV 
   int datasize;
   BTREE_MVCC_INFO mvcc_info;
   int error_code = NO_ERROR;
-  int dummy_unique;
 
   /* btid needs a place to unpack the sys_btid into.  We'll use stack space. */
   btid.sys_btid = &sys_btid;
@@ -34655,7 +34654,7 @@ btree_rv_keyval_undo_online_index_tran_delete (THREAD_ENTRY * thread_p, LOG_RCV 
   assert (!OID_ISNULL (&oid));
 
   /* Insert object and all its info. */
-  error_code = btree_online_index_dispatcher (thread_p, btid.sys_btid, &key, &cls_oid, &oid, &dummy_unique,
+  error_code = btree_online_index_dispatcher (thread_p, btid.sys_btid, &key, &cls_oid, &oid, btid.unique_pk,
 					      BTREE_OP_ONLINE_INDEX_UNDO_TRAN_DELETE, &recv->reference_lsa);
   if (error_code != NO_ERROR)
     {
@@ -34685,7 +34684,6 @@ btree_rv_keyval_undo_online_index_tran_insert (THREAD_ENTRY * thread_p, LOG_RCV 
   BTREE_MVCC_INFO dummy_mvcc_info;
   int err = NO_ERROR;
   DB_VALUE key;
-  int dummy_unique;
 
   /* btid needs a place to unpack the sys_btid into.  We'll use stack space. */
   btid.sys_btid = &sys_btid;
@@ -34703,7 +34701,7 @@ btree_rv_keyval_undo_online_index_tran_insert (THREAD_ENTRY * thread_p, LOG_RCV 
   assert (!OID_ISNULL (&oid));
 
   /* Undo insert: just delete object and all its information. */
-  err = btree_online_index_dispatcher (thread_p, btid.sys_btid, &key, &cls_oid, &oid, &dummy_unique,
+  err = btree_online_index_dispatcher (thread_p, btid.sys_btid, &key, &cls_oid, &oid, btid.unique_pk,
 				       BTREE_OP_ONLINE_INDEX_UNDO_TRAN_INSERT, &recv->reference_lsa);
   if (err != NO_ERROR)
     {

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -734,7 +734,7 @@ extern PERF_PAGE_TYPE btree_get_perf_btree_page_type (THREAD_ENTRY * thread_p, P
 extern void btree_dump_key (THREAD_ENTRY * thread_p, FILE * fp, DB_VALUE * key);
 
 extern int btree_online_index_dispatcher (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key, OID * cls_oid,
-					  OID * oid, int *unique, BTREE_OP_PURPOSE purpose, LOG_LSA * undo_nxlsa);
+					  OID * oid, int unique, BTREE_OP_PURPOSE purpose, LOG_LSA * undo_nxlsa);
 
 extern int btree_rv_keyval_undo_online_index_tran_insert (THREAD_ENTRY * thread_p, LOG_RCV * recv);
 extern int btree_rv_keyval_undo_online_index_tran_delete (THREAD_ENTRY * thread_p, LOG_RCV * recv);

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -4749,7 +4749,7 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
 
       /* Dispatch the insert operation */
       ret = btree_online_index_dispatcher (thread_p, btid_int->sys_btid, p_dbvalue, &class_oids[cur_class], &cur_oid,
-					   &unique_pk, BTREE_OP_ONLINE_INDEX_IB_INSERT, NULL);
+					   unique_pk, BTREE_OP_ONLINE_INDEX_IB_INSERT, NULL);
       /* Clear the index key. */
       pr_clear_value (p_dbvalue);
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7643,7 +7643,7 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
   BTID btid;
   DB_VALUE *key_dbvalue, *key_ins_del = NULL;
   DB_VALUE dbvalue;
-  int is_unique;
+  int unique_pk;
   BTREE_UNIQUE_STATS *unique_stat_info;
   HEAP_IDX_ELEMENTS_INFO idx_info;
   char buf[DBVAL_BUFSIZE + MAX_ALIGNMENT], *aligned_buf;
@@ -7774,6 +7774,16 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
 	      p_mvcc_rec_header = mvcc_rec_header;
 	    }
 
+	  unique_pk = 0;
+	  if (index->type == BTREE_UNIQUE || index->type == BTREE_REVERSE_UNIQUE)
+	    {
+	      unique_pk = BTREE_CONSTRAINT_UNIQUE;
+	    }
+	  else if (index->type == BTREE_PRIMARY_KEY)
+	    {
+	      unique_pk = BTREE_CONSTRAINT_UNIQUE | BTREE_CONSTRAINT_PRIMARY_KEY;
+	    }
+
 	  if (is_insert)
 	    {
 #if defined(ENABLE_SYSTEMTAP)
@@ -7791,17 +7801,15 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
 	      if (index->index_status == OR_ONLINE_INDEX_BUILDING_IN_PROGRESS)
 		{
 		  /* Online index is currently loading. */
-
-		  is_unique = btree_is_unique_type (index->type);
 		  error_code =
-		    btree_online_index_dispatcher (thread_p, &btid, key_dbvalue, class_oid, inst_oid, &is_unique,
+		    btree_online_index_dispatcher (thread_p, &btid, key_dbvalue, class_oid, inst_oid, unique_pk,
 						   BTREE_OP_ONLINE_INDEX_TRAN_INSERT, NULL);
 		}
 	      else
 		{
 		  error_code =
 		    btree_insert (thread_p, &btid, key_dbvalue, class_oid, inst_oid, op_type, unique_stat_info,
-				  &is_unique, p_mvcc_rec_header);
+				  &unique_pk, p_mvcc_rec_header);
 		}
 #if defined(ENABLE_SYSTEMTAP)
 	      CUBRID_IDX_INSERT_END (classname, index->btname, (error_code != NO_ERROR));
@@ -7818,24 +7826,22 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
 		  if (index->index_status == OR_ONLINE_INDEX_BUILDING_IN_PROGRESS)
 		    {
 		      /* Online index is currently loading. */
-		      is_unique = btree_is_unique_type (index->type);
-
 		      error_code =
 			btree_online_index_dispatcher (thread_p, &btid, key_dbvalue, class_oid, inst_oid,
-						       &is_unique, BTREE_OP_ONLINE_INDEX_TRAN_DELETE, NULL);
+						       unique_pk, BTREE_OP_ONLINE_INDEX_TRAN_DELETE, NULL);
 		    }
 		  else
 		    {
 		      /* in MVCC logical deletion means MVCC DEL_ID insertion */
 		      error_code =
 			btree_mvcc_delete (thread_p, &btid, key_dbvalue, class_oid, inst_oid, op_type, unique_stat_info,
-					   &is_unique, p_mvcc_rec_header);
+					   &unique_pk, p_mvcc_rec_header);
 		    }
 		}
 	      else
 		{
 		  error_code =
-		    btree_physical_delete (thread_p, &btid, key_dbvalue, inst_oid, class_oid, &is_unique, op_type,
+		    btree_physical_delete (thread_p, &btid, key_dbvalue, inst_oid, class_oid, &unique_pk, op_type,
 					   unique_stat_info);
 		  if (error_code != NO_ERROR)
 		    {
@@ -8166,7 +8172,7 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
   bool new_isnull, old_isnull;
   PR_TYPE *pr_type;
   OR_INDEX *index = NULL;
-  int i, j, k, num_btids, old_num_btids, unique;
+  int i, j, k, num_btids, old_num_btids, unique_pk;
   bool found_btid = true;
   BTREE_UNIQUE_STATS *unique_stat_info;
   HEAP_IDX_ELEMENTS_INFO new_idx_info;
@@ -8201,7 +8207,6 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
   LOG_TDES *tdes;
   LOG_LSA preserved_repl_lsa;
   int tran_index;
-  int is_unique;
   BTID_INT btid_int;
 
   assert_release (class_oid != NULL);
@@ -8485,13 +8490,23 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 							mvcc_rec_header);
 		  p_mvcc_rec_header = mvcc_rec_header;
 		}
+
+	      unique_pk = 0;
+	      if (index->type == BTREE_UNIQUE || index->type == BTREE_REVERSE_UNIQUE)
+		{
+		  unique_pk = BTREE_CONSTRAINT_UNIQUE;
+		}
+	      else if (index->type == BTREE_PRIMARY_KEY)
+		{
+		  unique_pk = BTREE_CONSTRAINT_UNIQUE | BTREE_CONSTRAINT_PRIMARY_KEY;
+		}
+
 	      if (do_delete_only)
 		{
 		  if (index->index_status == OR_ONLINE_INDEX_BUILDING_IN_PROGRESS)
 		    {
-		      is_unique = btree_is_unique_type (index->type);
 		      error_code =
-			btree_online_index_dispatcher (thread_p, &index->btid, old_key, class_oid, oid, &is_unique,
+			btree_online_index_dispatcher (thread_p, &index->btid, old_key, class_oid, oid, unique_pk,
 						       BTREE_OP_ONLINE_INDEX_TRAN_DELETE, NULL);
 		      if (error_code != NO_ERROR)
 			{
@@ -8506,7 +8521,7 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 			  /* in MVCC logical deletion means MVCC DEL_ID insertion */
 			  error_code =
 			    btree_mvcc_delete (thread_p, &old_btid, old_key, class_oid, oid, op_type, unique_stat_info,
-					       &unique, p_mvcc_rec_header);
+					       &unique_pk, p_mvcc_rec_header);
 			  if (error_code != NO_ERROR)
 			    {
 			      assert (er_errid () != NO_ERROR);
@@ -8516,7 +8531,7 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 		      else
 			{
 			  error_code =
-			    btree_physical_delete (thread_p, &old_btid, old_key, oid, class_oid, &unique, op_type,
+			    btree_physical_delete (thread_p, &old_btid, old_key, oid, class_oid, &unique_pk, op_type,
 						   unique_stat_info);
 			  if (error_code != NO_ERROR)
 			    {
@@ -8542,17 +8557,15 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 		      if (index->index_status == OR_ONLINE_INDEX_BUILDING_IN_PROGRESS)
 			{
 			  /* Online index loading on current index. */
-			  is_unique = btree_is_unique_type (index->type);
-
 			  error_code =
 			    btree_online_index_dispatcher (thread_p, &index->btid, new_key, class_oid, oid,
-							   &is_unique, BTREE_OP_ONLINE_INDEX_TRAN_INSERT, NULL);
+							   unique_pk, BTREE_OP_ONLINE_INDEX_TRAN_INSERT, NULL);
 			}
 		      else
 			{
 			  error_code =
 			    btree_insert (thread_p, &old_btid, new_key, class_oid, oid, op_type, unique_stat_info,
-					  &unique, p_mvcc_rec_header);
+					  &unique_pk, p_mvcc_rec_header);
 			}
 
 		      if (error_code != NO_ERROR)
@@ -8570,10 +8583,9 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 
 			  /* Delete old key. */
 
-			  is_unique = btree_is_unique_type (index->type);
 			  error_code =
 			    btree_online_index_dispatcher (thread_p, &index->btid, old_key, class_oid, oid,
-							   &is_unique, BTREE_OP_ONLINE_INDEX_TRAN_DELETE, NULL);
+							   unique_pk, BTREE_OP_ONLINE_INDEX_TRAN_DELETE, NULL);
 			  if (error_code != NO_ERROR)
 			    {
 			      goto error;
@@ -8582,13 +8594,13 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 			  /* Insert new key. */
 			  error_code =
 			    btree_online_index_dispatcher (thread_p, &index->btid, new_key, class_oid, oid,
-							   &is_unique, BTREE_OP_ONLINE_INDEX_TRAN_INSERT, NULL);
+							   unique_pk, BTREE_OP_ONLINE_INDEX_TRAN_INSERT, NULL);
 			}
 		      else
 			{
 			  error_code =
 			    btree_update (thread_p, &old_btid, old_key, new_key, class_oid, oid, op_type,
-					  unique_stat_info, &unique, p_mvcc_rec_header);
+					  unique_stat_info, &unique_pk, p_mvcc_rec_header);
 
 			  if (error_code != NO_ERROR)
 			    {


### PR DESCRIPTION
It fixes **unique** as well as **not_null** flag of index being built.

http://jira.cubrid.org/browse/CBRD-22424 requires to ship **not null** flag to server.