### PR TITLE
[CBRD-23753] Fix destroying Internal JDBC resources is not working and unexpected behavior

### DIFF
--- a/src/jdbc/com/cubrid/jsp/ExecuteThread.java
+++ b/src/jdbc/com/cubrid/jsp/ExecuteThread.java
@@ -70,9 +70,7 @@ import cubrid.jdbc.driver.CUBRIDConnectionDefault;
 import cubrid.jdbc.driver.CUBRIDResultSet;
 import cubrid.jdbc.jci.UConnection;
 import cubrid.jdbc.jci.UJCIUtil;
-import cubrid.jdbc.jci.UJCIManager;
 import cubrid.sql.CUBRIDOID;
-import java.sql.DriverManager;
 
 public class ExecuteThread extends Thread {
 	private String charSet = System.getProperty("file.encoding");
@@ -107,7 +105,6 @@ public class ExecuteThread extends Thread {
 
 	private Socket client;
 	private CUBRIDConnectionDefault connection = null;
-	private String threadName = null;
 
 	private DataInputStream input;
 	private DataOutputStream output;
@@ -243,11 +240,6 @@ public class ExecuteThread extends Thread {
 		StoredProcedure procedure = makeStoredProcedure();
 		Method m = procedure.getTarget().getMethod();
 		Object[] resolved = procedure.checkArgs(procedure.getArgs());
-
-		if (threadName == null || threadName.equalsIgnoreCase (m.getName())) {
-			threadName = m.getName();
-			Thread.currentThread().setName(threadName);
-		}
 
 		setStatus (ExecuteThreadStatus.INVOKE);
 		Object result = m.invoke(null, resolved);

--- a/src/jdbc/com/cubrid/jsp/ExecuteThread.java
+++ b/src/jdbc/com/cubrid/jsp/ExecuteThread.java
@@ -70,7 +70,9 @@ import cubrid.jdbc.driver.CUBRIDConnectionDefault;
 import cubrid.jdbc.driver.CUBRIDResultSet;
 import cubrid.jdbc.jci.UConnection;
 import cubrid.jdbc.jci.UJCIUtil;
+import cubrid.jdbc.jci.UJCIManager;
 import cubrid.sql.CUBRIDOID;
+import java.sql.DriverManager;
 
 public class ExecuteThread extends Thread {
 	private String charSet = System.getProperty("file.encoding");
@@ -80,6 +82,7 @@ public class ExecuteThread extends Thread {
 	private static final int REQ_CODE_ERROR = 0x04;
 	private static final int REQ_CODE_INTERNAL_JDBC = 0x08;
 	private static final int REQ_CODE_DESTROY = 0x10;
+	private static final int REQ_CODE_END = 0x20;
 
 	/* DB Types */
 	public static final int DB_NULL = 0;
@@ -104,6 +107,7 @@ public class ExecuteThread extends Thread {
 
 	private Socket client;
 	private CUBRIDConnectionDefault connection = null;
+	private String threadName = null;
 
 	private DataInputStream input;
 	private DataOutputStream output;
@@ -181,23 +185,22 @@ public class ExecuteThread extends Thread {
 		int requestCode = -1;
 		while (!Thread.interrupted()) {
 			try {
-				do {
-					requestCode = listenCommand();
-					switch (requestCode) {
-					case REQ_CODE_INVOKE_SP: {
-						processStoredProcedure();
-						break;
-					}
-					case REQ_CODE_DESTROY: {
-						destroyJDBCResources();
-						break;
-					}
-					default: {
-						/* invalid request */
-						throw new ExecuteException ("invalid request code: " + requestCode);
-					}
-					}
-				} while (requestCode != REQ_CODE_INVOKE_SP && requestCode != REQ_CODE_DESTROY);
+				requestCode = listenCommand();
+				switch (requestCode) {
+				case REQ_CODE_INVOKE_SP: {
+					processStoredProcedure();
+					break;
+				}
+				case REQ_CODE_DESTROY: {
+					destroyJDBCResources();
+					Thread.currentThread().interrupt();
+					break;
+				}
+				default: {
+					/* invalid request */
+					throw new ExecuteException ("invalid request code: " + requestCode);
+				}
+				}
 			} catch (Throwable e) {
 				if (e instanceof IOException) {
 					setStatus(ExecuteThreadStatus.END);
@@ -209,9 +212,7 @@ public class ExecuteThread extends Thread {
 					break;
 				} else {
 					try {
-						if (compareStatus(ExecuteThreadStatus.CALL)) {
-							closeJdbcConnection ();
-						}
+						closeJdbcConnection ();
 					} catch (Exception e2) {
 					}
 					setStatus (ExecuteThreadStatus.ERROR);
@@ -242,6 +243,11 @@ public class ExecuteThread extends Thread {
 		StoredProcedure procedure = makeStoredProcedure();
 		Method m = procedure.getTarget().getMethod();
 		Object[] resolved = procedure.checkArgs(procedure.getArgs());
+
+		if (threadName == null || threadName.equalsIgnoreCase (m.getName())) {
+			threadName = m.getName();
+			Thread.currentThread().setName(threadName);
+		}
 
 		setStatus (ExecuteThreadStatus.INVOKE);
 		Object result = m.invoke(null, resolved);
@@ -278,9 +284,18 @@ public class ExecuteThread extends Thread {
 
 	private void destroyJDBCResources () throws SQLException, IOException {
 		setStatus(ExecuteThreadStatus.DESTROY);
-		if (connection != null) {
+
+		if (connection != null)
+		{
+			output.writeInt(REQ_CODE_DESTROY);
+			output.flush();
 			connection.destroy();
-			connection.close();
+			connection = null;
+		}
+		else
+		{
+			output.writeInt(REQ_CODE_END);
+			output.flush();
 		}
 	}
 

--- a/src/jdbc/cubrid/jdbc/jci/UServerSideConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UServerSideConnection.java
@@ -164,6 +164,7 @@ public class UServerSideConnection extends UConnection {
 	protected void disconnect() {
 		try {
 			setBeginTime();
+			checkReconnect();
 			if (errorHandler.getErrorCode() != UErrorCode.ER_NO_ERROR)
 				return;
 

--- a/src/jdbc/cubrid/jdbc/jci/UStatementHandlerCache.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatementHandlerCache.java
@@ -37,7 +37,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class UStatementHandlerCache {
-	private ConcurrentHashMap<String, List<UStatementHandlerCacheEntry>> stmtHandlerCache;
+	private ConcurrentHashMap<String, List<UStatementHandlerCacheEntry>> stmtHandlerCache = null;
 
 	public UStatementHandlerCache() {
 		stmtHandlerCache = new ConcurrentHashMap<String, List<UStatementHandlerCacheEntry>> ();
@@ -48,23 +48,21 @@ public class UStatementHandlerCache {
 			List<UStatementHandlerCacheEntry> vec = new ArrayList<UStatementHandlerCacheEntry>();
 			stmtHandlerCache.putIfAbsent(sql, vec);
 		}
-		
+
 		return stmtHandlerCache.get(sql);
 	}
-	
+
 	public void destroy () {
 		for (Entry<String, List<UStatementHandlerCacheEntry>> entry : stmtHandlerCache.entrySet()) {
 			List<UStatementHandlerCacheEntry> cacheEntries = entry.getValue();
 			for (UStatementHandlerCacheEntry e: cacheEntries) {
 				UStatement s = e.getStatement();
-				s.closeCursor();
 				s.close();
 			}
 		}
 		stmtHandlerCache.clear();
-		stmtHandlerCache = null;
 	}
-	
+
 	public void clearStatus () {
 		for (Entry<String, List<UStatementHandlerCacheEntry>> entry : stmtHandlerCache.entrySet()) {
 			List<UStatementHandlerCacheEntry> cacheEntries = entry.getValue();

--- a/src/jsp/jsp_cl.c
+++ b/src/jsp/jsp_cl.c
@@ -2191,7 +2191,7 @@ jsp_send_destroy_request (const SOCKET sockfd)
   if (nbytes != (int) sizeof (int))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_NETWORK_ERROR, 1, nbytes);
-      return ER_SP_NETWORK_ERROR;
+      return er_errid ();
     }
   code = ntohl (code);
 

--- a/src/jsp/jsp_cl.c
+++ b/src/jsp/jsp_cl.c
@@ -2174,22 +2174,42 @@ jsp_send_destroy_request_all ()
 extern int
 jsp_send_destroy_request (const SOCKET sockfd)
 {
-  int nbytes;
-  int req_code = 0x10;
-  int res = NO_ERROR;
+  OR_ALIGNED_BUF (OR_INT_SIZE) a_request;
+  char *request = OR_ALIGNED_BUF_START (a_request);
 
-  nbytes = jsp_writen (sockfd, (void *) &req_code, (int) sizeof (int));
+  or_pack_int (request, (int) SP_CODE_DESTROY);
+  int nbytes = jsp_writen (sockfd, request, (int) sizeof (int));
   if (nbytes != (int) sizeof (int))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_NETWORK_ERROR, 1, "destroy");
       return er_errid ();
     }
 
-  tran_begin_libcas_function ();
-  res = libcas_main (sockfd);	/* jdbc call to destroy resources */
-  tran_end_libcas_function ();
+  /* read request code */
+  int code;
+  nbytes = jsp_readn (sockfd, (char *) &code, (int) sizeof (int));
+  if (nbytes != (int) sizeof (int))
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_NETWORK_ERROR, 1, nbytes);
+      return ER_SP_NETWORK_ERROR;
+    }
+  code = ntohl (code);
 
-  return res;
+  if (code == SP_CODE_DESTROY)
+    {
+      bool mode = ssl_client;
+      ssl_client = false;
+      tran_begin_libcas_function ();
+      libcas_main (sockfd);	/* jdbc call */
+      tran_end_libcas_function ();
+      ssl_client = mode;
+    }
+  else
+    {
+      /* end */ 
+    }
+
+  return NO_ERROR;
 }
 
 /*
@@ -3096,6 +3116,7 @@ end:
   if (error != NO_ERROR || is_prepare_call[call_cnt])
     {
       jsp_send_destroy_request (sock_fd);
+      jsp_close_internal_connection (sock_fd);
       sock_fds[call_cnt] = INVALID_SOCKET;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23753

- Disabled ssl_client in the destroying state of Java SP processing
- Added defensive code
    - Avoid caused unexpected NullPointerException in UStatementHandlerCache
    - Added checkReconnect() in UServerSideConnection.disconnect(). In some cases, output buffer (outBuffer) is not allocated and NullPointerException is caused.
    - Added REQ_CODE_END not to call libcas_main() when InternalJDBCConnection was not used in the stored procedure.