### PR TITLE
[CBRD-22484] backup failed with any other backup

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -8635,6 +8635,20 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
   time_t tmp_time;
   char time_val[CTIME_MAX];
 
+#if defined (SERVER_MODE)
+  // check whether there is ongoing backup.
+  LOG_CS_ENTER (thread_p);
+  if (log_Gl.backup_in_progress == true)
+    {
+      LOG_CS_EXIT (thread_p);
+      error_code = ER_LOG_BKUP_DUPLICATE_REQUESTS;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
+      return error_code;
+    }
+
+  log_Gl.backup_in_progress = true;
+  LOG_CS_EXIT (thread_p);
+#endif /* SERVER_MODE */
 
   memset (&session, 0, sizeof (FILEIO_BACKUP_SESSION));
 
@@ -8664,27 +8678,20 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
 
   /* 
    * Determine the first log archive that will be needed to insure
-   * consistency if we are forced to restore the database with nothing
-   * but this backup.
+   * consistency if we are forced to restore the database with nothing but this backup.
    * first_arv_needed may need to be based on what archive chkpt_lsa is in.
    */
-  LOG_CS_ENTER (thread_p);
-#if defined(SERVER_MODE)
-  if (log_Gl.backup_in_progress == true)
-    {
-      LOG_CS_EXIT (thread_p);
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_BKUP_DUPLICATE_REQUESTS, 0);
-      error_code = ER_LOG_BKUP_DUPLICATE_REQUESTS;
-      goto error;
-    }
 
-  log_Gl.backup_in_progress = true;
-  LOG_CS_EXIT (thread_p);
-
+#if defined (SERVER_MODE)
   print_backupdb_waiting_reason = false;
   wait_checkpoint_begin_time = time (NULL);
 loop:
+#endif /* SERVER_MODE */
+
+  // actually, it is not really necessary for SA but just for code consistency.
   LOG_CS_ENTER (thread_p);
+
+#if defined (SERVER_MODE)
   /* check if checkpoint is in progress */
   if (log_Gl.run_nxchkpt_atpageid == NULL_PAGEID)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22484

It is a legacy issue. 
To exit redundant backup request cleared some globals and the existing backup might be dead ended.
The fix is to early out the extra backup request without initializing backup session (globals).