### PR TITLE
[CBRD-21908] "cubrid.jdbc.driver.CUBRIDException: Cannot communicate with the broker" when there is one cas on windows

### DIFF
--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1379,6 +1379,10 @@ cas_main (void)
 
 	if (is_server_aborted ())
 	  {
+	    CLOSE_SOCKET (srv_sock_fd);
+#if defined(WINDOWS)
+	    WSACleanup ();
+#endif
 	    cas_final ();
 	    return 0;
 	  }
@@ -1386,6 +1390,10 @@ cas_main (void)
 	  {
 	    if (restart_is_needed ())
 	      {
+		CLOSE_SOCKET (srv_sock_fd);
+#if defined(WINDOWS)
+		WSACleanup ();
+#endif
 		cas_final ();
 		return 0;
 	      }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21908

Purpose
* When there is only one CAS and the CAS and the client are communicating, a "Connection reset" error occurs in the client when the CAS is restarted because the memory used by the CAS exceeds APPL_SERVER_MAX_SIZE.
* To prevent "Connection reset" error, when CAS is terminated, closesocket() was added.

Implementation
N/A

Remarks
N/A