### PR TITLE
[LETS-92] Fix perfmon init/finalize of 'n_watchers' when 'stats_on' enabled

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -3134,7 +3134,6 @@ perfmon_initialize (int num_trans)
     }
   memset (pstat_Global.is_watching, 0, memsize);
 
-  pstat_Global.n_watchers = 0;
   pstat_Global.initialized = true;
   return NO_ERROR;
 
@@ -3172,6 +3171,12 @@ perfmon_finalize (void)
     {
       free_and_init (pstat_Global.global_stats);
     }
+
+#if defined (SERVER_MODE)
+  // reset in case of 'always watching' initialization
+  pstat_Global.n_watchers = 0;
+#endif
+
 #if defined (SERVER_MODE) || defined (SA_MODE)
 #if !defined (HAVE_ATOMIC_BUILTINS)
   pthread_mutex_destroy (&pstat_Global.watch_lock);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2554,7 +2554,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   if (get_server_type () == SERVER_TYPE_PAGE)
     {
       ps_Gl.start_log_replicator (log_Gl.append.get_nxio_lsa ());
-      ps_Gl.init_log_page_fetcher();
+      ps_Gl.init_log_page_fetcher ();
     }
 #endif // SERVER_MODE
 
@@ -3934,7 +3934,6 @@ boot_server_all_finalize (THREAD_ENTRY * thread_p, ER_FINAL_CODE is_er_final,
   catalog_finalize ();
   qmgr_finalize (thread_p);
   (void) heap_manager_finalize ();
-  perfmon_finalize ();
   fileio_dismount_all (thread_p);
   disk_manager_final ();
   boot_server_status (BOOT_SERVER_DOWN);
@@ -3948,6 +3947,7 @@ boot_server_all_finalize (THREAD_ENTRY * thread_p, ER_FINAL_CODE is_er_final,
   lf_destroy_transaction_systems ();
 
   finalize_server_type ();
+  perfmon_finalize ();
 
 #if defined(SERVER_MODE)
   /* server mode shuts down all modules */


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-92

The function `perfmon_finalize` does not properly reset `n_watchers` in case the values was incremented because of enabled `PRM_ID_STATS_ON`.

This is visible, for instance, if perfmon logging is always active - `stats_on` parameter is on - and other modules want to do performance logging after the perfmon module is cleaned-up - `boot_server_all_finalize`.
