### PR TITLE
[CBRD-23917] Daemon Thread Initialization

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -82,6 +82,7 @@
 #include "vacuum.h"
 #include "tde.h"
 #include "porting.h"
+#include "log_manager.h"
 
 #if defined(SERVER_MODE)
 #include "connection_sr.h"
@@ -2495,6 +2496,8 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 #if defined(SERVER_MODE)
   pgbuf_daemons_init ();
   dwb_daemons_init ();
+
+  cdc_daemons_init ();
 #endif /* SERVER_MODE */
 
   // after recovery we can boot vacuum
@@ -2808,6 +2811,8 @@ error:
 #if defined(SERVER_MODE)
   pgbuf_daemons_destroy ();
   dwb_daemons_destroy ();
+
+  cdc_daemons_destroy ();
 #endif
 
   log_final (thread_p);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10214,6 +10214,36 @@ logtb_tran_update_stats_online_index_rb (THREAD_ENTRY * thread_p, void *data, vo
   return error_code;
 }
 
+static cubthread::daemon *cdc_Producer_daemon = NULL;
+
+void cdc_producer_daemon_init()
+{
+  assert (cdc_Producer_daemon == NULL);
+  
+  cubthread::looper looper = cubthread::looper (cdc_get_interval);
+  cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (cdc_log_producer_execute);
+
+  cdc_Producer_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "cdc_log_producer"); 
+}
+
+#if defined (SERVER_MODE)
+static void
+cdc_log_producer_execute (cubthread::entry & thread_ref)
+{
+  if (!BO_IS_SERVER_RESTARTED ())
+  {
+    return;
+  }
+  
+  cdc_log_producer (&thread_ref);
+}
+#endif
+
+void cdc_log_producer (THREAD_ENTRY *thread_p)
+{
+
+}
+
 //
 // log critical section
 //

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10218,17 +10218,17 @@ logtb_tran_update_stats_online_index_rb (THREAD_ENTRY * thread_p, void *data, vo
 }
 
 #if defined (SERVER_MODE)
-static void 
+static void
 cdc_thread_checker (THREAD_ENTRY * thread_p)
 {
-  if (LSA_LE (&log_Reader_info.next_lsa, log_Gl.append.get_nxio_lsa()))
-  {
-    //pthread_cond_signal (&lsa_cond);
-  }
+  if (LSA_LE (&log_Reader_info.next_lsa, log_Gl.append.get_nxio_lsa ()))
+    {
+      //pthread_cond_signal (&lsa_cond);
+    }
 }
 
-static void 
-cdc_log_producer (THREAD_ENTRY *thread_p)
+static void
+cdc_log_producer (THREAD_ENTRY * thread_p)
 {
 
 }
@@ -10278,11 +10278,11 @@ cdc_log_producer_interval (bool & is_timed_wait, cubthread::delta_time & period)
 }
 /* *INDENT-ON* */
 
-void 
-cdc_log_producer_daemon_init()
+void
+cdc_log_producer_daemon_init ()
 {
   assert (cdc_log_Producer_daemon == NULL);
-  
+
   /* *INDENT-OFF* */
   cubthread::looper looper = cubthread::looper (cdc_log_producer_interval);
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (cdc_log_producer_execute);
@@ -10291,8 +10291,8 @@ cdc_log_producer_daemon_init()
   /* *INDENT-ON* */
 }
 
-void 
-cdc_thread_checker_daemon_init()
+void
+cdc_thread_checker_daemon_init ()
 {
   assert (cdc_Thread_checker_daemon == NULL);
 
@@ -10304,15 +10304,15 @@ cdc_thread_checker_daemon_init()
   /* *INDENT-ON* */
 }
 
-void 
-cdc_daemons_init()
+void
+cdc_daemons_init ()
 {
   cdc_log_producer_daemon_init ();
   cdc_thread_checker_daemon_init ();
 }
 
-void 
-cdc_daemons_destroy()
+void
+cdc_daemons_destroy ()
 {
   /* *INDENT-OFF* */
   cubthread::get_manager ()->destroy_daemon (cdc_log_Producer_daemon);
@@ -10320,25 +10320,25 @@ cdc_daemons_destroy()
   /* *INDENT-ON* */
 }
 
-void 
-cdc_wakeup_log_producer()
+void
+cdc_wakeup_log_producer ()
 {
   if (cdc_log_Producer_daemon != NULL)
-  {
-    cdc_log_Producer_daemon->wakeup();
-  }
+    {
+      cdc_log_Producer_daemon->wakeup ();
+    }
 }
 
-void 
-cdc_wakeup_thread_checker()
+void
+cdc_wakeup_thread_checker ()
 {
   if (cdc_Thread_checker_daemon != NULL)
-  {
-    cdc_Thread_checker_daemon->wakeup();
-  }
+    {
+      cdc_Thread_checker_daemon->wakeup ();
+    }
 }
 
-#endif 
+#endif
 
 //
 // log critical section

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -216,6 +216,11 @@ extern void log_flush_daemon_get_stats (UINT64 * statsp);
 
 extern void log_update_global_btid_online_index_stats (THREAD_ENTRY * thread_p);
 
+#if defined (SERVER_MODE)
+extern void cdc_daemons_init ();
+extern void cdc_daemons_destroy ();
+#endif
+
 //
 // log critical section
 //


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23917

This PR is for initialization of CDC daemons

cdc log producer : Traverses log records and make log item (implemented in #2937) 
cdc thread checker : Check conditions to wakeup cdc log producer and consumer 

Managing producer, checker, consumer threads and queue handling are not covered in this PR. 