### PR TITLE
[CBRD-24025] Speedup redo recovery by avoiding "is reserved" check

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -22445,13 +22445,6 @@ btree_rv_redo_global_unique_stats_commit (THREAD_ENTRY * thread_p, LOG_RCV * rec
   num_keys = OR_GET_INT (datap);
   datap += OR_INT_SIZE;
 
-  /* Because this log record is logical, it will be processed even if the B-tree was deleted. If the B-tree was deleted
-   * then skip update of unique statistics in global hash. */
-  if (disk_is_page_sector_reserved (thread_p, btid.vfid.volid, btid.root_pageid) != DISK_VALID)
-    {
-      /* The B-tree was already deleted */
-      return NO_ERROR;
-    }
   if (logtb_rv_update_global_unique_stats_by_abs (thread_p, &btid, num_oids, num_nulls, num_keys) != NO_ERROR)
     {
       goto error;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -4803,7 +4803,6 @@ pgbuf_set_lsa_as_temporary (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
  *   return: void
  *   bufptr(in): pointer to buffer page
  *
- * Note: This function is used for debugging.
  */
 STATIC_INLINE void
 pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr)
@@ -4836,11 +4835,6 @@ pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr)
 	  /* values not reset upon page deallocation */
 	  assert (bufptr->iopage_buffer->iopage.prv.volid == bufptr->vpid.volid);
 	  assert (bufptr->iopage_buffer->iopage.prv.pageid == bufptr->vpid.pageid);
-
-	  /* values reset upon page deallocation */
-	  assert (bufptr->iopage_buffer->iopage.prv.ptype == PAGE_UNKNOWN);
-	  /* only compare the encryption part of the flag, the rest is, as of now, unused */
-	  assert ((bufptr->iopage_buffer->iopage.prv.pflag & FILEIO_PAGE_FLAG_ENCRYPTED_MASK) == '\0');
 	}
     }
 }

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -4831,6 +4831,17 @@ pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr)
 	  bufptr->iopage_buffer->iopage.prv.p_reserve_2 = 0;
 	  bufptr->iopage_buffer->iopage.prv.tde_nonce = 0;
 	}
+      else
+	{
+	  /* values not reset upon page deallocation */
+	  assert (bufptr->iopage_buffer->iopage.prv.volid == bufptr->vpid.volid);
+	  assert (bufptr->iopage_buffer->iopage.prv.pageid == bufptr->vpid.pageid);
+
+	  /* values reset upon page deallocation */
+	  assert (bufptr->iopage_buffer->iopage.prv.ptype == PAGE_UNKNOWN);
+	  /* only compare the encryption part of the flag, the rest is, as of now, unused */
+	  assert ((bufptr->iopage_buffer->iopage.prv.pflag & FILEIO_PAGE_FLAG_ENCRYPTED_MASK) == '\0');
+	}
     }
 }
 
@@ -5008,7 +5019,7 @@ pgbuf_initialize_bcb_table (void)
       ioptr->iopage.prv.pageid = -1;
       ioptr->iopage.prv.volid = -1;
 
-      ioptr->iopage.prv.ptype = '\0';
+      ioptr->iopage.prv.ptype = (unsigned char) PAGE_UNKNOWN;
       ioptr->iopage.prv.pflag = '\0';
       ioptr->iopage.prv.p_reserve_1 = 0;
       ioptr->iopage.prv.p_reserve_2 = 0;
@@ -10461,7 +10472,7 @@ pgbuf_scramble (FILEIO_PAGE * iopage)
   iopage->prv.pageid = -1;
   iopage->prv.volid = -1;
 
-  iopage->prv.ptype = '\0';
+  iopage->prv.ptype = (unsigned char) PAGE_UNKNOWN;
   iopage->prv.pflag = '\0';
   iopage->prv.p_reserve_1 = 0;
   iopage->prv.p_reserve_2 = 0;
@@ -14012,7 +14023,7 @@ pgbuf_dealloc_page (THREAD_ENTRY * thread_p, PAGE_PTR page_dealloc)
 #endif /* !NDEBUG */
 
   /* set unknown type */
-  bcb->iopage_buffer->iopage.prv.ptype = (char) PAGE_UNKNOWN;
+  bcb->iopage_buffer->iopage.prv.ptype = (unsigned char) PAGE_UNKNOWN;
   /* clear page flags (now only tde algorithm) */
   bcb->iopage_buffer->iopage.prv.pflag = (unsigned char) 0;
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1077,7 +1077,7 @@ STATIC_INLINE void pgbuf_wakeup_reader_writer (THREAD_ENTRY * thread_p, PGBUF_BC
 
 STATIC_INLINE bool pgbuf_get_check_page_validation_level (int page_validation_level) __attribute__ ((ALWAYS_INLINE));
 static bool pgbuf_is_valid_page_ptr (const PAGE_PTR pgptr);
-STATIC_INLINE void pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr, bool force_set_vpid) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE bool pgbuf_check_bcb_page_vpid (PGBUF_BCB * bufptr, bool maybe_deallocated)
   __attribute__ ((ALWAYS_INLINE));
 
@@ -1810,7 +1810,7 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
   bool had_holder = false;
 #endif /* !NDEBUG */
   PGBUF_FIX_PERF perf;
-  bool maybe_deallocated, force_set_vpid;
+  bool maybe_deallocated;
   int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[tran_index];
 
@@ -1950,8 +1950,7 @@ try_again:
 
   /* Set Page identifier if needed */
   // Redo recovery may find an immature page which should be set.
-  force_set_vpid = (fetch_mode == NEW_PAGE && log_is_in_crash_recovery_and_not_yet_completes_redo ());
-  pgbuf_set_bcb_page_vpid (bufptr, force_set_vpid);
+  pgbuf_set_bcb_page_vpid (bufptr);
 
   maybe_deallocated = (fetch_mode == OLD_PAGE_MAYBE_DEALLOCATED);
   if (pgbuf_check_bcb_page_vpid (bufptr, maybe_deallocated) != true)
@@ -2083,6 +2082,7 @@ try_again:
 	case NEW_PAGE:
 	case OLD_PAGE_DEALLOCATED:
 	case OLD_PAGE_IF_IN_BUFFER:
+	case RECOVERY_PAGE:
 	  /* fixing deallocated page is expected. fall through to return it. */
 	  break;
 	case OLD_PAGE:
@@ -4802,12 +4802,11 @@ pgbuf_set_lsa_as_temporary (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
  * pgbuf_set_bcb_page_vpid () -
  *   return: void
  *   bufptr(in): pointer to buffer page
- *   force_set_vpid(in): true, if forces VPID setting
  *
  * Note: This function is used for debugging.
  */
 STATIC_INLINE void
-pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr, bool force_set_vpid)
+pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr)
 {
   if (bufptr == NULL || VPID_ISNULL (&bufptr->vpid))
     {
@@ -4820,14 +4819,14 @@ pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr, bool force_set_vpid)
   if (bufptr->vpid.volid > NULL_VOLID)
     {
       /* Check if is the first time */
-      if (force_set_vpid
-	  || (bufptr->iopage_buffer->iopage.prv.pageid == -1 && bufptr->iopage_buffer->iopage.prv.volid == -1))
+      if (bufptr->iopage_buffer->iopage.prv.pageid == NULL_PAGEID
+	  && bufptr->iopage_buffer->iopage.prv.volid == NULL_VOLID)
 	{
 	  /* Set Page identifier */
 	  bufptr->iopage_buffer->iopage.prv.pageid = bufptr->vpid.pageid;
 	  bufptr->iopage_buffer->iopage.prv.volid = bufptr->vpid.volid;
 
-	  bufptr->iopage_buffer->iopage.prv.ptype = '\0';
+	  bufptr->iopage_buffer->iopage.prv.ptype = PAGE_UNKNOWN;
 	  bufptr->iopage_buffer->iopage.prv.p_reserve_1 = 0;
 	  bufptr->iopage_buffer->iopage.prv.p_reserve_2 = 0;
 	  bufptr->iopage_buffer->iopage.prv.tde_nonce = 0;
@@ -4863,7 +4862,7 @@ pgbuf_set_page_ptype (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PAGE_TYPE ptype)
   assert (!VPID_ISNULL (&bufptr->vpid));
 
   /* Set Page identifier if needed */
-  pgbuf_set_bcb_page_vpid (bufptr, false);
+  pgbuf_set_bcb_page_vpid (bufptr);
 
   if (pgbuf_check_bcb_page_vpid (bufptr, false) != true)
     {

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -170,6 +170,8 @@ typedef enum
   OLD_PAGE_PREVENT_DEALLOC,	/* Fetch existing page and mark its memory buffer, to prevent deallocation. */
   OLD_PAGE_DEALLOCATED,		/* Fetch page that has been deallocated. */
   OLD_PAGE_MAYBE_DEALLOCATED,	/* Fetch page that maybe was deallocated. */
+  RECOVERY_PAGE			/* Fetch page for recovery. The page may be new, or deallocated or normal, everything
+				 * is possible really. */
 } PAGE_FETCH_MODE;
 
 /* public page latch mode */

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3300,7 +3300,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid);
 		  if (rcv.pgptr == NULL)
 		    {
-		      /* deallocated */
 		      break;
 		    }
 		}
@@ -3486,7 +3485,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid);
 		  if (rcv.pgptr == NULL)
 		    {
-		      /* deallocated */
 		      break;
 		    }
 		}
@@ -3608,7 +3606,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid);
 		  if (rcv.pgptr == NULL)
 		    {
-		      /* deallocated */
 		      break;
 		    }
 		}
@@ -3695,7 +3692,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid);
 		  if (rcv.pgptr == NULL)
 		    {
-		      /* deallocated */
 		      break;
 		    }
 		}
@@ -6384,7 +6380,7 @@ log_rv_pack_undo_record_changes (char *ptr, int offset_to_data, int old_data_siz
 }
 
 /*
- * log_rv_redo_fix_page () - fix page for recovery
+ * log_rv_redo_fix_page () - fix page for recovery without upfront reservation check
  *
  * return        : fixed page or NULL
  * thread_p (in) : thread entry
@@ -6397,7 +6393,6 @@ log_rv_redo_fix_page (THREAD_ENTRY * thread_p, const VPID * vpid_rcv)
 
   assert (vpid_rcv != NULL && !VPID_ISNULL (vpid_rcv));
 
-  //
   // during recovery, we don't care if a page is deallocated or not, apply the changes regardless. since changes to
   // sector reservation table are applied in parallel with the changes in pages, at times the page may appear to be
   // deallocated (part of an unreserved sector). but the changes were done while the sector was reserved and must be

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -126,7 +126,7 @@ static int log_rv_record_modify_internal (THREAD_ENTRY * thread_p, LOG_RCV * rcv
 static int log_rv_undoredo_partial_changes_recursive (THREAD_ENTRY * thread_p, OR_BUF * rcv_buf, RECDES * record,
 						      bool is_undo);
 
-STATIC_INLINE PAGE_PTR log_rv_redo_fix_page (THREAD_ENTRY * thread_p, const VPID * vpid_rcv, LOG_RCVINDEX rcvindex)
+STATIC_INLINE PAGE_PTR log_rv_redo_fix_page (THREAD_ENTRY * thread_p, const VPID * vpid_rcv)
   __attribute__ ((ALWAYS_INLINE));
 
 static void log_rv_simulate_runtime_worker (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
@@ -3297,7 +3297,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 	      /* If the page does not exit, there is nothing to redo */
 	      if (rcv_vpid.pageid != NULL_PAGEID && rcv_vpid.volid != NULL_VOLID)
 		{
-		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid, rcvindex);
+		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid);
 		  if (rcv.pgptr == NULL)
 		    {
 		      /* deallocated */
@@ -3483,7 +3483,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 	      /* If the page does not exit, there is nothing to redo */
 	      if (rcv_vpid.pageid != NULL_PAGEID && rcv_vpid.volid != NULL_VOLID)
 		{
-		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid, rcvindex);
+		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid);
 		  if (rcv.pgptr == NULL)
 		    {
 		      /* deallocated */
@@ -3605,7 +3605,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 	      /* If the page does not exit, there is nothing to redo */
 	      if (rcv_vpid.pageid != NULL_PAGEID && rcv_vpid.volid != NULL_VOLID)
 		{
-		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid, rcvindex);
+		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid);
 		  if (rcv.pgptr == NULL)
 		    {
 		      /* deallocated */
@@ -3692,7 +3692,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 	      /* If the page does not exit, there is nothing to redo */
 	      if (rcv_vpid.pageid != NULL_PAGEID && rcv_vpid.volid != NULL_VOLID)
 		{
-		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid, rcvindex);
+		  rcv.pgptr = log_rv_redo_fix_page (thread_p, &rcv_vpid);
 		  if (rcv.pgptr == NULL)
 		    {
 		      /* deallocated */
@@ -6389,85 +6389,32 @@ log_rv_pack_undo_record_changes (char *ptr, int offset_to_data, int old_data_siz
  * return        : fixed page or NULL
  * thread_p (in) : thread entry
  * vpid_rcv (in) : page identifier
- * rcvindex (in) : recovery index of log record to redo
  */
 STATIC_INLINE PAGE_PTR
-log_rv_redo_fix_page (THREAD_ENTRY * thread_p, const VPID * vpid_rcv, LOG_RCVINDEX rcvindex)
+log_rv_redo_fix_page (THREAD_ENTRY * thread_p, const VPID * vpid_rcv)
 {
   PAGE_PTR page = NULL;
 
   assert (vpid_rcv != NULL && !VPID_ISNULL (vpid_rcv));
 
-  /* how it works:
-   * since we are during recovery, we don't know the current state of page. it may be unreserved (its file is destroyed)
-   * or it may not be allocated. these are expected cases and we don't want to raise errors if it happens.
-   * some redo records are used to initialize a page for the first time (also setting its page type which is necessary
-   * to consider a page allocated). even first attempt to fix page fails, but the page's sector is reserved, we will
-   * fix the page as NEW_PAGE and apply its initialization redo log record.
-   * In case of RVPGBUF_COMPENSATE_DEALLOC, we expect deallocated page.
-   */
-
-  if (rcvindex == RVPGBUF_COMPENSATE_DEALLOC)
+  //
+  // during recovery, we don't care if a page is deallocated or not, apply the changes regardless. since changes to
+  // sector reservation table are applied in parallel with the changes in pages, at times the page may appear to be
+  // deallocated (part of an unreserved sector). but the changes were done while the sector was reserved and must be
+  // re-applied to get a correct end result.
+  // 
+  // moreover, the sector reservation check is very expensive. running this check on every page fix costs much more
+  // than any time gained by skipping redoing changes on deallocated pages.
+  //
+  // therefore, fix page using RECOVERY_PAGE mode. pgbuf_fix will know to accept even new or deallocated pages.
+  //
+  page = pgbuf_fix (thread_p, vpid_rcv, RECOVERY_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
+  if (page == NULL)
     {
-      page = pgbuf_fix (thread_p, vpid_rcv, OLD_PAGE_DEALLOCATED, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
-      if (page == NULL)
-	{
-	  assert_release (false);
-	  return NULL;
-	}
-
-      return page;
-    }
-
-  /* let's first try to fix page if it is not deallocated. */
-  if (pgbuf_fix_if_not_deallocated (thread_p, vpid_rcv, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH, &page)
-      != NO_ERROR)
-    {
-      ASSERT_ERROR ();
+      // this is terrible, because it makes recovery impossible
+      assert_release (false);
       return NULL;
     }
-
-  if (page == NULL && RCV_IS_NEW_PAGE_INIT (rcvindex))
-    {
-      DISK_ISVALID isvalid;
-
-      /* see case OLD_PAGE_MAYBE_DEALLOCATED of pgbuf_fix
-       * redo recovery may try to fix an immature page, reserved, but which was not initialized
-       * or it was reused (deallocated and allocated again).
-       */
-
-      if (er_errid () == ER_PB_BAD_PAGEID && er_get_severity () == ER_WARNING_SEVERITY)
-	{
-	  // forget the warning since we are going to fix the page as NEW and don't want it will bother us.
-	  er_clear ();
-	}
-
-      /* page is deallocated. however, this is redo of a new page initialization, we still have to apply it.
-       * page must still be reserved, otherwise it means its file was completely destroyed.
-       */
-
-      isvalid = disk_is_page_sector_reserved (thread_p, vpid_rcv->volid, vpid_rcv->pageid);
-      if (isvalid == DISK_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  return NULL;
-	}
-      else if (isvalid == DISK_INVALID)
-	{
-	  /* not reserved */
-	  return NULL;
-	}
-
-      assert (isvalid == DISK_VALID);
-
-      page = pgbuf_fix (thread_p, vpid_rcv, NEW_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
-      if (page == NULL)
-	{
-	  ASSERT_ERROR ();
-	  return NULL;
-	}
-    }
-
   return page;
 }
 

--- a/src/transaction/recovery.h
+++ b/src/transaction/recovery.h
@@ -265,15 +265,4 @@ extern void rv_check_rvfuns (void);
    || (idx) == RVFL_TRACKER_HEAP_REUSE \
    || (idx) == RVFL_TRACKER_UNREGISTER)
 
-#define RCV_IS_NEW_PAGE_INIT(idx) \
-  ((idx) == RVPGBUF_NEW_PAGE \
-   || (idx) == RVDK_FORMAT \
-   || (idx) == RVDK_INITMAP \
-   || (idx) == RVHF_NEWPAGE \
-   || (idx) == RVEH_INIT_BUCKET \
-   || (idx) == RVEH_INIT_NEW_DIR_PAGE \
-   || (idx) == RVBT_GET_NEWPAGE \
-   || (idx) == RVCT_NEWPAGE \
-   || (idx) == RVHF_CREATE_HEADER)
-
 #endif /* _RECOVERY_H_ */


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-24025

During recovery, there is a step that checks if page is "reserved". The check fixes sector reservation table page and searches for the bit corresponding to the page's sector. If it is not reserved, applying redo is skipped. As a result, if a file is destroyed before crash (drop index, drop table), many redo changes may be skipped. Skipping these redo record is not a strict requirement; it may have been an optimization and it may pass some automatic page buffer fix checks.

However, the performance impact of the check is serious. Measurements in some artificial tests showed an overall 2x improvement of the recovery redo part of the recovery sequence without the checks.

The check is completely avoidable by applying redo on pages regardless of its reserved status. In the worst case scenario, some redo changes may be applied unnecessarily before the page is unreserved. Considering the impact of the check though, it is likely to get better performance by applying the redo without doing any checks instead of doing the check and skipping the redo.

Implementation:
- add a new page fetch mode, for recovery, that accepts any page status: new page, de-allocated page, or normal page.
- use new page fetch mode during redo recovery/replication
- no "is page sector reserved" check (update log_rv_redo_page_fix)