### PR TITLE
[CBRD-23444] change signature of db_make_string/db_make_db_char to accept const char *

### DIFF
--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -2626,7 +2626,7 @@ lang_db_put_charset (void)
   server_lang = lang_id ();
 
   AU_DISABLE (au_save);
-  db_make_string_by_const_str (&value, lang_get_lang_name_from_id (server_lang));
+  db_make_string (&value, lang_get_lang_name_from_id (server_lang));
   if (db_put_internal (Au_root, "lang", &value) != NO_ERROR)
     {
       /* Error Setting the language */

--- a/src/base/tz_support.c
+++ b/src/base/tz_support.c
@@ -4736,7 +4736,7 @@ tz_timezones_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg
 	  goto exit_on_error;
 	}
       /* Geographic timezone name */
-      db_make_string_by_const_str (&vals[0], tzd->names[i].name);
+      db_make_string (&vals[0], tzd->names[i].name);
     }
 
   *ptr = ctx;
@@ -4821,7 +4821,7 @@ tz_full_timezones_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE *
 	  goto exit_on_error;
 	}
       /* Geographic timezone name */
-      db_make_string_by_const_str (&vals[idx++], tzd->names[i].name);
+      db_make_string (&vals[idx++], tzd->names[i].name);
 
       /* First get the zone id */
       zone_id = i;

--- a/src/compat/cnv.c
+++ b/src/compat/cnv.c
@@ -6649,7 +6649,7 @@ db_string_value (const char *string, int str_size, const char *format, DB_VALUE 
 	case DB_TYPE_CHAR:
 	  {
 	    int size = strlen (string);
-	    db_make_char (value, size, (char *) string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_char (value, size, string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	    next = string + size;
 	    break;
 	  }
@@ -6657,7 +6657,7 @@ db_string_value (const char *string, int str_size, const char *format, DB_VALUE 
 	case DB_TYPE_VARCHAR:
 	  {
 	    int size = strlen (string);
-	    db_make_varchar (value, size, (char *) string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_varchar (value, size, string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	    next = string + size;
 	    break;
 	  }
@@ -6666,7 +6666,7 @@ db_string_value (const char *string, int str_size, const char *format, DB_VALUE 
 	  {
 	    int size;
 	    intl_char_count ((unsigned char *) string, strlen (string), LANG_SYS_CODESET, &size);
-	    db_make_nchar (value, size, (char *) string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_nchar (value, size, string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	    next = string + strlen (string);
 	    break;
 	  }
@@ -6675,7 +6675,7 @@ db_string_value (const char *string, int str_size, const char *format, DB_VALUE 
 	  {
 	    int char_count;
 	    intl_char_count ((unsigned char *) string, strlen (string), LANG_SYS_CODESET, &char_count);
-	    db_make_varnchar (value, char_count, (char *) string, char_count, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_varnchar (value, char_count, string, char_count, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	    next = string + strlen (string);
 	    break;
 	  }

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1977,7 +1977,7 @@ db_json_search_func (const JSON_DOC &doc, const DB_VALUE *pattern, const DB_VALU
   const std::string encoded_pattern = db_json_json_string_as_utf8 (raw_json_string);
 
   DB_VALUE encoded_pattern_dbval;
-  db_make_string (&encoded_pattern_dbval, const_cast<char *> (encoded_pattern.c_str ()));
+  db_make_string (&encoded_pattern_dbval, encoded_pattern.c_str ());
   db_string_put_cs_and_collation (&encoded_pattern_dbval, INTL_CODESET_UTF8, LANG_COLL_UTF8_BINARY);
 
   const map_func_type &f_search = [&json_paths, &paths, &encoded_pattern_dbval, esc_char, find_all] (const JSON_VALUE &jv,
@@ -1991,7 +1991,7 @@ db_json_search_func (const JSON_DOC &doc, const DB_VALUE *pattern, const DB_VALU
     const char *json_str = jv.GetString ();
     DB_VALUE str_val;
 
-    db_make_string (&str_val, (char *) json_str);
+    db_make_string (&str_val, json_str);
     db_string_put_cs_and_collation (&str_val, INTL_CODESET_UTF8, LANG_COLL_UTF8_BINARY);
 
     int match;

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -4913,9 +4913,8 @@ valcnv_convert_value_to_string (DB_VALUE * value_p)
 	  return ER_FAILED;
 	}
 
-      // TODO -Wwrite-strings
-      //db_make_varchar (&src_value, DB_MAX_STRING_LENGTH, buf_p->bytes, CAST_STRLEN (buf_p->length), LANG_SYS_CODESET,
-      // LANG_SYS_COLLATION);
+      db_make_varchar (&src_value, DB_MAX_STRING_LENGTH, REINTERPRET_CAST (char *, buf_p->bytes),
+		       CAST_STRLEN (buf_p->length), LANG_SYS_CODESET, LANG_SYS_COLLATION);
 
       pr_clear_value (value_p);
       tp_String.setval (value_p, &src_value, true);

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -834,7 +834,7 @@ db_value_domain_default (DB_VALUE * value, const DB_TYPE type,
       break;
     case DB_TYPE_BIT:
     case DB_TYPE_VARBIT:
-      db_make_bit (value, 1, (DB_C_BIT) "0", 1);
+      db_make_bit (value, 1, "0", 1);
       break;
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
@@ -4913,8 +4913,9 @@ valcnv_convert_value_to_string (DB_VALUE * value_p)
 	  return ER_FAILED;
 	}
 
-      db_make_varchar (&src_value, DB_MAX_STRING_LENGTH,
-		       (char *) buf_p->bytes, CAST_STRLEN (buf_p->length), LANG_SYS_CODESET, LANG_SYS_COLLATION);
+      // TODO -Wwrite-strings
+      //db_make_varchar (&src_value, DB_MAX_STRING_LENGTH, buf_p->bytes, CAST_STRLEN (buf_p->length), LANG_SYS_CODESET,
+      // LANG_SYS_COLLATION);
 
       pr_clear_value (value_p);
       tp_String.setval (value_p, &src_value, true);
@@ -4990,7 +4991,7 @@ db_convert_json_into_scalar (const DB_VALUE * src, DB_VALUE * dest)
     case DB_JSON_STRING:
       {
 	const char *str = db_json_get_string_from_document (doc);
-	int error_code = db_make_string_by_const_str (dest, str);
+	int error_code = db_make_string (dest, str);
 	if (error_code != NO_ERROR)
 	  {
 	    ASSERT_ERROR ();

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -1151,8 +1151,11 @@ extern "C"
   typedef float DB_C_FLOAT;
   typedef double DB_C_DOUBLE;
   typedef char *DB_C_CHAR;
+  typedef const char *DB_CONST_C_CHAR;
   typedef char *DB_C_NCHAR;
+  typedef const char *DB_CONST_C_NCHAR;
   typedef char *DB_C_BIT;
+  typedef const char *DB_CONST_C_BIT;
   typedef DB_OBJECT DB_C_OBJECT;
   typedef DB_COLLECTION DB_C_SET;
   typedef DB_COLLECTION DB_C_COLLECTION;

--- a/src/compat/dbtype_function.c
+++ b/src/compat/dbtype_function.c
@@ -35,7 +35,8 @@
 #include "system_parameter.h"
 
 // hidden functions (suppress -Wmissing-prototypes and -Wimplicit-function-declaration)
-int db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collation_id, char *str, const int size);
+int db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collation_id, const char *str,
+		     const int size);
 DB_TYPE setobj_type (struct setobj *set);
 
 #include "dbtype_function.i"

--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -372,23 +372,23 @@ extern "C"
   extern int db_make_short (DB_VALUE * value, const DB_C_SHORT num);
   extern int db_make_bigint (DB_VALUE * value, const DB_BIGINT num);
   extern int db_make_numeric (DB_VALUE * value, const DB_C_NUMERIC num, const int precision, const int scale);
-  extern int db_make_bit (DB_VALUE * value, const int bit_length, const DB_C_BIT bit_str, const int bit_str_bit_size);
-  extern int db_make_varbit (DB_VALUE * value, const int max_bit_length, const DB_C_BIT bit_str,
+  extern int db_make_bit (DB_VALUE * value, const int bit_length, DB_CONST_C_BIT bit_str, const int bit_str_bit_size);
+  extern int db_make_varbit (DB_VALUE * value, const int max_bit_length, DB_CONST_C_BIT bit_str,
 			     const int bit_str_bit_size);
-  extern int db_make_char (DB_VALUE * value, const int char_length, const DB_C_CHAR str, const int char_str_byte_size,
+  extern int db_make_char (DB_VALUE * value, const int char_length, DB_CONST_C_CHAR str, const int char_str_byte_size,
 			   const int codeset, const int collation_id);
-  extern int db_make_varchar (DB_VALUE * value, const int max_char_length, const DB_C_CHAR str,
+  extern int db_make_varchar (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str,
 			      const int char_str_byte_size, const int codeset, const int collation_id);
-  extern int db_make_nchar (DB_VALUE * value, const int nchar_length, const DB_C_NCHAR str,
+  extern int db_make_nchar (DB_VALUE * value, const int nchar_length, DB_CONST_C_NCHAR str,
 			    const int nchar_str_byte_size, const int codeset, const int collation_id);
-  extern int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, const DB_C_NCHAR str,
+  extern int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR str,
 			       const int nchar_str_byte_size, const int codeset, const int collation_id);
   extern int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size,
 				  unsigned char codeset, const int collation_id);
   extern int db_make_resultset (DB_VALUE * value, const DB_RESULTSET handle);
 
-  extern int db_make_string (DB_VALUE * value, char *str);
-  extern int db_make_string_copy (DB_VALUE * value, const char *str);
+  extern int db_make_string (DB_VALUE * value, DB_CONST_C_CHAR str);
+  extern int db_make_string_copy (DB_VALUE * value, DB_CONST_C_CHAR str);
 
   extern int db_make_oid (DB_VALUE * value, const OID * oid);
 

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -66,7 +66,7 @@ STATIC_INLINE int db_value_precision (const DB_VALUE * value) __attribute__ ((AL
 STATIC_INLINE int db_value_scale (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE JSON_DOC *db_get_json_document (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 
-STATIC_INLINE int db_make_db_char (DB_VALUE * value, INTL_CODESET codeset, const int collation_id, char *str,
+STATIC_INLINE int db_make_db_char (DB_VALUE * value, INTL_CODESET codeset, const int collation_id, DB_CONST_C_CHAR str,
 				   const int size) __attribute__ ((ALWAYS_INLINE));
 
 STATIC_INLINE int db_make_null (DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
@@ -93,32 +93,28 @@ STATIC_INLINE int db_make_short (DB_VALUE * value, const DB_C_SHORT num) __attri
 STATIC_INLINE int db_make_bigint (DB_VALUE * value, const DB_BIGINT num) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_numeric (DB_VALUE * value, const DB_C_NUMERIC num, const int precision, const int scale)
   __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_bit (DB_VALUE * value, const int bit_length, const DB_C_BIT bit_str,
+STATIC_INLINE int db_make_bit (DB_VALUE * value, const int bit_length, DB_CONST_C_BIT bit_str,
 			       const int bit_str_bit_size) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_varbit (DB_VALUE * value, const int max_bit_length, const DB_C_BIT bit_str,
+STATIC_INLINE int db_make_varbit (DB_VALUE * value, const int max_bit_length, DB_CONST_C_BIT bit_str,
 				  const int bit_str_bit_size) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_char (DB_VALUE * value, const int char_length, const DB_C_CHAR str,
+STATIC_INLINE int db_make_char (DB_VALUE * value, const int char_length, DB_CONST_C_CHAR str,
 				const int char_str_byte_size, const int codeset, const int collation_id)
   __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_varchar (DB_VALUE * value, const int max_char_length, const DB_C_CHAR str,
+STATIC_INLINE int db_make_varchar (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str,
 				   const int char_str_byte_size, const int codeset, const int collation_id)
   __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_nchar (DB_VALUE * value, const int nchar_length, const DB_C_NCHAR str,
+STATIC_INLINE int db_make_nchar (DB_VALUE * value, const int nchar_length, DB_CONST_C_NCHAR str,
 				 const int nchar_str_byte_size, const int codeset, const int collation_id)
   __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, const DB_C_NCHAR str,
+STATIC_INLINE int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR str,
 				    const int nchar_str_byte_size, const int codeset, const int collation_id)
   __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size,
 				       unsigned char codeset, const int collation_id) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_resultset (DB_VALUE * value, const DB_RESULTSET handle) __attribute__ ((ALWAYS_INLINE));
 
-STATIC_INLINE int db_make_string (DB_VALUE * value, char *str) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_string_copy (DB_VALUE * value, const char *str) __attribute__ ((ALWAYS_INLINE));
-
-// TODO: It is ugly but I would like to separate the existing usages of db_make_string_copy from those of const str.
-// In some day, we may need a way to make db_value without copying const str. Hope this helps for future refactoring.
-#define db_make_string_by_const_str db_make_string_copy
+STATIC_INLINE int db_make_string (DB_VALUE * value, DB_CONST_C_CHAR str) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE int db_make_string_copy (DB_VALUE * value, DB_CONST_C_CHAR str) __attribute__ ((ALWAYS_INLINE));
 
 STATIC_INLINE int db_make_oid (DB_VALUE * value, const OID * oid) __attribute__ ((ALWAYS_INLINE));
 
@@ -997,7 +993,8 @@ db_get_json_document (const DB_VALUE * value)
  * size(in):
  */
 int
-db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collation_id, char *str, const int size)
+db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collation_id, DB_CONST_C_CHAR str,
+		 const int size)
 {
 #if defined (API_ACTIVE_CHECKS)
   CHECK_1ARG_ERROR (value);
@@ -1559,7 +1556,7 @@ db_make_numeric (DB_VALUE * value, const DB_C_NUMERIC num, const int precision, 
  * bit_str_bit_size(in):
  */
 int
-db_make_bit (DB_VALUE * value, const int bit_length, const DB_C_BIT bit_str, const int bit_str_bit_size)
+db_make_bit (DB_VALUE * value, const int bit_length, DB_CONST_C_BIT bit_str, const int bit_str_bit_size)
 {
   int error;
 
@@ -1586,7 +1583,7 @@ db_make_bit (DB_VALUE * value, const int bit_length, const DB_C_BIT bit_str, con
  * bit_str_bit_size(in):
  */
 int
-db_make_varbit (DB_VALUE * value, const int max_bit_length, const DB_C_BIT bit_str, const int bit_str_bit_size)
+db_make_varbit (DB_VALUE * value, const int max_bit_length, DB_CONST_C_BIT bit_str, const int bit_str_bit_size)
 {
   int error;
 
@@ -1614,8 +1611,8 @@ db_make_varbit (DB_VALUE * value, const int max_bit_length, const DB_C_BIT bit_s
  * char_str_byte_size(in):
  */
 int
-db_make_char (DB_VALUE * value, const int char_length, const DB_C_CHAR str,
-	      const int char_str_byte_size, const int codeset, const int collation_id)
+db_make_char (DB_VALUE * value, const int char_length, DB_CONST_C_CHAR str, const int char_str_byte_size,
+	      const int codeset, const int collation_id)
 {
   int error;
 
@@ -1641,8 +1638,8 @@ db_make_char (DB_VALUE * value, const int char_length, const DB_C_CHAR str,
  * char_str_byte_size(in):
  */
 int
-db_make_varchar (DB_VALUE * value, const int max_char_length,
-		 const DB_C_CHAR str, const int char_str_byte_size, const int codeset, const int collation_id)
+db_make_varchar (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str, const int char_str_byte_size,
+		 const int codeset, const int collation_id)
 {
   int error;
 
@@ -1668,8 +1665,8 @@ db_make_varchar (DB_VALUE * value, const int max_char_length,
  * nchar_str_byte_size(in):
  */
 int
-db_make_nchar (DB_VALUE * value, const int nchar_length, const DB_C_NCHAR str,
-	       const int nchar_str_byte_size, const int codeset, const int collation_id)
+db_make_nchar (DB_VALUE * value, const int nchar_length, DB_CONST_C_NCHAR str, const int nchar_str_byte_size,
+	       const int codeset, const int collation_id)
 {
   int error;
 
@@ -1695,8 +1692,8 @@ db_make_nchar (DB_VALUE * value, const int nchar_length, const DB_C_NCHAR str,
  * nchar_str_byte_size(in):
  */
 int
-db_make_varnchar (DB_VALUE * value, const int max_nchar_length,
-		  const DB_C_NCHAR str, const int nchar_str_byte_size, const int codeset, const int collation_id)
+db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR str, const int nchar_str_byte_size,
+		  const int codeset, const int collation_id)
 {
   int error;
 
@@ -1724,8 +1721,8 @@ db_make_varnchar (DB_VALUE * value, const int max_nchar_length,
  * collation_id(in):
  */
 int
-db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str,
-		     int size, unsigned char codeset, const int collation_id)
+db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size, unsigned char codeset,
+		     const int collation_id)
 {
 #if defined (API_ACTIVE_CHECKS)
   CHECK_1ARG_ERROR (value);
@@ -1805,7 +1802,7 @@ db_make_oid (DB_VALUE * value, const OID * oid)
  * str(in):
  */
 int
-db_make_string (DB_VALUE * value, char *str)
+db_make_string (DB_VALUE * value, DB_CONST_C_CHAR str)
 {
   int error;
   int size;
@@ -1838,7 +1835,7 @@ db_make_string (DB_VALUE * value, char *str)
  * str(in):
  */
 int
-db_make_string_copy (DB_VALUE * value, const char *str)
+db_make_string_copy (DB_VALUE * value, DB_CONST_C_CHAR str)
 {
   int error;
   char *copy_str;
@@ -1857,7 +1854,7 @@ db_make_string_copy (DB_VALUE * value, const char *str)
 
   if (copy_str == NULL)
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, strlen(str) + 1);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, strlen (str) + 1);
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
@@ -1865,6 +1862,7 @@ db_make_string_copy (DB_VALUE * value, const char *str)
 
   if (error != NO_ERROR)
     {
+      db_private_free (NULL, copy_str);
       return error;
     }
 
@@ -2166,8 +2164,6 @@ db_set_compressed_string (DB_VALUE * value, char *compressed_string, int compres
   value->data.ch.medium.compressed_buf = compressed_string;
   value->data.ch.medium.compressed_size = compressed_size;
   value->data.ch.info.compressed_need_clear = compressed_need_clear;
-
-  return;
 }
 
 /*

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2607,7 +2607,6 @@ css_user_access_status_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE *
       db_make_datetime (&vals[1], &access_time);
 
       db_make_string_copy (&vals[2], access_status->host);
-
       db_make_string_copy (&vals[3], access_status->program_name);
     }
 #endif /* SERVER_MODE */
@@ -2797,7 +2796,6 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
 	  db_make_datetime (&vals[1], &access_time);
 
 	  db_make_string_copy (&vals[2], access_status->host);
-
 	  db_make_string_copy (&vals[3], access_status->program_name);
 	}
       else

--- a/src/jsp/jsp_cl.c
+++ b/src/jsp/jsp_cl.c
@@ -708,7 +708,7 @@ jsp_alter_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * statement)
   /* change the comment */
   if (sp_comment != NULL)
     {
-      db_make_string_by_const_str (&user_val, comment_str);
+      db_make_string (&user_val, comment_str);
       err = obj_set (sp_mop, SP_ATTR_COMMENT, &user_val);
       if (err < 0)
 	{
@@ -835,7 +835,7 @@ jsp_add_stored_procedure_argument (MOP * mop_p, const char *sp_name, const char 
       goto error;
     }
 
-  db_make_string_by_const_str (&value, sp_name);
+  db_make_string (&value, sp_name);
   err = dbt_put_internal (obt_p, SP_ATTR_NAME, &value);
   pr_clear_value (&value);
   if (err != NO_ERROR)
@@ -843,7 +843,7 @@ jsp_add_stored_procedure_argument (MOP * mop_p, const char *sp_name, const char 
       goto error;
     }
 
-  db_make_string_by_const_str (&value, arg_name);
+  db_make_string (&value, arg_name);
   err = dbt_put_internal (obt_p, SP_ATTR_ARG_NAME, &value);
   pr_clear_value (&value);
   if (err != NO_ERROR)
@@ -872,7 +872,7 @@ jsp_add_stored_procedure_argument (MOP * mop_p, const char *sp_name, const char 
       goto error;
     }
 
-  db_make_string_by_const_str (&value, arg_comment);
+  db_make_string (&value, arg_comment);
   err = dbt_put_internal (obt_p, SP_ATTR_ARG_COMMENT, &value);
   pr_clear_value (&value);
   if (err != NO_ERROR)
@@ -1082,7 +1082,7 @@ jsp_add_stored_procedure (const char *name, const PT_MISC_TYPE type, const PT_TY
       goto error;
     }
 
-  db_make_string_by_const_str (&value, java_method);
+  db_make_string (&value, java_method);
   err = dbt_put_internal (obt_p, SP_ATTR_TARGET, &value);
   pr_clear_value (&value);
   if (err != NO_ERROR)
@@ -1098,7 +1098,7 @@ jsp_add_stored_procedure (const char *name, const PT_MISC_TYPE type, const PT_TY
       goto error;
     }
 
-  db_make_string_by_const_str (&value, comment);
+  db_make_string (&value, comment);
   err = dbt_put_internal (obt_p, SP_ATTR_COMMENT, &value);
   pr_clear_value (&value);
   if (err != NO_ERROR)

--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -398,7 +398,7 @@ namespace cubload
     error = db_value_domain_init (val, type, char_count, 0);
     if (error == NO_ERROR)
       {
-	error = db_make_db_char (val, codeset, domain.collation_id, const_cast<char *> (str), str_len);
+	error = db_make_db_char (val, codeset, domain.collation_id, str, str_len);
       }
 
     return error;
@@ -429,7 +429,7 @@ namespace cubload
   int
   to_db_string (const char *str, const size_t str_size, const attribute *attr, db_value *val)
   {
-    return db_make_string (val, const_cast<char *> (str));
+    return db_make_string (val, str);
   }
 
   int

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -2524,7 +2524,7 @@ static int
 ldr_str_elem (LDR_CONTEXT *context, const char *str, size_t len, DB_VALUE *val)
 {
   /* todo: switch this to db_make_string_copy and avoid any possible leaks */
-  db_make_string (val, (char *) str);
+  db_make_string (val, str);
   return NO_ERROR;
 }
 
@@ -2689,7 +2689,7 @@ ldr_str_db_generic (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIB
   DB_VALUE val;
 
   /* todo: switch this to db_make_string_copy and avoid any possible leaks */
-  db_make_string (&val, (char *) str);
+  db_make_string (&val, str);
   return ldr_generic (context, &val);
 }
 
@@ -2873,7 +2873,7 @@ static int
 ldr_nstr_elem (LDR_CONTEXT *context, const char *str, size_t len, DB_VALUE *val)
 {
 
-  db_make_varnchar (val, TP_FLOATING_PRECISION_VALUE, (DB_C_NCHAR) str, (int) len, LANG_SYS_CODESET,
+  db_make_varnchar (val, TP_FLOATING_PRECISION_VALUE, str, (int) len, LANG_SYS_CODESET,
 		    LANG_SYS_COLLATION);
   return NO_ERROR;
 }
@@ -5940,8 +5940,8 @@ ldr_init_loader (LDR_CONTEXT *context)
   db_make_short (&ldr_short_tmpl, 0);
   db_make_int (&ldr_int_tmpl, 0);
   db_make_bigint (&ldr_bigint_tmpl, 0);
-  db_make_char (&ldr_char_tmpl, 1, (char *) "a", 1, LANG_SYS_CODESET, LANG_SYS_COLLATION);
-  db_make_varchar (&ldr_varchar_tmpl, 1, (char *) "a", 1, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+  db_make_char (&ldr_char_tmpl, 1, "a", 1, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+  db_make_varchar (&ldr_varchar_tmpl, 1, "a", 1, LANG_SYS_CODESET, LANG_SYS_COLLATION);
   db_make_float (&ldr_float_tmpl, (float) 0.0);
   db_make_double (&ldr_double_tmpl, (double) 0.0);
   db_make_date (&ldr_date_tmpl, 1, 1, 1996);
@@ -5959,7 +5959,7 @@ ldr_init_loader (LDR_CONTEXT *context)
   db_make_datetimetz (&ldr_datetimetz_tmpl, &datetimetz);
   db_make_elo (&ldr_blob_tmpl, DB_TYPE_BLOB, null_elo);
   db_make_elo (&ldr_clob_tmpl, DB_TYPE_CLOB, null_elo);
-  db_make_bit (&ldr_bit_tmpl, 1, (DB_C_BIT) "0", 1);
+  db_make_bit (&ldr_bit_tmpl, 1, "0", 1);
   db_make_json (&ldr_json_tmpl, NULL, false);
 
   /*

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -1543,7 +1543,7 @@ au_set_new_auth (MOP au_obj, MOP grantor, MOP user, MOP class_mop, DB_AUTH auth_
       return er_errid ();
     }
 
-  db_make_string_by_const_str (&class_name_val, sm_get_ch_name (class_mop));
+  db_make_string (&class_name_val, sm_get_ch_name (class_mop));
   db_class_inst = obj_find_unique (db_class, "class_name", &class_name_val, AU_FETCH_READ);
   if (db_class_inst == NULL)
     {
@@ -1560,7 +1560,7 @@ au_set_new_auth (MOP au_obj, MOP grantor, MOP user, MOP class_mop, DB_AUTH auth_
       ;
     }
 
-  db_make_varchar (&value, 7, (char *) type_set[i], strlen (type_set[i]), LANG_SYS_CODESET, LANG_SYS_COLLATION);
+  db_make_varchar (&value, 7, type_set[i], strlen (type_set[i]), LANG_SYS_CODESET, LANG_SYS_COLLATION);
   obj_set (au_obj, "auth_type", &value);
 
   db_make_int (&value, (int) grant_option);
@@ -1646,13 +1646,13 @@ au_get_new_auth (MOP grantor, MOP user, MOP class_mop, DB_AUTH auth_type)
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SM_INVALID_CLASS, 0);
       goto exit;
     }
-  db_make_string_by_const_str (&val[INDEX_FOR_CLASS_NAME], class_name);
+  db_make_string (&val[INDEX_FOR_CLASS_NAME], class_name);
 
   for (type = DB_AUTH_SELECT, i = 0; type != auth_type; type = (DB_AUTH) (type << 1), i++)
     {
       ;
     }
-  db_make_string_by_const_str (&val[INDEX_FOR_AUTH_TYPE], type_set[i]);
+  db_make_string (&val[INDEX_FOR_AUTH_TYPE], type_set[i]);
 
   session = db_open_buffer (sql_query);
   if (session == NULL)
@@ -2047,7 +2047,7 @@ au_delete_auth_of_dropping_table (const char *class_name)
       goto release;
     }
 
-  db_make_string_by_const_str (&val, class_name);
+  db_make_string (&val, class_name);
   error = db_push_values (session, 1, &val);
   if (error != NO_ERROR)
     {
@@ -2836,7 +2836,7 @@ au_set_user_comment (MOP user, const char *comment)
 	}
       else
 	{
-	  db_make_string_by_const_str (&value, comment);
+	  db_make_string (&value, comment);
 	  error = obj_set (user, "comment", &value);
 	  pr_clear_value (&value);
 	}

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -367,7 +367,7 @@ classobj_put_prop (DB_SEQ * properties, const char *name, DB_VALUE * pvalue)
 	{
 	  /* start with the property value to avoid growing the array twice */
 	  set_put_element (properties, max + 1, pvalue);
-	  db_make_string_by_const_str (&value, name);
+	  db_make_string (&value, name);
 	  set_put_element (properties, max, &value);
 	  pr_clear_value (&value);
 	}
@@ -911,7 +911,7 @@ classobj_put_seq_with_name_and_iterate (DB_SEQ * destination, int &index, const 
   int subseq_index = 0;
   int error_code = NO_ERROR;
 
-  db_make_string_by_const_str (&value, name);
+  db_make_string (&value, name);
   classobj_put_value_and_iterate (subseq, subseq_index, value);
 
   error_code = classobj_put_seq_and_iterate (subseq, subseq_index, seq);
@@ -1065,7 +1065,7 @@ classobj_put_index (DB_SEQ ** properties, SM_CONSTRAINT_TYPE type, const char *c
 	}
     }
 
-  db_make_string_by_const_str (&value, pbuf);
+  db_make_string (&value, pbuf);
   classobj_put_value_and_iterate (constraint, constraint_seq_index, value);
 
   if (pbuf && pbuf != &(buf[0]))
@@ -1079,7 +1079,7 @@ classobj_put_index (DB_SEQ ** properties, SM_CONSTRAINT_TYPE type, const char *c
       if (attr_name_instead_of_id)
 	{
 	  /* name */
-	  db_make_string_by_const_str (&value, atts[i]->header.name);
+	  db_make_string (&value, atts[i]->header.name);
 	}
       else
 	{
@@ -1219,7 +1219,7 @@ classobj_put_index (DB_SEQ ** properties, SM_CONSTRAINT_TYPE type, const char *c
   classobj_put_value_and_iterate (constraint, constraint_seq_index, value);
 
   /* comment */
-  db_make_string_by_const_str (&value, comment);
+  db_make_string (&value, comment);
   classobj_put_value_and_iterate (constraint, constraint_seq_index, value);
 
   /* Append the constraint to the unique property sequence */
@@ -1999,7 +1999,7 @@ classobj_change_constraint_comment (DB_SEQ * properties, SM_CLASS_CONSTRAINT * c
       goto end;
     }
 
-  db_make_string_by_const_str (&new_comment, comment);
+  db_make_string (&new_comment, comment);
   error = set_put_element (idx_seq, len - 1, &new_comment);
   if (error != NO_ERROR)
     {

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -5734,19 +5734,19 @@ make_desired_string_db_value (DB_TYPE desired_type, const TP_DOMAIN * desired_do
   switch (desired_type)
     {
     case DB_TYPE_CHAR:
-      db_make_char (&temp, desired_domain->precision, (DB_C_CHAR) new_string, strlen (new_string),
+      db_make_char (&temp, desired_domain->precision, new_string, strlen (new_string),
 		    TP_DOMAIN_CODESET (desired_domain), TP_DOMAIN_COLLATION (desired_domain));
       break;
     case DB_TYPE_NCHAR:
-      db_make_nchar (&temp, desired_domain->precision, (DB_C_NCHAR) new_string, strlen (new_string),
+      db_make_nchar (&temp, desired_domain->precision, new_string, strlen (new_string),
 		     TP_DOMAIN_CODESET (desired_domain), TP_DOMAIN_COLLATION (desired_domain));
       break;
     case DB_TYPE_VARCHAR:
-      db_make_varchar (&temp, desired_domain->precision, (DB_C_CHAR) new_string, strlen (new_string),
+      db_make_varchar (&temp, desired_domain->precision, new_string, strlen (new_string),
 		       TP_DOMAIN_CODESET (desired_domain), TP_DOMAIN_COLLATION (desired_domain));
       break;
     case DB_TYPE_VARNCHAR:
-      db_make_varnchar (&temp, desired_domain->precision, (DB_C_NCHAR) new_string, strlen (new_string),
+      db_make_varnchar (&temp, desired_domain->precision, new_string, strlen (new_string),
 			TP_DOMAIN_CODESET (desired_domain), TP_DOMAIN_COLLATION (desired_domain));
       break;
     default:			/* Can't get here.  This just quiets the compiler */
@@ -7152,7 +7152,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_JSON_STRING:
 	  {
 	    const char *json_string = db_json_get_string_from_document (src_doc);
-	    db_make_string_by_const_str (&src_replacement, json_string);
+	    db_make_string (&src_replacement, json_string);
 	  }
 	  break;
 	default:

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -51,7 +51,7 @@ void object_printer::describe_comment (const char *comment)
   assert (comment != NULL);
 
   db_make_null (&comment_value);
-  db_make_string_by_const_str (&comment_value, comment);
+  db_make_string (&comment_value, comment);
 
   m_buf ("COMMENT ");
   if (comment != NULL && comment[0] != '\0')

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -3651,13 +3651,9 @@ static int
 or_packed_json_schema_length (const char *json_schema)
 {
   DB_VALUE val;
-  int len;
-
-  // *INDENT-OFF*
   db_make_string (&val, json_schema);
-  // *INDENT-ON*
 
-  len = tp_String.get_disk_size_of_value (&val);
+  int len = tp_String.get_disk_size_of_value (&val);
 
   pr_clear_value (&val);
 

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -3654,7 +3654,7 @@ or_packed_json_schema_length (const char *json_schema)
   int len;
 
   // *INDENT-OFF*
-  db_make_string (&val, const_cast <char*>(json_schema));
+  db_make_string (&val, json_schema);
   // *INDENT-ON*
 
   len = tp_String.get_disk_size_of_value (&val);
@@ -8152,7 +8152,7 @@ or_put_json_schema (OR_BUF * buf, const char *schema)
     }
   else
     {
-      db_make_string_by_const_str (&schema_raw, schema);
+      db_make_string (&schema_raw, schema);
     }
 
   rc = tp_String.data_writeval (buf, &schema_raw);

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -1486,8 +1486,7 @@ string_disk_size (const char *string)
       str_length = 0;
     }
 
-  db_make_varnchar (&value, TP_FLOATING_PRECISION_VALUE, (DB_C_NCHAR) string, str_length, LANG_SYS_CODESET,
-		    LANG_SYS_COLLATION);
+  db_make_varnchar (&value, TP_FLOATING_PRECISION_VALUE, string, str_length, LANG_SYS_CODESET, LANG_SYS_COLLATION);
   length = tp_VarNChar.get_disk_size_of_value (&value);
 
   /* Clear the compressed_string of DB_VALUE */
@@ -1570,8 +1569,7 @@ put_string (OR_BUF * buf, const char *string)
       str_length = 0;
     }
 
-  db_make_varnchar (&value, TP_FLOATING_PRECISION_VALUE, (DB_C_NCHAR) string, str_length, LANG_SYS_CODESET,
-		    LANG_SYS_COLLATION);
+  db_make_varnchar (&value, TP_FLOATING_PRECISION_VALUE, string, str_length, LANG_SYS_CODESET, LANG_SYS_COLLATION);
   tp_VarNChar.data_writeval (buf, &value);
   pr_clear_value (&value);
 }
@@ -2108,7 +2106,7 @@ domain_to_disk (OR_BUF * buf, TP_DOMAIN * domain)
 
   if (domain->json_validator)
     {
-      db_make_string_by_const_str (&schema_value, db_json_get_schema_raw_from_validator (domain->json_validator));
+      db_make_string (&schema_value, db_json_get_schema_raw_from_validator (domain->json_validator));
       tp_String.data_writeval (buf, &schema_value);
       pr_clear_value (&schema_value);
     }

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -4802,7 +4802,7 @@ qo_set_cost (DB_OBJECT * target, DB_VALUE * result, DB_VALUE * plan, DB_VALUE * 
   plan_string = qo_plan_set_cost_fn (plan_string, cost_string[0]);
   if (plan_string != NULL)
     {
-      db_make_string_by_const_str (result, plan_string);
+      db_make_string (result, plan_string);
     }
   else
     {

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -3407,18 +3407,18 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 
     case PT_TYPE_NCHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      // TODO -Wwrite-strings
-      //db_make_nchar (db_value, TP_FLOATING_PRECISION_VALUE, value->info.value.data_value.str->bytes,
-      //value->info.value.data_value.str->length, codeset, collation_id);
+      db_make_nchar (db_value, TP_FLOATING_PRECISION_VALUE,
+		     REINTERPRET_CAST (char *, value->info.value.data_value.str->bytes),
+		     value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);
       break;
 
     case PT_TYPE_VARNCHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      // TODO -Wwrite-strings
-      //db_make_varnchar (db_value, TP_FLOATING_PRECISION_VALUE, value->info.value.data_value.str->bytes,
-      //value->info.value.data_value.str->length, codeset, collation_id);
+      db_make_varnchar (db_value, TP_FLOATING_PRECISION_VALUE,
+			REINTERPRET_CAST (char *, value->info.value.data_value.str->bytes),
+			value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);
       break;
@@ -3483,18 +3483,18 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 
     case PT_TYPE_CHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      // TODO -Wwrite-strings
-      //db_make_char (db_value, TP_FLOATING_PRECISION_VALUE, value->info.value.data_value.str->bytes,
-      //value->info.value.data_value.str->length, codeset, collation_id);
+      db_make_char (db_value, TP_FLOATING_PRECISION_VALUE,
+		    REINTERPRET_CAST (char *, value->info.value.data_value.str->bytes),
+		    value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);
       break;
 
     case PT_TYPE_VARCHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      // TODO -Wwrite-strings
-      //db_make_varchar (db_value, TP_FLOATING_PRECISION_VALUE, value->info.value.data_value.str->bytes,
-      //value->info.value.data_value.str->length, codeset, collation_id);
+      db_make_varchar (db_value, TP_FLOATING_PRECISION_VALUE,
+		       REINTERPRET_CAST (char *, value->info.value.data_value.str->bytes),
+		       value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);
       break;

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -3407,16 +3407,18 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 
     case PT_TYPE_NCHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      db_make_nchar (db_value, TP_FLOATING_PRECISION_VALUE, (DB_C_NCHAR) value->info.value.data_value.str->bytes,
-		     value->info.value.data_value.str->length, codeset, collation_id);
+      // TODO -Wwrite-strings
+      //db_make_nchar (db_value, TP_FLOATING_PRECISION_VALUE, value->info.value.data_value.str->bytes,
+      //value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);
       break;
 
     case PT_TYPE_VARNCHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      db_make_varnchar (db_value, TP_FLOATING_PRECISION_VALUE, (DB_C_NCHAR) value->info.value.data_value.str->bytes,
-			value->info.value.data_value.str->length, codeset, collation_id);
+      // TODO -Wwrite-strings
+      //db_make_varnchar (db_value, TP_FLOATING_PRECISION_VALUE, value->info.value.data_value.str->bytes,
+      //value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);
       break;
@@ -3481,16 +3483,18 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 
     case PT_TYPE_CHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      db_make_char (db_value, TP_FLOATING_PRECISION_VALUE, (DB_C_CHAR) value->info.value.data_value.str->bytes,
-		    value->info.value.data_value.str->length, codeset, collation_id);
+      // TODO -Wwrite-strings
+      //db_make_char (db_value, TP_FLOATING_PRECISION_VALUE, value->info.value.data_value.str->bytes,
+      //value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);
       break;
 
     case PT_TYPE_VARCHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      db_make_varchar (db_value, TP_FLOATING_PRECISION_VALUE, (DB_C_CHAR) value->info.value.data_value.str->bytes,
-		       value->info.value.data_value.str->length, codeset, collation_id);
+      // TODO -Wwrite-strings
+      //db_make_varchar (db_value, TP_FLOATING_PRECISION_VALUE, value->info.value.data_value.str->bytes,
+      //value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);
       break;

--- a/src/parser/parse_evaluate.c
+++ b/src/parser/parse_evaluate.c
@@ -1177,12 +1177,12 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 		case PT_RTRIM:
 		  if (type1 == PT_TYPE_NCHAR || type1 == PT_TYPE_VARNCHAR)
 		    {
-		      db_make_varnchar (&opd2, 1, (char *) " ", 1, opd1_cs, opd1_coll);
+		      db_make_varnchar (&opd2, 1, " ", 1, opd1_cs, opd1_coll);
 		      type2 = PT_TYPE_VARNCHAR;
 		    }
 		  else
 		    {
-		      db_make_varchar (&opd2, 1, (char *) " ", 1, opd1_cs, opd1_coll);
+		      db_make_varchar (&opd2, 1, " ", 1, opd1_cs, opd1_coll);
 		      type2 = PT_TYPE_VARCHAR;
 		    }
 		  break;
@@ -1211,12 +1211,12 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 		case PT_TRANSLATE:
 		  if (type1 == PT_TYPE_NCHAR || type1 == PT_TYPE_VARNCHAR)
 		    {
-		      db_make_varnchar (&opd3, 1, (char *) "", 0, opd1_cs, opd1_coll);
+		      db_make_varnchar (&opd3, 1, "", 0, opd1_cs, opd1_coll);
 		      type3 = PT_TYPE_VARNCHAR;
 		    }
 		  else
 		    {
-		      db_make_varchar (&opd3, 1, (char *) "", 0, opd1_cs, opd1_coll);
+		      db_make_varchar (&opd3, 1, "", 0, opd1_cs, opd1_coll);
 		      type3 = PT_TYPE_VARCHAR;
 		    }
 		  break;
@@ -1224,12 +1224,12 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 		case PT_RPAD:
 		  if (type1 == PT_TYPE_NCHAR || type1 == PT_TYPE_VARNCHAR)
 		    {
-		      db_make_varnchar (&opd3, 1, (char *) " ", 1, opd1_cs, opd1_coll);
+		      db_make_varnchar (&opd3, 1, " ", 1, opd1_cs, opd1_coll);
 		      type2 = PT_TYPE_VARNCHAR;
 		    }
 		  else
 		    {
-		      db_make_varchar (&opd3, 1, (char *) " ", 1, opd1_cs, opd1_coll);
+		      db_make_varchar (&opd3, 1, " ", 1, opd1_cs, opd1_coll);
 		      type2 = PT_TYPE_VARCHAR;
 		    }
 		  break;

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -7703,7 +7703,7 @@ pt_make_query_show_index (PARSER_CONTEXT * parser, PT_NODE * original_cls_id)
 			   LANG_SYS_COLLATION, NULL);
   db_value_domain_default (db_valuep + 11, DB_TYPE_VARCHAR, DB_DEFAULT_PRECISION, 0, LANG_SYS_CODESET,
 			   LANG_SYS_COLLATION, NULL);
-  db_make_varchar (db_valuep + 12, DB_DEFAULT_PRECISION, (DB_C_CHAR) "", 0, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+  db_make_varchar (db_valuep + 12, DB_DEFAULT_PRECISION, "", 0, LANG_SYS_CODESET, LANG_SYS_COLLATION);
   db_value_domain_default (db_valuep + 13, DB_TYPE_VARCHAR, DB_DEFAULT_PRECISION, 0, LANG_SYS_CODESET,
 			   LANG_SYS_COLLATION, NULL);
 

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -17724,7 +17724,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
       {
 	const char *username = au_user_name ();
 
-	error = db_make_string_by_const_str (result, username);
+	error = db_make_string (result, username);
 	db_string_free ((char *) username);
 	if (error < 0)
 	  {
@@ -18294,11 +18294,11 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		if (arg1->domain.general_info.type == DB_TYPE_NCHAR
 		    || arg1->domain.general_info.type == DB_TYPE_VARNCHAR)
 		  {
-		    db_make_nchar (esc_char, 1, (DB_C_NCHAR) slash_str, 1, arg1_cs, arg1_coll);
+		    db_make_nchar (esc_char, 1, slash_str, 1, arg1_cs, arg1_coll);
 		  }
 		else
 		  {
-		    db_make_char (esc_char, 1, (DB_C_CHAR) slash_str, 1, arg1_cs, arg1_coll);
+		    db_make_char (esc_char, 1, slash_str, 1, arg1_cs, arg1_coll);
 		  }
 
 		esc_char->need_clear = false;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -5682,7 +5682,7 @@ mq_set_non_updatable_oid (PARSER_CONTEXT * parser, PT_NODE * stmt, PT_NODE * vir
 	  select_list->type_enum = PT_TYPE_OBJECT;
 
 	  /* set vclass_name as literal string */
-	  db_make_string_by_const_str (&vid, db_get_class_name (virt_entity->info.name.db_object));
+	  db_make_string (&vid, db_get_class_name (virt_entity->info.name.db_object));
 	  select_list->info.function.arg_list = pt_dbval_to_value (parser, &vid);
 	  select_list->info.function.function_type = F_SEQUENCE;
 

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -4351,7 +4351,7 @@ db_typeof_dbval (DB_VALUE * result, DB_VALUE * value)
       break;
 
     default:
-      db_make_string_by_const_str (result, type_name);
+      db_make_string (result, type_name);
     }
 
   return NO_ERROR;
@@ -5176,7 +5176,7 @@ db_evaluate_json_type_dbval (DB_VALUE * result, DB_VALUE * const *arg, int const
       type = db_json_get_type_as_str (doc.get_immutable ());
       length = strlen (type);
 
-      return db_make_varchar (result, length, (DB_C_CHAR) type, length, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
+      return db_make_varchar (result, length, type, length, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
     }
 }
 
@@ -6261,7 +6261,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
   const DB_VALUE *esc_char = nullptr;
   const char * slash_str = "\\";
   DB_VALUE default_slash_str_dbval;
-  
+
   if (num_args >= 4)
     {
       esc_char = args[3];
@@ -6272,7 +6272,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
       if (prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) == false)
       {
 	 // This is equivalent to compat_mode=mysql. In this mode '\\' is default escape character for LIKE pattern
-	 db_make_string (&default_slash_str_dbval, const_cast<char *> (slash_str));
+	 db_make_string (&default_slash_str_dbval, slash_str);
 	 esc_char = &default_slash_str_dbval;
       }
     }
@@ -6464,7 +6464,7 @@ is_str_find_all (DB_VALUE * val, bool & find_all)
   std::string find_all_str (db_get_string (val), db_get_string_size (val));
   std::transform (find_all_str.begin (), find_all_str.end (), find_all_str.begin (), [] (unsigned char c)
   {
-    return std::tolower (c); 
+    return std::tolower (c);
   });
   // *INDENT-ON*
 

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -9734,8 +9734,8 @@ do_alter_change_owner (PARSER_CONTEXT * const parser, PT_NODE * const alter)
 
   db_make_null (&returnval);
 
-  db_make_string_by_const_str (&class_val, class_->info.name.original);
-  db_make_string_by_const_str (&user_val, user->info.name.original);
+  db_make_string (&class_val, class_->info.name.original);
+  db_make_string (&user_val, user->info.name.original);
 
   au_change_owner_method (obj, &returnval, &class_val, &user_val);
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -670,7 +670,7 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
     }
 
   /* name */
-  db_make_string_by_const_str (&value, serial_name);
+  db_make_string (&value, serial_name);
   error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_NAME, &value);
   pr_clear_value (&value);
   if (error != NO_ERROR)
@@ -734,7 +734,7 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
     }
 
   /* comment */
-  db_make_string_by_const_str (&value, comment);
+  db_make_string (&value, comment);
   error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_COMMENT, &value);
   pr_clear_value (&value);
   if (error != NO_ERROR)
@@ -745,7 +745,7 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
   /* class name */
   if (class_name)
     {
-      db_make_string_by_const_str (&value, class_name);
+      db_make_string (&value, class_name);
       error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_CLASS_NAME, &value);
       pr_clear_value (&value);
       if (error != NO_ERROR)
@@ -757,7 +757,7 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
   /* att name */
   if (att_name)
     {
-      db_make_string_by_const_str (&value, att_name);
+      db_make_string (&value, att_name);
       error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_ATT_NAME, &value);
       pr_clear_value (&value);
       if (error != NO_ERROR)
@@ -880,7 +880,7 @@ do_update_auto_increment_serial_on_rename (MOP serial_obj, const char *class_nam
 
   /* class name */
   pr_clear_value (&value);
-  db_make_string_by_const_str (&value, class_name);
+  db_make_string (&value, class_name);
   error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_CLASS_NAME, &value);
   pr_clear_value (&value);
   if (error != NO_ERROR)
@@ -889,7 +889,7 @@ do_update_auto_increment_serial_on_rename (MOP serial_obj, const char *class_nam
     }
 
   /* att name */
-  db_make_string_by_const_str (&value, att_name);
+  db_make_string (&value, att_name);
   error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_ATT_NAME, &value);
   pr_clear_value (&value);
   if (error != NO_ERROR)
@@ -2781,7 +2781,7 @@ do_alter_serial (PARSER_CONTEXT * parser, PT_NODE * statement)
     {
       assert (statement->info.serial.comment->node_type == PT_VALUE);
       comment = (char *) PT_VALUE_GET_BYTES (statement->info.serial.comment);
-      db_make_string_by_const_str (&value, comment);
+      db_make_string (&value, comment);
       error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_COMMENT, &value);
       pr_clear_value (&value);
       if (error < 0)
@@ -6504,8 +6504,8 @@ do_alter_trigger (PARSER_CONTEXT * parser, PT_NODE * statement)
 
 		  db_make_null (&returnval);
 
-		  db_make_string_by_const_str (&trigger_name_val, trigger_name->info.name.original);
-		  db_make_string_by_const_str (&user_val, trigger_owner_name);
+		  db_make_string (&trigger_name_val, trigger_name->info.name.original);
+		  db_make_string (&user_val, trigger_owner_name);
 
 		  au_change_trigger_owner_method (t->op, &returnval, &trigger_name_val, &user_val);
 
@@ -13828,7 +13828,7 @@ dbmeth_class_name (DB_OBJECT * self, DB_VALUE * result)
    * course, this gives the responsibility for freeing the cloned
    * string to someone else; is anybody accepting it?
    */
-  db_make_string_by_const_str (result, cname);
+  db_make_string (result, cname);
 }
 
 /*

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15383,8 +15383,8 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 			}
 
 		      /* set parent tuple position pseudocolumn value */
-		      db_make_bit (parent_pos_valp, DB_DEFAULT_PRECISION, (DB_C_BIT) (&parent_pos),
-				   sizeof (parent_pos) * 8);
+		      // TODO -Wwrite-strings
+		      // db_make_bit (parent_pos_valp, DB_DEFAULT_PRECISION, &parent_pos, sizeof (parent_pos) * 8);
 
 		      parent_tuple_added = true;
 		    }
@@ -16892,8 +16892,9 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 	  if (level > 1)
 	    {
 	      /* set parent position pseudocolumn value */
-	      db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, (DB_C_BIT) & pos_info_p->tpl_pos,
-			   sizeof (pos_info_p->tpl_pos) * 8);
+	      // TODO -Wwrite-strings
+	      //db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, &pos_info_p->tpl_pos,
+	      //sizeof (pos_info_p->tpl_pos) * 8);
 
 	      if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
 						(list_id_p->type_list.type_cnt - PCOL_PARENTPOS_TUPLE_OFFSET),
@@ -16923,8 +16924,8 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 
 	  qfile_save_current_scan_tuple_position (&prev_s_id, &pos_info_p->tpl_pos);
 
-	  db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, (DB_C_BIT) & pos_info_p->tpl_pos,
-		       sizeof (pos_info_p->tpl_pos) * 8);
+	  // TODO -Wwrite-strings
+	  //db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, &pos_info_p->tpl_pos, sizeof (pos_info_p->tpl_pos) * 8);
 
 	  if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
 					    (list_id_p->type_list.type_cnt - PCOL_PARENTPOS_TUPLE_OFFSET),
@@ -16958,8 +16959,9 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 
 	  if (level > 1)
 	    {
-	      db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, (DB_C_BIT) & pos_info_p->tpl_pos,
-			   sizeof (pos_info_p->tpl_pos) * 8);
+	      // TODO -Wwrite-strings
+	      //db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, &pos_info_p->tpl_pos,
+	      //sizeof (pos_info_p->tpl_pos) * 8);
 
 	      if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
 						(list_id_p->type_list.type_cnt - PCOL_PARENTPOS_TUPLE_OFFSET),
@@ -21822,7 +21824,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
       db_make_null (out_values[8]);
 
       /* index type */
-      db_make_string_by_const_str (out_values[10], "BTREE");
+      db_make_string (out_values[10], "BTREE");
 
       index = rep->indexes + i;
       /* Non_unique */
@@ -21840,7 +21842,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
       db_make_string (out_values[12], comment);
 
       /* Visible */
-      db_make_string_by_const_str (out_values[13], (index->index_status == OR_NORMAL_INDEX) ? "YES" : "NO");
+      db_make_string (out_values[13], (index->index_status == OR_NORMAL_INDEX) ? "YES" : "NO");
 
       if (index->func_index_info == NULL)
 	{
@@ -21875,11 +21877,11 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  /* Collation */
 	  if (index->asc_desc[j])
 	    {
-	      db_make_string_by_const_str (out_values[5], "D");
+	      db_make_string (out_values[5], "D");
 	    }
 	  else
 	    {
-	      db_make_string_by_const_str (out_values[5], "A");
+	      db_make_string (out_values[5], "A");
 	    }
 
 	  /* Cardinality */
@@ -21911,11 +21913,11 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  /* [Null] */
 	  if (index_att->is_notnull)
 	    {
-	      db_make_string_by_const_str (out_values[9], "NO");
+	      db_make_string (out_values[9], "NO");
 	    }
 	  else
 	    {
-	      db_make_string_by_const_str (out_values[9], "YES");
+	      db_make_string (out_values[9], "YES");
 	    }
 
 	  /* Column_name */
@@ -21950,11 +21952,11 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 
 	  if (function_asc_desc)
 	    {
-	      db_make_string_by_const_str (out_values[5], "D");
+	      db_make_string (out_values[5], "D");
 	    }
 	  else
 	    {
-	      db_make_string_by_const_str (out_values[5], "A");
+	      db_make_string (out_values[5], "A");
 	    }
 
 	  /* Seq_in_index */
@@ -21980,7 +21982,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  db_make_null (out_values[7]);
 
 	  /* [Null] */
-	  db_make_string_by_const_str (out_values[9], "YES");
+	  db_make_string (out_values[9], "YES");
 
 	  /* Column_name */
 	  db_make_null (out_values[4]);
@@ -22433,7 +22435,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
       pset_result = &set_result;
 
       db_make_string (&comma, ",");
-      db_make_string_by_const_str (pset_result, set_of_string);
+      db_make_string (pset_result, set_of_string);
 
       for (setdomain = domain->setdomain, i = 0; setdomain; setdomain = setdomain->next, i++)
 	{
@@ -22492,7 +22494,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
       db_make_string (&comma, ",");
       db_make_string (&bracket1, "(");
       db_make_string (&bracket2, ")");
-      db_make_string_by_const_str (pprec_scale_arg1, name);
+      db_make_string (pprec_scale_arg1, name);
 
       if ((db_string_concatenate (pprec_scale_arg1, &bracket1, pprec_scale_result, &data_stat) != NO_ERROR)
 	  || (data_stat != DATA_STATUS_OK))
@@ -22572,8 +22574,8 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 
       if (db_json_get_schema_raw_from_validator (validator) != NULL)
 	{
-	  db_make_string_by_const_str (result, name);
-	  db_make_string_by_const_str (&schema, db_json_get_schema_raw_from_validator (validator));
+	  db_make_string (result, name);
+	  db_make_string (&schema, db_json_get_schema_raw_from_validator (validator));
 	  db_make_string (&bracket1, "(\'");
 	  db_make_string (&bracket2, "\')");
 
@@ -22599,7 +22601,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
     }
   else
     {
-      db_make_string_by_const_str (result, name);
+      db_make_string (result, name);
       return NO_ERROR;
     }
 
@@ -22757,8 +22759,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 		case DB_TYPE_NCHAR:
 		case DB_TYPE_VARNCHAR:
 		case DB_TYPE_ENUMERATION:
-		  db_make_string_by_const_str (out_values[idx_val],
-					       lang_get_collation_name (attrepr->domain->collation_id));
+		  db_make_string (out_values[idx_val], lang_get_collation_name (attrepr->domain->collation_id));
 		  break;
 		default:
 		  db_make_null (out_values[idx_val]);
@@ -22769,11 +22770,11 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  /* attribute can store NULL ? */
 	  if (attrepr->is_notnull == 0)
 	    {
-	      db_make_string_by_const_str (out_values[idx_val], "YES");
+	      db_make_string (out_values[idx_val], "YES");
 	    }
 	  else
 	    {
-	      db_make_string_by_const_str (out_values[idx_val], "NO");
+	      db_make_string (out_values[idx_val], "NO");
 	    }
 	  idx_val++;
 
@@ -22808,21 +22809,21 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	    {
 	    case BTREE_UNIQUE:
 	    case BTREE_REVERSE_UNIQUE:
-	      db_make_string_by_const_str (out_values[idx_val], "UNI");
+	      db_make_string (out_values[idx_val], "UNI");
 	      break;
 
 	    case BTREE_INDEX:
 	    case BTREE_REVERSE_INDEX:
 	    case BTREE_FOREIGN_KEY:
-	      db_make_string_by_const_str (out_values[idx_val], "MUL");
+	      db_make_string (out_values[idx_val], "MUL");
 	      break;
 
 	    case BTREE_PRIMARY_KEY:
-	      db_make_string_by_const_str (out_values[idx_val], "PRI");
+	      db_make_string (out_values[idx_val], "PRI");
 	      break;
 
 	    default:
-	      db_make_string_by_const_str (out_values[idx_val], "");
+	      db_make_string (out_values[idx_val], "");
 	      break;
 	    }
 	  idx_val++;
@@ -22872,7 +22873,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 		{
 		  if (default_expr_type_string)
 		    {
-		      db_make_string_by_const_str (out_values[idx_val], default_expr_type_string);
+		      db_make_string (out_values[idx_val], default_expr_type_string);
 		    }
 		}
 	      idx_val++;
@@ -22899,11 +22900,11 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  /* attribute has auto_increment or not */
 	  if (attrepr->is_autoincrement == 0)
 	    {
-	      db_make_string_by_const_str (out_values[idx_val], "");
+	      db_make_string (out_values[idx_val], "");
 	    }
 	  else
 	    {
-	      db_make_string_by_const_str (out_values[idx_val], "auto_increment");
+	      db_make_string (out_values[idx_val], "auto_increment");
 	    }
 
 	  if (attrepr->on_update_expr != DB_DEFAULT_NONE)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15383,8 +15383,8 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 			}
 
 		      /* set parent tuple position pseudocolumn value */
-		      // TODO -Wwrite-strings
-		      // db_make_bit (parent_pos_valp, DB_DEFAULT_PRECISION, &parent_pos, sizeof (parent_pos) * 8);
+		      db_make_bit (parent_pos_valp, DB_DEFAULT_PRECISION, REINTERPRET_CAST (DB_C_BIT, &parent_pos),
+				   sizeof (parent_pos) * 8);
 
 		      parent_tuple_added = true;
 		    }
@@ -16892,9 +16892,8 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 	  if (level > 1)
 	    {
 	      /* set parent position pseudocolumn value */
-	      // TODO -Wwrite-strings
-	      //db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, &pos_info_p->tpl_pos,
-	      //sizeof (pos_info_p->tpl_pos) * 8);
+	      db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, REINTERPRET_CAST (DB_C_BIT, &pos_info_p->tpl_pos),
+			   sizeof (pos_info_p->tpl_pos) * 8);
 
 	      if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
 						(list_id_p->type_list.type_cnt - PCOL_PARENTPOS_TUPLE_OFFSET),
@@ -16924,8 +16923,8 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 
 	  qfile_save_current_scan_tuple_position (&prev_s_id, &pos_info_p->tpl_pos);
 
-	  // TODO -Wwrite-strings
-	  //db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, &pos_info_p->tpl_pos, sizeof (pos_info_p->tpl_pos) * 8);
+	  db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, REINTERPRET_CAST (DB_C_BIT, &pos_info_p->tpl_pos),
+		       sizeof (pos_info_p->tpl_pos) * 8);
 
 	  if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
 					    (list_id_p->type_list.type_cnt - PCOL_PARENTPOS_TUPLE_OFFSET),
@@ -16959,9 +16958,8 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 
 	  if (level > 1)
 	    {
-	      // TODO -Wwrite-strings
-	      //db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, &pos_info_p->tpl_pos,
-	      //sizeof (pos_info_p->tpl_pos) * 8);
+	      db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, REINTERPRET_CAST (DB_C_BIT, &pos_info_p->tpl_pos),
+			   sizeof (pos_info_p->tpl_pos) * 8);
 
 	      if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
 						(list_id_p->type_list.type_cnt - PCOL_PARENTPOS_TUPLE_OFFSET),

--- a/src/query/show_scan.c
+++ b/src/query/show_scan.c
@@ -544,22 +544,22 @@ thread_scan_mapfunc (THREAD_ENTRY & thread_ref, bool & stop_mapper, THREAD_ENTRY
   idx++;
 
   /* Type */
-  db_make_string_by_const_str (&vals[idx], thread_type_to_string (thrd->type));
+  db_make_string (&vals[idx], thread_type_to_string (thrd->type));
   idx++;
 
   /* Status */
-  db_make_string_by_const_str (&vals[idx], thread_status_to_string (thrd->m_status));
+  db_make_string (&vals[idx], thread_status_to_string (thrd->m_status));
   idx++;
 
   /* Resume_status */
-  db_make_string_by_const_str (&vals[idx], thread_resume_status_to_string (thrd->resume_status));
+  db_make_string (&vals[idx], thread_resume_status_to_string (thrd->resume_status));
   idx++;
 
   /* Net_request */
   ival = thrd->net_request_index;
   if (ival != -1)
     {
-      db_make_string_by_const_str (&vals[idx], net_server_request_name (ival));
+      db_make_string (&vals[idx], net_server_request_name (ival));
     }
   else
     {
@@ -732,7 +732,7 @@ thread_scan_mapfunc (THREAD_ENTRY & thread_ref, bool & stop_mapper, THREAD_ENTRY
       idx++;
 
       /* Lockwait_state */
-      db_make_string_by_const_str (&vals[idx], lock_wait_state_to_string (thrd->lockwait_state));
+      db_make_string (&vals[idx], lock_wait_state_to_string (thrd->lockwait_state));
       idx++;
     }
   else

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -693,9 +693,9 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
 	    }
 	  result[result_size] = 0;
 	  db_value_domain_init (db_result, result_type, precision, 0);
-	  error_status =
-	    db_make_db_char (db_result, codeset, collation_id, (char *) result,
-			     (result_type == DB_TYPE_VARBIT ? num_bits : result_size));
+	  // TODO -Wwrite-strings
+	  //error_status = db_make_db_char (db_result, codeset, collation_id, result,
+	  //(result_type == DB_TYPE_VARBIT ? num_bits : result_size));
 	  db_result->need_clear = true;
 	}
       else
@@ -7111,7 +7111,7 @@ db_get_string_length (const DB_VALUE * value)
  */
 
 void
-qstr_make_typed_string (const DB_TYPE db_type, DB_VALUE * value, const int precision, const DB_C_CHAR src,
+qstr_make_typed_string (const DB_TYPE db_type, DB_VALUE * value, const int precision, DB_CONST_C_CHAR src,
 			const int s_unit, const int codeset, const int collation_id)
 {
   switch (db_type)
@@ -12680,7 +12680,7 @@ db_to_date (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 	  goto exit;
 	}
 
-      db_make_char (&default_format, strlen (default_format_str), (DB_C_CHAR) default_format_str,
+      db_make_char (&default_format, strlen (default_format_str), default_format_str,
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
@@ -13251,7 +13251,7 @@ db_to_time (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
 	  goto exit;
 	}
-      db_make_char (&default_format, strlen (default_format_str), (DB_C_CHAR) default_format_str,
+      db_make_char (&default_format, strlen (default_format_str), default_format_str,
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
@@ -13834,7 +13834,7 @@ db_to_timestamp (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB
 	  goto exit;
 	}
 
-      db_make_char (&default_format, strlen (default_format_str), (DB_C_CHAR) default_format_str,
+      db_make_char (&default_format, strlen (default_format_str), default_format_str,
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
@@ -14745,7 +14745,7 @@ db_to_datetime (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_
 	  goto exit;
 	}
 
-      db_make_char (&default_format, strlen (default_format_str), (DB_C_CHAR) default_format_str,
+      db_make_char (&default_format, strlen (default_format_str), default_format_str,
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
@@ -27164,12 +27164,12 @@ db_get_cs_coll_info (DB_VALUE * result, const DB_VALUE * val, const int mode)
 
       if (mode == 0)
 	{
-	  db_make_string_by_const_str (result, lang_charset_cubrid_name ((INTL_CODESET) cs));
+	  db_make_string (result, lang_charset_cubrid_name ((INTL_CODESET) cs));
 	}
       else
 	{
 	  assert (mode == 1);
-	  db_make_string_by_const_str (result, lang_get_collation_name (coll));
+	  db_make_string (result, lang_get_collation_name (coll));
 	}
     }
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -693,9 +693,8 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
 	    }
 	  result[result_size] = 0;
 	  db_value_domain_init (db_result, result_type, precision, 0);
-	  // TODO -Wwrite-strings
-	  //error_status = db_make_db_char (db_result, codeset, collation_id, result,
-	  //(result_type == DB_TYPE_VARBIT ? num_bits : result_size));
+	  error_status = db_make_db_char (db_result, codeset, collation_id, REINTERPRET_CAST (char *, result),
+					  (result_type == DB_TYPE_VARBIT ? num_bits : result_size));
 	  db_result->need_clear = true;
 	}
       else

--- a/src/query/string_opfunc.h
+++ b/src/query/string_opfunc.h
@@ -252,7 +252,7 @@ extern int qstr_bit_to_bin (char *dest, int dest_size, char *src, int src_size);
 extern void qstr_bit_to_hex_coerce (char *buffer, int buffer_size, const char *src, int src_length, int pad_flag,
 				    int *copy_size, int *truncation);
 extern int db_get_string_length (const DB_VALUE * value);
-extern void qstr_make_typed_string (const DB_TYPE db_type, DB_VALUE * value, const int precision, const DB_C_CHAR src,
+extern void qstr_make_typed_string (const DB_TYPE db_type, DB_VALUE * value, const int precision, DB_CONST_C_CHAR src,
 				    const int s_unit, const int codeset, const int collation_id);
 extern int db_add_months (const DB_VALUE * src_date, const DB_VALUE * nmonth, DB_VALUE * result_date);
 extern int db_last_day (const DB_VALUE * src_date, DB_VALUE * result_day);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -16184,13 +16184,11 @@ btree_get_next_key_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_SCAN * bts,
 
   /* Get overflow key and overflow oids */
   pr_clear_value (key_info[BTREE_KEY_INFO_OVERFLOW_KEY]);
-  db_make_string_by_const_str (key_info[BTREE_KEY_INFO_OVERFLOW_KEY],
-			       btree_leaf_is_flaged (&bts->key_record,
-						     BTREE_LEAF_RECORD_OVERFLOW_KEY) ? "true" : "false");
+  db_make_string (key_info[BTREE_KEY_INFO_OVERFLOW_KEY],
+		  btree_leaf_is_flaged (&bts->key_record, BTREE_LEAF_RECORD_OVERFLOW_KEY) ? "true" : "false");
   pr_clear_value (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS]);
-  db_make_string_by_const_str (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS],
-			       btree_leaf_is_flaged (&bts->key_record,
-						     BTREE_LEAF_RECORD_OVERFLOW_OIDS) ? "true" : "false");
+  db_make_string (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS],
+		  btree_leaf_is_flaged (&bts->key_record, BTREE_LEAF_RECORD_OVERFLOW_OIDS) ? "true" : "false");
 
   /* Get OIDs count -> For now ignore the overflow OIDs */
   db_make_int (key_info[BTREE_KEY_INFO_OID_COUNT],
@@ -20208,8 +20206,7 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
 
   /* Get node type */
   pr_clear_value (node_info[BTREE_NODE_INFO_NODE_TYPE]);
-  db_make_string_by_const_str (node_info[BTREE_NODE_INFO_NODE_TYPE],
-			       (node_type == BTREE_NON_LEAF_NODE) ? "non-leaf" : "leaf");
+  db_make_string (node_info[BTREE_NODE_INFO_NODE_TYPE], (node_type == BTREE_NON_LEAF_NODE) ? "non-leaf" : "leaf");
 
   /* Get key count */
   db_make_int (node_info[BTREE_NODE_INFO_KEY_COUNT], key_cnt);

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -685,9 +685,8 @@ catcls_find_oid_by_class_name (THREAD_ENTRY * thread_p, const char *name_p, OID 
   DB_VALUE key_val;
   int error = NO_ERROR;
 
-  error =
-    db_make_varchar (&key_val, DB_MAX_IDENTIFIER_LENGTH, (char *) name_p, (int) strlen (name_p), LANG_SYS_CODESET,
-		     LANG_SYS_COLLATION);
+  error = db_make_varchar (&key_val, DB_MAX_IDENTIFIER_LENGTH, name_p, (int) strlen (name_p), LANG_SYS_CODESET,
+			   LANG_SYS_COLLATION);
   if (error != NO_ERROR)
     {
       return error;

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2983,10 +2983,10 @@ disk_volume_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** o
   db_make_int (out_values[idx], vhdr->iopagesize);
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], disk_purpose_to_string (vhdr->purpose));
+  db_make_string (out_values[idx], disk_purpose_to_string (vhdr->purpose));
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], disk_type_to_string (vhdr->type));
+  db_make_string (out_values[idx], disk_type_to_string (vhdr->type));
   idx++;
 
   db_make_int (out_values[idx], vhdr->sect_npgs);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -23340,7 +23340,7 @@ heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid
 
   /*  Here we check only the classname because this is the last field to be populated by other possible concurrent
    *  inserters. This means that if this field is already set by someone else, then the entry data is already
-   *  mature so we don't need to add data again. 
+   *  mature so we don't need to add data again.
    */
   if (entry->classname == NULL)
     {

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -151,6 +151,7 @@ static LF_ENTRY_DESCRIPTOR spage_Saving_entry_descriptor = {
 // *INDENT-OFF*
 using spage_saving_hashmap_type = cubthread::lockfree_hashmap<VPID, spage_save_head>;
 // *INDENT-ON*
+
 static spage_saving_hashmap_type spage_Saving_hashmap;
 
 /* context for slotted page header scan */
@@ -5008,10 +5009,10 @@ spage_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_val
   db_make_int (out_values[idx], header->num_records);
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], spage_anchor_flag_string (header->anchor_type));
+  db_make_string (out_values[idx], spage_anchor_flag_string (header->anchor_type));
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], spage_alignment_string (header->alignment));
+  db_make_string (out_values[idx], spage_alignment_string (header->alignment));
   idx++;
 
   db_make_int (out_values[idx], header->total_free);
@@ -5196,7 +5197,7 @@ spage_slots_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
   db_make_int (out_values[idx], ctx->slot->offset_to_record);
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], spage_record_type_string (ctx->slot->record_type));
+  db_make_string (out_values[idx], spage_record_type_string (ctx->slot->record_type));
   idx++;
 
   db_make_int (out_values[idx], ctx->slot->record_length);

--- a/src/thread/critical_section.c
+++ b/src/thread/critical_section.c
@@ -1660,7 +1660,7 @@ csect_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values
       idx++;
 
       /* The name of the critical section */
-      db_make_string_by_const_str (&vals[idx], csect_name (csect));
+      db_make_string (&vals[idx], csect_name (csect));
       idx++;
 
       /* 'N readers', '1 writer', 'none' */

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -2979,7 +2979,7 @@ boot_add_data_type (MOP class_mop)
 	  db_make_int (&val, i + 1);
 	  db_put_internal (obj, "type_id", &val);
 
-	  db_make_varchar (&val, 16, (char *) names[i], strlen (names[i]), LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	  db_make_varchar (&val, 16, names[i], strlen (names[i]), LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	  db_put_internal (obj, "type_name", &val);
 	}
     }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -8906,7 +8906,7 @@ log_active_log_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE *
   db_make_int (out_values[idx], header->has_logging_been_skipped);
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], "LOG_PSTATUS_OBSOLETE");
+  db_make_string (out_values[idx], "LOG_PSTATUS_OBSOLETE");
   idx++;
 
   logpb_backup_level_info_to_string (buf, sizeof (buf), header->bkinfo + FILEIO_BACKUP_FULL_LEVEL);
@@ -8934,11 +8934,11 @@ log_active_log_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE *
     }
 
   str = css_ha_server_state_string ((HA_SERVER_STATE) header->ha_server_state);
-  db_make_string_by_const_str (out_values[idx], str);
+  db_make_string (out_values[idx], str);
   idx++;
 
   str = logwr_log_ha_filestat_to_string ((LOG_HA_FILESTAT) header->ha_file_status);
-  db_make_string_by_const_str (out_values[idx], str);
+  db_make_string (out_values[idx], str);
   idx++;
 
   lsa_to_string (buf, sizeof (buf), &header->eof_lsa);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -5232,11 +5232,11 @@ logtb_descriptors_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg
       idx++;
 
       /* State */
-      db_make_string_by_const_str (&vals[idx], log_state_short_string (tdes->state));
+      db_make_string (&vals[idx], log_state_short_string (tdes->state));
       idx++;
 
       /* isolation */
-      db_make_string_by_const_str (&vals[idx], log_isolation_string (tdes->isolation));
+      db_make_string (&vals[idx], log_isolation_string (tdes->isolation));
       idx++;
 
       /* Wait_msecs */
@@ -5579,7 +5579,7 @@ logtb_descriptors_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg
 
       /* Abort_reason */
       str = tran_abort_reason_to_string (tdes->tran_abort_reason);
-      db_make_string_by_const_str (&vals[idx], str);
+      db_make_string (&vals[idx], str);
       idx++;
 
       assert (idx == num_cols);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23444

* change signature of `db_make_string (DB_VALUE * value, char *str)` to accept `const char *`
* change signature of `int db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collation_id, char *str, const int size);` to accept `const char *`
* remove `db_make_string_by_const_str` define
* Fix cases when `const` qualifier is applied to a typedef to a pointer type rather than to the pointee.
For example, in the code snippet below, the resulting type is `char * const` rather than `const char *`
Add new typedefs `DB_CONST_C_CHAR, DB_CONST_C_NCHAR` and `DB_CONST_C_BIT` and use them where is the case.
```cpp
typedef char *DB_C_CHAR;
void foo (const DB_C_CHAR bar);
```

Part 1 of #1656