### PR TITLE
[CBRD-23696] Core dump occurs when correlated subquery is used as in-line view.

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -2975,7 +2975,7 @@ get_term_subqueries (QO_ENV * env, QO_TERM * term)
   PT_NODE *pt_expr, *next;
   WALK_INFO info;
 
-  if (QO_IS_FAKE_TERM (term))
+  if (QO_IS_DEP_TERM (term))
     {
       /*
        * This is a pseudo-term introduced to keep track of derived
@@ -8230,6 +8230,12 @@ qo_node_dump (QO_NODE * node, FILE * f)
     {
       fputs (" (outer-dep-set ", f);
       bitset_print (&(QO_NODE_OUTER_DEP_SET (node)), f);
+      fputs (")", f);
+    }
+  if (!bitset_is_empty (&(QO_NODE_DEP_SET (node))))
+    {
+      fputs (" (dep-set ", f);
+      bitset_print (&(QO_NODE_DEP_SET (node)), f);
       fputs (")", f);
     }
 

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -571,6 +571,7 @@ typedef enum
 #define QO_IS_PATH_TERM(t)	(QO_TERM_CLASS(t) & 0x20)
 #define QO_IS_EDGE_TERM(t)	(QO_TERM_CLASS(t) & 0x10)
 #define QO_IS_FAKE_TERM(t)	(QO_TERM_CLASS(t) & 0x08)
+#define QO_IS_DEP_TERM(t)	(QO_TERM_CLASS(t) == QO_TC_DEP_LINK || QO_TERM_CLASS(t) == QO_TC_DEP_JOIN)
 
 struct qo_term
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23696

1. Term classification of 'QO_TC_DUMMY_JOIN' is excluded from pseudo-term of derived table dependency.
AS-is : QO_IS_FAKE_TERM()
           - QO_TC_DEP_LINK, QO_TC_DEP_JOIN,  QO_TC_DUMMY_JOIN.
TO-be : QO_IS_DEP_TERM()
           - QO_TC_DEP_LINK, QO_TC_DEP_JOIN

2. dep-set  is added to plan-output.