### PR TITLE
[CBRD-22998] prevent slave_node connect to self master_node

### DIFF
--- a/src/base/hostname.hpp
+++ b/src/base/hostname.hpp
@@ -183,7 +183,7 @@ namespace cubbase
       bool
       empty () const
       {
-	return !m_hostname.empty ();
+	return m_hostname.empty ();
       }
 
       // pack/unpack functions

--- a/src/base/hostname.hpp
+++ b/src/base/hostname.hpp
@@ -180,6 +180,12 @@ namespace cubbase
 	return m_hostname.c_str ();
       }
 
+      bool
+      empty () const
+      {
+	return !m_hostname.empty ();
+      }
+
       // pack/unpack functions
       size_t
       get_packed_size (cubpacking::packer &serializator, std::size_t start_offset) const override

--- a/src/master/master_heartbeat.cpp
+++ b/src/master/master_heartbeat.cpp
@@ -5300,7 +5300,7 @@ hb_is_hang_process (int sfd)
 const cubbase::hostname_type &
 hb_find_host_name_of_master_server ()
 {
-  static const empty_hostname;
+  static const cubbase::hostname_type empty_hostname;
 
   int rv = pthread_mutex_lock (&hb_Cluster->lock);
   for (cubhb::node_entry *node : hb_Cluster->nodes)

--- a/src/master/master_heartbeat.cpp
+++ b/src/master/master_heartbeat.cpp
@@ -191,7 +191,7 @@ static HB_DEACTIVATE_INFO hb_Deactivate_info = { NULL, 0, false };
 
 static bool hb_Is_activated = true;
 
-static const hostname_type current_master_hostname;
+static cubbase::hostname_type current_master_hostname;
 
 /* cluster jobs */
 static HB_JOB_FUNC hb_cluster_jobs[] =
@@ -2432,7 +2432,7 @@ hb_resource_job_shutdown (void)
 static void
 hb_resource_job_send_master_hostname (HB_JOB_ARG *arg)
 {
-  const hostname_type &master_hostname = hb_find_host_name_of_master_server ();
+  const cubbase::hostname_type &master_hostname = hb_find_host_name_of_master_server ();
   int error, rv;
   HB_PROC_ENTRY *proc = NULL;
   CSS_CONN_ENTRY *conn = NULL;
@@ -5297,7 +5297,7 @@ hb_is_hang_process (int sfd)
   return false;
 }
 
-const hostname_type &
+const cubbase::hostname_type &
 hb_find_host_name_of_master_server ()
 {
   static const empty_hostname;

--- a/src/master/master_heartbeat.cpp
+++ b/src/master/master_heartbeat.cpp
@@ -29,6 +29,7 @@
 #include "environment_variable.h"
 #include "error_context.hpp"
 #include "heartbeat.h"
+#include "hostname.hpp"
 #include "master_request.h"
 #include "master_util.h"
 #include "message_catalog.h"
@@ -189,6 +190,7 @@ static char hb_Nolog_event_msg[LINE_MAX] = "";
 static HB_DEACTIVATE_INFO hb_Deactivate_info = { NULL, 0, false };
 
 static bool hb_Is_activated = true;
+
 static const hostname_type current_master_hostname;
 
 /* cluster jobs */
@@ -5298,6 +5300,8 @@ hb_is_hang_process (int sfd)
 const hostname_type &
 hb_find_host_name_of_master_server ()
 {
+  static const empty_hostname;
+
   int rv = pthread_mutex_lock (&hb_Cluster->lock);
   for (cubhb::node_entry *node : hb_Cluster->nodes)
     {
@@ -5307,10 +5311,10 @@ hb_find_host_name_of_master_server ()
 	  assert (is_node_master);
 
 	  pthread_mutex_unlock (&hb_Cluster->lock);
-	  return node->get_hostname ().as_c_str ();
+	  return node->get_hostname ();
 	}
     }
   pthread_mutex_unlock (&hb_Cluster->lock);
 
-  return NULL;
+  return empty_hostname;
 }

--- a/src/master/master_heartbeat.hpp
+++ b/src/master/master_heartbeat.hpp
@@ -338,7 +338,7 @@ void hb_disable_er_log (int reason, const char *msg_fmt, ...);
 
 int hb_return_proc_state_by_fd (int sfd);
 bool hb_is_hang_process (int sfd);
-const cubbase::hostname_type& hb_find_host_name_of_master_server ();
+const cubbase::hostname_type &hb_find_host_name_of_master_server ();
 
 cubhb::ping_host::ping_result hb_check_ping (const char *host);
 const char *hb_valid_result_string (cubhb::ui_node_result v_result);

--- a/src/master/master_heartbeat.hpp
+++ b/src/master/master_heartbeat.hpp
@@ -338,7 +338,7 @@ void hb_disable_er_log (int reason, const char *msg_fmt, ...);
 
 int hb_return_proc_state_by_fd (int sfd);
 bool hb_is_hang_process (int sfd);
-const char *hb_find_host_name_of_master_server ();
+const cubbase::hostname_type& hb_find_host_name_of_master_server ();
 
 cubhb::ping_host::ping_result hb_check_ping (const char *host);
 const char *hb_valid_result_string (cubhb::ui_node_result v_result);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22998

Prevent slave_node connect to self master_node.
Use hostname_type instead of char * to make code more robust.