### PR TITLE
[CBRD-22637] Excessive domain cache degrades search performance using index scan

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -14150,9 +14150,10 @@ btree_locate_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_VALUE * key, 
   assert (!BTREE_INVALID_INDEX_ID (btid_int->sys_btid));
 
   *found_p = false;
+  bool reuse_btid_int = true;
 
   /* Advance in b-tree following key until leaf node is reached. */
-  error = btree_search_key_and_apply_functions (thread_p, btid_int->sys_btid, NULL, key, NULL, NULL,
+  error = btree_search_key_and_apply_functions (thread_p, btid_int->sys_btid, btid_int, key, NULL, &reuse_btid_int,
 						btree_advance_and_find_key, slot_id, NULL, NULL, &search_key,
 						&leaf_page);
   if (error != NO_ERROR)
@@ -22683,8 +22684,10 @@ btree_get_root_with_key (THREAD_ENTRY * thread_p, BTID * btid, BTID_INT * btid_i
   assert (is_leaf != NULL);
   assert (search_key != NULL);
 
+  bool reuse_btid_int = other_args ? *((bool *) other_args) : false;
+
   /* Get root page and BTID_INT. */
-  *root_page = btree_fix_root_with_info (thread_p, btid, PGBUF_LATCH_READ, NULL, &root_header, btid_int);
+  *root_page = btree_fix_root_with_info (thread_p, btid, PGBUF_LATCH_READ, NULL, &root_header, (reuse_btid_int ? NULL : btid_int));
   if (*root_page == NULL)
     {
       /* Error! */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -22687,7 +22687,8 @@ btree_get_root_with_key (THREAD_ENTRY * thread_p, BTID * btid, BTID_INT * btid_i
   bool reuse_btid_int = other_args ? *((bool *) other_args) : false;
 
   /* Get root page and BTID_INT. */
-  *root_page = btree_fix_root_with_info (thread_p, btid, PGBUF_LATCH_READ, NULL, &root_header, (reuse_btid_int ? NULL : btid_int));
+  *root_page =
+    btree_fix_root_with_info (thread_p, btid, PGBUF_LATCH_READ, NULL, &root_header, (reuse_btid_int ? NULL : btid_int));
   if (*root_page == NULL)
     {
       /* Error! */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22637

This issue is caused by the modification of 'Refactor btree.c'.(CUBRIDSUS-15385)

In CUBRIDSUS-15385 fix, btree_search_key_and_apply_functions() was added for general usage in other btree operations. The problem is that btid_int regenerates in scan_next_scan() without using btid_int saved when opened.

When called from qexec_execute_mainblock() ==> scan_next_scan(), btid_int must be modified to be reused. I modify to reuse btid_int by adding the reuse_btid_int variable.