### PR TITLE
[CBRD-23420] Flush the log in case of abort executed in parallel with…

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -4539,11 +4539,15 @@ log_change_tran_as_completed (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_RECT
       tdes->state = TRAN_UNACTIVE_ABORTED;
 
 #if defined(SERVER_MODE)
+      // [TODO] Here is an argument: committers are waiting for flush. Then, why not aborters?
+      // The current fix minimizes potential impacts but it may miss some other cases.
+      // I think it might be better to remove the condition and let aborters also wait for flush.
+      // Maybe in the next milestone.
       if (BO_IS_SERVER_RESTARTED () && VOLATILE_ACCESS (log_Gl.run_nxchkpt_atpageid, INT64) == NULL_PAGEID)
 	{
 	  /* Flush the log in case that checkpoint is started. Otherwise, the current transaction
 	   * may finish, but its LOG_ABORT not flushed yet. The checkpoint can advance with smallest
-	   * LSA. Also, VACCUM can finalize cleaning. So, the archive may be removed. If the server crashes,
+	   * LSA. Also, VACUUM can finalize cleaning. So, the archive may be removed. If the server crashes,
 	   * at recovery, the current transaction must be aborted. But, some of its log records are in
 	   * the archive that was previously removed => crash. Fixed, by forcing log flush before ending.
 	   */


### PR DESCRIPTION
… checkpoint

http://jira.cubrid.org/browse/CBRD-23420