### PR TITLE
[CBRD-23453] [loaddb] fix periodic commit verbose messages

### DIFF
--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -406,6 +406,8 @@ namespace cubload
       virtual void finish_line () = 0;
 
       virtual void flush_records () = 0;
+
+      virtual std::size_t get_rows_number () = 0;
   };
 
 ///////////////////// common global functions /////////////////////

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -124,17 +124,6 @@ print_stats (std::vector<cubload::stats> &stats, cubload::load_args &args, int *
 	      fprintf (stderr, "%s", stat.error_message.c_str ());
 	    }
 	}
-      else
-	{
-	  /* Don't print this during syntax checking */
-	  if (!args.syntax_check && stat.rows_committed != 0)
-	    {
-	      char *committed_instances_msg = msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB,
-					      LOADDB_MSG_COMMITTED_INSTANCES);
-	      const char *dummy = "";
-	      print_log_msg (args.verbose_commit, committed_instances_msg, dummy, stat.rows_committed);
-	    }
-	}
     }
 }
 /* *INDENT-ON* */

--- a/src/loaddb/load_driver.cpp
+++ b/src/loaddb/load_driver.cpp
@@ -34,7 +34,6 @@ namespace cubload
     , m_object_loader (NULL)
     , m_error_handler (NULL)
     , m_semantic_helper ()
-    , m_lines_inserted (0)
     , m_is_initialized (false)
   {
     //
@@ -55,7 +54,6 @@ namespace cubload
     m_error_handler = NULL;
 
     m_is_initialized = false;
-    m_lines_inserted = 0;
   }
 
   driver::~driver ()
@@ -73,7 +71,6 @@ namespace cubload
     m_error_handler = error_handler;
     m_scanner = new scanner (m_semantic_helper, *m_error_handler);
     m_is_initialized = true;
-    m_lines_inserted = 0;
   }
 
   bool
@@ -123,18 +120,6 @@ namespace cubload
   driver::get_scanner ()
   {
     return *m_scanner;
-  }
-
-  int
-  driver::get_lines_inserted ()
-  {
-    return m_lines_inserted;
-  }
-
-  void
-  driver::increment_lines_inserted (int no_lines)
-  {
-    m_lines_inserted += no_lines;
   }
 
 } // namespace cubload

--- a/src/loaddb/load_driver.hpp
+++ b/src/loaddb/load_driver.hpp
@@ -89,8 +89,6 @@ namespace cubload
       semantic_helper &get_semantic_helper ();
       error_handler &get_error_handler ();
       scanner &get_scanner ();
-      int get_lines_inserted ();
-      void increment_lines_inserted (int no_lines);
 
     private:
       scanner *m_scanner;
@@ -98,7 +96,6 @@ namespace cubload
       object_loader *m_object_loader;
       error_handler *m_error_handler;
       semantic_helper m_semantic_helper;
-      int m_lines_inserted;
 
       bool m_is_initialized;
   }; // class driver

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -769,6 +769,13 @@ error_exit:
     ; // Do nothing.
   }
 
+  std::size_t
+  sa_object_loader::get_rows_number ()
+  {
+    // Do nothing on SA_MODE
+    assert (false);
+  }
+
   /*
    * sa_object_loader::start_line - Finishes off the previous instance and resets the
    *                                     context to deal with a new instance.

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -774,6 +774,7 @@ error_exit:
   {
     // Do nothing on SA_MODE
     assert (false);
+    return 0;
   }
 
   /*

--- a/src/loaddb/load_sa_loader.hpp
+++ b/src/loaddb/load_sa_loader.hpp
@@ -26,7 +26,6 @@
 
 #include "load_common.hpp"
 
-/* *INDENT-OFF* */
 namespace cubload
 {
 
@@ -56,9 +55,9 @@ namespace cubload
       void process_line (constant_type *cons) override;
       void finish_line () override;
       void flush_records () override;
+      std::size_t get_rows_number () override;
   };
 }
-/* *INDENT-ON* */
 
 /* start load functions */
 void ldr_sa_load (cubload::load_args *args, int *status, bool *interrupted);

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -373,6 +373,7 @@ namespace cubload
     , m_recdes_collected ()
     , m_scancache_started (false)
     , m_scancache ()
+    , m_rows (0)
   {
     //
   }
@@ -468,6 +469,11 @@ namespace cubload
 	m_error_handler.on_syntax_failure ();
 	return;
       }
+
+    if (m_session.get_args ().syntax_check)
+      {
+	++m_rows;
+      }
   }
 
   void
@@ -528,7 +534,7 @@ namespace cubload
     if (m_session.get_args ().syntax_check)
       {
 	// Safeguard as we do not need to insert any records during syntax check.
-	assert (m_recdes_collected.size () == 0);
+	assert (m_recdes_collected.empty ());
 	return;
       }
 
@@ -538,7 +544,7 @@ namespace cubload
 	m_scancache.node.classname = m_class_entry->get_class_name ();
       }
 
-    if (m_recdes_collected.size () == 0)
+    if (m_recdes_collected.empty ())
       {
 	// Nothing to flush.
 	return;
@@ -575,7 +581,7 @@ namespace cubload
 
 	    // We attach to outer and we continue.
 	    log_sysop_attach_to_outer (m_thread_ref);
-	    m_thread_ref->m_loaddb_driver->increment_lines_inserted (1);
+	    ++m_rows;
 	  }
       }
     else
@@ -594,9 +600,15 @@ namespace cubload
 	else
 	  {
 	    log_sysop_attach_to_outer (m_thread_ref);
-	    m_thread_ref->m_loaddb_driver->increment_lines_inserted (m_recdes_collected.size ());
+	    m_rows += m_recdes_collected.size ();
 	  }
       }
+  }
+
+  std::size_t
+  server_object_loader::get_rows_number ()
+  {
+    return m_rows;
   }
 
   int

--- a/src/loaddb/load_server_loader.hpp
+++ b/src/loaddb/load_server_loader.hpp
@@ -84,6 +84,8 @@ namespace cubload
       void finish_line () override;
       void flush_records () override;
 
+      std::size_t get_rows_number () override;
+
     private:
       int process_constant (constant_type *cons, const attribute &attr);
       int process_generic_constant (constant_type *cons, const attribute &attr);
@@ -113,6 +115,8 @@ namespace cubload
 
       bool m_scancache_started;
       heap_scancache m_scancache;
+
+      std::size_t m_rows;
   };
 
 } // namespace cubload

--- a/src/loaddb/load_session.hpp
+++ b/src/loaddb/load_session.hpp
@@ -115,6 +115,8 @@ namespace cubload
       void fetch_status (load_status &status, bool has_lock = false);
 
       void stats_update_rows_committed (int rows_committed);
+      int stats_get_rows_committed ();
+
       void stats_update_last_committed_line (int last_committed_line);
       void stats_update_current_line (int current_line);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23453

* move `driver::m_lines_inserted` member to `object_loader::get_rows_number` interface as a virtual function
* remove duplicate LOADDB_MSG_COMMITTED_INSTANCES message log from load_db.c
* fix object syntax checking message logging