### PR TITLE
[CBRD-22979] Segmentation fault occurs when query has derived table with 3 or more unions (#2196)

### DIFF
--- a/src/parser/query_result.c
+++ b/src/parser/query_result.c
@@ -520,7 +520,7 @@ pt_get_select_list (PARSER_CONTEXT * parser, PT_NODE * query)
 	      common_type = pt_common_type (attr1->type_enum, attr2->type_enum);
 	    }
 
-	  if (col->type_enum == PT_TYPE_NA || col->type_enum == PT_TYPE_NULL)
+	  if (pt_is_value_node (col) && (col->type_enum == PT_TYPE_NA || col->type_enum == PT_TYPE_NULL))
 	    {
 	      db_make_null (&col->info.value.db_value);
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22979
backport #2196