### PR TITLE
[CBRD-22699] Ordinality in nested path does not get reset

### DIFF
--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -452,7 +452,7 @@ namespace cubscan
     void
     scanner::reset_ordinality (cubxasl::json_table::node &node)
     {
-      node.m_ordinality = 1;
+      node.init_ordinality ();
 
       for (size_t i = 0; i < node.m_nested_nodes_size; ++i)
 	{

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -243,7 +243,7 @@ namespace cubxasl
     node::init ()
     {
       m_path = NULL;
-      m_ordinality = 1;
+      init_ordinality ();
       m_output_columns = NULL;
       m_output_columns_size = 0;
       m_nested_nodes = NULL;
@@ -267,6 +267,7 @@ namespace cubxasl
 
 	  (void) pr_clear_value (output_column->m_output_value_pointer);
 	  (void) db_make_null (output_column->m_output_value_pointer);
+	  (void) init_ordinality ();
 	}
     }
 
@@ -306,6 +307,12 @@ namespace cubxasl
 	{
 	  m_iterator = db_json_create_iterator (DB_JSON_TYPE::DB_JSON_ARRAY);
 	}
+    }
+
+    void
+    node::init_ordinality()
+    {
+      m_ordinality = 1;
     }
 
     spec_node::spec_node ()

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -256,6 +256,7 @@ namespace cubxasl
     void
     node::clear_columns (bool is_final_clear)
     {
+      init_ordinality ();
       for (size_t i = 0; i < m_output_columns_size; ++i)
 	{
 	  column *output_column = &m_output_columns[i];
@@ -267,7 +268,6 @@ namespace cubxasl
 
 	  (void) pr_clear_value (output_column->m_output_value_pointer);
 	  (void) db_make_null (output_column->m_output_value_pointer);
-	  (void) init_ordinality ();
 	}
     }
 

--- a/src/xasl/access_json_table.hpp
+++ b/src/xasl/access_json_table.hpp
@@ -90,6 +90,7 @@ namespace cubxasl
       void clear_iterators (bool is_final_clear);
       void clear_tree (bool is_final_clear);
       void init_iterator ();
+      void init_ordinality ();
     };
 
     struct spec_node


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22699

After finishing iterating, m_ordinality should be reinited in the cursor's parent node.