### PR TITLE
[CBRD-23904] Github Checks to not only develop, but also feature and some release branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,10 @@
 name: github-checks
 on: 
   pull_request:
-    branches: [ develop ]
+    branches:
+      - develop
+      - 'release/11.**'
+      - 'feature/**'
 jobs:
   license:
     name: license


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23904

This makes Github Checks support some more branches besides develop.

- release/11.** : All the 11.x branches
- feature/**: All the feature branches

To make use of Github Checks, the proper branch prefix has to be used.

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet