### PR TITLE
[CBRD-23068] set ER_OBJ_OBJECT_NOT_FOUND error

### DIFF
--- a/src/replication/replication_row_apply.cpp
+++ b/src/replication/replication_row_apply.cpp
@@ -277,6 +277,7 @@ namespace cubreplication
     if (BTID_IS_NULL (&pkey_btid))
       {
 	// todo - reactivate: assert (false);
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OBJ_OBJECT_NOT_FOUND, 0);
 	return ER_OBJ_OBJECT_NOT_FOUND;
       }
 
@@ -285,6 +286,7 @@ namespace cubreplication
 			    &class_oid, &instance_oid, true) != BTREE_KEY_FOUND)
       {
 	// todo - reactivate: assert (false);
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OBJ_OBJECT_NOT_FOUND, 0);
 	return ER_OBJ_OBJECT_NOT_FOUND;
       }
     return NO_ERROR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23068

Set error when returning ER_OBJ_OBJECT_NOT_FOUND to fix crash.

TODO: testing the safe-guarded branch should reveal why object was not found earlier. For now, set error to suppress crash.