### PR TITLE
[CBRD-23170] Log entire heap page

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -22193,6 +22193,7 @@ heap_create_insert_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID
   context->recdes_p = recdes_p;
   context->scan_cache_p = scancache_p;
   context->type = HEAP_OPERATION_INSERT;
+  context->skip_logging = false;
 }
 
 /*
@@ -22217,6 +22218,7 @@ heap_create_delete_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID
   COPY_OID (&context->class_oid, class_oid_p);
   context->scan_cache_p = scancache_p;
   context->type = HEAP_OPERATION_DELETE;
+  context->skip_logging = false;
 }
 
 /*
@@ -22246,6 +22248,7 @@ heap_create_update_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID
   context->scan_cache_p = scancache_p;
   context->type = HEAP_OPERATION_UPDATE;
   context->update_in_place = in_place;
+  context->skip_logging = false;
 }
 
 /*
@@ -22374,8 +22377,11 @@ heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, 
   /*
    * Operation logging
    */
-  heap_log_insert_physical (thread_p, context->home_page_watcher_p->pgptr, &context->hfid.vfid, &context->res_oid,
-			    context->recdes_p, is_mvcc_op, context->is_redistribute_insert_with_delid);
+  if (!context->skip_logging)
+    {
+      heap_log_insert_physical (thread_p, context->home_page_watcher_p->pgptr, &context->hfid.vfid, &context->res_oid,
+				context->recdes_p, is_mvcc_op, context->is_redistribute_insert_with_delid);
+    }
 
   HEAP_PERF_TRACK_LOGGING (thread_p, context);
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -22193,7 +22193,7 @@ heap_create_insert_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID
   context->recdes_p = recdes_p;
   context->scan_cache_p = scancache_p;
   context->type = HEAP_OPERATION_INSERT;
-  context->skip_logging = false;
+  context->use_bulk_logging = false;
 }
 
 /*
@@ -22218,7 +22218,7 @@ heap_create_delete_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID
   COPY_OID (&context->class_oid, class_oid_p);
   context->scan_cache_p = scancache_p;
   context->type = HEAP_OPERATION_DELETE;
-  context->skip_logging = false;
+  context->use_bulk_logging = false;
 }
 
 /*
@@ -22248,7 +22248,7 @@ heap_create_update_context (HEAP_OPERATION_CONTEXT * context, HFID * hfid_p, OID
   context->scan_cache_p = scancache_p;
   context->type = HEAP_OPERATION_UPDATE;
   context->update_in_place = in_place;
-  context->skip_logging = false;
+  context->use_bulk_logging = false;
 }
 
 /*
@@ -22377,7 +22377,7 @@ heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, 
   /*
    * Operation logging
    */
-  if (!context->skip_logging)
+  if (!context->use_bulk_logging)
     {
       heap_log_insert_physical (thread_p, context->home_page_watcher_p->pgptr, &context->hfid.vfid, &context->res_oid,
 				context->recdes_p, is_mvcc_op, context->is_redistribute_insert_with_delid);

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -313,6 +313,10 @@ struct heap_operation_context
 
   /* Performance stat dump. */
   PERF_UTIME_TRACKER *time_track;
+
+  /* skip logging */
+  bool skip_logging;
+
 };
 
 enum

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -309,8 +309,9 @@ struct heap_operation_context
   bool is_redistribute_insert_with_delid;	/* true if the insert is due to a partition redistribute data operation
 						 * and has a valid delid */
   bool is_bulk_op;		// note - currently for insert only
-  bool use_bulk_logging;	// note - currently for bulk insert only
   // side-effect - disables MVCC operations
+
+  bool use_bulk_logging;	// note - currently for bulk insert only
 
   /* Performance stat dump. */
   PERF_UTIME_TRACKER *time_track;

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -309,14 +309,11 @@ struct heap_operation_context
   bool is_redistribute_insert_with_delid;	/* true if the insert is due to a partition redistribute data operation
 						 * and has a valid delid */
   bool is_bulk_op;		// note - currently for insert only
+  bool use_bulk_logging;	// note - currently for bulk insert only
   // side-effect - disables MVCC operations
 
   /* Performance stat dump. */
   PERF_UTIME_TRACKER *time_track;
-
-  /* skip logging */
-  bool skip_logging;
-
 };
 
 enum

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -13733,6 +13733,17 @@ pgbuf_log_new_page (THREAD_ENTRY * thread_p, PAGE_PTR page_new, int data_size, P
   pgbuf_set_dirty (thread_p, page_new, DONT_FREE);
 }
 
+void
+pgbuf_log_redo_new_page (THREAD_ENTRY * thread_p, PAGE_PTR page_new, int data_size, PAGE_TYPE ptype_new)
+{
+  assert (ptype_new != PAGE_UNKNOWN);
+  assert (page_new != NULL);
+  assert (data_size > 0);
+
+  log_append_redo_data2 (thread_p, RVPGBUF_NEW_PAGE, NULL, page_new, (PGLENGTH) ptype_new, data_size, page_new);
+  pgbuf_set_dirty (thread_p, page_new, DONT_FREE);
+}
+
 /*
  * log_redo_page () - Apply redo for changing entire page (or at least its first part).
  *

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -419,6 +419,7 @@ extern int pgbuf_get_hold_count (THREAD_ENTRY * thread_p);
 extern PERF_PAGE_TYPE pgbuf_get_page_type_for_stat (THREAD_ENTRY * thread_p, PAGE_PTR pgptr);
 
 extern void pgbuf_log_new_page (THREAD_ENTRY * thread_p, PAGE_PTR page_new, int data_size, PAGE_TYPE ptype_new);
+extern void pgbuf_log_redo_new_page (THREAD_ENTRY * thread_p, PAGE_PTR page_new, int data_size, PAGE_TYPE ptype_new);
 extern int pgbuf_rv_new_page_redo (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int pgbuf_rv_new_page_undo (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern void pgbuf_dealloc_page (THREAD_ENTRY * thread_p, PAGE_PTR page_dealloc);

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4964,7 +4964,7 @@ locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 
   /* TODO: Fix this!! */
   /* This is a hack for now. We skipp logging if we have multi insert enabled and we insert in a preallocated page. */
-  context.skip_logging = (has_BU_lock && scan_cache->cache_last_fix_page);
+  context.use_bulk_logging = (has_BU_lock && scan_cache->cache_last_fix_page);
 
   if (force_in_place == UPDATE_INPLACE_OLD_MVCCID)
     {

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4963,8 +4963,8 @@ locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
   context.is_bulk_op = has_BU_lock;
 
   /* TODO: Fix this!! */
-  /* This is a hack for now. We skipp logging if we have multi insert enabled. */
-  context.skip_logging = has_BU_lock;
+  /* This is a hack for now. We skipp logging if we have multi insert enabled and we insert in a preallocated page. */
+  context.skip_logging = (has_BU_lock && scan_cache->cache_last_fix_page);
 
   if (force_in_place == UPDATE_INPLACE_OLD_MVCCID)
     {

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13801,8 +13801,8 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 
 		  pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &home_hint_p);
 
-                  // Now log the whole page.
-                  pgbuf_log_redo_new_page (thread_p, home_hint_p.pgptr, DB_PAGESIZE, PAGE_HEAP);
+		  // Now log the whole page.
+		  pgbuf_log_redo_new_page (thread_p, home_hint_p.pgptr, DB_PAGESIZE, PAGE_HEAP);
 		}
 
 	      // Add the new VPID to the VPID array.

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13803,13 +13803,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 		  pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &home_hint_p);
 
                   // Now log the whole page.
-                  LOG_DATA_ADDR log_addr = LOG_DATA_ADDR_INITIALIZER;
-
-                  /* log the whole page for redo purposes. */
-                  log_addr.vfid = &hfid->vfid;
-                  log_addr.pgptr = home_hint_p.pgptr;
-                  log_addr.offset = -1;		/* irrelevant */
-                  log_append_redo_data (thread_p, RVBT_COPYPAGE, &log_addr, DB_PAGESIZE, home_hint_p.pgptr);
+                  pgbuf_log_new_page (thread_p, home_hint_p.pgptr, DB_PAGESIZE, PAGE_HEAP);
 		}
 
 	      // Add the new VPID to the VPID array.

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13802,7 +13802,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 		  pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &home_hint_p);
 
                   // Now log the whole page.
-                  pgbuf_log_new_page (thread_p, home_hint_p.pgptr, DB_PAGESIZE, PAGE_HEAP);
+                  pgbuf_log_redo_new_page (thread_p, home_hint_p.pgptr, DB_PAGESIZE, PAGE_HEAP);
 		}
 
 	      // Add the new VPID to the VPID array.

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -152,7 +152,8 @@ static void locator_repl_add_error_to_copyarea (LC_COPYAREA ** copy_area, RECDES
 static int locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID * oid, RECDES * recdes,
 				 int has_index, int op_type, HEAP_SCANCACHE * scan_cache, int *force_count,
 				 int pruning_type, PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
-				 UPDATE_INPLACE_STYLE force_in_place, PGBUF_WATCHER * home_hint_p, bool has_BU_lock);
+				 UPDATE_INPLACE_STYLE force_in_place, PGBUF_WATCHER * home_hint_p, bool has_BU_lock,
+				 bool use_bulk_logging = false);
 static int locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID * oid, RECDES * ikdrecdes,
 				 RECDES * recdes, int has_index, ATTR_ID * att_id, int n_att_id, int op_type,
 				 HEAP_SCANCACHE * scan_cache, int *force_count, bool not_check_fk,
@@ -4852,7 +4853,8 @@ static int
 locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID * oid, RECDES * recdes, int has_index,
 		      int op_type, HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type,
 		      PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
-		      UPDATE_INPLACE_STYLE force_in_place, PGBUF_WATCHER * home_hint_p, bool has_BU_lock)
+		      UPDATE_INPLACE_STYLE force_in_place, PGBUF_WATCHER * home_hint_p, bool has_BU_lock,
+		      bool use_bulk_logging)
 {
 #if 0				/* TODO - dead code; do not delete me */
   OID rep_dir = { NULL_PAGEID, NULL_SLOTID, NULL_VOLID };
@@ -4961,10 +4963,7 @@ locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
   heap_create_insert_context (&context, &real_hfid, &real_class_oid, recdes, local_scan_cache);
   context.update_in_place = force_in_place;
   context.is_bulk_op = has_BU_lock;
-
-  /* TODO: Fix this!! */
-  /* This is a hack for now. We skipp logging if we have multi insert enabled and we insert in a preallocated page. */
-  context.use_bulk_logging = (has_BU_lock && scan_cache->cache_last_fix_page);
+  context.use_bulk_logging = use_bulk_logging;
 
   if (force_in_place == UPDATE_INPLACE_OLD_MVCCID)
     {
@@ -13760,7 +13759,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 	  // We insert other records normally.
 	  error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, &local_record, has_index,
 					     op_type, scan_cache, force_count, pruning_type, pcontext, func_preds,
-					     force_in_place, NULL, has_BU_lock);
+					     force_in_place, NULL, has_BU_lock, false);
 	  if (error_code != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
@@ -13790,7 +13789,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 		{
 		  error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, &recdes_array[j], has_index,
 						     op_type, scan_cache, force_count, pruning_type, pcontext,
-						     func_preds, force_in_place, &home_hint_p, has_BU_lock);
+						     func_preds, force_in_place, &home_hint_p, has_BU_lock, true);
 		  if (error_code != NO_ERROR)
 		    {
 		      pgbuf_ordered_unfix_and_init (thread_p, home_hint_p.pgptr, &home_hint_p);
@@ -13832,7 +13831,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
       scan_cache->cache_last_fix_page = false;
       error_code = locator_insert_force (thread_p, hfid, class_oid, &dummy_oid, &recdes_array[i], has_index, op_type,
 					 scan_cache, force_count, pruning_type, pcontext, func_preds, force_in_place,
-					 NULL, has_BU_lock);
+					 NULL, has_BU_lock, false);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23170

This minimizes the logging required for the loading of the data. Since we are the only ones accessing the pages that we are inserting into, we can just log the entire page instead of every record inserted into this page. For now, I have added some sort of a "hack-ish" method to check if the insert has to log the heap operation by checking if we have `BU_LOCK` and if we cache the fixed page; this is only happening for multi insert operation, for now, but it should be addressed.