### PR TITLE
[CBRD-23100] Implement a global worker pool for loaddb

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -667,7 +667,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_LOG_CHKPT_DETAILED "detailed_checkpoint_logging"
 #define PRM_NAME_IB_TASK_MEMSIZE "index_load_task_memsize"
 #define PRM_NAME_STATS_ON "stats_on"
-#define PRM_NAME_LOADDB_WORKERS "loaddb_workers"
+#define PRM_NAME_LOADDB_WORKER_COUNT "loaddb_worker_count"
 
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
@@ -5773,8 +5773,8 @@ static SYSPRM_PARAM prm_Def[] = {
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},
-  {PRM_ID_LOADDB_WORKERS,
-   PRM_NAME_LOADDB_WORKERS,
+  {PRM_ID_LOADDB_WORKER_COUNT,
+   PRM_NAME_LOADDB_WORKER_COUNT,
    (PRM_FOR_SERVER | PRM_USER_CHANGE),
    PRM_INTEGER,
    &prm_loaddb_workers_flag,

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2246,8 +2246,8 @@ static bool prm_stats_on_default = false;
 static unsigned int prm_stats_on_flag = 0;
 
 int PRM_LOADDB_WORKERS = 8;
-static int prm_loaddb_workers_default = 4;
-static int prm_loaddb_workers_upper = 32;
+static int prm_loaddb_workers_default = 8;
+static int prm_loaddb_workers_upper = 64;
 static int prm_loaddb_workers_lower = 2;
 static unsigned int prm_loaddb_workers_flag = 0;
 

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -667,6 +667,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_LOG_CHKPT_DETAILED "detailed_checkpoint_logging"
 #define PRM_NAME_IB_TASK_MEMSIZE "index_load_task_memsize"
 #define PRM_NAME_STATS_ON "stats_on"
+#define PRM_NAME_LOADDB_WORKERS "loaddb_workers"
 
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
@@ -2243,6 +2244,12 @@ static unsigned int prm_ib_task_memsize_flag = 0;
 bool PRM_STATS_ON = false;
 static bool prm_stats_on_default = false;
 static unsigned int prm_stats_on_flag = 0;
+
+int PRM_LOADDB_WORKERS = 8;
+static int prm_loaddb_workers_default = 4;
+static int prm_loaddb_workers_upper = 32;
+static int prm_loaddb_workers_lower = 2;
+static unsigned int prm_loaddb_workers_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5763,6 +5770,17 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) &prm_stats_on_default,
    (void *) &PRM_STATS_ON,
    (void *) NULL, (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_LOADDB_WORKERS,
+   PRM_NAME_LOADDB_WORKERS,
+   (PRM_FOR_SERVER | PRM_USER_CHANGE),
+   PRM_INTEGER,
+   &prm_loaddb_workers_flag,
+   (void *) &prm_loaddb_workers_default,
+   (void *) &PRM_LOADDB_WORKERS,
+   (void *) &prm_loaddb_workers_upper, (void *) &prm_loaddb_workers_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -434,9 +434,10 @@ enum param_id
   PRM_ID_LOG_CHKPT_DETAILED,
   PRM_ID_IB_TASK_MEMSIZE,
   PRM_ID_STATS_ON,
+  PRM_ID_LOADDB_WORKERS,
 
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_STATS_ON
+  PRM_LAST_ID = PRM_ID_LOADDB_WORKERS
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -434,10 +434,10 @@ enum param_id
   PRM_ID_LOG_CHKPT_DETAILED,
   PRM_ID_IB_TASK_MEMSIZE,
   PRM_ID_STATS_ON,
-  PRM_ID_LOADDB_WORKERS,
+  PRM_ID_LOADDB_WORKER_COUNT,
 
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_LOADDB_WORKERS
+  PRM_LAST_ID = PRM_ID_LOADDB_WORKER_COUNT
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -9723,10 +9723,7 @@ sloaddb_init (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reql
 
   args.unpack (unpacker);
 
-  SESSION_ID session_id;
-  session_get_session_id (thread_p, &session_id);
-
-  load_session *session = new load_session (args, session_id);
+  load_session *session = new load_session (args);
 
   int error_code = session_set_load_session (thread_p, session);
   if (error_code != NO_ERROR)

--- a/src/loaddb/load_driver.cpp
+++ b/src/loaddb/load_driver.cpp
@@ -39,6 +39,23 @@ namespace cubload
     //
   }
 
+  void driver::uninitialize ()
+  {
+    delete m_class_installer;
+    m_class_installer = NULL;
+
+    delete m_object_loader;
+    m_object_loader = NULL;
+
+    delete m_scanner;
+    m_scanner = NULL;
+
+    delete m_error_handler;
+    m_error_handler = NULL;
+
+    m_is_initialized = false;
+  }
+
   driver::~driver ()
   {
     delete m_class_installer;

--- a/src/loaddb/load_driver.cpp
+++ b/src/loaddb/load_driver.cpp
@@ -39,7 +39,7 @@ namespace cubload
     //
   }
 
-  void driver::clear_driver ()
+  void driver::clear ()
   {
     delete m_class_installer;
     m_class_installer = NULL;
@@ -58,7 +58,7 @@ namespace cubload
 
   driver::~driver ()
   {
-    clear_driver ();
+    clear ();
   }
 
   void

--- a/src/loaddb/load_driver.cpp
+++ b/src/loaddb/load_driver.cpp
@@ -39,7 +39,7 @@ namespace cubload
     //
   }
 
-  void driver::uninitialize ()
+  void driver::clear_driver ()
   {
     delete m_class_installer;
     m_class_installer = NULL;
@@ -58,17 +58,7 @@ namespace cubload
 
   driver::~driver ()
   {
-    delete m_class_installer;
-    m_class_installer = NULL;
-
-    delete m_object_loader;
-    m_object_loader = NULL;
-
-    delete m_scanner;
-    m_scanner = NULL;
-
-    delete m_error_handler;
-    m_error_handler = NULL;
+    clear_driver ();
   }
 
   void

--- a/src/loaddb/load_driver.hpp
+++ b/src/loaddb/load_driver.hpp
@@ -81,7 +81,6 @@ namespace cubload
 
       void uninitialize ();
 
-
       // Parse functions
       int parse (std::istream &iss, int line_offset = 0);
 

--- a/src/loaddb/load_driver.hpp
+++ b/src/loaddb/load_driver.hpp
@@ -79,6 +79,9 @@ namespace cubload
       void initialize (class_installer *cls_installer, object_loader *obj_loader, error_handler *error_handler);
       bool is_initialized ();
 
+      void uninitialize ();
+
+
       // Parse functions
       int parse (std::istream &iss, int line_offset = 0);
 

--- a/src/loaddb/load_driver.hpp
+++ b/src/loaddb/load_driver.hpp
@@ -79,7 +79,7 @@ namespace cubload
       void initialize (class_installer *cls_installer, object_loader *obj_loader, error_handler *error_handler);
       bool is_initialized ();
 
-      void uninitialize ();
+      void clear_driver ();
 
       // Parse functions
       int parse (std::istream &iss, int line_offset = 0);

--- a/src/loaddb/load_driver.hpp
+++ b/src/loaddb/load_driver.hpp
@@ -79,7 +79,7 @@ namespace cubload
       void initialize (class_installer *cls_installer, object_loader *obj_loader, error_handler *error_handler);
       bool is_initialized ();
 
-      void clear_driver ();
+      void clear ();
 
       // Parse functions
       int parse (std::istream &iss, int line_offset = 0);

--- a/src/loaddb/load_session.cpp
+++ b/src/loaddb/load_session.cpp
@@ -266,9 +266,9 @@ namespace cubload
   void load_wp_register_session ()
   {
     g_loaddb_wp_mutex.lock ();
+
     if (g_loaddb_session_count == 0)
       {
-
 	assert (g_loaddb_worker_pool == NULL);
 	assert (g_loaddb_wp_context_manager == NULL);
 
@@ -286,6 +286,7 @@ namespace cubload
       }
 
     g_loaddb_session_count++;
+
     g_loaddb_wp_mutex.unlock ();
   }
 

--- a/src/loaddb/load_session.cpp
+++ b/src/loaddb/load_session.cpp
@@ -123,7 +123,7 @@ namespace cubload
 	    return;
 	  }
 
-	context.m_loaddb_driver->uninitialize ();
+	context.m_loaddb_driver->clear_driver ();
 
 	m_driver_pool.retire (*context.m_loaddb_driver);
 
@@ -162,7 +162,7 @@ namespace cubload
     private:
       resource_shared_pool<driver> m_driver_pool;
       bool m_interrupted;
-      std::atomic_int64_t m_sessions_started;
+      std::atomic<uint64_t> m_sessions_started;
   };
 
   /*
@@ -262,7 +262,7 @@ namespace cubload
 	// notify session that batch is done
 	m_session.notify_batch_done (m_batch.get_id ());
 
-	thread_ref.m_loaddb_driver->uninitialize ();
+	thread_ref.m_loaddb_driver->clear_driver ();
       }
 
     private:

--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -151,6 +151,7 @@ namespace cubload
 
       cubthread::entry_workpool *m_worker_pool;
       loaddb_worker_context_manager *m_wp_context_manager;
+      std::mutex &m_loaddb_wp_mutex;
 
       class_registry m_class_registry;
 

--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -72,7 +72,7 @@ namespace cubload
   class session
   {
     public:
-      session (load_args &args, SESSION_ID id);
+      session (load_args &args);
       ~session ();
 
       session (session &&other) = delete; // Move c-tor: deleted

--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -151,7 +151,6 @@ namespace cubload
 
       cubthread::entry_workpool *m_worker_pool;
       loaddb_worker_context_manager *m_wp_context_manager;
-      std::mutex &m_loaddb_wp_mutex;
 
       class_registry m_class_registry;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23100

We have decided to switch the individual client worker pool to a global one, which is created by the first session to initialize the loading process. Any other session that comes and wants to load will use the same worker pool and the last session to finish will also destroy it.

To ease the usage of this new worker pool I have also added a system parameter called `loaddb_worker_count ` which can be modified depending on the user's needs. The default size of the pool is set to 4 workers.