### PR TITLE
[CBRD-22590] scan_next_index_lookup_heap: handle S_ERROR (#1358)

### DIFF
--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5828,6 +5828,15 @@ scan_next_index_lookup_heap (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, INDX_SC
 
       return S_DOESNT_EXIST;	/* not qualified, continue to the next tuple */
     }
+  else if (sp_scan == S_ERROR)
+    {
+      ASSERT_ERROR ();
+      return sp_scan;
+    }
+  else
+    {
+      assert (sp_scan == S_SUCCESS || sp_scan == S_SUCCESS_CHN_UPTODATE);
+    }
 
 
   /* evaluate the predicates to see if the object qualifies */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22590

heap_get_visible_version was interrupted, but error was not handled by scan_next_index_lookup_heap

backport of #1358 