### PR TITLE
[CBRD-23899] Fix errors detected by cppcheck in api, broker and cci

### DIFF
--- a/src/api/cci_stub.c
+++ b/src/api/cci_stub.c
@@ -2594,7 +2594,7 @@ stmt_execute_batch_array (STATEMENT_IMPL * pstmt)
 static int
 stmt_complete_batch (STATEMENT_IMPL * pstmt)
 {
-  int res;
+  int res = NO_ERROR;
   int num_batch, i;
   dlisth h;
 

--- a/src/api/cci_stub.c
+++ b/src/api/cci_stub.c
@@ -3906,7 +3906,7 @@ xcol_to_cci_set (CI_COLLECTION col, T_CCI_SET * rtset)
   API_VAL_CCI_BIND *binds;	/* bind array */
 
   assert (col != NULL);
-  assert (tset != NULL);
+  assert (rtset != NULL);
 
   co = (CCI_COLLECTION *) col;
   res = co->indexer->ifs->length (co->indexer, &size);

--- a/src/broker/broker_log_util.c
+++ b/src/broker/broker_log_util.c
@@ -150,7 +150,7 @@ is_bind_with_size (char *buf, int *tot_val_size, int *info_size)
 {
   char *msg;
   char *p, *q;
-  char size[256];
+  char size[256] = { 0, };
   char *value_p;
   char *size_begin;
   char *size_end;

--- a/src/broker/broker_process_size.c
+++ b/src/broker/broker_process_size.c
@@ -351,10 +351,6 @@ alloc_counter_value ()
   tmp_pid = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_pid, _mem_size);
   if (tmp_pid == NULL)
     {
-      if (cntvalue_pid != NULL)
-        {
-          free (cntvalue_pid);
-        }
       cntvalue_pid = NULL;
     }
   else
@@ -365,10 +361,6 @@ alloc_counter_value ()
   tmp_workset = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_workset, _mem_size);
   if (tmp_workset == NULL)
     {
-      if (cntvalue_workset != NULL)
-        {
-          free (cntvalue_workset);
-	}
       cntvalue_workset = NULL;
     }
   else
@@ -379,10 +371,6 @@ alloc_counter_value ()
   tmp_cpu = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_pct_cpu, _mem_size);
   if (tmp_cpu == NULL)
     {
-      if (cntvalue_pct_cpu != NULL)
-        {
-          free (cntvalue_pct_cpu);
-        }
       cntvalue_pct_cpu = NULL;
     }
   else
@@ -393,10 +381,6 @@ alloc_counter_value ()
   tmp_num_thr = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_num_thr, _mem_size);
   if (tmp_num_thr == NULL)
     {
-      if (cntvalue_num_thr != NULL)
-        {
-          free (cntvalue_num_thr);
-        }
       cntvalue_num_thr = NULL;
     }
   else

--- a/src/broker/broker_process_size.c
+++ b/src/broker/broker_process_size.c
@@ -347,8 +347,8 @@ alloc_counter_value ()
   PDH_FMT_COUNTERVALUE_ITEM *tmp_workset = NULL;
   PDH_FMT_COUNTERVALUE_ITEM *tmp_num_thr = NULL;
 
-  int _mem_size = sizeof(PDH_FMT_COUNTERVALUE_ITEM) * num_counter_value;
-  tmp_pid = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_pid, _mem_size);
+  int _mem_size = sizeof (PDH_FMT_COUNTERVALUE_ITEM) * num_counter_value;
+  tmp_pid = (PDH_FMT_COUNTERVALUE_ITEM *) realloc (cntvalue_pid, _mem_size);
   if (tmp_pid == NULL)
     {
       cntvalue_pid = NULL;
@@ -358,7 +358,7 @@ alloc_counter_value ()
       cntvalue_pid = tmp_pid;
     }
 
-  tmp_workset = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_workset, _mem_size);
+  tmp_workset = (PDH_FMT_COUNTERVALUE_ITEM *) realloc (cntvalue_workset, _mem_size);
   if (tmp_workset == NULL)
     {
       cntvalue_workset = NULL;
@@ -368,7 +368,7 @@ alloc_counter_value ()
       cntvalue_workset = tmp_workset;
     }
 
-  tmp_cpu = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_pct_cpu, _mem_size);
+  tmp_cpu = (PDH_FMT_COUNTERVALUE_ITEM *) realloc (cntvalue_pct_cpu, _mem_size);
   if (tmp_cpu == NULL)
     {
       cntvalue_pct_cpu = NULL;
@@ -378,7 +378,7 @@ alloc_counter_value ()
       cntvalue_pct_cpu = tmp_cpu;
     }
 
-  tmp_num_thr = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_num_thr, _mem_size);
+  tmp_num_thr = (PDH_FMT_COUNTERVALUE_ITEM *) realloc (cntvalue_num_thr, _mem_size);
   if (tmp_num_thr == NULL)
     {
       cntvalue_num_thr = NULL;

--- a/src/broker/broker_process_size.c
+++ b/src/broker/broker_process_size.c
@@ -78,19 +78,11 @@ static char *skip_token (char *p);
 #endif
 
 #if defined(WINDOWS)
-#define ALLOC_COUNTER_VALUE()                                           \
-        do {                                                            \
-            int _mem_size = sizeof(PDH_FMT_COUNTERVALUE_ITEM) *         \
-                                   num_counter_value;                   \
-            cntvalue_pid = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_pid, _mem_size);               \
-            cntvalue_workset = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_workset, _mem_size);       \
-            cntvalue_pct_cpu = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_pct_cpu, _mem_size);       \
-            cntvalue_num_thr = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_num_thr, _mem_size);       \
-        } while (0)
-
 #define IS_COUNTER_VALUE_PTR_NULL()                                     \
         (cntvalue_pid == NULL || cntvalue_workset == NULL ||            \
          cntvalue_pct_cpu == NULL || cntvalue_num_thr == NULL)
+
+static void alloc_counter_value ();
 
 typedef PDH_STATUS (__stdcall * PDHOpenQuery) (LPCSTR, DWORD_PTR, PDH_HQUERY *);
 typedef PDH_STATUS (__stdcall * PDHCloseQuery) (PDH_HQUERY);
@@ -347,6 +339,72 @@ retry:
   return (int) (((INT64) info.pr_size) * ((INT64) page_size) / 1024);
 }
 #elif defined(WINDOWS)
+static void
+alloc_counter_value ()
+{
+  PDH_FMT_COUNTERVALUE_ITEM *tmp_pid = NULL;
+  PDH_FMT_COUNTERVALUE_ITEM *tmp_cpu = NULL;
+  PDH_FMT_COUNTERVALUE_ITEM *tmp_workset = NULL;
+  PDH_FMT_COUNTERVALUE_ITEM *tmp_num_thr = NULL;
+
+  int _mem_size = sizeof(PDH_FMT_COUNTERVALUE_ITEM) * num_counter_value;
+  tmp_pid = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_pid, _mem_size);
+  if (tmp_pid == NULL)
+    {
+      if (cntvalue_pid != NULL)
+        {
+          free (cntvalue_pid);
+        }
+      cntvalue_pid = NULL;
+    }
+  else
+    {
+      cntvalue_pid = tmp_pid;
+    }
+
+  tmp_workset = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_workset, _mem_size);
+  if (tmp_workset == NULL)
+    {
+      if (cntvalue_workset != NULL)
+        {
+          free (cntvalue_workset);
+	}
+      cntvalue_workset = NULL;
+    }
+  else
+    {
+      cntvalue_workset = tmp_workset;
+    }
+
+  tmp_cpu = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_pct_cpu, _mem_size);
+  if (tmp_cpu == NULL)
+    {
+      if (cntvalue_pct_cpu != NULL)
+        {
+          free (cntvalue_pct_cpu);
+        }
+      cntvalue_pct_cpu = NULL;
+    }
+  else
+    {
+      cntvalue_pct_cpu = tmp_cpu;
+    }
+
+  tmp_num_thr = (PDH_FMT_COUNTERVALUE_ITEM*) realloc(cntvalue_num_thr, _mem_size);
+  if (tmp_num_thr == NULL)
+    {
+      if (cntvalue_num_thr != NULL)
+        {
+          free (cntvalue_num_thr);
+        }
+      cntvalue_num_thr = NULL;
+    }
+  else
+    {
+      cntvalue_num_thr = tmp_num_thr;
+    }
+}
+
 int
 getsize (int pid)
 {
@@ -466,7 +524,7 @@ pdh_init ()
 
   num_counter_value = 128;
 
-  ALLOC_COUNTER_VALUE ();
+  alloc_counter_value ();
   if (IS_COUNTER_VALUE_PTR_NULL ())
     {
       return -1;
@@ -489,7 +547,7 @@ pdh_collect ()
 
   if (IS_COUNTER_VALUE_PTR_NULL ())
     {
-      ALLOC_COUNTER_VALUE ();
+      alloc_counter_value ();
       if (IS_COUNTER_VALUE_PTR_NULL ())
 	goto collect_error;
     }
@@ -509,7 +567,7 @@ pdh_collect ()
 	  if (pdh_status == PDH_MORE_DATA)
 	    {
 	      num_counter_value *= 2;
-	      ALLOC_COUNTER_VALUE ();
+	      alloc_counter_value ();
 	      if (IS_COUNTER_VALUE_PTR_NULL ())
 		{
 		  goto collect_error;

--- a/src/broker/cas_dbms_util.c
+++ b/src/broker/cas_dbms_util.c
@@ -74,7 +74,7 @@ cfg_get_dbinfo (char *alias, char *dbinfo)
   FILE *file;
   char *save, *token;
   char delim[] = "|";
-  char filename[BROKER_PATH_MAX];
+  char filename[BROKER_PATH_MAX] = { 0, };
   char line[DBINFO_MAX_LENGTH];
 
   if (shm_appl->db_connection_file[0] == '\0')
@@ -133,7 +133,7 @@ int
 cfg_read_dbinfo (DB_INFO ** db_info_p)
 {
   FILE *file;
-  char filename[BROKER_PATH_MAX];
+  char filename[BROKER_PATH_MAX] = { 0, };
   char line[DBINFO_MAX_LENGTH];
   char *str = NULL;
   DB_INFO *databases, *db, *last;

--- a/src/broker/shard_metadata.c
+++ b/src/broker/shard_metadata.c
@@ -677,7 +677,7 @@ shard_metadata_validate_key_range_internal (T_SHARD_KEY * key_p, T_SHM_SHARD_CON
   num_shard_conn = shm_conn_p->num_shard_conn;
   if (num_shard_conn < 0)
     {
-      SHARD_ERR ("%s: num shard connection is invalid.\n");
+      SHARD_ERR ("%s: num shard connection is invalid.\n", key_p->key_column);
       return -1;
     }
 
@@ -705,7 +705,7 @@ shard_metadata_validate_key_range_internal (T_SHARD_KEY * key_p, T_SHM_SHARD_CON
 	}
       if (j >= num_shard_conn)
 	{
-	  SHARD_ERR ("%s: shard range shard_id (%d) is invalid.\n", range_p->shard_id);
+	  SHARD_ERR ("%s: shard range shard_id (%d) is invalid.\n", key_p->key_column, range_p->shard_id);
 	  return -1;
 	}
 
@@ -714,7 +714,7 @@ shard_metadata_validate_key_range_internal (T_SHARD_KEY * key_p, T_SHM_SHARD_CON
 
   if ((modular >= 1) && (prv_range_max > modular))
     {
-      SHARD_ERR ("%s: shard range max (%d, modular %d) is invalid.\n", range_p->max, modular);
+      SHARD_ERR ("%s: shard range max (%d, modular %d) is invalid.\n", key_p->key_column, range_p->max, modular);
       return -1;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23899

Fix below item error detected by cppcheck
 * src/api/cci_stub.c:2614:7: error: Uninitialized variable: res [uninitvar]
 * src/api/cci_stub.c:3909:11: error: Uninitialized variable: tset [uninitvar]
 * src/broker/broker_log_util.c:228:29: error: Uninitialized variable: size [uninitvar]
 * src/broker/broker_process_size.c:469:3: error: Common realloc mistake: 'cntvalue_pid' nulled but not freed upon failure
 * src/broker/broker_process_size.c:469:3: error: Common realloc mistake: 'cntvalue_pct_cpu' nulled but not freed upon failure
 * src/broker/broker_process_size.c:469:3: error: Common realloc mistake: 'cntvalue_num_thr' nulled but not freed upon failure [memleakOnRealloc]
 * src/broker/broker_process_size.c:469:3: error: Common realloc mistake: 'cntvalue_num_thr' nulled but not freed upon failure [memleakOnRealloc]
 * src/broker/broker_process_size.c:492:7: error: Common realloc mistake: 'cntvalue_pid' nulled but not freed upon failure [memleakOnRealloc]
 * src/broker/broker_process_size.c:492:7: error: Common realloc mistake: 'cntvalue_workset' nulled but not freed upon failure [memleakOnRealloc]
 * src/broker/broker_process_size.c:492:7: error: Common realloc mistake: 'cntvalue_pct_cpu' nulled but not freed upon failure [memleakOnRealloc]
 * src/broker/broker_process_size.c:492:7: error: Common realloc mistake: 'cntvalue_num_thr' nulled but not freed upon failure [memleakOnRealloc]
 * src/broker/broker_process_size.c:512:8: error: Common realloc mistake: 'cntvalue_pid' nulled but not freed upon failure [memleakOnRealloc]
 * src/broker/broker_process_size.c:512:8: error: Common realloc mistake: 'cntvalue_workset' nulled but not freed upon failure [memleakOnRealloc]
 * src/broker/broker_process_size.c:512:8: error: Common realloc mistake: 'cntvalue_pct_cpu' nulled but not freed upon failure [memleakOnRealloc]
 * src/broker/broker_process_size.c:512:8: error: Common realloc mistake: 'cntvalue_num_thr' nulled but not freed upon failure [memleakOnRealloc]
 * src/broker/cas_dbms_util.c:100:17: error: Uninitialized variable: filename [uninitvar]
 * src/broker/cas_dbms_util.c:164:17: error: Uninitialized variable: filename [uninitvar]
 * src/broker/shard_metadata.c:708:4: error: fprintf format string requires 4 parameters but only 3 are given. [wrongPrintfScanfArgNum]
 * src/broker/shard_metadata.c:717:7: error: fprintf format string requires 5 parameters but only 4 are given. [wrongPrintfScanfArgNum]