### PR TITLE
[CBRD-22798] Low performance of JSON_WALKER

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1312,6 +1312,32 @@ db_json_contains_path (const JSON_DOC *document, const std::vector<std::string> 
 	}
     }
 
+  bool contains_wildcard = false;
+  for (const JSON_PATH &json_path : json_paths)
+    {
+      contains_wildcard = contains_wildcard || json_path.contains_wildcard ();
+    }
+
+  if (!contains_wildcard)
+    {
+      for (const JSON_PATH &json_path : json_paths)
+	{
+	  const JSON_VALUE *found = json_path.get (*document);
+	  if (find_all && found == NULL)
+	    {
+	      result = false;
+	      return NO_ERROR;
+	    }
+	  if (!find_all && found != NULL)
+	    {
+	      result = true;
+	      return NO_ERROR;
+	    }
+	}
+      result = find_all;
+      return NO_ERROR;
+    }
+
   std::unique_ptr<bool[]> found_set (new bool[paths.size ()]);
   for (std::size_t i = 0; i < paths.size (); ++i)
     {
@@ -1340,7 +1366,6 @@ db_json_contains_path (const JSON_DOC *document, const std::vector<std::string> 
   // todo: remove const_cast
   json_contains_path_walker.WalkDocument (const_cast<JSON_DOC &> (*document));
 
-  result = find_all;
   for (std::size_t i = 0; i < paths.size (); ++i)
     {
       if (find_all && !found_set[i])
@@ -1355,6 +1380,7 @@ db_json_contains_path (const JSON_DOC *document, const std::vector<std::string> 
 	}
     }
 
+  result = find_all;
   return NO_ERROR;
 }
 

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1201,55 +1201,19 @@ db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<
 
   // wrap result in json array in case we have multiple paths or we have a json_path containing wildcards
   bool array_result = false;
-  bool contains_wildcard = false;
   if (json_paths.size () > 1)
     {
       array_result = true;
-      for (const JSON_PATH &json_path : json_paths)
-	{
-	  // maybe split json_paths in a set that will go through f_extract and a set on which a get is called
-	  contains_wildcard = contains_wildcard || json_path.contains_wildcard ();
-	}
     }
   else
     {
-      array_result = contains_wildcard = json_paths[0].contains_wildcard ();
+      array_result = json_paths[0].contains_wildcard ();
     }
 
   std::vector<std::vector<const JSON_VALUE *>> produced_array (json_paths.size ());
-  if (!contains_wildcard)
+  for (size_t i = 0; i < json_paths.size (); ++i)
     {
-      // JSON_PATH::get is much faster than f_extract since it avoids to matching the already matched prefix tokens
-      // However, it does not work with wildcards.
-      for (size_t i = 0; i < json_paths.size (); ++i)
-	{
-	  const JSON_VALUE *found = json_paths[i].get (*document);
-	  if (found != NULL)
-	    {
-	      produced_array[i].push_back (found);
-	    }
-	}
-    }
-  else
-    {
-      // we gather extracted values in an array to match with the order of the given path arguments
-      const map_func_type &f_extract = [&json_paths, &produced_array] (const JSON_VALUE &jv, const JSON_PATH &crt_path,
-				       bool &stop) -> int
-      {
-	// todo: avoid doing matches of already matched tokens of the prefix. For simple wildcards it is doable by
-	// saving matched positions. Find a way to solve for double wildcards
-	for (std::size_t i = 0; i < json_paths.size (); ++i)
-	  {
-	    if (JSON_PATH::match_pattern (json_paths[i], crt_path) == JSON_PATH::MATCH_RESULT::FULL_MATCH)
-	      {
-		produced_array[i].push_back (&jv);
-	      }
-	  }
-	return NO_ERROR;
-      };
-
-      JSON_PATH_MAPPER json_extract_walker (f_extract);
-      json_extract_walker.WalkDocument (*document);
+      produced_array[i] = std::move (json_paths[i].extract (*document));
     }
 
   if (array_result)

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -396,21 +396,21 @@ class JSON_BASE_HANDLER
 class JSON_WALKER
 {
   public:
-    int WalkDocument (JSON_DOC &document);
+    int WalkDocument (const JSON_DOC &document);
 
   protected:
     // we should not instantiate this class, but extend it
     virtual ~JSON_WALKER () = default;
 
     virtual int
-    CallBefore (JSON_VALUE &value)
+    CallBefore (const JSON_VALUE &value)
     {
       // do nothing
       return NO_ERROR;
     }
 
     virtual int
-    CallAfter (JSON_VALUE &value)
+    CallAfter (const JSON_VALUE &value)
     {
       // do nothing
       return NO_ERROR;
@@ -424,14 +424,14 @@ class JSON_WALKER
     }
 
     virtual int
-    CallOnKeyIterate (JSON_VALUE &key)
+    CallOnKeyIterate (const JSON_VALUE &key)
     {
       // do nothing
       return NO_ERROR;
     }
 
   private:
-    int WalkValue (JSON_VALUE &value);
+    int WalkValue (const JSON_VALUE &value);
 
   protected:
     bool m_stop;
@@ -451,7 +451,7 @@ class JSON_DUPLICATE_KEYS_CHECKER : public JSON_WALKER
     ~JSON_DUPLICATE_KEYS_CHECKER () override = default;
 
   private:
-    int CallBefore (JSON_VALUE &value) override;
+    int CallBefore (const JSON_VALUE &value) override;
 };
 
 class JSON_PATH_MAPPER : public JSON_WALKER
@@ -462,10 +462,10 @@ class JSON_PATH_MAPPER : public JSON_WALKER
     ~JSON_PATH_MAPPER () override = default;
 
   private:
-    int CallBefore (JSON_VALUE &value) override;
-    int CallAfter (JSON_VALUE &value) override;
+    int CallBefore (const JSON_VALUE &value) override;
+    int CallAfter (const JSON_VALUE &value) override;
     int CallOnArrayIterate () override;
-    int CallOnKeyIterate (JSON_VALUE &key) override;
+    int CallOnKeyIterate (const JSON_VALUE &key) override;
 
     map_func_type m_producer;
     std::stack<unsigned int> m_index;
@@ -672,7 +672,7 @@ static int db_json_er_set_path_does_not_exist (const char *file_name, const int 
 static int db_json_er_set_expected_other_type (const char *file_name, const int line_no, const JSON_PATH &path,
     const DB_JSON_TYPE &found_type, const DB_JSON_TYPE &expected_type,
     const DB_JSON_TYPE &expected_type_optional = DB_JSON_NULL);
-static int db_json_contains_duplicate_keys (JSON_DOC &doc);
+static int db_json_contains_duplicate_keys (const JSON_DOC &doc);
 
 static int db_json_get_json_from_str (const char *json_raw, JSON_DOC &doc, size_t json_raw_length);
 static int db_json_add_json_value_to_object (JSON_DOC &doc, const char *name, JSON_VALUE &value);
@@ -690,7 +690,7 @@ static int db_json_unpack_array_to_value (OR_BUF *buf, JSON_VALUE &value, JSON_P
 static void db_json_add_element_to_array (JSON_DOC *doc, const JSON_VALUE *value);
 
 int
-JSON_DUPLICATE_KEYS_CHECKER::CallBefore (JSON_VALUE &value)
+JSON_DUPLICATE_KEYS_CHECKER::CallBefore (const JSON_VALUE &value)
 {
   std::vector<const char *> inserted_keys;
 
@@ -724,7 +724,7 @@ JSON_PATH_MAPPER::JSON_PATH_MAPPER (map_func_type func)
 }
 
 int
-JSON_PATH_MAPPER::CallBefore (JSON_VALUE &value)
+JSON_PATH_MAPPER::CallBefore (const JSON_VALUE &value)
 {
   if (value.IsArray ())
     {
@@ -742,7 +742,7 @@ JSON_PATH_MAPPER::CallBefore (JSON_VALUE &value)
 }
 
 int
-JSON_PATH_MAPPER::CallAfter (JSON_VALUE &value)
+JSON_PATH_MAPPER::CallAfter (const JSON_VALUE &value)
 {
   if (value.IsArray ())
     {
@@ -768,7 +768,7 @@ JSON_PATH_MAPPER::CallOnArrayIterate ()
 }
 
 int
-JSON_PATH_MAPPER::CallOnKeyIterate (JSON_VALUE &key)
+JSON_PATH_MAPPER::CallOnKeyIterate (const JSON_VALUE &key)
 {
   m_current_path.pop ();
   std::string path_item = "\"";
@@ -1245,7 +1245,7 @@ db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<
       };
 
       JSON_PATH_MAPPER json_extract_walker (f_extract);
-      json_extract_walker.WalkDocument (const_cast<JSON_DOC &> (*document));
+      json_extract_walker.WalkDocument (*document);
     }
 
   if (array_result)
@@ -1363,8 +1363,7 @@ db_json_contains_path (const JSON_DOC *document, const std::vector<std::string> 
   };
 
   JSON_PATH_MAPPER json_contains_path_walker (f_find);
-  // todo: remove const_cast
-  json_contains_path_walker.WalkDocument (const_cast<JSON_DOC &> (*document));
+  json_contains_path_walker.WalkDocument (*document);
 
   for (std::size_t i = 0; i < paths.size (); ++i)
     {
@@ -1593,7 +1592,7 @@ db_json_add_element_to_array (JSON_DOC *doc, const JSON_VALUE *value)
 * doc (in)                : json document
 */
 static int
-db_json_contains_duplicate_keys (JSON_DOC &doc)
+db_json_contains_duplicate_keys (const JSON_DOC &doc)
 {
   JSON_DUPLICATE_KEYS_CHECKER dup_keys_checker;
   int error_code = NO_ERROR;
@@ -2047,7 +2046,7 @@ db_json_search_func (const JSON_DOC &doc, const DB_VALUE *pattern, const DB_VALU
   };
 
   JSON_PATH_MAPPER json_search_walker (f_search);
-  return json_search_walker.WalkDocument (const_cast <JSON_DOC &> (doc));
+  return json_search_walker.WalkDocument (doc);
 }
 
 /*
@@ -3306,15 +3305,14 @@ db_json_value_wrap_as_array (JSON_VALUE &value, JSON_PRIVATE_MEMPOOL &allocator)
 }
 
 int
-JSON_WALKER::WalkDocument (JSON_DOC &document)
+JSON_WALKER::WalkDocument (const JSON_DOC &document)
 {
-  // todo: add a const overload
   m_stop = false;
   return WalkValue (db_json_doc_to_value (document));
 }
 
 int
-JSON_WALKER::WalkValue (JSON_VALUE &value)
+JSON_WALKER::WalkValue (const JSON_VALUE &value)
 {
   int error_code = NO_ERROR;
 
@@ -3356,7 +3354,7 @@ JSON_WALKER::WalkValue (JSON_VALUE &value)
     }
   else if (value.IsArray ())
     {
-      for (JSON_VALUE *it = value.Begin (); it != value.End (); ++it)
+      for (const JSON_VALUE *it = value.Begin (); it != value.End (); ++it)
 	{
 	  CallOnArrayIterate ();
 	  if (m_stop)

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1223,7 +1223,11 @@ db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<
       // However, it does not work with wildcards.
       for (size_t i = 0; i < json_paths.size (); ++i)
 	{
-	  produced_array[i].push_back (json_paths[i].get (*document));
+	  const JSON_VALUE *found = json_paths[i].get (*document);
+	  if (found != NULL)
+	    {
+	      produced_array[i].push_back (found);
+	    }
 	}
     }
   else

--- a/src/compat/db_json_path.cpp
+++ b/src/compat/db_json_path.cpp
@@ -115,6 +115,26 @@ db_json_path_quote_and_validate_unquoted_object_key (std::string &path, std::siz
   return validation_result;
 }
 
+std::string
+db_string_unquote (const std::string &path)
+{
+  std::string res;
+  assert (path.length () >= 2 && path[0] == '"' && path[path.length () - 1] == '"');
+  for (size_t i = 1; i < path.length () - 1; ++i)
+    {
+      if (path[i] == '\\')
+	{
+	  res += path[i + 1];
+	  ++i;
+	}
+      else
+	{
+	  res += path[i];
+	}
+    }
+  return std::move (res);
+}
+
 /*
  * db_json_path_is_token_valid_unquoted_object_key () - Check if an unquoted object_key is valid
  *
@@ -826,7 +846,7 @@ JSON_PATH::get (const JSON_DOC &jd) const
 	    }
 
 	  assert (tkn.get_object_key ().length () >= 2);
-	  std::string unquoted_key = tkn.get_object_key ().substr (1, tkn.get_object_key ().length () - 2);
+	  std::string unquoted_key = db_string_unquote (tkn.get_object_key ());
 	  JSON_VALUE::ConstMemberIterator m = val->FindMember (unquoted_key.c_str ());
 	  if (m == val->MemberEnd ())
 	    {

--- a/src/compat/db_json_path.cpp
+++ b/src/compat/db_json_path.cpp
@@ -921,6 +921,7 @@ JSON_PATH::extract_from_subtree (const JSON_PATH &path, size_t tkn_array_offset,
 	      return;
 	    }
 	  extract_from_subtree (path, tkn_array_offset + 1, m->value, vals);
+	  return;
 	}
 	case PATH_TOKEN::token_type::object_key_wildcard:
 	  for (JSON_VALUE::ConstMemberIterator m = jv.MemberBegin (); m != jv.MemberEnd (); ++m)

--- a/src/compat/db_json_path.cpp
+++ b/src/compat/db_json_path.cpp
@@ -872,9 +872,10 @@ JSON_PATH::extract_from_subtree (const JSON_PATH &path, size_t tkn_array_offset,
     {
       // No suffix remaining -> collect match
       vals.push_back (&jv);
+      return;
     }
 
-  const PATH_TOKEN &crt_tkn = path.at (tkn_array_offset);
+  const PATH_TOKEN &crt_tkn = path.m_path_tokens[tkn_array_offset];
   if (jv.IsArray ())
     {
       switch (crt_tkn.m_type)
@@ -993,13 +994,6 @@ const PATH_TOKEN *
 JSON_PATH::get_last_token () const
 {
   return get_token_count () > 0 ? &m_path_tokens[get_token_count () - 1] : NULL;
-}
-
-const PATH_TOKEN &
-JSON_PATH::at (size_t idx) const
-{
-  assert (idx < m_path_tokens.size ());
-  return m_path_tokens[idx];
 }
 
 size_t

--- a/src/compat/db_json_path.cpp
+++ b/src/compat/db_json_path.cpp
@@ -870,13 +870,13 @@ static void
 db_json_path_find_at (const JSON_PATH &path, size_t tkn_array_offset, const JSON_VALUE &jv,
 		      std::vector<const JSON_VALUE *> &vals)
 {
-  if (tkn_array_offset == path.m_path_tokens.size ())
+  if (tkn_array_offset == path.get_token_count ())
     {
       // No suffix remaining -> collect match
       vals.push_back (&jv);
     }
 
-  const PATH_TOKEN &crt_tkn = path.m_path_tokens[tkn_array_offset];
+  const PATH_TOKEN &crt_tkn = path.at (tkn_array_offset);
   if (jv.IsArray ())
     {
       switch (crt_tkn.m_type)
@@ -995,6 +995,13 @@ const PATH_TOKEN *
 JSON_PATH::get_last_token () const
 {
   return get_token_count () > 0 ? &m_path_tokens[get_token_count () - 1] : NULL;
+}
+
+const PATH_TOKEN &
+JSON_PATH::at (size_t idx) const
+{
+  assert (idx < m_path_tokens.size ());
+  return m_path_tokens[idx];
 }
 
 size_t

--- a/src/compat/db_json_path.hpp
+++ b/src/compat/db_json_path.hpp
@@ -112,7 +112,8 @@ class JSON_PATH
 				       const JSON_PATH &path, const token_containter_type::const_iterator &it2);
 
     static void extract_from_subtree (const JSON_PATH &path, size_t tkn_array_offset,
-				      const JSON_VALUE &jv, std::unordered_set<const JSON_VALUE *> &vals);
+				      const JSON_VALUE &jv, std::unordered_set<const JSON_VALUE *> &unique_elements,
+				      std::vector<const JSON_VALUE *> &vals);
 
     token_containter_type m_path_tokens;
 };

--- a/src/compat/db_json_path.hpp
+++ b/src/compat/db_json_path.hpp
@@ -84,6 +84,7 @@ class JSON_PATH
 
     const PATH_TOKEN *get_last_token () const;
     size_t get_token_count () const;
+    const PATH_TOKEN &at (size_t idx) const;
     bool is_root_path () const;
     bool is_last_array_index_less_than (size_t size) const;
     bool is_last_token_array_index_zero () const;
@@ -111,9 +112,6 @@ class JSON_PATH
 				       const JSON_PATH &path, const token_containter_type::const_iterator &it2);
 
     token_containter_type m_path_tokens;
-
-    friend void db_json_path_find_at (const JSON_PATH &path, size_t tkn_array_offset, const JSON_VALUE &jd,
-				      std::vector<const JSON_VALUE *> &vals);
 };
 
 void db_json_path_unquote_object_keys (std::string &sql_path);

--- a/src/compat/db_json_path.hpp
+++ b/src/compat/db_json_path.hpp
@@ -30,6 +30,7 @@
 #include "rapidjson/rapidjson.h"
 
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 struct PATH_TOKEN
@@ -110,8 +111,8 @@ class JSON_PATH
     static MATCH_RESULT match_pattern (const JSON_PATH &pattern, const token_containter_type::const_iterator &it1,
 				       const JSON_PATH &path, const token_containter_type::const_iterator &it2);
 
-    static void extract_from_subtree (const JSON_PATH &path, size_t tkn_array_offset, const JSON_VALUE &jv,
-				      std::vector<const JSON_VALUE *> &vals);
+    static void extract_from_subtree (const JSON_PATH &path, size_t tkn_array_offset,
+				      const JSON_VALUE &jv, std::unordered_set<const JSON_VALUE *> &vals);
 
     token_containter_type m_path_tokens;
 };

--- a/src/compat/db_json_path.hpp
+++ b/src/compat/db_json_path.hpp
@@ -111,6 +111,9 @@ class JSON_PATH
     static MATCH_RESULT match_pattern (const JSON_PATH &pattern, const token_containter_type::const_iterator &it1,
 				       const JSON_PATH &path, const token_containter_type::const_iterator &it2);
 
+    static void extract_from_subtree (const JSON_PATH &path, size_t tkn_array_offset, const JSON_VALUE &jv,
+				      std::vector<const JSON_VALUE *> &vals);
+
     token_containter_type m_path_tokens;
 };
 

--- a/src/compat/db_json_path.hpp
+++ b/src/compat/db_json_path.hpp
@@ -76,6 +76,8 @@ class JSON_PATH
 
     JSON_VALUE *get (JSON_DOC &jd) const;
     const JSON_VALUE *get (const JSON_DOC &jd) const;
+    std::vector<const JSON_VALUE *> extract (const JSON_DOC &) const;
+
     void set (JSON_DOC &jd, const JSON_VALUE &jv) const;
     void set (JSON_VALUE &jd, const JSON_VALUE &jv, JSON_PRIVATE_MEMPOOL &allocator) const;
     bool erase (JSON_DOC &jd) const;
@@ -109,6 +111,9 @@ class JSON_PATH
 				       const JSON_PATH &path, const token_containter_type::const_iterator &it2);
 
     token_containter_type m_path_tokens;
+
+    friend void db_json_path_find_at (const JSON_PATH &path, size_t tkn_array_offset, const JSON_VALUE &jd,
+				      std::vector<const JSON_VALUE *> &vals);
 };
 
 void db_json_path_unquote_object_keys (std::string &sql_path);

--- a/src/compat/db_json_path.hpp
+++ b/src/compat/db_json_path.hpp
@@ -84,7 +84,6 @@ class JSON_PATH
 
     const PATH_TOKEN *get_last_token () const;
     size_t get_token_count () const;
-    const PATH_TOKEN &at (size_t idx) const;
     bool is_root_path () const;
     bool is_last_array_index_less_than (size_t size) const;
     bool is_last_token_array_index_zero () const;

--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -400,7 +400,7 @@ namespace cubscan
     }
 
     int
-    scanner::set_next_cursor (const cursor &current_cursor, int next_depth)
+    scanner::set_next_cursor (const cursor &current_cursor, size_t next_depth)
     {
       return init_cursor (*current_cursor.m_process_doc,
 			  current_cursor.m_node->m_nested_nodes[current_cursor.m_child],

--- a/src/query/scan_json_table.hpp
+++ b/src/query/scan_json_table.hpp
@@ -146,7 +146,7 @@ namespace cubscan
 
 	// cursor functions
 	int init_cursor (const JSON_DOC &doc, cubxasl::json_table::node &node, cursor &cursor_out);
-	int set_next_cursor (const cursor &current_cursor, int next_depth);
+	int set_next_cursor (const cursor &current_cursor, size_t next_depth);
 
 	// to start scanning a node, an input document is set
 	int set_input_document (cursor &cursor, const cubxasl::json_table::node &node, const JSON_DOC &document);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22798

Implement & use JSON_PATH::extract instead of more expensive json_walkers.