### PR TITLE
[CBRD-22646] correct json_valid behavior

### DIFF
--- a/src/parser/func_type.cpp
+++ b/src/parser/func_type.cpp
@@ -42,6 +42,11 @@ func_all_signatures sig_ret_int_no_arg =
   {PT_TYPE_INTEGER, {}, {}},
 };
 
+func_all_signatures sig_ret_int_arg_any =
+{
+  {PT_TYPE_INTEGER, {PT_GENERIC_TYPE_ANY}, {}},
+};
+
 func_all_signatures sig_ret_int_arg_doc =
 {
   {PT_TYPE_INTEGER, {PT_GENERIC_TYPE_JSON_DOC}, {}},
@@ -431,7 +436,7 @@ get_signatures (FUNC_TYPE ft)
     case F_JSON_UNQUOTE:
       return &sig_ret_string_arg_jdoc;
     case F_JSON_VALID:
-      return &sig_ret_int_arg_str;
+      return &sig_ret_int_arg_any;
     case PT_FIRST_VALUE:
     case PT_LAST_VALUE:
       return &sig_ret_type0_arg_scalar;

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5187,13 +5187,27 @@ db_evaluate_json_valid (DB_VALUE * result, DB_VALUE * const *arg, int const num_
       assert (false);
       return ER_FAILED;
     }
-  DB_VALUE *json = arg[0];
-  if (DB_IS_NULL (json))
+  DB_VALUE *value = arg[0];
+  if (DB_IS_NULL (value))
     {
       return NO_ERROR;
     }
-  bool valid = db_json_is_valid (db_get_string (json));
-  return db_make_int (result, valid ? 1 : 0);
+  DB_TYPE type = db_value_domain_type (value);
+  bool valid;
+  if (type == DB_TYPE_JSON)
+    {
+      valid = true;
+    }
+  else if (TP_IS_CHAR_TYPE (type))
+    {
+      valid = db_json_is_valid (db_get_string (value));
+    }
+  else
+    {
+      valid = false;
+    }
+  db_make_int (result, valid ? 1 : 0);
+  return NO_ERROR;
 }
 
 int


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22646

JSON valid returns true if:

  1. argument is a json
  2. argument is a string that can be parsed as a json

JSON valid returns false if:

  1. argument is neither json, nor string
  2. argument is a string, but it cannot be parsed as a json