### PR TITLE
[LETS-160] Redoing unreserve sector doesn't wait for redoing other log records

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1864,7 +1864,7 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
 
   ATOMIC_INC_32 (&pgbuf_Pool.monitor.fix_req_cnt, 1);
 
-  if (pgbuf_get_check_page_validation_level (PGBUF_DEBUG_PAGE_VALIDATION_FETCH))
+  if (pgbuf_get_check_page_validation_level (PGBUF_DEBUG_PAGE_VALIDATION_FETCH) && fetch_mode != RECOVERY_PAGE)
     {
       /* Make sure that the page has been allocated (i.e., is a valid page) */
       /* Suppress errors if fetch mode is OLD_PAGE_IF_IN_BUFFER. */

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -507,8 +507,7 @@ log_rv_need_sync_redo (const vpid & a_rcv_vpid, LOG_RCVINDEX a_rcvindex)
       return true;
     case RVDK_RESERVE_SECTORS:
     case RVDK_UNRESERVE_SECTORS:
-      // When sectors are unreserved, redo ops on these pages are not applied.
-      // Sector reservation is handled synchronously for better control
+      // Sector reservation is handled synchronously for better control; may be changed to async
       return true;
     default:
       return false;

--- a/src/transaction/log_recovery_redo_parallel.hpp
+++ b/src/transaction/log_recovery_redo_parallel.hpp
@@ -513,7 +513,6 @@ log_rv_redo_record_sync_or_dispatch_async (
 #if defined(SERVER_MODE)
   const LOG_DATA &log_data = log_rv_get_log_rec_data<T> (log_rec);
   const bool need_sync_redo = log_rv_need_sync_redo (rcv_vpid, log_data.rcvindex);
-  assert (log_data.rcvindex != RVDK_UNRESERVE_SECTORS || need_sync_redo);
 
   // once vpid is extracted (or not), and depending on parameters, either dispatch the applying of
   // log redo asynchronously, or invoke synchronously

--- a/src/transaction/log_recovery_redo_parallel.hpp
+++ b/src/transaction/log_recovery_redo_parallel.hpp
@@ -519,21 +519,9 @@ log_rv_redo_record_sync_or_dispatch_async (
   // log redo asynchronously, or invoke synchronously
   if (parallel_recovery_redo == nullptr || need_sync_redo)
     {
-      // To apply RVDK_UNRESERVE_SECTORS, one must first wait for all changes in this sector to be redone.
-      // Otherwise, asynchronous jobs skip redoing changes in this sector's pages because they are seen as
-      // deallocated. When the same sector is reserved again, redo is resumed in the sector's pages, but
-      // the pages are not in a consistent state. The current workaround is to wait for all changes to be
-      // finished, including changes in the unreserved sector.
-      if (parallel_recovery_redo != nullptr && log_data.rcvindex == RVDK_UNRESERVE_SECTORS)
-	{
-	  parallel_recovery_redo->wait_for_idle ();
-	}
-#endif
-
       // invoke sync
       log_rv_redo_record_sync<T> (thread_p, log_pgptr_reader, log_rec, rcv_vpid, rcv_lsa, end_redo_lsa, log_rtype,
 				  undo_unzip_support, redo_unzip_support);
-#if defined(SERVER_MODE)
     }
   else
     {
@@ -545,7 +533,10 @@ log_rv_redo_record_sync_or_dispatch_async (
       };
       parallel_recovery_redo->add (std::move (job));
     }
-#endif
+#else // !SERVER_MODE = SA_MODE
+  log_rv_redo_record_sync<T> (thread_p, log_pgptr_reader, log_rec, rcv_vpid, rcv_lsa, end_redo_lsa, log_rtype,
+			      undo_unzip_support, redo_unzip_support);
+#endif // !SERVER_MODE = SA_MODE
 }
 
 #endif // _LOG_RECOVERY_REDO_PARALLEL_HPP_


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-160

As a consequence of the fact that redoing log records is no longer skipped if the page belongs to a not-reserved sector, un-reserving a sector does not have to wait for the log records to be applied.

**Implementation**
- Remove the `wait_for_idle()` for RVDK_UNRESERVE_SECTORS
- Remove safe-guard and update comment because reserve/unreserve are no longer required to by applied on sync; left it as sync because it is offers better control and possibly better performance.
- Don't do valid check when pages are fetched for recovery; they may be unreserved when redo is applied.
- Re-written SERVER_MODE/SA_MODE separation to make each flow more readable.
