### PR TITLE
[CBRD-22768] quick fix for windows build issue

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -500,7 +500,7 @@ install(FILES
   RENAME dbi.h
   )
 install(FILES
-  ${COMPAT_DIR}/dbtran_def.h
+  # ${COMPAT_DIR}/dbtran_def.h // temporary disabled
   ${COMPAT_DIR}/dbtype_def.h
   ${COMPAT_DIR}/dbtype_function.h
   ${COMPAT_DIR}/db_date.h


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22768

Remove duplicate dbtran_def.h install as quick fix.

TODO: make a proper fix by setting properly project dependencies and fixing CMS build.