### PR TITLE
[CBRD-22971] [replication_node] fix delete order of members

### DIFF
--- a/src/base/multi_thread_stream.cpp
+++ b/src/base/multi_thread_stream.cpp
@@ -697,8 +697,7 @@ namespace cubstream
     /* wake up flusher (if any) :
      * fill_factor : ratio of flush to disk trigger size occupied in the stream buffer
      */
-    if (m_filled_stream_handler
-	&& fill_factor > 1.0f)
+    if (!m_is_stopped && m_filled_stream_handler && fill_factor > 1.0f)
       {
 	m_filled_stream_handler (start_flush_pos, flush_amount);
       }

--- a/src/replication/replication_master_node.cpp
+++ b/src/replication/replication_master_node.cpp
@@ -45,25 +45,25 @@ namespace cubreplication
   {
 #if defined (SERVER_MODE)
     assert (g_instance == NULL);
-    master_node *g_instance = master_node::get_instance (name);
+    master_node *instance = master_node::get_instance (name);
 
-    g_instance->apply_start_position ();
+    instance->apply_start_position ();
 
     INT64 buffer_size = prm_get_bigint_value (PRM_ID_REPL_GENERATOR_BUFFER_SIZE);
     int num_max_appenders = log_Gl.trantable.num_total_indices + 1;
 
-    g_instance->m_stream = new cubstream::multi_thread_stream (buffer_size, num_max_appenders);
-    g_instance->m_stream->set_name ("repl_" + std::string (name));
-    g_instance->m_stream->set_trigger_min_to_read_size (stream_entry::compute_header_size ());
-    g_instance->m_stream->init (g_instance->m_start_position);
-    log_generator::set_global_stream (g_instance->m_stream);
+    instance->m_stream = new cubstream::multi_thread_stream (buffer_size, num_max_appenders);
+    instance->m_stream->set_name ("repl_" + std::string (name));
+    instance->m_stream->set_trigger_min_to_read_size (stream_entry::compute_header_size ());
+    instance->m_stream->init (instance->m_start_position);
+    log_generator::set_global_stream (instance->m_stream);
 
     /* create stream file */
     std::string replication_path;
     replication_node::get_replication_file_path (replication_path);
-    g_instance->m_stream_file = new cubstream::stream_file (*g_instance->m_stream, replication_path);
+    instance->m_stream_file = new cubstream::stream_file (*instance->m_stream, replication_path);
 
-    master_senders_manager::init (g_instance->m_stream);
+    master_senders_manager::init (instance->m_stream);
 
     er_log_debug_replication (ARG_FILE_LINE, "master_node:init replication_path:%s", replication_path.c_str ());
 #endif

--- a/src/replication/replication_node.cpp
+++ b/src/replication/replication_node.cpp
@@ -34,6 +34,9 @@ namespace cubreplication
 {
   replication_node::~replication_node ()
   {
+    // stream and stream file are interdependent, therefore first stop the stream
+    m_stream->set_stop ();
+
     delete m_stream_file;
     m_stream_file = NULL;
     delete m_stream;

--- a/src/replication/replication_node.cpp
+++ b/src/replication/replication_node.cpp
@@ -34,10 +34,10 @@ namespace cubreplication
 {
   replication_node::~replication_node ()
   {
-    delete m_stream;
-    m_stream = NULL;
     delete m_stream_file;
     m_stream_file = NULL;
+    delete m_stream;
+    m_stream = NULL;
   }
 
   int replication_node::apply_start_position (void)

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -56,29 +56,29 @@ namespace cubreplication
     assert (g_instance == NULL);
     slave_node *instance = slave_node::get_instance (hostname);
 
-    instance ->apply_start_position ();
+    instance->apply_start_position ();
 
     INT64 buffer_size = prm_get_bigint_value (PRM_ID_REPL_CONSUMER_BUFFER_SIZE);
 
     /* create stream :*/
     /* consumer needs only one stream appender (the stream transfer receiver) */
-    assert (instance ->m_stream == NULL);
-    instance ->m_stream = new cubstream::multi_thread_stream (buffer_size, 2);
-    instance ->m_stream->set_name ("repl" + std::string (hostname) + "_replica");
-    instance ->m_stream->set_trigger_min_to_read_size (stream_entry::compute_header_size ());
-    instance ->m_stream->init (instance ->m_start_position);
+    assert (instance->m_stream == NULL);
+    instance->m_stream = new cubstream::multi_thread_stream (buffer_size, 2);
+    instance->m_stream->set_name ("repl" + std::string (hostname) + "_replica");
+    instance->m_stream->set_trigger_min_to_read_size (stream_entry::compute_header_size ());
+    instance->m_stream->init (instance->m_start_position);
 
     /* create stream file */
     std::string replication_path;
     replication_node::get_replication_file_path (replication_path);
-    instance ->m_stream_file = new cubstream::stream_file (*instance ->m_stream, replication_path);
+    instance->m_stream_file = new cubstream::stream_file (*instance->m_stream, replication_path);
 
-    assert (instance ->m_lc == NULL);
-    instance ->m_lc = new log_consumer ();
+    assert (instance->m_lc == NULL);
+    instance->m_lc = new log_consumer ();
 
-    instance ->m_lc->set_stream (instance ->m_stream);
+    instance->m_lc->set_stream (instance->m_stream);
     /* start log_consumer daemons and apply thread pool */
-    instance ->m_lc->start_daemons ();
+    instance->m_lc->start_daemons ();
 #endif
   }
 

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -123,9 +123,6 @@ namespace cubreplication
     delete g_instance->m_lc;
     g_instance->m_lc = NULL;
 
-    delete g_instance->m_stream;
-    g_instance->m_stream = NULL;
-
     delete g_instance;
     g_instance = NULL;
 #endif

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -54,31 +54,31 @@ namespace cubreplication
   {
 #if defined (SERVER_MODE)
     assert (g_instance == NULL);
-    g_instance = slave_node::get_instance (hostname);
+    slave_node *instance = slave_node::get_instance (hostname);
 
-    g_instance->apply_start_position ();
+    instance ->apply_start_position ();
 
     INT64 buffer_size = prm_get_bigint_value (PRM_ID_REPL_CONSUMER_BUFFER_SIZE);
 
     /* create stream :*/
     /* consumer needs only one stream appender (the stream transfer receiver) */
-    assert (g_instance->m_stream == NULL);
-    g_instance->m_stream = new cubstream::multi_thread_stream (buffer_size, 2);
-    g_instance->m_stream->set_name ("repl" + std::string (hostname) + "_replica");
-    g_instance->m_stream->set_trigger_min_to_read_size (stream_entry::compute_header_size ());
-    g_instance->m_stream->init (g_instance->m_start_position);
+    assert (instance ->m_stream == NULL);
+    instance ->m_stream = new cubstream::multi_thread_stream (buffer_size, 2);
+    instance ->m_stream->set_name ("repl" + std::string (hostname) + "_replica");
+    instance ->m_stream->set_trigger_min_to_read_size (stream_entry::compute_header_size ());
+    instance ->m_stream->init (instance ->m_start_position);
 
     /* create stream file */
     std::string replication_path;
     replication_node::get_replication_file_path (replication_path);
-    g_instance->m_stream_file = new cubstream::stream_file (*g_instance->m_stream, replication_path);
+    instance ->m_stream_file = new cubstream::stream_file (*instance ->m_stream, replication_path);
 
-    assert (g_instance->m_lc == NULL);
-    g_instance->m_lc = new log_consumer ();
+    assert (instance ->m_lc == NULL);
+    instance ->m_lc = new log_consumer ();
 
-    g_instance->m_lc->set_stream (g_instance->m_stream);
+    instance ->m_lc->set_stream (instance ->m_stream);
     /* start log_consumer daemons and apply thread pool */
-    g_instance->m_lc->start_daemons ();
+    instance ->m_lc->start_daemons ();
 #endif
   }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22971

There is invalid read reported by valgrind in `cubstream::stream::get_last_committed_pos` caused by wrong order in which members of `cubreplication::replication_node` are destroyed

This is the order of initialization:
```cpp
master_node *instance = master_node::get_instance (...);
instance->m_stream = new cubstream::multi_thread_stream (...);
instance->m_stream_file = new cubstream::stream_file (...);
```
Correct destroy order will be:
```cpp
delete m_stream_file;
m_stream_file = NULL;
delete m_stream;
m_stream = NULL;
```