### PR TITLE
[CBRD-23937] Recreating heap file while TRUNCATE if REUSE_OID	

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -15776,7 +15776,7 @@ sm_truncate_class_internal (MOP class_mop)
       goto error_exit;
     }
 
-  /* collect index information */
+  /* collect index information to drop and recreate, or revmoe btree records if it can't be dropped. */
   for (c = class_->constraints; c; c = c->next)
     {
       if (!SM_IS_CONSTRAINT_INDEX_FAMILY (c->type))

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -6427,7 +6427,7 @@ heap_ovf_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFID * ovf_vfid,
 	  log_append_redo_data (thread_p, RVHF_STATS, &addr_hdr, sizeof (*heap_hdr), heap_hdr);
 	  pgbuf_set_dirty (thread_p, addr_hdr.pgptr, DONT_FREE);
 
-	  log_sysop_attach_to_outer (thread_p);
+	  log_sysop_commit (thread_p);
 	}
       else
 	{

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -6427,7 +6427,7 @@ heap_ovf_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFID * ovf_vfid,
 	  log_append_redo_data (thread_p, RVHF_STATS, &addr_hdr, sizeof (*heap_hdr), heap_hdr);
 	  pgbuf_set_dirty (thread_p, addr_hdr.pgptr, DONT_FREE);
 
-	  log_sysop_commit (thread_p);
+	  log_sysop_attach_to_outer (thread_p);
 	}
       else
 	{

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -4421,6 +4421,7 @@ catalog_update (THREAD_ENTRY * thread_p, RECDES * record_p, OID * class_oid_p)
   DISK_REPR *disk_repr_p = NULL;
   DISK_REPR *old_repr_p = NULL;
   CLS_INFO *class_info_p = NULL;
+  HFID class_hfid;
   OID rep_dir;
   int err;
 
@@ -4499,7 +4500,9 @@ catalog_update (THREAD_ENTRY * thread_p, RECDES * record_p, OID * class_oid_p)
 
   assert (OID_EQ (&rep_dir, &(class_info_p->ci_rep_dir)));
 
-  if (HFID_IS_NULL (&class_info_p->ci_hfid))
+  or_class_hfid (record_p, &(class_hfid));
+
+  if (HFID_IS_NULL (&class_info_p->ci_hfid) || !HFID_EQ (&class_info_p->ci_hfid, &class_hfid))
     {
       or_class_hfid (record_p, &(class_info_p->ci_hfid));
       if (!HFID_IS_NULL (&class_info_p->ci_hfid))

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -4502,9 +4502,9 @@ catalog_update (THREAD_ENTRY * thread_p, RECDES * record_p, OID * class_oid_p)
 
   or_class_hfid (record_p, &(class_hfid));
 
-  if (HFID_IS_NULL (&class_info_p->ci_hfid) || !HFID_EQ (&class_info_p->ci_hfid, &class_hfid))
+  if (!HFID_EQ (&class_info_p->ci_hfid, &class_hfid))
     {
-      or_class_hfid (record_p, &(class_info_p->ci_hfid));
+      class_info_p->ci_hfid = class_hfid;
       if (!HFID_IS_NULL (&class_info_p->ci_hfid))
 	{
 	  if (catalog_update_class_info (thread_p, class_oid_p, class_info_p, NULL, false) == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23937

See the Jira issue for more information.

As a side note, I've removed "log_does_allow_replication()" condition checking in the code that was commented out. According to my analysis and test, TRUNCATE is logged as one of Statement Based Logging, and it looks working well with destroying heap even if the PK is not dropped. I guess it is a kind of legacy code.