### PR TITLE
[CBRD-23315] Fix lines inserted reporting

### DIFF
--- a/src/loaddb/load_driver.cpp
+++ b/src/loaddb/load_driver.cpp
@@ -132,9 +132,9 @@ namespace cubload
   }
 
   void
-  driver::increment_lines_inserted ()
+  driver::increment_lines_inserted (int no_lines)
   {
-    m_lines_inserted++;
+    m_lines_inserted += no_lines;
   }
 
 } // namespace cubload

--- a/src/loaddb/load_driver.hpp
+++ b/src/loaddb/load_driver.hpp
@@ -90,7 +90,7 @@ namespace cubload
       error_handler &get_error_handler ();
       scanner &get_scanner ();
       int get_lines_inserted ();
-      void increment_lines_inserted ();
+      void increment_lines_inserted (int no_lines);
 
     private:
       scanner *m_scanner;

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -413,7 +413,6 @@ namespace cubload
 	if (!m_error_handler.current_line_has_error ())
 	  {
 	    m_recdes_collected.push_back (std::move (new_recdes));
-	    m_thread_ref->m_loaddb_driver->increment_lines_inserted ();
 	  }
 	else
 	  {
@@ -432,6 +431,7 @@ namespace cubload
     int force_count = 0;
     int pruning_type = 0;
     int op_type = MULTI_ROW_INSERT;
+    int records_inserted = 0;
 
     // First check if we have any errors set.
     if (m_session.is_failed ())
@@ -454,12 +454,14 @@ namespace cubload
 
     int error_code = locator_multi_insert_force (m_thread_ref, &m_scancache.node.hfid, &m_scancache.node.class_oid,
 		     m_recdes_collected, true, op_type, &m_scancache, &force_count, pruning_type, NULL, NULL,
-		     UPDATE_INPLACE_NONE, true);
+		     UPDATE_INPLACE_NONE, true, &records_inserted);
     if (error_code != NO_ERROR)
       {
 	ASSERT_ERROR ();
 	m_error_handler.on_failure ();
       }
+
+    m_thread_ref->m_loaddb_driver->increment_lines_inserted (records_inserted);
   }
 
   int

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13730,7 +13730,7 @@ int
 locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid,
 			    const std::vector<record_descriptor> &recdes, int has_index, int op_type,
 			    HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type, PRUNING_CONTEXT * pcontext,
-			    FUNC_PRED_UNPACK_INFO * func_preds, UPDATE_INPLACE_STYLE force_in_place, bool dont_check_fk)
+			    FUNC_PRED_UNPACK_INFO * func_preds, UPDATE_INPLACE_STYLE force_in_place, bool dont_check_fk, int *records_inserted)
 {
   int error_code = NO_ERROR;
   size_t accumulated_records_size = 0;
@@ -13771,6 +13771,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 	      ASSERT_ERROR ();
 	      return error_code;
 	    }
+          *records_inserted = *records_inserted + 1;
 	}
       else
 	{
@@ -13817,6 +13818,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 		    }
 
 		  pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &home_hint_p);
+                  *records_inserted = *records_inserted + 1;
 		}
 
 	      // Now log the whole page.
@@ -13854,10 +13856,14 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 	  ASSERT_ERROR ();
 	  return error_code;
 	}
+
+      *records_inserted = *records_inserted + 1;
     }
 
   // Log the postpone operation
   heap_log_postpone_heap_append_pages (thread_p, hfid, class_oid, heap_pages_array);
+
+  assert (*records_inserted == recdes_array.size ());
 
   return NO_ERROR;
 }

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -132,6 +132,6 @@ extern int locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID
 				       const std::vector<record_descriptor> &recdes, int has_index, int op_type,
 				       HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type,
 				       PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
-				       UPDATE_INPLACE_STYLE force_in_place, bool dont_check_fk);
+				       UPDATE_INPLACE_STYLE force_in_place, bool dont_check_fk, int * records_inserted);
 // *INDENT-ON*
 #endif /* _LOCATOR_SR_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23315

Fixed the lines inserted reported message in case of errors. Now we collect information about inserted records at each step, even if we encounter an error. Afterwards, we add these numbers into the driver of the loaddb.