### PR TITLE
[CBRD-22334] Cursor Holdability on stmt, get wrong results by rs.absolute(num)

### DIFF
--- a/src/query/cursor.c
+++ b/src/query/cursor.c
@@ -996,11 +996,6 @@ cursor_buffer_last_page (CURSOR_ID * cursor_id_p, VPID * vpid_p)
 
   if (cursor_id_p->list_id.last_pgptr && VPID_EQ (&(cursor_id_p->list_id.first_vpid), vpid_p))
     {
-      if (cursor_id_p->buffer == NULL)
-	{
-	  return ER_FAILED;
-	}
-
       cursor_id_p->buffer = cursor_id_p->list_id.last_pgptr;
     }
   else

--- a/src/query/cursor.c
+++ b/src/query/cursor.c
@@ -1001,7 +1001,7 @@ cursor_buffer_last_page (CURSOR_ID * cursor_id_p, VPID * vpid_p)
 	  return ER_FAILED;
 	}
 
-      memcpy (cursor_id_p->buffer, cursor_id_p->list_id.last_pgptr, CURSOR_BUFFER_SIZE);
+      cursor_id_p->buffer = cursor_id_p->list_id.last_pgptr;
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-22334

Purpose
In order to transmit the query result to the client, the error of copying the data of page0 to page1 when reading data from the page in the following order has been corrected.
page0 -> page1 -> page0 

Implementation
N/A

Remarks
N/A