### PR TITLE
[LETS-93] Proper transaction index for async log page fetcher threads

### DIFF
--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -707,6 +707,8 @@ thread_type_to_string (thread_type type)
       return "VACUUM_MASTER";
     case TT_VACUUM_WORKER:
       return "VACUUM_WORKER";
+    case TT_SYSTEM_WORKER:
+      return "SYSTEM_WORKER";
     case TT_NONE:
       return "NONE";
     }

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -122,7 +122,9 @@ enum thread_type
 {
   TT_MASTER,
   TT_SERVER,
+  // used to designate generic 'user' operations threads
   TT_WORKER,
+  // used to designate generic system operations
   TT_DAEMON,
   TT_LOADDB,
   TT_VACUUM_MASTER,

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -127,6 +127,7 @@ enum thread_type
   TT_LOADDB,
   TT_VACUUM_MASTER,
   TT_VACUUM_WORKER,
+  TT_SYSTEM_WORKER,
   TT_NONE
 };
 

--- a/src/thread/thread_entry_task.cpp
+++ b/src/thread/thread_entry_task.cpp
@@ -118,4 +118,24 @@ namespace cubthread
     on_daemon_retire (context);
   }
 
+  system_worker_entry_manager::system_worker_entry_manager (thread_type a_thread_type)
+    : m_thread_type { a_thread_type }
+  {
+  }
+
+  void
+  system_worker_entry_manager::on_create (entry &context)
+  {
+    context.type = m_thread_type;
+    context.tran_index = LOG_SYSTEM_TRAN_INDEX;
+  }
+
+  void
+  system_worker_entry_manager::on_recycle (entry &context)
+  {
+    // thread type is 'not' reset in the parent, checked here
+    assert (context.type == m_thread_type);
+    // transaction index is reset in parent
+    context.tran_index = LOG_SYSTEM_TRAN_INDEX;
+  }
 } // namespace cubthread

--- a/src/thread/thread_entry_task.hpp
+++ b/src/thread/thread_entry_task.hpp
@@ -27,15 +27,14 @@
 #error Wrong module
 #endif // not SERVER_MODE and not SA_MODE
 
+#include "thread_entry.hpp"
 #include "thread_task.hpp"
+#include "transaction_global.hpp"
 
 #include <cassert>
 
 namespace cubthread
 {
-
-  // forward definition
-  class entry;
 
   // cubthread::entry_task
   //
@@ -133,6 +132,31 @@ namespace cubthread
       }
   };
 
+  // system_worker_entry_manager
+  //
+  // description:
+  //    - generic context manager implementation can be used to provide custom
+  //      thread type and transaction index
+  //    - useful in scenarios where there is no actual transaction and perf logging
+  //      still needs a non-null transaction index
+  //
+  class system_worker_entry_manager : public entry_manager
+  {
+    public:
+      system_worker_entry_manager (thread_type a_thread_type);
+      system_worker_entry_manager (const system_worker_entry_manager &) = delete;
+      system_worker_entry_manager (system_worker_entry_manager &&) = delete;
+
+      system_worker_entry_manager &operator = (const system_worker_entry_manager &) = delete;
+      system_worker_entry_manager &operator = (system_worker_entry_manager &&) = delete;
+
+    public:
+      void on_create (entry &context) override;
+      void on_recycle (entry &context) override;
+
+    private:
+      const thread_type m_thread_type;
+  };
 } // namespace cubthread
 
 #endif // _THREAD_ENTRY_TASK_HPP_

--- a/src/transaction/log_page_async_fetcher.cpp
+++ b/src/transaction/log_page_async_fetcher.cpp
@@ -53,7 +53,7 @@ namespace cublog
 
     const auto thread_count = std::thread::hardware_concurrency ();
     m_worker_pool_context_manager.reset (
-	    new cubthread::system_worker_entry_manager (TT_WORKER));
+	    new cubthread::system_worker_entry_manager (TT_SYSTEM_WORKER));
     m_threads = thread_manager->create_worker_pool (thread_count, thread_count,
 		"async_page_fetcher_worker_pool",
 		m_worker_pool_context_manager.get (),

--- a/src/transaction/log_page_async_fetcher.cpp
+++ b/src/transaction/log_page_async_fetcher.cpp
@@ -49,11 +49,15 @@ namespace cublog
 
   async_page_fetcher::async_page_fetcher ()
   {
-    cubthread::manager *thread_manager = cubthread::get_manager ();
+    cubthread::manager *const thread_manager = cubthread::get_manager ();
 
     const auto thread_count = std::thread::hardware_concurrency ();
-    m_threads = thread_manager->create_worker_pool (thread_count, thread_count, "async_page_fetcher_worker_pool",
-		nullptr, thread_count, false /*debug_logging*/);
+    m_worker_pool_context_manager.reset (
+	    new cubthread::system_worker_entry_manager (TT_WORKER));
+    m_threads = thread_manager->create_worker_pool (thread_count, thread_count,
+		"async_page_fetcher_worker_pool",
+		m_worker_pool_context_manager.get (),
+		thread_count, false /*debug_logging*/);
 
     assert (m_threads);
   }
@@ -65,7 +69,7 @@ namespace cublog
 
   void async_page_fetcher::fetch_page (LOG_PAGEID pageid, callback_func_type &&func)
   {
-    log_page_fetch_task *task = new log_page_fetch_task (pageid, std::move (func));
+    log_page_fetch_task *const task = new log_page_fetch_task (pageid, std::move (func));
 
     // Ownership is transfered to m_threads.
     m_threads->execute (task);

--- a/src/transaction/log_page_async_fetcher.hpp
+++ b/src/transaction/log_page_async_fetcher.hpp
@@ -40,6 +40,10 @@ namespace cublog
 
     private:
       cubthread::entry_workpool *m_threads = nullptr;
+
+      // seed the worker pool threads with a non-null transaction and a valid thread
+      // identity as to properly identify these agains perf logging
+      std::unique_ptr<cubthread::entry_manager> m_worker_pool_context_manager;
   };
 
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-93

Fix for, when perfmon logging is activated, the tasks dispatched by the `async_page_fetcher` fail upon perfmon calls because of null `tran_index`.
