### PR TITLE
[LETS-188] Fix server name after connection with master is re-established

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1360,12 +1360,7 @@ net_server_start (THREAD_ENTRY * thread_p, const char *server_name)
     }
   else
     {
-      int message_to_master_size = 0;
-      char *message_to_master = css_pack_message_to_master (server_name, &message_to_master_size);
-
-      r = css_init (thread_p, message_to_master, message_to_master_size, prm_get_integer_value (PRM_ID_TCP_PORT_ID));
-      free_and_init (message_to_master);
-
+      r = css_init (thread_p, server_name, prm_get_integer_value (PRM_ID_TCP_PORT_ID));
       if (r < 0)
 	{
 	  assert (er_errid () != NO_ERROR);

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -66,7 +66,7 @@ css_initialize_server_interfaces (int (*request_handler)
 				  (THREAD_ENTRY * thrd, unsigned int eid, int request, int size, char *buffer),
 				  CSS_THREAD_FN connection_error_handler);
 extern char *css_pack_message_to_master (const char *server_name, int *message_length);
-extern int css_init (THREAD_ENTRY * thread_p, char *message_to_master, int message_to_master_length, int connection_id);
+extern int css_init (THREAD_ENTRY * thread_p, const char *server_name, int connection_id);
 extern char *css_add_client_version_string (THREAD_ENTRY * thread_p, const char *version_string);
 #if defined (ENABLE_UNUSED_FUNCTION)
 extern char *css_get_client_version_string (void);

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -65,7 +65,6 @@ extern void
 css_initialize_server_interfaces (int (*request_handler)
 				  (THREAD_ENTRY * thrd, unsigned int eid, int request, int size, char *buffer),
 				  CSS_THREAD_FN connection_error_handler);
-extern char *css_pack_message_to_master (const char *server_name, int *message_length);
 extern int css_init (THREAD_ENTRY * thread_p, const char *server_name, int connection_id);
 extern char *css_add_client_version_string (THREAD_ENTRY * thread_p, const char *version_string);
 #if defined (ENABLE_UNUSED_FUNCTION)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-188

The name registered on restarted cub_master after the server reconnects starts with the number character equivalent to the server type. The explanation is that css_Master_server_name global used to include the server type.

Fix by setting css_Master_server_name value to server name instead of the message sent to cub_master. Message packing was pushed down to css_init as a consequence.
