### PR TITLE
[CBRD-21560] Syntax errors can occur when a view containing TRUNC() or ROUND() function is fetched

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -26334,15 +26334,6 @@ parser_keyword_func (const char *name, PT_NODE * args)
       a2 = a1->next;
       a1->next = NULL;
 
-      if(a2->node_type == PT_VALUE
-         && PT_IS_STRING_TYPE(a2->type_enum)
-         && strcasecmp((const char *) a2->info.value.data_value.str->bytes, "default") == 0)
-        {
-          PT_ERRORf (this_parser, a2, "check syntax at %s",
-                     parser_print_tree (this_parser, a2));
-          return NULL;
-        }
-
       return parser_make_expression (this_parser, key->op, a1, a2, NULL);
 
     case PT_TRUNC:
@@ -26375,16 +26366,6 @@ parser_keyword_func (const char *name, PT_NODE * args)
       a1 = args;
       a2 = a1->next;
       a1->next = NULL;
-
-      /* prevent user input "default" */
-      if (a2->node_type == PT_VALUE
-          && a2->type_enum == PT_TYPE_CHAR
-          && strcasecmp ((const char *) a2->info.value.data_value.str->bytes, "default") == 0)
-        {
-          PT_ERRORf (this_parser, a2, "check syntax at %s",
-                     parser_print_tree (this_parser, a2));
-          return NULL;
-        }
 
       return parser_make_expression (this_parser, key->op, a1, a2, NULL);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21560

This change removes the returning error block when "default" is specified in fmt argument for TRUNC() and ROUND().
```
create table foo (a int, b date);
insert into foo values (1, '20170821');
insert into foo values (2, NULL);

create view foo_num as select trunc(sysdate-b) c1, round(sysdate-b) c2 from foo;
select * from foo_num;

create view foo_dt as select trunc(sysdate) c1, round(sysdate) c2 from foo;
select * from foo_dt;
```

The following is query specification information of each view.
```
csql> ;schema foo_num
...
 <VClass Name> 
     foo_num
...
 <Query_specifications> 
     select  trunc( SYS_DATE -[foo].[b], _iso88591'default'),  round( SYS_DATE -[foo].[b], _iso88591'default') from [foo] [foo]

csql> ;schema foo_num
...
 <VClass Name> 
     foo_dt
...
<Query_specifications> 
     select  trunc([foo].[b], _iso88591'default'),  round([foo].[b], _iso88591'default') from [foo] [foo]
```

For both cases, "check syntax at 'default'" error occurred before the change.
```
csql> select * from foo_num;

=== <Result of SELECT Command in Line 1> ===

                    c1                    c2
============================================
                  1109                  1109
                  NULL                  NULL

csql> select * from foo_dt;

=== <Result of SELECT Command in Line 1> ===

  c1          c2        
========================
  09/03/2020  09/03/2020
  09/03/2020  09/03/2020
```