### PR TITLE
[CBRD-23444] const db enumeration

### DIFF
--- a/src/base/unicode_support.c
+++ b/src/base/unicode_support.c
@@ -1275,13 +1275,14 @@ unicode_compose_string (const char *str_in, const int size_in, char *str_out, in
  *  Note : Input string is assumed UTF-8 character set.
  */
 bool
-unicode_string_need_decompose (char *str_in, const int size_in, int *decomp_size, const UNICODE_NORMALIZATION * norm)
+unicode_string_need_decompose (const char *str_in, const int size_in, int *decomp_size,
+			       const UNICODE_NORMALIZATION * norm)
 {
   int bytes_read, decomp_index, decomposed_size = 0;
   unsigned int cp;
-  char *src_cursor;
-  char *src_end;
-  char *next;
+  const char *src_cursor;
+  const char *src_end;
+  const char *next;
   bool can_decompose;
 
   if (!prm_get_bool_value (PRM_ID_UNICODE_OUTPUT_NORMALIZATION) || norm == NULL)
@@ -1359,14 +1360,14 @@ no_decompose_cnt:
  * norm(in) : the unicode context in which the normalization is performed
  */
 void
-unicode_decompose_string (char *str_in, const int size_in, char *str_out, int *size_out,
+unicode_decompose_string (const char *str_in, const int size_in, char *str_out, int *size_out,
 			  const UNICODE_NORMALIZATION * norm)
 {
   int bytes_read, decomp_index;
   unsigned int cp;
-  char *src_cursor;
-  char *src_end;
-  char *next;
+  const char *src_cursor;
+  const char *src_end;
+  const char *next;
   char *dest_cursor;
 
   assert (prm_get_bool_value (PRM_ID_UNICODE_OUTPUT_NORMALIZATION) && norm != NULL);

--- a/src/base/unicode_support.h
+++ b/src/base/unicode_support.h
@@ -48,9 +48,9 @@ extern "C"
 					   const UNICODE_NORMALIZATION * norm);
   extern void unicode_compose_string (const char *str_in, const int size_in, char *str_out, int *size_out,
 				      bool * is_composed, const UNICODE_NORMALIZATION * norm);
-  extern bool unicode_string_need_decompose (char *str_in, const int size_in, int *decomp_size,
+  extern bool unicode_string_need_decompose (const char *str_in, const int size_in, int *decomp_size,
 					     const UNICODE_NORMALIZATION * norm);
-  extern void unicode_decompose_string (char *str_in, const int size_in, char *str_out, int *size_out,
+  extern void unicode_decompose_string (const char *str_in, const int size_in, char *str_out, int *size_out,
 					const UNICODE_NORMALIZATION * norm);
 #endif
   extern int string_to_int_array (char *s, uint32 * cp_list, const int cp_list_size, const char *delims);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -4614,13 +4614,12 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
       break;
     case DB_TYPE_ENUMERATION:
       {
-	char *str;
 	int bytes_size = 0;
 	int decomp_size;
 	char *decomposed = NULL;
 	bool need_decomp = false;
 
-	str = db_get_enum_string (val);
+	const char *str = db_get_enum_string (val);
 	bytes_size = db_get_enum_string_size (val);
 	if (max_col_size > 0)
 	  {

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -102,7 +102,7 @@
 #define DB_GET_ENUM_ELEM_DBCHAR(elem) \
       ((elem)->str_val)
 #define DB_GET_ENUM_ELEM_STRING(elem) \
-      ((elem)->str_val.medium.buf)
+      ((const char*) (elem)->str_val.medium.buf)	// TODO enum: cast is temporary until db_char::medium::buf will be made const
 #define DB_GET_ENUM_ELEM_STRING_SIZE(elem) \
       ((elem)->str_val.medium.size)
 

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -101,8 +101,9 @@
       ((elem)->short_val)
 #define DB_GET_ENUM_ELEM_DBCHAR(elem) \
       ((elem)->str_val)
+// TODO enum: cast is temporary until db_char::medium::buf will be made const
 #define DB_GET_ENUM_ELEM_STRING(elem) \
-      ((const char*) (elem)->str_val.medium.buf)	// TODO enum: cast is temporary until db_char::medium::buf will be made const
+      ((const char*) (elem)->str_val.medium.buf)
 #define DB_GET_ENUM_ELEM_STRING_SIZE(elem) \
       ((elem)->str_val.medium.size)
 

--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -339,7 +339,7 @@ extern "C"
   extern DB_C_NCHAR db_get_nchar (const DB_VALUE * value, int *length);
   extern int db_get_string_size (const DB_VALUE * value);
   extern unsigned short db_get_enum_short (const DB_VALUE * value);
-  extern DB_C_CHAR db_get_enum_string (const DB_VALUE * value);
+  extern DB_CONST_C_CHAR db_get_enum_string (const DB_VALUE * value);
   extern int db_get_enum_string_size (const DB_VALUE * value);
   extern DB_C_CHAR db_get_method_error_msg (void);
   extern DB_RESULTSET db_get_resultset (const DB_VALUE * value);
@@ -383,7 +383,7 @@ extern "C"
 			    const int nchar_str_byte_size, const int codeset, const int collation_id);
   extern int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR str,
 			       const int nchar_str_byte_size, const int codeset, const int collation_id);
-  extern int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size,
+  extern int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_CONST_C_CHAR str, int size,
 				  unsigned char codeset, const int collation_id);
   extern int db_make_resultset (DB_VALUE * value, const DB_RESULTSET handle);
 

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -52,7 +52,7 @@ STATIC_INLINE DB_C_CHAR db_get_char (const DB_VALUE * value, int *length) __attr
 STATIC_INLINE DB_C_NCHAR db_get_nchar (const DB_VALUE * value, int *length) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_get_string_size (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE unsigned short db_get_enum_short (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE DB_C_CHAR db_get_enum_string (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE DB_CONST_C_CHAR db_get_enum_string (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_get_enum_string_size (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_C_CHAR db_get_method_error_msg (void) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_RESULTSET db_get_resultset (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
@@ -109,7 +109,7 @@ STATIC_INLINE int db_make_nchar (DB_VALUE * value, const int nchar_length, DB_CO
 STATIC_INLINE int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR str,
 				    const int nchar_str_byte_size, const int codeset, const int collation_id)
   __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size,
+STATIC_INLINE int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_CONST_C_CHAR str, int size,
 				       unsigned char codeset, const int collation_id) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_resultset (DB_VALUE * value, const DB_RESULTSET handle) __attribute__ ((ALWAYS_INLINE));
 
@@ -707,7 +707,7 @@ db_get_enum_short (const DB_VALUE * value)
  * return :
  * value(in):
  */
-char *
+DB_CONST_C_CHAR
 db_get_enum_string (const DB_VALUE * value)
 {
 #if defined (API_ACTIVE_CHECKS)
@@ -1721,7 +1721,7 @@ db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR
  * collation_id(in):
  */
 int
-db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size, unsigned char codeset,
+db_make_enumeration (DB_VALUE * value, unsigned short index, DB_CONST_C_CHAR str, int size, unsigned char codeset,
 		     const int collation_id)
 {
 #if defined (API_ACTIVE_CHECKS)
@@ -1738,7 +1738,8 @@ db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int 
   value->data.ch.medium.compressed_buf = NULL;
   value->data.ch.medium.compressed_size = 0;
   value->data.enumeration.str_val.medium.size = size;
-  value->data.enumeration.str_val.medium.buf = str;
+  // TODO enum: cast is temporary until db_char::medium::buf will be made const
+  value->data.enumeration.str_val.medium.buf = (char *) str;
   value->domain.general_info.is_null = 0;
   value->need_clear = false;
 

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -7154,10 +7154,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    }
 	  break;
 	case DB_JSON_STRING:
-	  {
-	    const char *json_string = db_json_get_string_from_document (src_doc);
-	    db_make_string (&src_replacement, json_string);
-	  }
+	  db_make_string_copy (&src_replacement, db_json_get_string_from_document (src_doc));
 	  break;
 	default:
 	  use_replacement = false;

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -803,7 +803,9 @@ tp_domain_clear_enumeration (DB_ENUMERATION * enumeration)
     {
       if (DB_GET_ENUM_ELEM_STRING (&enumeration->elements[i]) != NULL)
 	{
-	  free_and_init (DB_GET_ENUM_ELEM_STRING (&enumeration->elements[i]));
+	  // TODO enum: tmp variable is temporary until db_char::medium::buf will be made const
+	  const char *tmp = DB_GET_ENUM_ELEM_STRING (&enumeration->elements[i]);
+	  free_and_init (tmp);
 	}
     }
 
@@ -1238,7 +1240,9 @@ error_return:
 	{
 	  if (DB_GET_ENUM_ELEM_STRING (&dest->elements[i]) != NULL)
 	    {
-	      free_and_init (DB_GET_ENUM_ELEM_STRING (&dest->elements[i]));
+	      // TODO enum: tmp variable is temporary until db_char::medium::buf will be made const
+	      const char *tmp = DB_GET_ENUM_ELEM_STRING (&dest->elements[i]);
+	      free_and_init (tmp);
 	    }
 	}
       free_and_init (dest->elements);
@@ -4265,7 +4269,7 @@ tp_domain_select (const TP_DOMAIN * domain_list, const DB_VALUE * value, int all
   else if (vtype == DB_TYPE_ENUMERATION)
     {
       int val_idx, dom_size, val_size;
-      char *dom_str = NULL, *val_str = NULL;
+      const char *dom_str = NULL, *val_str = NULL;
 
       if (db_get_enum_short (value) == 0 && db_get_enum_string (value) != NULL)
 	{
@@ -9709,7 +9713,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
       {
 	unsigned short val_idx = 0;
 	int val_str_size = 0;
-	char *val_str = NULL;
+	const char *val_str = NULL;
 	bool exit = false, alloc_string = true;
 	DB_VALUE conv_val;
 
@@ -9770,7 +9774,6 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    {
 	      DB_VALUE val;
 	      DB_DATA_STATUS stat = DATA_STATUS_OK;
-	      int err = NO_ERROR;
 
 	      db_make_double (&val, 0);
 	      err = numeric_db_value_coerce_from_num ((DB_VALUE *) src, &val, &stat);
@@ -9983,7 +9986,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 	    if (status == DOMAIN_COMPATIBLE)
 	      {
-		char *enum_str;
+		const char *enum_str;
 
 		assert (val_str != NULL);
 
@@ -9996,8 +9999,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 		if (alloc_string)
 		  {
-		    enum_str = (char *) db_private_alloc (NULL, val_str_size + 1);
-		    if (enum_str == NULL)
+		    char *enum_str_tmp = (char *) db_private_alloc (NULL, val_str_size + 1);
+		    if (enum_str_tmp == NULL)
 		      {
 			status = DOMAIN_ERROR;
 			pr_clear_value (&conv_val);
@@ -10005,14 +10008,17 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		      }
 		    else
 		      {
-			memcpy (enum_str, val_str, val_str_size);
-			enum_str[val_str_size] = 0;
+			memcpy (enum_str_tmp, val_str, val_str_size);
+			enum_str_tmp[val_str_size] = 0;
 		      }
+
+		    enum_str = enum_str_tmp;
 		  }
 		else
 		  {
 		    enum_str = val_str;
 		  }
+
 		db_make_enumeration (target, val_idx, enum_str, val_str_size, TP_DOMAIN_CODESET (desired_domain),
 				     TP_DOMAIN_COLLATION (desired_domain));
 		target->need_clear = true;

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2057,7 +2057,8 @@ pr_clear_value (DB_VALUE * value)
     case DB_TYPE_ENUMERATION:
       if (value->need_clear)
 	{
-	  char *temp = db_get_enum_string (value);
+	  // here is safe to const_cast since the ownership was handed over by setting need_clear flag to true
+	  char *temp = CONST_CAST (char *, db_get_enum_string (value));
 	  if (temp != NULL)
 	    {
 	      db_private_free_and_init (NULL, temp);
@@ -9752,7 +9753,7 @@ int
 pr_complete_enum_value (DB_VALUE * value, struct tp_domain *domain)
 {
   unsigned short short_val;
-  char *str_val;
+  const char *str_val;
   int enum_count, str_val_size, idx;
   DB_ENUM_ELEMENT *db_elem = 0;
 
@@ -9788,13 +9789,15 @@ pr_complete_enum_value (DB_VALUE * value, struct tp_domain *domain)
       pr_clear_value (value);
 
       str_val_size = DB_GET_ENUM_ELEM_STRING_SIZE (db_elem);
-      str_val = (char *) db_private_alloc (NULL, str_val_size + 1);
-      if (str_val == NULL)
+      char *str_val_tmp = (char *) db_private_alloc (NULL, str_val_size + 1);
+      if (str_val_tmp == NULL)
 	{
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
-      memcpy (str_val, DB_GET_ENUM_ELEM_STRING (db_elem), str_val_size);
-      str_val[str_val_size] = 0;
+      memcpy (str_val_tmp, DB_GET_ENUM_ELEM_STRING (db_elem), str_val_size);
+      str_val_tmp[str_val_size] = 0;
+      str_val = str_val_tmp;
+
       db_make_enumeration (value, short_val, str_val, str_val_size, DB_GET_ENUM_ELEM_CODESET (db_elem),
 			   db_get_enum_collation (value));
       value->need_clear = true;
@@ -15505,7 +15508,7 @@ mr_getmem_enumeration (void *mem, TP_DOMAIN * domain, DB_VALUE * value, bool cop
 static int
 mr_setval_enumeration (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 {
-  char *str = NULL;
+  const char *str = NULL;
   bool need_clear = false;
 
   if (src == NULL || DB_IS_NULL (src))
@@ -15517,15 +15520,16 @@ mr_setval_enumeration (DB_VALUE * dest, const DB_VALUE * src, bool copy)
     {
       if (copy)
 	{
-	  str = (char *) db_private_alloc (NULL, db_get_enum_string_size (src) + 1);
-	  if (str == NULL)
+	  char *str_tmp = (char *) db_private_alloc (NULL, db_get_enum_string_size (src) + 1);
+	  if (str_tmp == NULL)
 	    {
 	      assert (er_errid () != NO_ERROR);
 	      return er_errid ();
 	    }
-	  memcpy (str, db_get_enum_string (src), db_get_enum_string_size (src));
-	  str[db_get_enum_string_size (src)] = 0;
+	  memcpy (str_tmp, db_get_enum_string (src), db_get_enum_string_size (src));
+	  str_tmp[db_get_enum_string_size (src)] = 0;
 	  need_clear = true;
+	  str = str_tmp;
 	}
       else
 	{
@@ -15581,7 +15585,7 @@ mr_setval_enumeration_internal (DB_VALUE * value, TP_DOMAIN * domain, unsigned s
 {
   bool need_clear = false;
   int str_size;
-  char *str;
+  const char *str = NULL;
   DB_ENUM_ELEMENT *db_elem = NULL;
 
   if (domain == NULL || DOM_GET_ENUM_ELEMS_COUNT (domain) == 0 || index == 0 || index == DB_ENUM_OVERFLOW_VAL)
@@ -15605,23 +15609,27 @@ mr_setval_enumeration_internal (DB_VALUE * value, TP_DOMAIN * domain, unsigned s
     }
   else
     {
+      char *str_tmp = NULL;
       if (copy_buf && copy_buf_len >= str_size + 1)
 	{
 	  /* read buf image into the copy_buf */
-	  str = copy_buf;
+	  str_tmp = copy_buf;
 	  need_clear = false;
 	}
       else
 	{
-	  str = (char *) db_private_alloc (NULL, str_size + 1);
-	  if (str == NULL)
+	  str_tmp = (char *) db_private_alloc (NULL, str_size + 1);
+	  if (str_tmp == NULL)
 	    {
 	      return ER_FAILED;
 	    }
 	  need_clear = true;
 	}
-      memcpy (str, DB_GET_ENUM_ELEM_STRING (db_elem), str_size);
-      str[str_size] = 0;
+
+      memcpy (str_tmp, DB_GET_ENUM_ELEM_STRING (db_elem), str_size);
+      str_tmp[str_size] = 0;
+
+      str = str_tmp;
     }
 
   db_make_enumeration (value, index, str, str_size, TP_DOMAIN_CODESET (domain), TP_DOMAIN_COLLATION (domain));

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -7260,7 +7260,9 @@ error_return:
     {
       for (--idx; idx >= 0; idx--)
 	{
-	  free_and_init (DB_GET_ENUM_ELEM_STRING (&enum_vals[idx]));
+	  // TODO enum: tmp variable is temporary until db_char::medium::buf will be made const
+	  const char *tmp = DB_GET_ENUM_ELEM_STRING (&enum_vals[idx]);
+	  free_and_init (tmp);
 	}
       free_and_init (enum_vals);
     }

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -1768,7 +1768,9 @@ error:
     {
       for (--idx; idx >= 0; idx--)
 	{
-	  free_and_init (DB_GET_ENUM_ELEM_STRING (&enum_elements[idx]));
+	  // TODO enum: tmp variable is temporary until db_char::medium::buf will be made const
+	  const char *tmp = DB_GET_ENUM_ELEM_STRING (&enum_elements[idx]);
+	  free_and_init (tmp);
 	}
       free_and_init (enum_elements);
     }

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -17724,7 +17724,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
       {
 	const char *username = au_user_name ();
 
-	error = db_make_string (result, username);
+	error = db_make_string_copy (result, username);
 	db_string_free ((char *) username);
 	if (error < 0)
 	  {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23444

Use `const char *` for `db_make_enumeration, db_get_enum_string` and `DB_GET_ENUM_ELEM_STRING`

Part 2 of #1656