### PR TITLE
[CBRD-23955] Speed improvement of pt_find_keyword() function

### DIFF
--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -526,22 +526,26 @@ static KEYWORD_RECORD keywords[] = {
 static KEYWORD_RECORD *pt_find_keyword (const char *text);
 static int keyword_cmp (const void *k1, const void *k2);
 
-#define GET_KEYWORD_HASH_VALUE(h,s)  do {       \
-  unsigned char* p = (unsigned char*)(s);       \
-  for((h) = 5381;  *p; p++ )                    \
-    {                                           \
-      (h) = (((h) << 5) + (h)) + *p; /* hash * 33 + c */ \
-    }                                           \
-}while(0)
+#define GET_KEYWORD_HASH_VALUE(h,s)             \
+  do {                                          \
+      unsigned char* p = (unsigned char*)(s);   \
+      for((h) = 5381;  *p; p++ )                \
+        {                                       \
+             (h) = (((h) << 5) + (h)) + *p; /* hash * 33 + c */ \
+        }                                       \
+  }while(0)
 
 static int
 keyword_cmp (const void *k1, const void *k2)
 {
   if (((KEYWORD_RECORD *) k1)->hash_value > ((KEYWORD_RECORD *) k2)->hash_value)
-    return 1;
+    {
+      return 1;
+    }
   if (((KEYWORD_RECORD *) k1)->hash_value < ((KEYWORD_RECORD *) k2)->hash_value)
-    return -1;
-
+    {
+      return -1;
+    }
   return strcmp (((KEYWORD_RECORD *) k1)->keyword, ((KEYWORD_RECORD *) k2)->keyword);
 }
 
@@ -568,9 +572,13 @@ pt_find_keyword (const char *text)
 	{
 	  len = strlen (keywords[i].keyword);
 	  if (len < keyword_min_len)
-	    keyword_min_len = len;
+	    {
+	      keyword_min_len = len;
+	    }
 	  if (len > keyword_max_len)
-	    keyword_max_len = len;
+	    {
+	      keyword_max_len = len;
+	    }
 
 	  GET_KEYWORD_HASH_VALUE (keywords[i].hash_value, keywords[i].keyword);
 	}
@@ -611,12 +619,18 @@ pt_find_keyword (const char *text)
   for (p = (unsigned char *) text; *p; p++, s++)
     {
       if (*p >= 0x80)
-	return NULL;
+	{
+	  return NULL;
+	}
 
       if (*p >= 'a' && *p <= 'z')
-	*s = *p + ('A' - 'a');
+	{
+	  *s = *p + ('A' - 'a');
+	}
       else if (*p < 0x80)
-	*s = *p;
+	{
+	  *s = *p;
+	}
     }
   *s = 0x00;
 #else
@@ -629,16 +643,24 @@ pt_find_keyword (const char *text)
     {
       for (len = start_pos[i]; len < start_pos[i + 1]; len++)
 	{
-	  if (dummy.hash_value < keywords[len].hash_value)
-	    continue;
-	  else if (dummy.hash_value > keywords[len].hash_value)
-	    return NULL;
+	  if (dummy.hash_value > keywords[len].hash_value)
+	    {
+	      continue;
+	    }
+	  else if (dummy.hash_value < keywords[len].hash_value)
+	    {
+	      return NULL;
+	    }
 
 	  cmp = strcmp (dummy.keyword, keywords[len].keyword);
 	  if (cmp < 0)
-	    continue;
+	    {
+	      continue;
+	    }
 	  else if (cmp > 0)
-	    return NULL;
+	    {
+	      return NULL;
+	    }
 
 	  return keywords + len;
 	}

--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -541,14 +541,13 @@ static int keyword_cmp (const void *k1, const void *k2);
 static int
 keyword_cmp (const void *k1, const void *k2)
 {
-  if (((KEYWORD_RECORD *) k1)->hash_value > ((KEYWORD_RECORD *) k2)->hash_value)
+  int cmp = ((KEYWORD_RECORD *) k1)->hash_value - ((KEYWORD_RECORD *) k2)->hash_value;
+
+  if (cmp != 0)
     {
-      return 1;
+      return cmp;
     }
-  if (((KEYWORD_RECORD *) k1)->hash_value < ((KEYWORD_RECORD *) k2)->hash_value)
-    {
-      return -1;
-    }
+
   return strcmp (((KEYWORD_RECORD *) k1)->keyword, ((KEYWORD_RECORD *) k2)->keyword);
 }
 
@@ -631,7 +630,8 @@ pt_find_keyword (const char *text)
 
   GET_KEYWORD_HASH_VALUE (dummy.hash_value, dummy.keyword);
   i = (dummy.hash_value >> 8);
-  if ((start_pos[i + 1] - start_pos[i]) <= MAGIC_NUM_BI_SEQ)
+  len = (start_pos[i + 1] - start_pos[i]);
+  if (len <= MAGIC_NUM_BI_SEQ)
     {
       for (len = start_pos[i]; len < start_pos[i + 1]; len++)
 	{
@@ -645,11 +645,11 @@ pt_find_keyword (const char *text)
 	    }
 
 	  cmp = strcmp (dummy.keyword, keywords[len].keyword);
-	  if (cmp < 0)
+	  if (cmp > 0)
 	    {
 	      continue;
 	    }
-	  else if (cmp > 0)
+	  else if (cmp < 0)
 	    {
 	      return NULL;
 	    }

--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -33,6 +33,7 @@
 #include "intl_support.h"
 #include "dbtype.h"
 #include "string_opfunc.h"
+#include "../base/chartype.h"
 
 /* It is not required for the keywords to be alphabetically sorted, as they
  * will be sorted when needed. See pt_find_keyword.
@@ -623,14 +624,7 @@ pt_find_keyword (const char *text)
 	  return NULL;
 	}
 
-      if (*p >= 'a' && *p <= 'z')
-	{
-	  *s = *p + ('A' - 'a');
-	}
-      else if (*p < 0x80)
-	{
-	  *s = *p;
-	}
+      *s = (unsigned char) char_toupper ((int) *p);
     }
   *s = 0x00;
 #else

--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -530,12 +530,13 @@ static int keyword_cmp (const void *k1, const void *k2);
 /* The GET_KEYWORD_HASH_VALUE() macro is the definition of the djb2 algorithm as a macro.
  * Refer to the string_hash() function implemented in the libcubmemc.c file.
  */
-#define GET_KEYWORD_HASH_VALUE(h,s) do { \
-      unsigned char* p = (unsigned char*)(s);   \
-      for((h) = 5381;  *p; p++ )                \
-        {                                       \
+#define GET_KEYWORD_HASH_VALUE(h,s) \
+  do { \
+      unsigned char* p = (unsigned char*)(s); \
+      for((h) = 5381;  *p; p++ ) \
+        { \
              (h) = (((h) << 5) + (h)) + *p; /* hash * 33 + c */ \
-        }                                       \
+        } \
   } while(0)
 
 static int

--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -33,7 +33,7 @@
 #include "intl_support.h"
 #include "dbtype.h"
 #include "string_opfunc.h"
-#include "../base/chartype.h"
+#include "chartype.h"
 
 /* It is not required for the keywords to be alphabetically sorted, as they
  * will be sorted when needed. See pt_find_keyword.

--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -526,10 +526,22 @@ static KEYWORD_RECORD keywords[] = {
 static KEYWORD_RECORD *pt_find_keyword (const char *text);
 static int keyword_cmp (const void *k1, const void *k2);
 
+#define GET_KEYWORD_HASH_VALUE(h,s)  do {       \
+  unsigned char* p = (unsigned char*)(s);       \
+  for((h) = 5381;  *p; p++ )                    \
+    {                                           \
+      (h) = (((h) << 5) + (h)) + *p; /* hash * 33 + c */ \
+    }                                           \
+}while(0)
 
 static int
 keyword_cmp (const void *k1, const void *k2)
 {
+  if (((KEYWORD_RECORD *) k1)->hash_value > ((KEYWORD_RECORD *) k2)->hash_value)
+    return 1;
+  if (((KEYWORD_RECORD *) k1)->hash_value < ((KEYWORD_RECORD *) k2)->hash_value)
+    return -1;
+
   return strcmp (((KEYWORD_RECORD *) k1)->keyword, ((KEYWORD_RECORD *) k2)->keyword);
 }
 
@@ -542,12 +554,42 @@ static KEYWORD_RECORD *
 pt_find_keyword (const char *text)
 {
   static bool keyword_sorted = false;
-  KEYWORD_RECORD *result_key;
+  static int keyword_min_len = MAX_KEYWORD_SIZE;
+  static int keyword_max_len = 0;
+  static int keyword_cnt = sizeof (keywords) / sizeof (keywords[0]);
+  static short start_pos[257];	// (0x00 ~ 0xFF) + 1  
+#define MAGIC_NUM_BI_SEQ        (5)	/* Performance intersection between binary and sequential search */
+  int i, len, cmp;
   KEYWORD_RECORD dummy;
 
   if (keyword_sorted == false)
     {
-      qsort (keywords, (sizeof (keywords) / sizeof (keywords[0])), sizeof (keywords[0]), keyword_cmp);
+      for (i = 0; i < keyword_cnt; i++)
+	{
+	  len = strlen (keywords[i].keyword);
+	  if (len < keyword_min_len)
+	    keyword_min_len = len;
+	  if (len > keyword_max_len)
+	    keyword_max_len = len;
+
+	  GET_KEYWORD_HASH_VALUE (keywords[i].hash_value, keywords[i].keyword);
+	}
+
+      memset (start_pos, 0x00, sizeof (start_pos));
+
+      qsort (keywords, keyword_cnt, sizeof (keywords[0]), keyword_cmp);
+
+      for (i = 0; i < keyword_cnt; i++)
+	{
+	  start_pos[((keywords[i].hash_value) >> 8)]++;
+	}
+
+      start_pos[256] = keyword_cnt;
+      for (i = 255; i >= 0; i--)
+	{
+	  start_pos[i] = start_pos[i + 1] - start_pos[i];
+	}
+
       keyword_sorted = true;
     }
 
@@ -556,18 +598,55 @@ pt_find_keyword (const char *text)
       return NULL;
     }
 
-  if (strlen (text) >= MAX_KEYWORD_SIZE)
+  len = strlen (text);
+  if (len < keyword_min_len || len > keyword_max_len)
     {
       return NULL;
     }
 
+#if 1
+  /* Keywords are composed of ASCII characters(English letters, underbar).  */
+  unsigned char *p, *s;
+  s = (unsigned char *) dummy.keyword;
+  for (p = (unsigned char *) text; *p; p++, s++)
+    {
+      if (*p >= 0x80)
+	return NULL;
+
+      if (*p >= 'a' && *p <= 'z')
+	*s = *p + ('A' - 'a');
+      else if (*p < 0x80)
+	*s = *p;
+    }
+  *s = 0x00;
+#else
   intl_identifier_upper (text, dummy.keyword);
+#endif
 
-  result_key =
-    (KEYWORD_RECORD *) bsearch (&dummy, keywords, (sizeof (keywords) / sizeof (keywords[0])), sizeof (KEYWORD_RECORD),
-				keyword_cmp);
+  GET_KEYWORD_HASH_VALUE (dummy.hash_value, dummy.keyword);
+  i = (dummy.hash_value >> 8);
+  if ((start_pos[i + 1] - start_pos[i]) <= MAGIC_NUM_BI_SEQ)
+    {
+      for (len = start_pos[i]; len < start_pos[i + 1]; len++)
+	{
+	  if (dummy.hash_value < keywords[len].hash_value)
+	    continue;
+	  else if (dummy.hash_value > keywords[len].hash_value)
+	    return NULL;
 
-  return result_key;
+	  cmp = strcmp (dummy.keyword, keywords[len].keyword);
+	  if (cmp < 0)
+	    continue;
+	  else if (cmp > 0)
+	    return NULL;
+
+	  return keywords + len;
+	}
+
+      return NULL;
+    }
+
+  return (KEYWORD_RECORD *) bsearch (&dummy, keywords + start_pos[i], len, sizeof (KEYWORD_RECORD), keyword_cmp);
 }
 
 #if defined(ENABLE_UNUSED_FUNCTION)

--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -30,7 +30,6 @@
 
 #include "csql_grammar.h"
 #include "parser.h"
-#include "intl_support.h"
 #include "dbtype.h"
 #include "string_opfunc.h"
 #include "chartype.h"
@@ -527,14 +526,17 @@ static KEYWORD_RECORD keywords[] = {
 static KEYWORD_RECORD *pt_find_keyword (const char *text);
 static int keyword_cmp (const void *k1, const void *k2);
 
-#define GET_KEYWORD_HASH_VALUE(h,s)             \
-  do {                                          \
+
+/* The GET_KEYWORD_HASH_VALUE() macro is the definition of the djb2 algorithm as a macro.
+ * Refer to the string_hash() function implemented in the libcubmemc.c file.
+ */
+#define GET_KEYWORD_HASH_VALUE(h,s) do { \
       unsigned char* p = (unsigned char*)(s);   \
       for((h) = 5381;  *p; p++ )                \
         {                                       \
              (h) = (((h) << 5) + (h)) + *p; /* hash * 33 + c */ \
         }                                       \
-  }while(0)
+  } while(0)
 
 static int
 keyword_cmp (const void *k1, const void *k2)
@@ -613,7 +615,6 @@ pt_find_keyword (const char *text)
       return NULL;
     }
 
-#if 1
   /* Keywords are composed of ASCII characters(English letters, underbar).  */
   unsigned char *p, *s;
   s = (unsigned char *) dummy.keyword;
@@ -627,9 +628,6 @@ pt_find_keyword (const char *text)
       *s = (unsigned char) char_toupper ((int) *p);
     }
   *s = 0x00;
-#else
-  intl_identifier_upper (text, dummy.keyword);
-#endif
 
   GET_KEYWORD_HASH_VALUE (dummy.hash_value, dummy.keyword);
   i = (dummy.hash_value >> 8);

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3515,7 +3515,11 @@ struct execution_state_values
 typedef struct keyword_record KEYWORD_RECORD;
 struct keyword_record
 {
+#if defined(ENABLE_UNUSED_FUNCTION)
   short value;
+#else
+  unsigned short hash_value;
+#endif
   char keyword[MAX_KEYWORD_SIZE];
   short unreserved;		/* keyword can be used as an identifier, 0 means it is reserved and cannot be used as
 				 * an identifier, nonzero means it can be */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23955

Purpose
   -Improves the speed of pt_find_keyword() for checking reserved keywords.

Implementation
   - We changed the sorting policy for bipartite search.
   - Previously, only keyword string comparison was performed,
   - Use the structure changed to (Hash Value, Keyword String).
   - We narrowed our search by adding an array to manage the scope of the search.
  -  By using the intl_identifier_upper() function, the part that was converted to upper case was removed and changed to upper case directly.

 -  The "value" variable in struct keyword_record is meaningful only when ENABLE_UNUSED_FUNCTION is declared.
 - ENABLE_UNUSED_FUNCTION will not be declared.
 - To minimize code changes, the existing structure value initialization part is kept as it is (because the types are compatible).

Remarks
  -N/A
