### PR TITLE
[CBRD-23505] Fixed bad message reporting in windows in loaddb

### DIFF
--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -25,6 +25,7 @@
 #define _LOAD_COMMON_HPP_
 
 #include "packable_object.hpp"
+#include "porting.h"
 
 #include <atomic>
 #include <cassert>

--- a/src/loaddb/load_common.hpp
+++ b/src/loaddb/load_common.hpp
@@ -25,7 +25,6 @@
 #define _LOAD_COMMON_HPP_
 
 #include "packable_object.hpp"
-#include "porting.h"
 
 #include <atomic>
 #include <cassert>

--- a/src/loaddb/load_error_handler.hpp
+++ b/src/loaddb/load_error_handler.hpp
@@ -25,6 +25,7 @@
 #define _LOAD_ERROR_HANDLER_HPP_
 
 #include "load_common.hpp"
+#include "porting.h"
 #include "utility.h"
 
 #include <memory>

--- a/src/loaddb/load_error_handler.hpp
+++ b/src/loaddb/load_error_handler.hpp
@@ -155,10 +155,10 @@ namespace cubload
   error_handler::format (const char *fmt, Args &&... args)
   {
     // Determine required size
-    int size = _sprintf_p (NULL, 0, fmt, std::forward<Args> (args)...) + 1; // +1 for '\0'
+    int size = snprintf (NULL, 0, fmt, std::forward<Args> (args)...) + 1; // +1 for '\0'
     std::unique_ptr<char[]> msg (new char[size]);
 
-    _sprintf_p (msg.get (), (size_t) size, fmt, std::forward<Args> (args)...);
+    snprintf (msg.get (), (size_t) size, fmt, std::forward<Args> (args)...);
 
     return std::string (msg.get (), msg.get () + size - 1);
   }

--- a/src/loaddb/load_error_handler.hpp
+++ b/src/loaddb/load_error_handler.hpp
@@ -155,10 +155,10 @@ namespace cubload
   error_handler::format (const char *fmt, Args &&... args)
   {
     // Determine required size
-    int size = snprintf (NULL, 0, fmt, std::forward<Args> (args)...) + 1; // +1 for '\0'
+    int size = _sprintf_p (NULL, 0, fmt, std::forward<Args> (args)...) + 1; // +1 for '\0'
     std::unique_ptr<char[]> msg (new char[size]);
 
-    snprintf (msg.get (), (size_t) size, fmt, std::forward<Args> (args)...);
+    _sprintf_p (msg.get (), (size_t) size, fmt, std::forward<Args> (args)...);
 
     return std::string (msg.get (), msg.get () + size - 1);
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23505

It seems that `snprintf` was not properly used as the windows version would not use its correct implementation, leading to bad results. Fixed it by including the `porting.h` header.