### PR TITLE
[CBRD-24027] The 'er_log_vacuum' becomes the hidden system parameter.

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -5167,7 +5167,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_ER_LOG_VACUUM,
    PRM_NAME_ER_LOG_VACUUM,
-   (PRM_FOR_SERVER),
+   (PRM_FOR_SERVER | PRM_HIDDEN),
    PRM_INTEGER,
    &prm_er_log_vacuum_flag,
    (void *) &prm_er_log_vacuum_default,


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-24027

### Purpose
The system parameter 'er_log_vacuum' is decided to be a hidden parameter In the [CBRD-23880](https://jira.cubrid.org/browse/CBRD-23880).

### Implementation
N/A

### Remarks
N/A