### PR TITLE
[CBRD-23548] Severity of ER_IO_SYNC as fatal error.

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -4495,7 +4495,8 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FIL
 
   if (ret != 0)
     {
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_SYNC, 1, (vlabel ? vlabel : "Unknown"));
+      /* sync error is not alwasy handled and I am not sure a proper safe handling is possible: raise as fatal error */
+      er_set_with_oserror (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_SYNC, 1, (vlabel ? vlabel : "Unknown"));
       return NULL_VOLDES;
     }
   else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23548

Severity of ER_IO_SYNC as fatal error.