### PR TITLE
[CBRD-22596] fix JSON_TABLE scan status

### DIFF
--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -324,7 +324,7 @@ namespace cubscan
 	{
 	  assert (false);
 	  sc = S_END;
-	  return  NO_ERROR;
+	  return ER_FAILED;
 	}
 
       while (true)

--- a/src/query/scan_json_table.hpp
+++ b/src/query/scan_json_table.hpp
@@ -74,6 +74,7 @@
 #define _SCAN_JSON_TABLE_HPP_
 
 #include "query_evaluator.h"
+#include "storage_common.h"
 
 #include <vector>
 
@@ -125,7 +126,7 @@ namespace cubscan
 	// returns error code or NO_ERROR
 	//
 	// sid (in/out) : status and position is updated based on the success of scan
-	int next_scan (cubthread::entry *thread_p, scan_id_struct &sid);
+	int next_scan (cubthread::entry *thread_p, scan_id_struct &sid, SCAN_CODE &sc);
 
 	SCAN_PRED &get_predicate ();
 	void set_value_descriptor (val_descr *vd);

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -6595,21 +6595,17 @@ static SCAN_CODE
 scan_next_json_table_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 {
   int error_code = NO_ERROR;
+  SCAN_CODE sc;
 
   // the status of the scan will be put in scan_id->status
-  error_code = scan_id->s.jtid.next_scan (thread_p, *scan_id);
+  error_code = scan_id->s.jtid.next_scan (thread_p, *scan_id, sc);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
       return S_ERROR;
     }
 
-  if (scan_id->status == S_ENDED)
-    {
-      return S_END;
-    }
-
-  return S_SUCCESS;
+  return sc;
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22596

Avoid changing sid.status from S_STARTED to S_ENDED (it is set for all scans in scan_end_scan).