### PR TITLE
[CBRD-23686] If the number of index columns is large, the optimizer cannot select a more appropriate index.

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -1931,11 +1931,7 @@ qo_iscan_cost (QO_PLAN * planp)
       for (t = bitset_iterate (&(planp->plan_un.scan.terms), &iter); t != -1; t = bitset_next_member (&iter))
 	{
 	  termp = QO_ENV_TERM (QO_NODE_ENV (nodep), t);
-
 	  sel *= QO_TERM_SELECTIVITY (termp);
-
-	  /* check upper bound */
-	  sel = MIN (sel, 1.0);
 
 	  /* each term can have multi index column. e.g.) (a,b) in .. */
 	  for (int j = 0; j < index_entryp->col_num; j++)
@@ -1946,6 +1942,8 @@ qo_iscan_cost (QO_PLAN * planp)
 		}
 	    }
 	}
+      /* check upper bound */
+      sel = MIN (sel, 1.0);
 
       sel_limit = 0.0;		/* init */
 

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -1932,21 +1932,7 @@ qo_iscan_cost (QO_PLAN * planp)
 	{
 	  termp = QO_ENV_TERM (QO_NODE_ENV (nodep), t);
 
-	  if (i == 0)
-	    {			/* the first key-range term of the index scan */
-	      sel *= QO_TERM_SELECTIVITY (termp);
-	    }
-	  else
-	    {			/* apply heuristic factor */
-	      if (QO_TERM_SELECTIVITY (termp) < 0.1)
-		{
-		  sel *= QO_TERM_SELECTIVITY (termp) * pow ((double) n, 2);
-		}
-	      else
-		{
-		  sel *= QO_TERM_SELECTIVITY (termp);
-		}
-	    }
+	  sel *= QO_TERM_SELECTIVITY (termp);
 
 	  /* check upper bound */
 	  sel = MIN (sel, 1.0);
@@ -1959,7 +1945,6 @@ qo_iscan_cost (QO_PLAN * planp)
 		  i++;
 		}
 	    }
-	  n--;
 	}
 
       sel_limit = 0.0;		/* init */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23686

heuristic factor of index scan formula is eliminated.

heuristic factor should be eliminated for the following reasons.
1. if the selectivity is less than the heuristic constant, a combination of multiple columns can be counted as worse.
2. In cubrid, the limit of selectivity is set with accumulated index cardinality, so selectivity is not excessively large.
3. When calculating the IO cost, the page size of the index leaf is considered, so if there are the same conditions, the index with many columns is not selected.
