### PR TITLE
[CBRD-23788] Change declaration position of a character array

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -3926,6 +3926,7 @@ gen_tz (UTIL_FUNCTION_ARG * arg)
 {
   UTIL_ARG_MAP *arg_map = NULL;
   char *input_path = NULL;
+  char inputpath_local[PATH_MAX] = { 0 };
   char *tz_gen_mode = NULL;
   TZ_GEN_TYPE tz_gen_type = TZ_GEN_TYPE_NEW;
   int exit_status = EXIT_SUCCESS;
@@ -3993,8 +3994,6 @@ gen_tz (UTIL_FUNCTION_ARG * arg)
 
   if (input_path == NULL || strlen (input_path) == 0)
     {
-      char inputpath_local[PATH_MAX] = { 0 };
-
       envvar_tzdata_dir_file (inputpath_local, sizeof (inputpath_local), "");
       input_path = inputpath_local;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23788

- in the file src/util_sa.c:3966, character array **inputpath_local** was defined inside if-block, and its address was referenced outside the block, as following style:
```
char *ptr;
if (cond)
 {
   char inputpath_local[PATH_MAX] = { 0 };
   ptr = inputpath_local;
 }
 ..
 if (timezone_compile_data (input_path, tz_gen_type, db_name, NULL, checksum) != NO_ERROR)
   {
      exit_status = EXIT_FAILURE;
      goto exit;
   } 

```