### PR TITLE
[CBRD-23035] minor changes (fix warnings & other)

### DIFF
--- a/src/base/packer.cpp
+++ b/src/base/packer.cpp
@@ -349,7 +349,7 @@ namespace cubpacking
   }
 
   size_t
-  packer::get_packed_int_vector_size (size_t curr_offset, const int count)
+  packer::get_packed_int_vector_size (size_t curr_offset, const size_t count)
   {
     return DB_ALIGN (curr_offset, INT_ALIGNMENT) - curr_offset + (OR_INT_SIZE * (count + 1));
   }

--- a/src/base/packer.hpp
+++ b/src/base/packer.hpp
@@ -79,7 +79,7 @@ namespace cubpacking
 
       void pack_int_array (const int *array, const int count);
 
-      size_t get_packed_int_vector_size (size_t curr_offset, const int count);
+      size_t get_packed_int_vector_size (size_t curr_offset, const size_t count);
       void pack_int_vector (const std::vector<int> &array);
 
       size_t get_packed_db_value_size (const db_value &value, size_t curr_offset);

--- a/src/base/stream_entry.hpp
+++ b/src/base/stream_entry.hpp
@@ -323,7 +323,7 @@ namespace cubstream
 	m_packable_entries.push_back (entry);
       };
 
-      PO *get_object_at (int pos)
+      PO *get_object_at (size_t pos)
       {
 	return m_packable_entries[pos];
       }

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -9481,8 +9481,8 @@ schksum_insert_repl_log_and_demote_table_lock (THREAD_ENTRY * thread_p, unsigned
   char *reply = OR_ALIGNED_BUF_START (a_reply);
   char *ptr;
   OID class_oid;
-  REPL_INFO repl_info = { NULL, 0, false };
-  REPL_INFO_SBR repl_stmt = { 0, NULL, NULL, NULL, NULL };
+  REPL_INFO repl_info;
+  REPL_INFO_SBR repl_stmt;
 
   ptr = or_unpack_oid (request, &class_oid);
   ptr = or_unpack_int (ptr, &repl_info.repl_info_type);

--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -71,7 +71,7 @@ namespace cubreplication
     LSA_SET_NULL (&m_lsa_stamp);
   }
 
-  replication_object::replication_object (LOG_LSA &lsa_stamp)
+  replication_object::replication_object (const LOG_LSA &lsa_stamp)
   {
     LSA_COPY (&m_lsa_stamp, &lsa_stamp);
   }
@@ -172,7 +172,8 @@ namespace cubreplication
       }
   }
 
-  single_row_repl_entry::single_row_repl_entry (const repl_entry_type type, const char *class_name, LOG_LSA &lsa_stamp)
+  single_row_repl_entry::single_row_repl_entry (const repl_entry_type type, const char *class_name,
+      const LOG_LSA &lsa_stamp)
     : replication_object (lsa_stamp)
     , m_type (type)
     , m_class_name (class_name)
@@ -600,7 +601,7 @@ namespace cubreplication
   }
 
   changed_attrs_row_repl_entry::changed_attrs_row_repl_entry (repl_entry_type type, const char *class_name,
-      const OID &inst_oid, LOG_LSA &lsa_stamp)
+      const OID &inst_oid, const LOG_LSA &lsa_stamp)
     : single_row_repl_entry (type, class_name, lsa_stamp)
     , m_changed_attributes ()
     , m_new_values ()
@@ -703,7 +704,7 @@ namespace cubreplication
   }
 
   rec_des_row_repl_entry::rec_des_row_repl_entry (repl_entry_type type, const char *class_name, const RECDES &rec_des,
-      LOG_LSA &lsa_stamp)
+      const LOG_LSA &lsa_stamp)
     : single_row_repl_entry (type, class_name, lsa_stamp)
     , m_rec_des (rec_des, cubmem::STANDARD_BLOCK_ALLOCATOR)
   {

--- a/src/replication/replication_object.hpp
+++ b/src/replication/replication_object.hpp
@@ -55,7 +55,7 @@ namespace cubreplication
   {
     public:
       replication_object ();
-      replication_object (LOG_LSA &lsa_stamp);
+      replication_object (const LOG_LSA &lsa_stamp);
       virtual int apply (void) = 0;
       // todo: const
       virtual void stringify (string_buffer &str) = 0;
@@ -117,7 +117,7 @@ namespace cubreplication
 
       void set_key_value (const DB_VALUE &db_val);
       void set_class_name (const char *class_name);
-      single_row_repl_entry (const repl_entry_type type, const char *class_name, LOG_LSA &lsa_stamp);
+      single_row_repl_entry (const repl_entry_type type, const char *class_name, const LOG_LSA &lsa_stamp);
       single_row_repl_entry () = default;
 
     protected:
@@ -141,7 +141,8 @@ namespace cubreplication
     public:
       static const int PACKING_ID = 3;
 
-      rec_des_row_repl_entry (repl_entry_type type, const char *class_name, const RECDES &rec_des, LOG_LSA &lsa_stamp);
+      rec_des_row_repl_entry (repl_entry_type type, const char *class_name, const RECDES &rec_des,
+			      const LOG_LSA &lsa_stamp);
 
       rec_des_row_repl_entry () = default;
       ~rec_des_row_repl_entry ();
@@ -165,7 +166,7 @@ namespace cubreplication
       static const int PACKING_ID = 4;
 
       changed_attrs_row_repl_entry (repl_entry_type type, const char *class_name, const OID &inst_oid,
-				    LOG_LSA &lsa_stamp);
+				    const LOG_LSA &lsa_stamp);
 
       changed_attrs_row_repl_entry () = default;
       ~changed_attrs_row_repl_entry ();

--- a/src/replication/replication_stream_entry.hpp
+++ b/src/replication/replication_stream_entry.hpp
@@ -158,27 +158,27 @@ namespace cubreplication
 	m_header.tran_state = state;
       }
 
-      bool is_group_commit (void)
+      bool is_group_commit (void) const
       {
 	return m_header.tran_state == stream_entry_header::GROUP_COMMIT;
       }
 
-      bool is_new_master ()
+      bool is_new_master () const
       {
 	return m_header.tran_state == stream_entry_header::NEW_MASTER;
       }
 
-      bool is_tran_commit (void)
+      bool is_tran_commit (void) const
       {
 	return m_header.tran_state == stream_entry_header::COMMITTED;
       }
 
-      bool is_tran_abort (void)
+      bool is_tran_abort (void) const
       {
 	return m_header.tran_state == stream_entry_header::ABORTED;
       }
 
-      bool is_tran_state_undefined (void)
+      bool is_tran_state_undefined (void) const
       {
 	return m_header.tran_state < stream_entry_header::ACTIVE
 	       || m_header.tran_state > stream_entry_header::NEW_MASTER;

--- a/src/replication/slave_control_channel.hpp
+++ b/src/replication/slave_control_channel.hpp
@@ -26,12 +26,8 @@
 
 #include <memory>
 
+#include "communication_channel.hpp"
 #include "cubstream.hpp"
-
-namespace cubcomm
-{
-  class channel;
-}
 
 namespace cubreplication
 {

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -5662,7 +5662,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 			  er_log_debug (ARG_FILE_LINE, "locator_update_force: unknown oid ( %d|%d|%d )\n",
 					oid->pageid, oid->slotid, oid->volid);
 			}
-		      else if (error_code == NO_ERROR)
+		      else
 			{
 			  ASSERT_ERROR_AND_SET (error_code);
 			}
@@ -5820,17 +5820,19 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 
 	  /* make sure we use the correct class oid - we could be dealing with a classoid resulted from a unique btid
 	   * pruning */
+	  if (heap_get_class_oid (thread_p, oid, class_oid) != S_SUCCESS)
+	    {
+	      ASSERT_ERROR_AND_SET (error_code);
+	      goto error;
+	    }
+
 	  error_code = heap_get_hfid_from_class_oid (thread_p, class_oid, hfid);
-	  if (error_code != S_SUCCESS)
+	  if (error_code != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
 	      goto error;
 	    }
 
-	  if (heap_get_hfid_from_class_oid (thread_p, class_oid, hfid) != NO_ERROR)
-	    {
-	      goto error;
-	    }
 
 	  if (!OID_EQ (class_oid, &real_class_oid))
 	    {

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -5400,6 +5400,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	  error_code = log_add_to_modified_class_list (thread_p, old_classname, oid);
 	  if (error_code != NO_ERROR)
 	    {
+	      ASSERT_ERROR ();
 	      goto error;
 	    }
 	}
@@ -5409,6 +5410,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	  error_code = catcls_update_catalog_classes (thread_p, old_classname, recdes, oid, force_in_place);
 	  if (error_code != NO_ERROR)
 	    {
+	      ASSERT_ERROR ();
 	      goto error;
 	    }
 	}
@@ -5492,6 +5494,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		  /*
 		   * An error occurred during the update of the catalog
 		   */
+		  ASSERT_ERROR ();
 		  goto error;
 		}
 	    }
@@ -5513,7 +5516,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		   * There is an error inserting the hash entry or catalog
 		   * information. The transaction must be aborted by the caller
 		   */
-		  error_code = ER_FAILED;
+		  ASSERT_ERROR_AND_SET (error_code);
 		  goto error;
 		}
 
@@ -5558,6 +5561,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	      error_code = catcls_insert_catalog_classes (thread_p, recdes);
 	      if (error_code != NO_ERROR)
 		{
+		  ASSERT_ERROR ();
 		  goto error;
 		}
 	    }
@@ -5594,6 +5598,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	  pcache = locator_get_partition_scancache (pcontext, &real_class_oid, &real_hfid, op_type, false);
 	  if (pcache == NULL)
 	    {
+	      assert (false);
 	      return ER_FAILED;
 	    }
 	  local_scan_cache = &pcache->scan_cache;
@@ -5659,7 +5664,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 			}
 		      else if (error_code == NO_ERROR)
 			{
-			  error_code = ER_FAILED;
+			  ASSERT_ERROR_AND_SET (error_code);
 			}
 
 		      goto error;
@@ -5697,6 +5702,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	      if (or_mvcc_get_header (oldrecdes, &old_rec_header) != NO_ERROR
 		  || or_mvcc_get_header (recdes, &new_rec_header) != NO_ERROR)
 		{
+		  assert (false);
 		  goto error;
 		}
 
@@ -5732,6 +5738,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 
 	      if (or_mvcc_set_header (recdes, &new_rec_header) != NO_ERROR)
 		{
+		  assert (false);
 		  goto error;
 		}
 	    }
@@ -5786,6 +5793,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 				    oid->slotid, oid->volid);
 		    }
 
+		  ASSERT_ERROR ();
 		  error_code = ER_HEAP_UNKNOWN_OBJECT;
 		  goto error;
 		}
@@ -5806,14 +5814,16 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 				    &superclass_oid);
 	  if (error_code != NO_ERROR)
 	    {
+	      ASSERT_ERROR ();
 	      goto error;
 	    }
 
 	  /* make sure we use the correct class oid - we could be dealing with a classoid resulted from a unique btid
 	   * pruning */
-	  if (heap_get_class_oid (thread_p, oid, class_oid) != S_SUCCESS)
+	  error_code = heap_get_hfid_from_class_oid (thread_p, class_oid, hfid);
+	  if (error_code != S_SUCCESS)
 	    {
-	      ASSERT_ERROR_AND_SET (error_code);
+	      ASSERT_ERROR ();
 	      goto error;
 	    }
 
@@ -5830,12 +5840,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	      granted = lock_subclass (thread_p, &real_class_oid, &superclass_oid, IX_LOCK, LK_UNCOND_LOCK);
 	      if (granted != LK_GRANTED)
 		{
-		  assert (er_errid () != NO_ERROR);
-		  error_code = er_errid ();
-		  if (error_code == NO_ERROR)
-		    {
-		      error_code = ER_FAILED;
-		    }
+		  ASSERT_ERROR_AND_SET (error_code);
 		  goto error;
 		}
 
@@ -5865,6 +5870,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		   * There is an error updating the index... Quit... The
 		   * transaction must be aborted by the caller
 		   */
+		  ASSERT_ERROR ();
 		  goto error;
 		}
 	    }
@@ -5889,6 +5895,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 						 true, true, hfid, NULL);
 		  if (error_code != NO_ERROR)
 		    {
+		      ASSERT_ERROR ();
 		      goto error;
 		    }
 		}
@@ -5902,6 +5909,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 					   &cache_attr_copyarea);
 	      if (error_code != NO_ERROR)
 		{
+		  ASSERT_ERROR ();
 		  goto error;
 		}
 

--- a/src/transaction/replication.h
+++ b/src/transaction/replication.h
@@ -55,6 +55,10 @@ struct repl_info
   char *info;
   int repl_info_type;
   bool need_replication;
+
+  // *INDENT-OFF*
+  repl_info () = default;
+  // *INDENT-ON*
 };
 
 typedef struct repl_info_sbr REPL_INFO_SBR;
@@ -67,6 +71,10 @@ struct repl_info_sbr
   char *db_password;
   char *sys_prm_context;
   char *savepoint_name;		/* Debug purpose, must be removed with PRM_ID_REPL_LOG_LOCAL_DEBUG */
+
+  // *INDENT-OFF*
+  repl_info_sbr () = default;
+  // *INDENT-ON*
 };
 
 #if defined(SERVER_MODE) || defined(SA_MODE)

--- a/unit_tests/packing/test_packing.cpp
+++ b/unit_tests/packing/test_packing.cpp
@@ -152,7 +152,7 @@ namespace test_packing
     entry_size += serializator.get_packed_short_size (entry_size);
     entry_size += serializator.get_packed_bigint_size (entry_size);
     entry_size += serializator.get_packed_int_vector_size (entry_size, sizeof (int_a) / sizeof (int_a[0]));
-    entry_size += serializator.get_packed_int_vector_size (entry_size, (int) int_v.size ());
+    entry_size += serializator.get_packed_int_vector_size (entry_size, int_v.size ());
     for (size_t i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
 	entry_size += serializator.get_packed_db_value_size (values[i], entry_size);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23035

- fix warnings
- make LOG_LSA constructor argument for replication_object const (allow initializing with NULL_LSA).
- add safe-guards to locator function to catch missed issue

[EDIT] Code extracted from https://github.com/CUBRID/cubrid/pull/1605