### PR TITLE
[LETS-18] Separate TCP and UNIX socket open

### DIFF
--- a/src/connection/tcp.h
+++ b/src/connection/tcp.h
@@ -42,7 +42,8 @@ extern char *css_get_master_domain_path (void);
 
 extern SOCKET css_tcp_client_open (const char *host, int port);
 extern SOCKET css_tcp_client_open_with_retry (const char *host, int port, bool will_retry);
-extern int css_tcp_master_open (int port, SOCKET * sockfd);
+extern int css_tcp_socket_bind_listen (int port, SOCKET & sockfd);
+extern int css_master_open_sockets (int port, SOCKET * sockfd);
 extern bool css_tcp_setup_server_datagram (char *pathname, SOCKET * sockfd);
 extern bool css_tcp_listen_server_datagram (SOCKET sockfd, SOCKET * newfd);
 extern bool css_tcp_master_datagram (char *pathname, SOCKET * sockfd);

--- a/src/connection/wintcp.c
+++ b/src/connection/wintcp.c
@@ -513,14 +513,14 @@ css_transfer_fd (SOCKET server_fd, SOCKET client_fd, unsigned short rid, CSS_SER
 /* These functions support the new-style connection protocol used by Windows. */
 
 /*
- * css_tcp_master_open() - initialize for the master server internet
+ * css_master_open_sockets() - initialize for the master server internet
  *                         communication
  *   return:
  *   port(in):
  *   sockfd(in):
  */
 int
-css_tcp_master_open (int port, SOCKET * sockfd)
+css_master_open_sockets (int port, SOCKET * sockfd)
 {
   struct sockaddr_in tcp_srv_addr;	/* server's internet socket addr */
   SOCKET sock;

--- a/src/connection/wintcp.h
+++ b/src/connection/wintcp.h
@@ -62,7 +62,7 @@ extern bool css_tcp_listen_server_datagram (SOCKET sockfd, SOCKET * newfd);
 extern bool css_tcp_master_datagram (char *pathname, SOCKET * sockfd);
 extern SOCKET css_open_new_socket_from_master (SOCKET fd, unsigned short *rid);
 extern bool css_transfer_fd (SOCKET server_fd, SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request);
-extern int css_tcp_master_open (int port, SOCKET * sockfd);
+extern int css_master_open_sockets (int port, SOCKET * sockfd);
 extern SOCKET css_master_accept (SOCKET sockfd);
 extern int css_open_server_connection_socket (void);
 extern void css_close_server_connection_socket (void);

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -263,7 +263,7 @@ css_master_init (int cport, SOCKET * clientfd)
   pthread_mutex_init (&css_Master_socket_anchor_lock, NULL);
 #endif
 
-  return (css_tcp_master_open (cport, clientfd));
+  return (css_master_open_sockets (cport, clientfd));
 }
 
 /*

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -28,7 +28,7 @@ EXPORTS
     css_send_request
     css_shutdown_socket
     css_tcp_master_datagram
-    css_tcp_master_open
+    css_master_open_sockets
     css_transfer_fd
     css_windows_shutdown
     css_windows_startup


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-18

Use existing code to open only TCP sockets (and not UNIX)

There was a single function in tcp.c which opened (for linux) both TCP and UNIX sockets (css_tcp_master_open). To be able to re-use the functionality for TCP sockets only, this was extracted to a new function (css_tcp_socket_bind_listen), which creates the TCP sockets, set socket options, binds, listens. The original one calls the new one for TCP and continues with the UNIX part. I also renamed it to "css_master_open_sockets"