### PR TITLE
[CBRD-22461] stx_restore: alloc struct, then mark as visited

### DIFF
--- a/src/xasl/xasl_stream.hpp
+++ b/src/xasl/xasl_stream.hpp
@@ -177,18 +177,17 @@ stx_restore (THREAD_ENTRY *thread_p, char *&ptr, T *&target)
 	{
 	  return;
 	}
-      if (stx_mark_struct_visited (thread_p, bufptr, target) != NO_ERROR)
-	{
-	  assert (false);
-	  return;
-	}
       target = (T *) stx_alloc_struct (thread_p, (int) sizeof (T));
       if (target == NULL)
 	{
 	  assert (false);
 	  return;
 	}
-
+      if (stx_mark_struct_visited (thread_p, bufptr, target) != NO_ERROR)
+	{
+	  assert (false);
+	  return;
+	}
       if (stx_build (thread_p, bufptr, *target) == NULL)
 	{
 	  assert (false);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22461

The issue is caused by bug in stx_restore. Pointer was marked as visited before allocating, while its value was NULL.

New function is mostly used for json table structures, which are usually right-most scans in query execution. Which hid the bug, because pointers were usually correctly marked as visited by other structures.

For the count query in the issue, column output value pointer is first to pack/unpack. Since it was not properly marked as visited, another pointer was generated for inner heap scan. When inner heap scan predicate was checked, the value read from json table scan was missing.

Fixed stx_restore operation order.