### PR TITLE
[CBRD-22441] do not interrupt fileio_expand_to

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -1883,7 +1883,7 @@ fileio_initialize_pages (THREAD_ENTRY * thread_p, int vol_fd, FILEIO_PAGE * io_p
       /* check for interrupts from user (i.e. Ctrl-C) */
       if ((page_id % FILEIO_CHECK_FOR_INTERRUPT_INTERVAL) == 0)
 	{
-	  if (pgbuf_is_log_check_for_interrupts (thread_p) == true)
+	  if (logtb_get_check_interrupt (thread_p) && pgbuf_is_log_check_for_interrupts (thread_p))
 	    {
 	      return NULL;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22441

This issue was a regression of propagating interrupt error from fileio_initialize_pages, because it lead to inconsistencies between volume header and disk cache.

After we "commit" the changes in volume header, we cannot permit any interruptions. Fix by verifying logtb_get_check_interrupt in fileio_initialize_pages.