### PR TITLE
[LETS-48] Add missing system headers to fix VS2019 compile fail

### DIFF
--- a/src/base/string_buffer.cpp
+++ b/src/base/string_buffer.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>  // for std::min
 #include <memory.h>
+#include <string>
 
 void string_buffer::add_bytes (size_t len, const char *bytes)
 {

--- a/src/loaddb/load_class_registry.cpp
+++ b/src/loaddb/load_class_registry.cpp
@@ -23,6 +23,7 @@
 #include "load_class_registry.hpp"
 
 #include <algorithm>
+#include <iterator>
 
 namespace cubload
 {

--- a/src/transaction/transaction_transient.hpp
+++ b/src/transaction/transaction_transient.hpp
@@ -26,6 +26,7 @@
 
 #include <forward_list>
 #include <functional>
+#include <string>
 
 // todo - namespace cubtx
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-48

Add missing system headers to fix VS2019 compile fail.

@hornetmj should this change be backported to develop?