### PR TITLE
[CBRD-23378] fix wait_for_complete

### DIFF
--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -145,7 +145,7 @@ namespace cubload
       load_args m_args;
       batch_id m_last_batch_id;
       std::atomic<batch_id> m_max_batch_id;
-      std::atomic<size_t> m_active_task_count;
+      std::atomic<size_t> m_active_task_count;    // note: all decrements need to be protected by mutex
 
       class_registry m_class_registry;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23378

Decrements, failure and setting last batch id should always be done under mutex and they should always notify waiting threads.