### PR TITLE
[CBRD-23901] Remove the hidden property of the dont_reuse_heap_file system parameter.

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -3075,7 +3075,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) prm_io_pages_to_size},
   {PRM_ID_DONT_REUSE_HEAP_FILE,
    PRM_NAME_DONT_REUSE_HEAP_FILE,
-   (PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_HIDDEN),
+   (PRM_FOR_SERVER | PRM_USER_CHANGE),
    PRM_BOOLEAN,
    &prm_dont_reuse_heap_file_flag,
    (void *) &prm_dont_reuse_heap_file_default,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23901

disclose the dont_reuse_heap_file system parameter which has the hidden property on the source code.