### PR TITLE
[CBRD-22993] fix 

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -13204,6 +13204,31 @@ mr_setval_varnchar (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 				db_get_string_collation (src));
 	      dest->need_clear = true;
 	    }
+
+	  if (src->data.ch.medium.compressed_buf == NULL)
+	    {
+	      dest->data.ch.medium.compressed_buf = NULL;
+	      dest->data.ch.info.compressed_need_clear = false;
+	    }
+	  else
+	    {
+	      char *new_compressed_buf = (char *) db_private_alloc (NULL, src->data.ch.medium.compressed_size + 1);
+	      if (new_compressed_buf == NULL)
+		{
+		  db_value_domain_init (dest, DB_TYPE_VARNCHAR, src_precision, 0);
+		  assert (er_errid () != NO_ERROR);
+		  error = er_errid ();
+		}
+	      else
+		{
+		  memcpy (new_compressed_buf, src->data.ch.medium.compressed_buf, src->data.ch.medium.compressed_size);
+		  new_compressed_buf[src->data.ch.medium.compressed_size] = '\0';
+		  dest->data.ch.medium.compressed_buf = new_compressed_buf;
+		  dest->data.ch.info.compressed_need_clear = true;
+		}
+	    }
+
+	  dest->data.ch.medium.compressed_size = src->data.ch.medium.compressed_size;
 	}
     }
 

--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -189,12 +189,9 @@ namespace cubreplication
 
     cubthread::entry *my_thread = thread_get_thread_entry_info ();
 
-    HL_HEAPID save_heapid;
-    save_heapid = db_change_private_heap (my_thread, 0);
-
+    HL_HEAPID save_heapid = db_change_private_heap (my_thread, 0);
     pr_clear_value (&m_key_value);
-
-    (void) db_change_private_heap (my_thread, save_heapid);
+    db_change_private_heap (my_thread, save_heapid);
   }
 
   int
@@ -234,10 +231,9 @@ namespace cubreplication
   void
   single_row_repl_entry::set_key_value (const DB_VALUE &db_val)
   {
-    HL_HEAPID save_heapid;
-    save_heapid = db_change_private_heap (NULL, 0);
+    HL_HEAPID save_heapid = db_change_private_heap (NULL, 0);
     pr_clone_value (&db_val, &m_key_value);
-    (void) db_change_private_heap (NULL, save_heapid);
+    db_change_private_heap (NULL, save_heapid);
   }
 
   std::size_t
@@ -250,7 +246,10 @@ namespace cubreplication
     /* type of RBR entry */
     entry_size += serializator.get_packed_int_size (entry_size);
     entry_size += serializator.get_packed_string_size (m_class_name, entry_size);
+
+    HL_HEAPID save_heapid = db_change_private_heap (NULL, 0);
     entry_size += serializator.get_packed_db_value_size (m_key_value, entry_size);
+    db_change_private_heap (NULL, save_heapid);
 
     return entry_size;
   }
@@ -260,26 +259,26 @@ namespace cubreplication
   {
     serializator.pack_int ((int) m_type);
     serializator.pack_string (m_class_name);
+
+    HL_HEAPID save_heapid = db_change_private_heap (NULL, 0);
     serializator.pack_db_value (m_key_value);
+    db_change_private_heap (NULL, save_heapid);
   }
 
   void
   single_row_repl_entry::unpack (cubpacking::unpacker &deserializator)
   {
-    int int_val;
-    HL_HEAPID save_heapid;
-
-    save_heapid = db_change_private_heap (NULL, 0);
+    HL_HEAPID save_heapid = db_change_private_heap (NULL, 0);
 
     /* RBR type */
+    int int_val;
     deserializator.unpack_int (int_val);
     m_type = (repl_entry_type) int_val;
 
     deserializator.unpack_string (m_class_name);
-
     deserializator.unpack_db_value (m_key_value);
 
-    (void) db_change_private_heap (NULL, save_heapid);
+    db_change_private_heap (NULL, save_heapid);
   }
 
   void
@@ -406,29 +405,26 @@ namespace cubreplication
   {
     cubthread::entry *my_thread = thread_get_thread_entry_info ();
 
-    HL_HEAPID save_heapid;
-    save_heapid = db_change_private_heap (my_thread, 0);
+    HL_HEAPID save_heapid = db_change_private_heap (my_thread, 0);
 
     for (std::vector <DB_VALUE>::iterator it = m_new_values.begin (); it != m_new_values.end (); it++)
       {
 	pr_clear_value (& (*it));
       }
-    (void) db_change_private_heap (my_thread, save_heapid);
+    db_change_private_heap (my_thread, save_heapid);
   }
 
   void
   changed_attrs_row_repl_entry::copy_and_add_changed_value (const ATTR_ID att_id, const DB_VALUE &db_val)
   {
-    HL_HEAPID save_heapid;
-
     m_new_values.emplace_back ();
     DB_VALUE &last_new_value = m_new_values.back ();
 
     m_changed_attributes.push_back (att_id);
 
-    save_heapid = db_change_private_heap (NULL, 0);
+    HL_HEAPID save_heapid = db_change_private_heap (NULL, 0);
     pr_clone_value (&db_val, &last_new_value);
-    (void) db_change_private_heap (NULL, save_heapid);
+    db_change_private_heap (NULL, save_heapid);
   }
 
   int
@@ -470,9 +466,7 @@ namespace cubreplication
     OID_SET_NULL (&m_inst_oid);
 
 #if defined (SERVER_MODE)
-    HL_HEAPID save_heapid;
-
-    save_heapid = db_change_private_heap (NULL, 0);
+    HL_HEAPID save_heapid = db_change_private_heap (NULL, 0);
 #endif
     /* create id */
     deserializator.unpack_int (int_val);
@@ -491,7 +485,7 @@ namespace cubreplication
       }
 
 #if defined (SERVER_MODE)
-    (void) db_change_private_heap (NULL, save_heapid);
+    db_change_private_heap (NULL, save_heapid);
 #endif
   }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22993

The issue occurs when the primary key is of type `DB_TYPE_VARNCHAR` and the values is longer than 255 characters (in order to be compressed).
```sql
create table t1 (id NCHAR VARYING primary key, nr integer);
insert into t1 values (n'aaaaaa ....', 1); /* id string must be longer than 255 characters */

```

There are two issues with compression of the `DB_TYPE_VARNCHAR` type:
1. there is an inconsistency between `mr_setval_varnchar` and `pr_do_db_value_string_compression` function. `mr_setval_varnchar` does not copy the compressed_buf even though `pr_do_db_value_string_compression` does compression for `DB_TYPE_VARNCHAR` type
2. there are cases when packing of the `m_key_value` from `single_row_repl_entry` class might allocate memory (in this case for compression buffer) therefore we need to change private heap id in `single_row_repl_entry::get_packed_size` and `single_row_repl_entry::pack`

**allocation stack:**
```
#0  mspace_malloc (msp=0x55ab449dbb00, bytes=1135) at src/heaplayers/malloc_2_8_3.c:4804
#1  0x00007f5e9866a734 in hl_lea_alloc (heap_id=94194078956224, sz=1135) at src/heaplayers/lea_heap.c:342
#2  0x00007f5e98578087 in db_private_alloc_debug (thrd=0x7f5e97393ea8, size=1135, rc_track=true, caller_file=0x7f5e98be5218 "src/object/object_primitive.c", caller_line=16294) at src/base/memory_alloc.c:462
#3  0x00007f5e986a750a in pr_do_db_value_string_compression (value=0x7f5d7800b788) at src/object/object_primitive.c:16294
#4  0x00007f5e986a1b54 in mr_lengthval_varnchar_internal (value=0x7f5d7800b788, disk=1, align=4) at src/object/object_primitive.c:13280
#5  0x00007f5e986a1a39 in mr_data_lengthval_varnchar (value=0x7f5d7800b788, disk=1) at src/object/object_primitive.c:13235
#6  0x00007f5e986aa075 in pr_type::get_disk_size_of_value (this=0x7f5e98e438e0 <tp_VarNChar>, value=0x7f5d7800b788) at src/object/object_primitive.h:442
#7  0x00007f5e986b3893 in or_packed_value_size (value=0x7f5d7800b788, collapse_null=1, include_domain=1, include_domain_classoids=0) at src/object/object_representation.c:6179
#8  0x00007f5e985950f7 in cubpacking::packer::get_packed_db_value_size (this=0x55ab45347470, value=..., curr_offset=12) at src/base/packer.cpp:398
#9  0x00007f5e9881a233 in cubreplication::single_row_repl_entry::get_packed_size (this=0x7f5d7800b750, serializator=..., start_offset=4) at src/replication/replication_object.cpp:250
#10 0x00007f5e9881b6ce in cubreplication::rec_des_row_repl_entry::get_packed_size (this=0x7f5d7800b750, serializator=..., start_offset=0) at src/replication/replication_object.cpp:644
#11 0x00007f5e98818161 in cubstream::entry<cubreplication::replication_object>::get_entries_size (this=0x55ab453473b0) at src/base/stream_entry.hpp:313
#12 0x00007f5e988179d6 in cubstream::entry<cubreplication::replication_object>::pack (this=0x55ab453473b0) at src/base/stream_entry.hpp:258
#13 0x00007f5e988167b2 in cubreplication::log_generator::pack_stream_entry (this=0x55ab45347398) at src/replication/log_generator.cpp:319
#14 0x00007f5e98816b02 in cubreplication::log_generator::on_transaction_finish (this=0x55ab45347398, state=cubreplication::stream_entry_header::COMMITTED) at src/replication/log_generator.cpp:388
#15 0x00007f5e98816b7b in cubreplication::log_generator::on_transaction_commit (this=0x55ab45347398) at src/replication/log_generator.cpp:401
#16 0x00007f5e98a09782 in log_commit_local (thread_p=0x7f5e97393ea8, tdes=0x55ab45346a38, retain_lock=false, is_local_tran=true) at src/transaction/log_manager.c:4878
#17 0x00007f5e98a09bfe in log_commit (thread_p=0x7f5e97393ea8, tran_index=1, retain_lock=false) at src/transaction/log_manager.c:5126
#18 0x00007f5e98a60455 in xtran_server_commit (thread_p=0x7f5e97393ea8, retain_lock=false) at src/transaction/transaction_sr.c:82
#19 0x00007f5e985ca2a0 in stran_server_commit_internal (thread_p=0x7f5e97393ea8, rid=65570, retain_lock=false, should_conn_reset=0x7f5dfc7eb0b7) at src/communication/network_interface_sr.c:151
#20 0x00007f5e985ca4cd in stran_server_auto_commit_or_abort (thread_p=0x7f5e97393ea8, rid=65570, p_end_queries=0x7f5dfc7eb240, n_query_ids=1, need_abort=false, has_updated=false, end_query_allowed=0x7f5dfc7eb0b6, tran_state=0x7f5dfc7eb0d4, should_conn_reset=0x7f5dfc7eb0b7) at src/communication/network_interface_sr.c:265
#21 0x00007f5e985d41d4 in sqmgr_execute_query (thread_p=0x7f5e97393ea8, rid=65570, request=0x7f5d80001270 "\264\t\032\060\177\252/\240}]\006\243\300ΐū\361,\361\\\361\004\"", reqlen=112) at src/communication/network_interface_sr.c:5124
#22 0x00007f5e985e0239 in net_server_request (thread_p=0x7f5e97393ea8, rid=65570, request=93, size=112, buffer=0x7f5d80001270 "\264\t\032\060\177\252/\240}]\006\243\300ΐū\361,\361\\\361\004\"") at src/communication/network_sr.c:1045
#23 0x00007f5e98650cfa in css_internal_request_handler (thread_ref=..., conn_ref=...) at src/connection/server_support.c:1302
#24 0x00007f5e986533ba in css_server_task::execute (this=0x7f5d800012f0, thread_ref=...) at src/connection/server_support.c:2856
#25 0x00007f5e986566a2 in cubthread::worker_pool<cubthread::entry>::core::worker::execute_current_task (this=0x55ab48eec340) at src/thread/thread_worker_pool.hpp:1287
#26 0x00007f5e98656022 in cubthread::worker_pool<cubthread::entry>::core::worker::run (this=0x55ab48eec340) at src/thread/thread_worker_pool.hpp:1399
#27 0x00007f5e9865695a in std::__invoke_impl<void, void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(), cubthread::worker_pool<cubthread::entry>::core::worker*> (__f=@0x55ab48eefa90: (void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(cubthread::worker_pool<cubthread::entry>::core::worker * const)) 0x7f5e98655fa0 <cubthread::worker_pool<cubthread::entry>::core::worker::run()>, __t=@0x55ab48eefa88: 0x55ab48eec340) at /usr/include/c++/8.3.0/bits/invoke.h:73
#28 0x00007f5e98656099 in std::__invoke<void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(), cubthread::worker_pool<cubthread::entry>::core::worker*> (__fn=@0x55ab48eefa90: (void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(cubthread::worker_pool<cubthread::entry>::core::worker * const)) 0x7f5e98655fa0 <cubthread::worker_pool<cubthread::entry>::core::worker::run()>, __args#0=@0x55ab48eefa88: 0x55ab48eec340) at /usr/include/c++/8.3.0/bits/invoke.h:95
#29 0x00007f5e98657e5f in std::thread::_Invoker<std::tuple<void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(), cubthread::worker_pool<cubthread::entry>::core::worker*> >::_M_invoke<0ul, 1ul> (this=0x55ab48eefa88) at /usr/include/c++/8.3.0/thread:244
#30 0x00007f5e98657e05 in std::thread::_Invoker<std::tuple<void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(), cubthread::worker_pool<cubthread::entry>::core::worker*> >::operator() (this=0x55ab48eefa88) at /usr/include/c++/8.3.0/thread:253
#31 0x00007f5e98657dda in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (cubthread::worker_pool<cubthread::entry>::core::worker::*)(), cubthread::worker_pool<cubthread::entry>::core::worker*> > >::_M_run (this=0x55ab48eefa80) at /usr/include/c++/8.3.0/thread:196
#32 0x00007f5e980b5053 in std::execute_native_thread_routine (__p=0x55ab48eefa80) at /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:80
#33 0x00007f5e98196a92 in start_thread (arg=<optimized out>) at pthread_create.c:486
#34 0x00007f5e97dcdd03 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```