### PR TITLE
[CBRD-23804][Regression] Core dumped in btree_key_find_and_insert_delete_mvccid

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -11767,19 +11767,13 @@ btree_get_prefix_separator (const DB_VALUE * key1, const DB_VALUE * key2, DB_VAL
 {
   int c;
   int err = NO_ERROR;
-  static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
-
-  /* for coerce = 2, we need to process key comparing as char-type
-   * in case that one of two arguments has varchar-type
-   * if the other argument has char-type */
-  static int coerce = (ignore_trailing_space) ? 1 : 2;
 
   assert (DB_IS_NULL (key1) || (DB_VALUE_DOMAIN_TYPE (key1) == DB_VALUE_DOMAIN_TYPE (key2)));
   assert (!DB_IS_NULL (key2));
   assert_release (key_domain != NULL);
 
 #if !defined(NDEBUG)
-  c = btree_compare_key ((DB_VALUE *) key1, (DB_VALUE *) key2, key_domain, coerce, 1, NULL);
+  c = btree_compare_key ((DB_VALUE *) key1, (DB_VALUE *) key2, key_domain, 1, 1, NULL);
   assert (c == DB_LT);
 #endif
 
@@ -11807,7 +11801,7 @@ btree_get_prefix_separator (const DB_VALUE * key1, const DB_VALUE * key2, DB_VAL
       return ER_FAILED;
     }
 
-  c = btree_compare_key ((DB_VALUE *) key1, prefix_key, key_domain, coerce, 1, NULL);
+  c = btree_compare_key ((DB_VALUE *) key1, prefix_key, key_domain, 1, 1, NULL);
 
   if (c != DB_LT)
     {
@@ -11815,7 +11809,7 @@ btree_get_prefix_separator (const DB_VALUE * key1, const DB_VALUE * key2, DB_VAL
       return ER_FAILED;
     }
 
-  c = btree_compare_key (prefix_key, (DB_VALUE *) key2, key_domain, coerce, 1, NULL);
+  c = btree_compare_key (prefix_key, (DB_VALUE *) key2, key_domain, 1, 1, NULL);
 
   if (!(c == DB_LT || c == DB_EQ))
     {
@@ -18746,6 +18740,12 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
 
       if (are_types_comparable)
 	{
+	  /*
+	   * for do_coercion = 2, we need to process key comparing as char-type
+	   * in case that one of two arguments has varchar-type
+	   * if the other argument has char-type
+	   */
+	  do_coercion = 2;
 	  c = key_domain->type->cmpval (key1, key2, do_coercion, total_order, NULL, key_domain->collation_id);
 	}
       else
@@ -18817,7 +18817,12 @@ btree_compare_individual_key_value (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN 
     }
 
   /* both are not null values */
-  c = key_domain->type->cmpval (key1, key2, 1, 1, NULL, key_domain->collation_id);
+  /* 
+   * for do_coercion = 2, we need to process key comparing as char-type
+   * in case that one of two arguments has varchar-type
+   * if the other argument has char-type 
+   */
+  c = key_domain->type->cmpval (key1, key2, 2, 1, NULL, key_domain->collation_id);
 
   if (key_domain->is_desc)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23804
http://jira.cubrid.org/browse/CBRD-23814
also related to http://jira.cubrid.org/browse/CBRD-23731

Core dumped in btree_key_find_and_insert_delete_mvccid

The b-tree key compare is not same as general compare when the char-type and varchar-type is mixed.
The mixed type case is commonly made at splitting b-tree node  to check a split position of the tree nodes.

I modified the codes related to b-tree compare to process mixed char and varchar-type.
The coerce 2 means tow comparing arguments may have char-type and varchar-type each other. 