### PR TITLE
[CBRD-22977] scan cache area block allocator

### DIFF
--- a/src/base/mem_block.cpp
+++ b/src/base/mem_block.cpp
@@ -180,7 +180,7 @@ namespace cubmem
   }
 
   const block_allocator &
-  single_block_allocator::get_allocator () const
+  single_block_allocator::get_block_allocator () const
   {
     return m_allocator;
   }
@@ -201,6 +201,12 @@ namespace cubmem
   single_block_allocator::get_size () const
   {
     return m_block.dim;
+  }
+
+  void
+  single_block_allocator::reserve (size_t size)
+  {
+    m_base_allocator.m_alloc_f (m_block, size);
   }
 
 } // namespace cubmem

--- a/src/base/mem_block.cpp
+++ b/src/base/mem_block.cpp
@@ -142,4 +142,65 @@ namespace cubmem
     m_dealloc_f = other.m_dealloc_f;
     return *this;
   }
+
+  //
+  // single_block_allocator
+  //
+
+  single_block_allocator::single_block_allocator (const block_allocator &base_alloc)
+    : m_base_allocator (base_alloc)
+    , m_block {}
+    , m_allocator { std::bind (&single_block_allocator::allocate, this, std::placeholders::_1, std::placeholders::_2),
+		    std::bind (&single_block_allocator::deallocate, this, std::placeholders::_1) }
+  {
+  }
+
+  single_block_allocator::~single_block_allocator ()
+  {
+    m_base_allocator.m_dealloc_f (m_block);
+  }
+
+  void
+  single_block_allocator::allocate (block &b, size_t size)
+  {
+    // argument should be uninitialized or should be same as m_block; giving a different block may be a logical error
+    assert (b.ptr == NULL || (b.ptr == m_block.ptr && b.dim == m_block.dim));
+
+    m_base_allocator.m_alloc_f (m_block, size);
+    b.ptr = m_block.ptr;
+    b.dim = m_block.dim;
+  }
+
+  void
+  single_block_allocator::deallocate (block &b)
+  {
+    // local block remains
+    b.ptr = NULL;
+    b.dim = 0;
+  }
+
+  const block_allocator &
+  single_block_allocator::get_allocator () const
+  {
+    return m_allocator;
+  }
+
+  const block &
+  single_block_allocator::get_block() const
+  {
+    return m_block;
+  }
+
+  char *
+  single_block_allocator::get_ptr () const
+  {
+    return m_block.ptr;
+  }
+
+  size_t
+  single_block_allocator::get_size () const
+  {
+    return m_block.dim;
+  }
+
 } // namespace cubmem

--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -127,7 +127,7 @@ namespace cubmem
       single_block_allocator (const block_allocator &base_alloc);
       ~single_block_allocator ();
 
-      const block_allocator &get_block_allocator () const;
+      const block_allocator &get_block_allocator () const;   // a block allocator that always outputs m_block
       const block &get_block () const;
 
       char *get_ptr () const;
@@ -137,13 +137,13 @@ namespace cubmem
 
     private:
 
-      void allocate (block &b, size_t size);
+      void allocate (block &b, size_t size);  // the output b will be always equal to m_block
       void deallocate (block &b);
 
-      const block_allocator &m_base_allocator;
+      const block_allocator &m_base_allocator;    // allocator for m_block
 
-      block m_block;
-      block_allocator m_allocator;
+      block m_block;                              // the single block
+      block_allocator m_allocator;                // allocator that always outputs m_block
   };
 
   /* Memory Block - Extensible

--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -120,11 +120,13 @@ namespace cubmem
       single_block_allocator (const block_allocator &base_alloc);
       ~single_block_allocator ();
 
-      const block_allocator &get_allocator () const;
+      const block_allocator &get_block_allocator () const;
       const block &get_block () const;
 
       char *get_ptr () const;
       size_t get_size () const;
+
+      void reserve (size_t size);
 
     private:
 

--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -114,6 +114,13 @@ namespace cubmem
   extern const block_allocator EXPONENTIAL_STANDARD_BLOCK_ALLOCATOR;
   extern const block_allocator CSTYLE_BLOCK_ALLOCATOR;
 
+  // single_block_allocator - maintains and allocates a single memory block
+  //
+  // it is designed as a memory cache that can be reused for multiple purposes in multiple places. must be used with
+  // care because it doesn't guarantee exclusive access to memory
+  //
+  // use get_block_allocator to pass the cached memory block to structures like extensible_buffer
+  //
   class single_block_allocator
   {
     public:

--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -114,6 +114,29 @@ namespace cubmem
   extern const block_allocator EXPONENTIAL_STANDARD_BLOCK_ALLOCATOR;
   extern const block_allocator CSTYLE_BLOCK_ALLOCATOR;
 
+  class single_block_allocator
+  {
+    public:
+      single_block_allocator (const block_allocator &base_alloc);
+      ~single_block_allocator ();
+
+      const block_allocator &get_allocator () const;
+      const block &get_block () const;
+
+      char *get_ptr () const;
+      size_t get_size () const;
+
+    private:
+
+      void allocate (block &b, size_t size);
+      void deallocate (block &b);
+
+      const block_allocator &m_base_allocator;
+
+      block m_block;
+      block_allocator m_allocator;
+  };
+
   /* Memory Block - Extensible
    * - able to extend/reallocate to accommodate additional bytes
    * - owns the memory by default and it will free the memory in destructor unless it is moved:

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24621,7 +24621,7 @@ heap_scancache_block_allocate (cubmem::block &b, size_t size)
       size = DB_ALIGN (size, (size_t) DB_PAGESIZE);
     }
 
-  if (b.ptr != NULL && b.dim > size)
+  if (b.ptr != NULL && b.dim >= size)
     {
       // no need to change
       return;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24656,6 +24656,15 @@ heap_scancache::start_area ()
 }
 
 void
+heap_scancache::alloc_area ()
+{
+  if (m_area == NULL)
+    {
+      m_area = new cubmem::single_block_allocator (HEAP_SCANCACHE_BLOCK_ALLOCATOR);
+    }
+}
+
+void
 heap_scancache::end_area ()
 {
   delete m_area;
@@ -24665,10 +24674,7 @@ heap_scancache::end_area ()
 void
 heap_scancache::reserve_area (size_t size)
 {
-  if (m_area == NULL)
-    {
-      m_area = new cubmem::single_block_allocator (HEAP_SCANCACHE_BLOCK_ALLOCATOR);
-    }
+  alloc_area ();
   m_area->reserve (size);
 }
 
@@ -24685,6 +24691,13 @@ bool
 heap_scancache::is_recdes_assigned_to_area (const RECDES & recdes) const
 {
   return m_area != NULL && recdes.data == m_area->get_ptr ();
+}
+
+const cubmem::block_allocator &
+heap_scancache::get_area_block_allocator ()
+{
+  alloc_area ();
+  return m_area->get_block_allocator ();
 }
 
 // *INDENT-ON*

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -36,7 +36,6 @@
 
 #include "heap_file.h"
 
-#include "mem_block.hpp"
 #include "porting.h"
 #include "porting_inline.hpp"
 #include "record_descriptor.hpp"

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -18656,8 +18656,8 @@ heap_get_bigone_content (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, b
   SCAN_CODE scan = S_SUCCESS;
 
   /* Try to reuse the previously allocated area No need to check the snapshot since was already checked */
-  if (scan_cache != NULL && (ispeeking == PEEK || recdes->data == NULL
-			     || scan_cache->is_recdes_assigned_to_area (*recdes)))
+  if (scan_cache != NULL
+      && (ispeeking == PEEK || recdes->data == NULL || scan_cache->is_recdes_assigned_to_area (*recdes)))
     {
       scan_cache->assign_recdes_to_area (*recdes);
 
@@ -23910,7 +23910,7 @@ heap_get_visible_version_from_log (THREAD_ENTRY * thread_p, RECDES * recdes, LOG
 	    {
 	      /* expand record area and try again */
 	      assert (recdes->length < 0);
-	      scan_cache->assign_recdes_to_area (*recdes, (size_t) - recdes->length);
+	      scan_cache->assign_recdes_to_area (*recdes, (size_t) (-recdes->length));
 	      /* final try to get the undo record */
 	      continue;
 	    }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -877,7 +877,8 @@ STATIC_INLINE int heap_get_last_vpid (THREAD_ENTRY * thread_p, const HFID * hfid
 static void heap_scancache_block_allocate (cubmem::block &b, size_t size);
 static void heap_scancache_block_deallocate (cubmem::block &b);
 
-static const cubmem::block_allocator HEAP_SCANCACHE_BLOCK_ALLOCATOR { heap_scancache_block_allocate, heap_scancache_block_deallocate };
+static const cubmem::block_allocator HEAP_SCANCACHE_BLOCK_ALLOCATOR =
+  { heap_scancache_block_allocate, heap_scancache_block_deallocate };
 // *INDENT-ON*
 
 /*

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -138,36 +138,37 @@ struct heap_scancache_node_list
 typedef struct heap_scancache HEAP_SCANCACHE;
 struct heap_scancache
 {				/* Define a scan over the whole heap file */
-public:
-  int debug_initpattern;	/* A pattern which indicates that the structure has been initialized */
-  HEAP_SCANCACHE_NODE node;	/* current scanned heap file information */
-  LOCK page_latch;		/* Indicates the latch/lock to be acquired on heap pages. Its value may be NULL_LOCK
+  public:
+    int debug_initpattern;	/* A pattern which indicates that the structure has been initialized */
+    HEAP_SCANCACHE_NODE node;	/* current scanned heap file information */
+    LOCK page_latch;		/* Indicates the latch/lock to be acquired on heap pages. Its value may be NULL_LOCK
 				 * when it is secure to skip lock on heap pages. For example, the class of the heap has
 				 * been locked with either S_LOCK, SIX_LOCK, or X_LOCK */
-  bool cache_last_fix_page;	/* Indicates if page buffers and memory are cached (left fixed) */
-  PGBUF_WATCHER page_watcher;
-  int num_btids;		/* Total number of indexes defined on the scanning class */
-  multi_index_unique_stats *m_index_stats;	// does this really belong to scan cache??
-  FILE_TYPE file_type;		/* The file type of the heap file being scanned. Can be FILE_HEAP or
-				 * FILE_HEAP_REUSE_SLOTS */
-  MVCC_SNAPSHOT *mvcc_snapshot;	/* mvcc snapshot */
-  HEAP_SCANCACHE_NODE_LIST *partition_list;	/* list holding the heap file information for partition nodes involved
+    bool cache_last_fix_page;	/* Indicates if page buffers and memory are cached (left fixed) */
+    PGBUF_WATCHER page_watcher;
+    int num_btids;		/* Total number of indexes defined on the scanning class */
+    multi_index_unique_stats *m_index_stats;	// does this really belong to scan cache??
+    FILE_TYPE file_type;		/* The file type of the heap file being scanned. Can be FILE_HEAP or
+				         * FILE_HEAP_REUSE_SLOTS */
+    MVCC_SNAPSHOT *mvcc_snapshot;	/* mvcc snapshot */
+    HEAP_SCANCACHE_NODE_LIST *partition_list;	/* list holding the heap file information for partition nodes involved
 						 * in the scan */
 
 
-  void start_area ();
-  void end_area ();
-  void reserve_area (size_t size = 0);
-  void assign_recdes_to_area (RECDES & recdes, size_t size = 0);
-  bool is_recdes_assigned_to_area (const RECDES & recdes) const;
-  const cubmem::block_allocator &get_area_block_allocator ();
+    void start_area ();
+    void end_area ();
+    void reserve_area (size_t size = 0);
+    void assign_recdes_to_area (RECDES & recdes, size_t size = 0);
+    bool is_recdes_assigned_to_area (const RECDES & recdes) const;
+    const cubmem::block_allocator &get_area_block_allocator ();
 
-private:
-  // todo - add constructor/destructor; should automatically call heap_scancache_end on destructor if started
+    // todo - add constructor/destructor; should automatically call heap_scancache_end on destructor if started
 
-  void alloc_area ();
+  private:
 
-  cubmem::single_block_allocator * m_area;
+    void alloc_area ();
+
+    cubmem::single_block_allocator * m_area;
 };
 // *INDENT-ON*
 

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -43,6 +43,13 @@
 // forward declarations
 class multi_index_unique_stats;
 class record_descriptor;
+// *INDENT-OFF*
+namespace cubmem
+{
+  struct block_allocator;
+  class single_block_allocator;
+} // namespace cubmem
+// *INDENT-ON*
 
 #define HFID_EQ(hfid_ptr1, hfid_ptr2) \
   ((hfid_ptr1) == (hfid_ptr2) \
@@ -133,7 +140,7 @@ struct heap_scancache_node_list
   HEAP_SCANCACHE_NODE_LIST *next;
 };
 
-// *IDENT-OFF*
+// *INDENT-OFF*
 typedef struct heap_scancache HEAP_SCANCACHE;
 struct heap_scancache
 {				/* Define a scan over the whole heap file */
@@ -159,11 +166,14 @@ public:
   void reserve_area (size_t size = 0);
   void assign_recdes_to_area (RECDES & recdes, size_t size = 0);
   bool is_recdes_assigned_to_area (const RECDES & recdes) const;
+  const cubmem::block_allocator &get_area_block_allocator ();
 
 private:
-  // todo - add constructor/destructor; should automatically call heap_scancache_end on destructor if started.
+  // todo - add constructor/destructor; should automatically call heap_scancache_end on destructor if started
 
-    cubmem::single_block_allocator * m_area;
+  void alloc_area ();
+
+  cubmem::single_block_allocator * m_area;
 };
 // *INDENT-ON*
 

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -133,9 +133,11 @@ struct heap_scancache_node_list
   HEAP_SCANCACHE_NODE_LIST *next;
 };
 
+// *IDENT-OFF*
 typedef struct heap_scancache HEAP_SCANCACHE;
 struct heap_scancache
 {				/* Define a scan over the whole heap file */
+public:
   int debug_initpattern;	/* A pattern which indicates that the structure has been initialized */
   HEAP_SCANCACHE_NODE node;	/* current scanned heap file information */
   LOCK page_latch;		/* Indicates the latch/lock to be acquired on heap pages. Its value may be NULL_LOCK
@@ -143,8 +145,6 @@ struct heap_scancache
 				 * been locked with either S_LOCK, SIX_LOCK, or X_LOCK */
   bool cache_last_fix_page;	/* Indicates if page buffers and memory are cached (left fixed) */
   PGBUF_WATCHER page_watcher;
-  char *area;			/* Pointer to last left fixed memory allocated */
-  int area_size;		/* Size of allocated area */
   int num_btids;		/* Total number of indexes defined on the scanning class */
   multi_index_unique_stats *m_index_stats;	// does this really belong to scan cache??
   FILE_TYPE file_type;		/* The file type of the heap file being scanned. Can be FILE_HEAP or
@@ -152,7 +152,20 @@ struct heap_scancache
   MVCC_SNAPSHOT *mvcc_snapshot;	/* mvcc snapshot */
   HEAP_SCANCACHE_NODE_LIST *partition_list;	/* list holding the heap file information for partition nodes involved
 						 * in the scan */
+
+
+  void start_area ();
+  void end_area ();
+  void reserve_area (size_t size = 0);
+  void assign_recdes_to_area (RECDES & recdes, size_t size = 0);
+  bool is_recdes_assigned_to_area (const RECDES & recdes) const;
+
+private:
+  // todo - add constructor/destructor; should automatically call heap_scancache_end on destructor if started.
+
+    cubmem::single_block_allocator * m_area;
 };
+// *INDENT-ON*
 
 typedef struct heap_scanrange HEAP_SCANRANGE;
 struct heap_scanrange

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -34,6 +34,7 @@
 #include "config.h"
 #include "file_manager.h"
 #include "heap_attrinfo.h"
+#include "mem_block.hpp"
 #include "mvcc.h"
 #include "page_buffer.h"
 #include "perf_monitor.h"
@@ -43,13 +44,6 @@
 // forward declarations
 class multi_index_unique_stats;
 class record_descriptor;
-// *INDENT-OFF*
-namespace cubmem
-{
-  struct block_allocator;
-  class single_block_allocator;
-} // namespace cubmem
-// *INDENT-ON*
 
 #define HFID_EQ(hfid_ptr1, hfid_ptr2) \
   ((hfid_ptr1) == (hfid_ptr2) \


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22977

The functionality around heap_scancache->area/area_size was rewritten using memory block and block allocator.

The heap scan cache area is designed to be reused for multiple heap operations and it is set to multiple record descriptors in this process. The reusing of a single block of memory for various operations was rewritten as *single_block_allocator*, a structure that maintains a single block and that provides an allocator that always returns this block.

For heap, this is specialized with a HEAP_SCANCACHE_BLOCK_ALLOCATOR.