### PR TITLE
[CBRD-23754] Outer join is incorrectly changed to inner join in queries that contain OR operation.

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -5515,7 +5515,7 @@ qo_rewrite_outerjoin (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
 	      for (expr = node->info.query.q.select.where; expr; expr = expr->next)
 		{
 		  if (expr->node_type == PT_EXPR && expr->info.expr.location == 0 && expr->info.expr.op != PT_IS_NULL
-		      && expr->or_next == NULL)
+		      && expr->or_next == NULL && expr->info.expr.op != PT_AND && expr->info.expr.op != PT_OR)
 		    {
 		      save_next = expr->next;
 		      expr->next = NULL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23754

```
AND table3.col_varchar_10_key <= 'z'
OR table1.col_varchar_10_key >= 'yeah'
```
As above, if predicates referenced by another tables are connected by OR, the outer join cannot be converted to inner join.
If the predicate contains an OR operation, modify it so that it is not converted to inner join.