### PR TITLE
[LETS-51] Add debug messages for log prior list send/receive

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -696,6 +696,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_PAGE_SERVER_HOSTS "page_server_hosts"
 #define PRM_NAME_SERVER_TYPE "server_type"
 
+#define PRM_NAME_ER_LOG_PRIOR_TRANSFER "er_log_prior_transfer"
+
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
 #define PRM_VALUE_MIN "MIN"
@@ -2357,6 +2359,10 @@ static int prm_server_type_default = SERVER_TYPE_TRANSACTION;
 static int prm_server_type_lower = SERVER_TYPE_TRANSACTION;
 static int prm_server_type_upper = SERVER_TYPE_PAGE;
 static unsigned int prm_server_type_flag = 0;
+
+bool PRM_ER_LOG_PRIOR_TRANSFER = false;
+static bool prm_er_log_prior_transfer_default = false;
+static unsigned int prm_er_log_prior_transfer_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -6074,6 +6080,18 @@ static SYSPRM_PARAM prm_Def[] = {
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},
+  {PRM_ID_ER_LOG_PRIOR_TRANSFER,
+   PRM_NAME_ER_LOG_PRIOR_TRANSFER,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   &prm_er_log_prior_transfer_flag,
+   (void *) &prm_er_log_prior_transfer_default,
+   (void *) &PRM_ER_LOG_PRIOR_TRANSFER,
+   (void *) NULL,
+   (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
 };
 
 #define NUM_PRM ((int)(sizeof(prm_Def)/sizeof(prm_Def[0])))
@@ -8200,8 +8218,7 @@ prm_print (const SYSPRM_PARAM * prm, char *buf, size_t len, PRM_PRINT_MODE print
 	}
       else if (intl_mbs_casecmp (prm->name, PRM_NAME_SERVER_TYPE) == 0)
 	{
-	  keyvalp =
-	    prm_keyword (PRM_GET_INT (prm->value), NULL, server_type_words, DIM (server_type_words));
+	  keyvalp = prm_keyword (PRM_GET_INT (prm->value), NULL, server_type_words, DIM (server_type_words));
 	}
       else
 	{

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -456,8 +456,9 @@ enum param_id
   PRM_ID_PAGE_SERVER_HOSTS,
   PRM_ID_SERVER_TYPE,
 
+  PRM_ID_ER_LOG_PRIOR_TRANSFER,
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_SERVER_TYPE
+  PRM_LAST_ID = PRM_ID_ER_LOG_PRIOR_TRANSFER
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -18,8 +18,10 @@
 
 #include "log_prior_recv.hpp"
 
+#include "error_manager.h"
 #include "log_append.hpp"
 #include "log_manager.h"
+#include "system_parameter.h"
 
 namespace cublog
 {
@@ -87,6 +89,14 @@ namespace cublog
 	    log_prior_node *list_head = nullptr;
 	    log_prior_node *list_tail = nullptr;
 	    prior_list_deserialize (backbuffer.front (), list_head, list_tail);
+
+	    if (prm_get_bool_value (PRM_ID_ER_LOG_PRIOR_TRANSFER))
+	      {
+		_er_log_debug (ARG_FILE_LINE,
+			       "[LOG_PRIOR_TRANSFER] Received list starting with lsa %lld|%d. Message size = %d.\n",
+			       LSA_AS_ARGS (&list_head->start_lsa), backbuffer.front ().size ());
+	      }
+
 	    m_prior_lsa_info.push_list (list_head, list_tail);
 	    log_wakeup_log_flush_daemon ();
 	    backbuffer.pop ();

--- a/src/transaction/log_prior_send.cpp
+++ b/src/transaction/log_prior_send.cpp
@@ -18,7 +18,10 @@
 
 #include "log_prior_send.hpp"
 
+#include "error_manager.h"
 #include "log_append.hpp"
+#include "log_lsa.hpp"
+#include "system_parameter.h"
 
 namespace cublog
 {
@@ -30,6 +33,14 @@ namespace cublog
 	return;
       }
     std::string message = prior_list_serialize (head);
+
+    if (prm_get_bool_value (PRM_ID_ER_LOG_PRIOR_TRANSFER))
+      {
+	_er_log_debug (ARG_FILE_LINE,
+		       "[LOG PRIOR TRANSFER] Sending list starting with lsa %lld|%d. Message size = %zu.\n",
+		       LSA_AS_ARGS (&head->start_lsa), message.size ());
+      }
+
     std::unique_lock<std::mutex> ulock (m_sink_hooks_mutex);
     for (auto &sink : m_sink_hooks)
       {

--- a/unit_tests/log_transfer/test_main_prior_sendrecv.cpp
+++ b/unit_tests/log_transfer/test_main_prior_sendrecv.cpp
@@ -237,6 +237,10 @@ test_env::require_prior_list_match () const
 //
 // Add mock definitions for used CUBRID stuff
 //
+#include "error_manager.h"
+#include "log_append.hpp"
+#include "log_manager.h"
+#include "system_parameter.h"
 
 log_prior_lsa_info::log_prior_lsa_info () = default;
 
@@ -326,4 +330,15 @@ void
 log_wakeup_log_flush_daemon ()
 {
   test_Flush_track.increment_count ();
+}
+
+void
+_er_log_debug (const char *file_name, const int line_no, const char *fmt, ...)
+{
+}
+
+bool
+prm_get_bool_value (PARAM_ID id)
+{
+  return false;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-51

Add er_log_prior_transfer system parameter to activate debug messages for sending and receiving log prior lists during log prior transfer.

**Other changes**

- Fix new prior send/receive unit test dependencies.