### PR TITLE
[CBRD-23213] fix append_to_buffer_and_pack_all

### DIFF
--- a/src/base/packer.hpp
+++ b/src/base/packer.hpp
@@ -122,8 +122,8 @@ namespace cubpacking
       const char *get_buffer_end (void);
       bool is_ended (void);
 
-      size_t get_packed_buffer_size (const char *stream, const size_t length, const size_t curr_offset) const;
-      void pack_buffer_with_length (const char *stream, const size_t length);
+      std::size_t get_packed_buffer_size (const char *stream, const std::size_t length, const std::size_t curr_offset) const;
+      void pack_buffer_with_length (const char *stream, const std::size_t length);
 
       // template function to pack object as int type
       template <typename T>
@@ -215,7 +215,7 @@ namespace cubpacking
       void unpack_overloaded (packable_object &po);
 
       void peek_unpack_buffer_length (int &value);
-      void unpack_buffer_with_length (char *stream, const size_t max_length);
+      void unpack_buffer_with_length (char *stream, const std::size_t max_length);
 
       void unpack_oid (OID &oid);
       void unpack_overloaded (OID &oid);
@@ -371,7 +371,9 @@ namespace cubpacking
       {
 	eb.extend_by (total_size - available);
       }
-    set_buffer (eb.get_ptr () + offset, total_size);
+    /* don't change m_start_ptr */
+    m_ptr = eb.get_ptr () + offset;
+    m_end_ptr = eb.get_ptr () + offset + total_size;
 
     pack_all (std::forward<Args> (args)...);
   }

--- a/unit_tests/packing/test_packing.cpp
+++ b/unit_tests/packing/test_packing.cpp
@@ -365,6 +365,49 @@ namespace test_packing
     return res;
   }
 
+
+  int test_pack_oid_list (void)
+  {
+    cubmem::extensible_block blk;
+    cubpacking::packer packer;
+
+    OID classes[10];
+    int cnt_classes = sizeof (classes) / sizeof (classes[0]);
+
+    for (int i = 0; i < cnt_classes; i++)
+      {
+	classes[i].volid = i;
+	classes[i].pageid= i + 100;
+	classes[i].slotid= i + 10;
+      }
+
+    blk.extend_to (OR_INT_SIZE + cnt_classes * OR_OID_SIZE);
+    packer.set_buffer_and_pack_all (blk, cnt_classes);
+
+    for (int i = 0; i < cnt_classes; i++)
+      {
+	packer.append_to_buffer_and_pack_all (blk, classes[i]);
+      }
+
+
+    OID classes_unpacked[10];
+
+    cubpacking::unpacker unpacker (blk.get_ptr (), blk.get_size ());
+
+    int cnt_classes_unpack;
+    unpacker.unpack_all (cnt_classes_unpack);
+
+    assert (cnt_classes_unpack = cnt_classes);
+    for (int i = 0; i < cnt_classes_unpack; i++)
+      {
+	OID cl;
+	unpacker.unpack_all (cl);
+
+	assert (OID_EQ (&cl, &classes[i]));
+      }
+
+    return 0;
+  }
   int test_packing_all (void)
   {
     po1 po_pack_1;
@@ -412,6 +455,8 @@ namespace test_packing
 	assert (false);
 	return ER_FAILED;
       }
+
+    test_pack_oid_list ();
 
     return NO_ERROR;
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23213

Fix append_to_buffer_and_pack_all, add unit tests for packing list of OIDs.
Replace size_t with std::size_t