### PR TITLE
[CBRD-22811] Log 2pc header

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -290,6 +290,7 @@ set(TRANSACTION_SOURCES
   )
 set(TRANSACTION_HEADERS
   ${TRANSACTION_DIR}/client_credentials.hpp
+  ${TRANSACTION_DIR}/log_2pc.h
   ${TRANSACTION_DIR}/log_archives.hpp
   ${TRANSACTION_DIR}/log_common_impl.h
   ${TRANSACTION_DIR}/log_lsa.hpp

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -344,6 +344,7 @@ set(TRANSACTION_SOURCES
   )
 set(TRANSACTION_HEADERS
   ${TRANSACTION_DIR}/client_credentials.hpp
+  ${TRANSACTION_DIR}/log_2pc.h
   ${TRANSACTION_DIR}/log_archives.hpp
   ${TRANSACTION_DIR}/log_common_impl.h
   ${TRANSACTION_DIR}/log_lsa.hpp

--- a/src/transaction/log_2pc.c
+++ b/src/transaction/log_2pc.c
@@ -1734,8 +1734,8 @@ log_2pc_recovery_start (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * log_
   if (*ack_count > 0 && ack_list != NULL)
     {
       /*
-       * Some participant acknowledgemnts have already been
-       * received. Copy this acknowledgment into the transaction
+       * Some participant acknowledgements have already been
+       * received. Copy this acknowledgement into the transaction
        * descriptor.
        */
       for (i = 0; i < *ack_count; i++)
@@ -2011,7 +2011,7 @@ log_2pc_recovery_analysis_info (THREAD_ENTRY * thread_p, log_tdes * tdes, LOG_LS
     }
 
   /* If this is a coordinator transaction performing 2PC and voting record has not been read from the log in the
-   * recovery redo phase, read the voting record and any acknowledgment records logged for this transaction */
+   * recovery redo phase, read the voting record and any acknowledgement records logged for this transaction */
 
   if (tdes->coord == NULL)
     {

--- a/src/transaction/log_2pc.c
+++ b/src/transaction/log_2pc.c
@@ -23,7 +23,29 @@
 
 #ident "$Id$"
 
+#include "log_2pc.h"
+
 #include "config.h"
+#if defined(SERVER_MODE)
+#include "connection_error.h"
+#endif /* SERVER_MODE */
+#include "error_manager.h"
+#include "lock_manager.h"
+#include "log_comm.h"
+#include "log_impl.h"
+#include "log_lsa.hpp"
+#include "log_manager.h"
+#include "memory_alloc.h"
+#include "page_buffer.h"
+#include "storage_common.h"
+#include "system_parameter.h"
+
+#if !defined(WINDOWS)
+#include "tcp.h"		/* for css_gethostid */
+#else /* !WINDOWS */
+#include "wintcp.h"
+#include "porting.h"
+#endif /* !WINDOWS */
 
 #include <stddef.h>
 #include <string.h>
@@ -32,27 +54,6 @@
 
 /* The following two are for getpid */
 #include <sys/types.h>
-
-#include "log_manager.h"
-#include "log_impl.h"
-#include "log_comm.h"
-#include "log_lsa.hpp"
-#include "lock_manager.h"
-#include "memory_alloc.h"
-#include "storage_common.h"
-#include "page_buffer.h"
-#include "error_manager.h"
-#include "system_parameter.h"
-#if defined(SERVER_MODE)
-#include "connection_error.h"
-#include "thread_compat.hpp"
-#endif /* SERVER_MODE */
-#if !defined(WINDOWS)
-#include "tcp.h"		/* for css_gethostid */
-#else /* !WINDOWS */
-#include "wintcp.h"
-#include "porting.h"
-#endif /* !WINDOWS */
 
 #if !defined(SERVER_MODE)
 #define	CSS_ENABLE_INTERRUPTS
@@ -72,9 +73,6 @@ struct log_2pc_global_data
 struct log_2pc_global_data log_2pc_Userfun = { NULL, NULL, NULL, NULL, NULL, NULL, NULL };
 
 static int log_2pc_get_num_participants (int *partid_len, void **block_particps_ids);
-#if defined (ENABLE_UNUSED_FUNCTION)
-static int log_2pc_lookup_particp (void *look_particp_id, int num_particps, void *block_particps_ids);
-#endif
 static int log_2pc_make_global_tran_id (TRANID tranid);
 static bool log_2pc_check_duplicate_global_tran_id (int gtrid);
 static int log_2pc_commit_first_phase (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_2PC_EXECUTE execute_2pc_type,
@@ -84,9 +82,6 @@ static void log_2pc_append_start (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
 static void log_2pc_append_decision (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_RECTYPE decsion);
 static LOG_TDES *log_2pc_find_tran_descriptor (int gtrid);
 static int log_2pc_attach_client (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_TDES * client_tdes);
-#if defined (ENABLE_UNUSED_FUNCTION)
-static int log_2pc_broadcast_decision_participant (THREAD_ENTRY * thread_p, LOG_TDES * tdes, int particp_index);
-#endif
 static void log_2pc_recovery_prepare (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * log_lsa,
 				      LOG_PAGE * log_page_p);
 static int log_2pc_recovery_start (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * log_lsa, LOG_PAGE * log_page_p,
@@ -108,54 +103,13 @@ static void log_2pc_recovery_aborted_informing_participants (THREAD_ENTRY * thre
  *      APPLICATION (I.E, BETWEEN COORDINATOR AND PARTICIPANTS OR VICE VERSA)
  */
 
-#if defined (ENABLE_UNUSED_FUNCTION)
 /*
- * log_2pc_define_funs - Define the user 2pc functions
- *
- * return:
- *
- *   get_participants(in):
- *   lookup_participant(in):
- *   sprintf_participant(in):
- *   dump_participants(in):
- *   send_prepare(in):
- *   send_commit(in):
- *   send_abort(in):
- *      functions for 2PC communication (See prototype.. too many to describe
- *                                      here)
- *
- * NOTE:Define the functions used for communication between the
- *              coordinator (this code or your application) and the
- *              participants (your application or this code).
- *              See description blocks of each function for it uses.
- */
-void
-log_2pc_define_funs (int (*get_participants) (int *particp_id_length, void **block_particps_ids),
-		     int (*lookup_participant) (void *particp_id, int num_particps, void *block_particps_ids),
-		     char *(*sprintf_participant) (void *particp_id),
-		     void (*dump_participants) (FILE * fp, int block_length, void *block_particps_id),
-		     int (*send_prepare) (int gtrid, int num_particps, void *block_particps_ids),
-		     bool (*send_commit) (int gtrid, int num_particps, int *particp_indices, void *block_particps_ids),
-		     bool (*send_abort) (int gtrid, int num_particps, int *particp_indices, void *block_particps_ids,
-					 int collect))
-{
-  log_2pc_Userfun.get_participants = get_participants;
-  log_2pc_Userfun.lookup_participant = lookup_participant;
-  log_2pc_Userfun.sprintf_participant = sprintf_participant;
-  log_2pc_Userfun.dump_participants = dump_participants;
-  log_2pc_Userfun.send_prepare = send_prepare;
-  log_2pc_Userfun.send_commit = send_commit;
-  log_2pc_Userfun.send_abort = send_abort;
-}
-#endif
-
-/*
- * log_2pc_find_particps - Find all particpants
+ * log_2pc_find_particps - Find all participants
  *
  * return:  number of participants
  *
  *   partid_len(in): Length of each participant (Set as a side effect)
- *   block_particps_ids(in): An array of particpant ids where each particpant id
+ *   block_particps_ids(in): An array of participant ids where each participant id
  *                        is of length "partid_len" (Set as a side effect)
  *
  * NOTE:Find the participants of the current transaction. If the
@@ -193,32 +147,6 @@ log_2pc_get_num_participants (int *partid_len, void **block_particps_ids)
 
   return num_particps;
 }
-
-#if defined (ENABLE_UNUSED_FUNCTION)
-/*
- * log_2pc_lookup_particp - LOOK UP FOR A PARTICIPANT
- *
- * return: index
- *
- *   look_particp_id(in): Desired participant identifier
- *   num_particps(in): Number of participants at block_particps_ids
- *   block_particps_ids(in): An array of particpant ids. The length of each
- *                        element should be known by the callee.
- *
- * NOTE:Locate the given participant identifier on the block. If it is
- *              not found (-1) is returned.
- */
-static int
-log_2pc_lookup_particp (void *look_particp_id, int num_particps, void *block_particps_ids)
-{
-  if (log_2pc_Userfun.lookup_participant == NULL)
-    {
-      return -1;
-    }
-
-  return (*log_2pc_Userfun.lookup_participant) (look_particp_id, num_particps, block_particps_ids);
-}
-#endif
 
 /*
  * log_2pc_sprintf_particp - A STRING VERSION OF PARTICIPANT-ID
@@ -404,7 +332,7 @@ log_get_global_tran_id (THREAD_ENTRY * thread_p)
   tdes = LOG_FIND_TDES (tran_index);
   if (tdes != NULL)
     {
-      if (tdes->gtrid == LOG_2PC_NULL_GTRID && log_is_tran_distributed (tdes) == true)
+      if (tdes->gtrid == LOG_2PC_NULL_GTRID && log_2pc_is_tran_distributed (tdes) == true)
 	{
 	  tdes->gtrid = log_2pc_make_global_tran_id (tdes->trid);
 	}
@@ -741,7 +669,7 @@ log_2pc_commit_second_phase (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool * de
  *
  */
 TRAN_STATE
-log_2pc_commit (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_2PC_EXECUTE execute_2pc_type, bool * decision)
+log_2pc_commit (THREAD_ENTRY * thread_p, log_tdes * tdes, LOG_2PC_EXECUTE execute_2pc_type, bool * decision)
 {
   TRAN_STATE state;
 
@@ -814,7 +742,7 @@ log_2pc_commit (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_2PC_EXECUTE execut
  *              transaction identifier such as XID of XA interface.
  */
 int
-log_set_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *info, int size)
+log_2pc_set_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *info, int size)
 {
   LOG_TDES *tdes;
   int i;
@@ -881,7 +809,7 @@ log_set_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *info, int si
  *              calling 'db_2pc_prepared_transactions' to support xa_recover()
  */
 int
-log_get_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *buffer, int size)
+log_2pc_get_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *buffer, int size)
 {
   LOG_TDES *tdes;
   int i;
@@ -1203,108 +1131,6 @@ error:
 
 }
 
-#if defined (ENABLE_UNUSED_FUNCTION)
-/*
- * log_2pc_append_recv_ack - Acknowledgement received from a participant
- *
- * return:
- *
- *   particp_index(in): index of the participant that sent the acknowledgement
- *
- * NOTE:This function is invoked when an acknowledgement of a commit
- *              or abort decision is received for the current distributed
- *              transaction. A log record for this effect is logged to make
- *              the acknowledgement as known permanently.
- */
-int
-log_2pc_append_recv_ack (THREAD_ENTRY * thread_p, int particp_index)
-{
-  LOG_TDES *tdes;		/* Transaction descriptor */
-  LOG_REC_2PC_PARTICP_ACK *received_ack;
-  int tran_index;
-  LOG_LSA start_lsa;
-
-  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  tdes = LOG_FIND_TDES (tran_index);
-  if (tdes == NULL)
-    {
-      er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_UNKNOWN_TRANINDEX, 1, tran_index);
-      return ER_LOG_UNKNOWN_TRANINDEX;
-    }
-
-  if ((tdes->coord == NULL) || (tdes->coord->ack_received == NULL)
-      || (!LOG_ISTRAN_2PC_INFORMING_PARTICIPANTS (tdes) && (tdes->state != TRAN_UNACTIVE_2PC_COMMIT_DECISION)
-	  && (tdes->state != TRAN_UNACTIVE_2PC_ABORT_DECISION)))
-    {
-      /*
-       * May be a system error since transaction is not collecting
-       * acknowledgement from participants. No participant is expected to send
-       * acknowledgement.
-       */
-#if defined(CUBRID_DEBUG)
-      er_log_debug (ARG_FILE_LINE,
-		    "log_2pc_recvack: Transaction %d " "(index = %d) is not expecting acknowledgement."
-		    " Its state is %s\n", tdes->trid, tdes->tran_index, log_state_string (tdes->state));
-#endif /* CUBRID_DEBUG */
-      return ER_FAILED;
-    }
-
-  if (tdes->coord->num_particps < particp_index || particp_index < 0)
-    {
-      /*
-       * It is a system error since the given participant index is greater than
-       * the expected range (which is from 0 to num_particps - 1).
-       */
-#if defined(CUBRID_DEBUG)
-      er_log_debug (ARG_FILE_LINE,
-		    "log_2pc_recvack: Wrong " " Participant index = %d for distributed transaction = %d"
-		    " (index = %d). Valid participant indices are from = %d" " to %d", particp_index, tdes->trid,
-		    tdes->tran_index, 0, tdes->coord->num_particps - 1);
-#endif /* CUBRID_DEBUG */
-      return ER_FAILED;
-    }
-
-  if (tdes->coord->ack_received[particp_index] == true)
-    {
-      /* May be a system error since this participant has already sent its acknowledgement. */
-#if defined(CUBRID_DEBUG)
-      er_log_debug (ARG_FILE_LINE,
-		    "log_2pc_recvack: Participant %d" " of transaction %d (index = %d) has already sent its"
-		    " acknowledgement. It may be a system error. Operation is" " ignored.\n", tdes->trid,
-		    tdes->tran_index);
-#endif /* CUBRID_DEBUG */
-      return ER_FAILED;
-    }
-
-  /* Set the ack_received flag for this participant */
-  tdes->coord->ack_received[particp_index] = true;
-
-  LOG_CS_ENTER (thread_p);
-
-  /* Enter Log record for this acknowledgement */
-  start_lsa = logpb_start_append (thread_p, LOG_2PC_RECV_ACK, tdes);
-
-  /* ADD the data header */
-  LOG_APPEND_ADVANCE_WHEN_DOESNOT_FIT (thread_p, sizeof (*received_ack));
-  received_ack = (LOG_REC_2PC_PARTICP_ACK *) LOG_APPEND_PTR ();
-
-  received_ack->particp_index = particp_index;
-  LOG_APPEND_SETDIRTY_ADD_ALIGN (thread_p, sizeof (*received_ack));
-  /*
-   * END append
-   * Don't need to flush, if there is a need the participant will be contacted
-   * again.
-   */
-  logpb_end_append (thread_p);
-  logpb_flush_pages (thread_p, &start_lsa);
-  assert (LOG_CS_OWN (thread_p));
-
-  LOG_CS_EXIT (thread_p);
-
-  return NO_ERROR;
-}
-#endif /* ENABLE_UNUSED_FUNCTION */
-
 /*
  * log_2pc_prepare_global_tran - Prepare the transaction to commit
  *
@@ -1427,7 +1253,7 @@ log_2pc_prepare_global_tran (THREAD_ENTRY * thread_p, int gtrid)
    */
 
   tdes->gtrid = gtrid;
-  if (log_is_tran_distributed (tdes))
+  if (log_2pc_is_tran_distributed (tdes))
     {
       /*
        * Site is also a coordinator, so we need to execute a nested 2PC
@@ -1516,7 +1342,7 @@ log_2pc_prepare_global_tran (THREAD_ENTRY * thread_p, int gtrid)
  *              record.
  */
 void
-log_2pc_read_prepare (THREAD_ENTRY * thread_p, int acquire_locks, LOG_TDES * tdes, LOG_LSA * log_lsa,
+log_2pc_read_prepare (THREAD_ENTRY * thread_p, int acquire_locks, log_tdes * tdes, LOG_LSA * log_lsa,
 		      LOG_PAGE * log_page_p)
 {
   LOG_REC_2PC_PREPCOMMIT *prepared;	/* A 2PC prepare to commit log record */
@@ -1625,28 +1451,6 @@ log_2pc_dump_acqobj_locks (FILE * fp, int length, void *data)
   acq_locks.obj = (LK_ACQOBJ_LOCK *) data;
   lock_dump_acquired (fp, &acq_locks);
 }
-
-#if defined (ENABLE_UNUSED_FUNCTION)
-/*
- * log_2pc_dump_acqpage_locks - DUMP THE ACQUIRED PAGE LOCKS
- *
- * return: nothing
- *
- *   length(in): Length to dump in bytes
- *   data(in): The data being logged
- *
- * NOTE:Dump the acquired page lock structure.
- */
-void
-log_2pc_dump_acqpage_locks (FILE * fp, int length, void *data)
-{
-  LK_ACQUIRED_LOCKS acq_locks;
-
-  acq_locks.nobj_locks = 0;
-  acq_locks.obj = NULL;
-  lock_dump_acquired (fp, &acq_locks);
-}
-#endif
 
 /*
  * log_2pc_append_start - APPEND A VOTING LOG RECORD FOR THE 2PC PROTOCOL
@@ -1769,8 +1573,8 @@ log_2pc_append_decision (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_RECTYPE d
  * NOTE:This function is used to allocate and initialize coordinator
  *              related information about participants.
  */
-LOG_TDES *
-log_2pc_alloc_coord_info (LOG_TDES * tdes, int num_particps, int particp_id_length, void *block_particps_ids)
+log_tdes *
+log_2pc_alloc_coord_info (log_tdes * tdes, int num_particps, int particp_id_length, void *block_particps_ids)
 {
   /* Initialize the coordinator information */
   tdes->coord = (LOG_2PC_COORDINATOR *) malloc (sizeof (LOG_2PC_COORDINATOR));
@@ -1800,7 +1604,7 @@ log_2pc_alloc_coord_info (LOG_TDES * tdes, int num_particps, int particp_id_leng
  *              about participants.
  */
 void
-log_2pc_free_coord_info (LOG_TDES * tdes)
+log_2pc_free_coord_info (log_tdes * tdes)
 {
   if (tdes->coord != NULL)
     {
@@ -1817,202 +1621,6 @@ log_2pc_free_coord_info (LOG_TDES * tdes)
       free_and_init (tdes->coord);
     }
 }
-
-#if defined (ENABLE_UNUSED_FUNCTION)
-/*
- * log_2pc_crash_participant - A participant aborted its local part of the global
- *                          transaction, or went down
- *
- * return: nothing
- *
- * NOTE:This function informs the transaction manager that one or
- *              more of the participanting sites of the current global
- *              transaction (whose coordinator is this site) has either went
- *              down, or decided to unilaterally abort their local part of
- *              this global transaction. As a result, this global transaction
- *              is aborted by this function, if it was in active state. If the
- *              transaction was already in two phase commit protocol, then
- *              this function does not take any action here as this condition
- *              will be handled naturally by the two phase commit protocol.
- */
-void
-log_2pc_crash_participant (THREAD_ENTRY * thread_p)
-{
-  LOG_TDES *tdes;		/* Transaction descriptor */
-  const char *client_prog_name;	/* Client program name for transaction */
-  const char *client_user_name;	/* Client user name for transaction */
-  const char *client_host_name;	/* Client host for transaction */
-  int client_pid;		/* Client process identifier for transaction */
-  int tran_index;
-
-  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  tdes = LOG_FIND_TDES (tran_index);
-  if (tdes == NULL)
-    {
-      er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_UNKNOWN_TRANINDEX, 1, tran_index);
-      return;
-    }
-
-  if (log_is_tran_distributed (tdes) == false)
-    {
-      /* It is a system error since transaction is not a coordinator. */
-#if defined(CUBRID_DEBUG)
-      er_log_debug (ARG_FILE_LINE,
-		    "log_2pc_particp_crash: Transaction %d " "(index = %d) is not a global one; and thus has no "
-		    "participants that could abort. It is in state: %s\n", tdes->trid, tdes->tran_index,
-		    log_state_string (tdes->state));
-#endif /* CUBRID_DEBUG */
-      return;
-    }
-
-  tdes->coord->ack_received = NULL;
-
-  /* If the coordinator info has not been recorded in the tdes, do it now */
-
-  /* If the transaction is active it needs to be aborted; Otherwise (i.e. the transaction is in 2PC protocol), no
-   * action needs to be taken here; 2PC protocol will consider this condition */
-
-  (void) log_abort (thread_p, tran_index);
-
-  /* Put an error code recording this situation */
-  (void) logtb_find_client_name_host_pid (tdes->tran_index, &client_prog_name, &client_user_name, &client_host_name,
-					  &client_pid);
-  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_UNILATERALLY_ABORTED, 4, tdes->tran_index, client_user_name,
-	  client_host_name, client_pid);
-}
-
-/*
- * log_2pc_broadcast_decision_participant -
- *
- * return:
- *
- *   tdes(in):
- *   particp_index(in):
- *
- * Note:
- */
-static int
-log_2pc_broadcast_decision_participant (THREAD_ENTRY * thread_p, LOG_TDES * tdes, int particp_index)
-{
-  int *temp;
-  int local_tran_index;
-  int i;
-
-  if (tdes->coord->ack_received[particp_index] == false)
-    {
-      temp = (int *) calloc (sizeof (int), tdes->coord->num_particps);
-      if (temp == NULL)
-	{
-	  return ER_OUT_OF_VIRTUAL_MEMORY;
-	}
-      for (i = 0; i < tdes->coord->num_particps; i++)
-	{
-	  temp[i] = true;
-	}
-
-      temp[particp_index] = false;
-
-      local_tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-      LOG_SET_CURRENT_TRAN_INDEX (thread_p, tdes->tran_index);
-
-      if (LOG_ISTRAN_COMMITTED (tdes))
-	{
-	  /*
-	   * Decision was commit. Broadcast the commit to the participant
-	   */
-
-	  /*
-	   * Note that this communication needs to be synchronous (i.e. we
-	   * should wait for the return of the function call
-	   *
-	   * If the following function fails, the transaction will be
-	   * dangling and we need to retry sending the decision at another
-	   * point.
-	   * We have already decided and log the decision in the log file.
-	   */
-	  (void) log_2pc_send_commit_decision (tdes->gtrid, tdes->coord->num_particps, tdes->coord->ack_received,
-					       tdes->coord->block_particps_ids);
-	  if (tdes->coord->ack_received[particp_index] == true)
-	    {
-	      (void) log_complete_for_2pc (thread_p, tdes, LOG_COMMIT, LOG_DONT_NEED_NEWTRID);
-	    }
-	}
-      else
-	{
-	  /*
-	   * Decsion was abort. Broadcast the abort to the participant
-	   */
-
-	  /*
-	   * Note that this communication needs to be syncronous (i.e. we
-	   * should wait for the return of the function call
-	   *
-	   * If the following function fails, the transaction will be
-	   * dangling and we need to retry sending the decision at another
-	   * point.
-	   * We have already decided and log the decision in the log file.
-	   */
-	  (void) log_2pc_send_abort_decision (tdes->gtrid, tdes->coord->num_particps, temp,
-					      tdes->coord->block_particps_ids, true);
-	  if (tdes->coord->ack_received[particp_index] == true)
-	    {
-	      (void) log_complete_for_2pc (thread_p, tdes, LOG_ABORT, LOG_DONT_NEED_NEWTRID);
-	    }
-	}			/* else */
-
-      LOG_SET_CURRENT_TRAN_INDEX (thread_p, local_tran_index);
-      free_and_init (temp);
-    }
-
-  return ER_FAILED;
-}
-
-/*
- * log_2pc_send_decision_participant - Send decision of blocked transactions to just
- *                               reconnected participant
- *
- * return: nothing
- *
- *   particp_id(in): info to identify the participant to reconnect
- *
- * NOTE:For all distributed loose end transactions which have
- *              "partic-id" as a participant, the decisions are sent to this
- *              participant.
- *              This function is used when a participant is restarted.
- */
-void
-log_2pc_send_decision_participant (THREAD_ENTRY * thread_p, void *particp_id)
-{
-  LOG_TDES *tdes;		/* Transaction descriptor */
-  int particp_index;
-  int i;
-
-  for (i = 0;; i++)
-    {
-
-      TR_TABLE_CS_ENTER (thread_p);
-
-      if ((i >= log_Gl.trantable.num_total_indices || log_Gl.trantable.num_coord_loose_end_indices <= 0))
-	{
-	  TR_TABLE_CS_EXIT (thread_p);
-	  break;
-	}
-
-      TR_TABLE_CS_EXIT (thread_p);
-
-      tdes = LOG_FIND_TDES (i);
-      if (tdes != NULL && LOG_ISTRAN_2PC_INFORMING_PARTICIPANTS (tdes) && tdes->isloose_end)
-	{
-	  particp_index =
-	    log_2pc_lookup_particp (particp_id, tdes->coord->num_particps, tdes->coord->block_particps_ids);
-	  if (particp_index != -1)
-	    {
-	      (void) log_2pc_broadcast_decision_participant (thread_p, tdes, particp_index);
-	    }
-	}
-    }
-}
-#endif
 
 /*
  * log_2pc_recovery_prepare -
@@ -2373,7 +1981,7 @@ log_2pc_recovery_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE record_ty
  *              transaction is read by the redo phase of the recovery process.
  */
 void
-log_2pc_recovery_analysis_info (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * upto_chain_lsa)
+log_2pc_recovery_analysis_info (THREAD_ENTRY * thread_p, log_tdes * tdes, LOG_LSA * upto_chain_lsa)
 {
   LOG_RECORD_HEADER *log_rec;	/* Pointer to log record */
   char log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT], *aligned_log_pgbuf;
@@ -2403,7 +2011,7 @@ log_2pc_recovery_analysis_info (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LS
     }
 
   /* If this is a coordinator transaction performing 2PC and voting record has not been read from the log in the
-   * recovery redo phase, read the voting record and any acknowledgement records logged for this transaction */
+   * recovery redo phase, read the voting record and any acknowledgment records logged for this transaction */
 
   if (tdes->coord == NULL)
     {
@@ -2746,7 +2354,7 @@ log_is_tran_in_2pc (THREAD_ENTRY * thread_p)
 #endif
 
 /*
- * log_is_tran_distributed - IS THIS A COORDINATOR OF A DISTRIBUTED TRANSACTION
+ * log_2pc_is_tran_distributed - IS THIS A COORDINATOR OF A DISTRIBUTED TRANSACTION
  *
  * return:
  *
@@ -2756,7 +2364,7 @@ log_is_tran_in_2pc (THREAD_ENTRY * thread_p)
  *              is, coordinator information is initialized by this function.
  */
 bool
-log_is_tran_distributed (LOG_TDES * tdes)
+log_2pc_is_tran_distributed (log_tdes * tdes)
 {
   int num_particps = 0;		/* Number of participating sites */
   int particp_id_length;	/* Length of a particp_id */
@@ -2780,7 +2388,7 @@ log_is_tran_distributed (LOG_TDES * tdes)
 }
 
 /*
- * log_clear_and_is_tran_distributed - FIND IF TRANSACTION IS DISTRIBUTED AFTER
+ * log_2pc_clear_and_is_tran_distributed - FIND IF TRANSACTION IS DISTRIBUTED AFTER
  *                               CLEARING OLD COORDINATOR INFORMATION.
  *
  * return:
@@ -2795,8 +2403,8 @@ log_is_tran_distributed (LOG_TDES * tdes)
  *              not inform me of new participants.
  */
 bool
-log_clear_and_is_tran_distributed (LOG_TDES * tdes)
+log_2pc_clear_and_is_tran_distributed (log_tdes * tdes)
 {
   log_2pc_free_coord_info (tdes);
-  return log_is_tran_distributed (tdes);
+  return log_2pc_is_tran_distributed (tdes);
 }

--- a/src/transaction/log_2pc.h
+++ b/src/transaction/log_2pc.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+//
+// Log 2 phase commit
+//
+
+#ifndef _LOG_2PC_H_
+#define _LOG_2PC_H_
+
+#if !defined (SERVER_MODE) && !defined (SA_MODE)
+#error Wrong module
+#endif
+
+#include "log_comm.h"
+#include "log_lsa.hpp"
+#include "log_storage.hpp"
+#include "thread_compat.hpp"
+
+#include <cstdio>
+
+// forward declarations
+struct log_tdes;
+
+const int LOG_2PC_NULL_GTRID = -1;
+const bool LOG_2PC_OBTAIN_LOCKS = true;
+const bool LOG_2PC_DONT_OBTAIN_LOCKS = false;
+
+enum log_2pc_execute
+{
+  LOG_2PC_EXECUTE_FULL,		/* For the root coordinator */
+  LOG_2PC_EXECUTE_PREPARE,	/* For a participant that is also a non root coordinator execute the first phase of 2PC */
+  LOG_2PC_EXECUTE_COMMIT_DECISION,	/* For a participant that is also a non root coordinator execute the second
+					 * phase of 2PC. The root coordinator has decided a commit decision */
+  LOG_2PC_EXECUTE_ABORT_DECISION	/* For a participant that is also a non root coordinator execute the second
+					 * phase of 2PC. The root coordinator has decided an abort decision with or
+					 * without going to the first phase (i.e., prepare) of the 2PC */
+};
+typedef enum log_2pc_execute LOG_2PC_EXECUTE;
+
+typedef struct log_2pc_gtrinfo LOG_2PC_GTRINFO;
+struct log_2pc_gtrinfo
+{				/* Global transaction user information */
+  int info_length;
+  void *info_data;
+};
+
+typedef struct log_2pc_coordinator LOG_2PC_COORDINATOR;
+struct log_2pc_coordinator
+{				/* Coordinator maintains this info */
+  int num_particps;		/* Number of participating sites */
+  int particp_id_length;	/* Length of a participant identifier */
+  void *block_particps_ids;	/* A block of participants identifiers */
+  int *ack_received;		/* Acknowledgment received vector */
+};
+
+char *log_2pc_sprintf_particp (void *particp_id);
+void log_2pc_dump_participants (FILE * fp, int block_length, void *block_particps_ids);
+bool log_2pc_send_prepare (int gtrid, int num_particps, void *block_particps_ids);
+bool log_2pc_send_commit_decision (int gtrid, int num_particps, int *particps_indices, void *block_particps_ids);
+bool log_2pc_send_abort_decision (int gtrid, int num_particps, int *particps_indices, void *block_particps_ids,
+				  bool collect);
+TRAN_STATE log_2pc_commit (THREAD_ENTRY * thread_p, log_tdes * tdes, LOG_2PC_EXECUTE execute_2pc_type, bool * decision);
+int log_2pc_set_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *info, int size);
+int log_2pc_get_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *buffer, int size);
+int log_2pc_start (THREAD_ENTRY * thread_p);
+TRAN_STATE log_2pc_prepare (THREAD_ENTRY * thread_p);
+int log_2pc_recovery_prepared (THREAD_ENTRY * thread_p, int gtrids[], int size);
+int log_2pc_attach_global_tran (THREAD_ENTRY * thread_p, int gtrid);
+
+TRAN_STATE log_2pc_prepare_global_tran (THREAD_ENTRY * thread_p, int gtrid);
+void log_2pc_read_prepare (THREAD_ENTRY * thread_p, int acquire_locks, log_tdes * tdes, LOG_LSA * lsa,
+			   LOG_PAGE * log_pgptr);
+void log_2pc_dump_gtrinfo (FILE * fp, int length, void *data);
+void log_2pc_dump_acqobj_locks (FILE * fp, int length, void *data);
+log_tdes *log_2pc_alloc_coord_info (log_tdes * tdes, int num_particps, int particp_id_length, void *block_particps_ids);
+void log_2pc_free_coord_info (log_tdes * tdes);
+void log_2pc_recovery_analysis_info (THREAD_ENTRY * thread_p, log_tdes * tdes, LOG_LSA * upto_chain_lsa);
+void log_2pc_recovery (THREAD_ENTRY * thread_p);
+bool log_2pc_is_tran_distributed (log_tdes * tdes);
+bool log_2pc_clear_and_is_tran_distributed (log_tdes * tdes);
+
+#endif // !_LOG_2PC_H_

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -41,6 +41,7 @@
 #include "file_io.h"
 #include "lock_free.h"
 #include "lock_manager.h"
+#include "log_2pc.h"
 #include "log_archives.hpp"
 #include "log_comm.h"
 #include "log_common_impl.h"
@@ -209,10 +210,6 @@ struct bo_restart_arg;
         } \
     } \
   while (0)
-
-#define LOG_2PC_NULL_GTRID        (-1)
-#define LOG_2PC_OBTAIN_LOCKS      true
-#define LOG_2PC_DONT_OBTAIN_LOCKS false
 
 #if defined(SERVER_MODE)
 // todo - separate the client & server/sa_mode transaction index
@@ -498,33 +495,7 @@ struct log_append_info
     PTHREAD_MUTEX_INITIALIZER}
 #endif
 
-enum log_2pc_execute
-{
-  LOG_2PC_EXECUTE_FULL,		/* For the root coordinator */
-  LOG_2PC_EXECUTE_PREPARE,	/* For a participant that is also a non root coordinator execute the first phase of 2PC */
-  LOG_2PC_EXECUTE_COMMIT_DECISION,	/* For a participant that is also a non root coordinator execute the second
-					 * phase of 2PC. The root coordinator has decided a commit decision */
-  LOG_2PC_EXECUTE_ABORT_DECISION	/* For a participant that is also a non root coordinator execute the second
-					 * phase of 2PC. The root coordinator has decided an abort decision with or
-					 * without going to the first phase (i.e., prepare) of the 2PC */
-};
-typedef enum log_2pc_execute LOG_2PC_EXECUTE;
 
-typedef struct log_2pc_gtrinfo LOG_2PC_GTRINFO;
-struct log_2pc_gtrinfo
-{				/* Global transaction user information */
-  int info_length;
-  void *info_data;
-};
-
-typedef struct log_2pc_coordinator LOG_2PC_COORDINATOR;
-struct log_2pc_coordinator
-{				/* Coordinator maintains this info */
-  int num_particps;		/* Number of participating sites */
-  int particp_id_length;	/* Length of a participant identifier */
-  void *block_particps_ids;	/* A block of participants identifiers */
-  int *ack_received;		/* Acknowledgment received vector */
-};
 
 typedef struct log_topops_addresses LOG_TOPOPS_ADDRESSES;
 struct log_topops_addresses
@@ -1475,60 +1446,6 @@ extern int logpb_remove_all_in_log_path (THREAD_ENTRY * thread_p, const char *db
 
 extern void log_recovery (THREAD_ENTRY * thread_p, int ismedia_crash, time_t * stopat);
 extern LOG_LSA *log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr);
-
-
-#if defined (ENABLE_UNUSED_FUNCTION)
-extern void log_2pc_define_funs (int (*get_participants) (int *particp_id_length, void **block_particps_ids),
-				 int (*lookup_participant) (void *particp_id, int num_particps,
-							    void *block_particps_ids),
-				 char *(*fmt_participant) (void *particp_id),
-				 void (*dump_participants) (FILE * fp, int block_length, void *block_particps_id),
-				 int (*send_prepare) (int gtrid, int num_particps, void *block_particps_ids),
-				 bool (*send_commit) (int gtrid, int num_particps, int *particp_indices,
-						      void *block_particps_ids),
-				 bool (*send_abort) (int gtrid, int num_particps, int *particp_indices,
-						     void *block_particps_ids, int collect));
-#endif
-extern char *log_2pc_sprintf_particp (void *particp_id);
-extern void log_2pc_dump_participants (FILE * fp, int block_length, void *block_particps_ids);
-extern bool log_2pc_send_prepare (int gtrid, int num_particps, void *block_particps_ids);
-extern bool log_2pc_send_commit_decision (int gtrid, int num_particps, int *particps_indices, void *block_particps_ids);
-extern bool log_2pc_send_abort_decision (int gtrid, int num_particps, int *particps_indices, void *block_particps_ids,
-					 bool collect);
-#if defined (ENABLE_UNUSED_FUNCTION)
-extern int log_get_global_tran_id (THREAD_ENTRY * thread_p);
-#endif
-extern TRAN_STATE log_2pc_commit (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_2PC_EXECUTE execute_2pc_type,
-				  bool * decision);
-extern int log_set_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *info, int size);
-extern int log_get_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *buffer, int size);
-extern int log_2pc_start (THREAD_ENTRY * thread_p);
-extern TRAN_STATE log_2pc_prepare (THREAD_ENTRY * thread_p);
-extern int log_2pc_recovery_prepared (THREAD_ENTRY * thread_p, int gtrids[], int size);
-extern int log_2pc_attach_global_tran (THREAD_ENTRY * thread_p, int gtrid);
-#if defined (ENABLE_UNUSED_FUNCTION)
-extern int log_2pc_append_recv_ack (THREAD_ENTRY * thread_p, int particp_index);
-#endif
-extern TRAN_STATE log_2pc_prepare_global_tran (THREAD_ENTRY * thread_p, int gtrid);
-extern void log_2pc_read_prepare (THREAD_ENTRY * thread_p, int acquire_locks, LOG_TDES * tdes, LOG_LSA * lsa,
-				  LOG_PAGE * log_pgptr);
-extern void log_2pc_dump_gtrinfo (FILE * fp, int length, void *data);
-extern void log_2pc_dump_acqobj_locks (FILE * fp, int length, void *data);
-#if defined (ENABLE_UNUSED_FUNCTION)
-extern void log_2pc_dump_acqpage_locks (FILE * fp, int length, void *data);
-#endif
-extern LOG_TDES *log_2pc_alloc_coord_info (LOG_TDES * tdes, int num_particps, int particp_id_length,
-					   void *block_particps_ids);
-extern void log_2pc_free_coord_info (LOG_TDES * tdes);
-#if defined (ENABLE_UNUSED_FUNCTION)
-extern void log_2pc_crash_participant (THREAD_ENTRY * thread_p);
-extern void log_2pc_send_decision_participant (THREAD_ENTRY * thread_p, void *particp_id);
-extern bool log_is_tran_in_2pc (THREAD_ENTRY * thread_p);
-#endif
-extern void log_2pc_recovery_analysis_info (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * upto_chain_lsa);
-extern void log_2pc_recovery (THREAD_ENTRY * thread_p);
-extern bool log_is_tran_distributed (LOG_TDES * tdes);
-extern bool log_clear_and_is_tran_distributed (LOG_TDES * tdes);
 
 extern void *logtb_realloc_topops_stack (LOG_TDES * tdes, int num_elms);
 extern void logtb_define_trantable (THREAD_ENTRY * thread_p, int num_expected_tran_indices, int num_expected_locks);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -5616,7 +5616,7 @@ log_commit (THREAD_ENTRY * thread_p, int tran_index, bool retain_lock)
       tdes->max_unique_btrees = 0;
     }
 
-  if (log_clear_and_is_tran_distributed (tdes))
+  if (log_2pc_clear_and_is_tran_distributed (tdes))
     {
       /* This is the coordinator of a distributed transaction If we are in prepare to commit mode. I cannot be the
        * root coordinator, so the decision has been taken at this moment by the root coordinator */
@@ -5747,7 +5747,7 @@ log_abort (THREAD_ENTRY * thread_p, int tran_index)
    * has been taken without using the 2PC.
    */
 
-  if (log_clear_and_is_tran_distributed (tdes))
+  if (log_2pc_clear_and_is_tran_distributed (tdes))
     {
       /* This is the coordinator of a distributed transaction */
       state = log_2pc_commit (thread_p, tdes, LOG_2PC_EXECUTE_ABORT_DECISION, &decision);

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -32,6 +32,7 @@
 #include <time.h>
 #include <assert.h>
 
+#include "log_2pc.h"
 #include "log_impl.h"
 #include "log_lsa.hpp"
 #include "log_manager.h"

--- a/src/transaction/log_storage.hpp
+++ b/src/transaction/log_storage.hpp
@@ -24,7 +24,9 @@
 #ifndef _LOG_STORAGE_HPP_
 #define _LOG_STORAGE_HPP_
 
+#include "file_io.h"
 #include "log_lsa.hpp"
+#include "release_string.h"
 #include "storage_common.h"
 #include "system.h"
 #include "transaction_global.hpp"

--- a/src/transaction/transaction_sr.c
+++ b/src/transaction/transaction_sr.c
@@ -30,6 +30,7 @@
 #include "transaction_sr.h"
 
 #include "locator_sr.h"
+#include "log_2pc.h"
 #include "log_lsa.hpp"
 #include "log_manager.h"
 #if defined(SERVER_MODE)
@@ -403,7 +404,7 @@ xtran_server_partial_abort (THREAD_ENTRY * thread_p, const char *savept_name, LO
 int
 xtran_server_set_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *info, int size)
 {
-  return log_set_global_tran_info (thread_p, gtrid, info, size);
+  return log_2pc_set_global_tran_info (thread_p, gtrid, info, size);
 }
 
 /*
@@ -425,7 +426,7 @@ xtran_server_set_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *inf
 int
 xtran_server_get_global_tran_info (THREAD_ENTRY * thread_p, int gtrid, void *buffer, int size)
 {
-  return log_get_global_tran_info (thread_p, gtrid, buffer, size);
+  return log_2pc_get_global_tran_info (thread_p, gtrid, buffer, size);
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22811

Move two phase commit structures and function declarations from log_impl.h to newly created header log_2pc.h. Some functions have been renames (by adding "2pc" to name prefix) and extern was stripped from function declarations.

Unused functions have been deleted.