### PR TITLE
[CBRD-22679] blacklist functions returning json_types as function_indexes

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -18275,6 +18275,7 @@ pt_function_is_allowed_as_function_index (const PT_NODE * func)
   // TODO: expose get_signatures () of func_type.cpp & filter out funcs returning PT_TYPE_JSON
   switch (func->info.function.function_type)
     {
+    case F_BENCHMARK:
     case F_JSON_OBJECT:
     case F_JSON_ARRAY:
     case F_JSON_MERGE:

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -18275,7 +18275,6 @@ pt_function_is_allowed_as_function_index (const PT_NODE * func)
   // TODO: expose get_signatures () of func_type.cpp & filter out funcs returning PT_TYPE_JSON
   switch (func->info.function.function_type)
     {
-      // TODO: investigate whether there are other functions that are treated underneath a PT_FUNCTION_HOLDER
     case F_JSON_OBJECT:
     case F_JSON_ARRAY:
     case F_JSON_MERGE:

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -18291,6 +18291,18 @@ pt_function_is_allowed_as_function_index (const PT_NODE * func)
     case F_JSON_SEARCH:
     case F_JSON_EXTRACT:
       return false;
+    case F_INSERT_SUBSTRING:
+    case F_ELT:
+    case F_JSON_CONTAINS:
+    case F_JSON_CONTAINS_PATH:
+    case F_JSON_DEPTH:
+    case F_JSON_LENGTH:
+    case F_JSON_TYPE:
+    case F_JSON_VALID:
+    case F_JSON_PRETTY:
+    case F_JSON_QUOTE:
+    case F_JSON_UNQUOTE:
+      return true;
     default:
       return true;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22679

Blacklist functions returning db_json_type from being accepted function_indexes.