### PR TITLE
[CBRD-23041] packer::get_all_packed_size_starting_offset

### DIFF
--- a/src/base/packer.cpp
+++ b/src/base/packer.cpp
@@ -349,7 +349,7 @@ namespace cubpacking
   }
 
   size_t
-  packer::get_packed_int_vector_size (size_t curr_offset, const int count)
+  packer::get_packed_int_vector_size (size_t curr_offset, const size_t count)
   {
     return DB_ALIGN (curr_offset, INT_ALIGNMENT) - curr_offset + (OR_INT_SIZE * (count + 1));
   }

--- a/src/base/packer.hpp
+++ b/src/base/packer.hpp
@@ -79,7 +79,7 @@ namespace cubpacking
 
       void pack_int_array (const int *array, const int count);
 
-      size_t get_packed_int_vector_size (size_t curr_offset, const int count);
+      size_t get_packed_int_vector_size (size_t curr_offset, const size_t count);
       void pack_int_vector (const std::vector<int> &array);
 
       size_t get_packed_db_value_size (const db_value &value, size_t curr_offset);
@@ -135,6 +135,8 @@ namespace cubpacking
       //
       template <typename ... Args>
       size_t get_all_packed_size (Args &&... args);
+      template <typename ... Args>
+      size_t get_all_packed_size_starting_offset (size_t start_offset, Args &&... args);
 
       // pack all arguments. equivalent to:
       //
@@ -273,6 +275,13 @@ namespace cubpacking
   packer::get_all_packed_size (Args &&... args)
   {
     return get_all_packed_size_recursive (0, std::forward<Args> (args)...);
+  }
+
+  template <typename ... Args>
+  size_t
+  packer::get_all_packed_size_starting_offset (size_t start_offset, Args &&... args)
+  {
+    return get_all_packed_size_recursive (start_offset, std::forward<Args> (args)...);
   }
 
   template <typename T>

--- a/src/base/packer.hpp
+++ b/src/base/packer.hpp
@@ -281,7 +281,8 @@ namespace cubpacking
   size_t
   packer::get_all_packed_size_starting_offset (size_t start_offset, Args &&... args)
   {
-    return get_all_packed_size_recursive (start_offset, std::forward<Args> (args)...);
+    size_t total_size = get_all_packed_size_recursive (start_offset, std::forward<Args> (args)...);
+    return total_size - start_offset;
   }
 
   template <typename T>

--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -131,7 +131,7 @@ namespace cubreplication
     /* type of packed object + type of RBR entry */
     entry_size += 2 * serializator.get_packed_int_size (entry_size);
 
-    entry_size += serializator.get_packed_int_vector_size (entry_size, (int) changed_attributes.size ());
+    entry_size += serializator.get_packed_int_vector_size (entry_size, changed_attributes.size ());
 
     entry_size += serializator.get_packed_small_string_size (m_class_name, entry_size);
 

--- a/unit_tests/packing/test_packing.cpp
+++ b/unit_tests/packing/test_packing.cpp
@@ -152,7 +152,7 @@ namespace test_packing
     entry_size += serializator.get_packed_short_size (entry_size);
     entry_size += serializator.get_packed_bigint_size (entry_size);
     entry_size += serializator.get_packed_int_vector_size (entry_size, sizeof (int_a) / sizeof (int_a[0]));
-    entry_size += serializator.get_packed_int_vector_size (entry_size, (int) int_v.size ());
+    entry_size += serializator.get_packed_int_vector_size (entry_size, int_v.size ());
     for (size_t i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
 	entry_size += serializator.get_packed_db_value_size (values[i], entry_size);

--- a/unit_tests/stream/test_stream.cpp
+++ b/unit_tests/stream/test_stream.cpp
@@ -224,7 +224,7 @@ namespace test_stream
     entry_size += serializer.get_packed_short_size (entry_size);
     entry_size += serializer.get_packed_bigint_size (entry_size);
     entry_size += serializer.get_packed_int_vector_size (entry_size, sizeof (int_a) / sizeof (int_a[0]));
-    entry_size += serializer.get_packed_int_vector_size (entry_size, (int) int_v.size ());
+    entry_size += serializer.get_packed_int_vector_size (entry_size, int_v.size ());
     for (unsigned int i = 0; i < sizeof (values) / sizeof (values[0]); i++)
       {
 	entry_size += serializer.get_packed_db_value_size (values[i], entry_size);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23041

- add get_all_packed_size_starting_offset (same as get_all_packed_size, but with start_offset not zero).
- backport get_packed_int_vector_size signature change from ha_replication.