### PR TITLE
[CBRD-23678] Remove the HANG bug that occurred when the table name and column name are the same.

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -12932,7 +12932,7 @@ pt_print_insert (PARSER_CONTEXT * parser, PT_NODE * p)
     {
       b = pt_append_nulstring (parser, b, " (");
 
-      if (p->info.insert.hint & PT_HINT_USE_SBR)
+      if ((p->info.insert.hint & PT_HINT_USE_SBR) && (parser->custom_print & PT_PRINT_ORIGINAL_BEFORE_CONST_FOLDING))
 	{
 	  PARSER_VARCHAR *column_list = NULL;
 	  PT_NODE *attr = NULL;

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -12914,43 +12914,30 @@ pt_print_insert (PARSER_CONTEXT * parser, PT_NODE * p)
 
       if (p->info.insert.hint & PT_HINT_USE_SBR)
 	{
-	  char *class_name = NULL;
-	  char *column_list = NULL;
-	  char *pos = NULL;
+	  PARSER_VARCHAR *column_list = NULL;
+	  PT_NODE *attr = NULL;
 
-	  class_name = (char *) r1->bytes;
-	  column_list = (char *) r2->bytes;
+	  attr = p->info.insert.attr_list;
 
-#if !defined(NDEBUG)
-	  assert (class_name != NULL && strlen (class_name) != 0 && strlen (class_name) != r1->length);
-	  assert (column_list != NULL && strlen (column_list) != 0 && strlen (column_list) != r2->length);
-#endif
-
-	  while (pos = strstr (column_list, class_name))
+	  while (attr)
 	    {
-	      strcpy (pos, pos + r1->length + 1);
-	      r2->length -= (r1->length + 1);
+	      column_list = pt_append_nulstring (parser, column_list, attr->info.name.original);
 
-	      pos = strstr (pos, ",");
+	      attr = attr->next;
 
-	      if (pos != NULL)
+	      if (attr)
 		{
-		  column_list = pos;
-		}
-	      else
-		{
-		  break;
+		  column_list = pt_append_nulstring (parser, column_list, ", ");
 		}
 	    }
 
-#if !defined(NDEBUG)
-	  column_list = (char *) r2->bytes;
-
-	  assert (strlen (column_list) != r2->length && r2->length <= 0);
-#endif
+	  b = pt_append_varchar (parser, b, column_list);
+	}
+      else
+	{
+	  b = pt_append_varchar (parser, b, r2);
 	}
 
-      b = pt_append_varchar (parser, b, r2);
       b = pt_append_nulstring (parser, b, ") ");
     }
   else

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -12921,7 +12921,7 @@ pt_print_insert (PARSER_CONTEXT * parser, PT_NODE * p)
 
 	  while (attr)
 	    {
-	      column_list = pt_append_nulstring (parser, column_list, attr->info.name.original);
+	      column_list = pt_append_name (parser, column_list, attr->info.name.original);
 
 	      attr = attr->next;
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -9491,10 +9491,30 @@ pt_print_spec (PARSER_CONTEXT * parser, PT_NODE * p)
       if (p->info.spec.range_var && p->info.spec.range_var->info.name.original
 	  && p->info.spec.range_var->info.name.original[0])
 	{
-	  r1 = pt_print_bytes (parser, p->info.spec.range_var);
+	  bool insert_with_use_sbr = false;
 
-	  if (r1->length != q->length || memcmp (&r1->bytes, &q->bytes, q->length))
+	  if (parser->custom_print & PT_PRINT_ORIGINAL_BEFORE_CONST_FOLDING)
 	    {
+	      PT_NODE *cur_stmt = NULL;
+
+	      for (int i = 0; i < parser->statement_number; i++)
+		{
+		  if (parser->statements[i] != NULL)
+		    {
+		      cur_stmt = parser->statements[i];
+		      break;
+		    }
+		}
+
+	      if (cur_stmt->info.insert.hint & PT_HINT_USE_SBR)
+		{
+		  insert_with_use_sbr = true;
+		}
+	    }
+
+	  if (!insert_with_use_sbr)
+	    {
+	      r1 = pt_print_bytes (parser, p->info.spec.range_var);
 	      q = pt_append_nulstring (parser, q, " ");
 	      q = pt_append_varchar (parser, q, r1);
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23678

Fixed a bug that occurred in the following medium test case. an infinite loop occurs If the table name and column name are the same.
- medium/_02_xtests/cases/coerce1.sql