### PR TITLE
[CBRD-23752] Case-insensitive handling of %class keyword in loaddb ob…

### DIFF
--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -648,8 +648,8 @@ namespace cubload
 
     for (std::string line; std::getline (object_file, line); ++lineno)
       {
-	bool is_id_line = starts_with (line, "%id");
-	bool is_class_line = starts_with (line, "%class");
+	bool is_id_line = starts_with (line, "%id") || starts_with (line, "%ID");
+	bool is_class_line = starts_with (line, "%class") || starts_with (line, "%CLASS");
 
 	if (is_id_line || is_class_line)
 	  {


### PR DESCRIPTION
…ject (#2469)

* [CBRD-23752] Case-insensitive handling of %class keyword in loaddb object file
* [CBRD-23752] Handle %id case-insensitive as well

* The commit is reverted accidently.