### PR TITLE
[LETS-149] Treat RVBT_MARK_DELETED as MVCC log record

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3434,6 +3434,11 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, boo
 			     (unsigned long long int) mvccid, LSA_AS_ARGS (&rcv_lsa));
 	      error_code = btree_vacuum_insert_mvccid (thread_p, btid_int.sys_btid, &key_buf, &oid, &class_oid, mvccid);
 	    }
+	  else if (log_record_data.rcvindex == RVBT_MARK_DELETED)
+	    {
+	      /* A serial object was marked deleted. It does not really need vacuuming */
+	      /* Fall through */
+	    }
 	  else
 	    {
 	      /* Unexpected. */

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3437,7 +3437,6 @@ vacuum_process_log_block (THREAD_ENTRY * thread_p, VACUUM_DATA_ENTRY * data, boo
 	  else if (log_record_data.rcvindex == RVBT_MARK_DELETED)
 	    {
 	      /* A serial object was marked deleted. It does not really need vacuuming */
-	      /* Fall through */
 	    }
 	  else
 	    {

--- a/src/transaction/mvcc.h
+++ b/src/transaction/mvcc.h
@@ -236,26 +236,32 @@ typedef enum mvcc_satisfies_vacuum_result MVCC_SATISFIES_VACUUM_RESULT;
 // TODO - replace with functions
 
 /* Is log record for a heap MVCC operation */
-#define LOG_IS_MVCC_HEAP_OPERATION(rcvindex) \
-  (((rcvindex) == RVHF_MVCC_DELETE_REC_HOME) \
-   || ((rcvindex) == RVHF_MVCC_INSERT) \
-   || ((rcvindex) == RVHF_UPDATE_NOTIFY_VACUUM) \
-   || ((rcvindex) == RVHF_MVCC_DELETE_MODIFY_HOME) \
-   || ((rcvindex) == RVHF_MVCC_NO_MODIFY_HOME) \
-   || ((rcvindex) == RVHF_MVCC_REDISTRIBUTE))
+inline bool
+LOG_IS_MVCC_HEAP_OPERATION (LOG_RCVINDEX rcvindex)
+{
+  return rcvindex == RVHF_MVCC_DELETE_REC_HOME
+    || rcvindex == RVHF_MVCC_INSERT
+    || rcvindex == RVHF_UPDATE_NOTIFY_VACUUM
+    || rcvindex == RVHF_MVCC_DELETE_MODIFY_HOME
+    || rcvindex == RVHF_MVCC_NO_MODIFY_HOME || rcvindex == RVHF_MVCC_REDISTRIBUTE;
+}
 
 /* Is log record for a b-tree MVCC operation */
-#define LOG_IS_MVCC_BTREE_OPERATION(rcvindex) \
-  ((rcvindex) == RVBT_MVCC_DELETE_OBJECT \
-   || (rcvindex) == RVBT_MVCC_INSERT_OBJECT \
-   || (rcvindex) == RVBT_MVCC_INSERT_OBJECT_UNQ \
-   || (rcvindex) == RVBT_MVCC_NOTIFY_VACUUM)
+inline bool
+LOG_IS_MVCC_BTREE_OPERATION (LOG_RCVINDEX rcvindex)
+{
+  return rcvindex == RVBT_MVCC_DELETE_OBJECT
+    || rcvindex == RVBT_MVCC_INSERT_OBJECT
+    || rcvindex == RVBT_MVCC_INSERT_OBJECT_UNQ || rcvindex == RVBT_MVCC_NOTIFY_VACUUM || rcvindex == RVBT_MARK_DELETED;
+}
 
 /* Is log record for a MVCC operation */
-#define LOG_IS_MVCC_OPERATION(rcvindex) \
-  (LOG_IS_MVCC_HEAP_OPERATION (rcvindex) \
-   || LOG_IS_MVCC_BTREE_OPERATION (rcvindex) \
-   || ((rcvindex) == RVES_NOTIFY_VACUUM))
+inline bool
+LOG_IS_MVCC_OPERATION (LOG_RCVINDEX rcvindex)
+{
+  return LOG_IS_MVCC_HEAP_OPERATION (rcvindex) || LOG_IS_MVCC_BTREE_OPERATION (rcvindex)
+    || rcvindex == RVES_NOTIFY_VACUUM;
+}
 
 extern MVCC_SATISFIES_SNAPSHOT_RESULT mvcc_satisfies_snapshot (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header,
 							       MVCC_SNAPSHOT * snapshot);

--- a/src/transaction/mvcc.h
+++ b/src/transaction/mvcc.h
@@ -233,34 +233,43 @@ enum mvcc_satisfies_vacuum_result
 typedef enum mvcc_satisfies_vacuum_result MVCC_SATISFIES_VACUUM_RESULT;
 
 /* Definitions used to identify MVCC log records. */
-// TODO - replace with functions
 
 /* Is log record for a heap MVCC operation */
 inline bool
 LOG_IS_MVCC_HEAP_OPERATION (LOG_RCVINDEX rcvindex)
 {
+  // *INDENT-OFF*
   return rcvindex == RVHF_MVCC_DELETE_REC_HOME
     || rcvindex == RVHF_MVCC_INSERT
     || rcvindex == RVHF_UPDATE_NOTIFY_VACUUM
     || rcvindex == RVHF_MVCC_DELETE_MODIFY_HOME
-    || rcvindex == RVHF_MVCC_NO_MODIFY_HOME || rcvindex == RVHF_MVCC_REDISTRIBUTE;
+    || rcvindex == RVHF_MVCC_NO_MODIFY_HOME
+    || rcvindex == RVHF_MVCC_REDISTRIBUTE;
+  // *INDENT-ON*
 }
 
 /* Is log record for a b-tree MVCC operation */
 inline bool
 LOG_IS_MVCC_BTREE_OPERATION (LOG_RCVINDEX rcvindex)
 {
+  // *INDENT-OFF*
   return rcvindex == RVBT_MVCC_DELETE_OBJECT
     || rcvindex == RVBT_MVCC_INSERT_OBJECT
-    || rcvindex == RVBT_MVCC_INSERT_OBJECT_UNQ || rcvindex == RVBT_MVCC_NOTIFY_VACUUM || rcvindex == RVBT_MARK_DELETED;
+    || rcvindex == RVBT_MVCC_INSERT_OBJECT_UNQ
+    || rcvindex == RVBT_MVCC_NOTIFY_VACUUM
+    || rcvindex == RVBT_MARK_DELETED;
+  // *INDENT-ON*
 }
 
 /* Is log record for a MVCC operation */
 inline bool
 LOG_IS_MVCC_OPERATION (LOG_RCVINDEX rcvindex)
 {
-  return LOG_IS_MVCC_HEAP_OPERATION (rcvindex) || LOG_IS_MVCC_BTREE_OPERATION (rcvindex)
+  // *INDENT-OFF*
+  return LOG_IS_MVCC_HEAP_OPERATION (rcvindex)
+    || LOG_IS_MVCC_BTREE_OPERATION (rcvindex)
     || rcvindex == RVES_NOTIFY_VACUUM;
+  // *INDENT-ON*
 }
 
 extern MVCC_SATISFIES_SNAPSHOT_RESULT mvcc_satisfies_snapshot (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header,


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-149

RVBT_MARK_DELETED is a log record index used for deletes in the serial name index. Although the updates on the serials does not abide the MVCC rules, an MVCCID is used on deletes to protect against unique constraint violation in the next case:

- T1 deletes serial s1 without committing
- T2 inserts serial s1
- T1 aborts and wants to reinstate s1
- Unique constraint is violated.

However, RVBT_MARK_DELETED is not used as a log record for an MVCC operation. In consequence, when it is replicated, the page server does not know to advance `log_Gl.hdr.mvcc_next_id` and `btree_check_valid_record()` fails after the update on the serial name index (it expected all encountered MVCCID's are less than `log_Gl.hdr.mvcc_next_id`).

This patch includes RVBT_MARK_DELETED to the list of MVCC log record indexes. Vacuum is also instructed to skip it, because the record MVCCID is cleared by the transaction and no cleanup is required.