### PR TITLE
[CBRD-23330] Fix vacuum_master_task refactoring regressions

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2885,8 +2885,7 @@ vacuum_master_task::execute (cubthread::entry &thread_ref)
   pgbuf_flush_if_requested (&thread_ref, (PAGE_PTR) vacuum_Data.first_page);
   pgbuf_flush_if_requested (&thread_ref, (PAGE_PTR) vacuum_Data.last_page);
 
-  vacuum_Data.update ();
-  m_cursor.load ();
+  m_cursor.force_data_update ();
   vacuum_er_log (VACUUM_ER_LOG_MASTER | VACUUM_ER_LOG_JOBS, "Start searching jobs at " vacuum_job_cursor_print_format,
                  vacuum_job_cursor_print_args (m_cursor));
   for (; m_cursor.is_valid () && !should_interrupt_iteration (); m_cursor.increment_blockid ())

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1256,13 +1256,17 @@ vacuum_stop (THREAD_ENTRY * thread_p)
 #if defined (SERVER_MODE)
       vacuum_Worker_threads->er_log_stats ();
 #endif // SERVER_MODE
-      thread_manager->destroy_worker_pool (vacuum_Worker_threads);
+      vacuum_Worker_threads->stop_execution ();
     }
 
   // stop master daemon
   if (vacuum_Master_daemon != NULL)
     {
       thread_manager->destroy_daemon (vacuum_Master_daemon);
+    }
+  if (vacuum_Worker_threads != NULL)
+    {
+      thread_manager->destroy_worker_pool (vacuum_Worker_threads);
     }
 
   delete vacuum_Master_context_manager;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1255,8 +1255,8 @@ vacuum_stop (THREAD_ENTRY * thread_p)
     {
 #if defined (SERVER_MODE)
       vacuum_Worker_threads->er_log_stats ();
-#endif // SERVER_MODE
       vacuum_Worker_threads->stop_execution ();
+#endif // SERVER_MODE
     }
 
   // stop master daemon


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23330

- Readjust cursor after first vacuum data update in each iteration.
- Destroy worker pool after master daemon. Daemon pushes task on own thread if pool is destroyed.

Regression of #1915