### PR TITLE
[CBRD-22422] fix leak when key value is reset to null

### DIFF
--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -1214,6 +1214,13 @@ classobj_put_index (DB_SEQ ** properties, SM_CONSTRAINT_TYPE type, const char *c
     }
 
   /* add index status. */
+  /*  If the index_status is set to SM_ONLINE_INDEX_BUILDING_DONE, we must change it to NORMAL_INDEX since
+   *  the index has finished loading and the temporary status was set to avoid some previous checks.
+   */
+  if (index_status == SM_ONLINE_INDEX_BUILDING_DONE)
+    {
+      index_status = SM_NORMAL_INDEX;
+    }
   db_make_int (&value, index_status);
   classobj_put_value_and_iterate (constraint, constraint_seq_index, value);
 

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1922,6 +1922,7 @@ btree_clear_key_value (bool * clear_flag, DB_VALUE * key_value)
       pr_clear_value (key_value);
       *clear_flag = false;
     }
+  // also set null
   db_make_null (key_value);
   return *clear_flag;
 }

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -4660,6 +4660,8 @@ btree_dump_leaf_record (THREAD_ENTRY * thread_p, FILE * fp, BTID_INT * btid, REC
   int error;
   BTREE_MVCC_INFO mvcc_info;
 
+  db_make_null (&key);
+
   if (BTREE_IS_UNIQUE (btid->unique_pk))
     {
       oid_size = (2 * OR_OID_SIZE);
@@ -4911,6 +4913,8 @@ btree_dump_non_leaf_record (THREAD_ENTRY * thread_p, FILE * fp, BTID_INT * btid,
 
   VPID_SET_NULL (&(non_leaf_record.pnt));
 
+  db_make_null (&key);
+
   /* output the non_leaf record structure content */
   error =
     btree_read_record_without_decompression (thread_p, btid, rec, &key, &non_leaf_record, BTREE_NON_LEAF_NODE,
@@ -5019,6 +5023,8 @@ btree_search_nonleaf_page (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pa
 
   /* initialize child page identifier */
   VPID_SET_NULL (child_vpid);
+
+  db_make_null (&temp_key);
 
 #if !defined(NDEBUG)
   if (!page_ptr || !key || DB_IS_NULL (key))
@@ -5338,6 +5344,8 @@ btree_search_leaf_page (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_
   assert (key != NULL && !DB_IS_NULL (key));
   assert (page_ptr != NULL);
   assert (search_key != NULL);
+
+  db_make_null (&temp_key);
 
   /* Initialize search results. */
   search_key->result = BTREE_KEY_NOTFOUND;
@@ -7395,6 +7403,7 @@ btree_verify_subtree (THREAD_ENTRY * thread_p, const OID * class_oid_p, BTID_INT
   char err_buf[LINE_MAX];
 
   db_make_null (&INFO2.max_key);
+  db_make_null (&curr_key);
 
   /* test the page for the order of the keys within the page and get the biggest key of this page */
   valid = btree_check_page_key (thread_p, class_oid_p, btid, btname, pg_ptr, pg_vpid);
@@ -8450,6 +8459,8 @@ btree_get_subtree_capacity (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR p
   /* initialize */
   leaf_pnt.key_len = 0;
   VPID_SET_NULL (&leaf_pnt.ovfl);
+
+  db_make_null (&key1);
 
   /* initialize capacity structure */
   cpc->dis_key_cnt = 0;
@@ -10502,6 +10513,8 @@ btree_node_size_uncompressed (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR
   LEAF_REC leaf_pnt;
   int error;
 
+  db_make_null (&key);
+
   used_size = DB_PAGESIZE - spage_get_free_space (thread_p, page_ptr);
 
   prefix = btree_node_common_prefix (thread_p, btid, page_ptr);
@@ -12345,6 +12358,9 @@ btree_node_common_prefix (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pag
   LEAF_REC leaf_pnt;
   int error = NO_ERROR;
 
+  db_make_null (&lf_key);
+  db_make_null (&uf_key);
+
   if (btree_node_is_compressed (thread_p, btid, page_ptr) == false)
     {
       return 0;
@@ -12424,6 +12440,8 @@ btree_recompress_record (THREAD_ENTRY * thread_p, BTID_INT * btid_int, RECDES * 
 
   assert (btid_int != NULL);
   assert (record != NULL);
+
+  db_make_null (&key);
 
   if (old_prefix == new_prefix)
     {
@@ -12512,6 +12530,8 @@ btree_compress_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_ptr
     {
       return diff_column;
     }
+
+  db_make_null (&key);
 
   /* compress prefix */
   for (i = 2; i < key_cnt; i++)
@@ -16268,6 +16288,7 @@ btree_find_min_or_max_key (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key,
     }
 
   db_make_null (key);
+  db_make_null (&key_value);
 
   BTS = &btree_scan;
   BTREE_INIT_SCAN (BTS);
@@ -19524,6 +19545,9 @@ btree_verify_nonleaf_node (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PAGE_PT
   key_cnt = btree_node_number_of_keys (thread_p, page_ptr);
   assert_release (key_cnt >= 1);
 
+  db_make_null (&prev_key);
+  db_make_null (&curr_key);
+
   /* check key order; exclude neg-inf separator */
   for (i = 1; i < key_cnt; i++)
     {
@@ -20204,6 +20228,7 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
 
   /* Get key count */
   db_make_int (node_info[BTREE_NODE_INFO_KEY_COUNT], key_cnt);
+  db_make_null (&key_value);
 
   if (key_cnt > 0)
     {

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1922,7 +1922,7 @@ btree_clear_key_value (bool * clear_flag, DB_VALUE * key_value)
       pr_clear_value (key_value);
       *clear_flag = false;
     }
-
+  db_make_null (key_value);
   return *clear_flag;
 }
 
@@ -4303,7 +4303,7 @@ btree_read_record_without_decompression (THREAD_ENTRY * thread_p, BTID_INT * bti
 
   if (key != NULL)
     {
-      db_make_null (key);
+      btree_clear_key_value (clear_key, key);
     }
 
   *clear_key = false;
@@ -25565,7 +25565,7 @@ btree_select_visible_object_for_range_scan (THREAD_ENTRY * thread_p, BTID_INT * 
 	      ASSERT_ERROR ();
 	      return error_code;
 	    }
-	  db_make_null (&bts->cur_key);
+	  btree_clear_key_value (&bts->clear_cur_key, &bts->cur_key);
 	}
       else
 	{

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -20192,7 +20192,6 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
   node_type = (node_header->node_level > 1) ? BTREE_NON_LEAF_NODE : BTREE_LEAF_NODE;
   key_cnt = btree_node_number_of_keys (thread_p, btns->crt_page);
 
-
   rec_header = (node_type == BTREE_NON_LEAF_NODE) ? (void *) &nleaf : (void *) &leaf_pnt;
 
   if (node_type == BTREE_NON_LEAF_NODE)
@@ -20232,10 +20231,11 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
 
   /* Get key count */
   db_make_int (node_info[BTREE_NODE_INFO_KEY_COUNT], key_cnt);
-  btree_init_temp_key_value (&clear_key, &key_value);
 
   if (key_cnt > 0)
     {
+      btree_init_temp_key_value (&clear_key, &key_value);
+
       /* Get first key */
       if (spage_get_record (thread_p, btns->crt_page, 1, &rec, PEEK) != S_SUCCESS)
 	{
@@ -20246,8 +20246,10 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
 	{
 	  goto error;
 	}
+
       pr_clear_value (node_info[BTREE_NODE_INFO_FIRST_KEY]);
-      *node_info[BTREE_NODE_INFO_FIRST_KEY] = key_value;	/* just copy. it will be cleared later */
+      pr_clone_value (&key_value, node_info[BTREE_NODE_INFO_FIRST_KEY]);
+      btree_clear_key_value (&clear_key, &key_value);
 
       /* Get last key */
       if (spage_get_record (thread_p, btns->crt_page, key_cnt, &rec, PEEK) != S_SUCCESS)
@@ -20259,8 +20261,10 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
 	{
 	  goto error;
 	}
+
       pr_clear_value (node_info[BTREE_NODE_INFO_LAST_KEY]);
-      *node_info[BTREE_NODE_INFO_LAST_KEY] = key_value;	/* just copy. it will be cleared later */
+      pr_clone_value (&key_value, node_info[BTREE_NODE_INFO_LAST_KEY]);
+      btree_clear_key_value (&clear_key, &key_value);
     }
   else
     {

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -163,7 +163,7 @@ static int btree_first_oid (THREAD_ENTRY * thread_p, DB_VALUE * this_key, OID * 
 			    MVCC_REC_HEADER * p_mvcc_rec_header, LOAD_ARGS * load_args);
 static int btree_construct_leafs (THREAD_ENTRY * thread_p, const RECDES * in_recdes, void *arg);
 static int btree_get_value_from_leaf_slot (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PAGE_PTR leaf_ptr,
-					   int slot_id, DB_VALUE * key);
+					   int slot_id, DB_VALUE * key, bool * clear_key);
 #if defined(CUBRID_DEBUG)
 static int btree_dump_sort_output (const RECDES * recdes, LOAD_ARGS * load_args);
 #endif /* defined(CUBRID_DEBUG) */
@@ -180,8 +180,9 @@ static void list_print (const BTREE_NODE * this_list);
 static int btree_pack_root_header (RECDES * Rec, BTREE_ROOT_HEADER * header, TP_DOMAIN * key_type);
 static void btree_rv_save_root_head (int null_delta, int oid_delta, int key_delta, RECDES * recdes);
 static int btree_advance_to_next_slot_and_fix_page (THREAD_ENTRY * thread_p, BTID_INT * btid, VPID * vpid,
-						    PAGE_PTR * pg_ptr, INT16 * slot_id, DB_VALUE * key, bool is_desc,
-						    int *key_cnt, BTREE_NODE_HEADER ** header, MVCC_SNAPSHOT * mvcc);
+						    PAGE_PTR * pg_ptr, INT16 * slot_id, DB_VALUE * key,
+						    bool * clear_key, bool is_desc, int *key_cnt,
+						    BTREE_NODE_HEADER ** header, MVCC_SNAPSHOT * mvcc);
 static int btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args_local,
 				const SORT_ARGS * sort_args_local);
 static int btree_is_slot_visible (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pg_ptr,
@@ -1416,8 +1417,8 @@ btree_build_nleafs (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args, int n_nulls,
   rec.area_size = DB_PAGESIZE;
   rec.data = PTR_ALIGN (rec_buf, BTREE_MAX_ALIGN);
 
-  db_make_null (&last_key);
-  db_make_null (&first_key);
+  btree_init_temp_key_value (&clear_last_key, &last_key);
+  btree_init_temp_key_value (&clear_first_key, &first_key);
   db_make_null (&prefix_key);
 
   temp_data = (char *) os_malloc (DB_PAGESIZE);
@@ -3712,6 +3713,7 @@ int
 btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const SORT_ARGS * sort_args)
 {
   DB_VALUE fk_key, pk_key;
+  bool clear_fk_key, clear_pk_key;
   int fk_node_key_cnt = -1, pk_node_key_cnt = -1;
   BTREE_NODE_HEADER *fk_node_header = NULL, *pk_node_header = NULL;
   VPID vpid;
@@ -3736,8 +3738,8 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
   BTREE_SCAN_PART partitions[MAX_PARTITIONS];
   bool has_nulls = false;
 
-  db_make_null (&fk_key);
-  db_make_null (&pk_key);
+  btree_init_temp_key_value (&clear_fk_key, &fk_key);
+  btree_init_temp_key_value (&clear_pk_key, &pk_key);
 
   mvcc_snapshot_dirty.snapshot_fnc = mvcc_satisfies_dirty;
 
@@ -3823,8 +3825,8 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
   while (true)
     {
       ret = btree_advance_to_next_slot_and_fix_page (thread_p, sort_args->btid, &vpid, &curr_fk_pageptr, &fk_slot_id,
-						     &fk_key, is_fk_scan_desc, &fk_node_key_cnt, &fk_node_header,
-						     &mvcc_snapshot_dirty);
+						     &fk_key, &clear_fk_key, is_fk_scan_desc, &fk_node_key_cnt,
+						     &fk_node_header, &mvcc_snapshot_dirty);
       if (ret != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -3992,8 +3994,9 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
 	  while (!found)
 	    {
 	      ret = btree_advance_to_next_slot_and_fix_page (thread_p, &pk_bt_scan.btid_int, &pk_bt_scan.C_vpid,
-							     &pk_bt_scan.C_page, &pk_bt_scan.slot_id, &pk_key, false,
-							     &pk_node_key_cnt, &pk_node_header, &mvcc_snapshot_dirty);
+							     &pk_bt_scan.C_page, &pk_bt_scan.slot_id, &pk_key,
+							     &clear_pk_key, false, &pk_node_key_cnt, &pk_node_header,
+							     &mvcc_snapshot_dirty);
 	      if (ret != NO_ERROR)
 		{
 		  goto end;
@@ -4051,10 +4054,10 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
 
       if (found == true)
 	{
-	  pr_clear_value (&fk_key);
+	  btree_clear_key_value (&clear_fk_key, &fk_key);
 	}
 
-      pr_clear_value (&pk_key);
+      btree_clear_key_value (&clear_pk_key, &pk_key);
     }
 
 end:
@@ -4085,15 +4088,8 @@ end:
       pgbuf_unfix_and_init (thread_p, pk_bt_scan.C_page);
     }
 
-  if (!DB_IS_NULL (&fk_key))
-    {
-      pr_clear_value (&fk_key);
-    }
-
-  if (!DB_IS_NULL (&pk_key))
-    {
-      pr_clear_value (&pk_key);
-    }
+  btree_clear_key_value (&clear_fk_key, &fk_key);
+  btree_clear_key_value (&clear_pk_key, &pk_key);
 
   if (clear_pcontext == true)
     {
@@ -4116,14 +4112,14 @@ end:
  *   leaf_ptr(in): The leaf where the value needs to be extracted from.
  *   slot_id(in): The slot from where the value must be pulled.
  *   key(out): The value requested.
+ *   clear_key(out): needs to clear key if set
  *
  */
 static int
 btree_get_value_from_leaf_slot (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PAGE_PTR leaf_ptr, int slot_id,
-				DB_VALUE * key)
+				DB_VALUE * key, bool * clear_key)
 {
   LEAF_REC leaf;
-  bool clear_first_key = false;
   int first_key_offset = 0;
   RECDES record;
   int ret = NO_ERROR;
@@ -4135,7 +4131,7 @@ btree_get_value_from_leaf_slot (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PA
       return ret;
     }
 
-  ret = btree_read_record (thread_p, btid_int, leaf_ptr, &record, key, &leaf, BTREE_LEAF_NODE, &clear_first_key,
+  ret = btree_read_record (thread_p, btid_int, leaf_ptr, &record, key, &leaf, BTREE_LEAF_NODE, clear_key,
 			   &first_key_offset, PEEK_KEY_VALUE, NULL);
   if (ret != NO_ERROR)
     {
@@ -4155,6 +4151,7 @@ btree_get_value_from_leaf_slot (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PA
  *   pg_ptr(in/out): Page pointer for the current page.
  *   slot_id(in/out): Slot id of the current/next value.
  *   key(out): Requested key.
+ *   clear_key(out): needs to clear key if set.
  *   key_cnt(in/out): Number of keys in current page.
  *   header(in/out): The header of the current page.
  *   mvcc(in): Needed for visibility check.
@@ -4166,7 +4163,7 @@ btree_get_value_from_leaf_slot (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PA
  */
 static int
 btree_advance_to_next_slot_and_fix_page (THREAD_ENTRY * thread_p, BTID_INT * btid, VPID * vpid, PAGE_PTR * pg_ptr,
-					 INT16 * slot_id, DB_VALUE * key, bool is_desc, int *key_cnt,
+					 INT16 * slot_id, DB_VALUE * key, bool * clear_key, bool is_desc, int *key_cnt,
 					 BTREE_NODE_HEADER ** header, MVCC_SNAPSHOT * mvcc)
 {
   int ret = NO_ERROR;
@@ -4275,7 +4272,7 @@ btree_advance_to_next_slot_and_fix_page (THREAD_ENTRY * thread_p, BTID_INT * bti
 
   if (page != NULL)
     {
-      ret = btree_get_value_from_leaf_slot (thread_p, btid, page, *slot_id, key);
+      ret = btree_get_value_from_leaf_slot (thread_p, btid, page, *slot_id, key, clear_key);
     }
 
   *header = local_header;

--- a/src/storage/btree_load.h
+++ b/src/storage/btree_load.h
@@ -257,6 +257,7 @@ extern void btree_rv_nodehdr_dump (FILE * fp, int length, void *data);
 extern void btree_rv_mvcc_save_increments (BTID * btid, int key_delta, int oid_delta, int null_delta, RECDES * recdes);
 
 extern bool btree_clear_key_value (bool * clear_flag, DB_VALUE * key_value);
+extern void btree_init_temp_key_value (bool * clear_flag, DB_VALUE * key_value);
 extern int btree_create_overflow_key_file (THREAD_ENTRY * thread_p, BTID_INT * btid);
 extern int btree_init_overflow_header (THREAD_ENTRY * thread_p, PAGE_PTR page_ptr, BTREE_OVERFLOW_HEADER * ovf_header);
 extern int btree_init_node_header (THREAD_ENTRY * thread_p, const VFID * vfid, PAGE_PTR page_ptr,

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -9245,6 +9245,8 @@ locator_repair_btree_by_delete (THREAD_ENTRY * thread_p, OID * class_oid, BTID *
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 #endif /* SERVER_MODE */
 
+  db_make_null (&key);
+
   if (btree_find_key (thread_p, btid, inst_oid, &key, &clear_key) != DISK_VALID)
     {
       return DISK_INVALID;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -9245,7 +9245,7 @@ locator_repair_btree_by_delete (THREAD_ENTRY * thread_p, OID * class_oid, BTID *
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 #endif /* SERVER_MODE */
 
-  db_make_null (&key);
+  btree_init_temp_key_value (&clear_key, &key);
 
   if (btree_find_key (thread_p, btid, inst_oid, &key, &clear_key) != DISK_VALID)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22422

The issue is caused by b-tree scan current key being reset to nil without clearing when index loose scan is used.

It didn't reproduce with offline index because it didn't generate fence keys and it used to "peak" key value. With online index, fence keys are added and b-tree scan key is reconstructed using fences. As a consequence it has to allocate the midxkey buffer.

Fix by correctly clearing the scan key.