### PR TITLE
[CBRD-23731] Regression: in prepare containing + '%' query cast as char which expected cast as varchar.

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -24378,7 +24378,7 @@ static PT_TYPE_ENUM
 pt_wrap_type_for_collation (const PT_NODE * arg1, const PT_NODE * arg2, const PT_NODE * arg3,
 			    PT_TYPE_ENUM * wrap_type_collection)
 {
-  PT_TYPE_ENUM common_type = PT_TYPE_CHAR;
+  PT_TYPE_ENUM common_type = (PT_IS_COLLECTION_TYPE (arg1->type_enum))?PT_TYPE_CHAR:PT_TYPE_VARCHAR;
   PT_TYPE_ENUM arg1_type = PT_TYPE_NONE, arg2_type = PT_TYPE_NONE, arg3_type = PT_TYPE_NONE;
 
   if (arg1)

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -24378,7 +24378,7 @@ static PT_TYPE_ENUM
 pt_wrap_type_for_collation (const PT_NODE * arg1, const PT_NODE * arg2, const PT_NODE * arg3,
 			    PT_TYPE_ENUM * wrap_type_collection)
 {
-  PT_TYPE_ENUM common_type = (PT_IS_COLLECTION_TYPE (arg1->type_enum))?PT_TYPE_CHAR:PT_TYPE_VARCHAR;
+  PT_TYPE_ENUM common_type = (PT_IS_COLLECTION_TYPE (arg1->type_enum)) ? PT_TYPE_CHAR : PT_TYPE_VARCHAR;
   PT_TYPE_ENUM arg1_type = PT_TYPE_NONE, arg2_type = PT_TYPE_NONE, arg3_type = PT_TYPE_NONE;
 
   if (arg1)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23731

in prepare statement containing + ''%'''  query cast as char which '' expected cast as varchar.
