### PR TITLE
[CBRD-23963] Parallel make for openssl external library project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1172,7 +1172,6 @@ if(WITH_JDBC AND EXISTS ${CMAKE_SOURCE_DIR}/cubrid-jdbc/src)
   )
 endif()
 
-
 # include subdirectories
 add_subdirectory(cas)
 add_subdirectory(sa)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1086,8 +1086,8 @@ if(WITH_LIBOPENSSL STREQUAL "EXTERNAL")
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND    <SOURCE_DIR>/config --prefix=${CMAKE_CURRENT_BINARY_DIR}/external no-shared # ${DEFAULT_CONFIGURE_OPTS}
-      BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      INSTALL_COMMAND      make install_sw AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      BUILD_COMMAND        $(MAKE) all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      INSTALL_COMMAND      $(MAKE) install_sw AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       )
     set(LIBOPENSSL_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libssl.a ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libcrypto.a)
     set(LIBOPENSSL_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
@@ -1171,6 +1171,7 @@ if(WITH_JDBC AND EXISTS ${CMAKE_SOURCE_DIR}/cubrid-jdbc/src)
     FILES_MATCHING PATTERN "*.jar"
   )
 endif()
+
 
 # include subdirectories
 add_subdirectory(cas)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23963

The following warning is shown when building libopenssl with externalproject_add().
```
make[4]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
```
It causes a bottleneck in build. This warning can be fixed by setting the BUILD_COMMAND to `$(MAKE)` instead of `make`.