### PR TITLE
[CBRD-22910] heap_attrinfo_transform_to_disk resize record

### DIFF
--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -136,6 +136,7 @@ namespace cubmem
 
       inline void extend_by (size_t additional_bytes);
       inline void extend_to (size_t total_bytes);
+      inline void freemem ();
 
       inline char *get_ptr ();
       inline const char *get_read_ptr () const;
@@ -317,6 +318,12 @@ namespace cubmem
 	return;
       }
     extend_by (total_bytes - m_block.dim);
+  }
+
+  void
+  extensible_block::freemem ()
+  {
+    m_allocator->m_dealloc_f (m_block);
   }
 
   char *

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -12197,7 +12197,6 @@ qexec_execute_increment (THREAD_ENTRY * thread_p, OID * oid, OID * class_oid, HF
 	  error = NO_ERROR;
 	}
       else if (error != NO_ERROR)
-
 	{
 	  error = ER_FAILED;
 	  goto wrapup;

--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -35,6 +35,7 @@
 #include "log_append.hpp"
 #include "numeric_opfunc.h"
 #include "object_primitive.h"
+#include "record_descriptor.hpp"
 #include "server_interface.h"
 #include "xserver_interface.h"
 #include "slotted_page.h"
@@ -832,9 +833,8 @@ static int
 serial_update_serial_object (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, RECDES * recdesc, HEAP_CACHE_ATTRINFO * attr_info,
 			     const OID * serial_class_oidp, const OID * serial_oidp, DB_VALUE * key_val)
 {
-  RECDES new_recdesc;
-  char copyarea_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
-  int new_copyarea_length;
+  cubmem::stack_block < IO_MAX_PAGE_SIZE + MAX_ALIGNMENT > copyarea;
+  record_descriptor new_recdesc;
   SCAN_CODE scan;
   LOG_DATA_ADDR addr;
   int ret;
@@ -861,9 +861,7 @@ serial_update_serial_object (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, RECDES * r
       repl_start_flush_mark (thread_p);
     }
 
-  new_copyarea_length = DB_PAGESIZE;
-  new_recdesc.data = PTR_ALIGN (copyarea_buf, MAX_ALIGNMENT);
-  new_recdesc.area_size = DB_PAGESIZE;
+  new_recdesc.set_external_buffer (copyarea);
 
   scan = heap_attrinfo_transform_to_disk (thread_p, attr_info, recdesc, &new_recdesc);
   if (scan != S_SUCCESS)
@@ -873,22 +871,16 @@ serial_update_serial_object (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, RECDES * r
     }
 
   /* Log the changes */
-  new_recdesc.type = recdesc->type;
+  new_recdesc.set_type (recdesc->type);
   addr.offset = serial_oidp->slotid;
   addr.pgptr = pgptr;
 
-#if defined (DEBUG)
-  if (spage_is_updatable (thread_p, addr.pgptr, serial_oidp->slotid, new_recdesc.length) == false)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_CANNOT_UPDATE_SERIAL, 0);
-      goto exit_on_error;
-    }
-#endif
+  assert (spage_is_updatable (thread_p, addr.pgptr, serial_oidp->slotid, (int) new_recdesc.get_size ()));
 
-  log_append_redo_recdes (thread_p, RVHF_UPDATE, &addr, &new_recdesc);
+  log_append_redo_recdes (thread_p, RVHF_UPDATE, &addr, &new_recdesc.get_recdes ());
 
   /* Now really update */
-  sp_success = spage_update (thread_p, addr.pgptr, serial_oidp->slotid, &new_recdesc);
+  sp_success = spage_update (thread_p, addr.pgptr, serial_oidp->slotid, &new_recdesc.get_recdes ());
   if (sp_success != SP_SUCCESS)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_CANNOT_UPDATE_SERIAL, 0);

--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -833,7 +833,9 @@ static int
 serial_update_serial_object (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, RECDES * recdesc, HEAP_CACHE_ATTRINFO * attr_info,
 			     const OID * serial_class_oidp, const OID * serial_oidp, DB_VALUE * key_val)
 {
-  cubmem::stack_block < IO_MAX_PAGE_SIZE + MAX_ALIGNMENT > copyarea;
+  // *INDENT-OFF*
+  cubmem::stack_block<IO_MAX_PAGE_SIZE> copyarea;
+  // *INDENT-ON*
   record_descriptor new_recdesc;
   SCAN_CODE scan;
   LOG_DATA_ADDR addr;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -38,6 +38,7 @@
 
 #include "porting.h"
 #include "porting_inline.hpp"
+#include "record_descriptor.hpp"
 #include "slotted_page.h"
 #include "overflow_file.h"
 #include "boot_sr.h"
@@ -722,7 +723,7 @@ static int heap_get_spage_type (void);
 static bool heap_is_reusable_oid (const FILE_TYPE file_type);
 
 static SCAN_CODE heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info,
-							   RECDES * old_recdes, RECDES * new_recdes,
+							   RECDES * old_recdes, record_descriptor * new_recdes,
 							   int lob_create_flag);
 static int heap_stats_del_bestspace_by_vpid (THREAD_ENTRY * thread_p, VPID * vpid);
 static int heap_stats_del_bestspace_by_hfid (THREAD_ENTRY * thread_p, const HFID * hfid);
@@ -11434,7 +11435,7 @@ re_check:
  */
 SCAN_CODE
 heap_attrinfo_transform_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, RECDES * old_recdes,
-				 RECDES * new_recdes)
+				 record_descriptor * new_recdes)
 {
   return heap_attrinfo_transform_to_disk_internal (thread_p, attr_info, old_recdes, new_recdes, LOB_FLAG_INCLUDE_LOB);
 }
@@ -11454,7 +11455,7 @@ heap_attrinfo_transform_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * 
  */
 SCAN_CODE
 heap_attrinfo_transform_to_disk_except_lob (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info,
-					    RECDES * old_recdes, RECDES * new_recdes)
+					    RECDES * old_recdes, record_descriptor * new_recdes)
 {
   return heap_attrinfo_transform_to_disk_internal (thread_p, attr_info, old_recdes, new_recdes, LOB_FLAG_EXCLUDE_LOB);
 }
@@ -11475,7 +11476,7 @@ heap_attrinfo_transform_to_disk_except_lob (THREAD_ENTRY * thread_p, HEAP_CACHE_
  */
 static SCAN_CODE
 heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, RECDES * old_recdes,
-					  RECDES * new_recdes, int lob_create_flag)
+					  record_descriptor * new_recdes, int lob_create_flag)
 {
   OR_BUF orep, *buf;
   char *ptr_bound, *ptr_varvals;
@@ -11486,10 +11487,13 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
   SCAN_CODE status;
   int i;
   DB_VALUE *dbvalue = NULL;
-  int expected_size, tmp;
+  size_t expected_size;
+  int tmp;
   volatile int offset_size;
   int mvcc_wasted_space = 0, header_size;
   bool is_mvcc_class;
+
+  assert (new_recdes != NULL);
 
   /* check to make sure the attr_info has been used, it should not be empty. */
   if (attr_info->num_values == -1)
@@ -11506,10 +11510,8 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
     }
 
   /* Start transforming the dbvalues into disk values for the object */
-  OR_BUF_INIT2 (orep, new_recdes->data, new_recdes->area_size);
-  buf = &orep;
-
   is_mvcc_class = !mvcc_is_mvcc_disabled_class (&(attr_info->class_oid));
+
   expected_size = heap_attrinfo_get_disksize (attr_info, is_mvcc_class, &tmp);
   offset_size = tmp;
 
@@ -11526,6 +11528,12 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 
   /* reserve enough space if need to add additional MVCC header info */
   expected_size += mvcc_wasted_space;
+
+resize_and_start:
+
+  new_recdes->resize_buffer (expected_size);
+  OR_BUF_INIT2 (orep, new_recdes->get_data_for_modify (), (int) expected_size);
+  buf = &orep;
 
   switch (_setjmp (buf->env))
     {
@@ -11606,8 +11614,9 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 
       if (ptr_varvals + mvcc_wasted_space >= buf->endptr)
 	{
-	  new_recdes->length = -expected_size;	/* set to negative */
-	  return S_DOESNT_FIT;
+	  // is it possible?
+	  expected_size += DB_PAGESIZE;
+	  goto resize_and_start;
 	}
 
       for (i = 0; i < attr_info->num_values; i++)
@@ -11774,7 +11783,7 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 	}
 
       /* Record the length of the object */
-      new_recdes->length = CAST_BUFLEN (ptr_varvals - buf->buffer);
+      new_recdes->set_record_length (ptr_varvals - buf->buffer);
 
       /* if not enough MVCC wasted space need to reallocate */
       if (ptr_varvals + mvcc_wasted_space < buf->endptr)
@@ -11788,29 +11797,8 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
        */
       /* FALLTHRU */
     case ER_TF_BUFFER_OVERFLOW:
-
-      status = S_DOESNT_FIT;
-
-      /*
-       * Give a hint of the needed space. The hint is given as a negative
-       * value in the record descriptor length. Make sure that this length
-       * is larger than the current record descriptor area.
-       */
-
-      new_recdes->length = -expected_size;	/* set to negative */
-
-      if (new_recdes->area_size > -new_recdes->length)
-	{
-	  /*
-	   * This may be an error. The estimated disk size is smaller
-	   * than the current record descriptor area size. For now assume
-	   * at least 20% above the current area descriptor. The main problem
-	   * is that heap_attrinfo_get_disksize () guess its size as much as
-	   * possible
-	   */
-	  new_recdes->length = -(int) (new_recdes->area_size * 1.20);
-	}
-      break;
+      expected_size += DB_PAGESIZE;
+      goto resize_and_start;
 
     default:
       status = S_ERROR;

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -40,6 +40,9 @@
 #include "storage_common.h"
 #include "thread_compat.hpp"
 
+// forward declarations
+class record_descriptor;
+
 #define HFID_EQ(hfid_ptr1, hfid_ptr2) \
   ((hfid_ptr1) == (hfid_ptr2) \
    || ((hfid_ptr1)->hpgid == (hfid_ptr2)->hpgid && VFID_EQ (&((hfid_ptr1)->vfid), &((hfid_ptr2)->vfid))))
@@ -447,9 +450,9 @@ extern DB_VALUE *heap_attrinfo_access (ATTR_ID attrid, HEAP_CACHE_ATTRINFO * att
 extern int heap_attrinfo_set (const OID * inst_oid, ATTR_ID attrid, DB_VALUE * attr_val,
 			      HEAP_CACHE_ATTRINFO * attr_info);
 extern SCAN_CODE heap_attrinfo_transform_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info,
-						  RECDES * old_recdes, RECDES * new_recdes);
+						  RECDES * old_recdes, record_descriptor * new_recdes);
 extern SCAN_CODE heap_attrinfo_transform_to_disk_except_lob (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info,
-							     RECDES * old_recdes, RECDES * new_recdes);
+							     RECDES * old_recdes, record_descriptor * new_recdes);
 
 extern DB_VALUE *heap_attrinfo_generate_key (THREAD_ENTRY * thread_p, int n_atts, int *att_ids, int *atts_prefix_length,
 					     HEAP_CACHE_ATTRINFO * attr_info, RECDES * recdes, DB_VALUE * dbvalue,

--- a/src/storage/record_descriptor.cpp
+++ b/src/storage/record_descriptor.cpp
@@ -112,7 +112,7 @@ record_descriptor::get (cubthread::entry *thread_p, PAGE_PTR page, PGSLOTID slot
       assert (mode == record_get_mode::COPY_RECORD);
 
       size_t required_size = static_cast<size_t> (-m_recdes.length);
-      resize (thread_p, required_size, false);
+      resize_buffer (required_size);
 
       sc = spage_get_record (thread_p, page, slotid, &m_recdes, mode_to_int);
       if (sc == S_SUCCESS)
@@ -128,8 +128,10 @@ record_descriptor::get (cubthread::entry *thread_p, PAGE_PTR page, PGSLOTID slot
 }
 
 void
-record_descriptor::resize (cubthread::entry *thread_p, std::size_t required_size, bool copy_data)
+record_descriptor::resize_buffer (std::size_t required_size)
 {
+  check_changes_are_permitted ();
+
   if (m_recdes.area_size > 0 && required_size <= (size_t) m_recdes.area_size)
     {
       // resize not required
@@ -200,6 +202,30 @@ record_descriptor::set_data (const char *data, size_t size)
 }
 
 void
+record_descriptor::set_record_length (size_t length)
+{
+  check_changes_are_permitted ();
+  assert (length <= m_recdes.area_size);
+  m_recdes.length = (int) length;
+}
+
+void
+record_descriptor::set_type (std::int16_t type)
+{
+  check_changes_are_permitted ();
+  m_recdes.type = type;
+}
+
+void
+record_descriptor::set_external_buffer (char *buf, size_t buf_size)
+{
+  m_own_data.freemem ();
+  m_recdes.data = buf;
+  m_recdes.area_size = (int) buf_size;
+  m_data_source = data_source::NEW;
+}
+
+void
 record_descriptor::move_data (std::size_t dest_offset, std::size_t source_offset)
 {
   check_changes_are_permitted ();
@@ -222,7 +248,7 @@ record_descriptor::move_data (std::size_t dest_offset, std::size_t source_offset
   if (dest_offset > source_offset)
     {
       // record is being increased; make sure we have enough space
-      resize (NULL, new_size, true);
+      resize_buffer (new_size);
     }
 
   if (memmove_size > 0)
@@ -263,7 +289,13 @@ record_descriptor::insert_data (std::size_t offset, std::size_t new_size, const 
 void
 record_descriptor::check_changes_are_permitted (void) const
 {
-  assert (m_data_source == data_source::COPIED || m_data_source == data_source::NEW);
+  assert (is_mutable ());
+}
+
+bool
+record_descriptor::is_mutable () const
+{
+  return m_data_source == data_source::COPIED || m_data_source == data_source::NEW;
 }
 
 void
@@ -278,7 +310,7 @@ record_descriptor::unpack (cubpacking::unpacker &unpacker)
 {
   unpacker.unpack_short (m_recdes.type);
   unpacker.peek_unpack_buffer_length (m_recdes.length);
-  resize (NULL, m_recdes.length, true);
+  resize_buffer (m_recdes.length);
   unpacker.unpack_buffer_with_length (m_recdes.data, m_recdes.length);
 }
 
@@ -289,4 +321,11 @@ record_descriptor::get_packed_size (cubpacking::packer &packer) const
   entry_size += packer.get_packed_buffer_size (m_recdes.data, m_recdes.length, entry_size);
 
   return entry_size;
+}
+
+void
+record_descriptor::release_buffer (char *&data, size_t &size)
+{
+  size = m_own_data.get_size ();
+  data = m_own_data.release_ptr ();
 }

--- a/src/storage/record_descriptor.hpp
+++ b/src/storage/record_descriptor.hpp
@@ -30,6 +30,8 @@
 #include "packable_object.hpp"
 #include "storage_common.h"
 
+#include <cinttypes>
+
 // forward definitions
 namespace cubthread
 {
@@ -95,6 +97,9 @@ class record_descriptor : public cubpacking::packable_object
     template <typename T>
     void set_data_to_object (const T &t);               // set record data to object
 
+    void set_record_length (size_t length);
+    void set_type (std::int16_t type);
+
     //
     // manipulate record data
     //
@@ -115,13 +120,23 @@ class record_descriptor : public cubpacking::packable_object
     void unpack (cubpacking::unpacker &unpacker) override;
     std::size_t get_packed_size (cubpacking::packer &packer) const override;
 
-  private:
+    //
+    // manipulate record memory buffer
+    //
 
-    // resize record buffer; copy_data is true if existing data must be preserved
-    void resize (cubthread::entry *thread_p, std::size_t size, bool copy_data);
+    // resize record buffer
+    void resize_buffer (std::size_t size);
+    // set external buffer; record type is set to new automatically
+    void set_external_buffer (char *buf, size_t buf_size);
+    template <size_t S>
+    void set_external_buffer (cubmem::stack_block<S> &membuf);
+    void release_buffer (char *&data, size_t &size);
+
+  private:
 
     // debug function to check if data changes are permitted; e.g. changes into peeked records are not permitted
     void check_changes_are_permitted (void) const;
+    bool is_mutable () const;
 
     void update_source_after_get (record_get_mode mode);
 
@@ -146,13 +161,12 @@ class record_descriptor : public cubpacking::packable_object
 //////////////////////////////////////////////////////////////////////////
 
 template <size_t S>
-record_descriptor::record_descriptor (cubmem::stack_block<S> &membuf)
+void
+record_descriptor::set_external_buffer (cubmem::stack_block<S> &membuf)
 {
+  m_own_data.freemem ();
   m_recdes.area_size = membuf.SIZE;
-  m_recdes.length = 0;
-  m_recdes.type = REC_HOME;
   m_recdes.data = membuf.get_ptr ();
-  m_own_data = NULL;
   m_data_source = data_source::NEW;
 }
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7181,7 +7181,9 @@ locator_allocate_copy_area_by_attr_info (THREAD_ENTRY * thread_p, HEAP_CACHE_ATT
   LC_COPYAREA *copyarea = NULL;
   int copyarea_length = copyarea_length_hint <= 0 ? DB_PAGESIZE : copyarea_length_hint;
   SCAN_CODE scan = S_DOESNT_FIT;
+  // *INDENT-OFF*
   record_descriptor build_record (cubmem::CSTYLE_BLOCK_ALLOCATOR);
+  // *INDENT-ON*
 
   new_recdes->data = NULL;
   new_recdes->area_size = 0;
@@ -7229,6 +7231,8 @@ locator_allocate_copy_area_by_attr_info (THREAD_ENTRY * thread_p, HEAP_CACHE_ATT
 	  return NULL;
 	}
       std::memcpy (copyarea->mem, allocated_data, build_record.get_size ());
+
+      free (allocated_data);	// c-style allocator was used
     }
 
   *new_recdes = build_record.get_recdes ();

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -54,6 +54,7 @@
 #if defined(ENABLE_SYSTEMTAP)
 #include "probes.h"
 #endif /* ENABLE_SYSTEMTAP */
+#include "record_descriptor.hpp"
 #include "slotted_page.h"
 #include "xasl_cache.h"
 #include "xasl_predicate.hpp"
@@ -7251,59 +7252,59 @@ locator_allocate_copy_area_by_attr_info (THREAD_ENTRY * thread_p, HEAP_CACHE_ATT
   LC_COPYAREA *copyarea = NULL;
   int copyarea_length = copyarea_length_hint <= 0 ? DB_PAGESIZE : copyarea_length_hint;
   SCAN_CODE scan = S_DOESNT_FIT;
+  record_descriptor build_record (cubmem::CSTYLE_BLOCK_ALLOCATOR);
 
-  while (scan == S_DOESNT_FIT)
+  new_recdes->data = NULL;
+  new_recdes->area_size = 0;
+
+  copyarea = locator_allocate_copy_area_by_length (copyarea_length);
+  if (copyarea == NULL)
     {
+      return NULL;
+    }
+
+  assert (copyarea->length > 0);
+  build_record.set_external_buffer (copyarea->mem, (size_t) copyarea->length);
+
+  new_recdes->data = copyarea->mem;
+  new_recdes->area_size = copyarea->length;
+
+  if (lob_create_flag == LOB_FLAG_EXCLUDE_LOB)
+    {
+      scan = heap_attrinfo_transform_to_disk_except_lob (thread_p, attr_info, old_recdes, &build_record);
+    }
+  else
+    {
+      scan = heap_attrinfo_transform_to_disk (thread_p, attr_info, old_recdes, &build_record);
+    }
+  if (scan != S_SUCCESS)
+    {
+      /* Get the real length used in the copy area */
+      copyarea_length = copyarea->length;
+      locator_free_copy_area (copyarea);
+      return NULL;
+    }
+
+  char *allocated_data = NULL;
+  size_t allocated_size = 0;
+  build_record.release_buffer (allocated_data, allocated_size);
+  if (allocated_data != NULL)
+    {
+      assert (allocated_size > (size_t) copyarea_length);
+      locator_free_copy_area (copyarea);
+
+      copyarea_length = DB_ALIGN ((int) allocated_size, DB_PAGESIZE);
       copyarea = locator_allocate_copy_area_by_length (copyarea_length);
       if (copyarea == NULL)
 	{
-	  break;
+	  return NULL;
 	}
-
-      new_recdes->data = copyarea->mem;
-      new_recdes->area_size = copyarea->length;
-
-      if (lob_create_flag == LOB_FLAG_EXCLUDE_LOB)
-	{
-	  scan = heap_attrinfo_transform_to_disk_except_lob (thread_p, attr_info, old_recdes, new_recdes);
-	}
-      else
-	{
-	  scan = heap_attrinfo_transform_to_disk (thread_p, attr_info, old_recdes, new_recdes);
-	}
-
-      if (scan != S_SUCCESS)
-	{
-	  /* Get the real length used in the copy area */
-	  copyarea_length = copyarea->length;
-	  locator_free_copy_area (copyarea);
-	  copyarea = NULL;
-	  new_recdes->data = NULL;
-	  new_recdes->area_size = 0;
-
-	  /* Is more space needed ? */
-	  if (scan == S_DOESNT_FIT)
-	    {
-	      /*
-	       * The object does not fit into copy area, increase the area
-	       * to estimated size included in length of record descriptor.
-	       */
-	      if (copyarea_length < (-new_recdes->length))
-		{
-		  copyarea_length = DB_ALIGN (-new_recdes->length, MAX_ALIGNMENT);
-		}
-	      else
-		{
-		  /*
-		   * This is done for security purposes only, since the
-		   * transformation may not have given us the correct length,
-		   * somehow.
-		   */
-		  copyarea_length += DB_PAGESIZE;
-		}
-	    }
-	}
+      std::memcpy (copyarea->mem, allocated_data, build_record.get_size ());
     }
+
+  *new_recdes = build_record.get_recdes ();
+  new_recdes->data = copyarea->mem;
+  new_recdes->area_size = copyarea->length;
   return copyarea;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22910

### heap_attrinfo_transform_to_disk

1. change new_recdes type from RECDES * to record_descriptor *
2. when record data buffer is not enough, extend it by DB_PAGESIZE and retry
3. update serial_update_serial_object and locator_allocate_copy_area_by_attr_info to use new signature

### locator_allocate_copy_area_by_attr_info

1. remove while loop since heap_attrinfo_transform_to_disk should success on first try
2. consume record_descriptor allocated buffer; it there is an allocated buffer, it means that the initial copy area was not enough; release it and allocate another copy area big enough to hold all record data.

### record_descriptor

1. new setter function for recdes info: set_record_length, set_type
2. buffer manipulation functions: resize_buffer, set_external_buffer, release_buffer.