### PR TITLE
[CBRD-23932] Core dumped in cubbase::restrack_assert at src/base/resource_tracker.hpp:455

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -5058,6 +5058,7 @@ btree_search_nonleaf_page (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pa
 
   while (left <= right)
     {
+      btree_clear_key_value (&clear_key, &temp_key); // clear previous key
       middle = CEIL_PTVDIV ((left + right), 2);	/* get the middle record */
 
       assert (middle > 0);
@@ -5451,6 +5452,8 @@ btree_search_leaf_page (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_
       /* Compare searched key with current middle key. */
       c = btree_compare_key (key, &temp_key, btid->key_type, 1, 1, &start_col);
 
+      /* Clear current middle key. */
+      btree_clear_key_value (&clear_key, &temp_key);
       if (c == DB_UNK)
 	{
 	  /* Unknown compare result? */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -5058,7 +5058,7 @@ btree_search_nonleaf_page (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pa
 
   while (left <= right)
     {
-      btree_clear_key_value (&clear_key, &temp_key); // clear previous key
+      btree_clear_key_value (&clear_key, &temp_key);
       middle = CEIL_PTVDIV ((left + right), 2);	/* get the middle record */
 
       assert (middle > 0);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23932

revert removing btree_clear_key_value().
