### PR TITLE
[CBRD-23930] Enable TRUNCATE without CASCADE to a class with self-referencing FK

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -15678,9 +15678,9 @@ sm_collect_truncatable_classes (MOP class_mop, std::unordered_set < OID > &trun_
   trun_classes.emplace (*ws_oid (class_mop));
 
   pk_constraint = classobj_find_cons_primary_key (class_->constraints);
-  if (pk_constraint == NULL || pk_constraint->fk_info == NULL)
+  if (pk_constraint == NULL || classobj_is_pk_referred (class_mop, pk_constraint->fk_info, false, NULL) == false)
     {
-      /* if no PK or FK-referred, it can be truncated */
+      /* if no PK, not FK-referred, or self-referencing, it can be truncated */
       return NO_ERROR;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23930

When truncating a class which has a foreign key referring to the primary key of itself, it will succeed without the CASCADE option. It was not defined, but this way seems reasonable and the other DB does like this.
