### PR TITLE
[CBRD-21452] In set (Union, Intersection, Difference) query, recompil…

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -12455,6 +12455,7 @@ select_expression_without_subquery
 			    stmt->info.query.id = (UINTPTR) stmt;
 			    stmt->info.query.q.union_.arg1 = $1;
 			    stmt->info.query.q.union_.arg2 = $9;
+                            stmt->recompile = $1->recompile | $9->recompile;
 
 			    if (arg1 != NULL
 			        && arg1->info.query.is_subquery != PT_IS_SUBQUERY
@@ -12546,6 +12547,7 @@ select_expression
 			    stmt->info.query.id = (UINTPTR) stmt;
 			    stmt->info.query.q.union_.arg1 = $1;
 			    stmt->info.query.q.union_.arg2 = $9;
+                            stmt->recompile = $1->recompile | $9->recompile;
 
 			    if (arg1 != NULL
 			        && arg1->info.query.is_subquery != PT_IS_SUBQUERY
@@ -12636,6 +12638,8 @@ select_expression_without_values_query
 			    stmt->info.query.id = (UINTPTR) stmt;
 			    stmt->info.query.q.union_.arg1 = $1;
 			    stmt->info.query.q.union_.arg2 = $9;
+                            stmt->recompile = $1->recompile | $9->recompile;
+
 			    if (arg1 != NULL
 			        && arg1->info.query.is_subquery != PT_IS_SUBQUERY
 			        && arg1->info.query.order_by != NULL)
@@ -12725,6 +12729,8 @@ select_expression_without_values_query_no_with_clause
 			    stmt->info.query.id = (UINTPTR) stmt;
 			    stmt->info.query.q.union_.arg1 = $1;
 			    stmt->info.query.q.union_.arg2 = $9;
+                            stmt->recompile = $1->recompile | $9->recompile;
+
 			    if (arg1 != NULL
 			        && arg1->info.query.is_subquery != PT_IS_SUBQUERY
 			        && arg1->info.query.order_by != NULL)
@@ -12815,6 +12821,8 @@ select_expression_without_values_and_single_subquery
 			     stmt->info.query.id = (UINTPTR) stmt;
 			     stmt->info.query.q.union_.arg1 = $1;
 			     stmt->info.query.q.union_.arg2 = $9;
+                             stmt->recompile = $1->recompile | $9->recompile;
+
 			     if (arg1 != NULL
 				 && arg1->info.query.is_subquery != PT_IS_SUBQUERY
 				 && arg1->info.query.order_by != NULL)
@@ -13256,6 +13264,7 @@ cte_query_list
 			    stmt->info.query.id = (UINTPTR) stmt;
 			    stmt->info.query.q.union_.arg1 = arg1;
 		            stmt->info.query.q.union_.arg2 = arg2;
+                            stmt->recompile = arg1->recompile | arg2->recompile;
 			  }
 
 			$$ = stmt;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3624,6 +3624,7 @@ mq_rewrite_query_as_derived (PARSER_CONTEXT * parser, PT_NODE * query)
 
   /* move query id # */
   new_query->info.query.id = query->info.query.id;
+  new_query->recompile = query->recompile;
   query->info.query.id = 0;
 
   return new_query;


### PR DESCRIPTION
[CBRD-21452] In set (Union, Intersection, Difference) query, recompile cannot be repeatedly applied for explicit 'recompile clause'.

Reason:
    In case that the Recompile option is used with Set Query (including Difference, Intersection) 
    including Union with two or more Select statements, the recompile option in the query tree is not
    reflected in the final union node during parsing.
Patch:
    When creating a union node in the SQL parser csql_grammar.y, copy the recompile option used
    in the two select statements linked with the argument to the union node.

`   Stmt-> info.query.id = (UINTPTR) stmt;`
`    Stmt-> info.query.q.union_.arg1 = arg1;`
`    Stmt-> info.query.q.union_.arg2 = arg2;`
`    Stmt-> recompile = arg1-> recompile | Arg2-> recompile;`

    With referring to the above modified code, new rewrite query has a recompile attribute as origin 
    query.
    
    In mq_rewrite_query_as_derived function (parser/view_transform.c),
`  /* move query id # */`
`   new_query->info.query.id = query->info.query.id;`
`   new_query->recompile = query->recompile; /* newly added */`
`   query->info.query.id = 0;`
    