### PR TITLE
[CBRD-23384] fix vacuum shutdown sequence

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -511,6 +511,7 @@ if(AT_LEAST_ONE_UNIT_TEST)
     ${CMAKE_SOURCE_DIR}/src/heaplayers/util
     ${JAVA_INC}
     ${EP_INCLUDES}
+    ${FLEX_INCLUDE_DIRS}
     )
 
   add_dependencies(cubrid-win-lib ${EP_TARGETS})

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1397,7 +1397,7 @@ shutdown:
   css_stop_all_workers (*thread_p, THREAD_STOP_WORKERS_EXCEPT_LOGWR);
 
   /* stop vacuum threads. */
-  vacuum_stop (thread_p);
+  vacuum_stop_workers (thread_p);
 
   // stop load sessions
   cubload::worker_manager_stop_all ();

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -8241,6 +8241,10 @@ vacuum_shutdown_sequence::vacuum_shutdown_sequence ()
 void
 vacuum_shutdown_sequence::request_shutdown ()
 {
+  if (m_state == SHUTDOWN_REGISTERED)
+    {
+      return;
+    }
   std::unique_lock<std::mutex> ulock { m_state_mutex };
   assert (m_state == NO_SHUTDOWN);
   m_state = SHUTDOWN_REQUESTED;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -53,6 +53,8 @@
 #include "util_func.h"
 
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <stack>
 
 #include <cstring>
@@ -324,6 +326,27 @@ class vacuum_job_cursor
 #define vacuum_job_cursor_print_args(cursor) \
   (long long int) (cursor).get_blockid (), VPID_AS_ARGS (&(cursor).get_page_vpid ()), (int) (cursor).get_index ()
 
+class vacuum_shutdown_sequence
+{
+  public:
+    vacuum_shutdown_sequence ();
+
+    void request_shutdown ();
+    bool is_shutdown_requested ();
+    bool check_shutdown_request ();
+
+  private:
+    enum state
+    {
+      NO_SHUTDOWN,
+      SHUTDOWN_REQUESTED,
+      SHUTDOWN_REGISTERED
+    };
+    state m_state;
+    std::mutex m_state_mutex;
+    std::condition_variable m_condvar;
+};
+
 /* Vacuum data.
  *
  * Stores data required for vacuum. It is also stored on disk in the first
@@ -346,8 +369,7 @@ struct vacuum_data
     int log_block_npages;		/* The number of pages in a log block. */
 
     bool is_loaded;		/* True if vacuum data is loaded. */
-    std::atomic<bool> shutdown_requested;	/* Set to true when shutdown is requested. It stops vacuum from generating or
-                                           * executing new jobs. */
+    vacuum_shutdown_sequence shutdown_sequence;
     bool is_archive_removal_safe;	/* Set to true after keep_from_log_pageid is updated. */
 
     LOG_LSA recovery_lsa;		/* This is the LSA where recovery starts. It will be used to go backward in the log
@@ -368,7 +390,7 @@ struct vacuum_data
       , page_data_max_count (0)
       , log_block_npages (0)
       , is_loaded (false)
-      , shutdown_requested (false)
+      , shutdown_sequence ()
       , is_archive_removal_safe (false)
       , recovery_lsa (LSA_INITIALIZER)
       , is_restoredb_session (false)
@@ -1076,7 +1098,6 @@ vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npages, VFID * 
     }
 
   /* Initialize vacuum data */
-  vacuum_Data.shutdown_requested = false;
   vacuum_Data.is_restoredb_session = is_restore;
   /* Save vacuum data VFID. */
   VFID_COPY (&vacuum_Data.vacuum_data_file, vacuum_data_vfid);
@@ -1237,7 +1258,7 @@ vacuum_boot (THREAD_ENTRY * thread_p)
 }
 
 void
-vacuum_stop (THREAD_ENTRY * thread_p)
+vacuum_stop_workers (THREAD_ENTRY * thread_p)
 {
   if (!vacuum_Is_booted)
     {
@@ -1248,8 +1269,6 @@ vacuum_stop (THREAD_ENTRY * thread_p)
   // notify master to stop generating new jobs
   vacuum_notify_server_shutdown ();
 
-  cubthread::manager * thread_manager = cubthread::get_manager ();
-
   // stop work pool
   if (vacuum_Worker_threads != NULL)
     {
@@ -1257,22 +1276,30 @@ vacuum_stop (THREAD_ENTRY * thread_p)
       vacuum_Worker_threads->er_log_stats ();
       vacuum_Worker_threads->stop_execution ();
 #endif // SERVER_MODE
+
+      cubthread::get_manager ()->destroy_worker_pool (vacuum_Worker_threads);
+    }
+
+  delete vacuum_Worker_context_manager;
+  vacuum_Worker_context_manager = NULL;
+}
+
+void
+vacuum_stop_master (THREAD_ENTRY * thread_p)
+{
+  if (!vacuum_Is_booted)
+    {
+      // not booted
+      return;
     }
 
   // stop master daemon
   if (vacuum_Master_daemon != NULL)
     {
-      thread_manager->destroy_daemon (vacuum_Master_daemon);
+      cubthread::get_manager ()->destroy_daemon (vacuum_Master_daemon);
     }
-  if (vacuum_Worker_threads != NULL)
-    {
-      thread_manager->destroy_worker_pool (vacuum_Worker_threads);
-    }
-
   delete vacuum_Master_context_manager;
-  delete vacuum_Worker_context_manager;
-
-  // all resources should be freed
+  vacuum_Master_context_manager = NULL;
 
   vacuum_Is_booted = false;
 }
@@ -2918,7 +2945,7 @@ vacuum_master_task::execute (cubthread::entry &thread_ref)
 bool
 vacuum_master_task::should_interrupt_iteration () const
 {
-  if (vacuum_Data.shutdown_requested)
+  if (vacuum_Data.shutdown_sequence.check_shutdown_request ())
     {
       // stop on shutdown
       vacuum_er_log (VACUUM_ER_LOG_MASTER, "%s", "Interrupt iteration: shutdown");
@@ -3533,7 +3560,7 @@ vacuum_finished_block_vacuum (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data,
 #if !defined (NDEBUG)
       /* Interrupting jobs without shutdown is unacceptable. */
       assert (thread_p->shutdown);
-      assert (vacuum_Data.shutdown_requested);
+      assert (vacuum_Data.shutdown_sequence.is_shutdown_requested ());
 #endif /* !NDEBUG */
 
 #else /* !SERVER_MODE */
@@ -7339,7 +7366,7 @@ vacuum_notify_server_crashed (LOG_LSA * recovery_lsa)
 void
 vacuum_notify_server_shutdown (void)
 {
-  vacuum_Data.shutdown_requested = true;
+  vacuum_Data.shutdown_sequence.request_shutdown ();
 }
 
 #if !defined (NDEBUG)
@@ -8199,5 +8226,54 @@ vacuum_job_cursor::search ()
         }
       data_page = vacuum_fix_data_page (&cubthread::get_entry (), &next_vpid);
     }
+}
+
+//
+// vacuum_shutdown_sequence
+//
+vacuum_shutdown_sequence::vacuum_shutdown_sequence ()
+  : m_state (NO_SHUTDOWN)
+  , m_state_mutex ()
+  , m_condvar ()
+{
+}
+
+void
+vacuum_shutdown_sequence::request_shutdown ()
+{
+  std::unique_lock<std::mutex> ulock { m_state_mutex };
+  assert (m_state == NO_SHUTDOWN);
+  m_state = SHUTDOWN_REQUESTED;
+  // must wait until shutdown is registered
+  m_condvar.wait (ulock, [this] ()
+    {
+      return m_state == SHUTDOWN_REGISTERED;
+    });
+}
+
+bool
+vacuum_shutdown_sequence::is_shutdown_requested ()
+{
+  return m_state != NO_SHUTDOWN;
+}
+
+bool
+vacuum_shutdown_sequence::check_shutdown_request ()
+{
+  if (m_state == NO_SHUTDOWN)
+    {
+      return false;
+    }
+  else if (m_state == SHUTDOWN_REGISTERED)
+    {
+      return true;
+    }
+  // register
+  std::unique_lock<std::mutex> ulock { m_state_mutex };
+  assert (m_state == SHUTDOWN_REQUESTED);
+  m_state = SHUTDOWN_REGISTERED;
+  ulock.unlock ();
+  m_condvar.notify_one ();
+  return true;
 }
 // *INDENT-ON*

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -8249,11 +8249,11 @@ vacuum_shutdown_sequence::vacuum_shutdown_sequence ()
 void
 vacuum_shutdown_sequence::request_shutdown ()
 {
+#if defined (SERVER_MODE)
   if (m_state == SHUTDOWN_REGISTERED)
     {
       return;
     }
-#if defined (SERVER_MODE)
   std::unique_lock<std::mutex> ulock { m_state_mutex };
   assert (m_state == NO_SHUTDOWN);
   m_state = SHUTDOWN_REQUESTED;

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -221,7 +221,8 @@ extern int vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npag
 			      VFID * dropped_files_vfid, bool is_restore);
 extern void vacuum_finalize (THREAD_ENTRY * thread_p);
 extern int vacuum_boot (THREAD_ENTRY * thread_p);
-extern void vacuum_stop (THREAD_ENTRY * thread_p);
+extern void vacuum_stop_workers (THREAD_ENTRY * thread_p);
+extern void vacuum_stop_master (THREAD_ENTRY * thread_p);
 extern int xvacuum (THREAD_ENTRY * thread_p);
 
 extern int vacuum_create_file_for_vacuum_data (THREAD_ENTRY * thread_p, VFID * vacuum_data_vfid);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23384

The crash is generated by log block being pushed after vacuum is finalized. Keep vacuum master active until no logging is possible.

This required separation of stopping vacuum workers and vacuum master. Also added mutex/conditional variable to make shutdown sequence safe, but making sure master is notified before destroying workers.