### PR TITLE
[CBRD-23034] replace simple task classes with callable tasks

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -697,24 +697,16 @@ class vacuum_master_context_manager : public cubthread::daemon_entry_manager
     }
 };
 
-// class vacuum_master_task
-//
-//  description:
-//    vacuum master task
-//
-class vacuum_master_task : public cubthread::entry_task
+void
+vacuum_master_execute (cubthread::entry & thread_ref)
 {
-  public:
-    void execute (cubthread::entry & thread_ref) final
+  if (!BO_IS_SERVER_RESTARTED ())
     {
-      if (!BO_IS_SERVER_RESTARTED ())
-	{
-	  // wait for boot to finish
-	  return;
-	}
-      vacuum_process_vacuum_data (&thread_ref);
+      // wait for boot to finish
+      return;
     }
-};
+  vacuum_process_vacuum_data (&thread_ref);
+}
 
 // class vacuum_worker_context_manager
 //
@@ -1049,7 +1041,8 @@ vacuum_boot (THREAD_ENTRY * thread_p)
 
   // create vacuum master thread
   vacuum_Master_daemon =
-    thread_manager->create_daemon (looper, new vacuum_master_task (), "vacuum_master", vacuum_Master_context_manager);
+    thread_manager->create_daemon (looper, new cubthread::entry_callable_task (vacuum_master_execute), "vacuum_master",
+				   vacuum_Master_context_manager);
 #endif /* SERVER_MODE */
 
   vacuum_Is_booted = true;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -697,7 +697,7 @@ class vacuum_master_context_manager : public cubthread::daemon_entry_manager
     }
 };
 
-void
+static void
 vacuum_master_execute (cubthread::entry & thread_ref)
 {
   if (!BO_IS_SERVER_RESTARTED ())
@@ -1027,7 +1027,6 @@ vacuum_boot (THREAD_ENTRY * thread_p)
   bool log_vacuum_worker_pool =
     cubthread::is_logging_configured (cubthread::LOG_WORKER_POOL_VACUUM)
     || flag<int>::is_flag_set (prm_get_integer_value (PRM_ID_ER_LOG_VACUUM), VACUUM_ER_LOG_WORKER);
-  /* *INDENT-ON* */
 
   // create thread pool
   vacuum_Worker_threads =
@@ -1043,6 +1042,8 @@ vacuum_boot (THREAD_ENTRY * thread_p)
   vacuum_Master_daemon =
     thread_manager->create_daemon (looper, new cubthread::entry_callable_task (vacuum_master_execute), "vacuum_master",
 				   vacuum_Master_context_manager);
+
+  /* *INDENT-ON* */
 #endif /* SERVER_MODE */
 
   vacuum_Is_booted = true;

--- a/src/replication/replication_master_senders_manager.cpp
+++ b/src/replication/replication_master_senders_manager.cpp
@@ -54,10 +54,10 @@ namespace cubreplication
       }
 
     master_server_stream_senders.clear ();
+
+    cubthread::entry_callable_task *task = new cubthread::entry_callable_task (master_senders_manager::execute);
     master_channels_supervisor_daemon = cubthread::get_manager ()->create_daemon (
-	cubthread::looper (std::chrono::milliseconds (SUPERVISOR_DAEMON_DELAY_MS)),
-	new master_senders_supervisor_task (),
-	"supervisor_daemon");
+	cubthread::looper (std::chrono::milliseconds (SUPERVISOR_DAEMON_DELAY_MS)), task, "supervisor_daemon");
     g_minimum_successful_stream_position = 0;
     g_stream = stream;
 
@@ -148,11 +148,7 @@ namespace cubreplication
 #endif
   }
 
-  master_senders_manager::master_senders_supervisor_task::master_senders_supervisor_task ()
-  {
-  }
-
-  void master_senders_manager::master_senders_supervisor_task::execute (cubthread::entry &context)
+  void master_senders_manager::execute (cubthread::entry &context)
   {
 #if defined (SERVER_MODE)
     static unsigned int check_conn_delay_counter = 0;

--- a/src/replication/replication_master_senders_manager.hpp
+++ b/src/replication/replication_master_senders_manager.hpp
@@ -68,13 +68,7 @@ namespace cubreplication
 
     private:
 
-      class master_senders_supervisor_task : public cubthread::entry_task
-      {
-	public:
-	  master_senders_supervisor_task ();
-
-	  void execute (cubthread::entry &context);
-      };
+      static void execute (cubthread::entry &context);
 
       friend class master_senders_supervisor_task;
 

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2471,25 +2471,17 @@ disk_auto_expand (THREAD_ENTRY * thread_p)
 
 // *INDENT-OFF*
 #if defined (SERVER_MODE)
-// class disk_auto_expansion_daemon_task
-//
-//  description:
-//    disk auto expansion daemon task
-//
-class disk_auto_expansion_daemon_task : public cubthread::entry_task
+static void
+disk_auto_expansion_execute (cubthread::entry & thread_ref)
 {
-  public:
-    void execute (cubthread::entry & thread_ref) override
+  if (!BO_IS_SERVER_RESTARTED ())
     {
-      if (!BO_IS_SERVER_RESTARTED ())
-	{
-	  // wait for boot to finish
-	  return;
-	}
-
-      disk_auto_expand (&thread_ref);
+      // wait for boot to finish
+      return;
     }
-};
+
+  disk_auto_expand (&thread_ref);
+}
 #endif /* SERVER_MODE */
 
 #if defined (SERVER_MODE)
@@ -2506,7 +2498,7 @@ disk_auto_volume_expansion_daemon_init ()
 
   std::chrono::seconds interval_time = std::chrono::seconds (60);
   disk_Auto_volume_expansion_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (interval_time),
-				      new disk_auto_expansion_daemon_task ());
+				      new cubthread::entry_callable_task (disk_auto_expansion_execute));
   */
 }
 #endif /* SERVER_MODE */

--- a/src/storage/external_sort.c
+++ b/src/storage/external_sort.c
@@ -1684,7 +1684,7 @@ px_sort_assign (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, int px_id, cha
 
 #if defined(SERVER_MODE)
 // *INDENT-OFF*
-void
+static void
 px_sort_myself_execute (cubthread::entry &thread_ref, PX_TREE_NODE * px_node)
 {
   (void) px_sort_myself (&thread_ref, px_node);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -15525,29 +15525,21 @@ pgbuf_get_page_flush_interval (bool & is_timed_wait, cubthread::delta_time & per
 
 // *INDENT-OFF*
 #if defined (SERVER_MODE)
-// class pgbuf_page_maintenance_daemon_task
-//
-//  description:
-//    page maintenance daemon task
-//
-class pgbuf_page_maintenance_daemon_task : public cubthread::entry_task
+static void
+pgbuf_page_maintenance_execute (cubthread::entry & thread_ref)
 {
-  public:
-    void execute (cubthread::entry & thread_ref) override
+  if (!BO_IS_SERVER_RESTARTED ())
     {
-      if (!BO_IS_SERVER_RESTARTED ())
-	{
-	  // wait for boot to finish
-	  return;
-	}
-
-      /* page buffer maintenance thread adjust quota's based on thread activity. */
-      pgbuf_adjust_quotas (&thread_ref);
-
-      /* search lists and assign victims directly */
-      pgbuf_direct_victims_maintenance (&thread_ref);
+      // wait for boot to finish
+      return;
     }
-};
+
+  /* page buffer maintenance thread adjust quota's based on thread activity. */
+  pgbuf_adjust_quotas (&thread_ref);
+
+  /* search lists and assign victims directly */
+  pgbuf_direct_victims_maintenance (&thread_ref);
+}
 #endif /* SERVER_MODE */
 
 #if defined (SERVER_MODE)
@@ -15610,30 +15602,22 @@ class pgbuf_page_flush_daemon_task : public cubthread::entry_task
 #endif /* SERVER_MODE */
 
 #if defined (SERVER_MODE)
-// class pgbuf_page_post_flush_daemon_task
-//
-//  description:
-//    page post flush daemon task
-//
-class pgbuf_page_post_flush_daemon_task : public cubthread::entry_task
+static void
+pgbuf_page_post_flush_execute (cubthread::entry & thread_ref)
 {
-  public:
-    void execute (cubthread::entry & thread_ref) override
+  if (!BO_IS_SERVER_RESTARTED ())
     {
-      if (!BO_IS_SERVER_RESTARTED ())
-	{
-	  // wait for boot to finish
-	  return;
-	}
-
-      /* assign flushed pages */
-      if (pgbuf_assign_flushed_pages (&thread_ref))
-	{
-	  /* reset daemon looper and be prepared to start over */
-	  pgbuf_Page_post_flush_daemon->reset_looper ();
-	}
+      // wait for boot to finish
+      return;
     }
-};
+
+  /* assign flushed pages */
+  if (pgbuf_assign_flushed_pages (&thread_ref))
+    {
+      /* reset daemon looper and be prepared to start over */
+      pgbuf_Page_post_flush_daemon->reset_looper ();
+    }
+}
 #endif /* SERVER_MODE */
 
 #if defined (SERVER_MODE)
@@ -15705,7 +15689,7 @@ pgbuf_page_maintenance_daemon_init ()
   assert (pgbuf_Page_maintenance_daemon == NULL);
 
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (100));
-  pgbuf_page_maintenance_daemon_task *daemon_task = new pgbuf_page_maintenance_daemon_task ();
+  cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (pgbuf_page_maintenance_execute);
 
   pgbuf_Page_maintenance_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
                                                                             "pgbuf_page_maintenance");
@@ -15744,7 +15728,7 @@ pgbuf_page_post_flush_daemon_init ()
     }};
 
   cubthread::looper looper = cubthread::looper (looper_interval);
-  pgbuf_page_post_flush_daemon_task *daemon_task = new pgbuf_page_post_flush_daemon_task ();
+  cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (pgbuf_page_post_flush_execute);
 
   pgbuf_Page_post_flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
                                                                            "pgbuf_page_post_flush");

--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -84,6 +84,7 @@ namespace cubthread
   class callable_task : public task<Context>
   {
     public:
+      using exec_func_type = std::function<void (Context &)>;
 
       callable_task () = delete;
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -309,9 +309,9 @@ static void log_sysop_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG
 static int logtb_tran_update_stats_online_index_rb (THREAD_ENTRY * thread_p, void *data, void *args);
 
 #if defined(SERVER_MODE)
-// *INDENT-OFF
-static void log_abort_task_execute (cubthread::entry & thread_ref, LOG_TDES & tdes);
-// *INDENT-ON
+// *INDENT-OFF*
+static void log_abort_task_execute (cubthread::entry &thread_ref, LOG_TDES &tdes);
+// *INDENT-ON*
 #endif // SERVER_MODE
 
 #if defined(SERVER_MODE)

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9613,25 +9613,17 @@ log_flush_daemon_get_stats (UINT64 * statsp)
 
 // *INDENT-OFF*
 #if defined(SERVER_MODE)
-// class log_checkpoint_daemon_task
-//
-//  description:
-//    log checkpoint daemon task
-//
-class log_checkpoint_daemon_task : public cubthread::entry_task
+static void
+log_checkpoint_execute (cubthread::entry & thread_ref)
 {
-  public:
-    void execute (cubthread::entry & thread_ref) override
+  if (!BO_IS_SERVER_RESTARTED ())
     {
-      if (!BO_IS_SERVER_RESTARTED ())
-	{
-	  // wait for boot to finish
-	  return;
-	}
-
-      logpb_checkpoint (&thread_ref);
+      // wait for boot to finish
+      return;
     }
-};
+
+  logpb_checkpoint (&thread_ref);
+}
 #endif /* SERVER_MODE */
 
 #if defined(SERVER_MODE)
@@ -9732,155 +9724,131 @@ class log_remove_log_archive_daemon_task : public cubthread::entry_task
 #endif /* SERVER_MODE */
 
 #if defined(SERVER_MODE)
-// class log_clock_daemon_task
-//
-//  description:
-//    log clock daemon task
-//
-class log_clock_daemon_task : public cubthread::entry_task
+static void
+log_clock_execute (cubthread::entry & thread_ref)
 {
-  public:
-    void execute (cubthread::entry & thread_ref) override
+  if (!BO_IS_SERVER_RESTARTED ())
     {
-      if (!BO_IS_SERVER_RESTARTED ())
-	{
-	  // wait for boot to finish
-	  return;
-	}
-
-      struct timeval now;
-      gettimeofday (&now, NULL);
-
-      log_Clock_msec = (now.tv_sec * 1000LL) + (now.tv_usec / 1000LL);
+      // wait for boot to finish
+      return;
     }
-};
+
+  struct timeval now;
+  gettimeofday (&now, NULL);
+
+  log_Clock_msec = (now.tv_sec * 1000LL) + (now.tv_usec / 1000LL);
+}
 #endif /* SERVER_MODE */
 
 #if defined(SERVER_MODE)
-// class log_check_ha_delay_info_daemon_task
-//
-//  description:
-//    log check ha delay info daemon_task
-//
-class log_check_ha_delay_info_daemon_task : public cubthread::entry_task
+static void
+log_check_ha_delay_info_execute (cubthread::entry &thread_ref)
 {
-  public:
-    void execute (cubthread::entry &thread_ref) override
-    {
 #if defined(WINDOWS)
-      return;
+  return;
 #endif /* WINDOWS */
 
-      if (!BO_IS_SERVER_RESTARTED ())
+  if (!BO_IS_SERVER_RESTARTED ())
+    {
+      // wait for boot to finish
+      return;
+    }
+
+  time_t log_record_time = 0;
+  int error_code;
+  int delay_limit_in_secs;
+  int acceptable_delay_in_secs;
+  int curr_delay_in_secs;
+  HA_SERVER_STATE server_state;
+
+  csect_enter (&thread_ref, CSECT_HA_SERVER_STATE, INF_WAIT);
+
+  server_state = css_ha_server_state ();
+
+  if (server_state == HA_SERVER_STATE_ACTIVE || server_state == HA_SERVER_STATE_TO_BE_STANDBY)
+    {
+      css_unset_ha_repl_delayed ();
+      perfmon_set_stat (&thread_ref, PSTAT_HA_REPL_DELAY, 0, true);
+
+      log_append_ha_server_state (&thread_ref, server_state);
+
+      csect_exit (&thread_ref, CSECT_HA_SERVER_STATE);
+    }
+  else
+    {
+      csect_exit (&thread_ref, CSECT_HA_SERVER_STATE);
+
+      delay_limit_in_secs = prm_get_integer_value (PRM_ID_HA_DELAY_LIMIT_IN_SECS);
+      acceptable_delay_in_secs = delay_limit_in_secs - prm_get_integer_value (PRM_ID_HA_DELAY_LIMIT_DELTA_IN_SECS);
+
+      if (acceptable_delay_in_secs < 0)
 	{
-	  // wait for boot to finish
-	  return;
+	  acceptable_delay_in_secs = 0;
 	}
 
-      time_t log_record_time = 0;
-      int error_code;
-      int delay_limit_in_secs;
-      int acceptable_delay_in_secs;
-      int curr_delay_in_secs;
-      HA_SERVER_STATE server_state;
+      error_code = catcls_get_apply_info_log_record_time (&thread_ref, &log_record_time);
 
-      csect_enter (&thread_ref, CSECT_HA_SERVER_STATE, INF_WAIT);
-
-      server_state = css_ha_server_state ();
-
-      if (server_state == HA_SERVER_STATE_ACTIVE || server_state == HA_SERVER_STATE_TO_BE_STANDBY)
+      if (error_code == NO_ERROR && log_record_time > 0)
 	{
-	  css_unset_ha_repl_delayed ();
-	  perfmon_set_stat (&thread_ref, PSTAT_HA_REPL_DELAY, 0, true);
-
-	  log_append_ha_server_state (&thread_ref, server_state);
-
-	  csect_exit (&thread_ref, CSECT_HA_SERVER_STATE);
-	}
-      else
-	{
-	  csect_exit (&thread_ref, CSECT_HA_SERVER_STATE);
-
-	  delay_limit_in_secs = prm_get_integer_value (PRM_ID_HA_DELAY_LIMIT_IN_SECS);
-	  acceptable_delay_in_secs = delay_limit_in_secs - prm_get_integer_value (PRM_ID_HA_DELAY_LIMIT_DELTA_IN_SECS);
-
-	  if (acceptable_delay_in_secs < 0)
+	  curr_delay_in_secs = (int) (time (NULL) - log_record_time);
+	  if (curr_delay_in_secs > 0)
 	    {
-	      acceptable_delay_in_secs = 0;
+	      curr_delay_in_secs -= HA_DELAY_ERR_CORRECTION;
 	    }
 
-	  error_code = catcls_get_apply_info_log_record_time (&thread_ref, &log_record_time);
-
-	  if (error_code == NO_ERROR && log_record_time > 0)
+	  if (delay_limit_in_secs > 0)
 	    {
-	      curr_delay_in_secs = (int) (time (NULL) - log_record_time);
-	      if (curr_delay_in_secs > 0)
+	      if (curr_delay_in_secs > delay_limit_in_secs)
 		{
-		  curr_delay_in_secs -= HA_DELAY_ERR_CORRECTION;
-		}
-
-	      if (delay_limit_in_secs > 0)
-		{
-		  if (curr_delay_in_secs > delay_limit_in_secs)
+		  if (!css_is_ha_repl_delayed ())
 		    {
-		      if (!css_is_ha_repl_delayed ())
-			{
-			  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_HA_REPL_DELAY_DETECTED, 2,
-				  curr_delay_in_secs, delay_limit_in_secs);
+		      er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_HA_REPL_DELAY_DETECTED, 2,
+			      curr_delay_in_secs, delay_limit_in_secs);
 
-			  css_set_ha_repl_delayed ();
-			}
-		    }
-		  else if (curr_delay_in_secs <= acceptable_delay_in_secs)
-		    {
-		      if (css_is_ha_repl_delayed ())
-			{
-			  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_HA_REPL_DELAY_RESOLVED, 2,
-				  curr_delay_in_secs, acceptable_delay_in_secs);
-
-			  css_unset_ha_repl_delayed ();
-			}
+		      css_set_ha_repl_delayed ();
 		    }
 		}
+	      else if (curr_delay_in_secs <= acceptable_delay_in_secs)
+		{
+		  if (css_is_ha_repl_delayed ())
+		    {
+		      er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_HA_REPL_DELAY_RESOLVED, 2,
+			      curr_delay_in_secs, acceptable_delay_in_secs);
 
-	      perfmon_set_stat (&thread_ref, PSTAT_HA_REPL_DELAY, curr_delay_in_secs, true);
+		      css_unset_ha_repl_delayed ();
+		    }
+		}
 	    }
+
+	  perfmon_set_stat (&thread_ref, PSTAT_HA_REPL_DELAY, curr_delay_in_secs, true);
 	}
     }
-};
+}
 #endif /* SERVER_MODE */
 
-#if defined (SERVER_MODE)
-// class log_flush_daemon_task
-//
-//  description:
-//    log flush daemon task
-//
-class log_flush_daemon_task : public cubthread::entry_task
+#if defined(SERVER_MODE)
+static void
+log_flush_execute (cubthread::entry & thread_ref)
 {
-  public:
-    void execute (cubthread::entry & thread_ref) override
+  if (!BO_IS_SERVER_RESTARTED () || !log_Flush_has_been_requested)
     {
-      if (!BO_IS_SERVER_RESTARTED () || !log_Flush_has_been_requested)
-	{
-	  return;
-	}
-
-      // refresh log trace flush time
-      thread_ref.event_stats.trace_log_flush_time = prm_get_integer_value (PRM_ID_LOG_TRACE_FLUSH_TIME_MSECS);
-
-      LOG_CS_ENTER (&thread_ref);
-      logpb_flush_pages_direct (&thread_ref);
-      LOG_CS_EXIT (&thread_ref);
-
-      log_Stat.gc_flush_count++;
-
-      pthread_mutex_lock (&log_Gl.group_commit_info.gc_mutex);
-      pthread_cond_broadcast (&log_Gl.group_commit_info.gc_cond);
-      log_Flush_has_been_requested = false;
-      pthread_mutex_unlock (&log_Gl.group_commit_info.gc_mutex);
+      return;
     }
-};
+
+  // refresh log trace flush time
+  thread_ref.event_stats.trace_log_flush_time = prm_get_integer_value (PRM_ID_LOG_TRACE_FLUSH_TIME_MSECS);
+
+  LOG_CS_ENTER (&thread_ref);
+  logpb_flush_pages_direct (&thread_ref);
+  LOG_CS_EXIT (&thread_ref);
+
+  log_Stat.gc_flush_count++;
+
+  pthread_mutex_lock (&log_Gl.group_commit_info.gc_mutex);
+  pthread_cond_broadcast (&log_Gl.group_commit_info.gc_cond);
+  log_Flush_has_been_requested = false;
+  pthread_mutex_unlock (&log_Gl.group_commit_info.gc_mutex);
+}
 #endif /* SERVER_MODE */
 
 #if defined(SERVER_MODE)
@@ -9893,7 +9861,7 @@ log_checkpoint_daemon_init ()
   assert (log_Checkpoint_daemon == NULL);
 
   cubthread::looper looper = cubthread::looper (log_get_checkpoint_interval);
-  log_checkpoint_daemon_task *daemon_task = new log_checkpoint_daemon_task ();
+  cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (log_checkpoint_execute);
 
   // create checkpoint daemon thread
   log_Checkpoint_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log_checkpoint");
@@ -9934,7 +9902,9 @@ log_clock_daemon_init ()
   assert (log_Clock_daemon == NULL);
 
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (200));
-  log_Clock_daemon = cubthread::get_manager ()->create_daemon (looper, new log_clock_daemon_task (), "log_clock");
+  log_Clock_daemon =
+    cubthread::get_manager ()->create_daemon (looper, new cubthread::entry_callable_task (log_clock_execute),
+                                              "log_clock");
 }
 #endif /* SERVER_MODE */
 
@@ -9948,7 +9918,7 @@ log_check_ha_delay_info_daemon_init ()
   assert (log_Check_ha_delay_info_daemon == NULL);
 
   cubthread::looper looper = cubthread::looper (std::chrono::seconds (1));
-  log_check_ha_delay_info_daemon_task *daemon_task = new log_check_ha_delay_info_daemon_task ();
+  cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (log_check_ha_delay_info_execute);
 
   log_Check_ha_delay_info_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
                                                                              "log_check_ha_delay_info");
@@ -9965,7 +9935,7 @@ log_flush_daemon_init ()
   assert (log_Flush_daemon == NULL);
 
   cubthread::looper looper = cubthread::looper (log_get_log_group_commit_interval);
-  log_flush_daemon_task *daemon_task = new log_flush_daemon_task ();
+  cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (log_flush_execute);
 
   log_Flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log_flush");
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23034

- replace simple tasks with cubthread::entry_callable_tasks based on function
- add cubthread::callable_task::exec_func_type
- fix several file_io.c warnings