### PR TITLE
[LETS-112] Remove disk dependency of vacuum dump

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1132,10 +1132,18 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
 	{
 	  LOG_CS_ENTER_READ_MODE (thread_p);
 	  archive_number = logpb_get_archive_number (thread_p, min_log_pageid);
-	  if (archive_number >= 0)
+	  if (archive_number < 0)
 	    {
-	      fprintf (outfp, "(in %s%s%03d)", log_Prefix, FILEIO_SUFFIX_LOGARCHIVE, archive_number);
+	      /* this is an assertion case but ignore. */
 	    }
+	  else
+	    {
+	      fprintf (outfp, "(in %s%s%03d)\n", log_Prefix, FILEIO_SUFFIX_LOGARCHIVE, archive_number);
+	    }
+//        if (archive_number >= 0)
+//          {
+//            fprintf (outfp, "(in %s%s%03d)", log_Prefix, FILEIO_SUFFIX_LOGARCHIVE, archive_number);
+//          }
 	  LOG_CS_EXIT (thread_p);
 	}
       else

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -40,7 +40,6 @@
 #include "overflow_file.h"
 #include "page_buffer.h"
 #include "perf_monitor.h"
-#include "porting.h"
 #include "resource_shared_pool.hpp"
 #include "server_type.hpp"
 #include "thread_entry_task.hpp"
@@ -1126,7 +1125,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
 
   fprintf (outfp, "\n");
   fprintf (outfp, "*** Vacuum Dump ***\n");
-  fprintf (outfp, "First log page ID referenced = %" PRId64 " ", min_log_pageid);
+  fprintf (outfp, "First log page ID referenced = %lld", (long long int) min_log_pageid);
   if (!is_tran_server_with_remote_storage ())
     {
       if (logpb_is_page_in_archive (min_log_pageid))

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1140,10 +1140,6 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
 	    {
 	      fprintf (outfp, "(in %s%s%03d)\n", log_Prefix, FILEIO_SUFFIX_LOGARCHIVE, archive_number);
 	    }
-//        if (archive_number >= 0)
-//          {
-//            fprintf (outfp, "(in %s%s%03d)", log_Prefix, FILEIO_SUFFIX_LOGARCHIVE, archive_number);
-//          }
 	  LOG_CS_EXIT (thread_p);
 	}
       else

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -40,6 +40,7 @@
 #include "overflow_file.h"
 #include "page_buffer.h"
 #include "perf_monitor.h"
+#include "porting.h"
 #include "resource_shared_pool.hpp"
 #include "server_type.hpp"
 #include "thread_entry_task.hpp"


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-112

On a transaction server with `remote_storage` enabled, disable displaying the archive file name of the minimum required log page.

Testing:
- tested on a transaction server with/without `remote_storage` enabled (`cubrid -C --dump <database name>`)
- tested in stand-alone mode (`cubrid -S --dump <database name>`)

Remarks:
- testing on a page server with `cubrid -C --dump <database name>` returns error message:
```
vacuum did not boot properly.
```