### PR TITLE
[CBRD-23076] [10.1p3] fix UMR of db_add_time (#1664)

### DIFF
--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -5963,7 +5963,7 @@ db_add_time (const DB_VALUE * left, const DB_VALUE * right, DB_VALUE * result, c
 	bool has_zone = false;
 	bool is_explicit_time = false;
 
-	error = db_string_to_datetimetz (DB_PULL_STRING (left), &ldatetimetz, &has_zone);
+	error = db_string_to_datetimetz_ex (DB_PULL_STRING (left), db_get_string_size (left), &ldatetimetz, &has_zone);
 	if (error == NO_ERROR && has_zone == true)
 	  {
 	    tz_id = ldatetimetz.tz_id;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23076

It is a backport of #1664 