### PR TITLE
[CBRD-23808] Core dumped in csql_execute_statements

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1862,7 +1862,8 @@ csql_execute_statements (const CSQL_ARGUMENT * csql_arg, int type, const void *s
       if (session->statements != NULL)
 	{
 	  statement = session->statements[num_stmts];
-	  if (statement != NULL && strlen (statement->sql_user_text) >= statement->sql_user_text_len)
+	  if (statement != NULL && statement->sql_user_text != NULL
+	      && strlen (statement->sql_user_text) >= statement->sql_user_text_len)
 	    {
 	      logddl_set_sql_text (statement->sql_user_text, statement->sql_user_text_len);
 	      logddl_set_stmt_type (statement->node_type);

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1862,7 +1862,7 @@ csql_execute_statements (const CSQL_ARGUMENT * csql_arg, int type, const void *s
       if (session->statements != NULL)
 	{
 	  statement = session->statements[num_stmts];
-	  if (statement != NULL && statement->sql_user_text != NULL
+	  if (statement && statement->sql_user_text
 	      && strlen (statement->sql_user_text) >= statement->sql_user_text_len)
 	    {
 	      logddl_set_sql_text (statement->sql_user_text, statement->sql_user_text_len);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23808

In case of FILE_INPUT type in csql, sql_user_text of the statement is null. Therefore, add null check to sql_user_text