### PR TITLE
[CBRD-23086] also update vacuum_Data_load.vpid_first when deallocates…

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4731,6 +4731,7 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 
       /* change first_page */
       vacuum_Data.first_page = *data_page;
+      vacuum_Data_load.vpid_first = save_first_page->next_page;
 
       /* Make sure the new first page is marked as dirty */
       vacuum_set_dirty_data_page (thread_p, vacuum_Data.first_page, DONT_FREE);
@@ -4749,10 +4750,12 @@ vacuum_data_empty_page (THREAD_ENTRY * thread_p, VACUUM_DATA_PAGE * prev_data_pa
 	   */
 	  save_first_page = vacuum_Data.first_page;
 	  vacuum_Data.first_page = vacuum_fix_data_page (thread_p, &save_first_vpid);
+	  vacuum_Data_load.vpid_first = save_first_vpid;
 	  vacuum_unfix_data_page (thread_p, save_first_page);
 	  *data_page = vacuum_Data.first_page;
 	  return;
 	}
+
       log_sysop_commit (thread_p);
 
       vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Changed first VPID from %d|%d to %d|%d.",


### PR DESCRIPTION
… the first page

http://jira.cubrid.org/browse/CBRD-23086

first page was deallocated and it leads SA_MODE to invalid page access to advance vacuum. 