### PR TITLE
[CBRD-23842] Change the default value for 'supplemental_log' parameter

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2348,7 +2348,7 @@ static UINT64 prm_ddl_audit_log_size_upper = 2147483648ULL;	/* 2G */
 static unsigned int prm_ddl_audit_log_size_flag = 0;
 
 int PRM_SUPPLEMENTAL_LOG = 0;
-static int prm_supplemental_log_default = 0;
+static int prm_supplemental_log_default = 1;
 static int prm_supplemental_log_lower = 0;
 static int prm_supplemental_log_upper = 2;
 static unsigned int prm_supplemental_log_flag = 0;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14912,9 +14912,11 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 
     case PT_CREATE_TRIGGER:
       target = PT_NODE_TR_TARGET (statement);
-      classname = target->info.event_target.class_name->info.name.original;
-
-      classoid = ws_oid (sm_find_class (classname));
+      if (target)
+	{
+	  classname = target->info.event_target.class_name->info.name.original;
+	  classoid = ws_oid (sm_find_class (classname));
+	}
 
       ddl_type = CDC_CREATE;
       objtype = CDC_TRIGGER;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3327,9 +3327,9 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 	    }
 	}
 
-      if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
+      if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) == 1)
 	{
-	  do_supplemental_statement (parser, statement);
+	  (void) do_supplemental_statement (parser, statement);
 	}
     }
 
@@ -3785,9 +3785,9 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 	}
     }
 
-  if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
+  if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) == 1)
     {
-      do_supplemental_statement (parser, statement);
+      (void) do_supplemental_statement (parser, statement);
     }
 
 end:

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3327,7 +3327,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 	    }
 	}
 
-      if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) == 1)
+      if (error >= 0 && prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) == 1)
 	{
 	  (void) do_supplemental_statement (parser, statement);
 	}
@@ -3785,7 +3785,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 	}
     }
 
-  if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) == 1)
+  if (err >= 0 && prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) == 1)
     {
       (void) do_supplemental_statement (parser, statement);
     }

--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -584,7 +584,21 @@ serial_update_cur_val_of_serial (THREAD_ENTRY * thread_p, SERIAL_CACHE_ENTRY * e
 
   if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0 && thread_p->no_supplemental_log == false)
     {
-      log_append_supplemental_serial (thread_p, db_get_string (&key_val), entry->cached_num, NULL, &entry->oid);
+
+      LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
+
+      if (tdes)
+	{
+	  if (!tdes->has_supplemental_log)
+	    {
+	      log_append_supplemental_info (thread_p, LOG_SUPPLEMENT_TRAN_USER, strlen (tdes->client.get_db_user ()),
+					    tdes->client.get_db_user ());
+
+	      tdes->has_supplemental_log = true;
+	    }
+	}
+
+      (void) log_append_supplemental_serial (thread_p, db_get_string (&key_val), entry->cached_num, NULL, &entry->oid);
     }
 
   pr_clear_value (&key_val);
@@ -818,8 +832,22 @@ xserial_get_next_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_num,
 
   if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0 && thread_p->no_supplemental_log == false)
     {
-      log_append_supplemental_serial (thread_p, db_get_string (&key_val), cached_num, NULL, serial_oidp);
+      LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
+
+      if (tdes)
+	{
+	  if (!tdes->has_supplemental_log)
+	    {
+	      log_append_supplemental_info (thread_p, LOG_SUPPLEMENT_TRAN_USER, strlen (tdes->client.get_db_user ()),
+					    tdes->client.get_db_user ());
+
+	      tdes->has_supplemental_log = true;
+	    }
+	}
+
+      (void) log_append_supplemental_serial (thread_p, db_get_string (&key_val), cached_num, NULL, serial_oidp);
     }
+
 
   /* copy result value */
   pr_share_value (&next_val, result_num);

--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -818,7 +818,7 @@ xserial_get_next_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_num,
 
   if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0 && thread_p->no_supplemental_log == false)
     {
-      log_append_supplemental_serial (thread_p, db_get_string (&key_val), entry->cached_num, NULL, &entry->oid);
+      log_append_supplemental_serial (thread_p, db_get_string (&key_val), cached_num, NULL, serial_oidp);
     }
 
   /* copy result value */

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -4946,7 +4946,6 @@ log_append_supplemental_serial (THREAD_ENTRY * thread_p, const char *serial_name
 
   char *ptr, *start_ptr;
 
-  LOG_TDES *tdes;
   if (cached_num == 0)
     {
       cached_num = 1;
@@ -4973,17 +4972,10 @@ log_append_supplemental_serial (THREAD_ENTRY * thread_p, const char *serial_name
 
   data_len = ptr - start_ptr;
 
-  tdes = LOG_FIND_CURRENT_TDES (thread_p);
-
-  if (!tdes->has_supplemental_log)
-    {
-      log_append_supplemental_info (thread_p, LOG_SUPPLEMENT_TRAN_USER, strlen (tdes->client.get_db_user ()),
-				    tdes->client.get_db_user ());
-      tdes->has_supplemental_log = true;
-    }
 
   log_append_supplemental_info (thread_p, LOG_SUPPLEMENT_DDL, data_len, (void *) supplemental_data);
 
+  return NO_ERROR;
 }
 
 /*

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -4934,7 +4934,7 @@ log_append_supplemental_undo_record (THREAD_ENTRY * thread_p, RECDES * undo_recd
 
 int
 log_append_supplemental_serial (THREAD_ENTRY * thread_p, const char *serial_name, int cached_num, OID * classoid,
-				OID * serial_oid)
+				const OID * serial_oid)
 {
   assert (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0);
 

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -174,7 +174,7 @@ extern int log_append_supplemental_lsa (THREAD_ENTRY * thread_p, SUPPLEMENT_REC_
 extern int log_append_supplemental_undo_record (THREAD_ENTRY * thread_p, RECDES * undo_recdes);
 
 extern int log_append_supplemental_serial (THREAD_ENTRY * thread_p, const char *serial_name, int cached_num,
-					   OID * classoid, OID * serial_oid);
+					   OID * classoid, const OID * serial_oid);
 /*
  * FOR DEBUGGING
  */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

This is temporary modification on system parameter 'supplemental_log'. 

Default value for 'supplemental_log' is set to 1 so that the system will append supplemental log by default.