### PR TITLE
[CBRD-23259] Increase the number of tasks available in the workerpool

### DIFF
--- a/src/loaddb/load_worker_manager.cpp
+++ b/src/loaddb/load_worker_manager.cpp
@@ -134,7 +134,7 @@ namespace cubload
 	unsigned int pool_size = prm_get_integer_value (PRM_ID_LOADDB_WORKER_COUNT);
 
 	g_wp_context_manager = new worker_context_manager (pool_size);
-	g_worker_pool = cubthread::get_manager ()->create_worker_pool (pool_size, pool_size, "loaddb-workers",
+	g_worker_pool = cubthread::get_manager ()->create_worker_pool (pool_size, 2 * pool_size, "loaddb-workers",
 			g_wp_context_manager, 1, false, true);
 
 	g_wp_task_capper = new cubthread::worker_pool_task_capper<cubthread::entry> (g_worker_pool);

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -1507,7 +1507,7 @@ namespace cubthread
   worker_pool_task_capper<Context>::worker_pool_task_capper (worker_pool<Context> *wp)
   {
     m_worker_pool = wp;
-    m_tasks_available = m_max_tasks = wp->get_max_count ();
+    m_tasks_available = m_max_tasks = 2 * wp->get_max_count ();
   }
 
   template <typename Context>

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -1507,7 +1507,7 @@ namespace cubthread
   worker_pool_task_capper<Context>::worker_pool_task_capper (worker_pool<Context> *wp)
   {
     m_worker_pool = wp;
-    m_tasks_available = m_max_tasks = 2 * wp->get_max_count ();
+    m_tasks_available = m_max_tasks = wp->get_max_count ();
   }
 
   template <typename Context>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23259

We increased the number of tasks available so that new tasks are queued and are left waiting for an open thread to be executed on. This will remove the dead time between finishing a task and getting a new one.