### PR TITLE
[CBRD-22377] loaddb: optimize batch commits ordering

### DIFF
--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -32,6 +32,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -105,8 +106,7 @@ namespace cubload
       int load_file (cubthread::entry &thread_ref);
 
       void wait_for_completion ();
-      void wait_for_previous_batch (batch_id id);
-      void notify_batch_done (batch_id id);
+      void notify_waiting_threads ();
 
       void on_error (std::string &err_msg);
 
@@ -114,6 +114,9 @@ namespace cubload
       bool is_failed ();
 
       void interrupt ();
+
+      void commit (cubthread::entry &thread_ref, const batch &b, int line_no, const std::string &class_name);
+      void abort (cubthread::entry &thread_ref, const batch &b);
 
       void fetch_stats (stats &stats_);
 
@@ -130,7 +133,6 @@ namespace cubload
       void append_log_msg (MSGCAT_LOADDB_MSG msg_id, Args &&... args);
 
     private:
-      void notify_waiting_threads ();
       bool is_completed ();
 
       template<typename T>
@@ -138,6 +140,8 @@ namespace cubload
 
       std::mutex m_commit_mutex;
       std::condition_variable m_commit_cond_var;
+
+      std::map<batch_id, int> m_commit_map;
 
       load_args m_args;
       batch_id m_last_batch_id;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22377

Refactor batch commit ordering for loaddb, pseudocode implementation:
```
commit (batch_id)
    if last_batch_id + 1 is different than batch_id
        // then save batch id (into commit map) and exit
        add batch_id to commit_map
        exit
    otherwise
        // commit everything from commit map, starting from last committed batch
        // and continuing with all consecutive entries from commit map
        for commit_entry ce in commit_map
            if ce.batch_id != last_batch_id + 1
                // there are no more consecutive entries
                exit

            commit (ce)
            delete ce from commit_map
            last_batch_id = ce.batch_id
```

Example with 4 batches:
commit batch 2, not possible since 1 was not yet committed: `commit_map = [2], last_batch_id=0`
commit batch 3, not possible since 2 was not yet committed: `commit_map = [2, 3], last_batch_id=0`
commit batch 1, possible, commit 1, 2 and 3: `commit_map = [], last_batch_id=3`
commit batch 4, possible: `commit_map = [], last_batch_id=4`
done