### PR TITLE
[CBRD-23888] Error -1106 occurs when using MERGE INTO statement with GROUP BY

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -13986,11 +13986,6 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 
 	      if (xptr2->status == XASL_CLEARED || xptr2->status == XASL_INITIALIZED)
 		{
-		  if (XASL_IS_FLAGED (xasl, XASL_IS_MERGE_QUERY))
-		    {
-		      XASL_SET_FLAG (xptr2, XASL_IS_MERGE_QUERY);
-		    }
-
 		  if (qexec_execute_mainblock (thread_p, xptr2, xasl_state, NULL) != NO_ERROR)
 		    {
 		      if (tplrec.tpl)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23888

Error -1106 (Multiple rows in source table match the same row in destination table.) occurs when using MERGE INTO statement with GROUP BY.