### PR TITLE
[CBRD-23831] Some collection-related (has VARCHAR elements) query returns incorrect result

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5446,6 +5446,8 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 	{
 	  PT_NODE *temp = NULL;
 	  int precision = 0, scale = 0;
+	  int units = data_type->info.data_type.units; /* code set */
+	  int collation_id = data_type->info.data_type.collation_id; /* collation_id */
 	  bool keep_searching = true;
 	  for (temp = arg2->data_type; temp != NULL && keep_searching; temp = temp->next)
 	    {
@@ -5460,7 +5462,7 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 		case PT_TYPE_NCHAR:
 		case PT_TYPE_BIT:
 		  /* CHAR, NCHAR types can be common type for one of all arguments is string type */
-		  if (precision > temp->info.data_type.precision)
+		  if (precision < temp->info.data_type.precision)
 		    {
 		      precision = temp->info.data_type.precision;
 		    }
@@ -5476,7 +5478,7 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 		      keep_searching = false;
 		      break;
 		    }
-		  if (precision > temp->info.data_type.precision)
+		  if (precision < temp->info.data_type.precision)
 		    {
 		      precision = temp->info.data_type.precision;
 		    }
@@ -5491,7 +5493,7 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 		      keep_searching = false;
 		      break;
 		    }
-		  if (precision > temp->info.data_type.precision)
+		  if (precision < temp->info.data_type.precision)
 		    {
 		      precision = temp->info.data_type.precision;
 		    }
@@ -5526,9 +5528,21 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 		  assert (false);
 		  break;
 		}
+
+	      if (PT_IS_STRING_TYPE (common_type) && PT_IS_STRING_TYPE (temp->type_enum))
+		{
+		  /* A bigger codesets's number can represent more characters. */
+		  if (units < temp->info.data_type.units)
+		    {
+		      units = temp->info.data_type.units;
+		      collation_id = temp->info.data_type.collation_id;
+		    }
+		}
 	    }
 	  data_type->info.data_type.precision = precision;
 	  data_type->info.data_type.dec_precision = scale;
+	  data_type->info.data_type.units = units;
+	  data_type->info.data_type.collation_id = collation_id;
 	}
 
       arg2 = pt_wrap_collection_with_cast_op (parser, arg2, sig.arg2_type.val.type, data_type, false);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5446,8 +5446,8 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 	{
 	  PT_NODE *temp = NULL;
 	  int precision = 0, scale = 0;
-	  int units = data_type->info.data_type.units; /* code set */
-	  int collation_id = data_type->info.data_type.collation_id; /* collation_id */
+	  int units = LANG_SYS_CODESET; /* code set */
+	  int collation_id = LANG_SYS_COLLATION; /* collation_id */
 	  bool keep_searching = true;
 	  for (temp = arg2->data_type; temp != NULL && keep_searching; temp = temp->next)
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23831

A codeset of collection type is not considered when implicit cast.
I add code set which is bigger among set's elements.
I also fix wrong inequality sign to avoid potential problems.