### PR TITLE
[LETS-177] Fix log page header fetch from page server

### DIFF
--- a/src/storage/async_page_fetcher.cpp
+++ b/src/storage/async_page_fetcher.cpp
@@ -66,8 +66,7 @@ namespace cublog
     if (m_logpageid == LOGPB_HEADER_PAGE_ID)
       {
 	// Make sure log page header is updated
-	const log_lsa lsa_upto = log_Gl.prior_info.prior_lsa;
-	logpb_flush_pages (&cubthread::get_entry (), &lsa_upto);
+	logpb_force_flush_header_and_pages (&cubthread::get_entry ());
       }
     int err = logreader.set_lsa_and_fetch_page (loglsa);
     m_callback (logreader.get_page (), err);

--- a/src/storage/async_page_fetcher.cpp
+++ b/src/storage/async_page_fetcher.cpp
@@ -63,6 +63,12 @@ namespace cublog
     log_lsa loglsa {m_logpageid, 0};
     log_reader logreader { LOG_CS_SAFE_READER };
 
+    if (m_logpageid == LOGPB_HEADER_PAGE_ID)
+      {
+	// Make sure log page header is updated
+	const log_lsa lsa_upto = log_Gl.prior_info.prior_lsa;
+	logpb_flush_pages (&cubthread::get_entry (), &lsa_upto);
+      }
     int err = logreader.set_lsa_and_fetch_page (loglsa);
     m_callback (logreader.get_page (), err);
   }

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -812,7 +812,7 @@ extern PGLENGTH logpb_find_header_parameters (THREAD_ENTRY * thread_p, const boo
 extern int logpb_fetch_start_append_page (THREAD_ENTRY * thread_p);
 extern LOG_PAGE *logpb_fetch_start_append_page_new (THREAD_ENTRY * thread_p);
 extern void logpb_flush_pages_direct (THREAD_ENTRY * thread_p);
-extern void logpb_flush_pages (THREAD_ENTRY * thread_p, LOG_LSA * flush_lsa);
+extern void logpb_flush_pages (THREAD_ENTRY * thread_p, const LOG_LSA * flush_lsa);
 extern void logpb_force_flush_pages (THREAD_ENTRY * thread_p);
 extern void logpb_force_flush_header_and_pages (THREAD_ENTRY * thread_p);
 extern void logpb_invalid_all_append_pages (THREAD_ENTRY * thread_p);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4295,7 +4295,7 @@ logpb_flush_pages (THREAD_ENTRY * thread_p, const LOG_LSA * flush_lsa)
 	}
 
       // *INDENT-OFF*
-      if (ats_Gl.is_page_server_connected ())
+      if (get_server_type () == SERVER_TYPE_TRANSACTION && ats_Gl.is_page_server_connected ())
 	{
 	  log_Gl.wait_flushed_lsa (*flush_lsa);
 	  if (prm_get_bool_value (PRM_ID_ER_LOG_COMMIT_CONFIRM))

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4182,7 +4182,7 @@ logpb_flush_pages_direct (THREAD_ENTRY * thread_p)
  *                O           O         : async & group commit, just return
  */
 void
-logpb_flush_pages (THREAD_ENTRY * thread_p, LOG_LSA * flush_lsa)
+logpb_flush_pages (THREAD_ENTRY * thread_p, const LOG_LSA * flush_lsa)
 {
 #if !defined(SERVER_MODE)
   LOG_CS_ENTER (thread_p);

--- a/unit_tests/log/test_main_data_page_fetcher.cpp
+++ b/unit_tests/log/test_main_data_page_fetcher.cpp
@@ -226,6 +226,12 @@ logpb_flush_pages (THREAD_ENTRY *thread_p, const LOG_LSA *flush_lsa)
 }
 
 void
+logpb_force_flush_header_and_pages (THREAD_ENTRY *thread_p)
+{
+  assert (false);
+}
+
+void
 logpb_fatal_error (THREAD_ENTRY *, bool, const char *, const int, const char *, ...)
 {
   assert (false);

--- a/unit_tests/log/test_main_data_page_fetcher.cpp
+++ b/unit_tests/log/test_main_data_page_fetcher.cpp
@@ -22,7 +22,6 @@
 
 #include "async_page_fetcher.hpp"
 #include "dbtype_def.h"
-#include "fake_packable_object.hpp"
 #include "log_reader.hpp"
 #include "page_buffer.h"
 
@@ -178,51 +177,11 @@ delete_page (PAGE_PTR page_ptr)
   delete io_page;
 }
 
-// implementation of cubrid stuff require for linking
-log_global log_Gl;
-
-log_global::log_global ()
-  : m_prior_recver (std::make_unique<cublog::prior_recver> (prior_info))
-{
-}
-
-log_global::~log_global ()
-{
-}
-
-namespace cublog
-{
-  EXPAND_PACKABLE_OBJECT_EMPTY_DEF (meta);
-  EXPAND_PACKABLE_OBJECT_EMPTY_DEF (checkpoint_info);
-
-  prior_recver::prior_recver (log_prior_lsa_info &prior_lsa_info)
-    : m_prior_lsa_info (prior_lsa_info)
-  {
-  }
-  prior_recver::~prior_recver () = default;
-}
-
-mvcc_active_tran::mvcc_active_tran () = default;
-mvcc_active_tran::~mvcc_active_tran () = default;
-mvcc_trans_status::mvcc_trans_status () = default;
-mvcc_trans_status::~mvcc_trans_status () = default;
-mvcctable::mvcctable () = default;
-mvcctable::~mvcctable () = default;
-
-log_append_info::log_append_info () = default;
-log_prior_lsa_info::log_prior_lsa_info () = default;
-
 int
 logpb_fetch_page (THREAD_ENTRY *, const LOG_LSA *, LOG_CS_ACCESS_MODE, LOG_PAGE *)
 {
   assert (false);
   return NO_ERROR;
-}
-
-void
-logpb_flush_pages (THREAD_ENTRY *thread_p, const LOG_LSA *flush_lsa)
-{
-  assert (false);
 }
 
 void

--- a/unit_tests/log/test_main_data_page_fetcher.cpp
+++ b/unit_tests/log/test_main_data_page_fetcher.cpp
@@ -19,8 +19,10 @@
 #define CATCH_CONFIG_MAIN
 
 #include "catch2/catch.hpp"
+
 #include "async_page_fetcher.hpp"
 #include "dbtype_def.h"
+#include "fake_packable_object.hpp"
 #include "log_reader.hpp"
 #include "page_buffer.h"
 
@@ -175,6 +177,39 @@ delete_page (PAGE_PTR page_ptr)
   FILEIO_PAGE *io_page = reinterpret_cast<FILEIO_PAGE *> (page_ptr);
   delete io_page;
 }
+
+// implementation of cubrid stuff require for linking
+log_global log_Gl;
+
+log_global::log_global ()
+  : m_prior_recver (std::make_unique<cublog::prior_recver> (prior_info))
+{
+}
+
+log_global::~log_global ()
+{
+}
+
+namespace cublog
+{
+  EXPAND_PACKABLE_OBJECT_EMPTY_DEF (meta);
+
+  prior_recver::prior_recver (log_prior_lsa_info &prior_lsa_info)
+    : m_prior_lsa_info (prior_lsa_info)
+  {
+  }
+  prior_recver::~prior_recver () = default;
+}
+
+mvcc_active_tran::mvcc_active_tran () = default;
+mvcc_active_tran::~mvcc_active_tran () = default;
+mvcc_trans_status::mvcc_trans_status () = default;
+mvcc_trans_status::~mvcc_trans_status () = default;
+mvcctable::mvcctable () = default;
+mvcctable::~mvcctable () = default;
+
+log_append_info::log_append_info () = default;
+log_prior_lsa_info::log_prior_lsa_info () = default;
 
 int
 logpb_fetch_page (THREAD_ENTRY *, const LOG_LSA *, LOG_CS_ACCESS_MODE, LOG_PAGE *)

--- a/unit_tests/log/test_main_data_page_fetcher.cpp
+++ b/unit_tests/log/test_main_data_page_fetcher.cpp
@@ -184,6 +184,12 @@ logpb_fetch_page (THREAD_ENTRY *, const LOG_LSA *, LOG_CS_ACCESS_MODE, LOG_PAGE 
 }
 
 void
+logpb_flush_pages (THREAD_ENTRY *thread_p, const LOG_LSA *flush_lsa)
+{
+  assert (false);
+}
+
+void
 logpb_fatal_error (THREAD_ENTRY *, bool, const char *, const int, const char *, ...)
 {
   assert (false);

--- a/unit_tests/log/test_main_data_page_fetcher.cpp
+++ b/unit_tests/log/test_main_data_page_fetcher.cpp
@@ -193,6 +193,7 @@ log_global::~log_global ()
 namespace cublog
 {
   EXPAND_PACKABLE_OBJECT_EMPTY_DEF (meta);
+  EXPAND_PACKABLE_OBJECT_EMPTY_DEF (checkpoint_info);
 
   prior_recver::prior_recver (log_prior_lsa_info &prior_lsa_info)
     : m_prior_lsa_info (prior_lsa_info)

--- a/unit_tests/log/test_main_log_page_fetcher.cpp
+++ b/unit_tests/log/test_main_log_page_fetcher.cpp
@@ -200,6 +200,11 @@ logpb_flush_pages (THREAD_ENTRY *thread_p, const LOG_LSA *flush_lsa)
 }
 
 void
+logpb_force_flush_header_and_pages (THREAD_ENTRY *thread_p)
+{
+}
+
+void
 logpb_fatal_error (THREAD_ENTRY *, bool, const char *, const int, const char *, ...)
 {
   // todo: don't do fatal error on failed fetch log page

--- a/unit_tests/log/test_main_log_page_fetcher.cpp
+++ b/unit_tests/log/test_main_log_page_fetcher.cpp
@@ -159,6 +159,11 @@ logpb_fetch_page (THREAD_ENTRY *, const LOG_LSA *log_lsa, LOG_CS_ACCESS_MODE, LO
 }
 
 void
+logpb_flush_pages (THREAD_ENTRY *thread_p, const LOG_LSA *flush_lsa)
+{
+}
+
+void
 logpb_fatal_error (THREAD_ENTRY *, bool, const char *, const int, const char *, ...)
 {
   // todo: don't do fatal error on failed fetch log page

--- a/unit_tests/log/test_main_log_page_fetcher.cpp
+++ b/unit_tests/log/test_main_log_page_fetcher.cpp
@@ -19,7 +19,9 @@
 #define CATCH_CONFIG_MAIN
 
 #include "catch2/catch.hpp"
+
 #include "async_page_fetcher.hpp"
+#include "fake_packable_object.hpp"
 #include "log_reader.hpp"
 #include "page_buffer.h"
 
@@ -141,6 +143,39 @@ void test_env::on_receive_log_page (LOG_PAGEID page_id, const LOG_PAGE *log_page
     }
   g_log_page_fetcher_test_data.page_ids_requested[page_id].is_page_received = true;
 }
+
+// implementation of cubrid stuff require for linking
+log_global log_Gl;
+
+log_global::log_global ()
+  : m_prior_recver (std::make_unique<cublog::prior_recver> (prior_info))
+{
+}
+
+log_global::~log_global ()
+{
+}
+
+namespace cublog
+{
+  EXPAND_PACKABLE_OBJECT_EMPTY_DEF (meta);
+
+  prior_recver::prior_recver (log_prior_lsa_info &prior_lsa_info)
+    : m_prior_lsa_info (prior_lsa_info)
+  {
+  }
+  prior_recver::~prior_recver () = default;
+}
+
+mvcc_active_tran::mvcc_active_tran () = default;
+mvcc_active_tran::~mvcc_active_tran () = default;
+mvcc_trans_status::mvcc_trans_status () = default;
+mvcc_trans_status::~mvcc_trans_status () = default;
+mvcctable::mvcctable () = default;
+mvcctable::~mvcctable () = default;
+
+log_append_info::log_append_info () = default;
+log_prior_lsa_info::log_prior_lsa_info () = default;
 
 int
 logpb_fetch_page (THREAD_ENTRY *, const LOG_LSA *log_lsa, LOG_CS_ACCESS_MODE, LOG_PAGE *log_pgptr)

--- a/unit_tests/log/test_main_log_page_fetcher.cpp
+++ b/unit_tests/log/test_main_log_page_fetcher.cpp
@@ -159,6 +159,7 @@ log_global::~log_global ()
 namespace cublog
 {
   EXPAND_PACKABLE_OBJECT_EMPTY_DEF (meta);
+  EXPAND_PACKABLE_OBJECT_EMPTY_DEF (checkpoint_info);
 
   prior_recver::prior_recver (log_prior_lsa_info &prior_lsa_info)
     : m_prior_lsa_info (prior_lsa_info)

--- a/unit_tests/log/test_main_log_page_fetcher.cpp
+++ b/unit_tests/log/test_main_log_page_fetcher.cpp
@@ -21,7 +21,6 @@
 #include "catch2/catch.hpp"
 
 #include "async_page_fetcher.hpp"
-#include "fake_packable_object.hpp"
 #include "log_reader.hpp"
 #include "page_buffer.h"
 
@@ -144,40 +143,6 @@ void test_env::on_receive_log_page (LOG_PAGEID page_id, const LOG_PAGE *log_page
   g_log_page_fetcher_test_data.page_ids_requested[page_id].is_page_received = true;
 }
 
-// implementation of cubrid stuff require for linking
-log_global log_Gl;
-
-log_global::log_global ()
-  : m_prior_recver (std::make_unique<cublog::prior_recver> (prior_info))
-{
-}
-
-log_global::~log_global ()
-{
-}
-
-namespace cublog
-{
-  EXPAND_PACKABLE_OBJECT_EMPTY_DEF (meta);
-  EXPAND_PACKABLE_OBJECT_EMPTY_DEF (checkpoint_info);
-
-  prior_recver::prior_recver (log_prior_lsa_info &prior_lsa_info)
-    : m_prior_lsa_info (prior_lsa_info)
-  {
-  }
-  prior_recver::~prior_recver () = default;
-}
-
-mvcc_active_tran::mvcc_active_tran () = default;
-mvcc_active_tran::~mvcc_active_tran () = default;
-mvcc_trans_status::mvcc_trans_status () = default;
-mvcc_trans_status::~mvcc_trans_status () = default;
-mvcctable::mvcctable () = default;
-mvcctable::~mvcctable () = default;
-
-log_append_info::log_append_info () = default;
-log_prior_lsa_info::log_prior_lsa_info () = default;
-
 int
 logpb_fetch_page (THREAD_ENTRY *, const LOG_LSA *log_lsa, LOG_CS_ACCESS_MODE, LOG_PAGE *log_pgptr)
 {
@@ -192,11 +157,6 @@ logpb_fetch_page (THREAD_ENTRY *, const LOG_LSA *log_lsa, LOG_CS_ACCESS_MODE, LO
     {
       return ER_FAILED;
     }
-}
-
-void
-logpb_flush_pages (THREAD_ENTRY *thread_p, const LOG_LSA *flush_lsa)
-{
 }
 
 void


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-177

Make sure the log header page is updated before sending it to the active transaction server. Otherwise, the log addresses on the transaction server and page server become unsynchronized.

When the page server fetched the log header page, it calls `logpb_force_flush_header_and_pages()` first.

In the first version of the fix (that did not work) `logpb_flush_pages()` was called and two issues were found:
 - logpb_flush_pages() signature should have const LSA
 - the active transaction server function should be called only on the transaction server
