### PR TITLE
[LETS-9] Allow only csql --sysadm connections to the page server

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -118,6 +118,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/printer.cpp
   ${BASE_DIR}/release_string.c
   ${BASE_DIR}/resource_tracker.cpp
+  ${BASE_DIR}/server_type.cpp
   ${BASE_DIR}/sha1.c
   ${BASE_DIR}/stack_dump.c
   ${BASE_DIR}/string_buffer.cpp
@@ -152,6 +153,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/pinnable_buffer.hpp
   ${BASE_DIR}/porting_inline.hpp
   ${BASE_DIR}/printer.hpp
+  ${BASE_DIR}/server_type.hpp
   ${BASE_DIR}/string_buffer.hpp
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/semaphore.hpp

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -118,7 +118,6 @@ set(BASE_SOURCES
   ${BASE_DIR}/printer.cpp
   ${BASE_DIR}/release_string.c
   ${BASE_DIR}/resource_tracker.cpp
-  ${BASE_DIR}/server_type.cpp
   ${BASE_DIR}/sha1.c
   ${BASE_DIR}/stack_dump.c
   ${BASE_DIR}/string_buffer.cpp
@@ -153,7 +152,6 @@ set(BASE_HEADERS
   ${BASE_DIR}/pinnable_buffer.hpp
   ${BASE_DIR}/porting_inline.hpp
   ${BASE_DIR}/printer.hpp
-  ${BASE_DIR}/server_type.hpp
   ${BASE_DIR}/string_buffer.hpp
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/semaphore.hpp

--- a/src/connection/connection_globals.c
+++ b/src/connection/connection_globals.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#include "server_type.cpp"
 #include "porting.h"
 #include "memory_alloc.h"
 #include "boot.h"
@@ -84,6 +85,8 @@ const int css_Conn_rules_size = DIM (css_Conn_rules);
 static int
 css_get_normal_client_max_conn (void)
 {
+  if (get_server_type () == SERVER_TYPE_PAGE)
+    return 0;
   return prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS);
 }
 

--- a/src/connection/connection_globals.c
+++ b/src/connection/connection_globals.c
@@ -86,7 +86,9 @@ static int
 css_get_normal_client_max_conn (void)
 {
   if (get_server_type () == SERVER_TYPE_PAGE)
-    return 0;
+    {
+      return 0;
+    }
   return prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS);
 }
 
@@ -239,4 +241,14 @@ css_get_max_conn (void)
     }
 
   return total;
+}
+
+/*
+ * css_get_max_normal_conn() -
+ *    return: max number of client connections
+ */
+int
+css_get_max_normal_conn (void)
+{
+  return css_get_normal_client_max_conn ();
 }

--- a/src/connection/connection_globals.c
+++ b/src/connection/connection_globals.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#include "server_type.cpp"
+#include "server_type.hpp"
 #include "porting.h"
 #include "memory_alloc.h"
 #include "boot.h"

--- a/src/connection/connection_globals.c
+++ b/src/connection/connection_globals.c
@@ -61,7 +61,6 @@ char css_Net_magic[CSS_NET_MAGIC_SIZE] = { 0x00, 0x00, 0x00, 0x01, 0x20, 0x08, 0
 
 static bool css_Is_conn_rules_initialized = false;
 
-static int css_get_normal_client_max_conn (void);
 static int css_get_admin_client_max_conn (void);
 static int css_get_ha_client_max_conn (void);
 
@@ -72,28 +71,12 @@ static bool css_is_ha_client (BOOT_CLIENT_TYPE client_type);
 static int css_get_required_conn_num_for_ha (void);
 
 CSS_CONN_RULE_INFO css_Conn_rules[] = {
-  {css_is_normal_client, css_get_normal_client_max_conn, CR_NORMAL_ONLY, 0, 0},
+  {css_is_normal_client, css_get_max_normal_conn, CR_NORMAL_ONLY, 0, 0},
   {css_is_admin_client, css_get_admin_client_max_conn, CR_NORMAL_FIRST, 0, 0},
   {css_is_ha_client, css_get_ha_client_max_conn, CR_RESERVED_FIRST, 0, 0}
 };
 
 const int css_Conn_rules_size = DIM (css_Conn_rules);
-
-/*
- * css_get_normal_client_max_conn() -
- *   return: max_clients set by user
- */
-static int
-css_get_normal_client_max_conn (void)
-{
-#if defined (SERVER_MODE)
-  if (get_server_type () == SERVER_TYPE_PAGE)
-    {
-      return 0;
-    }
-#endif
-  return prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS);
-}
 
 /*
  * css_get_admin_client_max_conn() -
@@ -253,5 +236,11 @@ css_get_max_conn (void)
 int
 css_get_max_normal_conn (void)
 {
-  return css_get_normal_client_max_conn ();
+#if defined (SERVER_MODE)
+  if (get_server_type () == SERVER_TYPE_PAGE)
+    {
+      return 0;
+    }
+#endif
+  return prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS);
 }

--- a/src/connection/connection_globals.c
+++ b/src/connection/connection_globals.c
@@ -30,8 +30,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-
+#if defined (SERVER_MODE)
 #include "server_type.hpp"
+#endif
 #include "porting.h"
 #include "memory_alloc.h"
 #include "boot.h"
@@ -85,10 +86,12 @@ const int css_Conn_rules_size = DIM (css_Conn_rules);
 static int
 css_get_normal_client_max_conn (void)
 {
+#if defined (SERVER_MODE)
   if (get_server_type () == SERVER_TYPE_PAGE)
     {
       return 0;
     }
+#endif
   return prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS);
 }
 

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -72,5 +72,6 @@ extern SOCKET css_Pipe_to_master;
 extern char css_Net_magic[CSS_NET_MAGIC_SIZE];
 extern void css_init_conn_rules (void);
 extern int css_get_max_conn (void);
+extern int css_get_max_normal_conn (void);
 
 #endif /* _CONNECTION_GLOBALS_H_ */

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -6700,7 +6700,7 @@ fileio_initialize_backup_thread (FILEIO_BACKUP_SESSION * session_p, int num_thre
   thread_info_p->num_threads = 1;
 #endif /* SERVER_MODE */
 #if defined(CUBRID_DEBUG)
-  fprintf (stdout, "PRM_CSS_MAX_CLIENTS = %d, tp->num_threads = %d\n", css_get_normal_client_max_conn (),
+  fprintf (stdout, "PRM_CSS_MAX_CLIENTS = %d, tp->num_threads = %d\n", css_get_max_normal_conn (),
 	   thread_info_p->num_threads);
 #endif /* CUBRID_DEBUG */
   queue_p->size = 0;

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -6700,7 +6700,7 @@ fileio_initialize_backup_thread (FILEIO_BACKUP_SESSION * session_p, int num_thre
   thread_info_p->num_threads = 1;
 #endif /* SERVER_MODE */
 #if defined(CUBRID_DEBUG)
-  fprintf (stdout, "PRM_CSS_MAX_CLIENTS = %d, tp->num_threads = %d\n", prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS),
+  fprintf (stdout, "PRM_CSS_MAX_CLIENTS = %d, tp->num_threads = %d\n", css_get_normal_client_max_conn (),
 	   thread_info_p->num_threads);
 #endif /* CUBRID_DEBUG */
   queue_p->size = 0;
@@ -11827,7 +11827,7 @@ fileio_page_bitmap_dump (FILE * out_fp, const FILEIO_RESTORE_PAGE_BITMAP * page_
  *   is_page_corrupted (out): true, if the page is corrupted.
  */
 int
-fileio_page_check_corruption (THREAD_ENTRY * thread_p, FILEIO_PAGE * io_page, bool * is_page_corrupted)
+fileio_page_check_corruption (THREAD_ENTRY * thread_p, FILEIO_PAGE * io_page, bool *is_page_corrupted)
 {
   assert (io_page != NULL && is_page_corrupted != NULL);
 

--- a/src/transaction/log_common_impl.h
+++ b/src/transaction/log_common_impl.h
@@ -45,7 +45,7 @@
  */
 #define LOG_PAGE_INIT_VALUE 0xff
 
-#define NUM_NORMAL_TRANS (prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS))
+#define NUM_NORMAL_TRANS (css_get_normal_client_max_conn())
 #define NUM_SYSTEM_TRANS 1
 #define NUM_NON_SYSTEM_TRANS (css_get_max_conn ())
 #define MAX_NTRANS \

--- a/src/transaction/log_common_impl.h
+++ b/src/transaction/log_common_impl.h
@@ -45,7 +45,7 @@
  */
 #define LOG_PAGE_INIT_VALUE 0xff
 
-#define NUM_NORMAL_TRANS (css_get_normal_client_max_conn())
+#define NUM_NORMAL_TRANS (css_get_max_normal_conn ())
 #define NUM_SYSTEM_TRANS 1
 #define NUM_NON_SYSTEM_TRANS (css_get_max_conn ())
 #define MAX_NTRANS \


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-9

Queries should not be run on the page server, only one sysadm connection is allowed.

Connections on the page server:
```bash
adrian@Sparrow:~/cubridScalabil/cubrid$ csql -udba workdb
Server refused client connection: max clients, (0), exceeded.
Failed to connect to database server, 'workdb', on the following host(s): localhost
```

normal working connection with --sysadm:
```bash
adrian@Sparrow:~/cubridScalabil/cubrid$ csql -udba workdb --sysadm

	CUBRID SQL Interpreter


Type `;help' for help messages.

sysadm> ;ex
```
Show threads on sysadm connection on the page server:
```bash
adrian@Sparrow:~/cubridScalabil$ csql --sysadm  -udba workdb -c "show threads" > show_threads.txt
adrian@Sparrow:~/cubridScalabil$ geany show_threads.txt 
adrian@Sparrow:~/cubridScalabil$ grep "RUN" show_threads.txt 
          123         NULL       139632733841152         NULL  'SERVER'              'RUN'                 'RESUME_NONE'         NULL                            NULL             NULL            1                0  NULL                  '0x559040b7ed00'      NULL                            0            0                1                       0  NULL                  NULL                                     NULL  NULL                                    NULL                         NULL                      NULL
          125         NULL       139632825734912            1  'WORKER'              'RUN'                 'RESUME_NONE'         'QM_QUERY_EXECUTE'                 8            65568            1                0  NULL                  '0x559040b9f400'      NULL                            0            0                1                       0  NULL                  NULL                                     NULL  NULL                                    NULL                         NULL                      NULL
```