### PR TITLE
[CBRD-22997] record_descriptor: allow resizing a record_descriptor with a invalid 

### DIFF
--- a/src/storage/record_descriptor.cpp
+++ b/src/storage/record_descriptor.cpp
@@ -149,7 +149,7 @@ record_descriptor::get (cubthread::entry *thread_p, PAGE_PTR page, PGSLOTID slot
 void
 record_descriptor::resize_buffer (std::size_t required_size)
 {
-  check_changes_are_permitted ();
+  assert (m_data_source == data_source::INVALID || is_mutable ());
 
   if (m_recdes.area_size > 0 && required_size <= (size_t) m_recdes.area_size)
     {
@@ -161,6 +161,11 @@ record_descriptor::resize_buffer (std::size_t required_size)
 
   m_recdes.data = m_own_data.get_ptr ();
   m_recdes.area_size = (int) required_size;
+
+  if (m_data_source == data_source::INVALID)
+    {
+      m_data_source = data_source::NEW;
+    }
 }
 
 void


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22997

Regression of #1611

A newly created `record_descriptor` will have `m_data_source = data_source::INVALID` and `area_size = 0` (zero), therefore allow resizing newly created instance and set data source to `data_source::NEW` after resize operation