### PR TITLE
[LETS-95] Only perform consistency check in recovery mode, not in replication mode

### DIFF
--- a/src/transaction/log_recovery_redo.cpp
+++ b/src/transaction/log_recovery_redo.cpp
@@ -19,29 +19,28 @@
 #include "log_recovery_redo.hpp"
 
 #if !defined(NDEBUG)
-vpid_lsa_consistency_check log_Gl_recovery_redo_consistency_check;
-#endif
-
 void
 vpid_lsa_consistency_check::check (const vpid &a_vpid, const log_lsa &a_log_lsa)
 {
-#if !defined(NDEBUG)
   std::lock_guard<std::mutex> lck (mtx);
   const vpid_key_t key {a_vpid.volid, a_vpid.pageid};
   const auto map_it =  consistency_check_map.find (key);
-  if (map_it != consistency_check_map.cend())
+  if (map_it != consistency_check_map.cend ())
     {
       assert ((*map_it).second < a_log_lsa);
     }
   consistency_check_map.emplace (key, a_log_lsa);
-#endif
 }
 
 void
 vpid_lsa_consistency_check::cleanup ()
 {
-#if !defined(NDEBUG)
   std::lock_guard<std::mutex> lck (mtx);
   consistency_check_map.clear ();
-#endif
 }
+#endif
+
+#if !defined(NDEBUG)
+vpid_lsa_consistency_check log_Gl_recovery_redo_consistency_check;
+#endif
+

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -508,6 +508,7 @@ inline int log_rv_get_log_rec_redo_data<LOG_REC_COMPENSATE> (THREAD_ENTRY *threa
   return log_rv_get_unzip_and_diff_redo_log_data (thread_p, log_pgptr_reader, &rcv, 0, nullptr, redo_unzip_support);
 }
 
+#if !defined(NDEBUG)
 class vpid_lsa_consistency_check
 {
   public:
@@ -527,11 +528,10 @@ class vpid_lsa_consistency_check
     using vpid_key_t = std::pair<short, int32_t>;
     using vpid_log_lsa_map_t = std::map<vpid_key_t, struct log_lsa>;
 
-#if !defined(NDEBUG)
     std::mutex mtx;
     vpid_log_lsa_map_t consistency_check_map;
-#endif
 };
+#endif
 
 #if !defined(NDEBUG)
 extern vpid_lsa_consistency_check log_Gl_recovery_redo_consistency_check;
@@ -543,9 +543,12 @@ void log_rv_redo_record_sync (THREAD_ENTRY *thread_p, log_reader &log_pgptr_read
 			      LOG_ZIP &undo_unzip_support, LOG_ZIP &redo_unzip_support)
 {
 #if !defined(NDEBUG)
-  // bit of debug code to ensure that, should this code be executed asynchronously, within the same page,
-  // the lsa is ever-increasing, thus, not altering the order in which it has been added to the log in the first place
-  log_Gl_recovery_redo_consistency_check.check (rcv_vpid, rcv_lsa);
+  if (log_Gl.rcv_phase != LOG_RESTARTED)
+    {
+      // bit of debug code to ensure that, should this code be executed asynchronously, within the same page,
+      // the lsa is ever-increasing, thus, not altering the order in which it has been added to the log in the first place
+      log_Gl_recovery_redo_consistency_check.check (rcv_vpid, rcv_lsa);
+    }
 #endif
 
   const LOG_DATA &log_data = log_rv_get_log_rec_data<T> (log_rec);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-95

When executing the recovery phase of the boot process `log_Gl.rcv_phase` is moved through a few values and ends up, at the end of the recovery process, with the `LOG_RESTARTED` value.
Use this flag to only execute the consistency check when in actual recovery, not when in "normal" mode. Thus, the code is not executed for replication on the page server side.