### PR TITLE
[CBRD-23290] no oldest unvacuumed update when data is empty

### DIFF
--- a/src/base/lockfree_circular_queue.hpp
+++ b/src/base/lockfree_circular_queue.hpp
@@ -55,8 +55,8 @@ namespace lockfree
       circular_queue (std::size_t size);
       ~circular_queue ();
 
-      inline bool is_empty () const;              // is query empty?
-      inline bool is_full () const;               // is query full?
+      inline bool is_empty () const;              // is query empty? use it for early outs but don't rely on the answer
+      inline bool is_full () const;               // is query full? use it for early outs but don't rely on the answer
       inline bool is_half_full ();
       inline std::size_t size ();
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23290

The existing logic of updating oldest unvacuumed in empty data corner case relies on the assumption that if `lockfree_circular_queue::is_empty ()` return false, following consume must succeed. The assumption is wrong, consume does additional checks (e.g. production is in progress) that may fail.

The fix just simplifies to only update oldest unvacuumed when data is not empty. As consequence, the oldest unvacuumed value may lag behind, but keeping an updated value is not critical. It is used for sanity checks that are still possible with a lagging value.