### PR TITLE
[CBRD-23734] Core dumped in cubbase::restrack_assert at src/base/resource_tracker.hpp:456

### DIFF
--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4544,9 +4544,9 @@ fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, va
 	      rc = fetch_peek_dbval (thread_p, &regup->value, vd, class_oid, obj_oid, tpl, &tmp);
 	    }
 
+	  pr_clear_value (regup->value.vfetch_to);
 	  if (rc != NO_ERROR)
 	    {
-	      pr_clear_value (regup->value.vfetch_to);
 	      return ER_FAILED;
 	    }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23734

add pr_clear_value() to prevent potential memory leak. back port (#2423)