### PR TITLE
[CBRD-23239] fix uninitialized variable in btree delete key from leaf

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -9098,15 +9098,15 @@ btree_delete_key_from_leaf (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR l
       goto exit_on_error;
     }
 
-      /* Before deleting the slot, we will need the record data for undo logging. */
-      leaf_record.area_size = DB_PAGESIZE;
-      leaf_record.data = PTR_ALIGN (leaf_record_buffer, BTREE_MAX_ALIGN);
-      if (spage_get_record (thread_p, leaf_pg, search_key->slotid, &leaf_record, COPY) != S_SUCCESS)
-	{
-	  assert_release (false);
-	  ret = ER_FAILED;
-	  goto exit_on_error;
-	}
+  /* Before deleting the slot, we will need the record data for undo logging. */
+  leaf_record.area_size = DB_PAGESIZE;
+  leaf_record.data = PTR_ALIGN (leaf_record_buffer, BTREE_MAX_ALIGN);
+  if (spage_get_record (thread_p, leaf_pg, search_key->slotid, &leaf_record, COPY) != S_SUCCESS)
+    {
+      assert_release (false);
+      ret = ER_FAILED;
+      goto exit_on_error;
+    }
 
   /* now delete the btree slot */
   assert (search_key->slotid > 0);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -9098,8 +9098,6 @@ btree_delete_key_from_leaf (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR l
       goto exit_on_error;
     }
 
-  if (delete_helper->is_system_op_started)
-    {
       /* Before deleting the slot, we will need the record data for undo logging. */
       leaf_record.area_size = DB_PAGESIZE;
       leaf_record.data = PTR_ALIGN (leaf_record_buffer, BTREE_MAX_ALIGN);
@@ -9109,7 +9107,6 @@ btree_delete_key_from_leaf (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR l
 	  ret = ER_FAILED;
 	  goto exit_on_error;
 	}
-    }
 
   /* now delete the btree slot */
   assert (search_key->slotid > 0);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23239

fix uninitialized variable in btree_delete_key_from_leaf

RECDES leaf_record;
is not initialized for the case leafrec_pnt->key_len >= 0  ==> delete_helper>is_system_op_started ==false