### PR TITLE
[CBRD-23631] Change the maximum value of the 'ha_apply_max_mem_size' property from 500MB to INT_MAX.

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1443,6 +1443,8 @@ static unsigned int prm_ha_copy_sync_mode_flag = 0;
 
 int PRM_HA_APPLY_MAX_MEM_SIZE = HB_DEFAULT_APPLY_MAX_MEM_SIZE;
 static int prm_ha_apply_max_mem_size_default = HB_DEFAULT_APPLY_MAX_MEM_SIZE;
+static int prm_ha_apply_max_mem_size_upper = INT_MAX;
+static int prm_ha_apply_max_mem_size_lower = 0;
 static unsigned int prm_ha_apply_max_mem_size_flag = 0;
 
 int PRM_HA_PORT_ID = HB_DEFAULT_HA_PORT_ID;
@@ -3692,7 +3694,7 @@ static SYSPRM_PARAM prm_Def[] = {
    &prm_ha_apply_max_mem_size_flag,
    (void *) &prm_ha_apply_max_mem_size_default,
    (void *) &PRM_HA_APPLY_MAX_MEM_SIZE,
-   (void *) NULL, (void *) NULL,
+   (void *) &prm_ha_apply_max_mem_size_upper, (void *) &prm_ha_apply_max_mem_size_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2856,10 +2856,6 @@ applylogdb (UTIL_FUNCTION_ARG * arg)
     {
       goto print_applylog_usage;
     }
-  if (max_mem_size > 500)
-    {
-      goto print_applylog_usage;
-    }
 
 #if defined(NDEBUG)
   util_redirect_stdout_to_null ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23631

- The maximum memory size of applylogdb can be set with the "ha_apply_max_mem_size" property, and the maximum value of this property has a limitation that can be set up to 500MB. This limitation was caused by the GC_MALLOC(related to CUBRIDSUS-5209, CUBRIDSUS-6068 etc), and GC_MALLOC was replaced by malloc(related to CUBRIDSUS-15243).
- Sometimes applylogdb requires more than 500MB of memory to process log records, but this limitation causes a problem that data cannot be applied to the slave DB.
- So, change the maximum value of this property from 500MB to INT_MAX.