### PR TITLE
[CBRD-23734] Core dumped in cubbase::restrack_assert at src/base/resource_tracker.hpp:456

### DIFF
--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4562,9 +4562,9 @@ fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, va
 	      rc = fetch_peek_dbval (thread_p, &regup->value, vd, class_oid, obj_oid, tpl, &tmp);
 	    }
 
-	  pr_clear_value (regup->value.vfetch_to);
 	  if (rc != NO_ERROR)
 	    {
+	      pr_clear_value (regup->value.vfetch_to);
 	      return ER_FAILED;
 	    }
 

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4562,9 +4562,9 @@ fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, va
 	      rc = fetch_peek_dbval (thread_p, &regup->value, vd, class_oid, obj_oid, tpl, &tmp);
 	    }
 
+	  pr_clear_value (regup->value.vfetch_to);
 	  if (rc != NO_ERROR)
 	    {
-	      pr_clear_value (regup->value.vfetch_to);
 	      return ER_FAILED;
 	    }
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -25017,6 +25017,15 @@ qexec_free_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * proc
       return;
     }
 
+  /* clear group by regular var list */
+  for (REGU_VARIABLE_LIST p = proc->g_regu_list; p; p = p->next)
+    {
+      if (p->value.vfetch_to != NULL)
+	{
+	  pr_clear_value (p->value.vfetch_to);
+	}
+    }
+
   /* free value array */
   if (proc->agg_hash_context->temp_dbval_array != NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23734

add to clear g_regu_list at free_agg_hash_context to prevent memery leak.