### PR TITLE
[CBRD-23653] subquery in 'EXISTS' operation retrieves the entire data and degrades the performance.

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -1545,6 +1545,12 @@ pt_to_pred_expr_local_with_arg (PARSER_CONTEXT * parser, PT_NODE * node, int *ar
 	    case PT_EXISTS:
 	      regu_var1 = pt_to_regu_variable (parser, node->info.expr.arg1, UNBOX_AS_TABLE);
 	      pred = pt_make_pred_term_comp (regu_var1, NULL, R_EXISTS, data_type);
+
+	      /* exists op must fetch one tuple */
+	      if (regu_var1 && regu_var1->xasl)
+		{
+		  XASL_SET_FLAG (regu_var1->xasl, XASL_NEED_SINGLE_TUPLE_SCAN);
+		}
 	      break;
 
 	    case PT_IS_NULL:

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -8047,6 +8047,16 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 				      return S_SUCCESS;
 				    }
 				}
+
+			      if (XASL_IS_FLAGED (xasl, XASL_NEED_SINGLE_TUPLE_SCAN))
+				{
+				  if (qexec_end_one_iteration (thread_p, xasl, xasl_state, tplrec) != NO_ERROR)
+				    {
+				      return S_ERROR;
+				    }
+				  return S_SUCCESS;
+				}
+
 			      qualified = (xasl->instnum_pred == NULL || ev_res == V_TRUE);
 			      if (qualified
 				  && (qexec_end_one_iteration (thread_p, xasl, xasl_state, tplrec) != NO_ERROR))
@@ -8110,6 +8120,16 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 					  return S_SUCCESS;
 					}
 				    }
+
+				  if (XASL_IS_FLAGED (xasl, XASL_NEED_SINGLE_TUPLE_SCAN))
+				    {
+				      if (qexec_end_one_iteration (thread_p, xasl, xasl_state, tplrec) != NO_ERROR)
+					{
+					  return S_ERROR;
+					}
+				      return S_SUCCESS;
+				    }
+
 				  qualified = (xasl->instnum_pred == NULL || ev_res == V_TRUE);
 
 				  if (qualified

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -8048,23 +8048,21 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 				    }
 				}
 
-			      if (XASL_IS_FLAGED (xasl, XASL_NEED_SINGLE_TUPLE_SCAN))
+			      qualified = (xasl->instnum_pred == NULL || ev_res == V_TRUE);
+			      if (qualified)
 				{
+				  /* one iteration successfully completed */
 				  if (qexec_end_one_iteration (thread_p, xasl, xasl_state, tplrec) != NO_ERROR)
 				    {
 				      return S_ERROR;
 				    }
-				  return S_SUCCESS;
-				}
-
-			      qualified = (xasl->instnum_pred == NULL || ev_res == V_TRUE);
-			      if (qualified
-				  && (qexec_end_one_iteration (thread_p, xasl, xasl_state, tplrec) != NO_ERROR))
-				{
-				  return S_ERROR;
+				  /* only one row is need for exists OP */
+				  if (XASL_IS_FLAGED (xasl, XASL_NEED_SINGLE_TUPLE_SCAN))
+				    {
+				      return S_SUCCESS;
+				    }
 				}
 			    }
-
 			}
 		      else
 			{	/* handle the scan procedure */
@@ -8121,25 +8119,21 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 					}
 				    }
 
-				  if (XASL_IS_FLAGED (xasl, XASL_NEED_SINGLE_TUPLE_SCAN))
+				  qualified = (xasl->instnum_pred == NULL || ev_res == V_TRUE);
+				  if (qualified)
 				    {
+				      /* one iteration successfully completed */
 				      if (qexec_end_one_iteration (thread_p, xasl, xasl_state, tplrec) != NO_ERROR)
 					{
 					  return S_ERROR;
 					}
-				      return S_SUCCESS;
-				    }
-
-				  qualified = (xasl->instnum_pred == NULL || ev_res == V_TRUE);
-
-				  if (qualified
-				      /* one iteration successfully completed */
-				      && qexec_end_one_iteration (thread_p, xasl, xasl_state, tplrec) != NO_ERROR)
-				    {
-				      return S_ERROR;
+				      /* only one row is need for exists OP */
+				      if (XASL_IS_FLAGED (xasl, XASL_NEED_SINGLE_TUPLE_SCAN))
+					{
+					  return S_SUCCESS;
+					}
 				    }
 				}
-
 			    }
 
 			  if (xs_scan != S_END)	/* an error happened */

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -492,6 +492,7 @@ struct cte_proc_node
 #define XASL_DECACHE_CLONE	      0x1000	/* decache clone */
 #define XASL_RETURN_GENERATED_KEYS    0x2000	/* return generated keys */
 #define XASL_NO_FIXED_SCAN	      0x4000	/* disable fixed scan for this proc */
+#define XASL_NEED_SINGLE_TUPLE_SCAN   0x8000	/* for exists operation */
 
 #define XASL_IS_FLAGED(x, f)        (((x)->flag & (int) (f)) != 0)
 #define XASL_SET_FLAG(x, f)         (x)->flag |= (int) (f)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23653

Due to the characteristic of the 'EXISTS' operation, if only 1 row is searched, it is possible to check true or false.

'XASL_NEED_SINGLE_TUPLE_SCAN' is added to the XASL.flag.
In case of 'EXISTS' operation in XASL generation step, the 'XASL_NEED_SINGLE_TUPLE_SCAN' flag is set.
Fix to stop scan when 1 row is searched in execution step.