### PR TITLE
[CBRD-23407] stop vacuum master daemon on failed boot

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2784,6 +2784,7 @@ error:
   logtb_finalize_global_unique_stats_table (thread_p);
 
   vacuum_stop_workers (thread_p);
+  vacuum_stop_master (thread_p);
 
 #if defined(SERVER_MODE)
   pgbuf_daemons_destroy ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23407

Vacuum master daemon needs to be stopped if boot fails before exiting boot_restart_server.