### PR TITLE
[CBRD-23339] Refactoring of lockfree hashmap

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -91,6 +91,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/locale_support.c
   ${BASE_DIR}/lock_free.c
   ${BASE_DIR}/lockfree_bitmap.cpp
+  ${BASE_DIR}/lockfree_hashmap.cpp
   ${BASE_DIR}/lockfree_transaction_descriptor.cpp
   ${BASE_DIR}/lockfree_transaction_table.cpp
   ${BASE_DIR}/lockfree_transaction_system.cpp
@@ -133,6 +134,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/fileline_location.hpp
   ${BASE_DIR}/lockfree_bitmap.hpp
   ${BASE_DIR}/lockfree_freelist.hpp
+  ${BASE_DIR}/lockfree_hashmap.hpp
   ${BASE_DIR}/lockfree_transaction_def.hpp
   ${BASE_DIR}/lockfree_transaction_descriptor.hpp
   ${BASE_DIR}/lockfree_transaction_reclaimable.hpp

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -132,6 +132,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
+  ${BASE_DIR}/lockfree_address_marker.hpp
   ${BASE_DIR}/lockfree_bitmap.hpp
   ${BASE_DIR}/lockfree_freelist.hpp
   ${BASE_DIR}/lockfree_hashmap.hpp

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -116,6 +116,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/tsc_timer.c
   ${BASE_DIR}/lock_free.c
   ${BASE_DIR}/lockfree_bitmap.cpp
+  ${BASE_DIR}/lockfree_hashmap.cpp
   ${BASE_DIR}/lockfree_transaction_descriptor.cpp
   ${BASE_DIR}/lockfree_transaction_table.cpp
   ${BASE_DIR}/lockfree_transaction_system.cpp
@@ -132,6 +133,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/fileline_location.hpp
   ${BASE_DIR}/lockfree_bitmap.hpp
   ${BASE_DIR}/lockfree_freelist.hpp
+  ${BASE_DIR}/lockfree_hashmap.hpp
   ${BASE_DIR}/lockfree_transaction_def.hpp
   ${BASE_DIR}/lockfree_transaction_descriptor.hpp
   ${BASE_DIR}/lockfree_transaction_reclaimable.hpp

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -131,6 +131,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
+  ${BASE_DIR}/lockfree_address_marker.hpp
   ${BASE_DIR}/lockfree_bitmap.hpp
   ${BASE_DIR}/lockfree_freelist.hpp
   ${BASE_DIR}/lockfree_hashmap.hpp

--- a/src/base/lockfree_address_marker.hpp
+++ b/src/base/lockfree_address_marker.hpp
@@ -31,11 +31,13 @@ namespace lockfree
   template <class T>
   class address_marker
   {
+    private:
+      static const T *MARK = static_cast<T *> (0x1);
     public:
       address_marker ();
       address_marker (T *addr);
 
-      static const size_t MARKED_NULLPTR = (NULL &MARK);
+      static const size_t MARKED_NULLPTR = (NULL | MARK);
 
       bool is_marked () const;
       T *get_address () const;
@@ -48,8 +50,6 @@ namespace lockfree
       static T *atomic_strip_address_mark (T *addr);
 
     private:
-      static const T *MARK = static_cast<T *> (0x1);
-
       std::atomic<T *> m_addr;
   };
 } // namespace lockfree

--- a/src/base/lockfree_address_marker.hpp
+++ b/src/base/lockfree_address_marker.hpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+//
+// lock-free address marker
+//
+
+#ifndef _LOCKFREE_ADDRESS_MARKER_HPP_
+#define _LOCKFREE_ADDRESS_MARKER_HPP_
+
+#include <atomic>
+
+namespace lockfree
+{
+  template <class T>
+  class address_marker
+  {
+    public:
+      address_marker ();
+      address_marker (T *addr);
+
+      bool is_marked () const;
+      T *get_address () const;
+      T *get_address_no_strip () const;
+
+      static T *set_adress_mark (T *addr);
+      static T *strip_address_mark (T *addr);
+      bool is_address_marked (const T *addr);
+
+      static T *atomic_strip_address_mark (T *addr);
+
+    private:
+      static const T *MARK = static_cast<T *> (0x1);
+
+      std::atomic<T *> m_addr;
+  };
+} // namespace lockfree
+
+//
+// implementation
+//
+
+namespace lockfree
+{
+  //
+  // address marker
+  //
+  template <class T>
+  address_marker<T>::address_marker ()
+    : m_addr { NULL }
+  {
+  }
+
+  template <class T>
+  address_marker<T>::address_marker (T *addr)
+    : m_addr (addr)
+  {
+  }
+
+  template <class T>
+  bool
+  address_marker<T>::is_marked () const
+  {
+    return is_address_marked (m_addr.load ());
+  }
+
+  template <class T>
+  T *
+  address_marker<T>::get_address () const
+  {
+    return strip_address_mark (m_addr.load ());
+  }
+
+  template <class T>
+  T *
+  address_marker<T>::get_address_no_strip () const
+  {
+    return m_addr.load ();
+  }
+
+  template <class T>
+  T *
+  address_marker<T>::set_adress_mark (T *addr)
+  {
+    return addr | MARK;
+  }
+
+  template <class T>
+  T *
+  address_marker<T>::strip_address_mark (T *addr)
+  {
+    return addr & (~MARK);
+  }
+
+  template <class T>
+  bool
+  address_marker<T>::is_address_marked (const T *addr)
+  {
+    return (addr & MARK) != 0;
+  }
+
+  template <class T>
+  T *
+  address_marker<T>::atomic_strip_address_mark (T *addr)
+  {
+    return address_marker (addr).get_address ();
+  }
+} // namespace lockfree
+#endif // !_LOCKFREE_ADDRESS_MARKER_HPP_

--- a/src/base/lockfree_address_marker.hpp
+++ b/src/base/lockfree_address_marker.hpp
@@ -35,6 +35,8 @@ namespace lockfree
       address_marker ();
       address_marker (T *addr);
 
+      static const size_t MARKED_NULLPTR = (NULL &MARK);
+
       bool is_marked () const;
       T *get_address () const;
       T *get_address_no_strip () const;

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -123,13 +123,6 @@ namespace lockfree
       freelist *m_owner;
       T m_t;
   };
-
-  template <class T>
-  static constexpr std::ptrdiff_t free_node_offset_of_data ()
-  {
-    typename freelist<T>::free_node fn;
-    return ((char *) (&fn.get_data ())) - ((char *) (&fn));
-  }
 } // namespace lockfree
 
 //

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -104,7 +104,7 @@ namespace lockfree
       free_node ();
       ~free_node () = default;
 
-      const size_t OFFSET_TO_DATA = offsetof (free_node, m_t);
+      static const size_t OFFSET_TO_DATA;
 
       T &get_data ();
 
@@ -459,6 +459,9 @@ namespace lockfree
   //
   // freelist::handle
   //
+  template <class T>
+  const size_t freelist<T>::free_node::OFFSET_TO_DATA = offsetof (typename freelist<T>::free_node, m_t);
+
   template<class T>
   freelist<T>::free_node::free_node ()
     : tran::reclaimable_node ()

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -125,9 +125,9 @@ namespace lockfree
   };
 
   template <class T>
-  static constexpr size_t free_node_offset_of_data ()
+  static constexpr std::ptrdiff_t free_node_offset_of_data ()
   {
-    freelist<T>::free_node fn;
+    typename freelist<T>::free_node fn;
     return ((char *) (&fn.get_data ())) - ((char *) (&fn));
   }
 } // namespace lockfree

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -102,6 +102,8 @@ namespace lockfree
       free_node ();
       ~free_node () = default;
 
+      const size_t OFFSET_TO_DATA = offsetof (free_node, m_t);
+
       T &get_data ();
 
       void reclaim () final override;

--- a/src/base/lockfree_freelist.hpp
+++ b/src/base/lockfree_freelist.hpp
@@ -104,8 +104,6 @@ namespace lockfree
       free_node ();
       ~free_node () = default;
 
-      static const size_t OFFSET_TO_DATA;
-
       T &get_data ();
 
       void reclaim () final override;
@@ -125,6 +123,13 @@ namespace lockfree
       freelist *m_owner;
       T m_t;
   };
+
+  template <class T>
+  static constexpr size_t free_node_offset_of_data ()
+  {
+    freelist<T>::free_node fn;
+    return ((char *) (&fn.get_data ())) - ((char *) (&fn));
+  }
 } // namespace lockfree
 
 //
@@ -459,9 +464,6 @@ namespace lockfree
   //
   // freelist::handle
   //
-  template <class T>
-  const size_t freelist<T>::free_node::OFFSET_TO_DATA = offsetof (typename freelist<T>::free_node, m_t);
-
   template<class T>
   freelist<T>::free_node::free_node ()
     : tran::reclaimable_node ()

--- a/src/base/lockfree_hashmap.cpp
+++ b/src/base/lockfree_hashmap.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; version 2 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ */
+
+#include "lockfree_hashmap.hpp"
+
+namespace lockfree
+{
+  hashmap<int, int>;
+} // namespace lockfree

--- a/src/base/lockfree_hashmap.cpp
+++ b/src/base/lockfree_hashmap.cpp
@@ -20,5 +20,5 @@
 
 namespace lockfree
 {
-  hashmap<int, int>;
+  using my_hashmap = hashmap<int, int>;
 } // namespace lockfree

--- a/src/base/lockfree_hashmap.cpp
+++ b/src/base/lockfree_hashmap.cpp
@@ -20,5 +20,4 @@
 
 namespace lockfree
 {
-  using my_hashmap = hashmap<int, int>;
 } // namespace lockfree

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -23,7 +23,11 @@
 #ifndef _LOCKFREE_HASHMAP_HPP_
 #define _LOCKFREE_HASHMAP_HPP_
 
+#include "lock_free.h"                        // for lf_entry_descriptor
+#include "lockfree_address_marker.hpp"
 #include "lockfree_freelist.hpp"
+
+#include <mutex>
 
 namespace lockfree
 {
@@ -34,6 +38,16 @@ namespace lockfree
       // todo
 
     private:
+      using link_type = address_marker<T>;
+      using freelist_type = freelist<T>;
+
+      link_type *m_buckets;
+      size_t m_size;
+
+      link_type *m_backbuffer;
+      std::mutex m_backbuffer_mutex;
+
+      lf_entry_descriptor &m_edesc;
   };
 }
 

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -35,20 +35,133 @@ namespace lockfree
   class hashmap
   {
     public:
-      // todo
+      hashmap ()
 
     private:
-      using link_type = address_marker<T>;
+      using address_type = address_marker<T>;
       using freelist_type = freelist<T>;
 
-      link_type *m_buckets;
+      address_type *m_buckets;
       size_t m_size;
 
-      link_type *m_backbuffer;
+      freelist_type *m_freelist;
+
+      address_type *m_backbuffer;
       std::mutex m_backbuffer_mutex;
 
-      lf_entry_descriptor &m_edesc;
+      lf_entry_descriptor *m_edesc;
+
+      void *get_ptr (T *p, size_t o);
+      void *get_keyp (T *p);
+      T *get_nextp (T *p);
+      pthread_mutex_t *get_pthread_mutexp (T *p);
+
+      void find_in_list (tran::index tran_index, address_marker &list_head, Key &key, int *behavior_flags,
+			 T *&ent);
   };
+}
+
+//
+// implementation
+//
+
+namespace lockfree
+{
+  template <class Key, class T>
+  void *
+  hashmap<Key, T>::get_ptr (T *p, size_t o)
+  {
+    return (void *) (((char *) p) + o);
+  }
+
+  template <class Key, class T>
+  void *
+  hashmap<Key, T>::get_keyp (T *p)
+  {
+    return get_ptr (p, m_edesc->of_key);
+  }
+
+  template <class Key, class T>
+  T *
+  hashmap<Key, T>::get_nextp (T *p)
+  {
+    return (T *) get_ptr (p, m_edesc->of_next);
+  }
+
+  template <class Key, class T>
+  pthread_mutex_t *
+  hashmap<Key, T>::get_pthread_mutexp (T *p)
+  {
+    return (pthread_mutex_t *) get_ptr (p, m_edesc->of_mutex);
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::find_in_list (tran::index tran_index, address_marker &list_head, Key &key, int *behavior_flags,
+				 T *&found_node)
+  {
+    tran::descriptor &tdes = m_freelist->get_transaction_table ().get_descriptor (tran_index);
+    T *curr = NULL;
+    pthread_mutex_t *entry_mutex;
+
+    tdes.start_tran ();
+    bool restart_search = true;
+
+    while (restart_search)    // restart_search:
+      {
+	curr = list_head.get_address ();
+	restart_search = false;
+
+	while (curr != NULL)
+	  {
+	    if (m_edesc->f_key_cmp (&key, get_keyp (curr)) == 0)
+	      {
+		/* found! */
+		if (m_edesc->using_mutex)
+		  {
+		    /* entry has a mutex protecting it's members; lock it */
+		    entry_mutex = get_pthread_mutexp (curr);
+		    pthread_mutex_lock (entry_mutex);
+
+		    /* mutex has been locked, no need to keep transaction */
+		    tdes.end_tran ();
+
+		    if (address_type::is_address_marked (get_nextp (curr)))
+		      {
+			/* while waiting for lock, somebody else deleted the entry; restart the search */
+			pthread_mutex_unlock (entry_mutex);
+
+			if (behavior_flags & (*behavior_flags & LF_LIST_BF_RETURN_ON_RESTART))
+			  {
+			    *behavior_flags = (*behavior_flags) | LF_LIST_BR_RESTARTED;
+			    return;
+			  }
+			else
+			  {
+			    // restart
+			    restart_search = true;
+			    break;
+			  }
+		      }
+		  }
+		else
+		  {
+		    // not using mutex
+		    // fall through
+		  }
+
+		found_node = curr;
+		return;
+	      }
+
+	    /* advance */
+	    curr = address_marker::atomic_strip_address_mark (get_nextp (curr));
+	  }
+      }
+
+    /* all ok but not found */
+    tdes.end_tran ();
+  }
 }
 
 #endif // !_LOCKFREE_HASHMAP_HPP_

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -440,7 +440,7 @@ namespace lockfree
   {
     // not nice, but necessary until we fully refactor lockfree hashmap
     char *cp = (char *) p;
-    cp -= free_node_type::OFFSET_TO_DATA;
+    cp -= free_node_offset_of_data<T> ();
     return (free_node_type *) cp;
   }
 

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -23,10 +23,13 @@
 #ifndef _LOCKFREE_HASHMAP_HPP_
 #define _LOCKFREE_HASHMAP_HPP_
 
+#include "error_code.h"
 #include "lock_free.h"                        // for lf_entry_descriptor
 #include "lockfree_address_marker.hpp"
 #include "lockfree_freelist.hpp"
+#include "porting.h"
 
+#include <cassert>
 #include <mutex>
 
 namespace lockfree
@@ -41,17 +44,19 @@ namespace lockfree
       using address_type = address_marker<T>;
       using freelist_type = freelist<T>;
 
-      address_type *m_buckets;
+      T **m_buckets;
       size_t m_size;
 
-      freelist_type *m_freelist;
+      T **m_freelist;
 
       address_type *m_backbuffer;
       std::mutex m_backbuffer_mutex;
 
       lf_entry_descriptor *m_edesc;
 
+      void *volatile *get_ref (T *p, size_t o);
       void *get_ptr (T *p, size_t o);
+      void *get_ptr_deref (T *p, size_t o);
       void *get_keyp (T *p);
       T *get_nextp (T *p);
       pthread_mutex_t *get_pthread_mutexp (T *p);
@@ -60,9 +65,20 @@ namespace lockfree
       T *from_free_node (freelist_type::free_node *fn);
       void save_temporary (tran::descriptor &tdes, T *&p);
       T *claim_temporary (tran::descriptor &tdes);
+      void freelist_retire (tran::descriptor &tdes, T *&p);
+      T *freelist_claim (tran::descriptor &tdes);
 
-      void list_find (tran::index tran_index, address_marker &list_head, Key &key, int *behavior_flags, T *&found_node);
-      bool list_insert_internal (tran::index tran_index, address_marker &list_head, Key &key, int *behavior_flags,
+      void safeguard_use_mutex_or_tran_started (const tran::descriptor &tdes, const pthread_mutex_t *mtx);
+      void safe_start_tran (tran::descriptor &tdes);
+      void safe_force_start_tran (tran::descriptor &tdes);
+      void safe_end_tran (tran::descriptor &tdes);
+      void safe_force_end_tran (tran::descriptor &tdes);
+      void safe_lock_entry (T &tolock, pthread_mutex_t *&mtx);
+      void safe_unlock_entry (pthread_mutex_t *&mtx);
+      void safe_force_unlock_entry (pthread_mutex_t *&mtx);
+
+      void list_find (tran::index tran_index, T *list_head, Key &key, int *behavior_flags, T *&found_node);
+      bool list_insert_internal (tran::index tran_index, T *&list_head, Key &key, int *behavior_flags,
 				 T *&found_node);
   };
 
@@ -83,6 +99,20 @@ namespace lockfree
   }
 
   template <class Key, class T>
+  void *volatile *
+  hashmap<Key, T>::get_ref (T *p, size_t o)
+  {
+    return (void *volatile *) (((char *) p) + o);
+  }
+
+  template <class Key, class T>
+  void *
+  hashmap<Key, T>::get_ptr_deref (T *p, size_t o)
+  {
+    return *get_ref (p, o);
+  }
+
+  template <class Key, class T>
   void *
   hashmap<Key, T>::get_keyp (T *p)
   {
@@ -93,7 +123,14 @@ namespace lockfree
   T *
   hashmap<Key, T>::get_nextp (T *p)
   {
-    return (T *) get_ptr (p, m_edesc->of_next);
+    return (T *) get_ptr_deref (p, m_edesc->of_next);
+  }
+
+  template <class Key, class T>
+  T *&
+  hashmap<Key, T>::get_nextp_ref (T *p)
+  {
+    return *get_ref (p, m_edesc->of_next);
   }
 
   template <class Key, class T>
@@ -139,19 +176,115 @@ namespace lockfree
 
   template <class Key, class T>
   void
-  hashmap<Key, T>::list_find (tran::index tran_index, address_marker &list_head, Key &key, int *behavior_flags,
-			      T *&found_node)
+  hashmap<Key, T>::freelist_retire (tran::descriptor &tdes, T *&p)
+  {
+    assert (p != NULL);
+    m_freelist->retire (tdes, *to_free_node (p));
+    p = NULL;
+  }
+
+  template <class Key, class T>
+  T *
+  hashmap<Key, T>::freelist_claim (tran::descriptor &tdes)
+  {
+    return from_free_node (m_freelist->claim (tdes));
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::safeguard_use_mutex_or_tran_started (const tran::descriptor &tdes, const pthread_mutex_t *mtx)
+  {
+    /* Assert used to make sure the current entry is protected by either transaction or mutex. */
+
+    /* The transaction is started if and only if we don't use mutex */ \
+    assert (tdes.is_tran_started () == !m_edesc->using_mutex);
+
+    /* If we use mutex, we have a mutex locked. */
+    assert (!m_edesc->using_mutex || mtx != NULL);
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::safe_start_tran (tran::descriptor &tdes)
+  {
+    tdes.start_tran ();   // same result if it was started or not
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::safe_force_start_tran (tran::descriptor &tdes)
+  {
+    assert (!tdes.is_tran_started ());
+    tdes.start_tran ();
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::safe_end_tran (tran::descriptor &tdes)
+  {
+    if (tdes.is_tran_started ())
+      {
+	tdes.end_tran ();
+      }
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::safe_force_end_tran (tran::descriptor &tdes)
+  {
+    assert (tdes.is_tran_started ());
+    tdes.end_tran ();
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::safe_lock_entry (T &tolock, pthread_mutex_t *&mtx)
+  {
+    assert (m_edesc->using_mutex);
+    assert (mtx == NULL);
+
+    mtx = get_pthread_mutexp (tolock);
+    pthread_mutex_lock (mtx);
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::safe_unlock_entry (pthread_mutex_t *&mtx)
+  {
+    if (m_edesc->using_mutex && mtx != NULL)
+      {
+	pthread_mutex_unlock (mtx);
+	mtx = NULL;
+      }
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::safe_force_unlock_entry (pthread_mutex_t *&mtx)
+  {
+    assert (m_edesc->using_mutex && mtx != NULL);
+    pthread_mutex_unlock (mtx);
+    mtx = NULL;
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::list_find (tran::index tran_index, T *&list_head, Key &key, int *behavior_flags,
+			      T *&entry)
   {
     tran::descriptor &tdes = m_freelist->get_transaction_table ().get_descriptor (tran_index);
     T *curr = NULL;
-    pthread_mutex_t *entry_mutex;
+    pthread_mutex_t *entry_mutex = NULL;
+
+    /* by default, not found */
+    entry = NULL;
 
     tdes.start_tran ();
     bool restart_search = true;
 
     while (restart_search)    // restart_search:
       {
-	curr = list_head.get_address ();
+	curr = address_type::atomic_strip_address_mark (list_head);
 	restart_search = false;
 
 	while (curr != NULL)
@@ -162,13 +295,12 @@ namespace lockfree
 		if (m_edesc->using_mutex)
 		  {
 		    /* entry has a mutex protecting it's members; lock it */
-		    entry_mutex = get_pthread_mutexp (curr);
-		    pthread_mutex_lock (entry_mutex);
+		    safe_lock_entry (curr, entry_mutex);
 
 		    /* mutex has been locked, no need to keep transaction */
 		    tdes.end_tran ();
 
-		    if (address_type::is_address_marked (get_nextp (curr)))
+		    if (address_type::is_address_marked (get_nextp_ref (curr)))
 		      {
 			/* while waiting for lock, somebody else deleted the entry; restart the search */
 			pthread_mutex_unlock (entry_mutex);
@@ -185,19 +317,14 @@ namespace lockfree
 			    break;
 			  }
 		      }
-		  }
-		else
-		  {
-		    // not using mutex
-		    // fall through
-		  }
+		  } // m_edesc->using_mutex
 
-		found_node = curr;
+		entry = curr;
 		return;
 	      }
 
 	    /* advance */
-	    curr = address_marker::atomic_strip_address_mark (get_nextp (curr));
+	    curr = address_marker::strip_address_mark (get_nextp_ref (curr));
 	  }
       }
 
@@ -205,13 +332,33 @@ namespace lockfree
     tdes.end_tran ();
   }
 
+
+  /*
+   * Behavior flags:
+   *
+   * LF_LIST_BF_RETURN_ON_RESTART - When insert fails because last entry in bucket was deleted, if this flag is set,
+   *				    then the operation is restarted from here, instead of looping inside
+   *				    lf_list_insert_internal (as a consequence, hash key is recalculated).
+   *				    NOTE: Currently, this flag is always used (I must find out why).
+   *
+   * LF_LIST_BF_INSERT_GIVEN	  - If this flag is set, the caller means to force its own entry into hash table.
+   *				    When the flag is not set, a new entry is claimed from freelist.
+   *				    NOTE: If an entry with the same key already exists, the entry given as argument is
+   *					  automatically retired.
+   *
+   * LF_LIST_BF_FIND_OR_INSERT	  - If this flag is set and an entry for the same key already exists, the existing
+   *				    key will be output. If the flag is not set and key exists, insert just gives up
+   *				    and a NULL entry is output.
+   *				    NOTE: insert will not give up when key exists, if m_edesc->f_update is provided.
+   *					  a new key is generated and insert is restarted.
+   */
   template <class Key, class T>
   bool
-  hashmap<Key, T>::list_insert_internal (tran::index tran_index, address_marker &list_head, Key &key,
-					 int *behavior_flags, T *&entry)
+  hashmap<Key, T>::list_insert_internal (tran::index tran_index, T *&list_head, Key &key, int *behavior_flags,
+					 T *&entry)
   {
     pthread_mutex_t *entry_mutex = NULL;	/* Locked entry mutex when not NULL */
-    T *curr_no_strip = NULL;
+    T **curr_p = NULL;
     T *curr = NULL;
     bool is_tran_started = false;
     tran::descriptor &tdes = m_freelist->get_transaction_table ().get_descriptor (tran_index);
@@ -219,14 +366,15 @@ namespace lockfree
 
     while (restart_search)
       {
-	tdes.start_tran ();
+	restart_search = false;
 
+	safe_force_start_tran (tdes);
 
-	curr_no_strip = list_head.get_address_no_strip ();
-	curr = address_marker::strip_address_mark (curr_no_strip);
+	curr_p = &list_head;
+	curr = address_marker::atomic_strip_address_mark (*curr_p);
 
 	/* search */
-	while (curr_no_strip != NULL)
+	while (curr_p != NULL)    // this is always true actually...
 	  {
 	    assert (tdes.is_tran_started ());
 	    assert (entry_mutex == NULL);
@@ -246,18 +394,175 @@ namespace lockfree
 		    if (m_edesc->using_mutex)
 		      {
 			/* entry has a mutex protecting it's members; lock it */
-			entry_mutex = get_pthread_mutexp (curr);
-			pthread_mutex_lock (entry_mutex);
+			safe_lock_entry (curr, entry_mutex);
 
-			tdes.end_tran ();
+			/* mutex has been locked, no need to keep transaction alive */
+			safe_force_end_tran (tdes);
 
-			/// todo...
+			if (address_type::is_address_marked (get_nextp_ref (curr)))
+			  {
+			    /* while waiting for lock, somebody else deleted the entry; restart the search */
+			    safe_force_unlock_entry (entry_mutex);
+
+			    if (behavior_flags && (*behavior_flags & LF_LIST_BF_RETURN_ON_RESTART))
+			      {
+				*behavior_flags = (*behavior_flags) | LF_LIST_BR_RESTARTED;
+				return;
+			      }
+			    else
+			      {
+				restart_search = true;
+				break;
+			      }
+			  }
+		      }
+
+		    safeguard_use_mutex_or_tran_started (tdes, entry_mutex);
+		    if (m_edesc->f_duplicate != NULL)
+		      {
+			/* we have a duplicate key callback. */
+			if (m_edesc->f_duplicate (&key, curr) != NO_ERROR)
+			  {
+			    safe_end_tran (tdes);
+			    safe_unlock_entry (entry_mutex);
+			    return;
+			  }
+
+#if 1
+			LF_LIST_BR_SET_FLAG (behavior_flags, LF_LIST_BR_RESTARTED);
+			safe_end_tran (tdes);
+			safe_unlock_entry (entry_mutex);
+			return;
+#else  /* !1 = 0 */
+			/* Could we have such cases that we just update existing entry without modifying anything else?
+			 * And would it be usable with just a flag?
+			 * Then this code may be used.
+			 * So far we have only one usage for f_duplicate, which increment SESSION_ID and requires
+			 * restarting hash search. This will be the usual approach if f_duplicate.
+			 * If we just increment a counter in existing entry, we don't need to do anything else. This
+			 * however most likely depends on f_duplicate implementation. Maybe it is more useful to give
+			 * behavior_flags argument to f_duplicate to tell us if restart is or is not needed.
+			 */
+			if (LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_RESTART_ON_DUPLICATE))
+			  {
+			    LF_LIST_BR_SET_FLAG (behavior_flags, LF_LIST_BR_RESTARTED);
+			    safe_end_tran (tdes);
+			    safe_unlock_entry (entry_mutex);
+			    return;
+			  }
+			else
+			  {
+			    /* duplicate does not require restarting search. */
+			    if (LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_INSERT_GIVEN))
+			      {
+				/* Could not be inserted. Retire the entry. */
+				freelist_retire (tdes, entry);
+			      }
+
+			    /* fall through to output current entry. */
+			  }
+#endif /* 0 */
+		      }
+		    else // m_edesc->f_duplicate == NULL
+		      {
+			if (LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_INSERT_GIVEN))
+			  {
+			    /* the given entry could not be inserted. retire it. */
+			    freelist_retire (tdes, entry);
+			  }
+
+			if (!LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_FIND_OR_INSERT))
+			  {
+			    /* found entry is not accepted */
+			    safe_end_tran (tdes);
+			    safe_unlock_entry (entry_mutex);
+			    return;
+			  }
+
+			/* fall through to output current entry. */
+		      } // m_edesc->f_duplicate == NULL
+
+		    assert (entry == NULL);
+		    safeguard_use_mutex_or_tran_started (tdes, entry_mutex);
+		    entry = curr;
+		    return;
+		  } // m_edesc->f_key_cmp (&key, get_keyp (curr)) == 0
+
+		/* advance */
+		curr_p = &get_nextp_ref (curr);
+		curr = address_marker::strip_address_mark (*curr_p);
+	      }
+	    else // curr == NULL
+	      {
+		/* end of bucket, we must insert */
+		if (entry == NULL)
+		  {
+		    assert (!LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_INSERT_GIVEN));
+
+		    entry = freelist_claim (tdes);
+		    assert (entry != NULL);
+
+		    /* set it's key */
+		    if (m_edesc->f_key_copy (&key, get_keyp (entry)) != NO_ERROR)
+		      {
+			assert (false);
+			safe_force_end_tran (tdes);
+			return;
 		      }
 		  }
-	      }
-	  }
-      }
+
+		if (m_edesc->using_mutex)
+		  {
+		    /* entry has a mutex protecting it's members; lock it */
+		    safe_lock_entry (entry, entry_mutex);
+		  }
+
+		/* attempt an add */
+		if (!ATOMIC_CAS_ADDR (curr_p, NULL, entry))
+		  {
+		    if (m_edesc->using_mutex)
+		      {
+			/* link failed, unlock mutex */
+			safe_force_unlock_entry (entry_mutex);
+		      }
+
+		    /* someone added before us, restart process */
+		    if (LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_RETURN_ON_RESTART))
+		      {
+			if (!LF_LIST_BF_IS_FLAG_SET (behavior_flags, LF_LIST_BF_INSERT_GIVEN))
+			  {
+			    save_temporary (entry);
+			  }
+			LF_LIST_BR_SET_FLAG (behavior_flags, LF_LIST_BR_RESTARTED);
+			safe_force_end_tran (tdes);
+			return;
+		      }
+		    else
+		      {
+			safe_force_end_tran (tdes);
+			restart_search = true;
+			break;
+		      }
+		  }
+
+		/* end transaction if mutex is acquired */
+		if (m_edesc->using_mutex)
+		  {
+		    safe_force_end_tran (tdes);
+		  }
+
+		/* done! */
+		return true;
+	      } //  else of if (curr != NULL)
+	  } // while (curr_p != NULL)
+
+	/* impossible case */
+	assert (false);
+      } // while (restart_search)
+    /* impossible case */
+    assert (false);
   }
-}
+
+} // namespace lockfree
 
 #endif // !_LOCKFREE_HASHMAP_HPP_

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -64,12 +64,12 @@ namespace lockfree
       using freelist_type = freelist<T>;
       using free_node_type = typename freelist_type::free_node;
 
+      freelist_type *m_freelist;
+
       T **m_buckets;
       size_t m_size;
 
-      T **m_freelist;
-
-      address_type *m_backbuffer;
+      T **m_backbuffer;
       std::mutex m_backbuffer_mutex;
 
       lf_entry_descriptor *m_edesc;
@@ -183,7 +183,7 @@ namespace lockfree
     m_backbuffer = new T *[m_size] ();
     for (size_t i = 0; i < m_size; i++)
       {
-	m_backbuffer[i] = address_type::MARKED_NULLPTR;
+	m_backbuffer[i] = address_type::set_adress_mark (NULL);
       }
   }
 
@@ -296,7 +296,7 @@ namespace lockfree
     /* clear bucket buffer, containing remains of old entries marked for delete */
     for (size_t i = 0; i < m_size; ++i)
       {
-	assert (m_backbuffer[i] == address_type::MARKED_NULLPTR);
+	assert (m_backbuffer[i] == address_type::set_adress_mark (NULL));
 	m_buckets[i] = NULL;
       }
 
@@ -317,7 +317,7 @@ namespace lockfree
 	  {
 	    curr = address_type::strip_address_mark (old_buckets[i]);
 	  }
-	while (!ATOMIC_CAS_ADDR (&old_buckets[i], curr, address_type::MARKED_NULLPTR));
+	while (!ATOMIC_CAS_ADDR (&old_buckets[i], curr, address_type::set_adress_mark (NULL)));
 
 	while (curr != NULL)
 	  {

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; version 2 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ */
+
+//
+// lock-free hash map structure
+//
+
+#ifndef _LOCKFREE_HASHMAP_HPP_
+#define _LOCKFREE_HASHMAP_HPP_
+
+#include "lockfree_freelist.hpp"
+
+namespace lockfree
+{
+  template <class Key, class T>
+  class hashmap
+  {
+    public:
+      // todo
+
+    private:
+  };
+}
+
+#endif // !_LOCKFREE_HASHMAP_HPP_

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -110,6 +110,11 @@ namespace lockfree
 
       bool hash_insert_internal (tran::index tran_index, Key &key, int bflags, T *&entry);
       bool hash_erase_internal (tran::index tran_index, Key &key, int bflags, T *locked_entry);
+
+      static constexpr std::ptrdiff_t free_node_offset_of_data (typename freelist<T>::free_node &fn)
+      {
+	return ((char *) (&fn.get_data ())) - ((char *) (&fn));
+      }
   }; // class hashmap
 
   template <class Key, class T>
@@ -439,8 +444,9 @@ namespace lockfree
   hashmap<Key, T>::to_free_node (T *p)
   {
     // not nice, but necessary until we fully refactor lockfree hashmap
+    const std::ptrdiff_t off = free_node_offset_of_data (free_node_type ());
     char *cp = (char *) p;
-    cp -= free_node_offset_of_data<T> ();
+    cp -= off;
     return (free_node_type *) cp;
   }
 

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -111,7 +111,7 @@ namespace lockfree
       bool hash_insert_internal (tran::index tran_index, Key &key, int bflags, T *&entry);
       bool hash_erase_internal (tran::index tran_index, Key &key, int bflags, T *locked_entry);
 
-      static constexpr std::ptrdiff_t free_node_offset_of_data (typename freelist<T>::free_node &fn)
+      static constexpr std::ptrdiff_t free_node_offset_of_data (typename freelist<T>::free_node fn)
       {
 	return ((char *) (&fn.get_data ())) - ((char *) (&fn));
       }

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -46,6 +46,9 @@ namespace lockfree
       void destroy ();
 
       T *find (tran::index tran_index, Key &key);
+      bool find_or_insert (tran::index tran_index, Key &key, T *&t);
+      bool insert (tran::index tran_index, Key &key, T *&t);
+      bool insert_given (tran::index tran_index, Key &key, T *&t);
 
     private:
       using address_type = address_marker<T>;
@@ -158,6 +161,29 @@ namespace lockfree
 	restart = (bflags & LF_LIST_BR_RESTARTED) != 0;
       }
     return entry;
+  }
+
+  template <class Key, class T>
+  bool
+  hashmap<Key, T>::find_or_insert (tran::index tran_index, Key &key, T *&t)
+  {
+    return hash_insert_internal (tran_index, key, LF_LIST_BF_RETURN_ON_RESTART | LF_LIST_BF_FIND_OR_INSERT, entry);
+  }
+
+  template <class Key, class T>
+  bool
+  hashmap<Key, T>::insert (tran::index tran_index, Key &key, T *&t)
+  {
+    return hash_insert_internal (tran_index, key, LF_LIST_BF_RETURN_ON_RESTART, entry);
+  }
+
+  template <class Key, class T>
+  bool
+  hashmap<Key, T>::insert_given (tran::index tran_index, Key &key, T *&t)
+  {
+    return hash_insert_internal (tran_index, key,
+				 LF_LIST_BF_RETURN_ON_RESTART | LF_LIST_BF_INSERT_GIVEN | LF_LIST_BF_FIND_OR_INSERT,
+				 entry);
   }
 
   template <class Key, class T>

--- a/src/base/lockfree_transaction_descriptor.cpp
+++ b/src/base/lockfree_transaction_descriptor.cpp
@@ -108,7 +108,7 @@ namespace lockfree
     }
 
     bool
-    descriptor::is_tran_started ()
+    descriptor::is_tran_started () const
     {
       return m_tranid != INVALID_TRANID;
     }

--- a/src/base/lockfree_transaction_descriptor.cpp
+++ b/src/base/lockfree_transaction_descriptor.cpp
@@ -47,6 +47,10 @@ namespace lockfree
 	{
 	  reclaim_retired_head ();
 	}
+      if (m_saved_node != NULL)
+	{
+	  m_saved_node->reclaim ();
+	}
     }
 
     void
@@ -158,6 +162,22 @@ namespace lockfree
       nodep->m_retired_next = NULL;
       nodep->reclaim ();
       ++m_reclaim_count;
+    }
+
+    void
+    descriptor::save_reclaimable (reclaimable_node *&node)
+    {
+      assert (m_saved_node == NULL);
+      m_saved_node = node;
+      node = NULL;
+    }
+
+    reclaimable_node *
+    descriptor::pull_saved_reclaimable ()
+    {
+      reclaimable_node *ret = m_saved_node;
+      m_saved_node = NULL;
+      return ret;
     }
 
     size_t

--- a/src/base/lockfree_transaction_descriptor.cpp
+++ b/src/base/lockfree_transaction_descriptor.cpp
@@ -35,6 +35,7 @@ namespace lockfree
       , m_retired_head (NULL)
       , m_retired_tail (NULL)
       , m_did_incr (false)
+      , m_saved_node (NULL)
       , m_retire_count (0)
       , m_reclaim_count (0)
     {

--- a/src/base/lockfree_transaction_descriptor.hpp
+++ b/src/base/lockfree_transaction_descriptor.hpp
@@ -72,6 +72,7 @@ namespace lockfree
 
 	void reclaim_retired_list ();
 
+	// a reclaimable node may be saved for later use; must not have been part of lock-free structure
 	void save_reclaimable (reclaimable_node *&node);
 	reclaimable_node *pull_saved_reclaimable ();
 

--- a/src/base/lockfree_transaction_descriptor.hpp
+++ b/src/base/lockfree_transaction_descriptor.hpp
@@ -72,6 +72,9 @@ namespace lockfree
 
 	void reclaim_retired_list ();
 
+	void save_reclaimable (reclaimable_node *&node);
+	reclaimable_node *pull_saved_reclaimable ();
+
 	size_t get_total_retire_count () const;
 	size_t get_total_reclaim_count () const;
 	size_t get_current_retire_count () const;
@@ -85,6 +88,8 @@ namespace lockfree
 	reclaimable_node *m_retired_head;
 	reclaimable_node *m_retired_tail;
 	bool m_did_incr;
+
+	reclaimable_node *m_saved_node;
 
 	// stats
 	size_t m_retire_count;

--- a/src/base/lockfree_transaction_descriptor.hpp
+++ b/src/base/lockfree_transaction_descriptor.hpp
@@ -66,7 +66,7 @@ namespace lockfree
 	void start_tran_and_increment_id ();
 	void end_tran ();
 
-	bool is_tran_started ();
+	bool is_tran_started () const;
 
 	id get_transaction_id () const;
 

--- a/src/thread/thread_lockfree_hash_map.cpp
+++ b/src/thread/thread_lockfree_hash_map.cpp
@@ -21,4 +21,5 @@
 
 namespace cubthread
 {
+  using a_lockfree_hashmap = lockfree_hashmap<int, int>;
 } // namespace cubthread

--- a/src/thread/thread_lockfree_hash_map.cpp
+++ b/src/thread/thread_lockfree_hash_map.cpp
@@ -21,5 +21,4 @@
 
 namespace cubthread
 {
-  using a_lockfree_hashmap = lockfree_hashmap<int, int>;
 } // namespace cubthread

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -25,6 +25,7 @@
 #define _THREAD_LOCKFREE_HASH_MAP_
 
 #include "lock_free.h"  // old implementation
+#include "lockfree_hashmap.hpp"
 #include "lockfree_transaction_def.hpp"
 #include "thread_entry.hpp"
 
@@ -55,8 +56,6 @@ namespace cubthread
       void clear (cubthread::entry *thread_p);    // NOT LOCK-FREE
 
     private:
-      class new_hashmap;
-
       bool is_old_type () const;
       lf_tran_entry *get_tran_entry (cubthread::entry *thread_p);
 
@@ -68,69 +67,9 @@ namespace cubthread
       };
 
       lf_hash_table_cpp<Key, T> m_old_hash;
-      new_hashmap m_new_hash;
+      lockfree::hashmap<Key, T> m_new_hash;
       type m_type;
       int m_entry_idx;
-  };
-
-  template <class Key, class T>
-  class lockfree_hashmap<Key, T>::new_hashmap
-  {
-    public:
-      new_hashmap () = default;
-
-      class iterator
-      {
-	public:
-	  iterator ();
-	  iterator (lockfree::tran::index tran_index, lockfree_hashmap &map) {}
-	  ~iterator ();
-
-	  T *
-	  iterate ()
-	  {
-	    return NULL;
-	  }
-      };
-
-      void init () {}
-      void destroy () {}
-
-      T *
-      find (lockfree::tran::index tran_index, Key &key)
-      {
-	return NULL;
-      }
-      bool
-      find_or_insert (lockfree::tran::index tran_index, Key &key, T *&t)
-      {
-	return false;
-      }
-      bool
-      insert (lockfree::tran::index tran_index, Key &key, T *&t)
-      {
-	return false;
-      }
-      bool
-      insert_given (lockfree::tran::index tran_index, Key &key, T *&t)
-      {
-	return false;
-      }
-      bool
-      erase (lockfree::tran::index tran_index, Key &key)
-      {
-	return false;
-      }
-      bool
-      erase_locked (lockfree::tran::index tran_index, Key &key, T *&t)
-      {
-	return false;
-      }
-
-      void unlock (lockfree::tran::index tran_index, T *&t) {}
-      void clear (lockfree::tran::index tran_index) {}
-
-    private:
   };
 
   template <class Key, class T>
@@ -146,8 +85,7 @@ namespace cubthread
       // old stuff
       lockfree_hashmap &m_map;
       typename lf_hash_table_cpp<Key, T>::iterator m_old_iter;
-      typename lockfree_hashmap::new_hashmap::iterator m_new_iter;
-      T *m_crt_val;
+      typename lockfree::hashmap<Key, T>::iterator m_new_iter;
   };
 } // namespace cubthread
 
@@ -291,7 +229,6 @@ namespace cubthread
     : m_map (map)
     , m_old_iter ()
     , m_new_iter ()
-    , m_crt_val (NULL)
   {
     if (m_map.is_old_type ())
       {

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -41,7 +41,8 @@ namespace cubthread
 
       void init_as_old (lf_tran_system &transys, int hash_size, int freelist_block_count, int freelist_block_size,
 			lf_entry_descriptor &edesc, int entry_idx);
-      void init_as_new ();
+      void init_as_new (lockfree::tran::system &transys, size_t hash_size, size_t freelist_block_size,
+			size_t freelist_block_count, lf_entry_descriptor &edesc);
       void destroy ();
 
       T *find (cubthread::entry *thread_p, Key &key);
@@ -118,10 +119,11 @@ namespace cubthread
 
   template <class Key, class T>
   void
-  lockfree_hashmap<Key, T>::init_as_new ()
+  lockfree_hashmap<Key, T>::init_as_new (lockfree::tran::system &transys, size_t hash_size, size_t freelist_block_size,
+					 size_t freelist_block_count, lf_entry_descriptor &edesc)
   {
-    // not implemented
-    assert (false);
+    m_type = NEW;
+    m_new_hash.init (transys, hash_size, freelist_block_size, freelist_block_count, edesc);
   }
 
 #define lockfree_hashmap_forward_func(f_, tp_, ...) \
@@ -210,8 +212,8 @@ namespace cubthread
   bool
   lockfree_hashmap<Key, T>::is_old_type () const
   {
-    // for now, always true
-    return true;
+    assert (m_type == OLD || m_type == NEW);
+    return m_type == OLD;
   }
 
   template <class Key, class T>

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -52,7 +52,7 @@ namespace cubthread
 
       void unlock (cubthread::entry *thread_p, T *&t);
 
-      void clear (cubthread::entry *thread_p);
+      void clear (cubthread::entry *thread_p);    // NOT LOCK-FREE
 
     private:
       class new_hashmap;

--- a/unit_tests/lockfree/CMakeLists.txt
+++ b/unit_tests/lockfree/CMakeLists.txt
@@ -20,10 +20,12 @@ set (TEST_LOCKFREE_SOURCES
   test_main.cpp
   test_cqueue_functional.cpp
   test_freelist_functional.cpp
+  test_hashmap.cpp
 )
 set (TEST_LOCKFREE_HEADERS
   test_cqueue_functional.hpp
   test_freelist_functional.hpp
+  test_hashmap.hpp
 )
 SET_SOURCE_FILES_PROPERTIES(
   ${TEST_LOCKFREE_SOURCES}

--- a/unit_tests/lockfree/test_hashmap.cpp
+++ b/unit_tests/lockfree/test_hashmap.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+#include "test_hashmap.hpp"
+
+#include "lockfree_hashmap.hpp"
+#include "lockfree_transaction_system.hpp"
+
+using namespace lockfree;
+
+namespace test_lockfree
+{
+  using int_hashmap = hashmap<int, int>;
+  static lf_entry_descriptor g_entdesc;
+
+  int
+  test_hashmap_functional ()
+  {
+    tran::system sys (10);
+    int_hashmap hash;
+    hash.init (sys, 10, 10, 10, g_entdesc);
+    return 0;
+  }
+
+  int
+  test_hashmap_performance ()
+  {
+    tran::system sys (10);
+    int_hashmap hash;
+    hash.init (sys, 10, 10, 10, g_entdesc);
+    return 0;
+  }
+} // namespace test_lockfree

--- a/unit_tests/lockfree/test_hashmap.hpp
+++ b/unit_tests/lockfree/test_hashmap.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+#ifndef _TEST_HASHMAP_HPP_
+#define _TEST_HASHMAP_HPP_
+
+namespace test_lockfree
+{
+  int test_hashmap_functional ();
+  int test_hashmap_performance ();
+} // namespace test_lockfree
+
+#endif // !_TEST_HASHMAP_HPP_

--- a/unit_tests/lockfree/test_main.cpp
+++ b/unit_tests/lockfree/test_main.cpp
@@ -31,9 +31,10 @@ main (int argc, char **argv)
   {
     "all",
     "cqueue",
-    "freelist"
+    "freelist",
+    "hashmap"
   };
-  if (argc == 2)
+  if (argc >= 2)
     {
       for (size_t i = 0; i < option_map.size (); i++)
 	{
@@ -51,6 +52,35 @@ main (int argc, char **argv)
   if (opt == 0 || opt == 2)
     {
       err = err | test_lockfree::test_freelist_functional ();
+    }
+  if (opt == 0 || opt == 3)
+    {
+      std::vector<std::string> suboption_map =
+      {
+	"functional",
+	"performance"
+      };
+      bool do_functional = (opt == 0) || (argc == 2);
+      bool do_performance = (opt == 0) || (argc == 2);
+      if (opt == 3 && argc >= 3)
+	{
+	  if (suboption_map[0] == argv[2])
+	    {
+	      do_functional = true;
+	    }
+	  else if (suboption_map[1] == argv[2])
+	    {
+	      do_performance = true;
+	    }
+	}
+      if (do_functional)
+	{
+	  err = err | test_lockfree::test_hashmap_functional ();
+	}
+      if (do_performance)
+	{
+	  err = err | test_lockfree::test_hashmap_performance ();
+	}
     }
 
   return err;

--- a/unit_tests/lockfree/test_main.cpp
+++ b/unit_tests/lockfree/test_main.cpp
@@ -19,6 +19,7 @@
 
 #include "test_cqueue_functional.hpp"
 #include "test_freelist_functional.hpp"
+#include "test_hashmap.hpp"
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23339

### lockfree::address_marker

Class wrapper over address pointer that can be marked. Can hold and manipulate a markable pointer; static interface to replace ADDR_HAS_MARK/ADDR_WITH_MARK/ADDR_STRIP_MARK.

After full hashmap refactoring, public interface should be extended and class should be used as type of head/next links in bucket lists.

### lockfree::hashmap

#### class lockfree::hashmap

Class wrapper for existing lock-free hash table, adapted to new transaction/freelist system
  - templetized by Key/Value to provide type safety
  - kept entry descriptor dependency
  - logic of operations is generally unchanged
  - using std::mutex

#### function equivalency

- lf_hash_init + lf_freelist_init => hashmap::init
- lf_hash_destroy + lf_freelist_destroy => hashmap::destroy
- lf_hash_find => hashmap::find
- lf_hash_find_or_insert => hashmap::find_or_insert
- lf_hash_insert => hashmap::insert
- lf_hash_insert_given => hashmap::insert_given
- lf_hash_delete => hashmap::erase
- lf_hash_delete_locked_entry => hashmap::erase_locked
- lf_hash_clear => hashmap::clear
- lf_freelist_claim => hashmap::freelist_claim
- lf_freelist_retire => hashmap::freelist_retire
- lf_list_find => hashmap::list_find
- lf_list_insert_internal => hashmap::list_insert_internal
- lf_list_delete => hashmap::list_delete
- lf_hash_insert_internal => hashmap::hash_insert_internal
- lf_hash_delete_internal => hashmap::hash_erase_internal
- lf_hash_create_iterator => hashmap::iterator constructor
- lf_hash_iterate =>hashmap::iterator::iterate
- OF_GET_REF => hashmap::get_ref
- OF_GET_PTR => hashmap::get_ptr
- OF_GET_PTR_DEREF => hashmap::get_pr_deref
- OF_GET_PTR_DEREF (entry, edesc->of_next) => hashmap::get_nextp (entry)
- OF_GET_REF (entry, edesc->of_next) => &hashmap::get_nextp_ref (entry)
- OF_GET_PTR (entry, edesc->of_key) => hashmap::get_keyp (entry)
- OF_GET_PTR (entry, edesc->of_mutex) => hashmap::get_pthread_mutexp (entry)
- LF_START_TRAN => hashmap::start_tran_if_not_started
- LF_START_TRAN_FORCE => hashmap::start_tran_force
- LF_END_TRAN => hashmap::end_tran_if_not_started
- LF_END_TRAN_FORCE => hashmap::end_tran_force
- LF_PROMOTE_TRAN_FORCE => hashmap::promote_tran_force
- LF_LOCK_ENTRY => hashmap::lock_entry_mutex
- LF_UNLOCK_ENTRY => hashmap::unlock_entry_mutex_if_locked
- LF_UNLOCK_ENTRY_FORCE => hashmap::unlock_entry_mutex_force

#### additional functions

- *unlock* => to be called after finishing using a hashmap entry
- get_hash + get_bucket => determine bucket of key
- get_tran_descriptor => tran_index to tran::descriptor
- to_free_node/from_free_node => convert to/from freelist free_node types; this approach was preferred to including free_node into existing value types (it requires too many changes); using constexpr to compute the offset of free_node to data.
- save_temporary/claim_temporary + tran::descriptor::save_reclaimable/pull_saved_reclaimable => save an entry into transaction descriptor for future claiming


#### implementation differences:

- destroy retires elements to freelist instead of deleting directly
- no unit test related code
- restart_search label is replaced with `while (restart_search)` loop.

### FUTURE TODO:

  - add statistics, counters/timers
  - add functional/performance unit testing
