### PR TITLE
[CBRD-22755] extend log postpone cache to all transactions

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -88,7 +88,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/condition_handler.c
   ${BASE_DIR}/databases_file.c
   ${BASE_DIR}/dtoa.c
-  ${BASE_DIR}/dynamic_array.c	
+  ${BASE_DIR}/dynamic_array.c
   ${BASE_DIR}/encryption.c
   ${BASE_DIR}/environment_variable.c
   ${BASE_DIR}/error_context.cpp
@@ -260,12 +260,12 @@ set(OBJECT_SOURCES
 set(OBJECT_HEADERS
   ${OBJECT_DIR}/lob_locator.hpp
 )
-  
+
 set(REPLICATION_SOURCES
   ${REPLICATION_DIR}/log_consumer.cpp
   ${REPLICATION_DIR}/log_generator.cpp
   ${REPLICATION_DIR}/replication_object.cpp
-  ${REPLICATION_DIR}/replication_master_senders_manager.cpp  
+  ${REPLICATION_DIR}/replication_master_senders_manager.cpp
   ${REPLICATION_DIR}/replication_stream_entry.cpp
   )
 
@@ -288,6 +288,7 @@ set(TRANSACTION_SOURCES
   ${TRANSACTION_DIR}/log_lsa.cpp
   ${TRANSACTION_DIR}/log_manager.c
   ${TRANSACTION_DIR}/log_page_buffer.c
+  ${TRANSACTION_DIR}/log_postpone_cache.cpp
   ${TRANSACTION_DIR}/log_recovery.c
   ${TRANSACTION_DIR}/log_system_tran.cpp
   ${TRANSACTION_DIR}/log_tran_table.c
@@ -308,6 +309,7 @@ set(TRANSACTION_HEADERS
   ${TRANSACTION_DIR}/log_archives.hpp
   ${TRANSACTION_DIR}/log_common_impl.h
   ${TRANSACTION_DIR}/log_lsa.hpp
+  ${TRANSACTION_DIR}/log_postpone_cache.hpp
   ${TRANSACTION_DIR}/log_record.hpp
   ${TRANSACTION_DIR}/log_storage.hpp
   ${TRANSACTION_DIR}/log_system_tran.hpp
@@ -436,7 +438,7 @@ set (CUBRID_LIB_SOURCES
   ${OBJECT_SOURCES}
   ${PROBES_OBJECT}
   ${QUERY_SOURCES}
-  ${REPLICATION_SOURCES}  
+  ${REPLICATION_SOURCES}
   ${SESSION_SOURCES}
   ${STORAGE_SOURCES}
   ${STREAM_SOURCES}
@@ -501,7 +503,7 @@ if(AT_LEAST_ONE_UNIT_TEST)
     ${CUBRID_LIB_HEADERS}
     )
 
-  target_compile_definitions(cubrid-win-lib PRIVATE 
+  target_compile_definitions(cubrid-win-lib PRIVATE
     SERVER_MODE
     ${COMMON_DEFS}
     )
@@ -535,7 +537,7 @@ install(TARGETS cubrid
 
 install(FILES
   ${COMPAT_DIR}/dbi_compat.h
-  DESTINATION ${CUBRID_INCLUDEDIR} COMPONENT Header  
+  DESTINATION ${CUBRID_INCLUDEDIR} COMPONENT Header
   RENAME dbi.h
   )
 install(FILES
@@ -545,12 +547,12 @@ install(FILES
   ${COMPAT_DIR}/db_date.h
   ${COMPAT_DIR}/db_elo.h
   ${COMPAT_DIR}/cache_time.h
-  DESTINATION ${CUBRID_INCLUDEDIR} COMPONENT Header  
+  DESTINATION ${CUBRID_INCLUDEDIR} COMPONENT Header
   )
 install(FILES
   ${BASE_DIR}/error_code.h
-  DESTINATION ${CUBRID_INCLUDEDIR} COMPONENT Header  
-  )  
+  DESTINATION ${CUBRID_INCLUDEDIR} COMPONENT Header
+  )
 
 # install pdb files for debugging on windows
 if(WIN32)

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -26,7 +26,7 @@ set(EXECUTABLE_SOURCES
   ${EXECUTABLES_DIR}/csql_result.c
   ${EXECUTABLES_DIR}/csql_support.c
   ${EXECUTABLES_DIR}/csql_result_format.c
-  ${EXECUTABLES_DIR}/extract_schema.cpp  
+  ${EXECUTABLES_DIR}/extract_schema.cpp
   ${EXECUTABLES_DIR}/util_sa.c
   ${EXECUTABLES_DIR}/util_cs.c
   ${EXECUTABLES_DIR}/util_common.c
@@ -291,7 +291,7 @@ set(REPLICATION_SOURCES
   ${REPLICATION_DIR}/log_consumer.cpp
   ${REPLICATION_DIR}/log_generator.cpp
   ${REPLICATION_DIR}/replication_object.cpp
-  ${REPLICATION_DIR}/replication_master_senders_manager.cpp  
+  ${REPLICATION_DIR}/replication_master_senders_manager.cpp
   ${REPLICATION_DIR}/replication_stream_entry.cpp
   )
 
@@ -344,6 +344,7 @@ set(TRANSACTION_SOURCES
   ${TRANSACTION_DIR}/log_lsa.cpp
   ${TRANSACTION_DIR}/log_manager.c
   ${TRANSACTION_DIR}/log_page_buffer.c
+  ${TRANSACTION_DIR}/log_postpone_cache.cpp
   ${TRANSACTION_DIR}/log_recovery.c
   ${TRANSACTION_DIR}/log_system_tran.cpp
   ${TRANSACTION_DIR}/log_tran_table.c
@@ -365,6 +366,7 @@ set(TRANSACTION_HEADERS
   ${TRANSACTION_DIR}/log_archives.hpp
   ${TRANSACTION_DIR}/log_common_impl.h
   ${TRANSACTION_DIR}/log_lsa.hpp
+  ${TRANSACTION_DIR}/log_postpone_cache.hpp
   ${TRANSACTION_DIR}/log_record.hpp
   ${TRANSACTION_DIR}/log_storage.hpp
   ${TRANSACTION_DIR}/log_system_tran.hpp
@@ -498,7 +500,7 @@ SET_SOURCE_FILES_PROPERTIES(
   ${QUERY_SOURCES}
   ${OBJECT_SOURCES}
   ${REPLICATION_SOURCES}
-  ${STREAM_SOURCES}  
+  ${STREAM_SOURCES}
   ${JSP_SOURCES}
   ${THREAD_SOURCES}
   ${TRANSACTION_SOURCES}
@@ -548,7 +550,7 @@ add_library(cubridsa SHARED
   ${PROBES_OBJECT}
   ${REPLICATION_HEADERS}
   ${REPLICATION_SOURCES}
-  ${STREAM_HEADERS}  
+  ${STREAM_HEADERS}
   ${STREAM_SOURCES}
   ${THREAD_SOURCES}
   ${TRANSACTION_HEADERS}

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -943,10 +943,6 @@ vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npages, VFID * 
   vacuum_Master.prefetch_log_buffer = NULL;
   vacuum_Master.prefetch_first_pageid = NULL_PAGEID;
   vacuum_Master.prefetch_last_pageid = NULL_PAGEID;
-  vacuum_Master.postpone_cache_status = VACUUM_CACHE_POSTPONE_NO;
-  vacuum_Master.postpone_redo_data_ptr = NULL;
-  vacuum_Master.postpone_redo_data_buffer = NULL;
-  vacuum_Master.postpone_cached_entries_count = 0;
   vacuum_Master.allocated_resources = false;
 
   /* Initialize workers */
@@ -963,19 +959,7 @@ vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npages, VFID * 
       vacuum_Workers[i].prefetch_log_buffer = NULL;
       vacuum_Workers[i].prefetch_first_pageid = NULL_PAGEID;
       vacuum_Workers[i].prefetch_last_pageid = NULL_PAGEID;
-      vacuum_Workers[i].postpone_cache_status = VACUUM_CACHE_POSTPONE_NO;
-      vacuum_Workers[i].postpone_redo_data_ptr = NULL;
-      vacuum_Workers[i].postpone_redo_data_buffer = NULL;
-      vacuum_Workers[i].postpone_cached_entries_count = 0;
       vacuum_Workers[i].allocated_resources = false;
-    }
-
-  vacuum_Master.postpone_redo_data_buffer = (char *) malloc (IO_PAGESIZE);
-  if (vacuum_Master.postpone_redo_data_buffer == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, IO_PAGESIZE);
-      error_code = ER_OUT_OF_VIRTUAL_MEMORY;
-      goto error;
     }
 
   vacuum_Global_oldest_active_blockers_counter = 0;
@@ -3454,14 +3438,6 @@ vacuum_worker_allocate_resources (THREAD_ENTRY * thread_p, VACUUM_WORKER * worke
     }
   worker->undo_data_buffer_capacity = IO_PAGESIZE;
 
-  worker->postpone_redo_data_buffer = (char *) malloc (IO_PAGESIZE);
-  if (worker->postpone_redo_data_buffer == NULL)
-    {
-      vacuum_er_log_error (VACUUM_ER_LOG_WORKER, "%s", "Could not allocate postpone_redo_data_buffer.");
-      logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "vacuum_worker_allocate_resources");
-      goto error;
-    }
-
   size_worker_prefetch_log_buffer = VACUUM_PREFETCH_LOG_BLOCK_BUFFER_PAGES * LOG_PAGESIZE;
   worker->prefetch_log_buffer = (char *) malloc (size_worker_prefetch_log_buffer);
   if (worker->prefetch_log_buffer == NULL)
@@ -3506,10 +3482,9 @@ vacuum_finalize_worker (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker_info)
     {
       free_and_init (worker_info->undo_data_buffer);
     }
-  if (worker_info->postpone_redo_data_buffer != NULL)
-    {
-      free_and_init (worker_info->postpone_redo_data_buffer);
-    }
+
+  worker_info->m_log_postpone_cache.clear ();
+
   if (worker_info->prefetch_log_buffer != NULL)
     {
       free_and_init (worker_info->prefetch_log_buffer);
@@ -7465,198 +7440,6 @@ vacuum_rv_redo_vacuum_heap_record (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   pgbuf_set_dirty (thread_p, rcv->pgptr, DONT_FREE);
 
   return NO_ERROR;
-}
-
-/*
- * vacuum_cache_log_postpone_redo_data () - Cache redo data for log postpone of vacuum operation.
- *
- * return		: Void.
- * thread_p (in)	: Thread entry.
- * data_header (in)	: Recovery data header (LOG_REC_REDO).
- * rcv_data (in)	: Recovery redo data.
- * rcv_data_length (in) : Recovery data size.
- */
-void
-vacuum_cache_log_postpone_redo_data (THREAD_ENTRY * thread_p, char *data_header, char *rcv_data, int rcv_data_length)
-{
-#if defined (SERVER_MODE)
-  VACUUM_WORKER *worker = vacuum_get_vacuum_worker (thread_p);
-  VACUUM_CACHE_POSTPONE_ENTRY *new_entry = NULL;
-  int total_data_size = 0;
-
-  assert (worker != NULL);
-  assert (data_header != NULL);
-  assert (rcv_data_length == 0 || rcv_data != NULL);
-
-  if (worker->postpone_cache_status == VACUUM_CACHE_POSTPONE_OVERFLOW)
-    {
-      /* Cannot cache postpones. */
-      return;
-    }
-
-  if (worker->postpone_cache_status == VACUUM_CACHE_POSTPONE_NO)
-    {
-      /* Initialize data to cache postpones. */
-      worker->postpone_cached_entries_count = 0;
-      worker->postpone_redo_data_ptr = worker->postpone_redo_data_buffer;
-      worker->postpone_cache_status = VACUUM_CACHE_POSTPONE_YES;
-    }
-
-  assert (worker->postpone_cached_entries_count <= VACUUM_CACHE_POSTPONE_ENTRIES_MAX_COUNT);
-  assert (worker->postpone_redo_data_ptr != NULL);
-  assert (worker->postpone_redo_data_ptr >= worker->postpone_redo_data_buffer);
-  assert (CAST_BUFLEN (worker->postpone_redo_data_ptr - worker->postpone_redo_data_buffer) <= IO_PAGESIZE);
-  ASSERT_ALIGN (worker->postpone_redo_data_ptr, MAX_ALIGNMENT);
-
-  if (worker->postpone_cached_entries_count == VACUUM_CACHE_POSTPONE_ENTRIES_MAX_COUNT)
-    {
-      /* Could not store all postpone records. */
-      worker->postpone_cache_status = VACUUM_CACHE_POSTPONE_OVERFLOW;
-      return;
-    }
-
-  /* Check if recovery data fits in preallocated buffer. */
-  total_data_size = CAST_BUFLEN (worker->postpone_redo_data_ptr - worker->postpone_redo_data_buffer);
-  total_data_size += sizeof (LOG_REC_REDO);
-  total_data_size += rcv_data_length;
-  total_data_size += 2 * MAX_ALIGNMENT;
-  if (total_data_size > IO_PAGESIZE)
-    {
-      /* Cannot store all recovery data. */
-      worker->postpone_cache_status = VACUUM_CACHE_POSTPONE_OVERFLOW;
-      return;
-    }
-
-  /* Cache a new postpone log record entry. */
-  new_entry = &worker->postpone_cached_entries[worker->postpone_cached_entries_count];
-  new_entry->redo_data = worker->postpone_redo_data_ptr;
-
-  /* Cache LOG_REC_REDO from data_header */
-  memcpy (worker->postpone_redo_data_ptr, data_header, sizeof (LOG_REC_REDO));
-  worker->postpone_redo_data_ptr += sizeof (LOG_REC_REDO);
-  worker->postpone_redo_data_ptr = PTR_ALIGN (worker->postpone_redo_data_ptr, MAX_ALIGNMENT);
-
-  /* Cache recovery data. */
-  assert (((LOG_REC_REDO *) data_header)->length == rcv_data_length);
-  if (rcv_data_length > 0)
-    {
-      memcpy (worker->postpone_redo_data_ptr, rcv_data, rcv_data_length);
-      worker->postpone_redo_data_ptr += rcv_data_length;
-      worker->postpone_redo_data_ptr = PTR_ALIGN (worker->postpone_redo_data_ptr, MAX_ALIGNMENT);
-    }
-
-  /* LSA will be saved later. */
-  LSA_SET_NULL (&new_entry->lsa);
-#endif /* SERVER_MODE */
-}
-
-/*
- * vacuum_cache_log_postpone_lsa () - Save LSA of postpone operations.
- *
- * return	 : Void.
- * thread_p (in) : Thread entry.
- * lsa (in)	 : Log postpone LSA.
- *
- * NOTE: This saves LSA after a new entry and its redo data have already been
- *	 added. They couldn't both be added in the same step.
- */
-void
-vacuum_cache_log_postpone_lsa (THREAD_ENTRY * thread_p, LOG_LSA * lsa)
-{
-#if defined (SERVER_MODE)
-  VACUUM_WORKER *worker = vacuum_get_vacuum_worker (thread_p);
-  VACUUM_CACHE_POSTPONE_ENTRY *new_entry = NULL;
-
-  assert (lsa != NULL && !LSA_ISNULL (lsa));
-  assert (worker != NULL);
-  assert (worker->postpone_cache_status != VACUUM_CACHE_POSTPONE_NO);
-
-  if (worker->postpone_cache_status == VACUUM_CACHE_POSTPONE_OVERFLOW)
-    {
-      return;
-    }
-  assert (worker->postpone_cached_entries_count >= 0);
-  assert (worker->postpone_cached_entries_count < VACUUM_CACHE_POSTPONE_ENTRIES_MAX_COUNT);
-  new_entry = &worker->postpone_cached_entries[worker->postpone_cached_entries_count];
-  LSA_COPY (&new_entry->lsa, lsa);
-
-  /* Now that all needed data is saved, increment cached entries counter. */
-  worker->postpone_cached_entries_count++;
-#endif /* SERVER_MODE */
-}
-
-/*
- * vacuum_do_postpone_from_cache () - Do postpone from vacuum worker's cached postpone entries.
- *
- * return		   : True if postpone was run from cached entries, false otherwise.
- * thread_p (in)	   : Thread entry.
- * start_postpone_lsa (in) : Start postpone LSA.
- */
-bool
-vacuum_do_postpone_from_cache (THREAD_ENTRY * thread_p, LOG_LSA * start_postpone_lsa)
-{
-#if defined (SERVER_MODE)
-  VACUUM_WORKER *worker = vacuum_get_vacuum_worker (thread_p);
-  VACUUM_CACHE_POSTPONE_ENTRY *entry = NULL;
-  LOG_REC_REDO *redo = NULL;
-  char *rcv_data = NULL;
-  int i;
-  int start_index = -1;
-
-  assert (start_postpone_lsa != NULL && !LSA_ISNULL (start_postpone_lsa));
-  assert (worker != NULL);
-  assert (worker->postpone_cache_status != VACUUM_CACHE_POSTPONE_NO);
-
-  if (worker->postpone_cache_status == VACUUM_CACHE_POSTPONE_OVERFLOW)
-    {
-      /* Cache is not usable. */
-      worker->postpone_cache_status = VACUUM_CACHE_POSTPONE_NO;
-      return false;
-    }
-  /* First cached postpone entry at start_postpone_lsa. */
-  for (i = 0; i < worker->postpone_cached_entries_count; i++)
-    {
-      entry = &worker->postpone_cached_entries[i];
-      if (LSA_EQ (&entry->lsa, start_postpone_lsa))
-	{
-	  /* Found start lsa. */
-	  start_index = i;
-	  break;
-	}
-    }
-  if (start_index < 0)
-    {
-      /* Start LSA was not found. Unexpected situation. */
-      assert (false);
-      return false;
-    }
-
-  /* Run all postpones after start_index. */
-  for (i = start_index; i < worker->postpone_cached_entries_count; i++)
-    {
-      entry = &worker->postpone_cached_entries[i];
-      /* Get redo data header. */
-      redo = (LOG_REC_REDO *) entry->redo_data;
-      /* Get recovery data. */
-      rcv_data = entry->redo_data + sizeof (LOG_REC_REDO);
-      rcv_data = PTR_ALIGN (rcv_data, MAX_ALIGNMENT);
-      (void) log_execute_run_postpone (thread_p, &entry->lsa, redo, rcv_data);
-    }
-  /* Finished running postpones. */
-  if (start_index == 0)
-    {
-      /* All postpone entries were run. */
-      worker->postpone_cache_status = VACUUM_CACHE_POSTPONE_NO;
-    }
-  else
-    {
-      /* Only some postpone entries were run. Update the number of entries which should be run on next commit. */
-      worker->postpone_cached_entries_count = start_index;
-    }
-  return true;
-#else /* !SERVER_MODE */
-  return false;
-#endif /* !SERVER_MODE */
 }
 
 /*

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3482,9 +3482,6 @@ vacuum_finalize_worker (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker_info)
     {
       free_and_init (worker_info->undo_data_buffer);
     }
-
-  worker_info->m_log_postpone_cache.clear ();
-
   if (worker_info->prefetch_log_buffer != NULL)
     {
       free_and_init (worker_info->prefetch_log_buffer);

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -32,8 +32,9 @@
 #include "disk_manager.h"
 #include "log_impl.h"
 #include "log_lsa.hpp"
-#include "recovery.h"
+#include "log_postpone_cache.hpp"
 #include "porting_inline.hpp"
+#include "recovery.h"
 #include "storage_common.h"
 #include "system_parameter.h"
 #include "thread_entry.hpp"
@@ -137,13 +138,7 @@ struct vacuum_worker
   // page buffer private lru list
   int private_lru_index;
 
-  /* Caches postpones to avoid reading them from log after commit top operation with postpone. Otherwise, log critical
-   * section may be required which will slow the access on merged index nodes. */
-  VACUUM_CACHE_POSTPONE_STATUS postpone_cache_status;
-  char *postpone_redo_data_buffer;
-  char *postpone_redo_data_ptr;
-  VACUUM_CACHE_POSTPONE_ENTRY postpone_cached_entries[VACUUM_CACHE_POSTPONE_ENTRIES_MAX_COUNT];
-  int postpone_cached_entries_count;
+  log_postpone_cache m_log_postpone_cache;
 
   char *prefetch_log_buffer;	/* buffer for prefetching log pages */
   LOG_PAGEID prefetch_first_pageid;	/* first prefetched log pageid */
@@ -266,11 +261,6 @@ extern int vacuum_rv_undoredo_data_set_link (THREAD_ENTRY * thread_p, LOG_RCV * 
 extern void vacuum_rv_undoredo_data_set_link_dump (FILE * fp, int length, void *data);
 extern int vacuum_rv_redo_append_data (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern void vacuum_rv_redo_append_data_dump (FILE * fp, int length, void *data);
-
-extern void vacuum_cache_log_postpone_redo_data (THREAD_ENTRY * thread_p, char *data_header, char *rcv_data,
-						 int rcv_data_length);
-extern void vacuum_cache_log_postpone_lsa (THREAD_ENTRY * thread_p, LOG_LSA * lsa);
-extern bool vacuum_do_postpone_from_cache (THREAD_ENTRY * thread_p, LOG_LSA * start_postpone_lsa);
 extern int vacuum_rv_redo_start_job (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 
 extern int vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, int n_heap_objects,

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -102,22 +102,6 @@ struct vacuum_heap_object
   OID oid;			/* Object OID. */
 };
 
-enum vacuum_cache_postpone_status
-{
-  VACUUM_CACHE_POSTPONE_NO,
-  VACUUM_CACHE_POSTPONE_YES,
-  VACUUM_CACHE_POSTPONE_OVERFLOW
-};
-typedef enum vacuum_cache_postpone_status VACUUM_CACHE_POSTPONE_STATUS;
-
-typedef struct vacuum_cache_postpone_entry VACUUM_CACHE_POSTPONE_ENTRY;
-struct vacuum_cache_postpone_entry
-{
-  LOG_LSA lsa;
-  char *redo_data;
-};
-#define VACUUM_CACHE_POSTPONE_ENTRIES_MAX_COUNT 10
-
 /* VACUUM_WORKER - Vacuum worker information */
 typedef struct vacuum_worker VACUUM_WORKER;
 struct vacuum_worker

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -122,8 +122,6 @@ struct vacuum_worker
   // page buffer private lru list
   int private_lru_index;
 
-  log_postpone_cache m_log_postpone_cache;
-
   char *prefetch_log_buffer;	/* buffer for prefetching log pages */
   LOG_PAGEID prefetch_first_pageid;	/* first prefetched log pageid */
   LOG_PAGEID prefetch_last_pageid;	/* last prefetch log pageid */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -47,7 +47,9 @@
 #include "log_archives.hpp"
 #include "log_comm.h"
 #include "log_common_impl.h"
+#include "log_generator.hpp"
 #include "log_lsa.hpp"
+#include "log_postpone_cache.hpp"
 #include "log_storage.hpp"
 #include "mvcc.h"
 #include "mvcc_table.hpp"
@@ -57,7 +59,6 @@
 #include "storage_common.h"
 #include "thread_entry.hpp"
 #include "transaction_transient.hpp"
-#include "log_generator.hpp"
 
 #include <assert.h>
 #if defined(SOLARIS)
@@ -545,6 +546,8 @@ struct log_tdes
   bool is_user_active;
 
   LOG_RCV_TDES rcv;
+
+  log_postpone_cache m_log_postpone_cache;
 
   // *INDENT-OFF*
 #if defined (SERVER_MODE) || (defined (SA_MODE) && defined (__cplusplus))

--- a/src/transaction/log_lsa.hpp
+++ b/src/transaction/log_lsa.hpp
@@ -41,6 +41,7 @@ struct log_lsa
   inline log_lsa () = default;
   inline log_lsa (std::int64_t log_pageid, std::int16_t log_offset);
   inline log_lsa (const log_lsa &olsa) = default;
+  inline log_lsa &operator= (const log_lsa &olsa) = default;
 
   inline bool is_null () const;
   inline void set_null ();

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7698,6 +7698,12 @@ log_tran_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   assert (tdes->topops.last < 0);
 
   log_append_commit_postpone (thread_p, tdes, &tdes->posp_nxlsa);
+
+  if (tdes->m_log_postpone_cache.do_postpone (*thread_p, &tdes->posp_nxlsa))
+    {
+      return;
+    }
+
   log_do_postpone (thread_p, tdes, &tdes->posp_nxlsa);
 }
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -2736,8 +2736,8 @@ log_append_postpone (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DATA_AD
    */
 
   if (LSA_ISNULL (&tdes->tail_lsa)
-      || (log_is_in_crash_recovery () && (crash_lsa = log_get_crash_point_lsa ()) != NULL
-	  && LSA_LE (&tdes->tail_lsa, crash_lsa)))
+      || (log_is_in_crash_recovery ()
+	  && (crash_lsa = log_get_crash_point_lsa ()) != NULL && LSA_LE (&tdes->tail_lsa, crash_lsa)))
     {
       log_append_empty_record (thread_p, LOG_DUMMY_HEAD_POSTPONE, addr);
     }
@@ -2833,9 +2833,8 @@ log_append_run_postpone (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DAT
     }
   else
     {
-      node =
-	prior_lsa_alloc_and_copy_data (thread_p, LOG_RUN_POSTPONE, RV_NOT_DEFINED, NULL, length, (char *) data, 0,
-				       NULL);
+      node = prior_lsa_alloc_and_copy_data (thread_p, LOG_RUN_POSTPONE, RV_NOT_DEFINED, NULL, length, (char *) data,
+					    0, NULL);
       if (node == NULL)
 	{
 	  return;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -2748,15 +2748,8 @@ log_append_postpone (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DATA_AD
       return;
     }
 
-  /* Cache postpone log record. Redo data must be saved before calling prior_lsa_next_record, which may free this
-   * prior node. */
-  tdes->m_log_postpone_cache.redo_data (node->data_header, node->rdata, node->rlength);
-
-  LOG_LSA start_lsa = prior_lsa_next_record (thread_p, node, tdes);
-
-  /* Cache postpone log record. An entry for this postpone log record was already created and we also need to save
-   * its LSA. */
-  tdes->m_log_postpone_cache.insert (start_lsa);
+  // Cache postpone log record
+  tdes->m_log_postpone_cache.insert (*thread_p, *node, *tdes);
 
   /* Set address early in case there is a crash, because of skip_head */
   if (tdes->topops.last >= 0)

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7694,6 +7694,7 @@ log_tran_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 
   if (tdes->m_log_postpone_cache.do_postpone (*thread_p, &tdes->posp_nxlsa))
     {
+      // do postpone from cache first
       return;
     }
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7736,7 +7736,7 @@ log_sysop_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_REC_SYSOP_E
   sysop_start_postpone.posp_lsa = *LOG_TDES_LAST_SYSOP_POSP_LSA (tdes);
   log_append_sysop_start_postpone (thread_p, tdes, &sysop_start_postpone, data_size, data);
 
-  if (tdes->m_log_postpone_cache.do_postpone (*thread_p, LOG_TDES_LAST_SYSOP (tdes)->posp_lsa))
+  if (tdes->m_log_postpone_cache.do_postpone (*thread_p, *(LOG_TDES_LAST_SYSOP_POSP_LSA (tdes))))
     {
       /* Do postpone was run from cached postpone entries. */
       tdes->state = save_state;

--- a/src/transaction/log_postpone_cache.cpp
+++ b/src/transaction/log_postpone_cache.cpp
@@ -160,8 +160,7 @@ log_postpone_cache::do_postpone (cubthread::entry &thread_ref, const log_lsa &st
   int start_index = -1;
   for (std::size_t i = 0; i < m_cache_entries_cursor; ++i)
     {
-      cache_entry *entry = &m_cache_entries[i];
-      if (entry->m_lsa == start_postpone_lsa)
+      if (m_cache_entries[i].m_lsa == start_postpone_lsa)
 	{
 	  // Found start lsa
 	  start_index = i;

--- a/src/transaction/log_postpone_cache.cpp
+++ b/src/transaction/log_postpone_cache.cpp
@@ -200,6 +200,7 @@ log_postpone_cache::do_postpone (cubthread::entry &thread_ref, const log_lsa &st
     {
       // Only some postpone entries were run. Update the number of entries which should be run on next commit
       m_cache_entries_cursor = start_index;
+      m_redo_data_ptr = m_cache_entries[start_index].m_redo_data;
     }
 
   return true;

--- a/src/transaction/log_postpone_cache.cpp
+++ b/src/transaction/log_postpone_cache.cpp
@@ -28,8 +28,6 @@
 #include "object_representation.h"
 #include "log_manager.h"
 
-const std::size_t log_postpone_cache::REDO_DATA_SIZE = IO_PAGESIZE;
-
 void
 log_postpone_cache::clear ()
 {

--- a/src/transaction/log_postpone_cache.cpp
+++ b/src/transaction/log_postpone_cache.cpp
@@ -48,7 +48,6 @@ log_postpone_cache::clear ()
 void
 log_postpone_cache::insert (log_lsa &lsa)
 {
-#if defined (SERVER_MODE)
   assert (!lsa.is_null ());
   assert (m_cache_status != LOG_POSTPONE_CACHE_NO);
 
@@ -64,7 +63,6 @@ log_postpone_cache::insert (log_lsa &lsa)
 
   /* Now that all needed data is saved, increment cached entries counter. */
   m_cache_entries_cursor++;
-#endif /* SERVER_MODE */
 }
 
 /**
@@ -78,7 +76,6 @@ log_postpone_cache::insert (log_lsa &lsa)
 void
 log_postpone_cache::redo_data (char *data_header, char *rcv_data, int rcv_data_length)
 {
-#if defined (SERVER_MODE)
   assert (data_header != NULL);
   assert (rcv_data_length == 0 || rcv_data != NULL);
 
@@ -141,7 +138,6 @@ log_postpone_cache::redo_data (char *data_header, char *rcv_data, int rcv_data_l
 
   /* LSA will be saved later. */
   new_entry->m_lsa.set_null ();
-#endif /* SERVER_MODE */
 }
 
 /**
@@ -154,7 +150,6 @@ log_postpone_cache::redo_data (char *data_header, char *rcv_data, int rcv_data_l
 bool
 log_postpone_cache::do_postpone (cubthread::entry &thread_ref, log_lsa *start_postpone_lsa)
 {
-#if defined (SERVER_MODE)
   assert (start_postpone_lsa != NULL && !start_postpone_lsa->is_null ());
   assert (m_cache_status != LOG_POSTPONE_CACHE_NO);
 
@@ -212,7 +207,4 @@ log_postpone_cache::do_postpone (cubthread::entry &thread_ref, log_lsa *start_po
     }
 
   return true;
-#else /* !SERVER_MODE */
-  return false;
-#endif /* !SERVER_MODE */
 }

--- a/src/transaction/log_postpone_cache.cpp
+++ b/src/transaction/log_postpone_cache.cpp
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * log_postpone_cache.cpp - log postpone cache module
+ */
+
+#include "log_postpone_cache.hpp"
+
+#include "log_record.hpp"
+#include "memory_alloc.h"
+#include "object_representation.h"
+#include "log_manager.h"
+
+const std::size_t log_postpone_cache::REDO_DATA_SIZE = IO_PAGESIZE;
+
+void
+log_postpone_cache::clear ()
+{
+  m_redo_data_ptr = NULL;
+  m_cache_entries_cursor = 0;
+  m_cache_status = LOG_POSTPONE_CACHE_NO;
+}
+
+/**
+ * Save LSA of postpone operations
+ *
+ * @param lsa - log postpone LSA
+ * @return void
+ *
+ * NOTE: This saves LSA after a new entry and its redo data have already been added.
+ *       They couldn't both be added in the same step.
+ */
+void
+log_postpone_cache::insert (log_lsa &lsa)
+{
+#if defined (SERVER_MODE)
+  assert (!lsa.is_null ());
+  assert (m_cache_status != LOG_POSTPONE_CACHE_NO);
+
+  if (m_cache_status == LOG_POSTPONE_CACHE_OVERFLOW)
+    {
+      return;
+    }
+
+  assert (m_cache_entries_cursor < MAX_CACHE_ENTRIES);
+
+  cache_entry *new_entry = &m_cache_entries[m_cache_entries_cursor];
+  new_entry->m_lsa = lsa;
+
+  /* Now that all needed data is saved, increment cached entries counter. */
+  m_cache_entries_cursor++;
+#endif /* SERVER_MODE */
+}
+
+/**
+ * Cache redo data for log postpone
+ *
+ * @param data_header - recovery data header (LOG_REC_REDO)
+ * @param rcv_data - recovery redo data
+ * @param rcv_data_length - recovery data size
+ * @return void
+ */
+void
+log_postpone_cache::redo_data (char *data_header, char *rcv_data, int rcv_data_length)
+{
+#if defined (SERVER_MODE)
+  assert (data_header != NULL);
+  assert (rcv_data_length == 0 || rcv_data != NULL);
+
+  if (m_cache_status == LOG_POSTPONE_CACHE_OVERFLOW)
+    {
+      /* Cannot cache postpones. */
+      return;
+    }
+
+  if (m_cache_status == LOG_POSTPONE_CACHE_NO)
+    {
+      /* Initialize data to cache postpones. */
+      m_cache_entries_cursor = 0;
+      m_redo_data_ptr = m_redo_data_buf;
+      m_cache_status = LOG_POSTPONE_CACHE_YES;
+    }
+
+  assert (m_cache_entries_cursor <= MAX_CACHE_ENTRIES);
+  assert (m_redo_data_ptr != NULL);
+  assert (m_redo_data_ptr >= m_redo_data_buf);
+  assert ((std::size_t) (m_redo_data_ptr - m_redo_data_buf) <= REDO_DATA_SIZE);
+  ASSERT_ALIGN (m_redo_data_ptr, MAX_ALIGNMENT);
+
+  if (m_cache_entries_cursor == MAX_CACHE_ENTRIES)
+    {
+      /* Could not store all postpone records. */
+      m_cache_status = LOG_POSTPONE_CACHE_OVERFLOW;
+      return;
+    }
+
+  /* Check if recovery data fits in preallocated buffer. */
+  std::size_t total_data_size = m_redo_data_ptr - m_redo_data_buf;
+  total_data_size += sizeof (log_rec_redo);
+  total_data_size += rcv_data_length;
+  total_data_size += 2 * MAX_ALIGNMENT;
+  if (total_data_size > REDO_DATA_SIZE)
+    {
+      /* Cannot store all recovery data. */
+      m_cache_status = LOG_POSTPONE_CACHE_OVERFLOW;
+      return;
+    }
+
+  /* Cache a new postpone log record entry. */
+  cache_entry *new_entry = &m_cache_entries[m_cache_entries_cursor];
+  new_entry->m_redo_data = m_redo_data_ptr;
+
+  /* Cache log_rec_redo from data_header */
+  memcpy (m_redo_data_ptr, data_header, sizeof (log_rec_redo));
+  m_redo_data_ptr += sizeof (log_rec_redo);
+  m_redo_data_ptr = PTR_ALIGN (m_redo_data_ptr, MAX_ALIGNMENT);
+
+  /* Cache recovery data. */
+  assert (((log_rec_redo *) data_header)->length == rcv_data_length);
+  if (rcv_data_length > 0)
+    {
+      memcpy (m_redo_data_ptr, rcv_data, rcv_data_length);
+      m_redo_data_ptr += rcv_data_length;
+      m_redo_data_ptr = PTR_ALIGN (m_redo_data_ptr, MAX_ALIGNMENT);
+    }
+
+  /* LSA will be saved later. */
+  new_entry->m_lsa.set_null ();
+#endif /* SERVER_MODE */
+}
+
+/**
+ * Do postpone from cached postpone entries.
+ *
+ * @param thread_ref - thread entry
+ * @param start_postpone_lsa - start postpone LSA
+ * @return - true if postpone was run from cached entries, false otherwise
+ */
+bool
+log_postpone_cache::do_postpone (cubthread::entry &thread_ref, log_lsa *start_postpone_lsa)
+{
+#if defined (SERVER_MODE)
+  assert (start_postpone_lsa != NULL && !start_postpone_lsa->is_null ());
+  assert (m_cache_status != LOG_POSTPONE_CACHE_NO);
+
+  if (m_cache_status == LOG_POSTPONE_CACHE_OVERFLOW)
+    {
+      /* Cache is not usable. */
+      m_cache_status = LOG_POSTPONE_CACHE_NO;
+      return false;
+    }
+
+  /* First cached postpone entry at start_postpone_lsa. */
+  int start_index = -1;
+  for (std::size_t i = 0; i < m_cache_entries_cursor; i++)
+    {
+      cache_entry *entry = &m_cache_entries[i];
+      if (entry->m_lsa == *start_postpone_lsa)
+	{
+	  /* Found start lsa. */
+	  start_index = i;
+	  break;
+	}
+    }
+
+  if (start_index < 0)
+    {
+      /* Start LSA was not found. Unexpected situation. */
+      assert (false);
+      return false;
+    }
+
+  /* Run all postpones after start_index. */
+  for (std::size_t i = start_index; i < m_cache_entries_cursor; i++)
+    {
+      cache_entry *entry = &m_cache_entries[i];
+
+      /* Get redo data header. */
+      log_rec_redo *redo = (log_rec_redo *) entry->m_redo_data;
+
+      /* Get recovery data. */
+      char *rcv_data = entry->m_redo_data + sizeof (log_rec_redo);
+      rcv_data = PTR_ALIGN (rcv_data, MAX_ALIGNMENT);
+      (void) log_execute_run_postpone (&thread_ref, &entry->m_lsa, redo, rcv_data);
+    }
+
+  /* Finished running postpones. */
+  if (start_index == 0)
+    {
+      /* All postpone entries were run. */
+      m_cache_status = LOG_POSTPONE_CACHE_NO;
+    }
+  else
+    {
+      /* Only some postpone entries were run. Update the number of entries which should be run on next commit. */
+      m_cache_entries_cursor = start_index;
+    }
+
+  return true;
+#else /* !SERVER_MODE */
+  return false;
+#endif /* !SERVER_MODE */
+}

--- a/src/transaction/log_postpone_cache.hpp
+++ b/src/transaction/log_postpone_cache.hpp
@@ -66,7 +66,7 @@ class log_postpone_cache
 
   private:
     static const std::size_t REDO_DATA_SIZE = IO_MAX_PAGE_SIZE;
-    static const std::size_t MAX_CACHE_ENTRIES = 10;
+    static const std::size_t MAX_CACHE_ENTRIES = 512;
 
     class cache_entry
     {

--- a/src/transaction/log_postpone_cache.hpp
+++ b/src/transaction/log_postpone_cache.hpp
@@ -65,7 +65,7 @@ class log_postpone_cache
     bool do_postpone (cubthread::entry &thread_ref, log_lsa *start_postpone_lsa);
 
   private:
-    static const std::size_t REDO_DATA_SIZE;
+    static const std::size_t REDO_DATA_SIZE = IO_MAX_PAGE_SIZE;
     static const std::size_t MAX_CACHE_ENTRIES = 10;
 
     class cache_entry

--- a/src/transaction/log_postpone_cache.hpp
+++ b/src/transaction/log_postpone_cache.hpp
@@ -68,8 +68,9 @@ class log_postpone_cache
 
     void clear ();
 
-    void insert (cubthread::entry &thread_ref, log_prior_node &node, log_tdes &tdes);
-    bool do_postpone (cubthread::entry &thread_ref, log_lsa *start_postpone_lsa);
+    void add_redo_data (const log_prior_node &node);
+    void add_lsa (const log_lsa &lsa);
+    bool do_postpone (cubthread::entry &thread_ref, const log_lsa &start_postpone_lsa);
 
   private:
     static const std::size_t REDO_DATA_SIZE = IO_MAX_PAGE_SIZE;

--- a/src/transaction/log_postpone_cache.hpp
+++ b/src/transaction/log_postpone_cache.hpp
@@ -26,9 +26,17 @@
 
 #include "log_lsa.hpp"
 #include "storage_common.h"
-#include "thread_entry.hpp"
 
 #include <array>
+
+// forward declarations
+struct log_tdes;
+struct log_prior_node;
+
+namespace cubthread
+{
+  class entry;
+}
 
 /**
  * Caches postpones to avoid reading them from log after commit top operation with postpone.
@@ -60,8 +68,7 @@ class log_postpone_cache
 
     void clear ();
 
-    void insert (log_lsa &lsa);
-    void redo_data (char *data_header, char *rcv_data, int rcv_data_length);
+    void insert (cubthread::entry &thread_ref, log_prior_node &node, log_tdes &tdes);
     bool do_postpone (cubthread::entry &thread_ref, log_lsa *start_postpone_lsa);
 
   private:

--- a/src/transaction/log_postpone_cache.hpp
+++ b/src/transaction/log_postpone_cache.hpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * log_postpone_cache.hpp - log postpone cache module
+ */
+
+#ifndef _LOG_POSTPONE_CACHE_HPP_
+#define _LOG_POSTPONE_CACHE_HPP_
+
+#include "log_lsa.hpp"
+#include "storage_common.h"
+#include "thread_entry.hpp"
+
+#include <array>
+
+/**
+ * Caches postpones to avoid reading them from log after commit top operation with postpone.
+ * Otherwise, log critical section may be required which will slow the access on merged index nodes
+ */
+class log_postpone_cache
+{
+  public:
+    log_postpone_cache ()
+      : m_redo_data_buf (NULL)
+      , m_redo_data_ptr (NULL)
+      , m_cache_status (LOG_POSTPONE_CACHE_NO)
+      , m_cache_entries_cursor (0)
+      , m_cache_entries ()
+    {
+      m_redo_data_buf = new char[REDO_DATA_SIZE];
+    }
+
+    log_postpone_cache (log_postpone_cache &&other) = delete;
+    log_postpone_cache (const log_postpone_cache &other) = delete;
+
+    log_postpone_cache &operator= (log_postpone_cache &&other) = delete;
+    log_postpone_cache &operator= (const log_postpone_cache &other) = delete;
+
+    ~log_postpone_cache ()
+    {
+      delete [] m_redo_data_buf;
+    }
+
+    void clear ();
+
+    void insert (log_lsa &lsa);
+    void redo_data (char *data_header, char *rcv_data, int rcv_data_length);
+    bool do_postpone (cubthread::entry &thread_ref, log_lsa *start_postpone_lsa);
+
+  private:
+    static const std::size_t REDO_DATA_SIZE;
+    static const std::size_t MAX_CACHE_ENTRIES = 10;
+
+    class cache_entry
+    {
+      public:
+	cache_entry ()
+	  : m_lsa ()
+	  , m_redo_data (NULL)
+	{
+	  m_lsa.set_null ();
+	}
+
+	log_lsa m_lsa;
+	char *m_redo_data;
+    };
+
+    enum cache_status
+    {
+      LOG_POSTPONE_CACHE_NO,
+      LOG_POSTPONE_CACHE_YES,
+      LOG_POSTPONE_CACHE_OVERFLOW
+    };
+
+    char *m_redo_data_buf;
+    char *m_redo_data_ptr;
+
+    cache_status m_cache_status;
+
+    std::size_t m_cache_entries_cursor;
+    std::array<cache_entry, MAX_CACHE_ENTRIES> m_cache_entries;
+};
+
+#endif /* _LOG_POSTPONE_CACHE_HPP_ */

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -877,6 +877,7 @@ logtb_set_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const BOOT_CLIENT_CRED
   tdes->num_transient_classnames = 0;
   tdes->first_save_entry = NULL;
   tdes->lob_locator_root.init ();
+  tdes->m_log_postpone_cache.clear ();
 }
 
 /*
@@ -1562,6 +1563,7 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   tdes->tran_abort_reason = TRAN_NORMAL;
   tdes->num_exec_queries = 0;
   tdes->suppress_replication = 0;
+  tdes->m_log_postpone_cache.clear ();
 
   logtb_tran_clear_update_stats (&tdes->log_upd_stats);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22755

Extract log postpone cache implementation to separate files and make use of it in all transactions not just for vacuum workers.

**renamings**:
*`struct/enum`*
`vacuum_cache_postpone_entry -> log_postpone_cache::cache_entry`
`vacuum_cache_postpone_status -> log_postpone_cache::cache_status`

*`define`*
`VACUUM_CACHE_POSTPONE_ENTRIES_MAX_COUNT -> log_postpone_cache::MAX_CACHE_ENTRIES`

*`function`*
`vacuum_cache_log_postpone_redo_data -> log_postpone_cache::add_redo_data`
`vacuum_cache_log_postpone_lsa -> log_postpone_cache::add_lsa`
`vacuum_do_postpone_from_cache -> log_postpone_cache::do_postpone`