### PR TITLE
[LETS-168] Identify recovery thread as belonging to user module for perf purposes

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -1870,13 +1870,13 @@ perfmon_get_module_type (THREAD_ENTRY * thread_p)
   switch (thread_p->type)
     {
     case TT_WORKER:
+    case TT_RECOVERY:
       return PERF_MODULE_USER;
     case TT_VACUUM_WORKER:
     case TT_VACUUM_MASTER:
       return PERF_MODULE_VACUUM;
     case TT_REPLICATION:
       return PERF_MODULE_REPLICATION;
-    case TT_RECOVERY:
     default:
       return PERF_MODULE_SYSTEM;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-168

Change the module the recovery thread is reported as belonging to from SYSTEM to USER for perf purposes.
