### PR TITLE
[CBRD-22818] Use default PUBLIC when no user name is provided.

### DIFF
--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -5802,6 +5802,12 @@ au_user_name (void)
   return name;
 }
 
+bool
+au_has_user_name (void)
+{
+  return Au_user != NULL || strlen (Au_user_name) > 0;
+}
+
 /*
  * CLASS ACCESSING
  */

--- a/src/object/authenticate.h
+++ b/src/object/authenticate.h
@@ -192,6 +192,7 @@ extern int au_set_user_comment (MOP user, const char *comment);
 
 extern const char *au_user_name (void);
 extern char *au_user_name_dup (void);
+extern bool au_has_user_name (void);
 
 /* grant/revoke */
 extern int au_grant (MOP user, MOP class_mop, DB_AUTH type, bool grant_option);

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -914,8 +914,11 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
   /* Get the user name */
   if (client_credential->db_user.empty ())
     {
-      client_credential->db_user = au_user_name ();
-      if (client_credential->db_user.empty ())
+      if (au_has_user_name ())
+	{
+	  client_credential->db_user = au_user_name ();
+	}
+      else
 	{
 	  // default is PUBLIC
 	  client_credential->db_user = AU_PUBLIC_USER_NAME;

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -914,22 +914,10 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
   /* Get the user name */
   if (client_credential->db_user.empty ())
     {
-      char *user_name = au_user_name_dup ();
-
-      if (user_name != NULL)
-	{
-	  /* user name is upper-cased in server using server's charset */
-	  client_credential->db_user = user_name;
-	}
-
+      client_credential->db_user = au_user_name ();
       if (client_credential->db_user.empty ())
 	{
-	  // no user string
-	  client_credential->db_user = boot_Client_no_user_string;
-	}
-      else if (client_credential->db_user == "\0")
-	{
-	  // empty user string
+	  // default is PUBLIC
 	  client_credential->db_user = AU_PUBLIC_USER_NAME;
 	}
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22818

1. Add au_has_user_name function - returns true if any name was provided, false otherwise.
2. is au_has_user_name returns false, use AU_PUBLIC_USER_NAME