### PR TITLE
[LETS-59] Recovery speedup by caching log pages in log page buffer

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -754,14 +754,16 @@ logpb_invalidate_pool (THREAD_ENTRY * thread_p)
 
   /*
    * Flush any append dirty buffers at this moment.
-   * Then, invalidate any buffer that it is not fixed and dirty
    */
   logpb_flush_pages_direct (thread_p);
 
+  /*
+   * Invalidate any buffer that is not fixed.
+   */
   for (i = 0; i < log_Pb.num_buffers; i++)
     {
       log_bufptr = LOGPB_FIND_BUFPTR (i);
-      if (log_bufptr->pageid != NULL_PAGEID && !log_bufptr->dirty == false)
+      if (log_bufptr->pageid != NULL_PAGEID)
 	{
 	  logpb_initialize_log_buffer (log_bufptr, log_bufptr->logpage);
 	}

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -758,7 +758,7 @@ logpb_invalidate_pool (THREAD_ENTRY * thread_p)
   logpb_flush_pages_direct (thread_p);
 
   /*
-   * Invalidate any buffer that is not fixed.
+   * Invalidate all buffers.
    */
   for (i = 0; i < log_Pb.num_buffers; i++)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-59

Function `logpb_copy_page` function first checks if the page is in log page buffer (`pageid` must match with the corresponding slot). If this does not match, then the page is read from disk (or, in the scalability setup, from the page server).
After reading the page from storage (disk or page server), logic attempts to save the page in the log page buffer using a "highest page id" criteria.
