### PR TITLE
[CBRD-23531] Fix vacuum_update_keep_from_log_pageid corner case

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5633,8 +5633,6 @@ vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p)
    * If vacuum data is not empty, then we need to preserve the log starting with the first page of first unvacuumed
    * block.
    */
-  VACUUM_LOG_BLOCKID keep_from_blockid;
-
   if (vacuum_is_empty ())
     {
       // keep starting with next after last_blockid ()
@@ -5642,8 +5640,7 @@ vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p)
     }
   else
     {
-      keep_from_blockid = vacuum_Data.first_page->data[vacuum_Data.first_page->index_unvacuumed].get_blockid ();
-      vacuum_Data.keep_from_log_pageid = VACUUM_FIRST_LOG_PAGEID_IN_BLOCK (keep_from_blockid);
+      vacuum_Data.keep_from_log_pageid = VACUUM_FIRST_LOG_PAGEID_IN_BLOCK (vacuum_Data.get_first_blockid ());
     }
 
   vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA,

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5629,9 +5629,7 @@ vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p)
    * does not remove log required for vacuum.
    * If vacuum data is empty, then all blocks until (and including) vacuum_Data.last_blockid have been
    * vacuumed, and first page belonging to next block must be preserved (this is most likely in the active area of the
-   * log, for now). However, it might happen that the page referred might belong in a log archive that might have
-   * been removed due to a previous action. So to be sure, we set the pageid, from which the vacuum must keep
-   * the remaining pages, to NULL_PAGEID.
+   * log, but not always).
    * If vacuum data is not empty, then we need to preserve the log starting with the first page of first unvacuumed
    * block.
    */
@@ -5639,19 +5637,8 @@ vacuum_update_keep_from_log_pageid (THREAD_ENTRY * thread_p)
 
   if (vacuum_is_empty ())
     {
-      LOG_LSA last_mvcc_lsa = log_Gl.hdr.mvcc_op_log_lsa;
-      if (last_mvcc_lsa.is_null () || vacuum_get_log_blockid (last_mvcc_lsa.pageid) <= vacuum_Data.get_last_blockid ())
-	{
-	  /* safe to remove all archives */
-	  keep_from_blockid = VACUUM_NULL_LOG_BLOCKID;
-	  vacuum_Data.keep_from_log_pageid = NULL_PAGEID;
-	}
-      else
-	{
-	  /* keep block of log_Gl.hdr.mvcc_op_log_lsa */
-	  keep_from_blockid = vacuum_get_log_blockid (log_Gl.hdr.mvcc_op_log_lsa.pageid);
-	  vacuum_Data.keep_from_log_pageid = VACUUM_FIRST_LOG_PAGEID_IN_BLOCK (keep_from_blockid);
-	}
+      // keep starting with next after last_blockid ()
+      vacuum_Data.keep_from_log_pageid = VACUUM_FIRST_LOG_PAGEID_IN_BLOCK (vacuum_Data.get_last_blockid () + 1);
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23531

Change vacuum_update_keep_from_log_pageid to be more conservative. Since vacuum_Data last blockid now closely trails end of log even if there are no MVCC operations, we can afford to set keep_from_log_pageid immediately after last blockid when vacuum data is empty.

Previous code missed one corner case:

  - vacuum data is empty
  - "current block" is split by last archive and active log
  - there are no MVCC operations in current block when archives are removed. that means vacuum_Data.keep_from_log_pageid is null and all archives are considered safe to remove.
  - an MVCC operation is logged in the active part of current block
  - logpb_backup checks all archives required for vacuum are present. however, current block's first part is now missing and check fails

An alternative fix is to consider current block when removing archives. However, current fix is even more conservative and safer.