### PR TITLE
[CBRD-22437] fix crash to print a bad group_concat expr

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -12473,12 +12473,12 @@ pt_print_function (PARSER_CONTEXT * parser, PT_NODE * p)
 	    {
 	      if (p->info.function.arg_list != NULL)
 		{
-	          r1 = pt_print_bytes (parser, p->info.function.arg_list);
+		  r1 = pt_print_bytes (parser, p->info.function.arg_list);
 		}
 	      else
 		{
 		  // it is unexpected but a badly formed function may miss its arg_list.
-	          r1 = NULL;
+		  r1 = NULL;
 		}
 
 	      if (p->info.function.order_by != NULL)

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -12471,7 +12471,16 @@ pt_print_function (PARSER_CONTEXT * parser, PT_NODE * p)
 	{
 	  if (code == PT_GROUP_CONCAT)
 	    {
-	      r1 = pt_print_bytes (parser, p->info.function.arg_list);
+	      if (p->info.function.arg_list != NULL)
+		{
+	          r1 = pt_print_bytes (parser, p->info.function.arg_list);
+		}
+	      else
+		{
+		  // it is unexpected but a badly formed function may miss its arg_list.
+	          r1 = NULL;
+		}
+
 	      if (p->info.function.order_by != NULL)
 		{
 		  PARSER_VARCHAR *r2;
@@ -12480,8 +12489,9 @@ pt_print_function (PARSER_CONTEXT * parser, PT_NODE * p)
 		  r1 = pt_append_nulstring (parser, r1, " order by ");
 		  r1 = pt_append_varchar (parser, r1, r2);
 		}
+
 	      /* SEPARATOR */
-	      if (p->info.function.arg_list->next != NULL)
+	      if (p->info.function.arg_list != NULL && p->info.function.arg_list->next != NULL)
 		{
 		  PARSER_VARCHAR *r2;
 		  /* print separator */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22437

It is a not json_table issue but legacy. 