### PR TITLE
[LETS-68] Fix -Wdeprecated-declarations caused by use of ftime

### DIFF
--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -40,6 +40,7 @@
 #include <signal.h>
 #endif
 #include <assert.h>
+#include <chrono>
 
 #include "porting.h"
 #include "cas_common.h"
@@ -1275,9 +1276,12 @@ logddl_get_time_string (char *buf, struct timeval *time_val)
       struct timeb tb;
 
       /* current time */
-      (void) ftime (&tb);
-      sec = tb.time;
-      millisec = tb.millitm;
+      timespec ts = { };
+      timespec_get (&ts, TIME_UTC);
+      sec = ts.tv_sec;
+      // *INDENT-OFF*
+      millisec = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::nanoseconds (ts.tv_nsec)).count();
+      // *INDENT-ON*
     }
   else
     {

--- a/src/base/tz_support.c
+++ b/src/base/tz_support.c
@@ -5470,6 +5470,7 @@ exit:
   return err_status;
 }
 
+//TODO: make tz_get_offset_in_mins get into account DST
 /*
  * tz_get_offset_in_mins () - time zone offset in minutes from GMT
  */
@@ -5487,12 +5488,6 @@ tz_get_offset_in_mins ()
 
   // Get offset in minutes from UTC
   double offsetFromUTC = difftime (utc, local) / 60;
-
-  // Adjust for DST
-  if (timeinfo->tm_isdst)
-    {
-      offsetFromUTC -= 60;
-    }
 
   return offsetFromUTC;
 }

--- a/src/base/tz_support.c
+++ b/src/base/tz_support.c
@@ -5487,7 +5487,7 @@ tz_get_offset_in_mins ()
   time_t local = mktime (timeinfo);
 
   // Get offset in minutes from UTC
-  double offsetFromUTC = difftime (utc, local) / 60;
+  int offsetFromUTC = difftime (utc, local) / 60;
 
   return offsetFromUTC;
 }

--- a/src/base/tz_support.c
+++ b/src/base/tz_support.c
@@ -84,7 +84,7 @@ typedef enum ds_search_direction DS_SEARCH_DIRECTION;
 
 
 #define FULL_DATE(jul_date, time_sec) ((full_date_t) jul_date * 86400ll \
-				       + (full_date_t) time_sec)
+                                       + (full_date_t) time_sec)
 #define TIME_OFFSET(is_utc, offset) \
   ((is_utc) ? (-offset) : (offset))
 #define ABS(i) ((i) >= 0 ? (i) : -(i))
@@ -188,9 +188,9 @@ static int tz_get_iana_zone_id_by_windows_zone (const char *windows_zone_name);
     v = (SYM_TYPE) TZ_GET_SYM_ADDR (lh, SYM_NAME);			    \
     if (v == NULL)							    \
       {									    \
-	strncpy (sym_name, (SYM_NAME), sizeof (sym_name) - 1);		    \
-	sym_name[sizeof (sym_name) - 1] = '\0';				    \
-	goto error_loading_symbol;					    \
+        strncpy (sym_name, (SYM_NAME), sizeof (sym_name) - 1);		    \
+        sym_name[sizeof (sym_name) - 1] = '\0';				    \
+        goto error_loading_symbol;					    \
       }									    \
   } while (0)
 
@@ -5472,13 +5472,27 @@ exit:
 
 /*
  * tz_get_offset_in_mins () - time zone offset in minutes from GMT
- - gmtime(0) returns the GMT time of the second ZERO of the epoch
- - mktime() simply translate the above moment into equivalent local time
- - the diff between these 2 values gives the timezone offset in seconds (but keep in mind that one of them is ZERO)
  */
 int
 tz_get_offset_in_mins ()
 {
-  time_t tt0 = 0;
-  return (int) (mktime (gmtime (&tt0)) / -60);
+  time_t currtime;
+  struct tm *timeinfo;
+
+  time (&currtime);
+  timeinfo = gmtime (&currtime);
+  time_t utc = mktime (timeinfo);
+  timeinfo = localtime (&currtime);
+  time_t local = mktime (timeinfo);
+
+  // Get offset in minutes from UTC
+  double offsetFromUTC = difftime (utc, local) / 60;
+
+  // Adjust for DST
+  if (timeinfo->tm_isdst)
+    {
+      offsetFromUTC -= 60;
+    }
+
+  return offsetFromUTC;
 }

--- a/src/base/tz_support.c
+++ b/src/base/tz_support.c
@@ -5469,3 +5469,16 @@ exit:
 
   return err_status;
 }
+
+/*
+ * tz_get_offset_in_mins () - time zone offset in minutes from GMT
+ - gmtime(0) returns the GMT time of the second ZERO of the epoch
+ - mktime() simply translate the above moment into equivalent local time
+ - the diff between these 2 values gives the timezone offset in seconds (but keep in mind that one of them is ZERO)
+ */
+int
+tz_get_offset_in_mins ()
+{
+  time_t tt0 = 0;
+  return (int) (mktime (gmtime (&tt0)) / -60);
+}

--- a/src/base/tz_support.h
+++ b/src/base/tz_support.h
@@ -228,6 +228,7 @@ extern "C"
   extern int tz_create_datetimetz_from_parts (const int m, const int d, const int y, const int h, const int mi,
 					      const int s, const int ms, const TZ_ID * tz_id, DB_DATETIMETZ * dt_tz);
   extern int conv_tz (void *, const void *, DB_TYPE);
+  int tz_get_offset_in_mins ();	//time zone offset in minutes from GMT
 #ifdef __cplusplus
 }
 #endif

--- a/src/base/util_func.c
+++ b/src/base/util_func.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <signal.h>
 #include <assert.h>
+#include <chrono>
 #include <time.h>
 #include <stdarg.h>
 #include <sys/timeb.h>
@@ -625,7 +626,7 @@ util_log_header (char *buf, size_t buf_len)
 {
   struct tm tm, *tm_p;
   time_t sec;
-  int millisec, len;
+  int len;
   struct timeb tb;
   char *p;
   const char *pid;
@@ -636,9 +637,12 @@ util_log_header (char *buf, size_t buf_len)
     }
 
   /* current time */
-  (void) ftime (&tb);
-  sec = tb.time;
-  millisec = tb.millitm;
+  timespec ts = { };
+  timespec_get (&ts, TIME_UTC);
+  sec = ts.tv_sec;
+  // *INDENT-OFF*
+  auto millisec = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::nanoseconds (ts.tv_nsec));
+  // *INDENT-ON*
 
   tm_p = localtime_r (&sec, &tm);
 
@@ -647,7 +651,7 @@ util_log_header (char *buf, size_t buf_len)
   buf_len -= len;
 
   pid = envvar_get (UTIL_PID_ENVVAR_NAME);
-  len += snprintf (p, buf_len, ".%03d (%s) ", millisec, ((pid == NULL) ? "    " : pid));
+  len += snprintf (p, buf_len, ".%03ld (%s) ", millisec.count (), ((pid == NULL) ? "    " : pid));
 
   assert (len <= UTIL_LOG_MAX_HEADER_LEN);
 

--- a/src/broker/broker_util.c
+++ b/src/broker/broker_util.c
@@ -422,7 +422,7 @@ ut_time_string (char *buf, struct timeval *time_val)
 {
   struct tm tm, *tm_p;
   time_t sec;
-  int millisec;
+  long millisec;
 
   if (buf == NULL)
     {

--- a/src/broker/broker_util.c
+++ b/src/broker/broker_util.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <chrono>
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>
@@ -430,12 +431,12 @@ ut_time_string (char *buf, struct timeval *time_val)
 
   if (time_val == NULL)
     {
-      struct timeb tb;
-
-      /* current time */
-      (void) ftime (&tb);
-      sec = tb.time;
-      millisec = tb.millitm;
+      timespec ts = { };
+      timespec_get (&ts, TIME_UTC);
+      sec = ts.tv_sec;
+      // *INDENT-OFF*
+      millisec = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::nanoseconds (ts.tv_nsec)).count();
+      // *INDENT-ON*
     }
   else
     {

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -30,6 +30,7 @@
 #include <sys/timeb.h>
 #include <time.h>
 #include <assert.h>
+#include <chrono>
 
 #include "authenticate.h"
 #include "db.h"
@@ -68,7 +69,7 @@ enum
 };
 
 static struct timeb base_server_timeb = { 0, 0, 0, 0 };
-static struct timeb base_client_timeb = { 0, 0, 0, 0 };
+static timespec base_client_time = { };
 
 static int get_dimension_of (PT_NODE ** array);
 static DB_SESSION *db_open_local (void);
@@ -411,8 +412,6 @@ db_calculate_current_server_time (PARSER_CONTEXT * parser)
   DB_DATETIME datetime;
 
   struct timeb curr_server_timeb;
-  struct timeb curr_client_timeb;
-  int diff_mtime;
   int diff_time;
 
   if (base_server_timeb.time == 0)
@@ -420,9 +419,13 @@ db_calculate_current_server_time (PARSER_CONTEXT * parser)
       return;
     }
 
-  ftime (&curr_client_timeb);
-  diff_time = (int) (curr_client_timeb.time - base_client_timeb.time);
-  diff_mtime = curr_client_timeb.millitm - base_client_timeb.millitm;
+  timespec curr_client_time = { };
+  timespec_get (&curr_client_time, TIME_UTC);
+  diff_time = (int) (curr_client_time.tv_sec - base_client_time.tv_sec);
+  // *INDENT-OFF*
+  auto diff_mtime = std::chrono::duration_cast<std::chrono::milliseconds>
+        (std::chrono::nanoseconds (curr_client_time.tv_nsec - base_client_time.tv_nsec)).count ();
+  // *INDENT-ON*
 
   if (diff_time > MAX_SERVER_TIME_CACHE)
     {
@@ -484,7 +487,7 @@ db_set_base_server_time (DB_VALUE * db_val)
   base_server_timeb.millitm = dt->time % 1000;	/* set milliseconds */
 
   base_server_timeb.time = mktime (&c_time_struct);
-  ftime (&base_client_timeb);
+  timespec_get (&base_client_time, TIME_UTC);
 }
 
 /*

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -1825,18 +1825,21 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	  DB_TIMESTAMP db_timestamp;
 	  DB_DATETIME sys_datetime;
 	  DB_TIME db_time;
-	  struct timeb tloc;
+	  timespec tloc = { };
 	  struct tm *c_time_struct, tm_val;
 
 	  /* get the local time of the system */
-	  ftime (&tloc);
-	  c_time_struct = localtime_r (&tloc.time, &tm_val);
+	  timespec_get (&tloc, TIME_UTC);
+	  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
 
 	  if (c_time_struct != NULL)
 	    {
+	      // *INDENT-OFF*
+	      auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
+	      // *INDENT-ON*
 	      db_datetime_encode (&sys_datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday,
 				  c_time_struct->tm_year + 1900, c_time_struct->tm_hour, c_time_struct->tm_min,
-				  c_time_struct->tm_sec, tloc.millitm);
+				  c_time_struct->tm_sec, ms.count ());
 	    }
 
 	  db_time = sys_datetime.time / 1000;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -81,6 +81,7 @@
 #include "xasl_predicate.hpp"
 
 #include <vector>
+#include <chrono>
 
 // XASL_STATE
 typedef struct xasl_state XASL_STATE;
@@ -6446,7 +6447,7 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 {
   SCAN_TYPE scan_type;
   INDX_INFO *indx_info;
-  QFILE_LIST_ID * list_id;
+  QFILE_LIST_ID *list_id;
   bool mvcc_select_lock_needed = false;
   int error_code = NO_ERROR;
 
@@ -6631,7 +6632,7 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 
     case TARGET_LIST:
       /* open a list file scan */
-      if (ACCESS_SPEC_XASL_NODE(curr_spec) && ACCESS_SPEC_XASL_NODE(curr_spec)->spec_list == curr_spec)
+      if (ACCESS_SPEC_XASL_NODE (curr_spec) && ACCESS_SPEC_XASL_NODE (curr_spec)->spec_list == curr_spec)
 	{
 	  /* if XASL of access spec for list scan is itself then this is for HQ */
 	  list_id = ACCESS_SPEC_CONNECT_BY_LIST_ID (curr_spec);
@@ -9505,7 +9506,7 @@ qexec_process_unique_stats (THREAD_ENTRY * thread_p, const OID * class_oid, UPDD
       /* Accumulate current statistics */
       qexec_update_btree_unique_stats_info (thread_p, &internal_class->m_unique_stats, &internal_class->m_scancache);
     }
-
+// *INDENT-OFF*
 for (const auto & it:internal_class->m_unique_stats.get_map ())
     {
       if (!it.second.is_unique ())
@@ -9520,6 +9521,7 @@ for (const auto & it:internal_class->m_unique_stats.get_map ())
 	  return error;
 	}
     }
+// *INDENT-ON*
   return NO_ERROR;
 }
 
@@ -14668,7 +14670,6 @@ qexec_execute_query (THREAD_ENTRY * thread_p, xasl_node * xasl, int dbval_cnt, c
   int stat = NO_ERROR;
   QFILE_LIST_ID *list_id = NULL;
   XASL_STATE xasl_state;
-  struct timeb tloc;
   struct tm *c_time_struct, tm_val;
   int tran_index;
 
@@ -14785,16 +14786,20 @@ qexec_execute_query (THREAD_ENTRY * thread_p, xasl_node * xasl, int dbval_cnt, c
   /* form the value descriptor to represent positional values */
   xasl_state.vd.dbval_cnt = dbval_cnt;
   xasl_state.vd.dbval_ptr = (DB_VALUE *) dbval_ptr;
-  ftime (&tloc);
-  c_time_struct = localtime_r (&tloc.time, &tm_val);
+  timespec tloc = { };
+  timespec_get (&tloc, TIME_UTC);
+  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
 
-  xasl_state.vd.sys_epochtime = (DB_TIMESTAMP) tloc.time;
+  xasl_state.vd.sys_epochtime = (DB_TIMESTAMP) tloc.tv_sec;
 
   if (c_time_struct != NULL)
     {
+      // *INDENT-OFF*
+      auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
+      // *INDENT-ON*
       db_datetime_encode (&xasl_state.vd.sys_datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday,
 			  c_time_struct->tm_year + 1900, c_time_struct->tm_hour, c_time_struct->tm_min,
-			  c_time_struct->tm_sec, tloc.millitm);
+			  c_time_struct->tm_sec, ms.count ());
     }
 
   rand_buf_p = qmgr_get_rand_buf (thread_p);
@@ -15352,7 +15357,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 		}
 
 	      if (cycle == 0)
-	        {
+		{
 		  isleaf_value = 0;
 		}
 
@@ -15376,8 +15381,9 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 		  db_make_int (isleaf_valp, isleaf_value);
 
 		  /* preserve the parent position pseudocolumn value */
-		  if (qexec_get_tuple_column_value (tuple_rec.tpl,(xasl->outptr_list->valptr_cnt - PCOL_PARENTPOS_TUPLE_OFFSET),
-						    parent_pos_valp, &tp_Bit_domain) != NO_ERROR)
+		  if (qexec_get_tuple_column_value
+		      (tuple_rec.tpl, (xasl->outptr_list->valptr_cnt - PCOL_PARENTPOS_TUPLE_OFFSET), parent_pos_valp,
+		       &tp_Bit_domain) != NO_ERROR)
 		    {
 		      GOTO_EXIT_ON_ERROR;
 		    }
@@ -15410,7 +15416,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 		  if (has_order_siblings_by)
 		    {
 		      if (qexec_insert_tuple_into_list (thread_p, listfile2_tmp, xasl->outptr_list, &xasl_state->vd,
-						        tplrec) != NO_ERROR)
+							tplrec) != NO_ERROR)
 			{
 			  GOTO_EXIT_ON_ERROR;
 			}

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -13215,7 +13215,7 @@ db_sys_datetime (DB_VALUE * result_datetime)
   /* now return null */
   db_value_domain_init (result_datetime, DB_TYPE_DATETIME, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 
-  if (timespec_get (&tloc, TIME_UTC) != TIME_UTC)
+  if (timespec_get (&tloc, TIME_UTC) != 0)
     {
       error_status = ER_SYSTEM_DATE;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
@@ -13261,7 +13261,7 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
   assert (dt_dbval != NULL);
   assert (ts_dbval != NULL);
 
-  if (timespec_get (&tloc, TIME_UTC) != TIME_UTC)
+  if (timespec_get (&tloc, TIME_UTC) != 0)
     {
       error_status = ER_SYSTEM_DATE;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -54,8 +54,10 @@
 #include "es_common.h"
 #include "db_elo.h"
 #include "string_regex.hpp"
+#include "tz_support.h"
 
 #include <algorithm>
+#include <chrono>
 #include <string>
 #include <locale>
 
@@ -13205,7 +13207,7 @@ db_sys_datetime (DB_VALUE * result_datetime)
   int error_status = NO_ERROR;
   DB_DATETIME datetime;
 
-  struct timeb tloc;
+  timespec tloc = { };
   struct tm *c_time_struct, tm_val;
 
   assert (result_datetime != (DB_VALUE *) NULL);
@@ -13213,14 +13215,14 @@ db_sys_datetime (DB_VALUE * result_datetime)
   /* now return null */
   db_value_domain_init (result_datetime, DB_TYPE_DATETIME, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 
-  if (ftime (&tloc) != 0)
+  if (timespec_get (&tloc, TIME_UTC) != TIME_UTC)
     {
       error_status = ER_SYSTEM_DATE;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  c_time_struct = localtime_r (&tloc.time, &tm_val);
+  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
   if (c_time_struct == NULL)
     {
       error_status = ER_SYSTEM_DATE;
@@ -13228,8 +13230,11 @@ db_sys_datetime (DB_VALUE * result_datetime)
       return error_status;
     }
 
+  // *INDENT-OFF*
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
+  // *INDENT-ON*
   db_datetime_encode (&datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900,
-		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, tloc.millitm);
+		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, ms.count ());
   db_make_datetime (result_datetime, &datetime);
 
   return error_status;
@@ -13250,20 +13255,20 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
 {
   int error_status = NO_ERROR;
   DB_DATETIME datetime;
-  struct timeb tloc;
+  timespec tloc = { };
   struct tm *c_time_struct, tm_val;
 
   assert (dt_dbval != NULL);
   assert (ts_dbval != NULL);
 
-  if (ftime (&tloc) != 0)
+  if (timespec_get (&tloc, TIME_UTC) != TIME_UTC)
     {
       error_status = ER_SYSTEM_DATE;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  c_time_struct = localtime_r (&tloc.time, &tm_val);
+  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
   if (c_time_struct == NULL)
     {
       error_status = ER_SYSTEM_DATE;
@@ -13271,11 +13276,14 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
       return error_status;
     }
 
+  // *INDENT-OFF*
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
+  // *INDENT-ON*
   db_datetime_encode (&datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900,
-		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, tloc.millitm);
+		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, ms.count ());
 
   db_make_datetime (dt_dbval, &datetime);
-  db_make_timestamp (ts_dbval, (DB_TIMESTAMP) tloc.time);
+  db_make_timestamp (ts_dbval, (DB_TIMESTAMP) tloc.tv_sec);
 
   return error_status;
 }
@@ -13287,24 +13295,12 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
 int
 db_sys_timezone (DB_VALUE * result_timezone)
 {
-  int error_status = NO_ERROR;
-  struct timeb tloc;
-
   assert (result_timezone != (DB_VALUE *) NULL);
 
   /* now return null */
   db_value_domain_init (result_timezone, DB_TYPE_INTEGER, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 
-  /* Need checking error */
-
-  if (ftime (&tloc) == -1)
-    {
-      error_status = ER_SYSTEM_DATE;
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
-      return error_status;
-    }
-
-  db_make_int (result_timezone, tloc.timezone);
+  db_make_int (result_timezone, tz_get_offset_in_mins ());
   return NO_ERROR;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-68

‘int ftime(timeb*)’ is deprecated and should be replaced with the usage of functions from std::chrono
