### PR TITLE
[CBRD-23796] some rewrite query was not found the character size

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -24077,6 +24077,10 @@ pt_fix_enumeration_comparison (PARSER_CONTEXT * parser, PT_NODE * expr)
   op = expr->info.expr.op;
   arg1 = expr->info.expr.arg1;
   arg2 = expr->info.expr.arg2;
+  if (arg1->type_enum == PT_TYPE_NULL || arg2->type_enum == PT_TYPE_NULL)
+    {
+      return expr;
+    }
 
   switch (op)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23796

There are two problems. 
1. wrong precision like 'char(-1)'
==> '-1' is mean to TP_FLOATING_PRECISION_VALUE. '-1' is not wrong precision. it is not a problem.

2. assertion fail related to enumeration comparison.
==> I fixed it to not generate PT_TO_ENUMERATION_VALUE() when argument is 'null'.