### PR TITLE
[LETS-64] Initialize log prior receiver only on the page server

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -22,6 +22,7 @@
 #include "communication_server_channel.hpp"
 #include "connection_defs.h"
 #include "error_manager.h"
+#include "log_impl.h"
 #include "page_server.hpp"
 #include "system_parameter.h"
 
@@ -51,6 +52,13 @@ void init_server_type (const char *db_name)
   if (g_server_type == SERVER_TYPE_TRANSACTION)
     {
       ats_Gl.init_page_server_hosts (db_name);
+    }
+  else
+    {
+      assert (g_server_type == SERVER_TYPE_PAGE);
+
+      // page server needs a log prior receiver
+      log_Gl.initialize_log_prior_receiver ();
     }
 
   er_log_debug (ARG_FILE_LINE, "Starting server type: %s\n",

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -82,7 +82,7 @@ void page_server::receive_log_prior_list (cubpacking::unpacker &upk)
 {
   std::string message;
   upk.unpack_string (message);
-  log_Gl.m_prior_recver.push_message (std::move (message));
+  log_Gl.get_log_prior_receiver ().push_message (std::move (message));
 }
 
 void page_server::receive_log_page_fetch (cubpacking::unpacker &upk)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3176,6 +3176,7 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
 #if defined (SERVER_MODE)
   if (get_server_type () == SERVER_TYPE_PAGE)
     {
+      log_Gl.finalize_log_prior_receiver ();	// stop receiving log before log_final()
       ps_Gl.finish_replication_during_shutdown (*thread_p);
       ps_Gl.finalize_log_page_fetcher ();
     }

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -76,9 +76,6 @@ log_global::log_global ()
   , mvcc_table ()
   , unique_stats_table GLOBAL_UNIQUE_STATS_TABLE_INITIALIZER
   , m_prior_sender ()
-#if defined (SERVER_MODE)
-  , m_prior_recver (prior_info)
-#endif // SERVER_MODE = !SA_MODE
 {
 }
 // *INDENT-ON*
@@ -125,5 +122,24 @@ log_global::wait_flushed_lsa (const log_lsa &flush_lsa)
     }
   std::unique_lock<std::mutex> lock (m_ps_lsa_mutex);
   m_ps_lsa_cv.wait (lock, [flush_lsa, this] { return m_max_ps_flushed_lsa >= flush_lsa; });
+}
+
+void
+log_global::initialize_log_prior_receiver ()
+{
+  m_prior_recver = std::make_unique<cublog::prior_recver> (prior_info);
+}
+
+void
+log_global::finalize_log_prior_receiver ()
+{
+  m_prior_recver.reset (nullptr);
+}
+
+cublog::prior_recver &
+log_global::get_log_prior_receiver ()
+{
+  assert (m_prior_recver != nullptr);
+  return *m_prior_recver;
 }
 // *INDENT-ON*

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -124,6 +124,7 @@ log_global::wait_flushed_lsa (const log_lsa &flush_lsa)
   m_ps_lsa_cv.wait (lock, [flush_lsa, this] { return m_max_ps_flushed_lsa >= flush_lsa; });
 }
 
+#if defined (SERVER_MODE)
 void
 log_global::initialize_log_prior_receiver ()
 {
@@ -142,4 +143,5 @@ log_global::get_log_prior_receiver ()
   assert (m_prior_recver != nullptr);
   return *m_prior_recver;
 }
+#endif // SERVER_MODE
 // *INDENT-ON*

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -652,19 +652,26 @@ struct log_global
   cublog::meta m_metainfo;
   cublog::prior_sender m_prior_sender;
 #if defined (SERVER_MODE)
-  cublog::prior_recver m_prior_recver;
+  std::unique_ptr<cublog::prior_recver> m_prior_recver = nullptr;
 #endif // SERVER_MODE = !SA_MODE
 
   std::mutex m_ps_lsa_mutex;
   std::condition_variable m_ps_lsa_cv;
-  LOG_LSA m_max_ps_flushed_lsa;
+  LOG_LSA m_max_ps_flushed_lsa = NULL_LSA;
 
   log_global ();
   ~log_global ();
-  // *INDENT-ON*
+
+#if defined (SERVER_MODE)
+  void initialize_log_prior_receiver ();
+  void finalize_log_prior_receiver ();
+  cublog::prior_recver &get_log_prior_receiver ();
+#endif // SERVER_MODE
 
   void update_max_ps_flushed_lsa (const LOG_LSA & lsa);
   void wait_flushed_lsa (const log_lsa & flush_lsa);
+
+  // *INDENT-ON*
 };
 
 /* logging statistics */

--- a/unit_tests/log/test_main_prior_list_serialize.cpp
+++ b/unit_tests/log/test_main_prior_list_serialize.cpp
@@ -452,7 +452,7 @@ namespace cublog
 }
 
 log_global::log_global ()
-  : m_prior_recver (prior_info)
+  : m_prior_recver (std::make_unique<cublog::prior_recver> (prior_info))
 {
 }
 log_global::~log_global () = default;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-64

Log prior receiver automatically starts a thread when it is constructed, ready to take over transferred log prior lists. On the active transaction server this thread does nothing, because the server does not receive any log.

Fix by changing the log_Gl.m_prior_recver member to a unique pointer. The log prior receiver is initialized with init_server_type(), only on the page server, and it is finalized during shutdown before log_final() is called.

**Tests**

- Tested deletedb/createdb
- Tested SA_MODE start/shutdown
- Tested that transaction server no longer has the thread.
- Tested that the page server has this thread
- Tested boot restart/shutdown on all TS/PS configurations
