### PR TITLE
Revert "[CBRD-23604] The restart of copylogdb and applylogdb fail if the length of copied log file path is over 64."

### DIFF
--- a/src/connection/heartbeat.c
+++ b/src/connection/heartbeat.c
@@ -288,6 +288,7 @@ hb_make_set_hbp_register (int type)
 {
   HBP_PROC_REGISTER *hbp_register;
   char *p, *last;
+  int argc;
   char **argv;
 
   hbp_register = (HBP_PROC_REGISTER *) malloc (sizeof (HBP_PROC_REGISTER));
@@ -304,9 +305,10 @@ hb_make_set_hbp_register (int type)
 
   p = (char *) &hbp_register->args[0];
   last = (char *) (p + sizeof (hbp_register->args));
-  for (argv = hb_Argv; *argv; argv++)
+  for (argc = 0, argv = hb_Argv; *argv && argc < HB_MAX_NUM_PROC_ARGV; argc++, argv++)
     {
       p += snprintf (p, MAX ((last - p), 0), "%s ", *argv);
+      strncpy ((char *) hbp_register->argv[argc], *argv, (HB_MAX_SZ_PROC_ARGV - 1));
     }
 
   return (hbp_register);

--- a/src/connection/heartbeat.h
+++ b/src/connection/heartbeat.h
@@ -142,6 +142,7 @@ struct hbp_proc_register
   int type;
   char exec_path[HB_MAX_SZ_PROC_EXEC_PATH];
   char args[HB_MAX_SZ_PROC_ARGS];
+  char argv[HB_MAX_NUM_PROC_ARGV][HB_MAX_SZ_PROC_ARGV];
 };
 
 

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -281,6 +281,7 @@ struct HB_PROC_ENTRY
   int pid;
   char exec_path[HB_MAX_SZ_PROC_EXEC_PATH];
   char args[HB_MAX_SZ_PROC_ARGS];
+  char argv[HB_MAX_NUM_PROC_ARGV][HB_MAX_SZ_PROC_ARGV];
 
   struct timeval frtime;	/* first registered time */
   struct timeval rtime;		/* registerd time */


### PR DESCRIPTION
Reverts CUBRID/cubrid#2191

reason: missing issue tracking linker '[CBRD-23604]'