### PR TITLE
[CBRD-23465] Fix register class call without mutex

### DIFF
--- a/src/loaddb/load_class_registry.cpp
+++ b/src/loaddb/load_class_registry.cpp
@@ -162,6 +162,8 @@ namespace cubload
   void
   class_registry::register_ignored_class (class_entry *cls_entry, class_id cls_id)
   {
+    std::unique_lock<std::mutex> ulock (m_mutex);
+
     assert (cls_entry != NULL);
     assert (cls_entry->is_ignored ());
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23465

Whenever an ignored class was added to the class registry, it was added without locking the mutex over the map. Which means that some thread could overwrite another entry in the map if both of them arrived at the same time. THis PR should fix it.