### PR TITLE
[CBRD-24009] Plan cache is not updated when view changes including inline view.

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -8865,12 +8865,6 @@ mq_class_lambda (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * class_,
 		}
 	      else
 		{
-		  if (newspec->info.spec.entity_name == NULL)
-		    {
-		      newspec->info.spec.entity_name = spec->info.spec.entity_name;
-		      /* spec will be free later, we don't want the entity_name will be freed */
-		      spec->info.spec.entity_name = NULL;
-		    }
 		  newspec->info.spec.range_var->info.name.original = spec->info.spec.range_var->info.name.original;
 		}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24009

Plan cache is not updated when view changes including inline view.
```
view : select * from (select * from tbl .... )
     ==> spec.entity_name = null
         spec.derived_table = (select ... )

select * from view ...
  ==> spec.entity_name = "view"
      derived_table = null

pushed : select * from (select * from tbl ... )
         ==> spec.entity_name = "view"                 <=== cause of problem
             derived_table = (select ... )  
```
spec.entity_name is not needed to copy. This routine is added in CUBRIDSUS-13334.
but CUBRIDSUS-13334 related tests do not cause any problems now.
I delete the added routine in CUBRIDSUS-13334.

