### PR TITLE
[CBRD-22753] fix clearing after parser_copy_tree

### DIFF
--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -911,7 +911,7 @@ parser_free_node (const PARSER_CONTEXT * parser, PT_NODE * node)
       col->on_empty.m_default_value = NULL;
       db_value_clear (col->on_error.m_default_value);
       col->on_error.m_default_value = NULL;
-      // db_values on_empty.m_default_value & on_error.m_default_value are allocated by the grammar
+      // db_values on_empty.m_default_value & on_error.m_default_value are allocated using area_alloc
     }
   /*
    * Always set the node type to maximum.  This may

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -810,6 +810,14 @@ copy_node_in_tree_pre (PARSER_CONTEXT * parser, PT_NODE * old_node, void *arg, i
 	}
     }
 
+  if (new_node->node_type == PT_JSON_TABLE_COLUMN)
+    {
+      PT_JSON_TABLE_COLUMN_INFO *old_col = &old_node->info.json_table_column_info;
+      PT_JSON_TABLE_COLUMN_INFO *new_col = &new_node->info.json_table_column_info;
+      new_col->on_empty.m_default_value = db_value_copy (old_col->on_empty.m_default_value);
+      new_col->on_error.m_default_value = db_value_copy (old_col->on_error.m_default_value);
+    }
+
   new_node->parser_id = parser->id;
 
   /* handle CTE copy so that the CTE pointers will be updated to point to new_node */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22753

Fix slip of #2053 . Json table column info dbvals are shallow copied by parser_copy_tree, and the original tree loses its reference when the tree-copy is freed. 