### PR TITLE
[CBRD-23434] Fix packing a string containing byte zero

### DIFF
--- a/src/base/packer.cpp
+++ b/src/base/packer.cpp
@@ -467,11 +467,11 @@ namespace cubpacking
 
     if (str_size == 0)
       {
-        len = strlen (string);
+	len = strlen (string);
       }
     else
       {
-        len = str_size;
+	len = str_size;
       }
 
     if (len > MAX_SMALL_STRING_SIZE)
@@ -543,11 +543,11 @@ namespace cubpacking
 
     if (str_size == 0)
       {
-        len = strlen (string);
+	len = strlen (string);
       }
     else
       {
-        len = str_size;
+	len = str_size;
       }
 
     align (INT_ALIGNMENT);

--- a/src/base/packer.cpp
+++ b/src/base/packer.cpp
@@ -461,11 +461,18 @@ namespace cubpacking
   }
 
   void
-  packer::pack_small_string (const char *string)
+  packer::pack_small_string (const char *string, const size_t str_size)
   {
     size_t len;
 
-    len = strlen (string);
+    if (str_size == 0)
+      {
+        len = strlen (string);
+      }
+    else
+      {
+        len = str_size;
+      }
 
     if (len > MAX_SMALL_STRING_SIZE)
       {
@@ -530,11 +537,18 @@ namespace cubpacking
   }
 
   void
-  packer::pack_large_string (const std::string &str)
+  packer::pack_large_c_string (const char *string, const size_t str_size)
   {
     size_t len;
 
-    len = str.size ();
+    if (str_size == 0)
+      {
+        len = strlen (string);
+      }
+    else
+      {
+        len = str_size;
+      }
 
     align (INT_ALIGNMENT);
     check_range (m_ptr, m_end_ptr, len + OR_INT_SIZE);
@@ -542,10 +556,16 @@ namespace cubpacking
     OR_PUT_INT (m_ptr, len);
     m_ptr += OR_INT_SIZE;
 
-    std::memcpy (m_ptr, str.c_str (), len);
+    std::memcpy (m_ptr, string, len);
     m_ptr += len;
 
     align (INT_ALIGNMENT);
+  }
+
+  void
+  packer::pack_large_string (const std::string &str)
+  {
+    pack_large_c_string (str.c_str (), str.size ());
   }
 
   void
@@ -649,7 +669,7 @@ namespace cubpacking
   {
     if (str_size < MAX_SMALL_STRING_SIZE)
       {
-	pack_small_string (str);
+	pack_small_string (str, str_size);
       }
     else
       {
@@ -658,7 +678,7 @@ namespace cubpacking
 	OR_PUT_BYTE (m_ptr, LARGE_STRING_CODE);
 	m_ptr++;
 
-	pack_large_string (str);
+	pack_large_c_string (str, str_size);
       }
   }
 

--- a/src/base/packer.hpp
+++ b/src/base/packer.hpp
@@ -89,7 +89,7 @@ namespace cubpacking
       void pack_overloaded (const db_value &value);
 
       size_t get_packed_small_string_size (const char *string, const size_t curr_offset);
-      void pack_small_string (const char *string);
+      void pack_small_string (const char *string, const size_t str_size = 0);
 
       size_t get_packed_large_string_size (const std::string &str, const size_t curr_offset);
       void pack_large_string (const std::string &str);
@@ -162,6 +162,7 @@ namespace cubpacking
       void append_to_buffer_and_pack_all (ExtBlk &eb, Args &&... args);
 
     private:
+      void pack_large_c_string (const char *string, const size_t str_size);
 
       template <typename T, typename ... Args>
       size_t get_all_packed_size_recursive (size_t curr_offset, T &&t, Args &&... args);

--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -559,7 +559,7 @@ namespace cubload
 	return ER_FILE_UNKNOWN_FILE;
       }
 
-    std::ifstream object_file (object_file_name, std::fstream::in);
+    std::ifstream object_file (object_file_name, std::fstream::in | std::fstream::binary);
     if (!object_file)
       {
 	// file does not exists


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23434

Fix packing of a string containing byte zero.
Loader CS : open objects file with binary mode.