### PR TITLE
[LETS-188] Transmit server type when server connection with master is re-established

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1361,7 +1361,7 @@ net_server_start (THREAD_ENTRY * thread_p, const char *server_name)
   else
     {
       int message_to_master_size = 0;
-      char *message_to_master = css_pack_server_name (server_name, &message_to_master_size);
+      char *message_to_master = css_pack_message_to_master (server_name, &message_to_master_size);
 
       r = css_init (thread_p, message_to_master, message_to_master_size, prm_get_integer_value (PRM_ID_TCP_PORT_ID));
       free_and_init (message_to_master);

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1294,8 +1294,6 @@ int
 net_server_start (THREAD_ENTRY * thread_p, const char *server_name)
 {
   int error = NO_ERROR;
-  int name_length;
-  char *packed_name;
   int r, status = 0;
   CHECK_ARGS check_coll_and_timezone = { true, true };
 
@@ -1362,10 +1360,11 @@ net_server_start (THREAD_ENTRY * thread_p, const char *server_name)
     }
   else
     {
-      packed_name = css_pack_server_name (server_name, &name_length);
+      int message_to_master_size = 0;
+      char *message_to_master = css_pack_server_name (server_name, &message_to_master_size);
 
-      r = css_init (thread_p, packed_name, name_length, prm_get_integer_value (PRM_ID_TCP_PORT_ID));
-      free_and_init (packed_name);
+      r = css_init (thread_p, message_to_master, message_to_master_size, prm_get_integer_value (PRM_ID_TCP_PORT_ID));
+      free_and_init (message_to_master);
 
       if (r < 0)
 	{

--- a/src/connection/connection_cl.h
+++ b/src/connection/connection_cl.h
@@ -49,7 +49,8 @@ extern void css_shutdown_conn (CSS_CONN_ENTRY * conn);
 extern CSS_CONN_ENTRY *css_make_conn (SOCKET fd);
 extern void css_free_conn (CSS_CONN_ENTRY * conn);
 
-extern CSS_CONN_ENTRY *css_connect_to_master_server (int master_port_id, const char *server_name, int name_length);
+extern CSS_CONN_ENTRY *css_connect_to_master_server (int master_port_id, const char *message_to_master,
+						     int message_to_master_length);
 
 extern CSS_CONN_ENTRY *css_find_exception_conn (void);
 extern int css_receive_error (CSS_CONN_ENTRY * conn, unsigned short req_id, char **buffer, int *buffer_size);

--- a/src/connection/connection_sr.h
+++ b/src/connection/connection_sr.h
@@ -156,7 +156,8 @@ extern void css_free_conn (CSS_CONN_ENTRY * conn);
 extern void css_print_conn_entry_info (CSS_CONN_ENTRY * p);
 extern void css_print_conn_list (void);
 extern void css_print_free_conn_list (void);
-extern CSS_CONN_ENTRY *css_connect_to_master_server (int master_port_id, const char *server_name, int name_length);
+extern CSS_CONN_ENTRY *css_connect_to_master_server (int master_port_id, const char *message_to_master,
+						     int message_to_master_length);
 extern void css_register_handler_routines (css_error_code (*connect_handler) (CSS_CONN_ENTRY * conn),
 					   CSS_THREAD_FN request_handler, CSS_THREAD_FN connection_error_handler);
 

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -66,7 +66,7 @@ css_initialize_server_interfaces (int (*request_handler)
 				  (THREAD_ENTRY * thrd, unsigned int eid, int request, int size, char *buffer),
 				  CSS_THREAD_FN connection_error_handler);
 extern char *css_pack_server_name (const char *server_name, int *name_length);
-extern int css_init (THREAD_ENTRY * thread_p, char *server_name, int server_name_length, int connection_id);
+extern int css_init (THREAD_ENTRY * thread_p, char *message_to_master, int message_to_master_length, int connection_id);
 extern char *css_add_client_version_string (THREAD_ENTRY * thread_p, const char *version_string);
 #if defined (ENABLE_UNUSED_FUNCTION)
 extern char *css_get_client_version_string (void);

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -65,7 +65,7 @@ extern void
 css_initialize_server_interfaces (int (*request_handler)
 				  (THREAD_ENTRY * thrd, unsigned int eid, int request, int size, char *buffer),
 				  CSS_THREAD_FN connection_error_handler);
-extern char *css_pack_server_name (const char *server_name, int *name_length);
+extern char *css_pack_message_to_master (const char *server_name, int *message_length);
 extern int css_init (THREAD_ENTRY * thread_p, char *message_to_master, int message_to_master_length, int connection_id);
 extern char *css_add_client_version_string (THREAD_ENTRY * thread_p, const char *version_string);
 #if defined (ENABLE_UNUSED_FUNCTION)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-188

If the connection with master is lost and then re-established, the server type is not transmitted. The first character in the server name is wrongfully interpreted as server type and the name gets trimmed.

Fix by always transmitting the server type first. css_pack_server_name was modified to append server type as suffix. The function name was changed to css_pack_message_to_master to be self-explanatory.

Other variables have been renamed to include message_to_master in the name.