### PR TITLE
[CBRD-23642] Relieve error severity with a wrong backup time

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7957,7 +7957,7 @@ logpb_check_stop_at_time (FILEIO_BACKUP_SESSION * session, time_t stop_at, time_
 	  ctime_buf2[time_str_len - 1] = 0;
 	}
 
-      er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_UPTODATE_ERROR, 2, ctime_buf1, ctime_buf2);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_UPTODATE_ERROR, 2, ctime_buf1, ctime_buf2);
 
       return ER_LOG_UPTODATE_ERROR;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23642

With #2251, if a too early backup time is given while "restoredb", it prints FATAL_ERROR and fails.
However, FATAL_ERROR is a too severe error to handle the case in which a utility to fail gracefully because of the wrong parameter. So, I relieve the severity of Error to ERROR from FATAL_ERROR.

As a note, the severity level is as following:
FATAL > ERROR > SYNTAX > NOTIFICATION > WARNING
