### PR TITLE
[CBRD-23201] Added the classname to the hfid cache

### DIFF
--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2726,7 +2726,7 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
   heap_scancache_end (thread_p, &scan_cache);
   scan_cache_inited = false;
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL, false, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL, NULL);
   if (error != NO_ERROR)
     {
       goto end;

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2726,7 +2726,7 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
   heap_scancache_end (thread_p, &scan_cache);
   scan_cache_inited = false;
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL, false, NULL);
   if (error != NO_ERROR)
     {
       goto end;

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2726,7 +2726,7 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
   heap_scancache_end (thread_p, &scan_cache);
   scan_cache_inited = false;
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL, NULL);
+  error = heap_get_class_info (thread_p, class_oid, &hfid, NULL, NULL);
   if (error != NO_ERROR)
     {
       goto end;

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2726,7 +2726,7 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
   heap_scancache_end (thread_p, &scan_cache);
   scan_cache_inited = false;
 
-  error = heap_get_hfid_from_class_oid (thread_p, class_oid, &hfid);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL);
   if (error != NO_ERROR)
     {
       goto end;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2407,7 +2407,7 @@ vacuum_heap_get_hfid_and_file_type (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER 
   assert (!OID_ISNULL (&class_oid));
 
   /* Get HFID for class OID. */
-  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &helper->hfid, &ftype, NULL);
+  error_code = heap_get_class_info (thread_p, &class_oid, &helper->hfid, &ftype, NULL);
   if (error_code == ER_HEAP_UNKNOWN_OBJECT)
     {
       FILE_DESCRIPTORS file_descriptor;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2407,7 +2407,7 @@ vacuum_heap_get_hfid_and_file_type (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER 
   assert (!OID_ISNULL (&class_oid));
 
   /* Get HFID for class OID. */
-  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &helper->hfid, &ftype, false, NULL);
+  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &helper->hfid, &ftype, NULL);
   if (error_code == ER_HEAP_UNKNOWN_OBJECT)
     {
       FILE_DESCRIPTORS file_descriptor;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2407,7 +2407,7 @@ vacuum_heap_get_hfid_and_file_type (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER 
   assert (!OID_ISNULL (&class_oid));
 
   /* Get HFID for class OID. */
-  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &helper->hfid, &ftype);
+  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &helper->hfid, &ftype, false, NULL);
   if (error_code == ER_HEAP_UNKNOWN_OBJECT)
     {
       FILE_DESCRIPTORS file_descriptor;

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -4577,7 +4577,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
   scan_cache_inited = false;
 
   /* read values of the single record in heap */
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, NULL);
+  error = heap_get_class_info (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;
@@ -5019,7 +5019,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
   scan_cache_inited = false;
 
   /* read values of all records in heap */
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, NULL);
+  error = heap_get_class_info (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;
@@ -5240,7 +5240,7 @@ catcls_get_apply_info_log_record_time (THREAD_ENTRY * thread_p, time_t * log_rec
   heap_scancache_end (thread_p, &scan_cache);
   scan_cache_inited = false;
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, NULL);
+  error = heap_get_class_info (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -4577,7 +4577,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
   scan_cache_inited = false;
 
   /* read values of the single record in heap */
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, false, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;
@@ -5019,7 +5019,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
   scan_cache_inited = false;
 
   /* read values of all records in heap */
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, false, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;
@@ -5240,7 +5240,7 @@ catcls_get_apply_info_log_record_time (THREAD_ENTRY * thread_p, time_t * log_rec
   heap_scancache_end (thread_p, &scan_cache);
   scan_cache_inited = false;
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, false, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -4577,7 +4577,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
   scan_cache_inited = false;
 
   /* read values of the single record in heap */
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, false, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;
@@ -5019,7 +5019,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
   scan_cache_inited = false;
 
   /* read values of all records in heap */
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, false, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;
@@ -5240,7 +5240,7 @@ catcls_get_apply_info_log_record_time (THREAD_ENTRY * thread_p, time_t * log_rec
   heap_scancache_end (thread_p, &scan_cache);
   scan_cache_inited = false;
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL, false, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -4577,7 +4577,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
   scan_cache_inited = false;
 
   /* read values of the single record in heap */
-  error = heap_get_hfid_from_class_oid (thread_p, &class_oid, &hfid);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;
@@ -5019,7 +5019,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
   scan_cache_inited = false;
 
   /* read values of all records in heap */
-  error = heap_get_hfid_from_class_oid (thread_p, &class_oid, &hfid);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;
@@ -5240,7 +5240,7 @@ catcls_get_apply_info_log_record_time (THREAD_ENTRY * thread_p, time_t * log_rec
   heap_scancache_end (thread_p, &scan_cache);
   scan_cache_inited = false;
 
-  error = heap_get_hfid_from_class_oid (thread_p, &class_oid, &hfid);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &class_oid, &hfid, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       error = ER_FAILED;

--- a/src/storage/compactdb_sr.c
+++ b/src/storage/compactdb_sr.c
@@ -572,7 +572,7 @@ boot_compact_db (THREAD_ENTRY * thread_p, OID * class_oids, int n_classes, int s
 	  continue;
 	}
 
-      if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oids + i, &hfid, NULL, NULL) != NO_ERROR)
+      if (heap_get_class_info (thread_p, class_oids + i, &hfid, NULL, NULL) != NO_ERROR)
 	{
 	  lock_unlock_object (thread_p, class_oids + i, oid_Root_class_oid, IX_LOCK, true);
 	  OID_SET_NULL (last_processed_oid);

--- a/src/storage/compactdb_sr.c
+++ b/src/storage/compactdb_sr.c
@@ -572,7 +572,7 @@ boot_compact_db (THREAD_ENTRY * thread_p, OID * class_oids, int n_classes, int s
 	  continue;
 	}
 
-      if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oids + i, &hfid, NULL, false, NULL) != NO_ERROR)
+      if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oids + i, &hfid, NULL, NULL) != NO_ERROR)
 	{
 	  lock_unlock_object (thread_p, class_oids + i, oid_Root_class_oid, IX_LOCK, true);
 	  OID_SET_NULL (last_processed_oid);

--- a/src/storage/compactdb_sr.c
+++ b/src/storage/compactdb_sr.c
@@ -572,7 +572,7 @@ boot_compact_db (THREAD_ENTRY * thread_p, OID * class_oids, int n_classes, int s
 	  continue;
 	}
 
-      if (heap_get_hfid_from_class_oid (thread_p, class_oids + i, &hfid) != NO_ERROR)
+      if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oids + i, &hfid, NULL) != NO_ERROR)
 	{
 	  lock_unlock_object (thread_p, class_oids + i, oid_Root_class_oid, IX_LOCK, true);
 	  OID_SET_NULL (last_processed_oid);

--- a/src/storage/compactdb_sr.c
+++ b/src/storage/compactdb_sr.c
@@ -572,7 +572,7 @@ boot_compact_db (THREAD_ENTRY * thread_p, OID * class_oids, int n_classes, int s
 	  continue;
 	}
 
-      if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oids + i, &hfid, NULL) != NO_ERROR)
+      if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oids + i, &hfid, NULL, false, NULL) != NO_ERROR)
 	{
 	  lock_unlock_object (thread_p, class_oids + i, oid_Root_class_oid, IX_LOCK, true);
 	  OID_SET_NULL (last_processed_oid);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -23209,6 +23209,7 @@ heap_cache_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hf
   HEAP_HFID_TABLE_ENTRY *entry = NULL;
   HFID hfid_local = HFID_INITIALIZER;
   char *classname_local;
+  int inserted = 0;
 
   assert (hfid != NULL && !HFID_IS_NULL (hfid));
   assert (ftype == FILE_HEAP || ftype == FILE_HEAP_REUSE_SLOTS);
@@ -23220,13 +23221,14 @@ heap_cache_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hf
     }
 
   error_code =
-    lf_hash_find_or_insert (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, (void **) &entry, NULL);
+    lf_hash_find_or_insert (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, (void **) &entry, &inserted);
   if (error_code != NO_ERROR)
     {
       return error_code;
     }
   assert (entry != NULL);
   assert (entry->hfid.hpgid == NULL_PAGEID);
+  assert ((inserted == 1) || entry->classname != NULL);
 
   HFID_COPY (&entry->hfid, hfid);
   if (classname_in != NULL)
@@ -23283,17 +23285,20 @@ heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid
   LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_HFID_TABLE);
   HEAP_HFID_TABLE_ENTRY *entry = NULL;
   char *classname_local = NULL;
+  int inserted = 0;
 
   assert (class_oid != NULL && !OID_ISNULL (class_oid));
 
   error_code =
-    lf_hash_find_or_insert (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, (void **) &entry, NULL);
+    lf_hash_find_or_insert (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, (void **) &entry, &inserted);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
       return error_code;
     }
   assert (entry != NULL);
+
+  assert ((inserted == 1) || entry->classname != NULL);
 
 
   if (entry->hfid.hpgid == NULL_PAGEID || entry->hfid.vfid.fileid == NULL_FILEID

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -22890,6 +22890,14 @@ heap_hfid_table_entry_free (void *entry)
 {
   if (entry != NULL)
     {
+      HEAP_HFID_TABLE_ENTRY *entry_p = (HEAP_HFID_TABLE_ENTRY *) entry;
+      if (entry_p != NULL)
+	{
+	  // Clear the classname.
+	  free (entry_p->classname);
+	  entry_p->classname = NULL;
+	}
+
       free (entry);
       return NO_ERROR;
     }
@@ -22920,6 +22928,7 @@ heap_hfid_table_entry_init (void *entry)
   entry_p->hfid.vfid.volid = NULL_VOLID;
   entry_p->hfid.hpgid = NULL_PAGEID;
   entry_p->ftype = FILE_UNKNOWN_TYPE;
+  entry_p->classname = NULL;
 
   return NO_ERROR;
 }
@@ -23271,7 +23280,7 @@ heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid
 
 
   if (entry->hfid.hpgid == NULL_PAGEID || entry->hfid.vfid.fileid == NULL_FILEID
-      || entry->hfid.vfid.volid == NULL_VOLID)
+      || entry->hfid.vfid.volid == NULL_VOLID || entry->classname == NULL)
     {
       HFID hfid_local = HFID_INITIALIZER;
 

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -202,6 +202,7 @@ struct heap_hfid_table_entry
 
   HFID hfid;			/* value - HFID */
   FILE_TYPE ftype;		/* value - FILE_HEAP or FILE_HEAP_REUSE_SLOTS */
+  char *classname;		/* Also cache the classname. */
 };
 
 // forward declaration

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -202,7 +202,7 @@ struct heap_hfid_table_entry
 
   HFID hfid;			/* value - HFID */
   FILE_TYPE ftype;		/* value - FILE_HEAP or FILE_HEAP_REUSE_SLOTS */
-  char *classname;		/* Also cache the classname. */
+    std::atomic < char *>classname;	/* Also cache the classname. */
 };
 
 // forward declaration
@@ -571,10 +571,10 @@ extern void heap_rv_dump_reuse_page (FILE * fp, int ignore_length, void *data);
 extern int heap_rv_mark_deleted_on_undo (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int heap_rv_mark_deleted_on_postpone (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 
-extern int heap_get_hfid_and_file_type_from_class_oid (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out,
-						       FILE_TYPE * ftype_out, char *classname_out);
-extern int heap_insert_hfid_for_class_oid (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid,
-					   FILE_TYPE ftype, char *classname_in);
+extern int heap_get_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out,
+				FILE_TYPE * ftype_out, char *classname_out);
+extern int heap_cache_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid,
+				  FILE_TYPE ftype, const char *classname_in);
 extern int heap_compact_pages (THREAD_ENTRY * thread_p, OID * class_oid);
 
 extern void heap_classrepr_dump_all (THREAD_ENTRY * thread_p, FILE * fp, OID * class_oid);

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -572,7 +572,7 @@ extern int heap_rv_mark_deleted_on_undo (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 extern int heap_rv_mark_deleted_on_postpone (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 
 extern int heap_get_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out,
-				FILE_TYPE * ftype_out, char *classname_out);
+				FILE_TYPE * ftype_out, char **classname_out);
 extern int heap_cache_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid,
 				  FILE_TYPE ftype, const char *classname_in);
 extern int heap_compact_pages (THREAD_ENTRY * thread_p, OID * class_oid);

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -571,7 +571,6 @@ extern void heap_rv_dump_reuse_page (FILE * fp, int ignore_length, void *data);
 extern int heap_rv_mark_deleted_on_undo (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int heap_rv_mark_deleted_on_postpone (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 
-extern int heap_get_hfid_from_class_oid (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid);
 extern int heap_get_hfid_and_file_type_from_class_oid (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out,
 						       FILE_TYPE * ftype_out);
 extern int heap_insert_hfid_for_class_oid (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid,

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -202,7 +202,9 @@ struct heap_hfid_table_entry
 
   HFID hfid;			/* value - HFID */
   FILE_TYPE ftype;		/* value - FILE_HEAP or FILE_HEAP_REUSE_SLOTS */
-    std::atomic < char *>classname;	/* Also cache the classname. */
+// *INDENT-OFF*
+  std::atomic<char*> classname;	/* Also cache the classname. */
+// *INDENT-ON*
 };
 
 // forward declaration

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -572,9 +572,9 @@ extern int heap_rv_mark_deleted_on_undo (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 extern int heap_rv_mark_deleted_on_postpone (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 
 extern int heap_get_hfid_and_file_type_from_class_oid (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out,
-						       FILE_TYPE * ftype_out, bool get_classname, char *classname_out);
+						       FILE_TYPE * ftype_out, char *classname_out);
 extern int heap_insert_hfid_for_class_oid (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid,
-					   FILE_TYPE ftype);
+					   FILE_TYPE ftype, char *classname_in);
 extern int heap_compact_pages (THREAD_ENTRY * thread_p, OID * class_oid);
 
 extern void heap_classrepr_dump_all (THREAD_ENTRY * thread_p, FILE * fp, OID * class_oid);

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -572,7 +572,7 @@ extern int heap_rv_mark_deleted_on_undo (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 extern int heap_rv_mark_deleted_on_postpone (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 
 extern int heap_get_hfid_and_file_type_from_class_oid (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out,
-						       FILE_TYPE * ftype_out);
+						       FILE_TYPE * ftype_out, bool get_classname, char *classname_out);
 extern int heap_insert_hfid_for_class_oid (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid,
 					   FILE_TYPE ftype);
 extern int heap_compact_pages (THREAD_ENTRY * thread_p, OID * class_oid);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -12077,7 +12077,7 @@ pgbuf_get_groupid_and_unfix (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAG
     }
   else
     {
-      er_status = heap_get_hfid_and_file_type_from_class_oid (thread_p, &cls_oid, &hfid, NULL, NULL);
+      er_status = heap_get_class_info (thread_p, &cls_oid, &hfid, NULL, NULL);
     }
 
   if (er_status == NO_ERROR)

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -12077,7 +12077,7 @@ pgbuf_get_groupid_and_unfix (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAG
     }
   else
     {
-      er_status = heap_get_hfid_and_file_type_from_class_oid (thread_p, &cls_oid, &hfid, NULL, false, NULL);
+      er_status = heap_get_hfid_and_file_type_from_class_oid (thread_p, &cls_oid, &hfid, NULL, NULL);
     }
 
   if (er_status == NO_ERROR)

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -12077,7 +12077,7 @@ pgbuf_get_groupid_and_unfix (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAG
     }
   else
     {
-      er_status = heap_get_hfid_and_file_type_from_class_oid (thread_p, &cls_oid, &hfid, NULL);
+      er_status = heap_get_hfid_and_file_type_from_class_oid (thread_p, &cls_oid, &hfid, NULL, false, NULL);
     }
 
   if (er_status == NO_ERROR)

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -12077,7 +12077,7 @@ pgbuf_get_groupid_and_unfix (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAG
     }
   else
     {
-      er_status = heap_get_hfid_from_class_oid (thread_p, &cls_oid, &hfid);
+      er_status = heap_get_hfid_and_file_type_from_class_oid (thread_p, &cls_oid, &hfid, NULL);
     }
 
   if (er_status == NO_ERROR)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3432,7 +3432,7 @@ xboot_checkdb_table (THREAD_ENTRY * thread_p, int check_flag, OID * oid, BTID * 
 	}
     }
 
-  if (heap_get_hfid_from_class_oid (thread_p, oid, &hfid) != NO_ERROR || HFID_IS_NULL (&hfid))
+  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, oid, &hfid, NULL) != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       return DISK_ERROR;
     }

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2383,7 +2383,8 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     }
   /* we need to manually add root class HFID to cache */
   error_code =
-    heap_insert_hfid_for_class_oid (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP);
+    heap_insert_hfid_for_class_oid (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP,
+				    boot_Db_parm->rootclass_name);
   if (error_code != NO_ERROR)
     {
       assert_release (false);
@@ -3432,8 +3433,7 @@ xboot_checkdb_table (THREAD_ENTRY * thread_p, int check_flag, OID * oid, BTID * 
 	}
     }
 
-  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, oid, &hfid, NULL, false, NULL) != NO_ERROR
-      || HFID_IS_NULL (&hfid))
+  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, oid, &hfid, NULL, NULL) != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       return DISK_ERROR;
     }
@@ -4834,7 +4834,8 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
   oid_set_root (&boot_Db_parm->rootclass_oid);
   /* we need to manually add root class HFID to cache */
   error_code =
-    heap_insert_hfid_for_class_oid (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP);
+    heap_insert_hfid_for_class_oid (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP,
+				    boot_Db_parm->rootclass_name);
   if (error_code != NO_ERROR)
     {
       assert_release (false);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2383,8 +2383,8 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     }
   /* we need to manually add root class HFID to cache */
   error_code =
-    heap_insert_hfid_for_class_oid (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP,
-				    boot_Db_parm->rootclass_name);
+    heap_cache_class_info (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP,
+			   boot_Db_parm->rootclass_name);
   if (error_code != NO_ERROR)
     {
       assert_release (false);
@@ -3433,7 +3433,7 @@ xboot_checkdb_table (THREAD_ENTRY * thread_p, int check_flag, OID * oid, BTID * 
 	}
     }
 
-  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, oid, &hfid, NULL, NULL) != NO_ERROR || HFID_IS_NULL (&hfid))
+  if (heap_get_class_info (thread_p, oid, &hfid, NULL, NULL) != NO_ERROR || HFID_IS_NULL (&hfid))
     {
       return DISK_ERROR;
     }
@@ -4834,8 +4834,8 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
   oid_set_root (&boot_Db_parm->rootclass_oid);
   /* we need to manually add root class HFID to cache */
   error_code =
-    heap_insert_hfid_for_class_oid (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP,
-				    boot_Db_parm->rootclass_name);
+    heap_cache_class_info (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP,
+			   boot_Db_parm->rootclass_name);
   if (error_code != NO_ERROR)
     {
       assert_release (false);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3432,7 +3432,8 @@ xboot_checkdb_table (THREAD_ENTRY * thread_p, int check_flag, OID * oid, BTID * 
 	}
     }
 
-  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, oid, &hfid, NULL) != NO_ERROR || HFID_IS_NULL (&hfid))
+  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, oid, &hfid, NULL, false, NULL) != NO_ERROR
+      || HFID_IS_NULL (&hfid))
     {
       return DISK_ERROR;
     }

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4261,7 +4261,8 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	  /* We might check for foreign key and schema consistency problems here but we rely on the schema manager to
 	   * prevent inconsistency; see do_check_fk_constraints() for details */
 
-	  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL);
+	  error_code =
+	    heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL, false, NULL);
 	  if (error_code != NO_ERROR)
 	    {
 	      goto error3;
@@ -4606,7 +4607,8 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	  /* We might check for foreign key and schema consistency problems here but we rely on the schema manager to
 	   * prevent inconsistency; see do_check_fk_constraints() for details */
 
-	  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL);
+	  error_code =
+	    heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL, false, NULL);
 	  if (error_code != NO_ERROR)
 	    {
 	      goto error3;
@@ -5781,7 +5783,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	      goto error;
 	    }
 
-	  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, hfid, NULL) != NO_ERROR)
+	  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, hfid, NULL, false, NULL) != NO_ERROR)
 	    {
 	      goto error;
 	    }
@@ -6796,7 +6798,8 @@ xlocator_repl_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, LC_COPYA
 
       LC_REPL_RECDES_FOR_ONEOBJ (force_area, obj, packed_key_value_len, &recdes);
 
-      error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &obj->class_oid, &obj->hfid, NULL);
+      error_code =
+	heap_get_hfid_and_file_type_from_class_oid (thread_p, &obj->class_oid, &obj->hfid, NULL, false, NULL);
       if (error_code != NO_ERROR)
 	{
 	  goto exit_on_error;
@@ -12061,7 +12064,7 @@ xlocator_upgrade_instances_domain (THREAD_ENTRY * thread_p, OID * class_oid, int
   nobjects = 0;
   nfetched = -1;
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL, false, NULL);
   if (error != NO_ERROR)
     {
       goto error_exit;
@@ -12630,7 +12633,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 
   PGBUF_INIT_WATCHER (&old_page_watcher, PGBUF_ORDERED_RANK_UNDEFINED, PGBUF_ORDERED_NULL_HFID);
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &class_hfid, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &class_hfid, NULL, false, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&class_hfid))
     {
       error = ER_FAILED;
@@ -12663,7 +12666,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 	  goto exit;
 	}
 
-      error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &oid_list[i], &hfid, NULL);
+      error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &oid_list[i], &hfid, NULL, false, NULL);
       if (error != NO_ERROR || HFID_IS_NULL (&hfid))
 	{
 	  error = ER_FAILED;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4261,7 +4261,7 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	  /* We might check for foreign key and schema consistency problems here but we rely on the schema manager to
 	   * prevent inconsistency; see do_check_fk_constraints() for details */
 
-	  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL, NULL);
+	  error_code = heap_get_class_info (thread_p, &fkref->self_oid, &hfid, NULL, NULL);
 	  if (error_code != NO_ERROR)
 	    {
 	      goto error3;
@@ -4606,7 +4606,7 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	  /* We might check for foreign key and schema consistency problems here but we rely on the schema manager to
 	   * prevent inconsistency; see do_check_fk_constraints() for details */
 
-	  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL, NULL);
+	  error_code = heap_get_class_info (thread_p, &fkref->self_oid, &hfid, NULL, NULL);
 	  if (error_code != NO_ERROR)
 	    {
 	      goto error3;
@@ -5781,7 +5781,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	      goto error;
 	    }
 
-	  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, hfid, NULL, NULL) != NO_ERROR)
+	  if (heap_get_class_info (thread_p, class_oid, hfid, NULL, NULL) != NO_ERROR)
 	    {
 	      goto error;
 	    }
@@ -6796,7 +6796,7 @@ xlocator_repl_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, LC_COPYA
 
       LC_REPL_RECDES_FOR_ONEOBJ (force_area, obj, packed_key_value_len, &recdes);
 
-      error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &obj->class_oid, &obj->hfid, NULL, NULL);
+      error_code = heap_get_class_info (thread_p, &obj->class_oid, &obj->hfid, NULL, NULL);
       if (error_code != NO_ERROR)
 	{
 	  goto exit_on_error;
@@ -12061,7 +12061,7 @@ xlocator_upgrade_instances_domain (THREAD_ENTRY * thread_p, OID * class_oid, int
   nobjects = 0;
   nfetched = -1;
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL, NULL);
+  error = heap_get_class_info (thread_p, class_oid, &hfid, NULL, NULL);
   if (error != NO_ERROR)
     {
       goto error_exit;
@@ -12630,7 +12630,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 
   PGBUF_INIT_WATCHER (&old_page_watcher, PGBUF_ORDERED_RANK_UNDEFINED, PGBUF_ORDERED_NULL_HFID);
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &class_hfid, NULL, NULL);
+  error = heap_get_class_info (thread_p, class_oid, &class_hfid, NULL, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&class_hfid))
     {
       error = ER_FAILED;
@@ -12663,7 +12663,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 	  goto exit;
 	}
 
-      error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &oid_list[i], &hfid, NULL, NULL);
+      error = heap_get_class_info (thread_p, &oid_list[i], &hfid, NULL, NULL);
       if (error != NO_ERROR || HFID_IS_NULL (&hfid))
 	{
 	  error = ER_FAILED;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4261,7 +4261,7 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	  /* We might check for foreign key and schema consistency problems here but we rely on the schema manager to
 	   * prevent inconsistency; see do_check_fk_constraints() for details */
 
-	  error_code = heap_get_hfid_from_class_oid (thread_p, &fkref->self_oid, &hfid);
+	  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL);
 	  if (error_code != NO_ERROR)
 	    {
 	      goto error3;
@@ -4606,7 +4606,7 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	  /* We might check for foreign key and schema consistency problems here but we rely on the schema manager to
 	   * prevent inconsistency; see do_check_fk_constraints() for details */
 
-	  error_code = heap_get_hfid_from_class_oid (thread_p, &fkref->self_oid, &hfid);
+	  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL);
 	  if (error_code != NO_ERROR)
 	    {
 	      goto error3;
@@ -5781,7 +5781,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	      goto error;
 	    }
 
-	  if (heap_get_hfid_from_class_oid (thread_p, class_oid, hfid) != NO_ERROR)
+	  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, hfid, NULL) != NO_ERROR)
 	    {
 	      goto error;
 	    }
@@ -6796,7 +6796,7 @@ xlocator_repl_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, LC_COPYA
 
       LC_REPL_RECDES_FOR_ONEOBJ (force_area, obj, packed_key_value_len, &recdes);
 
-      error_code = heap_get_hfid_from_class_oid (thread_p, &obj->class_oid, &obj->hfid);
+      error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &obj->class_oid, &obj->hfid, NULL);
       if (error_code != NO_ERROR)
 	{
 	  goto exit_on_error;
@@ -12061,7 +12061,7 @@ xlocator_upgrade_instances_domain (THREAD_ENTRY * thread_p, OID * class_oid, int
   nobjects = 0;
   nfetched = -1;
 
-  error = heap_get_hfid_from_class_oid (thread_p, class_oid, &hfid);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL);
   if (error != NO_ERROR)
     {
       goto error_exit;
@@ -12630,7 +12630,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 
   PGBUF_INIT_WATCHER (&old_page_watcher, PGBUF_ORDERED_RANK_UNDEFINED, PGBUF_ORDERED_NULL_HFID);
 
-  error = heap_get_hfid_from_class_oid (thread_p, class_oid, &class_hfid);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &class_hfid, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&class_hfid))
     {
       error = ER_FAILED;
@@ -12663,7 +12663,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 	  goto exit;
 	}
 
-      error = heap_get_hfid_from_class_oid (thread_p, &oid_list[i], &hfid);
+      error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &oid_list[i], &hfid, NULL);
       if (error != NO_ERROR || HFID_IS_NULL (&hfid))
 	{
 	  error = ER_FAILED;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4261,8 +4261,7 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	  /* We might check for foreign key and schema consistency problems here but we rely on the schema manager to
 	   * prevent inconsistency; see do_check_fk_constraints() for details */
 
-	  error_code =
-	    heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL, false, NULL);
+	  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL, NULL);
 	  if (error_code != NO_ERROR)
 	    {
 	      goto error3;
@@ -4607,8 +4606,7 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	  /* We might check for foreign key and schema consistency problems here but we rely on the schema manager to
 	   * prevent inconsistency; see do_check_fk_constraints() for details */
 
-	  error_code =
-	    heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL, false, NULL);
+	  error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &fkref->self_oid, &hfid, NULL, NULL);
 	  if (error_code != NO_ERROR)
 	    {
 	      goto error3;
@@ -5783,7 +5781,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	      goto error;
 	    }
 
-	  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, hfid, NULL, false, NULL) != NO_ERROR)
+	  if (heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, hfid, NULL, NULL) != NO_ERROR)
 	    {
 	      goto error;
 	    }
@@ -6798,8 +6796,7 @@ xlocator_repl_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, LC_COPYA
 
       LC_REPL_RECDES_FOR_ONEOBJ (force_area, obj, packed_key_value_len, &recdes);
 
-      error_code =
-	heap_get_hfid_and_file_type_from_class_oid (thread_p, &obj->class_oid, &obj->hfid, NULL, false, NULL);
+      error_code = heap_get_hfid_and_file_type_from_class_oid (thread_p, &obj->class_oid, &obj->hfid, NULL, NULL);
       if (error_code != NO_ERROR)
 	{
 	  goto exit_on_error;
@@ -12064,7 +12061,7 @@ xlocator_upgrade_instances_domain (THREAD_ENTRY * thread_p, OID * class_oid, int
   nobjects = 0;
   nfetched = -1;
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL, false, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &hfid, NULL, NULL);
   if (error != NO_ERROR)
     {
       goto error_exit;
@@ -12633,7 +12630,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 
   PGBUF_INIT_WATCHER (&old_page_watcher, PGBUF_ORDERED_RANK_UNDEFINED, PGBUF_ORDERED_NULL_HFID);
 
-  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &class_hfid, NULL, false, NULL);
+  error = heap_get_hfid_and_file_type_from_class_oid (thread_p, class_oid, &class_hfid, NULL, NULL);
   if (error != NO_ERROR || HFID_IS_NULL (&class_hfid))
     {
       error = ER_FAILED;
@@ -12666,7 +12663,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 	  goto exit;
 	}
 
-      error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &oid_list[i], &hfid, NULL, false, NULL);
+      error = heap_get_hfid_and_file_type_from_class_oid (thread_p, &oid_list[i], &hfid, NULL, NULL);
       if (error != NO_ERROR || HFID_IS_NULL (&hfid))
 	{
 	  error = ER_FAILED;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23201

This PR adds the `classname` to the `hfid` cache. Now, each time an entry is added into the `hfid` cache, the classname will be added as well, in order to retrieve whenever the retrieval of hfid is required. Also, I have merged two similar functions into one since they were doing almost the same thing.