### PR TITLE
[CBRD-23124] Fix invalid access on replication_object

### DIFF
--- a/src/replication/log_generator.cpp
+++ b/src/replication/log_generator.cpp
@@ -145,18 +145,17 @@ namespace cubreplication
      */
     logtb_get_current_mvccid (&cubthread::get_entry ());
 
+    er_log_repl_obj (&object, "log_generator::append_repl_object");
     m_stream_entry.add_packable_entry (&object);
 
     if (m_stream_entry.count_entries () >= MAX_PACKABLE_ENTRIES
-        && !prm_get_bool_value (PRM_ID_REPL_LOG_LOCAL_DEBUG))
+	&& !prm_get_bool_value (PRM_ID_REPL_LOG_LOCAL_DEBUG))
       {
-        /* Maybe is better to use a parameter here, instead MAX_PACKABLE_ENTRIES.
-         * TODO - consider stream entry total size also.
-         */
-        (void) pack_stream_entry ();
+	/* Maybe is better to use a parameter here, instead MAX_PACKABLE_ENTRIES.
+	 * TODO - consider stream entry total size also.
+	 */
+	(void) pack_stream_entry ();
       }
-
-    er_log_repl_obj (&object, "log_generator::append_repl_object");
   }
 
   /* in case inst_oid is not found, create a new entry and append it to pending,
@@ -255,8 +254,9 @@ namespace cubreplication
 	    /* Set the current transaction lsa. It may be rewritten later. */
 	    repl_obj->set_lsa_stamp (*p_lsa);
 
-	    append_repl_object (*repl_obj);
 	    er_log_repl_obj (repl_obj, "log_generator::set_key_to_repl_object");
+
+	    append_repl_object (*repl_obj);
 
 	    // remove
 	    (void) m_pending_to_be_added.erase (repl_obj_it);
@@ -278,9 +278,9 @@ namespace cubreplication
 
 	entry->set_key_value (key);
 
-	append_repl_object (*entry);
-
 	er_log_repl_obj (entry, "log_generator::set_key_to_repl_object");
+
+	append_repl_object (*entry);
       }
 
     free (class_name);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23124

After calling add_packable_entry, the replication object is owned by the stream_entry, so it should not be used anymore.

TODO: A more robust fix is planned in CBRD-23079; we experimented a solution, but due to design (class inheritance) we didn't reach a compileable code.