### PR TITLE
[CBRD-23152] Overload Callable tasks constructor for move-only F

### DIFF
--- a/src/thread/thread_task.hpp
+++ b/src/thread/thread_task.hpp
@@ -90,11 +90,15 @@ namespace cubthread
 
       // constructor with default retire (delete/do nothing)
       template <typename F>
-      callable_task (F f, bool delete_on_retire = true);
+      callable_task (const F &f, bool delete_on_retire = true);
+      template <typename F>
+      callable_task (F &&f, bool delete_on_retire = true);
 
       // constructor with custom retire
       template <typename FuncExec, typename FuncRetire>
-      callable_task (FuncExec fe, FuncRetire fr);
+      callable_task (const FuncExec &fe, const FuncRetire &fr);
+      template <typename FuncExec, typename FuncRetire>
+      callable_task (FuncExec &&fe, FuncRetire &&fr);
 
       void execute (Context &ctx) final
       {
@@ -136,11 +140,15 @@ namespace cubthread
 
       // constructor with default retire (delete/do nothing)
       template <typename F>
-      callable_task (F f, bool delete_on_retire = true);
+      callable_task (const F &f, bool delete_on_retire = true);
+      template <typename F>
+      callable_task (F &&f, bool delete_on_retire = true);
 
       // constructor with custom retire
       template <typename FuncExec, typename FuncRetire>
-      callable_task (FuncExec fe, FuncRetire fr);
+      callable_task (const FuncExec &fe, const FuncRetire &fr);
+      template <typename FuncExec, typename FuncRetire>
+      callable_task (FuncExec &&fe, FuncRetire &&fr);
 
       void execute () final
       {
@@ -223,7 +231,7 @@ namespace cubthread
 {
   template<typename Context>
   template<typename F>
-  callable_task<Context>::callable_task (F f, bool delete_on_retire)
+  callable_task<Context>::callable_task (const F &f, bool delete_on_retire)
     : m_exec_f (f)
   {
     if (delete_on_retire)
@@ -237,15 +245,38 @@ namespace cubthread
   }
 
   template<typename Context>
+  template<typename F>
+  callable_task<Context>::callable_task (F &&f, bool delete_on_retire)
+    : m_exec_f (std::move (f))
+  {
+    if (delete_on_retire)
+      {
+	m_retire_f = [this] { delete this; };
+      }
+    else
+      {
+	m_retire_f = [] {};  // do nothing
+      }
+  }
+
+  template<typename Context>
   template<typename FuncExec, typename FuncRetire>
-  callable_task<Context>::callable_task (FuncExec fe, FuncRetire fr)
+  callable_task<Context>::callable_task (const FuncExec &fe, const FuncRetire &fr)
     : m_exec_f (fe)
     , m_retire_f (fr)
   {
   }
 
+  template<typename Context>
+  template<typename FuncExec, typename FuncRetire>
+  callable_task<Context>::callable_task (FuncExec &&fe, FuncRetire &&fr)
+    : m_exec_f (std::move (fe))
+    , m_retire_f (std::move (fr))
+  {
+  }
+
   template<typename F>
-  callable_task<void>::callable_task (F f, bool delete_on_retire)
+  callable_task<void>::callable_task (const F &f, bool delete_on_retire)
     : m_exec_f (f)
   {
     if (delete_on_retire)
@@ -258,10 +289,31 @@ namespace cubthread
       }
   }
 
+  template<typename F>
+  callable_task<void>::callable_task (F &&f, bool delete_on_retire)
+    : m_exec_f (std::move (f))
+  {
+    if (delete_on_retire)
+      {
+	m_retire_f = [this] { delete this; };
+      }
+    else
+      {
+	m_retire_f = [] {};  // do nothing
+      }
+  }
+
   template<typename FuncExec, typename FuncRetire>
-  callable_task<void>::callable_task (FuncExec fe, FuncRetire fr)
+  callable_task<void>::callable_task (const FuncExec &fe, const FuncRetire &fr)
     : m_exec_f (fe)
     , m_retire_f (fr)
+  {
+  }
+
+  template<typename FuncExec, typename FuncRetire>
+  callable_task<void>::callable_task (FuncExec &&fe, FuncRetire &&fr)
+    : m_exec_f (std::move (fe))
+    , m_retire_f (std::move (fr))
   {
   }
 } // namespace cubthread


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23152

Allow callable tasks to be created with move-only F. E.g move-only standard structs: unique_lock, unique_ptr, future, thread.