### PR TITLE
[CBRD-22877] avoid checking type if db_val is null

### DIFF
--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -298,7 +298,8 @@ extern "C"
 	// do nothing
 	return;
       }
-     *dst = *src;
+
+    *dst = *src;
     dst->need_clear = false;
 
     if (DB_IS_NULL (src))

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -301,6 +301,12 @@ extern "C"
      *dst = *src;
     dst->need_clear = false;
 
+    if (DB_IS_NULL (src))
+      {
+	// avoid checking type if db_val is null
+	return;
+      }
+
     DB_TYPE type = db_value_domain_type (src);
     if (type == DB_TYPE_STRING || type == DB_TYPE_VARNCHAR)
       {

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -299,7 +299,7 @@ extern "C"
 	return;
       }
 
-    *dst = *src;
+    memcpy (dst, src, sizeof (DB_VALUE));
     dst->need_clear = false;
 
     if (DB_IS_NULL (src))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22877

Avoid checking uninitialized type before checking for is_null flag.