### PR TITLE
[CBRD-22624] Fix shared constraints with foreign keys

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -14638,18 +14638,29 @@ sm_add_constraint (MOP classop, DB_CONSTRAINT_TYPE constraint_type, const char *
 	}
 #endif /* SA_MODE */
 
-      if (index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS && classop->lock > IX_LOCK)
-	{
-	  // if the transaction already hold a lock which is greater than IX,
-	  // we don't allow online index creation for transaction consistency.
-	  index_status = SM_NORMAL_INDEX;
-	}
-
       def = smt_edit_class_mop (classop, auth);
       if (def == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error);
 	  goto error_exit;
+	}
+
+      if (index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS)
+	{
+	  bool is_online_index_allowed = false;
+	  error =
+	    smt_is_online_index_allowed (classop, def, constraint_type, constraint_name, att_names, asc_desc,
+					 filter_index, function_index, &is_online_index_allowed);
+	  if (error != NO_ERROR)
+	    {
+	      smt_quit (def);
+	      goto error_exit;
+	    }
+
+	  if (!is_online_index_allowed)
+	    {
+	      index_status = SM_NORMAL_INDEX;
+	    }
 	}
 
       error = sm_partitioned_class_type (classop, &partition_type, NULL, &sub_partitions);

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -14630,14 +14630,6 @@ sm_add_constraint (MOP classop, DB_CONSTRAINT_TYPE constraint_type, const char *
 	  auth = AU_ALTER;
 	}
 
-#if defined (SA_MODE)
-      if (index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS)
-	{
-	  // We don't allow online index for SA_MODE.
-	  index_status = SM_NORMAL_INDEX;
-	}
-#endif /* SA_MODE */
-
       def = smt_edit_class_mop (classop, auth);
       if (def == NULL)
 	{
@@ -14648,9 +14640,9 @@ sm_add_constraint (MOP classop, DB_CONSTRAINT_TYPE constraint_type, const char *
       if (index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS)
 	{
 	  bool is_online_index_allowed = false;
-	  error =
-	    smt_is_online_index_allowed (classop, def, constraint_type, constraint_name, att_names, asc_desc,
-					 filter_index, function_index, &is_online_index_allowed);
+
+	  error = smt_is_online_index_allowed (classop, def, constraint_type, constraint_name, att_names, asc_desc,
+					       filter_index, function_index, &is_online_index_allowed);
 	  if (error != NO_ERROR)
 	    {
 	      smt_quit (def);

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -399,7 +399,7 @@ static int sm_drop_cascade_foreign_key (SM_CLASS * class_);
 static char *sm_default_constraint_name (const char *class_name, DB_CONSTRAINT_TYPE type, const char **att_names,
 					 const int *asc_desc);
 
-static int sm_load_online_index (MOP classmop, const char *constraint_name, bool * is_shared);
+static int sm_load_online_index (MOP classmop, const char *constraint_name);
 
 static const char *sm_locate_method_file (SM_CLASS * class_, const char *function);
 
@@ -10655,12 +10655,6 @@ allocate_unique_constraint (MOP classop, SM_CLASS * class_, SM_CLASS_CONSTRAINT 
 	{
 	  shared_con = classobj_find_constraint_by_name (class_->constraints, con->shared_cons_name);
 	  con->index_btid = shared_con->index_btid;
-
-	  /* Since we have a shared index, we can easily set it to normal index as we do not load the BTID anymore. */
-	  if (con->index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS)
-	    {
-	      con->index_status = SM_NORMAL_INDEX;
-	    }
 	}
       else
 	{
@@ -10849,9 +10843,8 @@ allocate_disk_structures_index (MOP classop, SM_CLASS * class_, SM_CLASS_CONSTRA
    * This is where the promotion of attribute name references to ids references happens.
    */
   if (classobj_put_index (&(class_->properties), con->type, con->name, con->attributes, con->asc_desc,
-			  con->attrs_prefix_length, &(con->index_btid), con->filter_predicate, con->fk_info,
-			  con->shared_cons_name, con->func_index_info, con->comment, con->index_status,
-			  false) != NO_ERROR)
+			  con->attrs_prefix_length, &(con->index_btid), con->filter_predicate, con->fk_info, NULL,
+			  con->func_index_info, con->comment, con->index_status, false) != NO_ERROR)
     {
       return error;
     }
@@ -14751,18 +14744,12 @@ sm_add_constraint (MOP classop, DB_CONSTRAINT_TYPE constraint_type, const char *
       if (index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS && partition_type != DB_PARTITION_CLASS)
 	{
 	  // Load index phase.
-	  bool is_shared = false;
-	  error = sm_load_online_index (newmop, constraint_name, &is_shared);
+	  error = sm_load_online_index (newmop, constraint_name);
 	  if (error != NO_ERROR)
 	    {
 	      goto error_exit;
 	    }
 
-	  if (is_shared)
-	    {
-	      /* Nothing to do, everything is set. */
-	      break;
-	    }
 	  error = sm_update_statistics (newmop, STATS_WITH_SAMPLING);
 	  if (error != NO_ERROR)
 	    {
@@ -16452,7 +16439,7 @@ sm_stats_remove_bt_stats_at_position (ATTR_STATS * attr_stats, int position)
 }
 
 int
-sm_load_online_index (MOP classmop, const char *constraint_name, bool * is_shared)
+sm_load_online_index (MOP classmop, const char *constraint_name)
 {
   SM_CLASS *class_ = NULL, *subclass_ = NULL;
   int error = NO_ERROR;
@@ -16490,13 +16477,6 @@ sm_load_online_index (MOP classmop, const char *constraint_name, bool * is_share
 
   /* Safeguards. */
   assert (con != NULL);
-  if (con->index_status == SM_NORMAL_INDEX)
-    {
-      /* Index should already have been loaded. */
-      assert (!BTID_IS_NULL (&con->index_btid));
-      *is_shared = true;
-      return NO_ERROR;
-    }
   assert (con->index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS);
 
   /* We must check if the constraint isn't shared from another one. */

--- a/src/object/schema_template.c
+++ b/src/object/schema_template.c
@@ -4835,14 +4835,20 @@ smt_is_online_index_allowed (MOP class_mop, SM_TEMPLATE * template_, DB_CONSTRAI
 			     const char *constraint_name, const char **att_names, const int *asc_desc,
 			     SM_PREDICATE_INFO * filter_index, SM_FUNCTION_INFO * function_index, bool * is_allowed)
 {
+#if defined (SA_MODE)
+  // We don't allow online index for SA_MODE.
+  *is_allowed = false;
+  return NO_ERROR;
+#else /* SA_MODE */
   int error = NO_ERROR;
   char *shared_cons_name = NULL;
+
+  *is_allowed = false;
 
   if (class_mop->lock > IX_LOCK)
     {
       // if the transaction already hold a lock which is greater than IX,
       // we don't allow online index creation for transaction consistency.
-      *is_allowed = false;
       return NO_ERROR;
     }
 
@@ -4850,18 +4856,16 @@ smt_is_online_index_allowed (MOP class_mop, SM_TEMPLATE * template_, DB_CONSTRAI
 				 asc_desc, filter_index, function_index);
   if (error != NO_ERROR)
     {
-      *is_allowed = false;
       return error;
     }
 
   if (shared_cons_name != NULL)
     {
-      /* If index is shared with another constraint build it as a normal index. */
-      *is_allowed = false;
+      /* If index is shared with another constraint, build it as a normal index. */
       return NO_ERROR;
     }
 
   *is_allowed = true;
   return NO_ERROR;
-
+#endif /* !SA_MODE */
 }

--- a/src/object/schema_template.c
+++ b/src/object/schema_template.c
@@ -4829,3 +4829,39 @@ smt_change_constraint_status (SM_TEMPLATE * ctemplate, const char *index_name, S
 
   return NO_ERROR;
 }
+
+int
+smt_is_online_index_allowed (MOP class_mop, SM_TEMPLATE * template_, DB_CONSTRAINT_TYPE constraint_type,
+			     const char *constraint_name, const char **att_names, const int *asc_desc,
+			     SM_PREDICATE_INFO * filter_index, SM_FUNCTION_INFO * function_index, bool * is_allowed)
+{
+  int error = NO_ERROR;
+  char *shared_cons_name = NULL;
+
+  if (class_mop->lock > IX_LOCK)
+    {
+      // if the transaction already hold a lock which is greater than IX,
+      // we don't allow online index creation for transaction consistency.
+      *is_allowed = false;
+      return NO_ERROR;
+    }
+
+  error = smt_check_index_exist (template_, &shared_cons_name, constraint_type, constraint_name, att_names,
+				 asc_desc, filter_index, function_index);
+  if (error != NO_ERROR)
+    {
+      *is_allowed = false;
+      return error;
+    }
+
+  if (shared_cons_name != NULL)
+    {
+      /* If index is shared with another constraint build it as a normal index. */
+      *is_allowed = false;
+      return NO_ERROR;
+    }
+
+  *is_allowed = true;
+  return NO_ERROR;
+
+}

--- a/src/object/schema_template.h
+++ b/src/object/schema_template.h
@@ -165,6 +165,11 @@ extern int smt_change_attribute_w_dflt_w_order (DB_CTMPL * def, const char *name
 						const bool change_first, const char *change_after_attribute,
 						SM_ATTRIBUTE ** found_att);
 
+extern int smt_is_online_index_allowed (MOP class_mop, SM_TEMPLATE * template_, DB_CONSTRAINT_TYPE constraint_type,
+					const char *constraint_name, const char **att_names, const int *asc_desc,
+					SM_PREDICATE_INFO * filter_index, SM_FUNCTION_INFO * function_index,
+					bool * is_allowed);
+
 #if defined(ENABLE_UNUSED_FUNCTION)
 extern void smt_downcase_all_class_info (void);
 #endif


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22624

For unique indexes and foreign keys, the class constraints would have been decached and we would have lost the `shared_cons_name` value which was needed to skip the loading. I have added a workaround to tackle this issue by not allowing the online index creation since the `btree` is already loaded from the shared constraint. This way, we handle it like a normal index which translates into setting the `btid` of the shared constraint to the current one.