### PR TITLE
[CBRD-23903] Fix slip: BIGINT return type of COUNT for hash scan

### DIFF
--- a/src/query/query_aggregate.cpp
+++ b/src/query/query_aggregate.cpp
@@ -2037,7 +2037,7 @@ qdata_alloc_agg_hvalue (cubthread::entry *thread_p, int func_cnt, cubxasl::aggre
       /* This set is made, because if class is empty, aggregate results should return NULL, except count(*) and count */
       if (agg_p->function == PT_COUNT_STAR || agg_p->function == PT_COUNT)
 	{
-	  db_make_int (value->accumulators[i].value, 0);
+	  db_make_bigint (value->accumulators[i].value, 0);
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23903

Because of this slip, in hash scanning, counting logic increments for an uninitialized value so that an unexpected value is returned at the end.
Specically, by the `db_make_int()`, `value.data.i` is initialized to 0. but the following counting logic increments from the uninitialized `value.data.bigint` value.

```
// This repro is from http://jira.cubrid.org/browse/CBRD-23605.
drop table tmp_hash;
create table tmp_hash(num int, col1 varchar(50));
insert into tmp_hash select 0,'9999' from db_class c limit 2;
insert into tmp_hash select rownum,a.* from (select mod(rownum,300) from table({1,2,3,4,5,6,7,8,9,0}) a, table({1,2,3,4,5,6,7,8,9,0}) b, table({1,2,3,4,5,6,7,8,9,0}) c limit 300) a, table({1,2,3}) b;
insert into tmp_hash select 999,'9999' from db_class c limit 4;
create index idx on tmp_hash(num);
select /*+ recompile */ * 
  from (
         select col1,
                count(CASE
                      WHEN col1 = -1 THEN 1
                      END) AS "count_col1"
           from tmp_hash 
          where num >= 0
          group by col1) a
where count_col1 > 0;
```