### PR TITLE
[CBRD-22928] Transactions group

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -301,6 +301,7 @@ set(TRANSACTION_SOURCES
   ${TRANSACTION_DIR}/mvcc_table.cpp
   ${TRANSACTION_DIR}/recovery.c
   ${TRANSACTION_DIR}/replication.c
+  ${TRANSACTION_DIR}/transaction_group.cpp
   ${TRANSACTION_DIR}/transaction_sr.c
   ${TRANSACTION_DIR}/transaction_transient.cpp
   ${TRANSACTION_DIR}/wait_for_graph.c
@@ -320,6 +321,7 @@ set(TRANSACTION_HEADERS
   ${TRANSACTION_DIR}/mvcc_active_tran.hpp
   ${TRANSACTION_DIR}/mvcc_table.hpp
   ${TRANSACTION_DIR}/transaction_global.hpp
+  ${TRANSACTION_DIR}/transaction_group.hpp
   ${TRANSACTION_DIR}/transaction_transient.hpp
   )
 

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -361,6 +361,7 @@ set(TRANSACTION_SOURCES
   ${TRANSACTION_DIR}/replication.c
   ${TRANSACTION_DIR}/recovery.c
   ${TRANSACTION_DIR}/transaction_cl.c
+  ${TRANSACTION_DIR}/transaction_group.hpp
   ${TRANSACTION_DIR}/transaction_sr.c
   ${TRANSACTION_DIR}/transaction_transient.cpp
   ${TRANSACTION_DIR}/wait_for_graph.c
@@ -380,6 +381,7 @@ set(TRANSACTION_HEADERS
   ${TRANSACTION_DIR}/mvcc_active_tran.hpp
   ${TRANSACTION_DIR}/mvcc_table.hpp
   ${TRANSACTION_DIR}/transaction_global.hpp
+  ${TRANSACTION_DIR}/transaction_group.hpp
   ${TRANSACTION_DIR}/transaction_transient.hpp
   )
 

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -361,7 +361,7 @@ set(TRANSACTION_SOURCES
   ${TRANSACTION_DIR}/replication.c
   ${TRANSACTION_DIR}/recovery.c
   ${TRANSACTION_DIR}/transaction_cl.c
-  ${TRANSACTION_DIR}/transaction_group.hpp
+  ${TRANSACTION_DIR}/transaction_group.cpp
   ${TRANSACTION_DIR}/transaction_sr.c
   ${TRANSACTION_DIR}/transaction_transient.cpp
   ${TRANSACTION_DIR}/wait_for_graph.c

--- a/src/base/extensible_array.hpp
+++ b/src/base/extensible_array.hpp
@@ -149,15 +149,15 @@ namespace cubmem
   {
     ~appendible_block<Size> ();
     m_size = other.m_size;
-    m_use_stack = other.m_use_stack;
-    if (m_use_stack)
+    this->m_use_stack = other.m_use_stack;
+    if (this->m_use_stack)
       {
 	// m_stack = other.m_stack would copy entire buffer. we need only m_size
-	std::memcpy (m_stack.get_ptr (), other.get_ptr (), m_size);
+	std::memcpy (this->m_stack.get_ptr (), other.get_ptr (), m_size);
       }
     else
       {
-	m_ext_block = other.m_ext_block;
+	this->m_ext_block = other.m_ext_block;
       }
   }
 

--- a/src/base/extensible_array.hpp
+++ b/src/base/extensible_array.hpp
@@ -50,6 +50,8 @@ namespace cubmem
 
       inline std::size_t get_size () const;
 
+      inline appendible_block &operator= (appendible_block &&other);
+
     private:
       inline void reset ();
 
@@ -67,9 +69,13 @@ namespace cubmem
       void extend_to (size_t count);
 
       const T *get_array (void) const;
+      T *release_array ();
+
+      T *get_data_ptr ();
+
+      extensible_array &operator= (extensible_array &&other);
 
     protected:
-      T *get_data_ptr ();
 
       size_t get_memsize_for_count (size_t count) const;
   };
@@ -92,12 +98,14 @@ namespace cubmem
       void reset (void);                               // reset array
 
       inline size_t get_size (void) const;                    // get current size
-
       size_t get_memsize () const;
 
-    private:
-      inline T *get_append_ptr ();
+      T *get_append_ptr ();
+      const T *get_append_ptr () const;
 
+      appendable_array &operator= (appendable_array &&other);
+
+    private:
       size_t m_size;                                          // current size
   };
 } // namespace cubmem
@@ -133,6 +141,24 @@ namespace cubmem
   appendible_block<Size>::get_size () const
   {
     return m_size;
+  }
+
+  template <size_t Size>
+  appendible_block<Size> &
+  appendible_block<Size>::operator= (appendible_block &&other)
+  {
+    ~appendible_block<Size> ();
+    m_size = other.m_size;
+    m_use_stack = other.m_use_stack;
+    if (m_use_stack)
+      {
+	// m_stack = other.m_stack would copy entire buffer. we need only m_size
+	std::memcpy (m_stack.get_ptr (), other.get_ptr (), m_size);
+      }
+    else
+      {
+	m_ext_block = other.m_ext_block;
+      }
   }
 
   template <size_t Size>
@@ -193,6 +219,13 @@ namespace cubmem
 
   template <typename T, size_t Size>
   T *
+  extensible_array<T, Size>::release_array ()
+  {
+    return reinterpret_cast<T *> (base_type::release_ptr ());
+  }
+
+  template <typename T, size_t Size>
+  T *
   extensible_array<T, Size>::get_data_ptr ()
   {
     return reinterpret_cast<T *> (base_type::get_ptr ());
@@ -203,6 +236,14 @@ namespace cubmem
   extensible_array<T, Size>::get_memsize_for_count (size_t count) const
   {
     return count * sizeof (T);
+  }
+
+  template <typename T, size_t Size>
+  extensible_array<T, Size> &
+  extensible_array<T, Size>::operator= (extensible_array &&other)
+  {
+    base_type::operator= (std::move (other));
+    return *this;
   }
 
   //
@@ -235,6 +276,13 @@ namespace cubmem
   appendable_array<T, Size>::get_append_ptr ()
   {
     return base_type::get_data_ptr () + m_size;
+  }
+
+  template <typename T, size_t Size>
+  const T *
+  appendable_array<T, Size>::get_append_ptr () const
+  {
+    return base_type::get_array () + m_size;
   }
 
   template <typename T, size_t Size>
@@ -302,6 +350,14 @@ namespace cubmem
   {
     // set size to zero
     m_size = 0;
+  }
+
+  template <typename T, size_t Size>
+  appendable_array<T, Size> &
+  appendable_array<T, Size>::operator= (appendable_array &&other)
+  {
+    base_type::operator= (std::move (other));
+    return *this;
   }
 
 } // namespace cubmem

--- a/src/base/extensible_array.hpp
+++ b/src/base/extensible_array.hpp
@@ -89,13 +89,13 @@ namespace cubmem
       inline void append (const T *source, size_t length);    // append at the end of existing data
       inline void copy (const T *source, size_t length);      // overwrite entire array
       void erase (size_t index);    // remove at index; does not preserve order
+      void reset (void);                               // reset array
 
       inline size_t get_size (void) const;                    // get current size
 
       size_t get_memsize () const;
 
     private:
-      inline void reset (void);                               // reset array
       inline T *get_append_ptr ();
 
       size_t m_size;                                          // current size

--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -274,6 +274,7 @@ namespace cubmem
   stack_block<S>::operator= (stack_block &&other)
   {
     std::memcpy (m_buf, other.m_buf, S);
+    return *this;
   }
 
   //

--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -38,6 +38,7 @@
 
 #include <cassert>
 #include <cinttypes>
+#include <cstring>
 
 namespace cubmem
 {
@@ -434,12 +435,13 @@ namespace cubmem
     m_use_stack = b.m_use_stack;
     if (b.m_use_stack)
       {
-	m_stack = b.m_stack;
+	m_stack = std::move (b.m_stack);
       }
     else
       {
-	m_ext_block = b.m_ext_block;
+	m_ext_block = std::move (b.m_ext_block);
       }
+    return *this;
   }
 } // namespace cubmem
 

--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -85,6 +85,8 @@ namespace cubmem
       inline char *get_ptr (void);
       inline const char *get_read_ptr () const;
 
+      inline stack_block &operator= (stack_block &&other);
+
     private:
       union
       {
@@ -166,6 +168,10 @@ namespace cubmem
 
       inline char *get_ptr ();
       inline const char *get_read_ptr () const;
+
+      inline char *release_ptr ();
+
+      inline extensible_stack_block &operator= (extensible_stack_block &&b);                   //move assignment
 
     private:
       stack_block<S> m_stack;
@@ -260,6 +266,13 @@ namespace cubmem
   stack_block<S>::get_read_ptr (void) const
   {
     return &m_buf[0];
+  }
+
+  template <size_t S>
+  stack_block<S> &
+  stack_block<S>::operator= (stack_block &&other)
+  {
+    std::memcpy (m_buf, other.m_buf, S);
   }
 
   //
@@ -404,6 +417,29 @@ namespace cubmem
   extensible_stack_block<S>::get_read_ptr () const
   {
     return m_use_stack ? m_stack.get_read_ptr () : m_ext_block.get_read_ptr ();
+  }
+
+  template <size_t S>
+  char *
+  extensible_stack_block<S>::release_ptr ()
+  {
+    return m_ext_block.release_ptr ();
+  }
+
+  template <size_t S>
+  extensible_stack_block<S> &
+  extensible_stack_block<S>::operator= (extensible_stack_block &&b)
+  {
+    this->~extensible_stack_block ();
+    m_use_stack = b.m_use_stack;
+    if (b.m_use_stack)
+      {
+	m_stack = b.m_stack;
+      }
+    else
+      {
+	m_ext_block = b.m_ext_block;
+      }
   }
 } // namespace cubmem
 

--- a/src/transaction/transaction_group.cpp
+++ b/src/transaction/transaction_group.cpp
@@ -23,3 +23,113 @@
 
 #include "transaction_group.hpp"
 
+void
+tx_group::add (const node_info &ni)
+{
+  m_group.append (ni);
+}
+
+void
+tx_group::add (int tran_index, MVCCID mvccid, TRAN_STATE tran_state)
+{
+  add (node_info (tran_index, mvccid, tran_state));
+}
+
+// iterators
+
+tx_group::iterator::iterator (tx_group::node_info *ptr)
+  : m_ptr (ptr)
+{
+}
+
+tx_group::iterator::iterator (const iterator &other)
+  : m_ptr (other.m_ptr)
+{
+}
+
+tx_group::iterator &
+tx_group::iterator::operator= (const iterator &other)
+{
+  m_ptr = other.m_ptr;
+  return *this;
+}
+
+bool
+tx_group::iterator::operator== (const iterator &other) const
+{
+  return m_ptr == other.m_ptr;
+}
+
+bool
+tx_group::iterator::operator!= (const iterator &other) const
+{
+  return m_ptr != other.m_ptr;
+}
+
+tx_group::iterator &tx_group::iterator::operator++ ()
+{
+  m_ptr++;
+  return *this;
+}
+
+tx_group::iterator::reference
+tx_group::iterator::operator*() const
+{
+  return *m_ptr;
+}
+
+tx_group::iterator::pointer
+tx_group::iterator::operator->() const
+{
+  return m_ptr;
+}
+
+// const iterator
+
+tx_group::const_iterator::const_iterator (const tx_group::node_info *ptr)
+  : m_ptr (ptr)
+{
+}
+
+tx_group::const_iterator::const_iterator (const const_iterator &other)
+  : m_ptr (other.m_ptr)
+{
+}
+
+tx_group::const_iterator &
+tx_group::const_iterator::operator= (const const_iterator &other)
+{
+  m_ptr = other.m_ptr;
+  return *this;
+}
+
+bool
+tx_group::const_iterator::operator== (const const_iterator &other) const
+{
+  return m_ptr == other.m_ptr;
+}
+
+bool
+tx_group::const_iterator::operator!= (const const_iterator &other) const
+{
+  return m_ptr != other.m_ptr;
+}
+
+tx_group::const_iterator &
+tx_group::const_iterator::operator++ ()
+{
+  m_ptr++;
+  return *this;
+}
+
+tx_group::const_iterator::reference
+tx_group::const_iterator::operator*() const
+{
+  return *m_ptr;
+}
+
+tx_group::const_iterator::pointer
+tx_group::const_iterator::operator->() const
+{
+  return m_ptr;
+}

--- a/src/transaction/transaction_group.cpp
+++ b/src/transaction/transaction_group.cpp
@@ -35,6 +35,57 @@ tx_group::add (int tran_index, MVCCID mvccid, TRAN_STATE tran_state)
   add (node_info (tran_index, mvccid, tran_state));
 }
 
+tx_group::iterator
+tx_group::begin () noexcept
+{
+  return iterator (m_group.get_data_ptr ());
+}
+
+tx_group::const_iterator
+tx_group::begin () const noexcept
+{
+  return const_iterator (m_group.get_array ());
+}
+
+tx_group::const_iterator
+tx_group::cbegin () const noexcept
+{
+  return const_iterator (m_group.get_array ());
+}
+
+tx_group::iterator
+tx_group::end () noexcept
+{
+  return iterator (m_group.get_append_ptr ());
+}
+
+tx_group::const_iterator
+tx_group::end () const noexcept
+{
+  return const_iterator (m_group.get_append_ptr ());
+}
+
+tx_group::const_iterator
+tx_group::cend () const noexcept
+{
+  return const_iterator (m_group.get_append_ptr ());
+}
+
+void
+tx_group::transfer_to (tx_group &dest)
+{
+  dest.m_group = std::move (m_group);  // buffer is moved
+}
+
+// node_info
+
+tx_group::node_info::node_info (int tran_index, MVCCID mvccid, TRAN_STATE tran_state)
+  : m_tran_index (tran_index)
+  , m_mvccid (mvccid)
+  , m_tran_state (tran_state)
+{
+}
+
 // iterators
 
 tx_group::iterator::iterator (tx_group::node_info *ptr)

--- a/src/transaction/transaction_group.cpp
+++ b/src/transaction/transaction_group.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+//
+// group of transactions class
+//
+
+#include "transaction_group.hpp"
+

--- a/src/transaction/transaction_group.hpp
+++ b/src/transaction/transaction_group.hpp
@@ -45,18 +45,28 @@ class tx_group
       node_info (int tran_index, MVCCID mvccid, TRAN_STATE tran_state);
       ~node_info () = default;
     };
+
     class iterator;
     class const_iterator;
 
     tx_group () = default;
     ~tx_group () = default;
 
-    void emplace (const node_info &ni);
-    void emplace (int tran_index, MVCCID mvccid, TRAN_STATE tran_state);
+    void add (const node_info &ni);
+    void add (int tran_index, MVCCID mvccid, TRAN_STATE tran_state);
+
+    iterator begin () noexcept;
+    const_iterator begin () const noexcept;
+    const_iterator cbegin () const noexcept;
+    iterator end () noexcept;
+    const_iterator end () const noexcept;
+    const_iterator cend () const noexcept;
+
+    void transfer_to (tx_group &dest);
 
   private:
     static const size_t DEFAULT_GROUP_SIZE = 64;
-    cubmem::extensible_array<node_info, DEFAULT_GROUP_SIZE> m_group;
+    cubmem::appendable_array<node_info, DEFAULT_GROUP_SIZE> m_group;
 };
 
 class tx_group::iterator
@@ -68,15 +78,16 @@ class tx_group::iterator
     using pointer = tx_group::node_info*;
     using iterator_category = std::forward_iterator_tag;
 
-    iterator ();
+    iterator () = default;
+    iterator (tx_group::node_info *ptr);
     iterator (const iterator &);
-    ~iterator ();
+    ~iterator () = default;
 
     iterator &operator= (const iterator &);
     bool operator== (const iterator &) const;
     bool operator!= (const iterator &) const;
 
-    iterator &operator++();
+    iterator &operator++ ();
     reference operator*() const;
     pointer operator->() const;
 
@@ -89,24 +100,25 @@ class tx_group::const_iterator
   public:
     using difference_type = std::ptrdiff_t;
     using value_type = tx_group::node_info;
-    using reference = tx_group::node_info&;
-    using pointer = tx_group::node_info*;
+    using reference = const tx_group::node_info&;
+    using pointer = const tx_group::node_info*;
     using iterator_category = std::forward_iterator_tag;
 
-    const_iterator ();
+    const_iterator () = default;
+    const_iterator (const tx_group::node_info *ptr);
     const_iterator (const const_iterator &);
-    ~const_iterator ();
+    ~const_iterator () = default;
 
     const_iterator &operator= (const const_iterator &);
     bool operator== (const const_iterator &) const;
     bool operator!= (const const_iterator &) const;
 
     const_iterator &operator++ ();
-    reference operator*() const;
-    pointer operator->() const;
+    reference operator* () const;
+    pointer operator-> () const;
 
   private:
-    tx_group::node_info *m_ptr;
+    const tx_group::node_info *m_ptr;
 };
 
 #endif // !_TRANSACTION_GROUP_HPP_

--- a/src/transaction/transaction_group.hpp
+++ b/src/transaction/transaction_group.hpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+//
+// group of transactions class
+//
+
+#ifndef _TRANSACTION_GROUP_HPP_
+#define _TRANSACTION_GROUP_HPP_
+
+#include "extensible_array.hpp"
+#include "log_comm.h"
+
+#include <cstddef>
+#include <iterator>
+
+// todo - namespace cubtx
+class tx_group
+{
+  public:
+    // forward declarations
+    struct node_info
+    {
+      int m_tran_index;
+      MVCCID m_mvccid;
+      TRAN_STATE m_tran_state;
+
+      node_info () = default;
+      node_info (int tran_index, MVCCID mvccid, TRAN_STATE tran_state);
+      ~node_info () = default;
+    };
+    class iterator;
+    class const_iterator;
+
+    tx_group () = default;
+    ~tx_group () = default;
+
+    void emplace (const node_info &ni);
+    void emplace (int tran_index, MVCCID mvccid, TRAN_STATE tran_state);
+
+  private:
+    static const size_t DEFAULT_GROUP_SIZE = 64;
+    cubmem::extensible_array<node_info, DEFAULT_GROUP_SIZE> m_group;
+};
+
+class tx_group::iterator
+{
+  public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = tx_group::node_info;
+    using reference = tx_group::node_info&;
+    using pointer = tx_group::node_info*;
+    using iterator_category = std::forward_iterator_tag;
+
+    iterator ();
+    iterator (const iterator &);
+    ~iterator ();
+
+    iterator &operator= (const iterator &);
+    bool operator== (const iterator &) const;
+    bool operator!= (const iterator &) const;
+
+    iterator &operator++();
+    reference operator*() const;
+    pointer operator->() const;
+
+  private:
+    tx_group::node_info *m_ptr;
+};
+
+class tx_group::const_iterator
+{
+  public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = tx_group::node_info;
+    using reference = tx_group::node_info&;
+    using pointer = tx_group::node_info*;
+    using iterator_category = std::forward_iterator_tag;
+
+    const_iterator ();
+    const_iterator (const const_iterator &);
+    ~const_iterator ();
+
+    const_iterator &operator= (const const_iterator &);
+    bool operator== (const const_iterator &) const;
+    bool operator!= (const const_iterator &) const;
+
+    const_iterator &operator++ ();
+    reference operator*() const;
+    pointer operator->() const;
+
+  private:
+    tx_group::node_info *m_ptr;
+};
+
+#endif // !_TRANSACTION_GROUP_HPP_


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22928

### transaction group

- added tx_group class that store an array of ended transactions
- for each transaction, we store tran_index (local identifier), mvccid (global identifier) and tran_state (commit, commit with postpone, abort); it might be possible to deduce tran_state from tran_index, so later it may be removed
- added iterators to simplify future transaction group based functions (e.g. generating HA and log records)
- add functions to add new transactions
- transfer_to to consume a group
NOTE - base storage type for transactions is cubmem::appendible_array. replacing it with other containers may be possible (e.g. vector)

### extensible_array/memory_block

- add move operators to stack_block, extensible_stack_block, appendible_block, extensible_array, appendible_array
- add release functionality to extensible_stack_block, extensible_array
- make appendible_block's reset, get_append_ptr functions public

### TODO (later)

- backport extensible_array/memory_block changes to develop
- add iterators to extensible/appendible array; tx_group may use these iterators directly
