### PR TITLE
[CBRD-23243] Modify the way to caculate available disk space

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -4970,8 +4970,8 @@ fileio_get_number_of_partition_free_pages (const char *path_p, size_t page_size)
     }
   else
     {
-      const size_t io_pagesize_in_block = page_size / buf.f_bsize;
-      npages_of_partition = buf.f_bavail / io_pagesize_in_block;
+      const size_t f_avail_size = buf.f_bsize * buf.f_bavail;
+      npages_of_partition = f_avail_size / page_size;
       if (npages_of_partition < 0 || npages_of_partition > INT_MAX)
 	{
 	  npages_of_partition = INT_MAX;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23243

- When getting the number of free pages of a partition, If the block size of the file system is bigger than page size (IO_PAGE_SIZE, LOG_PAGESIZE or whatever), Arithmetic Exception occurs.
- It is because of the order to calculate.
- So, I've changed the order, calculating the total available space first.
- Since 64 bit OS is required for CUBRID, size_t can cover 2^64-1 and the type of buf.* variable is "long", so it can cover 2^63-1 bytes, 16 Exabyte, which is big enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cubrid/cubrid/2218)
<!-- Reviewable:end -->
