### PR TITLE
[CBRD-22130] Do not set pruned flag on errors

### DIFF
--- a/src/query/partition.c
+++ b/src/query/partition.c
@@ -2891,7 +2891,11 @@ partition_prune_spec (THREAD_ENTRY * thread_p, VAL_DESCR * vd, ACCESS_SPEC_TYPE 
     }
 
   partition_clear_pruning_context (&pinfo);
-  spec->pruned = true;
+
+  if (error == NO_ERROR)
+    {
+      spec->pruned = true;
+    }
 
   return error;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22130

- do not set pruned flag if error occurred during partition_prune_spec (next time it will early out)

Backport of #1788