### PR TITLE
[CBRD-22584] Fix btid restore for XASL nodes that were reused with partition cases

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1947,6 +1947,9 @@ qexec_clear_access_spec_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, ACCES
 		    {
 		      pg_cnt += qexec_clear_regu_var (thread_p, xasl_p, indx_info->key_info.key_limit_u, is_final);
 		    }
+
+		  /* Restore the BTID for future usages (needed for partition cases). */
+		  BTID_COPY (&indx_info->btid, &p->btid);
 		}
 	    }
 	  break;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1949,6 +1949,15 @@ qexec_clear_access_spec_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, ACCES
 		    }
 
 		  /* Restore the BTID for future usages (needed for partition cases). */
+		  /* XASL comes from the client with the btid set to the root class of the partitions hierarchy. 
+		   * Scan begins and starts with the rootclass, then jumps to a partition and sets the btid in the 
+		   * XASL to the one of the partition. Execution ends and the next identical statement comes and uses
+		   * the XASL previously generated. However, the BTID was not cleared from the INDEX_INFO structure
+		   * so the execution will fail.
+		   * We need to find a better solution so that we do not write on the XASL members during execution.
+		   */
+
+		  /* TODO: Fix me!! */
 		  BTID_COPY (&indx_info->btid, &p->btid);
 		}
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22584

Scanning multiple partitions will leave the XASL current spec have the btid set to where the last scan ended. Therefore, if the XASL would not have been cleaned, it would be in an incorrect state. This should fix it.