### PR TITLE
[CBRD-23430] update prior_lsa_next_record_internal safe-guard

### DIFF
--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1370,7 +1370,7 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
       if (vacuum_get_log_blockid (log_Gl.hdr.mvcc_op_log_lsa.pageid) != vacuum_get_log_blockid (start_lsa.pageid))
 	{
 	  assert (vacuum_get_log_blockid (log_Gl.hdr.mvcc_op_log_lsa.pageid)
-		  == (vacuum_get_log_blockid (start_lsa.pageid) - 1));
+		  <= (vacuum_get_log_blockid (start_lsa.pageid) - 1));
 
 	  vacuum_produce_log_block_data (thread_p);
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23430

A very large log record that spans over multiple blocks breaks the safe-guard saying current blockid must be one less than the blockid of next log record. Update to consider this case.

```
  log_header = {
    prev_tranlsa = {
      pageid = 2081,
      offset = 4128
    },
    back_lsa = {
      pageid = 2081,
      offset = 4128
    },
    forw_lsa = {
      pageid = -1,
      offset = -1
    },
    trid = 24,
    type = LOG_UNDO_DATA
  },
  start_lsa = {
    pageid = 3709,
    offset = 2504
  },
```
