### PR TITLE
[CBRD-22744] xts_debug_clear

### DIFF
--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -212,7 +212,7 @@ namespace cubscan
     scanner::clear (xasl_node *xasl_p, bool is_final, bool is_final_clear)
     {
       // columns should be released every time
-      m_specp->m_root_node->clear_tree (is_final_clear);
+      m_specp->m_root_node->clear_xasl (is_final_clear);
       reset_ordinality (*m_specp->m_root_node);
 
       // all json documents should be release depending on is_final

--- a/src/query/xasl_to_stream.c
+++ b/src/query/xasl_to_stream.c
@@ -110,6 +110,8 @@ static int xts_save (const T &t);
 
 template <typename T>
 static void xts_debug_check (const T &t, char *pack_start, const char *pack_end);
+template <typename T>
+static void xts_debug_clear (T &t);
 // *INDENT-ON*
 
 static int xts_save_db_value_array (DB_VALUE ** ptr, int size);
@@ -7580,9 +7582,19 @@ xts_debug_check (const T &t, char *pack_start, const char *pack_end)
       assert (false);
     }
 
+  xts_debug_clear (unpack_t);
+
   xasl_unpack_info* unpack_info = stx_get_xasl_unpack_info_ptr (NULL);
   db_private_free_and_init (NULL, unpack_info);
   stx_set_xasl_unpack_info_ptr (NULL, NULL);
 #endif // DEBUG
 }
+
+template <typename T>
+static void
+xts_debug_clear (T &t)
+{
+  t.clear_xasl ();
+}
+
 // *INDENT-ON*

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -234,6 +234,19 @@ namespace cubxasl
       return error_code;
     }
 
+    void
+    column::clear_xasl (bool is_final_clear /* = true */)
+    {
+      if (is_final_clear)
+	{
+	  (void) pr_clear_value (m_on_empty.m_default_value);
+	  (void) pr_clear_value (m_on_error.m_default_value);
+	}
+
+      (void) pr_clear_value (m_output_value_pointer);
+      (void) db_make_null (m_output_value_pointer);
+    }
+
     node::node (void)
     {
       init ();
@@ -259,15 +272,7 @@ namespace cubxasl
       init_ordinality ();
       for (size_t i = 0; i < m_output_columns_size; ++i)
 	{
-	  column *output_column = &m_output_columns[i];
-	  if (is_final_clear)
-	    {
-	      (void) pr_clear_value (output_column->m_on_empty.m_default_value);
-	      (void) pr_clear_value (output_column->m_on_error.m_default_value);
-	    }
-
-	  (void) pr_clear_value (output_column->m_output_value_pointer);
-	  (void) db_make_null (output_column->m_output_value_pointer);
+	  m_output_columns[i].clear_xasl (is_final_clear);
 	}
     }
 
@@ -290,13 +295,13 @@ namespace cubxasl
     }
 
     void
-    node::clear_tree (bool is_final_clear)
+    node::clear_xasl (bool is_final_clear /* = true */)
     {
       clear_columns (is_final_clear);
 
       for (size_t i = 0; i < m_nested_nodes_size; ++i)
 	{
-	  m_nested_nodes[i].clear_tree (is_final_clear);
+	  m_nested_nodes[i].clear_xasl (is_final_clear);
 	}
     }
 
@@ -326,6 +331,13 @@ namespace cubxasl
       m_root_node = NULL;
       m_json_reguvar = NULL;
       m_node_count = 0;
+    }
+
+    void
+    spec_node::clear_xasl (bool is_final_clear /* = true */)
+    {
+      // todo reguvar
+      m_root_node->clear_xasl (is_final_clear);
     }
 
   } // namespace json_table

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -244,7 +244,10 @@ namespace cubxasl
 	}
 
       (void) pr_clear_value (m_output_value_pointer);
-      (void) db_make_null (m_output_value_pointer);
+      if (m_output_value_pointer != NULL)
+	{
+	  (void) db_make_null (m_output_value_pointer);
+	}
     }
 
     node::node (void)

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -243,9 +243,9 @@ namespace cubxasl
 	  (void) pr_clear_value (m_on_error.m_default_value);
 	}
 
-      (void) pr_clear_value (m_output_value_pointer);
       if (m_output_value_pointer != NULL)
 	{
+	  (void) pr_clear_value (m_output_value_pointer);
 	  (void) db_make_null (m_output_value_pointer);
 	}
     }

--- a/src/xasl/access_json_table.hpp
+++ b/src/xasl/access_json_table.hpp
@@ -61,6 +61,7 @@ namespace cubxasl
 
 	void init ();
 	int evaluate (const JSON_DOC &input, size_t ordinality);
+	void clear_xasl (bool is_final_clear = true);
 
       private:
 	int evaluate_extract (const JSON_DOC &input);
@@ -88,7 +89,7 @@ namespace cubxasl
       void init ();
       void clear_columns (bool is_final_clear);
       void clear_iterators (bool is_final_clear);
-      void clear_tree (bool is_final_clear);
+      void clear_xasl (bool is_final_clear = true);
       void init_iterator ();
       void init_ordinality ();
     };
@@ -102,6 +103,7 @@ namespace cubxasl
       spec_node ();
 
       void init ();
+      void clear_xasl (bool is_final_clear = true);
     };
 
   } // namespace json_table


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22744

Clear the resources allocated by xts_debug_check.

Added an interface function clear_xasl to be used by XASL structures. It will be called by xts_debug_clear by default.

xts_debug_clear can be overloaded.