### PR TITLE
[CBRD-22844] cast logpb_get_memsize () to INT64

### DIFF
--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1494,7 +1494,7 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
     {
       log_Gl.prior_info.prior_lsa_mutex.unlock ();
 
-      if (log_Gl.prior_info.list_size >= (int) logpb_get_memsize ())
+      if (log_Gl.prior_info.list_size >= (INT64) logpb_get_memsize ())
 	{
 	  perfmon_inc_stat (thread_p, PSTAT_PRIOR_LSA_LIST_MAXED);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22844

Fix casting `logpb_get_memsize ()` to log_Gl.prior_info.list_size type = INT64.