### PR TITLE
[CBRD-23798] [Regression] some collation has wrong checked the null value

### DIFF
--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -3785,11 +3785,17 @@ lang_strmatch_utf8_uca_w_level (const COLL_DATA * coll_data, const int level, bo
 	      goto exit;
 	    }
 
+	  if (!ignore_trailing_space)
+	    {
+	      result = -1;
+	      goto exit;
+	    }
+
 	  /* consume any remaining zero-weight values (skip them) from str2 */
 	  do
 	    {
 	      w2 = GET_UCA_WEIGHT (level, ce_index2, uca_w_l13_2, uca_w_l4_2);
-	      if (w2 != 0 || !ignore_trailing_space)
+	      if (w2 != 0)
 		{
 		  /* non-zero weight : strings are not equal */
 		  result = -1;

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -3768,7 +3768,7 @@ lang_strmatch_utf8_uca_w_level (const COLL_DATA * coll_data, const int level, bo
 		}
 	      else
 		{
-		  if (is_match)
+		  if (is_match || !ignore_trailing_space)
 		    {
 		      result = -1;
 		      goto exit;
@@ -3789,7 +3789,7 @@ lang_strmatch_utf8_uca_w_level (const COLL_DATA * coll_data, const int level, bo
 	  do
 	    {
 	      w2 = GET_UCA_WEIGHT (level, ce_index2, uca_w_l13_2, uca_w_l4_2);
-	      if (w2 != 0)
+	      if (w2 != 0 || !ignore_trailing_space)
 		{
 		  /* non-zero weight : strings are not equal */
 		  result = -1;
@@ -3810,6 +3810,13 @@ lang_strmatch_utf8_uca_w_level (const COLL_DATA * coll_data, const int level, bo
 	      assert (result == 0);
 	      goto exit;
 	    }
+
+	  if (!ignore_trailing_space)
+	    {
+	      result = 1;
+	      goto exit;
+	    }
+
 	  /* consume any remaining zero-weight values (skip them) from str1 */
 	  while (num_ce1 > 0)
 	    {
@@ -5520,6 +5527,11 @@ lang_fastcmp_byte (const LANG_COLLATION * lang_coll, const unsigned char *string
   if (cmp || size1 == size2)
     {
       return cmp;
+    }
+
+  if (!ignore_trailing_space && size1 != size2)
+    {
+      return size1 - size2;
     }
 
   c1 = c2 = ZERO;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23798
also related to http://jira.cubrid.org/browse/CBRD-23731

This is related to the issue http://jira.cubrid.org/browse/CBRD-23731 processing ignore trailing space.

The trailing space should be ignore in System Parameter ignore_trailing_space=no, but in some collations the ignoring code is missed.

lang_fastcmp_byte is used at iso8859 collation and lang_strmatch_utf8_uca_w_level is used at uf8_uca collations should be reconsidered because ignoring space is not completed.

First, in lang_fastcmp_byte trailing space is processed well but 0-weight character is not, 0-weight character is ASCII code value 0 and it doesn't mean null.

In lang_strmatch_utf8_uca_w_level, modified point is as below.
  **is_match and ignore_trailing_space follows the same string compare rule to ignore trailing space.**
