### PR TITLE
[CBRD-22975] Broker CAS hangs in CLIENT_WAIT status when log file size is greater than 2G on Windows 64 (#2188)

### DIFF
--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -157,6 +157,7 @@ extern "C"
 #define strtoull            _strtoui64
 #define stat		    _stati64
 #define fstat		    _fstati64
+#define ftell		    _ftelli64
 #define ftime		    _ftime_s
 #define timeb		    _timeb
 #define fileno		_fileno

--- a/src/broker/cas_log.c
+++ b/src/broker/cas_log.c
@@ -91,11 +91,11 @@ static char cas_log_error_flag;
 #endif
 static FILE *log_fp = NULL, *slow_log_fp = NULL;
 static char log_filepath[BROKER_PATH_MAX], slow_log_filepath[BROKER_PATH_MAX];
-static long saved_log_fpos = 0;
+static INT64 saved_log_fpos = 0;
 
 static size_t cas_fwrite (const void *ptr, size_t size, size_t nmemb, FILE * stream);
-static long int cas_ftell (FILE * stream);
-static int cas_fseek (FILE * stream, long int offset, int whence);
+static INT64 cas_ftell (FILE * stream);
+static int cas_fseek (FILE * stream, INT64 offset, int whence);
 static FILE *cas_fopen (const char *path, const char *mode);
 #if defined (WINDOWS)
 static FILE *cas_fopen_and_lock (const char *path, const char *mode);
@@ -1204,14 +1204,14 @@ cas_fwrite (const void *ptr, size_t size, size_t nmemb, FILE * stream)
   return result;
 }
 
-static long int
+static INT64
 cas_ftell (FILE * stream)
 {
   return ftell (stream);
 }
 
 static int
-cas_fseek (FILE * stream, long int offset, int whence)
+cas_fseek (FILE * stream, INT64 offset, int whence)
 {
   bool is_prev_time_set;
   int result;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22975
backport #2188