### PR TITLE
[CBRD-23911] Implement log append functions for supplemental log

### DIFF
--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -339,6 +339,7 @@ prior_lsa_alloc_and_copy_data (THREAD_ENTRY *thread_p, LOG_RECTYPE rec_type, LOG
     case LOG_DUMMY_HA_SERVER_STATE:
     case LOG_DUMMY_OVF_RECORD:
     case LOG_DUMMY_GENERIC:
+    case LOG_SUPPLEMENTAL_INFO:
 
     case LOG_2PC_COMMIT_DECISION:
     case LOG_2PC_ABORT_DECISION:
@@ -1279,7 +1280,9 @@ prior_lsa_gen_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_RECTYPE 
     case LOG_END_CHKPT:
       node->data_header_length = sizeof (LOG_REC_CHKPT);
       break;
-
+    case LOG_SUPPLEMENTAL_INFO:
+      node->data_header_length = sizeof (LOG_REC_SUPPLEMENT);
+      break;
     default:
       break;
     }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -4639,10 +4639,6 @@ log_append_donetime_internal (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA 
     }
 
   LSA_COPY (eot_lsa, &lsa);
-#if !defined(NDEBUG) && 1	//JOOHOK
-  _er_log_debug (ARG_FILE_LINE, "LOG_TYPE : %s , time : %lld, LSA : %lld|%d \n ", log_to_string (iscommitted),
-		 donetime->at_time, LSA_AS_ARGS (eot_lsa));
-#endif
 }
 
 /*

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -166,6 +166,13 @@ extern int log_get_next_nested_top (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LO
 				    LOG_TOPOP_RANGE ** out_nxtop_range_stack);
 extern void log_append_repl_info (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool is_commit);
 
+extern void log_append_supplemental_log (THREAD_ENTRY * thread_p, SUPPLEMENT_REC_TYPE rec_type, int length,
+					 const void *data);
+extern int log_append_supplemental_lsa (THREAD_ENTRY * thread_p, SUPPLEMENT_REC_TYPE rec_type, OID * classoid,
+					LOG_LSA * undo_lsa, LOG_LSA * redo_lsa);
+
+extern int log_append_supplemental_undo_record (THREAD_ENTRY * thread_p, RECDES * undo_recdes);
+
 /*
  * FOR DEBUGGING
  */

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -133,6 +133,8 @@ enum log_rectype
   LOG_DUMMY_GENERIC,		/* used for flush for now. it is ridiculous to create dummy log records for every single
 				 * case. we should find a different approach */
 
+  LOG_SUPPLEMENTAL_INFO,
+
   LOG_LARGER_LOGREC_TYPE	/* A higher bound for checks */
 };
 typedef enum log_rectype LOG_RECTYPE;
@@ -401,6 +403,28 @@ typedef struct log_rec_2pc_particp_ack LOG_REC_2PC_PARTICP_ACK;
 struct log_rec_2pc_particp_ack
 {
   int particp_index;		/* Index of the acknowledging participant */
+};
+
+typedef enum supplement_rec_type
+{
+  LOG_SUPPLEMENT_TRAN_USER,
+  LOG_SUPPLEMENT_UNDO_RECORD, /*CONTAINS undo raw record */
+  LOG_SUPPLEMENT_DDL,
+/* CONTAINS LSA of logs which contain undo, redo raw record 
+ * | LOG_REC_HEADER | SUPPLEMENT_REC_TYPE | LENGTH | CLASS OID |  UNDO LSA (sizeof LOG_LSA) | REDO LSA | */
+  LOG_SUPPLEMENT_UPDATE, 
+  LOG_SUPPLEMENT_DELETE,
+  LOG_SUPPLEMENT_INSERT,
+  LOG_SUPPLEMENT_CLASS_OID,
+  LOG_SUPPLEMENT_STATEMENT,
+  LOG_SUPPLEMENT_LARGER_REC_TYPE,
+} SUPPLEMENT_REC_TYPE;
+
+typedef struct log_rec_supplement LOG_REC_SUPPLEMENT;
+struct log_rec_supplement
+{
+  SUPPLEMENT_REC_TYPE rec_type;
+  int length;
 };
 
 #define LOG_GET_LOG_RECORD_HEADER(log_page_p, lsa) \

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -410,9 +410,9 @@ typedef enum supplement_rec_type
   LOG_SUPPLEMENT_TRAN_USER,
   LOG_SUPPLEMENT_UNDO_RECORD, /*CONTAINS undo raw record */
   LOG_SUPPLEMENT_DDL,
-/* CONTAINS LSA of logs which contain undo, redo raw record 
- * | LOG_REC_HEADER | SUPPLEMENT_REC_TYPE | LENGTH | CLASS OID |  UNDO LSA (sizeof LOG_LSA) | REDO LSA | */
-  LOG_SUPPLEMENT_UPDATE, 
+  /* CONTAINS LSA of logs which contain undo, redo raw record
+   * | LOG_REC_HEADER | SUPPLEMENT_REC_TYPE | LENGTH | CLASS OID |  UNDO LSA (sizeof LOG_LSA) | REDO LSA | */
+  LOG_SUPPLEMENT_UPDATE,
   LOG_SUPPLEMENT_DELETE,
   LOG_SUPPLEMENT_INSERT,
   LOG_SUPPLEMENT_CLASS_OID,

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2323,6 +2323,7 @@ log_rv_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE log_type, int tran_
     case LOG_DUMMY_HA_SERVER_STATE:
     case LOG_DUMMY_OVF_RECORD:
     case LOG_DUMMY_GENERIC:
+    case LOG_SUPPLEMENTAL_INFO:
       break;
 
     case LOG_SMALLER_LOGREC_TYPE:
@@ -3998,6 +3999,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 	    case LOG_DUMMY_HA_SERVER_STATE:
 	    case LOG_DUMMY_OVF_RECORD:
 	    case LOG_DUMMY_GENERIC:
+	    case LOG_SUPPLEMENTAL_INFO:
 	    case LOG_END_OF_LOG:
 	    case LOG_SYSOP_ATOMIC_START:
 	      break;
@@ -4799,6 +4801,7 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		case LOG_DUMMY_HA_SERVER_STATE:
 		case LOG_DUMMY_OVF_RECORD:
 		case LOG_DUMMY_GENERIC:
+		case LOG_SUPPLEMENTAL_INFO:
 		case LOG_SYSOP_ATOMIC_START:
 		  /* Not for UNDO ... */
 		  /* Break switch to go to previous record */
@@ -5451,6 +5454,7 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
   LOG_REC_2PC_START *start_2pc;	/* A 2PC start log record */
   LOG_REC_2PC_PREPCOMMIT *prepared;	/* A 2PC prepare to commit */
   LOG_REC_REPLICATION *repl_log;
+  LOG_REC_SUPPLEMENT *supplement;
 
   int undo_length;		/* Undo length */
   int redo_length;		/* Redo length */
@@ -5734,6 +5738,11 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
       LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_2PC_PARTICP_ACK), &log_lsa, log_pgptr);
       break;
 
+    case LOG_SUPPLEMENTAL_INFO:
+      LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_SUPPLEMENT), &log_lsa, log_pgptr);
+      supplement = (LOG_REC_SUPPLEMENT *) ((char *) log_pgptr->area + log_lsa.offset);
+      LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_SUPPLEMENT), &log_lsa, log_pgptr);
+      LOG_READ_ADD_ALIGN (thread_p, supplement->length, &log_lsa, log_pgptr);
     case LOG_WILL_COMMIT:
     case LOG_START_CHKPT:
     case LOG_2PC_COMMIT_DECISION:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23911

Implemented log_append_supplemental_*
Ignore supplemental logs when recovery processed