### PR TITLE
[CBRD-23736] add query-output and loaddb-output option to csql utility

### DIFF
--- a/msg/de_DE.utf8/csql.msg
+++ b/msg/de_DE.utf8/csql.msg
@@ -40,13 +40,17 @@ gültigen Optionen:\n\
   -c, --command=ARG            CSQL-Befehle\n\
   -l, --line-output            jeden Wert in einer Zeile anzeigen\n\
   -r, --read-only              Nur-Lese-Modus\n\
-  -t, --plain-output           Darstellungsarten ergeben in einem Drucker-freundlichen Format angezeigt  (funktioniert nur mit -c and -i)\n\
+  -t, --plain-output           Darstellungsarten ergeben in einem Drucker-freundlichen Format angezeigt (funktioniert nur mit -c and -i)\n\
+  -q, --query-output           Darstellungsarten ergeben in einem abfrage-freundlichen Format angezeigt (funktioniert nur mit -c und -i)\n\
+  -d, --loaddb-output          Darstellungsarten ergeben in einem loaddb-freundlichen Format angezeigt (funktioniert nur mit -c und -i)\n\
   -N, --skip-column-names      Spaltendarstellung in Ergebnisse nicht anzuzeigen (funktioniert nur mit -c and -i)\n\
       --string-width           jede Spalte der Art String in dieser Breite anzeigen\n\
       --no-auto-commit         Auto-Commit-Modus deaktivieren\n\
       --no-pager               Pager nicht verwenden\n\
       --no-single-line         Ausführung ausgerichtet auf einer Zeile deaktivieren\n\
       --no-trigger-action      deaktivieren Trigger Aktion\n\
+      --delimiter=ARG          Trennzeichen zwischen Spalte (funktioniert nur mit -q)\n\
+      --enclosure=ARG          Gehäuse für eine Ergebniszeichenfolge (funktioniert nur mit -q)\n\
 \n\
 Für weitere Informationen, siehe http://www.cubrid.org\n
 41 %1$s: der Umgebungswert von %2$s_MODE ist inkorrekt. \nEr sollte entweder %3$s oder %4$s sein.\n

--- a/msg/en_US.utf8/csql.msg
+++ b/msg/en_US.utf8/csql.msg
@@ -41,12 +41,16 @@ valid options:\n\
   -l, --line-output            display each value in a line\n\
   -r, --read-only              read-only mode\n\
   -t, --plain-output           display results in a script-friendly format (only works with -c and -i)\n\
+  -q, --query-output           display results in a query-friendly format (only work with -c and -i)\n\
+  -d, --loaddb-output	       display results in a loaddb-friendly format (only work with -c and -i)\n\
   -N, --skip-column-names      do not display column names in results (only works with -c and -i)\n\
       --string-width           display each column which is a string type in this width\n\
       --no-auto-commit         disable auto commit mode execution\n\
       --no-pager               do not use pager\n\
       --no-single-line         turn off single line oriented execution\n\
       --no-trigger-action      disable trigger action\n\
+      --delimiter=ARG          delimiter between columns (only work with -q)\n\
+      --enclosure=ARG          enclosure for result string (only work with -q)\n\
 \n\
 For additional information, see http://www.cubrid.org\n
 41 %1$s: the environment value of %2$s_MODE is incorrect. \nIt should be either %3$s or %4$s.\n

--- a/msg/en_US/csql.msg
+++ b/msg/en_US/csql.msg
@@ -42,15 +42,15 @@ valid options:\n\
   -r, --read-only              read-only mode\n\
   -t, --plain-output           display results in a script-friendly format (only works with -c and -i)\n\
   -q, --query-output           display results in a query-friendly format (only work with -c and -i)\n\
+  -d, --loaddb-output	       display results in a loaddb-friendly format (only work with -c and -i)\n\
   -N, --skip-column-names      do not display column names in results (only works with -c and -i)\n\
-      --loaddb-output	       display results in a loaddb-friendly format (only work with -c and -i)\n\
       --string-width           display each column which is a string type in this width\n\
       --no-auto-commit         disable auto commit mode execution\n\
       --no-pager               do not use pager\n\
       --no-single-line         turn off single line oriented execution\n\
       --no-trigger-action      disable trigger action\n\
-      --delimiter=ARG          delimiter betwwen column (only work with -q)\n\
-      --encloser=ARG	       encloser of result string for query format (only work with -q)\n\
+      --delimiter=ARG          delimiter between columns (only work with -q)\n\
+      --enclosure=ARG	       enclosure for a result string (only work with -q)\n\
 \n\
 For additional information, see http://www.cubrid.org\n
 41 %1$s: the environment value of %2$s_MODE is incorrect. \nIt should be either %3$s or %4$s.\n

--- a/msg/en_US/csql.msg
+++ b/msg/en_US/csql.msg
@@ -41,12 +41,16 @@ valid options:\n\
   -l, --line-output            display each value in a line\n\
   -r, --read-only              read-only mode\n\
   -t, --plain-output           display results in a script-friendly format (only works with -c and -i)\n\
+  -q, --query-output           display results in a query-friendly format (only work with -c and -i)\n\
   -N, --skip-column-names      do not display column names in results (only works with -c and -i)\n\
+      --loaddb-output	       display results in a loaddb-friendly format (only work with -c and -i)\n\
       --string-width           display each column which is a string type in this width\n\
       --no-auto-commit         disable auto commit mode execution\n\
       --no-pager               do not use pager\n\
       --no-single-line         turn off single line oriented execution\n\
       --no-trigger-action      disable trigger action\n\
+      --delimiter=ARG          delimiter betwwen column (only work with -q)\n\
+      --encloser=ARG	       encloser of result string for query format (only work with -q)\n\
 \n\
 For additional information, see http://www.cubrid.org\n
 41 %1$s: the environment value of %2$s_MODE is incorrect. \nIt should be either %3$s or %4$s.\n

--- a/msg/es_ES.utf8/csql.msg
+++ b/msg/es_ES.utf8/csql.msg
@@ -41,12 +41,16 @@ opciones validas:\n\
   -l, --line-output            muestra cada valor en una linea\n\
   -r, --read-only              modo read-only\n\
   -t, --plain-output           mostrar resultados en un formato script-amigable (solo funciona con -c y -i)\n\
+  -q, --query-output           mostrar resultados en un formato query-amigable (solo funciona con -c y -i)\n\
+  -d, --loaddb-output          mostrar resultados en un formato loaddb-amigable (solo funciona con -c y -i)\n\
   -N, --skip-column-names      no mostrar nombres de columnas en resultados (solo funciona con -c y -i)\n\
       --string-width           muestra cada columna de tipo string en esta anchura\n\
       --no-auto-commit         inhabilitar modo de ejecucion cometer automaticamente\n\
       --no-pager               no utilize pager\n\
       --no-single-line         desactivar modo de ejecucion linea suelta\n\
       --no-trigger-action      inhabilitar accion del trigger\n\
+      --delimiter=ARG          delimitador entre columna (solo funciona con -q)\n\
+      --enclosure=ARG          recinto para una cadena de resultado (solo funciona con -q)\n\
 \n\
 Para mas informacion, vea http://www.cubrid.org\n
 41 %1$s: el valor de entorno de %2$s_MODE es incorrecto. \nDeberia ser sea %3$s o %4$s.\n

--- a/msg/fr_FR.utf8/csql.msg
+++ b/msg/fr_FR.utf8/csql.msg
@@ -41,8 +41,8 @@ valid options:\n\
   -l, --line-output            afficher chaque valeur dans une ligne\n\
   -r, --read-only              mode lecture seule\n\
   -t, --plain-output           afficher les résultats dans un format accueillant aux scripts (fonctionne seulement avec -c et -i)\n\
-  -t, --plain-output           afficher les résultats dans un format accueillant aux query (fonctionne seulement avec -c et -i)\n\
-  -t, --plain-output           afficher les résultats dans un format accueillant aux loaddb (fonctionne seulement avec -c et -i)\n\
+  -q, --query-output           afficher les résultats dans un format accueillant aux query (fonctionne seulement avec -c et -i)\n\
+  -d, --loaddb-output          afficher les résultats dans un format accueillant aux loaddb (fonctionne seulement avec -c et -i)\n\
   -N, --skip-column-names      ne pas afficher les nomes des colonnes dans les résultats (fonctionne seulement avec -c et -i)\n\
       --string-width           afficher chaque colonne qui est un type chaîne de caractères dans cette largeur\n\
       --no-auto-commit         désactiver le mode de validation automatique\n\

--- a/msg/fr_FR.utf8/csql.msg
+++ b/msg/fr_FR.utf8/csql.msg
@@ -41,12 +41,16 @@ valid options:\n\
   -l, --line-output            afficher chaque valeur dans une ligne\n\
   -r, --read-only              mode lecture seule\n\
   -t, --plain-output           afficher les résultats dans un format accueillant aux scripts (fonctionne seulement avec -c et -i)\n\
+  -t, --plain-output           afficher les résultats dans un format accueillant aux query (fonctionne seulement avec -c et -i)\n\
+  -t, --plain-output           afficher les résultats dans un format accueillant aux loaddb (fonctionne seulement avec -c et -i)\n\
   -N, --skip-column-names      ne pas afficher les nomes des colonnes dans les résultats (fonctionne seulement avec -c et -i)\n\
       --string-width           afficher chaque colonne qui est un type chaîne de caractères dans cette largeur\n\
       --no-auto-commit         désactiver le mode de validation automatique\n\
       --no-pager               ne pas utiliser pagineur\n\
       --no-single-line         désactiver exécution ligne par ligne\n\
       --no-trigger-action      désactiver action de déclenchement\n\
+      --delimiter=ARG          délimiteur entre colonne (fonctionne seulement avec -q)\n\
+      --enclosure=ARG          enceinte pour une chaîne de résultat (fonctionne seulement avec -q)\n\
 \n\
 Pour plus d'informations, visitez le site http://www.cubrid.org\n
 41 %1$s: la valeur d'environnement du %2$s_MODE est incorrecte. \nIl doit être %3$s ou %4$s.\n

--- a/msg/it_IT.utf8/csql.msg
+++ b/msg/it_IT.utf8/csql.msg
@@ -40,13 +40,17 @@ opzioni valide:\n\
   -c, --command=ARG            commandi-CSQL\n\
   -l, --line-output            ogni valore visualizzato in una riga\n\
   -r, --read-only              modalità read-only\n\
-  -t, --plain-output           visualizzare i risultati in un formato script-friendly (funziona solo con - c e -i)\n\
-  -N, --skip-column-names      non visualizzare i nomi delle colonne nei risultati (funziona solo con - c e -i)\n\
+  -t, --plain-output           visualizzare i risultati in un formato script-friendly (funziona solo con -c e -i)\n\
+  -q, --query-output           visualizzare i risultati in un formato query-friendly (funziona solo con -c e -i)\n\
+  -d, --loaddb-output          visualizzare i risultati in un formato loaddb-friendly (funziona solo con -c e -i)\n\
+  -N, --skip-column-names      non visualizzare i nomi delle colonne nei risultati (funziona solo con -c e -i)\n\
       --string-width           visualizzare ogni colonna che è un tipo stringa in questa larghezza\n\
       --no-auto-commit         disattivare modalità di esecuzione auto-commit\n\
       --no-pager               non utilizzare pager\n\
       --no-single-line         disattivare l'esecuzione orientata singola riga\n\
       --no-trigger-action      disattivare l'azione del trigger\n\
+      --delimiter=ARG          delimitatore tra le colonne (funziona solo con -q)\n\
+      --enclosure=ARG          allegato per una stringa di risultato (funziona solo con -q)\n\
 \n\
 Per ulteriori informazioni, vedere http://www.cubrid.org\n
 41 %1$s: non è corretto il valore di ambiente di %2$s_MODE. \nDovrebbe essere %3$s o %4$s.\n

--- a/msg/ja_JP.utf8/csql.msg
+++ b/msg/ja_JP.utf8/csql.msg
@@ -40,13 +40,17 @@ $set 1 MSGCAT_CSQL_SET_CSQL
   -c, --command=ARG            CSQLコマンド\n\
   -l, --line-output            一つのラインでバリューを表示\n\
   -r, --read-only              リードオンリーモード\n\
-  -t, --plain-output           display results in a script-friendly format (only works with -c and -i)\n\
-  -N, --skip-column-names      do not display column names in results (only works with -c and -i)\n\
+  -t, --plain-output           スクリプトに適した形式で結果を表示します（-cおよび-iでのみ機能します）\n\
+  -q, --query-output           クエリに適した形式で結果を表示します（-cおよび-iでのみ機能します）\n\
+  -d, --loaddb-output          loaddbに適した形式で結果を表示します（-cおよび-iでのみ機能します）\n\
+  -N, --skip-column-names      結果に列名を表示しません（-cおよび-iでのみ機能します）\n\
       --string-width           ストリングタイプの格コラムが表示される長さを制限する。\n\
       --no-auto-commit         自動コミットしない\n\
       --no-pager               ページ単位で表示しない\n\
       --no-single-line         シングルラインで実行しない\n\
       --no-trigger-action      トリガーアクションを無効にする\n\
+      --delimiter=ARG          列間の区切り文字（-qでのみ機能）\n\
+      --enclosure=ARG          結果文字列のエンクロージャ（-qでのみ機能）\n\
 \n\
 追加情報は「http://www.cubrid.org」で得られます。\n
 41 %1$s: 正しくない環境バリアブル「%2$s_MODE」 \n%3$s、または%4$sしかできません。\n

--- a/msg/km_KH.utf8/csql.msg
+++ b/msg/km_KH.utf8/csql.msg
@@ -41,12 +41,16 @@ valid options:\n\
   -l, --line-output            display each value in a line\n\
   -r, --read-only              read-only mode\n\
   -t, --plain-output           display results in a script-friendly format (only works with -c and -i)\n\
+  -t, --query-output           display results in a query-friendly format (only works with -c and -i)\n\
+  -t, --loaddb-output          display results in a loaddb-friendly format (only works with -c and -i)\n\
   -N, --skip-column-names      do not display column names in results (only works with -c and -i)\n\
       --string-width           display each column which is a string type in this width\n\
       --no-auto-commit         disable auto commit mode execution\n\
       --no-pager               do not use pager\n\
       --no-single-line         turn off single line oriented execution\n\
       --no-trigger-action      disable trigger action\n\
+      --delimiter=ARG          delimiter between columns (only work with -q) \n\
+      --enclosure=ARG          enclosure for a result string (only work with -q)\n\
 \n\
 For additional information, see http://www.cubrid.org\n
 41 %1$s: the environment value of %2$s_MODE is incorrect. \nIt should be either %3$s or %4$s.\n

--- a/msg/km_KH.utf8/csql.msg
+++ b/msg/km_KH.utf8/csql.msg
@@ -41,8 +41,8 @@ valid options:\n\
   -l, --line-output            display each value in a line\n\
   -r, --read-only              read-only mode\n\
   -t, --plain-output           display results in a script-friendly format (only works with -c and -i)\n\
-  -t, --query-output           display results in a query-friendly format (only works with -c and -i)\n\
-  -t, --loaddb-output          display results in a loaddb-friendly format (only works with -c and -i)\n\
+  -q, --query-output           display results in a query-friendly format (only works with -c and -i)\n\
+  -d, --loaddb-output          display results in a loaddb-friendly format (only works with -c and -i)\n\
   -N, --skip-column-names      do not display column names in results (only works with -c and -i)\n\
       --string-width           display each column which is a string type in this width\n\
       --no-auto-commit         disable auto commit mode execution\n\

--- a/msg/ko_KR.euckr/csql.msg
+++ b/msg/ko_KR.euckr/csql.msg
@@ -41,12 +41,16 @@ $set 1 MSGCAT_CSQL_SET_CSQL
   -l, --line-output            한 라인 내에 값 표시\n\
   -r, --read-only              읽기 전용 모드\n\
   -t, --plain-output           스크립트 사용에 용이한 포맷으로 결과 값 출력 (-c와 -i 옵션 사용 시 적용)\n\
+  -q, --query-output           질의문 만둘기에 용이한 포맷으로 결과 값 출력 (-c와 -i 옵션 사용 시 적용)\n\
+  -d, --loaddb-output          loaddb로 만들기에 용이한 포맷으로 결과 값 출력 (-c와 -i 옵션 사용 시 적용)\n\
   -N, --skip-column-names      결과 값 컬럼 이름 숨김 (-c와 -i 옵션 사용 시 적용)\n\
       --string-width           각 문자열 컬럼 값을 출력할 길이\n\
       --no-auto-commit         자동 커밋 안 함\n\
       --no-pager               페이지 단위로 표시 안 함\n\
       --no-single-line         단일 라인 실행 안 함\n\
       --no-trigger-action      트리거 실행 안함\n\
+      --delimiter=ARG          컬럼간 구분자 (-q에서만 사용 가능)\n\
+      --enclosure=ARG          결과 문자열 엔글러저 (-q에서만 사용 가능)\n\
 \n\
 추가적인 정보는 http://www.cubrid.org 에서 얻을 수 있습니다.\n
 41 %1$s: 환경 변수 %2$s_MODE 의 값이 틀림. \n%3$s 또는 %4$s 이어야 합니다.\n

--- a/msg/ko_KR.utf8/csql.msg
+++ b/msg/ko_KR.utf8/csql.msg
@@ -32,7 +32,7 @@ $set 1 MSGCAT_CSQL_SET_CSQL
   -S, --SA-mode                독립 모드 실행\n\
   -C, --CS-mode                클라이언트 서버 모드 실행\n\
   -u, --user=ARG               사용자 이름\n\
-  -p, --password=ARG            비밀번호 문자열, 없는 경우 ""\n\
+  -p, --password=ARG           비밀번호 문자열, 없는 경우 ""\n\
   -e, --error-continue         에러 발생 시 계속 수행\n\
   -i, --input-file=ARG         입력 파일 이름\n\
   -o, --output-file=ARG        출력 파일 이름\n\
@@ -41,12 +41,16 @@ $set 1 MSGCAT_CSQL_SET_CSQL
   -l, --line-output            한 라인 내에 값 표시\n\
   -r, --read-only              읽기 전용 모드\n\
   -t, --plain-output           스크립트 사용에 용이한 포맷으로 결과 값 출력 (-c와 -i 옵션 사용 시 적용)\n\
+  -q, --query-output           질의문 만들기에 용이한 포맷으로 결과 값 출력 (-c와 -i 옵션 사용 시 적용)\n\
+  -d, --loaddb-output          loaddb로 만들기에 용이한 포맷으로 결과 값 출력 (-c와 -i 옵션 사용 시 적용)\n\ 
   -N, --skip-column-names      결과 값 컬럼 이름 숨김 (-c와 -i 옵션 사용 시 적용)\n\
       --string-width           각 문자열 컬럼 값을 출력할 길이\n\
       --no-auto-commit         자동 커밋 안 함\n\
       --no-pager               페이지 단위로 표시 안 함\n\
       --no-single-line         단일 라인 실행 안 함\n\
       --no-trigger-action      트리거 실행 안함\n\
+      --delimiter=ARG          컬럼간 구분자 (-q에서만 사용 가능)\n\
+      --enclosure=ARG          결과 문자열 엔클러저 (-q에서만 사용 가능)\n\
 \n\
 추가적인 정보는 http://www.cubrid.org 에서 얻을 수 있습니다.\n
 41 %1$s: 환경 변수 %2$s_MODE 의 값이 틀림. \n%3$s 또는 %4$s 이어야 합니다.\n

--- a/msg/ro_RO.utf8/csql.msg
+++ b/msg/ro_RO.utf8/csql.msg
@@ -40,13 +40,17 @@ optiuni valide:\n\
   -c, --command=ARG            comenzi CSQL\n\
   -l, --line-output            afişarea fiecărei valori pe o singură linie\n\
   -r, --read-only              mod read-only\n\
-  -t, --plain-output           afișarea rezultatelor neformatate (doar împreună cu -c și -i)\n\
+  -t, --plain-output           afișează rezultatele într-un format compatibil cu scriptul (doar împreună cu -c și -i)\n\
+  -q, --query-output           afișează rezultatele într-un format compatibil cu interogările (doar împreună cu -c și -i)\n\
+  -d, --loaddb-output          afișează rezultatele într-un format prietenos cu loaddb (doar împreună cu -c și -i)\n\
   -N, --skip-column-names      afișarea rezultatelor fără numele coloanelor (doar împreună cu -c și -i)\n\
       --string-width           lăţimea de afişare a fiecărei coloane de tip string\n\
       --no-auto-commit         dezactivarea modului de execuţie auto-commit\n\
       --no-pager               dezactivarea paginatorilor\n\
       --no-single-line         dezactivarea modului de execuţie linie cu linie\n\
       --no-trigger-action      dezactivarea acţiunilor declanşatorilor\n\
+      --delimiter=ARG          delimitator între coloană (doar împreună cu -q)\n\
+      --enclosure=ARG          incintă pentru un șir de rezultate (doar împreună cu -q)\n\
 \n\
 Pentru informaţii suplimentare accesaţi http://www.cubrid.org\n
 41 %1$s: valoarea de mediu pentru %2$s_MODE este incorectă. \nTrebuie să fie %3$s sau %4$s.\n

--- a/msg/tr_TR.utf8/csql.msg
+++ b/msg/tr_TR.utf8/csql.msg
@@ -40,13 +40,17 @@ geçerli ayarlar:\n\
   -c, --command=ARG            CSQL-komutları\n\
   -l, --line-output            bir çizgi üzerinde her değeri görüntüle\n\
   -r, --read-only              sadece-oku modu\n\
-  -t, --plain-output           komut dostu formatta göster sonuçları (-c ve -i sadece çalışır)\n\
+  -t, --plain-output           sonuçları komut dosyası için uygun bir formatta görüntülemek (-c ve -i sadece çalışır)\n\
+  -q, --query-output           sonuçları sorguyla uyumlu bir biçimde göster (-c ve -i sadece çalışır)\n\
+  -d, --loaddb-output          sonuçları loaddb için uygun bir formatta görüntüleyin (-c ve -i sadece çalışır)\n\
   -N, --skip-column-names      sonuçlarında sütun adları gösterilmeyecek (-c ve -i sadece çalışır)\n\
       --string-width           bu genişlikte bir dizin tipi olan her sütunu görüntüler\n\
       --no-auto-commit         Otomatik tamamlama modu yürütme devre dışı\n\
       --no-pager               pager kullanmayın\n\
       --no-single-line         tek satır odaklı yürütmeyi kapatın\n\
       --no-trigger-action      tetikleyicileri devre dışı bırak\n\
+      --delimiter=ARG          sütunlar arası sınırlayıcı (-q sadece çalışır)\n\
+      --enclosure=ARG          bir sonuç dizesi için kapsam (-q sadece çalışır)\n\
 \n\
 Ek bilgi için, adresine bakın http://www.cubrid.org\n
 41 %1$s: doğru olmayan %2$s_MODE ortam değeri. \n%3$s veya %4$s olmalıdır.\n

--- a/msg/vi_VN.utf8/csql.msg
+++ b/msg/vi_VN.utf8/csql.msg
@@ -41,12 +41,16 @@ valid options:\n\
   -l, --line-output            display each value in a line\n\
   -r, --read-only              read-only mode\n\
   -t, --plain-output           display results in a script-friendly format (only works with -c and -i)\n\
+  -q, --query-output           display results in a query-friendly format (only works with -c and -i)\n\
+  -d, --loaddb-output          display results in a loaddb-friendly format (only works with -c and -i)\n\
   -N, --skip-column-names      do not display column names in results (only works with -c and -i)\n\
       --string-width           display each column which is a string type in this width\n\
       --no-auto-commit         disable auto commit mode execution\n\
       --no-pager               do not use pager\n\
       --no-single-line         turn off single line oriented execution\n\
       --no-trigger-action      disable trigger action\n\
+      --delimiter=ARG          delimiter between columns (only work wirh -q)\n\
+      --enclosure=ARG          enclosure for a result string (only work wirh -q)\n\
 \n\
 For additional information, see http://www.cubrid.org\n
 41 %1$s: the environment value of %2$s_MODE is incorrect. \nIt should be either %3$s or %4$s.\n

--- a/msg/zh_CN.utf8/csql.msg
+++ b/msg/zh_CN.utf8/csql.msg
@@ -40,13 +40,17 @@ $set 1 MSGCAT_CSQL_SET_CSQL
   -c, --command=ARG            CSQL命令\n\
   -l, --line-output            每个值都用单独的行表示\n\
   -r, --read-only              只读模式\n\
-  -t, --plain-output           display results in a script-friendly format (only works with -c and -i)\n\
-  -N, --skip-column-names      do not display column names in results (only works with -c and -i)\n\
+  -t, --plain-output           以脚本友好的格式显示结果（仅适用于-c和-i）\n\
+  -q, --query-output           以查询友好的格式显示结果（仅适用于-c和-i）\n\
+  -d, --loaddb-output          以loaddb友好格式显示结果（仅适用于-c和-i）\n\
+  -N, --skip-column-names      不在结果中显示列名（仅适用于-c和-i）\n\
       --string-width           用这个宽度显示每个字符串类型的列\n\
       --no-auto-commit         禁用自动提交执行模式\n\
       --no-pager               不要将查询结果分页\n\
       --no-single-line         关闭单行执行模式\n\
       --no-trigger-action      禁用触发器动作\n\
+      --delimiter=ARG          列之间的分隔符（仅适用于-q)\n\
+      --enclosure=ARG          结果字符串的附件（仅适用于-q)\n\
 \n\
 额外的信息, 请浏览 http://www.cubrid.org\n
 41 %1$s: 环境变量 %2$s_MODE 的值不正确. \n应该是 %3$s 或 %4$s.\n

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -2043,7 +2043,7 @@ csql_execute_statements (const CSQL_ARGUMENT * csql_arg, int type, const void *s
 	    }
 	}
 
-      if (csql_arg->plain_output == false)
+      if (csql_arg->plain_output == false && csql_arg->query_output == false && csql_arg->loaddb_output == false)
 	{
 	  fprintf (csql_Output_fp, "%s\n", stmt_msg);
 	}

--- a/src/executables/csql.h
+++ b/src/executables/csql.h
@@ -357,7 +357,8 @@ extern "C"
   extern void csql_help_info (const char *command, int aucommit_flag);
   extern void csql_killtran (const char *argument);
 
-  extern char *csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_OUTPUT_TYPE output_type, char cloumn_enclosure);
+  extern char *csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_OUTPUT_TYPE output_type,
+					char cloumn_enclosure);
 
   extern char *csql_string_to_plain_string (const char *string_value, int length, int *result_length);
 

--- a/src/executables/csql.h
+++ b/src/executables/csql.h
@@ -245,6 +245,13 @@ extern "C"
     CSQL_SUCCESS = 0
   };
 
+  typedef enum
+  {
+    CSQL_UNKNOWN_OUTPUT = 1,
+    CSQL_QUERY_OUTPUT,
+    CSQL_LOADDB_OUTPUT
+  } CSQL_OUTPUT_TYPE;
+
   typedef struct
   {
     const char *db_name;
@@ -269,6 +276,10 @@ extern "C"
     bool skip_column_names;
     bool skip_vacuum;
     int string_width;
+    bool query_output;
+    char column_delimiter;
+    char column_encloser;
+    bool loaddb_output;
 #if defined(CSQL_NO_LONGGING)
     bool no_logging;
 #endif				/* CSQL_NO_LONGGING */
@@ -346,7 +357,7 @@ extern "C"
   extern void csql_help_info (const char *command, int aucommit_flag);
   extern void csql_killtran (const char *argument);
 
-  extern char *csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string);
+  extern char *csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_OUTPUT_TYPE output_type, char cloumn_encloser);
 
   extern char *csql_string_to_plain_string (const char *string_value, int length, int *result_length);
 

--- a/src/executables/csql.h
+++ b/src/executables/csql.h
@@ -278,7 +278,7 @@ extern "C"
     int string_width;
     bool query_output;
     char column_delimiter;
-    char column_encloser;
+    char column_enclosure;
     bool loaddb_output;
 #if defined(CSQL_NO_LONGGING)
     bool no_logging;
@@ -357,7 +357,7 @@ extern "C"
   extern void csql_help_info (const char *command, int aucommit_flag);
   extern void csql_killtran (const char *argument);
 
-  extern char *csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_OUTPUT_TYPE output_type, char cloumn_encloser);
+  extern char *csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_OUTPUT_TYPE output_type, char cloumn_enclosure);
 
   extern char *csql_string_to_plain_string (const char *string_value, int length, int *result_length);
 

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -146,7 +146,7 @@ main (int argc, char *argv[])
     {CSQL_SKIP_VACUUM_L, 0, 0, CSQL_SKIP_VACUUM_S},
     {CSQL_QUERY_OUTPUT_L, 0, 0, CSQL_QUERY_OUTPUT_S},
     {CSQL_QUERY_COLUMN_DELIMITER_L, 1, 0, CSQL_QUERY_COLUMN_DELIMITER_S},
-    {CSQL_QUERY_COLUMN_ENCLOSER_L, 1, 0, CSQL_QUERY_COLUMN_ENCLOSER_S},
+    {CSQL_QUERY_COLUMN_ENCLOSURE_L, 1, 0, CSQL_QUERY_COLUMN_ENCLOSURE_S},
     {CSQL_LOADDB_OUTPUT_L, 0, 0, CSQL_LOADDB_OUTPUT_S},
     {VERSION_L, 0, 0, VERSION_S},
     {0, 0, 0, 0}
@@ -161,7 +161,7 @@ main (int argc, char *argv[])
   csql_arg.query_output = false;
   csql_arg.loaddb_output = false;
   csql_arg.column_delimiter = -1;
-  csql_arg.column_encloser = -1;
+  csql_arg.column_enclosure = -1;
   utility_make_getopt_optstring (csql_option, option_string);
 
   while (1)
@@ -327,14 +327,14 @@ main (int argc, char *argv[])
           }
           break;
 
-        case CSQL_QUERY_COLUMN_ENCLOSER_S:
+        case CSQL_QUERY_COLUMN_ENCLOSURE_S:
           if (strlen(optarg) >= 1)
             {
-              csql_arg.column_encloser = optarg[0];
+              csql_arg.column_enclosure = optarg[0];
             }
           else 
             {
-              csql_arg.column_encloser = '\'';
+              csql_arg.column_enclosure = '\'';
             }
           break;
 
@@ -386,22 +386,22 @@ main (int argc, char *argv[])
           csql_arg.column_delimiter = ',';
         }
 
-      if (csql_arg.column_encloser == -1)
+      if (csql_arg.column_enclosure == -1)
         {
-          csql_arg.column_encloser = '\'';
+          csql_arg.column_enclosure = '\'';
         }
       check_output++;
     }
-  else if (csql_arg.column_delimiter != -1 || csql_arg.column_encloser != -1)
+  else if (csql_arg.column_delimiter != -1 || csql_arg.column_enclosure != -1)
     {
-      /* delimiter and encloser can only use with query_output option */
+      /* delimiter and enclosure can only use with query_output option */
       goto print_usage;
     }
 
   if (csql_arg.loaddb_output == true)
     {
       csql_arg.column_delimiter = ' ';
-      csql_arg.column_encloser = '\'';
+      csql_arg.column_enclosure = '\'';
       check_output++;
     }
 

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -293,54 +293,54 @@ main (int argc, char *argv[])
 	  csql_arg.skip_vacuum = true;
 	  break;
 
-        case CSQL_QUERY_OUTPUT_S:
-          csql_arg.query_output = true;
-          break;
+	case CSQL_QUERY_OUTPUT_S:
+	  csql_arg.query_output = true;
+	  break;
 
-        case CSQL_QUERY_COLUMN_DELIMITER_S:
-          {
-            int len = strlen(optarg);
+	case CSQL_QUERY_COLUMN_DELIMITER_S:
+	  {
+	    int len = strlen (optarg);
 
-            if (len == 1)
-              {
-                csql_arg.column_delimiter = optarg[0];
-              }
-            else if (len >= 2 && optarg[0] == '\\')
-              {
-                if (optarg[1] == 't')
-                  {
-                    csql_arg.column_delimiter = '\t';
-                  }
-                else if (optarg[1] == 'n')
-                  {
-                    csql_arg.column_delimiter = '\n';
-                  }
-                else
-                  {
-                    csql_arg.column_delimiter = optarg[0];
-                  }
-              }
-            else
-              {
-                csql_arg.column_delimiter = ',';
-              }
-          }
-          break;
+	    if (len == 1)
+	      {
+		csql_arg.column_delimiter = optarg[0];
+	      }
+	    else if (len >= 2 && optarg[0] == '\\')
+	      {
+		if (optarg[1] == 't')
+		  {
+		    csql_arg.column_delimiter = '\t';
+		  }
+		else if (optarg[1] == 'n')
+		  {
+		    csql_arg.column_delimiter = '\n';
+		  }
+		else
+		  {
+		    csql_arg.column_delimiter = optarg[0];
+		  }
+	      }
+	    else
+	      {
+		csql_arg.column_delimiter = ',';
+	      }
+	  }
+	  break;
 
-        case CSQL_QUERY_COLUMN_ENCLOSURE_S:
-          if (strlen(optarg) >= 1)
-            {
-              csql_arg.column_enclosure = optarg[0];
-            }
-          else 
-            {
-              csql_arg.column_enclosure = '\'';
-            }
-          break;
+	case CSQL_QUERY_COLUMN_ENCLOSURE_S:
+	  if (strlen (optarg) >= 1)
+	    {
+	      csql_arg.column_enclosure = optarg[0];
+	    }
+	  else
+	    {
+	      csql_arg.column_enclosure = '\'';
+	    }
+	  break;
 
-        case CSQL_LOADDB_OUTPUT_S:
-          csql_arg.loaddb_output = true;
-          break;
+	case CSQL_LOADDB_OUTPUT_S:
+	  csql_arg.loaddb_output = true;
+	  break;
 
 	case VERSION_S:
 	  utility_csql_print (MSGCAT_UTIL_GENERIC_VERSION, UTIL_CSQL_NAME, PRODUCT_STRING);
@@ -378,18 +378,18 @@ main (int argc, char *argv[])
     {
       check_output++;
     }
-  
-  if (csql_arg.query_output == true) 
+
+  if (csql_arg.query_output == true)
     {
       if (csql_arg.column_delimiter == -1)
-        {
-          csql_arg.column_delimiter = ',';
-        }
+	{
+	  csql_arg.column_delimiter = ',';
+	}
 
       if (csql_arg.column_enclosure == -1)
-        {
-          csql_arg.column_enclosure = '\'';
-        }
+	{
+	  csql_arg.column_enclosure = '\'';
+	}
       check_output++;
     }
   else if (csql_arg.column_delimiter != -1 || csql_arg.column_enclosure != -1)
@@ -406,10 +406,10 @@ main (int argc, char *argv[])
     }
 
   if (check_output > 1)
-   {
-     /* can't use -p, -q, and --loaddb-output together */
-     goto print_usage;
-   }
+    {
+      /* can't use -p, -q, and --loaddb-output together */
+      goto print_usage;
+    }
 
   if (csql_arg.sysadm && (csql_arg.user_name == NULL || strcasecmp (csql_arg.user_name, "DBA")))
     {
@@ -430,12 +430,12 @@ main (int argc, char *argv[])
     }
   else if (!csql_arg.sa_mode && csql_arg.skip_vacuum)
     {
-       /* Don't allow to skip vacuum on CS mode
-       goto print_usage;
-    }
-  else if (explicit_single_line && csql_arg.single_line_execution == false)
-    {
-      /* Don't allow both at once. */
+      /* Don't allow to skip vacuum on CS mode
+         goto print_usage;
+         }
+         else if (explicit_single_line && csql_arg.single_line_execution == false)
+         {
+         /* Don't allow both at once. */
       goto print_usage;
     }
   else if (csql_arg.sa_mode)

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -119,7 +119,7 @@ main (int argc, char *argv[])
   CSQL_ARGUMENT csql_arg;
   DSO_HANDLE util_library;
   CSQL csql;
-  int check_output = 0;
+  int check_output_style = 0;
   bool explicit_single_line = false;
 
   GETOPT_LONG csql_option[] = {
@@ -376,7 +376,7 @@ main (int argc, char *argv[])
 
   if (csql_arg.plain_output == true)
     {
-      check_output++;
+      check_output_style++;
     }
 
   if (csql_arg.query_output == true)
@@ -390,7 +390,7 @@ main (int argc, char *argv[])
 	{
 	  csql_arg.column_enclosure = '\'';
 	}
-      check_output++;
+      check_output_style++;
     }
   else if (csql_arg.column_delimiter != -1 || csql_arg.column_enclosure != -1)
     {
@@ -402,10 +402,10 @@ main (int argc, char *argv[])
     {
       csql_arg.column_delimiter = ' ';
       csql_arg.column_enclosure = '\'';
-      check_output++;
+      check_output_style++;
     }
 
-  if (check_output > 1)
+  if (check_output_style > 1)
     {
       /* can't use -p, -q, and --loaddb-output together */
       goto print_usage;

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -119,6 +119,7 @@ main (int argc, char *argv[])
   CSQL_ARGUMENT csql_arg;
   DSO_HANDLE util_library;
   CSQL csql;
+  int check_output = 0;
   bool explicit_single_line = false;
 
   GETOPT_LONG csql_option[] = {
@@ -143,6 +144,10 @@ main (int argc, char *argv[])
     {CSQL_PLAIN_OUTPUT_L, 0, 0, CSQL_PLAIN_OUTPUT_S},
     {CSQL_SKIP_COL_NAMES_L, 0, 0, CSQL_SKIP_COL_NAMES_S},
     {CSQL_SKIP_VACUUM_L, 0, 0, CSQL_SKIP_VACUUM_S},
+    {CSQL_QUERY_OUTPUT_L, 0, 0, CSQL_QUERY_OUTPUT_S},
+    {CSQL_QUERY_COLUMN_DELIMITER_L, 1, 0, CSQL_QUERY_COLUMN_DELIMITER_S},
+    {CSQL_QUERY_COLUMN_ENCLOSER_L, 1, 0, CSQL_QUERY_COLUMN_ENCLOSER_S},
+    {CSQL_LOADDB_OUTPUT_L, 0, 0, CSQL_LOADDB_OUTPUT_S},
     {VERSION_L, 0, 0, VERSION_S},
     {0, 0, 0, 0}
   };
@@ -152,6 +157,11 @@ main (int argc, char *argv[])
   csql_arg.single_line_execution = true;
   csql_arg.string_width = 0;
   csql_arg.trigger_action_flag = true;
+  csql_arg.plain_output = false;
+  csql_arg.query_output = false;
+  csql_arg.loaddb_output = false;
+  csql_arg.column_delimiter = -1;
+  csql_arg.column_encloser = -1;
   utility_make_getopt_optstring (csql_option, option_string);
 
   while (1)
@@ -283,6 +293,55 @@ main (int argc, char *argv[])
 	  csql_arg.skip_vacuum = true;
 	  break;
 
+        case CSQL_QUERY_OUTPUT_S:
+          csql_arg.query_output = true;
+          break;
+
+        case CSQL_QUERY_COLUMN_DELIMITER_S:
+          {
+            int len = strlen(optarg);
+
+            if (len == 1)
+              {
+                csql_arg.column_delimiter = optarg[0];
+              }
+            else if (len >= 2 && optarg[0] == '\\')
+              {
+                if (optarg[1] == 't')
+                  {
+                    csql_arg.column_delimiter = '\t';
+                  }
+                else if (optarg[1] == 'n')
+                  {
+                    csql_arg.column_delimiter = '\n';
+                  }
+                else
+                  {
+                    csql_arg.column_delimiter = optarg[0];
+                  }
+              }
+            else
+              {
+                csql_arg.column_delimiter = ',';
+              }
+          }
+          break;
+
+        case CSQL_QUERY_COLUMN_ENCLOSER_S:
+          if (strlen(optarg) >= 1)
+            {
+              csql_arg.column_encloser = optarg[0];
+            }
+          else 
+            {
+              csql_arg.column_encloser = '\'';
+            }
+          break;
+
+        case CSQL_LOADDB_OUTPUT_S:
+          csql_arg.loaddb_output = true;
+          break;
+
 	case VERSION_S:
 	  utility_csql_print (MSGCAT_UTIL_GENERIC_VERSION, UTIL_CSQL_NAME, PRODUCT_STRING);
 	  goto exit_on_end;
@@ -311,7 +370,46 @@ main (int argc, char *argv[])
     {
       csql_arg.skip_column_names = false;
       csql_arg.plain_output = false;
+      csql_arg.query_output = false;
+      csql_arg.loaddb_output = false;
     }
+
+  if (csql_arg.plain_output == true)
+    {
+      check_output++;
+    }
+  
+  if (csql_arg.query_output == true) 
+    {
+      if (csql_arg.column_delimiter == -1)
+        {
+          csql_arg.column_delimiter = ',';
+        }
+
+      if (csql_arg.column_encloser == -1)
+        {
+          csql_arg.column_encloser = '\'';
+        }
+      check_output++;
+    }
+  else if (csql_arg.column_delimiter != -1 || csql_arg.column_encloser != -1)
+    {
+      /* delimiter and encloser can only use with query_output option */
+      goto print_usage;
+    }
+
+  if (csql_arg.loaddb_output == true)
+    {
+      csql_arg.column_delimiter = ' ';
+      csql_arg.column_encloser = '\'';
+      check_output++;
+    }
+
+  if (check_output > 1)
+   {
+     /* can't use -p, -q, and --loaddb-output together */
+     goto print_usage;
+   }
 
   if (csql_arg.sysadm && (csql_arg.user_name == NULL || strcasecmp (csql_arg.user_name, "DBA")))
     {
@@ -332,12 +430,12 @@ main (int argc, char *argv[])
     }
   else if (!csql_arg.sa_mode && csql_arg.skip_vacuum)
     {
-      /* Don't allow to skip vacuum on CS mode
-         goto print_usage;
-         }
-         else if (explicit_single_line && csql_arg.single_line_execution == false)
-         {
-         /* Don't allow both at once. */
+       /* Don't allow to skip vacuum on CS mode
+       goto print_usage;
+    }
+  else if (explicit_single_line && csql_arg.single_line_execution == false)
+    {
+      /* Don't allow both at once. */
       goto print_usage;
     }
   else if (csql_arg.sa_mode)

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -317,7 +317,7 @@ main (int argc, char *argv[])
 		  }
 		else
 		  {
-		    csql_arg.column_delimiter = optarg[0];
+		    csql_arg.column_delimiter = optarg[1];
 		  }
 	      }
 	    else

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -159,7 +159,8 @@ static jmp_buf csql_Jmp_buf;
 
 static const char *csql_cmd_string (CUBRID_STMT_TYPE stmt_type, const char *default_string);
 static void display_empty_result (int stmt_type, int line_no);
-static char **get_current_result (int **len, const CUR_RESULT_INFO * result_info, bool plain_output, bool query_output, bool loaddb_output, char column_enclosure);
+static char **get_current_result (int **len, const CUR_RESULT_INFO * result_info, bool plain_output, bool query_output,
+				  bool loaddb_output, char column_enclosure);
 static int write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RESULT_INFO * result_info);
 static char *uncontrol_strdup (const char *from);
 static char *uncontrol_strndup (const char *from, int length);
@@ -492,7 +493,8 @@ display_empty_result (int stmt_type, int line_no)
  *   Caller should be responsible for free the return array and its elements.
  */
 static char **
-get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool plain_output, bool query_output, bool loaddb_output, char column_enclosure)
+get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool plain_output, bool query_output,
+		    bool loaddb_output, char column_enclosure)
 {
   int i;
   char **val = NULL;		/* temporary array for values */
@@ -628,20 +630,20 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
 	  else
 	    {
 	      char *temp;
-              CSQL_OUTPUT_TYPE output_type;
+	      CSQL_OUTPUT_TYPE output_type;
 
 	      if (query_output == true)
-                {
-                  output_type = CSQL_QUERY_OUTPUT;
-                }
-              else if (loaddb_output == true)
-                {
-                  output_type = CSQL_LOADDB_OUTPUT;;
-                }
-              else
-                {
-                  output_type = CSQL_UNKNOWN_OUTPUT;
-                }
+		{
+		  output_type = CSQL_QUERY_OUTPUT;
+		}
+	      else if (loaddb_output == true)
+		{
+		  output_type = CSQL_LOADDB_OUTPUT;;
+		}
+	      else
+		{
+		  output_type = CSQL_UNKNOWN_OUTPUT;
+		}
 
 	      temp = csql_db_value_as_string (&db_value, &len[i], plain_output, output_type, column_enclosure);
 	      if (temp == NULL)
@@ -789,7 +791,7 @@ write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RE
 	    }
 	  else if (csql_arg->plain_output == true || csql_arg->query_output == true)
 	    {
-              csql_column_delimiter = (csql_arg->query_output == true) ? csql_arg->column_delimiter : '\t';
+	      csql_column_delimiter = (csql_arg->query_output == true) ? csql_arg->column_delimiter : '\t';
 
 	      for (i = 0; i < num_attrs; i++)
 		{
@@ -814,11 +816,11 @@ write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RE
 		    }
 		}
 	    }
-          else if (csql_arg->loaddb_output == true)
-            {
-              fprintf (pf, "%%class [ ] ("); 
-              for (i = 0; i < num_attrs; i++)
-                {
+	  else if (csql_arg->loaddb_output == true)
+	    {
+	      fprintf (pf, "%%class [ ] (");
+	      for (i = 0; i < num_attrs; i++)
+		{
 		  refined_attr_name = csql_string_to_plain_string (attr_names[i], strlen (attr_names[i]), NULL);
 		  if (refined_attr_name != NULL)
 		    {
@@ -839,7 +841,7 @@ write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RE
 		      fprintf (pf, " ");
 		    }
 		}
-           }
+	    }
 	  else
 	    {
 	      for (n = i = 0; i < num_attrs; i++)
@@ -869,7 +871,9 @@ write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RE
 		}
 	      int *len = NULL;
 
-	      val = get_current_result (&len, result_info, csql_arg->plain_output, csql_arg->query_output, csql_arg->loaddb_output, csql_arg->column_enclosure);
+	      val =
+		get_current_result (&len, result_info, csql_arg->plain_output, csql_arg->query_output,
+				    csql_arg->loaddb_output, csql_arg->column_enclosure);
 	      if (val == NULL)
 		{
 		  csql_Error_code = CSQL_ERR_SQL_ERROR;

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -199,7 +199,7 @@ csql_results (const CSQL_ARGUMENT * csql_arg, DB_QUERY_RESULT * result, DB_QUERY
   /* trivial case - no results */
   if (result == NULL || (err = db_query_first_tuple (result)) == DB_CURSOR_END)
     {
-      if (csql_arg->plain_output == false && csql_arg->query_output == false && csql_arg->loaddb_output)
+      if (csql_arg->plain_output == false && csql_arg->query_output == false && csql_arg->loaddb_output == false)
 	{
 	  display_empty_result (stmt_type, line_no);
 	}

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -159,7 +159,7 @@ static jmp_buf csql_Jmp_buf;
 
 static const char *csql_cmd_string (CUBRID_STMT_TYPE stmt_type, const char *default_string);
 static void display_empty_result (int stmt_type, int line_no);
-static char **get_current_result (int **len, const CUR_RESULT_INFO * result_info, bool plain_output, bool query_output, bool loaddb_output, char column_encloser);
+static char **get_current_result (int **len, const CUR_RESULT_INFO * result_info, bool plain_output, bool query_output, bool loaddb_output, char column_enclosure);
 static int write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RESULT_INFO * result_info);
 static char *uncontrol_strdup (const char *from);
 static char *uncontrol_strndup (const char *from, int length);
@@ -486,13 +486,13 @@ display_empty_result (int stmt_type, int line_no)
  *   plain_output(in): refine string for plain output
  *   query_output(in): refine string for query output
  *   loaddb_output(in): refine string for loaddb output
- *   column_encloser(in): column encloser for query output
+ *   column_enclosure(in): column enclosure for query output
  *
  * Note:
  *   Caller should be responsible for free the return array and its elements.
  */
 static char **
-get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool plain_output, bool query_output, bool loaddb_output, char column_encloser)
+get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool plain_output, bool query_output, bool loaddb_output, char column_enclosure)
 {
   int i;
   char **val = NULL;		/* temporary array for values */
@@ -643,7 +643,7 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
                   output_type = CSQL_UNKNOWN_OUTPUT;
                 }
 
-	      temp = csql_db_value_as_string (&db_value, &len[i], plain_output, output_type, column_encloser);
+	      temp = csql_db_value_as_string (&db_value, &len[i], plain_output, output_type, column_enclosure);
 	      if (temp == NULL)
 		{
 		  csql_Error_code = CSQL_ERR_NO_MORE_MEMORY;
@@ -869,7 +869,7 @@ write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RE
 		}
 	      int *len = NULL;
 
-	      val = get_current_result (&len, result_info, csql_arg->plain_output, csql_arg->query_output, csql_arg->loaddb_output, csql_arg->column_encloser);
+	      val = get_current_result (&len, result_info, csql_arg->plain_output, csql_arg->query_output, csql_arg->loaddb_output, csql_arg->column_enclosure);
 	      if (val == NULL)
 		{
 		  csql_Error_code = CSQL_ERR_SQL_ERROR;

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -159,7 +159,7 @@ static jmp_buf csql_Jmp_buf;
 
 static const char *csql_cmd_string (CUBRID_STMT_TYPE stmt_type, const char *default_string);
 static void display_empty_result (int stmt_type, int line_no);
-static char **get_current_result (int **len, const CUR_RESULT_INFO * result_info, bool plain_output);
+static char **get_current_result (int **len, const CUR_RESULT_INFO * result_info, bool plain_output, bool query_output, bool loaddb_output, char column_encloser);
 static int write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RESULT_INFO * result_info);
 static char *uncontrol_strdup (const char *from);
 static char *uncontrol_strndup (const char *from, int length);
@@ -199,7 +199,7 @@ csql_results (const CSQL_ARGUMENT * csql_arg, DB_QUERY_RESULT * result, DB_QUERY
   /* trivial case - no results */
   if (result == NULL || (err = db_query_first_tuple (result)) == DB_CURSOR_END)
     {
-      if (csql_arg->plain_output == false)
+      if (csql_arg->plain_output == false && csql_arg->query_output == false && csql_arg->loaddb_output)
 	{
 	  display_empty_result (stmt_type, line_no);
 	}
@@ -484,12 +484,15 @@ display_empty_result (int stmt_type, int line_no)
  *   lengths(out): lengths of returned values
  *   result_info(in): pointer to current query result info structure
  *   plain_output(in): refine string for plain output
+ *   query_output(in): refine string for query output
+ *   loaddb_output(in): refine string for loaddb output
+ *   column_encloser(in): column encloser for query output
  *
  * Note:
  *   Caller should be responsible for free the return array and its elements.
  */
 static char **
-get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool plain_output)
+get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool plain_output, bool query_output, bool loaddb_output, char column_encloser)
 {
   int i;
   char **val = NULL;		/* temporary array for values */
@@ -625,8 +628,22 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
 	  else
 	    {
 	      char *temp;
+              CSQL_OUTPUT_TYPE output_type;
 
-	      temp = csql_db_value_as_string (&db_value, &len[i], plain_output);
+	      if (query_output == true)
+                {
+                  output_type = CSQL_QUERY_OUTPUT;
+                }
+              else if (loaddb_output == true)
+                {
+                  output_type = CSQL_LOADDB_OUTPUT;;
+                }
+              else
+                {
+                  output_type = CSQL_UNKNOWN_OUTPUT;
+                }
+
+	      temp = csql_db_value_as_string (&db_value, &len[i], plain_output, output_type, column_encloser);
 	      if (temp == NULL)
 		{
 		  csql_Error_code = CSQL_ERR_NO_MORE_MEMORY;
@@ -729,6 +746,7 @@ write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RE
   int max_attr_name_length = result_info->max_attr_name_length;
   int column_width;
   int csql_string_width = csql_arg->string_width;
+  char csql_column_delimiter;
   int value_width;
   bool is_null;
 
@@ -749,7 +767,7 @@ write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RE
       csql_pipe_save = os_set_signal_handler (SIGPIPE, &csql_pipe_handler);
 #endif /* !WINDOWS */
 
-      if (csql_arg->plain_output == false)
+      if (csql_arg->plain_output == false && csql_arg->query_output == false && csql_arg->loaddb_output == false)
 	{
 	  csql_fputs ("\n=== ", pf);
 	  snprintf (csql_Scratch_text, SCRATCH_TEXT_LEN, csql_get_message (CSQL_RESULT_STMT_TITLE_FORMAT),
@@ -769,8 +787,10 @@ write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RE
 	    {
 	      ;
 	    }
-	  else if (csql_arg->plain_output == true)
+	  else if (csql_arg->plain_output == true || csql_arg->query_output == true)
 	    {
+              csql_column_delimiter = (csql_arg->query_output == true) ? csql_arg->column_delimiter : '\t';
+
 	      for (i = 0; i < num_attrs; i++)
 		{
 		  refined_attr_name = csql_string_to_plain_string (attr_names[i], strlen (attr_names[i]), NULL);
@@ -790,10 +810,36 @@ write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RE
 		    }
 		  else
 		    {
-		      fprintf (pf, "\t");
+		      fprintf (pf, "%c", csql_column_delimiter);
 		    }
 		}
 	    }
+          else if (csql_arg->loaddb_output == true)
+            {
+              fprintf (pf, "%%class [ ] ("); 
+              for (i = 0; i < num_attrs; i++)
+                {
+		  refined_attr_name = csql_string_to_plain_string (attr_names[i], strlen (attr_names[i]), NULL);
+		  if (refined_attr_name != NULL)
+		    {
+		      fprintf (pf, "[%s]", refined_attr_name);
+		      free_and_init (refined_attr_name);
+		    }
+		  else
+		    {
+		      fprintf (pf, "UNKNOWN");
+		    }
+
+		  if (i == num_attrs - 1)
+		    {
+		      fprintf (pf, ")\n");
+		    }
+		  else
+		    {
+		      fprintf (pf, " ");
+		    }
+		}
+           }
 	  else
 	    {
 	      for (n = i = 0; i < num_attrs; i++)
@@ -823,7 +869,7 @@ write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RE
 		}
 	      int *len = NULL;
 
-	      val = get_current_result (&len, result_info, csql_arg->plain_output);
+	      val = get_current_result (&len, result_info, csql_arg->plain_output, csql_arg->query_output, csql_arg->loaddb_output, csql_arg->column_encloser);
 	      if (val == NULL)
 		{
 		  csql_Error_code = CSQL_ERR_SQL_ERROR;
@@ -850,6 +896,14 @@ write_results_to_stream (const CSQL_ARGUMENT * csql_arg, FILE * fp, const CUR_RE
 		  for (i = 0; i < num_attrs - 1; i++)
 		    {
 		      fprintf (pf, "%s\t", val[i]);
+		    }
+		  fprintf (pf, "%s\n", val[i]);
+		}
+	      else if (csql_arg->query_output == true || csql_arg->loaddb_output == true)
+		{
+		  for (i = 0; i < num_attrs - 1; i++)
+		    {
+		      fprintf (pf, "%s%c", val[i], csql_arg->column_delimiter);
 		    }
 		  fprintf (pf, "%s\n", val[i]);
 		}

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -980,10 +980,10 @@ bit_to_string (DB_VALUE * value, char string_delimiter, bool plain_string)
  *   max_entries(in): maximum number of entries to convert. -1 for all
  *   plain_string(in): refine string for plain output
  *   output_type(in): query output or loaddb output
- *   column_encloser(in): column encloser for query output
+ *   column_enclosure(in): column enclosure for query output
  */
 static char *
-set_to_string (DB_VALUE * value, char begin_notation, char end_notation, int max_entries, bool plain_string, CSQL_OUTPUT_TYPE output_type, char column_encloser)
+set_to_string (DB_VALUE * value, char begin_notation, char end_notation, int max_entries, bool plain_string, CSQL_OUTPUT_TYPE output_type, char column_enclosure)
 {
   int cardinality, total_string_length, i;
   char **string_array;
@@ -1046,7 +1046,7 @@ set_to_string (DB_VALUE * value, char begin_notation, char end_notation, int max
 	{
 	  goto finalize;
 	}
-      string_array[i] = csql_db_value_as_string (&element, NULL, plain_string, output_type, column_encloser);
+      string_array[i] = csql_db_value_as_string (&element, NULL, plain_string, output_type, column_enclosure);
       db_value_clear (&element);
       if (string_array[i] == NULL)
 	{
@@ -1338,16 +1338,16 @@ string_to_string (const char *string_value, char string_delimiter, char string_i
  *   length(out): length of output string
  *   plain_output(in): refine string for plain output
  *   output_type(in): query output or loaddb output
- *   column_encloser(in): column encloser for query output
+ *   column_enclosure(in): column enclosure for query output
  */
 char *
-csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_OUTPUT_TYPE output_type, char column_encloser)
+csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_OUTPUT_TYPE output_type, char column_enclosure)
 {
   char *result = NULL;
   char *json_body = NULL;
   int len = 0;
-  char string_delimiter =  (output_type != CSQL_UNKNOWN_OUTPUT) ? column_encloser : default_string_profile.string_delimiter;
-  bool change_single_quote = (output_type != CSQL_UNKNOWN_OUTPUT);
+  char string_delimiter =  (output_type != CSQL_UNKNOWN_OUTPUT) ? column_enclosure : default_string_profile.string_delimiter;
+  bool change_single_quote = (output_type == CSQL_QUERY_OUTPUT && column_enclosure == '\'');
 
   if (value == NULL)
     {
@@ -1535,7 +1535,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
             {
               char *new_result;
 
-              new_result = string_to_string (result, column_encloser, '\0', strlen(result), &len, false, change_single_quote);
+              new_result = string_to_string (result, column_enclosure, '\0', strlen(result), &len, false, change_single_quote);
 
               if (new_result)
                 {
@@ -1551,7 +1551,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
     case DB_TYPE_SEQUENCE:
       result =
 	set_to_string (value, default_set_profile.begin_notation, default_set_profile.end_notation,
-		       default_set_profile.max_entries, plain_string, output_type, column_encloser);
+		       default_set_profile.max_entries, plain_string, output_type, column_enclosure);
       if (result)
 	{
 	  len = strlen (result);
@@ -1564,7 +1564,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	  {
             if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
               {
-	        result = string_to_string (buf, column_encloser, '\0', strlen(buf), &len, false, false);
+	        result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
               }
             else
               {
@@ -1624,7 +1624,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
             {
               char *new_result;
 
-	      new_result = string_to_string (result, column_encloser, '\0', strlen(result), &len, false, false);
+	      new_result = string_to_string (result, column_enclosure, '\0', strlen(result), &len, false, false);
 
               if (new_result) 
                 {
@@ -1642,7 +1642,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	  {
             if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
               {
-                result = string_to_string (buf, column_encloser, '\0', strlen(buf), &len, false, false);
+                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
               }
             else
               {
@@ -1664,7 +1664,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	  {
             if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
               {
-                result = string_to_string (buf, column_encloser, '\0', strlen(buf), &len, false, false);
+                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
               }
             else
               {
@@ -1686,7 +1686,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	  {
             if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
               {
-                result = string_to_string (buf, column_encloser, '\0', strlen(buf), &len, false, false);
+                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
               }
             else
               {
@@ -1707,7 +1707,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	  {
             if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
               {
-                result = string_to_string (buf, column_encloser, '\0', strlen(buf), &len, false, false);
+                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
               }
             else
               {
@@ -1729,7 +1729,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	  {
             if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
               {
-                result = string_to_string (buf, column_encloser, '\0', strlen(buf), &len, false, false);
+                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
               }
             else
               {
@@ -1751,7 +1751,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	  {
             if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
               {
-                result = string_to_string (buf, column_encloser, '\0', strlen(buf), &len, false, false);
+                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
               }
             else
               {
@@ -1843,7 +1843,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	      }
 	  }
 
-	result = string_to_string (str, default_string_profile.string_delimiter, '\0', bytes_size, &len, plain_string, change_single_quote);
+	result = string_to_string (str, string_delimiter, '\0', bytes_size, &len, plain_string, change_single_quote);
 	if (decomposed != NULL)
 	  {
 	    free_and_init (decomposed);

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -965,7 +965,8 @@ bit_to_string (DB_VALUE * value, char string_delimiter, bool plain_string)
       return (NULL);		/* Should never get here */
     }
 
-  return_string = string_to_string (temp_string, string_delimiter, 'X', strlen (temp_string), NULL, plain_string, false);
+  return_string =
+    string_to_string (temp_string, string_delimiter, 'X', strlen (temp_string), NULL, plain_string, false);
   free_and_init (temp_string);
 
   return (return_string);
@@ -983,7 +984,8 @@ bit_to_string (DB_VALUE * value, char string_delimiter, bool plain_string)
  *   column_enclosure(in): column enclosure for query output
  */
 static char *
-set_to_string (DB_VALUE * value, char begin_notation, char end_notation, int max_entries, bool plain_string, CSQL_OUTPUT_TYPE output_type, char column_enclosure)
+set_to_string (DB_VALUE * value, char begin_notation, char end_notation, int max_entries, bool plain_string,
+	       CSQL_OUTPUT_TYPE output_type, char column_enclosure)
 {
   int cardinality, total_string_length, i;
   char **string_array;
@@ -1258,16 +1260,16 @@ string_to_string (const char *string_value, char string_delimiter, char string_i
       ptr = (char *) string_value;
 
       while (*ptr != '\0')
-       {
-         if (*ptr == '\'')
-           {
-             num_found++;
-           }
-         ptr++;
-       }
+	{
+	  if (*ptr == '\'')
+	    {
+	      num_found++;
+	    }
+	  ptr++;
+	}
     }
 
-  if (num_found == 0) 
+  if (num_found == 0)
     {
       return_string = (char *) malloc (length + 4);
     }
@@ -1276,7 +1278,7 @@ string_to_string (const char *string_value, char string_delimiter, char string_i
       return_string = (char *) malloc (length + 4 + num_found);
     }
 
-   if (!return_string)
+  if (!return_string)
     {
       return (NULL);
     }
@@ -1291,21 +1293,21 @@ string_to_string (const char *string_value, char string_delimiter, char string_i
   if (change_single_quote == true)
     {
       for (i = 0; i < length; i++)
-        {
-          if (string_value[i] == '\'')
-            {
-              *(ptr++) = string_value[i];
-              *(ptr++) = '\'';
-            }
-          else
-            {
-              *(ptr++) = string_value[i];
-            }
-         }
+	{
+	  if (string_value[i] == '\'')
+	    {
+	      *(ptr++) = string_value[i];
+	      *(ptr++) = '\'';
+	    }
+	  else
+	    {
+	      *(ptr++) = string_value[i];
+	    }
+	}
       *(ptr++) = string_delimiter;
       *ptr = '\0';
     }
-  else 
+  else
     {
       memcpy (ptr, string_value, length);
       ptr[length] = string_delimiter;
@@ -1341,12 +1343,14 @@ string_to_string (const char *string_value, char string_delimiter, char string_i
  *   column_enclosure(in): column enclosure for query output
  */
 char *
-csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_OUTPUT_TYPE output_type, char column_enclosure)
+csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_OUTPUT_TYPE output_type,
+			 char column_enclosure)
 {
   char *result = NULL;
   char *json_body = NULL;
   int len = 0;
-  char string_delimiter =  (output_type != CSQL_UNKNOWN_OUTPUT) ? column_enclosure : default_string_profile.string_delimiter;
+  char string_delimiter =
+    (output_type != CSQL_UNKNOWN_OUTPUT) ? column_enclosure : default_string_profile.string_delimiter;
   bool change_single_quote = (output_type == CSQL_QUERY_OUTPUT && column_enclosure == '\'');
 
   if (value == NULL)
@@ -1530,21 +1534,22 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
       result = duplicate_string (json_body);
       db_private_free (NULL, json_body);
       if (result)
-        {
-          if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
-            {
-              char *new_result;
+	{
+	  if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
+	    {
+	      char *new_result;
 
-              new_result = string_to_string (result, column_enclosure, '\0', strlen(result), &len, false, change_single_quote);
+	      new_result =
+		string_to_string (result, column_enclosure, '\0', strlen (result), &len, false, change_single_quote);
 
-              if (new_result)
-                {
-                  free (result);
-                  result = new_result;
-                }
-            }
-          len = strlen (result);
-        }
+	      if (new_result)
+		{
+		  free (result);
+		  result = new_result;
+		}
+	    }
+	  len = strlen (result);
+	}
       break;
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
@@ -1562,14 +1567,14 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	char buf[TIME_BUF_SIZE];
 	if (db_time_to_string (buf, sizeof (buf), db_get_time (value)))
 	  {
-            if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
-              {
-	        result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
-              }
-            else
-              {
-	        result = duplicate_string (buf);
-              }
+	    if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
+	      {
+		result = string_to_string (buf, column_enclosure, '\0', strlen (buf), &len, false, false);
+	      }
+	    else
+	      {
+		result = duplicate_string (buf);
+	      }
 	  }
 	if (result)
 	  {
@@ -1620,18 +1625,18 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
       result = date_as_string (db_get_date (value), default_date_profile.format);
       if (result)
 	{
-          if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
-            {
-              char *new_result;
+	  if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
+	    {
+	      char *new_result;
 
-	      new_result = string_to_string (result, column_enclosure, '\0', strlen(result), &len, false, false);
+	      new_result = string_to_string (result, column_enclosure, '\0', strlen (result), &len, false, false);
 
-              if (new_result) 
-                {
-                  free (result);
-                  result = new_result;
-                }
-            }
+	      if (new_result)
+		{
+		  free (result);
+		  result = new_result;
+		}
+	    }
 	  len = strlen (result);
 	}
       break;
@@ -1640,14 +1645,14 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	char buf[TIMESTAMP_BUF_SIZE];
 	if (db_utime_to_string (buf, sizeof (buf), db_get_timestamp (value)))
 	  {
-            if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
-              {
-                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
-              }
-            else
-              {
-                result = duplicate_string (buf);
-              }
+	    if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
+	      {
+		result = string_to_string (buf, column_enclosure, '\0', strlen (buf), &len, false, false);
+	      }
+	    else
+	      {
+		result = duplicate_string (buf);
+	      }
 	  }
 
 	if (result)
@@ -1662,14 +1667,14 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	DB_TIMESTAMPTZ *ts_tz = db_get_timestamptz (value);
 	if (db_timestamptz_to_string (buf, sizeof (buf), &(ts_tz->timestamp), &(ts_tz->tz_id)))
 	  {
-            if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
-              {
-                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
-              }
-            else
-              {
-                result = duplicate_string (buf);
-              }
+	    if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
+	      {
+		result = string_to_string (buf, column_enclosure, '\0', strlen (buf), &len, false, false);
+	      }
+	    else
+	      {
+		result = duplicate_string (buf);
+	      }
 	  }
 
 	if (result)
@@ -1684,14 +1689,14 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 
 	if (db_timestampltz_to_string (buf, sizeof (buf), db_get_timestamp (value)))
 	  {
-            if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
-              {
-                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
-              }
-            else
-              {
-                result = duplicate_string (buf);
-              }
+	    if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
+	      {
+		result = string_to_string (buf, column_enclosure, '\0', strlen (buf), &len, false, false);
+	      }
+	    else
+	      {
+		result = duplicate_string (buf);
+	      }
 	  }
 
 	if (result)
@@ -1705,14 +1710,14 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	char buf[DATETIME_BUF_SIZE];
 	if (db_datetime_to_string (buf, sizeof (buf), db_get_datetime (value)))
 	  {
-            if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
-              {
-                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
-              }
-            else
-              {
-                result = duplicate_string (buf);
-              }
+	    if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
+	      {
+		result = string_to_string (buf, column_enclosure, '\0', strlen (buf), &len, false, false);
+	      }
+	    else
+	      {
+		result = duplicate_string (buf);
+	      }
 	  }
 
 	if (result)
@@ -1727,14 +1732,14 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	DB_DATETIMETZ *dt_tz = db_get_datetimetz (value);
 	if (db_datetimetz_to_string (buf, sizeof (buf), &(dt_tz->datetime), &(dt_tz->tz_id)))
 	  {
-            if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
-              {
-                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
-              }
-            else
-              {
-                result = duplicate_string (buf);
-              }
+	    if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
+	      {
+		result = string_to_string (buf, column_enclosure, '\0', strlen (buf), &len, false, false);
+	      }
+	    else
+	      {
+		result = duplicate_string (buf);
+	      }
 	  }
 
 	if (result)
@@ -1749,14 +1754,14 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 
 	if (db_datetimeltz_to_string (buf, sizeof (buf), db_get_datetime (value)))
 	  {
-            if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
-              {
-                result = string_to_string (buf, column_enclosure, '\0', strlen(buf), &len, false, false);
-              }
-            else
-              {
-                result = duplicate_string (buf);
-              }
+	    if (output_type == CSQL_QUERY_OUTPUT || output_type == CSQL_LOADDB_OUTPUT)
+	      {
+		result = string_to_string (buf, column_enclosure, '\0', strlen (buf), &len, false, false);
+	      }
+	    else
+	      {
+		result = duplicate_string (buf);
+	      }
 	  }
 
 	if (result)
@@ -1797,17 +1802,17 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 	const char *str;
 	char *decomposed = NULL;
 
-        if (output_type == CSQL_LOADDB_OUTPUT)
-          {
-            result = bigint_to_string (SHORT_TO_INT (db_get_enum_short (value)), default_short_profile.fieldwidth,
-                                       default_short_profile.leadingzeros, default_short_profile.leadingsymbol,
-                                       default_short_profile.commas, default_short_profile.format);
-            if (result)
-              {
-                len = strlen (result);
-              }
-            break;
-          } 
+	if (output_type == CSQL_LOADDB_OUTPUT)
+	  {
+	    result = bigint_to_string (SHORT_TO_INT (db_get_enum_short (value)), default_short_profile.fieldwidth,
+				       default_short_profile.leadingzeros, default_short_profile.leadingsymbol,
+				       default_short_profile.commas, default_short_profile.format);
+	    if (result)
+	      {
+		len = strlen (result);
+	      }
+	    break;
+	  }
 
 	if (db_get_enum_short (value) == 0 && db_get_enum_string (value) == NULL)
 	  {

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -1269,16 +1269,7 @@ string_to_string (const char *string_value, char string_delimiter, char string_i
 	}
     }
 
-  if (num_found == 0)
-    {
-      return_string = (char *) malloc (length + 4);
-    }
-  else
-    {
-      return_string = (char *) malloc (length + 4 + num_found);
-    }
-
-  if (!return_string)
+  if ((return_string = (char *) malloc (length + 4 + num_found)) == NULL)
     {
       return (NULL);
     }

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -1342,6 +1342,14 @@ typedef struct _ha_config
 #define CSQL_SKIP_COL_NAMES_L                   "skip-column-names"
 #define CSQL_SKIP_VACUUM_S			12017
 #define CSQL_SKIP_VACUUM_L			"skip-vacuum"
+#define CSQL_QUERY_OUTPUT_S			'q'
+#define CSQL_QUERY_OUTPUT_L			"query-output"
+#define CSQL_QUERY_COLUMN_DELIMITER_S		12018
+#define CSQL_QUERY_COLUMN_DELIMITER_L		"delimiter"
+#define CSQL_QUERY_COLUMN_ENCLOSER_S		12019
+#define CSQL_QUERY_COLUMN_ENCLOSER_L		"encloser"
+#define CSQL_LOADDB_OUTPUT_S			12020
+#define CSQL_LOADDB_OUTPUT_L			"loaddb-output"
 
 #define COMMDB_SERVER_LIST_S                    'P'
 #define COMMDB_SERVER_LIST_L                    "server-list"

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -1346,9 +1346,9 @@ typedef struct _ha_config
 #define CSQL_QUERY_OUTPUT_L			"query-output"
 #define CSQL_QUERY_COLUMN_DELIMITER_S		12018
 #define CSQL_QUERY_COLUMN_DELIMITER_L		"delimiter"
-#define CSQL_QUERY_COLUMN_ENCLOSER_S		12019
-#define CSQL_QUERY_COLUMN_ENCLOSER_L		"encloser"
-#define CSQL_LOADDB_OUTPUT_S			12020
+#define CSQL_QUERY_COLUMN_ENCLOSURE_S		12019
+#define CSQL_QUERY_COLUMN_ENCLOSURE_L		"enclosure"
+#define CSQL_LOADDB_OUTPUT_S			'd'
 #define CSQL_LOADDB_OUTPUT_L			"loaddb-output"
 
 #define COMMDB_SERVER_LIST_S                    'P'


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23736
      - The -q (--query-output) option displays query friendly format with --delimiter and --enclosure option.
      - The -d (--loaddb-output) option displays loaddb friendly format.
      - The two options only work with -c or -i option and are ignored if -c and -i option are omitted or -l option is used together.
      - This options can't work together and also use with -q option.
