### PR TITLE
[CBRD-23433] [loaddb] quick fix for missing completed statistic

### DIFF
--- a/src/loaddb/load_session.cpp
+++ b/src/loaddb/load_session.cpp
@@ -629,6 +629,12 @@ namespace cubload
   session::fetch_stats (std::vector<stats> &stats_)
   {
     std::unique_lock<std::mutex> ulock (m_mutex);
+    if (m_collected_stats.empty () && (is_failed () || is_completed ()))
+      {
+	// quick fix to make sure client is notified of completion/failure
+	// todo: fix properly by not missing is_completed ()
+	collect_stats (true);
+      }
     if (!m_collected_stats.empty ())
       {
 	stats_.clear ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23433

force generating a new set of statistics when fetching stats finds nothing but session is completed.

hint: it seems no batches are executed (m_last_batch_id == m_max_batch_id == 0).
to be properly handled and fixed with patch that unifies load/fetch requests.