### PR TITLE
[CBRD-23608] [regression] Modified to be able to change master key in Windows environment.

### DIFF
--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -3776,7 +3776,7 @@ tde (UTIL_FUNCTION_ARG * arg)
   printf ("Key File: %s\n", mk_path);
 
   /* 
-   * In Window, --change-keys operation is not supported because of this fileio_mount(). In Window, if a process mount a file with file_lock > 0, no other process can mount even with file_lock = 0, but the file lock here is necessary to procide exclusivness with backupdb in current design. 
+   * The file lock here is necessary to provide exclusiveness with backupdb in the current design.
    */
   vdes = fileio_mount (NULL, database_name, mk_path, LOG_DBTDE_KEYS_VOLID, 1, false);
   if (vdes == NULL_VOLDES)

--- a/src/storage/tde.c
+++ b/src/storage/tde.c
@@ -1256,7 +1256,7 @@ xtde_change_mk_without_flock (THREAD_ENTRY * thread_p, const int mk_index)
   tde_make_keys_file_fullname (mk_path, boot_db_full_name (), false);
 
   /* Without file lock: It is because it must've already been locked in client-side: tde() */
-  vdes = fileio_mount (thread_p, boot_db_full_name (), mk_path, LOG_DBTDE_KEYS_VOLID, false, false);
+  vdes = fileio_open (mk_path, O_RDWR, 0600);
   if (vdes == NULL_VOLDES)
     {
       ASSERT_ERROR ();
@@ -1295,7 +1295,7 @@ xtde_change_mk_without_flock (THREAD_ENTRY * thread_p, const int mk_index)
     }
 
 exit:
-  fileio_dismount (thread_p, vdes);
+  fileio_close (vdes);
   return err;
 }
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7492,6 +7492,12 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
   /* tde key file has to be mounted to access exclusively with TDE Utility if it exists */
   tde_make_keys_file_fullname (mk_path, log_Db_fullname, false);
   keys_vdes = fileio_mount (thread_p, log_Db_fullname, mk_path, LOG_DBTDE_KEYS_VOLID, 1, false);
+  if (keys_vdes == NULL_VOLDES)
+    {
+      ASSERT_ERROR ();
+      error_code = er_errid ();
+      goto error;
+    }
 
   /* Initialization gives us some useful information about the backup location. */
   session.type = FILEIO_BACKUP_WRITE;	/* access backup device for write */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7492,7 +7492,7 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
   /* tde key file has to be mounted to access exclusively with TDE Utility if it exists */
   tde_make_keys_file_fullname (mk_path, log_Db_fullname, false);
   keys_vdes = fileio_mount (thread_p, log_Db_fullname, mk_path, LOG_DBTDE_KEYS_VOLID, 1, false);
-  if (keys_vdes == NULL_VOLDES)
+  if (keys_vdes == NULL_VOLDES && fileio_is_volume_exist (mk_path))
     {
       ASSERT_ERROR ();
       error_code = er_errid ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23608

- Regression issue
  - https://github.com/CUBRID/cubrid-testcases-private-ex/blob/develop/shell/_36_damson/cbrd_23608_tde/utility_16/cases/utility_16.sh
- Description
  - In the Windows environment, the restrictions are removed so that the master key can be changed using the cubrid tde utility.
    - When designing, it was decided that the change of the master key and the backupdb cannot be performed at the same time.
    - To ensure this, a file lock was acquired by using the fileio_mount() function in the cubrid utility and the cub_server.
    - But, different processes cannot hold a file lock in _SH_DENYWR and _SH_DENYNO modes at the same time in the Windows environment.
    - Therefore, the fileio_open function() is used instead of the fileio_mount() function when referring to the key file to change the master key in the cub_server.
  - guarantee the mutually exclusive between cubrid tde with --change-key and cubrid backupdb. (bug fix)