### PR TITLE
[CBRD-23697] occurred error "Cannot coerce value of domain character to domain integer" when executing update.

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -252,8 +252,6 @@ static bool pt_is_explicit_coerce_allowed_for_default_value (PARSER_CONTEXT * pa
 static int pt_coerce_value_internal (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest,
 				     PT_TYPE_ENUM desired_type, PT_NODE * data_type, bool check_string_precision,
 				     bool implicit_coercion);
-static int pt_coerce_value_explicit (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE_ENUM desired_type,
-				     PT_NODE * data_type);
 #if defined(ENABLE_UNUSED_FUNCTION)
 static int generic_func_casecmp (const void *a, const void *b);
 static void init_generic_funcs (void);
@@ -9822,13 +9820,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	  d = tp_domain_cache (d);
 	  SET_EXPECTED_DOMAIN (arg2, d);
 	  pt_preset_hostvar (parser, arg2);
-	}
-      if (PT_IS_VALUE_NODE (arg2) && arg1->type_enum != arg2->type_enum)
-	{
-	  if (pt_coerce_value_explicit (parser, arg2, arg2, arg1_type, arg1->data_type) != NO_ERROR)
-	    {
-	      goto error;
-	    }
+	  arg2->type_enum = PT_TYPE_MAYBE;
 	}
       break;
 
@@ -20298,22 +20290,6 @@ int
 pt_coerce_value (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE_ENUM desired_type, PT_NODE * data_type)
 {
   return pt_coerce_value_internal (parser, src, dest, desired_type, data_type, false, true);
-}
-
-/*
- * pt_coerce_value_explicit () - coerce a PT_VALUE into another PT_VALUE of compatible type
- *   return: NO_ERROR on success, non-zero for ERROR
- *   parser(in):
- *   src(in): a pointer to the original PT_VALUE
- *   dest(out): a pointer to the coerced PT_VALUE
- *   desired_type(in): the desired type of the coerced result
- *   data_type(in): the data type list of a (desired) set type or the data type of an object or NULL
- */
-int
-pt_coerce_value_explicit (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE_ENUM desired_type,
-			  PT_NODE * data_type)
-{
-  return pt_coerce_value_internal (parser, src, dest, desired_type, data_type, false, false);
 }
 
 /*

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -252,6 +252,8 @@ static bool pt_is_explicit_coerce_allowed_for_default_value (PARSER_CONTEXT * pa
 static int pt_coerce_value_internal (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest,
 				     PT_TYPE_ENUM desired_type, PT_NODE * data_type, bool check_string_precision,
 				     bool implicit_coercion);
+static int pt_coerce_value_explicit (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE_ENUM desired_type,
+				     PT_NODE * data_type);
 #if defined(ENABLE_UNUSED_FUNCTION)
 static int generic_func_casecmp (const void *a, const void *b);
 static void init_generic_funcs (void);
@@ -9347,7 +9349,6 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	      node->type_enum = PT_TYPE_DATETIMETZ;
 	    }
 	  break;
-
 	default:
 	  break;
 	}
@@ -9821,6 +9822,13 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	  d = tp_domain_cache (d);
 	  SET_EXPECTED_DOMAIN (arg2, d);
 	  pt_preset_hostvar (parser, arg2);
+	}
+      if (PT_IS_VALUE_NODE (arg2) && arg1->type_enum != arg2->type_enum)
+	{
+	  if (pt_coerce_value_explicit (parser, arg2, arg2, arg1_type, arg1->data_type) != NO_ERROR)
+	    {
+	      goto error;
+	    }
 	}
       break;
 
@@ -20290,6 +20298,21 @@ int
 pt_coerce_value (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE_ENUM desired_type, PT_NODE * data_type)
 {
   return pt_coerce_value_internal (parser, src, dest, desired_type, data_type, false, true);
+}
+
+/*
+ * pt_coerce_value_explicit () - coerce a PT_VALUE into another PT_VALUE of compatible type
+ *   return: NO_ERROR on success, non-zero for ERROR
+ *   parser(in):
+ *   src(in): a pointer to the original PT_VALUE
+ *   dest(out): a pointer to the coerced PT_VALUE
+ *   desired_type(in): the desired type of the coerced result
+ *   data_type(in): the data type list of a (desired) set type or the data type of an object or NULL
+ */
+int
+pt_coerce_value_explicit (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE_ENUM desired_type, PT_NODE * data_type)
+{
+  return pt_coerce_value_internal (parser, src, dest, desired_type, data_type, false, false);
 }
 
 /*

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -20310,7 +20310,8 @@ pt_coerce_value (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE
  *   data_type(in): the data type list of a (desired) set type or the data type of an object or NULL
  */
 int
-pt_coerce_value_explicit (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE_ENUM desired_type, PT_NODE * data_type)
+pt_coerce_value_explicit (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE_ENUM desired_type,
+			  PT_NODE * data_type)
 {
   return pt_coerce_value_internal (parser, src, dest, desired_type, data_type, false, false);
 }

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -5720,6 +5720,12 @@ pt_make_regu_hostvar (PARSER_CONTEXT * parser, const PT_NODE * node)
 	  regu->domain = pt_xasl_node_to_domain (parser, node);
 	}
 
+      if (regu->domain == NULL && node->expected_domain)
+	{
+	  /* try to get domain infor from its expected_domain */
+	  regu->domain = node->expected_domain;
+	}
+
       if (regu->domain == NULL && (parser->set_host_var == 1 || typ != DB_TYPE_NULL))
 	{
 	  /* if the host var DB_VALUE was initialized before, use its domain for regu variable */
@@ -5749,12 +5755,6 @@ pt_make_regu_hostvar (PARSER_CONTEXT * parser, const PT_NODE * node)
 	    {
 	      regu->domain = pt_xasl_type_enum_to_domain (pt_db_to_type_enum (typ));
 	    }
-	}
-
-      if (regu->domain == NULL && node->expected_domain)
-	{
-	  /* try to get domain infor from its expected_domain */
-	  regu->domain = node->expected_domain;
 	}
 
       if (regu->domain == NULL)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -5714,16 +5714,16 @@ pt_make_regu_hostvar (PARSER_CONTEXT * parser, const PT_NODE * node)
       /* determine the domain of this host var */
       regu->domain = NULL;
 
-      if (node->data_type)
-	{
-	  /* try to get domain info from its data_type */
-	  regu->domain = pt_xasl_node_to_domain (parser, node);
-	}
-
       if (regu->domain == NULL && node->expected_domain)
 	{
 	  /* try to get domain infor from its expected_domain */
 	  regu->domain = node->expected_domain;
+	}
+
+      if (regu->domain == NULL && node->data_type)
+	{
+	  /* try to get domain info from its data_type */
+	  regu->domain = pt_xasl_node_to_domain (parser, node);
 	}
 
       if (regu->domain == NULL && (parser->set_host_var == 1 || typ != DB_TYPE_NULL))

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -5714,13 +5714,7 @@ pt_make_regu_hostvar (PARSER_CONTEXT * parser, const PT_NODE * node)
       /* determine the domain of this host var */
       regu->domain = NULL;
 
-      if (regu->domain == NULL && node->expected_domain)
-	{
-	  /* try to get domain infor from its expected_domain */
-	  regu->domain = node->expected_domain;
-	}
-
-      if (regu->domain == NULL && node->data_type)
+      if (node->data_type)
 	{
 	  /* try to get domain info from its data_type */
 	  regu->domain = pt_xasl_node_to_domain (parser, node);
@@ -5755,6 +5749,12 @@ pt_make_regu_hostvar (PARSER_CONTEXT * parser, const PT_NODE * node)
 	    {
 	      regu->domain = pt_xasl_type_enum_to_domain (pt_db_to_type_enum (typ));
 	    }
+	}
+
+      if (regu->domain == NULL && node->expected_domain)
+	{
+	  /* try to get domain infor from its expected_domain */
+	  regu->domain = node->expected_domain;
 	}
 
       if (regu->domain == NULL)

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -1213,13 +1213,13 @@ qdump_print_value (REGU_VARIABLE * value_p)
   switch (value_p->type)
     {
     case TYPE_DBVAL:
-      fprintf (foutput, "type:%s|", qdump_data_type_string (DB_VALUE_DOMAIN_TYPE (&value_p->value.dbval)));
+      fprintf (foutput, "[type:%s]", qdump_data_type_string (DB_VALUE_DOMAIN_TYPE (&value_p->value.dbval)));
       qdump_print_db_value (&value_p->value.dbval);
       return true;
 
     case TYPE_CONSTANT:
     case TYPE_ORDERBY_NUM:
-      fprintf (foutput, "type:%s|", qdump_data_type_string (DB_VALUE_DOMAIN_TYPE (value_p->value.dbvalptr)));
+      fprintf (foutput, "[type:%s]", qdump_data_type_string (DB_VALUE_DOMAIN_TYPE (value_p->value.dbvalptr)));
       qdump_print_db_value (value_p->value.dbvalptr);
       return true;
 
@@ -1231,6 +1231,7 @@ qdump_print_value (REGU_VARIABLE * value_p)
 	}
       return true;
     case TYPE_ATTR_ID:
+      fprintf (foutput, "[type:%s]", qdump_data_type_string (value_p->domain->type->id));
       if (!qdump_print_attribute_id (value_p->value.attr_descr))
 	{
 	  return false;
@@ -1255,6 +1256,7 @@ qdump_print_value (REGU_VARIABLE * value_p)
       return true;
 
     case TYPE_POSITION:
+      fprintf (foutput, "[type:%s]", qdump_data_type_string (value_p->domain->type->id));
       if (!qdump_print_tuple_value_position (value_p->value.pos_descr))
 	{
 	  return false;
@@ -1264,7 +1266,7 @@ qdump_print_value (REGU_VARIABLE * value_p)
 
     case TYPE_POS_VALUE:
     case TYPE_OID:
-      fprintf (foutput, "type:%s|", qdump_data_type_string (value_p->domain->type->id));
+      fprintf (foutput, "[type:%s]", qdump_data_type_string (value_p->domain->type->id));
       return true;
 
     case TYPE_FUNC:

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -1213,11 +1213,13 @@ qdump_print_value (REGU_VARIABLE * value_p)
   switch (value_p->type)
     {
     case TYPE_DBVAL:
+      fprintf (foutput, "type:%s|", qdump_data_type_string (DB_VALUE_DOMAIN_TYPE (&value_p->value.dbval)));
       qdump_print_db_value (&value_p->value.dbval);
       return true;
 
     case TYPE_CONSTANT:
     case TYPE_ORDERBY_NUM:
+      fprintf (foutput, "type:%s|", qdump_data_type_string (DB_VALUE_DOMAIN_TYPE (value_p->value.dbvalptr)));
       qdump_print_db_value (value_p->value.dbvalptr);
       return true;
 
@@ -1262,6 +1264,7 @@ qdump_print_value (REGU_VARIABLE * value_p)
 
     case TYPE_POS_VALUE:
     case TYPE_OID:
+      fprintf (foutput, "type:%s|", qdump_data_type_string (value_p->domain->type->id));
       return true;
 
     case TYPE_FUNC:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23697

1. fix to coerce the value to the type of the assigned column in set clause at semantic check.
2. add type of regu_var to xasl dump output.