### PR TITLE
[LETS-225] Crash caused by untreated HA configuration in receive_server_info

### DIFF
--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -436,6 +436,7 @@ css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_
 static int
 receive_server_info (CSS_CONN_ENTRY * conn, unsigned short rid, std::string & dbname, SERVER_TYPE & type)
 {
+  // *INDENT-OFF*
   int buffer_length;
   char *buffer = NULL;
 
@@ -459,9 +460,7 @@ receive_server_info (CSS_CONN_ENTRY * conn, unsigned short rid, std::string & db
       else
 	{
 	  // First character represents server type
-          // *INDENT-OFF*
           type = static_cast<SERVER_TYPE> (buffer[0] - '0');
-          // *INDENT-ON*
 	  dbname = std::string (buffer + 1, buffer_length - 1);
 	}
 
@@ -469,6 +468,7 @@ receive_server_info (CSS_CONN_ENTRY * conn, unsigned short rid, std::string & db
 			   server_type_to_string (type));
     }
   return exit_code;
+  // *INDENT-ON*
 }
 
 /*

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -433,10 +433,10 @@ css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_
     }
 }
 
+// *INDENT-OFF*
 static int
 receive_server_info (CSS_CONN_ENTRY * conn, unsigned short rid, std::string & dbname, SERVER_TYPE & type)
 {
-  // *INDENT-OFF*
   int buffer_length;
   char *buffer = NULL;
 
@@ -468,8 +468,8 @@ receive_server_info (CSS_CONN_ENTRY * conn, unsigned short rid, std::string & db
 			   server_type_to_string (type));
     }
   return exit_code;
-  // *INDENT-ON*
 }
+// *INDENT-ON*
 
 /*
  * css_register_new_server() - register a new server by reading the server name

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -460,7 +460,7 @@ receive_server_info (CSS_CONN_ENTRY * conn, unsigned short rid, std::string & db
       else
 	{
 	  // First character represents server type
-          type = static_cast<SERVER_TYPE> (buffer[0] - '0');
+	  type = static_cast<SERVER_TYPE> (buffer[0] - '0');
 	  dbname = std::string (buffer + 1, buffer_length - 1);
 	}
 

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -450,12 +450,18 @@ receive_server_info (CSS_CONN_ENTRY * conn, unsigned short rid, std::string & db
 	  // Include '#' in the dbname; legacy requirement
 	  dbname = std::string (buffer, buffer_length);
 	}
+      else if (first_char == '$' || first_char == '%')
+	{
+	  // not really a server, it is copylogdb or applylogdb
+	  type = SERVER_TYPE_UNKNOWN;
+	  dbname = std::string (buffer, buffer_length);
+	}
       else
 	{
 	  // First character represents server type
-	  // *INDENT-OFF*
-	  type = static_cast<SERVER_TYPE> (buffer[0] - '0');
-	  // *INDENT-ON*
+          // *INDENT-OFF*
+          type = static_cast<SERVER_TYPE> (buffer[0] - '0');
+          // *INDENT-ON*
 	  dbname = std::string (buffer + 1, buffer_length - 1);
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-225

Fixed core dumb caused by untreated HA clients. 

HB_PTYPE_COPYLOGDB and HB_PTYPE_APPLYLOGDB were treated as normal server and the '$' and '%' used as first character were being processed as server type.