### PR TITLE
[CBRD-23339] C++ interface for existing lock-free hash

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -46,6 +46,7 @@ set(THREAD_SOURCES
   ${THREAD_DIR}/thread_daemon.cpp
   ${THREAD_DIR}/thread_entry.cpp
   ${THREAD_DIR}/thread_entry_task.cpp
+  ${THREAD_DIR}/thread_lockfree_hash_map.cpp
   ${THREAD_DIR}/thread_looper.cpp
   ${THREAD_DIR}/thread_manager.cpp
   ${THREAD_DIR}/thread_waiter.cpp
@@ -58,9 +59,10 @@ set(THREAD_HEADERS
   ${THREAD_DIR}/thread_daemon.hpp
   ${THREAD_DIR}/thread_entry.hpp
   ${THREAD_DIR}/thread_entry_task.hpp
-  ${THREAD_DIR}/thread_task.hpp
+  ${THREAD_DIR}/thread_lockfree_hash_map.hpp
   ${THREAD_DIR}/thread_looper.hpp
   ${THREAD_DIR}/thread_manager.hpp
+  ${THREAD_DIR}/thread_task.hpp
   ${THREAD_DIR}/thread_waiter.hpp
   ${THREAD_DIR}/thread_worker_pool.hpp
   ${THREAD_DIR}/thread_worker_pool_taskcap.hpp

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -291,12 +291,14 @@ set(THREAD_SOURCES
   ${THREAD_DIR}/critical_section_tracker.cpp
   ${THREAD_DIR}/thread_entry.cpp
   ${THREAD_DIR}/thread_entry_task.cpp
+  ${THREAD_DIR}/thread_lockfree_hash_map.cpp
   ${THREAD_DIR}/thread_manager.cpp
   )
 set(THREAD_HEADERS
   ${THREAD_DIR}/critical_section_tracker.hpp
   ${THREAD_DIR}/thread_compat.hpp
   ${THREAD_DIR}/thread_entry.hpp
+  ${THREAD_DIR}/thread_lockfree_hash_map.hpp
   ${THREAD_DIR}/thread_manager.hpp
   )
 

--- a/src/base/lock_free.c
+++ b/src/base/lock_free.c
@@ -24,9 +24,6 @@
 
 #include "config.h"
 
-#if !defined (WINDOWS)
-#include <pthread.h>
-#endif
 #include <assert.h>
 
 #include "porting.h"

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -28,6 +28,11 @@
 #include "lockfree_bitmap.hpp"
 #include "porting.h"
 
+#include <cassert>
+#if !defined (WINDOWS)
+#include <pthread.h>
+#endif
+
 /*
  * Some common hash, copy and compare functions
  */
@@ -503,7 +508,7 @@ bool
 lf_hash_table_cpp<Key, T>::erase (lf_tran_entry *t_entry, Key &key)
 {
   int success = 0;
-  if (lf_hash_delete (t_entry, &m_table, &key, &success) != NO_ERROR)
+  if (lf_hash_delete (t_entry, &m_hash, &key, &success) != NO_ERROR)
     {
       assert (false);
     }

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -520,7 +520,7 @@ bool
 lf_hash_table_cpp<Key, T>::erase_locked (lf_tran_entry *t_entry, Key &key, T *&t)
 {
   int success = 0;
-  if (lf_hash_delete_already_locked (t_entry, &key, t, &success) != NO_ERROR)
+  if (lf_hash_delete_already_locked (t_entry, &key, &m_hash, t, &success) != NO_ERROR)
     {
       assert (false);
       pthread_mutex_unlock (get_pthread_mutex (t));

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -475,7 +475,7 @@ bool
 lf_hash_table_cpp<Key, T>::generic_insert (F &ins_func, lf_tran_entry *t_entry, Key &key, T *&t)
 {
   int inserted = 0;
-  if (ins_func (t_entry, &m_hash, &key, static_cast<void **> (&t), &inserted) != NO_ERROR)
+  if (ins_func (t_entry, &m_hash, &key, reinterpret_cast<void **> (&t), &inserted) != NO_ERROR)
     {
       assert (false);
     }

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -475,7 +475,7 @@ bool
 lf_hash_table_cpp<Key, T>::generic_insert (F &ins_func, lf_tran_entry *t_entry, Key &key, T *&t)
 {
   int inserted = 0;
-  if (ins_func (t_entry, &m_hash, &key, &t, &inserted) != NO_ERROR)
+  if (ins_func (t_entry, &m_hash, &key, static_cast<void **> (&t), &inserted) != NO_ERROR)
     {
       assert (false);
     }

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -525,7 +525,7 @@ lf_hash_table_cpp<Key, T>::erase_locked (lf_tran_entry *t_entry, Key &key, T *&t
       assert (false);
       pthread_mutex_unlock (get_pthread_mutex (t));
     }
-  if (success == 0)
+  if (success != 0)
     {
       t = NULL;
     }

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -475,7 +475,7 @@ bool
 lf_hash_table_cpp<Key, T>::generic_insert (F &ins_func, lf_tran_entry *t_entry, Key &key, T *&t)
 {
   int inserted = 0;
-  if (ins_func (t_entry, &m_hash, &key, t, &inserted) != NO_ERROR)
+  if (ins_func (t_entry, &m_hash, &key, &t, &inserted) != NO_ERROR)
     {
       assert (false);
     }
@@ -520,7 +520,7 @@ bool
 lf_hash_table_cpp<Key, T>::erase_locked (lf_tran_entry *t_entry, Key &key, T *&t)
 {
   int success = 0;
-  if (lf_hash_delete_already_locked (t_entry, &key, &m_hash, t, &success) != NO_ERROR)
+  if (lf_hash_delete_already_locked (t_entry, &m_hash, &key, t, &success) != NO_ERROR)
     {
       assert (false);
       pthread_mutex_unlock (get_pthread_mutex (t));
@@ -587,7 +587,7 @@ template <class Key, class T>
 T *
 lf_hash_table_cpp<Key, T>::iterator::iterate ()
 {
-  return lf_hash_iterate (&m_iter);
+  return static_cast<T *> (lf_hash_iterate (&m_iter));
 }
 
 // *INDENT-ON*

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -525,7 +525,10 @@ lf_hash_table_cpp<Key, T>::erase_locked (lf_tran_entry *t_entry, Key &key, T *&t
       assert (false);
       pthread_mutex_unlock (get_pthread_mutex (t));
     }
-  t = NULL;
+  if (success == 0)
+    {
+      t = NULL;
+    }
   return success != 0;
 }
 

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -359,6 +359,8 @@ template <class Key, class T>
 class lf_hash_table_cpp
 {
   public:
+    class iterator;
+
     lf_hash_table_cpp ();
 
     void init (lf_tran_system &transys, int hash_size, int freelist_block_count, int freelist_block_size,
@@ -376,6 +378,9 @@ class lf_hash_table_cpp
 
     void clear (lf_tran_entry *t_entry);
 
+    lf_hash_table &get_hash_table ();
+    lf_freelist &get_freelist ();
+
   private:
     pthread_mutex_t *get_pthread_mutex (T *t);
     template <typename F>
@@ -385,10 +390,28 @@ class lf_hash_table_cpp
     lf_hash_table m_hash;
 };
 
+template <class Key, class T>
+class lf_hash_table_cpp<Key, T>::iterator
+{
+  public:
+    iterator () = default;
+    iterator (lf_tran_entry *t_entry, lf_hash_table_cpp & hash);
+    ~iterator ();
+
+    T *iterate ();
+
+  private:
+    lf_hash_table_iterator m_iter;
+    T *m_crt_val;
+};
+
 //
 // implementation
 //
 
+//
+// lf_hash_table_cpp
+//
 template <class Key, class T>
 lf_hash_table_cpp<Key, T>::lf_hash_table_cpp ()
   : m_freelist LF_FREELIST_INITIALIZER
@@ -522,6 +545,44 @@ void
 lf_hash_table_cpp<Key, T>::clear (lf_tran_entry *t_entry)
 {
   lf_hash_clear (t_entry, &m_hash);
+}
+
+template <class Key, class T>
+lf_hash_table &
+lf_hash_table_cpp<Key, T>::get_hash_table ()
+{
+  return m_hash;
+}
+
+template <class Key, class T>
+lf_freelist &
+lf_hash_table_cpp<Key, T>::get_freelist ()
+{
+  return m_freelist;
+}
+
+//
+// lf_hash_table_cpp::iterator
+//
+
+template <class Key, class T>
+lf_hash_table_cpp<Key, T>::iterator::iterator (lf_tran_entry *t_entry, lf_hash_table_cpp & hash)
+  : m_iter ()
+  , m_crt_val (NULL)
+{
+  lf_hash_create_iterator (&m_iter, t_entry, &hash.m_hash);
+}
+
+template <class Key, class T>
+lf_hash_table_cpp<Key, T>::iterator::~iterator ()
+{
+}
+
+template <class Key, class T>
+T *
+lf_hash_table_cpp<Key, T>::iterator::iterate ()
+{
+  return lf_hash_iterate (&m_iter);
 }
 
 // *INDENT-ON*

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -362,7 +362,7 @@ class lf_hash_table_cpp
     lf_hash_table_cpp ();
 
     void init (lf_tran_system &transys, int hash_size, int freelist_block_count, int freelist_block_size,
-               lf_entry_descriptor &edes, int entry_idx);
+               lf_entry_descriptor &edes);
     void destroy ();
 
     T *find (lf_tran_entry *t_entry, Key &key);
@@ -383,7 +383,6 @@ class lf_hash_table_cpp
 
     lf_freelist m_freelist;
     lf_hash_table m_hash;
-    int m_entry_idx;
 };
 
 //
@@ -394,14 +393,13 @@ template <class Key, class T>
 lf_hash_table_cpp<Key, T>::lf_hash_table_cpp ()
   : m_freelist LF_FREELIST_INITIALIZER
   , m_hash LF_HASH_TABLE_INITIALIZER
-  , m_entry_idx (-1)
 {
 }
 
 template <class Key, class T>
 void
 lf_hash_table_cpp<Key, T>::init (lf_tran_system &transys, int hash_size, int freelist_block_count,
-    int freelist_block_size, lf_entry_descriptor &edesc, int entry_idx)
+                                 int freelist_block_size, lf_entry_descriptor &edesc)
 {
   if (lf_freelist_init (&m_freelist, freelist_block_count, freelist_block_size, &edesc, &transys) != NO_ERROR)
     {
@@ -413,7 +411,6 @@ lf_hash_table_cpp<Key, T>::init (lf_tran_system &transys, int hash_size, int fre
       assert (false);
       return;
     }
-  m_entry_idx = entry_idx;
 }
 
 template <class Key, class T>

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -1013,15 +1013,14 @@ test_hash_iterator ()
     }
 
   {
-    my_hashmap_iterator it
-    {
-    te, hashmap};
+    // *INDENT-OFF*
+    my_hashmap_iterator it { te, hashmap};
+    // *INDENT-ON*
     XENTRY *curr = NULL;
     char msg[256];
     int sum = 0;
 
-    lf_hash_create_iterator (&it, te, &hash);
-    for (curr = it->iterate (); curr != NULL; curr = it->iterate ())
+    for (curr = it.iterate (); curr != NULL; curr = it.iterate ())
       {
 	sum += curr->data;
       }

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -402,7 +402,7 @@ test_hash_proc_2 (void *param)
 
       if (i % 10 < 5)
 	{
-	  (void) hashmap->find_or_insert (te, key, &entry);
+	  (void) hashmap->find_or_insert (te, key, entry);
 	  if (entry == NULL)
 	    {
 	      PTHREAD_ABORT_AND_EXIT (ER_FAILED);
@@ -465,7 +465,7 @@ test_hash_proc_3 (void *param)
     {
       key = random_numbers[rand_base + i] % 1000;
 
-      (void) hashmap->find_or_insert (te, key, &entry);
+      (void) hashmap->find_or_insert (te, key, entry);
       if (entry == NULL)
 	{
 	  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
@@ -546,7 +546,7 @@ test_clear_proc_1 (void *param)
 	  if (i % 10 < 8)
 	    {
 	      entry = NULL;
-	      (void) hashmap->find_or_insert (te, key, &entry);
+	      (void) hashmap->find_or_insert (te, key, entry);
 	      hashmap->unlock (te, entry);
 	    }
 	  else if (i % 1000 < 999)
@@ -604,7 +604,7 @@ test_clear_proc_2 (void *param)
 	{
 	  if (i % 10 < 5)
 	    {
-	      (void) hashmap->find_or_insert (te, key, &entry);
+	      (void) hashmap->find_or_insert (te, key, entry);
 	      if (entry == NULL)
 		{
 		  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
@@ -675,7 +675,7 @@ test_clear_proc_3 (void *param)
 	  continue;
 	}
 
-      (void) hashmap->find_or_insert (te, key, &entry);
+      (void) hashmap->find_or_insert (te, key, entry);
       if (entry == NULL)
 	{
 	  PTHREAD_ABORT_AND_EXIT (ER_FAILED);
@@ -999,7 +999,7 @@ test_hash_iterator ()
     {
       XENTRY *entry;
 
-      (void) hashmap.find_or_insert (te, i, &entry);
+      (void) hashmap.find_or_insert (te, i, entry);
       if (entry == NULL)
 	{
 	  return fail ("null insert error");

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -694,7 +694,7 @@ test_clear_proc_3 (void *param)
 		  abort ();
 		}
 	      te->locked_mutex = NULL;
-	      pthread_mutex_unlock (&entry->mutex);
+	      hashmap->unlock (te, entry);
 	    }
 	}
       else
@@ -704,7 +704,7 @@ test_clear_proc_3 (void *param)
 	      abort ();
 	    }
 	  te->locked_mutex = NULL;
-	  pthread_mutex_unlock (&entry->mutex);
+	  hashmap->unlock (te, entry);
 	}
 
       assert (te->locked_mutex == NULL);

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -413,6 +413,12 @@ namespace cubthread
     return ret;
   }
 
+  lockfree::tran::index
+  entry::get_lf_tran_index ()
+  {
+    return m_lf_tran_index;
+  }
+
 } // namespace cubthread
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -332,6 +332,7 @@ namespace cubthread
 
       void assign_lf_tran_index (lockfree::tran::index idx);
       lockfree::tran::index pull_lf_tran_index ();
+      lockfree::tran::index get_lf_tran_index ();
 
     private:
       void clear_resources (void);

--- a/src/thread/thread_lockfree_hash_map.cpp
+++ b/src/thread/thread_lockfree_hash_map.cpp
@@ -21,5 +21,6 @@
 
 namespace cubthread
 {
-
+  // for compile
+  using lfht = lockfree_hashmap<int>;
 } // namespace cubthread

--- a/src/thread/thread_lockfree_hash_map.cpp
+++ b/src/thread/thread_lockfree_hash_map.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+#include "thread_lockfree_hash_map.hpp"
+
+namespace cubthread
+{
+
+} // namespace cubthread

--- a/src/thread/thread_lockfree_hash_map.cpp
+++ b/src/thread/thread_lockfree_hash_map.cpp
@@ -21,6 +21,4 @@
 
 namespace cubthread
 {
-  // for compile
-  using lfht = lockfree_hashmap<int, int>;
 } // namespace cubthread

--- a/src/thread/thread_lockfree_hash_map.cpp
+++ b/src/thread/thread_lockfree_hash_map.cpp
@@ -22,5 +22,5 @@
 namespace cubthread
 {
   // for compile
-  using lfht = lockfree_hashmap<int>;
+  using lfht = lockfree_hashmap<int, int>;
 } // namespace cubthread

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -189,11 +189,11 @@ namespace cubthread
 #define lockfree_hashmap_forward_func(f_, tp_, ...) \
   is_old_type () ? \
   m_old_hash.f_ (get_tran_entry (tp_), __VA_ARGS__) : \
-  m_new_hash.f_ ((tp_).get_lf_tran_index (), __VA_ARGS__)
-#define lockfree_hashmap_forward_func_noarg(f_) \
+  m_new_hash.f_ ((tp_)->get_lf_tran_index (), __VA_ARGS__)
+#define lockfree_hashmap_forward_func_noarg(f_, tp_) \
   is_old_type (tp_) ? \
   m_old_hash.f_ (get_tran_entry (tp_)) : \
-  m_new_hash.f_ ((tp_).get_lf_tran_index ())
+  m_new_hash.f_ ((tp_)->get_lf_tran_index ())
 
   template <class Key, class T>
   void

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -41,6 +41,7 @@ namespace cubthread
       void destroy ();
 
       T *find (cubthread::entry *thread_p, Key &key);
+      bool find_or_insert (cubthread::entry *thread_p, Key &key, T *&t);
       void unlock (cubthread::entry *thread_p, T *&t);
 
     private:
@@ -72,6 +73,7 @@ namespace cubthread
       void destroy ();
 
       T *find (cubthread::entry *thread_p, Key &key);
+      bool find_or_insert (cubthread::entry *thread_p, Key &key, T *&t);
       void unlock (cubthread::entry *thread_p, T *&t);
 
     private:
@@ -95,6 +97,11 @@ namespace cubthread
       find (cubthread::entry *thread_p, Key &key)
       {
 	return NULL;
+      }
+      bool
+      find_or_insert (cubthread::entry *thread_p, Key &key, T *&t)
+      {
+	return false;
       }
 
       void unlock (cubthread::entry *thread_p, T *&t) {}
@@ -154,6 +161,13 @@ namespace cubthread
   lockfree_hashmap<Key, T>::find (cubthread::entry *thread_p, Key &key)
   {
     return lockfree_hashmap_forward_func (find, thread_p, key);
+  }
+
+  template <class Key, class T>
+  bool
+  lockfree_hashmap<Key, T>::find_or_insert (cubthread::entry *thread_p, Key &key, T *&t)
+  {
+    return lockfree_hashmap_forward_func (find_or_insert, thread_p, key, t);
   }
 
   template <class Key, class T>
@@ -230,6 +244,19 @@ namespace cubthread
 	assert (false);
       }
     return ret;
+  }
+
+  template <class Key, class T>
+  bool
+  lockfree_hashmap<Key, T>::old_hashmap::find_or_insert (cubthread::entry *thread_p, Key &key, T *&t)
+  {
+    lf_tran_entry *t_entry = thread_get_tran_entry (thread_p, m_entry_idx);
+    int inserted = 0;
+    if (lf_hash_find_or_insert (t_entry, &m_hash, &key, t, &inserted) != NO_ERROR)
+      {
+	assert (false);
+      }
+    return inserted != 0;
   }
 
   template <class Key, class T>

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -28,7 +28,154 @@
 
 namespace cubthread
 {
-  class lockfree_hashmap;
+  template <class T>
+  class lockfree_hashmap
+  {
+    public:
+      lockfree_hashmap ();
+
+      void init_as_old (lf_tran_system &transys, int hash_size, int freelist_block_count, int freelist_block_size,
+			lf_entry_descriptor &edesc);
+      void init_as_new ();
+
+      void destroy ();
+
+    private:
+      class old_hashmap;
+      class new_hashmap;
+
+      bool is_old_type () const;
+
+      enum type
+      {
+	OLD,
+	NEW,
+	UNKNOWN
+      };
+
+      old_hashmap m_old_hash;
+      new_hashmap m_new_hash;
+      type m_type;
+  };
+
+  template <class T>
+  class lockfree_hashmap<T>::old_hashmap
+  {
+    public:
+      old_hashmap ();
+
+      void init (lf_tran_system &transys, int hash_size, int freelist_block_count, int freelist_block_size,
+		 lf_entry_descriptor &edes);
+      void destroy ();
+
+    private:
+      lf_freelist m_freelist;
+      lf_hash_table m_hash;
+  };
+
+  template <class T>
+  class lockfree_hashmap<T>::new_hashmap
+  {
+    public:
+      new_hashmap () = default;
+
+      void init () {}
+      void destroy () {}
+
+    private:
+  };
 } // namespace cubthread
+
+//
+// implementation
+//
+
+namespace cubthread
+{
+  //
+  //  lockfree_hashmap
+  //
+  template <class T>
+  lockfree_hashmap<T>::lockfree_hashmap ()
+    : m_old_hash {}
+    , m_new_hash {}
+    , m_type (UNKNOWN)
+  {
+  }
+
+  template <class T>
+  void
+  lockfree_hashmap<T>::init_as_old (lf_tran_system &transys, int hash_size, int freelist_block_count,
+				    int freelist_block_size, lf_entry_descriptor &edesc)
+  {
+    m_type = OLD;
+    m_old_hash.init (transys, hash_size, freelist_block_count, freelist_block_size);
+  }
+
+  template <class T>
+  void
+  lockfree_hashmap<T>::init_as_new ()
+  {
+    // not implemented
+    assert (false);
+  }
+
+  template <class T>
+  void
+  lockfree_hashmap<T>::destroy ()
+  {
+    if (is_old_type ())
+      {
+	m_old_hash.destroy ();
+      }
+    else
+      {
+	m_new_hash.destroy ();
+      }
+  }
+
+  template <class T>
+  bool
+  lockfree_hashmap<T>::is_old_type () const
+  {
+    // for now, always true
+    return true;
+  }
+
+  //
+  // lockfree_hashmap::old_hashmap
+  //
+  template <class T>
+  lockfree_hashmap<T>::old_hashmap::old_hashmap ()
+    : m_freelist LF_FREELIST_INITIALIZER
+    , m_hash LF_HASH_TABLE_INITIALIZER
+  {
+  }
+
+  template <class T>
+  void
+  lockfree_hashmap<T>::old_hashmap::init (lf_tran_system &transys, int hash_size, int freelist_block_count,
+					  int freelist_block_size, lf_entry_descriptor &edesc)
+  {
+    if (lf_freelist_init (&m_freelist, freelist_block_count, freelist_block_size, &edesc, &transys) != NO_ERROR)
+      {
+	assert (false);
+	return;
+      }
+    if (lf_hash_init (&m_hash, &m_freelist, hash_size, &edesc) != NO_ERROR)
+      {
+	assert (false);
+	return;
+      }
+  }
+
+  template <class T>
+  void
+  lockfree_hashmap<T>::old_hashmap::destroy ()
+  {
+    lf_hash_destroy (&m_hash);
+    lf_freelist_destroy (&m_freelist);
+  }
+}
 
 #endif // !_THREAD_LOCKFREE_HASH_MAP_

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -141,7 +141,7 @@ namespace cubthread
 					 int freelist_block_size, lf_entry_descriptor &edesc, int entry_idx)
   {
     m_type = OLD;
-    m_old_hash.init (transys, hash_size, freelist_block_count, freelist_block_size, entry_idx);
+    m_old_hash.init (transys, hash_size, freelist_block_count, freelist_block_size);
     m_entry_idx = entry_idx;
   }
 

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+//
+//  specialize lock-free hash map to thread manager and its entries
+//
+
+#ifndef _THREAD_LOCKFREE_HASH_MAP_
+#define _THREAD_LOCKFREE_HASH_MAP_
+
+#include "lock_free.h"  // old implementation
+
+namespace cubthread
+{
+  class lockfree_hashmap;
+} // namespace cubthread
+
+#endif // !_THREAD_LOCKFREE_HASH_MAP_


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23339

Wrap existing lock-free hash functionality into C++ interface that can be easily reused for refactorized transaction system.

The interface is templatized by key and node type:
```c
  template <class Key, class T>
  hash_map
  {
    class iterator;  // to iterate map

    init/destroy // initializes/destroys hash & freelist

    // operations on keys/nodes
    find, find_or_insert, insert, insert_given, erase, erase_locked

    // after finishing reading from/writing to node
    unlock (T);   // end transaction or unlock mutex

    clear ();  // remove all
  };
```

**thread_lockfree_hash_map**
A new class was added - cubthread::lockfree_hashmap - with the purpose of converting thread entry into lock-free transaction entry before calling the corresponding hashmap function.

Until refactoring of lock-free hash is complete, the class also has the secondary objectiv of acting as middle layer that can seamlessly switch between implementations.

In current patch, only implementation for old system is mature; a new_hashmap class is used as demonstration, but it is not implemented.

**lock_free**
Wrap existing lf_hash functionality into lf_hash_table_cpp class compatible with cubthread::lockfree_hashmap and refactorized hashmap.

Update unittest_lf.c to use lf_hash_table_cpp.