### PR TITLE
[CBRD-23286] Fixed class statistics report and update

### DIFF
--- a/src/communication/network.h
+++ b/src/communication/network.h
@@ -239,6 +239,7 @@ enum net_server_request
   NET_SERVER_LD_FETCH_STATS,
   NET_SERVER_LD_DESTROY,
   NET_SERVER_LD_INTERRUPT,
+  NET_SERVER_LD_UPDATE_STATS,
 
   /*
    * This is the last entry. It is also used for the end of an

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -644,6 +644,7 @@ net_histo_setup_names (void)
   net_Req_buffer[NET_SERVER_LD_LOAD_BATCH].name = "NET_SERVER_LD_LOAD_BATCH";
   net_Req_buffer[NET_SERVER_LD_DESTROY].name = "NET_SERVER_LD_DESTROY";
   net_Req_buffer[NET_SERVER_LD_INTERRUPT].name = "NET_SERVER_LD_INTERRUPT";
+  net_Req_buffer[NET_SERVER_LD_UPDATE_STATS].name = "NET_SERVER_LD_UPDATE_STATS";
 }
 
 /*

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -10108,3 +10108,24 @@ loaddb_interrupt ()
   return NO_ERROR;
 #endif /* !CS_MODE */
 }
+
+int
+loaddb_update_stats ()
+{
+#if defined(CS_MODE)
+  int rc = ER_FAILED;
+  OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
+  char *reply = OR_ALIGNED_BUF_START (a_reply);
+
+  int req_error =
+    net_client_request (NET_SERVER_LD_UPDATE_STATS, NULL, 0, reply, OR_ALIGNED_BUF_SIZE (a_reply), NULL, 0, NULL, 0);
+  if (!req_error)
+    {
+      or_unpack_int (reply, &rc);
+    }
+
+  return rc;
+#else /* CS_MODE */
+  return NO_ERROR;
+#endif /* !CS_MODE */
+}

--- a/src/communication/network_interface_cl.h
+++ b/src/communication/network_interface_cl.h
@@ -428,4 +428,5 @@ extern int loaddb_fetch_stats (std::vector<load_stats> &stats);
 /* *INDENT-ON* */
 extern int loaddb_destroy ();
 extern int loaddb_interrupt ();
+extern int loaddb_update_stats ();
 #endif /* _NETWORK_INTERFACE_CL_H_ */

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -9884,7 +9884,6 @@ sloaddb_destroy (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int r
       assert (session != NULL);
 
       session->wait_for_completion ();
-      session->update_class_statistics (*thread_p);
       delete session;
       session_set_load_session (thread_p, NULL);
     }
@@ -9916,4 +9915,31 @@ sloaddb_interrupt (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int
     {
       // what to do, what to do...
     }
+}
+
+void
+sloaddb_update_stats (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
+{
+  char *buffer = NULL;
+  int buffer_size = 0;
+
+  load_session *session = NULL;
+  int error_code = session_get_load_session (thread_p, session);
+  if (error_code == NO_ERROR)
+    {
+      assert (session != NULL);
+
+      session->update_class_statistics (*thread_p);
+    }
+
+  if (er_errid () != NO_ERROR || er_has_error ())
+    {
+      return_error_to_client (thread_p, rid);
+    }
+
+  OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
+  char *reply = OR_ALIGNED_BUF_START (a_reply);
+
+  or_pack_int (reply, error_code);
+  css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
 }

--- a/src/communication/network_interface_sr.h
+++ b/src/communication/network_interface_sr.h
@@ -231,4 +231,5 @@ extern void sloaddb_load_batch (THREAD_ENTRY * thread_p, unsigned int rid, char 
 extern void sloaddb_fetch_stats (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void sloaddb_destroy (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void sloaddb_interrupt (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
+extern void sloaddb_update_stats (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 #endif /* _NETWORK_INTERFACE_SR_H_ */

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -859,6 +859,10 @@ net_server_init (void)
   req_p->processing_function = sloaddb_interrupt;
   req_p->name = "NET_SERVER_LD_INTERRUPT";
 
+  req_p = &net_Requests[NET_SERVER_LD_UPDATE_STATS];
+  req_p->processing_function = sloaddb_update_stats;
+  req_p->name = "NET_SERVER_LD_UPDATE_STATS";
+
   /* checksumdb replication */
   req_p = &net_Requests[NET_SERVER_CHKSUM_REPL];
   req_p->action_attribute = IN_TRANSACTION;

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1183,7 +1183,7 @@ ldr_server_load (load_args * args, int *status, bool * interrupted)
 		     last_stat.rows_committed, last_stat.rows_failed);
     }
 
-  if (!load_interrupted && !is_failed && !args->syntax_check)
+  if (!load_interrupted && !is_failed && !args->syntax_check && error_code == NO_ERROR)
     {
       // Update class statistics
       error_code = loaddb_update_stats ();

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1191,20 +1191,22 @@ ldr_server_load (load_args * args, int *status, bool * interrupted)
 	{
 	  print_er_msg ();
 	  *status = 3;
-	  return;
 	}
-
-      // Fetch the latest stats.
-      error_code = loaddb_fetch_stats (stats);
-      if (error_code != NO_ERROR)
+      else			// NO_ERROR
 	{
-	  print_er_msg ();
-	  *status = 3;
-	  return;
+	  // Fetch the latest stats.
+	  error_code = loaddb_fetch_stats (stats);
+	  if (error_code != NO_ERROR)
+	    {
+	      print_er_msg ();
+	      *status = 3;
+	    }
+	  else			// NO_ERROR
+	    {
+	      // Print these stats.
+	      print_stats (stats, *args, status);
+	    }
 	}
-
-      // Print these stats.
-      print_stats (stats, *args, status);
     }
 
   // Destroy the session.

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1183,24 +1183,27 @@ ldr_server_load (load_args * args, int *status, bool * interrupted)
 		     last_stat.rows_committed, last_stat.rows_failed);
     }
 
-  // Update class statistics
-  error_code = loaddb_update_stats ();
-  if (error_code != NO_ERROR)
+  if (!load_interrupted && !is_failed && !args->syntax_check)
     {
-      print_er_msg ();
-      *status = 3;
-    }
+      // Update class statistics
+      error_code = loaddb_update_stats ();
+      if (error_code != NO_ERROR)
+	{
+	  print_er_msg ();
+	  *status = 3;
+	}
 
-  // Fetch the latest stats.
-  error_code = loaddb_fetch_stats (stats);
-  if (error_code != NO_ERROR)
-    {
-      print_er_msg ();
-      *status = 3;
-    }
+      // Fetch the latest stats.
+      error_code = loaddb_fetch_stats (stats);
+      if (error_code != NO_ERROR)
+	{
+	  print_er_msg ();
+	  *status = 3;
+	}
 
-  // Print these stats.
-  print_stats (stats, *args, status);
+      // Print these stats.
+      print_stats (stats, *args, status);
+    }
 
   // Destroy the session.
   error_code = loaddb_destroy ();

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1191,6 +1191,7 @@ ldr_server_load (load_args * args, int *status, bool * interrupted)
 	{
 	  print_er_msg ();
 	  *status = 3;
+	  return;
 	}
 
       // Fetch the latest stats.
@@ -1199,6 +1200,7 @@ ldr_server_load (load_args * args, int *status, bool * interrupted)
 	{
 	  print_er_msg ();
 	  *status = 3;
+	  return;
 	}
 
       // Print these stats.

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1183,6 +1183,26 @@ ldr_server_load (load_args * args, int *status, bool * interrupted)
 		     last_stat.rows_committed, last_stat.rows_failed);
     }
 
+  // Update class statistics
+  error_code = loaddb_update_stats ();
+  if (error_code != NO_ERROR)
+    {
+      print_er_msg ();
+      *status = 3;
+    }
+
+  // Fetch the latest stats.
+  error_code = loaddb_fetch_stats (stats);
+  if (error_code != NO_ERROR)
+    {
+      print_er_msg ();
+      *status = 3;
+    }
+
+  // Print these stats.
+  print_stats (stats, *args, status);
+
+  // Destroy the session.
   error_code = loaddb_destroy ();
   if (error_code != NO_ERROR)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23286

Statistics were not correctly updated and reported on the server side. With this PR, after a session completes, the client will send a request to update the class statistics, and then fetch the new messages as well to print them to the user.