### PR TITLE
[CBRD-22805] fix disk_to_class missing error (#1510)

### DIFF
--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -4062,6 +4062,11 @@ disk_to_class (OR_BUF * buf, SM_CLASS ** class_ptr)
 	  if (serial_class_mop == NULL)
 	    {
 	      serial_class_mop = sm_find_class (CT_SERIAL_NAME);
+	      if (serial_class_mop == NULL)
+		{
+		  ASSERT_ERROR ();
+		  goto on_error;
+		}
 	    }
 
 	  SET_AUTO_INCREMENT_SERIAL_NAME (auto_increment_name, sm_ch_name ((MOBJ) class_), att->header.name);

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -1541,7 +1541,10 @@ boot_server_die_or_changed (void)
 #if defined(CS_MODE)
       css_terminate (true);
 #endif /* !CS_MODE */
-      er_log_debug (ARG_FILE_LINE, "boot_server_die_or_changed() terminated\n");
+      if (prm_get_bool_value (PRM_ID_TEST_MODE))
+	{
+	  er_print_callstack (ARG_FILE_LINE, "boot_server_die_or_changed() terminated\n");
+	}
     }
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22805

disk_to_class did not check returned value of sm_find_class and missed error. Fix by checking it is not null.

printing callstack of boot_server_die_or_changed helped me find where the error was leaked. I activated it on TEST_MODE.

backport of #1510 