### PR TITLE
[CBRD-23912] Revise printing build type string and Fix slip for utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,17 @@ set(RELEASE_STRING ${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}.${CUBRID_PATC
 # BUILD_NUMBER (digital only version string) for legacy codes
 set(BUILD_NUMBER ${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}.${CUBRID_PATCH_VERSION}.${CUBRID_EXTRA_VERSION})
 set(BUILD_OS ${CMAKE_SYSTEM_NAME})
-string(TOLOWER ${CMAKE_BUILD_TYPE} BUILD_TYPE)
+
+# BUILD_TYPE
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+  set(BUILD_TYPE "debug")
+elseif(CMAKE_BUILD_TYPE MATCHES "Coverage|Profile")
+  string(TOLOWER "${CMAKE_BUILD_TYPE} debug" BUILD_TYPE)
+elseif(CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo")
+  set(BUILD_TYPE "release")
+else(CMAKE_BUILD_TYPE MATCHES "Debug")
+  set(BUILD_TYPE "unknown")
+endif(CMAKE_BUILD_TYPE MATCHES "Debug")
 
 if(MSVC)
   configure_file(cmake/version.rc.cmake version.rc)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1959,7 +1959,7 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
 		BOOT_FORMAT_MAX_LENGTH);
   fprintf (stdout, format, rel_name (), rel_build_number ());
 #else /* NDEBUG */
-  fprintf (stdout, "\n%s (%s) (%d debug build)\n\n", rel_name (), rel_build_number (), rel_bit_platform ());
+  fprintf (stdout, "\n%s (%s) (%d %s build)\n\n", rel_name (), rel_build_number (), rel_bit_platform (), rel_build_type ());
 #endif /* !NDEBUG */
 
   if (old_ctrl_c_handler != SIG_ERR)
@@ -2752,7 +2752,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 		    BOOT_FORMAT_MAX_LENGTH);
       fprintf (stdout, format, rel_name ());
 #else /* NDEBUG */
-      fprintf (stdout, "\n%s (%s) (%d debug build)\n\n", rel_name (), rel_build_number (), rel_bit_platform ());
+      fprintf (stdout, "\n%s (%s) (%d %s build)\n\n", rel_name (), rel_build_number (), rel_bit_platform (), rel_build_type ());
 #endif /* !NDEBUG */
     }
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1959,7 +1959,8 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
 		BOOT_FORMAT_MAX_LENGTH);
   fprintf (stdout, format, rel_name (), rel_build_number ());
 #else /* NDEBUG */
-  fprintf (stdout, "\n%s (%s) (%d %s build)\n\n", rel_name (), rel_build_number (), rel_bit_platform (), rel_build_type ());
+  fprintf (stdout, "\n%s (%s) (%d %s build)\n\n", rel_name (), rel_build_number (), rel_bit_platform (),
+	   rel_build_type ());
 #endif /* !NDEBUG */
 
   if (old_ctrl_c_handler != SIG_ERR)
@@ -2752,7 +2753,8 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 		    BOOT_FORMAT_MAX_LENGTH);
       fprintf (stdout, format, rel_name ());
 #else /* NDEBUG */
-      fprintf (stdout, "\n%s (%s) (%d %s build)\n\n", rel_name (), rel_build_number (), rel_bit_platform (), rel_build_type ());
+      fprintf (stdout, "\n%s (%s) (%d %s build)\n\n", rel_name (), rel_build_number (), rel_bit_platform (),
+	       rel_build_type ());
 #endif /* !NDEBUG */
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23912

1) QA requests "Coverage" and "Profile" prints like "coverage debug" and "profile debug"
2) Print "RelWithDebInfo" as "release"
3) Print the build type string when starting utility (e.g. createdb)