### PR TITLE
[CBRD-23682] Support to /*+ NO_LOGGING */ hint

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -8753,6 +8753,8 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
   bool need_locking;
   UPDDEL_CLASS_INSTANCE_LOCK_INFO class_instance_lock_info, *p_class_instance_lock_info = NULL;
 
+  thread_p->no_logging = (bool) update->no_logging;
+
   /* get the snapshot, before acquiring locks, since the transaction may be blocked and we need the snapshot when
    * update starts, not later */
   (void) logtb_get_mvcc_snapshot (thread_p);
@@ -9611,6 +9613,8 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   UPDDEL_MVCC_COND_REEVAL *mvcc_reev_classes = NULL, *mvcc_reev_class = NULL;
   bool need_locking;
   UPDDEL_CLASS_INSTANCE_LOCK_INFO class_instance_lock_info, *p_class_instance_lock_info = NULL;
+
+  thread_p->no_logging = (bool) delete_->no_logging;
 
   /* get the snapshot, before acquiring locks, since the transaction may be blocked and we need the snapshot when
    * delete starts, not later */
@@ -10891,6 +10895,8 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   int flag;
   TP_DOMAIN *result_domain;
   bool has_user_format;
+
+  thread_p->no_logging = (bool) insert->no_logging;
 
   aptr = xasl->aptr_list;
   val_no = insert->num_vals;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -13644,6 +13644,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
   int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   bool instant_lock_mode_started = false;
   bool mvcc_select_lock_needed;
+  bool old_no_logging;
 
   /*
    * Pre_processing
@@ -13737,7 +13738,13 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 	{
 	  old_wait_msecs = xlogtb_reset_wait_msecs (thread_p, xasl->proc.insert.wait_msecs);
 	}
+
+      old_no_logging = thread_p->no_logging;
+
       error = qexec_execute_insert (thread_p, xasl, xasl_state, false);
+
+      thread_p->no_logging = old_no_logging;
+
       if (old_wait_msecs != XASL_WAIT_MSECS_NOCHANGE)
 	{
 	  (void) xlogtb_reset_wait_msecs (thread_p, old_wait_msecs);

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1156,6 +1156,7 @@ qmgr_process_query (THREAD_ENTRY * thread_p, XASL_NODE * xasl_tree, char *xasl_s
 
   /* execute the query with the value list, if any */
   query_p->list_id = qexec_execute_query (thread_p, xasl_p, dbval_count, dbvals_p, query_p->query_id);
+  thread_p->no_logging = false;
 
   /* Note: qexec_execute_query() returns listid (NOT NULL) even if an error was occurred. We should check the error
    * condition and free listid. */

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -18827,14 +18827,7 @@ heap_mvcc_log_home_no_change (THREAD_ENTRY * thread_p, LOG_DATA_ADDR * p_addr)
       p_addr->offset |= HEAP_RV_FLAG_VACUUM_STATUS_CHANGE;
     }
 
-  if (thread_p->no_logging)
-    {
-      log_append_undo_data (thread_p, RVHF_MVCC_NO_MODIFY_HOME, p_addr, 0, NULL);
-    }
-  else
-    {
-      log_append_undoredo_data (thread_p, RVHF_MVCC_NO_MODIFY_HOME, p_addr, 0, 0, NULL, NULL);
-    }
+  log_append_undoredo_data (thread_p, RVHF_MVCC_NO_MODIFY_HOME, p_addr, 0, 0, NULL, NULL);
 }
 
 /*

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20348,25 +20348,11 @@ heap_log_insert_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, VFID * vfid_
       else if (recdes_p->type == REC_NEWHOME)
 	{
 	  /* replication for REC_NEWHOME is performed by following the link (OID) from REC_RELOCATION */
-	  if (thread_p->no_logging)
-	    {
-	      log_append_undo_recdes (thread_p, RVHF_INSERT_NEWHOME, &log_addr, NULL);
-	    }
-	  else
-	    {
-	      log_append_undoredo_recdes (thread_p, RVHF_INSERT_NEWHOME, &log_addr, NULL, recdes_p);
-	    }
+	  log_append_undoredo_recdes (thread_p, RVHF_INSERT_NEWHOME, &log_addr, NULL, recdes_p);
 	}
       else
 	{
-	  if (thread_p->no_logging)
-	    {
-	      log_append_undo_recdes (thread_p, RVHF_INSERT, &log_addr, NULL);
-	    }
-	  else
-	    {
-	      log_append_undoredo_recdes (thread_p, RVHF_INSERT, &log_addr, NULL, recdes_p);
-	    }
+	  log_append_undoredo_recdes (thread_p, RVHF_INSERT, &log_addr, NULL, recdes_p);
 	}
     }
 }
@@ -21477,14 +21463,7 @@ heap_log_delete_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, VFID * vfid_
   else
     {
       /* log record descriptor */
-      if (thread_p->no_logging)
-	{
-	  log_append_undo_recdes (thread_p, RVHF_DELETE, &log_addr, recdes_p);
-	}
-      else
-	{
-	  log_append_undoredo_recdes (thread_p, RVHF_DELETE, &log_addr, recdes_p, NULL);
-	}
+      log_append_undoredo_recdes (thread_p, RVHF_DELETE, &log_addr, recdes_p, NULL);
     }
 
   if (undo_lsa)
@@ -22237,7 +22216,7 @@ heap_log_update_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, VFID * vfid_
 	}
     }
 
-  if (thread_p->no_logging)
+  if (thread_p->no_logging && LOG_IS_MVCC_HEAP_OPERATION (rcvindex))
     {
       log_append_undo_recdes (thread_p, rcvindex, &address, old_recdes_p);
     }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -15595,7 +15595,14 @@ heap_mvcc_log_insert (THREAD_ENTRY * thread_p, RECDES * p_recdes, LOG_DATA_ADDR 
 
   /* Append redo crumbs; undo crumbs not necessary as the spage_delete physical operation uses the offset field of the
    * address */
-  log_append_undoredo_crumbs (thread_p, RVHF_MVCC_INSERT, p_addr, 0, n_redo_crumbs, NULL, redo_crumbs);
+  if (thread_p->no_logging)
+    {
+      log_append_undo_crumbs (thread_p, RVHF_MVCC_INSERT, p_addr, 0, NULL);
+    }
+  else
+    {
+      log_append_undoredo_crumbs (thread_p, RVHF_MVCC_INSERT, p_addr, 0, n_redo_crumbs, NULL, redo_crumbs);
+    }
 }
 
 /*
@@ -15781,7 +15788,14 @@ heap_mvcc_log_delete (THREAD_ENTRY * thread_p, LOG_DATA_ADDR * p_addr, LOG_RCVIN
   assert ((ptr - redo_data_buffer) <= (int) sizeof (redo_data_buffer));
 
   /* Log append undo/redo crumbs */
-  log_append_undoredo_data (thread_p, rcvindex, p_addr, 0, redo_data_size, NULL, redo_data_p);
+  if (thread_p->no_logging)
+    {
+      log_append_undo_data (thread_p, rcvindex, p_addr, 0, NULL);
+    }
+  else
+    {
+      log_append_undoredo_data (thread_p, rcvindex, p_addr, 0, redo_data_size, NULL, redo_data_p);
+    }
 }
 
 /*
@@ -18782,7 +18796,14 @@ heap_mvcc_log_home_change_on_delete (THREAD_ENTRY * thread_p, RECDES * old_recde
       p_addr->offset |= HEAP_RV_FLAG_VACUUM_STATUS_CHANGE;
     }
 
-  log_append_undoredo_recdes (thread_p, RVHF_MVCC_DELETE_MODIFY_HOME, p_addr, old_recdes, new_recdes);
+  if (thread_p->no_logging)
+    {
+      log_append_undo_recdes (thread_p, RVHF_MVCC_DELETE_MODIFY_HOME, p_addr, old_recdes);
+    }
+  else
+    {
+      log_append_undoredo_recdes (thread_p, RVHF_MVCC_DELETE_MODIFY_HOME, p_addr, old_recdes, new_recdes);
+    }
 }
 
 /*
@@ -18806,7 +18827,14 @@ heap_mvcc_log_home_no_change (THREAD_ENTRY * thread_p, LOG_DATA_ADDR * p_addr)
       p_addr->offset |= HEAP_RV_FLAG_VACUUM_STATUS_CHANGE;
     }
 
-  log_append_undoredo_data (thread_p, RVHF_MVCC_NO_MODIFY_HOME, p_addr, 0, 0, NULL, NULL);
+  if (thread_p->no_logging)
+    {
+      log_append_undo_data (thread_p, RVHF_MVCC_NO_MODIFY_HOME, p_addr, 0, NULL);
+    }
+  else
+    {
+      log_append_undoredo_data (thread_p, RVHF_MVCC_NO_MODIFY_HOME, p_addr, 0, 0, NULL, NULL);
+    }
 }
 
 /*
@@ -20327,11 +20355,25 @@ heap_log_insert_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, VFID * vfid_
       else if (recdes_p->type == REC_NEWHOME)
 	{
 	  /* replication for REC_NEWHOME is performed by following the link (OID) from REC_RELOCATION */
-	  log_append_undoredo_recdes (thread_p, RVHF_INSERT_NEWHOME, &log_addr, NULL, recdes_p);
+	  if (thread_p->no_logging)
+	    {
+	      log_append_undo_recdes (thread_p, RVHF_INSERT_NEWHOME, &log_addr, NULL);
+	    }
+	  else
+	    {
+	      log_append_undoredo_recdes (thread_p, RVHF_INSERT_NEWHOME, &log_addr, NULL, recdes_p);
+	    }
 	}
       else
 	{
-	  log_append_undoredo_recdes (thread_p, RVHF_INSERT, &log_addr, NULL, recdes_p);
+	  if (thread_p->no_logging)
+	    {
+	      log_append_undo_recdes (thread_p, RVHF_INSERT, &log_addr, NULL);
+	    }
+	  else
+	    {
+	      log_append_undoredo_recdes (thread_p, RVHF_INSERT, &log_addr, NULL, recdes_p);
+	    }
 	}
     }
 }
@@ -21442,7 +21484,14 @@ heap_log_delete_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, VFID * vfid_
   else
     {
       /* log record descriptor */
-      log_append_undoredo_recdes (thread_p, RVHF_DELETE, &log_addr, recdes_p, NULL);
+      if (thread_p->no_logging)
+	{
+	  log_append_undo_recdes (thread_p, RVHF_DELETE, &log_addr, recdes_p);
+	}
+      else
+	{
+	  log_append_undoredo_recdes (thread_p, RVHF_DELETE, &log_addr, recdes_p, NULL);
+	}
     }
 
   if (undo_lsa)
@@ -22195,7 +22244,14 @@ heap_log_update_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, VFID * vfid_
 	}
     }
 
-  log_append_undoredo_recdes (thread_p, rcvindex, &address, old_recdes_p, new_recdes_p);
+  if (thread_p->no_logging)
+    {
+      log_append_undo_recdes (thread_p, rcvindex, &address, old_recdes_p);
+    }
+  else
+    {
+      log_append_undoredo_recdes (thread_p, rcvindex, &address, old_recdes_p, new_recdes_p);
+    }
 }
 
 /*

--- a/src/storage/overflow_file.c
+++ b/src/storage/overflow_file.c
@@ -230,7 +230,7 @@ overflow_insert (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, VPID * ovf_vpid
 
       memcpy (copyto, data, copy_length);
 
-      if (file_type != FILE_TEMP)
+      if (file_type != FILE_TEMP && thread_p->no_logging != true)
 	{
 	  log_append_redo_data (thread_p, RVOVF_NEWPAGE_INSERT, &addr,
 				copy_length + CAST_BUFLEN (copyto - (char *) addr.pgptr), (char *) addr.pgptr);
@@ -511,7 +511,10 @@ overflow_update (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, const VPID * ov
       data += copy_length;
       length -= copy_length;
 
-      log_append_redo_data (thread_p, RVOVF_PAGE_UPDATE, &addr, copy_length + hdr_length, (char *) addr.pgptr);
+      if (thread_p->no_logging != true)
+	{
+	  log_append_redo_data (thread_p, RVOVF_PAGE_UPDATE, &addr, copy_length + hdr_length, (char *) addr.pgptr);
+	}
 
       if (length > 0)
 	{

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -116,6 +116,7 @@ namespace cubthread
     , log_zip_redo (NULL)
     , log_data_ptr (NULL)
     , log_data_length (0)
+    , no_logging (false)
     , net_request_index (-1)
     , vacuum_worker (NULL)
     , sort_stats_active (false)
@@ -253,6 +254,8 @@ namespace cubthread
       {
 	free (log_data_ptr);
       }
+
+    no_logging = false;
 
     end_resource_tracks ();
 

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -257,6 +257,8 @@ namespace cubthread
       char *log_data_ptr;
       int log_data_length;
 
+      bool no_logging;
+
       int net_request_index;	/* request index of net server functions */
 
       struct vacuum_worker *vacuum_worker;	/* Vacuum worker info */

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -2479,7 +2479,6 @@ log_append_undoredo_recdes2 (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, con
   log_append_undoredo_crumbs (thread_p, rcvindex, &addr, num_undo_crumbs, num_redo_crumbs, undo_crumbs, redo_crumbs);
 }
 
-#if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * log_append_undo_recdes - LOG UNDO (BEFORE) RECORD DESCRIPTOR
  *
@@ -2495,7 +2494,6 @@ log_append_undo_recdes (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DATA
 {
   log_append_undo_recdes2 (thread_p, rcvindex, addr->vfid, addr->pgptr, addr->offset, recdes);
 }
-#endif /* ENABLE_UNUSED_FUNCTION */
 
 void
 log_append_undo_recdes2 (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, const VFID * vfid, PAGE_PTR pgptr,

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -108,10 +108,8 @@ extern void log_append_undoredo_recdes2 (THREAD_ENTRY * thread_p, LOG_RCVINDEX r
 					 PAGE_PTR pgptr, PGLENGTH offset, const RECDES * undo_recdes,
 					 const RECDES * redo_recdes);
 
-#if defined(ENABLE_UNUSED_FUNCTION)
 extern void log_append_undo_recdes (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DATA_ADDR * addr,
 				    const RECDES * recdes);
-#endif
 extern void log_append_undo_recdes2 (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, const VFID * vfid, PAGE_PTR pgptr,
 				     PGLENGTH offset, const RECDES * recdes);
 

--- a/src/transaction/replication.c
+++ b/src/transaction/replication.c
@@ -515,11 +515,6 @@ repl_log_insert_statement (THREAD_ENTRY * thread_p, REPL_INFO_SBR * repl_info)
       return NO_ERROR;
     }
 
-  if (thread_p->no_logging)
-    {
-      return NO_ERROR;
-    }
-
   /* check the replication log array status, if we need to alloc? */
   if (REPL_LOG_IS_NOT_EXISTS (tran_index)
       && ((error = repl_log_info_alloc (tdes, REPL_LOG_INFO_ALLOC_SIZE, false)) != NO_ERROR))

--- a/src/transaction/replication.c
+++ b/src/transaction/replication.c
@@ -316,6 +316,11 @@ repl_log_insert (THREAD_ENTRY * thread_p, const OID * class_oid, const OID * ins
       return NO_ERROR;
     }
 
+  if (thread_p->no_logging && tdes->fl_mark_repl_recidx == -1)
+    {
+      return NO_ERROR;
+    }
+
   /* check the replication log array status, if we need to alloc? */
   if (REPL_LOG_IS_NOT_EXISTS (tran_index)
       && ((error = repl_log_info_alloc (tdes, REPL_LOG_INFO_ALLOC_SIZE, false)) != NO_ERROR))
@@ -506,6 +511,11 @@ repl_log_insert_statement (THREAD_ENTRY * thread_p, REPL_INFO_SBR * repl_info)
 
   /* If suppress_replication flag is set, do not write replication log. */
   if (tdes->suppress_replication != 0)
+    {
+      return NO_ERROR;
+    }
+
+  if (thread_p->no_logging)
     {
       return NO_ERROR;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23682

Supports to /*+ NO_LOGGING */ hint.

**Specifications**
- /*+ NO_LOGGING */ hint can be used in DML syntax.
- Does not write redo logs for table records when using /*+ NO_LOGGING */ hint in a DML statement.
- Does not write the replication log related to table records.
- Writes undo logs. because it must work normally that the transaction rollback by a user, a statement abort due to constraint violations, and so on.
- Among the logs generated when executing a DML statement, only those related to table records are affected by this hint.