### PR TITLE
[CBRD-23253] Fix conversion table for conversion functions

### DIFF
--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -136,10 +136,10 @@ namespace cubload
     setters_[DB_TYPE_DOUBLE][LDR_DOUBLE] = &to_db_double;
     setters_[DB_TYPE_DOUBLE][LDR_FLOAT] = &to_db_double;
 
-    setters_[DB_TYPE_NUMERIC][LDR_INT] = &to_db_numeric;
+    setters_[DB_TYPE_NUMERIC][LDR_INT] = &to_db_int;
     setters_[DB_TYPE_NUMERIC][LDR_NUMERIC] = &to_db_numeric;
-    setters_[DB_TYPE_NUMERIC][LDR_DOUBLE] = &to_db_numeric;
-    setters_[DB_TYPE_NUMERIC][LDR_FLOAT] = &to_db_numeric;
+    setters_[DB_TYPE_NUMERIC][LDR_DOUBLE] = &to_db_double;
+    setters_[DB_TYPE_NUMERIC][LDR_FLOAT] = &to_db_double;
 
     setters_[DB_TYPE_BIT][LDR_BSTR] = &to_db_varbit_from_bin_str;
     setters_[DB_TYPE_BIT][LDR_XSTR] = &to_db_varbit_from_hex_str;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23253

We fixed the conversion table for the `DB_C_NUMERIC` in order to use the correct conversion function during load.