### PR TITLE
[CBRD-24038] Modify the specifications for column property on ALTER TABLE clause

### DIFF
--- a/src/object/schema_template.c
+++ b/src/object/schema_template.c
@@ -4423,10 +4423,13 @@ smt_change_attribute_w_dflt_w_order (DB_CTMPL * def, const char *name, const cha
 	}
     }
 
-  error = smt_set_attribute_on_update (def, ((new_name != NULL) ? new_name : name), is_class_attr, on_update_expr);
-  if (error != NO_ERROR)
+  if (on_update_expr != DB_DEFAULT_NONE)
     {
-      return error;
+      error = smt_set_attribute_on_update (def, ((new_name != NULL) ? new_name : name), is_class_attr, on_update_expr);
+      if (error != NO_ERROR)
+	{
+	  return error;
+	}
     }
 
   /* change original default : continue only for normal attributes */

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -11065,6 +11065,11 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
       {
 	int *const p = &(attr_chg_properties->p[i]);
 
+	if (*p & ATT_CHG_PROPERTY_LOST)
+	  {
+	    continue;
+	  }
+
 	if (*p & ATT_CHG_PROPERTY_PRESENT_OLD)
 	  {
 	    if (*p & ATT_CHG_PROPERTY_PRESENT_NEW)

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -8616,28 +8616,28 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 
       /* check for mis-creating string type with -1 precision */
       for (column = query_columns; column != NULL; column = db_query_format_next (column))
-        {
-          switch (column->domain->type->id)
-            {
-              case DB_TYPE_VARCHAR:
-                if (column->domain->precision == DB_DEFAULT_PRECISION)
-                  {
-                    column->domain->precision = DB_MAX_VARCHAR_PRECISION;
-                  }
-                break;
-              case DB_TYPE_VARNCHAR:
-                if (column->domain->precision == DB_DEFAULT_PRECISION)
-                  {
-                    column->domain->precision = DB_MAX_VARNCHAR_PRECISION;
-                  }
-                else if (column->domain->precision > DB_MAX_VARNCHAR_PRECISION)
-                  {
-                    column->domain->precision = DB_MAX_VARNCHAR_PRECISION;
-                  }
-                default:
-                break;
-            }
-        }
+	{
+	  switch (column->domain->type->id)
+	    {
+	    case DB_TYPE_VARCHAR:
+	      if (column->domain->precision == DB_DEFAULT_PRECISION)
+		{
+		  column->domain->precision = DB_MAX_VARCHAR_PRECISION;
+		}
+	      break;
+	    case DB_TYPE_VARNCHAR:
+	      if (column->domain->precision == DB_DEFAULT_PRECISION)
+		{
+		  column->domain->precision = DB_MAX_VARNCHAR_PRECISION;
+		}
+	      else if (column->domain->precision > DB_MAX_VARNCHAR_PRECISION)
+		{
+		  column->domain->precision = DB_MAX_VARNCHAR_PRECISION;
+		}
+	    default:
+	      break;
+	    }
+	}
     }
   assert (!(create_like != NULL && create_select != NULL));
 
@@ -10982,6 +10982,8 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
 	  chg_prop_idx = P_S_CONSTR_UNI;
 	  save_pt_costraint = true;
 	  break;
+	case PT_CONSTRAIN_NULL:
+	  attr_chg_properties->p[P_NOT_NULL] = ATT_CHG_PROPERTY_LOST;
 	case PT_CONSTRAIN_NOT_NULL:
 	  constr_att_list = cnstr->info.constraint.un.not_null.attr;
 	  chg_prop_idx = P_NOT_NULL;
@@ -11072,7 +11074,7 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
 	      }
 	    else
 	      {
-		*p |= ATT_CHG_PROPERTY_LOST;
+		*p |= ATT_CHG_PROPERTY_UNCHANGED;
 	      }
 	  }
 	else
@@ -11217,7 +11219,6 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
 
   /* comment */
   attr_chg_properties->p[P_COMMENT] = 0;
-  attr_chg_properties->p[P_COMMENT] |= ATT_CHG_PROPERTY_LOST;
   comment = attr_def->info.attr_def.comment;
   if (comment != NULL)
     {
@@ -11228,6 +11229,10 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
 	  /* remove "LOST" flag */
 	  attr_chg_properties->p[P_COMMENT] &= ~ATT_CHG_PROPERTY_LOST;
 	}
+    }
+  else
+    {
+      attr_chg_properties->p[P_COMMENT] |= ATT_CHG_PROPERTY_UNCHANGED;
     }
 
   return error;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10572,7 +10572,6 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
 
   /* the serial property has not changed, we are only dealing with renaming */
   if (is_att_prop_set (attr_chg_prop->p[P_NAME], ATT_CHG_PROPERTY_DIFF)
-      && attribute->info.attr_def.auto_increment != NULL
       && !is_att_prop_set (attr_chg_prop->p[P_AUTO_INCR], ATT_CHG_PROPERTY_DIFF)
       && !is_att_prop_set (attr_chg_prop->p[P_AUTO_INCR], ATT_CHG_PROPERTY_LOST)
       && !is_att_prop_set (attr_chg_prop->p[P_AUTO_INCR], ATT_CHG_PROPERTY_GAINED))
@@ -10610,7 +10609,6 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
     {
       MOP auto_increment_obj = NULL;
 
-      assert (attribute->info.attr_def.auto_increment != NULL);
       assert_release (found_att->auto_increment != NULL);
 
       error = do_update_maxvalue_of_auto_increment_serial (parser, &auto_increment_obj, ctemplate->name, attribute);

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10572,6 +10572,7 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
 
   /* the serial property has not changed, we are only dealing with renaming */
   if (is_att_prop_set (attr_chg_prop->p[P_NAME], ATT_CHG_PROPERTY_DIFF)
+      && is_att_prop_set (attr_chg_prop->p[P_AUTO_INCR], ATT_CHG_PROPERTY_PRESENT_OLD)
       && !is_att_prop_set (attr_chg_prop->p[P_AUTO_INCR], ATT_CHG_PROPERTY_DIFF)
       && !is_att_prop_set (attr_chg_prop->p[P_AUTO_INCR], ATT_CHG_PROPERTY_LOST)
       && !is_att_prop_set (attr_chg_prop->p[P_AUTO_INCR], ATT_CHG_PROPERTY_GAINED))

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -2043,7 +2043,6 @@ do_update_maxvalue_of_auto_increment_serial (PARSER_CONTEXT * parser, MOP * seri
 
   numeric_coerce_string_to_num (DB_SERIAL_MAX, strlen (DB_SERIAL_MAX), INTL_CODESET_ISO88591, &e38);
 
-  assert_release (att->info.attr_def.auto_increment != NULL);
   assert (serial_object != NULL);
 
   /* find db_serial */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24038

AS-IS:
When the data type is changed with the ALTER CHANGE/MODIFY ...' query, the properties are dropped if the entire column properties are not listed.
There is an example where it is trying to change a column of INT data type to BIGINT data type, but COMMENT disappears because COMMENT part is not written.

Issue:
When the data type is changed with the 'ALTER CHANGE/MODIFY ...' query, the COMMENT disappears, the NOT NULL constraint, and the DEFAULT value disappear.
If there is no schema backed up, it is difficult to restore it.
It looks it's the user's mistake, but if there is a problem at the site that is providing technical support and an engineer tries to fix it, it takes a lot of effort.

TO-BE:
We will improve the function so that the column properties not be changed without specifying the properties as like the CBRD-23718 issue.
