### PR TITLE
[CBRD-23467] copylogdb : delete log active volume if header is just formatted (corrupted)

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -11812,3 +11812,28 @@ fileio_page_check_corruption (THREAD_ENTRY * thread_p, FILEIO_PAGE * io_page, bo
 
   return NO_ERROR;
 }
+
+bool
+fileio_is_formatted_page (THREAD_ENTRY * thread_p, const char *io_page)
+{
+  char *ref_page;
+  bool is_formatted = false;
+
+  ref_page = (char *) malloc (IO_PAGESIZE);
+  if (ref_page == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, IO_PAGESIZE);
+      return false;
+    }
+
+  memset ((char *) ref_page, 0, IO_PAGESIZE);
+  (void) fileio_initialize_res (thread_p, (FILEIO_PAGE *) ref_page, IO_PAGESIZE);
+
+  if (memcmp (io_page, ref_page, IO_PAGESIZE) == 0)
+    {
+      is_formatted = true;
+    }
+
+  free_and_init (ref_page);
+  return false;
+}

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -11835,5 +11835,5 @@ fileio_is_formatted_page (THREAD_ENTRY * thread_p, const char *io_page)
     }
 
   free_and_init (ref_page);
-  return false;
+  return is_formatted;
 }

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -617,4 +617,5 @@ extern void fileio_page_bitmap_list_destroy (FILEIO_RESTORE_PAGE_BITMAP_LIST * p
 extern int fileio_set_page_checksum (THREAD_ENTRY * thread_p, FILEIO_PAGE * io_page);
 extern int fileio_page_check_corruption (THREAD_ENTRY * thread_p, FILEIO_PAGE * io_page, bool * is_page_corrupted);
 extern void fileio_page_hexa_dump (const char *data, int length);
+extern bool fileio_is_formatted_page (THREAD_ENTRY * thread_p, const char *io_page);
 #endif /* _FILE_IO_H_ */

--- a/src/transaction/log_writer.c
+++ b/src/transaction/log_writer.c
@@ -286,6 +286,14 @@ logwr_read_log_header (void)
       else
 	{
 	  error = logwr_fetch_header_page (log_pgptr, logwr_Gl.append_vdes);
+	  if (error == ER_LOG_PAGE_CORRUPTED && fileio_is_formatted_page (NULL, (char *) log_pgptr))
+	    {
+	      fileio_dismount (NULL, LOG_DBLOG_ACTIVE_VOLID);
+	      fileio_unformat (NULL, logwr_Gl.active_name);
+	      er_clear ();
+	      return NO_ERROR;
+	    }
+
 	  if (error != NO_ERROR)
 	    {
 	      return error;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23467

Copylogdb : delete entire copied log active volume if header page appears corrupted but is just formatted.