### PR TITLE
[CBRD-22791] Move log impl to log writer

### DIFF
--- a/src/communication/network_interface_sr.h
+++ b/src/communication/network_interface_sr.h
@@ -33,7 +33,7 @@
 
 #include "file_io.h"
 #include "log_comm.h"
-#include "log_common_impl.h"
+#include "log_writer.h"
 #include "method_scan.h"
 #include "thread_compat.hpp"
 

--- a/src/executables/util_common.c
+++ b/src/executables/util_common.c
@@ -36,6 +36,7 @@
 #include "porting.h"
 #include "message_catalog.h"
 #include "log_common_impl.h"
+#include "log_writer.h"
 #include "mprec.h"
 #include "system_parameter.h"
 #include "environment_variable.h"

--- a/src/transaction/log_common_impl.h
+++ b/src/transaction/log_common_impl.h
@@ -54,28 +54,6 @@
 
 #define VACUUM_NULL_LOG_BLOCKID -1
 
-enum logwr_mode
-{
-  LOGWR_MODE_ASYNC = 1,
-  LOGWR_MODE_SEMISYNC,
-  LOGWR_MODE_SYNC
-};
-typedef enum logwr_mode LOGWR_MODE;
-#define LOGWR_COPY_FROM_FIRST_PHY_PAGE_MASK	(0x80000000)
-
-typedef struct log_bgarv_header LOG_BGARV_HEADER;
-struct log_bgarv_header
-{				/* Background log archive header information */
-  char magic[CUBRID_MAGIC_MAX_LENGTH];
-
-  INT32 dummy;
-  INT64 db_creation;
-
-  LOG_PAGEID start_page_id;
-  LOG_PAGEID current_page_id;
-  LOG_PAGEID last_sync_pageid;
-};
-
 enum LOG_HA_FILESTAT
 {
   LOG_HA_FILESTAT_CLEAR = 0,

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -28,6 +28,7 @@
 #include "log_archives.hpp"
 #include "log_impl.h"
 #include "log_storage.hpp"
+#include "log_writer.h"
 #include "porting.h"
 #include "storage_common.h"
 
@@ -95,7 +96,7 @@ LOG_GLOBAL log_Gl = {
   LOG_GROUP_COMMIT_INFO_INITIALIZER,
 
   /* log writer info */
-  LOGWR_INFO_INITIALIZER,
+  new logwr_info (),
 
   /* background archiving info */
   background_archiving_info (),
@@ -119,3 +120,10 @@ char log_Name_bkupinfo[PATH_MAX];
 char log_Name_volinfo[PATH_MAX];
 char log_Name_bg_archive[PATH_MAX];
 char log_Name_removed_archive[PATH_MAX];
+
+// *INDENT-OFF*
+log_global::~log_global ()
+{
+  delete writer_info;
+}
+// *INDENT-OFF*

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -126,4 +126,4 @@ log_global::~log_global ()
 {
   delete writer_info;
 }
-// *INDENT-OFF*
+// *INDENT-ON*

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1180,9 +1180,9 @@ struct log_global
   MVCCTABLE mvcc_table;		/* MVCC table */
   GLOBAL_UNIQUE_STATS_TABLE unique_stats_table;	/* global unique statistics */
 
-  // *INDENT-OFF
+  // *INDENT-OFF*
    ~log_global ();
-  // *INDENT-ON
+  // *INDENT-ON*
 };
 
 /* logging statistics */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -608,7 +608,7 @@ logpb_initialize_pool (THREAD_ENTRY * thread_p)
   int error_code = NO_ERROR;
   int i;
   LOG_GROUP_COMMIT_INFO *group_commit_info = &log_Gl.group_commit_info;
-  LOGWR_INFO *writer_info = &log_Gl.writer_info;
+  LOGWR_INFO *writer_info = log_Gl.writer_info;
   size_t size;
 
   if (lzo_init () == LZO_E_OK)
@@ -4353,7 +4353,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
   INT64 flush_completed_time = 0;
   INT64 all_writer_thr_end_time = 0;
 
-  LOGWR_INFO *writer_info = &log_Gl.writer_info;
+  LOGWR_INFO *writer_info = log_Gl.writer_info;
   LOGWR_ENTRY *entry;
   THREAD_ENTRY *wait_thread_p;
 #endif /* SERVER_MODE */
@@ -11782,7 +11782,7 @@ logpb_finalize_writer_info (void)
   int rv;
 #endif
   LOGWR_ENTRY *entry, *next_entry;
-  LOGWR_INFO *writer_info = &log_Gl.writer_info;
+  LOGWR_INFO *writer_info = log_Gl.writer_info;
 
   if (writer_info->is_init == true)
     {

--- a/src/transaction/log_writer.c
+++ b/src/transaction/log_writer.c
@@ -61,6 +61,19 @@
 static int prev_ha_server_state = HA_SERVER_STATE_NA;
 static bool logwr_need_shutdown = false;
 
+typedef struct log_bgarv_header LOG_BGARV_HEADER;
+struct log_bgarv_header
+{				/* Background log archive header information */
+  char magic[CUBRID_MAGIC_MAX_LENGTH];
+
+  INT32 dummy;
+  INT64 db_creation;
+
+  LOG_PAGEID start_page_id;
+  LOG_PAGEID current_page_id;
+  LOG_PAGEID last_sync_pageid;
+};
+
 #define logwr_er_log(...) if (prm_get_bool_value (PRM_ID_DEBUG_LOGWR)) _er_log_debug (ARG_FILE_LINE, __VA_ARGS__)
 
 static int logwr_check_page_checksum (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr);
@@ -1815,7 +1828,7 @@ logwr_register_writer_entry (LOGWR_ENTRY ** wr_entry_p, THREAD_ENTRY * thread_p,
 {
   LOGWR_ENTRY *entry;
   int rv;
-  LOGWR_INFO *writer_info = &log_Gl.writer_info;
+  LOGWR_INFO *writer_info = log_Gl.writer_info;
 
   *wr_entry_p = NULL;
   rv = pthread_mutex_lock (&writer_info->wr_list_mutex);
@@ -1888,7 +1901,7 @@ logwr_unregister_writer_entry (LOGWR_ENTRY * wr_entry, int status)
   LOGWR_ENTRY *entry;
   bool is_all_done;
   int rv;
-  LOGWR_INFO *writer_info = &log_Gl.writer_info;
+  LOGWR_INFO *writer_info = log_Gl.writer_info;
 
   rv = pthread_mutex_lock (&writer_info->wr_list_mutex);
 
@@ -2274,7 +2287,7 @@ xlogwr_get_log_pages (THREAD_ENTRY * thread_p, LOG_PAGEID first_pageid, LOGWR_MO
   bool copy_from_file = false;
   bool need_cs_exit_after_send = true;
   struct timespec to;
-  LOGWR_INFO *writer_info = &log_Gl.writer_info;
+  LOGWR_INFO *writer_info = log_Gl.writer_info;
   bool copy_from_first_phy_page = false;
 
   logpg_used_size = 0;
@@ -2525,7 +2538,7 @@ error:
 LOG_PAGEID
 logwr_get_min_copied_fpageid (void)
 {
-  LOGWR_INFO *writer_info = &log_Gl.writer_info;
+  LOGWR_INFO *writer_info = log_Gl.writer_info;
   LOGWR_ENTRY *entry;
   int num_entries = 0;
   LOG_PAGEID min_fpageid = LOGPAGEID_MAX;

--- a/src/transaction/log_writer.h
+++ b/src/transaction/log_writer.h
@@ -173,14 +173,25 @@ struct logwr_info
   CLIENTIDS last_writer_client_info;
   INT64 last_writer_elapsed_time;
 
-    logwr_info ():writer_list (NULL), wr_list_mutex PTHREAD_MUTEX_INITIALIZER,
-    flush_start_cond PTHREAD_COND_INITIALIZER, flush_start_mutex PTHREAD_MUTEX_INITIALIZER,
-    flush_wait_cond PTHREAD_COND_INITIALIZER, flush_wait_mutex PTHREAD_MUTEX_INITIALIZER,
-    flush_end_cond PTHREAD_COND_INITIALIZER, flush_end_mutex PTHREAD_MUTEX_INITIALIZER, skip_flush (false),
-    flush_completed (false), is_init (false), trace_last_writer (false), last_writer_client_info (),
-    last_writer_elapsed_time (0)
+  // *INDENT-OFF*
+  logwr_info ()
+    : writer_list (NULL)
+    , wr_list_mutex PTHREAD_MUTEX_INITIALIZER
+    , flush_start_cond PTHREAD_COND_INITIALIZER
+    , flush_start_mutex PTHREAD_MUTEX_INITIALIZER
+    , flush_wait_cond PTHREAD_COND_INITIALIZER
+    , flush_wait_mutex PTHREAD_MUTEX_INITIALIZER
+    , flush_end_cond PTHREAD_COND_INITIALIZER
+    , flush_end_mutex PTHREAD_MUTEX_INITIALIZER
+    , skip_flush (false)
+    , flush_completed (false)
+    , is_init (false)
+    , trace_last_writer (false)
+    , last_writer_client_info ()
+    , last_writer_elapsed_time (0)
   {
   }
+  // *INDENT-ON*
 };
 #endif /* !CS_MODE = SERVER_MODE || SA_MODE */
 

--- a/src/transaction/log_writer.h
+++ b/src/transaction/log_writer.h
@@ -26,6 +26,7 @@
 
 #ident "$Id$"
 
+#include "client_credentials.hpp"
 #include "log_archives.hpp"
 #include "log_common_impl.h"
 #include "log_lsa.hpp"
@@ -43,6 +44,15 @@ struct logwr_context
   int last_error;
   bool shutdown;
 };
+
+enum logwr_mode
+{
+  LOGWR_MODE_ASYNC = 1,
+  LOGWR_MODE_SEMISYNC,
+  LOGWR_MODE_SYNC
+};
+typedef enum logwr_mode LOGWR_MODE;
+#define LOGWR_COPY_FROM_FIRST_PHY_PAGE_MASK	(0x80000000)
 
 #if defined(CS_MODE)
 enum logwr_action
@@ -117,7 +127,62 @@ extern int logwr_set_hdr_and_flush_info (void);
 #if !defined(WINDOWS)
 extern int logwr_copy_log_header_check (const char *db_name, bool verbose, LOG_LSA * master_eof_lsa);
 #endif /* !WINDOWS */
-#endif /* CS_MODE */
+#else /* !CS_MODE = SERVER_MODE || SA_MODE */
+enum logwr_status
+{
+  LOGWR_STATUS_WAIT,
+  LOGWR_STATUS_FETCH,
+  LOGWR_STATUS_DONE,
+  LOGWR_STATUS_DELAY,
+  LOGWR_STATUS_ERROR
+};
+typedef enum logwr_status LOGWR_STATUS;
+
+typedef struct logwr_entry LOGWR_ENTRY;
+struct logwr_entry
+{
+  THREAD_ENTRY *thread_p;
+  LOG_PAGEID fpageid;
+  LOGWR_MODE mode;
+  LOGWR_STATUS status;
+  LOG_LSA eof_lsa;
+  LOG_LSA last_sent_eof_lsa;
+  LOG_LSA tmp_last_sent_eof_lsa;
+  INT64 start_copy_time;
+  bool copy_from_first_phy_page;
+  LOGWR_ENTRY *next;
+};
+
+typedef struct logwr_info LOGWR_INFO;
+struct logwr_info
+{
+  LOGWR_ENTRY *writer_list;
+  pthread_mutex_t wr_list_mutex;
+  pthread_cond_t flush_start_cond;
+  pthread_mutex_t flush_start_mutex;
+  pthread_cond_t flush_wait_cond;
+  pthread_mutex_t flush_wait_mutex;
+  pthread_cond_t flush_end_cond;
+  pthread_mutex_t flush_end_mutex;
+  bool skip_flush;
+  bool flush_completed;
+  bool is_init;
+
+  /* to measure the time spent by the last LWT delaying LFT */
+  bool trace_last_writer;
+  CLIENTIDS last_writer_client_info;
+  INT64 last_writer_elapsed_time;
+
+    logwr_info ():writer_list (NULL), wr_list_mutex PTHREAD_MUTEX_INITIALIZER,
+    flush_start_cond PTHREAD_COND_INITIALIZER, flush_start_mutex PTHREAD_MUTEX_INITIALIZER,
+    flush_wait_cond PTHREAD_COND_INITIALIZER, flush_wait_mutex PTHREAD_MUTEX_INITIALIZER,
+    flush_end_cond PTHREAD_COND_INITIALIZER, flush_end_mutex PTHREAD_MUTEX_INITIALIZER, skip_flush (false),
+    flush_completed (false), is_init (false), trace_last_writer (false), last_writer_client_info (),
+    last_writer_elapsed_time (0)
+  {
+  }
+};
+#endif /* !CS_MODE = SERVER_MODE || SA_MODE */
 
 extern bool logwr_force_shutdown (void);
 extern int logwr_copy_log_file (const char *db_name, const char *log_path, int mode, INT64 start_page_id);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22791

1. Move logwr_mode from log_common_impl.h to log_writer.h
2. Move LOG_BGARV_HEADER from log_common_impl.h to log_writer.c
3. logwr_info constructor instead of LOGWR_INFO_INITIALIZER
4. Move logwr_status, logwr_entry and logwr_info from log_impl.h to log_writer.h.
5. Changed log_Gl.writer_info to pointer to avoid log_writer.h dependency.