### PR TITLE
[CBRD-23030] disable by default debug replication data

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2222,7 +2222,7 @@ static bool prm_debug_autocommit_default = false;
 static unsigned int prm_debug_autocommit_flag = 0;
 
 bool PRM_DEBUG_REPLICATION_DATA = true;
-static bool prm_debug_replication_data_default = true;
+static bool prm_debug_replication_data_default = false;
 static unsigned int prm_debug_replication_data_flag = 0;
 
 bool PRM_TRACK_REQUESTS = false;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23030


Some tests: like https://github.com/CUBRID/cubrid-testcases/blob/e0941ae9902e18232d95c7809cde7bebb5b1296e/sql/_13_issues/_14_1h/cases/bug_bts_12463.sql sometimes exceeds 10m timeout on circleci test_sql job. It was caused by debug replication data being enabled by default 