### PR TITLE
[CBRD-23226] rename oldest/newest mvccid variables

### DIFF
--- a/src/executables/unittests_snapshot.c
+++ b/src/executables/unittests_snapshot.c
@@ -359,7 +359,7 @@ test_mvcc_get_oldest (void *param)
   for (i = 0; i < NOPS_OLDEST; i++)
     {
       prev_oldest = curr_oldest;
-      curr_oldest = logtb_get_oldest_active_mvccid (thread_p);
+      curr_oldest = logtb_get_oldest_visible_mvccid (thread_p);
       if (MVCC_ID_PRECEDES (curr_oldest, prev_oldest))
 	{
 	  abort ();

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -92,10 +92,10 @@ typedef struct vacuum_data_entry VACUUM_DATA_ENTRY;
 struct vacuum_data_entry
 {
   // *INDENT-OFF*
-  VACUUM_LOG_BLOCKID blockid;
-  LOG_LSA start_lsa;
-  MVCCID oldest_mvccid;
-  MVCCID newest_mvccid;
+  VACUUM_LOG_BLOCKID blockid;       // blockid and flags
+  LOG_LSA start_lsa;                // lsa of last mvcc op log record in block
+  MVCCID oldest_visible_mvccid;     // oldest visible MVCCID while block was logged
+  MVCCID newest_mvccid;             // newest MVCCID in log block
 
   vacuum_data_entry ();
   vacuum_data_entry (const log_lsa & lsa, MVCCID oldest, MVCCID newest);
@@ -426,13 +426,13 @@ VACUUM_WORKER vacuum_Master;
 /* Oldest MVCCID considered active by a running transaction.
  * Considered as threshold by vacuum workers.
  */
-MVCCID vacuum_Global_oldest_active_mvccid;
+MVCCID vacuum_Global_oldest_visible_mvccid;
 /* When transactions run some complex operations on heap files (upgrade domain, reorganize partitions), concurrent
- * access with vacuum workers can create problems. They avoid it by blocking vacuum_Global_oldest_active_mvccid updates
+ * access with vacuum workers can create problems. They avoid it by blocking vacuum_Global_oldest_visible_mvccid updates
  * and by running vacuum manually.
  * This is a counter that tracks blocking transactions.
  */
-INT32 vacuum_Global_oldest_active_blockers_counter;
+INT32 vacuum_Global_oldest_visible_blockers_counter;
 /* vacuum_Save_log_hdr_oldest_mvccid is used to estimate oldest unvacuumed MVCCID in the corner-case of empty vacuum
  * data. When vacuum data is not empty, oldest MVCCID of first block not yet vacuumed is used.
  * However, when vacuum data is not empty, the oldest MVCCID can be either the oldest MVCCID of first block in
@@ -652,10 +652,10 @@ bool vacuum_Is_booted = false;
 
 /* Logging */
 #define VACUUM_LOG_DATA_ENTRY_MSG(name) \
-  "name = {blockid = %lld, flags = %lld, start_lsa = %lld|%d, oldest_mvccid=%llu, newest_mvccid=%llu }"
+  "name = {blockid = %lld, flags = %lld, start_lsa = %lld|%d, oldest_visible_mvccid=%llu, newest_mvccid=%llu }"
 #define VACUUM_LOG_DATA_ENTRY_AS_ARGS(data) \
   (long long) VACUUM_BLOCKID_WITHOUT_FLAGS ((data)->blockid), (long long) VACUUM_BLOCKID_GET_FLAGS ((data)->blockid), \
-  LSA_AS_ARGS (&(data)->start_lsa), (unsigned long long) (data)->oldest_mvccid, \
+  LSA_AS_ARGS (&(data)->start_lsa), (unsigned long long) (data)->oldest_visible_mvccid, \
   (unsigned long long) (data)->newest_mvccid
 
 /* Vacuum static functions. */
@@ -1182,7 +1182,7 @@ vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npages, VFID * 
       vacuum_Workers[i].allocated_resources = false;
     }
 
-  vacuum_Global_oldest_active_blockers_counter = 0;
+  vacuum_Global_oldest_visible_blockers_counter = 0;
 
   return NO_ERROR;
 
@@ -2814,13 +2814,14 @@ vacuum_produce_log_block_data (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, MVC
   /* Set start lsa for block */
   LSA_COPY (&block_data.start_lsa, start_lsa);
   /* Set oldest and newest MVCCID */
-  block_data.oldest_mvccid = oldest_mvccid;
+  block_data.oldest_visible_mvccid = oldest_mvccid;
   block_data.newest_mvccid = newest_mvccid;
 
   vacuum_er_log (VACUUM_ER_LOG_LOGGING | VACUUM_ER_LOG_VACUUM_DATA,
 		 "vacuum_produce_log_block_data: blockid=(%lld) start_lsa=(%lld, %d) old_mvccid=(%llu) "
 		 "new_mvccid=(%llu)", (long long) block_data.blockid, LSA_AS_ARGS (&block_data.start_lsa),
-		 (unsigned long long int) block_data.oldest_mvccid, (unsigned long long int) block_data.newest_mvccid);
+		 (unsigned long long int) block_data.oldest_visible_mvccid,
+		 (unsigned long long int) block_data.newest_mvccid);
 
   /* Push new block into block data buffer */
   if (!vacuum_Block_data_buffer->produce (block_data))
@@ -2934,14 +2935,14 @@ vacuum_master_task::execute (cubthread::entry &thread_ref)
 
   PERF_UTIME_TRACKER_START (thread_p, &perf_tracker);
 
-  if (vacuum_Global_oldest_active_blockers_counter == 0)
+  if (vacuum_Global_oldest_visible_blockers_counter == 0)
     {
-      local_oldest_active_mvccid = logtb_get_oldest_active_mvccid (thread_p);
+      local_oldest_active_mvccid = logtb_get_oldest_visible_mvccid (thread_p);
 
       /* check again, maybe concurrent thread has modified the counter value */
-      if (vacuum_Global_oldest_active_blockers_counter == 0)
+      if (vacuum_Global_oldest_visible_blockers_counter == 0)
 	{
-	  ATOMIC_STORE_64 (&vacuum_Global_oldest_active_mvccid, local_oldest_active_mvccid);
+	  ATOMIC_STORE_64 (&vacuum_Global_oldest_visible_mvccid, local_oldest_active_mvccid);
 	}
     }
 
@@ -2990,7 +2991,7 @@ restart:
     {
       entry = &m_cursor.get_current_entry ();
 
-      if (!MVCC_ID_PRECEDES (entry->newest_mvccid, vacuum_Global_oldest_active_mvccid)
+      if (!MVCC_ID_PRECEDES (entry->newest_mvccid, vacuum_Global_oldest_visible_mvccid)
 	  || (entry->start_lsa.pageid + 1 >= log_Gl.append.prev_lsa.pageid))
 	{
 	  /* Newest MVCCID in block is not old enough. Or
@@ -3001,9 +3002,9 @@ restart:
 	   */
 	  vacuum_er_log (VACUUM_ER_LOG_JOBS,
 			 "Cannot generate job for " VACUUM_LOG_DATA_ENTRY_MSG ("entry") ". "
-			 "vacuum_Global_oldest_active_mvccid = %llu, log_Gl.append.prev_lsa.pageid = %d.",
+			 "vacuum_Global_oldest_visible_mvccid = %llu, log_Gl.append.prev_lsa.pageid = %d.",
 			 VACUUM_LOG_DATA_ENTRY_AS_ARGS (entry),
-			 (unsigned long long int) vacuum_Global_oldest_active_mvccid,
+			 (unsigned long long int) vacuum_Global_oldest_visible_mvccid,
 			 (long long int) log_Gl.append.prev_lsa.pageid);
 
 	  /* todo: remember this as starting point for next iteration of generating jobs */
@@ -3099,7 +3100,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, boo
   OID class_oid, oid;
   BTREE_OBJECT_INFO old_version;
   BTREE_OBJECT_INFO new_version;
-  MVCCID threshold_mvccid = vacuum_Global_oldest_active_mvccid;
+  MVCCID threshold_mvccid = vacuum_Global_oldest_visible_mvccid;
   BTREE_MVCC_INFO mvcc_info;
   MVCCID mvccid;
   LOG_VACUUM_INFO log_vacuum;
@@ -3228,7 +3229,7 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, boo
 	}
 
 #if !defined (NDEBUG)
-      if (MVCC_ID_FOLLOW_OR_EQUAL (mvccid, threshold_mvccid) || MVCC_ID_PRECEDES (mvccid, data->oldest_mvccid)
+      if (MVCC_ID_FOLLOW_OR_EQUAL (mvccid, threshold_mvccid) || MVCC_ID_PRECEDES (mvccid, data->oldest_visible_mvccid)
 	  || MVCC_ID_PRECEDES (data->newest_mvccid, mvccid))
 	{
 	  /* threshold_mvccid or mvccid or block data may be invalid */
@@ -4126,7 +4127,7 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
   vacuum_Data.is_loaded = true;
 
   /* get global oldest active MVCCID. */
-  vacuum_Global_oldest_active_mvccid = logtb_get_oldest_active_mvccid (thread_p);
+  vacuum_Global_oldest_visible_mvccid = logtb_get_oldest_visible_mvccid (thread_p);
 
   error_code = vacuum_recover_lost_block_data (thread_p);
   if (error_code != NO_ERROR)
@@ -4943,7 +4944,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
    */
   vacuum_Save_log_hdr_oldest_mvccid =
     LSA_ISNULL (&log_Gl.hdr.mvcc_op_log_lsa) ?
-    vacuum_Global_oldest_active_mvccid : ATOMIC_INC_64 (&log_Gl.hdr.last_block_oldest_mvccid, 0);
+    vacuum_Global_oldest_visible_mvccid : ATOMIC_INC_64 (&log_Gl.hdr.oldest_visible_mvccid, 0);
 
   if (vacuum_Block_data_buffer->is_empty ())
     {
@@ -5066,25 +5067,26 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 	      assert (page_free_data->is_available ());	// starts as available
 	      LSA_COPY (&page_free_data->start_lsa, &consumed_data.start_lsa);
 	      page_free_data->newest_mvccid = consumed_data.newest_mvccid;
-	      page_free_data->oldest_mvccid = consumed_data.oldest_mvccid;
-	      if (MVCC_ID_PRECEDES (vacuum_Global_oldest_active_mvccid, page_free_data->oldest_mvccid))
+	      page_free_data->oldest_visible_mvccid = consumed_data.oldest_visible_mvccid;
+	      if (MVCC_ID_PRECEDES (vacuum_Global_oldest_visible_mvccid, page_free_data->oldest_visible_mvccid))
 		{
-		  page_free_data->oldest_mvccid = vacuum_Global_oldest_active_mvccid;
+		  page_free_data->oldest_visible_mvccid = vacuum_Global_oldest_visible_mvccid;
 		}
 #if !defined (NDEBUG)
-	      /* Check that oldest_mvccid is not decreasing. */
+	      /* Check that oldest_visible_mvccid is not decreasing. */
 	      if (data_page->index_free > 0)
 		{
-		  assert ((page_free_data - 1)->oldest_mvccid <= page_free_data->oldest_mvccid);
+		  assert ((page_free_data - 1)->oldest_visible_mvccid <= page_free_data->oldest_visible_mvccid);
 		  assert ((page_free_data - 1)->get_blockid () + 1 == page_free_data->get_blockid ());
 		}
 #endif /* !NDEBUG */
 
 	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
-			     "Add block %lld, start_lsa=%lld|%d, oldest_mvccid=%llu, newest_mvccid=%llu. Hdr last blockid = %lld\n",
+			     "Add block %lld, start_lsa=%lld|%d, oldest_visible_mvccid=%llu, newest_mvccid=%llu. "
+			     "Hdr last blockid = %lld\n",
 			     (long long int) page_free_data->get_blockid (),
 			     (long long int) page_free_data->start_lsa.pageid, (int) page_free_data->start_lsa.offset,
-			     (unsigned long long int) page_free_data->oldest_mvccid,
+			     (unsigned long long int) page_free_data->oldest_visible_mvccid,
 			     (unsigned long long int) page_free_data->newest_mvccid,
 			     (long long int) log_Gl.hdr.vacuum_last_blockid);
 	    }
@@ -5093,7 +5095,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
 	      /* Mark the blocks with no MVCC operations as already vacuumed. */
 	      page_free_data->set_vacuumed ();
 	      LSA_SET_NULL (&page_free_data->start_lsa);
-	      page_free_data->oldest_mvccid = MVCCID_NULL;
+	      page_free_data->oldest_visible_mvccid = MVCCID_NULL;
 	      page_free_data->newest_mvccid = MVCCID_NULL;
 
 	      vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,
@@ -5240,7 +5242,8 @@ vacuum_rv_redo_append_data_dump (FILE * fp, int length, void *data)
 
       fprintf (fp, "  { Blockid = %lld, Start_Lsa = %lld|%d, Oldest_MVCCID = %llu, Newest_MVCCID = %llu } \n",
 	       (long long int) vacuum_data_entry->blockid, (long long int) vacuum_data_entry->start_lsa.pageid,
-	       (int) vacuum_data_entry->start_lsa.offset, (unsigned long long int) vacuum_data_entry->oldest_mvccid,
+	       (int) vacuum_data_entry->start_lsa.offset,
+	       (unsigned long long int) vacuum_data_entry->oldest_visible_mvccid,
 	       (unsigned long long int) vacuum_data_entry->newest_mvccid);
 
       vacuum_data_entry++;
@@ -5272,8 +5275,8 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   LOG_LSA mvcc_op_log_lsa = LSA_INITIALIZER;
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
-		 "vacuum_recover_lost_block_data, lsa = %lld|%d, global_oldest_mvccid = %llu",
-		 LSA_AS_ARGS (&vacuum_Data.recovery_lsa), (unsigned long long int) vacuum_Global_oldest_active_mvccid);
+		 "vacuum_recover_lost_block_data, lsa = %lld|%d, global_oldest_visible_mvccid = %llu",
+		 LSA_AS_ARGS (&vacuum_Data.recovery_lsa), (unsigned long long int) vacuum_Global_oldest_visible_mvccid);
   if (LSA_ISNULL (&vacuum_Data.recovery_lsa))
     {
       /* No recovery was done. */
@@ -5396,10 +5399,10 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
   std::stack<VACUUM_DATA_ENTRY> vacuum_block_data_buffer_stack;
   /* *INDENT-ON* */
 
-  /* we don't reset data.oldest_mvccid between blocks. we need to maintain ordered oldest_mvccid's, and if a block + 1
-   * MVCCID is smaller than all MVCCID's in block, then it must have been active (and probably suspended) while block
-   * was logged. therefore, we must keep it. */
-  data.oldest_mvccid = MVCCID_NULL;
+  /* we don't reset data.oldest_visible_mvccid between blocks. we need to maintain ordered oldest_visible_mvccid's, and
+   * if a block + 1 MVCCID is smaller than all MVCCID's in block, then it must have been active (and probably suspended)
+   * while block was logged. therefore, we must keep it. */
+  data.oldest_visible_mvccid = MVCCID_NULL;
   while (crt_blockid > vacuum_Data.get_last_blockid ())
     {
       /* Stop recovering this block when previous block is reached. */
@@ -5407,7 +5410,7 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
       /* Initialize this block data. */
       data.blockid = crt_blockid;
       LSA_COPY (&data.start_lsa, &log_lsa);
-      /* inherit data.oldest_mvccid */
+      /* inherit data.oldest_visible_mvccid */
       data.newest_mvccid = MVCCID_NULL;
       /* Loop through MVCC op log records in this block. */
       while (log_lsa.pageid > stop_at_pageid)
@@ -5432,9 +5435,9 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 	      return error_code;
 	    }
 	  /* Update oldest/newest MVCCID. */
-	  if (data.oldest_mvccid == MVCCID_NULL || MVCC_ID_PRECEDES (mvccid, data.oldest_mvccid))
+	  if (data.oldest_visible_mvccid == MVCCID_NULL || MVCC_ID_PRECEDES (mvccid, data.oldest_visible_mvccid))
 	    {
-	      data.oldest_mvccid = mvccid;
+	      data.oldest_visible_mvccid = mvccid;
 	    }
 	  if (data.newest_mvccid == MVCCID_NULL || MVCC_ID_PRECEDES (data.newest_mvccid, mvccid))
 	    {
@@ -5445,17 +5448,17 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 
       if (data.blockid == vacuum_get_log_blockid (log_Gl.prior_info.prior_lsa.pageid))
 	{
-	  log_Gl.hdr.last_block_oldest_mvccid = data.oldest_mvccid;
-	  log_Gl.hdr.last_block_newest_mvccid = data.newest_mvccid;
+	  log_Gl.hdr.oldest_visible_mvccid = data.oldest_visible_mvccid;
+	  log_Gl.hdr.newest_block_mvccid = data.newest_mvccid;
 	  log_Gl.hdr.does_block_need_vacuum = true;
 	  log_Gl.hdr.mvcc_op_log_lsa = mvcc_op_log_lsa;
 
 	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 			 "Restore log global cached info: \n\t mvcc_op_log_lsa = %lld|%d \n"
-			 "\t last_block_oldest_mvccid = %llu \n\t last_block_newest_mvccid = %llu ",
+			 "\t oldest_visible_mvccid = %llu \n\t newest_block_mvccid = %llu ",
 			 LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa),
-			 (unsigned long long int) log_Gl.hdr.last_block_oldest_mvccid,
-			 (unsigned long long int) log_Gl.hdr.last_block_newest_mvccid);
+			 (unsigned long long int) log_Gl.hdr.oldest_visible_mvccid,
+			 (unsigned long long int) log_Gl.hdr.newest_block_mvccid);
 	}
       else
 	{
@@ -5588,7 +5591,7 @@ vacuum_update_oldest_unvacuumed_mvccid (THREAD_ENTRY * thread_p)
        */
       VACUUM_DATA_ENTRY *data_entry = &vacuum_Data.first_page->data[vacuum_Data.first_page->index_unvacuumed];
       assert (!data_entry->is_vacuumed ());
-      oldest_mvccid = data_entry->oldest_mvccid;
+      oldest_mvccid = data_entry->oldest_visible_mvccid;
     }
   else
     {
@@ -6953,11 +6956,12 @@ vacuum_verify_vacuum_data_debug (THREAD_ENTRY * thread_p)
 	    }
 
 	  assert (entry->is_available () || entry->is_job_in_progress ());
-	  assert (entry->oldest_mvccid <= vacuum_Global_oldest_active_mvccid);
-	  assert (vacuum_Data.oldest_unvacuumed_mvccid <= entry->oldest_mvccid);
+	  assert (entry->oldest_visible_mvccid <= vacuum_Global_oldest_visible_mvccid);
+	  assert (vacuum_Data.oldest_unvacuumed_mvccid <= entry->oldest_visible_mvccid);
 	  assert (entry->get_blockid () <= vacuum_Data.get_last_blockid ());
 	  assert (vacuum_get_log_blockid (entry->start_lsa.pageid) == entry->get_blockid ());
-	  assert (last_unvacuumed == NULL || !MVCC_ID_PRECEDES (entry->oldest_mvccid, last_unvacuumed->oldest_mvccid));
+	  assert (last_unvacuumed == NULL
+		  || !MVCC_ID_PRECEDES (entry->oldest_visible_mvccid, last_unvacuumed->oldest_visible_mvccid));
 
 	  if (i > data_page->index_unvacuumed)
 	    {
@@ -7440,14 +7444,14 @@ vacuum_notify_server_shutdown (void)
 }
 
 /*
- * vacuum_get_global_oldest_active_mvccid () - Get global oldest active MVCCID.
+ * vacuum_get_global_oldest_visible_mvccid () - Get global oldest active MVCCID.
  *
  * return : Global oldest active MVCCID.
  */
 MVCCID
-vacuum_get_global_oldest_active_mvccid (void)
+vacuum_get_global_oldest_visible_mvccid (void)
 {
-  return vacuum_Global_oldest_active_mvccid;
+  return vacuum_Global_oldest_visible_mvccid;
 }
 
 #if !defined (NDEBUG)
@@ -7542,7 +7546,7 @@ vacuum_rv_check_at_undo (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slotid, 
     }
   else
     {
-      can_vacuum = mvcc_satisfies_vacuum (thread_p, &rec_header, vacuum_Global_oldest_active_mvccid);
+      can_vacuum = mvcc_satisfies_vacuum (thread_p, &rec_header, vacuum_Global_oldest_visible_mvccid);
     }
 
   /* it is impossible to restore a record that should be removed by vacuum */
@@ -7939,14 +7943,18 @@ vacuum_data_entry::vacuum_data_entry ()
 vacuum_data_entry::vacuum_data_entry (const log_lsa &lsa, MVCCID oldest, MVCCID newest)
   : blockid (VACUUM_NULL_LOG_BLOCKID)
   , start_lsa (lsa)
-  , oldest_mvccid (oldest)
+  , oldest_visible_mvccid (oldest)
   , newest_mvccid (newest)
 {
+  assert (!lsa.is_null ());
+  assert (MVCCID_IS_VALID (oldest));
+  assert (MVCCID_IS_VALID (newest));
+  assert (oldest <= newest);
   blockid = vacuum_get_log_blockid (start_lsa.pageid);
 }
 
 vacuum_data_entry::vacuum_data_entry (const log_header &hdr)
-  : vacuum_data_entry (hdr.mvcc_op_log_lsa, hdr.last_block_oldest_mvccid, hdr.last_block_newest_mvccid)
+  : vacuum_data_entry (hdr.mvcc_op_log_lsa, hdr.oldest_visible_mvccid, hdr.newest_block_mvccid)
 {
 }
 

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -223,7 +223,7 @@ extern void vacuum_finalize (THREAD_ENTRY * thread_p);
 extern int vacuum_boot (THREAD_ENTRY * thread_p);
 extern void vacuum_stop (THREAD_ENTRY * thread_p);
 extern int xvacuum (THREAD_ENTRY * thread_p);
-extern MVCCID vacuum_get_global_oldest_active_mvccid (void);
+extern MVCCID vacuum_get_global_oldest_visible_mvccid (void);
 
 extern int vacuum_create_file_for_vacuum_data (THREAD_ENTRY * thread_p, VFID * vacuum_data_vfid);
 extern int vacuum_data_load_and_recover (THREAD_ENTRY * thread_p);

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -789,7 +789,7 @@ xbtree_load_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_name, TP
   btid_int.nonleaf_key_type = btree_generate_prefix_domain (&btid_int);
 
   /* Initialize the fields of sorting argument structures */
-  sort_args->lowest_active_mvccid = logtb_get_oldest_active_mvccid (thread_p);
+  sort_args->lowest_active_mvccid = logtb_get_oldest_visible_mvccid (thread_p);
   sort_args->unique_pk = unique_pk;
   sort_args->not_null_flag = not_null_flag;
   sort_args->hfids = hfids;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -115,7 +115,7 @@ struct locator_return_nxobj
   int area_offset;		/* Relative offset to recdes->data in the communication area */
 };
 
-extern INT32 vacuum_Global_oldest_active_blockers_counter;
+extern INT32 vacuum_Global_oldest_visible_blockers_counter;
 
 bool locator_Dont_check_foreign_key = false;
 
@@ -12078,19 +12078,19 @@ xlocator_upgrade_instances_domain (THREAD_ENTRY * thread_p, OID * class_oid, int
   if (tdes->block_global_oldest_active_until_commit == false)
     {
       /* do not allow to advance with vacuum_Global_oldest_active_mvccid */
-      ATOMIC_INC_32 (&vacuum_Global_oldest_active_blockers_counter, 1);
+      ATOMIC_INC_32 (&vacuum_Global_oldest_visible_blockers_counter, 1);
       tdes->block_global_oldest_active_until_commit = true;
     }
   else
     {
-      assert (vacuum_Global_oldest_active_blockers_counter > 0);
+      assert (vacuum_Global_oldest_visible_blockers_counter > 0);
     }
 
   /* Can't use vacuum_Global_oldest_active_mvccid here. That's because we want to avoid scenarios where VACUUM compute
    * oldest active mvccid, but didn't set yet vacuum_Global_oldest_active_mvccid, current transaction uses the old
    * value of vacuum_Global_oldest_active_mvccid, then VACUUM uses updated value of vacuum_Global_oldest_active_mvccid.
    * In such scenario, VACUUM can remove heap records that can't be removed by the current thread. */
-  threshold_mvccid = logtb_get_oldest_active_mvccid (thread_p);
+  threshold_mvccid = logtb_get_oldest_visible_mvccid (thread_p);
 
   /* VACUUM all cleanable heap objects before upgrading the domain */
   error = heap_vacuum_all_objects (thread_p, &upd_scancache, threshold_mvccid);
@@ -12683,12 +12683,12 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
       if (tdes->block_global_oldest_active_until_commit == false)
 	{
 	  /* do not allow to advance with vacuum_Global_oldest_active_mvccid */
-	  ATOMIC_INC_32 (&vacuum_Global_oldest_active_blockers_counter, 1);
+	  ATOMIC_INC_32 (&vacuum_Global_oldest_visible_blockers_counter, 1);
 	  tdes->block_global_oldest_active_until_commit = true;
 	}
       else
 	{
-	  assert (vacuum_Global_oldest_active_blockers_counter > 0);
+	  assert (vacuum_Global_oldest_visible_blockers_counter > 0);
 	}
 
       if (threshold_mvccid == MVCCID_NULL)
@@ -12698,7 +12698,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 	   * uses the old value of vacuum_Global_oldest_active_mvccid, then VACUUM uses updated value of
 	   * vacuum_Global_oldest_active_mvccid.
 	   * In such scenario, VACUUM can remove heap records that can't be removed by the current thread. */
-	  threshold_mvccid = logtb_get_oldest_active_mvccid (thread_p);
+	  threshold_mvccid = logtb_get_oldest_visible_mvccid (thread_p);
 	}
 
       /* VACUUM all cleanable heap objects before upgrading the domain */

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1342,10 +1342,10 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 	{
 	  assert (vacuum_get_log_blockid (log_Gl.hdr.mvcc_op_log_lsa.pageid)
 		  == vacuum_get_log_blockid (start_lsa.pageid) - 1);
-	  vacuum_produce_log_block_data (thread_p, &log_Gl.hdr.mvcc_op_log_lsa, log_Gl.hdr.last_block_oldest_mvccid,
-					 log_Gl.hdr.last_block_newest_mvccid);
-	  log_Gl.hdr.last_block_oldest_mvccid = vacuum_get_global_oldest_active_mvccid ();
-	  log_Gl.hdr.last_block_newest_mvccid = MVCCID_NULL;
+	  vacuum_produce_log_block_data (thread_p, &log_Gl.hdr.mvcc_op_log_lsa, log_Gl.hdr.oldest_visible_mvccid,
+					 log_Gl.hdr.newest_block_mvccid);
+	  log_Gl.hdr.oldest_visible_mvccid = vacuum_get_global_oldest_visible_mvccid ();
+	  log_Gl.hdr.newest_block_mvccid = MVCCID_NULL;
 	  log_Gl.hdr.does_block_need_vacuum = false;
 	}
     }
@@ -1392,17 +1392,17 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 		     LSA_AS_ARGS (&node->start_lsa), LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa));
 
       /* Same block, update the oldest and the newest met MVCCID's */
-      if (log_Gl.hdr.last_block_newest_mvccid == MVCCID_NULL
-	  || MVCC_ID_PRECEDES (log_Gl.hdr.last_block_newest_mvccid, mvccid))
+      if (log_Gl.hdr.newest_block_mvccid == MVCCID_NULL
+	  || MVCC_ID_PRECEDES (log_Gl.hdr.newest_block_mvccid, mvccid))
 	{
 	  /* A newer MVCCID was found */
-	  log_Gl.hdr.last_block_newest_mvccid = mvccid;
+	  log_Gl.hdr.newest_block_mvccid = mvccid;
 	}
-      if (log_Gl.hdr.last_block_oldest_mvccid == MVCCID_NULL)
+      if (log_Gl.hdr.oldest_visible_mvccid == MVCCID_NULL)
 	{
-	  log_Gl.hdr.last_block_oldest_mvccid = vacuum_get_global_oldest_active_mvccid ();
+	  log_Gl.hdr.oldest_visible_mvccid = vacuum_get_global_oldest_visible_mvccid ();
 	}
-      assert (!MVCC_ID_PRECEDES (mvccid, log_Gl.hdr.last_block_oldest_mvccid));
+      assert (!MVCC_ID_PRECEDES (mvccid, log_Gl.hdr.oldest_visible_mvccid));
 
       /* Replace last MVCC deleted/updated log record */
       LSA_COPY (&log_Gl.hdr.mvcc_op_log_lsa, &start_lsa);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -993,7 +993,7 @@ extern char *logpb_backup_level_info_to_string (char *buf, int buf_size, const L
 extern const char *tran_abort_reason_to_string (TRAN_ABORT_REASON val);
 extern int logtb_descriptors_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int arg_cnt,
 					 void **ctx);
-extern MVCCID logtb_get_oldest_active_mvccid (THREAD_ENTRY * thread_p);
+extern MVCCID logtb_get_oldest_visible_mvccid (THREAD_ENTRY * thread_p);
 
 extern LOG_PAGEID logpb_find_oldest_available_page_id (THREAD_ENTRY * thread_p);
 extern int logpb_find_oldest_available_arv_num (THREAD_ENTRY * thread_p);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -179,7 +179,7 @@ static const int LOG_REC_UNDO_MAX_ATTEMPTS = 3;
 /* true: Skip logging, false: Don't skip logging */
 static bool log_No_logging = false;
 
-extern INT32 vacuum_Global_oldest_active_blockers_counter;
+extern INT32 vacuum_Global_oldest_visible_blockers_counter;
 
 #define LOG_TDES_LAST_SYSOP(tdes) (&(tdes)->topops.stack[(tdes)->topops.last])
 #define LOG_TDES_LAST_SYSOP_PARENT_LSA(tdes) (&LOG_TDES_LAST_SYSOP(tdes)->lastparent_lsa)
@@ -5284,9 +5284,9 @@ log_complete (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_RECTYPE iscommitted,
       /* Unblock global oldest active update. */
       if (tdes->block_global_oldest_active_until_commit)
 	{
-	  ATOMIC_INC_32 (&vacuum_Global_oldest_active_blockers_counter, -1);
+	  ATOMIC_INC_32 (&vacuum_Global_oldest_visible_blockers_counter, -1);
 	  tdes->block_global_oldest_active_until_commit = false;
-	  assert (vacuum_Global_oldest_active_blockers_counter >= 0);
+	  assert (vacuum_Global_oldest_visible_blockers_counter >= 0);
 	}
 
       if (iscommitted == LOG_COMMIT)
@@ -5573,9 +5573,9 @@ log_complete_for_2pc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_RECTYPE isco
       /* Unblock global oldest active update. */
       if (tdes->block_global_oldest_active_until_commit)
 	{
-	  ATOMIC_INC_32 (&vacuum_Global_oldest_active_blockers_counter, -1);
+	  ATOMIC_INC_32 (&vacuum_Global_oldest_visible_blockers_counter, -1);
 	  tdes->block_global_oldest_active_until_commit = false;
-	  assert (vacuum_Global_oldest_active_blockers_counter >= 0);
+	  assert (vacuum_Global_oldest_visible_blockers_counter >= 0);
 	}
 
       if (iscommitted == LOG_COMMIT)
@@ -8970,23 +8970,23 @@ log_active_log_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE *
       goto exit_on_error;
     }
 
-  if (header->last_block_oldest_mvccid == MVCCID_NULL)
+  if (header->oldest_visible_mvccid == MVCCID_NULL)
     {
       db_make_null (out_values[idx]);
     }
   else
     {
-      db_make_bigint (out_values[idx], header->last_block_oldest_mvccid);
+      db_make_bigint (out_values[idx], header->oldest_visible_mvccid);
     }
   idx++;
 
-  if (header->last_block_newest_mvccid == MVCCID_NULL)
+  if (header->newest_block_mvccid == MVCCID_NULL)
     {
       db_make_null (out_values[idx]);
     }
   else
     {
-      db_make_bigint (out_values[idx], header->last_block_newest_mvccid);
+      db_make_bigint (out_values[idx], header->newest_block_mvccid);
     }
   idx++;
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -10396,9 +10396,9 @@ logpb_dump_log_header (FILE * outfp)
 
   fprintf (outfp, "\tMVCC op lsa : (%lld|%d)\n", LSA_AS_ARGS (&log_Gl.hdr.mvcc_op_log_lsa));
 
-  fprintf (outfp, "\tLast block oldest MVCCID : (%lld)\n", (long long int) log_Gl.hdr.last_block_oldest_mvccid);
+  fprintf (outfp, "\tLast block oldest MVCCID : (%lld)\n", (long long int) log_Gl.hdr.oldest_visible_mvccid);
 
-  fprintf (outfp, "\tLast block newest MVCCID : (%lld)\n", (long long int) log_Gl.hdr.last_block_newest_mvccid);
+  fprintf (outfp, "\tLast block newest MVCCID : (%lld)\n", (long long int) log_Gl.hdr.newest_block_mvccid);
 }
 
 /*
@@ -10739,8 +10739,8 @@ logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HEADER * loghd
 {
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA, "Reset vacuum info in loghdr (%p)", loghdr);
   LSA_SET_NULL (&loghdr->mvcc_op_log_lsa);
-  loghdr->last_block_oldest_mvccid = MVCCID_NULL;
-  loghdr->last_block_newest_mvccid = MVCCID_NULL;
+  loghdr->oldest_visible_mvccid = MVCCID_NULL;
+  loghdr->newest_block_mvccid = MVCCID_NULL;
   loghdr->does_block_need_vacuum = false;
 }
 

--- a/src/transaction/log_storage.hpp
+++ b/src/transaction/log_storage.hpp
@@ -146,9 +146,10 @@ struct log_header
 
   LOG_LSA smallest_lsa_at_last_chkpt;
 
-  LOG_LSA mvcc_op_log_lsa;	/* Used to link log entries for mvcc operations. Vacuum will then process these entries */
-  MVCCID last_block_oldest_mvccid;	/* Used to find the oldest MVCCID in a block of log data. */
-  MVCCID last_block_newest_mvccid;	/* Used to find the newest MVCCID in a block of log data. */
+  // next fields track MVCC info relevant for vacuum
+  LOG_LSA mvcc_op_log_lsa;	/* LSA of last MVCC operation log record */
+  MVCCID oldest_visible_mvccid;	/* oldest visible MVCCID */
+  MVCCID newest_block_mvccid;	/* newest MVCCID for current block */
 
   INT64 ha_promotion_time;
   INT64 db_restore_time;
@@ -194,8 +195,8 @@ struct log_header
   , eof_lsa (NULL_LSA)
   , smallest_lsa_at_last_chkpt (NULL_LSA)
   , mvcc_op_log_lsa (NULL_LSA)
-  , last_block_oldest_mvccid (MVCCID_NULL)
-  , last_block_newest_mvccid (MVCCID_NULL)
+  , oldest_visible_mvccid (MVCCID_NULL)
+  , newest_block_mvccid (MVCCID_NULL)
   , ha_promotion_time (0)
   , db_restore_time (0)
   , mark_will_del (false)

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -3834,7 +3834,7 @@ xlogtb_get_mvcc_snapshot (THREAD_ENTRY * thread_p)
 }
 
 /*
- * logtb_get_oldest_active_mvccid () - Get oldest MVCCID that was running
+ * logtb_get_oldest_visible_mvccid () - Get oldest MVCCID that was running
  *				       when any active transaction started.
  *
  * return	 : MVCCID for oldest active transaction.
@@ -3848,7 +3848,7 @@ xlogtb_get_mvcc_snapshot (THREAD_ENTRY * thread_p)
  *	      transaction, this function return highest_completed_mvccid + 1.
  */
 MVCCID
-logtb_get_oldest_active_mvccid (THREAD_ENTRY * thread_p)
+logtb_get_oldest_visible_mvccid (THREAD_ENTRY * thread_p)
 {
   MVCCID lowest_active_mvccid = 0;
   TSC_TICKS start_tick, end_tick;
@@ -3862,7 +3862,7 @@ logtb_get_oldest_active_mvccid (THREAD_ENTRY * thread_p)
       tsc_getticks (&start_tick);
     }
 
-  lowest_active_mvccid = log_Gl.mvcc_table.compute_oldest_active_mvccid ();
+  lowest_active_mvccid = log_Gl.mvcc_table.compute_oldest_visible_mvccid ();
 
   if (is_perf_tracking)
     {
@@ -3881,7 +3881,7 @@ logtb_get_oldest_active_mvccid (THREAD_ENTRY * thread_p)
 #if !defined (NDEBUG)
   {
     /* Safe guard: vacuum_Global_oldest_active_mvccid can never become smaller. */
-    MVCCID crt_oldest = vacuum_get_global_oldest_active_mvccid ();
+    MVCCID crt_oldest = vacuum_get_global_oldest_visible_mvccid ();
     assert (!MVCC_ID_PRECEDES (lowest_active_mvccid, crt_oldest));
   }
 #endif /* !NDEBUG */

--- a/src/transaction/mvcc_table.cpp
+++ b/src/transaction/mvcc_table.cpp
@@ -161,8 +161,8 @@ mvcctable::advance_oldest_active (MVCCID next_oldest_active)
 //
 
 mvcctable::mvcctable ()
-  : m_transaction_lowest_active_mvccids (NULL)
-  , m_transaction_lowest_active_mvccids_size (0)
+  : m_transaction_lowest_visible_mvccids (NULL)
+  , m_transaction_lowest_visible_mvccids_size (0)
   , m_current_status_lowest_active_mvccid (MVCCID_FIRST)
   , m_current_trans_status ()
   , m_trans_status_history_position (0)
@@ -174,7 +174,7 @@ mvcctable::mvcctable ()
 
 mvcctable::~mvcctable ()
 {
-  delete [] m_transaction_lowest_active_mvccids;
+  delete [] m_transaction_lowest_visible_mvccids;
   delete [] m_trans_status_history;
 }
 
@@ -196,12 +196,12 @@ mvcctable::initialize ()
 void
 mvcctable::alloc_transaction_lowest_active ()
 {
-  if (m_transaction_lowest_active_mvccids_size != (size_t) logtb_get_number_of_total_tran_indices ())
+  if (m_transaction_lowest_visible_mvccids_size != (size_t) logtb_get_number_of_total_tran_indices ())
     {
       // either first time or transaction table size has changed
-      delete [] m_transaction_lowest_active_mvccids;
-      m_transaction_lowest_active_mvccids_size = logtb_get_number_of_total_tran_indices ();
-      m_transaction_lowest_active_mvccids = new lowest_active_mvccid_type[m_transaction_lowest_active_mvccids_size] ();
+      delete [] m_transaction_lowest_visible_mvccids;
+      m_transaction_lowest_visible_mvccids_size = logtb_get_number_of_total_tran_indices ();
+      m_transaction_lowest_visible_mvccids = new lowest_active_mvccid_type[m_transaction_lowest_visible_mvccids_size] ();
       // all are 0 = MVCCID_NULL
     }
 }
@@ -214,9 +214,9 @@ mvcctable::finalize ()
   delete [] m_trans_status_history;
   m_trans_status_history = NULL;
 
-  delete [] m_transaction_lowest_active_mvccids;
-  m_transaction_lowest_active_mvccids = NULL;
-  m_transaction_lowest_active_mvccids_size = 0;
+  delete [] m_transaction_lowest_visible_mvccids;
+  m_transaction_lowest_visible_mvccids = NULL;
+  m_transaction_lowest_visible_mvccids_size = 0;
 }
 
 void
@@ -245,7 +245,7 @@ mvcctable::build_mvcc_info (log_tdes &tdes)
   // make sure snapshot has allocated data
   tdes.mvccinfo.snapshot.m_active_mvccs.initialize ();
 
-  tx_lowest_active = oldest_active_get (m_transaction_lowest_active_mvccids[tdes.tran_index], tdes.tran_index,
+  tx_lowest_active = oldest_active_get (m_transaction_lowest_visible_mvccids[tdes.tran_index], tdes.tran_index,
 					oldest_active_event::BUILD_MVCC_INFO);
 
   // repeat steps until a trans_status can be read successfully without a version change
@@ -270,7 +270,7 @@ mvcctable::build_mvcc_info (log_tdes &tdes)
 	   *    - the VACUUM thread computes the threshold again and found a value (initial global lowest active MVCCID)
 	   * less than the previously threshold
 	   */
-	  oldest_active_set (m_transaction_lowest_active_mvccids[tdes.tran_index], tdes.tran_index,
+	  oldest_active_set (m_transaction_lowest_visible_mvccids[tdes.tran_index], tdes.tran_index,
 			     MVCCID_ALL_VISIBLE, oldest_active_event::BUILD_MVCC_INFO);
 
 	  /*
@@ -279,7 +279,7 @@ mvcctable::build_mvcc_info (log_tdes &tdes)
 	   */
 	  crt_status_lowest_active = oldest_active_get (m_current_status_lowest_active_mvccid, 0,
 				     oldest_active_event::BUILD_MVCC_INFO);
-	  oldest_active_set (m_transaction_lowest_active_mvccids[tdes.tran_index], tdes.tran_index,
+	  oldest_active_set (m_transaction_lowest_visible_mvccids[tdes.tran_index], tdes.tran_index,
 			     crt_status_lowest_active, oldest_active_event::BUILD_MVCC_INFO);
 	}
       else
@@ -352,7 +352,7 @@ mvcctable::build_mvcc_info (log_tdes &tdes)
 }
 
 MVCCID
-mvcctable::compute_oldest_active_mvccid () const
+mvcctable::compute_oldest_visible_mvccid () const
 {
   const size_t MVCC_OLDEST_ACTIVE_BUFFER_LENGTH = 32;
   cubmem::appendable_array<size_t, MVCC_OLDEST_ACTIVE_BUFFER_LENGTH> waiting_mvccids_pos;
@@ -360,9 +360,9 @@ mvcctable::compute_oldest_active_mvccid () const
   MVCCID lowest_active_mvccid = oldest_active_get (m_current_status_lowest_active_mvccid, 0,
 				oldest_active_event::GET_OLDEST_ACTIVE);
 
-  for (size_t idx = 0; idx < m_transaction_lowest_active_mvccids_size; idx++)
+  for (size_t idx = 0; idx < m_transaction_lowest_visible_mvccids_size; idx++)
     {
-      loaded_tran_mvccid = oldest_active_get (m_transaction_lowest_active_mvccids[idx], idx,
+      loaded_tran_mvccid = oldest_active_get (m_transaction_lowest_visible_mvccids[idx], idx,
 					      oldest_active_event::GET_OLDEST_ACTIVE);
       if (loaded_tran_mvccid == MVCCID_ALL_VISIBLE)
 	{
@@ -386,7 +386,7 @@ mvcctable::compute_oldest_active_mvccid () const
       for (size_t i = waiting_mvccids_pos.get_size () - 1; i < waiting_mvccids_pos.get_size (); --i)
 	{
 	  size_t pos = waiting_mvccids_pos.get_array ()[i];
-	  loaded_tran_mvccid = oldest_active_get (m_transaction_lowest_active_mvccids[pos], pos,
+	  loaded_tran_mvccid = oldest_active_get (m_transaction_lowest_visible_mvccids[pos], pos,
 						  oldest_active_event::GET_OLDEST_ACTIVE);
 	  if (loaded_tran_mvccid == MVCCID_ALL_VISIBLE)
 	    {
@@ -484,17 +484,17 @@ mvcctable::complete_mvcc (int tran_index, MVCCID mvccid, bool committed)
        *
        * It will be set to NULL after LOG_COMMIT
        */
-      MVCCID tran_lowest_active = oldest_active_get (m_transaction_lowest_active_mvccids[tran_index], tran_index,
+      MVCCID tran_lowest_active = oldest_active_get (m_transaction_lowest_visible_mvccids[tran_index], tran_index,
 				  oldest_active_event::COMPLETE_MVCC);
       if (tran_lowest_active == MVCCID_NULL || MVCC_ID_PRECEDES (tran_lowest_active, mvccid))
 	{
-	  oldest_active_set (m_transaction_lowest_active_mvccids[tran_index], tran_index, mvccid,
+	  oldest_active_set (m_transaction_lowest_visible_mvccids[tran_index], tran_index, mvccid,
 			     oldest_active_event::COMPLETE_MVCC);
 	}
     }
   else
     {
-      oldest_active_set (m_transaction_lowest_active_mvccids[tran_index], tran_index, MVCCID_NULL,
+      oldest_active_set (m_transaction_lowest_visible_mvccids[tran_index], tran_index, MVCCID_NULL,
 			 oldest_active_event::COMPLETE_MVCC);
     }
 
@@ -506,7 +506,7 @@ mvcctable::complete_mvcc (int tran_index, MVCCID mvccid, bool committed)
   // so we try to limit recalculation when mvccid matches current global_lowest_active; since we are not locked, it is
   // not guaranteed to be always updated; therefore we add the second condition to go below trans status
   // bit area starting MVCCID; the recalculation will happen on each iteration if there are long transactions.
-  MVCCID global_lowest_active = compute_oldest_active_mvccid ();
+  MVCCID global_lowest_active = compute_oldest_visible_mvccid ();
   if (global_lowest_active == mvccid
       || MVCC_ID_PRECEDES (mvccid, next_status.m_active_mvccs.get_bit_area_start_mvccid ()))
     {
@@ -579,7 +579,7 @@ mvcctable::get_two_new_mvccid (MVCCID &first, MVCCID &second)
 void
 mvcctable::reset_transaction_lowest_active (int tran_index)
 {
-  oldest_active_set (m_transaction_lowest_active_mvccids[tran_index], tran_index, MVCCID_NULL,
+  oldest_active_set (m_transaction_lowest_visible_mvccids[tran_index], tran_index, MVCCID_NULL,
 		     oldest_active_event::RESET);
 }
 

--- a/src/transaction/mvcc_table.hpp
+++ b/src/transaction/mvcc_table.hpp
@@ -84,7 +84,7 @@ struct mvcctable
     void get_two_new_mvccid (MVCCID &first, MVCCID &second);
 
     bool is_active (MVCCID mvccid) const;
-    MVCCID compute_oldest_active_mvccid () const;
+    MVCCID compute_oldest_visible_mvccid () const;
 
     void reset_start_mvccid ();     // not thread safe
 
@@ -94,8 +94,8 @@ struct mvcctable
     static const size_t HISTORY_INDEX_MASK = HISTORY_MAX_SIZE - 1;
 
     /* lowest active MVCCIDs - array of size NUM_TOTAL_TRAN_INDICES */
-    lowest_active_mvccid_type *m_transaction_lowest_active_mvccids;
-    size_t m_transaction_lowest_active_mvccids_size;
+    lowest_active_mvccid_type *m_transaction_lowest_visible_mvccids;
+    size_t m_transaction_lowest_visible_mvccids_size;
     /* lowest active MVCCID */
     lowest_active_mvccid_type m_current_status_lowest_active_mvccid;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23226

Rename variables to clarify their meaning. Replace "active" names with "visible". An MVCCID may be inactive (it was committed/aborted), but it is still visible as long as it is seen as active by concurrent transactions. When all concurrent transactions are finished, the MVCCID becomes invisible.

Vacuum for instance has to wait for an MVCCID to become invisible to clean after it. Inactive is not enough.

Patch includes no logic changes.