### PR TITLE
[CBRD-23546] wait pending request to close connection

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1105,6 +1105,7 @@ net_server_conn_down (THREAD_ENTRY * thread_p, CSS_THREAD_ARG arg)
   int client_id;
   int local_tran_index;
   THREAD_ENTRY *suspended_p;
+  size_t loop_count_for_pending_request = 0;
 
   if (thread_p == NULL)
     {
@@ -1225,6 +1226,21 @@ loop:
   if (thrd_cnt > 0)
     {
       goto loop;
+    }
+
+  if (conn_p->has_pending_request () && !css_is_shutdowning_server ())
+    {
+      // need to wait for pending request
+      thread_sleep (50);	/* 50 msec */
+      if (++loop_count_for_pending_request >= 10)
+	{
+	  // too long...
+	  assert (false);
+	}
+      else
+	{
+	  goto loop;
+	}
     }
 
   logtb_set_tran_index_interrupt (thread_p, tran_index, false);

--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -481,7 +481,9 @@ struct css_conn_entry
 private:
   // note - I want to protect this.
   int transaction_id;
-    std::atomic < size_t > pending_request_count;
+  // *INDENT-OFF*
+  std::atomic<size_t> pending_request_count;
+  // *INDENT-ON*
 #else				// not c++ = c
   int transaction_id;
 #endif				// not c++ = c

--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -51,6 +51,10 @@
 #include <pthread.h>
 #endif /* !WINDOWS && SERVER_MODE */
 
+#if defined (__cplusplus)
+#include <atomic>
+#endif // C++
+
 #define NUM_MASTER_CHANNEL 1
 
 /*
@@ -470,9 +474,14 @@ struct css_conn_entry
   void set_tran_index (int tran_index);
   int get_tran_index (void);
 
+  void add_pending_request ();
+  void start_request ();
+  bool has_pending_request () const;
+
 private:
   // note - I want to protect this.
   int transaction_id;
+    std::atomic < size_t > pending_request_count;
 #else				// not c++ = c
   int transaction_id;
 #endif				// not c++ = c

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2921,4 +2921,22 @@ css_conn_entry::get_tran_index ()
   assert (transaction_id != LOG_SYSTEM_TRAN_INDEX);
   return transaction_id;
 }
+
+void
+css_conn_entry::add_pending_request ()
+{
+  ++pending_request_count;
+}
+
+void
+css_conn_entry::start_request ()
+{
+  --pending_request_count;
+}
+
+bool
+css_conn_entry::has_pending_request () const
+{
+  return pending_request_count != 0;
+}
 // *INDENT-ON*

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2780,7 +2780,7 @@ css_server_external_task::execute (context_type &thread_ref)
   session_state *session_p = thread_ref.conn_entry != NULL ? thread_ref.conn_entry->session_p : NULL;
   if (session_p != NULL)
     {
-      thread_ref.private_lru_index = session_get_private_lru_idx (thread_ref.conn_entry->session_p);
+      thread_ref.private_lru_index = session_get_private_lru_idx (session_p);
     }
   else
     {

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2733,6 +2733,7 @@ css_push_server_task (CSS_CONN_ENTRY &conn_ref)
   //       randomly pushed to cores that are full. some of those tasks may belong to threads holding locks. as a
   //       consequence, lock waiters may wait longer or even indefinitely if we are really unlucky.
   //
+  conn_ref.add_pending_request ();
   thread_get_manager ()->push_task_on_core (css_Server_request_worker_pool, new css_server_task (conn_ref),
                                             static_cast<size_t> (conn_ref.idx));
 }
@@ -2746,6 +2747,8 @@ css_push_external_task (CSS_CONN_ENTRY *conn, cubthread::entry_task *task)
 void
 css_server_task::execute (context_type &thread_ref)
 {
+  m_conn.start_request ();
+
   thread_ref.conn_entry = &m_conn;
   session_state *session_p = thread_ref.conn_entry->session_p;
 
@@ -2773,7 +2776,9 @@ void
 css_server_external_task::execute (context_type &thread_ref)
 {
   thread_ref.conn_entry = m_conn;
-  if (thread_ref.conn_entry != NULL && thread_ref.conn_entry->session_p != NULL)
+
+  session_state *session_p = thread_ref.conn_entry != NULL ? thread_ref.conn_entry->session_p : NULL;
+  if (session_p != NULL)
     {
       thread_ref.private_lru_index = session_get_private_lru_idx (thread_ref.conn_entry->session_p);
     }

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2747,10 +2747,11 @@ void
 css_server_task::execute (context_type &thread_ref)
 {
   thread_ref.conn_entry = &m_conn;
+  session_state *session_p = thread_ref.conn_entry->session_p;
 
-  if (thread_ref.conn_entry->session_p != NULL)
+  if (session_p != NULL)
     {
-      thread_ref.private_lru_index = session_get_private_lru_idx (thread_ref.conn_entry->session_p);
+      thread_ref.private_lru_index = session_get_private_lru_idx (session_p);
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23546

Connection may be closed between pushing a request from client to worker pool and actually running it. Reusing connection resets the session_p field of CSS_CONN_ENTRY. If the thread that runs this lost request is preempted right when connection is reused, it is possible to generate reported crash.

Fix by tracking pending requests (pushed but not yet executed) and waiting for all of them to be accounted before closing connection.