### PR TITLE
[CBRD-22970] Constant variable is set to null when reusing cached XASL which is executed without data

### DIFF
--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -637,12 +637,12 @@ qdata_set_valptr_list_unbound (THREAD_ENTRY * thread_p, valptr_list_node * valpt
 	    {
 	      /* this may be shared with another regu variable that was already evaluated */
 	      pr_clear_value (dbval_p);
-	    }
 
-	  if (db_value_domain_init (dbval_p, DB_VALUE_DOMAIN_TYPE (dbval_p), DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE) !=
-	      NO_ERROR)
-	    {
-	      return ER_FAILED;
+	      if (db_value_domain_init (dbval_p, DB_VALUE_DOMAIN_TYPE (dbval_p), DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE)
+		  != NO_ERROR)
+		{
+		  return ER_FAILED;
+		}
 	    }
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22970

This issue is related to fixing memory leaks in XASL_CLONE.
https://github.com/CUBRID/cubrid/pull/360

When creating XASL_CLONE, regular variables use global memory allocation. After that, the private allocation is used during the executor process.
So it is fixed that allocated memory on XASL_CLONE generation is deallocated on XASL destruction by setting the 'REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE' flag.

qexec_end_mainblock_iterations
qexec_end_buildvalueblock_iterations
qdata_set_valptr_list_unbound
– fixed by (https://github.com/CUBRID/cubrid/pull/360)
```
if (!REGU_VARIABLE_IS_FLAGED (&reg_var_p->value, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))
{
      /* this may be shared with another regu variable that was already evaluated */
      pr_clear_value (dbval_p);
}
if (db_value_domain_init (dbval_p, DB_VALUE_DOMAIN_TYPE (dbval_p), DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE) !=NO_ERROR)
{
      return ER_FAILED;
}
```
dbval_p is not cleared and reused. The problem is in initializing the domain of the dbval_p to be reused.
I fixed to do NOT initialize db_value which is flagged as 'REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE'.