### PR TITLE
[CBRD-23043] fix UMR of db_add_time

### DIFF
--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -6145,7 +6145,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	bool has_zone = false;
 	bool is_explicit_time = false;
 
-	error = db_string_to_datetimetz (db_get_string (left), &ldatetimetz, &has_zone);
+	error = db_string_to_datetimetz_ex (db_get_string (left), db_get_string_size (left), &ldatetimetz, &has_zone);
 	if (error == NO_ERROR && has_zone == true)
 	  {
 	    tz_id = ldatetimetz.tz_id;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23043

`left` value might not be null terminated.