### PR TITLE
[CBRD-23410] Added error when a too long classname is given as argument to loaddb

### DIFF
--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -325,17 +325,23 @@ namespace cubload
     const std::vector<std::string> &classes_ignored = m_session.get_args ().ignore_classes;
     bool is_ignored;
 
-    char lower_case_string[DB_MAX_IDENTIFIER_LENGTH] = { 0 };
-    std::string class_name (lower_case_string);
-
-    assert (intl_identifier_lower_string_size (class_name.c_str ()) <= DB_MAX_IDENTIFIER_LENGTH);
+    char *lower_case_string = (char *) db_private_alloc (NULL, intl_identifier_lower_string_size (classname),
+			      sizeof (char));
 
     // Make the string to be lower case and take into consideration all types of characters.
     intl_identifier_lower (classname, lower_case_string);
 
+    std::string class_name (lower_case_string);
+
     auto result = std::find (classes_ignored.begin (), classes_ignored.end (), class_name);
 
     is_ignored = (result != classes_ignored.end ());
+
+    if (lower_case_string)
+      {
+	db_private_free (NULL, lower_case_string);
+	lower_case_string = NULL;
+      }
 
     return is_ignored;
   }

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -326,8 +326,7 @@ namespace cubload
     const std::vector<std::string> &classes_ignored = m_session.get_args ().ignore_classes;
     bool is_ignored;
 
-    char *lower_case_string = (char *) db_private_alloc (NULL, intl_identifier_lower_string_size (classname),
-			      sizeof (char));
+    char *lower_case_string = (char *) db_private_alloc (NULL, intl_identifier_lower_string_size (classname) + 1);
 
     // Make the string to be lower case and take into consideration all types of characters.
     intl_identifier_lower (classname, lower_case_string);
@@ -338,7 +337,7 @@ namespace cubload
 
     is_ignored = (result != classes_ignored.end ());
 
-    if (lower_case_string)
+    if (lower_case_string != NULL)
       {
 	db_private_free (NULL, lower_case_string);
 	lower_case_string = NULL;

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -31,6 +31,7 @@
 #include "load_error_handler.hpp"
 #include "load_session.hpp"
 #include "locator_sr.h"
+#include "memory_alloc.h"
 #include "object_primitive.h"
 #include "record_descriptor.hpp"
 #include "set_object.h"

--- a/src/loaddb/load_session.cpp
+++ b/src/loaddb/load_session.cpp
@@ -258,6 +258,14 @@ namespace cubload
       {
 	// just set class id to 1 since only one table can be specified as command line argument
 	cubthread::entry &thread_ref = cubthread::get_entry ();
+
+	if (intl_identifier_lower_string_size (m_args.table_name.c_str ()) >= SM_MAX_IDENTIFIER_LENGTH)
+	  {
+	    // This is an error.
+	    m_driver->get_error_handler ().on_error (LOADDB_MSG_EXCEED_MAX_LEN, SM_MAX_IDENTIFIER_LENGTH - 1);
+	    return;
+	  }
+
 	thread_ref.m_loaddb_driver = m_driver;
 	m_driver->get_class_installer ().set_class_id (FIRST_CLASS_ID);
 	m_driver->get_class_installer ().install_class (m_args.table_name.c_str ());


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23410

If a classname which has a too long name is given as the `-t` argument of loaddb, an error is set so that it will not try to install the said class.