### PR TITLE
[LETS-102] Use log_lsa packing function for checkpoint_information

### DIFF
--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -368,6 +368,7 @@ set(TRANSACTION_SOURCES
   ${TRANSACTION_DIR}/log_checkpoint_info.cpp
   ${TRANSACTION_DIR}/log_global.c
   ${TRANSACTION_DIR}/log_lsa.cpp
+  ${TRANSACTION_DIR}/log_lsa_utils.cpp
   ${TRANSACTION_DIR}/log_manager.c
   ${TRANSACTION_DIR}/log_meta.cpp
   ${TRANSACTION_DIR}/log_page_buffer.c
@@ -397,6 +398,7 @@ set(TRANSACTION_HEADERS
   ${TRANSACTION_DIR}/log_common_impl.h
   ${TRANSACTION_DIR}/log_checkpoint_info.hpp
   ${TRANSACTION_DIR}/log_lsa.hpp
+  ${TRANSACTION_DIR}/log_lsa_utils.hpp
   ${TRANSACTION_DIR}/log_meta.hpp
   ${TRANSACTION_DIR}/log_postpone_cache.hpp
   ${TRANSACTION_DIR}/log_prior_send.hpp

--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -118,8 +118,8 @@ namespace cublog
   checkpoint_info::get_packed_size (cubpacking::packer &serializator, std::size_t start_offset) const
   {
     size_t size =  0;
-    size += lsa_utils::get_packed_size (serializator, start_offset, size);
-    size += lsa_utils::get_packed_size (serializator, start_offset, size);
+    size += lsa_utils::get_packed_size (serializator, start_offset + size);
+    size += lsa_utils::get_packed_size (serializator, start_offset + size);
 
     size += serializator.get_packed_bigint_size (start_offset + size);
     for (const auto &tran_info : m_trans)
@@ -128,14 +128,14 @@ namespace cublog
 	size += serializator.get_packed_int_size (start_offset + size);
 	size += serializator.get_packed_int_size (start_offset + size);
 
-	size += lsa_utils::get_packed_size (serializator, start_offset, size);
-	size += lsa_utils::get_packed_size (serializator, start_offset, size);
-	size += lsa_utils::get_packed_size (serializator, start_offset, size);
+	size += lsa_utils::get_packed_size (serializator, start_offset + size);
+	size += lsa_utils::get_packed_size (serializator, start_offset + size);
+	size += lsa_utils::get_packed_size (serializator, start_offset + size);
 
-	size += lsa_utils::get_packed_size (serializator, start_offset, size);
-	size += lsa_utils::get_packed_size (serializator, start_offset, size);
-	size += lsa_utils::get_packed_size (serializator, start_offset, size);
-	size += lsa_utils::get_packed_size (serializator, start_offset, size);
+	size += lsa_utils::get_packed_size (serializator, start_offset + size);
+	size += lsa_utils::get_packed_size (serializator, start_offset + size);
+	size += lsa_utils::get_packed_size (serializator, start_offset + size);
+	size += lsa_utils::get_packed_size (serializator, start_offset + size);
 	size += serializator.get_packed_c_string_size (tran_info.user_name, strlen (tran_info.user_name), start_offset + size);
       }
 
@@ -143,8 +143,8 @@ namespace cublog
     for (const auto &sysop_info : m_sysops)
       {
 	size += serializator.get_packed_int_size (start_offset + size);
-	size += lsa_utils::get_packed_size (serializator, start_offset, size);
-	size += lsa_utils::get_packed_size (serializator, start_offset, size);
+	size += lsa_utils::get_packed_size (serializator, start_offset + size);
+	size += lsa_utils::get_packed_size (serializator, start_offset + size);
       }
 
     size += serializator.get_packed_bool_size (start_offset + size);

--- a/src/transaction/log_lsa_utils.cpp
+++ b/src/transaction/log_lsa_utils.cpp
@@ -40,8 +40,8 @@ namespace cublog::lsa_utils
   }
 
   std::size_t
-  get_packed_size (cubpacking::packer &serializator, std::size_t start_offset, std::size_t size)
+  get_packed_size (cubpacking::packer &serializator, std::size_t start_offset)
   {
-    return serializator.get_packed_bigint_size (start_offset + size);
+    return serializator.get_packed_bigint_size (start_offset);
   }
 }

--- a/src/transaction/log_lsa_utils.cpp
+++ b/src/transaction/log_lsa_utils.cpp
@@ -39,7 +39,7 @@ namespace cublog::lsa_utils
     lsa = big_int;
   }
 
-  std::size_t
+  size_t
   get_packed_size (cubpacking::packer &serializator, std::size_t start_offset)
   {
     return serializator.get_packed_bigint_size (start_offset);

--- a/src/transaction/log_lsa_utils.cpp
+++ b/src/transaction/log_lsa_utils.cpp
@@ -38,4 +38,10 @@ namespace cublog::lsa_utils
     deserializer.unpack_bigint (big_int);
     lsa = big_int;
   }
+
+  std::size_t
+  get_packed_size (cubpacking::packer &serializator, std::size_t start_offset, std::size_t size)
+  {
+    return serializator.get_packed_bigint_size (start_offset + size);
+  }
 }

--- a/src/transaction/log_lsa_utils.hpp
+++ b/src/transaction/log_lsa_utils.hpp
@@ -32,7 +32,7 @@ namespace cublog::lsa_utils
 {
   void pack (const log_lsa &lsa, cubpacking::packer &serializer);
   void unpack (cubpacking::unpacker &deserializer, log_lsa &lsa);
-  std::size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset, std::size_t size_arg);
+  std::size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset);
 }
 
 #endif // _LOG_LSA_UTILS_HPP_

--- a/src/transaction/log_lsa_utils.hpp
+++ b/src/transaction/log_lsa_utils.hpp
@@ -20,7 +20,7 @@
 #define _LOG_LSA_UTILS_HPP_
 
 #include <cstdint>
-#include <cstdlib>
+#include <cstdio>
 
 struct log_lsa;
 namespace cubpacking

--- a/src/transaction/log_lsa_utils.hpp
+++ b/src/transaction/log_lsa_utils.hpp
@@ -20,6 +20,7 @@
 #define _LOG_LSA_UTILS_HPP_
 
 #include <cstdint>
+#include <cstdlib>
 
 struct log_lsa;
 namespace cubpacking
@@ -32,7 +33,7 @@ namespace cublog::lsa_utils
 {
   void pack (const log_lsa &lsa, cubpacking::packer &serializer);
   void unpack (cubpacking::unpacker &deserializer, log_lsa &lsa);
-  std::size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset);
+  size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset);
 }
 
 #endif // _LOG_LSA_UTILS_HPP_

--- a/src/transaction/log_lsa_utils.hpp
+++ b/src/transaction/log_lsa_utils.hpp
@@ -32,6 +32,7 @@ namespace cublog::lsa_utils
 {
   void pack (const log_lsa &lsa, cubpacking::packer &serializer);
   void unpack (cubpacking::unpacker &deserializer, log_lsa &lsa);
+  std::size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset, std::size_t size_arg);
 }
 
 #endif // _LOG_LSA_UTILS_HPP_

--- a/unit_tests/log/CMakeLists.txt
+++ b/unit_tests/log/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEST_CHKPT_INFO_SOURCES
   test_main_chkpt_info.cpp
   ${TEST_FAKE_DIR}/fake_thread_entry.cpp
   ${TRANSACTION_DIR}/client_credentials.cpp
+  ${TRANSACTION_DIR}/log_lsa_utils.cpp
   ${BASE_DIR}/packer.cpp
   )
 SET_SOURCE_FILES_PROPERTIES(

--- a/unit_tests/log/test_main_chkpt_info.cpp
+++ b/unit_tests/log/test_main_chkpt_info.cpp
@@ -961,26 +961,6 @@ mvcc_snapshot::mvcc_snapshot ()
 {
 }
 
-void
-lsa_utils::pack (const log_lsa &lsa, cubpacking::packer &serializer)
-{
-  serializer.pack_bigint (static_cast<int64_t> (lsa));
-}
-
-void
-lsa_utils::unpack (cubpacking::unpacker &deserializer, log_lsa &lsa)
-{
-  uint64_t big_int = 0;
-  deserializer.unpack_bigint (big_int);
-  lsa = big_int;
-}
-
-std::size_t
-lsa_utils::get_packed_size (cubpacking::packer &serializator, std::size_t start_offset, std::size_t size)
-{
-  return serializator.get_packed_bigint_size (start_offset + size);
-}
-
 int
 basename_r (const char *path, char *pathbuf, size_t buflen)
 {

--- a/unit_tests/log/test_main_chkpt_info.cpp
+++ b/unit_tests/log/test_main_chkpt_info.cpp
@@ -28,6 +28,7 @@
 #include "fake_packable_object.hpp"
 #include "log_impl.h"
 #include "log_lsa.hpp"
+#include "log_lsa_utils.hpp"
 #include "log_record.hpp"
 #include "log_system_tran.hpp"
 #include "mem_block.hpp"
@@ -958,6 +959,26 @@ mvcc_snapshot::mvcc_snapshot ()
   , snapshot_fnc (NULL)
   , valid (false)
 {
+}
+
+void
+lsa_utils::pack (const log_lsa &lsa, cubpacking::packer &serializer)
+{
+  serializer.pack_bigint (static_cast<int64_t> (lsa));
+}
+
+void
+lsa_utils::unpack (cubpacking::unpacker &deserializer, log_lsa &lsa)
+{
+  uint64_t big_int = 0;
+  deserializer.unpack_bigint (big_int);
+  lsa = big_int;
+}
+
+std::size_t
+lsa_utils::get_packed_size (cubpacking::packer &serializator, std::size_t start_offset, std::size_t size)
+{
+  return serializator.get_packed_bigint_size (start_offset + size);
 }
 
 int


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-102

Changed the pack/unpack functions in the checkpoint_information class to use the newly added log_lsa serialization functions instead fo the local ones. 

Also added a get_pack_size function for log_lsa.
