### PR TITLE
[LETS-7] Disable vacuum on the page server

### DIFF
--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -123,6 +123,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/lockfree_transaction_system.cpp
   ${BASE_DIR}/fileline_location.cpp
   ${BASE_DIR}/resource_tracker.cpp
+  ${BASE_DIR}/server_type.cpp
   ${BASE_DIR}/tz_compile.c
   ${BASE_DIR}/tz_support.c
   ${BASE_DIR}/ddl_log.c
@@ -156,6 +157,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/printer.hpp
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/semaphore.hpp
+  ${BASE_DIR}/server_type.hpp
   ${BASE_DIR}/ddl_log.h
 )
 
@@ -174,7 +176,12 @@ set(CONNECTION_SOURCES
   )
 
 set(COMMUNICATION_SOURCES
+  ${COMMUNICATION_DIR}/communication_channel.cpp
   ${COMMUNICATION_DIR}/network_interface_cl.c
+  )
+
+set(COMMUNICATION_HEADERS
+  ${COMMUNICATION_DIR}/communication_channel.hpp
   )
 
 set(MONITOR_SOURCES
@@ -553,6 +560,7 @@ add_library(cubridsa SHARED
   ${BASE_SOURCES}
   ${BASE_HEADERS}
   ${COMMUNICATION_SOURCES}
+  ${COMMUNICATION_HEADERS}
   ${COMPAT_SOURCES}
   ${COMPAT_SOURCES_C}
   ${CONNECTION_SOURCES}

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -51,11 +51,16 @@ void connect_to_pageserver (std::string host, int port, const char *db_name);
 
 void init_server_type (const char *db_name)
 {
+  #if defined (SERVER_MODE)
   g_server_type = (SERVER_TYPE) prm_get_integer_value (PRM_ID_SERVER_TYPE);
+
   if (g_server_type == SERVER_TYPE_TRANSACTION)
     {
       init_page_server_hosts (db_name);
     }
+  #else
+g_server_type = SERVER_TYPE_TRANSACTION
+  #endif
 }
 
 void init_page_server_hosts (const char *db_name)

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -51,16 +51,11 @@ void connect_to_pageserver (std::string host, int port, const char *db_name);
 
 void init_server_type (const char *db_name)
 {
-  #if defined (SERVER_MODE)
   g_server_type = (SERVER_TYPE) prm_get_integer_value (PRM_ID_SERVER_TYPE);
-
   if (g_server_type == SERVER_TYPE_TRANSACTION)
     {
       init_page_server_hosts (db_name);
     }
-  #else
-g_server_type = SERVER_TYPE_TRANSACTION
-  #endif
 }
 
 void init_page_server_hosts (const char *db_name)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2505,7 +2505,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 #endif /* SERVER_MODE */
 
   // after recovery we can boot vacuum
-  if (get_server_type () != SERVER_TYPE_PAGE)
+  if (get_server_type () == SERVER_TYPE_TRANSACTION)
     {
       error_code = vacuum_boot (thread_p);
       if (error_code != NO_ERROR)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -213,7 +213,7 @@ static void boot_shutdown_server_at_exit (void);
 
 static INTL_CODESET boot_get_db_charset_from_header (THREAD_ENTRY * thread_p, const char *log_path,
 						     const char *log_prefix);
-STATIC_INLINE int boot_db_parm_update_heap (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE int boot_db_parm_update_heap (THREAD_ENTRY * thread_p) __attribute__((ALWAYS_INLINE));
 
 static int boot_after_copydb (THREAD_ENTRY * thread_p);
 
@@ -2505,7 +2505,15 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 #endif /* SERVER_MODE */
 
   // after recovery we can boot vacuum
-  error_code = vacuum_boot (thread_p);
+  if (get_server_type () != SERVER_TYPE_PAGE)
+    {
+      printf ("not page server\n");
+      error_code = vacuum_boot (thread_p);
+    }
+  else
+    {
+      error_code = NO_ERROR;
+    }
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2510,18 +2510,19 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       error_code = vacuum_boot (thread_p);
       if (error_code != NO_ERROR)
 	{
-	  log_append_empty_record (thread_p, LOG_VACUUM_BOOT_START, NULL);
+	  er_log_debug (ARG_FILE_LINE, "Vacuum was started on the transaction server.");
 	}
       else
 	{
-	  log_append_empty_record (thread_p, LOG_NO_VACUUM_BOOT_START, NULL);
+	  er_log_debug (ARG_FILE_LINE, "Vacuum was not started on the transaction server.");
 	}
     }
   else
     {
-      log_append_empty_record (thread_p, LOG_NO_VACUUM_BOOT_START, NULL);
+      er_log_debug (ARG_FILE_LINE, "Vacuum was not started on the page server.");
       error_code = NO_ERROR;
     }
+
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2507,11 +2507,19 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   // after recovery we can boot vacuum
   if (get_server_type () != SERVER_TYPE_PAGE)
     {
-      printf ("not page server\n");
       error_code = vacuum_boot (thread_p);
+      if (error_code != NO_ERROR)
+	{
+	  log_append_empty_record (thread_p, LOG_VACUUM_BOOT_START, NULL);
+	}
+      else
+	{
+	  log_append_empty_record (thread_p, LOG_NO_VACUUM_BOOT_START, NULL);
+	}
     }
   else
     {
+      log_append_empty_record (thread_p, LOG_NO_VACUUM_BOOT_START, NULL);
       error_code = NO_ERROR;
     }
   if (error_code != NO_ERROR)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2510,17 +2510,17 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       error_code = vacuum_boot (thread_p);
       if (error_code != NO_ERROR)
 	{
-	  er_log_debug (ARG_FILE_LINE, "Vacuum was started on the transaction server.");
+	  ASSERT_ERROR ();
+	  goto error;
 	}
       else
 	{
-	  er_log_debug (ARG_FILE_LINE, "Vacuum was not started on the transaction server.");
+	  er_log_debug (ARG_FILE_LINE, "Vacuum was started on the transaction server.");
 	}
     }
   else
     {
       er_log_debug (ARG_FILE_LINE, "Vacuum was not started on the page server.");
-      error_code = NO_ERROR;
     }
 
   if (error_code != NO_ERROR)

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -340,6 +340,9 @@ prior_lsa_alloc_and_copy_data (THREAD_ENTRY *thread_p, LOG_RECTYPE rec_type, LOG
     case LOG_DUMMY_OVF_RECORD:
     case LOG_DUMMY_GENERIC:
 
+    case LOG_VACUUM_BOOT_START:
+    case LOG_NO_VACUUM_BOOT_START:
+
     case LOG_2PC_COMMIT_DECISION:
     case LOG_2PC_ABORT_DECISION:
     case LOG_COMMIT_WITH_POSTPONE:
@@ -1219,6 +1222,10 @@ prior_lsa_gen_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_RECTYPE 
   node->data_header_length = 0;
   switch (rec_type)
     {
+
+    case LOG_VACUUM_BOOT_START:
+    case LOG_NO_VACUUM_BOOT_START:
+
     case LOG_DUMMY_HEAD_POSTPONE:
     case LOG_DUMMY_CRASH_RECOVERY:
     case LOG_DUMMY_OVF_RECORD:

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1219,7 +1219,6 @@ prior_lsa_gen_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_RECTYPE 
   node->data_header_length = 0;
   switch (rec_type)
     {
-
     case LOG_DUMMY_HEAD_POSTPONE:
     case LOG_DUMMY_CRASH_RECOVERY:
     case LOG_DUMMY_OVF_RECORD:

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -340,9 +340,6 @@ prior_lsa_alloc_and_copy_data (THREAD_ENTRY *thread_p, LOG_RECTYPE rec_type, LOG
     case LOG_DUMMY_OVF_RECORD:
     case LOG_DUMMY_GENERIC:
 
-    case LOG_VACUUM_BOOT_START:
-    case LOG_NO_VACUUM_BOOT_START:
-
     case LOG_2PC_COMMIT_DECISION:
     case LOG_2PC_ABORT_DECISION:
     case LOG_COMMIT_WITH_POSTPONE:
@@ -1222,9 +1219,6 @@ prior_lsa_gen_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_RECTYPE 
   node->data_header_length = 0;
   switch (rec_type)
     {
-
-    case LOG_VACUUM_BOOT_START:
-    case LOG_NO_VACUUM_BOOT_START:
 
     case LOG_DUMMY_HEAD_POSTPONE:
     case LOG_DUMMY_CRASH_RECOVERY:

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -281,7 +281,7 @@ static void log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LS
 static int log_run_postpone_op (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_PAGE * log_pgptr);
 static void log_find_end_log (THREAD_ENTRY * thread_p, LOG_LSA * end_lsa);
 
-static void log_cleanup_modified_class (const tx_transient_class_entry & t, bool & stop);
+static void log_cleanup_modified_class (const tx_transient_class_entry & t, bool &stop);
 static void log_cleanup_modified_class_list (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * savept_lsa,
 					     bool release, bool decache_classrepr);
 
@@ -289,16 +289,16 @@ static void log_append_compensate_internal (THREAD_ENTRY * thread_p, LOG_RCVINDE
 					    PGLENGTH offset, PAGE_PTR pgptr, int length, const void *data,
 					    LOG_TDES * tdes, const LOG_LSA * undo_nxlsa);
 
-STATIC_INLINE void log_sysop_end_random_exit (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void log_sysop_end_random_exit (THREAD_ENTRY * thread_p) __attribute__((ALWAYS_INLINE));
 STATIC_INLINE void log_sysop_end_begin (THREAD_ENTRY * thread_p, int *tran_index_out, LOG_TDES ** tdes_out)
-  __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE void log_sysop_end_unstack (THREAD_ENTRY * thread_p, LOG_TDES * tdes) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE void log_sysop_end_final (THREAD_ENTRY * thread_p, LOG_TDES * tdes) __attribute__ ((ALWAYS_INLINE));
+  __attribute__((ALWAYS_INLINE));
+STATIC_INLINE void log_sysop_end_unstack (THREAD_ENTRY * thread_p, LOG_TDES * tdes) __attribute__((ALWAYS_INLINE));
+STATIC_INLINE void log_sysop_end_final (THREAD_ENTRY * thread_p, LOG_TDES * tdes) __attribute__((ALWAYS_INLINE));
 static void log_sysop_commit_internal (THREAD_ENTRY * thread_p, LOG_REC_SYSOP_END * log_record, int data_size,
 				       const char *data, bool is_rv_finish_postpone);
 STATIC_INLINE void log_sysop_get_tran_index_and_tdes (THREAD_ENTRY * thread_p, int *tran_index_out,
-						      LOG_TDES ** tdes_out) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int log_sysop_get_level (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
+						      LOG_TDES ** tdes_out) __attribute__((ALWAYS_INLINE));
+STATIC_INLINE int log_sysop_get_level (THREAD_ENTRY * thread_p) __attribute__((ALWAYS_INLINE));
 
 static void log_tran_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
 static void log_sysop_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_REC_SYSOP_END * sysop_end,
@@ -451,6 +451,10 @@ log_to_string (LOG_RECTYPE type)
       return "LOG_DUMMY_OVF_RECORD";
     case LOG_DUMMY_GENERIC:
       return "LOG_DUMMY_GENERIC";
+    case LOG_VACUUM_BOOT_START:
+      return "LOG_VACUUM_BOOT_START";
+    case LOG_NO_VACUUM_BOOT_START:
+      return "LOG_NO_VACUUM_BOOT_START";
 
     case LOG_SMALLER_LOGREC_TYPE:
     case LOG_LARGER_LOGREC_TYPE:
@@ -4816,7 +4820,7 @@ log_is_class_being_modified (THREAD_ENTRY * thread_p, const OID * class_oid)
  *       This will be used to decache the class representations and XASLs when a transaction is finished.
  */
 static void
-log_cleanup_modified_class (const tx_transient_class_entry & t, bool & stop)
+log_cleanup_modified_class (const tx_transient_class_entry & t, bool &stop)
 {
   THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
 
@@ -9630,7 +9634,7 @@ log_read_sysop_start_postpone (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_P
  * log_get_log_group_commit_interval () - setup flush daemon period based on system parameter
  */
 void
-log_get_log_group_commit_interval (bool & is_timed_wait, cubthread::delta_time & period)
+log_get_log_group_commit_interval (bool &is_timed_wait, cubthread::delta_time & period)
 {
   is_timed_wait = true;
 
@@ -9661,7 +9665,7 @@ log_get_log_group_commit_interval (bool & is_timed_wait, cubthread::delta_time &
  * log_get_checkpoint_interval () - setup log checkpoint daemon period based on system parameter
  */
 void
-log_get_checkpoint_interval (bool & is_timed_wait, cubthread::delta_time & period)
+log_get_checkpoint_interval (bool &is_timed_wait, cubthread::delta_time & period)
 {
   int log_checkpoint_interval_sec = prm_get_integer_value (PRM_ID_LOG_CHECKPOINT_INTERVAL_SECS);
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -451,10 +451,6 @@ log_to_string (LOG_RECTYPE type)
       return "LOG_DUMMY_OVF_RECORD";
     case LOG_DUMMY_GENERIC:
       return "LOG_DUMMY_GENERIC";
-    case LOG_VACUUM_BOOT_START:
-      return "LOG_VACUUM_BOOT_START";
-    case LOG_NO_VACUUM_BOOT_START:
-      return "LOG_NO_VACUUM_BOOT_START";
 
     case LOG_SMALLER_LOGREC_TYPE:
     case LOG_LARGER_LOGREC_TYPE:
@@ -6717,9 +6713,6 @@ log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type
     case LOG_DUMMY_CRASH_RECOVERY:
     case LOG_DUMMY_OVF_RECORD:
     case LOG_DUMMY_GENERIC:
-
-    case LOG_VACUUM_BOOT_START:
-    case LOG_NO_VACUUM_BOOT_START:
       fprintf (out_fp, "\n");
       /* That is all for this kind of log record */
       break;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -6717,6 +6717,9 @@ log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type
     case LOG_DUMMY_CRASH_RECOVERY:
     case LOG_DUMMY_OVF_RECORD:
     case LOG_DUMMY_GENERIC:
+
+    case LOG_VACUUM_BOOT_START:
+    case LOG_NO_VACUUM_BOOT_START:
       fprintf (out_fp, "\n");
       /* That is all for this kind of log record */
       break;

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -130,8 +130,6 @@ enum log_rectype
   LOG_SYSOP_ATOMIC_START = 50,	/* Log marker to start atomic operations that need to be rollbacked immediately after
                  * redo phase of recovery and before finishing postpones */
 
-  LOG_VACUUM_BOOT_START = 51, /* vacuum was booted on a transaction server */
-  LOG_NO_VACUUM_BOOT_START = 52, /* vacuum was not booted on a page server */
   LOG_DUMMY_GENERIC,		/* used for flush for now. it is ridiculous to create dummy log records for every single
 				 * case. we should find a different approach */
 

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -128,8 +128,10 @@ enum log_rectype
   LOG_MVCC_REDO_DATA = 48,	/* Redo for MVCC operations */
   LOG_MVCC_DIFF_UNDOREDO_DATA = 49,	/* diff undo redo data for MVCC operations */
   LOG_SYSOP_ATOMIC_START = 50,	/* Log marker to start atomic operations that need to be rollbacked immediately after
-				 * redo phase of recovery and before finishing postpones */
+                 * redo phase of recovery and before finishing postpones */
 
+  LOG_VACUUM_BOOT_START = 51, /* vacuum was booted on a transaction server */
+  LOG_NO_VACUUM_BOOT_START = 52, /* vacuum was not booted on a page server */
   LOG_DUMMY_GENERIC,		/* used for flush for now. it is ridiculous to create dummy log records for every single
 				 * case. we should find a different approach */
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-7

Disabled vacuum start on page server.
Added 2 new log types to signal if vacuum started on current server.

show threads on transaction server:
```shell
adrian@Sparrow:~/cubridScalabil$ csql -udba workdb -c "show threads" > show_threads.txt
adrian@Sparrow:~/cubridScalabil$ grep "VACUUM" show_threads.txt -c
1
```

show threads on page server:
```shell
adrian@Sparrow:~/cubridScalabil$ csql -udba workdb -c "show threads" > show_threads.txt 
adrian@Sparrow:~/cubridScalabil$ grep "VACUUM" show_threads.txt -c
0
```

err log on transaction server:
```shell
adrian@Sparrow:~/cubridScalabil$ grep "Vacuum" inst/log/server/workdb_latest.err 
Vacuum was started on the transaction server.
```

err log on page server:
```shell
adrian@Sparrow:~/cubridScalabil$ grep "Vacuum" inst/log/server/workdb_latest.err 
Vacuum was not started on the page server.
```

