### PR TITLE
[CBRD-23006] create session without connection for replication apply

### DIFF
--- a/src/base/tz_support.c
+++ b/src/base/tz_support.c
@@ -2845,7 +2845,6 @@ tz_datetime_utc_conv (const DB_DATETIME * src_dt, TZ_DECODE_INFO * tz_info, bool
 #endif
 	  err_status = ER_TZ_INTERNAL_ERROR;
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, err_status, 0);
-	  assert (false);
 	}
       goto exit;
     }

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -480,6 +480,12 @@ extern "C"
   /* session state id */
   typedef unsigned int SESSION_ID;
 
+  typedef enum
+  {
+    SESSION_WITH_CONNECTION = 0,
+    SESSION_WITHOUT_CONNECTION
+  } SESSION_MODE;
+
 /* uninitialized value for session id */
 #define DB_EMPTY_SESSION			0
 

--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -476,9 +476,9 @@ struct css_conn_entry
   void set_session_id (SESSION_ID id);
   const SESSION_ID get_session_id () const;
 #if defined(SERVER_MODE)
-  void set_session (session_state *session_arg);
-  session_state* get_session (void);
-#endif /* SERVER_MODE */
+  void set_session (session_state * session_arg);
+  session_state *get_session (void);
+#endif				/* SERVER_MODE */
 
 private:
   // note - I want to protect this.
@@ -486,14 +486,14 @@ private:
   SESSION_ID session_id;
 #if defined(SERVER_MODE)
   session_state *session_p;	/* session object for current request */
-#endif /* SERVER_MODE */
+#endif				/* SERVER_MODE */
 
 #else				// not c++ = c
   int transaction_id;
   SESSION_ID session_id;
 #if defined(SERVER_MODE)
   struct session_state *session_p;	/* session object for current request */
-#endif /* SERVER_MODE */
+#endif				/* SERVER_MODE */
 #endif				// not c++ = c
 };
 

--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -474,10 +474,10 @@ struct css_conn_entry
   void set_tran_index (int tran_index);
   int get_tran_index (void);
   void set_session_id (SESSION_ID id);
-  const SESSION_ID get_session_id () const;
+  SESSION_ID get_session_id () const;
 #if defined(SERVER_MODE)
   void set_session (session_state * session_arg);
-  session_state *get_session (void);
+  session_state *get_session (void) const;
 #endif				/* SERVER_MODE */
 
 private:

--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -458,7 +458,6 @@ struct css_conn_entry
   CSS_LIST abort_queue;		/* list of aborted requests */
   CSS_LIST buffer_queue;	/* list of buffers queued for data */
   CSS_LIST error_queue;		/* list of (server) error messages */
-  struct session_state *session_p;	/* session object for current request */
 #else
   FILE *file;
   CSS_QUEUE_ENTRY *request_queue;	/* the header for unseen requests */
@@ -468,19 +467,33 @@ struct css_conn_entry
   CSS_QUEUE_ENTRY *error_queue;	/* queue of (server) error messages */
   void *cnxn;
 #endif
-  SESSION_ID session_id;
   CSS_CONN_ENTRY *next;
 
 #if defined __cplusplus
   // transaction ID manipulation
   void set_tran_index (int tran_index);
   int get_tran_index (void);
+  void set_session_id (SESSION_ID id);
+  const SESSION_ID get_session_id () const;
+#if defined(SERVER_MODE)
+  void set_session (session_state *session_arg);
+  session_state* get_session (void);
+#endif /* SERVER_MODE */
 
 private:
   // note - I want to protect this.
   int transaction_id;
+  SESSION_ID session_id;
+#if defined(SERVER_MODE)
+  session_state *session_p;	/* session object for current request */
+#endif /* SERVER_MODE */
+
 #else				// not c++ = c
   int transaction_id;
+  SESSION_ID session_id;
+#if defined(SERVER_MODE)
+  struct session_state *session_p;	/* session object for current request */
+#endif /* SERVER_MODE */
 #endif				// not c++ = c
 };
 

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -303,9 +303,9 @@ css_initialize_conn (CSS_CONN_ENTRY * conn, SOCKET fd)
   conn->free_net_header_list = NULL;
   conn->free_net_header_count = 0;
 
-  conn->session_id = DB_EMPTY_SESSION;
+  conn->set_session_id (DB_EMPTY_SESSION);
 #if defined(SERVER_MODE)
-  conn->session_p = NULL;
+  conn->set_session (NULL);
   conn->client_type = BOOT_CLIENT_UNKNOWN;
 #endif
 
@@ -402,11 +402,11 @@ css_shutdown_conn (CSS_CONN_ENTRY * conn)
     }
 
 #if defined(SERVER_MODE)
-  if (conn->session_p)
+  if (conn->get_session ())
     {
-      session_state_decrease_ref_count (NULL, conn->session_p);
-      conn->session_p = NULL;
-      conn->session_id = DB_EMPTY_SESSION;
+      session_state_decrease_ref_count (NULL, conn->get_session ());
+      conn->set_session (NULL);
+      conn->set_session_id (DB_EMPTY_SESSION);
     }
 #endif
 
@@ -1299,7 +1299,7 @@ css_get_session_ids_for_active_connections (SESSION_ID ** session_ids, int *coun
   for (conn = css_Active_conn_anchor; conn != NULL; conn = next)
     {
       next = conn->next;
-      sessions_p[i] = conn->session_id;
+      sessions_p[i] = conn->get_session_id ();
       i++;
     }
 

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2923,4 +2923,30 @@ css_conn_entry::get_tran_index ()
   assert (transaction_id != LOG_SYSTEM_TRAN_INDEX);
   return transaction_id;
 }
+
+void
+css_conn_entry::set_session_id (SESSION_ID id)
+{
+  session_id = id;
+}
+
+const SESSION_ID css_conn_entry::get_session_id () const
+{
+  return session_id;
+}
+
+#if defined(SERVER_MODE)
+void
+css_conn_entry::set_session (session_state *session_arg)
+{
+  session_p = session_arg;
+}
+
+session_state *
+css_conn_entry::get_session ()
+{
+  return session_p;
+}
+#endif
+
 // *INDENT-ON*

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2930,7 +2930,8 @@ css_conn_entry::set_session_id (SESSION_ID id)
   session_id = id;
 }
 
-const SESSION_ID css_conn_entry::get_session_id () const
+SESSION_ID
+css_conn_entry::get_session_id () const
 {
   return session_id;
 }
@@ -2943,7 +2944,7 @@ css_conn_entry::set_session (session_state *session_arg)
 }
 
 session_state *
-css_conn_entry::get_session ()
+css_conn_entry::get_session () const
 {
   return session_p;
 }

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2866,9 +2866,9 @@ css_server_task::execute (context_type &thread_ref)
 {
   thread_ref.conn_entry = &m_conn;
 
-  if (thread_ref.conn_entry->session_p != NULL)
+  if (thread_ref.get_session () != NULL)
     {
-      thread_ref.private_lru_index = session_get_private_lru_idx (thread_ref.conn_entry->session_p);
+      thread_ref.private_lru_index = session_get_private_lru_idx (thread_ref.get_session ());
     }
   else
     {
@@ -2891,9 +2891,9 @@ void
 css_server_external_task::execute (context_type &thread_ref)
 {
   thread_ref.conn_entry = m_conn;
-  if (thread_ref.conn_entry != NULL && thread_ref.conn_entry->session_p != NULL)
+  if (thread_ref.get_session () != NULL)
     {
-      thread_ref.private_lru_index = session_get_private_lru_idx (thread_ref.conn_entry->session_p);
+      thread_ref.private_lru_index = session_get_private_lru_idx (thread_ref.get_session ());
     }
   else
     {

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2883,7 +2883,7 @@ css_server_task::execute (context_type &thread_ref)
   (void) css_internal_request_handler (thread_ref, m_conn);
 
   thread_ref.private_lru_index = -1;
-  thread_ref.conn_entry = NULL;
+  thread_ref.clear_conn_session ();
   thread_ref.m_status = cubthread::entry::status::TS_FREE;
 }
 
@@ -2907,7 +2907,7 @@ css_server_external_task::execute (context_type &thread_ref)
   m_task->execute (thread_ref);
 
   thread_ref.private_lru_index = -1;
-  thread_ref.conn_entry = NULL;
+  thread_ref.clear_conn_session ();
 }
 
 void
@@ -2920,7 +2920,7 @@ css_connection_task::execute (context_type & thread_ref)
   pthread_mutex_lock (&thread_ref.tran_index_lock);
   (void) css_connection_handler_thread (&thread_ref, &m_conn);
 
-  thread_ref.conn_entry = NULL;
+  thread_ref.clear_conn_session ();
 }
 
 //

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -958,7 +958,7 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
 	      goto exit_on_end;
 	    }
 
-          /* TODO : implement a mechanism to expire sessions without connnection */
+	  /* TODO : implement a mechanism to expire sessions without connnection */
 	  if (state->mode != SESSION_WITHOUT_CONNECTION && is_expired)
 	    {
 	      expired_sid_buffer[n_expired_sids++] = state->id;
@@ -3057,7 +3057,7 @@ session_state_verify_ref_count (THREAD_ENTRY * thread_p, SESSION_STATE * session
       assert (ref_count == 0);
       ref_count = 1;
     }
-  
+
   if (ref_count != session_p->ref_count)
     {
       END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3051,14 +3051,8 @@ session_state_verify_ref_count (THREAD_ENTRY * thread_p, SESSION_STATE * session
 	}
     }
 
-  if (session_p->mode == SESSION_WITHOUT_CONNECTION)
-    {
-      /* TODO : implement reference from thread only */
-      assert (ref_count == 0);
-      ref_count = 1;
-    }
-
-  if (ref_count != session_p->ref_count)
+  /* TODO : implement reference check when session is linked from thread only */
+  if (session_p->mode != SESSION_WITHOUT_CONNECTION && ref_count != session_p->ref_count)
     {
       END_SHARED_ACCESS_ACTIVE_CONN_ANCHOR (r);
       assert (0);

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -2737,17 +2737,9 @@ session_set_session_data (THREAD_ENTRY * thread_p, SESSION_STATE * session_p)
 	}
     }
 
-  if (thread_p->conn_entry != NULL)
-    {
-      /* If we have a connection entry associated with this thread, setup session data for this conn_entry */
-      thread_p->conn_entry->set_session (session_p);
-      thread_p->conn_entry->set_session_id (session_p->id);
-    }
-  else
-    {
-      thread_p->set_connectionless_session (session_p);
-      thread_p->set_connectionless_session_id (session_p->id);
-    }
+  thread_p->set_session (session_p);
+  thread_p->set_session_id (session_p->id);
+
   thread_p->private_lru_index = session_p->private_lru_index;
 #endif
 }

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -38,7 +38,7 @@ struct xasl_cache_ent;
 
 extern int session_states_init (THREAD_ENTRY * thread_p);
 extern void session_states_finalize (THREAD_ENTRY * thread_p);
-extern int session_state_create (THREAD_ENTRY * thread_p, SESSION_ID * id);
+extern int session_state_create (THREAD_ENTRY * thread_p, SESSION_ID * id, const SESSION_MODE mode);
 extern int session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id);
 extern int session_check_session (THREAD_ENTRY * thread_p, const SESSION_ID id);
 extern int session_get_session_id (THREAD_ENTRY * thread_p, SESSION_ID * id);

--- a/src/session/session_sr.c
+++ b/src/session/session_sr.c
@@ -40,7 +40,7 @@ xsession_create_new (THREAD_ENTRY * thread_p, SESSION_ID * id)
 {
   assert (id != NULL);
 
-  return session_state_create (thread_p, id);
+  return session_state_create (thread_p, id, SESSION_WITH_CONNECTION);
 }
 
 /*

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -266,7 +266,7 @@ namespace cubthread
       {
 	assert (m_session_id == conn_entry->get_session_id ());
       }
-    
+
     return m_session_id;
 #else
     assert (0);

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -462,6 +462,13 @@ namespace cubthread
     tran_index = NULL_TRAN_INDEX;
   }
 
+  void
+  entry::clear_conn_session ()
+  {
+    conn_entry = NULL;
+    set_session (NULL);
+    set_session_id (DB_EMPTY_SESSION);
+  }
 } // namespace cubthread
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -249,7 +249,8 @@ namespace cubthread
 #if defined (SERVER_MODE)
     if (conn_entry != NULL)
       {
-	assert (m_session_p == conn_entry->get_session ());
+	assert (m_session_p == NULL || m_session_p == conn_entry->get_session ());
+	return conn_entry->get_session ();
       }
     return m_session_p;
 #else
@@ -264,7 +265,8 @@ namespace cubthread
 #if defined (SERVER_MODE)
     if (conn_entry != NULL)
       {
-	assert (m_session_id == conn_entry->get_session_id ());
+	assert (m_session_id == DB_EMPTY_SESSION || m_session_id == conn_entry->get_session_id ());
+	return conn_entry->get_session_id ();
       }
 
     return m_session_id;

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -218,12 +218,12 @@ namespace cubthread
 #if defined (SERVER_MODE)
     if (conn_entry != NULL)
       {
-        conn_entry->set_session (session_arg);
+	conn_entry->set_session (session_arg);
       }
     else
       {
-        /* no connection for this thread entry */
-        set_connectionless_session (session_arg);
+	/* no connection for this thread entry */
+	set_connectionless_session (session_arg);
       }
 #else
     assert (0);
@@ -244,12 +244,12 @@ namespace cubthread
 #if defined (SERVER_MODE)
     if (conn_entry != NULL)
       {
-        conn_entry->set_session_id (id);
+	conn_entry->set_session_id (id);
       }
     else
       {
-        /* no connection for this thread entry */
-        set_connectionless_session_id (id);
+	/* no connection for this thread entry */
+	set_connectionless_session_id (id);
       }
 #else
     assert (0);
@@ -263,18 +263,18 @@ namespace cubthread
     m_connectionless_session_id = id;
   }
 
-  session_state*
+  session_state *
   entry::get_session ()
   {
 #if defined (SERVER_MODE)
     if (conn_entry != NULL)
       {
-        return conn_entry->get_session ();
+	return conn_entry->get_session ();
       }
     else
       {
-        /* no connection for this thread entry */
-        return get_connectionless_session ();
+	/* no connection for this thread entry */
+	return get_connectionless_session ();
       }
 #else
     assert (0);
@@ -288,12 +288,12 @@ namespace cubthread
 #if defined (SERVER_MODE)
     if (conn_entry != NULL)
       {
-        return conn_entry->get_session_id ();
+	return conn_entry->get_session_id ();
       }
     else
       {
-        /* no connection for this thread entry */
-        return m_connectionless_session_id;
+	/* no connection for this thread entry */
+	return m_connectionless_session_id;
       }
 #else
     assert (0);
@@ -301,7 +301,7 @@ namespace cubthread
 #endif /* SERVER_MODE */
   }
 
-  session_state*
+  session_state *
   entry::get_connectionless_session ()
   {
     assert (conn_entry == NULL);

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -53,6 +53,10 @@ struct vacuum_worker;
 // from xasl_unpack_info.hpp
 struct xasl_unpack_info;
 
+struct session_state;
+
+typedef unsigned int SESSION_ID;
+
 // forward resource trackers
 namespace cubbase
 {
@@ -322,6 +326,14 @@ namespace cubthread
       void push_resource_tracks (void);
       void pop_resource_tracks (void);
 
+      void set_session (session_state *session_arg);
+      void set_connectionless_session (session_state *session_arg);
+      void set_session_id (SESSION_ID id);
+      void set_connectionless_session_id (SESSION_ID id);
+      session_state* get_session ();
+      SESSION_ID get_session_id ();
+      session_state* get_connectionless_session ();
+
     private:
       void clear_resources (void);
 
@@ -338,6 +350,9 @@ namespace cubthread
       cubbase::pgbuf_tracker &m_pgbuf_tracker;
       cubsync::critical_section_tracker &m_csect_tracker;
       log_system_tdes *m_systdes;
+
+      session_state *m_connectionless_session_p;
+      SESSION_ID m_connectionless_session_id;
   };
 
 } // namespace cubthread

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -321,6 +321,7 @@ namespace cubthread
       }
       void claim_system_worker ();
       void retire_system_worker ();
+      void clear_conn_session ();
 
       void end_resource_tracks (void);
       void push_resource_tracks (void);

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -330,9 +330,9 @@ namespace cubthread
       void set_connectionless_session (session_state *session_arg);
       void set_session_id (SESSION_ID id);
       void set_connectionless_session_id (SESSION_ID id);
-      session_state* get_session ();
+      session_state *get_session ();
       SESSION_ID get_session_id ();
-      session_state* get_connectionless_session ();
+      session_state *get_connectionless_session ();
 
     private:
       void clear_resources (void);

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -327,12 +327,9 @@ namespace cubthread
       void pop_resource_tracks (void);
 
       void set_session (session_state *session_arg);
-      void set_connectionless_session (session_state *session_arg);
       void set_session_id (SESSION_ID id);
-      void set_connectionless_session_id (SESSION_ID id);
-      session_state *get_session ();
-      SESSION_ID get_session_id ();
-      session_state *get_connectionless_session ();
+      session_state *get_session () const;
+      SESSION_ID get_session_id () const;
 
     private:
       void clear_resources (void);
@@ -351,8 +348,8 @@ namespace cubthread
       cubsync::critical_section_tracker &m_csect_tracker;
       log_system_tdes *m_systdes;
 
-      session_state *m_connectionless_session_p;
-      SESSION_ID m_connectionless_session_id;
+      session_state *m_session_p;
+      SESSION_ID m_session_id;
   };
 
 } // namespace cubthread

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -14306,7 +14306,7 @@ locator_repl_start_tran (THREAD_ENTRY * thread_p)
 
   SESSION_ID id = DB_EMPTY_SESSION;
 
-  error_code = session_state_create (thread_p, &id);
+  error_code = session_state_create (thread_p, &id, SESSION_WITHOUT_CONNECTION);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR_AND_SET (error_code);

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7552,8 +7552,8 @@ end:
 	    {
 	      /* Aborts and simulate apply replication RBR on master node. */
 	      error_code =
-		logtb_get_tdes (thread_p)->
-		replication_log_generator.abort_sysop_and_simulate_apply_repl_rbr_on_master (filter_replication_lsa);
+		logtb_get_tdes (thread_p)->replication_log_generator.
+		abort_sysop_and_simulate_apply_repl_rbr_on_master (filter_replication_lsa);
 	    }
 	  else
 	    {

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7552,8 +7552,8 @@ end:
 	    {
 	      /* Aborts and simulate apply replication RBR on master node. */
 	      error_code =
-		logtb_get_tdes (thread_p)->replication_log_generator.
-		abort_sysop_and_simulate_apply_repl_rbr_on_master (filter_replication_lsa);
+		logtb_get_tdes (thread_p)->
+		replication_log_generator.abort_sysop_and_simulate_apply_repl_rbr_on_master (filter_replication_lsa);
 	    }
 	  else
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23006

Allow to create session without a connection entry; in this case, the session is linked directly into thread entry.
The session is linked to both thread entry and connection entry.

TODO:
The apply thread should require timezone (or other specific session parameters) only for value printing.
We may need to rethink the replicating of system parameters to apply also for RBRs (currently they apply only for SBRs as in legacy behavior).
Implement reference count and timeout for session without connection.