### PR TITLE
[CBRD-23629] Fix usage of javasp is displayed by cubrid service status

### DIFF
--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -1425,7 +1425,12 @@ process_service (int command_type, bool process_window_service)
 	(void) process_server (command_type, 0, NULL, false, true, false);
 	(void) process_broker (command_type, 1, args, false);
 	(void) process_manager (command_type, false);
-	(void) process_javasp (command_type, 0, NULL, false);
+	if (strcmp (get_property (SERVICE_START_JAVASP), PROPERTY_ON) == 0
+	    && us_Property_map[SERVER_START_LIST].property_value != NULL
+	    && us_Property_map[SERVER_START_LIST].property_value[0] != '\0')
+	  {
+	    (void) process_javasp (command_type, 0, NULL, false);
+	  }
 	if (strcmp (get_property (SERVICE_START_HEARTBEAT), PROPERTY_ON) == 0)
 	  {
 	    (void) process_heartbeat (command_type, 0, NULL);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23629

Even `javasp` is not set in the `service` section, the usage of javasp is displayed unexpectedly.
It caused because database names are not set in `service::server` so the argument of `javasp status` is not given, usage is displayed in the `javasp status` routine unexpectedly.