### PR TITLE
[CBRD-20577] Use of alias with function inside ‘Order By’ Clause

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -7787,6 +7787,12 @@ pt_mark_group_having_pt_name (PARSER_CONTEXT * parser, PT_NODE * node, void *chk
 	parser_walk_tree (parser, node->info.query.q.select.having, pt_mark_pt_name, NULL, NULL, NULL);
     }
 
+  if (node->info.query.order_by != NULL)
+    {
+      node->info.query.order_by =
+	parser_walk_tree (parser, node->info.query.order_by, pt_mark_pt_name, NULL, NULL, NULL);
+    }
+
   return node;
 }
 
@@ -7979,6 +7985,14 @@ pt_resolve_group_having_alias (PARSER_CONTEXT * parser, PT_NODE * node, void *ch
 
   /* support for alias in HAVING */
   pt_cur = node->info.query.q.select.having;
+  while (pt_cur != NULL)
+    {
+      pt_resolve_group_having_alias_internal (parser, &pt_cur, node->info.query.q.select.list);
+      pt_cur = pt_cur->next;
+    }
+
+  /* support for alias in ORDER BY */
+  pt_cur = node->info.query.order_by;
   while (pt_cur != NULL)
     {
       pt_resolve_group_having_alias_internal (parser, &pt_cur, node->info.query.q.select.list);

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -7787,10 +7787,14 @@ pt_mark_group_having_pt_name (PARSER_CONTEXT * parser, PT_NODE * node, void *chk
 	parser_walk_tree (parser, node->info.query.q.select.having, pt_mark_pt_name, NULL, NULL, NULL);
     }
 
-  if (node->info.query.order_by != NULL)
+  if (!PT_SELECT_INFO_IS_FLAGED(node, PT_SELECT_INFO_COLS_SCHEMA | PT_SELECT_FULL_INFO_COLS_SCHEMA))
     {
-      node->info.query.order_by =
-	parser_walk_tree (parser, node->info.query.order_by, pt_mark_pt_name, NULL, NULL, NULL);
+
+      if (node->info.query.order_by != NULL)
+        {
+          node->info.query.order_by =
+	    parser_walk_tree (parser, node->info.query.order_by, pt_mark_pt_name, NULL, NULL, NULL);
+        }
     }
 
   return node;
@@ -7992,11 +7996,14 @@ pt_resolve_group_having_alias (PARSER_CONTEXT * parser, PT_NODE * node, void *ch
     }
 
   /* support for alias in ORDER BY */
-  pt_cur = node->info.query.order_by;
-  while (pt_cur != NULL)
+  if (!PT_SELECT_INFO_IS_FLAGED(node, PT_SELECT_INFO_COLS_SCHEMA | PT_SELECT_FULL_INFO_COLS_SCHEMA))
     {
-      pt_resolve_group_having_alias_internal (parser, &pt_cur, node->info.query.q.select.list);
-      pt_cur = pt_cur->next;
+      pt_cur = node->info.query.order_by;
+      while (pt_cur != NULL)
+        {
+          pt_resolve_group_having_alias_internal (parser, &pt_cur, node->info.query.q.select.list);
+          pt_cur = pt_cur->next;
+        }
     }
   return node;
 }

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -7790,10 +7790,10 @@ pt_mark_group_having_pt_name (PARSER_CONTEXT * parser, PT_NODE * node, void *chk
   if (!PT_SELECT_INFO_IS_FLAGED (node, PT_SELECT_INFO_COLS_SCHEMA | PT_SELECT_FULL_INFO_COLS_SCHEMA))
     {
       if (node->info.query.order_by != NULL)
-        {
-          node->info.query.order_by =
-            parser_walk_tree (parser, node->info.query.order_by, pt_mark_pt_name, NULL, NULL, NULL);
-        }
+	{
+	  node->info.query.order_by =
+	    parser_walk_tree (parser, node->info.query.order_by, pt_mark_pt_name, NULL, NULL, NULL);
+	}
     }
 
   return node;
@@ -7999,10 +7999,10 @@ pt_resolve_group_having_alias (PARSER_CONTEXT * parser, PT_NODE * node, void *ch
     {
       pt_cur = node->info.query.order_by;
       while (pt_cur != NULL)
-        {
-          pt_resolve_group_having_alias_internal (parser, &pt_cur, node->info.query.q.select.list);
-          pt_cur = pt_cur->next;
-        }
+	{
+	  pt_resolve_group_having_alias_internal (parser, &pt_cur, node->info.query.q.select.list);
+	  pt_cur = pt_cur->next;
+	}
     }
   return node;
 }

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -7787,13 +7787,12 @@ pt_mark_group_having_pt_name (PARSER_CONTEXT * parser, PT_NODE * node, void *chk
 	parser_walk_tree (parser, node->info.query.q.select.having, pt_mark_pt_name, NULL, NULL, NULL);
     }
 
-  if (!PT_SELECT_INFO_IS_FLAGED(node, PT_SELECT_INFO_COLS_SCHEMA | PT_SELECT_FULL_INFO_COLS_SCHEMA))
+  if (!PT_SELECT_INFO_IS_FLAGED (node, PT_SELECT_INFO_COLS_SCHEMA | PT_SELECT_FULL_INFO_COLS_SCHEMA))
     {
-
       if (node->info.query.order_by != NULL)
         {
           node->info.query.order_by =
-	    parser_walk_tree (parser, node->info.query.order_by, pt_mark_pt_name, NULL, NULL, NULL);
+            parser_walk_tree (parser, node->info.query.order_by, pt_mark_pt_name, NULL, NULL, NULL);
         }
     }
 
@@ -7996,7 +7995,7 @@ pt_resolve_group_having_alias (PARSER_CONTEXT * parser, PT_NODE * node, void *ch
     }
 
   /* support for alias in ORDER BY */
-  if (!PT_SELECT_INFO_IS_FLAGED(node, PT_SELECT_INFO_COLS_SCHEMA | PT_SELECT_FULL_INFO_COLS_SCHEMA))
+  if (!PT_SELECT_INFO_IS_FLAGED (node, PT_SELECT_INFO_COLS_SCHEMA | PT_SELECT_FULL_INFO_COLS_SCHEMA))
     {
       pt_cur = node->info.query.order_by;
       while (pt_cur != NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-20577

**The order by clause should allow the alias name specified at select list as ORACLE.**

The function **pt_resolve_names** calls **parser_walk_tree with pt_mark_group_having_pt_name**.
And  the function **pt_mark_group_having_pt_name** calls again _parser_walk_tree_ with _node->info.query.q.select.group_by_ and _node->info.query.q.select.having_ for resolving name resolutions.

We need to add parser_walk_tree with _node->info.query.order_by_.

As the same reason, we need to add the loop by **pt_resolve_group_having_alias_internal** with _node->info.query.order_by_ in the function **pt_resolve_group_having_alias**.