### PR TITLE
[LETS-181] Use chrono::steady_clock for perf

### DIFF
--- a/src/base/perf_def.hpp
+++ b/src/base/perf_def.hpp
@@ -36,7 +36,7 @@
 namespace cubperf
 {
   // clocking
-  using clock = std::chrono::high_resolution_clock;   // default clock
+  using clock = std::chrono::steady_clock;   // default clock
   using time_point = clock::time_point;               // default time point
   using duration = clock::duration;                   // default duration
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-181

Replace `std::chrono::high_resolution_clock` with `std::chrono::steady_clock` as default clock in perf.hpp because steady clock is indicated in situations where only duration is of concern.
