### PR TITLE
[CBRD-23266] lock-free freelist

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -128,6 +128,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
   ${BASE_DIR}/lockfree_bitmap.hpp
+  ${BASE_DIR}/lockfree_freelist.hpp
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_reference_store.hpp
   ${BASE_DIR}/memory_private_allocator.hpp

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -136,6 +136,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
   ${BASE_DIR}/lockfree_bitmap.hpp
+  ${BASE_DIR}/lockfree_freelist.hpp
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_private_allocator.cpp
   ${BASE_DIR}/msgcat_set_log.hpp

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -46,7 +46,7 @@ namespace lockfree
       };
 
       freelist () = delete;
-      freelist (factory<T> &freelist_factory, size_t block_size, size_t initial_block_count = 1);
+      freelist (factory &freelist_factory, size_t block_size, size_t initial_block_count = 1);
       ~freelist ();
 
       T *claim ();
@@ -56,7 +56,7 @@ namespace lockfree
       void retire_list (T *head);
 
     private:
-      factory<T> &m_factory;
+      factory &m_factory;
 
       size_t m_block_size;
 
@@ -78,7 +78,7 @@ namespace lockfree
   // freelist
   //
   template <class T>
-  freelist<T>::freelist (factory<T> &freelist_factory, size_t block_size, size_t initial_block_count)
+  freelist<T>::freelist (factory &freelist_factory, size_t block_size, size_t initial_block_count)
     : m_factory (freelist_factory)
     , m_block_size (block_size)
     , m_available_count (block_size * initial_block_count)

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -74,7 +74,7 @@ namespace lockfree
   // freelist
   //
   template <class T>
-  freelist<T>::freelist (factory &freelist_factory, size_t block_size, size_t initial_block_count)
+  freelist<T>::freelist (size_t block_size, size_t initial_block_count)
     : m_block_size (block_size)
     , m_available_list { NULL }
     , m_available_count { 0 }
@@ -176,7 +176,6 @@ namespace lockfree
     size_t list_size = 1;
     for (tail = head; tail->get_freelist_link () != NULL; tail = tail->get_freelist_link ())
       {
-	m_factory.uninit (*tail);
 	++list_size;
       }
     assert (tail != NULL);

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -72,6 +72,11 @@ namespace lockfree
   };
 } // namespace lockfree
 
+//
+// implementation
+//
+#include <cassert>
+
 namespace lockfree
 {
   //
@@ -81,8 +86,9 @@ namespace lockfree
   freelist<T>::freelist (factory &freelist_factory, size_t block_size, size_t initial_block_count)
     : m_factory (freelist_factory)
     , m_block_size (block_size)
-    , m_available_count (block_size * initial_block_count)
     , m_available_list { NULL }
+    , m_available_count (block_size * initial_block_count)
+    , m_alloc_count { 0 }
   {
     for (size_t i = 0; i < initial_block_count; i++)
       {
@@ -134,7 +140,7 @@ namespace lockfree
 	alloc_block ();
       }
     assert (t != NULL);
-    m_factory->init (*t);
+    m_factory.init (*t);
     m_available_count--;
     return t;
   }
@@ -182,11 +188,11 @@ namespace lockfree
     size_t list_size = 1;
     for (tail = head; tail->get_freelist_link () != NULL; tail = tail->get_freelist_link ())
       {
-	m_factory->uninit (*tail);
+	m_factory.uninit (*tail);
 	++list_size;
       }
     assert (tail != NULL);
-    m_factory->uninit (*tail);
+    m_factory.uninit (*tail);
     push (head, tail);
     m_available_count += list_size;
   }

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -376,7 +376,6 @@ namespace lockfree
 	++list_count;
       }
     assert (list_count == m_available_count);
-    m_available_list = 0;
 #endif // DEBUG
   }
 } // namespace lockfree

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+#ifndef _LOCKFREE_FREELIST_HPP_
+#define _LOCKFREE_FREELIST_HPP_
+
+#include <atomic>
+#include <cstddef>
+
+namespace lockfree
+{
+  // template T:
+  //  methods:
+  //    freelist::atomic_link_type &get_freelist_link ();
+  template <class T>
+  class freelist
+  {
+    public:
+      using atomic_link_type = std::atomic<T *>;
+
+      class factory
+      {
+	public:
+	  factory () = default;
+	  virtual ~factory () = default;
+
+	  virtual T *alloc ();
+	  virtual void init (T &t);
+	  virtual void uninit (T &t);
+      };
+
+      freelist () = delete;
+      freelist (factory<T> &freelist_factory, size_t block_size, size_t initial_block_count = 1);
+      ~freelist ();
+
+      T *claim ();
+
+      // make sure what you retire is no longer accessible
+      void retire (T &t);
+      void retire_list (T *head);
+
+    private:
+      factory<T> &m_factory;
+
+      size_t m_block_size;
+
+      atomic_link_type m_available_list;
+
+      // statistics:
+      std::atomic<size_t> m_available_count;
+      std::atomic<size_t> m_alloc_count;
+
+      T *alloc_block ();
+      T *pop ();
+      void push (T *head, T *tail);
+  };
+} // namespace lockfree
+
+namespace lockfree
+{
+  //
+  // freelist
+  //
+  template <class T>
+  freelist<T>::freelist (factory<T> &freelist_factory, size_t block_size, size_t initial_block_count)
+    : m_factory (freelist_factory)
+    , m_block_size (block_size)
+    , m_available_count (block_size * initial_block_count)
+    , m_available_list { NULL }
+  {
+    for (size_t i = 0; i < initial_block_count; i++)
+      {
+	alloc_block ();
+      }
+  }
+
+  template <class T>
+  T *
+  freelist<T>::alloc_block ()
+  {
+    T *block_head = NULL;
+    T *block_tail = NULL;
+    T *t;
+    for (size_t i = 0; i < m_block_size; i++)
+      {
+	t = m_factory.alloc ();
+	if (block_tail == NULL)
+	  {
+	    block_tail = t;
+	  }
+	t->get_freelist_link ().store (block_head);
+	block_head = t;
+      }
+    push (block_head, block_tail);
+
+    m_available_count += m_block_size;
+    m_alloc_count += m_block_size;
+  }
+
+  template <class T>
+  freelist<T>::~freelist ()
+  {
+    T *save_next = NULL;
+    for (T *t = m_available_list; t != NULL; t = save_next)
+      {
+	save_next = t->get_freelist_link ().load ();
+	delete t;
+      }
+  }
+
+  template <class T>
+  T *
+  freelist<T>::claim ()
+  {
+    T *t;
+    for (t = pop (); t == NULL; t = pop ())
+      {
+	alloc_block ();
+      }
+    assert (t != NULL);
+    m_factory->init (*t);
+    m_available_count--;
+    return t;
+  }
+
+  template <class T>
+  T *
+  freelist<T>::pop ()
+  {
+    T *rhead = NULL;
+    T *next;
+    do
+      {
+	rhead = m_available_list;
+	if (rhead == NULL)
+	  {
+	    return NULL;
+	  }
+	next = rhead->get_freelist_link ().load ();
+      }
+    while (!m_available_list.compare_exchange_strong (rhead, next));
+
+    rhead->get_freelist_link ().store (NULL);
+    return rhead;
+  }
+
+  template <class T>
+  void
+  freelist<T>::retire (T &t)
+  {
+    m_factory.uninit (t);
+    push (&t, &t);
+    m_available_count++;
+  }
+
+  template <class T>
+  void
+  freelist<T>::retire_list (T *head)
+  {
+    if (head == NULL)
+      {
+	return;
+      }
+
+    T *tail;
+    size_t list_size = 1;
+    for (tail = head; tail->get_freelist_link () != NULL; tail = tail->get_freelist_link ())
+      {
+	m_factory->uninit (*tail);
+	++list_size;
+      }
+    assert (tail != NULL);
+    m_factory->uninit (*tail);
+    push (head, tail);
+    m_available_count += list_size;
+  }
+
+  template <class T>
+  void
+  freelist<T>::push (T *head, T *tail)
+  {
+    T *avail_head;
+    assert (head != NULL);
+    assert (tail != NULL);
+    assert (tail->get_freelist_link () == NULL);
+
+    do
+      {
+	avail_head = m_available_list;
+	tail->get_freelist_link () = avail_head;
+      }
+    while (m_available_list.compare_exchange_strong (avail_head, head));
+  }
+
+  //
+  // freelist::factory
+  //
+  template<class T>
+  T *
+  freelist<T>::factory::alloc ()
+  {
+    return new T ();
+  }
+
+  template<class T>
+  void
+  freelist<T>::factory::init (T &t)
+  {
+  }
+
+  template<class T>
+  void
+  freelist<T>::factory::uninit (T &t)
+  {
+  }
+} // namespace lockfree
+
+#endif // !_LOCKFREE_FREELIST_HPP_

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -234,6 +234,7 @@ namespace lockfree
   T *
   freelist<T>::claim ()
   {
+    // todo: make sure transaction is open here
     T *t;
     size_t count = 0;
     for (t = pop_from_available (); t == NULL && count < 100; t = pop_from_available (), ++count)
@@ -287,6 +288,7 @@ namespace lockfree
   void
   freelist<T>::retire (T &t)
   {
+    // make sure transaction is open here and transaction ID was incremented
     push_to_list (&t, &t, m_available_list);
     m_available_count++;
   }
@@ -295,6 +297,7 @@ namespace lockfree
   void
   freelist<T>::retire_list (T *head)
   {
+    // make sure transaction is open here and transaction ID was incremented
     if (head == NULL)
       {
 	return;

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -66,7 +66,7 @@ namespace lockfree
       std::atomic<size_t> m_available_count;
       std::atomic<size_t> m_alloc_count;
 
-      T *alloc_block ();
+      void alloc_block ();
       T *pop ();
       void push (T *head, T *tail);
   };
@@ -97,7 +97,7 @@ namespace lockfree
   }
 
   template <class T>
-  T *
+  void
   freelist<T>::alloc_block ()
   {
     T *block_head = NULL;

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -78,7 +78,7 @@ namespace lockfree
       T *pop_from_available ();
       void push_to_list (T *head, T *tail, atomic_link_type &dest);
 
-      void final_sanity_checks ();
+      void final_sanity_checks () const;
   };
 } // namespace lockfree
 
@@ -223,22 +223,6 @@ namespace lockfree
     // move back-buffer to available
     dealloc_list (m_backbuffer_head.load ());
     dealloc_list (m_available_list.load ());
-  }
-
-  template <class T>
-  void
-  freelist::clear_available_list ()
-  {
-    // pull available list
-    T *rhead = NULL;
-    T *rhead_copy;
-    do
-      {
-	rhead = m_available_list;
-	rhead_copy = rhead;
-      }
-    while (!m_available_list.compare_exchange_strong (rhead_copy, NULL));
-    dealloc_list (rhead);
   }
 
   template <class T>

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -42,7 +42,6 @@ namespace lockfree
 
       // make sure what you retire is no longer accessible
       void retire (T &t);
-      void retire_list (T *head);
 
       size_t get_alloc_count () const;
       size_t get_available_count () const;
@@ -291,27 +290,6 @@ namespace lockfree
     // make sure transaction is open here and transaction ID was incremented
     push_to_list (&t, &t, m_available_list);
     m_available_count++;
-  }
-
-  template<class T>
-  void
-  freelist<T>::retire_list (T *head)
-  {
-    // make sure transaction is open here and transaction ID was incremented
-    if (head == NULL)
-      {
-	return;
-      }
-
-    T *tail;
-    size_t list_size = 1;
-    for (tail = head; tail->get_freelist_link () != NULL; tail = tail->get_freelist_link ())
-      {
-	++list_size;
-      }
-    assert (tail != NULL);
-    push_to_list (head, tail, m_available_list);
-    m_available_count += list_size;
   }
 
   template<class T>

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -270,6 +270,12 @@ namespace lockfree
 	  }
 	next = rhead->get_freelist_link ().load ();
 	rhead_copy = rhead;
+	// todo: this is a dangerous preemption point; if I am preempted here, and thread 2 comes and does:
+	//   - second thread gets same rhead and successfully moves m_available_list to next
+	//   - third thread gets next and successfully moves m_available_list to next->next
+	//   - second thread retires rhead. m_available_list becomes rhead and its next becomes next->next
+	//   - I wake up, compare exchange m_available_list successfully because it is rhead again, but next will
+	//     become the item third thread already claimed.
       }
     while (!m_available_list.compare_exchange_strong (rhead_copy, next));
 

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -211,7 +211,7 @@ namespace lockfree
 	avail_head = m_available_list;
 	tail->get_freelist_link () = avail_head;
       }
-    while (m_available_list.compare_exchange_strong (avail_head, head));
+    while (!m_available_list.compare_exchange_strong (avail_head, head));
   }
 
   //

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -55,6 +55,9 @@ namespace lockfree
       void retire (T &t);
       void retire_list (T *head);
 
+      size_t get_alloc_count () const;
+      size_t get_available_count () const;
+
     private:
       factory &m_factory;
 
@@ -175,7 +178,7 @@ namespace lockfree
     m_available_count++;
   }
 
-  template <class T>
+  template<class T>
   void
   freelist<T>::retire_list (T *head)
   {
@@ -197,7 +200,7 @@ namespace lockfree
     m_available_count += list_size;
   }
 
-  template <class T>
+  template<class T>
   void
   freelist<T>::push (T *head, T *tail)
   {
@@ -212,6 +215,20 @@ namespace lockfree
 	tail->get_freelist_link () = avail_head;
       }
     while (!m_available_list.compare_exchange_strong (avail_head, head));
+  }
+
+  template<class T>
+  size_t
+  freelist<T>::get_alloc_count () const
+  {
+    return m_alloc_count;
+  }
+
+  template<class T>
+  size_t
+  freelist<T>::get_available_count () const
+  {
+    return m_available_count;
   }
 
   //

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -90,7 +90,7 @@ namespace lockfree
     : m_factory (freelist_factory)
     , m_block_size (block_size)
     , m_available_list { NULL }
-    , m_available_count (block_size * initial_block_count)
+    , m_available_count { 0 }
     , m_alloc_count { 0 }
   {
     for (size_t i = 0; i < initial_block_count; i++)

--- a/unit_tests/lockfree/CMakeLists.txt
+++ b/unit_tests/lockfree/CMakeLists.txt
@@ -19,9 +19,11 @@
 set (TEST_LOCKFREE_SOURCES
   test_main.cpp
   test_cqueue_functional.cpp
+  test_freelist_functional.cpp
 )
 set (TEST_LOCKFREE_HEADERS
   test_cqueue_functional.hpp
+  test_freelist_functional.hpp
 )
 SET_SOURCE_FILES_PROPERTIES(
   ${TEST_LOCKFREE_SOURCES}

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -149,6 +149,9 @@ namespace test_lockfree
   run_test (size_t thread_count, size_t ops_per_thread, size_t claim_weight, size_t retire_weight,
 	    size_t retire_all_weight)
   {
+    g_item_alloc_count = 0;
+    g_item_dealloc_count = 0;
+
     my_freelist l_freelist { thread_count * 10, 1 };
     size_t total_weight = claim_weight + retire_weight + retire_all_weight;
     string_buffer desc_str;
@@ -193,9 +196,6 @@ namespace test_lockfree
 	  l_finish_condvar.notify_all ();
 	}
     };
-
-    g_item_alloc_count = 0;
-    g_item_dealloc_count = 0;
 
     for (size_t i = 0; i < thread_count; i++)
       {

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -149,7 +149,7 @@ namespace test_lockfree
     my_freelist l_freelist { thread_count * 10, 1 };
     size_t total_weight = claim_weight + retire_weight + retire_all_weight;
     string_buffer desc_str;
-    desc_str ("run_test: threads = %zu, ops = %zu", thread_count, ops_per_thread);
+    desc_str ("run_test: threads = %zu, ops = %zu, ", thread_count, ops_per_thread);
     dump_all_percentage (desc_str, claim_weight, retire_weight, retire_all_weight);
     desc_str ("\n");
 

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -31,7 +31,7 @@
 
 using namespace lockfree;
 
-namespace test_freelist
+namespace test_lockfree
 {
   struct my_item
   {

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -137,8 +137,6 @@ namespace test_lockfree
 	  }
       }
 
-    lffl.retire_list (my_list);
-
     f_on_finish (my_list);
   }
 

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+#include "test_freelist_functional.hpp"
+
+#include "lockfree_freelist.hpp"
+
+using namespace lockfree;
+
+namespace test_freelist
+{
+  int
+  test_freelist_function ()
+  {
+    return 0;
+  }
+}

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -171,7 +171,7 @@ namespace test_lockfree
 	  l_remaining_tail->get_freelist_link ().store (list);
 	}
       for (l_remaining_tail = list; l_remaining_tail->get_freelist_link() != NULL;
-	   l_remaining_tail = l_remaining_head->get_freelist_link())
+	   l_remaining_tail = l_remaining_tail->get_freelist_link())
 	;
       ulock.unlock ();
       if (l_finish_pred ())

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -231,6 +231,7 @@ namespace test_lockfree
     test_common::custom_assert (l_freelist.get_alloc_count ()
 				== l_freelist.get_available_count () + l_freelist.get_backbuffer_count ());
     test_common::custom_assert (l_freelist.get_backbuffer_count () == BLOCK_SIZE);
+    test_common::custom_assert (l_freelist.get_forced_allocation_count () == 0); // not sure we can really expect this
 
     l_freelist.clear ();
     test_common::custom_assert (g_item_dealloc_count == g_item_alloc_count);

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -85,7 +85,7 @@ namespace test_lockfree
     size_t random_var;
     size_t total_weight = claim_weight + retire_weight + retire_all_weight;
 
-    my_item *my_list;
+    my_item *my_list = NULL;
 
     while (ops-- > 0)
       {
@@ -115,6 +115,8 @@ namespace test_lockfree
 	    my_list = NULL;
 	  }
       }
+
+    lffl.retire_list (my_list);
 
     f_on_finish ();
   }

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -103,11 +103,14 @@ namespace test_lockfree
 	  }
 	else if (random_var < claim_weight + retire_weight)
 	  {
-	    my_item *t = my_list;
-	    my_list = t->m_link;
-	    t->m_link = NULL;
+	    if (my_list != NULL)
+	      {
+		my_item *t = my_list;
+		my_list = t->m_link;
+		t->m_link = NULL;
 
-	    lffl.retire (*t);
+		lffl.retire (*t);
+	      }
 	  }
 	else
 	  {

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -233,7 +233,7 @@ namespace test_lockfree
     test_common::custom_assert (l_freelist.get_backbuffer_count () == BLOCK_SIZE);
     test_common::custom_assert (l_freelist.get_forced_allocation_count () == 0); // not sure we can really expect this
 
-    l_freelist.clear ();
+    l_freelist.~my_freelist ();
     test_common::custom_assert (g_item_dealloc_count == g_item_alloc_count);
 
     return 0;

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -21,13 +21,183 @@
 
 #include "lockfree_freelist.hpp"
 
+#include <cassert>
+#include <condition_variable>
+#include <cstdlib>
+#include <ctime>
+#include <functional>
+#include <mutex>
+#include <thread>
+
 using namespace lockfree;
 
 namespace test_freelist
 {
-  int
-  test_freelist_function ()
+  struct my_item
   {
-    return 0;
+    std::atomic<bool> m_claimed;
+    freelist<my_item>::atomic_link_type m_link;
+
+    my_item ();
+
+    freelist<my_item>::atomic_link_type &get_freelist_link ()
+    {
+      return m_link;
+    }
+  };
+
+  using my_freelist = freelist<my_item>;
+
+  class my_factory : public my_freelist::factory
+  {
+    public:
+      my_factory () = default;
+
+      my_item *alloc () override;
+      void init (my_item &t);
+      void uninit (my_item &t);
+
+    private:
+      std::atomic<size_t> m_alloc_count;
+      std::atomic<size_t> m_init_count;
+      std::atomic<size_t> m_uninit_count;
+  };
+
+  static void run_job (my_freelist &lffl, size_t ops, size_t claim_weight, size_t retire_weight,
+		       size_t retire_all_weight, const std::function<void()> &f_on_finish);
+  static int run_test (size_t thread_count, size_t ops_per_thread, size_t claim_weight, size_t retire_weight,
+		       size_t retire_all_weight);
+
+  int
+  test_freelist_functional ()
+  {
+    std::srand (std::time (nullptr));
+
+    int err = run_test (4, 1000, 60, 39, 1);
+
+    return err;
+  }
+
+  void
+  run_job (my_freelist &lffl, size_t ops, size_t claim_weight, size_t retire_weight, size_t retire_all_weight,
+	   const std::function<void()> &f_on_finish)
+  {
+    size_t random_var;
+    size_t total_weight = claim_weight + retire_weight + retire_all_weight;
+
+    my_item *my_list;
+
+    while (ops-- > 0)
+      {
+	random_var = std::rand () % total_weight;
+	if (random_var < claim_weight)
+	  {
+	    my_item *t = lffl.claim ();
+	    if (t == NULL)
+	      {
+		// claim error
+		abort ();
+	      }
+	    t->get_freelist_link ().store (my_list);
+	    my_list = t;
+	  }
+	else if (random_var < claim_weight + retire_weight)
+	  {
+	    my_item *t = my_list;
+	    my_list = t->m_link;
+	    t->m_link = NULL;
+
+	    lffl.retire (*t);
+	  }
+	else
+	  {
+	    lffl.retire_list (my_list);
+	    my_list = NULL;
+	  }
+      }
+
+    f_on_finish ();
+  }
+
+  int
+  run_test (size_t thread_count, size_t ops_per_thread, size_t claim_weight, size_t retire_weight,
+	    size_t retire_all_weight)
+  {
+    my_factory l_factory;
+    my_freelist l_freelist { l_factory, thread_count * 10, 1 };
+
+    size_t l_finished_count = 0;
+    std::mutex l_finish_mutex;
+    std::condition_variable l_finish_condvar;
+    std::function<void ()> l_finish_func = [&thread_count, &l_finished_count, &l_finish_mutex, &l_finish_condvar] ()
+    {
+      size_t count;
+      std::unique_lock<std::mutex> ulock (l_finish_mutex);
+      count = ++l_finished_count;
+      ulock.unlock ();
+      if (count == thread_count)
+	{
+	  l_finish_condvar.notify_all ();
+	}
+    };
+
+    for (size_t i = 0; i < thread_count; i++)
+      {
+	std::thread thr
+	{
+	  run_job, std::ref (l_freelist), ops_per_thread, claim_weight, retire_weight, retire_all_weight,
+	  l_finish_func
+	};
+	thr.detach ();
+      }
+
+    std::unique_lock<std::mutex> ulock (l_finish_mutex);
+    l_finish_condvar.wait (ulock, [&thread_count, &l_finished_count] ()
+    {
+      return thread_count == l_finished_count;
+    });
+  }
+
+  //
+  // my_item
+  //
+  my_item::my_item ()
+    : m_claimed (false)
+    , m_link (NULL)
+  {
+  }
+
+  //
+  // my_factory
+  //
+  my_item *
+  my_factory::alloc ()
+  {
+    m_alloc_count++;
+    return new my_item ();
+  }
+
+  void
+  my_factory::init (my_item &t)
+  {
+    if (t.m_claimed.exchange (true))
+      {
+	// was claimed error
+	abort ();
+      }
+    m_init_count++;
+    t.m_claimed = true;
+  }
+
+  void
+  my_factory::uninit (my_item &t)
+  {
+    if (!t.m_claimed.exchange (false))
+      {
+	// was not claimed error
+	abort ();
+      }
+    m_uninit_count++;
+    t.m_claimed = false;
   }
 }

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -153,6 +153,8 @@ namespace test_lockfree
     dump_all_percentage (desc_str, claim_weight, retire_weight, retire_all_weight);
     desc_str ("\n");
 
+    test_common::sync_cout (desc_str.get_buffer ());
+
     size_t l_finished_count = 0;
     auto l_finish_pred = [&thread_count, &l_finished_count] ()
     {

--- a/unit_tests/lockfree/test_freelist_functional.cpp
+++ b/unit_tests/lockfree/test_freelist_functional.cpp
@@ -54,7 +54,7 @@ namespace test_lockfree
   class my_factory : public my_freelist::factory
   {
     public:
-      my_factory () = default;
+      my_factory ();
 
       my_item *alloc () override;
       void init (my_item &t);
@@ -225,6 +225,13 @@ namespace test_lockfree
   //
   // my_factory
   //
+  my_factory::my_factory ()
+    : m_alloc_count { 0 }
+    , m_init_count { 0 }
+    , m_uninit_count { 0 }
+  {
+  }
+
   my_item *
   my_factory::alloc ()
   {

--- a/unit_tests/lockfree/test_freelist_functional.hpp
+++ b/unit_tests/lockfree/test_freelist_functional.hpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+#ifndef _TEST_FREELIST_FUNCTIONAL_HPP_
+#define _TEST_FREELIST_FUNCTIONAL_HPP_
+
+namespace test_lockfree
+{
+  int test_freelist_function ();
+}
+
+#endif // !_TEST_FREELIST_FUNCTIONAL_HPP_

--- a/unit_tests/lockfree/test_freelist_functional.hpp
+++ b/unit_tests/lockfree/test_freelist_functional.hpp
@@ -22,7 +22,7 @@
 
 namespace test_lockfree
 {
-  int test_freelist_function ();
+  int test_freelist_functional ();
 }
 
 #endif // !_TEST_FREELIST_FUNCTIONAL_HPP_

--- a/unit_tests/lockfree/test_main.cpp
+++ b/unit_tests/lockfree/test_main.cpp
@@ -19,9 +19,38 @@
 
 #include "test_cqueue_functional.hpp"
 
+#include <string>
+#include <vector>
+
 int
-main (int, char **)
+main (int argc, char **argv)
 {
-  int err = test_lockfree::test_cqueue_functional ();
-  return 0;
+  size_t opt = 0;
+  std::vector<std::string> option_map =
+  {
+    "all",
+    "cqueue",
+    "freelist"
+  };
+  if (argc == 1)
+    {
+      for (size_t i = 0; i < option_map.size (); i++)
+	{
+	  if (option_map[i] == argv[0])
+	    {
+	      opt = i;
+	    }
+	}
+    }
+  int err = 0;
+  if (opt == 0 || opt == 1)
+    {
+      err = err | test_lockfree::test_cqueue_functional ();
+    }
+  if (opt == 0 || opt == 2)
+    {
+      // todo: lockfree
+    }
+
+  return err;
 }

--- a/unit_tests/lockfree/test_main.cpp
+++ b/unit_tests/lockfree/test_main.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "test_cqueue_functional.hpp"
+#include "test_freelist_functional.hpp"
 
 #include <string>
 #include <vector>
@@ -49,7 +50,7 @@ main (int argc, char **argv)
     }
   if (opt == 0 || opt == 2)
     {
-      // todo: lockfree
+      err = err | test_lockfree::test_freelist_functional ();
     }
 
   return err;

--- a/unit_tests/lockfree/test_main.cpp
+++ b/unit_tests/lockfree/test_main.cpp
@@ -33,11 +33,11 @@ main (int argc, char **argv)
     "cqueue",
     "freelist"
   };
-  if (argc == 1)
+  if (argc == 2)
     {
       for (size_t i = 0; i < option_map.size (); i++)
 	{
-	  if (option_map[i] == argv[0])
+	  if (option_map[i] == argv[1])
 	    {
 	      opt = i;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23266

Implement a class for subset functionality of existing LF_FREELIST. lockfree::freelist provides lock-free claim and retire of preallocated resources, but it does not guarantee no thread is accessing retired resources. This guarantee is to be provided by lock-free transaction system.

Freelist is a template class and can be specialized with any type that has a method with the signature `lockfree::freelist::atomic_link_type &get_freelist_link`, with `using atomic_link_type = std::atomic<T *>`. This link is used by freelist internally. Resources can then be claimed or retired one by one, or retired as a list using freelist link.

There are two tests in the unit test, with 4 threads and 64 threads respectively. The 64 threads test fails, I need to investigate it further.