### PR TITLE
[CBRD-22978] New locator function specialized on inserting multiple records

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24741,7 +24741,7 @@ heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, OID class_oid, PGBUF_
 int
 heap_nonheader_page_capacity ()
 {
-  return spage_get_default_size () - sizeof (SPAGE_HEADER) - sizeof (HEAP_CHAIN);
+  return spage_max_record_size () - sizeof (HEAP_CHAIN);
 }
 
 // *INDENT-ON*

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24708,6 +24708,8 @@ heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, PGBUF_WATCHER * home_
   VPID vpid;
   PAGE_PTR page_ptr;
 
+  assert (hfid != NULL && home_hint_p != NULL && new_page_vpid != NULL);
+
   PGBUF_INIT_WATCHER (home_hint_p, PGBUF_ORDERED_HEAP_NORMAL, hfid);
   
   // Alloc a new page.
@@ -24730,9 +24732,9 @@ heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, PGBUF_WATCHER * home_
 }
 
 int
-heap_get_default_empty_page_size ()
+heap_nonheader_page_capacity ()
 {
-  return SPAGE_DB_PAGESIZE - sizeof (SPAGE_HEADER) - sizeof (HEAP_CHAIN);
+  return spage_get_default_size () - sizeof (SPAGE_HEADER) - sizeof (HEAP_CHAIN);
 }
 
 // *INDENT-ON*

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24729,4 +24729,10 @@ heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, PGBUF_WATCHER * home_
   return error_code;
 }
 
+int
+heap_get_default_empty_page_size ()
+{
+  return SPAGE_DB_PAGESIZE - sizeof (SPAGE_HEADER) - sizeof (HEAP_CHAIN);
+}
+
 // *INDENT-ON*

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -673,6 +673,6 @@ extern bool heap_is_page_header (THREAD_ENTRY * thread_p, PAGE_PTR page);
 extern int heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, PGBUF_WATCHER * home_hint_p,
 				VPID * new_page_vpid);
 
-extern int heap_get_default_empty_page_size ();
+extern int heap_nonheader_page_capacity ();
 
 #endif /* _HEAP_FILE_H_ */

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -670,7 +670,7 @@ extern int heap_get_hfid_from_vfid (THREAD_ENTRY * thread_p, const VFID * vfid, 
 extern int heap_scan_cache_allocate_area (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache_p, int size);
 extern bool heap_is_page_header (THREAD_ENTRY * thread_p, PAGE_PTR page);
 
-extern int heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, PGBUF_WATCHER * home_hint_p,
+extern int heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, OID class_oid, PGBUF_WATCHER * home_hint_p,
 				VPID * new_page_vpid);
 
 extern int heap_nonheader_page_capacity ();

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -605,7 +605,7 @@ extern void heap_create_delete_context (HEAP_OPERATION_CONTEXT * context, HFID *
 					HEAP_SCANCACHE * scancache_p);
 extern void heap_create_update_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID * oid_p, OID * class_oid_p,
 					RECDES * recdes_p, HEAP_SCANCACHE * scancache_p, UPDATE_INPLACE_STYLE in_place);
-extern int heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);
+extern int heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, PGBUF_WATCHER * home_hint_p);
 extern int heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);
 extern int heap_update_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);
 
@@ -651,4 +651,9 @@ extern int heap_get_best_space_num_stats_entries (void);
 extern int heap_get_hfid_from_vfid (THREAD_ENTRY * thread_p, const VFID * vfid, HFID * hfid);
 extern int heap_scan_cache_allocate_area (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache_p, int size);
 extern bool heap_is_page_header (THREAD_ENTRY * thread_p, PAGE_PTR page);
+
+extern int heap_multi_insert_with_page_hint (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid,
+					     OID ** oid, std::vector < RECDES > recdes, HEAP_SCANCACHE * scan_cache,
+					     UPDATE_INPLACE_STYLE force_in_place, VPID * new_vpid);
+
 #endif /* _HEAP_FILE_H_ */

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -670,8 +670,7 @@ extern int heap_get_hfid_from_vfid (THREAD_ENTRY * thread_p, const VFID * vfid, 
 extern int heap_scan_cache_allocate_area (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache_p, int size);
 extern bool heap_is_page_header (THREAD_ENTRY * thread_p, PAGE_PTR page);
 
-extern int heap_multi_insert_with_page_hint (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid,
-					     OID ** oid, std::vector < RECDES > recdes, HEAP_SCANCACHE * scan_cache,
-					     UPDATE_INPLACE_STYLE force_in_place, VPID * new_vpid);
+extern int heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, PGBUF_WATCHER * home_hint_p,
+				VPID * new_page_vpid);
 
 #endif /* _HEAP_FILE_H_ */

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -673,4 +673,6 @@ extern bool heap_is_page_header (THREAD_ENTRY * thread_p, PAGE_PTR page);
 extern int heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, PGBUF_WATCHER * home_hint_p,
 				VPID * new_page_vpid);
 
+extern int heap_get_default_empty_page_size ();
+
 #endif /* _HEAP_FILE_H_ */

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -5283,9 +5283,3 @@ spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
 
   return false;
 }
-
-int
-spage_get_default_empty_page_size ()
-{
-  return SPAGE_DB_PAGESIZE - sizeof (SPAGE_HEADER);
-}

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -5283,3 +5283,9 @@ spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
 
   return false;
 }
+
+int
+spage_get_default_empty_page_size ()
+{
+  return SPAGE_DB_PAGESIZE - sizeof (SPAGE_HEADER);
+}

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -5283,3 +5283,9 @@ spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
 
   return false;
 }
+
+int
+spage_get_default_size ()
+{
+  return SPAGE_DB_PAGESIZE;
+}

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -5283,9 +5283,3 @@ spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
 
   return false;
 }
-
-int
-spage_get_default_size ()
-{
-  return SPAGE_DB_PAGESIZE;
-}

--- a/src/storage/slotted_page.h
+++ b/src/storage/slotted_page.h
@@ -167,4 +167,5 @@ extern int spage_slots_end_scan (THREAD_ENTRY * thread_p, void **ctx);
 
 extern void spage_vacuum_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slotid, bool reusable);
 extern bool spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p);
+extern int spage_get_default_empty_page_size ();
 #endif /* _SLOTTED_PAGE_H_ */

--- a/src/storage/slotted_page.h
+++ b/src/storage/slotted_page.h
@@ -167,5 +167,4 @@ extern int spage_slots_end_scan (THREAD_ENTRY * thread_p, void **ctx);
 
 extern void spage_vacuum_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slotid, bool reusable);
 extern bool spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p);
-int spage_get_default_size ();
 #endif /* _SLOTTED_PAGE_H_ */

--- a/src/storage/slotted_page.h
+++ b/src/storage/slotted_page.h
@@ -167,4 +167,5 @@ extern int spage_slots_end_scan (THREAD_ENTRY * thread_p, void **ctx);
 
 extern void spage_vacuum_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slotid, bool reusable);
 extern bool spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p);
+int spage_get_default_size ();
 #endif /* _SLOTTED_PAGE_H_ */

--- a/src/storage/slotted_page.h
+++ b/src/storage/slotted_page.h
@@ -167,5 +167,4 @@ extern int spage_slots_end_scan (THREAD_ENTRY * thread_p, void **ctx);
 
 extern void spage_vacuum_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slotid, bool reusable);
 extern bool spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p);
-extern int spage_get_default_empty_page_size ();
 #endif /* _SLOTTED_PAGE_H_ */

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -4871,7 +4871,7 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
   heap_create_insert_context (&heapop_context, &boot_Db_parm->hfid, &boot_Db_parm->rootclass_oid, &recdes, NULL);
 
   /* Insert and fetch location */
-  if (heap_insert_logical (thread_p, &heapop_context) != NO_ERROR)
+  if (heap_insert_logical (thread_p, &heapop_context, NULL) != NO_ERROR)
     {
       goto error;
     }

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13706,105 +13706,109 @@ xlocator_demote_class_lock (THREAD_ENTRY * thread_p, const OID * class_oid, LOCK
 // *INDENT-OFF*
 int 
 locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid,
-                            const std::vector<RECDES>& recdes, int has_index, int op_type, HEAP_SCANCACHE * scan_cache,
+                            const std::vector<RECDES> &recdes, int has_index, int op_type, HEAP_SCANCACHE * scan_cache,
                             int *force_count, int pruning_type, PRUNING_CONTEXT * pcontext,
                             FUNC_PRED_UNPACK_INFO * func_preds, UPDATE_INPLACE_STYLE force_in_place)
+// *INDENT-ON*
+
 {
   int error_code = NO_ERROR;
   size_t accumulated_records_size = 0;
   size_t heap_max_page_size;
   OID dummy_oid;
+// *INDENT-OFF*
   std::vector<RECDES> recdes_array;
   std::vector<VPID> heap_pages_array;
-  
+// *INDENT-ON*
+
   // Early-out
   if (recdes.size () == 0)
     {
       // Nothing to insert.
       return NO_ERROR;
     }
-  
+
   *force_count = 0;
 
   // Take into account the unfill factor of the heap file.
   heap_max_page_size = heap_nonheader_page_capacity () * (1.0f - prm_get_float_value (PRM_ID_HF_UNFILL_FACTOR));
 
   for (size_t i = 0; i < recdes.size (); i++)
-  {
-    // Loop until we insert all records.
+    {
+      // Loop until we insert all records.
 
-    if (heap_is_big_length (recdes[i].length))
-      {
-        // We insert other records normally.
-        error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, (RECDES*) &recdes[i], has_index, op_type,
-                                           scan_cache, force_count, pruning_type, pcontext, func_preds, force_in_place, NULL);
-        if (error_code != NO_ERROR)
-          {
-            ASSERT_ERROR ();
-            return error_code;
-          }
-      }
-    else
-      {        
-        // get records until we fit the size of a page.
-        if ((recdes[i].length + accumulated_records_size) >= heap_max_page_size)
-          {
-            VPID new_page_vpid;
-            PGBUF_WATCHER home_hint_p;
+      if (heap_is_big_length (recdes[i].length))
+	{
+	  // We insert other records normally.
+	  error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, (RECDES *) (&recdes[i]), has_index,
+					     op_type, scan_cache, force_count, pruning_type, pcontext, func_preds,
+					     force_in_place, NULL);
+	  if (error_code != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	      return error_code;
+	    }
+	}
+      else
+	{
+	  // get records until we fit the size of a page.
+	  if ((recdes[i].length + accumulated_records_size) >= heap_max_page_size)
+	    {
+	      VPID new_page_vpid;
+	      PGBUF_WATCHER home_hint_p;
 
-            VPID_SET_NULL (&new_page_vpid);
+	      VPID_SET_NULL (&new_page_vpid);
 
-            // First alloc a new empty heap page.
-            error_code = heap_alloc_new_page (thread_p, hfid, *class_oid, &home_hint_p, &new_page_vpid);
-            if (error_code != NO_ERROR)
-              {
-                ASSERT_ERROR ();
-                return error_code;
-              }
+	      // First alloc a new empty heap page.
+	      error_code = heap_alloc_new_page (thread_p, hfid, *class_oid, &home_hint_p, &new_page_vpid);
+	      if (error_code != NO_ERROR)
+		{
+		  ASSERT_ERROR ();
+		  return error_code;
+		}
 
-            for (size_t j = 0; j < recdes_array.size (); j++)
-              {
-                error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, &recdes_array[j], has_index, op_type,
-                                                   scan_cache, force_count, pruning_type, pcontext,
-                                                   func_preds, force_in_place, &home_hint_p);
-                if (error_code != NO_ERROR)
-                  {
-                    ASSERT_ERROR ();
-                    return error_code;
-                  }
-              }
+	      for (size_t j = 0; j < recdes_array.size (); j++)
+		{
+		  error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, &recdes_array[j], has_index,
+						     op_type, scan_cache, force_count, pruning_type, pcontext,
+						     func_preds, force_in_place, &home_hint_p);
+		  if (error_code != NO_ERROR)
+		    {
+		      ASSERT_ERROR ();
+		      return error_code;
+		    }
+		}
 
-            // Add the new VPID to the VPID array.
-            assert (!VPID_ISNULL (&new_page_vpid));
-            heap_pages_array.push_back (new_page_vpid);
+	      // Add the new VPID to the VPID array.
+	      assert (!VPID_ISNULL (&new_page_vpid));
+	      heap_pages_array.push_back (new_page_vpid);
 
-            // Clear the recdes array.
-            recdes_array.clear ();
-            accumulated_records_size = 0;
-          }
+	      // Clear the recdes array.
+	      recdes_array.clear ();
+	      accumulated_records_size = 0;
+	    }
 
-        // Add this record to the recdes array and increase the accumulated size.
-        recdes_array.push_back (recdes[i]);
-        accumulated_records_size += recdes[i].length;
-      }
-  }
+	  // Add this record to the recdes array and increase the accumulated size.
+	  recdes_array.push_back (recdes[i]);
+	  accumulated_records_size += recdes[i].length;
+	}
+    }
 
   // We must check if we have records which did not fill an entire page.
   for (size_t i = 0; i < recdes_array.size (); i++)
     {
       error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, &recdes_array[i], has_index, op_type,
-                                        scan_cache, force_count, pruning_type, pcontext, func_preds, force_in_place, NULL);
+					 scan_cache, force_count, pruning_type, pcontext, func_preds, force_in_place,
+					 NULL);
       if (error_code != NO_ERROR)
-        {
-          ASSERT_ERROR ();
-          return error_code;
-        }
+	{
+	  ASSERT_ERROR ();
+	  return error_code;
+	}
     }
 
   // Now form a heap chain with the pages and add the chain to the current heap.
   // TODO: this!
-  
+
   return error_code;
 }
-
-// *INDENT-ON*

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13705,32 +13705,38 @@ xlocator_demote_class_lock (THREAD_ENTRY * thread_p, const OID * class_oid, LOCK
 
 // *INDENT-OFF*
 int 
-locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID ** oids, RECDES ** recdes,
-                            int n_recdes, int has_index, int op_type, HEAP_SCANCACHE * scan_cache, int *force_count,
-                            int pruning_type, PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
-                            UPDATE_INPLACE_STYLE force_in_place)
-{		/* Make sure that this is an old object */
-  bool is_cached = false;
-  LC_COPYAREA *cache_attr_copyarea = NULL;
+locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, std::vector<OID> oids,
+                            std::vector<RECDES> recdes, int has_index, int op_type, HEAP_SCANCACHE * scan_cache,
+                            int *force_count, int pruning_type, PRUNING_CONTEXT * pcontext,
+                            FUNC_PRED_UNPACK_INFO * func_preds, UPDATE_INPLACE_STYLE force_in_place)
+{
   int error_code = NO_ERROR;
-  OID real_class_oid;
-  HFID real_hfid;
-  ssize_t accumulated_records_size = 0;
-  const ssize_t heap_max_page_size = spage_get_default_empty_page_size ();
+  size_t accumulated_records_size = 0;
+  size_t heap_max_page_size;
   std::vector <RECDES> recdes_array;
   std::vector <OID> oids_array;
   std::vector <VPID> heap_pages_array;
-  
-  HFID_COPY (&real_hfid, hfid);
-  COPY_OID (&real_class_oid, class_oid);
 
+  // Safeguard
+  assert (recdes.size() == oids.size ());
+
+  // Early-out
+  if (recdes.size () == 0)
+    {
+      // Nothing to insert.
+      return NO_ERROR;
+    }
+  
   *force_count = 0;
 
-  for (int i = 0; i < n_recdes; i++)
+  // Take into account the unfill factor of the heap file.
+  heap_max_page_size = heap_get_default_empty_page_size () * (1.0f - prm_get_float_value (PRM_ID_HF_UNFILL_FACTOR));
+
+  for (int i = 0; i < recdes.size (); i++)
   {
     // Loop until we insert all records.
-    RECDES *local_recdes = recdes[i];
-    OID *local_oid = oids[i];
+    RECDES *local_recdes = &recdes[i];
+    OID *local_oid = &oids[i];
     HEAP_SCANCACHE local_scan_cache;
     FUNC_PRED_UNPACK_INFO local_func_preds;
 
@@ -13745,26 +13751,25 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
         if (error_code != NO_ERROR)
           {
             ASSERT_ERROR ();
-            goto cleanup;
+            return error_code;
           }
       }
     else
       {        
         // get records until we fit the size of a page.
-        // TODO: Fix this!!
-        if ((local_recdes->length + accumulated_records_size) > heap_max_page_size)
+        if ((local_recdes->length + accumulated_records_size) >= heap_max_page_size)
           {
             VPID new_page_vpid;
-            PGBUF_WATCHER * home_hint_p;
+            PGBUF_WATCHER home_hint_p;
 
             VPID_SET_NULL (&new_page_vpid);
 
             // First alloc a new empty heap page.
-            error_code = heap_alloc_new_page (thread_p, hfid, home_hint_p, &new_page_vpid);
+            error_code = heap_alloc_new_page (thread_p, hfid, &home_hint_p, &new_page_vpid);
             if (error_code != NO_ERROR)
               {
                 ASSERT_ERROR ();
-                goto cleanup;
+                return error_code;
               }
 
             for (int j = 0; j < recdes_array.size (); j++)
@@ -13774,11 +13779,11 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 
                 error_code = locator_insert_force (thread_p, hfid, class_oid, &ins_oid, &ins_record, has_index, op_type,
                                                    &local_scan_cache, force_count, pruning_type, pcontext,
-                                                   &local_func_preds, force_in_place, home_hint_p);
+                                                   &local_func_preds, force_in_place, &home_hint_p);
                 if (error_code != NO_ERROR)
                   {
                     ASSERT_ERROR ();
-                    goto cleanup;
+                    return error_code;
                   }
               }
 
@@ -13812,18 +13817,12 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
       if (error_code != NO_ERROR)
         {
           ASSERT_ERROR ();
-          goto cleanup;
+          return error_code;
         }
     }
 
   // Now form a heap chain with the pages and add the chain to the current heap.
   // TODO: this!
-
-cleanup:
-
-  recdes_array.clear ();
-  oids_array.clear ();
-  heap_pages_array.clear ();
   
   return error_code;
 }

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13786,6 +13786,9 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 	      // Clear the recdes array.
 	      recdes_array.clear ();
 	      accumulated_records_size = 0;
+
+	      // Safeguard.
+	      assert (home_hint_p.pgptr == NULL);
 	    }
 
 	  // Add this record to the recdes array and increase the accumulated size.

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13770,14 +13770,14 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
             // Clear the recdes array.
             recdes_array.clear ();
             oids_array.clear ();
+            accumulated_records_size = 0;
+
           }
-        else
-          {
-            // Add this records to the recdes array and increase the accumulated size.
-            recdes_array.push_back (*local_recdes);
-            oids_array.push_back (*local_oid);
-            accumulated_records_size += local_recdes->length;
-          }
+
+        // Add this record to the recdes array and increase the accumulated size.
+        recdes_array.push_back (*local_recdes);
+        oids_array.push_back (*local_oid);
+        accumulated_records_size += local_recdes->length;
       }
   }
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13777,6 +13777,9 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 		      ASSERT_ERROR ();
 		      return error_code;
 		    }
+
+		  // Safeguard. We should not have the page fixed here.
+		  assert (home_hint_p.pgptr == NULL);
 		}
 
 	      // Add the new VPID to the VPID array.
@@ -13787,8 +13790,6 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 	      recdes_array.clear ();
 	      accumulated_records_size = 0;
 
-	      // Safeguard.
-	      assert (home_hint_p.pgptr == NULL);
 	    }
 
 	  // Add this record to the recdes array and increase the accumulated size.

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13706,7 +13706,7 @@ xlocator_demote_class_lock (THREAD_ENTRY * thread_p, const OID * class_oid, LOCK
 // *INDENT-OFF*
 int 
 locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid,
-                            std::vector<RECDES>& recdes, int has_index, int op_type, HEAP_SCANCACHE * scan_cache,
+                            const std::vector<RECDES>& recdes, int has_index, int op_type, HEAP_SCANCACHE * scan_cache,
                             int *force_count, int pruning_type, PRUNING_CONTEXT * pcontext,
                             FUNC_PRED_UNPACK_INFO * func_preds, UPDATE_INPLACE_STYLE force_in_place)
 {
@@ -13714,8 +13714,8 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
   size_t accumulated_records_size = 0;
   size_t heap_max_page_size;
   OID dummy_oid;
-  std::vector <RECDES> recdes_array;
-  std::vector <VPID> heap_pages_array;
+  std::vector<RECDES> recdes_array;
+  std::vector<VPID> heap_pages_array;
   
   // Early-out
   if (recdes.size () == 0)
@@ -13736,7 +13736,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
     if (heap_is_big_length (recdes[i].length))
       {
         // We insert other records normally.
-        error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, &recdes[i], has_index, op_type,
+        error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, (RECDES*) &recdes[i], has_index, op_type,
                                            scan_cache, force_count, pruning_type, pcontext, func_preds, force_in_place, NULL);
         if (error_code != NO_ERROR)
           {
@@ -13755,7 +13755,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
             VPID_SET_NULL (&new_page_vpid);
 
             // First alloc a new empty heap page.
-            error_code = heap_alloc_new_page (thread_p, hfid, &home_hint_p, &new_page_vpid);
+            error_code = heap_alloc_new_page (thread_p, hfid, *class_oid, &home_hint_p, &new_page_vpid);
             if (error_code != NO_ERROR)
               {
                 ASSERT_ERROR ();

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -127,9 +127,12 @@ extern SCAN_CODE locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, O
 extern SCAN_OPERATION_TYPE locator_decide_operation_type (LOCK lock_mode, LC_FETCH_VERSION_TYPE fetch_version_type);
 extern LOCK locator_get_lock_mode_from_op_type (SCAN_OPERATION_TYPE op_type);
 
-extern int locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, std::vector < OID > oids,
-				       std::vector < RECDES > recdes, int has_index, int op_type,
+
+// *INDENT-OFF*
+extern int locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid,
+				       const std::vector<RECDES> &recdes, int has_index, int op_type,
 				       HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type,
 				       PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
 				       UPDATE_INPLACE_STYLE force_in_place);
+// *INDENT-ON*
 #endif /* _LOCATOR_SR_H_ */

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -126,4 +126,10 @@ extern SCAN_CODE locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, O
 				     int ispeeking, int chn);
 extern SCAN_OPERATION_TYPE locator_decide_operation_type (LOCK lock_mode, LC_FETCH_VERSION_TYPE fetch_version_type);
 extern LOCK locator_get_lock_mode_from_op_type (SCAN_OPERATION_TYPE op_type);
+
+extern int locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, std::vector < OID > oids,
+				       std::vector < RECDES > recdes, int has_index, int op_type,
+				       HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type,
+				       PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
+				       UPDATE_INPLACE_STYLE force_in_place);
 #endif /* _LOCATOR_SR_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22978

This is a Work In Progress PR.

This function should be specialized into inserting an array of records into the same heap file. It works as it follows:


- ~~Records passed as parameters for this function should have already been partition pruned before this.~~ Pruning is handled by the insert function.
- Insert any records that are not normal ones (`REC_HOME`) using the old implementation of `locator_insert_force`.
- The normal records are then collected until we manage to fill a whole heap page. (~~TODO: Needs to be checked~~).
- When the size limit is hit, the insert is issued and we get a new page in which all of the records should have been inserted.


TODO:
- Create the heap chain using the pages and append the chain to the heap.
- Check for leaks.
- Check if the inserts are actually done in the same page!!.