### PR TITLE
[CBRD-23002] do name resolution & semantic checks on select pt node for PT_CREATE_ENTITY node

### DIFF
--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -3649,9 +3649,22 @@ start_ddl_proxy_client (const char *program_name, DDL_CLIENT_ARGUMENT * args)
 	  goto error;
 	}
 
-      if (db_get_errors (session) || er_errid () != NO_ERROR)
+      DB_SESSION_ERROR *session_errors = db_get_errors (session);
+      if (session_errors || er_errid () != NO_ERROR)
 	{
 	  ASSERT_ERROR_AND_SET (rc);
+
+	  do
+	    {
+	      int line = 0, col = 0;
+	      session_errors = db_get_next_error (session_errors, &line, &col);
+	      if (line >= 0)
+		{
+		  ASSERT_ERROR_AND_SET (rc);
+		}
+	    }
+	  while (session_errors);
+
 	  au_enable (save);
 	  goto error;
 	}

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -3652,19 +3652,14 @@ start_ddl_proxy_client (const char *program_name, DDL_CLIENT_ARGUMENT * args)
       DB_SESSION_ERROR *session_errors = db_get_errors (session);
       if (session_errors || er_errid () != NO_ERROR)
 	{
-	  ASSERT_ERROR_AND_SET (rc);
-
 	  do
 	    {
 	      int line = 0, col = 0;
 	      session_errors = db_get_next_error (session_errors, &line, &col);
-	      if (line >= 0)
-		{
-		  ASSERT_ERROR_AND_SET (rc);
-		}
 	    }
 	  while (session_errors);
 
+	  ASSERT_ERROR_AND_SET (rc);
 	  au_enable (save);
 	  goto error;
 	}

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8461,7 +8461,11 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
       select = node->info.create_entity.create_select;
       if (select != NULL)
 	{
-	  select = pt_semantic_check (parser, select);
+	  if (select->info.query.with != NULL)
+	    {
+	      // run semantic check only for CREATE ... AS WITH ...
+	      select = pt_semantic_check (parser, select);
+	    }
 
 	  if (pt_has_parameters (parser, select))
 	    {

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8466,6 +8466,8 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	      PT_ERRORmf (parser, select, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_VARIABLE_NOT_ALLOWED, 0);
 	      return;
 	    }
+
+	  pt_semantic_check (parser, select);
 	}
       if (!pt_has_error (parser) && node->info.create_entity.partition_info)
 	{
@@ -15557,7 +15559,7 @@ pt_get_select_list_coll_compat (PARSER_CONTEXT * parser, PT_NODE * query, SEMAN_
  * pt_apply_union_select_list_collation () - scans a UNION parse tree and
  *		sets for each node with collation the collation corresponding
  *		of the column in 'cinfo' array
- *				
+ *
  *   return:  union compatibility status
  *   parser(in): the parser context
  *   query(in): query node

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8461,13 +8461,13 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
       select = node->info.create_entity.create_select;
       if (select != NULL)
 	{
+	  select = pt_semantic_check (parser, select);
+
 	  if (pt_has_parameters (parser, select))
 	    {
 	      PT_ERRORmf (parser, select, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_VARIABLE_NOT_ALLOWED, 0);
 	      return;
 	    }
-
-	  pt_semantic_check (parser, select);
 	}
       if (!pt_has_error (parser) && node->info.create_entity.partition_info)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23002

1. add name resolution and semantic check for queries of form `CREATE ... AS SELECT ..`
2. collect and log all parse tree errors on ddl_proxy_client

Fix from point 1. needs to be ported on develop as well