### PR TITLE
[CBRD-24037] The LOG_DUMMY_HA_SERVER_STATE is logged even though the ha_mode is disabled.

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10054,6 +10054,11 @@ log_clock_daemon_init ()
 void
 log_check_ha_delay_info_daemon_init ()
 {
+  if (HA_DISABLED ())
+    {
+      return;
+    }
+
   assert (log_Check_ha_delay_info_daemon == NULL);
 
   cubthread::looper looper = cubthread::looper (std::chrono::seconds (1));


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24037

### Purpose
- The LOG_DUMMY_HA_SERVER_STATE is logged even though the ha_mode is disabled. But, This log is not necessary for the single-node configuration. So, I blocked it.

### Implementation
- The creation of 'log_Check_ha_delay_info_daemon' is blocked if ha_mode is disabled.

### Remarks
- N/A