### PR TITLE
[CBRD-23617] Query specification from system catalog is not displayed correctly when the syntax for creating view exceeds 4K

### DIFF
--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -58,7 +58,7 @@
 /* Maximum allowable class name. */
 #define DB_MAX_CLASS_LENGTH (DB_MAX_IDENTIFIER_LENGTH-DB_MAX_SCHEMA_LENGTH-4)
 
-#define DB_MAX_SPEC_LENGTH       4096
+#define DB_MAX_SPEC_LENGTH       (0x3FFFFFFF)
 
 /* Maximum allowable class comment length */
 #define DB_MAX_CLASS_COMMENT_LENGTH     2048

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -2535,7 +2535,7 @@ boot_define_query_spec (MOP class_mop)
       return error_code;
     }
 
-  error_code = smt_add_attribute (def, "spec", "varchar(4096)", NULL);
+  error_code = smt_add_attribute (def, "spec", "varchar(1073741823)", NULL);
   if (error_code != NO_ERROR)
     {
       return error_code;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23617

backport #2201