### PR TITLE
[CBRD-23795] [Regression] cub_server terminate after drop table query.

### DIFF
--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -1780,15 +1780,13 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
 	  /* Check invalidation conditions. */
 	  if (invalidate_check == NULL || invalidate_check (xcache_entry, arg))
 	    {
-	      if (xcache_entry->list_ht_no < 0)
+	      if (xcache_entry->list_ht_no >= 0)
 		{
-		  continue;
-		}
-
-	      qfile_clear_list_cache (thread_p, xcache_entry->list_ht_no, true);
-	      if (qfile_get_list_cache_number_of_entries (xcache_entry->list_ht_no) == 0)
-		{
-		  xcache_entry->list_ht_no = -1;
+	          qfile_clear_list_cache (thread_p, xcache_entry->list_ht_no, true);
+	          if (qfile_get_list_cache_number_of_entries (xcache_entry->list_ht_no) == 0)
+		    {
+		      xcache_entry->list_ht_no = -1;
+		    }
 		}
 
 	      /* Mark entry as deleted. */

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -1780,8 +1780,16 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
 	  /* Check invalidation conditions. */
 	  if (invalidate_check == NULL || invalidate_check (xcache_entry, arg))
 	    {
+	      if (xcache_entry->list_ht_no < 0)
+		{
+		  continue;
+		}
+
 	      qfile_clear_list_cache (thread_p, xcache_entry->list_ht_no, true);
-	      xcache_entry->list_ht_no = -1;
+	      if (qfile_get_list_cache_number_of_entries (xcache_entry->list_ht_no) == 0)
+		{
+		  xcache_entry->list_ht_no = -1;
+		}
 
 	      /* Mark entry as deleted. */
 	      if (xcache_entry_mark_deleted (thread_p, xcache_entry))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23795
also related http://jira.cubrid.org/browse/CBRD-23602

after drop table cub_server process terminated. in case after insert data and drop table occurs ERROR:111 'Your transaction has been aborted by the system due to server failure or mode change.'.

I found a bug at xcache_invalidate_entries and xcache_invalidate_qcaches.
When DDL or DML is committed, related SELECT query cache should be invalidated but related DML is also applied.
It's a bug. Any related DML must not be applied because the DML has no cache entry. 

xcache_invalidate_entries  is called at DDL committing (ex, drop table). 