### PR TITLE
[LETS-155] Regression in function logpb_fetch_header_from_file_or_page_server due to ASSSERT_ERROR

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1632,6 +1632,10 @@ logpb_fetch_header_from_file_or_page_server (THREAD_ENTRY * thread_p, const char
   if (is_tran_server_with_remote_storage ())
     {
       res_code = logpb_fetch_header_from_page_server (hdr, log_pgptr);
+      if (res_code != NO_ERROR)
+	{
+	  ASSERT_ERROR ();
+	}
     }
   else
     {
@@ -1643,7 +1647,6 @@ logpb_fetch_header_from_file_or_page_server (THREAD_ENTRY * thread_p, const char
 
   if (res_code != NO_ERROR)
     {
-      ASSERT_ERROR ();
       return res_code;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-155

When function logpb_fetch_header_from_file_or_page_server was added to fork between retrieving log header from either local storage or page server, an ASSERT_ERROR was added. It is only needed for the _from_page_server part.
