### PR TITLE
[LETS-118]alterdbhost does not mount/dismount active log

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1965,7 +1965,6 @@ alterdbhost (UTIL_FUNCTION_ARG * arg)
 	}
     }
   db = cfg_find_db_list (dir, db_name);
-
   if (db == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_BO_UNKNOWN_DATABASE, 1, db_name);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-118

alterdbhost changes the hostname set in databases.txt.

The implementation also mounts/dismounts the active log file, probably as a check that the database really exists. It is not mandatory for the mission of alterdbhost utilitary and it won't work with transaction servers running on remote storage (and it won't work with any transaction servers in the end).

Changed the code for alterdbhost to not mount/unmount the log active file.
The functionality of alterdbhost should not be altered by the change.
