### PR TITLE
[CBRD-22432] fix memory leaks in json table

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1114,7 +1114,10 @@ db_json_set_iterator (JSON_ITERATOR *&json_itr, const JSON_DOC &new_doc)
 void
 db_json_reset_iterator (JSON_ITERATOR *&json_itr)
 {
-  json_itr->reset ();
+  if (json_itr != NULL)
+    {
+      json_itr->reset ();
+    }
 }
 
 bool
@@ -1141,11 +1144,8 @@ db_json_create_iterator (const DB_JSON_TYPE &type)
 void
 db_json_delete_json_iterator (JSON_ITERATOR *&json_itr)
 {
-  if (json_itr != NULL)
-    {
-      delete json_itr;
-      json_itr = NULL;
-    }
+  delete json_itr;
+  json_itr = NULL;
 }
 
 void

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1288,13 +1288,13 @@ db_json_unquote (const JSON_DOC &doc, char *&result_str)
 {
   assert (result_str == nullptr);
 
-  if (!doc.IsString())
+  if (!doc.IsString ())
     {
       result_str = db_json_get_raw_json_body_from_document (&doc);
     }
   else
     {
-      result_str = db_private_strdup (NULL, doc.GetString());
+      result_str = db_private_strdup (NULL, doc.GetString ());
 
       if (result_str == nullptr)
 	{
@@ -2015,7 +2015,7 @@ db_json_search_func (JSON_DOC &doc, const DB_VALUE *pattern, const DB_VALUE *esc
   for (auto &starting_path : starting_paths)
     {
       JSON_DOC *resolved = nullptr;
-      int error_code = db_json_extract_document_from_path (&doc, starting_path.c_str(), resolved);
+      int error_code = db_json_extract_document_from_path (&doc, starting_path.c_str (), resolved);
 
       if (error_code != NO_ERROR)
 	{

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1141,14 +1141,20 @@ db_json_create_iterator (const DB_JSON_TYPE &type)
 void
 db_json_delete_json_iterator (JSON_ITERATOR *&json_itr)
 {
-  delete json_itr;
-  json_itr = NULL;
+  if (json_itr != NULL)
+    {
+      delete json_itr;
+      json_itr = NULL;
+    }
 }
 
 void
 db_json_clear_json_iterator (JSON_ITERATOR *&json_itr)
 {
-  json_itr->clear_content ();
+  if (json_itr != NULL)
+    {
+      json_itr->clear_content ();
+    }
 }
 
 bool

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -7129,9 +7129,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  break;
 	case DB_JSON_STRING:
 	  {
-	    const char *json_string = NULL;
-
-	    json_string = db_json_get_string_from_document (src_doc);
+	    const char *json_string = db_json_get_string_from_document (src_doc);
 	    db_make_string_by_const_str (&src_replacement, json_string);
 	  }
 	  break;
@@ -7142,6 +7140,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
       if (json_type != DB_JSON_ARRAY && json_type != DB_JSON_OBJECT)
 	{
+	  if (src == dest)
+	    {
+	      // if src is equal to dest then JSON_DOC can be deleted after required information was extracted from it
+	      pr_clear_value (dest);
+	    }
+
 	  original_type = DB_VALUE_TYPE (&src_replacement);
 	  src = &src_replacement;
 	}

--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -208,10 +208,7 @@ namespace cubscan
     {
       m_is_node_consumed = true;
 
-      if (m_node->m_iterator != NULL)
-	{
-	  db_json_reset_iterator (m_node->m_iterator);
-	}
+      db_json_reset_iterator (m_node->m_iterator);
 
       m_process_doc = NULL;
       m_node->clear_columns (false);

--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -50,6 +50,7 @@ namespace cubscan
       void start_json_iterator (void);    // start json iteration of changing input document
       int fetch_row (void);               // fetch current row (if not fetched)
       void end (void);                    // finish current node scan
+      void delete_input_doc ();
 
       cursor (void);
       ~cursor (void);
@@ -70,7 +71,16 @@ namespace cubscan
 
     scanner::cursor::~cursor (void)
     {
-      db_json_delete_doc (m_input_doc);
+      delete_input_doc ();
+    }
+
+    void
+    scanner::cursor::delete_input_doc ()
+    {
+      if (m_input_doc != NULL)
+	{
+	  db_json_delete_doc (m_input_doc);
+	}
     }
 
     void
@@ -190,6 +200,11 @@ namespace cubscan
 	    }
 	}
 
+      if (m_node->m_iterator != NULL)
+	{
+	  db_json_clear_json_iterator (m_node->m_iterator);
+	}
+
       return NO_ERROR;
     }
 
@@ -244,10 +259,10 @@ namespace cubscan
     }
 
     void
-    scanner::clear (xasl_node *xasl_p, bool is_final, bool clear_default_values)
+    scanner::clear (xasl_node *xasl_p, bool is_final, bool is_final_clear)
     {
       // columns should be released every time
-      m_specp->m_root_node->clear_tree (clear_default_values);
+      m_specp->m_root_node->clear_tree (is_final_clear);
       reset_ordinality (*m_specp->m_root_node);
 
       // all json documents should be release depending on is_final
@@ -256,13 +271,18 @@ namespace cubscan
 	  for (size_t i = 0; i < m_tree_height; ++i)
 	    {
 	      cursor &cursor = m_scan_cursor[i];
-	      db_json_delete_doc (cursor.m_input_doc);
+	      cursor.delete_input_doc ();
 
 	      cursor.m_child = 0;
 	      cursor.m_is_row_fetched = false;
 	    }
 
 	  m_specp->m_root_node->clear_iterators ();
+
+	  if (is_final_clear)
+	    {
+	      delete [] m_scan_cursor;
+	    }
 	}
     }
 

--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -200,11 +200,6 @@ namespace cubscan
 	    }
 	}
 
-      if (m_node->m_iterator != NULL)
-	{
-	  db_json_clear_json_iterator (m_node->m_iterator);
-	}
-
       return NO_ERROR;
     }
 

--- a/src/query/scan_json_table.hpp
+++ b/src/query/scan_json_table.hpp
@@ -112,7 +112,7 @@ namespace cubscan
 	// initialize scanner
 	void init (cubxasl::json_table::spec_node &spec);
 	// clear scanner
-	void clear (xasl_node *xasl_p, bool is_final, bool clear_default_values);
+	void clear (xasl_node *xasl_p, bool is_final, bool is_final_clear);
 
 	// open a new scan
 	int open (cubthread::entry *thread_p);

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -128,6 +128,7 @@ namespace cubxasl
       int error_code = NO_ERROR;
       JSON_DOC *docp = NULL;
       TP_DOMAIN_STATUS status_cast = TP_DOMAIN_STATUS::DOMAIN_COMPATIBLE;
+      db_value output_value_tmp;
 
       error_code = db_json_extract_document_from_path (&input, m_path, docp);
       if (error_code != NO_ERROR)
@@ -147,13 +148,13 @@ namespace cubxasl
 	  return error_code;
 	}
 
-      if (db_make_json (m_output_value_pointer, docp, true) != NO_ERROR)
+      if (db_make_json (&output_value_tmp, docp, true) != NO_ERROR)
 	{
 	  assert (false);
 	  return ER_FAILED;
 	}
 
-      status_cast = tp_value_cast (m_output_value_pointer, m_output_value_pointer, m_domain, false);
+      status_cast = tp_value_cast (&output_value_tmp, m_output_value_pointer, m_domain, false);
       if (status_cast != TP_DOMAIN_STATUS::DOMAIN_COMPATIBLE)
 	{
 	  error_code = trigger_on_error (input, status_cast, *m_output_value_pointer);
@@ -162,6 +163,9 @@ namespace cubxasl
 	      ASSERT_ERROR ();
 	    }
 	}
+
+      // clear output_value_tmp because content was copied to m_output_value_pointer on tp_value_cast
+      error_code = pr_clear_value (&output_value_tmp);
 
       return error_code;
     }
@@ -234,7 +238,7 @@ namespace cubxasl
 
     node::node (void)
     {
-      init();
+      init ();
     }
 
     void
@@ -275,6 +279,7 @@ namespace cubxasl
       if (m_iterator != nullptr)
 	{
 	  db_json_clear_json_iterator (m_iterator);
+	  db_json_delete_json_iterator (m_iterator);
 	}
 
       for (size_t i = 0; i < m_nested_nodes_size; ++i)

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -275,7 +275,6 @@ namespace cubxasl
     void
     node::clear_iterators ()
     {
-      db_json_clear_json_iterator (m_iterator);
       db_json_delete_json_iterator (m_iterator);
 
       for (size_t i = 0; i < m_nested_nodes_size; ++i)

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -128,7 +128,6 @@ namespace cubxasl
       int error_code = NO_ERROR;
       JSON_DOC *docp = NULL;
       TP_DOMAIN_STATUS status_cast = TP_DOMAIN_STATUS::DOMAIN_COMPATIBLE;
-      db_value output_value_tmp;
 
       error_code = db_json_extract_document_from_path (&input, m_path, docp);
       if (error_code != NO_ERROR)
@@ -148,13 +147,16 @@ namespace cubxasl
 	  return error_code;
 	}
 
-      if (db_make_json (&output_value_tmp, docp, true) != NO_ERROR)
+      // clear previous output_value
+      pr_clear_value (m_output_value_pointer);
+
+      if (db_make_json (m_output_value_pointer, docp, true) != NO_ERROR)
 	{
 	  assert (false);
 	  return ER_FAILED;
 	}
 
-      status_cast = tp_value_cast (&output_value_tmp, m_output_value_pointer, m_domain, false);
+      status_cast = tp_value_cast (m_output_value_pointer, m_output_value_pointer, m_domain, false);
       if (status_cast != TP_DOMAIN_STATUS::DOMAIN_COMPATIBLE)
 	{
 	  error_code = trigger_on_error (input, status_cast, *m_output_value_pointer);
@@ -163,9 +165,6 @@ namespace cubxasl
 	      ASSERT_ERROR ();
 	    }
 	}
-
-      // clear output_value_tmp because content was copied to m_output_value_pointer on tp_value_cast
-      error_code = pr_clear_value (&output_value_tmp);
 
       return error_code;
     }

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -276,11 +276,8 @@ namespace cubxasl
     void
     node::clear_iterators ()
     {
-      if (m_iterator != nullptr)
-	{
-	  db_json_clear_json_iterator (m_iterator);
-	  db_json_delete_json_iterator (m_iterator);
-	}
+      db_json_clear_json_iterator (m_iterator);
+      db_json_delete_json_iterator (m_iterator);
 
       for (size_t i = 0; i < m_nested_nodes_size; ++i)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22432

Fix memory leaks in json table (below are listed top elements of the call stack from jira issue):
- [ ] `#1` mr_readval_char_internal (fixed by #1254)
- [x] `#2` cubxasl::json_table::node::init_iterator
- [x] `#3` cubxasl::json_table::column::evaluate_extract
- [x] `#4` cubscan::json_table::scanner::init