### PR TITLE
[CBRD-23261] remove return error from lf_bitmap_free_entry/lf_tran_return_entry

### DIFF
--- a/src/base/area_alloc.c
+++ b/src/base/area_alloc.c
@@ -565,11 +565,7 @@ area_free (AREA * area, void *ptr)
 
   assert (entry_idx >= 0 && entry_idx < (int) area->alloc_count);
 
-  error = lf_bitmap_free_entry (&block->bitmap, entry_idx);
-  if (error != NO_ERROR)
-    {
-      return error;
-    }
+  lf_bitmap_free_entry (&block->bitmap, entry_idx);
 
   /* change hint block if needed */
   hint_block = VOLATILE_ACCESS (area->hint_block, AREA_BLOCK *);

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -226,7 +226,7 @@ extern int lf_tran_system_init (LF_TRAN_SYSTEM * sys, int max_threads);
 extern void lf_tran_system_destroy (LF_TRAN_SYSTEM * sys);
 
 extern LF_TRAN_ENTRY *lf_tran_request_entry (LF_TRAN_SYSTEM * sys);
-extern int lf_tran_return_entry (LF_TRAN_ENTRY * entry);
+extern void lf_tran_return_entry (LF_TRAN_ENTRY * entry);
 extern void lf_tran_destroy_entry (LF_TRAN_ENTRY * entry);
 extern void lf_tran_compute_minimum_transaction_id (LF_TRAN_SYSTEM * sys);
 
@@ -398,7 +398,7 @@ extern void *lf_hash_iterate (LF_HASH_TABLE_ITERATOR * it);
 extern int lf_bitmap_init (LF_BITMAP * bitmap, LF_BITMAP_STYLE style, int entries_cnt, float usage_threshold);
 extern void lf_bitmap_destroy (LF_BITMAP * bitmap);
 extern int lf_bitmap_get_entry (LF_BITMAP * bitmap);
-extern int lf_bitmap_free_entry (LF_BITMAP * bitmap, int entry_idx);
+extern void lf_bitmap_free_entry (LF_BITMAP * bitmap, int entry_idx);
 
 #if defined (UNITTEST_LF)
 extern void lf_reset_counters (void);

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -257,10 +257,7 @@ test_freelist_proc (void *param)
       lf_tran_end_with_mb (te);
     }
 
-  if (lf_tran_return_entry (te) != NO_ERROR)
-    {
-      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
-    }
+  lf_tran_return_entry (te);
 
   pthread_exit (NO_ERROR);
 
@@ -306,10 +303,7 @@ test_freelist_proc_local_tran (void *param)
 	}
     }
 
-  if (lf_tran_return_entry (te) != NO_ERROR)
-    {
-      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
-    }
+  lf_tran_return_entry (te);
 
   pthread_exit (NO_ERROR);
 
@@ -366,10 +360,7 @@ test_hash_proc_1 (void *param)
 	}
     }
 
-  if (lf_tran_return_entry (te) != NO_ERROR)
-    {
-      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
-    }
+  lf_tran_return_entry (te);
 
   pthread_exit (NO_ERROR);
 
@@ -437,11 +428,7 @@ test_hash_proc_2 (void *param)
       assert (te->locked_mutex == NULL);
     }
 
-  if (lf_tran_return_entry (te) != NO_ERROR)
-    {
-      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
-    }
-
+  lf_tran_return_entry (te);
 
   pthread_exit (NO_ERROR);
 
@@ -524,10 +511,7 @@ test_hash_proc_3 (void *param)
       assert (te->locked_mutex == NULL);
     }
 
-  if (lf_tran_return_entry (te) != NO_ERROR)
-    {
-      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
-    }
+  lf_tran_return_entry (te);
 
   ATOMIC_INC_32 (&del_op_count, local_del_op_count);
   pthread_exit (NO_ERROR);
@@ -593,10 +577,7 @@ test_clear_proc_1 (void *param)
 	}
     }
 
-  if (lf_tran_return_entry (te) != NO_ERROR)
-    {
-      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
-    }
+  lf_tran_return_entry (te);
 
   pthread_exit (NO_ERROR);
 
@@ -671,11 +652,7 @@ test_clear_proc_2 (void *param)
       assert (te->locked_mutex == NULL);
     }
 
-  if (lf_tran_return_entry (te) != NO_ERROR)
-    {
-      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
-    }
-
+  lf_tran_return_entry (te);
 
   pthread_exit (NO_ERROR);
 
@@ -763,10 +740,7 @@ test_clear_proc_3 (void *param)
       assert (te->locked_mutex == NULL);
     }
 
-  if (lf_tran_return_entry (te) != NO_ERROR)
-    {
-      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
-    }
+  lf_tran_return_entry (te);
 
   pthread_exit (NO_ERROR);
 

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -322,10 +322,7 @@ namespace cubthread
       {
 	if (tran_entries[i] != NULL)
 	  {
-	    if (lf_tran_return_entry (tran_entries[i]) != NO_ERROR)
-	      {
-		assert (false);
-	      }
+	    lf_tran_return_entry (tran_entries[i]);
 	    tran_entries[i] = NULL;
 	  }
       }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23261

No error code for free entry functions; assert safe-guard will be enough to detect errors. Double free may not be managed through an error.

part of lock-free bitmap refactoring.