### PR TITLE
[CBRD-22569] json_extract: ignore inexistent paths

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1444,7 +1444,11 @@ db_json_extract_document_from_path (const JSON_DOC *document, const char *raw_pa
     {
       if (result != NULL)
 	{
-	  result->SetNull ();
+	  // note - NULL result is different from DB_JSON_NULL.
+	  //        NULL means path was not found
+	  //        DB_JSON_NULL means a null value was found at given path
+	  delete result;
+	  result = NULL;
 	}
     }
 

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5562,14 +5562,29 @@ db_json_extract_multiple_paths (DB_VALUE * result, DB_VALUE * args[], int num_ar
 	  return error_code;
 	}
 
-      db_json_add_element_to_array (result_doc, extracted_doc);
+      if (extracted_doc != NULL)
+	{
+	  db_json_add_element_to_array (result_doc, extracted_doc);
+	}
+      else
+	{
+	  // continue
+	}
     }
 
   // free temporary resources
   db_json_delete_doc (extracted_doc);
   db_json_delete_doc (source_doc);
 
-  db_make_json (result, result_doc, true);
+  if (db_json_get_type (result_doc) == DB_JSON_NULL)
+    {
+      // let null result
+      db_json_delete_doc (result_doc);
+    }
+  else
+    {
+      db_make_json (result, result_doc, true);
+    }
   return NO_ERROR;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22569

Instead of appending a null value, an inexistent path is just ignored.