### PR TITLE
[CBRD-23907] POC: implementation of DBLink by cci

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -501,10 +501,11 @@ target_include_directories(cubrid PRIVATE ${JAVA_INC} ${EP_INCLUDES} ${FLEX_INCL
 if(UNIX)
   target_link_libraries(cubrid LINK_PRIVATE -Wl,-whole-archive ${EP_LIBS} -Wl,-no-whole-archive)
   target_link_libraries(cubrid LINK_PUBLIC ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
-  target_link_libraries(cubrid cascci)
 else(UNIX)
   target_link_libraries(cubrid LINK_PRIVATE ${EP_LIBS})
 endif(UNIX)
+# for dblink
+target_link_libraries(cubrid cascci)
 
 add_dependencies(cubrid ${EP_TARGETS} gen_loader_grammar gen_loader_lexer)
 

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -206,6 +206,7 @@ set(QUERY_SOURCES
   ${QUERY_DIR}/filter_pred_cache.c
   ${QUERY_DIR}/list_file.c
   ${QUERY_DIR}/method_scan.c
+  ${QUERY_DIR}/dblink_scan.c
   ${QUERY_DIR}/numeric_opfunc.c
   ${QUERY_DIR}/partition.c
   ${QUERY_DIR}/query_aggregate.cpp
@@ -500,6 +501,7 @@ target_include_directories(cubrid PRIVATE ${JAVA_INC} ${EP_INCLUDES} ${FLEX_INCL
 if(UNIX)
   target_link_libraries(cubrid LINK_PRIVATE -Wl,-whole-archive ${EP_LIBS} -Wl,-no-whole-archive)
   target_link_libraries(cubrid LINK_PUBLIC ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+  target_link_libraries(cubrid cascci)
 else(UNIX)
   target_link_libraries(cubrid LINK_PRIVATE ${EP_LIBS})
 endif(UNIX)

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -633,8 +633,9 @@ if(UNIX)
   # find out what this means:
   # target_link_libraries(cubridsa LINK_PRIVATE -Wl,-whole-archive cas ${EP_LIBS} -Wl,-no-whole-archive)
   target_link_libraries(cubridsa LINK_PUBLIC ${CURSES_LIBRARIES} ${CMAKE_DL_LIBS})
-  target_link_libraries(cubridsa cascci)
 endif(UNIX)
+# for dblink
+target_link_libraries(cubridsa cascci)
 
 add_dependencies(cubridsa gen_csql_grammar gen_csql_lexer gen_loader_grammar gen_loader_lexer)
 #add_dependencies(cubridsa ${EP_TARGETS})

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -243,6 +243,7 @@ set(QUERY_SOURCES
   ${QUERY_DIR}/filter_pred_cache.c
   ${QUERY_DIR}/list_file.c
   ${QUERY_DIR}/method_scan.c
+  ${QUERY_DIR}/dblink_scan.c
   ${QUERY_DIR}/numeric_opfunc.c
   ${QUERY_DIR}/partition.c
   ${QUERY_DIR}/query_aggregate.cpp
@@ -632,6 +633,7 @@ if(UNIX)
   # find out what this means:
   # target_link_libraries(cubridsa LINK_PRIVATE -Wl,-whole-archive cas ${EP_LIBS} -Wl,-no-whole-archive)
   target_link_libraries(cubridsa LINK_PUBLIC ${CURSES_LIBRARIES} ${CMAKE_DL_LIBS})
+  target_link_libraries(cubridsa cascci)
 endif(UNIX)
 
 add_dependencies(cubridsa gen_csql_grammar gen_csql_lexer gen_loader_grammar gen_loader_lexer)

--- a/src/cci/cas_cci.h
+++ b/src/cci/cas_cci.h
@@ -575,12 +575,12 @@ typedef enum
   CUBRID_MAX_STMT_TYPE
 } T_CCI_CUBRID_STMT;
 
+#endif
 typedef int T_CCI_CONN;
 typedef int T_CCI_REQ;
 typedef struct PROPERTIES_T T_CCI_PROPERTIES;
 typedef struct DATASOURCE_T T_CCI_DATASOURCE;
 
-#endif
 #endif
 #define CUBRID_STMT_CALL_SP	0x7e
 #define CUBRID_STMT_UNKNOWN	0x7f

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -5281,7 +5281,7 @@ pt_make_cselect_access_spec (XASL_NODE * xasl, METHOD_SIG_LIST * method_sig_list
  */
 static ACCESS_SPEC_TYPE *
 pt_make_dblink_access_spec (ACCESS_METHOD access, REGU_VARIABLE_LIST attr_list,
-					 char *url, char *user, char *password, char *sql)
+			    char *url, char *user, char *password, char *sql)
 {
   ACCESS_SPEC_TYPE *spec;
 
@@ -12250,25 +12250,26 @@ pt_to_class_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * where_
 		  free_and_init (reserved_offsets);
 		}
 
-	      if (strcmp(table_info->exposed, "dblink"))
-	      	{
-	          access =
-		    pt_make_class_access_spec (parser, flat, class_->info.name.db_object, scan_type, access_method, NULL,
-					       NULL, where, NULL, NULL, regu_attributes_pred, regu_attributes_rest, NULL,
-					       output_val_list, regu_var_list, NULL, cache_pred, cache_rest,
-					       NULL, NO_SCHEMA, db_values_array_p, regu_attributes_reserved);
-	      	}
+	      if (strcmp (table_info->exposed, "dblink"))
+		{
+		  access =
+		    pt_make_class_access_spec (parser, flat, class_->info.name.db_object, scan_type, access_method,
+					       NULL, NULL, where, NULL, NULL, regu_attributes_pred,
+					       regu_attributes_rest, NULL, output_val_list, regu_var_list, NULL,
+					       cache_pred, cache_rest, NULL, NO_SCHEMA, db_values_array_p,
+					       regu_attributes_reserved);
+		}
 	      else
-	        {
+		{
 		  /* this is a temmporal routine for dblink POC */
 		  static char dblink_url[] = "cci:CUBRID:192.168.1.8:55300:demodb:::";
 		  static char dblink_sql[] = "select col1, col2_varchar, col3_big from dblink";
 		  static char dblink_user[] = "dba";
 		  static char dblink_passowrd[] = "";
-		  
-	          access = pt_make_dblink_access_spec(access_method, regu_attributes_rest, 
-		  	dblink_url, dblink_user, dblink_passowrd, dblink_sql);
-	      	}
+
+		  access = pt_make_dblink_access_spec (access_method, regu_attributes_rest,
+						       dblink_url, dblink_user, dblink_passowrd, dblink_sql);
+		}
 	    }
 	  else if (PT_SPEC_SPECIAL_INDEX_SCAN (spec))
 	    {

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -5271,6 +5271,32 @@ pt_make_cselect_access_spec (XASL_NODE * xasl, METHOD_SIG_LIST * method_sig_list
   return spec;
 }
 
+/*
+ * pt_make_dblink_access_spec () - Create an initialized
+ * 				    ACCESS_SPEC_TYPE TARGET_DBLINK structure
+ *   return:
+ *   xasl(in):
+ *   access(in):
+ *   attr_list(in):
+ */
+static ACCESS_SPEC_TYPE *
+pt_make_dblink_access_spec (ACCESS_METHOD access, REGU_VARIABLE_LIST attr_list,
+					 char *url, char *user, char *password, char *sql)
+{
+  ACCESS_SPEC_TYPE *spec;
+
+  spec = pt_make_access_spec (TARGET_DBLINK, access, NULL, NULL, NULL, NULL);
+  if (spec)
+    {
+      spec->s.dblink_node.regu_list_p = attr_list;
+      spec->s.dblink_node.conn_url = url;
+      spec->s.dblink_node.conn_user = user;
+      spec->s.dblink_node.conn_password = password;
+      spec->s.dblink_node.conn_sql = sql;
+    }
+
+  return spec;
+}
 
 /*
  * pt_to_pos_descr () - Translate PT_SORT_SPEC node to QFILE_TUPLE_VALUE_POSITION node
@@ -12224,11 +12250,25 @@ pt_to_class_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * where_
 		  free_and_init (reserved_offsets);
 		}
 
-	      access =
-		pt_make_class_access_spec (parser, flat, class_->info.name.db_object, scan_type, access_method, NULL,
-					   NULL, where, NULL, NULL, regu_attributes_pred, regu_attributes_rest, NULL,
-					   output_val_list, regu_var_list, NULL, cache_pred, cache_rest,
-					   NULL, NO_SCHEMA, db_values_array_p, regu_attributes_reserved);
+	      if (strcmp(table_info->exposed, "dblink"))
+	      	{
+	          access =
+		    pt_make_class_access_spec (parser, flat, class_->info.name.db_object, scan_type, access_method, NULL,
+					       NULL, where, NULL, NULL, regu_attributes_pred, regu_attributes_rest, NULL,
+					       output_val_list, regu_var_list, NULL, cache_pred, cache_rest,
+					       NULL, NO_SCHEMA, db_values_array_p, regu_attributes_reserved);
+	      	}
+	      else
+	        {
+		  /* this is a temmporal routine for dblink POC */
+		  static char dblink_url[] = "cci:CUBRID:192.168.1.8:55300:demodb:::";
+		  static char dblink_sql[] = "select col1, col2_varchar, col3_big from dblink";
+		  static char dblink_user[] = "dba";
+		  static char dblink_passowrd[] = "";
+		  
+	          access = pt_make_dblink_access_spec(access_method, regu_attributes_rest, 
+		  	dblink_url, dblink_user, dblink_passowrd, dblink_sql);
+	      	}
 	    }
 	  else if (PT_SPEC_SPECIAL_INDEX_SCAN (spec))
 	    {

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -1,5 +1,4 @@
 /*
- * Copyright 2008 Search Solution Corporation
  * Copyright 2016 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -263,7 +262,7 @@ dblink_scan_next (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p, R
 	{
 	  valptrp->value.vfetch_to->domain.general_info.is_null = 0;
 	  value = valptrp->value.vfetch_to->data.p;
-	  switch (utype = (T_CCI_U_TYPE)CCI_GET_RESULT_INFO_TYPE (scan_buffer_p->col_info, col_no))
+	  switch (utype = (T_CCI_U_TYPE) CCI_GET_RESULT_INFO_TYPE (scan_buffer_p->col_info, col_no))
 	    {
 	    case CCI_U_TYPE_NULL:
 	      valptrp->value.vfetch_to->domain.general_info.is_null = 1;
@@ -284,7 +283,7 @@ dblink_scan_next (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p, R
 		{
 		  scan_result = S_ERROR;
 		}
-	      memcpy(valptrp->value.vfetch_to->data.num.d.buf, (char *) value, strlen((char *)value));
+	      memcpy (valptrp->value.vfetch_to->data.num.d.buf, (char *) value, strlen ((char *) value));
 	      break;
 	    case CCI_U_TYPE_STRING:
 	    case CCI_U_TYPE_VARNCHAR:

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ident "$Id$"
+
+#include "config.h"
+
+#include <string.h>
+
+#include "dblink_scan.h"
+
+#include "network_interface_sr.h"	/* TODO: should not be here */
+
+#ifndef	SERVER_MODE
+#include "object_accessor.h"
+#include "dbi.h"
+#include "authenticate.h"
+#endif
+
+#include "xasl.h"
+
+#include "dbtype.h"
+#include "object_primitive.h"
+#include "object_representation.h"
+#include "query_list.h"
+#include "regu_var.hpp"
+
+#ifndef DBDEF_HEADER_
+#define DBDEF_HEADER_
+#endif
+
+#include "db_date.h"
+#include "tz_support.h"
+#include <cas_cci.h>
+
+/*
+ * dblink_scan.c - Routines to implement scanning the values
+ *                 received by the cci interface
+ */
+
+static int type_map[] = {
+  0,
+  CCI_A_TYPE_STR,		/* CCI_U_TYPE_CHAR */
+  CCI_A_TYPE_STR,		/* CCI_U_TYPE_STRING */
+  CCI_A_TYPE_STR,		/* CCI_U_TYPE_NCHAR */
+  CCI_A_TYPE_STR,		/* CCI_U_TYPE_VARNCHAR */
+  CCI_A_TYPE_BIT,		/* CCI_U_TYPE_BIT */
+  CCI_A_TYPE_BIT,		/* CCI_U_TYPE_VARBIT */
+  CCI_A_TYPE_STR,		/* CCI_U_TYPE_NUMERIC */
+  CCI_A_TYPE_INT,		/* CCI_U_TYPE_INT */
+  CCI_A_TYPE_INT,		/* CCI_U_TYPE_SHORT */
+  CCI_A_TYPE_DOUBLE,		/* CCI_U_TYPE_MONETARY */
+  CCI_A_TYPE_FLOAT,		/* CCI_U_TYPE_FLOAT */
+  CCI_A_TYPE_DOUBLE,		/* CCI_U_TYPE_DOUBLE */
+  CCI_A_TYPE_DATE,		/* CCI_U_TYPE_DATE */
+  CCI_A_TYPE_DATE,		/* CCI_U_TYPE_TIME */
+  CCI_A_TYPE_DATE,		/* CCI_U_TYPE_TIMESTAMP */
+  CCI_A_TYPE_SET,		/* CCI_U_TYPE_SET */
+  CCI_A_TYPE_SET,		/* CCI_U_TYPE_MULTISET */
+  CCI_A_TYPE_SET,		/* CCI_U_TYPE_SEQUENCE */
+  0,				/* CCI_U_TYPE_OBJECT */
+  0,				/* CCI_U_TYPE_RESULTSET */
+  CCI_A_TYPE_BIGINT,		/* CCI_U_TYPE_BIGINT */
+  CCI_A_TYPE_DATE,		/* CCI_U_TYPE_DATETIME */
+  0,				/* CCI_U_TYPE_BLOB */
+  0,				/* CCI_U_TYPE_CLOB */
+  CCI_A_TYPE_STR,		/* CCI_U_TYPE_ENUM */
+  CCI_A_TYPE_UINT,		/* CCI_U_TYPE_USHORT */
+  CCI_A_TYPE_UINT,		/* CCI_U_TYPE_UINT */
+  CCI_A_TYPE_UBIGINT,		/* CCI_U_TYPE_UBIGINT */
+  CCI_A_TYPE_DATE_TZ,		/* CCI_U_TYPE_TIMESTAMPTZ */
+  CCI_A_TYPE_DATE_TZ,		/* CCI_U_TYPE_TIMESTAMPLTZ */
+  CCI_A_TYPE_DATE_TZ,		/* CCI_U_TYPE_DATETIMETZ */
+  CCI_A_TYPE_DATE_TZ,		/* CCI_U_TYPE_DATETIMELTZ */
+  /* Disabled type */
+  CCI_A_TYPE_DATE_TZ,		/* CCI_U_TYPE_TIMETZ - internal only, RESERVED */
+  /* end of disabled types */
+  CCI_A_TYPE_STR		/* CCI_U_TYPE_JSON */
+};
+
+static void
+dblink_make_date_time (T_CCI_U_TYPE utype, DB_VALUE * value_p, T_CCI_DATE * date_time)
+{
+  DB_TIME t_time;
+  DB_DATE t_date;
+  DB_DATETIME t_datetime;
+  DB_TIMESTAMP t_timestamp;
+
+  switch (utype)
+    {
+    case CCI_U_TYPE_TIME:
+      db_make_time (value_p, date_time->hh, date_time->mm, date_time->ss);
+      break;
+    case CCI_U_TYPE_DATE:
+      db_make_date (value_p, date_time->mon, date_time->day, date_time->yr);
+      break;
+    case CCI_U_TYPE_DATETIME:
+      db_datetime_encode (&t_datetime, date_time->mon, date_time->day, date_time->yr,
+			  date_time->hh, date_time->mm, date_time->ss, date_time->ms);
+      db_make_datetime (value_p, &t_datetime);
+      break;
+    case CCI_U_TYPE_TIMESTAMP:
+      db_time_encode (&t_time, date_time->hh, date_time->mm, date_time->ss);
+      db_date_encode (&t_date, date_time->mon, date_time->day, date_time->yr);
+      db_timestamp_encode (&t_timestamp, &t_date, &t_time);
+      db_make_timestamp (value_p, t_timestamp);
+      break;
+    default:
+      break;
+    }
+}
+
+static void
+dblink_make_date_time_tz (T_CCI_U_TYPE utype, DB_VALUE * value_p, T_CCI_DATE_TZ * date_time_tz)
+{
+  DB_TIME t_time;
+  DB_DATE t_date;
+  DB_DATETIME t_datetime;
+  DB_DATETIMETZ tz_datetime;
+  DB_TIMESTAMPTZ tz_timestamp;
+  TZ_REGION region;
+
+  switch (utype)
+    {
+    case CCI_U_TYPE_TIMESTAMPTZ:
+      db_time_encode (&t_time, date_time_tz->hh, date_time_tz->mm, date_time_tz->ss);
+      db_date_encode (&t_date, date_time_tz->mon, date_time_tz->day, date_time_tz->yr);
+      tz_create_timestamptz (&t_date, &t_time, date_time_tz->tz, strlen (date_time_tz->tz), &region, &tz_timestamp,
+			     NULL);
+      db_make_timestamptz (value_p, &tz_timestamp);
+      break;
+    case CCI_U_TYPE_DATETIMETZ:
+      db_datetime_encode (&t_datetime, date_time_tz->mon, date_time_tz->day, date_time_tz->yr,
+			  date_time_tz->hh, date_time_tz->mm, date_time_tz->ss, date_time_tz->ms);
+      tz_create_datetimetz (&t_datetime, date_time_tz->tz, strlen (date_time_tz->tz), &region, &tz_datetime, NULL);
+      db_make_datetimetz (value_p, &tz_datetime);
+      break;
+    case CCI_U_TYPE_TIMESTAMPLTZ:
+      db_time_encode (&t_time, date_time_tz->hh, date_time_tz->mm, date_time_tz->ss);
+      db_date_encode (&t_date, date_time_tz->mon, date_time_tz->day, date_time_tz->yr);
+      tz_create_timestamptz (&t_date, &t_time, date_time_tz->tz, strlen (date_time_tz->tz), &region, &tz_timestamp,
+			     NULL);
+      db_make_timestampltz (value_p, tz_timestamp.timestamp);
+      break;
+    case CCI_U_TYPE_DATETIMELTZ:
+      db_datetime_encode (&t_datetime, date_time_tz->mon, date_time_tz->day, date_time_tz->yr,
+			  date_time_tz->hh, date_time_tz->mm, date_time_tz->ss, date_time_tz->ms);
+      tz_create_datetimetz (&t_datetime, date_time_tz->tz, strlen (date_time_tz->tz), &region, &tz_datetime, NULL);
+      db_make_datetimeltz (value_p, &tz_datetime.datetime);
+      break;
+    default:
+      break;
+    }
+}
+
+/*
+ * dblink_open_scan () -
+ *   return: int
+ *   scan_buf(in)       : Value array buffer
+ *   list_id(in)        :
+ */
+int
+dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p,
+		  char *conn_url, char *user_name, char *password, char *sql_text)
+{
+  int ret, error;
+  T_CCI_ERROR err_buf;
+  T_CCI_CUBRID_STMT stmt_type;
+
+  scan_buffer_p->conn_handle = cci_connect_with_url_ex (conn_url, user_name, password, &err_buf);
+
+  if (scan_buffer_p->conn_handle < 0)
+    {
+      error = err_buf.err_code;
+    }
+  else
+    {
+      scan_buffer_p->stmt_handle = cci_prepare_and_execute (scan_buffer_p->conn_handle, sql_text, 0, &ret, &err_buf);
+      if (ret < 0)
+	{
+	  error = err_buf.err_code;
+	}
+      else
+	{
+	  scan_buffer_p->col_info = (void *) cci_get_result_info (scan_buffer_p->stmt_handle,
+								  &stmt_type, &scan_buffer_p->col_cnt);
+	  if (scan_buffer_p->col_info == NULL)
+	    {
+	      error = S_ERROR;
+	    }
+	}
+    }
+
+  return NO_ERROR;
+}
+
+/*
+ * dblink_close_scan () -
+ *   return: int
+ *   scan_buf(in)       : Value array buffer
+ */
+int
+dblink_close_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p)
+{
+  T_CCI_ERROR err_buf;
+  cci_close_req_handle (scan_buffer_p->stmt_handle);
+  cci_disconnect (scan_buffer_p->conn_handle, &err_buf);
+
+  return NO_ERROR;
+}
+
+/*
+ * dblink_scan_next () -
+ *   return: int
+ *   scan_buf(in)       : Value array buffer
+ *   val_list(in)       :
+ */
+SCAN_CODE
+dblink_scan_next (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p, REGU_VARIABLE_LIST regu_list_p)
+{
+  SCAN_CODE scan_result = S_SUCCESS;
+  T_CCI_ERROR err_buf;
+  int col_no, col_cnt, ind, error;
+  T_CCI_U_TYPE utype;
+  void *value;
+  DB_VALUE *value_p;
+  T_CCI_DATE date_time;
+  T_CCI_DATE_TZ date_time_tz;
+  T_CCI_BIT bit_value;
+  REGU_VARIABLE_LIST valptrp;
+
+  col_cnt = scan_buffer_p->col_cnt;
+
+  if (scan_buffer_p->stmt_handle >= 0)
+    {
+      if ((error = cci_cursor (scan_buffer_p->stmt_handle, 1, CCI_CURSOR_CURRENT, &err_buf)) < 0)
+	{
+	  if (error == CCI_ER_NO_MORE_DATA)
+	    {
+	      return S_END;
+	    }
+	}
+      if (cci_fetch (scan_buffer_p->stmt_handle, &err_buf))
+	{
+	  return S_ERROR;
+	}
+      for (valptrp = regu_list_p, col_no = 1; col_no <= col_cnt; col_no++, valptrp = valptrp->next)
+	{
+	  valptrp->value.vfetch_to->domain.general_info.is_null = 0;
+	  value = valptrp->value.vfetch_to->data.p;
+	  switch (utype = (T_CCI_U_TYPE)CCI_GET_RESULT_INFO_TYPE (scan_buffer_p->col_info, col_no))
+	    {
+	    case CCI_U_TYPE_NULL:
+	      valptrp->value.vfetch_to->domain.general_info.is_null = 1;
+	      break;
+	    case CCI_U_TYPE_BIGINT:
+	    case CCI_U_TYPE_INT:
+	    case CCI_U_TYPE_FLOAT:
+	    case CCI_U_TYPE_DOUBLE:
+	    case CCI_U_TYPE_MONETARY:
+	      value = valptrp->value.vfetch_to->data.p;
+	      if (cci_get_data (scan_buffer_p->stmt_handle, col_no, type_map[utype], &value, &ind) < 0)
+		{
+		  scan_result = S_ERROR;
+		}
+	      break;
+	    case CCI_U_TYPE_NUMERIC:
+	      if (cci_get_data (scan_buffer_p->stmt_handle, col_no, type_map[utype], &value, &ind) < 0)
+		{
+		  scan_result = S_ERROR;
+		}
+	      memcpy(valptrp->value.vfetch_to->data.num.d.buf, (char *) value, strlen((char *)value));
+	      break;
+	    case CCI_U_TYPE_STRING:
+	    case CCI_U_TYPE_VARNCHAR:
+	    case CCI_U_TYPE_CHAR:
+	    case CCI_U_TYPE_NCHAR:
+	    case CCI_U_TYPE_BIT:
+	    case CCI_U_TYPE_VARBIT:
+	      if (cci_get_data (scan_buffer_p->stmt_handle, col_no, type_map[utype], &value, &ind) < 0)
+		{
+		  scan_result = S_ERROR;
+		}
+	      valptrp->value.vfetch_to->data.ch.medium.buf = (char *) value;
+	      valptrp->value.vfetch_to->data.ch.medium.size = strlen ((char *) value);
+	      break;
+	    case CCI_U_TYPE_DATE:
+	    case CCI_U_TYPE_TIME:
+	    case CCI_U_TYPE_TIMESTAMP:
+	    case CCI_U_TYPE_DATETIME:
+	      value_p = valptrp->value.vfetch_to;
+	      if (cci_get_data (scan_buffer_p->stmt_handle, col_no, type_map[utype], &date_time, &ind) < 0)
+		{
+		  scan_result = S_ERROR;
+		}
+	      dblink_make_date_time (utype, value_p, &date_time);
+	      break;
+	    case CCI_U_TYPE_DATETIMETZ:
+	    case CCI_U_TYPE_DATETIMELTZ:
+	    case CCI_U_TYPE_TIMESTAMPTZ:
+	    case CCI_U_TYPE_TIMESTAMPLTZ:
+	      value_p = valptrp->value.vfetch_to;
+	      if (cci_get_data (scan_buffer_p->stmt_handle, col_no, type_map[utype], &date_time_tz, &ind) < 0)
+		{
+		  scan_result = S_ERROR;
+		}
+	      break;
+	      dblink_make_date_time_tz (utype, value_p, &date_time_tz);
+	      break;
+	    case CCI_U_TYPE_JSON:
+	    default:
+	      valptrp->value.vfetch_to->domain.general_info.is_null = 1;
+	      break;
+	    }
+	}
+    }
+  return scan_result;
+}

--- a/src/query/dblink_scan.h
+++ b/src/query/dblink_scan.h
@@ -1,5 +1,4 @@
 /*
- * Copyright 2008 Search Solution Corporation
  * Copyright 2016 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,15 +45,16 @@ struct regu_variable_list_node;
 typedef struct dblink_scan_buffer DBLINK_SCAN_BUFFER;
 struct dblink_scan_buffer
 {				/* value array scanbuf */
- int conn_handle;
- int stmt_handle;
- int col_cnt;
- void *col_info;
+  int conn_handle;
+  int stmt_handle;
+  int col_cnt;
+  void *col_info;
 };
 
 extern int dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p,
-			char *conn_url, char *user_name, char *password, char *sql_text);
+			     char *conn_url, char *user_name, char *password, char *sql_text);
 extern int dblink_close_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buf);
-extern SCAN_CODE dblink_scan_next (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p, regu_variable_list_node * value_list_p);
+extern SCAN_CODE dblink_scan_next (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p,
+				   regu_variable_list_node * value_list_p);
 
 #endif

--- a/src/query/dblink_scan.h
+++ b/src/query/dblink_scan.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+
+/*
+ * Public defines for value array scans
+ */
+
+#ifndef _DBLINK_SCAN_H_
+#define _DBLINK_SCAN_H_
+
+#ident "$Id$"
+
+#if !defined (SERVER_MODE) && !defined (SA_MODE)
+#error Belongs to server module
+#endif /* !defined (SERVER_MODE) && !defined (SA_MODE) */
+
+#include "dbtype_def.h"
+#include "storage_common.h"
+#include "thread_compat.hpp"
+
+typedef enum
+{
+  DBLINK_SUCCESS = 1,
+  DBLINK_EOF,
+  DBLINK_ERROR
+} DBLINK_STATUS;
+
+struct regu_variable_list_node;
+
+typedef struct dblink_scan_buffer DBLINK_SCAN_BUFFER;
+struct dblink_scan_buffer
+{				/* value array scanbuf */
+ int conn_handle;
+ int stmt_handle;
+ int col_cnt;
+ void *col_info;
+};
+
+extern int dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p,
+			char *conn_url, char *user_name, char *password, char *sql_text);
+extern int dblink_close_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buf);
+extern SCAN_CODE dblink_scan_next (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p, regu_variable_list_node * value_list_p);
+
+#endif

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -6714,13 +6714,12 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 	}
       break;
     case TARGET_DBLINK:
-    	error_code =
-	  scan_open_dblink_scan (thread_p, s_id,
-	  			curr_spec->s.dblink_node.conn_url,
-	  			curr_spec->s.dblink_node.conn_user,
-	  			curr_spec->s.dblink_node.conn_password,
-	  			curr_spec->s.dblink_node.conn_sql,
-	  			curr_spec->s.dblink_node.regu_list_p);
+      error_code =
+	scan_open_dblink_scan (thread_p, s_id,
+			       curr_spec->s.dblink_node.conn_url,
+			       curr_spec->s.dblink_node.conn_user,
+			       curr_spec->s.dblink_node.conn_password,
+			       curr_spec->s.dblink_node.conn_sql, curr_spec->s.dblink_node.regu_list_p);
       break;
     default:
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_XASLNODE, 0);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -6713,7 +6713,15 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 	  goto exit_on_error;
 	}
       break;
-
+    case TARGET_DBLINK:
+    	error_code =
+	  scan_open_dblink_scan (thread_p, s_id,
+	  			curr_spec->s.dblink_node.conn_url,
+	  			curr_spec->s.dblink_node.conn_user,
+	  			curr_spec->s.dblink_node.conn_password,
+	  			curr_spec->s.dblink_node.conn_sql,
+	  			curr_spec->s.dblink_node.regu_list_p);
+      break;
     default:
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_XASLNODE, 0);
       error_code = ER_QPROC_INVALID_XASLNODE;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3979,37 +3979,25 @@ scan_open_method_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
  * scan_open_dblink_scan () -
  *   return: NO_ERROR, or ER_code
  *   scan_id(out): Scan identifier
- *   grouped(in):
- *   single_fetch(in):
- *   join_dbval(in):
- *   val_list(in):
- *   vd(in):
- *   list_id(in):
+ *   conn_url(in):
+ *   conn_user(in):
+ *   conn_password(in):
+ *   sql_text(in):
  *
- * Note: If you feel the need
  */
 int
 scan_open_dblink_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
-				  char * conn_url,
-				  char * conn_user,
-				  char * conn_password,
-				  char * sql_text,
-				  REGU_VARIABLE_LIST regu_list_p
-		       )
+		       char *conn_url,
+		       char *conn_user, char *conn_password, char *sql_text, REGU_VARIABLE_LIST regu_list_p)
 {
   /* scan type is DBLINK SCAN */
   scan_id->type = S_DBLINK_SCAN;
   scan_id->s.dblid.regu_list_p = regu_list_p;
-  
+
   /* initialize SCAN_ID structure */
   scan_init_scan_id (scan_id, false, S_SELECT, true, 0, QPROC_NO_SINGLE_INNER, NULL, NULL, NULL);
 
-  return dblink_open_scan (thread_p, &scan_id->s.dblid.scan_buf,
-  				conn_url,
-  				conn_user,
-  				conn_password,
-  				sql_text
-  			   );
+  return dblink_open_scan (thread_p, &scan_id->s.dblid.scan_buf, conn_url, conn_user, conn_password, sql_text);
 }
 
 /*
@@ -5089,7 +5077,7 @@ scan_next_scan_local (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
     case S_DBLINK_SCAN:
       status = scan_next_dblink_scan (thread_p, scan_id);
-	  break;
+      break;
 
     default:
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_XASLNODE, 0);
@@ -8082,7 +8070,7 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
 	    }
 	  else if (llsidp->hlsid.hash_list_scan_yn == HASH_METH_HYBRID)
 	    {
-	      MAKE_TUPLE_POSTION(tuple_pos, hvalue->pos, scan_id_p);
+	      MAKE_TUPLE_POSTION (tuple_pos, hvalue->pos, scan_id_p);
 	      if (qfile_jump_scan_tuple_position (thread_p, scan_id_p, &tuple_pos, &tplrec, PEEK) != S_SUCCESS)
 		{
 		  return S_ERROR;
@@ -8113,7 +8101,7 @@ scan_hash_probe_next (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, QFILE_TUPLE * 
 	  else if (llsidp->hlsid.hash_list_scan_yn == HASH_METH_HYBRID)
 	    {
 	      simple_pos = ((HASH_SCAN_VALUE *) llsidp->hlsid.curr_hash_entry->data)->pos;
-	      MAKE_TUPLE_POSTION(tuple_pos, simple_pos, scan_id_p);
+	      MAKE_TUPLE_POSTION (tuple_pos, simple_pos, scan_id_p);
 
 	      if (qfile_jump_scan_tuple_position (thread_p, scan_id_p, &tuple_pos, &tplrec, PEEK) != S_SUCCESS)
 		{
@@ -8225,11 +8213,11 @@ check_hash_list_scan (LLIST_SCAN_ID * llsidp, int *val_cnt, int hash_list_scan_y
     {
       return HASH_METH_IN_MEM;
     }
-  else if ((UINT64) llsidp->list_id->tuple_cnt * (sizeof(HENTRY_HLS) + sizeof(QFILE_TUPLE_SIMPLE_POS)) <= mem_limit)
+  else if ((UINT64) llsidp->list_id->tuple_cnt * (sizeof (HENTRY_HLS) + sizeof (QFILE_TUPLE_SIMPLE_POS)) <= mem_limit)
     {
       /* bytes of 1 row = sizeof(HENTRY_HLS) + sizeof(QFILE_TUPLE_SIMPLE_POS) = 36 bytes (64bit) */
-      /* HENTRY_HLS = pointer(8bytes) * 3 = 24 bytes*/
-      /* SIMPLE_POS = pageid(4bytes) + voldid(2bytes) + padding(2bytes) + offset(4bytes) = 12 bytes*/
+      /* HENTRY_HLS = pointer(8bytes) * 3 = 24 bytes */
+      /* SIMPLE_POS = pageid(4bytes) + voldid(2bytes) + padding(2bytes) + offset(4bytes) = 12 bytes */
       return HASH_METH_HYBRID;
     }
   else

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -472,11 +472,8 @@ extern int scan_open_method_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 				  /* */
 				  QFILE_LIST_ID * list_id, method_sig_list * meth_sig_list);
 extern int scan_open_dblink_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
-				  char * conn_url,
-				  char * conn_user,
-				  char * conn_password,
-				  char * sql_text,
-				  REGU_VARIABLE_LIST regu_list_p);
+				  char *conn_url,
+				  char *conn_user, char *conn_password, char *sql_text, REGU_VARIABLE_LIST regu_list_p);
 
 extern int scan_start_scan (THREAD_ENTRY * thread_p, SCAN_ID * s_id);
 extern SCAN_CODE scan_reset_scan_block (THREAD_ENTRY * thread_p, SCAN_ID * s_id);

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -38,6 +38,7 @@
 #include "btree.h"		/* TODO: for BTREE_SCAN */
 #include "heap_file.h"		/* for HEAP_SCANCACHE */
 #include "method_scan.h"	/* for METHOD_SCAN_BUFFER */
+#include "dblink_scan.h"
 #include "oid.h"		/* for OID */
 #include "query_evaluator.h"
 #include "query_list.h"
@@ -87,8 +88,16 @@ typedef enum
 				 * through all slots even if they do not contain data. */
   S_HEAP_PAGE_SCAN,		/* scans heap pages and queries for page information */
   S_INDX_KEY_INFO_SCAN,		/* scans b-tree and queries for key info */
-  S_INDX_NODE_INFO_SCAN		/* scans b-tree nodes for info */
+  S_INDX_NODE_INFO_SCAN,	/* scans b-tree nodes for info */
+  S_DBLINK_SCAN			/* scans dblink */
 } SCAN_TYPE;
+
+typedef struct dblink_scan_id DBLINK_SCAN_ID;
+struct dblink_scan_id
+{
+  DBLINK_SCAN_BUFFER scan_buf;	/* value array buffer */
+  REGU_VARIABLE_LIST regu_list_p;
+};
 
 typedef struct heap_scan_id HEAP_SCAN_ID;
 struct heap_scan_id
@@ -356,6 +365,7 @@ struct scan_id_struct
     INDEX_NODE_SCAN_ID insid;	/* Scan b-tree nodes */
     SET_SCAN_ID ssid;		/* Set Scan Identifier */
     VA_SCAN_ID vaid;		/* Value Array Identifier */
+    DBLINK_SCAN_ID dblid;	/* DBLink Array Identifier */
     REGU_VALUES_SCAN_ID rvsid;	/* regu_variable list identifier */
     SHOWSTMT_SCAN_ID stsid;	/* show stmt identifier */
     JSON_TABLE_SCAN_ID jtid;
@@ -461,6 +471,13 @@ extern int scan_open_method_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 				  val_list_node * val_list, val_descr * vd,
 				  /* */
 				  QFILE_LIST_ID * list_id, method_sig_list * meth_sig_list);
+extern int scan_open_dblink_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
+				  char * conn_url,
+				  char * conn_user,
+				  char * conn_password,
+				  char * sql_text,
+				  REGU_VARIABLE_LIST regu_list_p);
+
 extern int scan_start_scan (THREAD_ENTRY * thread_p, SCAN_ID * s_id);
 extern SCAN_CODE scan_reset_scan_block (THREAD_ENTRY * thread_p, SCAN_ID * s_id);
 extern SCAN_CODE scan_next_scan_block (THREAD_ENTRY * thread_p, SCAN_ID * s_id);

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -5052,10 +5052,10 @@ stx_build_dblink_spec_type (THREAD_ENTRY * thread_p, char *ptr, DBLINK_SPEC_TYPE
 
   //ptr = or_unpack_int (ptr, &offset);
 
-  dblink_spec->conn_url = stx_restore_string(thread_p, ptr);
-  dblink_spec->conn_user = stx_restore_string(thread_p, ptr);
-  dblink_spec->conn_password = stx_restore_string(thread_p, ptr);
-  dblink_spec->conn_sql = stx_restore_string(thread_p, ptr);
+  dblink_spec->conn_url = stx_restore_string (thread_p, ptr);
+  dblink_spec->conn_user = stx_restore_string (thread_p, ptr);
+  dblink_spec->conn_password = stx_restore_string (thread_p, ptr);
+  dblink_spec->conn_sql = stx_restore_string (thread_p, ptr);
 
   return ptr;
 }

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -118,6 +118,7 @@ static char *stx_build_rlist_spec_type (THREAD_ENTRY * thread_p, char *ptr, REGU
 					OUTPTR_LIST * outptr_list);
 static char *stx_build_set_spec_type (THREAD_ENTRY * thread_p, char *tmp, SET_SPEC_TYPE * ptr);
 static char *stx_build_method_spec_type (THREAD_ENTRY * thread_p, char *tmp, METHOD_SPEC_TYPE * ptr);
+static char *stx_build_dblink_spec_type (THREAD_ENTRY * thread_p, char *ptr, DBLINK_SPEC_TYPE * dblink_spec);
 static char *stx_build_val_list (THREAD_ENTRY * thread_p, char *tmp, VAL_LIST * ptr);
 #if defined(ENABLE_UNUSED_FUNCTION)
 static char *stx_build_db_value_list (THREAD_ENTRY * thread_p, char *tmp, QPROC_DB_VALUE_LIST ptr);
@@ -4349,6 +4350,10 @@ stx_build_access_spec_type (THREAD_ENTRY * thread_p, char *ptr, ACCESS_SPEC_TYPE
       ptr = stx_build (thread_p, ptr, ACCESS_SPEC_JSON_TABLE_SPEC (access_spec));
       break;
 
+    case TARGET_DBLINK:
+      ptr = stx_build_dblink_spec_type (thread_p, ptr, &ACCESS_SPEC_DBLINK_SPEC (access_spec));
+      break;
+
     default:
       stx_set_xasl_errcode (thread_p, ER_QPROC_INVALID_XASLNODE);
       return NULL;
@@ -5020,6 +5025,37 @@ stx_build_method_spec_type (THREAD_ENTRY * thread_p, char *ptr, METHOD_SPEC_TYPE
 	  return NULL;
 	}
     }
+
+  return ptr;
+}
+
+static char *
+stx_build_dblink_spec_type (THREAD_ENTRY * thread_p, char *ptr, DBLINK_SPEC_TYPE * dblink_spec)
+{
+  int offset;
+  XASL_UNPACK_INFO *xasl_unpack_info = get_xasl_unpack_info_ptr (thread_p);
+
+  ptr = or_unpack_int (ptr, &offset);
+  if (offset == 0)
+    {
+      dblink_spec->regu_list_p = NULL;
+    }
+  else
+    {
+      dblink_spec->regu_list_p = stx_restore_regu_variable_list (thread_p, &xasl_unpack_info->packed_xasl[offset]);
+      if (dblink_spec->regu_list_p == NULL)
+	{
+	  stx_set_xasl_errcode (thread_p, ER_OUT_OF_VIRTUAL_MEMORY);
+	  return NULL;
+	}
+    }
+
+  //ptr = or_unpack_int (ptr, &offset);
+
+  dblink_spec->conn_url = stx_restore_string(thread_p, ptr);
+  dblink_spec->conn_user = stx_restore_string(thread_p, ptr);
+  dblink_spec->conn_password = stx_restore_string(thread_p, ptr);
+  dblink_spec->conn_sql = stx_restore_string(thread_p, ptr);
 
   return ptr;
 }

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -797,7 +797,7 @@ union hybrid_node
   SHOWSTMT_SPEC_TYPE showstmt_node;	/* show stmt specification */
   SET_SPEC_TYPE set_node;	/* set specification */
   METHOD_SPEC_TYPE method_node;	/* method specification */
-  DBLINK_SPEC_TYPE dblink_node; /* dblink specification */
+  DBLINK_SPEC_TYPE dblink_node;	/* dblink specification */
   REGUVAL_LIST_SPEC_TYPE reguval_list_node;	/* reguval_list specification */
   json_table_spec_node json_table_node;	/* json_table specification */
 };				/* class/list access specification */
@@ -880,7 +880,7 @@ union hybrid_node
 
 #define ACCESS_SPEC_DBLINK_SPEC(ptr) \
 	((ptr)->s.dblink_node)
-	
+
 #define ACCESS_SPEC_DBLINK_XASL_NODE(ptr) \
 	((ptr)->s.dblink_node.xasl_node)
 

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -131,6 +131,7 @@ typedef struct list_spec_node LIST_SPEC_TYPE;
 typedef struct showstmt_spec_node SHOWSTMT_SPEC_TYPE;
 typedef struct set_spec_node SET_SPEC_TYPE;
 typedef struct method_spec_node METHOD_SPEC_TYPE;
+typedef struct dblink_spec_node DBLINK_SPEC_TYPE;
 typedef struct reguval_list_spec_node REGUVAL_LIST_SPEC_TYPE;
 typedef union hybrid_node HYBRID_NODE;
 
@@ -681,7 +682,8 @@ typedef enum
   TARGET_JSON_TABLE,
   TARGET_METHOD,
   TARGET_REGUVAL_LIST,
-  TARGET_SHOWSTMT
+  TARGET_SHOWSTMT,
+  TARGET_DBLINK
 } TARGET_TYPE;
 
 typedef enum
@@ -774,6 +776,15 @@ struct method_spec_node
   METHOD_SIG_LIST *method_sig_list;	/* method signature list */
 };
 
+struct dblink_spec_node
+{
+  REGU_VARIABLE_LIST regu_list_p;	/* regulator variable list */
+  char *conn_url;		/* connection URL for remote DB server */
+  char *conn_user;		/* user name for remote DB server */
+  char *conn_password;		/* password for remote user */
+  char *conn_sql;		/* SQL command text for remote database */
+};
+
 struct reguval_list_spec_node
 {
   VALPTR_LIST *valptr_list;	/* point to xasl.outptr_list */
@@ -786,6 +797,7 @@ union hybrid_node
   SHOWSTMT_SPEC_TYPE showstmt_node;	/* show stmt specification */
   SET_SPEC_TYPE set_node;	/* set specification */
   METHOD_SPEC_TYPE method_node;	/* method specification */
+  DBLINK_SPEC_TYPE dblink_node; /* dblink specification */
   REGUVAL_LIST_SPEC_TYPE reguval_list_node;	/* reguval_list specification */
   json_table_spec_node json_table_node;	/* json_table specification */
 };				/* class/list access specification */
@@ -865,6 +877,15 @@ union hybrid_node
 
 #define ACCESS_SPEC_JSON_TABLE_M_NODE_COUNT(ptr) \
         ((ptr)->s.json_table_node.m_node_count)
+
+#define ACCESS_SPEC_DBLINK_SPEC(ptr) \
+	((ptr)->s.dblink_node)
+	
+#define ACCESS_SPEC_DBLINK_XASL_NODE(ptr) \
+	((ptr)->s.dblink_node.xasl_node)
+
+#define ACCESS_SPEC_DBLINK_LIST_ID(ptr) \
+	(ACCESS_SPEC_DBLINK_XASL_NODE(ptr)->list_id)
 
 #if defined (SERVER_MODE) || defined (SA_MODE)
 struct orderby_stat

--- a/src/query/xasl_to_stream.c
+++ b/src/query/xasl_to_stream.c
@@ -4420,7 +4420,7 @@ xts_process_access_spec_type (char *ptr, const ACCESS_SPEC_TYPE * access_spec)
     case TARGET_DBLINK:
       ptr = xts_process_dblink_spec_type (ptr, &ACCESS_SPEC_DBLINK_SPEC (access_spec));
       break;
- 
+
     default:
       xts_Xasl_errcode = ER_QPROC_INVALID_XASLNODE;
       return NULL;
@@ -4945,28 +4945,28 @@ xts_process_dblink_spec_type (char *ptr, const DBLINK_SPEC_TYPE * dblink_spec)
     }
   ptr = or_pack_int (ptr, offset);
 
-  offset = xts_save_string(dblink_spec->conn_url);
+  offset = xts_save_string (dblink_spec->conn_url);
   if (offset == ER_FAILED)
     {
       return NULL;
     }
   ptr = or_pack_int (ptr, offset);
 
-  offset = xts_save_string(dblink_spec->conn_user);
+  offset = xts_save_string (dblink_spec->conn_user);
   if (offset == ER_FAILED)
     {
       return NULL;
     }
   ptr = or_pack_int (ptr, offset);
 
-  offset = xts_save_string(dblink_spec->conn_password);
+  offset = xts_save_string (dblink_spec->conn_password);
   if (offset == ER_FAILED)
     {
       return NULL;
     }
   ptr = or_pack_int (ptr, offset);
 
-  offset = xts_save_string(dblink_spec->conn_sql);
+  offset = xts_save_string (dblink_spec->conn_sql);
   if (offset == ER_FAILED)
     {
       return NULL;

--- a/src/query/xasl_to_stream.c
+++ b/src/query/xasl_to_stream.c
@@ -168,6 +168,7 @@ static char *xts_process_showstmt_spec_type (char *ptr, const SHOWSTMT_SPEC_TYPE
 static char *xts_process_set_spec_type (char *ptr, const SET_SPEC_TYPE * set_spec);
 static char *xts_process_json_table_column_behavior (char *ptr, const json_table_column_behavior * behavior);
 static char *xts_process_method_spec_type (char *ptr, const METHOD_SPEC_TYPE * method_spec);
+static char *xts_process_dblink_spec_type (char *ptr, const DBLINK_SPEC_TYPE * dblink_spec);
 static char *xts_process_rlist_spec_type (char *ptr, const LIST_SPEC_TYPE * list_spec);
 static char *xts_process_list_id (char *ptr, const QFILE_LIST_ID * list_id);
 static char *xts_process_val_list (char *ptr, const VAL_LIST * val_list);
@@ -225,6 +226,7 @@ static int xts_sizeof_list_spec_type (const LIST_SPEC_TYPE * ptr);
 static int xts_sizeof_showstmt_spec_type (const SHOWSTMT_SPEC_TYPE * ptr);
 static int xts_sizeof_set_spec_type (const SET_SPEC_TYPE * ptr);
 static int xts_sizeof_method_spec_type (const METHOD_SPEC_TYPE * ptr);
+static int xts_sizeof_dblink_spec_type (const DBLINK_SPEC_TYPE * ptr);
 static int xts_sizeof_json_table_column_behavior (const json_table_column_behavior * behavior);
 static int xts_sizeof_list_id (const QFILE_LIST_ID * ptr);
 static int xts_sizeof_val_list (const VAL_LIST * ptr);
@@ -4415,6 +4417,10 @@ xts_process_access_spec_type (char *ptr, const ACCESS_SPEC_TYPE * access_spec)
       ptr = xts_process (ptr, ACCESS_SPEC_JSON_TABLE_SPEC (access_spec));
       break;
 
+    case TARGET_DBLINK:
+      ptr = xts_process_dblink_spec_type (ptr, &ACCESS_SPEC_DBLINK_SPEC (access_spec));
+      break;
+ 
     default:
       xts_Xasl_errcode = ER_QPROC_INVALID_XASLNODE;
       return NULL;
@@ -4918,6 +4924,49 @@ xts_process_method_spec_type (char *ptr, const METHOD_SPEC_TYPE * method_spec)
   ptr = or_pack_int (ptr, offset);
 
   offset = xts_save_method_sig_list (method_spec->method_sig_list);
+  if (offset == ER_FAILED)
+    {
+      return NULL;
+    }
+  ptr = or_pack_int (ptr, offset);
+
+  return ptr;
+}
+
+static char *
+xts_process_dblink_spec_type (char *ptr, const DBLINK_SPEC_TYPE * dblink_spec)
+{
+  int offset;
+
+  offset = xts_save_regu_variable_list (dblink_spec->regu_list_p);
+  if (offset == ER_FAILED)
+    {
+      return NULL;
+    }
+  ptr = or_pack_int (ptr, offset);
+
+  offset = xts_save_string(dblink_spec->conn_url);
+  if (offset == ER_FAILED)
+    {
+      return NULL;
+    }
+  ptr = or_pack_int (ptr, offset);
+
+  offset = xts_save_string(dblink_spec->conn_user);
+  if (offset == ER_FAILED)
+    {
+      return NULL;
+    }
+  ptr = or_pack_int (ptr, offset);
+
+  offset = xts_save_string(dblink_spec->conn_password);
+  if (offset == ER_FAILED)
+    {
+      return NULL;
+    }
+  ptr = or_pack_int (ptr, offset);
+
+  offset = xts_save_string(dblink_spec->conn_sql);
   if (offset == ER_FAILED)
     {
       return NULL;
@@ -6526,6 +6575,15 @@ xts_sizeof_access_spec_type (const ACCESS_SPEC_TYPE * access_spec)
       size += tmp_size;
       break;
 
+    case TARGET_DBLINK:
+      tmp_size = xts_sizeof_dblink_spec_type (&ACCESS_SPEC_DBLINK_SPEC (access_spec));
+      if (tmp_size == ER_FAILED)
+	{
+	  return ER_FAILED;
+	}
+      size += tmp_size;
+      break;
+
     case TARGET_JSON_TABLE:
       tmp_size = xts_sizeof (ACCESS_SPEC_JSON_TABLE_SPEC (access_spec));
       if (tmp_size == ER_FAILED)
@@ -6712,6 +6770,23 @@ xts_sizeof_method_spec_type (const METHOD_SPEC_TYPE * method_spec)
   size += (PTR_SIZE		/* method_regu_list */
 	   + PTR_SIZE		/* xasl_node */
 	   + PTR_SIZE);		/* method_sig_list */
+
+  return size;
+}
+
+/*
+ * xts_sizeof_dblink_spec_type () -
+ *   return:
+ *   ptr(in)    :
+ */
+static int
+xts_sizeof_dblink_spec_type (const DBLINK_SPEC_TYPE * dblink_spec)
+{
+  int size = 0;
+
+  size += (PTR_SIZE		/* dblink_regu_list */
+	   + PTR_SIZE		/* conn_rul */
+	   + PTR_SIZE);		/* conn_sql */
 
   return size;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23907

dblink implementation
- add a new access spec
   add a new node **dblink_node** to hybrid_node
``` 
union hybrid_node
{
  CLS_SPEC_TYPE cls_node;	/* class specification */
...
  METHOD_SPEC_TYPE method_node;	/* method specification */
  DBLINK_SPEC_TYPE dblink_node; /* dblink specification */**
...
};	
```
- add a dblink_spec_node
```
struct dblink_spec_node
{
  REGU_VARIABLE_LIST regu_list_p;	/* regulator variable list */
  char *conn_url;		/* connection URL for remote DB server */
  char *conn_user;		/* user name for remote DB server */
  char *conn_password;		/* password for remote user */
  char *conn_sql;		/* SQL command text for remote database */
};
```
- add new scan, dblink
```
struct regu_variable_list_node;

typedef struct dblink_scan_buffer DBLINK_SCAN_BUFFER;
struct dblink_scan_buffer
{				/* value array scanbuf */
 int conn_handle;
 int stmt_handle;
 int col_cnt;
 void *col_info;
};

extern int dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p,
			char *conn_url, char *user_name, char *password, char *sql_text);
extern int dblink_close_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buf);
extern SCAN_CODE dblink_scan_next (THREAD_ENTRY * thread_p, DBLINK_SCAN_BUFFER * scan_buffer_p, regu_variable_list_node * value_list_p);

```
- add a temporal code for dblink in the below routine.
`pt_to_class_spec_list(...)`