### PR TITLE
[CBRD-23175] do not consume if vacuum data was not loaded

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1129,7 +1129,7 @@ vacuum_finalize (THREAD_ENTRY * thread_p)
 
   if (vacuum_Block_data_buffer != NULL)
     {
-      if (vacuum_consume_buffer_log_blocks (thread_p) != NO_ERROR)
+      if (vacuum_Data.is_loaded && vacuum_consume_buffer_log_blocks (thread_p) != NO_ERROR)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  assert (0);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23175

vacuum may be finalized before vacuum data was loaded. check if loaded before trying to consume from block buffer.