### PR TITLE
[CBRD-23037] fix heartbeat cluster shutdown deadlock

### DIFF
--- a/src/base/udp_rpc.hpp
+++ b/src/base/udp_rpc.hpp
@@ -282,10 +282,10 @@ udp_server<MsgId>::stop ()
       return;
     }
 
-  close_socket ();
-
   m_shutdown = true;
   m_thread.join ();
+
+  close_socket ();
 }
 
 template <typename MsgId>

--- a/src/base/udp_rpc.hpp
+++ b/src/base/udp_rpc.hpp
@@ -43,9 +43,6 @@ using socket_type = SOCKET;
 using ipv4_type = std::uint32_t;
 using port_type = std::uint16_t;
 
-// constants
-static const std::size_t BUFFER_SIZE = 4096;
-
 /**
  * Server to Server communication model:
  *
@@ -208,6 +205,8 @@ class udp_server
     void register_handler (MsgId msg_id, server_request_handler &handler);
 
   private:
+    static const std::size_t BUFFER_SIZE = 4096;
+
     using request_handlers_type = std::map<MsgId, server_request_handler>;
 
     std::thread m_thread;

--- a/src/master/heartbeat_cluster.cpp
+++ b/src/master/heartbeat_cluster.cpp
@@ -105,7 +105,7 @@ namespace cubhb
 
   cluster::cluster (ha_server *server)
     : lock ()
-    , state (node_state ::UNKNOWN)
+    , state (node_state::UNKNOWN)
     , nodes ()
     , myself (NULL)
     , master (NULL)

--- a/src/master/heartbeat_cluster.cpp
+++ b/src/master/heartbeat_cluster.cpp
@@ -255,7 +255,6 @@ namespace cubhb
     ping_hosts.clear ();
 
     delete m_hb_service;
-    delete m_server;
 
     pthread_mutex_destroy (&lock);
   }
@@ -331,7 +330,6 @@ namespace cubhb
     myself = NULL;
     shutdown = true;
     state = node_state::UNKNOWN;
-    m_server->stop ();
   }
 
   const cubbase::hostname_type &

--- a/src/master/master_heartbeat.cpp
+++ b/src/master/master_heartbeat.cpp
@@ -3413,11 +3413,11 @@ hb_cluster_initialize ()
 
   if (error_code != NO_ERROR)
     {
-      hb_udp_server_cleanup ();
-
       hb_Cluster->stop ();
       delete hb_Cluster;
       hb_Cluster = NULL;
+
+      hb_udp_server_cleanup ();
     }
 
   return error_code;
@@ -3816,19 +3816,18 @@ hb_udp_server_cleanup ()
 static void
 hb_cluster_cleanup (void)
 {
-  hb_udp_server_cleanup ();
-
   pthread_mutex_lock (&hb_Cluster->lock);
 
   hb_Cluster->state = cubhb::node_state::UNKNOWN;
   hb_Cluster->send_heartbeat_to_all ();
-
   hb_Cluster->stop ();
 
   pthread_mutex_unlock (&hb_Cluster->lock);
 
   delete hb_Cluster;
   hb_Cluster = NULL;
+
+  hb_udp_server_cleanup ();
 }
 
 /*

--- a/src/master/master_heartbeat.cpp
+++ b/src/master/master_heartbeat.cpp
@@ -757,7 +757,7 @@ hb_cluster_job_calc_score (HB_JOB_ARG *arg)
   if ((hb_Cluster->state == cubhb::node_state::SLAVE)
       && (hb_Cluster->master && hb_Cluster->myself && hb_Cluster->master->priority == hb_Cluster->myself->priority))
     {
-      hb_Cluster->state = cubhb::node_state ::TO_BE_MASTER;
+      hb_Cluster->state = cubhb::node_state::TO_BE_MASTER;
       hb_Cluster->send_heartbeat_to_all ();
 
       pthread_mutex_unlock (&hb_Cluster->lock);
@@ -933,7 +933,7 @@ ping_check_cancel:
   if (hb_Cluster->state != cubhb::node_state::MASTER)
     {
       MASTER_ER_SET (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_HB_NODE_EVENT, 1, "Failover cancelled by ping check");
-      hb_Cluster->state = cubhb::node_state ::SLAVE;
+      hb_Cluster->state = cubhb::node_state::SLAVE;
     }
   hb_Cluster->send_heartbeat_to_all ();
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23037

heartbeat shutdown thread and heartbeat net poll thread shared same mutex. Therefore when shutdown event is fired the mutex is acquired but the poll thread won't exit since it is blocked on the same mutex.
The deadlock was caused by the fact that heartbeat udp server is stopped under acquired mutex, the fix is to stop the server under no mutex after the cluster is stopped.