### PR TITLE
[CBRD-23477] fix update last blockid after big log record

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4972,7 +4972,7 @@ vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p)
   if (vacuum_Block_data_buffer->is_empty ())
     {
       /* empty */
-      if (vacuum_is_empty ())
+      if (vacuum_is_empty () && !log_Gl.hdr.does_block_need_vacuum)
 	{
 	  const VACUUM_LOG_BLOCKID LOG_BLOCK_TRAILING_DIFF = 2;
 	  LOG_LSA log_lsa = log_Gl.prior_info.prior_lsa;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23477

A very big log record broke vacuum_consume_buffer_log_blocks trying to force updates on last vacuum data blockid when log advances without mvcc ops.

To fix `log_Gl.hdr.does_block_need_vacuum` must be considered. For a safe check, reading it and log_Gl.prior_info.prior_lsa must hold prior mutex.