### PR TITLE
[CBRD-22684] JSON_QUOTE wrong behavior for special character-strings

### DIFF
--- a/src/compat/db_json_path.cpp
+++ b/src/compat/db_json_path.cpp
@@ -1185,7 +1185,7 @@ JSON_PATH::from_json_pointer (const std::string &pointer_path)
 	  // object_key
 	  char *escaped;
 	  size_t escaped_size;
-	  db_string_escape (rapid_token.name, rapid_token.length, &escaped, &escaped_size);
+	  db_string_escape_str (rapid_token.name, rapid_token.length, &escaped, &escaped_size);
 
 	  push_object_key (escaped);
 	  db_private_free (NULL, escaped);

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5313,13 +5313,23 @@ db_evaluate_json_unquote (DB_VALUE * result, DB_VALUE * const *arg, int const nu
       return NO_ERROR;
     }
   char *str = NULL;
+
   JSON_DOC_STORE source_doc;
-  error_code = db_value_to_json_doc (*json, false, source_doc);
+  const char *json_val = db_get_string (json);
+  if (json_val[0] == '"')
+    {
+      error_code = db_value_to_json_doc (*json, false, source_doc);
+    }
+  else
+    {
+      error_code = db_value_to_json_value (*json, source_doc);
+    }
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
       return error_code;
     }
+
   error_code = db_json_unquote (*source_doc.get_immutable (), str);
   if (error_code != NO_ERROR)
     {

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -6287,7 +6287,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
 
       char *escaped;
       size_t escaped_size;
-      error_code = db_string_escape (paths[0].c_str (), paths[0].size (), &escaped, &escaped_size);
+      error_code = db_string_escape_str (paths[0].c_str (), paths[0].size (), &escaped, &escaped_size);
       cubmem::private_unique_ptr<char> escaped_unqique_ptr (escaped, NULL);
       if (error_code)
 	{
@@ -6315,7 +6315,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
 
       char *escaped;
       size_t escaped_size;
-      error_code = db_string_escape (paths[i].c_str (), paths[i].size (), &escaped, &escaped_size);
+      error_code = db_string_escape_str (paths[i].c_str (), paths[i].size (), &escaped, &escaped_size);
       cubmem::private_unique_ptr<char> escaped_unqique_ptr (escaped, NULL);
       if (error_code)
 	{

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5313,23 +5313,13 @@ db_evaluate_json_unquote (DB_VALUE * result, DB_VALUE * const *arg, int const nu
       return NO_ERROR;
     }
   char *str = NULL;
-
   JSON_DOC_STORE source_doc;
-  const char *json_val = db_get_string (json);
-  if (json_val[0] == '"')
-    {
-      error_code = db_value_to_json_doc (*json, false, source_doc);
-    }
-  else
-    {
-      error_code = db_value_to_json_value (*json, source_doc);
-    }
+  error_code = db_value_to_json_doc (*json, false, source_doc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
       return error_code;
     }
-
   error_code = db_json_unquote (*source_doc.get_immutable (), str);
   if (error_code != NO_ERROR)
     {

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -153,6 +153,7 @@ typedef enum
 
 #define GUID_STANDARD_BYTES_LENGTH 16
 
+static char db_string_escape_char (char uc);
 static int qstr_trim (MISC_OPERAND tr_operand, const unsigned char *trim, int trim_length, int trim_size,
 		      const unsigned char *src_ptr, DB_TYPE src_type, int src_length, int src_size,
 		      INTL_CODESET codeset, unsigned char **res, DB_TYPE * res_type, int *res_length, int *res_size);
@@ -1893,6 +1894,26 @@ db_string_substring (const MISC_OPERAND substr_operand, const DB_VALUE * src_str
   return error_status;
 }
 
+static char
+db_string_escape_char (char uc)
+{
+  switch (uc)
+    {
+    case '\b':
+      return 'b';
+    case '\f':
+      return 'f';
+    case '\n':
+      return 'n';
+    case '\r':
+      return 'r';
+    case '\t':
+      return 't';
+    default:
+      return uc;
+    }
+}
+
 int
 db_string_escape (const char *src_str, size_t src_size, char **res_string, size_t * dest_size)
 {
@@ -1924,6 +1945,7 @@ db_string_escape (const char *src_str, size_t src_size, char **res_string, size_
     {
       size_t len = special_idx[i] - src_last_pos;
       memcpy (&result[dest_crt_pos], &src_str[src_last_pos], len);
+      result[dest_crt_pos] = db_string_escape_char (result[dest_crt_pos]);
       dest_crt_pos += len;
       result[dest_crt_pos] = '\\';
       ++dest_crt_pos;
@@ -1931,6 +1953,7 @@ db_string_escape (const char *src_str, size_t src_size, char **res_string, size_
     }
 
   memcpy (&result[dest_crt_pos], &src_str[src_last_pos], src_size - src_last_pos);
+  result[dest_crt_pos] = db_string_escape_char (result[dest_crt_pos]);
   result[*dest_size - 2] = '"';
   result[*dest_size - 1] = '\0';
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -153,7 +153,7 @@ typedef enum
 
 #define GUID_STANDARD_BYTES_LENGTH 16
 
-static char db_string_escape_char (char uc);
+static char db_string_escape_char (char c);
 static int qstr_trim (MISC_OPERAND tr_operand, const unsigned char *trim, int trim_length, int trim_size,
 		      const unsigned char *src_ptr, DB_TYPE src_type, int src_length, int src_size,
 		      INTL_CODESET codeset, unsigned char **res, DB_TYPE * res_type, int *res_length, int *res_size);
@@ -1895,9 +1895,9 @@ db_string_substring (const MISC_OPERAND substr_operand, const DB_VALUE * src_str
 }
 
 static char
-db_string_escape_char (char uc)
+db_string_escape_char (char c)
 {
-  switch (uc)
+  switch (c)
     {
     case '\b':
       return 'b';
@@ -1910,12 +1910,12 @@ db_string_escape_char (char uc)
     case '\t':
       return 't';
     default:
-      return uc;
+      return c;
     }
 }
 
 int
-db_string_escape (const char *src_str, size_t src_size, char **res_string, size_t * dest_size)
+db_string_escape_str (const char *src_str, size_t src_size, char **res_string, size_t * dest_size)
 {
   size_t dest_crt_pos;
   size_t src_last_pos;
@@ -1982,7 +1982,7 @@ db_string_quote (const DB_VALUE * str, DB_VALUE * res)
 
       char *escaped_string = NULL;
       size_t escaped_string_size;
-      int error_code = db_string_escape (src_str, db_get_string_size (str), &escaped_string, &escaped_string_size);
+      int error_code = db_string_escape_str (src_str, db_get_string_size (str), &escaped_string, &escaped_string_size);
       if (error_code)
 	{
 	  return error_code;

--- a/src/query/string_opfunc.h
+++ b/src/query/string_opfunc.h
@@ -201,7 +201,7 @@ extern int db_string_space (DB_VALUE const *count, DB_VALUE * result);
 extern int db_string_insert_substring (DB_VALUE * src_string, const DB_VALUE * position, const DB_VALUE * length,
 				       DB_VALUE * sub_string, DB_VALUE * result);
 extern int db_string_elt (DB_VALUE * result, DB_VALUE * args[], int const num_args);
-extern int db_string_escape (const char *src_str, size_t src_size, char **res_string, size_t * dest_size);
+extern int db_string_escape_str (const char *src_str, size_t src_size, char **res_string, size_t * dest_size);
 
 #if defined (ENABLE_UNUSED_FUNCTION)
 extern int db_string_byte_length (const DB_VALUE * string, DB_VALUE * byte_count);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22684

Do transformation for special characters during escaping (\t -> t). 