### PR TITLE
[CBRD-23939] The system parameter 'read_only' should be the hidden pa…

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -4490,7 +4490,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_READ_ONLY_MODE,
    PRM_NAME_READ_ONLY_MODE,
-   (PRM_FOR_SERVER | PRM_FOR_CLIENT),
+   (PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_HIDDEN),
    PRM_BOOLEAN,
    &prm_read_only_mode_flag,
    (void *) &prm_read_only_mode_default,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23939

**Purpose**
The system parameter 'read_only' is not a hidden property. So it should be a hidden property. 


**Implementation**
read_only system parameter in system_parameter.c 
I added PRM_HIDDEN parameter to hide "read_only" property

**Remarks**
N/A
