### PR TITLE
[CBRD-23604] The restart of copylogdb and applylogdb fail if the length of copied log file path is over 64. (#2193)

### DIFF
--- a/src/connection/heartbeat.c
+++ b/src/connection/heartbeat.c
@@ -288,7 +288,6 @@ hb_make_set_hbp_register (int type)
 {
   HBP_PROC_REGISTER *hbp_register;
   char *p, *last;
-  int argc;
   char **argv;
 
   hbp_register = (HBP_PROC_REGISTER *) malloc (sizeof (HBP_PROC_REGISTER));
@@ -305,10 +304,9 @@ hb_make_set_hbp_register (int type)
 
   p = (char *) &hbp_register->args[0];
   last = (char *) (p + sizeof (hbp_register->args));
-  for (argc = 0, argv = hb_Argv; *argv && argc < HB_MAX_NUM_PROC_ARGV; argc++, argv++)
+  for (argv = hb_Argv; *argv; argv++)
     {
       p += snprintf (p, MAX ((last - p), 0), "%s ", *argv);
-      strncpy ((char *) hbp_register->argv[argc], *argv, (HB_MAX_SZ_PROC_ARGV - 1));
     }
 
   return (hbp_register);

--- a/src/connection/heartbeat.h
+++ b/src/connection/heartbeat.h
@@ -142,7 +142,6 @@ struct hbp_proc_register
   int type;
   char exec_path[HB_MAX_SZ_PROC_EXEC_PATH];
   char args[HB_MAX_SZ_PROC_ARGS];
-  char argv[HB_MAX_NUM_PROC_ARGV][HB_MAX_SZ_PROC_ARGV];
 };
 
 

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -187,7 +187,7 @@ static void hb_remove_all_procs (HB_PROC_ENTRY * first);
 static HB_PROC_ENTRY *hb_return_proc_by_args (char *args);
 static HB_PROC_ENTRY *hb_return_proc_by_pid (int pid);
 static HB_PROC_ENTRY *hb_return_proc_by_fd (int sfd);
-static void hb_proc_make_arg (char **arg, char *argv);
+static void hb_proc_make_arg (char **arg, char *args);
 static HB_JOB_ARG *hb_deregister_process (HB_PROC_ENTRY * proc);
 #if defined (ENABLE_UNUSED_FUNCTION)
 static void hb_deregister_nodes (char *node_to_dereg);
@@ -2731,7 +2731,7 @@ hb_resource_job_proc_start (HB_JOB_ARG * arg)
   struct timeval now;
   HB_PROC_ENTRY *proc;
   HB_RESOURCE_JOB_ARG *proc_arg = (arg) ? &(arg->resource_job_arg) : NULL;
-  char *argv[HB_MAX_NUM_PROC_ARGV] = { NULL, };
+  char *argv[HB_MAX_NUM_PROC_ARGV] = { NULL, }, *args;
 
   if (arg == NULL || proc_arg == NULL)
     {
@@ -2786,7 +2786,8 @@ hb_resource_job_proc_start (HB_JOB_ARG * arg)
   snprintf (error_string, LINE_MAX, "(args:%s)", proc->args);
   MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HB_PROCESS_EVENT, 2, "Restart the process", error_string);
 
-  hb_proc_make_arg (argv, (char *) proc->argv);
+  args = strdup (proc->args);
+  hb_proc_make_arg (argv, args);
 
   pid = fork ();
   if (pid < 0)
@@ -2801,6 +2802,9 @@ hb_resource_job_proc_start (HB_JOB_ARG * arg)
 	  assert (false);
 	  free_and_init (arg);
 	}
+
+      free (args);
+
       return;
     }
   else if (pid == 0)
@@ -2826,6 +2830,8 @@ hb_resource_job_proc_start (HB_JOB_ARG * arg)
       proc->pid = pid;
       proc->state = HB_PSTATE_STARTED;
       gettimeofday (&proc->stime, NULL);
+
+      free (args);
     }
 
   pthread_mutex_unlock (&hb_Resource->lock);
@@ -3703,19 +3709,18 @@ hb_return_proc_by_fd (int sfd)
  *   argv(in):
  */
 static void
-hb_proc_make_arg (char **arg, char *argv)
+hb_proc_make_arg (char **arg, char *args)
 {
-  int i;
+  char *tok, *save;
 
-  for (i = 0; i < HB_MAX_NUM_PROC_ARGV; i++, arg++, argv += HB_MAX_SZ_PROC_ARGV)
+  tok = strtok_r (args, " \t\n", &save);
+
+  while (tok)
     {
-      if ((*argv == 0))
-	{
-	  break;
-	}
-
-      (*arg) = argv;
+      (*arg++) = tok;
+      tok = strtok_r (NULL, " \t\n", &save);
     }
+
   return;
 }
 
@@ -3956,7 +3961,6 @@ hb_register_new_process (CSS_CONN_ENTRY * conn)
 	    }
 	  memcpy ((void *) &proc->exec_path[0], (void *) &hbp_proc_register->exec_path[0], sizeof (proc->exec_path));
 	  memcpy ((void *) &proc->args[0], (void *) &hbp_proc_register->args[0], sizeof (proc->args));
-	  memcpy ((void *) &proc->argv[0], (void *) &hbp_proc_register->argv[0], sizeof (proc->argv));
 	  hb_Resource->num_procs++;
 	}
 

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -281,7 +281,6 @@ struct HB_PROC_ENTRY
   int pid;
   char exec_path[HB_MAX_SZ_PROC_EXEC_PATH];
   char args[HB_MAX_SZ_PROC_ARGS];
-  char argv[HB_MAX_NUM_PROC_ARGV][HB_MAX_SZ_PROC_ARGV];
 
   struct timeval frtime;	/* first registered time */
   struct timeval rtime;		/* registerd time */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23604

backport https://github.com/CUBRID/cubrid/pull/2193