### PR TITLE
[CBRD-23725] Modification of return value due to abnormal behavior in…

### DIFF
--- a/src/executables/unload_object.c
+++ b/src/executables/unload_object.c
@@ -199,7 +199,7 @@ get_estimated_objs (HFID * hfid, int64_t *est_objects)
 
   *est_objects += nobjs;
 
-  return nobjs;
+  return 0;
 }
 
 /*


### PR DESCRIPTION
… case of a large number of objects
http://jira.cubrid.org/browse/CBRD-23725
* This module is called from two places. And only check whether the return value is greater than 0. **nobj** is not used as the return value.
* If **nobj** is greater than 2.1 billion, it is recognized as a negative number to prevent error processing.