### PR TITLE
[CBRD-22865] object_fetch.h

### DIFF
--- a/src/base/tz_compile.c
+++ b/src/base/tz_compile.c
@@ -24,10 +24,12 @@
 #include <stdio.h>
 #include <assert.h>
 
+#include "tz_support.h"
+
+#include "authenticate.h"
 #include "porting.h"
 #include "byte_order.h"
 #include "utility.h"
-#include "tz_support.h"
 #include "db_date.h"
 #include "environment_variable.h"
 #include "chartype.h"

--- a/src/compat/db.h
+++ b/src/compat/db.h
@@ -36,7 +36,6 @@
 #include "object_representation.h"
 #include "object_domain.h"
 #if !defined(SERVER_MODE)
-#include "authenticate.h"
 #include "trigger_manager.h"
 #include "dbi.h"
 #include "parser.h"

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -34,6 +34,7 @@
 #include <assert.h>
 #include <signal.h>
 
+#include "authenticate.h"
 #include "porting.h"
 #include "system_parameter.h"
 #include "storage_common.h"

--- a/src/compat/db_class.c
+++ b/src/compat/db_class.c
@@ -31,6 +31,7 @@
 #include <ctype.h>
 #include <assert.h>
 
+#include "authenticate.h"
 #include "system_parameter.h"
 #include "storage_common.h"
 #include "db.h"

--- a/src/compat/db_old.c
+++ b/src/compat/db_old.c
@@ -31,6 +31,7 @@
 #include <ctype.h>
 #include <assert.h>
 
+#include "authenticate.h"
 #include "system_parameter.h"
 #include "storage_common.h"
 #include "db.h"

--- a/src/compat/db_set.c
+++ b/src/compat/db_set.c
@@ -31,6 +31,9 @@
 #include <ctype.h>
 #include <string.h>
 
+#if !defined (SERVER_MODE)
+#include "authenticate.h"
+#endif // not SERVER_MODE
 #include "db.h"
 #include "dbtype.h"
 #include "error_manager.h"

--- a/src/compat/db_temp.c
+++ b/src/compat/db_temp.c
@@ -31,6 +31,7 @@
 #include <ctype.h>
 #include <assert.h>
 
+#include "authenticate.h"
 #include "system_parameter.h"
 #include "storage_common.h"
 #include "db.h"

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -32,6 +32,7 @@
 #include <time.h>
 #include <assert.h>
 
+#include "authenticate.h"
 #include "db.h"
 #include "dbi.h"
 #include "db_query.h"

--- a/src/compat/db_virt.c
+++ b/src/compat/db_virt.c
@@ -31,6 +31,7 @@
 #include <ctype.h>
 #include <assert.h>
 
+#include "authenticate.h"
 #include "system_parameter.h"
 #include "storage_common.h"
 #include "db.h"

--- a/src/executables/checksumdb.c
+++ b/src/executables/checksumdb.c
@@ -31,6 +31,7 @@
 #include <ctype.h>
 #include <assert.h>
 
+#include "authenticate.h"
 #include "error_code.h"
 #include "system_parameter.h"
 #include "message_catalog.h"

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -45,6 +45,7 @@
 #include <netdb.h>
 #endif /* !WINDOWS */
 
+#include "authenticate.h"
 #include "csql.h"
 #include "system_parameter.h"
 #include "message_catalog.h"

--- a/src/executables/unload_object.c
+++ b/src/executables/unload_object.c
@@ -41,6 +41,7 @@
 #define	SIGALRM	14
 #endif /* WINDOWS */
 
+#include "authenticate.h"
 #include "utility.h"
 #include "load_object.h"
 #include "log_lsa.hpp"

--- a/src/jsp/jsp_cl.c
+++ b/src/jsp/jsp_cl.c
@@ -41,6 +41,7 @@
 #include <windows.h>
 #endif /* not WINDOWS */
 
+#include "authenticate.h"
 #include "error_manager.h"
 #include "memory_alloc.h"
 #include "dbtype.h"

--- a/src/object/authenticate.h
+++ b/src/object/authenticate.h
@@ -32,12 +32,17 @@
 #error Does not belong to server module
 #endif /* defined (SERVER_MODE) */
 
+#ifndef __cplusplus
+#error Requires C++
+#endif // not c++
+
 #include <stdio.h>
 #include <stdlib.h>
 
 #include "error_manager.h"
 #include "class_object.h"
 #include "databases_file.h"
+#include "object_fetch.h"
 
 /*
  * Authorization Class Names
@@ -145,17 +150,6 @@ MOP au_get_dba_user (void);
       (cache) = NULL; \
     } \
   while (0)
-
-typedef enum au_fetchmode
-{
-  AU_FETCH_READ,
-  AU_FETCH_SCAN,		/* scan that does not allow write */
-  AU_FETCH_EXCLUSIVE_SCAN,	/* scan that does allow neither write nor other exclusive scan, i.e, scan for load
-				 * index. */
-  AU_FETCH_WRITE,
-  AU_FETCH_UPDATE
-} AU_FETCHMODE;
-
 
 /*
  * Global Variables

--- a/src/object/object_accessor.h
+++ b/src/object/object_accessor.h
@@ -33,11 +33,12 @@
 #endif /* defined (SERVER_MODE) */
 
 #include <stdarg.h>
+
 #include "area_alloc.h"
-#include "object_representation.h"
 #include "class_object.h"
+#include "object_fetch.h"
+#include "object_representation.h"
 #include "object_template.h"
-#include "authenticate.h"
 #include "work_space.h"
 
 /*

--- a/src/object/object_description.cpp
+++ b/src/object/object_description.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "object_description.hpp"
+
 #include "authenticate.h"
 #include "class_object.h"
 #include "db_value_printer.hpp"

--- a/src/object/object_fetch.h
+++ b/src/object/object_fetch.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+//
+// object_fetch.h - how to fetch objects on client
+//
+
+#ifndef _OBJECT_FETCH_H_
+#define _OBJECT_FETCH_H_
+
+#if defined (SERVER_MODE)
+#error Does not belong to server module
+#endif /* defined (SERVER_MODE) */
+
+typedef enum au_fetchmode
+{
+  AU_FETCH_READ,
+  AU_FETCH_SCAN,		/* scan that does not allow write */
+  AU_FETCH_EXCLUSIVE_SCAN,	/* scan that does allow neither write nor other exclusive scan, i.e, scan for load
+				 * index. */
+  AU_FETCH_WRITE,
+  AU_FETCH_UPDATE
+} AU_FETCHMODE;
+
+#endif // not _OBJECT_FETCH_H_

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -22,6 +22,8 @@
  */
 
 #include "object_printer.hpp"
+
+#include "authenticate.h"
 #include "class_description.hpp"
 #include "class_object.h"
 #include "db_json.hpp"

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -30,6 +30,9 @@
 #include <stdio.h>
 #include <assert.h>
 
+#if !defined (SERVER_MODE)
+#include "authenticate.h"
+#endif // not SERVER_MODE
 #include "db_value_printer.hpp"
 #include "dbtype.h"
 #include "error_manager.h"

--- a/src/object/virtual_object.c
+++ b/src/object/virtual_object.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "authenticate.h"
 #include "virtual_object.h"
 #include "set_object.h"
 #include "object_accessor.h"

--- a/src/parser/compile.c
+++ b/src/parser/compile.c
@@ -27,6 +27,7 @@
 
 #include <assert.h>
 
+#include "authenticate.h"
 #include "dbi.h"
 #include "parser.h"
 #include "semantic_check.h"

--- a/src/parser/method_transform.c
+++ b/src/parser/method_transform.c
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include "authenticate.h"
 #include "porting.h"
 #include "error_manager.h"
 #include "parser.h"

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 #include <unordered_map>
 
+#include "authenticate.h"
 #include "porting.h"
 #include "error_manager.h"
 #include "parser.h"

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -33,7 +33,7 @@
 #include <setjmp.h>
 #include <assert.h>
 
-#include "authenticate.h"
+#include "class_object.h"
 #include "compile_context.h"
 #include "config.h"
 #include "cursor.h"

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -33,6 +33,7 @@
 #include <assert.h>
 #include <math.h>
 
+#include "authenticate.h"
 #include "db_value_printer.hpp"
 #include "porting.h"
 #include "parser.h"

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -36,6 +36,7 @@
 #include <stdarg.h>
 #endif
 
+#include "authenticate.h"
 #include "chartype.h"
 #include "parser.h"
 #include "parser_message.h"

--- a/src/parser/query_result.c
+++ b/src/parser/query_result.c
@@ -26,6 +26,7 @@
 
 #include "config.h"
 
+#include "authenticate.h"
 #include "misc_string.h"
 #include "error_manager.h"
 #include "parser.h"

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -25,8 +25,9 @@
 
 #include "config.h"
 
-
 #include <assert.h>
+
+#include "authenticate.h"
 #include "error_manager.h"
 #include "parser.h"
 #include "parser_message.h"

--- a/src/parser/show_meta.c
+++ b/src/parser/show_meta.c
@@ -33,6 +33,7 @@
 #include <limits.h>
 #include <ctype.h>
 
+#include "authenticate.h"
 #include "show_meta.h"
 #include "error_manager.h"
 #include "parser.h"

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -40,6 +40,7 @@
 #include <sys/time.h>
 #endif /* ! WINDOWS */
 
+#include "authenticate.h"
 #include "error_manager.h"
 #include "parser.h"
 #include "parser_message.h"

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -25,6 +25,7 @@
 
 #include <assert.h>
 
+#include "authenticate.h"
 #include "view_transform.h"
 #include "parser.h"
 #include "parser_message.h"

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -31,6 +31,7 @@
 
 #include "xasl_generation.h"
 
+#include "authenticate.h"
 #include "misc_string.h"
 #include "error_manager.h"
 #include "parser.h"

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -29,6 +29,7 @@
 #include <ctype.h>
 #include <assert.h>
 
+#include "authenticate.h"
 #include "error_manager.h"
 #include "parser.h"
 #include "parser_message.h"

--- a/src/query/query_method.c
+++ b/src/query/query_method.c
@@ -25,6 +25,7 @@
 
 #include "query_method.h"
 
+#include "authenticate.h"
 #include "config.h"
 #include "db.h"
 #include "dbtype.h"

--- a/src/transaction/locator_cl.c
+++ b/src/transaction/locator_cl.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <signal.h>
 
+#include "authenticate.h"
 #include "db.h"
 #include "environment_variable.h"
 #include "porting.h"

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -36,6 +36,7 @@
 
 #include "log_applier.h"
 
+#include "authenticate.h"
 #include "porting.h"
 #include "utility.h"
 #include "environment_variable.h"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22865

Move AU_FETCH_MODE from authenticate.h to object_fetch.h and reduce authenticate.h exposure.

The most important consequence is avoiding authenticate.h include in C-compiled units, allowing future C++ extensions in the header.

This will help Razvan's patch #1522 