### PR TITLE
[CBRD-22650] can interrupt active workers doing vacuum

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1232,7 +1232,7 @@ vacuum_heap (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, MVCCID threshold_m
 			       page_ptr->oid.volid, page_ptr->oid.pageid);
 
 #if defined (NDEBUG)
-	  if (vacuum_is_thread_vacuum_worker (thread_p) && !thread_p->shutdown)
+	  if (!thread_p->shutdown)
 	    {
 	      // unexpected case
 	      // debug crashes; but can release do about it? just try to clean as much as possible

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1232,7 +1232,7 @@ vacuum_heap (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, MVCCID threshold_m
 			       page_ptr->oid.volid, page_ptr->oid.pageid);
 
 #if defined (NDEBUG)
-	  if (!thread_p->shutdown)
+	  if (vacuum_is_thread_vacuum_worker (thread_p) && !thread_p->shutdown)
 	    {
 	      // unexpected case
 	      // debug crashes; but can release do about it? just try to clean as much as possible
@@ -8069,7 +8069,10 @@ static void
 vacuum_check_shutdown_interruption (const THREAD_ENTRY * thread_p, int error_code)
 {
   ASSERT_ERROR ();
-  assert (thread_p->shutdown && error_code == ER_INTERRUPTED);
+  // interrupted is accepted if:
+  // 1. this is an active worker thread
+  // 2. or server is shutting down
+  assert (!vacuum_is_thread_vacuum_worker (thread_p) || (thread_p->shutdown && error_code == ER_INTERRUPTED));
 }
 
 //

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -157,9 +157,9 @@ struct vacuum_worker
 
 // inline vacuum functions replacing old macros
 STATIC_INLINE VACUUM_WORKER *vacuum_get_vacuum_worker (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE bool vacuum_is_thread_vacuum (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE bool vacuum_is_thread_vacuum_worker (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE bool vacuum_is_thread_vacuum_master (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE bool vacuum_is_thread_vacuum (const THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE bool vacuum_is_thread_vacuum_worker (const THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE bool vacuum_is_thread_vacuum_master (const THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE bool vacuum_is_skip_undo_allowed (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE LOG_TDES *vacuum_get_worker_tdes (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE VACUUM_WORKER_STATE vacuum_get_worker_state (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
@@ -181,21 +181,21 @@ vacuum_get_vacuum_worker (THREAD_ENTRY * thread_p)
 }
 
 bool
-vacuum_is_thread_vacuum (THREAD_ENTRY * thread_p)
+vacuum_is_thread_vacuum (const THREAD_ENTRY * thread_p)
 {
   assert (thread_p != NULL);
   return thread_p != NULL && (thread_p->type == TT_VACUUM_MASTER || thread_p->type == TT_VACUUM_WORKER);
 }
 
 bool
-vacuum_is_thread_vacuum_worker (THREAD_ENTRY * thread_p)
+vacuum_is_thread_vacuum_worker (const THREAD_ENTRY * thread_p)
 {
   assert (thread_p != NULL);
   return thread_p != NULL && thread_p->type == TT_VACUUM_WORKER;
 }
 
 bool
-vacuum_is_thread_vacuum_master (THREAD_ENTRY * thread_p)
+vacuum_is_thread_vacuum_master (const THREAD_ENTRY * thread_p)
 {
   assert (thread_p != NULL);
   return thread_p != NULL && thread_p->type == TT_VACUUM_MASTER;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22650

Update safe-guard to accept interruptions on active workers doing heap vacuum.