### PR TITLE
[CBRD-23990] patch 11.0.2: Redesign of query cache management to handle the plan cache overflown (#2854, #2892)

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -373,7 +373,7 @@ qfile_list_cache_cleanup (THREAD_ENTRY * thread_p)
 	}
     }
 
-  /* need to sort before traverse */
+  /* it needs to sort before traverse */
   bh_to_sorted_array (bh);
 
   /* traverse for weight ordering, from light weight to heavy weight */

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -373,8 +373,11 @@ qfile_list_cache_cleanup (THREAD_ENTRY * thread_p)
 	}
     }
 
-  /* traverse in reverse for weight ordering, from light weight to heavy weight */
-  for (candidate_index = bh->element_count - 1; candidate_index >= 0; candidate_index--)
+  /* need to sort before traverse */
+  bh_to_sorted_array (bh);
+
+  /* traverse for weight ordering, from light weight to heavy weight */
+  for (candidate_index = 0; candidate_index < bh->element_count; candidate_index++)
     {
       bh_element_at (bh, candidate_index, &candidate);
       qfile_delete_list_cache_entry (thread_p, candidate.qcache);

--- a/src/query/list_file.h
+++ b/src/query/list_file.h
@@ -98,6 +98,7 @@ struct qfile_list_cache_entry
   struct timeval time_last_used;	/* when this entry used lastly */
   int ref_count;		/* how many times this query used */
   bool deletion_marker;		/* this entry will be deleted if marker set */
+  bool invalidate;		/* related xcache entry is erased */
 };
 
 enum
@@ -153,18 +154,21 @@ extern QFILE_LIST_ID *qfile_sort_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * 
 /* Query result(list file) cache routines */
 extern int qfile_initialize_list_cache (THREAD_ENTRY * thread_p);
 extern int qfile_finalize_list_cache (THREAD_ENTRY * thread_p);
-extern int qfile_clear_list_cache (THREAD_ENTRY * thread_p, int list_ht_no);
+extern int qfile_clear_list_cache (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry, bool invalidate);
 extern int qfile_dump_list_cache_internal (THREAD_ENTRY * thread_p, FILE * fp);
 #if defined (CUBRID_DEBUG)
 extern int qfile_dump_list_cache (THREAD_ENTRY * thread_p, const char *fname);
 #endif
 /* query result(list file) cache entry manipulation functions */
 void qfile_clear_uncommited_list_cache_entry (THREAD_ENTRY * thread_p, int tran_index);
-QFILE_LIST_CACHE_ENTRY *qfile_lookup_list_cache_entry (THREAD_ENTRY * thread_p, int list_ht_no,
+QFILE_LIST_CACHE_ENTRY *qfile_lookup_list_cache_entry (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xasl,
 						       const DB_VALUE_ARRAY * params, bool * result_cached);
 QFILE_LIST_CACHE_ENTRY *qfile_update_list_cache_entry (THREAD_ENTRY * thread_p, int list_ht_no,
 						       const DB_VALUE_ARRAY * params, const QFILE_LIST_ID * list_id,
 						       XASL_CACHE_ENTRY * xasl);
+int qcache_get_new_ht_no (THREAD_ENTRY * thread_p);
+void qcache_free_ht_no (THREAD_ENTRY * thread_p, int ht_no);
+
 int qfile_end_use_of_list_cache_entry (THREAD_ENTRY * thread_p, QFILE_LIST_CACHE_ENTRY * lent, bool marker);
 
 /* Scan related routines */

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1392,8 +1392,8 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
       if (do_not_cache == false)
 	{
 	  /* lookup the list cache with the parameter values (DB_VALUE array) */
-	  list_cache_entry_p =
-	    qfile_lookup_list_cache_entry (thread_p, xasl_cache_entry_p->list_ht_no, &params, &cached_result);
+	  list_cache_entry_p = qfile_lookup_list_cache_entry (thread_p, xasl_cache_entry_p, &params, &cached_result);
+
 	  /* If we've got the cached result, return it. */
 	  if (cached_result)
 	    {
@@ -1507,7 +1507,7 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
   /* If it is allowed to cache the query result or if it is required to cache, put the list file id(QFILE_LIST_ID) into
    * the list cache. Provided are the corresponding XASL cache entry to be linked, and the parameters (host variables -
    * DB_VALUES). */
-  if (qmgr_is_allowed_result_cache (*flag_p) && do_not_cache == false)
+  if (qmgr_is_allowed_result_cache (*flag_p) && do_not_cache == false && xasl_cache_entry_p->list_ht_no >= 0)
     {
       /* check once more to ensure that the related XASL entry is still valid */
       if (xcache_can_entry_cache_list (xasl_cache_entry_p))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23990

This is a backport #2854 and #2892
