### PR TITLE
[CBRD-23701] Unexpected copylogdb is started even though a database with ha_mode=off

### DIFF
--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -2434,6 +2434,18 @@ us_hb_copylogdb_start (dynamic_array * out_ap, HA_CONF * ha_conf, const char *db
 	}
       num_db_found++;
 
+      prm_set_integer_value (PRM_ID_HA_MODE_FOR_SA_UTILS_ONLY, HA_MODE_FAIL_BACK);
+      status = sysprm_load_and_init (dbs[i], NULL, SYSPRM_IGNORE_INTL_PARAMS);
+      if (status != NO_ERROR)
+	{
+	  goto ret;
+	}
+
+      if (util_get_ha_mode_for_sa_utils () == HA_MODE_OFF)
+	{
+	  continue;
+	}
+
       for (j = 0; j < num_nodes; j++)
 	{
 	  if (node_name != NULL && strcmp (nc[j].node_name, node_name) != 0)
@@ -2703,6 +2715,18 @@ us_hb_applylogdb_start (dynamic_array * out_ap, HA_CONF * ha_conf, const char *d
 	  continue;
 	}
       num_db_found++;
+
+      prm_set_integer_value (PRM_ID_HA_MODE_FOR_SA_UTILS_ONLY, HA_MODE_FAIL_BACK);
+      status = sysprm_load_and_init (dbs[i], NULL, SYSPRM_IGNORE_INTL_PARAMS);
+      if (status != NO_ERROR)
+	{
+	  goto ret;
+	}
+
+      if (util_get_ha_mode_for_sa_utils () == HA_MODE_OFF)
+	{
+	  continue;
+	}
 
       for (j = 0; j < num_nodes; j++)
 	{
@@ -2996,6 +3020,23 @@ us_hb_server_start (HA_CONF * ha_conf, const char *db_name)
 
       if (!is_server_running (CHECK_SERVER, dbs[i], 0))
 	{
+	  prm_set_integer_value (PRM_ID_HA_MODE_FOR_SA_UTILS_ONLY, HA_MODE_FAIL_BACK);
+	  status = sysprm_load_and_init (dbs[i], NULL, SYSPRM_IGNORE_INTL_PARAMS);
+	  if (status != NO_ERROR)
+	    {
+	      util_log_write_errid (MSGCAT_UTIL_GENERIC_SERVICE_PROPERTY_FAIL);
+	      print_result (PRINT_SERVER_NAME, status, START);
+	      break;
+	    }
+
+	  if (util_get_ha_mode_for_sa_utils () == HA_MODE_OFF)
+	    {
+	      print_message (stderr, MSGCAT_UTIL_GENERIC_NOT_HA_MODE);
+	      print_result (PRINT_SERVER_NAME, status, START);
+	      util_log_write_errid (MSGCAT_UTIL_GENERIC_NOT_HA_MODE);
+	      continue;
+	    }
+
 	  status = process_server (START, 1, &(dbs[i]), true, false, false);
 	  if (status != NO_ERROR)
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23701

The 'cubrid hb start' command operates incorrectly if a database with ha_mode=off is registered in ha_node_list. this bug is caused by not applying the properties set in individual sector correctly.

