### PR TITLE
[CBRD-23679] Adding a configuration parameter and control for strict type translation

### DIFF
--- a/src/object/schema_template.c
+++ b/src/object/schema_template.c
@@ -4547,7 +4547,7 @@ smt_change_class_shared_attribute_domain (SM_ATTRIBUTE * att, DB_DOMAIN * new_do
 
   /* cast the value to new domain : explicit cast */
   new_value = pr_make_ext_value ();
-  cast_status = db_value_coerce (current_value, new_value, new_domain);
+  cast_status = tp_value_cast (current_value, new_value, new_domain, false);
   if (cast_status == DOMAIN_COMPATIBLE)
     {
       pr_clear_value (&att->default_value.value);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23679

fix: a bug for invalid processing to call db_value_coerce.