### PR TITLE
[CBRD-23437] flush error was not properly propagated

### DIFF
--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -1493,7 +1493,14 @@ ldr_clear_context (LDR_CONTEXT *context)
   context->inst_total = 0;
   context->inst_num = -1;
 
+  // not sure the param helps, however I don't like to change the existing behavior.
+  // We may remove it someday.
   context->flush_interval = prm_get_integer_value (PRM_ID_LOADDB_FLUSH_INTERVAL);
+  if (context->args->periodic_commit <= context->flush_interval)
+    {
+      // deactive flush_interval, since it is useless for this case
+      context->flush_interval = 0;
+    }
 
   context->table = NULL;
 

--- a/src/transaction/locator_cl.c
+++ b/src/transaction/locator_cl.c
@@ -5353,10 +5353,11 @@ locator_flush_all_instances (MOP class_mop, bool decache)
 	{
 	  /* flush all dirty instances of this class */
 	  map_status = ws_map_class_dirty (obj->op, locator_mflush, &mflush);
-	  if (map_status == WS_MAP_FAIL)
-	    {
-	      error_code = ER_FAILED;
-	    }
+	}
+
+      if (map_status == WS_MAP_FAIL)
+	{
+	  ASSERT_ERROR_AND_SET (error_code);
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23437

This includes two fixes:
- flush error was not propagated
- SA loaddb has PRM_ID_LOADDB_FLUSH_INTERVAL whose default value is 1000. deactivate the param when shorter periodic commit interval is given. 