### PR TITLE
[CBRD-23095] Use the aligned size of the record

### DIFF
--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13812,7 +13812,7 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
 
 	  // Add this record to the recdes array and increase the accumulated size.
 	  recdes_array.push_back (local_record);
-	  accumulated_records_size += local_record.length;
+	  accumulated_records_size += DB_ALIGN (local_record.length, DOUBLE_ALIGNMENT);
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23095

When we compute the size of the records that might fit in a page during `locator_multi_insert`, we should use the aligned size of the record to be sure that subsequent insert operations are successful.