### PR TITLE
[CBRD-23476] fix topops.last recovery

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1861,7 +1861,14 @@ log_rv_analysis_end_checkpoint (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_
 		}
 	    }
 
-	  tdes->topops.last++;
+	  if (tdes->topops.last == -1)
+	    {
+	      tdes->topops.last++;
+	    }
+	  else
+	    {
+	      assert (tdes->topops.last == 0);
+	    }
 	  tdes->rcv.sysop_start_postpone_lsa = chkpt_topone->sysop_start_postpone_lsa;
 	  tdes->rcv.atomic_sysop_start_lsa = chkpt_topone->atomic_sysop_start_lsa;
 	  log_lsa_local = chkpt_topone->sysop_start_postpone_lsa;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23476

Do not increment topops.last value during checkpoint analysis if it was already incremented. The log record of start atomic or start postpone may be found by analysis before checkpoint.

It was not reproduced before check pointing system workers because active workers rarely need postpone during sysops.

