### PR TITLE
[CBRD-22944] log_consumer does not receive GROUP_COMMIT stream_entry

### DIFF
--- a/src/replication/log_generator.cpp
+++ b/src/replication/log_generator.cpp
@@ -386,6 +386,12 @@ namespace cubreplication
 
     set_tran_repl_info (state);
     pack_stream_entry ();
+
+    /* TODO[replication] : force a group commit :
+     * move this to log_manager group commit when multi-threaded apply is enabled */
+    cubstream::stream_position sp1;
+    cubstream::stream_position sp2;    
+    pack_group_commit_entry (sp1, sp2);
   }
 
   void


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22944

Old Stream entry containing with stream_entry_header::TRAN_STATE::GROUP_COMMIT is needed from log_consumer to execute apply tasks.  
Quick fix: undo removing until properly adopting the stream entry for group commit into log_consumer.