### PR TITLE
[CBRD-23421] replace slotted page saving hash table

### DIFF
--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -386,6 +386,9 @@ class lf_hash_table_cpp
     T *freelist_claim (lf_tran_entry *t_entry);
     void freelist_retire (lf_tran_entry *t_entry, T *&t);
 
+    void start_tran (lf_tran_entry *t_entry);
+    void end_tran (lf_tran_entry *t_entry);
+
     size_t get_size () const;
 
     lf_hash_table &get_hash_table ();
@@ -573,6 +576,20 @@ lf_hash_table_cpp<Key, T>::freelist_retire (lf_tran_entry *t_entry, T *&t)
 {
   lf_freelist_retire (t_entry, &m_freelist, t);
   t = NULL;
+}
+
+template <class Key, class T>
+void
+lf_hash_table_cpp<Key, T>::start_tran (lf_tran_entry *t_entry)
+{
+  lf_tran_start_with_mb (t_entry, false);
+}
+
+template <class Key, class T>
+void
+lf_hash_table_cpp<Key, T>::end_tran (lf_tran_entry *t_entry)
+{
+  lf_tran_end_with_mb (t_entry);
 }
 
 template <class Key, class T>

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -65,6 +65,9 @@ namespace lockfree
       T *freelist_claim (tran::index tran_index);
       void freelist_retire (tran::index tran_index, T *&entry);
 
+      void start_tran (tran::index tran_index);
+      void end_tran (tran::index tran_index);
+
       template <typename D>
       void dump_stats (std::ostream &os) const;
       void activate_stats ();
@@ -550,6 +553,20 @@ namespace lockfree
   hashmap<Key, T>::freelist_retire (tran::index tran_index, T *&entry)
   {
     return freelist_retire (get_tran_descriptor (tran_index), entry);
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::start_tran (tran::index tran_index)
+  {
+    get_tran_descriptor (tran_index).start_tran ();
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::end_tran (tran::index tran_index)
+  {
+    get_tran_descriptor (tran_index).end_tran ();
   }
 
   template <class Key, class T>

--- a/src/base/lockfree_transaction_system.cpp
+++ b/src/base/lockfree_transaction_system.cpp
@@ -29,6 +29,7 @@ namespace lockfree
       : m_max_tran_per_table (max_tran_count)
       , m_tran_idx_map ()
     {
+      assert (m_max_tran_per_table > 0);
       m_tran_idx_map.init (bitmap::chunking_style::ONE_CHUNK, static_cast<int> (max_tran_count),
 			   bitmap::FULL_USAGE_RATIO);
     }

--- a/src/storage/slotted_page.h
+++ b/src/storage/slotted_page.h
@@ -90,7 +90,7 @@ struct spage_slot
   unsigned int record_type:4;	/* Record type (REC_HOME, REC_NEWHOME, ...) described by slot. */
 };
 
-extern int spage_boot (THREAD_ENTRY * thread_p);
+extern void spage_boot (THREAD_ENTRY * thread_p);
 extern void spage_finalize (THREAD_ENTRY * thread_p);
 extern void spage_free_saved_spaces (THREAD_ENTRY * thread_p, void *first_save_entry);
 extern int spage_slot_size (void);

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -63,6 +63,9 @@ namespace cubthread
       T *freelist_claim (cubthread::entry *thread_p);
       void freelist_retire (cubthread::entry *thread_p, T *&t);
 
+      void start_tran (cubthread::entry *thread_p);
+      void end_tran (cubthread::entry *thread_p);
+
       size_t get_size () const;
 
     private:
@@ -158,7 +161,7 @@ namespace cubthread
   m_old_hash.f_ (get_tran_entry (tp_), __VA_ARGS__) : \
   m_new_hash.f_ ((tp_)->get_lf_tran_index (), __VA_ARGS__)
 #define lockfree_hashmap_forward_func_noarg(f_, tp_) \
-  is_old_type (tp_) ? \
+  is_old_type () ? \
   m_old_hash.f_ (get_tran_entry (tp_)) : \
   m_new_hash.f_ ((tp_)->get_lf_tran_index ())
 
@@ -249,6 +252,20 @@ namespace cubthread
   lockfree_hashmap<Key, T>::freelist_retire (cubthread::entry *thread_p, T *&t)
   {
     lockfree_hashmap_forward_func (freelist_retire, thread_p, t);
+  }
+
+  template <class Key, class T>
+  void
+  lockfree_hashmap<Key, T>::start_tran (cubthread::entry *thread_p)
+  {
+    lockfree_hashmap_forward_func_noarg (start_tran, thread_p);
+  }
+
+  template <class Key, class T>
+  void
+  lockfree_hashmap<Key, T>::end_tran (cubthread::entry *thread_p)
+  {
+    lockfree_hashmap_forward_func_noarg (end_tran, thread_p);
   }
 
   template <class Key, class T>

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -166,6 +166,11 @@ namespace cubthread
   void
   lockfree_hashmap<Key, T>::destroy ()
   {
+    if (m_type == UNKNOWN)
+      {
+	// was not initialized
+	return;
+      }
     if (is_old_type ())
       {
 	m_old_hash.destroy ();

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -140,7 +140,7 @@ namespace cubthread
 					 int freelist_block_size, lf_entry_descriptor &edesc, int entry_idx)
   {
     m_type = OLD;
-    m_old_hash.init (transys, hash_size, freelist_block_count, freelist_block_size);
+    m_old_hash.init (transys, hash_size, freelist_block_count, freelist_block_size, edesc);
     m_entry_idx = entry_idx;
   }
 

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -111,7 +111,12 @@ namespace cubthread
   void
   manager::init_lockfree_system ()
   {
-    m_lf_tran_sys = new lockfree::tran::system (m_max_threads);
+#if defined (SERVER_MODE)
+    // threads + main
+    m_lf_tran_sys = new lockfree::tran::system (m_max_threads + 1);
+#else // !SERVER_MODE = SA_MODE
+    m_lf_tran_sys = new lockfree::tran::system (1);   // a single thread = main
+#endif // !SERVER_MODE = SA_MODE
   }
 
   template<typename Res>
@@ -551,6 +556,7 @@ namespace cubthread
     if (with_lock_free)
       {
 	Main_entry_p->request_lock_free_transactions ();
+	Main_entry_p->assign_lf_tran_index (Manager->get_lockfree_transys ().assign_index ());
       }
 
     Manager->init_entries (with_lock_free);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2347,11 +2347,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 	}
     }
 
-  error_code = spage_boot (thread_p);
-  if (error_code != NO_ERROR)
-    {
-      goto error;
-    }
+  spage_boot (thread_p);
   error_code = heap_manager_initialize ();
   if (error_code != NO_ERROR)
     {
@@ -4721,11 +4717,7 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
 
   assert (client_credential != NULL);
 
-  error_code = spage_boot (thread_p);
-  if (error_code != NO_ERROR)
-    {
-      goto error;
-    }
+  spage_boot (thread_p);
   error_code = heap_manager_initialize ();
   if (error_code != NO_ERROR)
     {
@@ -5279,11 +5271,7 @@ xboot_emergency_patch (const char *db_name, bool recreate_log, DKNPAGES log_npag
   /* Initialize the transaction table */
   logtb_define_trantable (thread_p, -1, -1);
 
-  error_code = spage_boot (thread_p);
-  if (error_code != NO_ERROR)
-    {
-      goto error_exit;
-    }
+  spage_boot (thread_p);
   error_code = heap_manager_initialize ();
   if (error_code != NO_ERROR)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23421

- replace spage_saving_freelist/spage_saving_ht with spage_Saving_hashmap
- remove return error code from spage_boot
- fix cubthread::lockfree_hashmap::destroy uninitialized & cubthread::lockfree_hashmap::init_as_old
- add start_tran/end_tran functions to all hashmaps
- add one more transaction to thread manager's lock-free transaction system to account for main thread