### PR TITLE
[CBRD-23797] [Regression] JDBC, in TYPE_SCROLL_SENSITIVE and in maxRows setting, exception fail

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -1433,7 +1433,7 @@ public class CUBRIDResultSet implements ResultSet {
 
 		clearCurrentRow();
 
-		u_stmt.reFetch();
+		u_stmt.reFresh();
 		error = u_stmt.getRecentError();
 
 		switch (error.getErrorCode()) {

--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -2280,7 +2280,12 @@ public class UStatement {
 
 		if (tuples == null) {
 			if (totalTupleNumber > 0) {
-				tuples = new UResultTuple[totalTupleNumber];
+				if (totalTupleNumber > fetchedTupleNumber) {
+					tuples = new UResultTuple[totalTupleNumber];
+				}
+				else {
+					tuples = new UResultTuple[fetchedTupleNumber]; /* for maxRow */
+				}
 			}
 		}
 
@@ -2491,4 +2496,10 @@ public class UStatement {
 		return relatedConnection.isConnectedToOracle() && isFetchCompleted
 		        && current_row >= currentFirstCursor + fetchedTupleNumber;
 	}
+
+	synchronized public void reFresh() {
+		readTupleNumber = 0;
+		reFetch();
+	}
+
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23797
also related to http://jira.cubrid.org/browse/CBRD-23602

In TYPE_SCROLL_SENSITIVE setting

```
Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
ResultSet rs = stmt.executeQuery("select * from table3 order by a asc");
rs.next();
rs.updateInt(1, 100);
rs.updateRow();  --> ArrayIndexOutOfBoundsException Exception

```
In maxRows setting

```
Statement stmt = con.createStatement();
stmt.execute("CREATE TABLE maxRows (val int)"
                       + " INSERT INTO maxRows VALUES (1)"
                       + " INSERT INTO maxRows VALUES (2)");
PreparedStatement pstmt = con.prepareStatement("SELECT * FROM maxRows WHERE val<? ORDER BY val");
pstmt.setInt(1, 100);
pstmt.setMaxRows(1);
ResultSet rs = pstmt.executeQuery(); --> ArrayIndexOutOfBoundsException Exception
```
