### PR TITLE
[CBRD-23452] remove unused struct db_collection

### DIFF
--- a/src/compat/db_value_printer.cpp
+++ b/src/compat/db_value_printer.cpp
@@ -368,7 +368,7 @@ void db_value_printer::describe_data (const db_value *value)
       set = db_get_set (value);
       if (set != NULL)
 	{
-	  describe_set ((const db_collection *) set);
+	  describe_set (set);
 	}
       else
 	{
@@ -540,7 +540,7 @@ void db_value_printer::describe_midxkey (const db_midxkey *midxkey, int help_Max
 }
 
 //--------------------------------------------------------------------------------
-void db_value_printer::describe_set (const db_collection *set, int help_Max_set_elements)
+void db_value_printer::describe_set (const db_set *set, int help_Max_set_elements)
 {
   DB_VALUE value;
   int size, end, i;

--- a/src/compat/db_value_printer.hpp
+++ b/src/compat/db_value_printer.hpp
@@ -28,7 +28,7 @@
 
 #include <cstdio>
 
-struct db_collection;
+struct db_set;
 struct db_midxkey;
 struct db_monetary;
 struct db_value;
@@ -54,7 +54,7 @@ class db_value_printer
 
   protected:
     void describe_midxkey (const db_midxkey *midxkey, int help_Max_set_elements=20);  //former describe_midxkey()
-    void describe_set (const db_collection *set, int help_Max_set_elements=20);       //former describe_set()
+    void describe_set (const db_set *set, int help_Max_set_elements=20);       //former describe_set()
 };
 
 void db_fprint_value (FILE *fp, const db_value *value);

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -43,8 +43,6 @@
 
 #define DB_CURRENCY_DEFAULT db_get_currency_default()
 
-#define db_set db_collection
-
 #define db_make_utime db_make_timestamp
 
 #define DB_VALUE_CLONE_AS_NULL(src_value, dest_value)                   \

--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -30,6 +30,7 @@
 
 #define DB_CURRENCY_DEFAULT db_get_currency_default()
 
+// for backward compatibility
 #define db_set db_collection
 
 #define db_make_utime db_make_timestamp

--- a/src/object/work_space.h
+++ b/src/object/work_space.h
@@ -35,6 +35,10 @@
 #include "locator.h"
 #include "dbtype_def.h"
 
+#if defined (SERVER_MODE)
+#error does not belong to server
+#endif // SERVER_MODE
+
 /*
  * VID_INFO
  *    typedefs for virtual objects.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23452

remove unused struct db_collection from engine code to avoid confusions; it is kept only as a definition in API headers.