### PR TITLE
[APIS-782] revised: JDBC isValid() in CUBRIDConnection throws UnsupportedOperationException

### DIFF
--- a/src/jdbc/cubrid/jdbc/jci/UConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UConnection.java
@@ -1844,6 +1844,9 @@ public class UConnection {
 			return !isClosed;
 		}
 		try {
+			byte[] session = new byte[4];
+			for (int i = 0; i < 4; i++) session[i] = sessionId[i + 8];
+
 			int status = BrokerHandler.statusBroker(CASIp, CASPort, processId, sessionId, timeout);
 			if (status == UConnection.FN_STATUS_NONE) {
     				return false;


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-782
This is a revised PR for #2270