### PR TITLE
[CBRD-21953] system generated select for client-side update has colum…

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -14546,23 +14546,45 @@ pt_print_select (PARSER_CONTEXT * parser, PT_NODE * p)
 	  q = pt_append_nulstring (parser, q, "distinct ");
 	}
 
-      if (!(parser->custom_print & PT_SUPPRESS_SELECT_LIST) || p->info.query.is_subquery == PT_IS_SUBQUERY)
+      if (PT_SELECT_INFO_IS_FLAGED (p, PT_SELECT_INFO_IS_UPD_DEL_QUERY))
 	{
-	  r1 = pt_print_bytes_l (parser, p->info.query.q.select.list);
-	  q = pt_append_varchar (parser, q, r1);
-	}
-      else
-	{
-	  temp = p->info.query.q.select.list;
-	  while (temp)
+	  /* print select list with column alias for system generated select of update query */
+	  for (temp = p->info.query.q.select.list; temp != NULL; temp = temp->next)
 	    {
-	      q = pt_append_nulstring (parser, q, "NA");
-	      if (temp->next)
+	      r1 = pt_print_bytes (parser, temp);
+	      q = pt_append_varchar (parser, q, r1);
+
+	      if (temp->alias_print != NULL)
+		{
+		  q = pt_append_nulstring (parser, q, " as [");
+		  q = pt_append_nulstring (parser, q, temp->alias_print);
+		  q = pt_append_nulstring (parser, q, "]");
+		}
+
+	      if (temp->next != NULL)
 		{
 		  q = pt_append_nulstring (parser, q, ",");
 		}
-	      temp = temp->next;
 	    }
+	}
+      else if ((parser->custom_print & PT_SUPPRESS_SELECT_LIST) != 0 && p->info.query.is_subquery != PT_IS_SUBQUERY)
+	{
+	  /* suppress select list: print NA */
+	  for (temp = p->info.query.q.select.list; temp != NULL; temp = temp->next)
+	    {
+	      q = pt_append_nulstring (parser, q, "NA");
+
+	      if (temp->next != NULL)
+		{
+		  q = pt_append_nulstring (parser, q, ",");
+		}
+	    }
+	}
+      else
+	{
+	  /* ordinary cases */
+	  r1 = pt_print_bytes_l (parser, p->info.query.q.select.list);
+	  q = pt_append_varchar (parser, q, r1);
 	}
 
       if (parser->custom_print & PT_PRINT_ALIAS)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -18879,6 +18879,27 @@ pt_to_upd_del_query (PARSER_CONTEXT * parser, PT_NODE * select_names, PT_NODE * 
 
       statement->info.query.q.select.list = parser_copy_tree_list (parser, select_list);
 
+      if (scan_op_type == S_UPDATE)
+	{
+	  /* The system generated select was "SELECT ..., rhs1, rhs2, ... FROM table ...".
+	   * When two different updates set different sets of attrs, generated select was lead to one XASL entry.
+	   * This causes unexpected issues of reusing an XASL entry, e.g, mismatched types.
+	   *
+	   * Uses lhs of an assignment as its column alias:
+	   * For example, "UPDATE t SET x = ?, y = ?;" will generate "SELECT ..., ? AS x, ? AS y FROM t;".
+	   *
+	   * pt_print_select will print aliases as well as values for the system generated select queries.
+	   */
+
+	  PT_NODE *lhs, *rhs;
+
+	  for (rhs = statement->info.query.q.select.list, lhs = select_names;
+	       rhs != NULL && lhs != NULL; rhs = rhs->next, lhs = lhs->next)
+	    {
+	      rhs->alias_print = parser_print_tree (parser, lhs);
+	    }
+	}
+
       statement->info.query.q.select.from = parser_copy_tree_list (parser, from);
       statement->info.query.q.select.using_index = parser_copy_tree_list (parser, using_index);
 


### PR DESCRIPTION
…n names as well as its value (#1037)

http://jira.cubrid.org/browse/CBRD-21953

It is an issue of legacy client-side update. Two different update queries badly share an XASL for select.

The system generated select was "SELECT ..., rhs1, rhs2, ... FROM table ...".
When two different updates set different sets of attrs, generated select was lead to one XASL entry.
This causes unexpected issues of reusing an XASL entry, e.g, mismatched types.

Uses lhs of an assignment as its column alias:
For example, "UPDATE t SET x = ?, y = ?;" will generate "SELECT ..., ? AS x, ? AS y FROM t;".

backport #1037 