### PR TITLE
[CBRD-23161] Change SINGLE_ROW_INSERT to MULTI_ROW_INSERT

### DIFF
--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -675,6 +675,26 @@ namespace cubload
 	return;
       }
 
+    // *INDENT-OFF*
+    if (m_scancache.m_index_stats != NULL)
+      {
+        for (const auto &it : m_scancache.m_index_stats->get_map ())
+	  {
+            if (!it.second.is_unique ())
+	      {
+	        break;
+	      }
+
+	    int error = logtb_tran_update_unique_stats (thread_get_thread_entry_info (), it.first, it.second, true);
+	    if (error != NO_ERROR)
+	      {
+                ASSERT_ERROR ();
+	        m_error_handler.on_failure ();
+	      }
+	  }
+      }
+    // *INDENT-ON*
+
     heap_scancache_end_modify (m_thread_ref, &m_scancache);
     m_scancache_started = false;
   }

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -682,7 +682,11 @@ namespace cubload
 	  {
             if (!it.second.is_unique ())
 	      {
-	        break;
+	        // We need to throw an error here and abort the load.
+                BTREE_SET_UNIQUE_VIOLATION_ERROR (thread_get_thread_entry_info (), NULL, NULL,
+                                                  &m_class_entry->get_class_oid (), &it.first, NULL);
+                m_error_handler.on_failure ();
+                break;
 	      }
 
 	    int error = logtb_tran_update_unique_stats (thread_get_thread_entry_info (), it.first, it.second, true);

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -389,7 +389,7 @@ namespace cubload
   {
     int force_count = 0;
     int pruning_type = 0;
-    int op_type = SINGLE_ROW_INSERT;
+    int op_type = MULTI_ROW_INSERT;
 
     // First check if we have any errors set.
     if (m_session.is_failed ())
@@ -657,7 +657,7 @@ namespace cubload
 	return;
       }
 
-    error_code = heap_scancache_start_modify (m_thread_ref, &m_scancache, &hfid, &class_oid, SINGLE_ROW_INSERT, NULL);
+    error_code = heap_scancache_start_modify (m_thread_ref, &m_scancache, &hfid, &class_oid, MULTI_ROW_INSERT, NULL);
     if (error_code != NO_ERROR)
       {
 	m_error_handler.on_failure_with_line (LOADDB_MSG_LOAD_FAIL);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23161

Previously we inserted each record using a `SINGLE_ROW_INSERT` operation. Now we want to insert them using `MULTI_ROW_INSERT` so that maybe we will minimize the logging operations needed for inserting multiple records.