### PR TITLE
[CBRD-22661] Disable FK check for loaddb

### DIFF
--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -24,7 +24,6 @@
 #include "load_server_loader.hpp"
 
 #include "btree.h"
-#include "dbtype.h"
 #include "load_class_registry.hpp"
 #include "load_db_value_converter.hpp"
 #include "load_driver.hpp"

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -413,7 +413,7 @@ namespace cubload
 
     int error_code = locator_multi_insert_force (m_thread_ref, &m_scancache.node.hfid, &m_scancache.node.class_oid,
 		     m_recdes_collected, true, op_type, &m_scancache, &force_count, pruning_type, NULL, NULL,
-		     UPDATE_INPLACE_NONE);
+		     UPDATE_INPLACE_NONE, true);
     if (error_code != NO_ERROR)
       {
 	ASSERT_ERROR ();

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -24,6 +24,7 @@
 #include "load_server_loader.hpp"
 
 #include "btree.h"
+#include "dbtype.h"
 #include "load_class_registry.hpp"
 #include "load_db_value_converter.hpp"
 #include "load_driver.hpp"

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4870,6 +4870,7 @@ locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
   HEAP_SCANCACHE *local_scan_cache = NULL;
   FUNC_PRED_UNPACK_INFO *local_func_preds = NULL;
   HEAP_OPERATION_CONTEXT context;
+  bool dont_check_fk = has_BU_lock;	// Temporary hack to skip fk check during bulk loading.
 
   assert (class_oid != NULL);
   assert (!OID_ISNULL (class_oid));
@@ -5107,7 +5108,7 @@ locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	}
 
       /* check the foreign key constraints */
-      if (has_index && !locator_Dont_check_foreign_key)
+      if (has_index && (!locator_Dont_check_foreign_key && !dont_check_fk))
 	{
 	  error_code =
 	    locator_check_foreign_key (thread_p, &real_hfid, &real_class_oid, oid, recdes, &new_recdes, &is_cached,

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -154,7 +154,7 @@ static int locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * cla
 				 int has_index, int op_type, HEAP_SCANCACHE * scan_cache, int *force_count,
 				 int pruning_type, PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
 				 UPDATE_INPLACE_STYLE force_in_place, PGBUF_WATCHER * home_hint_p, bool has_BU_lock,
-				 bool use_bulk_logging = false, bool dont_check_fk);
+				 bool dont_check_fk, bool use_bulk_logging = false);
 static int locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID * oid, RECDES * ikdrecdes,
 				 RECDES * recdes, int has_index, ATTR_ID * att_id, int n_att_id, int op_type,
 				 HEAP_SCANCACHE * scan_cache, int *force_count, bool not_check_fk,
@@ -4855,7 +4855,7 @@ locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		      int op_type, HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type,
 		      PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
 		      UPDATE_INPLACE_STYLE force_in_place, PGBUF_WATCHER * home_hint_p, bool has_BU_lock,
-		      bool use_bulk_logging, bool dont_check_fk)
+		      bool dont_check_fk, bool use_bulk_logging)
 {
 #if 0				/* TODO - dead code; do not delete me */
   OID rep_dir = { NULL_PAGEID, NULL_SLOTID, NULL_VOLID };

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -132,6 +132,6 @@ extern int locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID
 				       const std::vector<record_descriptor> &recdes, int has_index, int op_type,
 				       HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type,
 				       PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
-				       UPDATE_INPLACE_STYLE force_in_place);
+				       UPDATE_INPLACE_STYLE force_in_place, bool dont_check_fk);
 // *INDENT-ON*
 #endif /* _LOCATOR_SR_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22661

We need to disable the FK check for loaddb. This can easily be done by checking if the insert uses the `BU_LOCK` during its operation. If so, we disable the foreign key check as well.