### PR TITLE
[CBRD-23860]  Continue on error in Github Checks while get-changed-files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1
         id: files
+        continue-on-error: true
       - name: Check license
         run: |
           set +e # make this step proceed even if a command returns non-zero
@@ -62,6 +63,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: files
         uses: jitterbit/get-changed-files@v1
+        continue-on-error: true
       - name: Check code style
         id: stylecheck
         run: |
@@ -84,6 +86,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1
         id: files
+        continue-on-error: true
       - name: cppcheck
         run: |
           result_file="cppcheck.result"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,3 +1,19 @@
+#
+#
+#  Copyright 2016 CUBRID Corporation
+# 
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+# 
+#       http://www.apache.org/licenses/LICENSE-2.0
+# 
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+# 
 name: github-checks
 on: 
   pull_request:


### PR DESCRIPTION
 http://jira.cubrid.org/browse/CBRD-23876

_jitterbit/get-changed-files@v1_ sometimes spit errors in some corner cases.
The action still works and correctly displays the modified files so we can add continue-on-error: true to skip this issue.
