### PR TITLE
[CBRD-23328] shutdown load sessions

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -26,6 +26,7 @@
 #include "server_support.h"
 
 #include "config.h"
+#include "load_worker_manager.hpp"
 #include "log_append.hpp"
 #include "session.h"
 #include "thread_entry_task.hpp"
@@ -1397,6 +1398,9 @@ shutdown:
 
   /* stop vacuum threads. */
   vacuum_stop (thread_p);
+
+  // stop load sessions
+  cubload::worker_manager_stop_all ();
 
   /* we should flush all append pages before stop log writer */
   logpb_force_flush_pages (thread_p);

--- a/src/loaddb/load_session.cpp
+++ b/src/loaddb/load_session.cpp
@@ -220,7 +220,7 @@ namespace cubload
     , m_stats_mutex ()
     , m_driver (NULL)
   {
-    worker_manager_register_session ();
+    worker_manager_register_session (*this);
 
     m_driver = new driver ();
     init_driver (m_driver, *this);
@@ -240,7 +240,7 @@ namespace cubload
   {
     delete m_driver;
 
-    worker_manager_unregister_session ();
+    worker_manager_unregister_session (*this);
   }
 
   bool

--- a/src/loaddb/load_worker_manager.cpp
+++ b/src/loaddb/load_worker_manager.cpp
@@ -30,6 +30,8 @@
 #include "thread_worker_pool_taskcap.hpp"
 #include "xserver_interface.h"
 
+#include <set>
+
 namespace cubload
 {
   /*
@@ -60,6 +62,7 @@ namespace cubload
   };
 
   static std::mutex g_wp_mutex;
+  std::set<session *> g_active_sessions;
   static unsigned int g_session_count = 0;
   static cubthread::entry_workpool *g_worker_pool;
   static worker_context_manager *g_wp_context_manager;
@@ -116,11 +119,11 @@ namespace cubload
   }
 
   void
-  worker_manager_register_session ()
+  worker_manager_register_session (session &load_session)
   {
     g_wp_mutex.lock ();
 
-    if (g_session_count == 0)
+    if (g_active_sessions.empty ())
       {
 	assert (g_worker_pool == NULL);
 	assert (g_wp_context_manager == NULL);
@@ -139,20 +142,23 @@ namespace cubload
 	assert (g_wp_context_manager != NULL);
       }
 
-    g_session_count++;
+    g_active_sessions.insert (&load_session);
 
     g_wp_mutex.unlock ();
   }
 
   void
-  worker_manager_unregister_session ()
+  worker_manager_unregister_session (session &load_session)
   {
     g_wp_mutex.lock ();
 
-    g_session_count--;
+    if (g_active_sessions.erase (&load_session) != 1)
+      {
+	assert (false);
+      }
 
     // Check if there are any sessions attached to the wp. We are under lock so we are the only ones doing this.
-    if (g_session_count == 0)
+    if (g_active_sessions.empty ())
       {
 	// We are the last session so we can safely destroy the worker pool and the manager.
 	cubthread::get_manager ()->destroy_worker_pool (g_worker_pool);
@@ -166,6 +172,16 @@ namespace cubload
       }
 
     g_wp_mutex.unlock ();
+  }
+
+  void
+  worker_manager_stop_all ()
+  {
+    std::unique_lock<std::mutex> ulock (g_wp_mutex);
+    for (auto &it : g_active_sessions)
+      {
+	it->interrupt ();
+      }
   }
 
   void

--- a/src/loaddb/load_worker_manager.hpp
+++ b/src/loaddb/load_worker_manager.hpp
@@ -30,10 +30,14 @@
 
 namespace cubload
 {
-  void worker_manager_push_task (cubthread::entry_task *task);
+  // forward definitions
+  class session;
 
-  void worker_manager_register_session ();
-  void worker_manager_unregister_session ();
+  void worker_manager_push_task (cubthread::entry_task *task);
+  void worker_manager_stop_all ();
+
+  void worker_manager_register_session (session &load_session);
+  void worker_manager_unregister_session (session &load_session);
 
   void worker_manager_get_stats (UINT64 *stats_out);
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23328

use load worker manager to track registered sessions and interrupt all of them on shutdown.