### PR TITLE
[CBRD-23013] Fix error handling in case of string conversion scenarios

### DIFF
--- a/src/loaddb/load_lexer.l
+++ b/src/loaddb/load_lexer.l
@@ -26,6 +26,8 @@
 #include "load_driver.hpp"
 #include "load_grammar.hpp"
 #include "load_scanner.hpp"
+#include "error_manager.h"
+#include "error_code.h"
 
 #undef YY_DECL
 #define YY_DECL \
@@ -501,6 +503,10 @@ using token = cubload::parser::token;
     m_semantic_helper.append_char ('\0');
     // PRINT ("IDENTIFIER %s\n", qstr_Buf_p);
     yylval->string = m_semantic_helper.make_string_by_buffer ();
+	if (er_errid () != NO_ERROR)
+	{
+		YY_FATAL_ERROR (er_msg ());
+	}
     BEGIN INITIAL;
     return token::IDENTIFIER;
 }
@@ -513,6 +519,10 @@ using token = cubload::parser::token;
     m_semantic_helper.append_char ('\0');
     // PRINT ("IDENTIFIER %s\n", qstr_Buf_p);
     yylval->string = m_semantic_helper.make_string_by_buffer ();
+	if (er_errid () != NO_ERROR)
+	{
+		YY_FATAL_ERROR (er_msg ());
+	}
     BEGIN INITIAL;
     return token::IDENTIFIER;
 }
@@ -552,7 +562,11 @@ using token = cubload::parser::token;
 <DQS>\" {
     m_semantic_helper.append_char ('\0');
     // PRINT ("DQS_String_Body %s\n", qstr_Buf_p);
-    yylval->string = m_semantic_helper.make_string_by_buffer ();
+   yylval->string = m_semantic_helper.make_string_by_buffer ();
+	if (er_errid () != NO_ERROR)
+	{
+		YY_FATAL_ERROR (er_msg ());
+	}
     BEGIN INITIAL;
     return token::DQS_String_Body;
 }
@@ -572,6 +586,10 @@ using token = cubload::parser::token;
     m_semantic_helper.append_char ('\0');
     // PRINT ("String_Completion %s\n", qstr_Buf_p);
     yylval->string = m_semantic_helper.make_string_by_buffer ();
+	if (er_errid () != NO_ERROR)
+	{
+		YY_FATAL_ERROR (er_msg ());
+	}
     BEGIN INITIAL;
     return token::SQS_String_Body;
 }
@@ -580,6 +598,10 @@ using token = cubload::parser::token;
     m_semantic_helper.append_char ('\0');
     // PRINT ("String_Completion2 %s\n", qstr_Buf_p);
     yylval->string = m_semantic_helper.make_string_by_buffer ();
+	if (er_errid () != NO_ERROR)
+	{
+		YY_FATAL_ERROR (er_msg ());
+	}
     BEGIN INITIAL;
     return token::SQS_String_Body;
 }

--- a/src/loaddb/load_lexer.l
+++ b/src/loaddb/load_lexer.l
@@ -43,6 +43,14 @@ using token = cubload::parser::token;
 #else
 #define PRINT(a, b)
 #endif
+
+#define CHECK_NULL_AND_SET_ERROR(p)     \
+  do {                                  \
+    if (p == NULL) {                    \
+        ASSERT_ERROR ();                \
+        YY_FATAL_ERROR (er_msg ());     \
+      }                                 \
+  } while (0)                           \
 %}
 
 /*** Flex Declarations and Options ***/
@@ -503,10 +511,7 @@ using token = cubload::parser::token;
     m_semantic_helper.append_char ('\0');
     // PRINT ("IDENTIFIER %s\n", qstr_Buf_p);
     yylval->string = m_semantic_helper.make_string_by_buffer ();
-	if (er_errid () != NO_ERROR)
-	{
-		YY_FATAL_ERROR (er_msg ());
-	}
+    CHECK_NULL_AND_SET_ERROR (yylval->string);
     BEGIN INITIAL;
     return token::IDENTIFIER;
 }
@@ -519,10 +524,7 @@ using token = cubload::parser::token;
     m_semantic_helper.append_char ('\0');
     // PRINT ("IDENTIFIER %s\n", qstr_Buf_p);
     yylval->string = m_semantic_helper.make_string_by_buffer ();
-	if (er_errid () != NO_ERROR)
-	{
-		YY_FATAL_ERROR (er_msg ());
-	}
+    CHECK_NULL_AND_SET_ERROR (yylval->string);
     BEGIN INITIAL;
     return token::IDENTIFIER;
 }
@@ -562,11 +564,8 @@ using token = cubload::parser::token;
 <DQS>\" {
     m_semantic_helper.append_char ('\0');
     // PRINT ("DQS_String_Body %s\n", qstr_Buf_p);
-   yylval->string = m_semantic_helper.make_string_by_buffer ();
-	if (er_errid () != NO_ERROR)
-	{
-		YY_FATAL_ERROR (er_msg ());
-	}
+    yylval->string = m_semantic_helper.make_string_by_buffer ();
+    CHECK_NULL_AND_SET_ERROR (yylval->string);
     BEGIN INITIAL;
     return token::DQS_String_Body;
 }
@@ -586,10 +585,7 @@ using token = cubload::parser::token;
     m_semantic_helper.append_char ('\0');
     // PRINT ("String_Completion %s\n", qstr_Buf_p);
     yylval->string = m_semantic_helper.make_string_by_buffer ();
-	if (er_errid () != NO_ERROR)
-	{
-		YY_FATAL_ERROR (er_msg ());
-	}
+    CHECK_NULL_AND_SET_ERROR (yylval->string);
     BEGIN INITIAL;
     return token::SQS_String_Body;
 }
@@ -598,10 +594,7 @@ using token = cubload::parser::token;
     m_semantic_helper.append_char ('\0');
     // PRINT ("String_Completion2 %s\n", qstr_Buf_p);
     yylval->string = m_semantic_helper.make_string_by_buffer ();
-	if (er_errid () != NO_ERROR)
-	{
-		YY_FATAL_ERROR (er_msg ());
-	}
+    CHECK_NULL_AND_SET_ERROR (yylval->string);
     BEGIN INITIAL;
     return token::SQS_String_Body;
 }

--- a/src/loaddb/load_lexer.l
+++ b/src/loaddb/load_lexer.l
@@ -46,7 +46,7 @@ using token = cubload::parser::token;
 
 #define CHECK_NULL_AND_SET_ERROR(p)     \
   do {                                  \
-    if (p == NULL) {                    \
+    if ((p) == NULL) {                    \
         ASSERT_ERROR ();                \
         YY_FATAL_ERROR (er_msg ());     \
       }                                 \

--- a/src/loaddb/load_scanner.hpp
+++ b/src/loaddb/load_scanner.hpp
@@ -61,6 +61,7 @@ namespace cubload
        */
       virtual int yylex (parser::semantic_type *yylval, parser::location_type *yylloc);
 
+#if defined (SERVER_MODE)
       /*
        * Lexer error function
        * @param msg a description of the lexer error.
@@ -74,6 +75,7 @@ namespace cubload
 	 */
 	m_error_handler.on_failure_with_line (LOADDB_MSG_LEX_ERROR);
       }
+#endif
 
     private:
       semantic_helper &m_semantic_helper;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23013

With the new approach, string conversion errors were not correctly handled on SA_MODE. The lexer should throw a fatal error in case it finds such a conversion error, however, on the current SA_MODE, the lexer would just set the session as failed, which was not entirely correct. Now, on SA_MODE we will detect the conversion errors at the time they are encountered by removing the override of `LexerError` and letting the old implementation handle the error scenario.