### PR TITLE
[CBRD-21486] fileio_expand_to return error code

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2634,7 +2634,7 @@ fileio_expand_to (THREAD_ENTRY * thread_p, VOLID vol_id, DKNPAGES size_npages, D
 
   db_private_free (thread_p, io_page_p);
 
-  return NO_ERROR;
+  return error_code;
 }
 #endif /* not CS_MODE */
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21486

Even though error occurs, fileio_expand_to returns NO_ERROR.

file_create has a safe-guard. If everything worked correctly, it should find no error set. Safe-guard was triggered due to fileio_expand_to bug.

Fixed by returning error code.