### PR TITLE
[CBRD-22130] fix decaching representation on partial rollback

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -2492,6 +2492,7 @@ search_begin:
     {
       /* now, we have already cache_entry for class_oid. if it contains repr info for reprid, return it. else load
        * classrepr info for it */
+      assert (!cache_entry->force_decache);
 
       if (reprid == NULL_REPRID)
 	{

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -4968,7 +4968,6 @@ log_rollback_classrepr_cache (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA 
       if (LSA_GT (&t->m_last_modified_lsa, upto_lsa))
 	{
 	  (void) heap_classrepr_decache (thread_p, &t->m_class_oid);
-	  LSA_SET_NULL (&t->m_last_modified_lsa);
 	}
     }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22130

Do not reset the LSA marker of modified class when representation is decached on partial rollback. 

Backport of #1784.