### PR TITLE
[CBRD-23611] multi bytes blank is padded in char data of the table set to euckr

### DIFF
--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -1447,10 +1447,6 @@ intl_pad_char (const INTL_CODESET codeset, unsigned char *pad_char, int *pad_siz
       break;
 
     case INTL_CODESET_KSC5601_EUC:
-      pad_char[0] = ' ';
-      *pad_size = 1;
-      break;
-
     case INTL_CODESET_ASCII:
     case INTL_CODESET_ISO88591:
     case INTL_CODESET_UTF8:
@@ -1485,8 +1481,6 @@ intl_pad_size (INTL_CODESET codeset)
   switch (codeset)
     {
     case INTL_CODESET_KSC5601_EUC:
-      size = 1;
-      break;
     case INTL_CODESET_ISO88591:
     case INTL_CODESET_UTF8:
     case INTL_CODESET_RAW_BYTES:

--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -1485,7 +1485,7 @@ intl_pad_size (INTL_CODESET codeset)
   switch (codeset)
     {
     case INTL_CODESET_KSC5601_EUC:
-      size = 2;
+      size = 1;
       break;
     case INTL_CODESET_ISO88591:
     case INTL_CODESET_UTF8:

--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -1447,8 +1447,8 @@ intl_pad_char (const INTL_CODESET codeset, unsigned char *pad_char, int *pad_siz
       break;
 
     case INTL_CODESET_KSC5601_EUC:
-      pad_char[0] = pad_char[1] = '\241';
-      *pad_size = 2;
+      pad_char[0] = ' ';
+      *pad_size = 1;
       break;
 
     case INTL_CODESET_ASCII:

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -128,7 +128,7 @@ static const DB_CHARSET lang_Db_charsets[] = {
    "binary", INTL_CODESET_BINARY, 1},
   {"iso8859-1", "Latin 1 charset - ISO 8859 encoding", " ", "_iso88591",
    "iso88591", INTL_CODESET_ISO88591, 1},
-  {"ksc-euc", "KSC 5601 1990 charset - EUC encoding", "\241\241", "_euckr",
+  {"ksc-euc", "KSC 5601 1990 charset - EUC encoding", " ", "_euckr",
    "euckr", INTL_CODESET_KSC5601_EUC, 2},
   {"utf-8", "UNICODE charset - UTF-8 encoding", " ", "_utf8",
    "utf8", INTL_CODESET_UTF8, 1},


### PR DESCRIPTION
This is a back port for 10.1.4
http://jira.cubrid.org/browse/CBRD-23611
https://github.com/CUBRID/cubrid/pull/2237