### PR TITLE
[CBRD-23301] Fix error filtering and rows committed message

### DIFF
--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -88,6 +88,11 @@ namespace cubload
 
     for (int i = 0; i < NUM_DB_TYPES; i++)
       {
+	for (int j = 0; j < NUM_LDR_TYPES; j++)
+	  {
+	    setters_[i][j] = NULL;
+	  }
+
 	setters_[i][LDR_NULL] = &to_db_null;
       }
 

--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -90,9 +90,12 @@ namespace cubload
       {
 	for (int j = 0; j < NUM_LDR_TYPES; j++)
 	  {
-	    setters_[i][j] = NULL;
+	    setters_[i][j] = &mismatch;
 	  }
+      }
 
+    for (int i = 0; i < NUM_DB_TYPES; i++)
+      {
 	setters_[i][LDR_NULL] = &to_db_null;
       }
 
@@ -185,11 +188,6 @@ namespace cubload
   get_conv_func (const data_type ldr_type, const DB_TYPE db_type)
   {
     conv_func &c_func = setters[db_type][ldr_type];
-    if (c_func == NULL)
-      {
-	c_func = &mismatch;
-      }
-
     return c_func;
   }
 

--- a/src/loaddb/load_driver.cpp
+++ b/src/loaddb/load_driver.cpp
@@ -35,6 +35,7 @@ namespace cubload
     , m_error_handler (NULL)
     , m_semantic_helper ()
     , m_is_initialized (false)
+    , m_lines_inserted (0)
   {
     //
   }
@@ -54,6 +55,7 @@ namespace cubload
     m_error_handler = NULL;
 
     m_is_initialized = false;
+    m_lines_inserted = 0;
   }
 
   driver::~driver ()
@@ -71,6 +73,7 @@ namespace cubload
     m_error_handler = error_handler;
     m_scanner = new scanner (m_semantic_helper, *m_error_handler);
     m_is_initialized = true;
+    m_lines_inserted = 0;
   }
 
   bool
@@ -120,6 +123,18 @@ namespace cubload
   driver::get_scanner ()
   {
     return *m_scanner;
+  }
+
+  int
+  driver::get_lines_inserted ()
+  {
+    return m_lines_inserted;
+  }
+
+  void
+  driver::increment_lines_inserted ()
+  {
+    m_lines_inserted++;
   }
 
 } // namespace cubload

--- a/src/loaddb/load_driver.hpp
+++ b/src/loaddb/load_driver.hpp
@@ -89,6 +89,8 @@ namespace cubload
       semantic_helper &get_semantic_helper ();
       error_handler &get_error_handler ();
       scanner &get_scanner ();
+      int get_lines_inserted ();
+      void increment_lines_inserted ();
 
     private:
       scanner *m_scanner;
@@ -96,6 +98,7 @@ namespace cubload
       object_loader *m_object_loader;
       error_handler *m_error_handler;
       semantic_helper m_semantic_helper;
+      int m_lines_inserted;
 
       bool m_is_initialized;
   }; // class driver

--- a/src/loaddb/load_error_handler.cpp
+++ b/src/loaddb/load_error_handler.cpp
@@ -37,7 +37,8 @@ namespace cubload
 
 #if defined (SERVER_MODE)
   error_handler::error_handler (session &session)
-    : m_session (session)
+    : m_session (session),
+      m_current_line_has_error (false)
   {
     m_syntax_check = m_session.get_args ().syntax_check;
   }
@@ -137,12 +138,25 @@ namespace cubload
     // Clear the error if it is filtered
     if (is_filtered)
       {
-	er_clearid ();
+	er_clear ();
+	set_error_on_current_line (true);
       }
 
     return is_filtered;
 #endif
     return false;
+  }
+
+  bool
+  error_handler::current_line_has_error ()
+  {
+    return m_current_line_has_error;
+  }
+
+  void
+  error_handler::set_error_on_current_line (bool has_error)
+  {
+    m_current_line_has_error = has_error;
   }
 
 } // namespace cubload

--- a/src/loaddb/load_error_handler.hpp
+++ b/src/loaddb/load_error_handler.hpp
@@ -70,6 +70,9 @@ namespace cubload
       template<typename... Args>
       static std::string format_log_msg (MSGCAT_LOADDB_MSG msg_id, Args &&... args);
 
+      bool current_line_has_error ();
+      void set_error_on_current_line (bool has_error);
+
     private:
       int get_lineno ();
 
@@ -81,6 +84,8 @@ namespace cubload
 
       void log_error_message (std::string &err_msg, bool fail);
       bool is_last_error_filtered ();
+
+      bool m_current_line_has_error;
 
 #if defined (SERVER_MODE)
       session &m_session;

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -410,7 +410,16 @@ namespace cubload
 	  }
 
 	// Add the recdes to the collected array.
-	m_recdes_collected.push_back (std::move (new_recdes));
+	if (!m_error_handler.current_line_has_error ())
+	  {
+	    m_recdes_collected.push_back (std::move (new_recdes));
+	    m_thread_ref->m_loaddb_driver->increment_lines_inserted ();
+	  }
+	else
+	  {
+	    // Don't insert the record since we had an error.
+	    m_error_handler.set_error_on_current_line (false);
+	  }
       }
 
     m_session.stats_update_current_line (m_thread_ref->m_loaddb_driver->get_scanner ().lineno () + 1);

--- a/src/loaddb/load_session.cpp
+++ b/src/loaddb/load_session.cpp
@@ -153,6 +153,9 @@ namespace cubload
 	// We need this to update the stats.
 	int line_no = driver->get_scanner ().lineno ();
 
+	// Get the inserted lines
+	int lines_inserted = driver->get_lines_inserted ();
+
 	// We don't need anything from the driver anymore.
 	driver->clear ();
 
@@ -181,7 +184,7 @@ namespace cubload
 	      }
 
 	    // update load statistics after commit
-	    m_session.stats_update_rows_committed (m_batch.get_rows_number ());
+	    m_session.stats_update_rows_committed (lines_inserted);
 	    m_session.stats_update_last_committed_line (line_no + 1);
 
 	    if (!m_session.get_args ().syntax_check)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23301

When it happened to get an error during loading and the error was filtered, the worker will still insert the record, which proved to be `NULL`. Now, we avoid inserting the records that generated errors that were filtered during the load and we track them so that we generate the correct number of rows that were inserted.

Also, for the QA issue, the error that needs to be filtered to successfully avoid the coercion problem should be `ER_TP_CANT_COERCE -181`.