### PR TITLE
[CBRD-23587] Add sym link of libncurses.so.6 to libncurses.so.5 for C…

### DIFF
--- a/cmake/CPack.STGZ_Header.sh.in
+++ b/cmake/CPack.STGZ_Header.sh.in
@@ -188,54 +188,38 @@ export SHLIB_PATH
 export LIBPATH
 export PATH
 
-VERSION=${VERSION:-0}
 LIB=$CUBRID/lib
 
 if [ -f /etc/redhat-release ];then
 	OS=$(cat /etc/system-release-cpe | cut -d':' -f'3-3')
-	if [ $OS = "centos" ];then
-		VERSION=$(cat /etc/system-release-cpe | cut -d':' -f'5-5')
-	else
-		OS=$(cat /etc/system-release-cpe | cut -d':' -f'4-4')
-		if [ $OS = "fedora" ];then
-			VERSION=$(cat /etc/system-release-cpe | cut -d':' -f'5-5')
-		fi
-	fi
 elif [ -f /etc/os-release ];then
 	OS=$(cat /etc/os-release | egrep "^ID=" | cut -d'=' -f2-2)
-	VERSION=$(cat /etc/os-release | grep VERSION_ID | cut -d'=' -f2-2)
-	VERSION=${VERSION#\"}
-	VERSION=${VERSION%\"}
-	if [ $OS = "ubuntu" ];then
-		VERSION=$(echo  $VERSION | cut -d'.' -f1-1)
-	fi
 fi
-
 
 case $OS in
 	fedora)
-		if [ $VERSION -ge 24 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+		if [ ! -f /lib64/libncurses.so.5 ] && [ ! -f $LIB/libncurses.so.5 ];then
 			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib64/libform.so.6 $LIB/libform.so.5
 			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
 		fi
 		;;
 	centos)
-		if [ $VERSION -ge 8 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+		if [ ! -f /lib64/libncurses.so.5 ] && [ ! -f $LIB/libncurses.so.5 ];then
 			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib64/libform.so.6 $LIB/libform.so.5
 			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
 		fi
 		;;
 	ubuntu)
-		if [ $VERSION -ge 20 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+		if [ ! -f /lib/x86_64-linux-gnu/libncurses.so.5 ] && [ ! -f $LIB/libncurses.so.5 ];then
 			ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
 			ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
 		fi
 		;;
 	debian)
-		if [ $VERSION -ge 10 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+		if [ ! -f /lib/x86_64-linux-gnu/libncurses.so.5 ] && [ ! -f $LIB/libncurses.so.5 ];then
 			ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
 			ln -s /usr/lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5

--- a/cmake/CPack.STGZ_Header.sh.in
+++ b/cmake/CPack.STGZ_Header.sh.in
@@ -187,12 +187,61 @@ export LD_LIBRARY_PATH
 export SHLIB_PATH
 export LIBPATH
 export PATH
-centos=$(cat /etc/redhat-release | awk '{print $4}' | cut -c 1)
-if [ "$centos"x = "8x" ] && [ "CUBRID"x != "x" ] && [ ! -f $CUBRID/lib/libncurses.so.5 ];then
-        ln -s /lib64/libncurses.so.6 $CUBRID/lib/libncurses.so.5
-        ln -s /lib64/libtinfo.so.6 $CUBRID/lib/libtinfo.so.5
-        ln -s /lib64/libform.so.6 $CUBRID/lib/libform.so.5
+
+VERSION=${VERSION:-0}
+LIB=$CUBRID/lib
+
+if [ -f /etc/redhat-release ];then
+	OS=$(cat /etc/system-release-cpe | cut -d':' -f'3-3')
+	if [ $OS = "centos" ];then
+		VERSION=$(cat /etc/system-release-cpe | cut -d':' -f'5-5')
+	else
+		OS=$(cat /etc/system-release-cpe | cut -d':' -f'4-4')
+		if [ $OS = "fedora" ];then
+			VERSION=$(cat /etc/system-release-cpe | cut -d':' -f'5-5')
+		fi
+	fi
+elif [ -f /etc/os-release ];then
+	OS=$(cat /etc/os-release | egrep "^ID=" | cut -d'=' -f2-2)
+	VERSION=$(cat /etc/os-release | grep VERSION_ID | cut -d'=' -f2-2)
+	VERSION=${VERSION#\"}
+	VERSION=${VERSION%\"}
+	if [ $OS = "ubuntu" ];then
+		VERSION=$(echo  $VERSION | cut -d'.' -f1-1)
+	fi
 fi
+
+
+case $OS in
+	fedora)
+		if [ $VERSION -ge 24 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
+			ln -s /lib64/libform.so.6 $LIB/libform.so.5
+			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
+		fi
+		;;
+	centos)
+		if [ $VERSION -ge 8 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
+			ln -s /lib64/libform.so.6 $LIB/libform.so.5
+			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
+		fi
+		;;
+	ubuntu)
+		if [ $VERSION -ge 20 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+			ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
+			ln -s /lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
+			ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
+		fi
+		;;
+	debian)
+		if [ $VERSION -ge 10 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+			ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
+			ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
+			ln -s /usr/lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
+		fi
+		;;
+esac
 ____cubrid__here_doc____
 
 for e in "$cubrid_csh_envfile" "$cubrid_sh_envfile"; do

--- a/cmake/CPack.STGZ_Header.sh.in
+++ b/cmake/CPack.STGZ_Header.sh.in
@@ -187,6 +187,12 @@ export LD_LIBRARY_PATH
 export SHLIB_PATH
 export LIBPATH
 export PATH
+centos=$(cat /etc/redhat-release | awk '{print $4}' | cut -c 1)
+if [ "$centos"x = "8x" ] && [ "CUBRID"x != "x" ] && [ ! -f $CUBRID/lib/libncurses.so.5 ];then
+        ln -s /lib64/libncurses.so.6 $CUBRID/lib/libncurses.so.5
+        ln -s /lib64/libtinfo.so.6 $CUBRID/lib/libtinfo.so.5
+        ln -s /lib64/libform.so.6 $CUBRID/lib/libform.so.5
+fi
 ____cubrid__here_doc____
 
 for e in "$cubrid_csh_envfile" "$cubrid_sh_envfile"; do

--- a/cmake/CPack_postinstall.sh.in
+++ b/cmake/CPack_postinstall.sh.in
@@ -3,3 +3,4 @@ if [ -x /sbin/chkconfig ] ; then
   /sbin/chkconfig --add cubrid
 fi
 chown cubrid:cubrid -R $RPM_INSTALL_PREFIX
+. $RPM_INSTALL_PREFIX/share/rpm/cubrid.sh

--- a/contrib/rpm/cubrid.sh
+++ b/contrib/rpm/cubrid.sh
@@ -16,54 +16,38 @@ fi
 
 export CUBRID CUBRID_DATABASES LD_LIBRARY_PATH PATH
 
-VERSION=${VERSION:-0}
 LIB=$CUBRID/lib
 
 if [ -f /etc/redhat-release ];then
 	OS=$(cat /etc/system-release-cpe | cut -d':' -f'3-3')
-	if [ $OS = "centos" ];then
-		VERSION=$(cat /etc/system-release-cpe | cut -d':' -f'5-5')
-	else
-		OS=$(cat /etc/system-release-cpe | cut -d':' -f'4-4')
-		if [ $OS = "fedora" ];then
-			VERSION=$(cat /etc/system-release-cpe | cut -d':' -f'5-5')
-		fi
-	fi
 elif [ -f /etc/os-release ];then
 	OS=$(cat /etc/os-release | egrep "^ID=" | cut -d'=' -f2-2)
-	VERSION=$(cat /etc/os-release | grep VERSION_ID | cut -d'=' -f2-2)
-	VERSION=${VERSION#\"}
-	VERSION=${VERSION%\"}
-	if [ $OS = "ubuntu" ];then
-		VERSION=$(echo  $VERSION | cut -d'.' -f1-1)
-	fi
 fi
-
 
 case $OS in
 	fedora)
-		if [ $VERSION -ge 24 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+		if [ ! -f /lib64/libncurses.so.5 ] && [ ! -f $LIB/libncurses.so.5 ];then
 			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib64/libform.so.6 $LIB/libform.so.5
 			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
 		fi
 		;;
 	centos)
-		if [ $VERSION -ge 8 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+		if [ ! -f /lib64/libncurses.so.5 ] && [ ! -f $LIB/libncurses.so.5 ];then
 			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib64/libform.so.6 $LIB/libform.so.5
 			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
 		fi
 		;;
 	ubuntu)
-		if [ $VERSION -ge 20 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+		if [ ! -f /lib/x86_64-linux-gnu/libncurses.so.5 ] && [ ! -f $LIB/libncurses.so.5 ];then
 			ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
 			ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
 		fi
 		;;
 	debian)
-		if [ $VERSION -ge 10 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+		if [ ! -f /lib/x86_64-linux-gnu/libncurses.so.5 ] && [ ! -f $LIB/libncurses.so.5 ];then
 			ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
 			ln -s /usr/lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5

--- a/contrib/rpm/cubrid.sh
+++ b/contrib/rpm/cubrid.sh
@@ -15,3 +15,10 @@ then
 fi
 
 export CUBRID CUBRID_DATABASES LD_LIBRARY_PATH PATH
+
+centos=$(cat /etc/redhat-release | awk '{print $4}' | cut -c 1)
+if [ "$centos"x = "8x" ] && [ "CUBRID"x != "x" ] && [ ! -f $CUBRID/lib/libncurses.so.5 ];then
+        ln -s /lib64/libncurses.so.6 $CUBRID/lib/libncurses.so.5
+        ln -s /lib64/libtinfo.so.6 $CUBRID/lib/libtinfo.so.5
+        ln -s /lib64/libform.so.6 $CUBRID/lib/libform.so.5
+fi

--- a/contrib/rpm/cubrid.sh
+++ b/contrib/rpm/cubrid.sh
@@ -16,9 +16,57 @@ fi
 
 export CUBRID CUBRID_DATABASES LD_LIBRARY_PATH PATH
 
-centos=$(cat /etc/redhat-release | awk '{print $4}' | cut -c 1)
-if [ "$centos"x = "8x" ] && [ "CUBRID"x != "x" ] && [ ! -f $CUBRID/lib/libncurses.so.5 ];then
-        ln -s /lib64/libncurses.so.6 $CUBRID/lib/libncurses.so.5
-        ln -s /lib64/libtinfo.so.6 $CUBRID/lib/libtinfo.so.5
-        ln -s /lib64/libform.so.6 $CUBRID/lib/libform.so.5
+VERSION=${VERSION:-0}
+LIB=$CUBRID/lib
+
+if [ -f /etc/redhat-release ];then
+	OS=$(cat /etc/system-release-cpe | cut -d':' -f'3-3')
+	if [ $OS = "centos" ];then
+		VERSION=$(cat /etc/system-release-cpe | cut -d':' -f'5-5')
+	else
+		OS=$(cat /etc/system-release-cpe | cut -d':' -f'4-4')
+		if [ $OS = "fedora" ];then
+			VERSION=$(cat /etc/system-release-cpe | cut -d':' -f'5-5')
+		fi
+	fi
+elif [ -f /etc/os-release ];then
+	OS=$(cat /etc/os-release | egrep "^ID=" | cut -d'=' -f2-2)
+	VERSION=$(cat /etc/os-release | grep VERSION_ID | cut -d'=' -f2-2)
+	VERSION=${VERSION#\"}
+	VERSION=${VERSION%\"}
+	if [ $OS = "ubuntu" ];then
+		VERSION=$(echo  $VERSION | cut -d'.' -f1-1)
+	fi
 fi
+
+
+case $OS in
+	fedora)
+		if [ $VERSION -ge 24 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
+			ln -s /lib64/libform.so.6 $LIB/libform.so.5
+			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
+		fi
+		;;
+	centos)
+		if [ $VERSION -ge 8 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
+			ln -s /lib64/libform.so.6 $LIB/libform.so.5
+			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
+		fi
+		;;
+	ubuntu)
+		if [ $VERSION -ge 20 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+			ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
+			ln -s /lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
+			ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
+		fi
+		;;
+	debian)
+		if [ $VERSION -ge 10 ] && [ ! -f $LIB/libncurses.so.5 ] ;then
+			ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
+			ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
+			ln -s /usr/lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
+		fi
+		;;
+esac


### PR DESCRIPTION
…enOS 8
http://jira.cubrid.org/browse/CBRD-23587
* If the target is the CentOS 8, add the following to .cubrid.sh:
   * add symbolic link of /lib64/libncurses.so.6 to $CUBRID/lib/libncurses.so.5
   * add symbolic link of /lib64/libtinfo.so.6 to $CUBRID/lib/libtinfo.so.5
   * add symbolic link of /lib64/libform.so.6 to $CUBRID/lib/libform.so.5