### PR TITLE
[CBRD-23458] fix client-PRM accessed on server

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -3254,7 +3254,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_NO_BACKSLASH_ESCAPES,
    PRM_NAME_NO_BACKSLASH_ESCAPES,
-   (PRM_FOR_CLIENT | PRM_TEST_CHANGE),
+   (PRM_FOR_CLIENT | PRM_FOR_SESSION | PRM_FOR_SERVER | PRM_USER_CHANGE),
    PRM_BOOLEAN,
    &prm_no_backslash_escapes_flag,
    (void *) &prm_no_backslash_escapes_default,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23458

Make no_backslash_escapes also as server parameter. 