### PR TITLE
[APIS-782] JDBC isValid() in CUBRIDConnection throws UnsupportedOperationException (#2256)

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -849,7 +849,7 @@ receiver_thr_f (void *arg)
 
       if (strncmp (cas_req_header, "ST", 2) == 0)
 	{
-	  int status = -1;
+	  int status = FN_STATUS_NONE;
 	  int pid, i;
 	  unsigned int session_id;
 

--- a/src/broker/cas_common.h
+++ b/src/broker/cas_common.h
@@ -157,6 +157,15 @@ typedef size_t T_SOCKLEN;
 typedef socklen_t T_SOCKLEN;
 #endif
 
+enum
+{
+  FN_STATUS_NONE = -2,
+  FN_STATUS_IDLE = -1,
+  FN_STATUS_CONN = 0,
+  FN_STATUS_BUSY = 1,
+  FN_STATUS_DONE = 2
+};
+
 /* default charset for JDBC : ISO8859-1 */
 #if !defined(CAS_FOR_ORACLE) && !defined(CAS_FOR_MYSQL)
 #define CAS_SCHEMA_DEFAULT_CHARSET (lang_charset ())

--- a/src/broker/cas_function.h
+++ b/src/broker/cas_function.h
@@ -29,14 +29,6 @@
 
 #include "cas_net_buf.h"
 
-enum
-{
-  FN_STATUS_IDLE = -1,
-  FN_STATUS_CONN,
-  FN_STATUS_BUSY,
-  FN_STATUS_DONE
-};
-
 typedef enum
 {
   FN_KEEP_CONN = 0,

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
@@ -988,8 +988,14 @@ public class CUBRIDConnection implements Connection {
 	}
 
 	/* JDK 1.6 */
-	public boolean isValid(int arg0) throws SQLException {
-		throw new SQLException(new java.lang.UnsupportedOperationException());
+	public synchronized boolean isValid(int timeout) throws SQLException {
+		if (timeout < 0) {
+			throw new SQLException();
+		}
+
+		if (u_con == null || is_closed) return false;
+
+		return u_con.isValid(timeout);
 	}
 
 	/* JDK 1.6 */

--- a/src/jdbc/cubrid/jdbc/jci/UConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UConnection.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -171,6 +172,12 @@ public class UConnection {
 	public final static int MAX_CONNECT_TIMEOUT = 2000000;
 
         public final static int READ_TIMEOUT = 10000;
+
+	public final static int FN_STATUS_NONE = -2;
+	public final static int FN_STATUS_IDLE = -1;
+	public final static int FN_STATUS_CONN = 0;
+	public final static int FN_STATUS_BUSY = 1;
+	public final static int FN_STATUS_DONE = 2;
 
 	UOutputBuffer outBuffer;
 	CUBRIDConnection cubridcon;
@@ -1830,6 +1837,22 @@ public class UConnection {
 			createJciException(UErrorCode.ER_COMMUNICATION);
 		}
 		return send_recv_msg(true);
+	}
+
+	public boolean isValid(int timeout) throws SQLException {
+		if (protoVersionIsUnder(PROTOCOL_V9)) {
+			return !isClosed;
+		}
+		try {
+			int status = BrokerHandler.statusBroker(CASIp, CASPort, processId, sessionId, timeout);
+			if (status == UConnection.FN_STATUS_NONE) {
+    				return false;
+    	    		}
+    		} catch (Exception e) {
+    			return false;
+    		}
+	
+		return true;
 	}
 
 	void cancel() throws UJciException, IOException {

--- a/src/jdbc/cubrid/jdbc/net/BrokerHandler.java
+++ b/src/jdbc/cubrid/jdbc/net/BrokerHandler.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.sql.SQLException;
 
 import cubrid.jdbc.jci.UConnection;
 import cubrid.jdbc.jci.UErrorCode;


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-782
This is for a back port #2256 

* [APIS-782] JDBC isValid() in CUBRIDConnection throws UnsupportedOperationException

* [APIS-782] revised: wrong redundant modify

* [APIS-782] revised: shorten, readability, and indentation

* [APIS-782] revised: synchroized, protocol version checking

* [APIS-782] indentation