### PR TITLE
[CBRD-23090] do not update/reflect vacuum data last blockid on restoredb

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -257,6 +257,7 @@ struct vacuum_data
   LOG_LSA recovery_lsa;		/* This is the LSA where recovery starts. It will be used to go backward in the log
 				 * if data on log blocks must be recovered.
 				 */
+  bool is_restoredb_session;
 
 #if defined (SA_MODE)
   bool is_vacuum_complete;
@@ -276,7 +277,8 @@ static VACUUM_DATA vacuum_Data = {
   false,			/* is_archive_removal_safe */
   VPID_INITIALIZER,		/* vpid_job_cursor */
   0,				/* blockid_job_cursor */
-  LSA_INITIALIZER		/* recovery_lsa */
+  LSA_INITIALIZER,		/* recovery_lsa */
+  false				/* is_restoredb_session */
 #if defined (SA_MODE)
     , false			/* is_vacuum_complete. */
 #endif /* SA_MODE */
@@ -727,7 +729,7 @@ xvacuum (THREAD_ENTRY * thread_p)
  */
 int
 vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npages, VFID * vacuum_data_vfid,
-		   VFID * dropped_files_vfid)
+		   VFID * dropped_files_vfid, bool is_restore)
 {
   int error_code = NO_ERROR;
   int i;
@@ -739,6 +741,7 @@ vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npages, VFID * 
 
   /* Initialize vacuum data */
   vacuum_Data.shutdown_requested = false;
+  vacuum_Data.is_restoredb_session = is_restore;
   /* Save vacuum data VFID. */
   VFID_COPY (&vacuum_Data.vacuum_data_file, vacuum_data_vfid);
   /* Save vacuum log block size in pages. */
@@ -7809,6 +7812,11 @@ vacuum_sa_reflect_last_blockid (THREAD_ENTRY * thread_p)
   if (VPID_ISNULL (&vacuum_Data_load.vpid_first))
     {
       // database is freshly created or boot was aborted without doing anything
+      return;
+    }
+  if (vacuum_Data.is_restoredb_session)
+    {
+      // restoredb doesn't vacuum; we cannot do this here
       return;
     }
 

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -272,7 +272,7 @@ extern void vacuum_set_worker_sa_mode (VACUUM_WORKER * worker);
 #endif /* SA_MODE */
 
 extern int vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npages, VFID * vacuum_data_vfid,
-			      VFID * dropped_files_vfid);
+			      VFID * dropped_files_vfid, bool is_restore);
 extern void vacuum_finalize (THREAD_ENTRY * thread_p);
 extern int xvacuum (THREAD_ENTRY * thread_p);
 extern MVCCID vacuum_get_global_oldest_active_mvccid (void);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2421,7 +2421,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       /* We need to load vacuum data and initialize vacuum routine before recovery. */
       error_code =
 	vacuum_initialize (thread_p, boot_Db_parm->vacuum_log_block_npages, &boot_Db_parm->vacuum_data_vfid,
-			   &boot_Db_parm->dropped_files_vfid);
+			   &boot_Db_parm->dropped_files_vfid, r_args != NULL && r_args->is_restore_from_backup);
       if (error_code != NO_ERROR)
 	{
 	  goto error;
@@ -5287,7 +5287,7 @@ xboot_emergency_patch (THREAD_ENTRY * thread_p, const char *db_name, bool recrea
       /* We need initialize vacuum routine before recovery. */
       error_code =
 	vacuum_initialize (thread_p, boot_Db_parm->vacuum_log_block_npages, &boot_Db_parm->vacuum_data_vfid,
-			   &boot_Db_parm->dropped_files_vfid);
+			   &boot_Db_parm->dropped_files_vfid, false);
       if (error_code != NO_ERROR)
 	{
 	  goto error_exit;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23090

Save when vacuum data is initialized if this is a restoredb session and avoid vacuum_sa_reflect_last_blockid on shutdown.