### PR TITLE
[CBRD-23566] Fix bad line error report during schema load

### DIFF
--- a/src/compat/db.h
+++ b/src/compat/db.h
@@ -227,7 +227,7 @@ extern "C"
 }
 #endif
 extern int db_get_parser_line_col (DB_SESSION * session, int *line, int *col);
-extern void db_get_line_of_last_statement (DB_SESSION * session, int *line);
+extern int db_get_line_of_last_statement (DB_SESSION * session, int stmt_id);
 extern int db_get_line_col_of_1st_error (DB_SESSION * session, DB_QUERY_ERROR * linecol);
 extern DB_VALUE *db_get_hostvars (DB_SESSION * session);
 extern char **db_get_lock_classes (DB_SESSION * session);

--- a/src/compat/db.h
+++ b/src/compat/db.h
@@ -227,7 +227,7 @@ extern "C"
 }
 #endif
 extern int db_get_parser_line_col (DB_SESSION * session, int *line, int *col);
-extern int db_get_line_of_last_statement (DB_SESSION * session, int stmt_id);
+extern int db_get_line_of_statement (DB_SESSION * session, int stmt_id);
 extern int db_get_line_col_of_1st_error (DB_SESSION * session, DB_QUERY_ERROR * linecol);
 extern DB_VALUE *db_get_hostvars (DB_SESSION * session);
 extern char **db_get_lock_classes (DB_SESSION * session);

--- a/src/compat/db.h
+++ b/src/compat/db.h
@@ -227,6 +227,7 @@ extern "C"
 }
 #endif
 extern int db_get_parser_line_col (DB_SESSION * session, int *line, int *col);
+extern void db_get_line_of_last_statement (DB_SESSION * session, int *line);
 extern int db_get_line_col_of_1st_error (DB_SESSION * session, DB_QUERY_ERROR * linecol);
 extern DB_VALUE *db_get_hostvars (DB_SESSION * session);
 extern char **db_get_lock_classes (DB_SESSION * session);

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -4196,13 +4196,15 @@ db_can_execute_statement_with_autocommit (PARSER_CONTEXT * parser, PT_NODE * sta
 int
 db_get_line_of_statement (DB_SESSION * session, int stmt_id)
 {
+  assert (session->statements != NULL);
+
   // Safeguards
-  if (stmt_id <= 0 || stmt_id > session->dimension)
+  if (stmt_id <= 0 || stmt_id > session->dimension || session->statements == NULL
+      || session->statements[stmt_id - 1] == NULL)
     {
       // stmt_id is not valid.
       return -1;
     }
-  assert (session->statements != NULL);
 
   // Get last statement
   return session->statements[stmt_id - 1]->line_number;

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -4194,13 +4194,10 @@ db_can_execute_statement_with_autocommit (PARSER_CONTEXT * parser, PT_NODE * sta
 }
 
 int
-db_get_line_of_last_statement (DB_SESSION * session, int stmt_id)
+db_get_line_of_statement (DB_SESSION * session, int stmt_id)
 {
-  if (stmt_id < 0)
-    {
-      return 0;
-    }
-
+  // Safeguards
+  assert (stmt_id > 0);
   assert (session->statements != NULL);
 
   // Get last statement

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -4193,21 +4193,16 @@ db_can_execute_statement_with_autocommit (PARSER_CONTEXT * parser, PT_NODE * sta
   return can_execute_statement_with_commit;
 }
 
-void
-db_get_line_of_last_statement (DB_SESSION * session, int *line)
+int
+db_get_line_of_last_statement (DB_SESSION * session, int stmt_id)
 {
-  int st_index = session->dimension;
-
-  if (st_index == 0)
+  if (stmt_id < 0)
     {
-      return;
+      return 0;
     }
 
   assert (session->statements != NULL);
 
-  if (line)
-    {
-      // Get last statement
-      *line = session->statements[st_index - 1]->line_number;
-    }
+  // Get last statement
+  return session->statements[stmt_id - 1]->line_number;
 }

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -4197,7 +4197,11 @@ int
 db_get_line_of_statement (DB_SESSION * session, int stmt_id)
 {
   // Safeguards
-  assert (stmt_id > 0);
+  if (stmt_id <= 0 || stmt_id > session->dimension)
+    {
+      // stmt_id is not valid.
+      return -1;
+    }
   assert (session->statements != NULL);
 
   // Get last statement

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -4192,3 +4192,22 @@ db_can_execute_statement_with_autocommit (PARSER_CONTEXT * parser, PT_NODE * sta
 
   return can_execute_statement_with_commit;
 }
+
+void
+db_get_line_of_last_statement (DB_SESSION * session, int *line)
+{
+  int st_index = session->dimension;
+
+  if (st_index == 0)
+    {
+      return;
+    }
+
+  assert (session->statements != NULL);
+
+  if (line)
+    {
+      // Get last statement
+      *line = session->statements[st_index - 1]->line_number;
+    }
+}

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -910,7 +910,7 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
   int stmt_cnt, stmt_id = 0, stmt_type;
   int executed_cnt = 0;
   int parser_start_line_no;
-  int parser_end_line_no = 0;
+  int statement_line_no = 0;
   int check_line_no = true;
 
   if ((*start_line) > 1)
@@ -960,13 +960,13 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
 	  db_close_session (session);
 	  goto end;
 	}
-      parser_start_line_no = parser_end_line_no;
+      parser_start_line_no = statement_line_no;
 
       stmt_cnt = db_parse_one_statement (session);
       if (stmt_cnt > 0)
 	{
 	  stmt_id = db_compile_statement (session);
-	  parser_end_line_no = db_get_line_of_last_statement (session, stmt_id);
+	  statement_line_no = db_get_line_of_statement (session, stmt_id);
 	}
 
       if (stmt_cnt <= 0 || stmt_id <= 0)
@@ -1018,8 +1018,8 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
 	{
 	  db_commit_transaction ();
 	  print_log_msg (args->verbose_commit, "%8d statements executed. Commit transaction at line %d\n", executed_cnt,
-			 parser_end_line_no);
-	  *start_line = parser_end_line_no + 1;
+			 statement_line_no);
+	  *start_line = statement_line_no + 1;
 	}
       print_log_msg ((int) args->verbose, "Total %8d statements executed.\r", executed_cnt);
       fflush (stdout);
@@ -1032,7 +1032,7 @@ end:
     }
   else
     {
-      *start_line = parser_end_line_no + 1;
+      *start_line = statement_line_no + 1;
       print_log_msg (1, "Total %8d statements executed.\n", executed_cnt);
       fflush (stdout);
       db_commit_transaction ();

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1017,7 +1017,7 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
 	{
 	  db_commit_transaction ();
 	  print_log_msg (args->verbose_commit, "%8d statements executed. Commit transaction at line %d\n", executed_cnt,
-			 parser_end_line_no);
+			 parser_start_line_no);
 	  *start_line = parser_end_line_no + 1;
 	}
       print_log_msg ((int) args->verbose, "Total %8d statements executed.\r", executed_cnt);

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -965,8 +965,8 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
       stmt_cnt = db_parse_one_statement (session);
       if (stmt_cnt > 0)
 	{
-	  db_get_line_of_last_statement (session, &parser_end_line_no);
 	  stmt_id = db_compile_statement (session);
+	  parser_end_line_no = db_get_line_of_last_statement (session, stmt_id);
 	}
 
       if (stmt_cnt <= 0 || stmt_id <= 0)

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -909,8 +909,7 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
   int error = NO_ERROR;
   int stmt_cnt, stmt_id = 0, stmt_type;
   int executed_cnt = 0;
-  int parser_start_line_no;
-  int last_statement_line_no = 0;
+  int last_statement_line_no = 0;	// tracks line no of the last successfully executed stmt. -1 for failed ones.
   int check_line_no = true;
 
   if ((*start_line) > 1)
@@ -960,7 +959,6 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
 	  db_close_session (session);
 	  goto end;
 	}
-      parser_start_line_no = last_statement_line_no;
 
       stmt_cnt = db_parse_one_statement (session);
       if (stmt_cnt > 0)
@@ -974,7 +972,9 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
 	{
 	  DB_SESSION_ERROR *session_error;
 	  int line, col;
-	  if ((session_error = db_get_errors (session)) != NULL)
+
+	  session_error = db_get_errors (session);
+	  if (session_error != NULL)
 	    {
 	      do
 		{

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -980,7 +980,7 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
 		  session_error = db_get_next_error (session_error, &line, &col);
 		  if (line >= 0)
 		    {
-		      // We need -1 here since both start_line will offset the output.
+		      // We need -1 here since start_line will offset the output.
 		      print_log_msg (1, "In %s line %d,\n", file_name, line + (*start_line) - 1);
 		      print_log_msg (1, "ERROR: %s \n", db_error_string (3));
 		      assert (er_errid () != NO_ERROR);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23566

Verbose messages were reported wrongly using the line from the parser. We instead use the line of the last compiled statement to print messages now.

This was a legacy bug.