### PR TITLE
[CBRD-22454] add option to cast from DB_JSON_BOOL to any other type

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -705,6 +705,7 @@ static double db_json_get_double_from_value (const JSON_VALUE *doc);
 static const char *db_json_get_string_from_value (const JSON_VALUE *doc);
 static char *db_json_copy_string_from_value (const JSON_VALUE *doc);
 static char *db_json_get_bool_as_str_from_value (const JSON_VALUE *doc);
+static bool db_json_get_bool_from_value (const JSON_VALUE *doc);
 static char *db_json_bool_to_string (bool b);
 static void db_json_merge_two_json_objects_preserve (const JSON_VALUE *source, JSON_VALUE &dest,
     JSON_PRIVATE_MEMPOOL &allocator);
@@ -2603,6 +2604,12 @@ db_json_get_bool_as_str_from_document (const JSON_DOC *doc)
   return db_json_get_bool_as_str_from_value (doc);
 }
 
+bool
+db_json_get_bool_from_document (const JSON_DOC *doc)
+{
+  return db_json_get_bool_from_value (doc);
+}
+
 char *
 db_json_copy_string_from_document (const JSON_DOC *doc)
 {
@@ -2696,6 +2703,19 @@ db_json_get_bool_as_str_from_value (const JSON_VALUE *doc)
 
   assert (db_json_get_type_of_value (doc) == DB_JSON_BOOL);
   return db_json_bool_to_string (doc->GetBool ());
+}
+
+bool
+db_json_get_bool_from_value (const JSON_VALUE *doc)
+{
+  if (doc == NULL)
+    {
+      assert (false);
+      return NULL;
+    }
+
+  assert (db_json_get_type_of_value (doc) == DB_JSON_BOOL);
+  return doc->GetBool ();
 }
 
 static JSON_PATH_TYPE

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -2695,14 +2695,7 @@ db_json_bool_to_string (bool b)
 char *
 db_json_get_bool_as_str_from_value (const JSON_VALUE *doc)
 {
-  if (doc == NULL)
-    {
-      assert (false);
-      return NULL;
-    }
-
-  assert (db_json_get_type_of_value (doc) == DB_JSON_BOOL);
-  return db_json_bool_to_string (doc->GetBool ());
+  return db_json_bool_to_string (db_json_get_bool_from_value (doc));
 }
 
 bool

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -142,6 +142,7 @@ std::int64_t db_json_get_bigint_from_document (const JSON_DOC *doc);
 double db_json_get_double_from_document (const JSON_DOC *doc);
 const char *db_json_get_string_from_document (const JSON_DOC *doc);
 char *db_json_get_bool_as_str_from_document (const JSON_DOC *doc);
+bool db_json_get_bool_from_document (const JSON_DOC *doc);
 char *db_json_copy_string_from_document (const JSON_DOC *doc);
 
 void db_json_set_string_to_doc (JSON_DOC *doc, const char *str);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22454

* casting `DB_JSON_BOOL` to one of the following cases: `DB_TYPE_CHAR, DB_TYPE_VARCHAR, DB_TYPE_NCHAR or DB_TYPE_VARNCHAR` will generate the string true or false depending on the json value.
For example statements mentioned below will produce string `'true'` as output:
  * `select cast(cast('true' as json) as string);`
  * `select cast(cast('true' as json) as varchar);`
  * `select cast(cast('true' as json) as char(4));`
* casting `DB_JSON_BOOL` to any other type will generate int with value 1 or 0 depending on the json value. Then int value will be cast to desired type.
For example statements mentioned below will produce string `1` as output:
  * `select cast(cast('true' as json) as smallint);`
  * `select cast(cast('true' as json) as bigint);`
