### PR TITLE
[CBRD-24000] CAS Statement Handlers created by Server-Side JDBC are not properly cleared (#2888)

### DIFF
--- a/cas/CMakeLists.txt
+++ b/cas/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LIBCAS_SOURCES
   ${BROKER_DIR}/cas_function.c 
   ${BROKER_DIR}/cas_execute.c 
   ${BROKER_DIR}/cas_handle.c 
+  ${BROKER_DIR}/cas_handle_procedure.cpp 
   ${BROKER_DIR}/cas_util.c 
   ${BROKER_DIR}/cas_str_like.c 
   ${BROKER_DIR}/cas_xa.c 
@@ -35,6 +36,9 @@ set(LIBCAS_SOURCES
   ${BROKER_DIR}/cas_meta.c
   ${BROKER_DIR}/cas_ssl.c
   )
+set(LIBCAS_HEADERS
+  ${BROKER_DIR}/cas_handle_procedure.hpp
+  )
 
 if(WIN32)
   list(APPEND LIBCAS_SOURCES ${BROKER_DIR}/broker_wsa_init.c)
@@ -45,7 +49,7 @@ SET_SOURCE_FILES_PROPERTIES(
   PROPERTIES LANGUAGE CXX
   )
 
-add_library(cas STATIC ${LIBCAS_SOURCES})
+add_library(cas STATIC ${LIBCAS_SOURCES} ${LIBCAS_HEADERS})
 if(UNIX)
   set_target_properties(cas PROPERTIES COMPILE_FLAGS "-fPIC")
 endif(UNIX)

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1465,6 +1465,7 @@ libcas_get_db_result_set (int h_id)
 void
 libcas_srv_handle_free (int h_id)
 {
+  cas_log_write (0, false, "close_req_handle srv_h_id %d", h_id);
   hm_srv_handle_free (h_id);
 }
 #endif /* !LIBCAS_FOR_JSP */

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -1247,7 +1247,9 @@ ux_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_row,
     }
 #endif /* !LIBCAS_FOR_JSP && !CAS_FOR_ORACLE && !CAS_FOR_MYSQL */
 
+  hm_set_current_srv_handle (srv_handle->id);
   n = db_execute_and_keep_statement (session, stmt_id, &result);
+  hm_set_current_srv_handle (-1);
 
 #ifndef LIBCAS_FOR_JSP
   stmt_type = db_get_statement_type (session, stmt_id);
@@ -1559,10 +1561,11 @@ ux_execute_all (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
 	  goto execute_all_error;
 	}
 #endif /* !LIBCAS_FOR_JSP && !CAS_FOR_ORACLE && !CAS_FOR_MYSQL */
-
+      hm_set_current_srv_handle (srv_handle->id);
       SQL_LOG2_EXEC_BEGIN (as_info->cur_sql_log2, stmt_id);
       n = db_execute_and_keep_statement (session, stmt_id, &result);
       SQL_LOG2_EXEC_END (as_info->cur_sql_log2, stmt_id, n);
+      hm_set_current_srv_handle (-1);
 
 #ifndef LIBCAS_FOR_JSP
       update_query_execution_count (as_info, stmt_type);
@@ -1817,9 +1820,11 @@ ux_execute_call (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max
 
   stmt_id = srv_handle->q_result->stmt_id;
 
+  hm_set_current_srv_handle (srv_handle->id);
   jsp_set_prepare_call ();
   n = db_execute_and_keep_statement (session, stmt_id, &result);
   jsp_unset_prepare_call ();
+  hm_set_current_srv_handle (-1);
 
 #ifndef LIBCAS_FOR_JSP
   stmt_type = db_get_statement_type (session, stmt_id);
@@ -2314,9 +2319,13 @@ ux_execute_array (T_SRV_HANDLE * srv_handle, int argc, void **argv, T_NET_BUF * 
 	}
 #endif /* !LIBCAS_FOR_JSP && !CAS_FOR_ORACLE && !CAS_FOR_MYSQL */
 
+      hm_set_current_srv_handle (srv_handle->id);
+
       SQL_LOG2_EXEC_BEGIN (as_info->cur_sql_log2, stmt_id);
       res_count = db_execute_and_keep_statement (session, stmt_id, &result);
       SQL_LOG2_EXEC_END (as_info->cur_sql_log2, stmt_id, res_count);
+
+      hm_set_current_srv_handle (-1);
 
       if (stmt_type < 0)
 	{

--- a/src/broker/cas_function.c
+++ b/src/broker/cas_function.c
@@ -80,9 +80,7 @@ extern int jsp_send_destroy_request_all ();
 
 /* functions implemented in transaction_cl.c */
 extern void tran_set_query_timeout (int);
-#ifndef LIBCAS_FOR_JSP
 extern bool tran_is_in_libcas (void);
-#endif /* !LIBCAS_FOR_JSP */
 #endif
 
 static void update_error_query_count (T_APPL_SERVER_INFO * as_info_p, const T_ERROR_INFO * err_info_p);

--- a/src/broker/cas_handle.c
+++ b/src/broker/cas_handle.c
@@ -59,6 +59,9 @@ static int max_handle_id = 0;
 static int current_handle_count = 0;
 #endif
 
+/* implemented in transaction_cl.c */
+extern bool tran_is_in_libcas (void);
+
 static cas_procedure_handle_table procedure_handle_table;
 static int current_handle_id = -1;	/* it is used for javasp */
 
@@ -511,5 +514,12 @@ hm_srv_handle_get_current_count (void)
 void
 hm_set_current_srv_handle (int h_id)
 {
-  current_handle_id = h_id;
+  if (tran_is_in_libcas ())
+    {
+      /* do nothing */
+    }
+  else
+    {
+      current_handle_id = h_id;
+    }
 }

--- a/src/broker/cas_handle.c
+++ b/src/broker/cas_handle.c
@@ -43,6 +43,7 @@
 #include "cas.h"
 #include "cas_common.h"
 #include "cas_handle.h"
+#include "cas_handle_procedure.hpp"
 #include "cas_log.h"
 
 #define SRV_HANDLE_ALLOC_SIZE		256
@@ -57,6 +58,9 @@ static int max_handle_id = 0;
 #if !defined(LIBCAS_FOR_JSP)
 static int current_handle_count = 0;
 #endif
+
+static cas_procedure_handle_table procedure_handle_table;
+static int current_handle_id = -1;	/* it is used for javasp */
 
 int
 hm_new_srv_handle (T_SRV_HANDLE ** new_handle, unsigned int seq_num)
@@ -137,6 +141,9 @@ hm_new_srv_handle (T_SRV_HANDLE ** new_handle, unsigned int seq_num)
   current_handle_count++;
 #endif
 
+  /* register handler id created from server-side JDBC */
+  cas_procedure_handle_add (procedure_handle_table, current_handle_id, new_handle_id);
+
   return new_handle_id;
 }
 
@@ -167,6 +174,7 @@ hm_srv_handle_free (int h_id)
       return;
     }
 
+  cas_procedure_handle_free (procedure_handle_table, current_handle_id, h_id);
   srv_handle_content_free (srv_handle);
   srv_handle_rm_tmp_file (h_id, srv_handle);
 
@@ -498,4 +506,10 @@ hm_srv_handle_get_current_count (void)
 #else
   return 0;
 #endif
+}
+
+void
+hm_set_current_srv_handle (int h_id)
+{
+  current_handle_id = h_id;
 }

--- a/src/broker/cas_handle.h
+++ b/src/broker/cas_handle.h
@@ -214,6 +214,8 @@ extern void hm_col_update_info_clear (T_COL_UPDATE_INFO * col_update_info);
 extern void hm_srv_handle_set_pooled (void);
 #endif
 
+extern void hm_set_current_srv_handle (int h_id);
+
 extern int hm_srv_handle_get_current_count (void);
 extern void hm_srv_handle_unset_prepare_flag_all (void);
 #endif /* _CAS_HANDLE_H_ */

--- a/src/broker/cas_handle_procedure.cpp
+++ b/src/broker/cas_handle_procedure.cpp
@@ -89,9 +89,8 @@ cas_procedure_handle_free (cas_procedure_handle_table &handle_table, int current
 {
   if (tran_is_in_libcas ())
     {
-      /* just remove from the multimap, the srv_handle is going to be freed here */
-      /* so that h_id doesn't need to be destoryed later */
-      handle_table.remove (current_handle_id, sp_h_id);
+      /* it will be removed by srv_handler_map.erase (key) in cas_procedure_handle_table::destroy() */
+      /* do nothing */
     }
   else
     {

--- a/src/broker/cas_handle_procedure.cpp
+++ b/src/broker/cas_handle_procedure.cpp
@@ -1,0 +1,115 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+#include "cas_handle_procedure.hpp"
+
+#include <cassert>
+#include <algorithm>
+
+/* implemented in transaction_cl.c */
+extern void tran_begin_libcas_function (void);
+extern void tran_end_libcas_function (void);
+extern bool tran_is_in_libcas (void);
+
+/* implemented in cas.c */
+extern void libcas_srv_handle_free (int h_id);
+
+void
+cas_procedure_handle_table::iterate_by_key (int key, const map_func_type &func)
+{
+  auto const &r = srv_handler_map.equal_range (key);
+  for (auto it = r.first /* lower */; it != r.second /* upper */; ++it)
+    {
+      if (!func (it))
+	{
+	  break;
+	}
+    }
+}
+
+void
+cas_procedure_handle_table::add (int key, int value)
+{
+  // To prevent self-destorying, it should not happen
+  assert (key != value);
+  srv_handler_map.emplace (key, value);
+}
+
+void
+cas_procedure_handle_table::remove (int key, int value)
+{
+  auto remove_value = [&] (const map_iter_type& it)
+  {
+    if (it->second == value)
+      {
+	srv_handler_map.erase (it);
+	return false; /* stop iteration */
+      }
+    else
+      {
+	return true;
+      }
+  };
+
+  iterate_by_key (key, remove_value);
+}
+
+void
+cas_procedure_handle_table::destroy (int key)
+{
+  auto destroy_srv_handle = [&] (const map_iter_type& it)
+  {
+    libcas_srv_handle_free (it->second);
+    return true;
+  };
+
+  tran_begin_libcas_function ();
+  iterate_by_key (key, destroy_srv_handle);
+  tran_end_libcas_function ();
+
+  srv_handler_map.erase (key);
+}
+
+void
+cas_procedure_handle_free (cas_procedure_handle_table &handle_table, int current_handle_id, int sp_h_id)
+{
+  if (tran_is_in_libcas ())
+    {
+      /* just remove from the multimap, the srv_handle is going to be freed here */
+      /* so that h_id doesn't need to be destoryed later */
+      handle_table.remove (current_handle_id, sp_h_id);
+    }
+  else
+    {
+      /* destory nested query handlers by Server-side JDBC first */
+      handle_table.destroy (sp_h_id);
+    }
+}
+
+void
+cas_procedure_handle_add (cas_procedure_handle_table &handle_table, int current_handle_id, int sp_h_id)
+{
+  if (tran_is_in_libcas ())
+    {
+      /* register handler id created from server-side JDBC */
+      handle_table.add (current_handle_id, sp_h_id);
+    }
+  else
+    {
+      /* do nothing */
+    }
+}

--- a/src/broker/cas_handle_procedure.hpp
+++ b/src/broker/cas_handle_procedure.hpp
@@ -1,0 +1,54 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include <functional>
+#include <map>
+
+#ifndef _CAS_HANDLE_PROCEDURE_
+#define _CAS_HANDLE_PROCEDURE_
+
+class cas_procedure_handle_table
+{
+  public:
+    using map_iter_type = std::multimap<int, int>::iterator;
+    using map_func_type = std::function<bool (const map_iter_type &)>;
+
+    cas_procedure_handle_table () = default;
+    ~cas_procedure_handle_table () { /* do nothing */ }
+
+    cas_procedure_handle_table (const cas_procedure_handle_table &other) = delete;
+    cas_procedure_handle_table (cas_procedure_handle_table &&other) = delete;
+    cas_procedure_handle_table &operator= (const cas_procedure_handle_table &other) = delete;
+    cas_procedure_handle_table &operator= (cas_procedure_handle_table &&other) = delete;
+
+    void add (int key, int value);
+    void remove (int key, int value);
+    void destroy (int key);
+
+  private:
+    void iterate_by_key (int key, const map_func_type &func);
+
+    /* key: current executing query's srv_h_id by client, value: nested query's srv_h_id by server-side JDBC */
+    std::multimap <int, int> srv_handler_map;
+};
+
+/* wrapper functions to use cas_procedure_handle_table at cas_handle.c */
+void cas_procedure_handle_free (cas_procedure_handle_table &handle_table, int current_handle_id, int sp_h_id);
+void cas_procedure_handle_add (cas_procedure_handle_table &handle_table, int current_handle_id, int sp_h_id);
+
+#endif /* _CAS_HANDLE_PROCEDURE_ */

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -7,6 +7,8 @@ EXPORTS
     cas_default_isolation_level
     cas_default_lock_timeout
     cas_send_result_flag
+    cas_procedure_handle_add
+    cas_procedure_handle_free
     cfg_find_db
     cfg_free_directory
     char_isdigit


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24000

This commit is backporting of #2888, #2898

To clear the statement handler (T_SRV_HANDLE) created by server-side JDBC, cas_procedure_handle_table maintains the <key, value> structure (key representing the handler ID of the currently executing SQL, value representing handler ID of the server-side JDBC's query, respectively).

1. current_handle_id is the handler ID of the currently executing SQL issued by the client. it is set by hm_set_current_srv_handle() before calling db_execute_and_keep_statement ().
2. Server-side JDBC requests are handled by libcas_main, and you can check whether the CAS routine is being called from libcas_main (server-side) or cas_main (client-side) through tran_is_in_libcas().
3. When the client-side handler ID is freed by hm_srv_handle_free() at any routine in cas_function.c or cas_execute.c, server-side hanlder IDs are destroyed (freed) according to the <key, value> structure described above.