### PR TITLE
[CBRD-23999] Fix cppcheck to be able to deal with a file without an extension

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -145,7 +145,10 @@ jobs:
               continue
             fi
 
+            set +e
             ext=$(expr $f : ".*\(\..*\)")
+            set -e
+
             case $ext in
             .c|.h|.cpp|.hpp|.C|.H|.CPP|.HPP) true;; # only these formats are checked.
             *) continue ;; # skip others


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23999

The script failed if `expr` failed. I've fixed it to be able to ignore the failure.