### PR TITLE
[CBRD-23687] Add error message for both cert & pk were not found (SSL)

### DIFF
--- a/src/broker/cas_ssl.c
+++ b/src/broker/cas_ssl.c
@@ -118,7 +118,7 @@ cas_init_ssl (int sd)
 
   if (cert_not_found && pk_not_found)
     {
-      cas_log_write_and_end (0, false, "SSL: Both the certificate & Private key could not be found: %s/%s", cert, key);
+      cas_log_write_and_end (0, false, "SSL: Both the certificate & Private key could not be found: %s, %s", cert, key);
       return ER_CERT_COPPUPTED;
     }
 
@@ -130,7 +130,7 @@ cas_init_ssl (int sd)
 
   if (pk_not_found)
     {
-      cas_log_write_and_end (0, true, "SSL: Private key not found: %s", key);
+      cas_log_write_and_end (0, false, "SSL: Private key not found: %s", key);
       return ER_CERT_COPPUPTED;
     }
 

--- a/src/broker/cas_ssl.c
+++ b/src/broker/cas_ssl.c
@@ -92,6 +92,7 @@ cas_init_ssl (int sd)
   int err_code;
   unsigned long err;
   struct stat sbuf;
+  bool cert_not_found, pk_not_found;
 
   if (ssl)
     {
@@ -112,13 +113,22 @@ cas_init_ssl (int sd)
   snprintf (cert, CERT_FILENAME_LEN, "%s/conf/%s", getenv ("CUBRID"), CERTF);
   snprintf (key, CERT_FILENAME_LEN, "%s/conf/%s", getenv ("CUBRID"), KEYF);
 
-  if (stat (cert, &sbuf) < 0)
+  cert_not_found = (stat (cert, &sbuf) < 0) ? true : false;
+  pk_not_found = (stat (key, &sbuf) < 0) ? true : false;
+
+  if (cert_not_found && pk_not_found)
+    {
+      cas_log_write_and_end (0, false, "SSL: Both the certificate & Private key could not be found: %s/%s", cert, key);
+      return ER_CERT_COPPUPTED;
+    }
+
+  if (cert_not_found)
     {
       cas_log_write_and_end (0, false, "SSL: Certificate not found: %s", cert);
       return ER_CERT_COPPUPTED;
     }
 
-  if (stat (key, &sbuf) < 0)
+  if (pk_not_found)
     {
       cas_log_write_and_end (0, true, "SSL: Private key not found: %s", key);
       return ER_CERT_COPPUPTED;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23687
* Add a caslog for both certificate & private key were not found.

We already have caslog with no certificate or private key.
The user will see one of the three error messages below regarding the SSL file.

1. SSL: Certificate not found: /home/kshan/db/CUBRID/conf/cas_ssl_cert.crt
2. SSL: key not found: /home/kshan/db/CUBRID/conf/cas_ssl_cert.key
3. **SSL: Both the certificate & Private key could not be found: /home/CUBRID/conf/cas_ssl_cert.crt, /home/CUBRID/conf/cas_ssl_cert.key**