### PR TITLE
[CBRD-20008] remove useless extra key filter evaluation

### DIFF
--- a/src/query/query_evaluator.c
+++ b/src/query/query_evaluator.c
@@ -2613,15 +2613,9 @@ eval_fnc (THREAD_ENTRY * thread_p, const PRED_EXPR * pr, DB_TYPE * single_node_t
  *   ev_res(in): logical value to be checked
  *   qualification(in/out): a pointer to the qualification to be used in logical
  *			    value check. This member can be modified.
- *   key_filter(in): key filter info that will be used if ORACLE EMPTY STRING
- *		     STYLE is activated
- *   recdes(in): the record descriptor from wich values will be loaded into the
- *		 key_filter attributes cache
- *   oid(in): the OID of the current descriptor
  */
 DB_LOGICAL
-update_logical_result (THREAD_ENTRY * thread_p, DB_LOGICAL ev_res, int *qualification, FILTER_INFO * key_filter,
-		       RECDES * recdes, const OID * oid)
+update_logical_result (THREAD_ENTRY * thread_p, DB_LOGICAL ev_res, int *qualification)
 {
   int q;
 
@@ -2672,17 +2666,15 @@ update_logical_result (THREAD_ENTRY * thread_p, DB_LOGICAL ev_res, int *qualific
 	}
     }
 
-  if (ev_res == V_ERROR)
+  assert (ev_res != V_ERROR);
+  if (ev_res == V_TRUE)
     {
-      return V_ERROR;
-    }
-  else if (ev_res != V_TRUE)	/* V_FALSE || V_UNKNOWN */
-    {
-      return V_FALSE;		/* not qualified, continue to the next tuple */
+      return V_TRUE;
     }
   else
     {
-      return V_TRUE;
+      /* V_FALSE || V_UNKNOWN */
+      return V_FALSE;		/* not qualified, continue to the next tuple */
     }
 }
 

--- a/src/query/query_evaluator.h
+++ b/src/query/query_evaluator.h
@@ -146,7 +146,6 @@ extern PR_EVAL_FNC eval_fnc (THREAD_ENTRY * thread_p, const PRED_EXPR * pr, DB_T
 extern DB_LOGICAL eval_data_filter (THREAD_ENTRY * thread_p, OID * oid, RECDES * recdes, HEAP_SCANCACHE * scan_cache,
 				    FILTER_INFO * filter);
 extern DB_LOGICAL eval_key_filter (THREAD_ENTRY * thread_p, DB_VALUE * value, FILTER_INFO * filter);
-extern DB_LOGICAL update_logical_result (THREAD_ENTRY * thread_p, DB_LOGICAL ev_res, int *qualification,
-					 FILTER_INFO * key_filter, RECDES * recdes, const OID * oid);
+extern DB_LOGICAL update_logical_result (THREAD_ENTRY * thread_p, DB_LOGICAL ev_res, int *qualification);
 
 #endif /* _QUERY_EVALUATOR_H_ */

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5907,21 +5907,9 @@ scan_next_index_lookup_heap (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, INDX_SC
 
   /* evaluate the predicates to see if the object qualifies */
   ev_res = eval_data_filter (thread_p, isidp->curr_oidp, &recdes, &isidp->scan_cache, data_filter);
-  if (isidp->key_pred.regu_list != NULL)
-    {
-      FILTER_INFO key_filter;
 
-      scan_init_filter_info (&key_filter, &isidp->key_pred, &isidp->key_attrs, scan_id->val_list, scan_id->vd,
-			     &isidp->cls_oid, isidp->bt_num_attrs, isidp->bt_attr_ids, &isidp->num_vstr,
-			     isidp->vstr_ids);
-      ev_res =
-	update_logical_result (thread_p, ev_res, (int *) &scan_id->qualification, &key_filter, &recdes,
-			       isidp->curr_oidp);
-    }
-  else
-    {
-      ev_res = update_logical_result (thread_p, ev_res, (int *) &scan_id->qualification, NULL, NULL, NULL);
-    }
+  // no key filter evaluation is required.
+  ev_res = update_logical_result (thread_p, ev_res, (int *) &scan_id->qualification, NULL, NULL, NULL);
   if (ev_res == V_ERROR)
     {
       return S_ERROR;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5904,17 +5904,17 @@ scan_next_index_lookup_heap (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, INDX_SC
       assert (sp_scan == S_SUCCESS || sp_scan == S_SUCCESS_CHN_UPTODATE);
     }
 
-
   /* evaluate the predicates to see if the object qualifies */
   ev_res = eval_data_filter (thread_p, isidp->curr_oidp, &recdes, &isidp->scan_cache, data_filter);
 
-  // no key filter evaluation is required.
-  ev_res = update_logical_result (thread_p, ev_res, (int *) &scan_id->qualification, NULL, NULL, NULL);
+  // no key filter evaluation is required here.
+
+  ev_res = update_logical_result (thread_p, ev_res, (int *) &scan_id->qualification);
   if (ev_res == V_ERROR)
     {
       return S_ERROR;
     }
-  if (ev_res != V_TRUE)
+  else if (ev_res != V_TRUE)
     {
       return S_DOESNT_EXIST;
     }

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13557,14 +13557,11 @@ end:
 }
 
 /*
- * locator_mvcc_reevaluate_filters () - reevaluates key range, key filter and data
- *				filter predicates
+ * locator_mvcc_reevaluate_filters () - reevaluates key range, key filter and data filter predicates
  *   return: result of reevaluation
  *   thread_p(in): thread entry
- *   mvcc_reev_data(in): The structure that contains data needed for
- *			 reevaluation
- *   oid(in) : The record that was modified by other transactions and is
- *	       involved in filters.
+ *   mvcc_reev_data(in): The structure that contains data needed for reevaluation
+ *   oid(in) : The record that was modified by other transactions and is involved in filters.
  *   recdes(in): Record descriptor that will contain the record
  */
 static DB_LOGICAL
@@ -13581,12 +13578,12 @@ locator_mvcc_reevaluate_filters (THREAD_ENTRY * thread_p, MVCC_SCAN_REEV_DATA * 
 	{
 	  return V_ERROR;
 	}
-      ev_res =
-	(*filter->scan_pred->pr_eval_fnc) (thread_p, filter->scan_pred->pred_expr, filter->val_descr, (OID *) oid);
-      ev_res = update_logical_result (thread_p, ev_res, NULL, NULL, NULL, NULL);
+      ev_res = (*filter->scan_pred->pr_eval_fnc) (thread_p, filter->scan_pred->pred_expr, filter->val_descr,
+						  (OID *) oid);
+      ev_res = update_logical_result (thread_p, ev_res, NULL);
       if (ev_res != V_TRUE)
 	{
-	  goto end;
+	  return ev_res;
 	}
     }
 
@@ -13597,12 +13594,12 @@ locator_mvcc_reevaluate_filters (THREAD_ENTRY * thread_p, MVCC_SCAN_REEV_DATA * 
 	{
 	  return V_ERROR;
 	}
-      ev_res =
-	(*filter->scan_pred->pr_eval_fnc) (thread_p, filter->scan_pred->pred_expr, filter->val_descr, (OID *) oid);
-      ev_res = update_logical_result (thread_p, ev_res, NULL, NULL, NULL, NULL);
+      ev_res = (*filter->scan_pred->pr_eval_fnc) (thread_p, filter->scan_pred->pred_expr, filter->val_descr,
+						  (OID *) oid);
+      ev_res = update_logical_result (thread_p, ev_res, NULL);
       if (ev_res != V_TRUE)
 	{
-	  goto end;
+	  return ev_res;
 	}
     }
 
@@ -13610,12 +13607,9 @@ locator_mvcc_reevaluate_filters (THREAD_ENTRY * thread_p, MVCC_SCAN_REEV_DATA * 
   if (filter != NULL && filter->scan_pred != NULL && filter->scan_pred->pred_expr != NULL)
     {
       ev_res = eval_data_filter (thread_p, (OID *) oid, recdes, NULL, filter);
-      ev_res =
-	update_logical_result (thread_p, ev_res, (int *) mvcc_reev_data->qualification, mvcc_reev_data->key_filter,
-			       recdes, oid);
+      ev_res = update_logical_result (thread_p, ev_res, (int *) mvcc_reev_data->qualification);
     }
 
-end:
   return ev_res;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20008

This is a legacy issue.
To evaluate a particular key filter (oracle_style_empty_string) is neither useful nor correct.
