### PR TITLE
[LETS-17] incorrect test against mvcc flag in log recovery

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3972,11 +3972,8 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 		  MVCCID_FORWARD (log_Gl.hdr.mvcc_next_id);
 		}
 
-	      if (is_mvcc_op)
-		{
-		  /* Save last MVCC operation LOG_LSA. */
-		  LSA_COPY (&log_Gl.hdr.mvcc_op_log_lsa, &rcv_lsa);
-		}
+	      /* Save last MVCC operation LOG_LSA. */
+	      LSA_COPY (&log_Gl.hdr.mvcc_op_log_lsa, &rcv_lsa);
 	      break;
 
 	    case LOG_UNDO_DATA:


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-17

The check against 'is_mvcc_op' is superfluous as for the log type 'LOG_MVCC_UNDO_DATA' it would be true anyway; it is also incorrect because it is not properly initialized in the 'LOG_MVCC_UNDO_DATA' label's context.

This  is a preliminary change intended to help in a subsequent refactoring/extension of the log recovery mechanism where we intend to introduce a parallelization mechanism to speed up the process.