### PR TITLE
[CBRD-23911] Add system parameter for supplemental logging

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -692,6 +692,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_DDL_AUDIT_LOG "ddl_audit_log"
 #define PRM_NAME_DDL_AUDIT_LOG_SIZE "ddl_audit_log_size"
 
+#define PRM_NAME_SUPPLEMENTAL_LOG "supplemental_log"
+
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
 #define PRM_VALUE_MIN "MIN"
@@ -2343,6 +2345,10 @@ static UINT64 prm_ddl_audit_log_size_default = 10485760ULL;	/* 10M */
 static UINT64 prm_ddl_audit_log_size_lower = 10485760ULL;	/* 10M */
 static UINT64 prm_ddl_audit_log_size_upper = 2147483648ULL;	/* 2G */
 static unsigned int prm_ddl_audit_log_size_flag = 0;
+
+int PRM_SUPPLEMENTAL_LOG = 0;
+static int prm_supplemental_log_default = 0;
+static unsigned int prm_supplemental_log_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -6034,6 +6040,18 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) &PRM_DDL_AUDIT_LOG_SIZE,
    (void *) &prm_ddl_audit_log_size_upper,
    (void *) &prm_ddl_audit_log_size_lower,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_SUPPLEMENTAL_LOG,
+   PRM_NAME_SUPPLEMENTAL_LOG,
+   (PRM_FOR_SERVER | PRM_FOR_CLIENT),
+   PRM_INTEGER,
+   &prm_supplemental_log_flag,
+   (void *) &prm_supplemental_log_default,
+   (void *) &PRM_SUPPLEMENTAL_LOG,
+   (void *) NULL,
+   (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL}

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -452,8 +452,9 @@ enum param_id
   PRM_ID_IGNORE_TRAILING_SPACE,
   PRM_ID_DDL_AUDIT_LOG,
   PRM_ID_DDL_AUDIT_LOG_SIZE,
+  PRM_ID_SUPPLEMENTAL_LOG,
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_DDL_AUDIT_LOG_SIZE
+  PRM_LAST_ID = PRM_ID_SUPPLEMENTAL_LOG
 };
 typedef enum param_id PARAM_ID;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23911

System parameter for supplemental log is added.

Default value is 0 which means no supplemental logging.
