### PR TITLE
[CBRD-23349] Disable interrupt safe-guard in SA_MODE

### DIFF
--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -2705,7 +2705,9 @@ logtb_set_tran_index_interrupt (THREAD_ENTRY * thread_p, int tran_index, bool se
 
   if (tran_index == LOG_SYSTEM_TRAN_INDEX)
     {
+#if defined (SERVER_MODE)
       assert (false);
+#endif // SERVER_MODE
       return false;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23349

Disable safe-guard that does not allow interruptions on system transaction for SA_MODE. It was added to protect against faulty logic of interrupt in server mode. SA_MODE is single-threaded and can reach hit the safeguard. if it is not assigned a transaction.