### PR TITLE
[CBRD-24030] The db_get_ha_server_state API function is expected to return the current ha state of the sever.

### DIFF
--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -34,6 +34,7 @@
 #include <signal.h>
 
 #include "authenticate.h"
+#include "client_support.h"
 #include "porting.h"
 #include "system_parameter.h"
 #include "storage_common.h"
@@ -2828,7 +2829,7 @@ db_get_ha_server_state (char *buffer, int maxlen)
   CHECK_CONNECT_ERROR ();
 
 #if defined(CS_MODE)
-  ha_state = boot_get_ha_server_state ();
+  ha_state = css_ha_server_state ();
 #else
   ha_state = HA_SERVER_STATE_NA;
 #endif

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -5694,6 +5694,14 @@ boot_get_host_connected (void)
   return boot_Host_connected;
 }
 
+#if defined (ENABLE_UNUSED_FUNCTION)
+HA_SERVER_STATE
+boot_get_ha_server_state (void)
+{
+  return boot_Server_credential.ha_server_state;
+}
+#endif /* ENABLE_UNUSED_FUNCTION */
+
 /*
  * boot_get_lob_path - return the lob path which is received from the server
  */

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -5694,12 +5694,6 @@ boot_get_host_connected (void)
   return boot_Host_connected;
 }
 
-HA_SERVER_STATE
-boot_get_ha_server_state (void)
-{
-  return boot_Server_credential.ha_server_state;
-}
-
 /*
  * boot_get_lob_path - return the lob path which is received from the server
  */

--- a/src/transaction/boot_cl.h
+++ b/src/transaction/boot_cl.h
@@ -59,6 +59,9 @@ extern void boot_server_die_or_changed (void);
 extern void boot_client_all_finalize (bool iserfinal);
 #if defined(CS_MODE)
 extern char *boot_get_host_connected (void);
+#if defined(ENABLE_UNUSED_FUNCTION)
+extern HA_SERVER_STATE boot_get_ha_server_state (void);
+#endif /* ENABLE_UNUSED_FUNCTION */
 extern const char *boot_get_lob_path (void);
 #endif /* CS_MODE */
 

--- a/src/transaction/boot_cl.h
+++ b/src/transaction/boot_cl.h
@@ -59,7 +59,6 @@ extern void boot_server_die_or_changed (void);
 extern void boot_client_all_finalize (bool iserfinal);
 #if defined(CS_MODE)
 extern char *boot_get_host_connected (void);
-extern HA_SERVER_STATE boot_get_ha_server_state (void);
 extern const char *boot_get_lob_path (void);
 #endif /* CS_MODE */
 


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-24030

### Purpose
The db_get_ha_server_state API function is expected to return the current ha state of the sever.

### Implementation
The db_get_ha_server_state function calls the css_ha_server_state function instead of boot_get_ha_server_state function.

### Remarks
N/A