### PR TITLE
[CBRD-22933] add destructor body for tx_complete_manager class

### DIFF
--- a/src/transaction/transaction_complete_manager.cpp
+++ b/src/transaction/transaction_complete_manager.cpp
@@ -23,6 +23,11 @@
 
 #include "transaction_complete_manager.hpp"
 
+tx_complete_manager::~tx_complete_manager ()
+{
+  // pure virtual destructor must have a body
+}
+
 tx_group_complete_manager::ticket_type
 tx_group_complete_manager::register_transaction (int tran_index, MVCCID mvccid, TRAN_STATE state)
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22933

Pure virtual destructor must have a body, since destructors are always called in the reverse order of the class derivation.

```cpp
class base
{
  public:
    virtual ~base () = 0;
};
```

If `base` class is inherited and then child instance is deleted, `base`'s destructor will eventually be called.
Since it is pure and doesn't have a body it is undefined behavior