### PR TITLE
[CBRD-22869] Implement the --error-file-control argument on the server

### DIFF
--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -267,14 +267,11 @@ namespace cubload
     size_t ignore_errors_size = 0;
 
     deserializator.unpack_bigint (ignore_errors_size);
-    m_ignored_errors.reserve (ignore_errors_size);
+    m_ignored_errors.resize (ignore_errors_size);
     for (size_t i = 0; i < ignore_errors_size; i++)
       {
-	int error;
-	deserializator.unpack_int (error);
-	m_ignored_errors.push_back (error);
+	deserializator.unpack_int (m_ignored_errors[i]);
       }
-
   }
 
   size_t

--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -353,13 +353,6 @@ namespace cubload
     return NO_ERROR;
   }
 
-  int
-  load_args::set_ignored_errors_array (std::vector <int> &ignored_errors)
-  {
-    m_ignored_errors = ignored_errors;
-    return NO_ERROR;
-  }
-
   string_type::string_type ()
     : next (NULL)
     , last (NULL)

--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -187,6 +187,7 @@ namespace cubload
     , table_name ()
     , ignore_class_file ()
     , ignore_classes ()
+    , ignored_errors ()
   {
     //
   }
@@ -220,6 +221,11 @@ namespace cubload
     for (const std::string &ignore_class : ignore_classes)
       {
 	serializator.pack_string (ignore_class);
+      }
+    serializator.pack_bigint (ignored_errors.size ());
+    for (int error :ignored_errors)
+      {
+	serializator.pack_int (error);
       }
   }
 
@@ -258,6 +264,17 @@ namespace cubload
 	deserializator.unpack_string (ignore_class);
 	ignore_classes.push_back (ignore_class);
       }
+    size_t ignore_errors_size = 0;
+
+    deserializator.unpack_bigint (ignore_errors_size);
+    ignored_errors.reserve (ignore_errors_size);
+    for (size_t i = 0; i < ignore_errors_size; i++)
+      {
+	int error;
+	deserializator.unpack_int (error);
+	ignored_errors.push_back (error);
+      }
+
   }
 
   size_t
@@ -291,6 +308,12 @@ namespace cubload
     for (const std::string &ignore_class : ignore_classes)
       {
 	size += serializator.get_packed_string_size (ignore_class, size);
+      }
+
+    size += serializator.get_packed_bigint_size (size);
+    for (const int i : ignored_errors)
+      {
+	size += serializator.get_packed_int_size (size);
       }
 
     return size;
@@ -330,6 +353,13 @@ namespace cubload
       }
 
     file.close ();
+    return NO_ERROR;
+  }
+
+  int
+  load_args::set_ignored_errors_array (std::vector <int> &ignored_errors)
+  {
+    this->ignored_errors = ignored_errors;
     return NO_ERROR;
   }
 

--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -187,7 +187,7 @@ namespace cubload
     , table_name ()
     , ignore_class_file ()
     , ignore_classes ()
-    , ignored_errors ()
+    , m_ignored_errors ()
   {
     //
   }
@@ -222,8 +222,8 @@ namespace cubload
       {
 	serializator.pack_string (ignore_class);
       }
-    serializator.pack_bigint (ignored_errors.size ());
-    for (int error :ignored_errors)
+    serializator.pack_bigint (m_ignored_errors.size ());
+    for (const int error : m_ignored_errors)
       {
 	serializator.pack_int (error);
       }
@@ -267,12 +267,12 @@ namespace cubload
     size_t ignore_errors_size = 0;
 
     deserializator.unpack_bigint (ignore_errors_size);
-    ignored_errors.reserve (ignore_errors_size);
+    m_ignored_errors.reserve (ignore_errors_size);
     for (size_t i = 0; i < ignore_errors_size; i++)
       {
 	int error;
 	deserializator.unpack_int (error);
-	ignored_errors.push_back (error);
+	m_ignored_errors.push_back (error);
       }
 
   }
@@ -311,7 +311,7 @@ namespace cubload
       }
 
     size += serializator.get_packed_bigint_size (size);
-    for (const int i : ignored_errors)
+    for (const int i : m_ignored_errors)
       {
 	size += serializator.get_packed_int_size (size);
       }
@@ -359,7 +359,7 @@ namespace cubload
   int
   load_args::set_ignored_errors_array (std::vector <int> &ignored_errors)
   {
-    this->ignored_errors = ignored_errors;
+    m_ignored_errors = ignored_errors;
     return NO_ERROR;
   }
 

--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -113,7 +113,7 @@ namespace cubload
     std::string table_name;
     std::string ignore_class_file;
     std::vector<std::string> ignore_classes;
-    std::vector<int> ignored_errors;
+    std::vector<int> m_ignored_errors;
   };
 
   /*

--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -89,7 +89,6 @@ namespace cubload
     size_t get_packed_size (cubpacking::packer &serializator) const override;
 
     int parse_ignore_class_file ();
-    int set_ignored_errors_array (std::vector <int> &ignored_errors);
 
     std::string volume;
     std::string input_file;

--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -89,6 +89,7 @@ namespace cubload
     size_t get_packed_size (cubpacking::packer &serializator) const override;
 
     int parse_ignore_class_file ();
+    int set_ignored_errors_array (std::vector <int> &ignored_errors);
 
     std::string volume;
     std::string input_file;
@@ -112,6 +113,7 @@ namespace cubload
     std::string table_name;
     std::string ignore_class_file;
     std::vector<std::string> ignore_classes;
+    std::vector<int> ignored_errors;
   };
 
   /*

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -625,6 +625,7 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
 	}
       er_filter_fileset (error_file);
       fclose (error_file);
+      args.set_ignored_errors_array (get_ignored_errors ());
     }
 
   /* check if no log option can be applied */

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -625,7 +625,7 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
 	}
       er_filter_fileset (error_file);
       fclose (error_file);
-      args.set_ignored_errors_array (get_ignored_errors ());
+      get_ignored_errors (args.m_ignored_errors);
     }
 
   /* check if no log option can be applied */

--- a/src/loaddb/load_error_handler.cpp
+++ b/src/loaddb/load_error_handler.cpp
@@ -126,11 +126,6 @@ namespace cubload
       }
 
     is_filtered = std::find (ignored_errors.begin (), ignored_errors.end (), err_id) != ignored_errors.end ();
-    if (is_filtered)
-      {
-	// Clear the error
-	er_clearid ();
-      }
 
     return is_filtered;
   }
@@ -140,7 +135,22 @@ namespace cubload
   error_handler::is_last_error_filtered ()
   {
 #if defined (SERVER_MODE)
-    return is_error_filtered (er_errid ());
+    int err = er_errid ();
+
+    if (err == NO_ERROR)
+      {
+	return true;
+      }
+
+    bool is_filtered = is_error_filtered (err);
+
+    // Clear the error if it is filtered
+    if (is_filtered)
+      {
+	er_clearid ();
+      }
+
+    return is_filtered;
 #endif
     return false;
   }

--- a/src/loaddb/load_error_handler.cpp
+++ b/src/loaddb/load_error_handler.cpp
@@ -120,11 +120,6 @@ namespace cubload
     std::vector<int> ignored_errors = m_session.get_args ().m_ignored_errors;
     bool is_filtered = false;
 
-    if (err_id == NO_ERROR)
-      {
-	return true;
-      }
-
     is_filtered = std::find (ignored_errors.begin (), ignored_errors.end (), err_id) != ignored_errors.end ();
 
     return is_filtered;
@@ -136,11 +131,6 @@ namespace cubload
   {
 #if defined (SERVER_MODE)
     int err = er_errid ();
-
-    if (err == NO_ERROR)
-      {
-	return true;
-      }
 
     bool is_filtered = is_error_filtered (err);
 

--- a/src/loaddb/load_error_handler.hpp
+++ b/src/loaddb/load_error_handler.hpp
@@ -72,6 +72,7 @@ namespace cubload
       char *get_message_from_catalog (MSGCAT_LOADDB_MSG msg_id);
 
       void log_error_message (std::string &err_msg, bool fail);
+      bool is_last_error_filtered ();
 
       // Format string based on format string passed as input parameter. Check snprintf function for more details
       template<typename... Args>
@@ -80,6 +81,8 @@ namespace cubload
 #if defined (SERVER_MODE)
       session &m_session;
       bool m_syntax_check;
+
+      bool is_error_filtered (int err_id);
 #endif
   };
 }
@@ -95,40 +98,52 @@ namespace cubload
   void
   error_handler::on_error (MSGCAT_LOADDB_MSG msg_id, Args &&... args)
   {
-    std::string err_msg = format (get_message_from_catalog (msg_id), std::forward<Args> (args)...);
-    log_error_message (err_msg, false);
+    if (!is_last_error_filtered ())
+      {
+	std::string err_msg = format (get_message_from_catalog (msg_id), std::forward<Args> (args)...);
+	log_error_message (err_msg, false);
+      }
   }
 
   template<typename... Args>
   void
   error_handler::on_error_with_line (MSGCAT_LOADDB_MSG msg_id, Args &&... args)
   {
-    std::string err_msg;
+    if (!is_last_error_filtered ())
+      {
+	std::string err_msg;
 
-    err_msg.append (format (get_message_from_catalog (LOADDB_MSG_LINE), get_lineno ()));
-    err_msg.append (format (get_message_from_catalog (msg_id), std::forward<Args> (args)...));
+	err_msg.append (format (get_message_from_catalog (LOADDB_MSG_LINE), get_lineno ()));
+	err_msg.append (format (get_message_from_catalog (msg_id), std::forward<Args> (args)...));
 
-    log_error_message (err_msg, false);
+	log_error_message (err_msg, false);
+      }
   }
 
   template<typename... Args>
   void
   error_handler::on_failure (MSGCAT_LOADDB_MSG msg_id, Args &&... args)
   {
-    std::string err_msg = format (get_message_from_catalog (msg_id), std::forward<Args> (args)...);
-    log_error_message (err_msg, true);
+    if (!is_last_error_filtered ())
+      {
+	std::string err_msg = format (get_message_from_catalog (msg_id), std::forward<Args> (args)...);
+	log_error_message (err_msg, true);
+      }
   }
 
   template<typename... Args>
   void
   error_handler::on_failure_with_line (MSGCAT_LOADDB_MSG msg_id, Args &&... args)
   {
-    std::string err_msg;
+    if (!is_last_error_filtered ())
+      {
+	std::string err_msg;
 
-    err_msg.append (format (get_message_from_catalog (LOADDB_MSG_LINE), get_lineno ()));
-    err_msg.append (format (get_message_from_catalog (msg_id), std::forward<Args> (args)...));
+	err_msg.append (format (get_message_from_catalog (LOADDB_MSG_LINE), get_lineno ()));
+	err_msg.append (format (get_message_from_catalog (msg_id), std::forward<Args> (args)...));
 
-    log_error_message (err_msg, true);
+	log_error_message (err_msg, true);
+      }
   }
 
   template<typename... Args>
@@ -148,12 +163,15 @@ namespace cubload
   void
   error_handler::log_date_time_conversion_error (Args &&... args)
   {
-    std::string err_msg;
+    if (!is_last_error_filtered())
+      {
+	std::string err_msg;
 
-    err_msg.append (format (get_message_from_catalog (LOADDB_MSG_LINE), get_lineno ()));
-    err_msg.append (format (get_message_from_catalog (LOADDB_MSG_CONVERSION_ERROR), std::forward<Args> (args)...));
+	err_msg.append (format (get_message_from_catalog (LOADDB_MSG_LINE), get_lineno ()));
+	err_msg.append (format (get_message_from_catalog (LOADDB_MSG_CONVERSION_ERROR), std::forward<Args> (args)...));
 
-    log_error_message (err_msg, false);
+	log_error_message (err_msg, false);
+      }
   }
 
 } // namespace cubload

--- a/src/loaddb/load_error_handler.hpp
+++ b/src/loaddb/load_error_handler.hpp
@@ -98,26 +98,20 @@ namespace cubload
   void
   error_handler::on_error (MSGCAT_LOADDB_MSG msg_id, Args &&... args)
   {
-    if (!is_last_error_filtered ())
-      {
-	std::string err_msg = format (get_message_from_catalog (msg_id), std::forward<Args> (args)...);
-	log_error_message (err_msg, false);
-      }
+    std::string err_msg = format (get_message_from_catalog (msg_id), std::forward<Args> (args)...);
+    log_error_message (err_msg, false);
   }
 
   template<typename... Args>
   void
   error_handler::on_error_with_line (MSGCAT_LOADDB_MSG msg_id, Args &&... args)
   {
-    if (!is_last_error_filtered ())
-      {
-	std::string err_msg;
+    std::string err_msg;
 
-	err_msg.append (format (get_message_from_catalog (LOADDB_MSG_LINE), get_lineno ()));
-	err_msg.append (format (get_message_from_catalog (msg_id), std::forward<Args> (args)...));
+    err_msg.append (format (get_message_from_catalog (LOADDB_MSG_LINE), get_lineno ()));
+    err_msg.append (format (get_message_from_catalog (msg_id), std::forward<Args> (args)...));
 
-	log_error_message (err_msg, false);
-      }
+    log_error_message (err_msg, false);
   }
 
   template<typename... Args>

--- a/src/loaddb/load_error_handler.hpp
+++ b/src/loaddb/load_error_handler.hpp
@@ -157,15 +157,12 @@ namespace cubload
   void
   error_handler::log_date_time_conversion_error (Args &&... args)
   {
-    if (!is_last_error_filtered())
-      {
-	std::string err_msg;
+    std::string err_msg;
 
-	err_msg.append (format (get_message_from_catalog (LOADDB_MSG_LINE), get_lineno ()));
-	err_msg.append (format (get_message_from_catalog (LOADDB_MSG_CONVERSION_ERROR), std::forward<Args> (args)...));
+    err_msg.append (format (get_message_from_catalog (LOADDB_MSG_LINE), get_lineno ()));
+    err_msg.append (format (get_message_from_catalog (LOADDB_MSG_CONVERSION_ERROR), std::forward<Args> (args)...));
 
-	log_error_message (err_msg, false);
-      }
+    log_error_message (err_msg, false);
   }
 
 } // namespace cubload

--- a/src/loaddb/load_object.c
+++ b/src/loaddb/load_object.c
@@ -1805,3 +1805,17 @@ clear_errid:
     }
   goto exit_on_end;
 }
+
+std::vector < int >
+get_ignored_errors ()
+{
+  std::vector < int >vec;
+  for (int i = 0; i < -ER_LAST_ERROR; i++)
+    {
+      if (filter_ignore_errors[i] == true)
+	{
+	  vec.push_back (-i);
+	}
+    }
+  return vec;
+}

--- a/src/loaddb/load_object.c
+++ b/src/loaddb/load_object.c
@@ -1806,10 +1806,11 @@ clear_errid:
   goto exit_on_end;
 }
 
-std::vector < int >
+/* *INDENT-OFF* */
+std::vector<int>
 get_ignored_errors ()
 {
-  std::vector < int >vec;
+  std::vector<int> vec;
   for (int i = 0; i < -ER_LAST_ERROR; i++)
     {
       if (filter_ignore_errors[i] == true)
@@ -1819,3 +1820,4 @@ get_ignored_errors ()
     }
   return vec;
 }
+/* *INDENT-ON* */

--- a/src/loaddb/load_object.c
+++ b/src/loaddb/load_object.c
@@ -1807,17 +1807,15 @@ clear_errid:
 }
 
 /* *INDENT-OFF* */
-std::vector<int>
-get_ignored_errors ()
+void
+get_ignored_errors (std::vector<int> &vec)
 {
-  std::vector<int> vec;
   for (int i = 0; i < -ER_LAST_ERROR; i++)
     {
-      if (filter_ignore_errors[i] == true)
+      if (filter_ignore_errors[i])
 	{
 	  vec.push_back (-i);
 	}
     }
-  return vec;
 }
 /* *INDENT-ON* */

--- a/src/loaddb/load_object.h
+++ b/src/loaddb/load_object.h
@@ -90,7 +90,7 @@ extern int er_filter_fileset (FILE * ef);
 extern int er_filter_errid (bool ignore_warning);
 
 /* *INDENT-OFF* */
-extern std::vector<int> get_ignored_errors ();
+extern void get_ignored_errors (std::vector<int> &vec);
 /* *INDENT-ON* */
 
 #endif /* _LOAD_OBJECT_H_ */

--- a/src/loaddb/load_object.h
+++ b/src/loaddb/load_object.h
@@ -89,8 +89,8 @@ extern void desc_value_print (DB_VALUE * value);
 extern int er_filter_fileset (FILE * ef);
 extern int er_filter_errid (bool ignore_warning);
 
-extern
-std::vector < int >
-get_ignored_errors ();
+/* *INDENT-OFF* */
+extern std::vector<int> get_ignored_errors ();
+/* *INDENT-ON* */
 
 #endif /* _LOAD_OBJECT_H_ */

--- a/src/loaddb/load_object.h
+++ b/src/loaddb/load_object.h
@@ -26,6 +26,7 @@
 
 #include "dbtype_def.h"
 #include "class_object.h"
+#include <vector>
 
 #define CHECK_PRINT_ERROR(print_fnc)            \
   do {                                          \
@@ -87,5 +88,9 @@ extern void desc_value_print (DB_VALUE * value);
 #endif
 extern int er_filter_fileset (FILE * ef);
 extern int er_filter_errid (bool ignore_warning);
+
+extern
+std::vector < int >
+get_ignored_errors ();
 
 #endif /* _LOAD_OBJECT_H_ */

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -464,13 +464,9 @@ namespace cubload
     conv_func &func = get_conv_func (cons->type, attr.get_domain ().type->get_id ());
 
     int error_code = func (token, &attr, &db_val);
-    if (error_code != NO_ERROR)
+    if (error_code == ER_DATE_CONVERSION)
       {
-	if (error_code == ER_DATE_CONVERSION)
-	  {
-	    m_error_handler.log_date_time_conversion_error (token, pr_type_name (attr.get_domain ().type->get_id ()));
-	  }
-	return error_code;
+	m_error_handler.log_date_time_conversion_error (token, pr_type_name (attr.get_domain ().type->get_id ()));
       }
 
     return error_code;

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -694,7 +694,7 @@ namespace cubload
   server_object_loader::er_filter_errid (bool ignore_warning)
   {
     int errcode = er_errid (), erridx;
-    std::vector<int> ignored_errors = m_session.get_args().ignored_errors;
+    std::vector<int> ignored_errors = m_session.get_args().m_ignored_errors;
     bool is_filtered = false;
 
     if (errcode == NO_ERROR)

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -316,8 +316,11 @@ namespace cubload
     if (cons != NULL && attr_size == 0)
       {
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LDR_NO_CLASS_OR_NO_ATTRIBUTE, 0);
-	m_error_handler.on_syntax_failure ();
-	return;
+	if (er_filter_errid (false) != NO_ERROR)
+	  {
+	    m_error_handler.on_syntax_failure ();
+	    return;
+	  }
       }
 
     for (constant_type *c = cons; c != NULL; c = c->next, attr_index++)
@@ -325,16 +328,22 @@ namespace cubload
 	if (attr_index == attr_size)
 	  {
 	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LDR_VALUE_OVERFLOW, 1, attr_index);
-	    m_error_handler.on_syntax_failure ();
-	    return;
+	    if (er_filter_errid (false) != NO_ERROR)
+	      {
+		m_error_handler.on_syntax_failure ();
+		return;
+	      }
 	  }
 
 	const attribute &attr = m_class_entry->get_attribute (attr_index);
 	int error_code = process_constant (c, attr);
 	if (error_code != NO_ERROR)
 	  {
-	    m_error_handler.on_syntax_failure ();
-	    return;
+	    if (er_filter_errid (false) != NO_ERROR)
+	      {
+		m_error_handler.on_syntax_failure ();
+		return;
+	      }
 	  }
 
 	db_value &db_val = get_attribute_db_value (attr_index);
@@ -344,8 +353,11 @@ namespace cubload
     if (attr_index < attr_size)
       {
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LDR_MISSING_ATTRIBUTES, 2, attr_size, attr_index);
-	m_error_handler.on_syntax_failure ();
-	return;
+	if (er_filter_errid (false) != NO_ERROR)
+	  {
+	    m_error_handler.on_syntax_failure ();
+	    return;
+	  }
       }
   }
 
@@ -372,8 +384,11 @@ namespace cubload
 			 UPDATE_INPLACE_NONE, NULL, false);
 	if (error_code != NO_ERROR)
 	  {
-	    m_error_handler.on_failure ();
-	    return;
+	    if (er_filter_errid (true) != NO_ERROR)
+	      {
+		m_error_handler.on_failure ();
+		return;
+	      }
 	  }
       }
 
@@ -673,6 +688,48 @@ namespace cubload
 
     heap_attrinfo_end (m_thread_ref, &m_attrinfo);
     m_attrinfo_started = false;
+  }
+
+  int
+  server_object_loader::er_filter_errid (bool ignore_warning)
+  {
+    int errcode = er_errid (), erridx;
+    std::vector<int> ignored_errors = m_session.get_args().ignored_errors;
+    bool is_filtered = false;
+
+    if (errcode == NO_ERROR)
+      {
+	/* don't have to check */
+	return NO_ERROR;
+      }
+
+    erridx = (errcode < 0) ? -errcode : errcode;
+    is_filtered = std::find (ignored_errors.begin (), ignored_errors.end (), erridx) != ignored_errors.end ();
+    if (is_filtered)
+      {
+	goto clear_errid;
+      }
+
+    /* Check if it's an ignorable warning. */
+    if (std::find (ignored_errors.begin (), ignored_errors.end (), 0) != ignored_errors.end ())
+      {
+	if (ignore_warning && er_get_severity () == ER_WARNING_SEVERITY)
+	  {
+	    goto clear_errid;
+	  }
+      }
+
+exit_on_end:
+    return errcode;
+
+clear_errid:
+    if (errcode != NO_ERROR)
+      {
+	/* clear ignorable errid */
+	er_clearid ();
+	errcode = NO_ERROR;
+      }
+    goto exit_on_end;
   }
 
 } // namespace cubload

--- a/src/loaddb/load_server_loader.hpp
+++ b/src/loaddb/load_server_loader.hpp
@@ -84,6 +84,7 @@ namespace cubload
       int process_generic_constant (constant_type *cons, const attribute &attr);
       int process_monetary_constant (constant_type *cons, const attribute &attr);
       int process_collection_constant (constant_type *cons, const attribute &attr);
+      int er_filter_errid (bool ignore_warnings);
 
       void clear_db_values ();
       db_value &get_attribute_db_value (size_t attr_index);

--- a/src/loaddb/load_server_loader.hpp
+++ b/src/loaddb/load_server_loader.hpp
@@ -84,7 +84,6 @@ namespace cubload
       int process_generic_constant (constant_type *cons, const attribute &attr);
       int process_monetary_constant (constant_type *cons, const attribute &attr);
       int process_collection_constant (constant_type *cons, const attribute &attr);
-      int er_filter_errid (bool ignore_warnings);
 
       void clear_db_values ();
       db_value &get_attribute_db_value (size_t attr_index);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22869

The `--error-file-control` argument was not implemented on the server. When the argument is provided for loading a database we parse the file and collect errors that need to be filtered by the error handler. We create vector with these errors which is sent to the server and the load workers will treat the cases where an error can be ignored by looking up in the filtered errors vector.