### PR TITLE
[CBRD-22673] separate packer and unpacker

### DIFF
--- a/src/base/packable_object.hpp
+++ b/src/base/packable_object.hpp
@@ -36,8 +36,8 @@ namespace cubpacking
   {
     public:
       virtual ~packable_object () {};
-      virtual void pack (packer *serializator) const = 0;
-      virtual void unpack (unpacker *deserializator) = 0;
+      virtual void pack (packer &serializator) const = 0;
+      virtual void unpack (unpacker &deserializator) = 0;
 
       virtual bool is_equal (const packable_object *other)
       {
@@ -45,7 +45,7 @@ namespace cubpacking
       }
 
       /* used at packing to get info on how much memory to reserve */
-      virtual size_t get_packed_size (packer *serializator) const = 0;
+      virtual size_t get_packed_size (packer &serializator) const = 0;
   };
 
 } /* namespace cubpacking */

--- a/src/base/packable_object.hpp
+++ b/src/base/packable_object.hpp
@@ -36,13 +36,16 @@ namespace cubpacking
   {
     public:
       virtual ~packable_object () {};
-      virtual int pack (packer *serializator) = 0;
-      virtual int unpack (packer *serializator) = 0;
+      virtual void pack (packer *serializator) const = 0;
+      virtual void unpack (unpacker *deserializator) = 0;
 
-      virtual bool is_equal (const packable_object *other) = 0;
+      virtual bool is_equal (const packable_object *other)
+      {
+	return true;
+      }
 
       /* used at packing to get info on how much memory to reserve */
-      virtual size_t get_packed_size (packer *serializator) = 0;
+      virtual size_t get_packed_size (packer *serializator) const = 0;
   };
 
 } /* namespace cubpacking */

--- a/src/base/packer.cpp
+++ b/src/base/packer.cpp
@@ -572,7 +572,7 @@ namespace cubpacking
   }
 
   void
-  packer::assign_or_buf (const size_t size, or_buf &buf)
+  packer::delegate_to_or_buf (const size_t size, or_buf &buf)
   {
     check_range (m_ptr, m_end_ptr, size);
     m_ptr += size;
@@ -580,7 +580,7 @@ namespace cubpacking
   }
 
   void
-  unpacker::assign_or_buf (const size_t size, or_buf &buf)
+  unpacker::delegate_to_or_buf (const size_t size, or_buf &buf)
   {
     check_range (m_ptr, m_end_ptr, size);
     m_ptr += size;

--- a/src/base/packer.cpp
+++ b/src/base/packer.cpp
@@ -30,15 +30,22 @@
 #include <vector>
 #include <string>
 
+#include <cstring>
+
 namespace cubpacking
 {
 #define MAX_SMALL_STRING_SIZE 255
 #define LARGE_STRING_CODE 0xff
 
-  STATIC_INLINE void check_range (const char *ptr, const char *endptr, const size_t amount)
-  __attribute__ ((ALWAYS_INLINE));
+  //
+  // static function declarations
+  //
+  static void check_range (const char *ptr, const char *endptr, const size_t amount);
 
-  STATIC_INLINE void check_range (const char *ptr, const char *endptr, const size_t amount)
+  //
+  // static function definitions
+  static void
+  check_range (const char *ptr, const char *endptr, const size_t amount)
   {
     assert (ptr + amount <= endptr);
     if (ptr + amount > endptr)
@@ -47,155 +54,187 @@ namespace cubpacking
       }
   }
 
+  //
+  // packer
+  //
+
+  packer::packer (void)
+  {
+    // all pointers are initialized to NULL
+  }
+
   packer::packer (char *storage, const size_t amount)
   {
-    init (storage, amount);
+    set_buffer (storage, amount);
   }
 
-  int packer::init (char *storage, const size_t amount)
+  void
+  packer::set_buffer (char *storage, const size_t amount)
   {
-    m_packer_start_ptr = storage;
+    m_start_ptr = storage;
     m_ptr = storage;
-    m_end_ptr = storage + amount;
-
-    return NO_ERROR;
+    m_end_ptr = m_start_ptr + amount;
   }
 
-  size_t packer::get_packed_int_size (size_t curr_offset)
+  unpacker::unpacker (const char *storage, const size_t amount)
+  {
+    set_buffer (storage, amount);
+  }
+
+  void
+  unpacker::set_buffer (const char *storage, const size_t amount)
+  {
+    m_start_ptr = storage;
+    m_ptr = storage;
+    m_end_ptr = m_start_ptr + amount;
+  }
+
+  size_t
+  packer::get_packed_int_size (size_t curr_offset)
   {
     return DB_ALIGN (curr_offset, INT_ALIGNMENT) - curr_offset + OR_INT_SIZE;
   }
 
-  int packer::pack_int (const int value)
+  void
+  packer::pack_int (const int value)
   {
     align (INT_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, OR_INT_SIZE);
 
     OR_PUT_INT (m_ptr, value);
     m_ptr += OR_INT_SIZE;
-
-    return NO_ERROR;
   }
 
-  int packer::unpack_int (int *value)
+  void
+  unpacker::unpack_int (int &value)
   {
     align (INT_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, OR_INT_SIZE);
 
-    *value = OR_GET_INT (m_ptr);
+    value = OR_GET_INT (m_ptr);
     m_ptr += OR_INT_SIZE;
-
-    return NO_ERROR;
   }
 
-  int packer::peek_unpack_int (int *value)
+  void
+  unpacker::peek_unpack_int (int &value)
   {
     align (INT_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, OR_INT_SIZE);
 
-    *value = OR_GET_INT (m_ptr);
-
-    return NO_ERROR;
+    value = OR_GET_INT (m_ptr);
   }
 
-  size_t packer::get_packed_short_size (size_t curr_offset)
+  size_t
+  packer::get_packed_bool_size (size_t curr_offset)
+  {
+    return get_packed_int_size (curr_offset);
+  }
+
+  void
+  packer::pack_bool (bool value)
+  {
+    pack_int (value ? 1 : 0);
+  }
+
+  void
+  unpacker::unpack_bool (bool &value)
+  {
+    int int_val;
+    unpack_int (int_val);
+    assert (int_val == 1 || int_val == 0);
+    value = int_val != 0;
+  }
+
+  size_t
+  packer::get_packed_short_size (size_t curr_offset)
   {
     return DB_ALIGN (curr_offset, SHORT_ALIGNMENT) - curr_offset + OR_SHORT_SIZE;
   }
 
-  int packer::pack_short (short *value)
+  void
+  packer::pack_short (const short value)
   {
     align (SHORT_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, OR_SHORT_SIZE);
 
-    OR_PUT_SHORT (m_ptr, *value);
+    OR_PUT_SHORT (m_ptr, value);
     m_ptr += OR_SHORT_SIZE;
-
-    return NO_ERROR;
   }
 
-  int packer::unpack_short (short *value)
+  void
+  unpacker::unpack_short (short &value)
   {
     align (SHORT_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, OR_SHORT_SIZE);
 
-    *value = OR_GET_SHORT (m_ptr);
+    value = OR_GET_SHORT (m_ptr);
     m_ptr += OR_SHORT_SIZE;
-
-    return NO_ERROR;
   }
 
-  size_t packer::get_packed_bigint_size (size_t curr_offset)
+  size_t
+  packer::get_packed_bigint_size (size_t curr_offset)
   {
     return DB_ALIGN (curr_offset, MAX_ALIGNMENT) - curr_offset + OR_BIGINT_SIZE;
   }
 
-  int packer::pack_bigint (std::int64_t *value)
+  void
+  packer::pack_bigint (const std::int64_t &value)
   {
     align (MAX_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, OR_BIGINT_SIZE);
 
-    OR_PUT_INT64 (m_ptr, value);
+    OR_PUT_INT64 (m_ptr, &value);
     m_ptr += OR_BIGINT_SIZE;
-
-    return NO_ERROR;
   }
 
-  int packer::unpack_bigint (std::int64_t *value)
+  void
+  unpacker::unpack_bigint (std::int64_t &value)
   {
     align (MAX_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, OR_BIGINT_SIZE);
 
-    OR_GET_INT64 (m_ptr, value);
+    OR_GET_INT64 (m_ptr, &value);
     m_ptr += OR_BIGINT_SIZE;
-
-    return NO_ERROR;
   }
 
-  int packer::pack_bigint (std::uint64_t *value)
+  void
+  packer::pack_bigint (const std::uint64_t &value)
   {
     align (MAX_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, OR_BIGINT_SIZE);
 
-    OR_PUT_INT64 (m_ptr, value);
+    OR_PUT_INT64 (m_ptr, &value);
     m_ptr += OR_BIGINT_SIZE;
-
-    return NO_ERROR;
   }
 
-  int packer::unpack_bigint (std::uint64_t *value)
+  void
+  unpacker::unpack_bigint (std::uint64_t &value)
   {
     align (MAX_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, OR_BIGINT_SIZE);
 
-    OR_GET_INT64 (m_ptr, value);
+    OR_GET_INT64 (m_ptr, &value);
     m_ptr += OR_BIGINT_SIZE;
-
-    return NO_ERROR;
   }
 
-  int packer::pack_int_array (const int *array, const int count)
+  void
+  packer::pack_int_array (const int *array, const int count)
   {
-    int i;
-
     align (INT_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, (OR_INT_SIZE * (count + 1)));
 
     OR_PUT_INT (m_ptr, count);
     m_ptr += OR_INT_SIZE;
-    for (i = 0; i < count; i++)
+    for (int i = 0; i < count; i++)
       {
 	OR_PUT_INT (m_ptr, array[i]);
 	m_ptr += OR_INT_SIZE;
       }
-
-    return NO_ERROR;
   }
 
-  int packer::unpack_int_array (int *array, int &count)
+  void
+  unpacker::unpack_int_array (int *array, int &count)
   {
-    int i;
-
     align (INT_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, OR_INT_SIZE);
 
@@ -204,47 +243,44 @@ namespace cubpacking
 
     if (count == 0)
       {
-	return NO_ERROR;
+	return;
       }
 
     check_range (m_ptr, m_end_ptr, OR_INT_SIZE * count);
 
-    for (i = 0; i < count; i++)
+    for (int i = 0; i < count; i++)
       {
 	array[i] = OR_GET_INT (m_ptr);
 	m_ptr += OR_INT_SIZE;
       }
-
-    return NO_ERROR;
   }
 
-  size_t packer::get_packed_int_vector_size (size_t curr_offset, const int count)
+  size_t
+  packer::get_packed_int_vector_size (size_t curr_offset, const int count)
   {
     return DB_ALIGN (curr_offset, INT_ALIGNMENT) - curr_offset + (OR_INT_SIZE * (count + 1));
   }
 
-  int packer::pack_int_vector (const std::vector<int> &array)
+  void
+  packer::pack_int_vector (const std::vector<int> &array)
   {
     const int count = (const int) array.size ();
-    int i;
 
     align (INT_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, (OR_INT_SIZE * (count + 1)));
 
     OR_PUT_INT (m_ptr, count);
     m_ptr += OR_INT_SIZE;
-    for (i = 0; i < count; i++)
+    for (int i = 0; i < count; i++)
       {
 	OR_PUT_INT (m_ptr, array[i]);
 	m_ptr += OR_INT_SIZE;
       }
-
-    return NO_ERROR;
   }
 
-  int packer::unpack_int_vector (std::vector<int> &array)
+  void
+  unpacker::unpack_int_vector (std::vector<int> &array)
   {
-    int i;
     int count;
 
     align (INT_ALIGNMENT);
@@ -255,28 +291,28 @@ namespace cubpacking
 
     check_range (m_ptr, m_end_ptr, OR_INT_SIZE * count);
 
-    for (i = 0; i < count; i++)
+    for (int i = 0; i < count; i++)
       {
 	array.push_back (OR_GET_INT (m_ptr));
 	m_ptr += OR_INT_SIZE;
       }
-
-    return NO_ERROR;
   }
 
-  size_t packer::get_packed_db_value_size (const DB_VALUE &value, size_t curr_offset)
+  size_t
+  packer::get_packed_db_value_size (const DB_VALUE &value, size_t curr_offset)
   {
     size_t aligned_offset = DB_ALIGN (curr_offset, MAX_ALIGNMENT);
-    size_t unaligned_size = or_packed_value_size ((DB_VALUE *) &value, 1, 1, 0);
+    size_t unaligned_size = or_packed_value_size (&value, 1, 1, 0);
     size_t aligned_size = unaligned_size;
     return aligned_size + aligned_offset - curr_offset;
   }
 
-  int packer::pack_db_value (const DB_VALUE &value)
+  void
+  packer::pack_db_value (const DB_VALUE &value)
   {
     char *old_ptr;
 
-    size_t value_size = or_packed_value_size ((DB_VALUE *) &value, 1, 1, 0);
+    size_t value_size = or_packed_value_size (&value, 1, 1, 0);
 
     align (MAX_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, value_size);
@@ -286,27 +322,25 @@ namespace cubpacking
     assert (old_ptr + value_size == m_ptr);
 
     check_range (m_ptr, m_end_ptr, 0);
-
-    return NO_ERROR;
   }
 
-  int packer::unpack_db_value (DB_VALUE *value)
+  void
+  unpacker::unpack_db_value (DB_VALUE &value)
   {
-    char *old_ptr;
+    const char *old_ptr;
 
     align (MAX_ALIGNMENT);
     old_ptr = m_ptr;
-    m_ptr = or_unpack_value (m_ptr, (DB_VALUE *) value);
+    m_ptr = or_unpack_value (m_ptr, &value);
 
-    size_t value_size = or_packed_value_size (value, 1, 1, 0);
+    size_t value_size = or_packed_value_size (&value, 1, 1, 0);
     assert (old_ptr + value_size == m_ptr);
 
     check_range (m_ptr, m_end_ptr, 0);
-
-    return NO_ERROR;
   }
 
-  size_t packer::get_packed_small_string_size (const char *string, const size_t curr_offset)
+  size_t
+  packer::get_packed_small_string_size (const char *string, const size_t curr_offset)
   {
     size_t entry_size;
 
@@ -315,7 +349,8 @@ namespace cubpacking
     return DB_ALIGN (curr_offset + entry_size, INT_ALIGNMENT) - curr_offset;
   }
 
-  int packer::pack_small_string (const char *string)
+  void
+  packer::pack_small_string (const char *string)
   {
     size_t len;
 
@@ -323,7 +358,9 @@ namespace cubpacking
 
     if (len > MAX_SMALL_STRING_SIZE)
       {
-	return ER_FAILED;
+	assert (false);
+	pack_c_string (string, len);
+	return;
       }
 
     check_range (m_ptr, m_end_ptr, len + 1);
@@ -332,16 +369,15 @@ namespace cubpacking
     m_ptr += OR_BYTE_SIZE;
     if (len > 0)
       {
-	(void) memcpy (m_ptr, string, len);
+	std::memcpy (m_ptr, string, len);
 	m_ptr += len;
       }
 
     align (INT_ALIGNMENT);
-
-    return NO_ERROR;
   }
 
-  int packer::unpack_small_string (char *string, const size_t max_size)
+  void
+  unpacker::unpack_small_string (char *string, const size_t max_size)
   {
     size_t len;
 
@@ -350,7 +386,8 @@ namespace cubpacking
     len = OR_GET_BYTE (m_ptr);
     if (len > max_size)
       {
-	return ER_FAILED;
+	assert (false);
+	return;
       }
 
     m_ptr += OR_BYTE_SIZE;
@@ -358,7 +395,7 @@ namespace cubpacking
     check_range (m_ptr, m_end_ptr, len);
     if (len > 0)
       {
-	(void) memcpy (string, m_ptr, len);
+	std::memcpy (string, m_ptr, len);
 	string[len] = '\0';
 	m_ptr += len;
       }
@@ -368,12 +405,11 @@ namespace cubpacking
       }
 
     align (INT_ALIGNMENT);
-
-    return NO_ERROR;
   }
 
 
-  size_t packer::get_packed_large_string_size (const std::string &str, const size_t curr_offset)
+  size_t
+  packer::get_packed_large_string_size (const std::string &str, const size_t curr_offset)
   {
     size_t entry_size;
 
@@ -382,7 +418,8 @@ namespace cubpacking
     return DB_ALIGN (curr_offset + entry_size, INT_ALIGNMENT) - curr_offset;
   }
 
-  int packer::pack_large_string (const std::string &str)
+  void
+  packer::pack_large_string (const std::string &str)
   {
     size_t len;
 
@@ -394,15 +431,14 @@ namespace cubpacking
     OR_PUT_INT (m_ptr, len);
     m_ptr += OR_INT_SIZE;
 
-    (void) memcpy (m_ptr, str.c_str (), len);
+    std::memcpy (m_ptr, str.c_str (), len);
     m_ptr += len;
 
     align (INT_ALIGNMENT);
-
-    return NO_ERROR;
   }
 
-  int packer::unpack_large_string (std::string &str)
+  void
+  unpacker::unpack_large_string (std::string &str)
   {
     size_t len;
 
@@ -416,28 +452,29 @@ namespace cubpacking
     if (len > 0)
       {
 	check_range (m_ptr, m_end_ptr, len);
-	str = std::string ((const char *) m_ptr, len);
+	str = std::string (m_ptr, len);
 	m_ptr += len;
       }
 
     align (INT_ALIGNMENT);
-
-    return NO_ERROR;
   }
 
-  size_t packer::get_packed_string_size (const std::string &str, const size_t curr_offset)
+  size_t
+  packer::get_packed_string_size (const std::string &str, const size_t curr_offset)
   {
     return get_packed_c_string_size (str.c_str (), str.size (), curr_offset);
   }
 
-  int packer::pack_string (const std::string &str)
+  void
+  packer::pack_string (const std::string &str)
   {
     size_t len = str.size ();
 
-    return pack_c_string (str.c_str (), len);
+    pack_c_string (str.c_str (), len);
   }
 
-  int packer::unpack_string (std::string &str)
+  void
+  unpacker::unpack_string (std::string &str)
   {
     size_t len;
 
@@ -448,22 +485,21 @@ namespace cubpacking
     if (len == LARGE_STRING_CODE)
       {
 	m_ptr++;
-	return unpack_large_string (str);
+	unpack_large_string (str);
       }
     else
       {
 	m_ptr++;
 
-	str = std::string ((const char *) m_ptr, len);
+	str = std::string (m_ptr, len);
 	m_ptr += len;
 
 	align (INT_ALIGNMENT);
-
-	return NO_ERROR;
       }
   }
 
-  size_t packer::get_packed_c_string_size (const char *str, const size_t str_size, const size_t curr_offset)
+  size_t
+  packer::get_packed_c_string_size (const char *str, const size_t str_size, const size_t curr_offset)
   {
     size_t entry_size;
 
@@ -479,11 +515,12 @@ namespace cubpacking
     return DB_ALIGN (curr_offset + entry_size, INT_ALIGNMENT) - curr_offset;
   }
 
-  int packer::pack_c_string (const char *str, const size_t str_size)
+  void
+  packer::pack_c_string (const char *str, const size_t str_size)
   {
     if (str_size < MAX_SMALL_STRING_SIZE)
       {
-	return pack_small_string (str);
+	pack_small_string (str);
       }
     else
       {
@@ -492,11 +529,12 @@ namespace cubpacking
 	OR_PUT_BYTE (m_ptr, LARGE_STRING_CODE);
 	m_ptr++;
 
-	return pack_large_string (str);
+	pack_large_string (str);
       }
   }
 
-  int packer::unpack_c_string (char *str, const size_t max_str_size)
+  void
+  unpacker::unpack_c_string (char *str, const size_t max_str_size)
   {
     size_t len;
 
@@ -518,7 +556,8 @@ namespace cubpacking
 
     if (len >= max_str_size)
       {
-	return ER_FAILED;
+	assert (false);
+	return;
       }
     if (len > 0)
       {
@@ -530,9 +569,23 @@ namespace cubpacking
     str[len] = '\0';
 
     align (INT_ALIGNMENT);
-
-    return NO_ERROR;
   }
 
+  void
+  packer::assign_or_buf (const size_t size, or_buf &buf)
+  {
+    check_range (m_ptr, m_end_ptr, size);
+    m_ptr += size;
+    OR_BUF_INIT (buf, m_ptr, size);
+  }
+
+  void
+  unpacker::assign_or_buf (const size_t size, or_buf &buf)
+  {
+    check_range (m_ptr, m_end_ptr, size);
+    m_ptr += size;
+    // promise you won't write on it!
+    OR_BUF_INIT (buf, const_cast <char *> (m_ptr), size);
+  }
 
 } /* namespace cubpacking */

--- a/src/base/packer.hpp
+++ b/src/base/packer.hpp
@@ -90,7 +90,7 @@ namespace cubpacking
       // packer should gradually replace OR_BUF, but they will coexist for a while. there will be functionality
       // strictly dependent on or_buf, so packer will have to cede at least some of the packing to or_buf
       //
-      void assign_or_buf (const size_t size, or_buf &buf);
+      void delegate_to_or_buf (const size_t size, or_buf &buf);
 
       const char *get_curr_ptr (void)
       {
@@ -187,7 +187,7 @@ namespace cubpacking
       // packer should gradually replace OR_BUF, but they will coexist for a while. there will be functionality
       // strictly dependent on or_buf, so packer will have to cede at least some of the packing to or_buf
       //
-      void assign_or_buf (const size_t size, or_buf &buf);
+      void delegate_to_or_buf (const size_t size, or_buf &buf);
 
     private:
       const char *m_start_ptr; /* start of buffer */

--- a/src/base/packer.hpp
+++ b/src/base/packer.hpp
@@ -31,69 +31,128 @@
 #include <vector>
 #include <string>
 
+// forward definition
+struct or_buf;
+
 /*
- * the packer object packs or unpacks primitive objects from/into a buffer
- * the buffer is provided at initialization
- * each object is atomically packed into the buffer.
- * (atomically == means no other object could insert sub-objects in the middle of the packing of
- * currently serialized object)
+ * the packer object packs primitive objects from a buffer and unpacker unpacks same objects from the buffer.
+ * the packer & unpacker implementations should be mirrored.
+ *
+ * the buffer is provided at initialization; packer/unpacker classes are not meant for multi-threaded access.
  */
 namespace cubpacking
 {
-
   class packer
   {
     public:
-      /* method for starting a packing context */
-      packer (void)
-      {
-	m_ptr = NULL;
-      };
+      packer ();
       packer (char *storage, const size_t amount);
-
-      int init (char *storage, const size_t amount);
+      void set_buffer (char *storage, const size_t amount);
 
       size_t get_packed_int_size (size_t curr_offset);
-      int pack_int (const int value);
-      int unpack_int (int *value);
-      int peek_unpack_int (int *value);
+      void pack_int (const int value);
+
+      size_t get_packed_bool_size (size_t curr_offset);
+      void pack_bool (bool value);
 
       size_t get_packed_short_size (size_t curr_offset);
-      int pack_short (short *value);
-      int unpack_short (short *value);
+      void pack_short (const short value);
 
       size_t get_packed_bigint_size (size_t curr_offset);
-      int pack_bigint (std::int64_t *value);
-      int unpack_bigint (std::int64_t *value);
-      int pack_bigint (std::uint64_t *value);
-      int unpack_bigint (std::uint64_t *value);
+      void pack_bigint (const std::int64_t &value);
+      void pack_bigint (const std::uint64_t &value);
 
-      int pack_int_array (const int *array, const int count);
-      int unpack_int_array (int *array, int &count);
+      void pack_int_array (const int *array, const int count);
 
       size_t get_packed_int_vector_size (size_t curr_offset, const int count);
-      int pack_int_vector (const std::vector<int> &array);
-      int unpack_int_vector (std::vector <int> &array);
+      void pack_int_vector (const std::vector<int> &array);
 
       size_t get_packed_db_value_size (const DB_VALUE &value, size_t curr_offset);
-      int pack_db_value (const DB_VALUE &value);
-      int unpack_db_value (DB_VALUE *value);
+      void pack_db_value (const DB_VALUE &value);
+
 
       size_t get_packed_small_string_size (const char *string, const size_t curr_offset);
-      int pack_small_string (const char *string);
-      int unpack_small_string (char *string, const size_t max_size);
+      void pack_small_string (const char *string);
+
 
       size_t get_packed_large_string_size (const std::string &str, const size_t curr_offset);
-      int pack_large_string (const std::string &str);
-      int unpack_large_string (std::string &str);
+      void pack_large_string (const std::string &str);
+
 
       size_t get_packed_string_size (const std::string &str, const size_t curr_offset);
-      int pack_string (const std::string &str);
-      int unpack_string (std::string &str);
+      void pack_string (const std::string &str);
+
 
       size_t get_packed_c_string_size (const char *str, const size_t str_size, const size_t curr_offset);
-      int pack_c_string (const char *str, const size_t str_size);
-      int unpack_c_string (char *str, const size_t max_str_size);
+      void pack_c_string (const char *str, const size_t str_size);
+
+
+      // packer should gradually replace OR_BUF, but they will coexist for a while. there will be functionality
+      // strictly dependent on or_buf, so packer will have to cede at least some of the packing to or_buf
+      //
+      void assign_or_buf (const size_t size, or_buf &buf);
+
+      const char *get_curr_ptr (void)
+      {
+	return m_ptr;
+      };
+
+      size_t get_current_size (void)
+      {
+	return get_curr_ptr () - get_buffer_start ();
+      }
+
+      void align (const size_t req_alignment)
+      {
+	m_ptr = PTR_ALIGN (m_ptr, req_alignment);
+      };
+
+      const char *get_buffer_start (void)
+      {
+	return m_start_ptr;
+      };
+
+      const char *get_buffer_end (void)
+      {
+	return m_end_ptr;
+      };
+
+      bool is_ended (void)
+      {
+	return get_curr_ptr () == get_buffer_end ();
+      }
+
+    private:
+      const char *m_start_ptr; /* start of buffer */
+      const char *m_end_ptr;     /* end of available serialization scope */
+      char *m_ptr;
+  };
+
+  class unpacker
+  {
+    public:
+      unpacker () = default;
+      unpacker (const char *storage, const size_t amount);
+      void set_buffer (const char *storage, const size_t amount);
+
+      void unpack_int (int &value);
+      void peek_unpack_int (int &value);
+      void unpack_int_array (int *array, int &count);
+      void unpack_int_vector (std::vector <int> &array);
+
+      void unpack_bool (bool &value);
+
+      void unpack_short (short &value);
+
+      void unpack_bigint (std::int64_t &value);
+      void unpack_bigint (std::uint64_t &value);
+
+      void unpack_small_string (char *string, const size_t max_size);
+      void unpack_large_string (std::string &str);
+      void unpack_string (std::string &str);
+      void unpack_c_string (char *str, const size_t max_str_size);
+
+      void unpack_db_value (DB_VALUE &value);
 
       const char *get_curr_ptr (void)
       {
@@ -105,22 +164,41 @@ namespace cubpacking
 	m_ptr = PTR_ALIGN (m_ptr, req_alignment);
       };
 
-      const char *get_packer_buffer (void)
+      size_t get_current_size (void)
       {
-	return m_packer_start_ptr;
+	return get_curr_ptr () - get_buffer_start ();
+      }
+
+      const char *get_buffer_start (void)
+      {
+	return m_start_ptr;
       };
 
-      const char *get_packer_end (void)
+      const char *get_buffer_end (void)
       {
 	return m_end_ptr;
       };
 
+      bool is_ended (void)
+      {
+	return get_curr_ptr () == get_buffer_end ();
+      }
+
+      // packer should gradually replace OR_BUF, but they will coexist for a while. there will be functionality
+      // strictly dependent on or_buf, so packer will have to cede at least some of the packing to or_buf
+      //
+      void assign_or_buf (const size_t size, or_buf &buf);
+
     private:
-      char *m_packer_start_ptr; /* start of buffer */
-      char *m_ptr;         /* current pointer of serialization */
-      char *m_end_ptr;     /* end of available serialization scope */
+      const char *m_start_ptr; /* start of buffer */
+      const char *m_end_ptr;     /* end of available serialization scope */
+      const char *m_ptr;
   };
 
 } /* namespace cubpacking */
+
+// for legacy C files, because indent is confused by namespaces
+using packing_packer = cubpacking::packer;
+using packing_unpacker = cubpacking::unpacker;
 
 #endif /* _PACKER_HPP_ */

--- a/src/base/stream_entry.hpp
+++ b/src/base/stream_entry.hpp
@@ -120,12 +120,12 @@ namespace cubstream
       int prepare_func (const stream_position &data_start_pos, char *ptr, const size_t header_size,
 			size_t &payload_size)
       {
-	cubpacking::unpacker *serializator = get_unpacker ();
+	cubpacking::unpacker *deserializator = get_unpacker ();
 	int error_code;
 
 	assert (header_size == get_packed_header_size ());
 
-	serializator->set_buffer (ptr, header_size);
+	deserializator->set_buffer (ptr, header_size);
 
 	error_code = unpack_stream_entry_header ();
 	if (error_code != NO_ERROR)

--- a/src/base/stream_entry.hpp
+++ b/src/base/stream_entry.hpp
@@ -94,10 +94,10 @@ namespace cubstream
 #if !defined (NDEBUG)
 	    const char *start_ptr = serializator->get_curr_ptr ();
 	    const char *curr_ptr;
-	    size_t entry_size = m_packable_entries[i]->get_packed_size (serializator);
+	    size_t entry_size = m_packable_entries[i]->get_packed_size (*serializator);
 #endif
 
-	    m_packable_entries[i]->pack (serializator);
+	    m_packable_entries[i]->pack (*serializator);
 
 #if !defined (NDEBUG)
 	    curr_ptr = serializator->get_curr_ptr ();
@@ -177,7 +177,7 @@ namespace cubstream
 
 	    /* unpack one replication entry */
 	    add_packable_entry (packable_entry);
-	    packable_entry->unpack (deserializator);
+	    packable_entry->unpack (*deserializator);
 	  }
 	deserializator->align (MAX_ALIGNMENT);
 
@@ -290,7 +290,7 @@ namespace cubstream
 	for (i = 0; i < m_packable_entries.size (); i++)
 	  {
 	    total_size = DB_ALIGN (total_size, MAX_ALIGNMENT);
-	    entry_size = m_packable_entries[i]->get_packed_size (serializator);
+	    entry_size = m_packable_entries[i]->get_packed_size (*serializator);
 	    total_size += entry_size;
 	  }
 

--- a/src/base/stream_entry.hpp
+++ b/src/base/stream_entry.hpp
@@ -84,7 +84,7 @@ namespace cubstream
 	cubpacking::packer *serializator = get_packer ();
 
 	size_t aligned_amount = DB_ALIGN (reserved_amount, MAX_ALIGNMENT);
-	serializator->init (ptr, aligned_amount);
+	serializator->set_buffer (ptr, aligned_amount);
 
 	pack_stream_entry_header ();
 
@@ -106,7 +106,7 @@ namespace cubstream
 	  }
 	serializator->align (MAX_ALIGNMENT);
 
-	int packed_amount = (int) (serializator->get_curr_ptr () - serializator->get_packer_buffer ());
+	int packed_amount = (int) (serializator->get_curr_ptr () - serializator->get_buffer_start ());
 
 	return packed_amount;
       };
@@ -120,12 +120,12 @@ namespace cubstream
       int prepare_func (const stream_position &data_start_pos, char *ptr, const size_t header_size,
 			size_t &payload_size)
       {
-	cubpacking::packer *serializator = get_packer ();
+	cubpacking::unpacker *serializator = get_unpacker ();
 	int error_code;
 
 	assert (header_size == get_packed_header_size ());
 
-	serializator->init (ptr, header_size);
+	serializator->set_buffer (ptr, header_size);
 
 	error_code = unpack_stream_entry_header ();
 	if (error_code != NO_ERROR)
@@ -154,16 +154,16 @@ namespace cubstream
 	unsigned int i;
 	int error_code = NO_ERROR;
 	int object_id;
-	cubpacking::packer *serializator = get_packer ();
+	cubpacking::unpacker *deserializator = get_unpacker ();
 	size_t count_packable_entries = get_packable_entry_count_from_header ();
 
-	serializator->init (ptr, data_size);
+	deserializator->set_buffer (ptr, data_size);
 
 	for (i = 0 ; i < count_packable_entries; i++)
 	  {
-	    serializator->align (MAX_ALIGNMENT);
+	    deserializator->align (MAX_ALIGNMENT);
 	    /* peek type of object : it will be consumed by object's unpack */
-	    serializator->peek_unpack_int (&object_id);
+	    deserializator->peek_unpack_int (object_id);
 
 	    PO *packable_entry = get_builder ()->create_object (object_id);
 	    if (packable_entry == NULL)
@@ -177,15 +177,11 @@ namespace cubstream
 
 	    /* unpack one replication entry */
 	    add_packable_entry (packable_entry);
-	    error_code = packable_entry->unpack (serializator);
-	    if (error_code != NO_ERROR)
-	      {
-		return error_code;
-	      }
+	    packable_entry->unpack (deserializator);
 	  }
-	serializator->align (MAX_ALIGNMENT);
+	deserializator->align (MAX_ALIGNMENT);
 
-	assert (serializator->get_curr_ptr () - ptr == (int) data_size);
+	assert (deserializator->get_curr_ptr () - ptr == (int) data_size);
 
 	return error_code;
       };
@@ -315,6 +311,7 @@ namespace cubstream
 
       /* stream entry header methods : header is implementation dependent, is not known here ! */
       virtual cubpacking::packer *get_packer () = 0;
+      virtual cubpacking::unpacker *get_unpacker () = 0;
       virtual size_t get_packed_header_size (void) = 0;
       virtual void set_header_data_size (const size_t &data_size) = 0;
       virtual size_t get_data_packed_size (void) = 0;

--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -121,7 +121,7 @@ namespace cubreplication
     (void) db_change_private_heap (NULL, save_heapid);
   }
 
-  size_t single_row_repl_entry::get_packed_size (cubpacking::packer *serializator) const
+  size_t single_row_repl_entry::get_packed_size (cubpacking::packer &serializator) const
   {
     size_t i;
     size_t entry_size = 0;
@@ -129,48 +129,48 @@ namespace cubreplication
     /* we assume that offset start has already MAX_ALIGNMENT */
 
     /* type of packed object + type of RBR entry */
-    entry_size += 2 * serializator->get_packed_int_size (entry_size);
+    entry_size += 2 * serializator.get_packed_int_size (entry_size);
 
-    entry_size += serializator->get_packed_int_vector_size (entry_size, (int) changed_attributes.size ());
+    entry_size += serializator.get_packed_int_vector_size (entry_size, (int) changed_attributes.size ());
 
-    entry_size += serializator->get_packed_small_string_size (m_class_name, entry_size);
+    entry_size += serializator.get_packed_small_string_size (m_class_name, entry_size);
 
-    entry_size += serializator->get_packed_db_value_size (m_key_value, entry_size);
+    entry_size += serializator.get_packed_db_value_size (m_key_value, entry_size);
 
     /* count of new_values */
-    entry_size += serializator->get_packed_int_size (entry_size);
+    entry_size += serializator.get_packed_int_size (entry_size);
 
     for (i = 0; i < m_new_values.size (); i++)
       {
-	entry_size += serializator->get_packed_db_value_size (m_new_values[i], entry_size);
+	entry_size += serializator.get_packed_db_value_size (m_new_values[i], entry_size);
       }
 
     return entry_size;
   }
 
-  void single_row_repl_entry::pack (cubpacking::packer *serializator) const
+  void single_row_repl_entry::pack (cubpacking::packer &serializator) const
   {
     size_t i;
 
-    serializator->pack_int (single_row_repl_entry::PACKING_ID);
+    serializator.pack_int (single_row_repl_entry::PACKING_ID);
 
-    serializator->pack_int ((int) m_type);
+    serializator.pack_int ((int) m_type);
 
-    serializator->pack_int_vector (changed_attributes);
+    serializator.pack_int_vector (changed_attributes);
 
-    serializator->pack_small_string (m_class_name);
+    serializator.pack_small_string (m_class_name);
 
-    serializator->pack_db_value (m_key_value);
+    serializator.pack_db_value (m_key_value);
 
-    serializator->pack_int ((int) m_new_values.size ());
+    serializator.pack_int ((int) m_new_values.size ());
 
     for (i = 0; i < m_new_values.size (); i++)
       {
-	serializator->pack_db_value (m_new_values[i]);
+	serializator.pack_db_value (m_new_values[i]);
       }
   }
 
-  void single_row_repl_entry::unpack (cubpacking::unpacker *deserializator)
+  void single_row_repl_entry::unpack (cubpacking::unpacker &deserializator)
   {
     int count_new_values = 0;
     int i;
@@ -181,24 +181,24 @@ namespace cubreplication
     save_heapid = db_private_set_heapid_to_thread (NULL, 0);
 #endif
     /* create id */
-    deserializator->unpack_int (int_val);
+    deserializator.unpack_int (int_val);
 
     /* RBR type */
-    deserializator->unpack_int (int_val);
+    deserializator.unpack_int (int_val);
     m_type = (REPL_ENTRY_TYPE) int_val;
 
-    deserializator->unpack_int_vector (changed_attributes);
+    deserializator.unpack_int_vector (changed_attributes);
 
-    deserializator->unpack_small_string (m_class_name, sizeof (m_class_name) - 1);
+    deserializator.unpack_small_string (m_class_name, sizeof (m_class_name) - 1);
 
-    deserializator->unpack_db_value (m_key_value);
+    deserializator.unpack_db_value (m_key_value);
 
-    deserializator->unpack_int (count_new_values);
+    deserializator.unpack_int (count_new_values);
 
     for (i = 0; i < count_new_values; i++)
       {
 	m_new_values.emplace_back ();
-	deserializator->unpack_db_value (m_new_values.back ());
+	deserializator.unpack_db_value (m_new_values.back ());
       }
 
 #if defined (SERVER_MODE)
@@ -225,30 +225,30 @@ namespace cubreplication
     return true;
   }
 
-  size_t sbr_repl_entry::get_packed_size (cubpacking::packer *serializator) const
+  size_t sbr_repl_entry::get_packed_size (cubpacking::packer &serializator) const
   {
     /* we assume that offset start has already MAX_ALIGNMENT */
 
     /* type of packed object */
-    size_t entry_size = serializator->get_packed_int_size (0);
+    size_t entry_size = serializator.get_packed_int_size (0);
 
-    entry_size += serializator->get_packed_large_string_size (m_statement, entry_size);
+    entry_size += serializator.get_packed_large_string_size (m_statement, entry_size);
 
     return entry_size;
   }
 
-  void sbr_repl_entry::pack (cubpacking::packer *serializator) const
+  void sbr_repl_entry::pack (cubpacking::packer &serializator) const
   {
-    serializator->pack_int (sbr_repl_entry::PACKING_ID);
-    serializator->pack_large_string (m_statement);
+    serializator.pack_int (sbr_repl_entry::PACKING_ID);
+    serializator.pack_large_string (m_statement);
   }
 
-  void sbr_repl_entry::unpack (cubpacking::unpacker *deserializator)
+  void sbr_repl_entry::unpack (cubpacking::unpacker &deserializator)
   {
     int entry_type_not_used;
 
-    deserializator->unpack_int (entry_type_not_used);
-    deserializator->unpack_large_string (m_statement);
+    deserializator.unpack_int (entry_type_not_used);
+    deserializator.unpack_large_string (m_statement);
   }
 
 } /* namespace cubreplication */

--- a/src/replication/replication_object.hpp
+++ b/src/replication/replication_object.hpp
@@ -82,10 +82,10 @@ namespace cubreplication
 	m_statement = str;
       };
 
-      void pack (cubpacking::packer *serializator) const;
-      void unpack (cubpacking::unpacker *deserializator);
+      void pack (cubpacking::packer &serializator) const;
+      void unpack (cubpacking::unpacker &deserializator);
 
-      size_t get_packed_size (cubpacking::packer *serializator) const;
+      size_t get_packed_size (cubpacking::packer &serializator) const;
   };
 
   class single_row_repl_entry : public replication_object
@@ -120,10 +120,10 @@ namespace cubreplication
 
       void copy_and_add_changed_value (const int att_id, DB_VALUE *db_val);
 
-      void pack (cubpacking::packer *serializator) const;
-      void unpack (cubpacking::unpacker *deserializator);
+      void pack (cubpacking::packer &serializator) const;
+      void unpack (cubpacking::unpacker &deserializator);
 
-      size_t get_packed_size (cubpacking::packer *serializator) const;
+      size_t get_packed_size (cubpacking::packer &serializator) const;
   };
 
 } /* namespace cubreplication */

--- a/src/replication/replication_object.hpp
+++ b/src/replication/replication_object.hpp
@@ -82,10 +82,10 @@ namespace cubreplication
 	m_statement = str;
       };
 
-      int pack (cubpacking::packer *serializator);
-      int unpack (cubpacking::packer *serializator);
+      void pack (cubpacking::packer *serializator) const;
+      void unpack (cubpacking::unpacker *deserializator);
 
-      size_t get_packed_size (cubpacking::packer *serializator);
+      size_t get_packed_size (cubpacking::packer *serializator) const;
   };
 
   class single_row_repl_entry : public replication_object
@@ -120,10 +120,10 @@ namespace cubreplication
 
       void copy_and_add_changed_value (const int att_id, DB_VALUE *db_val);
 
-      int pack (cubpacking::packer *serializator);
-      int unpack (cubpacking::packer *serializator);
+      void pack (cubpacking::packer *serializator) const;
+      void unpack (cubpacking::unpacker *deserializator);
 
-      size_t get_packed_size (cubpacking::packer *serializator);
+      size_t get_packed_size (cubpacking::packer *serializator) const;
   };
 
 } /* namespace cubreplication */

--- a/src/replication/replication_stream_entry.cpp
+++ b/src/replication/replication_stream_entry.cpp
@@ -64,8 +64,8 @@ namespace cubreplication
     unsigned int state_flags;
 
     m_header.count_replication_entries = (int) m_packable_entries.size ();
-    serializator->pack_bigint (&m_header.prev_record);
-    serializator->pack_bigint (&m_header.mvccid);
+    serializator->pack_bigint (m_header.prev_record);
+    serializator->pack_bigint (m_header.mvccid);
 
     assert ((m_header.count_replication_entries & stream_entry_header::COUNT_VALUE_MASK)
 	    == m_header.count_replication_entries);
@@ -83,19 +83,19 @@ namespace cubreplication
 
   int stream_entry::unpack_stream_entry_header ()
   {
-    cubpacking::packer *serializator = get_packer ();
+    cubpacking::unpacker *serializator = get_unpacker ();
     unsigned int count_and_flags;
     unsigned int state_flags;
 
-    serializator->unpack_bigint (&m_header.prev_record);
-    serializator->unpack_bigint (&m_header.mvccid);
-    serializator->unpack_int ((int *) &count_and_flags);
+    serializator->unpack_bigint (m_header.prev_record);
+    serializator->unpack_bigint (m_header.mvccid);
+    serializator->unpack_int (reinterpret_cast<int &> (count_and_flags)); // is this safe?s
 
     state_flags = (count_and_flags & stream_entry_header::STATE_MASK) >> (32 - stream_entry_header::STATE_BITS);
     m_header.tran_state = (stream_entry_header::TRAN_STATE) state_flags;
 
     m_header.count_replication_entries = count_and_flags & stream_entry_header::COUNT_VALUE_MASK;
-    serializator->unpack_int (&m_header.data_size);
+    serializator->unpack_int (m_header.data_size);
 
     return NO_ERROR;
   }

--- a/src/replication/replication_stream_entry.hpp
+++ b/src/replication/replication_stream_entry.hpp
@@ -85,19 +85,22 @@ namespace cubreplication
     private:
       stream_entry_header m_header;
       cubpacking::packer m_serializator;
+      cubpacking::unpacker m_deserializator;
 
     public:
       stream_entry (cubstream::multi_thread_stream *stream_p)
-	: entry (stream_p),
-	  m_serializator (NULL, 0)
+	: entry (stream_p)
+	, m_serializator ()
+	, m_deserializator ()
       {
       };
 
       stream_entry (cubstream::multi_thread_stream *stream_p,
 		    MVCCID arg_mvccid,
 		    stream_entry_header::TRAN_STATE state)
-	: entry (stream_p),
-	  m_serializator (NULL, 0)
+	: entry (stream_p)
+	, m_serializator ()
+	, m_deserializator ()
       {
 	m_header.mvccid = arg_mvccid;
 	m_header.tran_state = state;
@@ -116,6 +119,11 @@ namespace cubreplication
       cubpacking::packer *get_packer ()
       {
 	return &m_serializator;
+      }
+
+      cubpacking::unpacker *get_unpacker ()
+      {
+	return &m_deserializator;
       }
 
       void set_mvccid (MVCCID mvccid)

--- a/unit_tests/packing/test_packing.cpp
+++ b/unit_tests/packing/test_packing.cpp
@@ -39,46 +39,46 @@ namespace test_packing
     str[i] = '\0';
   }
 
-  void po1::pack (cubpacking::packer *serializator) const
+  void po1::pack (cubpacking::packer &serializator) const
   {
-    serializator->pack_int (i1);
-    serializator->pack_short (sh1);
-    serializator->pack_bigint (b1);
-    serializator->pack_int_array (int_a, sizeof (int_a) / sizeof (int_a[0]));
-    serializator->pack_int_vector (int_v);
+    serializator.pack_int (i1);
+    serializator.pack_short (sh1);
+    serializator.pack_bigint (b1);
+    serializator.pack_int_array (int_a, sizeof (int_a) / sizeof (int_a[0]));
+    serializator.pack_int_vector (int_v);
     for (int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
-	serializator->pack_db_value (values[i]);
+	serializator.pack_db_value (values[i]);
       }
-    serializator->pack_small_string (small_str);
-    serializator->pack_large_string (large_str);
+    serializator.pack_small_string (small_str);
+    serializator.pack_large_string (large_str);
 
-    serializator->pack_string (str1);
+    serializator.pack_string (str1);
 
-    serializator->pack_c_string (str2, sizeof (str2) - 1);
+    serializator.pack_c_string (str2, sizeof (str2) - 1);
   }
 
-  void po1::unpack (cubpacking::unpacker *deserializator)
+  void po1::unpack (cubpacking::unpacker &deserializator)
   {
     int cnt = 0;
 
-    deserializator->unpack_int (i1);
-    deserializator->unpack_short (sh1);
-    deserializator->unpack_bigint (b1);
-    deserializator->unpack_int_array (int_a, cnt);
+    deserializator.unpack_int (i1);
+    deserializator.unpack_short (sh1);
+    deserializator.unpack_bigint (b1);
+    deserializator.unpack_int_array (int_a, cnt);
     assert (cnt == sizeof (int_a) / sizeof (int_a[0]));
 
-    deserializator->unpack_int_vector (int_v);
+    deserializator.unpack_int_vector (int_v);
 
     for (int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
-	deserializator->unpack_db_value (values[i]);
+	deserializator.unpack_db_value (values[i]);
       }
-    deserializator->unpack_small_string (small_str, sizeof (small_str));
-    deserializator->unpack_large_string (large_str);
+    deserializator.unpack_small_string (small_str, sizeof (small_str));
+    deserializator.unpack_large_string (large_str);
 
-    deserializator->unpack_string (str1);
-    deserializator->unpack_c_string (str2, sizeof (str2));
+    deserializator.unpack_string (str1);
+    deserializator.unpack_c_string (str2, sizeof (str2));
   }
 
   bool po1::is_equal (const cubpacking::packable_object *other)
@@ -135,24 +135,24 @@ namespace test_packing
     return true;
   }
 
-  size_t po1::get_packed_size (cubpacking::packer *serializator) const
+  size_t po1::get_packed_size (cubpacking::packer &serializator) const
   {
     size_t entry_size = 0;
 
-    entry_size += serializator->get_packed_int_size (entry_size);
-    entry_size += serializator->get_packed_short_size (entry_size);
-    entry_size += serializator->get_packed_bigint_size (entry_size);
-    entry_size += serializator->get_packed_int_vector_size (entry_size, sizeof (int_a) / sizeof (int_a[0]));
-    entry_size += serializator->get_packed_int_vector_size (entry_size, (int) int_v.size ());
+    entry_size += serializator.get_packed_int_size (entry_size);
+    entry_size += serializator.get_packed_short_size (entry_size);
+    entry_size += serializator.get_packed_bigint_size (entry_size);
+    entry_size += serializator.get_packed_int_vector_size (entry_size, sizeof (int_a) / sizeof (int_a[0]));
+    entry_size += serializator.get_packed_int_vector_size (entry_size, (int) int_v.size ());
     for (int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
-	entry_size += serializator->get_packed_db_value_size (values[i], int_v.size ());
+	entry_size += serializator.get_packed_db_value_size (values[i], int_v.size ());
       }
-    entry_size += serializator->get_packed_small_string_size (small_str, entry_size);
-    entry_size += serializator->get_packed_large_string_size (large_str, entry_size);
+    entry_size += serializator.get_packed_small_string_size (small_str, entry_size);
+    entry_size += serializator.get_packed_large_string_size (large_str, entry_size);
 
-    entry_size += serializator->get_packed_string_size (str1, entry_size);
-    entry_size += serializator->get_packed_c_string_size (str2, sizeof (str2), entry_size);
+    entry_size += serializator.get_packed_string_size (str1, entry_size);
+    entry_size += serializator.get_packed_c_string_size (str2, sizeof (str2), entry_size);
     return entry_size;
   }
 
@@ -290,21 +290,21 @@ namespace test_packing
     obj_size = 0;
     for (i = 0; i < TEST_OBJ_CNT; i++)
       {
-	obj_size += test_objects[i].get_packed_size (&packer_instance);
+	obj_size += test_objects[i].get_packed_size (packer_instance);
       }
 
     //assert (obj_size < buf1.get_buffer_size ());
 
     for (i = 0; i < TEST_OBJ_CNT; i++)
       {
-	test_objects[i].pack (&packer_instance);
+	test_objects[i].pack (packer_instance);
       }
 
     memcpy (buf2.get_buffer (), buf1.get_buffer (), buf1.get_buffer_size());
 
     for (i = 0; i < TEST_OBJ_CNT; i++)
       {
-	test_objects_unpack[i].unpack (&unpacker_instance);
+	test_objects_unpack[i].unpack (unpacker_instance);
       }
 
     for (i = 0; i < TEST_OBJ_CNT; i++)

--- a/unit_tests/packing/test_packing.hpp
+++ b/unit_tests/packing/test_packing.hpp
@@ -58,12 +58,12 @@ namespace test_packing
 
     public:
 
-      void pack (cubpacking::packer *serializator) const;
-      void unpack (cubpacking::unpacker *deserializator);
+      void pack (cubpacking::packer &serializator) const;
+      void unpack (cubpacking::unpacker &deserializator);
 
       bool is_equal (const packable_object *other);
 
-      size_t get_packed_size (cubpacking::packer *serializator) const;
+      size_t get_packed_size (cubpacking::packer &serializator) const;
 
       void generate_obj (void);
   };

--- a/unit_tests/packing/test_packing.hpp
+++ b/unit_tests/packing/test_packing.hpp
@@ -58,12 +58,12 @@ namespace test_packing
 
     public:
 
-      int pack (cubpacking::packer *serializator);
-      int unpack (cubpacking::packer *serializator);
+      void pack (cubpacking::packer *serializator) const;
+      void unpack (cubpacking::unpacker *deserializator);
 
       bool is_equal (const packable_object *other);
 
-      size_t get_packed_size (cubpacking::packer *serializator);
+      size_t get_packed_size (cubpacking::packer *serializator) const;
 
       void generate_obj (void);
   };

--- a/unit_tests/stream/test_stream.cpp
+++ b/unit_tests/stream/test_stream.cpp
@@ -113,51 +113,51 @@ namespace test_stream
   }
 
   /* po1 */
-  void po1::pack (cubpacking::packer *serializator) const
+  void po1::pack (cubpacking::packer &serializator) const
   {
-    serializator->pack_int (po1::ID);
+    serializator.pack_int (po1::ID);
 
-    serializator->pack_int (i1);
-    serializator->pack_short (sh1);
-    serializator->pack_bigint (b1);
-    serializator->pack_int_array (int_a, sizeof (int_a) / sizeof (int_a[0]));
-    serializator->pack_int_vector (int_v);
+    serializator.pack_int (i1);
+    serializator.pack_short (sh1);
+    serializator.pack_bigint (b1);
+    serializator.pack_int_array (int_a, sizeof (int_a) / sizeof (int_a[0]));
+    serializator.pack_int_vector (int_v);
     for (unsigned int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
-	serializator->pack_db_value (values[i]);
+	serializator.pack_db_value (values[i]);
       }
-    serializator->pack_small_string (small_str);
-    serializator->pack_large_string (large_str);
+    serializator.pack_small_string (small_str);
+    serializator.pack_large_string (large_str);
 
-    serializator->pack_string (str1);
+    serializator.pack_string (str1);
 
-    serializator->pack_c_string (str2, strlen (str2));
+    serializator.pack_c_string (str2, strlen (str2));
   }
 
-  void po1::unpack (cubpacking::unpacker *deserializator)
+  void po1::unpack (cubpacking::unpacker &deserializator)
   {
     int cnt;
 
-    deserializator->unpack_int (cnt);
+    deserializator.unpack_int (cnt);
     assert (cnt == po1::ID);
 
-    deserializator->unpack_int (i1);
-    deserializator->unpack_short (sh1);
-    deserializator->unpack_bigint (b1);
-    deserializator->unpack_int_array (int_a, cnt);
+    deserializator.unpack_int (i1);
+    deserializator.unpack_short (sh1);
+    deserializator.unpack_bigint (b1);
+    deserializator.unpack_int_array (int_a, cnt);
     assert (cnt == sizeof (int_a) / sizeof (int_a[0]));
 
-    deserializator->unpack_int_vector (int_v);
+    deserializator.unpack_int_vector (int_v);
 
     for (unsigned int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
-	deserializator->unpack_db_value (values[i]);
+	deserializator.unpack_db_value (values[i]);
       }
-    deserializator->unpack_small_string (small_str, sizeof (small_str));
-    deserializator->unpack_large_string (large_str);
+    deserializator.unpack_small_string (small_str, sizeof (small_str));
+    deserializator.unpack_large_string (large_str);
 
-    deserializator->unpack_string (str1);
-    deserializator->unpack_c_string (str2, sizeof (str2));
+    deserializator.unpack_string (str1);
+    deserializator.unpack_c_string (str2, sizeof (str2));
   }
 
   bool po1::is_equal (const cubpacking::packable_object *other)
@@ -214,26 +214,26 @@ namespace test_stream
     return true;
   }
 
-  size_t po1::get_packed_size (cubpacking::packer *serializator) const
+  size_t po1::get_packed_size (cubpacking::packer &serializator) const
   {
     size_t entry_size = 0;
     /* ID :*/
-    entry_size += serializator->get_packed_int_size (entry_size);
+    entry_size += serializator.get_packed_int_size (entry_size);
 
-    entry_size += serializator->get_packed_int_size (entry_size);
-    entry_size += serializator->get_packed_short_size (entry_size);
-    entry_size += serializator->get_packed_bigint_size (entry_size);
-    entry_size += serializator->get_packed_int_vector_size (entry_size, sizeof (int_a) / sizeof (int_a[0]));
-    entry_size += serializator->get_packed_int_vector_size (entry_size, (int) int_v.size ());
+    entry_size += serializator.get_packed_int_size (entry_size);
+    entry_size += serializator.get_packed_short_size (entry_size);
+    entry_size += serializator.get_packed_bigint_size (entry_size);
+    entry_size += serializator.get_packed_int_vector_size (entry_size, sizeof (int_a) / sizeof (int_a[0]));
+    entry_size += serializator.get_packed_int_vector_size (entry_size, (int) int_v.size ());
     for (unsigned int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
-	entry_size += serializator->get_packed_db_value_size (values[i], entry_size);
+	entry_size += serializator.get_packed_db_value_size (values[i], entry_size);
       }
-    entry_size += serializator->get_packed_small_string_size (small_str, entry_size);
-    entry_size += serializator->get_packed_large_string_size (large_str, entry_size);
+    entry_size += serializator.get_packed_small_string_size (small_str, entry_size);
+    entry_size += serializator.get_packed_large_string_size (large_str, entry_size);
 
-    entry_size += serializator->get_packed_string_size (str1, entry_size);
-    entry_size += serializator->get_packed_c_string_size (str2, strlen (str2), entry_size);
+    entry_size += serializator.get_packed_string_size (str1, entry_size);
+    entry_size += serializator.get_packed_c_string_size (str2, strlen (str2), entry_size);
     return entry_size;
   }
 
@@ -302,20 +302,20 @@ namespace test_stream
       }
   }
   /* po2 */
-  void po2::pack (cubpacking::packer *serializator) const
+  void po2::pack (cubpacking::packer &serializator) const
   {
-    serializator->pack_int (po2::ID);
+    serializator.pack_int (po2::ID);
 
-    serializator->pack_large_string (large_str);
+    serializator.pack_large_string (large_str);
   }
 
-  void po2::unpack (cubpacking::unpacker *deserializator)
+  void po2::unpack (cubpacking::unpacker &deserializator)
   {
     int id;
 
-    deserializator->unpack_int (id);
+    deserializator.unpack_int (id);
 
-    deserializator->unpack_large_string (large_str);
+    deserializator.unpack_large_string (large_str);
   }
 
   bool po2::is_equal (const cubpacking::packable_object *other)
@@ -336,14 +336,14 @@ namespace test_stream
     return true;
   }
 
-  size_t po2::get_packed_size (cubpacking::packer *serializator) const
+  size_t po2::get_packed_size (cubpacking::packer &serializator) const
   {
     size_t entry_size = 0;
     /* ID :*/
-    entry_size += serializator->get_packed_int_size (entry_size);
+    entry_size += serializator.get_packed_int_size (entry_size);
 
 
-    entry_size += serializator->get_packed_large_string_size (large_str, entry_size);
+    entry_size += serializator.get_packed_large_string_size (large_str, entry_size);
 
     return entry_size;
   }

--- a/unit_tests/stream/test_stream.cpp
+++ b/unit_tests/stream/test_stream.cpp
@@ -113,66 +113,51 @@ namespace test_stream
   }
 
   /* po1 */
-  int po1::pack (cubpacking::packer *serializator)
+  void po1::pack (cubpacking::packer *serializator) const
   {
-    int res = 0;
-
     serializator->pack_int (po1::ID);
 
     serializator->pack_int (i1);
-    serializator->pack_short (&sh1);
-    serializator->pack_bigint (&b1);
+    serializator->pack_short (sh1);
+    serializator->pack_bigint (b1);
     serializator->pack_int_array (int_a, sizeof (int_a) / sizeof (int_a[0]));
     serializator->pack_int_vector (int_v);
     for (unsigned int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
 	serializator->pack_db_value (values[i]);
       }
-    res = serializator->pack_small_string (small_str);
-    assert (res == 0);
-    res = serializator->pack_large_string (large_str);
-    assert (res == 0);
+    serializator->pack_small_string (small_str);
+    serializator->pack_large_string (large_str);
 
-    res = serializator->pack_string (str1);
-    assert (res == 0);
+    serializator->pack_string (str1);
 
-    res = serializator->pack_c_string (str2, strlen (str2));
-    assert (res == 0);
-
-    return NO_ERROR;
+    serializator->pack_c_string (str2, strlen (str2));
   }
 
-  int po1::unpack (cubpacking::packer *serializator)
+  void po1::unpack (cubpacking::unpacker *deserializator)
   {
     int cnt;
-    int res;
 
-    serializator->unpack_int (&cnt);
+    deserializator->unpack_int (cnt);
     assert (cnt == po1::ID);
 
-    serializator->unpack_int (&i1);
-    serializator->unpack_short (&sh1);
-    serializator->unpack_bigint (&b1);
-    serializator->unpack_int_array (int_a, cnt);
+    deserializator->unpack_int (i1);
+    deserializator->unpack_short (sh1);
+    deserializator->unpack_bigint (b1);
+    deserializator->unpack_int_array (int_a, cnt);
     assert (cnt == sizeof (int_a) / sizeof (int_a[0]));
 
-    serializator->unpack_int_vector (int_v);
+    deserializator->unpack_int_vector (int_v);
 
     for (unsigned int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
-	serializator->unpack_db_value (&values[i]);
+	deserializator->unpack_db_value (values[i]);
       }
-    res = serializator->unpack_small_string (small_str, sizeof (small_str));
-    assert (res == 0);
-    res = serializator->unpack_large_string (large_str);
-    assert (res == 0);
+    deserializator->unpack_small_string (small_str, sizeof (small_str));
+    deserializator->unpack_large_string (large_str);
 
-    res = serializator->unpack_string (str1);
-    assert (res == 0);
-    res = serializator->unpack_c_string (str2, sizeof (str2));
-    assert (res == 0);
-
-    return NO_ERROR;
+    deserializator->unpack_string (str1);
+    deserializator->unpack_c_string (str2, sizeof (str2));
   }
 
   bool po1::is_equal (const cubpacking::packable_object *other)
@@ -229,7 +214,7 @@ namespace test_stream
     return true;
   }
 
-  size_t po1::get_packed_size (cubpacking::packer *serializator)
+  size_t po1::get_packed_size (cubpacking::packer *serializator) const
   {
     size_t entry_size = 0;
     /* ID :*/
@@ -317,31 +302,20 @@ namespace test_stream
       }
   }
   /* po2 */
-  int po2::pack (cubpacking::packer *serializator)
+  void po2::pack (cubpacking::packer *serializator) const
   {
-    int res = 0;
+    serializator->pack_int (po2::ID);
 
-    res = serializator->pack_int (po2::ID);
-    assert (res == 0);
-
-    res = serializator->pack_large_string (large_str);
-    assert (res == 0);
-
-    return NO_ERROR;
+    serializator->pack_large_string (large_str);
   }
 
-  int po2::unpack (cubpacking::packer *serializator)
+  void po2::unpack (cubpacking::unpacker *deserializator)
   {
-    int res;
     int id;
 
-    serializator->unpack_int (&id);
-    assert (id == po2::ID);
+    deserializator->unpack_int (id);
 
-    res = serializator->unpack_large_string (large_str);
-    assert (res == 0);
-
-    return NO_ERROR;
+    deserializator->unpack_large_string (large_str);
   }
 
   bool po2::is_equal (const cubpacking::packable_object *other)
@@ -362,7 +336,7 @@ namespace test_stream
     return true;
   }
 
-  size_t po2::get_packed_size (cubpacking::packer *serializator)
+  size_t po2::get_packed_size (cubpacking::packer *serializator) const
   {
     size_t entry_size = 0;
     /* ID :*/

--- a/unit_tests/stream/test_stream.cpp
+++ b/unit_tests/stream/test_stream.cpp
@@ -113,51 +113,51 @@ namespace test_stream
   }
 
   /* po1 */
-  void po1::pack (cubpacking::packer &serializator) const
+  void po1::pack (cubpacking::packer &serializer) const
   {
-    serializator.pack_int (po1::ID);
+    serializer.pack_int (po1::ID);
 
-    serializator.pack_int (i1);
-    serializator.pack_short (sh1);
-    serializator.pack_bigint (b1);
-    serializator.pack_int_array (int_a, sizeof (int_a) / sizeof (int_a[0]));
-    serializator.pack_int_vector (int_v);
+    serializer.pack_int (i1);
+    serializer.pack_short (sh1);
+    serializer.pack_bigint (b1);
+    serializer.pack_int_array (int_a, sizeof (int_a) / sizeof (int_a[0]));
+    serializer.pack_int_vector (int_v);
     for (unsigned int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
-	serializator.pack_db_value (values[i]);
+	serializer.pack_db_value (values[i]);
       }
-    serializator.pack_small_string (small_str);
-    serializator.pack_large_string (large_str);
+    serializer.pack_small_string (small_str);
+    serializer.pack_large_string (large_str);
 
-    serializator.pack_string (str1);
+    serializer.pack_string (str1);
 
-    serializator.pack_c_string (str2, strlen (str2));
+    serializer.pack_c_string (str2, strlen (str2));
   }
 
-  void po1::unpack (cubpacking::unpacker &deserializator)
+  void po1::unpack (cubpacking::unpacker &deserializer)
   {
     int cnt;
 
-    deserializator.unpack_int (cnt);
+    deserializer.unpack_int (cnt);
     assert (cnt == po1::ID);
 
-    deserializator.unpack_int (i1);
-    deserializator.unpack_short (sh1);
-    deserializator.unpack_bigint (b1);
-    deserializator.unpack_int_array (int_a, cnt);
+    deserializer.unpack_int (i1);
+    deserializer.unpack_short (sh1);
+    deserializer.unpack_bigint (b1);
+    deserializer.unpack_int_array (int_a, cnt);
     assert (cnt == sizeof (int_a) / sizeof (int_a[0]));
 
-    deserializator.unpack_int_vector (int_v);
+    deserializer.unpack_int_vector (int_v);
 
     for (unsigned int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
-	deserializator.unpack_db_value (values[i]);
+	deserializer.unpack_db_value (values[i]);
       }
-    deserializator.unpack_small_string (small_str, sizeof (small_str));
-    deserializator.unpack_large_string (large_str);
+    deserializer.unpack_small_string (small_str, sizeof (small_str));
+    deserializer.unpack_large_string (large_str);
 
-    deserializator.unpack_string (str1);
-    deserializator.unpack_c_string (str2, sizeof (str2));
+    deserializer.unpack_string (str1);
+    deserializer.unpack_c_string (str2, sizeof (str2));
   }
 
   bool po1::is_equal (const cubpacking::packable_object *other)
@@ -214,26 +214,26 @@ namespace test_stream
     return true;
   }
 
-  size_t po1::get_packed_size (cubpacking::packer &serializator) const
+  size_t po1::get_packed_size (cubpacking::packer &serializer) const
   {
     size_t entry_size = 0;
     /* ID :*/
-    entry_size += serializator.get_packed_int_size (entry_size);
+    entry_size += serializer.get_packed_int_size (entry_size);
 
-    entry_size += serializator.get_packed_int_size (entry_size);
-    entry_size += serializator.get_packed_short_size (entry_size);
-    entry_size += serializator.get_packed_bigint_size (entry_size);
-    entry_size += serializator.get_packed_int_vector_size (entry_size, sizeof (int_a) / sizeof (int_a[0]));
-    entry_size += serializator.get_packed_int_vector_size (entry_size, (int) int_v.size ());
+    entry_size += serializer.get_packed_int_size (entry_size);
+    entry_size += serializer.get_packed_short_size (entry_size);
+    entry_size += serializer.get_packed_bigint_size (entry_size);
+    entry_size += serializer.get_packed_int_vector_size (entry_size, sizeof (int_a) / sizeof (int_a[0]));
+    entry_size += serializer.get_packed_int_vector_size (entry_size, (int) int_v.size ());
     for (unsigned int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
-	entry_size += serializator.get_packed_db_value_size (values[i], entry_size);
+	entry_size += serializer.get_packed_db_value_size (values[i], entry_size);
       }
-    entry_size += serializator.get_packed_small_string_size (small_str, entry_size);
-    entry_size += serializator.get_packed_large_string_size (large_str, entry_size);
+    entry_size += serializer.get_packed_small_string_size (small_str, entry_size);
+    entry_size += serializer.get_packed_large_string_size (large_str, entry_size);
 
-    entry_size += serializator.get_packed_string_size (str1, entry_size);
-    entry_size += serializator.get_packed_c_string_size (str2, strlen (str2), entry_size);
+    entry_size += serializer.get_packed_string_size (str1, entry_size);
+    entry_size += serializer.get_packed_c_string_size (str2, strlen (str2), entry_size);
     return entry_size;
   }
 
@@ -302,20 +302,20 @@ namespace test_stream
       }
   }
   /* po2 */
-  void po2::pack (cubpacking::packer &serializator) const
+  void po2::pack (cubpacking::packer &serializer) const
   {
-    serializator.pack_int (po2::ID);
+    serializer.pack_int (po2::ID);
 
-    serializator.pack_large_string (large_str);
+    serializer.pack_large_string (large_str);
   }
 
-  void po2::unpack (cubpacking::unpacker &deserializator)
+  void po2::unpack (cubpacking::unpacker &deserializer)
   {
     int id;
 
-    deserializator.unpack_int (id);
+    deserializer.unpack_int (id);
 
-    deserializator.unpack_large_string (large_str);
+    deserializer.unpack_large_string (large_str);
   }
 
   bool po2::is_equal (const cubpacking::packable_object *other)
@@ -336,14 +336,14 @@ namespace test_stream
     return true;
   }
 
-  size_t po2::get_packed_size (cubpacking::packer &serializator) const
+  size_t po2::get_packed_size (cubpacking::packer &serializer) const
   {
     size_t entry_size = 0;
     /* ID :*/
-    entry_size += serializator.get_packed_int_size (entry_size);
+    entry_size += serializer.get_packed_int_size (entry_size);
 
 
-    entry_size += serializator.get_packed_large_string_size (large_str, entry_size);
+    entry_size += serializer.get_packed_large_string_size (large_str, entry_size);
 
     return entry_size;
   }

--- a/unit_tests/stream/test_stream.hpp
+++ b/unit_tests/stream/test_stream.hpp
@@ -112,12 +112,12 @@ namespace test_stream
 
     public:
       ~po1();
-      void pack (cubpacking::packer *serializator) const;
-      void unpack (cubpacking::unpacker *deserializator);
+      void pack (cubpacking::packer &serializator) const;
+      void unpack (cubpacking::unpacker &deserializator);
 
       bool is_equal (const packable_object *other);
 
-      size_t get_packed_size (cubpacking::packer *serializator) const;
+      size_t get_packed_size (cubpacking::packer &serializator) const;
 
       void generate_obj (void);
   };
@@ -132,12 +132,12 @@ namespace test_stream
     public:
       ~po2() {};
 
-      void pack (cubpacking::packer *serializator) const;
-      void unpack (cubpacking::unpacker *deserializator);
+      void pack (cubpacking::packer &serializator) const;
+      void unpack (cubpacking::unpacker &deserializator);
 
       bool is_equal (const packable_object *other);
 
-      size_t get_packed_size (cubpacking::packer *serializator) const;
+      size_t get_packed_size (cubpacking::packer &serializator) const;
 
       void generate_obj (void);
   };

--- a/unit_tests/stream/test_stream.hpp
+++ b/unit_tests/stream/test_stream.hpp
@@ -112,12 +112,12 @@ namespace test_stream
 
     public:
       ~po1();
-      void pack (cubpacking::packer &serializator) const;
-      void unpack (cubpacking::unpacker &deserializator);
+      void pack (cubpacking::packer &serializer) const;
+      void unpack (cubpacking::unpacker &deserializer);
 
       bool is_equal (const packable_object *other);
 
-      size_t get_packed_size (cubpacking::packer &serializator) const;
+      size_t get_packed_size (cubpacking::packer &serializer) const;
 
       void generate_obj (void);
   };
@@ -132,12 +132,12 @@ namespace test_stream
     public:
       ~po2() {};
 
-      void pack (cubpacking::packer &serializator) const;
-      void unpack (cubpacking::unpacker &deserializator);
+      void pack (cubpacking::packer &serializer) const;
+      void unpack (cubpacking::unpacker &deserializer);
 
       bool is_equal (const packable_object *other);
 
-      size_t get_packed_size (cubpacking::packer &serializator) const;
+      size_t get_packed_size (cubpacking::packer &serializer) const;
 
       void generate_obj (void);
   };
@@ -155,8 +155,8 @@ namespace test_stream
     private:
       test_stream_entry_header m_header;
 
-      cubpacking::packer m_serializator;
-      cubpacking::unpacker m_deserializator;
+      cubpacking::packer m_serializer;
+      cubpacking::unpacker m_deserializer;
 
     public:
       test_stream_entry (cubstream::multi_thread_stream *stream_p)
@@ -168,11 +168,11 @@ namespace test_stream
       size_t get_packed_header_size ()
       {
 	size_t header_size = 0;
-	cubpacking::packer *serializator = get_packer ();
-	header_size += serializator->get_packed_int_size (header_size);
-	header_size += serializator->get_packed_int_size (header_size);
-	header_size += serializator->get_packed_int_size (header_size);
-	header_size += serializator->get_packed_int_size (header_size);
+	cubpacking::packer *serializer = get_packer ();
+	header_size += serializer->get_packed_int_size (header_size);
+	header_size += serializer->get_packed_int_size (header_size);
+	header_size += serializer->get_packed_int_size (header_size);
+	header_size += serializer->get_packed_int_size (header_size);
 
 	return header_size;
       };
@@ -208,24 +208,24 @@ namespace test_stream
 
       int pack_stream_entry_header ()
       {
-	cubpacking::packer *serializator = get_packer ();
+	cubpacking::packer *serializer = get_packer ();
 	m_header.count_objects = (int) m_packable_entries.size ();
 
-	serializator->pack_int (m_header.tran_id);
-	serializator->pack_int (m_header.mvcc_id);
-	serializator->pack_int (m_header.count_objects);
-	serializator->pack_int (m_header.data_size);
+	serializer->pack_int (m_header.tran_id);
+	serializer->pack_int (m_header.mvcc_id);
+	serializer->pack_int (m_header.count_objects);
+	serializer->pack_int (m_header.data_size);
 
 	return NO_ERROR;
       };
 
       int unpack_stream_entry_header ()
       {
-	cubpacking::unpacker *serializator = get_unpacker ();
-	serializator->unpack_int (m_header.tran_id);
-	serializator->unpack_int (m_header.mvcc_id);
-	serializator->unpack_int (reinterpret_cast<int &> (m_header.count_objects)); // is this safe?
-	serializator->unpack_int (m_header.data_size);
+	cubpacking::unpacker *deserializer = get_unpacker ();
+	deserializer->unpack_int (m_header.tran_id);
+	deserializer->unpack_int (m_header.mvcc_id);
+	deserializer->unpack_int (reinterpret_cast<int &> (m_header.count_objects)); // is this safe?
+	deserializer->unpack_int (m_header.data_size);
 
 	return NO_ERROR;
       };
@@ -237,12 +237,12 @@ namespace test_stream
 
       cubpacking::packer *get_packer ()
       {
-	return &m_serializator;
+	return &m_serializer;
       };
 
       cubpacking::unpacker *get_unpacker ()
       {
-	return &m_deserializator;
+	return &m_deserializer;
       };
 
       bool is_equal (const cubstream::entry<cubpacking::packable_object> *other)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22673

  1. Separate packer and unpacker functions (moved all unpack functions to unpacker). Unpacker can work with const buffers.
  2. Use copies or references for pack/unpack arguments. Remove return codes.
  3. Extend the packer/unpacker interfaces with bool type, switching to or_buf, get_current_size and is_ended functions. Add aliases for C-files - packing_packer and packing_unpacker.
  4. Adjust packable_object function signatures and add a default implementation for is_equal in order to allow not extending it. TODO: remove it completely.
  5. Add deserializator/get_unpack to stream_entry.
