### PR TITLE
[CBRD-23658] counting Error occurred when argument of COUNT function is constant 'NULL'.

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -12966,23 +12966,6 @@ pt_eval_function_type_old (PARSER_CONTEXT * parser, PT_NODE * node)
 	  PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_AGG_FUN_WANT_1_ARG,
 		      pt_short_print (parser, node));
 	}
-      else
-	{
-	  /* do special constant folding; COUNT(1), COUNT(?), COUNT(:x), ... -> COUNT(*) */
-	  /* TODO does this belong to type checking or constant folding? */
-	  if (pt_is_const (arg_list))
-	    {
-	      PT_MISC_TYPE all_or_distinct;
-
-	      all_or_distinct = node->info.function.all_or_distinct;
-	      if (fcode == PT_COUNT && all_or_distinct != PT_DISTINCT)
-		{
-		  fcode = node->info.function.function_type = PT_COUNT_STAR;
-		  parser_free_tree (parser, arg_list);
-		  arg_list = node->info.function.arg_list = NULL;
-		}
-	    }
-	}
     }
 
   if (node->type_enum == PT_TYPE_NONE || node->data_type == NULL || !(node->info.function.is_type_checked))
@@ -19943,7 +19926,7 @@ pt_fold_const_function (PARSER_CONTEXT * parser, PT_NODE * func)
     {
       parser_node *arg_list = func->info.function.arg_list;
       /* do special constant folding; COUNT(1), COUNT(?), COUNT(:x), ... -> COUNT(*) */
-      if (pt_is_const (arg_list))
+      if (pt_is_const (arg_list) && !PT_IS_NULL_NODE (arg_list))
 	{
 	  PT_MISC_TYPE all_or_distinct;
 	  all_or_distinct = func->info.function.all_or_distinct;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23658

This issue is a regression of CBRD-21694
In CBRD-21694, logic to change count_star when argument of count function is constant has been added.

When the argument of the count function is null, I modify it so that it does not change to count_star.
And I eliminates unnecessary duplicate logic in the type check.