### PR TITLE
[CBRD-23914] Fix -Wsign-compare

### DIFF
--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -781,7 +781,7 @@ logddl_write ()
 	}
 
       len = logddl_create_log_msg (buf);
-      if (len < 0 || fwrite (buf, sizeof (char), len, fp) != len)
+      if (len < 0 || fwrite (buf, sizeof (char), len, fp) != (size_t) len)
 	{
 	  goto write_error;
 	}
@@ -807,7 +807,7 @@ logddl_write_tran_str (const char *fmt, ...)
 {
   FILE *fp = NULL;
   char msg[DDL_LOG_BUFFER_SIZE] = { 0 };
-  int len = 0;
+  size_t len = 0;
   struct timeval time_val;
   va_list args;
 
@@ -888,7 +888,7 @@ logddl_write_tran_str (const char *fmt, ...)
 	  len = DDL_LOG_BUFFER_SIZE;
 	}
 
-      if (len < 0 || fwrite (msg, sizeof (char), len, fp) != len)
+      if (fwrite (msg, sizeof (char), len, fp) != len)
 	{
 	  goto write_error;
 	}
@@ -967,7 +967,7 @@ logddl_write_end_for_csql_fileinput (const char *fmt, ...)
       logddl_file_copy (ddl_audit_handle->load_filename, ddl_audit_handle->copy_fullpath);
 
       len = logddl_create_log_msg (buf);
-      if (len < 0 || fwrite (buf, sizeof (char), len, fp) != len)
+      if (len < 0 || fwrite (buf, sizeof (char), len, fp) != (size_t) len)
 	{
 	  goto write_error;
 	}

--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -807,7 +807,7 @@ logddl_write_tran_str (const char *fmt, ...)
 {
   FILE *fp = NULL;
   char msg[DDL_LOG_BUFFER_SIZE] = { 0 };
-  size_t len = 0;
+  int len = 0;
   struct timeval time_val;
   va_list args;
 
@@ -888,7 +888,7 @@ logddl_write_tran_str (const char *fmt, ...)
 	  len = DDL_LOG_BUFFER_SIZE;
 	}
 
-      if (fwrite (msg, sizeof (char), len, fp) != len)
+      if (len < 0 || fwrite (msg, sizeof (char), len, fp) != len)
 	{
 	  goto write_error;
 	}

--- a/src/broker/broker_shm.h
+++ b/src/broker/broker_shm.h
@@ -374,7 +374,7 @@ struct t_appl_server_info
   short shard_id;
   short shard_cas_id;
   short as_id;
-  int session_id;
+  unsigned int session_id;
   int fn_status;
 
   int advance_activate_flag;	/* it is used only in shard */

--- a/src/cci/cci_handle_mng.c
+++ b/src/cci/cci_handle_mng.c
@@ -1205,7 +1205,7 @@ hm_create_health_check_th (char useSSL)
   rv = pthread_attr_setdetachstate (&thread_attr, PTHREAD_CREATE_DETACHED);
   rv = pthread_attr_setscope (&thread_attr, PTHREAD_SCOPE_SYSTEM);
 #endif /* WINDOWS */
-  rv = pthread_create (&health_check_th, &thread_attr, hm_thread_health_checker, (void *) useSSL);
+  rv = pthread_create (&health_check_th, &thread_attr, hm_thread_health_checker, (void *) (size_t) useSSL);
 }
 
 /************************************************************************
@@ -1473,7 +1473,7 @@ hm_thread_health_checker (void *arg)
   int i;
   unsigned char *ip_addr;
   int port;
-  char useSSL = *((char *) (&arg));
+  char useSSL = ((size_t) arg) != 0 ? USESSL : NON_USESSL;
   time_t start_time;
   time_t elapsed_time;
   while (1)

--- a/src/executables/unload_object.c
+++ b/src/executables/unload_object.c
@@ -164,7 +164,7 @@ static int64_t total_approximate_class_objects = 0;
 static FILE *unloadlog_file = NULL;
 
 
-static int get_estimated_objs (HFID * hfid, int64_t *est_objects);
+static int get_estimated_objs (HFID * hfid, int64_t * est_objects);
 static int set_referenced_subclasses (DB_OBJECT * class_);
 static bool check_referenced_domain (DB_DOMAIN * dom_list, bool set_cls_ref, int *num_cls_refp);
 static void extractobjects_cleanup (void);
@@ -186,7 +186,7 @@ static int all_classes_processed (void);
  *    est_objects(out): estimated number of object
  */
 static int
-get_estimated_objs (HFID * hfid, int64_t *est_objects)
+get_estimated_objs (HFID * hfid, int64_t * est_objects)
 {
   int ignore_npages;
   int nobjs = 0;

--- a/src/executables/unload_object.c
+++ b/src/executables/unload_object.c
@@ -1217,11 +1217,11 @@ process_class (int cl_no)
 	{
 	  total = (int) (100 * ((float) total_objects / (float) total_approximate_class_objects));
 	}
-      fprintf (unloadlog_file, MSG_FORMAT "\n", sm_ch_name ((MOBJ) class_ptr), 0, 100, total);
+      fprintf (unloadlog_file, MSG_FORMAT "\n", sm_ch_name ((MOBJ) class_ptr), (long) 0, 100, total);
       fflush (unloadlog_file);
       if (verbose_flag)
 	{
-	  fprintf (stdout, MSG_FORMAT "\n", sm_ch_name ((MOBJ) class_ptr), 0, 100, total);
+	  fprintf (stdout, MSG_FORMAT "\n", sm_ch_name ((MOBJ) class_ptr), (long) 0, 100, total);
 	  fflush (stdout);
 	}
       goto exit_on_end;
@@ -1239,11 +1239,11 @@ process_class (int cl_no)
 	{
 	  total = (int) (100 * ((float) total_objects / (float) total_approximate_class_objects));
 	}
-      fprintf (unloadlog_file, MSG_FORMAT "\n", sm_ch_name ((MOBJ) class_ptr), 0, 100, total);
+      fprintf (unloadlog_file, MSG_FORMAT "\n", sm_ch_name ((MOBJ) class_ptr), (long) 0, 100, total);
       fflush (unloadlog_file);
       if (verbose_flag)
 	{
-	  fprintf (stdout, MSG_FORMAT "\n", sm_ch_name ((MOBJ) class_ptr), 0, 100, total);
+	  fprintf (stdout, MSG_FORMAT "\n", sm_ch_name ((MOBJ) class_ptr), (long) 0, 100, total);
 	  fflush (stdout);
 	}
       goto exit_on_end;

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -6811,7 +6811,8 @@ fileio_initialize_backup (const char *db_full_name_p, const char *backup_destina
   fileio_determine_backup_buffer_size (session_p, buf_size);
 #endif
   if (prm_get_bigint_value (PRM_ID_IO_BACKUP_MAX_VOLUME_SIZE) > 0
-      && (session_p->bkup.iosize >= MIN (prm_get_bigint_value (PRM_ID_IO_BACKUP_MAX_VOLUME_SIZE), DB_INT32_MAX)))
+      && ((UINT64) session_p->bkup.iosize >=
+	  MIN (prm_get_bigint_value (PRM_ID_IO_BACKUP_MAX_VOLUME_SIZE), DB_INT32_MAX)))
     {
       er_log_debug (ARG_FILE_LINE,
 		    "Backup block buffer size %ld must be less "
@@ -8582,7 +8583,7 @@ fileio_flush_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p)
   bool is_force_new_bkvol = false;
 
   if (prm_get_bigint_value (PRM_ID_IO_BACKUP_MAX_VOLUME_SIZE) > 0
-      && session_p->bkup.count > prm_get_bigint_value (PRM_ID_IO_BACKUP_MAX_VOLUME_SIZE))
+      && (UINT64) session_p->bkup.count > prm_get_bigint_value (PRM_ID_IO_BACKUP_MAX_VOLUME_SIZE))
     {
       er_log_debug (ARG_FILE_LINE, "Backup_flush: Backup aborted because count %d larger than max volume size %ld\n",
 		    session_p->bkup.count, prm_get_bigint_value (PRM_ID_IO_BACKUP_MAX_VOLUME_SIZE));
@@ -8676,7 +8677,7 @@ fileio_flush_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p)
 
 	  if (is_interactive_need_new || is_force_new_bkvol
 	      || (prm_get_bigint_value (PRM_ID_IO_BACKUP_MAX_VOLUME_SIZE) > 0
-		  && (session_p->bkup.voltotalio >= prm_get_bigint_value (PRM_ID_IO_BACKUP_MAX_VOLUME_SIZE))))
+		  && ((UINT64) session_p->bkup.voltotalio >= prm_get_bigint_value (PRM_ID_IO_BACKUP_MAX_VOLUME_SIZE))))
 	    {
 #if defined(CUBRID_DEBUG)
 	      fprintf (stdout, "open a new backup volume\n");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23914

Comparison between signed and unsigned variables generate warnings.
To fix this the variable type was changed where possible and cast were used where not.