### PR TITLE
[CBRD-23649] The dual table is excluded from the results of unloaddb utility because it is a system catalog.

### DIFF
--- a/src/executables/unload_object.c
+++ b/src/executables/unload_object.c
@@ -126,6 +126,7 @@ static const char *prohibited_classes[] = {
   CT_PARTITION_NAME,
   CT_COLLATION_NAME,
   CT_CHARSET_NAME,
+  CT_DUAL_NAME,
   /* catalog vclasses */
   CTV_CLASS_NAME,
   CTV_SUPER_CLASS_NAME,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23649

fix a bug reported from the regression test.