### PR TITLE
[CBRD-22841] fix LOG_PRIOR_LSA_LAST_APPEND_OFFSET

### DIFF
--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -39,7 +39,11 @@ static char *log_data_ptr = NULL;
 static int log_data_length = 0;
 #endif
 
-const size_t LOG_PRIOR_LSA_LAST_APPEND_OFFSET = LOGAREA_SIZE;
+size_t
+LOG_PRIOR_LSA_LAST_APPEND_OFFSET ()
+{
+  return LOGAREA_SIZE;
+}
 
 static void log_prior_lsa_append_align ();
 static void log_prior_lsa_append_advance_when_doesnot_fit (size_t length);
@@ -1605,7 +1609,7 @@ prior_lsa_end_append (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node)
 static void
 prior_lsa_append_data (int length)
 {
-  int copy_length;		/* Amount of contiguos data that can be copied */
+  int copy_length;		/* Amount of contiguous data that can be copied */
   int current_offset;
   int last_offset;
 
@@ -1621,7 +1625,7 @@ prior_lsa_append_data (int length)
   log_prior_lsa_append_align ();
 
   current_offset = (int) log_Gl.prior_info.prior_lsa.offset;
-  last_offset = (int) LOG_PRIOR_LSA_LAST_APPEND_OFFSET;
+  last_offset = (int) LOG_PRIOR_LSA_LAST_APPEND_OFFSET ();
 
   /* Does data fit completely in current page ? */
   if ((current_offset + length) >= last_offset)
@@ -1637,7 +1641,7 @@ prior_lsa_append_data (int length)
 	      log_Gl.prior_info.prior_lsa.offset = 0;
 
 	      current_offset = 0;
-	      last_offset = (int) LOG_PRIOR_LSA_LAST_APPEND_OFFSET;
+	      last_offset = (int) LOG_PRIOR_LSA_LAST_APPEND_OFFSET ();
 	    }
 	  /* Find the amount of contiguous data that can be copied */
 	  if (current_offset + length >= last_offset)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22841

LOG_PRIOR_LSA_LAST_APPEND_OFFSET is not a constant. It depends on log page size configuration.