### PR TITLE
[LETS-108] disallow checkpoint on a transaction server with remote storage enabled

### DIFF
--- a/src/base/server_type.hpp
+++ b/src/base/server_type.hpp
@@ -29,4 +29,6 @@ int init_server_type (const char *db_name);
 void finalize_server_type ();
 SERVER_TYPE get_server_type ();
 
+bool is_tran_server_with_remote_storage ();
+
 #endif

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -83,6 +83,7 @@
 #include "xasl_cache.h"
 #include "elo.h"
 #include "transaction_transient.hpp"
+#include "server_type.hpp"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
@@ -1822,7 +1823,14 @@ slog_checkpoint (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int r
 
   log_wakeup_checkpoint_daemon ();
 
-  /* just send back a dummy message */
+  if (is_tran_server_with_remote_storage ())
+    {
+      error = ER_TOOL_INVALID_WITH_REMOTE_STORAGE;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TOOL_INVALID_WITH_REMOTE_STORAGE, 1, "'checkpoint'");
+      return_error_to_client (thread_p, rid);
+    }
+
+  /* proper error code is expected as a response */
   (void) or_pack_errcode (reply, error);
   css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
 }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9645,7 +9645,7 @@ log_wakeup_remove_log_archive_daemon ()
 void
 log_wakeup_checkpoint_daemon ()
 {
-  if (log_Checkpoint_daemon)
+  if (log_Checkpoint_daemon != nullptr)
     {
       log_Checkpoint_daemon->wakeup ();
     }
@@ -9975,11 +9975,14 @@ log_checkpoint_daemon_init ()
 {
   assert (log_Checkpoint_daemon == NULL);
 
-  cubthread::looper looper = cubthread::looper (log_get_checkpoint_interval);
-  cubthread::entry_callable_task * daemon_task = new cubthread::entry_callable_task (log_checkpoint_execute);
+  if (!is_tran_server_with_remote_storage ())
+    {
+      cubthread::looper looper = cubthread::looper (log_get_checkpoint_interval);
+      cubthread::entry_callable_task * daemon_task = new cubthread::entry_callable_task (log_checkpoint_execute);
 
-  // create checkpoint daemon thread
-  log_Checkpoint_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log_checkpoint");
+      // create checkpoint daemon thread
+      log_Checkpoint_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log_checkpoint");
+    }
 }
 #endif /* SERVER_MODE */
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6708,6 +6708,12 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
   int flushed_page_cnt = 0, vdes;
   bool detailed_logging = prm_get_bool_value (PRM_ID_LOG_CHKPT_DETAILED);
 
+  if (is_tran_server_with_remote_storage ())
+    {
+      er_log_debug (ARG_FILE_LINE, "checkpoints are disallowed on transaction server with remote storage\n");
+      return NULL_PAGEID;
+    }
+
   LOG_CS_ENTER (thread_p);
 
 #if defined(SERVER_MODE)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-108

**Description**
Checkpoint flushes all data pages from page buffer to disk. On a transaction server without local storage, checkpoint loses relevance.
Do not run checkpoints on the transaction server without local storage.

**Implementation**
- disable log checkpoint daemon
- early-out in logpb_checkpoint
- add an error to slog_checkpoint (reused existing generic error message)

**Tests**
- manual tests with csql and `remote_storage` setting enabled


