### PR TITLE
[CBRD-22599] support qualified name for -> and --> operators

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -17258,7 +17258,7 @@ reserved_func
 		    $$ = node;
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
-         | identifier RIGHT_ARROW CHAR_STRING
+         | simple_path_id RIGHT_ARROW CHAR_STRING
 		{{
 			PT_NODE *matcher = parser_new_node (this_parser, PT_VALUE);
 
@@ -17274,7 +17274,7 @@ reserved_func
 			PT_NODE *expr = parser_make_expression (this_parser, PT_JSON_EXTRACT, $1, matcher, NULL);
 			$$ = expr;
 		DBG_PRINT}}
-         | identifier DOUBLE_RIGHT_ARROW CHAR_STRING
+         | simple_path_id DOUBLE_RIGHT_ARROW CHAR_STRING
 		{{
 			PT_NODE *matcher = parser_new_node (this_parser, PT_VALUE);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22599

LHS of -> and --> operator might be qualified, for example, 
```sql
select t.j->'$.key' from (select id, json_object('key', json_arrayagg(name)) as j from too group by id ) as t;
```