### PR TITLE
[CBRD-23789] increase the disk compatibility level.

### DIFF
--- a/src/base/release_string.c
+++ b/src/base/release_string.c
@@ -99,7 +99,7 @@ static REL_COMPATIBILITY rel_get_compatible_internal (const char *base_rel_str, 
 /*
  * Disk (database image) Version Compatibility
  */
-static float disk_compatibility_level = 10.15f;
+static float disk_compatibility_level = 11.0f;
 
 /*
  * rel_copy_version_string - version string of the product


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23789

The disk image was changed from CBRD-23608, CBRD-23703, and CBRD-23731. so it is necessary to change the disk compatibility level. I left a comment on the related issue about which tests were performed. please refer to it.