### PR TITLE
[CBRD-23862] Reset yylineno to 1 explicitly before start parsing

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -25710,6 +25710,7 @@ parser_main (PARSER_CONTEXT * parser)
   yycolumn = yycolumn_end = 1;
   yybuffer_pos=0;
   csql_yylloc.buffer_pos=0;
+  csql_yyset_lineno (1);
   dot_flag = 0;
 
   g_query_string = NULL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23862

Purpose

Whenever csql repeatedly executes a query with an error, lineno is accumulated and display wrong line number.
**yylineno** used in flex should be reset to '1' before start/restart parsing in parser_main () at 'parser/csql_grammar.y'.

Implementation
N/A

Remarks
