### PR TITLE
[CBRD-23251] Added glo_* classes as ignored on server side

### DIFF
--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -403,4 +403,9 @@ namespace cubload
 // alias declaration for legacy C files
 using load_stats = cubload::stats;
 
+#define IS_OLD_GLO_CLASS(class_name)                    \
+	 (strncasecmp ((class_name), "glo", MAX(strlen(class_name), 3)) == 0      || \
+	  strncasecmp ((class_name), "glo_name", MAX(strlen(class_name), 8)) == 0  || \
+	  strncasecmp ((class_name), "glo_holder", MAX(strlen(class_name), 10)) == 0)
+
 #endif /* _LOAD_COMMON_HPP_ */

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -168,11 +168,6 @@ const std::size_t LDR_MAX_ARGS = 32;
            }                                 \
          } while (0)
 
-#define IS_OLD_GLO_CLASS(class_name)                    \
-	 (strncasecmp ((class_name), "glo", MAX(strlen(class_name), 3)) == 0      || \
-	  strncasecmp ((class_name), "glo_name", MAX(strlen(class_name), 8)) == 0  || \
-	  strncasecmp ((class_name), "glo_holder", MAX(strlen(class_name), 10)) == 0)
-
 typedef struct ldr_context LDR_CONTEXT;
 
 typedef void (*LDR_POST_COMMIT_HANDLER) (int);

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -315,6 +315,11 @@ namespace cubload
   bool
   server_class_installer::is_class_ignored (const char *classname)
   {
+    if (IS_OLD_GLO_CLASS (classname))
+      {
+	return true;
+      }
+
     const std::vector<std::string> &classes_ignored = m_session.get_args ().ignore_classes;
     std::string class_name (classname);
     bool is_ignored;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23251

Added the ignore classes beginning with `glo_` on the server-side. This is related to old system tables which should be ignored if the unload is done on an old CUBRID version and the load is done on a newer one.