### PR TITLE
[CBRD-22685] GCC < 4.9.0 std::regex is experimental

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,10 @@ if(UNIX)
       message(SEND_ERROR "Cannot compile with gcc version ${CMAKE_CXX_COMPILER_VERSION}. Require at least 4.4.7.")
     endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4.7)
 
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.0)
+      add_compile_definitions(_USE_LIBEREGEX_)
+    endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.0)
+
     set(CMAKE_C_FLAGS_DEBUG "-ggdb -fno-inline -fno-omit-frame-pointer")
     set(CMAKE_CXX_FLAGS_DEBUG "-Wall -ggdb -fno-inline -fno-omit-frame-pointer -std=c++0x")
     set(CMAKE_C_FLAGS_RELEASE "-ggdb -O2 -DNDEBUG -finline-functions -fno-omit-frame-pointer -std=c++0x")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,7 @@ if(UNIX)
     endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4.7)
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.0)
-      add_compile_definitions(_USE_LIBEREGEX_)
+      add_definitions(-D_USE_LIBEREGEX_)
     endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.0)
 
     set(CMAKE_C_FLAGS_DEBUG "-ggdb -fno-inline -fno-omit-frame-pointer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,7 @@ if(UNIX)
     endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4.7)
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.0)
-      add_definitions(-D_USE_LIBEREGEX_)
+      add_definitions(-D_USE_LIBREGEX_)
     endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.0)
 
     set(CMAKE_C_FLAGS_DEBUG "-ggdb -fno-inline -fno-omit-frame-pointer")

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -103,24 +103,30 @@ class JSON_PRIVATE_ALLOCATOR
     void *Malloc (size_t size);
     void *Realloc (void *originalPtr, size_t originalSize, size_t newSize);
     static void Free (void *ptr);
-} regex_guy;
+};
 
 static void *
 wrap_malloc (void *dummy, size_t s)
 {
-  return regex_guy.Malloc (s);
+  return db_private_alloc (NULL, s);
 }
 
 static void *
 wrap_realloc (void *dummy, void *p, size_t s)
 {
-  return regex_guy.Realloc (p, s, s);
+  if (s == 0)
+    {
+      db_private_free (NULL, p);
+      return NULL;
+    }
+
+  return db_private_realloc (NULL, p, s);
 }
 
 static void
 wrap_free (void *dummy, void *p)
 {
-  JSON_PRIVATE_ALLOCATOR::Free (dummy);
+  db_private_free (NULL, p);
 }
 
 comp_regex::comp_regex (const std::string &pattern)

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -130,7 +130,6 @@ wrap_free (void *dummy, void *p)
 }
 
 libregex_wrapper::libregex_wrapper (const std::string &pattern)
-  : m_pattern (pattern)
 {
   cub_regset_malloc (&wrap_malloc);
   cub_regset_realloc (&wrap_realloc);
@@ -729,7 +728,7 @@ static bool match_regex (const std::string &str, const cub_regex_impl &reg)
 #ifdef _USE_LIBREGEX_
   return reg.reg_match (str);
 #else
-  return std::regex_match (crt_path, reg);
+  return std::regex_match (str, reg);
 #endif
 }
 
@@ -2161,7 +2160,7 @@ db_json_paths_to_regex (const std::vector<std::string> &paths, std::vector<cub_r
 	}
       if (!match_exactly)
 	{
-	  ss << "([^[$]])*";
+	  ss << "([^$])*";
 	}
       // match end of string
       ss << "$";

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -901,7 +901,16 @@ int JSON_PATH_MAPPER::CallOnKeyIterate (JSON_VALUE &key)
   m_accumulated_paths.pop ();
   std::string path_item = m_accumulated_paths.top ();
   path_item += ".\"";
-  path_item += key.GetString ();
+
+  std::string object_key = key.GetString ();
+  for (auto it = object_key.begin (); it != object_key.end (); ++it)
+    {
+      if (*it == '"')
+	{
+	  it = object_key.insert (it, '\\') + 1;
+	}
+    }
+  path_item += object_key;
   path_item += "\"";
 
   m_accumulated_paths.push (path_item);
@@ -2120,12 +2129,15 @@ db_json_paths_to_regex (const std::vector<std::string> &paths, std::vector<cub_r
 	    case '.':
 	      ss << "\\.";
 	      break;
-	    // todo: gather all characters that need escaping in regex string to be together
+	    // todo: probably most special characters for POSIX regex language should be escaped
 	    case '^':
 	      ss << "\\^";
 	      break;
 	    case '|':
 	      ss << "\\|";
+	      break;
+	    case '\\':
+	      ss << "\\\\";
 	      break;
 	    case '*':
 	      if (i < wild_card.length () - 1 && wild_card[i + 1] == '*')

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -141,7 +141,6 @@ libregex_wrapper::libregex_wrapper (const std::string &pattern)
   if (error_code != CUB_REG_OKAY)
     {
       // todo: convert CUB_REG errors to appropriate regex_error or add appropriate errcodes for the exceptions
-      //throw std::regex_error (std::regex_constants::error_type::error_backref);
       assert (false);
     }
 }
@@ -2131,7 +2130,7 @@ db_json_paths_to_regex (const std::vector<std::string> &paths, std::vector<cub_r
 	    case '.':
 	      ss << "\\.";
 	      break;
-	    // todo: probably most special characters for POSIX regex language should be escaped
+	    // todo: probably most of the special characters for POSIX regex language should be escaped
 	    case '^':
 	      ss << "\\^";
 	      break;
@@ -2157,7 +2156,7 @@ db_json_paths_to_regex (const std::vector<std::string> &paths, std::vector<cub_r
 		{
 		  // wild_card '.*'. Match any string between quotes (path must have been validated before)
 		  // match strings between quotes that do not contain unescaped quotes
-		  // todo: there are other characters that require same treatment as quotes they can be treated
+		  // todo: there are other characters that require same treatment as quotes;
 		  // they can be treated by applying the same pattern
 		  ss << "\"(([^\"\\])*|([\\]([\\][\\])*\")*)*\"";
 		}

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -135,13 +135,14 @@ libregex_wrapper::libregex_wrapper (const std::string &pattern)
   cub_regset_realloc (&wrap_realloc);
   cub_regset_free (wrap_free);
 
-  int error_code = cub_regcomp (&m_bsd_regex, pattern.c_str (),
+  int error_code = cub_regcomp (&m_reg, pattern.c_str (),
 				CUB_REG_EXTENDED);
 
   if (error_code != CUB_REG_OKAY)
     {
       // todo: convert CUB_REG errors to appropriate regex_error or add appropriate errcodes for the exceptions
       //throw std::regex_error (std::regex_constants::error_type::error_backref);
+      assert (false);
     }
 }
 

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -905,7 +905,8 @@ int JSON_PATH_MAPPER::CallOnKeyIterate (JSON_VALUE &key)
   std::string object_key = key.GetString ();
   for (auto it = object_key.begin (); it != object_key.end (); ++it)
     {
-      if (*it == '"')
+      // todo: take care of all chars that need escaping during simple object key -> object key conversion
+      if (*it == '"' || *it == '\\')
 	{
 	  it = object_key.insert (it, '\\') + 1;
 	}

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -51,8 +51,19 @@ typedef void JSON_ITERATOR;
 class comp_regex
 {
     cub_regex_t m_bsd_regex;
+    int error_code = NO_ERROR;
+    const std::string m_pattern;
+    bool m_moved_from;
   public:
     comp_regex (const std::string &pattern);
+    comp_regex (comp_regex &o) = delete;
+    comp_regex (comp_regex &&o)
+      : m_bsd_regex (o.m_bsd_regex)
+      , m_pattern (std::move (o.m_pattern))
+    {
+      // transfer resource ownership
+      o.m_moved_from = true;
+    }
 
     int reg_exec (const std::string &str) const
     {
@@ -64,7 +75,10 @@ class comp_regex
 
     ~comp_regex ()
     {
-      cub_regfree (&m_bsd_regex);
+      if (!m_moved_from)
+	{
+	  cub_regfree (&m_bsd_regex);
+	}
     }
 };
 

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -23,8 +23,6 @@
 
 #ifndef _DB_JSON_HPP_
 #define _DB_JSON_HPP_
-#ifndef _USE_LIBREGEX_
-#define _USE_LIBREGEX_
 
 #include "error_manager.h"
 #include "object_representation.h"
@@ -44,21 +42,17 @@ typedef void JSON_ITERATOR;
 #include <functional>
 #include <regex>
 #include <vector>
-
-// For gcc version < 4.9.0
 #include "libregex38a/regex38a.h"
 
 class libregex_wrapper
 {
     cub_regex_t m_bsd_regex;
-    const std::string m_pattern;
     bool m_moved_from = false;
   public:
     libregex_wrapper (const std::string &pattern);
     libregex_wrapper (libregex_wrapper &o) = delete;
     libregex_wrapper (libregex_wrapper &&o)
       : m_bsd_regex (o.m_bsd_regex)
-      , m_pattern (std::move (o.m_pattern))
     {
       if (o.m_moved_from)
 	{
@@ -82,7 +76,7 @@ class libregex_wrapper
       if (ret_code != CUB_REG_OKAY)
 	{
 	  /* should not reach on this */
-	  // assert (false);
+	  assert (false);
 	  return false;
 	}
 
@@ -101,7 +95,7 @@ class libregex_wrapper
 #ifdef _USE_LIBREGEX_
 typedef libregex_wrapper cub_regex_impl;
 #else
-typedef std::regex comp_regex;
+typedef std::regex cub_regex_impl;
 #endif
 
 /*
@@ -251,5 +245,4 @@ db_json_convert_string_and_call (const char *json_raw, size_t json_raw_length, F
 
 #endif /* defined (__cplusplus) */
 
-#endif /* _USE_LIBREGEX_ */
 #endif /* _DB_JSON_HPP_ */

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -72,12 +72,8 @@ class comp_regex
 
     bool reg_match (const std::string &str) const
     {
-      const char *tmp_str = str.c_str ();
-      assert (strlen (tmp_str) == str.length ());
-
-      int nr_matches;
-      cub_regmatch_t match[1];
-      int ret_code = cub_regexec (&m_bsd_regex, str.c_str (), str.length (), 1, match, 0);
+      cub_regmatch_t match;
+      int ret_code = cub_regexec (&m_bsd_regex, str.c_str (), str.length (), 1, &match, 0);
 
       if (ret_code == CUB_REG_NOMATCH)
 	{
@@ -91,12 +87,14 @@ class comp_regex
 	  return false;
 	}
 
-      if (match->rm_so == 0 && match->rm_eo == str.length ())
+      if (match.rm_so != 0 || match.rm_eo != str.length ())
 	{
-	  return true;
+	  /* regex should have matched the whole pattern */
+	  // assert (false);
+	  return false;
 	}
 
-      return false;
+      return true;
     }
 
     ~comp_regex ()

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -40,63 +40,7 @@ typedef void JSON_ITERATOR;
 #if defined (__cplusplus)
 
 #include <functional>
-#include <regex>
 #include <vector>
-#include "libregex38a/regex38a.h"
-
-class libregex_wrapper
-{
-    cub_regex_t m_reg;
-    bool m_moved_from = false;
-  public:
-    libregex_wrapper (const std::string &pattern);
-    libregex_wrapper (libregex_wrapper &o) = delete;
-    libregex_wrapper (libregex_wrapper &&o)
-    {
-      if (o.m_moved_from)
-	{
-	  // trying to move from a moved-from object
-	  assert (false);
-	}
-
-      // transfer resource ownership
-      m_reg = o.m_reg;
-      o.m_moved_from = true;
-    }
-
-    bool reg_match (const std::string &str) const
-    {
-      int ret_code = cub_regexec (&m_reg, str.c_str (), str.length (), 0, NULL, 0);
-
-      if (ret_code == CUB_REG_NOMATCH)
-	{
-	  return false;
-	}
-
-      if (ret_code != CUB_REG_OKAY)
-	{
-	  /* should not reach on this */
-	  assert (false);
-	  return false;
-	}
-
-      return true;
-    }
-
-    ~libregex_wrapper ()
-    {
-      if (!m_moved_from)
-	{
-	  cub_regfree (&m_reg);
-	}
-    }
-};
-
-#ifdef _USE_LIBREGEX_
-typedef libregex_wrapper cub_regex_impl;
-#else
-typedef std::regex cub_regex_impl;
-#endif
 
 /*
  * these also double as type precedence
@@ -161,10 +105,10 @@ int db_json_keys_func (const JSON_DOC &doc, JSON_DOC &result_json, const char *r
 int db_json_array_append_func (const JSON_DOC *value, JSON_DOC &doc, const char *raw_path);
 int db_json_array_insert_func (const JSON_DOC *value, JSON_DOC &doc, const char *raw_path);
 int db_json_remove_func (JSON_DOC &doc, const char *raw_path);
-int db_json_paths_to_regex (const std::vector<std::string> &paths, std::vector<cub_regex_impl> &regs,
+int db_json_paths_to_regex (const std::vector<std::string> &paths, std::vector<std::string> &regs,
 			    bool match_exactly = false);
 int db_json_search_func (JSON_DOC &doc, const DB_VALUE *pattern, const DB_VALUE *esc_char,
-			 std::vector<std::string> &paths, const std::vector<cub_regex_impl> &regs, bool find_all);
+			 std::vector<std::string> &paths, const std::vector<std::string> &regs, bool find_all);
 int db_json_merge_func (const JSON_DOC *source, JSON_DOC *&dest, bool patch);
 int db_json_get_all_paths_func (const JSON_DOC &doc, JSON_DOC *&result_json);
 void db_json_pretty_func (const JSON_DOC &doc, char *&result_str);

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -27,10 +27,6 @@
 #include "error_manager.h"
 #include "object_representation.h"
 
-#ifndef _USE_LIBREGEX_
-#define _USE_LIBREGEX_
-#endif
-
 #if defined (__cplusplus)
 class JSON_DOC;
 class JSON_VALIDATOR;

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -46,27 +46,27 @@ typedef void JSON_ITERATOR;
 
 class libregex_wrapper
 {
-    cub_regex_t m_bsd_regex;
+    cub_regex_t m_reg;
     bool m_moved_from = false;
   public:
     libregex_wrapper (const std::string &pattern);
     libregex_wrapper (libregex_wrapper &o) = delete;
     libregex_wrapper (libregex_wrapper &&o)
-      : m_bsd_regex (o.m_bsd_regex)
     {
       if (o.m_moved_from)
 	{
-	  // todo: assert before init
+	  // trying to move from a moved-from object
 	  assert (false);
 	}
 
       // transfer resource ownership
+      m_reg = o.m_reg;
       o.m_moved_from = true;
     }
 
     bool reg_match (const std::string &str) const
     {
-      int ret_code = cub_regexec (&m_bsd_regex, str.c_str (), str.length (), 0, NULL, 0);
+      int ret_code = cub_regexec (&m_reg, str.c_str (), str.length (), 0, NULL, 0);
 
       if (ret_code == CUB_REG_NOMATCH)
 	{
@@ -87,7 +87,7 @@ class libregex_wrapper
     {
       if (!m_moved_from)
 	{
-	  cub_regfree (&m_bsd_regex);
+	  cub_regfree (&m_reg);
 	}
     }
 };

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -48,15 +48,15 @@ typedef void JSON_ITERATOR;
 // For gcc version < 4.9.0
 #include "libregex38a/regex38a.h"
 
-class comp_regex
+class libregex_wrapper
 {
     cub_regex_t m_bsd_regex;
     const std::string m_pattern;
     bool m_moved_from = false;
   public:
-    comp_regex (const std::string &pattern);
-    comp_regex (comp_regex &o) = delete;
-    comp_regex (comp_regex &&o)
+    libregex_wrapper (const std::string &pattern);
+    libregex_wrapper (libregex_wrapper &o) = delete;
+    libregex_wrapper (libregex_wrapper &&o)
       : m_bsd_regex (o.m_bsd_regex)
       , m_pattern (std::move (o.m_pattern))
     {
@@ -72,8 +72,7 @@ class comp_regex
 
     bool reg_match (const std::string &str) const
     {
-      cub_regmatch_t match;
-      int ret_code = cub_regexec (&m_bsd_regex, str.c_str (), str.length (), 1, &match, 0);
+      int ret_code = cub_regexec (&m_bsd_regex, str.c_str (), str.length (), 0, NULL, 0);
 
       if (ret_code == CUB_REG_NOMATCH)
 	{
@@ -87,17 +86,10 @@ class comp_regex
 	  return false;
 	}
 
-      if (match.rm_so != 0 || match.rm_eo != str.length ())
-	{
-	  /* regex should have matched the whole pattern */
-	  // assert (false);
-	  return false;
-	}
-
       return true;
     }
 
-    ~comp_regex ()
+    ~libregex_wrapper ()
     {
       if (!m_moved_from)
 	{
@@ -107,7 +99,7 @@ class comp_regex
 };
 
 #ifdef _USE_LIBREGEX_
-typedef comp_regex cub_regex_impl;
+typedef libregex_wrapper cub_regex_impl;
 #else
 typedef std::regex comp_regex;
 #endif

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -27,6 +27,10 @@
 #include "error_manager.h"
 #include "object_representation.h"
 
+#ifndef _USE_LIBREGEX_
+#define _USE_LIBREGEX_
+#endif
+
 #if defined (__cplusplus)
 class JSON_DOC;
 class JSON_VALIDATOR;

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -35,6 +35,7 @@
 #include <ieeefp.h>
 #endif
 
+#include <algorithm>
 #include "arithmetic.h"
 #include "error_manager.h"
 #include "object_primitive.h"
@@ -6297,7 +6298,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
       starting_paths.emplace_back (s);
     }
 
-  std::vector<cub_regex_impl> regs;
+  std::vector<std::string> regs;
   if (starting_paths.empty ())
     {
       starting_paths.push_back ("$");

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -6297,7 +6297,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
       starting_paths.emplace_back (s);
     }
 
-  std::vector<std::regex> regs;
+  std::vector<cub_regex_impl> regs;
   if (starting_paths.empty ())
     {
       starting_paths.push_back ("$");

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4350,7 +4350,7 @@ regex_matches (const char *pattern, const char *str, int reg_flags, bool * match
       break;
 
     default:
-      int rx_err_len = (int) cub_regerror (ret_code, reg, reg_err_buf, REGEX_MAX_ERROR_MSG_SIZE);
+      int rx_err_len = (int) cub_regerror (rx_code, reg, reg_err_buf, REGEX_MAX_ERROR_MSG_SIZE);
       error_status = ER_REGEX_EXEC_ERROR;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 1, reg_err_buf);
       *match = false;

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4395,9 +4395,10 @@ regex_compile (cub_regex_t * &rx_compiled_regex, const char *rx_compiled_pattern
       /* regex compilation error */
       char rx_err_buf[REGEX_MAX_ERROR_MSG_SIZE] = { '\0' };
       int rx_err_len = (int) cub_regerror (rx_err, rx_compiled_regex, rx_err_buf, REGEX_MAX_ERROR_MSG_SIZE);
+      int error_status = ER_REGEX_COMPILE_ERROR;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 1, rx_err_buf);
       db_private_free_and_init (NULL, rx_compiled_regex);
-      return ER_REGEX_COMPILE_ERROR;
+      return error_status;
     }
 
   return NO_ERROR;
@@ -4544,9 +4545,9 @@ db_string_rlike (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB
       memcpy (rx_compiled_pattern, pattern_char_string_p, pattern_length);
       rx_compiled_pattern[pattern_length] = '\0';
 
-      rx_err = regex_compile (rx_compiled_regex, rx_compiled_pattern,
-			      CUB_REG_EXTENDED | CUB_REG_NOSUB | (is_case_sensitive ? 0 : CUB_REG_ICASE));
-      if (rx_err != NO_ERROR)
+      error_status = regex_compile (rx_compiled_regex, rx_compiled_pattern,
+				    CUB_REG_EXTENDED | CUB_REG_NOSUB | (is_case_sensitive ? 0 : CUB_REG_ICASE));
+      if (error_status != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
 	  *result = V_ERROR;
@@ -4610,7 +4611,7 @@ cleanup:
     }
 
   /* return */
-  return rx_err;
+  return error_status;
 }
 
 /*

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -54,6 +54,8 @@
 #include "elo.h"
 #include "db_elo.h"
 #include <algorithm>
+#include <regex>
+#include <string>
 #if !defined (SERVER_MODE)
 #include "parse_tree.h"
 #include "es_common.h"
@@ -284,6 +286,7 @@ static int print_string_date_token (const STRING_DATE_TOKEN token_type, const IN
 				    int *token_size);
 static void convert_locale_number (char *sz, const int size, const INTL_LANG src_locale, const INTL_LANG dst_locale);
 static int parse_tzd (const char *str, const int max_expect_len);
+static int regex_compile (cub_regex_t * &reg, const char *pattern, int reg_flags);
 
 #define TRIM_FORMAT_STRING(sz, n) {if (strlen(sz) > n) sz[n] = 0;}
 #define WHITESPACE(c) ((c) == ' ' || (c) == '\t' || (c) == '\r' || (c) == '\n')
@@ -4273,6 +4276,135 @@ db_string_like (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB_
   return ((*result == V_ERROR) ? ER_QSTR_INVALID_ESCAPE_SEQUENCE : error_status);
 }
 
+
+#ifndef _USE_LIBREGEX_
+#define _USE_LIBREGEX_
+#endif
+extern int
+regex_matches (const char *pattern, const char *str, int reg_flags, bool * match)
+{
+  int error_status = NO_ERROR;
+
+#ifndef _USE_LIBREGEX_
+  /* *INDENT-OFF* */  
+
+  // transform flags from cub_regex_t => std::regex_constants
+  std::regex_constants::syntax_option_type std_reg_flags = std::regex::extended;
+  while (reg_flags)
+  {
+    int before_pop = reg_flags;
+    // pop lsb
+    reg_flags &= (reg_flags - 1);
+    int lsb = before_pop ^ reg_flags;
+
+    switch (lsb)
+    {
+    case CUB_REG_NOSUB:
+      std_reg_flags |= std::regex::nosubs;
+      break;
+    case CUB_REG_ICASE:
+      std_reg_flags |= std::regex::icase;
+      break;
+    case CUB_REG_EXTENDED:
+      std_reg_flags |= std::regex::extended;
+      break;
+    default:
+      // unknown flag
+      assert (false);
+      break;
+    }
+  }
+
+  try
+    {
+      std::regex reg (pattern, std_reg_flags);
+      *match = std::regex_match (str, reg);
+    }
+  catch (std::regex_error &e)
+    {
+      // regex compilation exception
+      error_status = ER_REGEX_COMPILE_ERROR;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 1, e.what ());
+      *match = false;
+      return ER_REGEX_COMPILE_ERROR;
+    }
+  /* *INDENT-ON* */
+  return NO_ERROR;
+
+#else
+  cub_regex_t *reg = NULL;
+  int ret_code = regex_compile (reg, pattern, reg_flags);
+  if (ret_code != CUB_REG_OKAY)
+    {
+      ASSERT_ERROR ();
+      return ER_REGEX_COMPILE_ERROR;
+    }
+
+  ret_code = cub_regexec (reg, str, strlen (str), 0, NULL, 0);
+
+  char reg_err_buf[REGEX_MAX_ERROR_MSG_SIZE] = { '\0' };
+  switch (ret_code)
+    {
+    case CUB_REG_OKAY:
+      *match = true;
+      break;
+
+    case CUB_REG_NOMATCH:
+      *match = false;
+      break;
+
+    default:
+      int rx_err_len = (int) cub_regerror (ret_code, reg, reg_err_buf, REGEX_MAX_ERROR_MSG_SIZE);
+      error_status = ER_REGEX_EXEC_ERROR;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 1, reg_err_buf);
+      *match = false;
+      break;
+    }
+
+  cub_regfree (reg);
+  db_private_free_and_init (NULL, reg);
+  return error_status;
+#endif
+}
+
+static int
+regex_compile (cub_regex_t * &rx_compiled_regex, const char *rx_compiled_pattern, int reg_flags)
+{
+  /* initialize regex library memory allocator */
+  cub_regset_malloc ((CUB_REG_MALLOC) db_private_alloc_external);
+  cub_regset_realloc ((CUB_REG_REALLOC) db_private_realloc_external);
+  cub_regset_free ((CUB_REG_FREE) db_private_free_external);
+
+  if (rx_compiled_regex != NULL)
+    {
+      /* free previously allocated memory */
+      cub_regfree (rx_compiled_regex);
+      db_private_free_and_init (NULL, rx_compiled_regex);
+    }
+
+  /* allocate memory for new regex object */
+  rx_compiled_regex = (cub_regex_t *) db_private_alloc (NULL, sizeof (cub_regex_t));
+
+  if (rx_compiled_regex == NULL)
+    {
+      /* out of memory */
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+
+  /* compile regex */
+  int rx_err = cub_regcomp (rx_compiled_regex, rx_compiled_pattern, reg_flags);
+
+  if (rx_err != CUB_REG_OKAY)
+    {
+      /* regex compilation error */
+      char rx_err_buf[REGEX_MAX_ERROR_MSG_SIZE] = { '\0' };
+      int rx_err_len = (int) cub_regerror (rx_err, rx_compiled_regex, rx_err_buf, REGEX_MAX_ERROR_MSG_SIZE);
+      int error_status = ER_REGEX_COMPILE_ERROR;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 1, rx_err_buf);
+      db_private_free_and_init (NULL, rx_compiled_regex);
+    }
+}
+
 /*
  * db_string_rlike () - check for match between string and regex
  *
@@ -4382,11 +4514,6 @@ db_string_rlike (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB
   pattern_char_string_p = db_get_string (pattern);
   pattern_length = db_get_string_size (pattern);
 
-  /* initialize regex library memory allocator */
-  cub_regset_malloc ((CUB_REG_MALLOC) db_private_alloc_external);
-  cub_regset_realloc ((CUB_REG_REALLOC) db_private_realloc_external);
-  cub_regset_free ((CUB_REG_FREE) db_private_free_external);
-
   /* extract case sensitivity */
   is_case_sensitive = (case_sensitive->data.i != 0);
 
@@ -4419,38 +4546,11 @@ db_string_rlike (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB
       memcpy (rx_compiled_pattern, pattern_char_string_p, pattern_length);
       rx_compiled_pattern[pattern_length] = '\0';
 
-      /* update compiled regex */
-      if (rx_compiled_regex != NULL)
+      int error_code = regex_compile (rx_compiled_regex, rx_compiled_pattern,
+				      CUB_REG_EXTENDED | CUB_REG_NOSUB | (is_case_sensitive ? 0 : CUB_REG_ICASE));
+      if (error_code != NO_ERROR)
 	{
-	  /* free previously allocated memory */
-	  cub_regfree (rx_compiled_regex);
-	  db_private_free_and_init (NULL, rx_compiled_regex);
-	}
-
-      /* allocate memory for new regex object */
-      rx_compiled_regex = (cub_regex_t *) db_private_alloc (NULL, sizeof (cub_regex_t));
-
-      if (rx_compiled_regex == NULL)
-	{
-	  /* out of memory */
-	  error_status = ER_OUT_OF_VIRTUAL_MEMORY;
-	  *result = V_ERROR;
-	  goto cleanup;
-	}
-
-      /* compile regex */
-      rx_err =
-	cub_regcomp (rx_compiled_regex, rx_compiled_pattern,
-		     CUB_REG_EXTENDED | CUB_REG_NOSUB | (is_case_sensitive ? 0 : CUB_REG_ICASE));
-
-      if (rx_err != CUB_REG_OKAY)
-	{
-	  /* regex compilation error */
-	  rx_err_len = (int) cub_regerror (rx_err, rx_compiled_regex, rx_err_buf, REGEX_MAX_ERROR_MSG_SIZE);
-	  error_status = ER_REGEX_COMPILE_ERROR;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 1, rx_err_buf);
-	  *result = V_ERROR;
-	  db_private_free_and_init (NULL, rx_compiled_regex);
+	  ASSERT_ERROR ();
 	  goto cleanup;
 	}
     }
@@ -4468,7 +4568,7 @@ db_string_rlike (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB
       break;
 
     default:
-      rx_err_len = (int) cub_regerror (rx_err, rx_compiled_regex, rx_err_buf, REGEX_MAX_ERROR_MSG_SIZE);
+      int rx_err_len = (int) cub_regerror (rx_err, rx_compiled_regex, rx_err_buf, REGEX_MAX_ERROR_MSG_SIZE);
       error_status = ER_REGEX_EXEC_ERROR;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 1, rx_err_buf);
       *result = V_ERROR;

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4276,10 +4276,6 @@ db_string_like (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB_
   return ((*result == V_ERROR) ? ER_QSTR_INVALID_ESCAPE_SEQUENCE : error_status);
 }
 
-
-#ifndef _USE_LIBREGEX_
-#define _USE_LIBREGEX_
-#endif
 extern int
 regex_matches (const char *pattern, const char *str, int reg_flags, bool * match)
 {

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4322,24 +4322,24 @@ regex_matches (const char *pattern, const char *str, int reg_flags, bool * match
       error_status = ER_REGEX_COMPILE_ERROR;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 1, e.what ());
       *match = false;
-      return ER_REGEX_COMPILE_ERROR;
+      return error_status;
     }
   /* *INDENT-ON* */
   return NO_ERROR;
 
 #else
   cub_regex_t *reg = NULL;
-  int ret_code = regex_compile (reg, pattern, reg_flags);
-  if (ret_code != CUB_REG_OKAY)
+  error_status = regex_compile (reg, pattern, reg_flags);
+  if (error_status != NO_ERROR)
     {
       ASSERT_ERROR ();
-      return ER_REGEX_COMPILE_ERROR;
+      return error_status;
     }
 
-  ret_code = cub_regexec (reg, str, strlen (str), 0, NULL, 0);
+  int rx_code = cub_regexec (reg, str, strlen (str), 0, NULL, 0);
 
   char reg_err_buf[REGEX_MAX_ERROR_MSG_SIZE] = { '\0' };
-  switch (ret_code)
+  switch (rx_code)
     {
     case CUB_REG_OKAY:
       *match = true;
@@ -4395,12 +4395,12 @@ regex_compile (cub_regex_t * &rx_compiled_regex, const char *rx_compiled_pattern
       /* regex compilation error */
       char rx_err_buf[REGEX_MAX_ERROR_MSG_SIZE] = { '\0' };
       int rx_err_len = (int) cub_regerror (rx_err, rx_compiled_regex, rx_err_buf, REGEX_MAX_ERROR_MSG_SIZE);
-      int error_status = ER_REGEX_COMPILE_ERROR;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 1, rx_err_buf);
       db_private_free_and_init (NULL, rx_compiled_regex);
+      return ER_REGEX_COMPILE_ERROR;
     }
 
-  return rx_err;
+  return NO_ERROR;
 }
 
 /*

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4276,10 +4276,6 @@ db_string_like (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB_
   return ((*result == V_ERROR) ? ER_QSTR_INVALID_ESCAPE_SEQUENCE : error_status);
 }
 
-#ifndef _USE_LIBREGEX_
-#define _USE_LIBREGEX_
-#endif
-
 extern int
 regex_matches (const char *pattern, const char *str, int reg_flags, bool * match)
 {

--- a/src/query/string_opfunc.h
+++ b/src/query/string_opfunc.h
@@ -172,6 +172,7 @@ extern int nchar_compare (const unsigned char *string1, int size1, const unsigne
 			  INTL_CODESET codeset);
 extern int bit_compare (const unsigned char *string1, int size1, const unsigned char *string2, int size2);
 extern int varbit_compare (const unsigned char *string1, int size1, const unsigned char *string2, int size2);
+extern int regex_matches (const char *pattern, const char *str, int reg_flags, bool * match);
 extern int get_last_day (int month, int year);
 extern int get_day (int month, int day, int year);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22685

Use libregex when using gcc < 4.9.0 and switch the regex definition language from ECMAScript to POSIX.