### PR TITLE
[LETS-205] check before dwb daemons stop causes regression

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2899,10 +2899,7 @@ error:
 
 #if defined(SERVER_MODE)
   pgbuf_daemons_destroy ();
-  if (!is_tran_server_with_remote_storage ())
-    {
-      dwb_daemons_destroy ();
-    }
+  dwb_daemons_destroy ();
 #endif
 
   log_final (thread_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-205

no need for a check to destroy daemons, the `destroy_daemon` function handles whether daemons have been initialized or not

regression from [LETS-199](http://jira.cubrid.org/browse/LETS-199) - #3002

