### PR TITLE
[CBRD-22967] [record_descriptor] set data source properly when unpacking

### DIFF
--- a/src/storage/record_descriptor.cpp
+++ b/src/storage/record_descriptor.cpp
@@ -321,9 +321,12 @@ record_descriptor::unpack (cubpacking::unpacker &unpacker)
 {
   unpacker.unpack_short (m_recdes.type);
   unpacker.peek_unpack_buffer_length (m_recdes.length);
-  resize_buffer (m_recdes.length);
-  unpacker.unpack_buffer_with_length (m_recdes.data, m_recdes.length);
+
+  // resize_buffer requires m_data_source to be set
   m_data_source = data_source::COPIED;
+  resize_buffer (m_recdes.length);
+
+  unpacker.unpack_buffer_with_length (m_recdes.data, m_recdes.length);
 }
 
 size_t

--- a/src/storage/record_descriptor.cpp
+++ b/src/storage/record_descriptor.cpp
@@ -319,13 +319,12 @@ record_descriptor::pack (cubpacking::packer &packer) const
 void
 record_descriptor::unpack (cubpacking::unpacker &unpacker)
 {
-  unpacker.unpack_short (m_recdes.type);
-  unpacker.peek_unpack_buffer_length (m_recdes.length);
-
   // resize_buffer requires m_data_source to be set
   m_data_source = data_source::COPIED;
-  resize_buffer (m_recdes.length);
 
+  unpacker.unpack_short (m_recdes.type);
+  unpacker.peek_unpack_buffer_length (m_recdes.length);
+  resize_buffer (m_recdes.length);
   unpacker.unpack_buffer_with_length (m_recdes.data, m_recdes.length);
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22967

Set record descriptor's data source before resizing internal buffer on unpack operation