### PR TITLE
[CBRD-23032] thread tasks with callables

### DIFF
--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -31,14 +31,9 @@
 
 #include "connection_defs.h"
 #include "connection_sr.h"
-#include "thread_compat.hpp"
+#include "thread_entry.hpp"
+#include "thread_entry_task.hpp"
 #include "master_heartbeat.h"
-
-// forward definitions
-namespace cubthread
-{
-  class entry_task;
-}				// namespace cubthread
 
 enum css_thread_stop_type
 {

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -498,28 +498,18 @@ session_free_prepared_statement (PREPARED_STATEMENT * stmt_p)
 
 // *INDENT-OFF*
 #if defined (SERVER_MODE)
-// class session_control_daemon_task
-//
-//  description:
-//    session control daemon task
-//
-class session_control_daemon_task : public cubthread::entry_task
+void
+session_control_daemon_execute (cubthread::entry & thread_ref)
 {
-  public:
-    void execute (cubthread::entry & thread_ref) override
+  if (!BO_IS_SERVER_RESTARTED ())
     {
-      if (!BO_IS_SERVER_RESTARTED ())
-	{
-	  // wait for boot to finish
-	  return;
-	}
-
-      session_remove_expired_sessions (&thread_ref);
+      // wait for boot to finish
+      return;
     }
-};
-#endif /* SERVER_MODE */
 
-#if defined (SERVER_MODE)
+  session_remove_expired_sessions (&thread_ref);
+}
+
 /*
  * session_control_daemon_init () - initialize session control daemon
  */
@@ -529,14 +519,13 @@ session_control_daemon_init ()
   assert (session_Control_daemon == NULL);
 
   cubthread::looper looper = cubthread::looper (std::chrono::seconds (60));
-  session_control_daemon_task *daemon_task = new session_control_daemon_task ();
+  cubthread::entry_callable_task *daemon_task =
+    new cubthread::entry_callable_task (std::bind (session_control_daemon_execute, std::placeholders::_1));
 
   // create session control daemon thread
   session_Control_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "session_control");
 }
-#endif /* SERVER_MODE */
 
-#if defined (SERVER_MODE)
 /*
  * session_control_daemon_destroy () - destroy session control daemon
  */

--- a/src/thread/thread_entry_task.hpp
+++ b/src/thread/thread_entry_task.hpp
@@ -55,16 +55,8 @@ namespace cubthread
   //     2.2. pass it to a worker pool to be executed once
   //        see thread_manager.hpp, thread_daemon.hpp and thread_worker_pool.hpp for more details
   //
-  class entry_task : public task<entry>
-  {
-    public:
-
-      entry_task () = default;
-
-    private:
-      // disable copy constructor
-      entry_task (const entry_task &other);
-  };
+  using entry_task = task<entry>;
+  using entry_callable_task = callable_task<entry>;
 
   // cubthread::entry_manager
   //

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -30,6 +30,7 @@
 
 // same module includes
 #include "thread_entry.hpp"
+#include "thread_entry_task.hpp"
 #include "thread_task.hpp"
 #include "thread_waiter.hpp"
 
@@ -50,8 +51,6 @@ namespace cubthread
   class worker_pool;
   class looper;
   class daemon;
-  class entry_task;
-  class entry_manager;
   class daemon_entry_manager;
 
   // alias for worker_pool<entry>

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -24,6 +24,7 @@
 #ifndef _THREAD_TASK_HPP_
 #define _THREAD_TASK_HPP_
 
+#include <functional>
 #include <mutex>
 #include <thread>
 
@@ -78,6 +79,50 @@ namespace cubthread
       }
   };
 
+  // a class based on callable execution function
+  template <typename Context>
+  class callable_task : public task<Context>
+  {
+    public:
+
+      callable_task () = delete;
+
+      template <typename F>
+      callable_task (F f, bool delete_on_retire = true)
+	: m_exec_f (f)
+      {
+	if (delete_on_retire)
+	  {
+	    m_retire_f = [this] { delete this; };
+	  }
+	else
+	  {
+	    m_retire_f = [] {};  // do nothing
+	  }
+      }
+
+      template <typename FuncExec, typename FuncRetire>
+      callable_task (FuncExec fe, FuncRetire fr)
+	: m_exec_f (fe)
+	, m_retire_f (fr)
+      {
+      }
+
+      void execute (context_type &ctx) final
+      {
+	m_exec_f (ctx);
+      }
+
+      void retire () final
+      {
+	m_retire_f ();
+      }
+
+    private:
+      std::function<void (Context &)> m_exec_f;
+      std::function<void (void)> m_retire_f;
+  };
+
   // context-less task specialization. no argument for execute function
   template<>
   class task<void>
@@ -93,6 +138,49 @@ namespace cubthread
       }
   };
   using task_without_context = task<void>;
+
+  template<>
+  class callable_task<void> : public task_without_context
+  {
+    public:
+
+      callable_task () = delete;
+
+      template <typename F>
+      callable_task (F f, bool delete_on_retire = true)
+	: m_exec_f (f)
+      {
+	if (delete_on_retire)
+	  {
+	    m_retire_f = [this] { delete this; };
+	  }
+	else
+	  {
+	    m_retire_f = [] {};  // do nothing
+	  }
+      }
+
+      template <typename FuncExec, typename FuncRetire>
+      callable_task (FuncExec fe, FuncRetire fr)
+	: m_exec_f (fe)
+	, m_retire_f (fr)
+      {
+      }
+
+      void execute () final
+      {
+	m_exec_f ();
+      }
+
+      void retire () final
+      {
+	m_retire_f ();
+      }
+
+    private:
+      std::function<void (void)> m_exec_f;
+      std::function<void (void)> m_retire_f;
+  };
 
   // context_manager
   //

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -87,26 +87,13 @@ namespace cubthread
 
       callable_task () = delete;
 
+      // constructor with default retire (delete/do nothing)
       template <typename F>
-      callable_task (F f, bool delete_on_retire = true)
-	: m_exec_f (f)
-      {
-	if (delete_on_retire)
-	  {
-	    m_retire_f = [this] { delete this; };
-	  }
-	else
-	  {
-	    m_retire_f = [] {};  // do nothing
-	  }
-      }
+      callable_task (F f, bool delete_on_retire = true);
 
+      // constructor with custom retire
       template <typename FuncExec, typename FuncRetire>
-      callable_task (FuncExec fe, FuncRetire fr)
-	: m_exec_f (fe)
-	, m_retire_f (fr)
-      {
-      }
+      callable_task (FuncExec fe, FuncRetire fr);
 
       void execute (context_type &ctx) final
       {
@@ -146,26 +133,13 @@ namespace cubthread
 
       callable_task () = delete;
 
+      // constructor with default retire (delete/do nothing)
       template <typename F>
-      callable_task (F f, bool delete_on_retire = true)
-	: m_exec_f (f)
-      {
-	if (delete_on_retire)
-	  {
-	    m_retire_f = [this] { delete this; };
-	  }
-	else
-	  {
-	    m_retire_f = [] {};  // do nothing
-	  }
-      }
+      callable_task (F f, bool delete_on_retire = true);
 
+      // constructor with custom retire
       template <typename FuncExec, typename FuncRetire>
-      callable_task (FuncExec fe, FuncRetire fr)
-	: m_exec_f (fe)
-	, m_retire_f (fr)
-      {
-      }
+      callable_task (FuncExec fe, FuncRetire fr);
 
       void execute () final
       {
@@ -239,5 +213,57 @@ namespace cubthread
   };
 
 } // namespace cubthread
+
+//////////////////////////////////////////////////////////////////////////
+// Implementation
+//////////////////////////////////////////////////////////////////////////
+
+namespace cubthread
+{
+  template<typename Context>
+  template<typename F>
+  callable_task<Context>::callable_task (F f, bool delete_on_retire)
+    : m_exec_f (f)
+  {
+    if (delete_on_retire)
+      {
+	m_retire_f = [this] { delete this; };
+      }
+    else
+      {
+	m_retire_f = [] {};  // do nothing
+      }
+  }
+
+  template<typename Context>
+  template<typename FuncExec, typename FuncRetire>
+  callable_task<Context>::callable_task (FuncExec fe, FuncRetire fr)
+    : m_exec_f (fe)
+    , m_retire_f (fr)
+  {
+  }
+
+  template<typename F>
+  callable_task<void>::callable_task (F f, bool delete_on_retire)
+    : m_exec_f (f)
+  {
+    if (delete_on_retire)
+      {
+	m_retire_f = [this] { delete this; };
+      }
+    else
+      {
+	m_retire_f = [] {};  // do nothing
+      }
+  }
+
+  template<typename FuncExec, typename FuncRetire>
+  callable_task<void>::callable_task (FuncExec fe, FuncRetire fr)
+    : m_exec_f (fe)
+    , m_retire_f (fr)
+  {
+  }
+} // namespace cubthread
+
 
 #endif // _THREAD_TASK_HPP_

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -95,7 +95,7 @@ namespace cubthread
       template <typename FuncExec, typename FuncRetire>
       callable_task (FuncExec fe, FuncRetire fr);
 
-      void execute (context_type &ctx) final
+      void execute (Context &ctx) final
       {
 	m_exec_f (ctx);
       }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23032

Make it easy to instantiate custom callable_tasks based on execution callable (and optionally retire callable). 

Changes:

- callable_task classes (with and without context). template constructors with callable types.
- entry_callable_task specialization.
- replace session_control_daemon_task as proof of concept.

Future todo: replace other task classes with callable_task.