### PR TITLE
[CBRD-22594] Fix case of error during unique search

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -24080,6 +24080,13 @@ xbtree_find_unique (THREAD_ENTRY * thread_p, BTID * btid, SCAN_OPERATION_TYPE sc
       ASSERT_ERROR ();
 #if defined (SERVER_MODE)
       /* Safe guard: don't keep lock if error has occurred. */
+      if (er_errid () == ER_INTERRUPTED)
+	{
+	  /* In case of an interrupt, the oid might already be locked so we should clear it. */
+	  lock_unlock_object_donot_move_to_non2pl (thread_p, &find_unique_helper.locked_oid,
+						   &find_unique_helper.locked_class_oid, find_unique_helper.lock_mode);
+	  OID_SET_NULL (&find_unique_helper.locked_oid);
+	}
       assert (OID_ISNULL (&find_unique_helper.locked_oid));
 #endif /* SERVER_MODE */
       return BTREE_ERROR_OCCURRED;

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -24080,9 +24080,9 @@ xbtree_find_unique (THREAD_ENTRY * thread_p, BTID * btid, SCAN_OPERATION_TYPE sc
       ASSERT_ERROR ();
 #if defined (SERVER_MODE)
       /* Safe guard: don't keep lock if error has occurred. */
-      if (er_errid () == ER_INTERRUPTED)
+      if (!OID_ISNULL (&find_unique_helper.locked_oid))
 	{
-	  /* In case of an interrupt, the oid might already be locked so we should clear it. */
+	  /* Make sure to unlock the object. */
 	  lock_unlock_object_donot_move_to_non2pl (thread_p, &find_unique_helper.locked_oid,
 						   &find_unique_helper.locked_class_oid, find_unique_helper.lock_mode);
 	  OID_SET_NULL (&find_unique_helper.locked_oid);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -24087,7 +24087,6 @@ xbtree_find_unique (THREAD_ENTRY * thread_p, BTID * btid, SCAN_OPERATION_TYPE sc
 						   &find_unique_helper.locked_class_oid, find_unique_helper.lock_mode);
 	  OID_SET_NULL (&find_unique_helper.locked_oid);
 	}
-      assert (OID_ISNULL (&find_unique_helper.locked_oid));
 #endif /* SERVER_MODE */
       return BTREE_ERROR_OCCURRED;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22594

In case of an error, the `OID` would have been kept as locked after propagating the error. However the assert fails so, in case of an error, we now also unlock the object.