### PR TITLE
[CBRD-22978] Locator multi insert function

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24710,7 +24710,7 @@ heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, OID class_oid, PGBUF_
    assert (hfid != NULL && home_hint_p != NULL && new_page_vpid != NULL);
 
    PGBUF_INIT_WATCHER (home_hint_p, PGBUF_ORDERED_HEAP_NORMAL, hfid);
-   // Init the heap page chain
+  // Init the heap page chain
   new_page_chain.class_oid = class_oid;
   VPID_SET_NULL (&new_page_chain.prev_vpid);
   VPID_SET_NULL (&new_page_chain.next_vpid);
@@ -24720,7 +24720,7 @@ heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, OID class_oid, PGBUF_
 
    VPID_SET_NULL (new_page_vpid);
 
-   // Alloc a new page.
+  // Alloc a new page.
   error_code = file_alloc (thread_p, &hfid->vfid, heap_vpid_init_new, &new_page_chain, new_page_vpid, &page_ptr);
   if (error_code != NO_ERROR)
     {
@@ -24728,10 +24728,10 @@ heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, OID class_oid, PGBUF_
       return error_code;
     }
 
-   // Need to get the watcher to the new page.
+  // Need to get the watcher to the new page.
   pgbuf_attach_watcher (thread_p, page_ptr, PGBUF_LATCH_WRITE, hfid, home_hint_p);
 
-   // Make sure we have fixed the page.
+  // Make sure we have fixed the page.
   assert (pgbuf_is_page_fixed_by_thread (thread_p, new_page_vpid));
 
    return error_code;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -5888,7 +5888,7 @@ heap_assign_address (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid
   heap_create_insert_context (&insert_context, (HFID *) hfid, class_oid, &recdes, NULL);
 
   /* insert */
-  rc = heap_insert_logical (thread_p, &insert_context);
+  rc = heap_insert_logical (thread_p, &insert_context, NULL);
   if (rc != NO_ERROR)
     {
       return rc;
@@ -22259,7 +22259,7 @@ heap_create_update_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID
  *         moment.
  */
 int
-heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
+heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, PGBUF_WATCHER * home_hint_p)
 {
   bool is_mvcc_op;
   int rc = NO_ERROR;
@@ -22334,7 +22334,7 @@ heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
     }
 
   /* get insert location (includes locking) */
-  if (heap_get_insert_location_with_lock (thread_p, context, NULL) != NO_ERROR)
+  if (heap_get_insert_location_with_lock (thread_p, context, home_hint_p) != NO_ERROR)
     {
       return ER_FAILED;
     }
@@ -24699,5 +24699,49 @@ heap_scancache::get_area_block_allocator ()
   alloc_area ();
   return m_area->get_block_allocator ();
 }
+
+int
+heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, OID class_oid, PGBUF_WATCHER * home_hint_p, VPID * new_page_vpid)
+{
+  int error_code = NO_ERROR;
+  HEAP_CHAIN new_page_chain;
+  PAGE_PTR page_ptr;
+
+   assert (hfid != NULL && home_hint_p != NULL && new_page_vpid != NULL);
+
+   PGBUF_INIT_WATCHER (home_hint_p, PGBUF_ORDERED_HEAP_NORMAL, hfid);
+   // Init the heap page chain
+  new_page_chain.class_oid = class_oid;
+  VPID_SET_NULL (&new_page_chain.prev_vpid);
+  VPID_SET_NULL (&new_page_chain.next_vpid);
+  new_page_chain.max_mvccid = MVCCID_NULL;
+  new_page_chain.flags = 0;
+  HEAP_PAGE_SET_VACUUM_STATUS (&new_page_chain, HEAP_PAGE_VACUUM_NONE);
+
+   VPID_SET_NULL (new_page_vpid);
+
+   // Alloc a new page.
+  error_code = file_alloc (thread_p, &hfid->vfid, heap_vpid_init_new, &new_page_chain, new_page_vpid, &page_ptr);
+  if (error_code != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      return error_code;
+    }
+
+   // Need to get the watcher to the new page.
+  pgbuf_attach_watcher (thread_p, page_ptr, PGBUF_LATCH_WRITE, hfid, home_hint_p);
+
+   // Make sure we have fixed the page.
+  assert (pgbuf_is_page_fixed_by_thread (thread_p, new_page_vpid));
+
+   return error_code;
+}
+
+int
+heap_nonheader_page_capacity ()
+{
+  return spage_max_record_size () - sizeof (HEAP_CHAIN);
+}
+
 
 // *INDENT-ON*

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -623,7 +623,7 @@ extern void heap_create_delete_context (HEAP_OPERATION_CONTEXT * context, HFID *
 					HEAP_SCANCACHE * scancache_p);
 extern void heap_create_update_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID * oid_p, OID * class_oid_p,
 					RECDES * recdes_p, HEAP_SCANCACHE * scancache_p, UPDATE_INPLACE_STYLE in_place);
-extern int heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);
+extern int heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, PGBUF_WATCHER * home_hint_p);
 extern int heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);
 extern int heap_update_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);
 
@@ -669,4 +669,9 @@ extern int heap_get_best_space_num_stats_entries (void);
 extern int heap_get_hfid_from_vfid (THREAD_ENTRY * thread_p, const VFID * vfid, HFID * hfid);
 extern int heap_scan_cache_allocate_area (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache_p, int size);
 extern bool heap_is_page_header (THREAD_ENTRY * thread_p, PAGE_PTR page);
+
+ extern int heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, OID class_oid, PGBUF_WATCHER * home_hint_p,
+				 VPID * new_page_vpid);
+
+ extern int heap_nonheader_page_capacity ();
 #endif /* _HEAP_FILE_H_ */

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -4871,7 +4871,7 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
   heap_create_insert_context (&heapop_context, &boot_Db_parm->hfid, &boot_Db_parm->rootclass_oid, &recdes, NULL);
 
   /* Insert and fetch location */
-  if (heap_insert_logical (thread_p, &heapop_context) != NO_ERROR)
+  if (heap_insert_logical (thread_p, &heapop_context, NULL) != NO_ERROR)
     {
       goto error;
     }

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -152,7 +152,7 @@ static void locator_repl_add_error_to_copyarea (LC_COPYAREA ** copy_area, RECDES
 static int locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID * oid, RECDES * recdes,
 				 int has_index, int op_type, HEAP_SCANCACHE * scan_cache, int *force_count,
 				 int pruning_type, PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
-				 UPDATE_INPLACE_STYLE force_in_place);
+				 UPDATE_INPLACE_STYLE force_in_place, PGBUF_WATCHER * home_hint_p);
 static int locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID * oid, RECDES * ikdrecdes,
 				 RECDES * recdes, int has_index, ATTR_ID * att_id, int n_att_id, int op_type,
 				 HEAP_SCANCACHE * scan_cache, int *force_count, bool not_check_fk,
@@ -4852,7 +4852,7 @@ static int
 locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID * oid, RECDES * recdes, int has_index,
 		      int op_type, HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type,
 		      PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
-		      UPDATE_INPLACE_STYLE force_in_place)
+		      UPDATE_INPLACE_STYLE force_in_place, PGBUF_WATCHER * home_hint_p)
 {
 #if 0				/* TODO - dead code; do not delete me */
   OID rep_dir = { NULL_PAGEID, NULL_SLOTID, NULL_VOLID };
@@ -4972,7 +4972,7 @@ locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
     }
 
   /* execute insert */
-  if (heap_insert_logical (thread_p, &context) != NO_ERROR)
+  if (heap_insert_logical (thread_p, &context, home_hint_p) != NO_ERROR)
     {
       /*
        * Problems inserting the object...Maybe, the transaction should be
@@ -5223,7 +5223,7 @@ locator_move_record (THREAD_ENTRY * thread_p, HFID * old_hfid, OID * old_class_o
 
       error =
 	locator_insert_force (thread_p, new_class_hfid, new_class_oid, &new_obj_oid, recdes, has_index, op_type,
-			      insert_cache, force_count, context->pruning_type, NULL, NULL, UPDATE_INPLACE_NONE);
+			      insert_cache, force_count, context->pruning_type, NULL, NULL, UPDATE_INPLACE_NONE, NULL);
     }
   else
     {
@@ -5239,7 +5239,7 @@ locator_move_record (THREAD_ENTRY * thread_p, HFID * old_hfid, OID * old_class_o
       /* insert the new record */
       error =
 	locator_insert_force (thread_p, new_class_hfid, new_class_oid, &new_obj_oid, recdes, has_index, op_type,
-			      &insert_cache, force_count, DB_NOT_PARTITIONED_CLASS, NULL, NULL, UPDATE_INPLACE_NONE);
+			      &insert_cache, force_count, DB_NOT_PARTITIONED_CLASS, NULL, NULL, UPDATE_INPLACE_NONE, NULL);
       heap_scancache_end (thread_p, &insert_cache);
     }
 
@@ -6839,7 +6839,7 @@ xlocator_repl_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, LC_COPYA
 	      error_code =
 		locator_insert_force (thread_p, &obj->hfid, &obj->class_oid, &obj->oid, &recdes, has_index,
 				      SINGLE_ROW_INSERT, force_scancache, &force_count, pruning_type, NULL, NULL,
-				      UPDATE_INPLACE_NONE);
+				      UPDATE_INPLACE_NONE, NULL);
 
 	      if (error_code == NO_ERROR)
 		{
@@ -7028,7 +7028,7 @@ xlocator_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, int num_ignor
 	  error_code =
 	    locator_insert_force (thread_p, &obj->hfid, &obj->class_oid, &obj->oid, &recdes, has_index,
 				  SINGLE_ROW_INSERT, force_scancache, &force_count, pruning_type, NULL, NULL,
-				  UPDATE_INPLACE_NONE);
+				  UPDATE_INPLACE_NONE, NULL);
 
 	  if (error_code == NO_ERROR)
 	    {
@@ -7402,7 +7402,7 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 	{
 	  error_code =
 	    locator_insert_force (thread_p, &class_hfid, &class_oid, oid, &new_recdes, true, op_type, scan_cache,
-				  force_count, pruning_type, pcontext, func_preds, UPDATE_INPLACE_NONE);
+				  force_count, pruning_type, pcontext, func_preds, UPDATE_INPLACE_NONE, NULL);
 	}
       else
 	{
@@ -12783,7 +12783,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 	      error =
 		locator_insert_force (thread_p, &class_hfid, &cls_oid, &oid, &recdes, true, SINGLE_ROW_INSERT,
 				      &parent_scan_cache, &force_count, DB_PARTITIONED_CLASS, &pcontext, NULL,
-				      UPDATE_INPLACE_OLD_MVCCID);
+				      UPDATE_INPLACE_OLD_MVCCID, NULL);
 	      if (error != NO_ERROR)
 		{
 		  goto exit;
@@ -13699,4 +13699,118 @@ int
 xlocator_demote_class_lock (THREAD_ENTRY * thread_p, const OID * class_oid, LOCK lock, LOCK * ex_lock)
 {
   return lock_demote_class_lock (thread_p, class_oid, lock, ex_lock);
+}
+
+// *INDENT-OFF*
+int 
+locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid,
+                            const std::vector<RECDES> &recdes, int has_index, int op_type, HEAP_SCANCACHE * scan_cache,
+                            int *force_count, int pruning_type, PRUNING_CONTEXT * pcontext,
+                            FUNC_PRED_UNPACK_INFO * func_preds, UPDATE_INPLACE_STYLE force_in_place)
+// *INDENT-ON*
+
+ {
+  int error_code = NO_ERROR;
+  size_t accumulated_records_size = 0;
+  size_t heap_max_page_size;
+  OID dummy_oid;
+// *INDENT-OFF*
+  std::vector<RECDES> recdes_array;
+  std::vector<VPID> heap_pages_array;
+// *INDENT-ON*
+
+   // Early-out
+  if (recdes.size () == 0)
+    {
+      // Nothing to insert.
+      return NO_ERROR;
+    }
+
+   *force_count = 0;
+
+   // Take into account the unfill factor of the heap file.
+  heap_max_page_size = heap_nonheader_page_capacity () * (1.0f - prm_get_float_value (PRM_ID_HF_UNFILL_FACTOR));
+
+   for (size_t i = 0; i < recdes.size (); i++)
+    {
+      // Loop until we insert all records.
+
+       if (heap_is_big_length (recdes[i].length))
+	{
+	  // We insert other records normally.
+	  error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, (RECDES *) (&recdes[i]), has_index,
+					     op_type, scan_cache, force_count, pruning_type, pcontext, func_preds,
+					     force_in_place, NULL);
+	  if (error_code != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	      return error_code;
+	    }
+	}
+      else
+	{
+	  // get records until we fit the size of a page.
+	  if ((recdes[i].length + accumulated_records_size) >= heap_max_page_size)
+	    {
+	      VPID new_page_vpid;
+	      PGBUF_WATCHER home_hint_p;
+
+ 	      VPID_SET_NULL (&new_page_vpid);
+
+ 	      // First alloc a new empty heap page.
+	      error_code = heap_alloc_new_page (thread_p, hfid, *class_oid, &home_hint_p, &new_page_vpid);
+	      if (error_code != NO_ERROR)
+		{
+		  ASSERT_ERROR ();
+		  return error_code;
+		}
+
+ 	      for (size_t j = 0; j < recdes_array.size (); j++)
+		{
+		  error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, &recdes_array[j], has_index,
+						     op_type, scan_cache, force_count, pruning_type, pcontext,
+						     func_preds, force_in_place, &home_hint_p);
+		  if (error_code != NO_ERROR)
+		    {
+		      ASSERT_ERROR ();
+		      return error_code;
+		    }
+                  
+ 		  // Safeguard. We should not have the page fixed here.
+		  assert (home_hint_p.pgptr == NULL);
+		}
+
+ 	      // Add the new VPID to the VPID array.
+	      assert (!VPID_ISNULL (&new_page_vpid));
+	      heap_pages_array.push_back (new_page_vpid);
+
+ 	      // Clear the recdes array.
+	      recdes_array.clear ();
+	      accumulated_records_size = 0;
+
+ 	    }
+
+ 	  // Add this record to the recdes array and increase the accumulated size.
+	  recdes_array.push_back (recdes[i]);
+	  accumulated_records_size += recdes[i].length;
+	}
+    }
+
+   // We must check if we have records which did not fill an entire page.
+  for (size_t i = 0; i < recdes_array.size (); i++)
+    {
+      error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, &recdes_array[i], has_index, op_type,
+					 scan_cache, force_count, pruning_type, pcontext, func_preds, force_in_place,
+					 NULL);
+      if (error_code != NO_ERROR)
+	{
+	  ASSERT_ERROR ();
+	  return error_code;
+	}
+    }
+
+   // Now form a heap chain with the pages and add the chain to the current heap.
+  // TODO: this!
+
+   return error_code;
 }

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13719,7 +13719,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
   std::vector<VPID> heap_pages_array;
 // *INDENT-ON*
 
-   // Early-out
+  // Early-out
   if (recdes.size () == 0)
     {
       // Nothing to insert.
@@ -13728,12 +13728,12 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 
    *force_count = 0;
 
-   // Take into account the unfill factor of the heap file.
+  // Take into account the unfill factor of the heap file.
   heap_max_page_size = heap_nonheader_page_capacity () * (1.0f - prm_get_float_value (PRM_ID_HF_UNFILL_FACTOR));
 
    for (size_t i = 0; i < recdes.size (); i++)
     {
-      // Loop until we insert all records.
+        // Loop until we insert all records.
 
        if (heap_is_big_length (recdes[i].length))
 	{
@@ -13796,7 +13796,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 	}
     }
 
-   // We must check if we have records which did not fill an entire page.
+  // We must check if we have records which did not fill an entire page.
   for (size_t i = 0; i < recdes_array.size (); i++)
     {
       error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, &recdes_array[i], has_index, op_type,
@@ -13809,7 +13809,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 	}
     }
 
-   // Now form a heap chain with the pages and add the chain to the current heap.
+  // Now form a heap chain with the pages and add the chain to the current heap.
   // TODO: this!
 
    return error_code;

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -126,4 +126,12 @@ extern SCAN_CODE locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, O
 				     int ispeeking, int chn);
 extern SCAN_OPERATION_TYPE locator_decide_operation_type (LOCK lock_mode, LC_FETCH_VERSION_TYPE fetch_version_type);
 extern LOCK locator_get_lock_mode_from_op_type (SCAN_OPERATION_TYPE op_type);
+
+ // *INDENT-OFF*
+extern int locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid,
+				       const std::vector<RECDES> &recdes, int has_index, int op_type,
+				       HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type,
+				       PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
+				       UPDATE_INPLACE_STYLE force_in_place);
+// *INDENT-ON*
 #endif /* _LOCATOR_SR_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22978

This is a Work In Progress PR.

This function should be specialized into inserting an array of records into the same heap file. It works as it follows:


- ~~Records passed as parameters for this function should have already been partition pruned before this.~~ Pruning is handled by the insert function.
- Insert any records that are not normal ones (`REC_HOME`) using the old implementation of `locator_insert_force`.
- The normal records are then collected until we manage to fill a whole heap page. (~~TODO: Needs to be checked~~).
- When the size limit is hit, the insert is issued and we get a new page in which all of the records should have been inserted.


TODO:
- Create the heap chain using the pages and append the chain to the heap.
- Check for leaks.
- Check if the inserts are actually done in the same page!!.