### PR TITLE
[CBRD-22513] JSON_TABLE core dump in pt_semantic_check_local

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -3623,11 +3623,11 @@ pt_find_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
 	  if (spec->info.spec.derived_table_type == PT_DERIVED_JSON_TABLE)
 	    {
 	      // calling default() on any json_table's columns should return NULL
-	      // set PT_NAME_REAL_TABLE flag to pass pt_check_defaultf() 
+	      // set PT_NAME_DEFAULTF_ACCEPTS flag to pass pt_check_defaultf()
 	      DB_VALUE val;
 	      db_make_null (&val);
 	      name->info.name.default_value = pt_dbval_to_value (parser, &val);
-	      PT_NAME_INFO_SET_FLAG (name, PT_NAME_REAL_TABLE);
+	      PT_NAME_INFO_SET_FLAG (name, PT_NAME_DEFAULTF_ACCEPTS);
 	    }
 	}
     }
@@ -4662,7 +4662,7 @@ pt_resolve_correlation (PARSER_CONTEXT * parser, PT_NODE * in_node, PT_NODE * sc
       corr_name->info.name.resolved = exposed_spec->info.spec.range_var->info.name.original;
       if (PT_IS_SPEC_REAL_TABLE (exposed_spec))
 	{
-	  PT_NAME_INFO_SET_FLAG (corr_name, PT_NAME_REAL_TABLE);
+	  PT_NAME_INFO_SET_FLAG (corr_name, PT_NAME_DEFAULTF_ACCEPTS);
 	}
 
       /* attach the data type */
@@ -4844,7 +4844,7 @@ pt_get_resolution (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg, PT_NOD
 
 	  if (PT_IS_SPEC_REAL_TABLE (savespec))
 	    {
-	      PT_NAME_INFO_SET_FLAG (in_node, PT_NAME_REAL_TABLE);
+	      PT_NAME_INFO_SET_FLAG (in_node, PT_NAME_DEFAULTF_ACCEPTS);
 	    }
 
 	  savespec = pt_unwhacked_spec (parser, scope, savespec);
@@ -4915,7 +4915,7 @@ pt_get_resolution (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg, PT_NOD
 	      in_node->info.name.meta_class = PT_META_CLASS;
 	      in_node->info.name.spec_id = class_spec->info.spec.id;
 	      in_node->info.name.resolved = class_spec->info.spec.range_var->info.name.original;
-	      PT_NAME_INFO_SET_FLAG (in_node, PT_NAME_REAL_TABLE);
+	      PT_NAME_INFO_SET_FLAG (in_node, PT_NAME_DEFAULTF_ACCEPTS);
 	      /* attach the data type */
 	      in_node->type_enum = PT_TYPE_OBJECT;
 	      if (class_spec->info.spec.flat_entity_list)
@@ -5035,9 +5035,9 @@ pt_get_resolution (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg, PT_NOD
 	    {
 	      /* only mark it resolved if it was found! transfer the info from arg1 to arg2 */
 	      arg2->info.name.resolved = arg1->info.name.resolved;
-	      if (PT_NAME_INFO_IS_FLAGED (arg1, PT_NAME_REAL_TABLE))
+	      if (PT_NAME_INFO_IS_FLAGED (arg1, PT_NAME_DEFAULTF_ACCEPTS))
 		{
-		  PT_NAME_INFO_SET_FLAG (arg2, PT_NAME_REAL_TABLE);
+		  PT_NAME_INFO_SET_FLAG (arg2, PT_NAME_DEFAULTF_ACCEPTS);
 		}
 	      /* don't loose list */
 	      arg2->next = in_node->next;
@@ -5092,9 +5092,9 @@ pt_get_resolution (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg, PT_NOD
 
 	      /* A meta class attribute, transfer the class info from arg1 to arg2 */
 	      arg2->info.name.resolved = arg1->info.name.resolved;
-	      if (PT_NAME_INFO_IS_FLAGED (arg1, PT_NAME_REAL_TABLE))
+	      if (PT_NAME_INFO_IS_FLAGED (arg1, PT_NAME_DEFAULTF_ACCEPTS))
 		{
-		  PT_NAME_INFO_SET_FLAG (arg2, PT_NAME_REAL_TABLE);
+		  PT_NAME_INFO_SET_FLAG (arg2, PT_NAME_DEFAULTF_ACCEPTS);
 		}
 	      /* don't lose list */
 	      arg2->next = in_node->next;
@@ -6179,7 +6179,7 @@ pt_must_have_exposed_name (PARSER_CONTEXT * parser, PT_NODE * p)
 	      q->info.name.resolved = p->info.spec.range_var->info.name.original;
 	      if (PT_IS_SPEC_REAL_TABLE (p))
 		{
-		  PT_NAME_INFO_SET_FLAG (q, PT_NAME_REAL_TABLE);
+		  PT_NAME_INFO_SET_FLAG (q, PT_NAME_DEFAULTF_ACCEPTS);
 		}
 	      q = q->next;
 	    }
@@ -7531,7 +7531,7 @@ pt_create_pt_name (PARSER_CONTEXT * parser, PT_NODE * spec, NATURAL_JOIN_ATTR_IN
 
   if (PT_IS_SPEC_REAL_TABLE (spec))
     {
-      PT_NAME_INFO_SET_FLAG (name, PT_NAME_REAL_TABLE);
+      PT_NAME_INFO_SET_FLAG (name, PT_NAME_DEFAULTF_ACCEPTS);
     }
 
   name->info.name.spec_id = spec->info.spec.id;
@@ -9153,7 +9153,7 @@ pt_make_flat_list_from_data_types (PARSER_CONTEXT * parser, PT_NODE * res_list, 
       node->info.name.resolved = entity->info.spec.entity_name->info.name.original;
       if (PT_IS_SPEC_REAL_TABLE (entity))
 	{
-	  PT_NAME_INFO_SET_FLAG (node, PT_NAME_REAL_TABLE);
+	  PT_NAME_INFO_SET_FLAG (node, PT_NAME_DEFAULTF_ACCEPTS);
 	}
       node->info.name.meta_class = PT_CLASS;
     }

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -3619,6 +3619,16 @@ pt_find_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
 	    }
 	  name->info.name.spec_id = spec->info.spec.id;
 	  name->info.name.meta_class = PT_NORMAL;
+
+	  if (spec->info.spec.derived_table_type == PT_DERIVED_JSON_TABLE)
+	    {
+	      // calling default() on any json_table's columns should return NULL
+	      // set PT_NAME_REAL_TABLE flag to pass check_defaultf() 
+	      DB_VALUE val;
+	      db_make_null (&val);
+	      name->info.name.default_value = pt_dbval_to_value (parser, &val);
+	      PT_NAME_INFO_SET_FLAG (name, PT_NAME_REAL_TABLE);
+	    }
 	}
     }
 

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -3623,7 +3623,7 @@ pt_find_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
 	  if (spec->info.spec.derived_table_type == PT_DERIVED_JSON_TABLE)
 	    {
 	      // calling default() on any json_table's columns should return NULL
-	      // set PT_NAME_REAL_TABLE flag to pass check_defaultf() 
+	      // set PT_NAME_REAL_TABLE flag to pass pt_check_defaultf() 
 	      DB_VALUE val;
 	      db_make_null (&val);
 	      name->info.name.default_value = pt_dbval_to_value (parser, &val);

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2597,7 +2597,7 @@ struct pt_name_info
 #define PT_NAME_ALLOW_REUSABLE_OID 512	/* ignore the REUSABLE_OID restrictions for this name */
 #define PT_NAME_GENERATED_DERIVED_SPEC 1024	/* attribute generated from derived spec */
 #define PT_NAME_FOR_UPDATE	   2048	/* Table name in FOR UPDATE clause */
-#define PT_NAME_REAL_TABLE	   4096	/* name of table/column belongs to a real table */
+#define PT_NAME_DEFAULTF_ACCEPTS   4096	/* name of table/column that default function accepts: real table's, cte's */
 
   short flag;
 #define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (short) (f))

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -1461,7 +1461,7 @@ pt_get_attributes (PARSER_CONTEXT * parser, const DB_OBJECT * c)
       /* its name is class_name.attribute_name */
       i_attr->info.attr_def.attr_name = name = pt_name (parser, db_attribute_name (attributes));
       name->info.name.resolved = pt_append_string (parser, NULL, class_name);
-      PT_NAME_INFO_SET_FLAG (name, PT_NAME_REAL_TABLE);
+      PT_NAME_INFO_SET_FLAG (name, PT_NAME_DEFAULTF_ACCEPTS);
       name->info.name.meta_class = (db_attribute_is_shared (attributes) ? PT_SHARED : PT_NORMAL);
 
       /* set its data type */
@@ -13580,7 +13580,7 @@ pt_check_defaultf (PARSER_CONTEXT * parser, PT_NODE * node)
 
   /* OIDs don't have default value */
   if (arg == NULL || arg->node_type != PT_NAME || arg->info.name.meta_class == PT_OID_ATTR
-      || !PT_NAME_INFO_IS_FLAGED (arg, PT_NAME_REAL_TABLE))
+      || !PT_NAME_INFO_IS_FLAGED (arg, PT_NAME_DEFAULTF_ACCEPTS))
     {
       PT_ERRORm (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_DEFAULT_JUST_COLUMN_NAME);
       return ER_FAILED;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22513

Default() function called on json_table's columns that should return NULL.
Fix pt_node names of colums that reference json_table to have a null db_value as default_value