### PR TITLE
[LETS-207] incorrect message construction in server_channel::connect for connection to master process

### DIFF
--- a/src/communication/communication_server_channel.cpp
+++ b/src/communication/communication_server_channel.cpp
@@ -83,7 +83,7 @@ namespace cubcomm
      * character to the numer related to the server type enum value, the rest of the
      * buffer space is used to copy the server name.
      */
-    std::string msg { (char)m_server_type + '0' };
+    std::string msg { (char) m_server_type + '0' };
     msg.append (m_server_name);
     rc = (css_error_code) css_send_request_with_socket (m_socket, cmd_type, &m_request_id,
 	 msg.c_str (), static_cast<int> (msg.size ()));

--- a/src/communication/communication_server_channel.cpp
+++ b/src/communication/communication_server_channel.cpp
@@ -83,9 +83,8 @@ namespace cubcomm
      * character to the numer related to the server type enum value, the rest of the
      * buffer space is used to copy the server name.
      */
-    std::string msg;
-    msg = ((char) m_server_type) + '0';
-    msg.append (m_server_name, m_server_name.length ());
+    std::string msg { (char)m_server_type + '0' };
+    msg.append (m_server_name);
     rc = (css_error_code) css_send_request_with_socket (m_socket, cmd_type, &m_request_id,
 	 msg.c_str (), static_cast<int> (msg.size ()));
     if (rc != NO_ERRORS)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-207

The message must be of the form `<server type as char><server name (aka: database name)>`.
