### PR TITLE
[CBRD-22768] Move code from dbtype_def.h to dbtran_def.h

### DIFF
--- a/cci/CMakeLists.txt
+++ b/cci/CMakeLists.txt
@@ -43,7 +43,7 @@ SET_SOURCE_FILES_PROPERTIES(
 
 add_library(cascci SHARED ${CASCCI_SOURCES})
 set_target_properties(cascci PROPERTIES SOVERSION "${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}")
-set_target_properties(cascci PROPERTIES PUBLIC_HEADER "${CCI_DIR}/cas_cci.h;${BROKER_DIR}/cas_error.h")
+set_target_properties(cascci PROPERTIES PUBLIC_HEADER "${CCI_DIR}/cas_cci.h;${COMPAT_DIR}/dbtran_def.h;${BROKER_DIR}/cas_error.h")
 target_include_directories(cascci PRIVATE ${EP_INCLUDES})
 target_link_libraries(cascci LINK_PRIVATE ${EP_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 if(WIN32)

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -492,6 +492,7 @@ install(FILES
   RENAME dbi.h
   )
 install(FILES
+  ${COMPAT_DIR}/dbtran_def.h
   ${COMPAT_DIR}/dbtype_def.h
   ${COMPAT_DIR}/dbtype_function.h
   ${COMPAT_DIR}/db_date.h

--- a/src/cci/cas_cci.h
+++ b/src/cci/cas_cci.h
@@ -44,6 +44,7 @@
  * IMPORTED OTHER HEADER FILES						*
  ************************************************************************/
 #include "cas_error.h"
+#include "dbtran_def.h"
 
 /************************************************************************
  * EXPORTED DEFINITIONS							*
@@ -727,27 +728,7 @@ typedef enum
   CCI_DS_KEY_MAX_POOL_SIZE
 } T_CCI_DATASOURCE_KEY;
 
-#if !defined(CAS)
-#ifdef DBDEF_HEADER_
-typedef int T_CCI_TRAN_ISOLATION;
-#else
-typedef enum
-{
-  TRAN_UNKNOWN_ISOLATION = 0,
-  TRAN_ISOLATION_MIN = 4,
-
-  TRAN_READ_COMMITTED = 4,
-  TRAN_REP_CLASS_COMMIT_INSTANCE = 4,	/* for backward compatibility */
-
-  TRAN_REPEATABLE_READ = 5,
-  TRAN_REP_CLASS_REP_INSTANCE = 5,	/* for backward compatibility */
-
-  TRAN_SERIALIZABLE = 6,
-
-  TRAN_ISOLATION_MAX = 6
-} T_CCI_TRAN_ISOLATION;
-#endif
-#endif
+typedef DB_TRAN_ISOLATION T_CCI_TRAN_ISOLATION;	// alias
 
 typedef enum
 {

--- a/src/compat/dbi.h
+++ b/src/compat/dbi.h
@@ -34,6 +34,8 @@
 
 #include <stdio.h>
 #include <time.h>
+
+#include "dbtran_def.h"
 #include "dbtype_def.h"
 #include "db_date.h"
 #include "db_elo.h"

--- a/src/compat/dbi_compat.h
+++ b/src/compat/dbi_compat.h
@@ -40,6 +40,7 @@
 #define u_int64_t unsigned __int64
 #endif /* WINDOWS && !__GNUC__ */
 
+#include "dbtran_def.h"
 #include "dbtype_def.h"
 #include "error_code.h"
 #include "dbtype_function.h"

--- a/src/compat/dbtran_def.h
+++ b/src/compat/dbtran_def.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * Transaction isolation definitions
+ */
+
+#ifndef _DBTRAN_DEF_H_
+#define _DBTRAN_DEF_H_
+
+typedef enum
+{
+  TRAN_UNKNOWN_ISOLATION = 0x00,	/* 0 0000 */
+
+  TRAN_READ_COMMITTED = 0x04,	/* 0 0100 */
+  TRAN_REP_CLASS_COMMIT_INSTANCE = 0x04,	/* Alias of above */
+  TRAN_CURSOR_STABILITY = 0x04,	/* Alias of above */
+
+  TRAN_REPEATABLE_READ = 0x05,	/* 0 0101 */
+  TRAN_REP_READ = 0x05,		/* Alias of above */
+  TRAN_REP_CLASS_REP_INSTANCE = 0x05,	/* Alias of above */
+  TRAN_DEGREE_2_9999_CONSISTENCY = 0x05,	/* Alias of above */
+
+  TRAN_SERIALIZABLE = 0x06,	/* 0 0110 */
+  TRAN_DEGREE_3_CONSISTENCY = 0x06,	/* Alias of above */
+  TRAN_NO_PHANTOM_READ = 0x06,	/* Alias of above */
+
+  TRAN_DEFAULT_ISOLATION = TRAN_READ_COMMITTED,
+  MVCC_TRAN_DEFAULT_ISOLATION = TRAN_READ_COMMITTED,
+
+  TRAN_MINVALUE_ISOLATION = 0x04,	/* internal use only */
+  TRAN_MAXVALUE_ISOLATION = 0x06	/* internal use only */
+} DB_TRAN_ISOLATION;
+
+#define IS_VALID_ISOLATION_LEVEL(isolation_level) \
+    (TRAN_MINVALUE_ISOLATION <= (isolation_level) \
+     && (isolation_level) <= TRAN_MAXVALUE_ISOLATION)
+
+#define TRAN_DEFAULT_ISOLATION_LEVEL()	(TRAN_DEFAULT_ISOLATION)
+
+#define TRAN_ASYNC_WS_BIT                        0x10	/* 1 0000 */
+#define TRAN_ISO_LVL_BITS                        0x0F	/* 0 1111 */
+
+#endif // _DBTRAN_DEF_H_

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -42,12 +42,6 @@ extern "C"
   typedef char need_clear_type;
 #endif
 
-#define IS_VALID_ISOLATION_LEVEL(isolation_level) \
-    (TRAN_MINVALUE_ISOLATION <= (isolation_level) \
-     && (isolation_level) <= TRAN_MAXVALUE_ISOLATION)
-
-#define TRAN_DEFAULT_ISOLATION_LEVEL()	(TRAN_DEFAULT_ISOLATION)
-
 #if defined (__GNUC__) && defined (NDEBUG)
 #define ALWAYS_INLINE always_inline
 #else
@@ -75,29 +69,6 @@ extern "C"
 
   /******************************************/
   /* From cubrid_api.h */
-  typedef enum
-  {
-    TRAN_UNKNOWN_ISOLATION = 0x00,	/* 0 0000 */
-
-    TRAN_READ_COMMITTED = 0x04,	/* 0 0100 */
-    TRAN_REP_CLASS_COMMIT_INSTANCE = 0x04,	/* Alias of above */
-    TRAN_CURSOR_STABILITY = 0x04,	/* Alias of above */
-
-    TRAN_REPEATABLE_READ = 0x05,	/* 0 0101 */
-    TRAN_REP_READ = 0x05,	/* Alias of above */
-    TRAN_REP_CLASS_REP_INSTANCE = 0x05,	/* Alias of above */
-    TRAN_DEGREE_2_9999_CONSISTENCY = 0x05,	/* Alias of above */
-
-    TRAN_SERIALIZABLE = 0x06,	/* 0 0110 */
-    TRAN_DEGREE_3_CONSISTENCY = 0x06,	/* Alias of above */
-    TRAN_NO_PHANTOM_READ = 0x06,	/* Alias of above */
-
-    TRAN_DEFAULT_ISOLATION = TRAN_READ_COMMITTED,
-    MVCC_TRAN_DEFAULT_ISOLATION = TRAN_READ_COMMITTED,
-
-    TRAN_MINVALUE_ISOLATION = 0x04,	/* internal use only */
-    TRAN_MAXVALUE_ISOLATION = 0x06	/* internal use only */
-  } DB_TRAN_ISOLATION;
 
   typedef enum
   {
@@ -183,9 +154,6 @@ extern "C"
    *       then we can move all this back to dbdef, include dbdef in dbtype_common and add dbdef to the list of exposed
    *       headers.
    */
-
-#define TRAN_ASYNC_WS_BIT                        0x10	/* 1 0000 */
-#define TRAN_ISO_LVL_BITS                        0x0F	/* 0 1111 */
 
 #define DB_AUTH_ALL \
   ((DB_AUTH) (DB_AUTH_SELECT | DB_AUTH_INSERT | DB_AUTH_UPDATE | DB_AUTH_DELETE | \

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -30,6 +30,7 @@
 #include <assert.h>
 
 #include "csql.h"
+#include "dbtran_def.h"
 #include "dbtype.h"
 #include "memory_alloc.h"
 #include "object_primitive.h"

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -46,6 +46,7 @@
 
 #include "btree.h"
 #include "chartype.h"
+#include "dbtran_def.h"
 #include "error_manager.h"
 #include "system_parameter.h"
 #include "object_primitive.h"

--- a/src/transaction/log_comm.h
+++ b/src/transaction/log_comm.h
@@ -23,6 +23,8 @@
 #ident "$Id$"
 
 #include <stdio.h>
+
+#include "dbtran_def.h"
 #include "storage_common.h"
 #include "object_representation.h"
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -46,6 +46,7 @@
 #include <sys/stat.h>
 #include <assert.h>
 
+#include "dbtran_def.h"
 #include "log_impl.h"
 #include "log_system_tran.hpp"
 #include "error_manager.h"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22768

Separate transaction related code of dbtype_def.h and move to dbtran_def.h. File is exposed to CUBRID includes.