### PR TITLE
[LETS-144] Update server status output

### DIFF
--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -287,6 +287,7 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
   int bufsize = 0, required_size;
   char *buffer = NULL;
   SOCKET_QUEUE_ENTRY *temp;
+  std::string server_type_str;
 
   for (temp = css_Master_socket_anchor; temp; temp = temp->next)
     {
@@ -304,7 +305,15 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	  else
 	    {
 	      required_size += strlen (SERVER_FORMAT_STRING);
-	      required_size += strlen (temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction");
+	      if (temp->server_type == SERVER_TYPE_TRANSACTION)
+		{
+		  server_type_str = "Transaction";
+		}
+	      else if (temp->server_type == SERVER_TYPE_PAGE)
+		{
+		  server_type_str = "Page";
+		}
+	      required_size += server_type_str.length ();
 	    }
 	  required_size += strlen (temp->name);
 	  if (temp->version_string != NULL)
@@ -343,9 +352,8 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	    }
 	  else
 	    {
-	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING,
-			temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction", temp->name,
-			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
+	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING, server_type_str.c_str (),
+			temp->name, (temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 
 	    }
 	}
@@ -389,6 +397,7 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
   int bufsize = 0, required_size;
   char *buffer = NULL;
   SOCKET_QUEUE_ENTRY *temp;
+  std::string server_type_str;
 
   for (temp = css_Master_socket_anchor; temp; temp = temp->next)
     {
@@ -409,7 +418,15 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	      break;
 	    default:
 	      required_size += strlen (SERVER_FORMAT_STRING);
-	      required_size += strlen (temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction");
+	      if (temp->server_type == SERVER_TYPE_TRANSACTION)
+		{
+		  server_type_str = "Transaction";
+		}
+	      else if (temp->server_type == SERVER_TYPE_PAGE)
+		{
+		  server_type_str = "Page";
+		}
+	      required_size += server_type_str.length ();
 	      break;
 	    }
 	  required_size += strlen (temp->name);
@@ -456,9 +473,8 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 	      break;
 	    default:
-	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING,
-			temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction", temp->name,
-			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
+	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING, server_type_str.c_str (),
+			temp->name + 1, (temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 	      break;
 	    }
 	}

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -287,6 +287,7 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
   int bufsize = 0, required_size;
   char *buffer = NULL;
   SOCKET_QUEUE_ENTRY *temp;
+  std::string server_type_str;
 
   for (temp = css_Master_socket_anchor; temp; temp = temp->next)
     {
@@ -304,7 +305,15 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	  else
 	    {
 	      required_size += strlen (SERVER_FORMAT_STRING);
-	      required_size += strlen (temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction");
+	      if (temp->server_type == SERVER_TYPE_TRANSACTION)
+		{
+		  server_type_str = "Transaction";
+		}
+	      else if (temp->server_type == SERVER_TYPE_PAGE)
+		{
+		  server_type_str = "Page";
+		}
+	      required_size += server_type_str.length ();
 	    }
 	  required_size += strlen (temp->name);
 	  if (temp->version_string != NULL)
@@ -343,9 +352,8 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	    }
 	  else
 	    {
-	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING,
-			temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction", temp->name,
-			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
+	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING, server_type_str.c_str (),
+			temp->name, (temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 
 	    }
 	}
@@ -389,6 +397,7 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
   int bufsize = 0, required_size;
   char *buffer = NULL;
   SOCKET_QUEUE_ENTRY *temp;
+  std::string server_type_str;
 
   for (temp = css_Master_socket_anchor; temp; temp = temp->next)
     {
@@ -409,7 +418,15 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	      break;
 	    default:
 	      required_size += strlen (SERVER_FORMAT_STRING);
-	      required_size += strlen (temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction");
+	      if (temp->server_type == SERVER_TYPE_TRANSACTION)
+		{
+		  server_type_str = "Transaction";
+		}
+	      else if (temp->server_type == SERVER_TYPE_PAGE)
+		{
+		  server_type_str = "Page";
+		}
+	      required_size += server_type_str.length ();
 	      break;
 	    }
 	  required_size += strlen (temp->name);
@@ -456,9 +473,8 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 	      break;
 	    default:
-	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING,
-			temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction", temp->name,
-			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
+	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING, server_type_str.c_str (),
+			temp->name, (temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 	      break;
 	    }
 	}

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -64,7 +64,7 @@
 #define IS_MASTER_SOCKET_FD(FD)         \
       ((FD) == css_Master_socket_fd[0] || (FD) == css_Master_socket_fd[1])
 
-#define SERVER_FORMAT_STRING " Server %s (rel %s, pid %d)\n"
+#define SERVER_FORMAT_STRING " %s-Server %s (rel %s, pid %d)\n"
 #define HA_SERVER_FORMAT_STRING " HA-Server %s (rel %s, pid %d)\n"
 #define HA_COPYLOGDB_FORMAT_STRING " HA-copylogdb %s (rel %s, pid %d)\n"
 #define HA_APPLYLOGDB_FORMAT_STRING " HA-applylogdb %s (rel %s, pid %d)\n"
@@ -304,6 +304,7 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	  else
 	    {
 	      required_size += strlen (SERVER_FORMAT_STRING);
+	      required_size += strlen (temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction");
 	    }
 	  required_size += strlen (temp->name);
 	  if (temp->version_string != NULL)
@@ -342,7 +343,8 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	    }
 	  else
 	    {
-	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING, temp->name,
+	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING,
+			temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction", temp->name,
 			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 
 	    }
@@ -407,6 +409,7 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	      break;
 	    default:
 	      required_size += strlen (SERVER_FORMAT_STRING);
+	      required_size += strlen (temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction");
 	      break;
 	    }
 	  required_size += strlen (temp->name);
@@ -453,7 +456,8 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 	      break;
 	    default:
-	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING, temp->name,
+	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING,
+			temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction", temp->name,
 			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 	      break;
 	    }

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -287,7 +287,6 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
   int bufsize = 0, required_size;
   char *buffer = NULL;
   SOCKET_QUEUE_ENTRY *temp;
-  std::string server_type_str;
 
   for (temp = css_Master_socket_anchor; temp; temp = temp->next)
     {
@@ -305,15 +304,7 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	  else
 	    {
 	      required_size += strlen (SERVER_FORMAT_STRING);
-	      if (temp->server_type == SERVER_TYPE_TRANSACTION)
-		{
-		  server_type_str = "Transaction";
-		}
-	      else if (temp->server_type == SERVER_TYPE_PAGE)
-		{
-		  server_type_str = "Page";
-		}
-	      required_size += server_type_str.length ();
+	      required_size += strlen (temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction");
 	    }
 	  required_size += strlen (temp->name);
 	  if (temp->version_string != NULL)
@@ -352,8 +343,9 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	    }
 	  else
 	    {
-	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING, server_type_str.c_str (),
-			temp->name, (temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
+	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING,
+			temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction", temp->name,
+			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 
 	    }
 	}
@@ -397,7 +389,6 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
   int bufsize = 0, required_size;
   char *buffer = NULL;
   SOCKET_QUEUE_ENTRY *temp;
-  std::string server_type_str;
 
   for (temp = css_Master_socket_anchor; temp; temp = temp->next)
     {
@@ -418,15 +409,7 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	      break;
 	    default:
 	      required_size += strlen (SERVER_FORMAT_STRING);
-	      if (temp->server_type == SERVER_TYPE_TRANSACTION)
-		{
-		  server_type_str = "Transaction";
-		}
-	      else if (temp->server_type == SERVER_TYPE_PAGE)
-		{
-		  server_type_str = "Page";
-		}
-	      required_size += server_type_str.length ();
+	      required_size += strlen (temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction");
 	      break;
 	    }
 	  required_size += strlen (temp->name);
@@ -473,8 +456,9 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 	      break;
 	    default:
-	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING, server_type_str.c_str (),
-			temp->name + 1, (temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
+	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING,
+			temp->server_type == SERVER_TYPE_PAGE ? "Page" : "Transaction", temp->name,
+			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 	      break;
 	    }
 	}

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -1473,15 +1473,15 @@ check_server (const char *type, const char *server_name)
 
       if (strcmp (type, CHECK_SERVER) == 0)
 	{
-	  if (strcmp (type, CHECK_SERVER) != 0 && strcmp (token, CHECK_HA_SERVER) != 0)
+	  if (strcmp (token, CHECK_PAGE_SERVER) != 0 && strcmp (token, CHECK_TRANSACTION_SERVER) != 0
+	      && strcmp (token, CHECK_HA_SERVER) != 0)
 	    {
 	      continue;
 	    }
 	}
       else
 	{
-	  if (strcmp (token, type) != 0 || strcmp (token, CHECK_PAGE_SERVER) != 0
-	      || strcmp (token, CHECK_TRANSACTION_SERVER) != 0)
+	  if (strcmp (token, type) != 0)
 	    {
 	      continue;
 	    }

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -1473,14 +1473,15 @@ check_server (const char *type, const char *server_name)
 
       if (strcmp (type, CHECK_SERVER) == 0)
 	{
-	  if (strcmp (token, CHECK_SERVER) != 0 && strcmp (token, CHECK_HA_SERVER) != 0)
+	  if (strcmp (type, CHECK_SERVER) != 0 && strcmp (token, CHECK_HA_SERVER) != 0)
 	    {
 	      continue;
 	    }
 	}
       else
 	{
-	  if (strcmp (token, type) != 0)
+	  if (strcmp (token, type) != 0 || strcmp (token, CHECK_PAGE_SERVER) != 0
+	      || strcmp (token, CHECK_TRANSACTION_SERVER) != 0)
 	    {
 	      continue;
 	    }

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -874,8 +874,10 @@ typedef struct _ha_config
 #define PRINT_RESULT_SUCCESS    "success"
 #define PRINT_RESULT_FAIL       "fail"
 
-#define CHECK_SERVER            "Server"
-#define CHECK_HA_SERVER         "HA-Server"
+#define CHECK_SERVER              "Server"
+#define CHECK_HA_SERVER           "HA-Server"
+#define CHECK_PAGE_SERVER         "Page-Server"
+#define CHECK_TRANSACTION_SERVER  "Transaction-Server"
 
 #define COMMDB_SERVER_STOP      "-S"
 #define COMMDB_SERVER_STATUS    "-P"


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-144

Updated the output of `cubrid server status` command to reflect the current server type.

New output examples:
```
@ cubrid server status
 Page-Server scaldb3 (rel 12.0, pid 32040)
```
```
 @ cubrid server status
 Transaction-Server scaldb3 (rel 12.0, pid 31444)
```