### PR TITLE
[CBRD-23063] suppress windows spammer warnings

### DIFF
--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -35,6 +35,11 @@
 
 #ident "$Id$"
 
+#if defined (WINDOWS)
+// suppress warning C4005: 'NO_ERROR': macro redefinition
+#include "winerror.h"
+#endif // MSVC
+
 #ifdef NO_ERROR
 #undef NO_ERROR
 #endif

--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -79,6 +79,9 @@ static bool tran_systems_initialized = false;
 #if defined (__GNUC__)
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #endif
+#if defined (WINDOWS)
+#pragma warning (disable : 4197)
+#endif
 
 static INT64 lf_hash_size = 0;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23063

windows only

  - force include winerr.h in error_code.h
  - disable C4197 in lock_free.c