### PR TITLE
[LETS-40] Fix starting server type message

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -52,6 +52,9 @@ void init_server_type (const char *db_name)
     {
       ats_Gl.init_page_server_hosts (db_name);
     }
+
+  er_log_debug (ARG_FILE_LINE, "Starting server type: %s\n",
+		get_server_type () == SERVER_TYPE_PAGE ? "page" : "transaction");
 }
 
 void finalize_server_type ()

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2110,9 +2110,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 
   common_ha_mode = HA_GET_MODE ();
 
-  er_log_debug (ARG_FILE_LINE, "Starting server type: %s\n",
-		get_server_type () == SERVER_TYPE_PAGE ? "page" : "transaction");
-
 #endif /* SERVER_MODE */
 
   if (db_name == NULL)


### PR DESCRIPTION
Bug: Regardless of the server type it was always displaying "Starting server type: transaction", because the message is printed before initialization.

Fix: The message is now printed in the server_type initialization function.

```bash
Time: 03/22/21 16:30:08.679 - DEBUG *** file PATH/cubrid/src/base/server_type.cpp, line 56
Starting server type: page
```

```bash
Time: 03/22/21 16:38:36.942 - DEBUG *** file PATH/cubrid/src/base/server_type.cpp, line 56
Starting server type: transaction
```