### PR TITLE
[CBRD-22964] [replication] enable db modification before ha server state is forced set to active

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2309,6 +2309,13 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
 	{
 	  er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state:" " set force from %s to state %s\n",
 			css_ha_server_state_string (ha_Server_state), css_ha_server_state_string (state));
+
+	  if (state == HA_SERVER_STATE_ACTIVE)
+	    {
+	      er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state: logtb_enable_update()\n");
+	      logtb_enable_update (thread_p);
+	    }
+
 	  ha_Server_state = state;
 	  /* append a dummy log record for LFT to wake LWTs up */
 	  log_append_ha_server_state (thread_p, state);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22964

Enable db modification before  `ha_Server_state` is forced set to `HA_SERVER_STATE_ACTIVE`
This is a quick fix, we need atomic operation when `db_Disable_modifications` and `ha_Server_state` are changed

**bug behavior**
When in `css_change_ha_server_state` function `ha_Server_state` is forced set to `HA_SERVER_STATE_ACTIVE` thread might be preempted, therefore `db_Disable_modifications` will remain with value `1` until thread will be scheduled again on CPU, in the meantime another thread which sees that ha server state is active can commit a transaction