### PR TITLE
[CBRD-23913] Allow the inline suppressions of cppcheck

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -151,7 +151,7 @@ jobs:
             *) continue ;; # skip others
             esac
 
-            ${{ env.CPPCHECK_PATH }}/cppcheck --force -j4 --suppressions-list=.github/workflows/cppcheck-spr-list --quiet --enable=warning -iheaplayers $f 2>>$result_file
+            ${{ env.CPPCHECK_PATH }}/cppcheck --force -j4 --inline-suppr --suppressions-list=.github/workflows/cppcheck-spr-list --quiet --enable=warning -iheaplayers $f 2>>$result_file
           done
 
           echo "errors: `cat $result_file | grep " error: " | wc -l`" > $summary_file


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23913

ㅉe are going to suppress each reported line if a developer assignee and reviewers agree an error on the line is a false positive. To do that, `--inline-suppr` option has to be turned.