### PR TITLE
[CBRD-23023] reset private lru index after execution

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2882,7 +2882,6 @@ css_server_task::execute (context_type &thread_ref)
   pthread_mutex_lock (&thread_ref.tran_index_lock);
   (void) css_internal_request_handler (thread_ref, m_conn);
 
-  thread_ref.private_lru_index = -1;
   thread_ref.clear_conn_session ();
   thread_ref.m_status = cubthread::entry::status::TS_FREE;
 }
@@ -2906,7 +2905,6 @@ css_server_external_task::execute (context_type &thread_ref)
 
   m_task->execute (thread_ref);
 
-  thread_ref.private_lru_index = -1;
   thread_ref.clear_conn_session ();
 }
 

--- a/src/thread/thread_entry_task.cpp
+++ b/src/thread/thread_entry_task.cpp
@@ -83,6 +83,7 @@ namespace cubthread
     context.end_resource_tracks ();
     std::memset (&context.event_stats, 0, sizeof (context.event_stats));  // clear even stats
     context.tran_index = NULL_TRAN_INDEX;    // clear transaction ID
+    context.private_lru_index = -1;
 #if defined (SERVER_MODE)
     context.resume_status = THREAD_RESUME_NONE;
     context.shutdown = false;

--- a/src/thread/thread_entry_task.cpp
+++ b/src/thread/thread_entry_task.cpp
@@ -65,7 +65,7 @@ namespace cubthread
 
     // todo: here we should do more operations to clear thread entry before being reused
     context.unregister_id ();
-    context.tran_index = -1;
+    context.tran_index = NULL_TRAN_INDEX;
     context.check_interrupt = true;
     context.private_lru_index = -1;
 #if defined (SERVER_MODE)

--- a/src/thread/thread_entry_task.cpp
+++ b/src/thread/thread_entry_task.cpp
@@ -67,6 +67,7 @@ namespace cubthread
     context.unregister_id ();
     context.tran_index = -1;
     context.check_interrupt = true;
+    context.private_lru_index = -1;
 #if defined (SERVER_MODE)
     context.m_status = entry::status::TS_FREE;
     context.resume_status = THREAD_RESUME_NONE;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23023

The thread_entry context may be reused between thread worker pools.
A thread entry may server as context for replication apply worker pool (a private lru is assigned) and then attached to server worker pool.
The fix resets private lru on retire and recyle of context.
TODO : same fix on develop branch.