### PR TITLE
[CBRD-22983] [ddl proxy] connect explicitly to localhost

### DIFF
--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -61,6 +61,7 @@
 #include "replication_db_copy.hpp"
 #include "replication_object.hpp"
 #include "slotted_page.h"
+#include "string_buffer.hpp"
 #include "utility.h"
 #include "xasl_cache.h"
 #include "xasl_predicate.hpp"
@@ -14230,13 +14231,17 @@ locator_repl_apply_sbr (THREAD_ENTRY * thread_p, const char *db_user, const char
       command = "true";
     }
 
+  // connect explicitly to localhost
+  string_buffer db_name_buffer;
+  db_name_buffer ("%s@%s", db_name, "localhost");
+
   const char *ddl_argv[13] = {
     path,
     "-u",
     db_user,
     "-p",
     db_password,
-    db_name,
+    db_name_buffer.get_buffer (),
     command_option,
     command,
     "-t",


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22983

On HA cluster database.txt might contain multiple hosts, in case when db host is not passed to ddl_proxy it might be the case that ddl_proxy will connect to wrong host

database.txt example
```
#db-name  vol-path                 db-host                 log-path                 lob-base-path
test_db   /var/lib/cubrid/test_db  master-host:slave-host  /var/lib/cubrid/test_db  file:/var/lib/cubrid/test_db/lob
```