### PR TITLE
[CBRD-22476] fix btree_key_remove_object leaf record argument

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1779,6 +1779,8 @@ static inline void btree_delete_helper_to_insert_helper (BTREE_DELETE_HELPER * d
 							 BTREE_INSERT_HELPER * insert_helper);
 
 static inline bool btree_is_online_index_loading (BTREE_OP_PURPOSE purpose);
+static bool btree_is_single_object_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, BTREE_NODE_TYPE node_type,
+					RECDES * record, int offset_after_key);
 
 /*
  * btree_fix_root_with_info () - Fix b-tree root page and output its VPID, header and b-tree info if requested.
@@ -33533,8 +33535,7 @@ btree_key_online_index_IB_insert (THREAD_ENTRY * thread_p, BTID_INT * btid_int, 
 	      helper->delete_helper.op_type = SINGLE_ROW_DELETE;
 	      assert (helper->delete_helper.rv_keyval_data == NULL);	// otherwise, it will be leaked.
 
-	      if (node_type == BTREE_LEAF_NODE
-		  && (btree_record_get_num_oids (thread_p, btid_int, &new_record, offset_after_key, node_type) == 1))
+	      if (btree_is_single_object_key (thread_p, btid_int, node_type, &new_record, offset_after_key))
 		{
 		  /* Only one OID in the key, we will remove the key as well. */
 		  n_keys = -1;
@@ -33995,8 +33996,7 @@ btree_key_online_index_tran_delete (THREAD_ENTRY * thread_p, BTID_INT * btid_int
 	    {
 	      /* Normal state. We need to physically delete the object. */
 	      assert (btree_online_index_is_normal_state (btree_mvcc_info.insert_mvccid));
-	      if (node_type == BTREE_LEAF_NODE
-		  && (btree_record_get_num_oids (thread_p, btid_int, &new_record, offset_after_key, node_type) == 1))
+	      if (btree_is_single_object_key (thread_p, btid_int, node_type, &new_record, offset_after_key))
 		{
 		  /* Only one OID in the key, we will remove the key as well. */
 		  n_keys = -1;
@@ -34004,7 +34004,7 @@ btree_key_online_index_tran_delete (THREAD_ENTRY * thread_p, BTID_INT * btid_int
 	      n_oids = -1;
 
 	      error_code =
-		btree_key_remove_object (thread_p, key, btid_int, &helper->delete_helper, *leaf_page, &new_record,
+		btree_key_remove_object (thread_p, key, btid_int, &helper->delete_helper, *leaf_page, &record,
 					 &leaf_info, offset_after_key, search_key, &page_found, prev_page, node_type,
 					 offset_to_object);
 
@@ -34244,8 +34244,7 @@ btree_key_online_index_tran_insert_DF (THREAD_ENTRY * thread_p, BTID_INT * btid_
 	      helper->delete_helper.purpose = BTREE_OP_ONLINE_INDEX_TRAN_DELETE;
 	      helper->delete_helper.op_type = SINGLE_ROW_DELETE;
 
-	      if (node_type == BTREE_LEAF_NODE
-		  && (btree_record_get_num_oids (thread_p, btid_int, &new_record, offset_after_key, node_type) == 1))
+	      if (btree_is_single_object_key (thread_p, btid_int, node_type, &new_record, offset_after_key))
 		{
 		  /* Only one OID in the key, we will remove the key as well. */
 		  n_keys = -1;
@@ -35041,4 +35040,36 @@ btree_is_btid_online_index (THREAD_ENTRY * thread_p, OID * class_oid, BTID * bti
   heap_classrepr_free_and_init (rep, &idx_incache);
 
   return result;
+}
+
+//
+// btree_is_single_object_key () - returns true if there is only one object in key, false otherwise; parameters
+//                                 offer details on object location
+//
+// return                : true if single object
+// thread_p (in)         : thread entry
+// btid_int (in)         : b-tree info
+// node_type (in)        : node type - overflow or leaf
+// record (in)           : current record (overflow or leaf)
+// offset_after_key (in) : offset after key (only for leaf)
+//
+static bool
+btree_is_single_object_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, BTREE_NODE_TYPE node_type,
+			    RECDES * record, int offset_after_key)
+{
+  if (node_type == BTREE_OVERFLOW_NODE)
+    {
+      // has overflows, must have at least two
+      return false;
+    }
+  // leaf
+  assert (node_type == BTREE_LEAF_NODE);
+  if (offset_after_key > record->length)
+    {
+      // it has more than one object!
+      // this is a hack to avoid counting objects; maybe it is not safe
+      return false;
+    }
+  assert (offset_after_key == record->length);
+  return true;
 }

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -35088,7 +35088,7 @@ btree_is_single_object_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, BTREE_
     }
   // leaf
   assert (node_type == BTREE_LEAF_NODE);
-  if (offset_after_key > record->length)
+  if (offset_after_key < record->length)
     {
       // it has more than one object!
       // this is a hack to avoid counting objects; maybe it is not safe

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -32973,10 +32973,19 @@ btree_insert_sysop_end (THREAD_ENTRY * thread_p, BTREE_INSERT_HELPER * helper)
   switch (helper->purpose)
     {
     case BTREE_OP_INSERT_NEW_OBJECT:
-    case BTREE_OP_ONLINE_INDEX_TRAN_INSERT:
-    case BTREE_OP_ONLINE_INDEX_TRAN_INSERT_DF:
+      assert (helper->rcvindex != RV_NOT_DEFINED);
       log_sysop_end_logical_undo (thread_p, helper->rcvindex, helper->leaf_addr.vfid, helper->rv_keyval_data_length,
 				  helper->rv_keyval_data);
+      break;
+
+    case BTREE_OP_ONLINE_INDEX_TRAN_INSERT_DF:
+      log_sysop_end_logical_undo (thread_p, RVBT_ONLINE_INDEX_UNDO_TRAN_DELETE, helper->leaf_addr.vfid,
+				  helper->rv_keyval_data_length, helper->rv_keyval_data);
+      break;
+
+    case BTREE_OP_ONLINE_INDEX_TRAN_INSERT:
+      log_sysop_end_logical_undo (thread_p, RVBT_ONLINE_INDEX_UNDO_TRAN_INSERT, helper->leaf_addr.vfid,
+				  helper->rv_keyval_data_length, helper->rv_keyval_data);
       break;
 
     case BTREE_OP_INSERT_UNDO_PHYSICAL_DELETE:

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -4009,6 +4009,8 @@ log_sysop_end_logical_undo (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, cons
 {
   LOG_REC_SYSOP_END log_record;
 
+  assert (rcvindex != RV_NOT_DEFINED);
+
   if (LOG_IS_MVCC_OPERATION (rcvindex))
     {
       log_record.type = LOG_SYSOP_END_LOGICAL_MVCC_UNDO;
@@ -7702,13 +7704,8 @@ log_rollback_record (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_PAGE * log_
    * compensating records are logged.
    */
 
-#if defined(CUBRID_DEBUG)
-  if (RV_fun[rcvindex].undofun == NULL)
-    {
-      assert (false);
-      return;
-    }
-#endif /* CUBRID_DEBUG */
+  assert (rcvindex != RV_NOT_DEFINED);
+  assert (RV_fun[rcvindex].undofun != NULL);
 
   if (RCV_IS_LOGICAL_LOG (rcv_vpid, rcvindex))
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22476

Overflow record was passed instead of leaf record argument to `btree_key_remove_object`.