### PR TITLE
[LETS-86] Replace timespec_get with chrono functions

### DIFF
--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -1275,7 +1275,7 @@ logddl_get_time_string (char *buf, struct timeval *time_val)
   if (time_val == NULL)
     {
       /* current time */
-      util_get_second_and_ms_since_epoch (sec, millisec);
+      util_get_second_and_ms_since_epoch (&sec, &millisec);
     }
   else
     {

--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -49,6 +49,7 @@
 #include "system_parameter.h"
 #include "environment_variable.h"
 #include "broker_config.h"
+#include "util_func.h"
 
 #define DDL_LOG_MSG 	            (256)
 #define DDL_LOG_PATH    	    "log/ddl_audit"
@@ -1273,15 +1274,8 @@ logddl_get_time_string (char *buf, struct timeval *time_val)
 
   if (time_val == NULL)
     {
-      struct timeb tb;
-
       /* current time */
-      timespec ts = { };
-      timespec_get (&ts, TIME_UTC);
-      sec = ts.tv_sec;
-      // *INDENT-OFF*
-      millisec = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::nanoseconds (ts.tv_nsec)).count();
-      // *INDENT-ON*
+      util_get_second_and_ms_since_epoch (sec, millisec);
     }
   else
     {

--- a/src/base/util_func.c
+++ b/src/base/util_func.c
@@ -820,7 +820,6 @@ util_get_seconds_and_rest_since_epoch (std::chrono::seconds &secs, Duration &res
   secs = now_in_secs.time_since_epoch ();
   rest = std::chrono::duration_cast<Duration> (now_timepoint - now_in_secs);
 }
-// *INDENT-ON*
 
 void
 util_get_second_and_ms_since_epoch (time_t * secs, int *msec)
@@ -828,8 +827,9 @@ util_get_second_and_ms_since_epoch (time_t * secs, int *msec)
   assert (secs != NULL && msec != NULL);
   std::chrono::seconds secs_since_epoch;
   std::chrono::milliseconds rest_in_msec;
-  util_get_seconds_and_rest_since_epoch < std::chrono::milliseconds > (secs_since_epoch, rest_in_msec);
-  *secs = static_cast < time_t > (secs_since_epoch.count ());
-  *msec = static_cast < int >(rest_in_msec.count ());
+  util_get_seconds_and_rest_since_epoch<std::chrono::milliseconds> (secs_since_epoch, rest_in_msec);
+  *secs = static_cast<time_t> (secs_since_epoch.count ());
+  *msec = static_cast<int> (rest_in_msec.count ());
   assert (*msec < 1000);
 }
+// *INDENT-ON*

--- a/src/base/util_func.c
+++ b/src/base/util_func.c
@@ -61,6 +61,11 @@ static FILE *fopen_and_lock (const char *path);
 static int util_log_header (char *buf, size_t buf_len);
 static int util_log_write_internal (const char *msg, const char *prefix_str);
 
+// *INDENT-OFF*
+template <typename Duration>
+static void util_get_seconds_and_rest_since_epoch (std::chrono::seconds &secs, Duration &rest);
+// *INDENT-ON*
+
 /*
  * hashpjw() - returns hash value of given string
  *   return: hash value
@@ -637,7 +642,7 @@ util_log_header (char *buf, size_t buf_len)
     }
 
   /* current time */
-  util_get_second_and_ms_since_epoch (sec, millisec);
+  util_get_second_and_ms_since_epoch (&sec, &millisec);
 
   tm_p = localtime_r (&sec, &tm);
 
@@ -815,14 +820,16 @@ util_get_seconds_and_rest_since_epoch (std::chrono::seconds &secs, Duration &res
   secs = now_in_secs.time_since_epoch ();
   rest = std::chrono::duration_cast<Duration> (now_timepoint - now_in_secs);
 }
+// *INDENT-ON*
 
 void
-util_get_second_and_ms_since_epoch (time_t &secs, int &msec)
+util_get_second_and_ms_since_epoch (time_t * secs, int *msec)
 {
+  assert (secs != NULL && msec != NULL);
   std::chrono::seconds secs_since_epoch;
   std::chrono::milliseconds rest_in_msec;
-  util_get_seconds_and_rest_since_epoch<std::chrono::milliseconds> (secs_since_epoch, rest_in_msec);
-  secs = static_cast<time_t> (secs_since_epoch.count ());
-  msec = static_cast<int> (rest_in_msec.count ());
+  util_get_seconds_and_rest_since_epoch < std::chrono::milliseconds > (secs_since_epoch, rest_in_msec);
+  *secs = static_cast < time_t > (secs_since_epoch.count ());
+  *msec = static_cast < int >(rest_in_msec.count ());
+  assert (*msec < 1000);
 }
-// *INDENT-ON*

--- a/src/base/util_func.c
+++ b/src/base/util_func.c
@@ -627,7 +627,6 @@ util_log_header (char *buf, size_t buf_len)
   struct tm tm, *tm_p;
   time_t sec;
   int len;
-  struct timeb tb;
   char *p;
   const char *pid;
   int millisec;
@@ -809,9 +808,10 @@ template <typename Duration>
 void
 util_get_seconds_and_rest_since_epoch (std::chrono::seconds &secs, Duration &rest)
 {
-  using timept_secs = std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
-  auto now_timepoint = std::chrono::system_clock::now ();
-  timept_secs now_in_secs (now_timepoint);
+  using clock_t = std::chrono::system_clock;
+  using timept_secs = std::chrono::time_point<clock_t, std::chrono::seconds>;
+  auto now_timepoint = clock_t::now ();
+  timept_secs now_in_secs = std::chrono::time_point_cast<std::chrono::seconds> (now_timepoint);
   secs = now_in_secs.time_since_epoch ();
   rest = std::chrono::duration_cast<Duration> (now_timepoint - now_in_secs);
 }

--- a/src/base/util_func.h
+++ b/src/base/util_func.h
@@ -27,12 +27,9 @@
 
 #ident "$Id$"
 
-#if defined __cplusplus
-#include <chrono>
-#include <ctime>
-#endif
 #include <sys/types.h>
 #include <math.h>
+#include <time.h>
 
 #define UTIL_PID_ENVVAR_NAME         "UTIL_PID"
 #define UTIL_infinity()     (HUGE_VAL)
@@ -77,12 +74,6 @@ extern int util_log_write_command (int argc, char *argv[]);
 extern int util_bsearch (const void *key, const void *base, int n_elems, unsigned int sizeof_elem,
 			 int (*func_compare) (const void *, const void *), bool * out_found);
 
-// *INDENT-OFF*
-#if defined __cplusplus
-template <typename Duration>
-void util_get_seconds_and_rest_since_epoch (std::chrono::seconds &secs, Duration &rest);
-void util_get_second_and_ms_since_epoch (time_t &secs, int &msec);
-#endif
-// *INDENT-ON*
+extern void util_get_second_and_ms_since_epoch (time_t * secs, int *msec);
 
 #endif /* _UTIL_FUNC_H_ */

--- a/src/base/util_func.h
+++ b/src/base/util_func.h
@@ -27,6 +27,8 @@
 
 #ident "$Id$"
 
+#include <chrono>
+#include <ctime>
 #include <sys/types.h>
 #include <math.h>
 
@@ -72,5 +74,11 @@ extern int util_log_write_command (int argc, char *argv[]);
 
 extern int util_bsearch (const void *key, const void *base, int n_elems, unsigned int sizeof_elem,
 			 int (*func_compare) (const void *, const void *), bool * out_found);
+
+// *INDENT-OFF*
+template <typename Duration>
+void util_get_seconds_and_rest_since_epoch (std::chrono::seconds &secs, Duration &rest);
+void util_get_second_and_ms_since_epoch (time_t &secs, int &msec);
+// *INDENT-ON*
 
 #endif /* _UTIL_FUNC_H_ */

--- a/src/base/util_func.h
+++ b/src/base/util_func.h
@@ -27,8 +27,10 @@
 
 #ident "$Id$"
 
+#if defined __cplusplus
 #include <chrono>
 #include <ctime>
+#endif
 #include <sys/types.h>
 #include <math.h>
 
@@ -76,9 +78,11 @@ extern int util_bsearch (const void *key, const void *base, int n_elems, unsigne
 			 int (*func_compare) (const void *, const void *), bool * out_found);
 
 // *INDENT-OFF*
+#if defined __cplusplus
 template <typename Duration>
 void util_get_seconds_and_rest_since_epoch (std::chrono::seconds &secs, Duration &rest);
 void util_get_second_and_ms_since_epoch (time_t &secs, int &msec);
+#endif
 // *INDENT-ON*
 
 #endif /* _UTIL_FUNC_H_ */

--- a/src/broker/broker_util.c
+++ b/src/broker/broker_util.c
@@ -432,7 +432,7 @@ ut_time_string (char *buf, struct timeval *time_val)
 
   if (time_val == NULL)
     {
-      util_get_second_and_ms_since_epoch (sec, millisec);
+      util_get_second_and_ms_since_epoch (&sec, &millisec);
     }
   else
     {

--- a/src/broker/broker_util.c
+++ b/src/broker/broker_util.c
@@ -60,6 +60,7 @@
 #include "broker_filename.h"
 #include "environment_variable.h"
 #include "porting.h"
+#include "util_func.h"
 
 char db_err_log_file[BROKER_PATH_MAX];
 
@@ -422,7 +423,7 @@ ut_time_string (char *buf, struct timeval *time_val)
 {
   struct tm tm, *tm_p;
   time_t sec;
-  long millisec;
+  int millisec;
 
   if (buf == NULL)
     {
@@ -431,12 +432,7 @@ ut_time_string (char *buf, struct timeval *time_val)
 
   if (time_val == NULL)
     {
-      timespec ts = { };
-      timespec_get (&ts, TIME_UTC);
-      sec = ts.tv_sec;
-      // *INDENT-OFF*
-      millisec = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::nanoseconds (ts.tv_nsec)).count();
-      // *INDENT-ON*
+      util_get_second_and_ms_since_epoch (sec, millisec);
     }
   else
     {

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -399,20 +399,18 @@ db_open_file_name (const char *name)
   return session;
 }
 
-// *INDENT-OFF
 static void
-db_calculate_current_time (struct timeb &tb)
+db_calculate_current_time (struct timeb *tb)
 {
+  assert (tb != nullptr);
+
   // use chrono functions to populate timeb
   time_t sec;
   int millisec;
-  util_get_second_and_ms_since_epoch (sec, millisec);
-  tb =
-  {
-  sec, (unsigned short) millisec, 0, 0};
+  util_get_second_and_ms_since_epoch (&sec, &millisec);
+  tb->time = sec;
+  tb->millitm = (unsigned short) millisec;
 }
-
-// *INDENT-ON*
 
 /*
  * db_calculate_current_server_time () -
@@ -437,7 +435,7 @@ db_calculate_current_server_time (PARSER_CONTEXT * parser)
       return;
     }
 
-  db_calculate_current_time (curr_client_timeb);
+  db_calculate_current_time (&curr_client_timeb);
   diff_time = (int) (curr_client_timeb.time - base_client_timeb.time);
   diff_mtime = curr_client_timeb.millitm - base_client_timeb.millitm;
 
@@ -501,7 +499,7 @@ db_set_base_server_time (DB_VALUE * db_val)
   base_server_timeb.millitm = dt->time % 1000;	/* set milliseconds */
 
   base_server_timeb.time = mktime (&c_time_struct);
-  db_calculate_current_time (base_client_timeb);
+  db_calculate_current_time (&base_client_timeb);
 }
 
 /*

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -54,6 +54,7 @@
 #include "network_interface_cl.h"
 #include "transaction_cl.h"
 #include "dbtype.h"
+#include "util_func.h"
 #include "xasl.h"
 
 #define BUF_SIZE 1024
@@ -69,7 +70,7 @@ enum
 };
 
 static struct timeb base_server_timeb = { 0, 0, 0, 0 };
-static timespec base_client_time = { };
+static struct timeb base_client_timeb = { 0, 0, 0, 0 };
 
 static int get_dimension_of (PT_NODE ** array);
 static DB_SESSION *db_open_local (void);
@@ -398,6 +399,18 @@ db_open_file_name (const char *name)
   return session;
 }
 
+static void
+db_calculate_current_time (struct timeb &tb)
+{
+  // use chrono functions to populate timeb
+  time_t sec;
+  int millisec;
+  util_get_second_and_ms_since_epoch (sec, millisec);
+  tb =
+  {
+  sec, millisec, 0, 0};
+}
+
 /*
  * db_calculate_current_server_time () -
  * return:
@@ -412,6 +425,8 @@ db_calculate_current_server_time (PARSER_CONTEXT * parser)
   DB_DATETIME datetime;
 
   struct timeb curr_server_timeb;
+  struct timeb curr_client_timeb;
+  int diff_mtime;
   int diff_time;
 
   if (base_server_timeb.time == 0)
@@ -419,13 +434,9 @@ db_calculate_current_server_time (PARSER_CONTEXT * parser)
       return;
     }
 
-  timespec curr_client_time = { };
-  timespec_get (&curr_client_time, TIME_UTC);
-  diff_time = (int) (curr_client_time.tv_sec - base_client_time.tv_sec);
-  // *INDENT-OFF*
-  auto diff_mtime = std::chrono::duration_cast<std::chrono::milliseconds>
-        (std::chrono::nanoseconds (curr_client_time.tv_nsec - base_client_time.tv_nsec)).count ();
-  // *INDENT-ON*
+  db_calculate_current_time (curr_client_timeb);
+  diff_time = (int) (curr_client_timeb.time - base_client_timeb.time);
+  diff_mtime = curr_client_timeb.millitm - base_client_timeb.millitm;
 
   if (diff_time > MAX_SERVER_TIME_CACHE)
     {
@@ -487,7 +498,7 @@ db_set_base_server_time (DB_VALUE * db_val)
   base_server_timeb.millitm = dt->time % 1000;	/* set milliseconds */
 
   base_server_timeb.time = mktime (&c_time_struct);
-  timespec_get (&base_client_time, TIME_UTC);
+  db_calculate_current_time (base_client_timeb);
 }
 
 /*

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -399,6 +399,7 @@ db_open_file_name (const char *name)
   return session;
 }
 
+// *INDENT-OFF
 static void
 db_calculate_current_time (struct timeb &tb)
 {
@@ -408,8 +409,10 @@ db_calculate_current_time (struct timeb &tb)
   util_get_second_and_ms_since_epoch (sec, millisec);
   tb =
   {
-  sec, millisec, 0, 0};
+  sec, (unsigned short) millisec, 0, 0};
 }
+
+// *INDENT-ON*
 
 /*
  * db_calculate_current_server_time () -

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -1830,7 +1830,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	  struct tm *c_time_struct, tm_val;
 
 	  /* get the local time of the system */
-	  util_get_second_and_ms_since_epoch (sec, millisec);
+	  util_get_second_and_ms_since_epoch (&sec, &millisec);
 	  c_time_struct = localtime_r (&sec, &tm_val);
 
 	  if (c_time_struct != NULL)

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -1825,21 +1825,19 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	  DB_TIMESTAMP db_timestamp;
 	  DB_DATETIME sys_datetime;
 	  DB_TIME db_time;
-	  timespec tloc = { };
+	  time_t sec;
+	  int millisec;
 	  struct tm *c_time_struct, tm_val;
 
 	  /* get the local time of the system */
-	  timespec_get (&tloc, TIME_UTC);
-	  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
+	  util_get_second_and_ms_since_epoch (sec, millisec);
+	  c_time_struct = localtime_r (&sec, &tm_val);
 
 	  if (c_time_struct != NULL)
 	    {
-	      // *INDENT-OFF*
-	      auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
-	      // *INDENT-ON*
 	      db_datetime_encode (&sys_datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday,
 				  c_time_struct->tm_year + 1900, c_time_struct->tm_hour, c_time_struct->tm_min,
-				  c_time_struct->tm_sec, ms.count ());
+				  c_time_struct->tm_sec, millisec);
 	    }
 
 	  db_time = sys_datetime.time / 1000;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14781,20 +14781,18 @@ qexec_execute_query (THREAD_ENTRY * thread_p, xasl_node * xasl, int dbval_cnt, c
   /* form the value descriptor to represent positional values */
   xasl_state.vd.dbval_cnt = dbval_cnt;
   xasl_state.vd.dbval_ptr = (DB_VALUE *) dbval_ptr;
-  timespec tloc = { };
-  timespec_get (&tloc, TIME_UTC);
-  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
+  time_t sec;
+  int millisec;
+  util_get_second_and_ms_since_epoch (sec, millisec);
+  c_time_struct = localtime_r (&sec, &tm_val);
 
-  xasl_state.vd.sys_epochtime = (DB_TIMESTAMP) tloc.tv_sec;
+  xasl_state.vd.sys_epochtime = (DB_TIMESTAMP) sec;
 
   if (c_time_struct != NULL)
     {
-      // *INDENT-OFF*
-      auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
-      // *INDENT-ON*
       db_datetime_encode (&xasl_state.vd.sys_datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday,
 			  c_time_struct->tm_year + 1900, c_time_struct->tm_hour, c_time_struct->tm_min,
-			  c_time_struct->tm_sec, ms.count ());
+			  c_time_struct->tm_sec, millisec);
     }
 
   rand_buf_p = qmgr_get_rand_buf (thread_p);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14783,7 +14783,7 @@ qexec_execute_query (THREAD_ENTRY * thread_p, xasl_node * xasl, int dbval_cnt, c
   xasl_state.vd.dbval_ptr = (DB_VALUE *) dbval_ptr;
   time_t sec;
   int millisec;
-  util_get_second_and_ms_since_epoch (sec, millisec);
+  util_get_second_and_ms_since_epoch (&sec, &millisec);
   c_time_struct = localtime_r (&sec, &tm_val);
 
   xasl_state.vd.sys_epochtime = (DB_TIMESTAMP) sec;

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -55,6 +55,7 @@
 #include "db_elo.h"
 #include "string_regex.hpp"
 #include "tz_support.h"
+#include "util_func.h"
 
 #include <algorithm>
 #include <chrono>
@@ -13207,7 +13208,8 @@ db_sys_datetime (DB_VALUE * result_datetime)
   int error_status = NO_ERROR;
   DB_DATETIME datetime;
 
-  timespec tloc = { };
+  time_t sec;
+  int millisec;
   struct tm *c_time_struct, tm_val;
 
   assert (result_datetime != (DB_VALUE *) NULL);
@@ -13215,14 +13217,9 @@ db_sys_datetime (DB_VALUE * result_datetime)
   /* now return null */
   db_value_domain_init (result_datetime, DB_TYPE_DATETIME, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 
-  if (timespec_get (&tloc, TIME_UTC) != 0)
-    {
-      error_status = ER_SYSTEM_DATE;
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
-      return error_status;
-    }
+  util_get_second_and_ms_since_epoch (sec, millisec);
 
-  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
+  c_time_struct = localtime_r (&sec, &tm_val);
   if (c_time_struct == NULL)
     {
       error_status = ER_SYSTEM_DATE;
@@ -13230,11 +13227,8 @@ db_sys_datetime (DB_VALUE * result_datetime)
       return error_status;
     }
 
-  // *INDENT-OFF*
-  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
-  // *INDENT-ON*
   db_datetime_encode (&datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900,
-		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, ms.count ());
+		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, millisec);
   db_make_datetime (result_datetime, &datetime);
 
   return error_status;
@@ -13255,20 +13249,16 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
 {
   int error_status = NO_ERROR;
   DB_DATETIME datetime;
-  timespec tloc = { };
+  time_t sec;
+  int millisec;
   struct tm *c_time_struct, tm_val;
 
   assert (dt_dbval != NULL);
   assert (ts_dbval != NULL);
 
-  if (timespec_get (&tloc, TIME_UTC) != 0)
-    {
-      error_status = ER_SYSTEM_DATE;
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
-      return error_status;
-    }
+  util_get_second_and_ms_since_epoch (sec, millisec);
 
-  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
+  c_time_struct = localtime_r (&sec, &tm_val);
   if (c_time_struct == NULL)
     {
       error_status = ER_SYSTEM_DATE;
@@ -13276,14 +13266,11 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
       return error_status;
     }
 
-  // *INDENT-OFF*
-  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
-  // *INDENT-ON*
   db_datetime_encode (&datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900,
-		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, ms.count ());
+		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, millisec);
 
   db_make_datetime (dt_dbval, &datetime);
-  db_make_timestamp (ts_dbval, (DB_TIMESTAMP) tloc.tv_sec);
+  db_make_timestamp (ts_dbval, (DB_TIMESTAMP) sec);
 
   return error_status;
 }

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -13217,7 +13217,7 @@ db_sys_datetime (DB_VALUE * result_datetime)
   /* now return null */
   db_value_domain_init (result_datetime, DB_TYPE_DATETIME, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 
-  util_get_second_and_ms_since_epoch (sec, millisec);
+  util_get_second_and_ms_since_epoch (&sec, &millisec);
 
   c_time_struct = localtime_r (&sec, &tm_val);
   if (c_time_struct == NULL)
@@ -13256,7 +13256,7 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
   assert (dt_dbval != NULL);
   assert (ts_dbval != NULL);
 
-  util_get_second_and_ms_since_epoch (sec, millisec);
+  util_get_second_and_ms_since_epoch (&sec, &millisec);
 
   c_time_struct = localtime_r (&sec, &tm_val);
   if (c_time_struct == NULL)

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -445,6 +445,7 @@ EXPORTS
     utility_get_generic_message
     util_make_ha_conf
     util_get_ha_mode_for_sa_utils
+	util_get_second_and_ms_since_epoch
     util_is_localhost
     util_free_ha_conf
     util_split_string


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-86

On CentOS devtoolset-8 system compile fails because timespec_get and TIME_UTC are not found, even though the C++17 documentation includes them.

Quick fix by using std::chrono::now() and building the seconds/millisecond parts that were initially generated using the deprecated function ftime.

Some of the changes in db_vdb.c made by #2646 have been reverted.
