### PR TITLE
[CBRD-21800] avoid zero-sized hashmap freelist block

### DIFF
--- a/src/query/filter_pred_cache.c
+++ b/src/query/filter_pred_cache.c
@@ -34,6 +34,8 @@
 #include "xasl.h"
 #include "xasl_unpack_info.hpp"
 
+#include <algorithm>
+
 typedef struct fpcache_ent FPCACHE_ENTRY;
 struct fpcache_ent
 {
@@ -155,7 +157,7 @@ fpcache_initialize (THREAD_ENTRY * thread_p)
 
   /* Initialize free list */
   const int freelist_block_count = 2;
-  const int freelist_block_size = fpcache_Soft_capacity / freelist_block_count;
+  const int freelist_block_size = std::max (1, fpcache_Soft_capacity / freelist_block_count);
   fpcache_Hashmap.init (fpcache_Ts, THREAD_TS_FPCACHE, fpcache_Soft_capacity, freelist_block_size, freelist_block_count,
 			fpcache_Entry_descriptor);
   fpcache_Entry_counter = 0;

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -40,6 +40,7 @@
 #include "thread_manager.hpp"
 #include "xasl_unpack_info.hpp"
 
+#include <algorithm>
 #include <assert.h>
 
 #define XCACHE_ENTRY_MARK_DELETED	    ((INT32) 0x80000000)
@@ -297,7 +298,7 @@ xcache_initialize (THREAD_ENTRY * thread_p)
   xcache_Max_clones = prm_get_integer_value (PRM_ID_XASL_CACHE_MAX_CLONES);
 
   const int freelist_block_count = 2;
-  const int freelist_block_size = xcache_Soft_capacity / freelist_block_count;
+  const int freelist_block_size = std::max (1, xcache_Soft_capacity / freelist_block_count);
   xcache_Hashmap.init (xcache_Ts, THREAD_TS_XCACHE, xcache_Soft_capacity, freelist_block_size, freelist_block_count,
 		       xcache_Entry_descriptor);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21800

If parameter for xasl/filter cache size is 1, block size was set to 0. Fix by forcing minimum size of 1.