### PR TITLE
[CBRD-23171] Fix wp_er_log_stats dangling pointer issue

### DIFF
--- a/src/thread/thread_worker_pool.cpp
+++ b/src/thread/thread_worker_pool.cpp
@@ -144,7 +144,8 @@ namespace cubthread
 	ss << statsp[index] << std::endl;
       }
 
-    _er_log_debug (ARG_FILE_LINE, ss.str ().c_str ());
+    std::string str = ss.str ();
+    _er_log_debug (ARG_FILE_LINE, str.c_str ());
   }
 
 } // namespace cubthread


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23171

Using stringstream.str ().c_str () is unsafe. Make a string copy and then call c_str ().