### PR TITLE
[CBRD-24041] Problem that view that contain analytic functions is view-merged

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1398,7 +1398,7 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * query, bool is_only_
   cpi.check_query = false;	/* subqueries are pushable */
   cpi.check_method = true;	/* methods are non-pushable */
   cpi.check_xxxnum = !is_only_spec;
-  cpi.check_analytic = false;	/* analytic functions are not pushable */
+  cpi.check_analytic = true;	/* analytic functions are not pushable */
 
   cpi.method_found = false;
   cpi.query_found = false;
@@ -1417,7 +1417,7 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * query, bool is_only_
   cpi.check_query = false;	/* subqueries are pushable */
   cpi.check_method = true;	/* methods are non-pushable */
   cpi.check_xxxnum = !is_only_spec;
-  cpi.check_analytic = false;	/* analytic functions are pushable */
+  cpi.check_analytic = true;	/* analytic functions are not pushable */
 
   cpi.method_found = false;
   cpi.query_found = false;
@@ -1688,7 +1688,7 @@ mq_substitute_subquery_in_statement (PARSER_CONTEXT * parser, PT_NODE * statemen
       else
 	{
 	  /* determine if class_spec is the only spec in the statement */
-	  is_only_spec = true; /* (statement_spec->next == NULL ? true : false); */
+	  is_only_spec = (statement_spec->next == NULL ? true : false);
 
 	  /* determine if spec is outer joined */
 	  is_outer_joined = mq_is_outer_join_spec (parser, class_spec);

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -96,12 +96,10 @@ typedef struct check_pushable_info
   bool check_query;
   bool check_method;
   bool check_xxxnum;
-  bool check_analytic;
 
   bool query_found;
   bool method_found;
   bool xxxnum_found;		/* rownum, inst_num(), orderby_num(), groupby_num() */
-  bool analytic_found;
 } CHECK_PUSHABLE_INFO;
 
 static unsigned int top_cycle = 0;
@@ -2710,20 +2708,13 @@ pt_check_pushable (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *cont
 	      cinfop->xxxnum_found = true;	/* not pushable */
 	    }
 	}
-      else if (tree->info.function.analytic.is_analytic == true)
-	{
-	  if (cinfop->check_analytic)
-	    {
-	      cinfop->analytic_found = true;	/* not pushable */
-	    }
-	}
       break;
 
     default:
       break;
     }				/* switch (tree->node_type) */
 
-  if (cinfop->query_found || cinfop->method_found || cinfop->xxxnum_found || cinfop->analytic_found)
+  if (cinfop->query_found || cinfop->method_found || cinfop->xxxnum_found )
     {
       /* not pushable */
       /* do not need to traverse anymore */

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1398,7 +1398,7 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * query, bool is_only_
   cpi.check_query = false;	/* subqueries are pushable */
   cpi.check_method = true;	/* methods are non-pushable */
   cpi.check_xxxnum = !is_only_spec;
-  cpi.check_analytic = false;	/* analytic functions are pushable */
+  cpi.check_analytic = true;	/* analytic functions are not pushable */
 
   cpi.method_found = false;
   cpi.query_found = false;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -2714,7 +2714,7 @@ pt_check_pushable (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *cont
       break;
     }				/* switch (tree->node_type) */
 
-  if (cinfop->query_found || cinfop->method_found || cinfop->xxxnum_found )
+  if (cinfop->query_found || cinfop->method_found || cinfop->xxxnum_found)
     {
       /* not pushable */
       /* do not need to traverse anymore */

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1387,8 +1387,8 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * query, bool is_only_
       return false;
     }
 
-  /* check for aggregate or orderby_for */
-  if (pt_has_aggregate (parser, query) || query->info.query.orderby_for)
+  /* check for aggregate or orderby_for or analytic */
+  if (pt_has_aggregate (parser, query) || query->info.query.orderby_for || pt_has_analytic (parser, query))
     {
       /* not pushable */
       return false;
@@ -1398,16 +1398,14 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * query, bool is_only_
   cpi.check_query = false;	/* subqueries are pushable */
   cpi.check_method = true;	/* methods are non-pushable */
   cpi.check_xxxnum = !is_only_spec;
-  cpi.check_analytic = true;	/* analytic functions are not pushable */
 
   cpi.method_found = false;
   cpi.query_found = false;
   cpi.xxxnum_found = false;
-  cpi.analytic_found = false;
 
   parser_walk_tree (parser, query->info.query.q.select.list, pt_check_pushable, (void *) &cpi, NULL, NULL);
 
-  if (cpi.method_found || cpi.query_found || cpi.xxxnum_found || cpi.analytic_found)
+  if (cpi.method_found || cpi.query_found || cpi.xxxnum_found)
     {
       /* query not pushable */
       return false;
@@ -1417,16 +1415,14 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * query, bool is_only_
   cpi.check_query = false;	/* subqueries are pushable */
   cpi.check_method = true;	/* methods are non-pushable */
   cpi.check_xxxnum = !is_only_spec;
-  cpi.check_analytic = true;	/* analytic functions are not pushable */
 
   cpi.method_found = false;
   cpi.query_found = false;
   cpi.xxxnum_found = false;
-  cpi.analytic_found = false;
 
   parser_walk_tree (parser, query->info.query.q.select.where, pt_check_pushable, (void *) &cpi, NULL, NULL);
 
-  if (cpi.method_found || cpi.query_found || cpi.xxxnum_found || cpi.analytic_found)
+  if (cpi.method_found || cpi.query_found || cpi.xxxnum_found)
     {
       /* query not pushable */
       return false;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1398,7 +1398,7 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * query, bool is_only_
   cpi.check_query = false;	/* subqueries are pushable */
   cpi.check_method = true;	/* methods are non-pushable */
   cpi.check_xxxnum = !is_only_spec;
-  cpi.check_analytic = true;	/* analytic functions are not pushable */
+  cpi.check_analytic = false;	/* analytic functions are not pushable */
 
   cpi.method_found = false;
   cpi.query_found = false;
@@ -1688,7 +1688,7 @@ mq_substitute_subquery_in_statement (PARSER_CONTEXT * parser, PT_NODE * statemen
       else
 	{
 	  /* determine if class_spec is the only spec in the statement */
-	  is_only_spec = (statement_spec->next == NULL ? true : false);
+	  is_only_spec = true; /* (statement_spec->next == NULL ? true : false); */
 
 	  /* determine if spec is outer joined */
 	  is_outer_joined = mq_is_outer_join_spec (parser, class_spec);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24041

View containing analytic functions is modified so that it is not merged.
And the analytic function check is handled in pt_has_analytic() function instead of pt_check_pushable().
The analytic functions in subquery should not be checked. It has been applied in pt_has_analytic().
