### PR TITLE
[APIS-825] Supports ResultSet.getBlob() or ResultSet.getClob() method to read BIT VARYING type or VARCHAR type.

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDBlob.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDBlob.java
@@ -287,8 +287,12 @@ public class CUBRIDBlob implements Blob {
 		}
 	}
 
-	public String toString() {
-		return lobHandle.toString();
+	public String toString() throws RuntimeException {
+		if (isLobLocator == true) {
+			return lobHandle.toString();
+		} else {
+			throw new RuntimeException("The lob locator does not exist because the column type has changed.");
+		}
 	}
 
 	public boolean equals(Object obj) {

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDBlob.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDBlob.java
@@ -55,6 +55,7 @@ public class CUBRIDBlob implements Blob {
 	 */
 	private CUBRIDConnection conn;
 	private boolean isWritable;
+	private boolean isLobLocator;
 	private CUBRIDLobHandle lobHandle;
 
 	private ArrayList<java.io.Flushable> streamList = new ArrayList<java.io.Flushable>();
@@ -74,18 +75,20 @@ public class CUBRIDBlob implements Blob {
 
 		this.conn = conn;
 		isWritable = true;
-		lobHandle = new CUBRIDLobHandle(UUType.U_TYPE_BLOB, packedLobHandle);
+		isLobLocator = true;
+		lobHandle = new CUBRIDLobHandle(UUType.U_TYPE_BLOB, packedLobHandle, isLobLocator);
 	}
 
 	// get blob from existing result set
-	public CUBRIDBlob(CUBRIDConnection conn, byte[] packedLobHandle) throws SQLException {
+	public CUBRIDBlob(CUBRIDConnection conn, byte[] packedLobHandle, boolean isLobLocator) throws SQLException {
 		if (conn == null || packedLobHandle == null) {
 			throw new CUBRIDException(CUBRIDJDBCErrorCode.invalid_value);
 		}
 
 		this.conn = conn;
 		isWritable = false;
-		lobHandle = new CUBRIDLobHandle(UUType.U_TYPE_BLOB, packedLobHandle);
+		this.isLobLocator = isLobLocator;
+		lobHandle = new CUBRIDLobHandle(UUType.U_TYPE_BLOB, packedLobHandle, isLobLocator);
 	}
 
 	/*
@@ -124,18 +127,23 @@ public class CUBRIDBlob implements Blob {
 
 		byte[] buf = new byte[length];
 
-		while (length > 0) {
-			read_len = Math.min(length, BLOB_MAX_IO_LENGTH);
-			real_read_len = conn.lobRead(lobHandle.getPackedLobHandle(), pos,
-					buf, total_read_len, read_len);
+		if (isLobLocator) {
+			while (length > 0) {
+				read_len = Math.min(length, BLOB_MAX_IO_LENGTH);
+				real_read_len = conn.lobRead(lobHandle.getPackedLobHandle(), pos,
+						buf, total_read_len, read_len);
 
-			pos += real_read_len;
-			length -= real_read_len;
-			total_read_len += real_read_len;
+				pos += real_read_len;
+				length -= real_read_len;
+				total_read_len += real_read_len;
 
-			if (real_read_len == 0) {
-				break;
+				if (real_read_len == 0) {
+					break;
+				}
 			}
+		} else {
+			System.arraycopy(lobHandle.getPackedLobHandle(), (int) pos, buf, 0, length);
+			total_read_len = length;
 		}
 
 		if (total_read_len < buf.length) {
@@ -253,6 +261,7 @@ public class CUBRIDBlob implements Blob {
 		lobHandle = null;
 		streamList = null;
 		isWritable = false;
+		isLobLocator = true;
 	}
 
 	public CUBRIDLobHandle getLobHandle() {

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
@@ -367,7 +367,7 @@ public class CUBRIDClob implements Clob {
 
 		remaining_size = lobHandle.getLobSize() - offset;
 
-		if (remaining_size < 0) {
+		if (remaining_size <= 0) {
 			return 0;
 		}
 

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
@@ -37,6 +37,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.lang.System;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -60,6 +61,7 @@ public class CUBRIDClob implements Clob {
 	 */
 	private CUBRIDConnection conn;
 	private boolean isWritable;
+	private boolean isLobLocator;
 	private CUBRIDLobHandle lobHandle;
 	private String charsetName;
 
@@ -90,7 +92,8 @@ public class CUBRIDClob implements Clob {
 
 		this.conn = conn;
 		isWritable = true;
-		lobHandle = new CUBRIDLobHandle(UUType.U_TYPE_CLOB, packedLobHandle);
+		isLobLocator = true;
+		lobHandle = new CUBRIDLobHandle(UUType.U_TYPE_CLOB, packedLobHandle, isLobLocator);
 		this.charsetName = charsetName;
 
 		clobCharPos = 0;
@@ -101,14 +104,15 @@ public class CUBRIDClob implements Clob {
 
 	// get clob from existing result set
 	public CUBRIDClob(CUBRIDConnection conn, byte[] packedLobHandle,
-			String charsetName) throws SQLException {
+			String charsetName, boolean isLobLocator) throws SQLException {
 		if (conn == null || packedLobHandle == null) {
 			throw new CUBRIDException(CUBRIDJDBCErrorCode.invalid_value);
 		}
 
 		this.conn = conn;
 		isWritable = false;
-		lobHandle = new CUBRIDLobHandle(UUType.U_TYPE_CLOB, packedLobHandle);
+		this.isLobLocator = isLobLocator;
+		lobHandle = new CUBRIDLobHandle(UUType.U_TYPE_CLOB, packedLobHandle, isLobLocator);
 		this.charsetName = charsetName;
 
 		clobCharPos = 0;
@@ -307,6 +311,7 @@ public class CUBRIDClob implements Clob {
 		clobCharBuffer = null;
 		clobByteBuffer = null;
 		isWritable = false;
+		isLobLocator = true;
 	}
 
 	private int readClobPartially(long pos, int length) throws SQLException {
@@ -356,13 +361,36 @@ public class CUBRIDClob implements Clob {
 		return length;
 	}
 
+	private int lobRead(long offset, byte[] buf, int start, int len) throws SQLException {
+		int read_len;
+		long remaining_size;
+
+		remaining_size = lobHandle.getLobSize() - offset;
+
+		if (remaining_size < 0) {
+			return 0;
+		}
+
+		read_len = Math.min((int) remaining_size, len);
+
+		System.arraycopy(lobHandle.getPackedLobHandle(), (int) offset, buf, start, read_len);
+
+		return read_len;
+	}
+
 	private void readClob() throws SQLException {
+		int read_len;
+
 		if (conn == null || lobHandle == null) {
 			throw new NullPointerException();
 		}
 
-		int read_len = conn.lobRead(lobHandle.getPackedLobHandle(),
-				clobNextReadBytePos, clobByteBuffer, 0, CLOB_MAX_IO_LENGTH);
+		if (isLobLocator == true) {
+			read_len = conn.lobRead(lobHandle.getPackedLobHandle(),
+					clobNextReadBytePos, clobByteBuffer, 0, CLOB_MAX_IO_LENGTH);
+		} else {
+			read_len = lobRead(clobNextReadBytePos, clobByteBuffer, 0, CLOB_MAX_IO_LENGTH);
+		}
 
 		StringBuffer sb = new StringBuffer(bytes2string(clobByteBuffer, 0,
 				read_len));
@@ -454,8 +482,13 @@ public class CUBRIDClob implements Clob {
 
 		while (length > 0) {
 			read_len = Math.min(length, CLOB_MAX_IO_LENGTH);
-			real_read_len = conn.lobRead(lobHandle.getPackedLobHandle(), pos,
-					buf, total_read_len, read_len);
+
+			if (isLobLocator == true) {
+				real_read_len = conn.lobRead(lobHandle.getPackedLobHandle(), pos,
+						buf, total_read_len, read_len);
+			} else {
+				real_read_len = lobRead(pos, buf, total_read_len, read_len);
+			}
 
 			pos += real_read_len;
 			length -= real_read_len;

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDClob.java
@@ -448,8 +448,12 @@ public class CUBRIDClob implements Clob {
 		}
 	}
 
-	public String toString() {
-		return lobHandle.toString();
+	public String toString() throws RuntimeException {
+		if (isLobLocator == true) {
+			return lobHandle.toString();
+		} else {
+			throw new RuntimeException("The lob locator does not exist because the column type has changed.");
+		}
 	}
 
 	public boolean equals(Object obj) {

--- a/src/jdbc/cubrid/jdbc/jci/UGetTypeConvertedValue.java
+++ b/src/jdbc/cubrid/jdbc/jci/UGetTypeConvertedValue.java
@@ -47,6 +47,8 @@ import cubrid.sql.CUBRIDOID;
 import cubrid.sql.CUBRIDTimestamp;
 import cubrid.sql.CUBRIDTimestamptz;
 import cubrid.jdbc.driver.CUBRIDBinaryString;
+import cubrid.jdbc.driver.CUBRIDBlob;
+import cubrid.jdbc.driver.CUBRIDConnection;
 import cubrid.jdbc.driver.CUBRIDException;
 
 abstract public class UGetTypeConvertedValue {
@@ -71,6 +73,21 @@ abstract public class UGetTypeConvertedValue {
 			return new BigDecimal(
 					(((Boolean) data).booleanValue() == true) ? (double) 1
 							: (double) 0);
+		throw new UJciException(UErrorCode.ER_TYPE_CONVERSION);
+	}
+
+	static public CUBRIDBlob getBlob(Object data, CUBRIDConnection conn) throws UJciException {
+		if (data == null)
+			return null;
+		else if (data instanceof CUBRIDBlob)
+			return (CUBRIDBlob) data;
+		else if (data instanceof byte[]) {
+			try {
+				return new CUBRIDBlob(conn, (byte[]) data, false);
+			} catch (Exception e) {
+				throw new UJciException(UErrorCode.ER_TYPE_CONVERSION);
+			}
+		}
 		throw new UJciException(UErrorCode.ER_TYPE_CONVERSION);
 	}
 

--- a/src/jdbc/cubrid/jdbc/jci/UGetTypeConvertedValue.java
+++ b/src/jdbc/cubrid/jdbc/jci/UGetTypeConvertedValue.java
@@ -48,6 +48,7 @@ import cubrid.sql.CUBRIDTimestamp;
 import cubrid.sql.CUBRIDTimestamptz;
 import cubrid.jdbc.driver.CUBRIDBinaryString;
 import cubrid.jdbc.driver.CUBRIDBlob;
+import cubrid.jdbc.driver.CUBRIDClob;
 import cubrid.jdbc.driver.CUBRIDConnection;
 import cubrid.jdbc.driver.CUBRIDException;
 
@@ -134,6 +135,22 @@ abstract public class UGetTypeConvertedValue {
 		if (data instanceof byte[])
 			return (byte[]) ((byte[]) data).clone();
 
+		throw new UJciException(UErrorCode.ER_TYPE_CONVERSION);
+	}
+
+	static public CUBRIDClob getClob(Object data, CUBRIDConnection conn) throws UJciException {
+		if (data == null)
+			return null;
+		else if (data instanceof CUBRIDClob)
+			return (CUBRIDClob) data;
+		else if (data instanceof String) {
+			try {
+				return new CUBRIDClob(conn, ((String) data).getBytes(),
+						conn.getUConnection().getCharset(), false);
+			} catch (Exception e) {
+				throw new UJciException(UErrorCode.ER_TYPE_CONVERSION);
+			}
+		}
 		throw new UJciException(UErrorCode.ER_TYPE_CONVERSION);
 	}
 

--- a/src/jdbc/cubrid/jdbc/jci/UInputBuffer.java
+++ b/src/jdbc/cubrid/jdbc/jci/UInputBuffer.java
@@ -506,7 +506,7 @@ class UInputBuffer {
 		try {
 			byte[] packedLobHandle = readBytes(packedLobHandleSize);
 			return new CUBRIDClob(conn, packedLobHandle, conn.getUConnection()
-					.getCharset());
+					.getCharset(), true);
 		} catch (Exception e) {
 		    	throw uconn.createJciException(UErrorCode.ER_UNKNOWN);
 		}

--- a/src/jdbc/cubrid/jdbc/jci/UInputBuffer.java
+++ b/src/jdbc/cubrid/jdbc/jci/UInputBuffer.java
@@ -495,7 +495,7 @@ class UInputBuffer {
 			throws UJciException {
 		try {
 			byte[] packedLobHandle = readBytes(packedLobHandleSize);
-			return new CUBRIDBlob(conn, packedLobHandle);
+			return new CUBRIDBlob(conn, packedLobHandle, true);
 		} catch (Exception e) {
 		    	throw uconn.createJciException(UErrorCode.ER_UNKNOWN);
 		}

--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -1326,11 +1326,11 @@ public class UStatement {
 		if (obj == null)
 			return null;
 
-		if (obj instanceof CUBRIDClob) {
-			return ((CUBRIDClob) obj);
+		try {
+			return (UGetTypeConvertedValue.getClob(obj, relatedConnection.getCUBRIDConnection()));
+		} catch (UJciException e) {
+			e.toUError(errorHandler);
 		}
-
-		errorHandler.setErrorCode(UErrorCode.ER_TYPE_CONVERSION);
 		return null;
 	}
 

--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -1311,11 +1311,11 @@ public class UStatement {
 		if (obj == null)
 			return null;
 
-		if (obj instanceof CUBRIDBlob) {
-			return ((CUBRIDBlob) obj);
+		try {
+			return (UGetTypeConvertedValue.getBlob(obj, relatedConnection.getCUBRIDConnection()));
+		} catch (UJciException e) {
+			e.toUError(errorHandler);
 		}
-
-		errorHandler.setErrorCode(UErrorCode.ER_TYPE_CONVERSION);
 		return null;
 	}
 
@@ -2140,7 +2140,7 @@ public class UStatement {
 		String charsetName;
 
 		size = inBuffer.readInt();
-		if (size <= 0)
+		if (size < 0)
 			return null;
 
 		typeInfo = readTypeFromData(index, inBuffer);


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-825

In case of LOB columns in CUBRID, only the LOB locator(file path) is synchronized, and the actual data in that file is not replicated in HA environment. usually, to avoid this problem, table schema is created by converting BLOB column to BIT VARYING type and CLOB column to VARCHAR(MAX) type. therefore, when calling ResultSet.getBlob() or ResultSet.getClob() in JDBC, it should be supported if the table schema is BIT VARYING type or VARCHAR(MAX) type.

- The same result should be obtained when BLOB method is called for BLOB column and BIT VARYING column.
- The same result should be obtained when CLOB method is called for CLOB column and VARCHAR column.