### PR TITLE
[CBRD-22867] Fix the periodic-commit argument

### DIFF
--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -112,7 +112,7 @@ namespace cubload
     std::string table_name;
     std::string ignore_class_file;
     std::vector<std::string> ignore_classes;
-    static const int periodic_commit_default_value = 10240;
+    static const int PERIODIC_COMMIT_DEFAULT_VALUE = 10240;
   };
 
   /*

--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -112,6 +112,7 @@ namespace cubload
     std::string table_name;
     std::string ignore_class_file;
     std::vector<std::string> ignore_classes;
+    static const int periodic_commit_default_value = 10240;
   };
 
   /*

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -997,11 +997,13 @@ get_loaddb_args (UTIL_ARG_MAP * arg_map, load_args * args)
   args->periodic_commit = utility_get_option_int_value (arg_map, LOAD_PERIODIC_COMMIT_S);
   args->verbose_commit = args->periodic_commit > 0;
 
+  /* *INDENT-OFF* */
   if (args->periodic_commit == 0)
     {
       // We set the periodic commit to a default value.
-      args->periodic_commit = load_args::periodic_commit_default_value;
+      args->periodic_commit = load_args::PERIODIC_COMMIT_DEFAULT_VALUE;
     }
+  /* *INDENT-ON* */
   args->no_oid_hint = utility_get_option_bool_value (arg_map, LOAD_NO_OID_S);
   args->schema_file = schema_file ? schema_file : empty;
   args->index_file = index_file ? index_file : empty;

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -41,7 +41,6 @@
 #define LOAD_INDEX_MIN_SORT_BUFFER_PAGES 8192
 #define LOAD_INDEX_MIN_SORT_BUFFER_PAGES_STRING "8192"
 #define LOADDB_LOG_FILENAME_SUFFIX "loaddb.log"
-#define LOADDB_PERIODIC_COMMIT_DEFAULT 10240
 
 using namespace cubload;
 
@@ -1001,7 +1000,7 @@ get_loaddb_args (UTIL_ARG_MAP * arg_map, load_args * args)
   if (args->periodic_commit == 0)
     {
       // We set the periodic commit to a default value.
-      args->periodic_commit = LOADDB_PERIODIC_COMMIT_DEFAULT;
+      args->periodic_commit = load_args::periodic_commit_default_value;
     }
   args->no_oid_hint = utility_get_option_bool_value (arg_map, LOAD_NO_OID_S);
   args->schema_file = schema_file ? schema_file : empty;

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -41,6 +41,7 @@
 #define LOAD_INDEX_MIN_SORT_BUFFER_PAGES 8192
 #define LOAD_INDEX_MIN_SORT_BUFFER_PAGES_STRING "8192"
 #define LOADDB_LOG_FILENAME_SUFFIX "loaddb.log"
+#define LOADDB_PERIODIC_COMMIT_DEFAULT 10240
 
 using namespace cubload;
 
@@ -996,6 +997,12 @@ get_loaddb_args (UTIL_ARG_MAP * arg_map, load_args * args)
   args->disable_statistics = utility_get_option_bool_value (arg_map, LOAD_NO_STATISTICS_S);
   args->periodic_commit = utility_get_option_int_value (arg_map, LOAD_PERIODIC_COMMIT_S);
   args->verbose_commit = args->periodic_commit > 0;
+
+  if (args->periodic_commit == 0)
+    {
+      // We set the periodic commit to a default value.
+      args->periodic_commit = LOADDB_PERIODIC_COMMIT_DEFAULT;
+    }
   args->no_oid_hint = utility_get_option_bool_value (arg_map, LOAD_NO_OID_S);
   args->schema_file = schema_file ? schema_file : empty;
   args->index_file = index_file ? index_file : empty;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22867

In case the periodic commit argument is set to 0, the loading will fail and will crash the server. Since we set the batch size to be equal to the periodic commit, batches will have a size of 0 when the periodic commit is not provided. Therefore, we add a default value to the periodic commit argument in case it is not provided during the loading.