### PR TITLE
[LETS-124] Replace compiler dependent busy loop used in unit tests with generic one

### DIFF
--- a/unit_tests/recovery/main.cpp
+++ b/unit_tests/recovery/main.cpp
@@ -333,7 +333,7 @@ TEST_CASE ("minimum log lsa: simple test", "[ci]")
   }
 }
 
-TEST_CASE ("minimum log lsa: complete test", "[ci][dbg]")
+TEST_CASE ("minimum log lsa: complete test", "[ci]")
 {
   constexpr int TASK_THREAD_COUNT = 42;
   constexpr log_lsa SENTINEL_LSA { MAX_LSA };

--- a/unit_tests/recovery/ut_redo_job_impl.cpp
+++ b/unit_tests/recovery/ut_redo_job_impl.cpp
@@ -96,21 +96,11 @@ ux_ut_redo_job_impl ut_redo_job_impl::clone ()
 void ut_redo_job_impl::busy_loop (double a_millis)
 {
   const auto start = std::chrono::system_clock::now ();
-  int loop_count = 0;
-  while (true)
+  double volatile diff_millis_count = 0.;
+  do
     {
-      // https://stackoverflow.com/a/58758133
-      for (unsigned i = 0; i < 1000; i++)
-	{
-	  __asm__ __volatile__ ("" : "+g" (i) : :);
-	}
       const std::chrono::duration<double, std::milli> diff_millis = std::chrono::system_clock::now () - start;
-      const double diff_millis_count = diff_millis.count ();
-      if (a_millis <= diff_millis_count )
-	{
-	  auto dbg = loop_count;
-	  break;
-	}
-      ++loop_count;
+      diff_millis_count = diff_millis.count ();
     }
+  while (diff_millis_count < a_millis);
 }

--- a/unit_tests/recovery/ut_redo_job_impl.cpp
+++ b/unit_tests/recovery/ut_redo_job_impl.cpp
@@ -100,7 +100,7 @@ void ut_redo_job_impl::busy_loop (double a_millis)
   do
     {
       const std::chrono::duration<double, std::milli> diff_millis = std::chrono::system_clock::now () - start;
-      diff_millis_count = diff_millis.count ();
+      diff_millis_count = diff_millis.count (); // side effect
     }
   while (diff_millis_count < a_millis);
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-124

`__asm__ __volatile__` used to implement busy-loop is not portable across compilers.
It is not supported on VC++ and is not possible to replace with equivalent assembler instructions because assembler is not supported anymore by VC++ when compiling for 64 bit.
Replace with 'dumb' implementation that has the same effect.
