### PR TITLE
[CBRD-21524] Fix warnings

### DIFF
--- a/src/base/bip_buffer.hpp
+++ b/src/base/bip_buffer.hpp
@@ -276,7 +276,7 @@ namespace cubmem
 
       int end_read (const cubmem::buffer_latch_read_id &page_idx)
       {
-	assert (page_idx >= 0 && page_idx < P);
+	assert (page_idx >= 0 && page_idx < (int) P);
 
 	assert (m_read_fcnt[page_idx] > 0);
 	m_read_fcnt[page_idx]--;

--- a/src/base/ini_parser.c
+++ b/src/base/ini_parser.c
@@ -92,7 +92,7 @@ static unsigned int
 ini_table_hash (char *key)
 {
   size_t len;
-  int i;
+  size_t i;
   unsigned int hash;
 
   len = strlen (key);

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -2863,7 +2863,7 @@ perfmon_stat_dump_in_buffer_flushed_block_volumes_array_stat (const UINT64 * sta
 static void
 perfmon_stat_dump_in_file_flushed_block_volumes_array_stat (FILE * stream, const UINT64 * stats_ptr)
 {
-  int flushed_block_volumes;
+  unsigned int flushed_block_volumes;
   UINT64 counter = 0;
   char buffer[15];
 

--- a/src/broker/cas_net_buf.c
+++ b/src/broker/cas_net_buf.c
@@ -803,7 +803,7 @@ net_error_append_shard_info (char *err_buf, const char *err_msg, int buf_size)
 	{
 	  snprintf (err_buf, buf_size, "[SHARD/CAS ID-%d,%d]", shm_shard_id, shm_shard_cas_id + 1);
 	}
-      else if (strlen (err_msg) + MAX_SHARD_INFO_LENGTH >= buf_size)
+      else if ((int) strlen (err_msg) + MAX_SHARD_INFO_LENGTH >= buf_size)
 	{
 	  snprintf (err_buf, buf_size, "%s", err_msg);
 	}

--- a/src/cm_common/cm_nameval.c
+++ b/src/cm_common/cm_nameval.c
@@ -190,7 +190,7 @@ int
 nv_add_nvp_int64 (nvplist * ref, const char *name, int64_t value)
 {
   char strbuf[32];
-  sprintf (strbuf, "%lld", value);
+  sprintf (strbuf, "%lld", (long long int) value);
   return (nv_add_nvp (ref, name, strbuf));
 }
 

--- a/src/compat/dbtype_function.c
+++ b/src/compat/dbtype_function.c
@@ -30,4 +30,8 @@
 #include "language_support.h"
 #include "intl_support.h"
 #include "memory_alloc.h"
+
+// hidden functions (suppress -Wmissing-prototypes)
+int db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collation_id, char *str, const int size);
+
 #include "dbtype_function.i"

--- a/src/connection/heartbeat.c
+++ b/src/connection/heartbeat.c
@@ -529,11 +529,11 @@ hb_pack_server_name (const char *server_name, int *name_length, const char *log_
        * for the purpose of matching the name of the CUBRID driver. */
 
       snprintf (pid_string, sizeof (pid_string), "%d", getpid ());
-      n_len = strlen (server_name) + 1;
-      l_len = (log_path) ? strlen (log_path) + 1 : 0;
-      r_len = strlen (rel_major_release_string ()) + 1;
-      e_len = strlen (env_name) + 1;
-      p_len = strlen (pid_string) + 1;
+      n_len = (int) strlen (server_name) + 1;
+      l_len = (log_path) ? (int) strlen (log_path) + 1 : 0;
+      r_len = (int) strlen (rel_major_release_string ()) + 1;
+      e_len = (int) strlen (env_name) + 1;
+      p_len = (int) strlen (pid_string) + 1;
       *name_length = n_len + l_len + r_len + e_len + p_len + 5;
 
       packed_name = (char *) malloc (*name_length);

--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -763,7 +763,7 @@ struct sm_class
   unsigned int flags;
   unsigned int virtual_cache_local_schema_id;
   unsigned int virtual_cache_global_schema_id;
-  int virtual_cache_snapshot_version;
+  unsigned int virtual_cache_snapshot_version;
 
   unsigned methods_loaded:1;	/* set when dynamic linking was performed */
   unsigned post_load_cleanup:1;	/* set if post load cleanup has occurred */

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -10029,7 +10029,6 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      const char *original_str = db_get_string (src);
 	      int error_code;
 
-	      assert (str_size >= 0);	/* if this isn't correct, we cannot rely on strlen */
 	      error_code = db_json_get_json_from_str (original_str, doc, str_size);
 	      if (error_code != NO_ERROR)
 		{

--- a/src/object/work_space.c
+++ b/src/object/work_space.c
@@ -149,7 +149,7 @@ static AREA *Objlist_area = NULL;
  * checking on server, mark fetched object with the snapshot version and
  * don't re-fetch until snapshot version is changed.
  */
-static int ws_MVCC_snapshot_version = 0;
+static unsigned int ws_MVCC_snapshot_version = 0;
 
 /*
  * ws_area_init
@@ -4972,7 +4972,7 @@ ws_set_repl_error_into_error_link (LC_COPYAREA_ONEOBJ * obj, char *content_ptr)
  *
  * return : Current snapshot version.
  */
-int
+unsigned int
 ws_get_mvcc_snapshot_version (void)
 {
   return ws_MVCC_snapshot_version;

--- a/src/object/work_space.h
+++ b/src/object/work_space.h
@@ -129,8 +129,8 @@ struct db_object
   struct db_object *commit_link;	/* link for obj to be reset at commit/abort */
   WS_VALUE_LIST *label_value_list;	/* label value list */
   LOCK lock;			/* object lock */
-  int mvcc_snapshot_version;	/* The snapshot version at the time mop object is fetched and cached. Used only when
-				 * MVCC is enabled. */
+  unsigned int mvcc_snapshot_version;	/* The snapshot version at the time mop object is fetched and cached.
+					 * Used only when MVCC is enabled. */
 
   unsigned char pruning_type;	/* no pruning, prune as partitioned class, prune as partition */
   unsigned char composition_fetch;	/* set the left-most bit if this MOP */
@@ -659,7 +659,7 @@ extern WS_REPL_FLUSH_ERR *ws_get_repl_error_from_error_link (void);
 extern void ws_clear_all_repl_errors_of_error_link (void);
 extern void ws_free_repl_flush_error (WS_REPL_FLUSH_ERR * flush_err);
 
-extern int ws_get_mvcc_snapshot_version (void);
+extern unsigned int ws_get_mvcc_snapshot_version (void);
 extern void ws_increment_mvcc_snapshot_version (void);
 extern bool ws_is_mop_fetched_with_current_snapshot (MOP mop);
 extern void ws_set_mop_fetched_with_current_snapshot (MOP mop);

--- a/src/parser/compile.c
+++ b/src/parser/compile.c
@@ -953,7 +953,7 @@ pt_in_lck_array (PT_CLASS_LOCKS * lcks, const char *str, LC_PREFETCH_FLAGS flags
 static void
 remove_appended_trigger_info (char *msg, int with_evaluate)
 {
-  int i;
+  size_t i;
   const char *scope_str = "SCOPE___ ";
   const char *from_on_str = " FROM ON ";
   const char *eval_prefix = "EVALUATE ( ";

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -84,7 +84,6 @@ void csql_yyerror (const char *s);
 extern int g_msg[1024];
 extern int msg_ptr;
 extern int yybuffer_pos;
-extern size_t json_table_column_count;
 /*%CODE_END%*/%}
 
 %{
@@ -1847,8 +1846,8 @@ stmt
 
 			    if (node)
 			      {
-				char *curr_ptr = this_parser->original_buffer + pos;
-				int len = curr_ptr - g_query_string;
+				const char *curr_ptr = this_parser->original_buffer + pos;
+				int len = (int) (curr_ptr - g_query_string);
 				node->sql_user_text_len = len;
 				g_query_string_len = len;
 			      }
@@ -1959,7 +1958,7 @@ stmt_
 			PT_NODE *dt, *set_dt;
 			PT_TYPE_ENUM typ;
 
-			typ = TO_NUMBER (CONTAINER_AT_0 ($2));
+			typ = (PT_TYPE_ENUM) TO_NUMBER (CONTAINER_AT_0 ($2));
 			dt = CONTAINER_AT_1 ($2);
 
 			if (!dt)
@@ -2440,8 +2439,7 @@ session_variable
 			      pt_append_bytes (this_parser, NULL,
 			      				   id->info.name.original,
 			      				   strlen (id->info.name.original));
-			    node->info.value.text =
-			      node->info.value.data_value.str->bytes;
+			    node->info.value.text = (const char *) node->info.value.data_value.str->bytes;
 			  }
 
 			$$ = node;
@@ -3483,7 +3481,7 @@ alter_stmt
 			 * 1: increment_val,
 			 * 2: max_val,
 			 * 3: no_max,
-			 * 4: min_val,
+			 * 4: min_val, 
 			 * 5: no_min,
 			 * 6: cyclic,
 			 * 7: no_cyclic,
@@ -3495,13 +3493,13 @@ alter_stmt
 			PT_NODE *start_val = CONTAINER_AT_0 ($4);
 			PT_NODE *increment_val = CONTAINER_AT_1 ($4);
 			PT_NODE *max_val = CONTAINER_AT_2 ($4);
-			int no_max = TO_NUMBER (CONTAINER_AT_3 ($4));
+			int no_max = (int) TO_NUMBER (CONTAINER_AT_3 ($4));
 			PT_NODE *min_val = CONTAINER_AT_4 ($4);
-			int no_min = TO_NUMBER (CONTAINER_AT_5 ($4));
-			int cyclic = TO_NUMBER (CONTAINER_AT_6 ($4));
-			int no_cyclic = TO_NUMBER (CONTAINER_AT_7 ($4));
+			int no_min = (int) TO_NUMBER (CONTAINER_AT_5 ($4));
+			int cyclic = (int) TO_NUMBER (CONTAINER_AT_6 ($4));
+			int no_cyclic = (int) TO_NUMBER (CONTAINER_AT_7 ($4));
 			PT_NODE *cached_num_val = CONTAINER_AT_8 ($4);
-			int no_cache = TO_NUMBER (CONTAINER_AT_9 ($4));
+			int no_cache = (int) TO_NUMBER (CONTAINER_AT_9 ($4));
 			PT_NODE *comment = $5;
 
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_SERIAL);
@@ -4483,7 +4481,7 @@ extended_table_spec_list
 			container_2 ctn;
 			PT_NODE *n1 = CONTAINER_AT_0 ($1);
 			PT_NODE *n2 = $3;
-			int number = TO_NUMBER (CONTAINER_AT_1 ($1));
+			int number = (int) TO_NUMBER (CONTAINER_AT_1 ($1));
 			SET_CONTAINER_2 (ctn, parser_make_link (n1, n2), FROM_NUMBER (number));
 			$$ = ctn;
 
@@ -9859,7 +9857,7 @@ attr_index_def
 			  }
 			node->info.index.column_names = col;
 			node->info.index.index_status = SM_NORMAL_INDEX;
-			if ($6 != NULL)
+			if ($6)
 				{
 					node->info.index.index_status = SM_INVISIBLE_INDEX;
 				}
@@ -11715,7 +11713,7 @@ opt_of_data_type_cursor
 	| data_type
 		{{
 
-			$$ = TO_NUMBER (CONTAINER_AT_0 ($1));
+			$$ = (int) TO_NUMBER (CONTAINER_AT_0 ($1));
 
 		DBG_PRINT}}
 	| CURSOR
@@ -15807,7 +15805,7 @@ reserved_func
 			    node->info.function.all_or_distinct = PT_ALL;
 			    node->info.function.arg_list = $3;
 
-			    if ($5 == PT_IGNORE_NULLS)
+			    if ($5 == (PT_NODE *) PT_IGNORE_NULLS)
 			      {
 			        node->info.function.analytic.ignore_nulls = true;
 			      }
@@ -15840,12 +15838,12 @@ reserved_func
 				    node->info.function.analytic.default_value->type_enum = PT_TYPE_NULL;
 			      }
 
-			    if ($7 == PT_FROM_LAST)
+			    if ($7 == (PT_NODE *) PT_FROM_LAST)
 			      {
 			        node->info.function.analytic.from_last = true;
 			      }
 
-			    if ($8 == PT_IGNORE_NULLS)
+			    if ($8 == (PT_NODE *) PT_IGNORE_NULLS)
 			      {
 			        node->info.function.analytic.ignore_nulls = true;
 			      }
@@ -17498,7 +17496,7 @@ opt_analytic_from_last
 	| FROM LAST
 		{{
 
-			$$ = PT_FROM_LAST;
+			$$ = (PT_NODE *) PT_FROM_LAST;
 
 		DBG_PRINT}}
 	;
@@ -17519,7 +17517,7 @@ opt_analytic_ignore_nulls
 	| IGNORE_ NULLS
 		{{
 
-			$$ = PT_IGNORE_NULLS;
+			$$ = (PT_NODE *) PT_IGNORE_NULLS;
 
 		DBG_PRINT}}
 	;
@@ -20963,7 +20961,7 @@ signed_literal_
 			    {
 			      const char *min_big_int = "9223372036854775808";
 			      if (node->info.value.data_value.str->length == 19
-				  && (strcmp (node->info.value.data_value.str->bytes,
+				  && (strcmp ((const char *) node->info.value.data_value.str->bytes,
 				  	      min_big_int) == 0))
 			        {
 				  node->info.value.data_value.bigint = DB_BIGINT_MIN;
@@ -20978,9 +20976,7 @@ signed_literal_
 				  buf = pt_append_nulstring (this_parser, buf,
 							     minus_sign);
 				  buf = pt_append_nulstring (this_parser, buf,
-							     node->info.value.
-							     data_value.str->
-							     bytes);
+							     (const char *) node->info.value.data_value.str->bytes);
 				  node->info.value.data_value.str = buf;
 			        }
 			    }
@@ -21024,8 +21020,7 @@ signed_literal_
 			      buf = pt_append_nulstring (this_parser, buf,
 						       minus_sign);
 			      buf = pt_append_nulstring (this_parser, buf,
-						         node->info.value.
-						         data_value.str->bytes);
+						         (const char *) node->info.value.data_value.str->bytes);
 			      node->info.value.data_value.str = buf;
 			    }
 
@@ -26254,7 +26249,7 @@ parser_keyword_func (const char *name, PT_NODE * args)
 
       if(a2->node_type == PT_VALUE
          && PT_IS_STRING_TYPE(a2->type_enum)
-         && strcasecmp(a2->info.value.data_value.str->bytes, "default") == 0)
+         && strcasecmp((const char *) a2->info.value.data_value.str->bytes, "default") == 0)
         {
           PT_ERRORf (this_parser, a2, "check syntax at %s",
                      parser_print_tree (this_parser, a2));
@@ -26297,7 +26292,7 @@ parser_keyword_func (const char *name, PT_NODE * args)
       /* prevent user input "default" */
       if (a2->node_type == PT_VALUE
           && a2->type_enum == PT_TYPE_CHAR
-          && strcasecmp (a2->info.value.data_value.str->bytes, "default") == 0)
+          && strcasecmp ((const char *) a2->info.value.data_value.str->bytes, "default") == 0)
         {
           PT_ERRORf (this_parser, a2, "check syntax at %s",
                      parser_print_tree (this_parser, a2));
@@ -27332,7 +27327,7 @@ pt_value_set_collation_info (PARSER_CONTEXT *parser, PT_NODE *node,
       assert (coll_node->node_type == PT_VALUE);
 
       assert (coll_node->info.value.data_value.str != NULL);
-      lang_coll = lang_get_collation_by_name (coll_node->info.value.data_value.str->bytes);
+      lang_coll = lang_get_collation_by_name ((const char *) coll_node->info.value.data_value.str->bytes);
     }
 
   if (lang_coll != NULL)
@@ -27435,7 +27430,7 @@ pt_set_collation_modifier (PARSER_CONTEXT *parser, PT_NODE *node,
   assert (coll_node->node_type == PT_VALUE);
 
   assert (coll_node->info.value.data_value.str != NULL);
-  lang_coll = lang_get_collation_by_name (coll_node->info.value.data_value.str->bytes);
+  lang_coll = lang_get_collation_by_name ((const char *) coll_node->info.value.data_value.str->bytes);
 
   if (lang_coll == NULL)
     {

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -695,6 +695,8 @@ int g_original_buffer_len;
 %type <number> show_type_id_dot_id
 %type <number> kill_type
 %type <number> procedure_or_function
+%type <boolean> opt_analytic_from_last
+%type <boolean> opt_analytic_ignore_nulls
 /*}}}*/
 
 /* define rule type (node) */
@@ -985,8 +987,6 @@ int g_original_buffer_len;
 %type <node> session_variable_definition
 %type <node> session_variable_expression
 %type <node> session_variable_list
-%type <node> opt_analytic_from_last
-%type <node> opt_analytic_ignore_nulls
 %type <node> opt_analytic_partition_by
 %type <node> opt_over_analytic_partition_by
 %type <node> opt_analytic_order_by
@@ -15805,10 +15805,7 @@ reserved_func
 			    node->info.function.all_or_distinct = PT_ALL;
 			    node->info.function.arg_list = $3;
 
-			    if ($5 == (PT_NODE *) PT_IGNORE_NULLS)
-			      {
-			        node->info.function.analytic.ignore_nulls = true;
-			      }
+			    node->info.function.analytic.ignore_nulls = $5;
 
 			    node->info.function.analytic.is_analytic = true;
 			    node->info.function.analytic.partition_by = $8;
@@ -15838,15 +15835,8 @@ reserved_func
 				    node->info.function.analytic.default_value->type_enum = PT_TYPE_NULL;
 			      }
 
-			    if ($7 == (PT_NODE *) PT_FROM_LAST)
-			      {
-			        node->info.function.analytic.from_last = true;
-			      }
-
-			    if ($8 == (PT_NODE *) PT_IGNORE_NULLS)
-			      {
-			        node->info.function.analytic.ignore_nulls = true;
-			      }
+			    node->info.function.analytic.from_last = $7;
+			    node->info.function.analytic.ignore_nulls = $8;
 
 			    node->info.function.analytic.is_analytic = true;
 			    node->info.function.analytic.partition_by = $11;
@@ -17484,19 +17474,19 @@ opt_analytic_from_last
 	: /* empty */
 		{{
 
-			$$ = NULL;
+			$$ = false;
 
 		DBG_PRINT}}
 	| FROM FIRST
 		{{
 
-			$$ = NULL;
+			$$ = false;
 
 		DBG_PRINT}}
 	| FROM LAST
 		{{
 
-			$$ = (PT_NODE *) PT_FROM_LAST;
+			$$ = true;
 
 		DBG_PRINT}}
 	;
@@ -17505,19 +17495,19 @@ opt_analytic_ignore_nulls
 	: /* empty */
 		{{
 
-			$$ = NULL;
+			$$ = false;
 
 		DBG_PRINT}}
 	| RESPECT NULLS
 		{{
 
-			$$ = NULL;
+			$$ = false;
 
 		DBG_PRINT}}
 	| IGNORE_ NULLS
 		{{
 
-			$$ = (PT_NODE *) PT_IGNORE_NULLS;
+			$$ = true;
 
 		DBG_PRINT}}
 	;
@@ -27537,3 +27527,4 @@ pt_jt_append_column_or_nested_node (PT_NODE * jt_node, PT_NODE * jt_col_or_neste
         parser_append_node (jt_col_or_nested, jt_node->info.json_table_node_info.nested_paths);
     }
 }
+

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -52,7 +52,7 @@ extern int yycolumn;
 extern int yycolumn_end;
 extern int dot_flag;
 
-extern int str_identifier = '\0';
+int str_identifier = '\0';
 
 
 

--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -196,7 +196,7 @@ static void pt_free_node_blocks (const PARSER_CONTEXT * parser);
 static PARSER_STRING_BLOCK *parser_create_string_block (const PARSER_CONTEXT * parser, const int length);
 static void pt_free_a_string_block (const PARSER_CONTEXT * parser, PARSER_STRING_BLOCK * string_to_free);
 static PARSER_STRING_BLOCK *pt_find_string_block (const PARSER_CONTEXT * parser, const char *old_string);
-static char *pt_append_string_for (const PARSER_CONTEXT * parser, char *old_string, const char *new_tail,
+static char *pt_append_string_for (const PARSER_CONTEXT * parser, const char *old_string, const char *new_tail,
 				   const int wrap_with_single_quote);
 static PARSER_VARCHAR *pt_append_bytes_for (const PARSER_CONTEXT * parser, PARSER_VARCHAR * old_string,
 					    const char *new_tail, const int new_tail_length);
@@ -588,7 +588,7 @@ pt_find_string_block (const PARSER_CONTEXT * parser, const char *old_string)
  * The given old_string is OVERWRITTEN.
  */
 static char *
-pt_append_string_for (const PARSER_CONTEXT * parser, char *old_string, const char *new_tail,
+pt_append_string_for (const PARSER_CONTEXT * parser, const char *old_string, const char *new_tail,
 		      const int wrap_with_single_quote)
 {
   PARSER_STRING_BLOCK *string;
@@ -958,15 +958,18 @@ parser_alloc (const PARSER_CONTEXT * parser, const int length)
  * (for a null character). The two strings are logically concatenated
  * and copied into the result string. The physical operation is typically
  * more efficient, and conservative of memory
+ *
+ * Note :
+ * pt_append_string won't modify old_string but it will return it to caller if new_tail is NULL.
  */
 char *
-pt_append_string (const PARSER_CONTEXT * parser, char *old_string, const char *new_tail)
+pt_append_string (const PARSER_CONTEXT * parser, const char *old_string, const char *new_tail)
 {
   char *s;
 
   if (new_tail == NULL)
     {
-      s = old_string;
+      s = CONST_CAST (char *, old_string);	// it is up to caller
     }
   else if (old_string == NULL)
     {

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -119,7 +119,7 @@ extern "C"
   extern char *pt_short_print_l (PARSER_CONTEXT * parser, const PT_NODE * p);
 
   extern void *parser_alloc (const PARSER_CONTEXT * parser, const int length);
-  extern char *pt_append_string (const PARSER_CONTEXT * parser, char *old_string, const char *new_tail);
+  extern char *pt_append_string (const PARSER_CONTEXT * parser, const char *old_string, const char *new_tail);
 
   extern PARSER_VARCHAR *pt_append_bytes (const PARSER_CONTEXT * parser, PARSER_VARCHAR * old_bytes,
 					  const char *new_tail, const int length);

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -16730,7 +16730,7 @@ pt_plan_query (PARSER_CONTEXT * parser, PT_NODE * select_node)
 	      contextp->sql_plan_alloc_size = size;
 	      contextp->sql_plan_text[0] = '\0';
 	    }
-	  else if (contextp->sql_plan_alloc_size - strlen (contextp->sql_plan_text) < (long) plan_len)
+	  else if (contextp->sql_plan_alloc_size - (int) strlen (contextp->sql_plan_text) < (long) plan_len)
 	    {
 	      char *ptr;
 	      int size = (contextp->sql_plan_alloc_size + (int) plan_len) * 2;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -16472,13 +16472,13 @@ bf2df_str_son_index (THREAD_ENTRY * thread_p, char **son_index, char *father_ind
   size = strlen (counter) + n + 2;
 
   /* more space needed? */
-  if (size > *len_son_index)
+  if ((*len_son_index > 0) && (size > ((size_t) * len_son_index)))
     {
       do
 	{
 	  *len_son_index += CONNECTBY_TUPLE_INDEX_STRING_MEM;
 	}
-      while (size > *len_son_index);
+      while (size > ((size_t) * len_son_index));
       db_private_free_and_init (thread_p, *son_index);
       *son_index = (char *) db_private_alloc (thread_p, *len_son_index);
       if ((*son_index) == NULL)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -16750,7 +16750,7 @@ qexec_get_index_pseudocolumn_value_from_tuple (THREAD_ENTRY * thread_p, XASL_NOD
   if (!db_value_is_null (*index_valp))
     {
       /* increase the size if more space needed */
-      while (strlen ((*index_valp)->data.ch.medium.buf) + 1 > *index_len)
+      while ((int) strlen ((*index_valp)->data.ch.medium.buf) + 1 > *index_len)
 	{
 	  (*index_len) += CONNECTBY_TUPLE_INDEX_STRING_MEM;
 	  db_private_free_and_init (thread_p, *index_value);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -16472,19 +16472,21 @@ bf2df_str_son_index (THREAD_ENTRY * thread_p, char **son_index, char *father_ind
   size = strlen (counter) + n + 2;
 
   /* more space needed? */
-  if ((*len_son_index > 0) && (size > ((size_t) * len_son_index)))
+  if ((*len_son_index > 0) && (size > ((size_t) (*len_son_index))))
     {
       do
 	{
 	  *len_son_index += CONNECTBY_TUPLE_INDEX_STRING_MEM;
 	}
-      while (size > ((size_t) * len_son_index));
+      while (size > ((size_t) (*len_son_index)));
+
       db_private_free_and_init (thread_p, *son_index);
       *son_index = (char *) db_private_alloc (thread_p, *len_son_index);
       if ((*son_index) == NULL)
 	{
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
+
       memset (*son_index, 0, *len_son_index);
     }
 

--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -440,7 +440,7 @@ namespace cubscan
     }
 
     int
-    scanner::scan_next_internal (cubthread::entry *thread_p, int depth, bool &found_row_output)
+    scanner::scan_next_internal (cubthread::entry *thread_p, size_t depth, bool &found_row_output)
     {
       int error_code = NO_ERROR;
       cursor &this_cursor = m_scan_cursor[depth];

--- a/src/query/scan_json_table.hpp
+++ b/src/query/scan_json_table.hpp
@@ -155,7 +155,7 @@ namespace cubscan
 	size_t get_tree_height (const cubxasl::json_table::node &node);
 
 	// recursive scan next called on json table node / cursor
-	int scan_next_internal (cubthread::entry *thread_p, int depth, bool &found_row_output);
+	int scan_next_internal (cubthread::entry *thread_p, size_t depth, bool &found_row_output);
 
 	cubxasl::json_table::spec_node *m_specp;    // pointer to json table spec node in XASL
 	cursor *m_scan_cursor;                      // cursor to keep track progress in each scan node

--- a/src/query/xasl_to_stream.c
+++ b/src/query/xasl_to_stream.c
@@ -7405,7 +7405,7 @@ xts_get_offset_visited_ptr (const void *ptr)
 static void
 xts_free_visited_ptrs (void)
 {
-  int i;
+  size_t i;
 
   for (i = 0; i < MAX_PTR_BLOCKS; i++)
     {

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1111,7 +1111,7 @@ const size_t BTREE_RV_BUFFER_SIZE =
 #endif /* !NDEBUG */
 
 static void
-BTREE_RV_GET_DATA_LENGTH (const char *rv_ptr, const char *rv_start, int rv_length)
+BTREE_RV_GET_DATA_LENGTH (const char *rv_ptr, const char *rv_start, int &rv_length)
 {
   assert (rv_ptr != NULL);
   assert (rv_start != NULL);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1110,15 +1110,14 @@ const size_t BTREE_RV_BUFFER_SIZE =
   4 * LOG_RV_RECORD_UPDPARTIAL_ALIGNED_SIZE (BTREE_OBJECT_MAX_SIZE);
 #endif /* !NDEBUG */
 
-#define BTREE_RV_GET_DATA_LENGTH(rv_ptr, rv_start, rv_length) \
-  do \
-    { \
-      assert ((rv_ptr) != NULL); \
-      assert ((rv_start) != NULL); \
-      (rv_length) = CAST_BUFLEN ((rv_ptr) - (rv_start)); \
-      assert (0 <= (rv_length) && (rv_length) <= BTREE_RV_BUFFER_SIZE); \
-    } \
-  while (false)
+static void
+BTREE_RV_GET_DATA_LENGTH (const char *rv_ptr, const char *rv_start, int rv_length)
+{
+  assert (rv_ptr != NULL);
+  assert (rv_start != NULL);
+  rv_length = CAST_BUFLEN (rv_ptr - rv_start);
+  assert (0 <= rv_length && (size_t) rv_length <= BTREE_RV_BUFFER_SIZE);
+}
 
 /* Debug identifiers to help with detecting recovery issues. */
 enum btree_rv_debug_id

--- a/src/storage/btree_load.h
+++ b/src/storage/btree_load.h
@@ -170,22 +170,21 @@ extern int btree_get_next_overflow_vpid (THREAD_ENTRY * thread_p, PAGE_PTR page_
 		  ER_BTREE_DELETED_OVERFLOW_PAGE, __FILE__, __LINE__)
 
 /* set fixed size for MVCC record header */
-#define BTREE_MVCC_SET_HEADER_FIXED_SIZE(p_mvcc_rec_header) \
-  do \
-    { \
-      assert (p_mvcc_rec_header != NULL); \
-      if (!((p_mvcc_rec_header)->mvcc_flag & OR_MVCC_FLAG_VALID_INSID)) \
-        { \
-          (p_mvcc_rec_header)->mvcc_flag |= OR_MVCC_FLAG_VALID_INSID; \
-          (p_mvcc_rec_header)->mvcc_ins_id = MVCCID_ALL_VISIBLE; \
-        } \
-      if (!((p_mvcc_rec_header)->mvcc_flag & OR_MVCC_FLAG_VALID_DELID)) \
-        { \
-          (p_mvcc_rec_header)->mvcc_flag |= OR_MVCC_FLAG_VALID_DELID; \
-          (p_mvcc_rec_header)->mvcc_del_id = MVCCID_NULL; \
-        } \
-    } \
-  while (0)
+inline void
+BTREE_MVCC_SET_HEADER_FIXED_SIZE (MVCC_REC_HEADER * p_mvcc_rec_header)
+{
+  assert (p_mvcc_rec_header != NULL);
+  if (!(p_mvcc_rec_header->mvcc_flag & OR_MVCC_FLAG_VALID_INSID))
+    {
+      p_mvcc_rec_header->mvcc_flag |= OR_MVCC_FLAG_VALID_INSID;
+      p_mvcc_rec_header->mvcc_ins_id = MVCCID_ALL_VISIBLE;
+    }
+  if (!(p_mvcc_rec_header->mvcc_flag & OR_MVCC_FLAG_VALID_DELID))
+    {
+      p_mvcc_rec_header->mvcc_flag |= OR_MVCC_FLAG_VALID_DELID;
+      p_mvcc_rec_header->mvcc_del_id = MVCCID_NULL;
+    }
+}
 
 /*
  * Type definitions related to b+tree structure and operations

--- a/src/storage/double_write_buffer.c
+++ b/src/storage/double_write_buffer.c
@@ -3603,8 +3603,9 @@ start:
   /* Check whether the initial block was flushed */
 check_flushed_blocks:
 
+  assert (initial_block_no > 0);
   if ((ATOMIC_INC_32 (&dwb_Global.blocks_flush_counter, 0) > 0)
-      && (ATOMIC_INC_32 (&dwb_Global.next_block_to_flush, 0) == initial_block_no)
+      && (ATOMIC_INC_32 (&dwb_Global.next_block_to_flush, 0) == (unsigned int) initial_block_no)
       && (ATOMIC_INC_32 (&dwb_Global.blocks[initial_block_no].count_wb_pages, 0) == DWB_BLOCK_NUM_PAGES))
     {
       /* The initial block is currently flushing, wait for it. */

--- a/src/storage/record_descriptor.cpp
+++ b/src/storage/record_descriptor.cpp
@@ -131,7 +131,7 @@ record_descriptor::get (cubthread::entry *thread_p, PAGE_PTR page, PGSLOTID slot
 void
 record_descriptor::resize (cubthread::entry *thread_p, std::size_t required_size, bool copy_data)
 {
-  if (required_size <= m_recdes.area_size)
+  if (m_recdes.area_size > 0 && required_size <= (size_t) m_recdes.area_size)
     {
       // resize not required
       return;

--- a/src/xasl/xasl_stream.cpp
+++ b/src/xasl/xasl_stream.cpp
@@ -101,7 +101,7 @@ stx_set_xasl_errcode (THREAD_ENTRY *thread_p, int errcode)
 int
 stx_init_xasl_unpack_info (THREAD_ENTRY *thread_p, char *xasl_stream, int xasl_stream_size)
 {
-  int n;
+  size_t n;
   XASL_UNPACK_INFO *unpack_info;
   int head_offset, body_offset;
 
@@ -228,7 +228,7 @@ stx_get_struct_visited_ptr (THREAD_ENTRY *thread_p, const void *ptr)
 void
 stx_free_visited_ptrs (THREAD_ENTRY *thread_p)
 {
-  int i;
+  size_t i;
   XASL_UNPACK_INFO *xasl_unpack_info = stx_get_xasl_unpack_info_ptr (thread_p);
 
   for (i = 0; i < MAX_PTR_BLOCKS; i++)

--- a/unit_tests/lockfree/test_cqueue_functional.cpp
+++ b/unit_tests/lockfree/test_cqueue_functional.cpp
@@ -183,7 +183,7 @@ namespace test_lockfree
       {
 	if (cqueue.consume (val))
 	  {
-	    test_common::custom_assert (val < MAX_VAL);
+	    test_common::custom_assert ((size_t) val < MAX_VAL);
 	    ++valcount[val];
 	    op_count--;
 	  }

--- a/unit_tests/object_factory/test_object_factory.hpp
+++ b/unit_tests/object_factory/test_object_factory.hpp
@@ -32,6 +32,9 @@ namespace test_object_factory
   {
     public:
       virtual int get_height () = 0;
+      virtual ~animal ()
+      {
+      }
   };
 
   class lion : public animal

--- a/unit_tests/packing/test_packing.cpp
+++ b/unit_tests/packing/test_packing.cpp
@@ -48,7 +48,7 @@ namespace test_packing
     serializator.pack_bigint (b1);
     serializator.pack_int_array (int_a, sizeof (int_a) / sizeof (int_a[0]));
     serializator.pack_int_vector (int_v);
-    for (int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
+    for (size_t i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
 	serializator.pack_db_value (values[i]);
       }
@@ -72,7 +72,7 @@ namespace test_packing
 
     deserializator.unpack_int_vector (int_v);
 
-    for (int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
+    for (size_t i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
 	deserializator.unpack_db_value (values[i]);
       }
@@ -98,7 +98,7 @@ namespace test_packing
       {
 	return false;
       }
-    for (int i = 0; i < sizeof (int_a) / sizeof (int_a[0]); i++)
+    for (size_t i = 0; i < sizeof (int_a) / sizeof (int_a[0]); i++)
       {
 	if (int_a[i] != other_po1->int_a[i])
 	  {
@@ -106,7 +106,7 @@ namespace test_packing
 	  }
       }
 
-    for (int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
+    for (size_t i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
 	if (db_value_compare (&values[i], &other_po1->values[i]) != DB_EQ)
 	  {
@@ -146,7 +146,7 @@ namespace test_packing
     entry_size += serializator.get_packed_bigint_size (entry_size);
     entry_size += serializator.get_packed_int_vector_size (entry_size, sizeof (int_a) / sizeof (int_a[0]));
     entry_size += serializator.get_packed_int_vector_size (entry_size, (int) int_v.size ());
-    for (int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
+    for (size_t i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
 	entry_size += serializator.get_packed_db_value_size (values[i], entry_size);
       }
@@ -166,11 +166,11 @@ namespace test_packing
     i1 = std::rand ();
     sh1 = std::rand ();
     b1 = std::rand ();
-    for (int i = 0; i < sizeof (int_a) / sizeof (int_a[0]); i++)
+    for (size_t i = 0; i < sizeof (int_a) / sizeof (int_a[0]); i++)
       {
 	int_a[i] = std::rand ();
       }
-    for (int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
+    for (size_t i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
 	switch (std::rand () % 5)
 	  {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21524

Fix list of warnings:

-Wsign-compare
-Wtype-limits
-Waddress
-Wmissing-prototypes
-Wnonnull-compare
-Wredundant-decls
-Wformat=

Other changes:

- moved a block of code in page buffer to fix dependency on pgbuf_Pool. the only real change is replacing PGBUF_THREAD_HAS_PRIVATE_LRU macro with inline function.
- inline function for BTREE_MVCC_SET_HEADER_FIXED_SIZE
- changed signature of scanner::scan_next_internal (size_t depth)
- chagned signature of pt_append_string/pt_append_string_for (const char * old_string)
- changed work_space mvcc_snapshot_version to unsigned int