### PR TITLE
[CBRD-24010] Predicate push dose not work in nested subqueries.

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -7351,6 +7351,17 @@ qo_optimize_queries (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *co
 	    {
 	      return node;	/* give up */
 	    }
+
+	  /* predicate push */
+	  spec = node->info.query.q.select.from;
+	  while (spec)
+	    {
+	      if (spec->info.spec.derived_table_type == PT_IS_SUBQUERY)
+		{
+		  (void) mq_copypush_sargable_terms (parser, node, spec);
+		}
+	      spec = spec->next;
+	    }
 	}
 
       /* auto-parameterization is safe when it is done as the last step of rewrite optimization */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -11441,7 +11441,6 @@ pt_print_expr (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_RANGE:
       if (parser->custom_print & PT_CONVERT_RANGE)
 	{
-	  bool multiple_element = false;
 	  PT_STRING_BLOCK sb;
 	  sb.length = 0;
 	  sb.size = 1024;
@@ -11460,19 +11459,18 @@ pt_print_expr (PARSER_CONTEXT * parser, PT_NODE * p)
 	  if (p->info.expr.arg2 && p->info.expr.arg2->or_next)
 	    {
 	      strcat_with_realloc (&sb, "(");
-	      multiple_element = true;
 	    }
 
 	  for (t = p->info.expr.arg2; t; t = t->or_next)
 	    {
-	      if (!p->info.expr.paren_type && multiple_element)
+	      if (!p->info.expr.paren_type)
 		{
 		  strcat_with_realloc (&sb, "(");
 		}
 
 	      pt_print_range_op (parser, &sb, t, r4);
 
-	      if (!p->info.expr.paren_type && multiple_element)
+	      if (!p->info.expr.paren_type)
 		{
 		  strcat_with_realloc (&sb, ")");
 		}

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -11441,6 +11441,7 @@ pt_print_expr (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_RANGE:
       if (parser->custom_print & PT_CONVERT_RANGE)
 	{
+	  bool multiple_element = false;
 	  PT_STRING_BLOCK sb;
 	  sb.length = 0;
 	  sb.size = 1024;
@@ -11459,18 +11460,19 @@ pt_print_expr (PARSER_CONTEXT * parser, PT_NODE * p)
 	  if (p->info.expr.arg2 && p->info.expr.arg2->or_next)
 	    {
 	      strcat_with_realloc (&sb, "(");
+	      multiple_element = true;
 	    }
 
 	  for (t = p->info.expr.arg2; t; t = t->or_next)
 	    {
-	      if (!p->info.expr.paren_type)
+	      if (!p->info.expr.paren_type && multiple_element)
 		{
 		  strcat_with_realloc (&sb, "(");
 		}
 
 	      pt_print_range_op (parser, &sb, t, r4);
 
-	      if (!p->info.expr.paren_type)
+	      if (!p->info.expr.paren_type && multiple_element)
 		{
 		  strcat_with_realloc (&sb, ")");
 		}

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3198,6 +3198,14 @@ mq_copypush_sargable_terms_helper (PARSER_CONTEXT * parser, PT_NODE * statement,
 
   for (term = statement->info.query.q.select.where; term; term = term->next)
     {
+      /* check for on_cond term */
+      assert (term->node_type == PT_EXPR || term->node_type == PT_VALUE);
+      if ((term->node_type == PT_EXPR && term->info.expr.location > 0)
+	  || (term->node_type == PT_VALUE && term->info.expr.location > 0))
+	{
+	  continue;		/* do not copy-push on_cond-term */
+	}
+
       /* check for nullable-term */
       if (term->node_type == PT_EXPR)
 	{

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -213,7 +213,6 @@ static void pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE 
 			       FIND_ID_TYPE type);
 static int mq_copypush_sargable_terms_helper (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * spec,
 					      PT_NODE * new_query, FIND_ID_INFO * infop);
-static int mq_copypush_sargable_terms (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * spec);
 static PT_NODE *mq_rewrite_vclass_spec_as_derived (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * spec,
 						   PT_NODE * query_spec);
 static PT_NODE *mq_translate_select (PARSER_CONTEXT * parser, PT_NODE * select_statement);
@@ -3292,7 +3291,7 @@ mq_copypush_sargable_terms_helper (PARSER_CONTEXT * parser, PT_NODE * statement,
  *   statement(in):
  *   spec(in):
  */
-static int
+int
 mq_copypush_sargable_terms (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * spec)
 {
   PT_NODE *derived_table;
@@ -4630,10 +4629,6 @@ mq_check_rewrite_select (PARSER_CONTEXT * parser, PT_NODE * select_statement)
 	      return NULL;
 	    }
 	}
-      else if (from->info.spec.derived_table_type == PT_IS_SUBQUERY)
-	{
-	  (void) mq_copypush_sargable_terms (parser, select_statement, from);
-	}
 
       while (from->next)
 	{
@@ -4646,10 +4641,6 @@ mq_check_rewrite_select (PARSER_CONTEXT * parser, PT_NODE * select_statement)
 	  if (is_union_translation != 0)
 	    {
 	      from->next = mq_rewrite_vclass_spec_as_derived (parser, select_statement, from->next, NULL);
-	    }
-	  else if (from->next->info.spec.derived_table_type == PT_IS_SUBQUERY)
-	    {
-	      (void) mq_copypush_sargable_terms (parser, select_statement, from->next);
 	    }
 	  from = from->next;
 	}
@@ -4672,11 +4663,6 @@ mq_check_rewrite_select (PARSER_CONTEXT * parser, PT_NODE * select_statement)
 	      select_statement->info.query.q.select.from =
 		mq_rewrite_vclass_spec_as_derived (parser, select_statement, from, NULL);
 	    }
-	}
-
-      if (is_union_translation == false && from && from->info.spec.derived_table_type == PT_IS_SUBQUERY)
-	{
-	  (void) mq_copypush_sargable_terms (parser, select_statement, from);
 	}
     }
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -6258,13 +6258,11 @@ mq_translate_helper (PARSER_CONTEXT * parser, PT_NODE * node)
     case PT_DIFFERENCE:
     case PT_INTERSECTION:
       /*
-       * The mq_push_paths will convert the expression as CNF. if subquery is
-       * in the expression, it may be copied several times. To avoid repeatedly
-       * convert the expressions in subqueries and improve performance, we
-       * put mq_push_paths as post function.
+       * mq_push_paths : pushing paths (including predicate push)
+       * mq_translate_local : view pushing (view merging)
+       * mq_push_paths should be invoked in pre-order. mq_translate_local should be in post-order.
        */
-      node = parser_walk_tree (parser, node, NULL, NULL, mq_push_paths, NULL);
-      node = parser_walk_tree (parser, node, NULL, NULL, mq_translate_local, NULL);
+      node = parser_walk_tree (parser, node, mq_push_paths, NULL, mq_translate_local, NULL);
 
       mq_bump_order_dep_corr_lvl (parser, node);
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -6258,11 +6258,13 @@ mq_translate_helper (PARSER_CONTEXT * parser, PT_NODE * node)
     case PT_DIFFERENCE:
     case PT_INTERSECTION:
       /*
-       * mq_push_paths : pushing paths (including predicate push)
-       * mq_translate_local : view pushing (view merging)
-       * mq_push_paths should be invoked in pre-order. mq_translate_local should be in post-order.
+       * The mq_push_paths will convert the expression as CNF. if subquery is
+       * in the expression, it may be copied several times. To avoid repeatedly
+       * convert the expressions in subqueries and improve performance, we
+       * put mq_push_paths as post function.
        */
-      node = parser_walk_tree (parser, node, mq_push_paths, NULL, mq_translate_local, NULL);
+      node = parser_walk_tree (parser, node, NULL, NULL, mq_push_paths, NULL);
+      node = parser_walk_tree (parser, node, NULL, NULL, mq_translate_local, NULL);
 
       mq_bump_order_dep_corr_lvl (parser, node);
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3201,7 +3201,7 @@ mq_copypush_sargable_terms_helper (PARSER_CONTEXT * parser, PT_NODE * statement,
       /* check for on_cond term */
       assert (term->node_type == PT_EXPR || term->node_type == PT_VALUE);
       if ((term->node_type == PT_EXPR && term->info.expr.location > 0)
-	  || (term->node_type == PT_VALUE && term->info.expr.location > 0))
+	  || (term->node_type == PT_VALUE && term->info.value.location > 0))
 	{
 	  continue;		/* do not copy-push on_cond-term */
 	}

--- a/src/parser/view_transform.h
+++ b/src/parser/view_transform.h
@@ -96,4 +96,6 @@ extern PT_NODE *mq_reset_ids_in_methods (PARSER_CONTEXT * parser, PT_NODE * stat
 extern PT_NODE *mq_rewrite_aggregate_as_derived (PARSER_CONTEXT * parser, PT_NODE * agg_sel);
 
 extern PT_NODE *mq_rewrite_query_as_derived (PARSER_CONTEXT * parser, PT_NODE * query);
+
+extern int mq_copypush_sargable_terms (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * spec);
 #endif /* _VIEW_TRANSFORM_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24010
http://jira.cubrid.org/browse/CBRD-24001

This change solves the problem below.
1. nested subquery problem (CBRD-24010)
2. indirect predicate problem (CBRD-24001)
3. Perform predicate push after changing outer join to inner join (newly discovered problem)

**CBRD-24010**
The predicate push should be performed from the outermost to the inner subquery.
```
select ... 
   from ( select ... 
               from (select ...
                        from 
                        c.col1 =1  <== second push
                      ) c
           c.col1 =1  <== first push
           ) b      
  where b.col1 =1
```
When walking the tree, mq_push_path () is invoked in post order. So, it is executed from the innermost subquery.

mq_translate_helper()
```
node = parser_walk_tree (parser, node, NULL, NULL, mq_push_paths, NULL);

mq_push_paths()
  mq_copypush_sargable_terms() <== predicate push
```
I fix that mq_copypush_sargable_terms() is invoked in pre-order.

**CBRD-24001**
A predicate push is performed before a transitive predicate generation. This causes problems.
I move the location of mq_copypush_sargable_terms() in mq_optimize().
```
mq_translate
mq_translate_helper
  mq_push_paths
    mq_check_rewrite_select
      mq_copypush_sargable_terms  <== old location
  mq_optimize  
    qo_optimize_queries
      qo_reduce_equality_terms <== Transitive Predicate Generation
      qo_rewrite_outerjoin <== rewrite outerjoin to innerjoin
      mq_copypush_sargable_terms  <== new location, invoked in pre-order
```

