### PR TITLE
[CBRD-23606] An error occurs when the binding value is larger than 256 chars in merge query

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -13869,7 +13869,7 @@ dbmeth_print (DB_OBJECT * self, DB_VALUE * result, DB_VALUE * msg)
 int
 do_select (PARSER_CONTEXT * parser, PT_NODE * statement)
 {
-  do_select_internal (parser, statement, false);
+  return do_select_internal (parser, statement, false);
 }
 
 /*
@@ -13883,7 +13883,7 @@ do_select (PARSER_CONTEXT * parser, PT_NODE * statement)
 int
 do_select_for_ins_upd (PARSER_CONTEXT * parser, PT_NODE * statement)
 {
-  do_select_internal (parser, statement, true);
+  return do_select_internal (parser, statement, true);
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23606

this is a revised version of https://github.com/CUBRID/cubrid/pull/2411

revised for windows build fail

