### PR TITLE
[CBRD-21023] JDBC Clob's length() returns -1 when empty string

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
@@ -127,8 +127,8 @@ public class CUBRIDClob implements Clob {
 			throw conn.createCUBRIDException(CUBRIDJDBCErrorCode.invalid_value, null);
 		}
 		if (clobCharLength < 0) {
-			int read_len = readClobPartially(Long.MAX_VALUE, 1);
-			if (read_len <= 0) {
+			readClobPartially(Long.MAX_VALUE, 1);
+			if (clobCharLength < 0) {
 				return 0;
 			}
 		}


### PR DESCRIPTION
Modified for correcting the length of clob by twice callings of readClobPartially  because the clobCharLength is already set in readClobPartially(...).