### PR TITLE
[CBRD-22618] Fix invisible index during reorganize of partitions

### DIFF
--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4000,7 +4000,7 @@ classobj_is_possible_constraint (SM_CONSTRAINT_TYPE existed, DB_CONSTRAINT_TYPE 
  */
 
 TP_DOMAIN *
-classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons)
+classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons, OID * root_oid)
 {
   TP_DOMAIN *key_type = NULL;
   int i, j;
@@ -4018,8 +4018,17 @@ classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons)
       return NULL;		/* give up */
     }
 
+  if (OID_ISNULL (root_oid))
+    {
+      return NULL;
+    }
+
   /* Get local stats including invisible indexes. */
-  local_stats = stats_get_statistics (&cons->attributes[0]->class_mop->oid_info.oid, 0);
+  local_stats = stats_get_statistics (root_oid, 0);
+  if (local_stats == NULL)
+    {
+      return NULL;
+    }
 
   attr_statsp = local_stats->attr_stats;
   for (i = 0; i < local_stats->n_attrs && !key_type; i++, attr_statsp++)

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4000,14 +4000,15 @@ classobj_is_possible_constraint (SM_CONSTRAINT_TYPE existed, DB_CONSTRAINT_TYPE 
  */
 
 TP_DOMAIN *
-classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons, CLASS_STATS * stats)
+classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons)
 {
   TP_DOMAIN *key_type = NULL;
   int i, j;
   ATTR_STATS *attr_statsp;
   BTREE_STATS *bt_statsp;
+  CLASS_STATS *local_stats;
 
-  if (!cons || !stats)
+  if (!cons)
     {
       return NULL;		/* invalid args */
     }
@@ -4017,8 +4018,11 @@ classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons, CLASS_STATS
       return NULL;		/* give up */
     }
 
-  attr_statsp = stats->attr_stats;
-  for (i = 0; i < stats->n_attrs && !key_type; i++, attr_statsp++)
+  /* Get local stats including invisible indexes. */
+  local_stats = stats_get_statistics (&cons->attributes[0]->class_mop->oid_info.oid, 0);
+
+  attr_statsp = local_stats->attr_stats;
+  for (i = 0; i < local_stats->n_attrs && !key_type; i++, attr_statsp++)
     {
       bt_statsp = attr_statsp->bt_stats;
       for (j = 0; j < attr_statsp->n_btstats && !key_type; j++, bt_statsp++)

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4006,7 +4006,7 @@ classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons, OID * root_
   int i, j;
   ATTR_STATS *attr_statsp;
   BTREE_STATS *bt_statsp;
-  CLASS_STATS *local_stats;
+  CLASS_STATS *local_stats = NULL;
 
   if (!cons)
     {
@@ -4047,6 +4047,11 @@ classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons, OID * root_
     {
       /* get the column key-type of multi-column index */
       key_type = key_type->setdomain;
+    }
+
+  if (local_stats != NULL)
+    {
+      stats_free_statistics (local_stats);
     }
 
   return key_type;

--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -982,7 +982,7 @@ extern SM_CLASS_CONSTRAINT *classobj_find_constraint_by_name (SM_CLASS_CONSTRAIN
 extern SM_CLASS_CONSTRAINT *classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list,
 							       DB_CONSTRAINT_TYPE new_cons, const char **att_names,
 							       const int *asc_desc);
-extern TP_DOMAIN *classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons, CLASS_STATS * stats);
+extern TP_DOMAIN *classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons);
 extern void classobj_remove_class_constraint_node (SM_CLASS_CONSTRAINT ** constraints, SM_CLASS_CONSTRAINT * node);
 
 extern int classobj_populate_class_properties (DB_SET ** properties, SM_CLASS_CONSTRAINT * constraints,

--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -982,7 +982,7 @@ extern SM_CLASS_CONSTRAINT *classobj_find_constraint_by_name (SM_CLASS_CONSTRAIN
 extern SM_CLASS_CONSTRAINT *classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list,
 							       DB_CONSTRAINT_TYPE new_cons, const char **att_names,
 							       const int *asc_desc);
-extern TP_DOMAIN *classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons);
+extern TP_DOMAIN *classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons, OID * root_oid);
 extern void classobj_remove_class_constraint_node (SM_CLASS_CONSTRAINT ** constraints, SM_CLASS_CONSTRAINT * node);
 
 extern int classobj_populate_class_properties (DB_SET ** properties, SM_CLASS_CONSTRAINT * constraints,

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -5319,7 +5319,7 @@ do_create_partition_constraint (PT_NODE * alter, SM_CLASS * root_class, SM_CLASS
 
   attp = constraint->attributes;
   attrnames = namep;
-  key_type = classobj_find_cons_index2_col_type_list (constraint, root_class->stats);
+  key_type = classobj_find_cons_index2_col_type_list (constraint);
   if (key_type == NULL)
     {
       if ((error = er_errid ()) == NO_ERROR)
@@ -5398,7 +5398,7 @@ do_create_partition_constraint (PT_NODE * alter, SM_CLASS * root_class, SM_CLASS
 	  error =
 	    sm_add_constraint (subclass_op, db_constraint_type (constraint), constraint->name, (const char **) namep,
 			       asc_desc, constraint->attrs_prefix_length, false, constraint->filter_predicate,
-			       new_func_index_info, constraint->comment, SM_NORMAL_INDEX);
+			       new_func_index_info, constraint->comment, constraint->index_status);
 	  if (error != NO_ERROR)
 	    {
 	      goto cleanup;
@@ -5452,7 +5452,7 @@ do_create_partition_constraint (PT_NODE * alter, SM_CLASS * root_class, SM_CLASS
 	  error =
 	    sm_add_constraint (objs->op, db_constraint_type (constraint), constraint->name, (const char **) namep,
 			       asc_desc, constraint->attrs_prefix_length, false, constraint->filter_predicate,
-			       new_func_index_info, constraint->comment, SM_NORMAL_INDEX);
+			       new_func_index_info, constraint->comment, constraint->index_status);
 	  if (error != NO_ERROR)
 	    {
 	      goto cleanup;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -323,7 +323,8 @@ static SM_FUNCTION_INFO *pt_node_to_function_index (PARSER_CONTEXT * parser, PT_
 						    DO_INDEX do_index);
 
 static int do_create_partition_constraints (PARSER_CONTEXT * parser, PT_NODE * alter, SM_PARTITION_ALTER_INFO * pinfo);
-static int do_create_partition_constraint (PT_NODE * alter, SM_CLASS * root_class, SM_CLASS_CONSTRAINT * constraint);
+static int do_create_partition_constraint (PT_NODE * alter, SM_CLASS * root_class, SM_CLASS_CONSTRAINT * constraint,
+					   SM_PARTITION_ALTER_INFO * pinfo);
 static int do_alter_partitioning_pre (PARSER_CONTEXT * parser, PT_NODE * alter, SM_PARTITION_ALTER_INFO * pinfo);
 static int do_alter_partitioning_post (PARSER_CONTEXT * parser, PT_NODE * alter, SM_PARTITION_ALTER_INFO * pinfo);
 static int do_create_partition (PARSER_CONTEXT * parser, PT_NODE * alter, SM_PARTITION_ALTER_INFO * pinfo);
@@ -5253,7 +5254,7 @@ do_create_partition_constraints (PARSER_CONTEXT * parser, PT_NODE * alter, SM_PA
 	{
 	  continue;
 	}
-      error = do_create_partition_constraint (alter, smclass, cons);
+      error = do_create_partition_constraint (alter, smclass, cons, pinfo);
       if (error != NO_ERROR)
 	{
 	  return error;
@@ -5272,7 +5273,8 @@ do_create_partition_constraints (PARSER_CONTEXT * parser, PT_NODE * alter, SM_PA
  * constraint (in) : root constraint
  */
 static int
-do_create_partition_constraint (PT_NODE * alter, SM_CLASS * root_class, SM_CLASS_CONSTRAINT * constraint)
+do_create_partition_constraint (PT_NODE * alter, SM_CLASS * root_class, SM_CLASS_CONSTRAINT * constraint,
+				SM_PARTITION_ALTER_INFO * pinfo)
 {
   int error = NO_ERROR, i = 0;
   char **namep = NULL, **attrnames = NULL;
@@ -5319,7 +5321,7 @@ do_create_partition_constraint (PT_NODE * alter, SM_CLASS * root_class, SM_CLASS
 
   attp = constraint->attributes;
   attrnames = namep;
-  key_type = classobj_find_cons_index2_col_type_list (constraint);
+  key_type = classobj_find_cons_index2_col_type_list (constraint, &pinfo->root_op->oid_info.oid);
   if (key_type == NULL)
     {
       if ((error = er_errid ()) == NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22617

On client-side we do not get statistics on online and invisible indexes. However, these statistics are needed for the reorganize of partitions to get information regarding the key_type of current indexes. This should fix it.