### PR TITLE
[CBRD-23601] Initialize the extra version number into zero

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,8 +192,9 @@ if(VERSION_MATCHES_LENGTH GREATER 3)
 else(VERSION_MATCHES_LENGTH GREATER 3)
   find_package(Git)
   if(EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT_FOUND)
+    set(CUBRID_MAJOR_START_DATE "2019-12-13")
     if(GIT_VERSION VERSION_GREATER 1.7.6)
-      execute_process(COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD
+      execute_process(COMMAND ${GIT_EXECUTABLE} rev-list --count --after ${CUBRID_MAJOR_START_DATE} HEAD
         OUTPUT_VARIABLE commit_count RESULT_VARIABLE git_result
         ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
@@ -208,7 +209,7 @@ else(VERSION_MATCHES_LENGTH GREATER 3)
       #
       # If both fixes fail, just replace execute_process(...) with set (commit_count 0). It is not a critical step to generate the project.
       # Also you may send us a message at https://www.cubrid.org/contact
-      execute_process(COMMAND ${GIT_EXECUTABLE} log --oneline
+      execute_process(COMMAND ${GIT_EXECUTABLE} log --after ${CUBRID_MAJOR_START_DATE} --oneline
         COMMAND wc -l
         OUTPUT_VARIABLE commit_count RESULT_VARIABLE git_result
         ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/build.sh
+++ b/build.sh
@@ -122,11 +122,12 @@ function build_initialize ()
   minor_version=$(echo $version | cut -d . -f 2)
   patch_version=$(echo $version | cut -d . -f 3)
   extra_version=$(echo $version | cut -d . -f 4)
+  major_start_date='2019-12-13'
   if [ "x$extra_version" != "x" ]; then
     serial_number=$(echo $extra_version | cut -d - -f 1)
   elif [ -d $source_dir/.git ]; then
-    serial_number=$(cd $source_dir && git rev-list --count HEAD 2> /dev/null)
-    [ $? -ne 0 ] && serial_number=$(cd $source_dir && git log --oneline | wc -l)
+    serial_number=$(cd $source_dir && git rev-list --after $major_start_date --count HEAD 2> /dev/null)
+    [ $? -ne 0 ] && serial_number=$(cd $source_dir && git log --after $major_start_date --oneline | wc -l)
     hash_tag=$(cd $source_dir && git rev-parse --short=7 HEAD)
     extra_version="$serial_number-$hash_tag"
   else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23601

As CUBRID bumping up major build number for damson milestone, CUBIRD_EXTRA_VERSION needs to be initialized to zero.
CUBRID's versioning rule is as follow;
```
${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}.${CUBRID_PATCH_VERSION}.${CUBRID_EXTRA_VERSION}${CUBRID_HASH_TAG}
```