### PR TITLE
[CBRD-22477] - Add code to handle unique indexes for unloaddb

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -2656,6 +2656,11 @@ emit_index_def (DB_OBJECT * class_)
 	  asc_desc = db_constraint_asc_desc (constraint);
 	  prefix_length = db_constraint_prefix_length (constraint);
 	}
+      else if (ctype == DB_CONSTRAINT_UNIQUE)
+	{			/* is not reverse unique index */
+	  /* need to get asc/desc info */
+	  asc_desc = db_constraint_asc_desc (constraint);
+	}
 
       atts = db_constraint_attributes (constraint);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22477

This PR covers the unique indexes definitions during online index loading. For unique indexes, if there are in the process of being loaded with an online operation, for the unload we cannot tell whether the index is correct or not, as it may not finish. Therefore, we move the definitions to the `indexes` file resulted from the unload operation, so that DBAs can decide how to load them afterwards.