### PR TITLE
[CBRD-23802] The 'ignore_trailing_space' system parameter's property becomes 'hidden'

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -5994,7 +5994,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_IGNORE_TRAILING_SPACE,
    PRM_NAME_IGNORE_TRAILING_SPACE,
-   (PRM_FOR_SERVER | PRM_FOR_CLIENT | PRM_FORCE_SERVER),
+   (PRM_FOR_SERVER | PRM_FOR_CLIENT | PRM_FORCE_SERVER | PRM_HIDDEN),
    PRM_BOOLEAN,
    &prm_ignore_trailing_space_flag,
    (void *) &prm_ignore_trailing_space_default,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23802
also related to http://jira.cubrid.org/browse/CBRD-23731

The configurable parameter 'ignore_trailing_space' is a serious component to affect a whole database system environment and operations.

If this parameter could be changed easily, the database applications using index with unique string keys faced with serious circumstance.

So, we should change the parameter's property to 'hidden' not to change the value.
