### PR TITLE
[CBRD-22494] fix JSON_ARRAYAGG function when aggregating only NULL values

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -18478,6 +18478,14 @@ qexec_resolve_domains_for_aggregation (THREAD_ENTRY * thread_p, AGGREGATE_TYPE *
 	  continue;
 	}
 
+      if (agg_p->function == PT_JSON_ARRAYAGG || agg_p->function == PT_JSON_OBJECTAGG)
+	{
+	  /* PT_JSON_ARRAYAGG and PT_JSON_OBJECTAGG always have the same signature */
+	  agg_p->accumulator_domain.value_dom = &tp_Json_domain;
+	  agg_p->accumulator_domain.value2_dom = &tp_Null_domain;
+	  continue;
+	}
+
       /* fetch function operand */
       if (fetch_peek_dbval (thread_p, &agg_p->operands->value, &xasl_state->vd, NULL, NULL, NULL, &dbval) != NO_ERROR)
 	{
@@ -18528,8 +18536,6 @@ qexec_resolve_domains_for_aggregation (THREAD_ENTRY * thread_p, AGGREGATE_TYPE *
 	    case PT_AGG_BIT_XOR:
 	    case PT_MIN:
 	    case PT_MAX:
-	    case PT_JSON_ARRAYAGG:
-	    case PT_JSON_OBJECTAGG:
 	      agg_p->accumulator_domain.value_dom = agg_p->domain;
 	      agg_p->accumulator_domain.value2_dom = &tp_Null_domain;
 	      break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22494

Fix `JSON_ARRAYAGG` function when aggregating only NULL values
```sql
drop table if exists t1;
create table t1 (id int , col varchar(10));
insert into t1 values (2, NULL), (2, NULL);
select id, JSON_ARRAYAGG(col) from t1 group by id;
```
Expected result of the select statement is:
```sql
           id  json_arrayagg(col)
===================================
            2  [null, null]
```