### PR TITLE
[CBRD-23736] add query-output and loaddb-output option to csql utility

### DIFF
--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -1342,7 +1342,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
   int len = 0;
   char string_delimiter =
     (output_type != CSQL_UNKNOWN_OUTPUT) ? column_enclosure : default_string_profile.string_delimiter;
-  bool change_single_quote = (output_type == CSQL_QUERY_OUTPUT && column_enclosure == '\'');
+  bool change_single_quote = (output_type != CSQL_UNKNOWN_OUTPUT && column_enclosure == '\'');
 
   if (value == NULL)
     {


### PR DESCRIPTION
- fix error that occur if data contains single quotes and the -d option is used.