### PR TITLE
[CBRD-23468] Stop attached threads (load session) when connection is terminated

### DIFF
--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -9951,3 +9951,9 @@ sloaddb_update_stats (THREAD_ENTRY * thread_p, unsigned int rid, char *request, 
   or_pack_int (reply, error_code);
   css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
 }
+
+void
+ssession_stop_attached_threads (void *session)
+{
+  session_stop_attached_threads (session);
+}

--- a/src/communication/network_interface_sr.h
+++ b/src/communication/network_interface_sr.h
@@ -232,4 +232,5 @@ extern void sloaddb_fetch_status (THREAD_ENTRY * thread_p, unsigned int rid, cha
 extern void sloaddb_destroy (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void sloaddb_interrupt (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void sloaddb_update_stats (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
+extern void ssession_stop_attached_threads (void *session);
 #endif /* _NETWORK_INTERFACE_SR_H_ */

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1129,6 +1129,11 @@ net_server_conn_down (THREAD_ENTRY * thread_p, CSS_THREAD_ARG arg)
   /* avoid infinite waiting with xtran_wait_server_active_trans() */
   thread_p->m_status = cubthread::entry::status::TS_CHECK;
 
+  if (conn_p->session_p != NULL)
+    {
+      ssession_stop_attached_threads (conn_p->session_p);
+    }
+
 loop:
   prev_thrd_cnt = css_count_transaction_worker_threads (thread_p, tran_index, client_id);
   if (prev_thrd_cnt > 0)

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -87,4 +87,5 @@ extern int session_set_tran_auto_commit (THREAD_ENTRY * thread_p, bool auto_comm
 
 extern int session_set_load_session (THREAD_ENTRY * thread_p, load_session * load_session_p);
 extern int session_get_load_session (THREAD_ENTRY * thread_p, REFPTR (load_session, load_session_ref_ptr));
+extern void session_stop_attached_threads (void *session);
 #endif /* _SESSION_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23468

Stop (and wait for stop) attached threads (now only those attached to load session) to a session when connection is terminated.
session_state_uninit  : move stop code at start of function; attached load threads may still access session data before stopping them: better to stop them before destroying data.
