### PR TITLE
[CBRD-23874] The function IFNULL returns incorrect data type at the query with numeric host-variables

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -11467,7 +11467,7 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 			      // TODO: It should be considered for parameterized types, refer to PT_IS_PARAMETERIZED_TYPE()
 			      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
 				{
-				  tp_domain_resolve (lhs_dbtype, NULL, sci.prec, sci.scale, NULL, 0);
+				  d = tp_domain_resolve (lhs_dbtype, NULL, sci.prec, sci.scale, NULL, 0);
 				}
 			      else
 				{

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -11424,6 +11424,7 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 		  if (rhs->node_type != PT_HOST_VAR)
 		    {
 		      d = tp_domain_resolve_default (lhs_dbtype);
+		      // TODO: It should be considered for parameterized types, refer to PT_IS_PARAMETERIZED_TYPE()
 		      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
 			{
 			  d = tp_domain_copy (d, false);
@@ -11464,6 +11465,7 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 			  else
 			    {
 			      d = tp_domain_resolve_default (lhs_dbtype);
+			      // TODO: It should be considered for parameterized types, refer to PT_IS_PARAMETERIZED_TYPE()
 			      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
 				{
 				  d = tp_domain_copy (d, false);

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -11423,14 +11423,14 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 
 		  if (rhs->node_type != PT_HOST_VAR)
 		    {
-		      d = tp_domain_resolve_default (lhs_dbtype);
 		      // TODO: It should be considered for parameterized types, refer to PT_IS_PARAMETERIZED_TYPE()
 		      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
 			{
-			  d = tp_domain_copy (d, false);
-			  d->precision = sci.prec;
-			  d->scale = sci.scale;
-			  d = tp_domain_cache (d);
+			  d = tp_domain_resolve (lhs_dbtype, NULL, sci.prec, sci.scale, NULL, 0);
+			}
+		      else
+			{
+			  d = tp_domain_resolve_default (lhs_dbtype);
 			}
 		    }
 		  else
@@ -11464,14 +11464,14 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 			    }
 			  else
 			    {
-			      d = tp_domain_resolve_default (lhs_dbtype);
 			      // TODO: It should be considered for parameterized types, refer to PT_IS_PARAMETERIZED_TYPE()
 			      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
 				{
-				  d = tp_domain_copy (d, false);
-				  d->precision = sci.prec;
-				  d->scale = sci.scale;
-				  d = tp_domain_cache (d);
+				  tp_domain_resolve (lhs_dbtype, NULL, sci.prec, sci.scale, NULL, 0);
+				}
+			      else
+				{
+				  d = tp_domain_resolve_default (lhs_dbtype);
 				}
 			    }
 

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -11423,14 +11423,12 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 
 		  if (rhs->node_type != PT_HOST_VAR)
 		    {
-		      if (lhs->data_type != NULL)
+		      d = tp_domain_resolve_default (lhs_dbtype);
+		      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
 			{
-			  d = pt_data_type_to_db_domain (parser, lhs->data_type, NULL);
-			  d = tp_domain_cache (d);
-			}
-		      else
-			{
-			  d = tp_domain_resolve_default (lhs_dbtype);
+			  d = tp_domain_copy (d, false);
+			  d->precision = lhs->data_type->info.data_type.precision;
+			  d->scale = lhs->data_type->info.data_type.dec_precision;
 			}
 		    }
 		  else
@@ -11464,14 +11462,12 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 			    }
 			  else
 			    {
-			      if (lhs->data_type != NULL)
+			      d = tp_domain_resolve_default (lhs_dbtype);
+			      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
 				{
-				  d = pt_data_type_to_db_domain (parser, lhs->data_type, NULL);
-				  d = tp_domain_cache (d);
-				}
-			      else
-				{
-				  d = tp_domain_resolve_default (lhs_dbtype);
+				  d = tp_domain_copy (d, false);
+				  d->precision = lhs->data_type->info.data_type.precision;
+				  d->scale = lhs->data_type->info.data_type.dec_precision;
 				}
 			    }
 

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -2298,10 +2298,6 @@ pt_is_compatible_without_cast (PARSER_CONTEXT * parser, SEMAN_COMPATIBLE_INFO * 
 
   if (dest_sci->type_enum != src->type_enum)
     {
-      if (src->type_enum == PT_TYPE_MAYBE && dest_sci->type_enum == PT_TYPE_NUMERIC)
-	{
-	  return true;
-	}
       return false;
     }
 
@@ -11428,6 +11424,12 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 		  if (rhs->node_type != PT_HOST_VAR)
 		    {
 		      d = tp_domain_resolve_default (lhs_dbtype);
+		      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
+			{
+			  d = tp_domain_copy (d, false);
+			  d->precision = lhs->data_type->info.data_type.precision;
+			  d->scale = lhs->data_type->info.data_type.dec_precision;
+			}
 		    }
 		  else
 		    {

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -2298,6 +2298,10 @@ pt_is_compatible_without_cast (PARSER_CONTEXT * parser, SEMAN_COMPATIBLE_INFO * 
 
   if (dest_sci->type_enum != src->type_enum)
     {
+      if (src->type_enum == PT_TYPE_MAYBE)
+	{
+	  return true;
+	}
       return false;
     }
 

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -11463,6 +11463,12 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 			  else
 			    {
 			      d = tp_domain_resolve_default (lhs_dbtype);
+			      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
+				{
+				  d = tp_domain_copy (d, false);
+				  d->precision = lhs->data_type->info.data_type.precision;
+				  d->scale = lhs->data_type->info.data_type.dec_precision;
+				}
 			    }
 
 			  if (PT_HAS_COLLATION (lhs->type_enum))

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -11423,13 +11423,8 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 
 		  if (rhs->node_type != PT_HOST_VAR)
 		    {
-		      d = tp_domain_resolve_default (lhs_dbtype);
-		      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
-			{
-			  d = tp_domain_copy (d, false);
-			  d->precision = lhs->data_type->info.data_type.precision;
-			  d->scale = lhs->data_type->info.data_type.dec_precision;
-			}
+		      d = pt_data_type_to_db_domain (parser, lhs->data_type, NULL);
+		      d = tp_domain_cache (d);
 		    }
 		  else
 		    {
@@ -11462,13 +11457,8 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 			    }
 			  else
 			    {
-			      d = tp_domain_resolve_default (lhs_dbtype);
-			      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
-				{
-				  d = tp_domain_copy (d, false);
-				  d->precision = lhs->data_type->info.data_type.precision;
-				  d->scale = lhs->data_type->info.data_type.dec_precision;
-				}
+			      d = pt_data_type_to_db_domain (parser, lhs->data_type, NULL);
+			      d = tp_domain_cache (d);
 			    }
 
 			  if (PT_HAS_COLLATION (lhs->type_enum))

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -11423,8 +11423,15 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 
 		  if (rhs->node_type != PT_HOST_VAR)
 		    {
-		      d = pt_data_type_to_db_domain (parser, lhs->data_type, NULL);
-		      d = tp_domain_cache (d);
+		      if (lhs->data_type != NULL)
+			{
+			  d = pt_data_type_to_db_domain (parser, lhs->data_type, NULL);
+			  d = tp_domain_cache (d);
+			}
+		      else
+			{
+			  d = tp_domain_resolve_default (lhs_dbtype);
+			}
 		    }
 		  else
 		    {
@@ -11457,8 +11464,15 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 			    }
 			  else
 			    {
-			      d = pt_data_type_to_db_domain (parser, lhs->data_type, NULL);
-			      d = tp_domain_cache (d);
+			      if (lhs->data_type != NULL)
+				{
+				  d = pt_data_type_to_db_domain (parser, lhs->data_type, NULL);
+				  d = tp_domain_cache (d);
+				}
+			      else
+				{
+				  d = tp_domain_resolve_default (lhs_dbtype);
+				}
 			    }
 
 			  if (PT_HAS_COLLATION (lhs->type_enum))

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -2298,7 +2298,7 @@ pt_is_compatible_without_cast (PARSER_CONTEXT * parser, SEMAN_COMPATIBLE_INFO * 
 
   if (dest_sci->type_enum != src->type_enum)
     {
-      if (src->type_enum == PT_TYPE_MAYBE)
+      if (src->type_enum == PT_TYPE_MAYBE && dest_sci->type_enum == PT_TYPE_NUMERIC)
 	{
 	  return true;
 	}

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -11424,11 +11424,12 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 		  if (rhs->node_type != PT_HOST_VAR)
 		    {
 		      d = tp_domain_resolve_default (lhs_dbtype);
-		      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
+		      if (PT_IS_PARAMETERIZED_TYPE (lhs->type_enum))
 			{
 			  d = tp_domain_copy (d, false);
-			  d->precision = lhs->data_type->info.data_type.precision;
-			  d->scale = lhs->data_type->info.data_type.dec_precision;
+			  d->precision = sci.prec;
+			  d->scale = sci.scale;
+			  d = tp_domain_cache (d);
 			}
 		    }
 		  else
@@ -11463,11 +11464,12 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 			  else
 			    {
 			      d = tp_domain_resolve_default (lhs_dbtype);
-			      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
+			      if (PT_IS_PARAMETERIZED_TYPE (lhs->type_enum))
 				{
 				  d = tp_domain_copy (d, false);
-				  d->precision = lhs->data_type->info.data_type.precision;
-				  d->scale = lhs->data_type->info.data_type.dec_precision;
+				  d->precision = sci.prec;
+				  d->scale = sci.scale;
+				  d = tp_domain_cache (d);
 				}
 			    }
 

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -11424,7 +11424,7 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 		  if (rhs->node_type != PT_HOST_VAR)
 		    {
 		      d = tp_domain_resolve_default (lhs_dbtype);
-		      if (PT_IS_PARAMETERIZED_TYPE (lhs->type_enum))
+		      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
 			{
 			  d = tp_domain_copy (d, false);
 			  d->precision = sci.prec;
@@ -11464,7 +11464,7 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 			  else
 			    {
 			      d = tp_domain_resolve_default (lhs_dbtype);
-			      if (PT_IS_PARAMETERIZED_TYPE (lhs->type_enum))
+			      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
 				{
 				  d = tp_domain_copy (d, false);
 				  d->precision = sci.prec;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23874

The following query expects 12.34568 but query returns 12.00000. The function NVL also returns 12.00000 as like IFNULL.
```

CREATE TABLE dec_tbl (a decimal(10,5));
PREPARE stmt from 'INSERT INTO dec_tbl VALUES (IFNULL(?,0))';
EXECUTE stmt USING 12.3456789;

SELECT a FROM dec_tbl;
```
Expected Result
```
 a
======================
  12.34568 
```
Actual Result
```
  a
======================
  12.00000 
```
At the semantic checking, the type cast from PT_TYPE_MAYBE makes the precision and scale as their default values. So, the precision and scale is set 15 and 0 respectively.
I modified the **pt_is_compatible_without_cast** not to return 'false' at the above case.