### PR TITLE
[APIS-822] In JDBC Driver, translating empty string to null when the option oracleStyleEmptyString is set.

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/ConnectionProperties.java
+++ b/src/jdbc/cubrid/jdbc/driver/ConnectionProperties.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
-import cubrid.jdbc.driver.ConnectionProperties.BooleanConnectionProperty;
 import cubrid.jdbc.jci.BrokerHealthCheck;
 import cubrid.jdbc.jci.UConnection;
 

--- a/src/jdbc/cubrid/jdbc/driver/ConnectionProperties.java
+++ b/src/jdbc/cubrid/jdbc/driver/ConnectionProperties.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
+import cubrid.jdbc.driver.ConnectionProperties.BooleanConnectionProperty;
 import cubrid.jdbc.jci.BrokerHealthCheck;
 import cubrid.jdbc.jci.UConnection;
 
@@ -348,6 +349,9 @@ public class ConnectionProperties {
     BooleanConnectionProperty useOldBooleanValue = new BooleanConnectionProperty(
 	    "useOldBooleanValue", false);
 
+    BooleanConnectionProperty oracleStyleEmptyString = new BooleanConnectionProperty(
+            "oracleStyleEmptyString", false);
+
     public boolean getLogOnException() {
 	return logOnException.getValueAsBoolean();
     }
@@ -401,5 +405,9 @@ public class ConnectionProperties {
 
     public boolean getUseOldBooleanValue() {
         return useOldBooleanValue.getValueAsBoolean();
+    }
+
+    public boolean getOracleStyleEmptyString() {
+        return oracleStyleEmptyString.getValueAsBoolean();
     }
 }

--- a/src/jdbc/cubrid/jdbc/jci/UConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UConnection.java
@@ -418,6 +418,10 @@ public class UConnection {
 		return connectionProperties.getUseOldBooleanValue();
 	}
 
+        public boolean getOracleStyleEmpltyString() {
+                return connectionProperties.getOracleStyleEmptyString();
+        }
+
 	synchronized public void addElementToSet(CUBRIDOID oid,
 			String attributeName, Object value) {
 		errorHandler = new UError(this);

--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -131,8 +131,6 @@ public class UStatement {
 	private boolean result_cacheable = false;
 	private UStmtCache stmt_cache;
 
-        private ConnectionProperties connectionProperties = new ConnectionProperties();
-	
 	UStatement(UConnection relatedC, UInputBuffer inBuffer,
 	        boolean assign_only, String sql, byte _prepare_flag)
 	        throws UJciException {

--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -42,6 +42,7 @@ import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -50,6 +51,7 @@ import java.util.HashMap;
 import cubrid.jdbc.driver.CUBRIDBlob;
 import cubrid.jdbc.driver.CUBRIDClob;
 import cubrid.jdbc.driver.CUBRIDOutResultSet;
+import cubrid.jdbc.driver.ConnectionProperties;
 import cubrid.jdbc.driver.CUBRIDBinaryString;
 import cubrid.sql.CUBRIDOID;
 import cubrid.sql.CUBRIDTimestamptz;
@@ -129,6 +131,8 @@ public class UStatement {
 	private boolean result_cacheable = false;
 	private UStmtCache stmt_cache;
 
+        private ConnectionProperties connectionProperties = new ConnectionProperties();
+	
 	UStatement(UConnection relatedC, UInputBuffer inBuffer,
 	        boolean assign_only, String sql, byte _prepare_flag)
 	        throws UJciException {
@@ -385,7 +389,10 @@ public class UStatement {
 	}
 
 	public void bind(int index, String value) {
-		bindValue(index, UUType.U_TYPE_STRING, value);
+                if (relatedConnection.getOracleStyleEmpltyString()) {
+                    if ("".equals(value)) value = null;
+		}
+                bindValue(index, UUType.U_TYPE_STRING, value);
 	}
 
 	public void bind(int index, byte[] value) {
@@ -432,6 +439,12 @@ public class UStatement {
 			return;
 		}
 
+                if (type == UUType.U_TYPE_STRING) {
+                    if (relatedConnection.getOracleStyleEmpltyString()) {
+                        if ("".equals(value)) value = null;
+                    }
+                }
+
 		bindValue(index, type, value);
 	}
 
@@ -442,7 +455,16 @@ public class UStatement {
 			collectionData = null;
 		} else {
 			try {
-				collectionData = new CUBRIDArray(values);
+                            if (relatedConnection.getOracleStyleEmpltyString()
+                                    && values[0] instanceof String) {
+                                int length = values.length;
+                                for (int i = 0; i < length; i++) {
+                                    if ("".equals(values[i])) {
+                                        values[i] = null;
+                                    }
+                                }
+                            }
+                            collectionData = new CUBRIDArray(values);
 			} catch (UJciException e) {
 				errorHandler = new UError(relatedConnection);
 				e.toUError(errorHandler);
@@ -462,8 +484,16 @@ public class UStatement {
 	}
 
 	public void bindClob(int index, Clob clob) {
-		bindValue(index, UUType.U_TYPE_CLOB, clob);
-	}
+                try {
+                    if (relatedConnection.getOracleStyleEmpltyString()
+                            && clob != null && clob.length() == 0) {
+                        clob = null;
+                    }
+                } catch (SQLException e) {
+                    relatedConnection.logException(e);
+                }
+                bindValue(index, UUType.U_TYPE_CLOB, clob);
+        }
 
 	public void addBatch() {
 		errorHandler = new UError(relatedConnection);


### PR DESCRIPTION
When the option oracleStyleEmptyString is set as a connection string parameter, the empty string "" should be translated to null automatically.

This modified feature is applied to the following database types as JAVA string type:
  - CHAR
  - VARCHAR
  - CLOB