### PR TITLE
[CBRD-23944] Upgrade Parallel level for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
     <<: *defaults
     environment:
       TEST_SUITE: sql
-    parallelism: 16
+    parallelism: 8
     <<: *test_defaults
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ defaults: &defaults
   working_directory: /home
   docker:
     - image: cubridci/cubridci:develop
+  resource_class: large
 
 test_defaults: &test_defaults
   steps:
@@ -37,7 +38,7 @@ jobs:
   build:
     <<: *defaults
     environment:
-      MAKEFLAGS: -j2
+      MAKEFLAGS: -j4
     
     steps:
       - checkout
@@ -60,13 +61,14 @@ jobs:
     <<: *defaults
     environment:
       TEST_SUITE: medium
+    parallelism: 4
     <<: *test_defaults
 
   test_sql:
     <<: *defaults
     environment:
       TEST_SUITE: sql
-    parallelism: 4
+    parallelism: 8
     <<: *test_defaults
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
     <<: *defaults
     environment:
       TEST_SUITE: medium
-    parallelism: 4
     <<: *test_defaults
 
   test_sql:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
     <<: *defaults
     environment:
       TEST_SUITE: sql
-    parallelism: 8
+    parallelism: 16
     <<: *test_defaults
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ defaults: &defaults
   working_directory: /home
   docker:
     - image: cubridci/cubridci:develop
-  resource_class: large
 
 test_defaults: &test_defaults
   steps:
@@ -39,7 +38,7 @@ jobs:
     <<: *defaults
     environment:
       MAKEFLAGS: -j 10
-    
+    resource_class: large
     steps:
       - checkout
       - run:
@@ -61,12 +60,14 @@ jobs:
     <<: *defaults
     environment:
       TEST_SUITE: medium
+    resource_class: medium
     <<: *test_defaults
 
   test_sql:
     <<: *defaults
     environment:
       TEST_SUITE: sql
+    resource_class: medium
     parallelism: 8
     <<: *test_defaults
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
   build:
     <<: *defaults
     environment:
-      MAKEFLAGS: -j4
+      MAKEFLAGS: -j 10
     
     steps:
       - checkout


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23944

1) `resource_class` for `build` workflow is upgraded to `large`
2) upgrade MAKEFLAGS value from 2 to 10 (large machine provide 4 virtual CPUs, but the build was fast slightly when I set 10)
4) set parallelism from 4 to 8 for SQL test