### PR TITLE
[CBRD-23295] loaddb: copy attribute name

### DIFF
--- a/src/loaddb/load_class_registry.cpp
+++ b/src/loaddb/load_class_registry.cpp
@@ -29,7 +29,7 @@ namespace cubload
 {
 
   // attribute
-  attribute::attribute (std::string &name, std::size_t index, or_attribute *repr)
+  attribute::attribute (const std::string &name, std::size_t index, or_attribute *repr)
     : m_name (name)
     , m_index (index)
     , m_repr (repr)

--- a/src/loaddb/load_class_registry.cpp
+++ b/src/loaddb/load_class_registry.cpp
@@ -30,7 +30,7 @@ namespace cubload
 
   // attribute
   attribute::attribute (std::string &name, std::size_t index, or_attribute *repr)
-    : m_name (std::move (name))
+    : m_name (name)
     , m_index (index)
     , m_repr (repr)
   {

--- a/src/loaddb/load_class_registry.hpp
+++ b/src/loaddb/load_class_registry.hpp
@@ -39,7 +39,7 @@ namespace cubload
   {
     public:
       attribute () = delete; // Not DefaultConstructible
-      attribute (std::string &name, std::size_t index, or_attribute *repr);
+      attribute (const std::string &name, std::size_t index, or_attribute *repr);
 
       attribute (attribute &&other) = delete; // Not MoveConstructible
       attribute (const attribute &copy) = delete; // Not CopyConstructible


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23295

Make sure that after attribute c-tor is called, the attribute name is not moved and can be used