### PR TITLE
[CBRD-23373] wait for workers to complete loaddb

### DIFF
--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -9925,7 +9925,6 @@ sloaddb_interrupt (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int
       assert (session != NULL);
 
       session->interrupt ();
-      session->wait_for_completion ();
     }
   else
     {

--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -145,6 +145,7 @@ namespace cubload
       load_args m_args;
       batch_id m_last_batch_id;
       std::atomic<batch_id> m_max_batch_id;
+      std::atomic<size_t> m_active_task_count;
 
       class_registry m_class_registry;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23373

if load session completes before workers, its lock is released and workers are left unprotected. load session complete needs to wait for workers.

added a counter to track active tasks; it is incremented when batch is loaded and decremented when batch finished is notified (transactions are committed/aborted before this, so it is a safe point to decrement the counter). only counter decrements are protected by mutex, increments are atomic (increments are done on same thread that will wait for completion).

removed waiting for completion on interrupt request; load batch request will wait instead.