### PR TITLE
[LETS-152] When recovery is executed in parallel, volume head expansion log entry must be executed synchronously

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -502,6 +502,7 @@ log_rv_need_sync_redo (const vpid & a_rcv_vpid, LOG_RCVINDEX a_rcvindex)
     case RVDK_FORMAT:
     case RVDK_INITMAP:
     case RVDK_EXPAND_VOLUME:
+    case RVDK_VOLHEAD_EXPAND:
       // Creating/expanding a volume needs to be waited before applying other changes in new pages
       return true;
     case RVDK_RESERVE_SECTORS:


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-152

Add `RVDK_VOLHEAD_EXPAND` to the function `log_rv_need_sync_redo` in order to execute this log entry in sync because immediately subsequent log entries rely on the bookkeeping updated by this entry.
