### PR TITLE
[CBRD-23697] Fix regression caused by different domain of db_value (#2403)

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9823,7 +9823,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	  SET_EXPECTED_DOMAIN (arg2, d);
 	  pt_preset_hostvar (parser, arg2);
 	}
-      if (PT_IS_VALUE_NODE (arg2) && arg1->type_enum != arg2->type_enum)
+      if (PT_IS_VALUE_NODE (arg2))
 	{
 	  if (pt_coerce_value_explicit (parser, arg2, arg2, arg1_type, arg1->data_type) != NO_ERROR)
 	    {
@@ -20263,7 +20263,7 @@ int
 pt_coerce_value_explicit (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest, PT_TYPE_ENUM desired_type,
 			  PT_NODE * data_type)
 {
-  return pt_coerce_value_internal (parser, src, dest, desired_type, data_type, false, false);
+  return pt_coerce_value_internal (parser, src, dest, desired_type, data_type, true, false);
 }
 
 /*

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -1213,13 +1213,13 @@ qdump_print_value (REGU_VARIABLE * value_p)
   switch (value_p->type)
     {
     case TYPE_DBVAL:
-      fprintf (foutput, "[type:%s]", qdump_data_type_string (DB_VALUE_DOMAIN_TYPE (&value_p->value.dbval)));
+      fprintf (foutput, "[type:%s]", qdump_data_type_string (value_p->domain->type->id));
       qdump_print_db_value (&value_p->value.dbval);
       return true;
 
     case TYPE_CONSTANT:
     case TYPE_ORDERBY_NUM:
-      fprintf (foutput, "[type:%s]", qdump_data_type_string (DB_VALUE_DOMAIN_TYPE (value_p->value.dbvalptr)));
+      fprintf (foutput, "[type:%s]", qdump_data_type_string (value_p->domain->type->id));
       qdump_print_db_value (value_p->value.dbvalptr);
       return true;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23697

backport #2403

In the case of the same type as the allocated column, incorrect precision is entered without coerce the type. fix to coerce value to the type of the assigned column even if it is the same type.