### PR TITLE
[CBRD-22645] fix slip of #1399 on pt_is_const_expr_node

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -17949,6 +17949,7 @@ pt_is_const_expr_node (PT_NODE * node)
 	case PT_INET_NTOA:
 	case PT_CHARSET:
 	case PT_COLLATION:
+	  return pt_is_const_expr_node (node->info.expr.arg1);
 	case PT_COERCIBILITY:
 	  /* coercibility is always folded to constant */
 	  assert (false);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22645

It was accidentally removed as #1399.