### PR TITLE
[CBRD-23568] correct return type as varchar

### DIFF
--- a/src/parser/func_type.cpp
+++ b/src/parser/func_type.cpp
@@ -1048,6 +1048,8 @@ namespace func_type
 	    // always return string without precision
 	    m_node->type_enum = pt_to_variable_size_type (m_node->type_enum);
 	    m_node->data_type->info.data_type.precision = TP_FLOATING_PRECISION_VALUE;
+	    m_node->data_type->type_enum = pt_to_variable_size_type (m_node->type_enum);
+	    assert (m_node->type_enum == m_node->data_type->type_enum);
 	  }
       }
     else

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -3217,7 +3217,7 @@ btree_sort_get_next (THREAD_ENTRY * thread_p, RECDES * temp_recdes, void *arg)
 	  continue;
 	}
 
-      key_len = pr_data_writeval_disk_size (dbvalue_ptr);
+      key_len = sort_args->key_type->type->get_disk_size_of_value (dbvalue_ptr);
 
       if (key_len > 0)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23568

Issue is caused by an inconsistency between the result of db_json_quote function and parent regu variable domain. Reguvar domain is generated based on node.data_type.type_enum. In a special case like `JSON_QUOTE ( CAST ( int_col as CHAR(10) ) )`, node.type_enum is converted from char to varchar, precision is set floating preicision (-1), but node.data_type.type_enum remains char. The regu variable domain char and, in some cases, it is used as expected domain. In other cases, expected domain is based on node.type_enum.

A simple repro for this inconsistency (crash) is the next scenario:
```sql
  CREATE TABLE t (a INT);
  INSERT INTO t VALUES (1);
  SELECT JSON_QUOTE (CAST (a as CHAR(10)));
```

Fixes:

  - set variable string type in both node.type_enum and node.data_type.type_enum
  - use same type to compute key_len and to write the value in btree_sort_get_next