### PR TITLE
[LETS-204] Add server type to string function

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -110,8 +110,7 @@ int init_server_type (const char *db_name)
 
   if (er_code == NO_ERROR)
     {
-      er_log_debug (ARG_FILE_LINE, "Starting server type: %s\n",
-		    get_server_type () == SERVER_TYPE_PAGE ? "page" : "transaction");
+      er_log_debug (ARG_FILE_LINE, "Starting server type: %s\n", server_type_to_string (get_server_type ()));
     }
   else
     {

--- a/src/base/server_type_enum.hpp
+++ b/src/base/server_type_enum.hpp
@@ -33,4 +33,30 @@ enum class server_type_config
   PAGE,
   SINGLE_NODE,
 };
+
+inline const char *
+server_type_to_string (SERVER_TYPE type)
+{
+  switch (type)
+    {
+    case SERVER_TYPE_PAGE:
+      return "page";
+    default:
+      return "transaction";
+    }
+}
+
+inline const char *
+server_type_config_to_string (server_type_config type)
+{
+  switch (type)
+    {
+    case server_type_config::PAGE:
+      return "page";
+    case server_type_config::TRANSACTION:
+      return "transaction";
+    case server_type_config::SINGLE_NODE:
+      return "single_node";
+    }
+}
 #endif // _SERVER_TYPE_ENUM_H_

--- a/src/base/server_type_enum.hpp
+++ b/src/base/server_type_enum.hpp
@@ -18,6 +18,7 @@
 
 #ifndef _SERVER_TYPE_ENUM_H_
 #define _SERVER_TYPE_ENUM_H_
+#include <assert.h>
 
 typedef enum
 {
@@ -34,23 +35,25 @@ enum class server_type_config
   SINGLE_NODE,
 };
 
-inline const char *
+constexpr const char *
 server_type_to_string (SERVER_TYPE type)
 {
   switch (type)
     {
     case SERVER_TYPE_UNKNOWN:
-      return  "unknown";
+      return "unknown";
     case SERVER_TYPE_TRANSACTION:
       return "transaction";
     case SERVER_TYPE_PAGE:
       return "page";
     case SERVER_TYPE_ANY:
       return "any";
+    default:
+      assert (false);
     }
 }
 
-inline const char *
+constexpr const char *
 server_type_config_to_string (server_type_config type)
 {
   switch (type)
@@ -61,6 +64,8 @@ server_type_config_to_string (server_type_config type)
       return "transaction";
     case server_type_config::SINGLE_NODE:
       return "single_node";
+    default:
+      assert (false);
     }
 }
 #endif // _SERVER_TYPE_ENUM_H_

--- a/src/base/server_type_enum.hpp
+++ b/src/base/server_type_enum.hpp
@@ -39,10 +39,14 @@ server_type_to_string (SERVER_TYPE type)
 {
   switch (type)
     {
+    case SERVER_TYPE_UNKNOWN:
+      return  "unknown";
+    case SERVER_TYPE_TRANSACTION:
+      return "transaction";
     case SERVER_TYPE_PAGE:
       return "page";
-    default:
-      return "transaction";
+    case SERVER_TYPE_ANY:
+      return "any";
     }
 }
 

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -6448,9 +6448,9 @@ static KEYVAL tde_algorithm_words[] = {
 
 /* *INDENT-OFF* */
 static KEYVAL server_type_words[] = {
-  {"transaction", (int) server_type_config::TRANSACTION},
-  {"page", (int) server_type_config::PAGE},
-  {"single_node", (int) server_type_config::SINGLE_NODE}
+  {server_type_config_to_string (server_type_config::TRANSACTION), (int) server_type_config::TRANSACTION},
+  {server_type_config_to_string (server_type_config::PAGE), (int) server_type_config::PAGE},
+  {server_type_config_to_string (server_type_config::SINGLE_NODE), (int) server_type_config::SINGLE_NODE}
 };
 /* *INDENT-ON* */
 

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -459,8 +459,8 @@ receive_server_info (CSS_CONN_ENTRY * conn, unsigned short rid, std::string & db
 	  dbname = std::string (buffer + 1, buffer_length - 1);
 	}
 
-      MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "The %s server of type %s wants to connect to cub_master.",
-			   dbname.c_str (), type == SERVER_TYPE_PAGE ? "page" : "transaction");
+      MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "The %s server of type %s wants to connect to cub_master.", dbname.c_str (),
+			   server_type_to_string (type));
     }
   return exit_code;
 }

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -337,11 +337,11 @@ argument_handler (int argc, char **argv)
 	{
 	case SERVER_TYPE_SHORT:
 	  // *INDENT-ON*
-	  if (std::strcmp (optarg, "transaction") == 0)
+	  if (std::strcmp (optarg, server_type_to_string (SERVER_TYPE_TRANSACTION)) == 0)
 	    {
 	      set_server_type (SERVER_TYPE_TRANSACTION);
 	    }
-	  else if (std::strcmp (optarg, "page") == 0)
+	  else if (std::strcmp (optarg, server_type_to_string (SERVER_TYPE_PAGE)) == 0)
 	    {
 	      set_server_type (SERVER_TYPE_PAGE);
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-204

Added `server_type_to_string` and `server_type_config_to_string` to replace hard coded usages of `"page"` and `"transaction"` and group the already used logic into functions.
