### PR TITLE
[CBRD-23810] Improvement of DML and transaction processing for result-cache

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -6779,3 +6779,9 @@ qfile_get_list_cache_number_of_entries (int ht_no)
 
   return (qfile_List_cache.list_hts[ht_no]->nentries);
 }
+
+bool
+qfile_has_no_cache_entries ()
+{
+  return (qfile_List_cache.n_entries == 0);
+}

--- a/src/query/list_file.h
+++ b/src/query/list_file.h
@@ -224,5 +224,7 @@ extern int qfile_overwrite_tuple (THREAD_ENTRY * thread_p, PAGE_PTR first_page, 
 				  QFILE_TUPLE_RECORD * tplrec, QFILE_LIST_ID * list_idp);
 extern void qfile_update_qlist_count (THREAD_ENTRY * thread_p, const QFILE_LIST_ID * list_p, int inc);
 extern int qfile_get_list_cache_number_of_entries (int ht_no);
+extern bool qfile_has_no_cache_entries ();
+
 
 #endif /* _LIST_FILE_H_ */

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1537,6 +1537,11 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 	   * in case list_ht_no is not less than 0 and list_cache_entry_p is null
 	   *     the cache entry is found but the entry is used by other transaction
 	   */
+	  if (list_cache_entry_p && xasl_cache_entry_p->list_ht_no < 0)
+	    {
+	      assert (false);
+	    }
+
 	  if (list_cache_entry_p || xasl_cache_entry_p->list_ht_no < 0)
 	    {
 	      list_cache_entry_p =

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1534,7 +1534,7 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 	   * is, or make new one
 	   * in case list_ht_no is less than 0,
 	   *     the cache is not found and should be newly added (surely list_cache_entry_p is null)
-	   * in case list_ht_no is not less than 0 and list_cache_entry_p is not null
+	   * in case list_ht_no is not less than 0 and list_cache_entry_p is null
 	   *     the cache entry is found but the entry is used by other transaction
 	   */
 	  if (list_cache_entry_p || xasl_cache_entry_p->list_ht_no < 0)

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -40,6 +40,7 @@
 #include "thread_lockfree_hash_map.hpp"
 #include "thread_manager.hpp"
 #include "xasl_unpack_info.hpp"
+#include "list_file.h"
 
 #include <algorithm>
 #include <assert.h>
@@ -1780,10 +1781,10 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
 	  /* Check invalidation conditions. */
 	  if (invalidate_check == NULL || invalidate_check (xcache_entry, arg))
 	    {
-	      if (xcache_entry->list_ht_no >= 0)
+	      if (xcache_entry->list_ht_no >= 0 && !QFILE_IS_LIST_CACHE_DISABLED && !qfile_has_no_cache_entries ())
 		{
-	          qfile_clear_list_cache (thread_p, xcache_entry->list_ht_no, true);
-	          if (qfile_get_list_cache_number_of_entries (xcache_entry->list_ht_no) == 0)
+		  qfile_clear_list_cache (thread_p, xcache_entry->list_ht_no, true);
+		  if (qfile_get_list_cache_number_of_entries (xcache_entry->list_ht_no) == 0)
 		    {
 		      xcache_entry->list_ht_no = -1;
 		    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23810
also related to http://jira.cubrid.org/browse/CBRD-23602

Improvement of DML and transaction processing for result-cache

The update query affects the result-cache by cache invalidation for related tables.
We should minimize the affect for performance and the transaction processing should be also dealt in detail.
- The invalidation for DML does not need to start for 0 cache entry.
- The invalidation for DML does not need to start for no-cache mode.
- query caches "IN Transaction" must not refer.