### PR TITLE
[LETS-133] Do not mount data volumes on the transaction server with remote storage

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -98,7 +98,7 @@ int init_server_type (const char *db_name)
 #endif
   if (g_server_type == SERVER_TYPE_TRANSACTION)
     {
-      er_code = ats_Gl.init_page_server_hosts (db_name);
+      er_code = ats_Gl.boot (db_name);
     }
   else
     {

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -488,7 +488,7 @@ void active_tran_server::receive_boot_info (cubpacking::unpacker &upk)
   DKNVOLS nvols_perm;
   std::memcpy (&nvols_perm, message.c_str (), sizeof (nvols_perm));
 
-  disk_set_perm_volume_count (nvols_perm);
+  disk_set_page_server_perm_volume_count (nvols_perm);
 
   {
     std::unique_lock<std::mutex> ulock (m_boot_info_mutex);

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -247,8 +247,6 @@ active_tran_server::get_boot_info_from_page_server ()
   std::unique_lock<std::mutex> ulock (m_boot_info_mutex);
   m_boot_info_condvar.wait (ulock, [this] { return m_is_boot_info_received; });
   // fix me: connection error handling
-
-  assert (disk_get_perm_volume_count () > 0);
 }
 
 int

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -296,6 +296,10 @@ active_tran_server::connect_to_page_server (const cubcomm::node &node, const cha
   m_page_server_conn_vec.emplace_back (new page_server_conn_t (std::move (srv_chn),
   {
     {
+      ps_to_ats_request::SEND_BOOT_INFO,
+      std::bind (&active_tran_server::receive_boot_info, std::ref (*this), std::placeholders::_1)
+    },
+    {
       ps_to_ats_request::SEND_SAVED_LSA,
       std::bind (&active_tran_server::receive_saved_lsa, std::ref (*this), std::placeholders::_1)
     },

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -131,7 +131,10 @@ active_tran_server::boot (const char *db_name)
       return error;
     }
 
-  get_boot_info_from_page_server ();
+  if (m_uses_remote_storage)
+    {
+      get_boot_info_from_page_server ();
+    }
   return NO_ERROR;
 }
 

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -47,7 +47,8 @@ class active_tran_server
     active_tran_server &operator = (const active_tran_server &) = delete;
     active_tran_server &operator = (active_tran_server &&) = delete;
 
-    int init_page_server_hosts (const char *db_name);
+    int boot (const char *db_name);
+
     void disconnect_page_server ();
     bool is_page_server_connected () const;
 
@@ -68,8 +69,12 @@ class active_tran_server
   private:
     int connect_to_page_server (const cubcomm::node &node, const char *db_name);
 
+    int init_page_server_hosts (const char *db_name);
+    void get_boot_info_from_page_server ();
+
     int parse_server_host (const std::string &host);
     int parse_page_server_hosts_config (std::string &hosts);
+    void receive_boot_info (cubpacking::unpacker &upk);
     void receive_saved_lsa (cubpacking::unpacker &upk);
     void receive_log_page (cubpacking::unpacker &upk);
     void receive_data_page (cubpacking::unpacker &upk);
@@ -84,6 +89,10 @@ class active_tran_server
     std::unique_ptr<page_broker<log_page_type>> m_log_page_broker;
     std::unique_ptr<page_broker<data_page_type>> m_data_page_broker;
     std::vector<cubcomm::node> m_connection_list;
+
+    std::mutex m_boot_info_mutex;
+    std::condition_variable m_boot_info_condvar;
+    bool m_is_boot_info_received = false;
 
     bool m_uses_remote_storage = false;
 };

--- a/src/server/ats_ps_request.hpp
+++ b/src/server/ats_ps_request.hpp
@@ -21,6 +21,7 @@
 
 enum class ats_to_ps_request
 {
+  GET_BOOT_INFO,
   SEND_LOG_PRIOR_LIST,
   SEND_LOG_PAGE_FETCH,
   SEND_DATA_PAGE_FETCH,
@@ -29,6 +30,7 @@ enum class ats_to_ps_request
 
 enum class ps_to_ats_request
 {
+  SEND_BOOT_INFO,
   SEND_SAVED_LSA,
   SEND_LOG_PAGE,
   SEND_DATA_PAGE

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -18,6 +18,7 @@
 
 #include "page_server.hpp"
 
+#include "disk_manager.h"
 #include "error_manager.h"
 #include "log_impl.h"
 #include "log_lsa_utils.hpp"
@@ -141,6 +142,17 @@ void page_server::receive_disconnect_request (cubpacking::unpacker &upk)
   //start a thread to destroy the ATS to PS connection object
   std::thread disconnect_thread (&page_server::disconnect_active_tran_server, std::ref (*this));
   disconnect_thread.detach ();
+}
+
+void page_server::receive_boot_info_request (cubpacking::unpacker &upk)
+{
+  DKNVOLS nvols_perm = disk_get_perm_volume_count ();
+
+  std::string response_message;
+  response_message.reserve (sizeof (nvols_perm));
+  response_message.append (reinterpret_cast<const char *> (&nvols_perm), sizeof (nvols_perm));
+
+  m_active_tran_server_conn->push (ps_to_ats_request::SEND_BOOT_INFO, std::move (response_message));
 }
 
 void page_server::push_request_to_active_tran_server (ps_to_ats_request reqid, std::string &&payload)

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -56,6 +56,10 @@ void page_server::set_active_tran_server_connection (cubcomm::channel &&chn)
   m_active_tran_server_conn.reset (new active_tran_server_conn_t (std::move (chn),
   {
     {
+      ats_to_ps_request::GET_BOOT_INFO,
+      std::bind (&page_server::receive_boot_info_request, std::ref (*this), std::placeholders::_1)
+    },
+    {
       ats_to_ps_request::SEND_LOG_PRIOR_LIST,
       std::bind (&page_server::receive_log_prior_list, std::ref (*this), std::placeholders::_1)
     },

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -61,6 +61,7 @@ class page_server
     using active_tran_server_conn_t =
 	    cubcomm::request_sync_client_server<ps_to_ats_request, ats_to_ps_request, std::string>;
 
+    void receive_boot_info_request (cubpacking::unpacker &upk);
     void receive_log_prior_list (cubpacking::unpacker &upk);
     void receive_log_page_fetch (cubpacking::unpacker &upk);
     void receive_data_page_fetch (cubpacking::unpacker &upk);

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -6786,6 +6786,21 @@ disk_sectors_to_extend_npages (const int num_pages)
   return DISK_SECTS_ROUND_UP (DISK_PAGES_TO_SECTS (num_pages));
 }
 
+DKNVOLS
+disk_get_perm_volume_count ()
+{
+  return disk_Cache->nvols_perm;
+}
+
+void
+disk_set_perm_volume_count (DKNVOLS nvols)
+{
+  // this is called only during boot, only to set the number of volumes on a transaction server with remote storage.
+  // no sync required
+  assert (is_tran_server_with_remote_storage () && !LOG_ISRESTARTED ());
+  disk_Cache->nvols_perm = nvols;
+}
+
 /************************************************************************/
 /* End of file                                                          */
 /************************************************************************/

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -6818,6 +6818,7 @@ disk_set_page_server_perm_volume_count (DKNVOLS nvols)
 
   // Set the number of permanent volumes for transaction server with remote storage.
   // Disk manager is not initialized yet, so save the number to be used later when disk cache is loaded.
+  assert (disk_Page_server_perm_volume_count == 0);
   disk_Page_server_perm_volume_count = nvols;
 }
 

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2706,7 +2706,24 @@ disk_cache_load_all_volumes (THREAD_ENTRY * thread_p)
 {
   /* Cache every single volume */
   assert (disk_Cache != NULL);
-  return fileio_map_mounted (thread_p, disk_cache_load_volume, NULL);
+  if (is_tran_server_with_remote_storage ())
+    {
+      assert (disk_Cache->nvols_perm > 0);
+      for (VOLID volid = 0; volid < disk_Cache->nvols_perm; ++volid)
+	{
+	  if (!disk_cache_load_volume (thread_p, volid, NULL))
+	    {
+	      ASSERT_ERROR ();
+	      return false;
+	    }
+	}
+      return true;
+    }
+  else
+    {
+      // Load cache data from the mounted local volumes
+      return fileio_map_mounted (thread_p, disk_cache_load_volume, NULL);
+    }
 }
 
 /*

--- a/src/storage/disk_manager.h
+++ b/src/storage/disk_manager.h
@@ -120,7 +120,7 @@ extern DISK_ISVALID disk_check (THREAD_ENTRY * thread_p, bool repair);
 extern int disk_dump_all (THREAD_ENTRY * thread_p, FILE * fp);
 extern int disk_spacedb (THREAD_ENTRY * thread_p, SPACEDB_ALL * spaceall, SPACEDB_ONEVOL ** spacevols);
 extern DKNVOLS disk_get_perm_volume_count ();
-extern void disk_set_perm_volume_count (DKNVOLS nvols);
+extern void disk_set_page_server_perm_volume_count (DKNVOLS nvols);
 
 extern int disk_volume_header_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int arg_cnt,
 					  void **ctx);

--- a/src/storage/disk_manager.h
+++ b/src/storage/disk_manager.h
@@ -119,6 +119,8 @@ extern char *disk_get_link (THREAD_ENTRY * thread_p, INT16 volid, INT16 * next_v
 extern DISK_ISVALID disk_check (THREAD_ENTRY * thread_p, bool repair);
 extern int disk_dump_all (THREAD_ENTRY * thread_p, FILE * fp);
 extern int disk_spacedb (THREAD_ENTRY * thread_p, SPACEDB_ALL * spaceall, SPACEDB_ONEVOL ** spacevols);
+extern DKNVOLS disk_get_perm_volume_count ();
+extern void disk_set_perm_volume_count (DKNVOLS nvols);
 
 extern int disk_volume_header_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int arg_cnt,
 					  void **ctx);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -7878,6 +7878,12 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
       else
 	{
 	  fileio_init_lsa_of_page (&bufptr->iopage_buffer->iopage, IO_PAGESIZE);
+	  if (is_tran_server_with_remote_storage ())
+	    {
+	      // Permanent data pages on transaction servers with remote storage don't have to be flushed to disk when
+	      // they're dirty. Mark this by PGBUF_BCB_FLUSH_NOT_NEEDED flag
+	      bufptr->flags |= PGBUF_BCB_FLUSH_NOT_NEEDED_FLAG;
+	    }
 	}
 
       /* perm volume */

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -10426,9 +10426,14 @@ pgbuf_is_valid_page (THREAD_ENTRY * thread_p, const VPID * vpid, bool no_error,
 {
   DISK_ISVALID valid;
 
-  /* TODO: fix me */
+  if (VPID_ISNULL (vpid))
+    {
+      assert (no_error);
 
-  if (fileio_get_volume_label (vpid->volid, PEEK) == NULL || VPID_ISNULL (vpid))
+      return DISK_INVALID;
+    }
+
+  if (!is_tran_server_with_remote_storage () && fileio_get_volume_label (vpid->volid, PEEK) == NULL)
     {
       assert (no_error);
 
@@ -10441,8 +10446,9 @@ pgbuf_is_valid_page (THREAD_ENTRY * thread_p, const VPID * vpid, bool no_error,
     {
       if (valid != DISK_ERROR && !no_error)
 	{
+	  const char *vlabel = fileio_get_volume_label (vpid->volid, PEEK);
 	  er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_PB_BAD_PAGEID, 2, vpid->pageid,
-		  fileio_get_volume_label (vpid->volid, PEEK));
+		  vlabel == NULL ? "(unknown)" : vlabel);
 
 	  assert (false);
 	}

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2424,11 +2424,14 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
    * are ok. However, some recovery may need to take place
    */
 
-  /* Mount the data volume */
-  error_code = boot_mount (thread_p, LOG_DBFIRST_VOLID, boot_Db_full_name, NULL);
-  if (error_code != NO_ERROR)
+  if (!is_tran_server_with_remote_storage ())
     {
-      goto error;
+      /* Mount the data volume */
+      error_code = boot_mount (thread_p, LOG_DBFIRST_VOLID, boot_Db_full_name, NULL);
+      if (error_code != NO_ERROR)
+	{
+	  goto error;
+	}
     }
 
   /* Find the location of the database parameters and read them */
@@ -2478,12 +2481,14 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       lang_set_charset (db_charset_db_header);
     }
 
-  /* Find the rest of the volumes and mount them */
-
-  error_code = boot_find_rest_volumes (thread_p, from_backup ? r_args : NULL, LOG_DBFIRST_VOLID, boot_mount, NULL);
-  if (error_code != NO_ERROR)
+  if (!is_tran_server_with_remote_storage ())
     {
-      goto error;
+      /* Find the rest of the volumes and mount them */
+      error_code = boot_find_rest_volumes (thread_p, from_backup ? r_args : NULL, LOG_DBFIRST_VOLID, boot_mount, NULL);
+      if (error_code != NO_ERROR)
+	{
+	  goto error;
+	}
     }
 
   /* initialize disk manager */


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-133

**Do not mount any data volumes** during the boot of a transaction server with remote storage. Disable `boot_mount()` calls on TSRS.

As consequence, a **new system to boot disk cache** is required. The volids used to be obtained from the mounted file cache. The existing volids have to be obtained from the page server instead:

  - Add ATS<->PS requests to transfer boot information. For now, the only information passed from PS is the permanent volume count.
  - On `init_server_type()` call `ats_Gl.boot()` (initializes page server connections and also obtains boot information).
  - `active_tran_server::get_boot_info_from_page_server()` sends the request to get boot information from page server and then blocks until the information is obtained (with the help of mutex, condition variable and `m_is_boot_info_received` boolean).
  
When disk cache is loaded, map `disk_cache_load_volume()` on all volids in the range [0, permanent volume count) instead of mapping on fileio cache volumes.

**Other changes:**

  - Update pgbuf_is_valid_page(); getting volume label on TSRS is not possible.
  - Fix missing PGBUF_BCB_FLUSH_NOT_NEEDED_FLAG when fetch_mode is NEW_PAGE. 