### PR TITLE
[CBRD-22759] Header file for inline macros

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -126,15 +126,16 @@ set(BASE_HEADERS
   ${BASE_DIR}/error_context.hpp
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
+  ${BASE_DIR}/fileline_location.hpp
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_private_allocator.hpp
-  ${BASE_DIR}/fileline_location.hpp
+  ${BASE_DIR}/packable_object.hpp
   ${BASE_DIR}/packer.hpp
   ${BASE_DIR}/perf.hpp
   ${BASE_DIR}/perf_def.hpp
   ${BASE_DIR}/pinning.hpp
   ${BASE_DIR}/pinnable_buffer.hpp
-  ${BASE_DIR}/packable_object.hpp
+  ${BASE_DIR}/porting_inline.hpp
   ${BASE_DIR}/string_buffer.hpp
   ${BASE_DIR}/resource_tracker.hpp
   )

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -131,12 +131,13 @@ set (BASE_HEADERS
   ${BASE_DIR}/fileline_location.hpp
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_private_allocator.hpp
+  ${BASE_DIR}/packable_object.hpp
   ${BASE_DIR}/packer.hpp
   ${BASE_DIR}/perf.hpp
   ${BASE_DIR}/perf_def.hpp
   ${BASE_DIR}/pinning.hpp
   ${BASE_DIR}/pinnable_buffer.hpp
-  ${BASE_DIR}/packable_object.hpp
+  ${BASE_DIR}/porting_inline.hpp
   ${BASE_DIR}/process_util.h
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/string_buffer.hpp

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -127,12 +127,13 @@ set(BASE_HEADERS
   ${BASE_DIR}/fileline_location.hpp
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_private_allocator.cpp
+  ${BASE_DIR}/packable_object.hpp
   ${BASE_DIR}/packer.hpp
   ${BASE_DIR}/perf.hpp
   ${BASE_DIR}/perf_def.hpp
   ${BASE_DIR}/pinning.hpp
   ${BASE_DIR}/pinnable_buffer.hpp
-  ${BASE_DIR}/packable_object.hpp
+  ${BASE_DIR}/porting_inline.hpp
   ${BASE_DIR}/resource_tracker.hpp
 )
 

--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -43,6 +43,7 @@
 #include "oid.h"
 #include "byte_order.h"
 #include "memory_alloc.h"
+#include "porting_inline.hpp"
 
 /*
  * NUMERIC TYPE SIZES

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -35,6 +35,7 @@
 #include "log_impl.h"
 #endif // SERVER_MODE or SA_MODE
 #include "memory_alloc.h"
+#include "porting_inline.hpp"
 #include "storage_common.h"
 #include "thread_compat.hpp"
 #include "tsc_timer.h"

--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -37,25 +37,6 @@
 #define __attribute__(X)
 #endif
 
-#if defined (__GNUC__) && defined (NDEBUG)
-#define ALWAYS_INLINE always_inline
-#else
-#define ALWAYS_INLINE
-#endif
-
-#if defined (__cplusplus) || defined (__GNUC__)
-#define STATIC_INLINE static inline
-#define INLINE inline
-#elif _MSC_VER >= 1000
-#define STATIC_INLINE __forceinline static
-#define INLINE __forceinline
-#else
-/* TODO: we have several cases of using INLINE/STATIC_INLINE and adding function definition in headers. This won't
- * work. */
-#define STATIC_INLINE static
-#define INLINE
-#endif
-
 #if defined (__GNUC__) && defined (__GNUC_MINOR__) && defined (__GNUC_PATCHLEVEL__)
 #define CUB_GCC_VERSION (__GNUC__ * 10000 \
 			 + __GNUC_MINOR__ * 100 \

--- a/src/base/porting_inline.hpp
+++ b/src/base/porting_inline.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+//
+// porting inline
+//
+
+#ifndef _PORTING_INLINE_HPP_
+#define _PORTING_INLINE_HPP_
+
+#if !defined (__GNUC__)
+#define __attribute__(X)
+#endif
+
+#if defined (__GNUC__) && defined (NDEBUG)
+#define ALWAYS_INLINE always_inline
+#else
+#define ALWAYS_INLINE
+#endif
+
+#if defined (__cplusplus) || defined (__GNUC__)
+#define STATIC_INLINE static inline
+#define INLINE inline
+#elif _MSC_VER >= 1000
+#define STATIC_INLINE __forceinline static
+#define INLINE __forceinline
+#else
+/* TODO: we have several cases of using INLINE/STATIC_INLINE and adding function definition in headers. This won't
+ * work. */
+#define STATIC_INLINE static
+#define INLINE
+#endif
+
+#endif // _PORTING_INLINE_HPP_

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -31,6 +31,7 @@
 #include <assert.h>
 
 #include "porting.h"
+#include "porting_inline.hpp"
 #include "perf_monitor.h"
 #include "memory_alloc.h"
 #include "storage_common.h"

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -60,6 +60,7 @@
 #include "memory_alloc.h"
 #include "memory_private_allocator.hpp"
 #include "object_primitive.h"
+#include "porting_inline.hpp"
 #include "query_dump.h"
 #include "string_opfunc.h"
 #include "system_parameter.h"

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -25,26 +25,7 @@
 #include "dbtype_def.h"
 
 #if !defined (_NO_INLINE_DBTYPE_FUNCTION_)
-// copied from porting.h
-#if defined (__GNUC__) && defined (NDEBUG)
-#define ALWAYS_INLINE always_inline
-#else
-#define ALWAYS_INLINE
-#endif
-
-#if defined (__cplusplus) || defined (__GNUC__)
-#define STATIC_INLINE static inline
-#define INLINE inline
-#elif _MSC_VER >= 1000
-#define STATIC_INLINE __forceinline static
-#define INLINE __forceinline
-#else
-/* TODO: we have several cases of using INLINE/STATIC_INLINE and adding function definition in headers. This won't
- * work. */
-#define STATIC_INLINE static
-#define INLINE
-#endif
-// end of porting.h copy
+#include "porting_inline.hpp"
 
 STATIC_INLINE int db_get_int (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_C_SHORT db_get_short (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -41,6 +41,7 @@
 #include "tz_support.h"
 #include "db_date.h"
 #include "mprec.h"
+#include "porting_inline.hpp"
 #include "set_object.h"
 #include "string_opfunc.h"
 #include "tz_support.h"

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -41,6 +41,7 @@
 #include "object_primitive.h"
 #include "object_representation.h"
 #include "oid.h"
+#include "porting_inline.hpp"
 #include "query_list.h"
 #include "set_object.h"
 

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -32,6 +32,7 @@
 #include "disk_manager.h"
 #include "log_impl.h"
 #include "recovery.h"
+#include "porting_inline.hpp"
 #include "storage_common.h"
 #include "system_parameter.h"
 #include "thread_entry.hpp"

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -45,6 +45,7 @@
 #include "utility.h"
 #include "transform.h"
 #include "partition_sr.h"
+#include "porting_inline.hpp"
 #include "query_executor.h"
 #include "object_primitive.h"
 #include "perf_monitor.h"

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -39,6 +39,7 @@
 
 #include "disk_manager.h"
 #include "porting.h"
+#include "porting_inline.hpp"
 #include "system_parameter.h"
 #include "error_manager.h"
 #include "language_support.h"

--- a/src/storage/double_write_buffer.c
+++ b/src/storage/double_write_buffer.c
@@ -26,14 +26,16 @@
 #include <assert.h>
 #include <math.h>
 
-#include "system_parameter.h"
 #include "double_write_buffer.h"
+
+#include "system_parameter.h"
 #include "thread_daemon.hpp"
 #include "thread_entry_task.hpp"
 #include "thread_manager.hpp"
 #include "log_impl.h"
 #include "boot_sr.h"
 #include "perf_monitor.h"
+#include "porting_inline.hpp"
 
 
 #define DWB_SLOTS_HASH_SIZE		    1000

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -34,6 +34,7 @@
 #include "lzo/lzo1x.h"
 #include "memory_hash.h"
 #include "porting.h"
+#include "porting_inline.hpp"
 #include "release_string.h"
 #include "storage_common.h"
 #include "thread_compat.hpp"

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -33,6 +33,7 @@
 
 #include "btree.h"
 #include "porting.h"
+#include "porting_inline.hpp"
 #include "file_manager.h"
 #include "memory_alloc.h"
 #include "storage_common.h"

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -37,6 +37,7 @@
 #include "heap_file.h"
 
 #include "porting.h"
+#include "porting_inline.hpp"
 #include "slotted_page.h"
 #include "overflow_file.h"
 #include "boot_sr.h"

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -31,6 +31,7 @@
 #include <assert.h>
 
 #include "page_buffer.h"
+
 #include "storage_common.h"
 #include "memory_alloc.h"
 #include "system_parameter.h"
@@ -43,6 +44,7 @@
 #include "memory_hash.h"
 #include "critical_section.h"
 #include "perf_monitor.h"
+#include "porting_inline.hpp"
 #include "environment_variable.h"
 #include "thread_daemon.hpp"
 #include "thread_entry_task.hpp"

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -37,6 +37,7 @@
 #include "system_parameter.h"
 #include "memory_hash.h"
 #include "page_buffer.h"
+#include "porting_inline.hpp"
 #include "log_manager.h"
 #include "critical_section.h"
 #include "lock_free.h"

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -36,6 +36,7 @@
 #include <assert.h>
 
 #include "porting.h"
+#include "porting_inline.hpp"
 #include "dbtype_def.h"
 #include "sha1.h"
 #include "cache_time.h"

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -57,6 +57,7 @@
 #include "language_support.h"
 #include "message_catalog.h"
 #include "perf_monitor.h"
+#include "porting_inline.hpp"
 #include "set_object.h"
 #include "util_func.h"
 #include "intl_support.h"

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -51,6 +51,7 @@
 #include "recovery.h"
 #include "xserver_interface.h"
 #include "page_buffer.h"
+#include "porting_inline.hpp"
 #include "query_manager.h"
 #include "message_catalog.h"
 #include "environment_variable.h"

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -52,6 +52,7 @@
 #include <assert.h>
 
 #include "porting.h"
+#include "porting_inline.hpp"
 #include "connection_defs.h"
 #include "log_impl.h"
 #include "log_manager.h"

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -43,6 +43,7 @@
 #include "boot_sr.h"
 #include "locator_sr.h"
 #include "page_buffer.h"
+#include "porting_inline.hpp"
 #include "log_compress.h"
 #include "thread_entry.hpp"
 #include "thread_manager.hpp"

--- a/src/transaction/mvcc.c
+++ b/src/transaction/mvcc.c
@@ -29,6 +29,7 @@
 #include "page_buffer.h"
 #include "overflow_file.h"
 #include "perf_monitor.h"
+#include "porting_inline.hpp"
 #include "vacuum.h"
 
 #define MVCC_IS_REC_INSERTER_ACTIVE(thread_p, rec_header_p) \


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22759

Move all macros related to cross-platform compatibility of inline functionality to porting_inline.hpp.