### PR TITLE
[CBRD-23040] fix cleanup_migrate_to_long_transations check_valid safe-guard

### DIFF
--- a/src/transaction/mvcc_active_tran.cpp
+++ b/src/transaction/mvcc_active_tran.cpp
@@ -421,7 +421,6 @@ mvcc_active_tran::set_bitarea_mvccid (MVCCID mvccid)
     {
       // force cleanup_migrate_to_long_transations
       cleanup_migrate_to_long_transations ();
-      check_valid ();
       position = get_bit_offset (mvccid);
     }
   assert (position < BITAREA_MAX_BITS);   // is this a guaranteed?
@@ -455,7 +454,6 @@ mvcc_active_tran::set_bitarea_mvccid (MVCCID mvccid)
   if (m_bit_area_length > LONG_TRAN_THRESHOLD)
     {
       cleanup_migrate_to_long_transations ();
-      check_valid ();
     }
 }
 

--- a/src/transaction/mvcc_active_tran.cpp
+++ b/src/transaction/mvcc_active_tran.cpp
@@ -379,8 +379,6 @@ mvcc_active_tran::add_long_transaction (MVCCID mvccid)
   assert (m_long_tran_mvccids_length < long_tran_max_size ());
   assert (m_long_tran_mvccids[m_long_tran_mvccids_length - 1] < mvccid);
   m_long_tran_mvccids[m_long_tran_mvccids_length++] = mvccid;
-
-  check_valid ();
 }
 
 void
@@ -488,6 +486,8 @@ mvcc_active_tran::cleanup_migrate_to_long_transations ()
 	}
     }
   ltrim_area (delete_count);
+
+  check_valid ();
 }
 
 void


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23040

Move check_valid check from end of add_long_transaction to end of cleanup_migrate_to_long_transations. m_bit_area_start_mvccid is not updated until ltrim_area, which causes safe-guard fail:
```c
  assert (MVCC_ID_PRECEDES (m_long_tran_mvccids[i], m_bit_area_start_mvccid));
```

