### PR TITLE
[CBRD-23444] fix -Wwrite-strings warnings

### DIFF
--- a/src/api/db_value_table.c
+++ b/src/api/db_value_table.c
@@ -510,7 +510,7 @@ db_value_to_value (BIND_HANDLE conn, const DB_VALUE * val, CI_TYPE type, void *a
 		 || dbtype == DB_TYPE_VARNCHAR)
 	  {
 	    DB_VALUE nval;
-	    char *nstr;
+	    const char *nstr;
 
 	    /* need check if the string is numeric string */
 	    db_make_null (&nval);

--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -38,7 +38,6 @@
 #include "language_support.h"
 #include "chartype.h"
 #include "system_parameter.h"
-#include "locale_support.h"
 #include "charset_converters.h"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
@@ -89,24 +88,24 @@ bool intl_Mbs_support = true;
 bool intl_String_validation = false;
 
 /* General EUC string manipulations */
-static int intl_tolower_euc (unsigned char *s, int length_in_chars);
-static int intl_toupper_euc (unsigned char *s, int length_in_chars);
-static int intl_count_euc_chars (unsigned char *s, int length_in_bytes);
-static int intl_count_euc_bytes (unsigned char *s, int length_in_chars);
+static int intl_tolower_euc (const unsigned char *s, unsigned char *d, int length_in_chars);
+static int intl_toupper_euc (const unsigned char *s, unsigned char *d, int length_in_chars);
+static int intl_count_euc_chars (const unsigned char *s, int length_in_bytes);
+static int intl_count_euc_bytes (const unsigned char *s, int length_in_chars);
 #if defined (ENABLE_UNUSED_FUNCTION)
 static wchar_t *intl_copy_lowercase (const wchar_t * ws, size_t n);
 static int intl_is_korean (unsigned char ch);
 #endif /* ENABLE_UNUSED_FUNCTION */
 
 /* UTF-8 string manipulations */
-static int intl_tolower_utf8 (const ALPHABET_DATA * a, unsigned char *s, unsigned char *d, int length_in_chars,
+static int intl_tolower_utf8 (const ALPHABET_DATA * a, const unsigned char *s, unsigned char *d, int length_in_chars,
 			      int *d_size);
-static int intl_toupper_utf8 (const ALPHABET_DATA * a, unsigned char *s, unsigned char *d, int length_in_chars,
+static int intl_toupper_utf8 (const ALPHABET_DATA * a, const unsigned char *s, unsigned char *d, int length_in_chars,
 			      int *d_size);
-static int intl_count_utf8_bytes (unsigned char *s, int length_in_chars);
-static int intl_char_tolower_utf8 (const ALPHABET_DATA * a, unsigned char *s, const int size, unsigned char *d,
+static int intl_count_utf8_bytes (const unsigned char *s, int length_in_chars);
+static int intl_char_tolower_utf8 (const ALPHABET_DATA * a, const unsigned char *s, const int size, unsigned char *d,
 				   unsigned char **next);
-static int intl_char_toupper_utf8 (const ALPHABET_DATA * a, unsigned char *s, const int size, unsigned char *d,
+static int intl_char_toupper_utf8 (const ALPHABET_DATA * a, const unsigned char *s, const int size, unsigned char *d,
 				   unsigned char **next);
 static int intl_strcasecmp_utf8_one_cp (const ALPHABET_DATA * alphabet, unsigned char *str1, unsigned char *str2,
 					const int size_str1, const int size_str2, unsigned int cp1, unsigned int cp2,
@@ -775,8 +774,8 @@ intl_toupper_iso8859 (unsigned char *s, int length)
  *   s(in): string
  *   curr_char_length(out): length of the character at s
  */
-unsigned char *
-intl_nextchar_euc (unsigned char *s, int *curr_char_length)
+const unsigned char *
+intl_nextchar_euc (const unsigned char *s, int *curr_char_length)
 {
   assert (s != NULL);
 
@@ -804,8 +803,8 @@ intl_nextchar_euc (unsigned char *s, int *curr_char_length)
  *   s_start(in) : start of buffer string
  *   prev_char_length(out): length of the previous character
  */
-unsigned char *
-intl_prevchar_euc (unsigned char *s, const unsigned char *s_start, int *prev_char_length)
+const unsigned char *
+intl_prevchar_euc (const unsigned char *s, const unsigned char *s_start, int *prev_char_length)
 {
   assert (s != NULL);
   assert (s > s_start);
@@ -833,17 +832,17 @@ intl_prevchar_euc (unsigned char *s, const unsigned char *s_start, int *prev_cha
  *   length_in_chars(in): length of the string measured in characters
  */
 static int
-intl_tolower_euc (unsigned char *s, int length_in_chars)
+intl_tolower_euc (const unsigned char *s, unsigned char *d, int length_in_chars)
 {
   int char_count;
-  int dummy;
 
   assert (s != NULL);
 
   for (char_count = 0; char_count < length_in_chars; char_count++)
     {
-      *s = char_tolower (*s);
-      s = intl_nextchar_euc (s, &dummy);
+      *d = char_tolower (*s);
+      s++;
+      d++;
     }
 
   return char_count;
@@ -857,17 +856,17 @@ intl_tolower_euc (unsigned char *s, int length_in_chars)
  *   length_in_chars(in): length of the string measured in characters
  */
 static int
-intl_toupper_euc (unsigned char *s, int length_in_chars)
+intl_toupper_euc (const unsigned char *s, unsigned char *d, int length_in_chars)
 {
   int char_count;
-  int dummy;
 
   assert (s != NULL);
 
   for (char_count = 0; char_count < length_in_chars; char_count++)
     {
-      *s = char_toupper (*s);
-      s = intl_nextchar_euc (s, &dummy);
+      *d = char_toupper (*s);
+      s++;
+      d++;
     }
 
   return char_count;
@@ -887,9 +886,9 @@ intl_toupper_euc (unsigned char *s, int length_in_chars)
  *       counted.
  */
 static int
-intl_count_euc_chars (unsigned char *s, int length_in_bytes)
+intl_count_euc_chars (const unsigned char *s, int length_in_bytes)
 {
-  unsigned char *end;
+  const unsigned char *end;
   int dummy;
   int char_count;
 
@@ -916,7 +915,7 @@ intl_count_euc_chars (unsigned char *s, int length_in_bytes)
  *   byte_count(out): number of bytes used for encode
  */
 static int
-intl_count_euc_bytes (unsigned char *s, int length_in_chars)
+intl_count_euc_bytes (const unsigned char *s, int length_in_chars)
 {
   int char_count;
   int char_width;
@@ -950,7 +949,7 @@ intl_count_euc_bytes (unsigned char *s, int length_in_chars)
  * Note: Currently, codeset conversion is not supported
  */
 int
-intl_convert_charset (unsigned char *src, int length_in_chars, INTL_CODESET src_codeset, unsigned char *dest,
+intl_convert_charset (const unsigned char *src, int length_in_chars, INTL_CODESET src_codeset, unsigned char *dest,
 		      INTL_CODESET dest_codeset, int *unconverted)
 {
   int error_code = NO_ERROR;
@@ -980,7 +979,7 @@ intl_convert_charset (unsigned char *src, int length_in_chars, INTL_CODESET src_
  * Note: Embedded NULL characters are counted.
  */
 int
-intl_char_count (unsigned char *src, int length_in_bytes, INTL_CODESET src_codeset, int *char_count)
+intl_char_count (const unsigned char *src, int length_in_bytes, INTL_CODESET src_codeset, int *char_count)
 {
   switch (src_codeset)
     {
@@ -1019,7 +1018,7 @@ intl_char_count (unsigned char *src, int length_in_bytes, INTL_CODESET src_codes
  * Note: Embedded NULL's are counted as characters.
  */
 int
-intl_char_size (unsigned char *src, int length_in_chars, INTL_CODESET src_codeset, int *byte_count)
+intl_char_size (const unsigned char *src, int length_in_chars, INTL_CODESET src_codeset, int *byte_count)
 {
   switch (src_codeset)
     {
@@ -1063,7 +1062,7 @@ intl_char_size (unsigned char *src, int length_in_chars, INTL_CODESET src_codese
  *	 This function is used in context of some specific string functions.
  */
 int
-intl_char_size_pseudo_kor (unsigned char *src, int length_in_chars, INTL_CODESET src_codeset, int *byte_count)
+intl_char_size_pseudo_kor (const unsigned char *src, int length_in_chars, INTL_CODESET src_codeset, int *byte_count)
 {
   switch (src_codeset)
     {
@@ -1124,8 +1123,8 @@ intl_char_size_pseudo_kor (unsigned char *src, int length_in_chars, INTL_CODESET
  *   codeset(in) : enumeration of src codeset
  *   prev_char_size(out) : size of previous character
  */
-unsigned char *
-intl_prev_char (unsigned char *s, const unsigned char *s_start, INTL_CODESET codeset, int *prev_char_size)
+const unsigned char *
+intl_prev_char (const unsigned char *s, const unsigned char *s_start, INTL_CODESET codeset, int *prev_char_size)
 {
   assert (s > s_start);
 
@@ -1164,7 +1163,8 @@ intl_prev_char (unsigned char *s, const unsigned char *s_start, INTL_CODESET cod
  *	 This function is used in context of some specific string functions.
  */
 unsigned char *
-intl_prev_char_pseudo_kor (unsigned char *s, const unsigned char *s_start, INTL_CODESET codeset, int *prev_char_size)
+intl_prev_char_pseudo_kor (const unsigned char *s, const unsigned char *s_start, INTL_CODESET codeset,
+			   int *prev_char_size)
 {
   assert (s > s_start);
 
@@ -1213,8 +1213,8 @@ intl_prev_char_pseudo_kor (unsigned char *s, const unsigned char *s_start, INTL_
  * Note: Returns a pointer to the next character in the string.
  *	 curr_char_length is set to the byte length of the current character.
  */
-unsigned char *
-intl_next_char (unsigned char *s, INTL_CODESET codeset, int *current_char_size)
+const unsigned char *
+intl_next_char (const unsigned char *s, INTL_CODESET codeset, int *current_char_size)
 {
   switch (codeset)
     {
@@ -1251,7 +1251,7 @@ intl_next_char (unsigned char *s, INTL_CODESET codeset, int *current_char_size)
  *	 where korean characters are expected to be handled.
  */
 unsigned char *
-intl_next_char_pseudo_kor (unsigned char *s, INTL_CODESET codeset, int *current_char_size)
+intl_next_char_pseudo_kor (const unsigned char *s, INTL_CODESET codeset, int *current_char_size)
 {
   switch (codeset)
     {
@@ -1311,7 +1311,7 @@ intl_cmp_char (const unsigned char *s1, const unsigned char *s2, INTL_CODESET co
       return *s1 - *s2;
 
     case INTL_CODESET_KSC5601_EUC:
-      (void) intl_nextchar_euc ((unsigned char *) s1, char_size);
+      (void) intl_nextchar_euc (s1, char_size);
       return memcmp (s1, s2, *char_size);
 
     case INTL_CODESET_UTF8:
@@ -1341,7 +1341,7 @@ intl_cmp_char (const unsigned char *s1, const unsigned char *s2, INTL_CODESET co
  *
  */
 int
-intl_cmp_char_pseudo_kor (unsigned char *s1, unsigned char *s2, INTL_CODESET codeset, int *char_size)
+intl_cmp_char_pseudo_kor (const unsigned char *s1, const unsigned char *s2, INTL_CODESET codeset, int *char_size)
 {
   switch (codeset)
     {
@@ -1512,14 +1512,14 @@ intl_pad_size (INTL_CODESET codeset)
  *   src_length(in): length of the string measured in characters
  */
 int
-intl_upper_string_size (const void *alphabet, unsigned char *src, int src_size, int src_length)
+intl_upper_string_size (const ALPHABET_DATA * alphabet, const unsigned char *src, int src_size, int src_length)
 {
   int char_count;
   int req_size = src_size;
 
   assert (alphabet != NULL);
 
-  switch (((ALPHABET_DATA *) alphabet)->codeset)
+  switch (alphabet->codeset)
     {
     case INTL_CODESET_ISO88591:
     case INTL_CODESET_RAW_BYTES:
@@ -1536,7 +1536,7 @@ intl_upper_string_size (const void *alphabet, unsigned char *src, int src_size, 
 	req_size = 0;
 	for (char_count = 0; char_count < src_length && src_size > 0; char_count++)
 	  {
-	    req_size += intl_char_toupper_utf8 ((const ALPHABET_DATA *) alphabet, src, src_size, upper, &next);
+	    req_size += intl_char_toupper_utf8 (alphabet, src, src_size, upper, &next);
 	    src_size -= CAST_STRLEN (next - src);
 	    src = next;
 	  }
@@ -1561,13 +1561,13 @@ intl_upper_string_size (const void *alphabet, unsigned char *src, int src_size, 
  *   length_in_chars(in): length of the string measured in characters
  */
 int
-intl_upper_string (const void *alphabet, unsigned char *src, unsigned char *dst, int length_in_chars)
+intl_upper_string (const ALPHABET_DATA * alphabet, const unsigned char *src, unsigned char *dst, int length_in_chars)
 {
   int char_count = 0;
 
   assert (alphabet != NULL);
 
-  switch (((ALPHABET_DATA *) alphabet)->codeset)
+  switch (alphabet->codeset)
     {
     case INTL_CODESET_RAW_BYTES:
       memcpy (dst, src, length_in_chars);
@@ -1576,7 +1576,8 @@ intl_upper_string (const void *alphabet, unsigned char *src, unsigned char *dst,
 
     case INTL_CODESET_ISO88591:
       {
-	unsigned char *d, *s;
+	unsigned char *d;
+	const unsigned char *s;
 
 	for (d = dst, s = src; d < dst + length_in_chars; d++, s++)
 	  {
@@ -1592,8 +1593,7 @@ intl_upper_string (const void *alphabet, unsigned char *src, unsigned char *dst,
 	intl_char_size (src, length_in_chars, INTL_CODESET_KSC5601_EUC, &byte_count);
 	if (byte_count > 0)
 	  {
-	    memcpy (dst, src, byte_count);
-	    char_count = intl_toupper_euc (dst, length_in_chars);
+	    char_count = intl_toupper_euc (src, dst, length_in_chars);
 	  }
       }
       break;
@@ -1601,7 +1601,7 @@ intl_upper_string (const void *alphabet, unsigned char *src, unsigned char *dst,
     case INTL_CODESET_UTF8:
       {
 	int dummy_size;
-	char_count = intl_toupper_utf8 ((const ALPHABET_DATA *) alphabet, src, dst, length_in_chars, &dummy_size);
+	char_count = intl_toupper_utf8 (alphabet, src, dst, length_in_chars, &dummy_size);
       }
       break;
 
@@ -1623,14 +1623,14 @@ intl_upper_string (const void *alphabet, unsigned char *src, unsigned char *dst,
  *   src_length(in): length of the string measured in characters
  */
 int
-intl_lower_string_size (const void *alphabet, unsigned char *src, int src_size, int src_length)
+intl_lower_string_size (const ALPHABET_DATA * alphabet, const unsigned char *src, int src_size, int src_length)
 {
   int char_count;
   int req_size = src_size;
 
   assert (alphabet != NULL);
 
-  switch (((ALPHABET_DATA *) alphabet)->codeset)
+  switch (alphabet->codeset)
     {
     case INTL_CODESET_ISO88591:
     case INTL_CODESET_RAW_BYTES:
@@ -1647,7 +1647,7 @@ intl_lower_string_size (const void *alphabet, unsigned char *src, int src_size, 
 	req_size = 0;
 	for (char_count = 0; char_count < src_length && src_size > 0; char_count++)
 	  {
-	    req_size += intl_char_tolower_utf8 ((const ALPHABET_DATA *) alphabet, src, src_size, lower, &next);
+	    req_size += intl_char_tolower_utf8 (alphabet, src, src_size, lower, &next);
 	    src_size -= CAST_STRLEN (next - src);
 	    src = next;
 	  }
@@ -1672,17 +1672,18 @@ intl_lower_string_size (const void *alphabet, unsigned char *src, int src_size, 
  *   length_in_chars(in): length of the string measured in characters
  */
 int
-intl_lower_string (const void *alphabet, unsigned char *src, unsigned char *dst, int length_in_chars)
+intl_lower_string (const ALPHABET_DATA * alphabet, const unsigned char *src, unsigned char *dst, int length_in_chars)
 {
   int char_count = 0;
 
   assert (alphabet != NULL);
 
-  switch (((ALPHABET_DATA *) alphabet)->codeset)
+  switch (alphabet->codeset)
     {
     case INTL_CODESET_ISO88591:
       {
-	unsigned char *d, *s;
+	unsigned char *d;
+	const unsigned char *s;
 
 	for (d = dst, s = src; d < dst + length_in_chars; d++, s++)
 	  {
@@ -1702,8 +1703,7 @@ intl_lower_string (const void *alphabet, unsigned char *src, unsigned char *dst,
 	intl_char_size (src, length_in_chars, INTL_CODESET_KSC5601_EUC, &byte_count);
 	if (byte_count > 0)
 	  {
-	    memcpy (dst, src, byte_count);
-	    char_count = intl_tolower_euc (dst, length_in_chars);
+	    char_count = intl_tolower_euc (src, dst, length_in_chars);
 	  }
       }
       break;
@@ -1711,7 +1711,7 @@ intl_lower_string (const void *alphabet, unsigned char *src, unsigned char *dst,
     case INTL_CODESET_UTF8:
       {
 	int dummy_size;
-	char_count = intl_tolower_utf8 ((const ALPHABET_DATA *) alphabet, src, dst, length_in_chars, &dummy_size);
+	char_count = intl_tolower_utf8 (alphabet, src, dst, length_in_chars, &dummy_size);
       }
       break;
 
@@ -1798,10 +1798,11 @@ intl_zone (int category)
  *   codeset(in): enumeration of source string
  */
 int
-intl_reverse_string (unsigned char *src, unsigned char *dst, int length_in_chars, int size_in_bytes,
+intl_reverse_string (const unsigned char *src, unsigned char *dst, int length_in_chars, int size_in_bytes,
 		     INTL_CODESET codeset)
 {
-  unsigned char *end, *s, *d;
+  const unsigned char *end, *s;
+  unsigned char *d;
   int char_count = 0;
   int char_size, i;
 
@@ -2033,8 +2034,8 @@ const unsigned char *const intl_Len_utf8_char = len_utf8_char;
  *   s(in): input string
  *   curr_char_length(out): length of the character at s
  */
-unsigned char *
-intl_nextchar_utf8 (unsigned char *s, int *curr_char_length)
+const unsigned char *
+intl_nextchar_utf8 (const unsigned char *s, int *curr_char_length)
 {
   INTL_GET_NEXTCHAR_UTF8 (s, *curr_char_length);
   return s;
@@ -2048,8 +2049,8 @@ intl_nextchar_utf8 (unsigned char *s, int *curr_char_length)
  *   s_start(in) : start of buffer string
  *   prev_char_length(out): length of the previous character
  */
-unsigned char *
-intl_prevchar_utf8 (unsigned char *s, const unsigned char *s_start, int *prev_char_length)
+const unsigned char *
+intl_prevchar_utf8 (const unsigned char *s, const unsigned char *s_start, int *prev_char_length)
 {
   int l = 0;
 
@@ -2077,7 +2078,8 @@ intl_prevchar_utf8 (unsigned char *s, const unsigned char *s_start, int *prev_ch
  *   d_size(out): size in bytes of destination
  */
 static int
-intl_tolower_utf8 (const ALPHABET_DATA * alphabet, unsigned char *s, unsigned char *d, int length_in_chars, int *d_size)
+intl_tolower_utf8 (const ALPHABET_DATA * alphabet, const unsigned char *s, unsigned char *d, int length_in_chars,
+		   int *d_size)
 {
   int char_count, size;
   int s_size;
@@ -2117,7 +2119,8 @@ intl_tolower_utf8 (const ALPHABET_DATA * alphabet, unsigned char *s, unsigned ch
  *   d_size(out): size in bytes of destination
  */
 static int
-intl_toupper_utf8 (const ALPHABET_DATA * alphabet, unsigned char *s, unsigned char *d, int length_in_chars, int *d_size)
+intl_toupper_utf8 (const ALPHABET_DATA * alphabet, const unsigned char *s, unsigned char *d, int length_in_chars,
+		   int *d_size)
 {
   int char_count, size;
   int s_size;
@@ -2160,9 +2163,9 @@ intl_toupper_utf8 (const ALPHABET_DATA * alphabet, unsigned char *s, unsigned ch
  *       counted.
  */
 int
-intl_count_utf8_chars (unsigned char *s, int length_in_bytes)
+intl_count_utf8_chars (const unsigned char *s, int length_in_bytes)
 {
-  unsigned char *end;
+  const unsigned char *end;
   int dummy;
   int char_count;
 
@@ -2189,7 +2192,7 @@ intl_count_utf8_chars (unsigned char *s, int length_in_bytes)
  *   byte_count(out): number of bytes used for encode
  */
 static int
-intl_count_utf8_bytes (unsigned char *s, int length_in_chars)
+intl_count_utf8_bytes (const unsigned char *s, int length_in_chars)
 {
   int char_count;
   int char_width;
@@ -2219,7 +2222,7 @@ intl_count_utf8_bytes (unsigned char *s, int length_in_chars)
  *	   UTF-8 character
  */
 static int
-intl_char_tolower_utf8 (const ALPHABET_DATA * alphabet, unsigned char *s, const int size, unsigned char *d,
+intl_char_tolower_utf8 (const ALPHABET_DATA * alphabet, const unsigned char *s, const int size, unsigned char *d,
 			unsigned char **next)
 {
   unsigned int cp = intl_utf8_to_cp (s, size, next);
@@ -2281,7 +2284,7 @@ intl_char_tolower_utf8 (const ALPHABET_DATA * alphabet, unsigned char *s, const 
  *	   UTF-8 character
  */
 static int
-intl_char_toupper_utf8 (const ALPHABET_DATA * alphabet, unsigned char *s, const int size, unsigned char *d,
+intl_char_toupper_utf8 (const ALPHABET_DATA * alphabet, const unsigned char *s, const int size, unsigned char *d,
 			unsigned char **next)
 {
   unsigned int cp = intl_utf8_to_cp (s, size, next);
@@ -2844,18 +2847,19 @@ intl_identifier_lower_string_size (const char *src)
       {
 	unsigned char lower[INTL_UTF8_MAX_CHAR_SIZE];
 	unsigned char *next;
-	unsigned char *s;
+	const unsigned char *s;
 	const LANG_LOCALE_DATA *locale = lang_locale ();
 	const ALPHABET_DATA *alphabet = &(locale->ident_alphabet);
 	int s_size = src_size;
 	unsigned int cp;
 	int src_len;
 
-	intl_char_count ((unsigned char *) src, src_size, codeset, &src_len);
+	const unsigned char *usrc = REINTERPRET_CAST (const unsigned char *, src);
+	intl_char_count (usrc, src_size, codeset, &src_len);
 
 	src_lower_size = 0;
 
-	for (s = (unsigned char *) src; s < (unsigned char *) src + src_size;)
+	for (s = usrc; s < usrc + src_size;)
 	  {
 	    assert (s_size > 0);
 
@@ -2910,12 +2914,16 @@ intl_identifier_lower (const char *src, char *dst)
   int d_size = 0;
   int length_in_bytes = 0;
   int length_in_chars = 0;
-  unsigned char *d, *s;
+  unsigned char *d;
+  const unsigned char *s;
 
   if (src)
     {
       length_in_bytes = strlen (src);
     }
+
+  unsigned char *udst = REINTERPRET_CAST (unsigned char *, dst);
+  const unsigned char *usrc = REINTERPRET_CAST (const unsigned char *, src);
 
   switch (lang_charset ())
     {
@@ -2923,16 +2931,15 @@ intl_identifier_lower (const char *src, char *dst)
       {
 	const LANG_LOCALE_DATA *locale = lang_locale ();
 	const ALPHABET_DATA *alphabet = &(locale->ident_alphabet);
-	length_in_chars = intl_count_utf8_chars ((unsigned char *) src, length_in_bytes);
-	(void) intl_tolower_utf8 (alphabet, (unsigned char *) src, (unsigned char *) dst, length_in_chars, &d_size);
-	d = (unsigned char *) dst + d_size;
+	length_in_chars = intl_count_utf8_chars (usrc, length_in_bytes);
+	(void) intl_tolower_utf8 (alphabet, usrc, udst, length_in_chars, &d_size);
+	d = udst + d_size;
       }
       break;
 
     case INTL_CODESET_ISO88591:
       {
-	for (d = (unsigned char *) dst, s = (unsigned char *) src; d < (unsigned char *) dst + length_in_bytes;
-	     d++, s++)
+	for (d = udst, s = usrc; d < udst + length_in_bytes; d++, s++)
 	  {
 	    *d = char_tolower_iso8859 (*s);
 	  }
@@ -2942,8 +2949,7 @@ intl_identifier_lower (const char *src, char *dst)
     case INTL_CODESET_KSC5601_EUC:
     default:
       {
-	for (d = (unsigned char *) dst, s = (unsigned char *) src; d < (unsigned char *) dst + length_in_bytes;
-	     d++, s++)
+	for (d = udst, s = usrc; d < udst + length_in_bytes; d++, s++)
 	  {
 	    *d = char_tolower (*s);
 	  }
@@ -2970,6 +2976,8 @@ intl_identifier_upper_string_size (const char *src)
 
   src_size = strlen (src);
 
+  const unsigned char *usrc = REINTERPRET_CAST (const unsigned char *, src);
+
   switch (codeset)
     {
     case INTL_CODESET_UTF8:
@@ -2977,18 +2985,18 @@ intl_identifier_upper_string_size (const char *src)
       {
 	unsigned char upper[INTL_UTF8_MAX_CHAR_SIZE];
 	unsigned char *next;
-	unsigned char *s;
+	const unsigned char *s;
 	const LANG_LOCALE_DATA *locale = lang_locale ();
 	const ALPHABET_DATA *alphabet = &(locale->ident_alphabet);
 	int s_size = src_size;
 	unsigned int cp;
 	int src_len;
 
-	intl_char_count ((unsigned char *) src, src_size, codeset, &src_len);
+	intl_char_count (usrc, src_size, codeset, &src_len);
 
 	src_upper_size = 0;
 
-	for (s = (unsigned char *) src; s < (unsigned char *) src + src_size;)
+	for (s = usrc; s < usrc + src_size;)
 	  {
 	    assert (s_size > 0);
 
@@ -3043,12 +3051,16 @@ intl_identifier_upper (const char *src, char *dst)
   int d_size = 0;
   int length_in_bytes = 0;
   int length_in_chars = 0;
-  unsigned char *d, *s;
+  unsigned char *d;
+  const unsigned char *s;
 
   if (src)
     {
       length_in_bytes = strlen (src);
     }
+
+  unsigned char *udst = REINTERPRET_CAST (unsigned char *, dst);
+  const unsigned char *usrc = REINTERPRET_CAST (const unsigned char *, src);
 
   switch (lang_charset ())
     {
@@ -3056,15 +3068,14 @@ intl_identifier_upper (const char *src, char *dst)
       {
 	const LANG_LOCALE_DATA *locale = lang_locale ();
 	const ALPHABET_DATA *alphabet = &(locale->ident_alphabet);
-	length_in_chars = intl_count_utf8_chars ((unsigned char *) src, length_in_bytes);
-	(void) intl_toupper_utf8 (alphabet, (unsigned char *) src, (unsigned char *) dst, length_in_chars, &d_size);
-	d = (unsigned char *) dst + d_size;
+	length_in_chars = intl_count_utf8_chars (usrc, length_in_bytes);
+	(void) intl_toupper_utf8 (alphabet, usrc, udst, length_in_chars, &d_size);
+	d = udst + d_size;
       }
       break;
     case INTL_CODESET_ISO88591:
       {
-	for (d = (unsigned char *) dst, s = (unsigned char *) src; d < (unsigned char *) dst + length_in_bytes;
-	     d++, s++)
+	for (d = udst, s = usrc; d < udst + length_in_bytes; d++, s++)
 	  {
 	    *d = char_toupper_iso8859 (*s);
 	  }
@@ -3073,8 +3084,7 @@ intl_identifier_upper (const char *src, char *dst)
     case INTL_CODESET_KSC5601_EUC:
     default:
       {
-	for (d = (unsigned char *) dst, s = (unsigned char *) src; d < (unsigned char *) dst + length_in_bytes;
-	     d++, s++)
+	for (d = udst, s = usrc; d < udst + length_in_bytes; d++, s++)
 	  {
 	    *d = char_toupper (*s);
 	  }
@@ -3113,9 +3123,8 @@ intl_identifier_upper (const char *src, char *dst)
 int
 intl_identifier_fix (char *name, int ident_max_size, bool error_on_case_overflow)
 {
-  int i, length_bytes;
+  int truncated_size = 0, original_size = 0, char_size = 0;
   unsigned char *name_char = (unsigned char *) name;
-  int char_size;
   INTL_CODESET codeset = lang_charset ();
 
   assert (name != NULL);
@@ -3127,10 +3136,10 @@ intl_identifier_fix (char *name, int ident_max_size, bool error_on_case_overflow
 
   assert (ident_max_size > 0 && ident_max_size < DB_MAX_IDENTIFIER_LENGTH);
 
-  length_bytes = strlen (name);
+  original_size = strlen (name);
   if (INTL_CODESET_MULT (codeset) == 1)
     {
-      if (length_bytes > ident_max_size)
+      if (original_size > ident_max_size)
 	{
 	  name[ident_max_size] = '\0';
 	}
@@ -3144,33 +3153,33 @@ intl_identifier_fix (char *name, int ident_max_size, bool error_on_case_overflow
 
 check_truncation:
   /* check if last char of identifier may have been truncated */
-  if (length_bytes + INTL_CODESET_MULT (codeset) > ident_max_size)
+  if (original_size + INTL_CODESET_MULT (codeset) > ident_max_size)
     {
-      if (ident_max_size < length_bytes)
+      if (ident_max_size < original_size)
 	{
-	  length_bytes = ident_max_size;
+	  original_size = ident_max_size;
 	}
 
       /* count original size based on the size given by first byte of each char */
-      for (i = 0; i < length_bytes;)
+      const unsigned char *const_name_char = name_char;
+      for (truncated_size = 0; truncated_size < original_size;)
 	{
-	  INTL_NEXT_CHAR (name_char, name_char, codeset, &char_size);
-	  i += char_size;
+	  INTL_NEXT_CHAR (const_name_char, const_name_char, codeset, &char_size);
+	  truncated_size += char_size;
 	}
+      assert (truncated_size >= original_size);
 
-      assert (i >= length_bytes);
-
-      /* i == length_bytes means last character fit entirely in 'length_bytes' otherwise assume the last character was
-       * truncated */
-      if (i > length_bytes)
+      /* truncated_size == original_size means last character fit entirely in 'original_size'
+       * otherwise assume the last character was truncated */
+      if (truncated_size > original_size)
 	{
-	  assert (i < length_bytes + INTL_CODESET_MULT (codeset));
+	  assert (truncated_size < original_size + INTL_CODESET_MULT (codeset));
 	  assert ((unsigned char) *(name_char - char_size) > 0x80);
 	  /* truncate after the last full character */
-	  i -= char_size;
-	  length_bytes = i;
+	  truncated_size -= char_size;
+	  original_size = truncated_size;
 	}
-      name[length_bytes] = '\0';
+      name[original_size] = '\0';
     }
 
   /* ensure that lower or upper versions of identifier do not exceed maximum allowed size of an identifier */
@@ -3361,7 +3370,7 @@ intl_put_char (unsigned char *dest, const unsigned char *char_p, const INTL_CODE
       break;
 
     case INTL_CODESET_KSC5601_EUC:
-      (void) intl_nextchar_euc ((unsigned char *) char_p, &char_len);
+      (void) intl_nextchar_euc (char_p, &char_len);
       memcpy (dest, char_p, char_len);
       return char_len;
 

--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -3124,7 +3124,7 @@ int
 intl_identifier_fix (char *name, int ident_max_size, bool error_on_case_overflow)
 {
   int truncated_size = 0, original_size = 0, char_size = 0;
-  unsigned char *name_char = (unsigned char *) name;
+  const unsigned char *cname = (unsigned char *) name;
   INTL_CODESET codeset = lang_charset ();
 
   assert (name != NULL);
@@ -3161,10 +3161,9 @@ check_truncation:
 	}
 
       /* count original size based on the size given by first byte of each char */
-      const unsigned char *const_name_char = name_char;
       for (truncated_size = 0; truncated_size < original_size;)
 	{
-	  INTL_NEXT_CHAR (const_name_char, const_name_char, codeset, &char_size);
+	  INTL_NEXT_CHAR (cname, cname, codeset, &char_size);
 	  truncated_size += char_size;
 	}
       assert (truncated_size >= original_size);
@@ -3174,7 +3173,7 @@ check_truncation:
       if (truncated_size > original_size)
 	{
 	  assert (truncated_size < original_size + INTL_CODESET_MULT (codeset));
-	  assert ((unsigned char) *(name_char - char_size) > 0x80);
+	  assert ((unsigned char) *(cname - char_size) > 0x80);
 	  /* truncate after the last full character */
 	  truncated_size -= char_size;
 	  original_size = truncated_size;

--- a/src/base/intl_support.h
+++ b/src/base/intl_support.h
@@ -48,6 +48,7 @@
 #endif
 
 #include "dbtype_def.h"
+#include "locale_support.h"
 
 #ifndef MB_LEN_MAX
 #define MB_LEN_MAX            1
@@ -193,49 +194,57 @@ typedef enum intl_codeset INTL_CODESET;
 extern "C"
 {
 #endif
-  extern int intl_char_count (unsigned char *src, int length_in_bytes, INTL_CODESET src_codeset, int *char_count);
-  extern int intl_char_size (unsigned char *src, int length_in_chars, INTL_CODESET src_codeset, int *byte_count);
+  extern int intl_char_count (const unsigned char *src, int length_in_bytes, INTL_CODESET src_codeset, int *char_count);
+  extern int intl_char_size (const unsigned char *src, int length_in_chars, INTL_CODESET src_codeset, int *byte_count);
 
   extern int intl_tolower_iso8859 (unsigned char *s, int length);
   extern int intl_toupper_iso8859 (unsigned char *s, int length);
 
-  extern unsigned char *intl_nextchar_euc (unsigned char *s, int *curr_length);
-  extern unsigned char *intl_prevchar_euc (unsigned char *s, const unsigned char *s_start, int *prev_length);
-  extern unsigned char *intl_nextchar_utf8 (unsigned char *s, int *curr_length);
-  extern unsigned char *intl_prevchar_utf8 (unsigned char *s, const unsigned char *s_start, int *prev_length);
+  extern const unsigned char *intl_nextchar_euc (const unsigned char *s, int *curr_length);
+  extern const unsigned char *intl_prevchar_euc (const unsigned char *s, const unsigned char *s_start,
+						 int *prev_length);
+  extern const unsigned char *intl_nextchar_utf8 (const unsigned char *s, int *curr_length);
+  extern const unsigned char *intl_prevchar_utf8 (const unsigned char *s, const unsigned char *s_start,
+						  int *prev_length);
 
 #if defined (ENABLE_UNUSED_FUNCTION)
   extern INTL_LANG intl_language (int category);
 #endif				/* ENABLE_UNUSED_FUNCTION */
   extern INTL_ZONE intl_zone (int category);
 
-  extern int intl_convert_charset (unsigned char *src, int length_in_chars, INTL_CODESET src_codeset,
+  extern int intl_convert_charset (const unsigned char *src, int length_in_chars, INTL_CODESET src_codeset,
 				   unsigned char *dest, INTL_CODESET dest_codeset, int *unconverted);
 #if defined (ENABLE_UNUSED_FUNCTION)
-  extern int intl_char_size_pseudo_kor (unsigned char *src, int length_in_chars, INTL_CODESET src_codeset,
+  extern int intl_char_size_pseudo_kor (const unsigned char *src, int length_in_chars, INTL_CODESET src_codeset,
 					int *byte_count);
 #endif
-  extern unsigned char *intl_prev_char (unsigned char *s, const unsigned char *s_start, INTL_CODESET codeset,
-					int *prev_char_size);
+  extern const unsigned char *intl_prev_char (const unsigned char *s, const unsigned char *s_start,
+					      INTL_CODESET codeset, int *prev_char_size);
 #if defined (ENABLE_UNUSED_FUNCTION)
-  extern unsigned char *intl_prev_char_pseudo_kor (unsigned char *s, const unsigned char *s_start, INTL_CODESET codeset,
-						   int *prev_char_size);
+  extern unsigned char *intl_prev_char_pseudo_kor (const unsigned char *s, const unsigned char *s_start,
+						   INTL_CODESET codeset, int *prev_char_size);
 #endif
-  extern unsigned char *intl_next_char (unsigned char *s, INTL_CODESET codeset, int *current_char_size);
+  extern const unsigned char *intl_next_char (const unsigned char *s, INTL_CODESET codeset, int *current_char_size);
 #if defined (ENABLE_UNUSED_FUNCTION)
-  extern unsigned char *intl_next_char_pseudo_kor (unsigned char *s, INTL_CODESET codeset, int *current_char_size);
+  extern unsigned char *intl_next_char_pseudo_kor (const unsigned char *s, INTL_CODESET codeset,
+						   int *current_char_size);
 #endif
   extern int intl_cmp_char (const unsigned char *s1, const unsigned char *s2, INTL_CODESET codeset, int *char_size);
 #if defined (ENABLE_UNUSED_FUNCTION)
-  extern int intl_cmp_char_pseudo_kor (unsigned char *s1, unsigned char *s2, INTL_CODESET codeset, int *char_size);
+  extern int intl_cmp_char_pseudo_kor (const unsigned char *s1, const unsigned char *s2, INTL_CODESET codeset,
+				       int *char_size);
 #endif
   extern void intl_pad_char (const INTL_CODESET codeset, unsigned char *pad_char, int *pad_size);
   extern int intl_pad_size (INTL_CODESET codeset);
-  extern int intl_upper_string_size (const void *alphabet, unsigned char *src, int src_size, int src_length);
-  extern int intl_upper_string (const void *alphabet, unsigned char *src, unsigned char *dst, int length_in_chars);
-  extern int intl_lower_string_size (const void *alphabet, unsigned char *src, int src_size, int src_length);
-  extern int intl_lower_string (const void *alphabet, unsigned char *src, unsigned char *dst, int length_in_chars);
-  extern int intl_reverse_string (unsigned char *src, unsigned char *dst, int length_in_chars, int size_in_bytes,
+  extern int intl_upper_string_size (const ALPHABET_DATA * alphabet, const unsigned char *src, int src_size,
+				     int src_length);
+  extern int intl_upper_string (const ALPHABET_DATA * alphabet, const unsigned char *src, unsigned char *dst,
+				int length_in_chars);
+  extern int intl_lower_string_size (const ALPHABET_DATA * alphabet, const unsigned char *src, int src_size,
+				     int src_length);
+  extern int intl_lower_string (const ALPHABET_DATA * alphabet, const unsigned char *src, unsigned char *dst,
+				int length_in_chars);
+  extern int intl_reverse_string (const unsigned char *src, unsigned char *dst, int length_in_chars, int size_in_bytes,
 				  INTL_CODESET codeset);
   extern bool intl_is_max_bound_chr (INTL_CODESET codeset, const unsigned char *chr);
   extern bool intl_is_min_bound_chr (INTL_CODESET codeset, const unsigned char *chr);
@@ -324,7 +333,7 @@ extern "C"
   extern char *intl_get_money_UTF8_symbol (const DB_CURRENCY currency);
   extern char *intl_get_money_ISO88591_symbol (const DB_CURRENCY currency);
   extern int intl_get_currency_symbol_position (const DB_CURRENCY currency);
-  extern int intl_count_utf8_chars (unsigned char *s, int length_in_bytes);
+  extern int intl_count_utf8_chars (const unsigned char *s, int length_in_bytes);
   extern INTL_UTF8_VALIDITY intl_check_utf8 (const unsigned char *buf, int size, char **pos);
   extern INTL_UTF8_VALIDITY intl_check_euckr (const unsigned char *buf, int size, char **pos);
   extern int intl_utf8_to_iso88591 (const unsigned char *in_buf, const int in_size, unsigned char **out_buf,

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -2626,7 +2626,7 @@ lang_db_put_charset (void)
   server_lang = lang_id ();
 
   AU_DISABLE (au_save);
-  db_make_string_by_const_str (&value, lang_get_lang_name_from_id (server_lang));
+  db_make_string (&value, lang_get_lang_name_from_id (server_lang));
   if (db_put_internal (Au_root, "lang", &value) != NO_ERROR)
     {
       /* Error Setting the language */

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -262,22 +262,22 @@ static int lang_next_coll_char_utf8 (const LANG_COLLATION * lang_coll, const uns
 static int lang_next_coll_seq_utf8_w_contr (const LANG_COLLATION * lang_coll, const unsigned char *seq, const int size,
 					    unsigned char *next_seq, int *len_next);
 static int lang_split_key_iso (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1,
-			       const int size1, const unsigned char *str2, const int size2, unsigned char **key,
+			       const int size1, const unsigned char *str2, const int size2, const unsigned char **key,
 			       int *byte_size);
 static int lang_split_key_byte (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1,
-				const int size1, const unsigned char *str2, const int size2, unsigned char **key,
+				const int size1, const unsigned char *str2, const int size2, const unsigned char **key,
 				int *byte_size);
 static int lang_split_key_binary (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1,
-				  const int size1, const unsigned char *str2, const int size2, unsigned char **key,
-				  int *byte_size);
+				  const int size1, const unsigned char *str2, const int size2,
+				  const unsigned char **key, int *byte_size);
 static int lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1,
-				const int size1, const unsigned char *str2, const int size2, unsigned char **key,
+				const int size1, const unsigned char *str2, const int size2, const unsigned char **key,
 				int *byte_size);
 static int lang_split_key_w_exp (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1,
-				 const int size1, const unsigned char *str2, const int size2, unsigned char **key,
+				 const int size1, const unsigned char *str2, const int size2, const unsigned char **key,
 				 int *byte_size);
 static int lang_split_key_euc (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1,
-			       const int size1, const unsigned char *str2, const int size2, unsigned char **key,
+			       const int size1, const unsigned char *str2, const int size2, const unsigned char **key,
 			       int *byte_size);
 static unsigned int lang_mht2str_byte (const LANG_COLLATION * lang_coll, const unsigned char *str, const int size);
 static unsigned int lang_mht2str_default (const LANG_COLLATION * lang_coll, const unsigned char *str, const int size);
@@ -4612,7 +4612,7 @@ lang_next_coll_seq_utf8_w_contr (const LANG_COLLATION * lang_coll, const unsigne
  */
 static int
 lang_split_key_iso (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1, const int size1,
-		    const unsigned char *str2, const int size2, unsigned char **key, int *byte_size)
+		    const unsigned char *str2, const int size2, const unsigned char **key, int *byte_size)
 {
   const unsigned char *str1_end, *str2_end;
   const unsigned char *str1_begin, *str2_begin;
@@ -4701,7 +4701,7 @@ lang_split_key_iso (const LANG_COLLATION * lang_coll, const bool is_desc, const 
  */
 static int
 lang_split_key_byte (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1, const int size1,
-		     const unsigned char *str2, const int size2, unsigned char **key, int *byte_size)
+		     const unsigned char *str2, const int size2, const unsigned char **key, int *byte_size)
 {
   const unsigned char *str1_end, *str2_end;
   const unsigned char *str1_begin, *str2_begin;
@@ -4792,7 +4792,7 @@ lang_split_key_byte (const LANG_COLLATION * lang_coll, const bool is_desc, const
  */
 static int
 lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1, const int size1,
-		     const unsigned char *str2, const int size2, unsigned char **key, int *byte_size)
+		     const unsigned char *str2, const int size2, const unsigned char **key, int *byte_size)
 {
   const unsigned char *str1_end, *str2_end;
   const unsigned char *str1_begin, *str2_begin;
@@ -4893,7 +4893,7 @@ lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const
  */
 static int
 lang_split_key_w_exp (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1, const int size1,
-		      const unsigned char *str2, const int size2, unsigned char **key, int *byte_size)
+		      const unsigned char *str2, const int size2, const unsigned char **key, int *byte_size)
 {
   const unsigned char *str1_end;
   const unsigned char *str2_end;
@@ -5080,9 +5080,9 @@ lang_split_key_w_exp (const LANG_COLLATION * lang_coll, const bool is_desc, cons
  */
 static int
 lang_split_key_euc (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1, const int size1,
-		    const unsigned char *str2, const int size2, unsigned char **key, int *byte_size)
+		    const unsigned char *str2, const int size2, const unsigned char **key, int *byte_size)
 {
-  unsigned char *str1_next, *str2_next;
+  const unsigned char *str1_next, *str2_next;
   int key_size, char1_size, char2_size;
   const unsigned char *str1_end, *str2_end;
   const unsigned char *str1_begin, *str2_begin;
@@ -5097,8 +5097,8 @@ lang_split_key_euc (const LANG_COLLATION * lang_coll, const bool is_desc, const 
 
   for (; str1 < str1_end && str2 < str2_end;)
     {
-      str1_next = intl_nextchar_euc ((unsigned char *) str1, &char1_size);
-      str2_next = intl_nextchar_euc ((unsigned char *) str2, &char2_size);
+      str1_next = intl_nextchar_euc (str1, &char1_size);
+      str2_next = intl_nextchar_euc (str2, &char2_size);
 
       if (char1_size != char2_size || memcmp (str1, str2, char1_size) != 0)
 	{
@@ -5117,7 +5117,7 @@ lang_split_key_euc (const LANG_COLLATION * lang_coll, const bool is_desc, const 
       while (str2 < str2_end)
 	{
 	  bool is_zero_weight = false;
-	  str2_next = intl_nextchar_euc ((unsigned char *) str2, &char2_size);
+	  str2_next = intl_nextchar_euc (str2, &char2_size);
 	  if (*str2 == 0x20 || *str2 == 0 || (*str2 == 0xa1 && char2_size == 2 && *(str2 + 1) == 0xa1))
 	    {
 	      is_zero_weight = true;
@@ -5140,7 +5140,7 @@ lang_split_key_euc (const LANG_COLLATION * lang_coll, const bool is_desc, const 
       while (str1 < str1_end)
 	{
 	  bool is_zero_weight = false;
-	  str1_next = intl_nextchar_euc ((unsigned char *) str1, &char1_size);
+	  str1_next = intl_nextchar_euc (str1, &char1_size);
 	  if (*str1 == 0x20 || *str1 == 0 || (*str1 == 0xa1 && char1_size == 2 && *(str1 + 1) == 0xa1))
 	    {
 	      is_zero_weight = true;
@@ -6240,15 +6240,15 @@ lang_strmatch_ko (const LANG_COLLATION * lang_coll, bool is_match, const unsigne
       assert (str1_end - str1 > 0);
       assert (str2_end - str2 > 0);
 
-      str1_next = intl_nextchar_euc ((unsigned char *) str1, &char1_size);
-      str2_next = intl_nextchar_euc ((unsigned char *) str2, &char2_size);
+      str1_next = intl_nextchar_euc (str1, &char1_size);
+      str2_next = intl_nextchar_euc (str2, &char2_size);
 
       if (is_match && escape != NULL && memcmp (str2, escape, char2_size) == 0)
 	{
 	  if (!(has_last_escape && str2_next >= str2_end))
 	    {
 	      str2 = str2_next;
-	      str2_next = intl_nextchar_euc ((unsigned char *) str2, &char2_size);
+	      str2_next = intl_nextchar_euc (str2, &char2_size);
 	    }
 	}
 
@@ -6575,7 +6575,7 @@ lang_strmatch_binary (const LANG_COLLATION * lang_coll, bool is_match, const uns
  */
 static int
 lang_split_key_binary (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1, const int size1,
-		       const unsigned char *str2, const int size2, unsigned char **key, int *byte_size)
+		       const unsigned char *str2, const int size2, const unsigned char **key, int *byte_size)
 {
   const unsigned char *str1_end, *str2_end;
   const unsigned char *str1_begin, *str2_begin;

--- a/src/base/language_support.h
+++ b/src/base/language_support.h
@@ -182,7 +182,7 @@ struct lang_collation
 			unsigned char *next_seq, int *len_next);
   /* find common key where str1 <= key < str2 (BTREE string prefix) */
   int (*split_key) (const LANG_COLLATION * lang_coll, const bool is_desc, const unsigned char *str1, const int size1,
-		    const unsigned char *str2, const int size2, unsigned char **key, int *byte_size);
+		    const unsigned char *str2, const int size2, const unsigned char **key, int *byte_size);
   /* compute hash value pseudokey (mht_2str_pseudo_key) */
   unsigned int (*mht2str) (const LANG_COLLATION * lang_coll, const unsigned char *str, const int size);
   /* collation data init function */

--- a/src/base/memory_hash.c
+++ b/src/base/memory_hash.c
@@ -2011,7 +2011,7 @@ mht_get_hash_number (const int ht_size, const DB_VALUE * val)
 {
   unsigned int hashcode = 0;
   int i, len;
-  char *ptr;
+  const char *ptr;
 
   if (!val || DB_IS_NULL (val) || ht_size <= 1)
     {

--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -114,6 +114,7 @@ OR_PUT_FLOAT (char *ptr, float val)
   ui = htonf (val);
   memcpy (ptr, &ui, sizeof (ui));
 }
+
 inline void
 OR_PUT_DOUBLE (char *ptr, double val)
 {
@@ -1275,8 +1276,8 @@ extern int or_put_binary (OR_BUF * buf, DB_BINARY * binary);
 #endif
 extern int or_put_data (OR_BUF * buf, const char *data, int length);
 extern int or_put_oid (OR_BUF * buf, const OID * oid);
-extern int or_put_varbit (OR_BUF * buf, char *string, int bitlen);
-extern int or_packed_put_varbit (OR_BUF * buf, char *string, int bitlen);
+extern int or_put_varbit (OR_BUF * buf, const char *string, int bitlen);
+extern int or_packed_put_varbit (OR_BUF * buf, const char *string, int bitlen);
 extern int or_put_varchar (OR_BUF * buf, char *string, int charlen);
 extern int or_packed_put_varchar (OR_BUF * buf, char *string, int charlen);
 extern int or_put_align32 (OR_BUF * buf);

--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -1451,7 +1451,7 @@ or_cl_get_prop_nocopy (DB_SEQ * properties, const char *name, DB_VALUE * pvalue)
   int error;
   int found, max, i;
   DB_VALUE value;
-  char *prop_name;
+  const char *prop_name;
 
   error = NO_ERROR;
   found = 0;
@@ -1573,7 +1573,7 @@ or_install_btids_foreign_key_ref (DB_SEQ * fk_container, OR_INDEX * index)
   int pageid, slotid, volid, fileid;
   DB_SEQ *fk_seq;
   OR_FOREIGN_KEY *fk, *p = NULL;
-  char *fkname;
+  const char *fkname;
 
   size = set_size (fk_container);
 
@@ -1719,7 +1719,7 @@ or_install_btids_filter_pred (DB_SEQ * pred_seq, OR_INDEX * index)
   DB_VALUE val1, val2;
   int error = NO_ERROR;
   int buffer_len = 0;
-  char *buffer = NULL;
+  const char *buffer = NULL;
   OR_PREDICATE *filter_predicate = NULL;
 
   index->filter_predicate = NULL;
@@ -2347,7 +2347,7 @@ or_get_current_representation (RECDES * record, int do_indexes)
   int n_shared_attrs, n_class_attrs;
   OR_BUF buf;
   DB_VALUE properties_val, def_expr_op, def_expr, def_expr_type, def_expr_format;
-  char *def_expr_format_str = NULL;
+  const char *def_expr_format_str = NULL;
   DB_SEQ *att_props = NULL, *def_expr_set = NULL;
 
   rep = (OR_CLASSREP *) malloc (sizeof (OR_CLASSREP));
@@ -3544,7 +3544,7 @@ or_get_constraint_comment (RECDES * record, const char *constraint_name)
 	  else if (DB_VALUE_TYPE (&cvalue) == DB_TYPE_STRING)
 	    {
 	      /* strdup, caller shall free it */
-	      char *cvalue_string = db_get_string (&cvalue);
+	      const char *cvalue_string = db_get_string (&cvalue);
 	      comment = strdup (cvalue_string);
 	    }
 	  else
@@ -3991,7 +3991,7 @@ or_install_btids_function_info (DB_SEQ * fi_seq, OR_INDEX * index)
 {
   OR_FUNCTION_INDEX *fi_info = NULL;
   DB_VALUE val, val1;
-  char *buffer;
+  const char *buffer;
 
   index->func_index_info = NULL;
   if (fi_seq == NULL)

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -3803,7 +3803,7 @@ perfmon_unpack_stats (char *buf, UINT64 * stats)
 
 /*
  * perfmon_get_peek_stats - Copy into the statistics array the values of the peek statistics
- *		
+ *
  * return: void
  *
  *   stats (in): statistics array

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -1296,7 +1296,7 @@ perfmon_is_perf_tracking_and_active (int activation_flag)
 /*
  * perfmon_is_perf_tracking_force () - Skips the check for active threads if the always_collect
  *				       flag is set to true
- *				
+ *
  * return	        : true or false
  * always_collect (in)  : flag that tells that we should always collect statistics
  *

--- a/src/base/timezone_lib_common.h
+++ b/src/base/timezone_lib_common.h
@@ -76,9 +76,6 @@ typedef enum
  *		      - no new time zones are added;
  * TZ_GEN_TYPE_EXTEND - this flag is used when generating a new timezone library
  *		        using the old library and the new timezone data
- *		
- *		
- *		
  */
 typedef enum
 {

--- a/src/base/tz_compile.c
+++ b/src/base/tz_compile.c
@@ -6545,7 +6545,7 @@ tzc_update (TZ_DATA * tzd, const char *database_name)
   DB_INFO *db_info_p = NULL;
   bool need_db_shutdown = false;
   const char *program_name = "extend";
-  char *table_name = NULL;
+  const char *table_name = NULL;
   bool is_first_column = true;
   bool has_timezone_column;
 
@@ -6656,7 +6656,7 @@ tzc_update (TZ_DATA * tzd, const char *database_name)
 		  printf ("We will update the following columns:\n");
 		  while (db_query_next_tuple (result2) == DB_CURSOR_SUCCESS)
 		    {
-		      char *column_name = NULL;
+		      const char *column_name = NULL;
 		      int column_type = 0;
 
 		      /* Get the column name */

--- a/src/base/tz_support.c
+++ b/src/base/tz_support.c
@@ -4736,7 +4736,7 @@ tz_timezones_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg
 	  goto exit_on_error;
 	}
       /* Geographic timezone name */
-      db_make_string_by_const_str (&vals[0], tzd->names[i].name);
+      db_make_string (&vals[0], tzd->names[i].name);
     }
 
   *ptr = ctx;
@@ -4821,7 +4821,7 @@ tz_full_timezones_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE *
 	  goto exit_on_error;
 	}
       /* Geographic timezone name */
-      db_make_string_by_const_str (&vals[idx++], tzd->names[i].name);
+      db_make_string (&vals[idx++], tzd->names[i].name);
 
       /* First get the zone id */
       zone_id = i;

--- a/src/base/unicode_support.c
+++ b/src/base/unicode_support.c
@@ -1272,13 +1272,14 @@ unicode_compose_string (const char *str_in, const int size_in, char *str_out, in
  *  Note : Input string is assumed UTF-8 character set.
  */
 bool
-unicode_string_need_decompose (char *str_in, const int size_in, int *decomp_size, const UNICODE_NORMALIZATION * norm)
+unicode_string_need_decompose (const char *str_in, const int size_in, int *decomp_size,
+			       const UNICODE_NORMALIZATION * norm)
 {
   int bytes_read, decomp_index, decomposed_size = 0;
   unsigned int cp;
-  char *src_cursor;
-  char *src_end;
-  char *next;
+  const char *src_cursor;
+  const char *src_end;
+  const char *next;
   bool can_decompose;
 
   if (!prm_get_bool_value (PRM_ID_UNICODE_OUTPUT_NORMALIZATION) || norm == NULL)
@@ -1356,14 +1357,14 @@ no_decompose_cnt:
  * norm(in) : the unicode context in which the normalization is performed
  */
 void
-unicode_decompose_string (char *str_in, const int size_in, char *str_out, int *size_out,
+unicode_decompose_string (const char *str_in, const int size_in, char *str_out, int *size_out,
 			  const UNICODE_NORMALIZATION * norm)
 {
   int bytes_read, decomp_index;
   unsigned int cp;
-  char *src_cursor;
-  char *src_end;
-  char *next;
+  const char *src_cursor;
+  const char *src_end;
+  const char *next;
   char *dest_cursor;
 
   assert (prm_get_bool_value (PRM_ID_UNICODE_OUTPUT_NORMALIZATION) && norm != NULL);

--- a/src/base/unicode_support.h
+++ b/src/base/unicode_support.h
@@ -48,9 +48,9 @@ extern "C"
 					   const UNICODE_NORMALIZATION * norm);
   extern void unicode_compose_string (const char *str_in, const int size_in, char *str_out, int *size_out,
 				      bool * is_composed, const UNICODE_NORMALIZATION * norm);
-  extern bool unicode_string_need_decompose (char *str_in, const int size_in, int *decomp_size,
+  extern bool unicode_string_need_decompose (const char *str_in, const int size_in, int *decomp_size,
 					     const UNICODE_NORMALIZATION * norm);
-  extern void unicode_decompose_string (char *str_in, const int size_in, char *str_out, int *size_out,
+  extern void unicode_decompose_string (const char *str_in, const int size_in, char *str_out, int *size_out,
 					const UNICODE_NORMALIZATION * norm);
 #endif
   extern int string_to_int_array (char *s, uint32 * cp_list, const int cp_list_size, const char *delims);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -299,7 +299,7 @@ static int create_srv_handle_with_query_result (T_QUERY_RESULT * src_q_result, D
 static int get_client_result_cache_lifetime (DB_SESSION * session, int stmt_id);
 static bool has_stmt_result_set (char stmt_type);
 static bool check_auto_commit_after_getting_result (T_SRV_HANDLE * srv_handle);
-static char *convert_db_value_to_string (DB_VALUE * value, DB_VALUE * value_string);
+static const char *convert_db_value_to_string (DB_VALUE * value, DB_VALUE * value_string);
 static void serialize_collection_as_string (DB_VALUE * col, char **out);
 static void add_fk_info_before (T_FK_INFO_RESULT * pivot, T_FK_INFO_RESULT * pnew);
 static void add_fk_info_after (T_FK_INFO_RESULT * pivot, T_FK_INFO_RESULT * pnew);
@@ -4512,7 +4512,7 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
     case DB_TYPE_VARCHAR:
     case DB_TYPE_CHAR:
       {
-	DB_C_CHAR str;
+	DB_CONST_C_CHAR str;
 	int dummy = 0;
 	int bytes_size = 0;
 	int decomp_size;
@@ -4563,7 +4563,7 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
     case DB_TYPE_VARNCHAR:
     case DB_TYPE_NCHAR:
       {
-	DB_C_NCHAR nchar;
+	DB_CONST_C_NCHAR nchar;
 	int dummy = 0;
 	int bytes_size = 0;
 	int decomp_size;
@@ -4871,7 +4871,7 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
       {
 	DB_DOMAIN *char_domain;
 	DB_VALUE v;
-	char *str;
+	const char *str;
 	int len, err;
 	char buf[128];
 
@@ -9925,10 +9925,10 @@ ux_lob_read (DB_VALUE * lob_dbval, INT64 offset, int size, T_NET_BUF * net_buf)
 }
 
 /* converting a DB_VALUE to a char taking care of nchar strings */
-static char *
+static const char *
 convert_db_value_to_string (DB_VALUE * value, DB_VALUE * value_string)
 {
-  char *val_str = NULL;
+  const char *val_str = NULL;
   DB_TYPE val_type;
   int err, len;
 
@@ -9967,7 +9967,7 @@ serialize_collection_as_string (DB_VALUE * col, char **out)
   DB_VALUE value, value_string;
   int i, size;
   int needed_size = 0;
-  char *single_value = NULL;
+  const char *single_value = NULL;
 
   *out = NULL;
 

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -226,7 +226,7 @@ static int fetch_constraint (T_SRV_HANDLE *, int, int, char, int, T_NET_BUF *, T
 static int fetch_trigger (T_SRV_HANDLE *, int, int, char, int, T_NET_BUF *, T_REQ_INFO *);
 static int fetch_privilege (T_SRV_HANDLE *, int, int, char, int, T_NET_BUF *, T_REQ_INFO *);
 static int fetch_foreign_keys (T_SRV_HANDLE *, int, int, char, int, T_NET_BUF *, T_REQ_INFO *);
-static void add_res_data_bytes (T_NET_BUF * net_buf, char *str, int size, unsigned char ext_type, int *net_size);
+static void add_res_data_bytes (T_NET_BUF * net_buf, const char *str, int size, unsigned char ext_type, int *net_size);
 static void add_res_data_string (T_NET_BUF * net_buf, const char *str, int size, unsigned char ext_type,
 				 unsigned char charset, int *net_size);
 static void add_res_data_string_safe (T_NET_BUF * net_buf, const char *str, unsigned char ext_type,
@@ -4497,10 +4497,9 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
     case DB_TYPE_VARBIT:
     case DB_TYPE_BIT:
       {
-	DB_C_BIT bit;
 	int length = 0;
 
-	bit = db_get_bit (val, &length);
+	DB_CONST_C_BIT bit = db_get_bit (val, &length);
 	length = (length + 7) / 8;
 	if (max_col_size > 0)
 	  {
@@ -6403,7 +6402,7 @@ fetch_foreign_keys (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, 
 }
 
 static void
-add_res_data_bytes (T_NET_BUF * net_buf, char *str, int size, unsigned char ext_type, int *net_size)
+add_res_data_bytes (T_NET_BUF * net_buf, const char *str, int size, unsigned char ext_type, int *net_size)
 {
   if (ext_type)
     {

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -164,9 +164,9 @@ struct t_class_table
 typedef struct t_attr_table T_ATTR_TABLE;
 struct t_attr_table
 {
-  char *class_name;
-  char *attr_name;
-  char *source_class;
+  const char *class_name;
+  const char *attr_name;
+  const char *source_class;
   int precision;
   short scale;
   short attr_order;
@@ -178,7 +178,7 @@ struct t_attr_table
   char unique;
   char set_domain;
   char is_key;
-  char *comment;
+  const char *comment;
 };
 
 extern void histo_print (FILE * stream);
@@ -283,7 +283,7 @@ static int sch_imported_keys (T_NET_BUF * net_buf, char *class_name, void **resu
 static int sch_exported_keys_or_cross_reference (T_NET_BUF * net_buf, bool find_cross_ref, char *pktable_name,
 						 char *fktable_name, void **result);
 static int class_type (DB_OBJECT * class_obj);
-static int class_attr_info (char *class_name, DB_ATTRIBUTE * attr, char *attr_pattern, char pat_flag,
+static int class_attr_info (const char *class_name, DB_ATTRIBUTE * attr, char *attr_pattern, char pat_flag,
 			    T_ATTR_TABLE * attr_table);
 static int set_priv_table (unsigned int class_priv, char *name, T_PRIV_TABLE * priv_table, int index);
 static int sch_query_execute (T_SRV_HANDLE * srv_handle, char *sql_stmt, T_NET_BUF * net_buf);
@@ -5575,7 +5575,7 @@ fetch_attribute (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, cha
   DB_OBJECT *class_obj;
   DB_ATTRIBUTE *db_attr;
   const char *attr_name;
-  char *class_name, *p;
+  const char *class_name, *p;
   T_ATTR_TABLE attr_info;
   T_BROKER_VERSION client_version = req_info->client_version;
   char *default_value_string = NULL;
@@ -5628,7 +5628,7 @@ fetch_attribute (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, cha
 	  return ERROR_INFO_SET (err_code, DBMS_ERROR_INDICATOR);
 	}
 
-      class_name = CONST_CAST (char *, db_get_string (&val_class));
+      class_name = db_get_string (&val_class);
       class_obj = db_find_class (class_name);
       if (class_obj == NULL)
 	{
@@ -8139,9 +8139,10 @@ class_type (DB_OBJECT * class_obj)
 }
 
 static int
-class_attr_info (char *class_name, DB_ATTRIBUTE * attr, char *attr_pattern, char pat_flag, T_ATTR_TABLE * attr_table)
+class_attr_info (const char *class_name, DB_ATTRIBUTE * attr, char *attr_pattern, char pat_flag,
+		 T_ATTR_TABLE * attr_table)
 {
-  char *p;
+  const char *p;
   int db_type;
   DB_DOMAIN *domain;
   DB_OBJECT *class_obj;
@@ -8149,7 +8150,7 @@ class_attr_info (char *class_name, DB_ATTRIBUTE * attr, char *attr_pattern, char
   int precision;
   short scale;
 
-  p = (char *) db_attribute_name (attr);
+  p = db_attribute_name (attr);
 
   domain = db_attribute_domain (attr);
   db_type = TP_DOMAIN_TYPE (domain);
@@ -8157,7 +8158,7 @@ class_attr_info (char *class_name, DB_ATTRIBUTE * attr, char *attr_pattern, char
   attr_table->class_name = class_name;
   attr_table->attr_name = p;
 
-  p = (char *) db_attribute_comment (attr);
+  p = db_attribute_comment (attr);
   attr_table->comment = p;
 
   if (TP_IS_SET_TYPE (db_type))
@@ -8221,7 +8222,7 @@ class_attr_info (char *class_name, DB_ATTRIBUTE * attr, char *attr_pattern, char
     }
   else
     {
-      attr_table->source_class = (char *) db_get_class_name (class_obj);
+      attr_table->source_class = db_get_class_name (class_obj);
     }
 
   attr_table->attr_order = db_attribute_order (attr) + 1;

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -3692,8 +3692,8 @@ get_column_default_as_string (DB_ATTRIBUTE * attr, bool * alloc)
 {
   DB_VALUE *def = NULL;
   int err;
-  char *default_value_string = NULL, *default_expr_format = NULL;
-  const char *default_value_expr_type_string = NULL;
+  char *default_value_string = NULL;
+  const char *default_value_expr_type_string = NULL, *default_expr_format = NULL;
   const char *default_value_expr_op_string = NULL;
 
   *alloc = false;
@@ -3776,7 +3776,7 @@ get_column_default_as_string (DB_ATTRIBUTE * attr, bool * alloc)
     case DB_TYPE_VARNCHAR:
       {
 	int def_size = db_get_string_size (def);
-	char *def_str_p = db_get_string (def);
+	const char *def_str_p = db_get_string (def);
 	if (def_str_p)
 	  {
 	    default_value_string = (char *) malloc (def_size + 3);
@@ -3800,7 +3800,7 @@ get_column_default_as_string (DB_ATTRIBUTE * attr, bool * alloc)
 	if (err == NO_ERROR)
 	  {
 	    int def_size = db_get_string_size (&tmp_val);
-	    char *def_str_p = db_get_string (&tmp_val);
+	    const char *def_str_p = db_get_string (&tmp_val);
 
 	    default_value_string = (char *) malloc (def_size + 1);
 	    if (default_value_string != NULL)
@@ -5574,7 +5574,8 @@ fetch_attribute (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, cha
   DB_VALUE val_class, val_attr;
   DB_OBJECT *class_obj;
   DB_ATTRIBUTE *db_attr;
-  char *class_name, *attr_name, *p;
+  const char *attr_name;
+  char *class_name, *p;
   T_ATTR_TABLE attr_info;
   T_BROKER_VERSION client_version = req_info->client_version;
   char *default_value_string = NULL;
@@ -5627,7 +5628,7 @@ fetch_attribute (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, cha
 	  return ERROR_INFO_SET (err_code, DBMS_ERROR_INDICATOR);
 	}
 
-      class_name = db_get_string (&val_class);
+      class_name = CONST_CAST (char *, db_get_string (&val_class));
       class_obj = db_find_class (class_name);
       if (class_obj == NULL)
 	{

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -4614,13 +4614,12 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
       break;
     case DB_TYPE_ENUMERATION:
       {
-	char *str;
 	int bytes_size = 0;
 	int decomp_size;
 	char *decomposed = NULL;
 	bool need_decomp = false;
 
-	str = db_get_enum_string (val);
+	const char *str = db_get_enum_string (val);
 	bytes_size = db_get_enum_string_size (val);
 	if (max_col_size > 0)
 	  {

--- a/src/broker/cas_net_buf.c
+++ b/src/broker/cas_net_buf.c
@@ -842,7 +842,6 @@ net_error_append_shard_info (char *err_buf, const char *err_msg, int buf_size)
  *					 H = charset
  *			      (please note the bit 7 is 1)
  *			      LSB byte : TTTT TTTT : T = type bits
- *			
  */
 int
 net_buf_cp_cas_type_and_charset (T_NET_BUF * net_buf, unsigned char cas_type, unsigned char charset)

--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -840,7 +840,7 @@ reset_connect (T_CON_HANDLE * con_handle, T_REQ_HANDLE * req_handle, T_CCI_ERROR
  * after the last failure of a host is over rc_time.
  */
 int
-cci_prepare (int mapped_conn_id, char *sql_stmt, char flag, T_CCI_ERROR * err_buf)
+cci_prepare (int mapped_conn_id, const char *sql_stmt, char flag, T_CCI_ERROR * err_buf)
 {
   int statement_id = -1;
   int error = CCI_ER_NO_ERROR;

--- a/src/cci/cas_cci.h
+++ b/src/cci/cas_cci.h
@@ -794,7 +794,7 @@ extern "C"
   extern int cci_connect_with_url_ex (char *url, char *user, char *pass, T_CCI_ERROR * err_buf);
   extern int cci_disconnect (int con_handle, T_CCI_ERROR * err_buf);
   extern int cci_end_tran (int con_handle, char type, T_CCI_ERROR * err_buf);
-  extern int cci_prepare (int con_handle, char *sql_stmt, char flag, T_CCI_ERROR * err_buf);
+  extern int cci_prepare (int con_handle, const char *sql_stmt, char flag, T_CCI_ERROR * err_buf);
   extern int cci_get_bind_num (int req_handle);
   extern T_CCI_COL_INFO *cci_get_result_info (int req_handle, T_CCI_CUBRID_STMT * cmd_type, int *num);
   extern int cci_bind_param (int req_handle, int index, T_CCI_A_TYPE a_type,

--- a/src/cci/cci_common.c
+++ b/src/cci/cci_common.c
@@ -104,7 +104,7 @@ typedef enum cci_mht_put_opt CCI_MHT_PUT_OPT;
  * Note: if x is a prime number, the n is prime if X**(n-1) mod n == 1
  */
 
-static unsigned int cci_mht_5str_pseudo_key (void *key, int key_size);
+static unsigned int cci_mht_5str_pseudo_key (const void *key, int key_size);
 
 static unsigned int cci_mht_calculate_htsize (unsigned int ht_size);
 static int cci_mht_rehash (CCI_MHT_TABLE * ht);
@@ -120,7 +120,7 @@ static void *cci_mht_put_internal (CCI_MHT_TABLE * ht, void *key, void *data, CC
  * Note: Based on hash method reported by Diniel J. Bernstein.
  */
 static unsigned int
-cci_mht_5str_pseudo_key (void *key, int key_size)
+cci_mht_5str_pseudo_key (const void *key, int key_size)
 {
   unsigned int hash = 5381;
   int i = 0;
@@ -162,7 +162,7 @@ cci_mht_5str_pseudo_key (void *key, int key_size)
  * Note: Based on hash method reported by Diniel J. Bernstein.
  */
 unsigned int
-cci_mht_5strhash (void *key, unsigned int ht_size)
+cci_mht_5strhash (const void *key, unsigned int ht_size)
 {
   return cci_mht_5str_pseudo_key (key, -1) % ht_size;
 }
@@ -174,9 +174,9 @@ cci_mht_5strhash (void *key, unsigned int ht_size)
  *   key2(in): pointer to string key2
  */
 int
-cci_mht_strcasecmpeq (void *key1, void *key2)
+cci_mht_strcasecmpeq (const void *key1, const void *key2)
 {
-  if ((strcasecmp ((char *) key1, (char *) key2)) == 0)
+  if ((strcasecmp (REINTERPRET_CAST (const char *, key1), REINTERPRET_CAST (const char *, key2)) == 0))
     {
       return TRUE;
     }
@@ -477,7 +477,7 @@ cci_mht_destroy (CCI_MHT_TABLE * ht, bool free_key, bool free_data)
  * Note: For each entry in hash table
  */
 void *
-cci_mht_rem (CCI_MHT_TABLE * ht, void *key, bool free_key, bool free_data)
+cci_mht_rem (CCI_MHT_TABLE * ht, const void *key, bool free_key, bool free_data)
 {
   unsigned int hash;
   CCI_HENTRY_PTR prev_hentry;

--- a/src/cci/cci_common.h
+++ b/src/cci/cci_common.h
@@ -276,8 +276,8 @@ extern "C"
     int *con_handles;		/* realloc by pool_size */
   };
 
-  typedef unsigned int (*HASH_FUNC) (void *key, unsigned int ht_size);
-  typedef int (*CMP_FUNC) (void *key1, void *key2);
+  typedef unsigned int (*HASH_FUNC) (const void *key, unsigned int ht_size);
+  typedef int (*CMP_FUNC) (const void *key1, const void *key2);
   typedef int (*REM_FUNC) (void *key, void *data, void *args);
   typedef int (*PRINT_FUNC) (FILE * fp, void *key, void *data, void *args);
 
@@ -318,12 +318,12 @@ extern "C"
  ************************************************************************/
   extern int get_elapsed_time (struct timeval *start_time);
 
-  extern unsigned int cci_mht_5strhash (void *key, unsigned int ht_size);
-  extern int cci_mht_strcasecmpeq (void *key1, void *key2);
+  extern unsigned int cci_mht_5strhash (const void *key, unsigned int ht_size);
+  extern int cci_mht_strcasecmpeq (const void *key1, const void *key2);
 
   extern CCI_MHT_TABLE *cci_mht_create (char *name, int est_size, HASH_FUNC hash_func, CMP_FUNC cmp_func);
   extern void cci_mht_destroy (CCI_MHT_TABLE * ht, bool free_key, bool free_data);
-  extern void *cci_mht_rem (CCI_MHT_TABLE * ht, void *key, bool free_key, bool free_data);
+  extern void *cci_mht_rem (CCI_MHT_TABLE * ht, const void *key, bool free_key, bool free_data);
   extern void *cci_mht_get (CCI_MHT_TABLE * ht, void *key);
 #if defined(ENABLE_UNUSED_FUNCTION)
   extern void *cci_mht_put (CCI_MHT_TABLE * ht, void *key, void *data);

--- a/src/cci/cci_handle_mng.c
+++ b/src/cci/cci_handle_mng.c
@@ -529,7 +529,7 @@ hm_req_add_to_pool (T_CON_HANDLE * con, char *sql, int mapped_statement_id, T_RE
 }
 
 int
-hm_req_get_from_pool (T_CON_HANDLE * con, T_REQ_HANDLE ** req, char *sql)
+hm_req_get_from_pool (T_CON_HANDLE * con, T_REQ_HANDLE ** req, const char *sql)
 {
   int req_id;
   void *data;

--- a/src/cci/cci_handle_mng.h
+++ b/src/cci/cci_handle_mng.h
@@ -313,7 +313,7 @@ extern int hm_get_con_handle_holdable (T_CON_HANDLE * con_handle);
 extern int hm_get_req_handle_holdable (T_CON_HANDLE * con_handle, T_REQ_HANDLE * req_handle);
 
 extern int hm_req_add_to_pool (T_CON_HANDLE * con, char *sql, int req_id, T_REQ_HANDLE * req);
-extern int hm_req_get_from_pool (T_CON_HANDLE * con, T_REQ_HANDLE ** req, char *sql);
+extern int hm_req_get_from_pool (T_CON_HANDLE * con, T_REQ_HANDLE ** req, const char *sql);
 
 extern int cci_conn_set_properties (T_CON_HANDLE * handle, char *properties);
 

--- a/src/cci/cci_query_execute.c
+++ b/src/cci/cci_query_execute.c
@@ -401,8 +401,8 @@ qe_end_session (T_CON_HANDLE * con_handle, T_CCI_ERROR * err_buf)
 }
 
 int
-qe_prepare (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, char *sql_stmt, char flag, T_CCI_ERROR * err_buf,
-	    int reuse)
+qe_prepare (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, const char *sql_stmt, char flag,
+	    T_CCI_ERROR * err_buf, int reuse)
 {
   T_NET_BUF net_buf;
   char func_code = CAS_FC_PREPARE;

--- a/src/cci/cci_query_execute.h
+++ b/src/cci/cci_query_execute.h
@@ -388,7 +388,7 @@
  ************************************************************************/
 
 extern int qe_con_close (T_CON_HANDLE * con_handle);
-extern int qe_prepare (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, char *sql_stmt, char flag,
+extern int qe_prepare (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, const char *sql_stmt, char flag,
 		       T_CCI_ERROR * err_buf, int reuse);
 extern int qe_prepare_and_execute (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, char *sql_stmt,
 				   int max_col_size, T_CCI_ERROR * err_buf);

--- a/src/cm_common/cm_class_info_sa.c
+++ b/src/cm_common/cm_class_info_sa.c
@@ -245,7 +245,7 @@ dbmt_user_login (int argc, char *argv[], int opt_begin)
       DB_VALUE v;
       DB_COLLECTION *col;
       int i;
-      char *username;
+      const char *username;
 
       user = db_find_user (dbuser);
       if (user == NULL)

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -1940,7 +1940,7 @@ _op_get_constraint_info (nvplist * out, DB_CONSTRAINT * con)
 
       while (end == 0)
 	{
-	  char *db_string_p = NULL;
+	  const char *db_string_p = NULL;
 
 	  db_query_get_tuple_value (result, 0, &val);
 	  db_string_p = db_get_string (&val);
@@ -2265,7 +2265,7 @@ _op_get_value_string (DB_VALUE * value)
 #if !defined (NUMERIC_MAX_STRING_SIZE)
 #define NUMERIC_MAX_STRING_SIZE (80 + 1)
 #endif
-  const char *db_varnchar_p = NULL;
+  const char *db_varnchar_p = NULL, *db_string_p_tmp = NULL;
   char *result, *return_result, *db_string_p;
   DB_TYPE type;
   DB_DATE *date_v;
@@ -2300,10 +2300,10 @@ _op_get_value_string (DB_VALUE * value)
     {
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
-      db_string_p = db_get_string (value);
-      if (db_string_p != NULL)
+      db_string_p_tmp = db_get_string (value);
+      if (db_string_p_tmp != NULL)
 	{
-	  snprintf (result, result_size, "%s", db_string_p);
+	  snprintf (result, result_size, "%s", db_string_p_tmp);
 	}
       break;
     case DB_TYPE_NCHAR:

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -2265,6 +2265,7 @@ _op_get_value_string (DB_VALUE * value)
 #if !defined (NUMERIC_MAX_STRING_SIZE)
 #define NUMERIC_MAX_STRING_SIZE (80 + 1)
 #endif
+  const char *db_varnchar_p = NULL;
   char *result, *return_result, *db_string_p;
   DB_TYPE type;
   DB_DATE *date_v;
@@ -2307,10 +2308,10 @@ _op_get_value_string (DB_VALUE * value)
       break;
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
-      db_string_p = db_get_nchar (value, &size);
-      if (db_string_p != NULL)
+      db_varnchar_p = db_get_nchar (value, &size);
+      if (db_varnchar_p != NULL)
 	{
-	  snprintf (result, result_size, "N'%s'", db_string_p);
+	  snprintf (result, result_size, "N'%s'", db_varnchar_p);
 	}
       break;
     case DB_TYPE_BIT:

--- a/src/compat/cnv.c
+++ b/src/compat/cnv.c
@@ -5947,7 +5947,7 @@ bfmt_print (BIT_STRING_FORMAT * bfmt, const DB_VALUE * the_db_bit, char *string,
   int string_index = 0;
   int byte_index;
   int bit_index;
-  char *bstring;
+  const char *bstring;
   int error = NO_ERROR;
   static char digits[16] = {
     '0', '1', '2', '3', '4', '5', '6', '7',

--- a/src/compat/cnv.c
+++ b/src/compat/cnv.c
@@ -6649,7 +6649,7 @@ db_string_value (const char *string, int str_size, const char *format, DB_VALUE 
 	case DB_TYPE_CHAR:
 	  {
 	    int size = strlen (string);
-	    db_make_char (value, size, (char *) string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_char (value, size, string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	    next = string + size;
 	    break;
 	  }
@@ -6657,7 +6657,7 @@ db_string_value (const char *string, int str_size, const char *format, DB_VALUE 
 	case DB_TYPE_VARCHAR:
 	  {
 	    int size = strlen (string);
-	    db_make_varchar (value, size, (char *) string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_varchar (value, size, string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	    next = string + size;
 	    break;
 	  }
@@ -6666,7 +6666,7 @@ db_string_value (const char *string, int str_size, const char *format, DB_VALUE 
 	  {
 	    int size;
 	    intl_char_count ((unsigned char *) string, strlen (string), LANG_SYS_CODESET, &size);
-	    db_make_nchar (value, size, (char *) string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_nchar (value, size, string, size, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	    next = string + strlen (string);
 	    break;
 	  }
@@ -6675,7 +6675,7 @@ db_string_value (const char *string, int str_size, const char *format, DB_VALUE 
 	  {
 	    int char_count;
 	    intl_char_count ((unsigned char *) string, strlen (string), LANG_SYS_CODESET, &char_count);
-	    db_make_varnchar (value, char_count, (char *) string, char_count, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	    db_make_varnchar (value, char_count, string, char_count, LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	    next = string + strlen (string);
 	    break;
 	  }

--- a/src/compat/db_elo.c
+++ b/src/compat/db_elo.c
@@ -175,7 +175,7 @@ db_elo_read (const DB_ELO * elo, off_t pos, void *buf, size_t count, DB_BIGINT *
  * count(in):
  */
 int
-db_elo_write (DB_ELO * elo, off_t pos, void *buf, size_t count, DB_BIGINT * written_bytes)
+db_elo_write (DB_ELO * elo, off_t pos, const void *buf, size_t count, DB_BIGINT * written_bytes)
 {
   INT64 ret;
 

--- a/src/compat/db_elo.h
+++ b/src/compat/db_elo.h
@@ -40,6 +40,6 @@ extern int db_elo_delete (DB_ELO * elo);
 
 extern DB_BIGINT db_elo_size (DB_ELO * elo);
 extern int db_elo_read (const DB_ELO * elo, off_t pos, void *buf, size_t count, DB_BIGINT * read_bytes);
-extern int db_elo_write (DB_ELO * elo, off_t pos, void *buf, size_t count, DB_BIGINT * written_bytes);
+extern int db_elo_write (DB_ELO * elo, off_t pos, const void *buf, size_t count, DB_BIGINT * written_bytes);
 
 #endif /* _DB_ELO_H_ */

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1977,7 +1977,7 @@ db_json_search_func (const JSON_DOC &doc, const DB_VALUE *pattern, const DB_VALU
   const std::string encoded_pattern = db_json_json_string_as_utf8 (raw_json_string);
 
   DB_VALUE encoded_pattern_dbval;
-  db_make_string (&encoded_pattern_dbval, const_cast<char *> (encoded_pattern.c_str ()));
+  db_make_string (&encoded_pattern_dbval, encoded_pattern.c_str ());
   db_string_put_cs_and_collation (&encoded_pattern_dbval, INTL_CODESET_UTF8, LANG_COLL_UTF8_BINARY);
 
   const map_func_type &f_search = [&json_paths, &paths, &encoded_pattern_dbval, esc_char, find_all] (const JSON_VALUE &jv,
@@ -1991,7 +1991,7 @@ db_json_search_func (const JSON_DOC &doc, const DB_VALUE *pattern, const DB_VALU
     const char *json_str = jv.GetString ();
     DB_VALUE str_val;
 
-    db_make_string (&str_val, (char *) json_str);
+    db_make_string (&str_val, json_str);
     db_string_put_cs_and_collation (&str_val, INTL_CODESET_UTF8, LANG_COLL_UTF8_BINARY);
 
     int match;

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -964,7 +964,8 @@ db_string_truncate (DB_VALUE * value, const int precision)
 {
   int error = NO_ERROR;
   DB_VALUE src_value;
-  char *string = NULL, *val_str;
+  char *string = NULL;
+  const char *val_str = NULL;
   int length;
   int byte_size;
 

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -834,7 +834,7 @@ db_value_domain_default (DB_VALUE * value, const DB_TYPE type,
       break;
     case DB_TYPE_BIT:
     case DB_TYPE_VARBIT:
-      db_make_bit (value, 1, (DB_C_BIT) "0", 1);
+      db_make_bit (value, 1, "0", 1);
       break;
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
@@ -4913,8 +4913,8 @@ valcnv_convert_value_to_string (DB_VALUE * value_p)
 	  return ER_FAILED;
 	}
 
-      db_make_varchar (&src_value, DB_MAX_STRING_LENGTH,
-		       (char *) buf_p->bytes, CAST_STRLEN (buf_p->length), LANG_SYS_CODESET, LANG_SYS_COLLATION);
+      db_make_varchar (&src_value, DB_MAX_STRING_LENGTH, REINTERPRET_CAST (char *, buf_p->bytes),
+		       CAST_STRLEN (buf_p->length), LANG_SYS_CODESET, LANG_SYS_COLLATION);
 
       pr_clear_value (value_p);
       tp_String.setval (value_p, &src_value, true);
@@ -4990,7 +4990,7 @@ db_convert_json_into_scalar (const DB_VALUE * src, DB_VALUE * dest)
     case DB_JSON_STRING:
       {
 	const char *str = db_json_get_string_from_document (doc);
-	int error_code = db_make_string_by_const_str (dest, str);
+	int error_code = db_make_string (dest, str);
 	if (error_code != NO_ERROR)
 	  {
 	    ASSERT_ERROR ();

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -1983,7 +1983,7 @@ transfer_bit_string (char *buf, int *xflen, int *outlen, const int buflen, const
   DB_DATA_STATUS data_status;
   DB_TYPE db_type;
   int error_code;
-  char *tmp_val_str;
+  const char *tmp_val_str;
 
   if (c_type == DB_TYPE_C_BIT)
     {
@@ -4335,11 +4335,11 @@ valcnv_convert_double_to_string (VALCNV_BUFFER * buffer_p, const double value)
 static VALCNV_BUFFER *
 valcnv_convert_bit_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_p)
 {
-  unsigned char *bit_string_p;
+  const unsigned char *bit_string_p;
   int nibble_len, nibbles, count;
   char tbuf[10];
 
-  bit_string_p = (unsigned char *) db_get_string (value_p);
+  bit_string_p = REINTERPRET_CAST (const unsigned char *, db_get_string (value_p));
   nibble_len = (db_get_string_length (value_p) + 3) / 4;
 
   for (nibbles = 0, count = 0; nibbles < nibble_len - 1; count++, nibbles += 2)
@@ -4481,7 +4481,7 @@ valcnv_convert_data_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * value_
   OID *oid_p;
   DB_SET *set_p;
   DB_ELO *elo_p;
-  char *src_p, *end_p, *p;
+  const char *src_p, *end_p, *p;
   ptrdiff_t len;
 
   DB_MONETARY *money_p;

--- a/src/compat/db_value_printer.cpp
+++ b/src/compat/db_value_printer.cpp
@@ -45,12 +45,12 @@ namespace
   // DB_VALUE of type DB_TYPE_BIT or DB_TYPE_VARBIT
   void describe_bit_string (string_buffer &buf, const db_value *value, bool pad_byte)
   {
-    unsigned char *bstring;
+    const unsigned char *bstring;
     int nibble_length, nibbles, count;
 
     assert (value != NULL);
 
-    bstring = (unsigned char *) db_get_string (value);
+    bstring = REINTERPRET_CAST (const unsigned char *, db_get_string (value));
     if (bstring == NULL)
       {
 	return;
@@ -244,7 +244,7 @@ void db_value_printer::describe_data (const db_value *value)
   DB_SET      *set = 0;
   db_elo      *elo = 0;
   DB_MIDXKEY *midxkey;
-  char *src, *pos, *end;
+  const char *src, *pos, *end;
   double d;
   char line[1025];
   char *json_body = NULL;

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -101,9 +101,8 @@
       ((elem)->short_val)
 #define DB_GET_ENUM_ELEM_DBCHAR(elem) \
       ((elem)->str_val)
-// TODO enum: cast is temporary until db_char::medium::buf will be made const
 #define DB_GET_ENUM_ELEM_STRING(elem) \
-      ((const char*) (elem)->str_val.medium.buf)
+      ((elem)->str_val.medium.buf)
 #define DB_GET_ENUM_ELEM_STRING_SIZE(elem) \
       ((elem)->str_val.medium.size)
 

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -101,8 +101,9 @@
       ((elem)->short_val)
 #define DB_GET_ENUM_ELEM_DBCHAR(elem) \
       ((elem)->str_val)
+// TODO enum: cast is temporary until db_char::medium::buf will be made const
 #define DB_GET_ENUM_ELEM_STRING(elem) \
-      ((elem)->str_val.medium.buf)
+      ((const char*) (elem)->str_val.medium.buf)
 #define DB_GET_ENUM_ELEM_STRING_SIZE(elem) \
       ((elem)->str_val.medium.size)
 

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -1151,8 +1151,11 @@ extern "C"
   typedef float DB_C_FLOAT;
   typedef double DB_C_DOUBLE;
   typedef char *DB_C_CHAR;
+  typedef const char *DB_CONST_C_CHAR;
   typedef char *DB_C_NCHAR;
+  typedef const char *DB_CONST_C_NCHAR;
   typedef char *DB_C_BIT;
+  typedef const char *DB_CONST_C_BIT;
   typedef DB_OBJECT DB_C_OBJECT;
   typedef DB_COLLECTION DB_C_SET;
   typedef DB_COLLECTION DB_C_COLLECTION;

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -996,7 +996,7 @@ extern "C"
       unsigned char is_max_string;
       unsigned char compressed_need_clear;
       int size;
-      char *buf;
+      const char *buf;
       int compressed_size;
       char *compressed_buf;
     } medium;
@@ -1202,7 +1202,7 @@ extern "C"
   {
     DB_DEFAULT_EXPR_TYPE default_expr_type;	/* default expression identifier */
     int default_expr_op;	/* default expression operator */
-    char *default_expr_format;	/* default expression format */
+    const char *default_expr_format;	/* default expression format */
   };
 
   typedef DB_DATETIME DB_C_DATETIME;

--- a/src/compat/dbtype_function.c
+++ b/src/compat/dbtype_function.c
@@ -35,7 +35,8 @@
 #include "system_parameter.h"
 
 // hidden functions (suppress -Wmissing-prototypes and -Wimplicit-function-declaration)
-int db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collation_id, char *str, const int size);
+int db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collation_id, const char *str,
+		     const int size);
 DB_TYPE setobj_type (struct setobj *set);
 
 #include "dbtype_function.i"

--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -339,7 +339,7 @@ extern "C"
   extern DB_C_NCHAR db_get_nchar (const DB_VALUE * value, int *length);
   extern int db_get_string_size (const DB_VALUE * value);
   extern unsigned short db_get_enum_short (const DB_VALUE * value);
-  extern DB_C_CHAR db_get_enum_string (const DB_VALUE * value);
+  extern DB_CONST_C_CHAR db_get_enum_string (const DB_VALUE * value);
   extern int db_get_enum_string_size (const DB_VALUE * value);
   extern DB_C_CHAR db_get_method_error_msg (void);
   extern DB_RESULTSET db_get_resultset (const DB_VALUE * value);
@@ -383,7 +383,7 @@ extern "C"
 			    const int nchar_str_byte_size, const int codeset, const int collation_id);
   extern int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR str,
 			       const int nchar_str_byte_size, const int codeset, const int collation_id);
-  extern int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size,
+  extern int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_CONST_C_CHAR str, int size,
 				  unsigned char codeset, const int collation_id);
   extern int db_make_resultset (DB_VALUE * value, const DB_RESULTSET handle);
 

--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -335,8 +335,8 @@ extern "C"
   extern DB_ELO *db_get_elo (const DB_VALUE * value);
   extern DB_C_NUMERIC db_get_numeric (const DB_VALUE * value);
   extern DB_CONST_C_BIT db_get_bit (const DB_VALUE * value, int *length);
-  extern DB_C_CHAR db_get_char (const DB_VALUE * value, int *length);
-  extern DB_C_NCHAR db_get_nchar (const DB_VALUE * value, int *length);
+  extern DB_CONST_C_CHAR db_get_char (const DB_VALUE * value, int *length);
+  extern DB_CONST_C_NCHAR db_get_nchar (const DB_VALUE * value, int *length);
   extern int db_get_string_size (const DB_VALUE * value);
   extern unsigned short db_get_enum_short (const DB_VALUE * value);
   extern DB_CONST_C_CHAR db_get_enum_string (const DB_VALUE * value);

--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -334,7 +334,7 @@ extern "C"
   extern int db_get_error (const DB_VALUE * value);
   extern DB_ELO *db_get_elo (const DB_VALUE * value);
   extern DB_C_NUMERIC db_get_numeric (const DB_VALUE * value);
-  extern DB_C_BIT db_get_bit (const DB_VALUE * value, int *length);
+  extern DB_CONST_C_BIT db_get_bit (const DB_VALUE * value, int *length);
   extern DB_C_CHAR db_get_char (const DB_VALUE * value, int *length);
   extern DB_C_NCHAR db_get_nchar (const DB_VALUE * value, int *length);
   extern int db_get_string_size (const DB_VALUE * value);

--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -304,7 +304,7 @@ extern "C"
   extern int db_get_int (const DB_VALUE * value);
   extern DB_C_SHORT db_get_short (const DB_VALUE * value);
   extern DB_BIGINT db_get_bigint (const DB_VALUE * value);
-  extern DB_C_CHAR db_get_string (const DB_VALUE * value);
+  extern DB_CONST_C_CHAR db_get_string (const DB_VALUE * value);
   extern DB_C_FLOAT db_get_float (const DB_VALUE * value);
   extern DB_C_DOUBLE db_get_double (const DB_VALUE * value);
   extern DB_OBJECT *db_get_object (const DB_VALUE * value);

--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -372,23 +372,23 @@ extern "C"
   extern int db_make_short (DB_VALUE * value, const DB_C_SHORT num);
   extern int db_make_bigint (DB_VALUE * value, const DB_BIGINT num);
   extern int db_make_numeric (DB_VALUE * value, const DB_C_NUMERIC num, const int precision, const int scale);
-  extern int db_make_bit (DB_VALUE * value, const int bit_length, const DB_C_BIT bit_str, const int bit_str_bit_size);
-  extern int db_make_varbit (DB_VALUE * value, const int max_bit_length, const DB_C_BIT bit_str,
+  extern int db_make_bit (DB_VALUE * value, const int bit_length, DB_CONST_C_BIT bit_str, const int bit_str_bit_size);
+  extern int db_make_varbit (DB_VALUE * value, const int max_bit_length, DB_CONST_C_BIT bit_str,
 			     const int bit_str_bit_size);
-  extern int db_make_char (DB_VALUE * value, const int char_length, const DB_C_CHAR str, const int char_str_byte_size,
+  extern int db_make_char (DB_VALUE * value, const int char_length, DB_CONST_C_CHAR str, const int char_str_byte_size,
 			   const int codeset, const int collation_id);
-  extern int db_make_varchar (DB_VALUE * value, const int max_char_length, const DB_C_CHAR str,
+  extern int db_make_varchar (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str,
 			      const int char_str_byte_size, const int codeset, const int collation_id);
-  extern int db_make_nchar (DB_VALUE * value, const int nchar_length, const DB_C_NCHAR str,
+  extern int db_make_nchar (DB_VALUE * value, const int nchar_length, DB_CONST_C_NCHAR str,
 			    const int nchar_str_byte_size, const int codeset, const int collation_id);
-  extern int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, const DB_C_NCHAR str,
+  extern int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR str,
 			       const int nchar_str_byte_size, const int codeset, const int collation_id);
   extern int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size,
 				  unsigned char codeset, const int collation_id);
   extern int db_make_resultset (DB_VALUE * value, const DB_RESULTSET handle);
 
-  extern int db_make_string (DB_VALUE * value, char *str);
-  extern int db_make_string_copy (DB_VALUE * value, const char *str);
+  extern int db_make_string (DB_VALUE * value, DB_CONST_C_CHAR str);
+  extern int db_make_string_copy (DB_VALUE * value, DB_CONST_C_CHAR str);
 
   extern int db_make_oid (DB_VALUE * value, const OID * oid);
 

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -47,7 +47,7 @@ STATIC_INLINE DB_MONETARY *db_get_monetary (const DB_VALUE * value) __attribute_
 STATIC_INLINE int db_get_error (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_ELO *db_get_elo (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_C_NUMERIC db_get_numeric (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE DB_C_BIT db_get_bit (const DB_VALUE * value, int *length) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE DB_CONST_C_BIT db_get_bit (const DB_VALUE * value, int *length) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_C_CHAR db_get_char (const DB_VALUE * value, int *length) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_C_NCHAR db_get_nchar (const DB_VALUE * value, int *length) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_get_string_size (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
@@ -546,10 +546,10 @@ db_get_numeric (const DB_VALUE * value)
  * value(in):
  * length(out):
  */
-char *
+DB_CONST_C_BIT
 db_get_bit (const DB_VALUE * value, int *length)
 {
-  char *str = NULL;
+  const char *str = NULL;
 
 #if defined (API_ACTIVE_CHECKS)
   CHECK_1ARG_NULL (value);

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -52,7 +52,7 @@ STATIC_INLINE DB_C_CHAR db_get_char (const DB_VALUE * value, int *length) __attr
 STATIC_INLINE DB_C_NCHAR db_get_nchar (const DB_VALUE * value, int *length) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_get_string_size (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE unsigned short db_get_enum_short (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE DB_C_CHAR db_get_enum_string (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE DB_CONST_C_CHAR db_get_enum_string (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_get_enum_string_size (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_C_CHAR db_get_method_error_msg (void) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_RESULTSET db_get_resultset (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
@@ -109,7 +109,7 @@ STATIC_INLINE int db_make_nchar (DB_VALUE * value, const int nchar_length, DB_CO
 STATIC_INLINE int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR str,
 				    const int nchar_str_byte_size, const int codeset, const int collation_id)
   __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size,
+STATIC_INLINE int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_CONST_C_CHAR str, int size,
 				       unsigned char codeset, const int collation_id) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_resultset (DB_VALUE * value, const DB_RESULTSET handle) __attribute__ ((ALWAYS_INLINE));
 
@@ -707,7 +707,7 @@ db_get_enum_short (const DB_VALUE * value)
  * return :
  * value(in):
  */
-char *
+DB_CONST_C_CHAR
 db_get_enum_string (const DB_VALUE * value)
 {
 #if defined (API_ACTIVE_CHECKS)
@@ -1721,7 +1721,7 @@ db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR
  * collation_id(in):
  */
 int
-db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size, unsigned char codeset,
+db_make_enumeration (DB_VALUE * value, unsigned short index, DB_CONST_C_CHAR str, int size, unsigned char codeset,
 		     const int collation_id)
 {
 #if defined (API_ACTIVE_CHECKS)
@@ -1738,7 +1738,8 @@ db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int 
   value->data.ch.medium.compressed_buf = NULL;
   value->data.ch.medium.compressed_size = 0;
   value->data.enumeration.str_val.medium.size = size;
-  value->data.enumeration.str_val.medium.buf = str;
+  // TODO enum: cast is temporary until db_char::medium::buf will be made const
+  value->data.enumeration.str_val.medium.buf = (char *) str;
   value->domain.general_info.is_null = 0;
   value->need_clear = false;
 

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -48,8 +48,8 @@ STATIC_INLINE int db_get_error (const DB_VALUE * value) __attribute__ ((ALWAYS_I
 STATIC_INLINE DB_ELO *db_get_elo (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_C_NUMERIC db_get_numeric (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_CONST_C_BIT db_get_bit (const DB_VALUE * value, int *length) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE DB_C_CHAR db_get_char (const DB_VALUE * value, int *length) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE DB_C_NCHAR db_get_nchar (const DB_VALUE * value, int *length) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE DB_CONST_C_CHAR db_get_char (const DB_VALUE * value, int *length) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE DB_CONST_C_NCHAR db_get_nchar (const DB_VALUE * value, int *length) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_get_string_size (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE unsigned short db_get_enum_short (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_CONST_C_CHAR db_get_enum_string (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
@@ -593,10 +593,10 @@ db_get_bit (const DB_VALUE * value, int *length)
  * value(in):
  * length(out):
  */
-char *
+DB_CONST_C_CHAR
 db_get_char (const DB_VALUE * value, int *length)
 {
-  char *str = NULL;
+  const char *str = NULL;
 
 #if defined (API_ACTIVE_CHECKS)
   CHECK_1ARG_NULL (value);
@@ -642,7 +642,7 @@ db_get_char (const DB_VALUE * value, int *length)
  * value(in):
  * length(out):
  */
-char *
+DB_CONST_C_NCHAR
 db_get_nchar (const DB_VALUE * value, int *length)
 {
   return db_get_char (value, length);

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -66,7 +66,7 @@ STATIC_INLINE int db_value_precision (const DB_VALUE * value) __attribute__ ((AL
 STATIC_INLINE int db_value_scale (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE JSON_DOC *db_get_json_document (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 
-STATIC_INLINE int db_make_db_char (DB_VALUE * value, INTL_CODESET codeset, const int collation_id, char *str,
+STATIC_INLINE int db_make_db_char (DB_VALUE * value, INTL_CODESET codeset, const int collation_id, DB_CONST_C_CHAR str,
 				   const int size) __attribute__ ((ALWAYS_INLINE));
 
 STATIC_INLINE int db_make_null (DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
@@ -93,32 +93,28 @@ STATIC_INLINE int db_make_short (DB_VALUE * value, const DB_C_SHORT num) __attri
 STATIC_INLINE int db_make_bigint (DB_VALUE * value, const DB_BIGINT num) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_numeric (DB_VALUE * value, const DB_C_NUMERIC num, const int precision, const int scale)
   __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_bit (DB_VALUE * value, const int bit_length, const DB_C_BIT bit_str,
+STATIC_INLINE int db_make_bit (DB_VALUE * value, const int bit_length, DB_CONST_C_BIT bit_str,
 			       const int bit_str_bit_size) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_varbit (DB_VALUE * value, const int max_bit_length, const DB_C_BIT bit_str,
+STATIC_INLINE int db_make_varbit (DB_VALUE * value, const int max_bit_length, DB_CONST_C_BIT bit_str,
 				  const int bit_str_bit_size) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_char (DB_VALUE * value, const int char_length, const DB_C_CHAR str,
+STATIC_INLINE int db_make_char (DB_VALUE * value, const int char_length, DB_CONST_C_CHAR str,
 				const int char_str_byte_size, const int codeset, const int collation_id)
   __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_varchar (DB_VALUE * value, const int max_char_length, const DB_C_CHAR str,
+STATIC_INLINE int db_make_varchar (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str,
 				   const int char_str_byte_size, const int codeset, const int collation_id)
   __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_nchar (DB_VALUE * value, const int nchar_length, const DB_C_NCHAR str,
+STATIC_INLINE int db_make_nchar (DB_VALUE * value, const int nchar_length, DB_CONST_C_NCHAR str,
 				 const int nchar_str_byte_size, const int codeset, const int collation_id)
   __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, const DB_C_NCHAR str,
+STATIC_INLINE int db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR str,
 				    const int nchar_str_byte_size, const int codeset, const int collation_id)
   __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size,
 				       unsigned char codeset, const int collation_id) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_resultset (DB_VALUE * value, const DB_RESULTSET handle) __attribute__ ((ALWAYS_INLINE));
 
-STATIC_INLINE int db_make_string (DB_VALUE * value, char *str) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int db_make_string_copy (DB_VALUE * value, const char *str) __attribute__ ((ALWAYS_INLINE));
-
-// TODO: It is ugly but I would like to separate the existing usages of db_make_string_copy from those of const str.
-// In some day, we may need a way to make db_value without copying const str. Hope this helps for future refactoring.
-#define db_make_string_by_const_str db_make_string_copy
+STATIC_INLINE int db_make_string (DB_VALUE * value, DB_CONST_C_CHAR str) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE int db_make_string_copy (DB_VALUE * value, DB_CONST_C_CHAR str) __attribute__ ((ALWAYS_INLINE));
 
 STATIC_INLINE int db_make_oid (DB_VALUE * value, const OID * oid) __attribute__ ((ALWAYS_INLINE));
 
@@ -997,7 +993,8 @@ db_get_json_document (const DB_VALUE * value)
  * size(in):
  */
 int
-db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collation_id, char *str, const int size)
+db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collation_id, DB_CONST_C_CHAR str,
+		 const int size)
 {
 #if defined (API_ACTIVE_CHECKS)
   CHECK_1ARG_ERROR (value);
@@ -1559,7 +1556,7 @@ db_make_numeric (DB_VALUE * value, const DB_C_NUMERIC num, const int precision, 
  * bit_str_bit_size(in):
  */
 int
-db_make_bit (DB_VALUE * value, const int bit_length, const DB_C_BIT bit_str, const int bit_str_bit_size)
+db_make_bit (DB_VALUE * value, const int bit_length, DB_CONST_C_BIT bit_str, const int bit_str_bit_size)
 {
   int error;
 
@@ -1586,7 +1583,7 @@ db_make_bit (DB_VALUE * value, const int bit_length, const DB_C_BIT bit_str, con
  * bit_str_bit_size(in):
  */
 int
-db_make_varbit (DB_VALUE * value, const int max_bit_length, const DB_C_BIT bit_str, const int bit_str_bit_size)
+db_make_varbit (DB_VALUE * value, const int max_bit_length, DB_CONST_C_BIT bit_str, const int bit_str_bit_size)
 {
   int error;
 
@@ -1614,8 +1611,8 @@ db_make_varbit (DB_VALUE * value, const int max_bit_length, const DB_C_BIT bit_s
  * char_str_byte_size(in):
  */
 int
-db_make_char (DB_VALUE * value, const int char_length, const DB_C_CHAR str,
-	      const int char_str_byte_size, const int codeset, const int collation_id)
+db_make_char (DB_VALUE * value, const int char_length, DB_CONST_C_CHAR str, const int char_str_byte_size,
+	      const int codeset, const int collation_id)
 {
   int error;
 
@@ -1641,8 +1638,8 @@ db_make_char (DB_VALUE * value, const int char_length, const DB_C_CHAR str,
  * char_str_byte_size(in):
  */
 int
-db_make_varchar (DB_VALUE * value, const int max_char_length,
-		 const DB_C_CHAR str, const int char_str_byte_size, const int codeset, const int collation_id)
+db_make_varchar (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str, const int char_str_byte_size,
+		 const int codeset, const int collation_id)
 {
   int error;
 
@@ -1668,8 +1665,8 @@ db_make_varchar (DB_VALUE * value, const int max_char_length,
  * nchar_str_byte_size(in):
  */
 int
-db_make_nchar (DB_VALUE * value, const int nchar_length, const DB_C_NCHAR str,
-	       const int nchar_str_byte_size, const int codeset, const int collation_id)
+db_make_nchar (DB_VALUE * value, const int nchar_length, DB_CONST_C_NCHAR str, const int nchar_str_byte_size,
+	       const int codeset, const int collation_id)
 {
   int error;
 
@@ -1695,8 +1692,8 @@ db_make_nchar (DB_VALUE * value, const int nchar_length, const DB_C_NCHAR str,
  * nchar_str_byte_size(in):
  */
 int
-db_make_varnchar (DB_VALUE * value, const int max_nchar_length,
-		  const DB_C_NCHAR str, const int nchar_str_byte_size, const int codeset, const int collation_id)
+db_make_varnchar (DB_VALUE * value, const int max_nchar_length, DB_CONST_C_NCHAR str, const int nchar_str_byte_size,
+		  const int codeset, const int collation_id)
 {
   int error;
 
@@ -1724,8 +1721,8 @@ db_make_varnchar (DB_VALUE * value, const int max_nchar_length,
  * collation_id(in):
  */
 int
-db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str,
-		     int size, unsigned char codeset, const int collation_id)
+db_make_enumeration (DB_VALUE * value, unsigned short index, DB_C_CHAR str, int size, unsigned char codeset,
+		     const int collation_id)
 {
 #if defined (API_ACTIVE_CHECKS)
   CHECK_1ARG_ERROR (value);
@@ -1805,7 +1802,7 @@ db_make_oid (DB_VALUE * value, const OID * oid)
  * str(in):
  */
 int
-db_make_string (DB_VALUE * value, char *str)
+db_make_string (DB_VALUE * value, DB_CONST_C_CHAR str)
 {
   int error;
   int size;
@@ -1838,7 +1835,7 @@ db_make_string (DB_VALUE * value, char *str)
  * str(in):
  */
 int
-db_make_string_copy (DB_VALUE * value, const char *str)
+db_make_string_copy (DB_VALUE * value, DB_CONST_C_CHAR str)
 {
   int error;
   char *copy_str;
@@ -1857,7 +1854,7 @@ db_make_string_copy (DB_VALUE * value, const char *str)
 
   if (copy_str == NULL)
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, strlen(str) + 1);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, strlen (str) + 1);
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
@@ -1865,6 +1862,7 @@ db_make_string_copy (DB_VALUE * value, const char *str)
 
   if (error != NO_ERROR)
     {
+      db_private_free (NULL, copy_str);
       return error;
     }
 
@@ -2166,8 +2164,6 @@ db_set_compressed_string (DB_VALUE * value, char *compressed_string, int compres
   value->data.ch.medium.compressed_buf = compressed_string;
   value->data.ch.medium.compressed_size = compressed_size;
   value->data.ch.info.compressed_need_clear = compressed_need_clear;
-
-  return;
 }
 
 /*

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -30,7 +30,7 @@
 STATIC_INLINE int db_get_int (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_C_SHORT db_get_short (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_BIGINT db_get_bigint (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE DB_C_CHAR db_get_string (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE DB_CONST_C_CHAR db_get_string (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_C_FLOAT db_get_float (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_C_DOUBLE db_get_double (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE DB_OBJECT *db_get_object (const DB_VALUE * value) __attribute__ ((ALWAYS_INLINE));
@@ -200,10 +200,10 @@ db_get_bigint (const DB_VALUE * value)
  * return :
  * value(in):
  */
-char *
+DB_CONST_C_CHAR
 db_get_string (const DB_VALUE * value)
 {
-  char *str = NULL;
+  const char *str = NULL;
 
 #if defined (API_ACTIVE_CHECKS)
   CHECK_1ARG_NULL (value);
@@ -217,7 +217,7 @@ db_get_string (const DB_VALUE * value)
   switch (value->data.ch.info.style)
     {
     case SMALL_STRING:
-      str = (char *) value->data.ch.sm.buf;
+      str = value->data.ch.sm.buf;
       break;
     case MEDIUM_STRING:
       str = value->data.ch.medium.buf;
@@ -566,7 +566,7 @@ db_get_bit (const DB_VALUE * value, int *length)
     case SMALL_STRING:
       {
 	*length = value->data.ch.sm.size;
-	str = (char *) value->data.ch.sm.buf;
+	str = value->data.ch.sm.buf;
       }
       break;
     case MEDIUM_STRING:
@@ -612,7 +612,7 @@ db_get_char (const DB_VALUE * value, int *length)
     {
     case SMALL_STRING:
       {
-	str = (char *) value->data.ch.sm.buf;
+	str = value->data.ch.sm.buf;
 	intl_char_count ((unsigned char *) str, value->data.ch.sm.size,
 			 (INTL_CODESET) value->data.ch.info.codeset, length);
       }
@@ -1005,7 +1005,7 @@ db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collati
   value->data.ch.info.compressed_need_clear = false;
   value->data.ch.medium.codeset = codeset;
   value->data.ch.medium.size = size;
-  value->data.ch.medium.buf = (char *) str;
+  value->data.ch.medium.buf = str;
   value->data.ch.medium.compressed_buf = NULL;
   value->data.ch.medium.compressed_size = 0;
   value->domain.general_info.is_null = ((void *) str != NULL) ? 0 : 1;
@@ -1738,8 +1738,7 @@ db_make_enumeration (DB_VALUE * value, unsigned short index, DB_CONST_C_CHAR str
   value->data.ch.medium.compressed_buf = NULL;
   value->data.ch.medium.compressed_size = 0;
   value->data.enumeration.str_val.medium.size = size;
-  // TODO enum: cast is temporary until db_char::medium::buf will be made const
-  value->data.enumeration.str_val.medium.buf = (char *) str;
+  value->data.enumeration.str_val.medium.buf = str;
   value->domain.general_info.is_null = 0;
   value->need_clear = false;
 

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2607,7 +2607,6 @@ css_user_access_status_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE *
       db_make_datetime (&vals[1], &access_time);
 
       db_make_string_copy (&vals[2], access_status->host);
-
       db_make_string_copy (&vals[3], access_status->program_name);
     }
 #endif /* SERVER_MODE */
@@ -2797,7 +2796,6 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
 	  db_make_datetime (&vals[1], &access_time);
 
 	  db_make_string_copy (&vals[2], access_status->host);
-
 	  db_make_string_copy (&vals[3], access_status->program_name);
 	}
       else

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -165,7 +165,7 @@ static int css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * cla
 					      SHOWSTMT_ARRAY_CONTEXT * ctx);
 
 static LAST_ACCESS_STATUS *css_get_access_status_with_name (LAST_ACCESS_STATUS ** access_status_array, int num_user,
-							    char *user_name);
+							    const char *user_name);
 static LAST_ACCESS_STATUS *css_get_unused_access_status (LAST_ACCESS_STATUS ** access_status_array, int num_user);
 #endif /* !CS_MODE */
 
@@ -2653,7 +2653,7 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
   bool attr_info_inited;
   bool scan_cache_inited;
   char *rec_attr_name_p = NULL, *string = NULL;
-  char *user_name = NULL;
+  const char *user_name = NULL;
   HFID hfid;
   OID inst_oid;
   HEAP_CACHE_ATTRINFO attr_info;
@@ -2829,7 +2829,7 @@ end:
  *   user_name(in):
  */
 static LAST_ACCESS_STATUS *
-css_get_access_status_with_name (LAST_ACCESS_STATUS ** access_status_array, int num_user, char *user_name)
+css_get_access_status_with_name (LAST_ACCESS_STATUS ** access_status_array, int num_user, const char *user_name)
 {
   int i = 0;
   LAST_ACCESS_STATUS *access_status = NULL;

--- a/src/executables/checksumdb.c
+++ b/src/executables/checksumdb.c
@@ -824,7 +824,7 @@ chksum_get_prev_checksum_results (void)
     {
       int pos;
       int out_val_idx;
-      char *db_string_p = NULL;
+      const char *db_string_p = NULL;
 
       pos = db_query_first_tuple (query_result);
       while (pos == DB_CURSOR_SUCCESS)

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -1367,7 +1367,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       {
 	int dummy, bytes_size, decomp_size;
 	bool need_decomp = false;
-	char *str;
+	const char *str;
 	char *decomposed = NULL;
 
 	str = db_get_char (value, &dummy);
@@ -1408,7 +1408,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string)
       {
 	int dummy, bytes_size, decomp_size;
 	bool need_decomp = false;
-	char *str;
+	const char *str;
 	char *decomposed = NULL;
 
 	str = db_get_char (value, &dummy);

--- a/src/executables/esql_cli.c
+++ b/src/executables/esql_cli.c
@@ -1947,21 +1947,21 @@ uci_get_value_indirect (int cs_no, DB_INDICATOR * ind, void **bufp, int *sizep)
 	 * It would if the user tried to hang on to the pointer
 	 * for more than a row.
 	 */
-	*bufp = db_get_string (&val);
+	*bufp = CONST_CAST (char *, db_get_string (&val));
 	*sizep = db_get_string_size (&val);
       }
       break;
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
       {
-	*bufp = db_get_string (&val);
+	*bufp = CONST_CAST (char *, db_get_string (&val));
 	*sizep = db_get_string_size (&val);
       }
       break;
     case DB_TYPE_BIT:
     case DB_TYPE_VARBIT:
       {
-	*bufp = db_get_string (&val);
+	*bufp = CONST_CAST (char *, db_get_string (&val));
 	*sizep = db_get_string_size (&val);
       }
       break;

--- a/src/jsp/jsp_cl.c
+++ b/src/jsp/jsp_cl.c
@@ -103,7 +103,7 @@ typedef struct db_arg_list
 
 typedef struct
 {
-  char *name;
+  const char *name;
   DB_VALUE *returnval;
   DB_ARG_LIST *args;
   int arg_count;
@@ -1698,8 +1698,8 @@ jsp_pack_numeric_argument (char *buffer, DB_VALUE * value)
 static char *
 jsp_pack_string_argument (char *buffer, DB_VALUE * value)
 {
-  char *v;
-  char *ptr;
+  const char *v;
+  char *ptr, *decomposed = NULL;
   int v_size;
   int decomp_size;
   bool was_decomposed = false;
@@ -1712,7 +1712,6 @@ jsp_pack_string_argument (char *buffer, DB_VALUE * value)
   if (v_size > 0 && db_get_string_codeset (value) == INTL_CODESET_UTF8
       && unicode_string_need_decompose (v, v_size, &decomp_size, lang_get_generic_unicode_norm ()))
     {
-      char *decomposed;
       int alloc_size = decomp_size + 1;
 
       decomposed = (char *) db_private_alloc (NULL, alloc_size);
@@ -1737,7 +1736,7 @@ jsp_pack_string_argument (char *buffer, DB_VALUE * value)
 
   if (was_decomposed)
     {
-      db_private_free (NULL, v);
+      db_private_free (NULL, decomposed);
     }
 
   return ptr;

--- a/src/jsp/jsp_cl.c
+++ b/src/jsp/jsp_cl.c
@@ -708,7 +708,7 @@ jsp_alter_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * statement)
   /* change the comment */
   if (sp_comment != NULL)
     {
-      db_make_string_by_const_str (&user_val, comment_str);
+      db_make_string (&user_val, comment_str);
       err = obj_set (sp_mop, SP_ATTR_COMMENT, &user_val);
       if (err < 0)
 	{
@@ -835,7 +835,7 @@ jsp_add_stored_procedure_argument (MOP * mop_p, const char *sp_name, const char 
       goto error;
     }
 
-  db_make_string_by_const_str (&value, sp_name);
+  db_make_string (&value, sp_name);
   err = dbt_put_internal (obt_p, SP_ATTR_NAME, &value);
   pr_clear_value (&value);
   if (err != NO_ERROR)
@@ -843,7 +843,7 @@ jsp_add_stored_procedure_argument (MOP * mop_p, const char *sp_name, const char 
       goto error;
     }
 
-  db_make_string_by_const_str (&value, arg_name);
+  db_make_string (&value, arg_name);
   err = dbt_put_internal (obt_p, SP_ATTR_ARG_NAME, &value);
   pr_clear_value (&value);
   if (err != NO_ERROR)
@@ -872,7 +872,7 @@ jsp_add_stored_procedure_argument (MOP * mop_p, const char *sp_name, const char 
       goto error;
     }
 
-  db_make_string_by_const_str (&value, arg_comment);
+  db_make_string (&value, arg_comment);
   err = dbt_put_internal (obt_p, SP_ATTR_ARG_COMMENT, &value);
   pr_clear_value (&value);
   if (err != NO_ERROR)
@@ -1082,7 +1082,7 @@ jsp_add_stored_procedure (const char *name, const PT_MISC_TYPE type, const PT_TY
       goto error;
     }
 
-  db_make_string_by_const_str (&value, java_method);
+  db_make_string (&value, java_method);
   err = dbt_put_internal (obt_p, SP_ATTR_TARGET, &value);
   pr_clear_value (&value);
   if (err != NO_ERROR)
@@ -1098,7 +1098,7 @@ jsp_add_stored_procedure (const char *name, const PT_MISC_TYPE type, const PT_TY
       goto error;
     }
 
-  db_make_string_by_const_str (&value, comment);
+  db_make_string (&value, comment);
   err = dbt_put_internal (obt_p, SP_ATTR_COMMENT, &value);
   pr_clear_value (&value);
   if (err != NO_ERROR)

--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -398,7 +398,7 @@ namespace cubload
     error = db_value_domain_init (val, type, char_count, 0);
     if (error == NO_ERROR)
       {
-	error = db_make_db_char (val, codeset, domain.collation_id, const_cast<char *> (str), str_len);
+	error = db_make_db_char (val, codeset, domain.collation_id, str, str_len);
       }
 
     return error;
@@ -429,7 +429,7 @@ namespace cubload
   int
   to_db_string (const char *str, const size_t str_size, const attribute *attr, db_value *val)
   {
-    return db_make_string (val, const_cast<char *> (str));
+    return db_make_string (val, str);
   }
 
   int

--- a/src/loaddb/load_object.c
+++ b/src/loaddb/load_object.c
@@ -71,8 +71,8 @@ static void get_desc_old (OR_BUF * buf, SM_CLASS * class_, int repid, DESC_OBJ *
 static void print_set (print_output & output_ctx, DB_SET * set);
 static int fprint_special_set (TEXT_OUTPUT * tout, DB_SET * set);
 static int bfmt_print (int bfmt, const DB_VALUE * the_db_bit, char *string, int max_size);
-static char *strnchr (char *str, char ch, int nbytes);
-static int print_quoted_str (TEXT_OUTPUT * tout, char *str, int len, int max_token_len);
+static const char *strnchr (const char *str, char ch, int nbytes);
+static int print_quoted_str (TEXT_OUTPUT * tout, const char *str, int len, int max_token_len);
 static void itoa_strreverse (char *begin, char *end);
 static int itoa_print (TEXT_OUTPUT * tout, DB_BIGINT value, int base);
 static int fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value);
@@ -1184,8 +1184,8 @@ bfmt_print (int bfmt, const DB_VALUE * the_db_bit, char *string, int max_size)
  *    ch(in): character to find
  *    nbytes(in): length of string
  */
-static char *
-strnchr (char *str, char ch, int nbytes)
+const static char *
+strnchr (const char *str, char ch, int nbytes)
 {
   for (; nbytes; str++, nbytes--)
     {
@@ -1209,12 +1209,12 @@ strnchr (char *str, char ch, int nbytes)
  *  FIXME :: return error in fwrite...
  */
 static int
-print_quoted_str (TEXT_OUTPUT * tout, char *str, int len, int max_token_len)
+print_quoted_str (TEXT_OUTPUT * tout, const char *str, int len, int max_token_len)
 {
   int error = NO_ERROR;
-  char *p, *end;
+  const char *p, *end;
   int partial_len, write_len, left_nbytes;
-  char *internal_quote_p;
+  const char *internal_quote_p;
 
   /* opening quote */
   CHECK_PRINT_ERROR (text_print (tout, "'", 1, NULL));
@@ -1362,6 +1362,7 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
   int error = NO_ERROR;
   char buf[INTERNAL_BUFFER_SIZE];
   char *ptr;
+  const char *str_ptr = NULL;
   char *json_body = NULL;
   DB_TYPE type;
   int len;
@@ -1483,15 +1484,15 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
       /* fall through */
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
-      ptr = db_get_string (value);
+      str_ptr = db_get_string (value);
 
       len = db_get_string_size (value);
       if (len < 0)
 	{
-	  len = (int) strlen (ptr);
+	  len = (int) strlen (str_ptr);
 	}
 
-      CHECK_PRINT_ERROR (print_quoted_str (tout, ptr, len, MAX_DISPLAY_COLUMN));
+      CHECK_PRINT_ERROR (print_quoted_str (tout, str_ptr, len, MAX_DISPLAY_COLUMN));
       break;
 
     case DB_TYPE_NUMERIC:

--- a/src/loaddb/load_object.c
+++ b/src/loaddb/load_object.c
@@ -1116,7 +1116,7 @@ bfmt_print (int bfmt, const DB_VALUE * the_db_bit, char *string, int max_size)
   int string_index = 0;
   int byte_index;
   int bit_index;
-  char *bstring;
+  const char *bstring;
   int error = NO_ERROR;
   static char digits[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
     '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -2524,7 +2524,7 @@ static int
 ldr_str_elem (LDR_CONTEXT *context, const char *str, size_t len, DB_VALUE *val)
 {
   /* todo: switch this to db_make_string_copy and avoid any possible leaks */
-  db_make_string (val, (char *) str);
+  db_make_string (val, str);
   return NO_ERROR;
 }
 
@@ -2689,7 +2689,7 @@ ldr_str_db_generic (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIB
   DB_VALUE val;
 
   /* todo: switch this to db_make_string_copy and avoid any possible leaks */
-  db_make_string (&val, (char *) str);
+  db_make_string (&val, str);
   return ldr_generic (context, &val);
 }
 
@@ -2873,7 +2873,7 @@ static int
 ldr_nstr_elem (LDR_CONTEXT *context, const char *str, size_t len, DB_VALUE *val)
 {
 
-  db_make_varnchar (val, TP_FLOATING_PRECISION_VALUE, (DB_C_NCHAR) str, (int) len, LANG_SYS_CODESET,
+  db_make_varnchar (val, TP_FLOATING_PRECISION_VALUE, str, (int) len, LANG_SYS_CODESET,
 		    LANG_SYS_COLLATION);
   return NO_ERROR;
 }
@@ -5940,8 +5940,8 @@ ldr_init_loader (LDR_CONTEXT *context)
   db_make_short (&ldr_short_tmpl, 0);
   db_make_int (&ldr_int_tmpl, 0);
   db_make_bigint (&ldr_bigint_tmpl, 0);
-  db_make_char (&ldr_char_tmpl, 1, (char *) "a", 1, LANG_SYS_CODESET, LANG_SYS_COLLATION);
-  db_make_varchar (&ldr_varchar_tmpl, 1, (char *) "a", 1, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+  db_make_char (&ldr_char_tmpl, 1, "a", 1, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+  db_make_varchar (&ldr_varchar_tmpl, 1, "a", 1, LANG_SYS_CODESET, LANG_SYS_COLLATION);
   db_make_float (&ldr_float_tmpl, (float) 0.0);
   db_make_double (&ldr_double_tmpl, (double) 0.0);
   db_make_date (&ldr_date_tmpl, 1, 1, 1996);
@@ -5959,7 +5959,7 @@ ldr_init_loader (LDR_CONTEXT *context)
   db_make_datetimetz (&ldr_datetimetz_tmpl, &datetimetz);
   db_make_elo (&ldr_blob_tmpl, DB_TYPE_BLOB, null_elo);
   db_make_elo (&ldr_clob_tmpl, DB_TYPE_CLOB, null_elo);
-  db_make_bit (&ldr_bit_tmpl, 1, (DB_C_BIT) "0", 1);
+  db_make_bit (&ldr_bit_tmpl, 1, "0", 1);
   db_make_json (&ldr_json_tmpl, NULL, false);
 
   /*

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -1543,7 +1543,7 @@ au_set_new_auth (MOP au_obj, MOP grantor, MOP user, MOP class_mop, DB_AUTH auth_
       return er_errid ();
     }
 
-  db_make_string_by_const_str (&class_name_val, sm_get_ch_name (class_mop));
+  db_make_string (&class_name_val, sm_get_ch_name (class_mop));
   db_class_inst = obj_find_unique (db_class, "class_name", &class_name_val, AU_FETCH_READ);
   if (db_class_inst == NULL)
     {
@@ -1560,7 +1560,7 @@ au_set_new_auth (MOP au_obj, MOP grantor, MOP user, MOP class_mop, DB_AUTH auth_
       ;
     }
 
-  db_make_varchar (&value, 7, (char *) type_set[i], strlen (type_set[i]), LANG_SYS_CODESET, LANG_SYS_COLLATION);
+  db_make_varchar (&value, 7, type_set[i], strlen (type_set[i]), LANG_SYS_CODESET, LANG_SYS_COLLATION);
   obj_set (au_obj, "auth_type", &value);
 
   db_make_int (&value, (int) grant_option);
@@ -1646,13 +1646,13 @@ au_get_new_auth (MOP grantor, MOP user, MOP class_mop, DB_AUTH auth_type)
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SM_INVALID_CLASS, 0);
       goto exit;
     }
-  db_make_string_by_const_str (&val[INDEX_FOR_CLASS_NAME], class_name);
+  db_make_string (&val[INDEX_FOR_CLASS_NAME], class_name);
 
   for (type = DB_AUTH_SELECT, i = 0; type != auth_type; type = (DB_AUTH) (type << 1), i++)
     {
       ;
     }
-  db_make_string_by_const_str (&val[INDEX_FOR_AUTH_TYPE], type_set[i]);
+  db_make_string (&val[INDEX_FOR_AUTH_TYPE], type_set[i]);
 
   session = db_open_buffer (sql_query);
   if (session == NULL)
@@ -2047,7 +2047,7 @@ au_delete_auth_of_dropping_table (const char *class_name)
       goto release;
     }
 
-  db_make_string_by_const_str (&val, class_name);
+  db_make_string (&val, class_name);
   error = db_push_values (session, 1, &val);
   if (error != NO_ERROR)
     {
@@ -2836,7 +2836,7 @@ au_set_user_comment (MOP user, const char *comment)
 	}
       else
 	{
-	  db_make_string_by_const_str (&value, comment);
+	  db_make_string (&value, comment);
 	  error = obj_set (user, "comment", &value);
 	  pr_clear_value (&value);
 	}

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -514,7 +514,7 @@ static bool match_password (const char *user, const char *database);
 static int au_set_password_internal (MOP user, const char *password, int encode, char encrypt_prefix);
 
 static int au_add_direct_groups (DB_SET * new_groups, DB_VALUE * value);
-static int au_compute_groups (MOP member, char *name);
+static int au_compute_groups (MOP member, const char *name);
 static int au_add_member_internal (MOP group, MOP member, int new_user);
 
 static int find_grant_entry (DB_SET * grants, MOP class_mop, MOP grantor);
@@ -2252,7 +2252,7 @@ au_add_user_method (MOP class_mop, DB_VALUE * returnval, DB_VALUE * name, DB_VAL
   int error;
   int exists;
   MOP user;
-  char *tmp;
+  const char *tmp = NULL;
 
   if (name != NULL && IS_STRING (name) && !DB_IS_NULL (name) && ((tmp = db_get_string (name)) != NULL))
     {
@@ -2902,7 +2902,7 @@ au_add_direct_groups (DB_SET * new_groups, DB_VALUE * value)
  *   name(in): the new member name
  */
 static int
-au_compute_groups (MOP member, char *name)
+au_compute_groups (MOP member, const char *name)
 {
   int error = NO_ERROR;
   DB_SET *new_groups, *direct_groups;
@@ -3034,9 +3034,9 @@ au_add_member_internal (MOP group, MOP member, int new_user)
 {
   int error = NO_ERROR;
   DB_VALUE membervalue, member_name_val, groupvalue;
-  DB_SET *group_groups = NULL, *member_groups, *member_direct_groups;
+  DB_SET *group_groups = NULL, *member_groups = NULL, *member_direct_groups = NULL;
   int save;
-  char *member_name;
+  const char *member_name = NULL;
 
   AU_DISABLE (save);
   db_make_object (&membervalue, member);
@@ -3096,7 +3096,7 @@ au_add_member_internal (MOP group, MOP member, int new_user)
 				}
 			      else
 				{
-				  member_name = (char *) db_get_string (&member_name_val);
+				  member_name = db_get_string (&member_name_val);
 				}
 
 			      error = db_set_add (member_direct_groups, &groupvalue);
@@ -3229,9 +3229,9 @@ au_drop_member (MOP group, MOP member)
 {
   int syserr = NO_ERROR, error = NO_ERROR;
   DB_VALUE groupvalue, member_name_val;
-  DB_SET *groups, *member_groups, *member_direct_groups;
+  DB_SET *groups = NULL, *member_groups = NULL, *member_direct_groups = NULL;
   int save;
-  char *member_name;
+  const char *member_name = NULL;
 
   AU_DISABLE (save);
   db_make_object (&groupvalue, group);
@@ -3268,7 +3268,7 @@ au_drop_member (MOP group, MOP member)
 			}
 		      else
 			{
-			  member_name = (char *) db_get_string (&member_name_val);
+			  member_name = db_get_string (&member_name_val);
 			}
 		      if ((error = db_set_drop (member_direct_groups, &groupvalue)) == NO_ERROR)
 			{
@@ -5170,7 +5170,7 @@ au_change_owner_method (MOP obj, DB_VALUE * returnval, DB_VALUE * class_, DB_VAL
   int error = NO_ERROR;
   int is_partition = DB_NOT_PARTITIONED_CLASS, i, savepoint_owner = 0;
   MOP *sub_partitions = NULL;
-  char *class_name = NULL, *owner_name = NULL;
+  const char *class_name = NULL, *owner_name = NULL;
   SM_CLASS *clsobj;
 
   db_make_null (returnval);
@@ -5342,7 +5342,7 @@ au_change_serial_owner_method (MOP obj, DB_VALUE * returnval, DB_VALUE * serial,
   MOP user = NULL, serial_object = NULL;
   MOP serial_class_mop;
   DB_IDENTIFIER serial_obj_id;
-  char *serial_name, *owner_name;
+  const char *serial_name = NULL, *owner_name = NULL;
   int error = NO_ERROR;
 
   db_make_null (returnval);
@@ -6938,7 +6938,7 @@ au_export_users (print_output & output_ctx)
   DB_VALUE value, gvalue;
   MOP user = NULL, pwd = NULL;
   int g, gcard;
-  char *uname = NULL, *str = NULL, *gname = NULL, *comment = NULL;
+  const char *uname = NULL, *str = NULL, *gname = NULL, *comment = NULL;
   char passbuf[AU_MAX_PASSWORD_BUF];
   char *query = NULL;
   size_t query_size;
@@ -7168,7 +7168,7 @@ au_export_users (print_output & output_ctx)
 		}
 	      else
 		{
-		  gname = (char *) (db_get_string (&value));
+		  gname = db_get_string (&value);
 		}
 
 	      if (gname != NULL)
@@ -7869,7 +7869,7 @@ void
 au_dump_user (MOP user, FILE * fp)
 {
   DB_VALUE value;
-  DB_SET *groups;
+  DB_SET *groups = NULL;
   MOP auth;
   int i, card;
 
@@ -8027,8 +8027,8 @@ au_dump_to_file (FILE * fp)
 {
   MOP user;
   DB_VALUE value;
-  char *query;
-  DB_QUERY_RESULT *query_result;
+  char *query = NULL;
+  DB_QUERY_RESULT *query_result = NULL;
   DB_QUERY_ERROR query_error;
   int error = NO_ERROR;
   DB_VALUE user_val;

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -367,7 +367,7 @@ classobj_put_prop (DB_SEQ * properties, const char *name, DB_VALUE * pvalue)
 	{
 	  /* start with the property value to avoid growing the array twice */
 	  set_put_element (properties, max + 1, pvalue);
-	  db_make_string_by_const_str (&value, name);
+	  db_make_string (&value, name);
 	  set_put_element (properties, max, &value);
 	  pr_clear_value (&value);
 	}
@@ -911,7 +911,7 @@ classobj_put_seq_with_name_and_iterate (DB_SEQ * destination, int &index, const 
   int subseq_index = 0;
   int error_code = NO_ERROR;
 
-  db_make_string_by_const_str (&value, name);
+  db_make_string (&value, name);
   classobj_put_value_and_iterate (subseq, subseq_index, value);
 
   error_code = classobj_put_seq_and_iterate (subseq, subseq_index, seq);
@@ -1065,7 +1065,7 @@ classobj_put_index (DB_SEQ ** properties, SM_CONSTRAINT_TYPE type, const char *c
 	}
     }
 
-  db_make_string_by_const_str (&value, pbuf);
+  db_make_string (&value, pbuf);
   classobj_put_value_and_iterate (constraint, constraint_seq_index, value);
 
   if (pbuf && pbuf != &(buf[0]))
@@ -1079,7 +1079,7 @@ classobj_put_index (DB_SEQ ** properties, SM_CONSTRAINT_TYPE type, const char *c
       if (attr_name_instead_of_id)
 	{
 	  /* name */
-	  db_make_string_by_const_str (&value, atts[i]->header.name);
+	  db_make_string (&value, atts[i]->header.name);
 	}
       else
 	{
@@ -1219,7 +1219,7 @@ classobj_put_index (DB_SEQ ** properties, SM_CONSTRAINT_TYPE type, const char *c
   classobj_put_value_and_iterate (constraint, constraint_seq_index, value);
 
   /* comment */
-  db_make_string_by_const_str (&value, comment);
+  db_make_string (&value, comment);
   classobj_put_value_and_iterate (constraint, constraint_seq_index, value);
 
   /* Append the constraint to the unique property sequence */
@@ -1999,7 +1999,7 @@ classobj_change_constraint_comment (DB_SEQ * properties, SM_CLASS_CONSTRAINT * c
       goto end;
     }
 
-  db_make_string_by_const_str (&new_comment, comment);
+  db_make_string (&new_comment, comment);
   error = set_put_element (idx_seq, len - 1, &new_comment);
   if (error != NO_ERROR)
     {

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -317,7 +317,7 @@ classobj_put_prop (DB_SEQ * properties, const char *name, DB_VALUE * pvalue)
   int error;
   int found, max, i;
   DB_VALUE value;
-  char *val_str;
+  const char *val_str;
 
   error = NO_ERROR;
   found = 0;
@@ -397,7 +397,7 @@ classobj_drop_prop (DB_SEQ * properties, const char *name)
   int error;
   int dropped, max, i;
   DB_VALUE value;
-  char *val_str;
+  const char *val_str;
 
   error = NO_ERROR;
   dropped = 0;
@@ -2046,7 +2046,7 @@ end:
 int
 classobj_btid_from_property_value (DB_VALUE * value, BTID * btid, char **shared_cons_name)
 {
-  char *btid_string;
+  const char *btid_string = NULL;
   int volid, pageid, fileid;
   int args;
 
@@ -2100,7 +2100,7 @@ structure_error:
 int
 classobj_oid_from_property_value (DB_VALUE * value, OID * oid)
 {
-  char *oid_string;
+  const char *oid_string;
   int volid, pageid, slotid;
   int args;
 
@@ -2791,7 +2791,7 @@ classobj_make_foreign_key_ref (DB_SEQ * fk_seq)
 {
   DB_VALUE fvalue;
   SM_FOREIGN_KEY_INFO *fk_info;
-  char *val_str;
+  const char *val_str;
 
   fk_info = (SM_FOREIGN_KEY_INFO *) db_ws_alloc (sizeof (SM_FOREIGN_KEY_INFO));
   if (fk_info == NULL)
@@ -2961,9 +2961,9 @@ classobj_make_index_filter_pred_info (DB_SEQ * pred_seq)
 {
   SM_PREDICATE_INFO *filter_predicate = NULL;
   DB_VALUE fvalue, avalue, v;
-  char *val_str = NULL;
+  const char *val_str = NULL;
   size_t val_str_len = 0;
-  char *buffer = NULL;
+  const char *buffer = NULL;
   int buffer_len = 0;
   DB_SEQ *att_seq = NULL;
   int att_seq_size = 0, i;
@@ -8097,7 +8097,8 @@ classobj_make_function_index_info (DB_SEQ * func_seq)
 {
   SM_FUNCTION_INFO *fi_info = NULL;
   DB_VALUE val;
-  char *buffer, *ptr;
+  const char *buffer;
+  char *ptr;
   int size;
 
   if (func_seq == NULL)
@@ -8163,7 +8164,8 @@ classobj_make_function_index_info (DB_SEQ * func_seq)
       goto error;
     }
   buffer = db_get_string (&val);
-  ptr = buffer;
+  // use const_cast since of a limitation of or_unpack_* functions which do not accept const
+  ptr = CONST_CAST (char *, buffer);
   ptr = or_unpack_domain (ptr, &(fi_info->fi_domain), NULL);
 
   return fi_info;

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -5734,19 +5734,19 @@ make_desired_string_db_value (DB_TYPE desired_type, const TP_DOMAIN * desired_do
   switch (desired_type)
     {
     case DB_TYPE_CHAR:
-      db_make_char (&temp, desired_domain->precision, (DB_C_CHAR) new_string, strlen (new_string),
+      db_make_char (&temp, desired_domain->precision, new_string, strlen (new_string),
 		    TP_DOMAIN_CODESET (desired_domain), TP_DOMAIN_COLLATION (desired_domain));
       break;
     case DB_TYPE_NCHAR:
-      db_make_nchar (&temp, desired_domain->precision, (DB_C_NCHAR) new_string, strlen (new_string),
+      db_make_nchar (&temp, desired_domain->precision, new_string, strlen (new_string),
 		     TP_DOMAIN_CODESET (desired_domain), TP_DOMAIN_COLLATION (desired_domain));
       break;
     case DB_TYPE_VARCHAR:
-      db_make_varchar (&temp, desired_domain->precision, (DB_C_CHAR) new_string, strlen (new_string),
+      db_make_varchar (&temp, desired_domain->precision, new_string, strlen (new_string),
 		       TP_DOMAIN_CODESET (desired_domain), TP_DOMAIN_COLLATION (desired_domain));
       break;
     case DB_TYPE_VARNCHAR:
-      db_make_varnchar (&temp, desired_domain->precision, (DB_C_NCHAR) new_string, strlen (new_string),
+      db_make_varnchar (&temp, desired_domain->precision, new_string, strlen (new_string),
 			TP_DOMAIN_CODESET (desired_domain), TP_DOMAIN_COLLATION (desired_domain));
       break;
     default:			/* Can't get here.  This just quiets the compiler */
@@ -7152,7 +7152,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_JSON_STRING:
 	  {
 	    const char *json_string = db_json_get_string_from_document (src_doc);
-	    db_make_string_by_const_str (&src_replacement, json_string);
+	    db_make_string (&src_replacement, json_string);
 	  }
 	  break;
 	default:

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -5607,7 +5607,7 @@ bfmt_print (int bfmt, const DB_VALUE * the_db_bit, char *string, int max_size)
   int string_index = 0;
   int byte_index;
   int bit_index;
-  char *bstring;
+  const char *bstring;
   int error = NO_ERROR;
   static const char digits[16] = {
     '0', '1', '2', '3', '4', '5', '6', '7',

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -14259,7 +14259,8 @@ mr_setval_bit (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 {
   int error = NO_ERROR;
   int src_precision, src_length, src_number_of_bits = 0;
-  char *src_string, *new_;
+  char *new_ = NULL;
+  const char *src_string = NULL;
 
   assert (!db_value_is_corrupted (src));
   if (src == NULL || DB_IS_NULL (src))

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -12757,7 +12757,7 @@ mr_readval_nchar_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, i
     {
       int unconverted;
       int char_count;
-      char *temp_string = db_get_nchar (value, &char_count);
+      const char *temp_string = db_get_nchar (value, &char_count);
 
       if (char_count > 0)
 	{
@@ -13766,7 +13766,7 @@ mr_readval_varnchar_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain
 	{
 	  int unconverted;
 	  int char_count;
-	  char *temp_string = db_get_nchar (value, &char_count);
+	  const char *temp_string = db_get_nchar (value, &char_count);
 
 	  if (char_count > 0)
 	    {

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2057,7 +2057,8 @@ pr_clear_value (DB_VALUE * value)
     case DB_TYPE_ENUMERATION:
       if (value->need_clear)
 	{
-	  char *temp = db_get_enum_string (value);
+	  // here is safe to const_cast since the ownership was handed over by setting need_clear flag to true
+	  char *temp = CONST_CAST (char *, db_get_enum_string (value));
 	  if (temp != NULL)
 	    {
 	      db_private_free_and_init (NULL, temp);
@@ -9752,7 +9753,7 @@ int
 pr_complete_enum_value (DB_VALUE * value, struct tp_domain *domain)
 {
   unsigned short short_val;
-  char *str_val;
+  const char *str_val;
   int enum_count, str_val_size, idx;
   DB_ENUM_ELEMENT *db_elem = 0;
 
@@ -9788,13 +9789,15 @@ pr_complete_enum_value (DB_VALUE * value, struct tp_domain *domain)
       pr_clear_value (value);
 
       str_val_size = DB_GET_ENUM_ELEM_STRING_SIZE (db_elem);
-      str_val = (char *) db_private_alloc (NULL, str_val_size + 1);
-      if (str_val == NULL)
+      char *str_val_tmp = (char *) db_private_alloc (NULL, str_val_size + 1);
+      if (str_val_tmp == NULL)
 	{
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
-      memcpy (str_val, DB_GET_ENUM_ELEM_STRING (db_elem), str_val_size);
-      str_val[str_val_size] = 0;
+      memcpy (str_val_tmp, DB_GET_ENUM_ELEM_STRING (db_elem), str_val_size);
+      str_val_tmp[str_val_size] = 0;
+      str_val = str_val_tmp;
+
       db_make_enumeration (value, short_val, str_val, str_val_size, DB_GET_ENUM_ELEM_CODESET (db_elem),
 			   db_get_enum_collation (value));
       value->need_clear = true;
@@ -15504,7 +15507,7 @@ mr_getmem_enumeration (void *mem, TP_DOMAIN * domain, DB_VALUE * value, bool cop
 static int
 mr_setval_enumeration (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 {
-  char *str = NULL;
+  const char *str = NULL;
   bool need_clear = false;
 
   if (src == NULL || DB_IS_NULL (src))
@@ -15516,15 +15519,16 @@ mr_setval_enumeration (DB_VALUE * dest, const DB_VALUE * src, bool copy)
     {
       if (copy)
 	{
-	  str = (char *) db_private_alloc (NULL, db_get_enum_string_size (src) + 1);
-	  if (str == NULL)
+	  char *str_tmp = (char *) db_private_alloc (NULL, db_get_enum_string_size (src) + 1);
+	  if (str_tmp == NULL)
 	    {
 	      assert (er_errid () != NO_ERROR);
 	      return er_errid ();
 	    }
-	  memcpy (str, db_get_enum_string (src), db_get_enum_string_size (src));
-	  str[db_get_enum_string_size (src)] = 0;
+	  memcpy (str_tmp, db_get_enum_string (src), db_get_enum_string_size (src));
+	  str_tmp[db_get_enum_string_size (src)] = 0;
 	  need_clear = true;
+	  str = str_tmp;
 	}
       else
 	{
@@ -15580,7 +15584,7 @@ mr_setval_enumeration_internal (DB_VALUE * value, TP_DOMAIN * domain, unsigned s
 {
   bool need_clear = false;
   int str_size;
-  char *str;
+  const char *str = NULL;
   DB_ENUM_ELEMENT *db_elem = NULL;
 
   if (domain == NULL || DOM_GET_ENUM_ELEMS_COUNT (domain) == 0 || index == 0 || index == DB_ENUM_OVERFLOW_VAL)
@@ -15604,23 +15608,27 @@ mr_setval_enumeration_internal (DB_VALUE * value, TP_DOMAIN * domain, unsigned s
     }
   else
     {
+      char *str_tmp = NULL;
       if (copy_buf && copy_buf_len >= str_size + 1)
 	{
 	  /* read buf image into the copy_buf */
-	  str = copy_buf;
+	  str_tmp = copy_buf;
 	  need_clear = false;
 	}
       else
 	{
-	  str = (char *) db_private_alloc (NULL, str_size + 1);
-	  if (str == NULL)
+	  str_tmp = (char *) db_private_alloc (NULL, str_size + 1);
+	  if (str_tmp == NULL)
 	    {
 	      return ER_FAILED;
 	    }
 	  need_clear = true;
 	}
-      memcpy (str, DB_GET_ENUM_ELEM_STRING (db_elem), str_size);
-      str[str_size] = 0;
+
+      memcpy (str_tmp, DB_GET_ENUM_ELEM_STRING (db_elem), str_size);
+      str_tmp[str_size] = 0;
+
+      str = str_tmp;
     }
 
   db_make_enumeration (value, index, str, str_size, TP_DOMAIN_CODESET (domain), TP_DOMAIN_COLLATION (domain));

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -339,7 +339,8 @@ extern int pr_get_compressed_data_from_buffer (struct or_buf *buf, char *data, i
 extern int pr_get_size_and_write_string_to_buffer (struct or_buf *buf, char *val_p, DB_VALUE * value, int *val_size,
 						   int align);
 
-extern int pr_data_compress_string (char *string, int str_length, char *compressed_string, int *compressed_length);
+extern int pr_data_compress_string (const char *string, int str_length, char *compressed_string,
+				    int *compressed_length);
 extern int pr_clear_compressed_string (DB_VALUE * value);
 extern int pr_do_db_value_string_compression (DB_VALUE * value);
 

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -176,7 +176,6 @@ typedef struct pr_type
                               char *copy_buf, int copy_buf_len) const;
     inline DB_VALUE_COMPARE_RESULT index_cmpdisk (const void *memptr1, const void *memptr2, const tp_domain * domain,
                                                   int do_coercion, int total_order, int *start_colp) const;
-    
 } PR_TYPE, *PRIM;
 // *INDENT-ON*
 
@@ -516,7 +515,6 @@ pr_type::get_index_size_of_mem (const void * memptr, const tp_domain * domain) c
   if (f_index_lengthmem != NULL)
     {
       return (*f_index_lengthmem) (const_cast<void *> (memptr), const_cast<tp_domain *> (domain));
-      
     }
   else
     {

--- a/src/object/object_print.c
+++ b/src/object/object_print.c
@@ -348,8 +348,8 @@ char **
 help_class_names (const char *qualifier)
 {
   DB_OBJLIST *mops, *m;
-  char **names, *tmp;
-  const char *cname;
+  char **names;
+  const char *cname, *tmp;
   int count, i, outcount;
   DB_OBJECT *requested_owner, *owner;
   char buffer[2 * DB_MAX_IDENTIFIER_LENGTH + 4];

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -51,7 +51,7 @@ void object_printer::describe_comment (const char *comment)
   assert (comment != NULL);
 
   db_make_null (&comment_value);
-  db_make_string_by_const_str (&comment_value, comment);
+  db_make_string (&comment_value, comment);
 
   m_buf ("COMMENT ");
   if (comment != NULL && comment[0] != '\0')

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -3651,13 +3651,9 @@ static int
 or_packed_json_schema_length (const char *json_schema)
 {
   DB_VALUE val;
-  int len;
+  db_make_string (&val, json_schema);
 
-  // *INDENT-OFF*
-  db_make_string (&val, const_cast <char*>(json_schema));
-  // *INDENT-ON*
-
-  len = tp_String.get_disk_size_of_value (&val);
+  int len = tp_String.get_disk_size_of_value (&val);
 
   pr_clear_value (&val);
 
@@ -8152,7 +8148,7 @@ or_put_json_schema (OR_BUF * buf, const char *schema)
     }
   else
     {
-      db_make_string_by_const_str (&schema_raw, schema);
+      db_make_string (&schema_raw, schema);
     }
 
   rc = tp_String.data_writeval (buf, &schema_raw);

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -87,7 +87,7 @@ static char *unpack_str_array (char *buffer, char ***string_array, int count);
 static int or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align);
 static int or_varbit_length_internal (int bitlen, int align);
 static int or_varchar_length_internal (int charlen, int align);
-static int or_put_varbit_internal (OR_BUF * buf, char *string, int bitlen, int align);
+static int or_put_varbit_internal (OR_BUF * buf, const char *string, int bitlen, int align);
 static int or_packed_json_schema_length (const char *json_schema);
 static int or_packed_json_validator_length (JSON_VALIDATOR * json_validator);
 static char *or_unpack_var_table_internal (char *ptr, int nvars, OR_VARINFO * vars, int offset_size);
@@ -108,7 +108,7 @@ classobj_get_prop (DB_SEQ * properties, const char *name, DB_VALUE * pvalue)
   int error;
   int found, max, i;
   DB_VALUE value;
-  char *tmp_str;
+  const char *tmp_str;
 
   error = NO_ERROR;
   found = 0;
@@ -1174,7 +1174,7 @@ or_varbit_length_internal (int bitlen, int align)
  *    bitlen(in): length of varbit
  */
 int
-or_packed_put_varbit (OR_BUF * buf, char *string, int bitlen)
+or_packed_put_varbit (OR_BUF * buf, const char *string, int bitlen)
 {
   return or_put_varbit_internal (buf, string, bitlen, INT_ALIGNMENT);
 }
@@ -1187,13 +1187,13 @@ or_packed_put_varbit (OR_BUF * buf, char *string, int bitlen)
  *    bitlen(in): length of varbit
  */
 int
-or_put_varbit (OR_BUF * buf, char *string, int bitlen)
+or_put_varbit (OR_BUF * buf, const char *string, int bitlen)
 {
   return or_put_varbit_internal (buf, string, bitlen, CHAR_ALIGNMENT);
 }
 
 static int
-or_put_varbit_internal (OR_BUF * buf, char *string, int bitlen, int align)
+or_put_varbit_internal (OR_BUF * buf, const char *string, int bitlen, int align)
 {
   int net_bitlen;
   int bytelen;
@@ -7170,7 +7170,8 @@ or_get_enumeration (OR_BUF * buf, DB_ENUMERATION * enumeration)
   DB_ENUM_ELEMENT *enum_vals = NULL, *db_enum = NULL;
   int idx = 0, count = 0, error = NO_ERROR;
   DB_VALUE value;
-  char *enum_str = NULL, *value_str;
+  char *enum_str = NULL;
+  const char *value_str = NULL;
   int str_size = 0;
   LANG_COLLATION *lc;
 
@@ -7260,9 +7261,7 @@ error_return:
     {
       for (--idx; idx >= 0; idx--)
 	{
-	  // TODO enum: tmp variable is temporary until db_char::medium::buf will be made const
-	  const char *tmp = DB_GET_ENUM_ELEM_STRING (&enum_vals[idx]);
-	  free_and_init (tmp);
+	  free_and_init (DB_GET_ENUM_ELEM_STRING (&enum_vals[idx]));
 	}
       free_and_init (enum_vals);
     }

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -7260,7 +7260,9 @@ error_return:
     {
       for (--idx; idx >= 0; idx--)
 	{
-	  free_and_init (DB_GET_ENUM_ELEM_STRING (&enum_vals[idx]));
+	  // TODO enum: tmp variable is temporary until db_char::medium::buf will be made const
+	  const char *tmp = DB_GET_ENUM_ELEM_STRING (&enum_vals[idx]);
+	  free_and_init (tmp);
 	}
       free_and_init (enum_vals);
     }

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -2694,7 +2694,7 @@ sm_rename_class (MOP op, const char *new_name)
 		  if (att->auto_increment != NULL)
 		    {
 		      DB_VALUE name_val;
-		      char *class_name;
+		      const char *class_name;
 
 		      if (db_get (att->auto_increment, "class_name", &name_val) != NO_ERROR)
 			{
@@ -3144,7 +3144,7 @@ sm_partitioned_class_type (DB_OBJECT * classop, int *partition_type, char *keyat
       pcnt = psize.data.i;
       if (keyattr)
 	{
-	  char *p = NULL;
+	  const char *p = NULL;
 
 	  keyattr[0] = 0;
 	  if (DB_IS_NULL (&attrname) || (p = db_get_string (&attrname)) == NULL)
@@ -13083,7 +13083,7 @@ sm_delete_class_mop (MOP op, bool is_cascade_constraints)
       if (att->auto_increment != NULL)
 	{
 	  DB_VALUE name_val;
-	  char *class_name;
+	  const char *class_name;
 
 	  error = db_get (att->auto_increment, "class_name", &name_val);
 	  if (error == NO_ERROR)

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -3101,7 +3101,7 @@ disk_to_attribute (OR_BUF * buf, SM_ATTRIBUTE * att)
 		{
 		  DB_SEQ *def_expr_seq;
 		  DB_VALUE def_expr_op, def_expr_type, def_expr_format;
-		  char *def_expr_format_str;
+		  const char *def_expr_format_str;
 
 		  assert (set_size (db_get_set (&value)) == 3);
 

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -1486,8 +1486,7 @@ string_disk_size (const char *string)
       str_length = 0;
     }
 
-  db_make_varnchar (&value, TP_FLOATING_PRECISION_VALUE, (DB_C_NCHAR) string, str_length, LANG_SYS_CODESET,
-		    LANG_SYS_COLLATION);
+  db_make_varnchar (&value, TP_FLOATING_PRECISION_VALUE, string, str_length, LANG_SYS_CODESET, LANG_SYS_COLLATION);
   length = tp_VarNChar.get_disk_size_of_value (&value);
 
   /* Clear the compressed_string of DB_VALUE */
@@ -1570,8 +1569,7 @@ put_string (OR_BUF * buf, const char *string)
       str_length = 0;
     }
 
-  db_make_varnchar (&value, TP_FLOATING_PRECISION_VALUE, (DB_C_NCHAR) string, str_length, LANG_SYS_CODESET,
-		    LANG_SYS_COLLATION);
+  db_make_varnchar (&value, TP_FLOATING_PRECISION_VALUE, string, str_length, LANG_SYS_CODESET, LANG_SYS_COLLATION);
   tp_VarNChar.data_writeval (buf, &value);
   pr_clear_value (&value);
 }
@@ -2108,7 +2106,7 @@ domain_to_disk (OR_BUF * buf, TP_DOMAIN * domain)
 
   if (domain->json_validator)
     {
-      db_make_string_by_const_str (&schema_value, db_json_get_schema_raw_from_validator (domain->json_validator));
+      db_make_string (&schema_value, db_json_get_schema_raw_from_validator (domain->json_validator));
       tp_String.data_writeval (buf, &schema_value);
       pr_clear_value (&schema_value);
     }

--- a/src/object/trigger_description.cpp
+++ b/src/object/trigger_description.cpp
@@ -462,7 +462,7 @@ get_user_name (DB_OBJECT *user)
   static char namebuf[MAX_USER_NAME];
 
   DB_VALUE value;
-  char *tmp;
+  const char *tmp;
 
   if (db_get (user, "name", &value))
     {

--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -1174,7 +1174,7 @@ object_to_trigger (DB_OBJECT * object, TR_TRIGGER * trigger)
   int save;
   MOBJ obj;
   SM_CLASS *class_;
-  char *tmp;
+  const char *tmp;
 
   AU_DISABLE (save);
 

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -4802,7 +4802,7 @@ qo_set_cost (DB_OBJECT * target, DB_VALUE * result, DB_VALUE * plan, DB_VALUE * 
   plan_string = qo_plan_set_cost_fn (plan_string, cost_string[0]);
   if (plan_string != NULL)
     {
-      db_make_string_by_const_str (result, plan_string);
+      db_make_string (result, plan_string);
     }
   else
     {

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -3407,7 +3407,8 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 
     case PT_TYPE_NCHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      db_make_nchar (db_value, TP_FLOATING_PRECISION_VALUE, (DB_C_NCHAR) value->info.value.data_value.str->bytes,
+      db_make_nchar (db_value, TP_FLOATING_PRECISION_VALUE,
+		     REINTERPRET_CAST (char *, value->info.value.data_value.str->bytes),
 		     value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);
@@ -3415,7 +3416,8 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 
     case PT_TYPE_VARNCHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      db_make_varnchar (db_value, TP_FLOATING_PRECISION_VALUE, (DB_C_NCHAR) value->info.value.data_value.str->bytes,
+      db_make_varnchar (db_value, TP_FLOATING_PRECISION_VALUE,
+			REINTERPRET_CAST (char *, value->info.value.data_value.str->bytes),
 			value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);
@@ -3481,7 +3483,8 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 
     case PT_TYPE_CHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      db_make_char (db_value, TP_FLOATING_PRECISION_VALUE, (DB_C_CHAR) value->info.value.data_value.str->bytes,
+      db_make_char (db_value, TP_FLOATING_PRECISION_VALUE,
+		    REINTERPRET_CAST (char *, value->info.value.data_value.str->bytes),
 		    value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);
@@ -3489,7 +3492,8 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 
     case PT_TYPE_VARCHAR:
       /* for constants, set the precision to TP_FLOATING_PRECISION_VALUE */
-      db_make_varchar (db_value, TP_FLOATING_PRECISION_VALUE, (DB_C_CHAR) value->info.value.data_value.str->bytes,
+      db_make_varchar (db_value, TP_FLOATING_PRECISION_VALUE,
+		       REINTERPRET_CAST (char *, value->info.value.data_value.str->bytes),
 		       value->info.value.data_value.str->length, codeset, collation_id);
       value->info.value.db_value_is_in_workspace = false;
       *more_type_info_needed = (value->data_type == NULL);

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -1768,9 +1768,7 @@ error:
     {
       for (--idx; idx >= 0; idx--)
 	{
-	  // TODO enum: tmp variable is temporary until db_char::medium::buf will be made const
-	  const char *tmp = DB_GET_ENUM_ELEM_STRING (&enum_elements[idx]);
-	  free_and_init (tmp);
+	  free_and_init (DB_GET_ENUM_ELEM_STRING (&enum_elements[idx]));
 	}
       free_and_init (enum_elements);
     }

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -1768,7 +1768,9 @@ error:
     {
       for (--idx; idx >= 0; idx--)
 	{
-	  free_and_init (DB_GET_ENUM_ELEM_STRING (&enum_elements[idx]));
+	  // TODO enum: tmp variable is temporary until db_char::medium::buf will be made const
+	  const char *tmp = DB_GET_ENUM_ELEM_STRING (&enum_elements[idx]);
+	  free_and_init (tmp);
 	}
       free_and_init (enum_elements);
     }

--- a/src/parser/parse_evaluate.c
+++ b/src/parser/parse_evaluate.c
@@ -1177,12 +1177,12 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 		case PT_RTRIM:
 		  if (type1 == PT_TYPE_NCHAR || type1 == PT_TYPE_VARNCHAR)
 		    {
-		      db_make_varnchar (&opd2, 1, (char *) " ", 1, opd1_cs, opd1_coll);
+		      db_make_varnchar (&opd2, 1, " ", 1, opd1_cs, opd1_coll);
 		      type2 = PT_TYPE_VARNCHAR;
 		    }
 		  else
 		    {
-		      db_make_varchar (&opd2, 1, (char *) " ", 1, opd1_cs, opd1_coll);
+		      db_make_varchar (&opd2, 1, " ", 1, opd1_cs, opd1_coll);
 		      type2 = PT_TYPE_VARCHAR;
 		    }
 		  break;
@@ -1211,12 +1211,12 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 		case PT_TRANSLATE:
 		  if (type1 == PT_TYPE_NCHAR || type1 == PT_TYPE_VARNCHAR)
 		    {
-		      db_make_varnchar (&opd3, 1, (char *) "", 0, opd1_cs, opd1_coll);
+		      db_make_varnchar (&opd3, 1, "", 0, opd1_cs, opd1_coll);
 		      type3 = PT_TYPE_VARNCHAR;
 		    }
 		  else
 		    {
-		      db_make_varchar (&opd3, 1, (char *) "", 0, opd1_cs, opd1_coll);
+		      db_make_varchar (&opd3, 1, "", 0, opd1_cs, opd1_coll);
 		      type3 = PT_TYPE_VARCHAR;
 		    }
 		  break;
@@ -1224,12 +1224,12 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 		case PT_RPAD:
 		  if (type1 == PT_TYPE_NCHAR || type1 == PT_TYPE_VARNCHAR)
 		    {
-		      db_make_varnchar (&opd3, 1, (char *) " ", 1, opd1_cs, opd1_coll);
+		      db_make_varnchar (&opd3, 1, " ", 1, opd1_cs, opd1_coll);
 		      type2 = PT_TYPE_VARNCHAR;
 		    }
 		  else
 		    {
-		      db_make_varchar (&opd3, 1, (char *) " ", 1, opd1_cs, opd1_coll);
+		      db_make_varchar (&opd3, 1, " ", 1, opd1_cs, opd1_coll);
 		      type2 = PT_TYPE_VARCHAR;
 		    }
 		  break;

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -7703,7 +7703,7 @@ pt_make_query_show_index (PARSER_CONTEXT * parser, PT_NODE * original_cls_id)
 			   LANG_SYS_COLLATION, NULL);
   db_value_domain_default (db_valuep + 11, DB_TYPE_VARCHAR, DB_DEFAULT_PRECISION, 0, LANG_SYS_CODESET,
 			   LANG_SYS_COLLATION, NULL);
-  db_make_varchar (db_valuep + 12, DB_DEFAULT_PRECISION, (DB_C_CHAR) "", 0, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+  db_make_varchar (db_valuep + 12, DB_DEFAULT_PRECISION, "", 0, LANG_SYS_CODESET, LANG_SYS_COLLATION);
   db_value_domain_default (db_valuep + 13, DB_TYPE_VARCHAR, DB_DEFAULT_PRECISION, 0, LANG_SYS_CODESET,
 			   LANG_SYS_COLLATION, NULL);
 

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -12040,7 +12040,7 @@ static int
 pt_check_and_coerce_to_time (PARSER_CONTEXT * parser, PT_NODE * src)
 {
   DB_VALUE *db_src = NULL;
-  char *cp;
+  const char *cp;
   DB_TYPE dbtype;
   int cp_len;
 
@@ -12082,7 +12082,7 @@ static int
 pt_check_and_coerce_to_date (PARSER_CONTEXT * parser, PT_NODE * src)
 {
   DB_VALUE *db_src = NULL;
-  char *str = NULL;
+  const char *str = NULL;
   int str_len;
 
   assert (src != NULL);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -17724,7 +17724,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
       {
 	const char *username = au_user_name ();
 
-	error = db_make_string (result, username);
+	error = db_make_string_copy (result, username);
 	db_string_free ((char *) username);
 	if (error < 0)
 	  {

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -17724,7 +17724,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
       {
 	const char *username = au_user_name ();
 
-	error = db_make_string_by_const_str (result, username);
+	error = db_make_string (result, username);
 	db_string_free ((char *) username);
 	if (error < 0)
 	  {
@@ -18294,11 +18294,11 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 		if (arg1->domain.general_info.type == DB_TYPE_NCHAR
 		    || arg1->domain.general_info.type == DB_TYPE_VARNCHAR)
 		  {
-		    db_make_nchar (esc_char, 1, (DB_C_NCHAR) slash_str, 1, arg1_cs, arg1_coll);
+		    db_make_nchar (esc_char, 1, slash_str, 1, arg1_cs, arg1_coll);
 		  }
 		else
 		  {
-		    db_make_char (esc_char, 1, (DB_C_CHAR) slash_str, 1, arg1_cs, arg1_coll);
+		    db_make_char (esc_char, 1, slash_str, 1, arg1_cs, arg1_coll);
 		  }
 
 		esc_char->need_clear = false;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -5682,7 +5682,7 @@ mq_set_non_updatable_oid (PARSER_CONTEXT * parser, PT_NODE * stmt, PT_NODE * vir
 	  select_list->type_enum = PT_TYPE_OBJECT;
 
 	  /* set vclass_name as literal string */
-	  db_make_string_by_const_str (&vid, db_get_class_name (virt_entity->info.name.db_object));
+	  db_make_string (&vid, db_get_class_name (virt_entity->info.name.db_object));
 	  select_list->info.function.arg_list = pt_dbval_to_value (parser, &vid);
 	  select_list->info.function.function_type = F_SEQUENCE;
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -6813,8 +6813,8 @@ pt_make_prim_data_type (PARSER_CONTEXT * parser, PT_TYPE_ENUM e)
 void
 pt_to_regu_resolve_domain (int *p_precision, int *p_scale, const PT_NODE * node)
 {
-  char *format_buf;
-  char *fbuf_end_ptr;
+  const char *format_buf;
+  const char *fbuf_end_ptr;
   int format_sz;
   int precision, scale, maybe_sci_notation = 0;
 

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -4351,7 +4351,7 @@ db_typeof_dbval (DB_VALUE * result, DB_VALUE * value)
       break;
 
     default:
-      db_make_string_by_const_str (result, type_name);
+      db_make_string (result, type_name);
     }
 
   return NO_ERROR;
@@ -5176,7 +5176,7 @@ db_evaluate_json_type_dbval (DB_VALUE * result, DB_VALUE * const *arg, int const
       type = db_json_get_type_as_str (doc.get_immutable ());
       length = strlen (type);
 
-      return db_make_varchar (result, length, (DB_C_CHAR) type, length, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
+      return db_make_varchar (result, length, type, length, LANG_COERCIBLE_CODESET, LANG_COERCIBLE_COLL);
     }
 }
 
@@ -6261,7 +6261,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
   const DB_VALUE *esc_char = nullptr;
   const char * slash_str = "\\";
   DB_VALUE default_slash_str_dbval;
-  
+
   if (num_args >= 4)
     {
       esc_char = args[3];
@@ -6272,7 +6272,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
       if (prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) == false)
       {
 	 // This is equivalent to compat_mode=mysql. In this mode '\\' is default escape character for LIKE pattern
-	 db_make_string (&default_slash_str_dbval, const_cast<char *> (slash_str));
+	 db_make_string (&default_slash_str_dbval, slash_str);
 	 esc_char = &default_slash_str_dbval;
       }
     }
@@ -6464,7 +6464,7 @@ is_str_find_all (DB_VALUE * val, bool & find_all)
   std::string find_all_str (db_get_string (val), db_get_string_size (val));
   std::transform (find_all_str.begin (), find_all_str.end (), find_all_str.begin (), [] (unsigned char c)
   {
-    return std::tolower (c); 
+    return std::tolower (c);
   });
   // *INDENT-ON*
 

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5830,7 +5830,6 @@ db_evaluate_json_keys (DB_VALUE * result, DB_VALUE * const *arg, int const num_a
   /* *INDENT-OFF* */
   std::string path;
   /* *INDENT-ON* */
-  char *str = NULL;
 
   db_make_null (result);
 
@@ -5853,7 +5852,7 @@ db_evaluate_json_keys (DB_VALUE * result, DB_VALUE * const *arg, int const num_a
   else
     {
       /* *INDENT-OFF* */
-      path = std::move (std::string (db_get_string (arg[1]), db_get_string_size (arg[1])));
+      path = std::string (db_get_string (arg[1]), db_get_string_size (arg[1]));
       /* *INDENT-ON* */
     }
 
@@ -6314,7 +6313,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
       char *escaped;
       size_t escaped_size;
       error_code = db_string_escape_str (path.c_str (), path.size (), &escaped, &escaped_size);
-      cubmem::private_unique_ptr<char> escaped_unqique_ptr (escaped, NULL);
+      cubmem::private_unique_ptr<char> escaped_unique_ptr (escaped, NULL);
       if (error_code)
 	{
 	  return error_code;
@@ -6344,7 +6343,7 @@ db_evaluate_json_search (DB_VALUE *result, DB_VALUE * const * args, const int nu
       char *escaped;
       size_t escaped_size;
       error_code = db_string_escape_str (path.c_str (), path.size (), &escaped, &escaped_size);
-      cubmem::private_unique_ptr<char> escaped_unqique_ptr (escaped, NULL);
+      cubmem::private_unique_ptr<char> escaped_unique_ptr (escaped, NULL);
       if (error_code)
 	{
 	  return error_code;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -9734,8 +9734,8 @@ do_alter_change_owner (PARSER_CONTEXT * const parser, PT_NODE * const alter)
 
   db_make_null (&returnval);
 
-  db_make_string_by_const_str (&class_val, class_->info.name.original);
-  db_make_string_by_const_str (&user_val, user->info.name.original);
+  db_make_string (&class_val, class_->info.name.original);
+  db_make_string (&user_val, user->info.name.original);
 
   au_change_owner_method (obj, &returnval, &class_val, &user_val);
 

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -4409,7 +4409,7 @@ do_is_partitioned_subclass (int *is_partitioned, const char *classname, char *ke
 
       if (keyattr)
 	{
-	  char *p = NULL;
+	  const char *p = NULL;
 
 	  keyattr[0] = 0;
 
@@ -5072,7 +5072,7 @@ do_get_partition_keycol (char *keycol, MOP class_)
   int error = NO_ERROR;
   SM_CLASS *smclass;
   DB_VALUE keyname;
-  char *keyname_str;
+  const char *keyname_str;
 
   if (class_ == NULL || keycol == NULL)
     {

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -4381,7 +4381,7 @@ static int map_iso_levels (PARSER_CONTEXT * parser, PT_NODE * statement, DB_TRAN
 static int set_iso_level (PARSER_CONTEXT * parser, DB_TRAN_ISOLATION * tran_isolation, bool * async_ws,
 			  PT_NODE * statement, const DB_VALUE * level);
 static int check_timeout_value (PARSER_CONTEXT * parser, PT_NODE * statement, DB_VALUE * val);
-static char *get_savepoint_name_from_db_value (DB_VALUE * val);
+static const char *get_savepoint_name_from_db_value (DB_VALUE * val);
 
 /*
  * do_attach() - Attaches to named (distributed 2pc) transaction
@@ -4831,7 +4831,7 @@ do_set_optimization_param (PARSER_CONTEXT * parser, PT_NODE * statement)
 {
   PT_NODE *p1, *p2;
   DB_VALUE val1, val2;
-  char *plan, *cost;
+  const char *plan, *cost;
 
   db_make_null (&val1);
   db_make_null (&val2);
@@ -5110,7 +5110,7 @@ check_timeout_value (PARSER_CONTEXT * parser, PT_NODE * statement, DB_VALUE * va
  *       type string, a NULL termination will be assumed since the
  *       name came from a parse tree.
  */
-static char *
+const static char *
 get_savepoint_name_from_db_value (DB_VALUE * val)
 {
   if (DB_VALUE_TYPE (val) != DB_TYPE_CHAR && DB_VALUE_TYPE (val) != DB_TYPE_VARCHAR

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -670,7 +670,7 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
     }
 
   /* name */
-  db_make_string_by_const_str (&value, serial_name);
+  db_make_string (&value, serial_name);
   error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_NAME, &value);
   pr_clear_value (&value);
   if (error != NO_ERROR)
@@ -734,7 +734,7 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
     }
 
   /* comment */
-  db_make_string_by_const_str (&value, comment);
+  db_make_string (&value, comment);
   error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_COMMENT, &value);
   pr_clear_value (&value);
   if (error != NO_ERROR)
@@ -745,7 +745,7 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
   /* class name */
   if (class_name)
     {
-      db_make_string_by_const_str (&value, class_name);
+      db_make_string (&value, class_name);
       error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_CLASS_NAME, &value);
       pr_clear_value (&value);
       if (error != NO_ERROR)
@@ -757,7 +757,7 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
   /* att name */
   if (att_name)
     {
-      db_make_string_by_const_str (&value, att_name);
+      db_make_string (&value, att_name);
       error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_ATT_NAME, &value);
       pr_clear_value (&value);
       if (error != NO_ERROR)
@@ -880,7 +880,7 @@ do_update_auto_increment_serial_on_rename (MOP serial_obj, const char *class_nam
 
   /* class name */
   pr_clear_value (&value);
-  db_make_string_by_const_str (&value, class_name);
+  db_make_string (&value, class_name);
   error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_CLASS_NAME, &value);
   pr_clear_value (&value);
   if (error != NO_ERROR)
@@ -889,7 +889,7 @@ do_update_auto_increment_serial_on_rename (MOP serial_obj, const char *class_nam
     }
 
   /* att name */
-  db_make_string_by_const_str (&value, att_name);
+  db_make_string (&value, att_name);
   error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_ATT_NAME, &value);
   pr_clear_value (&value);
   if (error != NO_ERROR)
@@ -2781,7 +2781,7 @@ do_alter_serial (PARSER_CONTEXT * parser, PT_NODE * statement)
     {
       assert (statement->info.serial.comment->node_type == PT_VALUE);
       comment = (char *) PT_VALUE_GET_BYTES (statement->info.serial.comment);
-      db_make_string_by_const_str (&value, comment);
+      db_make_string (&value, comment);
       error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_COMMENT, &value);
       pr_clear_value (&value);
       if (error < 0)
@@ -6504,8 +6504,8 @@ do_alter_trigger (PARSER_CONTEXT * parser, PT_NODE * statement)
 
 		  db_make_null (&returnval);
 
-		  db_make_string_by_const_str (&trigger_name_val, trigger_name->info.name.original);
-		  db_make_string_by_const_str (&user_val, trigger_owner_name);
+		  db_make_string (&trigger_name_val, trigger_name->info.name.original);
+		  db_make_string (&user_val, trigger_owner_name);
 
 		  au_change_trigger_owner_method (t->op, &returnval, &trigger_name_val, &user_val);
 
@@ -13828,7 +13828,7 @@ dbmeth_class_name (DB_OBJECT * self, DB_VALUE * result)
    * course, this gives the responsibility for freeing the cloned
    * string to someone else; is anybody accepting it?
    */
-  db_make_string_by_const_str (result, cname);
+  db_make_string (result, cname);
 }
 
 /*

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4628,7 +4628,7 @@ is_argument_wrapped_with_cast_op (const REGU_VARIABLE * regu_var)
 /*
  * get_hour_minute_or_second () - extract hour, minute or second
  *				  information from datetime depending on
- *				  the value of the op_type variable	
+ *				  the value of the op_type variable
  *   return: error or no error
  *   datetime(in): datetime value
  *   op_type(in): operation type

--- a/src/query/partition.c
+++ b/src/query/partition.c
@@ -2457,13 +2457,13 @@ partition_load_partition_predicate (PRUNING_CONTEXT * pinfo, OR_PARTITION * mast
     }
 
   assert (DB_VALUE_TYPE (&val) == DB_TYPE_CHAR);
-  expr_stream = db_get_string (&val);
+  // use const_cast since of a limitation of or_unpack_* functions which do not accept const
+  expr_stream = CONST_CAST (char *, db_get_string (&val));
   stream_len = db_get_string_size (&val);
 
   /* unpack partition expression */
-  error =
-    stx_map_stream_to_func_pred (pinfo->thread_p, &pinfo->partition_pred, expr_stream, stream_len,
-				 &pinfo->fp_cache_context);
+  error = stx_map_stream_to_func_pred (pinfo->thread_p, &pinfo->partition_pred, expr_stream, stream_len,
+				       &pinfo->fp_cache_context);
   if (error != NO_ERROR)
     {
       ASSERT_ERROR ();

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -617,7 +617,7 @@ static int qexec_execute_do_stmt (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 
 static int bf2df_str_son_index (THREAD_ENTRY * thread_p, char **son_index, char *father_index, int *len_son_index,
 				int cnt);
-static DB_VALUE_COMPARE_RESULT bf2df_str_compare (unsigned char *s0, int l0, unsigned char *s1, int l1);
+static DB_VALUE_COMPARE_RESULT bf2df_str_compare (const unsigned char *s0, int l0, const unsigned char *s1, int l1);
 static DB_VALUE_COMPARE_RESULT bf2df_str_cmpdisk (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion,
 						  int total_order, int *start_colp);
 static DB_VALUE_COMPARE_RESULT bf2df_str_cmpval (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total_order,
@@ -17967,11 +17967,11 @@ qexec_execute_do_stmt (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * x
  *   l1(in): length of second string
  */
 static DB_VALUE_COMPARE_RESULT
-bf2df_str_compare (unsigned char *s0, int l0, unsigned char *s1, int l1)
+bf2df_str_compare (const unsigned char *s0, int l0, const unsigned char *s1, int l1)
 {
   DB_BIGINT b0, b1;
-  unsigned char *e0 = s0 + l0;
-  unsigned char *e1 = s1 + l1;
+  const unsigned char *e0 = s0 + l0;
+  const unsigned char *e1 = s1 + l1;
 
   if (!s0 || !s1)
     {
@@ -18191,10 +18191,8 @@ static DB_VALUE_COMPARE_RESULT
 bf2df_str_cmpval (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total_order, int *start_colp,
 		  int collation)
 {
-  unsigned char *string1, *string2;
-
-  string1 = (unsigned char *) db_get_string (value1);
-  string2 = (unsigned char *) db_get_string (value2);
+  const unsigned char *string1 = REINTERPRET_CAST (const unsigned char *, db_get_string (value1));
+  const unsigned char *string2 = REINTERPRET_CAST (const unsigned char *, db_get_string (value2));
 
   if (string1 == NULL || string2 == NULL)
     {
@@ -22908,7 +22906,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 
 	  if (attrepr->on_update_expr != DB_DEFAULT_NONE)
 	    {
-	      char *saved = db_get_string (out_values[idx_val]);
+	      const char *saved = db_get_string (out_values[idx_val]);
 	      size_t len = strlen (saved);
 
 	      const char *default_expr_op_string = db_default_expression_string (attrepr->on_update_expr);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15383,7 +15383,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 			}
 
 		      /* set parent tuple position pseudocolumn value */
-		      db_make_bit (parent_pos_valp, DB_DEFAULT_PRECISION, (DB_C_BIT) (&parent_pos),
+		      db_make_bit (parent_pos_valp, DB_DEFAULT_PRECISION, REINTERPRET_CAST (DB_C_BIT, &parent_pos),
 				   sizeof (parent_pos) * 8);
 
 		      parent_tuple_added = true;
@@ -16892,7 +16892,7 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 	  if (level > 1)
 	    {
 	      /* set parent position pseudocolumn value */
-	      db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, (DB_C_BIT) & pos_info_p->tpl_pos,
+	      db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, REINTERPRET_CAST (DB_C_BIT, &pos_info_p->tpl_pos),
 			   sizeof (pos_info_p->tpl_pos) * 8);
 
 	      if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
@@ -16923,7 +16923,7 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 
 	  qfile_save_current_scan_tuple_position (&prev_s_id, &pos_info_p->tpl_pos);
 
-	  db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, (DB_C_BIT) & pos_info_p->tpl_pos,
+	  db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, REINTERPRET_CAST (DB_C_BIT, &pos_info_p->tpl_pos),
 		       sizeof (pos_info_p->tpl_pos) * 8);
 
 	  if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
@@ -16958,7 +16958,7 @@ qexec_recalc_tuples_parent_pos_in_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID *
 
 	  if (level > 1)
 	    {
-	      db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, (DB_C_BIT) & pos_info_p->tpl_pos,
+	      db_make_bit (&parent_pos_dbval, DB_DEFAULT_PRECISION, REINTERPRET_CAST (DB_C_BIT, &pos_info_p->tpl_pos),
 			   sizeof (pos_info_p->tpl_pos) * 8);
 
 	      if (qfile_set_tuple_column_value (thread_p, list_id_p, s_id.curr_pgptr, &s_id.curr_vpid, tuple_rec.tpl,
@@ -21822,7 +21822,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
       db_make_null (out_values[8]);
 
       /* index type */
-      db_make_string_by_const_str (out_values[10], "BTREE");
+      db_make_string (out_values[10], "BTREE");
 
       index = rep->indexes + i;
       /* Non_unique */
@@ -21840,7 +21840,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
       db_make_string (out_values[12], comment);
 
       /* Visible */
-      db_make_string_by_const_str (out_values[13], (index->index_status == OR_NORMAL_INDEX) ? "YES" : "NO");
+      db_make_string (out_values[13], (index->index_status == OR_NORMAL_INDEX) ? "YES" : "NO");
 
       if (index->func_index_info == NULL)
 	{
@@ -21875,11 +21875,11 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  /* Collation */
 	  if (index->asc_desc[j])
 	    {
-	      db_make_string_by_const_str (out_values[5], "D");
+	      db_make_string (out_values[5], "D");
 	    }
 	  else
 	    {
-	      db_make_string_by_const_str (out_values[5], "A");
+	      db_make_string (out_values[5], "A");
 	    }
 
 	  /* Cardinality */
@@ -21911,11 +21911,11 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  /* [Null] */
 	  if (index_att->is_notnull)
 	    {
-	      db_make_string_by_const_str (out_values[9], "NO");
+	      db_make_string (out_values[9], "NO");
 	    }
 	  else
 	    {
-	      db_make_string_by_const_str (out_values[9], "YES");
+	      db_make_string (out_values[9], "YES");
 	    }
 
 	  /* Column_name */
@@ -21950,11 +21950,11 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 
 	  if (function_asc_desc)
 	    {
-	      db_make_string_by_const_str (out_values[5], "D");
+	      db_make_string (out_values[5], "D");
 	    }
 	  else
 	    {
-	      db_make_string_by_const_str (out_values[5], "A");
+	      db_make_string (out_values[5], "A");
 	    }
 
 	  /* Seq_in_index */
@@ -21980,7 +21980,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  db_make_null (out_values[7]);
 
 	  /* [Null] */
-	  db_make_string_by_const_str (out_values[9], "YES");
+	  db_make_string (out_values[9], "YES");
 
 	  /* Column_name */
 	  db_make_null (out_values[4]);
@@ -22433,7 +22433,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
       pset_result = &set_result;
 
       db_make_string (&comma, ",");
-      db_make_string_by_const_str (pset_result, set_of_string);
+      db_make_string (pset_result, set_of_string);
 
       for (setdomain = domain->setdomain, i = 0; setdomain; setdomain = setdomain->next, i++)
 	{
@@ -22492,7 +22492,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
       db_make_string (&comma, ",");
       db_make_string (&bracket1, "(");
       db_make_string (&bracket2, ")");
-      db_make_string_by_const_str (pprec_scale_arg1, name);
+      db_make_string (pprec_scale_arg1, name);
 
       if ((db_string_concatenate (pprec_scale_arg1, &bracket1, pprec_scale_result, &data_stat) != NO_ERROR)
 	  || (data_stat != DATA_STATUS_OK))
@@ -22572,8 +22572,8 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
 
       if (db_json_get_schema_raw_from_validator (validator) != NULL)
 	{
-	  db_make_string_by_const_str (result, name);
-	  db_make_string_by_const_str (&schema, db_json_get_schema_raw_from_validator (validator));
+	  db_make_string (result, name);
+	  db_make_string (&schema, db_json_get_schema_raw_from_validator (validator));
 	  db_make_string (&bracket1, "(\'");
 	  db_make_string (&bracket2, "\')");
 
@@ -22599,7 +22599,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
     }
   else
     {
-      db_make_string_by_const_str (result, name);
+      db_make_string (result, name);
       return NO_ERROR;
     }
 
@@ -22757,8 +22757,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 		case DB_TYPE_NCHAR:
 		case DB_TYPE_VARNCHAR:
 		case DB_TYPE_ENUMERATION:
-		  db_make_string_by_const_str (out_values[idx_val],
-					       lang_get_collation_name (attrepr->domain->collation_id));
+		  db_make_string (out_values[idx_val], lang_get_collation_name (attrepr->domain->collation_id));
 		  break;
 		default:
 		  db_make_null (out_values[idx_val]);
@@ -22769,11 +22768,11 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  /* attribute can store NULL ? */
 	  if (attrepr->is_notnull == 0)
 	    {
-	      db_make_string_by_const_str (out_values[idx_val], "YES");
+	      db_make_string (out_values[idx_val], "YES");
 	    }
 	  else
 	    {
-	      db_make_string_by_const_str (out_values[idx_val], "NO");
+	      db_make_string (out_values[idx_val], "NO");
 	    }
 	  idx_val++;
 
@@ -22808,21 +22807,21 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	    {
 	    case BTREE_UNIQUE:
 	    case BTREE_REVERSE_UNIQUE:
-	      db_make_string_by_const_str (out_values[idx_val], "UNI");
+	      db_make_string (out_values[idx_val], "UNI");
 	      break;
 
 	    case BTREE_INDEX:
 	    case BTREE_REVERSE_INDEX:
 	    case BTREE_FOREIGN_KEY:
-	      db_make_string_by_const_str (out_values[idx_val], "MUL");
+	      db_make_string (out_values[idx_val], "MUL");
 	      break;
 
 	    case BTREE_PRIMARY_KEY:
-	      db_make_string_by_const_str (out_values[idx_val], "PRI");
+	      db_make_string (out_values[idx_val], "PRI");
 	      break;
 
 	    default:
-	      db_make_string_by_const_str (out_values[idx_val], "");
+	      db_make_string (out_values[idx_val], "");
 	      break;
 	    }
 	  idx_val++;
@@ -22872,7 +22871,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 		{
 		  if (default_expr_type_string)
 		    {
-		      db_make_string_by_const_str (out_values[idx_val], default_expr_type_string);
+		      db_make_string (out_values[idx_val], default_expr_type_string);
 		    }
 		}
 	      idx_val++;
@@ -22899,11 +22898,11 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 	  /* attribute has auto_increment or not */
 	  if (attrepr->is_autoincrement == 0)
 	    {
-	      db_make_string_by_const_str (out_values[idx_val], "");
+	      db_make_string (out_values[idx_val], "");
 	    }
 	  else
 	    {
-	      db_make_string_by_const_str (out_values[idx_val], "auto_increment");
+	      db_make_string (out_values[idx_val], "auto_increment");
 	    }
 
 	  if (attrepr->on_update_expr != DB_DEFAULT_NONE)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -16297,7 +16297,8 @@ qexec_check_for_cycle (THREAD_ENTRY * thread_p, OUTPTR_LIST * outptr_list, QFILE
   DB_VALUE p_pos_dbval;
   QFILE_LIST_SCAN_ID s_id;
   QFILE_TUPLE_RECORD tuple_rec = { (QFILE_TUPLE) NULL, 0 };
-  QFILE_TUPLE_POSITION p_pos, *bitval;
+  const QFILE_TUPLE_POSITION *bitval = NULL;
+  QFILE_TUPLE_POSITION p_pos;
   int length;
 
   if (qfile_open_list_scan (list_id_p, &s_id) != NO_ERROR)
@@ -16330,7 +16331,7 @@ qexec_check_for_cycle (THREAD_ENTRY * thread_p, OUTPTR_LIST * outptr_list, QFILE
 	  return ER_FAILED;
 	}
 
-      bitval = (QFILE_TUPLE_POSITION *) db_get_bit (&p_pos_dbval, &length);
+      bitval = REINTERPRET_CAST (const QFILE_TUPLE_POSITION *, db_get_bit (&p_pos_dbval, &length));
 
       if (bitval)
 	{

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -7049,7 +7049,8 @@ qdata_evaluate_connect_by_root (THREAD_ENTRY * thread_p, void *xasl_p, regu_vari
   QFILE_LIST_ID *list_id_p;
   QFILE_LIST_SCAN_ID s_id;
   QFILE_TUPLE_RECORD tuple_rec = { (QFILE_TUPLE) NULL, 0 };
-  QFILE_TUPLE_POSITION p_pos, *bitval;
+  const QFILE_TUPLE_POSITION *bitval = NULL;
+  QFILE_TUPLE_POSITION p_pos;
   QPROC_DB_VALUE_LIST valp;
   DB_VALUE p_pos_dbval;
   XASL_NODE *xasl, *xptr;
@@ -7102,7 +7103,7 @@ qdata_evaluate_connect_by_root (THREAD_ENTRY * thread_p, void *xasl_p, regu_vari
 	  return false;
 	}
 
-      bitval = (QFILE_TUPLE_POSITION *) db_get_bit (&p_pos_dbval, &length);
+      bitval = REINTERPRET_CAST (const QFILE_TUPLE_POSITION *, db_get_bit (&p_pos_dbval, &length));
 
       if (bitval)
 	{
@@ -7176,7 +7177,8 @@ qdata_evaluate_qprior (THREAD_ENTRY * thread_p, void *xasl_p, regu_variable_node
   QFILE_LIST_ID *list_id_p;
   QFILE_LIST_SCAN_ID s_id;
   QFILE_TUPLE_RECORD tuple_rec = { (QFILE_TUPLE) NULL, 0 };
-  QFILE_TUPLE_POSITION p_pos, *bitval;
+  const QFILE_TUPLE_POSITION *bitval = NULL;
+  QFILE_TUPLE_POSITION p_pos;
   DB_VALUE p_pos_dbval;
   XASL_NODE *xasl, *xptr;
   int length;
@@ -7219,7 +7221,7 @@ qdata_evaluate_qprior (THREAD_ENTRY * thread_p, void *xasl_p, regu_variable_node
       return false;
     }
 
-  bitval = (QFILE_TUPLE_POSITION *) db_get_bit (&p_pos_dbval, &length);
+  bitval = REINTERPRET_CAST (const QFILE_TUPLE_POSITION *, db_get_bit (&p_pos_dbval, &length));
 
   if (bitval)
     {
@@ -7292,7 +7294,8 @@ qdata_evaluate_sys_connect_by_path (THREAD_ENTRY * thread_p, void *xasl_p, regu_
   QFILE_LIST_ID *list_id_p;
   QFILE_LIST_SCAN_ID s_id;
   QFILE_TUPLE_RECORD tuple_rec = { (QFILE_TUPLE) NULL, 0 };
-  QFILE_TUPLE_POSITION p_pos, *bitval;
+  const QFILE_TUPLE_POSITION *bitval = NULL;
+  QFILE_TUPLE_POSITION p_pos;
   QPROC_DB_VALUE_LIST valp;
   DB_VALUE p_pos_dbval, cast_value, arg_dbval;
   XASL_NODE *xasl, *xptr;
@@ -7542,7 +7545,7 @@ qdata_evaluate_sys_connect_by_path (THREAD_ENTRY * thread_p, void *xasl_p, regu_
 	  goto error;
 	}
 
-      bitval = (QFILE_TUPLE_POSITION *) db_get_bit (&p_pos_dbval, &length);
+      bitval = REINTERPRET_CAST (const QFILE_TUPLE_POSITION *, db_get_bit (&p_pos_dbval, &length));
 
       if (bitval)
 	{

--- a/src/query/show_scan.c
+++ b/src/query/show_scan.c
@@ -544,22 +544,22 @@ thread_scan_mapfunc (THREAD_ENTRY & thread_ref, bool & stop_mapper, THREAD_ENTRY
   idx++;
 
   /* Type */
-  db_make_string_by_const_str (&vals[idx], thread_type_to_string (thrd->type));
+  db_make_string (&vals[idx], thread_type_to_string (thrd->type));
   idx++;
 
   /* Status */
-  db_make_string_by_const_str (&vals[idx], thread_status_to_string (thrd->m_status));
+  db_make_string (&vals[idx], thread_status_to_string (thrd->m_status));
   idx++;
 
   /* Resume_status */
-  db_make_string_by_const_str (&vals[idx], thread_resume_status_to_string (thrd->resume_status));
+  db_make_string (&vals[idx], thread_resume_status_to_string (thrd->resume_status));
   idx++;
 
   /* Net_request */
   ival = thrd->net_request_index;
   if (ival != -1)
     {
-      db_make_string_by_const_str (&vals[idx], net_server_request_name (ival));
+      db_make_string (&vals[idx], net_server_request_name (ival));
     }
   else
     {
@@ -732,7 +732,7 @@ thread_scan_mapfunc (THREAD_ENTRY & thread_ref, bool & stop_mapper, THREAD_ENTRY
       idx++;
 
       /* Lockwait_state */
-      db_make_string_by_const_str (&vals[idx], lock_wait_state_to_string (thrd->lockwait_state));
+      db_make_string (&vals[idx], lock_wait_state_to_string (thrd->lockwait_state));
       idx++;
     }
   else

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -904,10 +904,10 @@ stx_restore_xasl_node (THREAD_ENTRY * thread_p, char *ptr)
 /*
  * stx_restore_filter_pred_node () -
  *   return: unpacked pred_expr_with_context
- *   thread_entry(in): 
+ *   thread_entry(in):
  *   ptr(in): pointer to stream
- *  
- * Note: returned pred is private_alloced and should be freed separately after 
+ *
+ * Note: returned pred is private_alloced and should be freed separately after
  *       pred->unpack_info.
  */
 static PRED_EXPR_WITH_CONTEXT *

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -693,9 +693,8 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
 	    }
 	  result[result_size] = 0;
 	  db_value_domain_init (db_result, result_type, precision, 0);
-	  error_status =
-	    db_make_db_char (db_result, codeset, collation_id, (char *) result,
-			     (result_type == DB_TYPE_VARBIT ? num_bits : result_size));
+	  error_status = db_make_db_char (db_result, codeset, collation_id, REINTERPRET_CAST (char *, result),
+					  (result_type == DB_TYPE_VARBIT ? num_bits : result_size));
 	  db_result->need_clear = true;
 	}
       else
@@ -7111,7 +7110,7 @@ db_get_string_length (const DB_VALUE * value)
  */
 
 void
-qstr_make_typed_string (const DB_TYPE db_type, DB_VALUE * value, const int precision, const DB_C_CHAR src,
+qstr_make_typed_string (const DB_TYPE db_type, DB_VALUE * value, const int precision, DB_CONST_C_CHAR src,
 			const int s_unit, const int codeset, const int collation_id)
 {
   switch (db_type)
@@ -12680,7 +12679,7 @@ db_to_date (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 	  goto exit;
 	}
 
-      db_make_char (&default_format, strlen (default_format_str), (DB_C_CHAR) default_format_str,
+      db_make_char (&default_format, strlen (default_format_str), default_format_str,
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
@@ -13251,7 +13250,7 @@ db_to_time (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
 	  goto exit;
 	}
-      db_make_char (&default_format, strlen (default_format_str), (DB_C_CHAR) default_format_str,
+      db_make_char (&default_format, strlen (default_format_str), default_format_str,
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
@@ -13834,7 +13833,7 @@ db_to_timestamp (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB
 	  goto exit;
 	}
 
-      db_make_char (&default_format, strlen (default_format_str), (DB_C_CHAR) default_format_str,
+      db_make_char (&default_format, strlen (default_format_str), default_format_str,
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
@@ -14745,7 +14744,7 @@ db_to_datetime (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_
 	  goto exit;
 	}
 
-      db_make_char (&default_format, strlen (default_format_str), (DB_C_CHAR) default_format_str,
+      db_make_char (&default_format, strlen (default_format_str), default_format_str,
 		    strlen (default_format_str), frmt_codeset, LANG_GET_BINARY_COLLATION (frmt_codeset));
       format_str = &default_format;
     }
@@ -27164,12 +27163,12 @@ db_get_cs_coll_info (DB_VALUE * result, const DB_VALUE * val, const int mode)
 
       if (mode == 0)
 	{
-	  db_make_string_by_const_str (result, lang_charset_cubrid_name ((INTL_CODESET) cs));
+	  db_make_string (result, lang_charset_cubrid_name ((INTL_CODESET) cs));
 	}
       else
 	{
 	  assert (mode == 1);
-	  db_make_string_by_const_str (result, lang_get_collation_name (coll));
+	  db_make_string (result, lang_get_collation_name (coll));
 	}
     }
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -91,6 +91,8 @@
 #define UINT64_MAX_BIN_DIGITS 64
 
 #define LOB_CHUNK_SIZE	(128 * 1024)
+#define DB_GET_UCHAR(dbval) (REINTERPRET_CAST (const unsigned char *, db_get_string ((dbval))))
+
 #define REGEX_MAX_ERROR_MSG_SIZE  100
 
 /*
@@ -172,12 +174,13 @@ static int qstr_eval_like (const char *tar, int tar_length, const char *expr, in
 #if defined(ENABLE_UNUSED_FUNCTION)
 static int kor_cmp (unsigned char *src, unsigned char *dest, int size);
 #endif
-static int qstr_replace (unsigned char *src_buf, int src_len, int src_size, INTL_CODESET codeset, int coll_id,
-			 unsigned char *srch_str_buf, int srch_str_size, unsigned char *repl_str_buf, int repl_str_size,
-			 unsigned char **result_buf, int *result_len, int *result_size);
-static int qstr_translate (unsigned char *src_ptr, DB_TYPE src_type, int src_size, INTL_CODESET codeset,
-			   unsigned char *from_str_ptr, int from_str_size, unsigned char *to_str_ptr, int to_str_size,
-			   unsigned char **result_ptr, DB_TYPE * result_type, int *result_len, int *result_size);
+static int qstr_replace (const unsigned char *src_buf, int src_len, int src_size, INTL_CODESET codeset, int coll_id,
+			 const unsigned char *srch_str_buf, int srch_str_size, const unsigned char *repl_str_buf,
+			 int repl_str_size, unsigned char **result_buf, int *result_len, int *result_size);
+static int qstr_translate (const unsigned char *src_ptr, DB_TYPE src_type, int src_size, INTL_CODESET codeset,
+			   const unsigned char *from_str_ptr, int from_str_size, const unsigned char *to_str_ptr,
+			   int to_str_size, unsigned char **result_ptr, DB_TYPE * result_type, int *result_len,
+			   int *result_size);
 static QSTR_CATEGORY qstr_get_category (const DB_VALUE * s);
 #if defined (ENABLE_UNUSED_FUNCTION)
 static bool is_string (const DB_VALUE * s);
@@ -243,8 +246,8 @@ static int make_number (char *src, char *last_src, INTL_CODESET codeset, char *t
 			const int precision, const int scale, const INTL_LANG number_lang_id);
 static int get_number_token (const INTL_LANG lang, char *fsp, int *length, char *last_position, char **next_fsp,
 			     INTL_CODESET codeset);
-static TIMESTAMP_FORMAT get_next_format (char *sp, const INTL_CODESET codeset, DB_TYPE str_type, int *format_length,
-					 char **next_pos);
+static TIMESTAMP_FORMAT get_next_format (const char *sp, const INTL_CODESET codeset, DB_TYPE str_type,
+					 int *format_length, const char **next_pos);
 static int get_cur_year (void);
 static int get_cur_month (void);
 /* utility functions */
@@ -261,7 +264,7 @@ static int parse_for_next_int (char **ch, char *output);
 #endif
 static int db_str_to_millisec (const char *str);
 static void copy_and_shift_values (int shift, int n, DB_BIGINT * first, ...);
-static DB_BIGINT get_single_unit_value (char *expr, DB_BIGINT int_val);
+static DB_BIGINT get_single_unit_value (const char *expr, DB_BIGINT int_val);
 static int db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const DB_VALUE * expr,
 					  const int unit, int is_add);
 static int db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const DB_VALUE * db_days,
@@ -416,14 +419,12 @@ db_string_compare (const DB_VALUE * string1, const DB_VALUE * string2, DB_VALUE 
 	  coll_id = db_get_string_collation (string1);
 	  assert (db_get_string_collation (string1) == db_get_string_collation (string2));
 
-	  cmp_result =
-	    QSTR_COMPARE (coll_id, (unsigned char *) db_get_string (string1), (int) db_get_string_size (string1),
-			  (unsigned char *) db_get_string (string2), (int) db_get_string_size (string2));
+	  cmp_result = QSTR_COMPARE (coll_id, DB_GET_UCHAR (string1), (int) db_get_string_size (string1),
+				     DB_GET_UCHAR (string2), (int) db_get_string_size (string2));
 	  break;
 	case QSTR_BIT:
-	  cmp_result =
-	    varbit_compare ((unsigned char *) db_get_string (string1), (int) db_get_string_size (string1),
-			    (unsigned char *) db_get_string (string2), (int) db_get_string_size (string2));
+	  cmp_result = varbit_compare (DB_GET_UCHAR (string1), (int) db_get_string_size (string1),
+				       DB_GET_UCHAR (string2), (int) db_get_string_size (string2));
 	  break;
 	default:		/* QSTR_UNKNOWN */
 	  break;
@@ -552,15 +553,16 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
   else
     {
       int size1, size2, result_size, pad_size = 0;
-      unsigned char *string1, *string2, *result, *key = NULL, pad[2], *t;
+      const unsigned char *string1 = NULL, *string2 = NULL, *t = NULL, *key = NULL;
+      unsigned char *result, pad[2];
       INTL_CODESET codeset;
       int num_bits = -1;
       int collation_id;
       bool bit_use_str2_size = false;
 
-      string1 = (unsigned char *) db_get_string (db_string1);
+      string1 = DB_GET_UCHAR (db_string1);
       size1 = (int) db_get_string_size (db_string1);
-      string2 = (unsigned char *) db_get_string (db_string2);
+      string2 = DB_GET_UCHAR (db_string2);
       size2 = (int) db_get_string_size (db_string2);
       codeset = db_get_string_codeset (db_string1);
       collation_id = db_get_string_collation (db_string1);
@@ -677,8 +679,8 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
 	}
       else
 	{
-	  error_status =
-	    QSTR_SPLIT_KEY (collation_id, key_domain->is_desc, string1, size1, string2, size2, &key, &result_size);
+	  error_status = QSTR_SPLIT_KEY (collation_id, key_domain->is_desc, string1, size1, string2, size2, &key,
+					 &result_size);
 	}
       assert (error_status == NO_ERROR);
 
@@ -1111,12 +1113,11 @@ db_string_concatenate (const DB_VALUE * string1, const DB_VALUE * string2, DB_VA
 	{
 	  int result_domain_length;
 
-	  error_status =
-	    qstr_bit_concatenate ((unsigned char *) db_get_string (string1), (int) db_get_string_length (string1),
-				  (int) QSTR_VALUE_PRECISION (string1), DB_VALUE_DOMAIN_TYPE (string1),
-				  (unsigned char *) db_get_string (string2), (int) db_get_string_length (string2),
-				  (int) QSTR_VALUE_PRECISION (string2), DB_VALUE_DOMAIN_TYPE (string2), &r, &r_length,
-				  &r_size, &r_type, data_status);
+	  error_status = qstr_bit_concatenate (DB_GET_UCHAR (string1), (int) db_get_string_length (string1),
+					       (int) QSTR_VALUE_PRECISION (string1), DB_VALUE_DOMAIN_TYPE (string1),
+					       DB_GET_UCHAR (string2), (int) db_get_string_length (string2),
+					       (int) QSTR_VALUE_PRECISION (string2), DB_VALUE_DOMAIN_TYPE (string2),
+					       &r, &r_length, &r_size, &r_type, data_status);
 
 	  if (error_status == NO_ERROR)
 	    {
@@ -1196,12 +1197,11 @@ db_string_concatenate (const DB_VALUE * string1, const DB_VALUE * string2, DB_VA
 		}
 	    }
 
-	  error_status =
-	    qstr_concatenate ((unsigned char *) db_get_string (string1), (int) db_get_string_length (string1),
-			      (int) QSTR_VALUE_PRECISION (string1), DB_VALUE_DOMAIN_TYPE (string1),
-			      (unsigned char *) db_get_string (string2), (int) db_get_string_length (string2),
-			      (int) QSTR_VALUE_PRECISION (string2), DB_VALUE_DOMAIN_TYPE (string2), codeset, &r,
-			      &r_length, &r_size, &r_type, data_status);
+	  error_status = qstr_concatenate (DB_GET_UCHAR (string1), (int) db_get_string_length (string1),
+					   (int) QSTR_VALUE_PRECISION (string1), DB_VALUE_DOMAIN_TYPE (string1),
+					   DB_GET_UCHAR (string2), (int) db_get_string_length (string2),
+					   (int) QSTR_VALUE_PRECISION (string2), DB_VALUE_DOMAIN_TYPE (string2),
+					   codeset, &r, &r_length, &r_size, &r_type, data_status);
 
 	  pr_clear_value (&temp);
 
@@ -1457,7 +1457,7 @@ db_string_instr (const DB_VALUE * src_string, const DB_VALUE * sub_string, const
 	  int sub_str_len;
 	  int offset = db_get_int (start_pos);
 	  INTL_CODESET codeset = (INTL_CODESET) db_get_string_codeset (src_string);
-	  char *search_from, *src_buf, *sub_str;
+	  const char *search_from, *src_buf, *sub_str;
 	  int coll_id;
 	  int sub_str_size = db_get_string_size (sub_string);
 	  int from_byte_offset;
@@ -1704,9 +1704,9 @@ db_string_position (const DB_VALUE * sub_string, const DB_VALUE * src_string, DB
 
       if (QSTR_IS_CHAR (src_type) || QSTR_IS_NATIONAL_CHAR (src_type))
 	{
-	  char *src_str = db_get_string (src_string);
+	  const char *src_str = db_get_string (src_string);
 	  int src_size = db_get_string_size (src_string);
-	  char *sub_str = db_get_string (sub_string);
+	  const char *sub_str = db_get_string (sub_string);
 	  int sub_size = db_get_string_size (sub_string);
 	  int coll_id;
 
@@ -1727,16 +1727,14 @@ db_string_position (const DB_VALUE * sub_string, const DB_VALUE * src_string, DB
 	      sub_size = strlen (sub_str);
 	    }
 
-	  error_status =
-	    qstr_position (sub_str, sub_size, db_get_string_length (sub_string), src_str, src_str + src_size,
-			   src_str + src_size, db_get_string_length (src_string), coll_id, true, &position);
+	  error_status = qstr_position (sub_str, sub_size, db_get_string_length (sub_string), src_str,
+					src_str + src_size, src_str + src_size, db_get_string_length (src_string),
+					coll_id, true, &position);
 	}
       else
 	{
-	  error_status =
-	    qstr_bit_position ((unsigned char *) db_get_string (sub_string), db_get_string_length (sub_string),
-			       (unsigned char *) db_get_string (src_string), db_get_string_length (src_string),
-			       &position);
+	  error_status = qstr_bit_position (DB_GET_UCHAR (sub_string), db_get_string_length (sub_string),
+					    DB_GET_UCHAR (src_string), db_get_string_length (src_string), &position);
 	}
 
       if (error_status == NO_ERROR)
@@ -1837,7 +1835,7 @@ db_string_substring (const MISC_OPERAND substr_operand, const DB_VALUE * src_str
 	    {
 	      int sub_size = 0;
 
-	      unsigned char *string = (unsigned char *) db_get_string (src_string);
+	      const unsigned char *string = DB_GET_UCHAR (src_string);
 	      int start_offset = db_get_int (start_position);
 	      int string_len = db_get_string_length (src_string);
 
@@ -1863,9 +1861,8 @@ db_string_substring (const MISC_OPERAND substr_operand, const DB_VALUE * src_str
 		    }
 		}
 
-	      error_status =
-		qstr_substring (string, string_len, start_offset, extract_nchars, db_get_string_codeset (src_string),
-				&sub, &sub_length, &sub_size);
+	      error_status = qstr_substring (string, string_len, start_offset, extract_nchars,
+					     db_get_string_codeset (src_string), &sub, &sub_length, &sub_size);
 	      if (error_status == NO_ERROR && sub != NULL)
 		{
 		  qstr_make_typed_string (result_type, sub_string, DB_VALUE_PRECISION (src_string), (char *) sub,
@@ -1877,10 +1874,8 @@ db_string_substring (const MISC_OPERAND substr_operand, const DB_VALUE * src_str
 	    }
 	  else
 	    {
-	      error_status =
-		qstr_bit_substring ((unsigned char *) db_get_string (src_string),
-				    (int) db_get_string_length (src_string), (int) db_get_int (start_position),
-				    extract_nchars, &sub, &sub_length);
+	      error_status = qstr_bit_substring (DB_GET_UCHAR (src_string), (int) db_get_string_length (src_string),
+						 (int) db_get_int (start_position), extract_nchars, &sub, &sub_length);
 	      if (error_status == NO_ERROR)
 		{
 		  qstr_make_typed_string (result_type, sub_string, DB_VALUE_PRECISION (src_string), (char *) sub,
@@ -2051,7 +2046,7 @@ db_string_repeat (const DB_VALUE * src_string, const DB_VALUE * count, DB_VALUE 
   src_size = db_get_string_size (src_string);
   if (src_size < 0)
     {
-      intl_char_size ((unsigned char *) db_get_string (result), src_length, codeset, &src_size);
+      intl_char_size (DB_GET_UCHAR (result), src_length, codeset, &src_size);
     }
 
   if (!QSTR_IS_ANY_CHAR (src_type) || !is_integer (count))
@@ -2072,7 +2067,8 @@ db_string_repeat (const DB_VALUE * src_string, const DB_VALUE * count, DB_VALUE 
   else
     {
       DB_VALUE dummy;
-      unsigned char *res_ptr, *src_ptr;
+      char *res_ptr;
+      const char *src_ptr;
       DB_BIGINT new_length, expected_size;
 
       /* init dummy */
@@ -2124,8 +2120,8 @@ db_string_repeat (const DB_VALUE * src_string, const DB_VALUE * count, DB_VALUE 
 
       pr_clear_value (&dummy);
 
-      res_ptr = (unsigned char *) db_get_string (result);
-      src_ptr = (unsigned char *) db_get_string (src_string);
+      res_ptr = CONST_CAST (char *, db_get_string (result));
+      src_ptr = db_get_string (src_string);
 
       while (count_i--)
 	{
@@ -3409,9 +3405,7 @@ db_string_lower (const DB_VALUE * string, DB_VALUE * lower_string)
       const ALPHABET_DATA *alphabet = lang_user_alphabet_w_coll (db_get_string_collation (string));
 
       src_length = db_get_string_length (string);
-      lower_size =
-	intl_lower_string_size (alphabet, (unsigned char *) db_get_string (string), db_get_string_size (string),
-				src_length);
+      lower_size = intl_lower_string_size (alphabet, DB_GET_UCHAR (string), db_get_string_size (string), src_length);
 
       lower_str = (unsigned char *) db_private_alloc (NULL, lower_size + 1);
       if (!lower_str)
@@ -3421,7 +3415,7 @@ db_string_lower (const DB_VALUE * string, DB_VALUE * lower_string)
       else
 	{
 	  int lower_length = TP_FLOATING_PRECISION_VALUE;
-	  intl_lower_string (alphabet, (unsigned char *) db_get_string (string), lower_str, src_length);
+	  intl_lower_string (alphabet, DB_GET_UCHAR (string), lower_str, src_length);
 	  lower_str[lower_size] = 0;
 
 	  if (db_value_precision (string) != TP_FLOATING_PRECISION_VALUE)
@@ -3507,9 +3501,7 @@ db_string_upper (const DB_VALUE * string, DB_VALUE * upper_string)
       const ALPHABET_DATA *alphabet = lang_user_alphabet_w_coll (db_get_string_collation (string));
 
       src_length = db_get_string_length (string);
-      upper_size =
-	intl_upper_string_size (alphabet, (unsigned char *) db_get_string (string), db_get_string_size (string),
-				src_length);
+      upper_size = intl_upper_string_size (alphabet, DB_GET_UCHAR (string), db_get_string_size (string), src_length);
 
       upper_str = (unsigned char *) db_private_alloc (NULL, upper_size + 1);
       if (!upper_str)
@@ -3519,7 +3511,7 @@ db_string_upper (const DB_VALUE * string, DB_VALUE * upper_string)
       else
 	{
 	  int upper_length = TP_FLOATING_PRECISION_VALUE;
-	  intl_upper_string (alphabet, (unsigned char *) db_get_string (string), upper_str, src_length);
+	  intl_upper_string (alphabet, DB_GET_UCHAR (string), upper_str, src_length);
 
 	  upper_str[upper_size] = 0;
 	  if (db_value_precision (string) != TP_FLOATING_PRECISION_VALUE)
@@ -3569,7 +3561,7 @@ db_string_trim (const MISC_OPERAND tr_operand, const DB_VALUE * trim_charset, co
   int result_length, result_size = 0, result_domain_length;
   DB_TYPE result_type = DB_TYPE_NULL;
 
-  unsigned char *trim_charset_ptr = NULL;
+  const unsigned char *trim_charset_ptr = NULL;
   int trim_charset_length = 0;
   int trim_charset_size = 0;
   DB_TYPE src_type, trim_type;
@@ -3644,16 +3636,15 @@ db_string_trim (const MISC_OPERAND tr_operand, const DB_VALUE * trim_charset, co
    */
   if (!is_trim_charset_omitted)
     {
-      trim_charset_ptr = (unsigned char *) db_get_string (trim_charset);
+      trim_charset_ptr = DB_GET_UCHAR (trim_charset);
       trim_charset_length = db_get_string_length (trim_charset);
       trim_charset_size = db_get_string_size (trim_charset);
     }
 
-  error_status =
-    qstr_trim (tr_operand, trim_charset_ptr, trim_charset_length, trim_charset_size,
-	       (unsigned char *) db_get_string (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
-	       db_get_string_length (src_string), db_get_string_size (src_string), db_get_string_codeset (src_string),
-	       &result, &result_type, &result_length, &result_size);
+  error_status = qstr_trim (tr_operand, trim_charset_ptr, trim_charset_length, trim_charset_size,
+			    DB_GET_UCHAR (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
+			    db_get_string_length (src_string), db_get_string_size (src_string),
+			    db_get_string_codeset (src_string), &result, &result_type, &result_length, &result_size);
 
   if (error_status == NO_ERROR && result != NULL)
     {
@@ -3845,8 +3836,8 @@ qstr_trim_trailing (const unsigned char *trim_charset_ptr, int trim_charset_size
 		    int *trail_trimmed_size, bool trim_ascii_spaces)
 {
   int prev_src_char_size, prev_trim_char_size;
-  unsigned char *cur_src_char_ptr, *cur_trim_char_ptr;
-  unsigned char *prev_src_char_ptr, *prev_trim_char_ptr;
+  const unsigned char *cur_src_char_ptr, *cur_trim_char_ptr;
+  const unsigned char *prev_src_char_ptr, *prev_trim_char_ptr;
   int cmp_flag = 0;
 
   *trail_trimmed_length = src_length;
@@ -3915,7 +3906,7 @@ db_string_pad (const MISC_OPERAND pad_operand, const DB_VALUE * src_string, cons
   int result_length = 0, result_size = 0;
   DB_TYPE result_type;
 
-  unsigned char *pad_charset_ptr = NULL;
+  const unsigned char *pad_charset_ptr = NULL;
   int pad_charset_length = 0;
   int pad_charset_size = 0;
   DB_TYPE src_type;
@@ -3988,16 +3979,15 @@ db_string_pad (const MISC_OPERAND pad_operand, const DB_VALUE * src_string, cons
 
   if (!is_pad_charset_omitted)
     {
-      pad_charset_ptr = (unsigned char *) db_get_string (pad_charset);
+      pad_charset_ptr = DB_GET_UCHAR (pad_charset);
       pad_charset_length = db_get_string_length (pad_charset);
       pad_charset_size = db_get_string_size (pad_charset);
     }
 
-  error_status =
-    qstr_pad (pad_operand, total_length, pad_charset_ptr, pad_charset_length, pad_charset_size,
-	      (unsigned char *) db_get_string (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
-	      db_get_string_length (src_string), db_get_string_size (src_string), db_get_string_codeset (src_string),
-	      &result, &result_type, &result_length, &result_size);
+  error_status = qstr_pad (pad_operand, total_length, pad_charset_ptr, pad_charset_length, pad_charset_size,
+			   DB_GET_UCHAR (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
+			   db_get_string_length (src_string), db_get_string_size (src_string),
+			   db_get_string_codeset (src_string), &result, &result_type, &result_length, &result_size);
 
   if (error_status == NO_ERROR && result != NULL)
     {
@@ -4177,9 +4167,9 @@ db_string_like (const DB_VALUE * src_string, const DB_VALUE * pattern, const DB_
   int error_status = NO_ERROR;
   DB_TYPE src_type = DB_TYPE_UNKNOWN;
   DB_TYPE pattern_type = DB_TYPE_UNKNOWN;
-  char *src_char_string_p = NULL;
-  char *pattern_char_string_p = NULL;
-  char const *esc_char_p = NULL;
+  const char *src_char_string_p = NULL;
+  const char *pattern_char_string_p = NULL;
+  const char *esc_char_p = NULL;
   int src_length = 0, pattern_length = 0;
   int coll_id;
 
@@ -4714,10 +4704,8 @@ db_string_limit_size_string (DB_VALUE * src_string, DB_VALUE * result, const int
     }
   else
     {
-      intl_char_count ((unsigned char *) db_get_string (src_string), result_size, db_get_string_codeset (src_string),
-		       &char_count);
-      intl_char_size ((unsigned char *) db_get_string (src_string), char_count, db_get_string_codeset (src_string),
-		      &adj_char_size);
+      intl_char_count (DB_GET_UCHAR (src_string), result_size, db_get_string_codeset (src_string), &char_count);
+      intl_char_size (DB_GET_UCHAR (src_string), char_count, db_get_string_codeset (src_string), &adj_char_size);
     }
 
   assert (adj_char_size <= result_size);
@@ -4732,7 +4720,7 @@ db_string_limit_size_string (DB_VALUE * src_string, DB_VALUE * result, const int
 
   if (adj_char_size > 0)
     {
-      memcpy ((char *) r, (char *) db_get_string (src_string), adj_char_size);
+      memcpy (r, db_get_string (src_string), adj_char_size);
     }
   /* adjust also domain precision in case of fixed length types */
   if (QSTR_IS_FIXED_LENGTH (src_type))
@@ -4822,11 +4810,11 @@ qstr_eval_like (const char *tar, int tar_length, const char *expr, int expr_leng
   const int IN_PERCENT = 1;
 
   int status = IN_CHECK;
-  unsigned char *tarstack[STACK_SIZE], *exprstack[STACK_SIZE];
+  const unsigned char *tarstack[STACK_SIZE], *exprstack[STACK_SIZE];
   int stackp = -1;
 
-  unsigned char *tar_ptr, *end_tar;
-  unsigned char *expr_ptr, *end_expr;
+  const unsigned char *tar_ptr, *end_tar;
+  const unsigned char *expr_ptr, *end_expr;
   bool escape_is_match_one = ((escape != NULL) && *escape == LIKE_WILDCARD_MATCH_ONE);
   bool escape_is_match_many = ((escape != NULL) && *escape == LIKE_WILDCARD_MATCH_MANY);
   unsigned char pad_char[2];
@@ -4839,10 +4827,10 @@ qstr_eval_like (const char *tar, int tar_length, const char *expr, int expr_leng
   current_collation = lang_get_collation (coll_id);
   intl_pad_char (codeset, pad_char, &pad_char_size);
 
-  tar_ptr = (unsigned char *) tar;
-  expr_ptr = (unsigned char *) expr;
-  end_tar = (unsigned char *) (tar + tar_length);
-  end_expr = (unsigned char *) (expr + expr_length);
+  tar_ptr = REINTERPRET_CAST (const unsigned char *, tar);
+  expr_ptr = REINTERPRET_CAST (const unsigned char *, expr);
+  end_tar = tar_ptr + tar_length;
+  end_expr = expr_ptr + expr_length;
 
   while (1)
     {
@@ -4919,7 +4907,7 @@ qstr_eval_like (const char *tar, int tar_length, const char *expr, int expr_leng
 		}
 	      else
 		{
-		  unsigned char *expr_seq_end = expr_ptr;
+		  const unsigned char *expr_seq_end = expr_ptr;
 		  int cmp;
 		  int tar_matched_size;
 		  unsigned char *match_escape = NULL;
@@ -5001,7 +4989,7 @@ qstr_eval_like (const char *tar, int tar_length, const char *expr, int expr_leng
 	}
       else
 	{
-	  unsigned char *next_expr_ptr;
+	  const unsigned char *next_expr_ptr;
 	  INTL_NEXT_CHAR (next_expr_ptr, expr_ptr, codeset, &dummy);
 
 	  assert (status == IN_PERCENT);
@@ -5032,7 +5020,7 @@ qstr_eval_like (const char *tar, int tar_length, const char *expr, int expr_leng
 
 	  if (tar_ptr < end_tar && next_expr_ptr < end_expr)
 	    {
-	      unsigned char *expr_seq_end = next_expr_ptr;
+	      const unsigned char *expr_seq_end = next_expr_ptr;
 	      int cmp;
 	      int tar_matched_size;
 	      unsigned char *match_escape = NULL;
@@ -5150,7 +5138,7 @@ db_string_replace (const DB_VALUE * src_string, const DB_VALUE * srch_string, co
   int coll_id, coll_id_tmp;
   DB_VALUE dummy_string;
   int is_repl_string_omitted = false;
-  unsigned char *repl_string_ptr = NULL;
+  const unsigned char *repl_string_ptr = NULL;
   int repl_string_size = 0;
 
   assert (src_string != (DB_VALUE *) NULL);
@@ -5249,14 +5237,13 @@ db_string_replace (const DB_VALUE * src_string, const DB_VALUE * srch_string, co
 
   if (!is_repl_string_omitted)
     {
-      repl_string_ptr = (unsigned char *) db_get_string (repl_string);
+      repl_string_ptr = DB_GET_UCHAR (repl_string);
       repl_string_size = db_get_string_size (repl_string);
     }
-  error_status =
-    qstr_replace ((unsigned char *) db_get_string (src_string), db_get_string_length (src_string),
-		  db_get_string_size (src_string), db_get_string_codeset (src_string), coll_id,
-		  (unsigned char *) db_get_string (srch_string), db_get_string_size (srch_string), repl_string_ptr,
-		  repl_string_size, &result_ptr, &result_length, &result_size);
+  error_status = qstr_replace (DB_GET_UCHAR (src_string), db_get_string_length (src_string),
+			       db_get_string_size (src_string), db_get_string_codeset (src_string), coll_id,
+			       DB_GET_UCHAR (srch_string), db_get_string_size (srch_string), repl_string_ptr,
+			       repl_string_size, &result_ptr, &result_length, &result_size);
 
   if (error_status == NO_ERROR && result_ptr != NULL)
     {
@@ -5284,19 +5271,20 @@ exit:
 /* qstr_replace () -
  */
 static int
-qstr_replace (unsigned char *src_buf, int src_len, int src_size, INTL_CODESET codeset, int coll_id,
-	      unsigned char *srch_str_buf, int srch_str_size, unsigned char *repl_str_buf, int repl_str_size,
-	      unsigned char **result_buf, int *result_len, int *result_size)
+qstr_replace (const unsigned char *src_buf, int src_len, int src_size, INTL_CODESET codeset, int coll_id,
+	      const unsigned char *srch_str_buf, int srch_str_size, const unsigned char *repl_str_buf,
+	      int repl_str_size, unsigned char **result_buf, int *result_len, int *result_size)
 {
 #define REPL_POS_ARRAY_EXTENT 32
 
   int error_status = NO_ERROR;
   int char_size, i;
-  unsigned char *matched_ptr, *matched_ptr_end, *target;
+  const unsigned char *matched_ptr, *matched_ptr_end;
+  unsigned char *target;
   int *repl_pos_array = NULL;
   int repl_pos_array_size;
   int repl_pos_array_cnt;
-  unsigned char *src_ptr;
+  const unsigned char *src_ptr;
   int repl_str_len;
 
   assert (result_buf != NULL);
@@ -5474,12 +5462,11 @@ db_string_translate (const DB_VALUE * src_string, const DB_VALUE * from_string, 
       return error_status;
     }
 
-  error_status =
-    qstr_translate ((unsigned char *) db_get_string (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
-		    db_get_string_size (src_string), db_get_string_codeset (src_string),
-		    (unsigned char *) db_get_string (from_string), db_get_string_size (from_string),
-		    (unsigned char *) db_get_string (to_string), db_get_string_size (to_string), &result_ptr,
-		    &result_type, &result_length, &result_size);
+  error_status = qstr_translate (DB_GET_UCHAR (src_string), DB_VALUE_DOMAIN_TYPE (src_string),
+				 db_get_string_size (src_string), db_get_string_codeset (src_string),
+				 DB_GET_UCHAR (from_string), db_get_string_size (from_string),
+				 DB_GET_UCHAR (to_string), db_get_string_size (to_string), &result_ptr,
+				 &result_type, &result_length, &result_size);
 
   if (error_status == NO_ERROR && result_ptr != NULL)
     {
@@ -5506,14 +5493,15 @@ db_string_translate (const DB_VALUE * src_string, const DB_VALUE * from_string, 
  * qstr_translate () -
  */
 static int
-qstr_translate (unsigned char *src_ptr, DB_TYPE src_type, int src_size, INTL_CODESET codeset,
-		unsigned char *from_str_ptr, int from_str_size, unsigned char *to_str_ptr, int to_str_size,
+qstr_translate (const unsigned char *src_ptr, DB_TYPE src_type, int src_size, INTL_CODESET codeset,
+		const unsigned char *from_str_ptr, int from_str_size, const unsigned char *to_str_ptr, int to_str_size,
 		unsigned char **result_ptr, DB_TYPE * result_type, int *result_len, int *result_size)
 {
   int error_status = NO_ERROR;
   int j, offset, offset1, offset2;
   int from_char_loc, to_char_cnt, to_char_loc;
-  unsigned char *srcp, *fromp, *target = NULL;
+  const unsigned char *srcp, *fromp;
+  unsigned char *target = NULL;
   int matched = 0, phase = 0;
 
   if ((from_str_ptr == NULL && to_str_ptr != NULL))
@@ -5707,10 +5695,9 @@ db_bit_string_coerce (const DB_VALUE * src_string, DB_VALUE * dest_string, DB_DA
 	  dest_prec = DB_VALUE_PRECISION (dest_string);
 	}
 
-      error_status =
-	qstr_bit_coerce ((unsigned char *) db_get_string (src_string), db_get_string_length (src_string),
-			 QSTR_VALUE_PRECISION (src_string), src_type, &dest, &dest_length, dest_prec, dest_type,
-			 data_status);
+      error_status = qstr_bit_coerce (DB_GET_UCHAR (src_string), db_get_string_length (src_string),
+				      QSTR_VALUE_PRECISION (src_string), src_type, &dest, &dest_length, dest_prec,
+				      dest_type, data_status);
 
       if (error_status == NO_ERROR)
 	{
@@ -5819,10 +5806,10 @@ db_char_string_coerce (const DB_VALUE * src_string, DB_VALUE * dest_string, DB_D
 	  dest_prec = DB_VALUE_PRECISION (dest_string);
 	}
 
-      error_status =
-	qstr_coerce ((unsigned char *) db_get_string (src_string), db_get_string_length (src_string),
-		     QSTR_VALUE_PRECISION (src_string), DB_VALUE_DOMAIN_TYPE (src_string), src_codeset, dest_codeset,
-		     &dest, &dest_length, &dest_size, dest_prec, DB_VALUE_DOMAIN_TYPE (dest_string), data_status);
+      error_status = qstr_coerce (DB_GET_UCHAR (src_string), db_get_string_length (src_string),
+				  QSTR_VALUE_PRECISION (src_string), DB_VALUE_DOMAIN_TYPE (src_string), src_codeset,
+				  dest_codeset, &dest, &dest_length, &dest_size, dest_prec,
+				  DB_VALUE_DOMAIN_TYPE (dest_string), data_status);
 
       if (error_status == NO_ERROR && dest != NULL)
 	{
@@ -6821,7 +6808,7 @@ qstr_bin_to_hex (char *dest, int dest_size, const char *src, int src_size)
  */
 
 int
-qstr_hex_to_bin (char *dest, int dest_size, char *src, int src_size)
+qstr_hex_to_bin (char *dest, int dest_size, const char *src, int src_size)
 {
   int i, copy_size, src_index, required_size;
 
@@ -6889,7 +6876,7 @@ qstr_hex_to_bin (char *dest, int dest_size, char *src, int src_size)
  */
 
 int
-qstr_bit_to_bin (char *dest, int dest_size, char *src, int src_size)
+qstr_bit_to_bin (char *dest, int dest_size, const char *src, int src_size)
 {
   int dest_byte, copy_size, src_index, required_size;
 
@@ -7042,7 +7029,7 @@ qstr_bit_to_hex_coerce (char *buffer, int buffer_size, const char *src, int src_
 int
 db_get_string_length (const DB_VALUE * value)
 {
-  DB_C_CHAR str;
+  DB_CONST_C_CHAR str;
   int size;
   INTL_CODESET codeset;
   int length = 0;
@@ -7839,7 +7826,7 @@ static int
 qstr_grow_string (DB_VALUE * src_string, DB_VALUE * result, int new_size)
 {
   int result_size = 0, src_length = 0, result_domain_length = 0, src_size = 0;
-  unsigned char *r = NULL;
+  char *r = NULL;
   int error_status = NO_ERROR;
   DB_TYPE src_type, result_type;
   INTL_CODESET codeset;
@@ -7885,7 +7872,7 @@ qstr_grow_string (DB_VALUE * src_string, DB_VALUE * result, int new_size)
       return NO_ERROR;
     }
   /* Allocate storage for the result string */
-  r = (unsigned char *) db_private_alloc (NULL, (size_t) result_size + 1);
+  r = (char *) db_private_alloc (NULL, (size_t) result_size + 1);
   if (r == NULL)
     {
       assert (er_errid () != NO_ERROR);
@@ -7895,9 +7882,9 @@ qstr_grow_string (DB_VALUE * src_string, DB_VALUE * result, int new_size)
 
   if (src_size > 0)
     {
-      memcpy ((char *) r, (char *) db_get_string (src_string), src_size);
+      memcpy (r, db_get_string (src_string), src_size);
     }
-  qstr_make_typed_string (result_type, result, result_domain_length, (char *) r, (int) MIN (result_size, src_size),
+  qstr_make_typed_string (result_type, result, result_domain_length, r, (int) MIN (result_size, src_size),
 			  codeset, db_get_string_collation (src_string));
 
   if (prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING) == true && DB_IS_NULL (result)
@@ -9210,7 +9197,7 @@ qstr_position (const char *sub_string, const int sub_size, const int sub_length,
   else
     {
       int i, num_searches, current_position, result;
-      unsigned char *ptr;
+      const unsigned char *ptr;
       int char_size;
       LANG_COLLATION *lc;
       INTL_CODESET codeset;
@@ -9247,15 +9234,18 @@ qstr_position (const char *sub_string, const int sub_size, const int sub_length,
        *  try again.  This is repeated until a match is found, or
        *  there are no more comparisons to be made.
        */
-      ptr = (unsigned char *) src_string;
+      const unsigned char *usub_string = REINTERPRET_CAST (const unsigned char *, sub_string);
+      const unsigned char *usrc_end = REINTERPRET_CAST (const unsigned char *, src_end);
+      const unsigned char *usrc_string = REINTERPRET_CAST (const unsigned char *, src_string);
+      const unsigned char *usrc_string_bound = REINTERPRET_CAST (const unsigned char *, src_string_bound);
+
+      ptr = usrc_string;
       current_position = 0;
       result = 1;
 
       for (i = 0; i < num_searches; i++)
 	{
-	  result =
-	    QSTR_MATCH (coll_id, ptr, CAST_BUFLEN ((unsigned char *) src_end - ptr), (unsigned char *) sub_string,
-			sub_size, NULL, false, &dummy);
+	  result = QSTR_MATCH (coll_id, ptr, CAST_BUFLEN (usrc_end - ptr), usub_string, sub_size, NULL, false, &dummy);
 	  current_position++;
 	  if (result == 0)
 	    {
@@ -9264,21 +9254,19 @@ qstr_position (const char *sub_string, const int sub_size, const int sub_length,
 
 	  if (is_forward_search)
 	    {
-	      if (ptr >= (unsigned char *) src_string_bound)
+	      if (ptr >= usrc_string_bound)
 		{
 		  break;
 		}
 
-	      INTL_NEXT_CHAR (ptr, (unsigned char *) ptr, codeset, &char_size);
+	      INTL_NEXT_CHAR (ptr, ptr, codeset, &char_size);
 	    }
 	  else
 	    {
 	      /* backward */
-	      if (ptr > (unsigned char *) src_string_bound)
+	      if (ptr > usrc_string_bound)
 		{
-		  ptr =
-		    intl_prev_char ((unsigned char *) ptr, (const unsigned char *) src_string_bound, codeset,
-				    &char_size);
+		  ptr = intl_prev_char (ptr, usrc_string_bound, codeset, &char_size);
 		}
 	      else
 		{
@@ -11037,8 +11025,8 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
   DB_DATETIME *dt_p;
   DB_DATE db_date;
   DB_TYPE res_type, format_type;
-  char *res, *res2, *format_s;
-  char *strend;
+  const char *format_s, *strend;
+  char *res, *res2;
   int format_s_len;
   int error_status = NO_ERROR, len;
   int h, mi, s, ms, year, month, day;
@@ -11619,8 +11607,7 @@ db_timestamp (const DB_VALUE * src_datetime1, const DB_VALUE * src_time2, DB_VAL
     {
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
-      parse_time_string ((const char *) db_get_string (src_time2), db_get_string_size (src_time2), &sign, &h, &mi, &s,
-			 &ms);
+      parse_time_string (db_get_string (src_time2), db_get_string_size (src_time2), &sign, &h, &mi, &s, &ms);
       break;
 
     case DB_TYPE_TIME:
@@ -12574,9 +12561,9 @@ int
 db_to_date (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALUE * date_lang, DB_VALUE * result_date)
 {
   int error_status = NO_ERROR;
-  char *cur_format_str_ptr, *next_format_str_ptr;
+  const char *cur_format_str_ptr, *next_format_str_ptr;
   char *cs;			/* current source string pointer */
-  char *last_src, *last_format;
+  const char *last_src, *last_format;
 
   TIMESTAMP_FORMAT cur_format;
 
@@ -13137,9 +13124,9 @@ db_to_time (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_VALU
 {
   int error_status = NO_ERROR;
 
-  char *cur_format_str_ptr, *next_format_str_ptr;
+  const char *cur_format_str_ptr, *next_format_str_ptr;
   char *cs;			/* current source string pointer */
-  char *last_format, *last_src;
+  const char *last_format, *last_src;
 
   TIMESTAMP_FORMAT cur_format;
 
@@ -13703,9 +13690,9 @@ db_to_timestamp (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB
   DB_TIME tmp_time;
   DB_TIMESTAMP tmp_timestamp;
 
-  char *cur_format_str_ptr, *next_format_str_ptr;
+  const char *cur_format_str_ptr, *next_format_str_ptr;
   char *cs;			/* current source string pointer */
-  char *last_format, *last_src;
+  const char *last_format, *last_src;
 
   int cur_format_size;
   TIMESTAMP_FORMAT cur_format;
@@ -14614,9 +14601,9 @@ db_to_datetime (const DB_VALUE * src_str, const DB_VALUE * format_str, const DB_
 
   DB_DATETIME tmp_datetime;
 
-  char *cur_format_str_ptr, *next_format_str_ptr;
+  const char *cur_format_str_ptr, *next_format_str_ptr;
   char *cs;			/* current source string pointer */
-  char *last_format, *last_src;
+  const char *last_format, *last_src;
 
   int cur_format_size;
   TIMESTAMP_FORMAT cur_format;
@@ -16059,8 +16046,8 @@ date_to_char (const DB_VALUE * src_value, const DB_VALUE * format_str, const DB_
 {
   int error_status = NO_ERROR;
   DB_TYPE src_type;
-  char *cur_format_str_ptr, *next_format_str_ptr;
-  char *last_format_str_ptr;
+  const char *cur_format_str_ptr, *next_format_str_ptr;
+  const char *last_format_str_ptr;
 
   int cur_format_size;
   TIMESTAMP_FORMAT cur_format;
@@ -18867,7 +18854,8 @@ get_number_token (const INTL_LANG lang, char *fsp, int *length, char *last_posit
  * get_number_format () -
  */
 static TIMESTAMP_FORMAT
-get_next_format (char *sp, const INTL_CODESET codeset, DB_TYPE str_type, int *format_length, char **next_pos)
+get_next_format (const char *sp, const INTL_CODESET codeset, DB_TYPE str_type, int *format_length,
+		 const char **next_pos)
 {
   /* sp : start position */
   *format_length = 0;
@@ -19101,7 +19089,7 @@ get_next_format (char *sp, const INTL_CODESET codeset, DB_TYPE str_type, int *fo
       while (sp[*format_length] != '"')
 	{
 	  int char_size;
-	  unsigned char *ptr = (unsigned char *) sp + (*format_length);
+	  const unsigned char *ptr = (const unsigned char *) sp + (*format_length);
 	  if (sp[*format_length] == '\0')
 	    {
 	      return DT_INVALID;
@@ -19313,7 +19301,7 @@ db_format (const DB_VALUE * value, const DB_VALUE * decimals, const DB_VALUE * n
 	    return error;
 	  }
 
-	c = db_get_string (&trimmed_val);
+	c = CONST_CAST (char *, db_get_string (&trimmed_val));
 	if (c == NULL)
 	  {
 	    goto invalid_argument_error;
@@ -19469,9 +19457,9 @@ db_string_reverse (const DB_VALUE * src_str, DB_VALUE * result_str)
       if (error_status == NO_ERROR)
 	{
 	  memset (res, 0, db_get_string_size (src_str) + 1);
-	  intl_reverse_string ((unsigned char *) db_get_string (src_str), (unsigned char *) res,
-			       db_get_string_length (src_str), db_get_string_size (src_str),
-			       db_get_string_codeset (src_str));
+	  intl_reverse_string (DB_GET_UCHAR (src_str),
+			       REINTERPRET_CAST (unsigned char *, res), db_get_string_length (src_str),
+			       db_get_string_size (src_str), db_get_string_codeset (src_str));
 	  if (QSTR_IS_CHAR (str_type))
 	    {
 	      db_make_varchar (result_str, DB_GET_STRING_PRECISION (src_str), res, db_get_string_size (src_str),
@@ -19851,7 +19839,8 @@ db_date_add_sub_interval_days (DB_VALUE * result, const DB_VALUE * date, const D
   DB_TIMESTAMP db_timestamp, *ts_p = NULL;
   int is_dt = -1, is_d = -1, is_t = -1, is_timest = -1, is_timezone = -1, is_local_timezone = -1;
   DB_TYPE res_type;
-  char *date_s = NULL, res_s[64];
+  const char *date_s = NULL;
+  char res_s[64];
   int y, m, d, h, mi, s, ms;
   int ret;
   char *res_final;
@@ -20423,7 +20412,7 @@ copy_and_shift_values (int shift, int n, DB_BIGINT * first, ...)
  *   int_val (in) : input as integer
  */
 static DB_BIGINT
-get_single_unit_value (char *expr, DB_BIGINT int_val)
+get_single_unit_value (const char *expr, DB_BIGINT int_val)
 {
   DB_BIGINT v = 0;
 
@@ -20461,7 +20450,8 @@ db_date_add_sub_interval_expr (DB_VALUE * result, const DB_VALUE * date, const D
   int sign = 0;
   int type = 0;			/* 1 -> time, 2 -> date, 3 -> both */
   DB_TYPE res_type, expr_type;
-  char *date_s = NULL, *expr_s, res_s[64], millisec_s[64];
+  const char *expr_s = NULL, *date_s = NULL;
+  char res_s[64], millisec_s[64];
   int error_status = NO_ERROR;
   DB_BIGINT millisec, seconds, minutes, hours;
   DB_BIGINT days, weeks, months, quarters, years;
@@ -21420,9 +21410,9 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
   DB_TIME db_time;
   DB_TIMESTAMP *ts_p;
   DB_TYPE res_type, format_type;
-  char *res, *res2, *format_s;
+  const char *format_s = NULL, *strend = NULL;
+  char *res, *res2;
   int format_s_len;
-  char *strend;
   int error_status = NO_ERROR, len;
   int y, m, d, h, mi, s, ms;
   int days[13] = { 0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
@@ -22125,7 +22115,8 @@ int
 db_str_to_date (const DB_VALUE * str, const DB_VALUE * format, const DB_VALUE * date_lang, DB_VALUE * result,
 		TP_DOMAIN * domain)
 {
-  char *sstr = NULL, *format_s = NULL, *format2_s = NULL;
+  const char *format2_s = NULL;
+  char *sstr = NULL, *format_s = NULL;
   int i, j, k, error_status = NO_ERROR;
   int type, len1, len2, h24 = 0, _v, _x;
   DB_TYPE res_type;
@@ -24012,7 +24003,7 @@ db_char_to_blob (const DB_VALUE * src_value, DB_VALUE * result_value)
   DB_TYPE src_type;
   int error_status = NO_ERROR;
   DB_ELO *elo;
-  char *src_str;
+  const char *src_str;
   int src_size;
 
   assert (src_value != NULL && result_value != NULL);
@@ -24198,7 +24189,7 @@ db_char_to_clob (const DB_VALUE * src_value, DB_VALUE * result_value)
   DB_TYPE src_type;
   int error_status = NO_ERROR;
   DB_ELO *elo;
-  char *src_str;
+  const char *src_str;
   int src_size;
 
   assert (src_value != NULL && result_value != NULL);
@@ -24422,7 +24413,7 @@ db_get_datetime_from_dbvalue (const DB_VALUE * src_date, int *year, int *month, 
       {
 	DB_DATETIME db_datetime;
 	int str_len;
-	char *strp;
+	const char *strp;
 
 	strp = db_get_string (src_date);
 	str_len = db_get_string_size (src_date);
@@ -24565,7 +24556,7 @@ db_get_time_from_dbvalue (const DB_VALUE * src_date, int *hour, int *minute, int
       {
 	DB_TIME db_time;
 	int str_len;
-	char *strp;
+	const char *strp;
 
 	strp = db_get_string (src_date);
 	str_len = db_get_string_size (src_date);
@@ -25441,9 +25432,9 @@ static int
 db_check_or_create_null_term_string (const DB_VALUE * str_val, char *pre_alloc_buf, int pre_alloc_buf_size,
 				     bool ignore_prec_spaces, bool ignore_trail_spaces, char **str_out, bool * do_alloc)
 {
-  char *val_buf;
+  const char *val_buf;
   char *new_buf;
-  char *val_buf_end = NULL, *val_buf_end_non_space = NULL;
+  const char *val_buf_end = NULL, *val_buf_end_non_space = NULL;
   int val_size;
 
   assert (pre_alloc_buf != NULL);
@@ -27031,7 +27022,7 @@ is_valid_ip_slice (const char *ipslice)
 int
 db_get_date_format (const DB_VALUE * format_str, TIMESTAMP_FORMAT * format)
 {
-  char *fmt_str_ptr, *next_fmt_str_ptr, *last_fmt;
+  const char *fmt_str_ptr, *next_fmt_str_ptr, *last_fmt;
   INTL_CODESET codeset;
   char stack_buf_format[64];
   char *initial_buf_format = NULL;
@@ -27278,7 +27269,7 @@ db_string_to_base64 (DB_VALUE const *src, DB_VALUE * result)
       return error_status;
     }
 
-  src_buf = (const unsigned char *) db_get_string (src);
+  src_buf = DB_GET_UCHAR (src);
 
   /* length in bytes */
   src_len = db_get_string_size (src);
@@ -27369,7 +27360,7 @@ db_string_from_base64 (DB_VALUE const *src, DB_VALUE * result)
       return NO_ERROR;
     }
 
-  src_buf = (const unsigned char *) db_get_string (src);
+  src_buf = DB_GET_UCHAR (src);
 
   /* length in bytes */
   src_len = db_get_string_size (src);
@@ -27559,7 +27550,7 @@ db_string_extract_dbval (const MISC_OPERAND extr_operand, DB_VALUE * dbval_p, DB
       {
 	DB_UTIME utime_s;
 	DB_DATETIME datetime_s;
-	char *str_date = db_get_string (dbval_p);
+	const char *str_date = db_get_string (dbval_p);
 	int str_date_len = db_get_string_size (dbval_p);
 
 	switch (extr_operand)
@@ -27649,7 +27640,7 @@ db_new_time (DB_VALUE * time_val, DB_VALUE * tz_source, DB_VALUE * tz_dest, DB_V
   int error = NO_ERROR, len_source, len_dest;
   DB_DATETIME *datetime = NULL;
   DB_TIME *time = NULL;
-  char *t_source, *t_dest;
+  const char *t_source, *t_dest;
 
   /*
    *  Assert that DB_VALUE structures have been allocated.
@@ -27811,7 +27802,7 @@ db_tz_offset (const DB_VALUE * src_str, DB_VALUE * result_str, DB_DATETIME * dat
 int
 db_from_tz (DB_VALUE * time_val, DB_VALUE * tz, DB_VALUE * time_val_with_tz)
 {
-  char *timezone;
+  const char *timezone_str = NULL;
   int len_timezone, error = NO_ERROR;
   DB_DATETIME *datetime = NULL;
 
@@ -27828,12 +27819,12 @@ db_from_tz (DB_VALUE * time_val, DB_VALUE * tz, DB_VALUE * time_val_with_tz)
       return NO_ERROR;
     }
 
-  timezone = db_get_string (tz);
+  timezone_str = db_get_string (tz);
   len_timezone = db_get_string_size (tz);
 
   if (len_timezone < 0)
     {
-      len_timezone = strlen (timezone);
+      len_timezone = strlen (timezone_str);
     }
 
   switch (DB_VALUE_TYPE (time_val))
@@ -27844,7 +27835,7 @@ db_from_tz (DB_VALUE * time_val, DB_VALUE * tz, DB_VALUE * time_val_with_tz)
 	TZ_REGION region;
 
 	datetime = db_get_datetime (time_val);
-	error = tz_str_to_region (timezone, len_timezone, &region);
+	error = tz_str_to_region (timezone_str, len_timezone, &region);
 	if (error != NO_ERROR)
 	  {
 	    return error;

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -26760,7 +26760,7 @@ db_inet_aton (DB_VALUE * result_numbered_ip, const DB_VALUE * string)
 {
   int error_code = NO_ERROR;
   DB_BIGINT numbered_ip = (DB_BIGINT) 0;
-  char *ip_string = NULL;
+  const char *ip_string = NULL;
   char *local_ipstring = NULL;
   char *local_ipslice = NULL;
   char *local_pivot = NULL;

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -23967,7 +23967,7 @@ db_bit_to_blob (const DB_VALUE * src_value, DB_VALUE * result_value)
   DB_TYPE src_type;
   int error_status = NO_ERROR;
   DB_ELO *elo;
-  char *src_str;
+  const char *src_str;
   int src_length = 0;
 
   assert (src_value != NULL && result_value != NULL);
@@ -25898,7 +25898,8 @@ db_hex (const DB_VALUE * param, DB_VALUE * result)
 
   /* other variables */
   DB_TYPE param_type = DB_TYPE_UNKNOWN;
-  char *str = NULL, *hexval = NULL;
+  const char *str = NULL;
+  char *hexval = NULL;
   int str_size = 0, hexval_len = 0, i = 0, error_code = NO_ERROR;
 
   /* check parameters for NULL values */
@@ -26132,7 +26133,7 @@ db_ascii (const DB_VALUE * param, DB_VALUE * result)
 {
   /* other variables */
   DB_TYPE param_type = DB_TYPE_UNKNOWN;
-  char *str = NULL;
+  const char *str = NULL;
   int str_size = 0, error_code = NO_ERROR;
 
   /* check parameters for NULL values */
@@ -26405,13 +26406,13 @@ db_conv (const DB_VALUE * num, const DB_VALUE * from_base, const DB_VALUE * to_b
   else if (TP_IS_BIT_TYPE (num_type))
     {
       /* get raw bytes */
-      num_p_str = db_get_bit (num, &num_size);
+      const char *num_bit_str = db_get_bit (num, &num_size);
       num_size = QSTR_NUM_BYTES (num_size);
 
       /* convert to hex; NOTE: qstr_bin_to_hex returns number of converted bytes, not the size of the hex string; also,
        * we convert at most 64 digits even if we need only 16 in order to let strtoll handle overflow (weird stuff
        * happens there ...) */
-      num_size = qstr_bin_to_hex (num_str, UINT64_MAX_BIN_DIGITS, num_p_str, num_size);
+      num_size = qstr_bin_to_hex (num_str, UINT64_MAX_BIN_DIGITS, num_bit_str, num_size);
       num_str[num_size * 2] = '\0';
 
       /* set up variables for hex -> base10 conversion */

--- a/src/query/string_opfunc.h
+++ b/src/query/string_opfunc.h
@@ -247,8 +247,8 @@ extern int db_string_convert (const DB_VALUE * src_string, DB_VALUE * dest_strin
 #endif
 extern unsigned char *qstr_pad_string (unsigned char *s, int length, INTL_CODESET codeset);
 extern int qstr_bin_to_hex (char *dest, int dest_size, const char *src, int src_size);
-extern int qstr_hex_to_bin (char *dest, int dest_size, char *src, int src_size);
-extern int qstr_bit_to_bin (char *dest, int dest_size, char *src, int src_size);
+extern int qstr_hex_to_bin (char *dest, int dest_size, const char *src, int src_size);
+extern int qstr_bit_to_bin (char *dest, int dest_size, const char *src, int src_size);
 extern void qstr_bit_to_hex_coerce (char *buffer, int buffer_size, const char *src, int src_length, int pad_flag,
 				    int *copy_size, int *truncation);
 extern int db_get_string_length (const DB_VALUE * value);

--- a/src/query/string_opfunc.h
+++ b/src/query/string_opfunc.h
@@ -252,7 +252,7 @@ extern int qstr_bit_to_bin (char *dest, int dest_size, char *src, int src_size);
 extern void qstr_bit_to_hex_coerce (char *buffer, int buffer_size, const char *src, int src_length, int pad_flag,
 				    int *copy_size, int *truncation);
 extern int db_get_string_length (const DB_VALUE * value);
-extern void qstr_make_typed_string (const DB_TYPE db_type, DB_VALUE * value, const int precision, const DB_C_CHAR src,
+extern void qstr_make_typed_string (const DB_TYPE db_type, DB_VALUE * value, const int precision, DB_CONST_C_CHAR src,
 				    const int s_unit, const int codeset, const int collation_id);
 extern int db_add_months (const DB_VALUE * src_date, const DB_VALUE * nmonth, DB_VALUE * result_date);
 extern int db_last_day (const DB_VALUE * src_date, DB_VALUE * result_day);

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -2362,7 +2362,6 @@ xcache_check_recompilation_threshold (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY 
 
 /*
  * xcache_get_entry_count () - Returns the number of xasl cache entries
- *					
  *
  * return : the number of xasl cache entries
  */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -16184,13 +16184,11 @@ btree_get_next_key_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_SCAN * bts,
 
   /* Get overflow key and overflow oids */
   pr_clear_value (key_info[BTREE_KEY_INFO_OVERFLOW_KEY]);
-  db_make_string_by_const_str (key_info[BTREE_KEY_INFO_OVERFLOW_KEY],
-			       btree_leaf_is_flaged (&bts->key_record,
-						     BTREE_LEAF_RECORD_OVERFLOW_KEY) ? "true" : "false");
+  db_make_string (key_info[BTREE_KEY_INFO_OVERFLOW_KEY],
+		  btree_leaf_is_flaged (&bts->key_record, BTREE_LEAF_RECORD_OVERFLOW_KEY) ? "true" : "false");
   pr_clear_value (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS]);
-  db_make_string_by_const_str (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS],
-			       btree_leaf_is_flaged (&bts->key_record,
-						     BTREE_LEAF_RECORD_OVERFLOW_OIDS) ? "true" : "false");
+  db_make_string (key_info[BTREE_KEY_INFO_OVERFLOW_OIDS],
+		  btree_leaf_is_flaged (&bts->key_record, BTREE_LEAF_RECORD_OVERFLOW_OIDS) ? "true" : "false");
 
   /* Get OIDs count -> For now ignore the overflow OIDs */
   db_make_int (key_info[BTREE_KEY_INFO_OID_COUNT],
@@ -20208,8 +20206,7 @@ btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid, BTREE_NODE_SCAN 
 
   /* Get node type */
   pr_clear_value (node_info[BTREE_NODE_INFO_NODE_TYPE]);
-  db_make_string_by_const_str (node_info[BTREE_NODE_INFO_NODE_TYPE],
-			       (node_type == BTREE_NON_LEAF_NODE) ? "non-leaf" : "leaf");
+  db_make_string (node_info[BTREE_NODE_INFO_NODE_TYPE], (node_type == BTREE_NON_LEAF_NODE) ? "non-leaf" : "leaf");
 
   /* Get key count */
   db_make_int (node_info[BTREE_NODE_INFO_KEY_COUNT], key_cnt);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -20489,7 +20489,7 @@ btree_index_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_
   OR_PARTITION *parts = NULL;
   int parts_count = 0;
   DB_CLASS_PARTITION_TYPE partition_type;
-  char *class_name = NULL;
+  const char *class_name = NULL;
 
   *ptr = NULL;
   ctx = (SHOW_INDEX_SCAN_CTX *) db_private_alloc (thread_p, sizeof (SHOW_INDEX_SCAN_CTX));

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -206,7 +206,7 @@ class index_builder_loader_task: public cubthread::entry_task
                                index_builder_loader_context &load_context, std::atomic<int> &num_keys,
 			       std::atomic<int> &num_oids, std::atomic<int> &num_nulls);
     ~index_builder_loader_task ();
-    
+
     // add key to key set and return true if task is ready for execution, false otherwise
     batch_key_status add_key (const DB_VALUE *key, const OID &oid);
     bool has_keys () const;

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -685,9 +685,8 @@ catcls_find_oid_by_class_name (THREAD_ENTRY * thread_p, const char *name_p, OID 
   DB_VALUE key_val;
   int error = NO_ERROR;
 
-  error =
-    db_make_varchar (&key_val, DB_MAX_IDENTIFIER_LENGTH, (char *) name_p, (int) strlen (name_p), LANG_SYS_CODESET,
-		     LANG_SYS_COLLATION);
+  error = db_make_varchar (&key_val, DB_MAX_IDENTIFIER_LENGTH, name_p, (int) strlen (name_p), LANG_SYS_CODESET,
+			   LANG_SYS_COLLATION);
   if (error != NO_ERROR)
     {
       return error;

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -1236,7 +1236,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
   int size;
   int error = NO_ERROR;
   const char *default_expr_type_string = NULL;
-  char *def_expr_format_string = NULL;
+  const char *def_expr_format_string = NULL;
   bool with_to_char = false;
 
   error = catcls_expand_or_value_by_def (value_p, &ct_Attribute);
@@ -1366,7 +1366,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
   if (att_props != NULL)
     {
       size_t default_value_len = 0;
-      char *default_str_val = NULL;
+      const char *default_str_val = NULL;
 
       if (classobj_get_prop (att_props, "default_expr", &default_expr) > 0)
 	{
@@ -1427,6 +1427,7 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	      goto error;
 	    }
 	  len = strlen (default_expr_type_string);
+	  char *default_str_val_tmp = NULL;
 
 	  if (with_to_char)
 	    {
@@ -1437,8 +1438,8 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 		      + 6	/* parenthesis, a comma, a blank and quotes */
 		      + (def_expr_format_string ? strlen (def_expr_format_string) : 0));	/* nothing or format */
 
-	      default_str_val = (char *) db_private_alloc (thread_p, len + 1);
-	      if (default_str_val == NULL)
+	      default_str_val_tmp = (char *) db_private_alloc (thread_p, len + 1);
+	      if (default_str_val_tmp == NULL)
 		{
 		  pr_clear_value (&default_expr);
 		  pr_clear_value (&val);
@@ -1446,29 +1447,30 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 		  goto error;
 		}
 
-	      strcpy (default_str_val, default_expr_op_string);
-	      strcat (default_str_val, "(");
-	      strcat (default_str_val, default_expr_type_string);
+	      strcpy (default_str_val_tmp, default_expr_op_string);
+	      strcat (default_str_val_tmp, "(");
+	      strcat (default_str_val_tmp, default_expr_type_string);
 	      if (def_expr_format_string)
 		{
-		  strcat (default_str_val, ", \'");
-		  strcat (default_str_val, def_expr_format_string);
-		  strcat (default_str_val, "\'");
+		  strcat (default_str_val_tmp, ", \'");
+		  strcat (default_str_val_tmp, def_expr_format_string);
+		  strcat (default_str_val_tmp, "\'");
 		}
-	      strcat (default_str_val, ")");
+	      strcat (default_str_val_tmp, ")");
 	    }
 	  else
 	    {
-	      default_str_val = (char *) db_private_alloc (thread_p, len + 1);
-	      if (default_str_val == NULL)
+	      default_str_val_tmp = (char *) db_private_alloc (thread_p, len + 1);
+	      if (default_str_val_tmp == NULL)
 		{
 		  pr_clear_value (&default_expr);
 		  pr_clear_value (&val);
 		  error = ER_OUT_OF_VIRTUAL_MEMORY;
 		  goto error;
 		}
-	      strcpy (default_str_val, default_expr_type_string);
+	      strcpy (default_str_val_tmp, default_expr_type_string);
 	    }
+	  default_str_val = default_str_val_tmp;
 
 	  pr_clear_value (attr_val_p);	/* clean old default value */
 	  db_make_string (attr_val_p, default_str_val);
@@ -2476,7 +2478,8 @@ catcls_get_or_value_from_indexes (DB_SEQ * seq_p, OR_VALUE * values, int is_uniq
 				  goto error;
 				}
 
-			      buffer = db_get_string (&temp);
+			      // use const_cast since of a limitation of or_unpack_* functions which do not accept const
+			      buffer = CONST_CAST (char *, db_get_string (&temp));
 			      ptr = buffer;
 			      ptr = or_unpack_domain (ptr, &fi_domain, NULL);
 
@@ -4617,7 +4620,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
 	    }
 	  else if (heap_value->attrid == lang_att_id)
 	    {
-	      char *lang_str = NULL;
+	      const char *lang_str = NULL;
 	      size_t lang_str_len;
 
 	      if (DB_IS_NULL (&heap_value->dbvalue))
@@ -4644,7 +4647,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
 	    }
 	  else if (heap_value->attrid == timezone_id)
 	    {
-	      char *checksum = NULL;
+	      const char *checksum = NULL;
 	      size_t checksum_len;
 
 	      if (DB_IS_NULL (&heap_value->dbvalue))
@@ -5079,7 +5082,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
 	    }
 	  else if (heap_value->attrid == coll_name_att_id)
 	    {
-	      char *lang_str = NULL;
+	      const char *lang_str = NULL;
 	      size_t lang_str_len;
 
 	      assert (DB_VALUE_DOMAIN_TYPE (&(heap_value->dbvalue)) == DB_TYPE_STRING);
@@ -5099,7 +5102,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
 	    }
 	  else if (heap_value->attrid == checksum_att_id)
 	    {
-	      char *checksum_str = NULL;
+	      const char *checksum_str = NULL;
 	      size_t str_len;
 
 	      assert (DB_VALUE_DOMAIN_TYPE (&(heap_value->dbvalue)) == DB_TYPE_STRING);

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2983,10 +2983,10 @@ disk_volume_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** o
   db_make_int (out_values[idx], vhdr->iopagesize);
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], disk_purpose_to_string (vhdr->purpose));
+  db_make_string (out_values[idx], disk_purpose_to_string (vhdr->purpose));
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], disk_type_to_string (vhdr->type));
+  db_make_string (out_values[idx], disk_type_to_string (vhdr->type));
   idx++;
 
   db_make_int (out_values[idx], vhdr->sect_npgs);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -17070,9 +17070,9 @@ heap_object_upgrade_domain (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scanca
 		case DB_TYPE_NCHAR:
 		case DB_TYPE_VARNCHAR:
 		  {
-		    char *str = db_get_string (&(value->dbvalue));
-		    char *str_end = str + db_get_string_length (&(value->dbvalue));
-		    char *p = NULL;
+		    const char *str = db_get_string (&(value->dbvalue));
+		    const char *str_end = str + db_get_string_length (&(value->dbvalue));
+		    const char *p = NULL;
 
 		    /* get the sign in the source string; look directly into the buffer string, no copy */
 		    p = str;
@@ -17554,7 +17554,7 @@ heap_header_capacity_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALU
 				 void **ptr)
 {
   int error = NO_ERROR;
-  char *class_name = NULL;
+  const char *class_name = NULL;
   DB_CLASS_PARTITION_TYPE partition_type = DB_NOT_PARTITIONED_CLASS;
   OID class_oid;
   LC_FIND_CLASSNAME status;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -23340,7 +23340,7 @@ heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid
 
   /*  Here we check only the classname because this is the last field to be populated by other possible concurrent
    *  inserters. This means that if this field is already set by someone else, then the entry data is already
-   *  mature so we don't need to add data again. 
+   *  mature so we don't need to add data again.
    */
   if (entry->classname == NULL)
     {

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -151,6 +151,7 @@ static LF_ENTRY_DESCRIPTOR spage_Saving_entry_descriptor = {
 // *INDENT-OFF*
 using spage_saving_hashmap_type = cubthread::lockfree_hashmap<VPID, spage_save_head>;
 // *INDENT-ON*
+
 static spage_saving_hashmap_type spage_Saving_hashmap;
 
 /* context for slotted page header scan */
@@ -5008,10 +5009,10 @@ spage_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_val
   db_make_int (out_values[idx], header->num_records);
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], spage_anchor_flag_string (header->anchor_type));
+  db_make_string (out_values[idx], spage_anchor_flag_string (header->anchor_type));
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], spage_alignment_string (header->alignment));
+  db_make_string (out_values[idx], spage_alignment_string (header->alignment));
   idx++;
 
   db_make_int (out_values[idx], header->total_free);
@@ -5196,7 +5197,7 @@ spage_slots_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
   db_make_int (out_values[idx], ctx->slot->offset_to_record);
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], spage_record_type_string (ctx->slot->record_type));
+  db_make_string (out_values[idx], spage_record_type_string (ctx->slot->record_type));
   idx++;
 
   db_make_int (out_values[idx], ctx->slot->record_length);

--- a/src/thread/critical_section.c
+++ b/src/thread/critical_section.c
@@ -1660,7 +1660,7 @@ csect_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values
       idx++;
 
       /* The name of the critical section */
-      db_make_string_by_const_str (&vals[idx], csect_name (csect));
+      db_make_string (&vals[idx], csect_name (csect));
       idx++;
 
       /* 'N readers', '1 writer', 'none' */

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -2979,7 +2979,7 @@ boot_add_data_type (MOP class_mop)
 	  db_make_int (&val, i + 1);
 	  db_put_internal (obj, "type_id", &val);
 
-	  db_make_varchar (&val, 16, (char *) names[i], strlen (names[i]), LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	  db_make_varchar (&val, 16, names[i], strlen (names[i]), LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	  db_put_internal (obj, "type_name", &val);
 	}
     }

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -5373,7 +5373,7 @@ la_update_query_execute_with_values (const char *sql, int arg_count, DB_VALUE * 
 static int
 la_apply_statement_log (LA_ITEM * item)
 {
-  char *stmt_text = NULL;
+  const char *stmt_text = NULL;
   int error = NO_ERROR, error2 = NO_ERROR;
   const char *error_msg = "";
   DB_OBJECT *user = NULL, *save_user = NULL;

--- a/src/transaction/log_applier_sql_log.c
+++ b/src/transaction/log_applier_sql_log.c
@@ -437,7 +437,7 @@ sl_write_delete_sql (char *class_name, MOBJ mclass, DB_VALUE * key)
 }
 
 int
-sl_write_statement_sql (char *class_name, char *db_user, int item_type, char *stmt_text, char *ha_sys_prm)
+sl_write_statement_sql (char *class_name, char *db_user, int item_type, const char *stmt_text, char *ha_sys_prm)
 {
   int error = NO_ERROR;
   char default_ha_prm[LINE_MAX];

--- a/src/transaction/log_applier_sql_log.h
+++ b/src/transaction/log_applier_sql_log.h
@@ -29,7 +29,7 @@
 #include "dbtype_def.h"
 #include "work_space.h"
 
-extern int sl_write_statement_sql (char *class_name, char *db_user, int item_type, char *ddl, char *ha_sys_prm);
+extern int sl_write_statement_sql (char *class_name, char *db_user, int item_type, const char *ddl, char *ha_sys_prm);
 extern int sl_write_insert_sql (DB_OTMPL * inst_tp, DB_VALUE * key);
 extern int sl_write_update_sql (DB_OTMPL * inst_tp, DB_VALUE * key);
 extern int sl_write_delete_sql (char *class_name, MOBJ mclass, DB_VALUE * key);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -8906,7 +8906,7 @@ log_active_log_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE *
   db_make_int (out_values[idx], header->has_logging_been_skipped);
   idx++;
 
-  db_make_string_by_const_str (out_values[idx], "LOG_PSTATUS_OBSOLETE");
+  db_make_string (out_values[idx], "LOG_PSTATUS_OBSOLETE");
   idx++;
 
   logpb_backup_level_info_to_string (buf, sizeof (buf), header->bkinfo + FILEIO_BACKUP_FULL_LEVEL);
@@ -8934,11 +8934,11 @@ log_active_log_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE *
     }
 
   str = css_ha_server_state_string ((HA_SERVER_STATE) header->ha_server_state);
-  db_make_string_by_const_str (out_values[idx], str);
+  db_make_string (out_values[idx], str);
   idx++;
 
   str = logwr_log_ha_filestat_to_string ((LOG_HA_FILESTAT) header->ha_file_status);
-  db_make_string_by_const_str (out_values[idx], str);
+  db_make_string (out_values[idx], str);
   idx++;
 
   lsa_to_string (buf, sizeof (buf), &header->eof_lsa);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -5232,11 +5232,11 @@ logtb_descriptors_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg
       idx++;
 
       /* State */
-      db_make_string_by_const_str (&vals[idx], log_state_short_string (tdes->state));
+      db_make_string (&vals[idx], log_state_short_string (tdes->state));
       idx++;
 
       /* isolation */
-      db_make_string_by_const_str (&vals[idx], log_isolation_string (tdes->isolation));
+      db_make_string (&vals[idx], log_isolation_string (tdes->isolation));
       idx++;
 
       /* Wait_msecs */
@@ -5579,7 +5579,7 @@ logtb_descriptors_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg
 
       /* Abort_reason */
       str = tran_abort_reason_to_string (tdes->tran_abort_reason);
-      db_make_string_by_const_str (&vals[idx], str);
+      db_make_string (&vals[idx], str);
       idx++;
 
       assert (idx == num_cols);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23444

* Change signature of functions `db_make_db_char`/`db_make_string` to accept `const char *`
* Change signature of functions `db_get_char`/`db_get_string` to return `const char *`
* Remove db_make_string_by_const_str define which was doing a copy behind the scene, except 2 cases:
  * https://github.com/CUBRID/cubrid/pull/2068/commits/acc30c4fa38f88c9ed563e4f12a3a3a6e2a70b7d#diff-97d22ef387ed8337098c4101b2e3dbe1L17727
  * https://github.com/CUBRID/cubrid/pull/2068/commits/86998c3e562f7f48db2d2d646b64f3e6f2981a68#diff-e40006abb05430e66503a3daef2802ccL7157-L7160
* Fix cases when `const` qualifier is applied to a typedef to a pointer type rather than to the pointee.
For example, in the code snippet below, the resulting type is `char * const` rather than `const char *`
Add new typedefs `DB_CONST_C_CHAR, DB_CONST_C_NCHAR` and `DB_CONST_C_BIT` and use them where is the case.
```cpp
typedef char *DB_C_CHAR;
void foo (const DB_C_CHAR bar);
```