### PR TITLE
[CBRD-23113] Add getter for transaction descriptor replication generator

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -8705,10 +8705,10 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 #if !defined(NDEBUG) && defined (SERVER_MODE)
   if (class_oid_cnt > 1
       && !LOG_CHECK_LOG_APPLIER (thread_p) && prm_get_bool_value (PRM_ID_REPL_LOG_LOCAL_DEBUG)
-      && !logtb_get_tdes (thread_p)->replication_log_generator.is_row_replication_disabled ())
+      && !logtb_get_tdes (thread_p)->get_replication_generator ().is_row_replication_disabled ())
     {
       /* Disable testing HA for multi update. */
-      logtb_get_tdes (thread_p)->replication_log_generator.set_row_replication_disabled (true);
+      logtb_get_tdes (thread_p)->get_replication_generator ().set_row_replication_disabled (true);
       disabled_row_replication = true;
     }
 #endif
@@ -9337,7 +9337,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 	  if (disabled_row_replication)
 	    {
 	      /* Enable row replication. */
-	      logtb_get_tdes (thread_p)->replication_log_generator.set_row_replication_disabled (false);
+	      logtb_get_tdes (thread_p)->get_replication_generator ().set_row_replication_disabled (false);
 	    }
 #endif
 	  return ER_FAILED;
@@ -9366,7 +9366,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
   if (disabled_row_replication)
     {
       /* Enable row replication. */
-      logtb_get_tdes (thread_p)->replication_log_generator.set_row_replication_disabled (false);
+      logtb_get_tdes (thread_p)->get_replication_generator ().set_row_replication_disabled (false);
     }
 
 #endif
@@ -9416,7 +9416,7 @@ exit_on_error:
   if (disabled_row_replication)
     {
       /* Enable row replication. */
-      logtb_get_tdes (thread_p)->replication_log_generator.set_row_replication_disabled (false);
+      logtb_get_tdes (thread_p)->get_replication_generator ().set_row_replication_disabled (false);
     }
 #endif
 

--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -903,8 +903,8 @@ serial_update_serial_object (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, RECDES * r
   /* make replication log for the special type of update for serial */
   if (!LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true)
     {
-      tdes->replication_log_generator.add_update_row (*key_val, *serial_oidp, *serial_class_oidp,
-						      &new_recdesc.get_recdes ());
+      tdes->get_replication_generator ().add_update_row (*key_val, *serial_oidp, *serial_class_oidp,
+							 &new_recdesc.get_recdes ());
 
       // todo - why was repl_end_flush_mark used here?
       // http://jira.cubrid.org/browse/CBRD-22340

--- a/src/replication/log_generator.cpp
+++ b/src/replication/log_generator.cpp
@@ -398,7 +398,7 @@ namespace cubreplication
       {
 	LOG_TDES *tdes = LOG_FIND_TDES (i);
 
-	log_generator *lg = &tdes->replication_log_generator;
+	log_generator *lg = &tdes->get_replication_generator ();
 
 	lg->set_stream (stream);
       }
@@ -577,7 +577,7 @@ namespace cubreplication
     replication_object *repl_obj;
     cubthread::entry *thread_p = &cubthread::get_entry ();
     LOG_TDES *tdes = logtb_get_tdes (&cubthread::get_entry ());
-    cubreplication::stream_entry *stream_entry = tdes->replication_log_generator.get_stream_entry ();
+    cubreplication::stream_entry *stream_entry = tdes->get_replication_generator ().get_stream_entry ();
 
     assert (stream_entry->count_entries () > 0);
 
@@ -597,7 +597,7 @@ namespace cubreplication
     log_sysop_abort (thread_p);
 
     /* Disable row replication, while we apply. */
-    logtb_get_tdes (thread_p)->replication_log_generator.set_row_replication_disabled (true);
+    logtb_get_tdes (thread_p)->get_replication_generator ().set_row_replication_disabled (true);
 
     /* Simulate it again with apply . */
     for (unsigned int i = 0; i < local_stream_entry.count_entries (); i++)
@@ -619,7 +619,7 @@ namespace cubreplication
 	  }
       }
 
-    logtb_get_tdes (thread_p)->replication_log_generator.set_row_replication_disabled (false);
+    logtb_get_tdes (thread_p)->get_replication_generator ().set_row_replication_disabled (false);
 
     return err_code;
   }
@@ -634,7 +634,7 @@ namespace cubreplication
     replication_object *repl_obj;
     cubthread::entry *thread_p = &cubthread::get_entry ();
     LOG_TDES *tdes = logtb_get_tdes (&cubthread::get_entry ());
-    cubreplication::stream_entry *stream_entry = tdes->replication_log_generator.get_stream_entry ();
+    cubreplication::stream_entry *stream_entry = tdes->get_replication_generator ().get_stream_entry ();
     LOG_LSA filter_replication_lsa, savept_lsa;
 
     assert (stream_entry->count_entries () > 0);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -11139,7 +11139,7 @@ heap_attrinfo_set (const OID * inst_oid, ATTR_ID attrid, const DB_VALUE * attr_v
 {
   // todo - find a more elegant way to manage replication context
   return heap_attrinfo_set_internal (inst_oid, attrid, attr_val, attr_info,
-				     logtb_get_tdes (thread_get_thread_entry_info ())->replication_log_generator);
+				     logtb_get_tdes (thread_get_thread_entry_info ())->get_replication_generator ());
 }
 
 int

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -543,22 +543,27 @@ struct log_tdes
   const char *ha_sbr_statement;
   // *INDENT-OFF*
 #if defined (SERVER_MODE) || (defined (SA_MODE) && defined (__cplusplus))
-  cubreplication::log_generator replication_log_generator;
-  cubreplication::copy_context replication_copy_context;
+  public:
+    cubreplication::copy_context replication_copy_context;
 
-  bool is_active_worker_transaction () const;
-  bool is_system_transaction () const;
-  bool is_system_main_transaction () const;
-  bool is_system_worker_transaction () const;
-  bool is_allowed_undo () const;
-  bool is_allowed_sysop () const;
-  bool is_under_sysop () const;
+    bool is_active_worker_transaction () const;
+    bool is_system_transaction () const;
+    bool is_system_main_transaction () const;
+    bool is_system_worker_transaction () const;
+    bool is_allowed_undo () const;
+    bool is_allowed_sysop () const;
+    bool is_under_sysop () const;
 
-  void lock_topop ();
-  void unlock_topop ();
+    void lock_topop ();
+    void unlock_topop ();
 
-  void on_sysop_start ();
-  void on_sysop_end ();
+    void on_sysop_start ();
+    void on_sysop_end ();
+
+    cubreplication::log_generator &get_replication_generator ();
+
+  private:
+    cubreplication::log_generator replication_log_generator;
 #endif
   // *INDENT-ON*
 };

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1571,7 +1571,7 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   /* TODO[replication] : replace this condition on merging with develop branch */
   if (thread_p != NULL && !VACUUM_IS_THREAD_VACUUM (thread_p))
     {
-      tdes->replication_log_generator.clear_transaction ();
+      tdes->get_replication_generator ().clear_transaction ();
     }
 }
 
@@ -2925,7 +2925,7 @@ logtb_set_suppress_repl_on_transaction (THREAD_ENTRY * thread_p, int tran_index,
       tdes = LOG_FIND_TDES (tran_index);
       if (tdes != NULL && tdes->trid != NULL_TRANID)
 	{
-	  tdes->replication_log_generator.set_row_replication_disabled (set != 0);
+	  tdes->get_replication_generator ().set_row_replication_disabled (set != 0);
 	  return true;
 	}
     }
@@ -3919,7 +3919,7 @@ logtb_get_current_mvccid (THREAD_ENTRY * thread_p)
   if (MVCCID_IS_VALID (curr_mvcc_info->id) == false)
     {
       curr_mvcc_info->id = log_Gl.mvcc_table.get_new_mvccid ();
-      tdes->replication_log_generator.apply_tran_mvccid ();
+      tdes->get_replication_generator ().apply_tran_mvccid ();
     }
 
   if (!tdes->mvccinfo.sub_ids.empty ())
@@ -5503,7 +5503,7 @@ logtb_descriptors_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg
       idx++;
 
       /* Suppress_replication */
-      db_make_int (&vals[idx], tdes->replication_log_generator.is_row_replication_disabled ()? 1 : 0);
+      db_make_int (&vals[idx], tdes->get_replication_generator ().is_row_replication_disabled ()? 1 : 0);
       idx++;
 
       /* Query_timeout */
@@ -6153,6 +6153,12 @@ log_tdes::on_sysop_end ()
       LSA_SET_NULL (&undo_nxlsa);
       LSA_SET_NULL (&tail_topresult_lsa);
     }
+}
+
+cubreplication::log_generator &
+log_tdes::get_replication_generator ()
+{
+  return replication_log_generator;
 }
 
 // *INDENT-ON*

--- a/src/transaction/transaction_master_group_complete_manager.cpp
+++ b/src/transaction/transaction_master_group_complete_manager.cpp
@@ -137,7 +137,7 @@ namespace cubtx
 	notify_group_mvcc_complete (closed_group);
 
 	/* Pack group commit that internally wakeups senders. Get stream position of group complete. */
-	logtb_get_tdes (thread_p)->replication_log_generator.pack_group_commit_entry (closed_group_stream_start_position,
+	logtb_get_tdes (thread_p)->get_replication_generator ().pack_group_commit_entry (closed_group_stream_start_position,
 	    closed_group_stream_end_position);
 	m_latest_closed_group_start_stream_position = closed_group_stream_start_position;
 	m_latest_closed_group_end_stream_position = closed_group_stream_end_position;

--- a/src/transaction/transaction_sr.c
+++ b/src/transaction/transaction_sr.c
@@ -228,7 +228,7 @@ xtran_server_start_topop (THREAD_ENTRY * thread_p, LOG_LSA * topop_lsa)
   if (need_ha_replication)
     {
       assert (topop_lsa != NULL);
-      logtb_get_tdes (thread_p)->replication_log_generator.add_start_sysop (*topop_lsa);
+      logtb_get_tdes (thread_p)->get_replication_generator ().add_start_sysop (*topop_lsa);
     }
   return NO_ERROR;
 }
@@ -292,8 +292,8 @@ xtran_server_end_topop (THREAD_ENTRY * thread_p, LOG_RESULT_TOPOP result, LOG_LS
 
 	  if (need_ha_replication)
 	    {
-	      tdes->replication_log_generator.abort_pending_repl_objects ();
-	      tdes->replication_log_generator.add_end_sysop (*topop_lsa);
+	      tdes->get_replication_generator ().abort_pending_repl_objects ();
+	      tdes->get_replication_generator ().add_end_sysop (*topop_lsa);
 	    }
 	}
       if (drop_transient_class)
@@ -371,7 +371,7 @@ xtran_server_savepoint (THREAD_ENTRY * thread_p, const char *savept_name, LOG_LS
 	{
 	  LOG_TDES *tdes = logtb_get_tdes (thread_p);
 	  assert (tdes != NULL);
-	  tdes->replication_log_generator.add_create_savepoint (savept_name);
+	  tdes->get_replication_generator ().add_create_savepoint (savept_name);
 	}
     }
 
@@ -408,7 +408,7 @@ xtran_server_partial_abort (THREAD_ENTRY * thread_p, const char *savept_name, LO
     {
       LOG_TDES *tdes = logtb_get_tdes (thread_p);
       assert (tdes != NULL);
-      tdes->replication_log_generator.add_rollback_to_savepoint (savept_name);
+      tdes->get_replication_generator ().add_rollback_to_savepoint (savept_name);
     }
 
   return state;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23113

Hide replication generator in use with a getter. CBRD-23055 can switch replication generator to sub-transaction.

Conflicts with other patches are very likely.