### PR TITLE
[LETS-47] Run scalability unit tests in circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
     <<: *defaults
     environment:
       MAKEFLAGS: -j2
+      BUILD_DIR_NAME: build_x86_64_release
     
     steps:
       - checkout:
@@ -48,7 +49,7 @@ jobs:
       - run:
           name: Unit tests
           command: |
-            cd /home/qa/cubrid/${BUILD_DIR_NAME}/bin
+            cd /home/cubrid/${BUILD_DIR_NAME}/bin
             sh ./run_scalability_unit_tests.sh
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,12 @@ jobs:
           path: cubrid
       - run:
           name: Build
-          command: scl enable devtoolset-8 -- /entrypoint.sh build
+          command: scl enable devtoolset-8 -- /entrypoint.sh build -b ${BUILD_DIR_NAME} -c -DUNIT_TESTS=ON
+      - run:
+          name: Unit tests
+          command: |
+            cd /home/qa/cubrid/${BUILD_DIR_NAME}/bin
+            sh ./run_scalability_unit_tests.sh
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: /home
   docker:
-    - image: cubridci/cubridci:develop
+    - image: cubridci/cubridci:12.0
 
 test_defaults: &test_defaults
   steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1153,6 +1153,8 @@ add_subdirectory(locales)
 add_subdirectory(timezones)
 if(AT_LEAST_ONE_UNIT_TEST)
   add_subdirectory(unit_tests)
+  file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/run_unit_tests.sh
+       DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/bin)
 endif()
 
 if(WITH_JDBC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1153,7 +1153,7 @@ add_subdirectory(locales)
 add_subdirectory(timezones)
 if(AT_LEAST_ONE_UNIT_TEST)
   add_subdirectory(unit_tests)
-  file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/run_unit_tests.sh
+  file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/run_scalability_unit_tests.sh
        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/bin)
 endif()
 

--- a/run_scalability_unit_tests.sh
+++ b/run_scalability_unit_tests.sh
@@ -1,0 +1,22 @@
+#
+#  Copyright 2008 Search Solution Corporation
+#  Copyright 2016 CUBRID Corporation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#
+
+# A-Z
+./test_prior_list_serialize
+./test_prior_sendrecv
+./test_request_cs


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-47

Run the scalability unit tests in circle-ci.

  - Add a script that runs scalability unit tests.
  - Modify circle-ci config file to compile unit tests and run the script during build phase.

The tests included in the script must be very small. No stress/performance tests will be allowed. Any longer unit tests should not be included or should be run in a short version.
