### PR TITLE
[CBRD-23097] Integrated the workerpool which limits how many tasks are pushed

### DIFF
--- a/src/loaddb/load_session.cpp
+++ b/src/loaddb/load_session.cpp
@@ -184,6 +184,8 @@ namespace cubload
 
 	// notify session that batch is done
 	m_session.notify_batch_done (m_batch.get_id ());
+
+	worker_manager_complete_task ();
       }
 
     private:

--- a/src/loaddb/load_worker_manager.hpp
+++ b/src/loaddb/load_worker_manager.hpp
@@ -36,6 +36,8 @@ namespace cubload
   void worker_manager_register_session ();
 
   void worker_manager_unregister_session ();
+
+  void worker_manager_complete_task ();
 }
 
 #endif /* _LOAD_WORKER_MANAGER_HPP_ */

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -1494,10 +1494,10 @@ namespace cubthread
   // worker_pool_task_capper template implementation
   //////////////////////////////////////////////////////////////////////////
   template <typename Context>
-  worker_pool_task_capper<Context>::worker_pool_task_capper (worker_pool<Context> *worker_pool_)
+  worker_pool_task_capper<Context>::worker_pool_task_capper (worker_pool<Context> *wp)
   {
-    m_worker_pool = worker_pool_;
-    m_tasks_available = m_max_tasks = worker_pool_->get_max_count ();
+    m_worker_pool = wp;
+    m_tasks_available = m_max_tasks = wp->get_max_count ();
   }
 
   template <typename Context>

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -1475,7 +1475,7 @@ namespace cubthread
       worker_pool_task_capper (worker_pool<Context> *worker_pool);
       ~worker_pool_task_capper ();
 
-      void push_task (context_manager<Context> *manager, task<Context> *task);
+      void push_task (task<Context> *task);
       cubthread::worker_pool<Context> *get_worker_pool ();
       void end_task ();
 
@@ -1494,10 +1494,10 @@ namespace cubthread
   // worker_pool_task_capper template implementation
   //////////////////////////////////////////////////////////////////////////
   template <typename Context>
-  worker_pool_task_capper<Context>::worker_pool_task_capper (worker_pool<Context> *worker_pool)
+  worker_pool_task_capper<Context>::worker_pool_task_capper (worker_pool<Context> *worker_pool_)
   {
-    m_worker_pool = worker_pool;
-    m_tasks_available = m_max_tasks = worker_pool.get_max_count ();
+    m_worker_pool = worker_pool_;
+    m_tasks_available = m_max_tasks = worker_pool_->get_max_count ();
   }
 
   template <typename Context>
@@ -1508,7 +1508,7 @@ namespace cubthread
 
   template <typename Context>
   void
-  worker_pool_task_capper<Context>::push_task (context_manager<Context> *manager, task<Context> *task)
+  worker_pool_task_capper<Context>::push_task (task<Context> *task)
   {
     auto pred = [&] () -> bool {return (m_tasks_available > 0); };
     std::unique_lock<std::mutex> ulock (m_mutex);
@@ -1521,7 +1521,7 @@ namespace cubthread
     assert (m_tasks_available > 0);
 
     m_tasks_available--;
-    manager->push_task (task);
+    m_worker_pool->execute (task);
   }
 
   template <typename Context>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23097

This PR integrates the new working pool which limits how many tasks are executed at once. This should limit the number of batches that are executed on the server, thus fixing the issue regarding huge memory usage to store these batches on the server.

TODO: We also need to backport the changes to develop of the workerpool since it no longer requires the thread manager in its implementation.