### PR TITLE
[CBRD-23623] Unexpected data overflow error occurs by order of select list when the numeric type and ROUND are used together (#2204)

### DIFF
--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -1632,6 +1632,10 @@ numeric_db_value_add (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE * a
 	{
 	  goto exit_on_error;
 	}
+      else
+	{
+	  er_clear ();
+	}
     }
   else if (ret != NO_ERROR)
     {
@@ -1727,6 +1731,10 @@ numeric_db_value_sub (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VALUE * a
       if (ret != NO_ERROR)
 	{
 	  goto exit_on_error;
+	}
+      else
+	{
+	  er_clear ();
 	}
     }
   else if (ret != NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23623
backport #2204