### PR TITLE
[CBRD-24040] Prevent from drop and alter of system tables by sysadm

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1022,7 +1022,7 @@ csql_do_session_cmd (char *line_read, CSQL_ARGUMENT * csql_arg)
 	{
 	  if (csql_arg->sysadm && au_is_dba_group_member (Au_user))
 	    {
-	      au_disable ();
+	      au_sysadm_disable ();
 	    }
 	  csql_Database_connected = true;
 
@@ -2871,7 +2871,7 @@ csql (const char *argv0, CSQL_ARGUMENT * csql_arg)
 
   if (csql_arg->sysadm && au_is_dba_group_member (Au_user))
     {
-      au_disable ();
+      au_sysadm_disable ();
     }
 
   /* allow environmental setting of the "-s" command line flag to enable automated testing */

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -307,6 +307,7 @@ MOP Au_root = NULL;
  * use the AU_DISABLE, AU_ENABLE macros instead.
  */
 int Au_disable = 1;
+bool Au_sysadm = false;
 
 /*
  * Au_ignore_passwords
@@ -5860,7 +5861,7 @@ check_authorization (MOP classobj, SM_CLASS * sm_class, DB_AUTH type)
    * Callers generally check Au_disable already to avoid the function call.
    * Check it again to be safe, at this point, it isn't going to add anything.
    */
-  if (Au_disable && !(sm_class->flags & SM_CLASSFLAG_SYSTEM))
+  if (Au_disable && (!Au_sysadm || !(sm_class->flags & SM_CLASSFLAG_SYSTEM)))
     {
       return NO_ERROR;
     }
@@ -8624,6 +8625,19 @@ au_disable (void)
 }
 
 /*
+ * au_sysadm_disable - set Au_disable for sysadm
+ *   return: original Au_disable value
+ */
+int
+au_sysadm_disable (void)
+{
+  int save = Au_disable;
+  Au_disable = 1;
+  Au_sysadm = true;
+  return save;
+}
+
+/*
  * au_enable - restore Au_disable
  *   return:
  *   save(in): original Au_disable value
@@ -8632,6 +8646,7 @@ void
 au_enable (int save)
 {
   Au_disable = save;
+  Au_sysadm = false;
 }
 
 /*

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -5860,7 +5860,7 @@ check_authorization (MOP classobj, SM_CLASS * sm_class, DB_AUTH type)
    * Callers generally check Au_disable already to avoid the function call.
    * Check it again to be safe, at this point, it isn't going to add anything.
    */
-  if (Au_disable)
+  if (Au_disable && !(sm_class->flags & SM_CLASSFLAG_SYSTEM))
     {
       return NO_ERROR;
     }
@@ -6150,7 +6150,7 @@ au_fetch_class_internal (MOP op, SM_CLASS ** class_ptr, AU_FETCHMODE fetchmode, 
 	}
     }
 
-  if (Au_disable || !(error = check_authorization (classmop, class_, type)))
+  if ((Au_disable && type != DB_AUTH_ALTER) || !(error = check_authorization (classmop, class_, type)))
     {
       if (class_ptr != NULL)
 	{

--- a/src/object/authenticate.h
+++ b/src/object/authenticate.h
@@ -99,6 +99,7 @@ extern const char *AU_DBA_USER_NAME;
 
 
 int au_disable (void);
+int au_sysadm_disable (void);
 void au_enable (int save);
 MOP au_get_public_user (void);
 MOP au_get_dba_user (void);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24040

The ALTER and DROP for system catalog tables should be prevented for proper system operation. Currently, the system catalog tables starts with named "db_" and "db" can be easily dropped or altered by system admin user called "sysadm" as follows:

```
csql -u dba -S --sysadm demodb

sysadm> drop table db_ha_apply_info;
Execute OK. (0.008472 sec) Committed
```

The DROP, ALTER, and RENAME operations cannot be permitted for system catalog tables even though it's sysadm mode.

To test the queries, please refer to the last comment of CBRD-24040