### PR TITLE
[LETS-5] Add server_type system parameter

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -118,6 +118,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/process_util.c
   ${BASE_DIR}/release_string.c
   ${BASE_DIR}/resource_tracker.cpp
+  ${BASE_DIR}/server_type.cpp
   ${BASE_DIR}/sha1.c
   ${BASE_DIR}/stack_dump.c
   ${BASE_DIR}/string_buffer.cpp
@@ -158,6 +159,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/porting_inline.hpp
   ${BASE_DIR}/process_util.h
   ${BASE_DIR}/resource_tracker.hpp
+  ${BASE_DIR}/server_type.hpp
   ${BASE_DIR}/string_buffer.hpp
   ${BASE_DIR}/semaphore.hpp
   )

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -123,6 +123,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/lockfree_transaction_system.cpp
   ${BASE_DIR}/fileline_location.cpp
   ${BASE_DIR}/resource_tracker.cpp
+  ${BASE_DIR}/server_type.cpp
   ${BASE_DIR}/tz_compile.c
   ${BASE_DIR}/tz_support.c
   ${BASE_DIR}/ddl_log.c
@@ -156,6 +157,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/printer.hpp
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/semaphore.hpp
+  ${BASE_DIR}/server_type.hpp
   ${BASE_DIR}/ddl_log.h
 )
 

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -20,15 +20,15 @@
 
 #include "system_parameter.h"
 
-static SERVER_TYPE server_type;
+static SERVER_TYPE g_server_type;
 
 void init_server_type ()
 {
-  server_type = (SERVER_TYPE) prm_get_integer_value (PRM_ID_SERVER_TYPE);
+  g_server_type = (SERVER_TYPE) prm_get_integer_value (PRM_ID_SERVER_TYPE);
 }
 
 SERVER_TYPE get_server_type ()
 {
-  return server_type;
+  return g_server_type;
 }
 

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2021 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "server_type.hpp"
+
+#include "system_parameter.h"
+
+static SERVER_TYPE server_type;
+
+void init_server_type ()
+{
+
+  server_type = (SERVER_TYPE) prm_get_integer_value (PRM_ID_SERVER_TYPE);
+}
+
+SERVER_TYPE get_server_type ()
+{
+  return server_type;
+}
+

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -24,7 +24,6 @@ static SERVER_TYPE server_type;
 
 void init_server_type ()
 {
-
   server_type = (SERVER_TYPE) prm_get_integer_value (PRM_ID_SERVER_TYPE);
 }
 

--- a/src/base/server_type.hpp
+++ b/src/base/server_type.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2021 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef _SERVER_TYPE_H_
+#define _SERVER_TYPE_H_
+
+typedef enum
+{
+  SERVER_TYPE_TRANSACTION,
+  SERVER_TYPE_PAGE,
+} SERVER_TYPE;
+
+void init_server_type ();
+SERVER_TYPE get_server_type ();
+
+#endif

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -452,8 +452,11 @@ enum param_id
   PRM_ID_IGNORE_TRAILING_SPACE,
   PRM_ID_DDL_AUDIT_LOG,
   PRM_ID_DDL_AUDIT_LOG_SIZE,
+
+  PRM_ID_SERVER_TYPE,
+
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_DDL_AUDIT_LOG_SIZE
+  PRM_LAST_ID = PRM_ID_SERVER_TYPE
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/loaddb/load_error_handler.cpp
+++ b/src/loaddb/load_error_handler.cpp
@@ -22,6 +22,7 @@
 
 #include "load_error_handler.hpp"
 
+#include <algorithm>
 #include "load_driver.hpp"
 #include "load_sa_loader.hpp"
 #if defined (SERVER_MODE)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -82,6 +82,7 @@
 #include "vacuum.h"
 #include "tde.h"
 #include "porting.h"
+#include "server_type.hpp"
 
 #if defined(SERVER_MODE)
 #include "connection_sr.h"
@@ -2065,9 +2066,10 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   char db_lang[LANG_MAX_LANGNAME + 1];
   char timezone_checksum[32 + 1];
   const TZ_DATA *tzd;
-  char *mk_path;
+#if defined (SA_MODE)
   int jsp_port;
   bool jsp;
+#endif
 
   /* language data is loaded in context of server */
   if (lang_init () != NO_ERROR)
@@ -2107,6 +2109,11 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     }
 
   common_ha_mode = HA_GET_MODE ();
+
+  init_server_type ();
+  er_log_debug (ARG_FILE_LINE, "Starting server type: %s\n",
+		get_server_type () == SERVER_TYPE_PAGE ? "page" : "transaction");
+
 #endif /* SERVER_MODE */
 
   if (db_name == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-5

Add a system parameter for configuring whether the server starts as a page- or a transaction-server (default when parameter is missing in `cubrid.conf`).

I had to include <algorithm> in `src/loaddb/load_error_handler.cpp`, otherwise it didn't build and also fixed some `unused variable` warnings in `boot_sr.c`
