### PR TITLE
[CBRD-23714] ] change an limit value of max_clients

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1100,7 +1100,7 @@ static bool prm_qo_dump_default = false;
 static unsigned int prm_qo_dump_flag = 0;
 
 #if !defined (SERVER_MODE) && !defined (SA_MODE)
-#define CSS_MAX_CLIENT_COUNT 2000
+#define CSS_MAX_CLIENT_COUNT 4000
 #endif /* !defined (SERVER_MODE) && !defined (SA_MODE) */
 int PRM_CSS_MAX_CLIENTS = 100;
 static int prm_css_max_clients_default = 100;

--- a/src/broker/broker_shm.h
+++ b/src/broker/broker_shm.h
@@ -135,7 +135,7 @@
 
 #define MAX_PROXY_NUM            8
 
-#define APPL_SERVER_NUM_LIMIT    2048
+#define APPL_SERVER_NUM_LIMIT    4096
 
 #define SHM_BROKER_PATH_MAX      (PATH_MAX)
 #define SHM_PROXY_NAME_MAX       (SHM_BROKER_PATH_MAX)

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -31,7 +31,7 @@
 
 #define CSS_CR_NORMAL_ONLY_IDX  0
 
-#define CSS_MAX_CLIENT_COUNT   2000
+#define CSS_MAX_CLIENT_COUNT   4000
 
 typedef bool (*CSS_CHECK_CLIENT_TYPE) (BOOT_CLIENT_TYPE client_type);
 typedef int (*CSS_GET_MAX_CONN_NUM) (void);


### PR DESCRIPTION
backport from develop

change the following
* an limit value of db's max_clients from 2000 to 4000.
* an limit value of broker's max_num_appl_server from 2048 to 4096.