### PR TITLE
[CBRD-22451] Handle type checking for JSON_(OBJECT|ARRAY)AGG functions on server side

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -3265,55 +3265,6 @@ db_json_pretty_func (const JSON_DOC &doc, char *&result_str)
 }
 
 /*
- * db_json_arrayagg_func_accumulate () - Appends the value to the result_json
- *
- * return                  : void
- * value (in)              : value to append
- * result_json (in)        : the document where we want to append
- * expand (in)             : expand will be true only when aggregate 2 accumulators
- */
-void
-db_json_arrayagg_func_accumulate (const JSON_DOC *value, JSON_DOC &result_json)
-{
-  DB_JSON_TYPE result_json_type = db_json_get_type (&result_json);
-
-  // only the first time the result_json will have DB_JSON_NULL type
-  if (result_json_type == DB_JSON_TYPE::DB_JSON_NULL)
-    {
-      result_json.SetArray ();
-    }
-
-  assert (result_json.IsArray ());
-
-  JSON_VALUE value_copy (*value, result_json.GetAllocator ());
-  result_json.PushBack (value_copy, result_json.GetAllocator ());
-}
-
-/*
- * db_json_objectagg_func_accumulate () - Inserts a (key, value) pair in the result_json
- *
- * return                  : void
- * key_str (in)            : the key string
- * val_doc (in)            : the value document
- * result_json (in)        : the document where we want to insert
- */
-void
-db_json_objectagg_func_accumulate (const char *key_str, const JSON_DOC *val_doc, JSON_DOC &result_json)
-{
-  DB_JSON_TYPE result_json_type = db_json_get_type (&result_json);
-
-  // only the first time the result_json will have DB_JSON_NULL type
-  if (result_json_type == DB_JSON_TYPE::DB_JSON_NULL)
-    {
-      result_json.SetObject ();
-    }
-
-  assert (result_json.IsObject ());
-
-  db_json_add_member_to_object (&result_json, key_str, val_doc);
-}
-
-/*
  * db_json_keys_func () - Returns the keys from the top-level value of a JSON object as a JSON array
  *
  * return                  : error code

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -110,8 +110,6 @@ int db_json_merge_func (const JSON_DOC *source, JSON_DOC *&dest, bool patch);
 int db_json_get_all_paths_func (const JSON_DOC &doc, JSON_DOC *&result_json);
 void db_json_pretty_func (const JSON_DOC &doc, char *&result_str);
 int db_json_unquote (const JSON_DOC &doc, char *&result_str);
-void db_json_arrayagg_func_accumulate (const JSON_DOC *value, JSON_DOC &result_json);
-void db_json_objectagg_func_accumulate (const char *key_str, const JSON_DOC *val_doc, JSON_DOC &result_json);
 
 int db_json_object_contains_key (JSON_DOC *obj, const char *key, int &result);
 const char *db_json_get_schema_raw_from_validator (JSON_VALIDATOR *val);

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -153,6 +153,10 @@ bool db_json_are_docs_equal (const JSON_DOC *doc1, const JSON_DOC *doc2);
 void db_json_make_document_null (JSON_DOC *doc);
 bool db_json_doc_has_numeric_type (const JSON_DOC *doc);
 bool db_json_doc_is_uncomparable (const JSON_DOC *doc);
+
+// DB_VALUE manipulation functions
+int db_value_to_json_doc (const DB_VALUE &db_val, REFPTR (JSON_DOC, json_doc));
+int db_value_to_json_value (const DB_VALUE &db_val, REFPTR (JSON_DOC, json_val));
 /* end of C functions */
 
 template <typename Fn, typename... Args>

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5500,7 +5500,7 @@ pt_infer_common_type (const PT_OP_TYPE op, PT_TYPE_ENUM * arg1, PT_TYPE_ENUM * a
     }
   if (arg3_eq_type != PT_TYPE_NONE)
     {
-      /* at this point either all arg1_eq_type, arg2_eq_type and common_type are PT_TYPE_MAYBE, or are already set to a 
+      /* at this point either all arg1_eq_type, arg2_eq_type and common_type are PT_TYPE_MAYBE, or are already set to a
        * PT_TYPE_ENUM */
       common_type = pt_common_type_op (common_type, op, arg3_eq_type);
       if (common_type == PT_TYPE_MAYBE)
@@ -5524,7 +5524,7 @@ pt_infer_common_type (const PT_OP_TYPE op, PT_TYPE_ENUM * arg1, PT_TYPE_ENUM * a
     }
   if (common_type == PT_TYPE_MAYBE && expected_type != PT_TYPE_NONE && !pt_is_op_hv_late_bind (op))
     {
-      /* if expected type if not PT_TYPE_NONE then a expression higher up in the parser tree has set an expected domain 
+      /* if expected type if not PT_TYPE_NONE then a expression higher up in the parser tree has set an expected domain
        * for this node and we can use it to set the expected domain of the arguments */
       common_type = expected_type;
     }
@@ -5756,7 +5756,7 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
   else if (PT_IS_COLLECTION_TYPE (arg2_type))
     {
       /* Because we're using collections, semantically, all three cases below are valid: 1. SELECT * FROM tbl WHERE
-       * int_col in {integer, set, object, date} 2. SELECT * FROM tbl WHERE int_col in {str, str, str} 3. SELECT * FROM 
+       * int_col in {integer, set, object, date} 2. SELECT * FROM tbl WHERE int_col in {str, str, str} 3. SELECT * FROM
        * tbl WHERE int_col in {integer, integer, integer} We will only coerce arg2 if there is a common type between
        * arg1 and all elements from the collection arg2. We do not consider the case in which we cannot discern a
        * common type to be a semantic error and we rely on the functionality of the comparison operators to be applied
@@ -6154,7 +6154,7 @@ pt_coerce_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE * arg
 	}
     }
 
-  /* We might have decided a new type for arg1 based on the common_type but, if the signature defines an exact type, we 
+  /* We might have decided a new type for arg1 based on the common_type but, if the signature defines an exact type, we
    * should keep it. For example, + is a symmetric operator but also defines date + bigint which is not symmetric and
    * we have to keep the bigint type even if the common type is date. This is why, before coercing expression
    * arguments, we check the signature that we decided to apply */
@@ -7280,7 +7280,7 @@ pt_where_type (PARSER_CONTEXT * parser, PT_NODE * where)
 
 always_false:
 
-  /* If any conjunct is false, the entire WHERE clause is false. Jack the return value to be a single false node (being 
+  /* If any conjunct is false, the entire WHERE clause is false. Jack the return value to be a single false node (being
    * sure to unlink the node from the "next" chain if we reuse the incoming node). */
   parser_free_tree (parser, where);
   where = parser_new_node (parser, PT_VALUE);
@@ -7349,7 +7349,7 @@ pt_false_where (PARSER_CONTEXT * parser, PT_NODE * node)
 
     case PT_SELECT:
 
-      /* If the "connect by" condition is false the query still has to return all the "start with" tuples. Therefore we 
+      /* If the "connect by" condition is false the query still has to return all the "start with" tuples. Therefore we
        * do not check that "connect by" is false. */
       if (node->info.query.q.select.start_with)
 	{
@@ -7944,7 +7944,7 @@ pt_eval_type_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *conti
 	 * argn-1), argn) we need to compute the common type between all arguments in order to give a correct return
 	 * type. Let's say we have the following call to PT_GREATEST: greatest(e1, e2, e3, 2) where e1, e2, e3 are
 	 * ENUMs. The internal form is rewrited to greatest(greatest(greatest(e1, e2), e3), 2). For the inner call the
-	 * common type will be STRING. For middle call the common type will be STRING and for the outer call the common 
+	 * common type will be STRING. For middle call the common type will be STRING and for the outer call the common
 	 * type will be DOUBLE and both arguments will be casted to DOUBLE including the returned STRING of the middle
 	 * (or even inner) call. If the string does not have a numeric format, the call will fail. The natural
 	 * behaviour is a conversion of all enum arguments to the type of '2' (integer). So we compute the common type
@@ -7967,7 +7967,7 @@ pt_eval_type_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *conti
 		norm_arg = &recurs_expr->info.expr.arg1;
 		recurs_arg = &recurs_expr->info.expr.arg2;
 	      }
-	    /* In order to correctly compute the common type we need to know the type of each argument and therefore we 
+	    /* In order to correctly compute the common type we need to know the type of each argument and therefore we
 	     * compute it. */
 	    node_tmp = pt_semantic_type (parser, *norm_arg, (SEMANTIC_CHK_INFO *) arg);
 	    if (*norm_arg == NULL || pt_has_error (parser))
@@ -9220,7 +9220,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	}
     }
 
-  /* 
+  /*
    * At this point, arg1_hv is non-NULL (and equal to arg1) if it represents
    * a dynamic host variable, i.e., a host var parameter that hasn't had
    * a value supplied at compile time.  Same for arg2_hv and arg3_hv...
@@ -9351,7 +9351,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
       /* [NOT] LIKE operators with an escape clause are parsed like PT_LIKE(arg1, PT_LIKE_ESCAPE(arg2, arg3)). We
        * convert it to PT_LIKE(arg1, arg2, arg3) to be able to decide the correct common type of all arguments and we
        * will convert it back once we apply the correct casts.
-       * 
+       *
        * A better approach would be to modify the parser to output PT_LIKE(arg1, arg2, arg3) directly. */
 
       if (arg2->node_type == PT_EXPR && arg2->info.expr.op == PT_LIKE_ESCAPE)
@@ -9739,7 +9739,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 
   if (pt_is_symmetric_op (op))
     {
-      /* 
+      /*
        * At most one of these next two cases will hold... these will
        * make a dynamic host var (one about whose type we know nothing
        * at this point) assume the type of its "mate" in a symmetric
@@ -9811,7 +9811,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 
 	  if (arg1_type != common_type)
 	    {
-	      /* 
+	      /*
 	       * pt_coerce_value may fail here, but it shouldn't be
 	       * considered a real failure yet, because it could still
 	       * be rescued by the gruesome date/time stuff below.
@@ -9922,7 +9922,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 
   if (node->type_enum == PT_TYPE_MAYBE && pt_is_able_to_determine_return_type (op))
     {
-      /* Because we can determine the return type of the expression regardless of its argument, go further to determine 
+      /* Because we can determine the return type of the expression regardless of its argument, go further to determine
        * it. temporary reset to NONE. */
       node->type_enum = PT_TYPE_NONE;
     }
@@ -10078,7 +10078,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	}
       else
 	{
-	  /* We have to decide a common type for arg2 and arg3. We cannot use pt_common_type_op because this function 
+	  /* We have to decide a common type for arg2 and arg3. We cannot use pt_common_type_op because this function
 	   * is designed mostly for arithmetic expression. This is why we use the tp_is_more_general_type here. */
 	  dbtype2 = pt_type_enum_to_db (arg2_type);
 	  dbtype3 = pt_type_enum_to_db (arg3_type);
@@ -11592,7 +11592,7 @@ pt_common_type_op (PT_TYPE_ENUM t1, PT_OP_TYPE op, PT_TYPE_ENUM t2)
     default:
       break;
     }
-  /* 
+  /*
    * true + true must not be logical.
    * Same goes for true*true, (i or j)+(i and j) etc.
    * Basic rule: if both operands are logical but the operation is not logical,
@@ -12807,7 +12807,7 @@ pt_eval_function_type (PARSER_CONTEXT * parser, PT_NODE * node)
       return node;
     }
 
-  /* to avoid "node->next" ambiguities, wrap any logical node within the arg list with a cast to integer. This way, the 
+  /* to avoid "node->next" ambiguities, wrap any logical node within the arg list with a cast to integer. This way, the
    * CNF trees do not mix up with the arg list. */
   for (arg = arg_list; arg != NULL; prev = arg, arg = arg->next)
     {
@@ -12838,7 +12838,7 @@ pt_eval_function_type (PARSER_CONTEXT * parser, PT_NODE * node)
       return node;
     }
 
-  /* 
+  /*
    * Should only get one arg to function; set to 0 if the function
    * accepts more than one.
    */
@@ -13010,18 +13010,7 @@ pt_eval_function_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	    arg_type = PT_TYPE_NONE;
 	    PT_ERRORmf2 (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_FUNC_NOT_DEFINED_ON,
 			 pt_show_function (fcode), pt_show_type_enum (arg_list->type_enum));
-	    break;
 	  }
-
-	/* cast arg_list to json */
-	arg_list = pt_wrap_with_cast_op (parser, arg_list, PT_TYPE_JSON, 0, 0, NULL);
-	if (arg_list == NULL)
-	  {
-	    return node;
-	  }
-
-	arg_type = PT_TYPE_JSON;
-	node->info.function.arg_list = arg_list;
       }
       break;
 
@@ -13052,15 +13041,6 @@ pt_eval_function_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	    break;
 	  }
 
-	/* cast value to json */
-	arg_list->next = pt_wrap_with_cast_op (parser, value, PT_TYPE_JSON, 0, 0, NULL);
-	if (arg_list->next == NULL)
-	  {
-	    return node;
-	  }
-
-	arg_type = PT_TYPE_JSON;
-	node->info.function.arg_list = arg_list;
 	// JSON_OBJECTAGG requires 2 arguments
 	check_agg_single_arg = false;
       }
@@ -13349,7 +13329,7 @@ pt_eval_function_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	      }
 	    else
 	      {
-		// args[4+] can be only paths 
+		// args[4+] can be only paths
 		is_supported = pt_is_json_path (arg->type_enum);
 	      }
 
@@ -13970,7 +13950,7 @@ pt_eval_function_type (PARSER_CONTEXT * parser, PT_NODE * node)
 		  }
 	      }
 
-	    /* 
+	    /*
 	     * Look for the first argument of character string type and obtain its category (CHAR/NCHAR). All other
 	     * arguments should be converted to this type, which is also the return type. */
 
@@ -15248,7 +15228,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      return 0;
 	    }
 
-	  /* If len, defined as second argument, is negative value, RIGHT function returns the entire string. It's same 
+	  /* If len, defined as second argument, is negative value, RIGHT function returns the entire string. It's same
 	   * behavior with LEFT and SUBSTRING. */
 	  if (db_get_int (&tmp_val2) < 0)
 	    {
@@ -16717,7 +16697,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 	    case DB_TYPE_INTEGER:
 	      {
-		/* NOTE that we need volatile to prevent optimizer from generating division expression as 
+		/* NOTE that we need volatile to prevent optimizer from generating division expression as
 		 * multiplication.
 		 */
 		volatile int i1, i2, itmp;
@@ -16738,7 +16718,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 	    case DB_TYPE_BIGINT:
 	      {
-		/* NOTE that we need volatile to prevent optimizer from generating division expression as 
+		/* NOTE that we need volatile to prevent optimizer from generating division expression as
 		 * multiplication.
 		 */
 		volatile DB_BIGINT bi1, bi2, bitmp;
@@ -16759,7 +16739,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 	    case DB_TYPE_SHORT:
 	      {
-		/* NOTE that we need volatile to prevent optimizer from generating division expression as 
+		/* NOTE that we need volatile to prevent optimizer from generating division expression as
 		 * multiplication.
 		 */
 		volatile short s1, s2, stmp;
@@ -19766,7 +19746,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	}
 
       /* a NULL OID is returned; the resulting PT_VALUE node will be replaced with a PT_HOST_VAR by the auto
-       * parameterization step because of the special force_auto_parameterize flag. Also see and pt_dup_key_update_stmt 
+       * parameterization step because of the special force_auto_parameterize flag. Also see and pt_dup_key_update_stmt
        * () and qo_optimize_queries () */
       tmp_value->type_enum = PT_TYPE_OBJECT;
       OID_SET_NULL (&null_oid);
@@ -20917,7 +20897,7 @@ pt_set_default_data_type (PARSER_CONTEXT * parser, PT_TYPE_ENUM type, PT_NODE **
 
     case PT_TYPE_NUMERIC:
       dt->info.data_type.precision = TP_FLOATING_PRECISION_VALUE;
-      /* 
+      /*
        * FIX ME!! Is it the case that this will always happen in
        * zero-scale context?  That's certainly the case when we're
        * coercing from integers, but what about floats and doubles?
@@ -21097,7 +21077,7 @@ pt_coerce_value_internal (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest
     {
     case PT_HOST_VAR:
       /* binding of host variables may be delayed in the case of an esql PREPARE statement until an OPEN cursor or an
-       * EXECUTE statement. in this case we seem to have no choice but to assume each host variable is typeless and can 
+       * EXECUTE statement. in this case we seem to have no choice but to assume each host variable is typeless and can
        * be coerced into any desired type. */
       if (parser->set_host_var == 0)
 	{
@@ -22472,7 +22452,7 @@ pt_get_collation_info (PT_NODE * node, PT_COLL_INFER * coll_infer)
  *
  *   return:  NO_COLLATION = node doesn't have collation;
  *	      HAS_COLLATION = node has collation
- *	      ERROR_COLLATION = node has multiple component types with 
+ *	      ERROR_COLLATION = node has multiple component types with
  *	      collation and collations are not compatible
  *
  *   parser(in)
@@ -22692,9 +22672,9 @@ error:
  *   parser(in)
  *   node(in): a parse tree node
  *   coll_infer(out): collation inference data
- *   is_inner_collection(in): the node is an inner collection (inside 
+ *   is_inner_collection(in): the node is an inner collection (inside
  *   another collection)
- *   first_element(in/out): is this the first element of the outer collection  
+ *   first_element(in/out): is this the first element of the outer collection
  *   (of all of the collections of collection)
  *
  */
@@ -23177,7 +23157,7 @@ pt_coerce_node_collation (PARSER_CONTEXT * parser, PT_NODE * node, const int col
       else if (PT_HAS_COLLATION (node->type_enum) || node->type_enum == PT_TYPE_MAYBE)
 	{
 	  /* We wrap with cast when: - force_mode is disabled (we apply new collation on existing node), and - it is a
-	   * string literal node with different codeset - it is a other node type with differrent collation - it is not 
+	   * string literal node with different codeset - it is a other node type with differrent collation - it is not
 	   * a CAST expression - it is not HOST_VAR node */
 	  if (!force_mode
 	      && ((node->data_type != NULL
@@ -23497,7 +23477,7 @@ pt_coerce_node_collation (PARSER_CONTEXT * parser, PT_NODE * node, const int col
       if (is_string_literal == true && node->node_type == PT_EXPR && node->info.expr.op == PT_CAST)
 	{
 	  PT_NODE *save_next;
-	  /* a PT_VALUE node was wrapped with CAST to change the charset and collation, but the value originated from a 
+	  /* a PT_VALUE node was wrapped with CAST to change the charset and collation, but the value originated from a
 	   * simple string literal which does not allow COLLATE; this forces a charset conversion and print with the
 	   * new charset introducer, and without COLLATE */
 	  assert (PT_EXPR_INFO_IS_FLAGED (node, PT_EXPR_INFO_CAST_SHOULD_FOLD));
@@ -24179,7 +24159,7 @@ coerce_arg:
 coerce_result:
   if (op == PT_CHR || op == PT_CLOB_TO_CHAR)
     {
-      /* for these operators, we don't want the arguments' collations to infere common collation, but special values of 
+      /* for these operators, we don't want the arguments' collations to infere common collation, but special values of
        * arg2 */
       common_cs = (INTL_CODESET) expr->data_type->info.data_type.units;
       common_coll = expr->data_type->info.data_type.collation_id;
@@ -24845,7 +24825,7 @@ pt_fix_enumeration_comparison (PARSER_CONTEXT * parser, PT_NODE * expr)
 
       while (list != NULL)
 	{
-	  /* Skip nodes that already have been wrapped with PT_TO_ENUMERATION_VALUE expression or have the correct type 
+	  /* Skip nodes that already have been wrapped with PT_TO_ENUMERATION_VALUE expression or have the correct type
 	   */
 	  if ((list->node_type == PT_EXPR && list->info.expr.op == PT_TO_ENUMERATION_VALUE)
 	      || (list->type_enum == PT_TYPE_ENUMERATION
@@ -25143,7 +25123,7 @@ pt_fix_arguments_collation_flag (PT_NODE * expr)
     }
 
   /* for each argument, determine a common type between signatures : if all signatures allows only data types having
-   * collation, we can promote the collation flag, if not - the signature type (argx_sig_type) is set to TYPE_NULL, and 
+   * collation, we can promote the collation flag, if not - the signature type (argx_sig_type) is set to TYPE_NULL, and
    * the collation flag is not promoted */
   for (i = 0; i < def.overloads_count; i++)
     {

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5302,26 +5302,7 @@ db_json_arrayagg_dbval_accumulate (DB_VALUE * json_db_val, DB_VALUE * json_res)
     }
 
   // get the current value
-  switch (DB_VALUE_DOMAIN_TYPE (json_db_val))
-    {
-    case DB_TYPE_CHAR:
-    case DB_TYPE_VARCHAR:
-    case DB_TYPE_NCHAR:
-    case DB_TYPE_VARNCHAR:
-      val_doc = db_json_allocate_doc ();
-      db_json_set_string_to_doc (val_doc, db_get_string (json_db_val));
-      break;
-    default:
-      DB_VALUE dest;
-      TP_DOMAIN_STATUS status = tp_value_cast (json_db_val, &dest, &tp_Json_domain, false);
-      if (status != DOMAIN_COMPATIBLE)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INVALID_DATA_TYPE, 0);
-	  return ER_QSTR_INVALID_DATA_TYPE;
-	}
-
-      val_doc = db_get_json_document (&dest);
-    }
+  db_value_to_json_value (*json_db_val, val_doc);
 
   // append to existing document
   // allocate only first time
@@ -5377,26 +5358,7 @@ db_json_objectagg_dbval_accumulate (DB_VALUE * json_key, DB_VALUE * json_db_val,
   key_str = db_get_string (json_key);
 
   // get the current value
-  switch (DB_VALUE_DOMAIN_TYPE (json_db_val))
-    {
-    case DB_TYPE_CHAR:
-    case DB_TYPE_VARCHAR:
-    case DB_TYPE_NCHAR:
-    case DB_TYPE_VARNCHAR:
-      val_doc = db_json_allocate_doc ();
-      db_json_set_string_to_doc (val_doc, db_get_string (json_db_val));
-      break;
-    default:
-      DB_VALUE dest;
-      TP_DOMAIN_STATUS status = tp_value_cast (json_db_val, &dest, &tp_Json_domain, false);
-      if (status != DOMAIN_COMPATIBLE)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INVALID_DATA_TYPE, 0);
-	  return ER_QSTR_INVALID_DATA_TYPE;
-	}
-
-      val_doc = db_get_json_document (&dest);
-    }
+  db_value_to_json_value (*json_db_val, val_doc);
 
   // append to existing document
   // allocate only first time

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5287,13 +5287,13 @@ db_json_pretty_dbval (DB_VALUE * json, DB_VALUE * res)
 }
 
 int
-db_json_arrayagg_dbval_accumulate (DB_VALUE * json, DB_VALUE * json_res)
+db_json_arrayagg_dbval_accumulate (DB_VALUE * json_db_val, DB_VALUE * json_res)
 {
-  JSON_DOC *this_doc;
-  JSON_DOC *result_doc = NULL;
   int error_code = NO_ERROR;
+  JSON_DOC *val_doc = NULL;
+  JSON_DOC *result_doc = NULL;
 
-  if (DB_IS_NULL (json))
+  if (DB_IS_NULL (json_db_val))
     {
       // this case should not be possible because we already wrapped a NULL value into a JSON with type DB_JSON_NULL
       assert (false);
@@ -5302,7 +5302,26 @@ db_json_arrayagg_dbval_accumulate (DB_VALUE * json, DB_VALUE * json_res)
     }
 
   // get the current value
-  this_doc = db_get_json_document (json);
+  switch (DB_VALUE_DOMAIN_TYPE (json_db_val))
+    {
+    case DB_TYPE_CHAR:
+    case DB_TYPE_VARCHAR:
+    case DB_TYPE_NCHAR:
+    case DB_TYPE_VARNCHAR:
+      val_doc = db_json_allocate_doc ();
+      db_json_set_string_to_doc (val_doc, db_get_string (json_db_val));
+      break;
+    default:
+      DB_VALUE dest;
+      TP_DOMAIN_STATUS status = tp_value_cast (json_db_val, &dest, &tp_Json_domain, false);
+      if (status != DOMAIN_COMPATIBLE)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INVALID_DATA_TYPE, 0);
+	  return ER_QSTR_INVALID_DATA_TYPE;
+	}
+
+      val_doc = db_get_json_document (&dest);
+    }
 
   // append to existing document
   // allocate only first time
@@ -5316,14 +5335,16 @@ db_json_arrayagg_dbval_accumulate (DB_VALUE * json, DB_VALUE * json_res)
       result_doc = db_get_json_document (json_res);
     }
 
-  db_json_arrayagg_func_accumulate (this_doc, *result_doc);
-
   if (result_doc == NULL)
     {
       db_make_null (json_res);
+      db_json_delete_doc (val_doc);
       return ER_FAILED;
     }
 
+  db_json_add_element_to_array (result_doc, val_doc);
+
+  db_json_delete_doc (val_doc);
   return error_code;
 }
 
@@ -5336,16 +5357,16 @@ db_json_arrayagg_dbval_accumulate (DB_VALUE * json, DB_VALUE * json_res)
  * json_res (in)           : the DB_VALUE that contains the document where we want to insert
  */
 int
-db_json_objectagg_dbval_accumulate (DB_VALUE * json_key, DB_VALUE * json_val, DB_VALUE * json_res)
+db_json_objectagg_dbval_accumulate (DB_VALUE * json_key, DB_VALUE * json_db_val, DB_VALUE * json_res)
 {
-  JSON_DOC *val_doc;
-  const char *key_str = NULL;
-  JSON_DOC *result_doc = NULL;
   int error_code = NO_ERROR;
+  const char *key_str = NULL;
+  JSON_DOC *val_doc = NULL;
+  JSON_DOC *result_doc = NULL;
 
   // this case should not be possible because we checked before if the key is NULL
   // and wrapped the value with a JSON with DB_JSON_NULL type
-  if (DB_IS_NULL (json_key) || DB_IS_NULL (json_val))
+  if (DB_IS_NULL (json_key) || DB_IS_NULL (json_db_val))
     {
       assert (false);
       db_make_null (json_res);
@@ -5356,7 +5377,26 @@ db_json_objectagg_dbval_accumulate (DB_VALUE * json_key, DB_VALUE * json_val, DB
   key_str = db_get_string (json_key);
 
   // get the current value
-  val_doc = db_get_json_document (json_val);
+  switch (DB_VALUE_DOMAIN_TYPE (json_db_val))
+    {
+    case DB_TYPE_CHAR:
+    case DB_TYPE_VARCHAR:
+    case DB_TYPE_NCHAR:
+    case DB_TYPE_VARNCHAR:
+      val_doc = db_json_allocate_doc ();
+      db_json_set_string_to_doc (val_doc, db_get_string (json_db_val));
+      break;
+    default:
+      DB_VALUE dest;
+      TP_DOMAIN_STATUS status = tp_value_cast (json_db_val, &dest, &tp_Json_domain, false);
+      if (status != DOMAIN_COMPATIBLE)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INVALID_DATA_TYPE, 0);
+	  return ER_QSTR_INVALID_DATA_TYPE;
+	}
+
+      val_doc = db_get_json_document (&dest);
+    }
 
   // append to existing document
   // allocate only first time
@@ -5370,14 +5410,16 @@ db_json_objectagg_dbval_accumulate (DB_VALUE * json_key, DB_VALUE * json_val, DB
       result_doc = db_get_json_document (json_res);
     }
 
-  db_json_objectagg_func_accumulate (key_str, val_doc, *result_doc);
-
   if (result_doc == NULL)
     {
       db_make_null (json_res);
+      db_json_delete_doc (val_doc);
       return ER_FAILED;
     }
 
+  db_json_add_member_to_object (result_doc, key_str, val_doc);
+
+  db_json_delete_doc (val_doc);
   return NO_ERROR;
 }
 

--- a/src/query/arithmetic.h
+++ b/src/query/arithmetic.h
@@ -76,8 +76,8 @@ extern int db_json_length_dbval (const DB_VALUE * json, const DB_VALUE * path, D
 extern int db_json_depth_dbval (DB_VALUE * json, DB_VALUE * res);
 extern int db_json_unquote_dbval (DB_VALUE * json, DB_VALUE * res);
 extern int db_json_pretty_dbval (DB_VALUE * json, DB_VALUE * res);
-extern int db_json_arrayagg_dbval_accumulate (DB_VALUE * dbval, DB_VALUE * res);
-extern int db_json_objectagg_dbval_accumulate (DB_VALUE * json_key, DB_VALUE * json_val, DB_VALUE * json_res);
+extern int db_json_arrayagg_dbval_accumulate (DB_VALUE * json_db_val, DB_VALUE * json_res);
+extern int db_json_objectagg_dbval_accumulate (DB_VALUE * json_key, DB_VALUE * json_db_val, DB_VALUE * json_res);
 extern int db_json_merge (DB_VALUE * json, DB_VALUE * json_res);
 extern int db_least_or_greatest (DB_VALUE * arg1, DB_VALUE * arg2, DB_VALUE * result, bool least);
 #endif /* _ARITHMETIC_H_ */

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -285,7 +285,6 @@ static int print_string_date_token (const STRING_DATE_TOKEN token_type, const IN
 				    int *token_size);
 static void convert_locale_number (char *sz, const int size, const INTL_LANG src_locale, const INTL_LANG dst_locale);
 static int parse_tzd (const char *str, const int max_expect_len);
-static int db_value_to_json_doc (const DB_VALUE & value, REFPTR (JSON_DOC, json));
 static int db_json_merge_helper (DB_VALUE * result, DB_VALUE * arg[], int const num_args, bool patch = false);
 
 #define TRIM_FORMAT_STRING(sz, n) {if (strlen(sz) > n) sz[n] = 0;}
@@ -28747,45 +28746,4 @@ db_conv_tz (DB_VALUE * time_val, DB_VALUE * result_time)
     }
 
   return error;
-}
-
-/* db_value_to_json_doc - create a JSON_DOC from db_value.
- *
- * return     : error code
- * value (in) : input db_value
- * json (out) : output JSON_DOC pointer
- */
-static int
-db_value_to_json_doc (const DB_VALUE & value, REFPTR (JSON_DOC, json))
-{
-  int error_code = NO_ERROR;
-
-  json = NULL;
-  switch (DB_VALUE_DOMAIN_TYPE (&value))
-    {
-    case DB_TYPE_CHAR:
-    case DB_TYPE_VARCHAR:
-    case DB_TYPE_NCHAR:
-    case DB_TYPE_VARNCHAR:
-      error_code = db_json_get_json_from_str (db_get_string (&value), json, db_get_string_size (&value));
-      if (error_code != NO_ERROR)
-	{
-	  assert (json == NULL);
-	  ASSERT_ERROR ();
-	}
-      return error_code;
-
-    case DB_TYPE_JSON:
-      json = db_json_get_copy_of_doc (value.data.json.document);
-      return NO_ERROR;
-
-    case DB_TYPE_NULL:
-      json = db_json_allocate_doc ();
-      return NO_ERROR;
-
-    default:
-      // todo: more specific error
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INVALID_DATA_TYPE, 0);
-      return ER_QSTR_INVALID_DATA_TYPE;
-    }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22451

In case of `JSON_ARRAYAGG` and `JSON_OBJECTAGG` functions, input values must be treated as `JSON_VALUE` and not `JSON_DOC`. Therefore for remove cast to json from type checking, and let server decide how to handle input values

Also this patch includes a side fix for a crash (see backtrace below). Fix was to check for a valid collation_id in qdata_aggregate_value_to_accumulator function only when needed
```
#0  qdata_aggregate_value_to_accumulator (thread_p=0x7ffff6659c18, acc=0x555556739868, domain=0x7fff0400a828, func_type=PT_JSON_ARRAYAGG, func_domain=0x7ffff7f1fa40 <tp_Json_domain>, value=0x7fff040090a0) at ./src/query/query_opfunc.c:6632
#1  0x00007ffff792ad57 in qdata_aggregate_multiple_values_to_accumulator (thread_p=0x7ffff6659c18, acc=0x555556739868, domain=0x7fff0400a828, func_type=PT_JSON_ARRAYAGG, func_domain=0x7ffff7f1fa40 <tp_Json_domain>, db_values=std::vector of length 1, capacity 1 = {...}) at ./src/query/query_opfunc.c:6841
#2  0x00007ffff792bc98 in qdata_evaluate_aggregate_list (thread_p=0x7ffff6659c18, agg_list_p=0x7fff0400a7b0, val_desc_p=0x7fff5ffc9c70, alt_acc_list=0x555556739868) at ./src/query/query_opfunc.c:7226
#3  0x00007ffff78e3d16 in qexec_hash_gby_agg_tuple (thread_p=0x7ffff6659c18, xasl=0x7fff04007900, xasl_state=0x7fff5ffc9c70, proc=0x7fff04007a50, tplrec=0x7fff5ffc9a70, tpldesc=0x7fff04007f88, groupby_list=0x7fff04007f30, output_tuple=0x7fff5ffc98cb) at ./src/query/query_executor.c:3774
#4  0x00007ffff78de822 in qexec_end_one_iteration (thread_p=0x7ffff6659c18, xasl=0x7fff04007900, xasl_state=0x7fff5ffc9c70, tplrec=0x7fff5ffc9a70) at ./src/query/query_executor.c:1194
#5  0x00007ffff78ee1b2 in qexec_intprt_fnc (thread_p=0x7ffff6659c18, xasl=0x7fff04007900, xasl_state=0x7fff5ffc9c70, tplrec=0x7fff5ffc9a70, next_scan_fnc=0x5555567396d0) at ./src/query/query_executor.c:7964
#6  0x00007ffff78fcaf9 in qexec_execute_mainblock_internal (thread_p=0x7ffff6659c18, xasl=0x7fff04007900, xasl_state=0x7fff5ffc9c70, p_class_instance_lock_info=0x0) at ./src/query/query_executor.c:14102
#7  0x00007ffff78fad98 in qexec_execute_mainblock (thread_p=0x7ffff6659c18, xasl=0x7fff04007900, xasl_state=0x7fff5ffc9c70, p_class_instance_lock_info=0x0) at ./src/query/query_executor.c:13379
#8  0x00007ffff78fdd9e in qexec_execute_query (thread_p=0x7ffff6659c18, xasl=0x7fff04007900, dbval_cnt=0, dbval_ptr=0x0, query_id=1) at ./src/query/query_executor.c:14652
#9  0x00007ffff791741b in qmgr_process_query (thread_p=0x7ffff6659c18, xasl_tree=0x7fff04007900, xasl_stream=0x0, xasl_stream_size=0, dbval_count=0, dbvals_p=0x0, flag=98304, query_p=0x7fff0400ae30, tran_entry_p=0x555556bfe0b8) at ./src/query/query_manager.c:1152
#10 0x00007ffff7917d4e in xqmgr_execute_query (thread_p=0x7ffff6659c18, xasl_id_p=0x7fff5ffca1d0, query_id_p=0x7fff5ffca0f0, dbval_count=0, dbval_p=0x0, flag_p=0x7fff5ffca0b4, client_cache_time_p=0x7fff5ffca170, server_cache_time_p=0x7fff5ffca178, query_timeout=0, ret_cache_entry_p=0x7fff5ffca100) at ./src/query/query_manager.c:1467
#11 0x00007ffff77b6aa9 in sqmgr_execute_query (thread_p=0x7ffff6659c18, rid=65570, request=0x7fff0c001b30 "\224u\215I\353\216H\352\235j\"Z;l\243\245\274\325Ie[\332\310u", reqlen=56) at ./src/communication/network_interface_sr.c:4939
#12 0x00007ffff77c3046 in net_server_request (thread_p=0x7ffff6659c18, rid=65570, request=93, size=56, buffer=0x7fff0c001b30 "\224u\215I\353\216H\352\235j\"Z;l\243\245\274\325Ie[\332\310u") at ./src/communication/network_sr.c:1033
#13 0x00007ffff782c0ba in css_internal_request_handler (thread_ref=..., conn_ref=...) at ./src/connection/server_support.c:1300
#14 0x00007ffff782e802 in css_server_task::execute (this=0x7fff0c001b70, thread_ref=...) at ./src/connection/server_support.c:2860
#15 0x00007ffff7831c36 in cubthread::worker_pool<cubthread::entry>::core::worker::execute_current_task (this=0x55555a886a60) at ./src/thread/thread_worker_pool.hpp:1287
#16 0x00007ffff78313e6 in cubthread::worker_pool<cubthread::entry>::core::worker::run (this=0x55555a886a60) at ./src/thread/thread_worker_pool.hpp:1399
#17 0x00007ffff7831eee in std::__invoke_impl<void, void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(), cubthread::worker_pool<cubthread::entry>::core::worker*> (__f=@0x55555a889fe0: (void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(cubthread::worker_pool<cubthread::entry>::core::worker * const)) 0x7ffff7831364 <cubthread::worker_pool<cubthread::entry>::core::worker::run()>, __t=@0x55555a889fd8: 0x55555a886a60) at /usr/include/c++/8.2.1/bits/invoke.h:73
#18 0x00007ffff783145d in std::__invoke<void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(), cubthread::worker_pool<cubthread::entry>::core::worker*> (__fn=@0x55555a889fe0: (void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(cubthread::worker_pool<cubthread::entry>::core::worker * const)) 0x7ffff7831364 <cubthread::worker_pool<cubthread::entry>::core::worker::run()>, __args#0=@0x55555a889fd8: 0x55555a886a60) at /usr/include/c++/8.2.1/bits/invoke.h:95
#19 0x00007ffff7833477 in std::thread::_Invoker<std::tuple<void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(), cubthread::worker_pool<cubthread::entry>::core::worker*> >::_M_invoke<0ul, 1ul> (this=0x55555a889fd8) at /usr/include/c++/8.2.1/thread:244
#20 0x00007ffff783341d in std::thread::_Invoker<std::tuple<void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(), cubthread::worker_pool<cubthread::entry>::core::worker*> >::operator() (this=0x55555a889fd8) at /usr/include/c++/8.2.1/thread:253
#21 0x00007ffff78333f2 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(), cubthread::worker_pool<cubthread::entry>::core::worker*> > >::_M_run (this=0x55555a889fd0) at /usr/include/c++/8.2.1/thread:196
#22 0x00007ffff7369063 in std::execute_native_thread_routine (__p=0x55555a889fd0) at /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:80
#23 0x00007ffff7448a9d in start_thread () from /usr/lib/libpthread.so.0
#24 0x00007ffff7043b23 in clone () from /usr/lib/libc.so.6
```