### PR TITLE
[CBRD-21897] fix to avoid deadlock of "show indexes" (#1003)

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -21580,6 +21580,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
   int ls_flag = 0;
   QFILE_LIST_ID *t_list_id = NULL;
   int idx_incache = -1;
+  REPR_ID class_repr_id = NULL_REPRID;
   OR_CLASSREP *rep = NULL;
   OR_INDEX *index = NULL;
   OR_ATTRIBUTE *index_att = NULL;
@@ -21598,6 +21599,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
   int non_unique;
   int cardinality;
   OID *class_oid = NULL;
+  OID dir_oid;
   int i, j, k;
   int error = NO_ERROR;
   int function_index_pos = -1;
@@ -21606,6 +21608,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
   char *comment = NULL;
   int alloced_string = 0;
   HL_HEAPID save_heapid = 0;
+  CATALOG_ACCESS_INFO catalog_access_info = CATALOG_ACCESS_INFO_INITIALIZER;
 
   assert (xasl != NULL && xasl_state != NULL);
 
@@ -21622,17 +21625,51 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
       GOTO_EXIT_ON_ERROR;
     }
 
-  heap_scancache_quick_start_root_hfid (thread_p, &scan);
-
   assert (xasl_state != NULL);
   class_oid = &(xasl->spec_list->s.cls_node.cls_oid);
+
+  /* get class disk representation */
+  if (catalog_get_dir_oid_from_cache (thread_p, class_oid, &dir_oid) != NO_ERROR)
+    {
+      ASSERT_ERROR_AND_SET (error);
+      GOTO_EXIT_ON_ERROR;
+    }
+
+  catalog_access_info.class_oid = class_oid;
+  catalog_access_info.dir_oid = &dir_oid;
+  if (catalog_start_access_with_dir_oid (thread_p, &catalog_access_info, S_LOCK) != NO_ERROR)
+    {
+      ASSERT_ERROR_AND_SET (error);
+      (void) catalog_end_access_with_dir_oid (thread_p, &catalog_access_info, error);
+      GOTO_EXIT_ON_ERROR;
+    }
+
+  error = catalog_get_last_representation_id (thread_p, class_oid, &class_repr_id);
+  if (error != NO_ERROR)
+    {
+      (void) catalog_end_access_with_dir_oid (thread_p, &catalog_access_info, error);
+      GOTO_EXIT_ON_ERROR;
+    }
+
+  disk_repr_p = catalog_get_representation (thread_p, class_oid, class_repr_id, &catalog_access_info);
+  if (disk_repr_p == NULL)
+    {
+      ASSERT_ERROR_AND_SET (error);
+      (void) catalog_end_access_with_dir_oid (thread_p, &catalog_access_info, error);
+      GOTO_EXIT_ON_ERROR;
+    }
+
+  (void) catalog_end_access_with_dir_oid (thread_p, &catalog_access_info, NO_ERROR);
+
+  /* read heap class record, get class representation */
+  heap_scancache_quick_start_root_hfid (thread_p, &scan);
 
   if (heap_get_class_record (thread_p, class_oid, &class_record, &scan, PEEK) != S_SUCCESS)
     {
       GOTO_EXIT_ON_ERROR;
     }
 
-  rep = heap_classrepr_get (thread_p, class_oid, &class_record, NULL_REPRID, &idx_incache);
+  rep = heap_classrepr_get (thread_p, class_oid, &class_record, class_repr_id, &idx_incache);
   if (rep == NULL)
     {
       GOTO_EXIT_ON_ERROR;
@@ -21652,12 +21689,6 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
     {
       out_values[i] = &(regu_var_p->value.value.dbval);
       pr_clear_value (out_values[i]);
-    }
-
-  disk_repr_p = catalog_get_representation (thread_p, class_oid, rep->id, NULL);
-  if (disk_repr_p == NULL)
-    {
-      GOTO_EXIT_ON_ERROR;
     }
 
   attr_names = (char **) malloc (rep->n_attributes * sizeof (char *));

--- a/src/storage/statistics_sr.c
+++ b/src/storage/statistics_sr.c
@@ -1232,8 +1232,7 @@ stats_dump_class_statistics (CLASS_STATS * class_stats, FILE * fpp)
 #endif /* CUBRID_DEBUG */
 
 /*
- * stats_update_partitioned_statistics () - compute statistics for a
- *						  partitioned class
+ * stats_update_partitioned_statistics () - compute statistics for a partitioned class
  * return : error code or NO_ERROR
  * thread_p (in) :
  * class_id_p (in) : oid of the partitioned class
@@ -1469,8 +1468,8 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 	  goto cleanup;
 	}
 
-      subcls_disk_rep =
-	catalog_get_representation (thread_p, &partitions[i], subcls_repr_id, &part_catalog_access_info);
+      subcls_disk_rep = catalog_get_representation (thread_p, &partitions[i], subcls_repr_id,
+						    &part_catalog_access_info);
       if (subcls_disk_rep == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error);
@@ -1514,9 +1513,10 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 
 	  for (k = 0, btree_stats_p = disk_attr_p->bt_stats; k < disk_attr_p->n_btstats; k++, btree_stats_p++)
 	    {
-	      const BTREE_STATS *subcls_stats = stats_find_inherited_index_stats (cls_rep, subcls_rep,
-										  subcls_attr_p,
-										  &btree_stats_p->btid);
+	      const BTREE_STATS *subcls_stats;
+
+	      subcls_stats = stats_find_inherited_index_stats (cls_rep, subcls_rep, subcls_attr_p,
+							       &btree_stats_p->btid);
 	      if (subcls_stats == NULL)
 		{
 		  error = ER_FAILED;
@@ -1596,8 +1596,8 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 	  goto cleanup;
 	}
 
-      subcls_disk_rep =
-	catalog_get_representation (thread_p, &partitions[i], subcls_repr_id, &part_catalog_access_info);
+      subcls_disk_rep = catalog_get_representation (thread_p, &partitions[i], subcls_repr_id,
+						    &part_catalog_access_info);
       if (subcls_disk_rep == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error);
@@ -1640,9 +1640,10 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 
 	  for (k = 0, btree_stats_p = disk_attr_p->bt_stats; k < disk_attr_p->n_btstats; k++, btree_stats_p++)
 	    {
-	      const BTREE_STATS *subcls_stats = stats_find_inherited_index_stats (cls_rep, subcls_rep,
-										  subcls_attr_p,
-										  &btree_stats_p->btid);
+	      const BTREE_STATS *subcls_stats;
+
+	      subcls_stats = stats_find_inherited_index_stats (cls_rep, subcls_rep, subcls_attr_p,
+							       &btree_stats_p->btid);
 	      if (subcls_stats == NULL)
 		{
 		  error = ER_FAILED;
@@ -1742,9 +1743,8 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 
   /* replace the current disk representation structure/information in the catalog with the newly computed statistics */
   assert (!OID_ISNULL (&(cls_info_p->ci_rep_dir)));
-  error =
-    catalog_add_representation (thread_p, class_id_p, repr_id, disk_repr_p, &(cls_info_p->ci_rep_dir),
-				&catalog_access_info);
+  error = catalog_add_representation (thread_p, class_id_p, repr_id, disk_repr_p, &(cls_info_p->ci_rep_dir),
+				      &catalog_access_info);
   if (error != NO_ERROR)
     {
       goto cleanup;
@@ -1809,9 +1809,7 @@ cleanup:
 }
 
 /*
- * stats_find_inherited_index_stats () - find the btree statistics
- *					 corresponding to an index in a
- *					 subclass
+ * stats_find_inherited_index_stats () - find the btree statistics corresponding to an index in a subclass
  * return : btree statistics
  * cls_rep (in)	   : superclass representation
  * subcls_rep (in) : subclass representation

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -5715,8 +5715,7 @@ catalog_rv_ovf_page_logical_insert_undo (THREAD_ENTRY * thread_p, LOG_RCV * recv
 }
 
 /*
- * catalog_get_dir_oid_from_cache () - Get directory OID from cache
- *				       or class record
+ * catalog_get_dir_oid_from_cache () - Get directory OID from cache or class record
  *   return: error status
  *   class_id_p(in): Class identifier
  *   dir_oid_p(out): directory OID
@@ -5808,8 +5807,7 @@ catalog_get_dir_oid_from_cache (THREAD_ENTRY * thread_p, const OID * class_id_p,
 }
 
 /*
- * catalog_start_access_with_dir_oid () - starts an access on catalog using
- *					  directory OID for locking purpose
+ * catalog_start_access_with_dir_oid () - starts an access on catalog using directory OID for locking purpose
  *   return: error code
  *   catalog_access_info(in/out): catalog access helper structure
  *   lock_mode(in): should be X_LOCK for update on catalog and S_LOCK for read
@@ -5916,8 +5914,7 @@ error:
 }
 
 /*
- * catalog_end_access_with_dir_oid () - ends access on catalog using directory
- *					OID
+ * catalog_end_access_with_dir_oid () - ends access on catalog using directory OID
  *   return: error code
  *   catalog_access_info(in/out): catalog access helper structure
  *   error(in): error code


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21897

This is a legacy issue.
Dead-lock/latch between qexec_execute_build_indexes and xstats_get_statistics_from_server.
The latter acquires lock and then fixes a page latch to access class representation, while the former did into reverse. This caused deadlock chances.

Fix is to make show indexes to follow the same order of query execution.

backport #1003 