### PR TITLE
[CBRD-23865] Hierarchical query execution time difference between V11 and V10.2 occurs when using SQL hints /*+ no_hash_list_scan */

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -462,6 +462,13 @@ struct json_t;
 	   (op) == PT_QPRIOR || \
            (op) == PT_SYS_CONNECT_BY_PATH) ? true : false )
 
+#define PT_CHECK_HQ_OP_EXCEPT_PRIOR(op) \
+        ( ((op) == PT_LEVEL || \
+           (op) == PT_CONNECT_BY_ISCYCLE || \
+           (op) == PT_CONNECT_BY_ISLEAF || \
+           (op) == PT_CONNECT_BY_ROOT  || \
+	   (op) == PT_SYS_CONNECT_BY_PATH) ? true : false )
+
 #define PT_IS_NUMBERING_AFTER_EXECUTION(op) \
         ( ((op) == PT_INST_NUM || \
            (op) == PT_ROWNUM || \

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -3076,7 +3076,7 @@ pt_split_hash_attrs_for_HQ (PARSER_CONTEXT * parser, PT_NODE * pred, PT_NODE ** 
 	      /* 3. predicate without OR (or_next is null) */
 	      /* 4. symmetric predicate (having PRIOR, probe. having NAME, build. Having these two makes it unhashable) */
 	      /* 5. subquery is not allowed in syntax check */
-	      /* 6. Reserved words for HQ is not allowed (LEVEL, CONNECT_BY_ISLEAF....) */
+	      /* 6. Reserved words for HQ is not allowed (LEVEL, CONNECT_BY_ISLEAF....)  */
 	      continue;
 	    }
 	  else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23865

In the case of hierarchical query, the data filter is separately performed to evaluate reserved words of HQ such as 'LEVEL'.

In CUBRID v11, it has been modified to call scan_next_scan() instead of qfile_scan_list_next(). At this point, because the data filter evaluated by scan_next_scan() was removed, fetch_val_list() is called excessively, which is the cause of the slowdown.

By adding a data filter excluding the reserved words of HQ, the cause of the slowdown is eliminated.
In addition, it also fixes the problem that reserved words of HQ may be the target of hash list scan.