### PR TITLE
[CBRD-23601] Git version and initial date not to include commits on the date

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,11 @@ if(VERSION_MATCHES_LENGTH GREATER 3)
 else(VERSION_MATCHES_LENGTH GREATER 3)
   find_package(Git)
   if(EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT_FOUND)
-    set(CUBRID_MAJOR_START_DATE "2019-12-13")
+    set(CUBRID_MAJOR_START_DATE "2019-12-12")
+    execute_process(COMMAND ${GIT_EXECUTABLE} --version
+    COMMAND awk "{ printf \"%s\", $3 }"
+    OUTPUT_VARIABLE GIT_VERSION
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
     if(GIT_VERSION VERSION_GREATER 1.7.6)
       execute_process(COMMAND ${GIT_EXECUTABLE} rev-list --count --after ${CUBRID_MAJOR_START_DATE} HEAD
         COMMAND awk "{ printf \"%04d\", $1 }"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23601 

Commit count error. 
Sometimes the output of git ..... --after "[date]" .... is wrong . 
The git option "–after [date]" should exclude commits on the date.
This has not been working properly.  

It should be changed to a date with no commits for stability.