### PR TITLE
[LETS-159] Add request server start/stop thread error logging

### DIFF
--- a/src/communication/request_client_server.cpp
+++ b/src/communication/request_client_server.cpp
@@ -66,4 +66,27 @@ namespace cubcomm
   {
     return er_log_sendrecv_fail ("Receive", chn, err);
   }
+
+  static void
+  er_log_thread_start_or_finish (const void *instance_ptr, const void *thread_ptr, std::thread::id thread_id,
+				 const char *action_str)
+  {
+    if (prm_get_bool_value (PRM_ID_ER_LOG_COMM_REQUEST))
+      {
+	_er_log_debug (ARG_FILE_LINE, "[COMM REQUEST] Thread ptr=%p, id=%d on instance_p=%p %s.\n", thread_ptr,
+		       thread_id, instance_ptr, action_str);
+      }
+  }
+
+  void
+  er_log_thread_started (const void *instance_ptr, const void *thread_ptr, std::thread::id thread_id)
+  {
+    er_log_thread_start_or_finish (instance_ptr, thread_ptr, thread_id, "started");
+  }
+
+  void
+  er_log_thread_finished (const void *instance_ptr, const void *thread_ptr, std::thread::id thread_id)
+  {
+    er_log_thread_start_or_finish (instance_ptr, thread_ptr, thread_id, "finished");
+  }
 }

--- a/src/communication/request_client_server.hpp
+++ b/src/communication/request_client_server.hpp
@@ -217,6 +217,8 @@ namespace cubcomm
   void er_log_recv_request (const channel &chn, int msgid, size_t size);
   void er_log_send_fail (const channel &chn, css_error_code err);
   void er_log_recv_fail (const channel &chn, css_error_code err);
+  void er_log_thread_started (const void *instance_ptr, const void *thread_ptr, std::thread::id thread_id);
+  void er_log_thread_finished (const void *instance_ptr, const void *thread_ptr, std::thread::id thread_id);
 }
 
 namespace cubcomm
@@ -280,6 +282,8 @@ namespace cubcomm
 
     m_shutdown = false;
     m_thread = std::thread (&request_server::loop_handle_requests, std::ref (*this));
+
+    er_log_thread_started (this, &m_thread, m_thread.get_id ());
   }
 
   template <typename MsgId>
@@ -314,6 +318,7 @@ namespace cubcomm
 	  }
 	handle_request (message_buffer, message_size);
       }
+    er_log_thread_finished (this, &m_thread, m_thread.get_id ());
   }
 
   template <typename MsgId>

--- a/unit_tests/request_client_server/CMakeLists.txt
+++ b/unit_tests/request_client_server/CMakeLists.txt
@@ -21,10 +21,12 @@ project (request_client_server)
 set (TEST_REQUEST_CS_SOURCES
   ${BASE_DIR}/mem_block.cpp
   ${BASE_DIR}/packer.cpp
+  ${COMMUNICATION_DIR}/request_client_server.cpp
   comm_channel_mock.cpp
   test_main.cpp
   )
 set (TEST_REQUEST_CS_HEADERS
+  ${COMMUNICATION_DIR}/request_client_server.hpp
   comm_channel_mock.hpp
   )
 

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -963,30 +963,3 @@ or_unpack_value (const char *buf, DB_VALUE *value)
 {
   return nullptr;
 }
-
-namespace cubcomm
-{
-  void
-  er_log_send_request (const channel &chn, int msgid, size_t size)
-  {
-
-  }
-
-  void
-  er_log_recv_request (const channel &chn, int msgid, size_t size)
-  {
-
-  }
-
-  void
-  er_log_send_fail (const channel &chn, css_error_code err)
-  {
-
-  }
-
-  void
-  er_log_recv_fail (const channel &chn, css_error_code err)
-  {
-
-  }
-}


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-159

Add error log messages when the request server is started and stopped. The message include information like the object address and the thread id.

It was originally incorporated into LETS-148 to investigate an issue that didn't reproduce a second time. It should help future efforts to reproduce and investigate it.
