### PR TITLE
[CBRD-22872] extend packer/unpacker to automatically convert to/from int

### DIFF
--- a/src/base/packer.hpp
+++ b/src/base/packer.hpp
@@ -119,6 +119,10 @@ namespace cubpacking
       size_t get_packed_buffer_size (const char *stream, const size_t length, const size_t curr_offset) const;
       void pack_buffer_with_length (const char *stream, const size_t length);
 
+      // template function to pack object as int type
+      template <typename T>
+      void pack_to_int (const T &t);
+
       // template functions to pack objects in bulk
       // note - it requires versions of get_packed_size_overloaded and pack_overloaded
 
@@ -212,6 +216,10 @@ namespace cubpacking
       //
       void delegate_to_or_buf (const size_t size, or_buf &buf);
 
+      // template function to unpack object from int type to T type
+      template <typename T>
+      void unpack_from_int (T &t);
+
       // template functions to unpack object in bulk
       // note - it requires implementations of unpack_overloaded for all types
 
@@ -252,6 +260,13 @@ namespace cubpacking
   //
   // packer
   //
+
+  template <typename T>
+  void
+  packer::pack_to_int (const T &t)
+  {
+    pack_int ((int) t);
+  }
 
   template <typename ... Args>
   size_t
@@ -311,6 +326,15 @@ namespace cubpacking
   //
   // unpacker
   //
+
+  template <typename T>
+  void
+  unpacker::unpack_from_int (T &t)
+  {
+    int int_val;
+    unpack_int (int_val);
+    t = (T) int_val;
+  }
 
   template <typename ... Args>
   void

--- a/unit_tests/packing/test_packing.cpp
+++ b/unit_tests/packing/test_packing.cpp
@@ -58,6 +58,7 @@ namespace test_packing
     serializator.pack_string (str1);
 
     serializator.pack_c_string (str2, sizeof (str2) - 1);
+    serializator.pack_to_int (color);
   }
 
   void po1::unpack (cubpacking::unpacker &deserializator)
@@ -81,6 +82,7 @@ namespace test_packing
 
     deserializator.unpack_string (str1);
     deserializator.unpack_c_string (str2, sizeof (str2));
+    deserializator.unpack_from_int (color);
   }
 
   bool po1::is_equal (const cubpacking::packable_object *other)
@@ -134,6 +136,11 @@ namespace test_packing
 	return false;
       }
 
+    if (color != other_po1->color)
+      {
+	return false;
+      }
+
     return true;
   }
 
@@ -155,6 +162,7 @@ namespace test_packing
 
     entry_size += serializator.get_packed_string_size (str1, entry_size);
     entry_size += serializator.get_packed_c_string_size (str2, sizeof (str2), entry_size);
+    entry_size += serializator.get_packed_int_size (entry_size);
     return entry_size;
   }
 
@@ -208,6 +216,8 @@ namespace test_packing
     str1 = tmp_str;
 
     generate_str (str2, sizeof (str2) - 1);
+
+    color = static_cast<rgb> (std::rand () % rgb::MAX);
   }
 
 /////////////////////////////

--- a/unit_tests/packing/test_packing.hpp
+++ b/unit_tests/packing/test_packing.hpp
@@ -47,6 +47,12 @@ namespace test_packing
   class po1 : public cubpacking::packable_object
   {
     public:
+      enum rgb
+      {
+	RED, GREEN, BLUE,
+	MAX
+      };
+
       int i1;
       short sh1;
       std::int64_t b1;
@@ -57,6 +63,7 @@ namespace test_packing
       std::string large_str;
       std::string str1;
       char str2[300];
+      rgb color;
 
     public:
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22872

Extend packer/unpacker with following functionality:
* `cubpacking::packer` with `template <typename T> void pack_to_int (const T &t);` function to pack object as `int` type
* `cubpacking::unpacker` with `template <typename T> void unpack_from_int (T &t);` function to unpack object from `int` type to `T` type