### PR TITLE
[CBRD-22714] Fix prunned recursive cte execution clearing

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15855,7 +15855,7 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 
   if (recursive_part && non_recursive_part->list_id->tuple_cnt == 0)
     {
-      // status needs to be changed from XASL_SUCCESS to enable proper cleaning in qexec_clear_xasl
+      // status needs to be changed to XASL_SUCCESS to enable proper cleaning in qexec_clear_xasl
       recursive_part->status = XASL_SUCCESS;
     }
   else if (recursive_part && non_recursive_part->list_id->tuple_cnt > 0)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15853,7 +15853,12 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
       GOTO_EXIT_ON_ERROR;
     }
 
-  if (recursive_part && non_recursive_part->list_id->tuple_cnt > 0)
+  if (recursive_part && non_recursive_part->list_id->tuple_cnt == 0)
+    {
+      // status needs to be changed from XASL_SUCCESS to enable proper cleaning in qexec_clear_xasl
+      recursive_part->status = XASL_SUCCESS;
+    }
+  else if (recursive_part && non_recursive_part->list_id->tuple_cnt > 0)
     {
       bool common_list_optimization = false;
       int recursive_iterations = 0;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22714

Recursive_part's status was never set to something different than XASL_INITIALIZED when recursive_part was prunned, causing a leak during qexec_clear_xasl recursive_part clearing.