### PR TITLE
[CBRD-22495] initialize json table scan properly

### DIFF
--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3853,7 +3853,7 @@ scan_open_json_table_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, int group
   DB_TYPE single_node_type = DB_TYPE_NULL;
 
   /* scan type is JSON_TABLE SCAN */
-  scan_id->type = S_JSON_TABLE_SCAN;
+  assert (scan_id->type == S_JSON_TABLE_SCAN);
 
   /* initialize SCAN_ID structure */
   /* mvcc_select_lock_needed = false, fixed = true */

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -4435,6 +4435,8 @@ stx_build_access_spec_type (THREAD_ENTRY * thread_p, char *ptr, ACCESS_SPEC_TYPE
   if (access_spec->type == TARGET_JSON_TABLE)
     {
       // also initialize scan part; it is enough to call it once here, not on each query execution
+      // since we initialize the json table here, we also have to initialize s_id.type
+      access_spec->s_id.type = S_JSON_TABLE_SCAN;
       access_spec->s_id.s.jtid.init (access_spec->s.json_table_node);
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22495

Scenario: Prepared plan containing json table is never executed. Allocated resources that are normally freed on final clear depend on s_id.type. However s_id.type is initialized on open scan, which is never called.

Fixed by initializing s_id.type when XASL is unpacked.