### PR TITLE
[CBRD-23608] Fix to use --CS-mode for TDE

### DIFF
--- a/src/executables/util_admin.c
+++ b/src/executables/util_admin.c
@@ -1074,6 +1074,10 @@ util_get_library_name (int utility_index)
 	      {
 		return LIB_UTIL_CS_NAME;
 	      }
+	    if (key == HIDDEN_CS_MODE_S && arg_map[i].arg_value.p != NULL)
+	      {
+		return LIB_UTIL_CS_NAME;
+	      }
 	    if (key == 'S' && arg_map[i].arg_value.p != NULL)
 	      {
 		return LIB_UTIL_SA_NAME;

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -956,6 +956,8 @@ typedef struct _ha_config
 #define UTIL_OPTION_CHECKSUMDB			"checksumdb"
 #define UTIL_OPTION_TDE			        "tde"
 
+#define HIDDEN_CS_MODE_S                        15000
+
 /* createdb option list */
 #define CREATE_PAGES_S                          'p'
 #define CREATE_PAGES_L                          "pages"
@@ -1604,7 +1606,7 @@ typedef struct _ha_config
 #define TDE_PRINT_KEY_VALUE_L "print-value"
 #define TDE_SA_MODE_S         'S'
 #define TDE_SA_MODE_L         "SA-mode"
-#define TDE_CS_MODE_S         14001
+#define TDE_CS_MODE_S         HIDDEN_CS_MODE_S
 #define TDE_CS_MODE_L         "CS-mode"
 #define TDE_CHANGE_KEY_S      'c'
 #define TDE_CHANGE_KEY_L      "change-key"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23608

CUBRID uses the literal word 'C' to check whether it is CS mode or not. 
So using dummy words like 14000 for the short option name of CS mode made TDE always load SA library.

Generally, dummy words are used to make it impossible to use the option, but this trick can't be used for the short name for mode selection.



