### PR TITLE
[CBRD-22693] pr_type functions with const signatures

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -228,7 +228,6 @@ set(QUERY_HEADERS
 
 set(OBJECT_SOURCES
   ${OBJECT_DIR}/elo.c
-  ${OBJECT_DIR}/object_print.c
   ${OBJECT_DIR}/set_object.c
   ${OBJECT_DIR}/object_representation.c
   ${OBJECT_DIR}/object_primitive.c

--- a/src/base/event_log.c
+++ b/src/base/event_log.c
@@ -422,7 +422,7 @@ event_log_bind_values (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_index, i
 
   for (i = 0; i < tdes->bind_history[bind_index].size; i++)
     {
-      val_str = pr_valstring (thread_p, &tdes->bind_history[bind_index].vals[i]);
+      val_str = pr_valstring (&tdes->bind_history[bind_index].vals[i]);
       fprintf (log_fp, "%*cbind: %s\n", indent, ' ', (val_str == NULL) ? "(null)" : val_str);
 
       if (val_str != NULL)

--- a/src/compat/db_date.h
+++ b/src/compat/db_date.h
@@ -27,6 +27,8 @@
 
 #ident "$Id$"
 
+#include "dbtype_def.h"
+
 #include <time.h>
 
 /* DB_DATE functions */

--- a/src/compat/db_info.c
+++ b/src/compat/db_info.c
@@ -2414,7 +2414,7 @@ db_get_schema_def_dbval (DB_VALUE * result, DB_VALUE * name_val)
   assert (result != (DB_VALUE *) NULL);
   if (DB_IS_NULL (name_val))
     {
-      db_make_null (result);
+      PRIM_SET_NULL (result);
       return NO_ERROR;
     }
 
@@ -2450,7 +2450,7 @@ db_get_schema_def_dbval (DB_VALUE * result, DB_VALUE * name_val)
   return error_status;
 
 error:
-  db_make_null (result);
+  PRIM_SET_NULL (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       return NO_ERROR;

--- a/src/compat/db_info.c
+++ b/src/compat/db_info.c
@@ -2414,7 +2414,7 @@ db_get_schema_def_dbval (DB_VALUE * result, DB_VALUE * name_val)
   assert (result != (DB_VALUE *) NULL);
   if (DB_IS_NULL (name_val))
     {
-      PRIM_SET_NULL (result);
+      db_make_null (result);
       return NO_ERROR;
     }
 
@@ -2450,7 +2450,7 @@ db_get_schema_def_dbval (DB_VALUE * result, DB_VALUE * name_val)
   return error_status;
 
 error:
-  PRIM_SET_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       return NO_ERROR;

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -984,7 +984,7 @@ db_string_truncate (DB_VALUE * value, const int precision)
 			   db_get_string_codeset (value), db_get_string_collation (value));
 
 	  pr_clear_value (value);
-	  (*(tp_String.setval)) (value, &src_value, true);
+	  tp_String.setval (value, &src_value, true);
 
 	  pr_clear_value (&src_value);
 	}
@@ -1009,7 +1009,7 @@ db_string_truncate (DB_VALUE * value, const int precision)
 			db_get_string_codeset (value), db_get_string_collation (value));
 
 	  pr_clear_value (value);
-	  (*(tp_Char.setval)) (value, &src_value, true);
+	  tp_Char.setval (value, &src_value, true);
 
 	  pr_clear_value (&src_value);
 
@@ -1035,7 +1035,7 @@ db_string_truncate (DB_VALUE * value, const int precision)
 			    db_get_string_codeset (value), db_get_string_collation (value));
 
 	  pr_clear_value (value);
-	  (*(tp_VarNChar.setval)) (value, &src_value, true);
+	  tp_VarNChar.setval (value, &src_value, true);
 
 	  pr_clear_value (&src_value);
 	}
@@ -1060,7 +1060,7 @@ db_string_truncate (DB_VALUE * value, const int precision)
 			 db_get_string_codeset (value), db_get_string_collation (value));
 
 	  pr_clear_value (value);
-	  (*(tp_NChar.setval)) (value, &src_value, true);
+	  tp_NChar.setval (value, &src_value, true);
 
 	  pr_clear_value (&src_value);
 
@@ -1083,7 +1083,7 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	  db_make_bit (&src_value, precision << 3, string, precision << 3);
 
 	  pr_clear_value (value);
-	  (*(tp_Bit.setval)) (value, &src_value, true);
+	  tp_Bit.setval (value, &src_value, true);
 
 	  pr_clear_value (&src_value);
 	}
@@ -1105,7 +1105,7 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	  db_make_varbit (&src_value, precision << 3, string, precision << 3);
 
 	  pr_clear_value (value);
-	  (*(tp_VarBit.setval)) (value, &src_value, true);
+	  tp_VarBit.setval (value, &src_value, true);
 
 	  pr_clear_value (&src_value);
 
@@ -4911,7 +4911,7 @@ valcnv_convert_value_to_string (DB_VALUE * value_p)
 		       (char *) buf_p->bytes, CAST_STRLEN (buf_p->length), LANG_SYS_CODESET, LANG_SYS_COLLATION);
 
       pr_clear_value (value_p);
-      (*(tp_String.setval)) (value_p, &src_value, true);
+      tp_String.setval (value_p, &src_value, true);
 
       pr_clear_value (&src_value);
       free_and_init (buf_p->bytes);

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -36,7 +36,7 @@
 #include "system_parameter.h"
 #include "error_manager.h"
 #include "db.h"
-#include "object_print.h"
+#include "db_value_printer.hpp"
 #include "string_opfunc.h"
 #include "set_object.h"
 #include "cnv.h"
@@ -1661,7 +1661,7 @@ db_value_print (const DB_VALUE * value)
 
   if (value != NULL)
     {
-      help_fprint_value (NULL, stdout, value);
+      db_fprint_value (stdout, value);
     }
 
 }
@@ -1679,9 +1679,8 @@ db_value_fprint (FILE * fp, const DB_VALUE * value)
 
   if (fp != NULL && value != NULL)
     {
-      help_fprint_value (NULL, fp, value);
+      db_fprint_value (fp, value);
     }
-
 }
 
 /*

--- a/src/compat/db_value_printer.cpp
+++ b/src/compat/db_value_printer.cpp
@@ -22,27 +22,17 @@
  */
 
 #include "db_value_printer.hpp"
-#include "tz_support.h"
+
 #include "db_date.h"
 #include "dbtype.h"
-#include "intl_support.h"
-#include "language_support.h"
-#include "numeric_opfunc.h"
+#include "memory_private_allocator.hpp"
 #include "object_primitive.h"
 #include "set_object.h"
 #include "string_buffer.hpp"
 #include "string_opfunc.h"
+#include "tz_support.h"
 #if !defined(SERVER_MODE)
 #include "virtual_object.h"
-#endif
-#include "work_space.h"
-#include "memory_alloc.h"
-
-#include <assert.h>
-#include <float.h>
-
-#if defined(SA_MODE)
-extern unsigned int db_on_server;
 #endif
 
 const char db_value_printer::DECIMAL_FORMAT[] = "%#.*g";
@@ -142,28 +132,9 @@ void db_value_printer::describe_value (const db_value *value)
 	case DB_TYPE_ENUMERATION:
 	  if (db_get_enum_string (value) == NULL && db_get_enum_short (value) != 0)
 	    {
-#if defined(SERVER_MODE)
 	      /* to print enum index as int */
 	      m_buf ("%d", (int)db_get_enum_short (value));
 	      break;
-#elif defined(SA_MODE)
-	      if (db_on_server)
-		{
-		  /* to print enum index as int */
-		  m_buf ("%d", (int)db_get_enum_short (value));
-		  break;
-		}
-	      else
-		{
-		  /* describe value should not be called on an enumeration which is not fully constructed */
-		  assert (false);
-		  m_buf ("''");
-		}
-#else /* CS_MODE */
-	      /* describe value should not be called on an enumeration which is not fully constructed */
-	      assert (false);
-	      m_buf ("''");
-#endif
 	    }
 	  else
 	    {
@@ -598,4 +569,34 @@ void db_value_printer::describe_set (const db_collection *set, int help_Max_set_
       m_buf (". . .");
     }
   m_buf += '}';
+}
+
+/*
+ * db_value_fprint() -  Prints a description of the contents of a DB_VALUE
+ *                        to the file
+ *   return: none
+ *   fp(in) : FILE stream pointer
+ *   value(in) : value to print
+ */
+void
+db_fprint_value (FILE *fp, const db_value *value)
+{
+  const size_t BUFFER_SIZE = 1024;
+  string_buffer sb (cubmem::PRIVATE_BLOCK_ALLOCATOR, BUFFER_SIZE);
+
+  db_value_printer printer (sb);
+  printer.describe_value (value);
+  fprintf (fp, "%.*s", (int) sb.len (), sb.get_buffer ());
+}
+
+/*
+ * db_sprint_value() - This places a printed representation of the supplied value in a buffer.
+ *   value(in) : value to describe
+ *   sb(in/out) : auto resizable buffer to contain description
+ */
+void
+db_sprint_value (const db_value *value, string_buffer &sb)
+{
+  db_value_printer printer (sb);
+  printer.describe_value (value);
 }

--- a/src/compat/db_value_printer.hpp
+++ b/src/compat/db_value_printer.hpp
@@ -26,6 +26,8 @@
 #ifndef _DB_VALUE_PRINTER_HPP_
 #define _DB_VALUE_PRINTER_HPP_
 
+#include <cstdio>
+
 struct db_collection;
 struct db_midxkey;
 struct db_monetary;
@@ -53,5 +55,8 @@ class db_value_printer
     void describe_midxkey (const db_midxkey *midxkey, int help_Max_set_elements=20);  //former describe_midxkey()
     void describe_set (const db_collection *set, int help_Max_set_elements=20);       //former describe_set()
 };
+
+void db_fprint_value (FILE *fp, const db_value *value);
+void db_sprint_value (const db_value *value, string_buffer &sb);
 
 #endif //_DB_VALUE_PRINTER_HPP_

--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -256,7 +256,7 @@ extern "C"
   extern int db_value_free (DB_VALUE * value);
   extern int db_value_clear_array (DB_VALUE_ARRAY * value_array);
   extern void db_value_print (const DB_VALUE * value);
-  extern void db_value_fprint (FILE * fp, const DB_VALUE * value);
+  extern void db_fprint_value (FILE * fp, const DB_VALUE * value);
   extern int db_value_coerce (const DB_VALUE * src, DB_VALUE * dest, const DB_DOMAIN * desired_domain);
 
   extern int db_value_equal (const DB_VALUE * value1, const DB_VALUE * value2);

--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -256,7 +256,7 @@ extern "C"
   extern int db_value_free (DB_VALUE * value);
   extern int db_value_clear_array (DB_VALUE_ARRAY * value_array);
   extern void db_value_print (const DB_VALUE * value);
-  extern void db_fprint_value (FILE * fp, const DB_VALUE * value);
+  extern void db_value_fprint (FILE * fp, const DB_VALUE * value);
   extern int db_value_coerce (const DB_VALUE * src, DB_VALUE * dest, const DB_DOMAIN * desired_domain);
 
   extern int db_value_equal (const DB_VALUE * value1, const DB_VALUE * value2);

--- a/src/executables/csql.h
+++ b/src/executables/csql.h
@@ -41,7 +41,6 @@
 #include "misc_string.h"
 #include "dbi.h"
 #include "error_manager.h"
-#include "object_print.h"
 #include "memory_alloc.h"
 
 #if defined(WINDOWS)

--- a/src/executables/csql_session.c
+++ b/src/executables/csql_session.c
@@ -30,10 +30,12 @@
 #include <signal.h>
 #include <assert.h>
 
+#include "csql.h"
+
 #include "class_description.hpp"
 #include "porting.h"
-#include "csql.h"
 #include "memory_alloc.h"
+#include "object_print.h"
 #include "util_func.h"
 #include "network_interface_cl.h"
 #include "unicode_support.h"

--- a/src/executables/load_object.c
+++ b/src/executables/load_object.c
@@ -50,7 +50,7 @@
 #include "schema_manager.h"
 #include "server_interface.h"
 #include "load_object.h"
-#include "object_print.h"
+#include "db_value_printer.hpp"
 #include "network_interface_cl.h"
 
 #include "message_catalog.h"
@@ -1644,7 +1644,7 @@ desc_value_fprint (FILE * fp, DB_VALUE * value)
       break;
 
     default:
-      db_value_fprint (fp, value);
+      db_fprint_value (fp, value);
       break;
     }
 }

--- a/src/executables/load_object.c
+++ b/src/executables/load_object.c
@@ -678,7 +678,7 @@ get_desc_current (OR_BUF * buf, SM_CLASS * class_, DESC_OBJ * obj, int bound_bit
       else
 	{
 	  /* read the disk value into the db_value */
-	  (*(att->type->data_readval)) (buf, &obj->values[i], att->domain, -1, true, NULL, 0);
+	  att->type->data_readval (buf, &obj->values[i], att->domain, -1, true, NULL, 0);
 	}
     }
 
@@ -701,7 +701,7 @@ get_desc_current (OR_BUF * buf, SM_CLASS * class_, DESC_OBJ * obj, int bound_bit
       for (i = class_->fixed_count, j = 0; i < class_->att_count && j < class_->variable_count;
 	   i++, j++, att = (SM_ATTRIBUTE *) att->header.next)
 	{
-	  (*(att->type->data_readval)) (buf, &obj->values[i], att->domain, vars[j], true, NULL, 0);
+	  att->type->data_readval (buf, &obj->values[i], att->domain, vars[j], true, NULL, 0);
 	}
 
       free_and_init (vars);
@@ -814,12 +814,12 @@ get_desc_old (OR_BUF * buf, SM_CLASS * class_, int repid, DESC_OBJ * obj, int bo
 	  if (attmap[i] == NULL)
 	    {
 	      /* its gone, skip over it */
-	      (*(type->data_readval)) (buf, NULL, rat->domain, -1, true, NULL, 0);
+	      type->data_readval (buf, NULL, rat->domain, -1, true, NULL, 0);
 	    }
 	  else
 	    {
 	      /* its real, get it into the proper value */
-	      (*(type->data_readval)) (buf, &obj->values[attmap[i]->storage_order], rat->domain, -1, true, NULL, 0);
+	      type->data_readval (buf, &obj->values[attmap[i]->storage_order], rat->domain, -1, true, NULL, 0);
 	    }
 	}
 
@@ -872,13 +872,13 @@ get_desc_old (OR_BUF * buf, SM_CLASS * class_, int repid, DESC_OBJ * obj, int bo
 	  if (attmap[att_index] == NULL)
 	    {
 	      /* its null, skip over it */
-	      (*(type->data_readval)) (buf, NULL, rat->domain, vars[i], true, NULL, 0);
+	      type->data_readval (buf, NULL, rat->domain, vars[i], true, NULL, 0);
 	    }
 	  else
 	    {
 	      /* read it into the proper value */
-	      (*(type->data_readval)) (buf, &obj->values[attmap[att_index]->storage_order], rat->domain, vars[i], true,
-				       NULL, 0);
+	      type->data_readval (buf, &obj->values[attmap[att_index]->storage_order], rat->domain, vars[i], true, NULL,
+				  0);
 	    }
 	}
 

--- a/src/executables/loader.c
+++ b/src/executables/loader.c
@@ -1720,7 +1720,7 @@ ldr_null_db_generic (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBU
   else
     {
       mem = context->mobj + att->offset;
-      CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, NULL));
+      CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, NULL));
       if (!att->domain->type->variable_p)
 	OBJ_CLEAR_BOUND_BIT (context->mobj, att->storage_order);
     }
@@ -2023,7 +2023,7 @@ ldr_int_db_bigint (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUTE
     }
 
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -2078,7 +2078,7 @@ ldr_int_db_int (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUTE * 
     }
 
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -2134,7 +2134,7 @@ ldr_int_db_short (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUTE 
     }
 
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -2237,7 +2237,7 @@ ldr_str_db_char (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUTE *
   val.data.ch.medium.compressed_buf = NULL;
   val.data.ch.medium.compressed_size = 0;
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -2307,7 +2307,7 @@ ldr_str_db_varchar (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUT
   val.data.ch.medium.compressed_size = 0;
 
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   /*
    * No bound bit to be set for a variable length attribute.
    */
@@ -2724,7 +2724,7 @@ ldr_real_db_float (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUTE
     val.data.f = (float) d;
 
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -2766,7 +2766,7 @@ ldr_real_db_double (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUT
     val.data.d = d;
 
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -2818,7 +2818,7 @@ ldr_date_db_date (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUTE 
 
   CHECK_ERR (err, ldr_date_elem (context, str, len, &val));
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -2862,7 +2862,7 @@ ldr_time_db_time (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUTE 
 
   CHECK_ERR (err, ldr_time_elem (context, str, len, &val));
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -2906,7 +2906,7 @@ ldr_timestamp_db_timestamp (LDR_CONTEXT * context, const char *str, int len, SM_
 
   CHECK_ERR (err, ldr_timestamp_elem (context, str, len, &val));
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -2974,7 +2974,7 @@ ldr_timestamptz_db_timestamptz (LDR_CONTEXT * context, const char *str, int len,
 
   CHECK_ERR (err, ldr_timestamptz_elem (context, str, len, &val));
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -2998,7 +2998,7 @@ ldr_timestampltz_db_timestampltz (LDR_CONTEXT * context, const char *str, int le
 
   CHECK_ERR (err, ldr_timestampltz_elem (context, str, len, &val));
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -3042,7 +3042,7 @@ ldr_datetime_db_datetime (LDR_CONTEXT * context, const char *str, int len, SM_AT
 
   CHECK_ERR (err, ldr_datetime_elem (context, str, len, &val));
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -3110,7 +3110,7 @@ ldr_datetimetz_db_datetimetz (LDR_CONTEXT * context, const char *str, int len, S
 
   CHECK_ERR (err, ldr_datetimetz_elem (context, str, len, &val));
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -3134,7 +3134,7 @@ ldr_datetimeltz_db_datetimeltz (LDR_CONTEXT * context, const char *str, int len,
 
   CHECK_ERR (err, ldr_datetimeltz_elem (context, str, len, &val));
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -3461,7 +3461,7 @@ ldr_elo_ext_db_elo (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUT
   name[new_len] = '\0';
   CHECK_ERR (err, ldr_elo_ext_elem (context, name, new_len, &val));
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   /* No bound bit to be set for a variable length attribute. */
 
 error_exit:
@@ -3834,7 +3834,7 @@ ldr_class_oid_db_object (LDR_CONTEXT * context, const char *str, int len, SM_ATT
   else
     {
       mem = context->mobj + att->offset;
-      CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+      CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
       OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
     }
 
@@ -3911,7 +3911,7 @@ ldr_oid_db_object (LDR_CONTEXT * context, const char *str, int len, SM_ATTRIBUTE
 
   mem = context->mobj + att->offset;
 
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:
@@ -3980,7 +3980,7 @@ ldr_monetary_db_monetary (LDR_CONTEXT * context, const char *str, int len, SM_AT
 
   CHECK_ERR (err, ldr_monetary_elem (context, str, len, &val));
   mem = context->mobj + att->offset;
-  CHECK_ERR (err, PRIM_SETMEM (att->domain->type, att->domain, mem, &val));
+  CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));
   OBJ_SET_BOUND_BIT (context->mobj, att->storage_order);
 
 error_exit:

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -1386,10 +1386,10 @@ classobj_put_foreign_key_ref (DB_SEQ ** properties, SM_FOREIGN_KEY_INFO * fk_inf
   int fk_container_pos, pk_seq_pos;
   int err = NO_ERROR;
 
-  PRIM_SET_NULL (&prop_val);
-  PRIM_SET_NULL (&pk_val);
-  PRIM_SET_NULL (&fk_container_val);
-  PRIM_SET_NULL (&fk_val);
+  db_make_null (&prop_val);
+  db_make_null (&pk_val);
+  db_make_null (&fk_container_val);
+  db_make_null (&fk_val);
 
   if (classobj_get_prop (*properties, SM_PROPERTY_PRIMARY_KEY, &prop_val) <= 0)
     {
@@ -1456,7 +1456,7 @@ classobj_put_foreign_key_ref (DB_SEQ ** properties, SM_FOREIGN_KEY_INFO * fk_inf
     {
       /* retrieve the last element */
       DB_VALUE save_last;
-      PRIM_SET_NULL (&save_last);
+      db_make_null (&save_last);
       err = set_get_element (pk_seq, size - 1, &save_last);
       if (err != NO_ERROR)
 	{
@@ -1466,7 +1466,7 @@ classobj_put_foreign_key_ref (DB_SEQ ** properties, SM_FOREIGN_KEY_INFO * fk_inf
 
       /* Retrieve status. */
       DB_VALUE save_status;
-      PRIM_SET_NULL (&save_status);
+      db_make_null (&save_status);
       err = set_get_element (pk_seq, size - 2, &save_status);
       if (err != NO_ERROR)
 	{
@@ -1547,12 +1547,12 @@ classobj_rename_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const 
   char *name = NULL;
   int found = 0;
 
-  PRIM_SET_NULL (&prop_val);
-  PRIM_SET_NULL (&pk_val);
-  PRIM_SET_NULL (&fk_container_val);
-  PRIM_SET_NULL (&fk_val);
-  PRIM_SET_NULL (&new_fk_val);
-  PRIM_SET_NULL (&new_name_val);
+  db_make_null (&prop_val);
+  db_make_null (&pk_val);
+  db_make_null (&fk_container_val);
+  db_make_null (&fk_val);
+  db_make_null (&new_fk_val);
+  db_make_null (&new_name_val);
 
   if (classobj_get_prop (*properties, SM_PROPERTY_PRIMARY_KEY, &prop_val) <= 0)
     {
@@ -1585,8 +1585,8 @@ classobj_rename_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const 
       /* find the position of the existing FK ref */
       for (i = 0; i < fk_container_len; i++)
 	{
-	  PRIM_SET_NULL (&fk_val);
-	  PRIM_SET_NULL (&name_val);
+	  db_make_null (&fk_val);
+	  db_make_null (&name_val);
 
 	  err = set_get_element (fk_container, i, &fk_val);
 	  if (err != NO_ERROR)
@@ -1716,11 +1716,11 @@ classobj_drop_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const ch
   int volid, pageid, fileid;
   int err = NO_ERROR;
 
-  PRIM_SET_NULL (&prop_val);
-  PRIM_SET_NULL (&pk_val);
-  PRIM_SET_NULL (&fk_container_val);
-  PRIM_SET_NULL (&fk_val);
-  PRIM_SET_NULL (&btid_val);
+  db_make_null (&prop_val);
+  db_make_null (&pk_val);
+  db_make_null (&fk_container_val);
+  db_make_null (&fk_val);
+  db_make_null (&btid_val);
 
   if (classobj_get_prop (*properties, SM_PROPERTY_PRIMARY_KEY, &prop_val) <= 0)
     {

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -1386,10 +1386,10 @@ classobj_put_foreign_key_ref (DB_SEQ ** properties, SM_FOREIGN_KEY_INFO * fk_inf
   int fk_container_pos, pk_seq_pos;
   int err = NO_ERROR;
 
-  db_make_null (&prop_val);
-  db_make_null (&pk_val);
-  db_make_null (&fk_container_val);
-  db_make_null (&fk_val);
+  PRIM_SET_NULL (&prop_val);
+  PRIM_SET_NULL (&pk_val);
+  PRIM_SET_NULL (&fk_container_val);
+  PRIM_SET_NULL (&fk_val);
 
   if (classobj_get_prop (*properties, SM_PROPERTY_PRIMARY_KEY, &prop_val) <= 0)
     {
@@ -1456,7 +1456,7 @@ classobj_put_foreign_key_ref (DB_SEQ ** properties, SM_FOREIGN_KEY_INFO * fk_inf
     {
       /* retrieve the last element */
       DB_VALUE save_last;
-      db_make_null (&save_last);
+      PRIM_SET_NULL (&save_last);
       err = set_get_element (pk_seq, size - 1, &save_last);
       if (err != NO_ERROR)
 	{
@@ -1466,7 +1466,7 @@ classobj_put_foreign_key_ref (DB_SEQ ** properties, SM_FOREIGN_KEY_INFO * fk_inf
 
       /* Retrieve status. */
       DB_VALUE save_status;
-      db_make_null (&save_status);
+      PRIM_SET_NULL (&save_status);
       err = set_get_element (pk_seq, size - 2, &save_status);
       if (err != NO_ERROR)
 	{
@@ -1547,12 +1547,12 @@ classobj_rename_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const 
   char *name = NULL;
   int found = 0;
 
-  db_make_null (&prop_val);
-  db_make_null (&pk_val);
-  db_make_null (&fk_container_val);
-  db_make_null (&fk_val);
-  db_make_null (&new_fk_val);
-  db_make_null (&new_name_val);
+  PRIM_SET_NULL (&prop_val);
+  PRIM_SET_NULL (&pk_val);
+  PRIM_SET_NULL (&fk_container_val);
+  PRIM_SET_NULL (&fk_val);
+  PRIM_SET_NULL (&new_fk_val);
+  PRIM_SET_NULL (&new_name_val);
 
   if (classobj_get_prop (*properties, SM_PROPERTY_PRIMARY_KEY, &prop_val) <= 0)
     {
@@ -1585,8 +1585,8 @@ classobj_rename_foreign_key_ref (DB_SEQ ** properties, const BTID * btid, const 
       /* find the position of the existing FK ref */
       for (i = 0; i < fk_container_len; i++)
 	{
-	  db_make_null (&fk_val);
-	  db_make_null (&name_val);
+	  PRIM_SET_NULL (&fk_val);
+	  PRIM_SET_NULL (&name_val);
 
 	  err = set_get_element (fk_container, i, &fk_val);
 	  if (err != NO_ERROR)

--- a/src/object/object_accessor.c
+++ b/src/object/object_accessor.c
@@ -469,7 +469,7 @@ assign_null_value (MOP op, SM_ATTRIBUTE * att, char *mem)
     }
   else
     {
-      if (PRIM_SETMEM (att->domain->type, att->domain, mem, NULL))
+      if (att->domain->type->setmem (mem, att->domain, NULL))
 	{
 	  assert (er_errid () != NO_ERROR);
 	  return er_errid ();
@@ -566,7 +566,7 @@ assign_set_value (MOP op, SM_ATTRIBUTE * att, char *mem, SETREF * setref)
 	      break;
 	    }
 
-	  error = PRIM_SETMEM (att->domain->type, att->domain, mem, &val);
+	  error = att->domain->type->setmem (mem, att->domain, &val);
 	  db_value_put_null (&val);
 
 	  if (error == NO_ERROR)
@@ -676,7 +676,7 @@ obj_assign_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * value)
 	      /* uncomplicated assignment, use the primitive type macros */
 	      if (mem != NULL)
 		{
-		  error = PRIM_SETMEM (att->domain->type, att->domain, mem, value);
+		  error = att->domain->type->setmem (mem, att->domain, value);
 		  if (!error && !att->domain->type->variable_p)
 		    {
 		      if (ws_find (op, &object) == WS_FIND_MOP_DELETED || object == NULL)
@@ -1086,7 +1086,7 @@ get_object_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * source, DB_V
   if (mem != NULL)
     {
       db_make_object (&curval, NULL);
-      if (PRIM_GETMEM (att->domain->type, att->domain, mem, &curval))
+      if (att->domain->type->getmem (mem, att->domain, &curval))
 	{
 	  ASSERT_ERROR_AND_SET (rc);
 	  return rc;
@@ -1146,7 +1146,7 @@ get_object_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * source, DB_V
 	{
 	  if (mem != NULL)
 	    {
-	      if (PRIM_SETMEM (att->domain->type, att->domain, mem, NULL))
+	      if (att->domain->type->setmem (mem, att->domain, NULL))
 		{
 		  ASSERT_ERROR_AND_SET (rc);
 		  return rc;
@@ -1216,7 +1216,7 @@ get_set_value (MOP op, SM_ATTRIBUTE * att, char *mem, DB_VALUE * source, DB_VALU
   if (mem != NULL)
     {
       db_value_domain_init (&setval, TP_DOMAIN_TYPE (att->domain), DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
-      if (PRIM_GETMEM (att->domain->type, att->domain, mem, &setval))
+      if (att->domain->type->getmem (mem, att->domain, &setval))
 	{
 	  assert (er_errid () != NO_ERROR);
 	  return er_errid ();
@@ -1346,7 +1346,7 @@ obj_get_value (MOP op, SM_ATTRIBUTE * att, void *mem, DB_VALUE * source, DB_VALU
 	{
 	  if (mem != NULL)
 	    {
-	      error = PRIM_GETMEM (att->domain->type, att->domain, mem, dest);
+	      error = att->domain->type->getmem (mem, att->domain, dest);
 	    }
 	  else
 	    {
@@ -1898,7 +1898,7 @@ obj_alloc (SM_CLASS * class_, int bound_bit_status)
       for (att = class_->attributes; att != NULL; att = (SM_ATTRIBUTE *) att->header.next)
 	{
 	  mem = obj + att->offset;
-	  PRIM_INITMEM (att->domain->type, mem, att->domain);
+	  att->domain->type->f_initmem (mem, att->domain);
 	}
     }
 
@@ -2069,7 +2069,7 @@ obj_free_memory (SM_CLASS * class_, MOBJ obj)
   for (att = class_->attributes; att != NULL; att = (SM_ATTRIBUTE *) att->header.next)
     {
       mem = ((char *) obj) + att->offset;
-      PRIM_FREEMEM (att->domain->type, mem);
+      att->domain->type->freemem (mem);
     }
 
   db_ws_free (obj);

--- a/src/object/object_accessor.c
+++ b/src/object/object_accessor.c
@@ -1898,7 +1898,7 @@ obj_alloc (SM_CLASS * class_, int bound_bit_status)
       for (att = class_->attributes; att != NULL; att = (SM_ATTRIBUTE *) att->header.next)
 	{
 	  mem = obj + att->offset;
-	  att->domain->type->f_initmem (mem, att->domain);
+	  att->domain->type->initmem (mem, att->domain);
 	}
     }
 

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -11005,8 +11005,14 @@ tp_domain_memory_size (TP_DOMAIN * domain)
     {
       return -1;
     }
-
-  return domain->type->data_lengthmem (NULL, domain, 0);
+  if (domain->type->is_variable_size ())
+    {
+      return domain->type->data_lengthmem (NULL, domain, 0);
+    }
+  else
+    {
+      return domain->type->size;
+    }
 }
 
 /*

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -10973,7 +10973,7 @@ tp_value_equal (const DB_VALUE * value1, const DB_VALUE * value2, int do_coercio
 int
 tp_domain_disk_size (TP_DOMAIN * domain)
 {
-  if (domain->type->is_variable_size ())
+  if (domain->type->is_always_variable ())
     {
       return -1;
     }
@@ -10986,7 +10986,7 @@ tp_domain_disk_size (TP_DOMAIN * domain)
 
   assert (domain->precision != TP_FLOATING_PRECISION_VALUE);
 
-  return domain->type->data_lengthmem (NULL, domain, 1);
+  return domain->type->get_disk_size_of_mem (NULL, domain);
 }
 
 
@@ -10999,20 +10999,13 @@ tp_domain_disk_size (TP_DOMAIN * domain)
 int
 tp_domain_memory_size (TP_DOMAIN * domain)
 {
-  if (domain->type->is_variable_size ()
-      && (domain->type->get_id () == DB_TYPE_CHAR || domain->type->get_id () == DB_TYPE_NCHAR
-	  || domain->type->get_id () == DB_TYPE_BIT) && domain->precision == TP_FLOATING_PRECISION_VALUE)
+  if ((domain->type->get_id () == DB_TYPE_CHAR || domain->type->get_id () == DB_TYPE_NCHAR
+       || domain->type->get_id () == DB_TYPE_BIT) && domain->precision == TP_FLOATING_PRECISION_VALUE)
     {
       return -1;
     }
-  if (domain->type->is_variable_size ())
-    {
-      return domain->type->data_lengthmem (NULL, domain, 0);
-    }
-  else
-    {
-      return domain->type->size;
-    }
+
+  return domain->type->get_mem_size_of_mem (NULL, domain);
 }
 
 /*

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -10895,7 +10895,7 @@ tp_value_compare_with_error (const DB_VALUE * value1, const DB_VALUE * value2, i
 		}
 	      else
 		{
-		  result = (*(pr_type->cmpval)) (v1, v2, do_coercion, total_order, NULL, common_coll);
+		  result = pr_type->cmpval (v1, v2, do_coercion, total_order, NULL, common_coll);
 		}
 
 	      if (result == DB_UNK)
@@ -10959,7 +10959,7 @@ tp_value_equal (const DB_VALUE * value1, const DB_VALUE * value2, int do_coercio
 
 
 /*
- * tp_domain_disk_size - Caluclate the disk size necessary to store a value
+ * tp_domain_disk_size - Calculate the disk size necessary to store a value
  * for a particular domain.
  *    return: disk size in bytes. -1 if this is a variable width domain or
  *            floating precision in fixed domain.
@@ -10973,14 +10973,12 @@ tp_value_equal (const DB_VALUE * value1, const DB_VALUE * value2, int do_coercio
 int
 tp_domain_disk_size (TP_DOMAIN * domain)
 {
-  int size;
-
   if (domain->type->variable_p)
     {
       return -1;
     }
 
-  if (domain->type->data_lengthmem != NULL
+  if (!domain->type->is_data_lengthmem_fixed ()
       && (domain->type->id == DB_TYPE_CHAR || domain->type->id == DB_TYPE_NCHAR || domain->type->id == DB_TYPE_BIT)
       && domain->precision == TP_FLOATING_PRECISION_VALUE)
     {
@@ -10989,22 +10987,7 @@ tp_domain_disk_size (TP_DOMAIN * domain)
 
   assert (domain->precision != TP_FLOATING_PRECISION_VALUE);
 
-  /*
-   * Use the "lengthmem" function here with a NULL pointer.  The size will
-   * not be dependent on the actual value.
-   * The decision of whether or not to use the lengthmem function probably
-   * should be based on the value of "disksize" ?
-   */
-  if (domain->type->data_lengthmem != NULL)
-    {
-      size = (*(domain->type->data_lengthmem)) (NULL, domain, 1);
-    }
-  else
-    {
-      size = domain->type->disksize;
-    }
-
-  return size;
+  return domain->type->data_lengthmem (NULL, domain, 1);
 }
 
 
@@ -11017,30 +11000,14 @@ tp_domain_disk_size (TP_DOMAIN * domain)
 int
 tp_domain_memory_size (TP_DOMAIN * domain)
 {
-  int size;
-
-  if (domain->type->data_lengthmem != NULL
+  if (!domain->type->is_data_lengthmem_fixed ()
       && (domain->type->id == DB_TYPE_CHAR || domain->type->id == DB_TYPE_NCHAR || domain->type->id == DB_TYPE_BIT)
       && domain->precision == TP_FLOATING_PRECISION_VALUE)
     {
       return -1;
     }
 
-  /*
-   * Use the "lengthmem" function here with a NULL pointer and a "disk"
-   * flag of zero.
-   * This will cause it to return the instance memory size.
-   */
-  if (domain->type->data_lengthmem != NULL)
-    {
-      size = (*(domain->type->data_lengthmem)) (NULL, domain, 0);
-    }
-  else
-    {
-      size = domain->type->size;
-    }
-
-  return size;
+  return domain->type->data_lengthmem (NULL, domain, 0);
 }
 
 /*
@@ -11068,7 +11035,7 @@ tp_init_value_domain (TP_DOMAIN * domain, DB_VALUE * value)
     }
   else
     {
-      (*(domain->type->initval)) (value, domain->precision, domain->scale);
+      domain->type->initval (value, domain->precision, domain->scale);
     }
 }
 

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -10973,14 +10973,13 @@ tp_value_equal (const DB_VALUE * value1, const DB_VALUE * value2, int do_coercio
 int
 tp_domain_disk_size (TP_DOMAIN * domain)
 {
-  if (domain->type->variable_p)
+  if (domain->type->is_variable_size ())
     {
       return -1;
     }
 
-  if (!domain->type->is_data_lengthmem_fixed ()
-      && (domain->type->id == DB_TYPE_CHAR || domain->type->id == DB_TYPE_NCHAR || domain->type->id == DB_TYPE_BIT)
-      && domain->precision == TP_FLOATING_PRECISION_VALUE)
+  if ((domain->type->get_id () == DB_TYPE_CHAR || domain->type->get_id () == DB_TYPE_NCHAR
+       || domain->type->get_id () == DB_TYPE_BIT) && domain->precision == TP_FLOATING_PRECISION_VALUE)
     {
       return -1;
     }
@@ -11000,9 +10999,9 @@ tp_domain_disk_size (TP_DOMAIN * domain)
 int
 tp_domain_memory_size (TP_DOMAIN * domain)
 {
-  if (!domain->type->is_data_lengthmem_fixed ()
-      && (domain->type->id == DB_TYPE_CHAR || domain->type->id == DB_TYPE_NCHAR || domain->type->id == DB_TYPE_BIT)
-      && domain->precision == TP_FLOATING_PRECISION_VALUE)
+  if (domain->type->is_variable_size ()
+      && (domain->type->get_id () == DB_TYPE_CHAR || domain->type->get_id () == DB_TYPE_NCHAR
+	  || domain->type->get_id () == DB_TYPE_BIT) && domain->precision == TP_FLOATING_PRECISION_VALUE)
     {
       return -1;
     }

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -185,6 +185,30 @@ pr_type::pr_type (const char * name_arg, DB_TYPE id_arg, int varp_arg, int size_
   , f_cmpval {cmpval_f_arg}
   {
   }
+
+void
+pr_type::set_data_cmpdisk_function (data_cmpdisk_function_type data_cmpdisk_arg)
+{
+  f_data_cmpdisk = data_cmpdisk_arg;
+}
+
+pr_type::data_cmpdisk_function_type
+pr_type::get_data_cmpdisk_function () const
+{
+  return f_data_cmpdisk;
+}
+
+void
+pr_type::set_cmpval_function (cmpval_function_type cmpval_arg)
+{
+  f_cmpval = cmpval_arg;
+}
+
+pr_type::cmpval_function_type
+pr_type::get_cmpval_function () const
+{
+  return f_cmpval;
+}
 // *INDENT-ON*
 
 static void mr_initmem_string (void *mem, TP_DOMAIN * domain);

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -884,8 +884,6 @@ int pr_Inhibit_oid_promotion = PR_INHIBIT_OID_PROMOTION_DEFAULT;
 int pr_Enable_string_compression = true;
 PR_TYPE tp_Null = {
   "*NULL*", DB_TYPE_NULL, 0, 0, 0, 0,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_null,
   mr_initval_null,
   mr_setmem_null,
@@ -911,8 +909,6 @@ PR_TYPE *tp_Type_null = &tp_Null;
 
 PR_TYPE tp_Integer = {
   "integer", DB_TYPE_INTEGER, 0, sizeof (int), sizeof (int), 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_int,
   mr_initval_int,
   mr_setmem_int,
@@ -938,8 +934,6 @@ PR_TYPE *tp_Type_integer = &tp_Integer;
 
 PR_TYPE tp_Short = {
   "smallint", DB_TYPE_SHORT, 0, sizeof (short), sizeof (short), 2,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_short,
   mr_initval_short,
   mr_setmem_short,
@@ -965,8 +959,6 @@ PR_TYPE *tp_Type_short = &tp_Short;
 
 PR_TYPE tp_Bigint = {
   "bigint", DB_TYPE_BIGINT, 0, sizeof (DB_BIGINT), sizeof (DB_BIGINT), 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_bigint,
   mr_initval_bigint,
   mr_setmem_bigint,
@@ -992,8 +984,6 @@ PR_TYPE *tp_Type_bigint = &tp_Bigint;
 
 PR_TYPE tp_Float = {
   "float", DB_TYPE_FLOAT, 0, sizeof (float), sizeof (float), 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_float,
   mr_initval_float,
   mr_setmem_float,
@@ -1019,8 +1009,6 @@ PR_TYPE *tp_Type_float = &tp_Float;
 
 PR_TYPE tp_Double = {
   "double", DB_TYPE_DOUBLE, 0, sizeof (double), sizeof (double), 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_double,
   mr_initval_double,
   mr_setmem_double,
@@ -1046,8 +1034,6 @@ PR_TYPE *tp_Type_double = &tp_Double;
 
 PR_TYPE tp_Time = {
   "time", DB_TYPE_TIME, 0, sizeof (DB_TIME), OR_TIME_SIZE, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_time,
   mr_initval_time,
   mr_setmem_time,
@@ -1073,8 +1059,6 @@ PR_TYPE *tp_Type_time = &tp_Time;
 
 PR_TYPE tp_Utime = {
   "timestamp", DB_TYPE_TIMESTAMP, 0, sizeof (DB_UTIME), OR_UTIME_SIZE, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_utime,
   mr_initval_utime,
   mr_setmem_utime,
@@ -1099,10 +1083,7 @@ PR_TYPE tp_Utime = {
 PR_TYPE *tp_Type_utime = &tp_Utime;
 
 PR_TYPE tp_Timestamptz = {
-  "timestamptz", DB_TYPE_TIMESTAMPTZ, 0, sizeof (DB_TIMESTAMPTZ),
-  OR_TIMESTAMPTZ_SIZE, 4,
-  db_fprint_value,
-  db_sprint_value,
+  "timestamptz", DB_TYPE_TIMESTAMPTZ, 0, sizeof (DB_TIMESTAMPTZ), OR_TIMESTAMPTZ_SIZE, 4,
   mr_initmem_timestamptz,
   mr_initval_timestamptz,
   mr_setmem_timestamptz,
@@ -1129,10 +1110,7 @@ PR_TYPE *tp_Type_Timestamptz = &tp_Timestamptz;
 /* timestamp with locale time zone has the same storage and primitives as
  * (simple) timestamp */
 PR_TYPE tp_Timestampltz = {
-  "timestampltz", DB_TYPE_TIMESTAMPLTZ, 0, sizeof (DB_UTIME), OR_UTIME_SIZE,
-  4,
-  db_fprint_value,
-  db_sprint_value,
+  "timestampltz", DB_TYPE_TIMESTAMPLTZ, 0, sizeof (DB_UTIME), OR_UTIME_SIZE, 4,
   mr_initmem_utime,
   mr_initval_timestampltz,
   mr_setmem_utime,
@@ -1156,8 +1134,6 @@ PR_TYPE tp_Timestampltz = {
 
 PR_TYPE tp_Datetime = {
   "datetime", DB_TYPE_DATETIME, 0, sizeof (DB_DATETIME), OR_DATETIME_SIZE, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_datetime,
   mr_initval_datetime,
   mr_setmem_datetime,
@@ -1182,10 +1158,7 @@ PR_TYPE tp_Datetime = {
 PR_TYPE *tp_Type_datetime = &tp_Datetime;
 
 PR_TYPE tp_Datetimetz = {
-  "datetimetz", DB_TYPE_DATETIMETZ, 0, sizeof (DB_DATETIMETZ),
-  OR_DATETIMETZ_SIZE, 4,
-  db_fprint_value,
-  db_sprint_value,
+  "datetimetz", DB_TYPE_DATETIMETZ, 0, sizeof (DB_DATETIMETZ), OR_DATETIMETZ_SIZE, 4,
   mr_initmem_datetimetz,
   mr_initval_datetimetz,
   mr_setmem_datetimetz,
@@ -1212,10 +1185,7 @@ PR_TYPE *tp_Type_Datetimetz = &tp_Datetimetz;
 /* datetime with locale time zone has the same storage and primitives as
  * (simple) datetime */
 PR_TYPE tp_Datetimeltz = {
-  "datetimeltz", DB_TYPE_DATETIMELTZ, 0, sizeof (DB_DATETIME),
-  OR_DATETIME_SIZE, 4,
-  db_fprint_value,
-  db_sprint_value,
+  "datetimeltz", DB_TYPE_DATETIMELTZ, 0, sizeof (DB_DATETIME), OR_DATETIME_SIZE, 4,
   mr_initmem_datetime,
   mr_initval_datetimeltz,
   mr_setmem_datetime,
@@ -1241,8 +1211,6 @@ PR_TYPE *tp_Type_datetimeltz = &tp_Datetimeltz;
 
 PR_TYPE tp_Monetary = {
   "monetary", DB_TYPE_MONETARY, 0, sizeof (DB_MONETARY), OR_MONETARY_SIZE, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_money,
   mr_initval_money,
   mr_setmem_money,
@@ -1268,8 +1236,6 @@ PR_TYPE *tp_Type_monetary = &tp_Monetary;
 
 PR_TYPE tp_Date = {
   "date", DB_TYPE_DATE, 0, sizeof (DB_DATE), OR_DATE_SIZE, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_date,
   mr_initval_date,
   mr_setmem_date,
@@ -1303,8 +1269,6 @@ PR_TYPE *tp_Type_date = &tp_Date;
 
 PR_TYPE tp_Object = {
   "object", DB_TYPE_OBJECT, 0, MR_OID_SIZE, OR_OID_SIZE, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_object,
   mr_initval_object,
   mr_setmem_object,
@@ -1330,8 +1294,6 @@ PR_TYPE *tp_Type_object = &tp_Object;
 
 PR_TYPE tp_Elo = {		/* todo: remove me */
   "*elo*", DB_TYPE_ELO, 1, sizeof (DB_ELO *), 0, 8,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_elo,
   mr_initval_elo,
   mr_setmem_elo,
@@ -1357,8 +1319,6 @@ PR_TYPE *tp_Type_elo = &tp_Elo;
 
 PR_TYPE tp_Blob = {
   "blob", DB_TYPE_BLOB, 1, sizeof (DB_ELO *), 0, 8,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_elo,
   mr_initval_blob,
   mr_setmem_elo,
@@ -1384,8 +1344,6 @@ PR_TYPE *tp_Type_blob = &tp_Blob;
 
 PR_TYPE tp_Clob = {
   "clob", DB_TYPE_CLOB, 1, sizeof (DB_ELO *), 0, 8,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_elo,
   mr_initval_clob,
   mr_setmem_elo,
@@ -1411,8 +1369,6 @@ PR_TYPE *tp_Type_clob = &tp_Clob;
 
 PR_TYPE tp_Variable = {
   "*variable*", DB_TYPE_VARIABLE, 1, sizeof (DB_VALUE), 0, 4,
-  db_fprint_value,
-  db_sprint_value,
   NULL,				/* initmem */
   mr_initval_variable,
   NULL,				/* setmem */
@@ -1438,8 +1394,6 @@ PR_TYPE *tp_Type_variable = &tp_Variable;
 
 PR_TYPE tp_Substructure = {
   "*substructure*", DB_TYPE_SUB, 1, sizeof (void *), 0, 8,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_sub,
   mr_initval_sub,
   mr_setmem_sub,
@@ -1465,8 +1419,6 @@ PR_TYPE *tp_Type_substructure = &tp_Substructure;
 
 PR_TYPE tp_Pointer = {
   "*pointer*", DB_TYPE_POINTER, 0, sizeof (void *), 0, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_ptr,
   mr_initval_ptr,
   mr_setmem_ptr,
@@ -1492,8 +1444,6 @@ PR_TYPE *tp_Type_pointer = &tp_Pointer;
 
 PR_TYPE tp_Error = {
   "*error*", DB_TYPE_ERROR, 0, sizeof (int), 0, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_error,
   mr_initval_error,
   mr_setmem_error,
@@ -1526,8 +1476,6 @@ PR_TYPE *tp_Type_error = &tp_Error;
  */
 PR_TYPE tp_Oid = {
   "*oid*", DB_TYPE_OID, 0, sizeof (OID), OR_OID_SIZE, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_oid,
   mr_initval_oid,
   mr_setmem_oid,
@@ -1553,8 +1501,6 @@ PR_TYPE *tp_Type_oid = &tp_Oid;
 
 PR_TYPE tp_Set = {
   "set", DB_TYPE_SET, 1, sizeof (SETOBJ *), 0, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_set,
   mr_initval_set,
   mr_setmem_set,
@@ -1580,8 +1526,6 @@ PR_TYPE *tp_Type_set = &tp_Set;
 
 PR_TYPE tp_Multiset = {
   "multiset", DB_TYPE_MULTISET, 1, sizeof (SETOBJ *), 0, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_set,
   mr_initval_multiset,
   mr_setmem_set,
@@ -1607,8 +1551,6 @@ PR_TYPE *tp_Type_multiset = &tp_Multiset;
 
 PR_TYPE tp_Sequence = {
   "sequence", DB_TYPE_SEQUENCE, 1, sizeof (SETOBJ *), 0, 4,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_set,
   mr_initval_sequence,
   mr_setmem_set,
@@ -1634,8 +1576,6 @@ PR_TYPE *tp_Type_sequence = &tp_Sequence;
 
 PR_TYPE tp_Midxkey = {
   "midxkey", DB_TYPE_MIDXKEY, 1, 0, 0, 1,
-  db_fprint_value,
-  db_sprint_value,
   NULL,				/* initmem */
   mr_initval_midxkey,
   NULL,				/* setmem */
@@ -1661,8 +1601,6 @@ PR_TYPE *tp_Type_midxkey = &tp_Midxkey;
 
 PR_TYPE tp_Vobj = {
   "*vobj*", DB_TYPE_VOBJ, 1, sizeof (SETOBJ *), 0, 8,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_set,
   mr_initval_vobj,
   mr_setmem_set,
@@ -1688,8 +1626,6 @@ PR_TYPE *tp_Type_vobj = &tp_Vobj;
 
 PR_TYPE tp_Numeric = {
   "numeric", DB_TYPE_NUMERIC, 0, 0, 0, 1,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_numeric,
   mr_initval_numeric,
   mr_setmem_numeric,
@@ -1714,10 +1650,7 @@ PR_TYPE tp_Numeric = {
 PR_TYPE *tp_Type_numeric = &tp_Numeric;
 
 PR_TYPE tp_Enumeration = {
-  "enum", DB_TYPE_ENUMERATION, 0, sizeof (unsigned short),
-  sizeof (unsigned short), sizeof (unsigned short),
-  db_fprint_value,
-  db_sprint_value,
+  "enum", DB_TYPE_ENUMERATION, 0, sizeof (unsigned short), sizeof (unsigned short), sizeof (unsigned short),
   mr_initmem_enumeration,
   mr_initval_enumeration,
   mr_setmem_enumeration,
@@ -1794,10 +1727,7 @@ PR_TYPE *tp_Type_id_map[] = {
 };
 
 PR_TYPE tp_ResultSet = {
-  "resultset", DB_TYPE_RESULTSET, 0, sizeof (DB_RESULTSET),
-  sizeof (DB_RESULTSET), 4,
-  db_fprint_value,
-  db_sprint_value,
+  "resultset", DB_TYPE_RESULTSET, 0, sizeof (DB_RESULTSET), sizeof (DB_RESULTSET), 4,
   mr_initmem_resultset,
   mr_initval_resultset,
   mr_setmem_resultset,
@@ -2181,7 +2111,7 @@ pr_clone_value (const DB_VALUE * src, DB_VALUE * dest)
 		   * destination domain.  No need to do it twice.
 		   * Make sure the COPY flag is set in the setval call.
 		   */
-		  (*(type->setval)) (dest, src, true);
+		  type->setval (dest, src, true);
 		}
 	      else
 		{
@@ -7741,13 +7671,13 @@ pr_midxkey_compare_element (char *mem1, char *mem2, TP_DOMAIN * dom1, TP_DOMAIN 
   db_make_null (&val1);
   db_make_null (&val2);
 
-  if ((*(dom1->type->index_readval)) (&buf_val1, &val1, dom1, -1, false, NULL, 0) != NO_ERROR)
+  if (dom1->type->index_readval (&buf_val1, &val1, dom1, -1, false, NULL, 0) != NO_ERROR)
     {
       error = true;
       goto clean_up;
     }
 
-  if ((*(dom2->type->index_readval)) (&buf_val2, &val2, dom2, -1, false, NULL, 0) != NO_ERROR)
+  if (dom2->type->index_readval (&buf_val2, &val2, dom2, -1, false, NULL, 0) != NO_ERROR)
     {
       error = true;
       goto clean_up;
@@ -7906,7 +7836,7 @@ pr_midxkey_compare (DB_MIDXKEY * mul1, DB_MIDXKEY * mul2, int do_coercion, int t
 	  /* check for val1 and val2 same domain */
 	  if (dom1 == dom2 || tp_domain_match (dom1, dom2, TP_EXACT_MATCH))
 	    {
-	      c = (*(dom1->type->index_cmpdisk)) (mem1, mem2, dom1, do_coercion, total_order, NULL);
+	      c = dom1->type->index_cmpdisk (mem1, mem2, dom1, do_coercion, total_order, NULL);
 	    }
 	  else
 	    {			/* coercion and comparison */
@@ -8972,18 +8902,7 @@ pr_disk_size (PR_TYPE * type, void *mem)
 int
 pr_total_mem_size (PR_TYPE * type, void *mem)
 {
-  int size;
-
-  if (type->data_lengthmem != NULL)
-    {
-      size = (*type->data_lengthmem) (mem, NULL, 0);
-    }
-  else
-    {
-      size = type->size;
-    }
-
-  return size;
+  return type->data_lengthmem (mem, NULL, 0);
 }
 
 /*
@@ -9017,25 +8936,18 @@ int
 pr_value_mem_size (DB_VALUE * value)
 {
   PR_TYPE *type;
-  int size;
   DB_TYPE dbval_type;
 
-  size = 0;
   dbval_type = DB_VALUE_DOMAIN_TYPE (value);
   type = pr_type_from_id (dbval_type);
   if (type != NULL)
     {
-      if (type->data_lengthval != NULL)
-	{
-	  size = (*type->data_lengthval) (value, 0);
-	}
-      else
-	{
-	  size = type->size;
-	}
+      return type->data_lengthval (value, 0);
     }
-
-  return size;
+  else
+    {
+      return 0;
+    }
 }
 
 /*
@@ -9048,26 +8960,13 @@ pr_value_mem_size (DB_VALUE * value)
 int
 pr_midxkey_element_disk_size (char *mem, DB_DOMAIN * domain)
 {
-  int disk_size = 0;
-
   /*
    * variable types except VARCHAR, VARNCHAR, and VARBIT
    * cannot be a member of midxkey
    */
   assert (!(domain->type->variable_p && !QSTR_IS_VARIABLE_LENGTH (TP_DOMAIN_TYPE (domain))));
 
-  if (domain->type->index_lengthmem != NULL)
-    {
-      disk_size = (*(domain->type->index_lengthmem)) (mem, domain);
-    }
-  else
-    {
-      assert (!domain->type->variable_p);
-
-      disk_size = domain->type->disksize;
-    }
-
-  return disk_size;
+  return domain->type->index_lengthmem (mem, domain);
 }
 
 /*
@@ -9414,7 +9313,7 @@ pr_midxkey_get_element_internal (const DB_MIDXKEY * midxkey, int index, DB_VALUE
 	  or_advance (buf, advance_size);
 	}
 
-      error = (*(domain->type->index_readval)) (buf, value, domain, -1, copy, NULL, 0);
+      error = domain->type->index_readval (buf, value, domain, -1, copy, NULL, 0);
       if (error != NO_ERROR)
 	{
 	  goto exit_on_error;
@@ -9683,7 +9582,7 @@ pr_midxkey_add_elements (DB_VALUE * keyval, DB_VALUE * dbvals, int num_dbvals, s
 	  continue;		/* skip and go ahead */
 	}
 
-      (*((dom->type)->index_writeval)) (&buf, &dbvals[i]);
+      dom->type->index_writeval (&buf, &dbvals[i]);
 
       OR_ENABLE_BOUND_BIT (bound_bits, midxkey->ncolumns + i);
     }				/* for (i = 0, ...) */
@@ -9741,14 +9640,7 @@ pr_data_writeval_disk_size (DB_VALUE * value)
 
   if (type)
     {
-      if (type->data_lengthval == NULL)
-	{
-	  return type->disksize;
-	}
-      else
-	{
-	  return (*(type->data_lengthval)) (value, 1);
-	}
+      return type->data_lengthval (value, 1);
     }
 
   return 0;
@@ -9774,16 +9666,7 @@ pr_index_writeval_disk_size (DB_VALUE * value)
 
   if (type)
     {
-      if (type->index_lengthval == NULL)
-	{
-	  assert (!type->variable_p);
-
-	  return type->disksize;
-	}
-      else
-	{
-	  return (*(type->index_lengthval)) (value);
-	}
+      return type->index_lengthval (value);
     }
 
   return 0;
@@ -9801,14 +9684,13 @@ pr_data_writeval (struct or_buf *buf, DB_VALUE * value)
     {
       type = tp_Type_null;	/* handle strange arguments with NULL */
     }
-  (*(type->data_writeval)) (buf, value);
+  type->data_writeval (buf, value);
 }
 
 /*
  * MISCELLANEOUS TYPE-RELATED HELPER FUNCTIONS
  */
 
-#if defined (SERVER_MODE) || defined (SA_MODE)
 /*
  * pr_valstring - Take the value and formats it using the sptrfunc member of
  * the pr_type vector for the appropriate type.
@@ -9822,37 +9704,23 @@ pr_data_writeval (struct or_buf *buf, DB_VALUE * value)
  *    representations into error messages and the like.
  */
 char *
-pr_valstring (DB_VALUE * val)
+pr_valstring (const DB_VALUE * val)
 {
   const size_t BUFFER_SIZE = 1024;
   string_buffer sb (cubmem::PRIVATE_BLOCK_ALLOCATOR, BUFFER_SIZE);
 
-  if (val == NULL)
+  if (val == NULL || DB_IS_NULL (val))
     {
       /* space with terminating NULL */
       sb ("(null)");
-      return sb.release_ptr ();
     }
-
-  if (DB_IS_NULL (val))
+  else
     {
-      /* space with terminating NULL */
-      sb ("NULL");
-      return sb.release_ptr ();
+      db_sprint_value (val, sb);
     }
 
-  DB_TYPE dbval_type = DB_VALUE_DOMAIN_TYPE (val);
-  PR_TYPE *pr_type = pr_type_from_id (dbval_type);
-
-  if (pr_type == NULL)
-    {
-      return NULL;
-    }
-
-  (*(pr_type->sptrfunc)) (val, sb);
   return sb.release_ptr ();	//caller should use db_private_free() to deallocate it
 }
-#endif //defined (SERVER_MODE) || defined (SA_MODE)
 
 /*
  * pr_complete_enum_value - Sets both index and string of a enum value in case
@@ -11270,8 +11138,6 @@ mr_cmpval_string2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coer
 
 PR_TYPE tp_String = {
   "character varying", DB_TYPE_STRING, 1, sizeof (const char *), 0, 1,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_string,
   mr_initval_string,
   mr_setmem_string,
@@ -12109,8 +11975,6 @@ mr_cmpval_char2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coerci
 
 PR_TYPE tp_Char = {
   "character", DB_TYPE_CHAR, 0, 0, 0, 1,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_char,
   mr_initval_char,
   mr_setmem_char,
@@ -13006,8 +12870,6 @@ mr_cmpval_nchar2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coerc
 
 PR_TYPE tp_NChar = {
   "national character", DB_TYPE_NCHAR, 0, 0, 0, 1,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_nchar,
   mr_initval_nchar,
   mr_setmem_nchar,
@@ -14114,10 +13976,7 @@ mr_cmpval_varnchar2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_co
 #endif
 
 PR_TYPE tp_VarNChar = {
-  "national character varying", DB_TYPE_VARNCHAR, 1, sizeof (const char *), 0,
-  1,
-  db_fprint_value,
-  db_sprint_value,
+  "national character varying", DB_TYPE_VARNCHAR, 1, sizeof (const char *), 0, 1,
   mr_initmem_varnchar,
   mr_initval_varnchar,
   mr_setmem_varnchar,
@@ -14851,8 +14710,6 @@ mr_cmpval_bit2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coercio
 
 PR_TYPE tp_Bit = {
   "bit", DB_TYPE_BIT, 0, 0, 0, 1,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_bit,
   mr_initval_bit,
   mr_setmem_bit,
@@ -15546,8 +15403,6 @@ mr_cmpval_varbit2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coer
 
 PR_TYPE tp_VarBit = {
   "bit varying", DB_TYPE_VARBIT, 1, sizeof (const char *), 0, 1,
-  db_fprint_value,
-  db_sprint_value,
   mr_initmem_varbit,
   mr_initval_varbit,
   mr_setmem_varbit,
@@ -16457,10 +16312,7 @@ error:
 }
 
 PR_TYPE tp_Json = {
-  "json", DB_TYPE_JSON, 1, sizeof (DB_JSON), 0,
-  1,
-  db_fprint_value,
-  db_sprint_value,
+  "json", DB_TYPE_JSON, 1, sizeof (DB_JSON), 0, 1,
   mr_initmem_json,
   mr_initval_json,
   mr_setmem_json,

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -9822,7 +9822,7 @@ pr_data_writeval (struct or_buf *buf, DB_VALUE * value)
  *    representations into error messages and the like.
  */
 char *
-pr_valstring (THREAD_ENTRY * threade, DB_VALUE * val)
+pr_valstring (DB_VALUE * val)
 {
   const size_t BUFFER_SIZE = 1024;
   string_buffer sb (cubmem::PRIVATE_BLOCK_ALLOCATOR, BUFFER_SIZE);

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -146,6 +146,47 @@ extern unsigned int db_on_server;
 #define IS_FLOATING_PRECISION(prec) \
   ((prec) == TP_FLOATING_PRECISION_VALUE)
 
+// *INDENT-OFF*
+pr_type::pr_type (const char * name_arg, DB_TYPE id_arg, int varp_arg, int size_arg, int disksize_arg, int align_arg,
+                  initmem_function_type initmem_f_arg, initval_function_type initval_f_arg,
+                  setmem_function_type setmem_f_arg, getmem_function_type getmem_f_arg,
+                  setval_function_type setval_f_arg, data_lengthmem_function_type data_lengthmem_f_arg,
+                  data_lengthval_function_type data_lengthval_f_arg, data_writemem_function_type data_writemem_f_arg,
+                  data_readmem_function_type data_readmem_f_arg, data_writeval_function_type data_writeval_f_arg,
+                  data_readval_function_type data_readval_f_arg, index_lengthmem_function_type index_lengthmem_f_arg,
+                  index_lengthval_function_type index_lengthval_f_arg,
+                  index_writeval_function_type index_writeval_f_arg, index_readval_function_type index_readval_f_arg,
+                  index_cmpdisk_function_type index_cmpdisk_f_arg, freemem_function_type freemem_f_arg,
+                  data_cmpdisk_function_type data_cmpdisk_f_arg, cmpval_function_type cmpval_f_arg)
+  : name {name_arg}
+  , id {}
+  , variable_p {varp_arg}
+  , size {size_arg}
+  , disksize {disksize_arg}
+  , alignment {align_arg}
+  , f_initmem {initmem_f_arg}
+  , f_initval {initval_f_arg}
+  , f_setmem {setmem_f_arg}
+  , f_getmem {getmem_f_arg}
+  , f_setval {setval_f_arg}
+  , f_data_lengthmem {data_lengthmem_f_arg}
+  , f_data_lengthval {data_lengthval_f_arg}
+  , f_data_writemem {data_writemem_f_arg}
+  , f_data_readmem {data_readmem_f_arg}
+  , f_data_writeval {data_writeval_f_arg}
+  , f_data_readval {data_readval_f_arg}
+  , f_index_lengthmem {index_lengthmem_f_arg}
+  , f_index_lengthval {index_lengthval_f_arg}
+  , f_index_writeval {index_writeval_f_arg}
+  , f_index_readval {index_readval_f_arg}
+  , f_index_cmpdisk {index_cmpdisk_f_arg}
+  , f_freemem {freemem_f_arg}
+  , f_data_cmpdisk {data_cmpdisk_f_arg}
+  , f_cmpval {cmpval_f_arg}
+  {
+  }
+// *INDENT-ON*
+
 static void mr_initmem_string (void *mem, TP_DOMAIN * domain);
 static int mr_setmem_string (void *memptr, TP_DOMAIN * domain, DB_VALUE * value);
 static int mr_getmem_string (void *memptr, TP_DOMAIN * domain, DB_VALUE * value, bool copy);

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -34,13 +34,13 @@
 
 #include "object_primitive.h"
 
+#include "db_value_printer.hpp"
 #include "db_json.hpp"
 #include "elo.h"
 #include "error_manager.h"
 #include "file_io.h"
 #include "mem_block.hpp"
 #include "object_domain.h"
-#include "object_print.h"
 #include "object_representation.h"
 #include "set_object.h"
 #include "string_buffer.hpp"
@@ -884,8 +884,8 @@ int pr_Inhibit_oid_promotion = PR_INHIBIT_OID_PROMOTION_DEFAULT;
 int pr_Enable_string_compression = true;
 PR_TYPE tp_Null = {
   "*NULL*", DB_TYPE_NULL, 0, 0, 0, 0,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_null,
   mr_initval_null,
   mr_setmem_null,
@@ -911,8 +911,8 @@ PR_TYPE *tp_Type_null = &tp_Null;
 
 PR_TYPE tp_Integer = {
   "integer", DB_TYPE_INTEGER, 0, sizeof (int), sizeof (int), 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_int,
   mr_initval_int,
   mr_setmem_int,
@@ -938,8 +938,8 @@ PR_TYPE *tp_Type_integer = &tp_Integer;
 
 PR_TYPE tp_Short = {
   "smallint", DB_TYPE_SHORT, 0, sizeof (short), sizeof (short), 2,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_short,
   mr_initval_short,
   mr_setmem_short,
@@ -965,8 +965,8 @@ PR_TYPE *tp_Type_short = &tp_Short;
 
 PR_TYPE tp_Bigint = {
   "bigint", DB_TYPE_BIGINT, 0, sizeof (DB_BIGINT), sizeof (DB_BIGINT), 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_bigint,
   mr_initval_bigint,
   mr_setmem_bigint,
@@ -992,8 +992,8 @@ PR_TYPE *tp_Type_bigint = &tp_Bigint;
 
 PR_TYPE tp_Float = {
   "float", DB_TYPE_FLOAT, 0, sizeof (float), sizeof (float), 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_float,
   mr_initval_float,
   mr_setmem_float,
@@ -1019,8 +1019,8 @@ PR_TYPE *tp_Type_float = &tp_Float;
 
 PR_TYPE tp_Double = {
   "double", DB_TYPE_DOUBLE, 0, sizeof (double), sizeof (double), 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_double,
   mr_initval_double,
   mr_setmem_double,
@@ -1046,8 +1046,8 @@ PR_TYPE *tp_Type_double = &tp_Double;
 
 PR_TYPE tp_Time = {
   "time", DB_TYPE_TIME, 0, sizeof (DB_TIME), OR_TIME_SIZE, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_time,
   mr_initval_time,
   mr_setmem_time,
@@ -1073,8 +1073,8 @@ PR_TYPE *tp_Type_time = &tp_Time;
 
 PR_TYPE tp_Utime = {
   "timestamp", DB_TYPE_TIMESTAMP, 0, sizeof (DB_UTIME), OR_UTIME_SIZE, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_utime,
   mr_initval_utime,
   mr_setmem_utime,
@@ -1101,8 +1101,8 @@ PR_TYPE *tp_Type_utime = &tp_Utime;
 PR_TYPE tp_Timestamptz = {
   "timestamptz", DB_TYPE_TIMESTAMPTZ, 0, sizeof (DB_TIMESTAMPTZ),
   OR_TIMESTAMPTZ_SIZE, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_timestamptz,
   mr_initval_timestamptz,
   mr_setmem_timestamptz,
@@ -1131,8 +1131,8 @@ PR_TYPE *tp_Type_Timestamptz = &tp_Timestamptz;
 PR_TYPE tp_Timestampltz = {
   "timestampltz", DB_TYPE_TIMESTAMPLTZ, 0, sizeof (DB_UTIME), OR_UTIME_SIZE,
   4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_utime,
   mr_initval_timestampltz,
   mr_setmem_utime,
@@ -1156,8 +1156,8 @@ PR_TYPE tp_Timestampltz = {
 
 PR_TYPE tp_Datetime = {
   "datetime", DB_TYPE_DATETIME, 0, sizeof (DB_DATETIME), OR_DATETIME_SIZE, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_datetime,
   mr_initval_datetime,
   mr_setmem_datetime,
@@ -1184,8 +1184,8 @@ PR_TYPE *tp_Type_datetime = &tp_Datetime;
 PR_TYPE tp_Datetimetz = {
   "datetimetz", DB_TYPE_DATETIMETZ, 0, sizeof (DB_DATETIMETZ),
   OR_DATETIMETZ_SIZE, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_datetimetz,
   mr_initval_datetimetz,
   mr_setmem_datetimetz,
@@ -1214,8 +1214,8 @@ PR_TYPE *tp_Type_Datetimetz = &tp_Datetimetz;
 PR_TYPE tp_Datetimeltz = {
   "datetimeltz", DB_TYPE_DATETIMELTZ, 0, sizeof (DB_DATETIME),
   OR_DATETIME_SIZE, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_datetime,
   mr_initval_datetimeltz,
   mr_setmem_datetime,
@@ -1241,8 +1241,8 @@ PR_TYPE *tp_Type_datetimeltz = &tp_Datetimeltz;
 
 PR_TYPE tp_Monetary = {
   "monetary", DB_TYPE_MONETARY, 0, sizeof (DB_MONETARY), OR_MONETARY_SIZE, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_money,
   mr_initval_money,
   mr_setmem_money,
@@ -1268,8 +1268,8 @@ PR_TYPE *tp_Type_monetary = &tp_Monetary;
 
 PR_TYPE tp_Date = {
   "date", DB_TYPE_DATE, 0, sizeof (DB_DATE), OR_DATE_SIZE, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_date,
   mr_initval_date,
   mr_setmem_date,
@@ -1303,8 +1303,8 @@ PR_TYPE *tp_Type_date = &tp_Date;
 
 PR_TYPE tp_Object = {
   "object", DB_TYPE_OBJECT, 0, MR_OID_SIZE, OR_OID_SIZE, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_object,
   mr_initval_object,
   mr_setmem_object,
@@ -1330,8 +1330,8 @@ PR_TYPE *tp_Type_object = &tp_Object;
 
 PR_TYPE tp_Elo = {		/* todo: remove me */
   "*elo*", DB_TYPE_ELO, 1, sizeof (DB_ELO *), 0, 8,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_elo,
   mr_initval_elo,
   mr_setmem_elo,
@@ -1357,8 +1357,8 @@ PR_TYPE *tp_Type_elo = &tp_Elo;
 
 PR_TYPE tp_Blob = {
   "blob", DB_TYPE_BLOB, 1, sizeof (DB_ELO *), 0, 8,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_elo,
   mr_initval_blob,
   mr_setmem_elo,
@@ -1384,8 +1384,8 @@ PR_TYPE *tp_Type_blob = &tp_Blob;
 
 PR_TYPE tp_Clob = {
   "clob", DB_TYPE_CLOB, 1, sizeof (DB_ELO *), 0, 8,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_elo,
   mr_initval_clob,
   mr_setmem_elo,
@@ -1411,8 +1411,8 @@ PR_TYPE *tp_Type_clob = &tp_Clob;
 
 PR_TYPE tp_Variable = {
   "*variable*", DB_TYPE_VARIABLE, 1, sizeof (DB_VALUE), 0, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   NULL,				/* initmem */
   mr_initval_variable,
   NULL,				/* setmem */
@@ -1438,8 +1438,8 @@ PR_TYPE *tp_Type_variable = &tp_Variable;
 
 PR_TYPE tp_Substructure = {
   "*substructure*", DB_TYPE_SUB, 1, sizeof (void *), 0, 8,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_sub,
   mr_initval_sub,
   mr_setmem_sub,
@@ -1465,8 +1465,8 @@ PR_TYPE *tp_Type_substructure = &tp_Substructure;
 
 PR_TYPE tp_Pointer = {
   "*pointer*", DB_TYPE_POINTER, 0, sizeof (void *), 0, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_ptr,
   mr_initval_ptr,
   mr_setmem_ptr,
@@ -1492,8 +1492,8 @@ PR_TYPE *tp_Type_pointer = &tp_Pointer;
 
 PR_TYPE tp_Error = {
   "*error*", DB_TYPE_ERROR, 0, sizeof (int), 0, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_error,
   mr_initval_error,
   mr_setmem_error,
@@ -1526,8 +1526,8 @@ PR_TYPE *tp_Type_error = &tp_Error;
  */
 PR_TYPE tp_Oid = {
   "*oid*", DB_TYPE_OID, 0, sizeof (OID), OR_OID_SIZE, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_oid,
   mr_initval_oid,
   mr_setmem_oid,
@@ -1553,8 +1553,8 @@ PR_TYPE *tp_Type_oid = &tp_Oid;
 
 PR_TYPE tp_Set = {
   "set", DB_TYPE_SET, 1, sizeof (SETOBJ *), 0, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_set,
   mr_initval_set,
   mr_setmem_set,
@@ -1580,8 +1580,8 @@ PR_TYPE *tp_Type_set = &tp_Set;
 
 PR_TYPE tp_Multiset = {
   "multiset", DB_TYPE_MULTISET, 1, sizeof (SETOBJ *), 0, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_set,
   mr_initval_multiset,
   mr_setmem_set,
@@ -1607,8 +1607,8 @@ PR_TYPE *tp_Type_multiset = &tp_Multiset;
 
 PR_TYPE tp_Sequence = {
   "sequence", DB_TYPE_SEQUENCE, 1, sizeof (SETOBJ *), 0, 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_set,
   mr_initval_sequence,
   mr_setmem_set,
@@ -1634,8 +1634,8 @@ PR_TYPE *tp_Type_sequence = &tp_Sequence;
 
 PR_TYPE tp_Midxkey = {
   "midxkey", DB_TYPE_MIDXKEY, 1, 0, 0, 1,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   NULL,				/* initmem */
   mr_initval_midxkey,
   NULL,				/* setmem */
@@ -1661,8 +1661,8 @@ PR_TYPE *tp_Type_midxkey = &tp_Midxkey;
 
 PR_TYPE tp_Vobj = {
   "*vobj*", DB_TYPE_VOBJ, 1, sizeof (SETOBJ *), 0, 8,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_set,
   mr_initval_vobj,
   mr_setmem_set,
@@ -1688,8 +1688,8 @@ PR_TYPE *tp_Type_vobj = &tp_Vobj;
 
 PR_TYPE tp_Numeric = {
   "numeric", DB_TYPE_NUMERIC, 0, 0, 0, 1,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_numeric,
   mr_initval_numeric,
   mr_setmem_numeric,
@@ -1716,8 +1716,8 @@ PR_TYPE *tp_Type_numeric = &tp_Numeric;
 PR_TYPE tp_Enumeration = {
   "enum", DB_TYPE_ENUMERATION, 0, sizeof (unsigned short),
   sizeof (unsigned short), sizeof (unsigned short),
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_enumeration,
   mr_initval_enumeration,
   mr_setmem_enumeration,
@@ -1796,8 +1796,8 @@ PR_TYPE *tp_Type_id_map[] = {
 PR_TYPE tp_ResultSet = {
   "resultset", DB_TYPE_RESULTSET, 0, sizeof (DB_RESULTSET),
   sizeof (DB_RESULTSET), 4,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_resultset,
   mr_initval_resultset,
   mr_setmem_resultset,
@@ -11270,8 +11270,8 @@ mr_cmpval_string2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coer
 
 PR_TYPE tp_String = {
   "character varying", DB_TYPE_STRING, 1, sizeof (const char *), 0, 1,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_string,
   mr_initval_string,
   mr_setmem_string,
@@ -12109,8 +12109,8 @@ mr_cmpval_char2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coerci
 
 PR_TYPE tp_Char = {
   "character", DB_TYPE_CHAR, 0, 0, 0, 1,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_char,
   mr_initval_char,
   mr_setmem_char,
@@ -13006,8 +13006,8 @@ mr_cmpval_nchar2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coerc
 
 PR_TYPE tp_NChar = {
   "national character", DB_TYPE_NCHAR, 0, 0, 0, 1,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_nchar,
   mr_initval_nchar,
   mr_setmem_nchar,
@@ -14116,8 +14116,8 @@ mr_cmpval_varnchar2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_co
 PR_TYPE tp_VarNChar = {
   "national character varying", DB_TYPE_VARNCHAR, 1, sizeof (const char *), 0,
   1,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_varnchar,
   mr_initval_varnchar,
   mr_setmem_varnchar,
@@ -14851,8 +14851,8 @@ mr_cmpval_bit2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coercio
 
 PR_TYPE tp_Bit = {
   "bit", DB_TYPE_BIT, 0, 0, 0, 1,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_bit,
   mr_initval_bit,
   mr_setmem_bit,
@@ -15546,8 +15546,8 @@ mr_cmpval_varbit2 (DB_VALUE * value1, DB_VALUE * value2, int length, int do_coer
 
 PR_TYPE tp_VarBit = {
   "bit varying", DB_TYPE_VARBIT, 1, sizeof (const char *), 0, 1,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_varbit,
   mr_initval_varbit,
   mr_setmem_varbit,
@@ -16459,8 +16459,8 @@ error:
 PR_TYPE tp_Json = {
   "json", DB_TYPE_JSON, 1, sizeof (DB_JSON), 0,
   1,
-  help_fprint_value,
-  help_sprint_value,
+  db_fprint_value,
+  db_sprint_value,
   mr_initmem_json,
   mr_initval_json,
   mr_setmem_json,

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2005,7 +2005,7 @@ pr_clear_value (DB_VALUE * value)
     }
 
   /* always make sure the value gets cleared */
-  PRIM_SET_NULL (value);
+  db_make_null (value);
   value->need_clear = false;
 
   return NO_ERROR;
@@ -4979,7 +4979,7 @@ mr_setval_object (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 #if !defined (SERVER_MODE)
   if (DB_IS_NULL (src))
     {
-      PRIM_SET_NULL (dest);
+      db_make_null (dest);
     }
   /* can get here on the server when dispatching through set element domains */
   else if (DB_VALUE_TYPE (src) == DB_TYPE_OID)
@@ -5015,7 +5015,7 @@ mr_setval_object (DB_VALUE * dest, const DB_VALUE * src, bool copy)
    */
   if (DB_IS_NULL (src) || DB_VALUE_TYPE (src) != DB_TYPE_OID)
     {
-      PRIM_SET_NULL (dest);
+      db_make_null (dest);
     }
   else
     {
@@ -5639,7 +5639,7 @@ getmem_elo_with_type (void *memptr, TP_DOMAIN * domain, DB_VALUE * value, bool c
 
   if (memptr == NULL)
     {
-      PRIM_SET_NULL (value);
+      db_make_null (value);
       return r;
     }
 
@@ -5647,7 +5647,7 @@ getmem_elo_with_type (void *memptr, TP_DOMAIN * domain, DB_VALUE * value, bool c
 
   if (elo == NULL || elo->size < 0)
     {
-      PRIM_SET_NULL (value);
+      db_make_null (value);
       return r;
     }
 
@@ -5697,7 +5697,7 @@ setval_elo_with_type (DB_VALUE * dest, const DB_VALUE * src, bool copy, DB_TYPE 
 
   if (DB_IS_NULL (src) || db_get_elo (src) == NULL)
     {
-      PRIM_SET_NULL (dest);
+      db_make_null (dest);
       return NO_ERROR;
     }
 
@@ -6261,7 +6261,7 @@ mr_setval_ptr (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 {
   if (DB_IS_NULL (src))
     {
-      PRIM_SET_NULL (dest);
+      db_make_null (dest);
       return NO_ERROR;
     }
   else
@@ -6393,7 +6393,7 @@ mr_setval_error (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 {
   if (DB_IS_NULL (src))
     {
-      PRIM_SET_NULL (dest);
+      db_make_null (dest);
       return NO_ERROR;
     }
   else
@@ -6557,7 +6557,7 @@ mr_setval_oid (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 
   if (DB_IS_NULL (src))
     {
-      PRIM_SET_NULL (dest);
+      db_make_null (dest);
       return NO_ERROR;
     }
   else
@@ -6923,7 +6923,7 @@ err_set:
     default:
       break;
     }
-  PRIM_SET_NULL (dest);
+  db_make_null (dest);
   return error;
 }
 
@@ -8857,39 +8857,9 @@ pr_mem_size (PR_TYPE * type)
   return type->size;
 }
 
-#if defined(ENABLE_UNUSED_FUNCTION)
-/*
- * pr_disk_size - Determine the number of bytes of disk storage required for
- * a value.
- *    return: disk size of an instance attribute
- *    type(in): type identifier
- *    mem(in): pointer to memory for value
- * Note:
- *    The value must be in instance memory format, NOT DB_VALUE format.
- *    If you have a DB_VALUE, use pr_value_disk_size.
- *    This is called by the transformer when calculating sizes and offset
- *    tables for instances.
- */
-int
-pr_disk_size (PR_TYPE * type, void *mem)
-{
-  int size;
-
-  if (type->lengthmem != NULL)
-    {
-      size = (*type->lengthmem) (mem, NULL, 1);
-    }
-  else
-    {
-      size = type->disksize;
-    }
-  return size;
-}
-#endif /* ENABLE_UNUSED_FUNCTION */
-
 /*
  * pr_total_mem_size - returns the total amount of storage used for a memory
- * attribute including any external allocatons (for strings etc.).
+ * attribute including any external allocations (for strings etc.).
  *    return: total memory size of type
  *    type(in): type identifier
  *    mem(in): pointer to memory for value

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -159,7 +159,7 @@ pr_type::pr_type (const char * name_arg, DB_TYPE id_arg, int varp_arg, int size_
                   index_cmpdisk_function_type index_cmpdisk_f_arg, freemem_function_type freemem_f_arg,
                   data_cmpdisk_function_type data_cmpdisk_f_arg, cmpval_function_type cmpval_f_arg)
   : name {name_arg}
-  , id {}
+  , id {id_arg}
   , variable_p {varp_arg}
   , size {size_arg}
   , disksize {disksize_arg}
@@ -8937,7 +8937,14 @@ pr_mem_size (PR_TYPE * type)
 int
 pr_total_mem_size (PR_TYPE * type, void *mem)
 {
-  return type->data_lengthmem (mem, NULL, 0);
+  if (type->is_variable_size ())
+    {
+      return type->data_lengthmem (mem, NULL, 0);
+    }
+  else
+    {
+      return type->size;
+    }
 }
 
 /*
@@ -8977,7 +8984,14 @@ pr_value_mem_size (DB_VALUE * value)
   type = pr_type_from_id (dbval_type);
   if (type != NULL)
     {
-      return type->data_lengthval (value, 0);
+      if (type->is_variable_size ())
+	{
+	  return type->data_lengthval (value, 0);
+	}
+      else
+	{
+	  return type->size;
+	}
     }
   else
     {

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -62,8 +62,8 @@ typedef struct pr_type
     typedef void (*data_writemem_function_type) (struct or_buf * buf, void *memptr, struct tp_domain * domain);
     typedef void (*data_readmem_function_type) (struct or_buf * buf, void *memptr, struct tp_domain * domain, int size);
     typedef int (*data_writeval_function_type) (struct or_buf * buf, DB_VALUE * value);
-    typedef int (*data_readval_function_type) (struct or_buf * buf, DB_VALUE * value, struct tp_domain * domain, int size, bool copy,
-                                               char *copy_buf, int copy_buf_len);
+    typedef int (*data_readval_function_type) (struct or_buf * buf, DB_VALUE * value, struct tp_domain * domain,
+                                               int size, bool copy, char *copy_buf, int copy_buf_len);
     typedef int (*index_lengthmem_function_type) (void *memptr, struct tp_domain * domain);
     typedef int (*index_lengthval_function_type) (DB_VALUE * value);
     typedef int (*index_writeval_function_type) (struct or_buf * buf, DB_VALUE * value);
@@ -131,11 +131,11 @@ typedef struct pr_type
     inline DB_TYPE get_id () const;
     inline size_t get_alignment () const;
 
-    inline void set_data_cmpdisk_function (data_cmpdisk_function_type data_cmpdisk_arg);
-    inline data_cmpdisk_function_type get_data_cmpdisk_function () const;
+    void set_data_cmpdisk_function (data_cmpdisk_function_type data_cmpdisk_arg);
+    data_cmpdisk_function_type get_data_cmpdisk_function () const;
 
-    inline void set_cmpval_function (cmpval_function_type cmpval_arg);
-    inline cmpval_function_type get_cmpval_function () const;
+    void set_cmpval_function (cmpval_function_type cmpval_arg);
+    cmpval_function_type get_cmpval_function () const;
 
     // is fixed/variable
     inline bool is_fixed_size () const;
@@ -365,30 +365,6 @@ size_t
 pr_type::get_alignment () const
 {
   return (size_t) alignment;
-}
-
-void
-pr_type::set_data_cmpdisk_function (data_cmpdisk_function_type data_cmpdisk_arg)
-{
-  f_data_cmpdisk = data_cmpdisk_arg;
-}
-
-pr_type::data_cmpdisk_function_type
-pr_type::get_data_cmpdisk_function () const
-{
-  return f_data_cmpdisk;
-}
-
-void
-pr_type::set_cmpval_function (cmpval_function_type cmpval_arg)
-{
-  f_cmpval = cmpval_arg;
-}
-
-pr_type::cmpval_function_type
-pr_type::get_cmpval_function () const
-{
-  return f_cmpval;
 }
 
 bool

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -28,7 +28,6 @@
 #ident "$Id$"
 
 #include "dbtype_def.h"
-#include "thread_compat.hpp"
 
 #include <stdio.h>
 #include <vector>
@@ -313,7 +312,7 @@ extern int pr_Inhibit_oid_promotion;
 
 #if defined (SERVER_MODE) || defined (SA_MODE)
 /* Helper function for DB_VALUE printing; caller must free_and_init result. */
-extern char *pr_valstring (THREAD_ENTRY *, DB_VALUE *);
+extern char *pr_valstring (DB_VALUE *);
 #endif //defined (SERVER_MODE) || defined (SA_MODE)
 
 /* area init */

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -53,7 +53,7 @@ typedef struct pr_type
   int disksize;
   int alignment;
   /* print dbvalue to file */
-  void (*fptrfunc) (THREAD_ENTRY * thread_p, FILE * fp, const DB_VALUE * value);
+  void (*fptrfunc) (FILE * fp, const DB_VALUE * value);
   /* print dbvalue to buffer */
   void (*sptrfunc) (const DB_VALUE * value, string_buffer & sb);
 

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -423,26 +423,26 @@ pr_type::initval (DB_VALUE * value, int precision, int scale) const
   (*f_initval) (value, precision, scale);
 }
 
-inline int
+int
 pr_type::setmem (void * memptr, const tp_domain * domain, const DB_VALUE * value) const
 {
   // Assign a value into instance memory, copy the value.
   return (*f_setmem) (memptr, const_cast<tp_domain *> (domain), const_cast<DB_VALUE *> (value));
 }
 
-inline int
+int
 pr_type::getmem (void * memptr, const tp_domain * domain, DB_VALUE * value, bool copy) const
 {
   return (*f_getmem) (memptr, const_cast<tp_domain *> (domain), value, copy);
 }
 
-inline int
+int
 pr_type::setval (DB_VALUE * dest, const DB_VALUE * src, bool copy) const
 {
   return (*f_setval) (dest, src, copy);
 }
 
-inline int
+int
 pr_type::data_lengthmem (const void * memptr, const tp_domain * domain, int disk) const
 {
   if (is_fixed_size ())
@@ -455,7 +455,7 @@ pr_type::data_lengthmem (const void * memptr, const tp_domain * domain, int disk
     }
 }
 
-inline int
+int
 pr_type::data_lengthval (const DB_VALUE * value, int disk) const
 {
   if (is_fixed_size ())
@@ -468,31 +468,31 @@ pr_type::data_lengthval (const DB_VALUE * value, int disk) const
     }
 }
 
-inline void
+void
 pr_type::data_writemem (or_buf * buf, const void * memptr, const tp_domain * domain) const
 {
   (*f_data_writemem) (buf, const_cast<void *> (memptr), const_cast <tp_domain *> (domain));
 }
 
-inline void
+void
 pr_type::data_readmem (or_buf * buf, void * memptr, const tp_domain * domain, int size) const
 {
   (*f_data_readmem) (buf, memptr, const_cast<tp_domain *> (domain), size);
 }
 
-inline int
+int
 pr_type::data_writeval (or_buf * buf, const DB_VALUE * value) const
 {
   return (*f_data_writeval) (buf, const_cast<DB_VALUE *> (value));
 }
 
-inline int
+int
 pr_type::data_readval (or_buf * buf, DB_VALUE * value, const tp_domain * domain, int size, bool copy, char * copy_buf, int copy_buf_len) const
 {
   return (*f_data_readval) (buf, value, const_cast<tp_domain *> (domain), size, copy, copy_buf, copy_buf_len);
 }
 
-inline int
+int
 pr_type::index_lengthmem (const void * memptr, const tp_domain * domain) const
 {
   if (is_fixed_size ())
@@ -505,7 +505,7 @@ pr_type::index_lengthmem (const void * memptr, const tp_domain * domain) const
     }
 }
 
-inline int
+int
 pr_type::index_lengthval (const DB_VALUE * value) const
 {
   if (is_fixed_size ())
@@ -518,26 +518,26 @@ pr_type::index_lengthval (const DB_VALUE * value) const
     }
 }
 
-inline int
+int
 pr_type::index_writeval (or_buf * buf, const DB_VALUE * value) const
 {
   return (*f_index_writeval) (buf, const_cast<DB_VALUE *> (value));
 }
 
-inline int
+int
 pr_type::index_readval (or_buf * buf, DB_VALUE * value, const tp_domain * domain, int size, bool copy, char * copy_buf, int copy_buf_len) const
 {
   return (*f_index_readval) (buf, value, const_cast<tp_domain *> (domain), size, copy, copy_buf, copy_buf_len);
 }
 
-inline DB_VALUE_COMPARE_RESULT
+DB_VALUE_COMPARE_RESULT
 pr_type::index_cmpdisk (const void * memptr1, const void * memptr2, const tp_domain * domain, int do_coercion, int total_order, int * start_colp) const
 {
   return (*f_index_cmpdisk) (const_cast<void *> (memptr1), const_cast<void *> (memptr2),
                              const_cast<tp_domain *> (domain), do_coercion, total_order, start_colp);
 }
 
-inline void
+void
 pr_type::freemem (void * memptr) const
 {
   if (f_freemem != NULL)
@@ -546,14 +546,14 @@ pr_type::freemem (void * memptr) const
     }
  }
 
-inline DB_VALUE_COMPARE_RESULT
+DB_VALUE_COMPARE_RESULT
 pr_type::data_cmpdisk (const void * memptr1, const void * memptr2, const tp_domain * domain, int do_coercion, int total_order, int * start_colp) const
 {
   return (*f_data_cmpdisk) (const_cast<void *> (memptr1), const_cast<void *> (memptr2),
                             const_cast<tp_domain *> (domain), do_coercion, total_order, start_colp);
 }
 
-inline DB_VALUE_COMPARE_RESULT
+DB_VALUE_COMPARE_RESULT
 pr_type::cmpval (const DB_VALUE * value, const DB_VALUE * value2, int do_coercion, int total_order, int * start_colp, int collation) const
 {
   return (*f_cmpval) (const_cast<DB_VALUE *> (value), const_cast<DB_VALUE *> (value2), do_coercion, total_order,

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -370,8 +370,10 @@ pr_type::get_alignment () const
 bool
 pr_type::is_variable_size () const
 {
-  assert (f_data_lengthmem != NULL && f_data_lengthval != NULL
-          && f_index_lengthval != NULL && f_index_lengthmem != NULL);
+  // if variable, we need to have length computing functions
+  assert (variable_p == 0
+          || (f_data_lengthmem != NULL && f_data_lengthval != NULL
+              && f_index_lengthval != NULL && f_index_lengthmem != NULL));
   return variable_p != 0;
 }
 

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -134,8 +134,8 @@ typedef struct pr_type
     inline void set_data_cmpdisk_function (data_cmpdisk_function_type data_cmpdisk_arg);
     inline data_cmpdisk_function_type get_data_cmpdisk_function () const;
 
-    void set_cmpval_function (cmpval_function_type cmpval_arg);
-    cmpval_function_type get_cmpval_function () const;
+    inline void set_cmpval_function (cmpval_function_type cmpval_arg);
+    inline cmpval_function_type get_cmpval_function () const;
 
     // is fixed/variable
     inline bool is_fixed_size () const;
@@ -394,7 +394,8 @@ pr_type::get_cmpval_function () const
 bool
 pr_type::is_variable_size () const
 {
-  assert (f_data_lengthmem != NULL && f_data_lengthval != NULL && f_index_lengthval != NULL);
+  assert (f_data_lengthmem != NULL && f_data_lengthval != NULL
+          && f_index_lengthval != NULL && f_index_lengthmem != NULL);
   return variable_p != 0;
 }
 
@@ -494,7 +495,7 @@ pr_type::data_readval (or_buf * buf, DB_VALUE * value, const tp_domain * domain,
 inline int
 pr_type::index_lengthmem (const void * memptr, const tp_domain * domain) const
 {
-  if (f_index_lengthmem == NULL)
+  if (is_fixed_size ())
     {
       return disksize;
     }

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -370,10 +370,6 @@ pr_type::get_alignment () const
 bool
 pr_type::is_variable_size () const
 {
-  // if variable, we need to have length computing functions
-  assert (variable_p == 0
-          || (f_data_lengthmem != NULL && f_data_lengthval != NULL
-              && f_index_lengthval != NULL && f_index_lengthmem != NULL));
   return variable_p != 0;
 }
 
@@ -429,6 +425,7 @@ pr_type::data_lengthmem (const void * memptr, const tp_domain * domain, int disk
     }
   else
     {
+      assert (f_data_lengthmem != NULL);
       return (*f_data_lengthmem) (const_cast<void *> (memptr), const_cast<tp_domain *> (domain), disk);
     }
 }
@@ -442,6 +439,7 @@ pr_type::data_lengthval (const DB_VALUE * value, int disk) const
     }
   else
     {
+      assert (f_data_lengthval != NULL);
       return (*f_data_lengthval) (const_cast<DB_VALUE *> (value), disk);
     }
 }
@@ -479,6 +477,7 @@ pr_type::index_lengthmem (const void * memptr, const tp_domain * domain) const
     }
   else
     {
+      assert (f_index_lengthmem != NULL);
       return (*f_index_lengthmem) (const_cast<void *> (memptr), const_cast<tp_domain *> (domain));
     }
 }
@@ -492,6 +491,7 @@ pr_type::index_lengthval (const DB_VALUE * value) const
     }
   else
     {
+      assert (f_index_lengthval != NULL);
       return (*f_index_lengthval) (const_cast<DB_VALUE *> (value));
     }
 }

--- a/src/object/object_print.c
+++ b/src/object/object_print.c
@@ -24,55 +24,32 @@
 #ident "$Id$"
 
 #include "object_print.h"
-#include "config.h"
-#include "db_value_printer.hpp"
-#include "mem_block.hpp"
 
-#include <stdlib.h>
-#include <float.h>
-#include <string.h>
-#include <ctype.h>
-#include <assert.h>
-
-
-#include "error_manager.h"
-#if !defined (SERVER_MODE)
+#include "authenticate.h"
 #include "chartype.h"
 #include "class_description.hpp"
-#include "misc_string.h"
 #include "dbi.h"
-#include "schema_manager.h"
-#include "trigger_description.hpp"
-#include "trigger_manager.h"
-#include "virtual_object.h"
-#include "set_object.h"
-#include "parse_tree.h"
-#include "parser.h"
-#include "transaction_cl.h"
+#include "dbtype.h"
+#include "error_manager.h"
+#include "locator_cl.h"
+#include "message_catalog.h"
 #include "msgcat_help.hpp"
 #include "network_interface_cl.h"
 #include "object_description.hpp"
-#include "object_printer.hpp"
 #include "object_print_util.hpp"
-#include "class_object.h"
-#include "work_space.h"
-#endif /* !defined (SERVER_MODE) */
+#include "object_printer.hpp"
+#include "schema_manager.h"
 #include "string_buffer.hpp"
-#include "dbtype.h"
-#include "memory_private_allocator.hpp"
+#include "trigger_description.hpp"
+#include "trigger_manager.h"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
 #endif /* defined (SUPPRESS_STRLEN_WARNING) */
 
-#if !defined(SERVER_MODE)
-
 #define MATCH_TOKEN(string, token) \
   ((string == NULL) ? 0 : intl_mbs_casecmp(string, token) == 0)
 
-extern unsigned int db_on_server;
-
-static char **obj_print_read_section (FILE * fp);
 static char *obj_print_next_token (char *ptr, char *buf);
 
 /* This will be in one of the language directories under $CUBRID/msg */
@@ -728,10 +705,6 @@ help_print_info (const char *command, FILE * fpp)
     }
 }
 
-#endif /* defined (SERVER_MODE) */
-
-
-
 /*
  * help_fprint_describe_comment() - Print description of a comment to a file.
  *   return: N/A
@@ -740,7 +713,6 @@ help_print_info (const char *command, FILE * fpp)
 void
 help_fprint_describe_comment (FILE * fp, const char *comment)
 {
-#if !defined (SERVER_MODE)
   string_buffer sb;
   object_printer printer (sb);
 
@@ -749,5 +721,4 @@ help_fprint_describe_comment (FILE * fp, const char *comment)
 
   printer.describe_comment (comment);
   fprintf (fp, "%.*s", int (sb.len ()), sb.get_buffer ());
-#endif /* !defined (SERVER_MODE) */
 }

--- a/src/object/object_print.c
+++ b/src/object/object_print.c
@@ -730,35 +730,7 @@ help_print_info (const char *command, FILE * fpp)
 
 #endif /* defined (SERVER_MODE) */
 
-/*
- * help_fprint_value() -  Prints a description of the contents of a DB_VALUE
- *                        to the file
- *   return: none
- *   fp(in) : FILE stream pointer
- *   value(in) : value to print
- */
-void
-help_fprint_value (THREAD_ENTRY * thread_p, FILE * fp, const DB_VALUE * value)
-{
-  const size_t BUFFER_SIZE = 1024;
-  string_buffer sb (cubmem::PRIVATE_BLOCK_ALLOCATOR, BUFFER_SIZE);
 
-  db_value_printer printer (sb);
-  printer.describe_value (value);
-  fprintf (fp, "%.*s", (int) sb.len (), sb.get_buffer ());
-}
-
-/*
- * help_sprint_value() - This places a printed representation of the supplied value in a buffer.
- *   value(in) : value to describe
- *   sb(in/out) : auto resizable buffer to contain description
- */
-void
-help_sprint_value (const DB_VALUE * value, string_buffer & sb)
-{
-  db_value_printer printer (sb);
-  printer.describe_value (value);
-}
 
 /*
  * help_fprint_describe_comment() - Print description of a comment to a file.

--- a/src/object/object_print.h
+++ b/src/object/object_print.h
@@ -26,53 +26,36 @@
 
 #ident "$Id$"
 
+#include "dbtype_def.h"
+
 #include <stdio.h>
 
-#include "dbtype_def.h"
-#include "thread_compat.hpp"
+#if defined(SERVER_MODE)
+#error Does not belong to server module
+#endif //defined(SERVER_MODE)
 
-#if !defined (SERVER_MODE)
-#include "parse_tree.h"
-#endif /* !SERVER_MODE */
-
-class string_buffer;
-
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
-#if !defined (SERVER_MODE)
-
-  struct trigger_description;
+struct trigger_description;
 
 /* HELP FUNCTIONS */
 
 /* Trigger help */
-  int help_trigger_names (char ***names_ptr);
+int help_trigger_names (char ***names_ptr);
 
 /* This can be used to free the class name list or the trigger name list */
-  void help_free_names (char **names);
+void help_free_names (char **names);
 
 
 /* Class/Instance printing */
-  void help_fprint_obj (FILE * fp, MOP obj);
+void help_fprint_obj (FILE * fp, MOP obj);
 
 /* Class name help */
-  extern char **help_class_names (const char *qualifier);
-  extern void help_free_class_names (char **names);
+extern char **help_class_names (const char *qualifier);
+extern void help_free_class_names (char **names);
 
 /* Misc help */
-  void help_print_info (const char *command, FILE * fpp);
-  int help_describe_mop (DB_OBJECT * obj, char *buffer, int maxlen);
-#endif				/* !SERVER_MODE */
+void help_print_info (const char *command, FILE * fpp);
+int help_describe_mop (DB_OBJECT * obj, char *buffer, int maxlen);
 
-  void help_fprint_value (THREAD_ENTRY * thread_p, FILE * fp, const DB_VALUE * value);
-  void help_sprint_value (const DB_VALUE * value, string_buffer & sb);
-  void help_fprint_describe_comment (FILE * fp, const char *comment);
+void help_fprint_describe_comment (FILE * fp, const char *comment);
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif				/* _OBJECT_PRINT_H */
+#endif /* _OBJECT_PRINT_H */

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -4148,7 +4148,7 @@ or_packed_json_schema_length (const char *json_schema)
   db_make_string (&val, const_cast <char*>(json_schema));
   // *INDENT-ON*
 
-  len = tp_String.data_lengthval (&val, 1);
+  len = tp_String.get_disk_size_of_value (&val);
 
   pr_clear_value (&val);
 
@@ -6661,7 +6661,7 @@ or_packed_value_size (const DB_VALUE * value, int collapse_null, int include_dom
 	      return size;
 	    }
 	}
-      size += type->data_lengthval (value, 1);
+      size += type->get_disk_size_of_value (value);
     }
 
   /* Values must as a unit be aligned to a word boundary.  We can't do this inside the writeval function because that
@@ -7599,7 +7599,7 @@ or_packed_enumeration_size (const DB_ENUMERATION * enumeration)
       db_make_varchar (&value, TP_FLOATING_PRECISION_VALUE, DB_GET_ENUM_ELEM_STRING (db_enum),
 		       DB_GET_ENUM_ELEM_STRING_SIZE (db_enum), DB_GET_ENUM_ELEM_CODESET (db_enum),
 		       LANG_GET_BINARY_COLLATION (DB_GET_ENUM_ELEM_CODESET (db_enum)));
-      size += tp_String.data_lengthval (&value, 1);
+      size += tp_String.get_disk_size_of_value (&value);
       pr_clear_value (&value);
     }
 

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -4643,56 +4643,6 @@ sm_is_partition (MOP classmop, MOP supermop)
   return 0;
 }
 
-#if defined(ENABLE_UNUSED_FUNCTION)
-/*
- * sm_object_size() - Walk through the instance or class and tally up
- *    the number of bytes used for storing the various object components.
- *    Information function only.  Not guaranteed acurate but should
- *    always be maintained as close as possible.
- *   return: memory byte size of object
- *   op(in): class or instance object
- */
-
-int
-sm_object_size (MOP op)
-{
-  SM_CLASS *class_;
-  SM_ATTRIBUTE *att;
-  MOBJ obj;
-  int size, pin;
-
-  size = 0;
-  if (locator_is_class (op, DB_FETCH_READ))
-    {
-      if (au_fetch_class (op, &class_, AU_FETCH_READ, AU_SELECT) == NO_ERROR)
-	{
-	  size = classobj_class_size (class_);
-	}
-    }
-  else
-    {
-      if (au_fetch_class (op, &class_, AU_FETCH_READ, AU_SELECT) == NO_ERROR)
-	{
-	  if (au_fetch_instance (op, &obj, AU_FETCH_READ, AU_SELECT) == NO_ERROR)
-	    {
-	      /* wouldn't have to pin here since we don't allocate storage but can't hurt to be safe */
-	      pin = ws_pin (op, 1);
-	      size = class_->object_size;
-	      for (att = class_->attributes; att != NULL; att = (SM_ATTRIBUTE *) att->header.next)
-		{
-		  if (att->type->variable_p)
-		    {
-		      size += pr_total_mem_size (att->type, obj + att->offset);
-		    }
-		}
-	      (void) ws_pin (op, pin);
-	    }
-	}
-    }
-
-  return size;
-}
-#endif /* ENABLE_UNUSED_FUNCTION */
 /*
  * sm_object_size_quick() - Calculate the memory size of an instance.
  *    Called only by the workspace statistics functions.
@@ -4715,7 +4665,7 @@ sm_object_size_quick (SM_CLASS * class_, MOBJ obj)
 	{
 	  if (att->type->variable_p)
 	    {
-	      size += pr_total_mem_size (att->type, obj + att->offset);
+	      size += att->type->get_mem_size_of_mem (obj + att->offset);
 	    }
 	}
     }

--- a/src/object/schema_manager.h
+++ b/src/object/schema_manager.h
@@ -200,9 +200,6 @@ extern OID *sm_get_ch_rep_dir (MOP classmop);
 
 extern int sm_is_subclass (MOP classmop, MOP supermop);
 extern int sm_is_partition (MOP classmop, MOP supermop);
-#if defined(ENABLE_UNUSED_FUNCTION)
-extern int sm_object_size (MOP op);
-#endif
 extern int sm_object_size_quick (SM_CLASS * class_, MOBJ obj);
 extern SM_CLASS_CONSTRAINT *sm_class_constraints (MOP classop);
 

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -655,7 +655,7 @@ col_null_values (COL * col, long bottomvalue, long topvalue)
     {
       for (; bottomvalue <= topvalue; bottomvalue++)
 	{
-	  db_make_null (INDEX (col, bottomvalue));
+	  PRIM_SET_NULL (INDEX (col, bottomvalue));
 	}
     }
   return;
@@ -1454,7 +1454,7 @@ col_insert (COL * col, long colindex, DB_VALUE * val)
       /* If this should be cloned, the caller should do it. This primitive just allows the assignment to the right
        * location in the collection */
       col->array[blockindex][offset] = *val;
-      db_make_null (val);
+      PRIM_SET_NULL (val);
       col->lastinsert = colindex;
     }
 
@@ -1533,7 +1533,7 @@ col_delete (COL * col, long colindex)
    *
    * Also, just in case the DB_VALUE pointed to an object, set the object pointer to NULL so that the GC doesn't get
    * confused. - JB */
-  db_make_null (INDEX (col, (col->size - 1)));
+  PRIM_SET_NULL (INDEX (col, (col->size - 1)));
   INDEX (col, (col->size - 1))->data.op = NULL;
 
   col->size--;
@@ -1699,7 +1699,7 @@ col_drop (COL * col, DB_VALUE * val)
     {
       if (col->coltype == DB_TYPE_SEQUENCE)
 	{
-	  db_make_null (INDEX (col, i));
+	  PRIM_SET_NULL (INDEX (col, i));
 	}
       else
 	{
@@ -6212,7 +6212,7 @@ setobj_put_value (COL * col, int index, DB_VALUE * value)
   /* if the value was added successfully, make sure caller does not inadvertantly clear or use this value container */
   if (error == NO_ERROR)
     {
-      db_make_null (value);
+      PRIM_SET_NULL (value);
     }
 
   return error;

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -655,7 +655,7 @@ col_null_values (COL * col, long bottomvalue, long topvalue)
     {
       for (; bottomvalue <= topvalue; bottomvalue++)
 	{
-	  PRIM_SET_NULL (INDEX (col, bottomvalue));
+	  db_make_null (INDEX (col, bottomvalue));
 	}
     }
   return;
@@ -1454,7 +1454,7 @@ col_insert (COL * col, long colindex, DB_VALUE * val)
       /* If this should be cloned, the caller should do it. This primitive just allows the assignment to the right
        * location in the collection */
       col->array[blockindex][offset] = *val;
-      PRIM_SET_NULL (val);
+      db_make_null (val);
       col->lastinsert = colindex;
     }
 
@@ -1533,7 +1533,7 @@ col_delete (COL * col, long colindex)
    *
    * Also, just in case the DB_VALUE pointed to an object, set the object pointer to NULL so that the GC doesn't get
    * confused. - JB */
-  PRIM_SET_NULL (INDEX (col, (col->size - 1)));
+  db_make_null (INDEX (col, (col->size - 1)));
   INDEX (col, (col->size - 1))->data.op = NULL;
 
   col->size--;
@@ -1699,7 +1699,7 @@ col_drop (COL * col, DB_VALUE * val)
     {
       if (col->coltype == DB_TYPE_SEQUENCE)
 	{
-	  PRIM_SET_NULL (INDEX (col, i));
+	  db_make_null (INDEX (col, i));
 	}
       else
 	{
@@ -6212,7 +6212,7 @@ setobj_put_value (COL * col, int index, DB_VALUE * value)
   /* if the value was added successfully, make sure caller does not inadvertantly clear or use this value container */
   if (error == NO_ERROR)
     {
-      PRIM_SET_NULL (value);
+      db_make_null (value);
     }
 
   return error;

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -30,12 +30,11 @@
 #include <stdio.h>
 #include <assert.h>
 
-#include "set_object.h"
+#include "db_value_printer.hpp"
+#include "dbtype.h"
 #include "error_manager.h"
 #include "object_primitive.h"
-#include "object_print.h"
-#include "dbtype.h"
-
+#include "set_object.h"
 
 #if !defined(SERVER_MODE)
 #include "locator_cl.h"
@@ -6125,7 +6124,7 @@ setobj_print (FILE * fp, COL * col)
   fprintf (fp, "{");
   for (i = 0; i < col->size; i++)
     {
-      help_fprint_value (NULL, fp, INDEX (col, i));
+      db_fprint_value (fp, INDEX (col, i));
       if (i < col->size - 1)
 	{
 	  fprintf (fp, ", ");

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -703,7 +703,7 @@ put_attributes (OR_BUF * buf, char *obj, SM_CLASS * class_)
   start = buf->ptr;
   for (att = class_->attributes; att != NULL && !att->type->variable_p; att = (SM_ATTRIBUTE *) att->header.next)
     {
-      PRIM_WRITE (att->type, att->domain, buf, obj + att->offset);
+      att->type->data_writemem (buf, obj + att->offset, att->domain);
     }
 
   /* bring the end of the fixed width block up to proper alignment */
@@ -727,7 +727,7 @@ put_attributes (OR_BUF * buf, char *obj, SM_CLASS * class_)
 
   for (; att != NULL; att = (SM_ATTRIBUTE *) att->header.next)
     {
-      PRIM_WRITE (att->type, att->domain, buf, obj + att->offset);
+      att->type->data_writemem (buf, obj + att->offset, att->domain);
     }
   return NO_ERROR;
 }
@@ -958,7 +958,7 @@ get_current (OR_BUF * buf, SM_CLASS * class_, MOBJ * obj_ptr, int bound_bit_flag
 	{
 	  att = &(class_->attributes[i]);
 	  mem = obj + att->offset;
-	  PRIM_READ (att->type, att->domain, buf, mem, -1);
+	  att->type->data_readmem (buf, mem, att->domain, -1);
 	}
 
       /* round up to a to the end of the fixed block */
@@ -980,7 +980,7 @@ get_current (OR_BUF * buf, SM_CLASS * class_, MOBJ * obj_ptr, int bound_bit_flag
 	    {
 	      att = &(class_->attributes[i]);
 	      mem = obj + att->offset;
-	      PRIM_READ (att->type, att->domain, buf, mem, vars[j]);
+	      att->type->data_readmem (buf, mem, att->domain, vars[j]);
 	    }
 	}
     }
@@ -1053,11 +1053,11 @@ clear_new_unbound (char *obj, SM_CLASS * class_, SM_REPRESENTATION * oldrep)
 	{
 	  mem = obj + att->offset;
 	  /* initialize in case there isn't an initial value */
-	  PRIM_INITMEM (att->type, mem, att->domain);
+	  att->type->f_initmem (mem, att->domain);
 	  if (!DB_IS_NULL (&att->default_value.original_value))
 	    {
 	      /* assign the initial value, should check for non-existance ? */
-	      PRIM_SETMEM (att->type, att->domain, mem, &att->default_value.original_value);
+	      att->type->setmem (mem, att->domain, &att->default_value.original_value);
 	      if (!att->type->variable_p)
 		{
 		  OBJ_SET_BOUND_BIT (obj, att->storage_order);
@@ -1188,11 +1188,11 @@ get_old (OR_BUF * buf, SM_CLASS * class_, MOBJ * obj_ptr, int repid, int bound_b
 
 	      if (attmap[i] == NULL)
 		{
-		  PRIM_READ (type, rat->domain, buf, NULL, -1);
+		  type->data_readmem (buf, NULL, rat->domain, -1);
 		}
 	      else
 		{
-		  PRIM_READ (type, rat->domain, buf, obj + attmap[i]->offset, -1);
+		  type->data_readmem (buf, obj + attmap[i]->offset, rat->domain, -1);
 		}
 	    }
 
@@ -1253,11 +1253,11 @@ get_old (OR_BUF * buf, SM_CLASS * class_, MOBJ * obj_ptr, int repid, int bound_b
 		  att_index = oldrep->fixed_count + i;
 		  if (attmap[att_index] == NULL)
 		    {
-		      PRIM_READ (type, rat->domain, buf, NULL, vars[i]);
+		      type->data_readmem (buf, NULL, rat->domain, vars[i]);
 		    }
 		  else
 		    {
-		      PRIM_READ (type, rat->domain, buf, obj + attmap[att_index]->offset, vars[i]);
+		      type->data_readmem (buf, obj + attmap[att_index]->offset, rat->domain, vars[i]);
 		    }
 		}
 	    }

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -619,7 +619,7 @@ put_varinfo (OR_BUF * buf, char *obj, SM_CLASS * class_, int offset_size)
 	  att = &class_->attributes[a];
 	  mem = obj + att->offset;
 
-	  len = att->domain->type->data_lengthmem (mem, att->domain, 1);
+	  len = att->domain->type->get_disk_size_of_mem (mem, att->domain);
 
 	  or_put_offset_internal (buf, offset, offset_size);
 	  offset += len;
@@ -659,7 +659,7 @@ re_check:
 	  att = &class_->attributes[a];
 	  mem = obj + att->offset;
 
-	  size += att->domain->type->data_lengthmem (mem, att->domain, 1);
+	  size += att->domain->type->get_disk_size_of_mem (mem, att->domain);
 	}
     }
 
@@ -1469,7 +1469,7 @@ string_disk_size (const char *string)
 
   db_make_varnchar (&value, TP_FLOATING_PRECISION_VALUE, (const DB_C_NCHAR) string, str_length, LANG_SYS_CODESET,
 		    LANG_SYS_COLLATION);
-  length = tp_VarNChar.data_lengthval (&value, 1);
+  length = tp_VarNChar.get_disk_size_of_value (&value);
 
   /* Clear the compressed_string of DB_VALUE */
   pr_clear_compressed_string (&value);
@@ -1936,7 +1936,7 @@ property_list_size (DB_SEQ * properties)
       if (max)
 	{
 	  db_make_sequence (&value, properties);
-	  size = tp_Sequence.data_lengthval (&value, 1);
+	  size = tp_Sequence.get_disk_size_of_value (&value);
 	}
     }
   return size;

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -1053,7 +1053,7 @@ clear_new_unbound (char *obj, SM_CLASS * class_, SM_REPRESENTATION * oldrep)
 	{
 	  mem = obj + att->offset;
 	  /* initialize in case there isn't an initial value */
-	  att->type->f_initmem (mem, att->domain);
+	  att->type->initmem (mem, att->domain);
 	  if (!DB_IS_NULL (&att->default_value.original_value))
 	    {
 	      /* assign the initial value, should check for non-existance ? */

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -959,8 +959,8 @@ vid_compare_non_updatable_objects (MOP mop1, MOP mop2)
 	{
 	  db_value_domain_init (&val1, att1->type->id, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	  db_value_domain_init (&val2, att1->type->id, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
-	  PRIM_GETMEM (att1->type, att1->domain, mem1, &val1);
-	  PRIM_GETMEM (att2->type, att2->domain, mem2, &val2);
+	  att1->type->getmem (mem1, att1->domain, &val1);
+	  att1->type->getmem (mem2, att2->domain, &val2);
 	  set1 = db_get_set (&val1);
 	  set2 = db_get_set (&val2);
 	  db_value_put_null (&val1);
@@ -981,8 +981,8 @@ vid_compare_non_updatable_objects (MOP mop1, MOP mop2)
 	{
 	  db_value_domain_init (&val1, DB_TYPE_OBJECT, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	  db_value_domain_init (&val2, DB_TYPE_OBJECT, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
-	  PRIM_GETMEM (att1->type, att1->domain, mem1, &val1);
-	  PRIM_GETMEM (att2->type, att2->domain, mem2, &val2);
+	  att1->type->getmem (mem1, att1->domain, &val1);
+	  att1->type->getmem (mem2, att2->domain, &val2);
 	  attobj1 = db_get_object (&val1);
 	  attobj2 = db_get_object (&val2);
 	  db_value_put_null (&val1);
@@ -1004,8 +1004,8 @@ vid_compare_non_updatable_objects (MOP mop1, MOP mop2)
 	{
 	  db_value_domain_init (&val1, att1->type->id, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	  db_value_domain_init (&val2, att2->type->id, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
-	  PRIM_GETMEM (att1->type, att1->domain, mem1, &val1);
-	  PRIM_GETMEM (att2->type, att2->domain, mem2, &val2);
+	  att1->type->getmem (mem1, att1->domain, &val1);
+	  att1->type->getmem (mem2, att2->domain, &val2);
 	  /*
 	   * Unlike most calls to this function, don't perform coercion
 	   * here so that an exact match can be performed.  Note, this

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -1797,7 +1797,7 @@ vid_pack_db_value (char *lbuf, DB_VALUE * dbval)
 
   or_init (&buf, lbuf, val_size);
 
-  if ((*(pr_type->data_writeval)) (&buf, dbval) != NO_ERROR)
+  if (pr_type->data_writeval (&buf, dbval) != NO_ERROR)
     {
       return NULL;
     }

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -960,7 +960,7 @@ vid_compare_non_updatable_objects (MOP mop1, MOP mop2)
 	  db_value_domain_init (&val1, att1->type->id, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	  db_value_domain_init (&val2, att1->type->id, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	  att1->type->getmem (mem1, att1->domain, &val1);
-	  att1->type->getmem (mem2, att2->domain, &val2);
+	  att2->type->getmem (mem2, att2->domain, &val2);
 	  set1 = db_get_set (&val1);
 	  set2 = db_get_set (&val2);
 	  db_value_put_null (&val1);
@@ -982,7 +982,7 @@ vid_compare_non_updatable_objects (MOP mop1, MOP mop2)
 	  db_value_domain_init (&val1, DB_TYPE_OBJECT, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	  db_value_domain_init (&val2, DB_TYPE_OBJECT, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	  att1->type->getmem (mem1, att1->domain, &val1);
-	  att1->type->getmem (mem2, att2->domain, &val2);
+	  att2->type->getmem (mem2, att2->domain, &val2);
 	  attobj1 = db_get_object (&val1);
 	  attobj2 = db_get_object (&val2);
 	  db_value_put_null (&val1);
@@ -1005,7 +1005,7 @@ vid_compare_non_updatable_objects (MOP mop1, MOP mop2)
 	  db_value_domain_init (&val1, att1->type->id, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	  db_value_domain_init (&val2, att2->type->id, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 	  att1->type->getmem (mem1, att1->domain, &val1);
-	  att1->type->getmem (mem2, att2->domain, &val2);
+	  att2->type->getmem (mem2, att2->domain, &val2);
 	  /*
 	   * Unlike most calls to this function, don't perform coercion
 	   * here so that an exact match can be performed.  Note, this

--- a/src/object/work_space.c
+++ b/src/object/work_space.c
@@ -967,7 +967,7 @@ ws_rehash_vmop (MOP mop, MOBJ classobj, DB_VALUE * newkey)
 		  /* Sets won't work as key components */
 		  mem = inst + att->offset;
 		  db_value_domain_init (&val, att->type->id, att->domain->precision, att->domain->scale);
-		  PRIM_GETMEM (att->type, att->domain, mem, &val);
+		  att->type->getmem (mem, att->domain, &val);
 		  if ((DB_VALUE_TYPE (value) == DB_TYPE_STRING) && (db_get_string (value) == NULL))
 		    {
 		      db_make_null (value);

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5031,7 +5031,7 @@ db_crc32_dbval (DB_VALUE * result, DB_VALUE * value)
 
   if (DB_IS_NULL (value))
     {
-      db_make_null (result);
+      PRIM_SET_NULL (result);
       return error_status;
     }
   else
@@ -5058,7 +5058,7 @@ db_crc32_dbval (DB_VALUE * result, DB_VALUE * value)
   return error_status;
 
 error:
-  db_make_null (result);
+  PRIM_SET_NULL (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       er_clear ();

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5031,7 +5031,7 @@ db_crc32_dbval (DB_VALUE * result, DB_VALUE * value)
 
   if (DB_IS_NULL (value))
     {
-      PRIM_SET_NULL (result);
+      db_make_null (result);
       return error_status;
     }
   else
@@ -5058,7 +5058,7 @@ db_crc32_dbval (DB_VALUE * result, DB_VALUE * value)
   return error_status;
 
 error:
-  PRIM_SET_NULL (result);
+  db_make_null (result);
   if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
     {
       er_clear ();

--- a/src/query/cursor.c
+++ b/src/query/cursor.c
@@ -382,7 +382,7 @@ cursor_copy_vobj_to_dbvalue (OR_BUF * buffer_p, DB_VALUE * value_p)
       return ER_FAILED;
     }
 
-  if ((*(pr_type->data_readval)) (buffer_p, &vobj_dbval, NULL, -1, true, NULL, 0) != NO_ERROR)
+  if (pr_type->data_readval (buffer_p, &vobj_dbval, NULL, -1, true, NULL, 0) != NO_ERROR)
     {
       return ER_FAILED;
     }
@@ -432,7 +432,7 @@ cursor_get_tuple_value_to_dbvalue (OR_BUF * buffer_p, TP_DOMAIN * domain_p, QFIL
     }
 
   /* for all other types, we can use the prim routines */
-  if ((*(pr_type->data_readval)) (buffer_p, value_p, domain_p, -1, is_copy, NULL, 0) != NO_ERROR)
+  if (pr_type->data_readval (buffer_p, value_p, domain_p, -1, is_copy, NULL, 0) != NO_ERROR)
     {
       return ER_FAILED;
     }

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -11504,14 +11504,7 @@ do_create_midxkey_for_constraint (DB_OTMPL * tmpl, SM_CLASS_CONSTRAINT * constra
 
       if (val != NULL && !DB_IS_NULL (val))
 	{
-	  if (attr_dom->type->index_lengthval != NULL)
-	    {
-	      buf_size += (*(attr_dom->type->index_lengthval)) (val);
-	    }
-	  else
-	    {
-	      buf_size += attr_dom->type->disksize;
-	    }
+	  buf_size += attr_dom->type->index_lengthval (val);
 	}
 
       if (setdomain == NULL)
@@ -11559,7 +11552,7 @@ do_create_midxkey_for_constraint (DB_OTMPL * tmpl, SM_CLASS_CONSTRAINT * constra
 
       if (val != NULL && !DB_IS_NULL (val))
 	{
-	  (*((dom->type)->index_writeval)) (&buf, val);
+	  dom->type->index_writeval (&buf, val);
 	  OR_ENABLE_BOUND_BIT (bound_bits, i);
 	}
       else

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -11504,7 +11504,7 @@ do_create_midxkey_for_constraint (DB_OTMPL * tmpl, SM_CLASS_CONSTRAINT * constra
 
       if (val != NULL && !DB_IS_NULL (val))
 	{
-	  buf_size += attr_dom->type->index_lengthval (val);
+	  buf_size += attr_dom->type->get_index_size_of_value (val);
 	}
 
       if (setdomain == NULL)

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -815,7 +815,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FLOOR:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_floor_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -826,7 +826,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CEIL:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_ceil_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -837,7 +837,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SIGN:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_sign_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -848,7 +848,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ABS:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_abs_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -859,7 +859,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_EXP:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_exp_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -870,7 +870,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SQRT:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_sqrt_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -881,7 +881,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SIN:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_sin_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -892,7 +892,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_COS:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_cos_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -903,7 +903,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TAN:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_tan_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -914,7 +914,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_COT:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_cot_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -925,7 +925,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LN:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_log_generic_dbval (arithptr->value, peek_right, -1 /* convention for e base */ ) !=
 	       NO_ERROR)
@@ -937,7 +937,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LOG2:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_log_generic_dbval (arithptr->value, peek_right, 2) != NO_ERROR)
 	{
@@ -948,7 +948,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LOG10:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_log_generic_dbval (arithptr->value, peek_right, 10) != NO_ERROR)
 	{
@@ -959,7 +959,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ACOS:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_acos_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -970,7 +970,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ASIN:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_asin_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -981,7 +981,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DEGREES:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_degrees_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -992,7 +992,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DATE:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_date_dbval (arithptr->value, peek_right, arithptr->domain) != NO_ERROR)
 	{
@@ -1003,7 +1003,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TIME:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_time_dbval (arithptr->value, peek_right, arithptr->domain) != NO_ERROR)
 	{
@@ -1018,7 +1018,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_RADIANS:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_radians_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -1055,7 +1055,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       if (DB_IS_NULL (peek_right))
 	{
 	  /* an instance does not exist to do increment */
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -1080,7 +1080,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CHR:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_chr (arithptr->value, peek_left, peek_right) != NO_ERROR)
 	{
@@ -1091,7 +1091,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_INSTR:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_instr (peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -1102,7 +1102,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_POSITION:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_position (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1113,7 +1113,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FINDINSET:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_find_string_in_in_set (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1124,7 +1124,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SUBSTRING:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || (arithptr->thirdptr && DB_IS_NULL (peek_third)))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (prm_get_integer_value (PRM_ID_COMPAT_MODE) == COMPAT_MYSQL)
 	{
@@ -1200,7 +1200,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_OCTET_LENGTH:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -1211,7 +1211,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_BIT_LENGTH:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (DB_VALUE_DOMAIN_TYPE (peek_right) == DB_TYPE_BIT || DB_VALUE_DOMAIN_TYPE (peek_right) == DB_TYPE_VARBIT)
 	{
@@ -1230,7 +1230,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CHAR_LENGTH:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -1241,7 +1241,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LOWER:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_lower (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1252,7 +1252,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_UPPER:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_upper (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1263,7 +1263,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_HEX:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_hex (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1274,7 +1274,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ASCII:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_ascii (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1285,7 +1285,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CONV:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -1299,7 +1299,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_BIN:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_bigint_to_binary_string (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1310,7 +1310,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_MD5:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_md5 (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1321,7 +1321,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SHA_ONE:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_sha_one (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1332,7 +1332,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_AES_ENCRYPT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_aes_encrypt (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1343,7 +1343,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_AES_DECRYPT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_aes_decrypt (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1354,7 +1354,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SHA_TWO:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_sha_two (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1365,7 +1365,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_BASE64:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_to_base64 (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1376,7 +1376,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FROM_BASE64:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_from_base64 (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1387,7 +1387,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SPACE:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_space (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1412,7 +1412,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_right && DB_IS_NULL (peek_right)))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_trim (arithptr->misc_operand, peek_right, peek_left, arithptr->value) != NO_ERROR)
 	{
@@ -1437,7 +1437,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_right && DB_IS_NULL (peek_right)))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_trim (LEADING, peek_right, peek_left, arithptr->value) != NO_ERROR)
 	{
@@ -1462,7 +1462,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_right && DB_IS_NULL (peek_right)))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_trim (TRAILING, peek_right, peek_left, arithptr->value) != NO_ERROR)
 	{
@@ -1473,7 +1473,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FROM_UNIXTIME:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_from_unixtime (peek_left, peek_right, peek_third, arithptr->value, arithptr->domain) != NO_ERROR)
 	{
@@ -1498,7 +1498,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_third && DB_IS_NULL (peek_third)))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_pad (LEADING, peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -1523,7 +1523,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_third && DB_IS_NULL (peek_third)))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_pad (TRAILING, peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -1548,7 +1548,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_third && DB_IS_NULL (peek_third)))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_replace (peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -1572,7 +1572,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_string_translate (peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -1583,7 +1583,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ADD_MONTHS:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_add_months (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1594,7 +1594,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LAST_DAY:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_last_day (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1605,7 +1605,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TIME_FORMAT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_time_format (peek_left, peek_right, peek_third, arithptr->value, arithptr->domain) != NO_ERROR)
 	{
@@ -1618,7 +1618,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DAY:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (get_year_month_or_day (peek_right, arithptr->opcode, arithptr->value) != NO_ERROR)
 	{
@@ -1641,7 +1641,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_QUARTER:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_get_date_quarter (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1653,7 +1653,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DAYOFWEEK:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (get_date_weekday (peek_right, arithptr->opcode, arithptr->value) != NO_ERROR)
 	{
@@ -1664,7 +1664,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DAYOFYEAR:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_get_date_dayofyear (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1675,7 +1675,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TODAYS:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_get_date_totaldays (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1686,7 +1686,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FROMDAYS:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_get_date_from_days (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1697,7 +1697,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TIMETOSEC:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_convert_time_to_sec (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1708,7 +1708,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SECTOTIME:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_convert_sec_to_time (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1719,7 +1719,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TIMESTAMP:
       if (DB_IS_NULL (peek_left) || (peek_right != NULL && DB_IS_NULL (peek_right)))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -1734,7 +1734,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LIKE_UPPER_BOUND:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -1750,7 +1750,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_MAKEDATE:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -1764,7 +1764,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ADDTIME:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -1778,7 +1778,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_MAKETIME:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -1792,7 +1792,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_WEEK:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -1808,7 +1808,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	{
 	  if (DB_IS_NULL (peek_right))
 	    {
-	      PRIM_SET_NULL (arithptr->value);
+	      db_make_null (arithptr->value);
 	    }
 	  else if (db_unix_timestamp (peek_right, arithptr->value) != NO_ERROR)
 	    {
@@ -1846,7 +1846,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_MONTHS_BETWEEN:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_months_between (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1857,7 +1857,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ATAN2:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_atan2_dbval (arithptr->value, peek_left, peek_right) != NO_ERROR)
 	{
@@ -1868,7 +1868,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ATAN:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_atan_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -1879,7 +1879,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FORMAT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_format (peek_left, peek_right, peek_third, arithptr->value, arithptr->domain) != NO_ERROR)
 	{
@@ -1890,7 +1890,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DATE_FORMAT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_date_format (peek_left, peek_right, peek_third, arithptr->value, arithptr->domain) != NO_ERROR)
 	{
@@ -1902,7 +1902,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_STR_TO_DATE:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_str_to_date (peek_left, peek_right, peek_third, arithptr->value, regu_var->domain) != NO_ERROR)
 	{
@@ -1913,7 +1913,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ADDDATE:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_date_add_interval_days (arithptr->value, peek_left, peek_right) != NO_ERROR)
 	{
@@ -1924,7 +1924,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DATE_ADD:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -1939,7 +1939,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SUBDATE:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_date_sub_interval_days (arithptr->value, peek_left, peek_right) != NO_ERROR)
 	{
@@ -1950,7 +1950,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DATEDIFF:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_date_diff (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1961,7 +1961,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TIMEDIFF:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_time_diff (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1972,7 +1972,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DATE_SUB:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -2113,7 +2113,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_CHAR:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_to_char (peek_left, peek_right, peek_third, arithptr->value, arithptr->domain) != NO_ERROR)
 	{
@@ -2125,7 +2125,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_BLOB_TO_BIT:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_blob_to_bit (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -2137,7 +2137,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CLOB_TO_CHAR:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_clob_to_char (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -2149,7 +2149,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_BIT_TO_BLOB:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (DB_VALUE_DOMAIN_TYPE (peek_left) == DB_TYPE_BIT || DB_VALUE_DOMAIN_TYPE (peek_left) == DB_TYPE_VARBIT)
 	{
@@ -2171,7 +2171,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CHAR_TO_CLOB:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_char_to_clob (peek_left, arithptr->value) != NO_ERROR)
 	{
@@ -2183,7 +2183,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LOB_LENGTH:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (DB_VALUE_DOMAIN_TYPE (peek_left) == DB_TYPE_BLOB)
 	{
@@ -2206,7 +2206,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_DATE:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_to_date (peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -2217,7 +2217,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_TIME:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_to_time (peek_left, peek_right, peek_third, DB_TYPE_TIME, arithptr->value) != NO_ERROR)
 	{
@@ -2228,7 +2228,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_TIMESTAMP:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_to_timestamp (peek_left, peek_right, peek_third, DB_TYPE_TIMESTAMP, arithptr->value) != NO_ERROR)
 	{
@@ -2239,7 +2239,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_DATETIME:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_to_datetime (peek_left, peek_right, peek_third, DB_TYPE_DATETIME, arithptr->value) != NO_ERROR)
 	{
@@ -2250,7 +2250,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_NUMBER:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -2269,7 +2269,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       assert (!REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_ALL_CONST));
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -2292,7 +2292,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       assert (!REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_ALL_CONST));
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -2386,7 +2386,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  status = tp_value_cast (peek_right, arithptr->value, arithptr->domain, false);
 	  if (status != NO_ERROR)
 	    {
-	      PRIM_SET_NULL (arithptr->value);
+	      db_make_null (arithptr->value);
 	    }
 	}
       break;
@@ -2608,14 +2608,14 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CONCAT_WS:
       if (DB_IS_NULL (peek_third))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	  break;
 	}
       if (arithptr->rightptr != NULL)
 	{
 	  if (DB_IS_NULL (peek_left) && DB_IS_NULL (peek_right))
 	    {
-	      PRIM_SET_NULL (arithptr->value);
+	      db_make_null (arithptr->value);
 	    }
 	  else if (DB_IS_NULL (peek_left))
 	    {
@@ -2656,7 +2656,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	{
 	  if (DB_IS_NULL (peek_left))
 	    {
-	      PRIM_SET_NULL (arithptr->value);
+	      db_make_null (arithptr->value);
 	    }
 	  else
 	    {
@@ -2757,7 +2757,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_REPEAT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -2771,7 +2771,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LEFT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -2795,7 +2795,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_RIGHT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -2817,7 +2817,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	    }
 	  if (DB_IS_NULL (&tmp_val))
 	    {
-	      PRIM_SET_NULL (arithptr->value);
+	      db_make_null (arithptr->value);
 	      break;
 	    }
 
@@ -2847,7 +2847,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LOCATE:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || (arithptr->thirdptr && DB_IS_NULL (peek_third)))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -2909,7 +2909,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SUBSTRING_INDEX:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -2923,7 +2923,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_MID:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -2984,7 +2984,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_STRCMP:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -3010,7 +3010,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_REVERSE:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -3042,7 +3042,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	target_domain = regu_var->domain;
 	if (DB_IS_NULL (peek_left))
 	  {
-	    PRIM_SET_NULL (arithptr->value);
+	    db_make_null (arithptr->value);
 	    break;
 	  }
 	else if (target_domain == NULL)
@@ -3058,7 +3058,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	cmp_res = tp_value_compare_with_error (peek_left, peek_right, 1, 0, &can_compare);
 	if (cmp_res == DB_EQ)
 	  {
-	    PRIM_SET_NULL (arithptr->value);
+	    db_make_null (arithptr->value);
 	  }
 	else if (cmp_res == DB_UNK && can_compare == false)
 	  {
@@ -3363,7 +3363,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_INDEX_CARDINALITY:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -3394,7 +3394,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_INET_ATON:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_inet_aton (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -3405,7 +3405,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_INET_NTOA:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_inet_ntoa (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -3490,7 +3490,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 
 	if (DB_IS_NULL (peek_right))
 	  {
-	    PRIM_SET_NULL (arithptr->value);
+	    db_make_null (arithptr->value);
 	  }
 	else
 	  {
@@ -3505,7 +3505,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_NEW_TIME:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -3519,7 +3519,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FROM_TZ:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -3533,7 +3533,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CONV_TZ:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else
 	{
@@ -3547,7 +3547,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_DATETIME_TZ:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_to_datetime (peek_left, peek_right, peek_third, DB_TYPE_DATETIMETZ, arithptr->value) != NO_ERROR)
 	{
@@ -3558,7 +3558,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_TIMESTAMP_TZ:
       if (DB_IS_NULL (peek_left))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_to_timestamp (peek_left, peek_right, peek_third, DB_TYPE_TIMESTAMPTZ, arithptr->value) != NO_ERROR)
 	{
@@ -3584,7 +3584,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CRC32:
       if (DB_IS_NULL (peek_right))
 	{
-	  PRIM_SET_NULL (arithptr->value);
+	  db_make_null (arithptr->value);
 	}
       else if (db_crc32_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -4636,7 +4636,7 @@ get_hour_minute_or_second (const DB_VALUE * datetime, OPERATOR_TYPE op_type, DB_
 
   if (DB_IS_NULL (datetime))
     {
-      PRIM_SET_NULL (db_value);
+      db_make_null (db_value);
       return NO_ERROR;
     }
 

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -3828,8 +3828,8 @@ fetch_peek_dbval (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 
 	  OR_BUF_INIT (buf, ptr, length);
 
-	  if ((*(pr_type->data_readval)) (&buf, *peek_dbval, regu_var->value.pos_descr.dom, -1, false /* Don't copy */ ,
-					  NULL, 0) != NO_ERROR)
+	  if (pr_type->data_readval (&buf, *peek_dbval, regu_var->value.pos_descr.dom, -1, false /* Don't copy */ ,
+				     NULL, 0) != NO_ERROR)
 	    {
 	      goto exit_on_error;
 	    }
@@ -4300,8 +4300,7 @@ fetch_peek_dbval_pos (REGU_VARIABLE * regu_var, QFILE_TUPLE tpl, int pos, DB_VAL
 
       OR_BUF_INIT (buf, ptr, length);
       /* read value from the tuple */
-      if ((*(pr_type->data_readval)) (&buf, *peek_dbval, pos_descr->dom, -1, false /* Don't copy */ ,
-				      NULL, 0) != NO_ERROR)
+      if (pr_type->data_readval (&buf, *peek_dbval, pos_descr->dom, -1, false /* Don't copy */ , NULL, 0) != NO_ERROR)
 	{
 	  return ER_FAILED;
 	}

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -815,7 +815,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FLOOR:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_floor_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -826,7 +826,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CEIL:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_ceil_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -837,7 +837,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SIGN:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_sign_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -848,7 +848,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ABS:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_abs_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -859,7 +859,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_EXP:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_exp_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -870,7 +870,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SQRT:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_sqrt_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -881,7 +881,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SIN:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_sin_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -892,7 +892,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_COS:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_cos_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -903,7 +903,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TAN:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_tan_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -914,7 +914,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_COT:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_cot_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -925,7 +925,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LN:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_log_generic_dbval (arithptr->value, peek_right, -1 /* convention for e base */ ) !=
 	       NO_ERROR)
@@ -937,7 +937,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LOG2:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_log_generic_dbval (arithptr->value, peek_right, 2) != NO_ERROR)
 	{
@@ -948,7 +948,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LOG10:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_log_generic_dbval (arithptr->value, peek_right, 10) != NO_ERROR)
 	{
@@ -959,7 +959,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ACOS:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_acos_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -970,7 +970,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ASIN:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_asin_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -981,7 +981,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DEGREES:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_degrees_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -992,7 +992,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DATE:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_date_dbval (arithptr->value, peek_right, arithptr->domain) != NO_ERROR)
 	{
@@ -1003,7 +1003,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TIME:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_time_dbval (arithptr->value, peek_right, arithptr->domain) != NO_ERROR)
 	{
@@ -1018,7 +1018,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_RADIANS:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_radians_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -1055,7 +1055,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       if (DB_IS_NULL (peek_right))
 	{
 	  /* an instance does not exist to do increment */
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -1080,7 +1080,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CHR:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_chr (arithptr->value, peek_left, peek_right) != NO_ERROR)
 	{
@@ -1091,7 +1091,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_INSTR:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_instr (peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -1102,7 +1102,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_POSITION:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_position (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1113,7 +1113,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FINDINSET:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_find_string_in_in_set (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1124,7 +1124,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SUBSTRING:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || (arithptr->thirdptr && DB_IS_NULL (peek_third)))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (prm_get_integer_value (PRM_ID_COMPAT_MODE) == COMPAT_MYSQL)
 	{
@@ -1200,7 +1200,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_OCTET_LENGTH:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -1211,7 +1211,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_BIT_LENGTH:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (DB_VALUE_DOMAIN_TYPE (peek_right) == DB_TYPE_BIT || DB_VALUE_DOMAIN_TYPE (peek_right) == DB_TYPE_VARBIT)
 	{
@@ -1230,7 +1230,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CHAR_LENGTH:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -1241,7 +1241,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LOWER:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_lower (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1252,7 +1252,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_UPPER:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_upper (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1263,7 +1263,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_HEX:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_hex (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1274,7 +1274,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ASCII:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_ascii (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1285,7 +1285,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CONV:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -1299,7 +1299,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_BIN:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_bigint_to_binary_string (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1310,7 +1310,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_MD5:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_md5 (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1321,7 +1321,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SHA_ONE:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_sha_one (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1332,7 +1332,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_AES_ENCRYPT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_aes_encrypt (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1343,7 +1343,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_AES_DECRYPT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_aes_decrypt (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1354,7 +1354,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SHA_TWO:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_sha_two (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1365,7 +1365,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_BASE64:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_to_base64 (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1376,7 +1376,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FROM_BASE64:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_from_base64 (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1387,7 +1387,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SPACE:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_space (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1412,7 +1412,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_right && DB_IS_NULL (peek_right)))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_trim (arithptr->misc_operand, peek_right, peek_left, arithptr->value) != NO_ERROR)
 	{
@@ -1437,7 +1437,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_right && DB_IS_NULL (peek_right)))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_trim (LEADING, peek_right, peek_left, arithptr->value) != NO_ERROR)
 	{
@@ -1462,7 +1462,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_right && DB_IS_NULL (peek_right)))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_trim (TRAILING, peek_right, peek_left, arithptr->value) != NO_ERROR)
 	{
@@ -1473,7 +1473,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FROM_UNIXTIME:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_from_unixtime (peek_left, peek_right, peek_third, arithptr->value, arithptr->domain) != NO_ERROR)
 	{
@@ -1498,7 +1498,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_third && DB_IS_NULL (peek_third)))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_pad (LEADING, peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -1523,7 +1523,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_third && DB_IS_NULL (peek_third)))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_pad (TRAILING, peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -1548,7 +1548,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left) || (peek_third && DB_IS_NULL (peek_third)))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_replace (peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -1572,7 +1572,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	}
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_string_translate (peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -1583,7 +1583,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ADD_MONTHS:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_add_months (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1594,7 +1594,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LAST_DAY:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_last_day (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1605,7 +1605,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TIME_FORMAT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_time_format (peek_left, peek_right, peek_third, arithptr->value, arithptr->domain) != NO_ERROR)
 	{
@@ -1618,7 +1618,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DAY:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (get_year_month_or_day (peek_right, arithptr->opcode, arithptr->value) != NO_ERROR)
 	{
@@ -1641,7 +1641,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_QUARTER:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_get_date_quarter (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1653,7 +1653,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DAYOFWEEK:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (get_date_weekday (peek_right, arithptr->opcode, arithptr->value) != NO_ERROR)
 	{
@@ -1664,7 +1664,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DAYOFYEAR:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_get_date_dayofyear (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1675,7 +1675,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TODAYS:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_get_date_totaldays (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1686,7 +1686,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FROMDAYS:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_get_date_from_days (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1697,7 +1697,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TIMETOSEC:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_convert_time_to_sec (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1708,7 +1708,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SECTOTIME:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_convert_sec_to_time (peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1719,7 +1719,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TIMESTAMP:
       if (DB_IS_NULL (peek_left) || (peek_right != NULL && DB_IS_NULL (peek_right)))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -1734,7 +1734,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LIKE_UPPER_BOUND:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -1750,7 +1750,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_MAKEDATE:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -1764,7 +1764,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ADDTIME:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -1778,7 +1778,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_MAKETIME:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -1792,7 +1792,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_WEEK:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -1808,7 +1808,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	{
 	  if (DB_IS_NULL (peek_right))
 	    {
-	      db_make_null (arithptr->value);
+	      PRIM_SET_NULL (arithptr->value);
 	    }
 	  else if (db_unix_timestamp (peek_right, arithptr->value) != NO_ERROR)
 	    {
@@ -1846,7 +1846,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_MONTHS_BETWEEN:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_months_between (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1857,7 +1857,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ATAN2:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_atan2_dbval (arithptr->value, peek_left, peek_right) != NO_ERROR)
 	{
@@ -1868,7 +1868,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ATAN:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_atan_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -1879,7 +1879,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FORMAT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_format (peek_left, peek_right, peek_third, arithptr->value, arithptr->domain) != NO_ERROR)
 	{
@@ -1890,7 +1890,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DATE_FORMAT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_date_format (peek_left, peek_right, peek_third, arithptr->value, arithptr->domain) != NO_ERROR)
 	{
@@ -1902,7 +1902,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_STR_TO_DATE:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_str_to_date (peek_left, peek_right, peek_third, arithptr->value, regu_var->domain) != NO_ERROR)
 	{
@@ -1913,7 +1913,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_ADDDATE:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_date_add_interval_days (arithptr->value, peek_left, peek_right) != NO_ERROR)
 	{
@@ -1924,7 +1924,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DATE_ADD:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -1939,7 +1939,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SUBDATE:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_date_sub_interval_days (arithptr->value, peek_left, peek_right) != NO_ERROR)
 	{
@@ -1950,7 +1950,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DATEDIFF:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_date_diff (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1961,7 +1961,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TIMEDIFF:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_time_diff (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -1972,7 +1972,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_DATE_SUB:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -2113,7 +2113,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_CHAR:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_to_char (peek_left, peek_right, peek_third, arithptr->value, arithptr->domain) != NO_ERROR)
 	{
@@ -2125,7 +2125,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_BLOB_TO_BIT:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_blob_to_bit (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -2137,7 +2137,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CLOB_TO_CHAR:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_clob_to_char (peek_left, peek_right, arithptr->value) != NO_ERROR)
 	{
@@ -2149,7 +2149,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_BIT_TO_BLOB:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (DB_VALUE_DOMAIN_TYPE (peek_left) == DB_TYPE_BIT || DB_VALUE_DOMAIN_TYPE (peek_left) == DB_TYPE_VARBIT)
 	{
@@ -2171,7 +2171,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CHAR_TO_CLOB:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_char_to_clob (peek_left, arithptr->value) != NO_ERROR)
 	{
@@ -2183,7 +2183,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LOB_LENGTH:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (DB_VALUE_DOMAIN_TYPE (peek_left) == DB_TYPE_BLOB)
 	{
@@ -2206,7 +2206,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_DATE:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_to_date (peek_left, peek_right, peek_third, arithptr->value) != NO_ERROR)
 	{
@@ -2217,7 +2217,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_TIME:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_to_time (peek_left, peek_right, peek_third, DB_TYPE_TIME, arithptr->value) != NO_ERROR)
 	{
@@ -2228,7 +2228,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_TIMESTAMP:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_to_timestamp (peek_left, peek_right, peek_third, DB_TYPE_TIMESTAMP, arithptr->value) != NO_ERROR)
 	{
@@ -2239,7 +2239,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_DATETIME:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_to_datetime (peek_left, peek_right, peek_third, DB_TYPE_DATETIME, arithptr->value) != NO_ERROR)
 	{
@@ -2250,7 +2250,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_NUMBER:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -2269,7 +2269,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       assert (!REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_ALL_CONST));
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -2292,7 +2292,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
       assert (!REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_ALL_CONST));
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -2386,7 +2386,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	  status = tp_value_cast (peek_right, arithptr->value, arithptr->domain, false);
 	  if (status != NO_ERROR)
 	    {
-	      db_make_null (arithptr->value);
+	      PRIM_SET_NULL (arithptr->value);
 	    }
 	}
       break;
@@ -2608,14 +2608,14 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CONCAT_WS:
       if (DB_IS_NULL (peek_third))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	  break;
 	}
       if (arithptr->rightptr != NULL)
 	{
 	  if (DB_IS_NULL (peek_left) && DB_IS_NULL (peek_right))
 	    {
-	      db_make_null (arithptr->value);
+	      PRIM_SET_NULL (arithptr->value);
 	    }
 	  else if (DB_IS_NULL (peek_left))
 	    {
@@ -2656,7 +2656,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	{
 	  if (DB_IS_NULL (peek_left))
 	    {
-	      db_make_null (arithptr->value);
+	      PRIM_SET_NULL (arithptr->value);
 	    }
 	  else
 	    {
@@ -2757,7 +2757,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_REPEAT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -2771,7 +2771,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LEFT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -2795,7 +2795,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_RIGHT:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -2817,7 +2817,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	    }
 	  if (DB_IS_NULL (&tmp_val))
 	    {
-	      db_make_null (arithptr->value);
+	      PRIM_SET_NULL (arithptr->value);
 	      break;
 	    }
 
@@ -2847,7 +2847,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_LOCATE:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || (arithptr->thirdptr && DB_IS_NULL (peek_third)))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -2909,7 +2909,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_SUBSTRING_INDEX:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -2923,7 +2923,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_MID:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -2984,7 +2984,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_STRCMP:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -3010,7 +3010,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_REVERSE:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -3042,7 +3042,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	target_domain = regu_var->domain;
 	if (DB_IS_NULL (peek_left))
 	  {
-	    db_make_null (arithptr->value);
+	    PRIM_SET_NULL (arithptr->value);
 	    break;
 	  }
 	else if (target_domain == NULL)
@@ -3058,7 +3058,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 	cmp_res = tp_value_compare_with_error (peek_left, peek_right, 1, 0, &can_compare);
 	if (cmp_res == DB_EQ)
 	  {
-	    db_make_null (arithptr->value);
+	    PRIM_SET_NULL (arithptr->value);
 	  }
 	else if (cmp_res == DB_UNK && can_compare == false)
 	  {
@@ -3363,7 +3363,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_INDEX_CARDINALITY:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -3394,7 +3394,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_INET_ATON:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_inet_aton (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -3405,7 +3405,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_INET_NTOA:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_inet_ntoa (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -3490,7 +3490,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
 
 	if (DB_IS_NULL (peek_right))
 	  {
-	    db_make_null (arithptr->value);
+	    PRIM_SET_NULL (arithptr->value);
 	  }
 	else
 	  {
@@ -3505,7 +3505,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_NEW_TIME:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || DB_IS_NULL (peek_third))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -3519,7 +3519,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_FROM_TZ:
       if (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -3533,7 +3533,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CONV_TZ:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else
 	{
@@ -3547,7 +3547,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_DATETIME_TZ:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_to_datetime (peek_left, peek_right, peek_third, DB_TYPE_DATETIMETZ, arithptr->value) != NO_ERROR)
 	{
@@ -3558,7 +3558,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_TO_TIMESTAMP_TZ:
       if (DB_IS_NULL (peek_left))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_to_timestamp (peek_left, peek_right, peek_third, DB_TYPE_TIMESTAMPTZ, arithptr->value) != NO_ERROR)
 	{
@@ -3584,7 +3584,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR *
     case T_CRC32:
       if (DB_IS_NULL (peek_right))
 	{
-	  db_make_null (arithptr->value);
+	  PRIM_SET_NULL (arithptr->value);
 	}
       else if (db_crc32_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
@@ -4636,7 +4636,7 @@ get_hour_minute_or_second (const DB_VALUE * datetime, OPERATOR_TYPE op_type, DB_
 
   if (DB_IS_NULL (datetime))
     {
-      db_make_null (db_value);
+      PRIM_SET_NULL (db_value);
       return NO_ERROR;
     }
 

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -650,7 +650,7 @@ qfile_compare_tuple_values (QFILE_TUPLE tuple1, QFILE_TUPLE tuple2, TP_DOMAIN * 
   else
     {
       or_init (&buf, (char *) tuple1 + QFILE_TUPLE_VALUE_HEADER_SIZE, length1);
-      rc = (*(pr_type_p->data_readval)) (&buf, &dbval1, domain_p, -1, is_copy, NULL, 0);
+      rc = pr_type_p->data_readval (&buf, &dbval1, domain_p, -1, is_copy, NULL, 0);
       if (rc != NO_ERROR)
 	{
 	  return ER_FAILED;
@@ -667,7 +667,7 @@ qfile_compare_tuple_values (QFILE_TUPLE tuple1, QFILE_TUPLE tuple2, TP_DOMAIN * 
   else
     {
       or_init (&buf, (char *) tuple2 + QFILE_TUPLE_VALUE_HEADER_SIZE, length2);
-      rc = (*(pr_type_p->data_readval)) (&buf, &dbval2, domain_p, -1, is_copy, NULL, 0);
+      rc = pr_type_p->data_readval (&buf, &dbval2, domain_p, -1, is_copy, NULL, 0);
       if (rc != NO_ERROR)
 	{
 	  pr_clear_value (&dbval1);
@@ -689,7 +689,7 @@ qfile_compare_tuple_values (QFILE_TUPLE tuple1, QFILE_TUPLE tuple2, TP_DOMAIN * 
     }
   else
     {
-      *compare_result = (*(pr_type_p->cmpval)) (&dbval1, &dbval2, 0, 1, NULL, domain_p->collation_id);
+      *compare_result = pr_type_p->cmpval (&dbval1, &dbval2, 0, 1, NULL, domain_p->collation_id);
     }
 
   pr_clear_value (&dbval1);
@@ -884,7 +884,7 @@ qfile_print_tuple (QFILE_TUPLE_VALUE_TYPE_LIST * type_list_p, QFILE_TUPLE tuple)
 	  or_init (&buf, tuple_p + QFILE_TUPLE_VALUE_HEADER_SIZE, QFILE_GET_TUPLE_VALUE_LENGTH (tuple_p));
 	  (*(pr_type_p->readval)) (&buf, &dbval, type_list_p->domp[i], -1, true, NULL, 0);
 
-	  (*(pr_type_p->fptrfunc)) (NULL, stdout, &dbval);
+	  db_fprint_value (stdout, &dbval);
 	  if (pr_is_set_type (pr_type_p->id))
 	    {
 	      pr_clear_value (&dbval);
@@ -1805,7 +1805,7 @@ qfile_fast_intval_tuple_to_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
       QFILE_PUT_TUPLE_VALUE_LENGTH (tuple_p, tuple_value_size);
 
       OR_BUF_INIT (buf, tuple_p + QFILE_TUPLE_VALUE_HEADER_SIZE, tuple_value_size);
-      if (pr_type == NULL || (*(pr_type->data_writeval)) (&buf, v2) != NO_ERROR)
+      if (pr_type == NULL || pr_type->data_writeval (&buf, v2) != NO_ERROR)
 	{
 	  return ER_FAILED;
 	}
@@ -1884,7 +1884,7 @@ qfile_fast_val_tuple_to_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id_p
       QFILE_PUT_TUPLE_VALUE_LENGTH (tuple_p, tuple_value_size);
 
       OR_BUF_INIT (buf, tuple_p + QFILE_TUPLE_VALUE_HEADER_SIZE, tuple_value_size);
-      if (pr_type == NULL || (*(pr_type->data_writeval)) (&buf, val) != NO_ERROR)
+      if (pr_type == NULL || pr_type->data_writeval (&buf, val) != NO_ERROR)
 	{
 	  return ER_FAILED;
 	}
@@ -3663,11 +3663,11 @@ qfile_initialize_sort_key_info (SORTKEY_INFO * key_info_p, SORT_LIST * list_p, Q
 
 	  if (p->pos_descr.dom->type->id == DB_TYPE_VARIABLE)
 	    {
-	      subkey->sort_f = types->domp[i]->type->data_cmpdisk;
+	      subkey->sort_f = types->domp[i]->type->get_data_cmpdisk_function ();
 	    }
 	  else
 	    {
-	      subkey->sort_f = p->pos_descr.dom->type->data_cmpdisk;
+	      subkey->sort_f = p->pos_descr.dom->type->get_data_cmpdisk_function ();
 	    }
 
 	  subkey->is_desc = (p->s_order == S_ASC) ? 0 : 1;
@@ -3694,7 +3694,7 @@ qfile_initialize_sort_key_info (SORTKEY_INFO * key_info_p, SORT_LIST * list_p, Q
 	  subkey->col_dom = types->domp[i];
 	  subkey->cmp_dom = NULL;
 	  subkey->use_cmp_dom = false;
-	  subkey->sort_f = types->domp[i]->type->data_cmpdisk;
+	  subkey->sort_f = types->domp[i]->type->get_data_cmpdisk_function ();
 	  subkey->is_desc = 0;
 	  subkey->is_nulls_first = 1;
 	}
@@ -6473,7 +6473,7 @@ qfile_set_tuple_column_value (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id_p
 	{
 	  OR_BUF_INIT (buf, ptr, length);
 
-	  if ((*(pr_type->data_writeval)) (&buf, value_p) != NO_ERROR)
+	  if (pr_type->data_writeval (&buf, value_p) != NO_ERROR)
 	    {
 	      error = ER_FAILED;
 	      goto cleanup;
@@ -6512,7 +6512,7 @@ qfile_set_tuple_column_value (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id_p
 	{
 	  OR_BUF_INIT (buf, ptr, length);
 
-	  if ((*(pr_type->data_writeval)) (&buf, value_p) != NO_ERROR)
+	  if (pr_type->data_writeval (&buf, value_p) != NO_ERROR)
 	    {
 	      error = ER_FAILED;
 	      goto cleanup;
@@ -6659,8 +6659,8 @@ qfile_compare_with_interpolation_domain (char *fp0, char *fp1, SUBKEY_INFO * sub
 
       OR_BUF_INIT (buf0, d0, QFILE_GET_TUPLE_VALUE_LENGTH (fp0));
       error =
-	(subkey->col_dom->type->data_readval) (&buf0, &val0, subkey->col_dom, QFILE_GET_TUPLE_VALUE_LENGTH (fp0), false,
-					       NULL, 0);
+	subkey->col_dom->type->data_readval (&buf0, &val0, subkey->col_dom, QFILE_GET_TUPLE_VALUE_LENGTH (fp0), false,
+					     NULL, 0);
       if (error != NO_ERROR || DB_IS_NULL (&val0))
 	{
 	  goto end;
@@ -6685,16 +6685,16 @@ qfile_compare_with_interpolation_domain (char *fp0, char *fp1, SUBKEY_INFO * sub
   OR_BUF_INIT (buf0, d0, QFILE_GET_TUPLE_VALUE_LENGTH (fp0));
   OR_BUF_INIT (buf1, d1, QFILE_GET_TUPLE_VALUE_LENGTH (fp1));
   error =
-    (subkey->col_dom->type->data_readval) (&buf0, &val0, subkey->col_dom, QFILE_GET_TUPLE_VALUE_LENGTH (fp0), false,
-					   NULL, 0);
+    subkey->col_dom->type->data_readval (&buf0, &val0, subkey->col_dom, QFILE_GET_TUPLE_VALUE_LENGTH (fp0), false,
+					 NULL, 0);
   if (error != NO_ERROR)
     {
       goto end;
     }
 
   error =
-    (subkey->col_dom->type->data_readval) (&buf1, &val1, subkey->col_dom, QFILE_GET_TUPLE_VALUE_LENGTH (fp1), false,
-					   NULL, 0);
+    subkey->col_dom->type->data_readval (&buf1, &val1, subkey->col_dom, QFILE_GET_TUPLE_VALUE_LENGTH (fp1), false,
+					 NULL, 0);
   if (error != NO_ERROR)
     {
       goto end;

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -37,7 +37,7 @@
 #include "dbtype.h"
 #include "error_manager.h"
 #include "object_primitive.h"
-#include "object_print.h"
+#include "db_value_printer.hpp"
 #include "query_manager.h"
 #include "query_opfunc.h"
 #include "stream_to_xasl.h"
@@ -5203,7 +5203,7 @@ qfile_print_list_cache_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *ke
   for (i = 0; i < ent->param_values.size; i++)
     {
       fprintf (fp, " ");
-      help_fprint_value (thread_p, fp, &ent->param_values.vals[i]);
+      db_fprint_value (fp, &ent->param_values.vals[i]);
     }
 
   fprintf (fp, " ]\n");

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -5480,7 +5480,7 @@ qfile_delete_list_cache_entry (THREAD_ENTRY * thread_p, void *data, void *args)
 
 	      if (lent->param_values.size > 0)
 		{
-		  s = pr_valstring (thread_p, &lent->param_values.vals[0]);
+		  s = pr_valstring (&lent->param_values.vals[0]);
 		}
 
 	      er_log_debug (ARG_FILE_LINE,
@@ -6101,7 +6101,7 @@ qfile_update_list_cache_entry (THREAD_ENTRY * thread_p, int *list_ht_no_ptr, con
     {
       char *s;
 
-      s = ((lent->param_values.size > 0) ? pr_valstring (thread_p, &lent->param_values.vals[0]) : NULL);
+      s = ((lent->param_values.size > 0) ? pr_valstring (&lent->param_values.vals[0]) : NULL);
       er_log_debug (ARG_FILE_LINE, "ls_update_list_cache_ent: mht_rem failed for param_values { %d %s ...}\n",
 		    lent->param_values.size, s ? s : "(null)");
       if (s)

--- a/src/query/query_evaluator.c
+++ b/src/query/query_evaluator.c
@@ -338,7 +338,7 @@ eval_some_eval (DB_VALUE * item, DB_SET * set, REL_OP rel_operator)
   DB_LOGICAL res, t_res;
   DB_VALUE elem_val;
 
-  db_make_null (&elem_val);
+  PRIM_SET_NULL (&elem_val);
 
   res = V_FALSE;
 
@@ -464,7 +464,7 @@ eval_item_card_set (DB_VALUE * item, DB_SET * set, REL_OP rel_operator)
   DB_LOGICAL res;
   DB_VALUE elem_val;
 
-  db_make_null (&elem_val);
+  PRIM_SET_NULL (&elem_val);
 
   num = 0;
 
@@ -546,7 +546,7 @@ eval_some_list_eval (THREAD_ENTRY * thread_p, DB_VALUE * item, QFILE_LIST_ID * l
       return V_ERROR;
     }
 
-  db_make_null (&list_val);
+  PRIM_SET_NULL (&list_val);
 
   if (list_id->tuple_cnt == 0)
     {
@@ -693,7 +693,7 @@ eval_item_card_sort_list (THREAD_ENTRY * thread_p, DB_VALUE * item, QFILE_LIST_I
       return ER_FAILED;
     }
 
-  db_make_null (&list_val);
+  PRIM_SET_NULL (&list_val);
   card = 0;
 
   if (qfile_open_list_scan (list_id, &s_id) != NO_ERROR)
@@ -779,8 +779,8 @@ eval_sub_multi_set_to_sort_list (THREAD_ENTRY * thread_p, DB_SET * set1, QFILE_L
   DB_VALUE elem_val, elem_val2;
   int found;
 
-  db_make_null (&elem_val);
-  db_make_null (&elem_val2);
+  PRIM_SET_NULL (&elem_val);
+  PRIM_SET_NULL (&elem_val2);
 
   card = set_size (set1);
   if (card == 0)
@@ -907,8 +907,8 @@ eval_sub_sort_list_to_multi_set (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
       return V_ERROR;
     }
 
-  db_make_null (&list_val);
-  db_make_null (&list_val2);
+  PRIM_SET_NULL (&list_val);
+  PRIM_SET_NULL (&list_val2);
 
   if (list_id->tuple_cnt == 0)
     {
@@ -1083,8 +1083,8 @@ eval_sub_sort_list_to_sort_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
       return V_ERROR;
     }
 
-  db_make_null (&list_val);
-  db_make_null (&list_val2);
+  PRIM_SET_NULL (&list_val);
+  PRIM_SET_NULL (&list_val2);
 
   if (list_id1->tuple_cnt == 0)
     {

--- a/src/query/query_evaluator.c
+++ b/src/query/query_evaluator.c
@@ -576,7 +576,7 @@ eval_some_list_eval (THREAD_ENTRY * thread_p, DB_VALUE * item, QFILE_LIST_ID * l
 	{
 	  OR_BUF_INIT (buf, ptr, length);
 
-	  if ((*(pr_type->data_readval)) (&buf, &list_val, list_id->type_list.domp[0], -1, true, NULL, 0) != NO_ERROR)
+	  if (pr_type->data_readval (&buf, &list_val, list_id->type_list.domp[0], -1, true, NULL, 0) != NO_ERROR)
 	    {
 	      qfile_close_scan (thread_p, &s_id);
 	      return V_ERROR;
@@ -718,7 +718,7 @@ eval_item_card_sort_list (THREAD_ENTRY * thread_p, DB_VALUE * item, QFILE_LIST_I
 
       OR_BUF_INIT (buf, ptr, length);
 
-      (*(pr_type->data_readval)) (&buf, &list_val, list_id->type_list.domp[0], -1, true, NULL, 0);
+      pr_type->data_readval (&buf, &list_val, list_id->type_list.domp[0], -1, true, NULL, 0);
 
       rc = eval_value_rel_cmp (item, &list_val, R_LT, NULL);
       if (rc == V_ERROR)
@@ -947,7 +947,7 @@ eval_sub_sort_list_to_multi_set (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
 
       OR_BUF_INIT (buf, ptr, length);
 
-      (*(pr_type->data_readval)) (&buf, &list_val, list_id->type_list.domp[0], -1, true, NULL, 0);
+      pr_type->data_readval (&buf, &list_val, list_id->type_list.domp[0], -1, true, NULL, 0);
 
       if (list_on == true)
 	{
@@ -955,7 +955,7 @@ eval_sub_sort_list_to_multi_set (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
 
 	  or_init (&buf, p_tplp + QFILE_TUPLE_VALUE_HEADER_SIZE, QFILE_GET_TUPLE_VALUE_LENGTH (p_tplp));
 
-	  (*(pr_type->data_readval)) (&buf, &list_val2, list_id->type_list.domp[0], -1, true, NULL, 0);
+	  pr_type->data_readval (&buf, &list_val2, list_id->type_list.domp[0], -1, true, NULL, 0);
 
 	  rc = eval_value_rel_cmp (&list_val, &list_val2, R_EQ, NULL);
 	  if (rc == V_ERROR)
@@ -1015,7 +1015,7 @@ eval_sub_sort_list_to_multi_set (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
 
       or_init (&buf, p_tplp + QFILE_TUPLE_VALUE_HEADER_SIZE, QFILE_GET_TUPLE_VALUE_LENGTH (p_tplp));
 
-      (*(pr_type->data_readval)) (&buf, &list_val2, list_id->type_list.domp[0], -1, true, NULL, 0);
+      pr_type->data_readval (&buf, &list_val2, list_id->type_list.domp[0], -1, true, NULL, 0);
 
       card2 = eval_item_card_set (&list_val2, set, R_EQ);
       if (card2 == ER_FAILED)
@@ -1123,7 +1123,7 @@ eval_sub_sort_list_to_sort_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
 
       OR_BUF_INIT (buf, ptr, length);
 
-      (*(pr_type->data_readval)) (&buf, &list_val, list_id1->type_list.domp[0], -1, true, NULL, 0);
+      pr_type->data_readval (&buf, &list_val, list_id1->type_list.domp[0], -1, true, NULL, 0);
 
       if (list_on == true)
 	{
@@ -1131,7 +1131,7 @@ eval_sub_sort_list_to_sort_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
 
 	  or_init (&buf, p_tplp + QFILE_TUPLE_VALUE_HEADER_SIZE, QFILE_GET_TUPLE_VALUE_LENGTH (p_tplp));
 
-	  (*(pr_type->data_readval)) (&buf, &list_val2, list_id1->type_list.domp[0], -1, true, NULL, 0);
+	  pr_type->data_readval (&buf, &list_val2, list_id1->type_list.domp[0], -1, true, NULL, 0);
 
 	  rc = eval_value_rel_cmp (&list_val, &list_val2, R_EQ, NULL);
 
@@ -1192,7 +1192,7 @@ eval_sub_sort_list_to_sort_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
 
       or_init (&buf, p_tplp + QFILE_TUPLE_VALUE_HEADER_SIZE, QFILE_GET_TUPLE_VALUE_LENGTH (p_tplp));
 
-      if ((*(pr_type->data_readval)) (&buf, &list_val2, list_id1->type_list.domp[0], -1, true, NULL, 0) != NO_ERROR)
+      if (pr_type->data_readval (&buf, &list_val2, list_id1->type_list.domp[0], -1, true, NULL, 0) != NO_ERROR)
 	{
 	  res = V_ERROR;
 	  goto end;

--- a/src/query/query_evaluator.c
+++ b/src/query/query_evaluator.c
@@ -338,7 +338,7 @@ eval_some_eval (DB_VALUE * item, DB_SET * set, REL_OP rel_operator)
   DB_LOGICAL res, t_res;
   DB_VALUE elem_val;
 
-  PRIM_SET_NULL (&elem_val);
+  db_make_null (&elem_val);
 
   res = V_FALSE;
 
@@ -464,7 +464,7 @@ eval_item_card_set (DB_VALUE * item, DB_SET * set, REL_OP rel_operator)
   DB_LOGICAL res;
   DB_VALUE elem_val;
 
-  PRIM_SET_NULL (&elem_val);
+  db_make_null (&elem_val);
 
   num = 0;
 
@@ -546,7 +546,7 @@ eval_some_list_eval (THREAD_ENTRY * thread_p, DB_VALUE * item, QFILE_LIST_ID * l
       return V_ERROR;
     }
 
-  PRIM_SET_NULL (&list_val);
+  db_make_null (&list_val);
 
   if (list_id->tuple_cnt == 0)
     {
@@ -693,7 +693,7 @@ eval_item_card_sort_list (THREAD_ENTRY * thread_p, DB_VALUE * item, QFILE_LIST_I
       return ER_FAILED;
     }
 
-  PRIM_SET_NULL (&list_val);
+  db_make_null (&list_val);
   card = 0;
 
   if (qfile_open_list_scan (list_id, &s_id) != NO_ERROR)
@@ -779,8 +779,8 @@ eval_sub_multi_set_to_sort_list (THREAD_ENTRY * thread_p, DB_SET * set1, QFILE_L
   DB_VALUE elem_val, elem_val2;
   int found;
 
-  PRIM_SET_NULL (&elem_val);
-  PRIM_SET_NULL (&elem_val2);
+  db_make_null (&elem_val);
+  db_make_null (&elem_val2);
 
   card = set_size (set1);
   if (card == 0)
@@ -907,8 +907,8 @@ eval_sub_sort_list_to_multi_set (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
       return V_ERROR;
     }
 
-  PRIM_SET_NULL (&list_val);
-  PRIM_SET_NULL (&list_val2);
+  db_make_null (&list_val);
+  db_make_null (&list_val2);
 
   if (list_id->tuple_cnt == 0)
     {
@@ -1083,8 +1083,8 @@ eval_sub_sort_list_to_sort_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_i
       return V_ERROR;
     }
 
-  PRIM_SET_NULL (&list_val);
-  PRIM_SET_NULL (&list_val2);
+  db_make_null (&list_val);
+  db_make_null (&list_val2);
 
   if (list_id1->tuple_cnt == 0)
     {

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -4829,7 +4829,7 @@ qexec_cmp_tpl_vals_merge (QFILE_TUPLE * left_tval, TP_DOMAIN ** left_dom, QFILE_
       /* Do not copy the string--just use the pointer.  The pr_ routines for strings and sets have different semantics
        * for length. */
       left_is_set = pr_is_set_type (TP_DOMAIN_TYPE (left_dom[i])) ? true : false;
-      if ((*(left_dom[i]->type->data_readval)) (&buf, &left_dbval, left_dom[i], -1, left_is_set, NULL, 0) != NO_ERROR)
+      if (left_dom[i]->type->data_readval (&buf, &left_dbval, left_dom[i], -1, left_is_set, NULL, 0) != NO_ERROR)
 	{
 	  cmp = DB_UNK;		/* is error */
 	  break;
@@ -4844,7 +4844,7 @@ qexec_cmp_tpl_vals_merge (QFILE_TUPLE * left_tval, TP_DOMAIN ** left_dom, QFILE_
       /* Do not copy the string--just use the pointer.  The pr_ routines for strings and sets have different semantics
        * for length. */
       right_is_set = pr_is_set_type (TP_DOMAIN_TYPE (rght_dom[i])) ? true : false;
-      if ((*(rght_dom[i]->type->data_readval)) (&buf, &right_dbval, rght_dom[i], -1, right_is_set, NULL, 0) != NO_ERROR)
+      if (rght_dom[i]->type->data_readval (&buf, &right_dbval, rght_dom[i], -1, right_is_set, NULL, 0) != NO_ERROR)
 	{
 	  cmp = DB_UNK;		/* is error */
 	  goto clear;
@@ -11126,8 +11126,8 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		  switch (_setjmp (buf.env))
 		    {
 		    case 0:
-		      error = (*(pr_type->data_readval)) (&buf, &insert_val, attr->domain,
-							  attr->current_default_value.val_length, copy, NULL, 0);
+		      error = pr_type->data_readval (&buf, &insert_val, attr->domain,
+						     attr->current_default_value.val_length, copy, NULL, 0);
 		      if (error != NO_ERROR)
 			{
 			  GOTO_EXIT_ON_ERROR;
@@ -15618,8 +15618,8 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
     PR_TYPE bf2df_str_type = tp_String;
 
     bf2df_str_domain.type = &bf2df_str_type;
-    bf2df_str_type.data_cmpdisk = bf2df_str_cmpdisk;
-    bf2df_str_type.cmpval = bf2df_str_cmpval;
+    bf2df_str_type.set_data_cmpdisk_function (bf2df_str_cmpdisk);
+    bf2df_str_type.set_cmpval_function (bf2df_str_cmpval);
 
     /* init sort list */
     bf2df_sort_list.next = NULL;
@@ -16219,7 +16219,7 @@ qexec_set_tuple_column_value (QFILE_TUPLE tpl, int index, DB_VALUE * valp, TP_DO
 
       OR_BUF_INIT (buf, ptr, length);
 
-      if ((*(pr_type->data_writeval)) (&buf, valp) != NO_ERROR)
+      if (pr_type->data_writeval (&buf, valp) != NO_ERROR)
 	{
 	  return ER_FAILED;
 	}
@@ -16262,7 +16262,7 @@ qexec_get_tuple_column_value (QFILE_TUPLE tpl, int index, DB_VALUE * valp, TP_DO
 
       OR_BUF_INIT (buf, ptr, length);
 
-      if ((*(pr_type->data_readval)) (&buf, valp, domain, -1, false, NULL, 0) != NO_ERROR)
+      if (pr_type->data_readval (&buf, valp, domain, -1, false, NULL, 0) != NO_ERROR)
 	{
 	  return ER_FAILED;
 	}
@@ -16402,7 +16402,7 @@ qexec_compare_valptr_with_tuple (OUTPTR_LIST * outptr_list, QFILE_TUPLE tpl, QFI
       else
 	{
 	  or_init (&buf, (char *) tuple + QFILE_TUPLE_VALUE_HEADER_SIZE, length1);
-	  if ((*(pr_type_p->data_readval)) (&buf, &dbval1, domp, -1, copy, NULL, 0) != NO_ERROR)
+	  if (pr_type_p->data_readval (&buf, &dbval1, domp, -1, copy, NULL, 0) != NO_ERROR)
 	    {
 	      return ER_FAILED;
 	    }
@@ -16422,7 +16422,7 @@ qexec_compare_valptr_with_tuple (OUTPTR_LIST * outptr_list, QFILE_TUPLE tpl, QFI
 	}
       else
 	{
-	  equal = ((*(pr_type_p->cmpval)) (&dbval1, dbvalp2, 0, 1, NULL, domp->collation_id) == DB_EQ);
+	  equal = pr_type_p->cmpval (&dbval1, dbvalp2, 0, 1, NULL, domp->collation_id) == DB_EQ;
 	}
 
       if (copy || DB_NEED_CLEAR (&dbval1))
@@ -22867,8 +22867,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 		  pr_type = pr_type_from_id (attrepr->type);
 		  if (pr_type)
 		    {
-		      (*(pr_type->data_readval)) (&buf, out_values[idx_val], attrepr->domain, disk_length, copy, NULL,
-						  0);
+		      pr_type->data_readval (&buf, out_values[idx_val], attrepr->domain, disk_length, copy, NULL, 0);
 		      valcnv_convert_value_to_string (out_values[idx_val]);
 		    }
 		  else

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -4806,8 +4806,8 @@ qexec_cmp_tpl_vals_merge (QFILE_TUPLE * left_tval, TP_DOMAIN ** left_dom, QFILE_
 
   for (i = 0; i < tval_cnt; i++)
     {
-      PRIM_SET_NULL (&left_dbval);
-      PRIM_SET_NULL (&right_dbval);
+      db_make_null (&left_dbval);
+      db_make_null (&right_dbval);
 
       /* get tpl values into db_values for the comparison */
 
@@ -17528,7 +17528,7 @@ qexec_gby_finalize_group (THREAD_ENTRY * thread_p, GROUPBY_STATE * gbstate, int 
 		  *g_outp->accumulator.value = *d_aggp->accumulator.value;
 		  /* Don't use db_make_null here to preserve the type information. */
 
-		  PRIM_SET_NULL (d_aggp->accumulator.value);
+		  db_make_null (d_aggp->accumulator.value);
 		}
 
 	      /* should not touch d_aggp->value2 */

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1519,7 +1519,7 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 	    {
 	      char *s;
 
-	      s = (params.size > 0) ? pr_valstring (thread_p, &params.vals[0]) : NULL;
+	      s = (params.size > 0) ? pr_valstring (&params.vals[0]) : NULL;
 	      er_log_debug (ARG_FILE_LINE,
 			    "xqmgr_execute_query: ls_update_xasl failed "
 			    "xasl_id { sha1 { %08x | %08x | %08x | %08x | %08x } time_stored { %d sec %d usec } } "

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -7835,7 +7835,7 @@ qdata_get_tuple_value_size_from_dbval (DB_VALUE * dbval_p)
       if (type_p)
 	{
 	  val_size = type_p->data_lengthval (dbval_p, 1);
-	  if (!type_p->is_data_lengthval_fixed ())
+	  if (type_p->is_variable_size ())
 	    {
 	      if (pr_is_string_type (dbval_type))
 		{

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1709,7 +1709,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	    }
 	}
 
-      buf_size += dom->type->index_lengthval (val);
+      buf_size += dom->type->get_index_size_of_value (val);
     }
 
   /* add more domain to setdomain for partial key */
@@ -2386,13 +2386,13 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
       if (range >= GE_INF && range <= GT_INF)
 	{
 	  pr_clear_value (&key_vals[0].key2);
-	  db_make_null (&key_vals[0].key2);
+	  PRIM_SET_NULL (&key_vals[0].key2);
 	}
 
       if (range >= INF_LE && range <= INF_LT)
 	{
 	  pr_clear_value (&key_vals[0].key1);
-	  db_make_null (&key_vals[0].key1);
+	  PRIM_SET_NULL (&key_vals[0].key1);
 	}
 
       if (key_vals[0].is_truncated == true)
@@ -2411,8 +2411,8 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
 
 	  pr_clear_value (&key_vals[0].key1);
 	  pr_clear_value (&key_vals[0].key2);
-	  db_make_null (&key_vals[0].key1);
-	  db_make_null (&key_vals[0].key2);
+	  PRIM_SET_NULL (&key_vals[0].key1);
+	  PRIM_SET_NULL (&key_vals[0].key2);
 
 	  assert_release (key_vals[0].num_index_term == 0);
 	}
@@ -2556,7 +2556,7 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
 	  if (range >= GE_INF && range <= GT_INF)
 	    {
 	      pr_clear_value (&key_vals[iscan_id->curr_keyno].key2);
-	      db_make_null (&key_vals[iscan_id->curr_keyno].key2);
+	      PRIM_SET_NULL (&key_vals[iscan_id->curr_keyno].key2);
 	    }
 
 	  if (key_vals[iscan_id->curr_keyno].is_truncated == true)
@@ -2567,7 +2567,7 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
 	  if (range >= INF_LE && range <= INF_LT)
 	    {
 	      pr_clear_value (&key_vals[iscan_id->curr_keyno].key1);
-	      db_make_null (&key_vals[iscan_id->curr_keyno].key1);
+	      PRIM_SET_NULL (&key_vals[iscan_id->curr_keyno].key1);
 	    }
 
 	  if (range == INF_INF)
@@ -2588,8 +2588,8 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
 
 	      pr_clear_value (&key_vals[0].key1);
 	      pr_clear_value (&key_vals[0].key2);
-	      db_make_null (&key_vals[0].key1);
-	      db_make_null (&key_vals[0].key2);
+	      PRIM_SET_NULL (&key_vals[0].key1);
+	      PRIM_SET_NULL (&key_vals[0].key2);
 	    }
 
 	  key_vals[iscan_id->curr_keyno].range = range;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -2386,13 +2386,13 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
       if (range >= GE_INF && range <= GT_INF)
 	{
 	  pr_clear_value (&key_vals[0].key2);
-	  PRIM_SET_NULL (&key_vals[0].key2);
+	  db_make_null (&key_vals[0].key2);
 	}
 
       if (range >= INF_LE && range <= INF_LT)
 	{
 	  pr_clear_value (&key_vals[0].key1);
-	  PRIM_SET_NULL (&key_vals[0].key1);
+	  db_make_null (&key_vals[0].key1);
 	}
 
       if (key_vals[0].is_truncated == true)
@@ -2411,8 +2411,8 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
 
 	  pr_clear_value (&key_vals[0].key1);
 	  pr_clear_value (&key_vals[0].key2);
-	  PRIM_SET_NULL (&key_vals[0].key1);
-	  PRIM_SET_NULL (&key_vals[0].key2);
+	  db_make_null (&key_vals[0].key1);
+	  db_make_null (&key_vals[0].key2);
 
 	  assert_release (key_vals[0].num_index_term == 0);
 	}
@@ -2556,7 +2556,7 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
 	  if (range >= GE_INF && range <= GT_INF)
 	    {
 	      pr_clear_value (&key_vals[iscan_id->curr_keyno].key2);
-	      PRIM_SET_NULL (&key_vals[iscan_id->curr_keyno].key2);
+	      db_make_null (&key_vals[iscan_id->curr_keyno].key2);
 	    }
 
 	  if (key_vals[iscan_id->curr_keyno].is_truncated == true)
@@ -2567,7 +2567,7 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
 	  if (range >= INF_LE && range <= INF_LT)
 	    {
 	      pr_clear_value (&key_vals[iscan_id->curr_keyno].key1);
-	      PRIM_SET_NULL (&key_vals[iscan_id->curr_keyno].key1);
+	      db_make_null (&key_vals[iscan_id->curr_keyno].key1);
 	    }
 
 	  if (range == INF_INF)
@@ -2588,8 +2588,8 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
 
 	      pr_clear_value (&key_vals[0].key1);
 	      pr_clear_value (&key_vals[0].key2);
-	      PRIM_SET_NULL (&key_vals[0].key1);
-	      PRIM_SET_NULL (&key_vals[0].key2);
+	      db_make_null (&key_vals[0].key1);
+	      db_make_null (&key_vals[0].key2);
 	    }
 
 	  key_vals[iscan_id->curr_keyno].range = range;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1709,14 +1709,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	    }
 	}
 
-      if (dom->type->index_lengthval == NULL)
-	{
-	  buf_size += dom->type->disksize;
-	}
-      else
-	{
-	  buf_size += (*(dom->type->index_lengthval)) (val);
-	}
+      buf_size += dom->type->index_lengthval (val);
     }
 
   /* add more domain to setdomain for partial key */
@@ -1790,7 +1783,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	    }
 	}
 
-      (*((dom->type)->index_writeval)) (&buf, val);
+      dom->type->index_writeval (&buf, val);
       OR_ENABLE_BOUND_BIT (nullmap_ptr, i);
     }
 

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -12699,7 +12699,7 @@ btree_split_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
   if (node_type == BTREE_LEAF_NODE)
     {
       PR_TYPE *pr_type = btid->key_type->type;
-      sep_key_len = pr_type->index_lengthval (sep_key);
+      sep_key_len = pr_type->get_index_size_of_value (sep_key);
 
       if (sep_key_len < BTREE_MAX_KEYLEN_INPAGE && sep_key_len <= qheader->max_key_len)
 	{
@@ -13274,7 +13274,7 @@ btree_split_test (THREAD_ENTRY * thread_p, BTID_INT * btid, DB_VALUE * key, VPID
 	  PR_TYPE *pr_type;
 
 	  pr_type = btid->key_type->type;
-	  sep_key_len = pr_type->index_lengthval (sep_key);
+	  sep_key_len = pr_type->get_index_size_of_value (sep_key);
 
 	  if (sep_key_len < BTREE_MAX_KEYLEN_INPAGE)
 	    {
@@ -13539,7 +13539,7 @@ btree_split_root (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
 
       pr_type = btid->key_type->type;
 
-      sep_key_len = pr_type->index_lengthval (sep_key);
+      sep_key_len = pr_type->get_index_size_of_value (sep_key);
 
       if (sep_key_len < BTREE_MAX_KEYLEN_INPAGE && sep_key_len <= pheader->node.max_key_len)
 	{

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -4607,7 +4607,7 @@ btree_dump_key (THREAD_ENTRY * thread_p, FILE * fp, DB_VALUE * key)
     {
 #if 1
       fprintf (fp, " ");
-      (*(pr_type->fptrfunc)) (thread_p, fp, key);
+      (*(pr_type->fptrfunc)) (fp, key);
       fprintf (fp, " ");
 
 #else /* debug routine - DO NOT DELETE ME */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -39,9 +39,6 @@
 #include "overflow_file.h"
 #include "xserver_interface.h"
 #include "scan_manager.h"
-#if defined(SERVER_MODE)
-#endif /* SERVER_MODE */
-#include "object_primitive.h"
 #include "fetch.h"
 #include "locator_sr.h"
 #include "network_interface_sr.h"	/* TODO: remove; used for xcallback_console_print */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -18373,7 +18373,7 @@ btree_set_error (THREAD_ENTRY * thread_p, DB_VALUE * key, OID * obj_oid, OID * c
 
   if (key && obj_oid)
     {
-      keyval = pr_valstring (thread_p, key);
+      keyval = pr_valstring (key);
       if (keyval)
 	{
 	  snprintf (oid_msg_buf, OID_MSG_BUF_SIZE, "(OID: %d|%d|%d)", obj_oid->volid, obj_oid->pageid, obj_oid->slotid);
@@ -18513,7 +18513,7 @@ btree_set_unknown_key_error (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * ke
       severity = ER_ERROR_SEVERITY;
     }
 
-  err_key = pr_valstring (thread_p, key);
+  err_key = pr_valstring (key);
   pr_type = pr_type_from_id (DB_VALUE_DOMAIN_TYPE (key));
 
   er_set (severity, ARG_FILE_LINE, ER_BTREE_UNKNOWN_KEY, 5, (err_key != NULL) ? err_key : "_NULL_KEY",
@@ -22060,7 +22060,7 @@ btree_check_foreign_key (THREAD_ENTRY * thread_p, OID * cls_oid, HFID * hfid, OI
     {
       char *val_print = NULL;
 
-      val_print = pr_valstring (thread_p, keyval);
+      val_print = pr_valstring (keyval);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FK_INVALID, 2, fk_name, (val_print ? val_print : "unknown value"));
       if (val_print)
 	{
@@ -26296,7 +26296,7 @@ btree_fix_root_for_insert (THREAD_ENTRY * thread_p, BTID * btid, BTID_INT * btid
   if (insert_helper->log_operations && insert_helper->printed_key == NULL)
     {
       /* This is postponed here to make sure midxkey domain was initialized. */
-      insert_helper->printed_key = pr_valstring (thread_p, key);
+      insert_helper->printed_key = pr_valstring (key);
       (void) SHA1Compute ((unsigned char *) insert_helper->printed_key, strlen (insert_helper->printed_key),
 			  &insert_helper->printed_key_sha1);
     }
@@ -27787,7 +27787,7 @@ btree_key_lock_and_append_object_unique (THREAD_ENTRY * thread_p, BTID_INT * bti
 	  /* Unique constraint violation. */
 	  if (prm_get_bool_value (PRM_ID_UNIQUE_ERROR_KEY_VALUE))
 	    {
-	      char *keyval = pr_valstring (thread_p, key);
+	      char *keyval = pr_valstring (key);
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_UNIQUE_VIOLATION_WITHKEY, 1,
 		      (keyval == NULL) ? "(null)" : keyval);
 	      if (keyval != NULL)
@@ -27860,7 +27860,7 @@ btree_key_lock_and_append_object_unique (THREAD_ENTRY * thread_p, BTID_INT * bti
 	  /* Not multi-update operation or there would be more than two objects visible. Unique constraint violation. */
 	  if (prm_get_bool_value (PRM_ID_UNIQUE_ERROR_KEY_VALUE))
 	    {
-	      char *keyval = pr_valstring (thread_p, key);
+	      char *keyval = pr_valstring (key);
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_UNIQUE_VIOLATION_WITHKEY, 1,
 		      (keyval == NULL) ? "(null)" : keyval);
 	      if (keyval != NULL)
@@ -29109,7 +29109,7 @@ btree_rv_record_modify_internal (THREAD_ENTRY * thread_p, LOG_RCV * rcv, bool is
 		  (void) btree_read_record (thread_p, &btid_int_for_debug, rcv->pgptr, &update_record, &key,
 					    &leaf_rec_info, node_type, &clear_key, &offset_after_key, PEEK_KEY_VALUE,
 					    NULL);
-		  printed_key = pr_valstring (thread_p, &key);
+		  printed_key = pr_valstring (&key);
 		  btree_clear_key_value (&clear_key, &key);
 
 		  (void) btree_unpack_object (update_record.data, &btid_int_for_debug, node_type, &update_record,
@@ -29212,7 +29212,7 @@ btree_rv_record_modify_internal (THREAD_ENTRY * thread_p, LOG_RCV * rcv, bool is
 	      btree_init_temp_key_value (&clear_key, &key);
 	      (void) btree_read_record (thread_p, &btid_int_for_debug, rcv->pgptr, &update_record, &key, &leaf_rec_info,
 					node_type, &clear_key, &offset_after_key, PEEK_KEY_VALUE, NULL);
-	      printed_key = pr_valstring (thread_p, &key);
+	      printed_key = pr_valstring (&key);
 	      btree_clear_key_value (&clear_key, &key);
 	    }
 
@@ -29836,7 +29836,7 @@ btree_fix_root_for_delete (THREAD_ENTRY * thread_p, BTID * btid, BTID_INT * btid
   if (delete_helper->log_operations)
     {
       /* Key must be printed. */
-      delete_helper->printed_key = pr_valstring (thread_p, key);
+      delete_helper->printed_key = pr_valstring (key);
       (void) SHA1Compute ((unsigned char *) delete_helper->printed_key, strlen (delete_helper->printed_key),
 			  &delete_helper->printed_key_sha1);
     }

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -731,7 +731,7 @@ extern DB_VALUE_COMPARE_RESULT btree_compare_key (DB_VALUE * key1, DB_VALUE * ke
 						  int do_coercion, int total_order, int *start_colp);
 extern PERF_PAGE_TYPE btree_get_perf_btree_page_type (THREAD_ENTRY * thread_p, PAGE_PTR page_ptr);
 
-extern void btree_dump_key (THREAD_ENTRY * thread_p, FILE * fp, DB_VALUE * key);
+extern void btree_dump_key (FILE * fp, const DB_VALUE * key);
 
 extern int btree_online_index_dispatcher (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key, OID * cls_oid,
 					  OID * oid, int unique, BTREE_OP_PURPOSE purpose, LOG_LSA * undo_nxlsa);

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -1514,7 +1514,7 @@ btree_build_nleafs (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args, int n_nulls,
 	      /* is the first leaf When the types of leaf node are char, nchar, bit, the type that is saved on non-leaf
 	       * node is different. non-leaf spec (char -> varchar, nchar -> varnchar, bit -> varbit) hence it should
 	       * be configured by using setval of nonleaf_key_type. */
-	      ret = (*(load_args->btid->nonleaf_key_type->type->setval)) (&prefix_key, &first_key, true);
+	      ret = load_args->btid->nonleaf_key_type->type->setval (&prefix_key, &first_key, true);
 	      if (ret != NO_ERROR)
 		{
 		  assert (!"setval error");
@@ -2291,8 +2291,8 @@ btree_construct_leafs (THREAD_ENTRY * thread_p, const RECDES * in_recdes, void *
 	  key_size = CAST_STRLEN (buf.endptr - buf.ptr);
 	}
 
-      ret = (*(load_args->btid->key_type->type->data_readval)) (&buf, &this_key, load_args->btid->key_type, key_size,
-								copy, NULL, 0);
+      ret = load_args->btid->key_type->type->data_readval (&buf, &this_key, load_args->btid->key_type, key_size, copy,
+							   NULL, 0);
       if (ret != NO_ERROR)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TF_CORRUPTED, 0);
@@ -2824,7 +2824,7 @@ btree_dump_sort_output (const RECDES * recdes, LOAD_ARGS * load_args)
     }
 
   printf ("Attribute: ");
-  btree_dump_key (&this_key);
+  btree_dump_key (stdout, &this_key);
   printf ("   Volid: %d", this_oid.volid);
   printf ("   Pageid: %d", this_oid.pageid);
   printf ("   Slotid: %d\n", this_oid.slotid);
@@ -3241,7 +3241,7 @@ btree_sort_get_next (THREAD_ENTRY * thread_p, RECDES * temp_recdes, void *arg)
 
 	  assert (buf.ptr == PTR_ALIGN (buf.ptr, INT_ALIGNMENT));
 
-	  if ((*(sort_args->key_type->type->data_writeval)) (&buf, dbvalue_ptr) != NO_ERROR)
+	  if (sort_args->key_type->type->data_writeval (&buf, dbvalue_ptr) != NO_ERROR)
 	    {
 	      goto nofit;
 	    }
@@ -3394,7 +3394,7 @@ compare_driver (const void *first, const void *second, void *arg)
 	    }
 
 	  /* check for val1 and val2 same domain */
-	  c = (*(dom->type->index_cmpdisk)) (mem1, mem2, dom, 0, 1, NULL);
+	  c = dom->type->index_cmpdisk (mem1, mem2, dom, 0, 1, NULL);
 	  assert (c == DB_LT || c == DB_EQ || c == DB_GT);
 
 	  if (c != DB_EQ)
@@ -3420,13 +3420,13 @@ compare_driver (const void *first, const void *second, void *arg)
       OR_BUF_INIT (buf_val1, mem1, -1);
       OR_BUF_INIT (buf_val2, mem2, -1);
 
-      if ((*(key_type->type->data_readval)) (&buf_val1, &val1, key_type, -1, false, NULL, 0) != NO_ERROR)
+      if (key_type->type->data_readval (&buf_val1, &val1, key_type, -1, false, NULL, 0) != NO_ERROR)
 	{
 	  assert (false);
 	  return DB_UNK;
 	}
 
-      if ((*(key_type->type->data_readval)) (&buf_val2, &val2, key_type, -1, false, NULL, 0) != NO_ERROR)
+      if (key_type->type->data_readval (&buf_val2, &val2, key_type, -1, false, NULL, 0) != NO_ERROR)
 	{
 	  assert (false);
 	  return DB_UNK;

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -3941,7 +3941,7 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
 	  else if (!found)
 	    {
 	      /* Value was not found at all, it means the foreign key is invalid. */
-	      val_print = pr_valstring (thread_p, &fk_key);
+	      val_print = pr_valstring (&fk_key);
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FK_INVALID, 2, sort_args->fk_name,
 		      (val_print ? val_print : "unknown value"));
 	      ret = ER_FK_INVALID;
@@ -3967,7 +3967,7 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
 	      if (!pk_has_slot_visible)
 		{
 		  /* No visible object in current page, but the key was located here. Should not happen often. */
-		  val_print = pr_valstring (thread_p, &fk_key);
+		  val_print = pr_valstring (&fk_key);
 		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FK_INVALID, 2, sort_args->fk_name,
 			  (val_print ? val_print : "unknown value"));
 		  ret = ER_FK_INVALID;
@@ -4002,7 +4002,7 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
 		{
 		  /* The primary key has ended, but the value from foreign key was not found. */
 		  /* Foreign key is invalid. Set error. */
-		  val_print = pr_valstring (thread_p, &fk_key);
+		  val_print = pr_valstring (&fk_key);
 		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FK_INVALID, 2, sort_args->fk_name,
 			  (val_print ? val_print : "unknown value"));
 		  ret = ER_FK_INVALID;
@@ -4025,7 +4025,7 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
 	      else
 		{
 		  /* Fk is invalid. Set error. */
-		  val_print = pr_valstring (thread_p, &fk_key);
+		  val_print = pr_valstring (&fk_key);
 		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FK_INVALID, 2, sort_args->fk_name,
 			  (val_print ? val_print : "unknown value"));
 		  ret = ER_FK_INVALID;

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -572,7 +572,7 @@ catcls_guess_record_length (OR_VALUE * value_p)
     {
       data_type = DB_VALUE_DOMAIN_TYPE (&attrs_p[i].value);
       map_p = tp_Type_id_map[data_type];
-      length += map_p->data_lengthval (&attrs_p[i].value, 1);
+      length += map_p->get_disk_size_of_value (&attrs_p[i].value);
     }
 
   return (length);

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -572,16 +572,7 @@ catcls_guess_record_length (OR_VALUE * value_p)
     {
       data_type = DB_VALUE_DOMAIN_TYPE (&attrs_p[i].value);
       map_p = tp_Type_id_map[data_type];
-
-      if (map_p->data_lengthval != NULL)
-	{
-	  length += (*(map_p->data_lengthval)) (&attrs_p[i].value, 1);
-	}
-      else if (map_p->disksize)
-	{
-	  length += map_p->disksize;
-	}
-      /* else : is null-type */
+      length += map_p->data_lengthval (&attrs_p[i].value, 1);
     }
 
   return (length);
@@ -1017,40 +1008,40 @@ catcls_get_or_value_from_class (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VALU
   or_advance (buf_p, ORC_ATT_COUNT_OFFSET);
 
   /* attribute_count */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[1].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[1].value, NULL, -1, true, NULL, 0);
 
   /* object_size */
   or_advance (buf_p, OR_INT_SIZE);
 
   /* shared_count */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[2].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[2].value, NULL, -1, true, NULL, 0);
 
   /* method_count */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[3].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[3].value, NULL, -1, true, NULL, 0);
 
   /* class_method_count */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[4].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[4].value, NULL, -1, true, NULL, 0);
 
   /* class_att_count */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[5].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[5].value, NULL, -1, true, NULL, 0);
 
   /* flags */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[6].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[6].value, NULL, -1, true, NULL, 0);
 
   /* class_type */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[7].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[7].value, NULL, -1, true, NULL, 0);
 
   /* owner */
-  (*(tp_Object.data_readval)) (buf_p, &attrs[8].value, NULL, -1, true, NULL, 0);
+  tp_Object.data_readval (buf_p, &attrs[8].value, NULL, -1, true, NULL, 0);
 
   /* collation_id */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[9].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[9].value, NULL, -1, true, NULL, 0);
 
   /* variable */
 
   /* name */
   attr_val_p = &attrs[10].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_NAME_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_NAME_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_IDENTIFIER_LENGTH);
 
   /* (class_of) */
@@ -1190,7 +1181,7 @@ catcls_get_or_value_from_class (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VALU
 
   /* comment */
   attr_val_p = &attrs[21].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_COMMENT_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_COMMENT_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_CLASS_COMMENT_LENGTH);
 
   /* partition information */
@@ -1271,17 +1262,17 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
   or_advance (buf_p, OR_INT_SIZE);
 
   /* type */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[4].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[4].value, NULL, -1, true, NULL, 0);
 
   /* offset */
   or_advance (buf_p, OR_INT_SIZE);
 
   /* order */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[5].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[5].value, NULL, -1, true, NULL, 0);
 
   /* class */
   attr_val_p = &attrs[6].value;
-  (*(tp_Object.data_readval)) (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
+  tp_Object.data_readval (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
   error = catcls_convert_class_oid_to_oid (thread_p, attr_val_p);
   if (error != NO_ERROR)
     {
@@ -1291,7 +1282,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 
   /* flag */
   attr_val_p = &attrs[7].value;
-  (*(tp_Integer.data_readval)) (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
 
   /* for 'is_nullable', reverse NON_NULL flag */
   db_make_int (attr_val_p, (db_get_int (attr_val_p) & SM_ATTFLAG_NON_NULL) ? false : true);
@@ -1309,7 +1300,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 
   /* name */
   attr_val_p = &attrs[1].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_ATT_NAME_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_ATT_NAME_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_IDENTIFIER_LENGTH);
 
   /* default value */
@@ -1552,7 +1543,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 
   /* comment */
   attr_val_p = &attrs[10].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_ATT_COMMENT_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_ATT_COMMENT_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_COMMENT_LENGTH);
 
   if (vars)
@@ -1611,13 +1602,13 @@ catcls_get_or_value_from_attrid (THREAD_ENTRY * thread_p, OR_BUF * buf, OR_VALUE
     }
 
   /* id */
-  (*(tp_Integer.data_readval)) (buf, &attrs[0].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf, &attrs[0].value, NULL, -1, true, NULL, 0);
 
   or_advance (buf, (int) (start_ptr - buf->ptr) + vars[ORC_ATT_NAME_INDEX].offset);
 
   /* name */
   attr_val = &attrs[1].value;
-  (*(tp_String.data_readval)) (buf, attr_val, NULL, vars[ORC_ATT_NAME_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf, attr_val, NULL, vars[ORC_ATT_NAME_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val, DB_MAX_IDENTIFIER_LENGTH);
 
   /* go to the end */
@@ -1676,23 +1667,23 @@ catcls_get_or_value_from_domain (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VAL
     }
 
   /* type */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[1].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[1].value, NULL, -1, true, NULL, 0);
 
   /* precision */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[2].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[2].value, NULL, -1, true, NULL, 0);
 
   /* scale */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[3].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[3].value, NULL, -1, true, NULL, 0);
 
   /* codeset */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[4].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[4].value, NULL, -1, true, NULL, 0);
 
   /* collation id */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[5].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[5].value, NULL, -1, true, NULL, 0);
 
   /* class */
   attr_val_p = &attrs[6].value;
-  (*(tp_Object.data_readval)) (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
+  tp_Object.data_readval (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
 
   if (!DB_IS_NULL (attr_val_p))
     {
@@ -1738,7 +1729,7 @@ catcls_get_or_value_from_domain (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VAL
 	}
       domain = tp_domain_cache (domain);
 
-      (*(seq_type->data_readval)) (buf_p, &attrs[7].value, domain, -1, true, NULL, 0);
+      seq_type->data_readval (buf_p, &attrs[7].value, domain, -1, true, NULL, 0);
     }
 
   /* set_domain */
@@ -1821,7 +1812,7 @@ catcls_get_or_value_from_method (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VAL
 
   /* class */
   attr_val_p = &attrs[4].value;
-  (*(tp_Object.data_readval)) (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
+  tp_Object.data_readval (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
   error = catcls_convert_class_oid_to_oid (thread_p, attr_val_p);
   if (error != NO_ERROR)
     {
@@ -1834,7 +1825,7 @@ catcls_get_or_value_from_method (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VAL
 
   /* name */
   attr_val_p = &attrs[1].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_METHOD_NAME_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_METHOD_NAME_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_IDENTIFIER_LENGTH);
 
   /* signatures */
@@ -1902,11 +1893,11 @@ catcls_get_or_value_from_method_signiture (THREAD_ENTRY * thread_p, OR_BUF * buf
     }
 
   /* arg_count */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[1].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[1].value, NULL, -1, true, NULL, 0);
 
   /* function_name */
   attr_val_p = &attrs[2].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_METHSIG_FUNCTION_NAME_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_METHSIG_FUNCTION_NAME_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_IDENTIFIER_LENGTH);
 
   /* string_def */
@@ -1982,10 +1973,10 @@ catcls_get_or_value_from_method_argument (THREAD_ENTRY * thread_p, OR_BUF * buf_
     }
 
   /* type */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[1].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[1].value, NULL, -1, true, NULL, 0);
 
   /* index */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[2].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[2].value, NULL, -1, true, NULL, 0);
 
   /* domain */
   error =
@@ -2050,7 +2041,7 @@ catcls_get_or_value_from_method_file (THREAD_ENTRY * thread_p, OR_BUF * buf_p, O
 
   /* class */
   attr_val_p = &attrs[1].value;
-  (*(tp_Object.data_readval)) (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
+  tp_Object.data_readval (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
   error = catcls_convert_class_oid_to_oid (thread_p, attr_val_p);
   if (error != NO_ERROR)
     {
@@ -2060,7 +2051,7 @@ catcls_get_or_value_from_method_file (THREAD_ENTRY * thread_p, OR_BUF * buf_p, O
 
   /* name */
   attr_val_p = &attrs[2].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_METHFILE_NAME_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_METHFILE_NAME_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_IDENTIFIER_LENGTH);
 
   /* properties */
@@ -2120,7 +2111,7 @@ catcls_get_or_value_from_resolution (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR
 
   /* class */
   attr_val_p = &attrs[0].value;
-  (*(tp_Object.data_readval)) (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
+  tp_Object.data_readval (buf_p, attr_val_p, NULL, -1, true, NULL, 0);
   error = catcls_convert_class_oid_to_oid (thread_p, attr_val_p);
   if (error != NO_ERROR)
     {
@@ -2129,16 +2120,16 @@ catcls_get_or_value_from_resolution (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR
     }
 
   /* type */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[2].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[2].value, NULL, -1, true, NULL, 0);
 
   /* name */
   attr_val_p = &attrs[3].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_RES_NAME_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_RES_NAME_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_IDENTIFIER_LENGTH);
 
   /* alias */
   attr_val_p = &attrs[1].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_RES_ALIAS_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_RES_ALIAS_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_IDENTIFIER_LENGTH);
 
   if (vars)
@@ -2195,7 +2186,7 @@ catcls_get_or_value_from_query_spec (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR
 
   /* specification */
   attr_val_p = &attrs[1].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_QUERY_SPEC_SPEC_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_QUERY_SPEC_SPEC_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_SPEC_LENGTH);
 
   if (vars)
@@ -2726,7 +2717,7 @@ catcls_get_object_set (THREAD_ENTRY * thread_p, OR_BUF * buf_p, int expected_siz
 
   for (i = 0; i < count; i++)
     {
-      (*(tp_Object.data_readval)) (buf_p, &oid_val, NULL, -1, true, NULL, 0);
+      tp_Object.data_readval (buf_p, &oid_val, NULL, -1, true, NULL, 0);
 
       error = catcls_convert_class_oid_to_oid (thread_p, &oid_val);
       if (error != NO_ERROR)
@@ -2794,7 +2785,7 @@ catcls_get_property_set (THREAD_ENTRY * thread_p, OR_BUF * buf_p, int expected_s
       db_value_put_null (&vals[i]);
     }
 
-  (*(tp_Sequence.data_readval)) (buf_p, &prop_val, NULL, expected_size, true, NULL, 0);
+  tp_Sequence.data_readval (buf_p, &prop_val, NULL, expected_size, true, NULL, 0);
   prop_seq_p = db_get_set (&prop_val);
 
   for (i = 0; i < SM_PROPERTY_NUM_INDEX_FAMILY; i++)
@@ -3158,7 +3149,7 @@ catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OI
 	}
       else
 	{
-	  (*((*tp_Type_id_map[data_type]).data_writeval)) (buf_p, &attrs[i].value);
+	  (*tp_Type_id_map[data_type]).data_writeval (buf_p, &attrs[i].value);
 	  OR_ENABLE_BOUND_BIT (bound_bits, i);
 	}
     }
@@ -3189,7 +3180,7 @@ catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OI
       offset = (int) (buf_p->ptr - buf_p->buffer - header_size);
 
       data_type = variable_p[i].type;
-      (*((*tp_Type_id_map[data_type]).data_writeval)) (buf_p, &var_attrs[i].value);
+      (*tp_Type_id_map[data_type]).data_writeval (buf_p, &var_attrs[i].value);
 
       OR_PUT_OFFSET (offset_p, offset);
       offset_p += BIG_VAR_OFFSET_SIZE;
@@ -3314,7 +3305,7 @@ catcls_get_or_value_from_buffer (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VAL
 
       if (bound_bits_flag && OR_GET_BOUND_BIT (bound_bits, i))
 	{
-	  (*((*tp_Type_id_map[data_type]).data_readval)) (buf_p, &attrs[i].value, NULL, -1, true, NULL, 0);
+	  (*tp_Type_id_map[data_type]).data_readval (buf_p, &attrs[i].value, NULL, -1, true, NULL, 0);
 	}
       else
 	{
@@ -3346,7 +3337,7 @@ catcls_get_or_value_from_buffer (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_VAL
   for (i = 0; i < n_variable; i++)
     {
       data_type = variable_p[i].type;
-      (*((*tp_Type_id_map[data_type]).data_readval)) (buf_p, &var_attrs[i].value, NULL, vars[i].length, true, NULL, 0);
+      (*tp_Type_id_map[data_type]).data_readval (buf_p, &var_attrs[i].value, NULL, vars[i].length, true, NULL, 0);
       error = catcls_expand_or_value_by_subset (thread_p, &var_attrs[i]);
       if (error != NO_ERROR)
 	{
@@ -5389,16 +5380,16 @@ catcls_get_or_value_from_partition (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
     }
 
   /* type */
-  (*(tp_Integer.data_readval)) (buf_p, &attrs[1].value, NULL, -1, true, NULL, 0);
+  tp_Integer.data_readval (buf_p, &attrs[1].value, NULL, -1, true, NULL, 0);
 
   /* name */
   attr_val_p = &attrs[2].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_PARTITION_NAME_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_PARTITION_NAME_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_SPEC_LENGTH);
 
   /* expr */
   attr_val_p = &attrs[3].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_PARTITION_EXPR_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_PARTITION_EXPR_INDEX].length, true, NULL, 0);
   assert (DB_IS_NULL (attr_val_p) || db_get_string_length (attr_val_p) <= DB_MAX_PARTITION_EXPR_LENGTH);
 
   /* values */
@@ -5411,7 +5402,7 @@ catcls_get_or_value_from_partition (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 
   /* comment */
   attr_val_p = &attrs[5].value;
-  (*(tp_String.data_readval)) (buf_p, attr_val_p, NULL, vars[ORC_PARTITION_COMMENT_INDEX].length, true, NULL, 0);
+  tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_PARTITION_COMMENT_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_SPEC_LENGTH);
 
   if (vars)

--- a/src/storage/external_sort.h
+++ b/src/storage/external_sort.h
@@ -33,6 +33,7 @@
 
 #include "error_manager.h"
 #include "query_list.h"
+#include "object_primitive.h"
 #include "storage_common.h"
 #include "thread_compat.hpp"
 
@@ -102,6 +103,8 @@ struct SUBKEY_INFO
 
   TP_DOMAIN *cmp_dom;		/* for median sorting string in different domain */
 
+  // signature should match pr_type::data_cmpdisk_function_type
+  // todo - use a function type for both sort_f and pr_type::data_cmpdisk_function_type
     DB_VALUE_COMPARE_RESULT (*sort_f) (void *tplp1, void *tplp2, TP_DOMAIN * dom, int do_coercion, int total_order,
 				       int *start_col);
 

--- a/src/storage/external_sort.h
+++ b/src/storage/external_sort.h
@@ -33,7 +33,6 @@
 
 #include "error_manager.h"
 #include "query_list.h"
-#include "object_primitive.h"
 #include "storage_common.h"
 #include "thread_compat.hpp"
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -62,6 +62,7 @@
 #endif /* ENABLE_SYSTEMTAP */
 #include "dbtype.h"
 #include "thread_manager.hpp"	// for thread_get_thread_entry_info
+#include "db_value_printer.hpp"
 
 #if !defined(SERVER_MODE)
 #define pthread_mutex_init(a, b)
@@ -2750,7 +2751,7 @@ heap_classrepr_dump (THREAD_ENTRY * thread_p, FILE * fp, const OID * class_oid, 
 		{
 		  (*(pr_type->data_readval)) (&buf, &def_dbvalue, attrepr->domain, disk_length, copy, NULL, 0);
 
-		  db_value_fprint (stdout, &def_dbvalue);
+		  db_fprint_value (stdout, &def_dbvalue);
 		  (void) pr_clear_value (&def_dbvalue);
 		}
 	      else
@@ -10520,7 +10521,7 @@ heap_attrinfo_dump (THREAD_ENTRY * thread_p, FILE * fp, HEAP_CACHE_ATTRINFO * at
 
       fprintf (fp, "  Memory_value_format:\n");
       fprintf (fp, "    value = ");
-      db_value_fprint (fp, &value->dbvalue);
+      db_fprint_value (fp, &value->dbvalue);
       fprintf (fp, "\n\n");
     }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -2749,7 +2749,7 @@ heap_classrepr_dump (THREAD_ENTRY * thread_p, FILE * fp, const OID * class_oid, 
 	      pr_type = pr_type_from_id (attrepr->type);
 	      if (pr_type)
 		{
-		  (*(pr_type->data_readval)) (&buf, &def_dbvalue, attrepr->domain, disk_length, copy, NULL, 0);
+		  pr_type->data_readval (&buf, &def_dbvalue, attrepr->domain, disk_length, copy, NULL, 0);
 
 		  db_fprint_value (stdout, &def_dbvalue);
 		  (void) pr_clear_value (&def_dbvalue);
@@ -10157,7 +10157,7 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
 	  pr_type = pr_type_from_id (attrepr->type);
 	  if (pr_type)
 	    {
-	      (*(pr_type->data_readval)) (&buf, &value->dbvalue, attrepr->domain, disk_length, false, NULL, 0);
+	      pr_type->data_readval (&buf, &value->dbvalue, attrepr->domain, disk_length, false, NULL, 0);
 	    }
 	  value->state = HEAP_READ_ATTRVALUE;
 	  break;
@@ -10260,7 +10260,7 @@ heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, H
       OR_BUF buf;
 
       or_init (&buf, disk_data, -1);
-      (*(att->domain->type->data_readval)) (&buf, value, att->domain, -1, false, NULL, 0);
+      att->domain->type->data_readval (&buf, value, att->domain, -1, false, NULL, 0);
     }
 
   return NO_ERROR;
@@ -11204,7 +11204,7 @@ heap_attrinfo_set (const OID * inst_oid, ATTR_ID attrid, DB_VALUE * attr_val, HE
        * the source only if it's a set-valued thing (that's the purpose
        * of the third argument).
        */
-      ret = (*(pr_type->setval)) (&value->dbvalue, attr_val, TP_IS_SET_TYPE (pr_type->id));
+      ret = pr_type->setval (&value->dbvalue, attr_val, TP_IS_SET_TYPE (pr_type->id));
     }
   else
     {
@@ -11668,7 +11668,7 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 		   * Write the value.
 		   */
 		  OR_ENABLE_BOUND_BIT (ptr_bound, value->last_attrepr->position);
-		  (*(pr_type->data_writeval)) (buf, dbvalue);
+		  pr_type->data_writeval (buf, dbvalue);
 		}
 	    }
 	  else
@@ -11751,7 +11751,7 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 			}
 		    }
 
-		  (*(pr_type->data_writeval)) (buf, dbvalue);
+		  pr_type->data_writeval (buf, dbvalue);
 		  ptr_varvals = buf->ptr;
 		}
 	    }
@@ -12333,7 +12333,7 @@ heap_midxkey_key_get (RECDES * recdes, DB_MIDXKEY * midxkey, OR_INDEX * index, H
 
 	  if (!db_value_is_null (func_res))
 	    {
-	      (*(func_domain->type->index_writeval)) (&buf, func_res);
+	      func_domain->type->index_writeval (&buf, func_res);
 	      OR_ENABLE_BOUND_BIT (nullmap_ptr, k);
 	    }
 
@@ -12371,7 +12371,7 @@ heap_midxkey_key_get (RECDES * recdes, DB_MIDXKEY * midxkey, OR_INDEX * index, H
       error = heap_midxkey_get_value (recdes, atts[i], &value, attrinfo);
       if (error == NO_ERROR && !db_value_is_null (&value))
 	{
-	  (*(atts[i]->domain->type->index_writeval)) (&buf, &value);
+	  atts[i]->domain->type->index_writeval (&buf, &value);
 	  OR_ENABLE_BOUND_BIT (nullmap_ptr, k);
 	}
 
@@ -12510,7 +12510,7 @@ heap_midxkey_key_generate (THREAD_ENTRY * thread_p, RECDES * recdes, DB_MIDXKEY 
 	  if (!db_value_is_null (func_res))
 	    {
 	      TP_DOMAIN *domain = tp_domain_resolve_default ((DB_TYPE) func_res->domain.general_info.type);
-	      (*(domain->type->index_writeval)) (&buf, func_res);
+	      domain->type->index_writeval (&buf, func_res);
 	      OR_ENABLE_BOUND_BIT (nullmap_ptr, k);
 	    }
 	  k++;
@@ -12524,7 +12524,7 @@ heap_midxkey_key_generate (THREAD_ENTRY * thread_p, RECDES * recdes, DB_MIDXKEY 
       error = heap_midxkey_get_value (recdes, att, &value, attrinfo);
       if (error == NO_ERROR && !db_value_is_null (&value))
 	{
-	  (*(att->domain->type->index_writeval)) (&buf, &value);
+	  att->domain->type->index_writeval (&buf, &value);
 	  OR_ENABLE_BOUND_BIT (nullmap_ptr, k);
 	}
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4120,7 +4120,7 @@ locator_check_foreign_key (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid
 	    {
 	      char *val_print = NULL;
 
-	      val_print = pr_valstring (thread_p, key_dbvalue);
+	      val_print = pr_valstring (key_dbvalue);
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FK_INVALID, 2, index->fk->fkname,
 		      (val_print ? val_print : "unknown value"));
 	      error_code = ER_FK_INVALID;
@@ -9458,7 +9458,7 @@ locator_check_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, HFID * hfid, 
 		    {
 		      char *key_dmp;
 
-		      key_dmp = pr_valstring (thread_p, key);
+		      key_dmp = pr_valstring (key);
 
 		      if (!OID_ISNULL (class_oid))
 			{
@@ -9908,7 +9908,7 @@ locator_check_unique_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, OID * 
 			{
 			  char *key_dmp;
 
-			  key_dmp = pr_valstring (thread_p, key);
+			  key_dmp = pr_valstring (key);
 			  if (!OID_ISNULL (class_oid))
 			    {
 			      if (heap_get_class_name (thread_p, class_oid, &classname) != NO_ERROR)

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -42,7 +42,7 @@
 #include "log_compress.h"
 #include "parser.h"
 #include "object_primitive.h"
-#include "object_print.h"
+#include "db_value_printer.hpp"
 #include "db.h"
 #include "object_accessor.h"
 #include "locator_cl.h"
@@ -3539,7 +3539,7 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
       else
 	{
 	  /* read the disk value into the db_value */
-	  (*(att->type->data_readval)) (buf, &value, att->domain, -1, true, NULL, 0);
+	  att->type->data_readval (buf, &value, att->domain, -1, true, NULL, 0);
 	}
 
       /* update the column */
@@ -3573,7 +3573,7 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
   for (i = sm_class->fixed_count, j = 0; i < sm_class->att_count && j < sm_class->variable_count;
        i++, j++, att = (SM_ATTRIBUTE *) att->header.next)
     {
-      (*(att->type->data_readval)) (buf, &value, att->domain, vars[j], true, NULL, 0);
+      att->type->data_readval (buf, &value, att->domain, vars[j], true, NULL, 0);
       v_start += vars[j];
       buf->ptr = v_start;
 
@@ -4658,7 +4658,7 @@ la_flush_repl_items (bool immediate)
 		}
 
 	      sb.clear ();
-	      help_sprint_value (&flush_err->pkey_value, sb);
+	      db_sprint_value (&flush_err->pkey_value, sb);
 	      snprintf (pkey_str, sizeof (pkey_str) - 1, sb.get_buffer ());
 
 	      if (LC_IS_FLUSH_INSERT (flush_err->operation) == true)
@@ -4846,7 +4846,7 @@ la_apply_delete_log (LA_ITEM * item)
 	  if (sl_write_delete_sql (item->class_name, mclass, la_get_item_pk_value (item)) != NO_ERROR)
 	    {
 	      sb.clear ();
-	      help_sprint_value (&item->key, sb);
+	      db_sprint_value (&item->key, sb);
 	      snprintf (sql_log_err, sizeof (sql_log_err), "failed to write SQL log. class: %s, key: %s",
 			item->class_name, sb.get_buffer ());
 
@@ -4867,7 +4867,7 @@ la_apply_delete_log (LA_ITEM * item)
   if (error != NO_ERROR)
     {
       sb.clear ();
-      help_sprint_value (la_get_item_pk_value (item), sb);
+      db_sprint_value (la_get_item_pk_value (item), sb);
 #if defined (LA_VERBOSE_DEBUG)
       er_log_debug (ARG_FILE_LINE, "apply_delete : error %d %s\n\tclass %s key %s\n", error, er_msg (),
 		    item->class_name, sb.get_buffer ());
@@ -5016,7 +5016,7 @@ la_apply_update_log (LA_ITEM * item)
       if (sql_logging_failed == true)
 	{
 	  sb.clear ();
-	  help_sprint_value (la_get_item_pk_value (item), sb);
+	  db_sprint_value (la_get_item_pk_value (item), sb);
 	  snprintf (sql_log_err, sizeof (sql_log_err), "failed to write SQL log. class: %s, key: %s", item->class_name,
 		    sb.get_buffer ());
 
@@ -5030,7 +5030,7 @@ end:
   if (error != NO_ERROR)
     {
       sb.clear ();
-      help_sprint_value (la_get_item_pk_value (item), sb);
+      db_sprint_value (la_get_item_pk_value (item), sb);
 #if defined (LA_VERBOSE_DEBUG)
       er_log_debug (ARG_FILE_LINE, "apply_update : error %d %s\n\tclass %s key %s\n", error, er_msg (),
 		    item->class_name, sb.get_buffer ());
@@ -5199,7 +5199,7 @@ la_apply_insert_log (LA_ITEM * item)
       if (sql_logging_failed == true)
 	{
 	  sb.clear ();
-	  help_sprint_value (la_get_item_pk_value (item), sb);
+	  db_sprint_value (la_get_item_pk_value (item), sb);
 	  snprintf (sql_log_err, sizeof (sql_log_err), "failed to write SQL log. class: %s, key: %s", item->class_name,
 		    sb.get_buffer ());
 
@@ -5213,7 +5213,7 @@ end:
   if (error != NO_ERROR)
     {
       sb.clear ();
-      help_sprint_value (la_get_item_pk_value (item), sb);
+      db_sprint_value (la_get_item_pk_value (item), sb);
 #if defined (LA_VERBOSE_DEBUG)
       er_log_debug (ARG_FILE_LINE, "apply_insert : error %d %s\n\tclass %s key %s\n", error, er_msg (),
 		    item->class_name, sb.get_buffer ());
@@ -5679,7 +5679,7 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 	      errid = er_errid ();
 
 	      sb.clear ();
-	      help_sprint_value (la_get_item_pk_value (item), sb);
+	      db_sprint_value (la_get_item_pk_value (item), sb);
 	      sprintf (error_string, "[%s,%s] %s", item->class_name, sb.get_buffer (), db_error_string (1));
 	      er_log_debug (ARG_FILE_LINE, "Internal system failure: %s", error_string);
 

--- a/src/transaction/transaction_cl.c
+++ b/src/transaction/transaction_cl.c
@@ -1409,7 +1409,7 @@ tran_set_latest_query_status (int end_query_result, int tran_state, int should_c
       tm_Tran_latest_query_status |= LATEST_QUERY_STATUS::ABORTED;
     }
 
-  if (should_conn_reset == true)
+  if (should_conn_reset != 0)
     {
       assert (tran_state == TRAN_UNACTIVE_COMMITTED || tran_state == TRAN_UNACTIVE_COMMITTED_INFORMING_PARTICIPANTS
 	      || tran_state == TRAN_UNACTIVE_ABORTED || tran_state == TRAN_UNACTIVE_ABORTED_INFORMING_PARTICIPANTS);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22693

This patch is kind of an workaround this issue. Instead of changing the signature of all object_primitive functions, we just wrap current function pointers with the correct signatures that includes const properties.

However, this is actually very dangerous and can hide painful bugs. It is recommended that we do a proper refactoring of object_primitive.

There are a lot of files touched by this patch, but there are no logic changes, only code rewrite. I recommend first reviewing object_primitive files after reading the complete list of changes:

Complete list of changes to object_primitive:

  - remove fptrfunc and sptrfunc from pr_type, because their implementation does not depend on pr_type. all references are replaced with help_fprint_value and help_sprint_value, now renamed as db_fprint_value and db_sprint_value and moved from object_print to db_value_printer.
  - remove thread_entry from some functions (help_fprint_value, pr_valstring) and completely from object_primitive.h
  - wrap all pr_type function pointers with inlined member functions. this allows minimum changes to allow using the function with constant arguments; a nice consequence is that we no longer need the ugly dereferencing to call the functions.
  - function pointers are now protected; they can only be accessed at initialization and through proper getter/setter functions
  - lengthmem/lengthval functions can properly handle the fixed-size types.
  - remove all PRIM_ macros and replace them with the appropriate member function calls. PRIM_SET_NULL was initially replaced by db_make_null, but the change was reverted due to unexpected regressions; sometimes, the type of NULL value matters (but it shouldn't)

Misc changes:
  - small refactoring inside db_value_printer.cpp.
  - remove object_print from libcubrid and all SERVER_MODE related code.
  - remove thread entry from btree_dump_key
  - fix transaction_cl.c warning