### PR TITLE
[CBRD-22696] no MRO for aggregate queries

### DIFF
--- a/src/optimizer/plan_generation.c
+++ b/src/optimizer/plan_generation.c
@@ -3421,6 +3421,21 @@ qo_check_iscan_for_multi_range_opt (QO_PLAN * plan)
       /* NO_MULTI_RANGE_OPT was hinted */
       return false;
     }
+  if (pt_has_aggregate (parser, query))
+    {
+      // CBRD-22696
+      //
+      // MRO XASL is flawed when query has aggregate. MRO depends on order by list, which is generated based on
+      // query's select list. Then it uses pointers from XASL outptr_list, which is normally also generated based
+      // on query's select list.
+      //
+      // In case of group by and/or aggregates, XASL outptr_list is used as input list for group by/aggregate. As a
+      // consequence, MRO is broken; sometimes it will fallback to normal index scan (because pointers do not match),
+      // but sometimes a safe-guard is hit (when order by position number is not found in outptr_list).
+      //
+      // until a proper fix is found, MRO is disabled for aggregate queries.
+      return false;
+    }
   all_distinct = query->info.query.all_distinct;
   order_by = query->info.query.order_by;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22696

The MRO execution relies on XASL fields orderby_list & outptr_list. However, these two are not in sync in aggregate queries:

Aggregate code that actually uses outptr_list as input for aggregate and buildlist->g_outptr_list as output:
```c
  if (pt_has_aggregate (parser, select_node))
...
      xasl->outptr_list = pt_to_outlist (parser, group_out_list, NULL, UNBOX_AS_VALUE);
...
      aggregate =
	pt_to_aggregate (parser, select_node, xasl->outptr_list, buildlist->g_val_list, buildlist->g_regu_list,
			 buildlist->g_scan_regu_list, group_out_list, &buildlist->g_grbynum_val);
...
      buildlist->g_outptr_list = pt_to_outlist (parser, select_node->info.query.q.select.list, NULL, unbox);
```

But orderby_list is always generated based on select list:

```c
	      xasl->orderby_list = pt_to_orderby (parser, select_node->info.query.order_by, select_node);
```

Since the code is complex and sensible, a proper fix may be complicated and even dangerous. This patch quickly fixes by disabling MRO in case of aggregate queries.