### PR TITLE
[CBRD-23265] loaddb: fix console output

### DIFF
--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -634,8 +634,8 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
   if (args.load_only)
     {
       /* This is the default behavior. It is changed from the old one so we notify the user. */
-      print_log_msg (1, "\n--load-only is deprecated. To check the object file \
-                         for any syntax errors use --data-file-check-only.\n");
+      print_log_msg (1, "\n--load-only is deprecated. To check the object file for any syntax errors");
+      print_log_msg (1, " use --data-file-check-only.\n");
     }
 
   /* if schema file is specified, do schema loading */

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -4835,7 +4835,7 @@ ldr_act_init_context (LDR_CONTEXT *context, const char *class_name, size_t len)
     }
 
   context->valid = true;
-  if (context->args->verbose)
+  if (context->args->verbose && class_name != NULL)
     {
       fprintf (stdout, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB, LOADDB_MSG_CLASS_TITLE),
 	       class_name);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23265

Fix loaddb console output:
- remove extra blank spaces
- print class message only if class is not null