### PR TITLE
[CBRD-23421] replace session hash table

### DIFF
--- a/src/session/session.c
+++ b/src/session/session.c
@@ -800,7 +800,6 @@ session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id)
   (void) session_state_uninit (session_p);
 
   // delete from hash
-  SESSION_ID key_id = id;
   if (!sessions.states_hashmap.erase_locked (thread_p, key_id, session_p))
     {
       /* we don't have clear operations on this hash table, this shouldn't happen */

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -141,18 +141,6 @@ struct session_state
   // *INDENT-ON*
 };
 
-// *INDENT-OFF*
-using session_hashmap_type = cubthread::lockfree_hashmap<SESSION_ID, session_state>;
-using session_hashmap_iterator = session_hashmap_type::iterator;
-// *INDENT-ON*
-
-typedef struct active_sessions
-{
-  session_hashmap_type states_hashmap;
-  SESSION_ID last_session_id;
-  int num_holdable_cursors;
-} ACTIVE_SESSIONS;
-
 /* session state manipulation functions */
 static void *session_state_alloc (void);
 static int session_state_free (void *st);
@@ -182,6 +170,18 @@ static LF_ENTRY_DESCRIPTOR session_state_Descriptor = {
   session_key_hash,
   session_key_increment
 };
+
+// *INDENT-OFF*
+using session_hashmap_type = cubthread::lockfree_hashmap<SESSION_ID, session_state>;
+using session_hashmap_iterator = session_hashmap_type::iterator;
+// *INDENT-ON*
+
+typedef struct active_sessions
+{
+  session_hashmap_type states_hashmap;
+  SESSION_ID last_session_id;
+  int num_holdable_cursors;
+} ACTIVE_SESSIONS;
 
 /* the active sessions storage */
 static ACTIVE_SESSIONS sessions = { {}, LF_HASH_TABLE_INITIALIZER, LF_FREELIST_INITIALIZER, 0, 0 };

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -68,18 +68,6 @@ static int rv;
 #define MAX_SESSION_VARIABLES_COUNT 20
 #define MAX_PREPARED_STATEMENTS_COUNT 20
 
-// *INDENT-OFF*
-using session_hashmap_type = cubthread::lockfree_hashmap<SESSION_ID, session_state>;
-using session_hashmap_iterator = session_hashmap_type::iterator;
-// *INDENT-ON*
-
-typedef struct active_sessions
-{
-  session_hashmap_type states_hashmap;
-  SESSION_ID last_session_id;
-  int num_holdable_cursors;
-} ACTIVE_SESSIONS;
-
 typedef struct session_info SESSION_INFO;
 struct session_info
 {
@@ -94,7 +82,6 @@ struct session_variable
   DB_VALUE *value;
   SESSION_VARIABLE *next;
 };
-
 
 typedef struct prepared_statement PREPARED_STATEMENT;
 struct prepared_statement
@@ -153,6 +140,18 @@ struct session_state
   ~session_state ();
   // *INDENT-ON*
 };
+
+// *INDENT-OFF*
+using session_hashmap_type = cubthread::lockfree_hashmap<SESSION_ID, session_state>;
+using session_hashmap_iterator = session_hashmap_type::iterator;
+// *INDENT-ON*
+
+typedef struct active_sessions
+{
+  session_hashmap_type states_hashmap;
+  SESSION_ID last_session_id;
+  int num_holdable_cursors;
+} ACTIVE_SESSIONS;
 
 /* session state manipulation functions */
 static void *session_state_alloc (void);

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -181,10 +181,19 @@ typedef struct active_sessions
   session_hashmap_type states_hashmap;
   SESSION_ID last_session_id;
   int num_holdable_cursors;
+
+  // *INDENT-OFF*
+  active_sessions ()
+    : states_hashmap {}
+    , last_session_id (0)
+    , num_holdable_cursors (0)
+  {
+  }
+  // *INDENT-ON*
 } ACTIVE_SESSIONS;
 
 /* the active sessions storage */
-static ACTIVE_SESSIONS sessions = { {}, LF_HASH_TABLE_INITIALIZER, LF_FREELIST_INITIALIZER, 0, 0 };
+static ACTIVE_SESSIONS sessions;
 
 static int session_remove_expired_sessions (THREAD_ENTRY * thread_p);
 

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -51,9 +51,9 @@
 #include "string_opfunc.h"
 #include "thread_daemon.hpp"
 #include "thread_entry_task.hpp"
+#include "thread_lockfree_hash_map.hpp"
 #include "thread_manager.hpp"
 #include "xasl_cache.h"
-
 
 #if !defined(SERVER_MODE)
 #define pthread_mutex_init(a, b)
@@ -68,10 +68,14 @@ static int rv;
 #define MAX_SESSION_VARIABLES_COUNT 20
 #define MAX_PREPARED_STATEMENTS_COUNT 20
 
+// *INDENT-OFF*
+using session_hashmap_type = cubthread::lockfree_hashmap<SESSION_ID, session_state>;
+using session_hashmap_iterator = session_hashmap_type::iterator;
+// *INDENT-ON*
+
 typedef struct active_sessions
 {
-  LF_HASH_TABLE sessions_table;
-  LF_FREELIST session_table_freelist;
+  session_hashmap_type states_hashmap;
   SESSION_ID last_session_id;
   int num_holdable_cursors;
 } ACTIVE_SESSIONS;
@@ -143,6 +147,11 @@ struct session_state
   int private_lru_index;
 
   load_session *load_session_p;
+
+  // *INDENT-OFF*
+  session_state ();
+  ~session_state ();
+  // *INDENT-ON*
 };
 
 /* session state manipulation functions */
@@ -176,7 +185,7 @@ static LF_ENTRY_DESCRIPTOR session_state_Descriptor = {
 };
 
 /* the active sessions storage */
-static ACTIVE_SESSIONS sessions = { LF_HASH_TABLE_INITIALIZER, LF_FREELIST_INITIALIZER, 0, 0 };
+static ACTIVE_SESSIONS sessions = { {}, LF_HASH_TABLE_INITIALIZER, LF_FREELIST_INITIALIZER, 0, 0 };
 
 static int session_remove_expired_sessions (THREAD_ENTRY * thread_p);
 
@@ -213,8 +222,17 @@ static cubthread::daemon *session_Control_daemon = NULL;
 
 static void session_control_daemon_init ();
 static void session_control_daemon_destroy ();
-// *INDENT-ON*
 
+session_state::session_state ()
+{
+  pthread_mutex_init (&mutex, NULL);
+}
+
+session_state::~session_state ()
+{
+  pthread_mutex_destroy (&mutex);
+}
+// *INDENT-ON*
 
 /*
  * session_state_alloc () - allocate a new session state
@@ -320,6 +338,7 @@ session_state_uninit (void *st)
       free_session_variable (vcurent);
       vcurent = vnext;
     }
+  session->session_variables = NULL;
 
   /* free session statements */
   pcurent = session->statements;
@@ -329,6 +348,8 @@ session_state_uninit (void *st)
       session_free_prepared_statement (pcurent);
       pcurent = pnext;
     }
+  session->statements = NULL;
+
   /* free holdable queries */
   qcurent = session->queries;
   while (qcurent)
@@ -340,6 +361,7 @@ session_state_uninit (void *st)
       qcurent = qnext;
       cnt++;
     }
+  session->queries = NULL;
 
   if (session->session_parameters)
     {
@@ -554,17 +576,14 @@ session_control_daemon_destroy ()
 
 /*
  * session_states_init () - Initialize session states area
- *   return: NO_ERROR or error code
  *
  * Note: Creates and initializes a main memory hash table that will be
  * used by session states operations. This routine should only be
  * called once during server boot.
  */
-int
+void
 session_states_init (THREAD_ENTRY * thread_p)
 {
-  int ret;
-
   sessions.last_session_id = 0;
   sessions.num_holdable_cursors = 0;
 
@@ -572,28 +591,11 @@ session_states_init (THREAD_ENTRY * thread_p)
   er_log_debug (ARG_FILE_LINE, "creating session states table\n");
 #endif /* SESSION_DEBUG */
 
-  /* initialize freelist */
-  ret = lf_freelist_init (&sessions.session_table_freelist, 1, 100, &session_state_Descriptor, &sessions_Ts);
-  if (ret != NO_ERROR)
-    {
-      return ret;
-    }
-
-  /* initialize hash table */
-  ret =
-    lf_hash_init (&sessions.sessions_table, &sessions.session_table_freelist, SESSIONS_HASH_SIZE,
-		  &session_state_Descriptor);
-  if (ret != NO_ERROR)
-    {
-      return ret;
-    }
+  sessions.states_hashmap.init (sessions_Ts, THREAD_TS_SESSIONS, SESSIONS_HASH_SIZE, 2, 50, session_state_Descriptor);
 
 #if defined (SERVER_MODE)
   session_control_daemon_init ();
 #endif /* SERVER_MODE */
-
-  /* all ok */
-  return NO_ERROR;
 }
 
 /*
@@ -622,8 +624,7 @@ session_states_finalize (THREAD_ENTRY * thread_p)
 #endif /* SESSION_DEBUG */
 
   /* destroy hash and freelist */
-  lf_hash_destroy (&sessions.sessions_table);
-  lf_freelist_destroy (&sessions.session_table_freelist);
+  sessions.states_hashmap.destroy ();
 }
 
 /*
@@ -638,10 +639,8 @@ session_states_finalize (THREAD_ENTRY * thread_p)
 int
 session_state_create (THREAD_ENTRY * thread_p, SESSION_ID * id)
 {
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_SESSIONS);
   SESSION_STATE *session_p = NULL;
   SESSION_ID next_session_id;
-  int ret;
 
   assert (id != NULL);
 
@@ -654,12 +653,7 @@ session_state_create (THREAD_ENTRY * thread_p, SESSION_ID * id)
 
       assert (thread_p->conn_entry->session_p->id == old_id);
 
-      ret = lf_hash_find (t_entry, &sessions.sessions_table, (void *) &old_id, (void **) &session_p);
-      if (ret != NO_ERROR)
-	{
-	  assert (false);
-	  return ER_FAILED;
-	}
+      session_p = sessions.states_hashmap.find (thread_p, old_id);
       if (session_p == NULL)
 	{
 	  thread_p->conn_entry->session_id = DB_EMPTY_SESSION;
@@ -687,12 +681,8 @@ session_state_create (THREAD_ENTRY * thread_p, SESSION_ID * id)
   *id = next_session_id;
 
   /* insert new entry into hash table */
-  ret = lf_hash_insert (t_entry, &sessions.sessions_table, (void *) id, (void **) &session_p, NULL);
-  if (ret != NO_ERROR)
-    {
-      return ret;
-    }
-  else if (session_p == NULL)
+  (void) sessions.states_hashmap.insert (thread_p, *id, session_p);
+  if (session_p == NULL)
     {
       /* should not happen */
       assert (false);
@@ -728,13 +718,12 @@ session_state_create (THREAD_ENTRY * thread_p, SESSION_ID * id)
   er_log_debug (ARG_FILE_LINE, "adding session with id %u\n", *id);
   if (prm_get_bool_value (PRM_ID_ER_LOG_DEBUG) == true)
     {
-      LF_HASH_TABLE_ITERATOR it;
+      session_hashmap_iterator it = { thread_p, sessions.states_hashmap };
       SESSION_STATE *state;
 
       er_log_debug (ARG_FILE_LINE, "printing active sessions\n");
 
-      lf_hash_create_iterator (&it, t_entry, &sessions.sessions_table);
-      for (state = lf_hash_iterate (&it); state != NULL; state = lf_hash_iterate (&it))
+      for (state = it.iterate (); state != NULL; state = it.iterate ())
 	{
 	  er_log_debug (ARG_FILE_LINE, "session %u", state->id);
 	}
@@ -754,7 +743,6 @@ session_state_create (THREAD_ENTRY * thread_p, SESSION_ID * id)
 int
 session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id)
 {
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_SESSIONS);
   SESSION_STATE *session_p;
   int error = NO_ERROR, success = 0;
 
@@ -762,12 +750,8 @@ session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id)
   er_log_debug (ARG_FILE_LINE, "removing session %u", id);
 #endif /* SESSION_DEBUG */
 
-  error = lf_hash_find (t_entry, &sessions.sessions_table, (void *) &id, (void **) &session_p);
-  if (error != NO_ERROR)
-    {
-      return ER_FAILED;
-    }
-  else if (session_p == NULL)
+  session_p = sessions.states_hashmap.find (thread_p, (SESSION_ID) id);
+  if (session_p == NULL)
     {
       er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_SES_SESSION_EXPIRED, 0);
       return ER_SES_SESSION_EXPIRED;
@@ -803,21 +787,17 @@ session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id)
   assert (session_p->ref_count == 0);
 #endif
 
-  error = lf_hash_delete_already_locked (t_entry, &sessions.sessions_table, (void *) &id, session_p, &success);
-  if (error != NO_ERROR)
-    {
-      return ER_FAILED;
-    }
-  if (!success)
+  /* Destroy the session related resources like session parameters */
+  (void) session_state_uninit (session_p);
+
+  // delete from hash
+  if (!sessions.states_hashmap.erase_locked (thread_p, (SESSION_ID) id, session_p))
     {
       /* we don't have clear operations on this hash table, this shouldn't happen */
       pthread_mutex_unlock (&session_p->mutex);
       assert_release (false);
       return ER_FAILED;
     }
-
-  /* Destroy the session related resources like session parameters */
-  lf_tran_destroy_entry (t_entry);
 
   return error;
 }
@@ -831,7 +811,6 @@ session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id)
 int
 session_check_session (THREAD_ENTRY * thread_p, const SESSION_ID id)
 {
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_SESSIONS);
   SESSION_STATE *session_p = NULL;
   int error = NO_ERROR;
 
@@ -846,12 +825,7 @@ session_check_session (THREAD_ENTRY * thread_p, const SESSION_ID id)
 
       assert (thread_p->conn_entry->session_p->id == old_id);
 
-      error = lf_hash_find (t_entry, &sessions.sessions_table, (void *) &old_id, (void **) &session_p);
-      if (error != NO_ERROR)
-	{
-	  assert (false);
-	  return error;
-	}
+      session_p = sessions.states_hashmap.find (thread_p, old_id);
       if (session_p == NULL)
 	{
 	  /* the session in connection entry no longer exists... */
@@ -876,12 +850,8 @@ session_check_session (THREAD_ENTRY * thread_p, const SESSION_ID id)
     }
 #endif
 
-  error = lf_hash_find (t_entry, &sessions.sessions_table, (void *) &id, (void **) &session_p);
-  if (error != NO_ERROR)
-    {
-      return error;
-    }
-  else if (session_p == NULL)
+  session_p = sessions.states_hashmap.find (thread_p, (SESSION_ID) id);
+  if (session_p == NULL)
     {
       er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_SES_SESSION_EXPIRED, 0);
       return ER_SES_SESSION_EXPIRED;
@@ -915,8 +885,7 @@ static int
 session_remove_expired_sessions (THREAD_ENTRY * thread_p)
 {
 #define EXPIRED_SESSION_BUFFER_SIZE 1024
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_SESSIONS);
-  LF_HASH_TABLE_ITERATOR it;
+  session_hashmap_iterator it = { thread_p, sessions.states_hashmap };
   SESSION_STATE *state = NULL;
   int err = NO_ERROR, success = 0;
   bool is_expired = false;
@@ -935,10 +904,10 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
    */
   while (!finished)
     {
-      lf_hash_create_iterator (&it, t_entry, &sessions.sessions_table);
+      // todo: activate it.restart ();
       while (true)
 	{
-	  state = (SESSION_STATE *) lf_hash_iterate (&it);
+	  state = it.iterate ();
 	  if (state == NULL)
 	    {
 	      finished = true;
@@ -949,7 +918,7 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
 	  if (session_check_timeout (state, &active_sessions, &is_expired) != NO_ERROR)
 	    {
 	      pthread_mutex_unlock (&state->mutex);
-	      lf_tran_end_with_mb (t_entry);
+	      sessions.states_hashmap.end_tran (thread_p);
 	      err = ER_FAILED;
 	      goto exit_on_end;
 	    }
@@ -965,7 +934,7 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
 		  /* Free current entry mutex. */
 		  pthread_mutex_unlock (&state->mutex);
 		  /* End lock-free transaction started by iterator. */
-		  lf_tran_end_with_mb (t_entry);
+		  sessions.states_hashmap.end_tran (thread_p);
 		  break;
 		}
 	    }
@@ -974,14 +943,7 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
       /* Remove expired sessions. */
       for (sid_index = 0; sid_index < n_expired_sids; sid_index++)
 	{
-	  err = lf_hash_delete (t_entry, &sessions.sessions_table, &expired_sid_buffer[sid_index], &success);
-	  if (err != NO_ERROR)
-	    {
-	      /* I don't think we can expect errors. */
-	      assert (false);
-	      goto exit_on_end;
-	    }
-	  if (!success)
+	  if (!sessions.states_hashmap.erase (thread_p, expired_sid_buffer[sid_index]))
 	    {
 	      /* we don't have clear operations on this hash table, this shouldn't happen */
 	      assert_release (false);
@@ -2107,13 +2069,11 @@ session_get_variable (THREAD_ENTRY * thread_p, const DB_VALUE * name, DB_VALUE *
 int
 session_get_variable_no_copy (THREAD_ENTRY * thread_p, const DB_VALUE * name, DB_VALUE ** result)
 {
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_SESSIONS);
   SESSION_ID id;
   SESSION_STATE *state_p = NULL;
   size_t name_len;
   const char *name_str;
   SESSION_VARIABLE *var;
-  int ret;
 
 #if defined (SERVER_MODE)
   /* do not call this function in a multi-threaded context */
@@ -2133,12 +2093,8 @@ session_get_variable_no_copy (THREAD_ENTRY * thread_p, const DB_VALUE * name, DB
       return ER_FAILED;
     }
 
-  ret = lf_hash_find (t_entry, &sessions.sessions_table, (void *) &id, (void **) &state_p);
-  if (ret != NO_ERROR)
-    {
-      return ret;
-    }
-  else if (state_p == NULL)
+  state_p = sessions.states_hashmap.find (thread_p, id);
+  if (state_p == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SES_SESSION_EXPIRED, 0);
       return ER_FAILED;
@@ -2252,19 +2208,12 @@ session_get_exec_stats_and_clear (THREAD_ENTRY * thread_p, const DB_VALUE * name
 void
 session_states_dump (THREAD_ENTRY * thread_p)
 {
-  LF_HASH_TABLE_ITERATOR it;
+  session_hashmap_iterator it = { thread_p, sessions.states_hashmap };
   SESSION_STATE *state;
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_SESSIONS);
-  int session_count = 0;
+  size_t session_count = sessions.states_hashmap.get_element_count ();
+  fprintf (stdout, "\nSESSION COUNT = %zu\n", session_count);
 
-  session_count =
-    sessions.session_table_freelist.alloc_cnt - sessions.session_table_freelist.available_cnt -
-    sessions.session_table_freelist.retired_cnt;
-  session_count = MAX (session_count, 0);
-  fprintf (stdout, "\nSESSION COUNT = %d\n", session_count);
-
-  lf_hash_create_iterator (&it, t_entry, &sessions.sessions_table);
-  for (state = (SESSION_STATE *) lf_hash_iterate (&it); state != NULL; state = (SESSION_STATE *) lf_hash_iterate (&it))
+  for (state = it.iterate (); state != NULL; state = it.iterate ())
     {
       session_dump_session (state);
     }
@@ -2813,7 +2762,6 @@ session_get_session_state (THREAD_ENTRY * thread_p)
       return NULL;
     }
 #else
-  LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_SESSIONS);
   SESSION_ID id;
   int error = NO_ERROR;
   SESSION_STATE *state_p = NULL;
@@ -2824,13 +2772,8 @@ session_get_session_state (THREAD_ENTRY * thread_p)
       return NULL;
     }
 
-  error = lf_hash_find (t_entry, &sessions.sessions_table, (void *) &id, (void **) &state_p);
-  if (error != NO_ERROR)
-    {
-      assert (false);
-      return NULL;
-    }
-  else if (state_p == NULL)
+  state_p = sessions.states_hashmap.find (thread_p, id);
+  if (state_p == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SES_SESSION_EXPIRED, 0);
       return NULL;

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -758,7 +758,8 @@ session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id)
   er_log_debug (ARG_FILE_LINE, "removing session %u", id);
 #endif /* SESSION_DEBUG */
 
-  session_p = sessions.states_hashmap.find (thread_p, (SESSION_ID) id);
+  SESSION_ID key_id = id;
+  session_p = sessions.states_hashmap.find (thread_p, key_id);
   if (session_p == NULL)
     {
       er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_SES_SESSION_EXPIRED, 0);
@@ -799,7 +800,8 @@ session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id)
   (void) session_state_uninit (session_p);
 
   // delete from hash
-  if (!sessions.states_hashmap.erase_locked (thread_p, (SESSION_ID) id, session_p))
+  SESSION_ID key_id = id;
+  if (!sessions.states_hashmap.erase_locked (thread_p, key_id, session_p))
     {
       /* we don't have clear operations on this hash table, this shouldn't happen */
       pthread_mutex_unlock (&session_p->mutex);
@@ -858,7 +860,8 @@ session_check_session (THREAD_ENTRY * thread_p, const SESSION_ID id)
     }
 #endif
 
-  session_p = sessions.states_hashmap.find (thread_p, (SESSION_ID) id);
+  SESSION_ID key_id = id;
+  session_p = sessions.states_hashmap.find (thread_p, key_id);
   if (session_p == NULL)
     {
       er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_SES_SESSION_EXPIRED, 0);

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -914,7 +914,7 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
    */
   while (!finished)
     {
-      // todo: activate it.restart ();
+      it.restart ();
       while (true)
 	{
 	  state = it.iterate ();

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -38,7 +38,7 @@
 // forward definitions
 struct xasl_cache_ent;
 
-extern int session_states_init (THREAD_ENTRY * thread_p);
+extern void session_states_init (THREAD_ENTRY * thread_p);
 extern void session_states_finalize (THREAD_ENTRY * thread_p);
 extern int session_state_create (THREAD_ENTRY * thread_p, SESSION_ID * id);
 extern int session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1942,12 +1942,7 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
     }
 
   // sessions state is required to continue
-  error_code = session_states_init (thread_p);
-  if (error_code != NO_ERROR)
-    {
-      assert (false);
-      goto exit_on_error;
-    }
+  session_states_init (thread_p);
 
   /* print_version string */
 #if defined (NDEBUG)
@@ -2690,11 +2685,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       goto error;
     }
 
-  error_code = session_states_init (thread_p);
-  if (error_code != NO_ERROR)
-    {
-      goto error;
-    }
+  session_states_init (thread_p);
 
 #if defined (SERVER_MODE)
   if (prm_get_bool_value (PRM_ID_ACCESS_IP_CONTROL) == true && from_backup == false)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23421

- replace session hash table
- add active_sessions default constructor
- remove error return from session_states_init
- make session_state_uninit idempotent by setting all freed pointers to null
- session_state_destroy: uninit entry before erasing from hash (while still holding mutex) instead of using `lf_tran_destroy_entry` to free its entries. it is more clear and applicable with both transaction implementations.