### PR TITLE
[CBRD-23105] remove duplicate b-tree root initialization

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -5418,7 +5418,6 @@ xbtree_add_index (THREAD_ENTRY * thread_p, BTID * btid, TP_DOMAIN * key_type, OI
   BTREE_ROOT_HEADER root_header_info, *root_header = NULL;
   VPID root_vpid;
   PAGE_PTR page_ptr = NULL;
-  unsigned short alignment;
 
   root_header = &root_header_info;
 
@@ -5444,13 +5443,6 @@ xbtree_add_index (THREAD_ENTRY * thread_p, BTID * btid, TP_DOMAIN * key_type, OI
       goto error;
     }
   pgbuf_check_page_ptype (thread_p, page_ptr, PAGE_BTREE);
-
-  alignment = BTREE_MAX_ALIGN;
-  if (btree_initialize_new_page (thread_p, page_ptr, (void *) &alignment) != NO_ERROR)
-    {
-      ASSERT_ERROR ();
-      goto error;
-    }
 
   /* form the root header information */
   root_header->node.split_info.pivot = 0.0f;

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -5933,13 +5933,15 @@ boot_db_parm_update_heap (THREAD_ENTRY * thread_p)
 static int
 boot_after_copydb (THREAD_ENTRY * thread_p)
 {
+  int error_code = NO_ERROR;
+
   if (!log_Gl.hdr.was_copied)
     {
       // this is not after copydb
       return NO_ERROR;
     }
 
-  int error_code = vacuum_reset_data_after_copydb (thread_p);
+  error_code = vacuum_reset_data_after_copydb (thread_p);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23105

Back-port of #1176 
http://jira.cubrid.org/browse/CBRD-22268

b-tree page initialization is logged with undoredo. on undo, page type is set to deallocated/unknown. xbtree_add_index initialized root page twice; which lead to inconsistent state during rollback.

remove duplicate b-tree root page initialization.