### PR TITLE
[CBRD-23563] Fix slip of SA_MODE when parsing has not started yet

### DIFF
--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -1631,6 +1631,12 @@ display_error_line (int adjust)
       lineno = ldr_Driver->get_start_line ();
     }
 
+  if (lineno == 0)
+    {
+      // Most likely parsing hasn't started yet so we should not print the line number.
+      return;
+    }
+
   fprintf (stderr, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB, LOADDB_MSG_LINE), lineno);
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23563

Fixed slip of `SA_MODE` error reporting when `-t` parameter is enabled. If any errors occur before the parsing of the object file has started, we should never report the error line since is not concise.