### PR TITLE
[CBRD-23020] [replication] fix memory leak in master_senders_supervisor_task::execute

### DIFF
--- a/src/replication/replication_master_node.cpp
+++ b/src/replication/replication_master_node.cpp
@@ -64,7 +64,7 @@ namespace cubreplication
     replication_node::get_replication_file_path (replication_path);
     instance->m_stream_file = new cubstream::stream_file (*instance->m_stream, replication_path);
 
-    master_senders_manager::init (instance->m_stream);
+    master_senders_manager::init ();
 
     cubtx::master_group_complete_manager::init ();
 
@@ -103,8 +103,7 @@ namespace cubreplication
     css_error_code rc = chn.accept (fd);
     assert (rc == NO_ERRORS);
 
-    master_senders_manager::add_stream_sender
-    (new cubstream::transfer_sender (std::move (chn), cubreplication::master_senders_manager::get_stream ()));
+    master_senders_manager::add_stream_sender (new cubstream::transfer_sender (std::move (chn), *g_instance->m_stream));
 
     er_log_debug_replication (ARG_FILE_LINE, "new_slave connected");
   }

--- a/src/replication/replication_master_senders_manager.cpp
+++ b/src/replication/replication_master_senders_manager.cpp
@@ -32,18 +32,17 @@
 namespace cubreplication
 {
 
-  std::vector <cubstream::transfer_sender *> master_senders_manager::master_server_stream_senders;
+  std::vector<cubstream::transfer_sender *> master_senders_manager::master_server_stream_senders;
   cubthread::daemon *master_senders_manager::master_channels_supervisor_daemon = NULL;
   bool master_senders_manager::is_initialized = false;
   std::mutex master_senders_manager::mutex_for_singleton;
   cubstream::stream_position master_senders_manager::g_minimum_successful_stream_position;
-  cubstream::stream *master_senders_manager::g_stream;
   SYNC_RWLOCK master_senders_manager::master_senders_lock;
 
   const unsigned int master_senders_manager::SUPERVISOR_DAEMON_DELAY_MS = 10;
   const unsigned int master_senders_manager::SUPERVISOR_DAEMON_CHECK_CONN_MS = 5000;
 
-  void master_senders_manager::init (cubstream::stream *stream)
+  void master_senders_manager::init ()
   {
 #if defined (SERVER_MODE)
     int error_code = NO_ERROR;
@@ -60,7 +59,6 @@ namespace cubreplication
 	new master_senders_supervisor_task (),
 	"supervisor_daemon");
     g_minimum_successful_stream_position = 0;
-    g_stream = stream;
 
     error_code = rwlock_initialize (&master_senders_lock, "MASTER_SENDERS_LOCK");
     assert (error_code == NO_ERROR);

--- a/src/replication/replication_master_senders_manager.hpp
+++ b/src/replication/replication_master_senders_manager.hpp
@@ -52,17 +52,11 @@ namespace cubreplication
       master_senders_manager () = delete;
       ~master_senders_manager () = delete;
 
-      static void init (cubstream::stream *stream);
+      static void init ();
       static void add_stream_sender (cubstream::transfer_sender *sender);
       static std::size_t get_number_of_stream_senders ();
       static void final ();
       static void block_until_position_sent (cubstream::stream_position desired_position);
-
-      static inline cubstream::stream &get_stream ()
-      {
-	assert (g_stream != NULL);
-	return *g_stream;
-      }
 
       static cubstream::stream_position g_minimum_successful_stream_position;
 
@@ -78,11 +72,10 @@ namespace cubreplication
 
       friend class master_senders_supervisor_task;
 
-      static std::vector <cubstream::transfer_sender *> master_server_stream_senders;
+      static std::vector<cubstream::transfer_sender *> master_server_stream_senders;
       static cubthread::daemon *master_channels_supervisor_daemon;
       static bool is_initialized;
       static std::mutex mutex_for_singleton;
-      static cubstream::stream *g_stream;
 
       static const unsigned int SUPERVISOR_DAEMON_DELAY_MS;
       static const unsigned int SUPERVISOR_DAEMON_CHECK_CONN_MS;

--- a/unit_tests/replication_channels/cub_master_mock.cpp
+++ b/unit_tests/replication_channels/cub_master_mock.cpp
@@ -85,8 +85,7 @@ namespace cub_master_mock
 	      }
 
 	    cubreplication::master_senders_manager::add_stream_sender (
-		    new cubstream::transfer_sender (std::move (listener_chn),
-						    cubreplication::master_senders_manager::get_stream ()));
+		    new cubstream::transfer_sender (std::move (listener_chn), master::get_mock_stream ()));
 	  }
       }
   };

--- a/unit_tests/replication_channels/master_replication_channel_mock.cpp
+++ b/unit_tests/replication_channels/master_replication_channel_mock.cpp
@@ -14,7 +14,6 @@
 #include "test_output.hpp"
 #include "connection_cl.h"
 #include "thread_looper.hpp"
-#include "mock_stream.hpp"
 
 static mock_stream master_mock_stream;
 
@@ -25,12 +24,18 @@ namespace master
   {
     master_mock_stream.init (0);
 
-    cubreplication::master_senders_manager::init (&master_mock_stream);
+    cubreplication::master_senders_manager::init ();
   }
 
   void finish ()
   {
     cubreplication::master_senders_manager::final ();
+  }
+
+  mock_stream &
+  get_mock_stream ()
+  {
+    return master_mock_stream;
   }
 
   void stream_produce (unsigned int num_bytes)

--- a/unit_tests/replication_channels/master_replication_channel_mock.hpp
+++ b/unit_tests/replication_channels/master_replication_channel_mock.hpp
@@ -2,7 +2,9 @@
 #define _MASTER_REPLICATION_CHANNEL_MOCK_HPP
 
 #define SERVER_MODE
+#include "mock_stream.hpp"
 #include "replication_master_senders_manager.hpp"
+
 #include <memory>
 
 namespace master
@@ -11,6 +13,7 @@ namespace master
   void init ();
   void finish ();
 
+  mock_stream &get_mock_stream ();
   void stream_produce (unsigned int num_bytes);
 
 } /* namespace master */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23020

- fix memory leak when erasing a transfer_sender https://github.com/CUBRID/cubrid/blob/0257b3ec51ac5f757d1f9a49799b3c148b281208/src/replication/replication_master_senders_manager.cpp#L185
- remove `cubreplication::master_senders_manager::g_stream` pointer, because when `cubreplication::master_node::g_instance` is deleted the pointer remains dangling