### PR TITLE
[CBRD-22925] An error occurs when there are two 'IN' operators and rewriting predicate to reduce the equality term.

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -2010,6 +2010,11 @@ qo_analyze_term (QO_TERM * term, int term_type)
 	case PT_IS_IN:
 	case PT_EQ_SOME:
 	  /* temporary guess; LHS could be a indexable segment */
+	  if (op_type == PT_IS_IN || op_type == PT_EQ_SOME)
+	    {
+	      /* 'RANGE LIST' flag is needed for 'IN' OP to avoid duplication of RANGE OP when index scan */
+	      QO_TERM_SET_FLAG (term, QO_TERM_RANGELIST);
+	    }
 	  lhs_indexable = true;
 	  /* FALLTHRU */
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -638,7 +638,7 @@ pt_lambda_node (PARSER_CONTEXT * parser, PT_NODE * tree_or_name, void *void_arg,
 	      if (lambda_arg->type == 1)
 		{
 		  /* at here, do clear. later is updated in pt_semantic_type */
-		  tree_or_name->type_enum = PT_TYPE_NONE;
+		  tree_or_name->info.function.is_type_checked = false;
 		}
 
 	      lambda_arg->replace_num = 0;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -12980,7 +12980,7 @@ pt_eval_function_type_old (PARSER_CONTEXT * parser, PT_NODE * node)
 	}
     }
 
-  if (node->type_enum == PT_TYPE_NONE || node->data_type == NULL)
+  if (node->type_enum == PT_TYPE_NONE || node->data_type == NULL || !(node->info.function.is_type_checked))
     {
       /* determine function result type */
       switch (fcode)
@@ -13368,6 +13368,8 @@ pt_eval_function_type_old (PARSER_CONTEXT * parser, PT_NODE * node)
 	  node->data_type = parser_copy_tree_list (parser, arg_list->data_type);
 	  break;
 	}
+      /* to prevent recheck of function return type at pt_eval_function_type_old() */
+      node->info.function.is_type_checked = true;
     }
 
   /* collation checking */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22925

There are two problems.
1. The RHS of the 'IN' operator is not converted to the range (= or) format because of rewriting RHS's enum type to PT_TYPE_NONE.
The reason for changing to PT_TYPE_NONE is to recheck the type for the function set in pt_semantic_type ().
Use the function_info.is_type_checked variable to remove side-effects caused by changing to PT_TYPE_NONE.
2. Two range list index scans(range(1= or 2=), in (1,2) ) are selected as index keys.
'RANGE LIST' flag is set for 'IN' OP to avoid duplication of 'RANGE LIST' scan.