### PR TITLE
[CBRD-22741] remove unstable data flush safe-guard

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -3456,17 +3456,6 @@ end:
 	  {
 	    return;
 	  }
-	if (lru_list->count_vict_cand > 0)
-	  {
-	    if (pgbuf_is_any_thread_waiting_for_direct_victim () == false)
-	      {
-		/* we had direct victim waiters at the start of check loop; now, all waiters got BCB from the direct
-		 * flush queue */
-		return;
-	      }
-	    /* should have found victim candidate */
-	    assert (false);
-	  }
 	if (!PGBUF_LRU_LIST_IS_OVER_QUOTA (lru_list))
 	  {
 	    if (pgbuf_is_any_thread_waiting_for_direct_victim () == false)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22741

when flush daemon thread finds no victim candidates, we do many safe-guard checks to see if it there was a fault in searching victim candidates or if it is normal.

one condition is that if list has count_vict_cand greater than zero, then it was expected to find a victim in the list. however, between searching the list and checking safe-guard, new candidates may appear. the condition is not stable and sometimes provides false alarms. fix by removing.