### PR TITLE
[CBRD-23985] Fix referring to null sm_class in the destructor of a context

### DIFF
--- a/src/object/schema_class_truncator.cpp
+++ b/src/object/schema_class_truncator.cpp
@@ -329,7 +329,10 @@ namespace cubschema
 
   class_truncate_context::~class_truncate_context ()
   {
-    m_class->load_index_from_heap = 1;
+    if (m_class != NULL)
+      {
+	m_class->load_index_from_heap = 1;
+      }
 
     if (m_unique_info != NULL)
       {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23985

When it fails to get the sm_class of a class, it tried to refer to NULL sm_class in the destructor of the truncate context object. As an example, there is a deadlock so it can fail.
