### PR TITLE
[CBRD-23421] replace xcache/filter pred hash tables

### DIFF
--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -413,6 +413,7 @@ class lf_hash_table_cpp<Key, T>::iterator
     ~iterator ();
 
     T *iterate ();
+    void restart ();
 
   private:
     lf_hash_table_iterator m_iter;
@@ -653,6 +654,17 @@ T *
 lf_hash_table_cpp<Key, T>::iterator::iterate ()
 {
   return static_cast<T *> (lf_hash_iterate (&m_iter));
+}
+
+template <class Key, class T>
+void
+lf_hash_table_cpp<Key, T>::iterator::restart ()
+{
+  if (m_iter.tran_entry->transaction_id != LF_NULL_TRANSACTION_ID)
+    {
+      lf_tran_end_with_mb (m_iter.tran_entry);
+    }
+  m_crt_val = NULL;
 }
 
 // *INDENT-ON*

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -85,6 +85,9 @@ namespace lockfree
 	T m_entry;
 	lf_entry_descriptor *m_edesc;
 
+	freelist_node_data () = default;
+	~freelist_node_data () = default;
+
 	void on_reclaim ()
 	{
 	  (void) m_edesc->f_uninit (&m_entry);

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -170,6 +170,8 @@ namespace lockfree
       ~iterator () = default;
 
       T *iterate ();
+      void restart ();
+
       iterator &operator= (iterator &&o);
 
     private:
@@ -1365,6 +1367,17 @@ namespace lockfree
 
     /* we have a valid entry */
     return m_curr;
+  }
+
+  template <class Key, class T>
+  void
+  hashmap<Key, T>::iterator::restart ()
+  {
+    if (m_tdes->is_tran_started ())
+      {
+	m_tdes->end_tran();
+      }
+    m_curr = NULL;
   }
 
   template <class Key, class T>

--- a/src/query/filter_pred_cache.c
+++ b/src/query/filter_pred_cache.c
@@ -51,6 +51,11 @@ struct fpcache_ent
 
   PRED_EXPR_WITH_CONTEXT **clone_stack;
   INT32 clone_stack_head;
+
+  // *INDENT-OFF*
+  fpcache_ent ();
+  ~fpcache_ent ();
+  // *INDENT-ON*
 };
 
 #define FPCACHE_PTR_TO_KEY(ptr) ((BTID *) ptr)
@@ -219,6 +224,18 @@ fpcache_finalize (THREAD_ENTRY * thread_p)
 
   fpcache_Enabled = false;
 }
+
+// *INDENT-OFF*
+fpcache_ent::fpcache_ent ()
+{
+  pthread_mutex_init (&mutex, NULL);
+}
+
+fpcache_ent::~fpcache_ent ()
+{
+  pthread_mutex_destroy (&mutex);
+}
+// *INDENT-ON*
 
 /*
  * fpcache_entry_alloc () - Allocate a filter predicate cache entry.

--- a/src/query/filter_pred_cache.c
+++ b/src/query/filter_pred_cache.c
@@ -486,6 +486,11 @@ fpcache_remove_by_class (THREAD_ENTRY * thread_p, const OID * class_oid)
 {
 #define FPCACHE_DELETE_BTIDS_SIZE 1024
 
+  if (!fpcache_Enabled)
+    {
+      return;
+    }
+
   // *INDENT-OFF*
   fpcache_hashmap_iterator iter { thread_p, fpcache_Hashmap };
   // *INDENT-ON*

--- a/src/query/filter_pred_cache.c
+++ b/src/query/filter_pred_cache.c
@@ -29,6 +29,7 @@
 #include "query_executor.h"
 #include "stream_to_xasl.h"
 #include "system_parameter.h"
+#include "thread_lockfree_hash_map.hpp"
 #include "thread_manager.hpp"	// for thread_get_thread_entry_info
 #include "xasl.h"
 #include "xasl_unpack_info.hpp"
@@ -55,8 +56,14 @@ struct fpcache_ent
 #define FPCACHE_PTR_TO_KEY(ptr) ((BTID *) ptr)
 #define FPCACHE_PTR_TO_ENTRY(ptr) ((FPCACHE_ENTRY *) ptr)
 
+// *INDENT-OFF*
+using fpcache_hashmap_type = cubthread::lockfree_hashmap<BTID, fpcache_ent>;
+using fpcache_hashmap_iterator = fpcache_hashmap_type::iterator;
+// *INDENT-ON*
+
 static bool fpcache_Enabled = false;
 static INT32 fpcache_Soft_capacity = 0;
+static fpcache_hashmap_type fpcache_Hashmap;
 static LF_HASH_TABLE fpcache_Ht = LF_HASH_TABLE_INITIALIZER;
 static LF_FREELIST fpcache_Ht_freelist = LF_FREELIST_INITIALIZER;
 /* TODO: Handle counter >= soft capacity. */
@@ -142,20 +149,10 @@ fpcache_initialize (THREAD_ENTRY * thread_p)
     }
 
   /* Initialize free list */
-  error_code =
-    lf_freelist_init (&fpcache_Ht_freelist, 1, fpcache_Soft_capacity, &fpcache_Entry_descriptor, &fpcache_Ts);
-  if (error_code != NO_ERROR)
-    {
-      return error_code;
-    }
-
-  /* Initialize hash table. */
-  error_code = lf_hash_init (&fpcache_Ht, &fpcache_Ht_freelist, fpcache_Soft_capacity, &fpcache_Entry_descriptor);
-  if (error_code != NO_ERROR)
-    {
-      lf_freelist_destroy (&fpcache_Ht_freelist);
-      return error_code;
-    }
+  const int freelist_block_count = 2;
+  const int freelist_block_size = fpcache_Soft_capacity / freelist_block_count;
+  fpcache_Hashmap.init (fpcache_Ts, THREAD_TS_FPCACHE, fpcache_Soft_capacity, freelist_block_size, freelist_block_count,
+			fpcache_Entry_descriptor);
   fpcache_Entry_counter = 0;
   fpcache_Clone_counter = 0;
 
@@ -209,8 +206,7 @@ fpcache_finalize (THREAD_ENTRY * thread_p)
       return;
     }
 
-  lf_freelist_destroy (&fpcache_Ht_freelist);
-  lf_hash_destroy (&fpcache_Ht);
+  fpcache_Hashmap.destroy ();
 
   /* Use global heap */
   save_heapid = db_change_private_heap (thread_p, 0);
@@ -344,7 +340,6 @@ fpcache_copy_key (void *src, void *dest)
 int
 fpcache_claim (THREAD_ENTRY * thread_p, BTID * btid, or_predicate * or_pred, pred_expr_with_context ** filter_pred)
 {
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_FPCACHE);
   FPCACHE_ENTRY *fpcache_entry = NULL;
   int error_code = NO_ERROR;
 
@@ -355,12 +350,7 @@ fpcache_claim (THREAD_ENTRY * thread_p, BTID * btid, or_predicate * or_pred, pre
       /* Try to find available filter predicate expression in cache. */
       ATOMIC_INC_64 (&fpcache_Stat_lookup, 1);
 
-      error_code = lf_hash_find (t_entry, &fpcache_Ht, btid, (void **) &fpcache_entry);
-      if (error_code != NO_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  return error_code;
-	}
+      fpcache_entry = fpcache_Hashmap.find (thread_p, *btid);
       if (fpcache_entry == NULL)
 	{
 	  /* Entry not found. */
@@ -418,21 +408,15 @@ fpcache_claim (THREAD_ENTRY * thread_p, BTID * btid, or_predicate * or_pred, pre
 int
 fpcache_retire (THREAD_ENTRY * thread_p, OID * class_oid, BTID * btid, pred_expr_with_context * filter_pred)
 {
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_FPCACHE);
   FPCACHE_ENTRY *fpcache_entry = NULL;
   int error_code = NO_ERROR;
-  int inserted = 0;
+  bool inserted = false;
 
   if (fpcache_Enabled)
     {
       /* Try to retire in cache entry. */
       ATOMIC_INC_64 (&fpcache_Stat_add, 1);
-      error_code = lf_hash_find_or_insert (t_entry, &fpcache_Ht, btid, (void **) &fpcache_entry, &inserted);
-      if (error_code != NO_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  return error_code;
-	}
+      inserted = fpcache_Hashmap.find_or_insert (thread_p, *btid, fpcache_entry);
       if (fpcache_entry != NULL)
 	{
 	  if (inserted)
@@ -502,8 +486,9 @@ fpcache_remove_by_class (THREAD_ENTRY * thread_p, const OID * class_oid)
 {
 #define FPCACHE_DELETE_BTIDS_SIZE 1024
 
-  LF_HASH_TABLE_ITERATOR iter;
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_FPCACHE);
+  // *INDENT-OFF*
+  fpcache_hashmap_iterator iter { thread_p, fpcache_Hashmap };
+  // *INDENT-ON*
   FPCACHE_ENTRY *fpcache_entry;
   int success = 0;
   BTID delete_btids[FPCACHE_DELETE_BTIDS_SIZE];
@@ -518,12 +503,12 @@ fpcache_remove_by_class (THREAD_ENTRY * thread_p, const OID * class_oid)
 
   while (!finished)
     {
-      lf_hash_create_iterator (&iter, t_entry, &fpcache_Ht);
+      iter.restart ();
 
       while (true)
 	{
 	  /* Start by iterating to next hash entry. */
-	  fpcache_entry = (FPCACHE_ENTRY *) lf_hash_iterate (&iter);
+	  fpcache_entry = iter.iterate ();
 
 	  if (fpcache_entry == NULL)
 	    {
@@ -545,7 +530,7 @@ fpcache_remove_by_class (THREAD_ENTRY * thread_p, const OID * class_oid)
 		  /* Free mutex. */
 		  pthread_mutex_unlock (&fpcache_entry->mutex);
 		  /* Full buffer. Interrupt iteration, delete entries collected so far and then start over. */
-		  lf_tran_end_with_mb (t_entry);
+		  fpcache_Hashmap.end_tran (thread_p);
 		  break;
 		}
 	    }
@@ -554,12 +539,7 @@ fpcache_remove_by_class (THREAD_ENTRY * thread_p, const OID * class_oid)
       /* Delete collected btids. */
       for (btid_index = 0; btid_index < n_delete_btids; btid_index++)
 	{
-	  if (lf_hash_delete (t_entry, &fpcache_Ht, &delete_btids[btid_index], &success) != NO_ERROR)
-	    {
-	      /* Unexpected. */
-	      assert (false);
-	    }
-	  else if (success)
+	  if (fpcache_Hashmap.erase (thread_p, delete_btids[btid_index]))
 	    {
 	      /* Successfully removed. */
 	      ATOMIC_INC_32 (&fpcache_Entry_counter, -1);
@@ -587,8 +567,9 @@ fpcache_remove_by_class (THREAD_ENTRY * thread_p, const OID * class_oid)
 void
 fpcache_dump (THREAD_ENTRY * thread_p, FILE * fp)
 {
-  LF_HASH_TABLE_ITERATOR iter;
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_FPCACHE);
+  // *INDENT-OFF*
+  fpcache_hashmap_iterator iter { thread_p, fpcache_Hashmap };
+  // *INDENT-ON*
   FPCACHE_ENTRY *fpcache_entry = NULL;
 
   assert (fp != NULL);
@@ -621,8 +602,7 @@ fpcache_dump (THREAD_ENTRY * thread_p, FILE * fp)
   fprintf (fp, "Cleaned entries:            %lld\n", (long long) ATOMIC_LOAD_64 (&fpcache_Stat_cleanup_entry));
 
   fprintf (fp, "\nEntries:\n");
-  lf_hash_create_iterator (&iter, t_entry, &fpcache_Ht);
-  while ((fpcache_entry = (FPCACHE_ENTRY *) lf_hash_iterate (&iter)) != NULL)
+  while ((fpcache_entry = iter.iterate ()) != NULL)
     {
       fprintf (fp, "\n  BTID = %d, %d|%d\n", fpcache_entry->btid.root_pageid, fpcache_entry->btid.vfid.volid,
 	       fpcache_entry->btid.vfid.fileid);
@@ -640,12 +620,12 @@ fpcache_dump (THREAD_ENTRY * thread_p, FILE * fp)
 static void
 fpcache_cleanup (THREAD_ENTRY * thread_p)
 {
-  LF_HASH_TABLE_ITERATOR iter;
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_FPCACHE);
+  // *INDENT-OFF*
+  fpcache_hashmap_iterator iter { thread_p, fpcache_Hashmap };
+  // *INDENT-ON*
   FPCACHE_ENTRY *fpcache_entry = NULL;
   FPCACHE_CLEANUP_CANDIDATE candidate;
   int candidate_index;
-  int success;
 
   /* We can allow only one cleanup process at a time. There is no point in duplicating this work. Therefore, anyone
    * trying to do the cleanup should first try to set fpcache_Cleanup_flag. */
@@ -679,9 +659,7 @@ fpcache_cleanup (THREAD_ENTRY * thread_p)
   fpcache_Cleanup_bh->element_count = 0;
 
   /* Collect candidates for cleanup. */
-  lf_hash_create_iterator (&iter, t_entry, &fpcache_Ht);
-
-  while ((fpcache_entry = (FPCACHE_ENTRY *) lf_hash_iterate (&iter)) != NULL)
+  while ((fpcache_entry = iter.iterate ()) != NULL)
     {
       candidate.btid = fpcache_entry->btid;
       candidate.time_last_used = fpcache_entry->time_last_used;
@@ -696,12 +674,7 @@ fpcache_cleanup (THREAD_ENTRY * thread_p)
       bh_element_at (fpcache_Cleanup_bh, candidate_index, &candidate);
 
       /* Try delete. */
-      if (lf_hash_delete (t_entry, &fpcache_Ht, &candidate.btid, &success) != NO_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  continue;
-	}
-      if (success)
+      if (fpcache_Hashmap.erase (thread_p, candidate.btid))
 	{
 	  ATOMIC_INC_64 (&fpcache_Stat_cleanup_entry, 1);
 	  ATOMIC_INC_64 (&fpcache_Stat_discard, 1);
@@ -762,8 +735,6 @@ fpcache_compare_cleanup_candidates (const void *left, const void *right, BH_CMP_
 void
 fpcache_drop_all (THREAD_ENTRY * thread_p)
 {
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_FPCACHE);
-
   /* Reset fpcache_Entry_counter and fpcache_Clone_counter.
    * NOTE: If entries/clones are created concurrently to this, the counters may become a little off. However, exact
    *       counters are not mandatory.
@@ -774,5 +745,5 @@ fpcache_drop_all (THREAD_ENTRY * thread_p)
   ATOMIC_INC_64 (&fpcache_Stat_clone_discard, fpcache_Clone_counter);
   fpcache_Clone_counter = 0;
 
-  lf_hash_clear (t_entry, &fpcache_Ht);
+  fpcache_Hashmap.clear (thread_p);
 }

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -36,6 +36,7 @@
 #include "statistics_sr.h"
 #include "stream_to_xasl.h"
 #include "thread_entry.hpp"
+#include "thread_lockfree_hash_map.hpp"
 #include "thread_manager.hpp"
 #include "xasl_unpack_info.hpp"
 
@@ -90,6 +91,11 @@ struct xcache_cleanup_candidate
   struct timeval time_last_used;
 };
 
+// *INDENT-OFF*
+using xcache_hashmap_type = cubthread::lockfree_hashmap<xasl_id, xasl_cache_ent>;
+using xcache_hashmap_iterator = xcache_hashmap_type::iterator;
+// *INDENT-ON*
+
 /* Structure to include all xasl cache global variable. It is easier to visualize the entire system when debugging. */
 typedef struct xcache XCACHE;
 struct xcache
@@ -98,8 +104,7 @@ struct xcache
   int soft_capacity;
   struct timeval last_cleaned_time;
   int time_threshold;
-  LF_HASH_TABLE ht;
-  LF_FREELIST freelist;
+  xcache_hashmap_type hashmap;
   volatile INT32 entry_count;
   bool logging_enabled;
   int max_clones;
@@ -108,31 +113,34 @@ struct xcache
   XCACHE_CLEANUP_CANDIDATE *cleanup_array;
 
   XCACHE_STATS stats;
+
+  // *INDENT-OFF*
+  xcache ()
+    : enabled (false)
+    , soft_capacity (0)
+    , last_cleaned_time { 0, 0 }
+    , time_threshold (360)
+    , hashmap {}
+    , entry_count (0)
+    , logging_enabled (false)
+    , max_clones (0)
+    , cleanup_flag (0)
+    , cleanup_bh (NULL)
+    , cleanup_array (NULL)
+    , stats XCACHE_STATS_INITIALIZER
+  {
+  }
+  // *INDENT-ON*
 };
 
-XCACHE xcache_Global = {
-  false,			/* enabled */
-  0,				/* soft_capacity */
-  {0, 0},			/* last_cleaned_time */
-  360,				/* time_threshold */
-  LF_HASH_TABLE_INITIALIZER,	/* ht */
-  LF_FREELIST_INITIALIZER,	/* freelist */
-  0,				/* entry_count */
-  false,			/* logging_enabled */
-  0,				/* max_clones */
-  0,				/* cleanup_flag */
-  NULL,				/* cleanup_bh */
-  NULL,				/* cleanup_array */
-  XCACHE_STATS_INITIALIZER
-};
+XCACHE xcache_Global;
 
 /* Create macro's for xcache_Global fields to access them as if they were global variables. */
 #define xcache_Enabled xcache_Global.enabled
 #define xcache_Soft_capacity xcache_Global.soft_capacity
 #define xcache_Time_threshold xcache_Global.time_threshold
 #define xcache_Last_cleaned_time xcache_Global.last_cleaned_time
-#define xcache_Ht xcache_Global.ht
-#define xcache_Ht_freelist xcache_Global.freelist
+#define xcache_Hashmap xcache_Global.hashmap
 #define xcache_Entry_count xcache_Global.entry_count
 #define xcache_Log xcache_Global.logging_enabled
 #define xcache_Max_clones xcache_Global.max_clones
@@ -288,22 +296,10 @@ xcache_initialize (THREAD_ENTRY * thread_p)
 
   xcache_Max_clones = prm_get_integer_value (PRM_ID_XASL_CACHE_MAX_CLONES);
 
-  error_code = lf_freelist_init (&xcache_Ht_freelist, 1, xcache_Soft_capacity, &xcache_Entry_descriptor, &xcache_Ts);
-  if (error_code != NO_ERROR)
-    {
-      xcache_log_error ("could not init freelist.\n");
-      ASSERT_ERROR ();
-      return error_code;
-    }
-
-  error_code = lf_hash_init (&xcache_Ht, &xcache_Ht_freelist, xcache_Soft_capacity, &xcache_Entry_descriptor);
-  if (error_code != NO_ERROR)
-    {
-      lf_freelist_destroy (&xcache_Ht_freelist);
-      xcache_log_error ("could not init hash table.\n");
-      ASSERT_ERROR ();
-      return error_code;
-    }
+  const int freelist_block_count = 2;
+  const int freelist_block_size = xcache_Soft_capacity / freelist_block_count;
+  xcache_Hashmap.init (xcache_Ts, THREAD_TS_XCACHE, xcache_Soft_capacity, freelist_block_size, freelist_block_count,
+		       xcache_Entry_descriptor);
 
   /* Use global heap */
   save_heapid = db_change_private_heap (thread_p, 0);
@@ -313,8 +309,7 @@ xcache_initialize (THREAD_ENTRY * thread_p)
   (void) db_change_private_heap (thread_p, save_heapid);
   if (xcache_Cleanup_bh == NULL)
     {
-      lf_freelist_destroy (&xcache_Ht_freelist);
-      lf_hash_destroy (&xcache_Ht);
+      xcache_Hashmap.destroy ();
       xcache_log_error ("could not init hash table.\n");
       ASSERT_ERROR_AND_SET (error_code);
       return error_code;
@@ -357,8 +352,7 @@ xcache_finalize (THREAD_ENTRY * thread_p)
   xcache_check_logging ();
   xcache_log ("finalize.\n");
 
-  lf_freelist_destroy (&xcache_Ht_freelist);
-  lf_hash_destroy (&xcache_Ht);
+  xcache_Hashmap.destroy ();
 
   /* Use global heap */
   save_heapid = db_change_private_heap (thread_p, 0);
@@ -772,7 +766,6 @@ xcache_find_sha1 (THREAD_ENTRY * thread_p, const SHA1Hash * sha1, const XASL_CAC
 {
   XASL_ID lookup_key;
   int error_code = NO_ERROR;
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_XCACHE);
 
   assert (xcache_entry != NULL && *xcache_entry == NULL);
 
@@ -789,16 +782,7 @@ xcache_find_sha1 (THREAD_ENTRY * thread_p, const SHA1Hash * sha1, const XASL_CAC
   XASL_ID_SET_NULL (&lookup_key);
   lookup_key.sha1 = *sha1;
 
-  error_code = lf_hash_find (t_entry, &xcache_Ht, &lookup_key, (void **) xcache_entry);
-  if (error_code != NO_ERROR)
-    {
-      ASSERT_ERROR ();
-      xcache_log_error ("error finding cache entry: \n"
-			XCACHE_LOG_SHA1_TEXT XCACHE_LOG_ERROR_TEXT XCACHE_LOG_TRAN_TEXT,
-			XCACHE_LOG_SHA1_ARGS (&lookup_key.sha1), error_code, XCACHE_LOG_TRAN_ARGS (thread_p));
-
-      return error_code;
-    }
+  *xcache_entry = xcache_Hashmap.find (thread_p, lookup_key);
   if (*xcache_entry == NULL)
     {
       /* No match! */
@@ -812,7 +796,7 @@ xcache_find_sha1 (THREAD_ENTRY * thread_p, const SHA1Hash * sha1, const XASL_CAC
     }
   /* Found a match. */
   /* We have incremented fix count, we don't need lf_tran anymore. */
-  lf_tran_end_with_mb (t_entry);
+  xcache_Hashmap.end_tran (thread_p);
 
   perfmon_inc_stat (thread_p, PSTAT_PC_NUM_HIT);
   XCACHE_STAT_INC (hits);
@@ -1072,9 +1056,7 @@ xcache_unfix (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry)
 {
   INT32 cache_flag = 0;
   INT32 new_cache_flag = 0;
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_XCACHE);
   int error_code = NO_ERROR;
-  int success = 0;
   struct timeval time_last_used;
 
   assert (xcache_entry != NULL);
@@ -1146,14 +1128,7 @@ xcache_unfix (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry)
 	  xcache_clone_decache (thread_p, &xcache_entry->cache_clones[--xcache_entry->n_cache_clones]);
 	}
 
-      error_code = lf_hash_delete (t_entry, &xcache_Ht, &xcache_entry->xasl_id, &success);
-      if (error_code != NO_ERROR)
-	{
-	  /* Errors are not expected. */
-	  assert (false);
-	  return;
-	}
-      if (success == 0)
+      if (!xcache_Hashmap.erase (thread_p, xcache_entry->xasl_id))
 	{
 	  /* Failure is not expected. */
 	  assert (false);
@@ -1230,7 +1205,7 @@ xcache_entry_mark_deleted (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_en
 /*
  * xcache_entry_set_request_recompile_flag () - Mark XASL cache entry as "request recompile".
  *
- * return	     : True if the flag was successfuly set (or cleared).
+ * return	     : True if the flag was successfully set (or cleared).
  * thread_p (in)     : Thread entry.
  * xcache_entry (in) : XASL cache entry.
  * set_flag (in)     : true if flag should be set, false if should be cleared
@@ -1346,8 +1321,7 @@ xcache_insert (THREAD_ENTRY * thread_p, const compile_context * context, XASL_ST
 	       XASL_CACHE_ENTRY ** xcache_entry)
 {
   int error_code = NO_ERROR;
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_XCACHE);
-  int inserted = 0;
+  bool inserted = false;
   XASL_ID xid;
   INT32 cache_flag;
   INT32 new_cache_flag;
@@ -1452,7 +1426,7 @@ xcache_insert (THREAD_ENTRY * thread_p, const compile_context * context, XASL_ST
   while (true)
     {
       /* Claim a new entry from freelist to initialize. */
-      *xcache_entry = (XASL_CACHE_ENTRY *) lf_freelist_claim (t_entry, &xcache_Ht_freelist);
+      *xcache_entry = xcache_Hashmap.freelist_claim (thread_p);
       if (*xcache_entry == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error_code);
@@ -1473,19 +1447,12 @@ xcache_insert (THREAD_ENTRY * thread_p, const compile_context * context, XASL_ST
       (*xcache_entry)->time_last_used = time_stored;
 
       /* Now that new entry is initialized, we can try to insert it. */
-      error_code = lf_hash_insert_given (t_entry, &xcache_Ht, &xid, (void **) xcache_entry, &inserted);
-      if (error_code != NO_ERROR)
-	{
-	  xcache_log_error ("error inserting new entry: \n",
-			    XCACHE_LOG_ENTRY_TEXT ("entry") XCACHE_LOG_ERROR_TEXT XCACHE_LOG_TRAN_TEXT,
-			    XCACHE_LOG_ENTRY_ARGS (*xcache_entry), XCACHE_LOG_TRAN_ARGS (thread_p), error_code);
-	  ASSERT_ERROR ();
-	  goto error;
-	}
+
+      inserted = xcache_Hashmap.insert_given (thread_p, xid, *xcache_entry);
       assert (*xcache_entry != NULL);
 
       /* We have incremented fix count, we don't need lf_tran anymore. */
-      lf_tran_end_with_mb (t_entry);
+      xcache_Hashmap.end_tran (thread_p);
 
       if (inserted)
 	{
@@ -1654,7 +1621,7 @@ error:
   ASSERT_ERROR ();
   if ((*xcache_entry) != NULL)
     {
-      (void) lf_freelist_retire (t_entry, &xcache_Ht_freelist, *xcache_entry);
+      xcache_Hashmap.freelist_retire (thread_p, *xcache_entry);
     }
   if (to_be_recompiled)
     {
@@ -1692,10 +1659,10 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
 			   const OID * arg)
 {
 #define XCACHE_DELETE_XIDS_SIZE 1024
-  LF_HASH_TABLE_ITERATOR iter;
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_XCACHE);
+  xcache_hashmap_iterator iter
+  {
+  thread_p, xcache_Hashmap};
   XASL_CACHE_ENTRY *xcache_entry = NULL;
-  int success;
   XASL_ID delete_xids[XCACHE_DELETE_XIDS_SIZE];
   int n_delete_xids = 0;
   int xid_index = 0;
@@ -1708,8 +1675,8 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
 
   while (!finished)
     {
-      /* Create iterator. */
-      lf_hash_create_iterator (&iter, t_entry, &xcache_Ht);
+      /* make sure to start from beginning */
+      iter.restart ();
 
       /* Iterate through hash, check entry OID's and if one matches the argument, mark the entry for delete and save
        * it in delete_xids buffer. We cannot delete them from hash while iterating, because the one lock-free
@@ -1717,7 +1684,7 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
        */
       while (true)
 	{
-	  xcache_entry = (XASL_CACHE_ENTRY *) lf_hash_iterate (&iter);
+	  xcache_entry = iter.iterate ();
 	  if (xcache_entry == NULL)
 	    {
 	      finished = true;
@@ -1745,7 +1712,7 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
 	  if (n_delete_xids == XCACHE_DELETE_XIDS_SIZE)
 	    {
 	      /* Full buffer. Interrupt iteration and we'll start over. */
-	      lf_tran_end_with_mb (t_entry);
+	      xcache_Hashmap.end_tran (thread_p);
 
 	      xcache_log ("xcache_remove_by_oid full buffer\n" XCACHE_LOG_TRAN_TEXT, XCACHE_LOG_TRAN_ARGS (thread_p));
 
@@ -1756,11 +1723,7 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
       /* Remove collected entries. */
       for (xid_index = 0; xid_index < n_delete_xids; xid_index++)
 	{
-	  if (lf_hash_delete (t_entry, &xcache_Ht, &delete_xids[xid_index], &success) != NO_ERROR)
-	    {
-	      assert (false);
-	    }
-	  if (success == 0)
+	  if (!xcache_Hashmap.erase (thread_p, delete_xids[xid_index]))
 	    {
 	      /* I don't think this is expected. */
 	      assert (false);
@@ -1841,8 +1804,7 @@ xcache_drop_all (THREAD_ENTRY * thread_p)
 void
 xcache_dump (THREAD_ENTRY * thread_p, FILE * fp)
 {
-  LF_HASH_TABLE_ITERATOR iter;
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_XCACHE);
+  xcache_hashmap_iterator iter = { thread_p, xcache_Hashmap };
   XASL_CACHE_ENTRY *xcache_entry = NULL;
   int oid_index;
   char *sql_id = NULL;
@@ -1878,8 +1840,7 @@ xcache_dump (THREAD_ENTRY * thread_p, FILE * fp)
   /* add overflow, RT checks. */
 
   fprintf (fp, "\nEntries:\n");
-  lf_hash_create_iterator (&iter, t_entry, &xcache_Ht);
-  while ((xcache_entry = (XASL_CACHE_ENTRY *) lf_hash_iterate (&iter)) != NULL)
+  while (xcache_entry = iter.iterate ())
     {
       fprintf (fp, "\n");
       fprintf (fp, "  XASL_ID = { \n");
@@ -2042,14 +2003,13 @@ xcache_retire_clone (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry, X
 static void
 xcache_cleanup (THREAD_ENTRY * thread_p)
 {
-  LF_HASH_TABLE_ITERATOR iter;
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_XCACHE);
+  xcache_hashmap_iterator iter = { thread_p, xcache_Hashmap };
   XASL_CACHE_ENTRY *xcache_entry = NULL;
   XCACHE_CLEANUP_CANDIDATE candidate;
   struct timeval current_time;
   int need_cleanup;
   int candidate_index;
-  int success, count;
+  int count;
   int cleanup_count;
   BINARY_HEAP *bh = NULL;
   int save_max_capacity = 0;
@@ -2129,9 +2089,7 @@ xcache_cleanup (THREAD_ENTRY * thread_p)
       bh->element_count = 0;
 
       /* Collect candidates for cleanup. */
-      lf_hash_create_iterator (&iter, t_entry, &xcache_Ht);
-
-      while ((xcache_entry = (XASL_CACHE_ENTRY *) lf_hash_iterate (&iter)) != NULL)
+      while ((xcache_entry = iter.iterate ()) != NULL)
 	{
 	  candidate.xid = xcache_entry->xasl_id;
 	  candidate.time_last_used = xcache_entry->time_last_used;
@@ -2149,12 +2107,11 @@ xcache_cleanup (THREAD_ENTRY * thread_p)
     }
   else
     {
-      count = 0;
       /* Collect candidates for cleanup. */
-      lf_hash_create_iterator (&iter, t_entry, &xcache_Ht);
+      count = 0;
       gettimeofday (&current_time, NULL);
 
-      while ((xcache_entry = (XASL_CACHE_ENTRY *) lf_hash_iterate (&iter)) != NULL && count < xcache_Soft_capacity)
+      while ((xcache_entry = iter.iterate ()) != NULL && count < xcache_Soft_capacity)
 	{
 	  candidate.xid = xcache_entry->xasl_id;
 	  candidate.time_last_used = xcache_entry->time_last_used;
@@ -2189,16 +2146,7 @@ xcache_cleanup (THREAD_ENTRY * thread_p)
       /* Try delete. Would be better to decache the clones here. For simplicity, since is not an usual case,
        * clone decache is postponed - is decached when retired list will be cleared.
        */
-      if (lf_hash_delete (t_entry, &xcache_Ht, &candidate.xid, &success) != NO_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  xcache_log_error ("failed hash delete: \n"
-			    XCACHE_LOG_XASL_ID_TEXT ("xasl id")
-			    XCACHE_LOG_TRAN_TEXT,
-			    XCACHE_LOG_XASL_ID_ARGS (&candidate.xid), XCACHE_LOG_TRAN_ARGS (thread_p));
-	  continue;
-	}
-      if (success)
+      if (xcache_Hashmap.erase (thread_p, candidate.xid))
 	{
 	  xcache_log ("cleanup: candidate was removed from hash"
 		      XCACHE_LOG_XASL_ID_TEXT ("xasl id") XCACHE_LOG_TRAN_TEXT,

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -1659,9 +1659,9 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
 			   const OID * arg)
 {
 #define XCACHE_DELETE_XIDS_SIZE 1024
-  xcache_hashmap_iterator iter
-  {
-  thread_p, xcache_Hashmap};
+  // *INDENT-OFF*
+  xcache_hashmap_iterator iter { thread_p, xcache_Hashmap };
+  // *INDENT-ON*
   XASL_CACHE_ENTRY *xcache_entry = NULL;
   XASL_ID delete_xids[XCACHE_DELETE_XIDS_SIZE];
   int n_delete_xids = 0;
@@ -1772,6 +1772,11 @@ xcache_entry_is_related_to_oid (XASL_CACHE_ENTRY * xcache_entry, const OID * rel
 void
 xcache_remove_by_oid (THREAD_ENTRY * thread_p, const OID * oid)
 {
+  if (!xcache_Enabled)
+    {
+      return;
+    }
+
   xcache_check_logging ();
 
   xcache_log ("remove all entries: \n"
@@ -1788,6 +1793,11 @@ xcache_remove_by_oid (THREAD_ENTRY * thread_p, const OID * oid)
 void
 xcache_drop_all (THREAD_ENTRY * thread_p)
 {
+  if (!xcache_Enabled)
+    {
+      return;
+    }
+
   xcache_check_logging ();
 
   xcache_log ("drop all queries \n" XCACHE_LOG_TRAN_TEXT, XCACHE_LOG_TRAN_ARGS (thread_p));
@@ -1804,7 +1814,9 @@ xcache_drop_all (THREAD_ENTRY * thread_p)
 void
 xcache_dump (THREAD_ENTRY * thread_p, FILE * fp)
 {
-  xcache_hashmap_iterator iter = { thread_p, xcache_Hashmap };
+  // *INDENT-OFF*
+  xcache_hashmap_iterator iter { thread_p, xcache_Hashmap };
+  // *INDENT-ON*
   XASL_CACHE_ENTRY *xcache_entry = NULL;
   int oid_index;
   char *sql_id = NULL;
@@ -2003,7 +2015,9 @@ xcache_retire_clone (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry, X
 static void
 xcache_cleanup (THREAD_ENTRY * thread_p)
 {
-  xcache_hashmap_iterator iter = { thread_p, xcache_Hashmap };
+  // *INDENT-OFF*
+  xcache_hashmap_iterator iter { thread_p, xcache_Hashmap };
+  // *INDENT-ON*
   XASL_CACHE_ENTRY *xcache_entry = NULL;
   XCACHE_CLEANUP_CANDIDATE candidate;
   struct timeval current_time;

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -366,6 +366,30 @@ xcache_finalize (THREAD_ENTRY * thread_p)
   xcache_Enabled = false;
 }
 
+// *INDENT-OFF*
+xasl_cache_ent::xasl_cache_ent ()
+{
+  pthread_mutex_init (&cache_clones_mutex, NULL);
+  init_clone_cache ();
+}
+
+xasl_cache_ent::~xasl_cache_ent ()
+{
+  assert (cache_clones == NULL || cache_clones == &one_clone);
+  pthread_mutex_destroy (&cache_clones_mutex);
+}
+
+void
+xasl_cache_ent::init_clone_cache ()
+{
+  cache_clones = &one_clone;
+  one_clone.xasl = NULL;
+  one_clone.xasl_buf = NULL;
+  cache_clones_capacity = 1;
+  n_cache_clones = 0;
+}
+// *INDENT-ON*
+
 /*
  * xcache_entry_alloc () - Allocate an XASL cache entry.
  *
@@ -379,11 +403,7 @@ xcache_entry_alloc (void)
     {
       return NULL;
     }
-  xcache_entry->cache_clones = &xcache_entry->one_clone;
-  xcache_entry->one_clone.xasl = NULL;
-  xcache_entry->one_clone.xasl_buf = NULL;
-  xcache_entry->cache_clones_capacity = 1;
-  xcache_entry->n_cache_clones = 0;
+  xcache_entry->init_clone_cache ();
   pthread_mutex_init (&xcache_entry->cache_clones_mutex, NULL);
   return xcache_entry;
 }

--- a/src/query/xasl_cache.h
+++ b/src/query/xasl_cache.h
@@ -126,6 +126,13 @@ struct xasl_cache_ent
   INT64 time_last_rt_check;
 
   bool initialized;
+
+  // *INDENT-OFF*
+  xasl_cache_ent ();
+  ~xasl_cache_ent ();
+
+  void init_clone_cache ();
+  // *INDENT-ON*
 };
 
 enum xasl_cache_search_mode

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -95,6 +95,8 @@ namespace cubthread
 
       T *iterate ();
 
+      void restart ();
+
     private:
       // old stuff
       lockfree_hashmap &m_map;
@@ -245,7 +247,7 @@ namespace cubthread
   T *
   lockfree_hashmap<Key, T>::freelist_claim (cubthread::entry *thread_p)
   {
-    lockfree_hashmap_forward_func_noarg (freelist_claim, thread_p);
+    return lockfree_hashmap_forward_func_noarg (freelist_claim, thread_p);
   }
 
   template <class Key, class T>
@@ -331,6 +333,20 @@ namespace cubthread
     else
       {
 	return m_new_iter.iterate ();
+      }
+  }
+
+  template <class Key, class T>
+  void
+  lockfree_hashmap<Key, T>::iterator::restart ()
+  {
+    if (m_map.is_old_type ())
+      {
+	m_old_iter.restart ();
+      }
+    else
+      {
+	m_new_iter.restart ();
       }
   }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23421

- replace xasl cache and filter predicate hash tables
- add iterator::restart () methods
- non-trivial f_alloc/f_dealloc implementations included into default xasl_cache_ent/fpcache_ent constructors and destructors\*
- fix cubthread::lockfree_hashmap::freelist_claim
- add default xcache constructor
- check if cache is enabled before calling xcache_remove_by_oid, xcache_drop_all, fpcache_remove_by_class

\* _already merged replacements will be revised to respect this condition_