### PR TITLE
[CBRD-23609] Before failure-over due to disk failure, syslog was used to record information and the disk failure detection algorithm was improved in HA environment. (#2195 #2211)

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1185,10 +1185,12 @@ static void
 css_process_get_eof_request (SOCKET master_fd)
 {
 #if !defined(WINDOWS)
+  static LOG_LSA prev_eof_lsa = LSA_INITIALIZER;
   LOG_LSA *eof_lsa;
-  OR_ALIGNED_BUF (OR_LOG_LSA_ALIGNED_SIZE) a_reply;
-  char *reply;
+  OR_ALIGNED_BUF (OR_LOG_LSA_ALIGNED_SIZE + OR_BIGINT_SIZE + OR_INT_SIZE) a_reply;
+  char *reply, *ptr = NULL;
   THREAD_ENTRY *thread_p;
+  INT64 num_free_block = 0;
 
   reply = OR_ALIGNED_BUF_START (a_reply);
 
@@ -1198,9 +1200,20 @@ css_process_get_eof_request (SOCKET master_fd)
   LOG_CS_ENTER_READ_MODE (thread_p);
 
   eof_lsa = log_get_eof_lsa ();
-  (void) or_pack_log_lsa (reply, eof_lsa);
+  ptr = or_pack_log_lsa (reply, eof_lsa);
 
   LOG_CS_EXIT (thread_p);
+
+  if (LSA_EQ (&prev_eof_lsa, eof_lsa))
+    {
+      log_get_num_free_block (&num_free_block);
+    }
+  else
+    {
+      LSA_COPY (&prev_eof_lsa, eof_lsa);
+    }
+
+  (void) or_pack_int64 (ptr, num_free_block);
 
   css_send_heartbeat_request (css_Master_conn, SERVER_GET_EOF);
   css_send_heartbeat_data (css_Master_conn, reply, OR_ALIGNED_BUF_SIZE (a_reply));

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -44,6 +44,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <pthread.h>
+#include <syslog.h>
 #endif
 
 #include "dbi.h"
@@ -3580,6 +3581,7 @@ hb_alloc_new_proc (void)
       p->server_hang = false;
       LSA_SET_NULL (&p->prev_eof);
       LSA_SET_NULL (&p->curr_eof);
+      p->num_free_block = 0;
 
       first_pp = &hb_Resource->procs;
       hb_list_add ((HB_LIST **) first_pp, (HB_LIST *) p);
@@ -3828,6 +3830,7 @@ hb_cleanup_conn_and_start_process (CSS_CONN_ENTRY * conn, SOCKET sfd)
   proc->server_hang = false;
   LSA_SET_NULL (&proc->prev_eof);
   LSA_SET_NULL (&proc->curr_eof);
+  proc->num_free_block = 0;
 
   pthread_mutex_unlock (&hb_Resource->lock);
 
@@ -4181,11 +4184,15 @@ hb_resource_check_server_log_grow (void)
       if (LSA_GT (&proc->curr_eof, &proc->prev_eof) == true)
 	{
 	  LSA_COPY (&proc->prev_eof, &proc->curr_eof);
+	  proc->num_free_block = 0;
 	}
       else
 	{
-	  proc->server_hang = true;
-	  dead_cnt++;
+	  if (proc->num_free_block == 0)
+	    {
+	      proc->server_hang = true;
+	      dead_cnt++;
+	    }
 	}
     }
   if (dead_cnt > 0)
@@ -4234,8 +4241,8 @@ hb_resource_receive_get_eof (CSS_CONN_ENTRY * conn)
 {
   int rv;
   HB_PROC_ENTRY *proc;
-  OR_ALIGNED_BUF (OR_LOG_LSA_ALIGNED_SIZE) a_reply;
-  char *reply;
+  OR_ALIGNED_BUF (OR_LOG_LSA_ALIGNED_SIZE + OR_BIGINT_SIZE + OR_INT_SIZE) a_reply;
+  char *reply, *ptr = NULL;
 
   reply = OR_ALIGNED_BUF_START (a_reply);
 
@@ -4257,7 +4264,8 @@ hb_resource_receive_get_eof (CSS_CONN_ENTRY * conn)
 
   if (proc->state == HB_PSTATE_REGISTERED_AND_ACTIVE)
     {
-      or_unpack_log_lsa (reply, &proc->curr_eof);
+      ptr = or_unpack_log_lsa (reply, &proc->curr_eof);
+      (void) or_unpack_int64 (ptr, &proc->num_free_block);
     }
 
   MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "received eof [%lld|%lld]\n", proc->curr_eof.pageid, proc->curr_eof.offset);
@@ -4462,6 +4470,8 @@ hb_thread_check_disk_failure (void *arg)
 		  pthread_mutex_unlock (&hb_Cluster->lock);
 #if !defined(WINDOWS)
 		  pthread_mutex_unlock (&css_Master_socket_anchor_lock);
+
+		  syslog (LOG_ALERT, "[CUBRID] %s () at %s:%d", __func__, __FILE__, __LINE__);
 #endif /* !WINDOWS */
 
 		  error = hb_resource_job_queue (HB_RJOB_DEMOTE_START_SHUTDOWN, NULL, HB_JOB_TIMER_IMMEDIATELY);

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -306,6 +306,8 @@ struct hb_proc_entry
   LOG_LSA prev_eof;
   LOG_LSA curr_eof;
 
+  INT64 num_free_block;
+
   CSS_CONN_ENTRY *conn;
 
   bool being_shutdown;		/* whether the proc is being shut down */

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -46,6 +46,9 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <sys/vfs.h>
+#if defined (SERVER_MODE)
+#include <syslog.h>
+#endif
 #endif /* WINDOWS */
 
 #ifdef _AIX
@@ -3735,6 +3738,10 @@ fileio_read (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_i
 	      /* This is an end of file. We are trying to read beyond the allocated disk space */
 	      er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_PB_BAD_PAGEID, 2, page_id,
 		      fileio_get_volume_label_by_fd (vol_fd, PEEK));
+
+#if defined (SERVER_MODE) && !defined (WINDOWS)
+	      syslog (LOG_ALERT, "[CUBRID] %s () at %s:%d %m", __func__, __FILE__, __LINE__);
+#endif
 	      return NULL;
 	    }
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -30,13 +30,21 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <time.h>
+
+#ifdef _AIX
+#include <sys/statfs.h>
+#endif /* _AIX */
+
 #if defined(SOLARIS)
 #include <netdb.h>
+#include <sys/statvfs.h>
 #endif /* SOLARIS */
 #include <sys/stat.h>
 #include <assert.h>
 #if defined(WINDOWS)
 #include <io.h>
+#else
+#include <sys/vfs.h>
 #endif /* WINDOWS */
 
 #include <sys/types.h>
@@ -558,6 +566,39 @@ log_get_eof_lsa (void)
 {
   return (&log_Gl.hdr.eof_lsa);
 }
+
+/*
+ * log_get_num_free_block -
+ *
+ * return:
+ *
+ * NOTE:
+ */
+#if !defined(WINDOWS)
+void
+log_get_num_free_block (INT64 * num_free_block)
+{
+#if defined(SOLARIS)
+  struct statvfs buf;
+#else
+  struct statfs buf;
+#endif /* SOLARIS */
+
+  memset (&buf, 0, sizeof (buf));
+  *num_free_block = 0;
+
+#if defined(SOLARIS)
+  if (statvfs (log_Path, &buf) == 0)
+#elif defined(AIX)
+  if (statfs ((char *) log_Path, &buf) == 0)
+#else
+  if (statfs (log_Path, &buf) == 0)
+#endif /* AIX */
+    {
+      *num_free_block = (INT64) buf.f_bavail;
+    }
+}
+#endif /* WINDOWS */
 
 /*
  * log_is_logged_since_restart - is log sequence address made after restart ?

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -85,6 +85,9 @@ extern LOG_LSA *log_get_restart_lsa (void);
 extern LOG_LSA *log_get_crash_point_lsa (void);
 extern LOG_LSA *log_get_append_lsa (void);
 extern LOG_LSA *log_get_eof_lsa (void);
+#if !defined(WINDOWS)
+extern void log_get_num_free_block (INT64 * num_free_block);
+#endif /* WINDOWS */
 extern bool log_is_logged_since_restart (const LOG_LSA * lsa_ptr);
 extern int log_get_db_start_parameters (INT64 * db_creation, LOG_LSA * chkpt_lsa);
 extern int log_get_num_pages_for_creation (int db_npages);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23609

backport https://github.com/CUBRID/cubrid/pull/2195 https://github.com/CUBRID/cubrid/pull/2211