### PR TITLE
[CBRD-23139] keep threads always alive for perf test

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -667,6 +667,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_LOG_CHKPT_DETAILED "detailed_checkpoint_logging"
 #define PRM_NAME_IB_TASK_MEMSIZE "index_load_task_memsize"
 #define PRM_NAME_STATS_ON "stats_on"
+#define PRM_NAME_PERF_TEST_MODE "perf_test_mode"
 
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
@@ -2243,6 +2244,10 @@ static unsigned int prm_ib_task_memsize_flag = 0;
 bool PRM_STATS_ON = false;
 static bool prm_stats_on_default = false;
 static unsigned int prm_stats_on_flag = 0;
+
+bool PRM_PERF_TEST_MODE = false;
+static bool prm_perf_test_mode_default = false;
+static unsigned int prm_perf_test_mode_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5762,6 +5767,17 @@ static SYSPRM_PARAM prm_Def[] = {
    &prm_stats_on_flag,
    (void *) &prm_stats_on_default,
    (void *) &PRM_STATS_ON,
+   (void *) NULL, (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_PERF_TEST_MODE,
+   PRM_NAME_PERF_TEST_MODE,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   &prm_perf_test_mode_flag,
+   (void *) &prm_perf_test_mode_default,
+   (void *) &PRM_PERF_TEST_MODE,
    (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -434,9 +434,10 @@ enum param_id
   PRM_ID_LOG_CHKPT_DETAILED,
   PRM_ID_IB_TASK_MEMSIZE,
   PRM_ID_STATS_ON,
+  PRM_ID_PERF_TEST_MODE,
 
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_STATS_ON
+  PRM_LAST_ID = PRM_ID_PERF_TEST_MODE
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -483,6 +483,14 @@ namespace cubthread
     my_entry = Main_entry_p;
 
     assert (my_entry == thread_get_thread_entry_info ());
+
+#if defined (SERVER_MODE)
+    if (prm_get_bool_value (PRM_ID_PERF_TEST_MODE))
+      {
+	// perf tool needs threads to be always alive to work
+	wp_set_force_thread_always_alive ();
+      }
+#endif // SERVER_MODE
   }
 
   void

--- a/src/thread/thread_waiter.hpp
+++ b/src/thread/thread_waiter.hpp
@@ -127,6 +127,9 @@ namespace cubthread
       m_duration = duration;
       m_infinite = false;
     }
+
+    void set_infinite_wait ();
+    void set_duration (const D &duration);
   };
   using wait_seconds = wait_duration<std::chrono::seconds>;
 
@@ -171,6 +174,22 @@ namespace cubthread
 	return condvar.wait_for (lock, duration.m_duration, pred);
       }
   }
+
+  template <class D>
+  void
+  wait_duration<D>::set_infinite_wait ()
+  {
+    m_infinite = true;
+  }
+
+  template <class D>
+  void
+  wait_duration<D>::set_duration (const D &duration)
+  {
+    m_duration = duration;
+    m_infinite = false;
+  }
+
 } // namespace cubthread
 
 #endif // _THREAD_WAITER_HPP_

--- a/src/thread/thread_worker_pool.cpp
+++ b/src/thread/thread_worker_pool.cpp
@@ -32,6 +32,20 @@
 
 namespace cubthread
 {
+  static bool FORCE_THREAD_ALWAYS_ALIVE = false;
+
+  bool
+  wp_is_thread_always_alive_forced ()
+  {
+    return FORCE_THREAD_ALWAYS_ALIVE;
+  }
+
+  void
+  wp_set_force_thread_always_alive ()
+  {
+    FORCE_THREAD_ALWAYS_ALIVE = true;
+  }
+
   //////////////////////////////////////////////////////////////////////////
   // statistics
   //////////////////////////////////////////////////////////////////////////
@@ -39,21 +53,21 @@ namespace cubthread
   static const cubperf::statset_definition Worker_pool_statdef =
   {
     cubperf::stat_definition (Wpstat_start_thread, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_start_thread", "Timer_start_thread"),
+    "Counter_start_thread", "Timer_start_thread"),
     cubperf::stat_definition (Wpstat_create_context, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_create_context", "Timer_create_context"),
+    "Counter_create_context", "Timer_create_context"),
     cubperf::stat_definition (Wpstat_execute_task, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_execute_task", "Timer_execute_task"),
+    "Counter_execute_task", "Timer_execute_task"),
     cubperf::stat_definition (Wpstat_retire_task, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_retire_task", "Timer_retire_task"),
+    "Counter_retire_task", "Timer_retire_task"),
     cubperf::stat_definition (Wpstat_found_in_queue, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_found_task_in_queue", "Timer_found_task_in_queue"),
+    "Counter_found_task_in_queue", "Timer_found_task_in_queue"),
     cubperf::stat_definition (Wpstat_wakeup_with_task, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_wakeup_with_task", "Timer_wakeup_with_task"),
+    "Counter_wakeup_with_task", "Timer_wakeup_with_task"),
     cubperf::stat_definition (Wpstat_recycle_context, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_recycle_context", "Timer_recycle_context"),
+    "Counter_recycle_context", "Timer_recycle_context"),
     cubperf::stat_definition (Wpstat_retire_context, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_retire_context", "Timer_retire_context")
+    "Counter_retire_context", "Timer_retire_context")
   };
 
   cubperf::statset &

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -522,6 +522,9 @@ namespace cubthread
   // dump worker pool statistics to error log
   void wp_er_log_stats (const char *header, cubperf::stat_value *statsp);
 
+  bool wp_is_thread_always_alive_forced ();
+  void wp_set_force_thread_always_alive ();
+
   /************************************************************************/
   /* Template/inline implementation                                       */
   /************************************************************************/
@@ -574,6 +577,13 @@ namespace cubthread
     for (; it < m_core_count; it++)
       {
 	m_core_array[it].init_pool_and_workers (*this, quotient);
+      }
+
+    if (wp_is_thread_always_alive_forced ())
+      {
+	// override pooling/wait time options to keep threads always alive
+	m_pool_threads = true;
+	m_wait_for_task_time.set_infinite_wait ();
       }
   }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23139

We need to pool and keep threads alive to allow perf test collect all their stats.