### PR TITLE
[CBRD-22675] backport record descriptor changes from ha replication

### DIFF
--- a/src/storage/record_descriptor.cpp
+++ b/src/storage/record_descriptor.cpp
@@ -342,9 +342,9 @@ record_descriptor::unpack (cubpacking::unpacker &unpacker)
 }
 
 size_t
-record_descriptor::get_packed_size (cubpacking::packer &packer, std::size_t curr_offset) const
+record_descriptor::get_packed_size (cubpacking::packer &packer) const
 {
-  size_t entry_size = packer.get_packed_short_size (curr_offset);
+  size_t entry_size = packer.get_packed_short_size (0);
   entry_size += packer.get_packed_buffer_size (m_recdes.data, m_recdes.length, entry_size);
 
   return entry_size;

--- a/src/storage/record_descriptor.cpp
+++ b/src/storage/record_descriptor.cpp
@@ -58,18 +58,7 @@ record_descriptor::record_descriptor (const recdes &rec,
 				      const cubmem::block_allocator &alloc /* = cubmem::PRIVATE_BLOCK_ALLOCATOR */)
   : record_descriptor (alloc)
 {
-  m_recdes.type = rec.type;
-  if (rec.length != 0)
-    {
-      // copy content from argument
-      m_recdes.area_size = rec.length;
-      m_recdes.length = m_recdes.area_size;
-      m_own_data.extend_to ((size_t) m_recdes.area_size);
-      m_recdes.data = m_own_data.get_ptr ();
-      std::memcpy (m_recdes.data, rec.data, m_recdes.length);
-
-      m_data_source = data_source::COPIED;  // we assume this is a copied record
-    }
+  set_recdes (rec);
 }
 
 record_descriptor::record_descriptor (record_descriptor &&other)
@@ -91,6 +80,25 @@ record_descriptor::record_descriptor (const char *data, size_t size)
 
 record_descriptor::~record_descriptor (void)
 {
+}
+
+void
+record_descriptor::set_recdes (const recdes &rec)
+{
+  assert (m_data_source == data_source::INVALID);
+
+  m_recdes.type = rec.type;
+  if (rec.length != 0)
+    {
+      // copy content from argument
+      m_recdes.area_size = rec.length;
+      m_recdes.length = m_recdes.area_size;
+      m_own_data.extend_to ((size_t) m_recdes.area_size);
+      m_recdes.data = m_own_data.get_ptr ();
+      std::memcpy (m_recdes.data, rec.data, m_recdes.length);
+
+      m_data_source = data_source::COPIED;  // we assume this is a copied record
+    }
 }
 
 int
@@ -141,7 +149,7 @@ record_descriptor::get (cubthread::entry *thread_p, PAGE_PTR page, PGSLOTID slot
 void
 record_descriptor::resize_buffer (std::size_t required_size)
 {
-  check_changes_are_permitted ();
+  assert (m_data_source == data_source::INVALID || is_mutable ());
 
   if (m_recdes.area_size > 0 && required_size <= (size_t) m_recdes.area_size)
     {
@@ -153,6 +161,11 @@ record_descriptor::resize_buffer (std::size_t required_size)
 
   m_recdes.data = m_own_data.get_ptr ();
   m_recdes.area_size = (int) required_size;
+
+  if (m_data_source == data_source::INVALID)
+    {
+      m_data_source = data_source::NEW;
+    }
 }
 
 void
@@ -329,9 +342,9 @@ record_descriptor::unpack (cubpacking::unpacker &unpacker)
 }
 
 size_t
-record_descriptor::get_packed_size (cubpacking::packer &packer) const
+record_descriptor::get_packed_size (cubpacking::packer &packer, std::size_t curr_offset) const
 {
-  size_t entry_size = packer.get_packed_short_size (0);
+  size_t entry_size = packer.get_packed_short_size (curr_offset);
   entry_size += packer.get_packed_buffer_size (m_recdes.data, m_recdes.length, entry_size);
 
   return entry_size;

--- a/src/storage/record_descriptor.hpp
+++ b/src/storage/record_descriptor.hpp
@@ -78,6 +78,8 @@ class record_descriptor : public cubpacking::packable_object
 
     record_descriptor (record_descriptor &&other);
 
+    void set_recdes (const recdes &rec);
+
     // peek record from page; changes into record data will not be permitted
     int peek (cubthread::entry *thread_p, PAGE_PTR page, PGSLOTID slotid);
 
@@ -120,7 +122,7 @@ class record_descriptor : public cubpacking::packable_object
 
     void pack (cubpacking::packer &packer) const override;
     void unpack (cubpacking::unpacker &unpacker) override;
-    std::size_t get_packed_size (cubpacking::packer &packer) const override;
+    std::size_t get_packed_size (cubpacking::packer &packer, std::size_t curr_offset) const override;
 
     //
     // manipulate record memory buffer

--- a/src/storage/record_descriptor.hpp
+++ b/src/storage/record_descriptor.hpp
@@ -122,7 +122,7 @@ class record_descriptor : public cubpacking::packable_object
 
     void pack (cubpacking::packer &packer) const override;
     void unpack (cubpacking::unpacker &unpacker) override;
-    std::size_t get_packed_size (cubpacking::packer &packer, std::size_t curr_offset) const override;
+    std::size_t get_packed_size (cubpacking::packer &packer) const override;
 
     //
     // manipulate record memory buffer


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22675

Backport record descriptor changes from ha replication branch