### PR TITLE
[CBRD-21524] fix -Wformat-overflow GCC warning

### DIFF
--- a/src/base/ini_parser.c
+++ b/src/base/ini_parser.c
@@ -573,7 +573,7 @@ ini_parser_load (const char *ininame)
   char line[INI_BUFSIZ + 1];
   char section[INI_BUFSIZ + 1];
   char key[INI_BUFSIZ + 1];
-  char tmp[INI_BUFSIZ + 1];
+  char tmp[(INI_BUFSIZ + 1) * 2];
   char val[INI_BUFSIZ + 1];
 
   int last = 0;

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -33,7 +33,7 @@
 #include "broker_util.h"
 #include "broker_filename.h"
 
-#define ADMIN_ERR_MSG_SIZE	1024
+#define ADMIN_ERR_MSG_SIZE	BROKER_PATH_MAX * 2
 #define ACCESS_FILE_DELIMITER ":"
 #define IP_FILE_DELIMITER ","
 

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -79,7 +79,7 @@
 #define DB_EMPTY_SESSION        (0)
 #endif /* CAS_FOR_ORACLE || CAS_FOR_MYSQL */
 
-#define ADMIN_ERR_MSG_SIZE	1024
+#define ADMIN_ERR_MSG_SIZE	BROKER_PATH_MAX * 2
 
 #define MAKE_VERSION(MAJOR, MINOR)	(((MAJOR) << 8) | (MINOR))
 
@@ -162,7 +162,7 @@ static int get_cubrid_version (void);
 
 static char shard_db_password_env_str[MAX_BROKER_NUM][128];
 
-char admin_err_msg[BROKER_PATH_MAX * 2];
+char admin_err_msg[ADMIN_ERR_MSG_SIZE];
 
 #if !defined(WINDOWS) && !defined(LINUX)
 extern char **environ;

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -162,7 +162,7 @@ static int get_cubrid_version (void);
 
 static char shard_db_password_env_str[MAX_BROKER_NUM][128];
 
-char admin_err_msg[ADMIN_ERR_MSG_SIZE];
+char admin_err_msg[BROKER_PATH_MAX * 2];
 
 #if !defined(WINDOWS) && !defined(LINUX)
 extern char **environ;

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -75,6 +75,7 @@
 #include "dbtype.h"
 #include "memory_alloc.h"
 #include "object_primitive.h"
+#include "string_buffer.hpp"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
@@ -5777,7 +5778,7 @@ fetch_method (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, char f
   DB_DOMAIN *domain;
   char *name;
   int db_type;
-  char arg_str[128];
+  string_buffer arg_str;
   int num_args;
   T_BROKER_VERSION client_version = req_info->client_version;
 
@@ -5831,7 +5832,6 @@ fetch_method (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, char f
       add_res_data_short (net_buf, cas_type, 0, NULL);
 
       /* 3. arg domain */
-      arg_str[0] = '\0';
       num_args = db_method_arg_count (tmp_p);
       for (j = 1; j <= num_args; j++)
 	{
@@ -5847,10 +5847,9 @@ fetch_method (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, char f
 	    {
 	      cas_type = set_extended_cas_type (CCI_U_TYPE_UNKNOWN, (DB_TYPE) db_type);
 	    }
-
-	  sprintf (arg_str, "%s%d ", arg_str, cas_type);
+	  arg_str ("%d ", cas_type);
 	}
-      add_res_data_string (net_buf, arg_str, strlen (arg_str), 0, CAS_SCHEMA_DEFAULT_CHARSET, NULL);
+      add_res_data_string (net_buf, arg_str.get_buffer (), arg_str.len (), 0, CAS_SCHEMA_DEFAULT_CHARSET, NULL);
 
       tuple_num++;
       cursor_pos++;

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -75,7 +75,6 @@
 #include "dbtype.h"
 #include "memory_alloc.h"
 #include "object_primitive.h"
-#include "string_buffer.hpp"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
@@ -5778,7 +5777,7 @@ fetch_method (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, char f
   DB_DOMAIN *domain;
   char *name;
   int db_type;
-  string_buffer arg_str;
+  std::string arg_str;
   int num_args;
   T_BROKER_VERSION client_version = req_info->client_version;
 
@@ -5847,9 +5846,10 @@ fetch_method (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, char f
 	    {
 	      cas_type = set_extended_cas_type (CCI_U_TYPE_UNKNOWN, (DB_TYPE) db_type);
 	    }
-	  arg_str ("%d ", cas_type);
+	  arg_str.push_back (cas_type);
+	  arg_str.push_back (' ');
 	}
-      add_res_data_string (net_buf, arg_str.get_buffer (), arg_str.len (), 0, CAS_SCHEMA_DEFAULT_CHARSET, NULL);
+      add_res_data_string (net_buf, arg_str.c_str (), arg_str.size (), 0, CAS_SCHEMA_DEFAULT_CHARSET, NULL);
 
       tuple_num++;
       cursor_pos++;

--- a/src/broker/shard_admin_pub.c
+++ b/src/broker/shard_admin_pub.c
@@ -68,7 +68,7 @@
 #include "shard_metadata.h"
 #include "shard_admin_pub.h"
 
-#define ADMIN_ERR_MSG_SIZE	1024
+#define ADMIN_ERR_MSG_SIZE	BROKER_PATH_MAX * 2
 
 char admin_err_msg[ADMIN_ERR_MSG_SIZE];
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21524

Fix -Wformat-overflow GCC warnings:
- https://github.com/CUBRID/cubrid/blob/56f2a7ca244c8a8ec8dde991726e51fd787cd003/src/base/ini_parser.c#L645
- https://github.com/CUBRID/cubrid/blob/56f2a7ca244c8a8ec8dde991726e51fd787cd003/src/broker/broker_admin_pub.c#L2293
- https://github.com/CUBRID/cubrid/blob/56f2a7ca244c8a8ec8dde991726e51fd787cd003/src/broker/broker_admin_pub.c#L2341
- https://github.com/CUBRID/cubrid/blob/56f2a7ca244c8a8ec8dde991726e51fd787cd003/src/broker/broker_admin_pub.c#L2389
- https://github.com/CUBRID/cubrid/blob/56f2a7ca244c8a8ec8dde991726e51fd787cd003/src/broker/cas_execute.c#L5851
- https://github.com/CUBRID/cubrid/blob/56f2a7ca244c8a8ec8dde991726e51fd787cd003/src/transaction/log_writer.c#L1127
- https://github.com/CUBRID/cubrid/blob/56f2a7ca244c8a8ec8dde991726e51fd787cd003/src/transaction/log_writer.c#L1660
- https://github.com/CUBRID/cubrid/blob/56f2a7ca244c8a8ec8dde991726e51fd787cd003/src/transaction/log_writer.c#L1684