### PR TITLE
[CBRD-23925] When used as a function parameter, the original pointer variable is not initialized to NULL. (#2785)

### DIFF
--- a/src/parser/parse_evaluate.c
+++ b/src/parser/parse_evaluate.c
@@ -1305,7 +1305,7 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 		}
 	    }
 
-	  cursor_free_self_list_id ((QFILE_LIST_ID *) temp->etc);
+	  cursor_free_self_list_id (temp->etc);
 	  pt_end_query (parser, query_id_self);
 	}
       else

--- a/src/parser/query_result.c
+++ b/src/parser/query_result.c
@@ -1154,7 +1154,7 @@ pt_free_query_etc_area (PARSER_CONTEXT * parser, PT_NODE * query)
       && (pt_node_to_cmd_type (query) == CUBRID_STMT_SELECT || pt_node_to_cmd_type (query) == CUBRID_STMT_DO
 	  || pt_is_server_insert_with_generated_keys (parser, query)))
     {
-      cursor_free_self_list_id ((QFILE_LIST_ID *) query->etc);
+      cursor_free_self_list_id (query->etc);
     }
 }
 

--- a/src/query/cursor.c
+++ b/src/query/cursor.c
@@ -146,49 +146,6 @@ cursor_copy_list_id (QFILE_LIST_ID * dest_list_id_p, const QFILE_LIST_ID * src_l
 }
 
 /*
- * cursor_free_list_id () - Area allocated for list file identifier is freed
- *   return: nothing
- *   list_id: List file identifier
- */
-void
-cursor_free_list_id (QFILE_LIST_ID * list_id_p, bool self)
-{
-  if (list_id_p->last_pgptr)
-    {
-      free_and_init (list_id_p->last_pgptr);
-    }
-  if (list_id_p->tpl_descr.f_valp)
-    {
-      free_and_init (list_id_p->tpl_descr.f_valp);
-    }
-  if (list_id_p->tpl_descr.clear_f_val_at_clone_decache)
-    {
-      free_and_init (list_id_p->tpl_descr.clear_f_val_at_clone_decache);
-    }
-  if (list_id_p->sort_list)
-    {
-      free_and_init (list_id_p->sort_list);
-    }
-  if (list_id_p->type_list.domp)
-    {
-      free_and_init (list_id_p->type_list.domp);
-    }
-  if (self)
-    {
-      free_and_init (list_id_p);
-    }
-}
-
-void
-cursor_free_self_list_id (QFILE_LIST_ID * list_id)
-{
-  if (list_id != NULL)
-    {
-      cursor_free_list_id (list_id, true);
-    }
-}
-
-/*
  * cursor_has_set_vobjs () -
  *   return: nonzero iff set has some vobjs, zero otherwise
  *   seq(in): set/sequence db_value
@@ -1398,7 +1355,7 @@ cursor_free (CURSOR_ID * cursor_id_p)
       return;
     }
 
-  cursor_free_list_id (&cursor_id_p->list_id, false);
+  cursor_free_list_id (&(cursor_id_p->list_id));
 
   if (cursor_id_p->buffer_area != NULL)
     {

--- a/src/query/cursor.h
+++ b/src/query/cursor.h
@@ -83,8 +83,35 @@ struct cursor_id
 };
 
 extern int cursor_copy_list_id (QFILE_LIST_ID * dest_list_id, const QFILE_LIST_ID * src_list_id);
-extern void cursor_free_list_id (QFILE_LIST_ID * list_id, bool self);
-extern void cursor_free_self_list_id (QFILE_LIST_ID * list_id);
+
+#define cursor_free_list_id(list_id) \
+        do { \
+          QFILE_LIST_ID *list_id_p = (QFILE_LIST_ID *) (list_id); \
+          if (list_id_p != NULL) { \
+            if (list_id_p->last_pgptr) { \
+              free_and_init (list_id_p->last_pgptr); \
+            } \
+            if (list_id_p->tpl_descr.f_valp) { \
+              free_and_init (list_id_p->tpl_descr.f_valp); \
+            } \
+            if (list_id_p->tpl_descr.clear_f_val_at_clone_decache) { \
+              free_and_init (list_id_p->tpl_descr.clear_f_val_at_clone_decache); \
+            } \
+            if (list_id_p->sort_list) { \
+              free_and_init (list_id_p->sort_list); \
+            } \
+            if (list_id_p->type_list.domp) { \
+              free_and_init (list_id_p->type_list.domp); \
+            } \
+          } \
+        } while (0)
+
+#define cursor_free_self_list_id(list_id) \
+        do { \
+          cursor_free_list_id (list_id); \
+          free_and_init (list_id); \
+        } while (0)
+
 extern int cursor_copy_vobj_to_dbvalue (struct or_buf *buf, DB_VALUE * db_value);
 extern int cursor_fetch_page_having_tuple (CURSOR_ID * cursor_id, VPID * vpid, int position, int offset);
 #if defined (WINDOWS) || defined (CUBRID_DEBUG)

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -12953,7 +12953,7 @@ cleanup:
       set_free (seq);
     }
 
-  cursor_free_self_list_id ((QFILE_LIST_ID *) qry->etc);
+  cursor_free_self_list_id (qry->etc);
   pt_end_query (parser, query_id_self);
 
   return cnt;
@@ -15669,7 +15669,7 @@ exit:
     {
       if (ins_select_stmt->etc != NULL)
 	{
-	  cursor_free_self_list_id ((QFILE_LIST_ID *) ins_select_stmt->etc);
+	  cursor_free_self_list_id (ins_select_stmt->etc);
 	  if (ins_query_id != NULL_QUERY_ID && !tran_was_latest_query_ended ())
 	    {
 	      qmgr_end_query (ins_query_id);
@@ -16473,7 +16473,7 @@ exit:
     {
       if (ins_select_stmt->etc != NULL)
 	{
-	  cursor_free_self_list_id ((QFILE_LIST_ID *) ins_select_stmt->etc);
+	  cursor_free_self_list_id (ins_select_stmt->etc);
 	  if (ins_query_id != NULL_QUERY_ID && !tran_was_latest_query_ended ())
 	    {
 	      qmgr_end_query (ins_query_id);


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-23925

backport #2785