### PR TITLE
[CBRD-23881] Add a new option to the vacuumdb utility to output the smallest log page ID and log volume name referenced by vacuum

### DIFF
--- a/msg/de_DE.utf8/utils.msg
+++ b/msg/de_DE.utf8/utils.msg
@@ -1174,13 +1174,16 @@ gültigen Optionen:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 vacuumdb vorübergehend nicht verfügbar ist für Client-Server-Modus\n
 21 Der Vakuumbetrieb gescheitert\n
+22 Ausgangsdatei '%1$s' konnte nicht geöffnet werden \n
 60 \
 vacuumdb: Vakuum Toten Datensätze aus der Datenbank.\n\
 Anwendung: %1$s vacuumdb [OPTION] Datenbank-Name\n\
 \n\
 gültigen Optionen:\n\
   -S, --SA-mode                    Stand-alone-Modus Ausführung\n\
-  -C, --CS-mode                    Client-Server-Modus Ausführung\n
+  -C, --CS-mode                    Client-Server-Modus Ausführung\n\
+      --dump                       aktuellen Vakuumzustand entleeren\n\
+  -o, --output-file=DATEI          Umleiten der Ausgabemeldungen in DATEI; Standard: keine\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Fehler beim Tabellennamen in %1$s zu laden.\n

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -1177,13 +1177,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb is temporary not available for client-server mode\n
 21 The vacuum operation failed\n
+22 Couldn't open output file '%1$s'\n
 60 \
 vacuumdb: Vacuums dead records from database.\n\
 usage: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                stand-alone mode execution\n\
-  -C, --CS-mode                client-server mode execution\n
+  -C, --CS-mode                client-server mode execution\n\
+      --dump                   dump current state of vacuum\n\
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Failed to load table names in %1$s.\n

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -1177,13 +1177,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb is temporary not available for client-server mode\n
 21 The vacuum operation failed\n
+22 Couldn't open output file '%1$s'\n
 60 \
 vacuumdb: Vacuums dead records from database.\n\
 usage: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                stand-alone mode execution\n\
-  -C, --CS-mode                client-server mode execution\n
+  -C, --CS-mode                client-server mode execution\n\
+      --dump                   dump current state of vacuum\n\
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Failed to load table names in %1$s.\n

--- a/msg/es_ES.utf8/utils.msg
+++ b/msg/es_ES.utf8/utils.msg
@@ -1176,13 +1176,16 @@ opciones validas:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb no disponible temporalmente para modo cliente-servidor\n
 21 La operacion de aspirar ha fallado\n
+22 No se puede abrir archivo de salida '%1$s'\n
 60 \
 vacuumdb: Aspira registros muertos de la base de datos.\n\
 uso: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 opciones validas:\n\
   -S, --SA-mode                modo de ejecucion stand-alone\n\
-  -C, --CS-mode                modo de ejecucion cliente-servidor\n
+  -C, --CS-mode                modo de ejecucion cliente-servidor\n\
+      --dump                   volcar el estado actual de vacío\n\
+  -o, --output-file=FILE       redireccionar mensajes de salida al ARCHIVO; estandar: ninguno\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Fallo al cargar los nombres de tablas en %1$s.\n

--- a/msg/fr_FR.utf8/utils.msg
+++ b/msg/fr_FR.utf8/utils.msg
@@ -809,7 +809,7 @@ lockdb: Affiche l'état du verrouillage de la base de données.\n\
 usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 options valids:\n\
-  -o, --output-file=FICHIER   redirige les messages de sortie à FICHIER; par défaut: aucun\n\
+  -o, --output-file=FICHIER   redirige les messages de sortie à FICHIER; par défaut: aucun\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN
@@ -1186,13 +1186,16 @@ options valides:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb est temporairement pas disponible pour le mode client-serveur\n
 21 L'operation de vidage à échoué\n
+22 Impossible d'ouvrir le fichier de sortie '%1$s'\n
 60 \
 vacuumdb: Supprime les entrées expirés depuis la base de données.\n\
 usage: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 options valides:\n\
   -S, --SA-mode                mode d'exécution autonome\n\
-  -C, --CS-mode                mode d'exécution client-serveur\n
+  -C, --CS-mode                mode d'exécution client-serveur\n\
+      --dump                   vidage de l'état actuel du vide\n\
+  -o, --output-file=FICHIER    redirige les messages de sortie à FICHIER; par défaut: aucun\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Impossible de charger les noms de table dans %1$s.\n

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -1175,13 +1175,16 @@ opzioni valide:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb non è temporaneamente disponibile per la modalità client-server\n
 21 L'operazione vacuum non è riuscita\n
+22 Impossibile aprire il file di output '%1$s'\n
 60 \
 vacuumdb: Pulisce record morti di database.\n\
 uso: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 opzioni valide:\n\
   -S, --SA-mode                esecuzione in modalità stand-alone\n\
-  -C, --CS-mode                esecuzione in modalità client-server\n
+  -C, --CS-mode                esecuzione in modalità client-server\n\
+      --dump                   scaricare lo stato attuale del vuoto\n\
+  -o, --output-file=FILE       reindirizzare i messaggi di output a FILE; predefinito: nessuno\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Impossibile caricare nomi di tabella in %1$s.\n

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -1177,13 +1177,16 @@ delvoldb: データベースの空のボリューム・ファイルを削除し�
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdbはclient-serverモードで一時的に利用することができません\n
 21 vacuum操作に失敗しました\n
+22 出力ファイル「%1$s」が開けません。\n
 60 \
 vacuumdb: データベースから死亡レコードを掃除。\n\
 使い方: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 オプション:\n\
   -S, --SA-mode                stand-aloneモードの実行\n\
-  -C, --CS-mode                client-serverモードの実行\n
+  -C, --CS-mode                client-serverモードの実行\n\
+      --dump                   真空の現在の状態をダンプします\n\
+  -o, --output-file=FILE       出力メッセージをセーブするファイル; デフォルト: なし\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 %1$sからテーブル名の読み込みに失敗しました。\n

--- a/msg/km_KH.utf8/utils.msg
+++ b/msg/km_KH.utf8/utils.msg
@@ -1177,13 +1177,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb is temporary not available for client-server mode\n
 21 The vacuum operation failed\n
+22 Couldn't open output file '%1$s'\n
 60 \
 vacuumdb: Vacuums dead records from database.\n\
 usage: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                stand-alone mode execution\n\
-  -C, --CS-mode                client-server mode execution\n
+  -C, --CS-mode                client-server mode execution\n\
+      --dump                   dump current state of vacuum\n\
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Failed to load table names in %1$s.\n

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -1164,13 +1164,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb는 현재 클라이언트 서버 모드에서 지원되지 않습니다.\n
 21 vacuum 작업 실패\n
+22 출력 파일 '%1$s'을 열 수 없습니다.\n
 60 \
 vacuumdb: 사용되지 않는 레코드를 데이터베이스에서 정리\n\
 usage: %1$s vacuumdb [옵션] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                독립 모드 실행\n\
-  -C, --CS-mode                클라이언트 서버 모드 실행\n
+  -C, --CS-mode                클라이언트 서버 모드 실행\n\
+      --dump                   현재 vacuum 상태 덤프\n\
+  -o, --output-file=FILE       출력 메시지를 재지정할 파일; 기본값: 없음\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 %1$s으로부터 테이블 이름 로딩 실패.\n

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -1164,13 +1164,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb는 현재 클라이언트 서버 모드에서 지원되지 않습니다.\n
 21 vacuum 작업 실패\n
+22 출력 파일 '%1$s'을 열 수 없습니다.\n
 60 \
 vacuumdb: 사용되지 않는 레코드를 데이터베이스에서 정리\n\
 usage: %1$s vacuumdb [옵션] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                독립 모드 실행\n\
-  -C, --CS-mode                클라이언트 서버 모드 실행\n
+  -C, --CS-mode                클라이언트 서버 모드 실행\n\
+      --dump                   현재 vacuum 상태 덤프\n\
+  -o, --output-file=FILE       출력 메시지를 재지정할 파일; 기본값: 없음\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 %1$s으로부터 테이블 이름 로딩 실패.\n

--- a/msg/ro_RO.utf8/utils.msg
+++ b/msg/ro_RO.utf8/utils.msg
@@ -1198,13 +1198,16 @@ opțiuni valide:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Momentan, vacuumdb nu este disponibil în modul client-server \n
 21 Operația de vacuum nu a reușit\n
+22 Fişierul de ieşire '%1$s' nu a putut fi deschis\n
 60 \
 vacuumdb: Șterge înregistrări nenecesare din baza de date\n\
 utilizare: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 opțiuni valide:\n\
   -S, --SA-mode                execuție în modul stand-alone\n\
-  -C, --CS-mode                execuție în modul client-server\n
+  -C, --CS-mode                execuție în modul client-server\n\
+      --dump                   descărcați starea curentă de vid\n\
+  -o, --output-file=FIŞIER     redirecţionează mesajele de ieşire către un FIŞIER; implicit: nul\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Încărcarea numelor tabelelor nu a reușit în %1$s.\n

--- a/msg/tr_TR.utf8/utils.msg
+++ b/msg/tr_TR.utf8/utils.msg
@@ -1170,13 +1170,16 @@ geçerli seçenekler:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb istemci-sunucu modunda geçici olarak kullanılamaz\n
 21 Vakum işlemi başarısız oldu\n
+22 Çıktı dosyası '%1$s' açılmaadı \n
 60 \
 vacuumdb: Veritabanından ölü kayıtları temizler.\n\
 kullanım: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 geçerli seçenekler:\n\
   -S, --SA-mode                stand-alone mod yürütme\n\
-  -C, --CS-mode                client-server mod yürütme\n
+  -C, --CS-mode                client-server mod yürütme\n\
+      --dump                   mevcut vakum durumunu boşalt\n\
+  -o, --output-file=FILE       FILE çıktı mesajları yönlendirme; varsayılan: hiçbir\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 %1$s içinde tablo adlarını yüklenemedi.\n

--- a/msg/vi_VN.utf8/utils.msg
+++ b/msg/vi_VN.utf8/utils.msg
@@ -1177,13 +1177,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb is temporary not available for client-server mode\n
 21 The vacuum operation failed\n
+22 Couldn't open output file '%1$s'\n
 60 \
 vacuumdb: Vacuums dead records from database.\n\
 usage: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                stand-alone mode execution\n\
-  -C, --CS-mode                client-server mode execution\n
+  -C, --CS-mode                client-server mode execution\n\
+      --dump                   dump current state of vacuum\n\
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Failed to load table names in %1$s.\n

--- a/msg/zh_CN.utf8/utils.msg
+++ b/msg/zh_CN.utf8/utils.msg
@@ -1166,13 +1166,16 @@ delvoldb: 删除一个空的数据库卷文件.\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb 对于客户端-服务器模式临时不可用\n
 21 清空(vacuum)操作失败\n
+22 无法打开输出文件 '%1$s'\n
 60 \
 vacuumdb: 清空(vacuum)数据库中的死记录.\n\
 用法: %1$s vacuumdb [选项] 数据库名\n\
 \n\
 可用选项:\n\
   -S, --SA-mode                单机模式执行\n\
-  -C, --CS-mode                客户端-服务器模式执行\n
+  -C, --CS-mode                客户端-服务器模式执行\n\
+      --dump                   转储当前真空状态\n\
+  -o, --output-file=FILE       重定向输出信息到文件 FILE ; 默认: 空\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 在 %1$s 中装载表名字失败.\n

--- a/src/communication/network.h
+++ b/src/communication/network.h
@@ -247,6 +247,7 @@ enum net_server_request
   NET_SERVER_LD_INTERRUPT,
   NET_SERVER_LD_UPDATE_STATS,
 
+  NET_SERVER_VACUUM_DUMP,
   /*
    * This is the last entry. It is also used for the end of an
    * array of statistics information on client/server communication.

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -652,6 +652,7 @@ net_histo_setup_names (void)
   net_Req_buffer[NET_SERVER_LD_DESTROY].name = "NET_SERVER_LD_DESTROY";
   net_Req_buffer[NET_SERVER_LD_INTERRUPT].name = "NET_SERVER_LD_INTERRUPT";
   net_Req_buffer[NET_SERVER_LD_UPDATE_STATS].name = "NET_SERVER_LD_UPDATE_STATS";
+  net_Req_buffer[NET_SERVER_VACUUM_DUMP].name = "NET_SERVER_VACUUM_DUMP";
 }
 
 /*

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -9556,6 +9556,35 @@ cvacuum (void)
 }
 
 /*
+ * vacuum_dump -
+ *
+ * return:
+ *
+ *   outfp(in):
+ */
+void
+vacuum_dump (FILE * outfp)
+{
+#if defined(CS_MODE)
+  int req_error;
+
+  if (outfp == NULL)
+    {
+      outfp = stdout;
+    }
+
+  req_error = net_client_request_recv_stream (NET_SERVER_VACUUM_DUMP, NULL, 0, NULL, 0, NULL, 0, outfp);
+#else /* CS_MODE */
+
+  THREAD_ENTRY *thread_p = enter_server ();
+
+  xvacuum_dump (thread_p, outfp);
+
+  exit_server (*thread_p);
+#endif /* !CS_MODE */
+}
+
+/*
  * log_get_mvcc_snapshot () - Get MVCC snapshot on server.
  *
  * return : Error code.

--- a/src/communication/network_interface_cl.h
+++ b/src/communication/network_interface_cl.h
@@ -179,6 +179,7 @@ extern "C"
 {
 #endif
   extern void lock_dump (FILE * outfp);
+  extern void vacuum_dump (FILE * outfp);
 #ifdef __cplusplus
 }
 #endif

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -9355,6 +9355,84 @@ svacuum (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 }
 
 /*
+ * svacuum_dump -
+ *
+ * return:
+ *
+ *   rid(in):
+ *   request(in):
+ *   reqlen(in):
+ *
+ * NOTE:
+ */
+void
+svacuum_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
+{
+  FILE *outfp;
+  int file_size;
+  char *buffer;
+  int buffer_size;
+  int send_size;
+  OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
+  char *reply = OR_ALIGNED_BUF_START (a_reply);
+
+  (void) or_unpack_int (request, &buffer_size);
+
+  buffer = (char *) db_private_alloc (thread_p, buffer_size);
+  if (buffer == NULL)
+    {
+      css_send_abort_to_client (thread_p->conn_entry, rid);
+      return;
+    }
+
+  outfp = tmpfile ();
+  if (outfp == NULL)
+    {
+      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      css_send_abort_to_client (thread_p->conn_entry, rid);
+      db_private_free_and_init (thread_p, buffer);
+      return;
+    }
+
+  xvacuum_dump (thread_p, outfp);
+  file_size = ftell (outfp);
+
+  /*
+   * Send the file in pieces
+   */
+  rewind (outfp);
+
+  (void) or_pack_int (reply, (int) file_size);
+  css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
+
+  while (file_size > 0)
+    {
+      if (file_size > buffer_size)
+	{
+	  send_size = buffer_size;
+	}
+      else
+	{
+	  send_size = file_size;
+	}
+
+      file_size -= send_size;
+      if (fread (buffer, 1, send_size, outfp) == 0)
+	{
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	  css_send_abort_to_client (thread_p->conn_entry, rid);
+	  /*
+	   * Continue sending the stuff that was prmoised to client. In this case
+	   * junk (i.e., whatever it is in the buffers) is sent.
+	   */
+	}
+      css_send_data_to_client (thread_p->conn_entry, rid, buffer, send_size);
+    }
+  fclose (outfp);
+  db_private_free_and_init (thread_p, buffer);
+}
+
+/*
  * slogtb_get_mvcc_snapshot () - Get MVCC Snapshot.
  *
  * return	 :

--- a/src/communication/network_interface_sr.h
+++ b/src/communication/network_interface_sr.h
@@ -219,6 +219,7 @@ extern void ssession_get_session_variable (THREAD_ENTRY * thread_p, unsigned int
 extern void ssession_drop_session_variables (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void sboot_get_locales_info (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void svacuum (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
+extern void svacuum_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void slogtb_get_mvcc_snapshot (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void stran_lock_rep_read (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void sboot_get_timezone_checksum (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -897,6 +897,10 @@ net_server_init (void)
   req_p->processing_function = slogtb_does_active_user_exist;
   req_p->name = "NET_SERVER_AU_DOES_ACTIVE_USER_EXIST";
 
+  req_p = &net_Requests[NET_SERVER_VACUUM_DUMP];
+  req_p->processing_function = svacuum_dump;
+  req_p->name = "NET_SERVER_VACUUM_DUMP";
+
 }
 
 #if defined(CUBRID_DEBUG)

--- a/src/executables/util_admin.c
+++ b/src/executables/util_admin.c
@@ -790,12 +790,16 @@ static UTIL_ARG_MAP ua_Vacuum_Option_Map[] = {
   {OPTION_STRING_TABLE, {0}, {0}},
   {VACUUM_SA_MODE_S, {ARG_BOOLEAN}, {0}},
   {VACUUM_CS_MODE_S, {ARG_BOOLEAN}, {0}},
+  {VACUUM_DUMP_S, {ARG_BOOLEAN}, {0}},
+  {VACUUM_OUTPUT_FILE_S, {ARG_STRING}, {0}},
   {0, {0}, {0}}
 };
 
 static GETOPT_LONG ua_Vacuum_Option[] = {
   {VACUUM_SA_MODE_L, 0, 0, VACUUM_SA_MODE_S},
   {VACUUM_CS_MODE_L, 0, 0, VACUUM_CS_MODE_S},
+  {VACUUM_DUMP_L, 0, 0, VACUUM_DUMP_S},
+  {VACUUM_OUTPUT_FILE_L, 1, 0, VACUUM_OUTPUT_FILE_S},
   {0, 0, 0, 0}
 };
 

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -3609,7 +3609,6 @@ vacuumdb (UTIL_FUNCTION_ARG * arg)
   er_init (er_msg_file, ER_NEVER_EXIT);
 
   sysprm_set_force (prm_get_name (PRM_ID_JAVA_STORED_PROCEDURE), "no");
-  sysprm_set_force (prm_get_name (PRM_ID_DISABLE_VACUUM), "no");
 
   AU_DISABLE_PASSWORDS ();
   if (dump_flag)
@@ -3618,6 +3617,7 @@ vacuumdb (UTIL_FUNCTION_ARG * arg)
     }
   else
     {
+      sysprm_set_force (prm_get_name (PRM_ID_DISABLE_VACUUM), "no");
       db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);
     }
   db_login ("DBA", NULL);

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -3560,10 +3560,10 @@ int
 vacuumdb (UTIL_FUNCTION_ARG * arg)
 {
   UTIL_ARG_MAP *arg_map = arg->arg_map;
-#if defined (SA_MODE)
   char er_msg_file[PATH_MAX];
-#endif /* SA_MODE */
-  const char *database_name;
+  const char *database_name, *output_file = NULL;
+  bool dump_flag;
+  FILE *outfp = NULL;
 
   if (utility_get_option_string_table_size (arg_map) < 1)
     {
@@ -3581,6 +3581,28 @@ vacuumdb (UTIL_FUNCTION_ARG * arg)
       goto error_exit;
     }
 
+  dump_flag = utility_get_option_bool_value (arg_map, VACUUM_DUMP_S);
+
+  if (dump_flag)
+    {
+      output_file = utility_get_option_string_value (arg_map, VACUUM_OUTPUT_FILE_S, 0);
+      if (output_file == NULL)
+	{
+	  outfp = stdout;
+	}
+      else
+	{
+	  outfp = fopen (output_file, "w");
+	  if (outfp == NULL)
+	    {
+	      PRINT_AND_LOG_ERR_MSG (msgcat_message
+				     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_VACUUMDB, VACUUMDB_MSG_BAD_OUTPUT),
+				     output_file);
+	      goto error_exit;
+	    }
+	}
+    }
+
 #if defined(SA_MODE)
   /* error message log file */
   snprintf (er_msg_file, sizeof (er_msg_file) - 1, "%s_%s.err", database_name, arg->command_name);
@@ -3590,24 +3612,45 @@ vacuumdb (UTIL_FUNCTION_ARG * arg)
   sysprm_set_force (prm_get_name (PRM_ID_DISABLE_VACUUM), "no");
 
   AU_DISABLE_PASSWORDS ();
-  db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);
+  if (dump_flag)
+    {
+      db_set_client_type (DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL);
+    }
+  else
+    {
+      db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);
+    }
   db_login ("DBA", NULL);
   if (db_restart (arg->command_name, TRUE, database_name) == NO_ERROR)
     {
-      if (db_set_isolation (TRAN_READ_COMMITTED) != NO_ERROR || cvacuum () != NO_ERROR)
+      (void) db_set_isolation (TRAN_READ_COMMITTED);
+
+      if (dump_flag)
 	{
-	  const char *tmpname;
+	  vacuum_dump (outfp);
 
-	  if ((tmpname = er_get_msglog_filename ()) == NULL)
+	  if (outfp != stdout)
 	    {
-	      tmpname = "/dev/null";
+	      fclose (outfp);
 	    }
-	  PRINT_AND_LOG_ERR_MSG (msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_VACUUMDB, VACUUMDB_MSG_FAILED),
-				 tmpname);
+	}
+      else
+	{
+	  if (cvacuum () != NO_ERROR)
+	    {
+	      const char *tmpname;
 
-	  util_log_write_errstr ("%s\n", db_error_string (3));
-	  db_shutdown ();
-	  goto error_exit;
+	      if ((tmpname = er_get_msglog_filename ()) == NULL)
+		{
+		  tmpname = "/dev/null";
+		}
+	      PRINT_AND_LOG_ERR_MSG (msgcat_message
+				     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_VACUUMDB, VACUUMDB_MSG_FAILED), tmpname);
+
+	      util_log_write_errstr ("%s\n", db_error_string (3));
+	      db_shutdown ();
+	      goto error_exit;
+	    }
 	}
       db_shutdown ();
     }
@@ -3619,10 +3662,39 @@ vacuumdb (UTIL_FUNCTION_ARG * arg)
 
   return EXIT_SUCCESS;
 #else
-  fprintf (stderr,
-	   msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_VACUUMDB, VACUUMDB_MSG_CLIENT_SERVER_NOT_AVAILABLE),
-	   basename (arg->argv0));
-  util_log_write_errid (MSGCAT_UTIL_GENERIC_INVALID_ARGUMENT);
+  if (dump_flag)
+    {
+      /* error message log file */
+      snprintf (er_msg_file, sizeof (er_msg_file) - 1, "%s_%s.err", database_name, arg->command_name);
+      er_init (er_msg_file, ER_NEVER_EXIT);
+
+      AU_DISABLE_PASSWORDS ();
+      db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);
+      db_login ("DBA", NULL);
+
+      if (db_restart (arg->command_name, TRUE, database_name) != NO_ERROR)
+	{
+	  PRINT_AND_LOG_ERR_MSG ("%s\n", db_error_string (3));
+	  goto error_exit;
+	}
+
+      (void) db_set_isolation (TRAN_READ_COMMITTED);
+
+      vacuum_dump (outfp);
+      db_shutdown ();
+
+      if (outfp != stdout)
+	{
+	  fclose (outfp);
+	}
+    }
+  else
+    {
+      fprintf (stderr,
+	       msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_VACUUMDB,
+			       VACUUMDB_MSG_CLIENT_SERVER_NOT_AVAILABLE), basename (arg->argv0));
+      util_log_write_errid (MSGCAT_UTIL_GENERIC_INVALID_ARGUMENT);
+    }
 
   return EXIT_SUCCESS;
 #endif

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -676,6 +676,7 @@ typedef enum
 {
   VACUUMDB_MSG_CLIENT_SERVER_NOT_AVAILABLE = 20,
   VACUUMDB_MSG_FAILED = 21,
+  VACUUMDB_MSG_BAD_OUTPUT = 22,
   VACUUMDB_MSG_USAGE = 60
 } MSGCAT_VACUUMDB_MSG;
 
@@ -1573,6 +1574,10 @@ typedef struct _ha_config
 #define VACUUM_SA_MODE_L                         "SA-mode"
 #define VACUUM_CS_MODE_S                         'C'
 #define VACUUM_CS_MODE_L                         "CS-mode"
+#define VACUUM_DUMP_S                            10700
+#define VACUUM_DUMP_L                            "dump"
+#define VACUUM_OUTPUT_FILE_S                     'o'
+#define VACUUM_OUTPUT_FILE_L                     "output-file"
 
 /* checksumdb option list */
 #define CHECKSUM_CHUNK_SIZE_S			'c'

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1132,7 +1132,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
 
   if (logpb_is_page_in_archive (min_log_pageid))
     {
-      LOG_CS_ENTER (thread_p);
+      LOG_CS_ENTER_READ_MODE (thread_p);
       archive_number = logpb_get_archive_number (thread_p, min_log_pageid);
       if (archive_number < 0)
 	{

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1114,6 +1114,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
   /* vacuum_boot () != NO_ERROR || prm_get_bool_value (PRM_ID_DISABLE_VACUUM) == true */
   if (!vacuum_is_safe_to_remove_archives ())
     {
+      fprintf (outfp, "VACUUM did not boot properly.\n");
       return;
     }
 
@@ -1121,6 +1122,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
   if (min_log_pageid == NULL_PAGEID)
     {
       /* this is an assertion case but ignore. */
+      fprintf (outfp, "VACUUM did not boot properly.\n");
       return;
     }
 

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1111,8 +1111,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
       outfp = stdout;
     }
 
-  /* vacuum_boot () != NO_ERROR || prm_get_bool_value (PRM_ID_DISABLE_VACUUM) == true */
-  if (!vacuum_is_safe_to_remove_archives ())
+  if (!vacuum_Is_booted)
     {
       fprintf (outfp, "vacuum did not boot properly.\n");
       return;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1106,10 +1106,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
   LOG_PAGEID min_log_pageid = NULL_PAGEID;
   int archive_number;
 
-  if (outfp == NULL)
-    {
-      outfp = stdout;
-    }
+  assert (outfp != NULL);
 
   if (!vacuum_Is_booted)
     {

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1114,7 +1114,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
   /* vacuum_boot () != NO_ERROR || prm_get_bool_value (PRM_ID_DISABLE_VACUUM) == true */
   if (!vacuum_is_safe_to_remove_archives ())
     {
-      fprintf (outfp, "VACUUM did not boot properly.\n");
+      fprintf (outfp, "vacuum did not boot properly.\n");
       return;
     }
 
@@ -1122,7 +1122,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
   if (min_log_pageid == NULL_PAGEID)
     {
       /* this is an assertion case but ignore. */
-      fprintf (outfp, "VACUUM did not boot properly.\n");
+      fprintf (outfp, "vacuum did not boot properly.\n");
       return;
     }
 

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -223,6 +223,7 @@ extern int vacuum_boot (THREAD_ENTRY * thread_p);
 extern void vacuum_stop_workers (THREAD_ENTRY * thread_p);
 extern void vacuum_stop_master (THREAD_ENTRY * thread_p);
 extern int xvacuum (THREAD_ENTRY * thread_p);
+extern void xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp);
 
 extern int vacuum_create_file_for_vacuum_data (THREAD_ENTRY * thread_p, VFID * vacuum_data_vfid);
 extern int vacuum_data_load_and_recover (THREAD_ENTRY * thread_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23881

Add the following two options to the vacuumdb utility.
- --dump
  - Prints the following two pieces of information
    - smallest log page ID referenced by vacuum
    - log volume name including smallest log page ID
- -o, --output-file=FILE

**Usage**
```
$ cubrid vacuumdb
vacuumdb: Vacuums dead records from database.
usage: cubrid vacuumdb [OPTION] database-name

valid options:
  -S, --SA-mode                stand-alone mode execution
  -C, --CS-mode                client-server mode execution
      --dump                   dump current state of vacuum
  -o, --output-file=FILE       redirect output messages to FILE; default: none
```

**result of --dump option**
- --CS-mode
```
$ cubrid vacuumdb --CS-mode --dump demodb

*** Vacuum Dump ***
First log page ID referenced = 93 (in demodb_lgat)
```
- --SA-mode
```
$ cubrid vacuumdb --SA-mode --dump demodb

*** Vacuum Dump ***
First log page ID referenced = 93 (in demodb_lgat)
```