### PR TITLE
[CBRD-23037] fix hearbeat deadlock on shutdown

### DIFF
--- a/src/master/heartbeat_cluster.cpp
+++ b/src/master/heartbeat_cluster.cpp
@@ -465,7 +465,14 @@ namespace cubhb
   void
   cluster::receive_heartbeat (const heartbeat_arg &arg, ipv4_type from_ip)
   {
+    if (shutdown)
+      {
+	return;
+      }
+
     pthread_mutex_lock (&lock);
+
+    // check again for shutdown after acquiring the lock
     if (shutdown)
       {
 	pthread_mutex_unlock (&lock);

--- a/src/master/heartbeat_cluster.cpp
+++ b/src/master/heartbeat_cluster.cpp
@@ -465,14 +465,7 @@ namespace cubhb
   void
   cluster::receive_heartbeat (const heartbeat_arg &arg, ipv4_type from_ip)
   {
-    if (shutdown)
-      {
-	return;
-      }
-
     pthread_mutex_lock (&lock);
-
-    // check again for shutdown after acquiring the lock
     if (shutdown)
       {
 	pthread_mutex_unlock (&lock);

--- a/src/master/master_heartbeat.cpp
+++ b/src/master/master_heartbeat.cpp
@@ -3824,10 +3824,10 @@ hb_cluster_cleanup (void)
 
   pthread_mutex_unlock (&hb_Cluster->lock);
 
+  hb_udp_server_cleanup ();
+
   delete hb_Cluster;
   hb_Cluster = NULL;
-
-  hb_udp_server_cleanup ();
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23037

Fix slip of #1652, stop first hearbeat udp server then the heartbeat cluster