### PR TITLE
[CBRD-23612] Fix memory leak of compiled regex and pattern

### DIFF
--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4330,18 +4330,16 @@ db_string_rlike (const DB_VALUE * src, const DB_VALUE * pattern, const DB_VALUE 
 		 cub_regex_object ** comp_regex, char **comp_pattern, int *result)
 {
   int error_status = NO_ERROR;
-  char *rx_compiled_pattern = NULL;
-  cub_regex_object *rx_compiled_regex = NULL;
+
+  /* get compiled pattern and regex object */
+  char *rx_compiled_pattern = (comp_pattern != NULL) ? *comp_pattern : NULL;
+  cub_regex_object *rx_compiled_regex = (comp_regex != NULL) ? *comp_regex : NULL;
 
   {
     /* check for allocated DB values */
     assert (src != NULL);
     assert (pattern != NULL);
     assert (case_sensitive != NULL);
-
-    /* get compiled pattern and regex object */
-    rx_compiled_pattern = (comp_pattern != NULL) ? *comp_pattern : NULL;
-    rx_compiled_regex = (comp_regex != NULL) ? *comp_regex : NULL;
 
     /* check type */
     QSTR_CATEGORY src_category = qstr_get_category (src);
@@ -4446,18 +4444,18 @@ cleanup:
 	}
     }
 
-    if (comp_regex == NULL || comp_pattern == NULL)
+  if (comp_regex == NULL || comp_pattern == NULL)
     {
-        /* free memory if this function is invoked in constant folding */
+      /* free memory if this function is invoked in constant folding */
           // *INDENT-OFF*
         cubregex::clear (rx_compiled_regex, rx_compiled_pattern);
         // *INDENT-ON*
     }
-    else
+  else
     {
       /* pass compiled regex object and compiled pattern out to reuse them */
-        *comp_regex = rx_compiled_regex;
-        *comp_pattern = rx_compiled_pattern;
+      *comp_regex = rx_compiled_regex;
+      *comp_pattern = rx_compiled_pattern;
     }
 
   return error_status;
@@ -4503,14 +4501,12 @@ db_string_regexp_replace (DB_VALUE * result, DB_VALUE * args[], int const num_ar
 			  cub_regex_object ** comp_regex, char **comp_pattern)
 {
   int error_status = NO_ERROR;
-  char *rx_compiled_pattern = NULL;
-  cub_regex_object *rx_compiled_regex = NULL;
+
+  /* get compiled pattern and regex object */
+  char *rx_compiled_pattern = (comp_pattern != NULL) ? *comp_pattern : NULL;
+  cub_regex_object *rx_compiled_regex = (comp_regex != NULL) ? *comp_regex : NULL;
 
   {
-    /* get compiled pattern and regex object */
-    rx_compiled_pattern = (comp_pattern != NULL) ? *comp_pattern : NULL;
-    rx_compiled_regex = (comp_regex != NULL) ? *comp_regex : NULL;
-
     for (int i = 0; i < num_args; i++)
       {
 	DB_VALUE *arg = args[i];
@@ -4718,18 +4714,18 @@ exit:
     }
 
   if (comp_regex == NULL || comp_pattern == NULL)
-  {
+    {
       /* free memory if this function is invoked in constant folding */
       // *INDENT-OFF*
       cubregex::clear (rx_compiled_regex, rx_compiled_pattern);
       // *INDENT-ON*
-  }
+    }
   else
-  {
-    /* pass compiled regex object and compiled pattern out to reuse them */
+    {
+      /* pass compiled regex object and compiled pattern out to reuse them */
       *comp_regex = rx_compiled_regex;
       *comp_pattern = rx_compiled_pattern;
-  }
+    }
 
   return error_status;
 }

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4444,18 +4444,18 @@ cleanup:
 	}
     }
 
-  if (comp_regex == NULL || comp_pattern == NULL)
+    if (comp_regex == NULL || comp_pattern == NULL)
     {
-      /* free memory if this function is invoked in constant folding */
+        /* free memory if this function is invoked in constant folding */
           // *INDENT-OFF*
         cubregex::clear (rx_compiled_regex, rx_compiled_pattern);
         // *INDENT-ON*
     }
-  else
+    else
     {
       /* pass compiled regex object and compiled pattern out to reuse them */
-      *comp_regex = rx_compiled_regex;
-      *comp_pattern = rx_compiled_pattern;
+        *comp_regex = rx_compiled_regex;
+        *comp_pattern = rx_compiled_pattern;
     }
 
   return error_status;
@@ -4714,18 +4714,18 @@ exit:
     }
 
   if (comp_regex == NULL || comp_pattern == NULL)
-    {
+  {
       /* free memory if this function is invoked in constant folding */
       // *INDENT-OFF*
       cubregex::clear (rx_compiled_regex, rx_compiled_pattern);
       // *INDENT-ON*
-    }
+  }
   else
-    {
-      /* pass compiled regex object and compiled pattern out to reuse them */
+  {
+    /* pass compiled regex object and compiled pattern out to reuse them */
       *comp_regex = rx_compiled_regex;
       *comp_pattern = rx_compiled_pattern;
-    }
+  }
 
   return error_status;
 }

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4445,18 +4445,18 @@ cleanup:
 	}
     }
 
-    if (comp_regex == NULL || comp_pattern == NULL)
+  if (comp_regex == NULL || comp_pattern == NULL)
     {
-        /* free memory if this function is invoked in constant folding */
+      /* free memory if this function is invoked in constant folding */
           // *INDENT-OFF*
         cubregex::clear (rx_compiled_regex, rx_compiled_pattern);
         // *INDENT-ON*
     }
-    else
+  else
     {
       /* pass compiled regex object and compiled pattern out to reuse them */
-        *comp_regex = rx_compiled_regex;
-        *comp_pattern = rx_compiled_pattern;
+      *comp_regex = rx_compiled_regex;
+      *comp_pattern = rx_compiled_pattern;
     }
 
   return error_status;
@@ -4716,18 +4716,18 @@ exit:
     }
 
   if (comp_regex == NULL || comp_pattern == NULL)
-  {
+    {
       /* free memory if this function is invoked in constant folding */
       // *INDENT-OFF*
       cubregex::clear (rx_compiled_regex, rx_compiled_pattern);
       // *INDENT-ON*
-  }
+    }
   else
-  {
-    /* pass compiled regex object and compiled pattern out to reuse them */
+    {
+      /* pass compiled regex object and compiled pattern out to reuse them */
       *comp_regex = rx_compiled_regex;
       *comp_pattern = rx_compiled_pattern;
-  }
+    }
 
   return error_status;
 }

--- a/src/query/string_regex.cpp
+++ b/src/query/string_regex.cpp
@@ -132,8 +132,6 @@ namespace cubregex
 
     if (pattern != NULL)
       {
-	//delete[] pattern;
-	//pattern = NULL;
 	db_private_free_and_init (NULL, pattern);
       }
   }

--- a/src/query/string_regex.cpp
+++ b/src/query/string_regex.cpp
@@ -167,7 +167,7 @@ namespace cubregex
 	*  It is hacky code finding collating element pattern and throw error.
 	*/
 	char *collate_elem_pattern = "[[.";
-	int found = pattern.find ( std::string (collate_elem_pattern));
+	int found = std::string (pattern).find (collate_elem_pattern);
 	if (found != std::string::npos)
 	  {
 	    throw std::regex_error (std::regex_constants::error_collate);

--- a/src/query/string_regex.cpp
+++ b/src/query/string_regex.cpp
@@ -124,15 +124,17 @@ namespace cubregex
   void
   clear (cub_regex_object *&regex, char *&pattern)
   {
-    if (pattern != NULL)
-      {
-	db_private_free_and_init (NULL, pattern);
-      }
-
     if (regex != NULL)
       {
 	delete regex;
 	regex = NULL;
+      }
+
+    if (pattern != NULL)
+      {
+	//delete[] pattern;
+	//pattern = NULL;
+	db_private_free_and_init (NULL, pattern);
       }
   }
 
@@ -155,7 +157,7 @@ namespace cubregex
     return false;
   }
 
-  int compile (cub_regex_object *&rx_compiled_regex, const std::string &pattern,
+  int compile (cub_regex_object *&rx_compiled_regex, const char *pattern,
 	       const std::regex_constants::syntax_option_type reg_flags)
   {
     int error_status = NO_ERROR;

--- a/src/query/string_regex.hpp
+++ b/src/query/string_regex.hpp
@@ -73,7 +73,7 @@ namespace cubregex
 			       const std::string &pattern,
 			       const std::regex_constants::syntax_option_type reg_flags);
 
-  int compile (cub_regex_object *&rx_compiled_regex, const std::string &pattern,
+  int compile (cub_regex_object *&rx_compiled_regex, const char *pattern,
 	       const std::regex_constants::syntax_option_type reg_flags);
   int search (bool &result, const cub_regex_object &reg, const std::string &src);
   int replace (std::string &result, const cub_regex_object &reg, const std::string &src,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23612

This PR is to fix regression of #2186.
- moved getting a compiled pattern and regex object at the beginning of each function to avoid NULL is assigned wrongly when parameter checking is failed.
- fixed memory leak when regex object is created with reference std::string.
- slip of indentation inside of `*INDENT-OFF*` comment.