### PR TITLE
[LETS-125] Transaction server crashes when page_server_hosts parameter is empty

### DIFF
--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -87,16 +87,8 @@ active_tran_server::parse_server_host (const std::string &host)
 }
 
 int
-active_tran_server::parse_page_server_hosts_config ()
+active_tran_server::parse_page_server_hosts_config (std::string &hosts)
 {
-  std::string hosts = prm_get_string_value (PRM_ID_PAGE_SERVER_HOSTS);
-
-  if (!hosts.length ())
-    {
-      // no page server
-      return NO_ERROR;
-    }
-
   auto col_pos = hosts.find (":");
 
   if (col_pos < 1 || col_pos >= hosts.length () - 1)
@@ -132,7 +124,16 @@ int
 active_tran_server::init_page_server_hosts (const char *db_name)
 {
   assert_is_active_tran_server ();
-  int exit_code = parse_page_server_hosts_config ();
+
+  std::string hosts = prm_get_string_value (PRM_ID_PAGE_SERVER_HOSTS);
+
+  if (!hosts.length ())
+    {
+      // no page server
+      return NO_ERROR;
+    }
+
+  int exit_code = parse_page_server_hosts_config (hosts);
 
   if (m_connection_list.empty ())
     {

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -57,7 +57,7 @@ class active_tran_server
 	    cubcomm::request_sync_client_server<ats_to_ps_request, ps_to_ats_request, std::string>;
 
     int parse_server_host (const std::string &host);
-    int parse_page_server_hosts_config ();
+    int parse_page_server_hosts_config (std::string &hosts);
     void receive_saved_lsa (cubpacking::unpacker &upk);
     void receive_log_page (cubpacking::unpacker &upk);
     void receive_data_page (cubpacking::unpacker &upk);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-125

Transaction server crashes if given an empty host list parameter,  solved by adding an early out if no host is provided.
