### PR TITLE
[LETS-184] Do not flush pages on transaction server with remote storage

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -1071,7 +1071,14 @@ disk_set_link (THREAD_ENTRY * thread_p, INT16 volid, INT16 next_volid, const cha
     }
   else
     {
-      pgbuf_flush (thread_p, addr.pgptr, FREE);
+      if (is_tran_server_with_remote_storage ())
+	{
+	  pgbuf_unfix (thread_p, addr.pgptr);
+	}
+      else
+	{
+	  pgbuf_flush (thread_p, addr.pgptr, FREE);
+	}
     }
   addr.pgptr = NULL;
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -13887,6 +13887,12 @@ pgbuf_rv_flush_page (THREAD_ENTRY * thread_p, const LOG_RCV * rcv)
   assert (rcv->pgptr == NULL);
   assert (rcv->length == sizeof (VPID));
 
+  if (is_tran_server_with_remote_storage ())
+    {
+      // don't flush
+      return NO_ERROR;
+    }
+
   VPID_COPY (&vpid_to_flush, (VPID *) rcv->data);
   page_to_flush =
     pgbuf_fix (thread_p, &vpid_to_flush, OLD_PAGE_MAYBE_DEALLOCATED, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-184

Fix missed cases in:

- disk_set_link
- pgbuf_rv_flush_page
