### PR TITLE
[CBRD-23048] [replication] fix flooding of the server err log file

### DIFF
--- a/src/communication/stream_transfer_receiver.cpp
+++ b/src/communication/stream_transfer_receiver.cpp
@@ -74,6 +74,10 @@ namespace cubstream
 	    m_first_loop = false;
 	  }
 
+	if (!this_consumer_channel.m_channel.is_connection_alive ())
+	  {
+	    return;
+	  }
 	rc = this_consumer_channel.m_channel.recv (this_consumer_channel.m_buffer, max_len);
 	if (rc != NO_ERRORS)
 	  {

--- a/src/communication/stream_transfer_sender.cpp
+++ b/src/communication/stream_transfer_sender.cpp
@@ -66,6 +66,10 @@ namespace cubstream
 	    static_assert (sizeof (stream_position) == sizeof (UINT64),
 			   "stream position size differs from requested start stream position");
 
+	    if (!this_producer_channel.m_channel.is_connection_alive ())
+	      {
+		return;
+	      }
 	    rc = this_producer_channel.m_channel.recv ((char *) &last_sent_position, max_len);
 	    if (rc != NO_ERRORS)
 	      {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23048

when cub_server process is killed transfer sender/receiver daemons will continue receiving from the socket which will log a lot of message into the server err log file