### PR TITLE
[LETS-179] Parallel recovery performance: reusable job container: use vector with reserve instead of stack

### DIFF
--- a/src/transaction/log_reader.hpp
+++ b/src/transaction/log_reader.hpp
@@ -120,8 +120,13 @@ class log_reader final
     inline const char *get_cptr () const;
 
     inline int fetch_page (THREAD_ENTRY *const thread_p);
+    inline THREAD_ENTRY *get_thread_entry ();
 
   private:
+    /* internally cached thread entry;
+     * assumption is that the entire execution happens in the same thread
+     */
+    THREAD_ENTRY *m_thread_entry = nullptr;
     log_lsa m_lsa = NULL_LSA;
     LOG_CS_ACCESS_MODE m_cs_access = LOG_CS_FORCE_USE;
     log_page *m_page = nullptr;
@@ -154,7 +159,7 @@ int log_reader::set_lsa_and_fetch_page (const log_lsa &lsa, fetch_mode fetch_pag
   m_lsa = lsa;
   if (do_fetch_page)
     {
-      THREAD_ENTRY *thread_p = &cubthread::get_entry ();
+      THREAD_ENTRY *const thread_p = get_thread_entry ();
       return fetch_page (thread_p);
     }
   return NO_ERROR;
@@ -172,19 +177,19 @@ const log_page *log_reader::get_page () const
 
 void log_reader::align ()
 {
-  THREAD_ENTRY *thread_p = &cubthread::get_entry ();
+  THREAD_ENTRY *const thread_p = get_thread_entry ();
   LOG_READ_ALIGN (thread_p, &m_lsa, m_page);
 }
 
 void log_reader::add_align (size_t size)
 {
-  THREAD_ENTRY *thread_p = &cubthread::get_entry ();
+  THREAD_ENTRY *const thread_p = get_thread_entry ();
   LOG_READ_ADD_ALIGN (thread_p, size, &m_lsa, m_page);
 }
 
 void log_reader::advance_when_does_not_fit (size_t size)
 {
-  THREAD_ENTRY *thread_p = &cubthread::get_entry ();
+  THREAD_ENTRY *const thread_p = get_thread_entry ();
   LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, size, &m_lsa, m_page);
 }
 
@@ -195,7 +200,7 @@ bool log_reader::does_fit_in_current_page (size_t size) const
 
 void log_reader::copy_from_log (char *dest, size_t length)
 {
-  THREAD_ENTRY *thread_p = &cubthread::get_entry ();
+  THREAD_ENTRY *const thread_p = get_thread_entry ();
   // will also advance log page if needed
   logpb_copy_from_log (thread_p, dest, static_cast<int> (length), &m_lsa, m_page);
 }
@@ -208,7 +213,7 @@ const char *log_reader::get_cptr () const
 
 int log_reader::skip (size_t size)
 {
-  THREAD_ENTRY *thread_p = &cubthread::get_entry ();
+  THREAD_ENTRY *const thread_p = get_thread_entry ();
   int temp_length = static_cast<int> (size);
 
   if (m_lsa.offset + temp_length < static_cast<int> (LOGAREA_SIZE))
@@ -258,6 +263,15 @@ int log_reader::fetch_page (THREAD_ENTRY *const thread_p)
     }
 
   return NO_ERROR;
+}
+
+THREAD_ENTRY *log_reader::get_thread_entry ()
+{
+  if (m_thread_entry == nullptr)
+    {
+      m_thread_entry = &cubthread::get_entry ();
+    }
+  return m_thread_entry;
 }
 
 template <typename T>

--- a/src/transaction/log_reader.hpp
+++ b/src/transaction/log_reader.hpp
@@ -160,6 +160,7 @@ int log_reader::set_lsa_and_fetch_page (const log_lsa &lsa, fetch_mode fetch_pag
   if (do_fetch_page)
     {
       THREAD_ENTRY *const thread_p = get_thread_entry ();
+      assert (thread_p == &cubthread::get_entry ());
       return fetch_page (thread_p);
     }
   return NO_ERROR;
@@ -178,18 +179,21 @@ const log_page *log_reader::get_page () const
 void log_reader::align ()
 {
   THREAD_ENTRY *const thread_p = get_thread_entry ();
+  assert (thread_p == &cubthread::get_entry ());
   LOG_READ_ALIGN (thread_p, &m_lsa, m_page);
 }
 
 void log_reader::add_align (size_t size)
 {
   THREAD_ENTRY *const thread_p = get_thread_entry ();
+  assert (thread_p == &cubthread::get_entry ());
   LOG_READ_ADD_ALIGN (thread_p, size, &m_lsa, m_page);
 }
 
 void log_reader::advance_when_does_not_fit (size_t size)
 {
   THREAD_ENTRY *const thread_p = get_thread_entry ();
+  assert (thread_p == &cubthread::get_entry ());
   LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, size, &m_lsa, m_page);
 }
 
@@ -201,6 +205,7 @@ bool log_reader::does_fit_in_current_page (size_t size) const
 void log_reader::copy_from_log (char *dest, size_t length)
 {
   THREAD_ENTRY *const thread_p = get_thread_entry ();
+  assert (thread_p == &cubthread::get_entry ());
   // will also advance log page if needed
   logpb_copy_from_log (thread_p, dest, static_cast<int> (length), &m_lsa, m_page);
 }
@@ -214,6 +219,7 @@ const char *log_reader::get_cptr () const
 int log_reader::skip (size_t size)
 {
   THREAD_ENTRY *const thread_p = get_thread_entry ();
+  assert (thread_p == &cubthread::get_entry ());
   int temp_length = static_cast<int> (size);
 
   if (m_lsa.offset + temp_length < static_cast<int> (LOGAREA_SIZE))

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1017,7 +1017,8 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
     assert (log_recovery_redo_parallel_count >= 0);
     if (log_recovery_redo_parallel_count > 0)
       {
-	reusable_jobs.initialize (cublog::PARALLEL_REDO_REUSABLE_JOBS_STACK_SIZE,
+	reusable_jobs.initialize (cublog::PARALLEL_REDO_REUSABLE_JOBS_COUNT, log_recovery_redo_parallel_count,
+				  cublog::PARALLEL_REDO_REUSABLE_JOBS_FLUSH_BACK_COUNT,
 				  &context.get_end_redo_lsa (), force_each_log_page_fetch);
 	parallel_recovery_redo.reset (new cublog::redo_parallel (log_recovery_redo_parallel_count, nullptr));
       }
@@ -1206,7 +1207,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 		   *undo_unzip_ptr, *redo_unzip_ptr, parallel_recovery_redo, reusable_jobs,
 		   force_each_log_page_fetch, rcv_redo_perf_stat);
                 // *INDENT-ON*
-		rcv_redo_perf_stat.time_and_increment (PERF_STAT_ID_REDO_OR_PUSH);
 	      }
 	      break;
 
@@ -1230,7 +1230,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 		   *undo_unzip_ptr, *redo_unzip_ptr, parallel_recovery_redo, reusable_jobs,
 		   force_each_log_page_fetch, rcv_redo_perf_stat);
                 // *INDENT-ON*
-		rcv_redo_perf_stat.time_and_increment (PERF_STAT_ID_REDO_OR_PUSH);
 	      }
 	      break;
 
@@ -1267,7 +1266,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 		   *undo_unzip_ptr, *redo_unzip_ptr, parallel_recovery_redo, reusable_jobs,
 		   force_each_log_page_fetch, rcv_redo_perf_stat);
                 // *INDENT-ON*
-		rcv_redo_perf_stat.time_and_increment (PERF_STAT_ID_REDO_OR_PUSH);
 	      }
 	      break;
 
@@ -1295,7 +1293,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 		   *undo_unzip_ptr, *redo_unzip_ptr, parallel_recovery_redo, reusable_jobs,
 		   force_each_log_page_fetch, rcv_redo_perf_stat);
                 // *INDENT-ON*
-		rcv_redo_perf_stat.time_and_increment (PERF_STAT_ID_REDO_OR_PUSH);
 	      }
 	      break;
 
@@ -1337,7 +1334,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 					&rcv_lsa, 0, nullptr, *redo_unzip_ptr);
 		    /* unzip_ptr used here only as a buffer for the underlying logic, the structure's buffer
 		     * will be reallocated downstream if needed */
-		    rcv_redo_perf_stat.time_and_increment (PERF_STAT_ID_REDO_OR_PUSH);
 		  }
 	      }
 	      break;
@@ -1361,7 +1357,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 		   *undo_unzip_ptr, *redo_unzip_ptr, parallel_recovery_redo, reusable_jobs,
 		   force_each_log_page_fetch, rcv_redo_perf_stat);
                 // *INDENT-ON*
-		rcv_redo_perf_stat.time_and_increment (PERF_STAT_ID_REDO_OR_PUSH);
 	      }
 	      break;
 
@@ -1383,7 +1378,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 		   *undo_unzip_ptr, *redo_unzip_ptr, parallel_recovery_redo, reusable_jobs,
 		   force_each_log_page_fetch, rcv_redo_perf_stat);
                 // *INDENT-ON*
-		rcv_redo_perf_stat.time_and_increment (PERF_STAT_ID_REDO_OR_PUSH);
 	      }
 	      break;
 

--- a/src/transaction/log_recovery_redo_parallel.cpp
+++ b/src/transaction/log_recovery_redo_parallel.cpp
@@ -833,7 +833,7 @@ namespace cublog
 
   reusable_jobs_stack::~reusable_jobs_stack ()
   {
-    // consistency check
+    // consistency check that all job instances have been 'retuned to the source'
     assert ([this] ()
     {
       const std::size_t pop_size = m_pop_jobs.size ();
@@ -847,6 +847,23 @@ namespace cublog
       return true;
     }
     ());
+
+    // formally invoke dtor  on all in-place constructed objects
+    for (auto &job : m_pop_jobs)
+      {
+        job->~redo_job_impl();
+      }
+    for (auto &job : m_push_jobs)
+      {
+        job->~redo_job_impl();
+      }
+    for (auto &push_job_container: m_per_task_push_jobs_vec)
+      {
+        for (auto &job : push_job_container)
+          {
+            job->~redo_job_impl();
+          }
+      }
 
     free (m_jobs_arr);
     m_jobs_arr = nullptr;

--- a/src/transaction/log_recovery_redo_parallel.cpp
+++ b/src/transaction/log_recovery_redo_parallel.cpp
@@ -486,7 +486,7 @@ namespace cublog
       static constexpr unsigned short WAIT_AND_CHECK_MILLIS = 5;
 
     public:
-      redo_task (redo_parallel::task_active_state_bookkeeping &task_state_bookkeeping
+      redo_task (std::size_t a_task_idx, redo_parallel::task_active_state_bookkeeping &task_state_bookkeeping
 		 , redo_parallel::redo_job_queue &a_queue);
       redo_task (const redo_task &) = delete;
       redo_task (redo_task &&) = delete;
@@ -499,6 +499,7 @@ namespace cublog
       void execute (context_type &context);
 
     private:
+      const std::size_t m_task_idx;
       redo_parallel::task_active_state_bookkeeping &m_task_state_bookkeeping;
       redo_parallel::redo_job_queue &m_queue;
 
@@ -513,9 +514,11 @@ namespace cublog
 
   constexpr unsigned short redo_parallel::redo_task::WAIT_AND_CHECK_MILLIS;
 
-  redo_parallel::redo_task::redo_task (redo_parallel::task_active_state_bookkeeping &task_state_bookkeeping
+  redo_parallel::redo_task::redo_task (std::size_t a_task_idx
+				       , redo_parallel::task_active_state_bookkeeping &task_state_bookkeeping
 				       , redo_parallel::redo_job_queue &a_queue)
-    : m_task_state_bookkeeping (task_state_bookkeeping)
+    : m_task_idx { a_task_idx }
+    , m_task_state_bookkeeping (task_state_bookkeeping)
     , m_queue (a_queue)
   {
     // important to set this at this moment and not when execution begins
@@ -563,7 +566,7 @@ namespace cublog
 
 		m_queue.notify_job_finished (job);
 
-		job->retire ();
+		job->retire (m_task_idx);
 	      }
 	  }
       }
@@ -576,8 +579,7 @@ namespace cublog
    *********************************************************************/
 
   redo_parallel::redo_parallel (unsigned a_worker_count, minimum_log_lsa_monitor *a_minimum_log_lsa)
-    : m_task_count { a_worker_count }
-    , m_worker_pool (nullptr)
+    : m_worker_pool (nullptr)
     , m_job_queue { a_minimum_log_lsa }
     , m_waited_for_termination (false)
   {
@@ -586,8 +588,8 @@ namespace cublog
     const thread_type tt = log_is_in_crash_recovery () ? TT_RECOVERY : TT_REPLICATION;
     m_pool_context_manager = std::make_unique<cubthread::system_worker_entry_manager> (tt);
 
-    do_init_worker_pool ();
-    do_init_tasks ();
+    do_init_worker_pool (a_worker_count);
+    do_init_tasks (a_worker_count);
   }
 
   redo_parallel::~redo_parallel ()
@@ -650,29 +652,29 @@ namespace cublog
   }
 
   void
-  redo_parallel::do_init_worker_pool ()
+  redo_parallel::do_init_worker_pool (std::size_t a_task_count)
   {
-    assert (m_task_count > 0);
+    assert (a_task_count > 0);
     assert (m_worker_pool == nullptr);
 
     // NOTE: already initialized globally (probably during boot)
     cubthread::manager *thread_manager = cubthread::get_manager ();
 
-    m_worker_pool = thread_manager->create_worker_pool (m_task_count, m_task_count, "log_recovery_redo_thread_pool",
+    m_worker_pool = thread_manager->create_worker_pool (a_task_count, a_task_count, "log_recovery_redo_thread_pool",
 		    m_pool_context_manager.get (),
-		    m_task_count, false /*debug_logging*/);
+		    a_task_count, false /*debug_logging*/);
   }
 
   void
-  redo_parallel::do_init_tasks ()
+  redo_parallel::do_init_tasks (std::size_t a_task_count)
   {
-    assert (m_task_count > 0);
+    assert (a_task_count > 0);
     assert (m_worker_pool != nullptr);
 
-    for (unsigned task_idx = 0; task_idx < m_task_count; ++task_idx)
+    for (unsigned task_idx = 0; task_idx < a_task_count; ++task_idx)
       {
 	// NOTE: task ownership goes to the worker pool
-	auto task = new redo_task (m_task_state_bookkeeping, m_job_queue);
+	auto task = new redo_task (task_idx, m_task_state_bookkeeping, m_job_queue);
 	m_worker_pool->execute (task);
       }
   }
@@ -756,10 +758,10 @@ namespace cublog
     return NO_ERROR;
   }
 
-  void redo_job_impl::retire ()
+  void redo_job_impl::retire (std::size_t a_task_idx)
   {
     // return the job back to the pool of available reusable jobs
-    m_reusable_job_stack->push (this);
+    m_reusable_job_stack->push (a_task_idx, this);
   }
 
   template <typename T>
@@ -779,75 +781,119 @@ namespace cublog
    *********************************************************************/
 
   reusable_jobs_stack::reusable_jobs_stack ()
-    : m_stack_size { 0 }
+    : m_job_count { 0 }
+    , m_push_task_count { 0 }
+    , m_flush_push_at_count { 0 }
+    , m_jobs_arr { nullptr }
   {
   }
 
-  void reusable_jobs_stack::initialize (std::size_t a_stack_size, const log_lsa *a_end_redo_lsa,
-					bool force_each_page_fetch)
+  void reusable_jobs_stack::initialize (std::size_t a_job_count, std::size_t a_push_task_count,
+					std::size_t a_flush_push_at_count,
+					const log_lsa *a_end_redo_lsa, bool force_each_page_fetch)
   {
-    assert (m_pop_stack.empty ());
-    assert (m_push_stack.empty ());
+    assert (m_job_count == 0);
+    assert (m_push_task_count == 0);
+    assert (m_flush_push_at_count == 0);
 
-    m_stack_size = a_stack_size;
-    for (std::size_t idx = 0; idx < m_stack_size; ++idx)
+    assert (m_jobs_arr == nullptr);
+
+    assert (m_pop_jobs.empty ());
+    assert (m_push_jobs.empty ());
+
+    assert (m_per_task_push_jobs_vec.empty ());
+
+    assert (a_job_count > 0);
+    assert (a_push_task_count > 0);
+    assert (a_flush_push_at_count > 0);
+
+    m_job_count = a_job_count;
+    m_push_task_count = a_push_task_count;
+    m_flush_push_at_count = a_flush_push_at_count;
+
+    m_jobs_arr = static_cast<unsigned char *> (malloc (sizeof (redo_job_impl) * m_job_count));
+
+    m_pop_jobs.reserve (m_job_count);
+    for (std::size_t idx = 0; idx < m_job_count; ++idx)
       {
-	redo_job_impl *job = new redo_job_impl (a_end_redo_lsa, force_each_page_fetch, this);
-	m_pop_stack.push (job);
+	redo_job_impl *const job = new (m_jobs_arr + sizeof (redo_job_impl) * idx)
+	redo_job_impl (a_end_redo_lsa, force_each_page_fetch, this);
+	m_pop_jobs.push_back (job);
+      }
+
+    m_push_jobs.reserve (m_job_count);
+
+    m_per_task_push_jobs_vec.resize (m_push_task_count);
+    const std::size_t per_task_reserve_size = m_job_count / m_push_task_count * 2;
+    for (job_container_t &jobs: m_per_task_push_jobs_vec)
+      {
+	jobs.reserve (per_task_reserve_size);
       }
   }
 
   reusable_jobs_stack::~reusable_jobs_stack ()
   {
-    assert ((m_pop_stack.size () + m_push_stack.size ()) == m_stack_size);
+    // consistency check
+    assert ([this] ()
+    {
+      const std::size_t pop_size = m_pop_jobs.size ();
+      const std::size_t push_size = m_push_jobs.size ();
+      std::size_t per_task_push_size = 0;
+      for (auto &push_container: m_per_task_push_jobs_vec)
+	{
+	  per_task_push_size += push_container.size ();
+	}
+      assert ((pop_size + push_size + per_task_push_size) == m_job_count);
+      return true;
+    }
+    ());
 
-    while (!m_push_stack.empty ())
-      {
-	redo_job_impl *const push_job = m_push_stack.top ();
-	m_push_stack.pop ();
-	delete push_job;
-      }
-    while (!m_pop_stack.empty ())
-      {
-	redo_job_impl *const pop_job = m_pop_stack.top ();
-	m_pop_stack.pop ();
-	delete pop_job;
-      }
+    free (m_jobs_arr);
+    m_jobs_arr = nullptr;
   }
 
   redo_job_impl *reusable_jobs_stack::blocking_pop ()
   {
-    if (!m_pop_stack.empty ())
+    if (!m_pop_jobs.empty ())
       {
-	redo_job_impl *const pop_job = m_pop_stack.top ();
-	m_pop_stack.pop ();
+	redo_job_impl *const pop_job = m_pop_jobs.back ();
+	m_pop_jobs.pop_back ();
 	return pop_job;
       }
     else
       {
-        std::unique_lock<std::mutex> ulock { m_mutex };
-        m_jobs_available_on_push_stack_cv.wait (ulock, [this] ()
-        {
-            return !m_push_stack.empty ();
-          });
+	{
+	  std::unique_lock<std::mutex> locku { m_push_mtx };
+	  m_push_jobs_available_cv.wait (locku, [this] ()
+	  {
+	    return !m_push_jobs.empty ();
+	  });
 
-        m_pop_stack.swap (m_push_stack);
+	  m_pop_jobs.swap (m_push_jobs);
+	}
 
-        redo_job_impl *const pop_job = m_pop_stack.top ();
-        m_pop_stack.pop ();
-        return pop_job;
+	redo_job_impl *const pop_job = m_pop_jobs.back ();
+	m_pop_jobs.pop_back ();
+	return pop_job;
       }
 
     assert ("unreachable state reached" == nullptr);
     return nullptr;
   }
 
-  void reusable_jobs_stack::push (redo_job_impl *a_job)
+  void reusable_jobs_stack::push (std::size_t a_task_idx, redo_job_impl *a_job)
   {
-    {
-      std::lock_guard<std::mutex> stack_lockg { m_mutex };
-      m_push_stack.push (a_job);
-    }
-    m_jobs_available_on_push_stack_cv.notify_one ();
+    job_container_t &push_jobs = m_per_task_push_jobs_vec[a_task_idx];
+    push_jobs.push_back (a_job);
+
+    if (push_jobs.size () > m_flush_push_at_count)
+      {
+	{
+	  std::lock_guard<std::mutex> locku { m_push_mtx };
+	  m_push_jobs.insert (m_push_jobs.end (), push_jobs.cbegin (), push_jobs.cend ());
+	}
+	push_jobs.clear ();
+	m_push_jobs_available_cv.notify_one ();
+      }
   }
 }

--- a/src/transaction/log_recovery_redo_parallel.hpp
+++ b/src/transaction/log_recovery_redo_parallel.hpp
@@ -38,7 +38,8 @@
 namespace cublog
 {
 #if defined(SERVER_MODE)
-  static constexpr size_t PARALLEL_REDO_REUSABLE_JOBS_STACK_SIZE = 100 * ONE_K;
+  static constexpr std::size_t PARALLEL_REDO_REUSABLE_JOBS_COUNT = ONE_M;
+  static constexpr std::size_t PARALLEL_REDO_REUSABLE_JOBS_FLUSH_BACK_COUNT = 100;
 
   // forward declaration
   class reusable_jobs_stack;
@@ -153,8 +154,8 @@ namespace cublog
       void wait_for_termination_and_stop_execution ();
 
     private:
-      void do_init_worker_pool ();
-      void do_init_tasks ();
+      void do_init_worker_pool (std::size_t a_task_count);
+      void do_init_tasks (std::size_t a_task_count);
 
     private:
       /* rynchronizes prod/cons of log entries in n-prod - m-cons fashion
@@ -295,7 +296,6 @@ namespace cublog
       };
 
     private:
-      const unsigned m_task_count;
       std::unique_ptr<cubthread::entry_manager> m_pool_context_manager;
 
       /* the workpool already has and internal bookkeeping and can also wait for the tasks to terminate;
@@ -363,7 +363,7 @@ namespace cublog
 
       virtual int execute (THREAD_ENTRY *thread_p, log_reader &log_pgptr_reader,
 			   LOG_ZIP &undo_unzip_support, LOG_ZIP &redo_unzip_support) = 0;
-      virtual void retire () = 0;
+      virtual void retire (std::size_t a_task_idx) = 0;
 
     private:
       VPID m_vpid;
@@ -397,7 +397,7 @@ namespace cublog
 
       int execute (THREAD_ENTRY *thread_p, log_reader &log_pgptr_reader,
 		   LOG_ZIP &undo_unzip_support, LOG_ZIP &redo_unzip_support) override;
-      void retire () override;
+      void retire (std::size_t a_task_idx) override;
 
     private:
       template <typename T>
@@ -420,6 +420,8 @@ namespace cublog
    */
   class reusable_jobs_stack final
   {
+      using job_container_t = std::vector<redo_job_impl *>;
+
     public:
       reusable_jobs_stack ();
       reusable_jobs_stack (const reusable_jobs_stack &) = delete;
@@ -430,32 +432,45 @@ namespace cublog
       reusable_jobs_stack &operator = (const reusable_jobs_stack &) = delete;
       reusable_jobs_stack &operator = (reusable_jobs_stack &&) = delete;
 
-      void initialize (std::size_t a_stack_size, const log_lsa *a_end_redo_lsa,
-		       bool force_each_page_fetch);
+      void initialize (std::size_t a_job_count, std::size_t a_push_task_count,
+		       std::size_t a_flush_push_at_count,
+		       const log_lsa *a_end_redo_lsa, bool force_each_page_fetch);
 
       std::size_t size () const
       {
-	return m_stack_size;
+	return m_job_count;
       }
 
       redo_job_impl *blocking_pop ();
-      void push (redo_job_impl *a_job);
+      void push (std::size_t a_task_idx, redo_job_impl *a_job);
 
     private:
-      std::size_t m_stack_size;
+      /* configuration, constants after initialization
+       */
+      std::size_t m_job_count;
+      std::size_t m_push_task_count;
+      std::size_t m_flush_push_at_count;
 
-      /* pop is done, unsynchronized, from this stack
-       * if empty, it is re-filled, synchronized, from the push stack
+      /* support array for initializing jobs in-place
        */
-      std::stack<redo_job_impl *> m_pop_stack;
-      /* push happens, synchronized, on this stack
+      unsigned char *m_jobs_arr;
+
+      /* pop is done, unsynchronized, from this container
+       * if empty, it is re-filled, synchronized, from the push container
        */
-      std::stack<redo_job_impl *> m_push_stack;
-      std::mutex m_mutex;
-      /* used to wait for jobs to be available on the push stack
-       * in case no jobs are found on the pop stack
+      job_container_t m_pop_jobs;
+
+      /* from time to time, the worker tasks (threads) also push data into this
+       * container using the synchronization primitives below
        */
-      std::condition_variable m_jobs_available_on_push_stack_cv;
+      job_container_t m_push_jobs;
+      std::mutex m_push_mtx;
+      std::condition_variable m_push_jobs_available_cv;
+
+      /* each worker task (thread) pushes, unsynched on its own container from this vector
+       * at configurable intervals, objects are further moved, synchronized, to the push container
+       */
+      std::vector<job_container_t> m_per_task_push_jobs_vec;
   };
 
 #else /* SERVER_MODE */
@@ -502,7 +517,7 @@ log_rv_redo_record_sync_or_dispatch_async (
   const VPID rcv_vpid = log_rv_get_log_rec_vpid<T> (log_rec);
   // at this point, vpid can either be valid or not
 
-#if defined(SERVER_MODE)
+#if defined (SERVER_MODE)
   const LOG_DATA &log_data = log_rv_get_log_rec_data<T> (log_rec);
   const bool need_sync_redo = log_rv_need_sync_redo (rcv_vpid, log_data.rcvindex);
   a_rcv_redo_perf_stat.time_and_increment (PERF_STAT_ID_REDO_OR_PUSH_PREP);

--- a/src/transaction/log_recovery_redo_perf.hpp
+++ b/src/transaction/log_recovery_redo_perf.hpp
@@ -36,7 +36,6 @@ enum PERF_STAT_RECOVERY_ID : cubperf::stat_id
 {
   PERF_STAT_ID_FETCH_PAGE,
   PERF_STAT_ID_READ_LOG,
-  PERF_STAT_ID_REDO_OR_PUSH,
   PERF_STAT_ID_REDO_OR_PUSH_PREP,
   PERF_STAT_ID_REDO_OR_PUSH_DO_SYNC,
   PERF_STAT_ID_REDO_OR_PUSH_POP_REUSABLE,
@@ -62,8 +61,6 @@ class log_recovery_redo_perf_stat
 				"Counter fetch_page", "Timer fetch_page (μs)"),
       cubperf::stat_definition (PERF_STAT_ID_READ_LOG, cubperf::stat_definition::COUNTER_AND_TIMER,
 				"Counter read_log", "Timer read_log (μs)"),
-      cubperf::stat_definition (PERF_STAT_ID_REDO_OR_PUSH, cubperf::stat_definition::COUNTER_AND_TIMER,
-				"Counter redo_or_push", "Timer redo_or_push (μs)"),
       cubperf::stat_definition (PERF_STAT_ID_REDO_OR_PUSH_PREP, cubperf::stat_definition::COUNTER_AND_TIMER,
 				"Counter redo_or_push_prep", "Timer redo_or_push_prep (μs)"),
       cubperf::stat_definition (PERF_STAT_ID_REDO_OR_PUSH_DO_SYNC, cubperf::stat_definition::COUNTER_AND_TIMER,

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -67,7 +67,7 @@ namespace cublog
 
       int execute (THREAD_ENTRY *thread_p, log_reader &log_pgptr_reader,
 		   LOG_ZIP &undo_unzip_support, LOG_ZIP &redo_unzip_support) override;
-      void retire () override;
+      void retire (std::size_t a_task_idx) override;
 
     private:
       const time_msec_t m_start_time_msec;
@@ -89,11 +89,15 @@ namespace cublog
 
       int execute (THREAD_ENTRY *thread_p, log_reader &log_pgptr_reader, LOG_ZIP &undo_unzip_support,
 		   LOG_ZIP &redo_unzip_support) override;
-      void retire () override;
+      void retire (std::size_t a_task_idx) override;
 
     private:
       log_unique_stats m_stats;
   };
+
+  /*********************************************************************
+   * replicator - definition
+   *********************************************************************/
 
   replicator::replicator (const log_lsa &start_redo_lsa)
     : m_redo_lsa { start_redo_lsa }
@@ -118,7 +122,8 @@ namespace cublog
 
 	const bool force_each_log_page_fetch = true;
 	m_reusable_jobs.reset (new cublog::reusable_jobs_stack ());
-	m_reusable_jobs->initialize (cublog::PARALLEL_REDO_REUSABLE_JOBS_STACK_SIZE,
+	m_reusable_jobs->initialize (cublog::PARALLEL_REDO_REUSABLE_JOBS_COUNT, replication_parallel,
+				     cublog::PARALLEL_REDO_REUSABLE_JOBS_FLUSH_BACK_COUNT,
 				     nullptr, force_each_log_page_fetch);
 	m_parallel_replication_redo.reset (new cublog::redo_parallel (
 	    replication_parallel, m_minimum_log_lsa.get ()));
@@ -412,7 +417,7 @@ namespace cublog
   }
 
   /*********************************************************************
-   * redo_job_replication_delay_impl - definition
+   * replication delay calculation - definition
    *********************************************************************/
 
   redo_job_replication_delay_impl::redo_job_replication_delay_impl (
@@ -430,7 +435,7 @@ namespace cublog
   }
 
   void
-  redo_job_replication_delay_impl::retire ()
+  redo_job_replication_delay_impl::retire (std::size_t)
   {
     delete this;
   }
@@ -471,7 +476,7 @@ namespace cublog
   }
 
   /*********************************************************************
-   * replication b-tree unique statistics - declaration
+   * replication b-tree unique statistics - definition
    *********************************************************************/
 
   void
@@ -504,7 +509,7 @@ namespace cublog
   }
 
   void
-  redo_job_btree_stats::retire ()
+  redo_job_btree_stats::retire (std::size_t)
   {
     delete this;
   }

--- a/unit_tests/log/ut_redo_job_impl.cpp
+++ b/unit_tests/log/ut_redo_job_impl.cpp
@@ -26,8 +26,7 @@
 ut_redo_job_impl::ut_redo_job_impl (ut_database &a_database_recovery, job_type a_job_type,
 				    const log_lsa &a_log_lsa_id, VPID a_vpid, double a_millis)
   : cublog::redo_parallel::redo_job_base (a_vpid, a_log_lsa_id)
-  , m_database_recovery (a_database_recovery)
-  , m_job_type (a_job_type), m_millis (a_millis)
+  , m_database_recovery (a_database_recovery), m_job_type (a_job_type), m_millis (a_millis)
 {
 }
 
@@ -46,7 +45,7 @@ int ut_redo_job_impl::execute (THREAD_ENTRY *thread_p, log_reader &log_pgptr_rea
   return NO_ERROR;
 }
 
-void ut_redo_job_impl::retire ()
+void ut_redo_job_impl::retire (std::size_t)
 {
   delete this;
 }

--- a/unit_tests/log/ut_redo_job_impl.hpp
+++ b/unit_tests/log/ut_redo_job_impl.hpp
@@ -60,7 +60,7 @@ class ut_redo_job_impl final : public cublog::redo_parallel::redo_job_base
 
     int execute (THREAD_ENTRY *thread_p, log_reader &log_pgptr_reader,
 		 LOG_ZIP &undo_unzip_support, LOG_ZIP &redo_unzip_support) override;
-    void retire () override;
+    void retire (std::size_t a_task_idx) override;
 
     void require_equal (const ut_redo_job_impl &that) const;
 
@@ -80,7 +80,7 @@ class ut_redo_job_impl final : public cublog::redo_parallel::redo_job_base
 
     const job_type m_job_type;
 
-    double m_millis;
+    const double m_millis;
 };
 
 #endif // ! _UT_REDO_JOB_IMPL_H_


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-179

Better synchronization is needed in `reusable_jobs_stack` in order to minimize contention both between worker threads and also between main thread and worker threads and allow main thread to work as much as possible in a lock-free way.

Perf revealed that `std::stack` spends quite some time [re]allocating internal memory.

Implementation:
- replace two stage transfer from worker threads towards main thread by a three stage transfer
- in the first stage (starting from the worker threads' side) each worker thread pushes one job at a time in a lock-free way in its own internal container
- from time to time, configurable by a variable, each worker thread pushes - synchronized - already collected jobs in an intermediary container
- main thread consumes jobs from its own container in a lock-free way, from time to time, when this container becomes empty, it will swap - synchronized - its empty container for the intermediary container
- replace `std::stack` with pre-reserved `std::vectors` as internal containers
- all reusable jobs are constructed in-place in a contiguous memory array for cache optimization

Other changes:
- remove redundant perf stats recording
- `log_reader`: obtain thread entry only once from the thread local variable
