### PR TITLE
[CBRD-23405] vacuum finalize consume buffer in a loop

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1351,10 +1351,18 @@ vacuum_finalize (THREAD_ENTRY * thread_p)
 
   if (vacuum_Block_data_buffer != NULL)
     {
-      if (vacuum_Data.is_loaded && vacuum_consume_buffer_log_blocks (thread_p) != NO_ERROR)
+      if (vacuum_Data.is_loaded)
 	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-	  assert (0);
+	  while (!vacuum_Block_data_buffer->is_empty ())
+	    {
+	      // vacuum_consume_buffer_log_blocks own logging may generate another log block. need to recheck
+	      // until buffer is completely empty
+	      if (vacuum_consume_buffer_log_blocks (thread_p) != NO_ERROR)
+		{
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+		  assert (0);
+		}
+	    }
 	}
       if (!vacuum_Block_data_buffer->is_empty ())
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23405

Logging after adding consumed log blocks to vacuum data may trigger the generation of another block. vacuum_finalize needs to check and redo consume in this case.