### PR TITLE
[CBRD-21828] Process '.5' style number in loaddb_object as well as '0.5

### DIFF
--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -481,7 +481,7 @@ namespace cubload
   int
   to_db_numeric (const char *str, const size_t str_size, const attribute *attr, db_value *val)
   {
-    int precision = (int) str_size - 1 - (str[0] == '+' || str[0] == '-' || str[0] == '.');
+    int precision = (int) str_size - 1 - (str[0] == '+' || str[0] == '-');
     int scale = (int) str_size - (int) strcspn (str, ".") - 1;
 
     int error_code = db_value_domain_init (val, DB_TYPE_NUMERIC, precision, scale);

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -2948,7 +2948,7 @@ ldr_numeric_elem (LDR_CONTEXT *context, const char *str, size_t len, DB_VALUE *v
   int precision, scale;
   int err = NO_ERROR;
 
-  precision = (int) len - 1 - (str[0] == '+' || str[0] == '-' || str[0] == '.');
+  precision = (int) len - 1 - (str[0] == '+' || str[0] == '-');
   scale = (int) len - (int) strcspn (str, ".") - 1;
 
   CHECK_PARSE_ERR (err, db_value_domain_init (val, DB_TYPE_NUMERIC, precision, scale), context, DB_TYPE_NUMERIC, str);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21828
* **loaddb** cannot handle '.5' style number in loaddb_object file.
* Generally, you will not see the'.5' style number in the loaddb object file, this is because **DBMS**, **unloaddb**, and **CMT** will convert .5 to 0.5.
* As a some exceptional case, If you build loaddb object file yourself using query result to file in Oracle, you can see .5, .12 style number.
* Currently, if loaddb meet '.5' style number in loaddb object file, it **calculate the precision of the number as  0**, and fail to load it, **it should be 1.**