### PR TITLE
[CBRD-23455] Always create object hash for unloaddb

### DIFF
--- a/src/executables/unload_object.c
+++ b/src/executables/unload_object.c
@@ -854,17 +854,14 @@ extract_objects (const char *exec_name, const char *output_dirname, const char *
   /*
    * Create the hash table
    */
-  if (has_obj_ref || num_cls_ref > 0)
-    {				/* found any referenced domain */
-      obj_table =
-	fh_create ("object hash", est_size, page_size, cached_pages, hash_filename, FH_OID_KEY, DB_SIZEOF (int),
-		   oid_hash, oid_compare_equals);
+  obj_table =
+    fh_create ("object hash", est_size, page_size, cached_pages, hash_filename, FH_OID_KEY, DB_SIZEOF (int),
+	       oid_hash, oid_compare_equals);
 
-      if (obj_table == NULL)
-	{
-	  status = 1;
-	  goto end;
-	}
+  if (obj_table == NULL)
+    {
+      status = 1;
+      goto end;
     }
 
   /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23455

Always create object hash for unloaddb.
