### PR TITLE
[CBRD-22553] Accept enum for JSON value

### DIFF
--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 Fehler bei CTE '%1$s': Der nicht rekursive Teil und der rekursive Teil müssen mit UNION ALL verbunden sein.
 300 Unterabfrage ist in der DEFAULT-Klausel nicht erlaubt.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 Unterabfrage ist in der DEFAULT-Klausel nicht erlaubt.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 Error in CTE '%1$s': The non-recursive part and the recursive part must be connected with UNION ALL.
 300 Subquery is not allowed in DEFAULT clause.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 Subquery is not allowed in DEFAULT clause.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/en_US/cubrid.msg
+++ b/msg/en_US/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 Error in CTE '%1$s': The non-recursive part and the recursive part must be connected with UNION ALL.
 300 Subquery is not allowed in DEFAULT clause.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/en_US/cubrid.msg
+++ b/msg/en_US/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 Subquery is not allowed in DEFAULT clause.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 La subconsulta no está permitida en la cláusula DEFAULT.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 Error en CTE '%1$s': La parte no recursiva y la parte recursiva deben estar conectadas con UNION ALL.
 300 La subconsulta no está permitida en la cláusula DEFAULT.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 La sous-requête n'est pas autorisée dans la clause DEFAULT.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 Erreur dans CTE '%1$s': la partie non récursive et la partie récursive doivent être connectées avec UNION ALL.
 300 La sous-requête n'est pas autorisée dans la clause DEFAULT.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 La sottoquery non è consentita nella clausola DEFAULT.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 Errore nel CTE '%1$s': la parte non ricorsiva e la parte ricorsiva devono essere collegati con UNION ALL.
 300 La sottoquery non è consentita nella clausola DEFAULT.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 Error in CTE '%1$s': The non-recursive part and the recursive part must be connected with UNION ALL.
 300 Subquery is not allowed in DEFAULT clause.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 Subquery is not allowed in DEFAULT clause.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 Error in CTE '%1$s': The non-recursive part and the recursive part must be connected with UNION ALL.
 300 Subquery is not allowed in DEFAULT clause.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 Subquery is not allowed in DEFAULT clause.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/ko_KR.euckr/cubrid.msg
+++ b/msg/ko_KR.euckr/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 DEFAULT 절에 부질의는 허용되지 않습니다.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/ko_KR.euckr/cubrid.msg
+++ b/msg/ko_KR.euckr/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 CTE '%1$s’의 에러: 비재귀 부분과 재귀 부분은 반드시 UNION ALL로 연결되어야 합니다.
 300 DEFAULT 절에 부질의는 허용되지 않습니다.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 DEFAULT 절에 부질의는 허용되지 않습니다.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 CTE '%1$s’의 에러: 비재귀 부분과 재귀 부분은 반드시 UNION ALL로 연결되어야 합니다.
 300 DEFAULT 절에 부질의는 허용되지 않습니다.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/ro_RO.utf8/cubrid.msg
+++ b/msg/ro_RO.utf8/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 Eroare în CTE '%1$s': Partea nerecursivă și partea recursivă trebuie conectate cu UNION ALL.
 300 Nu este permisă o subinterogare în clauza DEFAULT.
 301 Nu s-au gasit semnaturi pentru functia %1$s()
-302 Tip argument incompatibil %1$s; tip(uri) asteptate: %2$s
-303 Numar invalid de argumente
+302 Tip argument incompatibil %1$s, tipul asteptat: %2$s. Semnatura invalida %3$s.
+303 %1$d numar invalid de argumente. Semnatura invalida %2$s.
 304 Nu s-a gasit semnatura compatibila pentru functia %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 CTE '%1$s' hatası: yinelemesiz bölüm ve özyinelemeli bölüm UNION ALL ile bağlanmalıdır.
 300 DEFAULT yan tümcesi içinde alt sorguya izin verilmez.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 DEFAULT yan tümcesi içinde alt sorguya izin verilmez.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1769,8 +1769,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 Error in CTE '%1$s': The non-recursive part and the recursive part must be connected with UNION ALL.
 300 Subquery is not allowed in DEFAULT clause.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1770,7 +1770,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 Subquery is not allowed in DEFAULT clause.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/zh_CN.utf8/cubrid.msg
+++ b/msg/zh_CN.utf8/cubrid.msg
@@ -1771,7 +1771,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 300 DEFAULT子句中不允许使用子查询.
 301 Could not find signatures for function %1$s()
 302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
-303 Unexpected number of arguments %1$d. Invalid signature %1$s.
+303 Unexpected number of arguments %1$d. Invalid signature %2$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/msg/zh_CN.utf8/cubrid.msg
+++ b/msg/zh_CN.utf8/cubrid.msg
@@ -1770,8 +1770,8 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 299 CTE'%1$s'错误: 非递归部分和递归部分必须使用UNION ALL连接.
 300 DEFAULT子句中不允许使用子查询.
 301 Could not find signatures for function %1$s()
-302 Incompatible argument type %1$s; expected types are: %2$s
-303 Number of arguments don't match
+302 Incompatible argument type %1$s, expected type is: %2$s. Invalid signature %3$s.
+303 Unexpected number of arguments %1$d. Invalid signature %1$s.
 304 Could not find compatible signature for function %1$s()
 
 $set 9 MSGCAT_SET_PARSER_RUNTIME

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -3676,6 +3676,15 @@ db_value_to_json_value (const DB_VALUE &db_val, REFPTR (JSON_DOC, json_val))
       db_json_set_string_to_doc (json_val, db_get_string (&db_val));
       break;
 
+    case DB_TYPE_ENUMERATION:
+      json_val = db_json_allocate_doc ();
+      {
+	std::string enum_str;
+	enum_str.append (db_get_enum_string (&db_val), (size_t) db_get_enum_string_size (&db_val));
+	db_json_set_string_to_doc (json_val, enum_str.c_str ());
+      }
+      break;
+
     default:
       DB_VALUE dest;
       TP_DOMAIN_STATUS status = tp_value_cast (&db_val, &dest, &tp_Json_domain, false);

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -5049,6 +5049,7 @@ db_is_json_value_type (DB_TYPE type)
     case DB_TYPE_JSON:
     case DB_TYPE_NUMERIC:
     case DB_TYPE_BIGINT:
+    case DB_TYPE_ENUMERATION:
       return true;
     default:
       return false;

--- a/src/parser/func_type.cpp
+++ b/src/parser/func_type.cpp
@@ -713,7 +713,7 @@ Func::Node::cast (parser_node *prev, parser_node *arg, pt_type_enum type, int p,
 }
 
 bool
-Func::Node::preprocess()
+Func::Node::preprocess ()
 {
   auto arg_list = m_node->info.function.arg_list;
   switch (m_node->info.function.function_type)
@@ -771,23 +771,23 @@ Func::Node::get_types (const std::vector<func_signature> &signatures, size_t ind
   for (auto &signature: signatures)
     {
       auto i = index;
-      if (index < signature.fix.size())
+      if (index < signature.fix.size ())
 	{
 	  pt_arg_type_to_string_buffer (signature.fix[i], sb);
 	  sb (", ");
 	}
       else
 	{
-	  i -= signature.fix.size();
-	  if (signature.rep.size() > 0)
+	  i -= signature.fix.size ();
+	  if (signature.rep.size () > 0)
 	    {
-	      i %= signature.rep.size();
+	      i %= signature.rep.size ();
 	      pt_arg_type_to_string_buffer (signature.rep[i], sb);
 	      sb (", ");
 	    }
 	}
     }
-  return sb.get_buffer();
+  return sb.get_buffer ();
 }
 
 const func_signature *
@@ -844,7 +844,7 @@ Func::Node::get_signature (const std::vector<func_signature> &signatures)
 	{
 	  continue;
 	}
-      if ((arg != NULL && sig.rep.size() == 0) || (arg == NULL && sig.rep.size() != 0))
+      if ((arg != NULL && sig.rep.size () == 0) || (arg == NULL && sig.rep.size () != 0))
 	{
 	  // number of arguments don't match
 	  invalid_arg_count_error (arg_count, sig);
@@ -853,7 +853,7 @@ Func::Node::get_signature (const std::vector<func_signature> &signatures)
 
       //check repetitive args
       int index = 0;
-      for (; arg; arg = arg->next, index = (index + 1) % sig.rep.size())
+      for (; arg; arg = arg->next, index = (index + 1) % sig.rep.size ())
 	{
 	  auto &rep = sig.rep[index];
 	  auto t = ((rep.type == pt_arg_type::INDEX) ? sig.rep[rep.val.index] : rep);
@@ -1002,7 +1002,7 @@ Func::Node::apply_signature (const func_signature &signature)
       arg = arg->next;
     }
 
-  if (arg != NULL && signature.rep.size() == 0)
+  if (arg != NULL && signature.rep.size () == 0)
     {
       assert (false);
       return false;
@@ -1010,7 +1010,7 @@ Func::Node::apply_signature (const func_signature &signature)
 
   //check repetitive part of the function signature
   int index = 0;
-  for (; arg != NULL; prev = arg, arg = arg->next, index = (index + 1) % signature.rep.size(), ++arg_pos)
+  for (; arg != NULL; prev = arg, arg = arg->next, index = (index + 1) % signature.rep.size (), ++arg_pos)
     {
       if (m_compat.m_args_compat[arg_pos].m_compat == type_compatibility::EQUIVALENT)
 	{

--- a/src/parser/func_type.cpp
+++ b/src/parser/func_type.cpp
@@ -813,7 +813,7 @@ Func::Node::get_signature (const std::vector<func_signature> &signatures)
       bool matchCastable = true;
       size_t argIndex = 0;
 
-      m_compat.m_singature_compat = type_compatibility::EQUIVALENT;
+      m_compat.m_signature_compat = type_compatibility::EQUIVALENT;
 
       //check fix part of the signature
       for (auto &fix: sig.fix)
@@ -828,19 +828,19 @@ Func::Node::get_signature (const std::vector<func_signature> &signatures)
 	  if (args_compat[argIndex].m_compat == type_compatibility::INCOMPATIBLE)
 	    {
 	      invalid_arg_error (t, arg, sig);
-	      m_compat.m_singature_compat = type_compatibility::INCOMPATIBLE;
+	      m_compat.m_signature_compat = type_compatibility::INCOMPATIBLE;
 	      break;
 	    }
 	  else if (args_compat[argIndex].m_compat == type_compatibility::COERCIBLE)
 	    {
 	      // demote signature to coercible
-	      m_compat.m_singature_compat = type_compatibility::COERCIBLE;
+	      m_compat.m_signature_compat = type_compatibility::COERCIBLE;
 	    }
 
 	  ++argIndex;
 	  arg = arg->next;
 	}
-      if (m_compat.m_singature_compat == type_compatibility::INCOMPATIBLE)
+      if (m_compat.m_signature_compat == type_compatibility::INCOMPATIBLE)
 	{
 	  continue;
 	}
@@ -862,24 +862,24 @@ Func::Node::get_signature (const std::vector<func_signature> &signatures)
 	  if (args_compat[argIndex].m_compat == type_compatibility::INCOMPATIBLE)
 	    {
 	      invalid_arg_error (t, arg, sig);
-	      m_compat.m_singature_compat = type_compatibility::INCOMPATIBLE;
+	      m_compat.m_signature_compat = type_compatibility::INCOMPATIBLE;
 	      break;
 	    }
 	  else if (args_compat[argIndex].m_compat == type_compatibility::COERCIBLE)
 	    {
 	      // demote signature to coercible
-	      m_compat.m_singature_compat = type_compatibility::COERCIBLE;
+	      m_compat.m_signature_compat = type_compatibility::COERCIBLE;
 	    }
 	  ++argIndex;
 	}
 
-      if (m_compat.m_singature_compat == type_compatibility::EQUIVALENT)
+      if (m_compat.m_signature_compat == type_compatibility::EQUIVALENT)
 	{
 	  signature = &sig;
 	  m_compat.m_args_compat = std::move (args_compat);
 	  break; //stop at 1st equivalent signature
 	}
-      if (m_compat.m_singature_compat == type_compatibility::COERCIBLE && signature == nullptr)
+      if (m_compat.m_signature_compat == type_compatibility::COERCIBLE && signature == nullptr)
 	{
 	  //don't stop, continue because it is possible to find an equivalent signature later
 	  signature = &sig;

--- a/src/parser/func_type.cpp
+++ b/src/parser/func_type.cpp
@@ -240,6 +240,12 @@ std::vector<func_signature> func_signature::json_contains_path =
   {PT_TYPE_INTEGER, {PT_GENERIC_TYPE_JSON_DOC, PT_GENERIC_TYPE_STRING}, {PT_GENERIC_TYPE_STRING}},
 };
 
+std::vector<func_signature> func_signature::json_keys =
+{
+  {PT_TYPE_JSON, {PT_GENERIC_TYPE_JSON_DOC}, {}},
+  {PT_TYPE_JSON, {PT_GENERIC_TYPE_JSON_DOC, PT_GENERIC_TYPE_STRING}, {}},
+};
+
 std::vector<func_signature> func_signature::json_search =
 {
 // all signatures: json_doc, one_or_all_str, search_str[, escape_char[, path] ... -> JSON_DOC
@@ -364,7 +370,7 @@ func_signature::get_signatures (FUNC_TYPE ft)
     case F_JSON_INSERT:
       return &json_doc_r_path_val;
     case F_JSON_KEYS:
-      return &json_doc_path;
+      return &json_keys;
     case F_JSON_MERGE:
     case F_JSON_MERGE_PATCH:
       return &json_doc_r_doc;

--- a/src/parser/func_type.cpp
+++ b/src/parser/func_type.cpp
@@ -985,14 +985,10 @@ Func::Node::apply_signature (const func_signature &signature)
 	  assert (false);
 	  return false;
 	}
+      assert (m_compat.m_args_compat[arg_pos].m_compat != type_compatibility::INCOMPATIBLE);
 
-      if (m_compat.m_args_compat[arg_pos].m_compat == type_compatibility::EQUIVALENT)
+      if (m_compat.m_args_compat[arg_pos].m_type != arg->type_enum)
 	{
-	  // arg is good as is
-	}
-      else
-	{
-	  assert (m_compat.m_args_compat[arg_pos].m_compat == type_compatibility::COERCIBLE);
 	  arg = cast (prev, arg, m_compat.m_args_compat[arg_pos].m_type, TP_FLOATING_PRECISION_VALUE, 0, NULL);
 	  if (arg == NULL)
 	    {

--- a/src/parser/func_type.hpp
+++ b/src/parser/func_type.hpp
@@ -66,6 +66,7 @@ struct func_signature
   static std::vector<func_signature> json_doc_str_r_path;
   static std::vector<func_signature> json_doc_r_path_val;
   static std::vector<func_signature> json_contains_path;
+  static std::vector<func_signature> json_keys;
   static std::vector<func_signature> json_search;
   static std::vector<func_signature> json_arrayagg;
   static std::vector<func_signature> json_objectagg;

--- a/src/parser/func_type.hpp
+++ b/src/parser/func_type.hpp
@@ -105,7 +105,7 @@ namespace Func
 
   struct signature_compatibility
   {
-    type_compatibility m_singature_compat;
+    type_compatibility m_signature_compat;
     std::vector<argument_compatibility> m_args_compat;
   };
 

--- a/src/parser/parse_type.cpp
+++ b/src/parser/parse_type.cpp
@@ -25,35 +25,36 @@
 #include "parser.h"
 #include "string_buffer.hpp"
 
-const char *str (pt_generic_type_enum type)
+const char *pt_generic_type_to_string (pt_generic_type_enum type)
 {
   static const char *arr[] =
   {
-    "GT_NONE",
-    "GT_STRING",
-    "GT_STRING_VARYING",
-    "GT_CHAR",
-    "GT_NCHAR",
-    "GT_BIT",
-    "GT_DISCRETE_NUMBER",
-    "GT_NUMBER",
-    "GT_DATE",
-    "GT_DATETIME",
-    "GT_SEQUENCE",
-    "GT_LOB",
-    "GT_QUERY",
-    "GT_PRIMITIVE",
-    "GT_ANY",
-    "GT_JSON_VAL",
-    "GT_JSON_DOC",
-    "GT_JSON_PATH",
-    "GT_SCALAR",
+    "GENERIC TYPE NONE",
+    "GENERIC ANY STRING TYPE",
+    "GENERIC VARIABLE STRING TYPE",
+    "GENERIC ANY CHAR TYPE",
+    "GENERIC ANY NCHAR TYPE",
+    "GENERIC ANY BIT TYPE",
+    "GENERIC DISCRETE NUMBER TYPE",
+    "GENERIC ANY NUMBER TYPE",
+    "GENERIC DATE TYPE",
+    "GENERIC DATETIME TYPE",
+    "GENERIC SEQUENCE TYPE",
+    "GENERIC LOB TYPE",
+    "GENERIC QUERY TYPE",    // what is this?
+    "GENERIC PRIMITIVE TYPE",
+    "GENERIC ANY TYPE",
+    "JSON VALUE",
+    "JSON DOCUMENT",
+    "GENERIC SCALAR TYPE",
   };
+  static_assert ((PT_GENERIC_TYPE_SCALAR + 1) == (sizeof (arr) / sizeof (const char *)),
+		 "miss-match between pt_generic_type_enum and its name array");
   return arr[type];
 }
 
 //--------------------------------------------------------------------------------
-const char *str (const pt_arg_type &type, string_buffer &sb)
+const char *pt_arg_type_to_string_buffer (const pt_arg_type &type, string_buffer &sb)
 {
   switch (type.type)
     {
@@ -62,7 +63,7 @@ const char *str (const pt_arg_type &type, string_buffer &sb)
       sb ("%s", pt_show_type_enum (type.val.type));
       break;
     case pt_arg_type::GENERIC:
-      sb ("%s", str (type.val.generic_type));
+      sb ("%s", pt_generic_type_to_string (type.val.generic_type));
       break;
     case pt_arg_type::INDEX:
       sb ("IDX%d", type.val.index);

--- a/src/parser/parse_type.hpp
+++ b/src/parser/parse_type.hpp
@@ -54,7 +54,7 @@ enum pt_generic_type_enum
   PT_GENERIC_TYPE_SCALAR, // any type but set
 };
 
-const char *str (pt_generic_type_enum type);
+const char *pt_generic_type_to_string (pt_generic_type_enum type);
 
 /* expression argument type */
 struct pt_arg_type
@@ -126,6 +126,6 @@ struct pt_arg_type
 };
 typedef pt_arg_type PT_ARG_TYPE;
 
-const char *str (const pt_arg_type &type, string_buffer &sb);
+const char *pt_arg_type_to_string_buffer (const pt_arg_type &type, string_buffer &sb);
 
 #endif // _PARSE_TYPE_HPP_

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -12646,6 +12646,7 @@ pt_eval_function_type_new (PARSER_CONTEXT * parser, PT_NODE * node)
     }
 
   Func::Node funcNode (parser, node);
+  // todo - move below code to Func::Node
   if (funcNode.preprocess ())
     {
       if (node->type_enum == PT_TYPE_NONE || node->data_type == NULL)
@@ -12657,22 +12658,19 @@ pt_eval_function_type_new (PARSER_CONTEXT * parser, PT_NODE * node)
 	  if (!func_sigs)
 	    {
 	      pt_cat_error (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_FUNCTYPECHECK_NO_SIGNATURES,
-			    str (fcode) /*, parser_print_tree_list(parser, arg_list) */ );
+			    pt_func_type_to_string (fcode));
 	      return node;
 	    }
-	  string_buffer sb;
-	  const func_signature *func_sig = funcNode.get_signature (*func_sigs, sb);
-	  if (func_sig != NULL)
+	  const func_signature *func_sig = funcNode.get_signature (*func_sigs);
+	  if (func_sig == NULL || !funcNode.apply_signature (*func_sig))
 	    {
-	      funcNode.apply_signature (*func_sig);
-	      funcNode.set_return_type (*func_sig);
+	      node->type_enum = PT_TYPE_NA;	//to avoid entering here 2nd time
+	      pt_cat_error (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_FUNCTYPECHECK_NO_SIGNATURE,
+			    pt_func_type_to_string (fcode));
 	    }
 	  else
 	    {
-	      node->type_enum = PT_TYPE_NA;	//to avoid entering here 2nd time
-	      //arg_type = PT_TYPE_NONE;//unused!?
-	      pt_cat_error (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_FUNCTYPECHECK_NO_SIGNATURE,
-			    str (fcode) /*, parser_print_tree_list(parser, arg_list) */ );
+	      funcNode.set_return_type (*func_sig);
 	    }
 	}
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22553

cmp_type_equivalent/cmp_type_castable are not always synchronized with pt_get_equivalent_type. Sometimes equivalent/castable checks may pass and pt_get_equivalent_type then returns PT_TYPE_NONE.

Changed type checking to consider pt_get_equivalent_type in the first step.

Also changed error messages to make more clear (need to update all languages).