### PR TITLE
[CBRD-23708] change table option's default value to reuse_oid

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2304,7 +2304,7 @@ static unsigned int prm_allow_truncated_string_flag = 0;
 
 bool PRM_TB_REUSE_OID = true;
 static bool prm_create_table_reuseoid_default = true;
-static unsigned int prm_create_table_reuseoid = 1;
+static unsigned int prm_create_table_reuseoid = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5921,7 +5921,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_TB_DEFAULT_REUSE_OID,
    PRM_NAME_TB_DEFAULT_REUSE_OID,
-   (PRM_USER_CHANGE | PRM_FOR_CLIENT | PRM_FOR_SESSION),
+   (PRM_USER_CHANGE | PRM_FOR_CLIENT | PRM_FOR_SESSION | PRM_FOR_HA_CONTEXT),
    PRM_BOOLEAN,
    &prm_create_table_reuseoid,
    (void *) &prm_create_table_reuseoid_default,
@@ -5929,7 +5929,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
-   (DUP_PRM_FUNC) NULL},
+   (DUP_PRM_FUNC) NULL}
 };
 
 #define NUM_PRM ((int)(sizeof(prm_Def)/sizeof(prm_Def[0])))

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8317,10 +8317,16 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	}
     }
 
-  /* get default value of reuse_oid from system parameter, if don't use table option related reuse_oid */
+  /* get default value of reuse_oid from system parameter and create pt_node and add it into table_option_list, if don't use table option related reuse_oid */
   if (!found_reuse_oid_option)
     {
+      PT_NODE *tmp;
+
       reuse_oid = prm_get_bool_value (PRM_ID_TB_DEFAULT_REUSE_OID);
+      tmp = pt_table_option (parser, reuse_oid ? PT_TABLE_OPTION_REUSE_OID : PT_TABLE_OPTION_DONT_REUSE_OID, NULL);
+
+      tmp->next = node->info.create_entity.table_option_list;
+      node->info.create_entity.table_option_list = tmp;
     }
 
   /* validate charset and collation options, if any */

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8324,9 +8324,12 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 
       reuse_oid = prm_get_bool_value (PRM_ID_TB_DEFAULT_REUSE_OID);
       tmp = pt_table_option (parser, reuse_oid ? PT_TABLE_OPTION_REUSE_OID : PT_TABLE_OPTION_DONT_REUSE_OID, NULL);
-
-      tmp->next = node->info.create_entity.table_option_list;
-      node->info.create_entity.table_option_list = tmp;
+      
+      if (tmp) 
+        {
+          tmp->next = node->info.create_entity.table_option_list;
+          node->info.create_entity.table_option_list = tmp;
+        }
     }
 
   /* validate charset and collation options, if any */

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8324,12 +8324,12 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 
       reuse_oid = prm_get_bool_value (PRM_ID_TB_DEFAULT_REUSE_OID);
       tmp = pt_table_option (parser, reuse_oid ? PT_TABLE_OPTION_REUSE_OID : PT_TABLE_OPTION_DONT_REUSE_OID, NULL);
-      
-      if (tmp) 
-        {
-          tmp->next = node->info.create_entity.table_option_list;
-          node->info.create_entity.table_option_list = tmp;
-        }
+
+      if (tmp)
+	{
+	  tmp->next = node->info.create_entity.table_option_list;
+	  node->info.create_entity.table_option_list = tmp;
+	}
     }
 
   /* validate charset and collation options, if any */

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -8614,11 +8614,11 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	  switch (tbl_opt->info.table_option.option)
 	    {
 	    case PT_TABLE_OPTION_REUSE_OID:
-              found_reuse_oid_option = true;
+	      found_reuse_oid_option = true;
 	      reuse_oid = true;
 	      break;
 	    case PT_TABLE_OPTION_DONT_REUSE_OID:
-              found_reuse_oid_option = true;
+	      found_reuse_oid_option = true;
 	      reuse_oid = false;
 	      break;
 	    case PT_TABLE_OPTION_CHARSET:
@@ -8637,9 +8637,9 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 
       /* get default value of reuse_oid from system parameter, if don't use table option related reuse_oid */
       if (!found_reuse_oid_option)
-        {
-          reuse_oid = prm_get_bool_value (PRM_ID_TB_DEFAULT_REUSE_OID);
-        }
+	{
+	  reuse_oid = prm_get_bool_value (PRM_ID_TB_DEFAULT_REUSE_OID);
+	}
 
       /* validate charset and collation options, if any */
       cs_node = (tbl_opt_charset) ? tbl_opt_charset->info.table_option.val : NULL;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -8532,7 +8532,7 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
   PT_NODE *create_index = NULL;
   DB_QUERY_TYPE *query_columns = NULL;
   PT_NODE *tbl_opt = NULL;
-  bool reuse_oid = true;
+  bool found_reuse_oid_option = false, reuse_oid = true;
   bool do_rollback_on_error = false;
   bool do_abort_class_on_error = false;
   bool do_flush_class_mop = false;
@@ -8614,9 +8614,11 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	  switch (tbl_opt->info.table_option.option)
 	    {
 	    case PT_TABLE_OPTION_REUSE_OID:
+              found_reuse_oid_option = true;
 	      reuse_oid = true;
 	      break;
 	    case PT_TABLE_OPTION_DONT_REUSE_OID:
+              found_reuse_oid_option = true;
 	      reuse_oid = false;
 	      break;
 	    case PT_TABLE_OPTION_CHARSET:
@@ -8632,6 +8634,12 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	      break;
 	    }
 	}
+
+      /* get default value of reuse_oid from system parameter, if don't use table option related reuse_oid */
+      if (!found_reuse_oid_option)
+        {
+          reuse_oid = prm_get_bool_value (PRM_ID_TB_DEFAULT_REUSE_OID);
+        }
 
       /* validate charset and collation options, if any */
       cs_node = (tbl_opt_charset) ? tbl_opt_charset->info.table_option.val : NULL;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -8532,7 +8532,7 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
   PT_NODE *create_index = NULL;
   DB_QUERY_TYPE *query_columns = NULL;
   PT_NODE *tbl_opt = NULL;
-  bool found_reuse_oid_option = false, reuse_oid = true;
+  bool reuse_oid = true;
   bool do_rollback_on_error = false;
   bool do_abort_class_on_error = false;
   bool do_flush_class_mop = false;
@@ -8614,11 +8614,9 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	  switch (tbl_opt->info.table_option.option)
 	    {
 	    case PT_TABLE_OPTION_REUSE_OID:
-	      found_reuse_oid_option = true;
 	      reuse_oid = true;
 	      break;
 	    case PT_TABLE_OPTION_DONT_REUSE_OID:
-	      found_reuse_oid_option = true;
 	      reuse_oid = false;
 	      break;
 	    case PT_TABLE_OPTION_CHARSET:
@@ -8633,12 +8631,6 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	    default:
 	      break;
 	    }
-	}
-
-      /* get default value of reuse_oid from system parameter, if don't use table option related reuse_oid */
-      if (!found_reuse_oid_option)
-	{
-	  reuse_oid = prm_get_bool_value (PRM_ID_TB_DEFAULT_REUSE_OID);
 	}
 
       /* validate charset and collation options, if any */


### PR DESCRIPTION
I modified codes as the following for fixing the problem that is not replicate change default table option of reuse_oid to slave node when creating a table without table option.

- make new PT_NODE for table option and add it into table_option_list after getting default value from system parameter when creating a table without table option.(semantic_check.c)
- remove code that is checking routine and getting default value from system parameter since add table option at semantic checking routine. (execute_schema.c)
- modified by codes that is sending a system parameter for "reuse_oid" with "create table" statement to "applylogdb" of slave node, because can't modify original query when creating a table without table option. (system_parameter.c)