### PR TITLE
[CBRD-23281] loaddb: fix race condition on batch commit

### DIFF
--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -139,11 +139,8 @@ namespace cubload
       std::mutex m_commit_mutex;
       std::condition_variable m_commit_cond_var;
 
-      std::mutex m_completion_mutex;
-      std::condition_variable m_completion_cond_var;
-
       load_args m_args;
-      std::atomic<batch_id> m_last_batch_id;
+      batch_id m_last_batch_id;
       std::atomic<batch_id> m_max_batch_id;
 
       class_registry m_class_registry;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23281

Since `m_last_batch_id` is atomic there is a race condition between notification sent to `m_commit_cond_var` and `m_last_batch_id` assignment. Therefore assignment on `m_last_batch_id` must be protected by `m_commit_mutex`.