### PR TITLE
[CBRD-23006] Add assert in timezone module to catch internal error.

### DIFF
--- a/src/base/tz_support.c
+++ b/src/base/tz_support.c
@@ -2845,6 +2845,7 @@ tz_datetime_utc_conv (const DB_DATETIME * src_dt, TZ_DECODE_INFO * tz_info, bool
 #endif
 	  err_status = ER_TZ_INTERNAL_ERROR;
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, err_status, 0);
+	  assert (false);
 	}
       goto exit;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23006

This does not fix the issue, it just adds assertion to catch the issue earlier.