### PR TITLE
[CBRD-24028] Segment fault occurs when connections increase rapidly

### DIFF
--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -411,6 +411,8 @@ namespace cubmem
     if (m_use_stack)
       {
 	m_ext_block.extend_to (m_stack.SIZE + additional_bytes);
+	// copy data from m_stack to m_ext_block at first extension
+	memcpy (m_ext_block.get_ptr (), m_stack.get_ptr (), m_stack.SIZE);
       }
     else
       {
@@ -428,7 +430,12 @@ namespace cubmem
 	return;
       }
     m_ext_block.extend_to (total_bytes);
-    m_use_stack = false;
+    if (m_use_stack)
+      {
+	// copy data from m_stack to m_ext_block at first extension
+	memcpy (m_ext_block.get_ptr (), m_stack.get_ptr (), m_stack.SIZE);
+	m_use_stack = false;
+      }
   }
 
   template <size_t S>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24028

When the number of inputs becomes larger than the size of m_stack, m_ext_block is used. But it does not copy the old value of m_stack into m_ext_block. This means there are garbage values.
I fix to copy data from m_stack to m_ext_block at first extension.
