### PR TITLE
[CBRD-23708] change table option's default value to reuse_oid

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -5917,7 +5917,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_TB_DEFAULT_REUSE_OID,
    PRM_NAME_TB_DEFAULT_REUSE_OID,
-   (PRM_USER_CHANGE | PRM_FOR_SERVER),
+   (PRM_USER_CHANGE | PRM_FOR_CLIENT | PRM_FOR_SESSION),
    PRM_BOOLEAN,
    &prm_create_table_reuseoid,
    (void *) &prm_create_table_reuseoid_default,


### PR DESCRIPTION
modify system parameter (create_table_reuseoid) to can be changed at  client during session.