### PR TITLE
[CBRD-22823] Transaction transient objects - modified classes

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -287,6 +287,7 @@ set(TRANSACTION_SOURCES
   ${TRANSACTION_DIR}/recovery.c
   ${TRANSACTION_DIR}/replication.c
   ${TRANSACTION_DIR}/transaction_sr.c
+  ${TRANSACTION_DIR}/transaction_transient.cpp
   ${TRANSACTION_DIR}/wait_for_graph.c
   )
 set(TRANSACTION_HEADERS
@@ -300,6 +301,7 @@ set(TRANSACTION_HEADERS
   ${TRANSACTION_DIR}/log_system_tran.hpp
   ${TRANSACTION_DIR}/log_volids.hpp
   ${TRANSACTION_DIR}/transaction_global.hpp
+  ${TRANSACTION_DIR}/transaction_transient.hpp
   )
 
 set(STORAGE_SOURCES

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -340,6 +340,7 @@ set(TRANSACTION_SOURCES
   ${TRANSACTION_DIR}/recovery.c
   ${TRANSACTION_DIR}/transaction_cl.c
   ${TRANSACTION_DIR}/transaction_sr.c
+  ${TRANSACTION_DIR}/transaction_transient.cpp
   ${TRANSACTION_DIR}/wait_for_graph.c
   )
 set(TRANSACTION_HEADERS
@@ -353,6 +354,7 @@ set(TRANSACTION_HEADERS
   ${TRANSACTION_DIR}/log_system_tran.hpp
   ${TRANSACTION_DIR}/log_volids.hpp
   ${TRANSACTION_DIR}/transaction_global.hpp
+  ${TRANSACTION_DIR}/transaction_transient.hpp
   )
 
 set(STORAGE_SOURCES

--- a/src/query/filter_pred_cache.c
+++ b/src/query/filter_pred_cache.c
@@ -499,7 +499,7 @@ fpcache_retire (THREAD_ENTRY * thread_p, OID * class_oid, BTID * btid, pred_expr
  * class_oid (in) : Class OID.
  */
 void
-fpcache_remove_by_class (THREAD_ENTRY * thread_p, OID * class_oid)
+fpcache_remove_by_class (THREAD_ENTRY * thread_p, const OID * class_oid)
 {
 #define FPCACHE_DELETE_BTIDS_SIZE 1024
 

--- a/src/query/filter_pred_cache.h
+++ b/src/query/filter_pred_cache.h
@@ -40,7 +40,7 @@ extern void fpcache_finalize (THREAD_ENTRY * thread_p);
 extern int fpcache_claim (THREAD_ENTRY * thread_p, BTID * btid, or_predicate * or_pred,
 			  pred_expr_with_context ** pred_expr);
 extern int fpcache_retire (THREAD_ENTRY * thread_p, OID * class_oid, BTID * btid, pred_expr_with_context * filter_pred);
-extern void fpcache_remove_by_class (THREAD_ENTRY * thread_p, OID * class_oid);
+extern void fpcache_remove_by_class (THREAD_ENTRY * thread_p, const OID * class_oid);
 extern void fpcache_drop_all (THREAD_ENTRY * thread_p);
 extern void fpcache_dump (THREAD_ENTRY * thread_p, FILE * fp);
 

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -254,9 +254,9 @@ static void xcache_clone_decache (THREAD_ENTRY * thread_p, XASL_CLONE * xclone);
 static void xcache_cleanup (THREAD_ENTRY * thread_p);
 static BH_CMP_RESULT xcache_compare_cleanup_candidates (const void *left, const void *right, BH_CMP_ARG ignore_arg);
 static bool xcache_check_recompilation_threshold (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry);
-static void xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XASL_CACHE_ENTRY *, void *),
-				       void *arg);
-static bool xcache_entry_is_related_to_oid (XASL_CACHE_ENTRY * xcache_entry, void *arg);
+static void xcache_invalidate_entries (THREAD_ENTRY * thread_p,
+				       bool (*invalidate_check) (XASL_CACHE_ENTRY *, const OID *), const OID * arg);
+static bool xcache_entry_is_related_to_oid (XASL_CACHE_ENTRY * xcache_entry, const OID * related_to_oid);
 static XCACHE_CLEANUP_REASON xcache_need_cleanup (void);
 
 /*
@@ -1686,7 +1686,8 @@ error:
  * arg (in)		 : Argument for invalidation check function.
  */
 static void
-xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XASL_CACHE_ENTRY *, void *), void *arg)
+xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XASL_CACHE_ENTRY *, const OID *),
+			   const OID * arg)
 {
 #define XCACHE_DELETE_XIDS_SIZE 1024
   LF_HASH_TABLE_ITERATOR iter;
@@ -1777,9 +1778,8 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
  * arg (in)	     : Pointer to OID.
  */
 static bool
-xcache_entry_is_related_to_oid (XASL_CACHE_ENTRY * xcache_entry, void *arg)
+xcache_entry_is_related_to_oid (XASL_CACHE_ENTRY * xcache_entry, const OID * related_to_oid)
 {
-  OID *related_to_oid = (OID *) arg;
   int oid_idx = 0;
 
   assert (xcache_entry != NULL);
@@ -1805,7 +1805,7 @@ xcache_entry_is_related_to_oid (XASL_CACHE_ENTRY * xcache_entry, void *arg)
  * oid (in)	 : Object ID.
  */
 void
-xcache_remove_by_oid (THREAD_ENTRY * thread_p, OID * oid)
+xcache_remove_by_oid (THREAD_ENTRY * thread_p, const OID * oid)
 {
   xcache_check_logging ();
 

--- a/src/query/xasl_cache.h
+++ b/src/query/xasl_cache.h
@@ -154,7 +154,7 @@ extern void xcache_unfix (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_ent
 extern int xcache_insert (THREAD_ENTRY * thread_p, const compile_context * context, XASL_STREAM * stream,
 			  int n_oid, const OID * class_oids, const int *class_locks,
 			  const int *tcards, XASL_CACHE_ENTRY ** xcache_entry);
-extern void xcache_remove_by_oid (THREAD_ENTRY * thread_p, OID * oid);
+extern void xcache_remove_by_oid (THREAD_ENTRY * thread_p, const OID * oid);
 extern void xcache_drop_all (THREAD_ENTRY * thread_p);
 extern void xcache_dump (THREAD_ENTRY * thread_p, FILE * fp);
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -1251,7 +1251,6 @@ error:
 int
 locator_drop_transient_class_name_entries (THREAD_ENTRY * thread_p, LOG_LSA * savep_lsa)
 {
-  MODIFIED_CLASS_ENTRY *t;
   int tran_index;
   LOG_TDES *tdes;		/* Transaction descriptor */
   int error_code = NO_ERROR;
@@ -1282,14 +1281,17 @@ locator_drop_transient_class_name_entries (THREAD_ENTRY * thread_p, LOG_LSA * sa
       return ER_FAILED;
     }
 
-  const auto lambda_func =[&error_code, &thread_p, &savep_lsa] (const modified_class_entry & t, bool & stop) {
-    error_code = locator_drop_class_name_entry (thread_p, t.get_classname (), savep_lsa);
-    if (error_code != NO_ERROR)
-      {
-	assert (false);
-	stop = true;
-      }
-  };
+  // *INDENT-OFF*
+  const auto lambda_func =[&error_code, &thread_p, &savep_lsa] (const tx_transient_class_entry & t, bool & stop)
+    {
+      error_code = locator_drop_class_name_entry (thread_p, t.get_classname (), savep_lsa);
+      if (error_code != NO_ERROR)
+        {
+	  assert (false);
+	  stop = true;
+        }
+    };
+  // *INDENT-ON*
   tdes->m_modified_classes.map (lambda_func);
   assert (locator_get_num_transient_classnames (tran_index) >= 0);
 
@@ -1595,7 +1597,6 @@ locator_force_drop_class_name_entry (const void *name, void *ent, void *args)
 int
 locator_savepoint_transient_class_name_entries (THREAD_ENTRY * thread_p, LOG_LSA * savep_lsa)
 {
-  MODIFIED_CLASS_ENTRY *t;
   int tran_index;
   LOG_TDES *tdes;		/* Transaction descriptor */
   int error_code = NO_ERROR;
@@ -1626,14 +1627,17 @@ locator_savepoint_transient_class_name_entries (THREAD_ENTRY * thread_p, LOG_LSA
       return ER_FAILED;
     }
 
-  const auto lambda_func =[&error_code, &savep_lsa] (const modified_class_entry & t, bool & stop) {
-    error_code = locator_savepoint_class_name_entry (t.get_classname (), savep_lsa);
-    if (error_code != NO_ERROR)
-      {
-	assert (false);
-	stop = true;
-      }
-  };
+  // *INDENT-OFF*
+  const auto lambda_func = [&error_code, &savep_lsa] (const tx_transient_class_entry & t, bool & stop)
+    {
+      error_code = locator_savepoint_class_name_entry (t.get_classname (), savep_lsa);
+      if (error_code != NO_ERROR)
+        {
+	  assert (false);
+	  stop = true;
+        }
+    };
+  // *INDENT-ON*
   tdes->m_modified_classes.map (lambda_func);
 
   csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE);

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -58,6 +58,7 @@
 #include "xasl_cache.h"
 #include "xasl_predicate.hpp"
 #include "thread_manager.hpp"	// for thread_get_thread_entry_info
+#include "transaction_transient.hpp"
 #include "xserver_interface.h"
 
 /* TODO : remove */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -54,6 +54,7 @@
 #include "release_string.h"
 #include "storage_common.h"
 #include "thread_entry.hpp"
+#include "transaction_transient.hpp"
 #include "log_generator.hpp"
 
 #include <assert.h>
@@ -434,15 +435,6 @@ struct log_topops_stack
   int max;			/* Size of stack */
   int last;			/* Last entry in stack */
   LOG_TOPOPS_ADDRESSES *stack;	/* Stack for push and pop of top system actions */
-};
-
-typedef struct modified_class_entry MODIFIED_CLASS_ENTRY;
-struct modified_class_entry
-{
-  MODIFIED_CLASS_ENTRY *m_next;
-  const char *m_classname;	/* Name of the modified class */
-  OID m_class_oid;
-  LOG_LSA m_last_modified_lsa;
 };
 
 /* lob entry */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -864,6 +864,7 @@ struct log_tdes
   /* Set to one when the current execution must be stopped somehow. We stop it by sending an error message during
    * fetching of a page. */
   MODIFIED_CLASS_ENTRY *modified_class_list;	/* List of classes made dirty. */
+  tx_transient_classes m_modified_classes;	// list of classes made dirty
 
   int num_transient_classnames;	/* # of transient classnames by this transaction */
   int num_repl_records;		/* # of replication records */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -863,8 +863,7 @@ struct log_tdes
 #endif				/* _AIX */
   /* Set to one when the current execution must be stopped somehow. We stop it by sending an error message during
    * fetching of a page. */
-  MODIFIED_CLASS_ENTRY *modified_class_list;	/* List of classes made dirty. */
-  tx_transient_classes m_modified_classes;	// list of classes made dirty
+  tx_transient_class_registry m_modified_classes;	// list of classes made dirty
 
   int num_transient_classnames;	/* # of transient classnames by this transaction */
   int num_repl_records;		/* # of replication records */

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -275,7 +275,6 @@ static void log_change_tran_as_completed (THREAD_ENTRY * thread_p, LOG_TDES * td
 static void log_append_commit_log (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * commit_lsa);
 static void log_append_commit_log_with_lock (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * commit_lsa);
 static void log_append_abort_log (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * abort_lsa);
-static void log_rollback_classrepr_cache (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * upto_lsa);
 static void log_free_lob_locator (LOB_LOCATOR_ENTRY * entry);
 static int lob_locator_cmp (const LOB_LOCATOR_ENTRY * e1, const LOB_LOCATOR_ENTRY * e2);
 /* RB_PROTOTYPE_STATIC declares red-black tree functions. see base/rb_tree.h */
@@ -343,10 +342,7 @@ static void log_find_end_log (THREAD_ENTRY * thread_p, LOG_LSA * end_lsa);
 
 static int log_is_valid_locator (const char *locator);
 
-static void log_cleanup_modified_class (THREAD_ENTRY * thread_p, MODIFIED_CLASS_ENTRY * t, void *arg);
-static void log_map_modified_class_list (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * savept_lsa, bool release,
-					 void (*map_func) (THREAD_ENTRY * thread_p, MODIFIED_CLASS_ENTRY * clazz,
-							   void *arg), void *arg);
+static void log_cleanup_modified_class (const tx_transient_class_entry & t, bool & stop);
 static void log_cleanup_modified_class_list (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * savept_lsa,
 					     bool release, bool decache_classrepr);
 
@@ -4012,7 +4008,7 @@ log_sysop_abort (THREAD_ENTRY * thread_p)
 
       /* Rollback changes. */
       log_rollback (thread_p, tdes, LOG_TDES_LAST_SYSOP_PARENT_LSA (tdes));
-      log_rollback_classrepr_cache (thread_p, tdes, LOG_TDES_LAST_SYSOP_PARENT_LSA (tdes));
+      tdes->m_modified_classes.decache_heap_repr (*LOG_TDES_LAST_SYSOP_PARENT_LSA (tdes));
 
       /* Log abort system operation. */
       sysop_end.type = LOG_SYSOP_END_ABORT;
@@ -4667,10 +4663,6 @@ int
 log_add_to_modified_class_list (THREAD_ENTRY * thread_p, const char *classname, const OID * class_oid)
 {
   LOG_TDES *tdes;
-  MODIFIED_CLASS_ENTRY *t = NULL;
-#if !defined(NDEBUG)
-  MODIFIED_CLASS_ENTRY *n = NULL;
-#endif
   int tran_index;
 
   assert (classname != NULL);
@@ -4685,55 +4677,7 @@ log_add_to_modified_class_list (THREAD_ENTRY * thread_p, const char *classname, 
       return ER_FAILED;
     }
 
-#if !defined(NDEBUG)
-  /* check iff duplicated {classname, class_oid} pair */
-  for (t = tdes->modified_class_list; t != NULL; t = t->m_next)
-    {
-      assert (t->m_classname != NULL);
-      assert (!OID_ISNULL (&t->m_class_oid));
-      assert (t->m_class_oid.volid >= 0);	/* is not temp_oid */
-
-      for (n = t->m_next; n != NULL; n = n->m_next)
-	{
-	  assert (!(strcmp (t->m_classname, n->m_classname) == 0 && OID_EQ (&t->m_class_oid, &n->m_class_oid)));
-	}
-    }
-#endif
-
-  for (t = tdes->modified_class_list; t != NULL; t = t->m_next)
-    {
-      if (strcmp (t->m_classname, classname) == 0 && OID_EQ (&t->m_class_oid, class_oid))
-	{
-	  break;
-	}
-    }
-
-  if (t == NULL)
-    {				/* class is not in modified_class_list */
-      t = (MODIFIED_CLASS_ENTRY *) malloc (sizeof (MODIFIED_CLASS_ENTRY));
-      if (t == NULL)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (MODIFIED_CLASS_ENTRY));
-	  return ER_OUT_OF_VIRTUAL_MEMORY;
-	}
-
-      t->m_classname = strdup (classname);
-      if (t->m_classname == NULL)
-	{
-	  free_and_init (t);
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, strlen (classname));
-	  return ER_OUT_OF_VIRTUAL_MEMORY;
-	}
-
-      COPY_OID (&t->m_class_oid, class_oid);
-      LSA_SET_NULL (&t->m_last_modified_lsa);
-
-      t->m_next = tdes->modified_class_list;
-      tdes->modified_class_list = t;
-    }
-
-  LSA_COPY (&t->m_last_modified_lsa, &tdes->tail_lsa);
-
+  tdes->m_modified_classes.add (classname, *class_oid, tdes->tail_lsa);
   return NO_ERROR;
 }
 
@@ -4749,7 +4693,6 @@ log_is_class_being_modified (THREAD_ENTRY * thread_p, const OID * class_oid)
 {
   LOG_TDES *tdes;
   int tran_index;
-  MODIFIED_CLASS_ENTRY *t = NULL;
 
   assert (class_oid != NULL);
   assert (!OID_ISNULL (class_oid));
@@ -4764,15 +4707,7 @@ log_is_class_being_modified (THREAD_ENTRY * thread_p, const OID * class_oid)
       return false;
     }
 
-  for (t = tdes->modified_class_list; t != NULL; t = t->m_next)
-    {
-      if (OID_EQ (&t->m_class_oid, class_oid))
-	{
-	  return true;
-	}
-    }
-
-  return false;
+  return tdes->m_modified_classes.has_class (*class_oid);
 }
 
 /*
@@ -4787,71 +4722,20 @@ log_is_class_being_modified (THREAD_ENTRY * thread_p, const OID * class_oid)
  *       This will be used to decache the class representations and XASLs when a transaction is finished.
  */
 static void
-log_cleanup_modified_class (THREAD_ENTRY * thread_p, MODIFIED_CLASS_ENTRY * t, void *arg)
+log_cleanup_modified_class (const tx_transient_class_entry & t, bool & stop)
 {
-  bool decache_classrepr = (bool) * ((bool *) arg);
+  THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
 
-  if (decache_classrepr && !LSA_ISNULL (&t->m_last_modified_lsa))
-    {
-      (void) heap_classrepr_decache (thread_p, &t->m_class_oid);
-    }
   /* decache this class from the partitions cache also */
-  (void) partition_decache_class (thread_p, &t->m_class_oid);
+  (void) partition_decache_class (thread_p, &t.m_class_oid);
 
   /* remove XASL cache entries which are relevant with this class */
-  xcache_remove_by_oid (thread_p, &t->m_class_oid);
+  xcache_remove_by_oid (thread_p, &t.m_class_oid);
   /* remove filter predicate cache entries which are relevant with this class */
-  fpcache_remove_by_class (thread_p, &t->m_class_oid);
+  fpcache_remove_by_class (thread_p, &t.m_class_oid);
 }
 
 extern int locator_drop_transient_class_name_entries (THREAD_ENTRY * thread_p, LOG_LSA * savep_lsa);
-
-/*
- * log_map_modified_class_list -
- *
- * return:
- *
- *   tdes(in):
- *   savept_lsa(in): savepoint lsa to rollback
- *   release(in): release the memory or not
- *   map_func(in): optinal
- *   arg(in): optional
- *
- * NOTE: Function for LOG_TDES.modified_class_list
- *       This will be used to traverse a modified class list and to do something on each entry.
- */
-static void
-log_map_modified_class_list (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * savept_lsa, bool release,
-			     void (*map_func) (THREAD_ENTRY * thread_p, MODIFIED_CLASS_ENTRY * clazz, void *arg),
-			     void *arg)
-{
-  MODIFIED_CLASS_ENTRY *t = NULL;
-
-  if (map_func)
-    {
-      t = tdes->modified_class_list;
-      while (t != NULL)
-	{
-	  (void) (*map_func) (thread_p, t, arg);
-	  t = t->m_next;
-	}
-    }
-
-  /* always execute for defense */
-  (void) locator_drop_transient_class_name_entries (thread_p, savept_lsa);
-
-  if (release)
-    {
-      t = tdes->modified_class_list;
-      while (t != NULL)
-	{
-	  tdes->modified_class_list = t->m_next;
-	  free ((char *) t->m_classname);
-	  free (t);
-	  t = tdes->modified_class_list;
-	}
-    }
-}
 
 /*
  * log_cleanup_modified_class_list -
@@ -4869,32 +4753,19 @@ static void
 log_cleanup_modified_class_list (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * savept_lsa, bool release,
 				 bool decache_classrepr)
 {
-  (void) log_map_modified_class_list (thread_p, tdes, savept_lsa, release, log_cleanup_modified_class,
-				      &decache_classrepr);
-}
-
-/*
- * log_rollback_classrepr_cache - Decache class repr to rollback
- *
- * return:
- *
- *   thread_p(in):
- *   tdes(in): transaction description
- *   upto_lsa(in): LSA to rollback
- *
- */
-static void
-log_rollback_classrepr_cache (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * upto_lsa)
-{
-  MODIFIED_CLASS_ENTRY *t = NULL;
-
-  for (t = tdes->modified_class_list; t != NULL; t = t->m_next)
+  if (decache_classrepr)
     {
-      if (LSA_GT (&t->m_last_modified_lsa, upto_lsa))
-	{
-	  (void) heap_classrepr_decache (thread_p, &t->m_class_oid);
-	  LSA_SET_NULL (&t->m_last_modified_lsa);
-	}
+      // decache heap representations
+      tdes->m_modified_classes.decache_heap_repr (savept_lsa != NULL ? *savept_lsa : NULL_LSA);
+    }
+  tdes->m_modified_classes.map (log_cleanup_modified_class);
+
+  /* always execute for defense */
+  (void) locator_drop_transient_class_name_entries (thread_p, savept_lsa);
+
+  if (release)
+    {
+      tdes->m_modified_classes.clear ();
     }
 }
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -84,6 +84,7 @@
 #include "thread_entry.hpp"
 #include "thread_entry_task.hpp"
 #include "thread_manager.hpp"
+#include "transaction_transient.hpp"
 #include "vacuum.h"
 #include "xasl_cache.h"
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -910,7 +910,7 @@ logtb_set_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const BOOT_CLIENT_CRED
   tdes->topops.stack = NULL;
   tdes->topops.max = 0;
   tdes->topops.last = -1;
-  tdes->modified_class_list = NULL;
+  tdes->m_modified_classes.clear ();
   tdes->num_transient_classnames = 0;
   tdes->first_save_entry = NULL;
   RB_INIT (&tdes->lob_locator_root);
@@ -1837,7 +1837,7 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
       TR_TABLE_CS_EXIT (thread_p);
 #endif
     }
-  tdes->modified_class_list = NULL;
+  tdes->m_modified_classes.clear ();
 
   for (i = 0; i < tdes->cur_repl_record; i++)
     {
@@ -1994,7 +1994,9 @@ logtb_initialize_tdes (LOG_TDES * tdes, int tran_index)
 
   tdes->block_global_oldest_active_until_commit = false;
   tdes->is_user_active = false;
-  tdes->modified_class_list = NULL;
+  // *INDENT-OFF*
+  new (&tdes->m_modified_classes) tx_transient_classes ();
+  // *INDENT-ON*
 
   LSA_SET_NULL (&tdes->rcv.tran_start_postpone_lsa);
   LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
@@ -7074,20 +7076,15 @@ logtb_descriptors_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg
 	}
       idx++;
 
-      /* Modified_class_list */
-      ptr_val = tdes->modified_class_list;
-      if (ptr_val == NULL)
+      /* modified class list */
+      if (tdes->m_modified_classes.empty ())
 	{
 	  db_make_null (&vals[idx]);
 	}
       else
 	{
-	  snprintf (buf, sizeof (buf), "0x%08" PRIx64, (UINT64) ptr_val);
-	  error = db_make_string_copy (&vals[idx], buf);
-	  if (error != NO_ERROR)
-	    {
-	      goto exit_on_error;
-	    }
+	  (void) db_make_string (&vals[idx], tdes->m_modified_classes.to_string ());
+	  vals[idx].need_clear = true;
 	}
       idx++;
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -2018,6 +2018,7 @@ logtb_finalize_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 
   // *INDENT-OFF*
   tdes->client.~clientids ();
+  tdes->m_modified_classes.~tx_transient_class_registry ();
   // *INDENT-ON*
 
   logtb_clear_tdes (thread_p, tdes);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1995,7 +1995,7 @@ logtb_initialize_tdes (LOG_TDES * tdes, int tran_index)
   tdes->block_global_oldest_active_until_commit = false;
   tdes->is_user_active = false;
   // *INDENT-OFF*
-  new (&tdes->m_modified_classes) tx_transient_classes ();
+  new (&tdes->m_modified_classes) tx_transient_class_registry ();
   // *INDENT-ON*
 
   LSA_SET_NULL (&tdes->rcv.tran_start_postpone_lsa);

--- a/src/transaction/transaction_transient.cpp
+++ b/src/transaction/transaction_transient.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+#include "transaction_transient.hpp"
+
+#include "heap_file.h"
+#include "oid.h"
+#include "memory_private_allocator.hpp"
+#include "string_buffer.hpp"
+
+tx_transient_class_entry::tx_transient_class_entry (const char *class_name, const OID &class_oid, const LOG_LSA &lsa)
+  : m_class_oid (class_oid)
+  , m_last_modified_lsa (lsa)
+  , m_class_name (class_name)
+{
+}
+
+const char *
+tx_transient_class_entry::get_classname () const
+{
+  return m_class_name.c_str ();
+}
+
+void
+tx_transient_class_registry::add (const char *classname, const OID &class_oid, const LOG_LSA &lsa)
+{
+  assert (classname != NULL);
+  assert (!OID_ISNULL (&class_oid));
+  assert (class_oid.volid >= 0);      // is not temp volume
+
+  for (auto &it : m_list)
+    {
+      if (it.m_class_name == classname && OID_EQ (&it.m_class_oid, &class_oid))
+	{
+	  assert (false);   // not really expected
+	  it.m_last_modified_lsa = lsa;
+	  return;
+	}
+    }
+  m_list.emplace_front (classname, class_oid, lsa);
+}
+
+bool
+tx_transient_class_registry::has_class (const OID &class_oid) const
+{
+  for (auto &it : m_list)
+    {
+      if (OID_EQ (&class_oid, &it.m_class_oid))
+	{
+	  return true;
+	}
+    }
+  return false;
+}
+
+char *
+tx_transient_class_registry::to_string () const
+{
+  const size_t DEFAULT_STRBUF_SIZE = 128;
+  string_buffer strbuf (cubmem::PRIVATE_BLOCK_ALLOCATOR, DEFAULT_STRBUF_SIZE);
+
+  strbuf ("{");
+  for (list_type::const_iterator it = m_list.cbegin (); it != m_list.cend (); it++)
+    {
+      if (it != m_list.cbegin ())
+	{
+	  strbuf (", ");
+	}
+      strbuf ("name=%s, oid=%d|%d|%d, lsa=%lld|%d", it->m_class_name.c_str (), OID_AS_ARGS (&it->m_class_oid),
+	      LSA_AS_ARGS (&it->m_last_modified_lsa));
+    }
+  strbuf ("}");
+  return strbuf.release_ptr ();
+}
+
+void
+tx_transient_class_registry::map (const map_func_type &func) const
+{
+  bool stop = false;
+  for (const auto &it : m_list)
+    {
+      func (it, stop);
+      if (stop)
+	{
+	  return;
+	}
+    }
+}
+
+bool
+tx_transient_class_registry::empty () const
+{
+  return m_list.empty ();
+}
+
+void
+tx_transient_class_registry::decache_heap_repr (const LOG_LSA &downto_lsa)
+{
+  for (auto &it : m_list)
+    {
+      if (it.m_last_modified_lsa > downto_lsa)
+	{
+	  (void) heap_classrepr_decache (NULL, &it.m_class_oid);
+	  it.m_last_modified_lsa.set_null ();
+	}
+    }
+}
+
+void
+tx_transient_class_registry::clear ()
+{
+  m_list.clear ();
+}

--- a/src/transaction/transaction_transient.hpp
+++ b/src/transaction/transaction_transient.hpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+#ifndef _TRANSACTION_TRANSIENT_HPP_
+#define _TRANSACTION_TRANSIENT_HPP_
+
+#include "dbtype_def.h"
+#include "log_lsa.hpp"
+#include "storage_common.h"
+
+#include <forward_list>
+#include <functional>
+
+// todo - namespace cubtx
+
+struct tx_transient_class_entry
+{
+  OID m_class_oid;
+  LOG_LSA m_last_modified_lsa;
+  std::string m_class_name;
+
+  tx_transient_class_entry () = default;
+  tx_transient_class_entry (const char *class_name, const OID &class_oid, const LOG_LSA &lsa);
+
+  const char *get_classname () const;
+};
+
+class tx_transient_class_registry
+{
+  private:
+    using list_type = std::forward_list<tx_transient_class_entry>;
+    list_type m_list;
+
+  public:
+    using map_func_type = std::function<void (const tx_transient_class_entry &, bool &)>;
+
+    tx_transient_class_registry () = default;
+    ~tx_transient_class_registry () = default;
+
+    // inspection functions
+    bool empty () const;
+    bool has_class (const OID &class_oid) const;
+
+    // map all entries
+    void map (const map_func_type &func) const;
+
+    // utility functions
+    char *to_string () const;   // private allocated
+
+    // manipulation functions
+    void add (const char *classname, const OID &class_oid, const LOG_LSA &lsa);
+    void decache_heap_repr (const LOG_LSA &downto_lsa);
+    void clear ();
+};
+
+#endif // !_TRANSACTION_TRANSIENT_HPP_


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22823

Separate transaction transient objects (lifetime expires with transaction) from `log_impl.h`. The plan is to add here all similar objects. Long-term we may identify a common approach for all these objects.

### transaction transient files

- move modified_class_list and rename as tx_transient_class_entry/tx_transient_class_registry.
- tx_transient_class_entry: change class name to std::string.
- tx_transient_class_registry: provide necessary interface to interact with modified classes: add/decache_heap_repr/clear, empty/has_class, map, to_string
  NOTE: to_string is used for logtb_descriptors_start_scan and provides more verbose information than it used to. test results revising may be needed.
- replace all usages with new interface.

### other

- replace log_rollback_classrepr_cache with tx_transient_class_registry::decache_heap_repr
- make log_cleanup_modified_class and log_cleanup_modified_class_list more clean
- make fpcache_remove_by_class/xcache_remove_by_oid OID argument const. Several functions are modified as consequence in xasl_cache.c