### PR TITLE
[CBRD-23991] Clear the session information including holdable cursor when CAS connection is down

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -58,6 +58,7 @@
 #endif
 #include "thread_entry.hpp"
 #include "thread_manager.hpp"
+#include "session.h"
 
 enum net_req_act
 {
@@ -1274,6 +1275,7 @@ loop:
   if (tran_index != NULL_TRAN_INDEX)
     {
       (void) xboot_unregister_client (thread_p, tran_index);
+      session_remove_query_entry_all (thread_p);
     }
   css_free_conn (conn_p);
 

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -2394,7 +2394,7 @@ session_preserve_temporary_files (THREAD_ENTRY * thread_p, SESSION_QUERY_ENTRY *
 	    {
 	      if (!tfile_vfid_p->preserved)
 		{
-	          file_temp_preserve (thread_p, &tfile_vfid_p->temp_vfid);
+		  file_temp_preserve (thread_p, &tfile_vfid_p->temp_vfid);
 		  tfile_vfid_p->preserved = true;
 		}
 	    }
@@ -2544,6 +2544,34 @@ session_load_query_entry_info (THREAD_ENTRY * thread_p, QMGR_QUERY_ENTRY * qentr
       sentry_p = sentry_p->next;
     }
   return ER_FAILED;
+}
+
+/*
+ * session_remove_query_entry_all () - remove all query entries from the session
+ * thread_p (in) : active thread
+ */
+void
+session_remove_query_entry_all (THREAD_ENTRY * thread_p)
+{
+  SESSION_STATE *state_p = NULL;
+  SESSION_QUERY_ENTRY *sentry_p = NULL, *prev = NULL;
+
+  state_p = session_get_session_state (thread_p);
+  if (state_p == NULL)
+    {
+      return;
+    }
+
+  sentry_p = state_p->queries;
+  while (sentry_p != NULL)
+    {
+      session_free_sentry_data (thread_p, sentry_p);
+      prev = sentry_p;
+      sentry_p = sentry_p->next;
+
+      free_and_init (prev);
+    }
+  state_p->queries = NULL;
 }
 
 /*

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -67,6 +67,7 @@ extern void session_states_dump (THREAD_ENTRY * thread_p);
 extern void session_store_query_entry_info (THREAD_ENTRY * thread_p, QMGR_QUERY_ENTRY * qentry_p);
 extern int session_load_query_entry_info (THREAD_ENTRY * thread_p, QMGR_QUERY_ENTRY * qentry_p);
 extern int session_remove_query_entry_info (THREAD_ENTRY * thread_p, const QUERY_ID query_id);
+extern void session_remove_query_entry_all (THREAD_ENTRY * thread_p);
 extern int session_clear_query_entry_info (THREAD_ENTRY * thread_p, const QUERY_ID query_id);
 extern bool session_is_queryid_idle (THREAD_ENTRY * thread_p, const QUERY_ID query_id, QUERY_ID * max_query_id_uses);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23991

While holdable cursor processing, even though CAS is down the cursor-related information is not cleared because the server keep the information for holdable cursor only by query-id.

The transaction-id is already remove by commit and the only way to remove the information related to holdable cursor is query-id from CAS. The query-id is only available from query_end by CAS but if the CAS is down the query-id is not available any more. At this time, the server should clear the session information including holdable cursor to prevent memory leak (i.e. dangling session information).

```
public static Connection connect() {
      Connection conn = null;
      try { 
           Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
           conn = DriverManager.getConnection("jdbc:cubrid:192.168.1.3:55300:demodb:::","dba","");
           conn.setAutoCommit (false) ;
           conn.setHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT);
      } catch ( Exception e ) {
           System.err.println("SQLException : " + e.getMessage());
      }      return conn;
   } 

public static void main(String[] args) throws Exception {
    conn = connect();

    PreparedStatement stmt = conn.prepareStatement("select * from game where host_year = ?");
    stmt.setInt(1, 1988);
    rs = stmt.executeQuery();
    rs.next();

    System.out.println("1 " + rs.getInt(1));
    System.out.println("1 " + rs.getString(5));

    conn.commit();

    while (rs.next()) {
       System.out.println("2 " + rs.getInt(1));
       System.out.println("2 " + rs.getString(5));
       Thread.sleep(10000);
    }
}
```
- kill the CAS process at the server side.
- check stat by "cubrid statdump -s cursor -i 2 demodb"

**Expected:**
 *** SERVER EXECUTION STATISTICS ***
Num_query_holdable_cursors = 0

**Actual:**
 *** SERVER EXECUTION STATISTICS ***
Num_query_holdable_cursors = 1