### PR TITLE
[CBRD-23752] Case-insensitive handling of %class keyword in loaddb object

### DIFF
--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -648,7 +648,7 @@ namespace cubload
 
     for (std::string line; std::getline (object_file, line); ++lineno)
       {
-	bool is_id_line = starts_with (line, "%id");
+	bool is_id_line = starts_with (line, "%id") || starts_with (line, "%ID");
 	bool is_class_line = starts_with (line, "%class") || starts_with (line, "%CLASS");
 
 	if (is_id_line || is_class_line)

--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -649,7 +649,7 @@ namespace cubload
     for (std::string line; std::getline (object_file, line); ++lineno)
       {
 	bool is_id_line = starts_with (line, "%id");
-	bool is_class_line = starts_with (line, "%class");
+	bool is_class_line = starts_with (line, "%class") || starts_with (line, "%CLASS");
 
 	if (is_id_line || is_class_line)
 	  {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23752

- 10.2+ supports loaddb CS mode
- 10.2, in loaddb cs mode, the class line of an object file recognizes only the %class keyword.
- In the loaddb object file, lines starting with %class and %CLASS should be recognized as class definition lines.
- %ID and %id will be handled same way.