### PR TITLE
[CBRD-22878] record_descriptor extends packable_object

### DIFF
--- a/src/base/packer.cpp
+++ b/src/base/packer.cpp
@@ -30,10 +30,10 @@
 #include "object_representation.h"
 #include "packable_object.hpp"
 
+#include <algorithm>
+#include <cstring>
 #include <vector>
 #include <string>
-
-#include <cstring>
 
 namespace cubpacking
 {
@@ -783,6 +783,77 @@ namespace cubpacking
   {
     return get_curr_ptr () == get_buffer_end ();
   }
+
+  size_t
+  packer::get_packed_buffer_size (const char *stream, const size_t length, const size_t curr_offset) const
+  {
+    size_t actual_length = 0;
+
+    if (stream != NULL)
+      {
+	actual_length = length;
+      }
+
+    size_t entry_size = OR_INT_SIZE + actual_length;
+
+    return DB_ALIGN (curr_offset, INT_ALIGNMENT) + entry_size - curr_offset;
+  }
+
+  void
+  packer::pack_buffer_with_length (const char *stream, const size_t length)
+  {
+    align (INT_ALIGNMENT);
+
+    check_range (m_ptr, m_end_ptr, length + OR_INT_SIZE);
+
+    OR_PUT_INT (m_ptr, length);
+    m_ptr += OR_INT_SIZE;
+
+    if (length > 0)
+      {
+	std::memcpy (m_ptr, stream, length);
+	m_ptr += length;
+
+	align (INT_ALIGNMENT);
+      }
+  }
+
+  void unpacker::peek_unpack_buffer_length (int &value)
+  {
+    return peek_unpack_int (value);
+  }
+
+  /*
+   * unpack_buffer_with_length : unpacks a stream into a preallocated buffer
+   * stream (in/out) : output stream
+   * max_length (in) : maximum length to unpack
+   *
+   * Note : the unpacker pointer is incremented with the actual length of buffer (found in unpacker)
+   */
+  void
+  unpacker::unpack_buffer_with_length (char *stream, const size_t max_length)
+  {
+    size_t actual_len, copy_length;
+
+    align (INT_ALIGNMENT);
+
+    actual_len = OR_GET_INT (m_ptr);
+    m_ptr += OR_INT_SIZE;
+
+    assert (actual_len <= max_length);
+    copy_length = std::min (actual_len, max_length);
+
+    check_range (m_ptr, m_end_ptr, actual_len);
+
+    if (copy_length > 0)
+      {
+	memcpy (stream, m_ptr, copy_length);
+      }
+
+    m_ptr += actual_len;
+    align (INT_ALIGNMENT);
+  }
+
 
   void
   packer::delegate_to_or_buf (const size_t size, or_buf &buf)

--- a/src/base/packer.hpp
+++ b/src/base/packer.hpp
@@ -116,6 +116,9 @@ namespace cubpacking
       const char *get_buffer_end (void);
       bool is_ended (void);
 
+      size_t get_packed_buffer_size (const char *stream, const size_t length, const size_t curr_offset) const;
+      void pack_buffer_with_length (const char *stream, const size_t length);
+
       // template functions to pack objects in bulk
       // note - it requires versions of get_packed_size_overloaded and pack_overloaded
 
@@ -193,6 +196,9 @@ namespace cubpacking
       void unpack_overloaded (db_value &value);
 
       void unpack_overloaded (packable_object &po);
+
+      void peek_unpack_buffer_length (int &value);
+      void unpack_buffer_with_length (char *stream, const size_t max_length);
 
       const char *get_curr_ptr (void);
       void align (const size_t req_alignment);

--- a/src/storage/record_descriptor.hpp
+++ b/src/storage/record_descriptor.hpp
@@ -21,8 +21,12 @@
 // record_descriptor - RECDES extended functionality
 //
 
+#ifndef _RECORD_DESCRIPTOR_HPP_
+#define _RECORD_DESCRIPTOR_HPP_
+
 #include "mem_block.hpp"
 #include "memory_alloc.h"
+#include "packable_object.hpp"
 #include "storage_common.h"
 
 // forward definitions
@@ -51,7 +55,7 @@ enum class record_get_mode
   COPY_RECORD = COPY
 };
 
-class record_descriptor
+class record_descriptor : public cubpacking::packable_object
 {
   public:
 
@@ -106,6 +110,10 @@ class record_descriptor
     // move record data starting from source_offset to dest_offset
     void move_data (std::size_t dest_offset, std::size_t source_offset);
 
+    void pack (cubpacking::packer &packer) const override;
+    void unpack (cubpacking::unpacker &unpacker) override;
+    std::size_t get_packed_size (cubpacking::packer &packer) const override;
+
   private:
 
     // resize record buffer; copy_data is true if existing data must be preserved
@@ -153,3 +161,5 @@ record_descriptor::set_data_to_object (const T &t)
 {
   set_data (reinterpret_cast<const char *> (&t), sizeof (t));
 }
+
+#endif // !_RECORD_DESCRIPTOR_HPP_


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22878

- record_descriptor extends packable_object.
- add pack_buffer_with_length/unpack_buffer_with_length to packer.
- add header guard to record_descriptor.hpp