### PR TITLE
[CBRD-23990] revised: Redesign of query cache management to handle the plan cache overflown

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -373,8 +373,11 @@ qfile_list_cache_cleanup (THREAD_ENTRY * thread_p)
 	}
     }
 
-  /* traverse in reverse for weight ordering, from light weight to heavy weight */
-  for (candidate_index = bh->element_count - 1; candidate_index >= 0; candidate_index--)
+  /* need to sort before traverse */
+  bh_to_sorted_array (bh);
+
+  /* traverse for weight ordering, from light weight to heavy weight */
+  for (candidate_index = 0; candidate_index < bh->element_count; candidate_index++)
     {
       bh_element_at (bh, candidate_index, &candidate);
       qfile_delete_list_cache_entry (thread_p, candidate.qcache);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23990

This is a revised patch for #2854 

In the **qfile_list_cache_cleanup**, **bh_to_sorted_array**(bh) should be added for sorting before traverse candidate list (bh tree).
By the **bh_to_sorted_array**, the candidate list is sorted in order by weight.
