### PR TITLE
[CBRD-23870] occurred core dump when getting the specific system parameter at csql

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -8589,6 +8589,11 @@ sysprm_obtain_parameters (char *data, SYSPRM_ASSIGN_VALUE ** prm_values_ptr)
 	  error = PRM_ERR_UNKNOWN_PARAM;
 	  break;
 	}
+      else if (prm->value == NULL)
+        {
+	  error = PRM_ERR_NO_VALUE;
+          break;
+        }
 
 #if defined (CS_MODE)
       if (!PRM_IS_FOR_CLIENT (prm->static_flag) && !PRM_IS_FOR_SERVER (prm->static_flag))

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -8590,10 +8590,10 @@ sysprm_obtain_parameters (char *data, SYSPRM_ASSIGN_VALUE ** prm_values_ptr)
 	  break;
 	}
       else if (prm->value == NULL)
-        {
+	{
 	  error = PRM_ERR_NO_VALUE;
-          break;
-        }
+	  break;
+	}
 
 #if defined (CS_MODE)
       if (!PRM_IS_FOR_CLIENT (prm->static_flag) && !PRM_IS_FOR_SERVER (prm->static_flag))


### PR DESCRIPTION
- add code to check if the value of system parameter is NULL