### PR TITLE
[CBRD-23708] change table option's default value to reuse_oid

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8318,7 +8318,7 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
     }
 
   /* get default value of reuse_oid from system parameter and create pt_node and add it into table_option_list, if don't use table option related reuse_oid */
-  if (!found_reuse_oid_option)
+  if (!found_reuse_oid_option && entity_type == PT_CLASS)
     {
       PT_NODE *tmp;
 


### PR DESCRIPTION
exclude checking and adding reuse_oid table option, if creating view