### PR TITLE
[CBRD-23267] Reset set_Ref_area and set_Object_area on area_final

### DIFF
--- a/src/base/area_alloc.c
+++ b/src/base/area_alloc.c
@@ -118,6 +118,8 @@ area_final (void)
     }
   area_List = NULL;
 
+  set_area_reset ();
+
   pthread_mutex_destroy (&area_List_lock);
 }
 

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -201,6 +201,12 @@ set_area_final (void)
     }
 }
 
+void
+set_area_reset ()
+{
+  Set_Ref_Area = Set_Obj_Area = NULL;
+}
+
 /* VALUE BLOCK RESOURCE */
 
 /* SET STRUCTURE ALLOCATION/DEALLOCATION */

--- a/src/object/set_object.h
+++ b/src/object/set_object.h
@@ -112,6 +112,7 @@ struct setobj
 extern DB_COLLECTION *set_create (DB_TYPE type, int initial_size);
 extern int set_area_init (void);
 extern void set_area_final (void);
+extern void set_area_reset ();
 extern DB_COLLECTION *set_create_basic (void);
 extern DB_COLLECTION *set_create_multi (void);
 extern DB_COLLECTION *set_create_sequence (int size);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23267

Regression of 1876. when area_final is called, the set variables must also be reset.