### PR TITLE
[CBRD-23082] [10.1p3] avoid checking type if db_val is null (#1545)

### DIFF
--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -295,12 +295,12 @@ extern int pr_share_value (DB_VALUE * src, DB_VALUE * dest);
 	{ \
 	  *(dst) = *(src); \
 	  (dst)->need_clear = false; \
-	  if (db_value_domain_type (src) == DB_TYPE_STRING || db_value_domain_type (src) == DB_TYPE_VARNCHAR) \
+	  if (!DB_IS_NULL (src) \
+	      && (db_value_domain_type (src) == DB_TYPE_STRING || db_value_domain_type (src) == DB_TYPE_VARNCHAR)) \
 	    { \
 	      (dst)->data.ch.info.compressed_need_clear = false; \
 	    } \
-	  if (pr_is_set_type (DB_VALUE_DOMAIN_TYPE(src)) \
-	      && !DB_IS_NULL(src)) \
+	  if (!DB_IS_NULL (src) && pr_is_set_type (DB_VALUE_DOMAIN_TYPE (src))) \
 	    { \
 	      (src)->data.set->ref_count++; \
 	    } \


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23082

It is a backport of #1545.