### PR TITLE
[CBRD-23150] Added classname to scancache

### DIFF
--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -404,6 +404,12 @@ namespace cubload
 	return;
       }
 
+    // Add the classname to the scancache.
+    if (m_class_entry != NULL)
+      {
+	m_scancache.node.classname = m_class_entry->get_class_name ();
+      }
+
     int error_code = locator_multi_insert_force (m_thread_ref, &m_scancache.node.hfid, &m_scancache.node.class_oid,
 		     m_recdes_collected, true, op_type, &m_scancache, &force_count, pruning_type, NULL, NULL,
 		     UPDATE_INPLACE_NONE);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24798,7 +24798,7 @@ heap_rv_postpone_append_pages_to_heap (THREAD_ENTRY * thread_p, LOG_RCV * recv)
   /* recovery data: HFID, OID, array_size (int), array_of_VPID(array_size) */
   HFID_SET_NULL (&hfid);
   OID_SET_NULL (&class_oid);
-  
+
   OR_GET_HFID ((recv->data + offset), &hfid);
   offset += DB_ALIGN (OR_HFID_SIZE, PTR_ALIGNMENT);
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -6742,6 +6742,7 @@ heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_ca
 
   scan_cache->page_latch = S_LOCK;
 
+  scan_cache->node.classname = NULL;
   scan_cache->cache_last_fix_page = cache_last_fix_page;
   PGBUF_INIT_WATCHER (&(scan_cache->page_watcher), PGBUF_ORDERED_HEAP_NORMAL, hfid);
   scan_cache->start_area ();
@@ -6758,6 +6759,7 @@ exit_on_error:
   HFID_SET_NULL (&scan_cache->node.hfid);
   scan_cache->node.hfid.vfid.volid = NULL_VOLID;
   OID_SET_NULL (&scan_cache->node.class_oid);
+  scan_cache->node.classname = NULL;
   scan_cache->page_latch = NULL_LOCK;
   scan_cache->cache_last_fix_page = false;
   PGBUF_INIT_WATCHER (&(scan_cache->page_watcher), PGBUF_ORDERED_RANK_UNDEFINED, PGBUF_ORDERED_NULL_HFID);
@@ -6966,6 +6968,7 @@ heap_scancache_reset_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cach
 	}
     }
   scan_cache->page_latch = X_LOCK;
+  scan_cache->node.classname = NULL;
 
   return ret;
 }
@@ -7040,6 +7043,7 @@ heap_scancache_quick_start_internal (HEAP_SCANCACHE * scan_cache, const HFID * h
       PGBUF_INIT_WATCHER (&(scan_cache->page_watcher), PGBUF_ORDERED_HEAP_NORMAL, hfid);
     }
   OID_SET_NULL (&scan_cache->node.class_oid);
+  scan_cache->node.classname = NULL;
   scan_cache->page_latch = S_LOCK;
   scan_cache->cache_last_fix_page = true;
   scan_cache->start_area ();
@@ -7106,6 +7110,7 @@ heap_scancache_quick_end (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache)
 
   HFID_SET_NULL (&scan_cache->node.hfid);
   scan_cache->node.hfid.vfid.volid = NULL_VOLID;
+  scan_cache->node.classname = NULL;
   OID_SET_NULL (&scan_cache->node.class_oid);
   scan_cache->page_latch = NULL_LOCK;
   assert (PGBUF_IS_CLEAN_WATCHER (&(scan_cache->page_watcher)));

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -125,6 +125,7 @@ struct heap_scancache_node
 {
   HFID hfid;			/* Heap file of scan */
   OID class_oid;		/* Class oid of scanned instances */
+  const char *classname;
 };
 
 typedef struct heap_scancache_node_list HEAP_SCANCACHE_NODE_LIST;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7603,6 +7603,7 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
   bool use_mvcc = false;
   MVCCID mvccid;
   MVCC_REC_HEADER *p_mvcc_rec_header = NULL;
+  bool classname_was_alloced = false;
 
 /* temporary disable standalone optimization (non-mvcc insert/delete style).
  * Must be activated when dynamic heap is introduced */
@@ -7663,13 +7664,14 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
     }
 
 #if defined(ENABLE_SYSTEMTAP)
-  if (classname)
+  if (classname != NULL)
     {
       if (heap_get_class_name (thread_p, class_oid, &classname) != NO_ERROR || classname == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error_code);
 	  goto error;
 	}
+      classname_was_alloced = true;
     }
 
   assert (classname != NULL);
@@ -7921,7 +7923,7 @@ error:
     }
 
 #if defined(ENABLE_SYSTEMTAP)
-  if (classname != NULL)
+  if (classname != NULL && classname_was_alloced)
     {
       free_and_init (classname);
     }

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7664,7 +7664,7 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
     }
 
 #if defined(ENABLE_SYSTEMTAP)
-  if (classname != NULL)
+  if (classname == NULL)
     {
       if (heap_get_class_name (thread_p, class_oid, &classname) != NO_ERROR || classname == NULL)
 	{

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7611,7 +7611,7 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
 /* #endif */
 
 #if defined(ENABLE_SYSTEMTAP)
-  char *classname = NULL;
+  char *classname = scan_cache->node.classname;
 #endif /* ENABLE_SYSTEMTAP */
 
   assert_release (class_oid != NULL);
@@ -7663,11 +7663,16 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
     }
 
 #if defined(ENABLE_SYSTEMTAP)
-  if (heap_get_class_name (thread_p, class_oid, &classname) != NO_ERROR || classname == NULL)
+  if (classname)
     {
-      ASSERT_ERROR_AND_SET (error_code);
-      goto error;
+      if (heap_get_class_name (thread_p, class_oid, &classname) != NO_ERROR || classname == NULL)
+	{
+	  ASSERT_ERROR_AND_SET (error_code);
+	  goto error;
+	}
     }
+
+  assert (classname != NULL);
 #endif /* ENABLE_SYSTEMTAP */
 
   for (i = 0; i < num_btids; i++)

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7612,7 +7612,7 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
 /* #endif */
 
 #if defined(ENABLE_SYSTEMTAP)
-  char *classname = scan_cache->node.classname;
+  const char *classname = scan_cache->node.classname;
 #endif /* ENABLE_SYSTEMTAP */
 
   assert_release (class_oid != NULL);
@@ -7666,11 +7666,14 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
 #if defined(ENABLE_SYSTEMTAP)
   if (classname == NULL)
     {
-      if (heap_get_class_name (thread_p, class_oid, &classname) != NO_ERROR || classname == NULL)
+      char *heap_class_name = NULL;
+      if (heap_get_class_name (thread_p, class_oid, &heap_class_name) != NO_ERROR || heap_class_name == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error_code);
 	  goto error;
 	}
+
+      classname = heap_class_name;
       classname_was_alloced = true;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23150

Added the `classname` to `scancache` so that `locator_add_or_remove_index_internal` will not try to get the classname if the `scancache` already has it. This fixes some performance penalties for indexes during loading.