### PR TITLE
[CBRD-22511] JSON_TABLE crashes if expression is empty

### DIFF
--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -284,8 +284,6 @@ namespace cubscan
       int error_code = NO_ERROR;
       const JSON_DOC *document = NULL;
 
-      // so... we need to generate the whole list file
-
       // we need the starting value to expand into a list of records
       DB_VALUE *value_p = NULL;
       error_code = fetch_peek_dbval (thread_p, m_specp->m_json_reguvar, m_vd, NULL, NULL, NULL, &value_p);
@@ -294,10 +292,16 @@ namespace cubscan
 	  ASSERT_ERROR ();
 	  return error_code;
 	}
-      if (value_p == NULL || db_value_is_null (value_p))
+      if (value_p == NULL)
 	{
 	  assert (false);
 	  return ER_FAILED;
+	}
+
+      if (db_value_is_null (value_p))
+	{
+	  // input is empty
+	  return NO_ERROR;
 	}
 
       // build m_scan_cursor

--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -300,7 +300,7 @@ namespace cubscan
 
       if (db_value_is_null (value_p))
 	{
-	  // input is empty
+	  assert (m_scan_cursor[0].m_is_node_consumed);
 	  return NO_ERROR;
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22511

Remove assert in case json_table scan's input is empty to enable using an empty table's column as json expression argument.