### PR TITLE
[CBRD-23990] Redesign of query cache management to handle the plan cache overflown

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -5081,7 +5081,8 @@ qfile_finalize_list_cache (THREAD_ENTRY * thread_p)
       for (i = 0; i < qfile_List_cache.n_hts; i++)
 	{
 	  bool invalidate = true;
-	  (void) mht_map_no_key (thread_p, qfile_List_cache.list_hts[i], qfile_end_use_of_list_cache_entry_local, &invalidate);
+	  (void) mht_map_no_key (thread_p, qfile_List_cache.list_hts[i], qfile_end_use_of_list_cache_entry_local,
+				 &invalidate);
 	  mht_destroy (qfile_List_cache.list_hts[i]);
 	}
       free_and_init (qfile_List_cache.list_hts);

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -5094,19 +5094,16 @@ qfile_clear_list_cache (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry
   if (csect_enter (thread_p, CSECT_QPROC_LIST_CACHE, INF_WAIT) != NO_ERROR)
     {
       goto end;
-      //return ER_FAILED;
     }
 
   if (QFILE_IS_LIST_CACHE_DISABLED || xcache_entry->list_ht_no < 0)
     {
       goto end;
-      //return ER_FAILED;
     }
 
   if (qfile_List_cache.n_hts == 0)
     {
       goto end;
-      //return ER_FAILED;
     }
 
   list_ht_no = xcache_entry->list_ht_no;

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -5568,7 +5568,10 @@ qfile_lookup_list_cache_entry (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xasl,
 
   if (xasl->list_ht_no < 0)
     {
-      xasl->list_ht_no = qcache_get_new_ht_no (thread_p);
+      if ((xasl->list_ht_no = qcache_get_new_ht_no (thread_p)) < 0)
+	{
+	  goto end;
+	}
     }
 
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -373,7 +373,8 @@ qfile_list_cache_cleanup (THREAD_ENTRY * thread_p)
 	}
     }
 
-  for (candidate_index = 0; candidate_index < bh->element_count; candidate_index++)
+  /* traverse in reverse for weight ordering, from light weight to heavy weight */
+  for (candidate_index = bh->element_count - 1; candidate_index >= 0; candidate_index--)
     {
       bh_element_at (bh, candidate_index, &candidate);
       qfile_delete_list_cache_entry (thread_p, candidate.qcache);

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -5569,9 +5569,6 @@ qfile_lookup_list_cache_entry (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xasl,
   if (xasl->list_ht_no < 0)
     {
       xasl->list_ht_no = qcache_get_new_ht_no (thread_p);
-      csect_exit (thread_p, CSECT_QPROC_LIST_CACHE);
-
-      return NULL;
     }
 
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -4958,7 +4958,7 @@ qfile_initialize_list_cache (THREAD_ENTRY * thread_p)
       for (i = 0; i < qfile_List_cache.n_hts; i++)
 	{
 	  qfile_List_cache.list_hts[i] =
-	    mht_create ("list file cache (DB_VALUE list)", prm_get_integer_value (PRM_ID_LIST_MAX_QUERY_CACHE_ENTRIES),
+	    mht_create ("list file cache (DB_VALUE list)", qfile_List_cache.n_hts,
 			qfile_hash_db_value_array, qfile_compare_equal_db_value_array);
 	  qfile_List_cache.free_ht_list[i] = i + 1;
 	  if (qfile_List_cache.list_hts[i] == NULL)
@@ -5105,6 +5105,16 @@ qfile_clear_list_cache (THREAD_ENTRY * thread_p, int list_ht_no, bool invalidate
       return ER_FAILED;
     }
 
+  if (qfile_get_list_cache_number_of_entries (list_ht_no) == 0)
+    {
+      /* if no entries, to invalidate free the entry here */
+      if (invalidate)
+	{
+	  qcache_free_ht_no (thread_p, list_ht_no);
+	}
+      goto end;
+    }
+
   cnt = 0;
   do
     {
@@ -5129,6 +5139,7 @@ qfile_clear_list_cache (THREAD_ENTRY * thread_p, int list_ht_no, bool invalidate
       er_log_debug (ARG_FILE_LINE, "ls_clear_list_cache: failed to delete all entries\n");
     }
 
+end:
   csect_exit (thread_p, CSECT_QPROC_LIST_CACHE);
 
   return NO_ERROR;

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -4973,7 +4973,7 @@ qfile_initialize_list_cache (THREAD_ENTRY * thread_p)
   else
     {
       /* create */
-      qfile_List_cache.n_hts = prm_get_integer_value (PRM_ID_XASL_CACHE_MAX_ENTRIES);
+      qfile_List_cache.n_hts = prm_get_integer_value (PRM_ID_XASL_CACHE_MAX_ENTRIES) + 10;
       qfile_List_cache.list_hts = (MHT_TABLE **) calloc (qfile_List_cache.n_hts, sizeof (MHT_TABLE *));
       qfile_List_cache.free_list = (int *) calloc (qfile_List_cache.n_hts, sizeof (int));
       if (qfile_List_cache.list_hts == NULL)

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -411,21 +411,9 @@ qcache_get_new_ht_no (THREAD_ENTRY * thread_p)
 void
 qcache_free_ht_no (THREAD_ENTRY * thread_p, int ht_no)
 {
-  if (QFILE_IS_LIST_CACHE_DISABLED || ht_no < 0)
-    {
-      return;
-    }
-
-  if (csect_enter (thread_p, CSECT_QPROC_LIST_CACHE, INF_WAIT) != NO_ERROR)
-    {
-      return;
-    }
-
   (void) mht_clear (qfile_List_cache.list_hts[ht_no], NULL, NULL);
   qfile_List_cache.free_ht_list[ht_no] = qfile_List_cache.next_ht_no;
   qfile_List_cache.next_ht_no = ht_no;
-
-  csect_exit (thread_p, CSECT_QPROC_LIST_CACHE);
 }
 
 /* qfile_modify_type_list () -
@@ -5514,7 +5502,10 @@ qfile_end_use_of_list_cache_entry_local (THREAD_ENTRY * thread_p, void *data, vo
       return ER_FAILED;
     }
 
-  lent->invalidate = *((bool *) args);
+  if (lent->invalidate == false)
+    {
+      lent->invalidate = *((bool *) args);
+    }
 
   return qfile_end_use_of_list_cache_entry (thread_p, lent, true);
 }

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -85,7 +85,7 @@ typedef struct qfile_cleanup_candidate QFILE_CACHE_CLEANUP_CANDIDATE;
 struct qfile_cleanup_candidate
 {
   QFILE_LIST_CACHE_ENTRY *qcache;
-  INT64 weight;
+  double weight;
 };
 
 typedef SCAN_CODE (*ADVANCE_FUCTION) (THREAD_ENTRY * thread_p, QFILE_LIST_SCAN_ID *, QFILE_TUPLE_RECORD *,
@@ -290,10 +290,10 @@ static int qfile_compare_with_interpolation_domain (char *fp0, char *fp1, SUBKEY
 static BH_CMP_RESULT
 qfile_compare_cleanup_candidates (const void *left, const void *right, BH_CMP_ARG ignore_arg)
 {
-  INT64 left_weight = ((QFILE_CACHE_CLEANUP_CANDIDATE *) left)->weight;
-  INT64 right_weight = ((QFILE_CACHE_CLEANUP_CANDIDATE *) right)->weight;
+  double left_weight = ((QFILE_CACHE_CLEANUP_CANDIDATE *) left)->weight;
+  double right_weight = ((QFILE_CACHE_CLEANUP_CANDIDATE *) right)->weight;
 
-  if (left_weight > right_weight)
+  if (left_weight < right_weight)
     {
       return BH_LT;
     }
@@ -366,7 +366,7 @@ qfile_list_cache_cleanup (THREAD_ENTRY * thread_p)
 		    }
 		  page_ref = candidate.qcache->list_id.page_cnt + 1;
 		  lru_sec = current_time.tv_sec - candidate.qcache->time_last_used.tv_sec;
-		  candidate.weight = page_ref * lru_sec / (candidate.qcache->ref_count + 1);
+		  candidate.weight = (double) (candidate.qcache->ref_count + 1) / (double) (page_ref * lru_sec);
 		  (void) bh_try_insert (bh, &candidate, NULL);
 		}
 	    }

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -365,7 +365,7 @@ qfile_list_cache_cleanup (THREAD_ENTRY * thread_p)
 		      continue;
 		    }
 		  page_ref = candidate.qcache->list_id.page_cnt + 1;
-		  lru_sec = current_time.tv_sec - candidate.qcache->time_last_used.tv_sec;
+		  lru_sec = current_time.tv_sec - candidate.qcache->time_last_used.tv_sec + 1;
 		  candidate.weight = (double) (candidate.qcache->ref_count + 1) / (double) (page_ref * lru_sec);
 		  (void) bh_try_insert (bh, &candidate, NULL);
 		}

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -293,7 +293,7 @@ qfile_compare_cleanup_candidates (const void *left, const void *right, BH_CMP_AR
   INT64 left_weight = ((QFILE_CACHE_CLEANUP_CANDIDATE *) left)->weight;
   INT64 right_weight = ((QFILE_CACHE_CLEANUP_CANDIDATE *) right)->weight;
 
-  if (left_weight < right_weight)
+  if (left_weight > right_weight)
     {
       return BH_LT;
     }
@@ -347,7 +347,6 @@ qfile_list_cache_cleanup (THREAD_ENTRY * thread_p)
       HENTRY_PTR hentry;
       INT64 page_ref;
       INT64 lru_sec;
-      INT64 clr_cnt;
 
       ht = qfile_List_cache.list_hts[n];
       for (hvector = ht->table, i = 0; i < ht->size; hvector++, i++)
@@ -365,10 +364,9 @@ qfile_list_cache_cleanup (THREAD_ENTRY * thread_p)
 		      // exclude in-transaction
 		      continue;
 		    }
-		  page_ref = candidate.qcache->list_id.page_cnt / (candidate.qcache->ref_count + 1);
+		  page_ref = candidate.qcache->list_id.page_cnt + 1;
 		  lru_sec = current_time.tv_sec - candidate.qcache->time_last_used.tv_sec;
-		  clr_cnt = candidate.qcache->xcache_entry->clr_count + 1;
-		  candidate.weight = page_ref * lru_sec * clr_cnt;
+		  candidate.weight = page_ref * lru_sec / (candidate.qcache->ref_count + 1);
 		  (void) bh_try_insert (bh, &candidate, NULL);
 		}
 	    }

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -5087,6 +5087,10 @@ qfile_finalize_list_cache (THREAD_ENTRY * thread_p)
 	}
       free_and_init (qfile_List_cache.list_hts);
     }
+  if (qfile_List_cache.free_list)
+    {
+      free_and_init (qfile_List_cache.free_list);
+    }
 
   /* list cache entry pool */
   if (qfile_List_cache_entry_pool.pool)

--- a/src/query/list_file.h
+++ b/src/query/list_file.h
@@ -154,7 +154,7 @@ extern QFILE_LIST_ID *qfile_sort_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * 
 /* Query result(list file) cache routines */
 extern int qfile_initialize_list_cache (THREAD_ENTRY * thread_p);
 extern int qfile_finalize_list_cache (THREAD_ENTRY * thread_p);
-extern int qfile_clear_list_cache (THREAD_ENTRY * thread_p, int list_ht_no, bool invalidate);
+extern int qfile_clear_list_cache (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry, bool invalidate);
 extern int qfile_dump_list_cache_internal (THREAD_ENTRY * thread_p, FILE * fp);
 #if defined (CUBRID_DEBUG)
 extern int qfile_dump_list_cache (THREAD_ENTRY * thread_p, const char *fname);

--- a/src/query/list_file.h
+++ b/src/query/list_file.h
@@ -165,6 +165,9 @@ QFILE_LIST_CACHE_ENTRY *qfile_lookup_list_cache_entry (THREAD_ENTRY * thread_p, 
 QFILE_LIST_CACHE_ENTRY *qfile_update_list_cache_entry (THREAD_ENTRY * thread_p, int list_ht_no,
 						       const DB_VALUE_ARRAY * params, const QFILE_LIST_ID * list_id,
 						       XASL_CACHE_ENTRY * xasl);
+int qcache_get_new_ht_no (THREAD_ENTRY * thread_p);
+void qcache_free_ht_no (THREAD_ENTRY * thread_p, int ht_no);
+
 int qfile_end_use_of_list_cache_entry (THREAD_ENTRY * thread_p, QFILE_LIST_CACHE_ENTRY * lent, bool marker);
 
 /* Scan related routines */

--- a/src/query/list_file.h
+++ b/src/query/list_file.h
@@ -161,7 +161,7 @@ extern int qfile_dump_list_cache (THREAD_ENTRY * thread_p, const char *fname);
 #endif
 /* query result(list file) cache entry manipulation functions */
 void qfile_clear_uncommited_list_cache_entry (THREAD_ENTRY * thread_p, int tran_index);
-QFILE_LIST_CACHE_ENTRY *qfile_lookup_list_cache_entry (THREAD_ENTRY * thread_p, int list_ht_no,
+QFILE_LIST_CACHE_ENTRY *qfile_lookup_list_cache_entry (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xasl,
 						       const DB_VALUE_ARRAY * params, bool * result_cached);
 QFILE_LIST_CACHE_ENTRY *qfile_update_list_cache_entry (THREAD_ENTRY * thread_p, int list_ht_no,
 						       const DB_VALUE_ARRAY * params, const QFILE_LIST_ID * list_id,

--- a/src/query/list_file.h
+++ b/src/query/list_file.h
@@ -98,6 +98,7 @@ struct qfile_list_cache_entry
   struct timeval time_last_used;	/* when this entry used lastly */
   int ref_count;		/* how many times this query used */
   bool deletion_marker;		/* this entry will be deleted if marker set */
+  bool invalidate;		/* related xcache entry is erased */
 };
 
 enum
@@ -153,7 +154,7 @@ extern QFILE_LIST_ID *qfile_sort_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * 
 /* Query result(list file) cache routines */
 extern int qfile_initialize_list_cache (THREAD_ENTRY * thread_p);
 extern int qfile_finalize_list_cache (THREAD_ENTRY * thread_p);
-extern int qfile_clear_list_cache (THREAD_ENTRY * thread_p, int list_ht_no);
+extern int qfile_clear_list_cache (THREAD_ENTRY * thread_p, int list_ht_no, bool invalidate);
 extern int qfile_dump_list_cache_internal (THREAD_ENTRY * thread_p, FILE * fp);
 #if defined (CUBRID_DEBUG)
 extern int qfile_dump_list_cache (THREAD_ENTRY * thread_p, const char *fname);

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1396,8 +1396,7 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 	    {
 	      xasl_cache_entry_p->list_ht_no = qcache_get_new_ht_no (thread_p);
 	    }
-
-	  if (xasl_cache_entry_p->list_ht_no >= 0)
+	  else if (xasl_cache_entry_p->list_ht_no >= 0)
 	    {
 	      /* lookup the list cache with the parameter values (DB_VALUE array) */
 	      list_cache_entry_p =

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1391,22 +1391,14 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 
       if (do_not_cache == false)
 	{
-	  /* lookup the hash table number for qfile list cache */
-	  if (xasl_cache_entry_p->list_ht_no < 0)
+	  /* lookup the list cache with the parameter values (DB_VALUE array) */
+	  list_cache_entry_p = qfile_lookup_list_cache_entry (thread_p, xasl_cache_entry_p, &params, &cached_result);
+
+	  /* If we've got the cached result, return it. */
+	  if (cached_result)
 	    {
-	      xasl_cache_entry_p->list_ht_no = qcache_get_new_ht_no (thread_p);
-	    }
-	  else if (xasl_cache_entry_p->list_ht_no >= 0)
-	    {
-	      /* lookup the list cache with the parameter values (DB_VALUE array) */
-	      list_cache_entry_p =
-		qfile_lookup_list_cache_entry (thread_p, xasl_cache_entry_p->list_ht_no, &params, &cached_result);
-	      /* If we've got the cached result, return it. */
-	      if (cached_result)
-		{
-		  /* found the cached result */
-		  CACHE_TIME_MAKE (server_cache_time_p, &list_cache_entry_p->time_created);
-		}
+	      /* found the cached result */
+	      CACHE_TIME_MAKE (server_cache_time_p, &list_cache_entry_p->time_created);
 	    }
 	}
     }

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1391,14 +1391,23 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 
       if (do_not_cache == false)
 	{
-	  /* lookup the list cache with the parameter values (DB_VALUE array) */
-	  list_cache_entry_p =
-	    qfile_lookup_list_cache_entry (thread_p, xasl_cache_entry_p->list_ht_no, &params, &cached_result);
-	  /* If we've got the cached result, return it. */
-	  if (cached_result)
+	  /* lookup the hash table number for qfile list cache */
+	  if (xasl_cache_entry_p->list_ht_no < 0)
 	    {
-	      /* found the cached result */
-	      CACHE_TIME_MAKE (server_cache_time_p, &list_cache_entry_p->time_created);
+	      xasl_cache_entry_p->list_ht_no = qcache_get_new_ht_no (thread_p);
+	    }
+
+	  if (xasl_cache_entry_p->list_ht_no >= 0)
+	    {
+	      /* lookup the list cache with the parameter values (DB_VALUE array) */
+	      list_cache_entry_p =
+		qfile_lookup_list_cache_entry (thread_p, xasl_cache_entry_p->list_ht_no, &params, &cached_result);
+	      /* If we've got the cached result, return it. */
+	      if (cached_result)
+		{
+		  /* found the cached result */
+		  CACHE_TIME_MAKE (server_cache_time_p, &list_cache_entry_p->time_created);
+		}
 	    }
 	}
     }
@@ -1507,7 +1516,7 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
   /* If it is allowed to cache the query result or if it is required to cache, put the list file id(QFILE_LIST_ID) into
    * the list cache. Provided are the corresponding XASL cache entry to be linked, and the parameters (host variables -
    * DB_VALUES). */
-  if (qmgr_is_allowed_result_cache (*flag_p) && do_not_cache == false)
+  if (qmgr_is_allowed_result_cache (*flag_p) && do_not_cache == false && xasl_cache_entry_p->list_ht_no >= 0)
     {
       /* check once more to ensure that the related XASL entry is still valid */
       if (xcache_can_entry_cache_list (xasl_cache_entry_p))

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -1158,7 +1158,6 @@ xcache_unfix (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry)
       if (xcache_entry->list_ht_no >= 0)
 	{
 	  (void) qfile_clear_list_cache (thread_p, xcache_entry->list_ht_no);
-	  qcache_free_ht_no (thread_p, xcache_entry->list_ht_no);
 	}
       if (!xcache_Hashmap.erase (thread_p, xcache_entry->xasl_id))
 	{
@@ -1805,11 +1804,6 @@ xcache_invalidate_entries (THREAD_ENTRY * thread_p, bool (*invalidate_check) (XA
 		    {
 		      xcache_clone_decache (thread_p, &xcache_entry->cache_clones[--xcache_entry->n_cache_clones]);
 		    }
-		  if (xcache_entry->list_ht_no >= 0)
-		    {
-		      /* should be freed before xasl erase */
-		      qcache_free_ht_no (thread_p, xcache_entry->list_ht_no);
-		    }
 		  delete_xids[n_delete_xids++] = xcache_entry->xasl_id;
 		}
 	    }
@@ -2264,7 +2258,6 @@ xcache_cleanup (THREAD_ENTRY * thread_p)
       if (candidate.xcache->list_ht_no >= 0)
 	{
 	  (void) qfile_clear_list_cache (thread_p, candidate.xcache->list_ht_no);
-	  qcache_free_ht_no (thread_p, candidate.xcache->list_ht_no);
 	}
 
       /* Try delete. Would be better to decache the clones here. For simplicity, since is not an usual case,

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -1476,6 +1476,7 @@ xcache_insert (THREAD_ENTRY * thread_p, const compile_context * context, XASL_ST
       (*xcache_entry)->stream = *stream;
       (*xcache_entry)->time_last_rt_check = (INT64) time_stored.tv_sec;
       (*xcache_entry)->time_last_used = time_stored;
+      (*xcache_entry)->list_ht_no = -1;
 
       /* Now that new entry is initialized, we can try to insert it. */
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23990

A query cache is linked to an XASL cache entry by hash table number (list_ht_no of XASL_CACHE_ENTRY).

The qfile_List_cache has hash tables for query and result cache management. The number of hash tables is the same as max number of query plan (XASL_CACHE_MAX_ENTRIES). To minimize use of mutex, whenever allocation of xasl cache entry the list_ht_no is set to the number of current entries linked to qfile_List_cache's hash table index. See the routine xcache_entry_alloc.

But the xasl cache entries can be overflown to XASL_CACHE_MAX_ENTRIES, the list_ht_no of the entry can be out of range because the qfile_List_cache's hash table entries are fixed to XASL_CACHE_MAX_ENTRIES + 10.

I modified the routine xcache_entry_alloc not to assign the number of current entries. The list_ht_no is from qcache_get_new_ht_no ( ) instead. And the qfile_List_cache's structure is modified to get free hash table index (qcache_get_ht_no).

free_list and next field are newly added. qcache_get_new_ht_no and qcache_free_ht_no are also added for allocation and free for hash table index.

```
-- cubrid.conf
max_query_cache_entries = 2
query_cache_size_in_pages = 10000
max_plan_cache_entries = 2
max_plan_cache_clones = 2
 
create table tmp (col1 int, col2 int, col3 int);
select /*+ query_cache recompile */ * from tmp a, tmp b, tmp c where a.col1 = b.col1 and b.col1 = c.col1;
select /*+ query_cache recompile */ * from tmp a, tmp b where a.col1 = b.col1 and a.col1 = 1;
select /*+ query_cache recompile */ * from tmp a where col1 = 1;
```

the above execution should be successfully done.