### PR TITLE
[CBRD-22513] JSON_TABLE core dump in pt_semantic_check_local

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -3619,6 +3619,16 @@ pt_find_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
 	    }
 	  name->info.name.spec_id = spec->info.spec.id;
 	  name->info.name.meta_class = PT_NORMAL;
+
+	  if (spec->info.spec.derived_table_type == PT_DERIVED_JSON_TABLE)
+	    {
+	      // calling default() on any json_table's columns should return NULL
+	      // set PT_NAME_REAL_TABLE flag to pass check_defaultf() 
+	      DB_VALUE val;
+	      db_make_null (&val);
+	      name->info.name.default_value = pt_dbval_to_value (parser, &val);
+	      PT_NAME_INFO_SET_FLAG (name, PT_NAME_REAL_TABLE);
+	    }
 	}
     }
 

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -3623,7 +3623,7 @@ pt_find_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
 	  if (spec->info.spec.derived_table_type == PT_DERIVED_JSON_TABLE)
 	    {
 	      // calling default() on any json_table's columns should return NULL
-	      // set PT_NAME_REAL_TABLE flag to pass check_defaultf() 
+	      // set PT_NAME_REAL_TABLE flag to pass pt_check_defaultf() 
 	      DB_VALUE val;
 	      db_make_null (&val);
 	      name->info.name.default_value = pt_dbval_to_value (parser, &val);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22513

Default() function called on json_table's columns that should return NULL.
Fix pt_node names of colums that reference json_table to have a null db_value as default_value