### PR TITLE
[LETS-190] incorrect threadp pointer handling in relaying to calling function

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -89,7 +89,7 @@ int init_server_type (const char *db_name)
       g_server_type = get_value_from_config (parameter_value);
     }
 
-  if (g_server_type == SERVER_TYPE_TRANSACTION || parameter_value == server_type_config::SINGLE_NODE)
+  if (g_server_type == SERVER_TYPE_TRANSACTION && parameter_value == server_type_config::SINGLE_NODE)
     {
       setup_tran_server_params_on_single_node_config ();
     }
@@ -137,7 +137,7 @@ void finalize_server_type ()
     {
       ats_Gl.disconnect_page_server ();
     }
-  else if (get_server_type() == SERVER_TYPE_PAGE)
+  else if (get_server_type () == SERVER_TYPE_PAGE)
     {
       ps_Gl.disconnect_active_tran_server ();
     }

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -658,7 +658,7 @@ namespace cubthread
 
 } // namespace cubthread
 
-void thread_initialize_manager (THREAD_ENTRY *thread_p)
+void thread_initialize_manager (THREAD_ENTRY *&thread_p)
 {
   cubthread::initialize (thread_p);
 }

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -363,7 +363,7 @@ namespace cubthread
 
 } // namespace cubthread
 
-void thread_initialize_manager (THREAD_ENTRY *thread_p);
+void thread_initialize_manager (THREAD_ENTRY *&thread_p);
 
 //////////////////////////////////////////////////////////////////////////
 // alias functions to be used in C legacy code


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-190

- pass pointer by reference to surface its value in the calling function 
- incorrect condition for initialization of dependent parameters when single node parameter is read from config