### PR TITLE
[LETS-132] Don't flush perm data pages on transaction server with remote storage

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2998,8 +2998,11 @@ vacuum_master_task::execute (cubthread::entry &thread_ref)
       m_cursor.set_on_vacuum_data_start ();
     }
 
-  pgbuf_flush_if_requested (&thread_ref, (PAGE_PTR) vacuum_Data.first_page);
-  pgbuf_flush_if_requested (&thread_ref, (PAGE_PTR) vacuum_Data.last_page);
+  if (!is_tran_server_with_remote_storage ())
+    {
+      pgbuf_flush_if_requested (&thread_ref, (PAGE_PTR) vacuum_Data.first_page);
+      pgbuf_flush_if_requested (&thread_ref, (PAGE_PTR) vacuum_Data.last_page);
+    }
 
   m_cursor.force_data_update ();
   vacuum_er_log (VACUUM_ER_LOG_MASTER | VACUUM_ER_LOG_JOBS, "Start searching jobs at " vacuum_job_cursor_print_format,

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -59,6 +59,7 @@
 #include "fault_injection.h"
 #include "vacuum.h"
 #include "dbtype.h"
+#include "server_type.hpp"
 #include "thread_daemon.hpp"
 #include "thread_entry_task.hpp"
 #include "thread_manager.hpp"
@@ -4914,7 +4915,7 @@ disk_stab_init (THREAD_ENTRY * thread_p, DISK_VOLUME_HEADER * volheader)
 	  log_append_redo_data2 (thread_p, RVDK_INITMAP, NULL, page_stab, NULL_OFFSET, sizeof (nsects_set),
 				 &nsects_set);
 	}
-      if (!LOG_ISRESTARTED ())
+      if (!LOG_ISRESTARTED () && !is_tran_server_with_remote_storage ())
 	{
 	  /* page buffer will invalidated and pages will not be flushed. */
 	  pgbuf_set_dirty (thread_p, page_stab, DONT_FREE);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-132

Never flush permanent data pages on transaction server with remote storage. Add safe-guards that bcb's marked as flush not needed are really not flushed.

Tested with shell_debug for transaction server with local storage and manual tests for transaction server with remote storage.