### PR TITLE
[CBRD-23947] A problem that succeeds even when the size of the CHAR or VARCHAR type exceeds MAX when creating a table.

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -20334,7 +20334,7 @@ primitive_type
 				break;
 			      }
 
-			    if (l > maxlen)
+			    if ((l > maxlen) || (len->type_enum != PT_TYPE_INTEGER))
 			      {
 				if (typ == PT_TYPE_BIT || typ == PT_TYPE_VARBIT)
 				  {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23947

Purpose
Error handling for the limit value exceeding the appropriate size in relation to the string type in the create tabel syntax

Implementation
N/A

Remarks
N/A
