### PR TITLE
[LETS-77] Do not use slotted pages' saved space on page server.

### DIFF
--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -50,6 +50,7 @@
 #include "thread_entry.hpp"
 #include "thread_lockfree_hash_map.hpp"
 #include "thread_manager.hpp"	// for thread_get_thread_entry_info
+#include "server_type.hpp"
 
 #if !defined(SERVER_MODE)
 #define pthread_mutex_init(a, b)
@@ -233,6 +234,7 @@ static int spage_put_helper (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID s
 			     const RECDES * recdes, bool is_append);
 static void spage_add_contiguous_free_space (PAGE_PTR pgptr, int space);
 static void spage_reduce_contiguous_free_space (PAGE_PTR pgptr, int space);
+static bool spage_skip_save_space_altogether();
 static INLINE void spage_verify_header (PAGE_PTR page_p) __attribute__ ((ALWAYS_INLINE));
 
 // *INDENT-OFF*
@@ -486,7 +488,7 @@ spage_save_space (THREAD_ENTRY * thread_p, SPAGE_HEADER * page_header_p, PAGE_PT
   assert (page_p != NULL);
   SPAGE_VERIFY_HEADER (page_header_p);
 
-  if (space == 0 || log_is_in_crash_recovery ())
+  if (space == 0 || spage_skip_save_space_altogether ())
     {
       return NO_ERROR;
     }
@@ -701,8 +703,9 @@ spage_get_saved_spaces (THREAD_ENTRY * thread_p, SPAGE_HEADER * page_header_p, P
 
   /*
    * If we are recovering, no other transaction should exist.
+   * If in page server (when running in scalability mode), saved space is not used
    */
-  if (log_is_in_crash_recovery ())
+  if (spage_skip_save_space_altogether ())
     {
       if (saved_by_other_trans != NULL)
 	{
@@ -1710,7 +1713,7 @@ spage_find_empty_slot_at (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slo
 
   if (slot_id == page_header_p->num_slots)
     {
-      assert (log_is_in_crash_recovery () || !(page_header_p->is_saving && !logtb_is_current_active (thread_p)));
+      assert (spage_skip_save_space_altogether () || !(page_header_p->is_saving && !logtb_is_current_active (thread_p)));
 
       status = spage_add_new_slot (thread_p, page_p, page_header_p, &space);
     }
@@ -5262,4 +5265,15 @@ spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
     }
 
   return false;
+}
+
+/* spage_skip_save_space_altogether - in certain conditions, skip saved space utilization
+ *
+ */
+bool
+spage_skip_save_space_altogether()
+{
+  const bool during_crash_recovery = log_is_in_crash_recovery ();
+  const bool in_page_server { get_server_type () == SERVER_TYPE_PAGE };
+  return during_crash_recovery || in_page_server;
 }

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -234,7 +234,7 @@ static int spage_put_helper (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID s
 			     const RECDES * recdes, bool is_append);
 static void spage_add_contiguous_free_space (PAGE_PTR pgptr, int space);
 static void spage_reduce_contiguous_free_space (PAGE_PTR pgptr, int space);
-static bool spage_is_save_space_enabled ();
+static bool spage_is_save_space_disabled ();
 static INLINE void spage_verify_header (PAGE_PTR page_p) __attribute__ ((ALWAYS_INLINE));
 
 // *INDENT-OFF*
@@ -488,7 +488,7 @@ spage_save_space (THREAD_ENTRY * thread_p, SPAGE_HEADER * page_header_p, PAGE_PT
   assert (page_p != NULL);
   SPAGE_VERIFY_HEADER (page_header_p);
 
-  if (space == 0 || spage_is_save_space_enabled ())
+  if (space == 0 || spage_is_save_space_disabled ())
     {
       return NO_ERROR;
     }
@@ -703,9 +703,10 @@ spage_get_saved_spaces (THREAD_ENTRY * thread_p, SPAGE_HEADER * page_header_p, P
 
   /*
    * If we are recovering, no other transaction should exist.
-   * If in page server (when running in scalability mode), saved space is not used
+   * If in page server (when running in scalability mode), saved space is not used (already handled
+   * on the transaction server side).
    */
-  if (spage_is_save_space_enabled ())
+  if (spage_is_save_space_disabled ())
     {
       if (saved_by_other_trans != NULL)
 	{
@@ -1713,7 +1714,7 @@ spage_find_empty_slot_at (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slo
 
   if (slot_id == page_header_p->num_slots)
     {
-      assert (spage_is_save_space_enabled ()
+      assert (spage_is_save_space_disabled ()
 	      || !(page_header_p->is_saving && !logtb_is_current_active (thread_p)));
 
       status = spage_add_new_slot (thread_p, page_p, page_header_p, &space);
@@ -5268,11 +5269,11 @@ spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
   return false;
 }
 
-/* spage_is_save_space_enabled - in certain conditions, slotted pages' saved space is not used
+/* spage_is_save_space_disabled - in certain conditions, slotted pages' saved space is not used
  *
  */
 bool
-spage_is_save_space_enabled ()
+spage_is_save_space_disabled ()
 {
   const bool during_crash_recovery = log_is_in_crash_recovery ();
   const bool in_page_server (get_server_type () == SERVER_TYPE_PAGE);

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -234,7 +234,7 @@ static int spage_put_helper (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID s
 			     const RECDES * recdes, bool is_append);
 static void spage_add_contiguous_free_space (PAGE_PTR pgptr, int space);
 static void spage_reduce_contiguous_free_space (PAGE_PTR pgptr, int space);
-static bool spage_skip_save_space_altogether();
+static bool spage_skip_save_space_altogether ();
 static INLINE void spage_verify_header (PAGE_PTR page_p) __attribute__ ((ALWAYS_INLINE));
 
 // *INDENT-OFF*
@@ -1713,7 +1713,8 @@ spage_find_empty_slot_at (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slo
 
   if (slot_id == page_header_p->num_slots)
     {
-      assert (spage_skip_save_space_altogether () || !(page_header_p->is_saving && !logtb_is_current_active (thread_p)));
+      assert (spage_skip_save_space_altogether ()
+	      || !(page_header_p->is_saving && !logtb_is_current_active (thread_p)));
 
       status = spage_add_new_slot (thread_p, page_p, page_header_p, &space);
     }
@@ -5271,9 +5272,9 @@ spage_need_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
  *
  */
 bool
-spage_skip_save_space_altogether()
+spage_skip_save_space_altogether ()
 {
   const bool during_crash_recovery = log_is_in_crash_recovery ();
-  const bool in_page_server { get_server_type () == SERVER_TYPE_PAGE };
+  const bool in_page_server (get_server_type () == SERVER_TYPE_PAGE);
   return during_crash_recovery || in_page_server;
 }

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -5276,6 +5276,6 @@ bool
 spage_is_save_space_disabled ()
 {
   const bool during_crash_recovery = log_is_in_crash_recovery ();
-  //const bool in_page_server (get_server_type () == SERVER_TYPE_PAGE);
-  return during_crash_recovery; // || in_page_server;
+  const bool in_page_server (get_server_type () == SERVER_TYPE_PAGE);
+  return during_crash_recovery || in_page_server;
 }

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -5276,6 +5276,6 @@ bool
 spage_is_save_space_disabled ()
 {
   const bool during_crash_recovery = log_is_in_crash_recovery ();
-  const bool in_page_server (get_server_type () == SERVER_TYPE_PAGE);
-  return during_crash_recovery || in_page_server;
+  //const bool in_page_server (get_server_type () == SERVER_TYPE_PAGE);
+  return during_crash_recovery; // || in_page_server;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-77

Extend condition to skip slotted page saved space to include also the situation when the server is in page server mode because this - slotted page saved space provisioning - has already been performed on the transaction server.

This occurred in stress testing of sequential replication executing on the page server.