### PR TITLE
[LETS-137] Add LZ4 target to test_prior_list_serialize

### DIFF
--- a/unit_tests/log/CMakeLists.txt
+++ b/unit_tests/log/CMakeLists.txt
@@ -114,7 +114,7 @@ target_include_directories(test_prior_list_serialize PRIVATE
   ${TEST_INCLUDES}
   )
 add_dependencies(test_prior_list_serialize
-  ${CATCH2_TARGET}
+  ${CATCH2_TARGET} ${LZ4_TARGET}
   )
 
 #


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-137

Sometimes build may fail because of missing dependency of test_prior_list_serialize executable on lz4. test_prior_list_serialize may be build before LZ4 is downloaded and it cannot find the required header.
