### PR TITLE
[CBRD-23928] Change pt_has_error() function to macro

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -503,7 +503,7 @@ extern "C"
 
   extern PT_NODE *pt_get_next_error (PT_NODE * errors, int *stmt_no, int *line_no, int *col_no, const char **msg);
   extern void pt_reset_error (PARSER_CONTEXT * parser);
-  extern int pt_has_error (const PARSER_CONTEXT * parser);
+#define pt_has_error(parser) ( (parser) && ((parser)->error_msgs || (parser)->has_internal_error))
 
 #if defined (ENABLE_UNUSED_FUNCTION)
   extern bool pt_column_updatable (PARSER_CONTEXT * parser, PT_NODE * query);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -2717,25 +2717,6 @@ pt_column_updatable (PARSER_CONTEXT * parser, PT_NODE * statement)
 #endif
 
 /*
- * pt_has_error () - returns true if there are errors recorder for this parser
- *   return:
- *   parser(in):
- */
-int
-pt_has_error (const PARSER_CONTEXT * parser)
-{
-  if (parser && (parser->error_msgs != NULL || parser->has_internal_error))
-    {
-#if 0				/* TODO */
-      assert (er_errid () != NO_ERROR);
-#endif
-      return 1;
-    }
-
-  return 0;
-}
-
-/*
  * pt_statement_line_number () -
  *   return: a statement's starting source line number
  *   stmt(in):


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23928

Purpose
  Changing it to a macro would be more efficient.

Implementation
N/A

Remarks
N/A
