### PR TITLE
[CBRD-22809] Moved LOG_CS to log_manager

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1447,10 +1447,10 @@ shutdown:
   vacuum_stop (thread_p);
 
   /* we should flush all append pages before stop log writer */
-  LOG_CS_ENTER (thread_p);
-  logpb_flush_pages_direct (thread_p);
+  logpb_force_flush_pages (thread_p);
 
 #if !defined(NDEBUG)
+  LOG_CS_ENTER (thread_p);
   pthread_mutex_lock (&log_Gl.prior_info.prior_lsa_mutex);
   if (!LSA_EQ (&log_Gl.append.nxio_lsa, &log_Gl.prior_info.prior_lsa))
     {
@@ -1467,9 +1467,10 @@ shutdown:
 	}
     }
   pthread_mutex_unlock (&log_Gl.prior_info.prior_lsa_mutex);
+  LOG_CS_EXIT (thread_p);
 #endif
 
-  LOG_CS_EXIT (thread_p);
+
 
   // stop log writers
   css_stop_all_workers (*thread_p, THREAD_STOP_LOGWR);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2973,7 +2973,7 @@ restart:
   log_append_redo_data2 (thread_p, RVVAC_COMPLETE, NULL, (PAGE_PTR) vacuum_Data.first_page, 0,
 			 sizeof (log_Gl.hdr.mvcc_next_id), &log_Gl.hdr.mvcc_next_id);
   vacuum_set_dirty_data_page (thread_p, vacuum_Data.first_page, DONT_FREE);
-  logpb_flush_pages_direct (thread_p);
+  logpb_force_flush_pages (thread_p);
 
   /* Cleanup dropped files. */
   vacuum_cleanup_dropped_files (thread_p);

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -35,6 +35,7 @@
 #include "dbtype.h"
 #include "external_sort.h"
 #include "heap_file.h"
+#include "log_manager.h"
 #include "memory_private_allocator.hpp"
 #include "mvcc.h"
 #include "object_primitive.h"
@@ -1096,9 +1097,7 @@ xbtree_load_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_name, TP
       /* index was not loaded and xbtree_add_index was called instead. we have nothing to log here. */
     }
 
-  LOG_CS_ENTER (thread_p);
-  logpb_flush_pages_direct (thread_p);
-  LOG_CS_EXIT (thread_p);
+  logpb_force_flush_pages (thread_p);
 
   if (prm_get_bool_value (PRM_ID_LOG_BTREE_OPS))
     {
@@ -4731,9 +4730,7 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
       list_btid = NULL;
     }
 
-  LOG_CS_ENTER (thread_p);
-  logpb_flush_pages_direct (thread_p);
-  LOG_CS_EXIT (thread_p);
+  logpb_force_flush_pages (thread_p);
 
   /* TODO: Is this all right? */
   /* Invalidate snapshot. */

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -565,9 +565,7 @@ disk_format (THREAD_ENTRY * thread_p, const char *dbname, VOLID volid, DBDEF_VOL
   fault_inject_random_crash ();
 
   /* this log must be flushed. */
-  LOG_CS_ENTER (thread_p);
-  logpb_flush_pages_direct (thread_p);
-  LOG_CS_EXIT (thread_p);
+  logpb_force_flush_pages (thread_p);
   fault_inject_random_crash ();
 
   /* create and initialize the volume. recovery information is initialized in every page. */
@@ -1046,9 +1044,7 @@ disk_set_link (THREAD_ENTRY * thread_p, INT16 volid, INT16 next_volid, const cha
     }
 
   /* Forcing the log here to be safer, especially in the case of permanent temp volumes. */
-  LOG_CS_ENTER (thread_p);
-  logpb_flush_pages_direct (thread_p);
-  LOG_CS_EXIT (thread_p);
+  logpb_force_flush_pages (thread_p);
 
   (void) disk_verify_volume_header (thread_p, addr.pgptr);
 
@@ -1970,9 +1966,7 @@ disk_volume_expand (THREAD_ENTRY * thread_p, VOLID volid, DB_VOLTYPE voltype, DK
   FI_TEST (thread_p, FI_TEST_DISK_MANAGER_VOLUME_EXPAND, 0);
 
   /* to be sure expansion really happens on recovery too, we must flush log! */
-  LOG_CS_ENTER (thread_p);
-  logpb_flush_pages_direct (thread_p);
-  LOG_CS_EXIT (thread_p);
+  logpb_force_flush_pages (thread_p);
 
   FI_TEST (thread_p, FI_TEST_DISK_MANAGER_VOLUME_EXPAND, 0);
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -5307,9 +5307,7 @@ end:
   log_sysop_attach_to_outer (thread_p);
   vacuum_log_add_dropped_file (thread_p, &hfid->vfid, class_oid, VACUUM_LOG_ADD_DROPPED_FILE_UNDO);
 
-  LOG_CS_ENTER (thread_p);
-  logpb_flush_pages_direct (thread_p);
-  LOG_CS_EXIT (thread_p);
+  logpb_force_flush_pages (thread_p);
 
   return NO_ERROR;
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -3260,9 +3260,7 @@ pgbuf_flush_victim_candidates (THREAD_ENTRY * thread_p, float flush_ratio, PERF_
   else
 #endif /* SERVER_MODE */
     {
-      LOG_CS_ENTER (thread_p);
-      logpb_flush_pages_direct (thread_p);
-      LOG_CS_EXIT (thread_p);
+      logpb_force_flush_pages (thread_p);
     }
 
   if (prm_get_bool_value (PRM_ID_PB_SEQUENTIAL_VICTIM_FLUSH) == true)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -4941,7 +4941,7 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
       goto error;
     }
 
-  logpb_flush_pages_direct (thread_p);
+  logpb_force_flush_pages (thread_p);
   (void) pgbuf_flush_all (thread_p, NULL_VOLID);
   (void) fileio_synchronize_all (thread_p, false);
 
@@ -5971,10 +5971,7 @@ boot_after_copydb (THREAD_ENTRY * thread_p)
   log_Gl.hdr.was_copied = false;
 
   // flush log and header to disk to make sure everything is saved
-  LOG_CS_ENTER (thread_p);
-  logpb_flush_pages_direct (thread_p);
-  logpb_flush_header (thread_p);
-  LOG_CS_EXIT (thread_p);
+  logpb_force_flush_header_and_pages (thread_p);
 
   er_log_debug (ARG_FILE_LINE, "Complete boot_after_copydb \n");
 

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -68,17 +68,6 @@ struct bo_restart_arg;
 #define TRANS_STATUS_HISTORY_MAX_SIZE 2048
 
 #if defined(SERVER_MODE)
-#define LOG_CS_ENTER(thread_p) \
-        csect_enter((thread_p), CSECT_LOG, INF_WAIT)
-#define LOG_CS_ENTER_READ_MODE(thread_p) \
-        csect_enter_as_reader((thread_p), CSECT_LOG, INF_WAIT)
-#define LOG_CS_DEMOTE(thread_p) \
-        csect_demote((thread_p), CSECT_LOG, INF_WAIT)
-#define LOG_CS_PROMOTE(thread_p) \
-        csect_promote((thread_p), CSECT_LOG, INF_WAIT)
-#define LOG_CS_EXIT(thread_p) \
-        csect_exit((thread_p), CSECT_LOG)
-
 #define TR_TABLE_CS_ENTER(thread_p) \
         csect_enter((thread_p), CSECT_TRAN_TABLE, INF_WAIT)
 #define TR_TABLE_CS_ENTER_READ_MODE(thread_p) \
@@ -94,12 +83,6 @@ struct bo_restart_arg;
         csect_exit (thread_p, CSECT_LOG_ARCHIVE)
 
 #else /* SERVER_MODE */
-#define LOG_CS_ENTER(thread_p)
-#define LOG_CS_ENTER_READ_MODE(thread_p)
-#define LOG_CS_DEMOTE(thread_p)
-#define LOG_CS_PROMOTE(thread_p)
-#define LOG_CS_EXIT(thread_p)
-
 #define TR_TABLE_CS_ENTER(thread_p)
 #define TR_TABLE_CS_ENTER_READ_MODE(thread_p)
 #define TR_TABLE_CS_EXIT(thread_p)
@@ -110,16 +93,6 @@ struct bo_restart_arg;
 #endif /* SERVER_MODE */
 
 #if defined(SERVER_MODE)
-/* TODO: Vacuum workers never hold CSECT_LOG lock. Investigate any possible
- *	 unwanted consequences.
- * NOTE: It is considered that a vacuum worker holds a "shared" lock.
- * TODO: remove vacuum code from LOG_CS_OWN
- */
-#define LOG_CS_OWN(thread_p) \
-  (vacuum_is_process_log_for_vacuum (thread_p) \
-   || csect_check_own (thread_p, CSECT_LOG) >= 1)
-#define LOG_CS_OWN_WRITE_MODE(thread_p) \
-  (csect_check_own (thread_p, CSECT_LOG) == 1)
 
 #define LOG_ARCHIVE_CS_OWN(thread_p) \
   (csect_check (thread_p, CSECT_LOG_ARCHIVE) >= 1)
@@ -129,9 +102,6 @@ struct bo_restart_arg;
   (csect_check_own (thread_p, CSECT_LOG_ARCHIVE) == 2)
 
 #else /* SERVER_MODE */
-#define LOG_CS_OWN(thread_p) (true)
-#define LOG_CS_OWN_WRITE_MODE(thread_p) (true)
-
 #define LOG_ARCHIVE_CS_OWN(thread_p) (true)
 #define LOG_ARCHIVE_CS_OWN_WRITE_MODE(thread_p) (true)
 #define LOG_ARCHIVE_CS_OWN_READ_MODE(thread_p) (true)
@@ -1400,6 +1370,8 @@ extern int logpb_fetch_start_append_page (THREAD_ENTRY * thread_p);
 extern LOG_PAGE *logpb_fetch_start_append_page_new (THREAD_ENTRY * thread_p);
 extern void logpb_flush_pages_direct (THREAD_ENTRY * thread_p);
 extern void logpb_flush_pages (THREAD_ENTRY * thread_p, LOG_LSA * flush_lsa);
+extern void logpb_force_flush_pages (THREAD_ENTRY * thread_p);
+extern void logpb_force_flush_header_and_pages (THREAD_ENTRY * thread_p);
 extern void logpb_invalid_all_append_pages (THREAD_ENTRY * thread_p);
 extern void logpb_flush_log_for_wal (THREAD_ENTRY * thread_p, const LOG_LSA * lsa_ptr);
 extern LOG_PRIOR_NODE *prior_lsa_alloc_and_copy_data (THREAD_ENTRY * thread_p, LOG_RECTYPE rec_type,

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -84,6 +84,7 @@
 #include "thread_entry.hpp"
 #include "thread_entry_task.hpp"
 #include "thread_manager.hpp"
+#include "vacuum.h"
 #include "xasl_cache.h"
 
 #include "dbtype.h"
@@ -10762,4 +10763,88 @@ logtb_tran_update_stats_online_index_rb (THREAD_ENTRY * thread_p, void *data, vo
 					       false);
 
   return error_code;
+}
+
+//
+// log critical section
+//
+
+void
+LOG_CS_ENTER (THREAD_ENTRY * thread_p)
+{
+#if defined (SERVER_MODE)
+  if (csect_enter (thread_p, CSECT_LOG, INF_WAIT) != NO_ERROR)
+    {
+      assert (false);
+    }
+#endif
+}
+
+void
+LOG_CS_ENTER_READ_MODE (THREAD_ENTRY * thread_p)
+{
+#if defined (SERVER_MODE)
+  if (csect_enter_as_reader (thread_p, CSECT_LOG, INF_WAIT) != NO_ERROR)
+    {
+      assert (false);
+    }
+#endif
+}
+
+void
+LOG_CS_EXIT (THREAD_ENTRY * thread_p)
+{
+#if defined (SERVER_MODE)
+  if (csect_exit (thread_p, CSECT_LOG) != NO_ERROR)
+    {
+      assert (false);
+    }
+#endif
+}
+
+void
+LOG_CS_DEMOTE (THREAD_ENTRY * thread_p)
+{
+#if defined (SERVER_MODE)
+  if (csect_demote (thread_p, CSECT_LOG, INF_WAIT) != NO_ERROR)
+    {
+      assert (false);
+    }
+#endif
+}
+
+void
+LOG_CS_PROMOTE (THREAD_ENTRY * thread_p)
+{
+#if defined (SERVER_MODE)
+  if (csect_promote (thread_p, CSECT_LOG, INF_WAIT) != NO_ERROR)
+    {
+      assert (false);
+    }
+#endif
+}
+
+bool
+LOG_CS_OWN (THREAD_ENTRY * thread_p)
+{
+#if defined (SERVER_MODE)
+  /* TODO: Vacuum workers never hold CSECT_LOG lock. Investigate any possible
+   *     unwanted consequences.
+   * NOTE: It is considered that a vacuum worker holds a "shared" lock.
+   * TODO: remove vacuum code from LOG_CS_OWN
+   */
+  return vacuum_is_process_log_for_vacuum (thread_p) || (csect_check_own (thread_p, CSECT_LOG) >= 1);
+#else // not server mode
+  return true;
+#endif // not server mode
+}
+
+bool
+LOG_CS_OWN_WRITE_MODE (THREAD_ENTRY * thread_p)
+{
+#if defined (SERVER_MODE)
+  return csect_check_own (thread_p, CSECT_LOG) == 1;
+#else // not server mode
+  return true;
+#endif // not server mode
 }

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -218,4 +218,17 @@ extern void log_flush_daemon_get_stats (UINT64 * statsp);
 
 extern void log_update_global_btid_online_index_stats (THREAD_ENTRY * thread_p);
 
+//
+// log critical section
+//
+
+void LOG_CS_ENTER (THREAD_ENTRY * thread_p);
+void LOG_CS_ENTER_READ_MODE (THREAD_ENTRY * thread_p);
+void LOG_CS_EXIT (THREAD_ENTRY * thread_p);
+void LOG_CS_DEMOTE (THREAD_ENTRY * thread_p);
+void LOG_CS_PROMOTE (THREAD_ENTRY * thread_p);
+
+bool LOG_CS_OWN (THREAD_ENTRY * thread_p);
+bool LOG_CS_OWN_WRITE_MODE (THREAD_ENTRY * thread_p);
+
 #endif /* _LOG_MANAGER_H_ */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -5184,6 +5184,23 @@ logpb_flush_pages (THREAD_ENTRY * thread_p, LOG_LSA * flush_lsa)
 #endif /* SERVER_MODE */
 }
 
+void
+logpb_force_flush_pages (THREAD_ENTRY * thread_p)
+{
+  LOG_CS_ENTER (thread_p);
+  logpb_flush_pages_direct (thread_p);
+  LOG_CS_EXIT (thread_p);
+}
+
+void
+logpb_force_flush_header_and_pages (THREAD_ENTRY * thread_p)
+{
+  LOG_CS_ENTER (thread_p);
+  logpb_flush_pages_direct (thread_p);
+  logpb_flush_header (thread_p);
+  LOG_CS_EXIT (thread_p);
+}
+
 /*
  * logpb_invalid_all_append_pages - Invalidate all append pages
  *

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -49,6 +49,7 @@
 #include "dbtran_def.h"
 #include "log_impl.h"
 #include "log_lsa.hpp"
+#include "log_manager.h"
 #include "log_system_tran.hpp"
 #include "error_manager.h"
 #include "system_parameter.h"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22809

Moved LOG_CS_xxx macro's to log_manager.h and converted them to functions.

Added logpb_force_flush_pages/logpb_force_flush_header_and_pages functions to automatically lock/unlock critical section.