### PR TITLE
[LETS-26] Synchronize pushing requests and automate sending

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -192,6 +192,7 @@ set(COMMUNICATION_HEADERS
   ${COMMUNICATION_DIR}/communication_channel.hpp
   ${COMMUNICATION_DIR}/communication_server_channel.hpp
   ${COMMUNICATION_DIR}/request_client_server.hpp
+  ${COMMUNICATION_DIR}/request_sync_send_queue.hpp
   )
 
 set(MONITOR_SOURCES

--- a/src/communication/request_client_server.hpp
+++ b/src/communication/request_client_server.hpp
@@ -137,10 +137,12 @@ namespace cubcomm
   class request_client
   {
     public:
+      using client_request_id = MsgId;
+
       request_client () = delete;
       request_client (channel &&chn);
       request_client (const request_client &) = delete;
-      request_client (request_client &&other) = default;
+      request_client (request_client &&other) noexcept = default;
 
       template <typename ... PackableArgs>
       int send (MsgId msgid, const PackableArgs &... args);	//  pack args and send request of type msgid
@@ -157,6 +159,7 @@ namespace cubcomm
   {
     public:
       using server_request_handler = std::function<void (cubpacking::unpacker &upk)>;
+      using server_request_id = MsgId;
 
       request_server () = delete;
       request_server (channel &&chn);
@@ -167,7 +170,7 @@ namespace cubcomm
       void start_thread ();	  // start thread that receives and handles requests
       void stop_thread ();	  // stop the thread
 
-      void register_request_handler (MsgId msgid, server_request_handler &handler);	  // register a handler
+      void register_request_handler (MsgId msgid, const server_request_handler &handler);	  // register a handler
 
       const channel &get_channel () const;						  // get underlying channel
 
@@ -195,6 +198,8 @@ namespace cubcomm
   class request_client_server : public request_server<ServerMsgId>
   {
     public:
+      using client_request_id = ClientMsgId;
+
       request_client_server (channel &&chn);
       request_client_server (const request_client_server &) = delete;
       request_client_server (request_client_server &&other) = default;
@@ -238,7 +243,7 @@ namespace cubcomm
   }
 
   template <typename MsgId>
-  void request_server<MsgId>::register_request_handler (MsgId msgid, server_request_handler &handler)
+  void request_server<MsgId>::register_request_handler (MsgId msgid, const server_request_handler &handler)
   {
     m_request_handlers[msgid] = handler;
   }

--- a/src/communication/request_client_server.hpp
+++ b/src/communication/request_client_server.hpp
@@ -142,7 +142,7 @@ namespace cubcomm
       request_client () = delete;
       request_client (channel &&chn);
       request_client (const request_client &) = delete;
-      request_client (request_client &&other) noexcept = default;
+      request_client (request_client &&other) = default;
 
       template <typename ... PackableArgs>
       int send (MsgId msgid, const PackableArgs &... args);	//  pack args and send request of type msgid
@@ -364,7 +364,7 @@ namespace cubcomm
   template <typename ... PackableArgs>
   int request_client_server<ClientMsgId, ServerMsgId>::send (ClientMsgId msgid, const PackableArgs &... args)
   {
-    return send_client_request (m_channel, msgid, args...);
+    return send_client_request (this->request_server<ServerMsgId>::m_channel, msgid, args...);
   }
 
   template <typename MsgId, typename ... PackableArgs>

--- a/src/communication/request_sync_send_queue.hpp
+++ b/src/communication/request_sync_send_queue.hpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef _REQUEST_SYNC_SENDQUEUE_
+#define _REQUEST_SYNC_SEND_QUEUE_
+
+#include "request_client_server.hpp"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+namespace cubcomm
+{
+  // Synchronize sending requests. Allow multiple threads to push requests and to send requests to the server.
+  //
+  // Template types:
+  //
+  //    - ReqClient can be either a request_client or a request_client_server
+  //    - Payload needs to be a packable object
+  //
+  // How it works:
+  //
+  //    - Any number of threads can push requests using push_request
+  //    - One or more sender threads can send the queued requests using send_requests functions.
+  //    The requests are send in the exact order as they are pushed if there is only one sender.
+  //
+  template <typename ReqClient, typename ReqPayload>
+  class request_sync_send_queue
+  {
+    public:
+      // types:
+      using client_type = ReqClient;
+      using payload_type = ReqPayload;
+
+      struct queue_item_type
+      {
+	typename client_type::client_request_id m_id;
+	payload_type m_payload;
+      };
+      using queue_type = std::queue<queue_item_type>;
+
+      // ctor/dtor:
+      request_sync_send_queue () = delete;
+      request_sync_send_queue (client_type &&client);
+
+      // functions:
+
+      // Push a request to the end of queue
+      void push (typename client_type::client_request_id reqid, payload_type &&payload);
+
+      // Send all requests to the server. If queue is empty, nothing happens.
+      //
+      // The backbuffer argument consumes all requests and temporary holds them until they are sent to server.
+      // It is used to allow concurrent sends and to optimize queue consumption.
+      void send_all (queue_type &backbuffer);
+
+      // Send all requests to server, and if queue is empty, wait until timeout for new requests.
+      //
+      // The backbuffer argument consumes all requests and temporary holds them until they are sent to server.
+      // It is used to allow concurrent sends and to optimize queue consumption.
+      template <typename Duration>
+      void wait_not_empty_and_send_all (queue_type &backbuffer, const Duration &timeout);
+
+    private:
+      void send_queue (queue_type &q); // Send queued requests to the server
+
+      // Members used for sending requests:
+      client_type m_client;                       // The request client, sends requests over network
+      std::mutex m_send_mutex;                    // Synchronize request sending
+
+      queue_type m_request_queue;                 // Queue for pushed requests
+      std::mutex m_queue_mutex;                   // Synchronize request pushing and consuming
+      std::condition_variable m_queue_condvar;    // Notify request consumers
+  };
+
+  // The request_queue_autosend automatically sends requests pushed into request_sync_send_queue
+  //
+  // Template types:
+  //
+  //    - ReqQueue is request_sync_send_queue type
+  //
+  // How it works:
+  //
+  //    - A background thread loops and sends all requests pushed into req_queue.
+  //
+  template <typename ReqQueue>
+  class request_queue_autosend
+  {
+    public:
+      using request_queue_type = ReqQueue;
+
+      // ctor/dtor:
+      request_queue_autosend (request_queue_type &req_queue);
+      ~request_queue_autosend ();
+
+      void start_thread ();           // start background thread
+      void stop_thread ();            // stop background thread
+
+    private:
+      void loop_send_requests ();     // consume and sent requests in a loop
+
+      std::thread m_thread;           // background thread
+      bool m_shutdown = false;        // true to stop background thread loop
+
+      request_queue_type &m_req_queue;  // reference to the requests queue; !!!stop_thread() before queue is destroyed
+  };
+}
+
+//
+// Implementation
+//
+
+namespace cubcomm
+{
+
+  //
+  // request_sync_send_queue
+  //
+
+  template <typename ReqClient, typename ReqPayload>
+  request_sync_send_queue<ReqClient, ReqPayload>::request_sync_send_queue (client_type &&client)
+    : m_client (std::move (client))
+  {
+  }
+
+  template <typename ReqClient, typename ReqPayload>
+  void
+  request_sync_send_queue<ReqClient, ReqPayload>::push (typename client_type::client_request_id reqid,
+      payload_type &&payload)
+  {
+    // synchronize push request into the queue and notify consumers
+
+    std::unique_lock<std::mutex> ulock (m_queue_mutex);
+    m_request_queue.emplace ();
+    m_request_queue.back ().m_id = reqid;
+    m_request_queue.back ().m_payload = std::move (payload);
+
+    ulock.unlock ();
+    m_queue_condvar.notify_all ();
+  }
+
+  template <typename ReqClient, typename ReqPayload>
+  void
+  request_sync_send_queue<ReqClient, ReqPayload>::send_queue (queue_type &q)
+  {
+    // send all requests in q
+
+    std::unique_lock<std::mutex> ulock (m_send_mutex);
+    while (!q.empty ())
+      {
+	if (m_client.send (q.front ().m_id, q.front ().m_payload) != NO_ERRORS)
+	  {
+	    // what to do, what to do? we need proper handling
+	    assert (false);
+	  }
+	q.pop ();
+      }
+  }
+
+  template <typename ReqClient, typename ReqPayload>
+  void
+  request_sync_send_queue<ReqClient, ReqPayload>::send_all (queue_type &backbuffer)
+  {
+    // Swap requests queue with the backbuffer. If there are any requests in the backbuffer, send them.
+    assert (backbuffer.empty ());
+
+    std::unique_lock<std::mutex> ulock (m_queue_mutex);
+    m_request_queue.swap (backbuffer);
+    ulock.unlock ();
+
+    if (!backbuffer.empty ())
+      {
+	send_queue (backbuffer);
+      }
+  }
+
+  template <typename ReqClient, typename ReqPayload>
+  template <typename Duration>
+  void
+  request_sync_send_queue<ReqClient, ReqPayload>::wait_not_empty_and_send_all (queue_type &backbuffer,
+      const Duration &timeout)
+  {
+    // Wait until the queue in not empty or until timeout.
+    // If there are requests in the queue, swap the queue with the backbuffer. Then send them
+
+    assert (backbuffer.empty ());
+
+    std::unique_lock<std::mutex> ulock (m_queue_mutex);
+    auto condvar_ret = m_queue_condvar.wait_for (ulock, timeout, [this]
+    {
+      return !m_request_queue.empty ();
+    });
+    if (!condvar_ret)
+      {
+	return;
+      }
+    assert (!m_request_queue.empty ());
+    m_request_queue.swap (backbuffer);
+    ulock.unlock ();
+
+    send_queue (backbuffer);
+  }
+
+  //
+  // request_queue_sender
+  //
+
+  template <typename ReqQueue>
+  request_queue_autosend<ReqQueue>::request_queue_autosend (request_queue_type &req_queue)
+    : m_req_queue (req_queue)
+  {
+  }
+
+  template <typename ReqQueue>
+  request_queue_autosend<ReqQueue>::~request_queue_autosend ()
+  {
+    stop_thread ();
+  }
+
+  template <typename ReqQueue>
+  void
+  request_queue_autosend<ReqQueue>::loop_send_requests ()
+  {
+    ReqQueue::queue_type requests;
+    while (!m_shutdown)
+      {
+	// Check shutdown flag every 10 milliseconds
+	m_req_queue.wait_not_empty_and_send_all (requests, std::chrono::milliseconds (10));
+      }
+  }
+
+  template <typename ReqQueue>
+  void
+  request_queue_autosend<ReqQueue>::start_thread ()
+  {
+    m_shutdown = false;
+    m_thread = std::thread (&request_queue_autosend<ReqQueue>::loop_send_requests, std::ref (*this));
+  }
+
+  template <typename ReqQueue>
+  void
+  request_queue_autosend<ReqQueue>::stop_thread ()
+  {
+    m_shutdown = true;
+    if (m_thread.joinable ())
+      {
+	m_thread.join ();
+      }
+  }
+}
+
+#endif // !_REQUEST_SYNC_SEND_QUEUE_

--- a/src/communication/request_sync_send_queue.hpp
+++ b/src/communication/request_sync_send_queue.hpp
@@ -239,7 +239,7 @@ namespace cubcomm
   void
   request_queue_autosend<ReqQueue>::loop_send_requests ()
   {
-    ReqQueue::queue_type requests;
+    typename ReqQueue::queue_type requests;
     while (!m_shutdown)
       {
 	// Check shutdown flag every 10 milliseconds

--- a/unit_tests/request_client_server/CMakeLists.txt
+++ b/unit_tests/request_client_server/CMakeLists.txt
@@ -48,8 +48,13 @@ target_include_directories(test_request_cs PRIVATE
   )
 
 target_link_libraries(test_request_cs PRIVATE
-  test_common ws2_32
+  test_common
   )
+if(WIN32)
+  target_link_libraries(test_request_cs PRIVATE
+  ws2_32
+  )
+endif(WIN32)
 
 add_dependencies(test_request_cs
   ${CATCH2_TARGET}

--- a/unit_tests/request_client_server/comm_channel_mock.cpp
+++ b/unit_tests/request_client_server/comm_channel_mock.cpp
@@ -48,6 +48,7 @@ mock_socket_direction::push_message (std::string &&str)
       return false;
     }
   m_messages.push (std::move (str));
+  ++m_message_count;
   ulock.unlock ();
   m_condvar.notify_all ();
   return true;
@@ -99,6 +100,16 @@ mock_socket_direction::wait_for_all_messages ()
   m_condvar.wait (ulock, [this]
   {
     return m_messages.empty () || m_disconnect;
+  });
+}
+
+void
+mock_socket_direction::wait_until_message_count (size_t count)
+{
+  std::unique_lock<std::mutex> ulock (m_mutex);
+  m_condvar.wait (ulock, [this, &count]
+  {
+    return m_message_count >= count || m_disconnect;
   });
 }
 

--- a/unit_tests/request_client_server/comm_channel_mock.hpp
+++ b/unit_tests/request_client_server/comm_channel_mock.hpp
@@ -63,12 +63,14 @@ class mock_socket_direction
     bool has_message ();
     void disconnect ();                         // abort all waits when channels are disconnected
     void wait_for_all_messages ();              // wait until all messages are pulled and the message queue is empty
+    void wait_until_message_count (size_t count);
 
   private:
     std::queue<std::string> m_messages;
     std::mutex m_mutex;
     std::condition_variable m_condvar;
     bool m_disconnect = false;
+    size_t m_message_count = 0;
 };
 
 void add_socket_direction (const std::string &sender_id, const std::string &receiver_id,

--- a/unit_tests/request_client_server/comm_channel_mock.hpp
+++ b/unit_tests/request_client_server/comm_channel_mock.hpp
@@ -19,6 +19,7 @@
 #ifndef _COMM_CHANNEL_MOCK_HPP_
 #define _COMM_CHANNEL_MOCK_HPP_
 
+#include <condition_variable>
 #include <mutex>
 #include <queue>
 #include <string>

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -643,7 +643,7 @@ test_client_and_server_env::move_client ()
 void
 test_client_and_server_env::wait_for_all_messages ()
 {
-  m_sockdir.wait_until_message_count (global_sent_request_count);
+  m_sockdir.wait_until_message_count (global_sent_request_count * 2);  // each request sends two messages
   m_sockdir.wait_for_all_messages ();
 }
 

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -26,10 +26,11 @@
 #include "comm_channel_mock.hpp"
 
 #include <array>
+#include <atomic>
 #include <functional>
 
-static size_t global_sent_request_count;
-static size_t global_handled_request_count;
+static std::atomic<size_t> global_sent_request_count;
+static std::atomic<size_t> global_handled_request_count;
 
 static void init_globals ();                              // init global values for new test case
 
@@ -642,6 +643,7 @@ test_client_and_server_env::move_client ()
 void
 test_client_and_server_env::wait_for_all_messages ()
 {
+  m_sockdir.wait_until_message_count (global_sent_request_count);
   m_sockdir.wait_for_all_messages ();
 }
 

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -150,7 +150,7 @@ class test_two_client_server_env
 };
 
 //
-// Stuff for request_queue_sender test case.
+// Stuff for request_queue_autosend test case.
 // Also tests the request order. The request payload is extended to include the operation count.
 //
 
@@ -369,10 +369,10 @@ TEST_CASE ("Verify request_sync_send_queue with request_client", "")
   require_all_sent_requests_are_handled ();
 }
 
-TEST_CASE ("Test request_queue_sender", "")
+TEST_CASE ("Test request_queue_autosend", "")
 {
-  // Test the way requests are handled using a request_queue_sender. All pushed requests are automatically send by the
-  // request_queue_sender. The requests are sent in the same order that they are pushed.
+  // Test the way requests are handled using a request_queue_autosend. All pushed requests are automatically send by
+  // the request_queue_autosend. The requests are sent in the same order that they are pushed.
   //
   // Verify that:
   //	- all requests are handled by the expected type of handled

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -21,9 +21,11 @@
 
 #include "communication_channel.hpp"
 #include "request_client_server.hpp"
+#include "request_sync_send_queue.hpp"
 
 #include "comm_channel_mock.hpp"
 
+#include <array>
 #include <functional>
 
 static size_t global_sent_request_count;
@@ -38,6 +40,9 @@ static void require_all_sent_requests_are_handled ();     // require that all se
 template <typename ReqCl, typename ReqId>
 static void send_request_id_as_message (ReqCl &reqcl, ReqId rid);
 
+template <typename RSSQ, typename ReqId>
+static void push_request_id_as_message (RSSQ &rssq, ReqId rid);
+
 // Server request handler function for unpacking a ReqId and requiring to find ExpectedVal
 template <typename ReqId, ReqId ExpectedVal>
 static void
@@ -47,6 +52,7 @@ mock_check_expected_id (cubpacking::unpacker &upk);
 // Stuff for one client and one server test case
 //
 
+// Request ids for requests sent by a client to a server
 enum class reqids
 {
   _0,
@@ -54,16 +60,47 @@ enum class reqids
 };
 using test_request_client = cubcomm::request_client<reqids>;
 using test_request_server = cubcomm::request_server<reqids>;
+using test_handler_register_function = std::function<void (test_request_server &)>;
 
+// Create a request_client for this test
 static test_request_client create_request_client ();
-static test_request_server create_request_server ();
+// Create a request_server for this test. Different functions can be registered by passing different handler_register
+static test_request_server create_request_server (const test_handler_register_function &handler_register);
+// Set a mock socket between a client and a server
 static void mock_socket_between_client_and_server (const test_request_client &cl, const test_request_server &sr,
     mock_socket_direction &sockdir);
+static void handler_register_mock_check_expected_id (test_request_server &req_sr);
+
+// Environment for testing a client and server
+class test_client_and_server_env
+{
+  public:
+    // ctor/dtor:
+    // construct test server with custom handler functions
+    test_client_and_server_env (test_handler_register_function &hreg);
+    ~test_client_and_server_env ();
+
+    // get references to client/server
+    test_request_client &get_client ();
+    test_request_server &get_server ();
+
+    // move client
+    test_request_client move_client ();
+
+    // wait for all sent messages to be processed by server
+    void wait_for_all_messages ();
+
+  private:
+    test_request_client m_client;	// the client
+    test_request_server m_server;	// the server
+    mock_socket_direction m_sockdir;	// socket direction
+};
 
 //
 // Stuff for two client-server test case
 //
 
+// Request ids exchanged by two client-server's
 enum class reqids_1_to_2
 {
   _0,
@@ -90,6 +127,57 @@ static void mock_socket_between_two_client_servers (const test_request_client_se
     mock_socket_direction &sockdir_1_to_2,
     mock_socket_direction &sockdir_2_to_1);
 
+// Testing environment for two client-server's
+class test_two_client_server_env
+{
+  public:
+    // ctor/dtor:
+    test_two_client_server_env ();
+    ~test_two_client_server_env ();
+
+    // Get reference to a client-server instance
+    test_request_client_server_type_one &get_cs_one ();
+    test_request_client_server_type_two &get_cs_two ();
+
+    // Wait for all sent messages, from both ends, to be processed by both servers
+    void wait_for_all_messages ();
+
+  private:
+    test_request_client_server_type_one m_first_cs;	// the first client-server
+    test_request_client_server_type_two m_second_cs;	// the second client-server
+    mock_socket_direction m_sockdir_one_two;		// socket direction from first client to second server
+    mock_socket_direction m_sockdir_two_one;		// socket direction from second client to first server
+};
+
+//
+// Stuff for request_queue_sender test case.
+// Also tests the request order. The request payload is extended to include the operation count.
+//
+
+// Global op count, per each request id, is used by the server to check the requests are processed in the expected
+// order.
+std::array<int, 2> global_op_count;
+
+struct payload_with_op_count : public cubpacking::packable_object
+{
+  int val;	  // static_cast<int> (requid)
+  int op_count;	  // the op count
+
+  /* used at packing to get info on how much memory to reserve */
+  size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset = 0) const final;
+  void pack (cubpacking::packer &serializator) const final;
+  void unpack (cubpacking::unpacker &deserializator) final;
+};
+
+// Send both reqids and op_count into the request payload
+template <typename RSSQ, typename ReqId>
+static void push_message_id_and_op (RSSQ &rssq, ReqId reqid, int op_count);
+// Server handler checks both request id and request order
+template <typename ReqId, ReqId ExpectedVal>
+static void mock_check_expected_id_and_op_count (cubpacking::unpacker &upk);
+// Function for registering mock_check_expected_id_and_op_count handlers
+static void handler_register_mock_check_expected_id_and_op_count (test_request_server &req_sr);
+
 TEST_CASE ("A client and a server", "")
 {
   // Test how the requests sent by the request_client are handled by the request_server. The main thread of test case
@@ -98,32 +186,23 @@ TEST_CASE ("A client and a server", "")
   // Verify that:
   //    - the requests get handled on the server by the expected type of handler.
   //    - the number of requests sent is same as the number of requests handled.
+  test_handler_register_function hreg_fun = handler_register_mock_check_expected_id;
+  test_client_and_server_env env (hreg_fun);
 
-  test_request_client req_client = create_request_client ();
-  test_request_server req_server = create_request_server ();
+  env.get_server ().start_thread ();
 
-  mock_socket_direction sockdir;
-  mock_socket_between_client_and_server (req_client, req_server, sockdir);
+  send_request_id_as_message (env.get_client (), reqids::_0);
+  send_request_id_as_message (env.get_client (), reqids::_1);
+  send_request_id_as_message (env.get_client (), reqids::_1);
+  send_request_id_as_message (env.get_client (), reqids::_1);
+  send_request_id_as_message (env.get_client (), reqids::_0);
+  send_request_id_as_message (env.get_client (), reqids::_1);
+  send_request_id_as_message (env.get_client (), reqids::_0);
 
-  init_globals ();
-
-  req_server.start_thread ();
-
-  send_request_id_as_message (req_client, reqids::_0);
-  send_request_id_as_message (req_client, reqids::_1);
-  send_request_id_as_message (req_client, reqids::_1);
-  send_request_id_as_message (req_client, reqids::_1);
-  send_request_id_as_message (req_client, reqids::_0);
-  send_request_id_as_message (req_client, reqids::_1);
-  send_request_id_as_message (req_client, reqids::_0);
-
-  sockdir.wait_for_all_messages ();
-
-  req_server.stop_thread ();
+  env.wait_for_all_messages ();
+  env.get_server ().stop_thread ();
 
   require_all_sent_requests_are_handled ();
-
-  clear_socket_directions ();
 }
 
 TEST_CASE ("Two client-server communicate with each-other", "")
@@ -137,46 +216,206 @@ TEST_CASE ("Two client-server communicate with each-other", "")
   //    - the number of requests sent is same as the number of requests handled.
   //
 
-  test_request_client_server_type_one req_client_server_1 = create_request_client_server_one ();
-  test_request_client_server_type_two req_client_server_2 = create_request_client_server_two ();
+  test_two_client_server_env env;
 
-  mock_socket_direction sockdir_1_to_2;
-  mock_socket_direction sockdir_2_to_1;
-  mock_socket_between_two_client_servers (req_client_server_1, req_client_server_2, sockdir_1_to_2, sockdir_2_to_1);
-
-  init_globals ();
-
-  req_client_server_1.start_thread ();
-  req_client_server_2.start_thread ();
+  env.get_cs_one ().start_thread ();
+  env.get_cs_two ().start_thread ();
 
   // Mix sends on both ends
-  send_request_id_as_message (req_client_server_1, reqids_1_to_2::_0);
-  send_request_id_as_message (req_client_server_2, reqids_2_to_1::_0);
-  send_request_id_as_message (req_client_server_1, reqids_1_to_2::_1);
-  send_request_id_as_message (req_client_server_1, reqids_1_to_2::_1);
-  send_request_id_as_message (req_client_server_2, reqids_2_to_1::_0);
-  send_request_id_as_message (req_client_server_1, reqids_1_to_2::_0);
-  send_request_id_as_message (req_client_server_1, reqids_1_to_2::_0);
-  send_request_id_as_message (req_client_server_1, reqids_1_to_2::_1);
-  send_request_id_as_message (req_client_server_1, reqids_1_to_2::_1);
-  send_request_id_as_message (req_client_server_1, reqids_1_to_2::_1);
-  send_request_id_as_message (req_client_server_2, reqids_2_to_1::_1);
-  send_request_id_as_message (req_client_server_1, reqids_1_to_2::_1);
-  send_request_id_as_message (req_client_server_2, reqids_2_to_1::_0);
-  send_request_id_as_message (req_client_server_2, reqids_2_to_1::_1);
-  send_request_id_as_message (req_client_server_2, reqids_2_to_1::_0);
-  send_request_id_as_message (req_client_server_2, reqids_2_to_1::_1);
-  send_request_id_as_message (req_client_server_2, reqids_2_to_1::_0);
+  send_request_id_as_message (env.get_cs_one (), reqids_1_to_2::_0);
+  send_request_id_as_message (env.get_cs_two (), reqids_2_to_1::_0);
+  send_request_id_as_message (env.get_cs_one (), reqids_1_to_2::_1);
+  send_request_id_as_message (env.get_cs_one (), reqids_1_to_2::_1);
+  send_request_id_as_message (env.get_cs_two (), reqids_2_to_1::_0);
+  send_request_id_as_message (env.get_cs_one (), reqids_1_to_2::_0);
+  send_request_id_as_message (env.get_cs_one (), reqids_1_to_2::_0);
+  send_request_id_as_message (env.get_cs_one (), reqids_1_to_2::_1);
+  send_request_id_as_message (env.get_cs_one (), reqids_1_to_2::_1);
+  send_request_id_as_message (env.get_cs_one (), reqids_1_to_2::_1);
+  send_request_id_as_message (env.get_cs_two (), reqids_2_to_1::_1);
+  send_request_id_as_message (env.get_cs_one (), reqids_1_to_2::_1);
+  send_request_id_as_message (env.get_cs_two (), reqids_2_to_1::_0);
+  send_request_id_as_message (env.get_cs_two (), reqids_2_to_1::_1);
+  send_request_id_as_message (env.get_cs_two (), reqids_2_to_1::_0);
+  send_request_id_as_message (env.get_cs_two (), reqids_2_to_1::_1);
+  send_request_id_as_message (env.get_cs_two (), reqids_2_to_1::_0);
 
-  sockdir_1_to_2.wait_for_all_messages ();
-  sockdir_2_to_1.wait_for_all_messages ();
-
-  req_client_server_1.stop_thread ();
-  req_client_server_2.stop_thread ();
+  env.wait_for_all_messages ();
+  env.get_cs_one ().stop_thread ();
+  env.get_cs_two ().stop_thread ();
 
   require_all_sent_requests_are_handled ();
+}
 
-  clear_socket_directions ();
+TEST_CASE ("Verify request_sync_send_queue with request_client", "")
+{
+  // Test how requests are handled by request_sync_send_queue. Multiple threads may push requests, and multiple
+  // threads may send the queued requests.
+  //
+  // Verify that:
+  //	- all requests are handled by the expected type of handler
+  //	- the number of requests sent is same as the number of requests handled
+
+  test_handler_register_function hreg_fun = handler_register_mock_check_expected_id;
+  test_client_and_server_env env (hreg_fun);
+
+  using test_rssq = cubcomm::request_sync_send_queue<test_request_client, int>;
+
+  test_rssq rssq (env.move_client ());
+  test_rssq::queue_type backbuffer;
+
+  env.get_server ().start_thread ();
+
+  SECTION ("Push and send all request on current thread")
+  {
+    push_request_id_as_message (rssq, reqids::_0);
+    rssq.send_all (backbuffer);
+    push_request_id_as_message (rssq, reqids::_1);
+    push_request_id_as_message (rssq, reqids::_0);
+    push_request_id_as_message (rssq, reqids::_0);
+    rssq.send_all (backbuffer);
+    push_request_id_as_message (rssq, reqids::_1);
+    push_request_id_as_message (rssq, reqids::_0);
+    push_request_id_as_message (rssq, reqids::_0);
+    push_request_id_as_message (rssq, reqids::_1);
+    push_request_id_as_message (rssq, reqids::_0);
+    push_request_id_as_message (rssq, reqids::_0);
+    push_request_id_as_message (rssq, reqids::_1);
+    push_request_id_as_message (rssq, reqids::_0);
+    push_request_id_as_message (rssq, reqids::_0);
+    push_request_id_as_message (rssq, reqids::_1);
+    push_request_id_as_message (rssq, reqids::_0);
+    push_request_id_as_message (rssq, reqids::_0);
+    rssq.send_all (backbuffer);
+  }
+  SECTION ("Push requests on other threads and send everything at the end on current thread")
+  {
+    std::thread t1 ([&rssq]
+    {
+      push_request_id_as_message (rssq, reqids::_0);
+      push_request_id_as_message (rssq, reqids::_1);
+      push_request_id_as_message (rssq, reqids::_0);
+      push_request_id_as_message (rssq, reqids::_1);
+      push_request_id_as_message (rssq, reqids::_0);
+      push_request_id_as_message (rssq, reqids::_0);
+      push_request_id_as_message (rssq, reqids::_1);
+      push_request_id_as_message (rssq, reqids::_0);
+      push_request_id_as_message (rssq, reqids::_1);
+      push_request_id_as_message (rssq, reqids::_0);
+    });
+    std::thread t2 ([&rssq]
+    {
+      push_request_id_as_message (rssq, reqids::_0);
+      push_request_id_as_message (rssq, reqids::_1);
+      push_request_id_as_message (rssq, reqids::_1);
+      push_request_id_as_message (rssq, reqids::_0);
+      push_request_id_as_message (rssq, reqids::_1);
+      push_request_id_as_message (rssq, reqids::_0);
+      push_request_id_as_message (rssq, reqids::_1);
+      push_request_id_as_message (rssq, reqids::_1);
+      push_request_id_as_message (rssq, reqids::_1);
+      push_request_id_as_message (rssq, reqids::_0);
+    });
+    t1.join ();
+    t2.join ();
+    rssq.send_all (backbuffer);
+  }
+  SECTION ("Push requests on other threads and send requests on other threads")
+  {
+    std::thread t1 ([&rssq]
+    {
+      for (size_t op = 0; op < 1000; ++op)
+	{
+	  push_request_id_as_message (rssq, reqids::_0);
+	}
+    });
+    std::thread t2 ([&rssq]
+    {
+      for (size_t op = 0; op < 1000; ++op)
+	{
+	  push_request_id_as_message (rssq, reqids::_1);
+	}
+    });
+    std::thread t3 ([&rssq]
+    {
+      test_rssq::queue_type local_buffer;
+      auto start_time = std::chrono::system_clock::now ();
+      while (std::chrono::system_clock::now () - start_time < std::chrono::seconds (1))
+	{
+	  rssq.send_all (local_buffer);
+	  std::this_thread::sleep_for (std::chrono::milliseconds (1));
+	}
+    });
+    std::thread t4 ([&rssq]
+    {
+      test_rssq::queue_type local_buffer;
+      auto start_time = std::chrono::system_clock::now ();
+      while (std::chrono::system_clock::now () - start_time < std::chrono::seconds (1))
+	{
+	  rssq.wait_not_empty_and_send_all (local_buffer, std::chrono::milliseconds (1));
+	}
+    });
+    t1.join ();
+    t2.join ();
+    t3.join ();
+    t4.join ();
+
+    rssq.send_all (backbuffer);
+  }
+
+  env.wait_for_all_messages ();
+  env.get_server ().stop_thread ();
+
+  require_all_sent_requests_are_handled ();
+}
+
+TEST_CASE ("Test request_queue_sender", "")
+{
+  // Test the way requests are handled using a request_queue_sender. All pushed requests are automatically send by the
+  // request_queue_sender. The requests are sent in the same order that they are pushed.
+  //
+  // Verify that:
+  //	- all requests are handled by the expected type of handled
+  //	- the requests of each thread are handled in the same order as they are pushed
+  //	- the number of requests sent is the same as the number of requests handled
+  //
+
+  test_handler_register_function hreg_fun = handler_register_mock_check_expected_id_and_op_count;
+  test_client_and_server_env env (hreg_fun);
+
+  using test_rssq = cubcomm::request_sync_send_queue<test_request_client, payload_with_op_count>;
+
+  test_rssq rssq (env.move_client ());
+  test_rssq::queue_type backbuffer;
+
+  env.get_server ().start_thread ();
+
+  std::thread t1 ([&rssq]
+  {
+    for (int op_count = 0; op_count < 1000; ++op_count)
+      {
+	push_message_id_and_op (rssq, reqids::_0, op_count);
+      }
+  });
+  std::thread t2 ([&rssq]
+  {
+    for (int op_count = 0; op_count < 1000; ++op_count)
+      {
+	push_message_id_and_op (rssq, reqids::_1, op_count);
+      }
+  });
+
+  cubcomm::request_queue_autosend<test_rssq> autosend (rssq);
+  autosend.start_thread ();
+
+  t1.join ();
+  t2.join ();
+
+  env.wait_for_all_messages ();
+  env.get_server ().stop_thread ();
+  autosend.stop_thread ();
+
+  require_all_sent_requests_are_handled ();
 }
 
 static void
@@ -184,6 +423,9 @@ init_globals ()
 {
   global_sent_request_count = 0;
   global_handled_request_count = 0;
+
+  global_op_count[0] = 0;
+  global_op_count[1] = 0;
 }
 
 static void
@@ -200,8 +442,6 @@ mock_check_expected_id (cubpacking::unpacker &upk)
   upk.unpack_from_int (readval);
   REQUIRE (readval == Val);
   ++global_handled_request_count;
-
-  INFO ("Handle value: " << ((int) readval));
 }
 
 template <typename ReqCl, typename ReqId>
@@ -212,6 +452,55 @@ send_request_id_as_message (ReqCl &reqcl, ReqId rid)
   ++global_sent_request_count;
 }
 
+template <typename RSSQ, typename ReqId>
+static void
+push_request_id_as_message (RSSQ &rssq, ReqId rid)
+{
+  rssq.push (rid, static_cast<int> (rid));
+  ++global_sent_request_count;
+}
+
+template <typename ReqId, ReqId ExpectedVal>
+static void
+mock_check_expected_id_and_op_count (cubpacking::unpacker &upk)
+{
+  payload_with_op_count payload;
+  payload.unpack (upk);
+  REQUIRE (payload.val == static_cast<int> (ExpectedVal));
+  REQUIRE (global_op_count[payload.val] == payload.op_count);
+  ++global_op_count[payload.val];
+
+  ++global_handled_request_count;
+}
+
+template <typename RSSQ, typename ReqId>
+static void
+push_message_id_and_op (RSSQ &rssq, ReqId reqid, int op_count)
+{
+  payload_with_op_count payload;
+  payload.val = static_cast<int> (reqid);
+  payload.op_count = op_count;
+
+  rssq.push (reqid, std::move (payload));
+
+  ++global_sent_request_count;
+}
+
+static void
+handler_register_mock_check_expected_id_and_op_count (test_request_server &req_sr)
+{
+  cubcomm::request_server<reqids>::server_request_handler reqh0 = [] (cubpacking::unpacker &upk)
+  {
+    mock_check_expected_id_and_op_count<reqids, reqids::_0> (upk);
+  };
+  cubcomm::request_server<reqids>::server_request_handler reqh1 = [] (cubpacking::unpacker &upk)
+  {
+    mock_check_expected_id_and_op_count<reqids, reqids::_1> (upk);
+  };
+  req_sr.register_request_handler (reqids::_0, reqh0);
+  req_sr.register_request_handler (reqids::_1, reqh1);
+}
+
 test_request_client
 create_request_client ()
 {
@@ -220,17 +509,25 @@ create_request_client ()
 
   test_request_client req_cl (std::move (chncl));
 
-  return req_cl;
+  return std::move (req_cl);
 }
 
 test_request_server
-create_request_server ()
+create_request_server (const test_handler_register_function &handler_register)
 {
   cubcomm::channel chnsr;
   chnsr.set_channel_name ("server");
 
   test_request_server req_sr (std::move (chnsr));
 
+  handler_register (req_sr);
+
+  return req_sr;
+}
+
+void
+handler_register_mock_check_expected_id (test_request_server &req_sr)
+{
   cubcomm::request_server<reqids>::server_request_handler reqh0 = [] (cubpacking::unpacker &upk)
   {
     mock_check_expected_id<reqids, reqids::_0> (upk);
@@ -241,8 +538,6 @@ create_request_server ()
   };
   req_sr.register_request_handler (reqids::_0, reqh0);
   req_sr.register_request_handler (reqids::_1, reqh1);
-
-  return req_sr;
 }
 
 void
@@ -310,6 +605,101 @@ mock_socket_between_two_client_servers (const test_request_client_server_type_on
 {
   add_socket_direction (clsr1.get_channel ().get_channel_id (), clsr2.get_channel ().get_channel_id (), sockdir_1_to_2);
   add_socket_direction (clsr2.get_channel ().get_channel_id (), clsr1.get_channel ().get_channel_id (), sockdir_2_to_1);
+}
+
+test_client_and_server_env::test_client_and_server_env (test_handler_register_function &hreg)
+  : m_client (create_request_client ())
+  , m_server (create_request_server (hreg))
+  , m_sockdir ()
+{
+  mock_socket_between_client_and_server (m_client, m_server, m_sockdir);
+  init_globals ();
+}
+
+test_client_and_server_env::~test_client_and_server_env ()
+{
+  clear_socket_directions ();
+}
+
+test_request_client &
+test_client_and_server_env::get_client ()
+{
+  return m_client;
+}
+
+test_request_server &
+test_client_and_server_env::get_server ()
+{
+  return m_server;
+}
+
+test_request_client
+test_client_and_server_env::move_client ()
+{
+  return std::move (m_client);
+}
+
+void
+test_client_and_server_env::wait_for_all_messages ()
+{
+  m_sockdir.wait_for_all_messages ();
+}
+
+test_two_client_server_env::test_two_client_server_env ()
+  : m_first_cs (create_request_client_server_one())
+  , m_second_cs (create_request_client_server_two())
+  , m_sockdir_one_two ()
+  , m_sockdir_two_one ()
+{
+  mock_socket_between_two_client_servers (m_first_cs, m_second_cs, m_sockdir_one_two, m_sockdir_two_one);
+  init_globals ();
+}
+
+test_two_client_server_env::~test_two_client_server_env ()
+{
+  clear_socket_directions ();
+}
+
+test_request_client_server_type_one &
+test_two_client_server_env::get_cs_one ()
+{
+  return m_first_cs;
+}
+
+test_request_client_server_type_two &
+test_two_client_server_env::get_cs_two ()
+{
+  return m_second_cs;
+}
+
+void
+test_two_client_server_env::wait_for_all_messages ()
+{
+  m_sockdir_one_two.wait_for_all_messages ();
+  m_sockdir_two_one.wait_for_all_messages ();
+}
+
+void
+payload_with_op_count::pack (cubpacking::packer &serializator) const
+{
+  serializator.pack_all (val, op_count);
+}
+
+void
+payload_with_op_count::unpack (cubpacking::unpacker &deserializator)
+{
+  deserializator.unpack_all (val, op_count);
+}
+
+size_t
+payload_with_op_count::get_packed_size (cubpacking::packer &serializator, std::size_t start_offset /* = 0 */) const
+{
+  size_t size = 0;
+
+  size += serializator.get_packed_int_size (start_offset + size);
+  size += serializator.get_packed_int_size (start_offset + size);
+
+  return size;
 }
 
 //


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-26

Add two new request handling classes to synchronize request pushing and to automatically send pushed requests.

   - **request_sync_send_queue**: synchronize request pushes and synchronize send over network. Multiple threads can push and multiple threads can send the pushed requests.
   - **request_queue_autosend**: automatically send all requests pushed into a request_sync_send_queue. request_queue_autosend preserves requests order.

The new classes are found in **request_sync_send_queue.hpp**.

test_request_cs unit test was extended with two new test cases for the two new classes. other unit test changes:

  - new environment classes that holds client, servers and socket directions for a test case.
  - new payload/handlers to also verify the order of handling requests
  
 Minor changes to the request_client_server.hpp to fit new requirements.