### PR TITLE
[CBRD-22453] fix json_array_insert when invalid json path is provided

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1752,8 +1752,8 @@ db_json_resolve_json_parent (JSON_DOC &doc, const std::string &path, JSON_VALUE 
   std::size_t found = path.find_last_of ('/');
   if (found == std::string::npos)
     {
-      assert (false);
-      return ER_FAILED;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_JSON_INVALID_PATH, 0);
+      return ER_JSON_INVALID_PATH;
     }
 
   // parent pointer
@@ -2170,15 +2170,13 @@ db_json_array_insert_func (const JSON_DOC *value, JSON_DOC &doc, const char *raw
     }
 
   JSON_POINTER p (json_pointer_string.c_str ());
-  JSON_VALUE *resulting_json = NULL;
-
   if (!p.IsValid ())
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_JSON_INVALID_PATH, 0);
       return ER_JSON_INVALID_PATH;
     }
 
-  resulting_json = p.Get (doc);
+  JSON_VALUE *resulting_json = p.Get (doc);
   if (resulting_json != NULL)
     {
       // need to shift any following values to the right


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22453

When invalid json path is provided for json_array_insert function, instead of using assertion just set an error and return. Statement `select json_array_insert('true', '$', '1');` now returns `ERROR: Invalid JSON path`
