### PR TITLE
[CBRD-22717] fix ctltool build issue - help_class_names

### DIFF
--- a/src/object/object_print.h
+++ b/src/object/object_print.h
@@ -49,8 +49,16 @@ void help_free_names (char **names);
 void help_fprint_obj (FILE * fp, MOP obj);
 
 /* Class name help */
-extern char **help_class_names (const char *qualifier);
-extern void help_free_class_names (char **names);
+// ctltool uses the functions
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+  extern char **help_class_names (const char *qualifier);
+  extern void help_free_class_names (char **names);
+#ifdef __cplusplus
+}
+#endif
 
 /* Misc help */
 void help_print_info (const char *command, FILE * fpp);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22717

Unfortunately, the current ctltool won't be built by g++.
I hope we will fix it someday. 