### PR TITLE
[CBRD-22773] Fix recycling index build thread entry

### DIFF
--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -166,6 +166,7 @@ class index_builder_loader_context : public cubthread::entry_manager
   protected:
     void on_create (context_type & context) override;
     void on_retire (context_type & context) override;
+    void on_recycle (context_type & context) override;
 };
 
 struct index_builder_key_oid
@@ -5019,6 +5020,12 @@ void
 index_builder_loader_context::on_retire (context_type & context)
 {
   context.retire_system_worker ();
+}
+
+void
+index_builder_loader_context::on_recycle (context_type & context)
+{
+  context.tran_index = LOG_SYSTEM_TRAN_INDEX;
 }
 
 index_builder_loader_task::index_builder_loader_task (const BTID * btid, const OID * class_oid, int unique_pk,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22773

Set transaction index to LOG_SYSTEM_TRAN_INDEX when recycling thread entry for index builder. By default, recycle sets transaction index to NULL_TRAN_INDEX, thus invalidating the system worker.

We might consider avoid setting NULL_TRAN_INDEX altogether.