### PR TITLE
[CBRD-23600] Unexpected rounding up a numeric value when the case expressions are used recursively

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -10186,24 +10186,24 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 		  && (nextcase->info.expr.op == PT_CASE || nextcase->info.expr.op == PT_DECODE))
 		{
 		  /* cast nextcase->arg1 to common type */
-		  arg1 = nextcase->info.expr.arg1;
-		  arg1_type = arg1->type_enum;
-		  if (arg1_type != common_type && arg1_type != PT_TYPE_NULL)
+		  PT_NODE *next_arg1 = nextcase->info.expr.arg1;
+		  PT_TYPE_ENUM next_arg1_type = next_arg1->type_enum;
+		  if (next_arg1_type != common_type && next_arg1_type != PT_TYPE_NULL)
 		    {
-		      if (pt_coerce_expression_argument (parser, nextcase, &arg1, common_type, NULL) != NO_ERROR)
+		      if (pt_coerce_expression_argument (parser, nextcase, &next_arg1, common_type, NULL) != NO_ERROR)
 			{
 			  /* abandon implicit casting and return error */
 			  node->type_enum = PT_TYPE_NONE;
 			  goto error;
 			}
-		      nextcase->info.expr.arg1 = arg1;
+		      nextcase->info.expr.arg1 = next_arg1;
 		      /* nextcase was already evaluated and may have a data_type set. We need to replace it with the
 		       * cast data_type */
 		      nextcase->type_enum = common_type;
 		      if (nextcase->data_type)
 			{
 			  parser_free_tree (parser, nextcase->data_type);
-			  nextcase->data_type = parser_copy_tree_list (parser, arg1->data_type);
+			  nextcase->data_type = parser_copy_tree_list (parser, next_arg1->data_type);
 			}
 		    }
 		  /* set nextcase to nextcase->arg2 and continue */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23600

When the CASE expressions are used recursively and values specified in the THEN clause are numeric and integer types order repeatedly, one of the numeric values is rounded up unexpectedly.

this bug causes because the arg1 pointer variable for PT_NODE is incorrectly re-used at the part of checking the next case clause. please see the changes in this PR. To make a common data type of expression, pt_upd_domain_info () is invoked with the possibly wrong assigned arg1. As a consequence, the data type is going to be updated incorrect precision and scale.

It fixes to keep the arg1 from being re-used incorrectly.