### PR TITLE
[CBRD-23973] Improvements to the keyword_offset() function in csql_grammar.y

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -151,168 +151,6 @@ extern int yybuffer_pos;
 
 #define STACK_SIZE	128
 
-typedef struct function_map FUNCTION_MAP;
-struct function_map
-{
-  const char *keyword;
-  int op;
-};
-
-
-static FUNCTION_MAP functions[] = {
-  {"abs", PT_ABS},
-  {"acos", PT_ACOS},
-  {"addtime", PT_ADDTIME},
-  {"asin", PT_ASIN},
-  {"atan", PT_ATAN},
-  {"atan2", PT_ATAN2},
-  {"bin", PT_BIN},
-  {"bit_count", PT_BIT_COUNT},
-  {"bit_to_blob", PT_BIT_TO_BLOB},
-  {"blob_from_file", PT_BLOB_FROM_FILE},
-  {"blob_length", PT_BLOB_LENGTH},
-  {"blob_to_bit", PT_BLOB_TO_BIT},
-  {"ceil", PT_CEIL},
-  {"ceiling", PT_CEIL},
-  {"char_length", PT_CHAR_LENGTH},
-  {"char_to_blob", PT_CHAR_TO_BLOB},
-  {"char_to_clob", PT_CHAR_TO_CLOB},
-  {"character_length", PT_CHAR_LENGTH},
-  {"clob_from_file", PT_CLOB_FROM_FILE},
-  {"clob_length", PT_CLOB_LENGTH},
-  {"concat", PT_CONCAT},
-  {"concat_ws", PT_CONCAT_WS},
-  {"cos", PT_COS},
-  {"cot", PT_COT},
-  {"cume_dist", PT_CUME_DIST},
-  {"curtime", PT_CURRENT_TIME},
-  {"curdate", PT_CURRENT_DATE},
-  {"utc_time", PT_UTC_TIME},
-  {"utc_date", PT_UTC_DATE},
-  {"datediff", PT_DATEDIFF},
-  {"timediff",PT_TIMEDIFF},
-  {"date_format", PT_DATE_FORMAT},
-  {"dayofmonth", PT_DAYOFMONTH},
-  {"dayofyear", PT_DAYOFYEAR},
-  {"decode", PT_DECODE},
-  {"decr", PT_DECR},
-  {"degrees", PT_DEGREES},
-  {"drand", PT_DRAND},
-  {"drandom", PT_DRANDOM},
-  {"exec_stats", PT_EXEC_STATS},
-  {"exp", PT_EXP},
-  {"field", PT_FIELD},
-  {"floor", PT_FLOOR},
-  {"from_days", PT_FROMDAYS},
-  {"greatest", PT_GREATEST},
-  {"groupby_num", PT_GROUPBY_NUM},
-  {"incr", PT_INCR},
-  {"index_cardinality", PT_INDEX_CARDINALITY},
-  {"inst_num", PT_INST_NUM},
-  {"instr", PT_INSTR},
-  {"instrb", PT_INSTR},
-  {"last_day", PT_LAST_DAY},
-  {"length", PT_CHAR_LENGTH},
-  {"lengthb", PT_CHAR_LENGTH},
-  {"least", PT_LEAST},
-  {"like_match_lower_bound", PT_LIKE_LOWER_BOUND},
-  {"like_match_upper_bound", PT_LIKE_UPPER_BOUND},
-  {"list_dbs", PT_LIST_DBS},
-  {"locate", PT_LOCATE},
-  {"ln", PT_LN},
-  {"log2", PT_LOG2},
-  {"log10", PT_LOG10},
-  {"log", PT_LOG},
-  {"lpad", PT_LPAD},
-  {"ltrim", PT_LTRIM},
-  {"makedate", PT_MAKEDATE},
-  {"maketime", PT_MAKETIME},
-  {"mid", PT_MID},
-  {"months_between", PT_MONTHS_BETWEEN},
-  {"new_time", PT_NEW_TIME},
-  {"format", PT_FORMAT},
-  {"now", PT_CURRENT_DATETIME},
-  {"nvl", PT_NVL},
-  {"nvl2", PT_NVL2},
-  {"orderby_num", PT_ORDERBY_NUM},
-  {"percent_rank", PT_PERCENT_RANK},
-  {"power", PT_POWER},
-  {"pow", PT_POWER},
-  {"pi", PT_PI},
-  {"radians", PT_RADIANS},
-  {"rand", PT_RAND},
-  {"random", PT_RANDOM},
-  {"repeat", PT_REPEAT},
-  {"space", PT_SPACE},
-  {"reverse", PT_REVERSE},
-  {"disk_size", PT_DISK_SIZE},
-  {"round", PT_ROUND},
-  {"row_count", PT_ROW_COUNT},
-  {"last_insert_id", PT_LAST_INSERT_ID},
-  {"rpad", PT_RPAD},
-  {"rtrim", PT_RTRIM},
-  {"sec_to_time", PT_SECTOTIME},
-  {"serial_current_value", PT_CURRENT_VALUE},
-  {"serial_next_value", PT_NEXT_VALUE},
-  {"sign", PT_SIGN},
-  {"sin", PT_SIN},
-  {"sqrt", PT_SQRT},
-  {"strcmp", PT_STRCMP},
-  {"substr", PT_SUBSTRING},
-  {"substring_index", PT_SUBSTRING_INDEX},
-  {"find_in_set", PT_FINDINSET},
-  {"md5", PT_MD5},
-/*
- * temporarily block aes_encrypt and aes_decrypt functions until binary string charset is available.
- *
- *  {"aes_encrypt", PT_AES_ENCRYPT},
- *  {"aes_decrypt", PT_AES_DECRYPT},
- */
-  {"sha1", PT_SHA_ONE},
-  {"sha2", PT_SHA_TWO},
-  {"substrb", PT_SUBSTRING},
-  {"tan", PT_TAN},
-  {"time_format", PT_TIME_FORMAT},
-  {"to_char", PT_TO_CHAR},
-  {"to_date", PT_TO_DATE},
-  {"to_datetime", PT_TO_DATETIME},
-  {"to_days", PT_TODAYS},
-  {"time_to_sec", PT_TIMETOSEC},
-  {"to_number", PT_TO_NUMBER},
-  {"to_time", PT_TO_TIME},
-  {"to_timestamp", PT_TO_TIMESTAMP},
-  {"trunc", PT_TRUNC},
-  {"tz_offset", PT_TZ_OFFSET},
-  {"unix_timestamp", PT_UNIX_TIMESTAMP},
-  {"typeof", PT_TYPEOF},
-  {"from_unixtime", PT_FROM_UNIXTIME},
-  {"from_tz", PT_FROM_TZ},
-  {"weekday", PT_WEEKDAY},
-  {"dayofweek", PT_DAYOFWEEK},
-  {"version", PT_VERSION},
-  {"quarter", PT_QUARTERF},
-  {"week", PT_WEEKF},
-  {"hex", PT_HEX},
-  {"ascii", PT_ASCII},
-  {"conv", PT_CONV},
-  {"inet_aton", PT_INET_ATON},
-  {"inet_ntoa", PT_INET_NTOA},
-  {"coercibility", PT_COERCIBILITY},
-  {"width_bucket", PT_WIDTH_BUCKET},
-  {"trace_stats", PT_TRACE_STATS},
-  {"str_to_date", PT_STR_TO_DATE},
-  {"to_base64", PT_TO_BASE64},
-  {"from_base64", PT_FROM_BASE64},
-  {"sys_guid", PT_SYS_GUID},
-  {"sleep", PT_SLEEP},
-  {"to_datetime_tz", PT_TO_DATETIME_TZ},
-  {"to_timestamp_tz", PT_TO_TIMESTAMP_TZ},
-  {"utc_timestamp", PT_UTC_TIMESTAMP},
-  {"crc32", PT_CRC32},
-  {"schema_def", PT_SCHEMA_DEF},
-  {"conv_tz", PT_CONV_TZ},
-};
-
 
 static int parser_groupby_exception = 0;
 
@@ -422,7 +260,6 @@ typedef enum
   SERIAL_CACHE,
 } SERIAL_DEFINE;
 
-FUNCTION_MAP *keyword_offset (const char *name);
 
 static PT_NODE *parser_make_expr_with_func (PARSER_CONTEXT * parser, FUNC_TYPE func_code, PT_NODE * args_list);
 static PT_NODE *parser_make_func_with_arg_count (PARSER_CONTEXT * parser, FUNC_TYPE func_code, PT_NODE * args_list,
@@ -26065,52 +25902,6 @@ PT_HINT parser_hint_table[] = {
 
 
 
-static int
-function_keyword_cmp (const void *f1, const void *f2)
-{
-  return strcasecmp (((FUNCTION_MAP *) f1)->keyword,
-		     ((FUNCTION_MAP *) f2)->keyword);
-}
-
-
-
-FUNCTION_MAP *
-keyword_offset (const char *text)
-{
-  static bool function_keyword_sorted = false;
-  FUNCTION_MAP dummy;
-  FUNCTION_MAP *result_key;
-
-  if (function_keyword_sorted == false)
-    {
-      qsort (functions,
-	     (sizeof (functions) / sizeof (functions[0])),
-	     sizeof (functions[0]), function_keyword_cmp);
-
-      function_keyword_sorted = true;
-    }
-
-  if (!text)
-    {
-      return NULL;
-    }
-
-  if (strlen (text) >= MAX_KEYWORD_SIZE)
-    {
-      return NULL;
-    }
-
-  dummy.keyword = text;
-
-  result_key =
-    (FUNCTION_MAP *) bsearch (&dummy, functions,
-			      (sizeof (functions) / sizeof (functions[0])),
-			      sizeof (FUNCTION_MAP), function_keyword_cmp);
-
-  return result_key;
-}
-
-
 PT_NODE *
 parser_keyword_func (const char *name, PT_NODE * args)
 {
@@ -26124,7 +25915,7 @@ parser_keyword_func (const char *name, PT_NODE * args)
 
   parser_function_code = PT_EMPTY;
   c = parser_count_list (args);
-  key = keyword_offset (name);
+  key = pt_find_function_name (name);
   if (key == NULL)
     return NULL;
 

--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -38,6 +38,7 @@
  * will be sorted when needed. See pt_find_keyword.
  */
 
+/* Keyword names must be written in uppercase */
 static KEYWORD_RECORD keywords[] = {
   {ABSOLUTE_, "ABSOLUTE", 0},
   {ACCESS, "ACCESS", 1},
@@ -526,6 +527,161 @@ static KEYWORD_RECORD keywords[] = {
 static KEYWORD_RECORD *pt_find_keyword (const char *text);
 static int keyword_cmp (const void *k1, const void *k2);
 
+/* Function names must be written in lowercase */
+static FUNCTION_MAP functions[] = {
+  {0, "abs", PT_ABS},
+  {0, "acos", PT_ACOS},
+  {0, "addtime", PT_ADDTIME},
+  {0, "asin", PT_ASIN},
+  {0, "atan", PT_ATAN},
+  {0, "atan2", PT_ATAN2},
+  {0, "bin", PT_BIN},
+  {0, "bit_count", PT_BIT_COUNT},
+  {0, "bit_to_blob", PT_BIT_TO_BLOB},
+  {0, "blob_from_file", PT_BLOB_FROM_FILE},
+  {0, "blob_length", PT_BLOB_LENGTH},
+  {0, "blob_to_bit", PT_BLOB_TO_BIT},
+  {0, "ceil", PT_CEIL},
+  {0, "ceiling", PT_CEIL},
+  {0, "char_length", PT_CHAR_LENGTH},
+  {0, "char_to_blob", PT_CHAR_TO_BLOB},
+  {0, "char_to_clob", PT_CHAR_TO_CLOB},
+  {0, "character_length", PT_CHAR_LENGTH},
+  {0, "clob_from_file", PT_CLOB_FROM_FILE},
+  {0, "clob_length", PT_CLOB_LENGTH},
+  {0, "concat", PT_CONCAT},
+  {0, "concat_ws", PT_CONCAT_WS},
+  {0, "cos", PT_COS},
+  {0, "cot", PT_COT},
+  {0, "cume_dist", PT_CUME_DIST},
+  {0, "curtime", PT_CURRENT_TIME},
+  {0, "curdate", PT_CURRENT_DATE},
+  {0, "utc_time", PT_UTC_TIME},
+  {0, "utc_date", PT_UTC_DATE},
+  {0, "datediff", PT_DATEDIFF},
+  {0, "timediff", PT_TIMEDIFF},
+  {0, "date_format", PT_DATE_FORMAT},
+  {0, "dayofmonth", PT_DAYOFMONTH},
+  {0, "dayofyear", PT_DAYOFYEAR},
+  {0, "decode", PT_DECODE},
+  {0, "decr", PT_DECR},
+  {0, "degrees", PT_DEGREES},
+  {0, "drand", PT_DRAND},
+  {0, "drandom", PT_DRANDOM},
+  {0, "exec_stats", PT_EXEC_STATS},
+  {0, "exp", PT_EXP},
+  {0, "field", PT_FIELD},
+  {0, "floor", PT_FLOOR},
+  {0, "from_days", PT_FROMDAYS},
+  {0, "greatest", PT_GREATEST},
+  {0, "groupby_num", PT_GROUPBY_NUM},
+  {0, "incr", PT_INCR},
+  {0, "index_cardinality", PT_INDEX_CARDINALITY},
+  {0, "inst_num", PT_INST_NUM},
+  {0, "instr", PT_INSTR},
+  {0, "instrb", PT_INSTR},
+  {0, "last_day", PT_LAST_DAY},
+  {0, "length", PT_CHAR_LENGTH},
+  {0, "lengthb", PT_CHAR_LENGTH},
+  {0, "least", PT_LEAST},
+  {0, "like_match_lower_bound", PT_LIKE_LOWER_BOUND},
+  {0, "like_match_upper_bound", PT_LIKE_UPPER_BOUND},
+  {0, "list_dbs", PT_LIST_DBS},
+  {0, "locate", PT_LOCATE},
+  {0, "ln", PT_LN},
+  {0, "log2", PT_LOG2},
+  {0, "log10", PT_LOG10},
+  {0, "log", PT_LOG},
+  {0, "lpad", PT_LPAD},
+  {0, "ltrim", PT_LTRIM},
+  {0, "makedate", PT_MAKEDATE},
+  {0, "maketime", PT_MAKETIME},
+  {0, "mid", PT_MID},
+  {0, "months_between", PT_MONTHS_BETWEEN},
+  {0, "new_time", PT_NEW_TIME},
+  {0, "format", PT_FORMAT},
+  {0, "now", PT_CURRENT_DATETIME},
+  {0, "nvl", PT_NVL},
+  {0, "nvl2", PT_NVL2},
+  {0, "orderby_num", PT_ORDERBY_NUM},
+  {0, "percent_rank", PT_PERCENT_RANK},
+  {0, "power", PT_POWER},
+  {0, "pow", PT_POWER},
+  {0, "pi", PT_PI},
+  {0, "radians", PT_RADIANS},
+  {0, "rand", PT_RAND},
+  {0, "random", PT_RANDOM},
+  {0, "repeat", PT_REPEAT},
+  {0, "space", PT_SPACE},
+  {0, "reverse", PT_REVERSE},
+  {0, "disk_size", PT_DISK_SIZE},
+  {0, "round", PT_ROUND},
+  {0, "row_count", PT_ROW_COUNT},
+  {0, "last_insert_id", PT_LAST_INSERT_ID},
+  {0, "rpad", PT_RPAD},
+  {0, "rtrim", PT_RTRIM},
+  {0, "sec_to_time", PT_SECTOTIME},
+  {0, "serial_current_value", PT_CURRENT_VALUE},
+  {0, "serial_next_value", PT_NEXT_VALUE},
+  {0, "sign", PT_SIGN},
+  {0, "sin", PT_SIN},
+  {0, "sqrt", PT_SQRT},
+  {0, "strcmp", PT_STRCMP},
+  {0, "substr", PT_SUBSTRING},
+  {0, "substring_index", PT_SUBSTRING_INDEX},
+  {0, "find_in_set", PT_FINDINSET},
+  {0, "md5", PT_MD5},
+/*
+ * temporarily block aes_encrypt and aes_decrypt functions until binary string charset is available.
+ *
+ *  {0, "aes_encrypt", PT_AES_ENCRYPT},
+ *  {0, "aes_decrypt", PT_AES_DECRYPT},
+ */
+  {0, "sha1", PT_SHA_ONE},
+  {0, "sha2", PT_SHA_TWO},
+  {0, "substrb", PT_SUBSTRING},
+  {0, "tan", PT_TAN},
+  {0, "time_format", PT_TIME_FORMAT},
+  {0, "to_char", PT_TO_CHAR},
+  {0, "to_date", PT_TO_DATE},
+  {0, "to_datetime", PT_TO_DATETIME},
+  {0, "to_days", PT_TODAYS},
+  {0, "time_to_sec", PT_TIMETOSEC},
+  {0, "to_number", PT_TO_NUMBER},
+  {0, "to_time", PT_TO_TIME},
+  {0, "to_timestamp", PT_TO_TIMESTAMP},
+  {0, "trunc", PT_TRUNC},
+  {0, "tz_offset", PT_TZ_OFFSET},
+  {0, "unix_timestamp", PT_UNIX_TIMESTAMP},
+  {0, "typeof", PT_TYPEOF},
+  {0, "from_unixtime", PT_FROM_UNIXTIME},
+  {0, "from_tz", PT_FROM_TZ},
+  {0, "weekday", PT_WEEKDAY},
+  {0, "dayofweek", PT_DAYOFWEEK},
+  {0, "version", PT_VERSION},
+  {0, "quarter", PT_QUARTERF},
+  {0, "week", PT_WEEKF},
+  {0, "hex", PT_HEX},
+  {0, "ascii", PT_ASCII},
+  {0, "conv", PT_CONV},
+  {0, "inet_aton", PT_INET_ATON},
+  {0, "inet_ntoa", PT_INET_NTOA},
+  {0, "coercibility", PT_COERCIBILITY},
+  {0, "width_bucket", PT_WIDTH_BUCKET},
+  {0, "trace_stats", PT_TRACE_STATS},
+  {0, "str_to_date", PT_STR_TO_DATE},
+  {0, "to_base64", PT_TO_BASE64},
+  {0, "from_base64", PT_FROM_BASE64},
+  {0, "sys_guid", PT_SYS_GUID},
+  {0, "sleep", PT_SLEEP},
+  {0, "to_datetime_tz", PT_TO_DATETIME_TZ},
+  {0, "to_timestamp_tz", PT_TO_TIMESTAMP_TZ},
+  {0, "utc_timestamp", PT_UTC_TIMESTAMP},
+  {0, "crc32", PT_CRC32},
+  {0, "schema_def", PT_SCHEMA_DEF},
+  {0, "conv_tz", PT_CONV_TZ},
+};
+
 
 /* The GET_KEYWORD_HASH_VALUE() macro is the definition of the djb2 algorithm as a macro.
  * Refer to the string_hash() function implemented in the libcubmemc.c file.
@@ -538,6 +694,8 @@ static int keyword_cmp (const void *k1, const void *k2);
              (h) = (((h) << 5) + (h)) + *p; /* hash * 33 + c */ \
         } \
   } while(0)
+
+#define MAGIC_NUM_BI_SEQ        (5)	/* Performance intersection between binary and sequential search */
 
 static int
 keyword_cmp (const void *k1, const void *k2)
@@ -565,7 +723,6 @@ pt_find_keyword (const char *text)
   static int keyword_max_len = 0;
   static int keyword_cnt = sizeof (keywords) / sizeof (keywords[0]);
   static short start_pos[257];	// (0x00 ~ 0xFF) + 1  
-#define MAGIC_NUM_BI_SEQ        (5)	/* Performance intersection between binary and sequential search */
   int i, len, cmp;
   KEYWORD_RECORD dummy;
 
@@ -759,4 +916,130 @@ pt_get_keyword_rec (int *rec_count)
   *(rec_count) = sizeof (keywords) / sizeof (keywords[0]);
 
   return (KEYWORD_RECORD *) (keywords);
+}
+
+
+
+static int
+function_keyword_cmp (const void *f1, const void *f2)
+{
+  int cmp = ((FUNCTION_MAP *) f1)->hash_value - ((FUNCTION_MAP *) f2)->hash_value;
+
+  if (cmp != 0)
+    {
+      return cmp;
+    }
+
+  return strcmp (((FUNCTION_MAP *) f1)->keyword, ((FUNCTION_MAP *) f2)->keyword);
+}
+
+
+
+FUNCTION_MAP *
+pt_find_function_name (const char *text)
+{
+  static bool function_keyword_sorted = false;
+  static int function_min_len = MAX_KEYWORD_SIZE;
+  static int function_max_len = 0;
+  static int functions_cnt = sizeof (functions) / sizeof (functions[0]);
+  static short function_start_pos[257];	// (0x00 ~ 0xFF) + 1  
+  int i, len, cmp;
+  FUNCTION_MAP dummy;
+
+  if (function_keyword_sorted == false)
+    {
+      for (i = 0; i < functions_cnt; i++)
+	{
+	  len = strlen (functions[i].keyword);
+	  if (len < function_min_len)
+	    {
+	      function_min_len = len;
+	    }
+	  if (len > function_max_len)
+	    {
+	      function_max_len = len;
+	    }
+
+	  GET_KEYWORD_HASH_VALUE (functions[i].hash_value, functions[i].keyword);
+	}
+
+      memset (function_start_pos, 0x00, sizeof (function_start_pos));
+
+      qsort (functions, functions_cnt, sizeof (functions[0]), function_keyword_cmp);
+
+      for (i = 0; i < functions_cnt; i++)
+	{
+	  function_start_pos[((functions[i].hash_value) >> 8)]++;
+	}
+
+      function_start_pos[256] = functions_cnt;
+      for (i = 255; i >= 0; i--)
+	{
+	  function_start_pos[i] = function_start_pos[i + 1] - function_start_pos[i];
+	}
+
+      function_keyword_sorted = true;
+    }
+
+  if (!text)
+    {
+      return NULL;
+    }
+
+  len = strlen (text);
+  if (len < function_min_len || len > function_max_len)
+    {
+      return NULL;
+    }
+
+  /* function name are composed of ASCII characters.  */
+  char temp[MAX_KEYWORD_SIZE];
+  unsigned char *p, *s;
+  s = (unsigned char *) temp;
+  for (p = (unsigned char *) text; *p; p++, s++)
+    {
+      if (*p >= 0x80)
+	{
+	  return NULL;
+	}
+
+      *s = (unsigned char) char_tolower ((int) *p);
+    }
+  *s = 0x00;
+  dummy.keyword = temp;
+
+  GET_KEYWORD_HASH_VALUE (dummy.hash_value, dummy.keyword);
+  i = (dummy.hash_value >> 8);
+  len = (function_start_pos[i + 1] - function_start_pos[i]);
+  if (len <= MAGIC_NUM_BI_SEQ)
+    {
+      for (len = function_start_pos[i]; len < function_start_pos[i + 1]; len++)
+	{
+	  if (dummy.hash_value > functions[len].hash_value)
+	    {
+	      continue;
+	    }
+	  else if (dummy.hash_value < functions[len].hash_value)
+	    {
+	      return NULL;
+	    }
+
+	  cmp = strcmp (dummy.keyword, functions[len].keyword);
+	  if (cmp > 0)
+	    {
+	      continue;
+	    }
+	  else if (cmp < 0)
+	    {
+	      return NULL;
+	    }
+
+	  return functions + len;
+	}
+
+      return NULL;
+    }
+
+  return (FUNCTION_MAP *) bsearch (&dummy, functions + function_start_pos[i], len, sizeof (FUNCTION_MAP),
+				   function_keyword_cmp);
 }

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3521,6 +3521,15 @@ struct keyword_record
 				 * an identifier, nonzero means it can be */
 };
 
+
+typedef struct function_map FUNCTION_MAP;
+struct function_map
+{
+  unsigned short hash_value;
+  const char *keyword;
+  int op;
+};
+
 typedef struct pt_plan_trace_info
 {
   QUERY_TRACE_FORMAT format;

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -187,6 +187,8 @@ extern "C"
   extern bool pt_is_keyword (const char *s);
   extern bool pt_is_const_expr_node (PT_NODE * node);
 
+  extern FUNCTION_MAP *pt_find_function_name (const char *name);
+
   extern PT_NODE *pt_add_row_oid (PARSER_CONTEXT * parser, PT_NODE * stmt);
   extern PT_NODE *pt_add_row_oid_name (PARSER_CONTEXT * parser, PT_NODE * stmt);
   extern PT_NODE *pt_add_column_oid (PARSER_CONTEXT * parser, PT_NODE * stmt);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -291,8 +291,8 @@ extern "C"
 
 #if defined(ENABLE_UNUSED_FUNCTION)
   extern int pt_identifier_or_keyword (const char *text);
-#endif				/* ENABLE_UNUSED_FUNCTION */
   extern KEYWORD_RECORD *pt_get_keyword_rec (int *rec_count);
+#endif				/* ENABLE_UNUSED_FUNCTION */
   extern int pt_type_generic_func (PARSER_CONTEXT * parser, PT_NODE * node);
 #if defined(ENABLE_UNUSED_FUNCTION)
   extern void pt_string_to_data_type (PARSER_CONTEXT * parser, const char *s, PT_NODE * node);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23973

Purpose
   Since the configuration of the function or source is consistent with what was covered in the "CBRD-23955 Speed improvement of pt_find_keyword() function" issue, it can be improved in the same way.

Implementation
  Rename keyword_offset() to pt_find_function_name().
 The function name list table and functions for searching for this table are moved to the keyword.c file.
 Change the lookup method in the same way as the pt_find_keyword() function.

Remarks
  N/A