### PR TITLE
[CBRD-22284] Reduce object primitive header exposure

### DIFF
--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -37,6 +37,7 @@
 #include "chartype.h"
 #include "environment_variable.h"
 #include "memory_hash.h"
+#include "object_primitive.h"
 #include "util_func.h"
 #if !defined(WINDOWS)
 #include <dlfcn.h>

--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -1505,7 +1505,8 @@ extern SETOBJ *or_get_set (OR_BUF * buf, struct tp_domain *domain);
 extern int or_disk_set_size (OR_BUF * buf, struct tp_domain *domain, DB_TYPE * set_type);
 
 /* DB_VALUE functions */
-extern int or_packed_value_size (DB_VALUE * value, int collapse_null, int include_domain, int include_domain_classoids);
+extern int or_packed_value_size (const DB_VALUE * value, int collapse_null, int include_domain,
+				 int include_domain_classoids);
 
 extern int or_put_value (OR_BUF * buf, DB_VALUE * value, int collapse_null, int include_domain,
 			 int include_domain_classoids);
@@ -1514,7 +1515,7 @@ extern int or_get_value (OR_BUF * buf, DB_VALUE * value, struct tp_domain *domai
 
 extern char *or_pack_value (char *buf, DB_VALUE * value);
 extern char *or_pack_mem_value (char *ptr, DB_VALUE * value, int *packed_len_except_alignment);
-extern char *or_unpack_value (char *buf, DB_VALUE * value);
+extern char *or_unpack_value (const char *buf, DB_VALUE * value);
 extern char *or_unpack_mem_value (char *buf, DB_VALUE * value);
 
 extern int or_packed_enumeration_size (const DB_ENUMERATION * e);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -74,6 +74,7 @@
 #include "dbi.h"
 #include "dbtype.h"
 #include "memory_alloc.h"
+#include "object_primitive.h"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))

--- a/src/broker/cas_function.c
+++ b/src/broker/cas_function.c
@@ -59,6 +59,7 @@
 #include "broker_filename.h"
 #include "cas_sql_log2.h"
 #include "dbtype.h"
+#include "object_primitive.h"
 
 static FN_RETURN fn_prepare_internal (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf, T_REQ_INFO * req_info,
 				      int *ret_srv_h_id);

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -49,6 +49,7 @@
 #include "language_support.h"
 #include "system_parameter.h"
 #include "dbtype.h"
+#include "object_primitive.h"
 
 extern int set_size (DB_COLLECTION * set);
 extern int set_get_element (DB_COLLECTION * set, int index, DB_VALUE * value);

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -50,6 +50,7 @@
 #endif /* defined (SA_MODE) */
 #include "oid.h"
 #include "error_manager.h"
+#include "object_primitive.h"
 #include "object_representation.h"
 #include "log_comm.h"
 #include "log_writer.h"

--- a/src/compat/db_info.c
+++ b/src/compat/db_info.c
@@ -35,6 +35,7 @@
 #include "mem_block.hpp"
 #include "network_interface_cl.h"
 #include "object_accessor.h"
+#include "object_primitive.h"
 #include "object_print.h"
 #include "object_printer.hpp"
 #include "parser.h"

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -59,6 +59,7 @@
 #include "dbtype.h"
 #include "memory_alloc.h"
 #include "memory_private_allocator.hpp"
+#include "object_primitive.h"
 #include "query_dump.h"
 #include "string_opfunc.h"
 #include "system_parameter.h"

--- a/src/compat/db_query.h
+++ b/src/compat/db_query.h
@@ -34,7 +34,6 @@
 #include "config.h"
 
 #include "error_manager.h"
-#include "object_primitive.h"
 #include "class_object.h"
 #include "cursor.h"
 

--- a/src/compat/db_set.c
+++ b/src/compat/db_set.c
@@ -31,10 +31,11 @@
 #include <ctype.h>
 #include <string.h>
 
-#include "set_object.h"
-#include "error_manager.h"
 #include "db.h"
 #include "dbtype.h"
+#include "error_manager.h"
+#include "object_primitive.h"
+#include "set_object.h"
 
 #define ERROR_SET(error, code) \
   do {                     \

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -43,6 +43,7 @@
 #include "parser.h"
 #include "parser_message.h"
 #include "object_domain.h"
+#include "object_primitive.h"
 #include "schema_manager.h"
 #include "view_transform.h"
 #include "execute_statement.h"

--- a/src/compat/db_virt.c
+++ b/src/compat/db_virt.c
@@ -42,6 +42,7 @@
 #include "schema_manager.h"
 #include "schema_template.h"
 #include "object_accessor.h"
+#include "object_primitive.h"
 #include "set_object.h"
 #include "virtual_object.h"
 #include "parser.h"

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -39,7 +39,6 @@
 #include "object_domain.h"
 #include "language_support.h"
 #include "intl_support.h"
-#include "object_primitive.h"
 #include "memory_alloc.h"
 
 #define DB_CURRENCY_DEFAULT db_get_currency_default()

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -284,7 +284,30 @@ extern "C"
 #include "dbtype_function.i"
 
 #ifdef __cplusplus
+
+  // todo - find a better solution
+  inline void pr_share_value (DB_VALUE * src, DB_VALUE * dst)
+  {
+    if (src == NULL || dst == NULL || src == dst)
+      {
+	// do nothing
+	return;
+      }
+     *dst = *src;
+    dst->need_clear = false;
+
+    DB_TYPE type = db_value_domain_type (src);
+    if (type == DB_TYPE_STRING || type == DB_TYPE_VARNCHAR)
+      {
+	dst->data.ch.info.compressed_need_clear = false;
+      }
+
+    if ((TP_IS_SET_TYPE (type) || type == DB_TYPE_VOBJ) && !DB_IS_NULL (src))
+      {
+	src->data.set->ref_count++;
+      }
+  }
 }
 #endif
 
-#endif				/* _DBTYPE_H_ */
+#endif /* _DBTYPE_H_ */

--- a/src/compat/dbtype_function.c
+++ b/src/compat/dbtype_function.c
@@ -30,5 +30,4 @@
 #include "language_support.h"
 #include "intl_support.h"
 #include "memory_alloc.h"
-#include "object_primitive.h"
 #include "dbtype_function.i"

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -1884,7 +1884,6 @@ db_make_string_copy (DB_VALUE * value, const char *str)
 
   if (error != NO_ERROR)
     {
-      pr_clear_value (value);
       return error;
     }
 

--- a/src/executables/compactdb_cl.c
+++ b/src/executables/compactdb_cl.c
@@ -41,6 +41,7 @@
 #include "authenticate.h"
 #include "transaction_cl.h"
 #include "execute_schema.h"
+#include "object_primitive.h"
 
 #define COMPACT_MIN_PAGES 1
 #define COMPACT_MAX_PAGES 20

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -30,11 +30,11 @@
 #include <assert.h>
 
 #include "csql.h"
+#include "dbtype.h"
 #include "memory_alloc.h"
+#include "object_primitive.h"
 #include "porting.h"
 #include "transaction_cl.h"
-
-#include "dbtype.h"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))

--- a/src/executables/esql_cli.c
+++ b/src/executables/esql_cli.c
@@ -53,6 +53,7 @@
 #include "environment_variable.h"
 #include "authenticate.h"
 #include "dbtype.h"
+#include "object_primitive.h"
 
 #define UCI_OPT_UNSAFE_NULL     0x0001
 

--- a/src/executables/load_object.c
+++ b/src/executables/load_object.c
@@ -805,7 +805,7 @@ get_desc_old (OR_BUF * buf, SM_CLASS * class_, int repid, DESC_OBJ * obj, int bo
       start = buf->ptr;
       for (i = 0; i < oldrep->fixed_count && rat != NULL; i++, rat = rat->next)
 	{
-	  type = PR_TYPE_FROM_ID (rat->typeid_);
+	  type = pr_type_from_id (rat->typeid_);
 	  if (type == NULL)
 	    {
 	      goto abort_on_error;
@@ -862,7 +862,7 @@ get_desc_old (OR_BUF * buf, SM_CLASS * class_, int repid, DESC_OBJ * obj, int bo
       /* variable */
       for (i = 0; i < oldrep->variable_count && rat != NULL; i++, rat = rat->next)
 	{
-	  type = PR_TYPE_FROM_ID (rat->typeid_);
+	  type = pr_type_from_id (rat->typeid_);
 	  if (type == NULL)
 	    {
 	      goto abort_on_error;

--- a/src/executables/loader.c
+++ b/src/executables/loader.c
@@ -49,6 +49,7 @@
 #include "network.h"
 #include "authenticate.h"
 #include "schema_manager.h"
+#include "object_primitive.h"
 #include "object_accessor.h"
 #include "db.h"
 #include "loader_object_table.h"

--- a/src/executables/unload_object.c
+++ b/src/executables/unload_object.c
@@ -52,6 +52,7 @@
 #include "locator.h"
 #include "transform_cl.h"
 #include "object_accessor.h"
+#include "object_primitive.h"
 #include "set_object.h"
 
 #include "message_catalog.h"

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -2776,7 +2776,7 @@ emit_domain_def (DB_DOMAIN * domains)
   for (domain = domains; domain != NULL; domain = db_domain_next (domain))
     {
       type = TP_DOMAIN_TYPE (domain);
-      prtype = PR_TYPE_FROM_ID (type);
+      prtype = pr_type_from_id (type);
       if (prtype == NULL)
 	{
 	  continue;

--- a/src/jsp/jsp_cl.c
+++ b/src/jsp/jsp_cl.c
@@ -46,6 +46,7 @@
 #include "dbtype.h"
 #include "parser.h"
 #include "object_domain.h"
+#include "object_primitive.h"
 #include "db.h"
 #include "object_accessor.h"
 #include "set_object.h"

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4257,7 +4257,7 @@ classobj_domain_size (TP_DOMAIN * domain)
  */
 
 SM_ATTRIBUTE *
-classobj_make_attribute (const char *name, PR_TYPE * type, SM_NAME_SPACE name_space)
+classobj_make_attribute (const char *name, struct pr_type * type, SM_NAME_SPACE name_space)
 {
   SM_ATTRIBUTE *att;
 

--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -34,9 +34,11 @@
 
 #include "object_domain.h"
 #include "work_space.h"
-#include "object_primitive.h"
 #include "storage_common.h"
 #include "statistics.h"
+
+// forward definitions
+struct pr_type;
 
 /*
  *    This macro should be used whenever comparisons need to be made
@@ -439,7 +441,7 @@ struct sm_attribute
 {
   SM_COMPONENT header;		/* next, name, header */
 
-  PR_TYPE *type;		/* basic type */
+  struct pr_type *type;		/* basic type */
   TP_DOMAIN *domain;		/* allowable types */
 
   MOP class_mop;		/* origin class */
@@ -554,7 +556,7 @@ struct sm_method_argument
 {
   struct sm_method_argument *next;
 
-  PR_TYPE *type;		/* basic type */
+  struct pr_type *type;		/* basic type */
   TP_DOMAIN *domain;		/* full domain */
   int index;			/* argument index (one based) */
 };
@@ -991,7 +993,7 @@ extern int classobj_populate_class_properties (DB_SET ** properties, SM_CLASS_CO
 extern bool classobj_class_has_indexes (SM_CLASS * class_);
 
 /* Attribute */
-extern SM_ATTRIBUTE *classobj_make_attribute (const char *name, PR_TYPE * type, SM_NAME_SPACE name_space);
+extern SM_ATTRIBUTE *classobj_make_attribute (const char *name, struct pr_type *type, SM_NAME_SPACE name_space);
 extern SM_ATTRIBUTE *classobj_copy_attribute (SM_ATTRIBUTE * src, const char *alias);
 extern int classobj_copy_attlist (SM_ATTRIBUTE * attlist, MOP filter_class, int ordered, SM_ATTRIBUTE ** copy_ptr);
 

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -3151,7 +3151,7 @@ tp_domain_resolve_default_w_coll (DB_TYPE type, int coll_id, TP_DOMAIN_COLL_ACTI
  *    dbuf(out): if not NULL, founded domain initialized on dbuf
  */
 TP_DOMAIN *
-tp_domain_resolve_value (DB_VALUE * val, TP_DOMAIN * dbuf)
+tp_domain_resolve_value (const DB_VALUE * val, TP_DOMAIN * dbuf)
 {
   TP_DOMAIN *domain;
   DB_TYPE value_type;
@@ -3299,7 +3299,7 @@ tp_domain_resolve_value (DB_VALUE * val, TP_DOMAIN * dbuf)
 
 	  /*
 	   * Convert references to the "floating" precisions to actual
-	   * precisions.  This may not be necessary or desireable?
+	   * precisions. This may not be necessary or desirable?
 	   * Zero seems to pop up occasionally in DB_VALUE precisions, until
 	   * this is fixed, treat it as the floater for the variable width
 	   * types.

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -985,7 +985,7 @@ domain_init (TP_DOMAIN * domain, DB_TYPE type_id)
 
   domain->next = NULL;
   domain->next_list = NULL;
-  domain->type = PR_TYPE_FROM_ID (type_id);
+  domain->type = pr_type_from_id (type_id);
   domain->precision = 0;
   domain->scale = 0;
   domain->class_mop = NULL;
@@ -10794,7 +10794,7 @@ tp_value_compare_with_error (const DB_VALUE * value1, const DB_VALUE * value2, i
 	{
 	  PR_TYPE *pr_type;
 
-	  pr_type = PR_TYPE_FROM_ID (vtype1);
+	  pr_type = pr_type_from_id (vtype1);
 	  assert (pr_type != NULL);
 
 	  if (pr_type)

--- a/src/object/object_domain.h
+++ b/src/object/object_domain.h
@@ -443,7 +443,7 @@ extern "C"
   TP_DOMAIN *tp_domain_find_object (DB_TYPE type, OID * class_oid, struct db_object *class_, bool is_desc);
   TP_DOMAIN *tp_domain_find_set (DB_TYPE type, TP_DOMAIN * setdomain, bool is_desc);
   TP_DOMAIN *tp_domain_find_enumeration (const DB_ENUMERATION * enumeration, bool is_desc);
-  TP_DOMAIN *tp_domain_resolve_value (DB_VALUE * val, TP_DOMAIN * dbuf);
+  TP_DOMAIN *tp_domain_resolve_value (const DB_VALUE * val, TP_DOMAIN * dbuf);
 #if defined(ENABLE_UNUSED_FUNCTION)
   TP_DOMAIN *tp_create_domain_resolve_value (DB_VALUE * val, TP_DOMAIN * domain);
 #endif				/* ENABLE_UNUSED_FUNCTION */

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2172,7 +2172,7 @@ pr_clone_value (const DB_VALUE * src, DB_VALUE * dest)
 	    }
 	  else if (src != dest)
 	    {
-	      type = PR_TYPE_FROM_ID (src_dbtype);
+	      type = pr_type_from_id (src_dbtype);
 	      if (type != NULL)
 		{
 		  /*
@@ -8748,7 +8748,7 @@ pr_type_name (DB_TYPE id)
   const char *name = NULL;
   PR_TYPE *type;
 
-  type = PR_TYPE_FROM_ID (id);
+  type = pr_type_from_id (id);
 
   if (type != NULL)
     {
@@ -8822,7 +8822,7 @@ pr_is_variable_type (DB_TYPE id)
   PR_TYPE *type;
   int is_variable = 0;
 
-  type = PR_TYPE_FROM_ID (id);
+  type = pr_type_from_id (id);
   if (type != NULL)
     {
       is_variable = type->variable_p;
@@ -9022,7 +9022,7 @@ pr_value_mem_size (DB_VALUE * value)
 
   size = 0;
   dbval_type = DB_VALUE_DOMAIN_TYPE (value);
-  type = PR_TYPE_FROM_ID (dbval_type);
+  type = pr_type_from_id (dbval_type);
   if (type != NULL)
     {
       if (type->data_lengthval != NULL)
@@ -9735,7 +9735,7 @@ pr_data_writeval_disk_size (DB_VALUE * value)
   DB_TYPE dbval_type;
 
   dbval_type = DB_VALUE_DOMAIN_TYPE (value);
-  type = PR_TYPE_FROM_ID (dbval_type);
+  type = pr_type_from_id (dbval_type);
 
   assert (type != NULL);
 
@@ -9768,7 +9768,7 @@ pr_index_writeval_disk_size (DB_VALUE * value)
   DB_TYPE dbval_type;
 
   dbval_type = DB_VALUE_DOMAIN_TYPE (value);
-  type = PR_TYPE_FROM_ID (dbval_type);
+  type = pr_type_from_id (dbval_type);
 
   assert (type != NULL);
 
@@ -9796,7 +9796,7 @@ pr_data_writeval (struct or_buf *buf, DB_VALUE * value)
   DB_TYPE dbval_type;
 
   dbval_type = DB_VALUE_DOMAIN_TYPE (value);
-  type = PR_TYPE_FROM_ID (dbval_type);
+  type = pr_type_from_id (dbval_type);
   if (type == NULL)
     {
       type = tp_Type_null;	/* handle strange arguments with NULL */
@@ -9864,7 +9864,7 @@ pr_valstring (THREAD_ENTRY * threade, DB_VALUE * val)
     }
 
   DB_TYPE dbval_type = DB_VALUE_DOMAIN_TYPE (val);
-  PR_TYPE *pr_type = PR_TYPE_FROM_ID (dbval_type);
+  PR_TYPE *pr_type = pr_type_from_id (dbval_type);
 
   if (pr_type == NULL)
     {

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -9808,28 +9808,6 @@ pr_data_writeval (struct or_buf *buf, DB_VALUE * value)
  * MISCELLANEOUS TYPE-RELATED HELPER FUNCTIONS
  */
 
-void
-pr_share_value (DB_VALUE * src, DB_VALUE * dst)
-{
-  if (src == NULL || dst == NULL || src == dst)
-    {
-      // do nothing
-      return;
-    }
-  *dst = *src;
-  dst->need_clear = false;
-
-  if (db_value_domain_type (src) == DB_TYPE_STRING || db_value_domain_type (src) == DB_TYPE_VARNCHAR)
-    {
-      dst->data.ch.info.compressed_need_clear = false;
-    }
-
-  if (pr_is_set_type (DB_VALUE_DOMAIN_TYPE (src)) && !DB_IS_NULL (src))
-    {
-      src->data.set->ref_count++;
-    }
-}
-
 #if defined (SERVER_MODE) || defined (SA_MODE)
 /*
  * pr_valstring - Take the value and formats it using the sptrfunc member of

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -34,18 +34,20 @@
 
 #include "object_primitive.h"
 
+#include "db_json.hpp"
+#include "elo.h"
+#include "error_manager.h"
+#include "file_io.h"
 #include "mem_block.hpp"
 #include "object_domain.h"
-#include "string_buffer.hpp"
-
-#include "system_parameter.h"
-#include "set_object.h"
-#include "elo.h"
 #include "object_print.h"
+#include "object_representation.h"
+#include "set_object.h"
+#include "string_buffer.hpp"
 #include "string_opfunc.h"
+#include "system_parameter.h"
 #include "tz_support.h"
-#include "file_io.h"
-#include "db_json.hpp"
+
 #include <utility>
 
 #if !defined (SERVER_MODE)
@@ -9618,7 +9620,7 @@ pr_midxkey_init_boundbits (char *bufptr, int n_atts)
  */
 
 int
-pr_midxkey_add_elements (DB_VALUE * keyval, DB_VALUE * dbvals, int num_dbvals, TP_DOMAIN * dbvals_domain_list)
+pr_midxkey_add_elements (DB_VALUE * keyval, DB_VALUE * dbvals, int num_dbvals, struct tp_domain *dbvals_domain_list)
 {
   int i;
   TP_DOMAIN *dom;
@@ -9788,7 +9790,7 @@ pr_index_writeval_disk_size (DB_VALUE * value)
 }
 
 void
-pr_data_writeval (OR_BUF * buf, DB_VALUE * value)
+pr_data_writeval (struct or_buf *buf, DB_VALUE * value)
 {
   PR_TYPE *type;
   DB_TYPE dbval_type;
@@ -9882,7 +9884,7 @@ pr_valstring (THREAD_ENTRY * threade, DB_VALUE * val)
  *    domain(in): enumeration domain against which the value is checked.
  */
 int
-pr_complete_enum_value (DB_VALUE * value, TP_DOMAIN * domain)
+pr_complete_enum_value (DB_VALUE * value, struct tp_domain *domain)
 {
   unsigned short short_val;
   char *str_val;
@@ -15866,7 +15868,7 @@ mr_cmpval_enumeration (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, in
  * decompressed_size(in)			  : The uncompressed data size.
  */
 int
-pr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int compressed_size, int decompressed_size)
+pr_get_compressed_data_from_buffer (struct or_buf *buf, char *data, int compressed_size, int decompressed_size)
 {
   int rc = NO_ERROR;
 
@@ -16001,7 +16003,7 @@ cleanup:
  *	to the write of the DB_VALUE in the buffer.
  */
 int
-pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value, int *val_size, int align)
+pr_get_size_and_write_string_to_buffer (struct or_buf *buf, char *val_p, DB_VALUE * value, int *val_size, int align)
 {
   char *compressed_string = NULL, *string = NULL, *str = NULL;
   int rc = NO_ERROR, str_length = 0, length = 0;

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -27,8 +27,7 @@
 
 #ident "$Id$"
 
-#include "error_manager.h"
-#include "object_representation.h"
+#include "dbtype_def.h"
 #include "thread_compat.hpp"
 
 #include <stdio.h>
@@ -37,6 +36,7 @@
 // forward definitions
 class string_buffer;
 struct tp_domain;
+struct or_buf;
 
 /*
  * PR_TYPE
@@ -71,23 +71,23 @@ typedef struct pr_type
   /* return DB_VALUE size */
   int (*data_lengthval) (DB_VALUE * value, int disk);
   /* write disk rep from memory */
-  void (*data_writemem) (OR_BUF * buf, void *memptr, struct tp_domain * domain);
+  void (*data_writemem) (struct or_buf * buf, void *memptr, struct tp_domain * domain);
   /* read disk rep to memory */
-  void (*data_readmem) (OR_BUF * buf, void *memptr, struct tp_domain * domain, int size);
+  void (*data_readmem) (struct or_buf * buf, void *memptr, struct tp_domain * domain, int size);
   /* write disk rep from DB_VALUE */
-  int (*data_writeval) (OR_BUF * buf, DB_VALUE * value);
+  int (*data_writeval) (struct or_buf * buf, DB_VALUE * value);
   /* read disk rep to DB_VALUE */
-  int (*data_readval) (OR_BUF * buf, DB_VALUE * value, struct tp_domain * domain, int size, bool copy, char *copy_buf,
-		       int copy_buf_len);
+  int (*data_readval) (struct or_buf * buf, DB_VALUE * value, struct tp_domain * domain, int size, bool copy,
+		       char *copy_buf, int copy_buf_len);
   /* btree memory size */
   int (*index_lengthmem) (void *memptr, struct tp_domain * domain);
   /* return DB_VALUE size */
   int (*index_lengthval) (DB_VALUE * value);
   /* write btree rep from DB_VALUE */
-  int (*index_writeval) (OR_BUF * buf, DB_VALUE * value);
+  int (*index_writeval) (struct or_buf * buf, DB_VALUE * value);
   /* read btree rep to DB_VALUE */
-  int (*index_readval) (OR_BUF * buf, DB_VALUE * value, struct tp_domain * domain, int size, bool copy, char *copy_buf,
-			int copy_buf_len);
+  int (*index_readval) (struct or_buf * buf, DB_VALUE * value, struct tp_domain * domain, int size, bool copy,
+			char *copy_buf, int copy_buf_len);
   /* btree value compare */
     DB_VALUE_COMPARE_RESULT (*index_cmpdisk) (void *memptr1, void *memptr2, struct tp_domain * domain, int do_coercion,
 					      int total_order, int *start_colp);
@@ -306,7 +306,7 @@ extern int pr_midxkey_add_elements (DB_VALUE * keyval, DB_VALUE * dbvals, int nu
 extern int pr_midxkey_init_boundbits (char *bufptr, int n_atts);
 extern int pr_index_writeval_disk_size (DB_VALUE * value);
 extern int pr_data_writeval_disk_size (DB_VALUE * value);
-extern void pr_data_writeval (OR_BUF * buf, DB_VALUE * value);
+extern void pr_data_writeval (struct or_buf *buf, DB_VALUE * value);
 extern int pr_midxkey_unique_prefix (const DB_VALUE * db_midxkey1, const DB_VALUE * db_midxkey2, DB_VALUE * db_result);
 extern int pr_midxkey_get_element_offset (const DB_MIDXKEY * midxkey, int index);
 extern int pr_midxkey_add_prefix (DB_VALUE * result, DB_VALUE * prefix, DB_VALUE * postfix, int n_prefix);
@@ -326,9 +326,10 @@ extern void pr_area_final (void);
 
 extern int pr_complete_enum_value (DB_VALUE * value, struct tp_domain *domain);
 extern int pr_get_compression_length (const char *string, int charlen);
-extern int pr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int compressed_size, int decompressed_size);
-extern int pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value,
-						   int *val_size, int align);
+extern int pr_get_compressed_data_from_buffer (struct or_buf *buf, char *data, int compressed_size,
+					       int decompressed_size);
+extern int pr_get_size_and_write_string_to_buffer (struct or_buf *buf, char *val_p, DB_VALUE * value, int *val_size,
+						   int align);
 
 extern int pr_data_compress_string (char *string, int str_length, char *compressed_string, int *compressed_length);
 extern int pr_clear_compressed_string (DB_VALUE * value);

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -279,7 +279,6 @@ extern int pr_value_mem_size (DB_VALUE * value);
 extern DB_VALUE *pr_make_value (void);
 extern DB_VALUE *pr_copy_value (DB_VALUE * var);
 extern int pr_clone_value (const DB_VALUE * src, DB_VALUE * dest);
-extern void pr_share_value (DB_VALUE * src, DB_VALUE * dst);
 extern int pr_clear_value (DB_VALUE * var);
 /* *INDENT-OFF* */
 void pr_clear_value_vector (std::vector<DB_VALUE> &value_vector);

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -27,21 +27,16 @@
 
 #ident "$Id$"
 
-#include "config.h"
-
-#include <stdio.h>
 #include "error_manager.h"
 #include "object_representation.h"
-#include "object_domain.h"
-#if !defined (SERVER_MODE)
-#include "work_space.h"
-#endif
 #include "thread_compat.hpp"
 
-#ifdef __cplusplus
+#include <stdio.h>
 #include <vector>
+
+// forward definitions
 class string_buffer;
-#endif
+struct tp_domain;
 
 /*
  * PR_TYPE
@@ -60,11 +55,7 @@ typedef struct pr_type
   /* print dbvalue to file */
   void (*fptrfunc) (THREAD_ENTRY * thread_p, FILE * fp, const DB_VALUE * value);
   /* print dbvalue to buffer */
-#ifdef __cplusplus
   void (*sptrfunc) (const DB_VALUE * value, string_buffer & sb);
-#else
-  void *sptrfunc;
-#endif
 
   /* initialize memory */
   void (*initmem) (void *memptr, struct tp_domain * domain);
@@ -114,8 +105,6 @@ typedef struct pr_type
 /*
  * PRIMITIVE TYPE STRUCTURES
  */
-/* The number of following types */
-#define PR_TYPE_TOTAL 32
 
 extern PR_TYPE tp_Null;
 extern PR_TYPE tp_Integer;
@@ -195,12 +184,6 @@ extern PR_TYPE *tp_Type_datetime;
 extern PR_TYPE *tp_Type_json;
 
 extern PR_TYPE *tp_Type_id_map[];
-
-/* The sizes of the primitive types in descending order */
-extern int pr_ordered_mem_sizes[PR_TYPE_TOTAL];
-
-/* The number of items in pr_ordered_mem_sizes */
-extern int pr_ordered_mem_size_total;
 
 
 /* PRIMITIVE TYPE MACROS
@@ -298,57 +281,12 @@ extern int pr_value_mem_size (DB_VALUE * value);
 
 extern DB_VALUE *pr_make_value (void);
 extern DB_VALUE *pr_copy_value (DB_VALUE * var);
-
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
-  extern int pr_clone_value (const DB_VALUE * src, DB_VALUE * dest);
-
-#ifdef __cplusplus
-}
-#endif
-
-#if defined(ENABLE_UNUSED_FUNCTION)
-extern int pr_share_value (DB_VALUE * src, DB_VALUE * dest);
-#endif
-#define PR_SHARE_VALUE(src, dst) \
-  do \
-    { \
-      if (((DB_VALUE *) (src) != NULL) && ((DB_VALUE *) (dst) != NULL) && src != dst) \
-	{ \
-	  *(dst) = *(src); \
-	  (dst)->need_clear = false; \
-	  if (db_value_domain_type (src) == DB_TYPE_STRING || db_value_domain_type (src) == DB_TYPE_VARNCHAR) \
-	    { \
-	      (dst)->data.ch.info.compressed_need_clear = false; \
-	    } \
-	  if (pr_is_set_type (DB_VALUE_DOMAIN_TYPE(src)) \
-	      && !DB_IS_NULL(src)) \
-	    { \
-	      (src)->data.set->ref_count++; \
-	    } \
-	} \
-    } \
-  while (0)
-
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
-  extern int pr_clear_value (DB_VALUE * var);
-
-#if defined __cplusplus
-  /* *INDENT-OFF* */
-  void pr_clear_value_vector (std::vector<DB_VALUE> &value_vector);
-  /* *INDENT-ON* */
-#endif
-
-#ifdef __cplusplus
-}
-#endif
+extern int pr_clone_value (const DB_VALUE * src, DB_VALUE * dest);
+extern void pr_share_value (DB_VALUE * src, DB_VALUE * dst);
+extern int pr_clear_value (DB_VALUE * var);
+/* *INDENT-OFF* */
+void pr_clear_value_vector (std::vector<DB_VALUE> &value_vector);
+/* *INDENT-ON* */
 
 extern int pr_free_value (DB_VALUE * var);
 extern DB_VALUE *pr_make_ext_value (void);
@@ -364,7 +302,7 @@ extern int pr_midxkey_element_disk_size (char *mem, DB_DOMAIN * domain);
 extern int pr_midxkey_get_element_nocopy (const DB_MIDXKEY * midxkey, int index, DB_VALUE * value, int *prev_indexp,
 					  char **prev_ptrp);
 extern int pr_midxkey_add_elements (DB_VALUE * keyval, DB_VALUE * dbvals, int num_dbvals,
-				    TP_DOMAIN * dbvals_domain_list);
+				    struct tp_domain *dbvals_domain_list);
 extern int pr_midxkey_init_boundbits (char *bufptr, int n_atts);
 extern int pr_index_writeval_disk_size (DB_VALUE * value);
 extern int pr_data_writeval_disk_size (DB_VALUE * value);
@@ -377,15 +315,6 @@ extern int pr_midxkey_common_prefix (DB_VALUE * key1, DB_VALUE * key2);
 
 extern int pr_Inhibit_oid_promotion;
 
-#if !defined (SERVER_MODE)
-extern void pr_write_mop (OR_BUF * buf, MOP mop);
-#endif
-#if defined (ENABLE_UNUSED_FUNCTION)
-/* Utility functions */
-extern char *pr_copy_string (const char *str);
-extern void pr_free_string (char *str);
-#endif
-
 #if defined (SERVER_MODE) || defined (SA_MODE)
 /* Helper function for DB_VALUE printing; caller must free_and_init result. */
 extern char *pr_valstring (THREAD_ENTRY *, DB_VALUE *);
@@ -395,7 +324,7 @@ extern char *pr_valstring (THREAD_ENTRY *, DB_VALUE *);
 extern int pr_area_init (void);
 extern void pr_area_final (void);
 
-extern int pr_complete_enum_value (DB_VALUE * value, TP_DOMAIN * domain);
+extern int pr_complete_enum_value (DB_VALUE * value, struct tp_domain *domain);
 extern int pr_get_compression_length (const char *string, int charlen);
 extern int pr_get_compressed_data_from_buffer (OR_BUF * buf, char *data, int compressed_size, int decompressed_size);
 extern int pr_get_size_and_write_string_to_buffer (OR_BUF * buf, char *val_p, DB_VALUE * value,

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -256,9 +256,6 @@ extern PR_TYPE *tp_Type_id_map[];
  */
 
 /* Type structure accessors */
-#define PR_TYPE_FROM_ID(type) ((type) <= DB_TYPE_LAST && (type) != DB_TYPE_TABLE \
-                               ? tp_Type_id_map[(int)(type)] : NULL)
-
 extern PR_TYPE *pr_type_from_id (DB_TYPE id);
 extern PR_TYPE *pr_find_type (const char *name);
 extern const char *pr_type_name (DB_TYPE id);

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -30,6 +30,7 @@
 #include "dbtype.h"
 #include "misc_string.h"
 #include "object_domain.h"
+#include "object_primitive.h"
 #include "object_print_util.hpp"
 #include "parse_tree.h"
 #include "schema_manager.h"

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -6622,7 +6622,7 @@ or_packed_value_size (const DB_VALUE * value, int collapse_null, int include_dom
     }
 
   dbval_type = DB_VALUE_DOMAIN_TYPE (value);
-  type = PR_TYPE_FROM_ID (dbval_type);
+  type = pr_type_from_id (dbval_type);
 
   if (type == NULL)
     {
@@ -6712,7 +6712,7 @@ or_put_value (OR_BUF * buf, DB_VALUE * value, int collapse_null, int include_dom
     }
 
   dbval_type = DB_VALUE_DOMAIN_TYPE (value);
-  type = PR_TYPE_FROM_ID (dbval_type);
+  type = pr_type_from_id (dbval_type);
 
   if (type == NULL)
     {
@@ -6971,7 +6971,7 @@ or_pack_mem_value (char *ptr, DB_VALUE * value, int *packed_len_except_alignment
   ptr_to_packed_value = buf->ptr;
 
   dbval_type = DB_VALUE_DOMAIN_TYPE (value);
-  type = PR_TYPE_FROM_ID (dbval_type);
+  type = pr_type_from_id (dbval_type);
   if (type == NULL)
     {
       return NULL;

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -6609,7 +6609,7 @@ or_disk_set_size (OR_BUF * buf, TP_DOMAIN * set_domain, DB_TYPE * set_type)
  *    include_domain_classoids(in): non-zero to include the domain class OIDs
  */
 int
-or_packed_value_size (DB_VALUE * value, int collapse_null, int include_domain, int include_domain_classoids)
+or_packed_value_size (const DB_VALUE * value, int collapse_null, int include_domain, int include_domain_classoids)
 {
   PR_TYPE *type;
   TP_DOMAIN *domain;
@@ -6667,7 +6667,9 @@ or_packed_value_size (DB_VALUE * value, int collapse_null, int include_domain, i
 	}
       else
 	{
-	  size += (*(type->data_lengthval)) (value, 1);
+	  // todo - adding const to data_lengthval is a complicated story due to string compression
+	  // for now, just strip const from value
+	  size += (*(type->data_lengthval)) (CONST_CAST (DB_VALUE *, value), 1);
 	}
     }
 
@@ -7040,12 +7042,12 @@ or_pack_mem_value (char *ptr, DB_VALUE * value, int *packed_len_except_alignment
  *    details.
  */
 char *
-or_unpack_value (char *buf, DB_VALUE * value)
+or_unpack_value (const char *buf, DB_VALUE * value)
 {
   OR_BUF orbuf;
 
   buf = PTR_ALIGN (buf, MAX_ALIGNMENT);
-  or_init (&orbuf, buf, 0);
+  or_init (&orbuf, CONST_CAST (char *, buf) /* it is for read */ , 0);
   or_get_value (&orbuf, value, NULL, -1, true);
 
   return orbuf.ptr;

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5208,7 +5208,7 @@ sm_type_name (DB_TYPE id)
 {
   PR_TYPE *type;
 
-  type = PR_TYPE_FROM_ID (id);
+  type = pr_type_from_id (id);
   if (type != NULL)
     {
       return type->name;

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -1184,7 +1184,7 @@ get_old (OR_BUF * buf, SM_CLASS * class_, MOBJ * obj_ptr, int repid, int bound_b
 	  start = buf->ptr;
 	  for (i = 0; i < oldrep->fixed_count && rat != NULL && attmap != NULL; i++, rat = rat->next)
 	    {
-	      type = PR_TYPE_FROM_ID (rat->typeid_);
+	      type = pr_type_from_id (rat->typeid_);
 	      if (type == NULL)
 		{
 		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TF_INVALID_REPRESENTATION, 1,
@@ -1251,7 +1251,7 @@ get_old (OR_BUF * buf, SM_CLASS * class_, MOBJ * obj_ptr, int repid, int bound_b
 	    {
 	      for (i = 0; i < oldrep->variable_count && rat != NULL && attmap != NULL; i++, rat = rat->next)
 		{
-		  type = PR_TYPE_FROM_ID (rat->typeid_);
+		  type = pr_type_from_id (rat->typeid_);
 		  if (type == NULL)
 		    {
 		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TF_INVALID_REPRESENTATION, 1,
@@ -2349,7 +2349,7 @@ disk_to_metharg (OR_BUF * buf)
 	}
       else
 	{
-	  arg->type = PR_TYPE_FROM_ID (argtype);
+	  arg->type = pr_type_from_id (argtype);
 	}
       arg->index = or_get_int (buf, &rc);
       arg->domain =
@@ -3005,7 +3005,7 @@ disk_to_attribute (OR_BUF * buf, SM_ATTRIBUTE * att)
 
       att->id = or_get_int (buf, &rc);
       dbval_type = (DB_TYPE) or_get_int (buf, &rc);
-      att->type = PR_TYPE_FROM_ID (dbval_type);
+      att->type = pr_type_from_id (dbval_type);
       att->offset = or_get_int (buf, &rc);
       att->offset = 0;		/* calculated later */
       att->order = or_get_int (buf, &rc);

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -205,6 +205,7 @@ static int tf_attribute_default_expr_to_property (SM_ATTRIBUTE * attr_list);
 static int partition_info_to_disk (OR_BUF * buf, SM_PARTITION * partition_info);
 static SM_PARTITION *disk_to_partition_info (OR_BUF * buf);
 static int partition_info_size (SM_PARTITION * partition_info);
+static void or_pack_mop (OR_BUF * buf, MOP mop);
 
 #if defined(ENABLE_UNUSED_FUNCTION)
 /*
@@ -1629,7 +1630,29 @@ object_set_size (DB_OBJLIST * list)
 }
 
 /*
- * put_object_set - Translates a list objects into the disk represenataion of a
+ * or_pack_mop - write an OID to a disk representation buffer given a MOP
+ * instead of a WS_MEMOID.
+ *    return:
+ *    buf(): transformer buffer
+ *    mop(): mop to transform
+ * Note:
+ *    mr_write_object can't be used because it takes a WS_MEMOID as is the
+ *    case for object references in instances.
+ *    This must stay in sync with mr_write_object above !
+ */
+static void
+or_pack_mop (OR_BUF * buf, MOP mop)
+{
+  DB_VALUE value;
+
+  tp_Object.initval (&value, 0, 0);
+  db_make_object (&value, mop);
+  tp_Object.data_writeval (buf, &value);
+  tp_Object.setval (&value, NULL, false);
+}
+
+/*
+ * put_object_set - Translates a list objects into the disk representation of a
  * sequence of objects
  *    return: on overflow, or_overflow will call longjmp and jump to the outer
  *            caller
@@ -1667,14 +1690,14 @@ put_object_set (OR_BUF * buf, DB_OBJLIST * list)
   or_put_int (buf, OR_INT_SIZE);	/* size of the domain */
   or_put_domain (buf, &tp_Object_domain, 0, 0);	/* actual domain */
 
-  /* should be using something other than pr_write_mop here ! */
+  /* should be using something other than or_pack_mop here ! */
   for (l = list; l != NULL; l = l->next)
     {
       if (WS_IS_DELETED (l->op))
 	{
 	  continue;
 	}
-      pr_write_mop (buf, l->op);
+      or_pack_mop (buf, l->op);
     }
 
   return NO_ERROR;
@@ -2074,7 +2097,7 @@ domain_to_disk (OR_BUF * buf, TP_DOMAIN * domain)
   or_put_int (buf, domain->scale);
   or_put_int (buf, domain->codeset);
   or_put_int (buf, domain->collation_id);
-  pr_write_mop (buf, domain->class_mop);
+  or_pack_mop (buf, domain->class_mop);
 
   put_substructure_set (buf, (DB_LIST *) domain->setdomain, (LWRITER) domain_to_disk, &tf_Metaclass_domain.mc_classoid,
 			tf_Metaclass_domain.mc_repid);
@@ -2515,7 +2538,7 @@ method_to_disk (OR_BUF * buf, SM_METHOD * method)
 
   /* ATTRIBUTES */
   /* source class oid */
-  pr_write_mop (buf, method->class_mop);
+  or_pack_mop (buf, method->class_mop);
   or_put_int (buf, method->id);
 
   /* name */
@@ -2634,7 +2657,7 @@ methfile_to_disk (OR_BUF * buf, SM_METHOD_FILE * file)
   /* ATTRIBUTES */
 
   /* class */
-  pr_write_mop (buf, file->class_mop);
+  or_pack_mop (buf, file->class_mop);
 
   /* name */
   put_string (buf, file->name);
@@ -2865,7 +2888,7 @@ attribute_to_disk (OR_BUF * buf, SM_ATTRIBUTE * att)
   or_put_int (buf, (int) att->type->id);
   or_put_int (buf, 0);		/* memory offsets are now calculated after loading */
   or_put_int (buf, att->order);
-  pr_write_mop (buf, att->class_mop);
+  or_pack_mop (buf, att->class_mop);
   or_put_int (buf, att->flags);
 
   /* index BTID */
@@ -3143,7 +3166,7 @@ resolution_to_disk (OR_BUF * buf, SM_RESOLUTION * res)
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
-  pr_write_mop (buf, res->class_mop);
+  or_pack_mop (buf, res->class_mop);
   name_space = (int) res->name_space;	/* kludge for ansi */
   or_put_int (buf, name_space);
   put_string (buf, res->name);
@@ -3623,7 +3646,7 @@ put_class_attributes (OR_BUF * buf, SM_CLASS * class_)
   or_put_int (buf, (int) class_->class_type);
 
   /* owner object */
-  pr_write_mop (buf, class_->owner);
+  or_pack_mop (buf, class_->owner);
   or_put_int (buf, (int) class_->collation_id);
 
 

--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -36,6 +36,7 @@
 #include "work_space.h"
 #include "schema_manager.h"
 #include "object_accessor.h"
+#include "object_primitive.h"
 #include "object_print.h"
 #include "set_object.h"
 #include "authenticate.h"

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -32,6 +32,7 @@
 #include "virtual_object.h"
 #include "set_object.h"
 #include "object_accessor.h"
+#include "object_primitive.h"
 #include "db.h"
 #include "schema_manager.h"
 #include "view_transform.h"

--- a/src/optimizer/plan_generation.c
+++ b/src/optimizer/plan_generation.c
@@ -32,6 +32,7 @@
 #include "parser.h"
 #include "xasl_generation.h"
 
+#include "object_primitive.h"
 #include "optimizer.h"
 #include "query_graph.h"
 #include "query_planner.h"

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -39,6 +39,7 @@
 #include "parser.h"
 #include "error_code.h"
 #include "error_manager.h"
+#include "object_primitive.h"
 #include "object_representation.h"
 #include "optimizer.h"
 #include "query_graph.h"

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -35,6 +35,7 @@
 #include "jansson.h"
 
 #include "parser.h"
+#include "object_primitive.h"
 #include "optimizer.h"
 #include "query_planner.h"
 #include "query_graph.h"

--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -36,6 +36,7 @@
 #include "execute_schema.h"
 #include "view_transform.h"
 #include "parser.h"
+#include "object_primitive.h"
 
 #include "dbtype.h"
 

--- a/src/parser/func_type.cpp
+++ b/src/parser/func_type.cpp
@@ -23,6 +23,7 @@
 
 #include "func_type.hpp"
 #include "message_catalog.h"
+#include "object_primitive.h"
 #include "parse_tree.h"
 #include "parser.h"
 #include "parser_message.h"

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -35,6 +35,7 @@
 #include "semantic_check.h"
 #include "dbtype.h"
 #include "object_domain.h"
+#include "object_primitive.h"
 #include "memory_alloc.h"
 #include "intl_support.h"
 #include "memory_hash.h"

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -45,6 +45,7 @@
 #include "set_object.h"
 #include "intl_support.h"
 #include "virtual_object.h"
+#include "object_primitive.h"
 #include "object_template.h"
 #include "db_json.hpp"
 

--- a/src/parser/parse_evaluate.c
+++ b/src/parser/parse_evaluate.c
@@ -37,6 +37,7 @@
 #include "parser_message.h"
 #include "execute_statement.h"
 #include "object_domain.h"
+#include "object_primitive.h"
 #include "object_template.h"
 #include "work_space.h"
 #include "virtual_object.h"

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -5197,7 +5197,7 @@ regu_domain_init (SM_DOMAIN * ptr)
 {
   ptr->next = NULL;
   ptr->next_list = NULL;
-  ptr->type = PR_TYPE_FROM_ID (DB_TYPE_INTEGER);
+  ptr->type = pr_type_from_id (DB_TYPE_INTEGER);
   ptr->precision = 0;
   ptr->scale = 0;
   ptr->class_mop = NULL;

--- a/src/parser/query_result.c
+++ b/src/parser/query_result.c
@@ -70,7 +70,7 @@ pt_find_size_from_dbtype (const DB_TYPE db_type)
 
   if (db_type != DB_TYPE_NULL)
     {
-      type = PR_TYPE_FROM_ID (db_type);
+      type = pr_type_from_id (db_type);
       if (type && !(type->variable_p))
 	{
 	  size = pr_mem_size (type);
@@ -187,7 +187,7 @@ pt_set_domain_class (SM_DOMAIN * dom, const PT_NODE * nam, const DB_OBJECT * vir
   if (!dom || !nam || nam->node_type != PT_NAME)
     return;
 
-  dom->type = PR_TYPE_FROM_ID (DB_TYPE_OBJECT);
+  dom->type = pr_type_from_id (DB_TYPE_OBJECT);
   if (virt != NULL)
     {
       dom->class_mop = (DB_OBJECT *) virt;
@@ -257,7 +257,7 @@ pt_get_src_domain (PARSER_CONTEXT * parser, const PT_NODE * s, const PT_NODE * s
     }
 
   /* if s is not a path expression then its source domain is DB_TYPE_NULL */
-  result->type = PR_TYPE_FROM_ID (DB_TYPE_NULL);
+  result->type = pr_type_from_id (DB_TYPE_NULL);
 
   /* make leaf point to the last leaf name node */
   if (s->node_type == PT_DOT_)

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -43,6 +43,7 @@
 #include "show_meta.h"
 #include "partition.h"
 #include "db_json.hpp"
+#include "object_primitive.h"
 
 #include "dbtype.h"
 #define PT_CHAIN_LENGTH 10

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -48,6 +48,7 @@
 #include "arithmetic.h"
 #include "string_opfunc.h"
 #include "object_domain.h"
+#include "object_primitive.h"
 #include "semantic_check.h"
 #include "xasl_generation.h"
 #include "language_support.h"

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -35,6 +35,7 @@
 
 #include "dbi.h"
 #include "object_accessor.h"
+#include "object_primitive.h"
 #include "locator_cl.h"
 #include "virtual_object.h"
 #include "dbtype.h"

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -44,6 +44,7 @@
 #include "parser_message.h"
 #include "virtual_object.h"
 #include "set_object.h"
+#include "object_primitive.h"
 #include "object_print.h"
 #include "object_representation.h"
 #include "intl_support.h"

--- a/src/query/cursor.c
+++ b/src/query/cursor.c
@@ -371,7 +371,7 @@ cursor_copy_vobj_to_dbvalue (OR_BUF * buffer_p, DB_VALUE * value_p)
   DB_OBJECT *object_p;
   PR_TYPE *pr_type;
 
-  pr_type = PR_TYPE_FROM_ID (DB_TYPE_VOBJ);
+  pr_type = pr_type_from_id (DB_TYPE_VOBJ);
   if (pr_type == NULL)
     {
       return ER_FAILED;

--- a/src/query/cursor.h
+++ b/src/query/cursor.h
@@ -31,7 +31,6 @@
 #include "error_manager.h"
 #include "query_list.h"
 #include "storage_common.h"
-#include "object_primitive.h"
 #include "object_representation.h"
 
 enum

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -49,6 +49,7 @@
 #include "transform.h"
 #include "set_object.h"
 #include "object_accessor.h"
+#include "object_primitive.h"
 #include "memory_hash.h"
 #include "locator_cl.h"
 #include "xasl_support.h"

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -67,6 +67,7 @@
 #include "optimizer.h"
 #include "memory_alloc.h"
 #include "object_domain.h"
+#include "object_primitive.h"
 #include "trigger_manager.h"
 #include "release_string.h"
 #include "object_accessor.h"

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4545,7 +4545,7 @@ fetch_val_list (THREAD_ENTRY * thread_p, REGU_VARIABLE_LIST regu_list, VAL_DESCR
 	      return ER_FAILED;
 	    }
 
-	  PR_SHARE_VALUE (tmp, regup->value.vfetch_to);
+	  pr_share_value (tmp, regup->value.vfetch_to);
 	}
     }
   else

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -1798,7 +1798,7 @@ qfile_fast_intval_tuple_to_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
   else
     {
       DB_TYPE dbval_type = DB_VALUE_DOMAIN_TYPE (v2);
-      PR_TYPE *pr_type = PR_TYPE_FROM_ID (dbval_type);
+      PR_TYPE *pr_type = pr_type_from_id (dbval_type);
       OR_BUF buf;
 
       QFILE_PUT_TUPLE_VALUE_FLAG (tuple_p, V_BOUND);
@@ -1877,7 +1877,7 @@ qfile_fast_val_tuple_to_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id_p
   else
     {
       DB_TYPE dbval_type = DB_VALUE_DOMAIN_TYPE (val);
-      PR_TYPE *pr_type = PR_TYPE_FROM_ID (dbval_type);
+      PR_TYPE *pr_type = pr_type_from_id (dbval_type);
       OR_BUF buf;
 
       QFILE_PUT_TUPLE_VALUE_FLAG (tuple_p, V_BOUND);

--- a/src/query/method_scan.c
+++ b/src/query/method_scan.c
@@ -44,6 +44,7 @@
 #endif /* defined (SA_MODE) */
 
 #include "dbtype.h"
+#include "object_primitive.h"
 
 #if !defined(SERVER_MODE)
 extern unsigned int db_on_server;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -11117,7 +11117,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	  else
 	    {
 	      OR_BUF buf;
-	      PR_TYPE *pr_type = PR_TYPE_FROM_ID (attr->type);
+	      PR_TYPE *pr_type = pr_type_from_id (attr->type);
 	      bool copy = (pr_is_set_type (attr->type)) ? true : false;
 	      if (pr_type != NULL)
 		{
@@ -22864,7 +22864,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 
 		  disk_length = attrepr->current_default_value.val_length;
 		  copy = (pr_is_set_type (attrepr->type)) ? true : false;
-		  pr_type = PR_TYPE_FROM_ID (attrepr->type);
+		  pr_type = pr_type_from_id (attrepr->type);
 		  if (pr_type)
 		    {
 		      (*(pr_type->data_readval)) (&buf, out_values[idx_val], attrepr->domain, disk_length, copy, NULL,

--- a/src/query/query_method.c
+++ b/src/query/query_method.c
@@ -30,6 +30,7 @@
 #include "query_method.h"
 #include "object_accessor.h"
 #include "jsp_cl.h"
+#include "object_primitive.h"
 #include "object_representation.h"
 #include "network.h"
 #include "network_interface_cl.h"

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -322,7 +322,7 @@ qdata_copy_db_value (DB_VALUE * dest_p, DB_VALUE * src_p)
   (void) pr_clear_value (dest_p);
 
   src_type = DB_VALUE_DOMAIN_TYPE (src_p);
-  pr_type_p = PR_TYPE_FROM_ID (src_type);
+  pr_type_p = pr_type_from_id (src_type);
   if (pr_type_p == NULL)
     {
       return false;
@@ -371,7 +371,7 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, bool clear_compressed_st
       val_p = (char *) tuple_val_p + QFILE_TUPLE_VALUE_HEADER_SIZE;
 
       dbval_type = DB_VALUE_DOMAIN_TYPE (dbval_p);
-      pr_type = PR_TYPE_FROM_ID (dbval_type);
+      pr_type = pr_type_from_id (dbval_type);
       if (pr_type == NULL)
 	{
 	  return ER_FAILED;
@@ -6878,7 +6878,7 @@ qdata_evaluate_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 	    }
 
 	  dbval_type = DB_VALUE_DOMAIN_TYPE (db_value_p);
-	  pr_type_p = PR_TYPE_FROM_ID (dbval_type);
+	  pr_type_p = pr_type_from_id (dbval_type);
 
 	  if (pr_type_p == NULL)
 	    {
@@ -7544,7 +7544,7 @@ qdata_finalize_aggregate_list (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * agg_lis
 			      PR_TYPE *tmp_pr_type;
 			      DB_TYPE dbval_type = DB_VALUE_DOMAIN_TYPE (&dbval);
 
-			      tmp_pr_type = PR_TYPE_FROM_ID (dbval_type);
+			      tmp_pr_type = pr_type_from_id (dbval_type);
 			      if (tmp_pr_type == NULL)
 				{
 				  (void) pr_clear_value (&dbval);
@@ -7831,7 +7831,7 @@ qdata_get_tuple_value_size_from_dbval (DB_VALUE * dbval_p)
   else
     {
       dbval_type = DB_VALUE_DOMAIN_TYPE (dbval_p);
-      type_p = PR_TYPE_FROM_ID (dbval_type);
+      type_p = pr_type_from_id (dbval_type);
       if (type_p)
 	{
 	  if (type_p->data_lengthval == NULL)
@@ -8574,7 +8574,7 @@ qdata_convert_table_to_set (THREAD_ENTRY * thread_p, DB_TYPE stype, REGU_VARIABL
 	{
 	  /* grab column i and add it to the col */
 	  type = TP_DOMAIN_TYPE (list_id_p->type_list.domp[i]);
-	  pr_type_p = PR_TYPE_FROM_ID (type);
+	  pr_type_p = pr_type_from_id (type);
 	  if (pr_type_p == NULL)
 	    {
 	      qfile_close_scan (thread_p, &scan_id);
@@ -10394,7 +10394,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
     {
       /* handle distincts by adding to the temp list file */
       dbval_type = DB_VALUE_DOMAIN_TYPE (&dbval);
-      pr_type_p = PR_TYPE_FROM_ID (dbval_type);
+      pr_type_p = pr_type_from_id (dbval_type);
 
       if (pr_type_p == NULL)
 	{
@@ -10667,7 +10667,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
 	  (void) pr_clear_value (func_p->value);
 	  (void) pr_clear_value (func_p->value2);
 	  dbval_type = DB_VALUE_DOMAIN_TYPE (func_p->value);
-	  pr_type_p = PR_TYPE_FROM_ID (dbval_type);
+	  pr_type_p = pr_type_from_id (dbval_type);
 	  if (pr_type_p == NULL)
 	    {
 	      error = ER_FAILED;
@@ -10909,7 +10909,7 @@ qdata_evaluate_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, V
       /* copy resultant operand value to analytic node */
       (void) pr_clear_value (func_p->value);
       dbval_type = DB_VALUE_DOMAIN_TYPE (func_p->value);
-      pr_type_p = PR_TYPE_FROM_ID (dbval_type);
+      pr_type_p = pr_type_from_id (dbval_type);
       if (pr_type_p == NULL)
 	{
 	  error = ER_FAILED;
@@ -11073,7 +11073,7 @@ qdata_finalize_analytic_func (THREAD_ENTRY * thread_p, ANALYTIC_TYPE * func_p, b
 		      PR_TYPE *tmp_pr_type;
 		      DB_TYPE dbval_type = DB_VALUE_DOMAIN_TYPE (&dbval);
 
-		      tmp_pr_type = PR_TYPE_FROM_ID (dbval_type);
+		      tmp_pr_type = pr_type_from_id (dbval_type);
 		      if (tmp_pr_type == NULL)
 			{
 			  (void) pr_clear_value (&dbval);
@@ -12015,7 +12015,7 @@ qdata_calculate_aggregate_cume_dist_percent_rank (THREAD_ENTRY * thread_p, AGGRE
       else
 	{
 	  /* non-NULL values comparison */
-	  pr_type_p = PR_TYPE_FROM_ID (DB_VALUE_DOMAIN_TYPE (val_node));
+	  pr_type_p = pr_type_from_id (DB_VALUE_DOMAIN_TYPE (val_node));
 	  cmp = (*(pr_type_p->cmpval)) (val_node, info_p->const_array[i], 1, 0, NULL,
 					regu_var_node->value.domain->collation_id);
 

--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -239,7 +239,7 @@ xserial_get_current_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_n
 
   cur_val = heap_attrinfo_access (attrid, attr_info_p);
 
-  PR_SHARE_VALUE (cur_val, result_num);
+  pr_share_value (cur_val, result_num);
 
   heap_attrinfo_end (thread_p, attr_info_p);
 
@@ -669,32 +669,32 @@ xserial_get_next_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_num,
   attrid = serial_get_attrid (thread_p, SERIAL_ATTR_CURRENT_VAL_INDEX);
   assert (attrid != NOT_FOUND);
   val = heap_attrinfo_access (attrid, attr_info_p);
-  PR_SHARE_VALUE (val, &cur_val);
+  pr_share_value (val, &cur_val);
 
   attrid = serial_get_attrid (thread_p, SERIAL_ATTR_INCREMENT_VAL_INDEX);
   assert (attrid != NOT_FOUND);
   val = heap_attrinfo_access (attrid, attr_info_p);
-  PR_SHARE_VALUE (val, &inc_val);
+  pr_share_value (val, &inc_val);
 
   attrid = serial_get_attrid (thread_p, SERIAL_ATTR_MAX_VAL_INDEX);
   assert (attrid != NOT_FOUND);
   val = heap_attrinfo_access (attrid, attr_info_p);
-  PR_SHARE_VALUE (val, &max_val);
+  pr_share_value (val, &max_val);
 
   attrid = serial_get_attrid (thread_p, SERIAL_ATTR_MIN_VAL_INDEX);
   assert (attrid != NOT_FOUND);
   val = heap_attrinfo_access (attrid, attr_info_p);
-  PR_SHARE_VALUE (val, &min_val);
+  pr_share_value (val, &min_val);
 
   attrid = serial_get_attrid (thread_p, SERIAL_ATTR_CYCLIC_INDEX);
   assert (attrid != NOT_FOUND);
   val = heap_attrinfo_access (attrid, attr_info_p);
-  PR_SHARE_VALUE (val, &cyclic);
+  pr_share_value (val, &cyclic);
 
   attrid = serial_get_attrid (thread_p, SERIAL_ATTR_STARTED_INDEX);
   assert (attrid != NOT_FOUND);
   val = heap_attrinfo_access (attrid, attr_info_p);
-  PR_SHARE_VALUE (val, &started);
+  pr_share_value (val, &started);
 
   db_make_null (&last_val);
 
@@ -707,7 +707,7 @@ xserial_get_next_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_num,
       ret = heap_attrinfo_set (serial_oidp, attrid, &started, attr_info_p);
       if (ret == NO_ERROR)
 	{
-	  PR_SHARE_VALUE (&cur_val, &next_val);
+	  pr_share_value (&cur_val, &next_val);
 	  if (cached_num > 1)
 	    {
 	      assert (1 <= num_alloc);
@@ -768,7 +768,7 @@ xserial_get_next_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_num,
     }
 
   /* copy result value */
-  PR_SHARE_VALUE (&next_val, result_num);
+  pr_share_value (&next_val, result_num);
 
   pr_clear_value (&key_val);
 
@@ -792,7 +792,7 @@ xserial_get_next_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_num,
 	    }
 	  else
 	    {
-	      PR_SHARE_VALUE (&next_val, &cur_val);
+	      pr_share_value (&next_val, &cur_val);
 	      serial_set_cache_entry (entry, &inc_val, &cur_val, &min_val, &max_val, &started, &cyclic, &last_val,
 				      cached_num);
 	    }
@@ -958,7 +958,7 @@ serial_get_nth_value (DB_VALUE * inc_val, DB_VALUE * cur_val, DB_VALUE * min_val
     }
   else
     {
-      PR_SHARE_VALUE (inc_val, &add_val);
+      pr_share_value (inc_val, &add_val);
     }
 
   /* inc_val_flag (1 or 0) */
@@ -980,7 +980,7 @@ serial_get_nth_value (DB_VALUE * inc_val, DB_VALUE * cur_val, DB_VALUE * min_val
 	{
 	  if (db_get_int (cyclic))
 	    {
-	      PR_SHARE_VALUE (min_val, result_val);
+	      pr_share_value (min_val, result_val);
 	    }
 	  else
 	    {
@@ -1011,7 +1011,7 @@ serial_get_nth_value (DB_VALUE * inc_val, DB_VALUE * cur_val, DB_VALUE * min_val
 	{
 	  if (db_get_int (cyclic))
 	    {
-	      PR_SHARE_VALUE (max_val, result_val);
+	      pr_share_value (max_val, result_val);
 	    }
 	  else
 	    {

--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -23,10 +23,11 @@
 
 #ident "$Id$"
 
-#include "replication_object.hpp"
+#include "memory_alloc.h"
+#include "object_primitive.h"
 #include "object_representation.h"
 #include "thread_manager.hpp"
-#include "memory_alloc.h"
+#include "replication_object.hpp"
 
 namespace cubreplication
 {

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -4599,7 +4599,7 @@ void
 btree_dump_key (THREAD_ENTRY * thread_p, FILE * fp, DB_VALUE * key)
 {
   DB_TYPE key_type = DB_VALUE_DOMAIN_TYPE (key);
-  PR_TYPE *pr_type = PR_TYPE_FROM_ID (key_type);
+  PR_TYPE *pr_type = pr_type_from_id (key_type);
 
   assert (pr_type != NULL);
 
@@ -18514,7 +18514,7 @@ btree_set_unknown_key_error (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * ke
     }
 
   err_key = pr_valstring (thread_p, key);
-  pr_type = PR_TYPE_FROM_ID (DB_VALUE_DOMAIN_TYPE (key));
+  pr_type = pr_type_from_id (DB_VALUE_DOMAIN_TYPE (key));
 
   er_set (severity, ARG_FILE_LINE, ER_BTREE_UNKNOWN_KEY, 5, (err_key != NULL) ? err_key : "_NULL_KEY",
 	  btid->vfid.fileid, btid->vfid.volid, btid->root_pageid,

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -5968,8 +5968,8 @@ btree_find_foreign_key (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key, OI
   /* Find if key has any objects. */
 
   /* Define range of scan. */
-  PR_SHARE_VALUE (key, &key_val_range.key1);
-  PR_SHARE_VALUE (key, &key_val_range.key2);
+  pr_share_value (key, &key_val_range.key1);
+  pr_share_value (key, &key_val_range.key2);
   key_val_range.range = GE_LE;
   key_val_range.num_index_term = 0;
 
@@ -8369,8 +8369,8 @@ btree_keyoid_checkscan_check (THREAD_ENTRY * thread_p, BTREE_CHECKSCAN * btscan,
 
   assert (!pr_is_set_type (DB_VALUE_DOMAIN_TYPE (key)));
 
-  PR_SHARE_VALUE (key, &key_val_range.key1);
-  PR_SHARE_VALUE (key, &key_val_range.key2);
+  pr_share_value (key, &key_val_range.key1);
+  pr_share_value (key, &key_val_range.key2);
   key_val_range.range = GE_LE;
   key_val_range.num_index_term = 0;
 

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -1728,7 +1728,7 @@ catcls_get_or_value_from_domain (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VAL
     {
       /* enumerations are stored as a collection of strings */
       TP_DOMAIN *string_dom = tp_domain_resolve_default (DB_TYPE_STRING);
-      PR_TYPE *seq_type = PR_TYPE_FROM_ID (DB_TYPE_SEQUENCE);
+      PR_TYPE *seq_type = pr_type_from_id (DB_TYPE_SEQUENCE);
 
       TP_DOMAIN *domain = tp_domain_construct (DB_TYPE_SEQUENCE, NULL, 0, 0, string_dom);
       if (domain == NULL)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -2745,7 +2745,7 @@ heap_classrepr_dump (THREAD_ENTRY * thread_p, FILE * fp, const OID * class_oid, 
 
 	      disk_length = attrepr->default_value.val_length;
 	      copy = (pr_is_set_type (attrepr->type)) ? true : false;
-	      pr_type = PR_TYPE_FROM_ID (attrepr->type);
+	      pr_type = pr_type_from_id (attrepr->type);
 	      if (pr_type)
 		{
 		  (*(pr_type->data_readval)) (&buf, &def_dbvalue, attrepr->domain, disk_length, copy, NULL, 0);
@@ -10153,7 +10153,7 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
 	   * semantics for length. A negative length value for strings means "don't copy the string, just use the
 	   * pointer". For sets, don't translate the set into memory representation at this time.  It will only be
 	   * translated when needed. */
-	  pr_type = PR_TYPE_FROM_ID (attrepr->type);
+	  pr_type = pr_type_from_id (attrepr->type);
 	  if (pr_type)
 	    {
 	      (*(pr_type->data_readval)) (&buf, &value->dbvalue, attrepr->domain, disk_length, false, NULL, 0);
@@ -11170,7 +11170,7 @@ heap_attrinfo_set (const OID * inst_oid, ATTR_ID attrid, DB_VALUE * attr_val, HE
       goto exit_on_error;
     }
 
-  pr_type = PR_TYPE_FROM_ID (value->last_attrepr->type);
+  pr_type = pr_type_from_id (value->last_attrepr->type);
   if (pr_type == NULL)
     {
       goto exit_on_error;

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -84,7 +84,7 @@
 #include "show_meta.h"
 #include "tz_support.h"
 #include "dbtype.h"
-
+#include "object_primitive.h"
 
 #if defined(CS_MODE)
 #include "network.h"

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -8431,7 +8431,7 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 
       new_isnull = db_value_is_null (new_key);
       old_isnull = db_value_is_null (old_key);
-      pr_type = PR_TYPE_FROM_ID (dbval_type);
+      pr_type = pr_type_from_id (dbval_type);
       if (pr_type == NULL)
 	{
 	  error_code = ER_FAILED;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -12448,8 +12448,8 @@ locator_prefetch_index_page_internal (THREAD_ENTRY * thread_p, BTID * btid, OID 
       goto free_and_return;
     }
 
-  PR_SHARE_VALUE (key, &key_val_range.key1);
-  PR_SHARE_VALUE (key, &key_val_range.key2);
+  pr_share_value (key, &key_val_range.key1);
+  pr_share_value (key, &key_val_range.key2);
   key_val_range.range = GE_LE;
   key_val_range.num_index_term = 0;
 

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -41,6 +41,7 @@
 #include "message_catalog.h"
 #include "log_compress.h"
 #include "parser.h"
+#include "object_primitive.h"
 #include "object_print.h"
 #include "db.h"
 #include "object_accessor.h"

--- a/src/transaction/log_applier_sql_log.c
+++ b/src/transaction/log_applier_sql_log.c
@@ -31,6 +31,7 @@
 #include <unistd.h>
 #include "log_applier_sql_log.h"
 #include "system_parameter.h"
+#include "object_primitive.h"
 #include "object_template.h"
 #include "object_print.h"
 #include "error_manager.h"

--- a/unit_tests/stream/test_stream.cpp
+++ b/unit_tests/stream/test_stream.cpp
@@ -18,13 +18,16 @@
  */
 
 #include "test_stream.hpp"
-#include "object_representation.h"
+
+#include "dbtype.h"
 #include "multi_thread_stream.hpp"
+#include "object_primitive.h"
+#include "object_representation.h"
 #include "thread_compat.hpp"
+#include "thread_entry.hpp"
 #include "thread_manager.hpp"
 #include "thread_task.hpp"
-#include "thread_entry.hpp"
-#include "dbtype.h"
+
 #include <iostream>
 
 namespace test_stream


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22693

1. Remove object_primitive.h includes from other headers
2. Include object_primitive.h only in C++ units.
3. Remove unused pr_ordered_mem_sizes
4. Replace macro with pr_share_value function
5. Move pr_write_mop to transform_cl.c
6. Remove unnecessary pr_clear_value from dbtype_function.i.
7. Added object_primitive.h includes to many units.
8. Reduce object_primitive.h dependencies on other headers.

Patch contains only refactoring and should have no impact on engine functionality.