### PR TITLE
[CBRD-23866] Fix not to reuse heap when creating a table with REUSE_OID

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -5187,7 +5187,7 @@ heap_create_internal (THREAD_ENTRY * thread_p, HFID * hfid, const OID * class_oi
 
   memset (&des, 0, sizeof (des));
 
-  if (prm_get_bool_value (PRM_ID_DONT_REUSE_HEAP_FILE) == false)
+  if (prm_get_bool_value (PRM_ID_DONT_REUSE_HEAP_FILE) == false && file_type != FILE_HEAP_REUSE_SLOTS)
     {
       /*
        * Try to reuse an already mark deleted heap file

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -5187,7 +5187,7 @@ heap_create_internal (THREAD_ENTRY * thread_p, HFID * hfid, const OID * class_oi
 
   memset (&des, 0, sizeof (des));
 
-  if (prm_get_bool_value (PRM_ID_DONT_REUSE_HEAP_FILE) == false && file_type != FILE_HEAP_REUSE_SLOTS)
+  if (prm_get_bool_value (PRM_ID_DONT_REUSE_HEAP_FILE) == false && file_type == FILE_HEAP)
     {
       /*
        * Try to reuse an already mark deleted heap file


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23866