### PR TITLE
[CBRD-24003] When creating the view table, the IN operation is violated because the subquery's order by clause column is automatically added to select list.

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1104,6 +1104,7 @@ pt_mark_location (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *conti
 PT_NODE *
 pt_set_is_view_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
 {
+  bool do_not_replace_orderby = (bool *) arg ? *((bool *) arg) : false;
   if (!node)
     {
       return node;
@@ -1114,6 +1115,11 @@ pt_set_is_view_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *co
       /* Reset query id # */
       node->info.query.id = (UINTPTR) node;
       node->info.query.is_view_spec = 1;
+
+      if (do_not_replace_orderby)
+	{
+	  node->flag.do_not_replace_orderby = 1;
+	}
     }
 
   return node;

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1136,11 +1136,6 @@ pt_set_is_view_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *co
 PT_NODE *
 pt_set_do_not_replace_orderby (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
 {
-  if (!node)
-    {
-      return node;
-    }
-
   if (pt_is_query (node))
     {
       node->flag.do_not_replace_orderby = 1;

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1126,6 +1126,30 @@ pt_set_is_view_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *co
 }				/* pt_set_is_view_spec */
 
 /*
+ * pt_set_is_view_spec () -
+ *   return:
+ *   parser(in):
+ *   node(in):
+ *   arg(in):
+ *   continue_walk(in):
+ */
+PT_NODE *
+pt_set_do_not_replace_orderby (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
+{
+  if (!node)
+    {
+      return node;
+    }
+
+  if (pt_is_query (node))
+    {
+      node->flag.do_not_replace_orderby = 1;
+    }
+
+  return node;
+}
+
+/*
  * pt_bind_names_post() -  bind names & path expressions of this statement node
  *   return:  node
  *   parser(in): the parser context

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1126,7 +1126,7 @@ pt_set_is_view_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *co
 }				/* pt_set_is_view_spec */
 
 /*
- * pt_set_is_view_spec () -
+ * pt_set_do_not_replace_orderby () -
  *   return:
  *   parser(in):
  *   node(in):

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1126,25 +1126,6 @@ pt_set_is_view_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *co
 }				/* pt_set_is_view_spec */
 
 /*
- * pt_set_do_not_replace_orderby () -
- *   return:
- *   parser(in):
- *   node(in):
- *   arg(in):
- *   continue_walk(in):
- */
-PT_NODE *
-pt_set_do_not_replace_orderby (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
-{
-  if (pt_is_query (node))
-    {
-      node->flag.do_not_replace_orderby = 1;
-    }
-
-  return node;
-}
-
-/*
  * pt_bind_names_post() -  bind names & path expressions of this statement node
  *   return:  node
  *   parser(in): the parser context

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -386,6 +386,8 @@ extern "C"
   DB_ATTRIBUTE *db_get_attributes_force (DB_OBJECT * obj);
 
   extern PT_NODE *pt_set_is_view_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *dummy, int *continue_walk);
+  extern PT_NODE *pt_set_do_not_replace_orderby (PARSER_CONTEXT * parser, PT_NODE * node, void *dummy,
+						 int *continue_walk);
 
   extern PT_NODE *pt_resolve_star (PARSER_CONTEXT * parser, PT_NODE * from, PT_NODE * attr);
 

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -386,8 +386,6 @@ extern "C"
   DB_ATTRIBUTE *db_get_attributes_force (DB_OBJECT * obj);
 
   extern PT_NODE *pt_set_is_view_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *dummy, int *continue_walk);
-  extern PT_NODE *pt_set_do_not_replace_orderby (PARSER_CONTEXT * parser, PT_NODE * node, void *dummy,
-						 int *continue_walk);
 
   extern PT_NODE *pt_resolve_star (PARSER_CONTEXT * parser, PT_NODE * from, PT_NODE * attr);
 

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7986,7 +7986,8 @@ pt_check_create_view (PARSER_CONTEXT * parser, PT_NODE * stmt)
       /* TODO This seems to flag too many queries as view specs because it also traverses the tree to subqueries. It
        * might need a pre_function that returns PT_STOP_WALK for subqueries. */
       do_not_replace_orderby = true;
-      result_stmt = parser_walk_tree (parser, crt_qry, pt_set_is_view_spec, (void *) &do_not_replace_orderby, NULL, NULL);
+      result_stmt =
+	parser_walk_tree (parser, crt_qry, pt_set_is_view_spec, (void *) &do_not_replace_orderby, NULL, NULL);
       if (result_stmt == NULL)
 	{
 	  assert (false);

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7928,6 +7928,7 @@ pt_check_create_view (PARSER_CONTEXT * parser, PT_NODE * stmt)
   PT_NODE *prev_qry;
   const char *name = NULL;
   int attr_count = 0;
+  bool do_not_replace_orderby;
 
   assert (parser != NULL);
 
@@ -7984,7 +7985,8 @@ pt_check_create_view (PARSER_CONTEXT * parser, PT_NODE * stmt)
 
       /* TODO This seems to flag too many queries as view specs because it also traverses the tree to subqueries. It
        * might need a pre_function that returns PT_STOP_WALK for subqueries. */
-      result_stmt = parser_walk_tree (parser, crt_qry, pt_set_is_view_spec, NULL, NULL, NULL);
+      do_not_replace_orderby = true;
+      result_stmt = parser_walk_tree (parser, crt_qry, pt_set_is_view_spec, (void *) &do_not_replace_orderby, NULL, NULL);
       if (result_stmt == NULL)
 	{
 	  assert (false);
@@ -7993,7 +7995,6 @@ pt_check_create_view (PARSER_CONTEXT * parser, PT_NODE * stmt)
 	}
       crt_qry = result_stmt;
 
-      crt_qry->flag.do_not_replace_orderby = 1;
       result_stmt = pt_semantic_check (parser, crt_qry);
       if (pt_has_error (parser))
 	{

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7406,7 +7406,7 @@ pt_check_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_NODE * at
 
   if (do_semantic_check)
     {
-      qry->flag.do_not_replace_orderby = 1;
+      (void) parser_walk_tree (parser, qry, pt_set_do_not_replace_orderby, NULL, NULL, NULL);
       qry = pt_semantic_check (parser, qry);
       if (pt_has_error (parser) || qry == NULL)
 	{

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7406,7 +7406,6 @@ pt_check_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_NODE * at
 
   if (do_semantic_check)
     {
-      (void) parser_walk_tree (parser, qry, pt_set_do_not_replace_orderby, NULL, NULL, NULL);
       qry = pt_semantic_check (parser, qry);
       if (pt_has_error (parser) || qry == NULL)
 	{
@@ -13473,6 +13472,7 @@ pt_validate_query_spec (PARSER_CONTEXT * parser, PT_NODE * s, DB_OBJECT * c)
 {
   PT_NODE *attrs = NULL;
   int error_code = NO_ERROR;
+  bool do_not_replace_orderby;
 
   assert (parser != NULL && s != NULL && c != NULL);
 
@@ -13491,7 +13491,8 @@ pt_validate_query_spec (PARSER_CONTEXT * parser, PT_NODE * s, DB_OBJECT * c)
       goto error_exit;
     }
 
-  s = parser_walk_tree (parser, s, pt_set_is_view_spec, NULL, NULL, NULL);
+  do_not_replace_orderby = true;
+  s = parser_walk_tree (parser, s, pt_set_is_view_spec, (void *) &do_not_replace_orderby, NULL, NULL);
   assert (s != NULL);
 
   attrs = pt_get_attributes (parser, c);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24003

I fixed to set do_not_replace_orderby flag to 1 in the subquery using parser_walk_tree ()
