### PR TITLE
[LETS-161] Proper default identity for thread entry

### DIFF
--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -77,7 +77,7 @@ namespace cubthread
   entry::entry ()
   // public:
     : index (-1)
-    , type (TT_WORKER)
+    , type (TT_MASTER)
     , emulate_tid ()
     , client_id (-1)
     , tran_index (NULL_TRAN_INDEX)

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -77,7 +77,7 @@ namespace cubthread
   entry::entry ()
   // public:
     : index (-1)
-    , type (TT_MASTER)
+    , type (TT_NONE)
     , emulate_tid ()
     , client_id (-1)
     , tran_index (NULL_TRAN_INDEX)

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -487,6 +487,7 @@ namespace cubthread
     // init main entry
     assert (Main_entry_p == NULL);
     Main_entry_p = new entry ();
+    Main_entry_p->type = TT_MASTER;
     Main_entry_p->index = 0;
     Main_entry_p->register_id ();
     Main_entry_p->m_status = entry::status::TS_RUN;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-161

By default, a thread in the thread pool is created with the `TT_WORKER` identity.
This is misleading when analyzing perf results because the perf module identifies `TT_WORKER` as belonging to the `PERF_MODULE_USER` module type - as per `perfmon_get_module_type` function.
Construct a thread entry with `TT_NONE` and initialize with `TT_MASTER`.
Thus, perf collected on a default constructed thread entry will be assigned to the `PERF_MODULE_SYSTEM` module type.

