### PR TITLE
[CBRD-23522] Set system parameter for error log file in copylogdb process

### DIFF
--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2679,6 +2679,8 @@ copylogdb (UTIL_FUNCTION_ARG * arg)
       goto error_exit;
     }
 
+  sysprm_set_force (prm_get_name (PRM_ID_ER_LOG_FILE), er_msg_file);
+
   if (start_pageid < NULL_PAGEID && !HA_DISABLED ())
     {
       error = hb_process_init (database_name, log_path, HB_PTYPE_COPYLOGDB);

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2679,6 +2679,11 @@ copylogdb (UTIL_FUNCTION_ARG * arg)
       goto error_exit;
     }
 
+  /*
+   * Force error log file system parameter as copylogdb;
+   * during a retry loop, `db_restart` will reset the error file name as :
+   * er_init (prm_get_string_value (PRM_ID_ER_LOG_FILE), ... ) 
+   */
   sysprm_set_force (prm_get_name (PRM_ID_ER_LOG_FILE), er_msg_file);
 
   if (start_pageid < NULL_PAGEID && !HA_DISABLED ())


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23522

Set system parameter for error log file in copylogdb process instead of default cub_client.err.