### PR TITLE
[CBRD-23811] [Regression] 'Java.lang.OutOfMemoryError: Java heap space' occurred during 10 million data selection in JDBC

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -1433,7 +1433,7 @@ public class CUBRIDResultSet implements ResultSet {
 
 		clearCurrentRow();
 
-		u_stmt.reFresh();
+		u_stmt.reFetch();
 		error = u_stmt.getRecentError();
 
 		switch (error.getErrorCode()) {

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
@@ -302,7 +302,9 @@ public class CUBRIDStatement implements Statement {
 					checkIsOpen();
 
 					if (current_result_set != null) {
-						current_result_set.close();
+						if (!u_stmt.is_result_cacheable()) {
+							current_result_set.close();
+						}
 						current_result_set = null;
 					}
 
@@ -936,7 +938,8 @@ public class CUBRIDStatement implements Statement {
 		completed = true;
 
 		if (current_result_set != null) {
-			current_result_set.close();
+			if (!u_stmt.is_result_cacheable())
+				current_result_set.close();
 			current_result_set = null;
 		}
 

--- a/src/jdbc/cubrid/jdbc/driver/ConnectionProperties.java
+++ b/src/jdbc/cubrid/jdbc/driver/ConnectionProperties.java
@@ -353,6 +353,9 @@ public class ConnectionProperties {
 
     BooleanConnectionProperty useSSL = new BooleanConnectionProperty("useSSL", false);
 
+    IntegerConnectionProperty clientCacheSize = new IntegerConnectionProperty(
+    		"clientCacheSize", 16, 16, 256);
+    
     public boolean getLogOnException() {
 	return logOnException.getValueAsBoolean();
     }
@@ -414,5 +417,9 @@ public class ConnectionProperties {
 
     public boolean getUseSSL() {
         return useSSL.getValueAsBoolean();
+    }
+    
+    public int getClientCacheSize() {
+    	return clientCacheSize.getValueAsInteger();
     }
 }

--- a/src/jdbc/cubrid/jdbc/jci/UConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UConnection.java
@@ -1517,6 +1517,10 @@ public abstract class UConnection {
 	public boolean getOracleStyleEmpltyString() {
 		return connectionProperties.getOracleStyleEmptyString();
 	}
+	
+	public int getClientCacheSize() {
+		return connectionProperties.getClientCacheSize() * 16*1024;
+	}
 
 	public void setCasIp (String casIp) {
 		this.casIp = casIp;

--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -2159,8 +2159,6 @@ public class UStatement {
 				}
 			}
 			tuples = null;
-
-			getResCache().setExpire();
 		}
 	}
 	
@@ -2172,6 +2170,8 @@ public class UStatement {
 			tuple_list = null;
 			fetched_number = null;
 			first_cursor = null;
+			
+			getResCache().setExpire();
 		}
 		else {
 			closeTuples(tuples);

--- a/src/jdbc/cubrid/jdbc/jci/UStatementCacheData.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatementCacheData.java
@@ -34,6 +34,8 @@ public class UStatementCacheData {
 	int tuple_count;
 	UResultTuple[] tuples;
 	UResultInfo[] resultInfo;
+	int first;
+	int fetched;
 	long srvCacheTime;
 
 	UStatementCacheData(UStatementCacheData cache_data) {
@@ -47,14 +49,32 @@ public class UStatementCacheData {
 			this.tuples = cache_data.tuples;
 			this.resultInfo = cache_data.resultInfo;
 			this.srvCacheTime = cache_data.srvCacheTime;
+			this.first = cache_data.first;
+			this.fetched = cache_data.fetched;
 		}
 	}
 
+	void setCacheData(int tuple_count, UResultTuple[] tuples,
+			UResultInfo[] resultInfo, int firstCursor, int fetchedTuples) {
+		this.tuple_count = tuple_count;
+		this.tuples = tuples;
+		this.resultInfo = resultInfo;
+		this.first = firstCursor;
+		this.fetched = fetchedTuples;
+		if (resultInfo.length == 1)
+			this.srvCacheTime = resultInfo[0].getSrvCacheTime();
+		else
+			this.srvCacheTime = 0L;
+	}
+	
+	/* for QA test case */
 	void setCacheData(int tuple_count, UResultTuple[] tuples,
 			UResultInfo[] resultInfo) {
 		this.tuple_count = tuple_count;
 		this.tuples = tuples;
 		this.resultInfo = resultInfo;
+		this.first = 0;
+		this.fetched = 0;
 		if (resultInfo.length == 1)
 			this.srvCacheTime = resultInfo[0].getSrvCacheTime();
 		else

--- a/src/jdbc/cubrid/jdbc/jci/UStatementCacheData.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatementCacheData.java
@@ -55,10 +55,13 @@ public class UStatementCacheData {
 			this.fetched = cache_data.fetched;
 			this.first = cache_data.first;
 			this.resultInfo = cache_data.resultInfo;
-			if (resultInfo.length == 1)
-				this.srvCacheTime = resultInfo[0].getSrvCacheTime();
-			else
-				this.srvCacheTime = 0L;
+			if (resultInfo != null) {
+				if (resultInfo.length == 1)
+					this.srvCacheTime = resultInfo[0].getSrvCacheTime();
+				else
+					this.srvCacheTime = 0L;
+			}
+			else this.srvCacheTime = 0L;
 		}
 	}
 

--- a/src/jdbc/cubrid/jdbc/jci/UStatementCacheData.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatementCacheData.java
@@ -30,37 +30,52 @@
 
 package cubrid.jdbc.jci;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class UStatementCacheData {
 	int tuple_count;
-	UResultTuple[] tuples;
 	UResultInfo[] resultInfo;
-	int first;
-	int fetched;
 	long srvCacheTime;
+	
+	List<UResultTuple[]> tuples;
+	List<Integer> fetched;
+	List<Integer> first;
 
 	UStatementCacheData(UStatementCacheData cache_data) {
 		if (cache_data == null) {
 			this.tuple_count = 0;
 			this.tuples = null;
+			this.fetched = null;
 			this.resultInfo = null;
 			this.srvCacheTime = 0L;
 		} else {
 			this.tuple_count = cache_data.tuple_count;
 			this.tuples = cache_data.tuples;
-			this.resultInfo = cache_data.resultInfo;
-			this.srvCacheTime = cache_data.srvCacheTime;
-			this.first = cache_data.first;
 			this.fetched = cache_data.fetched;
+			this.first = cache_data.first;
+			this.resultInfo = cache_data.resultInfo;
+			if (resultInfo.length == 1)
+				this.srvCacheTime = resultInfo[0].getSrvCacheTime();
+			else
+				this.srvCacheTime = 0L;
 		}
 	}
 
-	void setCacheData(int tuple_count, UResultTuple[] tuples,
-			UResultInfo[] resultInfo, int firstCursor, int fetchedTuples) {
+	void setCacheData(UResultTuple[] tuples, int firstCursor, int fetchedTuples) {
+		this.tuples.add(tuples);
+		this.fetched.add(fetchedTuples);
+		this.first.add(firstCursor);
+	}
+	
+	void setCacheData(int tuple_count, UResultInfo[] resultInfo) {
+		if (this.tuples == null) {
+			this.tuples = new ArrayList<UResultTuple[]>();
+			this.fetched = new ArrayList<Integer>();
+			this.first = new ArrayList<Integer>();
+		}
 		this.tuple_count = tuple_count;
-		this.tuples = tuples;
 		this.resultInfo = resultInfo;
-		this.first = firstCursor;
-		this.fetched = fetchedTuples;
 		if (resultInfo.length == 1)
 			this.srvCacheTime = resultInfo[0].getSrvCacheTime();
 		else
@@ -71,10 +86,10 @@ public class UStatementCacheData {
 	void setCacheData(int tuple_count, UResultTuple[] tuples,
 			UResultInfo[] resultInfo) {
 		this.tuple_count = tuple_count;
-		this.tuples = tuples;
 		this.resultInfo = resultInfo;
-		this.first = 0;
-		this.fetched = 0;
+		this.tuples = null;
+		this.fetched = null;
+		this.first = null;
 		if (resultInfo.length == 1)
 			this.srvCacheTime = resultInfo[0].getSrvCacheTime();
 		else

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -5199,7 +5199,7 @@ qfile_clear_list_cache (THREAD_ENTRY * thread_p, int list_ht_no, bool release)
       er_log_debug (ARG_FILE_LINE, "ls_clear_list_cache: failed to delete all entries\n");
     }
 
-  if (qfile_get_list_cache_number_of_entries(list_ht_no) == 0)
+  if (qfile_get_list_cache_number_of_entries (list_ht_no) == 0)
     {
       (void) mht_clear (qfile_List_cache.list_hts[list_ht_no], NULL, NULL);
       /* release assigned memory hash table */
@@ -5745,9 +5745,12 @@ qfile_lookup_list_cache_entry (THREAD_ENTRY * thread_p, int list_ht_no, const DB
 	  num_elements = (int) lent->last_ta_idx;
 	  if (lent->uncommitted_marker == true)
 	    {
-	      lent->last_ta_idx = num_elements;
-	      /* treat as look-up failed */
-	      lent = NULL;
+	      if (lent->tran_index_array[tran_index] == 0)
+		{
+		  lent->last_ta_idx = num_elements;
+		  /* treat as look-up failed */
+		  lent = NULL;
+		}
 	    }
 	  else
 	    {

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1384,10 +1384,6 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 	  cached_result = true;
 
 	  CACHE_TIME_MAKE (server_cache_time_p, &list_cache_entry_p->time_created);
-	  if (CACHE_TIME_EQ (client_cache_time_p, server_cache_time_p))
-	    {
-	      goto end;
-	    }
 	}
     }
 
@@ -1467,7 +1463,9 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 	  goto exit_on_error;	/* maybe, memory allocation error */
 	}
       list_id_p->last_pgptr = NULL;
-
+#if defined (SERVER_MODE)
+      list_cache_entry_p->uncommitted_marker = true;	/* for transaction */
+#endif
       /* mark that the query is completed */
       qmgr_mark_query_as_completed (query_p);
 
@@ -2637,7 +2635,7 @@ qmgr_create_new_temp_file (THREAD_ENTRY * thread_p, QUERY_ID query_id, QMGR_TEMP
   tfile_vfid_p->preserved = false;
   tfile_vfid_p->tde_encrypted = false;
   tfile_vfid_p->membuf_last = -1;
-  
+
   page_p = (PAGE_PTR) ((PAGE_PTR) tfile_vfid_p->membuf
 		       + DB_ALIGN (sizeof (PAGE_PTR) * tfile_vfid_p->membuf_npages, MAX_ALIGNMENT));
 


### PR DESCRIPTION

**This issue has been closed with CBRD-23801**



http://jira.cubrid.org/browse/CBRD-23811
also related to http://jira.cubrid.org/browse/CBRD-23801 and http://jira.cubrid.org/browse/CBRD-23602

- CBRD-23811:
In two sessions, it select 10 million rows in both tables.
'java.lang.OutOfMemoryError: Java heap space' occurs during fetch.

- CBRD-23801
The JDBC provides cursor is set to some position to total tuple number. This issue is from result-cache.

The tuples are pre-assigned even though the tuples are not read once for the result-cache. The cursor position should be set properly in this circumstance.

The cursor variable is two, first is for the absolute position (currentCursor) of all of tuples and second is for the relative starting position (currentFirstCursor).

The two cursor pointer should be managed properly not to read invalid range of the tuples.