### PR TITLE
[CBRD-23611] multi bytes blank is padded in char data of the table set to euckr

### DIFF
--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4030,7 +4030,15 @@ qstr_pad (MISC_OPERAND pad_operand, int pad_length, const unsigned char *pad_cha
   int pad_reminder_size = 0;
   int error_status = NO_ERROR;
 
-  intl_pad_char (codeset, def_pad_char, &def_pad_char_size);
+  if (codeset == INTL_CODESET_KSC5601_EUC)
+    {
+      def_pad_char[0] = ' ';
+      def_pad_char_size = 1;
+    }
+  else
+    {
+      intl_pad_char (codeset, def_pad_char, &def_pad_char_size);
+    }
 
   if (pad_charset_length == 0)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23611

When blank is padded to a character type, multibytes blank is padded to a table setted to EUCKR. But when the table is setted to UTF8, a singlebyte blank is padded.
And when a blank is added by manually, the inserted data has single byte blank.

Therefore, a padding blank should be a single byte.