### PR TITLE
[CBRD-22897] fix mvcc_active_tran::reset_active_transactions

### DIFF
--- a/src/transaction/mvcc_active_tran.cpp
+++ b/src/transaction/mvcc_active_tran.cpp
@@ -518,7 +518,7 @@ mvcc_active_tran::reset_start_mvccid (MVCCID mvccid)
 void
 mvcc_active_tran::reset_active_transactions ()
 {
-  std::memset (m_bit_area, 0, get_bit_area_memsize ());
+  std::memset (m_bit_area, 0, BITAREA_MAX_MEMSIZE);
   m_bit_area_length = 0;
   m_long_tran_mvccids_length = 0;
 }

--- a/src/transaction/mvcc_active_tran.hpp
+++ b/src/transaction/mvcc_active_tran.hpp
@@ -69,6 +69,7 @@ struct mvcc_active_tran
     static const size_t UNIT_BYTE_COUNT = sizeof (unit_type);
     static const size_t UNIT_BIT_COUNT = UNIT_BYTE_COUNT * BYTE_BIT_COUNT;
 
+    static const size_t BITAREA_MAX_MEMSIZE = BITAREA_MAX_SIZE * UNIT_BYTE_COUNT;
     static const size_t BITAREA_MAX_BITS = BITAREA_MAX_SIZE * UNIT_BIT_COUNT;
 
     static const unit_type ALL_ACTIVE = 0;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22897

Clear all BITAREA_MAX_MEMSIZE, not current bit area memory size.