### PR TITLE
[CBRD-23860] Two broker keywords, SQL_LOG2, SHARD, are added by QA re…

### DIFF
--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -247,7 +247,10 @@ const char *broker_keywords[] = {
   "SHARD_PROXY_CONN_WAIT_TIMEOUT",
   "SHARD_PROXY_LOG_MAX_SIZE",
   "SHARD_PROXY_SHM_ID",
-  "SHARD_PROXY_TIMEOUT"
+  "SHARD_PROXY_TIMEOUT",
+  /* For backword compatibility */
+  "SQL_LOG2",
+  "SHARD"
 };
 
 int broker_keywords_size = sizeof (broker_keywords) / sizeof (char *);


### PR DESCRIPTION
…quest

http://jira.cubrid.org/browse/CBRD-23860
* SQL_LOG2, SHARD are added as a valid keyword.