### PR TITLE
[CBRD-22970] Constant variable is set to null when reusing cached XASL which is executed without data(#2197)

### DIFF
--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -633,12 +633,12 @@ qdata_set_valptr_list_unbound (THREAD_ENTRY * thread_p, valptr_list_node * valpt
 	    {
 	      /* this may be shared with another regu variable that was already evaluated */
 	      pr_clear_value (dbval_p);
-	    }
 
-	  if (db_value_domain_init (dbval_p, DB_VALUE_DOMAIN_TYPE (dbval_p), DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE) !=
-	      NO_ERROR)
-	    {
-	      return ER_FAILED;
+	      if (db_value_domain_init (dbval_p, DB_VALUE_DOMAIN_TYPE (dbval_p), DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE)
+		  != NO_ERROR)
+		{
+		  return ER_FAILED;
+		}
 	    }
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22970
backport #2197