### PR TITLE
[CBRD-23310] use original expression print for folded expressions in context of SBR replication

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3459,7 +3459,7 @@ struct parser_node
   PT_NODE *data_type;		/* for non-primitive types, Sets, objects stec. */
   XASL_ID *xasl_id;		/* XASL_ID for this SQL statement */
   const char *alias_print;	/* the column alias */
-  PARSER_VARCHAR *expr_before_const_folding; /* text before constant folding (used by value, host var nodes) */
+  PARSER_VARCHAR *expr_before_const_folding;	/* text before constant folding (used by value, host var nodes) */
   PT_TYPE_ENUM type_enum;	/* type enumeration tag PT_TYPE_??? */
   CACHE_TIME cache_time;	/* client or server cache time */
   unsigned recompile:1;		/* the statement should be recompiled - used for plan cache */

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -780,7 +780,9 @@ enum pt_custom_print
 
   PT_CHARSET_COLLATE_USER_ONLY = (0x1 << 19),
 
-  PT_PRINT_USER = (0x1 << 20)
+  PT_PRINT_USER = (0x1 << 20),
+
+  PT_PRINT_ORIGINAL_BEFORE_CONST_FOLDING = (0x1 << 21)
 };
 
 /* all statement node types should be assigned their API statement enumeration */
@@ -3457,6 +3459,7 @@ struct parser_node
   PT_NODE *data_type;		/* for non-primitive types, Sets, objects stec. */
   XASL_ID *xasl_id;		/* XASL_ID for this SQL statement */
   const char *alias_print;	/* the column alias */
+  PARSER_VARCHAR *expr_before_const_folding; /* text before constant folding (used by value, host var nodes) */
   PT_TYPE_ENUM type_enum;	/* type enumeration tag PT_TYPE_??? */
   CACHE_TIME cache_time;	/* client or server cache time */
   unsigned recompile:1;		/* the statement should be recompiled - used for plan cache */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2468,8 +2468,7 @@ pt_print_node_value (PARSER_CONTEXT * parser, const PT_NODE * val)
       return NULL;
     }
 
-  if (parser->custom_print & PT_PRINT_ORIGINAL_BEFORE_CONST_FOLDING
-      && val->expr_before_const_folding != NULL)
+  if (parser->custom_print & PT_PRINT_ORIGINAL_BEFORE_CONST_FOLDING && val->expr_before_const_folding != NULL)
     {
       return val->expr_before_const_folding;
     }

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2217,6 +2217,7 @@ parser_init_node (PT_NODE * node)
       node->data_type = NULL;
       node->xasl_id = NULL;
       node->alias_print = NULL;
+      node->expr_before_const_folding = NULL;
       node->recompile = 0;
       node->cannot_prepare = 0;
       node->partition_pruned = 0;
@@ -2465,6 +2466,12 @@ pt_print_node_value (PARSER_CONTEXT * parser, const PT_NODE * val)
       && (val->node_type != PT_NAME || val->info.name.meta_class != PT_PARAMETER))
     {
       return NULL;
+    }
+
+  if (parser->custom_print & PT_PRINT_ORIGINAL_BEFORE_CONST_FOLDING
+      && val->expr_before_const_folding != NULL)
+    {
+      return val->expr_before_const_folding;
     }
 
   db_val = pt_value_to_db (parser, (PT_NODE *) val);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3963,6 +3963,7 @@ pt_create_param_for_value (PARSER_CONTEXT * parser, PT_NODE * value, int host_va
     {
       host_var->info.host_var.index = host_var_index;
     }
+  host_var->expr_before_const_folding = value->expr_before_const_folding;
 
   return host_var;
 }

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -19507,7 +19507,11 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 				     qualifier))
 	{
 	  result = pt_dbval_to_value (parser, &dbval_res);
-	  if (result->data_type == NULL && result->type_enum != PT_TYPE_NULL)
+          if (result)
+            {
+              result->expr_before_const_folding = pt_print_bytes (parser, expr);
+            }
+	  if (result && result->data_type == NULL && result->type_enum != PT_TYPE_NULL)
 	    {
 	      /* data_type may be needed later... e.g. in CTEs */
 	      result->data_type = parser_copy_tree_list (parser, expr->data_type);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -19507,10 +19507,10 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 				     qualifier))
 	{
 	  result = pt_dbval_to_value (parser, &dbval_res);
-          if (result)
-            {
-              result->expr_before_const_folding = pt_print_bytes (parser, expr);
-            }
+	  if (result)
+	    {
+	      result->expr_before_const_folding = pt_print_bytes (parser, expr);
+	    }
 	  if (result && result->data_type == NULL && result->type_enum != PT_TYPE_NULL)
 	    {
 	      /* data_type may be needed later... e.g. in CTEs */

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14779,11 +14779,11 @@ do_replicate_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
       PT_PRINT_VALUE_FUNC saved_func = parser->print_db_value;
       int saved_custom_print = parser->custom_print;
 
-      parser->custom_print |= PT_PRINT_ORIGINAL_BEFORE_CONST_FOLDING; 
+      parser->custom_print |= PT_PRINT_ORIGINAL_BEFORE_CONST_FOLDING;
       parser->print_db_value = pt_print_node_value;
       repl_stmt.stmt_text = parser_print_tree (parser, statement);
       parser->print_db_value = saved_func;
-      parser->custom_print = saved_custom_print; 
+      parser->custom_print = saved_custom_print;
     }
 
   repl_stmt.db_user = db_get_user_name ();

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14777,9 +14777,13 @@ do_replicate_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   else
     {
       PT_PRINT_VALUE_FUNC saved_func = parser->print_db_value;
+      int saved_custom_print = parser->custom_print;
+
+      parser->custom_print |= PT_PRINT_ORIGINAL_BEFORE_CONST_FOLDING; 
       parser->print_db_value = pt_print_node_value;
       repl_stmt.stmt_text = parser_print_tree (parser, statement);
       parser->print_db_value = saved_func;
+      parser->custom_print = saved_custom_print; 
     }
 
   repl_stmt.db_user = db_get_user_name ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23310

checksumdb utility uses schema_def() function which is const folded during parser.
However, the logic of checksumdb requires that the statement string is replicated using original text.