### PR TITLE
[CBRD-23622] [Regression][shell] Able to skip TRUNCATE according to the optimization level

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -1234,6 +1234,7 @@ pt_is_ddl_statement (const PT_NODE * node)
 	case PT_REMOVE_TRIGGER:
 	case PT_RENAME_TRIGGER:
 	case PT_UPDATE_STATS:
+	case PT_TRUNCATE:
 	  return true;
 	default:
 	  break;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -2956,7 +2956,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   if (statement)
     {
       /* skip ddl execution in case of parameter or opt. level */
-      if (pt_is_ddl_statement (statement) != 0)
+      if (pt_is_ddl_statement (statement) != 0 || statement->node_type == PT_TRUNCATE)
 	{
 	  if (prm_get_bool_value (PRM_ID_BLOCK_DDL_STATEMENT))
 	    {
@@ -3443,7 +3443,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   SET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
 
   /* skip ddl execution in case of parameter or opt. level */
-  if (pt_is_ddl_statement (statement) != 0)
+  if (pt_is_ddl_statement (statement) != 0 || statement->node_type == PT_TRUNCATE)
     {
       if (prm_get_bool_value (PRM_ID_BLOCK_DDL_STATEMENT))
 	{

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -368,7 +368,6 @@ is_stmt_based_repl_type (const PT_NODE * node)
   switch (node->node_type)
     {
     case PT_DROP_VARIABLE:
-    case PT_TRUNCATE:
       return true;
     case PT_INSERT:
       if (node->info.insert.hint & PT_HINT_USE_SBR)
@@ -2956,7 +2955,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   if (statement)
     {
       /* skip ddl execution in case of parameter or opt. level */
-      if (pt_is_ddl_statement (statement) != 0 || statement->node_type == PT_TRUNCATE)
+      if (pt_is_ddl_statement (statement) != 0)
 	{
 	  if (prm_get_bool_value (PRM_ID_BLOCK_DDL_STATEMENT))
 	    {
@@ -3443,7 +3442,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   SET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
 
   /* skip ddl execution in case of parameter or opt. level */
-  if (pt_is_ddl_statement (statement) != 0 || statement->node_type == PT_TRUNCATE)
+  if (pt_is_ddl_statement (statement) != 0)
     {
       if (prm_get_bool_value (PRM_ID_BLOCK_DDL_STATEMENT))
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23622

Basically, statements can be skipped according to the optimization level like opt-level 2. TRUNCATE was skipped during executing DELETE, but now it may not use DELETE. DDLs are skipped in  do_statement() and do_execute_statement(), but by now TRUNCATE was not regarded as DDL. So, we need to deal with it independently.

Now, we have decided to consider TRUNCATE as DDL so that we can just add PT_TRUNCATE to `pt_is_ddl_statement()`, but I'm not sure it is safe because I don't really know about `sysprm_print_parameters_for_ha_repl()` which is executed if `pt_is_ddl_statement()` is true in `do_replicate_statement()`. I checked others and make sure I can easily modify them safely. So, I want to have your opinion about it, @hornetmj.

With this change, TRUNCATE can be blocked with the system parameter `block_ddl_statement` as a side effect, but I think it's OK and even better if we regard TRUNCATE as a DDL as we discussed.

