### PR TITLE
[CBRD-23629] Fix slip of javasp utility

### DIFF
--- a/win/cubridsa/cubridsa.def
+++ b/win/cubridsa/cubridsa.def
@@ -137,6 +137,7 @@ EXPORTS
     tr_map_trigger
     er_init
     er_final
+    er_clear
     jsp_connect_server
     jsp_disconnect_server
     jsp_writen


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23629

This PR fixes the following regression. It caused because an error is not cleared before starting JVM in javasp_start_server (). errors created by er_set() in javasp_is_running () was detected by jsp_start_server() and was handled incorrectly. it should be cleared.

**Repro.**  
```
cubrid javasp start demodb
ps -ef | grep cub_javasp
kill -9 <pid>
cubrid javasp start demodb
```

**Expected**
```
@ cubrid javasp start: demodb
++ cubrid javasp start: success
```

**Actual** 
```
@ cubrid javasp start: demodb
Can't connect Java VM: connect()
++ cubrid javasp start: fail
```

And I fixed some trivial slip.