### PR TITLE
[CBRD-23915] backport #2748 to 11.0.1, broker_log_converter

### DIFF
--- a/src/broker/broker_log_converter.c
+++ b/src/broker/broker_log_converter.c
@@ -406,12 +406,7 @@ log_bind_value (char *str, int bind_len, int lineno, FILE * outfp)
 
   if (bind_len > 0)
     {
-      fprintf (outfp, "B %d %d ", type, bind_len);
-      if (bind_len > 1)
-	{
-	  fwrite (value_p, bind_len - 1, 1, outfp);
-	}
-      fwrite ("\n", 1, 1, outfp);
+      fprintf (outfp, "B %d %d %s\n", type, bind_len, value_p);
     }
   else
     {

--- a/src/broker/broker_log_util.c
+++ b/src/broker/broker_log_util.c
@@ -131,10 +131,36 @@ is_bind_with_size (char *buf, int *tot_val_size, int *info_size)
     {
       *info_size = (char *) (p + 1) - (char *) buf;
     }
-  if (tot_val_size)
+
+  switch (type)
     {
-      *tot_val_size = size;
+    case CCI_U_TYPE_CHAR:
+    case CCI_U_TYPE_STRING:
+    case CCI_U_TYPE_NCHAR:
+    case CCI_U_TYPE_VARNCHAR:
+      {
+	int len = strlen (p + 1);
+
+	if (p[len] == '\n')
+	  {
+	    p[len] = 0;
+	    len--;
+	  }
+
+	if (tot_val_size)
+	  {
+	    *tot_val_size = len + 1;
+	  }
+      }
+      break;
+    default:
+      if (tot_val_size)
+	{
+	  *tot_val_size = size;
+	}
+      break;
     }
+
   return true;
 
 error_on_val_size:
@@ -150,7 +176,7 @@ is_bind_with_size (char *buf, int *tot_val_size, int *info_size)
 {
   char *msg;
   char *p, *q;
-  char size[256];
+  char size[256] = { 0, };
   char *value_p;
   char *size_begin;
   char *size_end;
@@ -213,7 +239,13 @@ is_bind_with_size (char *buf, int *tot_val_size, int *info_size)
     {
       *info_size = (char *) info_end - (char *) buf;
     }
-  if (tot_val_size)
+
+  if ((strncmp (p, "CHAR", 4) != 0) || (strncmp (p, "VARCHAR", 7) != 0) || (strncmp (p, "NCHAR", 5) != 0)
+      || (strncmp (p, "VARNCHAR", 8) != 0))
+    {
+      *tot_val_size = strlen (info_end);
+    }
+  else if (tot_val_size)
     {
       len = size_end - size_begin;
       if (len > (int) sizeof (size))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23915

Purpose
* Log more meaningful information in SQL_LOG for binding VARCHAR variables:
* Log num chars instead of num bytes
* backport #2748 to 11.0.1

Implementation
N/A

Remarks
N/A
