### PR TITLE
[CBRD-23731] regression-revised: In data comparing, no ignoring to trailing spaces at the end of the data.

### DIFF
--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -4227,6 +4227,7 @@ lang_back_strmatch_utf8_uca_w_level (const COLL_DATA * coll_data, bool is_match,
 
 	  if (!ignore_trailing_space)
 	    {
+	      result = 1;
 	      goto exit;
 	    }
 	  /* consume any remaining zero-weight values (skip them) from str1 */
@@ -5850,6 +5851,7 @@ lang_init_coll_Utf8_tr_cs (LANG_COLLATION * lang_coll)
       unsigned int w_repl = lang_Weight_TR[cp_repl];
 
       lang_Weight_TR[cp] = w_repl;
+      lang_Weight_TR_ti[cp] = w_repl;
 
       assert (cp_repl < cp);
       for (j = cp_repl; j < cp; j++)
@@ -5870,6 +5872,7 @@ lang_init_coll_Utf8_tr_cs (LANG_COLLATION * lang_coll)
       unsigned int w_repl = lang_Weight_TR[cp_repl];
 
       lang_Weight_TR[cp] = w_repl;
+      lang_Weight_TR_ti[cp] = w_repl;
 
       assert (cp_repl < cp);
       for (j = cp_repl; j < cp; j++)

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -37,6 +37,7 @@
 #include "object_primitive.h"
 #include "porting.h"
 #include "transaction_cl.h"
+#include "string_opfunc.h"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
@@ -554,7 +555,7 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
       assert (value_type == DB_TYPE_NULL
 	      /* UNKNOWN, maybe host variable */
 	      || result_info->attr_types[i] == DB_TYPE_NULL || result_info->attr_types[i] == DB_TYPE_VARIABLE
-	      || value_type == result_info->attr_types[i]);
+	      || (QSTR_IS_ANY_CHAR (value_type) && QSTR_IS_ANY_CHAR (result_info->attr_types[i])));
 
       switch (value_type)
 	{

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -37,7 +37,6 @@
 #include "object_primitive.h"
 #include "porting.h"
 #include "transaction_cl.h"
-#include "string_opfunc.h"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
@@ -555,8 +554,7 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
       assert (value_type == DB_TYPE_NULL
 	      /* UNKNOWN, maybe host variable */
 	      || result_info->attr_types[i] == DB_TYPE_NULL || result_info->attr_types[i] == DB_TYPE_VARIABLE
-	      || value_type == result_info->attr_types[i]
-	      || (QSTR_IS_ANY_CHAR (value_type) && QSTR_IS_ANY_CHAR (result_info->attr_types[i])));
+	      || value_type == result_info->attr_types[i]);
 
       switch (value_type)
 	{

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -555,6 +555,7 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
       assert (value_type == DB_TYPE_NULL
 	      /* UNKNOWN, maybe host variable */
 	      || result_info->attr_types[i] == DB_TYPE_NULL || result_info->attr_types[i] == DB_TYPE_VARIABLE
+	      || value_type == result_info->attr_types[i]
 	      || (QSTR_IS_ANY_CHAR (value_type) && QSTR_IS_ANY_CHAR (result_info->attr_types[i])));
 
       switch (value_type)

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -9302,11 +9302,11 @@ qstr_concatenate (const unsigned char *s1, int s1_length, int s1_precision, DB_T
 
       if (QSTR_IS_NATIONAL_CHAR (s1_type))
 	{
-	  *result_type = DB_TYPE_NCHAR;
+	  *result_type = DB_TYPE_VARNCHAR;
 	}
       else
 	{
-	  *result_type = DB_TYPE_CHAR;
+	  *result_type = DB_TYPE_VARCHAR;
 	}
 
       if (*result_size > (int) prm_get_bigint_value (PRM_ID_STRING_MAX_SIZE_BYTES))

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -423,7 +423,7 @@ db_string_compare (const DB_VALUE * string1, const DB_VALUE * string2, DB_VALUE 
 
 	  if (!ignore_trailing_space)
 	    {
-	      ti = (string2_category == QSTR_CHAR || string2_category == QSTR_NATIONAL_CHAR);
+	      ti = (QSTR_IS_FIXED_LENGTH (str1_type) && QSTR_IS_FIXED_LENGTH (str2_type));
 	    }
 	  cmp_result = QSTR_COMPARE (coll_id, DB_GET_UCHAR (string1), (int) db_get_string_size (string1),
 				     DB_GET_UCHAR (string2), (int) db_get_string_size (string2), ti);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23731

This is a revised version for #2483 

The below bug is patched:
- Turkey character set, comparison with ignoring trailing space.
- French (utf8_fr_exp_ab) character set, comparison with ignoring trailing space.
- two fixed length char-type db-string is compared with ignoring trailing space only if both type of them is char-type.
- issue fixed the string concatenation result in sub-query