### PR TITLE
[CBRD-23911] Supplemental logs for DML, User

### DIFF
--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -542,6 +542,8 @@ struct log_tdes
 
   log_postpone_cache m_log_postpone_cache;
 
+  bool has_supplemental_log;	/* Checks if supplemental log has been appended within the transaction */
+
   // *INDENT-OFF*
 #if defined (SERVER_MODE) || (defined (SA_MODE) && defined (__cplusplus))
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1564,6 +1564,7 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   tdes->num_exec_queries = 0;
   tdes->suppress_replication = 0;
   tdes->m_log_postpone_cache.reset ();
+  tdes->has_supplemental_log = false;
 
   logtb_tran_clear_update_stats (&tdes->log_upd_stats);
 
@@ -1676,6 +1677,8 @@ logtb_initialize_tdes (LOG_TDES * tdes, int tran_index)
 
   tdes->block_global_oldest_active_until_commit = false;
   tdes->is_user_active = false;
+
+  tdes->has_supplemental_log = false;
 
   LSA_SET_NULL (&tdes->rcv.tran_start_postpone_lsa);
   LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23911

1. DML : class OID, undo, redo LSA are recorded in supplemental logs
   - when DML (insert, update, delete) logs are appended. 
2. User : transaction user is recorded in supplemental logs
   - when supplemental log is first appended in the transaction 
   - when commit log is appended 
