### PR TITLE
[CBRD-22420] filtered index may not properly end but client misunders…

### DIFF
--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -3933,7 +3933,10 @@ end:
 
   if (return_btid == NULL)
     {
-      ptr = or_pack_int (reply, er_errid ());
+      int err;
+
+      ASSERT_ERROR_AND_SET (err);
+      ptr = or_pack_int (reply, err);
     }
   else
     {

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -4670,6 +4670,8 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
   /* Start extracting from heap. */
   for (;;)
     {
+      ret = NO_ERROR;
+
       /* Scan from heap and insert into the index. */
       attr_offset = cur_class * n_attrs;
 

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -4639,7 +4639,7 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
 		      PRED_EXPR_WITH_CONTEXT * filter_pred, int *attrs_prefix_length, HEAP_CACHE_ATTRINFO * attr_info,
 		      HEAP_SCANCACHE * scancache, int unique_pk)
 {
-  int ret = NO_ERROR;
+  int ret = NO_ERROR, eval_res;
   OID cur_oid;
   RECDES cur_record;
   int cur_class;
@@ -4670,8 +4670,6 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
   /* Start extracting from heap. */
   for (;;)
     {
-      ret = NO_ERROR;
-
       /* Scan from heap and insert into the index. */
       attr_offset = cur_class * n_attrs;
 
@@ -4679,14 +4677,13 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
       cur_record.area_size = IO_MAX_PAGE_SIZE;
 
       sc = heap_next (thread_p, &hfids[cur_class], &class_oids[cur_class], &cur_oid, &cur_record, scancache, true);
-      if (sc == S_END)
-	{
-	  break;
-	}
-
       if (sc == S_ERROR)
 	{
 	  ASSERT_ERROR_AND_SET (ret);
+	  return ret;
+	}
+      else if (sc == S_END)
+	{
 	  break;
 	}
 
@@ -4699,15 +4696,15 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
 	  ret = heap_attrinfo_read_dbvalues (thread_p, &cur_oid, &cur_record, NULL, filter_pred->cache_pred);
 	  if (ret != NO_ERROR)
 	    {
-	      break;
+	      return ret;
 	    }
 
-	  ret = (*filter_eval_fnc) (thread_p, filter_pred->pred, NULL, &cur_oid);
-	  if (ret == V_ERROR)
+	  eval_res = (*filter_eval_fnc) (thread_p, filter_pred->pred, NULL, &cur_oid);
+	  if (eval_res == V_ERROR)
 	    {
 	      return ER_FAILED;
 	    }
-	  else if (ret != V_TRUE)
+	  else if (eval_res != V_TRUE)
 	    {
 	      continue;
 	    }
@@ -4715,8 +4712,8 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
 
       if (p_func_idx_info && p_func_idx_info->expr)
 	{
-	  ret =
-	    heap_attrinfo_read_dbvalues (thread_p, &cur_oid, &cur_record, NULL, p_func_idx_info->expr->cache_attrinfo);
+	  ret = heap_attrinfo_read_dbvalues (thread_p, &cur_oid, &cur_record, NULL,
+					     p_func_idx_info->expr->cache_attrinfo);
 	  if (ret != NO_ERROR)
 	    {
 	      return ret;
@@ -4740,13 +4737,11 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
 	}
 
       /* Generate the key. */
-      p_dbvalue =
-	heap_attrinfo_generate_key (thread_p, n_attrs, &attrids[attr_offset], p_prefix_length, attr_info, &cur_record,
-				    &dbvalue, aligned_midxkey_buf, p_func_idx_info);
+      p_dbvalue = heap_attrinfo_generate_key (thread_p, n_attrs, &attrids[attr_offset], p_prefix_length, attr_info,
+					      &cur_record, &dbvalue, aligned_midxkey_buf, p_func_idx_info);
       if (p_dbvalue == NULL)
 	{
-	  ret = ER_FAILED;
-	  break;
+	  return ER_FAILED;
 	}
 
       /* Dispatch the insert operation */
@@ -4757,7 +4752,7 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
 
       if (ret != NO_ERROR)
 	{
-	  break;
+	  return ret;
 	}
     }
 


### PR DESCRIPTION
…tands

http://jira.cubrid.org/browse/CBRD-22420

It's a bad defect. To build a filtered index may return a bad error code. SCAN_END exits the loop and returned `ret` which was set by a previous evaluation of filter predicate. In our case, it was `V_UNKNOWN`.
Server-side index build failed but returned `NO_ERROR` to client, since no error was set. 
The class lock remained as `IX` and the next online index build hits assertion.

I don't think all potential issues are cleared by the fix. 
For instance, 

1. when online index build fails, recover class lock to `SCH_M`?
2. This is non-autocommit case and class itself is dirty. Do we really have to demote its lock for online index creation? Conversely, when lock count is greater than 1, do we allow demotion?
3. Even though the first filtered index creation failed, the next try should hold `SCH_M`. Why `IX` remained?