### PR TITLE
[CBRD-22972] fix qexec_execute_selupd_list operations

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -524,12 +524,12 @@ static int qexec_execute_merge (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_
 static int qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state);
 static int qexec_execute_obj_fetch (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
 				    SCAN_OPERATION_TYPE scan_operation_type);
-static int qexec_execute_increment (THREAD_ENTRY * thread_p, OID * oid, OID * class_oid, HFID * class_hfid,
-				    ATTR_ID attrid, int n_increment, int pruning_type, bool need_locking);
+static int qexec_execute_increment (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid,
+				    const HFID * class_hfid, ATTR_ID attrid, int n_increment, int pruning_type);
 static int qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state);
 static int qexec_execute_selupd_list_find_class (THREAD_ENTRY * thread_p, XASL_NODE * xasl, VAL_DESCR * vd, OID * oid,
-						 SELUPD_LIST * selupd, OID * class_oid, REFPTR (HFID, class_hfid),
-						 int *needs_pruning, bool * found);
+						 SELUPD_LIST * selupd, OID * class_oid, HFID * class_hfid,
+						 DB_CLASS_PARTITION_TYPE * needs_pruning, bool * found);
 static int qexec_start_connect_by_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state);
 static int qexec_update_connect_by_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
 					  QFILE_TUPLE_RECORD * tplrec);
@@ -12133,8 +12133,8 @@ exit_on_error:
  *   need_locking(in)	: true, if need locking
  */
 static int
-qexec_execute_increment (THREAD_ENTRY * thread_p, OID * oid, OID * class_oid, HFID * class_hfid, ATTR_ID attrid,
-			 int n_increment, int pruning_type, bool need_locking)
+qexec_execute_increment (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, const HFID * class_hfid,
+			 ATTR_ID attrid, int n_increment, int pruning_type)
 {
   HEAP_CACHE_ATTRINFO attr_info;
   int attr_info_inited = 0;
@@ -12187,10 +12187,11 @@ qexec_execute_increment (THREAD_ENTRY * thread_p, OID * oid, OID * class_oid, HF
 
       force_count = 0;
       /* oid was already locked in select phase */
+      OID copy_oid = *oid;
       error =
-	locator_attribute_info_force (thread_p, class_hfid, oid, &attr_info, &attrid, 1, area_op, op_type, &scan_cache,
-				      &force_count, false, REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL, NULL, NULL,
-				      UPDATE_INPLACE_NONE, NULL, need_locking);
+	locator_attribute_info_force (thread_p, class_hfid, &copy_oid, &attr_info, &attrid, 1, area_op, op_type,
+				      &scan_cache, &force_count, false, REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL,
+				      NULL, NULL, UPDATE_INPLACE_NONE, NULL, false);
       if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 	{
 	  assert (force_count == 0);
@@ -12250,8 +12251,8 @@ wrapup:
  */
 static int
 qexec_execute_selupd_list_find_class (THREAD_ENTRY * thread_p, XASL_NODE * xasl, VAL_DESCR * vd, OID * oid,
-				      SELUPD_LIST * selupd, OID * class_oid, REFPTR (HFID, class_hfid),
-				      int *needs_pruning, bool * found)
+				      SELUPD_LIST * selupd, OID * class_oid, HFID * class_hfid,
+				      DB_CLASS_PARTITION_TYPE * needs_pruning, bool * found)
 {
 
   OID class_oid_buf;
@@ -12263,7 +12264,7 @@ qexec_execute_selupd_list_find_class (THREAD_ENTRY * thread_p, XASL_NODE * xasl,
   if (!OID_EQ (&selupd->class_oid, &oid_Null_oid))
     {
       *class_oid = selupd->class_oid;
-      class_hfid = &selupd->class_hfid;
+      *class_hfid = selupd->class_hfid;
       *found = true;
       return NO_ERROR;
     }
@@ -12283,8 +12284,8 @@ qexec_execute_selupd_list_find_class (THREAD_ENTRY * thread_p, XASL_NODE * xasl,
 	  if (specp->type == TARGET_CLASS && OID_EQ (&specp->s.cls_node.cls_oid, class_oid))
 	    {
 	      *found = true;
-	      class_hfid = &specp->s.cls_node.hfid;
-	      *needs_pruning = specp->pruning_type;
+	      *class_hfid = specp->s.cls_node.hfid;
+	      *needs_pruning = (DB_CLASS_PARTITION_TYPE) specp->pruning_type;
 	      return NO_ERROR;
 	    }
 	  else if (specp->pruning_type)
@@ -12305,8 +12306,8 @@ qexec_execute_selupd_list_find_class (THREAD_ENTRY * thread_p, XASL_NODE * xasl,
 		  if (OID_EQ (&part_spec->oid, class_oid))
 		    {
 		      *found = true;
-		      class_hfid = &part_spec->hfid;
-		      *needs_pruning = specp->pruning_type;
+		      *class_hfid = part_spec->hfid;
+		      *needs_pruning = (DB_CLASS_PARTITION_TYPE) specp->pruning_type;
 		      return NO_ERROR;
 		    }
 		}
@@ -12343,28 +12344,42 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
   REGU_VARLIST_LIST outptr = NULL;
   REGU_VARIABLE *varptr = NULL;
   DB_VALUE *rightvalp = NULL, *thirdvalp = NULL;
-  CL_ATTR_ID attrid;
-  int n_increment;
-  int savepoint_used = 0;
-  OID *oid = NULL, *class_oid = NULL, class_oid_buf, last_cached_class_oid;
-  HFID *class_hfid = NULL;
+  bool savepoint_used = false;
+  bool submvcc_used = false;
+  OID last_cached_class_oid;
   int tran_index;
   int err = NO_ERROR;
-  int needs_pruning = DB_NOT_PARTITIONED_CLASS;
   HEAP_SCANCACHE scan_cache;
   bool scan_cache_inited = false;
   SCAN_CODE scan_code;
-  MVCC_INFO *curr_mvcc_info = NULL;
   LOG_TDES *tdes = NULL;
   UPDDEL_MVCC_COND_REEVAL upd_reev;
   MVCC_SCAN_REEV_DATA mvcc_sel_reev_data;
   MVCC_REEV_DATA mvcc_reev_data, *p_mvcc_reev_data = NULL;
   bool clear_list_id = false;
   MVCC_SNAPSHOT *mvcc_snapshot = logtb_get_mvcc_snapshot (thread_p);
-  bool need_locking;
+  bool need_ha_replication = !LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true;
+
+  struct incr_info
+  {
+    OID m_oid;
+    OID m_class_oid;
+    HFID m_class_hfid;
+    int m_attrid;
+    int m_n_increment;
+    DB_CLASS_PARTITION_TYPE m_ptype;
+
+      incr_info () = default;
+      incr_info (const incr_info & other) = default;
+  };
+  // *INDENT-OFF*
+  std::vector<incr_info> all_incr_info;
+  // *INDENT-ON*
 
   assert (xasl->list_id->tuple_cnt == 1);
   OID_SET_NULL (&last_cached_class_oid);
+
+  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 
   if (QEXEC_SEL_UPD_USE_REEVALUATION (xasl))
     {
@@ -12377,40 +12392,24 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 
       /* clear list id if all reevaluations result is false */
       clear_list_id = true;
+
+      /* need lock & reevaluation */
+      lock_start_instant_lock_mode (tran_index);
+    }
+  else
+    {
+      // locking and evaluation is done at scan phase
     }
 
   list = xasl->selected_upd_list;
 
-  /* in this function, several instances can be updated, so it need to be atomic */
-  log_sysop_start (thread_p);
-  savepoint_used = 1;
-
-  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  if (p_mvcc_reev_data)
-    {
-      /* need lock & reevaluation */
-      lock_start_instant_lock_mode (tran_index);
-    }
-
-  if (!LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true)
-    {
-      repl_start_flush_mark (thread_p);
-    }
-
-  tdes = LOG_FIND_TDES (LOG_FIND_THREAD_TRAN_INDEX (thread_p));
-  curr_mvcc_info = &tdes->mvccinfo;
-
-  if (logtb_get_new_subtransaction_mvccid (thread_p, curr_mvcc_info) != NO_ERROR)
-    {
-      goto exit_on_error;
-    }
-
   /* do increment operation */
   for (selupd = list; selupd; selupd = selupd->next)
     {
-      need_locking = false;
       for (outptr = selupd->select_list; outptr; outptr = outptr->next)
 	{
+	  incr_info crt_incr_info;
+
 	  if (outptr->list == NULL)
 	    {
 	      goto exit_on_error;
@@ -12434,14 +12433,14 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 	  /* get oid and attrid to be fetched last at scan */
 	  rightvalp = varptr->value.arithptr->value;
 
-	  oid = db_get_oid (rightvalp);
-	  if (oid == NULL)
+	  if (db_get_oid (rightvalp) == NULL)
 	    {
 	      /* Probably this would be INCR(NULL). When the source value is NULL, INCR/DECR expression is also NULL. */
 	      clear_list_id = false;
 	      continue;
 	    }
-	  if (OID_ISNULL (oid))
+	  crt_incr_info.m_oid = *db_get_oid (rightvalp);
+	  if (OID_ISNULL (&crt_incr_info.m_oid))
 	    {
 	      /* in some cases, a query returns no result even if it should have an result on dirty read mode. it may
 	       * be caused by index scan failure for index to be updated frequently (hot spot index). if this case is
@@ -12457,14 +12456,15 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 	    {
 	      goto exit_on_error;
 	    }
-	  attrid = db_get_int (thirdvalp);
+	  crt_incr_info.m_attrid = db_get_int (thirdvalp);
 
-	  n_increment = (varptr->value.arithptr->opcode == T_INCR ? 1 : -1);
+	  crt_incr_info.m_n_increment = (varptr->value.arithptr->opcode == T_INCR ? 1 : -1);
 
 	  /* check if class oid/hfid does not set, find class oid/hfid to access */
 	  bool found = false;
-	  err = qexec_execute_selupd_list_find_class (thread_p, xasl, &xasl_state->vd, oid, selupd, &class_oid_buf,
-						      class_hfid, &needs_pruning, &found);
+	  err = qexec_execute_selupd_list_find_class (thread_p, xasl, &xasl_state->vd, &crt_incr_info.m_oid, selupd,
+						      &crt_incr_info.m_class_oid, &crt_incr_info.m_class_hfid,
+						      &crt_incr_info.m_ptype, &found);
 	  if (err != NO_ERROR)
 	    {
 	      goto exit_on_error;
@@ -12477,12 +12477,10 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 	      goto exit_on_error;
 	    }
 
-	  class_oid = &class_oid_buf;
-
 	  if (p_mvcc_reev_data != NULL)
 	    {
 	      /* need locking and reevaluation */
-	      if (!OID_EQ (&last_cached_class_oid, class_oid) && scan_cache_inited == true)
+	      if (!OID_EQ (&last_cached_class_oid, &crt_incr_info.m_class_oid) && scan_cache_inited == true)
 		{
 		  (void) heap_scancache_end (thread_p, &scan_cache);
 		  scan_cache_inited = false;
@@ -12490,18 +12488,19 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 
 	      if (scan_cache_inited == false)
 		{
-		  if (heap_scancache_start (thread_p, &scan_cache, class_hfid, class_oid, false, false,
-					    mvcc_snapshot) != NO_ERROR)
+		  if (heap_scancache_start (thread_p, &scan_cache, &crt_incr_info.m_class_hfid,
+					    &crt_incr_info.m_class_oid, false, false, mvcc_snapshot) != NO_ERROR)
 		    {
 		      goto exit_on_error;
 		    }
 		  scan_cache_inited = true;
-		  COPY_OID (&last_cached_class_oid, class_oid);
+		  COPY_OID (&last_cached_class_oid, &crt_incr_info.m_class_oid);
 		}
 	      /* need to handle reevaluation */
 	      scan_code =
-		locator_lock_and_get_object_with_evaluation (thread_p, oid, class_oid, NULL, &scan_cache, COPY,
-							     NULL_CHN, p_mvcc_reev_data, LOG_WARNING_IF_DELETED);
+		locator_lock_and_get_object_with_evaluation (thread_p, &crt_incr_info.m_oid, &crt_incr_info.m_class_oid,
+							     NULL, &scan_cache, COPY, NULL_CHN, p_mvcc_reev_data,
+							     LOG_WARNING_IF_DELETED);
 	      if (scan_code != S_SUCCESS)
 		{
 		  int er_id = er_errid ();
@@ -12516,8 +12515,8 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 		      /* ignore lock timeout for click counter, and skip this increment operation */
 		      er_log_debug (ARG_FILE_LINE,
 				    "qexec_execute_selupd_list: lock(X_LOCK) timed out "
-				    "for OID { %d %d %d } class OID { %d %d %d }\n", oid->pageid, oid->slotid,
-				    oid->volid, class_oid->pageid, class_oid->slotid, class_oid->volid);
+				    "for OID { %d %d %d } class OID { %d %d %d }\n", OID_AS_ARGS (&crt_incr_info.m_oid),
+				    OID_AS_ARGS (&crt_incr_info.m_class_oid));
 		      er_clear ();
 		      continue;
 		    }
@@ -12530,8 +12529,9 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 		      /* simply, skip this increment operation */
 		      er_log_debug (ARG_FILE_LINE,
 				    "qexec_execute_selupd_list: skip for OID "
-				    "{ %d %d %d } class OID { %d %d %d } error_id %d\n", oid->pageid, oid->slotid,
-				    oid->volid, class_oid->pageid, class_oid->slotid, class_oid->volid, er_id);
+				    "{ %d %d %d } class OID { %d %d %d } error_id %d\n",
+				    OID_AS_ARGS (&crt_incr_info.m_oid), OID_AS_ARGS (&crt_incr_info.m_class_oid),
+				    er_id);
 
 		      continue;
 		    }
@@ -12541,8 +12541,8 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 		  /* simply, skip this increment operation */
 		  er_log_debug (ARG_FILE_LINE,
 				"qexec_execute_selupd_list: skip for OID "
-				"{ %d %d %d } class OID { %d %d %d } error_id %d\n", oid->pageid, oid->slotid,
-				oid->volid, class_oid->pageid, class_oid->slotid, class_oid->volid, NO_ERROR);
+				"{ %d %d %d } class OID { %d %d %d } error_id %d\n", OID_AS_ARGS (&crt_incr_info.m_oid),
+				OID_AS_ARGS (&crt_incr_info.m_class_oid), NO_ERROR);
 
 		  continue;
 		}
@@ -12555,16 +12555,46 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 	  else
 	    {
 	      /* already locked during scan phase */
-	      assert ((lock_get_object_lock (oid, class_oid, tran_index) == X_LOCK)
-		      || lock_get_object_lock (class_oid, oid_Root_class_oid, tran_index) >= X_LOCK);
+	      assert ((lock_get_object_lock (&crt_incr_info.m_oid, &crt_incr_info.m_class_oid, tran_index) == X_LOCK)
+		      || lock_get_object_lock (&crt_incr_info.m_class_oid, oid_Root_class_oid, tran_index) >= X_LOCK);
 	    }
 
-	  if (qexec_execute_increment (thread_p, oid, class_oid, class_hfid, attrid, n_increment, needs_pruning,
-				       need_locking) != NO_ERROR)
+	  all_incr_info.push_back (crt_incr_info);
+	}
+    }
+
+  if (lock_is_instant_lock_mode (tran_index))
+    {
+      /* in this function, several instances can be updated, so it need to be atomic */
+      log_sysop_start (thread_p);
+      savepoint_used = true;
+
+      if (need_ha_replication)
+	{
+	  repl_start_flush_mark (thread_p);
+	}
+
+      tdes = LOG_FIND_TDES (LOG_FIND_THREAD_TRAN_INDEX (thread_p));
+      assert (tdes != NULL);
+      if (logtb_get_new_subtransaction_mvccid (thread_p, &tdes->mvccinfo) != NO_ERROR)
+	{
+	  goto exit_on_error;
+	}
+      submvcc_used = true;
+    }
+
+  size_t index = 0;
+  for (selupd = list; selupd; selupd = selupd->next)
+    {
+      for (outptr = selupd->select_list; outptr; outptr = outptr->next)
+	{
+	  const incr_info & crt_incr_info = all_incr_info[index++];
+	  if (qexec_execute_increment (thread_p, &crt_incr_info.m_oid, &crt_incr_info.m_class_oid,
+				       &crt_incr_info.m_class_hfid, crt_incr_info.m_attrid, crt_incr_info.m_n_increment,
+				       crt_incr_info.m_ptype) != NO_ERROR)
 	    {
 	      goto exit_on_error;
 	    }
-	  need_locking = true;
 	}
     }
 
@@ -12574,24 +12604,21 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
       scan_cache_inited = false;
     }
 
-  if (!LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true)
-    {
-      repl_end_flush_mark (thread_p, false);
-    }
   if (savepoint_used)
     {
-      if (lock_is_instant_lock_mode (tran_index))
+      assert (lock_is_instant_lock_mode (tran_index));
+      if (need_ha_replication)
 	{
-	  log_sysop_commit (thread_p);
+	  repl_end_flush_mark (thread_p, false);
 	}
-      else
-	{
-	  log_sysop_attach_to_outer (thread_p);
-	}
+      log_sysop_commit (thread_p);
     }
 
 exit:
-  logtb_complete_sub_mvcc (thread_p, tdes);
+  if (submvcc_used)
+    {
+      logtb_complete_sub_mvcc (thread_p, tdes);
+    }
   lock_stop_instant_lock_mode (thread_p, tran_index, true);
 
   if (err != NO_ERROR)
@@ -12616,13 +12643,12 @@ exit_on_error:
       scan_cache_inited = false;
     }
 
-  if (!LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true)
-    {
-      repl_end_flush_mark (thread_p, true);
-    }
-
   if (savepoint_used)
     {
+      if (need_ha_replication)
+	{
+	  repl_end_flush_mark (thread_p, true);
+	}
       log_sysop_abort (thread_p);
     }
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -79,6 +79,8 @@
 #include "xasl_analytic.hpp"
 #include "xasl_predicate.hpp"
 
+#include <vector>
+
 // XASL_STATE
 typedef struct xasl_state XASL_STATE;
 struct xasl_state
@@ -12359,6 +12361,7 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
   bool clear_list_id = false;
   MVCC_SNAPSHOT *mvcc_snapshot = logtb_get_mvcc_snapshot (thread_p);
   bool need_ha_replication = !LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true;
+  size_t index = 0;
 
   // *INDENT-OFF*
   struct incr_info
@@ -12583,7 +12586,6 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
       submvcc_used = true;
     }
 
-  size_t index = 0;
   for (selupd = list; selupd; selupd = selupd->next)
     {
       for (outptr = selupd->select_list; outptr; outptr = outptr->next)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -12360,6 +12360,7 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
   MVCC_SNAPSHOT *mvcc_snapshot = logtb_get_mvcc_snapshot (thread_p);
   bool need_ha_replication = !LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true;
 
+  // *INDENT-OFF*
   struct incr_info
   {
     OID m_oid;
@@ -12369,10 +12370,9 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
     int m_n_increment;
     DB_CLASS_PARTITION_TYPE m_ptype;
 
-      incr_info () = default;
-      incr_info (const incr_info & other) = default;
+    incr_info () = default;
+    incr_info (const incr_info & other) = default;
   };
-  // *INDENT-OFF*
   std::vector<incr_info> all_incr_info;
   // *INDENT-ON*
 

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -950,10 +950,9 @@ prior_lsa_gen_undoredo_record_from_crumbs (THREAD_ENTRY *thread_p, LOG_PRIOR_NOD
 	}
       else
 	{
-	  if (tdes->mvccinfo.count_sub_ids > 0 && tdes->mvccinfo.is_sub_active)
+	  if (!tdes->mvccinfo.sub_ids.empty ())
 	    {
-	      assert (tdes->mvccinfo.sub_ids != NULL);
-	      *mvccid_p = tdes->mvccinfo.sub_ids[tdes->mvccinfo.count_sub_ids - 1];
+	      *mvccid_p = tdes->mvccinfo.sub_ids.back ();
 	    }
 	  else
 	    {

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -997,7 +997,7 @@ extern MVCCID logtb_get_oldest_active_mvccid (THREAD_ENTRY * thread_p);
 extern LOG_PAGEID logpb_find_oldest_available_page_id (THREAD_ENTRY * thread_p);
 extern int logpb_find_oldest_available_arv_num (THREAD_ENTRY * thread_p);
 
-extern int logtb_get_new_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_INFO * curr_mvcc_info);
+extern void logtb_get_new_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_INFO * curr_mvcc_info);
 
 extern MVCCID logtb_find_current_mvccid (THREAD_ENTRY * thread_p);
 extern MVCCID logtb_get_current_mvccid (THREAD_ENTRY * thread_p);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -136,7 +136,7 @@ static int logtb_global_unique_stat_init (void *unique_stat);
 static int logtb_global_unique_stat_key_copy (void *src, void *dest);
 static void logtb_free_tran_mvcc_info (LOG_TDES * tdes);
 
-static int logtb_assign_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_INFO * curr_mvcc_info, MVCCID mvcc_subid);
+static void logtb_assign_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_INFO * curr_mvcc_info, MVCCID mvcc_subid);
 
 static int logtb_check_kill_tran_auth (THREAD_ENTRY * thread_p, int tran_id, bool * has_authorization);
 static void logtb_find_thread_entry_mapfunc (THREAD_ENTRY & thread_ref, bool & stop_mapper, int tran_index,
@@ -1469,12 +1469,7 @@ logtb_free_tran_mvcc_info (LOG_TDES * tdes)
   MVCC_INFO *curr_mvcc_info = &tdes->mvccinfo;
 
   curr_mvcc_info->snapshot.m_active_mvccs.finalize ();
-
-  if (curr_mvcc_info->sub_ids != NULL)
-    {
-      free_and_init (curr_mvcc_info->sub_ids);
-      curr_mvcc_info->count_sub_ids = 0;
-    }
+  curr_mvcc_info->sub_ids.clear ();
 }
 
 /*
@@ -3908,10 +3903,9 @@ logtb_find_current_mvccid (THREAD_ENTRY * thread_p)
   tdes = LOG_FIND_TDES (LOG_FIND_THREAD_TRAN_INDEX (thread_p));
   if (tdes != NULL)
     {
-      if (tdes->mvccinfo.count_sub_ids > 0 && tdes->mvccinfo.is_sub_active)
+      if (!tdes->mvccinfo.sub_ids.empty ())
 	{
-	  assert (tdes->mvccinfo.sub_ids != NULL);
-	  id = tdes->mvccinfo.sub_ids[tdes->mvccinfo.count_sub_ids - 1];
+	  id = tdes->mvccinfo.sub_ids.back ();
 	}
       else
 	{
@@ -3947,10 +3941,9 @@ logtb_get_current_mvccid (THREAD_ENTRY * thread_p)
       curr_mvcc_info->id = log_Gl.mvcc_table.get_new_mvccid ();
     }
 
-  if (tdes->mvccinfo.count_sub_ids > 0 && tdes->mvccinfo.is_sub_active)
+  if (!tdes->mvccinfo.sub_ids.empty ())
     {
-      assert (tdes->mvccinfo.sub_ids != NULL);
-      return tdes->mvccinfo.sub_ids[tdes->mvccinfo.count_sub_ids - 1];
+      return tdes->mvccinfo.sub_ids.back ();
     }
 
   return curr_mvcc_info->id;
@@ -3969,7 +3962,6 @@ logtb_is_current_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid)
 {
   LOG_TDES *tdes = LOG_FIND_TDES (LOG_FIND_THREAD_TRAN_INDEX (thread_p));
   MVCC_INFO *curr_mvcc_info;
-  int i;
 
   assert (tdes != NULL);
 
@@ -3978,12 +3970,9 @@ logtb_is_current_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid)
     {
       return true;
     }
-  else if (curr_mvcc_info->count_sub_ids > 0)
+  else if (curr_mvcc_info->sub_ids.size () > 0)
     {
-      /* is the child of current transaction ? */
-      assert (curr_mvcc_info->sub_ids != NULL);
-
-      for (i = 0; i < curr_mvcc_info->count_sub_ids; i++)
+      for (size_t i = 0; i < curr_mvcc_info->sub_ids.size (); i++)
 	{
 	  if (curr_mvcc_info->sub_ids[i] == mvccid)
 	    {
@@ -4577,7 +4566,7 @@ logtb_has_deadlock_priority (int tran_index)
  *  Note: If transaction MVCCID is NULL then a new transaction MVCCID is
  *    allocated first.
  */
-int
+void
 logtb_get_new_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_INFO * curr_mvcc_info)
 {
   MVCCID mvcc_subid;
@@ -4597,7 +4586,7 @@ logtb_get_new_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_INFO * curr_m
       mvcc_table->get_two_new_mvccid (curr_mvcc_info->id, mvcc_subid);
     }
 
-  return logtb_assign_subtransaction_mvccid (thread_p, curr_mvcc_info, mvcc_subid);
+  logtb_assign_subtransaction_mvccid (thread_p, curr_mvcc_info, mvcc_subid);
 }
 
 /*
@@ -4608,41 +4597,12 @@ logtb_get_new_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_INFO * curr_m
  * curr_mvcc_info (in) : Current transaction MVCC information.
  * mvcc_subid (in)     : Sub-transaction MVCCID.
  */
-static int
+static void
 logtb_assign_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_INFO * curr_mvcc_info, MVCCID mvcc_subid)
 {
   assert (curr_mvcc_info != NULL);
   assert (MVCCID_IS_VALID (curr_mvcc_info->id));
-
-  if (curr_mvcc_info->sub_ids == NULL)
-    {
-      curr_mvcc_info->sub_ids = (MVCCID *) malloc (OR_MVCCID_SIZE * 10);
-      if (curr_mvcc_info->sub_ids == NULL)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (MVCCID) * 10);
-	  return ER_OUT_OF_VIRTUAL_MEMORY;
-	}
-      curr_mvcc_info->count_sub_ids = 0;
-      curr_mvcc_info->max_sub_ids = 10;
-    }
-  else if (curr_mvcc_info->count_sub_ids >= curr_mvcc_info->max_sub_ids)
-    {
-      curr_mvcc_info->sub_ids =
-	(MVCCID *) realloc (curr_mvcc_info->sub_ids, OR_MVCCID_SIZE * (curr_mvcc_info->max_sub_ids + 10));
-      if (curr_mvcc_info->sub_ids == NULL)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
-		  (size_t) (OR_MVCCID_SIZE * (curr_mvcc_info->max_sub_ids + 10)));
-	  return ER_OUT_OF_VIRTUAL_MEMORY;
-	}
-      curr_mvcc_info->max_sub_ids += 10;
-    }
-
-  curr_mvcc_info->sub_ids[curr_mvcc_info->count_sub_ids] = mvcc_subid;
-  curr_mvcc_info->count_sub_ids++;
-  curr_mvcc_info->is_sub_active = true;
-
-  return NO_ERROR;
+  curr_mvcc_info->sub_ids.push_back (mvcc_subid);
 }
 
 /*
@@ -4662,11 +4622,11 @@ logtb_complete_sub_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   assert (tdes != NULL);
 
   curr_mvcc_info = &tdes->mvccinfo;
-  mvcc_sub_id = curr_mvcc_info->sub_ids[curr_mvcc_info->count_sub_ids - 1];
+  mvcc_sub_id = curr_mvcc_info->sub_ids.back ();
 
   mvcc_table->complete_sub_mvcc (mvcc_sub_id);
+  curr_mvcc_info->sub_ids.pop_back ();
 
-  curr_mvcc_info->is_sub_active = false;
   if (tdes->mvccinfo.snapshot.valid)
     {
       /* adjust snapshot to reflect committed sub-transaction, since the parent transaction didn't finished yet */

--- a/src/transaction/mvcc.c
+++ b/src/transaction/mvcc.c
@@ -678,10 +678,7 @@ mvcc_info::mvcc_info ()
   : snapshot ()
   , id (MVCCID_NULL)
   , recent_snapshot_lowest_active_mvccid (MVCCID_NULL)
-  , sub_ids (NULL)
-  , max_sub_ids (0)
-  , count_sub_ids (0)
-  , is_sub_active (false)
+  , sub_ids ()
 {
 }
 
@@ -697,7 +694,6 @@ mvcc_info::reset ()
   snapshot.reset ();
   id = MVCCID_NULL;
   recent_snapshot_lowest_active_mvccid = MVCCID_NULL;
-  count_sub_ids = 0;
-  is_sub_active = false;
+  sub_ids.clear ();
 }
 // *INDENT-ON*

--- a/src/transaction/mvcc.h
+++ b/src/transaction/mvcc.h
@@ -32,6 +32,8 @@
 #include "storage_common.h"
 #include "thread_compat.hpp"
 
+#include <vector>
+
 /* MVCC RECORD HEADER */
 typedef struct mvcc_rec_header MVCC_REC_HEADER;
 struct mvcc_rec_header
@@ -200,9 +202,9 @@ struct mvcc_info
    * are not active anymore */
   MVCCID recent_snapshot_lowest_active_mvccid;
 
-  MVCCID *sub_ids;		/* MVCC sub-transaction ID array */
-  int max_sub_ids;		/* allocated MVCC sub-transaction ids */
-  int count_sub_ids;		/* count sub-transaction ids */
+  // *INDENT-OFF*
+  std::vector<MVCCID> sub_ids;		/* MVCC sub-transaction ID array */
+  // *INDENT-ON*
   bool is_sub_active;		/* true in case that sub-transaction is running */
 
   // *INDENT-OFF*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22972

### Issue

qexec_execute_selupd_list is used to do fast click counter operations; changes are locked/unlocked and committed immediately. If one of the rows impacted by click counter was previously locked, modified rows are no longer unlocked and changes are not immediately committed, however complete sub-mvcc is still executed (but shouldn't).

The "instant" locking is forcefully disabled by lock manager. An operation reordering is required to correctly handle the case - first lock all to-be-modified rows, then check that instant locking was not disabled and only then decide to use system operation and sub-mvcc to make the changes.

### Changes

1. run two loops on selupd list: in the first iteration collect increment info and lock objects; on the second iteration call qexec_execute_increment. information relevant for both loops is saved to an incr_info and collected into a vector (some local variables have been replaced).
2. after first iteration, open a system operation, call repl_start_flush_mark and assign subtransaction mvccid only if instant locking is still enabled; none of these operations are executed if instant locking is disabled (this is different from previous behavior).
3. on end, if savepoint_used is true, `lock_is_instant_lock_mode (tran_index) == true` is expected; it is never attached to outer
4. logtb_complete_sub_mvcc is called only if submvcc_used is true
5. remove need_locking variable/argument; objects are always locked prior calling qexec_execute_increment