### PR TITLE
[CBRD-22682]  json_merge_patch adds null object_members from second parameter

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -2781,7 +2781,7 @@ db_json_merge_two_json_objects_patch (const JSON_VALUE &source, JSON_VALUE &dest
 	      db_json_merge_patch_values (itr->value, dest[name], allocator);
 	    }
 	}
-      else
+      else if (!itr->value.IsNull ())
 	{
 	  db_json_object_add_member (itr->name, itr->value, dest, allocator);
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22682

Fix json_merge_patch to not add null object_members from second object