### PR TITLE
[CBRD-23812] [Regression] The results of two queries that scan different indexes in the same transaction are different.

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -4110,7 +4110,7 @@ tp_domain_select (const TP_DOMAIN * domain_list, const DB_VALUE * value, int all
 
   best = NULL;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   /*
@@ -7092,7 +7092,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
   int year, month, day;
   TZ_ID ses_tz_id;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   DB_VALUE src_replacement;

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -147,10 +147,6 @@ extern unsigned int db_on_server;
 #define IS_FLOATING_PRECISION(prec) \
   ((prec) == TP_FLOATING_PRECISION_VALUE)
 
-#define TP_IS_CHAR_STRING(db_val_type)					\
-    (db_val_type == DB_TYPE_CHAR || db_val_type == DB_TYPE_VARCHAR ||	\
-     db_val_type == DB_TYPE_NCHAR || db_val_type == DB_TYPE_VARNCHAR)
-
 // *INDENT-OFF*
 pr_type::pr_type (const char * name_arg, DB_TYPE id_arg, int varp_arg, int size_arg, int disksize_arg, int align_arg,
                   initmem_function_type initmem_f_arg, initval_function_type initval_f_arg,
@@ -7760,8 +7756,6 @@ pr_midxkey_compare_element (char *mem1, char *mem2, TP_DOMAIN * dom1, TP_DOMAIN 
     }
 
   c = tp_value_compare_with_error (&val1, &val2, do_coercion, total_order, &comparable);
-  //if (c == DB_GT) c = DB_LT;
-  //if (c == DB_LT) c = DB_GT;
 
 clean_up:
   if (DB_NEED_CLEAR (&val1))
@@ -11958,7 +11952,7 @@ mr_cmpdisk_char_internal (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
       mem_length1 = mem_length2 = STR_SIZE (domain->precision, TP_DOMAIN_CODESET (domain));
     }
 
-  if (!ignore_trailing_space && do_coercion < 2)
+  if (!ignore_trailing_space)
     {
       ti = (domain->type->id == DB_TYPE_CHAR || domain->type->id == DB_TYPE_NCHAR);
     }

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -7911,14 +7911,14 @@ pr_midxkey_compare (DB_MIDXKEY * mul1, DB_MIDXKEY * mul2, int do_coercion, int t
 	      c = dom1->type->index_cmpdisk (mem1, mem2, dom1, do_coercion, total_order, NULL);
 	    }
 	  else
-	    {			/* coercion and comparison
-				 * val1 and val2 have different domain
-				 * and it can be char-type and varchar-type mixed
-				 *
-				 * for do_coercion = 2, we need to process key comparing as char-type
-				 * in case that one of two arguments has varchar-type
-				 * if the other argument has char-type
-				 */
+	    { /* coercion and comparison
+	       * val1 and val2 have different domain
+	       * and it can be char-type and varchar-type mixed
+	       *
+	       * for do_coercion = 2, we need to process key comparing as char-type
+	       * in case that one of two arguments has varchar-type
+	       * if the other argument has char-type
+	       */
 	      do_coercion = 2;
 	      c = pr_midxkey_compare_element (mem1, mem2, dom1, dom2, do_coercion, total_order);
 	    }

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -7911,8 +7911,15 @@ pr_midxkey_compare (DB_MIDXKEY * mul1, DB_MIDXKEY * mul2, int do_coercion, int t
 	      c = dom1->type->index_cmpdisk (mem1, mem2, dom1, do_coercion, total_order, NULL);
 	    }
 	  else
-	    {			/* coercion and comparison */
-	      /* val1 and val2 have different domain */
+	    {			/* coercion and comparison
+				 * val1 and val2 have different domain
+				 * and it can be char-type and varchar-type mixed
+				 *
+				 * for do_coercion = 2, we need to process key comparing as char-type
+				 * in case that one of two arguments has varchar-type
+				 * if the other argument has char-type
+				 */
+	      do_coercion = 2;
 	      c = pr_midxkey_compare_element (mem1, mem2, dom1, dom2, do_coercion, total_order);
 	    }
 	}

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -12041,7 +12041,9 @@ mr_cmpval_char (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
 	      for (i = size1; i > 0; i--)
 		{
 		  if (string1[i - 1] != 0x20)
-		    break;
+		    {
+		      break;
+		    }
 		}
 	      size1 = i;
 	    }
@@ -12051,7 +12053,9 @@ mr_cmpval_char (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
 	      for (i = size2; i > 0; i--)
 		{
 		  if (string2[i - 1] != 0x20)
-		    break;
+		    {
+		      break;
+		    }
 		}
 	      size2 = i;
 	    }
@@ -12967,7 +12971,9 @@ mr_cmpval_nchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
 	      for (i = size1; i > 0; i--)
 		{
 		  if (string1[i - 1] != 0x20)
-		    break;
+		    {
+		      break;
+		    }
 		}
 	      size1 = i;
 	    }
@@ -12977,7 +12983,9 @@ mr_cmpval_nchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
 	      for (i = size2; i > 0; i--)
 		{
 		  if (string2[i - 1] != 0x20)
-		    break;
+		    {
+		      break;
+		    }
 		}
 	      size2 = i;
 	    }

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -7911,10 +7911,10 @@ pr_midxkey_compare (DB_MIDXKEY * mul1, DB_MIDXKEY * mul2, int do_coercion, int t
 	      c = dom1->type->index_cmpdisk (mem1, mem2, dom1, do_coercion, total_order, NULL);
 	    }
 	  else
-	    {			/* coercion and comparison
-				 * val1 and val2 have different domain
-				 * and it can be char-type and varchar-type mixed
-				 */
+	    {
+	      /* coercion and comparison
+	       * val1 and val2 have different domain
+	       */
 	      c = pr_midxkey_compare_element (mem1, mem2, dom1, dom2, do_coercion, total_order);
 	    }
 	}
@@ -11157,7 +11157,7 @@ mr_cmpval_string (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
 	  size1 = i;
 	}
 
-      if (value2->domain.char_info.type == DB_TYPE_NCHAR || value2->domain.char_info.type == DB_TYPE_NCHAR)
+      if (value2->domain.char_info.type == DB_TYPE_CHAR || value2->domain.char_info.type == DB_TYPE_NCHAR)
 	{
 	  for (i = size2; i > 0; i--)
 	    {
@@ -14147,7 +14147,7 @@ mr_cmpval_varnchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int t
 	  size1 = i;
 	}
 
-      if (value2->domain.char_info.type == DB_TYPE_NCHAR || value2->domain.char_info.type == DB_TYPE_NCHAR)
+      if (value2->domain.char_info.type == DB_TYPE_CHAR || value2->domain.char_info.type == DB_TYPE_NCHAR)
 	{
 	  for (i = size2; i > 0; i--)
 	    {

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -12018,31 +12018,33 @@ mr_cmpval_char (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
     {
       int i;
 
-      ti = false;
-
       /* TODO: We might need to make refactoring the code for corcing between CHAR and VARCHAR */
       /* 
        * from btree_get_prefix_separator
        * we need to process the ti-comparison for this case (CHAR and VARCHAR mixed)
        */
-      if (value1->domain.char_info.type == DB_TYPE_CHAR)
+      if (value1->domain.char_info.type != DB_TYPE_CHAR || value2->domain.char_info.type != DB_TYPE_CHAR)
 	{
-	  for (i = size1; i > 0; i--)
+	  ti = false;
+	  if (value1->domain.char_info.type == DB_TYPE_CHAR)
 	    {
-	      if (string1[i - 1] != 0x20)
-		break;
+	      for (i = size1; i > 0; i--)
+		{
+		  if (string1[i - 1] != 0x20)
+		    break;
+		}
+	      size1 = i;
 	    }
-	  size1 = i;
-	}
 
-      if (value2->domain.char_info.type == DB_TYPE_CHAR)
-	{
-	  for (i = size2; i > 0; i--)
+	  if (value2->domain.char_info.type == DB_TYPE_CHAR)
 	    {
-	      if (string2[i - 1] != 0x20)
-		break;
+	      for (i = size2; i > 0; i--)
+		{
+		  if (string2[i - 1] != 0x20)
+		    break;
+		}
+	      size2 = i;
 	    }
-	  size2 = i;
 	}
     }
 
@@ -12944,25 +12946,27 @@ mr_cmpval_nchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
     {
       int i;
 
-      ti = false;
-
-      if (value1->domain.char_info.type == DB_TYPE_CHAR)
+      if (value1->domain.char_info.type != DB_TYPE_NCHAR || value2->domain.char_info.type != DB_TYPE_NCHAR)
 	{
-	  for (i = size1; i > 0; i--)
+	  ti = false;
+	  if (value1->domain.char_info.type == DB_TYPE_NCHAR)
 	    {
-	      if (string1[i - 1] != 0x20)
-		break;
+	      for (i = size1; i > 0; i--)
+		{
+		  if (string1[i - 1] != 0x20)
+		    break;
+		}
+	      size1 = i;
 	    }
-	  size1 = i;
-	}
-      if (value2->domain.char_info.type == DB_TYPE_CHAR)
-	{
-	  for (i = size2; i > 0; i--)
+	  if (value2->domain.char_info.type == DB_TYPE_NCHAR)
 	    {
-	      if (string2[i - 1] != 0x20)
-		break;
+	      for (i = size2; i > 0; i--)
+		{
+		  if (string2[i - 1] != 0x20)
+		    break;
+		}
+	      size2 = i;
 	    }
-	  size2 = i;
 	}
     }
 

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -9364,7 +9364,7 @@ pt_check_enum_data_type (PARSER_CONTEXT * parser, PT_NODE * dt)
   int char_count = 0;
   unsigned char pad[2];
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   if (dt == NULL || dt->node_type != PT_DATA_TYPE || dt->type_enum != PT_TYPE_ENUMERATION)

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -355,7 +355,7 @@ db_string_compare (const DB_VALUE * string1, const DB_VALUE * string2, DB_VALUE 
   int cmp_result = 0;
   DB_TYPE str1_type, str2_type;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   /* Assert that DB_VALUE structures have been allocated. */
@@ -496,7 +496,7 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
   DB_VALUE tmp_result;
   int c;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   /* Assertions */
@@ -3709,7 +3709,7 @@ db_string_prefix_compare (const DB_VALUE * string1, const DB_VALUE * string2, DB
   int cmp_result = 0;
   DB_TYPE str1_type, str2_type;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   /* Assert that DB_VALUE structures have been allocated. */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -18740,12 +18740,6 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
 
       if (are_types_comparable)
 	{
-	  /*
-	   * for do_coercion = 2, we need to process key comparing as char-type
-	   * in case that one of two arguments has varchar-type
-	   * if the other argument has char-type
-	   */
-	  do_coercion = 2;
 	  c = key_domain->type->cmpval (key1, key2, do_coercion, total_order, NULL, key_domain->collation_id);
 	}
       else
@@ -18817,12 +18811,7 @@ btree_compare_individual_key_value (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN 
     }
 
   /* both are not null values */
-  /* 
-   * for do_coercion = 2, we need to process key comparing as char-type
-   * in case that one of two arguments has varchar-type
-   * if the other argument has char-type 
-   */
-  c = key_domain->type->cmpval (key1, key2, 2, 1, NULL, key_domain->collation_id);
+  c = key_domain->type->cmpval (key1, key2, 1, 1, NULL, key_domain->collation_id);
 
   if (key_domain->is_desc)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23812
related to http://jira.cubrid.org/browse/CBRD-23731

Environment:
1. Create a table by increasing columns from 2 to 30.
2. Insert/update/select sequentially with 10 threads targeting each table.
3. 10,000 times per thread.

Fail case:
When comparing each column value by executing the same select query that scans different indexes in the same transaction, in the select result comparison step, the result of the first query is failing with 0 tuple.

I found a weak point to compare with "midxkey" in b-tree index processing. The point is related to coercion at the different components consist of multi-column key. The comparing is performed by pr_midxkey_compare_element  through the pr_midxkey_compare function. I modified the coercion of pr_midxkey_compare to 2 to char-type compare in char-type and varchar-type mixed case. In modified version, the fail case is not occurred.