### PR TITLE
[CBRD-23678] implementation of /*+ USE_SBR */ hint for DML in HA environment

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -9488,8 +9488,12 @@ pt_print_spec (PARSER_CONTEXT * parser, PT_NODE * p)
 	  && p->info.spec.range_var->info.name.original[0])
 	{
 	  r1 = pt_print_bytes (parser, p->info.spec.range_var);
-	  q = pt_append_nulstring (parser, q, " ");
-	  q = pt_append_varchar (parser, q, r1);
+
+	  if (r1->length != q->length || memcmp (&r1->bytes, &q->bytes, q->length))
+	    {
+	      q = pt_append_nulstring (parser, q, " ");
+	      q = pt_append_varchar (parser, q, r1);
+	    }
 	}
       parser->custom_print = save_custom;
     }
@@ -12902,7 +12906,16 @@ pt_print_insert (PARSER_CONTEXT * parser, PT_NODE * p)
   b = pt_append_varchar (parser, b, r1);
   if (r2)
     {
+      char *class_name = NULL;
+
       b = pt_append_nulstring (parser, b, " (");
+
+      while (class_name = strstr ((char *) r2->bytes, (char *) r1->bytes))
+	{
+	  strcpy (class_name, class_name + r1->length + 1);
+	  r2->length = r2->length - r1->length - 1;
+	}
+
       b = pt_append_varchar (parser, b, r2);
       b = pt_append_nulstring (parser, b, ") ");
     }

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -8855,7 +8855,7 @@ do_prepare_update (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  lhs = lhs->info.expr.arg1;
 	}
       statement->info.update.server_update = server_update;
-      if (server_update && !has_any_update_trigger)
+      if (server_update && !has_any_update_trigger && !(statement->info.update.hint & PT_HINT_USE_SBR))
 	{
 	  statement->info.update.execute_with_commit_allowed = 1;
 	}
@@ -10215,7 +10215,7 @@ do_prepare_delete (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * paren
       server_delete = (!has_trigger && !has_virt_obj);
 
       statement->info.delete_.server_delete = server_delete;
-      if (server_delete && !has_any_delete_trigger)
+      if (server_delete && !has_any_delete_trigger && !(statement->info.delete_.hint & PT_HINT_USE_SBR))
 	{
 	  statement->info.delete_.execute_with_commit_allowed = 1;
 	}
@@ -17518,7 +17518,7 @@ do_insert_checks (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** class
 	  goto exit;
 	}
 
-      if (!trigger_involved)
+      if (!trigger_involved && !(statement->info.insert.hint & PT_HINT_USE_SBR))
 	{
 	  statement->info.insert.execute_with_commit_allowed = 1;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23678

- implementation of /*+ USE_SBR */ hint for DML in HA environment.
- refer to simple test scenario in issue.
- various tests are required. so I added /*+ USE_SBR */ hint to the CTP testcases and it is in progress