### PR TITLE
[CBRD-23377] add FLEX_INCLUDE_DIRS to cubrid-win-lib

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -511,6 +511,7 @@ if(AT_LEAST_ONE_UNIT_TEST)
     ${CMAKE_SOURCE_DIR}/src/heaplayers/util
     ${JAVA_INC}
     ${EP_INCLUDES}
+    ${FLEX_INCLUDE_DIRS}
     )
 
   add_dependencies(cubrid-win-lib ${EP_TARGETS})


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23377

fix unit test buiding for windows