### PR TITLE
[CBRD-22937] pack stream entry state and count separately

### DIFF
--- a/src/replication/replication_stream_entry.cpp
+++ b/src/replication/replication_stream_entry.cpp
@@ -116,16 +116,8 @@ namespace cubreplication
     m_header.count_replication_entries = (int) m_packable_entries.size ();
     serializator->pack_bigint (m_header.prev_record);
     serializator->pack_bigint (m_header.mvccid);
-
-    assert ((m_header.count_replication_entries & stream_entry_header::COUNT_VALUE_MASK)
-	    == m_header.count_replication_entries);
-
-    state_flags = m_header.tran_state;
-    state_flags = state_flags << (32 - stream_entry_header::STATE_BITS);
-
-    count_and_flags = m_header.count_replication_entries | state_flags;
-
-    serializator->pack_int (count_and_flags);
+    serializator->pack_to_int (m_header.tran_state);
+    serializator->pack_to_int (m_header.count_replication_entries);
     serializator->pack_int (m_header.data_size);
 
     return NO_ERROR;
@@ -149,12 +141,9 @@ namespace cubreplication
 
     serializator->unpack_bigint (m_header.prev_record);
     serializator->unpack_bigint (m_header.mvccid);
-    serializator->unpack_int (reinterpret_cast<int &> (count_and_flags)); // is this safe?s
-
-    state_flags = (count_and_flags & stream_entry_header::STATE_MASK) >> (32 - stream_entry_header::STATE_BITS);
-    m_header.tran_state = (stream_entry_header::TRAN_STATE) state_flags;
-
-    m_header.count_replication_entries = count_and_flags & stream_entry_header::COUNT_VALUE_MASK;
+    serializator->unpack_from_int (m_header.tran_state);
+    assert (m_header.tran_state != stream_entry_header::UNDEFINED);
+    serializator->unpack_from_int (m_header.count_replication_entries);
     serializator->unpack_int (m_header.data_size);
 
     return NO_ERROR;

--- a/src/replication/replication_stream_entry.hpp
+++ b/src/replication/replication_stream_entry.hpp
@@ -49,12 +49,6 @@ namespace cubreplication
       NEW_MASTER
     } TRAN_STATE;
 
-    const static unsigned STATE_BITS = 3;
-
-    const static unsigned int STATE_MASK = 0xe0000000;
-
-    const static unsigned int COUNT_VALUE_MASK = ~ (STATE_MASK);
-
     cubstream::stream_position prev_record;
     MVCCID mvccid;
     unsigned int count_replication_entries;
@@ -77,6 +71,7 @@ namespace cubreplication
 
       header_size += serializator.get_packed_bigint_size (header_size);
       header_size += serializator.get_packed_bigint_size (header_size);
+      header_size += serializator.get_packed_int_size (header_size);
       header_size += serializator.get_packed_int_size (header_size);
       header_size += serializator.get_packed_int_size (header_size);
 
@@ -184,9 +179,9 @@ namespace cubreplication
 	       || m_header.tran_state > stream_entry_header::NEW_MASTER;
       }
 
-      int pack_stream_entry_header ();
-      int unpack_stream_entry_header ();
-      int get_packable_entry_count_from_header (void);
+      int pack_stream_entry_header () override;
+      int unpack_stream_entry_header () override;
+      int get_packable_entry_count_from_header (void) override;
 
       void stringify (string_buffer &sb, const string_dump_mode mode = short_dump);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22937

Separate packing of stream entry tran state and count to avoid bitmask missmatch.

Code extracted from https://github.com/CUBRID/cubrid/pull/160