### PR TITLE
[CBRD-23929]  Improved use of parser_init_node() function

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -226,13 +226,13 @@ qo_check_nullable_expr_with_spec (PARSER_CONTEXT * parser, PT_NODE * node, void 
 	case PT_IFNULL:
 	case PT_ISNULL:
 	case PT_CONCAT_WS:
-	    info->appears = false;
-	    parser_walk_tree (parser, node, qo_get_name_by_spec_id, info, NULL, NULL);
-	    if (info->appears)
-	      {
-		info->nullable = true;
-		*continue_walk = PT_STOP_WALK;
-	      }
+	  info->appears = false;
+	  parser_walk_tree (parser, node, qo_get_name_by_spec_id, info, NULL, NULL);
+	  if (info->appears)
+	    {
+	      info->nullable = true;
+	      *continue_walk = PT_STOP_WALK;
+	    }
 	  break;
 	default:
 	  break;
@@ -839,7 +839,6 @@ qo_construct_new_set (PARSER_CONTEXT * parser, PT_NODE * node)
   /* create mset constructor subtree */
   if (arg && (set = parser_new_node (parser, PT_FUNCTION)) != NULL)
     {
-      parser_init_node (set);
       set->info.function.function_type = F_SEQUENCE;
       set->info.function.arg_list = arg;
       set->type_enum = PT_TYPE_SEQUENCE;
@@ -875,13 +874,14 @@ qo_make_new_derived_tblspec (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * 
   const char *dtblnam, *dattnam;
 
   dtbl = qo_construct_new_set (parser, pred);
-  if (dtbl)
+  if (!dtbl)
     {
-      spec = parser_new_node (parser, PT_SPEC);
+      return NULL;
     }
+
+  spec = parser_new_node (parser, PT_SPEC);
   if (spec)
     {
-      parser_init_node (spec);
       spec_id = (UINTPTR) spec;
       spec->info.spec.id = spec_id;
       spec->info.spec.only_all = PT_ONLY;
@@ -913,7 +913,6 @@ qo_make_new_derived_tblspec (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * 
 	  node->info.spec.path_conjuncts = eq = parser_new_node (parser, PT_EXPR);
 	  if (eq)
 	    {
-	      parser_init_node (eq);
 	      eq->type_enum = PT_TYPE_LOGICAL;
 	      eq->info.expr.op = PT_EQ;
 	      eq->info.expr.arg1 = pt_name (parser, dattnam);
@@ -5496,7 +5495,8 @@ qo_rewrite_outerjoin (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
       prev_spec = NULL;
       for (spec = node->info.query.q.select.from; spec; prev_spec = spec, spec = spec->next)
 	{
-	  if (spec->info.spec.join_type == PT_JOIN_LEFT_OUTER || (spec->info.spec.join_type == PT_JOIN_RIGHT_OUTER && prev_spec))
+	  if (spec->info.spec.join_type == PT_JOIN_LEFT_OUTER
+	      || (spec->info.spec.join_type == PT_JOIN_RIGHT_OUTER && prev_spec))
 	    {
 	      if (spec->info.spec.join_type == PT_JOIN_LEFT_OUTER)
 		{

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -6379,7 +6379,7 @@ pt_resolve_star (PARSER_CONTEXT * parser, PT_NODE * from, PT_NODE * attr)
 		    }
 		  else
 		    {
-		      parser_init_node (attr_name, attr_name->node_type, false, true);
+		      parser_reuse_init_node (attr_name);
 		      attr_name->node_type = PT_DOT_;
 		      attr_name->info.dot.arg1 = dot_arg1;
 		      attr_name->info.dot.arg2 = dot_arg2;

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -6379,7 +6379,7 @@ pt_resolve_star (PARSER_CONTEXT * parser, PT_NODE * from, PT_NODE * attr)
 		    }
 		  else
 		    {
-		      parser_init_node (attr_name);
+		      parser_init_node (attr_name, attr_name->node_type, false, true);
 		      attr_name->node_type = PT_DOT_;
 		      attr_name->info.dot.arg1 = dot_arg1;
 		      attr_name->info.dot.arg2 = dot_arg2;
@@ -7479,7 +7479,6 @@ pt_create_pt_expr_equal_node (PARSER_CONTEXT * parser, PT_NODE * arg1, PT_NODE *
       return NULL;
     }
 
-  parser_init_node (expr);
   expr->type_enum = PT_TYPE_LOGICAL;
   expr->info.expr.op = PT_EQ;
   expr->info.expr.arg1 = arg1;
@@ -7511,7 +7510,6 @@ pt_create_pt_name (PARSER_CONTEXT * parser, PT_NODE * spec, NATURAL_JOIN_ATTR_IN
       return NULL;
     }
 
-  parser_init_node (name);
   name->info.name.original = pt_append_string (parser, NULL, attr->name);
   name->type_enum = attr->type_enum;
   name->info.name.meta_class = attr->meta_class;
@@ -7559,7 +7557,6 @@ pt_create_pt_expr_and_node (PARSER_CONTEXT * parser, PT_NODE * arg1, PT_NODE * a
       return NULL;
     }
 
-  parser_init_node (expr);
   expr->type_enum = PT_TYPE_LOGICAL;
   expr->info.expr.op = PT_AND;
   expr->info.expr.arg1 = arg1;

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -6379,7 +6379,7 @@ pt_resolve_star (PARSER_CONTEXT * parser, PT_NODE * from, PT_NODE * attr)
 		    }
 		  else
 		    {
-		      parser_reuse_init_node (attr_name);
+		      parser_reinit_node (attr_name);
 		      attr_name->node_type = PT_DOT_;
 		      attr_name->info.dot.arg1 = dot_arg1;
 		      attr_name->info.dot.arg2 = dot_arg2;

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -3009,7 +3009,7 @@ pt_bind_set_type (PARSER_CONTEXT * parser, PT_NODE * node, DB_VALUE * val, int *
     }
   set_type = NULL;
 
-  parser_init_node (&tmp, PT_DATA_TYPE, true, false);
+  parser_init_node (&tmp, PT_DATA_TYPE);
   tmp.line_number = node->line_number;
   tmp.column_number = node->column_number;
 

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -3009,8 +3009,7 @@ pt_bind_set_type (PARSER_CONTEXT * parser, PT_NODE * node, DB_VALUE * val, int *
     }
   set_type = NULL;
 
-  tmp.node_type = PT_DATA_TYPE;
-  parser_init_node (&tmp);
+  parser_init_node (&tmp, PT_DATA_TYPE, true, false);
   tmp.line_number = node->line_number;
   tmp.column_number = node->column_number;
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2200,10 +2200,8 @@ parser_new_node (PARSER_CONTEXT * parser, PT_NODE_TYPE node_type)
   node = parser_create_node (parser);
   if (node)
     {
-      node->node_type = node_type;
+      parser_init_node (node, node_type, true, false);
       pt_parser_line_col (node);
-      parser_init_node (node);
-
       node->sql_user_text = g_query_string;
       node->sql_user_text_len = g_query_string_len;
     }
@@ -2216,52 +2214,55 @@ parser_new_node (PARSER_CONTEXT * parser, PT_NODE_TYPE node_type)
  *   node(in/out):
  */
 PT_NODE *
-parser_init_node (PT_NODE * node)
+parser_init_node (PT_NODE * node, PT_NODE_TYPE node_type, bool bFirst, bool bKeepLnCn)
 {
+  assert (node_type < PT_LAST_NODE_NUMBER);
+  int parser_id = node->parser_id;
+  if (bFirst)
+    {
+      memset (node, 0x00, sizeof (PT_NODE));
+      node->buffer_pos = -1;
+      node->type_enum = PT_TYPE_NONE;
+
+      node->parser_id = parser_id;
+      node->node_type = node_type;
+      node = (pt_init_f[node_type]) (node);
+      return node;
+    }
+
   if (node)
     {
       PARSER_INIT_NODE_FUNC f;
 
-      assert (node->node_type < PT_LAST_NODE_NUMBER);
+      assert (node_type < PT_LAST_NODE_NUMBER);
 
-      /* don't write over node_type, parser_id, line or column */
-      node->next = NULL;
-      node->or_next = NULL;
-      node->etc = NULL;
-      node->spec_ident = 0;
-      node->type_enum = PT_TYPE_NONE;
-      node->expected_domain = NULL;
-      node->data_type = NULL;
-      node->xasl_id = NULL;
-      node->alias_print = NULL;
-      node->expr_before_const_folding = NULL;
-      node->recompile = 0;
-      node->cannot_prepare = 0;
-      node->partition_pruned = 0;
-      node->si_datetime = 0;
-      node->si_tran_id = 0;
-      node->clt_cache_check = 0;
-      node->clt_cache_reusable = 0;
-      node->use_plan_cache = 0;
-      node->use_query_cache = 0;
-      node->is_hidden_column = 0;
-      node->is_paren = 0;
-      node->with_rollup = 0;
-      node->force_auto_parameterize = 0;
-      node->do_not_fold = 0;
-      node->is_cnf_start = 0;
-      node->is_click_counter = 0;
+      /* don't write over node_type, parser_id, sql_user_text, sql_user_text_len, cache_time */
+      char *sql_user_text = node->sql_user_text;
+      int sql_user_text_len = node->sql_user_text_len;
+      CACHE_TIME cache_time = node->cache_time;
+      int line_number, column_number;
+
+      if (bKeepLnCn)
+	{
+	  line_number = node->line_number;
+	  column_number = node->column_number;
+	}
+
+      memset (node, 0x00, sizeof (PT_NODE));
       node->buffer_pos = -1;
-      node->next_row = NULL;
-      node->is_value_query = 0;
-      node->do_not_replace_orderby = 0;
-      node->is_added_by_parser = 0;
-      node->is_alias_enabled_expr = 0;
-      node->is_wrapped_res_for_coll = 0;
-      node->is_system_generated_stmt = 0;
-      node->use_auto_commit = 0;
-      /* initialize node info field */
-      memset (&(node->info), 0, sizeof (node->info));
+      node->type_enum = PT_TYPE_NONE;
+
+      node->parser_id = parser_id;
+      node->node_type = node_type;
+
+      node->sql_user_text = sql_user_text;
+      node->sql_user_text_len = sql_user_text_len;
+      node->cache_time = cache_time;
+      if (bKeepLnCn)
+	{
+	  node->line_number = line_number;
+	  node->column_number = column_number;
+	}
 
       f = pt_init_f[node->node_type];
       node = f (node);
@@ -4455,7 +4456,7 @@ pt_select_list_to_one_col (PARSER_CONTEXT * parser, PT_NODE * node, bool do_one)
 	      /* reset single tuple mark and move to derived */
 	      node->info.query.single_tuple = 0;
 	      derived = parser_copy_tree (parser, node);
-	      parser_init_node (node);
+	      parser_init_node (node, node->node_type, false, true);
 
 	      /* new range var */
 	      from = derived->info.query.q.select.from;

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2209,7 +2209,7 @@ parser_new_node (PARSER_CONTEXT * parser, PT_NODE_TYPE node_type)
 }
 
 /*
- * parser_init_node() - initialize a node
+ * parser_init_node() - initialize a node (Used when initializing the node for the first time after creation)
  *   return:
  *   node(in/out):
  */
@@ -2230,6 +2230,11 @@ parser_init_node (PT_NODE * node, PT_NODE_TYPE node_type)
   return node;
 }
 
+/*
+ * parser_reuse_init_node() - initialize a node (Used when re-initializing an existing Node while in use)
+ *   return:
+ *   node(in/out):
+ */
 PT_NODE *
 parser_reuse_init_node (PT_NODE * node)
 {

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2216,6 +2216,7 @@ parser_new_node (PARSER_CONTEXT * parser, PT_NODE_TYPE node_type)
 PT_NODE *
 parser_init_node (PT_NODE * node, PT_NODE_TYPE node_type)
 {
+  assert (node != NULL);
   assert (node_type < PT_LAST_NODE_NUMBER);
   int parser_id = node->parser_id;
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2231,12 +2231,12 @@ parser_init_node (PT_NODE * node, PT_NODE_TYPE node_type)
 }
 
 /*
- * parser_reuse_init_node() - initialize a node (Used when re-initializing an existing Node while in use)
+ * parser_reinit_node() - initialize a node (Used when re-initializing an existing Node while in use)
  *   return:
  *   node(in/out):
  */
 PT_NODE *
-parser_reuse_init_node (PT_NODE * node)
+parser_reinit_node (PT_NODE * node)
 {
   if (node)
     {
@@ -4455,7 +4455,7 @@ pt_select_list_to_one_col (PARSER_CONTEXT * parser, PT_NODE * node, bool do_one)
 	      /* reset single tuple mark and move to derived */
 	      node->info.query.single_tuple = 0;
 	      derived = parser_copy_tree (parser, node);
-	      parser_reuse_init_node (node);
+	      parser_reinit_node (node);
 
 	      /* new range var */
 	      from = derived->info.query.q.select.from;

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -83,7 +83,8 @@ extern "C"
 
   extern PT_NODE *parser_create_node (const PARSER_CONTEXT * parser);
   extern PT_NODE *parser_new_node (PARSER_CONTEXT * parser, PT_NODE_TYPE node);
-  extern PT_NODE *parser_init_node (PT_NODE * node, PT_NODE_TYPE node_type, bool bFirst, bool bKeepLnCn);
+  extern PT_NODE *parser_init_node (PT_NODE * node, PT_NODE_TYPE node_type);
+  extern PT_NODE *parser_reuse_init_node (PT_NODE * node);
   extern void parser_free_node_resources (PT_NODE * node);
   extern void parser_free_node (const PARSER_CONTEXT * parser, PT_NODE * node);
   extern void parser_free_tree (PARSER_CONTEXT * parser, PT_NODE * tree);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -83,7 +83,7 @@ extern "C"
 
   extern PT_NODE *parser_create_node (const PARSER_CONTEXT * parser);
   extern PT_NODE *parser_new_node (PARSER_CONTEXT * parser, PT_NODE_TYPE node);
-  extern PT_NODE *parser_init_node (PT_NODE * node);
+  extern PT_NODE *parser_init_node (PT_NODE * node, PT_NODE_TYPE node_type, bool bFirst, bool bKeepLnCn);
   extern void parser_free_node_resources (PT_NODE * node);
   extern void parser_free_node (const PARSER_CONTEXT * parser, PT_NODE * node);
   extern void parser_free_tree (PARSER_CONTEXT * parser, PT_NODE * tree);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -84,7 +84,7 @@ extern "C"
   extern PT_NODE *parser_create_node (const PARSER_CONTEXT * parser);
   extern PT_NODE *parser_new_node (PARSER_CONTEXT * parser, PT_NODE_TYPE node);
   extern PT_NODE *parser_init_node (PT_NODE * node, PT_NODE_TYPE node_type);
-  extern PT_NODE *parser_reuse_init_node (PT_NODE * node);
+  extern PT_NODE *parser_reinit_node (PT_NODE * node);
   extern void parser_free_node_resources (PT_NODE * node);
   extern void parser_free_node (const PARSER_CONTEXT * parser, PT_NODE * node);
   extern void parser_free_tree (PARSER_CONTEXT * parser, PT_NODE * tree);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -227,7 +227,6 @@ pt_and (PARSER_CONTEXT * parser, const PT_NODE * arg1, const PT_NODE * arg2)
   node = parser_new_node (parser, PT_EXPR);
   if (node)
     {
-      parser_init_node (node);
       node->info.expr.op = PT_AND;
       node->info.expr.arg1 = (PT_NODE *) arg1;
       node->info.expr.arg2 = (PT_NODE *) arg2;
@@ -253,7 +252,6 @@ pt_union (PARSER_CONTEXT * parser, PT_NODE * arg1, PT_NODE * arg2)
 
   if (node)
     {
-      parser_init_node (node);
       /* set query id # */
       node->info.query.id = (UINTPTR) node;
 
@@ -308,7 +306,6 @@ pt_name (PARSER_CONTEXT * parser, const char *name)
   node = parser_new_node (parser, PT_NAME);
   if (node)
     {
-      parser_init_node (node);
       node->info.name.original = pt_append_string (parser, NULL, name);
     }
 
@@ -330,7 +327,6 @@ pt_table_option (PARSER_CONTEXT * parser, const PT_TABLE_OPTION_TYPE option, PT_
   node = parser_new_node (parser, PT_TABLE_OPTION);
   if (node)
     {
-      parser_init_node (node);
       node->info.table_option.option = option;
       node->info.table_option.val = val;
     }
@@ -355,7 +351,6 @@ pt_expression (PARSER_CONTEXT * parser, PT_OP_TYPE op, PT_NODE * arg1, PT_NODE *
   node = parser_new_node (parser, PT_EXPR);
   if (node)
     {
-      parser_init_node (node);
       node->info.expr.op = op;
       node->info.expr.arg1 = arg1;
       node->info.expr.arg2 = arg2;
@@ -428,7 +423,6 @@ pt_entity (PARSER_CONTEXT * parser, const PT_NODE * entity_name, const PT_NODE *
   node = parser_new_node (parser, PT_SPEC);
   if (node)
     {
-      parser_init_node (node);
       node->info.spec.entity_name = (PT_NODE *) entity_name;
       node->info.spec.range_var = (PT_NODE *) range_var;
       node->info.spec.flat_entity_list = (PT_NODE *) flat_list;
@@ -453,7 +447,6 @@ pt_tuple_value (PARSER_CONTEXT * parser, PT_NODE * name, CURSOR_ID * cursor_p, i
   node = parser_new_node (parser, PT_TUPLE_VALUE);
   if (node)
     {
-      parser_init_node (node);
       node->info.tuple_value.name = name;
       node->info.tuple_value.index = index;
       node->info.tuple_value.cursor_p = cursor_p;
@@ -475,7 +468,6 @@ pt_insert_value (PARSER_CONTEXT * parser, PT_NODE * node)
   PT_NODE *insert_val = parser_new_node (parser, PT_INSERT_VALUE);
   if (insert_val != NULL)
     {
-      parser_init_node (insert_val);
       insert_val->info.insert_value.original_node = node;
     }
   return insert_val;

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -3212,7 +3212,7 @@ pt_append_statements_on_change_default (PARSER_CONTEXT * parser, PT_NODE * state
   /* redefine the default value */
   save_next = value->next;
   parser_free_subtrees (parser, value);
-  parser_reuse_init_node (value);
+  parser_reinit_node (value);
   value->type_enum = PT_TYPE_NULL;
   value->next = save_next;
 
@@ -3348,7 +3348,7 @@ pt_append_statements_on_insert (PARSER_CONTEXT * parser, PT_NODE * stmt_node, co
   /* redefine the insert value */
   save_next = value->next;
   parser_free_subtrees (parser, value);
-  parser_reuse_init_node (value);
+  parser_reinit_node (value);
   value->node_type = PT_VALUE;
   value->type_enum = PT_TYPE_NULL;
   value->next = save_next;
@@ -3502,7 +3502,7 @@ pt_append_statements_on_update (PARSER_CONTEXT * parser, PT_NODE * stmt_node, co
   /* redefine the assignment value */
   save_next = value->next;
   parser_free_subtrees (parser, value);
-  parser_reuse_init_node (value);
+  parser_reinit_node (value);
   value->node_type = PT_NAME;
   value->info.name.original = pt_append_string (parser, NULL, attr_name);
   PT_NAME_INFO_SET_FLAG (value, PT_NAME_INFO_EXTERNAL);
@@ -3712,7 +3712,7 @@ pt_resolve_insert_external (PARSER_CONTEXT * parser, PT_NODE * insert)
 	      rhs = a->info.expr.arg2;
 	      *a = *lhs;
 	      a->next = save_next;
-	      parser_reuse_init_node (lhs);	/* not to free subtrees */
+	      parser_reinit_node (lhs);	/* not to free subtrees */
 	      parser_free_tree (parser, lhs);
 	      parser_free_tree (parser, rhs);
 
@@ -3753,7 +3753,7 @@ pt_resolve_insert_external (PARSER_CONTEXT * parser, PT_NODE * insert)
 	      rhs = a->info.expr.arg2;
 	      *a = *lhs;
 	      a->next = save_next;
-	      parser_reuse_init_node (lhs);	/* not to free subtrees */
+	      parser_reinit_node (lhs);	/* not to free subtrees */
 	      parser_free_tree (parser, lhs);
 	      parser_free_tree (parser, rhs);
 

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -3212,7 +3212,7 @@ pt_append_statements_on_change_default (PARSER_CONTEXT * parser, PT_NODE * state
   /* redefine the default value */
   save_next = value->next;
   parser_free_subtrees (parser, value);
-  parser_init_node (value);
+  parser_init_node (value, value->node_type, false, true);
   value->type_enum = PT_TYPE_NULL;
   value->next = save_next;
 
@@ -3348,7 +3348,7 @@ pt_append_statements_on_insert (PARSER_CONTEXT * parser, PT_NODE * stmt_node, co
   /* redefine the insert value */
   save_next = value->next;
   parser_free_subtrees (parser, value);
-  parser_init_node (value);
+  parser_init_node (value, value->node_type, false, true);
   value->node_type = PT_VALUE;
   value->type_enum = PT_TYPE_NULL;
   value->next = save_next;
@@ -3502,7 +3502,7 @@ pt_append_statements_on_update (PARSER_CONTEXT * parser, PT_NODE * stmt_node, co
   /* redefine the assignment value */
   save_next = value->next;
   parser_free_subtrees (parser, value);
-  parser_init_node (value);
+  parser_init_node (value, value->node_type, false, true);
   value->node_type = PT_NAME;
   value->info.name.original = pt_append_string (parser, NULL, attr_name);
   PT_NAME_INFO_SET_FLAG (value, PT_NAME_INFO_EXTERNAL);
@@ -3712,7 +3712,7 @@ pt_resolve_insert_external (PARSER_CONTEXT * parser, PT_NODE * insert)
 	      rhs = a->info.expr.arg2;
 	      *a = *lhs;
 	      a->next = save_next;
-	      parser_init_node (lhs);	/* not to free subtrees */
+	      parser_init_node (lhs, lhs->node_type, false, true);	/* not to free subtrees */
 	      parser_free_tree (parser, lhs);
 	      parser_free_tree (parser, rhs);
 
@@ -3753,7 +3753,7 @@ pt_resolve_insert_external (PARSER_CONTEXT * parser, PT_NODE * insert)
 	      rhs = a->info.expr.arg2;
 	      *a = *lhs;
 	      a->next = save_next;
-	      parser_init_node (lhs);	/* not to free subtrees */
+	      parser_init_node (lhs, lhs->node_type, false, true);	/* not to free subtrees */
 	      parser_free_tree (parser, lhs);
 	      parser_free_tree (parser, rhs);
 

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -3212,7 +3212,7 @@ pt_append_statements_on_change_default (PARSER_CONTEXT * parser, PT_NODE * state
   /* redefine the default value */
   save_next = value->next;
   parser_free_subtrees (parser, value);
-  parser_init_node (value, value->node_type, false, true);
+  parser_reuse_init_node (value);
   value->type_enum = PT_TYPE_NULL;
   value->next = save_next;
 
@@ -3348,7 +3348,7 @@ pt_append_statements_on_insert (PARSER_CONTEXT * parser, PT_NODE * stmt_node, co
   /* redefine the insert value */
   save_next = value->next;
   parser_free_subtrees (parser, value);
-  parser_init_node (value, value->node_type, false, true);
+  parser_reuse_init_node (value);
   value->node_type = PT_VALUE;
   value->type_enum = PT_TYPE_NULL;
   value->next = save_next;
@@ -3502,7 +3502,7 @@ pt_append_statements_on_update (PARSER_CONTEXT * parser, PT_NODE * stmt_node, co
   /* redefine the assignment value */
   save_next = value->next;
   parser_free_subtrees (parser, value);
-  parser_init_node (value, value->node_type, false, true);
+  parser_reuse_init_node (value);
   value->node_type = PT_NAME;
   value->info.name.original = pt_append_string (parser, NULL, attr_name);
   PT_NAME_INFO_SET_FLAG (value, PT_NAME_INFO_EXTERNAL);
@@ -3712,7 +3712,7 @@ pt_resolve_insert_external (PARSER_CONTEXT * parser, PT_NODE * insert)
 	      rhs = a->info.expr.arg2;
 	      *a = *lhs;
 	      a->next = save_next;
-	      parser_init_node (lhs, lhs->node_type, false, true);	/* not to free subtrees */
+	      parser_reuse_init_node (lhs);	/* not to free subtrees */
 	      parser_free_tree (parser, lhs);
 	      parser_free_tree (parser, rhs);
 
@@ -3753,7 +3753,7 @@ pt_resolve_insert_external (PARSER_CONTEXT * parser, PT_NODE * insert)
 	      rhs = a->info.expr.arg2;
 	      *a = *lhs;
 	      a->next = save_next;
-	      parser_init_node (lhs, lhs->node_type, false, true);	/* not to free subtrees */
+	      parser_reuse_init_node (lhs);	/* not to free subtrees */
 	      parser_free_tree (parser, lhs);
 	      parser_free_tree (parser, rhs);
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -10087,7 +10087,7 @@ mq_fetch_expression_for_real_class_update (PARSER_CONTEXT * parser, DB_OBJECT * 
   PT_NODE *spec;
   const char *attr_name;
 
-  parser_init_node (&vclass, PT_NAME, true, false);
+  parser_init_node (&vclass, PT_NAME);
   vclass.info.name.original = NULL;
   vclass.info.name.db_object = vclass_obj;
 
@@ -10239,7 +10239,7 @@ mq_is_updatable_local (DB_OBJECT * class_object, PT_FETCH_AS fetch_as)
       return false;
     }
 
-  parser_init_node (&class_, PT_NAME, true, false);
+  parser_init_node (&class_, PT_NAME);
   class_.info.name.original = NULL;
   class_.info.name.db_object = class_object;
 
@@ -10285,10 +10285,10 @@ mq_is_updatable_att (PARSER_CONTEXT * parser, DB_OBJECT * vmop, const char *att_
 {
   PT_NODE real, attr, *expr;
 
-  parser_init_node (&attr, PT_NAME, true, false);
+  parser_init_node (&attr, PT_NAME);
   attr.info.name.original = att_nam;
 
-  parser_init_node (&real, PT_NAME, true, false);
+  parser_init_node (&real, PT_NAME);
   real.info.name.original = NULL;
   real.info.name.db_object = rmop;
 
@@ -10458,10 +10458,10 @@ mq_get_attribute (DB_OBJECT * vclass_object, const char *attr_name, DB_OBJECT * 
 
   parser->au_save = save;
 
-  parser_init_node (&attr, PT_NAME, true, false);
+  parser_init_node (&attr, PT_NAME);
   attr.info.name.original = attr_name;
 
-  parser_init_node (&real, PT_NAME, true, false);
+  parser_init_node (&real, PT_NAME);
   real.info.name.original = NULL;
   real.info.name.db_object = real_class_object;
 
@@ -10507,7 +10507,7 @@ mq_oid (PARSER_CONTEXT * parser, PT_NODE * spec)
   AU_DISABLE (save);
   parser->au_save = save;
 
-  parser_init_node (&attr, PT_NAME, true, false);
+  parser_init_node (&attr, PT_NAME);
   attr.info.name.original = "";	/* oid's have null string attr name */
 
   real = spec->info.spec.flat_entity_list;
@@ -10563,10 +10563,10 @@ mq_update_attribute (DB_OBJECT * vclass_object, const char *attr_name, DB_OBJECT
 	}
     }
 
-  parser_init_node (&attr, PT_NAME, true, false);
+  parser_init_node (&attr, PT_NAME);
   attr.info.name.original = attr_name;
 
-  parser_init_node (&real, PT_NAME, true, false);
+  parser_init_node (&real, PT_NAME);
   real.info.name.original = NULL;
   real.info.name.db_object = real_class_object;
 
@@ -10648,7 +10648,7 @@ mq_fetch_one_real_class_get_cache (DB_OBJECT * vclass_object, PARSER_CONTEXT ** 
 	}
     }
 
-  parser_init_node (&vclass, PT_NAME, true, false);
+  parser_init_node (&vclass, PT_NAME);
   vclass.info.name.original = NULL;
   vclass.info.name.db_object = vclass_object;
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -10087,10 +10087,7 @@ mq_fetch_expression_for_real_class_update (PARSER_CONTEXT * parser, DB_OBJECT * 
   PT_NODE *spec;
   const char *attr_name;
 
-  vclass.node_type = PT_NAME;
-  parser_init_node (&vclass);
-  vclass.line_number = 0;
-  vclass.column_number = 0;
+  parser_init_node (&vclass, PT_NAME, true, false);
   vclass.info.name.original = NULL;
   vclass.info.name.db_object = vclass_obj;
 
@@ -10242,10 +10239,7 @@ mq_is_updatable_local (DB_OBJECT * class_object, PT_FETCH_AS fetch_as)
       return false;
     }
 
-  class_.node_type = PT_NAME;
-  parser_init_node (&class_);
-  class_.line_number = 0;
-  class_.column_number = 0;
+  parser_init_node (&class_, PT_NAME, true, false);
   class_.info.name.original = NULL;
   class_.info.name.db_object = class_object;
 
@@ -10291,16 +10285,10 @@ mq_is_updatable_att (PARSER_CONTEXT * parser, DB_OBJECT * vmop, const char *att_
 {
   PT_NODE real, attr, *expr;
 
-  attr.node_type = PT_NAME;
-  parser_init_node (&attr);
-  attr.line_number = 0;
-  attr.column_number = 0;
+  parser_init_node (&attr, PT_NAME, true, false);
   attr.info.name.original = att_nam;
 
-  real.node_type = PT_NAME;
-  parser_init_node (&real);
-  real.line_number = 0;
-  real.column_number = 0;
+  parser_init_node (&real, PT_NAME, true, false);
   real.info.name.original = NULL;
   real.info.name.db_object = rmop;
 
@@ -10470,16 +10458,10 @@ mq_get_attribute (DB_OBJECT * vclass_object, const char *attr_name, DB_OBJECT * 
 
   parser->au_save = save;
 
-  attr.node_type = PT_NAME;
-  parser_init_node (&attr);
-  attr.line_number = 0;
-  attr.column_number = 0;
+  parser_init_node (&attr, PT_NAME, true, false);
   attr.info.name.original = attr_name;
 
-  real.node_type = PT_NAME;
-  parser_init_node (&real);
-  real.line_number = 0;
-  real.column_number = 0;
+  parser_init_node (&real, PT_NAME, true, false);
   real.info.name.original = NULL;
   real.info.name.db_object = real_class_object;
 
@@ -10525,10 +10507,7 @@ mq_oid (PARSER_CONTEXT * parser, PT_NODE * spec)
   AU_DISABLE (save);
   parser->au_save = save;
 
-  attr.node_type = PT_NAME;
-  parser_init_node (&attr);
-  attr.line_number = 0;
-  attr.column_number = 0;
+  parser_init_node (&attr, PT_NAME, true, false);
   attr.info.name.original = "";	/* oid's have null string attr name */
 
   real = spec->info.spec.flat_entity_list;
@@ -10584,16 +10563,10 @@ mq_update_attribute (DB_OBJECT * vclass_object, const char *attr_name, DB_OBJECT
 	}
     }
 
-  attr.node_type = PT_NAME;
-  parser_init_node (&attr);
-  attr.line_number = 0;
-  attr.column_number = 0;
+  parser_init_node (&attr, PT_NAME, true, false);
   attr.info.name.original = attr_name;
 
-  real.node_type = PT_NAME;
-  parser_init_node (&real);
-  real.line_number = 0;
-  real.column_number = 0;
+  parser_init_node (&real, PT_NAME, true, false);
   real.info.name.original = NULL;
   real.info.name.db_object = real_class_object;
 
@@ -10675,11 +10648,7 @@ mq_fetch_one_real_class_get_cache (DB_OBJECT * vclass_object, PARSER_CONTEXT ** 
 	}
     }
 
-  vclass.node_type = PT_NAME;
-
-  parser_init_node (&vclass);
-  vclass.line_number = 0;
-  vclass.column_number = 0;
+  parser_init_node (&vclass, PT_NAME, true, false);
   vclass.info.name.original = NULL;
   vclass.info.name.db_object = vclass_object;
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -13494,7 +13494,8 @@ pt_to_outlist (PARSER_CONTEXT * parser, PT_NODE * node_list, SELUPD_LIST ** selu
 
       for (i = 0, node = node_list->info.node_list.list; i < list_len && node; ++i, node = node->next)
 	{
-	  parser_init_node (&new_node_list[i], PT_NODE_LIST, false, true);	/* type must be set before init */
+	  new_node_list[i].node_type = PT_NODE_LIST;
+	  parser_reuse_init_node (&new_node_list[i]);	/* type must be set before init */
 
 	  new_node_list[i].info.node_list.list = node;
 	  PT_SET_VALUE_QUERY (&new_node_list[i]);

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -13495,7 +13495,7 @@ pt_to_outlist (PARSER_CONTEXT * parser, PT_NODE * node_list, SELUPD_LIST ** selu
       for (i = 0, node = node_list->info.node_list.list; i < list_len && node; ++i, node = node->next)
 	{
 	  new_node_list[i].node_type = PT_NODE_LIST;
-	  parser_reuse_init_node (&new_node_list[i]);	/* type must be set before init */
+	  parser_reinit_node (&new_node_list[i]);	/* type must be set before init */
 
 	  new_node_list[i].info.node_list.list = node;
 	  PT_SET_VALUE_QUERY (&new_node_list[i]);

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -13494,8 +13494,8 @@ pt_to_outlist (PARSER_CONTEXT * parser, PT_NODE * node_list, SELUPD_LIST ** selu
 
       for (i = 0, node = node_list->info.node_list.list; i < list_len && node; ++i, node = node->next)
 	{
-	  new_node_list[i].node_type = PT_NODE_LIST;	/* type must be set before init */
-	  parser_init_node (&new_node_list[i]);
+	  parser_init_node (&new_node_list[i], PT_NODE_LIST, false, true);	/* type must be set before init */
+
 	  new_node_list[i].info.node_list.list = node;
 	  PT_SET_VALUE_QUERY (&new_node_list[i]);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23929

Purpose
N/A

Implementation
Modify & Add init functions.

Used when initializing the node for the first time after creation:
PT_NODE * parser_init_node (PT_NODE * node, PT_NODE_TYPE node_type);

Used when re-initializing an existing Node while in use:
PT_NODE * parser_reinit_node (PT_NODE * node);

Remarks
N/A