### PR TITLE
[CBRD-23581] fix bad usages of gethostname

### DIFF
--- a/src/broker/broker_shm.c
+++ b/src/broker/broker_shm.c
@@ -739,7 +739,7 @@ shm_id_to_name (int shm_key)
 static int
 get_host_ip (unsigned char *ip_addr)
 {
-  char hostname[64];
+  char hostname[CUB_MAXHOSTNAMELEN];
   struct hostent *hp;
 
   if (gethostname (hostname, sizeof (hostname)) < 0)

--- a/src/broker/cas_network.c
+++ b/src/broker/cas_network.c
@@ -660,7 +660,7 @@ retry_poll:
 static int
 get_host_ip (unsigned char *ip_addr)
 {
-  char hostname[64];
+  char hostname[CUB_MAXHOSTNAMELEN];
   struct hostent *hp;
 
   if (gethostname (hostname, sizeof (hostname)) < 0)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23581

probably `gethostname` dead-ended `ENAMETOOLONG`.