### PR TITLE
[LETS-156] Fix page for recovery redo without reservation check

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -22447,13 +22447,6 @@ btree_rv_redo_global_unique_stats_commit (THREAD_ENTRY * thread_p, const LOG_RCV
   num_keys = OR_GET_INT (datap);
   datap += OR_INT_SIZE;
 
-  /* Because this log record is logical, it will be processed even if the B-tree was deleted. If the B-tree was deleted
-   * then skip update of unique statistics in global hash. */
-  if (disk_is_page_sector_reserved (thread_p, btid.vfid.volid, btid.root_pageid) != DISK_VALID)
-    {
-      /* The B-tree was already deleted */
-      return NO_ERROR;
-    }
   if (logtb_rv_update_global_unique_stats_by_abs (thread_p, &btid, num_oids, num_nulls, num_keys) != NO_ERROR)
     {
       goto error;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1111,7 +1111,7 @@ STATIC_INLINE void pgbuf_wakeup_reader_writer (THREAD_ENTRY * thread_p, PGBUF_BC
 
 STATIC_INLINE bool pgbuf_get_check_page_validation_level (int page_validation_level) __attribute__ ((ALWAYS_INLINE));
 static bool pgbuf_is_valid_page_ptr (const PAGE_PTR pgptr);
-STATIC_INLINE void pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr, bool force_set_vpid) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE bool pgbuf_check_bcb_page_vpid (PGBUF_BCB * bufptr, bool maybe_deallocated)
   __attribute__ ((ALWAYS_INLINE));
 
@@ -1844,7 +1844,7 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
   bool had_holder = false;
 #endif /* !NDEBUG */
   PGBUF_FIX_PERF perf;
-  bool maybe_deallocated, force_set_vpid;
+  bool maybe_deallocated;
   int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[tran_index];
 
@@ -1984,8 +1984,7 @@ try_again:
 
   /* Set Page identifier if needed */
   // Redo recovery may find an immature page which should be set.
-  force_set_vpid = (fetch_mode == NEW_PAGE && log_is_in_crash_recovery_and_not_yet_completes_redo ());
-  pgbuf_set_bcb_page_vpid (bufptr, force_set_vpid);
+  pgbuf_set_bcb_page_vpid (bufptr);
 
   maybe_deallocated = (fetch_mode == OLD_PAGE_MAYBE_DEALLOCATED);
   if (pgbuf_check_bcb_page_vpid (bufptr, maybe_deallocated) != true)
@@ -2117,6 +2116,7 @@ try_again:
 	case NEW_PAGE:
 	case OLD_PAGE_DEALLOCATED:
 	case OLD_PAGE_IF_IN_BUFFER:
+	case RECOVERY_PAGE:
 	  /* fixing deallocated page is expected. fall through to return it. */
 	  break;
 	case OLD_PAGE:
@@ -4839,12 +4839,11 @@ pgbuf_set_lsa_as_temporary (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
  * pgbuf_set_bcb_page_vpid () -
  *   return: void
  *   bufptr(in): pointer to buffer page
- *   force_set_vpid(in): true, if forces VPID setting
  *
  * Note: This function is used for debugging.
  */
 STATIC_INLINE void
-pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr, bool force_set_vpid)
+pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr)
 {
   if (bufptr == NULL || VPID_ISNULL (&bufptr->vpid))
     {
@@ -4857,14 +4856,14 @@ pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr, bool force_set_vpid)
   if (bufptr->vpid.volid > NULL_VOLID)
     {
       /* Check if is the first time */
-      if (force_set_vpid
-	  || (bufptr->iopage_buffer->iopage.prv.pageid == -1 && bufptr->iopage_buffer->iopage.prv.volid == -1))
+      if (bufptr->iopage_buffer->iopage.prv.pageid == NULL_PAGEID
+	  && bufptr->iopage_buffer->iopage.prv.volid == NULL_VOLID)
 	{
 	  /* Set Page identifier */
 	  bufptr->iopage_buffer->iopage.prv.pageid = bufptr->vpid.pageid;
 	  bufptr->iopage_buffer->iopage.prv.volid = bufptr->vpid.volid;
 
-	  bufptr->iopage_buffer->iopage.prv.ptype = '\0';
+	  bufptr->iopage_buffer->iopage.prv.ptype = PAGE_UNKNOWN;
 	  bufptr->iopage_buffer->iopage.prv.p_reserve_1 = 0;
 	  bufptr->iopage_buffer->iopage.prv.p_reserve_2 = 0;
 	  bufptr->iopage_buffer->iopage.prv.tde_nonce = 0;
@@ -4900,7 +4899,7 @@ pgbuf_set_page_ptype (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PAGE_TYPE ptype)
   assert (!VPID_ISNULL (&bufptr->vpid));
 
   /* Set Page identifier if needed */
-  pgbuf_set_bcb_page_vpid (bufptr, false);
+  pgbuf_set_bcb_page_vpid (bufptr);
 
   if (pgbuf_check_bcb_page_vpid (bufptr, false) != true)
     {

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -170,6 +170,8 @@ typedef enum
   OLD_PAGE_PREVENT_DEALLOC,	/* Fetch existing page and mark its memory buffer, to prevent deallocation. */
   OLD_PAGE_DEALLOCATED,		/* Fetch page that has been deallocated. */
   OLD_PAGE_MAYBE_DEALLOCATED,	/* Fetch page that maybe was deallocated. */
+  RECOVERY_PAGE			/* Fetch page for recovery. The page may be new, or deallocated or normal, everything
+				 * is possible really. */
 } PAGE_FETCH_MODE;
 
 /* public page latch mode */


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-156

Reduce redo recovery execution time by avoiding reservation check. The check proves to be very expensive, especially if redo recovery is parallelized.

The page fix for recovery redo is much simplified. Any type of page, new, deallocated or normal is accepted and redo is applied regardless of the page status. The same rule is \applied to updating b-tree statistics too.

A consequence is that pages are no longer fixed with NEW_PAGE fetch mode during redo recovery; therefore, setting VPID & resetting page type is no longer necessary.
