### PR TITLE
[CBRD-23891] backport #2665 to 11.0.1, fix num_instance for loaddb cs

### DIFF
--- a/src/loaddb/load_session.cpp
+++ b/src/loaddb/load_session.cpp
@@ -198,7 +198,7 @@ namespace cubload
 		msg_type = LOADDB_MSG_COMMITTED_INSTANCES;
 	      }
 
-	    m_session.append_log_msg (msg_type, class_name.c_str (), m_session.stats_get_rows_committed ());
+	    m_session.append_log_msg (msg_type, class_name.c_str (), rows_number);
 	  }
 
 	// Clear the clientids.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23891

Purpose
* backport #2665 to 11.0.1
* Fix num instances committed in loaddb CS

Implementation
N/A

Remarks
N/A


