### PR TITLE
[CBRD-23978] execute command returns error in prepared statement includes DECODE

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5444,8 +5444,8 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 	{
 	  PT_NODE *temp = NULL;
 	  int precision = 0, scale = 0;
-	  int units = LANG_SYS_CODESET; /* code set */
-	  int collation_id = LANG_SYS_COLLATION; /* collation_id */
+	  int units = LANG_SYS_CODESET;	/* code set */
+	  int collation_id = LANG_SYS_COLLATION;	/* collation_id */
 	  bool keep_searching = true;
 	  for (temp = arg2->data_type; temp != NULL && keep_searching; temp = temp->next)
 	    {
@@ -10167,9 +10167,10 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	  node->type_enum = PT_TYPE_NONE;
 	  break;
 	}
-      if (common_type == PT_TYPE_MAYBE)
+
+      if (common_type == PT_TYPE_MAYBE && arg1_type != PT_TYPE_NULL && arg2_type != PT_TYPE_NULL)
 	{
-	  common_type = (arg1_type == PT_TYPE_MAYBE && arg2_type != PT_TYPE_NULL) ? arg2_type : arg1_type;
+	  common_type = (arg1_type == PT_TYPE_MAYBE) ? arg2_type : arg1_type;
 	}
 
       if (common_type == PT_TYPE_MAYBE || common_type == PT_TYPE_NULL)

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -10172,7 +10172,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	  common_type = (arg1_type == PT_TYPE_MAYBE && arg2_type != PT_TYPE_NULL) ? arg2_type : arg1_type;
 	}
 
-      if (common_type == PT_TYPE_MAYBE)
+      if (common_type == PT_TYPE_MAYBE || common_type == PT_TYPE_NULL)
 	{
 	  /* both args are MAYBE, default to VARCHAR */
 	  common_type = PT_TYPE_VARCHAR;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -10173,7 +10173,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	  common_type = (arg1_type == PT_TYPE_MAYBE) ? arg2_type : arg1_type;
 	}
 
-      if (common_type == PT_TYPE_MAYBE || common_type == PT_TYPE_NULL)
+      if (common_type == PT_TYPE_MAYBE)
 	{
 	  /* both args are MAYBE, default to VARCHAR */
 	  common_type = PT_TYPE_VARCHAR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23978

The csql result is different from execution by prepared statement and direct execution.
In case of the same result expected, execution by prepared statement raise error but the direct execution runs successfully.
It fails only if the prepared statement has DECODE function with host variable as follows:
```
PREPARE pst FROM 'SELECT DECODE(?,'''',NULL,?)';
EXECUTE pst using '1', '1'; 

ERROR: Cannot coerce value of domain "character" to domain "*NULL*".
```
but the following statement runs successfully.
```
SELECT DECODE('1', '', NULL, '1');

decode('1', '', null, '1')
======================
'1' 
```
