### PR TITLE
[CBRD-24022] The problem of using reserved words of HQ as data filters in hierarchical queries

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -491,7 +491,8 @@ static int pt_split_hash_attrs (PARSER_CONTEXT * parser, TABLE_INFO * table_info
 static int pt_split_hash_attrs_for_HQ (PARSER_CONTEXT * parser, PT_NODE * pred, PT_NODE ** build_attrs,
 				       PT_NODE ** probe_attrs, PT_NODE ** pred_without_HQ);
 
-static int pt_split_pred_for_HQ (PARSER_CONTEXT * parser, PT_NODE * pred, PT_NODE ** pred_without_HQ, PT_NODE ** pred_with_HQ);
+static int pt_split_pred_for_HQ (PARSER_CONTEXT * parser, PT_NODE * pred, PT_NODE ** pred_without_HQ,
+				 PT_NODE ** pred_with_HQ);
 
 static int pt_to_index_attrs (PARSER_CONTEXT * parser, TABLE_INFO * table_info, QO_XASL_INDEX_INFO * index_pred,
 			      PT_NODE * pred, PT_NODE ** pred_attrs, int **pred_offsets);

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -723,6 +723,8 @@ pt_make_connect_by_proc (PARSER_CONTEXT * parser, PT_NODE * select_node, XASL_NO
 
       if (xasl == NULL)
 	{
+	  parser_free_tree (parser, pred_without_HQ);
+	  parser_free_tree (parser, pred_with_HQ);
 	  PT_INTERNAL_ERROR (parser, "generate hq xasl");
 	  return NULL;
 	}

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -712,7 +712,7 @@ pt_make_connect_by_proc (PARSER_CONTEXT * parser, PT_NODE * select_node, XASL_NO
       /* pred_with_HQ is appended to if_pred instead of data filter. */
       pt_split_pred_for_HQ (parser, where, &pred_without_HQ, &pred_with_HQ);
 
-      select_node->info.query.q.select.where = pred_without_HQ;
+      select_node->info.query.q.select.where = pred_with_HQ ? pred_without_HQ : where;
       save_from = select_node->info.query.q.select.from->next;
       select_node->info.query.q.select.from->next = NULL;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24022

Exclude predicates with reserved words for HQ from data filter.
