### PR TITLE
[CBRD-21022] executeBatch returns Cannot communicate with the broker or received invalid packet & CAS down with core dump

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -20987,8 +20987,8 @@ parser_generate_xasl_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, in
     case PT_UNION:
     case PT_DIFFERENCE:
     case PT_INTERSECTION:
-      /* The parser tree can be reused when multiple queries are executed through ux_execute_array ().
-	 The XASL object has already been freed at pt_exit_packing_buf (), so only node->info.query.xasl is changed to null. */
+      /* The parser tree can be reused when multiple queries are executed through ux_execute_array (). */
+      /* The XASL object has already been freed at pt_exit_packing_buf (), so only node->info.query.xasl is changed to null. */
       node->info.query.xasl = NULL;
 
       (void) pt_query_set_reference (parser, node);

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -20987,11 +20987,12 @@ parser_generate_xasl_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, in
     case PT_UNION:
     case PT_DIFFERENCE:
     case PT_INTERSECTION:
-      if (!node->info.query.xasl)
+      if (node->info.query.xasl)
 	{
-	  (void) pt_query_set_reference (parser, node);
-	  pt_push_symbol_info (parser, node);
+	  node->info.query.xasl = NULL;
 	}
+      (void) pt_query_set_reference (parser, node);
+      pt_push_symbol_info (parser, node);
       break;
 
     default:

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -20987,10 +20987,10 @@ parser_generate_xasl_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, in
     case PT_UNION:
     case PT_DIFFERENCE:
     case PT_INTERSECTION:
-      if (node->info.query.xasl)
-	{
-	  node->info.query.xasl = NULL;
-	}
+      /* The parser tree can be reused when multiple queries are executed through ux_execute_array ().
+	 The XASL object has already been freed at pt_exit_packing_buf (), so only node->info.query.xasl is changed to null. */
+      node->info.query.xasl = NULL;
+
       (void) pt_query_set_reference (parser, node);
       pt_push_symbol_info (parser, node);
       break;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -13432,16 +13432,6 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
       goto cleanup;
     }
 
-  /* prevent blob, clob plan cache */
-  for (attr_list = statement->info.insert.attr_list; attr_list != NULL; attr_list = attr_list->next)
-    {
-      if (attr_list->type_enum == PT_TYPE_BLOB || attr_list->type_enum == PT_TYPE_CLOB)
-	{
-	  goto cleanup;
-	}
-    }
-  /* Checks above are required before any early outs. */
-
   error = do_prepare_insert_internal (parser, statement);
 
 cleanup:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21022

fix to enable XASL cache for insert statements containing clobs and blobs and do not reuse XASL at XASL generator step