### PR TITLE
[CBRD-22746] loaddb: handle SIGINT and SIGQUIT signals

### DIFF
--- a/msg/de_DE.utf8/utils.msg
+++ b/msg/de_DE.utf8/utils.msg
@@ -437,7 +437,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 Parse-Fehler \"%1$s\", wie %2$s Typ.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d Instanzen\r
-113 Letzte festgeschriebene Zeile: %1$d
+113 Letzte festgeschriebene Zeile: %1$d\n
 114 Fehler-Kontroll-Datei
 115 Eingangsdatei für Fehlerkontrolle während Ladung
 116 Total %8d object(s) inserted, %d object(s) failed.\n

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -438,7 +438,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 Error parsing \"%1$s\", as %2$s type.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d instances\r
-113 Last committed line : %1$d
+113 Last committed line : %1$d\n
 114 error-control-file
 115 input file to control error(s) during loading
 116 Total %1$8d object(s) inserted, %2$d object(s) failed.\n

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -438,7 +438,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 Error parsing \"%1$s\", as %2$s type.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d instances\r
-113 Last committed line : %1$d
+113 Last committed line : %1$d\n
 114 error-control-file
 115 input file to control error(s) during loading
 116 Total %1$8d object(s) inserted, %2$d object(s) failed.\n

--- a/msg/es_ES.utf8/utils.msg
+++ b/msg/es_ES.utf8/utils.msg
@@ -437,7 +437,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 Error al analizar \"%1$s\", como tipo %2$s.\n
 61 Object Reference is not supported in CS mode.\n
 112 %1$d instancias\r
-113 Ultima linea cometida: %1$d
+113 Ultima linea cometida: %1$d\n
 114 error-control-file
 115 archivo de entrada para controlar error(es) al cargar
 116 Total %8d object(s) inserted, %d object(s) failed.\n

--- a/msg/fr_FR.utf8/utils.msg
+++ b/msg/fr_FR.utf8/utils.msg
@@ -439,7 +439,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 Erreur d'analyse du \"%1$s\", comme type %2$s.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d instances\r
-113 Dernière ligne validée: %1$d
+113 Dernière ligne validée: %1$d\n
 114 error-control-file
 115 fichier d'entrée pour le contrôle d'erreur(s) pendant le chargement
 116 Total %8d object(s) inserted, %d object(s) failed.\n

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -437,7 +437,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 Errore durante l'analisi di \"%1$s\", come tipo %2$s.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d instanze\r
-113 Ultima linea committed : %1$d
+113 Ultima linea committed : %1$d\n
 114 error-control-file
 115 file di input per il controllo di errori durante il carico
 116 Total %8d object(s) inserted, %d object(s) failed.\n

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -437,7 +437,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 「%1$s」を「%2$s」タイプにパーシングエラー \n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d個のインスタンス\r
-113 最後にコミットされたライン : %1$d
+113 最後にコミットされたライン : %1$d\n
 114 エラーコントロールファイル
 115 ロードする時にエラー制御のための入力ファイル
 116 Total %1$8d object(s) inserted, %2$d object(s) failed.\n

--- a/msg/km_KH.utf8/utils.msg
+++ b/msg/km_KH.utf8/utils.msg
@@ -438,7 +438,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 Error parsing \"%1$s\", as %2$s type.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d instances\r
-113 Last committed line : %1$d
+113 Last committed line : %1$d\n
 114 error-control-file
 115 input file to control error(s) during loading
 116 Total %1$8d object(s) inserted, %2$d object(s) failed.\n

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -437,7 +437,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 에러 parsing \"%1$s\", as %2$s type.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d 개의 인스턴스\r
-113 마지막으로 커밋된 라인 : %1$d
+113 마지막으로 커밋된 라인 : %1$d\n
 114 에러 제어 파일
 115 로드 시에 에러 제어를 위한 입력 파일
 116 총 %1$8d 개의 객체가 삽입되었으며, %2$d 개의 객체가 실패하였습니다.\n

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -437,7 +437,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 에러 parsing \"%1$s\", as %2$s type.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d 개의 인스턴스\r
-113 마지막으로 커밋된 라인 : %1$d
+113 마지막으로 커밋된 라인 : %1$d\n
 114 에러 제어 파일
 115 로드 시에 에러 제어를 위한 입력 파일
 116 총 %1$8d 개의 객체가 삽입되었으며, %2$d 개의 객체가 실패하였습니다.\n

--- a/msg/ro_RO.utf8/utils.msg
+++ b/msg/ro_RO.utf8/utils.msg
@@ -449,7 +449,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 Eroare la parsarea lui \"%1$s\", ca fiind de tip %2$s.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d instanţe\r
-113 Ultima linie salvata (prin commit) : %1$d
+113 Ultima linie salvata (prin commit) : %1$d\n
 114 error-control-file
 115 una sau mai multe erori la încărcarea fişierului de intrare de control
 116 Total %8d object(s) inserted, %d object(s) failed.\n

--- a/msg/tr_TR.utf8/utils.msg
+++ b/msg/tr_TR.utf8/utils.msg
@@ -437,7 +437,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 Hata ayrıştırma \"%1$s\", gibi %2$s tür.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d örnekleri\r
-113 Son kararlı hattı: %1$d
+113 Son kararlı hattı: %1$d\n
 114 hata-kontrol-dosyası
 115 yükleme sırasında bir hata(lar) kontrol etmek için giriş dosyası
 116 Toplam %1$8d nesne (ler) eklenen, %2$d nesne (ler) başarısız oldu.\n

--- a/msg/vi_VN.utf8/utils.msg
+++ b/msg/vi_VN.utf8/utils.msg
@@ -438,7 +438,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 Error parsing \"%1$s\", as %2$s type.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d instances\r
-113 Last committed line : %1$d
+113 Last committed line : %1$d\n
 114 error-control-file
 115 input file to control error(s) during loading
 116 Total %1$8d object(s) inserted, %2$d object(s) failed.\n

--- a/msg/zh_CN.utf8/utils.msg
+++ b/msg/zh_CN.utf8/utils.msg
@@ -437,7 +437,7 @@ $set 12 MSGCAT_UTIL_SET_LOADDB
 60 将 \"%1$s\" 解析为 %2$s 类型时出错.\n
 61 Object Reference is not supported in CS mode.\n
 112   %1$d 个实例\r
-113 最后提交的行 : %1$d
+113 最后提交的行 : %1$d\n
 114 错误控制文件
 115 在加载过程中输入文件来控制错误
 116 共插入了 %1$8d 个对象, 其中 %2$d 个对象插入失败.\n

--- a/src/communication/network.h
+++ b/src/communication/network.h
@@ -239,6 +239,7 @@ enum net_server_request
   NET_SERVER_LD_LOAD_BATCH,
   NET_SERVER_LD_FETCH_STATS,
   NET_SERVER_LD_DESTROY,
+  NET_SERVER_LD_INTERRUPT,
 
   /*
    * This is the last entry. It is also used for the end of an

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -644,6 +644,7 @@ net_histo_setup_names (void)
   net_Req_buffer[NET_SERVER_LD_INSTALL_CLASS].name = "NET_SERVER_LD_INSTALL_CLASS";
   net_Req_buffer[NET_SERVER_LD_LOAD_BATCH].name = "NET_SERVER_LD_LOAD_BATCH";
   net_Req_buffer[NET_SERVER_LD_DESTROY].name = "NET_SERVER_LD_DESTROY";
+  net_Req_buffer[NET_SERVER_LD_INTERRUPT].name = "NET_SERVER_LD_INTERRUPT";
 }
 
 /*

--- a/src/communication/network_interface_cl.h
+++ b/src/communication/network_interface_cl.h
@@ -411,9 +411,10 @@ extern int netcl_spacedb (SPACEDB_ALL * spaceall, SPACEDB_ONEVOL ** spacevols, S
 extern int locator_demote_class_lock (const OID * class_oid, LOCK lock, LOCK * ex_lock);
 
 extern int loaddb_init ();
-extern int loaddb_load_object_file (const char *file_name);
+extern int loaddb_load_object_file (std::string & object_file_name);
 extern int loaddb_install_class (const cubload::batch & batch);
 extern int loaddb_load_batch (const cubload::batch & batch);
 extern int loaddb_fetch_stats (load_stats * stats);
 extern int loaddb_destroy ();
+extern int loaddb_interrupt ();
 #endif /* _NETWORK_INTERFACE_CL_H_ */

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -9978,7 +9978,7 @@ sloaddb_interrupt (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int
     {
       assert (session != NULL);
 
-      session->fail ();
+      session->interrupt ();
       session->wait_for_completion ();
     }
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -9782,44 +9782,57 @@ slocator_demote_class_lock (THREAD_ENTRY * thread_p, unsigned int rid, char *req
 void
 sloaddb_init (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  int ret;
-  OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
-  char *reply = OR_ALIGNED_BUF_START (a_reply);
   SESSION_ID session_id;
-
   session_get_session_id (thread_p, &session_id);
 
-  /* *INDENT-OFF* */
-  ret = session_set_load_session (thread_p, new load_session (session_id));
-  /* *INDENT-ON* */
+  load_session *session = new load_session (session_id);
 
-  or_pack_int (reply, ret);
+  int error_code = session_set_load_session (thread_p, session);
+  if (error_code != NO_ERROR)
+    {
+      delete session;
+    }
+
+  OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
+  char *reply = OR_ALIGNED_BUF_START (a_reply);
+
+  or_pack_int (reply, error_code);
   css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
 }
 
 void
 sloaddb_load_object_file (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  int ret;
-  char *object_file_name;
+  packing_unpacker unpacker (request, (size_t) reqlen);
+
+  /* *INDENT-OFF* */
+  std::string object_file_name;
+  /* *INDENT-ON* */
+
+  unpacker.unpack_string (object_file_name);
+
+  load_session *session = NULL;
+  int error_code = session_get_load_session (thread_p, session);
+  if (error_code == NO_ERROR)
+    {
+      assert (session != NULL);
+      error_code = session->load_file (*thread_p, object_file_name);
+    }
+  else
+    {
+      if (er_errid () == NO_ERROR || !er_has_error ())
+	{
+	  error_code = ER_LDR_INVALID_STATE;
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
+	}
+
+      return_error_to_client (thread_p, rid);
+    }
+
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply = OR_ALIGNED_BUF_START (a_reply);
 
-  or_unpack_string (request, &object_file_name);
-
-  /* *INDENT-OFF* */
-  std::string object_file_name_str (object_file_name);
-  /* *INDENT-ON* */
-
-  load_session *session = NULL;
-  session_get_load_session (thread_p, session);
-  assert (session != NULL);
-  ret = session->load_file (*thread_p, object_file_name_str);
-
-  db_private_free (thread_p, object_file_name);
-
-  or_pack_int (reply, ret);
-
+  or_pack_int (reply, error_code);
   css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
 }
 
@@ -9835,10 +9848,22 @@ sloaddb_install_class (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
   batch.unpack (unpacker);
 
   load_session *session = NULL;
-  session_get_load_session (thread_p, session);
-  assert (session != NULL);
+  int error_code = session_get_load_session (thread_p, session);
+  if (error_code == NO_ERROR)
+    {
+      assert (session != NULL);
+      error_code = session->install_class (*thread_p, batch);
+    }
+  else
+    {
+      if (er_errid () == NO_ERROR || !er_has_error ())
+	{
+	  error_code = ER_LDR_INVALID_STATE;
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
+	}
 
-  int error_code = session->install_class (*thread_p, batch);
+      return_error_to_client (thread_p, rid);
+    }
 
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply = OR_ALIGNED_BUF_START (a_reply);
@@ -9850,10 +9875,6 @@ sloaddb_install_class (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
 void
 sloaddb_load_batch (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  int error_code = NO_ERROR;
-  OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
-  char *reply = OR_ALIGNED_BUF_START (a_reply);
-
   packing_unpacker unpacker (request, (size_t) reqlen);
 
   /* *INDENT-OFF* */
@@ -9864,9 +9885,25 @@ sloaddb_load_batch (THREAD_ENTRY * thread_p, unsigned int rid, char *request, in
 
   load_session *session = NULL;
   session_get_load_session (thread_p, session);
-  assert (session != NULL);
+  int error_code = session_get_load_session (thread_p, session);
+  if (error_code == NO_ERROR)
+    {
+      assert (session != NULL);
+      error_code = session->load_batch (*thread_p, batch);
+    }
+  else
+    {
+      if (er_errid () == NO_ERROR || !er_has_error ())
+	{
+	  error_code = ER_LDR_INVALID_STATE;
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
+	}
 
-  error_code = session->load_batch (*thread_p, batch);
+      return_error_to_client (thread_p, rid);
+    }
+
+  OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
+  char *reply = OR_ALIGNED_BUF_START (a_reply);
 
   or_pack_int (reply, error_code);
   css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
@@ -9875,40 +9912,79 @@ sloaddb_load_batch (THREAD_ENTRY * thread_p, unsigned int rid, char *request, in
 void
 sloaddb_fetch_stats (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
-  char *reply = OR_ALIGNED_BUF_START (a_reply);
-
-  load_session *session = NULL;
-  session_get_load_session (thread_p, session);
-  assert (session != NULL);
-
-  load_stats loaddb_stats = session->get_stats ();
-
   packing_packer packer;
   cubmem::extensible_block eb;
 
-  packer.set_buffer_and_pack_all (eb, loaddb_stats);
+  char *buffer = NULL;
+  int buffer_size = 0;
 
-  or_pack_int (reply, (int) packer.get_current_size ());
+  load_session *session = NULL;
+  int error_code = session_get_load_session (thread_p, session);
+  if (error_code == NO_ERROR)
+    {
+      assert (session != NULL);
+      load_stats loaddb_stats = session->get_stats ();
 
-  css_send_reply_and_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply), eb.get_ptr (),
-				     (int) packer.get_current_size ());
+      packer.set_buffer_and_pack_all (eb, loaddb_stats);
+
+      buffer = eb.get_ptr ();
+      buffer_size = (int) packer.get_current_size ();
+    }
+  else
+    {
+      if (er_errid () == NO_ERROR || !er_has_error ())
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LDR_INVALID_STATE, 0);
+	}
+
+      return_error_to_client (thread_p, rid);
+    }
+
+  OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
+  char *reply = OR_ALIGNED_BUF_START (a_reply);
+
+  or_pack_int (reply, buffer_size);
+  css_send_reply_and_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply), buffer,
+				     buffer_size);
 }
 
 void
 sloaddb_destroy (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
+  load_session *session = NULL;
+  int error_code = session_get_load_session (thread_p, session);
+  if (error_code == NO_ERROR)
+    {
+      assert (session != NULL);
+
+      session->wait_for_completion ();
+      delete session;
+      session_set_load_session (thread_p, NULL);
+    }
+
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply = OR_ALIGNED_BUF_START (a_reply);
 
+  or_pack_int (reply, error_code);
+  css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
+}
+
+void
+sloaddb_interrupt (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
+{
   load_session *session = NULL;
-  session_get_load_session (thread_p, session);
-  assert (session != NULL);
+  int error_code = session_get_load_session (thread_p, session);
+  if (error_code == NO_ERROR)
+    {
+      assert (session != NULL);
 
-  session->wait_for_completion ();
-  delete session;
-  session_set_load_session (thread_p, NULL);
+      session->fail ();
+      session->wait_for_completion ();
+    }
 
-  or_pack_int (reply, NO_ERROR);
+  OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
+  char *reply = OR_ALIGNED_BUF_START (a_reply);
+
+  or_pack_int (reply, error_code);
   css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
 }

--- a/src/communication/network_interface_sr.h
+++ b/src/communication/network_interface_sr.h
@@ -231,4 +231,5 @@ extern void sloaddb_install_class (THREAD_ENTRY * thread_p, unsigned int rid, ch
 extern void sloaddb_load_batch (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void sloaddb_fetch_stats (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void sloaddb_destroy (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
+extern void sloaddb_interrupt (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 #endif /* _NETWORK_INTERFACE_SR_H_ */

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -850,13 +850,17 @@ net_server_init (void)
   req_p->processing_function = sloaddb_load_batch;
   req_p->name = "NET_SERVER_LD_LOAD_BATCH";
 
+  req_p = &net_Requests[NET_SERVER_LD_FETCH_STATS];
+  req_p->processing_function = sloaddb_fetch_stats;
+  req_p->name = "NET_SERVER_LD_FETCH_STATS";
+
   req_p = &net_Requests[NET_SERVER_LD_DESTROY];
   req_p->processing_function = sloaddb_destroy;
   req_p->name = "NET_SERVER_LD_DESTROY";
 
-  req_p = &net_Requests[NET_SERVER_LD_FETCH_STATS];
-  req_p->processing_function = sloaddb_fetch_stats;
-  req_p->name = "NET_SERVER_LD_FETCH_STATS";
+  req_p = &net_Requests[NET_SERVER_LD_INTERRUPT];
+  req_p->processing_function = sloaddb_interrupt;
+  req_p->name = "NET_SERVER_LD_INTERRUPT";
 
   /* checksumdb replication */
   req_p = &net_Requests[NET_SERVER_CHKSUM_REPL];

--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -251,10 +251,8 @@ namespace cubload
   }
 
   stats::stats ()
-    : defaults (0)
-    , total_objects (0)
-    , last_commit (0)
-    , errors (0)
+    : rows_committed (0)
+    , rows_failed (0)
     , error_message ()
     , is_failed (false)
     , is_completed (false)
@@ -264,10 +262,8 @@ namespace cubload
 
   // Copy constructor
   stats::stats (const stats &copy)
-    : defaults (copy.defaults)
-    , total_objects (copy.total_objects)
-    , last_commit (copy.last_commit)
-    , errors (copy.errors)
+    : rows_committed (copy.rows_committed)
+    , rows_failed (copy.rows_failed)
     , error_message (copy.error_message)
     , is_failed (copy.is_failed)
     , is_completed (copy.is_completed)
@@ -278,10 +274,8 @@ namespace cubload
   stats &
   stats::operator= (const stats &other)
   {
-    this->defaults = other.defaults;
-    this->total_objects = other.total_objects;
-    this->last_commit = other.last_commit;
-    this->errors = other.errors;
+    this->rows_committed = other.rows_committed;
+    this->rows_failed = other.rows_failed;
     this->error_message = other.error_message;
     this->is_failed = other.is_failed;
     this->is_completed = other.is_completed;
@@ -292,10 +286,8 @@ namespace cubload
   void
   stats::clear ()
   {
-    defaults = 0;
-    total_objects = 0;
-    last_commit = 0;
-    errors = 0;
+    rows_committed = 0;
+    rows_failed = 0;
     error_message.clear ();
     is_failed = false;
     is_completed = false;
@@ -304,10 +296,8 @@ namespace cubload
   void
   stats::pack (cubpacking::packer &serializator) const
   {
-    serializator.pack_int (defaults);
-    serializator.pack_int (total_objects);
-    serializator.pack_int (last_commit);
-    serializator.pack_int (errors);
+    serializator.pack_int (rows_committed);
+    serializator.pack_int (rows_failed);
     serializator.pack_string (error_message);
     serializator.pack_bool (is_failed);
     serializator.pack_bool (is_completed);
@@ -316,10 +306,8 @@ namespace cubload
   void
   stats::unpack (cubpacking::unpacker &deserializator)
   {
-    deserializator.unpack_int (defaults);
-    deserializator.unpack_int (total_objects);
-    deserializator.unpack_int (last_commit);
-    deserializator.unpack_int (errors);
+    deserializator.unpack_int (rows_committed);
+    deserializator.unpack_int (rows_failed);
     deserializator.unpack_string (error_message);
     deserializator.unpack_bool (is_failed);
     deserializator.unpack_bool (is_completed);
@@ -330,10 +318,8 @@ namespace cubload
   {
     size_t size = 0;
 
-    size += serializator.get_packed_int_size (size); // defaults
-    size += serializator.get_packed_int_size (size); // total_objects
-    size += serializator.get_packed_int_size (size); // last_commit
-    size += serializator.get_packed_int_size (size); // errors
+    size += serializator.get_packed_int_size (size); // rows_committed
+    size += serializator.get_packed_int_size (size); // rows_failed
     size += serializator.get_packed_string_size (error_message, size);
     size += serializator.get_packed_bool_size (size); // is_failed
     size += serializator.get_packed_bool_size (size); // is_completed

--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -239,7 +239,7 @@ namespace cubload
   struct stats : public cubpacking::packable_object
   {
     int rows_committed; // equivalent of 'last_commit' from SA_MODE
-    std::atomic_int current_line;
+    std::atomic<int> current_line;
     int last_committed_line;
     int rows_failed; // // equivalent of 'errors' from SA_MODE
     std::string error_message;

--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -46,7 +46,7 @@ namespace cubload
   {
     public:
       batch ();
-      batch (batch_id id, class_id clsid, std::string &content, int line_offset);
+      batch (batch_id id, class_id clsid, std::string &content, int line_offset, int rows);
 
       batch (batch &&other) noexcept; // MoveConstructible
       batch &operator= (batch &&other) noexcept; // MoveAssignable
@@ -58,6 +58,7 @@ namespace cubload
       class_id get_class_id () const;
       int get_line_offset () const;
       const std::string &get_content () const;
+      int get_rows_number () const;
 
       void pack (cubpacking::packer &serializator) const override;
       void unpack (cubpacking::unpacker &deserializator) override;
@@ -68,6 +69,7 @@ namespace cubload
       class_id m_clsid;
       std::string m_content;
       int m_line_offset;
+      int m_rows;
   };
 
   using batch_handler = std::function<int (const batch &)>;
@@ -236,8 +238,8 @@ namespace cubload
   struct stats : public cubpacking::packable_object
   {
     int defaults;
-    std::int64_t total_objects;
-    std::int64_t last_commit;
+    int total_objects;
+    int last_commit;
     int errors;
     std::string error_message;
     bool is_failed;

--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -237,10 +237,8 @@ namespace cubload
 
   struct stats : public cubpacking::packable_object
   {
-    int defaults;
-    int total_objects;
-    int last_commit;
-    int errors;
+    int rows_committed; // equivalent of 'last_commit' from SA_MODE
+    int rows_failed; // // equivalent of 'errors' from SA_MODE
     std::string error_message;
     bool is_failed;
     bool is_completed;

--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -26,6 +26,7 @@
 
 #include "packable_object.hpp"
 
+#include <atomic>
 #include <cassert>
 #include <functional>
 
@@ -238,6 +239,8 @@ namespace cubload
   struct stats : public cubpacking::packable_object
   {
     int rows_committed; // equivalent of 'last_commit' from SA_MODE
+    std::atomic_int current_line;
+    int last_committed_line;
     int rows_failed; // // equivalent of 'errors' from SA_MODE
     std::string error_message;
     bool is_failed;

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -67,6 +67,7 @@ static int index_file_start_line = 1;
 static FILE *loaddb_log_file;
 
 int interrupt_query = false;
+bool load_interrupted = false;
 
 static int ldr_validate_object_file (FILE * outfp, const char *argv0, load_args * args);
 static int ldr_check_file_name_and_line_no (load_args * args);
@@ -80,8 +81,12 @@ static int get_ignore_class_list (const char *filename);
 static void free_ignoreclasslist (void);
 static int ldr_compare_attribute_with_meta (char *table_name, char *meta, DB_ATTRIBUTE * attribute);
 static int ldr_compare_storage_order (FILE * schema_file);
-static void ldr_server_load (load_args * args, int *status, bool * interrupted);
 static void get_loaddb_args (UTIL_ARG_MAP * arg_map, load_args * args);
+
+static void ldr_server_load (load_args * args, int *status, bool * interrupted);
+static void register_signal_handlers ();
+static int load_object_file (load_args * args);
+static void print_er_msg ();
 
 /*
  * print_log_msg - print log message
@@ -114,6 +119,17 @@ print_log_msg (int verbose, const char *fmt, ...)
     {
       assert (false);
     }
+}
+
+static void
+print_er_msg ()
+{
+  if (!er_has_error ())
+    {
+      return;
+    }
+
+  fprintf (stderr, "%s\n", er_msg ());
 }
 
 /*
@@ -1150,40 +1166,23 @@ get_loaddb_args (UTIL_ARG_MAP * arg_map, load_args * args)
   args->table_name = args->table_name ? args->table_name : (char *) "";
 }
 
-void
+static void
 ldr_server_load (load_args * args, int *status, bool * interrupted)
 {
-  char object_file_abs_path[PATH_MAX];
+  register_signal_handlers ();
 
-  if (realpath (args->object_file, object_file_abs_path) == NULL)
+  int error_code = loaddb_init ();
+  if (error_code != NO_ERROR)
     {
-      fprintf (stderr, "ERROR: failed to resolve real path name for %s\n", args->object_file);
+      print_er_msg ();
       *status = 3;
       return;
     }
 
-  loaddb_init ();
-
-  int error_code = loaddb_load_object_file (object_file_abs_path);
-  if (error_code == ER_FILE_UNKNOWN_FILE)
-    {
-      /* *INDENT-OFF* */
-      std::string object_file_abs_path_ (object_file_abs_path);
-      batch_handler b_handler = [] (const batch &batch)
-      {
-	return loaddb_load_batch (batch);
-      };
-      batch_handler c_handler = [] (const batch &batch)
-      {
-	return loaddb_install_class (batch);
-      };
-      /* *INDENT-ON* */
-
-      error_code = split (args->periodic_commit, object_file_abs_path_, c_handler, b_handler);
-    }
-
+  error_code = load_object_file (args);
   if (error_code != NO_ERROR)
     {
+      print_er_msg ();
       *status = 3;
     }
 
@@ -1191,7 +1190,20 @@ ldr_server_load (load_args * args, int *status, bool * interrupted)
   long prev_last_commit = 0;
   do
     {
-      loaddb_fetch_stats (&stats);
+      if (load_interrupted)
+	{
+	  *interrupted = true;
+	  *status = 3;
+	  break;
+	}
+
+      error_code = loaddb_fetch_stats (&stats);
+      if (error_code != NO_ERROR)
+	{
+	  print_er_msg ();
+	  *status = 3;
+	  break;
+	}
 
       if (!stats.error_message.empty ())
 	{
@@ -1215,8 +1227,70 @@ ldr_server_load (load_args * args, int *status, bool * interrupted)
     }
   while (!(stats.is_completed || stats.is_failed) && *status != 3);
 
-  loaddb_destroy ();
-
+  loaddb_fetch_stats (&stats);
   print_log_msg (1, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB, LOADDB_MSG_INSERT_AND_FAIL_COUNT),
-		 stats.total_objects, stats.errors);
+		 stats.last_commit, stats.errors);
+
+  error_code = loaddb_destroy ();
+  if (error_code != NO_ERROR)
+    {
+      print_er_msg ();
+      *status = 3;
+      return;
+    }
+}
+
+static void
+register_signal_handlers ()
+{
+  /* *INDENT-OFF* */
+  SIG_HANDLER sig_handler = [] ()
+  {
+    load_interrupted = true;
+    loaddb_interrupt ();
+    print_er_msg ();
+
+    print_log_msg (1, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB, LOADDB_MSG_SIG1));
+    fprintf (stderr, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB, LOADDB_MSG_INTERRUPTED_ABORT));
+  };
+  /* *INDENT-ON* */
+
+  // register handlers for SIGINT and SIGQUIT signals
+  util_arm_signal_handlers (sig_handler, sig_handler);
+}
+
+
+static int
+load_object_file (load_args * args)
+{
+  // resolve absolute path for the object file
+  char object_file_abs_path[PATH_MAX];
+  if (realpath (args->object_file, object_file_abs_path) == NULL)
+    {
+      fprintf (stderr, "ERROR: failed to resolve real path name for %s\n", args->object_file);
+      return ER_FAILED;
+    }
+
+  /* *INDENT-OFF* */
+  std::string object_file_abs_path_str (object_file_abs_path);
+  /* *INDENT-ON* */
+
+  int error_code = loaddb_load_object_file (object_file_abs_path_str);
+  if (error_code == ER_FILE_UNKNOWN_FILE)
+    {
+      /* *INDENT-OFF* */
+      batch_handler b_handler = [] (const batch &batch)
+      {
+	return loaddb_load_batch (batch);
+      };
+      batch_handler c_handler = [] (const batch &batch)
+      {
+	return loaddb_install_class (batch);
+      };
+      /* *INDENT-ON* */
+
+      error_code = split (args->periodic_commit, object_file_abs_path_str, c_handler, b_handler);
+    }
+
+  return error_code;
 }

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1187,7 +1187,7 @@ ldr_server_load (load_args * args, int *status, bool * interrupted)
     }
 
   stats stats;
-  long prev_last_commit = 0;
+  int prev_rows_committed = 0;
   do
     {
       if (load_interrupted)
@@ -1212,12 +1212,14 @@ ldr_server_load (load_args * args, int *status, bool * interrupted)
 	}
       else
 	{
-	  long curr_last_commit = stats.last_commit;
-	  if (curr_last_commit > prev_last_commit)
+	  int curr_rows_committed = stats.rows_committed;
+	  // log committed instances msg only there was a commit since last check
+	  if (curr_rows_committed > prev_rows_committed)
 	    {
-	      print_log_msg (args->verbose_commit, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB,
-								   LOADDB_MSG_COMMITTED_INSTANCES), curr_last_commit);
-	      prev_last_commit = curr_last_commit;
+	      char *committed_instances_msg = msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB,
+							      LOADDB_MSG_COMMITTED_INSTANCES);
+	      print_log_msg (args->verbose_commit, committed_instances_msg, curr_rows_committed);
+	      prev_rows_committed = curr_rows_committed;
 	    }
 	}
 
@@ -1229,7 +1231,7 @@ ldr_server_load (load_args * args, int *status, bool * interrupted)
 
   loaddb_fetch_stats (&stats);
   print_log_msg (1, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB, LOADDB_MSG_INSERT_AND_FAIL_COUNT),
-		 stats.last_commit, stats.errors);
+		 stats.rows_committed, stats.rows_failed);
 
   error_code = loaddb_destroy ();
   if (error_code != NO_ERROR)

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -315,8 +315,6 @@ namespace cubload
 	return;
       }
 
-    m_session.stats_update_total_objects ();
-
     clear_db_values ();
   }
 

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -315,7 +315,7 @@ namespace cubload
 	return;
       }
 
-    m_session.inc_total_objects ();
+    m_session.stats_update_total_objects ();
 
     clear_db_values ();
   }

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -316,7 +316,7 @@ namespace cubload
 	return;
       }
 
-    m_session.stats_update_current_line (m_thread_ref->m_loaddb_driver->get_scanner ().lineno() + 1);
+    m_session.stats_update_current_line (m_thread_ref->m_loaddb_driver->get_scanner ().lineno () + 1);
     clear_db_values ();
   }
 

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -26,6 +26,7 @@
 #include "btree.h"
 #include "load_class_registry.hpp"
 #include "load_db_value_converter.hpp"
+#include "load_driver.hpp"
 #include "load_error_handler.hpp"
 #include "load_session.hpp"
 #include "locator_sr.h"
@@ -315,6 +316,7 @@ namespace cubload
 	return;
       }
 
+    m_session.stats_update_current_line (m_thread_ref->m_loaddb_driver->get_scanner ().lineno() + 1);
     clear_db_values ();
   }
 

--- a/src/loaddb/load_session.cpp
+++ b/src/loaddb/load_session.cpp
@@ -181,7 +181,7 @@ namespace cubload
 
 	    xtran_server_commit (&thread_ref, false);
 
-	    m_session.stats_update_last_commit (m_batch.get_rows_number ());
+	    m_session.stats_update_rows_committed (m_batch.get_rows_number ());
 	  }
 
 	// free transaction index
@@ -283,7 +283,7 @@ namespace cubload
   {
     std::unique_lock<std::mutex> ulock (m_stats_mutex);
 
-    m_stats.errors++;
+    m_stats.rows_failed++;
     m_stats.error_message.append (err_msg);
   }
 
@@ -318,17 +318,10 @@ namespace cubload
   }
 
   void
-  session::stats_update_total_objects ()
+  session::stats_update_rows_committed (int rows_committed)
   {
     std::unique_lock<std::mutex> ulock (m_stats_mutex);
-    m_stats.total_objects++;
-  }
-
-  void
-  session::stats_update_last_commit (int last_commit)
-  {
-    std::unique_lock<std::mutex> ulock (m_stats_mutex);
-    m_stats.last_commit += last_commit;
+    m_stats.rows_committed += rows_committed;
   }
 
   class_registry &

--- a/src/loaddb/load_session.cpp
+++ b/src/loaddb/load_session.cpp
@@ -181,8 +181,7 @@ namespace cubload
 
 	    xtran_server_commit (&thread_ref, false);
 
-	    // TODO fix last_commit assignment
-	    //m_session.m_stats.last_commit = m_batch.get_id () * m_session.m_batch_size;
+	    m_session.stats_update_last_commit (m_batch.get_rows_number ());
 	  }
 
 	// free transaction index
@@ -319,10 +318,17 @@ namespace cubload
   }
 
   void
-  session::inc_total_objects ()
+  session::stats_update_total_objects ()
   {
     std::unique_lock<std::mutex> ulock (m_stats_mutex);
     m_stats.total_objects++;
+  }
+
+  void
+  session::stats_update_last_commit (int last_commit)
+  {
+    std::unique_lock<std::mutex> ulock (m_stats_mutex);
+    m_stats.last_commit += last_commit;
   }
 
   class_registry &

--- a/src/loaddb/load_session.cpp
+++ b/src/loaddb/load_session.cpp
@@ -359,7 +359,7 @@ namespace cubload
 
     std::unique_lock<std::mutex> ulock (m_stats_mutex);
 
-    // check if failed after lock was acquired
+    // check if again after lock was acquired
     if (last_committed_line <= m_stats.last_committed_line)
       {
 	return;

--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -114,8 +114,7 @@ namespace cubload
       bool is_failed ();
 
       stats get_stats ();
-      void stats_update_total_objects ();
-      void stats_update_last_commit (int last_commit);
+      void stats_update_rows_committed (int rows_committed);
 
       class_registry &get_class_registry ();
 

--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -114,7 +114,8 @@ namespace cubload
       bool is_failed ();
 
       stats get_stats ();
-      void inc_total_objects ();
+      void stats_update_total_objects ();
+      void stats_update_last_commit (int last_commit);
 
       class_registry &get_class_registry ();
 

--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -118,12 +118,17 @@ namespace cubload
 
       stats get_stats ();
       void stats_update_rows_committed (int rows_committed);
+      void stats_update_last_committed_line (int last_committed_line);
+      void stats_update_current_line (int current_line);
 
       class_registry &get_class_registry ();
 
     private:
       void notify_waiting_threads ();
       bool is_completed ();
+
+      template<typename T>
+      void update_atomic_value_with_max (std::atomic<T> &atomic_val, T new_max);
 
       std::mutex m_commit_mutex;
       std::condition_variable m_commit_cond_var;

--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -38,6 +38,7 @@ namespace cubload
 {
 
   class driver;
+  class loaddb_worker_context_manager;
 
   /*
    * cubload::session
@@ -113,6 +114,8 @@ namespace cubload
       void fail ();
       bool is_failed ();
 
+      void interrupt ();
+
       stats get_stats ();
       void stats_update_rows_committed (int rows_committed);
 
@@ -133,7 +136,7 @@ namespace cubload
       std::atomic<batch_id> m_max_batch_id;
 
       cubthread::entry_workpool *m_worker_pool;
-      cubthread::entry_manager *m_wp_context_manager;
+      loaddb_worker_context_manager *m_wp_context_manager;
 
       class_registry m_class_registry;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22746

On SIGINT/SIGQUIT signal is CS_MODE, notify server loaddb session for interruption. As well when server is down, close the client and print an error message to stderr.