### PR TITLE
[CBRD-23264] Fix locks check during index insert

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1782,7 +1782,7 @@ static inline bool btree_is_online_index_loading (BTREE_OP_PURPOSE purpose);
 static bool btree_is_single_object_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, BTREE_NODE_TYPE node_type,
 					RECDES * record, int offset_after_key);
 
-static bool btree_has_correct_locks (THREAD_ENTRY * thread_p, const BTREE_INSERT_HELPER * insert_helper);
+static bool btree_check_locking_for_insert_unique (THREAD_ENTRY * thread_p, const BTREE_INSERT_HELPER * insert_helper);
 
 /*
  * btree_fix_root_with_info () - Fix b-tree root page and output its VPID, header and b-tree info if requested.
@@ -27343,7 +27343,7 @@ btree_key_insert_new_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_VALUE
   assert (insert_helper->is_system_op_started == false);
 #if defined (SERVER_MODE)
   assert ((btree_is_online_index_loading (insert_helper->purpose)) || !BTREE_IS_UNIQUE (btid_int->unique_pk)
-	  || log_is_in_crash_recovery () || btree_has_correct_locks (thread_p, insert_helper));
+	  || log_is_in_crash_recovery () || btree_check_locking_for_insert_unique (thread_p, insert_helper));
 #endif /* SERVER_MODE */
 
   /* Insert new key. */
@@ -27606,7 +27606,7 @@ btree_key_lock_and_append_object_unique (THREAD_ENTRY * thread_p, BTID_INT * bti
   assert (insert_helper->rv_redo_data != NULL && insert_helper->rv_redo_data_ptr != NULL);
   assert (insert_helper->purpose == BTREE_OP_INSERT_NEW_OBJECT);
 #if defined (SERVER_MODE)
-  assert (log_is_in_crash_recovery () || btree_has_correct_locks (thread_p, insert_helper));
+  assert (log_is_in_crash_recovery () || btree_check_locking_for_insert_unique (thread_p, insert_helper));
 #endif /* SERVER_MODE */
 
   /* Insert object in the beginning of leaf record if unique constraint is not violated. Step 1: Protect key by
@@ -35057,27 +35057,35 @@ btree_is_single_object_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, BTREE_
 }
 
 static bool
-btree_has_correct_locks (THREAD_ENTRY * thread_p, const BTREE_INSERT_HELPER * insert_helper)
+btree_check_locking_for_insert_unique (THREAD_ENTRY * thread_p, const BTREE_INSERT_HELPER * insert_helper)
 {
-  int has_class_lock, has_instance_lock;
+  int has_class_bu_lock;
+  int has_instance_lock;
   int tran_index = logtb_get_current_tran_index ();
 
   /*  The insert operation in index has to check if the object is currently inserting is locked by the transaction.
    *  However, after the introduction of the BU_LOCK this is no longer valid. For this case, the inserter should
    *  make sure that he has a BU_LOCK on the class he is inserting into.
+   *
+   *  Now in order to correctly insert into the b-tree the transaction should either have and X_LOCK on the object,
+   *  or a BU_LOCK on the class.
    */
 
-  has_instance_lock = lock_has_lock_on_object (BTREE_INSERT_OID (insert_helper), BTREE_INSERT_CLASS_OID (insert_helper),
-					       tran_index, X_LOCK);
-  has_class_lock = lock_has_lock_on_object (BTREE_INSERT_CLASS_OID (insert_helper), oid_Root_class_oid,
-					    tran_index, BU_LOCK);
-
-  // Now in order to correctly insert into the b-tree the transaction should either have and X_LOCK on the object,
-  // or a BU_LOCK on the class.
-  if (has_instance_lock > 0 || has_class_lock > 0)
+  has_class_bu_lock = lock_has_lock_on_object (BTREE_INSERT_CLASS_OID (insert_helper), oid_Root_class_oid,
+					       tran_index, BU_LOCK);
+  if (has_class_bu_lock > 0)
     {
       return true;
     }
+
+  has_instance_lock = lock_has_lock_on_object (BTREE_INSERT_OID (insert_helper), BTREE_INSERT_CLASS_OID (insert_helper),
+					       tran_index, X_LOCK);
+  if (has_instance_lock > 0)
+    {
+      return true;
+    }
+
+
 
   return false;
 }

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -35085,7 +35085,5 @@ btree_check_locking_for_insert_unique (THREAD_ENTRY * thread_p, const BTREE_INSE
       return true;
     }
 
-
-
   return false;
 }

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -35062,11 +35062,18 @@ btree_has_correct_locks (THREAD_ENTRY * thread_p, const BTREE_INSERT_HELPER * in
   int has_class_lock, has_instance_lock;
   int tran_index = logtb_get_current_tran_index ();
 
+  /*  The insert operation in index has to check if the object is currently inserting is locked by the transaction.
+   *  However, after the introduction of the BU_LOCK this is no longer valid. For this case, the inserter should
+   *  make sure that he has a BU_LOCK on the class he is inserting into.
+   */
+
   has_instance_lock = lock_has_lock_on_object (BTREE_INSERT_OID (insert_helper), BTREE_INSERT_CLASS_OID (insert_helper),
 					       tran_index, X_LOCK);
   has_class_lock = lock_has_lock_on_object (BTREE_INSERT_CLASS_OID (insert_helper), oid_Root_class_oid,
 					    tran_index, BU_LOCK);
 
+  // Now in order to correctly insert into the b-tree the transaction should either have and X_LOCK on the object,
+  // or a BU_LOCK on the class.
   if (has_instance_lock > 0 || has_class_lock > 0)
     {
       return true;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23264

Since the introduction of the `BU_LOCK` and the removal of the instance locking, the b-tree insert operation during loaddb should not always require and `X_LOCK` on the object. I have updated the check and it translates into: 
`Transaction has an X_LOCK on the object`
         - or -
` Transaction has a BU_LOCK on the class`