### PR TITLE
[CBRD-23609] Before failure-over due to disk failure, syslog was used to record information and the disk failure detection algorithm was improved in HA environment. (#2195 #2211)

### DIFF
--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -44,6 +44,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <pthread.h>
+#include <syslog.h>
 #endif
 
 #include "connection_cl.h"
@@ -3584,6 +3585,7 @@ hb_alloc_new_proc (void)
       p->server_hang = false;
       LSA_SET_NULL (&p->prev_eof);
       LSA_SET_NULL (&p->curr_eof);
+      p->num_free_block = 0;
 
       first_pp = &hb_Resource->procs;
       hb_list_add ((HB_LIST **) first_pp, (HB_LIST *) p);
@@ -3829,6 +3831,7 @@ hb_cleanup_conn_and_start_process (CSS_CONN_ENTRY * conn, SOCKET sfd)
   proc->server_hang = false;
   LSA_SET_NULL (&proc->prev_eof);
   LSA_SET_NULL (&proc->curr_eof);
+  proc->num_free_block = 0;
 
   pthread_mutex_unlock (&hb_Resource->lock);
 
@@ -4181,11 +4184,15 @@ hb_resource_check_server_log_grow (void)
       if (LSA_GT (&proc->curr_eof, &proc->prev_eof) == true)
 	{
 	  LSA_COPY (&proc->prev_eof, &proc->curr_eof);
+	  proc->num_free_block = 0;
 	}
       else
 	{
-	  proc->server_hang = true;
-	  dead_cnt++;
+	  if (proc->num_free_block == 0)
+	    {
+	      proc->server_hang = true;
+	      dead_cnt++;
+	    }
 	}
     }
   if (dead_cnt > 0)
@@ -4234,8 +4241,8 @@ hb_resource_receive_get_eof (CSS_CONN_ENTRY * conn)
 {
   int rv;
   HB_PROC_ENTRY *proc;
-  OR_ALIGNED_BUF (OR_LOG_LSA_ALIGNED_SIZE) a_reply;
-  char *reply;
+  OR_ALIGNED_BUF (OR_LOG_LSA_ALIGNED_SIZE + OR_BIGINT_SIZE + OR_INT_SIZE) a_reply;
+  char *reply, *ptr = NULL;
 
   reply = OR_ALIGNED_BUF_START (a_reply);
 
@@ -4257,7 +4264,8 @@ hb_resource_receive_get_eof (CSS_CONN_ENTRY * conn)
 
   if (proc->state == HB_PSTATE_REGISTERED_AND_ACTIVE)
     {
-      or_unpack_log_lsa (reply, &proc->curr_eof);
+      ptr = or_unpack_log_lsa (reply, &proc->curr_eof);
+      (void) or_unpack_int64 (ptr, &proc->num_free_block);
     }
 
   MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "received eof [%lld|%lld]\n", proc->curr_eof.pageid, proc->curr_eof.offset);
@@ -4475,6 +4483,8 @@ hb_thread_check_disk_failure (void *arg)
 		  pthread_mutex_unlock (&hb_Cluster->lock);
 #if !defined(WINDOWS)
 		  pthread_mutex_unlock (&css_Master_socket_anchor_lock);
+
+		  syslog (LOG_ALERT, "[CUBRID] %s () at %s:%d", __func__, __FILE__, __LINE__);
 #endif /* !WINDOWS */
 
 		  error = hb_resource_job_queue (HB_RJOB_DEMOTE_START_SHUTDOWN, NULL, HB_JOB_TIMER_IMMEDIATELY);

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -295,6 +295,8 @@ struct HB_PROC_ENTRY
   LOG_LSA prev_eof;
   LOG_LSA curr_eof;
 
+  INT64 num_free_block;
+
   CSS_CONN_ENTRY *conn;
 
   bool being_shutdown;		/* whether the proc is being shut down */

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -47,6 +47,9 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <sys/vfs.h>
+#if defined (SERVER_MODE)
+#include <syslog.h>
+#endif
 #endif /* WINDOWS */
 
 #ifdef _AIX
@@ -4175,6 +4178,10 @@ fileio_write (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_WRITE_OUT_OF_SPACE, 2, page_id,
 		      fileio_get_volume_label_by_fd (vol_fd, PEEK));
+
+#if defined (SERVER_MODE) && !defined (WINDOWS)
+	      syslog (LOG_ALERT, "[CUBRID] %s () at %s:%d %m", __func__, __FILE__, __LINE__);
+#endif
 	      return NULL;
 	    }
 	  else

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -66,6 +66,9 @@ extern LOG_LSA *log_get_restart_lsa (void);
 extern LOG_LSA *log_get_crash_point_lsa (void);
 extern LOG_LSA *log_get_append_lsa (void);
 extern LOG_LSA *log_get_eof_lsa (void);
+#if !defined(WINDOWS)
+extern void log_get_num_free_block (INT64 * num_free_block);
+#endif /* WINDOWS */
 extern bool log_is_logged_since_restart (const LOG_LSA * lsa_ptr);
 extern int log_get_db_start_parameters (INT64 * db_creation, LOG_LSA * chkpt_lsa);
 extern int log_get_num_pages_for_creation (int db_npages);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23609

backport https://github.com/CUBRID/cubrid/pull/2195 https://github.com/CUBRID/cubrid/pull/2211