### PR TITLE
[CBRD-22434] fix cast from empty DB_TYPE_JSON to DB_TYPE_DATETIME

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -8304,7 +8304,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_VARNCHAR:
 	  if (tp_atoudatetime (src, &v_datetime) != NO_ERROR)
 	    {
-	      return DOMAIN_ERROR;
+	      status = DOMAIN_ERROR;
 	    }
 	  else
 	    {

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -7405,9 +7405,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      {
 		if (er_errid () != NO_ERROR)	/* i.e, malloc failure */
 		  {
-		    return DOMAIN_ERROR;
+		    status = DOMAIN_ERROR;
 		  }
-		status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		else
+		  {
+		    status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		  }
 		break;
 	      }
 
@@ -7518,9 +7521,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      {
 		if (er_errid () != NO_ERROR)	/* i.e, malloc failure */
 		  {
-		    return DOMAIN_ERROR;
+		    status = DOMAIN_ERROR;
 		  }
-		status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		else
+		  {
+		    status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		  }
 		break;
 	      }
 
@@ -7657,9 +7663,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      {
 		if (er_errid () != NO_ERROR)	/* i.e, malloc failure */
 		  {
-		    return DOMAIN_ERROR;
+		    status = DOMAIN_ERROR;
 		  }
-		status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		else
+		  {
+		    status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		  }
 		break;
 	      }
 
@@ -7731,9 +7740,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      {
 		if (er_errid () != NO_ERROR)	/* i.e, malloc failure */
 		  {
-		    return DOMAIN_ERROR;
+		    status = DOMAIN_ERROR;
 		  }
-		status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		else
+		  {
+		    status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		  }
 		break;
 	      }
 
@@ -7793,9 +7805,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      {
 		if (er_errid () != NO_ERROR)	/* i.e, malloc failure */
 		  {
-		    return DOMAIN_ERROR;
+		    status = DOMAIN_ERROR;
 		  }
-		status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		else
+		  {
+		    status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		  }
 		break;
 	      }
 
@@ -7838,9 +7853,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      {
 		if (er_errid () != NO_ERROR)
 		  {
-		    return DOMAIN_ERROR;
+		    status = DOMAIN_ERROR;
 		  }
-		status = DOMAIN_INCOMPATIBLE;
+		else
+		  {
+		    status = DOMAIN_INCOMPATIBLE;
+		  }
 	      }
 	    else
 	      {
@@ -7905,9 +7923,12 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      {
 		if (er_errid () != NO_ERROR)	/* i.e, malloc failure */
 		  {
-		    return DOMAIN_ERROR;
+		    status = DOMAIN_ERROR;
 		  }
-		status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		else
+		  {
+		    status = DOMAIN_INCOMPATIBLE;	/* conversion error */
+		  }
 		break;
 	      }
 
@@ -7939,7 +7960,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_VARNCHAR:
 	  if (tp_atoutime (src, &v_utime) != NO_ERROR)
 	    {
-	      return DOMAIN_ERROR;
+	      status = DOMAIN_ERROR;
 	    }
 	  else
 	    {
@@ -8055,7 +8076,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_VARNCHAR:
 	  if (tp_atotimestamptz (src, &v_timestamptz) != NO_ERROR)
 	    {
-	      return DOMAIN_ERROR;
+	      status = DOMAIN_ERROR;
 	    }
 	  else
 	    {
@@ -8401,7 +8422,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_VARNCHAR:
 	  if (tp_atodatetimetz (src, &v_datetimetz) != NO_ERROR)
 	    {
-	      return DOMAIN_ERROR;
+	      status = DOMAIN_ERROR;
 	    }
 	  else
 	    {
@@ -8589,12 +8610,13 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    }
 	  else
 	    {
-	      return DOMAIN_ERROR;
+	      status = DOMAIN_ERROR;
+	      break;
 	    }
 
 	  if (db_make_date (target, month, day, year) != NO_ERROR)
 	    {
-	      return DOMAIN_ERROR;
+	      status = DOMAIN_ERROR;
 	    }
 	  break;
 
@@ -8803,12 +8825,13 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    }
 	  else
 	    {
-	      return DOMAIN_ERROR;
+	      status = DOMAIN_ERROR;
+	      break;
 	    }
 
 	  if (db_make_time (target, hour, minute, second) != NO_ERROR)
 	    {
-	      return DOMAIN_ERROR;
+	      status = DOMAIN_ERROR;
 	    }
 	  break;
 	case DB_TYPE_ENUMERATION:
@@ -8848,6 +8871,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    if (!sm_check_class_domain ((TP_DOMAIN *) desired_domain, ((DB_OTMPL *) db_get_pointer (src))->classobj))
 	      {
 		status = DOMAIN_INCOMPATIBLE;
+		break;
 	      }
 	    db_make_pointer (target, db_get_pointer (src));
 	    break;
@@ -8860,7 +8884,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    is_vclass = db_is_vclass (desired_domain->class_mop);
 	    if (is_vclass < 0)
 	      {
-		return DOMAIN_ERROR;
+		status = DOMAIN_ERROR;
+		break;
 	      }
 	    if (!is_vclass)
 	      {
@@ -8892,7 +8917,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		    is_vclass = db_is_vclass (desired_domain->class_mop);
 		    if (is_vclass < 0)
 		      {
-			return DOMAIN_ERROR;
+			status = DOMAIN_ERROR;
+			break;
 		      }
 		    if (is_vclass)
 		      {
@@ -9262,7 +9288,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    new_string = (char *) db_private_alloc (NULL, max_size);
 	    if (!new_string)
 	      {
-		return DOMAIN_ERROR;
+		status = DOMAIN_ERROR;
+		break;
 	      }
 
 	    if (original_type == DB_TYPE_BIGINT)
@@ -9345,7 +9372,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    new_string = (char *) db_private_alloc (NULL, max_size);
 	    if (new_string == NULL)
 	      {
-		return DOMAIN_ERROR;
+		status = DOMAIN_ERROR;
+		break;
 	      }
 
 	    strcpy (new_string, str_buf);
@@ -9373,7 +9401,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    new_string = (char *) db_private_alloc (NULL, max_size);
 	    if (!new_string)
 	      {
-		return DOMAIN_ERROR;
+		status = DOMAIN_ERROR;
+		break;
 	      }
 
 	    snprintf (new_string, max_size - 1, "%s%.*f", lang_currency_symbol (db_get_monetary (src)->type), 2,
@@ -9418,7 +9447,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    new_string = (char *) db_private_alloc (NULL, max_size);
 	    if (!new_string)
 	      {
-		return DOMAIN_ERROR;
+		status = DOMAIN_ERROR;
+		break;
 	      }
 
 	    err = NO_ERROR;
@@ -9496,7 +9526,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    new_string = (char *) db_private_alloc (NULL, max_size);
 	    if (!new_string)
 	      {
-		return DOMAIN_ERROR;
+		status = DOMAIN_ERROR;
+		break;
 	      }
 
 	    convert_error = bfmt_print (1 /* BIT_STRING_HEX */ , src,
@@ -9983,7 +10014,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      if (error_code != NO_ERROR)
 		{
 		  assert (doc == NULL);
-		  return DOMAIN_ERROR;
+		  status = DOMAIN_ERROR;
+		  break;
 		}
 
 	      if (desired_domain->json_validator
@@ -9991,7 +10023,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		{
 		  ASSERT_ERROR ();
 		  db_json_delete_doc (doc);
-		  return DOMAIN_ERROR;
+		  status = DOMAIN_ERROR;
+		  break;
 		}
 	    }
 	    break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22434

Fix cast from empty `DB_TYPE_JSON` to `DB_TYPE_DATETIME`.
When cast from empty `DB_TYPE_JSON` to `DB_TYPE_DATETIME` is not possible `db_value src_replacement` variable needs to be cleared otherwise there is a memory leak