### PR TITLE
[CBRD-22441] do not interrupt fileio_expand_to (#1274)

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -1979,7 +1979,9 @@ disk_volume_expand (THREAD_ENTRY * thread_p, VOLID volid, DB_VOLTYPE voltype, DK
   error_code = fileio_expand_to (thread_p, volid, volume_new_npages, voltype);
   if (error_code != NO_ERROR)
     {
-      ASSERT_ERROR ();
+      // important note - we just committed volume expansion; we cannot afford any failures here
+      // caller won't update cache!!
+      assert (false);
       return error_code;
     }
 
@@ -6173,6 +6175,8 @@ exit:
       pgbuf_unfix_and_init (thread_p, page_volheader);
     }
 
+  disk_log ("disk_check_volume", "check volume %d is %s", volid, valid == DISK_VALID ? "valid" : "not valid");
+
   csect_exit (thread_p, CSECT_DISK_CHECK);
 
   return valid;
@@ -6258,6 +6262,8 @@ disk_check (THREAD_ENTRY * thread_p, bool repair)
 	  return DISK_INVALID;
 	}
     }
+
+  disk_log ("disk_check", "first check step is %s", valid == DISK_VALID ? "valid" : "not valid");
 
   /* release critical section. we will get it for each volume we check, to avoid blocking all reservations and
    * extensions for a long time. */
@@ -6357,6 +6363,8 @@ disk_check (THREAD_ENTRY * thread_p, bool repair)
 	  return DISK_INVALID;
 	}
     }
+
+  disk_log ("disk_check", "full check is %s", "valid");
 
   /* all valid or all repaired */
   csect_exit (thread_p, CSECT_DISK_CHECK);

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -1859,7 +1859,7 @@ fileio_initialize_pages (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, D
       /* check for interrupts from user (i.e. Ctrl-C) */
       if ((page_id % FILEIO_CHECK_FOR_INTERRUPT_INTERVAL) == 0)
 	{
-	  if (logtb_get_check_interrupt (thread_p) && pgbuf_is_log_check_for_interrupts (thread_p))
+	  if (thread_get_check_interrupt (thread_p) && pgbuf_is_log_check_for_interrupts (thread_p))
 	    {
 	      return NULL;
 	    }

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -1859,7 +1859,7 @@ fileio_initialize_pages (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, D
       /* check for interrupts from user (i.e. Ctrl-C) */
       if ((page_id % FILEIO_CHECK_FOR_INTERRUPT_INTERVAL) == 0)
 	{
-	  if (pgbuf_is_log_check_for_interrupts (thread_p) == true)
+	  if (logtb_get_check_interrupt (thread_p) && pgbuf_is_log_check_for_interrupts (thread_p))
 	    {
 	      return NULL;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22441

This issue was a regression of propagating interrupt error from fileio_initialize_pages, because it lead to inconsistencies between volume header and disk cache.

After we "commit" the changes in volume header, we cannot permit any interruptions. Fix by verifying logtb_get_check_interrupt in fileio_initialize_pages.

backport #1274 