### PR TITLE
[CBRD-23261] fix bitmap entry free

### DIFF
--- a/src/base/lockfree_bitmap.cpp
+++ b/src/base/lockfree_bitmap.cpp
@@ -264,7 +264,7 @@ restart:			/* wait-free process */
 
     if (bitmap->style == LF_BITMAP_LIST_OF_CHUNKS)
       {
-	bitmap->entry_count_in_use++;
+	bitmap->entry_count_in_use--;
       }
 
 #if !defined (SERVER_MODE)

--- a/src/base/lockfree_bitmap.cpp
+++ b/src/base/lockfree_bitmap.cpp
@@ -221,6 +221,7 @@ restart:			/* wait-free process */
 	  }
       }
     while (!bitmap->bitfield[chunk_idx].compare_exchange_weak (chunk, chunk | mask));
+
     if (bitmap->style == LF_BITMAP_LIST_OF_CHUNKS)
       {
 	bitmap->entry_count_in_use++;

--- a/src/base/lockfree_bitmap.cpp
+++ b/src/base/lockfree_bitmap.cpp
@@ -220,7 +220,7 @@ restart:			/* wait-free process */
 	    goto restart;
 	  }
       }
-    while (!bitmap->bitfield[chunk_idx].compare_exchange_strong (chunk, chunk | mask));
+    while (!bitmap->bitfield[chunk_idx].compare_exchange_weak (chunk, chunk | mask));
     if (bitmap->style == LF_BITMAP_LIST_OF_CHUNKS)
       {
 	bitmap->entry_count_in_use++;
@@ -260,7 +260,7 @@ restart:			/* wait-free process */
 	    return;
 	  }
       }
-    while (!bitmap->bitfield[pos].compare_exchange_strong (curr, curr & mask));
+    while (!bitmap->bitfield[pos].compare_exchange_weak (curr, curr & mask));
 
     if (bitmap->style == LF_BITMAP_LIST_OF_CHUNKS)
       {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23261

Fix to decrement used entry count on free intead of incrementing. Fixes memory being quickly consumed by area_alloc.

Replace compare_exchange_strong with compare_exchange_weak in loops.