### PR TITLE
[CBRD-22856] fix to avoid compilation warning

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -19939,7 +19939,7 @@ pt_fold_const_function (PARSER_CONTEXT * parser, PT_NODE * func)
 	  func_arg = func->info.function.arg_list;
 	  memset (&(func->info), 0, sizeof (func->info));
 	  func->info.value.data_value.set = func_arg;
-	  func->type_enum == PT_TYPE_SEQUENCE;
+	  func->type_enum = PT_TYPE_SEQUENCE;
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22856

I correct my mistake.
```
func->type_enum == PT_TYPE_SEQUENCE;
==>
func->type_enum = PT_TYPE_SEQUENCE;
```
The reason the test was normal despite the above fault,
This is because type_enum is PT_TYPE_SEQUENCE even without the above code.
The code above is a defense code for unexpected situations.
