### PR TITLE
[CBRD-23539] safe conversions to json key/path

### DIFF
--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1150,6 +1150,13 @@ db_json_value_get_depth (const JSON_VALUE *doc)
     }
 }
 
+int
+db_json_extract_document_from_path (const JSON_DOC *document, const std::string &path,
+				    JSON_DOC_STORE &result, bool allow_wildcards)
+{
+  return db_json_extract_document_from_path (document, { path }, result, allow_wildcards);
+}
+
 /*
  * db_json_extract_document_from_path () - Extracts from within the json a value based on the given path
  *
@@ -1162,7 +1169,7 @@ db_json_value_get_depth (const JSON_VALUE *doc)
  * example                 : json_extract('{"a":["b", 123]}', '/a/1') yields 123
  */
 int
-db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<const char *> &paths,
+db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<std::string> &paths,
 				    JSON_DOC_STORE &result, bool allow_wildcards)
 {
   int error_code = NO_ERROR;
@@ -1178,10 +1185,10 @@ db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<
 
   std::vector<JSON_PATH> json_paths;
 
-  for (const char *path : paths)
+  for (const std::string &path : paths)
     {
       json_paths.emplace_back ();
-      error_code = json_paths.back ().parse (path);
+      error_code = json_paths.back ().parse (path.c_str ());
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -3154,15 +3161,15 @@ db_json_doc_is_uncomparable (const JSON_DOC *doc)
 // path_str (out)  : path string
 //
 int
-db_value_to_json_path (const DB_VALUE *path_value, FUNC_TYPE fcode, const char **path_str)
+db_value_to_json_path (const DB_VALUE &path_value, FUNC_TYPE fcode, std::string &path_str)
 {
-  if (!TP_IS_CHAR_TYPE (db_value_domain_type (path_value)))
+  if (!TP_IS_CHAR_TYPE (db_value_domain_type (&path_value)))
     {
       int error_code = ER_ARG_CAN_NOT_BE_CASTED_TO_DESIRED_DOMAIN;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 2, fcode_get_uppercase_name (fcode), "STRING");
       return error_code;
     }
-  *path_str = db_get_string (path_value);
+  path_str = { db_get_string (&path_value), (size_t) db_get_string_size (&path_value) };
   return NO_ERROR;
 }
 
@@ -3295,6 +3302,30 @@ db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc)
       // if db_val is json a copy to dest is made so we can own it
       json_doc.set_mutable_reference (db_get_json_document (&dest));
     }
+
+  return NO_ERROR;
+}
+
+int
+db_value_to_json_key (const DB_VALUE &db_val, std::string &key_str)
+{
+  DB_VALUE cnv_to_str;
+  const DB_VALUE *str_valp = &db_val;
+
+  db_make_null (&cnv_to_str);
+
+  if (!DB_IS_STRING (&db_val))
+    {
+      TP_DOMAIN_STATUS status = tp_value_cast (&db_val, &cnv_to_str, &tp_String_domain, false);
+      if (status != DOMAIN_COMPATIBLE)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QSTR_INVALID_DATA_TYPE, 0);
+	  return ER_QSTR_INVALID_DATA_TYPE;
+	}
+      str_valp = &cnv_to_str;
+    }
+  key_str = { db_get_string (str_valp), (size_t) db_get_string_size (str_valp) };
+  pr_clear_value (&cnv_to_str);
 
   return NO_ERROR;
 }

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1154,7 +1154,7 @@ int
 db_json_extract_document_from_path (const JSON_DOC *document, const std::string &path,
 				    JSON_DOC_STORE &result, bool allow_wildcards)
 {
-  return db_json_extract_document_from_path (document, { path }, result, allow_wildcards);
+  return db_json_extract_document_from_path (document, std::vector<std::string> { path }, result, allow_wildcards);
 }
 
 /*

--- a/src/compat/db_json.hpp
+++ b/src/compat/db_json.hpp
@@ -72,7 +72,9 @@ bool db_json_is_valid (const char *json_str);
 const char *db_json_get_type_as_str (const JSON_DOC *document);
 unsigned int db_json_get_length (const JSON_DOC *document);
 unsigned int db_json_get_depth (const JSON_DOC *doc);
-int db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<const char *> &raw_path,
+int db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<std::string> &raw_path,
+					JSON_DOC_STORE &result, bool allow_wildcards = true);
+int db_json_extract_document_from_path (const JSON_DOC *document, const std::string &path,
 					JSON_DOC_STORE &result, bool allow_wildcards = true);
 int db_json_contains_path (const JSON_DOC *document, const std::vector<std::string> &paths, bool find_all,
 			   bool &result);
@@ -165,7 +167,8 @@ bool db_json_doc_is_uncomparable (const JSON_DOC *doc);
 int db_value_to_json_doc (const DB_VALUE &db_val, bool copy_json, JSON_DOC_STORE &json_doc);
 int db_value_to_json_value (const DB_VALUE &db_val, JSON_DOC_STORE &json_doc);
 void db_make_json_from_doc_store_and_release (DB_VALUE &value, JSON_DOC_STORE &doc_store);
-int db_value_to_json_path (const DB_VALUE *path_value, FUNC_TYPE fcode, const char **path_str);
+int db_value_to_json_path (const DB_VALUE &path_value, FUNC_TYPE fcode, std::string &path_str);
+int db_value_to_json_key (const DB_VALUE &db_val, std::string &key_str);
 
 int db_json_normalize_path_string (const char *pointer_path, std::string &normalized_path);
 template <typename Fn, typename... Args>

--- a/src/query/scan_json_table.cpp
+++ b/src/query/scan_json_table.cpp
@@ -362,7 +362,7 @@ namespace cubscan
       cursor_arg.m_input_doc.clear ();
 
       // extract input document
-      error_code = db_json_extract_document_from_path (&document, {node.m_path}, cursor_arg.m_input_doc);
+      error_code = db_json_extract_document_from_path (&document, node.m_path, cursor_arg.m_input_doc);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();

--- a/src/xasl/access_json_table.cpp
+++ b/src/xasl/access_json_table.cpp
@@ -131,7 +131,7 @@ namespace cubxasl
       JSON_DOC_STORE docp;
       TP_DOMAIN_STATUS status_cast = TP_DOMAIN_STATUS::DOMAIN_COMPATIBLE;
 
-      error_code = db_json_extract_document_from_path (&input, {m_path}, docp);
+      error_code = db_json_extract_document_from_path (&input, m_path, docp);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23539

Replace all unchecked db_get_string with db_value_to_json_key and db_value_json_path. Update db_value_to_json_path and db_json_extract_document_from_path signatures to use strings instead of `const char *`.