### PR TITLE
[CBRD-23633] revised: UInputBuffer constructor modified for compatibility

### DIFF
--- a/src/jdbc/cubrid/jdbc/jci/UInputBuffer.java
+++ b/src/jdbc/cubrid/jdbc/jci/UInputBuffer.java
@@ -62,6 +62,61 @@ class UInputBuffer {
 	private final static int CAS_INFO_SIZE = 4;
 	private UConnection uconn;
 
+	UInputBuffer(UTimedDataInputStream relatedI, UConnection con)
+			throws IOException, UJciException {
+		input = relatedI;
+		position = 0;
+		uconn = con;
+
+		int readLen = 0;
+		int totalReadLen = 0;
+		byte[] headerData = new byte[8];
+
+		while (totalReadLen < 8) {
+			readLen = input.read(headerData, totalReadLen, 8 - totalReadLen, 0);
+			if (readLen == -1) {
+				throw uconn.createJciException(UErrorCode.ER_ILLEGAL_DATA_SIZE);
+			}
+			totalReadLen = totalReadLen + readLen;
+		}
+
+		capacity = UJCIUtil.bytes2int(headerData, 0);
+		casinfo = new byte[CAS_INFO_SIZE];
+		System.arraycopy(headerData, 4, casinfo, 0, 4);
+		con.setCASInfo(casinfo);
+
+		if (capacity <= 0) {
+			resCode = 0;
+			capacity = 0;
+			return;
+		}
+
+		buffer = new byte[capacity];
+		readData();
+
+		resCode = readInt();
+
+		if (resCode < 0) {
+			int eCode = readInt();
+			String msg;
+			
+			if (con.isRenewedSessionId()) {
+				byte[] newSessionId = new byte[20];
+				
+				msg = readString(remainedCapacity() - newSessionId.length, 
+						 UJCIManager.sysCharsetName);
+				readBytes(newSessionId);
+				con.setNewSessionId (newSessionId);
+			} else {
+				msg = readString(remainedCapacity(), 
+						 UJCIManager.sysCharsetName);
+			}
+			
+			eCode = convertErrorByVersion(resCode, eCode);
+			throw uconn.createJciException(UErrorCode.ER_DBMS, resCode, eCode, msg);
+		}
+	}
+
 	UInputBuffer(UTimedDataInputStream relatedI, UConnection con, int timeout)
 			throws IOException, UJciException {
 		input = relatedI;


### PR DESCRIPTION
The revised method UInputBuffer has  two interface.
One is the interface with timeout as a parameter.
The other is the interface without timeout parameter.
This revision is for compatibility with Test Case of QA.