### PR TITLE
[CBRD-23914] Deprecated usage of ftime

### DIFF
--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -40,6 +40,7 @@
 #include <signal.h>
 #endif
 #include <assert.h>
+#include <chrono>
 
 #include "porting.h"
 #include "cas_common.h"
@@ -1275,9 +1276,12 @@ logddl_get_time_string (char *buf, struct timeval *time_val)
       struct timeb tb;
 
       /* current time */
-      (void) ftime (&tb);
-      sec = tb.time;
-      millisec = tb.millitm;
+      timespec ts = { };
+      timespec_get (&ts, TIME_UTC);
+      sec = ts.tv_sec;
+      // *INDENT-OFF*
+      millisec = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::nanoseconds (ts.tv_nsec)).count();
+      // *INDENT-ON*
     }
   else
     {

--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -40,7 +40,6 @@
 #include <signal.h>
 #endif
 #include <assert.h>
-#include <chrono>
 
 #include "porting.h"
 #include "cas_common.h"

--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -49,6 +49,7 @@
 #include "system_parameter.h"
 #include "environment_variable.h"
 #include "broker_config.h"
+#include "util_func.h"
 
 #define DDL_LOG_MSG 	            (256)
 #define DDL_LOG_PATH    	    "log/ddl_audit"
@@ -1273,15 +1274,8 @@ logddl_get_time_string (char *buf, struct timeval *time_val)
 
   if (time_val == NULL)
     {
-      struct timeb tb;
-
       /* current time */
-      timespec ts = { };
-      timespec_get (&ts, TIME_UTC);
-      sec = ts.tv_sec;
-      // *INDENT-OFF*
-      millisec = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::nanoseconds (ts.tv_nsec)).count();
-      // *INDENT-ON*
+      util_get_second_and_ms_since_epoch (&sec, &millisec);
     }
   else
     {

--- a/src/base/tz_support.c
+++ b/src/base/tz_support.c
@@ -84,7 +84,7 @@ typedef enum ds_search_direction DS_SEARCH_DIRECTION;
 
 
 #define FULL_DATE(jul_date, time_sec) ((full_date_t) jul_date * 86400ll \
-				       + (full_date_t) time_sec)
+                                       + (full_date_t) time_sec)
 #define TIME_OFFSET(is_utc, offset) \
   ((is_utc) ? (-offset) : (offset))
 #define ABS(i) ((i) >= 0 ? (i) : -(i))
@@ -188,9 +188,9 @@ static int tz_get_iana_zone_id_by_windows_zone (const char *windows_zone_name);
     v = (SYM_TYPE) TZ_GET_SYM_ADDR (lh, SYM_NAME);			    \
     if (v == NULL)							    \
       {									    \
-	strncpy (sym_name, (SYM_NAME), sizeof (sym_name) - 1);		    \
-	sym_name[sizeof (sym_name) - 1] = '\0';				    \
-	goto error_loading_symbol;					    \
+        strncpy (sym_name, (SYM_NAME), sizeof (sym_name) - 1);		    \
+        sym_name[sizeof (sym_name) - 1] = '\0';				    \
+        goto error_loading_symbol;					    \
       }									    \
   } while (0)
 
@@ -5470,4 +5470,26 @@ exit:
   tz_set_data (&save_data);
 
   return err_status;
+}
+
+//TODO: make tz_get_offset_in_mins get into account DST
+/*
+ * tz_get_offset_in_mins () - time zone offset in minutes from GMT
+ */
+int
+tz_get_offset_in_mins ()
+{
+  time_t currtime;
+  struct tm *timeinfo;
+
+  time (&currtime);
+  timeinfo = gmtime (&currtime);
+  time_t utc = mktime (timeinfo);
+  timeinfo = localtime (&currtime);
+  time_t local = mktime (timeinfo);
+
+  // Get offset in minutes from UTC
+  int offsetFromUTC = difftime (utc, local) / 60;
+
+  return offsetFromUTC;
 }

--- a/src/base/tz_support.h
+++ b/src/base/tz_support.h
@@ -228,6 +228,7 @@ extern "C"
   extern int tz_create_datetimetz_from_parts (const int m, const int d, const int y, const int h, const int mi,
 					      const int s, const int ms, const TZ_ID * tz_id, DB_DATETIMETZ * dt_tz);
   extern int conv_tz (void *, const void *, DB_TYPE);
+  int tz_get_offset_in_mins ();	//time zone offset in minutes from GMT
 #ifdef __cplusplus
 }
 #endif

--- a/src/base/util_func.c
+++ b/src/base/util_func.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <signal.h>
 #include <assert.h>
+#include <chrono>
 #include <time.h>
 #include <stdarg.h>
 #include <sys/timeb.h>
@@ -629,7 +630,7 @@ util_log_header (char *buf, size_t buf_len)
 {
   struct tm tm, *tm_p;
   time_t sec;
-  int millisec, len;
+  int len;
   struct timeb tb;
   char *p;
   const char *pid;
@@ -640,9 +641,12 @@ util_log_header (char *buf, size_t buf_len)
     }
 
   /* current time */
-  (void) ftime (&tb);
-  sec = tb.time;
-  millisec = tb.millitm;
+  timespec ts = { };
+  timespec_get (&ts, TIME_UTC);
+  sec = ts.tv_sec;
+  // *INDENT-OFF*
+  auto millisec = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::nanoseconds (ts.tv_nsec));
+  // *INDENT-ON*
 
   tm_p = localtime_r (&sec, &tm);
 
@@ -651,7 +655,7 @@ util_log_header (char *buf, size_t buf_len)
   buf_len -= len;
 
   pid = envvar_get (UTIL_PID_ENVVAR_NAME);
-  len += snprintf (p, buf_len, ".%03d (%s) ", millisec, ((pid == NULL) ? "    " : pid));
+  len += snprintf (p, buf_len, ".%03ld (%s) ", millisec.count (), ((pid == NULL) ? "    " : pid));
 
   assert (len <= UTIL_LOG_MAX_HEADER_LEN);
 

--- a/src/base/util_func.c
+++ b/src/base/util_func.c
@@ -61,6 +61,11 @@ static FILE *fopen_and_lock (const char *path);
 static int util_log_header (char *buf, size_t buf_len);
 static int util_log_write_internal (const char *msg, const char *prefix_str);
 
+// *INDENT-OFF*
+template <typename Duration>
+static void util_get_seconds_and_rest_since_epoch (std::chrono::seconds &secs, Duration &rest);
+// *INDENT-ON*
+
 /*
  * hashpjw() - returns hash value of given string
  *   return: hash value
@@ -631,9 +636,9 @@ util_log_header (char *buf, size_t buf_len)
   struct tm tm, *tm_p;
   time_t sec;
   int len;
-  struct timeb tb;
   char *p;
   const char *pid;
+  int millisec;
 
   if (buf == NULL)
     {
@@ -641,12 +646,7 @@ util_log_header (char *buf, size_t buf_len)
     }
 
   /* current time */
-  timespec ts = { };
-  timespec_get (&ts, TIME_UTC);
-  sec = ts.tv_sec;
-  // *INDENT-OFF*
-  auto millisec = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::nanoseconds (ts.tv_nsec));
-  // *INDENT-ON*
+  util_get_second_and_ms_since_epoch (&sec, &millisec);
 
   tm_p = localtime_r (&sec, &tm);
 
@@ -655,7 +655,7 @@ util_log_header (char *buf, size_t buf_len)
   buf_len -= len;
 
   pid = envvar_get (UTIL_PID_ENVVAR_NAME);
-  len += snprintf (p, buf_len, ".%03ld (%s) ", millisec.count (), ((pid == NULL) ? "    " : pid));
+  len += snprintf (p, buf_len, ".%03d (%s) ", millisec, ((pid == NULL) ? "    " : pid));
 
   assert (len <= UTIL_LOG_MAX_HEADER_LEN);
 
@@ -811,3 +811,29 @@ util_bsearch (const void *key, const void *base, int n_elems, unsigned int sizeo
   /* mid is the right position for key */
   return mid;
 }
+
+// *INDENT-OFF*
+template <typename Duration>
+void
+util_get_seconds_and_rest_since_epoch (std::chrono::seconds &secs, Duration &rest)
+{
+  using clock_t = std::chrono::system_clock;
+  using timept_secs = std::chrono::time_point<clock_t, std::chrono::seconds>;
+  auto now_timepoint = clock_t::now ();
+  timept_secs now_in_secs = std::chrono::time_point_cast<std::chrono::seconds> (now_timepoint);
+  secs = now_in_secs.time_since_epoch ();
+  rest = std::chrono::duration_cast<Duration> (now_timepoint - now_in_secs);
+}
+
+void
+util_get_second_and_ms_since_epoch (time_t * secs, int *msec)
+{
+  assert (secs != NULL && msec != NULL);
+  std::chrono::seconds secs_since_epoch;
+  std::chrono::milliseconds rest_in_msec;
+  util_get_seconds_and_rest_since_epoch<std::chrono::milliseconds> (secs_since_epoch, rest_in_msec);
+  *secs = static_cast<time_t> (secs_since_epoch.count ());
+  *msec = static_cast<int> (rest_in_msec.count ());
+  assert (*msec < 1000);
+}
+// *INDENT-ON*

--- a/src/base/util_func.h
+++ b/src/base/util_func.h
@@ -29,6 +29,7 @@
 
 #include <sys/types.h>
 #include <math.h>
+#include <time.h>
 
 #define UTIL_PID_ENVVAR_NAME         "UTIL_PID"
 #define UTIL_infinity()     (HUGE_VAL)
@@ -72,5 +73,7 @@ extern int util_log_write_command (int argc, char *argv[]);
 
 extern int util_bsearch (const void *key, const void *base, int n_elems, unsigned int sizeof_elem,
 			 int (*func_compare) (const void *, const void *), bool * out_found);
+
+extern void util_get_second_and_ms_since_epoch (time_t * secs, int *msec);
 
 #endif /* _UTIL_FUNC_H_ */

--- a/src/broker/broker_util.c
+++ b/src/broker/broker_util.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <chrono>
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>
@@ -421,7 +422,7 @@ ut_time_string (char *buf, struct timeval *time_val)
 {
   struct tm tm, *tm_p;
   time_t sec;
-  int millisec;
+  long millisec;
 
   if (buf == NULL)
     {
@@ -430,12 +431,12 @@ ut_time_string (char *buf, struct timeval *time_val)
 
   if (time_val == NULL)
     {
-      struct timeb tb;
-
-      /* current time */
-      (void) ftime (&tb);
-      sec = tb.time;
-      millisec = tb.millitm;
+      timespec ts = { };
+      timespec_get (&ts, TIME_UTC);
+      sec = ts.tv_sec;
+      // *INDENT-OFF*
+      millisec = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::nanoseconds (ts.tv_nsec)).count();
+      // *INDENT-ON*
     }
   else
     {

--- a/src/broker/broker_util.c
+++ b/src/broker/broker_util.c
@@ -26,7 +26,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <chrono>
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>

--- a/src/broker/broker_util.c
+++ b/src/broker/broker_util.c
@@ -60,6 +60,7 @@
 #include "broker_filename.h"
 #include "environment_variable.h"
 #include "porting.h"
+#include "util_func.h"
 
 char db_err_log_file[BROKER_PATH_MAX];
 
@@ -422,7 +423,7 @@ ut_time_string (char *buf, struct timeval *time_val)
 {
   struct tm tm, *tm_p;
   time_t sec;
-  long millisec;
+  int millisec;
 
   if (buf == NULL)
     {
@@ -431,12 +432,7 @@ ut_time_string (char *buf, struct timeval *time_val)
 
   if (time_val == NULL)
     {
-      timespec ts = { };
-      timespec_get (&ts, TIME_UTC);
-      sec = ts.tv_sec;
-      // *INDENT-OFF*
-      millisec = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::nanoseconds (ts.tv_nsec)).count();
-      // *INDENT-ON*
+      util_get_second_and_ms_since_epoch (&sec, &millisec);
     }
   else
     {

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -30,6 +30,7 @@
 #include <sys/timeb.h>
 #include <time.h>
 #include <assert.h>
+#include <chrono>
 
 #include "authenticate.h"
 #include "db.h"
@@ -68,7 +69,7 @@ enum
 };
 
 static struct timeb base_server_timeb = { 0, 0, 0, 0 };
-static struct timeb base_client_timeb = { 0, 0, 0, 0 };
+static timespec base_client_time = { };
 
 static int get_dimension_of (PT_NODE ** array);
 static DB_SESSION *db_open_local (void);
@@ -411,8 +412,6 @@ db_calculate_current_server_time (PARSER_CONTEXT * parser)
   DB_DATETIME datetime;
 
   struct timeb curr_server_timeb;
-  struct timeb curr_client_timeb;
-  int diff_mtime;
   int diff_time;
 
   if (base_server_timeb.time == 0)
@@ -420,9 +419,13 @@ db_calculate_current_server_time (PARSER_CONTEXT * parser)
       return;
     }
 
-  ftime (&curr_client_timeb);
-  diff_time = (int) (curr_client_timeb.time - base_client_timeb.time);
-  diff_mtime = curr_client_timeb.millitm - base_client_timeb.millitm;
+  timespec curr_client_time = { };
+  timespec_get (&curr_client_time, TIME_UTC);
+  diff_time = (int) (curr_client_time.tv_sec - base_client_time.tv_sec);
+  // *INDENT-OFF*
+  auto diff_mtime = std::chrono::duration_cast<std::chrono::milliseconds>
+        (std::chrono::nanoseconds (curr_client_time.tv_nsec - base_client_time.tv_nsec)).count ();
+  // *INDENT-ON*
 
   if (diff_time > MAX_SERVER_TIME_CACHE)
     {
@@ -484,7 +487,7 @@ db_set_base_server_time (DB_VALUE * db_val)
   base_server_timeb.millitm = dt->time % 1000;	/* set milliseconds */
 
   base_server_timeb.time = mktime (&c_time_struct);
-  ftime (&base_client_timeb);
+  timespec_get (&base_client_time, TIME_UTC);
 }
 
 /*

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -30,7 +30,6 @@
 #include <sys/timeb.h>
 #include <time.h>
 #include <assert.h>
-#include <chrono>
 
 #include "authenticate.h"
 #include "db.h"

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -1825,18 +1825,21 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	  DB_TIMESTAMP db_timestamp;
 	  DB_DATETIME sys_datetime;
 	  DB_TIME db_time;
-	  struct timeb tloc;
+	  timespec tloc = { };
 	  struct tm *c_time_struct, tm_val;
 
 	  /* get the local time of the system */
-	  ftime (&tloc);
-	  c_time_struct = localtime_r (&tloc.time, &tm_val);
+	  timespec_get (&tloc, TIME_UTC);
+	  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
 
 	  if (c_time_struct != NULL)
 	    {
+	      // *INDENT-OFF*
+	      auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
+	      // *INDENT-ON*
 	      db_datetime_encode (&sys_datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday,
 				  c_time_struct->tm_year + 1900, c_time_struct->tm_hour, c_time_struct->tm_min,
-				  c_time_struct->tm_sec, tloc.millitm);
+				  c_time_struct->tm_sec, ms.count ());
 	    }
 
 	  db_time = sys_datetime.time / 1000;

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -1825,21 +1825,19 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	  DB_TIMESTAMP db_timestamp;
 	  DB_DATETIME sys_datetime;
 	  DB_TIME db_time;
-	  timespec tloc = { };
+	  time_t sec;
+	  int millisec;
 	  struct tm *c_time_struct, tm_val;
 
 	  /* get the local time of the system */
-	  timespec_get (&tloc, TIME_UTC);
-	  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
+	  util_get_second_and_ms_since_epoch (&sec, &millisec);
+	  c_time_struct = localtime_r (&sec, &tm_val);
 
 	  if (c_time_struct != NULL)
 	    {
-	      // *INDENT-OFF*
-	      auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
-	      // *INDENT-ON*
 	      db_datetime_encode (&sys_datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday,
 				  c_time_struct->tm_year + 1900, c_time_struct->tm_hour, c_time_struct->tm_min,
-				  c_time_struct->tm_sec, ms.count ());
+				  c_time_struct->tm_sec, millisec);
 	    }
 
 	  db_time = sys_datetime.time / 1000;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14781,20 +14781,18 @@ qexec_execute_query (THREAD_ENTRY * thread_p, xasl_node * xasl, int dbval_cnt, c
   /* form the value descriptor to represent positional values */
   xasl_state.vd.dbval_cnt = dbval_cnt;
   xasl_state.vd.dbval_ptr = (DB_VALUE *) dbval_ptr;
-  timespec tloc = { };
-  timespec_get (&tloc, TIME_UTC);
-  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
+  time_t sec;
+  int millisec;
+  util_get_second_and_ms_since_epoch (&sec, &millisec);
+  c_time_struct = localtime_r (&sec, &tm_val);
 
-  xasl_state.vd.sys_epochtime = (DB_TIMESTAMP) tloc.tv_sec;
+  xasl_state.vd.sys_epochtime = (DB_TIMESTAMP) sec;
 
   if (c_time_struct != NULL)
     {
-      // *INDENT-OFF*
-      auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
-      // *INDENT-ON*
       db_datetime_encode (&xasl_state.vd.sys_datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday,
 			  c_time_struct->tm_year + 1900, c_time_struct->tm_hour, c_time_struct->tm_min,
-			  c_time_struct->tm_sec, ms.count ());
+			  c_time_struct->tm_sec, millisec);
     }
 
   rand_buf_p = qmgr_get_rand_buf (thread_p);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -81,7 +81,6 @@
 #include "xasl_predicate.hpp"
 
 #include <vector>
-#include <chrono>
 
 // XASL_STATE
 typedef struct xasl_state XASL_STATE;

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -54,8 +54,10 @@
 #include "es_common.h"
 #include "db_elo.h"
 #include "string_regex.hpp"
+#include "tz_support.h"
 
 #include <algorithm>
+#include <chrono>
 #include <string>
 #include <locale>
 
@@ -13205,7 +13207,7 @@ db_sys_datetime (DB_VALUE * result_datetime)
   int error_status = NO_ERROR;
   DB_DATETIME datetime;
 
-  struct timeb tloc;
+  timespec tloc = { };
   struct tm *c_time_struct, tm_val;
 
   assert (result_datetime != (DB_VALUE *) NULL);
@@ -13213,14 +13215,14 @@ db_sys_datetime (DB_VALUE * result_datetime)
   /* now return null */
   db_value_domain_init (result_datetime, DB_TYPE_DATETIME, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 
-  if (ftime (&tloc) != 0)
+  if (timespec_get (&tloc, TIME_UTC) != 0)
     {
       error_status = ER_SYSTEM_DATE;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  c_time_struct = localtime_r (&tloc.time, &tm_val);
+  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
   if (c_time_struct == NULL)
     {
       error_status = ER_SYSTEM_DATE;
@@ -13228,8 +13230,11 @@ db_sys_datetime (DB_VALUE * result_datetime)
       return error_status;
     }
 
+  // *INDENT-OFF*
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
+  // *INDENT-ON*
   db_datetime_encode (&datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900,
-		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, tloc.millitm);
+		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, ms.count ());
   db_make_datetime (result_datetime, &datetime);
 
   return error_status;
@@ -13250,20 +13255,20 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
 {
   int error_status = NO_ERROR;
   DB_DATETIME datetime;
-  struct timeb tloc;
+  timespec tloc = { };
   struct tm *c_time_struct, tm_val;
 
   assert (dt_dbval != NULL);
   assert (ts_dbval != NULL);
 
-  if (ftime (&tloc) != 0)
+  if (timespec_get (&tloc, TIME_UTC) != 0)
     {
       error_status = ER_SYSTEM_DATE;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
       return error_status;
     }
 
-  c_time_struct = localtime_r (&tloc.time, &tm_val);
+  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
   if (c_time_struct == NULL)
     {
       error_status = ER_SYSTEM_DATE;
@@ -13271,11 +13276,14 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
       return error_status;
     }
 
+  // *INDENT-OFF*
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
+  // *INDENT-ON*
   db_datetime_encode (&datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900,
-		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, tloc.millitm);
+		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, ms.count ());
 
   db_make_datetime (dt_dbval, &datetime);
-  db_make_timestamp (ts_dbval, (DB_TIMESTAMP) tloc.time);
+  db_make_timestamp (ts_dbval, (DB_TIMESTAMP) tloc.tv_sec);
 
   return error_status;
 }
@@ -13287,24 +13295,12 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
 int
 db_sys_timezone (DB_VALUE * result_timezone)
 {
-  int error_status = NO_ERROR;
-  struct timeb tloc;
-
   assert (result_timezone != (DB_VALUE *) NULL);
 
   /* now return null */
   db_value_domain_init (result_timezone, DB_TYPE_INTEGER, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 
-  /* Need checking error */
-
-  if (ftime (&tloc) == -1)
-    {
-      error_status = ER_SYSTEM_DATE;
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
-      return error_status;
-    }
-
-  db_make_int (result_timezone, tloc.timezone);
+  db_make_int (result_timezone, tz_get_offset_in_mins ());
   return NO_ERROR;
 }
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -58,7 +58,6 @@
 #include "util_func.h"
 
 #include <algorithm>
-#include <chrono>
 #include <string>
 #include <locale>
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -55,6 +55,7 @@
 #include "db_elo.h"
 #include "string_regex.hpp"
 #include "tz_support.h"
+#include "util_func.h"
 
 #include <algorithm>
 #include <chrono>
@@ -13207,7 +13208,8 @@ db_sys_datetime (DB_VALUE * result_datetime)
   int error_status = NO_ERROR;
   DB_DATETIME datetime;
 
-  timespec tloc = { };
+  time_t sec;
+  int millisec;
   struct tm *c_time_struct, tm_val;
 
   assert (result_datetime != (DB_VALUE *) NULL);
@@ -13215,14 +13217,9 @@ db_sys_datetime (DB_VALUE * result_datetime)
   /* now return null */
   db_value_domain_init (result_datetime, DB_TYPE_DATETIME, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
 
-  if (timespec_get (&tloc, TIME_UTC) != 0)
-    {
-      error_status = ER_SYSTEM_DATE;
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
-      return error_status;
-    }
+  util_get_second_and_ms_since_epoch (&sec, &millisec);
 
-  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
+  c_time_struct = localtime_r (&sec, &tm_val);
   if (c_time_struct == NULL)
     {
       error_status = ER_SYSTEM_DATE;
@@ -13230,11 +13227,8 @@ db_sys_datetime (DB_VALUE * result_datetime)
       return error_status;
     }
 
-  // *INDENT-OFF*
-  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
-  // *INDENT-ON*
   db_datetime_encode (&datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900,
-		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, ms.count ());
+		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, millisec);
   db_make_datetime (result_datetime, &datetime);
 
   return error_status;
@@ -13255,20 +13249,16 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
 {
   int error_status = NO_ERROR;
   DB_DATETIME datetime;
-  timespec tloc = { };
+  time_t sec;
+  int millisec;
   struct tm *c_time_struct, tm_val;
 
   assert (dt_dbval != NULL);
   assert (ts_dbval != NULL);
 
-  if (timespec_get (&tloc, TIME_UTC) != 0)
-    {
-      error_status = ER_SYSTEM_DATE;
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_status, 0);
-      return error_status;
-    }
+  util_get_second_and_ms_since_epoch (&sec, &millisec);
 
-  c_time_struct = localtime_r (&tloc.tv_sec, &tm_val);
+  c_time_struct = localtime_r (&sec, &tm_val);
   if (c_time_struct == NULL)
     {
       error_status = ER_SYSTEM_DATE;
@@ -13276,14 +13266,11 @@ db_sys_date_and_epoch_time (DB_VALUE * dt_dbval, DB_VALUE * ts_dbval)
       return error_status;
     }
 
-  // *INDENT-OFF*
-  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds(tloc.tv_nsec));
-  // *INDENT-ON*
   db_datetime_encode (&datetime, c_time_struct->tm_mon + 1, c_time_struct->tm_mday, c_time_struct->tm_year + 1900,
-		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, ms.count ());
+		      c_time_struct->tm_hour, c_time_struct->tm_min, c_time_struct->tm_sec, millisec);
 
   db_make_datetime (dt_dbval, &datetime);
-  db_make_timestamp (ts_dbval, (DB_TIMESTAMP) tloc.tv_sec);
+  db_make_timestamp (ts_dbval, (DB_TIMESTAMP) sec);
 
   return error_status;
 }

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -445,7 +445,7 @@ EXPORTS
     utility_get_generic_message
     util_make_ha_conf
     util_get_ha_mode_for_sa_utils
-	util_get_second_and_ms_since_epoch
+    util_get_second_and_ms_since_epoch
     util_is_localhost
     util_free_ha_conf
     util_split_string

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -445,6 +445,7 @@ EXPORTS
     utility_get_generic_message
     util_make_ha_conf
     util_get_ha_mode_for_sa_utils
+	util_get_second_and_ms_since_epoch
     util_is_localhost
     util_free_ha_conf
     util_split_string


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23914

The use of ftime is deprecated and should be replaced with functions from std::chrono
