### PR TITLE
[CBRD-23101] Fix crash during slave to master

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2324,29 +2324,29 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
   switch (state)
     {
     case HA_SERVER_STATE_ACTIVE:
-        state = css_transit_ha_server_state (thread_p, HA_SERVER_STATE_ACTIVE);
-        if (state == HA_SERVER_STATE_NA)
-  	  {
-  	    break;
-  	  }
-        if (!HA_DISABLED ())
-  	  {
-  	    // currently this only guarantees that fetched data from stream is applied
-  	    cubreplication::replication_node_manager::commute_to_master_state ();
-  	  }
-  
-        /* If log appliers have changed their state to done, go directly to active mode */
-	if (css_check_ha_log_applier_done ())
-          {
-	    if (state == HA_SERVER_STATE_TO_BE_ACTIVE)
-	      {
-	        // db_Disable_modifications flag should be set false before fully transitioning to HA_SERVER_STATE_ACTIVE
-	        logtb_enable_update (thread_p);
-	      }
-	    er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state: " "css_check_ha_log_applier_done ()\n");
-            state = css_transit_ha_server_state (thread_p, HA_SERVER_STATE_ACTIVE);
-            assert (state == HA_SERVER_STATE_ACTIVE);
-          }
+      state = css_transit_ha_server_state (thread_p, HA_SERVER_STATE_ACTIVE);
+      if (state == HA_SERVER_STATE_NA)
+	{
+	  break;
+	}
+      if (!HA_DISABLED ())
+	{
+	  // currently this only guarantees that fetched data from stream is applied
+	  cubreplication::replication_node_manager::commute_to_master_state ();
+	}
+
+      /* If log appliers have changed their state to done, go directly to active mode */
+      if (css_check_ha_log_applier_done ())
+	{
+	  if (state == HA_SERVER_STATE_TO_BE_ACTIVE)
+	    {
+	      // db_Disable_modifications flag should be set false before fully transitioning to HA_SERVER_STATE_ACTIVE
+	      logtb_enable_update (thread_p);
+	    }
+	  er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state: " "css_check_ha_log_applier_done ()\n");
+	  state = css_transit_ha_server_state (thread_p, HA_SERVER_STATE_ACTIVE);
+	  assert (state == HA_SERVER_STATE_ACTIVE);
+	}
       break;
 
     case HA_SERVER_STATE_STANDBY:

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2324,27 +2324,29 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
   switch (state)
     {
     case HA_SERVER_STATE_ACTIVE:
-      state = css_transit_ha_server_state (thread_p, HA_SERVER_STATE_ACTIVE);
-      if (state == HA_SERVER_STATE_NA)
-	{
-	  break;
-	}
-      /* If log appliers have changed their state to done, go directly to active mode */
-      if (!HA_DISABLED ())
-	{
-	  // currently this only guarantees that fetched data from stream is applied
-	  cubreplication::replication_node_manager::commute_to_master_state ();
-	}
-
-      if (state == HA_SERVER_STATE_TO_BE_ACTIVE)
-        {
-	  // db_Disable_modifications flag should be set false before fully transitioning to HA_SERVER_STATE_ACTIVE
-	  logtb_enable_update (thread_p);
-        }
-	
-      er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state: " "css_check_ha_log_applier_done ()\n");
-      state = css_transit_ha_server_state (thread_p, HA_SERVER_STATE_ACTIVE);
-      assert (state == HA_SERVER_STATE_ACTIVE);      
+        state = css_transit_ha_server_state (thread_p, HA_SERVER_STATE_ACTIVE);
+        if (state == HA_SERVER_STATE_NA)
+  	  {
+  	    break;
+  	  }
+        if (!HA_DISABLED ())
+  	  {
+  	    // currently this only guarantees that fetched data from stream is applied
+  	    cubreplication::replication_node_manager::commute_to_master_state ();
+  	  }
+  
+        /* If log appliers have changed their state to done, go directly to active mode */
+	if (css_check_ha_log_applier_done ())
+          {
+	    if (state == HA_SERVER_STATE_TO_BE_ACTIVE)
+	      {
+	        // db_Disable_modifications flag should be set false before fully transitioning to HA_SERVER_STATE_ACTIVE
+	        logtb_enable_update (thread_p);
+	      }
+	    er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state: " "css_check_ha_log_applier_done ()\n");
+            state = css_transit_ha_server_state (thread_p, HA_SERVER_STATE_ACTIVE);
+            assert (state == HA_SERVER_STATE_ACTIVE);
+          }
       break;
 
     case HA_SERVER_STATE_STANDBY:

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2329,15 +2329,16 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
 	{
 	  break;
 	}
-      if (!HA_DISABLED ())
-	{
-	  // currently this only guarantees that fetched data from stream is applied
-	  cubreplication::replication_node_manager::commute_to_master_state ();
-	}
 
       /* If log appliers have changed their state to done, go directly to active mode */
       if (css_check_ha_log_applier_done ())
 	{
+	  if (!HA_DISABLED () && state == HA_SERVER_STATE_TO_BE_ACTIVE)
+	    {
+	      // currently this only guarantees that fetched data from stream is applied
+	      cubreplication::replication_node_manager::commute_to_master_state ();
+	    }
+      
 	  if (state == HA_SERVER_STATE_TO_BE_ACTIVE)
 	    {
 	      // db_Disable_modifications flag should be set false before fully transitioning to HA_SERVER_STATE_ACTIVE

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2329,11 +2329,6 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
 	{
 	  break;
 	}
-      if (state == HA_SERVER_STATE_TO_BE_ACTIVE)
-        {
-	  // db_disable_modifications should be set before fully transitioning to HA_SERVER_STATE_ACTIVE
-	  logtb_enable_update (thread_p);
-        }
 
       /* If log appliers have changed their state to done, go directly to active mode */
       if (!HA_DISABLED ())
@@ -2341,6 +2336,13 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
 	  // currently this only guarantees that fetched data from stream is applied
 	  cubreplication::replication_node_manager::commute_to_master_state ();
 	}
+
+      if (state == HA_SERVER_STATE_TO_BE_ACTIVE)
+        {
+	  // db_disable_modifications should be set before fully transitioning to HA_SERVER_STATE_ACTIVE
+	  logtb_enable_update (thread_p);
+        }
+	
       er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state: " "css_check_ha_log_applier_done ()\n");
       state = css_transit_ha_server_state (thread_p, HA_SERVER_STATE_ACTIVE);
       assert (state == HA_SERVER_STATE_ACTIVE);      

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2338,7 +2338,7 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
 
       if (state == HA_SERVER_STATE_TO_BE_ACTIVE)
         {
-	  // db_disable_modifications should be set before fully transitioning to HA_SERVER_STATE_ACTIVE
+	  // db_Disable_modifications flag should be set false before fully transitioning to HA_SERVER_STATE_ACTIVE
 	  logtb_enable_update (thread_p);
         }
 	

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2289,8 +2289,6 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
 	  er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state:" " set force from %s to state %s\n",
 			css_ha_server_state_string (ha_Server_state), css_ha_server_state_string (state));
 
-	  ha_Server_state = state;
-
 	  if (state == HA_SERVER_STATE_ACTIVE)
 	    {
 	      er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state: logtb_enable_update()\n");
@@ -2305,6 +2303,8 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
 	      assert (!HA_DISABLED ());
 	      cubreplication::replication_node_manager::commute_to_slave_state ();
 	    }
+	  
+	  ha_Server_state = state;
 
 	  /* append a dummy log record for LFT to wake LWTs up */
 	  log_append_ha_server_state (thread_p, state);
@@ -2329,22 +2329,21 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
 	{
 	  break;
 	}
-      /* If log appliers have changed their state to done, go directly to active mode */
-      if (css_check_ha_log_applier_done ())
-	{
-	  er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state: " "css_check_ha_log_applier_done ()\n");
-	  state = css_transit_ha_server_state (thread_p, HA_SERVER_STATE_ACTIVE);
-	  assert (state == HA_SERVER_STATE_ACTIVE);
-	}
-      if (state == HA_SERVER_STATE_ACTIVE)
-	{
-	  er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state: " "logtb_enable_update() \n");
-	  if (!HA_DISABLED ())
-	    {
-	      cubreplication::replication_node_manager::commute_to_master_state ();
-	    }
+      if (state == HA_SERVER_STATE_TO_BE_ACTIVE)
+        {
+	  // db_disable_modifications should be set before fully transitioning to HA_SERVER_STATE_ACTIVE
 	  logtb_enable_update (thread_p);
+        }
+
+      /* If log appliers have changed their state to done, go directly to active mode */
+      if (!HA_DISABLED ())
+	{
+	  // currently this only guarantees that fetched data from stream is applied
+	  cubreplication::replication_node_manager::commute_to_master_state ();
 	}
+      er_log_debug (ARG_FILE_LINE, "css_change_ha_server_state: " "css_check_ha_log_applier_done ()\n");
+      state = css_transit_ha_server_state (thread_p, HA_SERVER_STATE_ACTIVE);
+      assert (state == HA_SERVER_STATE_ACTIVE);      
       break;
 
     case HA_SERVER_STATE_STANDBY:

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2329,7 +2329,6 @@ css_change_ha_server_state (THREAD_ENTRY * thread_p, HA_SERVER_STATE state, bool
 	{
 	  break;
 	}
-
       /* If log appliers have changed their state to done, go directly to active mode */
       if (!HA_DISABLED ())
 	{

--- a/src/transaction/log_comm.c
+++ b/src/transaction/log_comm.c
@@ -295,6 +295,12 @@ log_does_allow_replication (void)
       return false;
     }
 
+  if (prm_get_bool_value (PRM_ID_REPL_LOG_LOCAL_DEBUG))
+    {
+      /* Testing purpose */
+      return true;
+    }
+
   if (HA_DISABLED ())
     {
       return false;

--- a/src/transaction/log_comm.c
+++ b/src/transaction/log_comm.c
@@ -295,12 +295,6 @@ log_does_allow_replication (void)
       return false;
     }
 
-  if (prm_get_bool_value (PRM_ID_REPL_LOG_LOCAL_DEBUG))
-    {
-      /* Testing purpose */
-      return true;
-    }
-
   if (HA_DISABLED ())
     {
       return false;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23101

In log_does_allow_replication there was a window during commute_to_master_state when the pair (ha_state, db_Disable_modifications) was inconsistent. Fix order in css_change_ha_server_state()