### PR TITLE
[CBRD-23742] Core dumped in heap_update_set_prev_version at src/storage/heap_file.c:24343

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24340,7 +24340,7 @@ heap_update_set_prev_version (THREAD_ENTRY * thread_p, const OID * oid, PGBUF_WA
   PGBUF_WATCHER overflow_pg_watcher;
 
   assert (oid != NULL && !OID_ISNULL (oid) && prev_version_lsa != NULL && !LSA_ISNULL (prev_version_lsa));
-  assert (prev_version_lsa->pageid > 0 && prev_version_lsa->offset >= 0);
+  assert (prev_version_lsa->pageid >= 0 && prev_version_lsa->offset >= 0);
 
   /* the home page should be already fixed */
   assert (home_pg_watcher != NULL && home_pg_watcher->pgptr != NULL);


### PR DESCRIPTION
* modify condition of assert() by considering copydb utility and reuse_oid table option.