### PR TITLE
[apsisware/tesseractdb] [SC-107] Refactoring commit/abort in log_manager

### DIFF
--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -548,6 +548,8 @@ struct log_tdes
   log_postpone_cache m_log_postpone_cache;
 
   // *INDENT-OFF*
+
+  cubtx::complete_manager::id_type id_complete;
 #if defined (SERVER_MODE)
   cubreplication::source_copy_context *replication_copy_context;
 #endif

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -323,8 +323,8 @@ STATIC_INLINE void log_prepare_transaction_complete (THREAD_ENTRY * thread_p, LO
   __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE void log_complete_transaction_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool commmitted)
   __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE TRAN_STATE log_get_transaction_state_for_complete_logging (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
-__attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE TRAN_STATE log_get_transaction_state_for_complete_logging (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
+  __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE void log_complete_transaction_logging (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE void log_complete_transaction (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool is_committed)

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -149,7 +149,7 @@ extern TRAN_STATE log_abort_local (THREAD_ENTRY * thread_p, LOG_TDES * tdes, boo
 extern TRAN_STATE log_commit (THREAD_ENTRY * thread_p, int tran_index, bool retain_lock);
 extern TRAN_STATE log_abort (THREAD_ENTRY * thread_p, int tran_index);
 extern TRAN_STATE log_abort_partial (THREAD_ENTRY * thread_p, const char *savepoint_name, LOG_LSA * savept_lsa);
-extern TRAN_STATE log_complete (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_RECTYPE iscommitted,
+extern TRAN_STATE log_complete (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool iscommitted,
 				LOG_GETNEWTRID get_newtrid, LOG_WRITE_EOT_LOG wrote_eot_log);
 extern TRAN_STATE log_complete_for_2pc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_RECTYPE iscommitted,
 					LOG_GETNEWTRID get_newtrid);
@@ -171,7 +171,7 @@ extern void log_simulate_crash (THREAD_ENTRY * thread_p, int flush_log, int flus
 #endif
 extern void log_append_run_postpone (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DATA_ADDR * addr,
 				     const VPID * rcv_vpid, int length, const void *data, const LOG_LSA * ref_lsa);
-extern void log_append_finish_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * commit_lsa);
+extern void log_append_finish_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
 extern int log_get_next_nested_top (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postpone_lsa,
 				    LOG_TOPOP_RANGE ** out_nxtop_range_stack);
 extern void log_append_repl_info (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool is_commit);

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -4358,9 +4358,8 @@ log_recovery_finish_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 
       if (tdes->coord == NULL)
 	{
-	  LOG_LSA finish_lsa;
 	  assert (!LSA_ISNULL (&tdes->posp_nxlsa));
-	  log_append_finish_postpone (thread_p, tdes, &finish_lsa);
+	  (void) log_complete (thread_p, tdes, true, LOG_DONT_NEED_NEWTRID, LOG_NEED_TO_WRITE_EOT_LOG);
 	  logtb_free_tran_index (thread_p, tdes->tran_index);
 	}
     }
@@ -4369,7 +4368,7 @@ log_recovery_finish_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
       if (tdes->coord == NULL)
 	{
 	  // add 1-tran gc without postpone
-	  (void) log_complete (thread_p, tdes, LOG_COMMIT, LOG_DONT_NEED_NEWTRID, LOG_NEED_TO_WRITE_EOT_LOG);
+	  (void) log_complete (thread_p, tdes, true, LOG_DONT_NEED_NEWTRID, LOG_ALREADY_WROTE_EOT_LOG);
 	  logtb_free_tran_index (thread_p, tdes->tran_index);
 	}
     }
@@ -4605,7 +4604,7 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 	  && LSA_ISNULL (&tdes->undo_nxlsa))
 	{
 	  // todo: also take into account mccids set during redo
-	  (void) log_complete (thread_p, tdes, LOG_ABORT, LOG_DONT_NEED_NEWTRID, LOG_NEED_TO_WRITE_EOT_LOG);
+	  (void) log_complete (thread_p, tdes, false, LOG_DONT_NEED_NEWTRID, LOG_NEED_TO_WRITE_EOT_LOG);
 	  logtb_free_tran_index (thread_p, tran_index);
 	}
     }
@@ -4963,7 +4962,7 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		    }
 		  else
 		    {
-		      (void) log_complete (thread_p, tdes, LOG_ABORT, LOG_DONT_NEED_NEWTRID, LOG_NEED_TO_WRITE_EOT_LOG);
+		      (void) log_complete (thread_p, tdes, false, LOG_DONT_NEED_NEWTRID, LOG_NEED_TO_WRITE_EOT_LOG);
 		      logtb_free_tran_index (thread_p, tran_index);
 		    }
 		  tdes = NULL;
@@ -4998,7 +4997,7 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		    }
 		  else
 		    {
-		      (void) log_complete (thread_p, tdes, LOG_ABORT, LOG_DONT_NEED_NEWTRID, LOG_NEED_TO_WRITE_EOT_LOG);
+		      (void) log_complete (thread_p, tdes, false, LOG_DONT_NEED_NEWTRID, LOG_NEED_TO_WRITE_EOT_LOG);
 		      logtb_free_tran_index (thread_p, tran_index);
 		    }
 		  tdes = NULL;
@@ -5022,8 +5021,7 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 			}
 		      else
 			{
-			  (void) log_complete (thread_p, tdes, LOG_ABORT, LOG_DONT_NEED_NEWTRID,
-					       LOG_NEED_TO_WRITE_EOT_LOG);
+			  (void) log_complete (thread_p, tdes, false, LOG_DONT_NEED_NEWTRID, LOG_NEED_TO_WRITE_EOT_LOG);
 			  logtb_free_tran_index (thread_p, tran_index);
 			  tdes = NULL;
 			}

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -137,6 +137,7 @@ static int logtb_global_unique_stat_key_copy (void *src, void *dest);
 static void logtb_free_tran_mvcc_info (LOG_TDES * tdes);
 
 static void logtb_assign_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_INFO * curr_mvcc_info, MVCCID mvcc_subid);
+static void logtb_reset_mvcc_and_related_states (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
 
 static int logtb_check_kill_tran_auth (THREAD_ENTRY * thread_p, int tran_id, bool * has_authorization);
 static void logtb_find_thread_entry_mapfunc (THREAD_ENTRY & thread_ref, bool & stop_mapper, int tran_index,
@@ -1575,6 +1576,8 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
     {
       tdes->get_replication_generator ().clear_transaction ();
     }
+
+  tdes->id_complete = cubtx::complete_manager::NULL_ID;
 }
 
 /*
@@ -4037,59 +4040,11 @@ logtb_complete_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool committed)
     }
   else
     {
-#if defined(SA_MODE)
-      if (committed && logtb_tran_update_all_global_unique_stats (thread_p) != NO_ERROR)
-	{
-	  assert (false);
-	}
-#else	/* !SA_MODE */	       /* SERVER_MODE */
-      if (committed)
-	{
-	  /* There is one unique index that can be modified with no MVCCID being generated: db_serial primary key. This
-	   * could happen in a transaction that only does a create serial and commits. Next code makes sure serial
-	   * index statistics are reflected. */
-	  BTID serial_index_btid = BTID_INITIALIZER;
-	  LOG_TRAN_BTID_UNIQUE_STATS *serial_unique_stats = NULL;
-
-	  /* Get serial index BTID. */
-	  serial_get_index_btid (&serial_index_btid);
-	  assert (!BTID_IS_NULL (&serial_index_btid));
-
-	  /* Get statistics for serial unique index. */
-	  serial_unique_stats = logtb_tran_find_btid_stats (thread_p, &serial_index_btid, false);
-	  if (serial_unique_stats != NULL)
-	    {
-	      /* Reflect serial unique statistics. */
-	      if (logtb_update_global_unique_stats_by_delta (thread_p, &serial_index_btid,
-							     serial_unique_stats->tran_stats.num_oids,
-							     serial_unique_stats->tran_stats.num_nulls,
-							     serial_unique_stats->tran_stats.num_keys,
-							     true) != NO_ERROR)
-		{
-		  /* No errors are permitted here. */
-		  assert (false);
-
-		  /* Fall through to do everything we would do in case of no error. */
-		}
-	    }
-	}
-#endif /* SERVER_MODE */
-
       /* atomic set transaction lowest active MVCCID */
       log_Gl.mvcc_table.reset_transaction_lowest_active (tran_index);
     }
 
-  curr_mvcc_info->recent_snapshot_lowest_active_mvccid = MVCCID_NULL;
-
-  p_mvcc_snapshot = &(curr_mvcc_info->snapshot);
-  if (p_mvcc_snapshot->valid)
-    {
-      logtb_tran_reset_count_optim_state (thread_p);
-    }
-
-  curr_mvcc_info->reset ();
-
-  logtb_tran_clear_update_stats (&tdes->log_upd_stats);
+  logtb_reset_mvcc_and_related_states (thread_p, tdes);
 
   if (is_perf_tracking)
     {
@@ -4102,6 +4057,37 @@ logtb_complete_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool committed)
 	}
     }
 }
+
+/*
+* logtb_reset_mvcc_and_related_states () - Reset MVCC and related states
+*
+* return	  : Void.
+* thread_p (in)  : Thread entry.
+* tdes (in)	  : Transaction descriptor.
+*
+*  Note : This function reset MVCC and clear related states - update stats and count optimization.
+*      Clearing update stats and count optimization may be moved outside.
+*/
+static void
+logtb_reset_mvcc_and_related_states (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
+{
+  mvcctable *mvcc_table = &log_Gl.mvcc_table;
+  MVCC_SNAPSHOT *p_mvcc_snapshot = NULL;
+  MVCC_INFO *curr_mvcc_info = &tdes->mvccinfo;
+
+  curr_mvcc_info->recent_snapshot_lowest_active_mvccid = MVCCID_NULL;
+
+  p_mvcc_snapshot = &(curr_mvcc_info->snapshot);
+  if (p_mvcc_snapshot->valid)
+    {
+      logtb_tran_reset_count_optim_state (thread_p);
+    }
+
+  curr_mvcc_info->reset ();
+
+  logtb_tran_clear_update_stats (&tdes->log_upd_stats);
+}
+
 
 /*
  * logtb_set_loose_end_tdes -

--- a/src/transaction/mvcc_table.cpp
+++ b/src/transaction/mvcc_table.cpp
@@ -461,12 +461,6 @@ mvcctable::complete_mvcc (int tran_index, MVCCID mvccid, bool committed)
   size_t next_index;
   mvcc_trans_status &next_status = next_trans_status_start (next_version, next_index);
 
-  // todo - until we activate count optimization (if ever), should we move this outside mutex?
-  if (committed && logtb_tran_update_all_global_unique_stats (thread_get_thread_entry_info ()) != NO_ERROR)
-    {
-      assert (false);
-    }
-
   // update current trans status
   m_current_trans_status.m_active_mvccs.set_inactive_mvccid (mvccid);
   m_current_trans_status.m_last_completed_mvccid = mvccid;


### PR DESCRIPTION
Split commit/abort/complete into several functions: log_prepare_transaction_complete, log_complete_transaction_mvcc, log_complete_transaction_logging, log_complete_transaction

Also, small issues and improvements, detailed here:
1. Added tdes->id_complete with the following purpose:
- currently keeps complete LSA. It is used for synchronization between transaction that completes and the flush thread. Thus, before completion, the transaction must wait for log flush thread to flush complete LSA of the current transaction.
- will keep id of current group. It will be used for synchronization between transaction that completes and group complete thread. Thus, before completion, the transaction must wait for group complete thread to complete the group id of the current transaction.

2. Before MVCC completion or logging completion, prepare completion must be called. Currently, at prepare completion, a not NULL LSA is assigned to id_complete. It is used for debug purpose currently. The function will be adapted to the new group complete code.

3. Separated update_statistics by complete_mvcc.

4. Log completion. For compliance with develop, the following transaction states maybe contained into a grup completion log record: TRAN_UNACTIVE_WILL_COMMIT, TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE, TRAN_UNACTIVE_ABORTED. Group complete log record together with each transaction state contained in group, are enough to detect what to do with transaction at recovery. The id_complete is rewritten with the real completion LSA.

5. log_append_group_complete_internal - tdes->rcv.tran_start_postpone_lsa points to group complete log record.

6. log_recovery_finish_postpone
 - if transaction state is TRAN_UNACTIVE_COMMITTED, it means that log commit was already written. Probably is no need to call log complete... but, if we call, uses LOG_ALREADY_WROTE_EOT_LOG instead LOG_NEED_TO_WRITE_EOT_LOG 
- if transaction state is TRAN_UNACTIVE_WILL_COMMIT or TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE, then, calls log_complete that does log_append_finish_postpone and other things.

2pc functions updated temporary, since some functions signature has changed.

When new group complete will be activated, the following functions will be adapted:
log_prepare_transaction_complete, log_complete_transaction_mvcc, log_complete_transaction_logging, log_complete_transaction.