### PR TITLE
[CBRD-23199] fix how vacuum_recover_lost_block_data changes log_Gl.hdr

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5421,7 +5421,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   assert (!LSA_ISNULL (&mvcc_op_log_lsa));
 
   // reset header; info will be restored if last block is not consumed.
-  logpb_vacuum_reset_log_header_cache (thread_p, log_Gl.hdr);
+  logpb_vacuum_reset_log_header_cache (thread_p, &log_Gl.hdr);
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 		 "vacuum_recover_lost_block_data, start recovering from %lld|%d ", LSA_AS_ARGS (&mvcc_op_log_lsa));

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5419,7 +5419,9 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
       LSA_COPY (&mvcc_op_log_lsa, &log_Gl.hdr.mvcc_op_log_lsa);
     }
   assert (!LSA_ISNULL (&mvcc_op_log_lsa));
-  log_Gl.hdr.mvcc_op_log_lsa.set_null ();
+
+  // reset header; info will be restored if last block is not consumed.
+  logpb_vacuum_reset_log_header_cache (thread_p, log_Gl.hdr);
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 		 "vacuum_recover_lost_block_data, start recovering from %lld|%d ", LSA_AS_ARGS (&mvcc_op_log_lsa));

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5418,7 +5418,6 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
       LSA_COPY (&mvcc_op_log_lsa, &log_Gl.hdr.mvcc_op_log_lsa);
     }
   assert (!LSA_ISNULL (&mvcc_op_log_lsa));
-  log_Gl.hdr.mvcc_op_log_lsa = mvcc_op_log_lsa;
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 		 "vacuum_recover_lost_block_data, start recovering from %lld|%d ", LSA_AS_ARGS (&mvcc_op_log_lsa));
@@ -5484,6 +5483,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	  log_Gl.hdr.last_block_oldest_mvccid = data.oldest_mvccid;
 	  log_Gl.hdr.last_block_newest_mvccid = data.newest_mvccid;
 	  log_Gl.hdr.does_block_need_vacuum = true;
+	  log_Gl.hdr.mvcc_op_log_lsa = mvcc_op_log_lsa;
 
 	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 			 "Restore log global cached info: \n\t mvcc_op_log_lsa = %lld|%d \n"

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5419,6 +5419,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
       LSA_COPY (&mvcc_op_log_lsa, &log_Gl.hdr.mvcc_op_log_lsa);
     }
   assert (!LSA_ISNULL (&mvcc_op_log_lsa));
+  log_Gl.hdr.mvcc_op_log_lsa.set_null ();
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 		 "vacuum_recover_lost_block_data, start recovering from %lld|%d ", LSA_AS_ARGS (&mvcc_op_log_lsa));


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23199

Clear info from log_Gl.hdr in first phase and set relevant information only if mvcc op is found after vacuum data last blockid.

Regression of #1797 #1812 