### PR TITLE
[CBRD-23914] Fix -Wregister warnings 

### DIFF
--- a/src/base/mprec.c
+++ b/src/base/mprec.c
@@ -248,9 +248,9 @@ _DEFUN (s2b, (ptr, s, nd0, nd, y9), struct _reent * ptr _AND _CONST char *s _AND
 
 #endif /* ENABLE_UNUSED_FUNCTION */
 int
-_DEFUN (hi0bits, (x), register __ULong x)
+_DEFUN (hi0bits, (x), __ULong x)
 {
-  register int k = 0;
+  int k = 0;
 
   if (!(x & 0xffff0000))
     {
@@ -284,8 +284,8 @@ _DEFUN (hi0bits, (x), register __ULong x)
 int
 _DEFUN (lo0bits, (y), __ULong * y)
 {
-  register int k;
-  register __ULong x = *y;
+  int k;
+  __ULong x = *y;
 
   if (x & 7)
     {

--- a/src/compat/cnvlex.c
+++ b/src/compat/cnvlex.c
@@ -767,9 +767,9 @@ static int input YY_PROTO ((void));
 
 YY_DECL
 {
-  register yy_state_type yy_current_state;
-  register YY_CHAR *yy_cp, *yy_bp;
-  register int yy_act;
+  yy_state_type yy_current_state;
+  YY_CHAR *yy_cp, *yy_bp;
+  int yy_act;
 
 
   /* Preliminary "actions" */
@@ -827,7 +827,7 @@ YY_DECL
     yy_match:
       do
 	{
-	  register YY_CHAR yy_c = yy_ec[*yy_cp];
+	  YY_CHAR yy_c = yy_ec[*yy_cp];
 	  if (yy_accept[yy_current_state])
 	    {
 	      yy_last_accepting_state = yy_current_state;
@@ -1471,9 +1471,9 @@ YY_DECL
 static int
 yy_get_next_buffer ()
 {
-  register YY_CHAR *dest = yy_current_buffer->yy_ch_buf;
-  register YY_CHAR *source = yytext - 1;	/* copy prev. char, too */
-  register int number_to_move, i;
+  YY_CHAR *dest = yy_current_buffer->yy_ch_buf;
+  YY_CHAR *source = yytext - 1;	/* copy prev. char, too */
+  int number_to_move, i;
   int ret_val;
 
   if (yy_c_buf_p > &yy_current_buffer->yy_ch_buf[yy_n_chars + 1])
@@ -1546,14 +1546,14 @@ yy_get_next_buffer ()
 static yy_state_type
 yy_get_previous_state ()
 {
-  register yy_state_type yy_current_state;
-  register YY_CHAR *yy_cp;
+  yy_state_type yy_current_state;
+  YY_CHAR *yy_cp;
 
   yy_current_state = yy_start;
 
   for (yy_cp = yytext + YY_MORE_ADJ; yy_cp < yy_c_buf_p; ++yy_cp)
     {
-      register YY_CHAR yy_c = (*yy_cp ? yy_ec[*yy_cp] : 1);
+      YY_CHAR yy_c = (*yy_cp ? yy_ec[*yy_cp] : 1);
       if (yy_accept[yy_current_state])
 	{
 	  yy_last_accepting_state = yy_current_state;
@@ -1580,7 +1580,7 @@ yy_get_previous_state ()
 
 #ifdef YY_USE_PROTOS
 static yy_state_type
-yy_try_NUL_trans (register yy_state_type yy_current_state)
+yy_try_NUL_trans (yy_state_type yy_current_state)
 #else
 static yy_state_type
 yy_try_NUL_trans (yy_current_state)
@@ -1588,10 +1588,10 @@ yy_try_NUL_trans (yy_current_state)
 #endif
 
 {
-  register int yy_is_jam;
-  register YY_CHAR *yy_cp = yy_c_buf_p;
+  int yy_is_jam;
+  YY_CHAR *yy_cp = yy_c_buf_p;
 
-  register YY_CHAR yy_c = 1;
+  YY_CHAR yy_c = 1;
   if (yy_accept[yy_current_state])
     {
       yy_last_accepting_state = yy_current_state;
@@ -1612,7 +1612,7 @@ yy_try_NUL_trans (yy_current_state)
 
 #ifdef YY_USE_PROTOS
 static void
-yyunput (YY_CHAR c, register YY_CHAR * yy_bp)
+yyunput (YY_CHAR c, YY_CHAR * yy_bp)
 #else
 static void
 yyunput (c, yy_bp)
@@ -1621,16 +1621,16 @@ yyunput (c, yy_bp)
 #endif
 
 {
-  register YY_CHAR *yy_cp = yy_c_buf_p;
+  YY_CHAR *yy_cp = yy_c_buf_p;
 
   /* undo effects of setting up yytext */
   *yy_cp = yy_hold_char;
 
   if (yy_cp < yy_current_buffer->yy_ch_buf + 2)
     {				/* need to shift things up to make room */
-      register int number_to_move = yy_n_chars + 2;	/* +2 for EOB chars */
-      register YY_CHAR *dest = &yy_current_buffer->yy_ch_buf[yy_current_buffer->yy_buf_size + 2];
-      register YY_CHAR *source = &yy_current_buffer->yy_ch_buf[number_to_move];
+      int number_to_move = yy_n_chars + 2;	/* +2 for EOB chars */
+      YY_CHAR *dest = &yy_current_buffer->yy_ch_buf[yy_current_buffer->yy_buf_size + 2];
+      YY_CHAR *source = &yy_current_buffer->yy_ch_buf[number_to_move];
 
       while (source > yy_current_buffer->yy_ch_buf)
 	*--dest = *--source;

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -391,7 +391,7 @@ add_commas (char *string)
 static void
 strip_trailing_zeros (char *numeric_string)
 {
-  register char *prefix;
+  char *prefix;
   size_t remainder_len;
 
   if (numeric_string == NULL)

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -4337,7 +4337,7 @@ setobj_clear (COL * col)
 void
 setobj_free (COL * col)
 {
-  register DB_COLLECTION *start, *r;
+  DB_COLLECTION *start, *r;
 
   if (col == NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23914

With the upgrade to C++17 a new type of warning will appear as 
`ISO C++17 does not allow 'register' storage class specifier.`

This PR will remove all `register` specifiers in the project.
