### PR TITLE
[CBRD-23421] construct/destruct lk_res and spage_save_head

### DIFF
--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -107,6 +107,11 @@ struct spage_save_head
   VPID vpid;			/* Page and volume where the space is saved */
   int total_saved;		/* Total saved space by all transactions */
   SPAGE_SAVE_ENTRY *first;	/* First saving space entry */
+
+  // *INDENT-OFF*
+  spage_save_head ();
+  ~spage_save_head ();
+  // *INDENT-ON*
 };
 
 #define SPAGE_OVERFLOW(offset) ((int) (offset) > SPAGE_DB_PAGESIZE)
@@ -227,6 +232,18 @@ static int spage_put_helper (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID s
 static void spage_add_contiguous_free_space (PAGE_PTR pgptr, int space);
 static void spage_reduce_contiguous_free_space (PAGE_PTR pgptr, int space);
 static INLINE void spage_verify_header (PAGE_PTR page_p) __attribute__ ((ALWAYS_INLINE));
+
+// *INDENT-OFF*
+spage_save_head::spage_save_head ()
+{
+  pthread_mutex_init (&mutex, NULL);
+}
+
+spage_save_head::~spage_save_head ()
+{
+  pthread_mutex_destroy (&mutex);
+}
+// *INDENT-ON*
 
 /*
  * spage_save_head_alloc () - callback for allocation of a SPAGE_SAVE_HEAD

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -710,6 +710,18 @@ lock_uninit_entry (void *entry)
   return NO_ERROR;
 }
 
+// *INDENT-OFF*
+lk_res::lk_res ()
+{
+  pthread_mutex_init (&res_mutex, NULL);
+}
+
+lk_res::~lk_res ()
+{
+  pthread_mutex_destroy (&res_mutex);
+}
+// *INDENT-ON*
+
 static void *
 lock_alloc_resource (void)
 {

--- a/src/transaction/lock_manager.h
+++ b/src/transaction/lock_manager.h
@@ -185,6 +185,11 @@ struct lk_res
   LK_RES *hash_next;		/* for hash chain */
   LK_RES *stack;		/* for freelist */
   UINT64 del_id;		/* delete transaction ID (for latch free) */
+
+  // *INDENT-OFF*
+  lk_res ();
+  ~lk_res ();
+  // *INDENT-ON*
 };
 
 #if defined(SERVER_MODE)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23421

Add constructor and destructor to properly initialize and destroy mutex when allocated and deallocated by lockfree::freelist.