### PR TITLE
[CBRD-23147] Revert #1792: Removing archived log should also care copied log positi…"

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -5658,7 +5658,6 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
   int log_max_archives = prm_get_integer_value (PRM_ID_LOG_MAX_ARCHIVES);
   char *catmsg;
   int deleted_count = 0;
-  HA_MODE ha_mode = (HA_MODE) prm_get_integer_value (PRM_ID_HA_MODE);
 
   if (log_max_archives == INT_MAX)
     {
@@ -5679,8 +5678,7 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 
   LOG_CS_ENTER (thread_p);
 
-  // Removing archive should care copied log for HA as well as PRM_ID_FORCE_REMOVE_LOG_ARCHIVES.
-  if ((ha_mode != HA_MODE_OFF && ha_mode != HA_MODE_REPLICA) || !prm_get_bool_value (PRM_ID_FORCE_REMOVE_LOG_ARCHIVES))
+  if (!prm_get_bool_value (PRM_ID_FORCE_REMOVE_LOG_ARCHIVES))
     {
 #if defined(SERVER_MODE)
       min_copied_pageid = logwr_get_min_copied_fpageid ();


### PR DESCRIPTION
Reverts CUBRID/cubrid#1792

http://jira.cubrid.org/browse/CBRD-23166 is a counter case to this fix.
Since these two are conflicting each other, I don't see a fix for both. 
If a slave lags and master removes logs that it needs, it should be rebuilt.