### PR TITLE
[CBRD-22510] JSON_TABLE fix final clear

### DIFF
--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -266,7 +266,9 @@ namespace cubscan
 	      cursor.delete_input_doc ();
 
 	      cursor.m_child = 0;
+	      cursor.m_need_advance_row = false;
 	      cursor.m_is_row_fetched = false;
+	      cursor.m_row_was_expanded = false;
 	    }
 
 	  m_specp->m_root_node->clear_iterators (is_final_clear);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22510

Reset json_table cursor's m_need_advance_row and m_row_was_expanded members to defaults during final clear.