### PR TITLE
[CBRD-23544] btree_compare_key set error for different collation

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -18710,7 +18710,7 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
 	{
 	  // check strings codeset
 	  if (TP_IS_STRING_TYPE (key1_type) && TP_IS_STRING_TYPE (key2_type)
-	      && db_get_string_codeset (key1) != db_get_string_codeset (key2))
+	      && db_get_string_collation (key1) != db_get_string_collation (key2))
 	    {
 	      // not comparable
 	      are_types_comparable = false;

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -18704,8 +18704,20 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
 	  return DB_UNK;
 	}
 
-      if (TP_ARE_COMPARABLE_KEY_TYPES (key1_type, key2_type) && TP_ARE_COMPARABLE_KEY_TYPES (key1_type, dom_type)
-	  && TP_ARE_COMPARABLE_KEY_TYPES (key2_type, dom_type))
+      bool are_types_comparable = TP_ARE_COMPARABLE_KEY_TYPES (key1_type, key2_type)
+	&& TP_ARE_COMPARABLE_KEY_TYPES (key1_type, dom_type) && TP_ARE_COMPARABLE_KEY_TYPES (key2_type, dom_type);
+      if (are_types_comparable)
+	{
+	  // check strings codeset
+	  if (TP_IS_STRING_TYPE (key1_type) && TP_IS_STRING_TYPE (key2_type)
+	      && db_get_string_codeset (key1) != db_get_string_codeset (key2))
+	    {
+	      // not comparable
+	      are_types_comparable = false;
+	    }
+	}
+
+      if (are_types_comparable)
 	{
 	  c = key_domain->type->cmpval (key1, key2, do_coercion, total_order, NULL, key_domain->collation_id);
 	}

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -18704,11 +18704,12 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
 	  return DB_UNK;
 	}
 
-      bool are_types_comparable = TP_ARE_COMPARABLE_KEY_TYPES (key1_type, key2_type)
-	&& TP_ARE_COMPARABLE_KEY_TYPES (key1_type, dom_type) && TP_ARE_COMPARABLE_KEY_TYPES (key2_type, dom_type);
+      bool are_types_comparable = (TP_ARE_COMPARABLE_KEY_TYPES (key1_type, key2_type)
+				   && TP_ARE_COMPARABLE_KEY_TYPES (key1_type, dom_type)
+				   && TP_ARE_COMPARABLE_KEY_TYPES (key2_type, dom_type));
       if (are_types_comparable)
 	{
-	  // check strings codeset
+	  // check strings collation
 	  if (TP_IS_STRING_TYPE (key1_type) && TP_IS_STRING_TYPE (key2_type)
 	      && db_get_string_collation (key1) != db_get_string_collation (key2))
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23544

Force tp_value_compare_with_error call if keys are strings with different collation.