### PR TITLE
[CBRD-23608] Close the vdes of backup key file after validation (restoredb)

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3011,6 +3011,9 @@ boot_reset_mk_after_restart_from_backup (THREAD_ENTRY * thread_p, BO_RESTART_ARG
       goto exit;
     }
 
+  fileio_close (backup_mk_vdes);
+  backup_mk_vdes = NULL_VOLDES;
+
   /* if a server key file exists, move it */
   if (server_mk_vdes != NULL_VOLDES)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23608

The file descriptor for a backup file must be closed after validation for the backup key file (no need to keep it), but it was missed not considering WINDOWS.

After validation, the backup key file is mounted. In WINDOWS, the file locking in `fileio_mount()` uses constants for [file-sharing modes](https://docs.microsoft.com/ko-kr/cpp/c-runtime-library/sharing-constants?view=msvc-160) given to open(), although Linux uses file lock interface. Because WINDOWS `_SH_DENYWR` to lock a file in `fileio_mount()`, we need to close the file opened with `O_RDWR`. This is not a problem in LINUX.

