### PR TITLE
[CBRD-22509] propagate network error on btree_load_index

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -5593,7 +5593,7 @@ btree_load_index (BTID * btid, const char *bt_name, TP_DOMAIN * key_type, OID * 
   int index_info_size = 0;
   char *stream = NULL;
   int stream_size = 0;
-  LOCK curr_cls_lock;
+  LOCK curr_cls_lock = SCH_M_LOCK;
 
   reply = OR_ALIGNED_BUF_START (a_reply);
 
@@ -5701,7 +5701,7 @@ btree_load_index (BTID * btid, const char *bt_name, TP_DOMAIN * key_type, OID * 
     net_client_request (NET_SERVER_BTREE_LOADINDEX, request, request_size, reply, OR_ALIGNED_BUF_SIZE (a_reply),
 			stream, stream_size, NULL, 0);
 
-  if (!req_error)
+  if (req_error == NO_ERROR)
     {
       int t;
 
@@ -5719,6 +5719,7 @@ btree_load_index (BTID * btid, const char *bt_name, TP_DOMAIN * key_type, OID * 
   else
     {
       btid = NULL;
+      error = req_error;
     }
 
   if (index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS && curr_cls_lock != SCH_M_LOCK)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22509

btree_load_index returns NO_ERROR when net_client_request call fails. Fix by propagating network error.