### PR TITLE
[CBRD-23054] [replication] switch to new master

### DIFF
--- a/src/replication/log_consumer.cpp
+++ b/src/replication/log_consumer.cpp
@@ -378,6 +378,14 @@ namespace cubreplication
       }
   }
 
+  void log_consumer::start (void)
+  {
+    get_stream ()->start ();
+
+    std::unique_lock<std::mutex> ulock (m_queue_mutex);
+    m_is_stopped = false;
+  }
+
   void log_consumer::stop (void)
   {
     get_stream ()->stop ();

--- a/src/replication/log_consumer.hpp
+++ b/src/replication/log_consumer.hpp
@@ -122,7 +122,7 @@ namespace cubreplication
 	m_use_daemons (false),
 	m_started_tasks (0),
 	m_apply_task_ready (false),
-	m_is_stopped (false),
+	m_is_stopped (true),
 	ack_produce ([] (cubstream::stream_position)
       {
 	assert (false);
@@ -173,6 +173,7 @@ namespace cubreplication
 	return m_is_stopped;
       }
 
+      void start (void);
       void stop (void);
   };
 

--- a/src/replication/log_generator.cpp
+++ b/src/replication/log_generator.cpp
@@ -394,7 +394,7 @@ namespace cubreplication
     if (prm_get_bool_value (PRM_ID_REPL_LOG_LOCAL_DEBUG))
       {
 	/* Reset stream entry. */
-	m_stream_entry.reset();
+	m_stream_entry.reset ();
 	return;
       }
 #endif

--- a/src/replication/log_generator.hpp
+++ b/src/replication/log_generator.hpp
@@ -158,7 +158,7 @@ namespace cubreplication
       bool is_row_replication_disabled (void);
       void apply_tran_mvccid (void);
 
-#if !defined(NDEBUG) && defined (SERVER_MODE)
+#if !defined (NDEBUG) && defined (SERVER_MODE)
       int abort_sysop_and_simulate_apply_repl_rbr_on_master (LOG_LSA &filter_replication_lsa);
       int abort_partial_and_simulate_apply_sbr_repl_on_master (const char *savepoint_name);
 #endif

--- a/src/replication/replication_common.hpp
+++ b/src/replication/replication_common.hpp
@@ -31,11 +31,11 @@
 
 namespace cubreplication
 {
-  typedef enum
+  enum repl_semisync_ack_mode
   {
     REPL_SEMISYNC_ACK_ON_CONSUME,
     REPL_SEMISYNC_ACK_ON_FLUSH
-  } REPL_SEMISYNC_ACK_MODE;
-};
+  };
+}
 
 #endif /* _REPLICATION_COMMON_HPP_ */

--- a/src/replication/replication_node_manager.cpp
+++ b/src/replication/replication_node_manager.cpp
@@ -97,7 +97,7 @@ namespace cubreplication
 
       if (g_slave_node == NULL)
 	{
-	  g_slave_node = new cubreplication::slave_node (g_hostname.c_str (), g_stream, g_stream_file);
+	  g_slave_node = new slave_node (g_hostname.c_str (), g_stream, g_stream_file);
 	}
     }
 

--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -318,7 +318,7 @@ namespace cubreplication
     int err = NO_ERROR;
 #if defined (SERVER_MODE)
     cubthread::entry &my_thread = cubthread::get_entry ();
-    err = locator_repl_apply_sbr (&my_thread, m_db_user.c_str (), m_db_password.c_str(),
+    err = locator_repl_apply_sbr (&my_thread, m_db_user.c_str (), m_db_password.c_str (),
 				  m_sys_prm_context.empty () ? NULL : m_sys_prm_context.c_str (),
 				  m_statement.c_str ());
 #endif
@@ -707,8 +707,8 @@ namespace cubreplication
       }
 
     if (m_rec_des.get_size () != other_t->m_rec_des.get_size ()
-	|| m_rec_des.get_recdes().type != other_t->m_rec_des.get_recdes ().type
-	|| std::memcmp (m_rec_des.get_recdes ().data, other_t->m_rec_des.get_recdes().data, m_rec_des.get_size ()) != 0)
+	|| m_rec_des.get_recdes ().type != other_t->m_rec_des.get_recdes ().type
+	|| std::memcmp (m_rec_des.get_recdes ().data, other_t->m_rec_des.get_recdes ().data, m_rec_des.get_size ()) != 0)
       {
 	return false;
       }
@@ -839,7 +839,7 @@ namespace cubreplication
 	    return false;
 	  }
 
-	if (std::memcmp (m_rec_des_list[i].get_recdes ().data, other_t->m_rec_des_list[i].get_recdes().data,
+	if (std::memcmp (m_rec_des_list[i].get_recdes ().data, other_t->m_rec_des_list[i].get_recdes ().data,
 			 m_rec_des_list[i].get_size ()) != 0)
 	  {
 	    return false;

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -109,8 +109,7 @@ namespace cubreplication
     m_ctrl_sender = sender;
     cubstream::stream_file *sf = m_stream_file;
 
-    if ((REPL_SEMISYNC_ACK_MODE) prm_get_integer_value (PRM_ID_REPL_SEMISYNC_ACK_MODE) ==
-	REPL_SEMISYNC_ACK_ON_FLUSH)
+    if ((REPL_SEMISYNC_ACK_MODE) prm_get_integer_value (PRM_ID_REPL_SEMISYNC_ACK_MODE) == REPL_SEMISYNC_ACK_ON_FLUSH)
       {
 	m_stream_file->set_sync_notifier ([sender] (const cubstream::stream_position & sp)
 	{

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -109,7 +109,7 @@ namespace cubreplication
     m_ctrl_sender = sender;
     cubstream::stream_file *sf = m_stream_file;
 
-    if ((REPL_SEMISYNC_ACK_MODE) prm_get_integer_value (PRM_ID_REPL_SEMISYNC_ACK_MODE) == REPL_SEMISYNC_ACK_ON_FLUSH)
+    if ((repl_semisync_ack_mode) prm_get_integer_value (PRM_ID_REPL_SEMISYNC_ACK_MODE) == REPL_SEMISYNC_ACK_ON_FLUSH)
       {
 	m_stream_file->set_sync_notifier ([sender] (const cubstream::stream_position & sp)
 	{

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -132,11 +132,16 @@ namespace cubreplication
 
     m_transfer_receiver = new cubstream::transfer_receiver (std::move (srv_chn), *m_stream, start_position);
 
+    // ready to start log consumer
+    m_lc->start ();
+
     return NO_ERROR;
   }
 
   void slave_node::disconnect_from_master ()
   {
+    m_lc->stop ();
+
     delete m_transfer_receiver;
     m_transfer_receiver = NULL;
 

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -79,7 +79,6 @@ namespace cubreplication
     er_log_debug_replication (ARG_FILE_LINE, "slave_node::connect_to_master host:%s, port: %d\n",
 			      master_node_hostname, master_node_port_id);
 
-    // todo: remove after slave node is able to connect to a different master
     assert (m_transfer_receiver == NULL);
 
     /* connect to replication master node */

--- a/src/replication/replication_slave_node.hpp
+++ b/src/replication/replication_slave_node.hpp
@@ -59,6 +59,7 @@ namespace cubreplication
       ~slave_node ();
 
       int connect_to_master (const char *master_node_hostname, const int master_node_port_id);
+      void disconnect_from_master ();
   };
 
 } /* namespace cubreplication */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23054

On a cluster with 3 or more machines (M1: master, M2: slave, M3: slave), in case M1 crashes then M2 will be promoted to master and M3 must switch to newly elected master.