### PR TITLE
[CBRD-23008] [replication] ddl_proxy: disable trigger execution

### DIFF
--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -3597,6 +3597,9 @@ start_ddl_proxy_client (const char *program_name, DDL_CLIENT_ARGUMENT * args)
       return rc;
     }
 
+  // ddl_proxy should not fire trigger action
+  db_disable_trigger ();
+
   if (args->sys_param != NULL)
     {
       er_stack_push ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23008

Trigger execution needs to be disabled in ddl_proxy client, as legacy implementation of applylogdb does.
https://github.com/CUBRID/cubrid/blob/b85a234af25f8f27bb08cb7b8bf377383bcafa21/src/executables/util_cs.c#L2926