### PR TITLE
[CBRD-22963] [replication] set user read/write access for replication file

### DIFF
--- a/src/base/stream_file.cpp
+++ b/src/base/stream_file.cpp
@@ -531,7 +531,7 @@ namespace cubstream
 
     if ((flags & FILE_CREATE_FLAG) == FILE_CREATE_FLAG)
       {
-	fd = create_file (file_path);
+	fd = create_file (file_path, RW_USR_MODE);
 	if (fd < 0 && errno == EACCES)
 	  {
 	    if (std::remove (file_path) != 0)
@@ -541,7 +541,7 @@ namespace cubstream
 		return ER_BO_TRYING_TO_REMOVE_PERMANENT_VOLUME;
 	      }
 
-	    fd = create_file (file_path);
+	    fd = create_file (file_path, RW_USR_MODE);
 	    if (fd < 0)
 	      {
 		/* TODO[replication] : error */
@@ -568,14 +568,14 @@ namespace cubstream
     return fd;
   }
 
-  int stream_file::create_file (const char *file_path)
+  int stream_file::create_file (const char *file_path, unsigned int mode)
   {
     int fd;
 
 #if defined (WINDOWS)
-    fd = _sopen (file_path, O_RDWR | O_CREAT | O_BINARY, _SH_DENYWR, 0600);
+    fd = _sopen (file_path, O_RDWR | O_CREAT | O_BINARY, _SH_DENYWR, mode);
 #else
-    fd = open (file_path, O_RDWR | O_CREAT | O_EXCL);
+    fd = open (file_path, O_RDWR | O_CREAT | O_EXCL, mode);
 #endif
 
     if (fd < 0)

--- a/src/base/stream_file.hpp
+++ b/src/base/stream_file.hpp
@@ -37,6 +37,10 @@ namespace cubthread
 namespace cubstream
 {
 
+  // same as FILEIO_DISK_PROTECTION_MODE from file_io.c
+  // better redefine another one here in order not to pull all dependencies from file_io module
+  static const unsigned int RW_USR_MODE = 0600;
+
   /*
    * class for handling reading/writing to volumes from a stream
    * stream file consists of several physical files (volumes) on disk;
@@ -136,7 +140,7 @@ namespace cubstream
 
       int open_file (const char *file_path, int flags = 0);
 
-      int create_file (const char *file_path);
+      int create_file (const char *file_path, unsigned int mode);
 
       size_t read_buffer (const int vol_seqno, const size_t volume_offset, char *buf, const size_t amount);
       size_t write_buffer (const int vol_seqno, const size_t volume_offset, const char *buf, const size_t amount);
@@ -180,7 +184,7 @@ namespace cubstream
 
       size_t get_max_available_from_pos (const stream_position &pos)
       {
-        assert (m_append_position >= pos);
+	assert (m_append_position >= pos);
 	if (m_append_position > pos)
 	  {
 	    return m_append_position - pos;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22963

Set explicitly file permission for replication file to read/write access for user.

**bug behavior**:
Creation of the replication file is done without specifying permissions, therefore the file has just user execute access (0100).
After file is created the file descriptor is closed and the file is opened again with `O_RDWR` flag, which will fail since the file has no read/write access.