### PR TITLE
[CBRD-22849] Stats ON system parameter

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -2979,6 +2979,14 @@ perfmon_initialize (int num_trans)
   pstat_Global.initialized = false;
   pstat_Global.activation_flag = prm_get_integer_value (PRM_ID_EXTENDED_STATISTICS_ACTIVATION);
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
+  if (prm_get_bool_value (PRM_ID_STATS_ON))
+    {
+      // always watching
+      pstat_Global.n_watchers++;
+    }
+#endif
+
   for (idx = 0; idx < PSTAT_COUNT; idx++)
     {
       assert (pstat_Metadata[idx].psid == (PERF_STAT_ID) idx);
@@ -4211,4 +4219,22 @@ perfmon_peek_thread_daemon_stats (UINT64 * stats)
   statsp += perfmon_per_daemon_stat_count ();
 }
 #endif // SERVER_MODE
+
+#if defined (SERVER_MODE) || defined (SA_MODE)
+void
+perfmon_er_log_current_stats (THREAD_ENTRY * thread_p)
+{
+  UINT64 *stats = perfmon_server_get_stats (thread_p);
+
+  const size_t STATS_DUMP_MAX_SIZE = ONE_M;     // a mega-byte
+  char *strbuf = new char[STATS_DUMP_MAX_SIZE];
+  strbuf[0] = '\0';
+
+  perfmon_server_dump_stats_to_buffer (stats, strbuf, STATS_DUMP_MAX_SIZE, NULL);
+
+  _er_log_debug (ARG_FILE_LINE, "%s\n", strbuf);
+
+  delete strbuf;
+}
+#endif // SERVER_MODE || SA_MODE
 // *INDENT-ON*

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -2979,7 +2979,7 @@ perfmon_initialize (int num_trans)
   pstat_Global.initialized = false;
   pstat_Global.activation_flag = prm_get_integer_value (PRM_ID_EXTENDED_STATISTICS_ACTIVATION);
 
-#if defined (SERVER_MODE) || defined (SA_MODE)
+#if defined (SERVER_MODE)
   if (prm_get_bool_value (PRM_ID_STATS_ON))
     {
       // always watching

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -4224,7 +4224,14 @@ perfmon_peek_thread_daemon_stats (UINT64 * stats)
 void
 perfmon_er_log_current_stats (THREAD_ENTRY * thread_p)
 {
-  UINT64 *stats = perfmon_server_get_stats (thread_p);
+  UINT64 *stats = perfmon_allocate_values ();
+  if (stats == NULL)
+    {
+      assert (false);
+      return;
+    }
+
+  xperfmon_server_copy_global_stats (stats);
 
   const size_t STATS_DUMP_MAX_SIZE = ONE_M;     // a mega-byte
   char *strbuf = new char[STATS_DUMP_MAX_SIZE];

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -808,6 +808,7 @@ extern void perfmon_copy_values (UINT64 * src, UINT64 * dest);
 #if defined (SERVER_MODE) || defined (SA_MODE)
 extern void perfmon_start_watch (THREAD_ENTRY * thread_p);
 extern void perfmon_stop_watch (THREAD_ENTRY * thread_p);
+extern void perfmon_er_log_current_stats (THREAD_ENTRY * thread_p);
 #endif /* SERVER_MODE || SA_MODE */
 
 STATIC_INLINE bool perfmon_is_perf_tracking (void) __attribute__ ((ALWAYS_INLINE));

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -666,6 +666,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_LOG_PGBUF_VICTIM_FLUSH "log_pgbuf_victim_flush"
 #define PRM_NAME_LOG_CHKPT_DETAILED "detailed_checkpoint_logging"
 #define PRM_NAME_IB_TASK_MEMSIZE "index_load_task_memsize"
+#define PRM_NAME_STATS_ON "stats_on"
 
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
@@ -2238,6 +2239,10 @@ static UINT64 prm_ib_task_memsize_default = 16 * ONE_M;
 static UINT64 prm_ib_task_memsize_lower = ONE_K;
 static UINT64 prm_ib_task_memsize_upper = 128 * ONE_M;
 static unsigned int prm_ib_task_memsize_flag = 0;
+
+bool PRM_STATS_ON = true;	// todo - change to false
+static bool prm_stats_on_default = true;	// todo - change to false
+static unsigned int prm_stats_on_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5747,6 +5752,17 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) &prm_ib_task_memsize_default,
    (void *) &PRM_IB_TASK_MEMSIZE,
    (void *) &prm_ib_task_memsize_upper, (void *) &prm_ib_task_memsize_lower,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_STATS_ON,
+   PRM_NAME_STATS_ON,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   &prm_stats_on_flag,
+   (void *) &prm_stats_on_default,
+   (void *) &PRM_STATS_ON,
+   (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2240,8 +2240,8 @@ static UINT64 prm_ib_task_memsize_lower = ONE_K;
 static UINT64 prm_ib_task_memsize_upper = 128 * ONE_M;
 static unsigned int prm_ib_task_memsize_flag = 0;
 
-bool PRM_STATS_ON = true;	// todo - change to false
-static bool prm_stats_on_default = true;	// todo - change to false
+bool PRM_STATS_ON = false;
+static bool prm_stats_on_default = false;
 static unsigned int prm_stats_on_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -432,11 +432,11 @@ enum param_id
   PRM_ID_TRACK_REQUESTS,
   PRM_ID_LOG_PGBUF_VICTIM_FLUSH,
   PRM_ID_LOG_CHKPT_DETAILED,
-
   PRM_ID_IB_TASK_MEMSIZE,
+  PRM_ID_STATS_ON,
 
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_IB_TASK_MEMSIZE
+  PRM_LAST_ID = PRM_ID_STATS_ON
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1462,11 +1462,8 @@ shutdown:
     {
       perfmon_er_log_current_stats (thread_p);
     }
-  else
-    {
-      css_Server_request_worker_pool->er_log_stats ();
-      css_Connection_worker_pool->er_log_stats ();
-    }
+  css_Server_request_worker_pool->er_log_stats ();
+  css_Connection_worker_pool->er_log_stats ();
 
   // destroy thread worker pools
   thread_get_manager ()->destroy_worker_pool (css_Server_request_worker_pool);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1458,8 +1458,15 @@ shutdown:
   // stop log writers
   css_stop_all_workers (*thread_p, THREAD_STOP_LOGWR);
 
-  css_Server_request_worker_pool->er_log_stats ();
-  css_Connection_worker_pool->er_log_stats ();
+  if (prm_get_bool_value (PRM_ID_STATS_ON))
+    {
+      perfmon_er_log_current_stats (thread_p);
+    }
+  else
+    {
+      css_Server_request_worker_pool->er_log_stats ();
+      css_Connection_worker_pool->er_log_stats ();
+    }
 
   // destroy thread worker pools
   thread_get_manager ()->destroy_worker_pool (css_Server_request_worker_pool);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2913,6 +2913,11 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
   boot_check_db_at_num_shutdowns (true);
 #endif /* CUBRID_DEBUG */
 
+  if (prm_get_bool_value (PRM_ID_STATS_ON))
+    {
+      perfmon_er_log_current_stats (thread_p);
+    }
+
   sysprm_set_force (prm_get_name (PRM_ID_SUPPRESS_FSYNC), "0");
 
   /* Shutdown the system with the system transaction */
@@ -3671,11 +3676,6 @@ void
 boot_server_all_finalize (THREAD_ENTRY * thread_p, ER_FINAL_CODE is_er_final,
 			  BOOT_SERVER_SHUTDOWN_MODE shutdown_common_modules)
 {
-  if (prm_get_bool_value (PRM_ID_STATS_ON))
-    {
-      perfmon_er_log_current_stats (thread_p);
-    }
-
   logtb_finalize_global_unique_stats_table (thread_p);
   locator_finalize (thread_p);
   spage_finalize (thread_p);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2913,11 +2913,6 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
   boot_check_db_at_num_shutdowns (true);
 #endif /* CUBRID_DEBUG */
 
-  if (prm_get_bool_value (PRM_ID_STATS_ON))
-    {
-      perfmon_er_log_current_stats (thread_p);
-    }
-
   sysprm_set_force (prm_get_name (PRM_ID_SUPPRESS_FSYNC), "0");
 
   /* Shutdown the system with the system transaction */

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3671,6 +3671,11 @@ void
 boot_server_all_finalize (THREAD_ENTRY * thread_p, ER_FINAL_CODE is_er_final,
 			  BOOT_SERVER_SHUTDOWN_MODE shutdown_common_modules)
 {
+  if (prm_get_bool_value (PRM_ID_STATS_ON))
+    {
+      perfmon_er_log_current_stats (thread_p);
+    }
+
   logtb_finalize_global_unique_stats_table (thread_p);
   locator_finalize (thread_p);
   spage_finalize (thread_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22849

Use hidden system parameter stats_on to automatically collect statistics on server mode. When server is stopped, all stats are dumped to error log file.