### PR TITLE
[CBRD-22530] fix click counter functions over partitions

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -12318,6 +12318,7 @@ qexec_execute_selupd_list_find_class (THREAD_ENTRY * thread_p, XASL_NODE * xasl,
     {
       *class_oid = selupd->class_oid;
       class_hfid = &selupd->class_hfid;
+      *found = true;
       return NO_ERROR;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22530

The issue was that when executing select update the lookup for class oid/hfid was done only at `xasl->spec_list` level and `xasl->scan_ptr` was excluded.

instead of:
```cpp
for (specp = xasl->spec_list; specp; specp = specp->next)
  {
    // search for class oid/hfid
  }
```
should be:
```cpp
for (scan_ptr = xasl; scan_ptr; scan_ptr = scan_ptr->scan_ptr)
  {
    for (specp = scan_ptr->spec_list; specp; specp = specp->next)
      {
        // search for class oid/hfid
      }
  }
```