### PR TITLE
[CBRD-23908] Upgrade cppcheck version to 2.4.1 in Github Check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -112,7 +112,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install packages
-        run: sudo apt-get install -yq cppcheck 
+        run: |
+          sudo apt-get install -yq wget build-essential
+
+          # Download cppcheck-2.4.1 source
+          wd=`pwd`
+          cd ..
+          wget https://github.com/danmar/cppcheck/archive/2.4.1.tar.gz
+          tar xf 2.4.1.tar.gz
+
+          # build cppcheck-2.4.1
+          cd cppcheck-2.4.1
+          make -j4 SRCDIR=build CFGDIR=cfg CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
+          echo "CPPCHECK_PATH=`pwd`" >> $GITHUB_ENV
+
+          cd $wd
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1
         id: files
@@ -137,7 +151,7 @@ jobs:
             *) continue ;; # skip others
             esac
 
-            cppcheck --force -j4 --suppressions-list=.github/workflows/cppcheck-spr-list --quiet --enable=warning -iheaplayers $f 2>>$result_file
+            ${{ env.CPPCHECK_PATH }}/cppcheck --force -j4 --suppressions-list=.github/workflows/cppcheck-spr-list --quiet --enable=warning -iheaplayers $f 2>>$result_file
           done
 
           echo "errors: `cat $result_file | grep " error: " | wc -l`" > $summary_file


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23908

I can't find an apt-repo to be able to install cppcheck over 1.9.0 version, so I've chosen to download the source and build manually.