### PR TITLE
[CBRD-23070] Update vacuum last blockid on SA_MODE shutdown

### DIFF
--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -299,8 +299,6 @@ extern DISK_ISVALID vacuum_check_not_vacuumed_rec_header (THREAD_ENTRY * thread_
 extern bool vacuum_is_mvccid_vacuumed (MVCCID id);
 extern int vacuum_rv_check_at_undo (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slotid, INT16 rec_type);
 
-extern void vacuum_log_last_blockid (THREAD_ENTRY * thread_p);
-
 extern int vacuum_rv_es_nop (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 #if defined (SERVER_MODE)
 extern void vacuum_notify_es_deleted (THREAD_ENTRY * thread_p, const char *uri);

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -305,4 +305,6 @@ extern void vacuum_notify_es_deleted (THREAD_ENTRY * thread_p, const char *uri);
 #endif /* SERVER_MODE */
 
 extern int vacuum_reset_data_after_copydb (THREAD_ENTRY * thread_p);
+
+extern void vacuum_sa_reflect_last_blockid (THREAD_ENTRY * thread_p);
 #endif /* _VACUUM_H_ */

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -77,6 +77,7 @@
 #include "double_write_buffer.h"
 #include "xasl_cache.h"
 #include "log_volids.hpp"
+#include "vacuum.h"
 
 #if defined(SERVER_MODE)
 #include "connection_sr.h"
@@ -2933,6 +2934,9 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
   pgbuf_daemons_destroy ();
 #endif
 
+#if defined (SA_MODE)
+  vacuum_sa_reflect_last_blockid (thread_p);
+#endif // SA_MODE
   log_final (thread_p);
 
   /* Since all pages were flushed, now it's safe to destroy DWB. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23070

Update vacuum data last blockid before shutting down SA_MODE to make sure it is not left way behind after a long stand-alone session (e.g. loaddb).

