### PR TITLE
[CBRD-23004] convert xtran start/end sysop intro replication savepoints

### DIFF
--- a/src/replication/log_generator.cpp
+++ b/src/replication/log_generator.cpp
@@ -49,7 +49,9 @@ namespace cubreplication
   {
     std::ostringstream oss;
     oss << g_Savepoint_generated_name << "_";
-    oss << lsa.pageid << '|' << lsa.offset;
+    oss << (long long int) lsa.pageid;
+    oss << '|';
+    oss << (int) lsa.offset;
 
     f (oss.str ().c_str ());
   }

--- a/src/replication/log_generator.hpp
+++ b/src/replication/log_generator.hpp
@@ -126,6 +126,8 @@ namespace cubreplication
       void add_attribute_change (const OID &class_oid, const OID &inst_oid, ATTR_ID col_id, const DB_VALUE &value);
       void add_create_savepoint (const char *savept_name);
       void add_rollback_to_savepoint (const char *savept_name);
+      void add_start_sysop (const LOG_LSA &lsa);
+      void add_end_sysop (const LOG_LSA &lsa);
 
       void remove_attribute_change (const OID &class_oid, const OID &inst_oid);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23004

DML statements server-side execution and xlocator_force are guarded with xtran_server_start_topop/xtran_server_end_topop to keep changes atomic. If statements have many changes, it is possible that multiple replication stream entries will be generated and applied on slave side. We need to make sure changes are atomic on slave side too.

We discussed internally and reached the conclusion that the easiest solution is to generate savepoint names based on LSA. This guarantees name uniqueness, start/end name consistency and very unlikely conflicts with user defined savepoints.

**TODO:**

  - remove replication objects for unused generated savepoints. in some production scenarios, point insert/delete/update statements may be dominating. for each replication_object of an actual modification, we also add a savepoint replication object. on xtran_server_sysop_commit, we may remove the replication object of generated savepoint.
  - update "local" rollback to savepoint. if savepoint replication object and all subsequent replication objects have not been packed, they can be dropped immediately; this functionality is already implemented based on LSA markers, we only need to update it based on savepoints.