### PR TITLE
[CBRD-23649] make dummy table instead of db_root

### DIFF
--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -174,7 +174,8 @@ const char *AU_DBA_USER_NAME = "DBA";
          strcmp(name, CT_PASSWORD_NAME) == 0 || \
          strcmp(name, CT_AUTHORIZATION_NAME) == 0 || \
          strcmp(name, CT_AUTHORIZATIONS_NAME) == 0 || \
-	 strcmp(name, CT_CHARSET_NAME) == 0)
+	 strcmp(name, CT_CHARSET_NAME) == 0 || \
+   strcmp(name, CT_DUAL_NAME) == 0)
 
 enum fetch_by
 {

--- a/src/object/transform.h
+++ b/src/object/transform.h
@@ -143,6 +143,7 @@ typedef struct tf_ct_class
 #define CT_AUTHORIZATION_NAME      "db_authorization"
 #define CT_AUTHORIZATIONS_NAME     "db_authorizations"
 #define CT_CHARSET_NAME		   "_db_charset"
+#define CT_DUAL_NAME               "dual"
 
 /* catalog vclasses */
 #define CTV_CLASS_NAME             "db_class"

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -6741,7 +6741,7 @@ pt_make_query_show_create_table (PARSER_CONTEXT * parser, PT_NODE * table_name)
    */
   pt_add_string_col_to_sel_list (parser, select, table_name->info.name.original, "TABLE");
   pt_add_string_col_to_sel_list (parser, select, strbuf.get_buffer (), "CREATE TABLE");
-  pt_add_table_name_to_from_list (parser, select, "db_root", NULL, DB_AUTH_SELECT);
+  pt_add_table_name_to_from_list (parser, select, "dual", NULL, DB_AUTH_SELECT);
   return select;
 }
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -3266,7 +3266,7 @@ pt_filter_pseudo_specs (PARSER_CONTEXT * parser, PT_NODE * spec)
       spec->info.spec.id = (UINTPTR) spec;
       spec->info.spec.only_all = PT_ONLY;
       spec->info.spec.meta_class = PT_CLASS;
-      spec->info.spec.entity_name = pt_name (parser, "db_root");
+      spec->info.spec.entity_name = pt_name (parser, "dual");
       if (spec->info.spec.entity_name == NULL)
 	{
 	  parser_free_node (parser, spec);

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -190,6 +190,7 @@ static int boot_define_ha_apply_info (MOP class_mop);
 static int boot_define_collations (MOP class_mop);
 static int boot_add_charsets (MOP class_mop);
 static int boot_define_charsets (MOP class_mop);
+static int boot_define_dual (MOP class_mop);
 static int boot_define_view_class (void);
 static int boot_define_view_super_class (void);
 static int boot_define_view_vclass (void);
@@ -3939,6 +3940,83 @@ boot_define_charsets (MOP class_mop)
   return NO_ERROR;
 }
 
+#define CT_DUAL_DUMMY   "dummy"
+
+  /*
+   * boot_define_dual :
+   *
+   * returns : NO_ERROR if all OK, ER_ status otherwise
+   *
+   *   class(IN) :
+   */
+
+static int
+boot_define_dual (MOP class_mop)
+{
+  SM_TEMPLATE *def;
+  int error_code = NO_ERROR;
+  DB_OBJECT *obj;
+  DB_VALUE val;
+  char *dummy = "X";
+
+  def = smt_edit_class_mop (class_mop, AU_ALTER);
+  if (def == NULL)
+    {
+      assert (er_errid () != NO_ERROR);
+      return er_errid ();
+    }
+
+  error_code = smt_add_attribute (def, CT_DUAL_DUMMY, "varchar(1)", NULL);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+
+  error_code = sm_update_class (def, NULL);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+
+  if (locator_has_heap (class_mop) == NULL)
+    {
+      assert (er_errid () != NO_ERROR);
+      return er_errid ();
+    }
+
+  error_code = au_change_owner (class_mop, Au_dba_user);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+
+  error_code = au_grant (Au_public_user, class_mop, AU_SELECT, false);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+
+  obj = db_create_internal (class_mop);
+  if (obj == NULL)
+    {
+      assert (er_errid () != NO_ERROR);
+      return er_errid ();
+    }
+  error_code = db_make_varchar (&val, 1, dummy, strlen (dummy), LANG_SYS_CODESET, LANG_SYS_COLLATION);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+
+  error_code = db_put_internal (obj, CT_DUAL_DUMMY, &val);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+
+  return NO_ERROR;
+}
+
 /*
  * catcls_class_install :
  *
@@ -3973,7 +4051,8 @@ catcls_class_install (void)
     {CT_SERIAL_NAME, boot_define_serial},
     {CT_HA_APPLY_INFO_NAME, boot_define_ha_apply_info},
     {CT_COLLATION_NAME, boot_define_collations},
-    {CT_CHARSET_NAME, boot_define_charsets}
+    {CT_CHARSET_NAME, boot_define_charsets},
+    {CT_DUAL_NAME, boot_define_dual}
   };
   // *INDENT-ON*
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23649

make a 'dual' table to replace 'db_root' which was used as a dummy table.

- dual table is made by 'createdb'
- DBA and PUBLIC user are not allowed to drop, alter, insert, update and delete on dual table
- db_root is replaced when skip "FROM" in SELECT clause 
- db_root is replaced when creating SELECT clause in the process of making "show create table" query.