### PR TITLE
[CBRD-23172] produce vacuum data block immediately

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5326,7 +5326,6 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   MVCCID mvccid;
   VACUUM_LOG_BLOCKID crt_blockid;
   LOG_LSA mvcc_op_log_lsa = LSA_INITIALIZER;
-  bool is_last_block = false;
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 		 "vacuum_recover_lost_block_data, lsa = %lld|%d, global_oldest_mvccid = %llu",
@@ -5437,6 +5436,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
       LSA_COPY (&mvcc_op_log_lsa, &log_Gl.hdr.mvcc_op_log_lsa);
     }
   assert (!LSA_ISNULL (&mvcc_op_log_lsa));
+  log_Gl.hdr.mvcc_op_log_lsa = mvcc_op_log_lsa;
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 		 "vacuum_recover_lost_block_data, start recovering from %lld|%d ", LSA_AS_ARGS (&mvcc_op_log_lsa));
@@ -5497,13 +5497,12 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	    }
 	  LSA_COPY (&log_lsa, &vacuum_info.prev_mvcc_op_log_lsa);
 	}
-      if (is_last_block)
+
+      if (data.blockid == vacuum_get_log_blockid (log_Gl.prior_info.prior_lsa.pageid))
 	{
-	  /* This block is cached in log_Gl.hdr and will be produced later. */
 	  log_Gl.hdr.last_block_oldest_mvccid = data.oldest_mvccid;
 	  log_Gl.hdr.last_block_newest_mvccid = data.newest_mvccid;
-	  LSA_COPY (&log_Gl.hdr.mvcc_op_log_lsa, &data.start_lsa);
-	  is_last_block = false;
+	  log_Gl.hdr.does_block_need_vacuum = true;
 
 	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 			 "Restore log global cached info: \n\t mvcc_op_log_lsa = %lld|%d \n"

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5442,7 +5442,6 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 		 "vacuum_recover_lost_block_data, start recovering from %lld|%d ", LSA_AS_ARGS (&mvcc_op_log_lsa));
 
   /* Start recovering blocks. */
-  is_last_block = true;
   crt_blockid = vacuum_get_log_blockid (mvcc_op_log_lsa.pageid);
   LSA_COPY (&log_lsa, &mvcc_op_log_lsa);
 

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1335,6 +1335,21 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 
   LSA_COPY (&start_lsa, &node->start_lsa);
 
+  if (log_Gl.hdr.does_block_need_vacuum)
+    {
+      assert (!LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa));
+      if (vacuum_get_log_blockid (log_Gl.hdr.mvcc_op_log_lsa.pageid) != vacuum_get_log_blockid (start_lsa.pageid))
+	{
+	  assert (vacuum_get_log_blockid (log_Gl.hdr.mvcc_op_log_lsa.pageid)
+		  == vacuum_get_log_blockid (start_lsa.pageid) - 1);
+	  vacuum_produce_log_block_data (thread_p, &log_Gl.hdr.mvcc_op_log_lsa, log_Gl.hdr.last_block_oldest_mvccid,
+					 log_Gl.hdr.last_block_newest_mvccid);
+	  log_Gl.hdr.last_block_oldest_mvccid = vacuum_get_global_oldest_active_mvccid ();
+	  log_Gl.hdr.last_block_newest_mvccid = MVCCID_NULL;
+	  log_Gl.hdr.does_block_need_vacuum = false;
+	}
+    }
+
   /* Is this a valid MVCC operations: 1. node must be undoredo/undo type and must have undo data. 2. record index must
    * the index of MVCC operations. */
   if (node->log_header.type == LOG_MVCC_UNDO_DATA || node->log_header.type == LOG_MVCC_UNDOREDO_DATA
@@ -1376,36 +1391,22 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 		     "log mvcc op at (%lld, %d) and create link with log_lsa(%lld, %d)",
 		     LSA_AS_ARGS (&node->start_lsa), LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa));
 
-      /* Check if the block of log data is changed */
-      if (!LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa)
-	  && (vacuum_get_log_blockid (log_Gl.hdr.mvcc_op_log_lsa.pageid) != vacuum_get_log_blockid (start_lsa.pageid)))
+      /* Same block, update the oldest and the newest met MVCCID's */
+      if (log_Gl.hdr.last_block_newest_mvccid == MVCCID_NULL
+	  || MVCC_ID_PRECEDES (log_Gl.hdr.last_block_newest_mvccid, mvccid))
 	{
-	  /* Notify vacuum of a new block */
-	  vacuum_produce_log_block_data (thread_p, &log_Gl.hdr.mvcc_op_log_lsa, log_Gl.hdr.last_block_oldest_mvccid,
-					 log_Gl.hdr.last_block_newest_mvccid);
-	  assert (log_Gl.hdr.last_block_oldest_mvccid <= vacuum_get_global_oldest_active_mvccid ());
-	  log_Gl.hdr.last_block_oldest_mvccid = vacuum_get_global_oldest_active_mvccid ();
+	  /* A newer MVCCID was found */
 	  log_Gl.hdr.last_block_newest_mvccid = mvccid;
-	  assert (!MVCC_ID_PRECEDES (mvccid, log_Gl.hdr.last_block_oldest_mvccid));
 	}
-      else
+      if (log_Gl.hdr.last_block_oldest_mvccid == MVCCID_NULL)
 	{
-	  /* Same block, update the oldest and the newest met MVCCID's */
-	  if (log_Gl.hdr.last_block_newest_mvccid == MVCCID_NULL
-	      || MVCC_ID_PRECEDES (log_Gl.hdr.last_block_newest_mvccid, mvccid))
-	    {
-	      /* A newer MVCCID was found */
-	      log_Gl.hdr.last_block_newest_mvccid = mvccid;
-	    }
-	  if (log_Gl.hdr.last_block_oldest_mvccid == MVCCID_NULL)
-	    {
-	      log_Gl.hdr.last_block_oldest_mvccid = vacuum_get_global_oldest_active_mvccid ();
-	    }
-	  assert (!MVCC_ID_PRECEDES (mvccid, log_Gl.hdr.last_block_oldest_mvccid));
+	  log_Gl.hdr.last_block_oldest_mvccid = vacuum_get_global_oldest_active_mvccid ();
 	}
+      assert (!MVCC_ID_PRECEDES (mvccid, log_Gl.hdr.last_block_oldest_mvccid));
 
       /* Replace last MVCC deleted/updated log record */
       LSA_COPY (&log_Gl.hdr.mvcc_op_log_lsa, &start_lsa);
+      log_Gl.hdr.does_block_need_vacuum = true;
     }
   else if (node->log_header.type == LOG_SYSOP_START_POSTPONE)
     {

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -10740,6 +10740,7 @@ logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HEADER * loghd
   LSA_SET_NULL (&loghdr->mvcc_op_log_lsa);
   loghdr->last_block_oldest_mvccid = MVCCID_NULL;
   loghdr->last_block_newest_mvccid = MVCCID_NULL;
+  loghdr->does_block_need_vacuum = false;
 }
 
 /*

--- a/src/transaction/log_storage.hpp
+++ b/src/transaction/log_storage.hpp
@@ -153,6 +153,7 @@ struct log_header
   INT64 ha_promotion_time;
   INT64 db_restore_time;
   bool mark_will_del;
+  bool does_block_need_vacuum;
 
   log_header ()
     : magic {'0'}
@@ -198,6 +199,7 @@ struct log_header
   , ha_promotion_time (0)
   , db_restore_time (0)
   , mark_will_del (false)
+  , does_block_need_vacuum (false)
   {
     //
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23172

This is a regression of updating vacuum data last blockid when no mvcc ops are executed for a long time.

To fix it, I've done something I wanted to do long ago: produce the vacuum data block when first log record of next block is generated instead of first mvcc log record.

A flag in log header was added to know if current log block needs vacuum. Also updated prior_lsa_next_record_internal and vacuum_recover_lost_block_data.