### PR TITLE
[CBRD-22838] Strip path from program name

### DIFF
--- a/src/transaction/client_credentials.cpp
+++ b/src/transaction/client_credentials.cpp
@@ -30,6 +30,9 @@ string_ncopy (std::string &dest, const char *src, size_t max_size)
   dest.assign (src, copyupto);
 }
 
+const char *
+clientids::UNKNOWN_ID = "(unknown)";
+
 clientids::clientids ()
   : client_type (BOOT_CLIENT_UNKNOWN)
   , client_info {}
@@ -112,7 +115,16 @@ clientids::set_user (const char *db_user_arg)
 void
 clientids::set_program_name (const char *program_name_arg)
 {
-  string_ncopy (program_name, program_name_arg, PATH_MAX);
+  char prgname_buf[PATH_MAX] = {'\0'};
+
+  if (program_name_arg == NULL || basename_r (program_name_arg, prgname_buf, PATH_MAX) < 0)
+    {
+      string_ncopy (program_name, UNKNOWN_ID, PATH_MAX);
+    }
+  else
+    {
+      string_ncopy (program_name, prgname_buf, PATH_MAX);
+    }
 }
 
 void

--- a/src/transaction/client_credentials.hpp
+++ b/src/transaction/client_credentials.hpp
@@ -88,6 +88,8 @@ struct clientids : public cubpacking::packable_object
     virtual void pack (cubpacking::packer &serializator) const override;
     virtual void unpack (cubpacking::unpacker &deserializator) override;
 
+    static const char *UNKNOWN_ID;
+
   private:
     void set_client_info (const char *client_info);
     void set_program_name (const char *program_name);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -114,7 +114,6 @@
 static const int LOG_MAX_NUM_CONTIGUOUS_TDES = INT_MAX / sizeof (LOG_TDES);
 static const float LOG_EXPAND_TRANTABLE_RATIO = 1.25;	/* Increase table by 25% */
 static const int LOG_TOPOPS_STACK_INCREMENT = 3;	/* No more than 3 nested top system operations */
-static const char *log_Client_id_unknown_string = "(unknown)";
 static BOOT_CLIENT_CREDENTIAL log_Client_credential;
 
 static const unsigned int LOGTB_RETRY_SLAM_MAX_TIMES = 10;
@@ -2361,7 +2360,9 @@ logtb_set_user_name (int tran_index, const char *user_name)
   tdes = LOG_FIND_TDES (tran_index);
   if (tdes != NULL && tdes->trid != NULL_TRANID)
     {
-      tdes->client.set_user ((user_name) ? user_name : log_Client_id_unknown_string);
+      // *INDENT-OFF*
+      tdes->client.set_user ((user_name) ? user_name : clientids::UNKNOWN_ID);
+      // *INDENT-ON*
     }
   return;
 }
@@ -2444,9 +2445,11 @@ logtb_find_client_name_host_pid (int tran_index, const char **client_prog_name, 
 
   if (tdes == NULL || tdes->trid == NULL_TRANID)
     {
-      *client_prog_name = log_Client_id_unknown_string;
-      *client_user_name = log_Client_id_unknown_string;
-      *client_host_name = log_Client_id_unknown_string;
+      // *INDENT-OFF*
+      *client_prog_name = clientids::UNKNOWN_ID;
+      *client_user_name = clientids::UNKNOWN_ID;
+      *client_host_name = clientids::UNKNOWN_ID;
+      // *INDENT-ON*
       *client_pid = -1;
       return ER_FAILED;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22838

Strip path from program name using basename_r. Move log_Client_id_unknown_string to clientids::UNKNOWN_ID.

This is a regression of clientids refactoring. 