### PR TITLE
[CBRD-24000] Fix slip of #2888

### DIFF
--- a/src/broker/cas_handle.c
+++ b/src/broker/cas_handle.c
@@ -59,6 +59,9 @@ static int max_handle_id = 0;
 static int current_handle_count = 0;
 #endif
 
+/* implemented in transaction_cl.c */
+extern bool tran_is_in_libcas (void);
+
 static cas_procedure_handle_table procedure_handle_table;
 static int current_handle_id = -1;	/* it is used for javasp */
 
@@ -511,5 +514,12 @@ hm_srv_handle_get_current_count (void)
 void
 hm_set_current_srv_handle (int h_id)
 {
-  current_handle_id = h_id;
+  if (tran_is_in_libcas ())
+    {
+      /* do nothing */
+    }
+  else
+    {
+      current_handle_id = h_id;
+    }
 }

--- a/src/broker/cas_handle_procedure.cpp
+++ b/src/broker/cas_handle_procedure.cpp
@@ -89,9 +89,8 @@ cas_procedure_handle_free (cas_procedure_handle_table &handle_table, int current
 {
   if (tran_is_in_libcas ())
     {
-      /* just remove from the multimap, the srv_handle is going to be freed here */
-      /* so that h_id doesn't need to be destoryed later */
-      handle_table.remove (current_handle_id, sp_h_id);
+      /* it will be removed by srv_handler_map.erase (key) in cas_procedure_handle_table::destroy() */
+      /* do nothing */
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24000

This PR is to fix the slip of #2888 
1) When setting current handle id, libcas mode should be checked in `hm_set_current_srv_handle()`
2) In iterating the multimap, If an element is erased, It may cause unexpected behavior

Below is the sql_log message when I tested.
```
...
21-07-15 02:04:19.755 (12) cursor_close srv_h_id 1
21-07-15 02:04:19.755 (0) close_req_handle srv_h_id 1
21-07-15 02:04:19.755 (0) close_req_handle srv_h_id 2
21-07-15 02:04:19.755 (14) prepare 8 select *,       FN_TEST(),       FN_TEST()  from t3 limit 10;
21-07-15 02:04:19.757 (14) prepare srv_h_id 1
21-07-15 02:04:19.758 (14) set query timeout to 0 (no limit)
21-07-15 02:04:19.758 (14) execute srv_h_id 1 select *,       FN_TEST(),       FN_TEST()  from t3 limit 10;
21-07-15 02:04:19.761 (15) prepare 8 SELECT *    FROM t3   WHERE col1 = ?
21-07-15 02:04:19.761 (15) prepare srv_h_id 2 (PC)
21-07-15 02:04:19.762 (15) execute srv_h_id 2 SELECT *    FROM t3   WHERE col1 = ?
21-07-15 02:04:19.762 (15) bind 1 : INT 2
21-07-15 02:04:19.762 (15) execute 0 tuple 1 time 0.000
21-07-15 02:04:19.762 (15) cursor_close srv_h_id 2
21-07-15 02:04:19.762 (0) con_close
21-07-15 02:04:19.763 (15) execute srv_h_id 2 SELECT *    FROM t3   WHERE col1 = ?
21-07-15 02:04:19.763 (15) bind 1 : INT 2
21-07-15 02:04:19.764 (15) execute 0 tuple 1 time 0.001
21-07-15 02:04:19.764 (15) cursor_close srv_h_id 2
21-07-15 02:04:19.764 (0) con_close
21-07-15 02:04:19.765 (14) execute 0 tuple 10 time 0.007
21-07-15 02:04:19.765 (0) con_close
21-07-15 02:04:19.765 (0) auto_commit (server)
21-07-15 02:04:19.765 (0) auto_commit 0
21-07-15 02:04:19.765 (0) *** elapsed time 0.010

21-07-15 02:04:19.766 (14) cursor_close srv_h_id 1
21-07-15 02:04:19.766 (0) close_req_handle srv_h_id 1
21-07-15 02:04:19.766 (0) close_req_handle srv_h_id 2
...
```