### PR TITLE
[CBRD-23629] Fix slip in cubridservice on windows

### DIFF
--- a/src/win_tools/cubridservice/cubridservice.cpp
+++ b/src/win_tools/cubridservice/cubridservice.cpp
@@ -326,6 +326,7 @@ vHandler (DWORD opcode)
 	args[4] = "--for-windows-service";
 	args[5] = NULL;
       }
+      break;
     case SERVICE_CONTROL_JAVASP_START:
       {
 	args[1] = CUBRID_UTIL_JAVASP;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23629
`break;` is omitted for stopping server routine on windows