### PR TITLE
[CBRD-22590] one/all error message is unclear

### DIFF
--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/en_US/cubrid.msg
+++ b/msg/en_US/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/ko_KR.euckr/cubrid.msg
+++ b/msg/ko_KR.euckr/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in a Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/ro_RO.utf8/cubrid.msg
+++ b/msg/ro_RO.utf8/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Calea Json "%1$s" nu adresează un element al unui Json ARRAY.
 1207 Cale de JSON invalida. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1274,7 +1274,7 @@ $ LOADDB
 1205 Invalid type %1$s. Expecting JSON document compatible data type (STRING or JSON).
 1206 Json PATH "%1$s" does not address a cell in an Json ARRAY.
 1207 Invalid JSON path. Index is larger than allowed by system parameter json_max_array_idx.
-1208 Reserved error for JSON.
+1208 Invalid one/all argument. The one/all argument may only take one of these two values: "one", "all".
 1209 Reserved error for JSON.
 1210 Reserved error for JSON.
 1211 Reserved error for JSON.

--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -1551,7 +1551,7 @@
 
 #define ER_JSON_PATH_IS_NOT_ARRAY_CELL              -1206
 #define ER_JSON_ARRAY_INDEX_TOO_LARGE               -1207
-#define ER_JSON_RESERVED_ERROR_3                    -1208
+#define ER_INVALID_ONE_ALL_ARGUMENT                 -1208
 #define ER_JSON_RESERVED_ERROR_4                    -1209
 #define ER_JSON_RESERVED_ERROR_5                    -1210
 #define ER_JSON_RESERVED_ERROR_6                    -1211

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -6059,8 +6059,7 @@ db_evaluate_json_contains_path (DB_VALUE * result, DB_VALUE * const *arg, const 
   error_code = is_str_find_all (arg[1], find_all);
   if (error_code != NO_ERROR)
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INVALID_DATA_TYPE, 0);
-      error_code = ER_QSTR_INVALID_DATA_TYPE;
+      ASSERT_ERROR ();
       return error_code;
     }
 
@@ -6241,8 +6240,8 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
   error_code = is_str_find_all (args[1], find_all);
   if (error_code != NO_ERROR)
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INVALID_DATA_TYPE, 0);
-      return ER_QSTR_INVALID_DATA_TYPE;
+      ASSERT_ERROR ();
+      return error_code;
     }
 
   DB_VALUE *pattern = args[2];
@@ -6428,7 +6427,8 @@ is_str_find_all (DB_VALUE * val, bool & find_all)
 {
   if (DB_IS_NULL (val))
     {
-      return ER_QSTR_INVALID_DATA_TYPE;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INVALID_ONE_ALL_ARGUMENT, 0);
+      return ER_INVALID_ONE_ALL_ARGUMENT;
     }
 
   // *INDENT-OFF*
@@ -6443,7 +6443,8 @@ is_str_find_all (DB_VALUE * val, bool & find_all)
     }
   if (!find_all && find_all_str != "one")
     {
-      return ER_QSTR_INVALID_DATA_TYPE;	// todo - set a proper error
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INVALID_ONE_ALL_ARGUMENT, 0);
+      return ER_INVALID_ONE_ALL_ARGUMENT;
     }
   return NO_ERROR;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22490

Add message for invalid one/all args.