### PR TITLE
[CBRD-23643] A hang occurs when exiting 'csql' after connecting to server through csql in standalone mode

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -8547,7 +8547,7 @@ file_tempcache_init (void)
 
   /* allocate file_Tempcache */
   memsize = sizeof (FILE_TEMPCACHE);
-  file_Tempcache = (FILE_TEMPCACHE *) malloc (memsize);
+  file_Tempcache = (FILE_TEMPCACHE *) calloc (1, memsize);
   if (file_Tempcache == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, memsize);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23643

This issue occurs because the pthread mutex object of 'file_Tempcache' has dummy value before executing dynamic initialization function. 
In RHEL6 & RHEL7, problems related with robust mutex were reported about 2016 and resolved RHEL7.6. 
So, over RHEL7.6(CentOS 7.6) the same issue doesn't occur. 
But in CentOS 6.9~7.4, the problem still remain so, change the memory allocation function from malloc to calloc.