### PR TITLE
[CBRD-23709] error message is displayed incorrectly in 'MERGE' clause

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -4719,7 +4719,7 @@ wrapup:
     result = (gbstate.state == NO_ERROR || gbstate.state == SORT_PUT_STOP) ? NO_ERROR : ER_FAILED;
 
     /* check merge result */
-    if (gbstate.state == NO_ERROR && XASL_IS_FLAGED (xasl, XASL_IS_MERGE_QUERY)
+    if (result == NO_ERROR && XASL_IS_FLAGED (xasl, XASL_IS_MERGE_QUERY)
 	&& list_id->tuple_cnt != gbstate.input_recs)
       {
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MERGE_TOO_MANY_SOURCE_ROWS, 0);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -4719,7 +4719,8 @@ wrapup:
     result = (gbstate.state == NO_ERROR || gbstate.state == SORT_PUT_STOP) ? NO_ERROR : ER_FAILED;
 
     /* check merge result */
-    if (XASL_IS_FLAGED (xasl, XASL_IS_MERGE_QUERY) && list_id->tuple_cnt != gbstate.input_recs)
+    if (gbstate.state == NO_ERROR && XASL_IS_FLAGED (xasl, XASL_IS_MERGE_QUERY)
+	&& list_id->tuple_cnt != gbstate.input_recs)
       {
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MERGE_TOO_MANY_SOURCE_ROWS, 0);
 	result = ER_FAILED;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -4719,8 +4719,7 @@ wrapup:
     result = (gbstate.state == NO_ERROR || gbstate.state == SORT_PUT_STOP) ? NO_ERROR : ER_FAILED;
 
     /* check merge result */
-    if (result == NO_ERROR && XASL_IS_FLAGED (xasl, XASL_IS_MERGE_QUERY)
-	&& list_id->tuple_cnt != gbstate.input_recs)
+    if (result == NO_ERROR && XASL_IS_FLAGED (xasl, XASL_IS_MERGE_QUERY) && list_id->tuple_cnt != gbstate.input_recs)
       {
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MERGE_TOO_MANY_SOURCE_ROWS, 0);
 	result = ER_FAILED;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23709

fix to display 'Multiple rows in source table match the same row in destination table.' error when there are no existing errors