### PR TITLE
[CBRD-23339] switch between lockfree hash implementations

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -668,6 +668,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_LOADDB_WORKER_COUNT "loaddb_worker_count"
 #define PRM_NAME_PERF_TEST_MODE "perf_test_mode"
 #define PRM_NAME_REPR_CACHE_LOG "er_log_repr_cache"
+#define PRM_NAME_ENABLE_NEW_LFHASH "new_lfhash"
 
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
@@ -2254,6 +2255,10 @@ static unsigned int prm_perf_test_mode_flag = 0;
 bool PRM_REPR_CACHE_LOG = false;
 static bool prm_repr_cache_log_default = false;
 static unsigned int prm_repr_cache_log_flag = 0;
+
+bool PRM_NEW_LFHASH = false;
+static bool prm_new_lfhash_default = false;
+static unsigned int prm_new_lfhash_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5795,6 +5800,17 @@ static SYSPRM_PARAM prm_Def[] = {
    &prm_repr_cache_log_flag,
    (void *) &prm_repr_cache_log_default,
    (void *) &PRM_REPR_CACHE_LOG,
+   (void *) NULL, (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_ENABLE_NEW_LFHASH,
+   PRM_NAME_ENABLE_NEW_LFHASH,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   &prm_new_lfhash_flag,
+   (void *) &prm_new_lfhash_default,
+   (void *) &PRM_NEW_LFHASH,
    (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -437,8 +437,10 @@ enum param_id
   PRM_ID_PERF_TEST_MODE,
   PRM_ID_REPR_CACHE_LOG,
 
+  PRM_ID_ENABLE_NEW_LFHASH,
+
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_REPR_CACHE_LOG
+  PRM_LAST_ID = PRM_ID_ENABLE_NEW_LFHASH
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/thread/thread_lockfree_hash_map.cpp
+++ b/src/thread/thread_lockfree_hash_map.cpp
@@ -19,6 +19,13 @@
 
 #include "thread_lockfree_hash_map.hpp"
 
+#include "thread_manager.hpp"
+
 namespace cubthread
 {
+  lockfree::tran::system &
+  get_thread_entry_lftransys ()
+  {
+    return cubthread::get_manager ()->get_lockfree_transys ();
+  }
 } // namespace cubthread

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -27,6 +27,7 @@
 #include "lock_free.h"  // old implementation
 #include "lockfree_hashmap.hpp"
 #include "lockfree_transaction_def.hpp"
+#include "system_parameter.h"
 #include "thread_entry.hpp"
 
 namespace cubthread

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -21,8 +21,8 @@
 //  specialize lock-free hash map to thread manager and its entries
 //
 
-#ifndef _THREAD_LOCKFREE_HASH_MAP_
-#define _THREAD_LOCKFREE_HASH_MAP_
+#ifndef _THREAD_LOCKFREE_HASH_MAP_HPP_
+#define _THREAD_LOCKFREE_HASH_MAP_HPP_
 
 #include "lock_free.h"  // old implementation
 #include "lockfree_hashmap.hpp"
@@ -38,6 +38,9 @@ namespace cubthread
       lockfree_hashmap ();
 
       class iterator;
+
+      void init (lf_tran_system &transys, int entry_idx, int hash_size, int freelist_block_size,
+		 int freelist_block_count, lf_entry_descriptor &edesc);
 
       void init_as_old (lf_tran_system &transys, int hash_size, int freelist_block_count, int freelist_block_size,
 			lf_entry_descriptor &edesc, int entry_idx);
@@ -93,6 +96,8 @@ namespace cubthread
       typename lf_hash_table_cpp<Key, T>::iterator m_old_iter;
       typename lockfree::hashmap<Key, T>::iterator m_new_iter;
   };
+
+  lockfree::tran::system &get_thread_entry_lftransys ();
 } // namespace cubthread
 
 //
@@ -110,6 +115,22 @@ namespace cubthread
     , m_new_hash {}
     , m_type (UNKNOWN)
   {
+  }
+
+  template <class Key, class T>
+  void
+  lockfree_hashmap<Key, T>::init (lf_tran_system &transys, int entry_idx, int hash_size, int freelist_block_size,
+				  int freelist_block_count, lf_entry_descriptor &edesc)
+  {
+    if (prm_get_bool_value (PRM_ID_ENABLE_NEW_LFHASH))
+      {
+	init_as_new (get_thread_entry_lftransys (), (size_t) hash_size, (size_t) freelist_block_size,
+		     (size_t) freelist_block_count, edesc);
+      }
+    else
+      {
+	init_as_old (transys, hash_size, freelist_block_count, freelist_block_size, edesc, entry_idx);
+      }
   }
 
   template <class Key, class T>
@@ -283,4 +304,4 @@ namespace cubthread
   }
 }
 
-#endif // !_THREAD_LOCKFREE_HASH_MAP_
+#endif // !_THREAD_LOCKFREE_HASH_MAP_HPP_

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -201,6 +201,11 @@ namespace cubthread
 	return m_all_entries;
       }
 
+      lockfree::tran::system &get_lockfree_transys ()
+      {
+	return *m_lf_tran_sys;
+      }
+
       void set_max_thread_count_from_config ();
       void set_max_thread_count (std::size_t count);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23339

Added system parameter to switch between lockfree hash implementation.

A common init wraps init_as_new/init_as_old; the parameter will decide which functions is called.