### PR TITLE
[LETS-191] crash when recovery is executed in parallel mode without any extended perfmon activation flags enabled

### DIFF
--- a/src/transaction/log_recovery_redo_parallel.cpp
+++ b/src/transaction/log_recovery_redo_parallel.cpp
@@ -713,32 +713,35 @@ namespace cublog
   void
   redo_parallel::log_perf_stats () const
   {
-    const cubperf::statset_definition definition
-    {
-      perf_stats_async_definition_init_list
-    };
-
-    std::vector<cubperf::stat_value> accum_perf_stat_results;
-    accum_perf_stat_results.resize (definition.get_value_count ());
-
-    for (auto &redo_task: m_redo_tasks)
+    if ( perf_stats_is_active_for_async () )
       {
-	redo_task->accumulate_perf_stats (accum_perf_stat_results.data (), accum_perf_stat_results.size ());
-	redo_task->log_perf_stats ();
-      }
+	const cubperf::statset_definition definition
+	{
+	  perf_stats_async_definition_init_list
+	};
 
-    // average
-    const std::size_t task_count = m_redo_tasks.size ();
-    const std::size_t value_count = accum_perf_stat_results.size ();
-    std::vector<cubperf::stat_value> avg_perf_stat_results;
-    avg_perf_stat_results.resize (value_count, 0.0);
-    for (std::size_t idx = 0; idx < value_count; ++idx)
-      {
-	avg_perf_stat_results[idx] = accum_perf_stat_results[idx] / task_count;
-      }
+	std::vector<cubperf::stat_value> accum_perf_stat_results;
+	accum_perf_stat_results.resize (definition.get_value_count ());
 
-    log_perf_stats_values_with_definition ("Log recovery redo worker threads averaged perf stats",
-					   definition, avg_perf_stat_results.data (), value_count);
+	for (auto &redo_task: m_redo_tasks)
+	  {
+	    redo_task->accumulate_perf_stats (accum_perf_stat_results.data (), accum_perf_stat_results.size ());
+	    redo_task->log_perf_stats ();
+	  }
+
+	// average
+	const std::size_t task_count = m_redo_tasks.size ();
+	const std::size_t value_count = accum_perf_stat_results.size ();
+	std::vector<cubperf::stat_value> avg_perf_stat_results;
+	avg_perf_stat_results.resize (value_count, 0.0);
+	for (std::size_t idx = 0; idx < value_count; ++idx)
+	  {
+	    avg_perf_stat_results[idx] = accum_perf_stat_results[idx] / task_count;
+	  }
+
+	log_perf_stats_values_with_definition ("Log recovery redo worker threads averaged perf stats",
+					       definition, avg_perf_stat_results.data (), value_count);
+      }
   }
 
   /*********************************************************************

--- a/src/transaction/log_recovery_redo_parallel.cpp
+++ b/src/transaction/log_recovery_redo_parallel.cpp
@@ -713,35 +713,37 @@ namespace cublog
   void
   redo_parallel::log_perf_stats () const
   {
-    if ( perf_stats_is_active_for_async () )
+    if ( !perf_stats_is_active_for_async () )
       {
-	const cubperf::statset_definition definition
-	{
-	  perf_stats_async_definition_init_list
-	};
-
-	std::vector<cubperf::stat_value> accum_perf_stat_results;
-	accum_perf_stat_results.resize (definition.get_value_count ());
-
-	for (auto &redo_task: m_redo_tasks)
-	  {
-	    redo_task->accumulate_perf_stats (accum_perf_stat_results.data (), accum_perf_stat_results.size ());
-	    redo_task->log_perf_stats ();
-	  }
-
-	// average
-	const std::size_t task_count = m_redo_tasks.size ();
-	const std::size_t value_count = accum_perf_stat_results.size ();
-	std::vector<cubperf::stat_value> avg_perf_stat_results;
-	avg_perf_stat_results.resize (value_count, 0.0);
-	for (std::size_t idx = 0; idx < value_count; ++idx)
-	  {
-	    avg_perf_stat_results[idx] = accum_perf_stat_results[idx] / task_count;
-	  }
-
-	log_perf_stats_values_with_definition ("Log recovery redo worker threads averaged perf stats",
-					       definition, avg_perf_stat_results.data (), value_count);
+	return;
       }
+
+    const cubperf::statset_definition definition
+    {
+      perf_stats_async_definition_init_list
+    };
+
+    std::vector<cubperf::stat_value> accum_perf_stat_results;
+    accum_perf_stat_results.resize (definition.get_value_count ());
+
+    for (auto &redo_task: m_redo_tasks)
+      {
+	redo_task->accumulate_perf_stats (accum_perf_stat_results.data (), accum_perf_stat_results.size ());
+	redo_task->log_perf_stats ();
+      }
+
+    // average
+    const std::size_t task_count = m_redo_tasks.size ();
+    const std::size_t value_count = accum_perf_stat_results.size ();
+    std::vector<cubperf::stat_value> avg_perf_stat_results;
+    avg_perf_stat_results.resize (value_count, 0.0);
+    for (std::size_t idx = 0; idx < value_count; ++idx)
+      {
+	avg_perf_stat_results[idx] = accum_perf_stat_results[idx] / task_count;
+      }
+
+    log_perf_stats_values_with_definition ("Log recovery redo worker threads averaged perf stats",
+					   definition, avg_perf_stat_results.data (), value_count);
   }
 
   /*********************************************************************

--- a/src/transaction/log_recovery_redo_perf.hpp
+++ b/src/transaction/log_recovery_redo_perf.hpp
@@ -186,10 +186,13 @@ namespace cublog
   void perf_stats::accumulate (cubperf::stat_value *a_output_stats,
 			       std::size_t a_output_stats_size) const
   {
-    // minimal checking to ensure there is enough space for the underlying logic to write data
-    if (a_output_stats != nullptr && a_output_stats_size == m_definition.get_value_count ())
+    if (m_stats_set != nullptr)
       {
-	m_definition.add_stat_values_with_converted_timers<std::chrono::milliseconds> (*m_stats_set, a_output_stats);
+	// minimal checking to ensure there is enough space for the underlying logic to write data
+	if (a_output_stats != nullptr && a_output_stats_size == m_definition.get_value_count ())
+	  {
+	    m_definition.add_stat_values_with_converted_timers<std::chrono::milliseconds> (*m_stats_set, a_output_stats);
+	  }
       }
   }
 


### PR DESCRIPTION
https://jira.cubrid.org/browse/LETS-191

Guard execution of perf stats reporting function with the same function used to activated perf stats logging in the first place.


