### PR TITLE
[CBRD-23609] Send messages to the system logger when there is insufficient space in operating system device.

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -779,7 +779,7 @@ css_process_get_eof_request (SOCKET master_fd)
   OR_ALIGNED_BUF (OR_LOG_LSA_ALIGNED_SIZE + OR_BIGINT_SIZE + OR_INT_SIZE) a_reply;
   char *reply, *ptr = NULL;
   THREAD_ENTRY *thread_p;
-  INT64 num_free_block;
+  INT64 num_free_block = 0;
 
   reply = OR_ALIGNED_BUF_START (a_reply);
 

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -774,10 +774,12 @@ static void
 css_process_get_eof_request (SOCKET master_fd)
 {
 #if !defined(WINDOWS)
+  static LOG_LSA prev_eof_lsa (NULL_LSA);
   LOG_LSA *eof_lsa;
-  OR_ALIGNED_BUF (OR_LOG_LSA_ALIGNED_SIZE) a_reply;
-  char *reply;
+  OR_ALIGNED_BUF (OR_LOG_LSA_ALIGNED_SIZE + OR_BIGINT_SIZE + OR_INT_SIZE) a_reply;
+  char *reply, *ptr = NULL;
   THREAD_ENTRY *thread_p;
+  INT64 num_free_block;
 
   reply = OR_ALIGNED_BUF_START (a_reply);
 
@@ -787,9 +789,20 @@ css_process_get_eof_request (SOCKET master_fd)
   LOG_CS_ENTER_READ_MODE (thread_p);
 
   eof_lsa = log_get_eof_lsa ();
-  (void) or_pack_log_lsa (reply, eof_lsa);
+  ptr = or_pack_log_lsa (reply, eof_lsa);
 
   LOG_CS_EXIT (thread_p);
+
+  if (LSA_EQ (&prev_eof_lsa, eof_lsa))
+    {
+      log_get_num_free_block (&num_free_block);
+    }
+  else
+    {
+      LSA_COPY (&prev_eof_lsa, eof_lsa);
+    }
+
+  (void) or_pack_int64 (ptr, num_free_block);
 
   css_send_heartbeat_request (css_Master_conn, SERVER_GET_EOF);
   css_send_heartbeat_data (css_Master_conn, reply, OR_ALIGNED_BUF_SIZE (a_reply));

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -44,6 +44,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <pthread.h>
+#include <syslog.h>
 #endif
 
 #include "connection_cl.h"
@@ -4479,6 +4480,8 @@ hb_thread_check_disk_failure (void *arg)
 		  pthread_mutex_unlock (&hb_Cluster->lock);
 #if !defined(WINDOWS)
 		  pthread_mutex_unlock (&css_Master_socket_anchor_lock);
+
+		  syslog (LOG_ALERT, "[CUBRID] %s () at %s:%d", __func__, __FILE__, __LINE__);
 #endif /* !WINDOWS */
 
 		  error = hb_resource_job_queue (HB_RJOB_DEMOTE_START_SHUTDOWN, NULL, HB_JOB_TIMER_IMMEDIATELY);

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -3591,6 +3591,7 @@ hb_alloc_new_proc (void)
       p->server_hang = false;
       LSA_SET_NULL (&p->prev_eof);
       LSA_SET_NULL (&p->curr_eof);
+      p->num_free_block = 0;
 
       first_pp = &hb_Resource->procs;
       hb_list_add ((HB_LIST **) first_pp, (HB_LIST *) p);
@@ -3835,6 +3836,7 @@ hb_cleanup_conn_and_start_process (CSS_CONN_ENTRY * conn, SOCKET sfd)
   proc->server_hang = false;
   LSA_SET_NULL (&proc->prev_eof);
   LSA_SET_NULL (&proc->curr_eof);
+  proc->num_free_block = 0;
 
   pthread_mutex_unlock (&hb_Resource->lock);
 
@@ -4186,11 +4188,15 @@ hb_resource_check_server_log_grow (void)
       if (LSA_GT (&proc->curr_eof, &proc->prev_eof) == true)
 	{
 	  LSA_COPY (&proc->prev_eof, &proc->curr_eof);
+	  proc->num_free_block = 0;
 	}
       else
 	{
-	  proc->server_hang = true;
-	  dead_cnt++;
+	  if (proc->num_free_block == 0)
+	    {
+	      proc->server_hang = true;
+	      dead_cnt++;
+	    }
 	}
     }
   if (dead_cnt > 0)
@@ -4239,8 +4245,8 @@ hb_resource_receive_get_eof (CSS_CONN_ENTRY * conn)
 {
   int rv;
   HB_PROC_ENTRY *proc;
-  OR_ALIGNED_BUF (OR_LOG_LSA_ALIGNED_SIZE) a_reply;
-  char *reply;
+  OR_ALIGNED_BUF (OR_LOG_LSA_ALIGNED_SIZE + OR_BIGINT_SIZE + OR_INT_SIZE) a_reply;
+  char *reply, *ptr = NULL;
 
   reply = OR_ALIGNED_BUF_START (a_reply);
 
@@ -4262,7 +4268,8 @@ hb_resource_receive_get_eof (CSS_CONN_ENTRY * conn)
 
   if (proc->state == HB_PSTATE_REGISTERED_AND_ACTIVE)
     {
-      or_unpack_log_lsa (reply, &proc->curr_eof);
+      ptr = or_unpack_log_lsa (reply, &proc->curr_eof);
+      (void) or_unpack_int64 (ptr, &proc->num_free_block);
     }
 
   MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "received eof [%lld|%lld]\n", proc->curr_eof.pageid, proc->curr_eof.offset);

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -294,6 +294,8 @@ struct HB_PROC_ENTRY
   LOG_LSA prev_eof;
   LOG_LSA curr_eof;
 
+  INT64 num_free_block;
+
   CSS_CONN_ENTRY *conn;
 
   bool being_shutdown;		/* whether the proc is being shut down */

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -47,6 +47,9 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <sys/vfs.h>
+#if defined (SERVER_MODE)
+#include <syslog.h>
+#endif
 #endif /* WINDOWS */
 
 #ifdef _AIX
@@ -4175,6 +4178,10 @@ fileio_write (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_WRITE_OUT_OF_SPACE, 2, page_id,
 		      fileio_get_volume_label_by_fd (vol_fd, PEEK));
+
+#if defined (SERVER_MODE) && !defined (WINDOWS)
+	      syslog (LOG_ALERT, "[CUBRID] %s () at %s:%d %m", __func__, __FILE__, __LINE__);
+#endif
 	      return NULL;
 	    }
 	  else

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -43,7 +43,7 @@
 #include <assert.h>
 #if defined(WINDOWS)
 #include <io.h>
-#else /* WINDOWS */
+#else
 #include <sys/vfs.h>
 #endif /* WINDOWS */
 
@@ -595,7 +595,7 @@ log_get_num_free_block (INT64 * num_free_block)
 {
 #if defined(SOLARIS)
   struct statvfs buf;
-#else /* SOLARIS */
+#else
   struct statfs buf;
 #endif /* SOLARIS */
 
@@ -606,7 +606,7 @@ log_get_num_free_block (INT64 * num_free_block)
   if (statvfs (log_Path, &buf) == 0)
 #elif defined(AIX)
   if (statfs ((char *) log_Path, &buf) == 0)
-#else /* AIX */
+#else
   if (statfs (log_Path, &buf) == 0)
 #endif /* AIX */
     {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -30,13 +30,21 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <time.h>
+
+#ifdef _AIX
+#include <sys/statfs.h>
+#endif /* _AIX */
+
 #if defined(SOLARIS)
 #include <netdb.h>
+#include <sys/statvfs.h>
 #endif /* SOLARIS */
 #include <sys/stat.h>
 #include <assert.h>
 #if defined(WINDOWS)
 #include <io.h>
+#else /* WINDOWS */
+#include <sys/vfs.h>
 #endif /* WINDOWS */
 
 #include <sys/types.h>
@@ -573,6 +581,37 @@ LOG_LSA *
 log_get_eof_lsa (void)
 {
   return (&log_Gl.hdr.eof_lsa);
+}
+
+/*
+ * log_get_num_free_block -
+ *
+ * return:
+ *
+ * NOTE:
+ */
+void
+log_get_num_free_block (INT64 * num_free_block)
+{
+#if defined(SOLARIS)
+  struct statvfs buf;
+#else /* SOLARIS */
+  struct statfs buf;
+#endif /* SOLARIS */
+
+  memset (&buf, 0, sizeof (buf));
+  *num_free_block = 0;
+
+#if defined(SOLARIS)
+  if (statvfs (log_Path, &buf) == 0)
+#elif defined(AIX)
+  if (statfs ((char *) log_Path, &buf) == 0)
+#else /* AIX */
+  if (statfs (log_Path, &buf) == 0)
+#endif /* AIX */
+    {
+      *num_free_block = (INT64) buf.f_bavail;
+    }
 }
 
 /*

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -66,6 +66,7 @@ extern LOG_LSA *log_get_restart_lsa (void);
 extern LOG_LSA *log_get_crash_point_lsa (void);
 extern LOG_LSA *log_get_append_lsa (void);
 extern LOG_LSA *log_get_eof_lsa (void);
+extern void log_get_num_free_block (INT64 * num_free_block);
 extern bool log_is_logged_since_restart (const LOG_LSA * lsa_ptr);
 extern int log_get_db_start_parameters (INT64 * db_creation, LOG_LSA * chkpt_lsa);
 extern int log_get_num_pages_for_creation (int db_npages);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23609

- Failover with insufficient disk space does not leave enough logs.
- Therefore, it is too difficult for the DBA to figure out why failover occurred.
- Allows the system logger to record the information in case of problems with insufficient disk space.