### PR TITLE
[CBRD-23560] Fix slip of LexerError

### DIFF
--- a/src/loaddb/load_scanner.hpp
+++ b/src/loaddb/load_scanner.hpp
@@ -74,7 +74,7 @@ namespace cubload
 	 *  set, but it will not fail the session is --data-check-only is enabled, and it will just report the line
 	 *  where the parsing error occured.
 	 */
-	m_error_handler.on_error_with_line (LOADDB_MSG_LEX_ERROR);
+	m_error_handler.on_error_with_line (m_error_handler.get_scanner_lineno (), LOADDB_MSG_LEX_ERROR);
 	m_error_handler.on_syntax_failure (true);   // Use scanner line in this case.
       }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23560

Fixed a bug regarding `LexerError`. Since the approach is to raise an error and then try to fail the session if `--data-file-check-only` is not enabled, reporting the error would use the driver line, instead of the scanner line. This patch will fix it and use the scanner line instead.
