### PR TITLE
[CBRD-23254] loaddb: fix line number parsing from file name

### DIFF
--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -187,28 +187,32 @@ ldr_check_file (std::string & file_name, int &error_code)
 static int
 ldr_get_start_line_no (std::string & file_name)
 {
+  // default start from line no 1
+  int line_no = 1;
+
   if (!file_name.empty ())
     {
-      const char *p = strchr (file_name.c_str (), ':');
-      if (p != NULL)
+      std::string::size_type p = file_name.find (':');
+      if (p != std::string::npos)
 	{
-	  const char *q;
-	  for (q = p + 1; *q; q++)
+	  std::string::size_type q = p + 1;
+	  for (; q != std::string::npos; ++q)
 	    {
-	      if (!char_isdigit (*q))
+	      if (!char_isdigit (file_name[q]))
 		{
 		  break;
 		}
 	    }
-	  if (*q == 0)
+	  if (file_name[q] == 0)
 	    {
-	      return atoi (p + 1);
+	      line_no = std::stoi (file_name.substr (p + 1));
+	      // remove line no from file name
+	      file_name.resize (p);
 	    }
 	}
     }
 
-  // default start from line no 1
-  return 1;
+  return line_no;
 }
 
 static char *

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -205,7 +205,15 @@ ldr_get_start_line_no (std::string & file_name)
 	    }
 	  if (file_name[q] == 0)
 	    {
-	      line_no = std::stoi (file_name.substr (p + 1));
+	      try
+	      {
+		line_no = std::stoi (file_name.substr (p + 1));
+	      }
+	      catch (...)
+	      {
+		// parse failed, fallback to default value
+	      }
+
 	      // remove line no from file name
 	      file_name.resize (p);
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23254

Fix line number parsing from file name.
For example after parsing this string `schema_file:5`, line number must be cut out from original file name. Before it was trying to open the file, whose name was containing the line number.  