### PR TITLE
[CBRD-22659] JSON csql crashed when insert json data with enable_string_compression=n

### DIFF
--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -106,6 +106,8 @@ static int or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int
 static int or_varbit_length_internal (int bitlen, int align);
 static int or_varchar_length_internal (int charlen, int align);
 static int or_put_varbit_internal (OR_BUF * buf, char *string, int bitlen, int align);
+static int or_packed_json_schema_length (const char *json_schema);
+static int or_packed_json_validator_length (JSON_VALIDATOR * json_validator);
 static char *or_unpack_var_table_internal (char *ptr, int nvars, OR_VARINFO * vars, int offset_size);
 static char or_mvcc_get_flag (RECDES * record);
 static void or_mvcc_set_flag (RECDES * record, char flags);
@@ -4131,6 +4133,39 @@ or_packed_string_length (const char *string, int *strlenp)
 }
 
 /*
+ * or_packed_json_schema_length - Determines the number of bytes required to hold
+ * the packed representation of a json_schema.
+ *    return: length of packed json_schema
+ *    json_schema(in): json_schema
+ */
+static int
+or_packed_json_schema_length (const char *json_schema)
+{
+  DB_VALUE val;
+  // *INDENT-OFF*
+  db_make_string (&val, const_cast <char*>(json_schema));
+  // *INDENT-ON*
+
+  return (*(tp_String.data_lengthval)) (&val, 1);
+}
+
+/*
+ * or_packed_json_validator_length - Determines the number of bytes required to hold
+ * the packed representation of a json_validator.
+ *    return: length of packed json_validator
+ *    json_validator(in): json_validator
+ */
+static int
+or_packed_json_validator_length (JSON_VALIDATOR * json_validator)
+{
+  if (json_validator == NULL)
+    {
+      return 0;
+    }
+  return or_packed_json_schema_length (db_json_get_schema_raw_from_validator (json_validator));
+}
+
+/*
  * or_packed_stream_length - Determines the number of bytes required to hold
  * the packed representation of a stream.
  *    return: length of packed stream
@@ -4489,15 +4524,7 @@ or_packed_domain_size (TP_DOMAIN * domain, int include_classoids)
 	  break;
 
 	case DB_TYPE_JSON:
-	  if (d->json_validator != NULL)
-	    {
-	      DB_VALUE temp;
-	      // *INDENT-OFF*
-	      db_make_string (&temp, const_cast <char*>(db_json_get_schema_raw_from_validator (d->json_validator)));
-	      // *INDENT-ON*
-
-	      size += (*(tp_String.data_lengthval)) (&temp, 1);
-	    }
+	  size += or_packed_json_validator_length (d->json_validator);
 	  break;
 
 	default:

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -4491,7 +4491,10 @@ or_packed_domain_size (TP_DOMAIN * domain, int include_classoids)
 	case DB_TYPE_JSON:
 	  if (d->json_validator != NULL)
 	    {
-	      size += or_packed_string_length (db_json_get_schema_raw_from_validator (d->json_validator), NULL);
+	      DB_VALUE temp;
+	      db_make_string (&temp, const_cast < char *>(db_json_get_schema_raw_from_validator (d->json_validator)));
+
+	      size += (*(tp_String.data_lengthval)) (&temp, 1);
 	    }
 	  break;
 

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -4492,7 +4492,9 @@ or_packed_domain_size (TP_DOMAIN * domain, int include_classoids)
 	  if (d->json_validator != NULL)
 	    {
 	      DB_VALUE temp;
-	      db_make_string (&temp, const_cast < char *>(db_json_get_schema_raw_from_validator (d->json_validator)));
+	      // *INDENT-OFF*
+	      db_make_string (&temp, const_cast <char*>(db_json_get_schema_raw_from_validator (d->json_validator)));
+	      // *INDENT-ON*
 
 	      size += (*(tp_String.data_lengthval)) (&temp, 1);
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22659

Use mr_data_lengthval_string to compute json_validator's length to take in account extra compression data.