### PR TITLE
[LETS-134] Add system parameter to dump fileio cache

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -709,6 +709,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_REPLICATION_PARALLEL_COUNT "replication_parallel_count"
 
 #define PRM_NAME_REMOTE_STORAGE "remote_storage"
+#define PRM_NAME_DUMP_FILE_CACHE "dump_fileio_cache_after_boot"
 
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
@@ -2415,6 +2416,10 @@ static int prm_replication_parallel_count_lower_value = 0;
 static bool prm_remote_storage_default = false;
 bool PRM_REMOTE_STORAGE_CURRENT_VALUE = prm_remote_storage_default;
 static unsigned int prm_remote_storage_flag = 0;
+
+static bool prm_dump_file_cache_default = false;
+bool PRM_DUMP_FILE_CACHE_CURRENT_VALUE = prm_dump_file_cache_default;
+static unsigned int prm_dump_file_cache_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -6247,6 +6252,18 @@ static SYSPRM_PARAM prm_Def[] = {
    &prm_remote_storage_flag,
    (void *) &prm_remote_storage_default,
    (void *) &PRM_REMOTE_STORAGE_CURRENT_VALUE,
+   (void *) NULL,
+   (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_DUMP_FILE_CACHE,
+   PRM_NAME_DUMP_FILE_CACHE,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   &prm_dump_file_cache_flag,
+   (void *) &prm_dump_file_cache_default,
+   (void *) &PRM_DUMP_FILE_CACHE_CURRENT_VALUE,
    (void *) NULL,
    (void *) NULL,
    (char *) NULL,

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -468,9 +468,10 @@ enum param_id
   PRM_ID_REPLICATION_PARALLEL_COUNT,
 
   PRM_ID_REMOTE_STORAGE,
+  PRM_ID_DUMP_FILE_CACHE,
 
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_REMOTE_STORAGE
+  PRM_LAST_ID = PRM_ID_DUMP_FILE_CACHE
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -502,7 +502,6 @@ static bool fileio_synchronize_sys_volume (THREAD_ENTRY * thread_p, FILEIO_SYSTE
 static bool fileio_synchronize_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p, APPLY_ARG * arg);
 static int fileio_cache (VOLID volid, const char *vlabel, int vdes, FILEIO_LOCKF_TYPE lockf_type);
 static void fileio_decache (THREAD_ENTRY * thread_p, int vdes);
-void fileio_cache_dump (void);
 static void fileio_dump_cached_file (VOLID volid, int vdes, const char *vlabel);
 static bool fileio_dump_volinfo (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p, APPLY_ARG *);
 static bool fileio_dump_sysvolinfo (THREAD_ENTRY * thread_p, FILEIO_SYSTEM_VOLUME_INFO * sys_volinfo, APPLY_ARG *);

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -502,6 +502,7 @@ static bool fileio_synchronize_sys_volume (THREAD_ENTRY * thread_p, FILEIO_SYSTE
 static bool fileio_synchronize_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p, APPLY_ARG * arg);
 static int fileio_cache (VOLID volid, const char *vlabel, int vdes, FILEIO_LOCKF_TYPE lockf_type);
 static void fileio_decache (THREAD_ENTRY * thread_p, int vdes);
+void fileio_cache_dump (void);
 static void fileio_dump_cached_file (VOLID volid, int vdes, const char *vlabel);
 static bool fileio_dump_volinfo (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p, APPLY_ARG *);
 static bool fileio_dump_sysvolinfo (THREAD_ENTRY * thread_p, FILEIO_SYSTEM_VOLUME_INFO * sys_volinfo, APPLY_ARG *);
@@ -2123,7 +2124,7 @@ fileio_dump_cached_file (VOLID volid, int vdes, const char *vlabel)
 }
 
 /*
- * fileio_dump_cached_file () - Iterator function to call fileio_dump_volinfo to print volume info.
+ * fileio_dump_volinfo () - Iterator function to call fileio_dump_volinfo to print volume info.
  *    return: false to keep the iteration going
  *    vdvol_info_p(in): Volume information structure
  */
@@ -2135,7 +2136,7 @@ fileio_dump_volinfo (THREAD_ENTRY *, FILEIO_VOLUME_INFO * vol_info_p, APPLY_ARG 
 }
 
 /*
- * fileio_dump_cached_file () - Iterator function to call fileio_dump_volinfo to print system volume info.
+ * fileio_dump_sysvolinfo () - Iterator function to call fileio_dump_volinfo to print system volume info.
  *    return: false to keep the iteration going
  *    sys_volinfo(in): System volume information structure
  */

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2111,7 +2111,7 @@ fileio_cache_dump (THREAD_ENTRY * thread_p)
 }
 
 /*
- * fileio_dump_cached_file () - Dump information about given valume.
+ * fileio_dump_cached_file () - Dump information about given volume.
  *    return: void
  *    volid(in):  Volume ID
  *    vdes(in):   Volume descriptor
@@ -2124,7 +2124,8 @@ fileio_dump_cached_file (VOLID volid, int vdes, const char *vlabel)
 }
 
 /*
- * fileio_dump_volinfo () - Iterator function to call fileio_dump_volinfo to print volume info.
+ * fileio_dump_volinfo () - Iterator function to call fileio_dump_volinfo
+ * to print volume information.
  *    return: false to keep the iteration going
  *    vdvol_info_p(in): Volume information structure
  */
@@ -2136,7 +2137,8 @@ fileio_dump_volinfo (THREAD_ENTRY *, FILEIO_VOLUME_INFO * vol_info_p, APPLY_ARG 
 }
 
 /*
- * fileio_dump_sysvolinfo () - Iterator function to call fileio_dump_volinfo to print system volume info.
+ * fileio_dump_sysvolinfo () - Iterator function to call fileio_dump_volinfo
+ * to print system volume information.
  *    return: false to keep the iteration going
  *    sys_volinfo(in): System volume information structure
  */

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -502,6 +502,9 @@ static bool fileio_synchronize_sys_volume (THREAD_ENTRY * thread_p, FILEIO_SYSTE
 static bool fileio_synchronize_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p, APPLY_ARG * arg);
 static int fileio_cache (VOLID volid, const char *vlabel, int vdes, FILEIO_LOCKF_TYPE lockf_type);
 static void fileio_decache (THREAD_ENTRY * thread_p, int vdes);
+static void fileio_dump_cached_file (VOLID volid, int vdes, const char *vlabel);
+static bool fileio_dump_volinfo (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p, APPLY_ARG *);
+static bool fileio_dump_sysvolinfo (THREAD_ENTRY * thread_p, FILEIO_SYSTEM_VOLUME_INFO * sys_volinfo, APPLY_ARG *);
 static VOLID fileio_get_volume_id (int vdes);
 static bool fileio_is_volume_label_equal (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p, APPLY_ARG * arg);
 static int fileio_expand_permanent_volume_info (FILEIO_VOLUME_HEADER * header, int volid);
@@ -2089,6 +2092,58 @@ fileio_close (int vol_fd)
       er_set_with_oserror (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_IO_DISMOUNT_FAIL, 1,
 			   fileio_get_volume_label_by_fd (vol_fd, PEEK));
     }
+}
+
+/*
+ * fileio_cache_dump () - Iterate through all the cached volumes
+ * and dump all the important information about the volume.
+ *    return: void
+ *    thread_p(in) - Thread entry
+ */
+void
+fileio_cache_dump (THREAD_ENTRY * thread_p)
+{
+  APPLY_ARG arg = { 0 };
+  (void) fileio_traverse_system_volume (thread_p, fileio_dump_sysvolinfo, &arg);
+  (void) fileio_traverse_permanent_volume (thread_p, fileio_dump_volinfo, &arg);
+  (void) fileio_traverse_temporary_volume (thread_p, fileio_dump_volinfo, &arg);
+}
+
+/*
+ * fileio_dump_cached_file () - Dump information about given valume.
+ *    return: void
+ *    volid(in):  Volume ID
+ *    vdes(in):   Volume descriptor
+ *    vlabel(in): Volume label
+ */
+static void
+fileio_dump_cached_file (VOLID volid, int vdes, const char *vlabel)
+{
+  _er_log_debug (ARG_FILE_LINE, "Cached volume with volid=%d, vdes=%d, label=%s\n", volid, vdes, vlabel);
+}
+
+/*
+ * fileio_dump_cached_file () - Iterator function to call fileio_dump_volinfo to print volume info.
+ *    return: false to keep the iteration going
+ *    vdvol_info_p(in): Volume information structure
+ */
+static bool
+fileio_dump_volinfo (THREAD_ENTRY *, FILEIO_VOLUME_INFO * vol_info_p, APPLY_ARG *)
+{
+  fileio_dump_cached_file (vol_info_p->volid, vol_info_p->vdes, vol_info_p->vlabel);
+  return false;
+}
+
+/*
+ * fileio_dump_cached_file () - Iterator function to call fileio_dump_volinfo to print system volume info.
+ *    return: false to keep the iteration going
+ *    sys_volinfo(in): System volume information structure
+ */
+static bool
+fileio_dump_sysvolinfo (THREAD_ENTRY *, FILEIO_SYSTEM_VOLUME_INFO * sys_volinfo, APPLY_ARG *)
+{
+  fileio_dump_cached_file (sys_volinfo->volid, sys_volinfo->vdes, sys_volinfo->vlabel);
+  return false;
 }
 
 /*

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -464,6 +464,7 @@ struct flush_stats
 
 extern int fileio_open (const char *vlabel, int flags, int mode);
 extern void fileio_close (int vdes);
+extern void fileio_cache_dump ();
 extern int fileio_format (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel, VOLID volid,
 			  DKNPAGES npages, bool sweep_clean, bool dolock, bool dosync, size_t page_size,
 			  int kbytes_to_be_written_per_sec, bool reuse_file);

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -464,7 +464,7 @@ struct flush_stats
 
 extern int fileio_open (const char *vlabel, int flags, int mode);
 extern void fileio_close (int vdes);
-extern void fileio_cache_dump ();
+extern void fileio_cache_dump (THREAD_ENTRY * thread_p);
 extern int fileio_format (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel, VOLID volid,
 			  DKNPAGES npages, bool sweep_clean, bool dolock, bool dosync, size_t page_size,
 			  int kbytes_to_be_written_per_sec, bool reuse_file);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2900,6 +2900,11 @@ error:
   cubthread::finalize ();
 #endif /* SA_MODE */
 
+  if (prm_get_bool_value (PRM_ID_DUMP_FILE_CACHE))
+    {
+      fileio_cache_dump ();
+    }
+
   return error_code;
 }
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2385,10 +2385,10 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 	}
     }
 
-  if (prm_get_bool_value (PRM_ID_DUMP_FILE_CACHE))
-    {
-      fileio_cache_dump (thread_p);
-    }
+//  if (prm_get_bool_value (PRM_ID_DUMP_FILE_CACHE))
+//    {
+//      fileio_cache_dump (thread_p);
+//    }
 
   /* Initialize the transaction table */
   logtb_define_trantable (thread_p, -1, -1);
@@ -2852,6 +2852,11 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   json_set_alloc_funcs (malloc, free);
 #endif
 
+  if (prm_get_bool_value (PRM_ID_DUMP_FILE_CACHE))
+    {
+      fileio_cache_dump (thread_p);
+    }
+
   return NO_ERROR;
 
 error:
@@ -2875,11 +2880,6 @@ error:
   if (tran_index != NULL_TRAN_INDEX)
     {
       logtb_free_tran_index (thread_p, tran_index);
-    }
-
-  if (prm_get_bool_value (PRM_ID_DUMP_FILE_CACHE))
-    {
-      fileio_cache_dump (thread_p);
     }
 
   session_states_finalize (thread_p);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2385,6 +2385,11 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 	}
     }
 
+  if (prm_get_bool_value (PRM_ID_DUMP_FILE_CACHE))
+    {
+      fileio_cache_dump (thread_p);
+    }
+
   /* Initialize the transaction table */
   logtb_define_trantable (thread_p, -1, -1);
 
@@ -2872,6 +2877,11 @@ error:
       logtb_free_tran_index (thread_p, tran_index);
     }
 
+  if (prm_get_bool_value (PRM_ID_DUMP_FILE_CACHE))
+    {
+      fileio_cache_dump (thread_p);
+    }
+
   session_states_finalize (thread_p);
   logtb_finalize_global_unique_stats_table (thread_p);
 
@@ -2899,11 +2909,6 @@ error:
 #if defined (SA_MODE)
   cubthread::finalize ();
 #endif /* SA_MODE */
-
-  if (prm_get_bool_value (PRM_ID_DUMP_FILE_CACHE))
-    {
-      fileio_cache_dump ();
-    }
 
   return error_code;
 }

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2385,11 +2385,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 	}
     }
 
-//  if (prm_get_bool_value (PRM_ID_DUMP_FILE_CACHE))
-//    {
-//      fileio_cache_dump (thread_p);
-//    }
-
   /* Initialize the transaction table */
   logtb_define_trantable (thread_p, -1, -1);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-134

Added a new hidden system parameter 'dump_fileio_cache_after_boot' used to dump cached volume information at the end of boot.
This a boolean parameter with the default value set on false.

Example of parameter output:
```
Time: 07/06/21 12:15:54.945 - DEBUG *** file /home/adrian/cubridScalabil/cubrid/src/storage/file_io.c, line 2123
Cached volume with volid=-2, vdes=110, label=/home/adrian/cubridScalabil/db/testdb/testdb_lgat

Time: 07/06/21 12:15:54.945 - DEBUG *** file /home/adrian/cubridScalabil/cubrid/src/storage/file_io.c, line 2123
Cached volume with volid=-21, vdes=113, label=/home/adrian/cubridScalabil/db/testdb/testdb_lgar_t

Time: 07/06/21 12:15:54.945 - DEBUG *** file /home/adrian/cubridScalabil/cubrid/src/storage/file_io.c, line 2123
Cached volume with volid=0, vdes=111, label=/home/adrian/cubridScalabil/db/testdb/testdb
```