### PR TITLE
[CBRD-23911] Add hint for not appending supplemental logs

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -15513,16 +15513,7 @@ sm_truncate_using_delete (MOP class_mop)
   /* We will run a DELETE statement with triggers disabled. */
   save_tr_state = tr_set_execution_state (false);
 
-  if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
-    {
-      (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE NO_SUPPLEMENTAL_LOG */ FROM [%s];",
-		       class_name);
-    }
-  else
-    {
-    
-    }
-
+  (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE NO_SUPPLEMENTAL_LOG */ FROM [%s];", class_name);
 
   session = db_open_buffer (delete_query);
   if (session == NULL)

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -15520,7 +15520,7 @@ sm_truncate_using_delete (MOP class_mop)
     }
   else
     {
-      (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE */ FROM [%s];", class_name);
+    
     }
 
 

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -15513,7 +15513,16 @@ sm_truncate_using_delete (MOP class_mop)
   /* We will run a DELETE statement with triggers disabled. */
   save_tr_state = tr_set_execution_state (false);
 
-  (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE */ FROM [%s];", class_name);
+  if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
+    {
+      (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE NO_SUPPLEMENTAL_LOG */ FROM [%s];",
+		       class_name);
+    }
+  else
+    {
+      (void) snprintf (delete_query, sizeof (delete_query), "DELETE /*+ RECOMPILE */ FROM [%s];", class_name);
+    }
+
 
   session = db_open_buffer (delete_query);
   if (session == NULL)

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -25897,6 +25897,8 @@ PT_HINT parser_hint_table[] = {
   ,
   {"USE_SBR", NULL, PT_HINT_USE_SBR}
   ,
+  {"NO_SUPPLEMENTAL_LOG", NULL, PT_HINT_NO_SUPPLEMENTAL_LOG}
+  ,
   {NULL, NULL, -1}		/* mark as end */
 };
 

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -1201,7 +1201,8 @@ typedef enum
   /* SELECT page header information from heap file instead of record data */
   PT_HINT_SELECT_KEY_INFO = 0x80000000,	/* 1000 0000 0000 0000 0000 0000 0000 0000 */
   /* SELECT key information from index b-tree instead of table record data */
-  PT_HINT_NO_SUPPLEMENTAL_LOG = 0x100000000
+  PT_HINT_NO_SUPPLEMENTAL_LOG = 0x100000000 /* 0001 0000 0000 0000 0000 0000 0000 0000 0000 */
+  /* Used in DML (insert, update, delete) to avoid adding DML supplemental logs that may be duplicated by DDL */
 } PT_HINT_ENUM;
 
 /* Codes for error messages */

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -1199,8 +1199,9 @@ typedef enum
   /* SELECT record info from tuple header instead of data */
   PT_HINT_SELECT_PAGE_INFO = 0x40000000,	/* 0100 0000 0000 0000 0000 0000 0000 0000 */
   /* SELECT page header information from heap file instead of record data */
-  PT_HINT_SELECT_KEY_INFO = 0x80000000	/* 1000 0000 0000 0000 0000 0000 0000 0000 */
-    /* SELECT key information from index b-tree instead of table record data */
+  PT_HINT_SELECT_KEY_INFO = 0x80000000,	/* 1000 0000 0000 0000 0000 0000 0000 0000 */
+  /* SELECT key information from index b-tree instead of table record data */
+  PT_HINT_NO_SUPPLEMENTAL_LOG = 0x100000000
 } PT_HINT_ENUM;
 
 /* Codes for error messages */

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -1201,8 +1201,8 @@ typedef enum
   /* SELECT page header information from heap file instead of record data */
   PT_HINT_SELECT_KEY_INFO = 0x80000000,	/* 1000 0000 0000 0000 0000 0000 0000 0000 */
   /* SELECT key information from index b-tree instead of table record data */
-  PT_HINT_NO_SUPPLEMENTAL_LOG = 0x100000000 /* 0001 0000 0000 0000 0000 0000 0000 0000 0000 */
-  /* Used in DML (insert, update, delete) to avoid adding DML supplemental logs that may be duplicated by DDL */
+  PT_HINT_NO_SUPPLEMENTAL_LOG = 0x100000000	/* 0001 0000 0000 0000 0000 0000 0000 0000 0000 */
+    /* Used in DML (insert, update, delete) to avoid adding DML supplemental logs that may be duplicated by DDL */
 } PT_HINT_ENUM;
 
 /* Codes for error messages */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -8506,6 +8506,11 @@ pt_print_delete (PARSER_CONTEXT * parser, PT_NODE * p)
 	  q = pt_append_nulstring (parser, q, " USE_SBR ");
 	}
 
+      if (p->info.delete_.hint & PT_HINT_NO_SUPPLEMENTAL_LOG)
+	{
+	  q = pt_append_nulstring (parser, q, " NO_SUPPLEMENTAL_LOG");
+	}
+
       q = pt_append_nulstring (parser, q, " */");
     }
   if (r1)
@@ -12419,6 +12424,11 @@ pt_print_insert (PARSER_CONTEXT * parser, PT_NODE * p)
 	  b = pt_append_nulstring (parser, b, " USE_SBR");
 	}
 
+      if (p->info.insert.hint & PT_HINT_NO_SUPPLEMENTAL_LOG)
+	{
+	  b = pt_append_nulstring (parser, b, " NO_SUPPLEMENTAL_LOG");
+	}
+
       b = pt_append_nulstring (parser, b, " */ ");
     }
   b = pt_append_nulstring (parser, b, "into ");
@@ -14984,6 +14994,11 @@ pt_print_update (PARSER_CONTEXT * parser, PT_NODE * p)
       if (p->info.update.hint & PT_HINT_USE_SBR)
 	{
 	  b = pt_append_nulstring (parser, b, " USE_SBR ");
+	}
+
+      if (p->info.update.hint & PT_HINT_NO_SUPPLEMENTAL_LOG)
+	{
+	  b = pt_append_nulstring (parser, b, " NO_SUPPLEMENTAL_LOG");
 	}
 
       b = pt_append_nulstring (parser, b, " */ ");

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -12424,11 +12424,6 @@ pt_print_insert (PARSER_CONTEXT * parser, PT_NODE * p)
 	  b = pt_append_nulstring (parser, b, " USE_SBR");
 	}
 
-      if (p->info.insert.hint & PT_HINT_NO_SUPPLEMENTAL_LOG)
-	{
-	  b = pt_append_nulstring (parser, b, " NO_SUPPLEMENTAL_LOG");
-	}
-
       b = pt_append_nulstring (parser, b, " */ ");
     }
   b = pt_append_nulstring (parser, b, "into ");

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -8508,7 +8508,7 @@ pt_print_delete (PARSER_CONTEXT * parser, PT_NODE * p)
 
       if (p->info.delete_.hint & PT_HINT_NO_SUPPLEMENTAL_LOG)
 	{
-	  q = pt_append_nulstring (parser, q, " NO_SUPPLEMENTAL_LOG");
+	  q = pt_append_nulstring (parser, q, " NO_SUPPLEMENTAL_LOG ");
 	}
 
       q = pt_append_nulstring (parser, q, " */");
@@ -14998,7 +14998,7 @@ pt_print_update (PARSER_CONTEXT * parser, PT_NODE * p)
 
       if (p->info.update.hint & PT_HINT_NO_SUPPLEMENTAL_LOG)
 	{
-	  b = pt_append_nulstring (parser, b, " NO_SUPPLEMENTAL_LOG");
+	  b = pt_append_nulstring (parser, b, " NO_SUPPLEMENTAL_LOG ");
 	}
 
       b = pt_append_nulstring (parser, b, " */ ");

--- a/src/parser/scanner_support.c
+++ b/src/parser/scanner_support.c
@@ -510,23 +510,6 @@ pt_get_hint (const char *text, PT_HINT hint_table[], PT_NODE * node)
 		  node->info.update.hint = (PT_HINT_ENUM) (node->info.update.hint | hint_table[i].hint);
 		}
 	      break;
-	    case PT_HINT_NO_SUPPLEMENTAL_LOG:	/* no supplemental_log */
-	      if (node->node_type == PT_UPDATE)
-		{
-		  node->info.update.hint = (PT_HINT_ENUM) (node->info.update.hint | hint_table[i].hint);
-		}
-	      else if (node->node_type == PT_DELETE)
-		{
-		  node->info.delete_.hint = (PT_HINT_ENUM) (node->info.delete_.hint | hint_table[i].hint);
-		}
-	      else if (node->node_type == PT_INSERT)
-		{
-		  node->info.insert.hint = (PT_HINT_ENUM) (node->info.insert.hint | hint_table[i].hint);
-		}
-
-	      hint_table[i].arg_list = NULL;
-	      break;
-
 	    default:
 	      break;
 	    }

--- a/src/parser/scanner_support.c
+++ b/src/parser/scanner_support.c
@@ -510,6 +510,23 @@ pt_get_hint (const char *text, PT_HINT hint_table[], PT_NODE * node)
 		  node->info.update.hint = (PT_HINT_ENUM) (node->info.update.hint | hint_table[i].hint);
 		}
 	      break;
+	    case PT_HINT_NO_SUPPLEMENTAL_LOG:	/* no supplemental_log */
+	      if (node->node_type == PT_UPDATE)
+		{
+		  node->info.update.hint = (PT_HINT_ENUM) (node->info.update.hint | hint_table[i].hint);
+		}
+	      else if (node->node_type == PT_DELETE)
+		{
+		  node->info.delete_.hint = (PT_HINT_ENUM) (node->info.delete_.hint | hint_table[i].hint);
+		}
+	      else if (node->node_type == PT_INSERT)
+		{
+		  node->info.insert.hint = (PT_HINT_ENUM) (node->info.insert.hint | hint_table[i].hint);
+		}
+
+	      hint_table[i].arg_list = NULL;
+	      break;
+
 	    default:
 	      break;
 	    }

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -18401,6 +18401,7 @@ pt_to_insert_xasl (PARSER_CONTEXT * parser, PT_NODE * statement)
 	}
 
       insert->no_logging = (statement->info.insert.hint & PT_HINT_NO_LOGGING);
+      insert->no_supplemental_log = (statement->info.insert.hint & PT_HINT_NO_SUPPLEMENTAL_LOG);
       insert->do_replace = (statement->info.insert.do_replace ? 1 : 0);
 
       if (error >= NO_ERROR && (num_vals + num_default_expr > 0))
@@ -20280,6 +20281,7 @@ pt_to_delete_xasl (PARSER_CONTEXT * parser, PT_NODE * statement)
 	    }
 	}
       delete_->no_logging = (statement->info.delete_.hint & PT_HINT_NO_LOGGING);
+      delete_->no_supplemental_log = (statement->info.delete_.hint & PT_HINT_NO_SUPPLEMENTAL_LOG);
     }
 
   if (pt_has_error (parser) || error < 0)
@@ -20956,6 +20958,7 @@ pt_to_update_xasl (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** non_
 	}
     }
   update->no_logging = (statement->info.update.hint & PT_HINT_NO_LOGGING);
+  update->no_supplemental_log = (statement->info.update.hint & PT_HINT_NO_SUPPLEMENTAL_LOG);
 
   /* iterate through classes and check constants */
   for (p = from, cls_idx = num_classes; p; p = p->next)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -18401,7 +18401,6 @@ pt_to_insert_xasl (PARSER_CONTEXT * parser, PT_NODE * statement)
 	}
 
       insert->no_logging = (statement->info.insert.hint & PT_HINT_NO_LOGGING);
-      insert->no_supplemental_log = (statement->info.insert.hint & PT_HINT_NO_SUPPLEMENTAL_LOG);
       insert->do_replace = (statement->info.insert.do_replace ? 1 : 0);
 
       if (error >= NO_ERROR && (num_vals + num_default_expr > 0))

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -4656,15 +4656,7 @@ do_redistribute_partitions_data (const char *classname, const char *keyname, cha
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, query_size + 1);
 	  return ER_FAILED;
 	}
-
-      if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
-	{
-	  sprintf (query_buf, "UPDATE /*+ NO_SUPPLEMENTAL_LOG */ [%s] SET [%s]=[%s];", classname, keyname, keyname);
-	}
-      else
-	{
-	  sprintf (query_buf, "UPDATE [%s] SET [%s]=[%s];", classname, keyname, keyname);
-	}
+      sprintf (query_buf, "UPDATE /*+ NO_SUPPLEMENTAL_LOG */ [%s] SET [%s]=[%s];", classname, keyname, keyname);
 
       error = db_compile_and_execute_local (query_buf, &query_result, &query_error);
       if (error >= 0)
@@ -13120,7 +13112,7 @@ do_run_update_query_for_new_notnull_fields (PARSER_CONTEXT * parser, PT_NODE * a
 
   /* Using UPDATE ALL to update the current class and all its children. */
 
-  n = snprintf (q, remaining, "UPDATE ALL [%s] SET ", alter->info.alter.entity_name->info.name.original);
+  n = snprintf (q, remaining, "UPDATE /*+ NO_SUPPLEMENTAL_LOG */ ALL [%s] SET ", alter->info.alter.entity_name->info.name.original);
   if (n < 0)
     {
       ERROR1 (error, ER_UNEXPECTED, "Building UPDATE statement failed.");
@@ -13208,7 +13200,7 @@ do_run_update_query_for_new_default_expression_fields (PARSER_CONTEXT * parser, 
   query[0] = 0;
 
   /* Using UPDATE ALL to update the current class and all its children. */
-  n = snprintf (q, remaining, "UPDATE ALL [%s] SET ", alter->info.alter.entity_name->info.name.original);
+  n = snprintf (q, remaining, "UPDATE /*+ NO_SUPPLEMENTAL_LOG */ ALL [%s] SET ", alter->info.alter.entity_name->info.name.original);
   if (n < 0)
     {
       ERROR1 (error, ER_UNEXPECTED, "Building UPDATE statement failed.");

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -4656,7 +4656,15 @@ do_redistribute_partitions_data (const char *classname, const char *keyname, cha
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, query_size + 1);
 	  return ER_FAILED;
 	}
-      sprintf (query_buf, "UPDATE [%s] SET [%s]=[%s];", classname, keyname, keyname);
+
+      if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
+	{
+	  sprintf (query_buf, "UPDATE /*+ NO_SUPPLEMENTAL_LOG */ [%s] SET [%s]=[%s];", classname, keyname, keyname);
+	}
+      else
+	{
+	  sprintf (query_buf, "UPDATE [%s] SET [%s]=[%s];", classname, keyname, keyname);
+	}
 
       error = db_compile_and_execute_local (query_buf, &query_result, &query_error);
       if (error >= 0)

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -13112,7 +13112,9 @@ do_run_update_query_for_new_notnull_fields (PARSER_CONTEXT * parser, PT_NODE * a
 
   /* Using UPDATE ALL to update the current class and all its children. */
 
-  n = snprintf (q, remaining, "UPDATE /*+ NO_SUPPLEMENTAL_LOG */ ALL [%s] SET ", alter->info.alter.entity_name->info.name.original);
+  n =
+    snprintf (q, remaining, "UPDATE /*+ NO_SUPPLEMENTAL_LOG */ ALL [%s] SET ",
+	      alter->info.alter.entity_name->info.name.original);
   if (n < 0)
     {
       ERROR1 (error, ER_UNEXPECTED, "Building UPDATE statement failed.");
@@ -13200,7 +13202,9 @@ do_run_update_query_for_new_default_expression_fields (PARSER_CONTEXT * parser, 
   query[0] = 0;
 
   /* Using UPDATE ALL to update the current class and all its children. */
-  n = snprintf (q, remaining, "UPDATE /*+ NO_SUPPLEMENTAL_LOG */ ALL [%s] SET ", alter->info.alter.entity_name->info.name.original);
+  n =
+    snprintf (q, remaining, "UPDATE /*+ NO_SUPPLEMENTAL_LOG */ ALL [%s] SET ",
+	      alter->info.alter.entity_name->info.name.original);
   if (n < 0)
     {
       ERROR1 (error, ER_UNEXPECTED, "Building UPDATE statement failed.");

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -8772,6 +8772,8 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 
   thread_p->no_logging = (bool) update->no_logging;
 
+  thread_p->no_supplemental_log = (bool) update->no_supplemental_log;
+
   /* get the snapshot, before acquiring locks, since the transaction may be blocked and we need the snapshot when
    * update starts, not later */
   (void) logtb_get_mvcc_snapshot (thread_p);
@@ -9633,6 +9635,8 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   UPDDEL_CLASS_INSTANCE_LOCK_INFO class_instance_lock_info, *p_class_instance_lock_info = NULL;
 
   thread_p->no_logging = (bool) delete_->no_logging;
+
+  thread_p->no_supplemental_log = (bool) delete_->no_supplemental_log;
 
   /* get the snapshot, before acquiring locks, since the transaction may be blocked and we need the snapshot when
    * delete starts, not later */
@@ -10915,6 +10919,8 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   bool has_user_format;
 
   thread_p->no_logging = (bool) insert->no_logging;
+
+  thread_p->no_supplemental_log = (bool) insert->no_supplemental_log;
 
   aptr = xasl->aptr_list;
   val_no = insert->num_vals;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -10920,8 +10920,6 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 
   thread_p->no_logging = (bool) insert->no_logging;
 
-  thread_p->no_supplemental_log = (bool) insert->no_supplemental_log;
-
   aptr = xasl->aptr_list;
   val_no = insert->num_vals;
 

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1176,6 +1176,7 @@ qmgr_process_query (THREAD_ENTRY * thread_p, XASL_NODE * xasl_tree, char *xasl_s
   /* execute the query with the value list, if any */
   query_p->list_id = qexec_execute_query (thread_p, xasl_p, dbval_count, dbvals_p, query_p->query_id);
   thread_p->no_logging = false;
+  thread_p->no_supplemental_log = false;
 
   /* Note: qexec_execute_query() returns listid (NOT NULL) even if an error was occurred. We should check the error
    * condition and free listid. */

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -3513,6 +3513,7 @@ stx_build_update_proc (THREAD_ENTRY * thread_p, char *ptr, UPDATE_PROC_NODE * up
 
   ptr = or_unpack_int (ptr, &update_info->wait_msecs);
   ptr = or_unpack_int (ptr, &update_info->no_logging);
+  ptr = or_unpack_int (ptr, &update_info->no_supplemental_log);
   ptr = or_unpack_int (ptr, &update_info->num_orderby_keys);
 
   /* restore MVCC condition reevaluation data */
@@ -3566,6 +3567,7 @@ stx_build_delete_proc (THREAD_ENTRY * thread_p, char *ptr, DELETE_PROC_NODE * de
 
   ptr = or_unpack_int (ptr, &delete_info->wait_msecs);
   ptr = or_unpack_int (ptr, &delete_info->no_logging);
+  ptr = or_unpack_int (ptr, &delete_info->no_supplemental_log);
 
   /* restore MVCC condition reevaluation data */
   ptr = or_unpack_int (ptr, &delete_info->num_reev_classes);
@@ -3652,6 +3654,7 @@ stx_build_insert_proc (THREAD_ENTRY * thread_p, char *ptr, INSERT_PROC_NODE * in
   ptr = or_unpack_int (ptr, &insert_info->has_uniques);
   ptr = or_unpack_int (ptr, &insert_info->wait_msecs);
   ptr = or_unpack_int (ptr, &insert_info->no_logging);
+  ptr = or_unpack_int (ptr, &insert_info->no_supplemental_log);
   ptr = or_unpack_int (ptr, &insert_info->do_replace);
   ptr = or_unpack_int (ptr, &insert_info->pruning_type);
 

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -373,6 +373,7 @@ struct update_proc_node
   UPDATE_ASSIGNMENT *assigns;	/* assignments array */
   int wait_msecs;		/* lock timeout in milliseconds */
   int no_logging;		/* no logging */
+  int no_supplemental_log;	/* no supplemental log */
   int num_orderby_keys;		/* no of keys for ORDER_BY */
   int num_assign_reev_classes;
   int num_reev_classes;		/* no of classes involved in mvcc condition and assignment reevaluation */
@@ -394,6 +395,7 @@ struct insert_proc_node
   int has_uniques;		/* whether there are unique constraints */
   int wait_msecs;		/* lock timeout in milliseconds */
   int no_logging;		/* no logging */
+  int no_supplemental_log;	/* no supplemental log */
   int do_replace;		/* duplicate tuples should be replaced */
   int pruning_type;		/* DB_CLASS_PARTITION_TYPE indicating the way in which pruning should be performed */
   int num_val_lists;		/* number of value lists in values clause */
@@ -408,6 +410,7 @@ struct delete_proc_node
   int num_classes;		/* total number of classes involved */
   int wait_msecs;		/* lock timeout in milliseconds */
   int no_logging;		/* no logging */
+  int no_supplemental_log;	/* no supplemental log */
   int num_reev_classes;		/* no of classes involved in mvcc condition */
   int *mvcc_reev_classes;	/* array of indexes into the SELECT list that references pairs of OID - CLASS OID used
 				 * in conditions */

--- a/src/query/xasl_to_stream.c
+++ b/src/query/xasl_to_stream.c
@@ -3912,6 +3912,8 @@ xts_process_update_proc (char *ptr, const UPDATE_PROC_NODE * update_info)
   /* no_logging */
   ptr = or_pack_int (ptr, update_info->no_logging);
 
+  ptr = or_pack_int (ptr, update_info->no_supplemental_log);
+
   /* num_orderby_keys */
   ptr = or_pack_int (ptr, update_info->num_orderby_keys);
 
@@ -3954,6 +3956,8 @@ xts_process_delete_proc (char *ptr, const DELETE_PROC_NODE * delete_info)
   ptr = or_pack_int (ptr, delete_info->wait_msecs);
 
   ptr = or_pack_int (ptr, delete_info->no_logging);
+
+  ptr = or_pack_int (ptr, delete_info->no_supplemental_log);
 
   /* mvcc condition reevaluation data */
   ptr = or_pack_int (ptr, delete_info->num_reev_classes);
@@ -4006,6 +4010,8 @@ xts_process_insert_proc (char *ptr, const INSERT_PROC_NODE * insert_info)
   ptr = or_pack_int (ptr, insert_info->wait_msecs);
 
   ptr = or_pack_int (ptr, insert_info->no_logging);
+
+  ptr = or_pack_int (ptr, insert_info->no_supplemental_log);
 
   ptr = or_pack_int (ptr, insert_info->do_replace);
 
@@ -6121,6 +6127,7 @@ xts_sizeof_update_proc (const UPDATE_PROC_NODE * update_info)
 	   + PTR_SIZE		/* assignments */
 	   + OR_INT_SIZE	/* wait_msecs */
 	   + OR_INT_SIZE	/* no_logging */
+	   + OR_INT_SIZE	/* no_supplemental_log */
 	   + OR_INT_SIZE	/* num_orderby_keys */
 	   + OR_INT_SIZE	/* num_assign_reev_classes */
 	   + OR_INT_SIZE	/* num_cond_reev_classes */
@@ -6143,6 +6150,7 @@ xts_sizeof_delete_proc (const DELETE_PROC_NODE * delete_info)
 	   + OR_INT_SIZE	/* num_classes */
 	   + OR_INT_SIZE	/* wait_msecs */
 	   + OR_INT_SIZE	/* no_logging */
+	   + OR_INT_SIZE	/* no_supplemental_log */
 	   + OR_INT_SIZE	/* num_cond_reev_classes */
 	   + PTR_SIZE);		/* mvcc_cond_reev_classes */
 
@@ -6169,6 +6177,7 @@ xts_sizeof_insert_proc (const INSERT_PROC_NODE * insert_info)
 	   + OR_INT_SIZE	/* has_uniques */
 	   + OR_INT_SIZE	/* wait_msecs */
 	   + OR_INT_SIZE	/* no_logging */
+	   + OR_INT_SIZE	/* no_supplemental_log */
 	   + OR_INT_SIZE	/* do_replace */
 	   + OR_INT_SIZE	/* needs pruning */
 	   + OR_INT_SIZE	/* num_val_lists */

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -124,6 +124,7 @@ namespace cubthread
     , on_trace (false)
     , clear_trace (false)
     , tran_entries ()
+    , no_supplemental_log (false)
 #if !defined (NDEBUG)
     , fi_test_array (NULL)
     , count_private_allocators (0)
@@ -255,6 +256,8 @@ namespace cubthread
       }
 
     no_logging = false;
+
+    no_supplemental_log = false;
 
     end_resource_tracks ();
 

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -274,6 +274,9 @@ namespace cubthread
       /* for lock free structures */
       lf_tran_entry *tran_entries[THREAD_TS_COUNT];
 
+      /* for supplemental log */
+      bool no_supplemental_log;
+
 #if !defined(NDEBUG)
       fi_test_item *fi_test_array;
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -12791,6 +12791,9 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 		  goto exit;
 		}
 
+              /* No supplemental log for insert is appended due to DDL statement */
+              thread_p->no_supplemental_log = true;
+
 	      /* make sure that pruning does not change the given class OID */
 	      COPY_OID (&cls_oid, class_oid);
 	      error =

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -12791,8 +12791,8 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 		  goto exit;
 		}
 
-              /* No supplemental log for insert is appended due to DDL statement */
-              thread_p->no_supplemental_log = true;
+	      /* No supplemental log for insert is appended due to DDL statement */
+	      thread_p->no_supplemental_log = true;
 
 	      /* make sure that pruning does not change the given class OID */
 	      COPY_OID (&cls_oid, class_oid);
@@ -12804,6 +12804,8 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 		{
 		  goto exit;
 		}
+
+	      thread_p->no_supplemental_log = false;
 	    }
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23911

This PR is for not appending supplemental logs. 

Some supplemental logs for DML are able to be appended redundantly by the DDL supplemental logs.
Therefore, supplemental logs for DML are required to be blocked if the logs are generated during DDL execution. 

To block the DML supplemental log, /*+ NO_SUPPLEMENTAL_LOG */ hint is added, and it implemented as /*+ NO_LOGGING */ hint. 
