### PR TITLE
[CBRD-23930] Fix to check fk info even if the fk-child is already checked

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -15661,13 +15661,13 @@ sm_collect_truncatable_classes (MOP class_mop, std::unordered_set < OID > &trun_
   /* Find FK-child classes to cascade. */
   for (fk_ref = pk_constraint->fk_info; fk_ref; fk_ref = fk_ref->next)
     {
-      if (trun_classes.find (fk_ref->self_oid) != trun_classes.end ())
-	{
-	  continue;		/* already checked */
-	}
-
       if (fk_ref->delete_action == SM_FOREIGN_KEY_CASCADE)
 	{
+	  if (trun_classes.find (fk_ref->self_oid) != trun_classes.end ())
+	    {
+	      continue;		/* already checked */
+	    }
+
 	  MOP fk_child_mop = ws_mop (&fk_ref->self_oid, NULL);
 	  if (fk_child_mop == NULL)
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23930

The `fk_info` has to be checked even if fk child class is already checked. Even if the PK of fk-child is checked, FKs of fk-child is not yet checked. Imaging that you do TRUNCATE A, and there is A->B->A FK-cycle (->: refers to by a FK). 
1. the FK of A checked, and A is put into `trun_classes`.
2. then FK of B is checked, and B is put into `trun_claases`.
3. Although A is already in `trun_claasses`, the cascade action of B->A has to be checked.