### PR TITLE
[CBRD-23687] Backport CBRD-23687 (#2387) to 10.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,8 +701,8 @@ configure_file(cmake/version.h.cmake version.h)
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   # Definitions for system
   add_definitions(-DGCC -DLINUX -D_GNU_SOURCE -DI386 -DX86)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wmissing-prototypes -Wredundant-decls -Wextra -Wno-unused -Wno-format-security")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wredundant-decls -Wextra -Wno-unused -Wno-unused-parameter -Wno-format-security")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wmissing-prototypes -Wredundant-decls -Wextra -Wno-unused -Wno-format-security -pthread")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wwrite-strings -Wno-cast-qual -Wredundant-decls -Wextra -Wno-unused -Wno-unused-parameter -Wno-format-security -pthread")
 
   if(SIZEOF_OFF64_T)
     add_definitions( -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64)
@@ -1237,9 +1237,6 @@ if (TARGET ${LIBGCRYPT_TARGET})
   endif(TARGET ${LIBGPG_ERROR_TARGET})
 endif(TARGET ${LIBGCRYPT_TARGET})
 
-#
-# For OPENSSL
-#
 # WITH_LOBOPENSSL can have multiple values with different meanings
 # on Linux:
 # * "EXTERNAL" - (default) builds openssl library from URL stored in ${WITH_LIBOPENSSL_URL} uses the library created by the build
@@ -1260,7 +1257,7 @@ if(WITH_LIBOPENSSL STREQUAL "EXTERNAL")
       URL                  ${WITH_LIBOPENSSL_URL}
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
-      CONFIGURE_COMMAND    <SOURCE_DIR>/config --prefix=${CMAKE_CURRENT_BINARY_DIR}/external no-threads no-shared # ${DEFAULT_CONFIGURE_OPTS}
+      CONFIGURE_COMMAND    <SOURCE_DIR>/config --prefix=${CMAKE_CURRENT_BINARY_DIR}/external no-shared # ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install_sw AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       )

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ * Copyright (C) 2016 CUBRID Corporation
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by

--- a/src/broker/broker_config.h
+++ b/src/broker/broker_config.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ * Copyright (C) 2016 CUBRID Corporation
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ * Copyright (C) 2016 CUBRID Corporation
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -123,8 +124,8 @@ static void set_db_connection_info (void);
 static void clear_db_connection_info (void);
 static bool need_database_reconnect (void);
 
-extern int initSSL (int);
 extern bool ssl_client;
+extern int cas_init_ssl (int);
 extern void cas_ssl_close (int client_sock_fd);
 
 #else /* !LIBCAS_FOR_JSP */
@@ -1016,7 +1017,7 @@ cas_main (void)
 
 	if (IS_SSL_CLIENT (req_info.driver_info))
 	  {
-	    err_code = initSSL (client_sock_fd);
+	    err_code = cas_init_ssl (client_sock_fd);
 	    if (err_code < 0)
 	      {
 		net_write_error (client_sock_fd, req_info.client_version, req_info.driver_info, cas_info, cas_info_size,
@@ -1329,12 +1330,12 @@ cas_main (void)
 #endif /* !CAS_FOR_ORACLE && !CAS_FOR_MYSQL */
 	  }
 
+	CLOSE_SOCKET (client_sock_fd);
+
 	if (ssl_client)
 	  {
 	    cas_ssl_close (client_sock_fd);
 	  }
-
-	CLOSE_SOCKET (client_sock_fd);
 
       finish_cas:
 	as_info->fn_status = FN_STATUS_IDLE;

--- a/src/broker/cas_error.h
+++ b/src/broker/cas_error.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ * Copyright (C) 2016 CUBRID Corporation
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:

--- a/src/broker/cas_protocol.h
+++ b/src/broker/cas_protocol.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ * Copyright (C) 2016 CUBRID Corporation
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by

--- a/src/broker/cas_ssl.c
+++ b/src/broker/cas_ssl.c
@@ -145,7 +145,7 @@ cas_init_ssl (int sd)
   if ((err_code = cas_ssl_validity_check (ctx)) < 0)
     {
       cas_log_write (0, true, "SSL: Certificate validity error (%s)",
-                     err_code == ER_CERT_EXPIRED ? "Expired" : "Unknow");
+		     err_code == ER_CERT_EXPIRED ? "Expired" : "Unknow");
       return err_code;
     }
 

--- a/src/broker/cas_ssl.c
+++ b/src/broker/cas_ssl.c
@@ -145,7 +145,7 @@ cas_init_ssl (int sd)
   if ((err_code = cas_ssl_validity_check (ctx)) < 0)
     {
       cas_log_write (0, true, "SSL: Certificate validity error (%s)",
-		     err_code == ER_CERT_EXPIRED ? "Expired" : "Unknow");
+		     err_code == ER_CERT_EXPIRED ? "Expired" : "Unknown");
       return err_code;
     }
 

--- a/src/jsp/jsp_cl.c
+++ b/src/jsp/jsp_cl.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008 Search Solution Corporation. All rights reserved by Search Solution.
+ * Copyright (C) 2016 CUBRID Corporation
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23687
* This is backport of #2387 to release/10.2.
   * It has exactly the same functionality with 10.2.1, and stable version 
     (10.2.1 TestCases could be applicable without changes)
   * Network I/O was changed to support async mode with timeout.
   * Checks validity of certificate.
   * contains resource return at the middle of error
   * The SSL library will be built in a thread-safe way.
