### PR TITLE
[CBRD-23914] Fix tmpnam is dangerous warning by replacing with mkstemp

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -94,6 +94,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/fault_injection.c
   ${BASE_DIR}/fileline_location.cpp
   ${BASE_DIR}/fixed_alloc.c
+  ${BASE_DIR}/filesys_temp.cpp
   ${BASE_DIR}/cubrid_getopt_long.c
   ${BASE_DIR}/ini_parser.c
   ${BASE_DIR}/intl_support.c
@@ -138,6 +139,8 @@ set(BASE_HEADERS
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
+  ${BASE_DIR}/filesys.hpp
+  ${BASE_DIR}/filesys_temp.hpp
   ${BASE_DIR}/locale_helper.hpp
   ${BASE_DIR}/lockfree_bitmap.hpp
   ${BASE_DIR}/mem_block.hpp
@@ -487,6 +490,7 @@ target_include_directories(cubridcs PRIVATE ${FLEX_INCLUDE_DIRS} ${EP_INCLUDES})
 if(UNIX)
   target_link_libraries(cubridcs LINK_PRIVATE -Wl,-whole-archive cas ${EP_LIBS} -Wl,-no-whole-archive)
   target_link_libraries(cubridcs LINK_PUBLIC ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+  target_link_libraries(cubridcs PUBLIC stdc++fs)
 else(UNIX)
   target_link_libraries(cubridcs LINK_PRIVATE cas ${EP_LIBS})
 endif(UNIX)

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -87,6 +87,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/event_log.c
   ${BASE_DIR}/fault_injection.c
   ${BASE_DIR}/fileline_location.cpp
+  ${BASE_DIR}/filesys_temp.cpp
   ${BASE_DIR}/fixed_alloc.c
   ${BASE_DIR}/ini_parser.c
   ${BASE_DIR}/intl_support.c
@@ -135,6 +136,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
+  ${BASE_DIR}/filesys_temp.hpp
   ${BASE_DIR}/locale_helper.hpp
   ${BASE_DIR}/lockfree_address_marker.hpp
   ${BASE_DIR}/lockfree_bitmap.hpp
@@ -500,6 +502,7 @@ target_include_directories(cubrid PRIVATE ${JAVA_INC} ${EP_INCLUDES} ${FLEX_INCL
 if(UNIX)
   target_link_libraries(cubrid LINK_PRIVATE -Wl,-whole-archive ${EP_LIBS} -Wl,-no-whole-archive)
   target_link_libraries(cubrid LINK_PUBLIC ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+  target_link_libraries(cubrid PUBLIC stdc++fs)
 else(UNIX)
   target_link_libraries(cubrid LINK_PRIVATE ${EP_LIBS})
 endif(UNIX)

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -71,6 +71,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/porting.c
   ${BASE_DIR}/area_alloc.c
   ${BASE_DIR}/fixed_alloc.c
+  ${BASE_DIR}/filesys_temp.cpp
   ${BASE_DIR}/mem_block.cpp
   ${BASE_DIR}/memory_private_allocator.cpp
   ${BASE_DIR}/memory_alloc.c
@@ -133,6 +134,8 @@ set(BASE_HEADERS
   ${BASE_DIR}/error_manager.h
   ${BASE_DIR}/extensible_array.hpp
   ${BASE_DIR}/fileline_location.hpp
+  ${BASE_DIR}/filesys.hpp
+  ${BASE_DIR}/filesys_temp.hpp
   ${BASE_DIR}/locale_helper.hpp
   ${BASE_DIR}/lockfree_address_marker.hpp
   ${BASE_DIR}/lockfree_bitmap.hpp
@@ -632,6 +635,7 @@ if(UNIX)
   # find out what this means:
   # target_link_libraries(cubridsa LINK_PRIVATE -Wl,-whole-archive cas ${EP_LIBS} -Wl,-no-whole-archive)
   target_link_libraries(cubridsa LINK_PUBLIC ${CURSES_LIBRARIES} ${CMAKE_DL_LIBS})
+  target_link_libraries(cubridsa PUBLIC stdc++fs)
 endif(UNIX)
 
 add_dependencies(cubridsa gen_csql_grammar gen_csql_lexer gen_loader_grammar gen_loader_lexer)

--- a/src/base/filesys.hpp
+++ b/src/base/filesys.hpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * filesys.hpp: File System namespace & functionality
+ */
+#ifndef _FILESYS_H_
+#define _FILESYS_H_
+
+#include <stdio.h>
+#include <memory>
+#ifdef LINUX
+#include <unistd.h>
+#elif WINDOWS
+#include <io.h>
+#endif
+
+namespace filesys //File System
+{
+  struct file_closer //predicate|operator used as custom deleter in std::unique_ptr
+  {
+    void operator() (FILE *fp) const
+    {
+      fclose (fp);
+    }
+  };
+
+  using auto_close_file = std::unique_ptr<FILE, file_closer>;//normal unique_ptr with a custom deleter
+
+
+  struct file_deleter //predicate|operator used as custom deleter in std::unique_ptr
+  {
+    void operator() (const char *filename) const
+    {
+#ifdef LINUX
+      unlink (filename);
+#elif WINDOWS
+      _unlink (filename);
+#endif
+    }
+  };
+
+  using auto_delete_file = std::unique_ptr<const char, file_deleter>;//normal unique_ptr with a custom deleter
+}
+
+#endif //_FILESYS_H_

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -20,6 +20,7 @@
  * file_sys.cpp: File System namespace & functionality
  */
 #include "filesys_temp.hpp"
+#include <filesystem>
 #include <stdlib.h>
 
 #ifdef LINUX
@@ -35,7 +36,10 @@ namespace
   std::string unique_tmp_filename (const char *prefix="cub_") //generates an unique filename in tmp folder
   {
 #ifdef LINUX
-    std::string filename = std::string ("/tmp/") + prefix + "XXXXXX"; //used with mkstemp()
+    std::string filename = std::filesystem::temp_directory_path ();
+    filename += "/";
+    filename += prefix;
+    filename += "XXXXXX"; //used with mkstemp()
     //TBD (not necessary yet)
 #elif WINDOWS
     char buf[L_tmpnam] = {};

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * file_sys.cpp: File System namespace & functionality
+ */
+#include "filesys_temp.hpp"
+#include <stdlib.h>
+
+#ifdef LINUX
+#include "porting.h"
+#elif WINDOWS
+#include <cstdio>
+#include <fcntl.h>
+#include <io.h>
+#endif
+
+namespace
+{
+  std::string unique_tmp_filename (const char *prefix="cub_") //generates an unique filename in tmp folder
+  {
+#ifdef LINUX
+    std::string filename = std::string ("/tmp/") + prefix + "XXXXXX"; //used with mkstemp()
+    //TBD (not necessary yet)
+#elif WINDOWS
+    char buf[L_tmpnam] = {};
+    std::string filename = std::tmpnam (buf);
+    auto pos = filename.rfind ('\\');
+    filename.insert (pos+1, prefix);
+#endif
+    return filename;
+  }
+}
+
+//--------------------------------------------------------------------------------
+std::pair<std::string, int> filesys::open_temp_filedes (const char *prefix, int flags)
+{
+#ifdef LINUX
+  char filename[PATH_MAX] = {};
+  snprintf (filename, sizeof (filename), "%s", unique_tmp_filename (prefix).c_str());
+  auto filedesc = mkostemp (filename, flags);
+#elif WINDOWS
+  auto filename = unique_tmp_filename (prefix);
+  auto filedesc = _open (filename.c_str(), _O_CREAT|_O_EXCL|_O_RDWR|flags);
+#endif
+  return {filename, filedesc};
+}
+
+//--------------------------------------------------------------------------------
+std::pair<std::string, FILE *> filesys::open_temp_file (const char *prefix, const char *mode, int flags)
+{
+#ifdef LINUX
+  char filename[PATH_MAX] = {};
+  snprintf (filename, sizeof (filename), "%s", unique_tmp_filename (prefix).c_str());
+  auto filedesc = mkostemp (filename, flags);
+  FILE *fileptr = fdopen (filedesc, mode);
+#elif WINDOWS
+  auto filename = unique_tmp_filename (prefix);
+  auto *fileptr = fopen (filename.c_str(), mode);
+#endif
+  return {filename, fileptr};
+}

--- a/src/base/filesys_temp.hpp
+++ b/src/base/filesys_temp.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * filesys_temp.hpp: File System - Automatic Close File
+ */
+#ifndef _FILESYS_TEMP_H_
+#define _FILESYS_TEMP_H_
+
+#include <stdio.h>
+#include <string>
+#include <utility>
+
+namespace filesys //File System
+{
+  //opens a new file in OS's tmp folder; return file name & open descriptor
+  std::pair<std::string, int> open_temp_filedes (const char *prefix, int flags=0);
+
+  //opens a new file in OS's tmp folder; return file name & FILE*
+  std::pair<std::string, FILE *> open_temp_file (const char *prefix, const char *mode="w", int flags=0);
+}
+
+#endif //_FILESYS_TEMP_H_

--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -979,10 +979,9 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
       if (!css_tcp_listen_server_datagram (socket_fd, &datagram_fd))
 	{
 	  (void) unlink (pname.c_str ());
-	  css_free_conn (conn);
 	  close (socket_fd);
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
-	  return NULL;
+	  goto fail_end;
 	}
       // success
       (void) unlink (pname.c_str ());

--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -26,6 +26,10 @@
 
 #include "config.h"
 
+#if defined (WINDOWS)
+#include <io.h>
+#endif
+#include <filesystem>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -57,6 +61,8 @@
 #include "porting.h"
 #include "error_manager.h"
 #include "connection_globals.h"
+#include "filesys.hpp"
+#include "filesys_temp.hpp"
 #include "memory_alloc.h"
 #include "system_parameter.h"
 #include "environment_variable.h"
@@ -861,7 +867,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
   int server_port_id;
   int connection_protocol;
 #if !defined(WINDOWS)
-  char *pname;
+  std::string pname;
   int datagram_fd, socket_fd;
 #endif
 
@@ -953,35 +959,35 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 #else /* WINDOWS */
       /* send the "pathname" for the datagram */
       /* be sure to open the datagram first.  */
-      pname = tempnam (NULL, "csql");
-      if (pname)
+      pname = std::filesystem::temp_directory_path ();
+      pname += "/csql_tcp_setup_server" + std::to_string (getpid ());
+      (void) unlink (pname.c_str ());	// make sure file is deleted
+
+      if (!css_tcp_setup_server_datagram (pname.c_str (), &socket_fd))
 	{
-	  if (css_tcp_setup_server_datagram (pname, &socket_fd)
-	      && css_send_data (conn, rid, pname, strlen (pname) + 1) == NO_ERRORS
-	      && css_tcp_listen_server_datagram (socket_fd, &datagram_fd))
-	    {
-	      (void) unlink (pname);
-	      /* don't use free_and_init on pname since it came from tempnam() */
-	      free (pname);
-	      css_free_conn (conn);
-	      close (socket_fd);
-	      return (css_make_conn (datagram_fd));
-	    }
-	  else
-	    {
-	      /* don't use free_and_init on pname since it came from tempnam() */
-	      free (pname);
-	      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1,
-				   server_name);
-	      goto fail_end;
-	    }
-	}
-      else
-	{
-	  /* Could not create the temporary file */
+	  (void) unlink (pname.c_str ());
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
 	  goto fail_end;
 	}
+      if (css_send_data (conn, rid, pname.c_str (), pname.length () + 1) != NO_ERRORS)
+	{
+	  (void) unlink (pname.c_str ());
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
+	  goto fail_end;
+	}
+      if (!css_tcp_listen_server_datagram (socket_fd, &datagram_fd))
+	{
+	  (void) unlink (pname.c_str ());
+	  css_free_conn (conn);
+	  close (socket_fd);
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
+	  goto fail_end;
+	}
+      // success
+      (void) unlink (pname.c_str ());
+      css_free_conn (conn);
+      close (socket_fd);
+      return (css_make_conn (datagram_fd));
 #endif /* WINDOWS */
     }
 

--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -972,6 +972,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
       if (css_send_data (conn, rid, pname.c_str (), pname.length () + 1) != NO_ERRORS)
 	{
 	  (void) unlink (pname.c_str ());
+	  close (socket_fd);
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
 	  goto fail_end;
 	}
@@ -981,7 +982,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 	  css_free_conn (conn);
 	  close (socket_fd);
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
-	  goto fail_end;
+	  return NULL;
 	}
       // success
       (void) unlink (pname.c_str ());

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1177,6 +1177,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
       if (css_send_data (conn, rid, pname.c_str (), pname.length () + 1) != NO_ERRORS)
 	{
 	  (void) unlink (pname.c_str ());
+	  close (socket_fd);
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
 	  goto fail_end;
 	}
@@ -1186,7 +1187,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 	  css_free_conn (conn);
 	  close (socket_fd);
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
-	  goto fail_end;
+	  return NULL;
 	}
       // success
       (void) unlink (pname.c_str ());

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -24,6 +24,10 @@
 
 #include "config.h"
 
+#if defined (WINDOWS)
+#include <io.h>
+#endif
+#include <filesystem>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -58,6 +62,9 @@
 #include "porting.h"
 #include "error_manager.h"
 #include "connection_globals.h"
+#include "connection_server_rules.hpp"
+#include "filesys.hpp"
+#include "filesys_temp.hpp"
 #include "memory_alloc.h"
 #include "environment_variable.h"
 #include "system_parameter.h"
@@ -1079,7 +1086,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
   int server_port_id;
   int connection_protocol;
 #if !defined(WINDOWS)
-  char *pname;
+  std::string pname;
   int datagram_fd, socket_fd;
 #endif
 
@@ -1157,38 +1164,35 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 #else /* WINDOWS */
       /* send the "pathname" for the datagram */
       /* be sure to open the datagram first.  */
+      pname = std::filesystem::temp_directory_path ();
+      pname += "/cubrid_tcp_setup_server" + std::to_string (getpid ());
+      (void) unlink (pname.c_str ());	// make sure file is deleted
 
-      //on newer systems (e.g. fedora 25) the following line of code
-      //produces this warning: the use of `tempnam' is dangerous, better use `mkstemp'
-
-      pname = tempnam (NULL, "cubrid");
-      if (pname)
+      if (!css_tcp_setup_server_datagram (pname.c_str (), &socket_fd))
 	{
-	  if (css_tcp_setup_server_datagram (pname, &socket_fd)
-	      && (css_send_data (conn, rid, pname, strlen (pname) + 1) == NO_ERRORS)
-	      && (css_tcp_listen_server_datagram (socket_fd, &datagram_fd)))
-	    {
-	      (void) unlink (pname);
-	      /* don't use free_and_init on pname since it came from tempnam() */
-	      free (pname);
-	      css_free_conn (conn);
-	      return (css_make_conn (datagram_fd));
-	    }
-	  else
-	    {
-	      /* don't use free_and_init on pname since it came from tempnam() */
-	      free (pname);
-	      er_set_with_oserror (ER_ERROR_SEVERITY,
-				   ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
-	      goto fail_end;
-	    }
-	}
-      else
-	{
-	  /* Could not create the temporary file */
+	  (void) unlink (pname.c_str ());
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
 	  goto fail_end;
 	}
+      if (css_send_data (conn, rid, pname.c_str (), pname.length () + 1) != NO_ERRORS)
+	{
+	  (void) unlink (pname.c_str ());
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
+	  goto fail_end;
+	}
+      if (!css_tcp_listen_server_datagram (socket_fd, &datagram_fd))
+	{
+	  (void) unlink (pname.c_str ());
+	  css_free_conn (conn);
+	  close (socket_fd);
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
+	  goto fail_end;
+	}
+      // success
+      (void) unlink (pname.c_str ());
+      css_free_conn (conn);
+      close (socket_fd);
+      return (css_make_conn (datagram_fd));
 #endif /* WINDOWS */
     }
 

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -62,7 +62,6 @@
 #include "porting.h"
 #include "error_manager.h"
 #include "connection_globals.h"
-#include "connection_server_rules.hpp"
 #include "filesys.hpp"
 #include "filesys_temp.hpp"
 #include "memory_alloc.h"

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1183,10 +1183,9 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
       if (!css_tcp_listen_server_datagram (socket_fd, &datagram_fd))
 	{
 	  (void) unlink (pname.c_str ());
-	  css_free_conn (conn);
 	  close (socket_fd);
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
-	  return NULL;
+	  goto fail_end;
 	}
       // success
       (void) unlink (pname.c_str ());

--- a/src/connection/tcp.c
+++ b/src/connection/tcp.c
@@ -879,7 +879,7 @@ css_master_accept (SOCKET sockfd)
  *       the new socket fd
  */
 bool
-css_tcp_setup_server_datagram (char *pathname, SOCKET * sockfd)
+css_tcp_setup_server_datagram (const char *pathname, SOCKET * sockfd)
 {
   int servlen;
   struct sockaddr_un serv_addr;

--- a/src/connection/tcp.h
+++ b/src/connection/tcp.h
@@ -42,11 +42,11 @@ extern char *css_get_master_domain_path (void);
 
 extern SOCKET css_tcp_client_open (const char *host, int port);
 extern SOCKET css_tcp_client_open_with_retry (const char *host, int port, bool will_retry);
-extern bool css_tcp_setup_server_datagram (const char *pathname, SOCKET * sockfd);
-extern SOCKET css_master_accept (SOCKET sockfd);
 extern int css_tcp_master_open (int port, SOCKET * sockfd);
-extern bool css_tcp_master_datagram (char *pathname, SOCKET * sockfd);
+extern bool css_tcp_setup_server_datagram (const char *pathname, SOCKET * sockfd);
 extern bool css_tcp_listen_server_datagram (SOCKET sockfd, SOCKET * newfd);
+extern bool css_tcp_master_datagram (char *pathname, SOCKET * sockfd);
+extern SOCKET css_master_accept (SOCKET sockfd);
 extern SOCKET css_open_new_socket_from_master (SOCKET fd, unsigned short *rid);
 extern bool css_transfer_fd (SOCKET server_fd, SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request);
 extern void css_shutdown_socket (SOCKET fd);

--- a/src/connection/tcp.h
+++ b/src/connection/tcp.h
@@ -42,9 +42,7 @@ extern char *css_get_master_domain_path (void);
 
 extern SOCKET css_tcp_client_open (const char *host, int port);
 extern SOCKET css_tcp_client_open_with_retry (const char *host, int port, bool will_retry);
-extern int css_tcp_socket_bind_listen (int port, SOCKET & sockfd);
-extern int css_master_open_sockets (int port, SOCKET * sockfd);
-extern bool css_tcp_setup_server_datagram (const char *pathname, SOCKET * sockfd);
+extern bool css_tcp_setup_server_datagram (char *pathname, SOCKET * sockfd);
 extern bool css_tcp_listen_server_datagram (SOCKET sockfd, SOCKET * newfd);
 extern bool css_tcp_master_datagram (char *pathname, SOCKET * sockfd);
 extern SOCKET css_master_accept (SOCKET sockfd);

--- a/src/connection/tcp.h
+++ b/src/connection/tcp.h
@@ -42,8 +42,9 @@ extern char *css_get_master_domain_path (void);
 
 extern SOCKET css_tcp_client_open (const char *host, int port);
 extern SOCKET css_tcp_client_open_with_retry (const char *host, int port, bool will_retry);
-extern int css_tcp_master_open (int port, SOCKET * sockfd);
-extern bool css_tcp_setup_server_datagram (char *pathname, SOCKET * sockfd);
+extern int css_tcp_socket_bind_listen (int port, SOCKET & sockfd);
+extern int css_master_open_sockets (int port, SOCKET * sockfd);
+extern bool css_tcp_setup_server_datagram (const char *pathname, SOCKET * sockfd);
 extern bool css_tcp_listen_server_datagram (SOCKET sockfd, SOCKET * newfd);
 extern bool css_tcp_master_datagram (char *pathname, SOCKET * sockfd);
 extern SOCKET css_master_accept (SOCKET sockfd);

--- a/src/connection/tcp.h
+++ b/src/connection/tcp.h
@@ -42,10 +42,11 @@ extern char *css_get_master_domain_path (void);
 
 extern SOCKET css_tcp_client_open (const char *host, int port);
 extern SOCKET css_tcp_client_open_with_retry (const char *host, int port, bool will_retry);
-extern bool css_tcp_setup_server_datagram (char *pathname, SOCKET * sockfd);
-extern bool css_tcp_listen_server_datagram (SOCKET sockfd, SOCKET * newfd);
-extern bool css_tcp_master_datagram (char *pathname, SOCKET * sockfd);
+extern bool css_tcp_setup_server_datagram (const char *pathname, SOCKET * sockfd);
 extern SOCKET css_master_accept (SOCKET sockfd);
+extern int css_tcp_master_open (int port, SOCKET * sockfd);
+extern bool css_tcp_master_datagram (char *pathname, SOCKET * sockfd);
+extern bool css_tcp_listen_server_datagram (SOCKET sockfd, SOCKET * newfd);
 extern SOCKET css_open_new_socket_from_master (SOCKET fd, unsigned short *rid);
 extern bool css_transfer_fd (SOCKET server_fd, SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request);
 extern void css_shutdown_socket (SOCKET fd);

--- a/src/executables/file_hash.c
+++ b/src/executables/file_hash.c
@@ -35,6 +35,7 @@
 #include "utility.h"
 #include "error_manager.h"
 #include "file_hash.h"
+#include "filesys_temp.hpp"
 #include "memory_alloc.h"
 #include "object_representation.h"
 
@@ -215,7 +216,9 @@ fh_create (const char *name, int est_size, int page_size, int cached_pages, cons
   /* Open the hash file */
   if (!hash_filename || hash_filename[0] == '\0')
     {
-      ht->hash_filename = strdup (tmpnam (NULL));
+      auto[filename, filedes] = filesys::open_temp_filedes ("fhash_");
+      close (filedes);
+      ht->hash_filename = strdup (filename.c_str ());
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23914

The usage of tmpnam is considered dangerous, this patch replaces usages of the function with std variants and adds the usage of filesystem library.
