### PR TITLE
[CBRD-22427] Fix partition issues for Unique Online Index

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -16529,7 +16529,7 @@ sm_load_online_index (MOP classmop, const char *constraint_name)
   /* Enter the base class information into the arrays */
   n_classes = 0;
   COPY_OID (&oids[n_classes], WS_OID (classmop));
-  for (int i = 0; i < n_attrs; i++)
+  for (i = 0; i < n_attrs; i++)
     {
       attr_ids[i] = con->attributes[i]->id;
     }

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -16534,8 +16534,8 @@ sm_load_online_index (MOP classmop, const char *constraint_name)
       attr_ids[i] = con->attributes[i]->id;
     }
   HFID_COPY (&hfids[n_classes], sm_ch_heap ((MOBJ) class_));
-
   n_classes++;
+
   for (sub = subclasses; sub != NULL; sub = sub->next, n_classes++)
     {
       error = au_fetch_class (sub->op, &subclass_, AU_FETCH_UPDATE, AU_ALTER);
@@ -16546,24 +16546,16 @@ sm_load_online_index (MOP classmop, const char *constraint_name)
 	}
 
       COPY_OID (&oids[n_classes], WS_OID (sub->op));
+
       for (int j = 0; j < n_attrs; j++)
 	{
 	  attr_ids[n_classes * n_attrs + j] = con->attributes[j]->id;
 	}
+
       HFID_COPY (&hfids[n_classes], sm_ch_heap ((MOBJ) subclass_));
+
       subclass_ = NULL;
     }
-
-  /*for (int j = 0; j < max_classes; j++)
-     {
-     COPY_OID (&oids[j], WS_OID (classmop));
-     for (i = 0; i < n_attrs; i++)
-     {
-     attr_ids[j * n_attrs + i] = con->attributes[i]->id;
-     }
-     HFID_COPY (&hfids[n_classes], sm_ch_heap ((MOBJ) class_));
-     n_classes++;
-     } */
 
   if (con->type == SM_CONSTRAINT_REVERSE_INDEX || con->type == SM_CONSTRAINT_REVERSE_UNIQUE)
     {

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -4445,8 +4445,6 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
 	}
     }
 
-  cur_class = 0;
-
   for (cur_class = 0; cur_class < n_classes; cur_class++)
     {
       attr_offset = cur_class * n_attrs;

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -4436,6 +4436,13 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
       tdes->has_deadlock_priority = true;
     }
 
+  /* Acquire snapshot!! */
+  builder_snapshot = logtb_get_mvcc_snapshot (thread_p);
+  if (builder_snapshot == NULL)
+    {
+      goto error;
+    }
+
   /* Alloc memory for btid list for unique indexes. */
   if (BTREE_IS_UNIQUE (unique_pk))
     {
@@ -4499,13 +4506,6 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
 	{
 	  _er_log_debug (ARG_FILE_LINE, "DEBUG_BTREE: load start on class(%d, %d, %d), btid(%d, (%d, %d)).",
 			 OID_AS_ARGS (&class_oids[cur_class]), BTID_AS_ARGS (btid_int.sys_btid));
-	}
-
-      /* Acquire snapshot!! */
-      builder_snapshot = logtb_get_mvcc_snapshot (thread_p);
-      if (builder_snapshot == NULL)
-	{
-	  goto error;
 	}
 
       /* Assign the snapshot to the scan_cache. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22427

This tries to fix the issue with the partition case for Online Index where the index was not loading for partitions, but only for the top class.

The flow looks like this:

`Create empty indices for the top class and all its subclasses.`
`Demote the lock on the top class and all its subclasses to IX_LOCK.`
`Each index begins loading and checks for unique constraint violation.`
`Promote all locks back to SCH_M_LOCK.`
`Commit changes if everything is in order.`