### PR TITLE
[CBRD-23599] Error occurs if select list has in the order of an scalar subquery and expression which include an analytic function

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -1107,6 +1107,10 @@ pt_is_analytic_node (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *co
     {
       *continue_walk = PT_LIST_WALK;
     }
+  else
+    {
+      *continue_walk = PT_CONTINUE_WALK;
+    }
 
   return tree;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23599

To check whether the select list contains an analytic function, pt_is_analytic_node () is invoked in traversing for the select list nodes. In order not to traverse inside of subquery, it changes traversal behavior into PT_LIST_WALK. But the traversal behavior has to be restored from the next node.