### PR TITLE
[CBRD-23692] The heartbeat starts fail on the master node if master and slave node exist on the different network and can't communicate each other.

### DIFF
--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2808,7 +2808,7 @@ error_exit:
 
   if (logwr_force_shutdown () == false
       && (error == ER_NET_SERVER_CRASHED || error == ER_NET_CANT_CONNECT_SERVER || error == ER_BO_CONNECT_FAILED
-	  || error == ERR_CSS_TCP_CANNOT_CONNECT_TO_MASTER))
+	  || error == ERR_CSS_TCP_CANNOT_CONNECT_TO_MASTER || error == ERR_CSS_TCP_CONNECT_TIMEDOUT))
     {
       (void) sleep (sleep_nsecs);
       /* sleep 1, 2, 4, 8, etc; don't wait for more than 1/2 min */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23692

case 1 : copylogdb process repeatedly try to connect to server 
-  The master node can be routed to the slave node, but it cannot connect to the slave's server process

case 2 : copylogdb process is shut down
 - master node is not able to be routed to slave nodes 

the heartbeat process succeeds if copylogdb process is not shut down like in case 1. 
To make the policy consistent, Case 2 follows the actions of Case 1. 

So, add the error returned by case 2 while connecting to server process to the retry condition like case 1. 
