### PR TITLE
[LETS-39] perfmon_initialize() with one transaction in CS/SA mode 

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -3067,9 +3067,7 @@ perfmon_initialize (int num_trans)
     }
   memset (pstat_Global.global_stats, 0, PERFMON_VALUES_MEMSIZE);
 
-#if defined (SERVER_MODE)
   assert (num_trans > 0);
-#endif // SERVER_MODE
 
   pstat_Global.n_trans = num_trans + 1;	/* 1 more for easier indexing with tran_index */
   memsize = pstat_Global.n_trans * sizeof (UINT64 *);

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -183,8 +183,8 @@ static void perfmon_stat_dump_in_buffer_thread_daemon_stats (const UINT64 * stat
 static void perfmon_print_timer_to_file (FILE * stream, int stat_index, UINT64 * stats_ptr);
 static void perfmon_print_timer_to_buffer (char **s, int stat_index, UINT64 * stats_ptr, int *remained_size);
 
-STATIC_INLINE size_t thread_stats_count (void) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE size_t perfmon_thread_daemon_stats_count (void) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE size_t thread_stats_count (void) __attribute__((ALWAYS_INLINE));
+STATIC_INLINE size_t perfmon_thread_daemon_stats_count (void) __attribute__((ALWAYS_INLINE));
 #if defined (SERVER_MODE)
 static void perfmon_peek_thread_daemon_stats (UINT64 * stats);
 #endif // SERVER_MODE
@@ -608,25 +608,25 @@ PSTAT_METADATA pstat_Metadata[] = {
 };
 
 STATIC_INLINE void perfmon_add_stat_at_offset (THREAD_ENTRY * thread_p, PERF_STAT_ID psid, const int offset,
-					       UINT64 amount) __attribute__ ((ALWAYS_INLINE));
+					       UINT64 amount) __attribute__((ALWAYS_INLINE));
 
 static void perfmon_server_calc_stats (UINT64 * stats);
 
-STATIC_INLINE const char *perfmon_stat_module_name (const int module) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_module_name (const int module) __attribute__((ALWAYS_INLINE));
 #if defined (SERVER_MODE) || defined (SA_MODE)
-STATIC_INLINE int perfmon_get_module_type (THREAD_ENTRY * thread_p) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE int perfmon_get_module_type (THREAD_ENTRY * thread_p) __attribute__((ALWAYS_INLINE));
 #endif
-STATIC_INLINE const char *perfmon_stat_page_type_name (const int page_type) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE const char *perfmon_stat_page_mode_name (const int page_mode) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE const char *perfmon_stat_holder_latch_name (const int holder_latch) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE const char *perfmon_stat_cond_type_name (const int cond_type) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE const char *perfmon_stat_promote_cond_name (const int cond_type) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE const char *perfmon_stat_snapshot_name (const int snapshot) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE const char *perfmon_stat_snapshot_record_type (const int rec_type) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE const char *perfmon_stat_lock_mode_name (const int lock_mode) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_page_type_name (const int page_type) __attribute__((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_page_mode_name (const int page_mode) __attribute__((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_holder_latch_name (const int holder_latch) __attribute__((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_cond_type_name (const int cond_type) __attribute__((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_promote_cond_name (const int cond_type) __attribute__((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_snapshot_name (const int snapshot) __attribute__((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_snapshot_record_type (const int rec_type) __attribute__((ALWAYS_INLINE));
+STATIC_INLINE const char *perfmon_stat_lock_mode_name (const int lock_mode) __attribute__((ALWAYS_INLINE));
 static const char *perfmon_stat_thread_stat_name (size_t index);
 
-STATIC_INLINE void perfmon_get_peek_stats (UINT64 * stats) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void perfmon_get_peek_stats (UINT64 * stats) __attribute__((ALWAYS_INLINE));
 
 #if defined(CS_MODE) || defined(SA_MODE)
 bool perfmon_Iscollecting_stats = false;
@@ -3067,7 +3067,9 @@ perfmon_initialize (int num_trans)
     }
   memset (pstat_Global.global_stats, 0, PERFMON_VALUES_MEMSIZE);
 
+#if defined (SERVER_MODE)
   assert (num_trans > 0);
+#endif // SERVER_MODE
 
   pstat_Global.n_trans = num_trans + 1;	/* 1 more for easier indexing with tran_index */
   memsize = pstat_Global.n_trans * sizeof (UINT64 *);

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -560,7 +560,7 @@ boot_initialize_client (BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_DB_PATH
       tran_lock_wait_msecs = tran_lock_wait_msecs * 1000;
     }
 
-  error_code = perfmon_initialize (0);
+  error_code = perfmon_initialize (1);	/* 1 transaction for SA_MODE */
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1735,7 +1735,7 @@ prior_list_deserialize (const std::string &str)
 static void
 prior_lsa_start_append (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_TDES *tdes)
 {
-  assertm (get_server_type() == SERVER_TYPE_TRANSACTION, "Log append can be executed only on transaction server");
+  assertm (get_server_type () == SERVER_TYPE_TRANSACTION, "Log append can be executed only on transaction server");
   /* Does the new log record fit in this page ? */
   log_prior_lsa_append_advance_when_doesnot_fit (sizeof (LOG_RECORD_HEADER));
 

--- a/unit_tests/log_transfer/test_main_prior_list_serialize.cpp
+++ b/unit_tests/log_transfer/test_main_prior_list_serialize.cpp
@@ -295,6 +295,7 @@ test_env::require_mem_equal (const char *memleft, const char *memrite, size_t me
 #include "error_manager.h"
 #include "log_compress.h"
 #include "perf_monitor.h"
+#include "server_type.hpp"
 #include "tde.h"
 #include "vacuum.h"
 
@@ -320,6 +321,13 @@ db_io_page_size ()
 {
   assert (false);
   return 0;
+}
+
+SERVER_TYPE
+get_server_type ()
+{
+  assert (false);
+  return SERVER_TYPE_TRANSACTION;
 }
 
 PGLENGTH


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-39

Set the number of transactions argument of perfmon_initialize(). Also fixes assert that is hit.

**Out of scope**

  - Indentation
  - Fix unit test compile
