### PR TITLE
[CBRD-23812] [revised] The results of two queries that scan different indexes in the same transaction are different.

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -4110,7 +4110,7 @@ tp_domain_select (const TP_DOMAIN * domain_list, const DB_VALUE * value, int all
 
   best = NULL;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   /*
@@ -7092,7 +7092,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
   int year, month, day;
   TZ_ID ses_tz_id;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   DB_VALUE src_replacement;

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -11141,7 +11141,16 @@ mr_cmpval_string (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
 
   if (!ignore_trailing_space)
     {
-      ti = false;
+      if (value1->domain.general_info.type == DB_TYPE_CHAR ||
+	  value1->domain.general_info.type == DB_TYPE_NCHAR ||
+	  value2->domain.general_info.type == DB_TYPE_CHAR || value2->domain.general_info.type == DB_TYPE_NCHAR)
+	{
+	  ti = true;
+	}
+      else
+	{
+	  ti = false;
+	}
     }
 
   strc = QSTR_COMPARE (collation, string1, size1, string2, size2, ti);

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -14041,7 +14041,16 @@ mr_cmpval_varnchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int t
 
   if (!ignore_trailing_space)
     {
-      ti = false;
+      if (value1->domain.general_info.type == DB_TYPE_CHAR ||
+	  value1->domain.general_info.type == DB_TYPE_NCHAR ||
+	  value2->domain.general_info.type == DB_TYPE_CHAR || value2->domain.general_info.type == DB_TYPE_NCHAR)
+	{
+	  ti = true;
+	}
+      else
+	{
+	  ti = false;
+	}
     }
 
   strc = QSTR_NCHAR_COMPARE (collation, string1, size1, string2, size2, db_get_string_codeset (value2), ti);

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -7911,8 +7911,10 @@ pr_midxkey_compare (DB_MIDXKEY * mul1, DB_MIDXKEY * mul2, int do_coercion, int t
 	      c = dom1->type->index_cmpdisk (mem1, mem2, dom1, do_coercion, total_order, NULL);
 	    }
 	  else
-	    {			/* coercion and comparison */
-	      /* val1 and val2 have different domain */
+	    {
+	      /* coercion and comparison
+	       * val1 and val2 have different domain
+	       */
 	      c = pr_midxkey_compare_element (mem1, mem2, dom1, dom2, do_coercion, total_order);
 	    }
 	}
@@ -10928,7 +10930,7 @@ mr_data_cmpdisk_string (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
   bool alloced_string1 = false, alloced_string2 = false;
   int strc;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   assert (domain != NULL);
@@ -11083,7 +11085,7 @@ mr_cmpval_string (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tot
   int size1, size2;
   int strc;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   const unsigned char *string1 = REINTERPRET_CAST (const unsigned char *, db_get_string (value1));
@@ -11900,7 +11902,7 @@ mr_cmpdisk_char_internal (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coe
   DB_VALUE_COMPARE_RESULT c;
   int mem_length1, mem_length2, strc;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   if (IS_FLOATING_PRECISION (domain->precision))
@@ -11945,10 +11947,9 @@ static DB_VALUE_COMPARE_RESULT
 mr_cmpval_char (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total_order, int *start_colp, int collation)
 {
   DB_VALUE_COMPARE_RESULT c;
-  int strc;
+  int strc, size1, size2;
 
-  static bool ti = true;
-  static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
+  bool ti = true;
 
   const unsigned char *string1 = REINTERPRET_CAST (const unsigned char *, db_get_string (value1));
   const unsigned char *string2 = REINTERPRET_CAST (const unsigned char *, db_get_string (value2));
@@ -11988,31 +11989,10 @@ mr_cmpval_char (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
       return DB_UNK;
     }
 
-  if (!ignore_trailing_space)
-    {
-      /* TODO: We might need to make refactoring the code for corcing between CHAR and VARCHAR */
-      switch (do_coercion)
-	{
-	case 2:
-	  /* 
-	   * from btree_get_prefix_separator
-	   * we need to process the ti-comparison for this case (CHAR and VARCHAR mixed)
-	   */
-	  ti = (value1->domain.char_info.type == DB_TYPE_CHAR || value2->domain.char_info.type == DB_TYPE_CHAR);
-	  break;
-	case 3:
-	  /* 
-	   * from eliminate_duplicated_keys and scan_key_compre
-	   * we need to process enforcing no-ignore-trailing space.
-	   */
-	  ti = false;
-	  break;
-	default:
-	  ti = (value1->domain.char_info.type == DB_TYPE_CHAR && value2->domain.char_info.type == DB_TYPE_CHAR);
-	}
-    }
-  strc = QSTR_CHAR_COMPARE (collation, string1, (int) db_get_string_size (value1), string2,
-			    (int) db_get_string_size (value2), ti);
+  size1 = db_get_string_size (value1);
+  size2 = db_get_string_size (value2);
+
+  strc = QSTR_CHAR_COMPARE (collation, string1, size1, string2, size2, ti);
   c = MR_CMP_RETURN_CODE (strc);
 
   return c;
@@ -12884,10 +12864,9 @@ static DB_VALUE_COMPARE_RESULT
 mr_cmpval_nchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total_order, int *start_colp, int collation)
 {
   DB_VALUE_COMPARE_RESULT c;
-  int strc;
+  int strc, size1, size2;
 
-  static bool ti = true;
-  static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
+  bool ti = true;
 
   const unsigned char *string1 = REINTERPRET_CAST (const unsigned char *, db_get_string (value1));
   const unsigned char *string2 = REINTERPRET_CAST (const unsigned char *, db_get_string (value2));
@@ -12903,21 +12882,10 @@ mr_cmpval_nchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int tota
       return DB_UNK;
     }
 
+  size1 = db_get_string_size (value1);
+  size2 = db_get_string_size (value2);
 
-  if (!ignore_trailing_space)
-    {
-      if (do_coercion == 2)
-	{
-	  ti = (value1->domain.char_info.type == DB_TYPE_NCHAR || value2->domain.char_info.type == DB_TYPE_NCHAR);
-	}
-      else
-	{
-	  ti = (value1->domain.char_info.type == DB_TYPE_NCHAR && value2->domain.char_info.type == DB_TYPE_NCHAR);
-	}
-    }
-
-  strc = QSTR_NCHAR_COMPARE (collation, string1, (int) db_get_string_size (value1), string2,
-			     (int) db_get_string_size (value2), db_get_string_codeset (value2), ti);
+  strc = QSTR_NCHAR_COMPARE (collation, string1, size1, string2, size2, db_get_string_codeset (value2), ti);
   c = MR_CMP_RETURN_CODE (strc);
 
   return c;
@@ -14030,9 +13998,9 @@ mr_cmpval_varnchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int t
 		    int collation)
 {
   DB_VALUE_COMPARE_RESULT c;
-  int strc;
+  int strc, size1, size2;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   const unsigned char *string1 = REINTERPRET_CAST (const unsigned char *, db_get_string (value1));
@@ -14049,12 +14017,25 @@ mr_cmpval_varnchar (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int t
       return DB_UNK;
     }
 
+  size1 = (int) db_get_string_size (value1);
+  size2 = (int) db_get_string_size (value2);
+
+  if (size1 < 0)
+    {
+      size1 = strlen ((char *) string1);
+    }
+
+  if (size2 < 0)
+    {
+      size2 = strlen ((char *) string2);
+    }
+
   if (!ignore_trailing_space)
     {
       ti = false;
     }
-  strc = QSTR_NCHAR_COMPARE (collation, string1, (int) db_get_string_size (value1), string2,
-			     (int) db_get_string_size (value2), db_get_string_codeset (value2), ti);
+
+  strc = QSTR_NCHAR_COMPARE (collation, string1, size1, string2, size2, db_get_string_codeset (value2), ti);
   c = MR_CMP_RETURN_CODE (strc);
 
   return c;

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -23419,7 +23419,7 @@ char_string
 			  }
 
 			node = pt_create_char_string_literal (this_parser,
-							      PT_TYPE_VARNCHAR,
+							      PT_TYPE_NCHAR,
 							      $1, charset);
 
 			if (node && lang_get_parser_use_client_charset ())

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -23382,7 +23382,7 @@ char_string
 			  }
 
 			node = pt_create_char_string_literal (this_parser,
-							      PT_TYPE_CHAR,
+							      PT_TYPE_VARCHAR,
 							      $1, charset);
 
 			if (node)
@@ -23419,7 +23419,7 @@ char_string
 			  }
 
 			node = pt_create_char_string_literal (this_parser,
-							      PT_TYPE_NCHAR,
+							      PT_TYPE_VARNCHAR,
 							      $1, charset);
 
 			if (node && lang_get_parser_use_client_charset ())
@@ -23439,7 +23439,7 @@ char_string
 
 			PT_NODE *node = NULL;
 
-			node = pt_create_char_string_literal (this_parser, PT_TYPE_CHAR,
+			node = pt_create_char_string_literal (this_parser, PT_TYPE_VARCHAR,
 							      $1, INTL_CODESET_RAW_BYTES);
 
 			if (node)
@@ -23460,7 +23460,7 @@ char_string
 
 			PT_NODE *node = NULL;
 
-			node = pt_create_char_string_literal (this_parser, PT_TYPE_CHAR,
+			node = pt_create_char_string_literal (this_parser, PT_TYPE_VARCHAR,
 							      $1, INTL_CODESET_KSC5601_EUC);
 
 			if (node)
@@ -23481,7 +23481,7 @@ char_string
 
 			PT_NODE *node = NULL;
 
-			node = pt_create_char_string_literal (this_parser, PT_TYPE_CHAR,
+			node = pt_create_char_string_literal (this_parser, PT_TYPE_VARCHAR,
 							      $1, INTL_CODESET_ISO88591);
 
 			if (node)
@@ -23502,7 +23502,7 @@ char_string
 
 			PT_NODE *node = NULL;
 
-			node = pt_create_char_string_literal (this_parser, PT_TYPE_CHAR,
+			node = pt_create_char_string_literal (this_parser, PT_TYPE_VARCHAR,
 							      $1, INTL_CODESET_UTF8);
 
 			if (node)
@@ -25792,7 +25792,9 @@ parser_make_date_lang (int arg_cnt, PT_NODE * arg3)
 	{
 	  date_lang->type_enum = PT_TYPE_INTEGER;
 	  if (arg3->type_enum != PT_TYPE_CHAR
-	      && arg3->type_enum != PT_TYPE_NCHAR)
+	      && arg3->type_enum != PT_TYPE_NCHAR
+	      && arg3->type_enum != PT_TYPE_VARCHAR
+	      && arg3->type_enum != PT_TYPE_VARNCHAR)
 	    {
 	      PT_ERROR (this_parser, arg3,
 			"argument 3 must be character string");
@@ -26586,7 +26588,9 @@ parser_keyword_func (const char *name, PT_NODE * args)
 	  PT_NODE *node = args->next;
 	  if (node->node_type != PT_VALUE ||
 	      (node->type_enum != PT_TYPE_CHAR &&
-	       node->type_enum != PT_TYPE_NCHAR))
+	       node->type_enum != PT_TYPE_NCHAR &&
+	       node->type_enum != PT_TYPE_VARCHAR &&
+	       node->type_enum != PT_TYPE_VARNCHAR))
 	    {
 	      push_msg (MSGCAT_SYNTAX_INVALID_TO_NUMBER);
 	      csql_yyerror_explicit (10, 10);
@@ -26818,7 +26822,7 @@ parser_keyword_func (const char *name, PT_NODE * args)
 	  parser_cannot_prepare = true;
 	  node = parser_make_expression (this_parser, key->op, a1, a2, NULL);
 
-	  if (a1->node_type != PT_VALUE || a1->type_enum != PT_TYPE_CHAR)
+	  if (a1->node_type != PT_VALUE || (a1->type_enum != PT_TYPE_CHAR && a1->type_enum != PT_TYPE_VARCHAR))
 	    {
 	      PT_ERRORf (this_parser, node,
 			 "%s argument must be a string liternal",

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -9364,7 +9364,7 @@ pt_check_enum_data_type (PARSER_CONTEXT * parser, PT_NODE * dt)
   int char_count = 0;
   unsigned char pad[2];
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   if (dt == NULL || dt->node_type != PT_DATA_TYPE || dt->type_enum != PT_TYPE_ENUMERATION)

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -13328,7 +13328,8 @@ pt_eval_function_type_old (PARSER_CONTEXT * parser, PT_NODE * node)
 	    arg = arg_list->next;
 	    while (arg)
 	      {
-		if (arg->type_enum != arg_type || arg->data_type->info.data_type.precision != max_precision)
+		if ((arg->type_enum != arg_type) ||
+		    (arg->data_type && arg->data_type->info.data_type.precision != max_precision))
 		  {
 		    PT_NODE *new_attr = pt_wrap_with_cast_op (parser, arg, arg_type,
 							      max_precision, 0, NULL);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -24378,7 +24378,7 @@ static PT_TYPE_ENUM
 pt_wrap_type_for_collation (const PT_NODE * arg1, const PT_NODE * arg2, const PT_NODE * arg3,
 			    PT_TYPE_ENUM * wrap_type_collection)
 {
-  PT_TYPE_ENUM common_type = (PT_IS_COLLECTION_TYPE (arg1->type_enum)) ? PT_TYPE_CHAR : PT_TYPE_VARCHAR;
+  PT_TYPE_ENUM common_type = PT_TYPE_VARCHAR;
   PT_TYPE_ENUM arg1_type = PT_TYPE_NONE, arg2_type = PT_TYPE_NONE, arg3_type = PT_TYPE_NONE;
 
   if (arg1)

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -355,7 +355,7 @@ db_string_compare (const DB_VALUE * string1, const DB_VALUE * string2, DB_VALUE 
   int cmp_result = 0;
   DB_TYPE str1_type, str2_type;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   /* Assert that DB_VALUE structures have been allocated. */
@@ -496,7 +496,7 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
   DB_VALUE tmp_result;
   int c;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   /* Assertions */
@@ -3709,7 +3709,7 @@ db_string_prefix_compare (const DB_VALUE * string1, const DB_VALUE * string2, DB
   int cmp_result = 0;
   DB_TYPE str1_type, str2_type;
 
-  static bool ti = true;
+  bool ti = true;
   static bool ignore_trailing_space = prm_get_bool_value (PRM_ID_IGNORE_TRAILING_SPACE);
 
   /* Assert that DB_VALUE structures have been allocated. */

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -7029,9 +7029,27 @@ db_char_string_coerce (const DB_VALUE * src_string, DB_VALUE * dest_string, DB_D
 
       if (error_status == NO_ERROR && dest != NULL)
 	{
+	  DB_TYPE src_type = DB_VALUE_DOMAIN_TYPE (src_string);
+	  DB_TYPE dest_type = DB_VALUE_DOMAIN_TYPE (dest_string);
+
 	  qstr_make_typed_string (DB_VALUE_DOMAIN_TYPE (dest_string), dest_string, DB_VALUE_PRECISION (dest_string),
 				  (char *) dest, dest_size, db_get_string_codeset (dest_string),
 				  db_get_string_collation (dest_string));
+
+	  if ((src_type == DB_TYPE_CHAR || src_type == DB_TYPE_NCHAR) &&
+	      (dest_type == DB_TYPE_VARCHAR || dest_type == DB_TYPE_VARNCHAR))
+	    {
+	      int i;
+
+	      for (i = db_get_string_length (src_string) - 1; i > 0; i--)
+		{
+		  if (dest_string->data.ch.medium.buf[i] != 0x20)
+		    {
+		      break;
+		    }
+		  dest_string->data.ch.medium.size--;
+		}
+	    }
 	  dest[dest_size] = 0;
 	  dest_string->need_clear = true;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23812
also related to http://jira.cubrid.org/browse/CBRD-23731

Environment:

Create a table by increasing columns from 2 to 30.
Insert/update/select sequentially with 10 threads targeting each table.
10,000 times per thread.
Fail case:
When comparing each column value by executing the same select query that scans different indexes in the same transaction, in the select result comparison step, the result of the first query is failing with 0 tuple.

I changed the default type to VARCHAR for constant string.
And I also modified comparing routine mr_cmpval_string and mr_cmpval_char.
In the modified comparing routine, varchar-type data comparing always no ignore trailing spaces and char-type data comparing always ignore trailing spaces.
  