### PR TITLE
[CBRD-22443] client resynchronizes cached lock if server fails to restore the demoted lock

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -5724,7 +5724,7 @@ btree_load_index (BTID * btid, const char *bt_name, TP_DOMAIN * key_type, OID * 
   if (index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS && curr_cls_lock != SCH_M_LOCK)
     {
       // hope it won't happen. server failed to restore the demoted lock.
-      // It just help things go worse.
+      // It just help things don't go worse.
 
       MOP class_mop = ws_mop (&class_oids[0], sm_Root_class_mop);
       if (class_mop != NULL)

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -5587,7 +5587,7 @@ btree_load_index (BTID * btid, const char *bt_name, TP_DOMAIN * key_type, OID * 
   int error = NO_ERROR, req_error, request_size, domain_size;
   char *ptr;
   char *request;
-  OR_ALIGNED_BUF (OR_INT_SIZE + OR_BTID_ALIGNED_SIZE) a_reply;
+  OR_ALIGNED_BUF (OR_INT_SIZE * 2 + OR_BTID_ALIGNED_SIZE) a_reply;
   char *reply;
   int i, total_attrs, bt_strlen, fk_strlen;
   int index_info_size = 0;

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -5593,6 +5593,7 @@ btree_load_index (BTID * btid, const char *bt_name, TP_DOMAIN * key_type, OID * 
   int index_info_size = 0;
   char *stream = NULL;
   int stream_size = 0;
+  LOCK curr_cls_lock;
 
   reply = OR_ALIGNED_BUF_START (a_reply);
 
@@ -5702,7 +5703,13 @@ btree_load_index (BTID * btid, const char *bt_name, TP_DOMAIN * key_type, OID * 
 
   if (!req_error)
     {
+      int t;
+
       ptr = or_unpack_int (reply, &error);
+
+      ptr = or_unpack_int (ptr, &t);
+      curr_cls_lock = (LOCK) t;
+
       ptr = or_unpack_btid (ptr, btid);
       if (error != NO_ERROR)
 	{
@@ -5712,6 +5719,18 @@ btree_load_index (BTID * btid, const char *bt_name, TP_DOMAIN * key_type, OID * 
   else
     {
       btid = NULL;
+    }
+
+  if (index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS && curr_cls_lock != SCH_M_LOCK)
+    {
+      // hope it won't happen. server failed to restore the demoted lock.
+      // It just help things go worse.
+
+      MOP class_mop = ws_mop (&class_oids[0], sm_Root_class_mop);
+      if (class_mop != NULL)
+	{
+	  ws_set_lock (class_mop, curr_cls_lock);
+	}
     }
 
   free_and_init (request);

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -3950,11 +3950,11 @@ end:
       LOCK cls_lock = lock_get_object_lock (&class_oids[0], oid_Root_class_oid, tran_index);
 
       assert (cls_lock == SCH_M_LOCK);	// hope it never be IX_LOCK.
-      ptr = or_pack_int (reply, (int) cls_lock);
+      ptr = or_pack_int (ptr, (int) cls_lock);
     }
   else
     {
-      ptr = or_pack_int (reply, SCH_M_LOCK);	// irrelevant
+      ptr = or_pack_int (ptr, SCH_M_LOCK);	// irrelevant
     }
 
   ptr = or_pack_btid (ptr, &btid);

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -3945,7 +3945,7 @@ end:
 
   if (index_status == OR_ONLINE_INDEX_BUILDING_IN_PROGRESS)
     {
-      // it may not be really necessary. it just help things go worse that client keep caching ex-lock.
+      // it may not be really necessary. it just help things don't go worse that client keep caching ex-lock.
       int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
       LOCK cls_lock = lock_get_object_lock (&class_oids[0], oid_Root_class_oid, tran_index);
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -3949,12 +3949,12 @@ end:
       int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
       LOCK cls_lock = lock_get_object_lock (&class_oids[0], oid_Root_class_oid, tran_index);
 
-      assert (cls_lock == SCH_M_LOCK); // hope it never be IX_LOCK.
+      assert (cls_lock == SCH_M_LOCK);	// hope it never be IX_LOCK.
       ptr = or_pack_int (reply, (int) cls_lock);
     }
   else
     {
-      ptr = or_pack_int (reply, SCH_M_LOCK); // irrelevant
+      ptr = or_pack_int (reply, SCH_M_LOCK);	// irrelevant
     }
 
   ptr = or_pack_btid (ptr, &btid);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22443

- [x]   lock should be restored even though operation fails (by #1271)
- [x]   class was already locked by another DDL, not allow demotion (by #1276)
- [x]   mismatch between server lock and client lock cache. (by this)

It is just a safe guard that helps things don't go worse. I hope we will remove it in someday. 
When server fails to promote the demoted lock, client synchronizes its lock cache with server's.