### PR TITLE
[CBRD-23879] Outer dependency is set improperly when rewriting SQL from outer join to inner join

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -1884,9 +1884,10 @@ qo_add_dummy_join_term (QO_ENV * env, QO_NODE * p_node, QO_NODE * on_node)
       break;
     case PT_JOIN_RIGHT_OUTER:
       QO_TERM_JOIN_TYPE (term) = JOIN_RIGHT;
+      bitset_union (&(QO_NODE_RIGHT_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (p_node)));
+      bitset_add (&(QO_NODE_RIGHT_DEP_SET (on_node)), QO_NODE_IDX (p_node));
       bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_OUTER_DEP_SET (p_node)));
       bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (p_node)));
-      bitset_add (&(QO_NODE_OUTER_DEP_SET (on_node)), QO_NODE_IDX (p_node));
       break;
     case PT_JOIN_FULL_OUTER:	/* not used */
       QO_TERM_JOIN_TYPE (term) = JOIN_OUTER;
@@ -1902,7 +1903,6 @@ qo_add_dummy_join_term (QO_ENV * env, QO_NODE * p_node, QO_NODE * on_node)
 
   env->nterms++;
 
-  QO_ASSERT (env, QO_TERM_LOCATION (term) == QO_NODE_LOCATION (on_node));
   QO_ASSERT (env, QO_TERM_CAN_USE_INDEX (term) == 0);
 
   return term;

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -1896,7 +1896,7 @@ qo_add_dummy_join_term (QO_ENV * env, QO_NODE * p_node, QO_NODE * on_node)
   env->nterms++;
 
   /* record outer join dependecy */
-  if (QO_ON_COND_TERM (term))
+  if (QO_OUTER_JOIN_TERM (term))
     {
       QO_ASSERT (env, QO_TERM_LOCATION (term) == QO_NODE_LOCATION (on_node));
 
@@ -2616,8 +2616,11 @@ qo_analyze_term (QO_TERM * term, int term_type)
 		}
 
 	      /* record explicit join dependecy */
-	      bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_OUTER_DEP_SET (head_node)));
-	      bitset_add (&(QO_NODE_OUTER_DEP_SET (on_node)), QO_NODE_IDX (head_node));
+	      if (QO_NODE_IS_OUTER_JOIN (on_node))
+		{
+		  bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_OUTER_DEP_SET (head_node)));
+		  bitset_add (&(QO_NODE_OUTER_DEP_SET (on_node)), QO_NODE_IDX (head_node));
+		}
 	    }
 	  else
 	    {

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -1874,20 +1874,17 @@ qo_add_dummy_join_term (QO_ENV * env, QO_NODE * p_node, QO_NODE * on_node)
     {
     case PT_JOIN_INNER:
       QO_TERM_JOIN_TYPE (term) = JOIN_INNER;
-      bitset_union (&(QO_NODE_RIGHT_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (p_node)));
-      bitset_add (&(QO_NODE_RIGHT_DEP_SET (on_node)), QO_NODE_IDX (p_node));
+      QO_ADD_RIGHT_DEP_SET (on_node, p_node);
       break;
     case PT_JOIN_LEFT_OUTER:
       QO_TERM_JOIN_TYPE (term) = JOIN_LEFT;
-      bitset_union (&(QO_NODE_RIGHT_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (p_node)));
-      bitset_add (&(QO_NODE_RIGHT_DEP_SET (on_node)), QO_NODE_IDX (p_node));
+      QO_ADD_RIGHT_DEP_SET (on_node, p_node);
       break;
     case PT_JOIN_RIGHT_OUTER:
       QO_TERM_JOIN_TYPE (term) = JOIN_RIGHT;
-      bitset_union (&(QO_NODE_RIGHT_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (p_node)));
-      bitset_add (&(QO_NODE_RIGHT_DEP_SET (on_node)), QO_NODE_IDX (p_node));
-      bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_OUTER_DEP_SET (p_node)));
-      bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (on_node)));
+      QO_ADD_RIGHT_DEP_SET (on_node, p_node);
+      QO_ADD_OUTER_DEP_SET (on_node, p_node);
+      QO_ADD_RIGHT_TO_OUTER (on_node, p_node);
       break;
     case PT_JOIN_FULL_OUTER:	/* not used */
       QO_TERM_JOIN_TYPE (term) = JOIN_OUTER;
@@ -2604,15 +2601,15 @@ qo_analyze_term (QO_TERM * term, int term_type)
 	      if (QO_NODE_PT_JOIN_TYPE (on_node) == PT_JOIN_LEFT_OUTER)
 		{
 		  QO_TERM_JOIN_TYPE (term) = JOIN_LEFT;
-		  bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_OUTER_DEP_SET (head_node)));
-		  bitset_add (&(QO_NODE_OUTER_DEP_SET (on_node)), QO_NODE_IDX (head_node));
+		  QO_ADD_RIGHT_DEP_SET (on_node, head_node);
+		  QO_ADD_OUTER_DEP_SET (on_node, head_node);
 		}
 	      else if (QO_NODE_PT_JOIN_TYPE (on_node) == PT_JOIN_RIGHT_OUTER)
 		{
 		  QO_TERM_JOIN_TYPE (term) = JOIN_RIGHT;
-		  bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (head_node)));
-		  bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_OUTER_DEP_SET (head_node)));
-		  bitset_add (&(QO_NODE_OUTER_DEP_SET (on_node)), QO_NODE_IDX (head_node));
+		  QO_ADD_RIGHT_DEP_SET (on_node, head_node);
+		  QO_ADD_OUTER_DEP_SET (on_node, head_node);
+		  QO_ADD_RIGHT_TO_OUTER (on_node, head_node);
 		}
 	      else if (QO_NODE_PT_JOIN_TYPE (on_node) == PT_JOIN_FULL_OUTER)
 		{		/* not used */
@@ -2621,8 +2618,7 @@ qo_analyze_term (QO_TERM * term, int term_type)
 	      else if (QO_NODE_PT_JOIN_TYPE (on_node) == PT_JOIN_INNER)
 		{
 		  QO_TERM_JOIN_TYPE (term) = JOIN_INNER;
-		  bitset_union (&(QO_NODE_RIGHT_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (head_node)));
-		  bitset_add (&(QO_NODE_RIGHT_DEP_SET (on_node)), QO_NODE_IDX (head_node));
+		  QO_ADD_RIGHT_DEP_SET (on_node, head_node);
 		}
 	    }
 	  else

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -1887,7 +1887,7 @@ qo_add_dummy_join_term (QO_ENV * env, QO_NODE * p_node, QO_NODE * on_node)
       bitset_union (&(QO_NODE_RIGHT_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (p_node)));
       bitset_add (&(QO_NODE_RIGHT_DEP_SET (on_node)), QO_NODE_IDX (p_node));
       bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_OUTER_DEP_SET (p_node)));
-      bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (p_node)));
+      bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (on_node)));
       break;
     case PT_JOIN_FULL_OUTER:	/* not used */
       QO_TERM_JOIN_TYPE (term) = JOIN_OUTER;

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -1879,8 +1879,8 @@ qo_add_dummy_join_term (QO_ENV * env, QO_NODE * p_node, QO_NODE * on_node)
       break;
     case PT_JOIN_LEFT_OUTER:
       QO_TERM_JOIN_TYPE (term) = JOIN_LEFT;
-      bitset_union (&(QO_NODE_OUTER_DEP_SET (on_node)), &(QO_NODE_OUTER_DEP_SET (p_node)));
-      bitset_add (&(QO_NODE_OUTER_DEP_SET (on_node)), QO_NODE_IDX (p_node));
+      bitset_union (&(QO_NODE_RIGHT_DEP_SET (on_node)), &(QO_NODE_RIGHT_DEP_SET (p_node)));
+      bitset_add (&(QO_NODE_RIGHT_DEP_SET (on_node)), QO_NODE_IDX (p_node));
       break;
     case PT_JOIN_RIGHT_OUTER:
       QO_TERM_JOIN_TYPE (term) = JOIN_RIGHT;

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -371,10 +371,10 @@ struct qo_node
   /* NULL if no USING INDEX clause in the query */
 
   BITSET outer_dep_set;		/* outer join dependency; to preserve join sequence */
+  BITSET right_dep_set;		/* outer join dependency for right outer join; to preserve join sequence */
   PT_HINT_ENUM hint;		/* hint comment contained in given */
   bool sargable;		/* whether sargs are applicable to this node */
   bool sort_limit_candidate;	/* whether this node is a candidate for a SORT_LIMIT plan */
-  BITSET right_dep_set;		/* outer join dependency for right outer join; to preserve join sequence */
 };
 
 #define QO_NODE_ENV(node)		(node)->env
@@ -423,6 +423,17 @@ struct qo_node
   (QO_NODE_PT_JOIN_TYPE(node) == PT_JOIN_LEFT_OUTER  || \
    QO_NODE_PT_JOIN_TYPE(node) == PT_JOIN_RIGHT_OUTER || \
    QO_NODE_PT_JOIN_TYPE(node) == PT_JOIN_FULL_OUTER)
+
+#define QO_ADD_OUTER_DEP_SET(tail,head) \
+   bitset_union (&(QO_NODE_OUTER_DEP_SET (tail)), &(QO_NODE_OUTER_DEP_SET (head))); \
+   bitset_add (&(QO_NODE_OUTER_DEP_SET (tail)), QO_NODE_IDX (head));
+
+#define QO_ADD_RIGHT_DEP_SET(tail,head) \
+   bitset_union (&(QO_NODE_RIGHT_DEP_SET (tail)), &(QO_NODE_RIGHT_DEP_SET (head))); \
+   bitset_add (&(QO_NODE_RIGHT_DEP_SET (tail)), QO_NODE_IDX (head));
+
+#define QO_ADD_RIGHT_TO_OUTER(tail,head) \
+   bitset_union (&(QO_NODE_OUTER_DEP_SET (tail)), &(QO_NODE_RIGHT_DEP_SET (head)));
 
 struct qo_segment
 {

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -374,6 +374,7 @@ struct qo_node
   PT_HINT_ENUM hint;		/* hint comment contained in given */
   bool sargable;		/* whether sargs are applicable to this node */
   bool sort_limit_candidate;	/* whether this node is a candidate for a SORT_LIMIT plan */
+  BITSET right_dep_set;		/* outer join dependency for right outer join; to preserve join sequence */
 };
 
 #define QO_NODE_ENV(node)		(node)->env
@@ -394,6 +395,7 @@ struct qo_node
 #define QO_NODE_USING_INDEX(node)       (node)->using_index
 
 #define QO_NODE_OUTER_DEP_SET(node)     (node)->outer_dep_set
+#define QO_NODE_RIGHT_DEP_SET(node)     (node)->right_dep_set
 #define QO_NODE_SARGABLE(node)          (node)->sargable
 
 #define QO_NODE_NAME(node)		(node)->class_name

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -6745,7 +6745,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 
 	    /* set join type */
 	    if (join_type == NO_JOIN || is_dummy_term)
-	      {			/* the first time */
+	      {
+		/* the first time except dummy term */
 		join_type = QO_TERM_JOIN_TYPE (term);
 		is_dummy_term = QO_TERM_CLASS (term) == QO_TC_DUMMY_JOIN ? true : false;
 	      }

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -6481,6 +6481,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
   QO_INFO *new_info = (QO_INFO *) NULL;
   int i, j;
   bool check_afj_terms = false;
+  bool is_dummy_term = false;
   BITSET_ITERATOR bi, bj;
   BITSET nl_join_terms;		/* nested-loop join terms */
   BITSET sm_join_terms;		/* sort merge join terms */
@@ -6743,9 +6744,14 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	    edge_cnt++;
 
 	    /* set join type */
-	    if (join_type == NO_JOIN)
+	    if (join_type == NO_JOIN || is_dummy_term)
 	      {			/* the first time */
 		join_type = QO_TERM_JOIN_TYPE (term);
+		is_dummy_term = QO_TERM_CLASS (term) == QO_TC_DUMMY_JOIN ? true : false;
+	      }
+	    else if (QO_TERM_CLASS (term) == QO_TC_DUMMY_JOIN)
+	      {
+		/* The dummy join term is excluded from the outer join check. */
 	      }
 	    else
 	      {			/* already assigned */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23879

AS-is: When written in ANSI SQL syntax, the order of scan of tables cannot be changed.
```
select * from t1 inner join t2 on t1.a = t2.a left outer join t3 on t1.a = t3.a

t1->t2->t3 join order only can be selected
actually t2->t1->t3, t1->t3->t2 can be generated
```

To-be: Outer dependency is set only for outer joined tables.

Dependency is set based on the following two criteria.
1. Left outer join: The preceding table is set as a dependency.
2. Right outer join: The all preceding tables written in the ANSI SQL syntax are set as dependency.
                        (The right dep set is used to check the preceding tables of the right outer join)