### PR TITLE
[CBRD-23149] file_create: remove no error safe-guard

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -3830,7 +3830,6 @@ exit:
 	}
       else
 	{
-	  ASSERT_NO_ERROR ();
 	  log_sysop_end_logical_undo (thread_p, RVFL_DESTROY, NULL, sizeof (*vfid), (char *) vfid);
 	}
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23149

Remove annoying safe-guard. It often falsely flags because of errors leaked from other operations.