### PR TITLE
[CBRD-23874] The function IFNULL returns incorrect data type at the query with numeric host-variables

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -3273,7 +3273,7 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
 
       def->overloads_count = num;
       break;
-
+#if 0
     case PT_NVL:
     case PT_IFNULL:
     case PT_COALESCE:
@@ -3611,6 +3611,9 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
       def->overloads_count = num;
 
       break;
+
+#endif
+
     case PT_CONNECT_BY_ROOT:
     case PT_PRIOR:
     case PT_QPRIOR:

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -3273,7 +3273,7 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
 
       def->overloads_count = num;
       break;
-#if 0
+
     case PT_NVL:
     case PT_IFNULL:
     case PT_COALESCE:
@@ -3611,8 +3611,6 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
       def->overloads_count = num;
 
       break;
-
-#endif
 
     case PT_CONNECT_BY_ROOT:
     case PT_PRIOR:

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -3412,8 +3412,8 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
       sig.arg2_type.type = pt_arg_type::GENERIC;
       sig.arg2_type.val.generic_type = PT_GENERIC_TYPE_ANY;
 
-      sig.return_type.type = pt_arg_type::GENERIC;
-      sig.return_type.val.generic_type = PT_GENERIC_TYPE_ANY;
+      sig.return_type.type = pt_arg_type::NORMAL;
+      sig.return_type.val.type = PT_TYPE_VARCHAR;
       def->overloads[num++] = sig;
 
       def->overloads_count = num;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -3412,8 +3412,8 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
       sig.arg2_type.type = pt_arg_type::GENERIC;
       sig.arg2_type.val.generic_type = PT_GENERIC_TYPE_ANY;
 
-      sig.return_type.type = pt_arg_type::NORMAL;
-      sig.return_type.val.type = PT_TYPE_VARCHAR;
+      sig.return_type.type = pt_arg_type::GENERIC;
+      sig.return_type.val.generic_type = PT_GENERIC_TYPE_ANY;
       def->overloads[num++] = sig;
 
       def->overloads_count = num;
@@ -10444,7 +10444,7 @@ pt_common_type (PT_TYPE_ENUM arg1_type, PT_TYPE_ENUM arg2_type)
   else if ((PT_IS_NUMERIC_TYPE (arg1_type) && arg2_type == PT_TYPE_MAYBE)
 	   || (PT_IS_NUMERIC_TYPE (arg2_type) && arg1_type == PT_TYPE_MAYBE))
     {
-      common_type = PT_TYPE_DOUBLE;
+      common_type = PT_TYPE_VARCHAR;
     }
   else
     {

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5444,8 +5444,8 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 	{
 	  PT_NODE *temp = NULL;
 	  int precision = 0, scale = 0;
-	  int units = LANG_SYS_CODESET; /* code set */
-	  int collation_id = LANG_SYS_COLLATION; /* collation_id */
+	  int units = LANG_SYS_CODESET;	/* code set */
+	  int collation_id = LANG_SYS_COLLATION;	/* collation_id */
 	  bool keep_searching = true;
 	  for (temp = arg2->data_type; temp != NULL && keep_searching; temp = temp->next)
 	    {
@@ -21350,13 +21350,6 @@ pt_is_op_hv_late_bind (PT_OP_TYPE op)
     case PT_HEX:
     case PT_CONV:
     case PT_ASCII:
-    case PT_IFNULL:
-    case PT_NVL:
-    case PT_NVL2:
-    case PT_COALESCE:
-    case PT_NULLIF:
-    case PT_LEAST:
-    case PT_GREATEST:
     case PT_FROM_TZ:
     case PT_NEW_TIME:
     case PT_STR_TO_DATE:

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7602,7 +7602,7 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 		    {
 		      if (node->type_enum == PT_TYPE_MAYBE)
 			{
-			  if (pt_is_op_hv_late_bind (node->info.expr.op))
+			  if (pt_is_op_hv_late_bind (node->info.expr.op) || node->expected_domain == NULL)
 			    {
 			      domain = pt_xasl_node_to_domain (parser, node);
 			    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23874

The following query expects 12.34568 but query returns 12.00000. The function NVL also returns 12.00000 as like IFNULL.

```
CREATE TABLE dec_tbl (a decimal(10,5));
PREPARE stmt from 'INSERT INTO dec_tbl VALUES (IFNULL(?,0))';
EXECUTE stmt USING 12.3456789;

SELECT a FROM dec_tbl;
```
**Expected result:**

```
  a
======================
  12.34568 
```
**Actual result:**

```
  a
======================
  12.00000 
```