### PR TITLE
[CBRD-23901] Remove the hidden property of the dont_reuse_heap_file system parameter. (#2652)

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2994,7 +2994,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) prm_io_pages_to_size},
   {PRM_ID_DONT_REUSE_HEAP_FILE,
    PRM_NAME_DONT_REUSE_HEAP_FILE,
-   (PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_HIDDEN),
+   (PRM_FOR_SERVER | PRM_USER_CHANGE),
    PRM_BOOLEAN,
    &prm_dont_reuse_heap_file_flag,
    (void *) &prm_dont_reuse_heap_file_default,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23901

backport #2652
