### PR TITLE
[CBRD-23024] safe guard master/slave node finalize

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1455,7 +1455,7 @@ shutdown:
   css_stop_all_workers (*thread_p, THREAD_STOP_WORKERS_EXCEPT_LOGWR);
 
   /* replication stops after workers */
-  if (!HA_DISABLED ())
+  if (!HA_DISABLED () && conn != NULL)
     {
       cubreplication::master_node::final ();
       cubreplication::slave_node::final ();

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1356,7 +1356,7 @@ css_initialize_server_interfaces (int (*request_handler) (THREAD_ENTRY * thrd, u
 int
 css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_id)
 {
-  CSS_CONN_ENTRY *conn;
+  CSS_CONN_ENTRY *conn = NULL;
   int status = NO_ERROR;
 
   if (server_name == NULL || port_id <= 0)

--- a/src/replication/replication_master_node.cpp
+++ b/src/replication/replication_master_node.cpp
@@ -129,6 +129,11 @@ namespace cubreplication
 
   void master_node::final (void)
   {
+    if (g_instance == NULL)
+      {
+	return;
+      }
+
     master_senders_manager::final ();
 
     delete g_instance->m_control_channel_manager;

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -119,7 +119,10 @@ namespace cubreplication
 
   void slave_node::final (void)
   {
-    assert (g_instance != NULL);
+    if (g_instance == NULL)
+      {
+	return;
+      }
 
     delete g_instance->m_transfer_receiver;
     g_instance->m_transfer_receiver = NULL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23024

`cubreplication` `master_node` and `slave_node` instances are initialized only if `!HA_DISABLED` and `conn != NULL` (conn is the connection to the cub_master). Nodes must be stopped under same conditions, in order to avoid stopping uninitialized nodes 