### PR TITLE
[CBRD-23862] Reset yyline only when csql interactive

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1818,6 +1818,11 @@ csql_execute_statements (const CSQL_ARGUMENT * csql_arg, int type, const void *s
   logddl_set_logging_enabled (prm_get_bool_value (PRM_ID_DDL_AUDIT_LOG));
   logddl_set_commit_mode (csql_is_auto_commit_requested (csql_arg));
 
+  if (csql_Is_interactive)
+    {
+      csql_yyset_lineno (1);
+    }
+
   /* execute the statements one-by-one */
   for (num_stmts = 0; num_stmts < total; num_stmts++)
     {

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -25727,7 +25727,6 @@ parser_main (PARSER_CONTEXT * parser)
   yycolumn = yycolumn_end = 1;
   yybuffer_pos=0;
   csql_yylloc.buffer_pos=0;
-  csql_yyset_lineno (1);
   dot_flag = 0;
 
   g_query_string = NULL;

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -61,6 +61,7 @@ extern "C"
     HIDDEN_CLASSOID_NAME
   } VIEW_HANDLING;
 
+  extern void csql_yyset_lineno (int line_number);
   extern size_t json_table_column_count;
 
   extern PT_NODE **parser_main (PARSER_CONTEXT * p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23862

Purpose

* Compensation of #2962
  * reset **_yylineno_** only when **csql_interactive**
  * For others, for example, **csql from files**, do as before #2962  (do not reset yylineno)

Implementation
N/A

Remarks
* During QA, we found there are unexpected result (**lineno**), when csql is running from files.
* Moved '**csql_yyset_lineno (1)**' from src/parser/csql_grammar.y to src/executables/csql.c