### PR TITLE
[LETS-150] Register page in the data page broker before requesting from page server

### DIFF
--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -402,7 +402,7 @@ void active_tran_server::receive_data_page (cubpacking::unpacker &upk)
 
       if (prm_get_bool_value (PRM_ID_ER_LOG_READ_DATA_PAGE))
 	{
-	  _er_log_debug (ARG_FILE_LINE, "Received data page message from Page Server. Error: %d \n", error_code);
+	  _er_log_debug (ARG_FILE_LINE, "[READ DATA] Received error: %d \n", error_code);
 	}
     }
   else
@@ -420,8 +420,8 @@ void active_tran_server::receive_data_page (cubpacking::unpacker &upk)
 
       if (prm_get_bool_value (PRM_ID_ER_LOG_READ_DATA_PAGE))
 	{
-	  _er_log_debug (ARG_FILE_LINE, "Received data page message from Page Server. LSA: %lld|%d, Page ID: %ld, Volid: %d",
-			 LSA_AS_ARGS (&io_page->prv.lsa), io_page->prv.pageid, io_page->prv.volid);
+	  _er_log_debug (ARG_FILE_LINE, "[READ DATA] Received data page VPID: %d|%d, LSA: %lld|%d \n",
+			 io_page->prv.volid, io_page->prv.pageid, LSA_AS_ARGS (&io_page->prv.lsa));
 	}
     }
 }

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -194,12 +194,12 @@ void page_server::on_data_page_read_result (const FILEIO_PAGE *io_page, int erro
     {
       if (error_code == NO_ERROR)
 	{
-	  _er_log_debug (ARG_FILE_LINE, "Sending data page.. LSA: %lld|%d, Page ID: %ld, Volid: %d",
-			 LSA_AS_ARGS (&io_page->prv.lsa), io_page->prv.pageid, io_page->prv.volid);
+	  _er_log_debug (ARG_FILE_LINE, "[READ DATA] Sending data page.. VPID: %d|%d, LSA: %lld|%d\n",
+			 io_page->prv.volid, io_page->prv.pageid, LSA_AS_ARGS (&io_page->prv.lsa));
 	}
       else
 	{
-	  _er_log_debug (ARG_FILE_LINE, "Sending data page.. Error code: %d\n", error_code);
+	  _er_log_debug (ARG_FILE_LINE, "[READ DATA] Sending data page.. Error code: %d\n", error_code);
 	}
     }
 

--- a/src/storage/page_broker.hpp
+++ b/src/storage/page_broker.hpp
@@ -128,8 +128,8 @@ page_broker<PageT>::wait_for_page (typename map_type<PageT>::key id)
 
   auto result = m_received_pages[id];
 
-  m_requested_page_id_count[id]--;
-  if (m_requested_page_id_count[id] == 0)
+  assert (m_requested_page_id_count[id] > 0);
+  if (--m_requested_page_id_count[id] == 0)
     {
       m_requested_page_id_count.erase (id);
       m_received_pages.erase (id);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -7915,7 +7915,9 @@ pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * 
 
       if (prm_get_bool_value (PRM_ID_ER_LOG_READ_DATA_PAGE))
 	{
-	  FILEIO_PAGE_RESERVED prv = reinterpret_cast < FILEIO_PAGE * >(io_page)->prv;
+	  // *INDENT-OFF*
+	  FILEIO_PAGE_RESERVED prv = reinterpret_cast<FILEIO_PAGE *> (io_page)->prv;
+	  // *INDENT-ON*
 	  _er_log_debug (ARG_FILE_LINE, "[READ DATA] Received data page VPID: %d|%d LSA=%lld|%d\n",
 			 prv.volid, prv.pageid, LSA_AS_ARGS (&prv.lsa));
 	}

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1044,7 +1044,9 @@ static PGBUF_BCB *pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID *
 					   PGBUF_BUFFER_HASH * hash_anchor, PGBUF_FIX_PERF * perf, bool * try_again);
 static int pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * vpid, void *io_page);
 static int pgbuf_read_page_from_file (THREAD_ENTRY * thread_p, const VPID * vpid, void *io_page);
+#if defined (SERVER_MODE)
 static void pgbuf_request_data_page_from_page_server (const VPID * vpid);
+#endif // SERVER_MODE
 static int pgbuf_victimize_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr);
 static int pgbuf_bcb_safe_flush_internal (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, bool synchronous, bool * locked);
 static int pgbuf_invalidate_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr);
@@ -7900,6 +7902,7 @@ pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * 
     {
       pgbuf_request_data_page_from_page_server (vpid);
       auto data_page = ats_Gl.get_data_page_broker ().wait_for_page (*vpid);
+
       if (read_from_local)
 	{
 	  // *INDENT-OFF*
@@ -7909,6 +7912,13 @@ pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * 
 	}
 
       std::memcpy (io_page, data_page->c_str (), db_io_page_size ());
+
+      if (prm_get_bool_value (PRM_ID_ER_LOG_READ_DATA_PAGE))
+	{
+	  FILEIO_PAGE_RESERVED prv = reinterpret_cast < FILEIO_PAGE * >(io_page)->prv;
+	  _er_log_debug (ARG_FILE_LINE, "[READ DATA] Received data page VPID: %d|%d LSA=%lld|%d\n",
+			 prv.volid, prv.pageid, LSA_AS_ARGS (&prv.lsa));
+	}
     }
   return NO_ERROR;
 #else // !SERVER_MODE = SA_MODE
@@ -7941,6 +7951,7 @@ pgbuf_read_page_from_file (THREAD_ENTRY * thread_p, const VPID * vpid, void *io_
   return NO_ERROR;
 }
 
+#if defined (SERVER_MODE)
 /*
  * pgbuf_request_data_page_from_page_server () - Sends a request for a page to Page Server.
  *   return: void
@@ -7948,34 +7959,34 @@ pgbuf_read_page_from_file (THREAD_ENTRY * thread_p, const VPID * vpid, void *io_
 static void
 pgbuf_request_data_page_from_page_server (const VPID * vpid)
 {
-#if defined (SERVER_MODE)
+  assert (get_server_type () == SERVER_TYPE_TRANSACTION);
+
   // *INDENT-OFF*
   /* Send a request to Page Server for the Page. */
-  if (get_server_type () == SERVER_TYPE_TRANSACTION)
+  auto entry_state = ats_Gl.get_data_page_broker ().register_entry (*vpid);
+  assert (entry_state == page_broker_register_entry_state::ADDED);
+
+  cubpacking::packer pac;
+  size_t size = 0;
+
+  size += cublog::lsa_utils::get_packed_size (pac, size);
+  size += vpid_utils::get_packed_size (pac, size);
+  std::unique_ptr<char[]> buffer (new char[size]);
+
+  pac.set_buffer (buffer.get (), size);
+  vpid_utils::pack (pac, *vpid);
+  LOG_LSA lsa = pgbuf_Pool.get_highest_evicted_lsa ();
+  cublog::lsa_utils::pack (pac, lsa);
+
+  std::string message (buffer.get (), size);
+  ats_Gl.push_request (ats_to_ps_request::SEND_DATA_PAGE_FETCH, std::move (message));
+  if (prm_get_bool_value (PRM_ID_ER_LOG_READ_DATA_PAGE))
     {
-      cubpacking::packer pac;
-      size_t size = 0;
-
-      size += cublog::lsa_utils::get_packed_size (pac, size);
-      size += vpid_utils::get_packed_size (pac, size);
-      std::unique_ptr<char[]> buffer (new char[size]);
-
-      pac.set_buffer (buffer.get (), size);
-      vpid_utils::pack (pac, *vpid);
-      LOG_LSA lsa = pgbuf_Pool.get_highest_evicted_lsa ();
-      cublog::lsa_utils::pack (pac, lsa);
-
-      std::string message (buffer.get (), size);
-      ats_Gl.push_request (ats_to_ps_request::SEND_DATA_PAGE_FETCH, std::move (message));
-      if (prm_get_bool_value (PRM_ID_ER_LOG_READ_DATA_PAGE))
-        {
-          _er_log_debug (ARG_FILE_LINE, "Sent request for Page to Page Server. pageid: %ld volid: %d\n", vpid->pageid,
-                      vpid->volid);
-	}
+      _er_log_debug (ARG_FILE_LINE, "[READ DATA] Sent request for Page to Page Server. VPID: %d|%d\n", VPID_AS_ARGS (vpid));
     }
   // *INDENT-ON*
-#endif // SERVER_MODE
 }
+#endif // SERVER_MODE
 
 /*
  * pgbuf_victimize_bcb () - Victimize given buffer page


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-150

Fix data page corruption caused by bug in data page request handling. Before requesting and waiting for a data page, it is meant to be registered in the page broker first. This registration is missing.

As consequence, the request count tracked by the page broker starts as 0 and is decremented to -1 when the page is first served. The condition to remove it from page broker, `count == 0`, never happens. When the same page is requested a second time, the initial version of the page is found in the broker and used. Any changes after this version are lost in the process.

Fix by correcting the page registration in the broker before requesting it from page server. Add a safe-guard that the count stays always positive or zero.

Added additional logging and normalized how VPID's are printed.