### PR TITLE
Revert "[CBRD-23734] Core dumped in cubbase::restrack_assert at src/base/resource_tracker.hpp:456"

### DIFF
--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4562,9 +4562,9 @@ fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, va
 	      rc = fetch_peek_dbval (thread_p, &regup->value, vd, class_oid, obj_oid, tpl, &tmp);
 	    }
 
-	  pr_clear_value (regup->value.vfetch_to);
 	  if (rc != NO_ERROR)
 	    {
+	      pr_clear_value (regup->value.vfetch_to);
 	      return ER_FAILED;
 	    }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23734

Reverts CUBRID/cubrid#2423

The vfetch_to variable can be referenced in other reguvars, so it must be cleared at the end of execution of the XASL block.