### PR TITLE
[CBRD-21524] suppress external libraries compile warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,9 +138,8 @@ set(WITH_LIBGPG_ERROR_URL "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-erro
 # gcrypt library sources URL
 set(WITH_LIBGCRYPT_URL "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.5.6.tar.bz2")
 
-# rapidjson library git properties
-set(WITH_RAPIDJSON_GIT_REPOSITORY "https://github.com/miloyip/rapidjson.git")
-set(WITH_RAPIDJSON_GIT_TAG "v1.1.0")
+# rapidjson library sources URL
+set(WITH_RAPIDJSON_URL "https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz")
 
 set(WITH_EXTERNAL_PREFIX "EXTERNAL" CACHE STRING "External library prefix (default: EXTERNAL)")
 set(WITH_BUNDLED_PREFIX "BUNDLED" CACHE STRING "Bundled library prefix (default: BUNDLED)")
@@ -691,8 +690,8 @@ configure_file(cmake/version.h.cmake version.h)
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   # Definitions for system
   add_definitions(-DGCC -DLINUX -D_GNU_SOURCE -DI386 -DX86)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wmissing-prototypes -Wredundant-decls -Wextra -Wno-unused -Wno-format-truncation -Wno-format-overflow")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wredundant-decls -Wextra -Wno-unused -Wno-unused-parameter -Wno-format-truncation -Wno-format-overflow")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wmissing-prototypes -Wredundant-decls -Wextra -Wno-unused")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wredundant-decls -Wextra -Wno-unused -Wno-unused-parameter")
 
   if(SIZEOF_OFF64_T)
     add_definitions( -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64)
@@ -939,12 +938,12 @@ if(WITH_LIBEXPAT STREQUAL "EXTERNAL")
   list(APPEND EP_TARGETS ${LIBEXPAT_TARGET})
   if(UNIX)
     externalproject_add(${LIBEXPAT_TARGET}
-      URL               ${WITH_LIBEXPAT_URL}
-      TIMEOUT 300
+      URL                  ${WITH_LIBEXPAT_URL}
+      TIMEOUT              300
       DOWNLOAD_NO_PROGRESS 1
-      CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS} --without-xmlwf  --without-docbook
-      BUILD_COMMAND     make AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      INSTALL_COMMAND   make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS} --without-xmlwf  --without-docbook
+      BUILD_COMMAND        make AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       )
     set(LIBEXPAT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libexpat.a)
     set(LIBEXPAT_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/expat)
@@ -984,12 +983,12 @@ if(WITH_LIBJANSSON STREQUAL "EXTERNAL")
   list(APPEND EP_TARGETS ${LIBJANSSON_TARGET})
   if(UNIX)
     externalproject_add(${LIBJANSSON_TARGET}
-      URL               ${WITH_LIBJANSSON_URL}
-      TIMEOUT 300
+      URL                  ${WITH_LIBJANSSON_URL}
+      TIMEOUT              300
       DOWNLOAD_NO_PROGRESS 1
-      CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
-      BUILD_COMMAND     make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      INSTALL_COMMAND   make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS}
+      BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       )
     set(LIBJANSSON_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libjansson.a)
     set(LIBJANSSON_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/jansson)
@@ -1060,12 +1059,12 @@ if(UNIX)
   if(WITH_LIBEDIT STREQUAL "EXTERNAL")
     set(LIBEDIT_TARGET libedit)
     externalproject_add(${LIBEDIT_TARGET}
-      URL               ${WITH_LIBEDIT_URL}
-      TIMEOUT 300
+      URL                  ${WITH_LIBEDIT_URL}
+      TIMEOUT              300
       DOWNLOAD_NO_PROGRESS 1
-      CONFIGURE_COMMAND "LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/external/lib" ${DEFAULT_CONFIGURE_OPTS}
-      BUILD_COMMAND     make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      INSTALL_COMMAND   make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      CONFIGURE_COMMAND    "LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/external/lib" ${DEFAULT_CONFIGURE_OPTS}
+      BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       )
     if(TARGET ${LIBNCURSES_TARGET})
       add_dependencies(${LIBEDIT_TARGET} ${LIBNCURSES_TARGET})
@@ -1101,12 +1100,12 @@ if(WITH_LIBLZO STREQUAL "EXTERNAL")
     #compile LZO library given an internet url to a LZO archive
     #e.g. http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz
     externalproject_add(${LIBLZO_TARGET}
-      URL               ${WITH_LIBLZO_URL}
-      TIMEOUT 300
+      URL                  ${WITH_LIBLZO_URL}
+      TIMEOUT              300
       DOWNLOAD_NO_PROGRESS 1
-      CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
-      BUILD_COMMAND     make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      INSTALL_COMMAND   make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS}
+      BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       )
     set(LIBLZO_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/liblzo2.a)
     set(LIBLZO_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
@@ -1140,12 +1139,12 @@ set(LIBGPG_ERROR_TARGET libgpg-error)
 if(UNIX)
   if(WITH_LIBGPG_ERROR STREQUAL "EXTERNAL")
     externalproject_add(${LIBGPG_ERROR_TARGET}
-      URL               ${WITH_LIBGPG_ERROR_URL}
-      TIMEOUT 300
+      URL                  ${WITH_LIBGPG_ERROR_URL}
+      TIMEOUT              300
       DOWNLOAD_NO_PROGRESS 1
-      CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS} --enable-maintainer-mode --disable-doc --disable-tests
-      BUILD_COMMAND     make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      INSTALL_COMMAND   make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS} --enable-maintainer-mode --disable-doc --disable-tests
+      BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       )
     set(LIBGPG_ERROR_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libgpg-error.a)
     set(LIBGPG_ERROR_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
@@ -1189,12 +1188,12 @@ if(WITH_LIBGCRYPT STREQUAL "EXTERNAL")
       set(WITH_LIBGPG_ERROR_PREFIX "--with-gpg-error-prefix=${CMAKE_CURRENT_BINARY_DIR}/external")
     endif()
     externalproject_add(${LIBGCRYPT_TARGET}
-      URL               ${WITH_LIBGCRYPT_URL}
+      URL                  ${WITH_LIBGCRYPT_URL}
+      TIMEOUT              300
       DOWNLOAD_NO_PROGRESS 1
-      TIMEOUT 300
-      CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS} CPPFLAGS=-I${CMAKE_CURRENT_BINARY_DIR}/external/include --enable-maintainer-mode ${WITH_LIBGPG_ERROR_PREFIX}
-      BUILD_COMMAND     make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      INSTALL_COMMAND   make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS} CPPFLAGS=-I${CMAKE_CURRENT_BINARY_DIR}/external/include --enable-maintainer-mode ${WITH_LIBGPG_ERROR_PREFIX}
+      BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       )
 
     set(LIBGCRYPT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libgcrypt.a)
@@ -1241,15 +1240,15 @@ endif(WIN32)
 set(RAPIDJSON_TARGET rapidjson)
 externalproject_add(${RAPIDJSON_TARGET}
   # tried URL but archive gets downloaded every time. URL_MD5 may help
-  URL https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz
-  TIMEOUT 300
+  URL                  ${WITH_RAPIDJSON_URL}
+  TIMEOUT              300
   DOWNLOAD_NO_PROGRESS 1
   # don't install
-  INSTALL_COMMAND ""
+  INSTALL_COMMAND      ""
   # don't build test, doc and examples
-  CMAKE_CACHE_ARGS -DRAPIDJSON_BUILD_TESTS:STRING=off
-                   -DRAPIDJSON_BUILD_DOC:STRING=off
-                   -DRAPIDJSON_BUILD_EXAMPLES:STRING=off
+  CMAKE_CACHE_ARGS     -DRAPIDJSON_BUILD_TESTS:STRING=off
+                       -DRAPIDJSON_BUILD_DOC:STRING=off
+                       -DRAPIDJSON_BUILD_EXAMPLES:STRING=off
 )
 # add to include directories
 include_directories(${CMAKE_BINARY_DIR}/external/Source/rapidjson/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,8 +691,8 @@ configure_file(cmake/version.h.cmake version.h)
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   # Definitions for system
   add_definitions(-DGCC -DLINUX -D_GNU_SOURCE -DI386 -DX86)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wmissing-prototypes -Wredundant-decls -Wextra -Wno-unused")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wredundant-decls -Wextra -Wno-unused -Wno-unused-parameter")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wmissing-prototypes -Wredundant-decls -Wextra -Wno-unused -Wno-format-truncation -Wno-format-overflow")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wredundant-decls -Wextra -Wno-unused -Wno-unused-parameter -Wno-format-truncation -Wno-format-overflow")
 
   if(SIZEOF_OFF64_T)
     add_definitions( -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64)
@@ -878,7 +878,7 @@ endif(USE_CUBRID_ENV)
 # For external library options
 include(ExternalProject)
 set_property(DIRECTORY PROPERTY EP_BASE "${CMAKE_BINARY_DIR}/external")
-set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external --enable-static --disable-shared --with-pic CFLAGS=${CMAKE_C_FLAGS} CXXFLAGS=${CMAKE_CXX_FLAGS})
+set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external --enable-static --disable-shared --with-pic CFLAGS=-w CXXFLAGS=-w)
 
 # WITH_LIBREGEX can have multiple values with different meanings
 # on Linux:
@@ -941,6 +941,7 @@ if(WITH_LIBEXPAT STREQUAL "EXTERNAL")
     externalproject_add(${LIBEXPAT_TARGET}
       URL               ${WITH_LIBEXPAT_URL}
       TIMEOUT 300
+      DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS} --without-xmlwf  --without-docbook
       BUILD_COMMAND     make AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND   make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
@@ -985,6 +986,7 @@ if(WITH_LIBJANSSON STREQUAL "EXTERNAL")
     externalproject_add(${LIBJANSSON_TARGET}
       URL               ${WITH_LIBJANSSON_URL}
       TIMEOUT 300
+      DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND     make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND   make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
@@ -1060,6 +1062,7 @@ if(UNIX)
     externalproject_add(${LIBEDIT_TARGET}
       URL               ${WITH_LIBEDIT_URL}
       TIMEOUT 300
+      DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND "LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/external/lib" ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND     make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND   make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
@@ -1100,6 +1103,7 @@ if(WITH_LIBLZO STREQUAL "EXTERNAL")
     externalproject_add(${LIBLZO_TARGET}
       URL               ${WITH_LIBLZO_URL}
       TIMEOUT 300
+      DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND     make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND   make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
@@ -1138,6 +1142,7 @@ if(UNIX)
     externalproject_add(${LIBGPG_ERROR_TARGET}
       URL               ${WITH_LIBGPG_ERROR_URL}
       TIMEOUT 300
+      DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS} --enable-maintainer-mode --disable-doc --disable-tests
       BUILD_COMMAND     make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND   make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
@@ -1185,6 +1190,7 @@ if(WITH_LIBGCRYPT STREQUAL "EXTERNAL")
     endif()
     externalproject_add(${LIBGCRYPT_TARGET}
       URL               ${WITH_LIBGCRYPT_URL}
+      DOWNLOAD_NO_PROGRESS 1
       TIMEOUT 300
       CONFIGURE_COMMAND ${DEFAULT_CONFIGURE_OPTS} CPPFLAGS=-I${CMAKE_CURRENT_BINARY_DIR}/external/include --enable-maintainer-mode ${WITH_LIBGPG_ERROR_PREFIX}
       BUILD_COMMAND     make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
@@ -1237,12 +1243,13 @@ externalproject_add(${RAPIDJSON_TARGET}
   # tried URL but archive gets downloaded every time. URL_MD5 may help
   URL https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz
   TIMEOUT 300
+  DOWNLOAD_NO_PROGRESS 1
   # don't install
   INSTALL_COMMAND ""
   # don't build test, doc and examples
-  CMAKE_CACHE_ARGS -DRAPIDJSON_BUILD_TESTS:string=off
-                   -DRAPIDJSON_BUILD_DOC:string=off
-                   -DRAPIDJSON_BUILD_EXAMPLES:string=off
+  CMAKE_CACHE_ARGS -DRAPIDJSON_BUILD_TESTS:STRING=off
+                   -DRAPIDJSON_BUILD_DOC:STRING=off
+                   -DRAPIDJSON_BUILD_EXAMPLES:STRING=off
 )
 # add to include directories
 include_directories(${CMAKE_BINARY_DIR}/external/Source/rapidjson/include)

--- a/src/base/encryption.c
+++ b/src/base/encryption.c
@@ -35,6 +35,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+
+// disable gcrypt compile warnings
+#define GCRYPT_NO_MPI_MACROS
+#define GCRYPT_NO_DEPRECATED
 #include <gcrypt.h>
 #else
 #error "libgcrypt or rpc/des_crypt.h file required"

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -67,11 +67,20 @@
 #include "string_opfunc.h"
 #include "system_parameter.h"
 
+// disable rapidjson compile warnings
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
 #include "rapidjson/error/en.h"
 #include "rapidjson/rapidjson.h"
 #include "rapidjson/schema.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include <sstream>
 #include <algorithm>

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -58,6 +58,7 @@
 
 #include "db_json_path.hpp"
 #include "db_json_types_internal.hpp"
+#include "db_rapidjson.hpp"
 #include "dbtype.h"
 #include "memory_alloc.h"
 #include "memory_private_allocator.hpp"
@@ -67,23 +68,8 @@
 #include "string_opfunc.h"
 #include "system_parameter.h"
 
-// disable rapidjson compile warnings
-#if defined (__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-#include "rapidjson/error/en.h"
-#include "rapidjson/rapidjson.h"
-#include "rapidjson/schema.h"
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/writer.h"
-#if defined (__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-
-#include <sstream>
 #include <algorithm>
+#include <sstream>
 #include <stack>
 
 #define TODO_OPTIMIZE_JSON_BODY_STRING true

--- a/src/compat/db_json_allocator.hpp
+++ b/src/compat/db_json_allocator.hpp
@@ -20,7 +20,16 @@
 #ifndef _DB_JSON_PRIVATE_ALLOCATOR_
 #define _DB_JSON_PRIVATE_ALLOCATOR_
 
+// disable rapidjson compile warnings
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
 #include "rapidjson/allocators.h"
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 class JSON_PRIVATE_ALLOCATOR
 {

--- a/src/compat/db_json_path.cpp
+++ b/src/compat/db_json_path.cpp
@@ -19,25 +19,15 @@
 
 #include "db_json_path.hpp"
 
+#include "db_rapidjson.hpp"
 #include "memory_alloc.h"
 #include "string_opfunc.h"
 #include "system_parameter.h"
 
-// disable rapidjson compile warnings
-#if defined (__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-#include "rapidjson/pointer.h"
-#if defined (__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-
 #include <algorithm>
 #include <cctype>
+#include <cerrno>
 #include <cstdlib>
-#include <errno.h>
 #include <limits>
 #include <string>
 #include <unordered_set>

--- a/src/compat/db_json_path.cpp
+++ b/src/compat/db_json_path.cpp
@@ -23,7 +23,16 @@
 #include "string_opfunc.h"
 #include "system_parameter.h"
 
+// disable rapidjson compile warnings
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
 #include "rapidjson/pointer.h"
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include <algorithm>
 #include <cctype>

--- a/src/compat/db_json_path.hpp
+++ b/src/compat/db_json_path.hpp
@@ -27,7 +27,16 @@
 #include "db_json_allocator.hpp"
 #include "db_json_types_internal.hpp"
 
+// disable rapidjson compile warnings
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
 #include "rapidjson/rapidjson.h"
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include <string>
 #include <unordered_set>

--- a/src/compat/db_json_path.hpp
+++ b/src/compat/db_json_path.hpp
@@ -26,17 +26,7 @@
 
 #include "db_json_allocator.hpp"
 #include "db_json_types_internal.hpp"
-
-// disable rapidjson compile warnings
-#if defined (__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-#include "rapidjson/rapidjson.h"
-#if defined (__GNUC__)
-#pragma GCC diagnostic pop
-#endif
+#include "db_rapidjson.hpp"
 
 #include <string>
 #include <unordered_set>

--- a/src/compat/db_json_types_internal.hpp
+++ b/src/compat/db_json_types_internal.hpp
@@ -21,18 +21,7 @@
 #define _DB_JSON_TYPES_INTERNAL_HPP
 
 #include "db_json_allocator.hpp"
-
-// disable rapidjson compile warnings
-#if defined (__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-#include "rapidjson/document.h"
-#include "rapidjson/encodings.h"
-#if defined (__GNUC__)
-#pragma GCC diagnostic pop
-#endif
+#include "db_rapidjson.hpp"
 
 #if defined GetObject
 /* stupid windows and their definitions; GetObject is defined as GetObjectW or GetObjectA */

--- a/src/compat/db_json_types_internal.hpp
+++ b/src/compat/db_json_types_internal.hpp
@@ -22,8 +22,17 @@
 
 #include "db_json_allocator.hpp"
 
+// disable rapidjson compile warnings
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
 #include "rapidjson/document.h"
 #include "rapidjson/encodings.h"
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #if defined GetObject
 /* stupid windows and their definitions; GetObject is defined as GetObjectW or GetObjectA */

--- a/src/compat/db_rapidjson.hpp
+++ b/src/compat/db_rapidjson.hpp
@@ -17,20 +17,25 @@
  *
  */
 
-#ifndef _DB_JSON_PRIVATE_ALLOCATOR_
-#define _DB_JSON_PRIVATE_ALLOCATOR_
+//
+// cubrid rapidjson header
+// include this header instead of specific rapid json header
+//
 
-#include "db_rapidjson.hpp"
+#ifndef _DB_RAPIDJSON_HPP_
+#define _DB_RAPIDJSON_HPP_
 
-class JSON_PRIVATE_ALLOCATOR
-{
-  public:
-    static const bool kNeedFree;
-    void *Malloc (size_t size);
-    void *Realloc (void *originalPtr, size_t originalSize, size_t newSize);
-    static void Free (void *ptr);
-};
+// disable rapidjson compile warnings
+#pragma GCC system_header
 
-typedef rapidjson::MemoryPoolAllocator <JSON_PRIVATE_ALLOCATOR> JSON_PRIVATE_MEMPOOL;
+#include "rapidjson/allocators.h"
+#include "rapidjson/document.h"
+#include "rapidjson/encodings.h"
+#include "rapidjson/error/en.h"
+#include "rapidjson/pointer.h"
+#include "rapidjson/rapidjson.h"
+#include "rapidjson/schema.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
 
-#endif
+#endif /*_DB_RAPIDJSON_HPP_*/

--- a/src/compat/db_rapidjson.hpp
+++ b/src/compat/db_rapidjson.hpp
@@ -26,7 +26,9 @@
 #define _DB_RAPIDJSON_HPP_
 
 // disable rapidjson compile warnings
+#if defined (__GNUC__)
 #pragma GCC system_header
+#endif
 
 #include "rapidjson/allocators.h"
 #include "rapidjson/document.h"

--- a/src/heaplayers/customheaps.cpp
+++ b/src/heaplayers/customheaps.cpp
@@ -7,7 +7,15 @@
 
 #include "system.h"
 #include "obstackheap.h"
+
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 #include "heaplayers.h"
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 using namespace HL;
 
@@ -216,9 +224,9 @@ hl_kingsley_realloc (UINTPTR heap_id, void *ptr, size_t sz)
       memcpy (new_ptr, ptr, (old_sz > sz ? sz : old_sz));
 
       if (ptr)
-        {
-          th->free (ptr);
-        }
+	{
+	  th->free (ptr);
+	}
       return new_ptr;
     }
   return NULL;

--- a/src/heaplayers/customheaps.cpp
+++ b/src/heaplayers/customheaps.cpp
@@ -7,15 +7,7 @@
 
 #include "system.h"
 #include "obstackheap.h"
-
-#if defined (__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-function-type"
-#endif
 #include "heaplayers.h"
-#if defined (__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
 using namespace HL;
 

--- a/src/heaplayers/heaplayers.h
+++ b/src/heaplayers/heaplayers.h
@@ -38,7 +38,11 @@
 #ifndef _HEAPLAYERS_H_
 #define _HEAPLAYERS_H_
 
-namespace HL {};
+#pragma GCC system_header
+
+namespace HL
+{
+};
 
 #include "hldefines.h"
 
@@ -72,14 +76,14 @@ namespace HL {};
 
 
 #include "util/sassert.h"
-// #include "utility.h"		// convenient wrappers to replace C++ new & delete operators
-#include "util/dynarray.h"		// an array that grows by doubling
+// #include "utility.h"         // convenient wrappers to replace C++ new & delete operators
+#include "util/dynarray.h"	// an array that grows by doubling
 #include "util/myhashmap.h"
 
 // Hiding machine dependencies.
 
 #include "util/cpuinfo.h"
-#include "util/timer.h"			// allows high-resolution timing across a wide range of platforms
+#include "util/timer.h"		// allows high-resolution timing across a wide range of platforms
 #include "util/guard.h"
 #include "util/fred.h"
 
@@ -88,7 +92,7 @@ namespace HL {};
 #include "spinlock.h"		// spin-then-yield
 
 #if defined(_WIN32)
-#include "util/winlock.h"		// critical-sections (i.e., for Windows only)
+#include "util/winlock.h"	// critical-sections (i.e., for Windows only)
 #include "util/recursivelock.h"	// a wrapper for recursive locking
 #endif
 
@@ -111,13 +115,13 @@ namespace HL {};
 // NB: All of these should be used for exactly one size class.
 
 #include "freelistheap.h"	// a free list. Never frees memory.
-#include "fifofreelist.h"   // a FIFO free list.
-#include "fifodlfreelist.h"  // a doubly-linked FIFO free list.
-#include "boundedfreelistheap.h"	// a free list with a bounded length. 
+#include "fifofreelist.h"	// a FIFO free list.
+#include "fifodlfreelist.h"	// a doubly-linked FIFO free list.
+#include "boundedfreelistheap.h"	// a free list with a bounded length.
 
 
 #include "nullheap.h"
-#include "coalesceheap.h" // A chunk heap with coalescing.
+#include "coalesceheap.h"	// A chunk heap with coalescing.
 #include "coalesceableheap.h"
 
 // Utility heap layers
@@ -125,10 +129,10 @@ namespace HL {};
 #include "sizethreadheap.h"	// Adds size(ptr) & thread(ptr) methods
 #include "lockedheap.h"		// Code-locks a heap
 #include "checkheap.h"		// Raises assertions if malloc'ed objects aren't right.
-// #include "exceptionheap.h"	// Raise an exception if a malloc fails.
+// #include "exceptionheap.h"   // Raise an exception if a malloc fails.
 
-#include "sanitycheckheap.h" // Check for multiple frees and mallocs of same locations.
-#include "ansiwrapper.h"     // Provide ANSI C like behavior for malloc (alignment, etc.)
+#include "sanitycheckheap.h"	// Check for multiple frees and mallocs of same locations.
+#include "ansiwrapper.h"	// Provide ANSI C like behavior for malloc (alignment, etc.)
 
 // Multi-threaded heaps
 //   hashes the thread id across a number of heaps
@@ -167,7 +171,7 @@ namespace HL {};
 #include "obstackheap.h"
 #include "sbrkheap.h"
 
-#include "xallocHeap.h" // 197.parser's heap
+#include "xallocHeap.h"		// 197.parser's heap
 
 #include "staticheap.h"
 

--- a/src/heaplayers/heaplayers.h
+++ b/src/heaplayers/heaplayers.h
@@ -38,7 +38,9 @@
 #ifndef _HEAPLAYERS_H_
 #define _HEAPLAYERS_H_
 
+#if defined (__GNUC__)
 #pragma GCC system_header
+#endif
 
 namespace HL
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21524

- Disable cmake download progress for external projects
- Suppress external libraries compile warnings for:
  - libexpat cmake target
  - libjansson cmake target
  - libedit cmake target
  - liblzo cmake target
  - libgpg-error cmake target
  - libgcrypt cmake target and header includes
  - rapidjson header includes
  - heaplayers header includes