### PR TITLE
[CBRD-22968] [log_generator] fix memory leak

### DIFF
--- a/src/replication/log_generator.cpp
+++ b/src/replication/log_generator.cpp
@@ -179,7 +179,9 @@ namespace cubreplication
       {
 	if ((*repl_obj)->compare_inst_oid (inst_oid))
 	  {
+	    changed_attrs_row_repl_entry *entry = *repl_obj;
 	    (void) m_pending_to_be_added.erase (repl_obj--);
+	    delete entry;
 	    break;
 	  }
       }

--- a/src/replication/log_generator.cpp
+++ b/src/replication/log_generator.cpp
@@ -135,8 +135,6 @@ namespace cubreplication
       }
 
     changed_attrs_row_repl_entry *entry = NULL;
-    char *class_name = NULL;
-
     for (auto &repl_obj : m_pending_to_be_added)
       {
 	if (repl_obj->compare_inst_oid (inst_oid))
@@ -153,8 +151,6 @@ namespace cubreplication
     else
       {
 	LOG_LSA *p_lsa;
-	int error_code = NO_ERROR;
-
 	char *class_name = get_classname (class_oid);
 
 	cubthread::entry *thread_p = &cubthread::get_entry ();
@@ -183,7 +179,7 @@ namespace cubreplication
       {
 	if ((*repl_obj)->compare_inst_oid (inst_oid))
 	  {
-	    (void) m_pending_to_be_added.erase (repl_obj);
+	    (void) m_pending_to_be_added.erase (repl_obj--);
 	    break;
 	  }
       }
@@ -221,7 +217,7 @@ namespace cubreplication
 	    er_log_repl_obj (repl_obj, "log_generator::set_key_to_repl_object");
 
 	    // remove
-	    (void) m_pending_to_be_added.erase (repl_obj_it);
+	    (void) m_pending_to_be_added.erase (repl_obj_it--);
 
 	    found = true;
 

--- a/src/replication/log_generator.hpp
+++ b/src/replication/log_generator.hpp
@@ -94,7 +94,8 @@ namespace cubreplication
       };
 
       log_generator (cubstream::multi_thread_stream *stream)
-	: m_stream_entry (stream)
+	: m_pending_to_be_added ()
+	, m_stream_entry (stream)
 	, m_has_stream (false)
 	, m_is_row_replication_disabled (true)
       {

--- a/src/replication/replication_master_senders_manager.cpp
+++ b/src/replication/replication_master_senders_manager.cpp
@@ -182,7 +182,7 @@ namespace cubreplication
 		  }
 		else
 		  {
-		    it = master_server_stream_senders.erase (it);
+		    it = master_server_stream_senders.erase (it--);
 		  }
 	      }
 	    else

--- a/src/replication/replication_master_senders_manager.cpp
+++ b/src/replication/replication_master_senders_manager.cpp
@@ -182,7 +182,7 @@ namespace cubreplication
 		  }
 		else
 		  {
-		    it = master_server_stream_senders.erase (it--);
+		    it = master_server_stream_senders.erase (it);
 		  }
 	      }
 	    else

--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -576,8 +576,11 @@ namespace cubreplication
   changed_attrs_row_repl_entry::changed_attrs_row_repl_entry (repl_entry_type type, const char *class_name,
       const OID &inst_oid, LOG_LSA &lsa_stamp)
     : single_row_repl_entry (type, class_name, lsa_stamp)
+    , m_changed_attributes ()
+    , m_new_values ()
+    , m_inst_oid (inst_oid)
   {
-    m_inst_oid = inst_oid;
+    //
   }
 
   int

--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -578,9 +578,8 @@ namespace cubreplication
     : single_row_repl_entry (type, class_name, lsa_stamp)
     , m_changed_attributes ()
     , m_new_values ()
-    , m_inst_oid (inst_oid)
   {
-    //
+    m_inst_oid = inst_oid;
   }
 
   int


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22968

Delete changed_attrs_row_repl_entry entry on update on a table without primary key
NOTE: fix also std::vector::erase using iterators