### PR TITLE
[LETS-8] Disable writing (and log creation) on the page server

### DIFF
--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -44,7 +44,9 @@
 #include "server_interface.h"
 #include "boot_cl.h"
 #include "locator_cl.h"
+#ifndef CS_MODE
 #include "server_type.hpp"
+#endif
 #include "schema_manager.h"
 #include "schema_template.h"
 #include "object_accessor.h"
@@ -1016,10 +1018,14 @@ int
 db_enable_modification (void)
 {
   /* CHECK_CONNECT_ERROR (); */
+#ifndef CS_MODE
   if (get_server_type () != SERVER_TYPE_PAGE)
     {
       db_Disable_modifications--;
     }
+#else
+  db_Disable_modifications--;
+#endif
   return NO_ERROR;
 }
 

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -44,9 +44,6 @@
 #include "server_interface.h"
 #include "boot_cl.h"
 #include "locator_cl.h"
-#ifndef CS_MODE
-#include "server_type.hpp"
-#endif
 #include "schema_manager.h"
 #include "schema_template.h"
 #include "object_accessor.h"
@@ -1018,14 +1015,7 @@ int
 db_enable_modification (void)
 {
   /* CHECK_CONNECT_ERROR (); */
-#ifndef CS_MODE
-  if (get_server_type () != SERVER_TYPE_PAGE)
-    {
-      db_Disable_modifications--;
-    }
-#else
   db_Disable_modifications--;
-#endif
   return NO_ERROR;
 }
 

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -44,6 +44,7 @@
 #include "server_interface.h"
 #include "boot_cl.h"
 #include "locator_cl.h"
+#include "server_type.hpp"
 #include "schema_manager.h"
 #include "schema_template.h"
 #include "object_accessor.h"
@@ -1015,7 +1016,10 @@ int
 db_enable_modification (void)
 {
   /* CHECK_CONNECT_ERROR (); */
-  db_Disable_modifications--;
+  if (get_server_type () != SERVER_TYPE_PAGE)
+    {
+      db_Disable_modifications--;
+    }
   return NO_ERROR;
 }
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2736,7 +2736,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 #endif
 
   /* read only mode ? */
-  if (prm_get_bool_value (PRM_ID_READ_ONLY_MODE))
+  if (prm_get_bool_value (PRM_ID_READ_ONLY_MODE) || get_server_type () == SERVER_TYPE_PAGE)
     {
       logtb_disable_update (NULL);
     }
@@ -2761,11 +2761,14 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 #endif
 
 #if defined (SERVER_MODE)
-  /* set number of hosts */
-  css_set_ha_num_of_hosts (db->num_hosts);
-  /* set server's starting mode for HA according to the 'ha_mode' parameter */
-  css_change_ha_server_state (thread_p, (HA_SERVER_STATE) prm_get_integer_value (PRM_ID_HA_SERVER_STATE), false,
-			      HA_CHANGE_MODE_IMMEDIATELY, true);
+  if (get_server_type () == SERVER_TYPE_TRANSACTION)
+    {
+      /* set number of hosts */
+      css_set_ha_num_of_hosts (db->num_hosts);
+      /* set server's starting mode for HA according to the 'ha_mode' parameter */
+      css_change_ha_server_state (thread_p, (HA_SERVER_STATE) prm_get_integer_value (PRM_ID_HA_SERVER_STATE), false,
+				  HA_CHANGE_MODE_IMMEDIATELY, true);
+    }
 #endif
 
   /* initialize partitions cache */

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -27,6 +27,7 @@
 #include "perf_monitor.h"
 #include "thread_entry.hpp"
 #include "thread_manager.hpp"
+#include "server_type.hpp"
 #include "vacuum.h"
 
 static bool log_Zip_support = false;
@@ -37,6 +38,8 @@ static LOG_ZIP *log_zip_redo = NULL;
 static char *log_data_ptr = NULL;
 static int log_data_length = 0;
 #endif
+
+#define assertm(exp, msg) assert(((void)msg, exp))
 
 size_t
 LOG_PRIOR_LSA_LAST_APPEND_OFFSET ()
@@ -1536,6 +1539,7 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 LOG_LSA
 prior_lsa_next_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, log_tdes *tdes)
 {
+  assertm(get_server_type() == SERVER_TYPE_TRANSACTION, "Log append can be executed only on transaction server");
   return prior_lsa_next_record_internal (thread_p, node, tdes, LOG_PRIOR_LSA_WITHOUT_LOCK);
 }
 

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -27,9 +27,7 @@
 #include "perf_monitor.h"
 #include "thread_entry.hpp"
 #include "thread_manager.hpp"
-#ifndef CS_MODE
 #include "server_type.hpp"
-#endif
 #include "vacuum.h"
 
 static bool log_Zip_support = false;
@@ -1583,9 +1581,7 @@ prior_is_tde_encrypted (const log_prior_node *node)
 static void
 prior_lsa_start_append (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_TDES *tdes)
 {
-#ifndef CS_MODE
-  assertm(get_server_type() == SERVER_TYPE_TRANSACTION, "Log append can be executed only on transaction server");
-#endif
+  assertm (get_server_type() == SERVER_TYPE_TRANSACTION, "Log append can be executed only on transaction server");
   /* Does the new log record fit in this page ? */
   log_prior_lsa_append_advance_when_doesnot_fit (sizeof (LOG_RECORD_HEADER));
 

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -27,7 +27,9 @@
 #include "perf_monitor.h"
 #include "thread_entry.hpp"
 #include "thread_manager.hpp"
+#ifndef CS_MODE
 #include "server_type.hpp"
+#endif
 #include "vacuum.h"
 
 static bool log_Zip_support = false;
@@ -1539,7 +1541,9 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 LOG_LSA
 prior_lsa_next_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, log_tdes *tdes)
 {
+#ifndef CS_MODE
   assertm(get_server_type() == SERVER_TYPE_TRANSACTION, "Log append can be executed only on transaction server");
+#endif
   return prior_lsa_next_record_internal (thread_p, node, tdes, LOG_PRIOR_LSA_WITHOUT_LOCK);
 }
 

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1541,9 +1541,6 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 LOG_LSA
 prior_lsa_next_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, log_tdes *tdes)
 {
-#ifndef CS_MODE
-  assertm(get_server_type() == SERVER_TYPE_TRANSACTION, "Log append can be executed only on transaction server");
-#endif
   return prior_lsa_next_record_internal (thread_p, node, tdes, LOG_PRIOR_LSA_WITHOUT_LOCK);
 }
 
@@ -1586,6 +1583,9 @@ prior_is_tde_encrypted (const log_prior_node *node)
 static void
 prior_lsa_start_append (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_TDES *tdes)
 {
+#ifndef CS_MODE
+  assertm(get_server_type() == SERVER_TYPE_TRANSACTION, "Log append can be executed only on transaction server");
+#endif
   /* Does the new log record fit in this page ? */
   log_prior_lsa_append_advance_when_doesnot_fit (sizeof (LOG_RECORD_HEADER));
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6729,7 +6729,10 @@ LOG_PAGEID
 logpb_checkpoint (THREAD_ENTRY * thread_p)
 {
   if (get_server_type () == SERVER_TYPE_PAGE)
-    return NULL_LOG_PAGEID;
+    {
+      // TODO: reactivate once checkpoint is changed without log records
+      return NULL_LOG_PAGEID;
+    }
 
 #define detailed_er_log(...) if (detailed_logging) _er_log_debug (ARG_FILE_LINE, __VA_ARGS__)
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -61,9 +61,7 @@
 #include "partition_sr.h"
 #include "btree_load.h"
 #include "serial.h"
-#ifndef CS_MODE
 #include "server_type.hpp"
-#endif
 #include "show_scan.h"
 #include "boot_sr.h"
 #include "tz_support.h"
@@ -3144,13 +3142,8 @@ logtb_disable_update (THREAD_ENTRY * thread_p)
 void
 logtb_enable_update (THREAD_ENTRY * thread_p)
 {
-#ifndef CS_MODE
-  bool correct_server_type = get_server_type () != SERVER_TYPE_PAGE;
-#else
-  bool correct_server_type = true;
-#endif
-
-  if (prm_get_bool_value (PRM_ID_READ_ONLY_MODE) == false && correct_server_type)
+  assert (get_server_type () == SERVER_TYPE_TRANSACTION);
+  if (prm_get_bool_value (PRM_ID_READ_ONLY_MODE) == false)
     {
       db_Disable_modifications = 0;
       er_log_debug (ARG_FILE_LINE, "logtb_enable_update: db_Disable_modifications = %d\n", db_Disable_modifications);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -61,7 +61,9 @@
 #include "partition_sr.h"
 #include "btree_load.h"
 #include "serial.h"
+#ifndef CS_MODE
 #include "server_type.hpp"
+#endif
 #include "show_scan.h"
 #include "boot_sr.h"
 #include "tz_support.h"
@@ -3142,7 +3144,13 @@ logtb_disable_update (THREAD_ENTRY * thread_p)
 void
 logtb_enable_update (THREAD_ENTRY * thread_p)
 {
-  if (prm_get_bool_value (PRM_ID_READ_ONLY_MODE) == false && get_server_type () != SERVER_TYPE_PAGE)
+#ifndef CS_MODE
+  bool correct_server_type = get_server_type () != SERVER_TYPE_PAGE;
+#else
+  bool correct_server_type = true;
+#endif
+
+  if (prm_get_bool_value (PRM_ID_READ_ONLY_MODE) == false && correct_server_type)
     {
       db_Disable_modifications = 0;
       er_log_debug (ARG_FILE_LINE, "logtb_enable_update: db_Disable_modifications = %d\n", db_Disable_modifications);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -61,6 +61,7 @@
 #include "partition_sr.h"
 #include "btree_load.h"
 #include "serial.h"
+#include "server_type.hpp"
 #include "show_scan.h"
 #include "boot_sr.h"
 #include "tz_support.h"
@@ -110,7 +111,7 @@ static void logtb_increment_number_of_assigned_tran_indices ();
 static void logtb_decrement_number_of_assigned_tran_indices ();
 static void logtb_set_number_of_total_tran_indices (int num_total_trans);
 static void logtb_set_loose_end_tdes (LOG_TDES * tdes);
-static bool logtb_is_interrupted_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool clear, bool * continue_checking);
+static bool logtb_is_interrupted_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool clear, bool *continue_checking);
 static void logtb_dump_tdes_distribute_transaction (FILE * out_fp, int global_tran_id, LOG_2PC_COORDINATOR * coord);
 static void logtb_dump_top_operations (FILE * out_fp, LOG_TOPOPS_STACK * topops_p);
 static void logtb_dump_tdes (FILE * out_fp, LOG_TDES * tdes);
@@ -138,8 +139,8 @@ static void logtb_free_tran_mvcc_info (LOG_TDES * tdes);
 
 static void logtb_assign_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_INFO * curr_mvcc_info, MVCCID mvcc_subid);
 
-static int logtb_check_kill_tran_auth (THREAD_ENTRY * thread_p, int tran_id, bool * has_authorization);
-static void logtb_find_thread_entry_mapfunc (THREAD_ENTRY & thread_ref, bool & stop_mapper, int tran_index,
+static int logtb_check_kill_tran_auth (THREAD_ENTRY * thread_p, int tran_id, bool *has_authorization);
+static void logtb_find_thread_entry_mapfunc (THREAD_ENTRY & thread_ref, bool &stop_mapper, int tran_index,
 					     bool except_me, REFPTR (THREAD_ENTRY, found_ptr));
 
 /*
@@ -2549,7 +2550,7 @@ logtb_find_wait_msecs (int tran_index)
  *
  */
 int
-logtb_find_interrupt (int tran_index, bool * interrupt)
+logtb_find_interrupt (int tran_index, bool *interrupt)
 {
   LOG_TDES *tdes;
 
@@ -2775,7 +2776,7 @@ logtb_set_tran_index_interrupt (THREAD_ENTRY * thread_p, int tran_index, bool se
  * Note:
  */
 static bool
-logtb_is_interrupted_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool clear, bool * continue_checking)
+logtb_is_interrupted_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool clear, bool *continue_checking)
 {
   bool interrupt;
   INT64 now;
@@ -2865,7 +2866,7 @@ logtb_is_interrupted_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool clear,
  *       action... in this case the transaction will be partially aborted.
  */
 bool
-logtb_is_interrupted (THREAD_ENTRY * thread_p, bool clear, bool * continue_checking)
+logtb_is_interrupted (THREAD_ENTRY * thread_p, bool clear, bool *continue_checking)
 {
   LOG_TDES *tdes;		/* Transaction descriptor */
   int tran_index;
@@ -2903,7 +2904,7 @@ logtb_is_interrupted (THREAD_ENTRY * thread_p, bool clear, bool * continue_check
  *       be interrupted.
  */
 bool
-logtb_is_interrupted_tran (THREAD_ENTRY * thread_p, bool clear, bool * continue_checking, int tran_index)
+logtb_is_interrupted_tran (THREAD_ENTRY * thread_p, bool clear, bool *continue_checking, int tran_index)
 {
   LOG_TDES *tdes;		/* Transaction descriptor */
 
@@ -3141,7 +3142,7 @@ logtb_disable_update (THREAD_ENTRY * thread_p)
 void
 logtb_enable_update (THREAD_ENTRY * thread_p)
 {
-  if (prm_get_bool_value (PRM_ID_READ_ONLY_MODE) == false)
+  if (prm_get_bool_value (PRM_ID_READ_ONLY_MODE) == false && get_server_type () != SERVER_TYPE_PAGE)
     {
       db_Disable_modifications = 0;
       er_log_debug (ARG_FILE_LINE, "logtb_enable_update: db_Disable_modifications = %d\n", db_Disable_modifications);
@@ -5674,7 +5675,7 @@ logtb_slam_transaction (THREAD_ENTRY * thread_p, int tran_index)
  *   has_authorization(out):
  */
 static int
-logtb_check_kill_tran_auth (THREAD_ENTRY * thread_p, int tran_id, bool * has_authorization)
+logtb_check_kill_tran_auth (THREAD_ENTRY * thread_p, int tran_id, bool *has_authorization)
 {
   const char *tran_client_name;
   const char *current_client_name;
@@ -5886,7 +5887,7 @@ xlogtb_kill_or_interrupt_tran (THREAD_ENTRY * thread_p, int tran_index, bool is_
 // found_ptr (out)   : saves pointer to found thread entry
 //
 static void
-logtb_find_thread_entry_mapfunc (THREAD_ENTRY & thread_ref, bool & stop_mapper, int tran_index, bool except_me,
+logtb_find_thread_entry_mapfunc (THREAD_ENTRY & thread_ref, bool &stop_mapper, int tran_index, bool except_me,
 				 REFPTR (THREAD_ENTRY, found_ptr))
 {
   if (thread_ref.tran_index != tran_index)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-8

Queries and log creation should be disabled on the page server. Other tools that operate changes on the database like addvoldb, compactdb, loaddb, optimizedb, synccoldb, are also disabled. New error messages will appear when trying to run changes on the page server, or when the server is appending a log record.