### PR TITLE
[CBRD-21446] Installing CUBRID with zip on Windows, cubrid server start fail.

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -88,3 +88,9 @@ if(ENABLE_SYSTEMTAP)
     ${CMAKE_SOURCE_DIR}/contrib/systemtap/scripts/topcallstack/topcallstack
     DESTINATION ${CUBRID_DATADIR}/systemtap/tapset/scripts)
 endif(ENABLE_SYSTEMTAP)
+
+if(WIN32)
+  install(FILES
+    ${CMAKE_SOURCE_DIR}/contrib/windows_scripts/cubrid_env.bat
+    DESTINATION ${CUBRID_DATADIR}/windows_scripts/)
+endif(Win32)

--- a/contrib/windows_scripts/cubrid_env.bat
+++ b/contrib/windows_scripts/cubrid_env.bat
@@ -1,0 +1,23 @@
+@echo off
+rem batch script for CUBRID Environments, (window services, registry)
+
+rem LOADING CUBRID Environments
+echo Setting CUBRID Environments
+
+
+set CUBRID "C:\CUBRID"
+set CUBRID_DATABASES "%CUBRID%\DATABASES"
+
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\cmserver" /v "ROOT_PATH" /t REG_SZ /d "%CUBRID%\\" /f
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\cmserver" /v "Version" /t REG_SZ /d "10.2" /f
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\CUBRID" /v "ROOT_PATH" /t REG_SZ /d "%CUBRID%\\" /f
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\CUBRID" /v "Version" /t REG_SZ /d "10.2" /f
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\CUBRID" /v "Patch" /t REG_SZ /d "0" /f
+
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "CUBRID" /t REG_SZ /d "%CUBRID%\\" /f
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "CUBRID_DATABASES" /t REG_SZ /d "%CUBRID%\databases" /f
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "Path" /t REG_SZ /d "%CUBRID%\bin;%PATH%" /f
+
+echo %CUBRID%
+echo %CUBRID_DATABASES%
+echo %Path%


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21446

When installing CUBRID as a zip file on Windows, execution may fail because there is no DLL,  environment variables or registry settings are not set.
In this case, DLL installation, environment variables, and registry settings are required.