### PR TITLE
[CBRD-23602] processing in case that xasl clone is disable

### DIFF
--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1382,19 +1382,16 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
    /* if needed to invalidate query cache, invalidate the cache */
   if (qmgr_can_get_from_cache (*flag_p))
     {
-      if (xasl_cache_entry_p->cache_clones && xasl_cache_entry_p->cache_clones->xasl)
+      switch (xclone.xasl->type)
         {
-          switch (xasl_cache_entry_p->cache_clones->xasl->type)
-            {
-              case UPDATE_PROC:
-              case INSERT_PROC:
-              case DELETE_PROC:
-              case MERGE_PROC:
-                xcache_invalidate_qcaches(thread_p, &xasl_cache_entry_p->related_objects[0].oid);
-                break;
-              default:
-                break;
-            }
+          case UPDATE_PROC:
+          case INSERT_PROC:
+          case DELETE_PROC:
+          case MERGE_PROC:
+            xcache_invalidate_qcaches(thread_p, &xasl_cache_entry_p->related_objects[0].oid);
+            break;
+          default:
+            break;
         }
     }
 

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -136,7 +136,7 @@ QMGR_QUERY_TABLE qmgr_Query_table = { NULL, 0, NULL,
   {{PTHREAD_MUTEX_INITIALIZER, NULL, 0}, {PTHREAD_MUTEX_INITIALIZER, NULL, 0}}
 };
 
-void xcache_invalidate_qcaches(THREAD_ENTRY * thread_p, const OID * arg);
+void xcache_invalidate_qcaches (THREAD_ENTRY * thread_p, const OID * arg);
 
 #if !defined(SERVER_MODE)
 static struct drand48_data qmgr_rand_buf;
@@ -1379,20 +1379,20 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
       goto exit_on_error;
     }
 
-   /* if needed to invalidate query cache, invalidate the cache */
+  /* if needed to invalidate query cache, invalidate the cache */
   if (qmgr_can_get_from_cache (*flag_p))
     {
       switch (xclone.xasl->type)
-        {
-          case UPDATE_PROC:
-          case INSERT_PROC:
-          case DELETE_PROC:
-          case MERGE_PROC:
-            xcache_invalidate_qcaches(thread_p, &xasl_cache_entry_p->related_objects[0].oid);
-            break;
-          default:
-            break;
-        }
+	{
+	case UPDATE_PROC:
+	case INSERT_PROC:
+	case DELETE_PROC:
+	case MERGE_PROC:
+	  xcache_invalidate_qcaches (thread_p, &xasl_cache_entry_p->related_objects[0].oid);
+	  break;
+	default:
+	  break;
+	}
     }
 
   if (qmgr_can_get_result_from_cache (*flag_p))
@@ -1401,16 +1401,16 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
       list_cache_entry_p = qfile_lookup_list_cache_entry (thread_p, xasl_cache_entry_p->list_ht_no, &params);
       /* If we've got the cached result, return it. */
       if (list_cache_entry_p)
-        {
-          /* found the cached result */
-          cached_result = true;
+	{
+	  /* found the cached result */
+	  cached_result = true;
 
-          CACHE_TIME_MAKE (server_cache_time_p, &list_cache_entry_p->time_created);
-          if (CACHE_TIME_EQ (client_cache_time_p, server_cache_time_p))
-            {
-              goto end;
-            }
-        }
+	  CACHE_TIME_MAKE (server_cache_time_p, &list_cache_entry_p->time_created);
+	  if (CACHE_TIME_EQ (client_cache_time_p, server_cache_time_p))
+	    {
+	      goto end;
+	    }
+	}
     }
 
   if (client_cache_time_p)

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1550,7 +1550,7 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 	   * is, or make new one */
 	  list_cache_entry_p =
 	    qfile_update_list_cache_entry (thread_p, &xasl_cache_entry_p->list_ht_no, &params, list_id_p,
-					   xasl_cache_entry_p->sql_info.sql_hash_text);
+					   xasl_cache_entry_p);
 	  if (list_cache_entry_p == NULL)
 	    {
 	      char *s;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23602

It's needed to process in case that xasl clone is disable, so it will use xclone.xasl instead of xasl_cache_entry_p in checking the query type.