### PR TITLE
[CBRD-23679] Adding a configuration parameter and control for strict type translation

### DIFF
--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -1782,7 +1782,7 @@ db_value_coerce (const DB_VALUE * src, DB_VALUE * dest, const DB_DOMAIN * desire
   TP_DOMAIN_STATUS status;
   int err = NO_ERROR;
 
-  status = tp_value_cast_ex (src, dest, desired_domain, false, true);
+  status = tp_value_cast_force (src, dest, desired_domain, false);
   if (status != DOMAIN_COMPATIBLE)
     {
       err = tp_domain_status_er_set (status, ARG_FILE_LINE, src, desired_domain);

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -1782,7 +1782,7 @@ db_value_coerce (const DB_VALUE * src, DB_VALUE * dest, const DB_DOMAIN * desire
   TP_DOMAIN_STATUS status;
   int err = NO_ERROR;
 
-  status = tp_value_cast (src, dest, desired_domain, false);
+  status = tp_value_cast_ex (src, dest, desired_domain, false, true);
   if (status != DOMAIN_COMPATIBLE)
     {
       err = tp_domain_status_er_set (status, ARG_FILE_LINE, src, desired_domain);

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -9244,7 +9244,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    {
 	      status = DOMAIN_INCOMPATIBLE;
 	    }
-	  else if (data_stat == DATA_STATUS_TRUNCATED &&
+	  else if (data_stat == DATA_STATUS_TRUNCATED && coercion_mode != TP_FORCE_COERCION &&
 		   (prm_get_bool_value (PRM_ID_ALLOW_TRUNCATED_STRING) == false
 		    || coercion_mode == TP_IMPLICIT_COERCION))
 	    {

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -95,7 +95,8 @@
 typedef enum tp_coersion_mode
 {
   TP_EXPLICIT_COERCION = 0,
-  TP_IMPLICIT_COERCION
+  TP_IMPLICIT_COERCION,
+  TP_FORCE_COERCION
 } TP_COERCION_MODE;
 
 /*
@@ -9177,7 +9178,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		      {
 			status = DOMAIN_INCOMPATIBLE;
 		      }
-		    else if (data_stat == DATA_STATUS_TRUNCATED &&
+		    else if (data_stat == DATA_STATUS_TRUNCATED && coercion_mode != TP_FORCE_COERCION &&
 			     (prm_get_bool_value (PRM_ID_ALLOW_TRUNCATED_STRING) == false
 			      || coercion_mode == TP_IMPLICIT_COERCION))
 		      {
@@ -9282,7 +9283,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    {
 	      status = DOMAIN_INCOMPATIBLE;
 	    }
-	  else if (data_stat == DATA_STATUS_TRUNCATED &&
+	  else if (data_stat == DATA_STATUS_TRUNCATED && coercion_mode != TP_FORCE_COERCION &&
 		   (prm_get_bool_value (PRM_ID_ALLOW_TRUNCATED_STRING) == false
 		    || coercion_mode == TP_IMPLICIT_COERCION))
 	    {
@@ -10184,6 +10185,19 @@ tp_value_cast (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN * desired_
   TP_COERCION_MODE mode;
 
   mode = (implicit_coercion ? TP_IMPLICIT_COERCION : TP_EXPLICIT_COERCION);
+  return tp_value_cast_internal (src, dest, desired_domain, mode, true, false);
+}
+
+TP_DOMAIN_STATUS
+tp_value_cast_ex (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN * desired_domain, bool implicit_coercion, bool force)
+{
+  TP_COERCION_MODE mode;
+
+  mode = (implicit_coercion ? TP_IMPLICIT_COERCION : TP_EXPLICIT_COERCION);
+  if (force)
+    {
+      mode = TP_FORCE_COERCION;
+    }
   return tp_value_cast_internal (src, dest, desired_domain, mode, true, false);
 }
 

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -10189,16 +10189,11 @@ tp_value_cast (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN * desired_
 }
 
 TP_DOMAIN_STATUS
-tp_value_cast_ex (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN * desired_domain, bool implicit_coercion,
-		  bool force)
+tp_value_cast_force (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN * desired_domain, bool implicit_coercion)
 {
   TP_COERCION_MODE mode;
 
-  mode = (implicit_coercion ? TP_IMPLICIT_COERCION : TP_EXPLICIT_COERCION);
-  if (force)
-    {
-      mode = TP_FORCE_COERCION;
-    }
+  mode = TP_FORCE_COERCION;
   return tp_value_cast_internal (src, dest, desired_domain, mode, true, false);
 }
 

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -10189,7 +10189,8 @@ tp_value_cast (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN * desired_
 }
 
 TP_DOMAIN_STATUS
-tp_value_cast_ex (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN * desired_domain, bool implicit_coercion, bool force)
+tp_value_cast_ex (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN * desired_domain, bool implicit_coercion,
+		  bool force)
 {
   TP_COERCION_MODE mode;
 

--- a/src/object/object_domain.h
+++ b/src/object/object_domain.h
@@ -457,8 +457,7 @@ extern "C"
 					 bool implicit_coercion);
 
   extern TP_DOMAIN_STATUS tp_value_cast_ex (const DB_VALUE * src, DB_VALUE * dest,
-							 const TP_DOMAIN * desired_domain, bool implicit_coercion,
-							 bool force);
+					    const TP_DOMAIN * desired_domain, bool implicit_coercion, bool force);
 
   extern TP_DOMAIN_STATUS tp_value_cast_preserve_domain (const DB_VALUE * src, DB_VALUE * dest,
 							 const TP_DOMAIN * desired_domain, bool implicit_coercion,

--- a/src/object/object_domain.h
+++ b/src/object/object_domain.h
@@ -456,8 +456,8 @@ extern "C"
   extern TP_DOMAIN_STATUS tp_value_cast (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN * desired_domain,
 					 bool implicit_coercion);
 
-  extern TP_DOMAIN_STATUS tp_value_cast_ex (const DB_VALUE * src, DB_VALUE * dest,
-					    const TP_DOMAIN * desired_domain, bool implicit_coercion, bool force);
+  extern TP_DOMAIN_STATUS tp_value_cast_force (const DB_VALUE * src, DB_VALUE * dest,
+					       const TP_DOMAIN * desired_domain, bool implicit_coercion);
 
   extern TP_DOMAIN_STATUS tp_value_cast_preserve_domain (const DB_VALUE * src, DB_VALUE * dest,
 							 const TP_DOMAIN * desired_domain, bool implicit_coercion,

--- a/src/object/object_domain.h
+++ b/src/object/object_domain.h
@@ -456,6 +456,10 @@ extern "C"
   extern TP_DOMAIN_STATUS tp_value_cast (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN * desired_domain,
 					 bool implicit_coercion);
 
+  extern TP_DOMAIN_STATUS tp_value_cast_ex (const DB_VALUE * src, DB_VALUE * dest,
+							 const TP_DOMAIN * desired_domain, bool implicit_coercion,
+							 bool force);
+
   extern TP_DOMAIN_STATUS tp_value_cast_preserve_domain (const DB_VALUE * src, DB_VALUE * dest,
 							 const TP_DOMAIN * desired_domain, bool implicit_coercion,
 							 bool preserve_domain);

--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -1632,7 +1632,7 @@ qo_reduce_equality_terms (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE ** wh
 		      continue;	/* give up */
 		    }
 		  db_make_null (&dbval_res);
-		  if (tp_value_cast_ex (dbval, &dbval_res, dom, false, true) != DOMAIN_COMPATIBLE)
+		  if (tp_value_cast_force (dbval, &dbval_res, dom, false) != DOMAIN_COMPATIBLE)
 		    {
 		      PT_ERRORmf2 (parser, arg2, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CANT_COERCE_TO,
 				   pt_short_print (parser, arg2), pt_show_type_enum (arg1->type_enum));

--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -1632,7 +1632,7 @@ qo_reduce_equality_terms (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE ** wh
 		      continue;	/* give up */
 		    }
 		  db_make_null (&dbval_res);
-		  if (tp_value_cast (dbval, &dbval_res, dom, false) != DOMAIN_COMPATIBLE)
+		  if (tp_value_cast_ex (dbval, &dbval_res, dom, false, true) != DOMAIN_COMPATIBLE)
 		    {
 		      PT_ERRORmf2 (parser, arg2, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CANT_COERCE_TO,
 				   pt_short_print (parser, arg2), pt_show_type_enum (arg1->type_enum));

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -17456,10 +17456,18 @@ pt_make_aptr_parent_node (PARSER_CONTEXT * parser, PT_NODE * node, PROC_TYPE typ
       if (PT_IS_QUERY_NODE_TYPE (node->node_type))
 	{
 	  PT_NODE *namelist;
+	  REGU_VARIABLE_LIST regu_var_list;
 
 	  namelist = NULL;
 
 	  aptr = parser_generate_xasl (parser, node);
+	  if (type == UPDATE_PROC)
+	    {
+	      for (regu_var_list = aptr->outptr_list->valptrp; regu_var_list; regu_var_list = regu_var_list->next)
+		{
+		  regu_var_list->value.flags |= REGU_VARIABLE_UPD_INS_LIST;
+		}
+	    }
 	  if (aptr != NULL)
 	    {
 	      XASL_CLEAR_FLAG (aptr, XASL_TOP_MOST_XASL);

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10816,7 +10816,8 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
   }
 
   /* special case : TYPE */
-  if (tp_domain_match (attr_db_domain, att->domain, TP_EXACT_MATCH) != 0)
+  if ((tp_domain_match (attr_db_domain, att->domain, TP_EXACT_MATCH) != 0)
+      && (tp_domain_match (attr_db_domain, att->domain, TP_STR_MATCH) != 0))
     {
       attr_chg_properties->p[P_TYPE] |= ATT_CHG_PROPERTY_UNCHANGED;
     }
@@ -10827,8 +10828,9 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
       /* remove "UNCHANGED" flag */
       attr_chg_properties->p[P_TYPE] &= ~ATT_CHG_PROPERTY_UNCHANGED;
 
-      if (TP_DOMAIN_TYPE (attr_db_domain) == TP_DOMAIN_TYPE (att->domain)
-	  && TP_IS_CHAR_BIT_TYPE (TP_DOMAIN_TYPE (attr_db_domain)))
+      if (TP_IS_CHAR_BIT_TYPE (TP_DOMAIN_TYPE (attr_db_domain))
+	  && (TP_IS_CHAR_TYPE(TP_DOMAIN_TYPE (attr_db_domain)) == TP_IS_CHAR_TYPE(TP_DOMAIN_TYPE (att->domain))
+	  || (TP_IS_BIT_TYPE(TP_DOMAIN_TYPE (attr_db_domain)) == TP_IS_BIT_TYPE(TP_DOMAIN_TYPE (att->domain)))))
 	{
 	  if (tp_domain_match (attr_db_domain, att->domain, TP_STR_MATCH) != 0)
 	    {

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10829,8 +10829,8 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
       attr_chg_properties->p[P_TYPE] &= ~ATT_CHG_PROPERTY_UNCHANGED;
 
       if (TP_IS_CHAR_BIT_TYPE (TP_DOMAIN_TYPE (attr_db_domain))
-	  && (TP_IS_CHAR_TYPE(TP_DOMAIN_TYPE (attr_db_domain)) == TP_IS_CHAR_TYPE(TP_DOMAIN_TYPE (att->domain))
-	  || (TP_IS_BIT_TYPE(TP_DOMAIN_TYPE (attr_db_domain)) == TP_IS_BIT_TYPE(TP_DOMAIN_TYPE (att->domain)))))
+	  && (TP_IS_CHAR_TYPE (TP_DOMAIN_TYPE (attr_db_domain)) == TP_IS_CHAR_TYPE (TP_DOMAIN_TYPE (att->domain))
+	      || (TP_IS_BIT_TYPE (TP_DOMAIN_TYPE (attr_db_domain)) == TP_IS_BIT_TYPE (TP_DOMAIN_TYPE (att->domain)))))
 	{
 	  if (tp_domain_match (attr_db_domain, att->domain, TP_STR_MATCH) != 0)
 	    {

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -2347,7 +2347,15 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	}
       else
 	{
-	  dom_status = tp_value_cast_ex (peek_right, arithptr->value, arithptr->domain, false, true);
+	  if (REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_STRICT_TYPE_CAST))
+	    {
+	      dom_status = tp_value_cast (peek_right, arithptr->value, arithptr->domain, false);
+	    }
+	  else
+	    {
+	      dom_status = tp_value_cast_ex (peek_right, arithptr->value, arithptr->domain, false, true);
+	    }
+
 	  if (dom_status != DOMAIN_COMPATIBLE)
 	    {
 	      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, peek_right, arithptr->domain);

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -2347,7 +2347,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	}
       else
 	{
-	  dom_status = tp_value_cast (peek_right, arithptr->value, arithptr->domain, false);
+	  dom_status = tp_value_cast_ex (peek_right, arithptr->value, arithptr->domain, false, true);
 	  if (dom_status != DOMAIN_COMPATIBLE)
 	    {
 	      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, peek_right, arithptr->domain);

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -2353,7 +2353,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	    }
 	  else
 	    {
-	      dom_status = tp_value_cast_ex (peek_right, arithptr->value, arithptr->domain, false, true);
+	      dom_status = tp_value_cast_force (peek_right, arithptr->value, arithptr->domain, false);
 	    }
 
 	  if (dom_status != DOMAIN_COMPATIBLE)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -11450,6 +11450,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	  for (regu_list = insert->valptr_lists[i]->valptrp, vallist = xasl->val_list->valp, k = num_default_expr;
 	       k < val_no; k++, regu_list = regu_list->next, vallist = vallist->next)
 	    {
+	      regu_list->value.flags |= REGU_VARIABLE_STRICT_TYPE_CAST;
 	      if (fetch_peek_dbval (thread_p, &regu_list->value, &xasl_state->vd, &class_oid, NULL, NULL, &valp) !=
 		  NO_ERROR)
 		{

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -6472,6 +6472,11 @@ qdata_get_dbval_from_constant_regu_variable (THREAD_ENTRY * thread_p, REGU_VARIA
   assert (regu_var_p != NULL);
   assert (regu_var_p->domain != NULL);
 
+  if (REGU_VARIABLE_IS_FLAGED (regu_var_p, REGU_VARIABLE_UPD_INS_LIST))
+    {
+      REGU_VARIABLE_SET_FLAG (regu_var_p, REGU_VARIABLE_STRICT_TYPE_CAST);
+    }
+
   result = fetch_peek_dbval (thread_p, regu_var_p, val_desc_p, NULL, NULL, NULL, &peek_value_p);
   if (result != NO_ERROR)
     {

--- a/src/query/regu_var.hpp
+++ b/src/query/regu_var.hpp
@@ -163,6 +163,8 @@ const int REGU_VARIABLE_INFER_COLLATION = 0x20;	/* infer collation for default p
 const int REGU_VARIABLE_FETCH_ALL_CONST = 0x40;	/* is all constant */
 const int REGU_VARIABLE_FETCH_NOT_CONST = 0x80;	/* is not constant */
 const int REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE = 0x100;	/* clears regu variable at clone decache */
+const int REGU_VARIABLE_UPD_INS_LIST = 0x200;	/* for update or insert query */
+const int REGU_VARIABLE_STRICT_TYPE_CAST = 0x400;/* for update or insert query */
 
 class regu_variable_node
 {
@@ -170,7 +172,6 @@ class regu_variable_node
     REGU_DATATYPE type;
 
     int flags;			/* flags */
-
     TP_DOMAIN *domain;		/* domain of the value in this regu variable */
     TP_DOMAIN *original_domain;	/* original domain, used at execution in case of XASL clones */
     DB_VALUE *vfetch_to;		/* src db_value to fetch into in qp_fetchvlist */

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -9949,12 +9949,13 @@ qstr_bit_coerce (const unsigned char *src, int src_length, int src_precision, DB
     {
       int i, n = 0;
       i = dest_precision / 8;
-      if (src[i] & (0x80 >> (dest_precision % 8)))
+      if (src[i] & (0x80 >> (dest_precision % 8)) || ((src[i] << (dest_precision % 8)) & 0xff))
 	{
           *data_status = DATA_STATUS_TRUNCATED;
 	}
       else
 	{
+	  i++; /* for check reamin trailing bits */
           for (; i < (src_padded_length + 4) / 8; i++)
 	    {
 	      if (src[i])

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -9951,18 +9951,18 @@ qstr_bit_coerce (const unsigned char *src, int src_length, int src_precision, DB
       i = dest_precision / 8;
       if (src[i] & (0x80 >> (dest_precision % 8)) || ((src[i] << (dest_precision % 8)) & 0xff))
 	{
-          *data_status = DATA_STATUS_TRUNCATED;
+	  *data_status = DATA_STATUS_TRUNCATED;
 	}
       else
 	{
-	  i++; /* for check reamin trailing bits */
-          for (; i < (src_padded_length + 4) / 8; i++)
+	  i++;			/* for check reamin trailing bits */
+	  for (; i < (src_padded_length + 4) / 8; i++)
 	    {
 	      if (src[i])
-	        {
-                  *data_status = DATA_STATUS_TRUNCATED;
-	          break;
-	        }
+		{
+		  *data_status = DATA_STATUS_TRUNCATED;
+		  break;
+		}
 	    }
 	}
       src_padded_length = dest_precision;

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -9947,8 +9947,25 @@ qstr_bit_coerce (const unsigned char *src, int src_length, int src_precision, DB
    */
   if (src_padded_length > dest_precision)
     {
+      int i, n = 0;
+      i = dest_precision / 8;
+      if (src[i] & (0x80 >> (dest_precision % 8)))
+	{
+          *data_status = DATA_STATUS_TRUNCATED;
+	}
+      else
+	{
+          i++;
+          for (; i < (src_padded_length + 4) / 8; i++)
+	    {
+	      if (src[i])
+	        {
+                  *data_status = DATA_STATUS_TRUNCATED;
+	          break;
+	        }
+	    }
+	}
       src_padded_length = dest_precision;
-      *data_status = DATA_STATUS_TRUNCATED;
     }
 
   copy_length = MIN (src_length, src_padded_length);

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -9955,7 +9955,6 @@ qstr_bit_coerce (const unsigned char *src, int src_length, int src_precision, DB
 	}
       else
 	{
-          i++;
           for (; i < (src_padded_length + 4) / 8; i++)
 	    {
 	      if (src[i])

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -17016,7 +17016,8 @@ heap_object_upgrade_domain (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scanca
 
       if (TP_IS_CHAR_TYPE (TP_DOMAIN_TYPE (dest_dom))
 	  && !(TP_IS_CHAR_TYPE (src_type) || src_type == DB_TYPE_ENUMERATION)
-	  && prm_get_bool_value (PRM_ID_ALTER_TABLE_CHANGE_TYPE_STRICT) == false)
+	  && prm_get_bool_value (PRM_ID_ALTER_TABLE_CHANGE_TYPE_STRICT) == false
+	  && prm_get_bool_value (PRM_ID_ALLOW_TRUNCATED_STRING) == true)
 	{
 	  /* If destination is char/varchar, we need to first cast the value to a string with no precision, then to
 	   * destination type with the desired precision. */
@@ -17043,8 +17044,8 @@ heap_object_upgrade_domain (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scanca
 	  bool set_max_value = false;
 
 	  if (prm_get_bool_value (PRM_ID_ALTER_TABLE_CHANGE_TYPE_STRICT) == true
-	      || TP_IS_CHAR_TYPE ((TP_DOMAIN_TYPE (dest_dom))
-				  && prm_get_bool_value (PRM_ID_ALLOW_TRUNCATED_STRING) == false))
+	      || (TP_IS_CHAR_TYPE (TP_DOMAIN_TYPE (dest_dom))
+		  && prm_get_bool_value (PRM_ID_ALLOW_TRUNCATED_STRING) == false))
 	    {
 	      error = ER_ALTER_CHANGE_TRUNC_OVERFLOW_NOT_ALLOWED;
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23679

During query compiling the overflowed string is truncated at string operation including schema modify through ALTER clause.
We have to change to specification to produce semantic error with message like "can not coerce ..."

PRM_ID_ALLOW_TRUNCATED_STRING is added and the default value is "false" (not allowed string truncated)
PRM_ID_ALTER_TABLE_CHANGE_TYPE_STRICT default value is changed to "true"

In addition, in altering table, "nchar" to "char" type change is allowed only if the precision is valid.
