### PR TITLE
[CBRD-23415] fix postpone cache bad invalidation

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -25207,7 +25207,7 @@ heap_update_and_log_header (THREAD_ENTRY * thread_p, const HFID * hfid, const PG
 
 void
 heap_log_postpone_heap_append_pages (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * class_oid,
-                               const std::vector <VPID> heap_pages_array)
+                                     const std::vector<VPID> &heap_pages_array)
 {
   if (heap_pages_array.empty ())
     {

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -683,10 +683,9 @@ extern int heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, OID class_
 
 extern int heap_nonheader_page_capacity ();
 
-// *INDENT-OFF*
 extern int heap_rv_postpone_append_pages_to_heap (THREAD_ENTRY * thread_p, LOG_RCV * recv);
+// *INDENT-OFF*
 extern void heap_log_postpone_heap_append_pages (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * class_oid,
-						 const std::vector <VPID> heap_pages_array);
-
+						 const std::vector<VPID> &heap_pages_array);
 // *INDENT-ON*
 #endif /* _HEAP_FILE_H_ */

--- a/src/transaction/log_postpone_cache.cpp
+++ b/src/transaction/log_postpone_cache.cpp
@@ -32,6 +32,10 @@ log_postpone_cache::reset ()
 {
   m_cursor = 0;
   m_is_redo_data_buf_full = false;
+  if (m_redo_data_buf.get_size () > BUFFER_RESET_SIZE)
+    {
+      m_redo_data_buf.freemem ();
+    }
 }
 
 /**
@@ -55,7 +59,7 @@ log_postpone_cache::add_redo_data (const log_prior_node &node)
 
   // Check if recovery data fits in preallocated buffer
   std::size_t redo_data_size = sizeof (log_rec_redo) + node.rlength + (2 * MAX_ALIGNMENT);
-  std::size_t total_size = redo_data_size + m_redo_data_buf.get_size ();
+  std::size_t total_size = redo_data_size + m_redo_data_offset;
   if (total_size > REDO_DATA_MAX_SIZE)
     {
       // Cannot store all recovery data
@@ -143,7 +147,7 @@ log_postpone_cache::do_postpone (cubthread::entry &thread_ref, const log_lsa &st
       if (m_cache_entries[i].m_lsa == start_postpone_lsa)
 	{
 	  // Found start lsa
-	  start_index = i;
+	  start_index = (int) i;
 	  break;
 	}
     }
@@ -170,9 +174,14 @@ log_postpone_cache::do_postpone (cubthread::entry &thread_ref, const log_lsa &st
     }
 
   // Finished running postpones, update the number of entries which should be run on next commit
+  assert (!m_is_redo_data_buf_full);
   m_cursor = start_index;
-  m_is_redo_data_buf_full = false;
   m_redo_data_offset = m_cache_entries[start_index].m_offset;
+  if (m_cursor == 0)
+    {
+      assert (m_redo_data_offset == 0); // should be 0 when cursor is back to 0
+      reset ();
+    }
 
   return true;
 }

--- a/src/transaction/log_postpone_cache.hpp
+++ b/src/transaction/log_postpone_cache.hpp
@@ -72,8 +72,8 @@ class log_postpone_cache
 
   private:
     static const std::size_t MAX_CACHE_ENTRIES = 512;
-    // on average redo data size for an entry is 48 bytes
-    static const std::size_t REDO_DATA_MAX_SIZE = 48 * MAX_CACHE_ENTRIES;
+    static const std::size_t REDO_DATA_MAX_SIZE = 100 * 1024;   // 100k
+    static const std::size_t BUFFER_RESET_SIZE = 1024;
 
     class cache_entry
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23415

Bad computation of total_size of redo data invalidates postpone cache, affecting loaddb performance.

Changes:

  - fix total_size computation
  - pass heap_pages_array reference to heap_log_postpone_heap_append_pages (instead of copy)
  - free buffer if its size exceeds BUFFER_RESET_SIZE (1k)
  - fix compile warning (case from size_t to int)