### PR TITLE
[CBRD-23559] fix bad scancache usages

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -21668,6 +21668,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
   int *attr_ids = NULL;
   int function_asc_desc;
   HEAP_SCANCACHE scan;
+  bool scancache_inited = false;
   RECDES class_record;
   DISK_REPR *disk_repr_p = NULL;
   char *class_name = NULL;
@@ -21738,6 +21739,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 
   /* read heap class record, get class representation */
   heap_scancache_quick_start_root_hfid (thread_p, &scan);
+  scancache_inited = true;
 
   if (heap_get_class_record (thread_p, class_oid, &class_record, &scan, PEEK) != S_SUCCESS)
     {
@@ -22016,6 +22018,7 @@ qexec_execute_build_indexes (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
     {
       GOTO_EXIT_ON_ERROR;
     }
+  scancache_inited = false;
 
   if (qexec_end_mainblock_iterations (thread_p, xasl, xasl_state, &tplrec) != NO_ERROR)
     {
@@ -22085,7 +22088,11 @@ exit_on_error:
       heap_classrepr_free_and_init (rep, &idx_incache);
     }
 
-  heap_scancache_end (thread_p, &scan);
+  if (scancache_inited)
+    {
+      heap_scancache_end (thread_p, &scan);
+      scancache_inited = false;
+    }
 
 #if defined(SERVER_MODE)
   /* query execution error must be set up before qfile_close_list(). */
@@ -22626,6 +22633,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
   DB_VALUE **out_values = NULL;
   REGU_VARIABLE_LIST regu_var_p;
   HEAP_SCANCACHE scan;
+  bool scancache_inited = false;
   RECDES class_record;
   OID *class_oid = NULL;
   volatile int idx_val;
@@ -22663,6 +22671,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
     }
 
   heap_scancache_quick_start_root_hfid (thread_p, &scan);
+  scancache_inited = true;
 
   assert (xasl_state != NULL);
   class_oid = &(xasl->spec_list->s.cls_node.cls_oid);
@@ -22985,6 +22994,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
     {
       GOTO_EXIT_ON_ERROR;
     }
+  scancache_inited = false;
 
   if (qexec_end_mainblock_iterations (thread_p, xasl, xasl_state, &tplrec) != NO_ERROR)
     {
@@ -23021,7 +23031,10 @@ exit_on_error:
       heap_classrepr_free_and_init (rep, &idx_incache);
     }
 
-  heap_scancache_end (thread_p, &scan);
+  if (scancache_inited)
+    {
+      heap_scancache_end (thread_p, &scan);
+    }
 
 #if defined(SERVER_MODE)
   /* query execution error must be set up before qfile_close_list(). */

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -4391,6 +4391,7 @@ catcls_compile_catalog_classes (THREAD_ENTRY * thread_p)
 	  if (error != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
+	      (void) heap_scancache_end (thread_p, &scan);
 	      return error;
 	    }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -10724,8 +10724,8 @@ heap_class_get_partition_info (THREAD_ENTRY * thread_p, const OID * class_oid, O
   scan_cache.mvcc_snapshot = logtb_get_mvcc_snapshot (thread_p);
   if (scan_cache.mvcc_snapshot == NULL)
     {
-      error = er_errid ();
-      return (error == NO_ERROR ? ER_FAILED : error);
+      error = ER_FAILED;
+      goto cleanup;
     }
 
   if (heap_get_class_record (thread_p, class_oid, &recdes, &scan_cache, PEEK) != S_SUCCESS)

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -6528,6 +6528,7 @@ locator_force_for_multi_update (THREAD_ENTRY * thread_p, LC_COPYAREA * force_are
 
   if (locator_manyobj_flag_is_set (mobjs, END_MULTI_UPDATE))
     {
+      // *INDENT-OFF*
       for (const auto & it:tdes->m_multiupd_stats.get_map ())
 	{
 	  if (!it.second.is_unique ())
@@ -6543,6 +6544,7 @@ locator_force_for_multi_update (THREAD_ENTRY * thread_p, LC_COPYAREA * force_are
 	      goto error;
 	    }
 	}
+      // *INDENT-ON*
       tdes->m_multiupd_stats.clear ();
     }
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -6528,7 +6528,7 @@ locator_force_for_multi_update (THREAD_ENTRY * thread_p, LC_COPYAREA * force_are
 
   if (locator_manyobj_flag_is_set (mobjs, END_MULTI_UPDATE))
     {
-    for (const auto & it:tdes->m_multiupd_stats.get_map ())
+      for (const auto & it:tdes->m_multiupd_stats.get_map ())
 	{
 	  if (!it.second.is_unique ())
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23559

#2147 leads to me these bad usages. 
Fixes are:
* bad free: qexec_execute_build_indexes, qexec_execute_build_columns
* leak: catcls_compile_catalog_classes, heap_class_get_partition_info, catalog_fixup_missing_disk_representation(unused)