### PR TITLE
[LETS-158] Do not update minimum lsa monitoring during recovery

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -991,7 +991,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
    */
   LOG_CS_EXIT (thread_p);
   // *INDENT-OFF*
-  std::unique_ptr<cublog::minimum_log_lsa_monitor> minimum_log_lsa;
   std::unique_ptr<cublog::redo_parallel> parallel_recovery_redo;
 #if defined(SERVER_MODE)
   {
@@ -999,9 +998,8 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
     assert (log_recovery_redo_parallel_count >= 0);
     if (log_recovery_redo_parallel_count > 0)
       {
-	minimum_log_lsa.reset (new cublog::minimum_log_lsa_monitor ());
-	parallel_recovery_redo.reset (new cublog::redo_parallel (log_recovery_redo_parallel_count,
-								 *minimum_log_lsa.get ()));
+	parallel_recovery_redo.reset (
+	      new cublog::redo_parallel (log_recovery_redo_parallel_count, nullptr));
       }
   }
 #endif

--- a/src/transaction/log_recovery_redo_parallel.cpp
+++ b/src/transaction/log_recovery_redo_parallel.cpp
@@ -154,7 +154,7 @@ namespace cublog
    * redo_parallel::redo_job_queue - definition
    *********************************************************************/
 
-  redo_parallel::redo_job_queue::redo_job_queue (minimum_log_lsa_monitor &a_minimum_log_lsa)
+  redo_parallel::redo_job_queue::redo_job_queue (minimum_log_lsa_monitor *a_minimum_log_lsa)
     : m_produce_queue (new ux_redo_job_deque ())
     , m_consume_queue (new ux_redo_job_deque ())
     , m_queues_empty (true)
@@ -178,9 +178,9 @@ namespace cublog
   redo_parallel::redo_job_queue::push_job (ux_redo_job_base &&job)
   {
     std::lock_guard<std::mutex> lockg (m_produce_queue_mutex);
-    if (m_produce_queue->empty ())
+    if (m_minimum_log_lsa != nullptr && m_produce_queue->empty ())
       {
-	m_minimum_log_lsa.set_for_produce (job->get_log_lsa ());
+	m_minimum_log_lsa->set_for_produce (job->get_log_lsa ());
       }
     m_produce_queue->push_back (std::move (job));
     m_queues_empty = false;
@@ -274,12 +274,15 @@ namespace cublog
 	  m_queues_empty = m_produce_queue->empty () && m_consume_queue->empty ();
 	  notify_queues_empty = m_queues_empty;
 
-	  // lsa's are ever incresing
-	  const log_lsa produce_minimum_log_lsa =
-		  m_produce_queue->empty () ? MAX_LSA : (*m_produce_queue->begin ())->get_log_lsa ();
-	  const log_lsa consume_minimum_log_lsa =
-		  m_consume_queue->empty () ? MAX_LSA : (* m_consume_queue->begin ())->get_log_lsa ();
-	  m_minimum_log_lsa.set_for_produce_and_consume (produce_minimum_log_lsa, consume_minimum_log_lsa);
+	  if (m_minimum_log_lsa != nullptr)
+	    {
+	      // lsa's are ever incresing
+	      const log_lsa produce_minimum_log_lsa =
+		      m_produce_queue->empty () ? MAX_LSA : (*m_produce_queue->begin ())->get_log_lsa ();
+	      const log_lsa consume_minimum_log_lsa =
+		      m_consume_queue->empty () ? MAX_LSA : (* m_consume_queue->begin ())->get_log_lsa ();
+	      m_minimum_log_lsa->set_for_produce_and_consume (produce_minimum_log_lsa, consume_minimum_log_lsa);
+	    }
 	}
 	if (notify_queues_empty)
 	  {
@@ -303,20 +306,23 @@ namespace cublog
 
 	    do_locked_mark_job_in_progress (a_in_progress_lockg, job);
 
-	    const log_lsa consume_minimum_log_lsa =
-		    m_consume_queue->empty () ? MAX_LSA : (* m_consume_queue->begin ())->get_log_lsa ();
-	    // mark transition in one go for consistency
-	    // if:
-	    //  - first the consume is being changed (or even cleared)
-	    //  - then, separately, the in-progress is updated
-	    // the following might happen:
-	    //  - suppose that there is only one job left in the consume queue, everything else is empty
-	    //  - the minimum value for the consume queue would be cleared
-	    //  - at this point, the minimum log lsa will actually be MAX_LSA
-	    //  - while there is actually one more job (that has just been taken out of the consume queue
-	    //    and is to be transferred to the in progress set)
-	    m_minimum_log_lsa.set_for_consume_and_in_progress (
-		    consume_minimum_log_lsa, *m_in_progress_lsas.cbegin ());
+	    if (m_minimum_log_lsa != nullptr)
+	      {
+		const log_lsa consume_minimum_log_lsa =
+			m_consume_queue->empty () ? MAX_LSA : (* m_consume_queue->begin ())->get_log_lsa ();
+		// mark transition in one go for consistency
+		// if:
+		//  - first the consume is being changed (or even cleared)
+		//  - then, separately, the in-progress is updated
+		// the following might happen:
+		//  - suppose that there is only one job left in the consume queue, everything else is empty
+		//  - the minimum value for the consume queue would be cleared
+		//  - at this point, the minimum log lsa will actually be MAX_LSA
+		//  - while there is actually one more job (that has just been taken out of the consume queue
+		//    and is to be transferred to the in progress set)
+		m_minimum_log_lsa->set_for_consume_and_in_progress (
+			consume_minimum_log_lsa, *m_in_progress_lsas.cbegin ());
+	      }
 
 	    return job;
 	  }
@@ -360,10 +366,13 @@ namespace cublog
       assert (log_lsa_it != m_in_progress_lsas.cend ());
       m_in_progress_lsas.erase (log_lsa_it);
 
-      const log_lsa in_progress_minimum_log_lsa = m_in_progress_lsas.empty ()
-	  ? MAX_LSA
-	  : *m_in_progress_lsas.cbegin ();
-      m_minimum_log_lsa.set_for_in_progress (in_progress_minimum_log_lsa);
+      if (m_minimum_log_lsa != nullptr)
+	{
+	  const log_lsa in_progress_minimum_log_lsa = m_in_progress_lsas.empty ()
+	      ? MAX_LSA
+	      : *m_in_progress_lsas.cbegin ();
+	  m_minimum_log_lsa->set_for_in_progress (in_progress_minimum_log_lsa);
+	}
 
       assert (m_in_progress_vpids.size () == m_in_progress_lsas.size ());
     }
@@ -563,7 +572,7 @@ namespace cublog
    * redo_parallel - definition
    *********************************************************************/
 
-  redo_parallel::redo_parallel (unsigned a_worker_count, minimum_log_lsa_monitor &a_minimum_log_lsa)
+  redo_parallel::redo_parallel (unsigned a_worker_count, minimum_log_lsa_monitor *a_minimum_log_lsa)
     : m_task_count { a_worker_count }
     , m_worker_pool (nullptr)
     , m_job_queue { a_minimum_log_lsa }

--- a/src/transaction/log_recovery_redo_parallel.hpp
+++ b/src/transaction/log_recovery_redo_parallel.hpp
@@ -113,7 +113,7 @@ namespace cublog
     public:
       /* - worker_count: the number of parallel tasks to spin that consume jobs
        */
-      redo_parallel (unsigned a_worker_count, minimum_log_lsa_monitor &a_minimum_log_lsa);
+      redo_parallel (unsigned a_worker_count, minimum_log_lsa_monitor *a_minimum_log_lsa);
 
       redo_parallel (const redo_parallel &) = delete;
       redo_parallel (redo_parallel &&) = delete;
@@ -162,7 +162,7 @@ namespace cublog
 	  using log_lsa_set = std::set<log_lsa>;
 
 	public:
-	  redo_job_queue (minimum_log_lsa_monitor &a_minimum_log_lsa);
+	  redo_job_queue (minimum_log_lsa_monitor *a_minimum_log_lsa);
 	  ~redo_job_queue ();
 
 	  redo_job_queue (redo_job_queue const &) = delete;
@@ -252,10 +252,9 @@ namespace cublog
 	  mutable std::condition_variable m_in_progress_vpids_empty_cv;
 
 	  /* utility class to maintain a minimum log_lsa that is still
-	   * to be processed (consumed); if no job exists in the queue, the
-	   * value is null
+	   * to be processed (consumed); non-owning pointer, can be null
 	   */
-	  minimum_log_lsa_monitor &m_minimum_log_lsa;
+	  minimum_log_lsa_monitor *m_minimum_log_lsa;
       };
 
       /* maintain a bookkeeping of tasks that are still performing work;

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -54,7 +54,7 @@ namespace cublog
 	m_minimum_log_lsa.reset (new cublog::minimum_log_lsa_monitor ());
 	// no need to reset with start redo lsa
 
-	m_parallel_replication_redo.reset (new cublog::redo_parallel (replication_parallel, *m_minimum_log_lsa.get ()));
+	m_parallel_replication_redo.reset (new cublog::redo_parallel (replication_parallel, m_minimum_log_lsa.get ()));
       }
 
     // Create the daemon

--- a/unit_tests/log/test_main_log_recovery_parallel.cpp
+++ b/unit_tests/log/test_main_log_recovery_parallel.cpp
@@ -68,7 +68,7 @@ void execute_test (const log_recovery_test_config &a_test_config,
     }
 
   cublog::minimum_log_lsa_monitor minimum_log_lsa;
-  cublog::redo_parallel log_redo_parallel (a_test_config.parallel_count, minimum_log_lsa);
+  cublog::redo_parallel log_redo_parallel (a_test_config.parallel_count, &minimum_log_lsa);
 
   ux_ut_database db_online { new ut_database (a_database_config) };
   ux_ut_database db_recovery { new ut_database (a_database_config) };
@@ -202,7 +202,7 @@ TEST_CASE ("log recovery parallel test: idle status", "[ci]")
   initialize_thread_infrastructure ();
 
   cublog::minimum_log_lsa_monitor minimum_log_lsa;
-  cublog::redo_parallel log_redo_parallel (std::thread::hardware_concurrency (), minimum_log_lsa);
+  cublog::redo_parallel log_redo_parallel (std::thread::hardware_concurrency (), &minimum_log_lsa);
 
   REQUIRE (log_redo_parallel.is_idle ());
   REQUIRE (minimum_log_lsa.get () == MAX_LSA);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-158

The mechanism to monitor the recovery/replication progress via monitoring the minimum unreplicated `log_lsa` is only of use for the replication scenario. Thus, dead weight, on the recovery scenario.

NOTE: this is preliminary modification that just disables it; a refactoring will be needed when the internal implementation of `redo_parallel::redo_job_queue` will change with the next PR;
