### PR TITLE
[CBRD-23956] If an error occurs when executing a MERGE query in Autocommit, a -550 (Unknown savepoint name UmsP_ #) error also occurs.

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -16620,7 +16620,7 @@ exit:
     }
   /* If error and a savepoint was created, rollback to savepoint. No need to rollback if the TM aborted the
    * transaction. */
-  if (err < NO_ERROR && savepoint_name && err != ER_LK_UNILATERALLY_ABORTED)
+  if (err < NO_ERROR && savepoint_name && err != ER_LK_UNILATERALLY_ABORTED && statement->flag.use_auto_commit == false)
     {
       db_abort_to_savepoint (savepoint_name);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23956

If an error occurs when executing a MERGE query in Autocommit, a -550 (Unknown savepoint name UmsP_ #) error also occurs.

```
DROP TABLE IF EXISTS T1;	
CREATE TABLE T1 (C1 INT, C2 INT);

INSERT INTO T1 VALUES (1, 1), (1, 2);
```

```
$ rm csql.err
$ csql -u dba demodb

csql> MERGE INTO T1 A USING (SELECT C1, C2 FROM T1) B ON (A.C1 = B.C1) WHEN MATCHED THEN UPDATE SET A.C2 = B.C2;

csql> ;ex
$ cat csql.err
```

```
Time: 04/16/21 16:39:35.213 - ERROR *** file Unknown from server, line -1 ERROR CODE = -1106, Tran = 1, EID = 2
Multiple rows in source table match the same row in destination table.

Time: 04/16/21 16:38:47.939 - ERROR *** file Unknown from server, line -1 ERROR CODE = -550, Tran = 1, EID = 3
Unknown savepoint name UmsP_1

Time: 04/16/21 16:39:35.214 - SYNTAX ERROR *** file /home/jenkins/workspace/cubrid_develop/src/compat/db_vdb.c, line 953 ERROR CODE = -492, Tran = 1, EID = 3
Multiple rows in source table match the same row in destination table.

*** The previous error message is the last one. ***
```

The error message includes "ERROR_CODE -550" is not expected.
It's the reason why the abort of merge query is executed twice in the case of auto commit.

This issue is a regression of server-side auto commit (CBRD-22015).
The stran_server_auto_commit_or_abort() was added in CBRD-22015.
In case of auto commit, it proceeds with abort in the server and client twice. (stran_server_auto_commit_or_abort() and do_execute_merge() )
Therefore, the abort in client should fix not to be performed.