### PR TITLE
[CBRD-23759] [Regression][ha_repl_debug] Core dumped in btree_get_prefix_separator

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -11990,7 +11990,14 @@ mr_cmpval_char (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
 
   if (!ignore_trailing_space)
     {
-      ti = (value1->domain.char_info.type == DB_TYPE_CHAR && value2->domain.char_info.type == DB_TYPE_CHAR);
+      if (do_coercion == 2)
+	{
+	  ti = (value1->domain.char_info.type == DB_TYPE_CHAR || value2->domain.char_info.type == DB_TYPE_CHAR);
+	}
+      else
+	{
+	  ti = (value1->domain.char_info.type == DB_TYPE_CHAR && value2->domain.char_info.type == DB_TYPE_CHAR);
+	}
     }
   strc = QSTR_CHAR_COMPARE (collation, string1, (int) db_get_string_size (value1), string2,
 			    (int) db_get_string_size (value2), ti);
@@ -12884,10 +12891,19 @@ mr_cmpval_nchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
       return DB_UNK;
     }
 
+
   if (!ignore_trailing_space)
     {
-      ti = (value1->domain.char_info.type == DB_TYPE_NCHAR && value2->domain.char_info.type == DB_TYPE_NCHAR);
+      if (do_coercion == 2)
+	{
+	  ti = (value1->domain.char_info.type == DB_TYPE_NCHAR || value2->domain.char_info.type == DB_TYPE_NCHAR);
+	}
+      else
+	{
+	  ti = (value1->domain.char_info.type == DB_TYPE_NCHAR && value2->domain.char_info.type == DB_TYPE_NCHAR);
+	}
     }
+
   strc = QSTR_NCHAR_COMPARE (collation, string1, (int) db_get_string_size (value1), string2,
 			     (int) db_get_string_size (value2), db_get_string_codeset (value2), ti);
   c = MR_CMP_RETURN_CODE (strc);

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -11947,8 +11947,8 @@ mr_cmpval_char (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
   DB_VALUE_COMPARE_RESULT c;
   int strc;
 
-  bool ti = true;
-  bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
+  static bool ti = true;
+  static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   const unsigned char *string1 = REINTERPRET_CAST (const unsigned char *, db_get_string (value1));
   const unsigned char *string2 = REINTERPRET_CAST (const unsigned char *, db_get_string (value2));
@@ -11990,12 +11990,13 @@ mr_cmpval_char (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
 
   if (!ignore_trailing_space)
     {
-      if (do_coercion == 2)
+      switch (do_coercion)
 	{
+	case 2:		/* from btree_get_prefix_separator */
+	  /* we have to process the ti-comparison for this case (CHAR and VARCHAR mixed) */
 	  ti = (value1->domain.char_info.type == DB_TYPE_CHAR || value2->domain.char_info.type == DB_TYPE_CHAR);
-	}
-      else
-	{
+	  break;
+	default:
 	  ti = (value1->domain.char_info.type == DB_TYPE_CHAR && value2->domain.char_info.type == DB_TYPE_CHAR);
 	}
     }

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -285,7 +285,6 @@
    && spage_get_slot (page, HEADER)->record_length == sizeof (BTREE_NODE_HEADER) \
    && (btree_get_node_header (thread_p, page))->node_level == 1)
 
-extern PR_TYPE *tp_Type_char;
 typedef struct recset_header RECSET_HEADER;
 struct recset_header
 {				/* Recovery set of recdes structure */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -285,6 +285,7 @@
    && spage_get_slot (page, HEADER)->record_length == sizeof (BTREE_NODE_HEADER) \
    && (btree_get_node_header (thread_p, page))->node_level == 1)
 
+extern PR_TYPE *tp_Type_char;
 typedef struct recset_header RECSET_HEADER;
 struct recset_header
 {				/* Recovery set of recdes structure */
@@ -11748,8 +11749,12 @@ btree_get_prefix_separator (const DB_VALUE * key1, const DB_VALUE * key2, DB_VAL
 {
   int c;
   int err = NO_ERROR;
-  bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
-  int coerce = (ignore_trailing_space) ? 1 : 2;
+  static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
+
+  /* for coerce = 2, we need to process key comparing as char-type
+   * in case that one of two arguments has varchar-type
+   * if the other argument has char-type */
+  static int coerce = (ignore_trailing_space) ? 1 : 2;
 
   assert (DB_IS_NULL (key1) || (DB_VALUE_DOMAIN_TYPE (key1) == DB_VALUE_DOMAIN_TYPE (key2)));
   assert (!DB_IS_NULL (key2));

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -18721,7 +18721,16 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
 
       if (are_types_comparable)
 	{
-	  c = key_domain->type->cmpval (key1, key2, do_coercion, total_order, NULL, key_domain->collation_id);
+	  bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
+
+	  if (!ignore_trailing_space && TP_IS_STRING_TYPE (key1_type) && TP_IS_STRING_TYPE (key2_type))
+	    {
+	      c = key_domain->type->cmpval (key1, key2, 2, total_order, NULL, key_domain->collation_id);
+	    }
+	  else
+	    {
+	      c = key_domain->type->cmpval (key1, key2, do_coercion, total_order, NULL, key_domain->collation_id);
+	    }
 	}
       else
 	{

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -11748,13 +11748,15 @@ btree_get_prefix_separator (const DB_VALUE * key1, const DB_VALUE * key2, DB_VAL
 {
   int c;
   int err = NO_ERROR;
+  bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
+  int coerce = (ignore_trailing_space) ? 1 : 2;
 
   assert (DB_IS_NULL (key1) || (DB_VALUE_DOMAIN_TYPE (key1) == DB_VALUE_DOMAIN_TYPE (key2)));
   assert (!DB_IS_NULL (key2));
   assert_release (key_domain != NULL);
 
 #if !defined(NDEBUG)
-  c = btree_compare_key ((DB_VALUE *) key1, (DB_VALUE *) key2, key_domain, 1, 1, NULL);
+  c = btree_compare_key ((DB_VALUE *) key1, (DB_VALUE *) key2, key_domain, coerce, 1, NULL);
   assert (c == DB_LT);
 #endif
 
@@ -11782,7 +11784,7 @@ btree_get_prefix_separator (const DB_VALUE * key1, const DB_VALUE * key2, DB_VAL
       return ER_FAILED;
     }
 
-  c = btree_compare_key ((DB_VALUE *) key1, prefix_key, key_domain, 1, 1, NULL);
+  c = btree_compare_key ((DB_VALUE *) key1, prefix_key, key_domain, coerce, 1, NULL);
 
   if (c != DB_LT)
     {
@@ -11790,7 +11792,7 @@ btree_get_prefix_separator (const DB_VALUE * key1, const DB_VALUE * key2, DB_VAL
       return ER_FAILED;
     }
 
-  c = btree_compare_key (prefix_key, (DB_VALUE *) key2, key_domain, 1, 1, NULL);
+  c = btree_compare_key (prefix_key, (DB_VALUE *) key2, key_domain, coerce, 1, NULL);
 
   if (!(c == DB_LT || c == DB_EQ))
     {
@@ -18721,16 +18723,7 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
 
       if (are_types_comparable)
 	{
-	  bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
-
-	  if (!ignore_trailing_space && TP_IS_STRING_TYPE (key1_type) && TP_IS_STRING_TYPE (key2_type))
-	    {
-	      c = key_domain->type->cmpval (key1, key2, 2, total_order, NULL, key_domain->collation_id);
-	    }
-	  else
-	    {
-	      c = key_domain->type->cmpval (key1, key2, do_coercion, total_order, NULL, key_domain->collation_id);
-	    }
+	  c = key_domain->type->cmpval (key1, key2, do_coercion, total_order, NULL, key_domain->collation_id);
 	}
       else
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23759

This a bug from #2476 (http://jira.cubrid.org/browse/CBRD-23731)
This is a bug from btree index prefix processing under char-type index key.

the prefix is handled as varchar in comparing const key value, but the comparing function for char-type mr_cmpval_char handles two comparing argument as ti-style only if both of two arguments type are DB_TYPE_CHAR.
So, we have to change the mr_cmpval_char to process specially in case that one of argument type is DB_TYPE_CHAR under the btree-comparing. I have an idea that cmpval's argument do_coercion has value 2 in btree-compare and mr_cmpval_char do process the case in special.