### PR TITLE
[CBRD-23697] Fix regression caused by different domain of db_value

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1111,7 +1111,7 @@ static bool prm_qo_dump_default = false;
 static unsigned int prm_qo_dump_flag = 0;
 
 #if !defined (SERVER_MODE) && !defined (SA_MODE)
-#define CSS_MAX_CLIENT_COUNT 4000
+#define CSS_MAX_CLIENT_COUNT 2000
 #endif /* !defined (SERVER_MODE) && !defined (SA_MODE) */
 int PRM_CSS_MAX_CLIENTS = 100;
 static int prm_css_max_clients_default = 100;
@@ -1310,9 +1310,9 @@ bool PRM_RETURN_NULL_ON_FUNCTION_ERRORS = false;
 static bool prm_return_null_on_function_errors_default = false;
 static unsigned int prm_return_null_on_function_errors_flag = 0;
 
-bool PRM_ALTER_TABLE_CHANGE_TYPE_STRICT = true;
-static bool prm_alter_table_change_type_strict_default = true;
-static unsigned int prm_alter_table_change_type_strict_flag = 1;
+bool PRM_ALTER_TABLE_CHANGE_TYPE_STRICT = false;
+static bool prm_alter_table_change_type_strict_default = false;
+static unsigned int prm_alter_table_change_type_strict_flag = 0;
 
 bool PRM_PLUS_AS_CONCAT = true;
 static bool prm_plus_as_concat_default = true;
@@ -2294,9 +2294,9 @@ bool PRM_JAVA_STORED_PROCEDURE_RESERVE_01 = false;
 static bool prm_java_stored_procedure_reserve_01_default = false;
 static unsigned int prm_java_stored_procedure_reserve_01_flag = 0;
 
-bool PRM_ALLOW_TRUNCATED_STRING = false;
-static bool prm_allow_truncated_string_default = false;
-static unsigned int prm_allow_truncated_string_flag = 0;
+bool PRM_ALLOW_TRUNCATED_STRING = true;
+static bool prm_allow_truncated_string_default = true;
+static unsigned int prm_allow_truncated_string_flag = 1;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -174,8 +174,7 @@ const char *AU_DBA_USER_NAME = "DBA";
          strcmp(name, CT_PASSWORD_NAME) == 0 || \
          strcmp(name, CT_AUTHORIZATION_NAME) == 0 || \
          strcmp(name, CT_AUTHORIZATIONS_NAME) == 0 || \
-	 strcmp(name, CT_CHARSET_NAME) == 0 || \
-   strcmp(name, CT_DUAL_NAME) == 0)
+	 strcmp(name, CT_CHARSET_NAME) == 0)
 
 enum fetch_by
 {

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -6741,7 +6741,7 @@ pt_make_query_show_create_table (PARSER_CONTEXT * parser, PT_NODE * table_name)
    */
   pt_add_string_col_to_sel_list (parser, select, table_name->info.name.original, "TABLE");
   pt_add_string_col_to_sel_list (parser, select, strbuf.get_buffer (), "CREATE TABLE");
-  pt_add_table_name_to_from_list (parser, select, "dual", NULL, DB_AUTH_SELECT);
+  pt_add_table_name_to_from_list (parser, select, "db_root", NULL, DB_AUTH_SELECT);
   return select;
 }
 

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9823,7 +9823,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	  SET_EXPECTED_DOMAIN (arg2, d);
 	  pt_preset_hostvar (parser, arg2);
 	}
-      if (PT_IS_VALUE_NODE (arg2) && arg1->type_enum != arg2->type_enum)
+      if (PT_IS_VALUE_NODE (arg2))
 	{
 	  if (pt_coerce_value_explicit (parser, arg2, arg2, arg1_type, arg1->data_type) != NO_ERROR)
 	    {
@@ -20313,7 +20313,7 @@ int
 pt_coerce_value_explicit (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE_ENUM desired_type,
 			  PT_NODE * data_type)
 {
-  return pt_coerce_value_internal (parser, src, dest, desired_type, data_type, false, false);
+  return pt_coerce_value_internal (parser, src, dest, desired_type, data_type, true, false);
 }
 
 /*

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9823,13 +9823,13 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	  SET_EXPECTED_DOMAIN (arg2, d);
 	  pt_preset_hostvar (parser, arg2);
 	}
-      if (PT_IS_VALUE_NODE (arg2))
+/*      if (PT_IS_VALUE_NODE (arg2))
 	{
 	  if (pt_coerce_value_explicit (parser, arg2, arg2, arg1_type, arg1->data_type) != NO_ERROR)
 	    {
 	      goto error;
 	    }
-	}
+	}*/
       break;
 
     case PT_LIKE_ESCAPE:

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -3266,7 +3266,7 @@ pt_filter_pseudo_specs (PARSER_CONTEXT * parser, PT_NODE * spec)
       spec->info.spec.id = (UINTPTR) spec;
       spec->info.spec.only_all = PT_ONLY;
       spec->info.spec.meta_class = PT_CLASS;
-      spec->info.spec.entity_name = pt_name (parser, "dual");
+      spec->info.spec.entity_name = pt_name (parser, "db_root");
       if (spec->info.spec.entity_name == NULL)
 	{
 	  parser_free_node (parser, spec);

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -4051,8 +4051,7 @@ catcls_class_install (void)
     {CT_SERIAL_NAME, boot_define_serial},
     {CT_HA_APPLY_INFO_NAME, boot_define_ha_apply_info},
     {CT_COLLATION_NAME, boot_define_collations},
-    {CT_CHARSET_NAME, boot_define_charsets},
-    {CT_DUAL_NAME, boot_define_dual}
+    {CT_CHARSET_NAME, boot_define_charsets}
   };
   // *INDENT-ON*
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23697

In the case of the same type as the allocated column, incorrect precision is entered without coerce the type.
fix to coerce value to the type of the assigned column even if it is the same type.
