### PR TITLE
[CBRD-20577] Use of alias with function inside ‘Order By’ Clause

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -14662,7 +14662,16 @@ opt_orderby_clause
 
 			if (stmt)
 			  {
-			    stmt->info.query.order_by = order = $5;
+                            PT_NODE *n = NULL;
+
+                            stmt->info.query.order_by = order = n = $5;
+
+                            while (n)
+                              {
+                                resolve_alias_in_expr_node (n, stmt->info.query.q.select.list);
+                                n = n->next;
+                              }
+
 			    if (order)
 			      {				/* not dummy */
 				PT_SELECT_INFO_CLEAR_FLAG (stmt, PT_SELECT_INFO_DUMMY);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20577

In the 'csql_grammar.y', we can find alias resolving function
'resolve_alias_in_expr_node(...)'. And it is already adapted in
'ORDER BY FOR' clause
`stmt->info.query.orderby_for = $7;`
`/* support for alias in FOR */`
`n = stmt->info.query.orderby_for;`
`while (n)`
`{`
`  resolve_alias_in_expr_node (n, stmt->info.query.q.select.list);`
`  n = n->next;`
`}`

In the pt_find_attr_in_class_list(...) at src/parser/name_resolution.c,
all class names are checked and retrieved its attribute(DB_ATTRIBUTE *)
in Database by calling db_get_attribute_force(...).

And, db_get_attribute_force(...) resolves all column reference such as
X.attr not aliases.

So, aliases used in Query should be resolved before this routine is called (parsing stage)
If not, "Attribute "alias_name" was not found." error message will be
received.
