### PR TITLE
[CBRD-23633] protocol: Prevent endless busy waiting for query execution in abnormal network circumstance

### DIFF
--- a/src/broker/cas_protocol.h
+++ b/src/broker/cas_protocol.h
@@ -219,7 +219,8 @@ extern "C"
     PROTOCOL_V6 = 6,		/* cci/cas4m support unsigned integer type */
     PROTOCOL_V7 = 7,		/* timezone types, to pin xasl entry for retry */
     PROTOCOL_V8 = 8,		/* JSON type */
-    CURRENT_PROTOCOL = PROTOCOL_V8
+    PROTOCOL_V9 = 9,		/* cas health check: get function status */
+    CURRENT_PROTOCOL = PROTOCOL_V9
   };
   typedef enum t_cas_protocol T_CAS_PROTOCOL;
 

--- a/src/jdbc/cubrid/jdbc/jci/UConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UConnection.java
@@ -96,9 +96,10 @@ public class UConnection {
 	public static final int PROTOCOL_V6 = 6;
 	public static final int PROTOCOL_V7 = 7;
 	public static final int PROTOCOL_V8 = 8;
+	public static final int PROTOCOL_V9 = 9;
 
 	/* Current protocol version */
-	private final static byte CAS_PROTOCOL_VERSION = PROTOCOL_V8;
+	private final static byte CAS_PROTOCOL_VERSION = PROTOCOL_V9;
 	private final static byte CAS_PROTO_INDICATOR = 0x40;
 	private final static byte CAS_PROTO_VER_MASK = 0x3F;
 	private final static byte CAS_RENEWED_ERROR_CODE = (byte) 0x80;
@@ -200,6 +201,7 @@ public class UConnection {
 	private byte[] broker_info = null;
 	private byte[] casinfo = null;
 	private int brokerVersion = 0;
+	private static int protocolVersion = 0;
 
 	private boolean isServerSideJdbc = false;
 	boolean skip_checkcas = false;
@@ -1936,6 +1938,8 @@ public class UConnection {
 				(int) broker_info[BROKER_INFO_PATCH_VERSION]);
 		}
 
+		protocolVersion = (int)version & CAS_PROTO_VER_MASK;
+
 		if (protoVersionIsAbove(PROTOCOL_V4)) {
 		    casId = is.readInt();
 		} else {
@@ -2053,6 +2057,13 @@ public class UConnection {
 	public boolean protoVersionIsAbove(int ver) {
 		if (isServerSideJdbc()
 				|| (brokerInfoVersion() >= makeProtoVersion(ver))) {
+			return true;
+		}
+		return false;
+	}
+
+	public static boolean protoVersionIsLower(int ver) {
+		if (protocolVersion < ver){
 			return true;
 		}
 		return false;

--- a/src/jdbc/cubrid/jdbc/jci/UTimedDataInputStream.java
+++ b/src/jdbc/cubrid/jdbc/jci/UTimedDataInputStream.java
@@ -145,6 +145,10 @@ public class UTimedDataInputStream {
               String msg = UErrorCode.codeToMessage(UErrorCode.ER_TIMEOUT);
               throw new SocketTimeoutException(msg);
             }
+            if (UConnection.protoVersionIsLower(UConnection.PROTOCOL_V9)) {
+              BrokerHandler.pingBroker(ip, port, PING_TIMEOUT);
+              continue;
+            }
             if (BrokerHandler.statusBroker(ip, port, pid, session, PING_TIMEOUT) != 1) {
               if (retry) {
                 throw new UJciException(UErrorCode.ER_COMMUNICATION);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23633

It's needed to upgrade cas protocol V8 to V9 for backward compatibility.