### PR TITLE
[LETS-176] Core dumped in argument_handler at src/executables/server.c:355

### DIFF
--- a/src/communication/network.h
+++ b/src/communication/network.h
@@ -280,7 +280,7 @@ typedef enum
 } QUERY_SERVER_REQUEST;
 
 /* Server startup */
-extern int net_server_start (const char *name, THREAD_ENTRY * thread_p);
+extern int net_server_start (THREAD_ENTRY * thread_p, const char *server_name);
 extern const char *net_server_request_name (int request);
 
 #endif /* _NETWORK_H_ */

--- a/src/communication/network.h
+++ b/src/communication/network.h
@@ -280,7 +280,7 @@ typedef enum
 } QUERY_SERVER_REQUEST;
 
 /* Server startup */
-extern int net_server_start (const char *name);
+extern int net_server_start (const char *name, THREAD_ENTRY * thread_p);
 extern const char *net_server_request_name (int request);
 
 #endif /* _NETWORK_H_ */

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1291,7 +1291,7 @@ loop:
  *   server_name(in): name of server
  */
 int
-net_server_start (const char *server_name, THREAD_ENTRY * thread_p)
+net_server_start (THREAD_ENTRY * thread_p, const char *server_name)
 {
   int error = NO_ERROR;
   int name_length;

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1291,23 +1291,14 @@ loop:
  *   server_name(in): name of server
  */
 int
-net_server_start (const char *server_name)
+net_server_start (const char *server_name, THREAD_ENTRY * thread_p)
 {
   int error = NO_ERROR;
   int name_length;
   char *packed_name;
   int r, status = 0;
   CHECK_ARGS check_coll_and_timezone = { true, true };
-  THREAD_ENTRY *thread_p = NULL;
 
-  if (er_init (NULL, ER_NEVER_EXIT) != NO_ERROR)
-    {
-      PRINT_AND_LOG_ERR_MSG ("Failed to initialize error manager\n");
-      status = -1;
-      goto end;
-    }
-
-  cubthread::initialize (thread_p);
   cubthread::internal_tasks_worker_pool::initialize ();
   assert (thread_p == thread_get_thread_entry_info ());
 

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -46,11 +46,11 @@
 #include "connection_error.h"
 #include "network.h"
 #include "environment_variable.h"
-#include "internal_tasks_worker_pool.hpp"
 #include "boot_sr.h"
 #include "system_parameter.h"
 #include "server_type.hpp"
 #include "perf_monitor.h"
+#include "thread_manager.hpp"
 #include "util_func.h"
 #include "util_support.h"
 #if defined(WINDOWS)
@@ -433,7 +433,7 @@ main (int argc, char **argv)
     setsid ();
 #endif
 
-    ret_val = net_server_start (database_name, thread_p);
+    ret_val = net_server_start (thread_p, database_name);
 
   }
 #if defined(WINDOWS)

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -412,7 +412,7 @@ main (int argc, char **argv)
         PRINT_AND_LOG_ERR_MSG ("Failed to initialize error manager\n");
         return 1;
       }
-    cubthread::initialize (thread_p);
+    thread_initialize_manager (thread_p);
     fprintf (stdout, "\nThis may take a long time depending on the amount " "of recovery works to do.\n");
 
     /* save executable path */

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -46,6 +46,7 @@
 #include "connection_error.h"
 #include "network.h"
 #include "environment_variable.h"
+#include "internal_tasks_worker_pool.hpp"
 #include "boot_sr.h"
 #include "system_parameter.h"
 #include "server_type.hpp"
@@ -380,6 +381,7 @@ main (int argc, char **argv)
 {
   char *binary_name;
   int ret_val = 0;
+  THREAD_ENTRY *thread_p = nullptr;
 
 #if defined(WINDOWS)
   FreeConsole ();
@@ -401,10 +403,16 @@ main (int argc, char **argv)
   {				/* to make indent happy */
     if (argc < 2)
       {
-	PRINT_AND_LOG_ERR_MSG ("Usage: server databasename\n");
-	return 1;
+        PRINT_AND_LOG_ERR_MSG ("Usage: server databasename\n");
+        return 1;
       }
 
+    if (er_init (NULL, ER_NEVER_EXIT) != NO_ERROR)
+      {
+        PRINT_AND_LOG_ERR_MSG ("Failed to initialize error manager\n");
+        return 1;
+      }
+    cubthread::initialize (thread_p);
     fprintf (stdout, "\nThis may take a long time depending on the amount " "of recovery works to do.\n");
 
     /* save executable path */
@@ -414,7 +422,7 @@ main (int argc, char **argv)
     ret_val = argument_handler (argc, argv);
     if (ret_val != NO_ERROR)
       {
-	return ret_val;
+        return ret_val;
       }
 
 #if !defined(WINDOWS)
@@ -425,7 +433,7 @@ main (int argc, char **argv)
     setsid ();
 #endif
 
-    ret_val = net_server_start (database_name);
+    ret_val = net_server_start (database_name, thread_p);
 
   }
 #if defined(WINDOWS)

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -658,7 +658,7 @@ namespace cubthread
 
 } // namespace cubthread
 
-void thread_initialize_manager(THREAD_ENTRY * thread_p)
+void thread_initialize_manager (THREAD_ENTRY *thread_p)
 {
-    cubthread::initialize(thread_p);
+  cubthread::initialize (thread_p);
 }

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -657,3 +657,8 @@ namespace cubthread
   }
 
 } // namespace cubthread
+
+void thread_initialize_manager(THREAD_ENTRY * thread_p)
+{
+    cubthread::initialize(thread_p);
+}

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -363,7 +363,7 @@ namespace cubthread
 
 } // namespace cubthread
 
-void thread_initialize_manager(THREAD_ENTRY * thread_p);
+void thread_initialize_manager (THREAD_ENTRY *thread_p);
 
 //////////////////////////////////////////////////////////////////////////
 // alias functions to be used in C legacy code

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -363,6 +363,8 @@ namespace cubthread
 
 } // namespace cubthread
 
+void thread_initialize_manager(THREAD_ENTRY * thread_p);
+
 //////////////////////////////////////////////////////////////////////////
 // alias functions to be used in C legacy code
 //

--- a/win/libcubrid/libcubrid.def
+++ b/win/libcubrid/libcubrid.def
@@ -9,7 +9,8 @@ EXPORTS
 	util_log_write_errid
 	util_log_write_errstr
 	util_log_write_command
-    er_set
+    er_init
+	er_set
     getopt_long
     set_server_type
 

--- a/win/libcubrid/libcubrid.def
+++ b/win/libcubrid/libcubrid.def
@@ -13,6 +13,7 @@ EXPORTS
 	er_set
     getopt_long
     set_server_type
+	thread_initialize_manager
 
 ;
 ;   porting.h


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-176

Fixed core caused by the `cubrid server start -a` command.
The problem was due to the late initialization of the error manager, the init code was moved to an earlier location.

Tested by running the failing shell tests again, output is now OK.
