### PR TITLE
[LETS-122] Wait for replication to catch-up when running checkpoint on the page server.

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -3625,6 +3625,9 @@ pgbuf_flush_checkpoint (THREAD_ENTRY * thread_p, const LOG_LSA * flush_upto_lsa,
 	  continue;
 	}
 
+      detailed_er_log ("pgbuf_flush_checkpoint: bcb=%p, vpid=%d|%d, oldest_unflush_lsa=%lld|%d selected for flush.\n",
+		       bufptr, VPID_AS_ARGS (&bufptr->vpid), LSA_AS_ARGS (&bufptr->oldest_unflush_lsa));
+
       if (!LSA_ISNULL (&bufptr->oldest_unflush_lsa) && prev_chkpt_redo_lsa != NULL && !LSA_ISNULL (prev_chkpt_redo_lsa))
 	{
 	  if (LSA_LT (&bufptr->oldest_unflush_lsa, prev_chkpt_redo_lsa))

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6840,11 +6840,13 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
     // *INDENT-ON*
   }
 
+#if defined (SERVER_MODE)
   if (get_server_type () == SERVER_TYPE_PAGE)
     {
       // Wait the replication to catch up first
       ps_Gl.get_replicator ().wait_past_target_lsa (new_chkpt_redo_lsa);
     }
+#endif // SERVER_MODE = not SA_MODE
 
   /*
    * Modify log header to record present checkpoint. The header is flushed

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -66,6 +66,7 @@
 #include "log_volids.hpp"
 #include "log_writer.h"
 #include "lock_manager.h"
+#include "log_replication.hpp"
 #include "log_system_tran.hpp"
 #include "boot_sr.h"
 #if !defined(SERVER_MODE)
@@ -79,6 +80,7 @@
 #include "ats_ps_request.hpp"
 #include "critical_section.h"
 #include "page_buffer.h"
+#include "page_server.hpp"
 #include "double_write_buffer.h"
 #include "file_io.h"
 #include "disk_manager.h"
@@ -6838,6 +6840,11 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
     // *INDENT-ON*
   }
 
+  if (get_server_type () == SERVER_TYPE_PAGE)
+    {
+      // Wait the replication to catch up first
+      ps_Gl.get_replicator ().wait_past_target_lsa (new_chkpt_redo_lsa);
+    }
 
   /*
    * Modify log header to record present checkpoint. The header is flushed


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-122

On the transaction server, the regular order of operating database changes is:

  1. Fix data page
  2. Log change on the page &  make change in the page
  3. Unfix page.

When checkpoint gets its checkpoint LSA, all changes up to checkpoint LSA are already reflected in the pages that will be flushed to disk.

On the page server, the log comes from the transaction server. The log records exist way before the change is reflected into the data page. When checkpoint got its checkpoint LSA, the replication was behind and changes that occurred before checkpoint LSA were missed while pages were being flushed to disk. This caused consistencies caught by checkpoint safe-guards.

Fix by waiting for the replication to catch-up with the checkpoint LSA before proceeding to flushing data pages to disk.