### PR TITLE
[CBRD-22528] json_table leaked error not checked

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -10014,6 +10014,10 @@ pt_semantic_check_local (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int
       break;
 
     case PT_JSON_TABLE:
+      if (pt_has_error (parser))
+	{
+	  break;
+	}
       if (node->info.json_table_info.expr->type_enum != PT_TYPE_JSON
 	  && node->info.json_table_info.expr->type_enum != PT_TYPE_CHAR
 	  && node->info.json_table_info.expr->type_enum != PT_TYPE_MAYBE)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22528

Coercion error is not checked and json_table's expr is removed.