### PR TITLE
[CBRD-23154] dump resource tracker to error log file

### DIFF
--- a/src/base/resource_tracker.cpp
+++ b/src/base/resource_tracker.cpp
@@ -23,6 +23,8 @@
 
 #include "resource_tracker.hpp"
 
+#include "error_manager.h"
+
 namespace cubbase
 {
   resource_tracker_item::resource_tracker_item (const char *fn_arg, int l_arg, unsigned reuse)
@@ -68,6 +70,12 @@ namespace cubbase
   restrack_is_assert_suppressed (void)
   {
     return Restrack_suppress_assert;
+  }
+
+  void
+  restrack_log (const std::string &str)
+  {
+    _er_log_debug (ARG_FILE_LINE, str.c_str ());
   }
 
 } // namespace cubbase

--- a/src/base/resource_tracker.hpp
+++ b/src/base/resource_tracker.hpp
@@ -64,7 +64,7 @@
 
 #include <map>
 #include <forward_list>
-#include <iostream>
+#include <sstream>
 
 #include <cassert>
 
@@ -168,6 +168,8 @@ namespace cubbase
   bool restrack_is_assert_suppressed (void);
   // check condition to be true; based on assert mode, assert is hit or error is set
   inline void restrack_assert (bool cond);
+
+  void restrack_log (const std::string &str);
 
   //////////////////////////////////////////////////////////////////////////
   // template/inline implementation
@@ -350,7 +352,7 @@ namespace cubbase
   void
   resource_tracker<Res>::dump (void) const
   {
-    std::ostream &out = std::cerr;
+    std::stringstream out;
 
     out << std::endl;
     out << "   +--- " << m_name << std::endl;
@@ -363,6 +365,8 @@ namespace cubbase
 	dump_map (stack_it, out);
 	level++;
       }
+
+    restrack_log (out.str ());
   }
 
   template <typename Res>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23154

Change resource tracker dump output from cerr to error log file. Most our QA scenarios save error log files, but cerr output is lost. Dumping to error log file should help investigating issues.

It is not easy to print std::map in gdb and finding leak source from core file is difficult.

_Note: this does not fix jira issue_