### PR TITLE
[APIS-869] Administrative setting of CUBRID jdbc property

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/ConnectionProperties.java
+++ b/src/jdbc/cubrid/jdbc/driver/ConnectionProperties.java
@@ -388,7 +388,7 @@ public class ConnectionProperties {
     IntegerConnectionProperty clientCacheSize = new IntegerConnectionProperty(
     		"clientCacheSize", 1, 1, 1024);
     
-    BooleanConnectionProperty holdCursor = new BooleanConnectionProperty("hold_cursor", false);
+    BooleanConnectionProperty holdCursor = new BooleanConnectionProperty("hold_cursor", true);
     public boolean getLogOnException() {
 	return logOnException.getValueAsBoolean();
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-869

Purpose
The default value of hold_cursor was changed to TRUE.

Implementation
N/A

Remarks
N/A
