### PR TITLE
[CBRD-22879] Change signature of packable_object::get_packed_size

### DIFF
--- a/src/base/packable_object.hpp
+++ b/src/base/packable_object.hpp
@@ -37,7 +37,7 @@ namespace cubpacking
       virtual ~packable_object () {};
 
       /* used at packing to get info on how much memory to reserve */
-      virtual size_t get_packed_size (packer &serializator) const = 0;
+      virtual size_t get_packed_size (packer &serializator, std::size_t start_offset = 0) const = 0;
       virtual void pack (packer &serializator) const = 0;
       virtual void unpack (unpacker &deserializator) = 0;
 

--- a/src/storage/record_descriptor.cpp
+++ b/src/storage/record_descriptor.cpp
@@ -72,7 +72,7 @@ record_descriptor::record_descriptor (record_descriptor &&other)
   other.m_recdes.type = REC_UNKNOWN;
 }
 
-record_descriptor::record_descriptor (const char *data, size_t size)
+record_descriptor::record_descriptor (const char *data, std::size_t size)
   : record_descriptor ()
 {
   set_data (data, size);
@@ -93,7 +93,7 @@ record_descriptor::set_recdes (const recdes &rec)
       // copy content from argument
       m_recdes.area_size = rec.length;
       m_recdes.length = m_recdes.area_size;
-      m_own_data.extend_to ((size_t) m_recdes.area_size);
+      m_own_data.extend_to ((std::size_t) m_recdes.area_size);
       m_recdes.data = m_own_data.get_ptr ();
       std::memcpy (m_recdes.data, rec.data, m_recdes.length);
 
@@ -130,7 +130,7 @@ record_descriptor::get (cubthread::entry *thread_p, PAGE_PTR page, PGSLOTID slot
       assert (m_recdes.length < 0);
       assert (mode == record_get_mode::COPY_RECORD);
 
-      size_t required_size = static_cast<size_t> (-m_recdes.length);
+      std::size_t required_size = static_cast<std::size_t> (-m_recdes.length);
       resize_buffer (required_size);
 
       sc = spage_get_record (thread_p, page, slotid, &m_recdes, mode_to_int);
@@ -151,7 +151,7 @@ record_descriptor::resize_buffer (std::size_t required_size)
 {
   assert (m_data_source == data_source::INVALID || is_mutable ());
 
-  if (m_recdes.area_size > 0 && required_size <= (size_t) m_recdes.area_size)
+  if (m_recdes.area_size > 0 && required_size <= (std::size_t) m_recdes.area_size)
     {
       // resize not required
       return;
@@ -217,7 +217,7 @@ record_descriptor::get_data_for_modify (void)
 }
 
 void
-record_descriptor::set_data (const char *data, size_t size)
+record_descriptor::set_data (const char *data, std::size_t size)
 {
   // data is assigned and cannot be changed
   m_data_source = data_source::IMMUTABLE;
@@ -226,7 +226,7 @@ record_descriptor::set_data (const char *data, size_t size)
 }
 
 void
-record_descriptor::set_record_length (size_t length)
+record_descriptor::set_record_length (std::size_t length)
 {
   check_changes_are_permitted ();
   assert (length <= m_recdes.area_size);
@@ -241,7 +241,7 @@ record_descriptor::set_type (std::int16_t type)
 }
 
 void
-record_descriptor::set_external_buffer (char *buf, size_t buf_size)
+record_descriptor::set_external_buffer (char *buf, std::size_t buf_size)
 {
   m_own_data.freemem ();
   m_recdes.data = buf;
@@ -341,17 +341,17 @@ record_descriptor::unpack (cubpacking::unpacker &unpacker)
   unpacker.unpack_buffer_with_length (m_recdes.data, m_recdes.length);
 }
 
-size_t
-record_descriptor::get_packed_size (cubpacking::packer &packer) const
+std::size_t
+record_descriptor::get_packed_size (cubpacking::packer &packer, std::size_t curr_offset) const
 {
-  size_t entry_size = packer.get_packed_short_size (0);
+  std::size_t entry_size = packer.get_packed_short_size (curr_offset);
   entry_size += packer.get_packed_buffer_size (m_recdes.data, m_recdes.length, entry_size);
 
   return entry_size;
 }
 
 void
-record_descriptor::release_buffer (char *&data, size_t &size)
+record_descriptor::release_buffer (char *&data, std::size_t &size)
 {
   size = m_own_data.get_size ();
   data = m_own_data.release_ptr ();

--- a/src/storage/record_descriptor.hpp
+++ b/src/storage/record_descriptor.hpp
@@ -68,10 +68,7 @@ class record_descriptor : public cubpacking::packable_object
     record_descriptor (const cubmem::block_allocator &alloc = cubmem::PRIVATE_BLOCK_ALLOCATOR);
     ~record_descriptor (void);
 
-    // based on an buffers
-    template <size_t S>
-    record_descriptor (cubmem::stack_block<S> &membuf);
-    record_descriptor (const char *data, size_t size);
+    record_descriptor (const char *data, std::size_t size);
 
     // based on recdes
     record_descriptor (const recdes &rec, const cubmem::block_allocator &alloc = cubmem::PRIVATE_BLOCK_ALLOCATOR);
@@ -97,11 +94,11 @@ class record_descriptor : public cubpacking::packable_object
     char *get_data_for_modify (void);
 
     // setters
-    void set_data (const char *data, size_t size);      // set record data to byte array
+    void set_data (const char *data, std::size_t size);      // set record data to byte array
     template <typename T>
     void set_data_to_object (const T &t);               // set record data to object
 
-    void set_record_length (size_t length);
+    void set_record_length (std::size_t length);
     void set_type (std::int16_t type);
 
     //
@@ -122,7 +119,7 @@ class record_descriptor : public cubpacking::packable_object
 
     void pack (cubpacking::packer &packer) const override;
     void unpack (cubpacking::unpacker &unpacker) override;
-    std::size_t get_packed_size (cubpacking::packer &packer) const override;
+    std::size_t get_packed_size (cubpacking::packer &packer, std::size_t curr_offset) const override;
 
     //
     // manipulate record memory buffer
@@ -131,10 +128,10 @@ class record_descriptor : public cubpacking::packable_object
     // resize record buffer
     void resize_buffer (std::size_t size);
     // set external buffer; record type is set to new automatically
-    void set_external_buffer (char *buf, size_t buf_size);
-    template <size_t S>
+    void set_external_buffer (char *buf, std::size_t buf_size);
+    template <std::size_t S>
     void set_external_buffer (cubmem::stack_block<S> &membuf);
-    void release_buffer (char *&data, size_t &size);
+    void release_buffer (char *&data, std::size_t &size);
 
   private:
 
@@ -164,7 +161,7 @@ class record_descriptor : public cubpacking::packable_object
 // template/inline
 //////////////////////////////////////////////////////////////////////////
 
-template <size_t S>
+template <std::size_t S>
 void
 record_descriptor::set_external_buffer (cubmem::stack_block<S> &membuf)
 {

--- a/src/transaction/client_credentials.cpp
+++ b/src/transaction/client_credentials.cpp
@@ -173,7 +173,7 @@ clientids::reset ()
   client_type_as_int, client_info, db_user, program_name, login_name, host_name, process_id
 
 size_t
-clientids::get_packed_size (cubpacking::packer &serializator) const
+clientids::get_packed_size (cubpacking::packer &serializator, std::size_t start_offset) const
 {
   return serializator.get_all_packed_size (CLIENTID_PACKER_ARGS (static_cast<int> (client_type)));
 }
@@ -229,7 +229,7 @@ boot_client_credential::get_db_password () const
   db_name, db_password
 
 size_t
-boot_client_credential::get_packed_size (cubpacking::packer &serializator) const
+boot_client_credential::get_packed_size (cubpacking::packer &serializator, std::size_t start_offset) const
 {
   return clientids::get_packed_size (serializator) + serializator.get_all_packed_size (BOOTCLCRED_PACKER_ARGS);
 }

--- a/src/transaction/client_credentials.hpp
+++ b/src/transaction/client_credentials.hpp
@@ -66,7 +66,7 @@ struct clientids : public cubpacking::packable_object
     void reset ();
 
     // packable_object
-    virtual size_t get_packed_size (cubpacking::packer &serializator) const override;
+    virtual size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset = 0) const override;
     virtual void pack (cubpacking::packer &serializator) const override;
     virtual void unpack (cubpacking::unpacker &deserializator) override;
 
@@ -94,7 +94,7 @@ struct boot_client_credential : public clientids
   const char *get_db_password () const;
 
   // packable_object
-  virtual size_t get_packed_size (cubpacking::packer &serializator) const override;
+  virtual size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset = 0) const override;
   virtual void pack (cubpacking::packer &serializator) const override;
   virtual void unpack (cubpacking::unpacker &deserializator) override;
 };


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22879

Backport from ha_replication.
Add offset to signature of packable_object::get_packed_size.
Side changes:
- use std::size_t instead of size_t
- remove undefined templetized contructor of record_descriptor 