### PR TITLE
[CBRD-23223] replication copy apply on slave server

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -68,6 +68,7 @@ set(THREAD_HEADERS
 set(STREAM_SOURCES
   ${BASE_DIR}/cubstream.cpp
   ${BASE_DIR}/multi_thread_stream.cpp
+  ${BASE_DIR}/stream_entry_consumer.cpp
   ${BASE_DIR}/stream_file.cpp
   )
 set (STREAM_HEADERS
@@ -76,6 +77,7 @@ set (STREAM_HEADERS
   ${BASE_DIR}/cubstream.hpp
   ${BASE_DIR}/multi_thread_stream.hpp
   ${BASE_DIR}/stream_entry.hpp
+  ${BASE_DIR}/stream_entry_consumer.hpp
   ${BASE_DIR}/stream_entry_fetcher.hpp
   ${BASE_DIR}/stream_file.hpp
   )
@@ -212,6 +214,7 @@ set (REPLICATION_HEADERS
   ${REPLICATION_DIR}/ha_server_state.hpp
   ${REPLICATION_DIR}/log_generator.hpp
   ${REPLICATION_DIR}/log_consumer.hpp
+  ${REPLICATION_DIR}/replication_apply_db_copy.hpp
   ${REPLICATION_DIR}/replication_common.hpp
   ${REPLICATION_DIR}/replication_master_node.hpp
   ${REPLICATION_DIR}/stream_senders_manager.hpp
@@ -282,8 +285,9 @@ set(REPLICATION_SOURCES
   ${REPLICATION_DIR}/ha_server_state.cpp
   ${REPLICATION_DIR}/log_consumer.cpp
   ${REPLICATION_DIR}/log_generator.cpp
-  ${REPLICATION_DIR}/slave_control_channel.cpp
   ${REPLICATION_DIR}/master_control_channel.cpp
+  ${REPLICATION_DIR}/replication_apply_db_copy.cpp
+  ${REPLICATION_DIR}/replication_common.cpp
   ${REPLICATION_DIR}/replication_object.cpp
   ${REPLICATION_DIR}/replication_master_node.cpp
   ${REPLICATION_DIR}/stream_senders_manager.cpp
@@ -295,6 +299,7 @@ set(REPLICATION_SOURCES
   ${REPLICATION_DIR}/replication_stream_entry.cpp
   ${REPLICATION_DIR}/replication_subtran_apply.cpp
   ${REPLICATION_DIR}/replication_subtran_generate.cpp
+  ${REPLICATION_DIR}/slave_control_channel.cpp
   )
 
 set(JSP_SOURCES

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -292,6 +292,7 @@ set (REPLICATION_HEADERS
 set(REPLICATION_SOURCES
   ${REPLICATION_DIR}/ha_server_state.cpp
   ${REPLICATION_DIR}/log_generator.cpp
+  ${REPLICATION_DIR}/replication_common.cpp
   ${REPLICATION_DIR}/replication_object.cpp
   ${REPLICATION_DIR}/replication_schema_extract.cpp
   ${REPLICATION_DIR}/replication_stream_entry.cpp
@@ -300,6 +301,7 @@ set(REPLICATION_SOURCES
 set(STREAM_SOURCES
   ${BASE_DIR}/cubstream.cpp
   ${BASE_DIR}/multi_thread_stream.cpp
+  ${BASE_DIR}/stream_entry_consumer.cpp
   ${BASE_DIR}/stream_file.cpp
   )
 
@@ -309,6 +311,7 @@ set (STREAM_HEADERS
   ${BASE_DIR}/cubstream.hpp
   ${BASE_DIR}/multi_thread_stream.hpp
   ${BASE_DIR}/stream_entry.hpp
+  ${BASE_DIR}/stream_entry_consumer.hpp
   ${BASE_DIR}/stream_file.hpp  
   )
 

--- a/src/base/multi_thread_stream.cpp
+++ b/src/base/multi_thread_stream.cpp
@@ -28,6 +28,7 @@
 
 #include "error_code.h"
 #include "error_manager.h"
+#include "replication_common.hpp" // TODO[replication] : remove this when stream flush is improved
 #include "system_parameter.h"
 
 #include <algorithm>  /* for std::min */
@@ -81,7 +82,7 @@ namespace cubstream
   {
     stream::init (start_position);
     m_oldest_buffered_position = start_position;
-    m_flush_on_commit = prm_get_bool_value (PRM_ID_DEBUG_REPLICATION_DATA);
+    m_flush_on_commit = cubreplication::is_debug_process_enabled ();  // TODO : remove replication_common header
     return NO_ERROR;
   }
 

--- a/src/base/stream_entry_consumer.cpp
+++ b/src/base/stream_entry_consumer.cpp
@@ -35,6 +35,10 @@ namespace cubstream
   {
   }
 
+  stream_entry_consumer::~stream_entry_consumer ()
+  {
+  }
+
   void stream_entry_consumer::start (void)
   {
     std::string pool_name = m_name + std::string ("_worker_thread_pool");

--- a/src/base/stream_entry_consumer.cpp
+++ b/src/base/stream_entry_consumer.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * stream_entry_consumer.cpp
+ */
+
+
+#include "stream_entry_consumer.hpp"
+#include "multi_thread_stream.hpp"
+
+namespace cubstream
+{
+  stream_entry_consumer::stream_entry_consumer (const char *name, multi_thread_stream *stream, size_t applier_threads)
+    : m_name (name ? name : "")
+    , m_stream (stream)
+    , m_applier_worker_threads_count (applier_threads)
+    , m_started_tasks (0)
+    {
+    }
+
+  void stream_entry_consumer::start (void)
+  {
+    std::string pool_name = m_name + std::string ("_worker_thread_pool");
+
+    m_applier_workers_pool = cubthread::get_manager ()->create_worker_pool (m_applier_worker_threads_count,
+			     m_applier_worker_threads_count, pool_name.c_str (),NULL, 1, 1);
+    start_dispatcher ();
+  }
+
+  void stream_entry_consumer::stop (void)
+  {
+    m_stream->stop ();
+
+    stop_dispatcher ();
+
+    cubthread::get_manager ()->destroy_worker_pool (m_applier_workers_pool);
+  }
+
+  void stream_entry_consumer::wait_for_tasks (void)
+  {
+    while (m_started_tasks.load () > 0)
+      {
+	thread_sleep (1);
+      }
+  }
+} /* namespace cubstream */

--- a/src/base/stream_entry_consumer.cpp
+++ b/src/base/stream_entry_consumer.cpp
@@ -32,8 +32,8 @@ namespace cubstream
     , m_stream (stream)
     , m_applier_worker_threads_count (applier_threads)
     , m_started_tasks (0)
-    {
-    }
+  {
+  }
 
   void stream_entry_consumer::start (void)
   {

--- a/src/base/stream_entry_consumer.hpp
+++ b/src/base/stream_entry_consumer.hpp
@@ -34,14 +34,14 @@
 namespace cubstream
 {
   class multi_thread_stream;
-  
+
   /*
    * stream_entry_consumer : abtract class for "consuming" stream entries with a thread pool
    *
    * Requires a multi_thread_stream
    * It does not include the dispatcher functionality, it requires the implementation of start and stop of dispatcher
    *
-   * Usage : 
+   * Usage :
    *  - implement consumer derived from stream_entry_consumer
    *  - required : implement start_dispatcher, stop_dispatcher (it must include a stream_fetcher mechanism)
    *  - optional : implement on_task_execution; this is executed before execute_task method
@@ -55,7 +55,7 @@ namespace cubstream
       cubthread::entry_workpool *m_applier_workers_pool;
 
     protected:
-      
+
       size_t m_applier_worker_threads_count;
       std::atomic<int> m_started_tasks;
 
@@ -73,7 +73,7 @@ namespace cubstream
       void stop ();
 
       virtual void start_dispatcher (void) = 0;
-      
+
       virtual void stop_dispatcher (void) = 0;
 
       void end_one_task (void)
@@ -85,7 +85,7 @@ namespace cubstream
       {
 	return m_started_tasks;
       }
-   
+
       void wait_for_tasks (void);
 
       virtual void on_task_execution () {}
@@ -93,24 +93,24 @@ namespace cubstream
       template <typename Task>
       void execute_task (Task *task, bool detailed_dump = false)
       {
-        on_task_execution ();
+	on_task_execution ();
 
-        if (detailed_dump)
-          {
+	if (detailed_dump)
+	  {
 	    string_buffer sb;
 	    task->stringify (sb);
 	    _er_log_debug (ARG_FILE_LINE, "%s::execute_task:\n%s", m_name.c_str (), sb.get_buffer ());
-          }
+	  }
 
-        push_task (task);
+	push_task (task);
       }
 
       template <typename Task>
       void push_task (Task *task)
       {
-        cubthread::get_manager ()->push_task (m_applier_workers_pool, task);
+	cubthread::get_manager ()->push_task (m_applier_workers_pool, task);
 
-        m_started_tasks++;
+	m_started_tasks++;
       }
   };
 

--- a/src/base/stream_entry_consumer.hpp
+++ b/src/base/stream_entry_consumer.hpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * stream_entry_consumer.hpp
+ */
+
+#ident "$Id$"
+
+#ifndef _STREAM_ENTRY_CONSUMER_HPP_
+#define _STREAM_ENTRY_CONSUMER_HPP_
+
+#include "error_manager.h"
+#include "string_buffer.hpp"
+#include "thread_manager.hpp"
+#include <string>
+
+namespace cubstream
+{
+  class multi_thread_stream;
+  
+  /*
+   * stream_entry_consumer : abtract class for "consuming" stream entries with a thread pool
+   *
+   * Requires a multi_thread_stream
+   * It does not include the dispatcher functionality, it requires the implementation of start and stop of dispatcher
+   *
+   * Usage : 
+   *  - implement consumer derived from stream_entry_consumer
+   *  - required : implement start_dispatcher, stop_dispatcher (it must include a stream_fetcher mechanism)
+   *  - optional : implement on_task_execution; this is executed before execute_task method
+   */
+  class stream_entry_consumer
+  {
+    private:
+      std::string m_name;
+      multi_thread_stream *m_stream;
+
+      cubthread::entry_workpool *m_applier_workers_pool;
+
+    protected:
+      
+      size_t m_applier_worker_threads_count;
+      std::atomic<int> m_started_tasks;
+
+    public:
+
+      stream_entry_consumer (const char *name, multi_thread_stream *stream, size_t applier_threads);
+
+      cubstream::multi_thread_stream *get_stream (void)
+      {
+	return m_stream;
+      }
+
+      void start ();
+
+      void stop ();
+
+      virtual void start_dispatcher (void) = 0;
+      
+      virtual void stop_dispatcher (void) = 0;
+
+      void end_one_task (void)
+      {
+	m_started_tasks--;
+      }
+
+      int get_started_task (void)
+      {
+	return m_started_tasks;
+      }
+   
+      void wait_for_tasks (void);
+
+      virtual void on_task_execution () {}
+
+      template <typename Task>
+      void execute_task (Task *task, bool detailed_dump = false)
+      {
+        on_task_execution ();
+
+        if (detailed_dump)
+          {
+	    string_buffer sb;
+	    task->stringify (sb);
+	    _er_log_debug (ARG_FILE_LINE, "%s::execute_task:\n%s", m_name.c_str (), sb.get_buffer ());
+          }
+
+        push_task (task);
+      }
+
+      template <typename Task>
+      void push_task (Task *task)
+      {
+        cubthread::get_manager ()->push_task (m_applier_workers_pool, task);
+
+        m_started_tasks++;
+      }
+  };
+
+} /* namespace cubstream */
+
+#endif /* _STREAM_ENTRY_CONSUMER_HPP_ */

--- a/src/base/stream_entry_consumer.hpp
+++ b/src/base/stream_entry_consumer.hpp
@@ -63,6 +63,8 @@ namespace cubstream
 
       stream_entry_consumer (const char *name, multi_thread_stream *stream, size_t applier_threads);
 
+      virtual ~stream_entry_consumer () = 0;
+
       cubstream::multi_thread_stream *get_stream (void)
       {
 	return m_stream;

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2222,8 +2222,8 @@ bool PRM_DEBUG_AUTOCOMMIT = false;
 static bool prm_debug_autocommit_default = false;
 static unsigned int prm_debug_autocommit_flag = 0;
 
-bool PRM_DEBUG_REPLICATION_DATA = true;
-static bool prm_debug_replication_data_default = false;
+int PRM_DEBUG_REPLICATION_DATA = true;
+static int prm_debug_replication_data_default = false;
 static unsigned int prm_debug_replication_data_flag = 0;
 
 bool PRM_TRACK_REQUESTS = false;
@@ -5724,7 +5724,7 @@ static SYSPRM_PARAM prm_Def[] = {
   {PRM_ID_DEBUG_REPLICATION_DATA,
    PRM_NAME_DEBUG_REPLICATION_DATA,
    (PRM_FOR_SERVER | PRM_FOR_CLIENT | PRM_USER_CHANGE | PRM_HIDDEN),
-   PRM_BOOLEAN,
+   PRM_INTEGER,
    &prm_debug_replication_data_flag,
    (void *) &prm_debug_replication_data_default,
    (void *) &PRM_DEBUG_REPLICATION_DATA,

--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -68,6 +68,7 @@ enum css_command_type
   SERVER_REQUEST_NEW = 5,	/* new-style server request */
   COMMAND_SERVER_REQUEST_CONNECT_SLAVE = 6,	/* slave server wants to connect to master server */
   COMMAND_SERVER_REQUEST_CONNECT_SLAVE_CONTROL = 7,	/* slave connects to a control channel */
+  COMMAND_SERVER_REQUEST_CONNECT_SLAVE_COPY_DB = 8,	/* slave server wants to connect to master server and copy DB */
 
   CSS_COMMAND_CNT
 };
@@ -154,7 +155,8 @@ enum css_server_request
   SERVER_GET_EOF = 13,
   SERVER_RECEIVE_MASTER_HOSTNAME = 14,
   SERVER_CONNECT_SLAVE_REPL = 15,
-  SERVER_CONNECT_SLAVE_CONTROL_CHANNEL = 16
+  SERVER_CONNECT_SLAVE_CONTROL_CHANNEL = 16,
+  SERVER_CONNECT_SLAVE_COPY_DB = 17
 };
 typedef enum css_server_request CSS_SERVER_REQUEST;
 

--- a/src/replication/log_consumer.cpp
+++ b/src/replication/log_consumer.cpp
@@ -62,7 +62,7 @@ namespace cubreplication
 
       void execute (cubthread::entry &thread_ref) final
       {
-	(void) locator_repl_start_tran (&thread_ref, DB_CLIENT_TYPE_LOG_APPLIER);
+	(void) locator_repl_start_tran (&thread_ref);
 
 	for (stream_entry *&curr_stream_entry : m_repl_stream_entries)
 	  {

--- a/src/replication/log_consumer.hpp
+++ b/src/replication/log_consumer.hpp
@@ -97,7 +97,7 @@ namespace cubreplication
       std::function<void (cubstream::stream_position)> ack_produce;
 
       log_consumer (const char *name, cubstream::multi_thread_stream *stream, size_t applier_threads)
-        : cubstream::stream_entry_consumer (name, stream, applier_threads)
+	: cubstream::stream_entry_consumer (name, stream, applier_threads)
 	, m_dispatch_daemon (NULL)
 	, m_subtran_applier (*this)
 	, m_dispatch_finished (false)

--- a/src/replication/log_consumer.hpp
+++ b/src/replication/log_consumer.hpp
@@ -109,7 +109,7 @@ namespace cubreplication
 	fetch_suspend ();
       };
 
-      ~log_consumer ();
+      ~log_consumer () override;
 
       void start_dispatcher (void);
       void stop_dispatcher ();

--- a/src/replication/log_generator.cpp
+++ b/src/replication/log_generator.cpp
@@ -375,7 +375,7 @@ namespace cubreplication
     assert (m_stream_entry.get_stream () != NULL);
     assert (!m_stream_entry.is_tran_state_undefined ());
 
-    if (prm_get_bool_value (PRM_ID_DEBUG_REPLICATION_DATA))
+    if (is_debug_detailed_dump_enabled ())
       {
 	string_buffer sb;
 	m_stream_entry.stringify (sb, stream_entry::detailed_dump);

--- a/src/replication/replication_apply_db_copy.cpp
+++ b/src/replication/replication_apply_db_copy.cpp
@@ -267,7 +267,7 @@ namespace cubreplication
     public:
       copy_dispatch_task (copy_db_consumer &copy_consumer)
 	: m_copy_consumer (copy_consumer)
-        , m_entry_fetcher (*copy_consumer.get_stream ())
+	, m_entry_fetcher (*copy_consumer.get_stream ())
       {
       }
 
@@ -280,7 +280,7 @@ namespace cubreplication
 	while (phase != copy_db_consumer::apply_phase::END)
 	  {
 	    bool is_control_se = false;
-            stream_entry *se = NULL;
+	    stream_entry *se = NULL;
 	    int err = m_entry_fetcher.fetch_entry (se);
 	    if (err != NO_ERROR)
 	      {

--- a/src/replication/replication_apply_db_copy.cpp
+++ b/src/replication/replication_apply_db_copy.cpp
@@ -1,0 +1,391 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * replication_apply_db_copy.cpp
+ */
+
+#ident "$Id$"
+
+#include "replication_apply_db_copy.hpp"
+#include "communication_server_channel.hpp"
+#include "locator_sr.h"
+#include "log_impl.h"
+#include "replication_common.hpp"
+#include "replication_node.hpp"
+#include "replication_stream_entry.hpp"
+#include "stream_transfer_receiver.hpp"
+#include "stream_entry_fetcher.hpp"
+#include "stream_file.hpp"
+#include "string_buffer.hpp"
+#include "thread_entry_task.hpp"
+#include "thread_looper.hpp"
+#include <unordered_map>
+
+namespace cubreplication
+{
+  using stream_entry_fetcher = cubstream::entry_fetcher<stream_entry>;
+
+  apply_copy_context::apply_copy_context (node_definition *myself, node_definition *source_node)
+  {
+    m_my_identity = myself;
+    m_source_identity = source_node;
+    m_transfer_receiver = NULL;
+    m_copy_consumer = NULL;
+    m_online_repl_start_pos = 0;
+
+    INT64 buffer_size = prm_get_bigint_value (PRM_ID_REPL_BUFFER_SIZE);
+    /* create stream */
+    m_stream = new cubstream::multi_thread_stream (buffer_size, 2);
+    m_stream->set_name ("repl_copy_" + std::string (m_source_identity->get_hostname ().c_str ()));
+    m_stream->set_trigger_min_to_read_size (stream_entry::compute_header_size ());
+    m_stream->init (0);
+
+    /* create stream file */
+    std::string replication_path;
+    replication_node::get_replication_file_path (replication_path);
+    m_stream_file = new cubstream::stream_file (*m_stream, replication_path);
+  }
+
+  apply_copy_context::~apply_copy_context ()
+  {
+    delete m_transfer_receiver;
+    m_transfer_receiver = NULL;
+
+    if (m_copy_consumer)
+      {
+	m_copy_consumer->stop ();
+      }
+    delete m_copy_consumer;
+    m_copy_consumer = NULL;
+
+    delete m_stream_file;
+    m_stream_file = NULL;
+
+    delete m_stream;
+    m_stream = NULL;
+  }
+
+  int apply_copy_context::setup_copy_protocol (cubcomm::channel &chn)
+  {
+    UINT64 pos = 0, expected_magic;
+    std::size_t max_len = sizeof (UINT64);
+
+    if (chn.send ((char *) &replication_node::SETUP_COPY_REPLICATION_MAGIC, max_len) != css_error_code::NO_ERRORS)
+      {
+	return ER_FAILED;
+      }
+
+    if (chn.recv ((char *) &expected_magic, max_len) != css_error_code::NO_ERRORS)
+      {
+	return ER_FAILED;
+      }
+
+    if (expected_magic != replication_node::SETUP_COPY_REPLICATION_MAGIC)
+      {
+	er_log_debug_replication (ARG_FILE_LINE, "apply_copy_context::setup_copy_protocol error in setup protocol");
+	assert (false);
+	return ER_FAILED;
+      }
+
+    if (chn.recv ((char *) &pos, max_len) != css_error_code::NO_ERRORS)
+      {
+	return ER_FAILED;
+      }
+
+    m_online_repl_start_pos = ntohi64 (pos);
+
+    er_log_debug_replication (ARG_FILE_LINE, "apply_copy_context::setup_copy_protocol online replication start pos :%lld",
+			      m_online_repl_start_pos);
+
+    return NO_ERROR;
+  }
+
+  int apply_copy_context::execute_copy ()
+  {
+    int error = NO_ERROR;
+
+    m_start_time = std::chrono::system_clock::now ();
+
+    er_log_debug_replication (ARG_FILE_LINE, "apply_copy_context::connect_to_source host:%s, port: %d\n",
+			      m_source_identity->get_hostname ().c_str (), m_source_identity->get_port ());
+
+    assert (m_stream != NULL);
+    /* connect to replication master node */
+    cubcomm::server_channel srv_chn (m_my_identity->get_hostname ().c_str ());
+    srv_chn.set_channel_name (REPL_COPY_CHANNEL_NAME);
+
+    error = srv_chn.connect (m_source_identity->get_hostname ().c_str (), m_source_identity->get_port (),
+			     COMMAND_SERVER_REQUEST_CONNECT_SLAVE_COPY_DB);
+    if (error != css_error_code::NO_ERRORS)
+      {
+	return error;
+      }
+
+    setup_copy_protocol (srv_chn);
+
+    /* start transfer receiver */
+    assert (m_transfer_receiver == NULL);
+    /* TODO[replication] : start position in case of resume of copy process */
+    cubstream::stream_position start_position = 0;
+    m_transfer_receiver = new cubstream::transfer_receiver (std::move (srv_chn), *m_stream, start_position);
+
+    m_copy_consumer = new copy_db_consumer ("copy_consumer", m_stream, copy_db_consumer::MAX_APPLIER_THREADS);
+
+    m_copy_consumer->start ();
+
+    wait_replication_copy ();
+
+    m_transfer_receiver->terminate_connection ();
+
+    while (m_transfer_receiver->get_channel ().is_connection_alive ())
+      {
+	thread_sleep (10);
+      }
+
+    std::chrono::duration<double> execution_time = std::chrono::system_clock::now () - m_start_time;
+    er_log_debug_replication (ARG_FILE_LINE, "apply_copy_context::connection terminated (time since start:%.6f)",
+			      execution_time.count ());
+
+    /* update position in log_Gl */
+    log_Gl.hdr.m_ack_stream_position = m_online_repl_start_pos;
+
+    return error;
+  }
+
+  void apply_copy_context::wait_replication_copy ()
+  {
+    while (!m_copy_consumer->is_finished ())
+      {
+	std::chrono::duration<double> execution_time = std::chrono::system_clock::now () - m_start_time;
+
+	er_log_debug_replication (ARG_FILE_LINE, "wait_replication_copy: current stream_position:%lld\n"
+				  "running tasks:%d\n"
+				  "time since start:%.6f\n",
+				  m_copy_consumer->m_last_fetched_position,
+				  m_copy_consumer->get_started_task (),
+				  execution_time.count ());
+	thread_sleep (1000);
+      }
+  }
+
+  /* TODO : refactor with log_consumer:: applier_worker_task */
+  class copy_db_worker_task : public cubthread::entry_task
+  {
+    public:
+      copy_db_worker_task (stream_entry *repl_stream_entry, copy_db_consumer &copy_consumer)
+	: m_copy_consumer (copy_consumer)
+      {
+	add_repl_stream_entry (repl_stream_entry);
+      }
+
+      void execute (cubthread::entry &thread_ref) final
+      {
+	if (locator_repl_start_tran (&thread_ref, DB_CLIENT_TYPE_LOG_APPLIER) != NO_ERROR)
+	  {
+	    assert (false);
+	    return;
+	  }
+
+	for (stream_entry *curr_stream_entry : m_repl_stream_entries)
+	  {
+	    curr_stream_entry->unpack ();
+
+	    if (is_debug_detailed_dump_enabled ())
+	      {
+		string_buffer sb;
+		curr_stream_entry->stringify (sb, stream_entry::detailed_dump);
+		_er_log_debug (ARG_FILE_LINE, "applier_worker_task execute:\n%s", sb.get_buffer ());
+	      }
+
+	    for (int i = 0; i < curr_stream_entry->get_packable_entry_count_from_header (); i++)
+	      {
+		replication_object *obj = curr_stream_entry->get_object_at (i);
+
+		/* clean error code */
+		er_clear ();
+
+		int err = obj->apply ();
+		if (err != NO_ERROR)
+		  {
+		    assert (false);
+		    /* TODO[replication] : error handling */
+		  }
+	      }
+
+	    delete curr_stream_entry;
+	  }
+
+	m_copy_consumer.end_one_task ();
+
+	locator_repl_end_tran (&thread_ref, true);
+      }
+
+      void add_repl_stream_entry (stream_entry *repl_stream_entry)
+      {
+	m_repl_stream_entries.push_back (repl_stream_entry);
+      }
+
+      size_t get_entries_cnt (void)
+      {
+	return m_repl_stream_entries.size ();
+      }
+
+      void stringify (string_buffer &sb)
+      {
+	sb ("apply_task: stream_entries:%d\n", get_entries_cnt ());
+	for (auto it = m_repl_stream_entries.begin (); it != m_repl_stream_entries.end (); it++)
+	  {
+	    (*it)->stringify (sb, stream_entry::detailed_dump);
+	  }
+      }
+
+    private:
+      std::vector<stream_entry *> m_repl_stream_entries;
+      copy_db_consumer &m_copy_consumer;
+  };
+
+
+  class copy_dispatch_task : public cubthread::entry_task
+  {
+    public:
+      copy_dispatch_task (copy_db_consumer &copy_consumer)
+	: m_copy_consumer (copy_consumer)
+        , m_entry_fetcher (*copy_consumer.get_stream ())
+      {
+      }
+
+      void execute (cubthread::entry &thread_ref) override
+      {
+	copy_db_consumer::apply_phase phase = copy_db_consumer::apply_phase::CLASS_SCHEMA;
+
+	er_log_debug_replication (ARG_FILE_LINE, "copy_dispatch_task : start of replication copy");
+
+	while (phase != copy_db_consumer::apply_phase::END)
+	  {
+	    bool is_control_se = false;
+            stream_entry *se = NULL;
+	    int err = m_entry_fetcher.fetch_entry (se);
+	    if (err != NO_ERROR)
+	      {
+		if (err == ER_STREAM_NO_MORE_DATA)
+		  {
+		    ASSERT_ERROR ();
+		    delete se;
+		    break;
+		  }
+		else
+		  {
+		    ASSERT_ERROR ();
+		    // should not happen
+		    assert (false);
+		    break;
+		  }
+	      }
+
+	    m_copy_consumer.m_last_fetched_position = se->get_stream_entry_start_position ();
+
+	    if (is_debug_short_dump_enabled ())
+	      {
+		string_buffer sb;
+		se->stringify (sb, stream_entry::short_dump);
+		_er_log_debug (ARG_FILE_LINE, "copy_dispatch_task \n%s", sb.get_buffer ());
+	      }
+
+	    /* during extract heap phase we may apply objects in parallel, otherwise we wait of all tasks to finish */
+	    if (phase != copy_db_consumer::apply_phase::CLASS_HEAP)
+	      {
+		m_copy_consumer.wait_for_tasks ();
+	      }
+
+	    if (se->is_start_of_extract_heap ())
+	      {
+		phase = copy_db_consumer::apply_phase::CLASS_HEAP;
+		is_control_se = true;
+		er_log_debug_replication (ARG_FILE_LINE, "copy_dispatch_task : receive of start of extract heap phase");
+	      }
+	    else if (se->is_end_of_extract_heap ())
+	      {
+		phase = copy_db_consumer::apply_phase::TRIGGER;
+		is_control_se = true;
+		er_log_debug_replication (ARG_FILE_LINE, "copy_dispatch_task : receive of end of extract heap phase");
+	      }
+	    else if (se->is_end_of_replication_copy ())
+	      {
+		assert (phase != copy_db_consumer::apply_phase::CLASS_HEAP);
+		is_control_se = true;
+		phase = copy_db_consumer::apply_phase::END;
+		er_log_debug_replication (ARG_FILE_LINE, "copy_dispatch_task : receive of end of replication");
+	      }
+
+	    if (is_control_se)
+	      {
+		delete se;
+	      }
+	    else
+	      {
+		copy_db_worker_task *my_copy_db_worker_task = new copy_db_worker_task (se, m_copy_consumer);
+		m_copy_consumer.execute_task (my_copy_db_worker_task, is_debug_detailed_dump_enabled ());
+		/* stream entry is deleted by applier task thread */
+	      }
+	  }
+
+	m_copy_consumer.wait_for_tasks ();
+
+	m_copy_consumer.set_is_finished ();
+	er_log_debug_replication (ARG_FILE_LINE, "copy_dispatch_task finished");
+      }
+
+    private:
+      copy_db_consumer &m_copy_consumer;
+      stream_entry_fetcher m_entry_fetcher;
+  };
+
+  copy_db_consumer::~copy_db_consumer ()
+  {
+    stop ();
+  }
+
+  void copy_db_consumer::start_dispatcher (void)
+  {
+#if defined (SERVER_MODE)
+    er_log_debug_replication (ARG_FILE_LINE, "copy_db_consumer::start_dispatcher\n");
+
+    m_dispatch_workers_pool = cubthread::get_manager ()->create_worker_pool (1, 1, "repl_copy_db_dispatch_pool", NULL,
+			      1, 1);
+
+    cubthread::get_manager ()->push_task (m_dispatch_workers_pool, new copy_dispatch_task (*this));
+#endif /* defined (SERVER_MODE) */
+  }
+
+  void copy_db_consumer::stop_dispatcher (void)
+  {
+    cubthread::get_manager ()->destroy_worker_pool (m_dispatch_workers_pool);
+  }
+
+  void copy_db_consumer::on_task_execution (void)
+  {
+    /* throtle tasks pushing */
+    while (m_started_tasks.load () > 2 * m_applier_worker_threads_count)
+      {
+	thread_sleep (10);
+      }
+  }
+
+} /* namespace cubreplication */

--- a/src/replication/replication_apply_db_copy.cpp
+++ b/src/replication/replication_apply_db_copy.cpp
@@ -197,7 +197,7 @@ namespace cubreplication
 
       void execute (cubthread::entry &thread_ref) final
       {
-	if (locator_repl_start_tran (&thread_ref, DB_CLIENT_TYPE_LOG_APPLIER) != NO_ERROR)
+	if (locator_repl_start_tran (&thread_ref) != NO_ERROR)
 	  {
 	    assert (false);
 	    return;

--- a/src/replication/replication_apply_db_copy.hpp
+++ b/src/replication/replication_apply_db_copy.hpp
@@ -83,7 +83,7 @@ namespace cubreplication
       {
       };
 
-      ~copy_db_consumer ();
+      ~copy_db_consumer () override;
 
       void start_dispatcher (void) override;
       void stop_dispatcher (void) override;

--- a/src/replication/replication_apply_db_copy.hpp
+++ b/src/replication/replication_apply_db_copy.hpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * replication_apply_db_copy.hpp
+ */
+
+#ident "$Id$"
+
+#ifndef _REPLICATION_APPLY_DB_COPY_HPP_
+#define _REPLICATION_APPLY_DB_COPY_HPP_
+
+#include "cubstream.hpp"
+#include "stream_entry_consumer.hpp"
+#include "thread_manager.hpp"
+
+#include <chrono>
+#include <queue>
+
+namespace cubcomm
+{
+  class channel;
+}
+
+namespace cubstream
+{
+  class multi_thread_stream;
+  class stream_file;
+  class transfer_receiver;
+}
+
+namespace cubreplication
+{
+  class node_definition;
+  class copy_db_worker_task;
+  class stream_entry;
+
+  /* TODO : this is copied from log_consumer : refactor */
+  class copy_db_consumer : public cubstream::stream_entry_consumer
+  {
+    public:
+      /* TODO : thread requires a TDES, do we need to increase the number of TDES to account of this ? */
+      static const int MAX_APPLIER_THREADS = 50;
+
+      enum apply_phase
+      {
+	CLASS_SCHEMA,
+	CLASS_HEAP,
+	TRIGGER,
+	INDEX,
+	END
+      };
+
+    private:
+
+      cubthread::entry_workpool *m_dispatch_workers_pool;
+
+      bool m_is_stopped;
+      bool m_is_finished;
+
+    public:
+      copy_db_consumer (const char *name, cubstream::multi_thread_stream *stream, size_t applier_threads)
+	: cubstream::stream_entry_consumer (name, stream, applier_threads)
+	, m_is_stopped (false)
+	, m_is_finished (false)
+	, m_last_fetched_position (0)
+      {
+      };
+
+      ~copy_db_consumer ();
+
+      void start_dispatcher (void) override;
+      void stop_dispatcher (void) override;
+
+      void on_task_execution (void) override;
+
+      bool is_stopping (void)
+      {
+	return m_is_stopped;
+      }
+
+      void set_is_finished ()
+      {
+	m_is_finished = true;
+      }
+
+      bool is_finished ()
+      {
+	return m_is_finished;
+      }
+
+      cubstream::stream_position m_last_fetched_position;
+  };
+
+  class apply_copy_context
+  {
+    public:
+      apply_copy_context (node_definition *myself, node_definition *source_node);
+
+      ~apply_copy_context ();
+
+      int execute_copy ();
+
+      void wait_replication_copy ();
+
+    private:
+
+      int setup_copy_protocol (cubcomm::channel &chn);
+
+      node_definition *m_source_identity;
+      node_definition *m_my_identity;
+
+      cubstream::stream_position m_online_repl_start_pos;
+
+      cubstream::multi_thread_stream *m_stream;
+      cubstream::stream_file *m_stream_file;
+      cubstream::transfer_receiver *m_transfer_receiver;
+      copy_db_consumer *m_copy_consumer;
+
+      std::chrono::system_clock::time_point m_start_time;
+  };
+
+} /* namespace cubreplication */
+
+#endif /* _REPLICATION_APPLY_DB_COPY_HPP_ */

--- a/src/replication/replication_common.cpp
+++ b/src/replication/replication_common.cpp
@@ -18,36 +18,35 @@
  */
 
 /*
- * replication_common.hpp
+ * replication_common.cpp
  */
 
-#ident "$Id$"
-
-#ifndef _REPLICATION_COMMON_HPP_
-#define _REPLICATION_COMMON_HPP_
-
-#include "error_manager.h"
-#include "system_parameter.h"
-#include <string>
-
-#define er_log_debug_replication(...) if (cubreplication::is_debug_process_enabled ()) _er_log_debug(__VA_ARGS__)
+#include "replication_common.hpp"
 
 namespace cubreplication
 {
-  typedef enum
+  const int REPL_DEBUG_PROCESS = 0x001;
+  const int REPL_DEBUG_SHORT_DUMP = 0x002;
+  const int REPL_DEBUG_DETAILED_DUMP = 0x004;
+  const int REPL_DEBUG_COMMUNICATION_DATA_DUMP = 0x010;
+
+  bool is_debug_process_enabled ()
   {
-    REPL_SEMISYNC_ACK_ON_CONSUME,
-    REPL_SEMISYNC_ACK_ON_FLUSH
-  } REPL_SEMISYNC_ACK_MODE;
+    return prm_get_integer_value (PRM_ID_DEBUG_REPLICATION_DATA) & REPL_DEBUG_PROCESS;
+  }
 
-  const std::string REPL_ONLINE_CHANNEL_NAME = "online_replication";
-  const std::string REPL_COPY_CHANNEL_NAME = "copy_db_replication";
-  const std::string REPL_CONTROL_CHANNEL_NAME = "control_replication";
+  bool is_debug_short_dump_enabled ()
+  {
+    return prm_get_integer_value (PRM_ID_DEBUG_REPLICATION_DATA) & REPL_DEBUG_SHORT_DUMP;
+  }
 
-  bool is_debug_process_enabled ();
-  bool is_debug_short_dump_enabled ();
-  bool is_debug_detailed_dump_enabled ();
-  bool is_debug_communication_data_dump_enabled ();
-};
+  bool is_debug_detailed_dump_enabled ()
+  {
+    return prm_get_integer_value (PRM_ID_DEBUG_REPLICATION_DATA) & REPL_DEBUG_DETAILED_DUMP;
+  }
 
-#endif /* _REPLICATION_COMMON_HPP_ */
+  bool is_debug_communication_data_dump_enabled ()
+  {
+    return prm_get_integer_value (PRM_ID_DEBUG_REPLICATION_DATA) & REPL_DEBUG_COMMUNICATION_DATA_DUMP;
+  }
+}

--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -344,7 +344,7 @@ namespace cubreplication
     const sbr_repl_entry *other_t = dynamic_cast<const sbr_repl_entry *> (other);
 
     if (other_t == NULL
-        || m_id != other_t->m_id
+	|| m_id != other_t->m_id
 	|| m_statement != other_t->m_statement
 	|| m_db_user != other_t->m_db_user
 	|| m_sys_prm_context != other_t->m_sys_prm_context)

--- a/src/replication/replication_object.cpp
+++ b/src/replication/replication_object.cpp
@@ -754,7 +754,26 @@ namespace cubreplication
 
   int multirow_object::apply (void)
   {
-    /* TODO[replication] */
+    int err = NO_ERROR;
+
+#if defined (SERVER_MODE)
+    LC_COPYAREA_OPERATION op = LC_FLUSH_INSERT;
+    cubthread::entry &my_thread = cubthread::get_entry ();
+
+    std::vector<int> dummy_int_vector;
+    std::vector<DB_VALUE> dummy_val_vector;
+
+    for (record_descriptor &record : m_rec_des_list)
+      {
+	const RECDES &recdes = record.get_recdes ();
+	/* TODO[replication] : use optimized load into page */
+	err = row_apply_insert (m_class_name, record);
+	if (err != NO_ERROR)
+	  {
+	    return err;
+	  }
+      }
+#endif
     return NO_ERROR;
   }
 

--- a/src/replication/replication_slave_node.cpp
+++ b/src/replication/replication_slave_node.cpp
@@ -197,9 +197,7 @@ namespace cubreplication
 			      start_position);
 
     assert (m_stream != NULL);
-    m_lc = new log_consumer ();
-
-    m_lc->set_stream (m_stream);
+    m_lc = new log_consumer ("online_repl_consumer", m_stream, log_consumer::MAX_APPLIER_THREADS);
 
     if ((REPL_SEMISYNC_ACK_MODE) prm_get_integer_value (PRM_ID_REPL_SEMISYNC_ACK_MODE) ==
 	REPL_SEMISYNC_ACK_ON_FLUSH)
@@ -212,7 +210,7 @@ namespace cubreplication
       }
 
     /* start log_consumer daemons and apply thread pool */
-    m_lc->start_daemons ();
+    m_lc->start ();
 
     cubcomm::server_channel control_chn (m_identity.get_hostname ().c_str ());
     control_chn.set_channel_name (REPL_CONTROL_CHANNEL_NAME);

--- a/src/replication/replication_stream_entry.cpp
+++ b/src/replication/replication_stream_entry.cpp
@@ -120,8 +120,6 @@ namespace cubreplication
   stream_entry::pack_stream_entry_header ()
   {
     cubpacking::packer *serializator = get_packer ();
-    unsigned int count_and_flags;
-    unsigned int state_flags;
 
     assert (check_mvccid_is_valid ());
 
@@ -141,10 +139,8 @@ namespace cubreplication
   stream_entry::unpack_stream_entry_header ()
   {
     cubpacking::unpacker *serializator = get_unpacker ();
-    unsigned int count_and_flags;
-    unsigned int state_flags;
 
-    if (prm_get_bool_value (PRM_ID_DEBUG_REPLICATION_DATA))
+    if (is_debug_detailed_dump_enabled ())
       {
 	string_buffer sb, sb_hex;
 	size_t buf_size = serializator->get_buffer_end () - serializator->get_buffer_start ();

--- a/src/replication/replication_stream_entry.hpp
+++ b/src/replication/replication_stream_entry.hpp
@@ -192,6 +192,21 @@ namespace cubreplication
 
       bool check_mvccid_is_valid () const;
 
+      bool is_start_of_extract_heap (void)
+      {
+	return m_header.tran_state == stream_entry_header::START_OF_EXTRACT_HEAP;
+      }
+
+      bool is_end_of_extract_heap (void)
+      {
+	return m_header.tran_state == stream_entry_header::END_OF_EXTRACT_HEAP;
+      }
+
+      bool is_end_of_replication_copy (void)
+      {
+	return m_header.tran_state == stream_entry_header::END_OF_REPLICATION_COPY;
+      }
+
       int pack_stream_entry_header () override;
       int unpack_stream_entry_header () override;
       int get_packable_entry_count_from_header (void) override;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4429,8 +4429,8 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 			    {
 			      /* Disable row replication: SM_FOREIGN_KEY_CASCADE constraint from slave will make sure
 			       * these changes are replicated */
-			      logtb_get_tdes (thread_p)->get_replication_generator ().
-				set_row_replication_disabled (true);
+			      logtb_get_tdes (thread_p)->
+				get_replication_generator ().set_row_replication_disabled (true);
 			      disabled_row_replication = true;
 			    }
 			}
@@ -7571,8 +7571,8 @@ end:
 	    {
 	      /* Aborts and simulate apply replication RBR on master node. */
 	      error_code =
-		logtb_get_tdes (thread_p)->get_replication_generator ().
-		abort_sysop_and_simulate_apply_repl_rbr_on_master (filter_replication_lsa);
+		logtb_get_tdes (thread_p)->
+		get_replication_generator ().abort_sysop_and_simulate_apply_repl_rbr_on_master (filter_replication_lsa);
 	    }
 	  else
 	    {

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4429,8 +4429,8 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 			    {
 			      /* Disable row replication: SM_FOREIGN_KEY_CASCADE constraint from slave will make sure
 			       * these changes are replicated */
-			      logtb_get_tdes (thread_p)->
-				get_replication_generator ().set_row_replication_disabled (true);
+			      logtb_get_tdes (thread_p)->get_replication_generator ().
+				set_row_replication_disabled (true);
 			      disabled_row_replication = true;
 			    }
 			}
@@ -7571,8 +7571,8 @@ end:
 	    {
 	      /* Aborts and simulate apply replication RBR on master node. */
 	      error_code =
-		logtb_get_tdes (thread_p)->
-		get_replication_generator ().abort_sysop_and_simulate_apply_repl_rbr_on_master (filter_replication_lsa);
+		logtb_get_tdes (thread_p)->get_replication_generator ().
+		abort_sysop_and_simulate_apply_repl_rbr_on_master (filter_replication_lsa);
 	    }
 	  else
 	    {
@@ -14057,7 +14057,7 @@ locator_repl_start_tran (THREAD_ENTRY * thread_p)
   /* TODO */
   int error_code = NO_ERROR;
   BOOT_CLIENT_CREDENTIAL applier_Client_credentials;
-  applier_Client_credentials.client_type = DB_CLIENT_TYPE_LOG_APPLIER;;
+  applier_Client_credentials.client_type = DB_CLIENT_TYPE_LOG_APPLIER;
   applier_Client_credentials.program_name = "(repl_applier)";
   applier_Client_credentials.process_id = -1;
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -60,7 +60,6 @@
 #include "process_util.h"
 #include "replication_common.hpp"
 #include "replication_object.hpp"
-#include "replication_source_db_copy.hpp"
 #include "session.h"
 #include "slotted_page.h"
 #include "string_buffer.hpp"

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -14052,23 +14052,13 @@ locator_repl_extract_schema (THREAD_ENTRY * thread_p, const char *db_user, const
 }
 
 int
-locator_repl_start_tran (THREAD_ENTRY * thread_p, const db_client_type client_type)
+locator_repl_start_tran (THREAD_ENTRY * thread_p)
 {
   /* TODO */
   int error_code = NO_ERROR;
   BOOT_CLIENT_CREDENTIAL applier_Client_credentials;
-
-  applier_Client_credentials.client_type = client_type;
-
-  if (client_type == DB_CLIENT_TYPE_DDL_PROXY)
-    {
-      applier_Client_credentials.program_name = "(ddl_proxy)";
-    }
-  else if (client_type == DB_CLIENT_TYPE_LOG_APPLIER)
-    {
-      applier_Client_credentials.program_name = "(repl_applier)";
-    }
-
+  applier_Client_credentials.client_type = DB_CLIENT_TYPE_LOG_APPLIER;;
+  applier_Client_credentials.program_name = "(repl_applier)";
   applier_Client_credentials.process_id = -1;
 
   int client_lock_wait = TRAN_LOCK_INFINITE_WAIT;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -60,6 +60,7 @@
 #include "process_util.h"
 #include "replication_common.hpp"
 #include "replication_object.hpp"
+#include "replication_source_db_copy.hpp"
 #include "session.h"
 #include "slotted_page.h"
 #include "string_buffer.hpp"
@@ -14051,13 +14052,23 @@ locator_repl_extract_schema (THREAD_ENTRY * thread_p, const char *db_user, const
 }
 
 int
-locator_repl_start_tran (THREAD_ENTRY * thread_p)
+locator_repl_start_tran (THREAD_ENTRY * thread_p, const db_client_type client_type)
 {
   /* TODO */
   int error_code = NO_ERROR;
   BOOT_CLIENT_CREDENTIAL applier_Client_credentials;
-  applier_Client_credentials.client_type = DB_CLIENT_TYPE_LOG_APPLIER;
-  applier_Client_credentials.program_name = "(repl_applier)";
+
+  applier_Client_credentials.client_type = client_type;
+
+  if (client_type == DB_CLIENT_TYPE_DDL_PROXY)
+    {
+      applier_Client_credentials.program_name = "(ddl_proxy)";
+    }
+  else if (client_type == DB_CLIENT_TYPE_LOG_APPLIER)
+    {
+      applier_Client_credentials.program_name = "(repl_applier)";
+    }
+
   applier_Client_credentials.process_id = -1;
 
   int client_lock_wait = TRAN_LOCK_INFINITE_WAIT;

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -146,7 +146,7 @@ extern int locator_repl_apply_sbr (THREAD_ENTRY * thread_p, const char *db_user,
 				   const char *statement);
 
 extern int locator_repl_extract_schema (THREAD_ENTRY * thread_p, const char *db_user, const char *ha_sys_prm_context);
-extern int locator_repl_start_tran (THREAD_ENTRY * thread_p, const db_client_type client_type);
+extern int locator_repl_start_tran (THREAD_ENTRY * thread_p);
 extern int locator_repl_end_tran (THREAD_ENTRY * thread_p, bool commit);
 
  // *INDENT-OFF*

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -146,7 +146,7 @@ extern int locator_repl_apply_sbr (THREAD_ENTRY * thread_p, const char *db_user,
 				   const char *statement);
 
 extern int locator_repl_extract_schema (THREAD_ENTRY * thread_p, const char *db_user, const char *ha_sys_prm_context);
-extern int locator_repl_start_tran (THREAD_ENTRY * thread_p);
+extern int locator_repl_start_tran (THREAD_ENTRY * thread_p, const db_client_type client_type);
 extern int locator_repl_end_tran (THREAD_ENTRY * thread_p, bool commit);
 
  // *INDENT-OFF*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23223

Partial refactoring of log_consumer with copy db consumer:
 - added stream_entry_consumer as abstract class : contains stream pointer (provided as agument to contructor) and a apply worker pool
 - TODO (future PR) : apply worker task and dispatcher (hopefully as an object)
 - TODO (future PR) : stream_fetcher is an object insde the dispatcher task, it is difficult to have a generic dispatcher; it is also difficult to manage stream_fetcher life time outside of dispatcher
 - TODO (future PR) : log_consumer will be renamed as repl_online_consumer (its source files also)
 
Replication apply code:
 - copy db consumer is similar to log_consumer; a major difference is the dispather : in copy db consumer, it is a short lived thread task (it uses a worker pool, instead of deamon)
 - added code for multirow_object::apply
 - added new stream entry types to detect phases of copy data
 - table schema are applied on single thread; heap loading and index creation uses multiple threads (heap loading is limited by pre-existing PK)
 - TODO (future PR) : primary key are created with table; an optimization would be to first create table without PK and include PK as constraint after loading heap data

System parameter:
 - system parameter 'debug_replication_data' changed from bool to int (bit field);