### PR TITLE
[CBRD-22266] expect allocated page for OLD_PAGE_DEALLOCATED (#1175)

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2065,7 +2065,7 @@ try_again:
     {
       /* this cannot be a new page or a deallocated page.
        * note: temporary pages are not strictly handled in regard with their deallocation status. */
-      assert ((fetch_mode != NEW_PAGE && fetch_mode != OLD_PAGE_DEALLOCATED) || pgbuf_is_lsa_temporary (pgptr));
+      assert (fetch_mode != NEW_PAGE || pgbuf_is_lsa_temporary (pgptr));
     }
 
   /* Record number of fetches in statistics */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22266

Deallocate is undone and a compensate record is appended to overwrite usual fetch mode - we need to force page fix even if it is deallocated.

However, it does not mean fixed page is always deallocated. Compensation may have been flushed to disk.

Backport #1175 