### PR TITLE
[LETS-111] Request log header page from page server

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -3724,7 +3724,7 @@ pwrite_with_injected_fault (THREAD_ENTRY * thread_p, int fd, const void *buf, si
 		      pthread_mutex_unlock (&fileio_Sys_vol_info_header.mutex);
 		      if (sys_volinfo)
 			{
-			  logpb_debug_check_log_page (thread_p, buf);
+			  logpb_debug_check_log_page (thread_p, (LOG_PAGE *) buf);
 			}
 		    }
 #endif /* defined (SERVER_MODE) || (SA_MODE) */

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -3724,7 +3724,7 @@ pwrite_with_injected_fault (THREAD_ENTRY * thread_p, int fd, const void *buf, si
 		      pthread_mutex_unlock (&fileio_Sys_vol_info_header.mutex);
 		      if (sys_volinfo)
 			{
-			  logpb_debug_check_log_page (thread_p, (void *) buf);
+			  logpb_debug_check_log_page (thread_p, buf);
 			}
 		    }
 #endif /* defined (SERVER_MODE) || (SA_MODE) */

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2360,6 +2360,14 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       goto error;
     }
 
+#if defined (SERVER_MODE)
+  if (get_server_type () == SERVER_TYPE_TRANSACTION)
+    {
+      // Data page broker is required before volumes are mounted.
+      ats_Gl.init_page_brokers ();
+    }
+#endif
+
   /*
    * Compose the full name of the database and find location of logs
    */
@@ -2407,14 +2415,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     {
       goto error;
     }
-
-#if defined (SERVER_MODE)
-  if (get_server_type () == SERVER_TYPE_TRANSACTION)
-    {
-      // Data page broker is required before volumes are mounted.
-      ats_Gl.init_page_brokers ();
-    }
-#endif
 
   /*
    * Now continue the normal restart process. At this point the data volumes

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2363,7 +2363,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 #if defined (SERVER_MODE)
   if (get_server_type () == SERVER_TYPE_TRANSACTION)
     {
-      // Data page broker is required before volumes are mounted.
+      // Log page broker is required to load log header.
       ats_Gl.init_page_brokers ();
     }
 #endif

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -926,7 +926,7 @@ extern int logtb_find_client_name_host_pid (int tran_index, const char **client_
 					    const char **client_user_name, const char **client_host_name,
 					    int *client_pid);
 #if !defined(NDEBUG)
-extern void logpb_debug_check_log_page (THREAD_ENTRY * thread_p, void *log_pgptr_ptr);
+extern void logpb_debug_check_log_page (THREAD_ENTRY * thread_p, const void *log_pgptr_ptr);
 #endif
 #if defined (SERVER_MODE)
 extern int logtb_find_client_tran_name_host_pid (int &tran_index, const char **client_prog_name,

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -926,7 +926,7 @@ extern int logtb_find_client_name_host_pid (int tran_index, const char **client_
 					    const char **client_user_name, const char **client_host_name,
 					    int *client_pid);
 #if !defined(NDEBUG)
-extern void logpb_debug_check_log_page (THREAD_ENTRY * thread_p, const void *log_pgptr_ptr);
+extern void logpb_debug_check_log_page (THREAD_ENTRY * thread_p, const LOG_PAGE * log_pgptr);
 #endif
 #if defined (SERVER_MODE)
 extern int logtb_find_client_tran_name_host_pid (int &tran_index, const char **client_prog_name,

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -314,7 +314,7 @@ static void logpb_archive_active_log (THREAD_ENTRY * thread_p);
 static void logpb_verify_page_read (LOG_PAGEID pageid, const LOG_PAGE * left_log_pgptr,
 				    const LOG_PAGE * rite_log_pgptr);
 #endif /* SERVER_MODE */
-extern int logpb_read_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_ACCESS_MODE access_mode,
+static int logpb_read_page_from_file (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_ACCESS_MODE access_mode,
 				      LOG_PAGE * log_pgptr);
 static int logpb_remove_archive_logs_internal (THREAD_ENTRY * thread_p, int first, int last, const char *info_reason);
 static void logpb_append_archives_removed_to_log_info (int first, int last, const char *info_reason);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -139,7 +139,7 @@ static int rv;
 
 
 /* PAGES OF ACTIVE LOG PORTION */
-#define LOGPB_HEADER_PAGE_ID             (-9)	/* The first log page in the infinite log sequence. It is always kept
+#define LOGPB_HEADER_PAGE_ID             (-9LL)	/* The first log page in the infinite log sequence. It is always kept
 						 * on the active portion of the log. Log records are not stored on this
 						 * page. This page is backed up in all archive logs */
 #define LOGPB_NEXT_ARCHIVE_PAGE_ID    (log_Gl.hdr.nxarv_pageid)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -2002,9 +2002,9 @@ logpb_verify_page_read (LOG_PAGEID pageid, const LOG_PAGE * left_log_pgptr, cons
 
   if (!pages_equal && pageid == log_Gl.hdr.append_lsa.pageid)
     {
-      const char* const left_log_page_area = left_log_pgptr->area;
-      const char* const rite_log_page_area = rite_log_pgptr->area;
-      const int cmp_res = strncmp(left_log_page_area, rite_log_page_area, log_Gl.hdr.append_lsa.offset);
+      const char *const left_log_page_area = left_log_pgptr->area;
+      const char *const rite_log_page_area = rite_log_pgptr->area;
+      const int cmp_res = strncmp (left_log_page_area, rite_log_page_area, log_Gl.hdr.append_lsa.offset);
       pages_equal = left_log_pgptr->hdr == rite_log_pgptr->hdr && cmp_res == 0;
     }
 
@@ -2059,18 +2059,18 @@ logpb_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, LOG_PAGEID pa
       std::shared_ptr<log_page_owner> log_page_from_page_server
           = ats_Gl.get_log_page_broker ().wait_for_page (pageid);
       // *INDENT-ON*
+      const LOG_PAGE *const log_page_from_page_server_pgptr = log_page_from_page_server->get_log_page ();
       if (read_from_disk)
 	{
 	  // context 2)
 	  // log_pgptr already contains value read from local storage
-	  const LOG_PAGE *const log_page_from_page_server_pgptr = log_page_from_page_server->get_log_page ();
-	  logpb_verify_page_read(pageid, log_page_from_page_server_pgptr, log_pgptr);
+	  logpb_verify_page_read (pageid, log_page_from_page_server_pgptr, log_pgptr);
 	}
       else
 	{
 	  // context 1)
           // *INDENT-OFF*
-	  std::memcpy (log_pgptr, log_page_from_page_server->get_log_page (), LOG_PAGESIZE);
+	  std::memcpy (log_pgptr, log_page_from_page_server_pgptr, LOG_PAGESIZE);
           // *INDENT-ON*
 	}
     }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -2424,12 +2424,12 @@ logpb_read_page_from_active_log (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, int
 		  ASSERT_ERROR ();
 		  assert (false);
 		}
-	      logpb_debug_check_log_page (thread_p, (LOG_PAGE *) aligned_log_pgbuf);
+	      logpb_debug_check_log_page (thread_p, aligned_log_pgbuf);
 	      ptr += LOG_PAGESIZE;
 	    }
 	  else
 	    {
-	      logpb_debug_check_log_page (thread_p, (LOG_PAGE *) ptr);
+	      logpb_debug_check_log_page (thread_p, ptr);
 	      ptr += LOG_PAGESIZE;
 	    }
 	}
@@ -11280,11 +11280,9 @@ logpb_last_complete_blockid (void)
 
 #if !defined(NDEBUG)
 void
-logpb_debug_check_log_page (THREAD_ENTRY * thread_p, void *log_pgptr_ptr)
+logpb_debug_check_log_page (THREAD_ENTRY * thread_p, const void *log_pgptr_ptr)
 {
-  int err;
-  bool is_log_page_corrupted;
-  LOG_PAGE *log_pgptr = (LOG_PAGE *) log_pgptr_ptr;
+  const LOG_PAGE *const log_pgptr = (LOG_PAGE *) log_pgptr_ptr;
 
   assert (log_pgptr != NULL);
   if (boot_Server_status != BOOT_SERVER_UP && log_pgptr->hdr.logical_pageid == LOGPB_HEADER_PAGE_ID)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-111

If server type is transaction server and if it run on remote storage, instead of mounting the active log file and reading the header page from local disk, add a request to the page server and wait to receive the page.

Implementation:
- add `logpb_fetch_header_from_page_server` that retrieves the log header from page server
- add `logpb_fetch_header_from_file_or_page_server` that forks whether to read log header from either file (as before) or from page server
- move log and data page brokers before they are actually needed to retrieve the log header in `boot_restart_server`

Other changes:
- const and type correctness for `logpb_debug_check_log_page`

Tests:
- manual tests using script