### PR TITLE
[CBRD-23678] support to keywords when using /*+ USE_SBR */ hint.

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14812,7 +14812,7 @@ do_replicate_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
       PT_PRINT_VALUE_FUNC saved_func = parser->print_db_value;
       int saved_custom_print = parser->custom_print;
 
-      parser->custom_print |= PT_PRINT_ORIGINAL_BEFORE_CONST_FOLDING;
+      parser->custom_print |= (PT_PRINT_ORIGINAL_BEFORE_CONST_FOLDING | PT_PRINT_QUOTES);
       parser->print_db_value = pt_print_node_value;
       repl_stmt.stmt_text = parser_print_tree (parser, statement);
       parser->print_db_value = saved_func;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23678

The syntax error occurs on the slave node when using /\*+ USE_SBR hint \*/. Because the input insert statement is changed as follows:
- on MASTER node:
  - insert /*+ USE_SBR */ into xoo values(1);
- on SLAVE node:
  - insert /*+ USE_SBR */ into xoo (encrypt) values (1);

So, convert the identifier into [identifier] for keyword support as follows:
- AS-IS:
  - insert /*+ USE_SBR */ into xoo (encrypt) values (1);
- TO-BE:
  - insert /*+ USE_SBR */ into [xoo] ([encrypt]) values (1);