### PR TITLE
[CBRD-23424] stop HA delay info daemon before vacuum master

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2933,6 +2933,9 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
 
   (void) boot_remove_all_temp_volumes (thread_p, REMOVE_TEMP_VOL_DEFAULT_ACTION);
 
+  // ha delays are registered and logged, and must be stopped before vacuum master
+  log_stop_ha_delay_registration ();
+
   // only after all logging is finished can this vacuum master be stopped; boot_remove_all_temp_volumes may add a final
   // log entry
   // hopefully, nothing else follows

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9953,7 +9953,7 @@ static void
 log_daemons_destroy ()
 {
   cubthread::get_manager ()->destroy_daemon (log_Remove_log_archive_daemon);
-  cubthread::get_manager ()->destroy_daemon (log_Checkpoint_daemon);)
+  cubthread::get_manager ()->destroy_daemon (log_Checkpoint_daemon);
   cubthread::get_manager ()->destroy_daemon (log_Check_ha_delay_info_daemon);
   cubthread::get_manager ()->destroy_daemon (log_Clock_daemon);
   cubthread::get_manager ()->destroy_daemon (log_Flush_daemon);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1786,6 +1786,12 @@ log_final (THREAD_ENTRY * thread_p)
   LOG_CS_EXIT (thread_p);
 }
 
+void
+log_stop_ha_delay_registration ()
+{
+  cubthread::get_manager ()->destroy_daemon (log_Check_ha_delay_info_daemon);
+}
+
 /*
  * log_restart_emergency - Emergency restart of log manager
  *
@@ -9947,7 +9953,7 @@ static void
 log_daemons_destroy ()
 {
   cubthread::get_manager ()->destroy_daemon (log_Remove_log_archive_daemon);
-  cubthread::get_manager ()->destroy_daemon (log_Checkpoint_daemon);
+  cubthread::get_manager ()->destroy_daemon (log_Checkpoint_daemon);)
   cubthread::get_manager ()->destroy_daemon (log_Check_ha_delay_info_daemon);
   cubthread::get_manager ()->destroy_daemon (log_Clock_daemon);
   cubthread::get_manager ()->destroy_daemon (log_Flush_daemon);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1789,7 +1789,9 @@ log_final (THREAD_ENTRY * thread_p)
 void
 log_stop_ha_delay_registration ()
 {
+#if defined (SERVER_MODE)
   cubthread::get_manager ()->destroy_daemon (log_Check_ha_delay_info_daemon);
+#endif // SERVER_MODE
 }
 
 /*

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -78,6 +78,7 @@ extern int log_update_compatibility_and_release (THREAD_ENTRY * thread_p, float 
 #endif
 extern void log_abort_all_active_transaction (THREAD_ENTRY * thread_p);
 extern void log_final (THREAD_ENTRY * thread_p);
+extern void log_stop_ha_delay_registration ();
 extern void log_restart_emergency (THREAD_ENTRY * thread_p, const char *db_fullname, const char *logpath,
 				   const char *prefix_logname);
 extern void log_append_undoredo_data (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DATA_ADDR * addr,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23424

HA delay info daemon adds log entries and must be stopped before vacuum master on shutdown.

On failed boot, enforcing this order is not necessary because the daemon does nothing.