### PR TITLE
[LETS-25] [Refactoring] Move connection server rules out of connection_globals

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -118,6 +118,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/printer.cpp
   ${BASE_DIR}/release_string.c
   ${BASE_DIR}/resource_tracker.cpp
+  ${BASE_DIR}/server_type.cpp
   ${BASE_DIR}/sha1.c
   ${BASE_DIR}/stack_dump.c
   ${BASE_DIR}/string_buffer.cpp
@@ -155,6 +156,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/string_buffer.hpp
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/semaphore.hpp
+  ${BASE_DIR}/server_type.hpp
   ${BASE_DIR}/ddl_log.h
   )
 
@@ -167,6 +169,7 @@ set(CONNECTION_SOURCES
   ${CONNECTION_DIR}/connection_less.c
   ${CONNECTION_DIR}/connection_cl.c
   ${CONNECTION_DIR}/connection_globals.c
+  ${CONNECTION_DIR}/connection_server_rules.cpp
   ${CONNECTION_DIR}/connection_list_cl.c
   ${CONNECTION_DIR}/client_support.c
   ${CONNECTION_DIR}/connection_support.c
@@ -174,6 +177,7 @@ set(CONNECTION_SOURCES
 
 set(COMMUNICATION_HEADERS
   ${COMMUNICATION_DIR}/communication_channel.hpp
+  ${CONNECTION_DIR}/connection_server_rules.hpp
   ${COMMUNICATION_DIR}/request_client_server.hpp
   )
 

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -168,6 +168,7 @@ set(HEAPLAYER_SOURCES
 set(CONNECTION_SOURCES
   ${CONNECTION_DIR}/connection_less.c
   ${CONNECTION_DIR}/connection_cl.c
+  ${CONNECTION_DIR}/connection_globals.c
   ${CONNECTION_DIR}/connection_server_rules.cpp
   ${CONNECTION_DIR}/connection_list_cl.c
   ${CONNECTION_DIR}/client_support.c
@@ -176,6 +177,7 @@ set(CONNECTION_SOURCES
 
 set(COMMUNICATION_HEADERS
   ${COMMUNICATION_DIR}/communication_channel.hpp
+  ${CONNECTION_DIR}/connection_globals.h
   ${CONNECTION_DIR}/connection_server_rules.hpp
   ${COMMUNICATION_DIR}/request_client_server.hpp
   )

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -168,7 +168,6 @@ set(HEAPLAYER_SOURCES
 set(CONNECTION_SOURCES
   ${CONNECTION_DIR}/connection_less.c
   ${CONNECTION_DIR}/connection_cl.c
-  ${CONNECTION_DIR}/connection_globals.c
   ${CONNECTION_DIR}/connection_server_rules.cpp
   ${CONNECTION_DIR}/connection_list_cl.c
   ${CONNECTION_DIR}/client_support.c

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -118,7 +118,6 @@ set(BASE_SOURCES
   ${BASE_DIR}/printer.cpp
   ${BASE_DIR}/release_string.c
   ${BASE_DIR}/resource_tracker.cpp
-  ${BASE_DIR}/server_type.cpp
   ${BASE_DIR}/sha1.c
   ${BASE_DIR}/stack_dump.c
   ${BASE_DIR}/string_buffer.cpp

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -156,7 +156,6 @@ set(BASE_HEADERS
   ${BASE_DIR}/string_buffer.hpp
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/semaphore.hpp
-  ${BASE_DIR}/server_type.hpp
   ${BASE_DIR}/ddl_log.h
   )
 
@@ -169,7 +168,6 @@ set(CONNECTION_SOURCES
   ${CONNECTION_DIR}/connection_less.c
   ${CONNECTION_DIR}/connection_cl.c
   ${CONNECTION_DIR}/connection_globals.c
-  ${CONNECTION_DIR}/connection_server_rules.cpp
   ${CONNECTION_DIR}/connection_list_cl.c
   ${CONNECTION_DIR}/client_support.c
   ${CONNECTION_DIR}/connection_support.c
@@ -177,7 +175,6 @@ set(CONNECTION_SOURCES
 
 set(COMMUNICATION_HEADERS
   ${COMMUNICATION_DIR}/communication_channel.hpp
-  ${CONNECTION_DIR}/connection_server_rules.hpp
   ${COMMUNICATION_DIR}/request_client_server.hpp
   )
 

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -177,7 +177,6 @@ set(CONNECTION_SOURCES
 
 set(COMMUNICATION_HEADERS
   ${COMMUNICATION_DIR}/communication_channel.hpp
-  ${CONNECTION_DIR}/connection_globals.h
   ${CONNECTION_DIR}/connection_server_rules.hpp
   ${COMMUNICATION_DIR}/request_client_server.hpp
   )

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -177,6 +177,7 @@ set(CONNECTION_SOURCES
   ${CONNECTION_DIR}/connection_sr.c
   ${CONNECTION_DIR}/connection_list_sr.c
   ${CONNECTION_DIR}/connection_globals.c
+  ${CONNECTION_DIR}/connection_server_rules.cpp
   ${CONNECTION_DIR}/server_support.c
   ${CONNECTION_DIR}/connection_support.c
   )
@@ -191,6 +192,7 @@ set(COMMUNICATION_SOURCES
 set(COMMUNICATION_HEADERS
   ${COMMUNICATION_DIR}/communication_channel.hpp
   ${COMMUNICATION_DIR}/communication_server_channel.hpp
+  ${CONNECTION_DIR}/connection_server_rules.hpp
   ${COMMUNICATION_DIR}/request_client_server.hpp
   )
 

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -169,6 +169,7 @@ set(HEAPLAYER_SOURCES
 set(CONNECTION_SOURCES
   ${CONNECTION_DIR}/connection_less.c
   ${CONNECTION_DIR}/connection_cl.c
+  ${CONNECTION_DIR}/connection_globals.c
   ${CONNECTION_DIR}/connection_list_cl.c
   ${CONNECTION_DIR}/client_support.c
   ${CONNECTION_DIR}/connection_support.c

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -169,7 +169,6 @@ set(HEAPLAYER_SOURCES
 set(CONNECTION_SOURCES
   ${CONNECTION_DIR}/connection_less.c
   ${CONNECTION_DIR}/connection_cl.c
-  ${CONNECTION_DIR}/connection_globals.c
   ${CONNECTION_DIR}/connection_list_cl.c
   ${CONNECTION_DIR}/client_support.c
   ${CONNECTION_DIR}/connection_support.c

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -170,9 +170,14 @@ set(CONNECTION_SOURCES
   ${CONNECTION_DIR}/connection_less.c
   ${CONNECTION_DIR}/connection_cl.c
   ${CONNECTION_DIR}/connection_globals.c
+  ${CONNECTION_DIR}/connection_server_rules.cpp
   ${CONNECTION_DIR}/connection_list_cl.c
   ${CONNECTION_DIR}/client_support.c
   ${CONNECTION_DIR}/connection_support.c
+  )
+
+set(COMMUNICATION_HEADERS
+  ${CONNECTION_DIR}/connection_server_rules.hpp
   )
 
 set(COMMUNICATION_SOURCES

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -157,7 +157,6 @@ set(BASE_HEADERS
   ${BASE_DIR}/printer.hpp
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/semaphore.hpp
-  ${BASE_DIR}/server_type.hpp
   ${BASE_DIR}/ddl_log.h
 )
 

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -21,7 +21,6 @@
 #include "communication_server_channel.hpp"
 #include "connection_defs.h"
 #include "error_manager.h"
-#include "server_support.h"
 #include "system_parameter.h"
 
 #include <string>

--- a/src/connection/connection_globals.c
+++ b/src/connection/connection_globals.c
@@ -35,8 +35,6 @@
 #include "boot.h"
 #include "connection_globals.h"
 #include "utility.h"
-#include "system_parameter.h"
-#include "connection_server_rules.hpp"
 
 const char *css_Service_name = "cubrid";
 int css_Service_id = 1523;
@@ -56,30 +54,6 @@ int css_Server_use_new_connection_protocol = 0;
 
 /* do not change first 4 bytes of css_Net_magic */
 char css_Net_magic[CSS_NET_MAGIC_SIZE] = { 0x00, 0x00, 0x00, 0x01, 0x20, 0x08, 0x11, 0x22 };
-
-/*
- * css_is_normal_client() -
- *   return: whether a client is a normal client or not
- */
-static bool
-css_is_normal_client (BOOT_CLIENT_TYPE client_type)
-{
-  int i;
-
-  for (i = 0; i < css_Conn_rules_size; i++)
-    {
-      if (i == CSS_CR_NORMAL_ONLY_IDX)
-	{
-	  continue;
-	}
-
-      if (css_Conn_rules[i].check_client_type_fn (client_type))
-	{
-	  return false;
-	}
-    }
-  return true;
-}
 
 /*
  * css_is_admin_client() -

--- a/src/connection/connection_globals.c
+++ b/src/connection/connection_globals.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <assert.h>
 #include "porting.h"
-#include "memory_alloc.h"
 #include "boot.h"
 #include "connection_globals.h"
 #include "utility.h"

--- a/src/connection/connection_globals.c
+++ b/src/connection/connection_globals.c
@@ -53,23 +53,3 @@ int css_Server_use_new_connection_protocol = 0;
 
 /* do not change first 4 bytes of css_Net_magic */
 char css_Net_magic[CSS_NET_MAGIC_SIZE] = { 0x00, 0x00, 0x00, 0x01, 0x20, 0x08, 0x11, 0x22 };
-
-/*
- * css_is_admin_client() -
- *   return: whether a client is a admin client or not
- */
-static bool
-css_is_admin_client (BOOT_CLIENT_TYPE client_type)
-{
-  return BOOT_ADMIN_CLIENT_TYPE (client_type);
-}
-
-/*
- * css_is_ha_client() -
- *   return: whether a client is a HA client or not
- */
-static bool
-css_is_ha_client (BOOT_CLIENT_TYPE client_type)
-{
-  return BOOT_LOG_REPLICATOR_TYPE (client_type);
-}

--- a/src/connection/connection_globals.c
+++ b/src/connection/connection_globals.c
@@ -30,15 +30,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-#if defined (SERVER_MODE)
-#include "server_type.hpp"
-#endif
 #include "porting.h"
 #include "memory_alloc.h"
 #include "boot.h"
 #include "connection_globals.h"
 #include "utility.h"
 #include "system_parameter.h"
+#include "connection_server_rules.hpp"
 
 const char *css_Service_name = "cubrid";
 int css_Service_id = 1523;
@@ -58,45 +56,6 @@ int css_Server_use_new_connection_protocol = 0;
 
 /* do not change first 4 bytes of css_Net_magic */
 char css_Net_magic[CSS_NET_MAGIC_SIZE] = { 0x00, 0x00, 0x00, 0x01, 0x20, 0x08, 0x11, 0x22 };
-
-static bool css_Is_conn_rules_initialized = false;
-
-static int css_get_admin_client_max_conn (void);
-static int css_get_ha_client_max_conn (void);
-
-static bool css_is_normal_client (BOOT_CLIENT_TYPE client_type);
-static bool css_is_admin_client (BOOT_CLIENT_TYPE client_type);
-static bool css_is_ha_client (BOOT_CLIENT_TYPE client_type);
-
-static int css_get_required_conn_num_for_ha (void);
-
-CSS_CONN_RULE_INFO css_Conn_rules[] = {
-  {css_is_normal_client, css_get_max_normal_conn, CR_NORMAL_ONLY, 0, 0},
-  {css_is_admin_client, css_get_admin_client_max_conn, CR_NORMAL_FIRST, 0, 0},
-  {css_is_ha_client, css_get_ha_client_max_conn, CR_RESERVED_FIRST, 0, 0}
-};
-
-const int css_Conn_rules_size = DIM (css_Conn_rules);
-
-/*
- * css_get_admin_client_max_conn() -
- *   return: a num of reserved conn for admin clients
- */
-static int
-css_get_admin_client_max_conn (void)
-{
-  return 1;
-}
-
-/*
- * css_get_ha_client_max_conn() -
- *   return: a num of reserved conn for HA clients
- */
-static int
-css_get_ha_client_max_conn (void)
-{
-  return css_get_required_conn_num_for_ha ();
-}
 
 /*
  * css_is_normal_client() -
@@ -140,107 +99,4 @@ static bool
 css_is_ha_client (BOOT_CLIENT_TYPE client_type)
 {
   return BOOT_LOG_REPLICATOR_TYPE (client_type);
-}
-
-/*
- * css_get_required_conn_num_for_ha() - calculate the number
- *      of connections required for HA
- *   return: the number of connections required for HA
- */
-static int
-css_get_required_conn_num_for_ha (void)
-{
-  int required_conn_num = 0, num_of_nodes = 0;
-  char *ha_node_list_p = NULL;
-  char *ha_replica_list_p = NULL;
-  int curr_ha_mode;
-
-#if defined (SA_MODE)
-  curr_ha_mode = util_get_ha_mode_for_sa_utils ();
-#else /* SA_MODE */
-  curr_ha_mode = HA_GET_MODE ();
-#endif /* !SA_MODE */
-
-  if (curr_ha_mode == HA_MODE_OFF)
-    {
-      return 0;
-    }
-
-  ha_node_list_p = prm_get_string_value (PRM_ID_HA_NODE_LIST);
-  num_of_nodes = util_get_num_of_ha_nodes (ha_node_list_p);
-
-  if (HA_GET_MODE () == HA_MODE_REPLICA)
-    {
-      /* one applylogdb for each node */
-      return num_of_nodes * 2;
-    }
-
-  ha_replica_list_p = prm_get_string_value (PRM_ID_HA_REPLICA_LIST);
-  /* one copylogdb for each replica */
-  required_conn_num = util_get_num_of_ha_nodes (ha_replica_list_p);
-
-  /* applylogdb and copylogdb for each node */
-  required_conn_num += (num_of_nodes - 1) * 3;
-
-  return required_conn_num;
-}
-
-/*
- * css_init_conn_rules() - initialize connection rules
- *  which are determined in runtime
- *   return:
- */
-void
-css_init_conn_rules (void)
-{
-  int i;
-
-  for (i = 0; i < css_Conn_rules_size; i++)
-    {
-      assert (css_Conn_rules[i].get_max_conn_num_fn != NULL);
-
-      css_Conn_rules[i].max_num_conn = css_Conn_rules[i].get_max_conn_num_fn ();
-    }
-
-  css_Is_conn_rules_initialized = true;
-
-  return;
-}
-
-/*
- * css_get_max_conn() -
- *   return: max_clients + a total num of reserved connections
- */
-int
-css_get_max_conn (void)
-{
-  int i, total = 0;
-
-  if (!css_Is_conn_rules_initialized)
-    {
-      css_init_conn_rules ();
-    }
-
-  for (i = 0; i < css_Conn_rules_size; i++)
-    {
-      total += css_Conn_rules[i].max_num_conn;
-    }
-
-  return total;
-}
-
-/*
- * css_get_max_normal_conn() -
- *    return: max number of client connections
- */
-int
-css_get_max_normal_conn (void)
-{
-#if defined (SERVER_MODE)
-  if (get_server_type () == SERVER_TYPE_PAGE)
-    {
-      return 0;
-    }
-#endif
-  return prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS);
 }

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -26,8 +26,6 @@
 
 #ident "$Id$"
 
-#include "connection_defs.h"
-
 #define CSS_MAX_CLIENT_COUNT   4000
 
 extern int css_Service_id;

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -28,8 +28,6 @@
 
 #include "connection_defs.h"
 
-#define CSS_CR_NORMAL_ONLY_IDX  0
-
 #define CSS_MAX_CLIENT_COUNT   4000
 
 extern int css_Service_id;

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -32,46 +32,16 @@
 
 #define CSS_MAX_CLIENT_COUNT   4000
 
-typedef bool (*CSS_CHECK_CLIENT_TYPE) (BOOT_CLIENT_TYPE client_type);
-typedef int (*CSS_GET_MAX_CONN_NUM) (void);
-
-/*
- * a rule defining how a client consumes connections.
- * ex) a client using CR_NORMAL_FIRST_RESERVED_LAST
- * consumes a normal connection first and uses
- * a reserved one last
- */
-typedef enum css_conn_rule
-{
-  CR_NORMAL_ONLY,
-  CR_NORMAL_FIRST,
-  CR_RESERVED_FIRST
-} CSS_CONN_RULE;
-
-typedef struct css_conn_rule_info
-{
-  CSS_CHECK_CLIENT_TYPE check_client_type_fn;
-  CSS_GET_MAX_CONN_NUM get_max_conn_num_fn;
-  CSS_CONN_RULE rule;
-  int max_num_conn;
-  int num_curr_conn;
-} CSS_CONN_RULE_INFO;
-
 extern int css_Service_id;
 extern const char *css_Service_name;
 
 extern int css_Server_use_new_connection_protocol;
 extern int css_Server_inhibit_connection_socket;
 extern SOCKET css_Server_connection_socket;
-extern CSS_CONN_RULE_INFO css_Conn_rules[];
-extern const int css_Conn_rules_size;
 
 extern SOCKET css_Pipe_to_master;
 
 #define CSS_NET_MAGIC_SIZE		8
 extern char css_Net_magic[CSS_NET_MAGIC_SIZE];
-extern void css_init_conn_rules (void);
-extern int css_get_max_conn (void);
-extern int css_get_max_normal_conn (void);
 
 #endif /* _CONNECTION_GLOBALS_H_ */

--- a/src/connection/connection_server_rules.cpp
+++ b/src/connection/connection_server_rules.cpp
@@ -3,10 +3,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include "connection_server_rules.hpp"
-#include "porting.h"
-#include "memory_alloc.h"
 #include "server_type.hpp"
-#include "boot.h"
 #include "utility.h"
 #include "system_parameter.h"
 

--- a/src/connection/connection_server_rules.cpp
+++ b/src/connection/connection_server_rules.cpp
@@ -1,11 +1,30 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "connection_server_rules.hpp"
+
+#include "server_type.hpp"
+#include "utility.h"
+#include "system_parameter.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-#include "connection_server_rules.hpp"
-#include "server_type.hpp"
-#include "utility.h"
-#include "system_parameter.h"
 
 static int css_get_admin_client_max_conn (void);
 static int css_get_ha_client_max_conn (void);
@@ -169,4 +188,24 @@ css_is_normal_client (BOOT_CLIENT_TYPE client_type)
     }
     }
   return true;
+}
+
+/*
+ * css_is_admin_client() -
+ *   return: whether a client is a admin client or not
+ */
+static bool
+css_is_admin_client (BOOT_CLIENT_TYPE client_type)
+{
+  return BOOT_ADMIN_CLIENT_TYPE (client_type);
+}
+
+/*
+ * css_is_ha_client() -
+ *   return: whether a client is a HA client or not
+ */
+static bool
+css_is_ha_client (BOOT_CLIENT_TYPE client_type)
+{
+  return BOOT_LOG_REPLICATOR_TYPE (client_type);
 }

--- a/src/connection/connection_server_rules.cpp
+++ b/src/connection/connection_server_rules.cpp
@@ -19,12 +19,12 @@
 #include "connection_server_rules.hpp"
 
 #include "server_type.hpp"
-#include "utility.h"
 #include "system_parameter.h"
+#include "utility.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 
 static int css_get_admin_client_max_conn (void);
 static int css_get_ha_client_max_conn (void);

--- a/src/connection/connection_server_rules.cpp
+++ b/src/connection/connection_server_rules.cpp
@@ -149,3 +149,27 @@ css_get_required_conn_num_for_ha (void)
 
   return required_conn_num;
 }
+
+/*
+ * css_is_normal_client() -
+ *   return: whether a client is a normal client or not
+ */
+static bool
+css_is_normal_client (BOOT_CLIENT_TYPE client_type)
+{
+  int i;
+
+  for (i = 0; i < css_Conn_rules_size; i++)
+    {
+      if (i == CSS_CR_NORMAL_ONLY_IDX)
+    {
+      continue;
+    }
+
+      if (css_Conn_rules[i].check_client_type_fn (client_type))
+    {
+      return false;
+    }
+    }
+  return true;
+}

--- a/src/connection/connection_server_rules.cpp
+++ b/src/connection/connection_server_rules.cpp
@@ -1,0 +1,151 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "connection_server_rules.hpp"
+#include "porting.h"
+#include "memory_alloc.h"
+#include "server_type.hpp"
+#include "boot.h"
+#include "utility.h"
+#include "system_parameter.h"
+
+static int css_get_admin_client_max_conn (void);
+static int css_get_ha_client_max_conn (void);
+
+static bool css_is_normal_client (BOOT_CLIENT_TYPE client_type);
+static bool css_is_admin_client (BOOT_CLIENT_TYPE client_type);
+static bool css_is_ha_client (BOOT_CLIENT_TYPE client_type);
+
+CSS_CONN_RULE_INFO css_Conn_rules[] = {
+  {css_is_normal_client, css_get_max_normal_conn, CR_NORMAL_ONLY, 0, 0},
+  {css_is_admin_client, css_get_admin_client_max_conn, CR_NORMAL_FIRST, 0, 0},
+  {css_is_ha_client, css_get_ha_client_max_conn, CR_RESERVED_FIRST, 0, 0}
+};
+
+static bool css_Is_conn_rules_initialized = false;
+const int css_Conn_rules_size = DIM (css_Conn_rules);
+
+static int css_get_required_conn_num_for_ha (void);
+
+/*
+ * css_get_ha_client_max_conn() -
+ *   return: a num of reserved conn for HA clients
+ */
+static int
+css_get_ha_client_max_conn (void)
+{
+  return css_get_required_conn_num_for_ha ();
+}
+
+/*
+ * css_get_admin_client_max_conn() -
+ *   return: a num of reserved conn for admin clients
+ */
+static int
+css_get_admin_client_max_conn (void)
+{
+  return 1;
+}
+
+/*
+ * css_init_conn_rules() - initialize connection rules
+ *  which are determined in runtime
+ *   return:
+ */
+void
+css_init_conn_rules (void)
+{
+  int i;
+
+  for (i = 0; i < css_Conn_rules_size; i++)
+    {
+      assert (css_Conn_rules[i].get_max_conn_num_fn != NULL);
+
+      css_Conn_rules[i].max_num_conn = css_Conn_rules[i].get_max_conn_num_fn ();
+    }
+
+  css_Is_conn_rules_initialized = true;
+
+  return;
+}
+
+/*
+ * css_get_max_conn() -
+ *   return: max_clients + a total num of reserved connections
+ */
+int
+css_get_max_conn (void)
+{
+  int i, total = 0;
+
+  if (!css_Is_conn_rules_initialized)
+    {
+      css_init_conn_rules ();
+    }
+
+  for (i = 0; i < css_Conn_rules_size; i++)
+    {
+      total += css_Conn_rules[i].max_num_conn;
+    }
+
+  return total;
+}
+
+
+/*
+ * css_get_max_normal_conn() -
+ *    return: max number of client connections
+ */
+int
+css_get_max_normal_conn (void)
+{
+  if (get_server_type () == SERVER_TYPE_PAGE)
+    {
+      return 0;
+    }
+  return prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS);
+}
+
+/*
+ * css_get_required_conn_num_for_ha() - calculate the number
+ *      of connections required for HA
+ *   return: the number of connections required for HA
+ */
+static int
+css_get_required_conn_num_for_ha (void)
+{
+  int required_conn_num = 0, num_of_nodes = 0;
+  char *ha_node_list_p = NULL;
+  char *ha_replica_list_p = NULL;
+  int curr_ha_mode;
+
+#if defined (SA_MODE)
+  curr_ha_mode = util_get_ha_mode_for_sa_utils ();
+#else /* SA_MODE */
+  curr_ha_mode = HA_GET_MODE ();
+#endif /* !SA_MODE */
+
+  if (curr_ha_mode == HA_MODE_OFF)
+    {
+      return 0;
+    }
+
+  ha_node_list_p = prm_get_string_value (PRM_ID_HA_NODE_LIST);
+  num_of_nodes = util_get_num_of_ha_nodes (ha_node_list_p);
+
+  if (HA_GET_MODE () == HA_MODE_REPLICA)
+    {
+      /* one applylogdb for each node */
+      return num_of_nodes * 2;
+    }
+
+  ha_replica_list_p = prm_get_string_value (PRM_ID_HA_REPLICA_LIST);
+  /* one copylogdb for each replica */
+  required_conn_num = util_get_num_of_ha_nodes (ha_replica_list_p);
+
+  /* applylogdb and copylogdb for each node */
+  required_conn_num += (num_of_nodes - 1) * 3;
+
+  return required_conn_num;
+}

--- a/src/connection/connection_server_rules.hpp
+++ b/src/connection/connection_server_rules.hpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
 
 #ifndef _CONNECTION_SERVER_H_
 #define _CONNECTION_SERVER_H_

--- a/src/connection/connection_server_rules.hpp
+++ b/src/connection/connection_server_rules.hpp
@@ -1,0 +1,42 @@
+
+#ifndef _CONNECTION_SERVER_H_
+#define _CONNECTION_SERVER_H_
+
+#ident "$Id$"
+#include "connection_defs.h"
+
+typedef bool (*CSS_CHECK_CLIENT_TYPE) (BOOT_CLIENT_TYPE client_type);
+typedef int (*CSS_GET_MAX_CONN_NUM) (void);
+
+/*
+ * a rule defining how a client consumes connections.
+ * ex) a client using CR_NORMAL_FIRST_RESERVED_LAST
+ * consumes a normal connection first and uses
+ * a reserved one last
+ */
+typedef enum css_conn_rule
+{
+  CR_NORMAL_ONLY,
+  CR_NORMAL_FIRST,
+  CR_RESERVED_FIRST
+} CSS_CONN_RULE;
+
+typedef struct css_conn_rule_info
+{
+  CSS_CHECK_CLIENT_TYPE check_client_type_fn;
+  CSS_GET_MAX_CONN_NUM get_max_conn_num_fn;
+  CSS_CONN_RULE rule;
+  int max_num_conn;
+  int num_curr_conn;
+} CSS_CONN_RULE_INFO;
+
+
+extern void css_init_conn_rules (void);
+extern int css_get_max_conn (void);
+extern int css_get_max_normal_conn (void);
+
+
+extern CSS_CONN_RULE_INFO css_Conn_rules[];
+extern const int css_Conn_rules_size;
+
+#endif /* _CONNECTION_SERVER_H_ */

--- a/src/connection/connection_server_rules.hpp
+++ b/src/connection/connection_server_rules.hpp
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef _CONNECTION_SERVER_H_
-#define _CONNECTION_SERVER_H_
+#ifndef _CONNECTION_SERVER_RULES_H_
+#define _CONNECTION_SERVER_RULES_H_
 
 #ident "$Id$"
 #include "connection_defs.h"
@@ -49,13 +49,11 @@ typedef struct css_conn_rule_info
   int num_curr_conn;
 } CSS_CONN_RULE_INFO;
 
-
 extern void css_init_conn_rules (void);
 extern int css_get_max_conn (void);
 extern int css_get_max_normal_conn (void);
 
-
 extern CSS_CONN_RULE_INFO css_Conn_rules[];
 extern const int css_Conn_rules_size;
 
-#endif /* _CONNECTION_SERVER_H_ */
+#endif /* _CONNECTION_SERVER_RULES_H_ */

--- a/src/connection/connection_server_rules.hpp
+++ b/src/connection/connection_server_rules.hpp
@@ -5,6 +5,8 @@
 #ident "$Id$"
 #include "connection_defs.h"
 
+#define CSS_CR_NORMAL_ONLY_IDX  0
+
 typedef bool (*CSS_CHECK_CLIENT_TYPE) (BOOT_CLIENT_TYPE client_type);
 typedef int (*CSS_GET_MAX_CONN_NUM) (void);
 

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -57,6 +57,7 @@
 
 #include "porting.h"
 #include "error_manager.h"
+#include "connection_globals.h"
 #include "connection_server_rules.hpp"
 #include "memory_alloc.h"
 #include "environment_variable.h"

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -57,7 +57,7 @@
 
 #include "porting.h"
 #include "error_manager.h"
-#include "connection_globals.h"
+#include "connection_server_rules.hpp"
 #include "memory_alloc.h"
 #include "environment_variable.h"
 #include "system_parameter.h"

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -54,7 +54,7 @@
 #include "memory_alloc.h"
 #include "boot_sr.h"
 #include "connection_defs.h"
-#include "connection_globals.h"
+#include "connection_server_rules.hpp"
 #include "release_string.h"
 #include "system_parameter.h"
 #include "environment_variable.h"

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -1972,7 +1972,7 @@ fileio_open (const char *vol_label_p, int flags, int mode)
   if (vol_fd > NULL_VOLDES)
     {
       int high_vol_fd;
-      int range = MAX_NTRANS + 10;
+      int range = prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS) + 10;
 
       /* move fd to the over max_clients range */
       high_vol_fd = fcntl (vol_fd, F_DUPFD, range);

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -68,7 +68,7 @@
 #include "porting.h"
 
 #include "chartype.h"
-#include "connection_globals.h"
+#include "connection_server_rules.hpp"
 #include "file_io.h"
 #include "storage_common.h"
 #include "memory_alloc.h"

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -560,7 +560,7 @@ boot_initialize_client (BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_DB_PATH
       tran_lock_wait_msecs = tran_lock_wait_msecs * 1000;
     }
 
-  error_code = perfmon_initialize (MAX_NTRANS);
+  error_code = perfmon_initialize (0);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();

--- a/src/transaction/log_common_impl.h
+++ b/src/transaction/log_common_impl.h
@@ -23,7 +23,9 @@
 #ifndef _LOG_COMMON_IMPL_H_
 #define _LOG_COMMON_IMPL_H_
 
+#ifndef CS_MODE
 #include "connection_server_rules.hpp"
+#endif
 #include "file_io.h"
 #include "log_comm.h"
 #include "log_lsa.hpp"

--- a/src/transaction/log_common_impl.h
+++ b/src/transaction/log_common_impl.h
@@ -31,6 +31,7 @@
 #include "release_string.h"
 #include "storage_common.h"
 #include "system.h"
+#include "connection_server_rules.hpp"
 
 /************************************************************************/
 /* Section shared with client... TODO: remove any code accessing log    */

--- a/src/transaction/log_common_impl.h
+++ b/src/transaction/log_common_impl.h
@@ -23,6 +23,7 @@
 #ifndef _LOG_COMMON_IMPL_H_
 #define _LOG_COMMON_IMPL_H_
 
+#include "connection_server_rules.hpp"
 #include "file_io.h"
 #include "log_comm.h"
 #include "log_lsa.hpp"
@@ -31,7 +32,6 @@
 #include "release_string.h"
 #include "storage_common.h"
 #include "system.h"
-#include "connection_server_rules.hpp"
 
 /************************************************************************/
 /* Section shared with client... TODO: remove any code accessing log    */
@@ -46,11 +46,13 @@
  */
 #define LOG_PAGE_INIT_VALUE 0xff
 
+#ifndef CS_MODE
 #define NUM_NORMAL_TRANS (css_get_max_normal_conn ())
 #define NUM_SYSTEM_TRANS 1
 #define NUM_NON_SYSTEM_TRANS (css_get_max_conn ())
 #define MAX_NTRANS \
   (NUM_NON_SYSTEM_TRANS + NUM_SYSTEM_TRANS)
+#endif
 
 #define VACUUM_NULL_LOG_BLOCKID -1
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-25

Connection server rules were part of connection_global, which was included in both the client and the server modules. To this end a new file connection_server_rules was created to be part only of the the server modules.