### PR TITLE
[CBRD-23168] Returns error if permanent oid was not assigned

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -9973,7 +9973,16 @@ collect_hier_class_info (MOP classop, DB_OBJLIST * subclasses, const char *const
 		   * subclasses.  We're assuming that the base class has already been processed. */
 		  if (OID_ISTEMP (ws_oid (sub->op)))
 		    {
-		      locator_assign_permanent_oid (sub->op);
+		      if (locator_assign_permanent_oid (sub->op) == NULL)
+			{
+			  if (er_errid () == NO_ERROR)
+			    {
+			      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OBJ_CANT_ASSIGN_OID, 0);
+			    }
+
+			  classobj_free_class_constraints (constraints);
+			  return er_errid ();
+			}
 		    }
 
 		  COPY_OID (&oids[*n_classes], WS_OID (sub->op));
@@ -10868,7 +10877,15 @@ allocate_disk_structures (MOP classop, SM_CLASS * class_, DB_OBJLIST * subclasse
 
   if (OID_ISTEMP (ws_oid (classop)))
     {
-      locator_assign_permanent_oid (classop);
+      if (locator_assign_permanent_oid (classop) == NULL)
+	{
+	  if (er_errid () == NO_ERROR)
+	    {
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OBJ_CANT_ASSIGN_OID, 0);
+	    }
+
+	  goto structure_error;
+	}
     }
 
   for (con = class_->constraints; con != NULL; con = con->next)

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -542,6 +542,11 @@ tf_need_permanent_oid (OR_BUF * buf, DB_OBJECT * obj)
        */
       if (locator_assign_permanent_oid (obj) == NULL)
 	{
+	  if (er_errid () == NO_ERROR)
+	    {
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OBJ_CANT_ASSIGN_OID, 0);
+	    }
+
 	  /* this is serious */
 	  or_abort (buf);
 	}
@@ -823,6 +828,11 @@ tf_mem_to_disk (MOP classmop, MOBJ classobj, MOBJ volatile obj, RECDES * record,
 	   */
 	  if (locator_assign_permanent_oid (classmop) == NULL)
 	    {
+	      if (er_errid () == NO_ERROR)
+		{
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OBJ_CANT_ASSIGN_OID, 0);
+		}
+
 	      or_abort (buf);
 	    }
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23168

Maybe is better to move ER_OBJ_CANT_ASSIGN_OID error inside of locator_assign_permanent_oid.