### PR TITLE
[CBRD-23898] Fix for formatted print

### DIFF
--- a/src/loaddb/load_object.c
+++ b/src/loaddb/load_object.c
@@ -486,11 +486,11 @@ start:
       va_end (ap);
     }
 
-  if (nbytes > 0 && buf != NULL)
+  if (nbytes > 0)
     {
       if (nbytes < size)
 	{			/* OK */
-	  if (buflen > 0)
+	  if (buflen > 0 && buf != NULL)
 	    {			/* unformatted print */
 	      memcpy (tout->ptr, buf, buflen);
 	      *(tout->ptr + buflen) = '\0';	/* Null terminate */

--- a/src/loaddb/load_object.c
+++ b/src/loaddb/load_object.c
@@ -490,8 +490,9 @@ start:
     {
       if (nbytes < size)
 	{			/* OK */
-	  if (buflen > 0 && buf != NULL)
+	  if (buflen > 0)
 	    {			/* unformatted print */
+	      assert (buf != NULL);
 	      memcpy (tout->ptr, buf, buflen);
 	      *(tout->ptr + buflen) = '\0';	/* Null terminate */
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23898

the NULL checking for the _buf_ should be performed only for unformatted print.
it caused by #2673. Sorry for missing it while the code review.