### PR TITLE
[CBRD-21524] Fix bad safe-guard from df3e705

### DIFF
--- a/src/storage/double_write_buffer.c
+++ b/src/storage/double_write_buffer.c
@@ -3603,7 +3603,7 @@ start:
   /* Check whether the initial block was flushed */
 check_flushed_blocks:
 
-  assert (initial_block_no > 0);
+  assert (initial_block_no >= 0);
   if ((ATOMIC_INC_32 (&dwb_Global.blocks_flush_counter, 0) > 0)
       && (ATOMIC_INC_32 (&dwb_Global.next_block_to_flush, 0) == (unsigned int) initial_block_no)
       && (ATOMIC_INC_32 (&dwb_Global.blocks[initial_block_no].count_wb_pages, 0) == DWB_BLOCK_NUM_PAGES))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21524

Fix slip of PR#1505 - safe-guard `assert (initial_block_no >= 0);`