### PR TITLE
[CBRD-23350] loaddb: check for matching single quotes on split

### DIFF
--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -621,13 +621,6 @@ namespace cubload
 	// since std::getline eats end line character, add it back in order to make loaddb lexer happy
 	batch_buffer.append ("\n");
 
-	// it could be that a row is wrapped on the next line,
-	// this means that the row ends on the last line that does not end with '+' (plus) character
-	if (ends_with (line, "+"))
-	  {
-	    continue;
-	  }
-
 	// check for matching single quotes
 	for (const char &c: line)
 	  {
@@ -636,6 +629,14 @@ namespace cubload
 		single_quote_checker ^= 1;
 	      }
 	  }
+
+	// it could be that a row is wrapped on the next line,
+	// this means that the row ends on the last line that does not end with '+' (plus) character
+	if (ends_with (line, "+"))
+	  {
+	    continue;
+	  }
+
 	// if single_quote_checker is 1, it means that a single quote was opened but not closed
 	if (single_quote_checker == 1)
 	  {

--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -186,6 +186,9 @@ namespace cubload
     setters_[DB_TYPE_TIMESTAMPTZ][LDR_TIMESTAMPTZ] = &to_db_timestamptz;
     setters_[DB_TYPE_TIMESTAMPLTZ][LDR_TIMESTAMPLTZ] = &to_db_timestampltz;
 
+    setters_[DB_TYPE_ENUMERATION][LDR_INT] = &to_db_int;
+    setters_[DB_TYPE_ENUMERATION][LDR_STR] = &to_db_string;
+
     return setters_;
   }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23350

```sql
create table t (s string);
```
object file:
```
%class t (s)
'
aaa
bbb
ccc
'
```
Take into account when splitting object file into batches cases when new line is part of data