### PR TITLE
[LETS-94] Update circle-ci path to run_scalability_unit_tests.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: Unit tests
           command: |
-            cd /home/cubrid/${BUILD_DIR_NAME}/bin
+            cd /home/${BUILD_DIR_NAME}/bin
             sh ./run_scalability_unit_tests.sh
       - persist_to_workspace:
           root: .


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-94

The build path on circle-ci has changed after the last merge with develop branch. Update the path to fix circle-ci unit tests step.