### PR TITLE
[CBRD-22443] online index creation is only allowed for safe cases

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -14619,6 +14619,13 @@ sm_add_constraint (MOP classop, DB_CONSTRAINT_TYPE constraint_type, const char *
 	  auth = AU_ALTER;
 	}
 
+      if (index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS && classop->lock > IX_LOCK)
+	{
+	  // if the transaction already hold a lock which is greater than IX,
+	  // we don't allow online index creation for transaction consistency.
+	  index_status = SM_NORMAL_INDEX;
+	}
+
       def = smt_edit_class_mop (classop, auth);
       if (def == NULL)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22443

- [x] lock should be restored even though operation fails (by #1271)
- [x] class was already locked by another DDL, not allow demotion (by this)
- [ ]  mismatch between server lock and client lock cache.

This fixes the second issue.
I was thinking to solve it as lock manager and change my mind to have a simpler fix. (We may have to manage full lock acquisition history. I don't really like it.)
If the transaction holds a lock greater than `IX`, it may break transaction consistencies to demote the lock. Online index creation is only allowed where transaction holds weaker locks, typically, it should be `SCH_S`.