### PR TITLE
[CBRD-22338] vacuum_data_load_and_recover: remove wrong safe-guard

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4165,7 +4165,6 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
   else
     {
       /* Get last_blockid from last vacuum data entry. */
-      assert (vacuum_Data.last_page->index_free > 0);
       INT16 last_block_index = (vacuum_Data.last_page->index_free <= 0) ? 0 : vacuum_Data.last_page->index_free - 1;
       vacuum_Data.set_last_blockid (vacuum_Data.last_page->data[last_block_index].blockid);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22338

Safe-guard said that if vacuum is not empty, it expects there is at least one entry in last page. However, it is invalidated by a corner case involving very long transaction and a very long period of time with no MVCC operations.

According to log dump, this is what happens:

  1. Multiple vacuum data blocks cannot be vacuumed because of very long transactions.
  2. Transactions are aborted. A very long rollback phase occurs, which is logged using compensate log records and generates no MVCC ops.
  3. Active transactions restart and new MVCC operations are logged. A new vacuum data block is consumed, adding many dummy vacuumed blocks and a block to be vacuumed. A new page is created for new block.
  4. In the meantime, jobs that vacuum old blocks start.
  5. Also vacuuming new block starts.
  6. New block is vacuumed before some of the old blocks. It is marked as vacuumed; since there is no other block in its page, page is reset.
  7. Crash.
  8. Restart - safe-guard wrongly assumes that if vacuum is not empty, its last page has to have at least one block to vacuum.

Removed safe-guard.