### PR TITLE
[CBRD-23733] add windows security patch update notification popup when cubrid install

### DIFF
--- a/cmake/CPackWixPatch.cmake.in
+++ b/cmake/CPackWixPatch.cmake.in
@@ -5,6 +5,23 @@
 <!-- Check System -->
     <Condition Message="This application is only supported on Windows Vista, Windows Server 2008, or higher."><![CDATA[Installed OR (VersionNT >= 600)]]></Condition>
     <Condition Message="This installer is only supported on Windows @WIX_SUPPORTED_PLATFORM@."><![CDATA[Installed OR @WIX_SUPPORTED_PLATFORM_CONDITION@]]></Condition>
+<!-- Check currentBuild number -->
+    <Property Id="WINDOWS_BUILD_VERSION">
+      <RegistrySearch Id="WIN_CURRENT_VERSION_REGSEARCH" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Name="CurrentBuild" Type="raw"/>
+    </Property>
+    <UI>
+      <Dialog Id="WinWarningDlg" Width="284" Height="73" Title="Check for update" NoMinimize="yes">
+        <Control Id="Text" Type="Text" X="38" Y="8" Width="240" Height="40" TabSkip="no">
+          <Text>Installation may fail if the latest version of the Windows security patch is not installed.</Text>
+        </Control>
+        <Control Id="OK" Type="PushButton" X="114" Y="52" Width="56" Height="17" Default="yes" Cancel="yes" Text="OK">
+          <Publish Event="EndDialog" Value="Return">1</Publish>
+        </Control>
+      </Dialog>
+      <InstallUISequence>
+        <Show Dialog="WinWarningDlg" Before="ResumeDlg"><![CDATA[WINDOWS_BUILD_VERSION >= "7600" AND WINDOWS_BUILD_VERSION <= "9600"]]></Show>
+      </InstallUISequence>
+    </UI>
 <!-- Check Java requirements ONLY on "install", but not on modify or uninstall -->
     <Property Id="JAVA_CURRENT_VERSION">
       <RegistrySearch Id="JRE_CURRENT_VERSION_REGSEARCH" Root="HKLM" Key="SOFTWARE\JavaSoft\Java Runtime Environment" Name="CurrentVersion" Type="raw"/>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23733

In the case of the following OS, a security patch notification pop-up is displayed.
* Windows 7
* Windows Server 2008 R2
* Windows 7, Service Pack 1
* Windows Server 2008 R2
* Windows Home Server 2011
* Windows Server 2012
* Windows 8
* Windows 8.1
* Windows Server 2012 R2
