### PR TITLE
[CBRD-24021] Put libncurses6 symbolic link to CUBRID/lib as libncurses5

### DIFF
--- a/cmake/CPack.STGZ_Header.sh.in
+++ b/cmake/CPack.STGZ_Header.sh.in
@@ -197,14 +197,7 @@ elif [ -f /etc/os-release ];then
 fi
 
 case $OS in
-	fedoraproject)
-		if [ ! -h /lib64/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
-			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
-			ln -s /lib64/libform.so.6 $LIB/libform.so.5
-			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
-		fi
-		;;
-	centos)
+	fedoraproject | centos | redhat)
 		if [ ! -h /lib64/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
 			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib64/libform.so.6 $LIB/libform.so.5

--- a/contrib/rpm/cubrid.sh
+++ b/contrib/rpm/cubrid.sh
@@ -25,14 +25,7 @@ elif [ -f /etc/os-release ];then
 fi
 
 case $OS in
-	fedoraproject)
-		if [ ! -h /lib64/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
-			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
-			ln -s /lib64/libform.so.6 $LIB/libform.so.5
-			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
-		fi
-		;;
-	centos)
+	fedoraproject | centos | redhat)
 		if [ ! -h /lib64/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
 			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib64/libform.so.6 $LIB/libform.so.5


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24021

Purpose

* In CUBRID Distribution packages (sh, rpm) for Redhat Linux (including 8.4)
  * Add symbolic link of ncurses6 as ncurses5 in $CUBRID/lib
  * Same works as CBRD-23587

Implementation
N/A

Remarks