### PR TITLE
[LETS-123] Always make sure the log is flushed to disk on the page server

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9932,7 +9932,7 @@ log_flush_execute (cubthread::entry & thread_ref)
 
   if (!need_flush && get_server_type () == SERVER_TYPE_PAGE)
     {
-      // page server needs to confirm that flushed log asap. if there is any unflushed log, flush it.
+      // page server needs to confirm the flushed log asap. if there is any unflushed log, flush it.
       // Unflushed log may be either:
       //    - In prior list (prior_list_header != nullptr)
       //    - Appended into pages, but not flushed to disk (nxio_lsa < append_lsa)

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9939,30 +9939,32 @@ log_flush_execute (cubthread::entry & thread_ref)
 
       // log_lsa compare is not thread safe. Use atomic load on non-atomic type log_Gl.hdr.append_lsa
       // Atomic operations need to reinterpret the 8-bytes of log_lsa as int64
+      // *INDENT-OFF*
       log_lsa append_lsa =
 	static_cast<log_lsa> (ATOMIC_LOAD_64 (reinterpret_cast<std::int64_t *> (&log_Gl.hdr.append_lsa)));
+      // *INDENT-ON*
 
-      need_flush = log_Gl.prior_info.prior_list_header != nullptr || log_Gl.append.get_nxio_lsa () < append_lsa;
-    }
+need_flush = log_Gl.prior_info.prior_list_header != nullptr || log_Gl.append.get_nxio_lsa () < append_lsa;
+}
 
-  if (!need_flush)
-    {
-      // Try again later
-      return;
-    }
+if (!need_flush)
+  {
+    // Try again later
+    return;
+  }
 
   // refresh log trace flush time
-  thread_ref.event_stats.trace_log_flush_time = prm_get_integer_value (PRM_ID_LOG_TRACE_FLUSH_TIME_MSECS);
+thread_ref.event_stats.trace_log_flush_time = prm_get_integer_value (PRM_ID_LOG_TRACE_FLUSH_TIME_MSECS);
 
-  LOG_CS_ENTER (&thread_ref);
-  logpb_flush_pages_direct (&thread_ref);
-  LOG_CS_EXIT (&thread_ref);
+LOG_CS_ENTER (&thread_ref);
+logpb_flush_pages_direct (&thread_ref);
+LOG_CS_EXIT (&thread_ref);
 
-  log_Stat.gc_flush_count++;
+log_Stat.gc_flush_count++;
 
-  pthread_mutex_lock (&log_Gl.group_commit_info.gc_mutex);
-  pthread_cond_broadcast (&log_Gl.group_commit_info.gc_cond);
-  pthread_mutex_unlock (&log_Gl.group_commit_info.gc_mutex);
+pthread_mutex_lock (&log_Gl.group_commit_info.gc_mutex);
+pthread_cond_broadcast (&log_Gl.group_commit_info.gc_cond);
+pthread_mutex_unlock (&log_Gl.group_commit_info.gc_mutex);
 }
 #endif /* SERVER_MODE */
 
@@ -9976,7 +9978,7 @@ log_checkpoint_daemon_init ()
   assert (log_Checkpoint_daemon == NULL);
 
   cubthread::looper looper = cubthread::looper (log_get_checkpoint_interval);
-  cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (log_checkpoint_execute);
+  cubthread::entry_callable_task * daemon_task = new cubthread::entry_callable_task (log_checkpoint_execute);
 
   // create checkpoint daemon thread
   log_Checkpoint_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log_checkpoint");
@@ -9993,17 +9995,15 @@ log_remove_log_archive_daemon_init ()
   assert (log_Remove_log_archive_daemon == NULL);
 
   log_remove_log_archive_daemon_task *daemon_task = new log_remove_log_archive_daemon_task ();
-  cubthread::period_function setup_period_function = std::bind (
-      &log_remove_log_archive_daemon_task::get_remove_log_archives_interval,
-      daemon_task,
-      std::placeholders::_1,
-      std::placeholders::_2);
+  cubthread::period_function setup_period_function =
+    std::bind (&log_remove_log_archive_daemon_task::get_remove_log_archives_interval, daemon_task,
+	       std::placeholders::_1, std::placeholders::_2);
 
   cubthread::looper looper = cubthread::looper (setup_period_function);
 
   // create log archive remover daemon thread
   log_Remove_log_archive_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
-                                                                            "log_remove_log_archive");
+									    "log_remove_log_archive");
 }
 #endif /* SERVER_MODE */
 
@@ -10019,7 +10019,7 @@ log_clock_daemon_init ()
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (200));
   log_Clock_daemon =
     cubthread::get_manager ()->create_daemon (looper, new cubthread::entry_callable_task (log_clock_execute),
-                                              "log_clock");
+					      "log_clock");
 }
 #endif /* SERVER_MODE */
 
@@ -10033,10 +10033,10 @@ log_check_ha_delay_info_daemon_init ()
   assert (log_Check_ha_delay_info_daemon == NULL);
 
   cubthread::looper looper = cubthread::looper (std::chrono::seconds (1));
-  cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (log_check_ha_delay_info_execute);
+  cubthread::entry_callable_task * daemon_task = new cubthread::entry_callable_task (log_check_ha_delay_info_execute);
 
   log_Check_ha_delay_info_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
-                                                                             "log_check_ha_delay_info");
+									     "log_check_ha_delay_info");
 }
 #endif /* SERVER_MODE */
 
@@ -10050,7 +10050,7 @@ log_flush_daemon_init ()
   assert (log_Flush_daemon == NULL);
 
   cubthread::looper looper = cubthread::looper (log_get_log_group_commit_interval);
-  cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (log_flush_execute);
+  cubthread::entry_callable_task * daemon_task = new cubthread::entry_callable_task (log_flush_execute);
 
   log_Flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log_flush");
 }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9932,8 +9932,7 @@ log_flush_execute (cubthread::entry & thread_ref)
 
   if (!need_flush && get_server_type () == SERVER_TYPE_PAGE)
     {
-      // page server needs to confirm that if flushed log asap.
-      // if there is any unflushed log, flush it.
+      // page server needs to confirm that flushed log asap. if there is any unflushed log, flush it.
       // Unflushed log may be either:
       //    - In prior list (prior_list_header != nullptr)
       //    - Appended into pages, but not flushed to disk (nxio_lsa < append_lsa)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-123

Running many operations in a single transaction on the transaction server sometimes hangs. The reason is that the log flush thread on the page server misses a wakeup call and never flushes the last batch of log records. The transaction server does nothing but waits for a confirmation from the page server that never comes.

Two reasons have been discovered for missing the confirmation:

  1. A wakeup call that came while a log flush iteration was still in progress was lost because the requested flag is reset at the end of log flush execution. In the next iteration it earlies out.
  2. Prior list has been serialized to log pages, but was not flushed to disk.

log_flush_execute (the loop function of log flush daemon) has fixes for both problems:

  1. Use compare exchange when testing the requested flag, from true to false. If it returns true, it means there are requests. Any wakeup calls during log_flush_execute will not be missed.
  2. Even if no wakeup requests are registered, on the page server, if there are any unflushed log records in prior list or appended in the log pages, flush is forced.
