### PR TITLE
[CBRD-23828] Support the use of OID of temp file in HASH LIST SCAN.

### DIFF
--- a/src/base/memory_hash.c
+++ b/src/base/memory_hash.c
@@ -1568,7 +1568,10 @@ mht_get_hls (const MHT_HLS_TABLE * ht, const void *key, void **last)
 
   if (hentry != NULL)
     {
-      *((HENTRY_HLS_PTR *) last) = hentry;
+      if (last != NULL)
+	{
+	  *((HENTRY_HLS_PTR *) last) = hentry;
+	}
       return hentry->data;
     }
   return NULL;

--- a/src/base/memory_hash.c
+++ b/src/base/memory_hash.c
@@ -105,7 +105,7 @@ static int mht_rehash (MHT_TABLE * ht);
 
 static const void *mht_put_internal (MHT_TABLE * ht, const void *key, void *data, MHT_PUT_OPT opt);
 static const void *mht_put2_internal (MHT_TABLE * ht, const void *key, void *data, MHT_PUT_OPT opt);
-static const void *mht_put_orderly_internal (MHT_TABLE * ht, const void *key, void *data, MHT_PUT_OPT opt);
+static const void *mht_put_hls_internal (MHT_HLS_TABLE * ht, const void *key, void *data, MHT_PUT_OPT opt);
 
 static unsigned int mht_get_shiftmult32 (unsigned int key, const unsigned int ht_size);
 #if defined (ENABLE_UNUSED_FUNCTION)
@@ -968,6 +968,89 @@ mht_create (const char *name, int est_size, unsigned int (*hash_func) (const voi
 }
 
 /*
+ * mht_create_hls - create a hash table
+ *   return: hash table
+ *   name(in): name of hash table
+ *   est_size(in): estimated number of entries
+ *   hash_func(in): hash function
+ *   cmp_func(in): key compare function
+ *
+ * Note: Create a new hash table for HASH LIST SCAN.
+ *       The estimated number of entries for the hash table is fixed in HASH LIST SCAN.
+ *       rehashing hash table is not needed becaues of that.
+ *       key comparison is performed in executor.
+ */
+MHT_HLS_TABLE *
+mht_create_hls (const char *name, int est_size, unsigned int (*hash_func) (const void *key, unsigned int ht_size),
+	    int (*cmp_func) (const void *key1, const void *key2))
+{
+  MHT_HLS_TABLE *ht;
+  HENTRY_HLS_PTR *hvector;		/* Entries of hash table */
+  unsigned int ht_estsize;
+  size_t size;
+
+  assert (hash_func != NULL && cmp_func != NULL);
+
+  /* Get a good number of entries for hash table */
+  if (est_size <= 0)
+    {
+      est_size = 2;
+    }
+
+  ht_estsize = mht_calculate_htsize ((unsigned int) est_size);
+
+  /* Allocate the header information for hash table */
+  ht = (MHT_HLS_TABLE *) malloc (DB_SIZEOF (MHT_HLS_TABLE));
+  if (ht == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, DB_SIZEOF (MHT_HLS_TABLE));
+
+      return NULL;
+    }
+
+  /* Initialize the chunky memory manager */
+  ht->heap_id = db_create_fixed_heap (DB_SIZEOF (HENTRY_HLS), MAX (2, ht_estsize / 2 + 1));
+  if (ht->heap_id == 0)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, DB_SIZEOF (HENTRY_HLS));
+
+      free_and_init (ht);
+      return NULL;
+    }
+
+  /* Allocate the hash table entry pointers */
+  size = ht_estsize * DB_SIZEOF (*hvector);
+  hvector = (HENTRY_HLS_PTR *) malloc (size);
+  if (hvector == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, size);
+
+      db_destroy_fixed_heap (ht->heap_id);
+      free_and_init (ht);
+      return NULL;
+    }
+
+  ht->hash_func = hash_func;
+  ht->cmp_func = cmp_func;
+  ht->name = name;
+  ht->table = hvector;
+  ht->prealloc_entries = NULL;
+  ht->size = ht_estsize;
+  ht->nentries = 0;
+  ht->nprealloc_entries = 0;
+  ht->ncollisions = 0;
+  ht->build_lru_list = false;
+
+  /* Initialize each of the hash entries */
+  for (; ht_estsize > 0; ht_estsize--)
+    {
+      *hvector++ = NULL;
+    }
+
+  return ht;
+}
+
+/*
  * mht_rehash - rehash all entires of a hash table
  *   return: error code
  *   ht(in/out): hash table to rehash
@@ -1069,6 +1152,26 @@ mht_destroy (MHT_TABLE * ht)
 }
 
 /*
+ * mht_destroy_hls - destroy a hash table
+ *   return: void
+ *   ht(in/out): hash table
+ *
+ * Note: ht is set as a side effect
+ */
+void
+mht_destroy_hls (MHT_HLS_TABLE * ht)
+{
+  assert (ht != NULL);
+
+  free_and_init (ht->table);
+
+  /* release hash table entry storage */
+  db_destroy_fixed_heap (ht->heap_id);
+
+  free_and_init (ht);
+}
+
+/*
  * mht_clear - remove and free all entries of hash table
  *   return: error code
  *   ht(in/out): hash table
@@ -1120,6 +1223,59 @@ mht_clear (MHT_TABLE * ht, int (*rem_func) (const void *key, void *data, void *a
   ht->act_tail = NULL;
   ht->lru_head = NULL;
   ht->lru_tail = NULL;
+  ht->ncollisions = 0;
+  ht->nentries = 0;
+
+  return NO_ERROR;
+}
+
+/*
+ * mht_hls_clear - remove and free all entries of hash table
+ *   return: error code
+ *   ht(in/out): hash table
+ *   rem_func(in): removal function
+ *   func_args(in): removal function arguments
+ */
+int
+mht_clear_hls (MHT_HLS_TABLE * ht, int (*rem_func) (const void *key, void *data, void *args), void *func_args)
+{
+  HENTRY_HLS_PTR *hvector;		/* Entries of hash table */
+  HENTRY_HLS_PTR hentry;		/* A hash table entry. linked list */
+  HENTRY_HLS_PTR next_hentry = NULL;	/* Next element in linked list */
+  unsigned int i, error_code;
+
+  assert (ht != NULL);
+
+  /*
+   * Go over the hash table, removing all entries and setting the vector
+   * entries to NULL.
+   */
+  for (hvector = ht->table, i = 0; i < ht->size; hvector++, i++)
+    {
+      /* Go over the linked list for this hash table entry */
+      for (hentry = *hvector; hentry != NULL; hentry = next_hentry)
+	{
+	  /* free */
+	  if (rem_func)
+	    {
+	      error_code = (*rem_func) (NULL, hentry->data, func_args);
+	      if (error_code != NO_ERROR)
+		{
+		  return error_code;
+		}
+
+	      hentry->data = NULL;
+	    }
+
+	  next_hentry = hentry->next;
+	  /* Save the entries for future insertions */
+	  ht->nprealloc_entries++;
+	  hentry->next = ht->prealloc_entries;
+	  ht->prealloc_entries = hentry;
+	}
+      *hvector = NULL;
+    }
+
   ht->ncollisions = 0;
   ht->nentries = 0;
 
@@ -1191,6 +1347,63 @@ mht_dump (THREAD_ENTRY * thread_p, FILE * out_fp, const MHT_TABLE * ht, const in
 	}
     }
 
+  fprintf (out_fp, "\n");
+
+  return (cont);
+}
+
+/*
+ * mht_dump_hls - display all entries of hash table for HASH LIST SCAN
+ *   return: TRUE/FALSE
+ *   out_fp(in): FILE stream where to dump; if NULL, stdout
+ *   ht(in): hash table to print
+ *   print_id_opt(in): option for printing hash index vector id
+ *   print_func(in): supplied printing function
+ *   func_args(in): arguments to be passed to print_func
+ *
+ * Note: Dump the header of hash table, and for each entry in hash table,
+ *       call function "print_func" on three arguments: the key of the entry,
+ *       the data associated with the key, and args, in order to print the entry
+ *       print_id_opt - Print hash index ? Will run faster if we do not need to
+ *       print this information
+ */
+int
+mht_dump_hls (THREAD_ENTRY * thread_p, FILE * out_fp, const MHT_HLS_TABLE * ht, const int print_id_opt,
+	      int (*print_func) (THREAD_ENTRY * thread_p, FILE * fp, const void *data, void *args),
+	      void *func_args)
+{
+  HENTRY_HLS_PTR *hvector;		/* Entries of hash table */
+  HENTRY_HLS_PTR hentry;		/* A hash table entry. linked list */
+  unsigned int i;
+  int cont = TRUE;
+
+  assert (ht != NULL);
+
+  if (out_fp == NULL)
+    {
+      out_fp = stdout;
+    }
+
+  fprintf (out_fp,
+	   "HTABLE NAME = %s, SIZE = %d,\n" "NENTRIES = %d, NPREALLOC = %d, NCOLLISIONS = %d\n\n",
+	   ht->name, ht->size, ht->nentries, ht->nprealloc_entries, ht->ncollisions);
+
+  if (print_id_opt)
+    {
+      /* Need to print the index vector id. Therefore, scan the whole table */
+      for (hvector = ht->table, i = 0; i < ht->size; hvector++, i++)
+	{
+	  if (*hvector != NULL)
+	    {
+	      fprintf (out_fp, "HASH AT %d\n", i);
+	      /* Go over the linked list */
+	      for (hentry = *hvector; cont == TRUE && hentry != NULL; hentry = hentry->next)
+		{
+		  cont = (*print_func) (thread_p, out_fp, hentry->data, func_args);
+		}
+	    }
+	}
+    }
   fprintf (out_fp, "\n");
 
   return (cont);
@@ -1322,6 +1535,44 @@ mht_get2 (const MHT_TABLE * ht, const void *key, void **last)
 	}
     }
 
+  return NULL;
+}
+
+/*
+ * mht_get_hls - Find the next data associated with the key; Search the entry next
+ *            to the last result
+ *   return: the data associated with the key, or NULL if not found
+ *   ht(in):
+ *   key(in):
+ *   last(in/out):
+ *
+ * NOTE: This call does not affect the LRU list.
+ */
+void *
+mht_get_hls (const MHT_HLS_TABLE * ht, const void *key, void **last)
+{
+  unsigned int hash;
+  HENTRY_HLS_PTR hentry;
+
+  assert (ht != NULL && key != NULL);
+
+  /*
+   * Hash the key and make sure that the return value is between 0 and size of hash table
+   */
+  hash = (*ht->hash_func) (key, ht->size);
+  if (hash >= ht->size)
+    {
+      hash %= ht->size;
+    }
+
+  /* In HASH LIST SCAN, key comparison is performed in executor. */
+  hentry = ht->table[hash];
+
+  if (hentry != NULL)
+    {
+      *((HENTRY_HLS_PTR *) last) = hentry;
+      return hentry->data;
+    }
   return NULL;
 }
 
@@ -1475,10 +1726,10 @@ mht_put_new (MHT_TABLE * ht, const void *key, void *data)
 }
 
 const void *
-mht_put_orderly (MHT_TABLE * ht, const void *key, void *data)
+mht_put_hls (MHT_HLS_TABLE * ht, const void *key, void *data)
 {
   assert (ht != NULL && key != NULL);
-  return mht_put_orderly_internal (ht, key, data, MHT_OPT_INSERT_ONLY);
+  return mht_put_hls_internal (ht, key, data, MHT_OPT_INSERT_ONLY);
 }
 
 /*
@@ -2300,8 +2551,8 @@ mht_get_linear_hash32 (const unsigned int key, const unsigned int ht_size)
 #endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
- * mht_put_orderly_internal
- *   internal function for mht_put_orderly()
+ * mht_put_hls_internal
+ *   internal function for mht_put_hls()
  *   put data in the order.
  *   eliminates unnecessary logic to improve performance for hash list scan.
  *
@@ -2312,10 +2563,10 @@ mht_get_linear_hash32 (const unsigned int key, const unsigned int ht_size)
  *   opt(in): options;
  */
 static const void *
-mht_put_orderly_internal (MHT_TABLE * ht, const void *key, void *data, MHT_PUT_OPT opt)
+mht_put_hls_internal (MHT_HLS_TABLE * ht, const void *key, void *data, MHT_PUT_OPT opt)
 {
   unsigned int hash;
-  HENTRY_PTR hentry;
+  HENTRY_HLS_PTR hentry;
 
   assert (ht != NULL && key != NULL);
 
@@ -2338,29 +2589,27 @@ mht_put_orderly_internal (MHT_TABLE * ht, const void *key, void *data, MHT_PUT_O
     }
   else
     {
-      hentry = (HENTRY_PTR) db_fixed_alloc (ht->heap_id, DB_SIZEOF (HENTRY));
+      hentry = (HENTRY_HLS_PTR) db_fixed_alloc (ht->heap_id, DB_SIZEOF (HENTRY_HLS));
       if (hentry == NULL)
 	{
 	  return NULL;
 	}
     }
 
-  hentry->key = key;
   hentry->data = data;
 
-  /* To input in order, use the act_next variable as tail. */
-  /* lru and act-related logics are not used for hash list scan, so delete them. */
+  /* To input in order, use the tail node. */
   if (ht->table[hash] == NULL)
     {
       ht->table[hash] = hentry;
     }
   else
     {
-      ht->table[hash]->act_next->next = hentry;
+      ht->table[hash]->tail->next = hentry;
       ht->ncollisions++;
     }
   hentry->next = NULL;
-  ht->table[hash]->act_next = hentry;
+  ht->table[hash]->tail = hentry;
   ht->nentries++;
 
   return key;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5530,6 +5530,7 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 	      if (PT_IS_STRING_TYPE (common_type) && PT_IS_STRING_TYPE (temp->type_enum))
 		{
 		  /* A bigger codesets's number can represent more characters. */
+		  /* to_do : check to use functions pt_common_collation() or pt_make_cast_with_compatble_info(). */
 		  if (units < temp->info.data_type.units)
 		    {
 		      units = temp->info.data_type.units;

--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -248,7 +248,7 @@ qdata_print_hash_scan_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *dat
   HASH_SCAN_VALUE *data2 = (HASH_SCAN_VALUE *) data;
   int hash_list_scan_yn = *((int *) args);
 
-  if (!data2)
+  if (data2 == NULL || args == NULL)
     {
       return false;
     }
@@ -354,6 +354,10 @@ qdata_copy_hscan_key_without_alloc (cubthread::entry * thread_p, HASH_SCAN_KEY *
   DB_TYPE vtype1, vtype2;
   TP_DOMAIN_STATUS status = DOMAIN_COMPATIBLE;
 
+  if (key == NULL)
+    {
+      return NULL;
+    }
   if (new_key)
     {
       /* copy values */

--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -245,13 +245,12 @@ qdata_build_hscan_key (THREAD_ENTRY * thread_p, val_descr * vd, REGU_VARIABLE_LI
  *   args(in)   :
  */
 int
-qdata_print_hash_scan_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *key, void *data, void *args)
+qdata_print_hash_scan_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *data, void *args)
 {
   HASH_SCAN_VALUE *data2 = (HASH_SCAN_VALUE *) data;
-  HASH_SCAN_KEY *key2 = (HASH_SCAN_KEY *) key;
   QFILE_TUPLE_VALUE_TYPE_LIST *list = (QFILE_TUPLE_VALUE_TYPE_LIST *) args;
 
-  if (!data2 || !key2)
+  if (!data2)
     {
       return false;
     }
@@ -261,16 +260,10 @@ qdata_print_hash_scan_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *key
     }
 
   fprintf (fp, "LIST_CACHE_ENTRY (%p) {\n", data);
-  /* temporarily disable */
+  /* temporarily disable. I will fix after fixing hash_list_scan_yn */
   /*fprintf (fp, "data_size = [%d]  data = [%.*s]\n", QFILE_GET_TUPLE_LENGTH (data2->tuple),
 	   QFILE_GET_TUPLE_LENGTH (data2->tuple), data2->tuple);*/
 
-  fprintf (fp, "key : ");
-  for (int i = 0; i < key2->val_count; i++)
-    {
-      db_fprint_value (fp, key2->values[i]);
-      fprintf (fp, " ");
-    }
   fprintf (fp, "\n}");
 
   return true;

--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -248,7 +248,7 @@ int
 qdata_print_hash_scan_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *data, void *args)
 {
   HASH_SCAN_VALUE *data2 = (HASH_SCAN_VALUE *) data;
-  QFILE_TUPLE_VALUE_TYPE_LIST *list = (QFILE_TUPLE_VALUE_TYPE_LIST *) args;
+  int hash_list_scan_yn = *((int *) args);
 
   if (!data2)
     {
@@ -260,9 +260,17 @@ qdata_print_hash_scan_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *dat
     }
 
   fprintf (fp, "LIST_CACHE_ENTRY (%p) {\n", data);
-  /* temporarily disable. I will fix after fixing hash_list_scan_yn */
-  /*fprintf (fp, "data_size = [%d]  data = [%.*s]\n", QFILE_GET_TUPLE_LENGTH (data2->tuple),
-	   QFILE_GET_TUPLE_LENGTH (data2->tuple), data2->tuple);*/
+  if (hash_list_scan_yn == 1)
+    {
+      fprintf (fp, "data_size = [%d]  data = [%.*s]\n", QFILE_GET_TUPLE_LENGTH (data2->data),
+	       QFILE_GET_TUPLE_LENGTH (data2->data), data2->data);
+    }
+  else if (hash_list_scan_yn == 2)
+    {
+      QFILE_TUPLE_SIMPLE_POS *simple_pos = (QFILE_TUPLE_SIMPLE_POS *) data2->data;
+      fprintf (fp, "pageid = [%d]  volid = [%d]  offset = [%d]\n", simple_pos->vpid.pageid,
+	       simple_pos->vpid.volid, simple_pos->offset);
+    }
 
   fprintf (fp, "\n}");
 

--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -343,7 +343,7 @@ qdata_copy_hscan_key (cubthread::entry * thread_p, HASH_SCAN_KEY * key, REGU_VAR
 }
 
 /*
- * qdata_alloc_agg_hkey () - allocate new hash aggregate key
+ * qdata_alloc_hscan_value () - allocate new hash value
  *   returns: pointer to new structure or NULL on error
  *   thread_p(in): thread
  */
@@ -374,6 +374,32 @@ qdata_alloc_hscan_value (cubthread::entry * thread_p, QFILE_TUPLE tpl)
       qdata_free_hscan_value (thread_p, value);
       return NULL;
     }
+  return value;
+}
+
+/*
+ * qdata_alloc_hscan_value_OID () - allocate new hash OID value
+ *   returns: pointer to new structure or NULL on error
+ *   thread_p(in): thread
+ */
+HASH_SCAN_VALUE *
+qdata_alloc_hscan_value_OID (cubthread::entry * thread_p, QFILE_LIST_SCAN_ID * scan_id_p)
+{
+  HASH_SCAN_VALUE *value;
+
+  /* alloc structure */
+  value = (HASH_SCAN_VALUE *) db_private_alloc (thread_p, sizeof (HASH_SCAN_VALUE));
+  if (value == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (HASH_SCAN_VALUE));
+      return NULL;
+    }
+
+  /* save position */
+  value->simple_pos.offset = scan_id_p->curr_offset;
+  value->simple_pos.vpid = scan_id_p->curr_vpid;
+  value->tuple = NULL;
+
   return value;
 }
 

--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -246,7 +246,7 @@ int
 qdata_print_hash_scan_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *data, void *args)
 {
   HASH_SCAN_VALUE *data2 = (HASH_SCAN_VALUE *) data;
-  int hash_list_scan_yn = *((int *) args);
+  int hash_list_scan_yn = args ? *((int *) args) : 0;
 
   if (data2 == NULL || args == NULL)
     {

--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -258,12 +258,12 @@ qdata_print_hash_scan_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *dat
     }
 
   fprintf (fp, "LIST_CACHE_ENTRY (%p) {\n", data);
-  if (hash_list_scan_yn == IN_MEMORY)
+  if (hash_list_scan_yn == HASH_METH_IN_MEM)
     {
       fprintf (fp, "data_size = [%d]  data = [%.*s]\n", QFILE_GET_TUPLE_LENGTH (data2->tuple),
 	       QFILE_GET_TUPLE_LENGTH (data2->tuple), data2->tuple);
     }
-  else if (hash_list_scan_yn == HYBRID_IN_MEMORY)
+  else if (hash_list_scan_yn == HASH_METH_HYBRID)
     {
       fprintf (fp, "pageid = [%d]  volid = [%d]  offset = [%d]\n", data2->pos->vpid.pageid,
 	       data2->pos->vpid.volid, data2->pos->offset);

--- a/src/query/query_hash_scan.h
+++ b/src/query/query_hash_scan.h
@@ -1,5 +1,5 @@
 /*
- * 
+ *
  * Copyright 2016 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,6 +41,16 @@
     } \
   while (0)
 
+/* kind of hash list scan method */
+enum hash_method
+{
+  NOT_USE = 0,
+  IN_MEMORY = 1,
+  HYBRID_IN_MEMORY = 2,
+  HASH_TEMP_FILE = 3 /* not used */
+};
+typedef enum hash_method HASH_METHOD;
+
 /* Tuple position structure for hash value */
 typedef struct qfile_tuple_simple_pos QFILE_TUPLE_SIMPLE_POS;
 struct qfile_tuple_simple_pos
@@ -50,10 +60,12 @@ struct qfile_tuple_simple_pos
 };
 
 /* hash scan value */
-typedef struct hash_scan_value HASH_SCAN_VALUE;
-struct hash_scan_value
+typedef union hash_scan_value HASH_SCAN_VALUE;
+union hash_scan_value
 {
-  void *data;
+  void *data;			/* for free() */
+  QFILE_TUPLE_SIMPLE_POS *pos;	/* tuple position of temp file */
+  QFILE_TUPLE tuple;		/* tuple data */
 };
 
 /* hash scan key */

--- a/src/query/query_hash_scan.h
+++ b/src/query/query_hash_scan.h
@@ -44,10 +44,10 @@
 /* kind of hash list scan method */
 enum hash_method
 {
-  NOT_USE = 0,
-  IN_MEMORY = 1,
-  HYBRID_IN_MEMORY = 2,
-  HASH_TEMP_FILE = 3 /* not used */
+  HASH_METH_NOT_USE = 0,
+  HASH_METH_IN_MEM = 1,
+  HASH_METH_HYBRID = 2,
+  HASH_METH_HASH_FILE = 3 /* not used */
 };
 typedef enum hash_method HASH_METHOD;
 

--- a/src/query/query_hash_scan.h
+++ b/src/query/query_hash_scan.h
@@ -75,6 +75,7 @@ struct hash_list_scan
   regu_variable_list_node *probe_regu_list;	/* regulator variable list */
   mht_hls_table *hash_table;	/* memory hash table for hash list scan */
   hash_scan_key *temp_key;	/* temp probe key */
+  hash_scan_key *temp_new_key;	/* temp probe key with db_value */
   HENTRY_HLS_PTR curr_hash_entry;	/* current hash entry */
 };
 
@@ -92,6 +93,8 @@ int qdata_build_hscan_key (THREAD_ENTRY * thread_p, val_descr * vd, REGU_VARIABL
 unsigned int qdata_hash_scan_key (const void *key, unsigned int ht_size);
 HASH_SCAN_KEY *qdata_copy_hscan_key (THREAD_ENTRY * thread_p, HASH_SCAN_KEY * key,
 				     REGU_VARIABLE_LIST probe_regu_list, val_descr * vd);
+HASH_SCAN_KEY *qdata_copy_hscan_key_without_alloc (THREAD_ENTRY * thread_p, HASH_SCAN_KEY * key,
+						   REGU_VARIABLE_LIST probe_regu_list, HASH_SCAN_KEY * new_key);
 
 int qdata_print_hash_scan_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *data, void *args);
 

--- a/src/query/query_hash_scan.h
+++ b/src/query/query_hash_scan.h
@@ -70,7 +70,7 @@ struct hash_scan_key
 typedef struct hash_list_scan HASH_LIST_SCAN;
 struct hash_list_scan
 {
-  bool hash_list_scan_yn;	/* Is hash list scan possible? */
+  int hash_list_scan_yn;	/* Is hash list scan possible? */
   regu_variable_list_node *build_regu_list;	/* regulator variable list */
   regu_variable_list_node *probe_regu_list;	/* regulator variable list */
   mht_hls_table *hash_table;	/* memory hash table for hash list scan */

--- a/src/query/query_hash_scan.h
+++ b/src/query/query_hash_scan.h
@@ -30,6 +30,18 @@
 
 #include "regu_var.hpp"
 
+#define MAKE_TUPLE_POSTION(tuple_pos, simple_pos, scan_id_p) \
+  do \
+    { \
+      tuple_pos.status = scan_id_p->status; \
+      tuple_pos.position = S_ON; \
+      tuple_pos.vpid = simple_pos.vpid; \
+      tuple_pos.offset = simple_pos.offset; \
+      tuple_pos.tpl = NULL; \
+      tuple_pos.tplno = 0; /* If tplno is needed, add it from scan_build_hash_list_scan() */ \
+    } \
+  while (0)
+
 /* Tuple position structure for hash value */
 typedef struct qfile_tuple_simple_pos QFILE_TUPLE_SIMPLE_POS;
 struct qfile_tuple_simple_pos

--- a/src/query/query_hash_scan.h
+++ b/src/query/query_hash_scan.h
@@ -35,8 +35,8 @@
     { \
       tuple_pos.status = scan_id_p->status; \
       tuple_pos.position = S_ON; \
-      tuple_pos.vpid = simple_pos.vpid; \
-      tuple_pos.offset = simple_pos.offset; \
+      tuple_pos.vpid = simple_pos->vpid; \
+      tuple_pos.offset = simple_pos->offset; \
       tuple_pos.tpl = NULL; \
       tuple_pos.tplno = 0; /* If tplno is needed, add it from scan_build_hash_list_scan() */ \
     } \
@@ -54,8 +54,9 @@ struct qfile_tuple_simple_pos
 typedef struct hash_scan_value HASH_SCAN_VALUE;
 struct hash_scan_value
 {
-  QFILE_TUPLE tuple;		/* tuple */
-  QFILE_TUPLE_SIMPLE_POS simple_pos; /* tuple simple position */
+  /*QFILE_TUPLE tuple;		/* tuple */
+  /*QFILE_TUPLE_SIMPLE_POS simple_pos; /* tuple simple position */
+  void *data;
 };
 
 /* hash scan key */

--- a/src/query/query_hash_scan.h
+++ b/src/query/query_hash_scan.h
@@ -54,8 +54,6 @@ struct qfile_tuple_simple_pos
 typedef struct hash_scan_value HASH_SCAN_VALUE;
 struct hash_scan_value
 {
-  /*QFILE_TUPLE tuple;		/* tuple */
-  /*QFILE_TUPLE_SIMPLE_POS simple_pos; /* tuple simple position */
   void *data;
 };
 
@@ -75,9 +73,9 @@ struct hash_list_scan
   bool hash_list_scan_yn;	/* Is hash list scan possible? */
   regu_variable_list_node *build_regu_list;	/* regulator variable list */
   regu_variable_list_node *probe_regu_list;	/* regulator variable list */
-  mht_table *hash_table;	/* memory hash table for hash list scan */
+  mht_hls_table *hash_table;	/* memory hash table for hash list scan */
   hash_scan_key *temp_key;	/* temp probe key */
-  HENTRY_PTR curr_hash_entry;	/* current hash entry */
+  HENTRY_HLS_PTR curr_hash_entry;	/* current hash entry */
 };
 
 HASH_SCAN_KEY *qdata_alloc_hscan_key (THREAD_ENTRY * thread_p, int val_cnt, bool alloc_vals);
@@ -95,6 +93,6 @@ unsigned int qdata_hash_scan_key (const void *key, unsigned int ht_size);
 HASH_SCAN_KEY *qdata_copy_hscan_key (THREAD_ENTRY * thread_p, HASH_SCAN_KEY * key,
 				     REGU_VARIABLE_LIST probe_regu_list, val_descr * vd);
 
-int qdata_print_hash_scan_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *key, void *data, void *args);
+int qdata_print_hash_scan_entry (THREAD_ENTRY * thread_p, FILE * fp, const void *data, void *args);
 
 #endif /* _QUERY_HASH_SCAN_H_ */

--- a/src/query/query_hash_scan.h
+++ b/src/query/query_hash_scan.h
@@ -81,13 +81,14 @@ struct hash_scan_key
 typedef struct hash_list_scan HASH_LIST_SCAN;
 struct hash_list_scan
 {
-  int hash_list_scan_yn;	/* Is hash list scan possible? */
   regu_variable_list_node *build_regu_list;	/* regulator variable list */
   regu_variable_list_node *probe_regu_list;	/* regulator variable list */
   mht_hls_table *hash_table;	/* memory hash table for hash list scan */
   hash_scan_key *temp_key;	/* temp probe key */
   hash_scan_key *temp_new_key;	/* temp probe key with db_value */
   HENTRY_HLS_PTR curr_hash_entry;	/* current hash entry */
+  int hash_list_scan_yn;	/* Is hash list scan possible? */
+  bool need_coerce_type;	/* Are the types of probe and build different? */
 };
 
 HASH_SCAN_KEY *qdata_alloc_hscan_key (THREAD_ENTRY * thread_p, int val_cnt, bool alloc_vals);

--- a/src/query/query_hash_scan.h
+++ b/src/query/query_hash_scan.h
@@ -30,11 +30,20 @@
 
 #include "regu_var.hpp"
 
+/* Tuple position structure for hash value */
+typedef struct qfile_tuple_simple_pos QFILE_TUPLE_SIMPLE_POS;
+struct qfile_tuple_simple_pos
+{
+  VPID vpid;			/* Real tuple page identifier */
+  int offset;			/* Tuple offset inside the page */
+};
+
 /* hash scan value */
 typedef struct hash_scan_value HASH_SCAN_VALUE;
 struct hash_scan_value
 {
   QFILE_TUPLE tuple;		/* tuple */
+  QFILE_TUPLE_SIMPLE_POS simple_pos; /* tuple simple position */
 };
 
 /* hash scan key */
@@ -60,6 +69,7 @@ struct hash_list_scan
 
 HASH_SCAN_KEY *qdata_alloc_hscan_key (THREAD_ENTRY * thread_p, int val_cnt, bool alloc_vals);
 HASH_SCAN_VALUE *qdata_alloc_hscan_value (THREAD_ENTRY * thread_p, QFILE_TUPLE tpl);
+HASH_SCAN_VALUE *qdata_alloc_hscan_value_OID (THREAD_ENTRY * thread_p, QFILE_LIST_SCAN_ID * scan_id_p);
 
 void qdata_free_hscan_key (THREAD_ENTRY * thread_p, HASH_SCAN_KEY * key, int val_count);
 void qdata_free_hscan_value (THREAD_ENTRY * thread_p, HASH_SCAN_VALUE * value);

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -7936,7 +7936,7 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
   HASH_SCAN_VALUE *hvalue;
   QFILE_LIST_SCAN_ID *scan_id_p;
   QFILE_TUPLE_POSITION tuple_pos;
-  QFILE_TUPLE_SIMPLE_POS simple_pos;
+  QFILE_TUPLE_SIMPLE_POS *simple_pos;
   QFILE_TUPLE_RECORD tplrec = { NULL, 0 };
 
   llsidp = &scan_id->s.llsid;
@@ -7964,11 +7964,11 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
 	    }
 	  if (0)
 	    {
-	      *tuple = hvalue->tuple;
+	      *tuple = (QFILE_TUPLE) hvalue->data;
 	    }
 	  else
 	    {
-	      simple_pos = hvalue->simple_pos;
+	      simple_pos = (QFILE_TUPLE_SIMPLE_POS *) hvalue->data;
 	      MAKE_TUPLE_POSTION(tuple_pos, simple_pos, scan_id_p);
 
 	      if (qfile_jump_scan_tuple_position (thread_p, scan_id_p, &tuple_pos, &tplrec, PEEK) != S_SUCCESS)
@@ -7992,11 +7992,11 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
 	  llsidp->hlsid.curr_hash_entry = llsidp->hlsid.curr_hash_entry->next;
 	  if (0)
 	    {
-	      *tuple = ((HASH_SCAN_VALUE *) llsidp->hlsid.curr_hash_entry->data)->tuple;
+	      *tuple = (QFILE_TUPLE) ((HASH_SCAN_VALUE *) llsidp->hlsid.curr_hash_entry->data)->data;
 	    }
 	  else
 	    {
-	      simple_pos = ((HASH_SCAN_VALUE *) llsidp->hlsid.curr_hash_entry->data)->simple_pos;
+	      simple_pos = (QFILE_TUPLE_SIMPLE_POS *) ((HASH_SCAN_VALUE *) llsidp->hlsid.curr_hash_entry->data)->data;
 	      MAKE_TUPLE_POSTION(tuple_pos, simple_pos, scan_id_p);
 
 	      if (qfile_jump_scan_tuple_position (thread_p, scan_id_p, &tuple_pos, &tplrec, PEEK) != S_SUCCESS)

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -7667,11 +7667,11 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
     case S_LIST_SCAN:
       if (scan_id->s.llsid.hlsid.hash_list_scan_yn == 1)
 	{
-	  fprintf (fp, "(hash temp, buildtime : %d,", TO_MSEC (scan_id->scan_stats.elapsed_hash_build));
+	  fprintf (fp, "(hash temp buildtime : %d,", TO_MSEC (scan_id->scan_stats.elapsed_hash_build));
 	}
       else if (scan_id->s.llsid.hlsid.hash_list_scan_yn == 2)
 	{
-	  fprintf (fp, "(hash temp(h), buildtime : %d,", TO_MSEC (scan_id->scan_stats.elapsed_hash_build));
+	  fprintf (fp, "(hash temp(h) buildtime : %d,", TO_MSEC (scan_id->scan_stats.elapsed_hash_build));
 	}
       else
 	{

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3671,7 +3671,7 @@ scan_open_list_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 
   /* check if hash list scan is possible? */
   llsidp->hlsid.hash_list_scan_yn = check_hash_list_scan (llsidp, &val_cnt, hash_list_scan_yn);
-  if (llsidp->hlsid.hash_list_scan_yn != NOT_USE)
+  if (llsidp->hlsid.hash_list_scan_yn != HASH_METH_NOT_USE)
     {
       bool on_trace;
       TSC_TICKS start_tick, end_tick;
@@ -5012,7 +5012,7 @@ scan_next_scan_local (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
       break;
 
     case S_LIST_SCAN:
-      if (scan_id->s.llsid.hlsid.hash_list_scan_yn != NOT_USE)
+      if (scan_id->s.llsid.hlsid.hash_list_scan_yn != HASH_METH_NOT_USE)
 	{
 	  status = scan_next_hash_list_scan (thread_p, scan_id);
 	}
@@ -7673,11 +7673,11 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
       break;
 
     case S_LIST_SCAN:
-      if (scan_id->s.llsid.hlsid.hash_list_scan_yn == IN_MEMORY)
+      if (scan_id->s.llsid.hlsid.hash_list_scan_yn == HASH_METH_IN_MEM)
 	{
 	  fprintf (fp, "(hash temp buildtime : %d,", TO_MSEC (scan_id->scan_stats.elapsed_hash_build));
 	}
-      else if (scan_id->s.llsid.hlsid.hash_list_scan_yn == HYBRID_IN_MEMORY)
+      else if (scan_id->s.llsid.hlsid.hash_list_scan_yn == HASH_METH_HYBRID)
 	{
 	  fprintf (fp, "(hash temp(h) buildtime : %d,", TO_MSEC (scan_id->scan_stats.elapsed_hash_build));
 	}
@@ -7816,11 +7816,11 @@ scan_build_hash_list_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	}
 
       /* create new value */
-      if (llsidp->hlsid.hash_list_scan_yn == IN_MEMORY)
+      if (llsidp->hlsid.hash_list_scan_yn == HASH_METH_IN_MEM)
 	{
 	  new_value = qdata_alloc_hscan_value (thread_p, tplrec.tpl);
 	}
-      else if (llsidp->hlsid.hash_list_scan_yn == HYBRID_IN_MEMORY)
+      else if (llsidp->hlsid.hash_list_scan_yn == HASH_METH_HYBRID)
 	{
 	  new_value = qdata_alloc_hscan_value_OID (thread_p, &llsidp->lsid);
 	}
@@ -7985,11 +7985,11 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
 	    {
 	      return S_END;
 	    }
-	  if (llsidp->hlsid.hash_list_scan_yn == IN_MEMORY)
+	  if (llsidp->hlsid.hash_list_scan_yn == HASH_METH_IN_MEM)
 	    {
 	      *tuple = hvalue->tuple;
 	    }
-	  else if (llsidp->hlsid.hash_list_scan_yn == HYBRID_IN_MEMORY)
+	  else if (llsidp->hlsid.hash_list_scan_yn == HASH_METH_HYBRID)
 	    {
 	      MAKE_TUPLE_POSTION(tuple_pos, hvalue->pos, scan_id_p);
 	      if (qfile_jump_scan_tuple_position (thread_p, scan_id_p, &tuple_pos, &tplrec, PEEK) != S_SUCCESS)
@@ -8015,11 +8015,11 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
       if (llsidp->hlsid.curr_hash_entry->next)
 	{
 	  llsidp->hlsid.curr_hash_entry = llsidp->hlsid.curr_hash_entry->next;
-	  if (llsidp->hlsid.hash_list_scan_yn == IN_MEMORY)
+	  if (llsidp->hlsid.hash_list_scan_yn == HASH_METH_IN_MEM)
 	    {
 	      *tuple = ((HASH_SCAN_VALUE *) llsidp->hlsid.curr_hash_entry->data)->tuple;
 	    }
-	  else if (llsidp->hlsid.hash_list_scan_yn == HYBRID_IN_MEMORY)
+	  else if (llsidp->hlsid.hash_list_scan_yn == HASH_METH_HYBRID)
 	    {
 	      simple_pos = ((HASH_SCAN_VALUE *) llsidp->hlsid.curr_hash_entry->data)->pos;
 	      MAKE_TUPLE_POSTION(tuple_pos, simple_pos, scan_id_p);
@@ -8038,7 +8038,7 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
 	}
       else
 	{
-	  if (llsidp->hlsid.hash_list_scan_yn == HYBRID_IN_MEMORY)
+	  if (llsidp->hlsid.hash_list_scan_yn == HASH_METH_HYBRID)
 	    {
 	      qmgr_free_old_page_and_init (thread_p, scan_id_p->curr_pgptr, scan_id_p->list_id.tfile_vfid);
 	    }
@@ -8082,18 +8082,18 @@ check_hash_list_scan (LLIST_SCAN_ID * llsidp, int *val_cnt, int hash_list_scan_y
   /* no_hash_list_scan sql hint check */
   if (hash_list_scan_yn == 0)
     {
-      return NOT_USE;
+      return HASH_METH_NOT_USE;
     }
 
   /* count of tuple of list file > 0 */
   if (llsidp->list_id->tuple_cnt <= 0)
     {
-      return NOT_USE;
+      return HASH_METH_NOT_USE;
     }
   /* regu_list_build, regu_list_probe is not null */
   if (llsidp->hlsid.build_regu_list == NULL || llsidp->hlsid.probe_regu_list == NULL)
     {
-      return NOT_USE;
+      return HASH_METH_NOT_USE;
     }
 
   build = llsidp->hlsid.build_regu_list;
@@ -8110,7 +8110,7 @@ check_hash_list_scan (LLIST_SCAN_ID * llsidp, int *val_cnt, int hash_list_scan_y
       if (((vtype1 == DB_TYPE_OBJECT || vtype1 == DB_TYPE_VOBJ) && vtype2 == DB_TYPE_OID) ||
 	  ((vtype2 == DB_TYPE_OBJECT || vtype2 == DB_TYPE_VOBJ) && vtype1 == DB_TYPE_OID))
 	{
-	  return NOT_USE;
+	  return HASH_METH_NOT_USE;
 	}
       if (vtype1 != vtype2)
 	{
@@ -8122,7 +8122,7 @@ check_hash_list_scan (LLIST_SCAN_ID * llsidp, int *val_cnt, int hash_list_scan_y
   /* The number of probe regu_var and build regu match */
   if (build != NULL || probe != NULL)
     {
-      return NOT_USE;
+      return HASH_METH_NOT_USE;
     }
   *val_cnt = build_cnt;
 
@@ -8132,19 +8132,19 @@ check_hash_list_scan (LLIST_SCAN_ID * llsidp, int *val_cnt, int hash_list_scan_y
   /* list file size check */
   if ((UINT64) llsidp->list_id->page_cnt * DB_PAGESIZE <= mem_limit)
     {
-      return IN_MEMORY;
+      return HASH_METH_IN_MEM;
     }
   else if ((UINT64) llsidp->list_id->tuple_cnt * (sizeof(HENTRY_HLS) + sizeof(QFILE_TUPLE_SIMPLE_POS)) <= mem_limit)
     {
       /* bytes of 1 row = sizeof(HENTRY_HLS) + sizeof(QFILE_TUPLE_SIMPLE_POS) = 36 bytes (64bit) */
       /* HENTRY_HLS = pointer(8bytes) * 3 = 24 bytes*/
       /* SIMPLE_POS = pageid(4bytes) + voldid(2bytes) + padding(2bytes) + offset(4bytes) = 12 bytes*/
-      return HYBRID_IN_MEMORY;
+      return HASH_METH_HYBRID;
     }
   else
     {
-      return NOT_USE;
+      return HASH_METH_NOT_USE;
     }
 
-  return NOT_USE;
+  return HASH_METH_NOT_USE;
 }

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -7936,6 +7936,7 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
   HASH_SCAN_VALUE *hvalue;
   QFILE_LIST_SCAN_ID *scan_id_p;
   QFILE_TUPLE_POSITION tuple_pos;
+  QFILE_TUPLE_SIMPLE_POS simple_pos;
   QFILE_TUPLE_RECORD tplrec = { NULL, 0 };
 
   llsidp = &scan_id->s.llsid;
@@ -7967,13 +7968,8 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
 	    }
 	  else
 	    {
-	      tuple_pos.status = scan_id_p->status;
-	      tuple_pos.position = S_ON;
-	      tuple_pos.vpid = hvalue->simple_pos.vpid;
-	      tuple_pos.offset = hvalue->simple_pos.offset;
-	      tuple_pos.tpl = NULL;
-	      /* If tplno is needed, add it from scan_build_hash_list_scan() */
-	      tuple_pos.tplno = 0;
+	      simple_pos = hvalue->simple_pos;
+	      MAKE_TUPLE_POSTION(tuple_pos, simple_pos, scan_id_p);
 
 	      if (qfile_jump_scan_tuple_position (thread_p, scan_id_p, &tuple_pos, &tplrec, PEEK) != S_SUCCESS)
 		{
@@ -8000,12 +7996,8 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
 	    }
 	  else
 	    {
-	      tuple_pos.status = scan_id_p->status;
-	      tuple_pos.position = S_ON;
-	      tuple_pos.vpid = ((HASH_SCAN_VALUE *) llsidp->hlsid.curr_hash_entry->data)->simple_pos.vpid;
-	      tuple_pos.offset = ((HASH_SCAN_VALUE *) llsidp->hlsid.curr_hash_entry->data)->simple_pos.offset;
-	      tuple_pos.tpl = NULL;
-	      tuple_pos.tplno = 0;
+	      simple_pos = ((HASH_SCAN_VALUE *) llsidp->hlsid.curr_hash_entry->data)->simple_pos;
+	      MAKE_TUPLE_POSTION(tuple_pos, simple_pos, scan_id_p);
 
 	      if (qfile_jump_scan_tuple_position (thread_p, scan_id_p, &tuple_pos, &tplrec, PEEK) != S_SUCCESS)
 		{

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3686,7 +3686,7 @@ scan_open_list_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 
       /* create hash table */
       llsidp->hlsid.hash_table =
-	mht_create ("Hash List Scan", llsidp->list_id->tuple_cnt, qdata_hash_scan_key, qdata_hscan_key_eq);
+	mht_create_hls ("Hash List Scan", llsidp->list_id->tuple_cnt, qdata_hash_scan_key, qdata_hscan_key_eq);
       if (llsidp->hlsid.hash_table == NULL)
 	{
 	  return S_ERROR;
@@ -4813,12 +4813,12 @@ scan_close_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
       if (llsidp->hlsid.hash_table != NULL)
 	{
 #if 0
-	  (void) mht_dump (thread_p, stdout, llsidp->hlsid.hash_table, -1, qdata_print_hash_scan_entry, NULL);
+	  (void) mht_dump_hls (thread_p, stdout, llsidp->hlsid.hash_table, 1, qdata_print_hash_scan_entry, NULL);
 	  printf ("temp file : tuple count = %d, file_size = %dK\n", llsidp->list_id->tuple_cnt,
 		  llsidp->list_id->page_cnt * 16);
 #endif
-	  mht_clear (llsidp->hlsid.hash_table, qdata_free_hscan_entry, (void *) thread_p);
-	  mht_destroy (llsidp->hlsid.hash_table);
+	  mht_clear_hls (llsidp->hlsid.hash_table, qdata_free_hscan_entry, (void *) thread_p);
+	  mht_destroy_hls (llsidp->hlsid.hash_table);
 	}
       /* free temp keys and values */
       if (llsidp->hlsid.temp_key != NULL)
@@ -7811,7 +7811,7 @@ scan_build_hash_list_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	  return S_ERROR;
 	}
       /* add to hash table */
-      if (mht_put_orderly (llsidp->hlsid.hash_table, (void *) new_key, (void *) new_value) == NULL)
+      if (mht_put_hls (llsidp->hlsid.hash_table, (void *) new_key, (void *) new_value) == NULL)
 	{
 	  return S_ERROR;
 	}
@@ -7957,7 +7957,7 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
 
 	  /* get value from hash table */
 	  hvalue =
-	    (HASH_SCAN_VALUE *) mht_get2 (llsidp->hlsid.hash_table, key, (void **) &llsidp->hlsid.curr_hash_entry);
+	    (HASH_SCAN_VALUE *) mht_get_hls (llsidp->hlsid.hash_table, key, (void **) &llsidp->hlsid.curr_hash_entry);
 	  if (hvalue == NULL)
 	    {
 	      return S_END;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -4813,7 +4813,8 @@ scan_close_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
       if (llsidp->hlsid.hash_table != NULL)
 	{
 #if 0
-	  (void) mht_dump_hls (thread_p, stdout, llsidp->hlsid.hash_table, 1, qdata_print_hash_scan_entry, NULL);
+	  (void) mht_dump_hls (thread_p, stdout, llsidp->hlsid.hash_table, 1, qdata_print_hash_scan_entry,
+			       (void *) &llsidp->hlsid.hash_list_scan_yn);
 	  printf ("temp file : tuple count = %d, file_size = %dK\n", llsidp->list_id->tuple_cnt,
 		  llsidp->list_id->page_cnt * 16);
 #endif

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -8123,7 +8123,9 @@ check_hash_list_scan (LLIST_SCAN_ID * llsidp, int *val_cnt, int hash_list_scan_y
     }
   else if ((UINT64) llsidp->list_id->tuple_cnt * (sizeof(HENTRY_HLS) + sizeof(QFILE_TUPLE_SIMPLE_POS)) <= mem_limit)
     {
-      /* bytes of 1 row = hash entry 12bytes + simple pos(VPID+offset) 10bytes = 22 bytes */
+      /* bytes of 1 row = sizeof(HENTRY_HLS) + sizeof(QFILE_TUPLE_SIMPLE_POS) = 36 bytes (64bit) */
+      /* HENTRY_HLS = pointer(8bytes) * 3 = 24 bytes*/
+      /* SIMPLE_POS = pageid(4bytes) + voldid(2bytes) + padding(2bytes) + offset(4bytes) = 12 bytes*/
       return HYBRID_IN_MEMORY;
     }
   else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23828

The HASH LIST SCAN operates with the following priorities. (check_hash_list_scan() )
```
1. in-memory hash if all data can be stored (hash value : tuple)
2. Hybrid in-memory hash if all OID of data can be stored (hash value : OID)
3. LIST SCAN if all data cannot be stored (After CBRD-23816, use HASH TEMP FILE.)
```

**Hash table for HASH LIST SCAN**
In order to minimize the size of the hash entry, a hash table for HASH LIST SCAN is created separately. It has the following features.
```
1. lru, act is not used. (remove variable related to lru, act)
2. key comparison is performed in executor. (remove key of hash entry)
3. put data orderly. (add tail pointer for it)
4. Since hash size is fixed, rehashing the hash table is not necessary.
```
A key of entry of hash table is removed. Previously, a data filter related to key comparison has been performed redundantly in the executor. If hash collision occur, this is a way to improve performance. However, it is rather the cause of performance degradation in situations where hash collisions do not occur. I believe that deleting duplicate key comparison will be more advantageous in all cases. And to reduce the size of the hash entry, the key is needed to remove.

**EXECUTOR**
OIDs of temp file are stored when building hash table. (scan_build_hash_list_scan() )
When probing hash table, data is retrieved from temp file using OIDs. (scan_hash_probe_next() )