### PR TITLE
[CBRD-22611] do not accept numerics for json document arguments

### DIFF
--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/en_US/cubrid.msg
+++ b/msg/en_US/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/ko_KR.euckr/cubrid.msg
+++ b/msg/ko_KR.euckr/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/ro_RO.utf8/cubrid.msg
+++ b/msg/ro_RO.utf8/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Calea "%1$s" nu exista in %2$s
 1203 Tipul JSON-ului de la calea %1$s este invalid. Expected %2$s, dar am gasit %3$s.
 1204 Cheia "%1$s" din json este duplicata
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1271,7 +1271,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/msg/zh_CN.utf8/cubrid.msg
+++ b/msg/zh_CN.utf8/cubrid.msg
@@ -1272,7 +1272,7 @@ $ LOADDB
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
-1205 Reserved error for JSON.
+1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Reserved error for JSON.
 1207 Reserved error for JSON.
 1208 Reserved error for JSON.

--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -1547,8 +1547,8 @@
 #define ER_JSON_PATH_DOES_NOT_EXIST                 -1202
 #define ER_JSON_EXPECTED_OTHER_TYPE                 -1203
 #define ER_JSON_DUPLICATE_KEY                       -1204
+#define ER_JSON_EXPECTING_JSON_DOC                  -1205
 
-#define ER_JSON_RESERVED_ERROR_0                    -1205
 #define ER_JSON_RESERVED_ERROR_1                    -1206
 #define ER_JSON_RESERVED_ERROR_2                    -1207
 #define ER_JSON_RESERVED_ERROR_3                    -1208

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -3620,7 +3620,7 @@ db_value_to_json_doc (const DB_VALUE &db_val, REFPTR (JSON_DOC, json_doc))
   int error_code = NO_ERROR;
 
   json_doc = NULL;
-  switch (DB_VALUE_DOMAIN_TYPE (&db_val))
+  switch (db_value_domain_type (&db_val))
     {
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
@@ -3644,8 +3644,9 @@ db_value_to_json_doc (const DB_VALUE &db_val, REFPTR (JSON_DOC, json_doc))
 
     default:
       // todo: more specific error
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INVALID_DATA_TYPE, 0);
-      return ER_QSTR_INVALID_DATA_TYPE;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_JSON_EXPECTING_JSON_DOC, 1,
+	      pr_type_name (db_value_domain_type (&db_val)));
+      return ER_JSON_EXPECTING_JSON_DOC;
     }
 }
 

--- a/src/parser/func_type.cpp
+++ b/src/parser/func_type.cpp
@@ -658,10 +658,12 @@ Func::cmp_types_castable (const pt_arg_type &type, pt_type_enum type_enum) //is 
     case PT_GENERIC_TYPE_SCALAR:
       return !PT_IS_COLLECTION_TYPE (type_enum);
 
-    case PT_GENERIC_TYPE_JSON_DOC:
     case PT_GENERIC_TYPE_JSON_VAL:
       // it will be resolved at runtime
-      return PT_IS_NUMERIC_TYPE (type_enum);      // numerics can be converted to json
+      return PT_IS_NUMERIC_TYPE (type_enum);      // numerics can be converted to a json value
+
+    case PT_GENERIC_TYPE_JSON_DOC:
+      return false;     // only equivalent types
 
     case PT_GENERIC_TYPE_SEQUENCE:
       // todo -
@@ -1340,10 +1342,6 @@ pt_get_equivalent_type (const PT_ARG_TYPE def_type, const PT_TYPE_ENUM arg_type)
       if (pt_is_json_doc_type (arg_type))
 	{
 	  return arg_type;
-	}
-      else if (PT_IS_NUMERIC_TYPE (arg_type))
-	{
-	  return PT_TYPE_JSON;
 	}
       else
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22611

Change behavior to reject numeric types conversion to json document.

NOTE: json value arguments can still accept numeric types.