### PR TITLE
[CBRD-23994] fix coredump when calling vacuum_get_log_blockid() if vacuum_disable is set to true.

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -5611,7 +5611,14 @@ vacuum_recover_lost_block_data (THREAD_ENTRY * thread_p)
 VACUUM_LOG_BLOCKID
 vacuum_get_log_blockid (LOG_PAGEID pageid)
 {
-  return ((pageid == NULL_PAGEID) ? VACUUM_NULL_LOG_BLOCKID : (pageid / vacuum_Data.log_block_npages));
+  if (prm_get_bool_value (PRM_ID_DISABLE_VACUUM) || pageid == NULL_PAGEID)
+    {
+      return VACUUM_NULL_LOG_BLOCKID;
+    }
+
+  assert (vacuum_Data.log_block_npages != 0);
+
+  return pageid / vacuum_Data.log_block_npages;
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23994

**Purpose**
- fix coredump
- if the hidden system parameter 'vacuum_disable' is set to true, then the coredump is occurred whenever calling the vacuum_get_log_blockid() function. Because the vacuum_Data.log_block_npages is always set to 0 and it make a 'divide by 0' problem'

**Implementation**
N/A

**Remarks**
N/A