### PR TITLE
[CBRD-22813] Index Builder has to use the global HEAPID when generating compressed strings

### DIFF
--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -5055,10 +5055,6 @@ index_builder_loader_task::add_key (const DB_VALUE * key, const OID & oid)
   db_value & last_key = m_keys_oids.back ().m_key;
   db_make_null (&last_key);
   int disk_size = 0;
-  /*
-  cubmem::switch_to_global_allocator_and_call (qdata_copy_db_value, &last_key, key);
-
-  m_memsize += m_load_context.m_key_type->type->get_disk_size_of_value (&last_key);*/
 
   cubmem::switch_to_global_allocator_and_call (copy_db_value_and_get_size, &last_key, key, m_load_context.m_key_type, &disk_size);
   m_memsize += disk_size;

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -36,6 +36,7 @@
 #include "external_sort.h"
 #include "heap_file.h"
 #include "log_manager.h"
+#include "memory_alloc.h"
 #include "memory_private_allocator.hpp"
 #include "mvcc.h"
 #include "object_primitive.h"
@@ -49,7 +50,6 @@
 #include "thread_entry_task.hpp"
 #include "xserver_interface.h"
 #include "xasl.h"
-#include "memory_alloc.h"
 
 typedef struct sort_args SORT_ARGS;
 struct sort_args
@@ -5011,25 +5011,25 @@ btree_is_worker_pool_logging_true ()
 }
 
 void
-index_builder_loader_context::on_create (context_type & context)
+index_builder_loader_context::on_create (context_type &context)
 {
   context.claim_system_worker ();
 }
 
 void
-index_builder_loader_context::on_retire (context_type & context)
+index_builder_loader_context::on_retire (context_type &context)
 {
   context.retire_system_worker ();
 }
 
 void
-index_builder_loader_context::on_recycle (context_type & context)
+index_builder_loader_context::on_recycle (context_type &context)
 {
   context.tran_index = LOG_SYSTEM_TRAN_INDEX;
 }
 
-index_builder_loader_task::index_builder_loader_task (const BTID * btid, const OID * class_oid, int unique_pk,
-						      index_builder_loader_context & load_context)
+index_builder_loader_task::index_builder_loader_task (const BTID *btid, const OID *class_oid, int unique_pk,
+						      index_builder_loader_context &load_context)
   : m_load_context (load_context)
 {
   BTID_COPY (&m_btid, btid);
@@ -5045,16 +5045,16 @@ index_builder_loader_task::~index_builder_loader_task ()
 }
 
 index_builder_loader_task::batch_key_status
-index_builder_loader_task::add_key (const DB_VALUE * key, const OID & oid)
+index_builder_loader_task::add_key (const DB_VALUE *key, const OID &oid)
 {
   m_keys_oids.emplace_back ();
 
   m_keys_oids.back ().m_oid = oid;
 
-  db_value & last_key = m_keys_oids.back ().m_key;
+  db_value &last_key = m_keys_oids.back ().m_key;
   db_make_null (&last_key);
   
-  THREAD_ENTRY * thread_p = thread_get_thread_entry_info ();
+  THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
 
   /* Switch to global heapID. */
   HL_HEAPID prev_id = db_change_private_heap (thread_p, 0);
@@ -5062,10 +5062,12 @@ index_builder_loader_task::add_key (const DB_VALUE * key, const OID & oid)
   qdata_copy_db_value (&last_key, key);
   m_memsize += m_load_context.m_key_type->type->get_disk_size_of_value (&last_key);
 
+  /* reset back to previous heapID. */
   db_change_private_heap (thread_p, prev_id);
 
   m_memsize += OR_OID_SIZE;
   m_memsize = DB_ALIGN (m_memsize, BTREE_MAX_ALIGN);
+
   return (m_memsize > (size_t) prm_get_bigint_value (PRM_ID_IB_TASK_MEMSIZE)) ? BATCH_FULL : BATCH_CONTINUE;
 }
 
@@ -5078,14 +5080,14 @@ index_builder_loader_task::has_keys () const
 void
 index_builder_loader_task::clear_keys ()
 {
-  for (auto & key_oid:m_keys_oids)
+  for (auto &key_oid : m_keys_oids)
     {
       pr_clear_value (&key_oid.m_key);
     }
 }
 
 void
-index_builder_loader_task::execute (cubthread::entry & thread_ref)
+index_builder_loader_task::execute (cubthread::entry &thread_ref)
 {
   int ret = NO_ERROR;
   size_t key_count = 0;
@@ -5096,7 +5098,7 @@ index_builder_loader_task::execute (cubthread::entry & thread_ref)
       return;
     }
 
-  for (auto & key_oid : m_keys_oids)
+  for (auto &key_oid : m_keys_oids)
     {
       ret = btree_online_index_dispatcher (&thread_ref, &m_btid, &key_oid.m_key, &m_class_oid, &key_oid.m_oid,
 					   m_unique_pk, BTREE_OP_ONLINE_INDEX_IB_INSERT, NULL);
@@ -5120,6 +5122,7 @@ index_builder_loader_task::execute (cubthread::entry & thread_ref)
     {
       _er_log_debug (ARG_FILE_LINE, "Finished task; loaded %zu keys\n", key_count);
     }
+
   m_load_context.m_tasks_executed++;
 }
 // *INDENT-ON*

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -5055,20 +5055,14 @@ index_builder_loader_task::add_key (const DB_VALUE * key, const OID & oid)
   db_make_null (&last_key);
   
   THREAD_ENTRY * thread_p = thread_get_thread_entry_info ();
-  HL_HEAPID prev_id = thread_p->private_heap_id;
 
   /* Switch to global heapID. */
-#if defined (SERVER_MODE)
-  db_private_set_heapid_to_thread (thread_p, 0);
-#endif // SERVER_MODE
+  HL_HEAPID prev_id = db_change_private_heap (thread_p, 0);
 
   qdata_copy_db_value (&last_key, key);
   m_memsize += m_load_context.m_key_type->type->get_disk_size_of_value (&last_key);
 
-  /* Switch back the heapID. */
-#if defined (SERVER_MODE)
-  db_private_set_heapid_to_thread (thread_p, prev_id);
-#endif // SERVER_MODE
+  db_change_private_heap (thread_p, prev_id);
 
   m_memsize += OR_OID_SIZE;
   m_memsize = DB_ALIGN (m_memsize, BTREE_MAX_ALIGN);

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -49,6 +49,7 @@
 #include "thread_entry_task.hpp"
 #include "xserver_interface.h"
 #include "xasl.h"
+#include "memory_alloc.h"
 
 typedef struct sort_args SORT_ARGS;
 struct sort_args
@@ -257,8 +258,6 @@ static int online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, H
 				 HEAP_CACHE_ATTRINFO * attr_info, HEAP_SCANCACHE * scancache, int unique_pk,
 				 int ib_thread_count, const TP_DOMAIN * key_type);
 static bool btree_is_worker_pool_logging_true ();
-static void copy_db_value_and_get_size (DB_VALUE * key, const DB_VALUE * key_to_be_copied,
-					const TP_DOMAIN * key_type, int *disk_size);
 
 /*
  * btree_get_node_header () -
@@ -5054,10 +5053,23 @@ index_builder_loader_task::add_key (const DB_VALUE * key, const OID & oid)
 
   db_value & last_key = m_keys_oids.back ().m_key;
   db_make_null (&last_key);
-  int disk_size = 0;
+  
+  THREAD_ENTRY * thread_p = thread_get_thread_entry_info ();
+  HL_HEAPID prev_id = thread_p->private_heap_id;
 
-  cubmem::switch_to_global_allocator_and_call (copy_db_value_and_get_size, &last_key, key, m_load_context.m_key_type, &disk_size);
-  m_memsize += disk_size;
+  /* Switch to global heapID. */
+#if defined (SERVER_MODE)
+  db_private_set_heapid_to_thread (thread_p, 0);
+#endif // SERVER_MODE
+
+  qdata_copy_db_value (&last_key, key);
+  m_memsize += m_load_context.m_key_type->type->get_disk_size_of_value (&last_key);
+
+  /* Switch back the heapID. */
+#if defined (SERVER_MODE)
+  db_private_set_heapid_to_thread (thread_p, prev_id);
+#endif // SERVER_MODE
+
   m_memsize += OR_OID_SIZE;
   m_memsize = DB_ALIGN (m_memsize, BTREE_MAX_ALIGN);
   return (m_memsize > (size_t) prm_get_bigint_value (PRM_ID_IB_TASK_MEMSIZE)) ? BATCH_FULL : BATCH_CONTINUE;
@@ -5117,11 +5129,3 @@ index_builder_loader_task::execute (cubthread::entry & thread_ref)
   m_load_context.m_tasks_executed++;
 }
 // *INDENT-ON*
-
-static void
-copy_db_value_and_get_size (DB_VALUE * key, const DB_VALUE * key_to_be_copied, const TP_DOMAIN * key_type,
-			    int *disk_size)
-{
-  qdata_copy_db_value (key, key_to_be_copied);
-  *disk_size = key_type->type->get_disk_size_of_value (key);
-}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22813

Here, we allocate the new key using the global heap id. However, when we want to get the disk size of the newly created value, if the string compression is enabled it will allocate the compressed string using the heap id of the calling thread. This will fail during the clearing of the value since the clearing is done using the global heap id. This PR should fix it by calling the disk size function when we are using the global heap id.