### PR TITLE
[CBRD-23643] A hang occurs when exiting 'csql' after connecting to server through csql in standalone mode

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -8576,7 +8576,7 @@ file_tempcache_init (void)
 
   /* allocate file_Tempcache */
   memsize = sizeof (FILE_TEMPCACHE);
-  file_Tempcache = (FILE_TEMPCACHE *) malloc (memsize);
+  file_Tempcache = (FILE_TEMPCACHE *) calloc (1, memsize);
   if (file_Tempcache == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, memsize);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23643

This PR is for 10.2 patch related with CBRD-23643
Please refer to #2244 