### PR TITLE
[CBRD-22881] initialize offset in log_lsa::set_null

### DIFF
--- a/src/transaction/log_lsa.hpp
+++ b/src/transaction/log_lsa.hpp
@@ -98,6 +98,8 @@ void
 log_lsa::set_null ()
 {
   pageid = NULL_LOG_PAGEID;
+  offset = NULL_LOG_OFFSET;   // this is how LOG_LSA is initialized many times; we need to initialize both fields or
+  // we'll have "conditional jump or move on uninitialized value"
 }
 
 bool


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22881

We often use C-style allocation of structures that have log_lsa in their composition; the value is then initialized using LSA_SET_NULL. Initialize both pageid and offset to make sure the value is fully initialized.

This fixes UMR in issue. It is kind of strange that we end up having this issue in pgbuf_flush_page_and_neighbors_fb, but I did not investigate further.