### PR TITLE
[CBRD-23881] Add a new option to the vacuumdb utility to output the smallest log page ID and log volume name referenced by vacuum (#2629)

### DIFF
--- a/msg/de_DE.utf8/utils.msg
+++ b/msg/de_DE.utf8/utils.msg
@@ -1156,13 +1156,16 @@ gültigen Optionen:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 vacuumdb vorübergehend nicht verfügbar ist für Client-Server-Modus\n
 21 Der Vakuumbetrieb gescheitert\n
+22 Ausgangsdatei '%1$s' konnte nicht geöffnet werden \n
 60 \
 vacuumdb: Vakuum Toten Datensätze aus der Datenbank.\n\
 Anwendung: %1$s vacuumdb [OPTION] Datenbank-Name\n\
 \n\
 gültigen Optionen:\n\
   -S, --SA-mode                    Stand-alone-Modus Ausführung\n\
-  -C, --CS-mode                    Client-Server-Modus Ausführung\n
+  -C, --CS-mode                    Client-Server-Modus Ausführung\n\
+      --dump                       aktuellen Vakuumzustand entleeren\n\
+  -o, --output-file=DATEI          Umleiten der Ausgabemeldungen in DATEI; Standard: keine\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Fehler beim Tabellennamen in %1$s zu laden.\n

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -1159,13 +1159,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb is temporary not available for client-server mode\n
 21 The vacuum operation failed\n
+22 Couldn't open output file '%1$s'\n
 60 \
 vacuumdb: Vacuums dead records from database.\n\
 usage: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                stand-alone mode execution\n\
-  -C, --CS-mode                client-server mode execution\n
+  -C, --CS-mode                client-server mode execution\n\
+      --dump                   dump current state of vacuum\n\
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Failed to load table names in %1$s.\n

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -1159,13 +1159,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb is temporary not available for client-server mode\n
 21 The vacuum operation failed\n
+22 Couldn't open output file '%1$s'\n
 60 \
 vacuumdb: Vacuums dead records from database.\n\
 usage: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                stand-alone mode execution\n\
-  -C, --CS-mode                client-server mode execution\n
+  -C, --CS-mode                client-server mode execution\n\
+      --dump                   dump current state of vacuum\n\
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Failed to load table names in %1$s.\n

--- a/msg/es_ES.utf8/utils.msg
+++ b/msg/es_ES.utf8/utils.msg
@@ -1158,13 +1158,16 @@ opciones validas:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb no disponible temporalmente para modo cliente-servidor\n
 21 La operacion de aspirar ha fallado\n
+22 No se puede abrir archivo de salida '%1$s'\n
 60 \
 vacuumdb: Aspira registros muertos de la base de datos.\n\
 uso: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 opciones validas:\n\
   -S, --SA-mode                modo de ejecucion stand-alone\n\
-  -C, --CS-mode                modo de ejecucion cliente-servidor\n
+  -C, --CS-mode                modo de ejecucion cliente-servidor\n\
+      --dump                   volcar el estado actual de vacío\n\
+  -o, --output-file=FILE       redireccionar mensajes de salida al ARCHIVO; estandar: ninguno\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Fallo al cargar los nombres de tablas en %1$s.\n

--- a/msg/fr_FR.utf8/utils.msg
+++ b/msg/fr_FR.utf8/utils.msg
@@ -779,7 +779,7 @@ lockdb: Affiche l'état du verrouillage de la base de données.\n\
 usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 options valids:\n\
-  -o, --output-file=FICHIER   redirige les messages de sortie à FICHIER; par défaut: aucun\n\
+  -o, --output-file=FICHIER   redirige les messages de sortie à FICHIER; par défaut: aucun\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN
@@ -1168,13 +1168,16 @@ options valides:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb est temporairement pas disponible pour le mode client-serveur\n
 21 L'operation de vidage à échoué\n
+22 Impossible d'ouvrir le fichier de sortie '%1$s'\n
 60 \
 vacuumdb: Supprime les entrées expirés depuis la base de données.\n\
 usage: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 options valides:\n\
   -S, --SA-mode                mode d'exécution autonome\n\
-  -C, --CS-mode                mode d'exécution client-serveur\n
+  -C, --CS-mode                mode d'exécution client-serveur\n\
+      --dump                   vidage de l'état actuel du vide\n\
+  -o, --output-file=FICHIER    redirige les messages de sortie à FICHIER; par défaut: aucun\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Impossible de charger les noms de table dans %1$s.\n

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -1157,13 +1157,16 @@ opzioni valide:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb non è temporaneamente disponibile per la modalità client-server\n
 21 L'operazione vacuum non è riuscita\n
+22 Impossibile aprire il file di output '%1$s'\n
 60 \
 vacuumdb: Pulisce record morti di database.\n\
 uso: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 opzioni valide:\n\
   -S, --SA-mode                esecuzione in modalità stand-alone\n\
-  -C, --CS-mode                esecuzione in modalità client-server\n
+  -C, --CS-mode                esecuzione in modalità client-server\n\
+      --dump                   scaricare lo stato attuale del vuoto\n\
+  -o, --output-file=FILE       reindirizzare i messaggi di output a FILE; predefinito: nessuno\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Impossibile caricare nomi di tabella in %1$s.\n

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -1159,13 +1159,16 @@ delvoldb: データベースの空のボリューム・ファイルを削除し�
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdbはclient-serverモードで一時的に利用することができません\n
 21 vacuum操作に失敗しました\n
+22 出力ファイル「%1$s」が開けません。\n
 60 \
 vacuumdb: データベースから死亡レコードを掃除。\n\
 使い方: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 オプション:\n\
   -S, --SA-mode                stand-aloneモードの実行\n\
-  -C, --CS-mode                client-serverモードの実行\n
+  -C, --CS-mode                client-serverモードの実行\n\
+      --dump                   真空の現在の状態をダンプします\n\
+  -o, --output-file=FILE       出力メッセージをセーブするファイル; デフォルト: なし\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 %1$sからテーブル名の読み込みに失敗しました。\n

--- a/msg/km_KH.utf8/utils.msg
+++ b/msg/km_KH.utf8/utils.msg
@@ -1159,13 +1159,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb is temporary not available for client-server mode\n
 21 The vacuum operation failed\n
+22 Couldn't open output file '%1$s'\n
 60 \
 vacuumdb: Vacuums dead records from database.\n\
 usage: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                stand-alone mode execution\n\
-  -C, --CS-mode                client-server mode execution\n
+  -C, --CS-mode                client-server mode execution\n\
+      --dump                   dump current state of vacuum\n\
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Failed to load table names in %1$s.\n

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -1146,13 +1146,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb는 현재 클라이언트 서버 모드에서 지원되지 않습니다.\n
 21 vacuum 작업 실패\n
+22 출력 파일 '%1$s'을 열 수 없습니다.\n
 60 \
 vacuumdb: 사용되지 않는 레코드를 데이터베이스에서 정리\n\
 usage: %1$s vacuumdb [옵션] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                독립 모드 실행\n\
-  -C, --CS-mode                클라이언트 서버 모드 실행\n
+  -C, --CS-mode                클라이언트 서버 모드 실행\n\
+      --dump                   현재 vacuum 상태 덤프\n\
+  -o, --output-file=FILE       출력 메시지를 파일에 저장; 기본값: 없음\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 %1$s으로부터 테이블 이름 로딩 실패.\n

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -1146,13 +1146,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb는 현재 클라이언트 서버 모드에서 지원되지 않습니다.\n
 21 vacuum 작업 실패\n
+22 출력 파일 '%1$s'을 열 수 없습니다.\n
 60 \
 vacuumdb: 사용되지 않는 레코드를 데이터베이스에서 정리\n\
 usage: %1$s vacuumdb [옵션] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                독립 모드 실행\n\
-  -C, --CS-mode                클라이언트 서버 모드 실행\n
+  -C, --CS-mode                클라이언트 서버 모드 실행\n\
+      --dump                   현재 vacuum 상태 덤프\n\
+  -o, --output-file=FILE       출력 메시지를 재지정할 파일; 기본값: 없음\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 %1$s으로부터 테이블 이름 로딩 실패.\n

--- a/msg/ro_RO.utf8/utils.msg
+++ b/msg/ro_RO.utf8/utils.msg
@@ -1181,13 +1181,16 @@ opțiuni valide:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Momentan, vacuumdb nu este disponibil în modul client-server \n
 21 Operația de vacuum nu a reușit\n
+22 Fişierul de ieşire '%1$s' nu a putut fi deschis\n
 60 \
 vacuumdb: Șterge înregistrări nenecesare din baza de date\n\
 utilizare: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 opțiuni valide:\n\
   -S, --SA-mode                execuție în modul stand-alone\n\
-  -C, --CS-mode                execuție în modul client-server\n
+  -C, --CS-mode                execuție în modul client-server\n\
+      --dump                   descărcați starea curentă de vid\n\
+  -o, --output-file=FIŞIER     redirecţionează mesajele de ieşire către un FIŞIER; implicit: nul\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Încărcarea numelor tabelelor nu a reușit în %1$s.\n

--- a/msg/tr_TR.utf8/utils.msg
+++ b/msg/tr_TR.utf8/utils.msg
@@ -1152,13 +1152,16 @@ geçerli seçenekler:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb istemci-sunucu modunda geçici olarak kullanılamaz\n
 21 Vakum işlemi başarısız oldu\n
+22 Çıktı dosyası '%1$s' açılmaadı \n
 60 \
 vacuumdb: Veritabanından ölü kayıtları temizler.\n\
 kullanım: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 geçerli seçenekler:\n\
   -S, --SA-mode                stand-alone mod yürütme\n\
-  -C, --CS-mode                client-server mod yürütme\n
+  -C, --CS-mode                client-server mod yürütme\n\
+      --dump                   mevcut vakum durumunu boşalt\n\
+  -o, --output-file=FILE       FILE çıktı mesajları yönlendirme; varsayılan: hiçbir\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 %1$s içinde tablo adlarını yüklenemedi.\n

--- a/msg/vi_VN.utf8/utils.msg
+++ b/msg/vi_VN.utf8/utils.msg
@@ -1159,13 +1159,16 @@ valid options:\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb is temporary not available for client-server mode\n
 21 The vacuum operation failed\n
+22 Couldn't open output file '%1$s'\n
 60 \
 vacuumdb: Vacuums dead records from database.\n\
 usage: %1$s vacuumdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -S, --SA-mode                stand-alone mode execution\n\
-  -C, --CS-mode                client-server mode execution\n
+  -C, --CS-mode                client-server mode execution\n\
+      --dump                   dump current state of vacuum\n\
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 Failed to load table names in %1$s.\n

--- a/msg/zh_CN.utf8/utils.msg
+++ b/msg/zh_CN.utf8/utils.msg
@@ -1148,13 +1148,16 @@ delvoldb: 删除一个空的数据库卷文件.\n\
 $set 55 MSGCAT_UTIL_SET_VACUUMDB
 20 Vacuumdb 对于客户端-服务器模式临时不可用\n
 21 清空(vacuum)操作失败\n
+22 无法打开输出文件 '%1$s'\n
 60 \
 vacuumdb: 清空(vacuum)数据库中的死记录.\n\
 用法: %1$s vacuumdb [选项] 数据库名\n\
 \n\
 可用选项:\n\
   -S, --SA-mode                单机模式执行\n\
-  -C, --CS-mode                客户端-服务器模式执行\n
+  -C, --CS-mode                客户端-服务器模式执行\n\
+      --dump                   转储当前真空状态\n\
+  -o, --output-file=FILE       重定向输出信息到文件 FILE ; 默认: 空\n
 
 $set 56 MSGCAT_UTIL_SET_CHECKSUMDB
 1 在 %1$s 中装载表名字失败.\n

--- a/src/communication/network.h
+++ b/src/communication/network.h
@@ -234,6 +234,7 @@ enum net_server_request
   /* Followings are not grouped because they are appended after the above. It is necessary to rearrange with changing
    * network compatibility. */
 
+  NET_SERVER_VACUUM_DUMP,
   /* 
    * This is the last entry. It is also used for the end of an
    * array of statistics information on client/server communication.

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -639,6 +639,7 @@ net_histo_setup_names (void)
   net_Req_buffer[NET_SERVER_LOCK_RR].name = "NET_SERVER_LOCK_RR";
   net_Req_buffer[NET_SERVER_TZ_GET_CHECKSUM].name = "NET_SERVER_TZ_GET_CHECKSUM";
   net_Req_buffer[NET_SERVER_SPACEDB].name = "NET_SERVER_SPACEDB";
+  net_Req_buffer[NET_SERVER_VACUUM_DUMP].name = "NET_SERVER_VACUUM_DUMP";
 }
 
 /*

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -9344,6 +9344,35 @@ cvacuum (void)
 }
 
 /*
+ * vacuum_dump -
+ *
+ * return:
+ *
+ *   outfp(in):
+ */
+void
+vacuum_dump (FILE * outfp)
+{
+#if defined(CS_MODE)
+  int req_error;
+
+  if (outfp == NULL)
+    {
+      outfp = stdout;
+    }
+
+  req_error = net_client_request_recv_stream (NET_SERVER_VACUUM_DUMP, NULL, 0, NULL, 0, NULL, 0, outfp);
+#else /* CS_MODE */
+
+  ENTER_SERVER ();
+
+  xvacuum_dump (NULL, outfp);
+
+  EXIT_SERVER ();
+#endif /* !CS_MODE */
+}
+
+/*
  * log_get_mvcc_snapshot () - Get MVCC snapshot on server.
  *
  * return : Error code.

--- a/src/communication/network_interface_cl.h
+++ b/src/communication/network_interface_cl.h
@@ -143,6 +143,7 @@ extern int tran_server_savepoint (const char *savept_name, LOG_LSA * savept_lsa)
 extern TRAN_STATE tran_server_partial_abort (const char *savept_name, LOG_LSA * savept_lsa);
 extern const char *tran_get_tranlist_state_name (TRAN_STATE state);
 extern void lock_dump (FILE * outfp);
+extern void vacuum_dump (FILE * outfp);
 extern int acl_reload (void);
 extern void acl_dump (FILE * outfp);
 

--- a/src/communication/network_interface_sr.h
+++ b/src/communication/network_interface_sr.h
@@ -206,6 +206,7 @@ extern void slocator_prefetch_repl_insert (THREAD_ENTRY * thread_p, unsigned int
 extern void slocator_prefetch_repl_update_or_delete (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
 						     int reqlen);
 extern void svacuum (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
+extern void svacuum_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void slogtb_get_mvcc_snapshot (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void stran_lock_rep_read (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void sboot_get_timezone_checksum (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -843,6 +843,10 @@ net_server_init (void)
   req_p->action_attribute = IN_TRANSACTION;
   req_p->processing_function = slocator_redistribute_partition_data;
   req_p->name = "NET_SERVER_LC_REDISTRIBUTE_PARTITION_DATA";
+
+  req_p = &net_Requests[NET_SERVER_VACUUM_DUMP];
+  req_p->processing_function = svacuum_dump;
+  req_p->name = "NET_SERVER_VACUUM_DUMP";
 }
 
 #if defined(CUBRID_DEBUG)
@@ -1310,7 +1314,7 @@ net_server_start (const char *server_name)
   css_initialize_server_interfaces (net_server_request, net_server_conn_down);
 
   if (boot_restart_server (thread_get_thread_entry_info (), true, server_name, false, &check_coll_and_timezone,
-			   NULL) != NO_ERROR)
+			   NULL, false) != NO_ERROR)
     {
       assert (er_errid () != NO_ERROR);
       error = er_errid ();

--- a/src/compat/db.h
+++ b/src/compat/db.h
@@ -77,7 +77,8 @@ extern int db_Disable_modifications;
 #define DB_CLIENT_TYPE_SO_BROKER_REPLICA_ONLY   13
 #define DB_CLIENT_TYPE_ADMIN_CSQL_WOS   14	/* admin csql that can write on standby */
 #define DB_CLIENT_TYPE_LOG_PREFETCHER   15
-#define DB_CLIENT_TYPE_MAX              DB_CLIENT_TYPE_LOG_PREFETCHER
+#define DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL   16
+#define DB_CLIENT_TYPE_MAX              DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL
 extern int db_Client_type;
 
 extern char db_Database_name[];

--- a/src/executables/util_admin.c
+++ b/src/executables/util_admin.c
@@ -817,12 +817,16 @@ static UTIL_ARG_MAP ua_Vacuum_Option_Map[] = {
   {OPTION_STRING_TABLE, {0}, {0}},
   {VACUUM_SA_MODE_S, {ARG_BOOLEAN}, {0}},
   {VACUUM_CS_MODE_S, {ARG_BOOLEAN}, {0}},
+  {VACUUM_DUMP_S, {ARG_BOOLEAN}, {0}},
+  {VACUUM_OUTPUT_FILE_S, {ARG_STRING}, {0}},
   {0, {0}, {0}}
 };
 
 static GETOPT_LONG ua_Vacuum_Option[] = {
   {VACUUM_SA_MODE_L, 0, 0, VACUUM_SA_MODE_S},
   {VACUUM_CS_MODE_L, 0, 0, VACUUM_CS_MODE_S},
+  {VACUUM_DUMP_L, 0, 0, VACUUM_DUMP_S},
+  {VACUUM_OUTPUT_FILE_L, 1, 0, VACUUM_OUTPUT_FILE_S},
   {0, 0, 0, 0}
 };
 

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -676,6 +676,7 @@ typedef enum
 {
   VACUUMDB_MSG_CLIENT_SERVER_NOT_AVAILABLE = 20,
   VACUUMDB_MSG_FAILED = 21,
+  VACUUMDB_MSG_BAD_OUTPUT = 22,
   VACUUMDB_MSG_USAGE = 60
 } MSGCAT_VACUUMDB_MSG;
 
@@ -1538,6 +1539,10 @@ typedef struct _ha_config
 #define VACUUM_SA_MODE_L                         "SA-mode"
 #define VACUUM_CS_MODE_S                         'C'
 #define VACUUM_CS_MODE_L                         "CS-mode"
+#define VACUUM_DUMP_S                            10700
+#define VACUUM_DUMP_L                            "dump"
+#define VACUUM_OUTPUT_FILE_S                     'o'
+#define VACUUM_OUTPUT_FILE_L                     "output-file"
 
 /* checksumdb option list */
 #define CHECKSUM_CHUNK_SIZE_S			'c'

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -275,6 +275,7 @@ extern int vacuum_initialize (THREAD_ENTRY * thread_p, int vacuum_log_block_npag
 			      VFID * dropped_files_vfid, bool is_restore);
 extern void vacuum_finalize (THREAD_ENTRY * thread_p);
 extern int xvacuum (THREAD_ENTRY * thread_p);
+extern void xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp);
 extern MVCCID vacuum_get_global_oldest_active_mvccid (void);
 #if defined (SERVER_MODE)
 extern void vacuum_master_start (THREAD_ENTRY * thread_p);

--- a/src/transaction/boot.h
+++ b/src/transaction/boot.h
@@ -48,7 +48,8 @@ enum boot_client_type
   BOOT_CLIENT_RO_BROKER_REPLICA_ONLY = 12,
   BOOT_CLIENT_SO_BROKER_REPLICA_ONLY = 13,
   BOOT_CLIENT_ADMIN_CSQL_WOS = 14,	/* admin csql that can write on standby */
-  BOOT_CLIENT_LOG_PREFETCHER = 15
+  BOOT_CLIENT_LOG_PREFETCHER = 15,
+  BOOT_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL = 16
 };
 
 #define BOOT_NORMAL_CLIENT_TYPE(client_type) \
@@ -70,7 +71,8 @@ enum boot_client_type
 #define BOOT_ADMIN_CLIENT_TYPE(client_type) \
         ((client_type) == BOOT_CLIENT_ADMIN_UTILITY \
          || (client_type) == BOOT_CLIENT_ADMIN_CSQL \
-         || (client_type) == BOOT_CLIENT_ADMIN_CSQL_WOS)
+         || (client_type) == BOOT_CLIENT_ADMIN_CSQL_WOS \
+         || (client_type) == BOOT_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL)
 
 #define BOOT_LOG_REPLICATOR_TYPE(client_type) \
         ((client_type) == BOOT_CLIENT_LOG_COPIER \
@@ -80,6 +82,7 @@ enum boot_client_type
 #define BOOT_CSQL_CLIENT_TYPE(client_type) \
         ((client_type) == BOOT_CLIENT_CSQL \
         || (client_type) == BOOT_CLIENT_READ_ONLY_CSQL \
+        || (client_type) == BOOT_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL \
         || (client_type) == BOOT_CLIENT_ADMIN_CSQL \
         || (client_type) == BOOT_CLIENT_ADMIN_CSQL_WOS)
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2036,7 +2036,7 @@ boot_make_session_server_key (void)
  */
 int
 boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db_name, bool from_backup,
-		     CHECK_ARGS * check_coll_and_timezone, BO_RESTART_ARG * r_args)
+		     CHECK_ARGS * check_coll_and_timezone, BO_RESTART_ARG * r_args, bool skip_vacuum)
 {
   char log_path[PATH_MAX];
   const char *log_prefix;
@@ -2661,7 +2661,10 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   if (r_args == NULL || r_args->is_restore_from_backup == false)
     {
       er_clear ();		/* forget any warning or error to start vacuumming */
-      xvacuum (thread_p);
+      if (!skip_vacuum)
+	{
+	  xvacuum (thread_p);
+	}
     }
 #endif
 
@@ -2854,7 +2857,7 @@ xboot_restart_from_backup (THREAD_ENTRY * thread_p, int print_restart, const cha
       return NULL_TRAN_INDEX;
     }
 
-  if (boot_restart_server (thread_p, print_restart, db_name, true, &check_coll_and_timezone, r_args) != NO_ERROR)
+  if (boot_restart_server (thread_p, print_restart, db_name, true, &check_coll_and_timezone, r_args, false) != NO_ERROR)
     {
       return NULL_TRAN_INDEX;
     }
@@ -2966,8 +2969,9 @@ xboot_register_client (THREAD_ENTRY * thread_p, BOOT_CLIENT_CREDENTIAL * client_
   char *adm_prg_file_name = NULL;
   char db_user_upper[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
   CHECK_ARGS check_coll_and_timezone = { true, true };
-
 #if defined(SA_MODE)
+  bool skip_vacuum = false;
+
   if (client_credential != NULL && client_credential->program_name != NULL
       && client_credential->client_type == BOOT_CLIENT_ADMIN_UTILITY)
     {
@@ -2995,10 +2999,15 @@ xboot_register_client (THREAD_ENTRY * thread_p, BOOT_CLIENT_CREDENTIAL * client_
 	}
     }
 
+  if (client_credential->client_type == BOOT_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL)
+    {
+      skip_vacuum = true;
+    }
+
   /* If the server is not restarted, restart the server at this moment */
   if (!BO_IS_SERVER_RESTARTED ()
       && boot_restart_server (thread_p, false, client_credential->db_name, false, &check_coll_and_timezone,
-			      NULL) != NO_ERROR)
+			      NULL, skip_vacuum) != NO_ERROR)
     {
       *tran_state = TRAN_UNACTIVE_UNKNOWN;
       return NULL_TRAN_INDEX;
@@ -3992,7 +4001,7 @@ xboot_copy (THREAD_ENTRY * thread_p, const char *from_dbname, const char *new_db
 	      goto error;
 	    }
 	  check_col_and_timezone.check_db_coll = false;
-	  error_code = boot_restart_server (thread_p, false, from_dbname, false, &check_col_and_timezone, NULL);
+	  error_code = boot_restart_server (thread_p, false, from_dbname, false, &check_col_and_timezone, NULL, false);
 	  if (error_code != NO_ERROR)
 	    {
 	      goto error;
@@ -5744,6 +5753,8 @@ boot_client_type_to_string (BOOT_CLIENT_TYPE type)
       return "ADMIN_CSQL_WOS";
     case BOOT_CLIENT_LOG_PREFETCHER:
       return "LOG_PREFETCHER";
+    case BOOT_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL:
+      return "SKIP_VACUUM_ADMIN_CSQL";
     case BOOT_CLIENT_UNKNOWN:
     default:
       return "UNKNOWN";

--- a/src/transaction/boot_sr.h
+++ b/src/transaction/boot_sr.h
@@ -103,7 +103,7 @@ extern VOLID boot_find_next_permanent_volid (THREAD_ENTRY * thread_p);
 extern int boot_reset_db_parm (THREAD_ENTRY * thread_p);
 
 extern int boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db_name, bool from_backup,
-				CHECK_ARGS * check_coll_and_timezone, BO_RESTART_ARG * r_args);
+				CHECK_ARGS * check_coll_and_timezone, BO_RESTART_ARG * r_args, bool skip_vacuum);
 extern int xboot_restart_from_backup (THREAD_ENTRY * thread_p, int print_restart, const char *db_name,
 				      BO_RESTART_ARG * r_args);
 extern bool xboot_shutdown_server (THREAD_ENTRY * thread_p, ER_FINAL_CODE is_er_final);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23881

backport #2629

The following is different compared to the develop branch modification.
- When using the --dump option in SA mode, VACUUM should not be performed. For this, I used the code committed in CBRD-23712 when modifying the develop branch. Currently, the modifications of CBRD-23712 are not merged in version 10.1, so only necessary parts have been applied.
- One of the messages is changed in the xvacuum_dump() function. Because, unlike the develop branch, the return value of vacuum_min_log_pageid_to_keep() may be NULL_PAGEID even after vacuum_initialize() in version 10.1. (The code is a little different.)
   - AS-IS
     - "vacuum did not boot properly."
   - TO-BE
     - "There are no log pages referenced by vacuum."
- The vacuum_Is_booted global variable is added.
- Other processing parts for SA_MODE have been slightly changed.
