### PR TITLE
[CBRD-23027] fix get session parameter when session parameters are missing

### DIFF
--- a/src/session/session.c
+++ b/src/session/session.c
@@ -2763,19 +2763,16 @@ session_set_session_data (THREAD_ENTRY * thread_p, SESSION_STATE * session_p)
 SESSION_PARAM *
 session_get_session_parameter (THREAD_ENTRY * thread_p, PARAM_ID id)
 {
-  int i, count;
-  SESSION_STATE *session_p = NULL;
-
-  session_p = session_get_session_state (thread_p);
-  if (session_p == NULL)
+  SESSION_STATE *session_p = session_get_session_state (thread_p);
+  if (session_p == NULL || session_p->session_parameters == NULL)
     {
       return NULL;
     }
 
   assert (id <= PRM_LAST_ID);
 
-  count = sysprm_get_session_parameters_count ();
-  for (i = 0; i < count; i++)
+  int count = sysprm_get_session_parameters_count ();
+  for (int i = 0; i < count; ++i)
     {
       if (session_p->session_parameters[i].prm_id == id)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23027

`session_get_session_parameter`: return `NULL` if `session_p->session_parameters` are missing