### PR TITLE
[CBRD-23877] To CREATE a table as SELECT query, the alias of attributes should be checked.

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8512,14 +8512,12 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	{
 	  for (crt_attr = qspec_attr; crt_attr != NULL; crt_attr = crt_attr->next)
 	    {
-	      if (crt_attr->alias_print || crt_attr->node_type == PT_NAME || crt_attr->node_type == PT_DOT_)
+	      if (crt_attr->alias_print == NULL && crt_attr->node_type != PT_NAME && crt_attr->node_type != PT_DOT_)
 		{
-                  continue;
+	          PT_ERRORmf (parser, qry_specs, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_MISSING_ATTR_NAME,
+		          pt_short_print (parser, crt_attr));
+	          return;
 		}
-
-	      PT_ERRORmf (parser, qry_specs, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_MISSING_ATTR_NAME,
-		      pt_short_print (parser, crt_attr));
-	      return;
 	    }
 
 	  if (select->info.query.with != NULL)

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8514,9 +8514,9 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	    {
 	      if (crt_attr->alias_print == NULL && crt_attr->node_type != PT_NAME && crt_attr->node_type != PT_DOT_)
 		{
-	          PT_ERRORmf (parser, qry_specs, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_MISSING_ATTR_NAME,
-		          pt_short_print (parser, crt_attr));
-	          return;
+		  PT_ERRORmf (parser, qry_specs, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_MISSING_ATTR_NAME,
+			      pt_short_print (parser, crt_attr));
+		  return;
 		}
 	    }
 

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8497,7 +8497,10 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
   qry_specs = node->info.create_entity.as_query_list;
   if (node->info.create_entity.entity_type == PT_CLASS)
     {
-      PT_NODE *select = NULL;
+      PT_NODE *select = node->info.create_entity.create_select;
+      PT_NODE *crt_attr = NULL;
+      PT_NODE *const qspec_attr = pt_get_select_list (parser, select);
+
       /* simple CLASSes must not have any query specs */
       if (qry_specs)
 	{
@@ -8505,9 +8508,25 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	  return;
 	}
       /* user variables are not allowed in select list for CREATE ... AS SELECT ... */
-      select = node->info.create_entity.create_select;
       if (select != NULL)
 	{
+	  for (crt_attr = qspec_attr; crt_attr != NULL; crt_attr = crt_attr->next)
+	    {
+	      PT_NODE *s_attr = NULL;
+
+	      if (crt_attr->node_type == PT_NAME || crt_attr->alias_print)
+		{
+		  s_attr = crt_attr;
+		}
+
+	      if (s_attr == NULL)
+		{
+		  PT_ERRORmf (parser, qry_specs, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_MISSING_ATTR_NAME,
+			      pt_short_print (parser, crt_attr));
+		  return;
+		}
+	    }
+
 	  if (select->info.query.with != NULL)
 	    {
 	      // run semantic check only for CREATE ... AS WITH ...

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8512,19 +8512,14 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	{
 	  for (crt_attr = qspec_attr; crt_attr != NULL; crt_attr = crt_attr->next)
 	    {
-	      PT_NODE *s_attr = NULL;
-
-	      if (crt_attr->node_type == PT_NAME || crt_attr->alias_print)
+	      if (crt_attr->alias_print || crt_attr->node_type == PT_NAME || crt_attr->node_type == PT_DOT_)
 		{
-		  s_attr = crt_attr;
+                  continue;
 		}
 
-	      if (s_attr == NULL)
-		{
-		  PT_ERRORmf (parser, qry_specs, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_MISSING_ATTR_NAME,
-			      pt_short_print (parser, crt_attr));
-		  return;
-		}
+	      PT_ERRORmf (parser, qry_specs, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_MISSING_ATTR_NAME,
+		      pt_short_print (parser, crt_attr));
+	      return;
 	    }
 
 	  if (select->info.query.with != NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23877

```
csql> CREATE TABLE nvl_tbl3 AS SELECT SUM(1),MAX(1),COUNT(*),NVL(1,'');
Execute OK. (0.006011 sec) Committed.
1 command(s) successfully processed.

csql> ;sc nvl_tbl3
=== <Help: Schema of a Class> ===
<Class Name>nvl_tbl3<Attributes>sum(1) INTEGER
max(1) INTEGER
count(*) INTEGER
nvl(1, '') CHARACTER VARYING(1073741823)

csql> DESC nvl_tbl3;
=== <Result of SELECT Command in Line 1> ===
Field Type Null Key Default Extra
===================================================================================
'sum(1)' 'INTEGER' 'YES' '' NULL ''
'max(1)' 'INTEGER' 'YES' '' NULL ''
'count(*)' 'INTEGER' 'YES' '' NULL ''
'nvl(1, '')' 'VARCHAR(1073741823)' 'YES' '' NULL '' 
```
**Expected**
`ERROR: Missing an expected attribute name for sum(1). `

Unlike the CREATE TABLE statement, the CREATE VIEW statement checks the alias of the column attributes. This issue can be solved by checking the alias of the column attribute in the CREATE TABLE statement and treating a non-aliased column.

However, aliases are required only in SELECT statements that include functions such as SUM, COUNT, and AVG, or that contain calculation expressions, so alias checks for all columns are not required.