### PR TITLE
[CBRD-22640] update stats even though table has no index

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -12445,7 +12445,7 @@ update_subclasses (DB_OBJLIST * subclasses)
 		      /* an error has happened */
 		      error = num_indexes;
 		    }
-		  else if (!class_->dont_decache_constraints_or_flush && num_indexes > 0)
+		  else if (!class_->dont_decache_constraints_or_flush)
 		    {
 		      error = sm_update_statistics (sub->op, STATS_WITH_SAMPLING);
 		    }
@@ -12787,13 +12787,10 @@ update_class (SM_TEMPLATE * template_, MOP * classmop, int auto_res, DB_AUTH aut
   class_->new_ = NULL;
 
   /* All objects are updated, now we can update class statistics also. */
-  if (num_indexes > 0)
+  error = sm_update_statistics (template_->op, STATS_WITH_SAMPLING);
+  if (error != NO_ERROR)
     {
-      error = sm_update_statistics (template_->op, STATS_WITH_SAMPLING);
-      if (error != NO_ERROR)
-	{
-	  goto error_return;
-	}
+      goto error_return;
     }
 
   classobj_free_template (flat);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22640

Whenever the last index on a class was removed, statistics on that class were never updated automatically. This should fix it.