### PR TITLE
[CBRD-22784] Large json array index causes unclear invalid path error

### DIFF
--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/en_US/cubrid.msg
+++ b/msg/en_US/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/en_US/cubrid.msg
+++ b/msg/en_US/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/ko_KR.euckr/cubrid.msg
+++ b/msg/ko_KR.euckr/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/ko_KR.euckr/cubrid.msg
+++ b/msg/ko_KR.euckr/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in a Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/ro_RO.utf8/cubrid.msg
+++ b/msg/ro_RO.utf8/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Json invalid: %1$s (%2$d)
 1198 Trebuie furnizat un obiect de tipul json.
 1199 Json-ul furnizat a fost invalidat de catre schema json (Calea catre schema invalidă: %1$s, Cuvantul cheie: %2$s, Calea catre json-ul invalid furnizat: %3$s)
-1200 Cale de JSON invalida. %1$s
+1200 Cale de JSON invalida
 1201 Numele unei valori dintr-un JSON Object nu poate fi NULL.
 1202 Calea "%1$s" nu exista in %2$s
 1203 Tipul JSON-ului de la calea %1$s este invalid. Expected %2$s, dar am gasit %3$s.
 1204 Cheia "%1$s" din json este duplicata
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Calea Json "%1$s" nu adresează un element al unui Json ARRAY.
-1207 Reserved error for JSON.
+1207 Cale de JSON invalida. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/ro_RO.utf8/cubrid.msg
+++ b/msg/ro_RO.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Json invalid: %1$s (%2$d)
 1198 Trebuie furnizat un obiect de tipul json.
 1199 Json-ul furnizat a fost invalidat de catre schema json (Calea catre schema invalidă: %1$s, Cuvantul cheie: %2$s, Calea catre json-ul invalid furnizat: %3$s)
-1200 Cale de JSON invalida
+1200 Cale de JSON invalida. %1$s
 1201 Numele unei valori dintr-un JSON Object nu poate fi NULL.
 1202 Calea "%1$s" nu exista in %2$s
 1203 Tipul JSON-ului de la calea %1$s este invalid. Expected %2$s, dar am gasit %3$s.

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1266,14 +1266,14 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 1202 Json PATH "%1$s" does not exist in %2$s
 1203 Invalid JSON type at path %1$s. Expected %2$s, but found %3$s.
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/msg/zh_CN.utf8/cubrid.msg
+++ b/msg/zh_CN.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path
+1200 Invalid JSON path. %1$s
 1201 Json object name cannot be NULL.
 
 1202 Json PATH "%1$s" does not exist in %2$s

--- a/msg/zh_CN.utf8/cubrid.msg
+++ b/msg/zh_CN.utf8/cubrid.msg
@@ -1266,7 +1266,7 @@ $ LOADDB
 1197 Invalid json: %1$s (%2$d)
 1198 A json object must be provided
 1199 The provided JSON has been invalidated by the JSON schema (Invalid schema path: %1$s, Keyword: %2$s, Invalid provided JSON path: %3$s)
-1200 Invalid JSON path. %1$s
+1200 Invalid JSON path
 1201 Json object name cannot be NULL.
 
 1202 Json PATH "%1$s" does not exist in %2$s
@@ -1274,7 +1274,7 @@ $ LOADDB
 1204 Json KEY "%1$s" is duplicate
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
-1207 Reserved error for JSON.
+1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
 1208 Reserved error for JSON.
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.

--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -1550,7 +1550,7 @@
 #define ER_JSON_EXPECTING_JSON_DOC                  -1205
 
 #define ER_JSON_PATH_IS_NOT_ARRAY_CELL              -1206
-#define ER_JSON_RESERVED_ERROR_2                    -1207
+#define ER_JSON_ARRAY_INDEX_TOO_LARGE               -1207
 #define ER_JSON_RESERVED_ERROR_3                    -1208
 #define ER_JSON_RESERVED_ERROR_4                    -1209
 #define ER_JSON_RESERVED_ERROR_5                    -1210

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -2735,10 +2735,10 @@ db_json_normalize_path_string (const char *pointer_path, std::string &output)
   return NO_ERROR;
 }
 
-void
+int
 db_json_path_unquote_object_keys_external (std::string &sql_path)
 {
-  db_json_path_unquote_object_keys (sql_path);
+  return db_json_path_unquote_object_keys (sql_path);
 }
 
 /*

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -158,7 +158,7 @@ void db_make_json_from_doc_store_and_release (DB_VALUE &value, JSON_DOC_STORE &d
 int db_value_to_json_path (const DB_VALUE *path_value, FUNC_TYPE fcode, const char **path_str);
 
 int db_json_normalize_path_string (const char *pointer_path, std::string &normalized_path);
-void db_json_path_unquote_object_keys_external (std::string &sql_path);
+int db_json_path_unquote_object_keys_external (std::string &sql_path);
 
 template <typename Fn, typename... Args>
 inline int

--- a/src/compat/db_json_path.cpp
+++ b/src/compat/db_json_path.cpp
@@ -171,7 +171,7 @@ db_json_path_is_token_valid_array_index (const std::string &str, bool allow_wild
   // this will point to the 4th element of the array (zero indexed)
   if (str == "-")
     {
-      return true;
+      return NO_ERROR;
     }
 
   if (end == 0)
@@ -182,14 +182,14 @@ db_json_path_is_token_valid_array_index (const std::string &str, bool allow_wild
 
   if (start == end)
     {
-      return false;
+      return db_json_er_set_path_is_invalid (ARG_FILE_LINE);
     }
 
   std::size_t last_non_space = end - 1;
   for (; last_non_space > start && str[last_non_space] == ' '; --last_non_space);
   if (allow_wildcards && start == last_non_space && str[start] == '*')
     {
-      return true;
+      return NO_ERROR;
     }
 
   // Remaining invalid cases are: 1. Non-digits are present
@@ -201,7 +201,7 @@ db_json_path_is_token_valid_array_index (const std::string &str, bool allow_wild
     {
       if (!std::isdigit (static_cast<unsigned char> (*it)))
 	{
-	  return false;
+	  return db_json_er_set_path_is_invalid (ARG_FILE_LINE);
 	}
     }
 

--- a/src/compat/db_json_path.cpp
+++ b/src/compat/db_json_path.cpp
@@ -58,7 +58,7 @@ db_json_iszero (const unsigned char &ch)
   return ch == '0';
 }
 
-const char *larger_than_max_array_idx_msg = "index is larger than allowed by system variable json_max_array_idx";
+const char *larger_than_max_array_idx_msg = "Index is larger than allowed by system variable json_max_array_idx.";
 
 /*
  * db_json_path_is_token_valid_quoted_object_key () - Check if a quoted object_key is valid
@@ -154,7 +154,8 @@ db_json_path_is_token_valid_unquoted_object_key (const std::string &path, std::s
  * db_json_path_is_token_valid_array_index () - verify if token is a valid array index. token can be a substring of
  *                                              first argument (by default the entire argument).
  *
- * return          : true if all token characters are digits followed by spaces (valid index)
+ * return          : no error if token can be converted successfully to an integer smaller than json_max_array_idx
+ *                   variable
  * str (in)        : token or the string that token belong to
  * allow_wildcards : whether json_path wildcards are allowed
  * index (out)     : created index token
@@ -267,7 +268,7 @@ db_json_get_path_type (std::string &path_string)
 /*
  * validate_and_create_from_json_path () - Check if a given path is a SQL valid path
  *
- * return                  : true/false
+ * return                  : ER_JSON_INVALID_PATH if path is invalid
  * sql_path (in/out)       : path to be checked
  */
 int
@@ -502,6 +503,7 @@ JSON_PATH::match_pattern (const JSON_PATH &pattern, const JSON_PATH &path)
 /*
  * db_json_path_unquote_object_keys () - Unquote, when possible, object_keys of the json_path
  *
+ * return                  : ER_JSON_INVALID_PATH if a validation error occured
  * sql_path (in/out)       : path
  */
 int

--- a/src/compat/db_json_path.cpp
+++ b/src/compat/db_json_path.cpp
@@ -452,8 +452,9 @@ db_json_split_path_by_delimiters (const std::string &path, const std::string &de
       int error_code = db_json_path_is_token_valid_array_index (split_path[i], false, index);
       if (error_code != NO_ERROR)
 	{
-	  ASSERT_ERROR ();
-	  return error_code;
+	  // ignore error. We only need to decide whether to skip it in case it is not array_idx
+	  er_clear ();
+	  continue;
 	}
 
       db_json_remove_leading_zeros_index (split_path[i]);

--- a/src/compat/db_json_path.hpp
+++ b/src/compat/db_json_path.hpp
@@ -103,7 +103,7 @@ class JSON_PATH
 
     int from_json_pointer (const std::string &pointer_path);
 
-    bool validate_and_create_from_json_path (std::string &sql_path);
+    int validate_and_create_from_json_path (std::string &sql_path);
 
     static MATCH_RESULT match_pattern (const JSON_PATH &pattern, const token_containter_type::const_iterator &it1,
 				       const JSON_PATH &path, const token_containter_type::const_iterator &it2);
@@ -111,5 +111,5 @@ class JSON_PATH
     token_containter_type m_path_tokens;
 };
 
-void db_json_path_unquote_object_keys (std::string &sql_path);
+int db_json_path_unquote_object_keys (std::string &sql_path);
 #endif /* _DB_JSON_HPP_ */

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -6278,11 +6278,15 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
 
   JSON_DOC *result_json = nullptr;
   if (paths.size () == 1)
-    {      
-      size_t escaped_size;
+    {
+      error_code = db_json_path_unquote_object_keys_external (paths[0]);
+      if (error_code != NO_ERROR)
+      {
+        return error_code;
+      }
 
-      db_json_path_unquote_object_keys_external (paths[0]);
       char *escaped;
+      size_t escaped_size;
       error_code = db_string_escape (paths[0].c_str (), paths[0].size (), &escaped, &escaped_size);
       cubmem::private_unique_ptr<char> escaped_unqique_ptr (escaped, NULL);
       if (error_code)
@@ -6303,17 +6307,22 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
   result_json_owner.create_mutable_reference ();
   for (std::size_t i = 0; i < paths.size (); ++i)
     {
-      JSON_DOC *json_array_elem = nullptr;
+      error_code = db_json_path_unquote_object_keys_external (paths[i]);
+      if (error_code != NO_ERROR)
+      {
+        return error_code;
+      }
+
       char *escaped;
       size_t escaped_size;
-
-      db_json_path_unquote_object_keys_external (paths[i]);
       error_code = db_string_escape (paths[i].c_str (), paths[i].size (), &escaped, &escaped_size);
       cubmem::private_unique_ptr<char> escaped_unqique_ptr (escaped, NULL);
       if (error_code)
 	{
 	  return error_code;
 	}
+
+      JSON_DOC *json_array_elem = nullptr;
       error_code = db_json_get_json_from_str (escaped, json_array_elem, escaped_size);
       json_array_elem_owner.set_mutable_reference (json_array_elem);
       if (error_code != NO_ERROR)

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -6281,9 +6281,9 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
     {
       error_code = db_json_path_unquote_object_keys_external (paths[0]);
       if (error_code != NO_ERROR)
-      {
-        return error_code;
-      }
+	{
+	  return error_code;
+	}
 
       char *escaped;
       size_t escaped_size;
@@ -6309,9 +6309,9 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
     {
       error_code = db_json_path_unquote_object_keys_external (paths[i]);
       if (error_code != NO_ERROR)
-      {
-        return error_code;
-      }
+	{
+	  return error_code;
+	}
 
       char *escaped;
       size_t escaped_size;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22784

Added new Invalid json path; index too large error (-1207).