### PR TITLE
[CBRD-23444] fix cci map warning

### DIFF
--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -5675,7 +5675,7 @@ cci_datasource_make_url (T_CCI_PROPERTIES * prop, char *new_url, char *url, T_CC
 
       return false;
     }
-  rlen = LINE_MAX - strlen (new_url);
+  rlen = LINE_MAX - (int) strlen (new_url);
 
   if (strchr (new_url, '?'))
     {

--- a/src/cci/cci_common.h
+++ b/src/cci/cci_common.h
@@ -80,7 +80,6 @@
       CCI_LOGF_DEBUG ((con)->logger, "[%04d][API][E][%s] ERROR[%d]", (con)->id, __func__, (err)); \
   } while (false)
 
-#define strlen(s1)  ((int) strlen(s1))
 #define CAST_STRLEN (int)
 
 #if defined(WINDOWS)

--- a/src/cci/cci_log.cpp
+++ b/src/cci/cci_log.cpp
@@ -673,7 +673,7 @@ void _Logger::write (const char *msg)
 {
   logAppender->write (msg);
 
-  unflushedBytes += strlen (msg);
+  unflushedBytes += (int) strlen (msg);
 
   if (isForceFlush || unflushedBytes >= LOG_FLUSH_SIZE
       || nextFlushTime >= (unsigned long) context.now.tv_usec)

--- a/src/cci/cci_map.cpp
+++ b/src/cci/cci_map.cpp
@@ -32,33 +32,15 @@
  * cci_map.cpp
  */
 
-/* hash_map is deprecated and should be replaced with unordered_map if compiler supports it */
-#if defined WINDOWS
-#if defined _MSC_VER && _MSC_VER > 1500
-#include <unordered_map>
-#else /* !_MSC_VER || _MSC_VER < 1500 */
-#include <hash_map>
-#endif /* !_MSC_VER || _MSC_VER < 1500 */
-#else /* !WINDOWS */
-#include <ext/hash_map>
-#endif
-
-#include <map>
-#include "cci_handle_mng.h"
-#include "cas_cci.h"
-#include "cci_mutex.h"
 #include "cci_map.h"
 
-#if defined (_UNORDERED_MAP_)
+#include "cci_mutex.h"
+#include "cci_handle_mng.h"
+
+#include <unordered_map>
+
 typedef std::unordered_map<T_CCI_CONN, T_CCI_CONN> MapConnection;
 typedef std::unordered_map<T_CCI_REQ, T_CCI_REQ> MapStatement;
-#elif defined (WINDOWS)
-typedef stdext::hash_map<T_CCI_CONN, T_CCI_CONN> MapConnection;
-typedef stdext::hash_map<T_CCI_REQ, T_CCI_REQ> MapStatement;
-#else
-typedef __gnu_cxx::hash_map<T_CCI_CONN, T_CCI_CONN> MapConnection;
-typedef __gnu_cxx::hash_map<T_CCI_REQ, T_CCI_REQ> MapStatement;
-#endif
 
 typedef MapConnection::iterator IteratorMapConnection;
 typedef MapStatement::iterator IteratorMapStatement;

--- a/src/cci/cci_map.h
+++ b/src/cci/cci_map.h
@@ -35,6 +35,8 @@
 #ifndef CCI_MAP_H_
 #define CCI_MAP_H_
 
+#include "cas_cci.h"
+
 /* one time connection_id */
 extern T_CCI_ERROR_CODE map_open_otc (T_CCI_CONN connection_id, T_CCI_CONN * mapped_conn_id);
 extern T_CCI_ERROR_CODE map_get_otc_value (T_CCI_CONN mapped_conn_id, T_CCI_CONN * connection_id, bool force);

--- a/src/cci/cci_mutex.h
+++ b/src/cci/cci_mutex.h
@@ -8,7 +8,12 @@
 #ifndef CCI_MUTEX_H_
 #define CCI_MUTEX_H_
 
+#if defined (WINDOWS)
 #include "porting.h"
+#endif
+#if defined (LINUX)
+#include "pthread.h"
+#endif
 
 namespace cci
 {

--- a/src/cci/cci_net_buf.h
+++ b/src/cci/cci_net_buf.h
@@ -92,7 +92,7 @@
 #define NET_SIZE_TIMESTAMP	(NET_SIZE_SHORT * 6)
 #define NET_SIZE_DATETIME       (NET_SIZE_SHORT * 7)
 
-#define NET_SIZE_TZ(val)	(strlen (((T_CCI_DATE_TZ *)(val))->tz))
+#define NET_SIZE_TZ(val)	((int) strlen (((T_CCI_DATE_TZ *)(val))->tz))
 /*
  *  change function names to avoid naming conflict with cas server.
   */

--- a/src/cci/cci_network.c
+++ b/src/cci/cci_network.c
@@ -798,7 +798,7 @@ net_peer_alive (unsigned char *ip_addr, int port, int timeout_msec)
     }
 
 send_again:
-  ret = WRITE_TO_SOCKET (sock_fd, ping_msg, strlen (ping_msg));
+  ret = WRITE_TO_SOCKET (sock_fd, ping_msg, (int) strlen (ping_msg));
   if (ret < 0)
     {
       if (errno == EAGAIN)

--- a/src/cci/cci_query_execute.c
+++ b/src/cci/cci_query_execute.c
@@ -425,7 +425,7 @@ qe_prepare (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, char *sql_stmt
       return CCI_ER_NO_MORE_MEMORY;
     }
 
-  sql_stmt_size = strlen (req_handle->sql_text) + 1;
+  sql_stmt_size = (int) strlen (req_handle->sql_text) + 1;
 
   net_buf_init (&net_buf);
 
@@ -828,7 +828,7 @@ qe_prepare_and_execute (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, ch
       return CCI_ER_NO_MORE_MEMORY;
     }
 
-  sql_stmt_size = strlen (req_handle->sql_text) + 1;
+  sql_stmt_size = (int) strlen (req_handle->sql_text) + 1;
 
   net_buf_init (&net_buf);
 
@@ -1887,13 +1887,21 @@ qe_schema_info (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, int type, 
   ADD_ARG_INT (&net_buf, type);
 
   if (arg1 == NULL)
-    ADD_ARG_BYTES (&net_buf, NULL, 0);
+    {
+      ADD_ARG_BYTES (&net_buf, NULL, 0);
+    }
   else
-    ADD_ARG_STR (&net_buf, arg1, strlen (arg1) + 1, con_handle->charset);
+    {
+      ADD_ARG_STR (&net_buf, arg1, (int) strlen (arg1) + 1, con_handle->charset);
+    }
   if (arg2 == NULL)
-    ADD_ARG_BYTES (&net_buf, NULL, 0);
+    {
+      ADD_ARG_BYTES (&net_buf, NULL, 0);
+    }
   else
-    ADD_ARG_STR (&net_buf, arg2, strlen (arg2) + 1, con_handle->charset);
+    {
+      ADD_ARG_STR (&net_buf, arg2, (int) strlen (arg2) + 1, con_handle->charset);
+    }
   ADD_ARG_BYTES (&net_buf, &flag, 1);
 
   broker_ver = hm_get_broker_version (con_handle);
@@ -1957,7 +1965,7 @@ qe_oid_get (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, char *oid_str,
     {
       for (i = 0; attr_name[i] != NULL; i++)
 	{
-	  ADD_ARG_STR (&net_buf, attr_name[i], strlen (attr_name[i]) + 1, con_handle->charset);
+	  ADD_ARG_STR (&net_buf, attr_name[i], (int) strlen (attr_name[i]) + 1, con_handle->charset);
 	}
     }
 
@@ -2009,12 +2017,16 @@ qe_oid_put (T_CON_HANDLE * con_handle, char *oid_str, char **attr_name, char **n
   ADD_ARG_OBJECT (&net_buf, &oid);
   for (i = 0; attr_name[i] != NULL; i++)
     {
-      ADD_ARG_STR (&net_buf, attr_name[i], strlen (attr_name[i]) + 1, con_handle->charset);
+      ADD_ARG_STR (&net_buf, attr_name[i], (int) strlen (attr_name[i]) + 1, con_handle->charset);
       ADD_ARG_BYTES (&net_buf, &u_type, 1);
       if (new_val[i] == NULL)
-	ADD_ARG_BYTES (&net_buf, NULL, 0);
+        {
+	  ADD_ARG_BYTES (&net_buf, NULL, 0);
+        }
       else
-	ADD_ARG_STR (&net_buf, new_val[i], strlen (new_val[i]) + 1, con_handle->charset);
+        {
+	  ADD_ARG_STR (&net_buf, new_val[i], (int) strlen (new_val[i]) + 1, con_handle->charset);
+        }
     }
 
   if (net_buf.err_code < 0)
@@ -2061,7 +2073,7 @@ qe_oid_put2 (T_CON_HANDLE * con_handle, char *oid_str, char **attr_name, void **
       tmp_cell.flag = BIND_PTR_STATIC;
       tmp_cell.value = NULL;
 
-      ADD_ARG_STR (&net_buf, attr_name[i], strlen (attr_name[i]) + 1, con_handle->charset);
+      ADD_ARG_STR (&net_buf, attr_name[i], (int) strlen (attr_name[i]) + 1, con_handle->charset);
 
       value = NULL;
 
@@ -2074,7 +2086,7 @@ qe_oid_put2 (T_CON_HANDLE * con_handle, char *oid_str, char **attr_name, void **
 	  switch (a_type[i])
 	    {
 	    case CCI_A_TYPE_STR:
-	      data_size = strlen ((char *) (new_val[i])) + 1;
+	      data_size = (int) strlen ((char *) (new_val[i])) + 1;
 	      u_type = CCI_U_TYPE_STRING;
 	      value = new_val[i];
 	      break;
@@ -2236,7 +2248,7 @@ qe_get_class_num_objs (T_CON_HANDLE * con_handle, char *class_name, char flag, i
 
   net_buf_init (&net_buf);
   net_buf_cp_str (&net_buf, &func_code, 1);
-  ADD_ARG_STR (&net_buf, class_name, strlen (class_name) + 1, con_handle->charset);
+  ADD_ARG_STR (&net_buf, class_name, (int) strlen (class_name) + 1, con_handle->charset);
   ADD_ARG_BYTES (&net_buf, &flag, 1);
 
   if (net_buf.err_code < 0)
@@ -2367,7 +2379,7 @@ qe_col_get (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, char *oid_str,
 
   ADD_ARG_BYTES (&net_buf, &col_cmd, 1);
   ADD_ARG_OBJECT (&net_buf, &oid);
-  ADD_ARG_STR (&net_buf, col_attr, strlen (col_attr) + 1, con_handle->charset);
+  ADD_ARG_STR (&net_buf, col_attr, (int) strlen (col_attr) + 1, con_handle->charset);
 
   if (net_buf.err_code < 0)
     {
@@ -2598,7 +2610,7 @@ qe_col_size (T_CON_HANDLE * con_handle, char *oid_str, const char *col_attr, int
 
   ADD_ARG_BYTES (&net_buf, &col_cmd, 1);
   ADD_ARG_OBJECT (&net_buf, &oid);
-  ADD_ARG_STR (&net_buf, (char *) col_attr, strlen (col_attr) + 1, con_handle->charset);
+  ADD_ARG_STR (&net_buf, (char *) col_attr, (int) strlen (col_attr) + 1, con_handle->charset);
 
   if (net_buf.err_code < 0)
     {
@@ -2657,12 +2669,16 @@ qe_col_set_add_drop (T_CON_HANDLE * con_handle, char col_cmd, char *oid_str, con
 
   ADD_ARG_BYTES (&net_buf, &col_cmd, 1);
   ADD_ARG_OBJECT (&net_buf, &oid);
-  ADD_ARG_STR (&net_buf, (char *) col_attr, strlen (col_attr) + 1, con_handle->charset);
+  ADD_ARG_STR (&net_buf, (char *) col_attr, (int) strlen (col_attr) + 1, con_handle->charset);
   ADD_ARG_BYTES (&net_buf, &u_type, 1);
   if (value == NULL)
-    ADD_ARG_BYTES (&net_buf, NULL, 0);
+    {
+      ADD_ARG_BYTES (&net_buf, NULL, 0);
+    }
   else
-    ADD_ARG_STR (&net_buf, value, strlen (value) + 1, con_handle->charset);
+    {
+      ADD_ARG_STR (&net_buf, value, (int) strlen (value) + 1, con_handle->charset);
+    }
 
   if (net_buf.err_code < 0)
     {
@@ -2707,7 +2723,7 @@ qe_col_seq_op (T_CON_HANDLE * con_handle, char col_cmd, char *oid_str, const cha
   ADD_ARG_BYTES (&net_buf, &col_cmd, 1);
   ADD_ARG_OBJECT (&net_buf, &oid);
   ADD_ARG_INT (&net_buf, index);
-  ADD_ARG_STR (&net_buf, (char *) col_attr, strlen (col_attr) + 1, con_handle->charset);
+  ADD_ARG_STR (&net_buf, (char *) col_attr, (int) strlen (col_attr) + 1, con_handle->charset);
   if (col_cmd == CCI_COL_SEQ_INSERT || col_cmd == CCI_COL_SEQ_PUT)
     {
       ADD_ARG_BYTES (&net_buf, &u_type, 1);
@@ -2717,7 +2733,7 @@ qe_col_seq_op (T_CON_HANDLE * con_handle, char col_cmd, char *oid_str, const cha
 	}
       else
 	{
-	  ADD_ARG_STR (&net_buf, (char *) value, strlen (value) + 1, con_handle->charset);
+	  ADD_ARG_STR (&net_buf, (char *) value, (int) strlen (value) + 1, con_handle->charset);
 	}
     }
 
@@ -3196,7 +3212,7 @@ qe_execute_batch (T_CON_HANDLE * con_handle, int num_query, char **sql_stmt, T_C
 
   for (i = 0; i < num_query; i++)
     {
-      sql_len = strlen (sql_stmt[i]) + 1;
+      sql_len = (int) strlen (sql_stmt[i]) + 1;
       ADD_ARG_STR (&net_buf, sql_stmt[i], sql_len, con_handle->charset);
     }
 
@@ -3449,7 +3465,7 @@ qe_get_data_str (T_VALUE_BUF * conv_val_buf, T_CCI_U_TYPE u_type, char *col_valu
     }
 
   *((char **) value) = (char *) conv_val_buf->data;
-  *indicator = strlen ((char *) conv_val_buf->data);
+  *indicator = (int) strlen ((char *) conv_val_buf->data);
 
   return 0;
 }
@@ -4113,8 +4129,8 @@ qe_get_attr_type_str (T_CON_HANDLE * con_handle, char *class_name, char *attr_na
 
   net_buf_cp_str (&net_buf, &func_code, 1);
 
-  ADD_ARG_STR (&net_buf, class_name, strlen (class_name) + 1, con_handle->charset);
-  ADD_ARG_STR (&net_buf, attr_name, strlen (attr_name) + 1, con_handle->charset);
+  ADD_ARG_STR (&net_buf, class_name, (int) strlen (class_name) + 1, con_handle->charset);
+  ADD_ARG_STR (&net_buf, attr_name, (int) strlen (attr_name) + 1, con_handle->charset);
 
   if (net_buf.err_code < 0)
     {
@@ -4162,7 +4178,7 @@ qe_get_query_info (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, char lo
     {
       int sql_stmt_size;
 
-      sql_stmt_size = strlen (req_handle->sql_text) + 1;
+      sql_stmt_size = (int) strlen (req_handle->sql_text) + 1;
 
       ADD_ARG_STR (&net_buf, req_handle->sql_text, sql_stmt_size, con_handle->charset);
     }
@@ -4221,7 +4237,7 @@ qe_savepoint_cmd (T_CON_HANDLE * con_handle, char cmd, const char *savepoint_nam
   net_buf_cp_str (&net_buf, &func_code, 1);
 
   ADD_ARG_BYTES (&net_buf, &cmd, 1);
-  ADD_ARG_STR (&net_buf, (char *) savepoint_name, strlen (savepoint_name) + 1, con_handle->charset);
+  ADD_ARG_STR (&net_buf, (char *) savepoint_name, (int) strlen (savepoint_name) + 1, con_handle->charset);
 
   if (net_buf.err_code < 0)
     {
@@ -5732,7 +5748,7 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
 	case CCI_U_TYPE_JSON:
 	  if (length == UNMEASURED_LENGTH)
 	    {
-	      bind_value->size = strlen ((const char *) value);
+	      bind_value->size = (int) strlen ((const char *) value);
 	    }
 	  else
 	    {
@@ -5929,7 +5945,7 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
 	      {
 		return CCI_ER_NO_MORE_MEMORY;
 	      }
-	    bind_value->size = sizeof (T_CCI_DATE) + strlen (date_tz.tz);
+	    bind_value->size = (int) (sizeof (T_CCI_DATE) + strlen (date_tz.tz));
 	    bind_value->flag = BIND_PTR_DYNAMIC;
 	  }
 	  break;
@@ -5967,7 +5983,7 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
 	      {
 		return CCI_ER_NO_MORE_MEMORY;
 	      }
-	    bind_value->size = sizeof (T_CCI_DATE) + strlen (date_tz.tz);
+	    bind_value->size = (int) (sizeof (T_CCI_DATE) + strlen (date_tz.tz));
 	    bind_value->flag = BIND_PTR_DYNAMIC;
 	  }
 	  break;
@@ -6019,7 +6035,7 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
 	      {
 		return CCI_ER_NO_MORE_MEMORY;
 	      }
-	    bind_value->size = strlen (buf) + 1;
+	    bind_value->size = (int) strlen (buf) + 1;
 	  }
 	  break;
 	case CCI_U_TYPE_BIGINT:
@@ -6096,7 +6112,7 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
 	      {
 		return CCI_ER_NO_MORE_MEMORY;
 	      }
-	    bind_value->size = strlen (buf) + 1;
+	    bind_value->size = (int) strlen (buf) + 1;
 	  }
 	  break;
 	case CCI_U_TYPE_BIGINT:
@@ -6170,7 +6186,7 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
 	      {
 		return CCI_ER_NO_MORE_MEMORY;
 	      }
-	    bind_value->size = strlen (buf) + 1;
+	    bind_value->size = (int) strlen (buf) + 1;
 	  }
 	  break;
 	case CCI_U_TYPE_BIGINT:
@@ -6243,7 +6259,7 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
 	      {
 		return CCI_ER_NO_MORE_MEMORY;
 	      }
-	    bind_value->size = strlen (buf) + 1;
+	    bind_value->size = (int) strlen (buf) + 1;
 	  }
 	  break;
 	case CCI_U_TYPE_BIGINT:
@@ -6316,7 +6332,7 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
 	    ALLOC_COPY (bind_value->value, buf);
 	    if (bind_value->value == NULL)
 	      return CCI_ER_NO_MORE_MEMORY;
-	    bind_value->size = strlen (buf) + 1;
+	    bind_value->size = (int) strlen (buf) + 1;
 	  }
 	  break;
 	case CCI_U_TYPE_BIGINT:
@@ -6383,7 +6399,7 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
 	    ALLOC_COPY (bind_value->value, buf);
 	    if (bind_value->value == NULL)
 	      return CCI_ER_NO_MORE_MEMORY;
-	    bind_value->size = strlen (buf) + 1;
+	    bind_value->size = (int) strlen (buf) + 1;
 	  }
 	  break;
 	case CCI_U_TYPE_BIGINT:
@@ -6519,7 +6535,7 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
 	      {
 		return CCI_ER_NO_MORE_MEMORY;
 	      }
-	    bind_value->size = sizeof (T_CCI_DATE) + NET_SIZE_TZ (value);
+	    bind_value->size = (int) (sizeof (T_CCI_DATE) + NET_SIZE_TZ (value));
 	    bind_value->flag = BIND_PTR_DYNAMIC;
 	  }
 	  break;

--- a/src/cci/cci_query_execute.c
+++ b/src/cci/cci_query_execute.c
@@ -2020,13 +2020,13 @@ qe_oid_put (T_CON_HANDLE * con_handle, char *oid_str, char **attr_name, char **n
       ADD_ARG_STR (&net_buf, attr_name[i], (int) strlen (attr_name[i]) + 1, con_handle->charset);
       ADD_ARG_BYTES (&net_buf, &u_type, 1);
       if (new_val[i] == NULL)
-        {
+	{
 	  ADD_ARG_BYTES (&net_buf, NULL, 0);
-        }
+	}
       else
-        {
+	{
 	  ADD_ARG_STR (&net_buf, new_val[i], (int) strlen (new_val[i]) + 1, con_handle->charset);
-        }
+	}
     }
 
   if (net_buf.err_code < 0)

--- a/src/cci/cci_t_set.c
+++ b/src/cci/cci_t_set.c
@@ -242,7 +242,7 @@ t_set_make (T_SET * set, char ele_type, int size, void *value, int *indicator)
 	  {
 	    char *ele_value;
 	    ele_value = ((char **) value)[i];
-	    ADD_ARG_STR (&net_buf, ele_value, strlen (ele_value) + 1, NULL);
+	    ADD_ARG_STR (&net_buf, ele_value, (int) strlen (ele_value) + 1, NULL);
 	  }
 	  break;
 	case CCI_U_TYPE_BIT:
@@ -443,7 +443,7 @@ t_set_to_str (T_SET * set, T_VALUE_BUF * conv_val)
 	  buf = (char *) "NULL";
 	}
 
-      net_buf_cp_str (&net_buf, buf, strlen (buf));
+      net_buf_cp_str (&net_buf, buf, (int) strlen (buf));
     }
 
   net_buf_cp_str (&net_buf, "}", 2);

--- a/src/cci/cci_util.c
+++ b/src/cci/cci_util.c
@@ -808,7 +808,7 @@ ut_date_tz_to_str (T_CCI_DATE_TZ * value, T_CCI_U_TYPE u_type, char *str, int si
       int remain_size;
       ut_date_to_str ((T_CCI_DATE *) value, u_type, str, size);
 
-      len = strlen (str);
+      len = (int) strlen (str);
       remain_size = size - len;
       if (remain_size > 1)
 	{
@@ -1015,7 +1015,7 @@ cci_url_match (const char *src, char *token[])
       return CCI_ER_INVALID_URL;	/* pattern compilation error */
     }
 
-  len = strlen (src);
+  len = (int) strlen (src);
   error = cub_regexec (&regex, src, len, 100, match, 0);
   if (error == CUB_REG_NOMATCH)
     {
@@ -1092,7 +1092,7 @@ get_pm_offset (char *str, int hh)
       str++;
     }
 
-  len = strlen (str);
+  len = (int) strlen (str);
 
   if ((((len > 2) && (*(str + 2) == ' ')) || (len == 2))
       && ((((*str) == 'p') || ((*str) == 'P')) && ((*(str + 1) == 'm') || (*(str + 1) == 'M'))) && (hh < 12))
@@ -1114,7 +1114,7 @@ skip_ampm_chars (char *str)
       ampm_skipped_chars++;
     }
 
-  len = strlen (str);
+  len = (int) strlen (str);
   if ((len > 2 && (*(str + 2) == ' ')) || (len == 2))
     {
       if (((*str == 'a') || (*str == 'A') || (*str == 'p') || (*str == 'P'))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23444

Fix following warning:
```
In file included from /usr/include/c++/9.2.0/ext/hash_map:60,
                 from ./cubrid/src/cci/cci_map.cpp:43:
/usr/include/c++/9.2.0/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
   32 | #warning
```