### PR TITLE
[CBRD-22997] adjust recdes area for apply

### DIFF
--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -25,6 +25,7 @@
 
 #include "replication_object.hpp"
 
+#include "heap_file.h"
 #include "locator_sr.h"
 #include "mem_block.hpp"
 #include "memory_alloc.h"
@@ -630,7 +631,10 @@ namespace cubreplication
 
     (void) single_row_repl_entry::unpack (deserializator);
 
+    m_rec_des.resize_buffer ((size_t) DB_PAGESIZE);
     m_rec_des.unpack (deserializator);
+    // record may be resized by heap_update_adjust_recdes_header; make sure there is enough space.
+    heap_record_reserve_for_adjustments (m_rec_des);
   }
 
   std::size_t

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24616,6 +24616,13 @@ heap_is_page_header (THREAD_ENTRY * thread_p, PAGE_PTR page)
   return false;
 }
 
+void
+heap_record_reserve_for_adjustments (record_descriptor & record)
+{
+  // to be sure there is enough space for adjustments, add record header size to current record length.
+  record.resize_buffer (record.get_size () + OR_MVCC_MAX_HEADER_SIZE);
+}
+
 //
 // C++ code
 //

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -669,4 +669,6 @@ extern int heap_get_best_space_num_stats_entries (void);
 extern int heap_get_hfid_from_vfid (THREAD_ENTRY * thread_p, const VFID * vfid, HFID * hfid);
 extern int heap_scan_cache_allocate_area (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache_p, int size);
 extern bool heap_is_page_header (THREAD_ENTRY * thread_p, PAGE_PTR page);
+
+extern void heap_record_reserve_for_adjustments (record_descriptor & record);
 #endif /* _HEAP_FILE_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22997

allocate recdes area big enough to allow heap_update_adjust_recdes_header execute safely.