### PR TITLE
[CBRD-23641] Collation compatible check between string parameters of expression/function does not work properly

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -22969,13 +22969,13 @@ pt_common_collation (PT_COLL_INFER * arg1_coll_infer, PT_COLL_INFER * arg2_coll_
 {
 #define MORE_COERCIBLE(arg1_coll_infer, arg2_coll_infer)		     \
   ((((arg1_coll_infer)->can_force_cs) && !((arg2_coll_infer)->can_force_cs)) \
-   || (arg1_coll_infer)->coerc_level == PT_COLLATION_L4_BINARY_COERC \
-   || (arg2_coll_infer)->coerc_level == PT_COLLATION_L4_BINARY_COERC \
+   || (arg1_coll_infer)->coll_id == arg2_coll_infer->coll_id \
    || (arg1_coll_infer)->coerc_level == PT_COLLATION_L4_BIN_COERC \
     || (arg2_coll_infer)->coerc_level == PT_COLLATION_L4_BIN_COERC \
     ||((arg1_coll_infer)->coerc_level > (arg2_coll_infer)->coerc_level \
        && (arg1_coll_infer)->can_force_cs == (arg2_coll_infer)->can_force_cs))
 
+  assert (common_coll != NULL);
   assert (common_cs != NULL);
   assert (arg1_coll_infer != NULL);
   assert (arg2_coll_infer != NULL);
@@ -23000,17 +23000,8 @@ pt_common_collation (PT_COLL_INFER * arg1_coll_infer, PT_COLL_INFER * arg2_coll_
 	{
 	  goto error;
 	}
-      if (arg2_coll_infer->coerc_level == PT_COLLATION_L4_BIN_COERC
-	  || arg2_coll_infer->coerc_level == PT_COLLATION_L4_BINARY_COERC)
-	{
-	  *common_coll = arg2_coll_infer->coll_id;
-	  *common_cs = arg2_coll_infer->codeset;
-	}
-      else
-	{
-	  *common_coll = arg1_coll_infer->coll_id;
-	  *common_cs = arg1_coll_infer->codeset;
-	}
+      *common_coll = arg1_coll_infer->coll_id;
+      *common_cs = arg1_coll_infer->codeset;
 
       /* check arg3 */
       if (op_has_3_args && arg3_coll_infer->coll_id != *common_coll)
@@ -23072,17 +23063,8 @@ pt_common_collation (PT_COLL_INFER * arg1_coll_infer, PT_COLL_INFER * arg2_coll_
 	  goto error;
 	}
 
-      if (arg1_coll_infer->coerc_level == PT_COLLATION_L4_BIN_COERC
-	  || arg1_coll_infer->coerc_level == PT_COLLATION_L4_BINARY_COERC)
-	{
-	  *common_coll = arg1_coll_infer->coll_id;
-	  *common_cs = arg1_coll_infer->codeset;
-	}
-      else
-	{
-	  *common_coll = arg2_coll_infer->coll_id;
-	  *common_cs = arg2_coll_infer->codeset;
-	}
+      *common_coll = arg2_coll_infer->coll_id;
+      *common_cs = arg2_coll_infer->codeset;
 
       /* check arg3 */
       if (op_has_3_args && arg3_coll_infer->coll_id != *common_coll)
@@ -23286,7 +23268,8 @@ pt_check_expr_collation (PARSER_CONTEXT * parser, PT_NODE ** node)
   else if (PT_IS_COLLECTION_TYPE (arg1_type)
 	   || (arg1_type == PT_TYPE_MAYBE && TP_IS_SET_TYPE (TP_DOMAIN_TYPE (arg1->expected_domain))))
     {
-      int status = pt_get_collation_info_for_collection_type (parser, arg1, &arg1_coll_inf);
+      int status = pt_get_collation_info_for_collection_type (parser, arg1,
+							      &arg1_coll_inf);
 
       if (status == ERROR_COLLATION)
 	{
@@ -23331,7 +23314,8 @@ pt_check_expr_collation (PARSER_CONTEXT * parser, PT_NODE ** node)
   else if (PT_IS_COLLECTION_TYPE (arg2_type)
 	   || (arg2_type == PT_TYPE_MAYBE && TP_IS_SET_TYPE (TP_DOMAIN_TYPE (arg2->expected_domain))))
     {
-      int status = pt_get_collation_info_for_collection_type (parser, arg2, &arg2_coll_inf);
+      int status = pt_get_collation_info_for_collection_type (parser, arg2,
+							      &arg2_coll_inf);
 
       if (status == ERROR_COLLATION)
 	{
@@ -23375,7 +23359,8 @@ pt_check_expr_collation (PARSER_CONTEXT * parser, PT_NODE ** node)
 	}
       else if (PT_IS_COLLECTION_TYPE (arg3_type))
 	{
-	  int status = pt_get_collation_info_for_collection_type (parser, arg3, &arg3_coll_inf);
+	  int status = pt_get_collation_info_for_collection_type (parser, arg3,
+								  &arg3_coll_inf);
 
 	  if (status == ERROR_COLLATION)
 	    {

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -22983,7 +22983,9 @@ pt_common_collation (PT_COLL_INFER * arg1_coll_infer, PT_COLL_INFER * arg2_coll_
     }
 
   if (arg1_coll_infer->coll_id != arg2_coll_infer->coll_id
-      && arg1_coll_infer->coerc_level == arg2_coll_infer->coerc_level
+      && (arg1_coll_infer->coerc_level == PT_COLLATION_NOT_COERC
+         || arg2_coll_infer->coerc_level == PT_COLLATION_NOT_COERC
+         || arg1_coll_infer->coerc_level == arg2_coll_infer->coerc_level)
       && arg1_coll_infer->can_force_cs == arg2_coll_infer->can_force_cs)
     {
       goto error;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5444,8 +5444,8 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 	{
 	  PT_NODE *temp = NULL;
 	  int precision = 0, scale = 0;
-	  int units = LANG_SYS_CODESET; /* code set */
-	  int collation_id = LANG_SYS_COLLATION; /* collation_id */
+	  int units = LANG_SYS_CODESET;	/* code set */
+	  int collation_id = LANG_SYS_COLLATION;	/* collation_id */
 	  bool keep_searching = true;
 	  for (temp = arg2->data_type; temp != NULL && keep_searching; temp = temp->next)
 	    {
@@ -22984,8 +22984,8 @@ pt_common_collation (PT_COLL_INFER * arg1_coll_infer, PT_COLL_INFER * arg2_coll_
 
   if (arg1_coll_infer->coll_id != arg2_coll_infer->coll_id
       && (arg1_coll_infer->coerc_level == PT_COLLATION_NOT_COERC
-         || arg2_coll_infer->coerc_level == PT_COLLATION_NOT_COERC
-         || arg1_coll_infer->coerc_level == arg2_coll_infer->coerc_level)
+	  || arg2_coll_infer->coerc_level == PT_COLLATION_NOT_COERC
+	  || arg1_coll_infer->coerc_level == arg2_coll_infer->coerc_level)
       && arg1_coll_infer->can_force_cs == arg2_coll_infer->can_force_cs)
     {
       goto error;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23641

COLLATE modifier does not convert a charset of expressions without using CAST(). Therefore, if collation compatibility of parameters should be checked for expression or function and the codeset of the string parameters is clearly different, incompatible collation error should occur regardless of using the collate modifier.

at **pt_common_collation**, it should be checked if corec_level or arguments are **PT_COLLATION_NOT_COERC**