### PR TITLE
[CBRD-22951] fix case slave_node has no connection to a master

### DIFF
--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -169,8 +169,13 @@ namespace cubreplication
     delete g_instance->m_lc;
     g_instance->m_lc = NULL;
 
-    g_instance->m_ctrl_sender->stop ();
-    cubthread::get_manager ()->destroy_daemon_without_entry (g_instance->m_ctrl_sender_daemon);
+    if (g_instance->m_ctrl_sender != NULL)
+      {
+	g_instance->m_ctrl_sender->stop ();
+	cubthread::get_manager ()->destroy_daemon_without_entry (g_instance->m_ctrl_sender_daemon);
+	// g_instance->m_ctrl_sender cleared by daemon destroy
+	g_instance->m_ctrl_sender = NULL;
+      }
 
     delete g_instance;
     g_instance = NULL;

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -173,7 +173,7 @@ namespace cubreplication
       {
 	g_instance->m_ctrl_sender->stop ();
 	cubthread::get_manager ()->destroy_daemon_without_entry (g_instance->m_ctrl_sender_daemon);
-	// g_instance->m_ctrl_sender cleared by daemon destroy
+	delete g_instance->m_ctrl_sender;
 	g_instance->m_ctrl_sender = NULL;
       }
 

--- a/src/replication/slave_control_channel.cpp
+++ b/src/replication/slave_control_channel.cpp
@@ -54,6 +54,11 @@ namespace cubreplication
       }
   }
 
+  void slave_control_sender::retire ()
+  {
+    // customize destroy daemon to not dealloc resources
+  }
+
   void slave_control_sender::stop ()
   {
     std::unique_lock<std::mutex> ul (m_mtx);

--- a/src/replication/slave_control_channel.hpp
+++ b/src/replication/slave_control_channel.hpp
@@ -49,6 +49,7 @@ namespace cubreplication
       slave_control_sender (slave_control_channel &&ctrl_chn);
 
       void execute () override;
+      void retire () override;
       void stop ();
       void set_synced_position (const cubstream::stream_position &sp);
 


### PR DESCRIPTION
Fix slip of https://github.com/CUBRID/cubrid/pull/1617 (slave_node contains no connection to a master)