### PR TITLE
[LETS-115] Reset nxio_lsa to append_lsa during boot/recovery

### DIFF
--- a/src/storage/async_page_fetcher.cpp
+++ b/src/storage/async_page_fetcher.cpp
@@ -68,7 +68,7 @@ namespace cublog
 
   void data_page_fetch_task::execute (context_type &context)
   {
-    if (m_lsa.is_null ())
+    if (!m_lsa.is_null ())
       {
 	// TODO: FIXME
 	// The transaction server boots and reads pages before initializing its log module and before knowing a safe target

--- a/src/storage/async_page_fetcher.cpp
+++ b/src/storage/async_page_fetcher.cpp
@@ -68,7 +68,13 @@ namespace cublog
 
   void data_page_fetch_task::execute (context_type &context)
   {
-    ps_Gl.get_replicator ().wait_past_target_lsa (m_lsa);
+    if (m_lsa.is_null ())
+      {
+	// TODO: FIXME
+	// The transaction server boots and reads pages before initializing its log module and before knowing a safe target
+	// LSA for replication. A way of knowing this target LSA is required, but disable this wait until that's fixed.
+	ps_Gl.get_replicator ().wait_past_target_lsa (m_lsa);
+      }
 
     PAGE_PTR page_ptr = pgbuf_fix (&context, &m_vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
 

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -177,6 +177,7 @@ LOG_RESET_APPEND_LSA (const LOG_LSA *lsa)
   // todo - concurrency safe-guard
   log_Gl.hdr.append_lsa = *lsa;
   log_Gl.prior_info.prior_lsa = *lsa;
+  log_Gl.append.set_nxio_lsa (*lsa);
 }
 
 void


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-115

Pages are requested during boot/recovery, before any log being flushed to disk and thus, before setting any value to nxio_lsa. These requests are sent with a null target replication LSA and trigger an assert on the page server.

The pages need to be sent with a valid target replication LSA. E.g. if page server replication is a couple of seconds behind, and if the transaction server restarts, it needs to wait until all the changes in the requested pages are replicated.

nxio_lsa is the LSA after the last log record written to disk. During boot/recovery, append LSA is reset to the same value with the  
LOG_RESET_APPEND_LSA function. Same function is used to also set the value of nxio_lsa.

EDIT: Some pages (e.g. data volume headers) are requested before the log module is initialized. The transaction server has no idea at this point what target LSA to set for its data page requests. For now, the wait for replication is disabled when target_lsa is null. In the future, the transaction server should set a good target from the start (probably with the help of page server, by obtaining some information from there).