### PR TITLE
[CBRD-22403] Core dumped in pt_uncorr_post (#1249)

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -12591,7 +12591,13 @@ pt_uncorr_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continu
 	   * After validation, the CTE XASL is added to the list */
 
 	  PT_NODE *non_recursive_part = node->info.cte.non_recursive_part;
-	  assert (PT_IS_QUERY (non_recursive_part));
+	  // non_recursive_part can become PT_VALUE during constant folding
+	  assert (PT_IS_QUERY (non_recursive_part) || PT_IS_VALUE_NODE (non_recursive_part));
+	  if (PT_IS_VALUE_NODE (non_recursive_part))
+	    {
+	      info->xasl = pt_append_xasl (xasl, info->xasl);
+	      break;
+	    }
 
 	  if (non_recursive_part->info.query.correlation_level == 0)
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22403

Create as subquery creates underneath an insert subquery. Since there is a false where in the non_recursive part of the cte, the non_recursive part is transformed to a false_subquery. This transforms the non_recursive part into a PT_VALUE, making the assert test fail.
It is however alright to just change the assertion since the non_recursive_part will not get its xasl built. Execution does recognize non_recursive_part null as being a false where.

backport #1249 