### PR TITLE
[CBRD-23878] To prevent setting the precision to -1 for STRING type as derived attribute

### DIFF
--- a/src/object/object_domain.h
+++ b/src/object/object_domain.h
@@ -242,6 +242,12 @@ typedef enum tp_match
   (((typeid) == DB_TYPE_VARCHAR)  || ((typeid) == DB_TYPE_CHAR) || \
    ((typeid) == DB_TYPE_VARNCHAR) || ((typeid) == DB_TYPE_NCHAR))
 
+#define TP_IS_FIXED_LEN_CHAR_TYPE(typeid) \
+  (((typeid) == DB_TYPE_CHAR) || ((typeid) == DB_TYPE_NCHAR))
+
+#define TP_IS_VAR_LEN_CHAR_TYPE(typeid) \
+    (((typeid) == DB_TYPE_VARCHAR) || ((typeid) == DB_TYPE_VARNCHAR))
+
 /*
  * TP_IS_CHAR_BIT_TYPE
  *    Tests to see if a type is one of the character or bit types.

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -6409,16 +6409,6 @@ pt_make_regu_arith (const REGU_VARIABLE * arg1, const REGU_VARIABLE * arg2, cons
 
   regu_dbval_type_init (dbval, TP_DOMAIN_TYPE (domain));
   arith->domain = (TP_DOMAIN *) domain;
-  if (domain->type->id == DB_TYPE_STRING)
-    {
-      /* if the domain is STRING, it should be checked
-       * its precision is negative, commonly default is -1
-       */
-      if (arith->domain->precision < 0)
-        {
-          arith->domain->precision = DB_MAX_VARCHAR_PRECISION;
-        }
-    }
   arith->value = dbval;
   arith->opcode = op;
   arith->leftptr = (REGU_VARIABLE *) arg1;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -6409,6 +6409,16 @@ pt_make_regu_arith (const REGU_VARIABLE * arg1, const REGU_VARIABLE * arg2, cons
 
   regu_dbval_type_init (dbval, TP_DOMAIN_TYPE (domain));
   arith->domain = (TP_DOMAIN *) domain;
+  if (domain->type->id == DB_TYPE_STRING)
+    {
+      /* if the domain is STRING, it should be checked
+       * its precision is negative, commonly default is -1
+       */
+      if (arith->domain->precision < 0)
+        {
+          arith->domain->precision = DB_MAX_VARCHAR_PRECISION;
+        }
+    }
   arith->value = dbval;
   arith->opcode = op;
   arith->leftptr = (REGU_VARIABLE *) arg1;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -8617,16 +8617,25 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
       /* check for mis-creating string type with -1 precision */
       for (column = query_columns; column != NULL; column = db_query_format_next (column))
         {
-          if (column->domain->precision == DB_DEFAULT_PRECISION)
+          switch (column->domain->type->id)
             {
-              switch (column->domain->type->id)
-                {
-                case DB_TYPE_VARCHAR:
-                  column->domain->precision = DB_MAX_VARCHAR_PRECISION;
-                  break;
+              case DB_TYPE_VARCHAR:
+                if (column->domain->precision == DB_DEFAULT_PRECISION)
+                  {
+                    column->domain->precision = DB_MAX_VARCHAR_PRECISION;
+                  }
+                break;
+              case DB_TYPE_VARNCHAR:
+                if (column->domain->precision == DB_DEFAULT_PRECISION)
+                  {
+                    column->domain->precision = DB_MAX_VARNCHAR_PRECISION;
+                  }
+                else if (column->domain->precision > DB_MAX_VARNCHAR_PRECISION)
+                  {
+                    column->domain->precision = DB_MAX_VARNCHAR_PRECISION;
+                  }
                 default:
-                  break;
-                }
+                break;
             }
         }
     }

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -8621,17 +8621,8 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
             {
               switch (column->domain->type->id)
                 {
-                case DB_TYPE_CHAR:
-                  column->domain->precision = DB_MAX_CHAR_PRECISION;
-                  break;
-                case DB_TYPE_NCHAR:
-                  column->domain->precision = DB_MAX_NCHAR_PRECISION;
-                  break;
                 case DB_TYPE_VARCHAR:
                   column->domain->precision = DB_MAX_VARCHAR_PRECISION;
-                  break;
-                case DB_TYPE_VARNCHAR:
-                  column->domain->precision = DB_MAX_VARNCHAR_PRECISION;
                   break;
                 default:
                   break;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -8617,19 +8617,25 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
       /* check for mis-creating string type with -1 precision */
       for (column = query_columns; column != NULL; column = db_query_format_next (column))
         {
-          if (TP_IS_VAR_LEN_CHAR_TYPE(column->domain->type->id))
+          if (column->domain->precision == DB_DEFAULT_PRECISION)
             {
-              if (column->domain->precision == DB_DEFAULT_PRECISION)
+              switch (column->domain->type->id)
                 {
+                case DB_TYPE_CHAR:
+                  column->domain->precision = DB_MAX_CHAR_PRECISION;
+                  break;
+                case DB_TYPE_NCHAR:
+                  column->domain->precision = DB_MAX_NCHAR_PRECISION;
+                  break;
+                case DB_TYPE_VARCHAR:
                   column->domain->precision = DB_MAX_VARCHAR_PRECISION;
+                  break;
+                case DB_TYPE_VARNCHAR:
+                  column->domain->precision = DB_MAX_VARNCHAR_PRECISION;
+                  break;
+                default:
+                  break;
                 }
-            }
-          else if (TP_IS_FIXED_LEN_CHAR_TYPE(column->domain->type->id))
-            {
-             if (column->domain->precision == DB_DEFAULT_PRECISION)
-               {
-                 column->domain->precision = DB_MAX_CHAR_PRECISION;
-               }
             }
         }
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23878

```
csql> CREATE TABLE nvl_tbl1 AS SELECT NVL(x,111) AS x, NVL(y,'aaa') AS y, NVL(z,sysdatetime) AS z FROM tbl1;
Execute OK. (0.004824 sec) Committed.1 

command(s) successfully processed.

csql> ;sc nvL_tbl1
=== <Help: Schema of a Class> ===
<Class Name> 
nvl_tbl1

<Attributes>
x INTEGER
y STRING
z DATETIME
```

**Expected:**
```
<Attributes>
x INTEGER 
y VARCHAR(1073741823) 
z DATETIME
```

This is an issue that occurs because the data value of the string type is copied and the precision of the domain is not copied in the process of creating a column through pt_make_regu_arith with the CREATE TABLE AS SELECT statement. For string type domain, the default precision is -1, and this value should be copied from the precision of the data value