### PR TITLE
[CBRD-22812] Add java.sql.Driver service provider

### DIFF
--- a/jdbc/build.xml
+++ b/jdbc/build.xml
@@ -51,10 +51,11 @@
 
     <target name="dist-cubrid" depends="build-cubrid">
         <jar jarfile="${cubrid-jar-file}">
-        <fileset dir="${bin-cubrid}"/>
-        <fileset file="${src}/sql-error-codes.xml"/>
-	<fileset file="src/CUBRID-JDBC-${version}"/>
-    </jar>
+            <fileset dir="${bin-cubrid}"/>
+            <fileset file="${src}/sql-error-codes.xml"/>
+            <fileset file="src/CUBRID-JDBC-${version}"/>
+            <service type="java.sql.Driver" provider="cubrid.jdbc.driver.CUBRIDDriver"/>
+        </jar>
     </target>
 
     <target name="build-cubrid" depends="compile-cubrid">
@@ -82,7 +83,8 @@
         <jar jarfile="JDBC-${version}-cubrid-src.jar">
             <fileset dir="${src-cubrid}"/>
             <fileset file="${src}/sql-error-codes.xml"/>
-	    <fileset file="src/CUBRID-JDBC-${version}"/>
+            <fileset file="src/CUBRID-JDBC-${version}"/>
+            <service type="java.sql.Driver" provider="cubrid.jdbc.driver.CUBRIDDriver"/>
         </jar>
     </target>
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22812

The DriverManager methods getConnection and getDrivers have been enhanced to support the Java SE Service Provider mechanism (SPM). According to SPM, a service is defined as a well-known set of interfaces and abstract classes, and a service provider is a specific implementation of a service. It also specifies that the service provider configuration files are stored in the META-INF/services directory. JDBC 4.0 drivers must include the file META-INF/services/java.sql.Driver. This file contains the name of the JDBC driver's implementation of java.sql.Driver.