### PR TITLE
[CBRD-23809] [Regression] Decreased volume reuse rate.

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -4354,7 +4354,6 @@ file_temp_retire_internal (THREAD_ENTRY * thread_p, const VFID * vfid, bool was_
     {
       entry = file_tempcache_pop_tran_file (thread_p, vfid);
       assert (entry != NULL);
-      return NO_ERROR;
     }
 
   if (entry != NULL && file_tempcache_put (thread_p, entry))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23809
also related to http://jira.cubrid.org/browse/CBRD-23602

Temp file should be deleted when a query is closed or a result cache is removed.
The code is modified not to return without deleting temp file. I remove one line unnecessary "return NO_ERROR" of the code to prior CBRD-23602.