### PR TITLE
[CBRD-23921] JDBC error when building with circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,12 @@ jobs:
       MAKEFLAGS: -j2
     
     steps:
-      - checkout:
-          path: cubrid
+      - checkout
+      - run:
+          name: Submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build
           command: scl enable devtoolset-8 -- /entrypoint.sh build


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23921 

Circleci cannot find jdbc source directory after the JDBC repository is separated.
It needs to update jdbc source which is the submodule.
