### PR TITLE
[CBRD-23018] changed_attrs_row_repl_entry: use proper heap id on pack/get_packed_size

### DIFF
--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -411,10 +411,9 @@ namespace cubreplication
   changed_attrs_row_repl_entry::~changed_attrs_row_repl_entry ()
   {
     cubthread::entry *my_thread = thread_get_thread_entry_info ();
-
     HL_HEAPID save_heapid = db_change_private_heap (my_thread, 0);
 
-    for (std::vector <DB_VALUE>::iterator it = m_new_values.begin (); it != m_new_values.end (); it++)
+    for (std::vector<DB_VALUE>::iterator it = m_new_values.begin (); it != m_new_values.end (); ++it)
       {
 	pr_clear_value (& (*it));
       }
@@ -453,6 +452,9 @@ namespace cubreplication
   void
   changed_attrs_row_repl_entry::pack (cubpacking::packer &serializator) const
   {
+    cubthread::entry &thread_ref = cubthread::get_entry ();
+    HL_HEAPID save_heapid = db_change_private_heap (&thread_ref, 0);
+
     serializator.pack_int (changed_attrs_row_repl_entry::PACKING_ID);
     single_row_repl_entry::pack (serializator);
     serializator.pack_int_vector (m_changed_attributes);
@@ -462,6 +464,8 @@ namespace cubreplication
       {
 	serializator.pack_db_value (m_new_values[i]);
       }
+
+    db_change_private_heap (&thread_ref, save_heapid);
   }
 
   void
@@ -502,6 +506,9 @@ namespace cubreplication
     /* we assume that offset start has already MAX_ALIGNMENT */
 
     /* type of packed object */
+    cubthread::entry &thread_ref = cubthread::get_entry ();
+    HL_HEAPID save_heapid = db_change_private_heap (&thread_ref, 0);
+
     std::size_t entry_size = start_offset;
 
     entry_size += serializator.get_packed_int_size (0);
@@ -514,6 +521,8 @@ namespace cubreplication
       {
 	entry_size += serializator.get_packed_db_value_size (m_new_values[i], entry_size);
       }
+
+    db_change_private_heap (&thread_ref, save_heapid);
 
     return entry_size;
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23018

Change private heap id when allocating memory on `pack` and `get_packed_size` of the `changed_attrs_row_repl_entry` (the memory is allocated when compressing strings)