### PR TITLE
[CBRD-23649] Get rid of warnings due to data type

### DIFF
--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -3954,7 +3954,7 @@ boot_define_dual (MOP class_mop)
   int error_code = NO_ERROR;
   DB_OBJECT *obj;
   DB_VALUE val;
-  char *dummy = "X";
+  const char *dummy = "X";
 
   def = smt_edit_class_mop (class_mop, AU_ALTER);
   if (def == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23649

Eliminated warning that caused by trying to convert a string constant to char*.

 "char* dummy" are passed as a argument to the db_make_varchar() function, but db_make_varchar() takes argument of type const char*. 