### PR TITLE
[CBRD-23128] Stream fetcher refactoring

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -140,6 +140,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
+  ${BASE_DIR}/generic_utils.hpp
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_reference_store.hpp
   ${BASE_DIR}/memory_private_allocator.hpp

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -140,7 +140,6 @@ set(BASE_HEADERS
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
-  ${BASE_DIR}/generic_utils.hpp
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_reference_store.hpp
   ${BASE_DIR}/memory_private_allocator.hpp
@@ -156,6 +155,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/string_buffer.hpp
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/semaphore.hpp
+  ${BASE_DIR}/type_traits_utils.hpp
   )
 
 set(HEAPLAYER_SOURCES

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -139,7 +139,6 @@ set (BASE_HEADERS
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
-  ${BASE_DIR}/generic_utils.hpp
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_reference_store.hpp
   ${BASE_DIR}/memory_private_allocator.hpp
@@ -155,6 +154,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/string_buffer.hpp
   ${BASE_DIR}/semaphore.hpp
+  ${BASE_DIR}/type_traits_utils.hpp
   )
 
 set(EXECUTABLE_SOURCES

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -139,6 +139,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
+  ${BASE_DIR}/generic_utils.hpp
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_reference_store.hpp
   ${BASE_DIR}/memory_private_allocator.hpp

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -74,6 +74,7 @@ set (STREAM_HEADERS
   ${BASE_DIR}/cubstream.hpp
   ${BASE_DIR}/multi_thread_stream.hpp
   ${BASE_DIR}/stream_entry.hpp
+  ${BASE_DIR}/stream_entry_fetcher.hpp
   ${BASE_DIR}/stream_file.hpp
   )
 

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -134,6 +134,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
+  ${BASE_DIR}/generic_utils.hpp
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_private_allocator.cpp
   ${BASE_DIR}/msgcat_set_log.hpp

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -134,7 +134,6 @@ set(BASE_HEADERS
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
-  ${BASE_DIR}/generic_utils.hpp
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_private_allocator.cpp
   ${BASE_DIR}/msgcat_set_log.hpp
@@ -148,6 +147,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/printer.hpp
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/semaphore.hpp
+  ${BASE_DIR}/type_traits_utils.hpp
 )
 
 set(HEAPLAYER_SOURCES

--- a/src/base/generic_utils.hpp
+++ b/src/base/generic_utils.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * generic_utils.hpp - Utilities for generic programming usage
+ */
+
+#ifndef _GENERIC_UTILS_HPP_
+#define _GENERIC_UTILS_HPP_
+
+#include <type_traits>
+
+namespace cubbase
+{
+  template <template <typename> class G>
+  struct conversion_tester
+  {
+    template <typename T>
+    conversion_tester (const G<T> &);
+  };
+
+  template <typename From, template <typename> class To>
+  struct is_instance_of
+  {
+    // Tests whether From is derived from a specialization of To or is itself a specialization
+    static constexpr bool value = std::is_convertible<From,conversion_tester<To>>::value;
+  };
+}
+
+#endif //_GENERIC_UTILS_HPP_

--- a/src/base/multi_thread_stream.cpp
+++ b/src/base/multi_thread_stream.cpp
@@ -236,6 +236,7 @@ namespace cubstream
     ptr = get_data_from_pos (to_read_pos, amount, actual_read_bytes, read_context);
     if (ptr == NULL)
       {
+	// TODO: stream should never return errors
 	ASSERT_ERROR_AND_SET (err);
 	return err;
       }

--- a/src/base/stream_entry_fetcher.hpp
+++ b/src/base/stream_entry_fetcher.hpp
@@ -35,66 +35,29 @@ namespace cubstream
   template<typename T>
   class entry_fetcher
   {
+    private:
       static_assert (cubbase::is_instance_of<T, cubstream::entry>::value,
-		     "T derived from or specialisation of cubstream::entry;");
+		     "T needs to be derived from or be a specialisation of cubstream::entry");
       using stream_entry_type = T;
     public:
       entry_fetcher (cubstream::multi_thread_stream &stream);
-      void set_on_fetch_func (const std::function<void (stream_entry_type *, bool &)> &on_fetch);
-      stream_entry_type *pop_entry (bool &should_stop, bool &skip);
+      int fetch_entry (stream_entry_type *&se);
 
     private:
-      int fetch_stream_entry (stream_entry_type *&entry);
-
       cubstream::multi_thread_stream &m_stream;
-      std::function<void (stream_entry_type *, bool &)> m_on_fetch;
   };
 
   template<typename T>
   entry_fetcher<T>::entry_fetcher (cubstream::multi_thread_stream &stream)
     : m_stream (stream)
-    , m_on_fetch ([] (T *, bool &)
-  {
-    assert (false);
-  })
   {
   }
 
   template<typename T>
-  void entry_fetcher<T>::set_on_fetch_func (const std::function<void (stream_entry_type *, bool &)> &on_fetch)
+  int entry_fetcher<T>::fetch_entry (stream_entry_type *&se)
   {
-    m_on_fetch = on_fetch;
-  }
-
-  template<typename T>
-  T *entry_fetcher<T>::pop_entry (bool &should_stop, bool &skip)
-  {
-    stream_entry_type *se = nullptr;
-    int err = fetch_stream_entry (se);
-    if (err == NO_ERROR)
-      {
-	m_on_fetch (se, skip);
-      }
-    else
-      {
-	should_stop = true;
-      }
-    return se;
-  }
-
-  template<typename T>
-  int entry_fetcher<T>::fetch_stream_entry (stream_entry_type *&entry)
-  {
-    stream_entry_type *se = new stream_entry_type (&m_stream);
-
+    se = new stream_entry_type (&m_stream);
     int err = se->prepare ();
-    if (err != NO_ERROR)
-      {
-	delete se;
-	return err;
-      }
-
-    entry = se;
     return err;
   }
 };

--- a/src/base/stream_entry_fetcher.hpp
+++ b/src/base/stream_entry_fetcher.hpp
@@ -25,6 +25,8 @@
 #define _STREAM_ENTRY_FETCHER_HPP_
 
 #include "multi_thread_stream.hpp"
+#include <cassert>
+#include <functional>
 
 namespace cubstream
 {
@@ -33,8 +35,8 @@ namespace cubstream
   class stream_entry_fetcher
   {
     public:
-      stream_entry_fetcher (cubstream::multi_thread_stream &stream, const std::function<void (T *, bool &)> &on_fetch);
-      void set_on_fetch (const std::function<void (T *, bool &)> &on_fetch);
+      stream_entry_fetcher (cubstream::multi_thread_stream &stream);
+      void set_on_fetch_func (const std::function<void (T *, bool &)> &on_fetch);
       T *pop_entry (bool &should_stop, bool &skip);
 
     private:
@@ -45,15 +47,17 @@ namespace cubstream
   };
 
   template<typename T>
-  stream_entry_fetcher<T>::stream_entry_fetcher (cubstream::multi_thread_stream &stream,
-      const std::function<void (T *, bool &)> &on_fetch)
+  stream_entry_fetcher<T>::stream_entry_fetcher (cubstream::multi_thread_stream &stream)
     : m_stream (stream)
-    , m_on_fetch (on_fetch)
+    , m_on_fetch ([] (T *, bool &)
+  {
+    assert (false);
+  })
   {
   }
 
   template<typename T>
-  void stream_entry_fetcher<T>::set_on_fetch (const std::function<void (T *, bool &)> &on_fetch)
+  void stream_entry_fetcher<T>::set_on_fetch_func (const std::function<void (T *, bool &)> &on_fetch)
   {
     m_on_fetch = on_fetch;
   }

--- a/src/base/stream_entry_fetcher.hpp
+++ b/src/base/stream_entry_fetcher.hpp
@@ -18,7 +18,7 @@
  */
 
 /*
- * entry_fetcher.hpp - Fetcher of stream entries from a stream
+ * stream_entry_fetcher.hpp - Fetcher of stream entries from a stream
  */
 
 #ifndef _STREAM_ENTRY_FETCHER_HPP_

--- a/src/base/stream_entry_fetcher.hpp
+++ b/src/base/stream_entry_fetcher.hpp
@@ -24,30 +24,19 @@
 #ifndef _STREAM_ENTRY_FETCHER_HPP_
 #define _STREAM_ENTRY_FETCHER_HPP_
 
+#include "generic_utils.hpp"
 #include "multi_thread_stream.hpp"
-#include "replication_stream_entry.hpp"
+#include "stream_entry.hpp"
 #include <cassert>
 #include <functional>
 
 namespace cubstream
 {
-  template <template <typename> class F>
-  struct conversion_tester
-  {
-    template <typename T>
-    conversion_tester (const F<T> &);
-  };
-
-  template <class From, template <typename> class To>
-  struct is_instance_of
-  {
-    static constexpr bool value = std::is_convertible<From,conversion_tester<To>>::value;
-  };
-
   template<typename T>
   class entry_fetcher
   {
-      static_assert (is_instance_of<T, cubstream::entry>::value, "T derived from or specialisation of cubstream::entry;");
+      static_assert (cubbase::is_instance_of<T, cubstream::entry>::value,
+		     "T derived from or specialisation of cubstream::entry;");
       using stream_entry_type = T;
     public:
       entry_fetcher (cubstream::multi_thread_stream &stream);

--- a/src/base/stream_entry_fetcher.hpp
+++ b/src/base/stream_entry_fetcher.hpp
@@ -24,7 +24,7 @@
 #ifndef _STREAM_ENTRY_FETCHER_HPP_
 #define _STREAM_ENTRY_FETCHER_HPP_
 
-#include "generic_utils.hpp"
+#include "type_traits_utils.hpp"
 #include "multi_thread_stream.hpp"
 #include "stream_entry.hpp"
 #include <cassert>

--- a/src/base/stream_entry_fetcher.hpp
+++ b/src/base/stream_entry_fetcher.hpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * stream_entry_fetcher.hpp - Fetcher of stream entries from a stream
+ */
+
+#ifndef _STREAM_ENTRY_FETCHER_HPP_
+#define _STREAM_ENTRY_FETCHER_HPP_
+
+#include "multi_thread_stream.hpp"
+
+namespace cubstream
+{
+  // todo: find a way to constrain T to be of type cubstream::entry<T>
+  template<typename T>
+  class stream_entry_fetcher
+  {
+    public:
+      stream_entry_fetcher (cubstream::multi_thread_stream &stream, const std::function<void (T *, bool &)> &on_fetch);
+      void set_on_fetch (const std::function<void (T *, bool &)> &on_fetch);
+      T *pop_entry (bool &should_stop, bool &skip);
+
+    private:
+      int fetch_stream_entry (T *&entry);
+
+      cubstream::multi_thread_stream &m_stream;
+      std::function<void (T *, bool &)> m_on_fetch;
+  };
+
+  template<typename T>
+  stream_entry_fetcher<T>::stream_entry_fetcher (cubstream::multi_thread_stream &stream,
+      const std::function<void (T *, bool &)> &on_fetch)
+    : m_stream (stream)
+    , m_on_fetch (on_fetch)
+  {
+  }
+
+  template<typename T>
+  void stream_entry_fetcher<T>::set_on_fetch (const std::function<void (T *, bool &)> &on_fetch)
+  {
+    m_on_fetch = on_fetch;
+  }
+
+  template<typename T>
+  T *stream_entry_fetcher<T>::pop_entry (bool &should_stop, bool &skip)
+  {
+    T *se = nullptr;
+    int err = fetch_stream_entry (se);
+    if (err == NO_ERROR)
+      {
+	m_on_fetch (se, skip);
+      }
+    else
+      {
+	should_stop = true;
+      }
+    return se;
+  }
+
+  template<typename T>
+  int stream_entry_fetcher<T>::fetch_stream_entry (T *&entry)
+  {
+    T *se = new T (&m_stream);
+
+    int err = se->prepare ();
+    if (err != NO_ERROR)
+      {
+	delete se;
+	return err;
+      }
+
+    entry = se;
+    return err;
+  }
+};
+
+#endif // _STREAM_ENTRY_FETCHER_HPP_

--- a/src/base/type_traits_utils.hpp
+++ b/src/base/type_traits_utils.hpp
@@ -18,11 +18,11 @@
  */
 
 /*
- * generic_utils.hpp - Utilities for generic programming usage
+ * type_traits_utils.hpp - Utilities for type traits information
  */
 
-#ifndef _GENERIC_UTILS_HPP_
-#define _GENERIC_UTILS_HPP_
+#ifndef _TYPE_TRAITS_UTILS_HPP_
+#define _TYPE_TRAITS_UTILS_HPP_
 
 #include <type_traits>
 
@@ -31,6 +31,11 @@ namespace cubbase
   template <template <typename> class G>
   struct conversion_tester
   {
+    // Non-explicit constructors enable implicit conversion from the type of the constructor's argument to
+    // constructor's class type. Here, concretely, we enable implicit conversions from G<T> to conversion_tester<G>
+    // thus accepting from the point of view of is_instance_of<From, To<typnemae>> any From that is either of the form:
+    // From : To<Something> or From = To<Something> (conditions necessary to have aforementioned conversions
+    // avilable and implicitly std::is_convertible<From,conversion_tester<To>>::value true)
     template <typename T>
     conversion_tester (const G<T> &);
   };
@@ -43,4 +48,4 @@ namespace cubbase
   };
 }
 
-#endif //_GENERIC_UTILS_HPP_
+#endif // _TYPE_TRAITS_UTILS_HPP_

--- a/src/replication/log_consumer.cpp
+++ b/src/replication/log_consumer.cpp
@@ -134,6 +134,7 @@ namespace cubreplication
 	: m_filtered_apply_end (log_Gl.hdr.m_ack_stream_position)
 	, m_entry_fetcher (entry_fetcher)
 	, m_lc (lc)
+	, m_stop (false)
       {
 	m_entry_fetcher.set_on_fetch_func ([this] (stream_entry *se, bool & should_skip)
 	{
@@ -153,13 +154,12 @@ namespace cubreplication
 	tasks_map repl_tasks;
 	tasks_map nonexecutable_repl_tasks;
 
-	while (true)
+	while (!m_stop)
 	  {
-	    bool should_stop = false;
 	    bool filter_out = false;
-	    stream_entry *se = m_entry_fetcher.pop_entry (should_stop, filter_out);
+	    stream_entry *se = m_entry_fetcher.pop_entry (m_stop, filter_out);
 
-	    if (should_stop)
+	    if (m_stop)
 	      {
 		delete se;
 		break;
@@ -284,6 +284,7 @@ namespace cubreplication
       cubstream::stream_position m_filtered_apply_end;
       cubstream::repl_stream_entry_fetcher m_entry_fetcher;
       log_consumer &m_lc;
+      bool m_stop;
   };
 
   log_consumer::~log_consumer ()

--- a/src/replication/log_consumer.cpp
+++ b/src/replication/log_consumer.cpp
@@ -152,7 +152,7 @@ namespace cubreplication
 	    int err = m_entry_fetcher.fetch_entry (se);
 	    if (err != NO_ERROR)
 	      {
-		if (ER_STREAM_NO_MORE_DATA)
+		if (err == ER_STREAM_NO_MORE_DATA)
 		  {
 		    ASSERT_ERROR ();
 		    m_stop = true;
@@ -179,7 +179,7 @@ namespace cubreplication
 		se->unpack ();
 		assert (se->get_stream_entry_end_position () > se->get_stream_entry_start_position ());
 		m_lc.ack_produce (se->get_stream_entry_end_position ());
-	      };
+	      }
 
 	    if (prm_get_bool_value (PRM_ID_DEBUG_REPLICATION_DATA))
 	      {

--- a/src/replication/log_consumer.cpp
+++ b/src/replication/log_consumer.cpp
@@ -132,7 +132,7 @@ namespace cubreplication
     public:
       dispatch_daemon_task (log_consumer &lc)
 	: m_filtered_apply_end (log_Gl.hdr.m_ack_stream_position)
-	, m_entry_fetcher (cubstream::repl_stream_entry_fetcher (*lc.get_stream ()))
+	, m_entry_fetcher (*lc.get_stream ())
 	, m_lc (lc)
 	, m_stop (false)
       {

--- a/src/replication/log_consumer.cpp
+++ b/src/replication/log_consumer.cpp
@@ -292,7 +292,7 @@ namespace cubreplication
       }
 
       cubstream::stream_position m_filtered_apply_end;
-      cubstream::repl_stream_entry_fetcher m_entry_fetcher;
+      cubstream::stream_entry_fetcher m_entry_fetcher;
       log_consumer &m_lc;
       bool m_stop;
   };

--- a/src/replication/log_consumer.cpp
+++ b/src/replication/log_consumer.cpp
@@ -156,6 +156,8 @@ namespace cubreplication
 	tasks_map repl_tasks;
 	tasks_map nonexecutable_repl_tasks;
 
+	m_lc.wait_for_fetch_resume ();
+
 	while (!m_stop)
 	  {
 	    bool filter_out = false;
@@ -349,7 +351,25 @@ namespace cubreplication
 
   void log_consumer::stop (void)
   {
+    /* wakeup fetch daemon to allow it time to detect it is stopped */
+    fetch_resume ();
+
     get_stream ()->stop ();
+  }
+
+  void log_consumer::fetch_suspend (void)
+  {
+    m_fetch_suspend.clear ();
+  }
+
+  void log_consumer::fetch_resume (void)
+  {
+    m_fetch_suspend.set ();
+  }
+
+  void log_consumer::wait_for_fetch_resume (void)
+  {
+    m_fetch_suspend.wait ();
   }
 
   subtran_applier &log_consumer::get_subtran_applier ()

--- a/src/replication/log_consumer.cpp
+++ b/src/replication/log_consumer.cpp
@@ -292,7 +292,7 @@ namespace cubreplication
       }
 
       cubstream::stream_position m_filtered_apply_end;
-      cubstream::stream_entry_fetcher m_entry_fetcher;
+      stream_entry_fetcher m_entry_fetcher;
       log_consumer &m_lc;
       bool m_stop;
   };

--- a/src/replication/log_consumer.hpp
+++ b/src/replication/log_consumer.hpp
@@ -27,6 +27,7 @@
 #define _LOG_CONSUMER_HPP_
 
 #include "cubstream.hpp"
+#include "semaphore.hpp"
 #include "stream_entry_fetcher.hpp"
 #include "thread_manager.hpp"
 #include <cstddef>
@@ -90,6 +91,12 @@ namespace cubreplication
 
       std::atomic<int> m_started_tasks;
 
+      /* fetch suspend flag : this is required in context of replication with copy phase :
+      * while replication copy is running the fetch from online replication must be suspended
+      * (although the stream contents are received and stored on local slave node)
+      */
+      cubsync::event_semaphore m_fetch_suspend;
+
     public:
 
       std::function<void (cubstream::stream_position)> ack_produce;
@@ -143,6 +150,10 @@ namespace cubreplication
       void wait_for_tasks (void);
 
       void stop (void);
+
+      void fetch_suspend ();
+      void fetch_resume ();
+      void wait_for_fetch_resume ();
 
       subtran_applier &get_subtran_applier ();
   };

--- a/src/replication/log_consumer.hpp
+++ b/src/replication/log_consumer.hpp
@@ -48,7 +48,7 @@ namespace cubreplication
 namespace cubstream
 {
   class multi_thread_stream;
-  using repl_stream_entry_fetcher = entry_fetcher<cubreplication::stream_entry>;
+  using stream_entry_fetcher = entry_fetcher<cubreplication::stream_entry>;
 };
 
 namespace cubreplication

--- a/src/replication/log_consumer.hpp
+++ b/src/replication/log_consumer.hpp
@@ -47,7 +47,7 @@ namespace cubreplication
 namespace cubstream
 {
   class multi_thread_stream;
-  using repl_stream_entry_fetcher = stream_entry_fetcher<cubreplication::stream_entry>;
+  using repl_stream_entry_fetcher = entry_fetcher<cubreplication::stream_entry>;
 };
 
 namespace cubreplication

--- a/src/replication/log_consumer.hpp
+++ b/src/replication/log_consumer.hpp
@@ -65,17 +65,14 @@ namespace cubreplication
    *    object which aggregates both log_consumer and stream)
    *
    * Methods/daemons/threads:
-   *  - a daemon which "consumes" replication stream entries : create a new replication_stream_entry object,
-   *    prepares it (uses stream to receive and unpacks its header), and pushes to the queue
-   *  - a dispatch daemon which extracts replication stream entry frin stream and builds applier_worker_task
+   *  - a dispatch daemon which extracts replication stream entry from stream and builds applier_worker_task
    *    objects; each applier_worker_task contains a list of stream_entries belonging to the same transaction;
    *    when a group commit special stream entry is encoutered by dispatch daemon, all gathered commited
    *    applier_worker_task are pushed to a worker thread pool (m_applier_workers_pool);
    *    the remainder of applier_worker_task objects (not having coommit), are copied to next cycle (until next
    *    group commit) : see dispatch_daemon_task::execute;
-   *  - a thread pool for applying applier_worker_task; all replication stream entries are unpacked
-   *    (the consumer daemon task is unpacking only the header) and then each replication object from a stream entry
-   *    is applied
+   *  - a thread pool for applying applier_worker_task; all replication stream entries are unpacked and then
+   *    each replication object from a stream entry is applied
    */
   class log_consumer
   {

--- a/src/replication/log_consumer.hpp
+++ b/src/replication/log_consumer.hpp
@@ -92,9 +92,9 @@ namespace cubreplication
       std::atomic<int> m_started_tasks;
 
       /* fetch suspend flag : this is required in context of replication with copy phase :
-      * while replication copy is running the fetch from online replication must be suspended
-      * (although the stream contents are received and stored on local slave node)
-      */
+       * while replication copy is running the fetch from online replication must be suspended
+       * (although the stream contents are received and stored on local slave node)
+       */
       cubsync::event_semaphore m_fetch_suspend;
 
     public:

--- a/src/replication/log_consumer.hpp
+++ b/src/replication/log_consumer.hpp
@@ -36,20 +36,12 @@
 namespace cubthread
 {
   class daemon;
-};
-
-namespace cubreplication
-{
-  class applier_worker_task;
-  class stream_entry;
-  class subtran_applier;
 }
 
 namespace cubstream
 {
   class multi_thread_stream;
-  using stream_entry_fetcher = entry_fetcher<cubreplication::stream_entry>;
-};
+}
 
 namespace cubreplication
 {
@@ -57,6 +49,10 @@ namespace cubreplication
    * main class for consuming log packing stream entries;
    * it should be created only as a global instance
    */
+  class applier_worker_task;
+  class stream_entry;
+  class subtran_applier;
+  using stream_entry_fetcher = cubstream::entry_fetcher<stream_entry>;
 
   /*
    * log_consumer : class intended as singleton for slave server

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -47,8 +47,8 @@ namespace cubreplication
     , m_lc (NULL)
     , m_master_identity ("")
     , m_transfer_receiver (NULL)
-    , m_ctrl_sender (NULL)
     , m_ctrl_sender_daemon (NULL)
+    , m_ctrl_sender (NULL)
     , m_source_min_available_pos (0)
     , m_source_curr_pos (0)
   {
@@ -197,7 +197,6 @@ namespace cubreplication
 
     assert (m_stream != NULL);
     m_lc = new log_consumer ();
-    m_lc->fetch_suspend ();
 
     m_lc->set_stream (m_stream);
 
@@ -253,8 +252,6 @@ namespace cubreplication
 
     m_transfer_receiver = new cubstream::transfer_receiver (std::move (srv_chn), *m_stream,
 	start_position);
-
-    m_lc->fetch_resume ();
 
     return NO_ERROR;
   }

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -197,6 +197,7 @@ namespace cubreplication
 
     assert (m_stream != NULL);
     m_lc = new log_consumer ();
+    m_lc->fetch_suspend ();
 
     m_lc->set_stream (m_stream);
 
@@ -252,6 +253,8 @@ namespace cubreplication
 
     m_transfer_receiver = new cubstream::transfer_receiver (std::move (srv_chn), *m_stream,
 	start_position);
+
+    m_lc->fetch_resume ();
 
     return NO_ERROR;
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23128

Comprising changes:
1. Unify fetcher & dispatcher threads (make the dispatch thread fetch directly from stream)
2. Move ack-sending to dispatcher
