### PR TITLE
[CBRD-23444] Fix Wstringop-truncation warnings

### DIFF
--- a/src/base/fileline_location.cpp
+++ b/src/base/fileline_location.cpp
@@ -23,6 +23,8 @@
 
 #include "fileline_location.hpp"
 
+#include "porting.h"
+
 #include <cstring>
 
 namespace cubbase
@@ -47,7 +49,7 @@ namespace cubbase
 	    break;
 	  }
       }
-    std::strncpy (m_file, start_chp, MAX_FILENAME_SIZE);
+    strncpy_bufsize (m_file, start_chp);
 
     m_line = l_arg;
   }

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -1066,8 +1066,7 @@ set_msg_lang_from_env (void)
       INTL_CODESET dummy_cs;
       char msg_lang[LANG_MAX_LANGNAME];
 
-      strncpy (lang_Msg_loc_name, env, sizeof (lang_Msg_loc_name));
-      lang_Msg_loc_name[sizeof (lang_Msg_loc_name) - 1] = '\0';
+      strncpy_bufsize (lang_Msg_loc_name, env);
 
       status = check_env_lang_val (lang_Msg_loc_name, msg_lang, &charset, &dummy_cs);
       if (status != NO_ERROR)
@@ -1122,8 +1121,7 @@ lang_set_charset_lang (const char *lang_charset)
 
   if (lang_charset != NULL)
     {
-      strncpy (lang_Loc_name, lang_charset, sizeof (lang_Loc_name));
-      lang_Loc_name[sizeof (lang_Loc_name) - 1] = '\0';
+      strncpy_bufsize (lang_Loc_name, lang_charset);
     }
   else
     {

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -1067,6 +1067,7 @@ set_msg_lang_from_env (void)
       char msg_lang[LANG_MAX_LANGNAME];
 
       strncpy (lang_Msg_loc_name, env, sizeof (lang_Msg_loc_name));
+      lang_Msg_loc_name[sizeof (lang_Msg_loc_name) - 1] = '\0';
 
       status = check_env_lang_val (lang_Msg_loc_name, msg_lang, &charset, &dummy_cs);
       if (status != NO_ERROR)
@@ -1122,6 +1123,7 @@ lang_set_charset_lang (const char *lang_charset)
   if (lang_charset != NULL)
     {
       strncpy (lang_Loc_name, lang_charset, sizeof (lang_Loc_name));
+      lang_Loc_name[sizeof (lang_Loc_name) - 1] = '\0';
     }
   else
     {

--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -317,6 +317,10 @@ extern int free_space (const char *, int);
 #define snprintf_dots_truncate(dest, max_len, ...) \
   if (snprintf (dest, max_len, __VA_ARGS__) < 0) \
     snprintf (dest + max_len - 4, 4, "...")
+#define strncpy_size(buf, str, size) \
+  strncpy (buf, str, size); buf[(size) - 1] = '\0'
+#define strncpy_bufsize(buf, str) \
+  strncpy_size (buf, str, sizeof (buf))
 
 #if defined (WINDOWS)
 #define PATH_SEPARATOR  '\\'

--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -89,6 +89,7 @@
 
 #if defined (__cplusplus)
 #include <type_traits>
+#include <utility>
 #endif // C++
 
 #if defined (WINDOWS)

--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -139,6 +139,7 @@ extern char *realpath (const char *path, char *resolved_path);
 #define strtok_r            strtok_s
 #define strtoll             _strtoi64
 #define strtoull            _strtoui64
+// todo - remove define stat; name is too common
 #define stat		    _stati64
 #define fstat		    _fstati64
 #define ftime		    _ftime_s
@@ -345,7 +346,7 @@ check_is_array (const T & a)
   static_assert (std::is_array<T>::value == 1, "expected array");
 }
 #define strncpy_bufsize(buf, str) \
-  check_is_array (buf); strncpy_size (buf, str, sizeof (buf))
+  strncpy_size (buf, str, sizeof (buf)); check_is_array (buf); 
 // *INDENT-ON*
 #else // not C++
 #define snprintf_dots_truncate(dest, max_len, ...) \

--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -320,26 +320,13 @@ extern int free_space (const char *, int);
 
 #endif /* WINDOWS */
 
+#define snprintf_dots_truncate(dest, max_len, ...) \
+  if (snprintf (dest, max_len, __VA_ARGS__) < 0) \
+    snprintf (dest + max_len - 4, 4, "...")
+#define strncpy_size(buf, str, size) \
+  strncpy (buf, str, size); buf[(size) - 1] = '\0'
 #if defined (__cplusplus)
 // *INDENT-OFF*
-template <typename ... Args>
-inline void
-snprintf_dots_truncate (char *dest, size_t max_len, Args &&... args)
-{
-  if (snprintf (dest, max_len, std::forward<Args> (args)...) < 0)
-    {
-      snprintf (dest + max_len - 4, 4, "...");
-    }
-}
-
-inline char *
-strncpy_size (char * buf, const char * str, size_t size)
-{
-  strncpy (buf, str, size);
-  buf[size - 1] = '\0';
-  return buf;
-}
-
 template<typename T>
 inline void
 check_is_array (const T & a)
@@ -350,11 +337,6 @@ check_is_array (const T & a)
   strncpy_size (buf, str, sizeof (buf)); check_is_array (buf); 
 // *INDENT-ON*
 #else // not C++
-#define snprintf_dots_truncate(dest, max_len, ...) \
-  if (snprintf (dest, max_len, __VA_ARGS__) < 0) \
-    snprintf (dest + max_len - 4, 4, "...")
-#define strncpy_size(buf, str, size) \
-  strncpy (buf, str, size); buf[(size) - 1] = '\0'
 #define strncpy_bufsize(buf, str) \
   strncpy_size (buf, str, sizeof (buf))
 #endif // not C++

--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -334,7 +334,7 @@ check_is_array (const T & a)
   static_assert (std::is_array<T>::value == 1, "expected array");
 }
 #define strncpy_bufsize(buf, str) \
-  strncpy_size (buf, str, sizeof (buf)); check_is_array (buf); 
+  strncpy_size (buf, str, sizeof (buf)); check_is_array (buf)
 // *INDENT-ON*
 #else // not C++
 #define strncpy_bufsize(buf, str) \

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -6282,7 +6282,7 @@ sysprm_set_er_log_file (const char *db_name)
       return;
     }
 
-  strncpy (local_db_name, db_name, DB_MAX_IDENTIFIER_LENGTH);
+  strncpy_bufsize (local_db_name, db_name);
   s = strchr (local_db_name, '@');
   if (s)
     {
@@ -6355,7 +6355,7 @@ sysprm_load_and_init_internal (const char *db_name, const char *conf_file, bool 
     }
   else
     {
-      strncpy (local_db_name, db_name, DB_MAX_IDENTIFIER_LENGTH);
+      strncpy_bufsize (local_db_name, db_name);
       s = strchr (local_db_name, '@');
       if (s)
 	{
@@ -6417,7 +6417,7 @@ sysprm_load_and_init_internal (const char *db_name, const char *conf_file, bool 
       conf_file = envvar_get ("HA_CONF_FILE");
       if (conf_file != NULL && conf_file[0] != '\0')
 	{
-	  strncpy (file_being_dealt_with, conf_file, PATH_MAX);
+	  strncpy_bufsize (file_being_dealt_with, conf_file);
 	}
       else
 	{

--- a/src/base/tz_compile.c
+++ b/src/base/tz_compile.c
@@ -1138,7 +1138,7 @@ tzc_load_countries (TZ_RAW_DATA * tzd_raw, const char *input_folder)
       memset (temp_tz_country, 0, sizeof (temp_tz_country[0]));
       /* store parsed data */
       memcpy (temp_tz_country->code, str, TZ_COUNTRY_CODE_LEN);
-      strncpy (temp_tz_country->full_name, str_country_name + 1, TZ_COUNTRY_NAME_SIZE);
+      strncpy_bufsize (temp_tz_country->full_name, str_country_name + 1);
       temp_tz_country->id = -1;
     }
 

--- a/src/base/xml_parser.c
+++ b/src/base/xml_parser.c
@@ -888,7 +888,9 @@ xml_init_parser_common (void *data, const char *xml_file, const char *encoding)
       return NULL;
     }
 
-  strncpy (pd->encoding, encoding, MAX_ENCODE_LEN);
+  size_t encoding_len = strnlen (encoding, MAX_ENCODE_LEN);
+  memcpy (pd->encoding, encoding, MAX_ENCODE_LEN);
+  pd->encoding[MAX_ENCODE_LEN - 1] = '\0';
 
   pd->xml_parser = p;
   pd->xml_error = XML_CUB_NO_ERROR;

--- a/src/base/xml_parser.c
+++ b/src/base/xml_parser.c
@@ -889,8 +889,8 @@ xml_init_parser_common (void *data, const char *xml_file, const char *encoding)
     }
 
   size_t encoding_len = strnlen (encoding, MAX_ENCODE_LEN);
-  memcpy (pd->encoding, encoding, MAX_ENCODE_LEN);
-  pd->encoding[MAX_ENCODE_LEN - 1] = '\0';
+  memcpy (pd->encoding, encoding, encoding_len);
+  pd->encoding[encoding_len] = '\0';
 
   pd->xml_parser = p;
   pd->xml_error = XML_CUB_NO_ERROR;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1999,8 +1999,8 @@ insert_db_server_check_list (T_DB_SERVER * list_p, int check_list_cnt, const cha
       return UNUSABLE_DATABASE_MAX;
     }
 
-  strncpy (list_p[i].database_name, db_name, SRV_CON_DBNAME_SIZE - 1);
-  strncpy (list_p[i].database_host, db_host, CUB_MAXHOSTNAMELEN - 1);
+  strncpy_bufsize (list_p[i].database_name, db_name);
+  strncpy_bufsize (list_p[i].database_host, db_host);
   list_p[i].state = -1;
 
   return i + 1;
@@ -2866,7 +2866,7 @@ init_proxy_env ()
 
   memset (&shard_sock_addr, 0, sizeof (shard_sock_addr));
   shard_sock_addr.sun_family = AF_UNIX;
-  strncpy (shard_sock_addr.sun_path, shm_appl->port_name, sizeof (shard_sock_addr.sun_path) - 1);
+  strncpy_bufsize (shard_sock_addr.sun_path, shm_appl->port_name);
 
 #ifdef  _SOCKADDR_LEN		/* 4.3BSD Reno and later */
   len = sizeof (shard_sock_addr.sun_len) + sizeof (shard_sock_addr.sun_family) + strlen (shard_sock_addr.sun_path) + 1;

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -2198,8 +2198,8 @@ admin_conf_change (int master_shm_id, const char *br_name, const char *conf_name
 	  goto set_conf_error;
 	}
 
-      strncpy (br_info_p->preferred_hosts, host_name, host_name_len);
-      strncpy (shm_as_p->preferred_hosts, host_name, host_name_len);
+      strcpy (br_info_p->preferred_hosts, host_name);
+      strcpy (shm_as_p->preferred_hosts, host_name);
     }
   else if (strcasecmp (conf_name, "MAX_PREPARED_STMT_COUNT") == 0)
     {

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -747,8 +747,7 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy (time_str, ini_getstr (ini, sec_name, "MYSQL_READ_TIMEOUT", DEFAULT_MYSQL_READ_TIMEOUT, &lineno),
-	       sizeof (time_str));
+      strncpy_bufsize (time_str, ini_getstr (ini, sec_name, "MYSQL_READ_TIMEOUT", DEFAULT_MYSQL_READ_TIMEOUT, &lineno));
       br_info[num_brs].mysql_read_timeout = (int) ut_time_string_to_sec (time_str, "sec");
       if (br_info[num_brs].mysql_read_timeout < 0)
 	{

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -242,7 +242,7 @@ dir_repath (char *path, size_t path_len)
       return;
     }
 
-  strncpy (tmp_str, path, BROKER_PATH_MAX);
+  strncpy_bufsize (tmp_str, path);
   if (snprintf (path, path_len, "%s/%s", get_cubrid_home (), tmp_str) < 0)
     {
       assert (false);
@@ -459,8 +459,7 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 
       br_info[num_brs].appl_server_shm_id = ini_gethex (ini, sec_name, "APPL_SERVER_SHM_ID", 0, &lineno);
 
-      strncpy (size_str, ini_getstr (ini, sec_name, "APPL_SERVER_MAX_SIZE", DEFAULT_SERVER_MAX_SIZE, &lineno),
-	       sizeof (size_str));
+      strncpy_bufsize (size_str, ini_getstr (ini, sec_name, "APPL_SERVER_MAX_SIZE", DEFAULT_SERVER_MAX_SIZE, &lineno));
       br_info[num_brs].appl_server_max_size = (int) ut_size_string_to_kbyte (size_str, "M");
       if (br_info[num_brs].appl_server_max_size < 0)
 	{
@@ -468,9 +467,8 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy (size_str,
-	       ini_getstr (ini, sec_name, "APPL_SERVER_MAX_SIZE_HARD_LIMIT", DEFAULT_SERVER_HARD_LIMIT, &lineno),
-	       sizeof (size_str));
+      strncpy_bufsize (size_str, ini_getstr (ini, sec_name, "APPL_SERVER_MAX_SIZE_HARD_LIMIT",
+					     DEFAULT_SERVER_HARD_LIMIT, &lineno));
       br_info[num_brs].appl_server_hard_limit = (int) ut_size_string_to_kbyte (size_str, "M");
       if (br_info[num_brs].appl_server_hard_limit <= 0)
 	{
@@ -478,8 +476,7 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy (time_str, ini_getstr (ini, sec_name, "SESSION_TIMEOUT", DEFAULT_SESSION_TIMEOUT, &lineno),
-	       sizeof (time_str));
+      strncpy_bufsize (time_str, ini_getstr (ini, sec_name, "SESSION_TIMEOUT", DEFAULT_SESSION_TIMEOUT, &lineno));
       br_info[num_brs].session_timeout = (int) ut_time_string_to_sec (time_str, "sec");
       if (br_info[num_brs].session_timeout < 0)
 	{
@@ -540,8 +537,7 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
       br_info[num_brs].sql_log2 = ini_getuint_max (ini, sec_name, "SQL_LOG2", SQL_LOG2_NONE, SQL_LOG2_MAX, &lineno);
 #endif
 
-      strncpy (size_str, ini_getstr (ini, sec_name, "SQL_LOG_MAX_SIZE", DEFAULT_SQL_LOG_MAX_SIZE, &lineno),
-	       sizeof (size_str));
+      strncpy_bufsize (size_str, ini_getstr (ini, sec_name, "SQL_LOG_MAX_SIZE", DEFAULT_SQL_LOG_MAX_SIZE, &lineno));
       br_info[num_brs].sql_log_max_size = (int) ut_size_string_to_kbyte (size_str, "K");
       if (br_info[num_brs].sql_log_max_size < 0)
 	{
@@ -554,8 +550,7 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy (time_str, ini_getstr (ini, sec_name, "LONG_QUERY_TIME", DEFAULT_LONG_QUERY_TIME, &lineno),
-	       sizeof (time_str));
+      strncpy_bufsize (time_str, ini_getstr (ini, sec_name, "LONG_QUERY_TIME", DEFAULT_LONG_QUERY_TIME, &lineno));
       tmp_float = (float) ut_time_string_to_sec (time_str, "sec");
       if (tmp_float < 0 || tmp_float > LONG_QUERY_TIME_LIMIT)
 	{
@@ -565,8 +560,8 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
       /* change float to msec */
       br_info[num_brs].long_query_time = (int) (tmp_float * 1000.0);
 
-      strncpy (time_str, ini_getstr (ini, sec_name, "LONG_TRANSACTION_TIME", DEFAULT_LONG_TRANSACTION_TIME, &lineno),
-	       sizeof (time_str));
+      strncpy_bufsize (time_str, ini_getstr (ini, sec_name, "LONG_TRANSACTION_TIME", DEFAULT_LONG_TRANSACTION_TIME,
+					     &lineno));
       tmp_float = (float) ut_time_string_to_sec (time_str, "sec");
       if (tmp_float < 0 || tmp_float > LONG_TRANSACTION_TIME_LIMIT)
 	{
@@ -587,7 +582,7 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
       br_info[num_brs].job_queue_size =
 	ini_getuint_max (ini, sec_name, "JOB_QUEUE_SIZE", DEFAULT_JOB_QUEUE_SIZE, JOB_QUEUE_MAX_SIZE, &lineno);
 
-      strncpy (time_str, ini_getstr (ini, sec_name, "TIME_TO_KILL", DEFAULT_TIME_TO_KILL, &lineno), sizeof (time_str));
+      strncpy_bufsize (time_str, ini_getstr (ini, sec_name, "TIME_TO_KILL", DEFAULT_TIME_TO_KILL, &lineno));
       br_info[num_brs].time_to_kill = (int) ut_time_string_to_sec (time_str, "sec");
       if (br_info[num_brs].time_to_kill < 0)
 	{
@@ -603,8 +598,8 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy (size_str, ini_getstr (ini, sec_name, "ACCESS_LOG_MAX_SIZE", DEFAULT_ACCESS_LOG_MAX_SIZE, &lineno),
-	       sizeof (size_str));
+      strncpy_bufsize (size_str, ini_getstr (ini, sec_name, "ACCESS_LOG_MAX_SIZE", DEFAULT_ACCESS_LOG_MAX_SIZE,
+					     &lineno));
       br_info[num_brs].access_log_max_size = (int) ut_size_string_to_kbyte (size_str, "K");
 
       if (br_info[num_brs].access_log_max_size < 0)
@@ -731,8 +726,7 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy (time_str, ini_getstr (ini, sec_name, "RECONNECT_TIME", DEFAULT_RECONNECT_TIME, &lineno),
-	       sizeof (time_str));
+      strncpy_bufsize (time_str, ini_getstr (ini, sec_name, "RECONNECT_TIME", DEFAULT_RECONNECT_TIME, &lineno));
       br_info[num_brs].cas_rctime = (int) ut_time_string_to_sec (time_str, "sec");
       if (br_info[num_brs].cas_rctime < 0)
 	{
@@ -740,8 +734,7 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy (time_str, ini_getstr (ini, sec_name, "MAX_QUERY_TIMEOUT", DEFAULT_MAX_QUERY_TIMEOUT, &lineno),
-	       sizeof (time_str));
+      strncpy_bufsize (time_str, ini_getstr (ini, sec_name, "MAX_QUERY_TIMEOUT", DEFAULT_MAX_QUERY_TIMEOUT, &lineno));
       br_info[num_brs].query_timeout = (int) ut_time_string_to_sec (time_str, "sec");
       if (br_info[num_brs].query_timeout < 0)
 	{
@@ -768,9 +761,8 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy (time_str,
-	       ini_getstr (ini, sec_name, "MYSQL_KEEPALIVE_INTERVAL", DEFAULT_MYSQL_KEEPALIVE_INTERVAL, &lineno),
-	       sizeof (time_str));
+      strncpy_bufsize (time_str, ini_getstr (ini, sec_name, "MYSQL_KEEPALIVE_INTERVAL",
+					     DEFAULT_MYSQL_KEEPALIVE_INTERVAL, &lineno));
       br_info[num_brs].mysql_keepalive_interval = (int) ut_time_string_to_sec (time_str, "sec");
       if (br_info[num_brs].mysql_keepalive_interval < MIN_MYSQL_KEEPALIVE_INTERVAL)
 	{
@@ -822,17 +814,14 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
       /* SHARD PHASE0 */
       br_info[num_brs].proxy_shm_id = ini_gethex (ini, sec_name, "SHARD_PROXY_SHM_ID", 0, &lineno);
 
-      strncpy (br_info[num_brs].shard_db_name,
-	       ini_getstr (ini, sec_name, "SHARD_DB_NAME", DEFAULT_EMPTY_STRING, &lineno),
-	       sizeof (br_info[num_brs].shard_db_name));
+      strncpy_bufsize (br_info[num_brs].shard_db_name, ini_getstr (ini, sec_name, "SHARD_DB_NAME", DEFAULT_EMPTY_STRING,
+								   &lineno));
 
-      strncpy (br_info[num_brs].shard_db_user,
-	       ini_getstr (ini, sec_name, "SHARD_DB_USER", DEFAULT_EMPTY_STRING, &lineno),
-	       sizeof (br_info[num_brs].shard_db_user));
+      strncpy_bufsize (br_info[num_brs].shard_db_user, ini_getstr (ini, sec_name, "SHARD_DB_USER", DEFAULT_EMPTY_STRING,
+								   &lineno));
 
-      strncpy (br_info[num_brs].shard_db_password,
-	       ini_getstr (ini, sec_name, "SHARD_DB_PASSWORD", DEFAULT_EMPTY_STRING, &lineno),
-	       sizeof (br_info[num_brs].shard_db_password));
+      strncpy_bufsize (br_info[num_brs].shard_db_password, ini_getstr (ini, sec_name, "SHARD_DB_PASSWORD",
+								       DEFAULT_EMPTY_STRING, &lineno));
 
       br_info[num_brs].num_proxy = ini_getuint (ini, sec_name, "SHARD_NUM_PROXY", DEFAULT_SHARD_NUM_PROXY, &lineno);
 
@@ -862,17 +851,16 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy (br_info[num_brs].shard_connection_file,
-	       ini_getstr (ini, sec_name, "SHARD_CONNECTION_FILE", "shard_connection.txt", &lineno),
-	       sizeof (br_info[num_brs].shard_connection_file));
+      strncpy_bufsize (br_info[num_brs].shard_connection_file, ini_getstr (ini, sec_name, "SHARD_CONNECTION_FILE",
+									   "shard_connection.txt", &lineno));
       if (br_info[num_brs].shard_connection_file[0] == '\0')
 	{
 	  errcode = PARAM_BAD_VALUE;
 	  goto conf_error;
 	}
 
-      strncpy (br_info[num_brs].shard_key_file, ini_getstr (ini, sec_name, "SHARD_KEY_FILE", "shard_key.txt", &lineno),
-	       sizeof (br_info[num_brs].shard_key_file));
+      strncpy_bufsize (br_info[num_brs].shard_key_file, ini_getstr (ini, sec_name, "SHARD_KEY_FILE", "shard_key.txt",
+								    &lineno));
       if (br_info[num_brs].shard_key_file[0] == '\0')
 	{
 	  errcode = PARAM_BAD_VALUE;
@@ -900,9 +888,8 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
       strcpy (br_info[num_brs].shard_key_function_name,
 	      ini_getstr (ini, sec_name, "SHARD_KEY_FUNCTION_NAME", DEFAULT_EMPTY_STRING, &lineno));
 
-      strncpy (size_str,
-	       ini_getstr (ini, sec_name, "SHARD_PROXY_LOG_MAX_SIZE", DEFAULT_SHARD_PROXY_LOG_MAX_SIZE, &lineno),
-	       sizeof (size_str));
+      strncpy_bufsize (size_str, ini_getstr (ini, sec_name, "SHARD_PROXY_LOG_MAX_SIZE",
+					     DEFAULT_SHARD_PROXY_LOG_MAX_SIZE, &lineno));
       br_info[num_brs].proxy_log_max_size = (int) ut_size_string_to_kbyte (size_str, "K");
       if (br_info[num_brs].proxy_log_max_size < 0)
 	{
@@ -931,8 +918,8 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy (time_str, ini_getstr (ini, sec_name, "SHARD_PROXY_TIMEOUT", DEFAULT_SHARD_PROXY_TIMEOUT, &lineno),
-	       sizeof (time_str));
+      strncpy_bufsize (time_str, ini_getstr (ini, sec_name, "SHARD_PROXY_TIMEOUT", DEFAULT_SHARD_PROXY_TIMEOUT,
+					     &lineno));
       br_info[num_brs].proxy_timeout = (int) ut_time_string_to_sec (time_str, "sec");
       if (br_info[num_brs].proxy_timeout < 0)
 	{
@@ -945,9 +932,8 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy (time_str,
-	       ini_getstr (ini, sec_name, "SHARD_PROXY_CONN_WAIT_TIMEOUT", DEFAULT_SHARD_PROXY_CONN_WAIT_TIMEOUT,
-			   &lineno), sizeof (time_str));
+      strncpy_bufsize (time_str, ini_getstr (ini, sec_name, "SHARD_PROXY_CONN_WAIT_TIMEOUT",
+					     DEFAULT_SHARD_PROXY_CONN_WAIT_TIMEOUT, &lineno));
       br_info[num_brs].proxy_conn_wait_timeout = (int) ut_time_string_to_sec (time_str, "sec");
       if (br_info[num_brs].proxy_conn_wait_timeout < 0)
 	{

--- a/src/broker/broker_shm.c
+++ b/src/broker/broker_shm.c
@@ -562,7 +562,7 @@ broker_shm_initialize_shm_as (T_BROKER_INFO * br_info_p, T_SHM_PROXY * shm_proxy
       return shm_as_p;
     }
 
-  strncpy (shm_as_p->proxy_log_dir, br_info_p->proxy_log_dir, sizeof (shm_as_p->proxy_log_dir) - 1);
+  strncpy_bufsize (shm_as_p->proxy_log_dir, br_info_p->proxy_log_dir);
 
   shm_as_p->proxy_log_max_size = br_info_p->proxy_log_max_size;
 
@@ -670,10 +670,10 @@ shard_shm_set_shard_conn_info (T_SHM_APPL_SERVER * shm_as_p, T_SHM_PROXY * shm_p
       conn_p = &shm_conn_p->shard_conn[i];
       shard_conn_info_p = &shm_as_p->shard_conn_info[i];
 
-      strncpy (shard_conn_info_p->db_user, user_p->db_user, sizeof (shard_conn_info_p->db_user) - 1);
-      strncpy (shard_conn_info_p->db_name, conn_p->db_name, sizeof (shard_conn_info_p->db_name) - 1);
-      strncpy (shard_conn_info_p->db_host, conn_p->db_conn_info, sizeof (shard_conn_info_p->db_host) - 1);
-      strncpy (shard_conn_info_p->db_password, user_p->db_password, sizeof (shard_conn_info_p->db_password) - 1);
+      strncpy_bufsize (shard_conn_info_p->db_user, user_p->db_user);
+      strncpy_bufsize (shard_conn_info_p->db_name, conn_p->db_name);
+      strncpy_bufsize (shard_conn_info_p->db_host, conn_p->db_conn_info);
+      strncpy_bufsize (shard_conn_info_p->db_password, user_p->db_password);
     }
 }
 

--- a/src/broker/broker_tester.c
+++ b/src/broker/broker_tester.c
@@ -288,7 +288,7 @@ get_master_shm_id (void)
 
   if (conf_file != NULL)
     {
-      strncpy (conf_file_path, conf_file, strlen (conf_file));
+      strncpy_bufsize (conf_file_path, conf_file);
     }
   else
     {

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1089,7 +1089,7 @@ cas_main (void)
 
 		CAS_PROTO_TO_VER_STR (&ver, (int) (CAS_PROTO_VER_MASK & req_info.client_version));
 
-		strncpy (as_info->driver_version, ver, SRV_CON_VER_STR_MAX_SIZE);
+		strncpy_bufsize (as_info->driver_version, ver);
 	      }
 	    else
 	      {

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -422,9 +422,9 @@ ux_check_connection (void)
 	      char dbuser[SRV_CON_DBUSER_SIZE];
 	      char dbpasswd[SRV_CON_DBPASSWD_SIZE];
 
-	      strncpy (dbname, database_name, sizeof (dbname) - 1);
-	      strncpy (dbuser, database_user, sizeof (dbuser) - 1);
-	      strncpy (dbpasswd, database_passwd, sizeof (dbpasswd) - 1);
+	      strncpy_bufsize (dbname, database_name);
+	      strncpy_bufsize (dbuser, database_user);
+	      strncpy_bufsize (dbpasswd, database_passwd);
 
 	      cas_log_debug (ARG_FILE_LINE,
 			     "ux_check_connection: ux_database_shutdown()" " ux_database_connect(%s, %s)", dbname,

--- a/src/broker/cas_network.c
+++ b/src/broker/cas_network.c
@@ -227,7 +227,7 @@ net_connect_proxy (void)
 
   memset (&shard_sock_addr, 0, sizeof (shard_sock_addr));
   shard_sock_addr.sun_family = AF_UNIX;
-  strncpy (shard_sock_addr.sun_path, port_name, sizeof (shard_sock_addr.sun_path) - 1);
+  strncpy_bufsize (shard_sock_addr.sun_path, port_name);
 #ifdef  _SOCKADDR_LEN		/* 4.3BSD Reno and later */
   len = sizeof (shard_sock_addr.sun_len) + sizeof (shard_sock_addr.sun_family) + strlen (shard_sock_addr.sun_path) + 1;
   shard_sock_addr.sun_len = len;

--- a/src/broker/shard_metadata.c
+++ b/src/broker/shard_metadata.c
@@ -194,7 +194,7 @@ shard_metadata_read_key (const char *filename, T_SHM_PROXY * shm_proxy_p)
 	      trim (section);
 	      if (strncasecmp (section, key_column, SHARD_KEY_COLUMN_LEN) != 0)
 		{
-		  strncpy (key_column, section, sizeof (key_column) - 1);
+		  strncpy_bufsize (key_column, section);
 
 		  shm_key_p->num_shard_key++;
 		  idx_key = shm_key_p->num_shard_key - 1;
@@ -225,7 +225,7 @@ shard_metadata_read_key (const char *filename, T_SHM_PROXY * shm_proxy_p)
 	}
 
       key_p = &(shm_key_p->shard_key[idx_key]);
-      strncpy (key_p->key_column, key_column, sizeof (key_p->key_column) - 1);
+      strncpy_bufsize (key_p->key_column, key_column);
 
       if (idx_range >= SHARD_KEY_RANGE_MAX)
 	{

--- a/src/broker/shard_metadata.c
+++ b/src/broker/shard_metadata.c
@@ -125,9 +125,9 @@ shard_metadata_read_user (T_SHM_PROXY * shm_proxy_p, char *db_name, char *db_use
   shm_user_p->num_shard_user = max_user;
 
   user_p = &(shm_user_p->shard_user[0]);
-  strncpy (user_p->db_name, db_name, sizeof (user_p->db_name) - 1);
-  strncpy (user_p->db_user, db_user, sizeof (user_p->db_user) - 1);
-  strncpy (user_p->db_password, db_password, sizeof (user_p->db_password) - 1);
+  strncpy_bufsize (user_p->db_name, db_name);
+  strncpy_bufsize (user_p->db_user, db_user);
+  strncpy_bufsize (user_p->db_password, db_password);
 
   SHARD_INF ("<USERINFO> [%d] db_name:[%s], " "db_user:[%s], db_password:[%s]\n", 0, user_p->db_name, user_p->db_user,
 	     user_p->db_password);

--- a/src/broker/shard_proxy_io.c
+++ b/src/broker/shard_proxy_io.c
@@ -1720,7 +1720,7 @@ proxy_process_client_register (T_SOCKET_IO * sock_io_p)
 
 	  CAS_PROTO_TO_VER_STR (&ver, (int) (CAS_PROTO_VER_MASK & client_version));
 
-	  strncpy (driver_version, ver, SRV_CON_VER_STR_MAX_SIZE);
+	  strncpy_bufsize (driver_version, ver);
 	}
       else
 	{
@@ -4609,8 +4609,8 @@ proxy_set_conn_info (int func_code, int ctx_cid, int ctx_uid, int shard_id, int 
   /* this cas will reconnect to database. */
   shard_stmt_del_all_srv_h_id_for_shard_cas (shard_id, cas_id);
 
-  strncpy (as_info_p->database_user, ctx_p->database_user, SRV_CON_DBUSER_SIZE - 1);
-  strncpy (as_info_p->database_passwd, ctx_p->database_passwd, SRV_CON_DBPASSWD_SIZE - 1);
+  strncpy_bufsize (as_info_p->database_user, ctx_p->database_user);
+  strncpy_bufsize (as_info_p->database_passwd, ctx_p->database_passwd);
 }
 
 static T_CAS_IO *

--- a/src/broker/shard_shm.c
+++ b/src/broker/shard_shm.c
@@ -252,10 +252,8 @@ shard_shm_set_shm_proxy (T_SHM_PROXY * shm_proxy_p, T_BROKER_INFO * br_info_p)
 
   /* SHARD SHARD_KEY_ID */
   shm_proxy_p->shard_key_modular = br_info_p->shard_key_modular;
-  strncpy (shm_proxy_p->shard_key_library_name, br_info_p->shard_key_library_name,
-	   sizeof (br_info_p->shard_key_library_name));
-  strncpy (shm_proxy_p->shard_key_function_name, br_info_p->shard_key_function_name,
-	   sizeof (br_info_p->shard_key_function_name));
+  strncpy_bufsize (shm_proxy_p->shard_key_library_name, br_info_p->shard_key_library_name);
+  strncpy_bufsize (shm_proxy_p->shard_key_function_name, br_info_p->shard_key_function_name);
 
   return;
 }

--- a/src/broker/shard_statement.c
+++ b/src/broker/shard_statement.c
@@ -485,7 +485,7 @@ shard_stmt_new_internal (int stmt_type, char *sql_stmt, int ctx_cid, unsigned in
 
       stmt_p->ctx_cid = ctx_cid;
       stmt_p->ctx_uid = ctx_uid;
-      strncpy (stmt_p->database_user, ctx_p->database_user, SRV_CON_DBUSER_SIZE - 1);
+      strncpy_bufsize (stmt_p->database_user, ctx_p->database_user);
 
       stmt_p->num_pinned = 0;
       stmt_p->lru_prev = NULL;

--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -5696,7 +5696,7 @@ cci_datasource_make_url (T_CCI_PROPERTIES * prop, char *new_url, char *url, T_CC
 
       n = snprintf (append_str, rlen, "%c%s=%d", delim, str, login_timeout);
       assert (rlen >= 0);
-      if (rlen < n)
+      if (rlen < n || n < 0)
 	{
 	  set_error_buffer (err_buf, CCI_ER_NO_MORE_MEMORY, NULL);
 	  return false;
@@ -5718,7 +5718,7 @@ cci_datasource_make_url (T_CCI_PROPERTIES * prop, char *new_url, char *url, T_CC
 
       n = snprintf (append_str, rlen, "%c%s=%d", delim, str, query_timeout);
       assert (rlen >= 0);
-      if (rlen < n)
+      if (rlen < n || n < 0)
 	{
 	  set_error_buffer (err_buf, CCI_ER_NO_MORE_MEMORY, NULL);
 	  return false;
@@ -5742,7 +5742,7 @@ cci_datasource_make_url (T_CCI_PROPERTIES * prop, char *new_url, char *url, T_CC
 
       n = snprintf (append_str, rlen, "%c%s=%s", delim, str, disconnect_on_query_timeout ? "true" : "false");
       assert (rlen >= 0);
-      if (rlen < n)
+      if (rlen < n || n < 0)
 	{
 	  set_error_buffer (err_buf, CCI_ER_NO_MORE_MEMORY, NULL);
 	  return false;

--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -5695,6 +5695,7 @@ cci_datasource_make_url (T_CCI_PROPERTIES * prop, char *new_url, char *url, T_CC
       str = datasource_key[CCI_DS_KEY_LOGIN_TIMEOUT];
 
       n = snprintf (append_str, rlen, "%c%s=%d", delim, str, login_timeout);
+      assert (rlen >= 0);
       if (rlen < n)
 	{
 	  set_error_buffer (err_buf, CCI_ER_NO_MORE_MEMORY, NULL);
@@ -5716,6 +5717,7 @@ cci_datasource_make_url (T_CCI_PROPERTIES * prop, char *new_url, char *url, T_CC
       str = datasource_key[CCI_DS_KEY_QUERY_TIMEOUT];
 
       n = snprintf (append_str, rlen, "%c%s=%d", delim, str, query_timeout);
+      assert (rlen >= 0);
       if (rlen < n)
 	{
 	  set_error_buffer (err_buf, CCI_ER_NO_MORE_MEMORY, NULL);
@@ -5739,6 +5741,7 @@ cci_datasource_make_url (T_CCI_PROPERTIES * prop, char *new_url, char *url, T_CC
       str = datasource_key[CCI_DS_KEY_DISCONNECT_ON_QUERY_TIMEOUT];
 
       n = snprintf (append_str, rlen, "%c%s=%s", delim, str, disconnect_on_query_timeout ? "true" : "false");
+      assert (rlen >= 0);
       if (rlen < n)
 	{
 	  set_error_buffer (err_buf, CCI_ER_NO_MORE_MEMORY, NULL);

--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -5695,13 +5695,13 @@ cci_datasource_make_url (T_CCI_PROPERTIES * prop, char *new_url, char *url, T_CC
       str = datasource_key[CCI_DS_KEY_LOGIN_TIMEOUT];
 
       n = snprintf (append_str, rlen, "%c%s=%d", delim, str, login_timeout);
-      rlen -= n;
-      if (rlen <= 0 || n < 0)
+      if (rlen < n)
 	{
 	  set_error_buffer (err_buf, CCI_ER_NO_MORE_MEMORY, NULL);
 	  return false;
 	}
-      strncat (new_url, append_str, rlen);
+      strcat (new_url, append_str);
+      rlen -= n;
       delim = '&';
 
       reset_error_buffer (err_buf);
@@ -5716,13 +5716,13 @@ cci_datasource_make_url (T_CCI_PROPERTIES * prop, char *new_url, char *url, T_CC
       str = datasource_key[CCI_DS_KEY_QUERY_TIMEOUT];
 
       n = snprintf (append_str, rlen, "%c%s=%d", delim, str, query_timeout);
-      rlen -= n;
-      if (rlen <= 0 || n < 0)
+      if (rlen < n)
 	{
 	  set_error_buffer (err_buf, CCI_ER_NO_MORE_MEMORY, NULL);
 	  return false;
 	}
-      strncat (new_url, append_str, rlen);
+      strcat (new_url, append_str);
+      rlen -= n;
       delim = '&';
 
       reset_error_buffer (err_buf);
@@ -5739,13 +5739,13 @@ cci_datasource_make_url (T_CCI_PROPERTIES * prop, char *new_url, char *url, T_CC
       str = datasource_key[CCI_DS_KEY_DISCONNECT_ON_QUERY_TIMEOUT];
 
       n = snprintf (append_str, rlen, "%c%s=%s", delim, str, disconnect_on_query_timeout ? "true" : "false");
-      rlen -= n;
-      if (rlen <= 0 || n < 0)
+      if (rlen < n)
 	{
 	  set_error_buffer (err_buf, CCI_ER_NO_MORE_MEMORY, NULL);
 	  return false;
 	}
-      strncat (new_url, append_str, rlen);
+      strcat (new_url, append_str);
+      rlen -= n;
       delim = '&';
 
       reset_error_buffer (err_buf);

--- a/src/cci/cci_network.c
+++ b/src/cci/cci_network.c
@@ -177,11 +177,12 @@ net_connect_srv (T_CON_HANDLE * con_handle, int host_id, T_CCI_ERROR * err_buf, 
     }
   info += SRV_CON_DBPASSWD_SIZE;
 
-  strncpy (info, con_handle->url, SRV_CON_URL_SIZE - 1);
-  strncpy (ver_str, MAKE_STR (BUILD_NUMBER), SRV_CON_VER_STR_MAX_SIZE);
+  size_t url_len = strnlen (con_handle->url, SRV_CON_URL_SIZE - 1);
+  memcpy (info, con_handle->url, url_len);
 
-  ver_ptr = info + strlen (con_handle->url) + 1;
-  if (strlen (con_handle->url) + strlen (ver_str) + 3 <= SRV_CON_URL_SIZE)
+  strncpy (ver_str, MAKE_STR (BUILD_NUMBER), SRV_CON_VER_STR_MAX_SIZE);
+  ver_ptr = info + url_len + 1;
+  if (url_len + strlen (ver_str) + 3 <= SRV_CON_URL_SIZE)
     {
       ver_ptr[0] = (char) strlen (ver_str) + 1;
       memcpy (ver_ptr + 1, ver_str, strlen (ver_str) + 1);
@@ -870,10 +871,12 @@ net_check_broker_alive (unsigned char *ip_addr, int port, int timeout_msec)
 
   info = db_info;
 
-  strncpy (info, db_name, SRV_CON_DBNAME_SIZE - 1);
+  size_t db_name_len = strnlen (db_name, SRV_CON_DBNAME_SIZE - 1);
+  memcpy (info, db_name, db_name_len);
   info += (SRV_CON_DBNAME_SIZE + SRV_CON_DBUSER_SIZE + SRV_CON_DBPASSWD_SIZE);
 
-  strncpy (info, url, SRV_CON_URL_SIZE - 1);
+  size_t url_len = strnlen (url, SRV_CON_URL_SIZE - 1);
+  memcpy (info, url, url_len);
 
   if (connect_srv (ip_addr, port, 0, &sock_fd, timeout_msec) < 0)
     {

--- a/src/cci/cci_network.c
+++ b/src/cci/cci_network.c
@@ -179,6 +179,7 @@ net_connect_srv (T_CON_HANDLE * con_handle, int host_id, T_CCI_ERROR * err_buf, 
 
   size_t url_len = strnlen (con_handle->url, SRV_CON_URL_SIZE - 1);
   memcpy (info, con_handle->url, url_len);
+  info[url_len] = '\0';
 
   strncpy (ver_str, MAKE_STR (BUILD_NUMBER), SRV_CON_VER_STR_MAX_SIZE);
   ver_ptr = info + url_len + 1;
@@ -873,10 +874,12 @@ net_check_broker_alive (unsigned char *ip_addr, int port, int timeout_msec)
 
   size_t db_name_len = strnlen (db_name, SRV_CON_DBNAME_SIZE - 1);
   memcpy (info, db_name, db_name_len);
+  info[db_name_len] = '\0';
   info += (SRV_CON_DBNAME_SIZE + SRV_CON_DBUSER_SIZE + SRV_CON_DBPASSWD_SIZE);
 
   size_t url_len = strnlen (url, SRV_CON_URL_SIZE - 1);
   memcpy (info, url, url_len);
+  info[url_len] = '\0';
 
   if (connect_srv (ip_addr, port, 0, &sock_fd, timeout_msec) < 0)
     {

--- a/src/cm_common/cm_broker_admin.c
+++ b/src/cm_common/cm_broker_admin.c
@@ -461,8 +461,8 @@ job_info_copy (T_CM_JOB_INFO * dest_info, T_JOB_INFO * src_info)
   dest_info->recv_time = src_info->recv_time;
   /* memcpy (dest_info->ip, src_info->ip, 4); */
   ip2str (src_info->ip, dest_info->ipstr);
-  strncpy (dest_info->script, src_info->script, sizeof (dest_info->script) - 1);
-  strncpy (dest_info->prgname, src_info->prgname, sizeof (dest_info->prgname) - 1);
+  strncpy_bufsize (dest_info->script, src_info->script);
+  strncpy_bufsize (dest_info->prgname, src_info->prgname);
 }
 
 static void

--- a/src/cm_common/cm_mem_cpu_stat.c
+++ b/src/cm_common/cm_mem_cpu_stat.c
@@ -1465,6 +1465,8 @@ get_pagesize (void)
 static char *
 strcpy_limit (char *dest, const char *src, int buf_len)
 {
-  strncpy_size (dest, src, buf_len);
+  size_t src_len = strnlen (src, buf_len - 1);
+  memcpy (dest, src, src_len);
+  dest[src_len] = '\0';
   return dest;
 }

--- a/src/cm_common/cm_mem_cpu_stat.c
+++ b/src/cm_common/cm_mem_cpu_stat.c
@@ -29,8 +29,6 @@
 #include "utility.h"
 #include "environment_variable.h"
 #include "cm_utils.h"
-#include "porting.h"
-
 
 #include <string.h>
 #include <stdio.h>

--- a/src/cm_common/cm_mem_cpu_stat.c
+++ b/src/cm_common/cm_mem_cpu_stat.c
@@ -29,6 +29,7 @@
 #include "utility.h"
 #include "environment_variable.h"
 #include "cm_utils.h"
+#include "porting.h"
 
 
 #include <string.h>
@@ -1464,7 +1465,6 @@ get_pagesize (void)
 static char *
 strcpy_limit (char *dest, const char *src, int buf_len)
 {
-  strncpy (dest, src, buf_len - 1);
-  dest[buf_len - 1] = '\0';
+  strncpy_size (dest, src, buf_len);
   return dest;
 }

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -878,7 +878,7 @@ db_restart (const char *program, int print_version, const char *volume)
     }
   else
     {
-      strncpy (db_Program_name, program, PATH_MAX);
+      strncpy_bufsize (db_Program_name, program);
       db_Database_name[0] = '\0';
 
       /* authorization will need to access the database and call some db_ functions so assume connection will be ok

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -4770,7 +4770,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
 	    }
 
 	  currency_symbol_p = lang_currency_symbol (money_p->type);
-	  strncpy (line, currency_symbol_p, strlen (currency_symbol_p));
+	  strcpy (line, currency_symbol_p);
 	  strncpy (line + strlen (currency_symbol_p), (char *) money_string_p->bytes, money_string_p->length);
 	  line[strlen (currency_symbol_p) + money_string_p->length] = '\0';
 

--- a/src/connection/heartbeat.c
+++ b/src/connection/heartbeat.c
@@ -301,7 +301,8 @@ hb_make_set_hbp_register (int type)
   memset ((void *) hbp_register, 0, sizeof (HBP_PROC_REGISTER));
   hbp_register->pid = htonl (getpid ());
   hbp_register->type = htonl (type);
-  strncpy (hbp_register->exec_path, hb_Exec_path, sizeof (hbp_register->exec_path) - 1);
+  strncpy (hbp_register->exec_path, hb_Exec_path, sizeof (hbp_register->exec_path));
+  hbp_register->exec_path[sizeof (hbp_register->exec_path) - 1] = '\0';
 
   p = (char *) &hbp_register->args[0];
   last = (char *) (p + sizeof (hbp_register->args));

--- a/src/connection/heartbeat.c
+++ b/src/connection/heartbeat.c
@@ -301,8 +301,7 @@ hb_make_set_hbp_register (int type)
   memset ((void *) hbp_register, 0, sizeof (HBP_PROC_REGISTER));
   hbp_register->pid = htonl (getpid ());
   hbp_register->type = htonl (type);
-  strncpy (hbp_register->exec_path, hb_Exec_path, sizeof (hbp_register->exec_path));
-  hbp_register->exec_path[sizeof (hbp_register->exec_path) - 1] = '\0';
+  strncpy_bufsize (hbp_register->exec_path, hb_Exec_path);
 
   p = (char *) &hbp_register->args[0];
   last = (char *) (p + sizeof (hbp_register->args));

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1489,7 +1489,7 @@ csql_read_file (const char *file_name)
    * We've successfully read the file, so remember its name for
    * subsequent reads.
    */
-  strncpy (current_file, p, sizeof (current_file));
+  strncpy_bufsize (current_file, p);
 
   if (csql_edit_read_file (fp) == CSQL_FAILURE)
     {
@@ -1568,7 +1568,7 @@ csql_write_file (const char *file_name, int append_flag)
    * We've successfully opened the file, so remember its name for
    * subsequent writes.
    */
-  strncpy (current_file, p, sizeof (current_file));
+  strncpy_bufsize (current_file, p);
 
   if (csql_edit_write_file (fp) == CSQL_FAILURE)
     {
@@ -2613,18 +2613,18 @@ csql (const char *argv0, CSQL_ARGUMENT * csql_arg)
   /* set up prompt and message fields. */
   if (csql_arg->sysadm)
     {
-      strncpy (csql_Prompt, csql_get_message (CSQL_SYSADM_PROMPT), sizeof (csql_Prompt));
+      strncpy_bufsize (csql_Prompt, csql_get_message (CSQL_SYSADM_PROMPT));
     }
   else
     {
-      strncpy (csql_Prompt, csql_get_message (CSQL_PROMPT), sizeof (csql_Prompt));
+      strncpy_bufsize (csql_Prompt, csql_get_message (CSQL_PROMPT));
     }
   avail_size = sizeof (csql_Prompt) - strlen (csql_Prompt) - 1;
   if (avail_size > 0)
     {
       strncat (csql_Prompt, " ", avail_size);
     }
-  strncpy (csql_Name, csql_get_message (CSQL_NAME), sizeof (csql_Name));
+  strncpy_bufsize (csql_Name, csql_get_message (CSQL_NAME));
 
   /* as we must use db_open_file_name() to open the input file, it is necessary to be opening csql_Input_fp at this
    * point */

--- a/src/executables/csql_support.c
+++ b/src/executables/csql_support.c
@@ -886,7 +886,7 @@ nonscr_display_error (char *buffer, int buf_length)
 
       print_len = (remaining - 3 - separator_len) / 2;
       strncat (buffer, errmsg, print_len);	/* first half */
-      strncat (buffer, separator, separator_len);
+      strcat (buffer, separator);
       strncat (buffer, errmsg + len_errmsg - print_len, print_len);	/* second half */
       remaining -= (print_len * 2 + separator_len);
     }

--- a/src/executables/esql_symbol_table.c
+++ b/src/executables/esql_symbol_table.c
@@ -708,7 +708,7 @@ pp_type_str (LINK * link)
 	  /* it's a specifier */
 	  const char *noun_str;
 
-	  strncpy (buf, pp_attr_str (link), sizeof (buf));
+	  strncpy_bufsize (buf, pp_attr_str (link));
 
 	  switch (link->decl.s.noun)
 	    {

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -1796,12 +1796,9 @@ hb_set_net_header (HBP_HEADER * header, unsigned char type, bool is_req, unsigne
   header->r = (is_req) ? 1 : 0;
   header->len = htons (len);
   header->seq = htonl (seq);
-  strncpy (header->group_id, hb_Cluster->group_id, sizeof (header->group_id) - 1);
-  header->group_id[sizeof (header->group_id) - 1] = '\0';
-  strncpy (header->dest_host_name, dest_host_name, sizeof (header->dest_host_name) - 1);
-  header->dest_host_name[sizeof (header->dest_host_name) - 1] = '\0';
-  strncpy (header->orig_host_name, hb_Cluster->myself->host_name, sizeof (header->orig_host_name) - 1);
-  header->orig_host_name[sizeof (header->orig_host_name) - 1] = '\0';
+  strncpy_bufsize (header->group_id, hb_Cluster->group_id);
+  strncpy_bufsize (header->dest_host_name, dest_host_name);
+  strncpy_bufsize (header->orig_host_name, hb_Cluster->myself->host_name);
 
   return NO_ERROR;
 }
@@ -2158,7 +2155,7 @@ hb_cluster_load_ping_host_list (char *ha_ping_host_list)
       return 0;
     }
 
-  strncpy (host_list, ha_ping_host_list, LINE_MAX);
+  strncpy_bufsize (host_list, ha_ping_host_list);
 
   for (host_list_p = host_list;; host_list_p = NULL)
     {
@@ -2334,8 +2331,8 @@ hb_add_ui_node (char *host_name, char *group_id, struct sockaddr_in saddr, int v
   node = (HB_UI_NODE_ENTRY *) malloc (sizeof (HB_UI_NODE_ENTRY));
   if (node)
     {
-      strncpy (node->host_name, host_name, sizeof (node->host_name) - 1);
-      strncpy (node->group_id, group_id, sizeof (node->group_id) - 1);
+      strncpy_bufsize (node->host_name, host_name);
+      strncpy_bufsize (node->group_id, group_id);
       memcpy ((void *) &node->saddr, (void *) &saddr, sizeof (struct sockaddr_in));
       gettimeofday (&node->last_recv_time, NULL);
       node->v_result = v_result;
@@ -2434,7 +2431,7 @@ hb_cluster_load_group_and_node_list (char *ha_node_list, char *ha_replica_list)
 
   hb_Cluster->myself = NULL;
 
-  strncpy (tmp_string, ha_node_list, LINE_MAX);
+  strncpy_bufsize (tmp_string, ha_node_list);
   for (priority = 0, p = strtok_r (tmp_string, "@", &savep); p; priority++, p = strtok_r (NULL, " ,:", &savep))
     {
 
@@ -2442,9 +2439,7 @@ hb_cluster_load_group_and_node_list (char *ha_node_list, char *ha_replica_list)
 	{
 	  /* TODO : trim group id */
 	  /* set heartbeat group id */
-	  strncpy (hb_Cluster->group_id, p, sizeof (hb_Cluster->group_id) - 1);
-	  hb_Cluster->group_id[sizeof (hb_Cluster->group_id) - 1] = '\0';
-
+	  strncpy_bufsize (hb_Cluster->group_id, p);
 	}
       else
 	{
@@ -2473,7 +2468,7 @@ hb_cluster_load_group_and_node_list (char *ha_node_list, char *ha_replica_list)
 
   if (ha_replica_list)
     {
-      strncpy (tmp_string, ha_replica_list, LINE_MAX);
+      strncpy_bufsize (tmp_string, ha_replica_list);
     }
   else
     {

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -705,7 +705,7 @@ checkdb (UTIL_FUNCTION_ARG * arg)
 	    {
 	      continue;
 	    }
-	  strncpy (n, p, SM_MAX_IDENTIFIER_LENGTH);
+	  strncpy_bufsize (n, p);
 	  if (da_add (darray, n) != NO_ERROR)
 	    {
 	      util_log_write_errid (MSGCAT_UTIL_GENERIC_NO_MEM);

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -3432,6 +3432,7 @@ us_hb_stop_get_options (char *db_name, int db_name_size, char *remote_host_name,
   char opt_str[64];
   int tmp_argc;
   const char **tmp_argv = NULL;
+  size_t copy_len;
 
   const struct option hb_stop_opts[] = {
     {COMMDB_HB_DEACT_IMMEDIATELY_L, 0, 0, COMMDB_HB_DEACT_IMMEDIATELY_S},
@@ -3471,7 +3472,7 @@ us_hb_stop_get_options (char *db_name, int db_name_size, char *remote_host_name,
       switch (opt)
 	{
 	case COMMDB_HOST_S:
-	  size_t copy_len = strnlen (optarg, remote_host_name_size - 1);
+	  copy_len = strnlen (optarg, remote_host_name_size - 1);
 	  memcpy (remote_host_name, optarg, copy_len);
 	  remote_host_name[copy_len] = '\0';
 	  break;
@@ -3532,6 +3533,7 @@ us_hb_status_get_options (bool * verbose, char *remote_host_name, int remote_hos
   char opt_str[64];
   int tmp_argc;
   const char **tmp_argv = NULL;
+  int copy_len;
 
   const struct option hb_status_opts[] = {
     {"verbose", 0, 0, 'v'},
@@ -3574,7 +3576,7 @@ us_hb_status_get_options (bool * verbose, char *remote_host_name, int remote_hos
 	  *verbose = true;
 	  break;
 	case COMMDB_HOST_S:
-	  int copy_len = (int) strnlen (optarg, (size_t) (remote_host_name_size - 1));
+	  copy_len = (int) strnlen (optarg, (size_t) (remote_host_name_size - 1));
 	  memcpy (remote_host_name, optarg, copy_len);
 	  remote_host_name[copy_len] = '\0';
 	  break;

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -3471,7 +3471,7 @@ us_hb_stop_get_options (char *db_name, int db_name_size, char *remote_host_name,
       switch (opt)
 	{
 	case COMMDB_HOST_S:
-	  strncpy (remote_host_name, optarg, remote_host_name_size);
+	  strncpy_size (remote_host_name, optarg, remote_host_name_size);
 	  break;
 	case COMMDB_HB_DEACT_IMMEDIATELY_S:
 	  *immediate_stop = true;
@@ -3497,7 +3497,7 @@ us_hb_stop_get_options (char *db_name, int db_name_size, char *remote_host_name,
 
       if ((tmp_argc - optind) == 1)
 	{
-	  strncpy (db_name, tmp_argv[optind], db_name_size);
+	  strncpy_size (db_name, tmp_argv[optind], db_name_size);
 	}
     }
 
@@ -3572,7 +3572,7 @@ us_hb_status_get_options (bool * verbose, char *remote_host_name, int remote_hos
 	  *verbose = true;
 	  break;
 	case COMMDB_HOST_S:
-	  strncpy (remote_host_name, optarg, remote_host_name_size);
+	  strncpy_size (remote_host_name, optarg, remote_host_name_size);
 	  break;
 	default:
 	  status = ER_GENERIC_ERROR;
@@ -3665,7 +3665,7 @@ us_hb_util_get_options (char *db_name, int db_name_size, char *node_name, int no
       switch (opt)
 	{
 	case COMMDB_HOST_S:
-	  strncpy (remote_host_name, optarg, remote_host_name_size);
+	  strncpy_size (remote_host_name, optarg, remote_host_name_size);
 	  break;
 	default:
 	  status = ER_GENERIC_ERROR;
@@ -3692,8 +3692,8 @@ us_hb_util_get_options (char *db_name, int db_name_size, char *node_name, int no
 	  goto ret;
 	}
 
-      strncpy (db_name, tmp_argv[optind], db_name_size);
-      strncpy (node_name, tmp_argv[optind + 1], node_name_size);
+      strncpy_size (db_name, tmp_argv[optind], db_name_size);
+      strncpy_size (node_name, tmp_argv[optind + 1], node_name_size);
     }
 
 ret:

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -3471,7 +3471,9 @@ us_hb_stop_get_options (char *db_name, int db_name_size, char *remote_host_name,
       switch (opt)
 	{
 	case COMMDB_HOST_S:
-	  strncpy_size (remote_host_name, optarg, remote_host_name_size);
+	  size_t copy_len = strnlen (optarg, remote_host_name_size - 1);
+	  memcpy (remote_host_name, optarg, copy_len);
+	  remote_host_name[copy_len] = '\0';
 	  break;
 	case COMMDB_HB_DEACT_IMMEDIATELY_S:
 	  *immediate_stop = true;
@@ -3572,7 +3574,9 @@ us_hb_status_get_options (bool * verbose, char *remote_host_name, int remote_hos
 	  *verbose = true;
 	  break;
 	case COMMDB_HOST_S:
-	  strncpy_size (remote_host_name, optarg, remote_host_name_size);
+	  int copy_len = (int) strnlen (optarg, (size_t) (remote_host_name_size - 1));
+	  memcpy (remote_host_name, optarg, copy_len);
+	  remote_host_name[copy_len] = '\0';
 	  break;
 	default:
 	  status = ER_GENERIC_ERROR;
@@ -3692,8 +3696,13 @@ us_hb_util_get_options (char *db_name, int db_name_size, char *node_name, int no
 	  goto ret;
 	}
 
-      strncpy_size (db_name, tmp_argv[optind], db_name_size);
-      strncpy_size (node_name, tmp_argv[optind + 1], node_name_size);
+      size_t copy_len = strnlen (tmp_argv[optind], db_name_size - 1);
+      memcpy (db_name, tmp_argv[optind], copy_len);
+      db_name[copy_len] = '\0';
+
+      copy_len = strnlen (tmp_argv[optind + 1], node_name_size - 1);
+      memcpy (node_name, tmp_argv[optind + 1], copy_len);
+      node_name[copy_len] = '\0';
     }
 
 ret:

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -3500,7 +3500,9 @@ us_hb_stop_get_options (char *db_name, int db_name_size, char *remote_host_name,
 
       if ((tmp_argc - optind) == 1)
 	{
-	  strncpy_size (db_name, tmp_argv[optind], db_name_size);
+	  copy_len = strnlen (tmp_argv[optind], db_name_size);
+	  memcpy (db_name, tmp_argv[optind], copy_len);
+	  db_name[copy_len] = '\0';
 	}
     }
 
@@ -3628,6 +3630,7 @@ us_hb_util_get_options (char *db_name, int db_name_size, char *node_name, int no
   char opt_str[64];
   int tmp_argc;
   const char **tmp_argv = NULL;
+  size_t copy_len;
 
   const struct option hb_util_opts[] = {
     {COMMDB_HOST_L, 1, 0, COMMDB_HOST_S},
@@ -3671,7 +3674,9 @@ us_hb_util_get_options (char *db_name, int db_name_size, char *node_name, int no
       switch (opt)
 	{
 	case COMMDB_HOST_S:
-	  strncpy_size (remote_host_name, optarg, remote_host_name_size);
+	  copy_len = strnlen (optarg, remote_host_name_size);
+	  memcpy (remote_host_name, optarg, copy_len);
+	  remote_host_name[copy_len] = '\0';
 	  break;
 	default:
 	  status = ER_GENERIC_ERROR;
@@ -3698,7 +3703,7 @@ us_hb_util_get_options (char *db_name, int db_name_size, char *node_name, int no
 	  goto ret;
 	}
 
-      size_t copy_len = strnlen (tmp_argv[optind], db_name_size - 1);
+      copy_len = strnlen (tmp_argv[optind], db_name_size - 1);
       memcpy (db_name, tmp_argv[optind], copy_len);
       db_name[copy_len] = '\0';
 

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -9466,9 +9466,6 @@ do_alter_clause_change_attribute (PARSER_CONTEXT * const parser, PT_NODE * const
 			  && attr_chg_prop.name_space == ID_ATTRIBUTE) ? true : false;
   if (is_srv_update_needed)
     {
-      char tbl_name[DB_MAX_IDENTIFIER_LENGTH];
-
-      strncpy_bufsize (tbl_name, ctemplate->name);
       COPY_OID (&class_oid, &(ctemplate->op->oid_info.oid));
       att_id = attr_chg_prop.att_id;
     }

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -9468,7 +9468,7 @@ do_alter_clause_change_attribute (PARSER_CONTEXT * const parser, PT_NODE * const
     {
       char tbl_name[DB_MAX_IDENTIFIER_LENGTH];
 
-      strncpy (tbl_name, ctemplate->name, DB_MAX_IDENTIFIER_LENGTH);
+      strncpy_bufsize (tbl_name, ctemplate->name);
       COPY_OID (&class_oid, &(ctemplate->op->oid_info.oid));
       att_id = attr_chg_prop.att_id;
     }

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -4665,7 +4665,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
 		{
 		  /* Copying length 0 from NULL pointer fails when DUMA is enabled. */
 		  assert (checksum != NULL);
-		  strncpy (timezone_checksum, checksum, checksum_len);
+		  strcpy (timezone_checksum, checksum);
 		}
 	      timezone_checksum[checksum_len] = '\0';
 	    }

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -6675,8 +6675,8 @@ fileio_initialize_backup (const char *db_full_name_p, const char *backup_destina
    * Adjustments are made at a later point, if the backup_destination is
    * a directory.
    */
-  strncpy (session_p->bkup.name, backup_destination_p, PATH_MAX);
-  strncpy (session_p->bkup.current_path, backup_destination_p, PATH_MAX);
+  strncpy_bufsize (session_p->bkup.name, backup_destination_p);
+  strncpy_bufsize (session_p->bkup.current_path, backup_destination_p);
   session_p->bkup.vlabel = session_p->bkup.name;
   session_p->bkup.vdes = NULL_VOLDES;
   session_p->bkup.dtype = FILEIO_BACKUP_VOL_UNKNOWN;
@@ -7117,8 +7117,8 @@ fileio_start_backup (THREAD_ENTRY * thread_p, const char *db_full_name_p, INT64 
   backup_header_p = session_p->bkup.bkuphdr;
   backup_header_p->iopageid = FILEIO_BACKUP_START_PAGE_ID;
   strncpy (backup_header_p->magic, CUBRID_MAGIC_DATABASE_BACKUP, CUBRID_MAGIC_MAX_LENGTH);
-  strncpy (backup_header_p->db_release, rel_release_string (), REL_MAX_RELEASE_LENGTH);
-  strncpy (backup_header_p->db_fullname, db_full_name_p, PATH_MAX);
+  strncpy_bufsize (backup_header_p->db_release, rel_release_string ());
+  strncpy_bufsize (backup_header_p->db_fullname, db_full_name_p);
   backup_header_p->db_creation = *db_creation_time_p;
   backup_header_p->db_iopagesize = IO_PAGESIZE;
   backup_header_p->db_compatibility = rel_disk_compatible ();

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -5238,7 +5238,7 @@ fileio_get_primitive_way_max (const char *path_p, long int *file_name_max_p, lon
 
   /* Verify the above compilation guesses */
 
-  strncpy (new_guess_path, path_p, PATH_MAX);
+  strncpy_bufsize (new_guess_path, path_p);
   name_p = strrchr (new_guess_path, '/');
 #if defined(WINDOWS)
   {
@@ -5473,7 +5473,7 @@ fileio_get_max_name (const char *given_path_p, long int *file_name_max_p, long i
       if (stat (path_p, &stbuf) != -1 && ((stbuf.st_mode & S_IFMT) != S_IFDIR))
 	{
 	  /* Try it with the directory instead */
-	  strncpy (new_path, given_path_p, PATH_MAX);
+	  strncpy_bufsize (new_path, given_path_p);
 	  name_p = strrchr (new_path, '/');
 #if defined(WINDOWS)
 	  {
@@ -5958,7 +5958,7 @@ fileio_cache (VOLID vol_id, const char *vol_label_p, int vol_fd, FILEIO_LOCKF_TY
 	      sys_vol_info_p->volid = vol_id;
 	      sys_vol_info_p->vdes = vol_fd;
 	      sys_vol_info_p->lockf_type = lockf_type;
-	      strncpy (sys_vol_info_p->vlabel, vol_label_p, PATH_MAX);
+	      strncpy_bufsize (sys_vol_info_p->vlabel, vol_label_p);
 	      sys_vol_info_p->next = fileio_Sys_vol_info_header.anchor.next;
 	      fileio_Sys_vol_info_header.anchor.next = sys_vol_info_p;
 	      fileio_Sys_vol_info_header.num_vols++;
@@ -5974,7 +5974,7 @@ fileio_cache (VOLID vol_id, const char *vol_label_p, int vol_fd, FILEIO_LOCKF_TY
 	  sys_vol_info_p->vdes = vol_fd;
 	  sys_vol_info_p->lockf_type = lockf_type;
 	  sys_vol_info_p->next = NULL;
-	  strncpy (sys_vol_info_p->vlabel, vol_label_p, PATH_MAX);
+	  strncpy_bufsize (sys_vol_info_p->vlabel, vol_label_p);
 #if defined(WINDOWS)
 	  pthread_mutex_init (&sys_vol_info_p->sysvol_mutex, NULL);
 #endif /* WINDOWS */

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -8926,7 +8926,7 @@ fileio_initialize_restore (THREAD_ENTRY * thread_p, const char *db_full_name_p, 
    * which we just checked. */
   session_p->type = FILEIO_BACKUP_READ;	/* access backup device for read */
   /* save database full-pathname specified in the database-loc-file */
-  strncpy (session_p->bkup.loc_db_fullname, is_new_vol_path ? db_full_name_p : "", PATH_MAX);
+  strncpy_bufsize (session_p->bkup.loc_db_fullname, is_new_vol_path ? db_full_name_p : "");
   return (fileio_initialize_backup (db_full_name_p, (const char *) backup_source_p, session_p, level,
 				    restore_verbose_file_path, 0 /* no multi-thread */ , 0 /* no sleep */ ));
 }

--- a/src/thread/thread_looper.cpp
+++ b/src/thread/thread_looper.cpp
@@ -70,6 +70,7 @@ namespace cubthread
 
     // we need to use same target function, however for default setup function first argument must be this and not
     // other
+    m_wait_type = other.m_wait_type;
     switch (other.m_wait_type)
       {
       case INF_WAITS:

--- a/src/thread/thread_looper.cpp
+++ b/src/thread/thread_looper.cpp
@@ -70,7 +70,6 @@ namespace cubthread
 
     // we need to use same target function, however for default setup function first argument must be this and not
     // other
-    m_wait_type = other.m_wait_type;
     switch (other.m_wait_type)
       {
       case INF_WAITS:

--- a/src/tools/cci_applier.c
+++ b/src/tools/cci_applier.c
@@ -923,7 +923,7 @@ static void
 init_con_info (CA_CON_INFO * con_info)
 {
   memset (con_info, 0, sizeof (CA_CON_INFO));
-  strncpy (con_info->db_user, "dba", sizeof (con_info->db_user) - 1);
+  strncpy (con_info->db_user, "dba", sizeof (con_info->db_user));
 
   return;
 }
@@ -961,7 +961,8 @@ validate_args (CA_CON_INFO * con_info, char *repl_log_path)
     }
   else
     {
-      strncpy (repl_log_path, resolved_path, PATH_MAX - 1);
+      strncpy (repl_log_path, resolved_path, PATH_MAX);
+      repl_log_path[PATH_MAX - 1] = '\0';
     }
 
   return;

--- a/src/tools/cci_applier.c
+++ b/src/tools/cci_applier.c
@@ -961,7 +961,7 @@ validate_args (CA_CON_INFO * con_info, char *repl_log_path)
     }
   else
     {
-      strncpy_bufsize (repl_log_path, resolved_path);
+      strncpy_size (repl_log_path, resolved_path, PATH_MAX);
     }
 
   return;

--- a/src/tools/cci_applier.c
+++ b/src/tools/cci_applier.c
@@ -961,8 +961,7 @@ validate_args (CA_CON_INFO * con_info, char *repl_log_path)
     }
   else
     {
-      strncpy (repl_log_path, resolved_path, PATH_MAX);
-      repl_log_path[PATH_MAX - 1] = '\0';
+      strncpy_bufsize (repl_log_path, resolved_path);
     }
 
   return;

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -639,8 +639,8 @@ boot_initialize_client (BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_DB_PATH
       boot_client (tran_index, tran_lock_wait_msecs, tran_isolation);
 #if defined (CS_MODE)
       /* print version string */
-      strncpy (format, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_GENERAL, MSGCAT_GENERAL_DATABASE_INIT),
-	       BOOT_FORMAT_MAX_LENGTH);
+      strncpy_bufsize (format, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_GENERAL,
+					       MSGCAT_GENERAL_DATABASE_INIT));
       (void) fprintf (stdout, format, rel_name ());
 #endif /* CS_MODE */
     }
@@ -1716,7 +1716,7 @@ boot_client_initialize_css (DB_INFO * db, int client_type, bool check_capabiliti
 	  /* save the hostname for the use of calling functions */
 	  if (boot_Host_connected != hostlist[n])
 	    {
-	      strncpy (boot_Host_connected, hostlist[n], CUB_MAXHOSTNAMELEN);
+	      strncpy_bufsize (boot_Host_connected, hostlist[n]);
 	    }
 	  db_set_connected_host_status (hostlist[n]);
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1952,8 +1952,8 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
 
   /* print_version string */
 #if defined (NDEBUG)
-  strncpy (format, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_GENERAL, MSGCAT_GENERAL_DATABASE_INIT),
-	   BOOT_FORMAT_MAX_LENGTH);
+  strncpy_size (format, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_GENERAL, MSGCAT_GENERAL_DATABASE_INIT),
+		BOOT_FORMAT_MAX_LENGTH);
   fprintf (stdout, format, rel_name (), rel_build_number ());
 #else /* NDEBUG */
   fprintf (stdout, "\n%s (%s) (%d debug build)\n\n", rel_name (), rel_build_number (), rel_bit_platform ());
@@ -2724,8 +2724,8 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   if (print_restart)
     {
 #if defined (NDEBUG)
-      strncpy (format, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_GENERAL, MSGCAT_GENERAL_DATABASE_INIT),
-	       BOOT_FORMAT_MAX_LENGTH);
+      strncpy_size (format, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_GENERAL, MSGCAT_GENERAL_DATABASE_INIT),
+		    BOOT_FORMAT_MAX_LENGTH);
       fprintf (stdout, format, rel_name ());
 #else /* NDEBUG */
       fprintf (stdout, "\n%s (%s) (%d debug build)\n\n", rel_name (), rel_build_number (), rel_bit_platform ());
@@ -4390,7 +4390,7 @@ xboot_soft_rename (THREAD_ENTRY * thread_p, const char *old_db_name, const char 
 	  old_lob_path = boot_get_lob_path ();
 	  if (*old_lob_path != '\0')
 	    {
-	      new_lob_path = strncpy (new_lob_pathbuf, old_lob_path, PATH_MAX);
+	      new_lob_path = strncpy_bufsize (new_lob_pathbuf, old_lob_path);
 	    }
 
 	  cfg_delete_db (&dir, old_db_name);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1267,7 +1267,7 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
 	  error_code = ER_LOG_COMPILATION_RELEASE;
 	  goto error;
 	}
-      strncpy (log_Gl.hdr.db_release, rel_release_string (), REL_MAX_RELEASE_LENGTH);
+      strncpy_bufsize (log_Gl.hdr.db_release, rel_release_string ());
     }
 
   /*

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -8034,7 +8034,7 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
 	}
 
       memset (session_storage.bkup.log_path, 0, PATH_MAX);
-      strncpy (session_storage.bkup.log_path, logpath, PATH_MAX);
+      strncpy_bufsize (session_storage.bkup.log_path, logpath);
 
       session = &session_storage;
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1329,7 +1329,7 @@ logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const cha
       return ER_LOG_COMPILATION_RELEASE;
     }
 
-  strncpy (loghdr->db_release, rel_release_string (), REL_MAX_RELEASE_LENGTH);
+  strncpy_bufsize (loghdr->db_release, rel_release_string ());
   loghdr->db_compatibility = rel_disk_compatible ();
   loghdr->db_iopagesize = IO_PAGESIZE;
   loghdr->db_logpagesize = LOG_PAGESIZE;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23444

Warning complains that terminator character may be stripped after strncpy/strncat. Most may be fixed by adding `str[len_after_copy_or_cat] = '\0'`. Sometimes only memcpy solved the warning.