### PR TITLE
[CBRD-22882] mvcc_active_tran::copy_to thread safety

### DIFF
--- a/src/transaction/mvcc.c
+++ b/src/transaction/mvcc.c
@@ -666,7 +666,7 @@ void
 mvcc_snapshot::copy_to (mvcc_snapshot & dest) const
 {
   dest.m_active_mvccs.initialize ();
-  m_active_mvccs.copy_to (dest.m_active_mvccs);
+  m_active_mvccs.copy_to (dest.m_active_mvccs, mvcc_active_tran::copy_safety::THREAD_SAFE);
 
   dest.lowest_active_mvccid = lowest_active_mvccid;
   dest.highest_completed_mvccid = highest_completed_mvccid;

--- a/src/transaction/mvcc_active_tran.cpp
+++ b/src/transaction/mvcc_active_tran.cpp
@@ -276,11 +276,15 @@ mvcc_active_tran::compute_lowest_active_mvccid () const
 }
 
 void
-mvcc_active_tran::copy_to (mvcc_active_tran &dest) const
+mvcc_active_tran::copy_to (mvcc_active_tran &dest, copy_safety safety) const
 {
   assert (m_initialized && dest.m_initialized);
-  check_valid ();
-  dest.check_valid ();
+
+  if (safety == copy_safety::THREAD_SAFE)
+    {
+      check_valid ();
+      dest.check_valid ();
+    }
 
   size_t new_bit_area_memsize = get_bit_area_memsize ();
   size_t old_bit_area_memsize = dest.get_bit_area_memsize ();
@@ -304,7 +308,10 @@ mvcc_active_tran::copy_to (mvcc_active_tran &dest) const
   dest.m_bit_area_length = m_bit_area_length;
   dest.m_long_tran_mvccids_length = m_long_tran_mvccids_length;
 
-  dest.check_valid ();
+  if (safety == copy_safety::THREAD_SAFE)
+    {
+      dest.check_valid ();
+    }
 }
 
 bool

--- a/src/transaction/mvcc_active_tran.hpp
+++ b/src/transaction/mvcc_active_tran.hpp
@@ -35,6 +35,12 @@ struct mvcc_active_tran
     mvcc_active_tran ();
     ~mvcc_active_tran ();
 
+    enum class copy_safety
+    {
+      THREAD_SAFE,
+      THREAD_UNSAFE
+    };
+
     void initialize ();
     void finalize ();
     void reset ();
@@ -42,7 +48,7 @@ struct mvcc_active_tran
     MVCCID get_bit_area_start_mvccid ();
 
     bool is_active (MVCCID mvccid) const;
-    void copy_to (mvcc_active_tran &dest) const;
+    void copy_to (mvcc_active_tran &dest, copy_safety safety) const;
     mvcc_active_tran &operator= (const mvcc_active_tran &other) = delete;
 
     MVCCID compute_highest_completed_mvccid () const;
@@ -50,6 +56,8 @@ struct mvcc_active_tran
 
     void set_inactive_mvccid (MVCCID mvccid);
     void reset_start_mvccid (MVCCID mvccid);
+
+    void check_valid () const;
 
   private:
     using unit_type = std::uint64_t;
@@ -96,8 +104,6 @@ struct mvcc_active_tran
     size_t get_area_size () const;
     size_t get_bit_area_memsize () const;
     size_t get_long_tran_memsize () const;
-
-    void check_valid () const;
 
     void remove_long_transaction (MVCCID mvccid);
     void add_long_transaction (MVCCID mvccid);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22882

- add `copy_safety::THREAD_SAFE/THREAD_UNSAFE` argument to `mvcc_active_tran::copy_to`.
- deactivate `mvcc_active_tran` validity check during `build_mvcc_info`; data is not protected and concurrent access may invalidate it
- postpone data validity check when it is safe