### PR TITLE
[CBRD-22698] Accept json table resolved names 

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -10147,7 +10147,7 @@ pt_bind_name_to_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
 
   if (pt_resolved (node))
     {
-      assert (node->info.name.spec_id = spec->info.spec.id);
+      assert (node->info.name.spec_id == spec->info.spec.id);
       return node;
     }
 

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -10145,7 +10145,12 @@ pt_bind_name_to_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
       return node;
     }
 
-  assert (!pt_resolved (node));
+  if (pt_resolved (node))
+    {
+      assert (node->info.name.spec_id = spec->info.spec.id);
+      return node;
+    }
+
   node->info.name.spec_id = spec->info.spec.id;
   node->info.name.resolved = spec->info.spec.range_var->info.name.original;
   node->info.name.meta_class = PT_NORMAL;	// so far, only normals are used.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22698

JSON table names are already resolved after tree is copied and ID's reset.