### PR TITLE
[CBRD-23883] backport #2617 to 11.0.1, JDBC_CACHE_HINT_ONLY

### DIFF
--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -2009,7 +2009,7 @@ admin_conf_change (int master_shm_id, const char *br_name, const char *conf_name
       br_info_p->jdbc_cache = val;
       shm_as_p->jdbc_cache = val;
     }
-  else if (strcasecmp (conf_name, "JDBC_CACHE_ONLY_HINT") == 0)
+  else if (strcasecmp (conf_name, "JDBC_CACHE_HINT_ONLY") == 0)
     {
       int val;
 

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -666,7 +666,7 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	}
 
       br_info[num_brs].jdbc_cache_only_hint =
-	conf_get_value_table_on_off (ini_getstr (ini, sec_name, "JDBC_CACHE_ONLY_HINT", "OFF", &lineno));
+	conf_get_value_table_on_off (ini_getstr (ini, sec_name, "JDBC_CACHE_HINT_ONLY", "OFF", &lineno));
       if (br_info[num_brs].jdbc_cache_only_hint < 0)
 	{
 	  errcode = PARAM_BAD_VALUE;
@@ -1340,7 +1340,7 @@ broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int num_broker, in
       tmp_str = get_conf_string (br_info[i].jdbc_cache_only_hint, tbl_on_off);
       if (tmp_str)
 	{
-	  fprintf (fp, "JDBC_CACHE_ONLY_HINT\t=%s\n", tmp_str);
+	  fprintf (fp, "JDBC_CACHE_HINT_ONLY\t=%s\n", tmp_str);
 	}
 
       fprintf (fp, "JDBC_CACHE_LIFE_TIME\t=%d\n", br_info[i].jdbc_cache_life_time);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23883

Purpose
* backport #2617 to 11.0.1
* Fix broker keyword **_JDBC_CACHE_ONLY_HINT_** to **JDBC_CACHE_HINT_ONLY** as in CUBRID Manual

Implementation
N/A

Remarks
N/A
