### PR TITLE
[CBRD-23412] Fix error in case of not null attribute

### DIFF
--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -214,7 +214,9 @@ namespace cubload
   {
     if (attr->get_repr ().is_notnull)
       {
-	return mismatch (str, attr, val);
+	int error_code = ER_OBJ_ATTRIBUTE_CANT_BE_NULL;
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 1, attr->get_name ());
+	return error_code;
       }
     else
       {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23412

In case of a not null attribute defined in the schema, the correct error which needs to be thrown if we load a null value should be `ER_OBJ_ATTRIBUTE_CANT_BE_NULL`. This PR will fix it.