### PR TITLE
[CBRD-22130] fix decaching representation on partial rollback

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -668,6 +668,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_IB_TASK_MEMSIZE "index_load_task_memsize"
 #define PRM_NAME_STATS_ON "stats_on"
 #define PRM_NAME_PERF_TEST_MODE "perf_test_mode"
+#define PRM_NAME_REPR_CACHE_LOG "er_log_repr_cache"
 
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
@@ -2248,6 +2249,10 @@ static unsigned int prm_stats_on_flag = 0;
 bool PRM_PERF_TEST_MODE = false;
 static bool prm_perf_test_mode_default = false;
 static unsigned int prm_perf_test_mode_flag = 0;
+
+bool PRM_REPR_CACHE_LOG = false;
+static bool prm_repr_cache_log_default = false;
+static unsigned int prm_repr_cache_log_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5778,6 +5783,17 @@ static SYSPRM_PARAM prm_Def[] = {
    &prm_perf_test_mode_flag,
    (void *) &prm_perf_test_mode_default,
    (void *) &PRM_PERF_TEST_MODE,
+   (void *) NULL, (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_REPR_CACHE_LOG,
+   PRM_NAME_REPR_CACHE_LOG,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   &prm_repr_cache_log_flag,
+   (void *) &prm_repr_cache_log_default,
+   (void *) &PRM_REPR_CACHE_LOG,
    (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -435,9 +435,10 @@ enum param_id
   PRM_ID_IB_TASK_MEMSIZE,
   PRM_ID_STATS_ON,
   PRM_ID_PERF_TEST_MODE,
+  PRM_ID_REPR_CACHE_LOG,
 
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_PERF_TEST_MODE
+  PRM_LAST_ID = PRM_ID_REPR_CACHE_LOG
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/transaction/transaction_transient.cpp
+++ b/src/transaction/transaction_transient.cpp
@@ -126,10 +126,9 @@ tx_transient_class_registry::decache_heap_repr (const LOG_LSA &downto_lsa)
 {
   for (auto &it : m_list)
     {
-      if (it.m_last_modified_lsa > downto_lsa)
+      if (downto_lsa.is_null () || it.m_last_modified_lsa > downto_lsa)
 	{
 	  (void) heap_classrepr_decache (NULL, &it.m_class_oid);
-	  it.m_last_modified_lsa.set_null ();
 	}
     }
 }

--- a/src/transaction/transaction_transient.cpp
+++ b/src/transaction/transaction_transient.cpp
@@ -126,6 +126,7 @@ tx_transient_class_registry::decache_heap_repr (const LOG_LSA &downto_lsa)
 {
   for (auto &it : m_list)
     {
+      assert (!it.m_last_modified_lsa.is_null ());
       if (downto_lsa.is_null () || it.m_last_modified_lsa > downto_lsa)
 	{
 	  (void) heap_classrepr_decache (NULL, &it.m_class_oid);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22130

Do not reset the LSA marker of modified class when representation is decached on partial rollback. Potential changes preceding the start LSA of partial rollback still have to be discarded on transaction rollback.

Fix can be found in transaction_transient.cpp.

Other changes
  - added a system parameter and logging functions for class representation cache.
  - added safe-guard that cache entry is not marked for decache when a new representation comes.