### PR TITLE
[CBRD-22398] bestspace ignores warnings to interogate existing errors…

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -3296,7 +3296,8 @@ heap_stats_find_page_in_bestspace (THREAD_ENTRY * thread_p, const HFID * hfid, H
 	      break;
 	    }
 #if defined (SERVER_MODE)
-	  assert (er_errid () == ER_INTERRUPTED);
+	  // ignores a warning and expects no other errors
+	  assert (er_errid_if_has_error () == NO_ERROR);
 #endif /* SERVER_MODE */
 	  er_clear ();
 	}


### PR DESCRIPTION
… (#1242)

http://jira.cubrid.org/browse/CBRD-22398

backport #1242 