### PR TITLE
[CBRD-22979] Segmentation fault occurs when query has derived table with 3 or more unions

### DIFF
--- a/src/parser/query_result.c
+++ b/src/parser/query_result.c
@@ -520,7 +520,7 @@ pt_get_select_list (PARSER_CONTEXT * parser, PT_NODE * query)
 	      common_type = pt_common_type (attr1->type_enum, attr2->type_enum);
 	    }
 
-	  if (col->type_enum == PT_TYPE_NA || col->type_enum == PT_TYPE_NULL)
+	  if (pt_is_value_node(col) && (col->type_enum == PT_TYPE_NA || col->type_enum == PT_TYPE_NULL))
 	    {
 	      db_make_null (&col->info.value.db_value);
 	    }

--- a/src/parser/query_result.c
+++ b/src/parser/query_result.c
@@ -520,7 +520,7 @@ pt_get_select_list (PARSER_CONTEXT * parser, PT_NODE * query)
 	      common_type = pt_common_type (attr1->type_enum, attr2->type_enum);
 	    }
 
-	  if (pt_is_value_node(col) && (col->type_enum == PT_TYPE_NA || col->type_enum == PT_TYPE_NULL))
+	  if (pt_is_value_node (col) && (col->type_enum == PT_TYPE_NA || col->type_enum == PT_TYPE_NULL))
 	    {
 	      db_make_null (&col->info.value.db_value);
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22979

PT_NODE.info is changed using the other node_type.
```
       if (col->type_enum == PT_TYPE_NA || col->type_enum == PT_TYPE_NULL)
	    {
	      db_make_null (&col->info.value.db_value);
	    }
```
info.value.db_value.is_null is changed to '1' when col->node_type is NOT 'PT_VALUE' type.
i fixed to check node type is 'PT_VALUE'