### PR TITLE
[CBRD-22485] incorrect escape characters passed validation

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -834,7 +834,11 @@ int JSON_SEARCHER::CallAfter (JSON_VALUE &value)
 	}
 
       int match;
-      db_string_like (&str_val, m_pattern, m_esc_char, &match);
+      error_code = db_string_like (&str_val, m_pattern, m_esc_char, &match);
+      if (error_code != NO_ERROR)
+	{
+	  return error_code;
+	}
 
       if (match)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22485

Fix slip of not checking db_string_like returned error_code