### PR TITLE
[CBRD-23859] ROUND()'s result of decimal data type is wrong

### DIFF
--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -2003,14 +2003,8 @@ round_double (double num, double integer)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IT_DATA_OVERFLOW, 1, tp_Double_domain.type->name);
     }
-  if (num > 0)
-    {
-      result = floor (num * scale_up + 0.5) / scale_up;
-    }
-  else
-    {
-      result = ceil (num * scale_up - 0.5) / scale_up;
-    }
+
+  result = round (num * scale_up) / scale_up;
 
   return result;
 }

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -1990,27 +1990,26 @@ round_double (double num, double integer)
    * Under high optimization level, some optimizers (e.g, gcc -O3 on linux)
    * generates a wrong result without "volatile".
    */
-  volatile double scale_down, num_scale_up, result;
+  volatile double scale_up, result;
 
   if (num == 0)
     {
       return num;
     }
 
-  scale_down = pow (10, -integer);
-  num_scale_up = num / scale_down;
-  if (!FINITE (num_scale_up))
+  scale_up = pow (10, integer);
+
+  if (!FINITE (num * scale_up))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IT_DATA_OVERFLOW, 1, tp_Double_domain.type->name);
     }
-
-  if (num_scale_up > 0)
+  if (num > 0)
     {
-      result = floor (num_scale_up + 0.5) * scale_down;
+      result = floor (num * scale_up + 0.5) / scale_up;
     }
   else
     {
-      result = ceil (num_scale_up - 0.5) * scale_down;
+      result = ceil (num * scale_up - 0.5) / scale_up;
     }
 
   return result;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14627,6 +14627,7 @@ do_execute_select (PARSER_CONTEXT * parser, PT_NODE * statement)
  *
  * Note:
  */
+
 int
 do_replicate_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23859

In the case of a division operation in the process of calculating a double type in the linux gcc environment, 0 may change to 1 at the 16th digit below the decimal point.
If we change this operation to a multiplication operation, it is calculated correctly.