### PR TITLE
[CBRD-23900] Limit license checking only to specific file formats

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,6 +37,12 @@ jobs:
             if [ -d "$f" ]; then
               continue
             fi
+  
+            ext=$(expr $f : ".*\(\..*\)")
+            case $ext in
+            .c|.h|.cpp|.hpp|.ipp|.sh|.bat|.y|.l) true;; # only these formats are checked.
+            *) continue ;; # skip others 
+            esac
 
             result_for_f="FAIL"
             for header in `find $license_headers -type f`; do

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,11 +37,11 @@ jobs:
             if [ -d "$f" ]; then
               continue
             fi
-  
+
             ext=$(expr $f : ".*\(\..*\)")
             case $ext in
             .c|.h|.cpp|.hpp|.ipp|.sh|.bat|.y|.l) true;; # only these formats are checked.
-            *) continue ;; # skip others 
+            *) continue ;; # skip others
             esac
 
             result_for_f="FAIL"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,6 +34,10 @@ jobs:
           result="PASS"
 
           for f in ${{ steps.files.outputs.added_modified }}; do
+            if [ -d "$f" ]; then
+              continue
+            fi
+
             result_for_f="FAIL"
             for header in `find $license_headers -type f`; do
               line_cnt=`wc -l < $header`
@@ -43,6 +47,7 @@ jobs:
                 break
               fi
             done
+
             echo "$f: $result_for_f"
             if [ "$result_for_f" = "FAIL" ]; then
               result="FAIL"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,7 @@ jobs:
 
             ext=$(expr $f : ".*\(\..*\)")
             case $ext in
-            .c|.h|.cpp|.hpp|.ipp|.sh|.bat|.y|.l) true;; # only these formats are checked.
+            .c|.h|.cpp|.hpp|.ipp|.sh|.bat|.y|.l|.msg) true;; # only these formats are checked.
             *) continue ;; # skip others
             esac
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -108,6 +108,9 @@ jobs:
           result_file="cppcheck.result"
           summary_file="cppcheck.summary"
 
+          touch $result_file
+          touch $summary_file
+
           # to suppress other error, add it to .github/workflows/cppcheck-spr-list
           for f in ${{ steps.files.outputs.added_modified }}; do
             cppcheck --force -j4 --suppressions-list=.github/workflows/cppcheck-spr-list --quiet --enable=warning -iheaplayers $f 2>>$result_file


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23900

This patch includes:
1. ignore directories when checking license
2. specify file formats to be checked when checking license
    - .c .cpp .h .hpp .sh .bat .y .l .ipp .msg 
3. touch results files to prevent an error if no file has been changed during cppcheck

We could check a specific license header for each file format, but now just filter the file formats for convenience. 
We can improve it when the performance matters.