### PR TITLE
[CBRD-23763] fix coredump that occurs when executing the copydb utility with -d option

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -4197,7 +4197,7 @@ boot_delete (const char *db_name, bool force_delete)
 
   enter_server_no_thread_entry ();
 
-  error_code = xboot_delete (db_name, force_delete, BOOT_SHUTDOWN_ALL_MODULES);
+  error_code = xboot_delete (db_name, force_delete, BOOT_SHUTDOWN_EXCEPT_COMMON_MODULES);
 
   exit_server_no_thread_entry ();
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23763

### Purpose
- fix coredump that occurs when executing the copydb utility with -d option because it uses a deallocated global variable after calling tp_final function.
- tp_domain_free(...) -> area_free (tp_Domain_area, dom) -> assert (tp_Domain_area != NULL)
  - tp_Domain_area is null value because tp_final() has already called by boot_server_all_finalize() with BOOT_SHUTDOWN_ALL_MODULES shutdown mode.
  - So, I change the shutdown mode from BOOT_SHUTDOWN_ALL_MODULES to BOOT_SHUTDOWN_EXCEPT_COMMON_MODULES
### Implementation
N/A
### Remarks
- -d (--delete-source) option deletes the source database.
  - [copydb manual](https://www.cubrid.org/manual/en/11.0/admin/admin_utils.html?highlight=delete%20source#cmdoption-copydb-d)
- copydb -d operates like copydb + deletedb