### PR TITLE
[CBRD-23734] Core dumped in cubbase::restrack_assert at src/base/resource_tracker.hpp:456

### DIFF
--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4562,9 +4562,9 @@ fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, va
 	      rc = fetch_peek_dbval (thread_p, &regup->value, vd, class_oid, obj_oid, tpl, &tmp);
 	    }
 
+	  pr_clear_value (regup->value.vfetch_to);
 	  if (rc != NO_ERROR)
 	    {
-	      pr_clear_value (regup->value.vfetch_to);
 	      return ER_FAILED;
 	    }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23734

The resource tracker detects a memory leak and generates a core by assertion.

The points where memory leaks occur are at fetch_val_list()
The pr_share_value() in fetch_val_list() ignores the dest value and overwrites it with the src value.
add pr_clear_value() in fetsch_val_list() to prevent this potential memory leak.