### PR TITLE
[LETS-76] Set 1 second timeout for ATS<->PS communication channel polls

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2638,7 +2638,8 @@ css_process_server_server_connect (SOCKET master_fd)
       assert (false);
       return;
     }
-  cubcomm::channel chn;
+  constexpr int CHANNEL_POLL_TIMEOUT = 1000;	// 1000 milliseconds = 1 second
+  cubcomm::channel chn (CHANNEL_POLL_TIMEOUT);
   chn.accept (slave_fd);
   int request = css_get_master_request (slave_fd);	//read an integer to determine connection type
   switch (STATIC_CAST (cubcomm::server_server, request))

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -99,7 +99,8 @@ int active_tran_server::connect_to_page_server (const std::string &host, int por
   assert (!is_page_server_connected ());
 
   // connect to page server
-  cubcomm::server_channel srv_chn (db_name);
+  constexpr int CHANNEL_POLL_TIMEOUT = 1000;    // 1000 milliseconds = 1 second
+  cubcomm::server_channel srv_chn (db_name, CHANNEL_POLL_TIMEOUT);
 
   srv_chn.set_channel_name ("ATS_PS_comm");
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-76

Construct the channels used by active_tran_server to communicate with the page_server and vice-versa with a timeout of 1 second (1000 milliseconds).

 As consequence, the request server's don't poll without timeout and the servers do not hang during shutdown.
 
 The patch also fixes the line endings of active_tran_server.cpp file. Use "Hide whitespace changes" setting to see only relevant differences.