### PR TITLE
[CBRD-23418] fix dropping online index on shutdown

### DIFF
--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -4666,6 +4666,7 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
   // never give up
   old_wait_msec = xlogtb_reset_wait_msecs (thread_p, LK_INFINITE_WAIT);
   old_check_intr = logtb_set_check_interrupt (thread_p, false);
+
   for (cur_class = 0; cur_class < n_classes; cur_class++)
     {
       /* Promote the lock to SCH_M_LOCK */
@@ -4677,6 +4678,7 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
 	    {
 	      break;
 	    }
+#if defined (SERVER_MODE)
 	  else if (lock_ret == LK_NOTGRANTED_DUE_ERROR)
 	    {
 	      if (er_errid () == ER_INTERRUPTED)
@@ -4695,11 +4697,10 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
 	      er_clear ();
 	      continue;
 	    }
+#endif // SERVER_MODE
 
-#if defined (SERVER_MODE)
 	  // it is neither expected nor acceptable.
 	  assert (0);
-#endif // SERVER_MODE
 	}
     }
 

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -4442,6 +4442,8 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
   LOG_TDES *tdes;
   int lock_ret;
   BTID *list_btid = NULL;
+  int old_wait_msec;
+  bool old_check_intr;
 
   func_index_info.expr = NULL;
 
@@ -4662,8 +4664,8 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
   // We are going to do best to avoid lock promotion errors such as timeout and deadlocked.
 
   // never give up
-  int old_wait_msec = xlogtb_reset_wait_msecs (thread_p, LK_INFINITE_WAIT);
-  bool old_check_intr = logtb_set_check_interrupt (thread_p, false);
+  old_wait_msec = xlogtb_reset_wait_msecs (thread_p, LK_INFINITE_WAIT);
+  old_check_intr = logtb_set_check_interrupt (thread_p, false);
   for (cur_class = 0; cur_class < n_classes; cur_class++)
     {
       /* Promote the lock to SCH_M_LOCK */

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -7703,6 +7703,11 @@ void
 lock_force_thread_timeout_lock (THREAD_ENTRY * thrd)
 {
 #if defined (SERVER_MODE)
+  if (!logtb_get_check_interrupt (thrd))
+    {
+      // don't interrupt
+      return;
+    }
   thread_lock_entry (thrd);
   if (LK_IS_LOCKWAIT_THREAD (thrd))
     {

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -7703,11 +7703,6 @@ void
 lock_force_thread_timeout_lock (THREAD_ENTRY * thrd)
 {
 #if defined (SERVER_MODE)
-  if (!logtb_get_check_interrupt (thrd))
-    {
-      // don't interrupt
-      return;
-    }
   thread_lock_entry (thrd);
   if (LK_IS_LOCKWAIT_THREAD (thrd))
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23418

On shutdown, lock upgrade is abandoned and index creation is aborted/rollbacked. Concurrent transactions that accessed the index may access again to rollback their own work.

Fix by forcing lock upgrade even if shutdown forces timeout.