### PR TITLE
[CBRD-23637] Implementation of secure CUBRID jdbc driver

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/ConnectionProperties.java
+++ b/src/jdbc/cubrid/jdbc/driver/ConnectionProperties.java
@@ -351,6 +351,8 @@ public class ConnectionProperties {
     BooleanConnectionProperty oracleStyleEmptyString = new BooleanConnectionProperty(
             "oracleStyleEmptyString", false);
 
+    BooleanConnectionProperty useSSL = new BooleanConnectionProperty("useSSL", false);
+
     public boolean getLogOnException() {
 	return logOnException.getValueAsBoolean();
     }
@@ -408,5 +410,9 @@ public class ConnectionProperties {
 
     public boolean getOracleStyleEmptyString() {
         return oracleStyleEmptyString.getValueAsBoolean();
+    }
+
+    public boolean getUseSSL() {
+        return useSSL.getValueAsBoolean();
     }
 }

--- a/src/jdbc/cubrid/jdbc/jci/UClientSideConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UClientSideConnection.java
@@ -198,6 +198,8 @@ public class UClientSideConnection extends UConnection {
 		} else {
 			int retry = 0;
 			UUnreachableHostList unreachableHosts = UUnreachableHostList.getInstance();
+			boolean useSSL = connectionProperties.getUseSSL();
+			unreachableHosts.setUseSSL(useSSL);
 
 			do {
 				for (int hostId = 0; hostId < altHosts.size(); hostId++) {
@@ -254,7 +256,8 @@ public class UClientSideConnection extends UConnection {
 		}
 
 		int timeout = connectionProperties.getConnectTimeout() * 1000;
-		client = BrokerHandler.connectBroker(casIp, casPort, getTimeout(endTimestamp, timeout));
+		boolean useSSL = connectionProperties.getUseSSL();
+		client = BrokerHandler.connectBroker(casIp, casPort, useSSL, getTimeout(endTimestamp, timeout));
 		output = new DataOutputStream(client.getOutputStream());
 		connectDB(getTimeout(endTimestamp, timeout));
 

--- a/src/jdbc/cubrid/jdbc/jci/UConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UConnection.java
@@ -82,6 +82,7 @@ public abstract class UConnection {
 
 	// this value is defined in broker/cas_protocol.h
 	private final static String magicString = "CUBRK";
+	private final static String magicStringSSL = "CUBRS";
 	private final static byte CAS_CLIENT_JDBC = 3;
 
 	public static final int PROTOCOL_V0 = 0;
@@ -178,6 +179,7 @@ public abstract class UConnection {
 	public final static int FN_STATUS_DONE = 2;
 
 	public static byte[] driverInfo;
+	public static byte[] driverInfossl;
 
 	static {
 		driverInfo = new byte[10];
@@ -187,6 +189,16 @@ public abstract class UConnection {
 		driverInfo[7] = CAS_RENEWED_ERROR_CODE | CAS_SUPPORT_HOLDABLE_RESULT;
 		driverInfo[8] = 0; // reserved
 		driverInfo[9] = 0; // reserved
+	}
+
+	static {
+		driverInfossl = new byte[10];
+		UJCIUtil.copy_bytes(driverInfossl, 0, 5, magicStringSSL);
+		driverInfossl[5] = CAS_CLIENT_JDBC;
+		driverInfossl[6] = CAS_PROTO_INDICATOR | CAS_PROTOCOL_VERSION;
+		driverInfossl[7] = CAS_RENEWED_ERROR_CODE | CAS_SUPPORT_HOLDABLE_RESULT;
+		driverInfossl[8] = 0; // reserved
+		driverInfossl[9] = 0; // reserved
 	}
 
 	protected UError errorHandler;

--- a/src/jdbc/cubrid/jdbc/jci/UErrorCode.java
+++ b/src/jdbc/cubrid/jdbc/jci/UErrorCode.java
@@ -106,6 +106,7 @@ abstract public class UErrorCode {
 	public static final int CAS_ER_NOT_IMPLEMENTED = -10100;
 	public static final int CAS_ER_MAX_CLIENT_EXCEEDED = -10101;
 	public static final int CAS_ER_INVALID_CURSOR_POS = -10102;
+	public static final int CAS_ER_SSL_TYPE_NOT_ALLOWED = -10103;
 	public static final int CAS_ER_IS = -10200;
 
 	public final static int CAS_ERROR_INDICATOR = -1;
@@ -237,6 +238,8 @@ abstract public class UErrorCode {
 		CASMessageString.put(new Integer(CAS_ER_NOT_IMPLEMENTED),
 				"Attempt to use a not supported service");
 		CASMessageString.put(new Integer(CAS_ER_MAX_CLIENT_EXCEEDED), "Proxy refused client connection. max clients exceeded");
+		CASMessageString.put(new Integer(CAS_ER_SSL_TYPE_NOT_ALLOWED), 
+                "The requested SSL mode is not permitted, the CAS server is running in a different mode (check useSSL property).");
 		CASMessageString.put(new Integer(CAS_ER_IS), "Authentication failure");
 	}
 }

--- a/src/jdbc/cubrid/jdbc/jci/UUnreachableHostList.java
+++ b/src/jdbc/cubrid/jdbc/jci/UUnreachableHostList.java
@@ -44,6 +44,7 @@ public class UUnreachableHostList {
 
 	private static UUnreachableHostList instance = null;
 	private List<String> unreachableHosts;
+	private boolean useSSL = false;
 
 	private UUnreachableHostList() {
 		unreachableHosts = new CopyOnWriteArrayList<String>();
@@ -107,7 +108,7 @@ public class UUnreachableHostList {
 		long startTime = System.currentTimeMillis();
 
 		try {
-			toBroker = BrokerHandler.connectBroker(ip, port, timeout);
+			toBroker = BrokerHandler.connectBroker(ip, port, useSSL, timeout);
 			if (timeout > 0) {
 				timeout -= (System.currentTimeMillis() - startTime);
 				if (timeout <= 0) {
@@ -141,5 +142,9 @@ public class UUnreachableHostList {
 			if (toBroker != null)
 				toBroker.close();
 		}
+	}
+
+	public void setUseSSL(boolean useSSL) {
+		this.useSSL = useSSL;
 	}
 }

--- a/src/jdbc/cubrid/jdbc/net/BrokerHandler.java
+++ b/src/jdbc/cubrid/jdbc/net/BrokerHandler.java
@@ -8,6 +8,18 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.sql.SQLException;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 import cubrid.jdbc.jci.UConnection;
 import cubrid.jdbc.jci.UErrorCode;
@@ -17,9 +29,10 @@ import cubrid.jdbc.jci.UTimedDataInputStream;
 public class BrokerHandler {
     private static int TIMEOUT_UNIT = 1000;
 
-    public static Socket connectBroker(String ip, int port, int timeout)
+    public static Socket connectBroker(String ip, int port, boolean useSSL, int timeout)
             throws IOException, UJciException {
         Socket toBroker = null;
+        Socket toSSLBroker = null;
         UTimedDataInputStream in = null;
         DataOutputStream out = null;
         long begin = System.currentTimeMillis();
@@ -43,19 +56,36 @@ public class BrokerHandler {
           toBroker.setKeepAlive(true);
           in = new UTimedDataInputStream(toBroker.getInputStream(), ip, port, timeout);
           out = new DataOutputStream(toBroker.getOutputStream());
-          out.write(UConnection.driverInfo);
+
+          if (useSSL == true) {
+	          out.write(UConnection.driverInfossl);
+          } else {
+              out.write(UConnection.driverInfo);
+          }
+
           out.flush();
           int code = in.readInt();
           if (code < 0) {
           // in here, all errors are sent by only a broker
           // the error greater than -10000 is sent by old broker
-            if (code > -10000) {
+          if (code > -10000) {
               code -= 9000;
-            }
-            throw new UJciException(code);
           }
-          else if (code == 0) {
-            return toBroker;
+
+          // There is an issue that cannot display an error text. (All cas error code)
+          if (code == UErrorCode.CAS_ER_SSL_TYPE_NOT_ALLOWED) {
+              throw new UJciException(UErrorCode.ER_DBMS, UErrorCode.CAS_ERROR_INDICATOR, code, "");
+          } else {
+              throw new UJciException(code);   
+          }
+
+	      } else if (code == 0) {
+              if (useSSL == true) {
+                  toSSLBroker = (Socket)createSSLSocket(toBroker, ip, port);
+                  return (Socket)toSSLBroker;
+              } else {
+                  return toBroker;
+              }
           }
 
           // if (code > 0) { only windows }
@@ -76,7 +106,12 @@ public class BrokerHandler {
           }
 
           toBroker.setKeepAlive(true);
-          return toBroker;
+          if (useSSL == true) {
+              toSSLBroker = (Socket)createSSLSocket(toBroker, ip, code);
+              return (Socket)toSSLBroker;
+          } else {
+              return toBroker;
+          }
         } catch (SocketTimeoutException e) {
           if (toBroker != null) {
           toBroker.close();
@@ -251,5 +286,51 @@ public class BrokerHandler {
         dao.writeInt(process);
 
         cancelRequest(ip, port, bao.toByteArray(), timeout);
+    }
+
+    private static SSLSocket createSSLSocket(Socket plainSocket, String ip, int port) throws UJciException {
+        SSLSocket sslSocket = null;
+        SSLContext ctx = null;
+        SSLSocketFactory sslsocketfactory = null;
+
+        X509TrustManager tm = new X509TrustManager() {
+            public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            }
+
+            public void checkServerTrusted(X509Certificate[] xcs, String string) throws CertificateException {
+            }
+
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+
+        try {
+            ctx = SSLContext.getInstance("TLS");
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            throw new UJciException(UErrorCode.ER_CONNECTION, e);
+        }
+
+        try {
+            ctx.init(null, new TrustManager[] { tm }, new SecureRandom());
+        } catch (KeyManagementException e) {
+            e.printStackTrace();
+            throw new UJciException(UErrorCode.ER_CONNECTION, e);
+        }
+
+        sslsocketfactory = ctx.getSocketFactory();
+        try {
+            sslSocket = (SSLSocket) sslsocketfactory.createSocket(plainSocket, ip, port, true);
+            sslSocket.startHandshake();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+            throw new UJciException(UErrorCode.ER_CONNECTION, e);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new UJciException(UErrorCode.ER_CONNECTION, e);
+        }
+
+        return sslSocket;
     }
 }

--- a/src/jdbc/cubrid/jdbc/net/BrokerHandler.java
+++ b/src/jdbc/cubrid/jdbc/net/BrokerHandler.java
@@ -308,14 +308,12 @@ public class BrokerHandler {
         try {
             ctx = SSLContext.getInstance("TLS");
         } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
             throw new UJciException(UErrorCode.ER_CONNECTION, e);
         }
 
         try {
             ctx.init(null, new TrustManager[] { tm }, new SecureRandom());
         } catch (KeyManagementException e) {
-            e.printStackTrace();
             throw new UJciException(UErrorCode.ER_CONNECTION, e);
         }
 
@@ -323,11 +321,7 @@ public class BrokerHandler {
         try {
             sslSocket = (SSLSocket) sslsocketfactory.createSocket(plainSocket, ip, port, true);
             sslSocket.startHandshake();
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
-            throw new UJciException(UErrorCode.ER_CONNECTION, e);
         } catch (IOException e) {
-            e.printStackTrace();
             throw new UJciException(UErrorCode.ER_CONNECTION, e);
         }
 


### PR DESCRIPTION
* Add useSSL to property.
* Add MagicStr(CUBRS) for SSL.
* Add SSL parameter for Broker connection.
* Add SSL for encryption only. (without server authentication)
* Add error code : CAS_ER_SSL_TYPE_NOT_ALLOWED = -10103
* Add driverInfossl for SSL

http://jira.cubrid.org/browse/CBRD-23637
