### PR TITLE
[CBRD-22174] first boot after copydb

### DIFF
--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -335,4 +335,5 @@ extern bool vacuum_is_mvccid_vacuumed (MVCCID id);
 extern int vacuum_rv_check_at_undo (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slotid, INT16 rec_type);
 
 extern void vacuum_sa_reflect_last_blockid (THREAD_ENTRY * thread_p);
+extern int vacuum_reset_data_after_copydb (THREAD_ENTRY * thread_p);
 #endif /* _VACUUM_H_ */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -938,7 +938,7 @@ struct log_header
   int avg_nlocks;		/* Average number of object locks */
   DKNPAGES npages;		/* Number of pages in the active log portion. Does not include the log header page. */
   INT8 db_charset;
-  INT8 dummy2;			/* Dummy fields for 8byte align */
+  bool was_copied;		/* set to true for copied database; should be reset on first server start */
   INT8 dummy3;
   INT8 dummy4;
   LOG_PAGEID fpageid;		/* Logical pageid at physical location 1 in active log */
@@ -994,7 +994,12 @@ struct log_header
      0, 0, 0,					 \
      /* db_charset */				 \
      0,						 \
-     0, 0, 0, 0,				 \
+     /* was_copied */                            \
+     false,                                      \
+     /* dummy INT8 for align */                  \
+     0, 0,                                       \
+     /* fpageid */                               \
+     0,				                 \
      /* append_lsa */                            \
      {NULL_PAGEID, NULL_OFFSET},                 \
      /* chkpt_lsa */                             \
@@ -1058,7 +1063,12 @@ struct log_header
      0, 0, 0,					 \
      /* db_charset */				 \
      0,						 \
-     0, 0, 0, 0,				 \
+     /* was_copied */                            \
+     false,                                      \
+     /* dummy INT8 for align */                  \
+     0, 0,                                       \
+     /* fpageid */                               \
+     0,				                 \
      /* append_lsa */                            \
      {NULL_PAGEID, NULL_OFFSET},                 \
      /* chkpt_lsa */                             \

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1416,6 +1416,8 @@ logpb_copy_log_header (THREAD_ENTRY * thread_p, LOG_HEADER * to_hdr, const LOG_H
   assert (to_hdr != NULL);
   assert (from_hdr != NULL);
 
+  to_hdr->was_copied = true;	// should be reset on first restart
+
   to_hdr->mvcc_next_id = from_hdr->mvcc_next_id;
 
   /* Add other attributes that need to be copied */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22174

Add a routine to handle first boot after copydb. Log header is extended for this purpose, but it should be backward compatible.

Properly handle the case when log_blockid is `NULL`. It may happen on both branches of condition:
`if (LSA_ISNULL (&vacuum_Data.recovery_lsa) && LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa))`

Backport #1148 