### PR TITLE
[CBRD-22636] Improper cast to json error message

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -11577,6 +11577,12 @@ tp_domain_status_er_set (TP_DOMAIN_STATUS status, const char *file_name, const i
 #endif
       error = er_errid ();
 
+      if (error == ER_JSON_INVALID_JSON)
+	{
+	  // We keep invalid json errors that happend during cast since they are more descriptive
+	  return error;
+	}
+
       if (error == ER_IT_DATA_OVERFLOW)
 	{
 	  status = DOMAIN_OVERFLOW;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22636

Do not override ER_JSON_INVALID_JSON errors to ER_TP_CANT_COERCE because they are more descriptive.