### PR TITLE
[CBRD-23830] [Regression] [shell_ext] Core dumped in do_prepare_select

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14184,7 +14184,7 @@ do_prepare_select (PARSER_CONTEXT * parser, PT_NODE * statement)
       AU_SAVE_AND_DISABLE (au_save);	/* this prevents authorization checking during generating XASL */
       /* parser_generate_xasl() will build XASL tree from parse tree */
       contextp->xasl = parser_generate_xasl (parser, statement);
-      if (statement->info.query.oids_included)
+      if (contextp->xasl && statement->info.query.oids_included)
 	{
 	  contextp->xasl->header.xasl_flag |= RESULT_CACHE_INHIBITED;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23830
also related to http://jira.cubrid.org/browse/CBRD-23602

This issue is from result-cache where it checks if OID is included in a query.
