### PR TITLE
[CBRD-23787] Memory leak in csession_create_prepared_statement()

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -4757,7 +4757,7 @@ cleanup:
       if (result != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
-	  return result;
+	  goto error;
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23787

In csession_create_prepared_statement(), 
if `SHA1Compute() returns an error, `local_alias_print` remains not freed.
