### PR TITLE
[CBRD-22525] fix nested json tables

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -24434,14 +24434,12 @@ json_table_node_rule
     ;
 
 json_table_rule
-    : {{
-	    json_table_column_count = 0;
-      DBG_PRINT}} 
-	'(' expression_ ',' json_table_node_rule ')'
+    : '(' expression_ ',' json_table_node_rule ')'
       {{
         PT_NODE *jt = parser_new_node (this_parser, PT_JSON_TABLE);
-        jt->info.json_table_info.expr = $3;
-        jt->info.json_table_info.tree = $5;
+        jt->info.json_table_info.expr = $2;
+        jt->info.json_table_info.tree = $4;
+        json_table_column_count = 0;  // reset
 
         $$ = jt;
       DBG_PRINT}}

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -9937,7 +9937,7 @@ pt_get_attr_list_of_derived_table (PARSER_CONTEXT * parser, PT_MISC_TYPE derived
     case PT_DERIVED_JSON_TABLE:
       assert (derived_table->node_type == PT_JSON_TABLE);
 
-      as_attr_list = pt_get_all_json_table_attributes_and_types (parser, derived_table,
+      as_attr_list = pt_get_all_json_table_attributes_and_types (parser, derived_table->info.json_table_info.tree,
 								 derived_alias->info.name.original);
       break;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22525

1. Reset column index count in grammar after building a json table.

    - Initializing before does not help (the order of code execution is before_1, before_2, json_table_2, after_2, json_table_1, after_1)

2. Building json table attribute list should not walk expression.