### PR TITLE
[CBRD-23535] Treat json uint64 as double

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -2627,7 +2627,7 @@ db_json_get_bigint_from_value (const JSON_VALUE *val)
 
   assert (db_json_get_type_of_value (val) == DB_JSON_BIGINT);
 
-  return val->GetInt64 ();
+  return val->IsInt64 () ? val->GetInt64 () : val->GetUint ();
 }
 
 double

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -2573,12 +2573,13 @@ db_json_get_type_of_value (const JSON_VALUE *val)
     {
       return DB_JSON_INT;
     }
-  else if (val->IsInt64 ())
+  else if (val->IsInt64 () || val->IsUint ())
     {
       return DB_JSON_BIGINT;
     }
-  else if (val->IsFloat () || val->IsDouble ())
+  else if (val->IsFloat () || val->IsDouble () || val->IsUint64 ())
     {
+      /* quick fix: treat uint64 as double since we don't have an ubigint type */
       return DB_JSON_DOUBLE;
     }
   else if (val->IsObject ())


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23535

Quick fix: treat json uint64 as double since we do not have an unsigned bigint type.