### PR TITLE
[CBRD-22896] SA_MODE: don't do checkpoint during sysop

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3707,7 +3707,15 @@ log_sysop_end_final (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 #if defined(SERVER_MODE)
       log_wakeup_checkpoint_daemon ();
 #else /* SERVER_MODE */
-      (void) logpb_checkpoint (thread_p);
+      if (!tdes->is_under_sysop ())
+	{
+	  (void) logpb_checkpoint (thread_p);
+	}
+      else
+	{
+	  // not safe to do a checkpoint in the middle of a system operations; for instance, tdes is cleared after
+	  // checkpoint
+	}
 #endif /* SERVER_MODE */
     }
 }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6839,6 +6839,7 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
   log_Gl.run_nxchkpt_atpageid = (log_Gl.hdr.append_lsa.pageid + log_Gl.chkpt_every_npages);
   /*
    * Clear all tail and heads information of current system transaction
+   * todo - is it safe to clear though?
    */
   logtb_clear_tdes (thread_p, tdes);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22896

checkpoint clears transaction descriptor which invalidates system operation. don't call checkpoint under system operation.