### PR TITLE
[CBRD-23803] The parameters related to 'query_cache_mode' reconfigured to change the mode.

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1411,13 +1411,13 @@ static unsigned int prm_list_query_cache_mode_flag = 0;
 int PRM_LIST_MAX_QUERY_CACHE_ENTRIES = 200;
 static int prm_list_max_query_cache_entries_default = 200;
 static int prm_list_max_query_cache_entries_upper = INT_MAX;
-static int prm_list_max_query_cache_entries_lower = 1;
+static int prm_list_max_query_cache_entries_lower = 0;
 static unsigned int prm_list_max_query_cache_entries_flag = 0;
 
 int PRM_LIST_MAX_QUERY_CACHE_PAGES = 1000;
 static int prm_list_max_query_cache_pages_default = 1000;
 static int prm_list_max_query_cache_pages_upper = INT_MAX;
-static int prm_list_max_query_cache_pages_lower = 1;
+static int prm_list_max_query_cache_pages_lower = 0;
 static unsigned int prm_list_max_query_cache_pages_flag = 0;
 
 bool PRM_USE_ORDERBY_SORT_LIMIT = true;

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -1102,7 +1102,8 @@ qfile_initialize (void)
 {
   qfile_Is_list_cache_disabled =
     ((prm_get_integer_value (PRM_ID_LIST_QUERY_CACHE_MODE) == QFILE_LIST_QUERY_CACHE_MODE_OFF)
-     || (prm_get_integer_value (PRM_ID_LIST_MAX_QUERY_CACHE_ENTRIES) <= 0));
+     || (prm_get_integer_value (PRM_ID_LIST_MAX_QUERY_CACHE_ENTRIES) <= 0)
+     || (prm_get_integer_value (PRM_ID_LIST_MAX_QUERY_CACHE_PAGES) <= 0));
 
   qfile_Max_tuple_page_size = QFILE_MAX_TUPLE_SIZE_IN_PAGE;
 
@@ -5199,7 +5200,7 @@ qfile_clear_list_cache (THREAD_ENTRY * thread_p, int list_ht_no, bool release)
       er_log_debug (ARG_FILE_LINE, "ls_clear_list_cache: failed to delete all entries\n");
     }
 
-  if (qfile_get_list_cache_number_of_entries(list_ht_no) == 0)
+  if (qfile_get_list_cache_number_of_entries (list_ht_no) == 0)
     {
       (void) mht_clear (qfile_List_cache.list_hts[list_ht_no], NULL, NULL);
       /* release assigned memory hash table */

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -219,9 +219,13 @@ qmgr_get_page_type (PAGE_PTR page_p, QMGR_TEMP_FILE * temp_file_p)
 static bool
 qmgr_is_allowed_result_cache (QUERY_FLAG flag)
 {
-  int query_cache_mode;
+  static int query_cache_mode = prm_get_integer_value (PRM_ID_LIST_QUERY_CACHE_MODE);
 
-  query_cache_mode = prm_get_integer_value (PRM_ID_LIST_QUERY_CACHE_MODE);
+  if (QFILE_IS_LIST_CACHE_DISABLED)
+    {
+      return false;
+    }
+
   if (query_cache_mode == QFILE_LIST_QUERY_CACHE_MODE_OFF
       || (query_cache_mode == QFILE_LIST_QUERY_CACHE_MODE_SELECTIVELY_OFF && (flag & RESULT_CACHE_INHIBITED))
       || (query_cache_mode == QFILE_LIST_QUERY_CACHE_MODE_SELECTIVELY_ON && !(flag & RESULT_CACHE_REQUIRED)))
@@ -235,9 +239,12 @@ qmgr_is_allowed_result_cache (QUERY_FLAG flag)
 static bool
 qmgr_can_get_result_from_cache (QUERY_FLAG flag)
 {
-  int query_cache_mode;
+  static int query_cache_mode = prm_get_integer_value (PRM_ID_LIST_QUERY_CACHE_MODE);
 
-  query_cache_mode = prm_get_integer_value (PRM_ID_LIST_QUERY_CACHE_MODE);
+  if (QFILE_IS_LIST_CACHE_DISABLED)
+    {
+      return false;
+    }
 
   if (query_cache_mode == QFILE_LIST_QUERY_CACHE_MODE_OFF
       || (query_cache_mode != QFILE_LIST_QUERY_CACHE_MODE_OFF && (flag & NOT_FROM_RESULT_CACHE)))
@@ -2637,7 +2644,7 @@ qmgr_create_new_temp_file (THREAD_ENTRY * thread_p, QUERY_ID query_id, QMGR_TEMP
   tfile_vfid_p->preserved = false;
   tfile_vfid_p->tde_encrypted = false;
   tfile_vfid_p->membuf_last = -1;
-  
+
   page_p = (PAGE_PTR) ((PAGE_PTR) tfile_vfid_p->membuf
 		       + DB_ALIGN (sizeof (PAGE_PTR) * tfile_vfid_p->membuf_npages, MAX_ALIGNMENT));
 


### PR DESCRIPTION
The parameters related to 'query_cache_mode' is as below:

- max_query_cache_entries
- query_cache_size_in_pages

By the above parameters, the query cache mode can be changed to enable or disable.
In order to this, the related some routines is need to be changed.