### PR TITLE
[CBRD-23608] Revise error handling and cleanup when applying tde to files fails

### DIFF
--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -2509,8 +2509,9 @@ qmgr_get_new_page (THREAD_ENTRY * thread_p, VPID * vpid_p, QMGR_TEMP_FILE * tfil
 
       if (file_apply_tde_algorithm (thread_p, &tfile_vfid_p->temp_vfid, tde_algo) != NO_ERROR)
 	{
-	  file_temp_retire (thread_p, &tfile_vfid_p->temp_vfid);
 	  ASSERT_ERROR ();
+	  file_temp_retire (thread_p, &tfile_vfid_p->temp_vfid);
+	  VFID_SET_NULL (&tfile_vfid_p->temp_vfid);
 	  return NULL;
 	}
     }
@@ -2770,12 +2771,6 @@ qmgr_create_result_file (THREAD_ENTRY * thread_p, QUERY_ID query_id)
       return NULL;
     }
 
-  if (qmgr_is_allowed_result_cache (query_p->query_flag))
-    {
-      file_temp_preserve (thread_p, &tfile_vfid_p->temp_vfid);
-      tfile_vfid_p->preserved = true;
-    }
-
   if (query_p->includes_tde_class)
     {
       tfile_vfid_p->tde_encrypted = true;
@@ -2787,6 +2782,12 @@ qmgr_create_result_file (THREAD_ENTRY * thread_p, QUERY_ID query_id)
       file_temp_retire (thread_p, &tfile_vfid_p->temp_vfid);
       free_and_init (tfile_vfid_p);
       return NULL;
+    }
+
+  if (qmgr_is_allowed_result_cache (query_p->query_flag))
+    {
+      file_temp_preserve (thread_p, &tfile_vfid_p->temp_vfid);
+      tfile_vfid_p->preserved = true;
     }
 
   /* chain the tfile_vfid to the query_entry->temp_vfid */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1973,9 +1973,15 @@ btree_create_overflow_key_file (THREAD_ENTRY * thread_p, BTID_INT * btid)
   error_code = heap_get_class_tde_algorithm (thread_p, &btid->topclass_oid, &tde_algo);
   if (error_code != NO_ERROR)
     {
+      VFID_SET_NULL (&btid->ovfid);
       return error_code;
     }
   error_code = file_apply_tde_algorithm (thread_p, &btid->ovfid, tde_algo);
+  if (error_code != NO_ERROR)
+    {
+      VFID_SET_NULL (&btid->ovfid);
+      return error_code;
+    }
   return error_code;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23608

This fetch includes:
- Fix to cleanup VFIDs if `file_apply_tde_algorithm()` fails (in some cases)
- Revise error handling and missed cleanup OR_CLASS_REPR in `xfile_apply_tde_to_class_files()`