### PR TITLE
[CBRD-23462] Copy wait type in looper copy constructor

### DIFF
--- a/src/thread/thread_looper.cpp
+++ b/src/thread/thread_looper.cpp
@@ -70,6 +70,7 @@ namespace cubthread
 
     // we need to use same target function, however for default setup function first argument must be this and not
     // other
+    m_wait_type = other.m_wait_type;
     switch (other.m_wait_type)
       {
       case INF_WAITS:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23462

It is not a fix for the issue but while investigating I observed that m_wait_type was not the one expected. The reason is that copy constructor does not copy it.