### PR TITLE
[CBRD-21023] [JDBC] Clob's length() returns -1 when empty string

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
@@ -128,6 +128,9 @@ public class CUBRIDClob implements Clob {
 		}
 		if (clobCharLength < 0) {
 			readClobPartially(Long.MAX_VALUE, 1);
+			if (clobCharLength < 0) {
+				return 0;
+			}
 		}
 
 		return clobCharLength;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21023

This is a back port for CBRD-21023