### PR TITLE
[CBRD-22797] Avoid superfluous copying in db_value_to_json_doc

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -135,6 +135,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
   ${BASE_DIR}/mem_block.hpp
+  ${BASE_DIR}/memory_reference_store.hpp
   ${BASE_DIR}/memory_private_allocator.hpp
   ${BASE_DIR}/msgcat_set_log.hpp
   ${BASE_DIR}/packable_object.hpp

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -137,6 +137,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
   ${BASE_DIR}/mem_block.hpp
+  ${BASE_DIR}/memory_reference_store.hpp
   ${BASE_DIR}/memory_private_allocator.hpp
   ${BASE_DIR}/msgcat_set_log.hpp
   ${BASE_DIR}/packable_object.hpp

--- a/src/base/memory_private_allocator.hpp
+++ b/src/base/memory_private_allocator.hpp
@@ -171,34 +171,6 @@ namespace cubmem
       std::unique_ptr<T, private_pointer_deleter<T>> m_smart_ptr;
   };
 
-  template <typename T>
-  class reference_store
-  {
-    public:
-      reference_store ();
-      reference_store &operator= (reference_store &&);
-
-      reference_store (reference_store &) = delete;
-      reference_store &operator= (reference_store &) = delete;
-
-      const T *get_immutable_reference () const;
-      bool is_mutable () const;
-      T *get_mutable_reference () const;
-      T *release_mutable_reference ();
-
-      void create_mutable_reference ();
-      void set_immutable_reference (T *ptr);
-      void set_mutable_reference (T *ptr);
-
-      void delete_mutable ();
-      void clear ();
-      ~reference_store ();
-    private:
-
-      const T *m_immutable_reference;
-      T *m_mutable_reference;
-  };
-
   extern const block_allocator PRIVATE_BLOCK_ALLOCATOR;
 
   // Calls func with the global heap set for allocating memory
@@ -373,103 +345,6 @@ namespace cubmem
   private_unique_ptr<T>::operator* () const
   {
     return *m_smart_ptr.get ();
-  }
-
-  template <class T>
-  reference_store<T>::reference_store ()
-    : m_immutable_reference (nullptr)
-    , m_mutable_reference (nullptr)
-  {
-
-  }
-
-  template <class T>
-  reference_store<T> &
-  reference_store<T>::operator= (reference_store<T> &&other)
-  {
-    if (this != &other)
-      {
-	std::swap (m_mutable_reference, other.m_mutable_reference);
-	std::swap (m_immutable_reference, other.m_immutable_reference);
-      }
-    return *this;
-  }
-
-  template <class T>
-  const T *
-  reference_store<T>::get_immutable_reference () const
-  {
-    assert (m_immutable_reference != nullptr);
-    return m_immutable_reference;
-  }
-
-  template <class T>
-  bool
-  reference_store<T>::is_mutable () const
-  {
-    return m_mutable_reference != nullptr;
-  }
-
-  template <class T>
-  T *
-  reference_store<T>::get_mutable_reference () const
-  {
-    assert (is_mutable ());
-    return m_mutable_reference;
-  }
-
-  template <class T>
-  T *
-  reference_store<T>::release_mutable_reference ()
-  {
-    assert (is_mutable ());
-    T *ret_ref = m_mutable_reference;
-    m_immutable_reference = m_mutable_reference = nullptr;
-    return ret_ref;
-  }
-
-  template <class T>
-  void
-  reference_store<T>::set_immutable_reference (T *ptr)
-  {
-    if (ptr != m_mutable_reference)
-      {
-	// we should not clear the doc we assign to ourselves
-	clear ();
-      }
-
-    m_mutable_reference = nullptr;
-    m_immutable_reference = ptr;
-  }
-
-  template <class T>
-  void
-  reference_store<T>::set_mutable_reference (T *ptr)
-  {
-    if (ptr != m_mutable_reference)
-      {
-	clear ();
-	m_immutable_reference = m_mutable_reference = ptr;
-      }
-
-  }
-
-  template <class T>
-  void
-  reference_store<T>::clear ()
-  {
-    if (is_mutable ())
-      {
-	delete_mutable ();
-	m_mutable_reference = nullptr;
-      }
-    m_immutable_reference = nullptr;
-  }
-
-  template <class T>
-  reference_store<T>::~reference_store ()
-  {
-    clear ();
   }
 
   template < typename Func, typename...Args >

--- a/src/base/memory_reference_store.hpp
+++ b/src/base/memory_reference_store.hpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+//
+// memory_reference_store.hpp - extension to handle permanent & temporary ownership of db_vals
+//
+
+namespace cubmem
+{
+  template <typename T>
+  class reference_store
+  {
+    public:
+      reference_store ();
+      reference_store &operator= (reference_store &&);
+
+      reference_store (reference_store &) = delete;
+      reference_store &operator= (reference_store &) = delete;
+
+      const T *get_immutable () const;
+      bool is_mutable () const;
+      T *get_mutable () const;
+      T *release_mutable_reference ();
+
+      void create_mutable_reference ();
+      void set_immutable_reference (T *ptr);
+      void set_mutable_reference (T *ptr);
+
+      void clear ();
+      ~reference_store ();
+    private:
+      void delete_mutable ();
+
+      const T *m_immutable_reference;
+      T *m_mutable_reference;
+  };
+}
+
+namespace cubmem
+{
+  template <class T>
+  reference_store<T>::reference_store ()
+    : m_immutable_reference (nullptr)
+    , m_mutable_reference (nullptr)
+  {
+
+  }
+
+  template <class T>
+  reference_store<T> &
+  reference_store<T>::operator= (reference_store<T> &&other)
+  {
+    if (this != &other)
+      {
+	std::swap (m_mutable_reference, other.m_mutable_reference);
+	std::swap (m_immutable_reference, other.m_immutable_reference);
+      }
+    return *this;
+  }
+
+  template <class T>
+  const T *
+  reference_store<T>::get_immutable () const
+  {
+    return m_immutable_reference;
+  }
+
+  template <class T>
+  bool
+  reference_store<T>::is_mutable () const
+  {
+    return m_mutable_reference != nullptr;
+  }
+
+  template <class T>
+  T *
+  reference_store<T>::get_mutable () const
+  {
+    assert (is_mutable ());
+    return m_mutable_reference;
+  }
+
+  template <class T>
+  T *
+  reference_store<T>::release_mutable_reference ()
+  {
+    assert (is_mutable ());
+    T *ret_ref = m_mutable_reference;
+    m_immutable_reference = m_mutable_reference = nullptr;
+    return ret_ref;
+  }
+
+  template <class T>
+  void
+  reference_store<T>::set_immutable_reference (T *ptr)
+  {
+    if (ptr != m_mutable_reference)
+      {
+	// we should not clear the doc we assign to ourselves
+	clear ();
+      }
+
+    m_mutable_reference = nullptr;
+    m_immutable_reference = ptr;
+  }
+
+  template <class T>
+  void
+  reference_store<T>::set_mutable_reference (T *ptr)
+  {
+    if (ptr != m_mutable_reference)
+      {
+	clear ();
+	m_immutable_reference = m_mutable_reference = ptr;
+      }
+  }
+
+  template <class T>
+  void
+  reference_store<T>::clear ()
+  {
+    if (is_mutable ())
+      {
+	delete_mutable ();
+	m_mutable_reference = nullptr;
+      }
+    m_immutable_reference = nullptr;
+  }
+
+  template <class T>
+  reference_store<T>::~reference_store ()
+  {
+    clear ();
+  }
+}

--- a/src/base/memory_reference_store.hpp
+++ b/src/base/memory_reference_store.hpp
@@ -21,6 +21,11 @@
 // memory_reference_store.hpp - extension to handle permanent & temporary ownership of db_vals
 //
 
+#ifndef _MEMORY_REFERENCE_STORE_HPP_
+#define _MEMORY_REFERENCE_STORE_HPP_
+
+#include <algorithm>
+
 namespace cubmem
 {
   template <typename T>
@@ -149,3 +154,5 @@ namespace cubmem
     clear ();
   }
 }
+
+#endif // _MEMORY_REFERENCE_STORE_HPP_

--- a/src/base/memory_reference_store.hpp
+++ b/src/base/memory_reference_store.hpp
@@ -18,7 +18,7 @@
  */
 
 //
-// memory_reference_store.hpp - extension to handle permanent & temporary ownership of db_vals
+// memory_reference_store.hpp - extension to handle permanent & temporary ownership
 //
 
 #ifndef _MEMORY_REFERENCE_STORE_HPP_
@@ -39,6 +39,7 @@ namespace cubmem
       reference_store &operator= (reference_store &) = delete;
 
       const T *get_immutable () const;
+      bool is_null () const;
       bool is_mutable () const;
       T *get_mutable () const;
       T *release_mutable_reference ();
@@ -84,6 +85,13 @@ namespace cubmem
   reference_store<T>::get_immutable () const
   {
     return m_immutable_reference;
+  }
+
+  template <class T>
+  bool
+  reference_store<T>::is_null () const
+  {
+    return m_immutable_reference == nullptr;
   }
 
   template <class T>

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -139,12 +139,10 @@ JSON_DOC_WRAPPER::borrow_doc (JSON_DOC *jd)
 void
 JSON_DOC_WRAPPER::own_doc (JSON_DOC *jd)
 {
-  if (jd == m_owning_doc)
+  if (jd != m_owning_doc)
     {
-      return;
+      release_owning ();
     }
-
-  release_owning ();
 
   m_borrowed_doc = m_owning_doc = jd;
 }

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -3207,6 +3207,12 @@ db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc)
   return NO_ERROR;
 }
 
+void
+db_make_json_from_doc_store_and_release (DB_VALUE &value, JSON_DOC_STORE &doc_store)
+{
+  db_make_json (&value, doc_store.release_mutable_reference (), true);
+}
+
 static void
 db_json_value_wrap_as_array (JSON_VALUE &value, JSON_PRIVATE_MEMPOOL &allocator)
 {

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -96,71 +96,93 @@ typedef rapidjson::GenericArray<true, JSON_VALUE>::ConstValueIterator JSON_VALUE
 
 typedef std::function<int (const JSON_VALUE &, const JSON_PATH &, bool &)> map_func_type;
 
-JSON_DOC_WRAPPER::JSON_DOC_WRAPPER ()
-  : m_borrowed_doc (nullptr)
-  , m_owning_doc (nullptr)
+JSON_DOC_STORE::JSON_DOC_STORE ()
+  : m_immutable_reference (nullptr)
+  , m_mutable_reference (nullptr)
 {
 
+}
+
+JSON_DOC_STORE &&JSON_DOC_STORE::operator= (JSON_DOC_STORE &&other)
+{
+  if (m_mutable_reference == other.m_mutable_reference || m_mutable_reference == m_immutable_reference)
+    {
+      // we should not clear the doc we assign to ourselves
+      return std::move (*this);
+    }
+
+  clear ();
+
+  m_mutable_reference = other.m_mutable_reference;
+  m_immutable_reference = other.m_immutable_reference;
+
+  other.m_mutable_reference = nullptr;
+  other.m_immutable_reference = nullptr;
+
+  return std::move (*this);
 }
 
 const JSON_DOC *
-JSON_DOC_WRAPPER::get_borrowed () const
+JSON_DOC_STORE::get_immutable_reference () const
 {
-  return m_borrowed_doc;
+  assert (m_immutable_reference != nullptr);
+  return m_immutable_reference;
 }
 
 JSON_DOC *
-JSON_DOC_WRAPPER::get_owned ()
+JSON_DOC_STORE::get_mutable_reference ()
 {
-  return m_owning_doc;
+  assert (m_mutable_reference != nullptr);
+  return m_mutable_reference;
 }
 
 JSON_DOC *
-JSON_DOC_WRAPPER::transfer_ownership ()
+JSON_DOC_STORE::release_mutable_reference ()
 {
   // assume we are owner
-  assert (m_owning_doc != nullptr && m_owning_doc == m_borrowed_doc);
-  m_owning_doc = nullptr;
-  return const_cast<JSON_DOC *> (m_borrowed_doc);
+  assert (m_mutable_reference != nullptr && m_mutable_reference == m_immutable_reference);
+  m_mutable_reference = nullptr;
+  return const_cast<JSON_DOC *> (m_immutable_reference);
 }
 
 void
-JSON_DOC_WRAPPER::borrow_doc (JSON_DOC *jd)
+JSON_DOC_STORE::set_as_immutable_reference (JSON_DOC *jd)
 {
-  if (jd != m_owning_doc)
+  if (jd != m_mutable_reference)
     {
-      release_owning ();
+      // we should not clear the doc we assign to ourselves
+      clear ();
     }
 
-  m_owning_doc = nullptr;
-  m_borrowed_doc = jd;
+  m_mutable_reference = nullptr;
+  m_immutable_reference = jd;
 }
 
 void
-JSON_DOC_WRAPPER::own_doc (JSON_DOC *jd)
+JSON_DOC_STORE::set_as_mutable_reference (JSON_DOC *jd)
 {
-  if (jd != m_owning_doc)
+  if (jd != m_mutable_reference)
     {
-      release_owning ();
+      clear ();
     }
 
-  m_borrowed_doc = m_owning_doc = jd;
+  m_immutable_reference = m_mutable_reference = jd;
 }
 
 void
-JSON_DOC_WRAPPER::release_owning ()
+JSON_DOC_STORE::clear ()
 {
-  if (m_owning_doc != nullptr)
+  if (m_mutable_reference != nullptr)
     {
-      delete m_owning_doc;
-      m_owning_doc = nullptr;
+      delete m_mutable_reference;
+      m_mutable_reference = nullptr;
     }
-  m_borrowed_doc = nullptr;
+  m_immutable_reference = nullptr;
 }
 
-JSON_DOC_WRAPPER::~JSON_DOC_WRAPPER ()
+JSON_DOC_STORE::~JSON_DOC_STORE ()
 {
-  release_owning ();
+  clear ();
 }
 
 // class JSON_ITERATOR - virtual interface to wrap array and object iterators
@@ -1218,16 +1240,17 @@ db_json_value_get_depth (const JSON_VALUE *doc)
  * example                 : json_extract('{"a":["b", 123]}', '/a/1') yields 123
  */
 int
-db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<const char *> &paths, JSON_DOC *&result,
+db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<const char *> &paths,
+				    JSON_DOC_STORE &result,
 				    bool allow_wildcards)
 {
   int error_code = NO_ERROR;
 
   if (document == NULL)
     {
-      if (result != NULL)
+      if (result.get_mutable_reference () != nullptr)
 	{
-	  result->SetNull ();
+	  result.get_mutable_reference ()->SetNull ();
 	}
       return NO_ERROR;
     }
@@ -1286,13 +1309,13 @@ db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<
 	{
 	  for (const JSON_VALUE *p : produced)
 	    {
-	      if (result == NULL)
+	      if (result.get_mutable_reference () == nullptr)
 		{
-		  result = db_json_allocate_doc ();
-		  result->SetArray ();
+		  result.set_as_mutable_reference (db_json_allocate_doc ());
+		  result.get_mutable_reference ()->SetArray ();
 		}
 
-	      db_json_add_element_to_array (result, p);
+	      db_json_add_element_to_array (result.get_mutable_reference (), p);
 	    }
 	}
     }
@@ -1302,12 +1325,12 @@ db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<
 
       if (!produced_array[0].empty ())
 	{
-	  if (result == NULL)
+	  if (result.get_mutable_reference () == nullptr)
 	    {
-	      result = db_json_allocate_doc ();
+	      result.set_as_mutable_reference (db_json_allocate_doc ());
 	    }
 
-	  result->CopyFrom (*produced_array[0][0], result->GetAllocator ());
+	  result.get_mutable_reference ()->CopyFrom (*produced_array[0][0], result.get_mutable_reference ()->GetAllocator ());
 	}
     }
 
@@ -3154,18 +3177,17 @@ db_value_to_json_path (const DB_VALUE *path_value, FUNC_TYPE fcode, const char *
  * return         : error code
  * db_val(in)     : input db_value
  * json_doc(out)  : output JSON_DOC pointer
- * force_copy(in) : whether jdw needs to own the json_doc
- *
+ * force_copy(in) : whether json_doc needs to own the json_doc
  */
 int
-db_value_to_json_doc (const DB_VALUE &db_val, JSON_DOC_WRAPPER &jdw, bool force_copy)
+db_value_to_json_doc (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc, bool force_copy)
 {
   int error_code = NO_ERROR;
 
   if (db_value_is_null (&db_val))
     {
-      jdw.own_doc (db_json_allocate_doc ());
-      db_json_make_document_null (jdw.get_owned ());
+      json_doc.set_as_mutable_reference (db_json_allocate_doc ());
+      db_json_make_document_null (json_doc.get_mutable_reference ());
       return NO_ERROR;
     }
 
@@ -3176,9 +3198,9 @@ db_value_to_json_doc (const DB_VALUE &db_val, JSON_DOC_WRAPPER &jdw, bool force_
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
     {
-      JSON_DOC *json_doc = NULL;
-      error_code = db_json_get_json_from_str (db_get_string (&db_val), json_doc, db_get_string_size (&db_val));
-      jdw.own_doc (json_doc);
+      JSON_DOC *json_doc_ptr = NULL;
+      error_code = db_json_get_json_from_str (db_get_string (&db_val), json_doc_ptr, db_get_string_size (&db_val));
+      json_doc.set_as_mutable_reference (json_doc_ptr);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -3189,16 +3211,16 @@ db_value_to_json_doc (const DB_VALUE &db_val, JSON_DOC_WRAPPER &jdw, bool force_
     case DB_TYPE_JSON:
       if (force_copy)
 	{
-	  jdw.own_doc (db_json_get_copy_of_doc (db_val.data.json.document));
+	  json_doc.set_as_mutable_reference (db_json_get_copy_of_doc (db_val.data.json.document));
 	}
       else
 	{
-	  jdw.borrow_doc (db_val.data.json.document);
+	  json_doc.set_as_immutable_reference (db_val.data.json.document);
 	}
       return NO_ERROR;
 
     case DB_TYPE_NULL:
-      jdw.own_doc (db_json_allocate_doc ());
+      json_doc.set_as_mutable_reference (db_json_allocate_doc ());
       return NO_ERROR;
 
     default:
@@ -3219,12 +3241,12 @@ db_value_to_json_doc (const DB_VALUE &db_val, JSON_DOC_WRAPPER &jdw, bool force_
  *       necessary. adapt function for those cases.
  */
 int
-db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_WRAPPER &jdw)
+db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc)
 {
   if (db_value_is_null (&db_val))
     {
-      jdw.own_doc (db_json_allocate_doc ());
-      db_json_make_document_null (jdw.get_owned ());
+      json_doc.set_as_mutable_reference (db_json_allocate_doc ());
+      db_json_make_document_null (json_doc.get_mutable_reference ());
       return NO_ERROR;
     }
 
@@ -3234,12 +3256,13 @@ db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_WRAPPER &jdw)
     case DB_TYPE_VARCHAR:
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      jdw.own_doc (db_json_allocate_doc ());
-      db_json_set_string_to_doc (jdw.get_owned (), db_get_string (&db_val), (unsigned) db_get_string_size (&db_val));
+      json_doc.set_as_mutable_reference (db_json_allocate_doc ());
+      db_json_set_string_to_doc (json_doc.get_mutable_reference (), db_get_string (&db_val),
+				 (unsigned) db_get_string_size (&db_val));
       break;
     case DB_TYPE_ENUMERATION:
-      jdw.own_doc (db_json_allocate_doc ());
-      db_json_set_string_to_doc (jdw.get_owned (), db_get_enum_string (&db_val),
+      json_doc.set_as_mutable_reference (db_json_allocate_doc ());
+      db_json_set_string_to_doc (json_doc.get_mutable_reference (), db_get_enum_string (&db_val),
 				 (unsigned) db_get_enum_string_size (&db_val));
       break;
 
@@ -3253,7 +3276,7 @@ db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_WRAPPER &jdw)
 	}
 
       // if db_val is json a copy to dest is made so we can own it
-      jdw.own_doc (db_get_json_document (&dest));
+      json_doc.set_as_mutable_reference (db_get_json_document (&dest));
     }
 
   return NO_ERROR;

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -96,14 +96,19 @@ typedef rapidjson::GenericArray<true, JSON_VALUE>::ConstValueIterator JSON_VALUE
 
 typedef std::function<int (const JSON_VALUE &, const JSON_PATH &, bool &)> map_func_type;
 
-void JSON_DOC_STORE::create_mutable_reference ()
+namespace cubmem
 {
-  set_mutable_reference (db_json_allocate_doc ());
-}
+  template <>
+  void JSON_DOC_STORE::create_mutable_reference ()
+  {
+    set_mutable_reference (db_json_allocate_doc ());
+  }
 
-void JSON_DOC_STORE::delete_mutable ()
-{
-  delete m_mutable_reference;
+  template <>
+  void JSON_DOC_STORE::delete_mutable ()
+  {
+    delete m_mutable_reference;
+  }
 }
 
 // class JSON_ITERATOR - virtual interface to wrap array and object iterators
@@ -1170,7 +1175,7 @@ db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<
     {
       if (result.is_mutable ())
 	{
-	  result.get_mutable_reference ()->SetNull ();
+	  result.get_mutable ()->SetNull ();
 	}
       return NO_ERROR;
     }
@@ -1232,10 +1237,10 @@ db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<
 	      if (!result.is_mutable ())
 		{
 		  result.create_mutable_reference ();
-		  result.get_mutable_reference ()->SetArray ();
+		  result.get_mutable ()->SetArray ();
 		}
 
-	      db_json_add_element_to_array (result.get_mutable_reference (), p);
+	      db_json_add_element_to_array (result.get_mutable (), p);
 	    }
 	}
     }
@@ -1250,7 +1255,7 @@ db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<
 	      result.create_mutable_reference ();
 	    }
 
-	  result.get_mutable_reference ()->CopyFrom (*produced_array[0][0], result.get_mutable_reference ()->GetAllocator ());
+	  result.get_mutable ()->CopyFrom (*produced_array[0][0], result.get_mutable ()->GetAllocator ());
 	}
     }
 
@@ -3107,7 +3112,7 @@ db_value_to_json_doc (const DB_VALUE &db_val, bool force_copy, JSON_DOC_STORE &j
   if (db_value_is_null (&db_val))
     {
       json_doc.create_mutable_reference ();
-      db_json_make_document_null (json_doc.get_mutable_reference ());
+      db_json_make_document_null (json_doc.get_mutable ());
       return NO_ERROR;
     }
 
@@ -3166,7 +3171,7 @@ db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc)
   if (db_value_is_null (&db_val))
     {
       json_doc.create_mutable_reference ();
-      db_json_make_document_null (json_doc.get_mutable_reference ());
+      db_json_make_document_null (json_doc.get_mutable ());
       return NO_ERROR;
     }
 
@@ -3177,12 +3182,12 @@ db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc)
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
       json_doc.create_mutable_reference ();
-      db_json_set_string_to_doc (json_doc.get_mutable_reference (), db_get_string (&db_val),
+      db_json_set_string_to_doc (json_doc.get_mutable (), db_get_string (&db_val),
 				 (unsigned) db_get_string_size (&db_val));
       break;
     case DB_TYPE_ENUMERATION:
       json_doc.create_mutable_reference ();
-      db_json_set_string_to_doc (json_doc.get_mutable_reference (), db_get_enum_string (&db_val),
+      db_json_set_string_to_doc (json_doc.get_mutable (), db_get_enum_string (&db_val),
 				 (unsigned) db_get_enum_string_size (&db_val));
       break;
 

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -103,14 +103,6 @@ JSON_DOC_WRAPPER::JSON_DOC_WRAPPER ()
 
 }
 
-JSON_DOC_WRAPPER::JSON_DOC_WRAPPER (JSON_DOC_WRAPPER &&other)
-  : m_owning_doc (other.m_owning_doc)
-  , m_borrowed_doc (other.m_borrowed_doc)
-{
-  other.m_borrowed_doc = nullptr;
-  other.m_owning_doc = nullptr;
-}
-
 const JSON_DOC *
 JSON_DOC_WRAPPER::get_borrowed () const
 {
@@ -126,31 +118,10 @@ JSON_DOC_WRAPPER::get_owned ()
 JSON_DOC *
 JSON_DOC_WRAPPER::transfer_ownership ()
 {
+  // assume we are owner
   assert (m_owning_doc != nullptr && m_owning_doc == m_borrowed_doc);
   m_owning_doc = nullptr;
   return const_cast<JSON_DOC *> (m_borrowed_doc);
-}
-
-JSON_DOC_WRAPPER &&
-JSON_DOC_WRAPPER::operator= (JSON_DOC_WRAPPER &&other)
-{
-  if (&other == this)
-    {
-      return std::move (*this);
-    }
-
-  if (m_owning_doc != other.m_owning_doc)
-    {
-      release_owning ();
-    }
-
-  m_owning_doc = other.m_owning_doc;
-  m_borrowed_doc = other.m_borrowed_doc;
-
-  other.m_borrowed_doc = nullptr;
-  other.m_owning_doc = nullptr;
-
-  return std::move (*this);
 }
 
 void

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -154,6 +154,7 @@ bool db_json_doc_is_uncomparable (const JSON_DOC *doc);
 // DB_VALUE manipulation functions
 int db_value_to_json_doc (const DB_VALUE &db_val, bool copy_json, JSON_DOC_STORE &json_doc);
 int db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc);
+void db_make_json_from_doc_store_and_release (DB_VALUE &value, JSON_DOC_STORE &doc_store);
 int db_value_to_json_path (const DB_VALUE *path_value, FUNC_TYPE fcode, const char **path_str);
 
 int db_json_normalize_path_string (const char *pointer_path, std::string &normalized_path);

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -60,7 +60,6 @@ enum DB_JSON_TYPE
 class JSON_DOC_WRAPPER
 {
   public:
-
     JSON_DOC_WRAPPER ();
 
     const JSON_DOC *get_borrowed () const;

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -62,8 +62,6 @@ class JSON_DOC_WRAPPER
   public:
 
     JSON_DOC_WRAPPER ();
-    JSON_DOC_WRAPPER (JSON_DOC_WRAPPER &&other);
-    JSON_DOC_WRAPPER &&operator= (JSON_DOC_WRAPPER &&other);
 
     const JSON_DOC *get_borrowed () const;
     JSON_DOC *get_owned ();
@@ -72,11 +70,12 @@ class JSON_DOC_WRAPPER
     void borrow_doc (JSON_DOC *jd);
     void own_doc (JSON_DOC *jd);
 
-    void release_owning ();
     ~JSON_DOC_WRAPPER ();
   private:
     const JSON_DOC *m_borrowed_doc;
     JSON_DOC *m_owning_doc;
+
+    void release_owning ();
 };
 
 bool db_json_is_valid (const char *json_str);

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -25,7 +25,7 @@
 #define _DB_JSON_HPP_
 
 #include "error_manager.h"
-#include "memory_private_allocator.hpp"
+#include "memory_reference_store.hpp"
 #include "object_representation.h"
 
 #if defined (__cplusplus)

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -57,11 +57,33 @@ enum DB_JSON_TYPE
   DB_JSON_BOOL,
 };
 
+class JSON_DOC_WRAPPER
+{
+  public:
+
+    JSON_DOC_WRAPPER ();
+    JSON_DOC_WRAPPER (JSON_DOC_WRAPPER &&other);
+    JSON_DOC_WRAPPER &&operator= (JSON_DOC_WRAPPER &&other);
+
+    const JSON_DOC *get_borrowed () const;
+    JSON_DOC *get_owned ();
+    JSON_DOC *transfer_ownership ();
+
+    void borrow_doc (JSON_DOC *jd);
+    void own_doc (JSON_DOC *jd);
+
+    void release_owning ();
+    ~JSON_DOC_WRAPPER ();
+  private:
+    const JSON_DOC *m_borrowed_doc;
+    JSON_DOC *m_owning_doc;
+};
+
 bool db_json_is_valid (const char *json_str);
 const char *db_json_get_type_as_str (const JSON_DOC *document);
 unsigned int db_json_get_length (const JSON_DOC *document);
 unsigned int db_json_get_depth (const JSON_DOC *doc);
-int db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<std::string> &raw_path,
+int db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<const char *> &raw_path,
 					JSON_DOC *&result, bool allow_wildcards = true);
 int db_json_contains_path (const JSON_DOC *document, const std::vector<std::string> &paths, bool find_all,
 			   bool &result);
@@ -149,8 +171,8 @@ bool db_json_doc_has_numeric_type (const JSON_DOC *doc);
 bool db_json_doc_is_uncomparable (const JSON_DOC *doc);
 
 // DB_VALUE manipulation functions
-int db_value_to_json_doc (const DB_VALUE &db_val, REFPTR (JSON_DOC, json_doc));
-int db_value_to_json_value (const DB_VALUE &db_val, REFPTR (JSON_DOC, json_val));
+int db_value_to_json_doc (const DB_VALUE &db_val, JSON_DOC_WRAPPER &jdw, bool copy_json);
+int db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_WRAPPER &jdw);
 int db_value_to_json_path (const DB_VALUE *path_value, FUNC_TYPE fcode, const char **path_str);
 
 int db_json_normalize_path_string (const char *pointer_path, std::string &normalized_path);

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -25,6 +25,7 @@
 #define _DB_JSON_HPP_
 
 #include "error_manager.h"
+#include "memory_private_allocator.hpp"
 #include "object_representation.h"
 
 #if defined (__cplusplus)
@@ -57,36 +58,14 @@ enum DB_JSON_TYPE
   DB_JSON_BOOL,
 };
 
-class JSON_DOC_STORE
-{
-  public:
-    JSON_DOC_STORE ();
-    JSON_DOC_STORE &&operator= (JSON_DOC_STORE &&);
-
-    JSON_DOC_STORE (JSON_DOC_STORE &) = delete;
-    JSON_DOC_STORE &operator= (JSON_DOC_STORE &) = delete;
-
-    const JSON_DOC *get_immutable_reference () const;
-    JSON_DOC *get_mutable_reference ();
-    JSON_DOC *release_mutable_reference ();
-
-    void set_as_immutable_reference (JSON_DOC *jd);
-    void set_as_mutable_reference (JSON_DOC *jd);
-
-    void clear ();
-    ~JSON_DOC_STORE ();
-  private:
-    const JSON_DOC *m_immutable_reference;
-    JSON_DOC *m_mutable_reference;
-
-};
+using JSON_DOC_STORE = cubmem::reference_store<JSON_DOC>;
 
 bool db_json_is_valid (const char *json_str);
 const char *db_json_get_type_as_str (const JSON_DOC *document);
 unsigned int db_json_get_length (const JSON_DOC *document);
 unsigned int db_json_get_depth (const JSON_DOC *doc);
-int db_json_extract_document_from_path (const JSON_DOC *document,
-					const std::vector<const char *> &raw_path, JSON_DOC_STORE &result, bool allow_wildcards = true);
+int db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<const char *> &raw_path,
+					JSON_DOC_STORE &result, bool allow_wildcards = true);
 int db_json_contains_path (const JSON_DOC *document, const std::vector<std::string> &paths, bool find_all,
 			   bool &result);
 char *db_json_get_raw_json_body_from_document (const JSON_DOC *doc);
@@ -119,7 +98,7 @@ int db_json_keys_func (const JSON_DOC &doc, JSON_DOC &result_json, const char *r
 int db_json_array_append_func (const JSON_DOC *value, JSON_DOC &doc, const char *raw_path);
 int db_json_array_insert_func (const JSON_DOC *value, JSON_DOC &doc, const char *raw_path);
 int db_json_remove_func (JSON_DOC &doc, const char *raw_path);
-int db_json_search_func (JSON_DOC &doc, const DB_VALUE *pattern, const DB_VALUE *esc_char,
+int db_json_search_func (const JSON_DOC &doc, const DB_VALUE *pattern, const DB_VALUE *esc_char,
 			 std::vector<std::string> &paths, const std::vector<std::string> &patterns, bool find_all);
 int db_json_merge_patch_func (const JSON_DOC *source, JSON_DOC *&dest);
 int db_json_merge_preserve_func (const JSON_DOC *source, JSON_DOC *&dest);
@@ -173,7 +152,7 @@ bool db_json_doc_has_numeric_type (const JSON_DOC *doc);
 bool db_json_doc_is_uncomparable (const JSON_DOC *doc);
 
 // DB_VALUE manipulation functions
-int db_value_to_json_doc (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc, bool copy_json);
+int db_value_to_json_doc (const DB_VALUE &db_val, bool copy_json, JSON_DOC_STORE &json_doc);
 int db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc);
 int db_value_to_json_path (const DB_VALUE *path_value, FUNC_TYPE fcode, const char **path_str);
 

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -57,32 +57,36 @@ enum DB_JSON_TYPE
   DB_JSON_BOOL,
 };
 
-class JSON_DOC_WRAPPER
+class JSON_DOC_STORE
 {
   public:
-    JSON_DOC_WRAPPER ();
+    JSON_DOC_STORE ();
+    JSON_DOC_STORE &&operator= (JSON_DOC_STORE &&);
 
-    const JSON_DOC *get_borrowed () const;
-    JSON_DOC *get_owned ();
-    JSON_DOC *transfer_ownership ();
+    JSON_DOC_STORE (JSON_DOC_STORE &) = delete;
+    JSON_DOC_STORE &operator= (JSON_DOC_STORE &) = delete;
 
-    void borrow_doc (JSON_DOC *jd);
-    void own_doc (JSON_DOC *jd);
+    const JSON_DOC *get_immutable_reference () const;
+    JSON_DOC *get_mutable_reference ();
+    JSON_DOC *release_mutable_reference ();
 
-    ~JSON_DOC_WRAPPER ();
+    void set_as_immutable_reference (JSON_DOC *jd);
+    void set_as_mutable_reference (JSON_DOC *jd);
+
+    void clear ();
+    ~JSON_DOC_STORE ();
   private:
-    const JSON_DOC *m_borrowed_doc;
-    JSON_DOC *m_owning_doc;
+    const JSON_DOC *m_immutable_reference;
+    JSON_DOC *m_mutable_reference;
 
-    void release_owning ();
 };
 
 bool db_json_is_valid (const char *json_str);
 const char *db_json_get_type_as_str (const JSON_DOC *document);
 unsigned int db_json_get_length (const JSON_DOC *document);
 unsigned int db_json_get_depth (const JSON_DOC *doc);
-int db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<const char *> &raw_path,
-					JSON_DOC *&result, bool allow_wildcards = true);
+int db_json_extract_document_from_path (const JSON_DOC *document,
+					const std::vector<const char *> &raw_path, JSON_DOC_STORE &result, bool allow_wildcards = true);
 int db_json_contains_path (const JSON_DOC *document, const std::vector<std::string> &paths, bool find_all,
 			   bool &result);
 char *db_json_get_raw_json_body_from_document (const JSON_DOC *doc);
@@ -169,8 +173,8 @@ bool db_json_doc_has_numeric_type (const JSON_DOC *doc);
 bool db_json_doc_is_uncomparable (const JSON_DOC *doc);
 
 // DB_VALUE manipulation functions
-int db_value_to_json_doc (const DB_VALUE &db_val, JSON_DOC_WRAPPER &jdw, bool copy_json);
-int db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_WRAPPER &jdw);
+int db_value_to_json_doc (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc, bool copy_json);
+int db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc);
 int db_value_to_json_path (const DB_VALUE *path_value, FUNC_TYPE fcode, const char **path_str);
 
 int db_json_normalize_path_string (const char *pointer_path, std::string &normalized_path);

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -6286,7 +6286,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
       db_json_path_unquote_object_keys_external (paths[0]);
       char *escaped;
       error_code = db_string_escape (paths[0].c_str (), paths[0].size (), &escaped, &escaped_size);
-      cubmem::private_unique_ptr<char> (escaped, NULL);
+      cubmem::private_unique_ptr<char> escaped_unqique_ptr (escaped, NULL);
       if (error_code)
 	{
 	  return error_code;
@@ -6294,6 +6294,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
       error_code = db_json_get_json_from_str (escaped, result_json, escaped_size);
       if (error_code != NO_ERROR)
 	{
+          ASSERT_ERROR ();
 	  return error_code;
 	}
       return db_make_json (result, result_json, true);
@@ -6310,7 +6311,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
 
       db_json_path_unquote_object_keys_external (paths[i]);
       error_code = db_string_escape (paths[i].c_str (), paths[i].size (), &escaped, &escaped_size);
-      cubmem::private_unique_ptr<char> (escaped, NULL);
+      cubmem::private_unique_ptr<char> escaped_unqique_ptr (escaped, NULL);
       if (error_code)
 	{
 	  return error_code;
@@ -6319,6 +6320,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
       json_array_elem_owner.own_doc (json_array_elem);
       if (error_code != NO_ERROR)
 	{
+          ASSERT_ERROR ();
 	  return error_code;
 	}
 
@@ -6360,7 +6362,6 @@ db_evaluate_json_get_all_paths (DB_VALUE * result, DB_VALUE * const *arg, int co
   error_code = db_json_get_all_paths_func (*new_doc.get_borrowed (), result_json);
 
   db_make_json (result, result_json, true);
-
 
   return NO_ERROR;
 }

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5417,7 +5417,7 @@ db_accumulate_json_arrayagg (const DB_VALUE * json_db_val, DB_VALUE * json_res)
 
   db_json_add_element_to_array (result_doc.get_mutable (), val_doc.get_immutable ());
 
-  db_make_json (json_res, result_doc.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*json_res, result_doc);
   return error_code;
 }
 
@@ -5475,7 +5475,7 @@ db_accumulate_json_objectagg (const DB_VALUE * json_key, const DB_VALUE * json_d
     }
 
   error_code = db_json_add_member_to_object (result_doc.get_mutable (), key_str, val_doc.get_immutable ());
-  db_make_json (json_res, result_doc.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*json_res, result_doc);
   if (error_code == ER_JSON_DUPLICATE_KEY)
     {
       // ignore
@@ -5550,7 +5550,7 @@ db_evaluate_json_extract (DB_VALUE * result, DB_VALUE * const *args, int num_arg
 
   if (db_json_get_type (res_doc.get_immutable ()) != DB_JSON_NULL)
     {
-      db_make_json (result, res_doc.release_mutable_reference (), true);
+      db_make_json_from_doc_store_and_release (*result, res_doc);
     }
 
   return NO_ERROR;
@@ -5600,7 +5600,7 @@ db_evaluate_json_object (DB_VALUE * result, DB_VALUE * const *arg, int const num
 	}
     }
 
-  db_make_json (result, new_doc.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, new_doc);
 
   return NO_ERROR;
 }
@@ -5627,7 +5627,7 @@ db_evaluate_json_array (DB_VALUE * result, DB_VALUE * const *arg, int const num_
       db_json_add_element_to_array (new_doc.get_mutable (), value_doc.get_immutable ());
     }
 
-  db_make_json (result, new_doc.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, new_doc);
 
   return NO_ERROR;
 }
@@ -5688,7 +5688,7 @@ db_evaluate_json_insert (DB_VALUE * result, DB_VALUE * const *arg, int const num
 	}
     }
 
-  db_make_json (result, new_doc.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, new_doc);
 
   return NO_ERROR;
 }
@@ -5748,7 +5748,7 @@ db_evaluate_json_replace (DB_VALUE * result, DB_VALUE * const *arg, int const nu
 	}
     }
 
-  db_make_json (result, new_doc.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, new_doc);
 
   return NO_ERROR;
 }
@@ -5808,7 +5808,7 @@ db_evaluate_json_set (DB_VALUE * result, DB_VALUE * const *arg, int const num_ar
 	}
     }
 
-  db_make_json (result, new_doc.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, new_doc);
 
   return NO_ERROR;
 }
@@ -5860,7 +5860,7 @@ db_evaluate_json_keys (DB_VALUE * result, DB_VALUE * const *arg, int const num_a
       return error_code;
     }
 
-  db_make_json (result, result_json.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, result_json);
   return NO_ERROR;
 }
 
@@ -5906,7 +5906,7 @@ db_evaluate_json_remove (DB_VALUE * result, DB_VALUE * const *arg, int const num
 	}
     }
 
-  db_make_json (result, new_doc.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, new_doc);
 
   return NO_ERROR;
 }
@@ -5967,7 +5967,7 @@ db_evaluate_json_array_append (DB_VALUE * result, DB_VALUE * const *arg, int con
 	}
     }
 
-  db_make_json (result, new_doc.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, new_doc);
 
   return NO_ERROR;
 }
@@ -6028,7 +6028,7 @@ db_evaluate_json_array_insert (DB_VALUE * result, DB_VALUE * const *arg, int con
 	}
     }
 
-  db_make_json (result, new_doc.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, new_doc);
 
   return NO_ERROR;
 }
@@ -6139,7 +6139,7 @@ db_evaluate_json_merge_preserve (DB_VALUE * result, DB_VALUE * const *arg, const
 	}
     }
 
-  db_make_json (result, accumulator_owner.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, accumulator_owner);
 
   return NO_ERROR;
 }
@@ -6193,7 +6193,7 @@ db_evaluate_json_merge_patch (DB_VALUE * result, DB_VALUE * const *arg, const in
 	}
     }
 
-  db_make_json (result, accumulator_owner.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, accumulator_owner);
 
   return NO_ERROR;
 }
@@ -6325,7 +6325,8 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
       db_json_add_element_to_array (result_json_owner.get_mutable (), json_array_elem_owner.get_immutable ());
     }
 
-  return db_make_json (result, result_json_owner.release_mutable_reference (), true);
+  db_make_json_from_doc_store_and_release (*result, result_json_owner)
+  return NO_ERROR;
 }
 /* *INDENT-ON* */
 

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5105,7 +5105,7 @@ db_evaluate_json_contains (DB_VALUE * result, DB_VALUE * const *arg, int const n
     {
       const char *raw_path = db_get_string (path);
 
-      JSON_DOC *extracted_doc = NULL;
+      JSON_DOC *extracted_doc = nullptr;
       /* *INDENT-OFF* */
       error_code = db_json_extract_document_from_path (source.get_borrowed (), {raw_path}, extracted_doc);
       /* *INDENT-ON* */
@@ -5239,7 +5239,7 @@ db_evaluate_json_length (DB_VALUE * result, DB_VALUE * const *arg, int const num
   if (path != NULL)
     {
       const char *raw_path = db_get_string (path);
-      JSON_DOC *extracted_doc = NULL;
+      JSON_DOC *extracted_doc = nullptr;
 
       /* *INDENT-OFF* */
       error_code = db_json_extract_document_from_path (source_doc.get_borrowed (), {raw_path}, extracted_doc, false);
@@ -5540,7 +5540,7 @@ db_evaluate_json_extract (DB_VALUE * result, DB_VALUE * const *args, int num_arg
     }
 
   JSON_DOC_WRAPPER res_doc;
-  JSON_DOC *result_doc = NULL;
+  JSON_DOC *result_doc = nullptr;
   error_code = db_json_extract_document_from_path (source_doc.get_borrowed (), paths, result_doc);
   res_doc.own_doc (result_doc);
   if (error_code != NO_ERROR)
@@ -6104,7 +6104,7 @@ int
 db_evaluate_json_merge_preserve (DB_VALUE * result, DB_VALUE * const *arg, const int num_args)
 {
   int error_code;
-  JSON_DOC *accumulator;
+  JSON_DOC *accumulator = nullptr;
   JSON_DOC_WRAPPER accumulator_owner;
   JSON_DOC_WRAPPER doc;
 
@@ -6159,7 +6159,7 @@ int
 db_evaluate_json_merge_patch (DB_VALUE * result, DB_VALUE * const *arg, const int num_args)
 {
   int error_code;
-  JSON_DOC *accumulator = NULL;
+  JSON_DOC *accumulator = nullptr;
   JSON_DOC_WRAPPER accumulator_owner;
   JSON_DOC_WRAPPER doc;
 

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5095,7 +5095,7 @@ db_evaluate_json_contains (DB_VALUE * result, DB_VALUE * const *arg, int const n
       return NO_ERROR;
     }
 
-  error_code = db_value_to_json_doc (*json, source, false);
+  error_code = db_value_to_json_doc (*json, false, source);
   if (error_code != NO_ERROR)
     {
       return error_code;
@@ -5126,7 +5126,7 @@ db_evaluate_json_contains (DB_VALUE * result, DB_VALUE * const *arg, int const n
       bool has_member = false;
       JSON_DOC_STORE value_doc;
 
-      int error_code = db_value_to_json_doc (*value, value_doc, false);
+      int error_code = db_value_to_json_doc (*value, false, value_doc);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -5166,7 +5166,7 @@ db_evaluate_json_type_dbval (DB_VALUE * result, DB_VALUE * const *arg, int const
       unsigned int length;
       JSON_DOC_STORE doc;
 
-      int error_code = db_value_to_json_doc (*json, doc, false);
+      int error_code = db_value_to_json_doc (*json, false, doc);
       if (error_code != NO_ERROR)
 	{
 	  return error_code;
@@ -5232,7 +5232,7 @@ db_evaluate_json_length (DB_VALUE * result, DB_VALUE * const *arg, int const num
     }
   unsigned int length;
 
-  error_code = db_value_to_json_doc (*json, source_doc, false);
+  error_code = db_value_to_json_doc (*json, false, source_doc);
   if (error_code != NO_ERROR)
     {
       return error_code;
@@ -5277,7 +5277,7 @@ db_evaluate_json_depth (DB_VALUE * result, DB_VALUE * const *arg, int const num_
       return NO_ERROR;
     }
   JSON_DOC_STORE source_doc;
-  int error_code = db_value_to_json_doc (*json, source_doc, false);
+  int error_code = db_value_to_json_doc (*json, false, source_doc);
   if (error_code != NO_ERROR)
     {
       return error_code;
@@ -5315,7 +5315,7 @@ db_evaluate_json_unquote (DB_VALUE * result, DB_VALUE * const *arg, int const nu
     }
   char *str = NULL;
   JSON_DOC_STORE source_doc;
-  error_code = db_value_to_json_doc (*json, source_doc, false);
+  error_code = db_value_to_json_doc (*json, false, source_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -5356,7 +5356,7 @@ db_evaluate_json_pretty (DB_VALUE * result, DB_VALUE * const *arg, int const num
     }
   char *str = NULL;
   JSON_DOC_STORE source_doc;
-  error_code = db_value_to_json_doc (*json, source_doc, false);
+  error_code = db_value_to_json_doc (*json, false, source_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -5403,11 +5403,11 @@ db_accumulate_json_arrayagg (const DB_VALUE * json_db_val, DB_VALUE * json_res)
   // allocate only first time
   if (DB_IS_NULL (json_res))
     {
-      result_doc.set_as_mutable_reference (db_json_allocate_doc ());
+      result_doc.create_mutable_reference ();
     }
   else
     {
-      result_doc.set_as_mutable_reference (db_get_json_document (json_res));
+      result_doc.set_mutable_reference (db_get_json_document (json_res));
     }
 
   if (result_doc.get_immutable_reference () == NULL)
@@ -5462,11 +5462,11 @@ db_accumulate_json_objectagg (const DB_VALUE * json_key, const DB_VALUE * json_d
   // allocate only first time
   if (DB_IS_NULL (json_res))
     {
-      result_doc.set_as_mutable_reference (db_json_allocate_doc ());
+      result_doc.create_mutable_reference ();
     }
   else
     {
-      result_doc.set_as_mutable_reference (db_get_json_document (json_res));
+      result_doc.set_mutable_reference (db_get_json_document (json_res));
     }
 
   if (result_doc.get_immutable_reference () == NULL)
@@ -5520,7 +5520,7 @@ db_evaluate_json_extract (DB_VALUE * result, DB_VALUE * const *args, int num_arg
       return NO_ERROR;
     }
 
-  error_code = db_value_to_json_doc (*args[0], source_doc, false);
+  error_code = db_value_to_json_doc (*args[0], false, source_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -5576,7 +5576,7 @@ db_evaluate_json_object (DB_VALUE * result, DB_VALUE * const *arg, int const num
     }
 
   JSON_DOC_STORE new_doc;
-  new_doc.set_as_mutable_reference (db_json_make_json_object ());
+  new_doc.set_mutable_reference (db_json_make_json_object ());
 
   for (i = 0; i < num_args; i += 2)
     {
@@ -5614,7 +5614,7 @@ db_evaluate_json_array (DB_VALUE * result, DB_VALUE * const *arg, int const num_
 {
   int error_code;
   JSON_DOC_STORE new_doc;
-  new_doc.set_as_mutable_reference (db_json_make_json_array ());
+  new_doc.set_mutable_reference (db_json_make_json_array ());
   JSON_DOC_STORE value_doc;
 
   db_make_null (result);
@@ -5658,7 +5658,7 @@ db_evaluate_json_insert (DB_VALUE * result, DB_VALUE * const *arg, int const num
       return db_make_null (result);
     }
 
-  error_code = db_value_to_json_doc (*arg[0], new_doc, true);
+  error_code = db_value_to_json_doc (*arg[0], true, new_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -5720,7 +5720,7 @@ db_evaluate_json_replace (DB_VALUE * result, DB_VALUE * const *arg, int const nu
       return NO_ERROR;
     }
 
-  error_code = db_value_to_json_doc (*arg[0], new_doc, true);
+  error_code = db_value_to_json_doc (*arg[0], true, new_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -5781,7 +5781,7 @@ db_evaluate_json_set (DB_VALUE * result, DB_VALUE * const *arg, int const num_ar
       return NO_ERROR;
     }
 
-  error_code = db_value_to_json_doc (*arg[0], new_doc, true);
+  error_code = db_value_to_json_doc (*arg[0], true, new_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -5851,7 +5851,7 @@ db_evaluate_json_keys (DB_VALUE * result, DB_VALUE * const *arg, int const num_a
       path = db_get_string (arg[1]);
     }
 
-  error_code = db_value_to_json_doc (*arg[0], new_doc, false);
+  error_code = db_value_to_json_doc (*arg[0], false, new_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -5859,7 +5859,7 @@ db_evaluate_json_keys (DB_VALUE * result, DB_VALUE * const *arg, int const num_a
     }
 
   JSON_DOC_STORE result_json;
-  result_json.set_as_mutable_reference (db_json_allocate_doc ());
+  result_json.create_mutable_reference ();
   error_code =
     db_json_keys_func (*new_doc.get_immutable_reference (), *result_json.get_mutable_reference (), path.c_str ());
   if (error_code != NO_ERROR)
@@ -5892,7 +5892,7 @@ db_evaluate_json_remove (DB_VALUE * result, DB_VALUE * const *arg, int const num
       return NO_ERROR;
     }
 
-  error_code = db_value_to_json_doc (*arg[0], new_doc, true);
+  error_code = db_value_to_json_doc (*arg[0], true, new_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -5941,7 +5941,7 @@ db_evaluate_json_array_append (DB_VALUE * result, DB_VALUE * const *arg, int con
       return NO_ERROR;
     }
 
-  error_code = db_value_to_json_doc (*arg[0], new_doc, true);
+  error_code = db_value_to_json_doc (*arg[0], true, new_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -6003,7 +6003,7 @@ db_evaluate_json_array_insert (DB_VALUE * result, DB_VALUE * const *arg, int con
       return NO_ERROR;
     }
 
-  error_code = db_value_to_json_doc (*arg[0], new_doc, true);
+  error_code = db_value_to_json_doc (*arg[0], true, new_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -6059,7 +6059,7 @@ db_evaluate_json_contains_path (DB_VALUE * result, DB_VALUE * const *arg, const 
       return NO_ERROR;
     }
 
-  error_code = db_value_to_json_doc (*arg[0], doc, false);
+  error_code = db_value_to_json_doc (*arg[0], false, doc);
   if (error_code != NO_ERROR)
     {
       return error_code;
@@ -6134,7 +6134,7 @@ db_evaluate_json_merge_preserve (DB_VALUE * result, DB_VALUE * const *arg, const
 
   for (int i = 0; i < num_args; ++i)
     {
-      error_code = db_value_to_json_doc (*arg[i], doc, false);
+      error_code = db_value_to_json_doc (*arg[i], false, doc);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -6142,7 +6142,7 @@ db_evaluate_json_merge_preserve (DB_VALUE * result, DB_VALUE * const *arg, const
 	}
 
       error_code = db_json_merge_preserve_func (doc.get_immutable_reference (), accumulator);
-      accumulator_owner.set_as_mutable_reference (accumulator);
+      accumulator_owner.set_mutable_reference (accumulator);
       if (error_code != NO_ERROR)
 	{
 	  return error_code;
@@ -6189,14 +6189,14 @@ db_evaluate_json_merge_patch (DB_VALUE * result, DB_VALUE * const *arg, const in
 
   for (int i = 0; i < num_args; ++i)
     {
-      error_code = db_value_to_json_doc (*arg[i], doc, false);
+      error_code = db_value_to_json_doc (*arg[i], false, doc);
       if (error_code != NO_ERROR)
 	{
 	  return error_code;
 	}
 
       error_code = db_json_merge_patch_func (doc.get_immutable_reference (), accumulator);
-      accumulator_owner.set_as_mutable_reference (accumulator);
+      accumulator_owner.set_mutable_reference (accumulator);
       if (error_code != NO_ERROR)
 	{
 	  return error_code;
@@ -6241,7 +6241,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
         }
     }
 
-  error_code = db_value_to_json_doc (*args[0], doc, false);
+  error_code = db_value_to_json_doc (*args[0], false, doc);
   if (error_code != NO_ERROR)
     {
       return error_code;
@@ -6275,8 +6275,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
     }
 
   std::vector<std::string> paths;
-  // todo: add overload for JSON_WALKER::WalkDocument(const JSON_DOC&)
-  error_code = db_json_search_func (const_cast<JSON_DOC &>(*doc.get_immutable_reference ()), pattern, esc_char, paths, starting_paths, find_all);
+  error_code = db_json_search_func (*doc.get_immutable_reference (), pattern, esc_char, paths, starting_paths, find_all);
   if (error_code != NO_ERROR)
     {
       return error_code;
@@ -6311,7 +6310,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
 
   JSON_DOC_STORE result_json_owner;
   JSON_DOC_STORE json_array_elem_owner;
-  result_json_owner.set_as_mutable_reference (db_json_allocate_doc ());
+  result_json_owner.create_mutable_reference ();
   for (std::size_t i = 0; i < paths.size (); ++i)
     {
       JSON_DOC *json_array_elem = nullptr;
@@ -6326,7 +6325,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
 	  return error_code;
 	}
       error_code = db_json_get_json_from_str (escaped, json_array_elem, escaped_size);
-      json_array_elem_owner.set_as_mutable_reference (json_array_elem);
+      json_array_elem_owner.set_mutable_reference (json_array_elem);
       if (error_code != NO_ERROR)
 	{
           ASSERT_ERROR ();
@@ -6360,7 +6359,7 @@ db_evaluate_json_get_all_paths (DB_VALUE * result, DB_VALUE * const *arg, int co
       return NO_ERROR;
     }
 
-  error_code = db_value_to_json_doc (*arg[0], new_doc, false);
+  error_code = db_value_to_json_doc (*arg[0], false, new_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -6325,7 +6325,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
       db_json_add_element_to_array (result_json_owner.get_mutable (), json_array_elem_owner.get_immutable ());
     }
 
-  db_make_json_from_doc_store_and_release (*result, result_json_owner)
+  db_make_json_from_doc_store_and_release (*result, result_json_owner);
   return NO_ERROR;
 }
 /* *INDENT-ON* */

--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -215,7 +215,7 @@ namespace cubscan
       m_specp->m_root_node->clear_xasl (is_final_clear);
       reset_ordinality (*m_specp->m_root_node);
 
-      // all json documents should be release depending on is_final
+      // all json documents should be released depending on is_final
       if (is_final)
 	{
 	  for (size_t i = 0; i < m_tree_height; ++i)
@@ -381,14 +381,12 @@ namespace cubscan
     {
       int error_code = NO_ERROR;
 
-      if (cursor_arg.m_input_doc != nullptr)
-	{
-	  // do not gather previous result
-	  db_json_delete_doc (cursor_arg.m_input_doc);
-	}
+      JSON_DOC_STORE input_doc;
+      input_doc.set_as_mutable_reference (cursor_arg.m_input_doc);
+      input_doc.clear ();
 
       // extract input document
-      error_code = db_json_extract_document_from_path (&document, {node.m_path}, cursor_arg.m_input_doc);
+      error_code = db_json_extract_document_from_path (&document, {node.m_path}, input_doc);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -406,6 +404,8 @@ namespace cubscan
 	  cursor_arg.start_json_iterator ();
 	}
 
+      // transfer ownership to cursor_arg
+      input_doc.release_mutable_reference ();
       return NO_ERROR;
     }
 

--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -68,7 +68,6 @@ namespace cubscan
     }
 
     void
-
     scanner::cursor::advance_row_cursor ()
     {
       // don't advance again in row
@@ -100,7 +99,7 @@ namespace cubscan
       m_is_node_consumed = false;
       if (m_node->m_is_iterable_node)
 	{
-	  assert (db_json_get_type (m_input_doc.get_mutable ()) == DB_JSON_ARRAY);
+	  assert (db_json_get_type (m_input_doc.get_immutable ()) == DB_JSON_ARRAY);
 	  db_json_set_iterator (m_node->m_iterator, *m_input_doc.get_mutable ());
 	}
     }
@@ -123,7 +122,7 @@ namespace cubscan
 	{
 	  assert (!m_node->m_is_iterable_node);
 	  // todo: is it guaranteed we do not use m_process_doc after we delete input_doc?
-	  m_process_doc = m_input_doc.get_mutable ();
+	  m_process_doc = m_input_doc.get_immutable ();
 	}
 
       if (m_process_doc == NULL)
@@ -376,7 +375,7 @@ namespace cubscan
 	  return error_code;
 	}
 
-      if (!cursor_arg.m_input_doc.is_mutable ())
+      if (cursor_arg.m_input_doc.is_null ())
 	{
 	  // cannot retrieve input_doc from path
 	  cursor_arg.m_is_node_consumed = true;

--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -100,8 +100,8 @@ namespace cubscan
       m_is_node_consumed = false;
       if (m_node->m_is_iterable_node)
 	{
-	  assert (db_json_get_type (m_input_doc.get_mutable_reference ()) == DB_JSON_ARRAY);
-	  db_json_set_iterator (m_node->m_iterator, *m_input_doc.get_mutable_reference ());
+	  assert (db_json_get_type (m_input_doc.get_mutable ()) == DB_JSON_ARRAY);
+	  db_json_set_iterator (m_node->m_iterator, *m_input_doc.get_mutable ());
 	}
     }
 
@@ -123,7 +123,7 @@ namespace cubscan
 	{
 	  assert (!m_node->m_is_iterable_node);
 	  // todo: is it guaranteed we do not use m_process_doc after we delete input_doc?
-	  m_process_doc = m_input_doc.get_mutable_reference ();
+	  m_process_doc = m_input_doc.get_mutable ();
 	}
 
       if (m_process_doc == NULL)

--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -388,8 +388,7 @@ namespace cubscan
 	}
 
       // extract input document
-      error_code = db_json_extract_document_from_path (&document, std::vector<std::string> (1, node.m_path),
-		   cursor_arg.m_input_doc);
+      error_code = db_json_extract_document_from_path (&document, {node.m_path}, cursor_arg.m_input_doc);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -28,6 +28,7 @@
 #include "error_code.h"
 #include "error_manager.h"
 #include "memory_private_allocator.hpp"
+#include "memory_reference_store.hpp"
 #include "object_primitive.h"
 
 #include <cassert>

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -139,7 +139,7 @@ namespace cubxasl
 	  return ER_FAILED;
 	}
 
-      if (!docp.is_mutable ())
+      if (docp.is_null ())
 	{
 	  error_code = trigger_on_empty (*m_output_value_pointer);
 	  if (error_code != NO_ERROR)
@@ -151,12 +151,7 @@ namespace cubxasl
 
       // clear previous output_value
       pr_clear_value (m_output_value_pointer);
-
-      if (db_make_json (m_output_value_pointer, docp.release_mutable_reference (), true) != NO_ERROR)
-	{
-	  assert (false);
-	  return ER_FAILED;
-	}
+      db_make_json_from_doc_store_and_release (*m_output_value_pointer, docp);
 
       status_cast = tp_value_cast (m_output_value_pointer, m_output_value_pointer, m_domain, false);
       if (status_cast != TP_DOMAIN_STATUS::DOMAIN_COMPATIBLE)

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -138,7 +138,7 @@ namespace cubxasl
 	  return ER_FAILED;
 	}
 
-      if (docp.get_mutable_reference () == nullptr)
+      if (!docp.is_mutable ())
 	{
 	  error_code = trigger_on_empty (*m_output_value_pointer);
 	  if (error_code != NO_ERROR)

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -130,7 +130,7 @@ namespace cubxasl
       JSON_DOC *docp = NULL;
       TP_DOMAIN_STATUS status_cast = TP_DOMAIN_STATUS::DOMAIN_COMPATIBLE;
 
-      error_code = db_json_extract_document_from_path (&input, std::vector<std::string> (1, m_path), docp);
+      error_code = db_json_extract_document_from_path (&input, {m_path}, docp);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -127,7 +127,7 @@ namespace cubxasl
     column::evaluate_extract (const JSON_DOC &input)
     {
       int error_code = NO_ERROR;
-      JSON_DOC *docp = NULL;
+      JSON_DOC_STORE docp;
       TP_DOMAIN_STATUS status_cast = TP_DOMAIN_STATUS::DOMAIN_COMPATIBLE;
 
       error_code = db_json_extract_document_from_path (&input, {m_path}, docp);
@@ -138,7 +138,7 @@ namespace cubxasl
 	  return ER_FAILED;
 	}
 
-      if (docp == NULL)
+      if (docp.get_mutable_reference () == nullptr)
 	{
 	  error_code = trigger_on_empty (*m_output_value_pointer);
 	  if (error_code != NO_ERROR)
@@ -151,7 +151,7 @@ namespace cubxasl
       // clear previous output_value
       pr_clear_value (m_output_value_pointer);
 
-      if (db_make_json (m_output_value_pointer, docp, true) != NO_ERROR)
+      if (db_make_json (m_output_value_pointer, docp.release_mutable_reference (), true) != NO_ERROR)
 	{
 	  assert (false);
 	  return ER_FAILED;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22797

Comprising changes:

1. Avoid copying in db_value_to_json_doc when the json_doc_wrapper does not need to own the json_doc
2. Add cubmem::reference_store<T> to manage T's deallocations if it is owner during destructor. Use JSON_DOC_STORE = cubmem::reference_store<JSON_DOC> when appropriate
3. Begin replacing db_allocate_doc & db_json_delete_doc with JSON_DOC_STORE in arithmetic.c