### PR TITLE
[CBRD-21023] JDBC Driver patch for Clob's length() returns -1 for empty string

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
@@ -127,7 +127,10 @@ public class CUBRIDClob implements Clob {
 			throw conn.createCUBRIDException(CUBRIDJDBCErrorCode.invalid_value, null);
 		}
 		if (clobCharLength < 0) {
-			readClobPartially(Long.MAX_VALUE, 1);
+			int read_len = readClobPartially(Long.MAX_VALUE, 1);
+			if (read_len <= 0) {
+				return 0;
+			}
 		}
 
 		return clobCharLength;


### PR DESCRIPTION
patch for: Clob's length() returns -1 when empty string
http://jira.cubrid.org/browse/CBRD-21023
