### PR TITLE
[CBRD-23217] use ext mem block for log postpone cache entry

### DIFF
--- a/src/transaction/log_postpone_cache.cpp
+++ b/src/transaction/log_postpone_cache.cpp
@@ -23,7 +23,6 @@
 
 #include "log_postpone_cache.hpp"
 
-#include "log_record.hpp"
 #include "memory_alloc.h"
 #include "object_representation.h"
 #include "log_manager.h"

--- a/src/transaction/log_postpone_cache.cpp
+++ b/src/transaction/log_postpone_cache.cpp
@@ -29,11 +29,9 @@
 #include "log_manager.h"
 
 void
-log_postpone_cache::clear ()
+log_postpone_cache::reset ()
 {
-  m_redo_data_ptr = NULL;
-  m_cache_entries_cursor = 0;
-  m_cache_status = LOG_POSTPONE_CACHE_NO;
+  m_cursor = 0;
 }
 
 /**
@@ -47,63 +45,27 @@ log_postpone_cache::add_redo_data (const log_prior_node &node)
 {
   assert (node.data_header != NULL);
   assert (node.rlength == 0 || node.rdata != NULL);
+  assert (m_cursor <= MAX_CACHE_ENTRIES);
 
-  if (m_cache_status == LOG_POSTPONE_CACHE_OVERFLOW)
+  if (is_full ())
     {
-      // Cannot cache postpones
-      return;
-    }
-
-  if (m_cache_status == LOG_POSTPONE_CACHE_NO)
-    {
-      // Initialize data to cache postpones
-      m_cache_entries_cursor = 0;
-      m_redo_data_ptr = m_redo_data_buf;
-      m_cache_status = LOG_POSTPONE_CACHE_YES;
-    }
-
-  assert (m_cache_entries_cursor <= MAX_CACHE_ENTRIES);
-  assert (m_redo_data_ptr != NULL);
-  assert (m_redo_data_ptr >= m_redo_data_buf);
-  assert ((std::size_t) (m_redo_data_ptr - m_redo_data_buf) <= REDO_DATA_SIZE);
-  ASSERT_ALIGN (m_redo_data_ptr, MAX_ALIGNMENT);
-
-  if (m_cache_entries_cursor == MAX_CACHE_ENTRIES)
-    {
-      // Could not store all postpone records
-      m_cache_status = LOG_POSTPONE_CACHE_OVERFLOW;
-      return;
-    }
-
-  // Check if recovery data fits in preallocated buffer
-  std::size_t total_data_size = m_redo_data_ptr - m_redo_data_buf;
-  total_data_size += sizeof (log_rec_redo);
-  total_data_size += node.rlength;
-  total_data_size += 2 * MAX_ALIGNMENT;
-  if (total_data_size > REDO_DATA_SIZE)
-    {
-      // Cannot store all recovery data
-      m_cache_status = LOG_POSTPONE_CACHE_OVERFLOW;
+      // Cannot cache postpones, cache reached max capacity
       return;
     }
 
   // Cache a new postpone log record entry
-  cache_entry *new_entry = &m_cache_entries[m_cache_entries_cursor];
-  new_entry->m_redo_data = m_redo_data_ptr;
+  cache_entry *new_entry = &m_cache_entries[m_cursor];
   new_entry->m_lsa.set_null ();
 
   // Cache log_rec_redo from data_header
-  memcpy (m_redo_data_ptr, node.data_header, sizeof (log_rec_redo));
-  m_redo_data_ptr += sizeof (log_rec_redo);
-  m_redo_data_ptr = PTR_ALIGN (m_redo_data_ptr, MAX_ALIGNMENT);
+  memcpy (new_entry->m_data_header, node.data_header, sizeof (log_rec_redo));
 
   // Cache recovery data
   assert (((log_rec_redo *) node.data_header)->length == node.rlength);
   if (node.rlength > 0)
     {
-      memcpy (m_redo_data_ptr, node.rdata, node.rlength);
-      m_redo_data_ptr += node.rlength;
-      m_redo_data_ptr = PTR_ALIGN (m_redo_data_ptr, MAX_ALIGNMENT);
+      new_entry->m_redo_data.extend_to (node.rlength);
+      memcpy (new_entry->m_redo_data.get_ptr (), node.rdata, node.rlength);
     }
 }
 
@@ -120,20 +82,19 @@ void
 log_postpone_cache::add_lsa (const log_lsa &lsa)
 {
   assert (!lsa.is_null ());
-  assert (m_cache_status != LOG_POSTPONE_CACHE_NO);
 
-  if (m_cache_status == LOG_POSTPONE_CACHE_OVERFLOW)
+  if (is_full ())
     {
       return;
     }
 
-  assert (m_cache_entries_cursor < MAX_CACHE_ENTRIES);
+  assert (m_cursor < MAX_CACHE_ENTRIES);
 
-  cache_entry *new_entry = &m_cache_entries[m_cache_entries_cursor];
+  cache_entry *new_entry = &m_cache_entries[m_cursor];
   new_entry->m_lsa = lsa;
 
   /* Now that all needed data is saved, increment cached entries counter. */
-  m_cache_entries_cursor++;
+  m_cursor++;
 }
 
 /**
@@ -147,18 +108,17 @@ bool
 log_postpone_cache::do_postpone (cubthread::entry &thread_ref, const log_lsa &start_postpone_lsa)
 {
   assert (!start_postpone_lsa.is_null ());
-  assert (m_cache_status != LOG_POSTPONE_CACHE_NO);
 
-  if (m_cache_status == LOG_POSTPONE_CACHE_OVERFLOW)
+  if (is_full ())
     {
       // Cache is not usable
-      m_cache_status = LOG_POSTPONE_CACHE_NO;
+      reset ();
       return false;
     }
 
   // First cached postpone entry at start_postpone_lsa
   int start_index = -1;
-  for (std::size_t i = 0; i < m_cache_entries_cursor; ++i)
+  for (std::size_t i = 0; i < m_cursor; ++i)
     {
       if (m_cache_entries[i].m_lsa == start_postpone_lsa)
 	{
@@ -176,31 +136,25 @@ log_postpone_cache::do_postpone (cubthread::entry &thread_ref, const log_lsa &st
     }
 
   // Run all postpones after start_index
-  for (std::size_t i = start_index; i < m_cache_entries_cursor; ++i)
+  for (std::size_t i = start_index; i < m_cursor; ++i)
     {
       cache_entry *entry = &m_cache_entries[i];
 
       // Get redo data header
-      log_rec_redo *redo = (log_rec_redo *) entry->m_redo_data;
+      log_rec_redo *redo = (log_rec_redo *) entry->m_data_header;
 
       // Get recovery data
-      char *rcv_data = entry->m_redo_data + sizeof (log_rec_redo);
-      rcv_data = PTR_ALIGN (rcv_data, MAX_ALIGNMENT);
-      (void) log_execute_run_postpone (&thread_ref, &entry->m_lsa, redo, rcv_data);
+      (void) log_execute_run_postpone (&thread_ref, &entry->m_lsa, redo, entry->m_redo_data.get_ptr ());
     }
 
-  // Finished running postpones
-  if (start_index == 0)
-    {
-      // All postpone entries were run
-      m_cache_status = LOG_POSTPONE_CACHE_NO;
-    }
-  else
-    {
-      // Only some postpone entries were run. Update the number of entries which should be run on next commit
-      m_cache_entries_cursor = start_index;
-      m_redo_data_ptr = m_cache_entries[start_index].m_redo_data;
-    }
+  // Finished running postpones, update the number of entries which should be run on next commit
+  m_cursor = start_index;
 
   return true;
+}
+
+bool
+log_postpone_cache::is_full () const
+{
+  return m_cursor == MAX_CACHE_ENTRIES;
 }

--- a/src/transaction/log_postpone_cache.cpp
+++ b/src/transaction/log_postpone_cache.cpp
@@ -131,7 +131,6 @@ log_postpone_cache::do_postpone (cubthread::entry &thread_ref, const log_lsa &st
   if (start_index < 0)
     {
       // Start LSA was not found. Unexpected situation
-      assert (false);
       return false;
     }
 

--- a/src/transaction/log_postpone_cache.hpp
+++ b/src/transaction/log_postpone_cache.hpp
@@ -48,7 +48,10 @@ class log_postpone_cache
 {
   public:
     log_postpone_cache ()
-      : m_cursor (0)
+      : m_redo_data_buf ()
+      , m_redo_data_offset (0)
+      , m_is_redo_data_buf_full (false)
+      , m_cursor (0)
       , m_cache_entries ()
     {
     }
@@ -69,22 +72,26 @@ class log_postpone_cache
 
   private:
     static const std::size_t MAX_CACHE_ENTRIES = 512;
+    // on average redo data size for an entry is 48 bytes
+    static const std::size_t REDO_DATA_MAX_SIZE = 48 * MAX_CACHE_ENTRIES;
 
     class cache_entry
     {
       public:
 	cache_entry ()
 	  : m_lsa ()
-	  , m_data_header {}
-	  , m_redo_data ()
+	  , m_offset (0)
 	{
 	  m_lsa.set_null ();
 	}
 
 	log_lsa m_lsa;
-	char m_data_header[sizeof (log_rec_redo)];
-	cubmem::extensible_block m_redo_data;
+	std::size_t m_offset;
     };
+
+    cubmem::extensible_block m_redo_data_buf;
+    std::size_t m_redo_data_offset;
+    bool m_is_redo_data_buf_full;
 
     std::size_t m_cursor;
     std::array<cache_entry, MAX_CACHE_ENTRIES> m_cache_entries;

--- a/src/transaction/log_postpone_cache.hpp
+++ b/src/transaction/log_postpone_cache.hpp
@@ -25,6 +25,8 @@
 #define _LOG_POSTPONE_CACHE_HPP_
 
 #include "log_lsa.hpp"
+#include "log_record.hpp"
+#include "mem_block.hpp"
 #include "storage_common.h"
 
 #include <array>
@@ -46,13 +48,9 @@ class log_postpone_cache
 {
   public:
     log_postpone_cache ()
-      : m_redo_data_buf (NULL)
-      , m_redo_data_ptr (NULL)
-      , m_cache_status (LOG_POSTPONE_CACHE_NO)
-      , m_cache_entries_cursor (0)
+      : m_cursor (0)
       , m_cache_entries ()
     {
-      m_redo_data_buf = new char[REDO_DATA_SIZE];
     }
 
     log_postpone_cache (log_postpone_cache &&other) = delete;
@@ -61,19 +59,15 @@ class log_postpone_cache
     log_postpone_cache &operator= (log_postpone_cache &&other) = delete;
     log_postpone_cache &operator= (const log_postpone_cache &other) = delete;
 
-    ~log_postpone_cache ()
-    {
-      delete [] m_redo_data_buf;
-    }
+    ~log_postpone_cache () = default;
 
-    void clear ();
+    void reset ();
 
     void add_redo_data (const log_prior_node &node);
     void add_lsa (const log_lsa &lsa);
     bool do_postpone (cubthread::entry &thread_ref, const log_lsa &start_postpone_lsa);
 
   private:
-    static const std::size_t REDO_DATA_SIZE = IO_MAX_PAGE_SIZE;
     static const std::size_t MAX_CACHE_ENTRIES = 512;
 
     class cache_entry
@@ -81,29 +75,21 @@ class log_postpone_cache
       public:
 	cache_entry ()
 	  : m_lsa ()
-	  , m_redo_data (NULL)
+	  , m_data_header {}
+	  , m_redo_data ()
 	{
 	  m_lsa.set_null ();
 	}
 
 	log_lsa m_lsa;
-	char *m_redo_data;
+	char m_data_header[sizeof (log_rec_redo)];
+	cubmem::extensible_block m_redo_data;
     };
 
-    enum cache_status
-    {
-      LOG_POSTPONE_CACHE_NO,
-      LOG_POSTPONE_CACHE_YES,
-      LOG_POSTPONE_CACHE_OVERFLOW
-    };
-
-    char *m_redo_data_buf;
-    char *m_redo_data_ptr;
-
-    cache_status m_cache_status;
-
-    std::size_t m_cache_entries_cursor;
+    std::size_t m_cursor;
     std::array<cache_entry, MAX_CACHE_ENTRIES> m_cache_entries;
+
+    bool is_full () const;
 };
 
 #endif /* _LOG_POSTPONE_CACHE_HPP_ */

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -877,7 +877,7 @@ logtb_set_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const BOOT_CLIENT_CRED
   tdes->num_transient_classnames = 0;
   tdes->first_save_entry = NULL;
   tdes->lob_locator_root.init ();
-  tdes->m_log_postpone_cache.clear ();
+  tdes->m_log_postpone_cache.reset ();
 }
 
 /*
@@ -1563,7 +1563,7 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   tdes->tran_abort_reason = TRAN_NORMAL;
   tdes->num_exec_queries = 0;
   tdes->suppress_replication = 0;
-  tdes->m_log_postpone_cache.clear ();
+  tdes->m_log_postpone_cache.reset ();
 
   logtb_tran_clear_update_stats (&tdes->log_upd_stats);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23217

Refactor log postpone cache to use extensible memory block as redo data container