### PR TITLE
[LETS-131] Adapt disk volume add/expand to transaction server with remote storage

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -567,9 +567,12 @@ disk_format (THREAD_ENTRY * thread_p, const char *dbname, VOLID volid, DBDEF_VOL
     }
   fault_inject_random_crash ();
 
-  /* this log must be flushed. */
-  logpb_force_flush_pages (thread_p);	//todo
-  fault_inject_random_crash ();
+  if (!is_tran_server_with_remote_storage ())
+    {
+      /* this log must be flushed. */
+      logpb_force_flush_pages (thread_p);
+      fault_inject_random_crash ();
+    }
 
   if (!(is_tran_server_with_remote_storage () && ext_info->voltype == DB_PERMANENT_VOLTYPE))
     {

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -1983,17 +1983,20 @@ disk_volume_expand (THREAD_ENTRY * thread_p, VOLID volid, DB_VOLTYPE voltype, DK
 
   FI_TEST (thread_p, FI_TEST_DISK_MANAGER_VOLUME_EXPAND, 0);
 
-  /* expand volume */
-  error_code = fileio_expand_to (thread_p, volid, volume_new_npages, voltype);
-  if (error_code != NO_ERROR)
+  if (!(is_tran_server_with_remote_storage () && voltype == DB_PERMANENT_VOLTYPE))
     {
-      // important note - we just committed volume expansion; we cannot afford any failures here
-      // caller won't update cache!!
-      assert (false);
-      return error_code;
-    }
+      /* expand volume */
+      error_code = fileio_expand_to (thread_p, volid, volume_new_npages, voltype);
+      if (error_code != NO_ERROR)
+	{
+	  // important note - we just committed volume expansion; we cannot afford any failures here
+	  // caller won't update cache!!
+	  assert (false);
+	  return error_code;
+	}
 
-  FI_TEST (thread_p, FI_TEST_DISK_MANAGER_VOLUME_EXPAND, 0);
+      FI_TEST (thread_p, FI_TEST_DISK_MANAGER_VOLUME_EXPAND, 0);
+    }
 
   *nsect_extended_out = nsect_extend;
 

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -89,6 +89,7 @@
 #include "vacuum.h"
 #endif /* SERVER_MODE */
 #include "crypt_opfunc.h"
+#include "server_type.hpp"
 
 #if defined(WINDOWS)
 #include "wintcp.h"
@@ -6497,25 +6498,34 @@ fileio_find_next_perm_volume (THREAD_ENTRY * thread_p, VOLID volid)
 VOLID
 fileio_find_previous_perm_volume (THREAD_ENTRY * thread_p, VOLID volid)
 {
-  FILEIO_VOLUME_INFO *vol_info_p;
-  APPLY_ARG arg = { 0 };
-
-  if (volid == NULL_VOLID)
+  if (is_tran_server_with_remote_storage ())
     {
+      // volumes are always assigned successively
+      assert (volid > 0);
+      return volid - 1;
+    }
+  else
+    {
+      FILEIO_VOLUME_INFO *vol_info_p;
+      APPLY_ARG arg = { 0 };
+
+      if (volid == NULL_VOLID)
+	{
+	  return NULL_VOLID;
+	}
+
+      FILEIO_CHECK_AND_INITIALIZE_VOLUME_HEADER_CACHE (NULL_VOLID);
+
+      arg.vol_id = volid;
+      vol_info_p = fileio_reverse_traverse_permanent_volume (thread_p, fileio_is_volume_id_lt, &arg);
+      if (vol_info_p)
+	{
+	  assert (fileio_get_volume_descriptor (volid) != NULL_VOLDES);
+	  return vol_info_p->volid;
+	}
+
       return NULL_VOLID;
     }
-
-  FILEIO_CHECK_AND_INITIALIZE_VOLUME_HEADER_CACHE (NULL_VOLID);
-
-  arg.vol_id = volid;
-  vol_info_p = fileio_reverse_traverse_permanent_volume (thread_p, fileio_is_volume_id_lt, &arg);
-  if (vol_info_p)
-    {
-      assert (fileio_get_volume_descriptor (volid) != NULL_VOLDES);
-      return vol_info_p->volid;
-    }
-
-  return NULL_VOLID;
 }
 
 VOLID

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -89,7 +89,9 @@
 #include "vacuum.h"
 #endif /* SERVER_MODE */
 #include "crypt_opfunc.h"
+#if !defined (CS_MODE)
 #include "server_type.hpp"
+#endif
 
 #if defined(WINDOWS)
 #include "wintcp.h"
@@ -6498,6 +6500,7 @@ fileio_find_next_perm_volume (THREAD_ENTRY * thread_p, VOLID volid)
 VOLID
 fileio_find_previous_perm_volume (THREAD_ENTRY * thread_p, VOLID volid)
 {
+#if !defined (CS_MODE)
   if (is_tran_server_with_remote_storage ())
     {
       // volumes are always assigned successively
@@ -6506,6 +6509,7 @@ fileio_find_previous_perm_volume (THREAD_ENTRY * thread_p, VOLID volid)
     }
   else
     {
+#endif // !CS_MODE
       FILEIO_VOLUME_INFO *vol_info_p;
       APPLY_ARG arg = { 0 };
 
@@ -6525,7 +6529,9 @@ fileio_find_previous_perm_volume (THREAD_ENTRY * thread_p, VOLID volid)
 	}
 
       return NULL_VOLID;
+#if !defined (CS_MODE)
     }
+#endif // !CS_MODE
 }
 
 VOLID

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -6193,7 +6193,7 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
 {
   assert (log_check_system_op_is_started (thread_p));
 
-  if (voltype == DB_PERMANENT_VOLTYPE)
+  if (voltype == DB_PERMANENT_VOLTYPE && !is_tran_server_with_remote_storage ())
     {
       BOOT_DB_PARM saved_boot_db_parm = *boot_Db_parm;
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -6229,7 +6229,8 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
       heap_flush (thread_p, boot_Db_parm_oid);
       fileio_synchronize (thread_p, fileio_get_volume_descriptor (boot_Db_parm_oid->volid), NULL, FILEIO_SYNC_ALSO_FLUSH_DWB);	/* label? */
     }
-  else
+
+  if (voltype == DB_TEMPORARY_VOLTYPE)
     {
       if (boot_Temp_info.temp_nvols < 0 || (boot_Temp_info.temp_nvols == 0 && volid != LOG_MAX_DBVOLID)
 	  || (boot_Temp_info.temp_nvols > 0 && boot_Temp_info.temp_last_volid - 1 != volid))


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-131

Do not create/extend the physical file of a volume on the transaction server with remote storage disk. Disable all log and data flushing to disk.

Assume all volume ID's are consecutive when getting the ID of previous volume.

disk_is_page_sector_reserved_with_debug_crash does not look for volume descriptor on TSRS. It was also rewritten with a unified exit routine.
