### PR TITLE
[CBRD-23689] If both outer join and inner join are present, the optimizer cannot find the optimal join order.

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -2069,11 +2069,12 @@ qo_analyze_term (QO_TERM * term, int term_type)
 	  break;
 
 	case PT_OR:
+	  QO_TERM_SET_FLAG (term, QO_TERM_OR_PRED);
+	  /* FALLTHRU */
 	case PT_NOT:
 	case PT_XOR:
 	  /* get segments from the expression itself */
 	  qo_expr_segs (env, pt_expr, &lhs_segs);
-	  QO_TERM_SET_FLAG (term, QO_TERM_OR_PRED);
 	  break;
 
 	  /* the other operators that can not be used as term; error case */

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -6096,7 +6096,7 @@ qo_discover_edges (QO_ENV * env)
 static void
 qo_classify_outerjoin_terms (QO_ENV * env)
 {
-  bool is_null_padded, is_outerjoin;
+  bool is_null_padded, is_outerjoin_for_or_pred;
   int n, i, t;
   BITSET_ITERATOR iter;
   QO_NODE *node, *on_node;
@@ -6156,22 +6156,14 @@ qo_classify_outerjoin_terms (QO_ENV * env)
 	}
 
       nidx_self = -1;		/* init */
-      is_outerjoin = false;
+      is_outerjoin_for_or_pred = false;
       for (t = bitset_iterate (&(QO_TERM_NODES (term)), &iter); t != -1; t = bitset_next_member (&iter))
 	{
 	  node = QO_ENV_NODE (env, t);
 	  nidx_self = MAX (nidx_self, QO_NODE_IDX (node));
 	  if (QO_TERM_IS_FLAGED (term, QO_TERM_OR_PRED) && QO_NODE_IS_OUTER_JOIN (node))
 	    {
-	      is_outerjoin = true;	/* for OR predicate */
-	    }
-	}
-      if (nidx_self != -1)
-	{
-	  node = QO_ENV_NODE (env, nidx_self);
-	  if (QO_NODE_IS_OUTER_JOIN (node))
-	    {
-	      is_outerjoin = true;
+	      is_outerjoin_for_or_pred = true;	/* for OR predicate */
 	    }
 	}
       QO_ASSERT (env, nidx_self < env->nnodes);
@@ -6216,7 +6208,7 @@ qo_classify_outerjoin_terms (QO_ENV * env)
 	    }
 	  else
 	    {
-	      if (is_outerjoin)
+	      if (QO_NODE_IS_OUTER_JOIN (node) || is_outerjoin_for_or_pred)
 		{
 		  QO_TERM_CLASS (term) = QO_TC_AFTER_JOIN;
 
@@ -6232,7 +6224,7 @@ qo_classify_outerjoin_terms (QO_ENV * env)
 	  if (nidx_self >= 0)
 	    {
 	      node = QO_ENV_NODE (env, nidx_self);
-	      if (is_outerjoin)
+	      if (QO_NODE_IS_OUTER_JOIN (node) || is_outerjoin_for_or_pred)
 		{
 		  if (QO_ON_COND_TERM (term))
 		    {

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -6163,7 +6163,7 @@ qo_classify_outerjoin_terms (QO_ENV * env)
 	  nidx_self = MAX (nidx_self, QO_NODE_IDX (node));
 	  if (QO_TERM_IS_FLAGED (term, QO_TERM_OR_PRED) && QO_NODE_IS_OUTER_JOIN (node))
 	    {
-	      is_outerjoin = true; /* for OR predicate */
+	      is_outerjoin = true;	/* for OR predicate */
 	    }
 	}
       if (nidx_self != -1)

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -2073,6 +2073,7 @@ qo_analyze_term (QO_TERM * term, int term_type)
 	case PT_XOR:
 	  /* get segments from the expression itself */
 	  qo_expr_segs (env, pt_expr, &lhs_segs);
+	  QO_TERM_SET_FLAG (term, QO_TERM_OR_PRED);
 	  break;
 
 	  /* the other operators that can not be used as term; error case */
@@ -2085,9 +2086,8 @@ qo_analyze_term (QO_TERM * term, int term_type)
   else
     {				/* if (pt_expr->or_next == NULL) */
       /* term that consist of more than one predicates; do same as PT_OR */
-
       qo_expr_segs (env, pt_expr, &lhs_segs);
-
+      QO_TERM_SET_FLAG (term, QO_TERM_OR_PRED);
     }				/* if (pt_expr->or_next == NULL) */
 
   /* get nodes from segments */
@@ -2630,27 +2630,6 @@ qo_analyze_term (QO_TERM * term, int term_type)
 	      QO_TERM_CLEAR_FLAG (term, QO_TERM_MERGEABLE_EDGE);
 	    }
 	}
-      else
-	{
-	  QO_NODE *node;
-
-	  for (i = 0; i < env->nnodes; i++)
-	    {
-	      node = QO_ENV_NODE (env, i);
-
-	      if (QO_NODE_IDX (node) >= QO_NODE_IDX (head_node) && QO_NODE_IDX (node) < QO_NODE_IDX (tail_node))
-		{
-		  if (QO_NODE_PT_JOIN_TYPE (node) == PT_JOIN_LEFT_OUTER
-		      || QO_NODE_PT_JOIN_TYPE (node) == PT_JOIN_RIGHT_OUTER
-		      || QO_NODE_PT_JOIN_TYPE (node) == PT_JOIN_FULL_OUTER)
-		    {
-		      /* record explicit join dependecy */
-		      bitset_union (&(QO_NODE_OUTER_DEP_SET (tail_node)), &(QO_NODE_OUTER_DEP_SET (node)));
-		      bitset_add (&(QO_NODE_OUTER_DEP_SET (tail_node)), QO_NODE_IDX (node));
-		    }
-		}
-	    }
-	}			/* else */
     }
 
 wrapup:
@@ -6117,7 +6096,7 @@ qo_discover_edges (QO_ENV * env)
 static void
 qo_classify_outerjoin_terms (QO_ENV * env)
 {
-  bool is_null_padded;
+  bool is_null_padded, is_outerjoin;
   int n, i, t;
   BITSET_ITERATOR iter;
   QO_NODE *node, *on_node;
@@ -6177,11 +6156,23 @@ qo_classify_outerjoin_terms (QO_ENV * env)
 	}
 
       nidx_self = -1;		/* init */
+      is_outerjoin = false;
       for (t = bitset_iterate (&(QO_TERM_NODES (term)), &iter); t != -1; t = bitset_next_member (&iter))
 	{
 	  node = QO_ENV_NODE (env, t);
-
 	  nidx_self = MAX (nidx_self, QO_NODE_IDX (node));
+	  if (QO_TERM_IS_FLAGED (term, QO_TERM_OR_PRED) && QO_NODE_IS_OUTER_JOIN (node))
+	    {
+	      is_outerjoin = true; /* for OR predicate */
+	    }
+	}
+      if (nidx_self != -1)
+	{
+	  node = QO_ENV_NODE (env, nidx_self);
+	  if (QO_NODE_IS_OUTER_JOIN (node))
+	    {
+	      is_outerjoin = true;
+	    }
 	}
       QO_ASSERT (env, nidx_self < env->nnodes);
 
@@ -6225,7 +6216,7 @@ qo_classify_outerjoin_terms (QO_ENV * env)
 	    }
 	  else
 	    {
-	      if (QO_NODE_IS_OUTER_JOIN (node))
+	      if (is_outerjoin)
 		{
 		  QO_TERM_CLASS (term) = QO_TC_AFTER_JOIN;
 
@@ -6241,17 +6232,13 @@ qo_classify_outerjoin_terms (QO_ENV * env)
 	  if (nidx_self >= 0)
 	    {
 	      node = QO_ENV_NODE (env, nidx_self);
-
-	      if (QO_ON_COND_TERM (term))
+	      if (is_outerjoin)
 		{
-		  if (QO_NODE_IS_OUTER_JOIN (node))
+		  if (QO_ON_COND_TERM (term))
 		    {
 		      QO_TERM_CLASS (term) = QO_TC_DURING_JOIN;
 		    }
-		}
-	      else
-		{
-		  if (QO_NODE_IS_OUTER_JOIN (node))
+		  else
 		    {
 		      QO_TERM_CLASS (term) = QO_TC_AFTER_JOIN;
 		    }

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -731,6 +731,7 @@ struct qo_term
 #define QO_TERM_NON_IDX_SARG_COLL   32	/* not suitable for key range/filter */
 #define QO_TERM_MULTI_COLL_PRED     64	/* multi column && in OP, (a,b) in .. */
 #define QO_TERM_MULTI_COLL_CONST    128	/* multi column && have constant value, (a,1) in .. */
+#define QO_TERM_OR_PRED             256	/* or predicate. e.g.) a=1 or b=2 */
 
 #define QO_TERM_IS_FLAGED(t, f)        (QO_TERM_FLAG(t) & (int) (f))
 #define QO_TERM_SET_FLAG(t, f)         QO_TERM_FLAG(t) |= (int) (f)

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -1931,11 +1931,7 @@ qo_iscan_cost (QO_PLAN * planp)
       for (t = bitset_iterate (&(planp->plan_un.scan.terms), &iter); t != -1; t = bitset_next_member (&iter))
 	{
 	  termp = QO_ENV_TERM (QO_NODE_ENV (nodep), t);
-
 	  sel *= QO_TERM_SELECTIVITY (termp);
-
-	  /* check upper bound */
-	  sel = MIN (sel, 1.0);
 
 	  /* each term can have multi index column. e.g.) (a,b) in .. */
 	  for (int j = 0; j < index_entryp->col_num; j++)
@@ -1946,6 +1942,8 @@ qo_iscan_cost (QO_PLAN * planp)
 		}
 	    }
 	}
+      /* check upper bound */
+      sel = MIN (sel, 1.0);
 
       sel_limit = 0.0;		/* init */
 

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -1932,21 +1932,7 @@ qo_iscan_cost (QO_PLAN * planp)
 	{
 	  termp = QO_ENV_TERM (QO_NODE_ENV (nodep), t);
 
-	  if (i == 0)
-	    {			/* the first key-range term of the index scan */
-	      sel *= QO_TERM_SELECTIVITY (termp);
-	    }
-	  else
-	    {			/* apply heuristic factor */
-	      if (QO_TERM_SELECTIVITY (termp) < 0.1)
-		{
-		  sel *= QO_TERM_SELECTIVITY (termp) * pow ((double) n, 2);
-		}
-	      else
-		{
-		  sel *= QO_TERM_SELECTIVITY (termp);
-		}
-	    }
+	  sel *= QO_TERM_SELECTIVITY (termp);
 
 	  /* check upper bound */
 	  sel = MIN (sel, 1.0);
@@ -1959,7 +1945,6 @@ qo_iscan_cost (QO_PLAN * planp)
 		  i++;
 		}
 	    }
-	  n--;
 	}
 
       sel_limit = 0.0;		/* init */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23689

This issue is a regression of CUBRIDSUS-13884.
I fix to add 'QO_TERM_OR_PRED' flag to the term. and in the case of 'QO_TERM_OR_PRED', if there are outer join among all the nodes included, modify term classification to become after-join-term.