### PR TITLE
[LETS-185] vacuumdb dump does not print first log page ID

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1116,7 +1116,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
       return;
     }
 
-  min_log_pageid = vacuum_min_log_pageid_to_keep (thread_p);
+  min_log_pageid = vacuum_min_log_pageid_to_keep ();
   if (min_log_pageid == NULL_PAGEID)
     {
       /* this is an assertion case but ignore. */
@@ -1126,7 +1126,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
 
   fprintf (outfp, "\n");
   fprintf (outfp, "*** Vacuum Dump ***\n");
-  fprintf (outfp, "First log page ID referenced = %lld", (long long int) min_log_pageid);
+  fprintf (outfp, "First log page ID referenced = %lld ", (long long int) min_log_pageid);
   if (!is_tran_server_with_remote_storage ())
     {
       if (logpb_is_page_in_archive (min_log_pageid))
@@ -5633,7 +5633,7 @@ vacuum_get_log_blockid (LOG_PAGEID pageid)
  * thread_p (in) : Thread entry.
  */
 LOG_PAGEID
-vacuum_min_log_pageid_to_keep (THREAD_ENTRY * thread_p)
+vacuum_min_log_pageid_to_keep ()
 {
   /* Return first pageid from first block in vacuum data table */
   if (prm_get_bool_value (PRM_ID_DISABLE_VACUUM))

--- a/src/query/vacuum.h
+++ b/src/query/vacuum.h
@@ -230,7 +230,7 @@ extern int vacuum_data_load_and_recover (THREAD_ENTRY * thread_p);
 extern VACUUM_LOG_BLOCKID vacuum_get_log_blockid (LOG_PAGEID pageid);
 extern void vacuum_produce_log_block_data (THREAD_ENTRY * thread_p);
 extern int vacuum_consume_buffer_log_blocks (THREAD_ENTRY * thread_p);
-extern LOG_PAGEID vacuum_min_log_pageid_to_keep (THREAD_ENTRY * thread_p);
+extern LOG_PAGEID vacuum_min_log_pageid_to_keep ();
 extern bool vacuum_is_safe_to_remove_archives (void);
 extern void vacuum_notify_server_crashed (const LOG_LSA * recovery_lsa);
 extern void vacuum_notify_server_shutdown (void);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6248,7 +6248,7 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
     }
 
   /* Get first log pageid needed for vacuum before locking LOG_CS. */
-  vacuum_first_pageid = vacuum_min_log_pageid_to_keep (thread_p);
+  vacuum_first_pageid = vacuum_min_log_pageid_to_keep ();
 
   LOG_CS_ENTER (thread_p);
 
@@ -6447,7 +6447,7 @@ logpb_remove_archive_logs (THREAD_ENTRY * thread_p, const char *info_reason)
 
   last_deleted_arv_num--;
 
-  vacuum_first_pageid = vacuum_min_log_pageid_to_keep (thread_p);
+  vacuum_first_pageid = vacuum_min_log_pageid_to_keep ();
   if (vacuum_first_pageid != NULL_PAGEID && logpb_is_page_in_archive (vacuum_first_pageid))
     {
       min_arv_required_for_vacuum = logpb_get_archive_number (thread_p, vacuum_first_pageid);
@@ -7596,7 +7596,7 @@ loop:
       first_arv_needed = log_Gl.hdr.nxarv_num;
     }
 
-  vacuum_first_pageid = vacuum_min_log_pageid_to_keep (thread_p);
+  vacuum_first_pageid = vacuum_min_log_pageid_to_keep ();
   vacuum_er_log (VACUUM_ER_LOG_ARCHIVES, "First log pageid in vacuum data is %lld\n", vacuum_first_pageid);
 
   if (vacuum_first_pageid != NULL_PAGEID && logpb_is_page_in_archive (vacuum_first_pageid))


### PR DESCRIPTION
https://jira.cubrid.org/browse/LETS-185

Changed vacuumdb first log message to add the back the missing white space.

The lack of the white space is making the shell test cbrd_23881_vacuumdb_dump from _37_elderberry.
