### PR TITLE
[CBRD-23398] Fix ignore classes to be case insensitive

### DIFF
--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -24,6 +24,7 @@
 #include "load_common.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include "dbtype_def.h"
 #include "error_code.h"
 
@@ -343,7 +344,7 @@ namespace cubload
 
 	// scan first string, and ignore rest of the line
 	sscanf (line.c_str (), fmt, class_name.c_str ());
-	std::transform (class_name.begin (), class_name.end (), class_name.begin (), ::tolower);
+	std::transform (class_name.begin (), class_name.end (), class_name.begin (), std::tolower);
 	ignore_classes.emplace_back (class_name.c_str (), strlen (class_name.c_str ()));
       }
 

--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -23,6 +23,7 @@
 
 #include "load_common.hpp"
 
+#include <algorithm>
 #include "dbtype_def.h"
 #include "error_code.h"
 
@@ -342,6 +343,7 @@ namespace cubload
 
 	// scan first string, and ignore rest of the line
 	sscanf (line.c_str (), fmt, class_name.c_str ());
+	transform (class_name.begin(), class_name.end(), class_name.begin(), ::tolower);
 	ignore_classes.emplace_back (class_name.c_str (), strlen (class_name.c_str ()));
       }
 

--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -343,7 +343,7 @@ namespace cubload
 
 	// scan first string, and ignore rest of the line
 	sscanf (line.c_str (), fmt, class_name.c_str ());
-	transform (class_name.begin(), class_name.end(), class_name.begin(), ::tolower);
+	std::transform (class_name.begin (), class_name.end (), class_name.begin (), ::tolower);
 	ignore_classes.emplace_back (class_name.c_str (), strlen (class_name.c_str ()));
       }
 

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -319,7 +319,7 @@ namespace cubload
     std::string class_name (classname);
     bool is_ignored;
 
-    transform (class_name.begin(), class_name.end(), class_name.begin(), ::tolower);
+    std::transform (class_name.begin (), class_name.end (), class_name.begin (), ::tolower);
 
     auto result = std::find (classes_ignored.begin (), classes_ignored.end (), class_name);
 

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -24,6 +24,7 @@
 #include "load_server_loader.hpp"
 
 #include "btree.h"
+#include <cctype>
 #include "dbtype.h"
 #include "load_class_registry.hpp"
 #include "load_db_value_converter.hpp"
@@ -319,7 +320,7 @@ namespace cubload
     std::string class_name (classname);
     bool is_ignored;
 
-    std::transform (class_name.begin (), class_name.end (), class_name.begin (), ::tolower);
+    std::transform (class_name.begin (), class_name.end (), class_name.begin (), std::tolower);
 
     auto result = std::find (classes_ignored.begin (), classes_ignored.end (), class_name);
 

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -319,6 +319,8 @@ namespace cubload
     std::string class_name (classname);
     bool is_ignored;
 
+    transform (class_name.begin(), class_name.end(), class_name.begin(), ::tolower);
+
     auto result = std::find (classes_ignored.begin (), classes_ignored.end (), class_name);
 
     is_ignored = (result != classes_ignored.end ());


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23398

Fixed the ignore classes mechanism on server by disabling case sensitivity for class names.