### PR TITLE
[LETS-224] transaction server shutdown flag

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1847,6 +1847,8 @@ log_final (THREAD_ENTRY * thread_p)
 
   free_and_init (log_Gl.loghdr_pgptr);
 
+  log_Log_header_initialized = false;
+
   LOG_CS_EXIT (thread_p);
 }
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1410,14 +1410,10 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
   log_Gl.rcv_phase = LOG_RESTARTED;
 
   // PREREQ: metalog is loaded at this point
-  if (is_tran_server_with_remote_storage ())
+  if (log_Gl.m_metainfo.get_clean_shutdown () && is_tran_server_with_remote_storage ())
     {
-      er_log_debug (ARG_FILE_LINE,
-		    "TEMP: log_initialize_internal: transaction server with remote storage clean shutdown: %s\n",
-		    log_Gl.m_metainfo.get_is_tsrs_shutdown ()? "yes" : "no");
-
-      // mark that transaction server with remote storage is running and save the meta log to persist the value
-      log_Gl.m_metainfo.set_is_tsrs_shutdown (false);
+      // mark, if needed, that transaction server with remote storage is running and persist the value
+      log_Gl.m_metainfo.set_clean_shutdown (false);
 
       const int res_metalog_to_file = log_write_metalog_to_file ();
       if (res_metalog_to_file != NO_ERROR)
@@ -1750,7 +1746,7 @@ log_final (THREAD_ENTRY * thread_p)
   // mark and persist that transaction server with remote storage has been correctly closed
   if (is_tran_server_with_remote_storage ())
     {
-      log_Gl.m_metainfo.set_is_tsrs_shutdown (true);
+      log_Gl.m_metainfo.set_clean_shutdown (true);
 
       const int res_metalog_to_file = log_write_metalog_to_file ();
       if (res_metalog_to_file != NO_ERROR)

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -216,7 +216,7 @@ extern void log_flush_daemon_get_stats (UINT64 * statsp);
 
 extern void log_update_global_btid_online_index_stats (THREAD_ENTRY * thread_p);
 
-extern int log_write_metalog_to_file ();
+extern void log_write_metalog_to_file ();
 
 //
 // log critical section

--- a/src/transaction/log_meta.cpp
+++ b/src/transaction/log_meta.cpp
@@ -43,7 +43,7 @@ namespace cublog
   void
   meta::pack (cubpacking::packer &serializer) const
   {
-    serializer.pack_bool (m_is_tsrs_shutdown);
+    serializer.pack_bool (m_clean_shutdown);
     serializer.pack_to_int (m_checkpoints.size ());
     for (const auto chkinfo : m_checkpoints)
       {
@@ -57,7 +57,7 @@ namespace cublog
   meta::unpack (cubpacking::unpacker &deserializer)
   {
     size_t size;
-    deserializer.unpack_bool (m_is_tsrs_shutdown);
+    deserializer.unpack_bool (m_clean_shutdown);
     deserializer.unpack_from_int (size);
     for (size_t i = 0; i < size; ++i)
       {
@@ -128,9 +128,9 @@ namespace cublog
   }
 
   void
-  meta::set_is_tsrs_shutdown (bool a_is)
+  meta::set_clean_shutdown (bool a_clean_shutdown)
   {
-    m_is_tsrs_shutdown = a_is;
+    m_clean_shutdown = a_clean_shutdown;
   }
 
   const checkpoint_info *

--- a/src/transaction/log_meta.hpp
+++ b/src/transaction/log_meta.hpp
@@ -35,18 +35,17 @@ namespace cublog
       ~meta () = default;
 
       void load_from_file (std::FILE *stream);       // load meta from meta log file
-      // TODO: function can be called from different threads (main, daemon); must be synched ???
       void flush_to_file (std::FILE *stream) const;  // write meta to disk
 
       size_t get_packed_size (cubpacking::packer &serializer, std::size_t start_offset = 0) const;
       void pack (cubpacking::packer &serializer) const;
       void unpack (cubpacking::unpacker &deserializer);
 
-      inline bool get_is_tsrs_shutdown () const
+      inline bool get_clean_shutdown () const
       {
-	return m_is_tsrs_shutdown;
+	return m_clean_shutdown;
       }
-      void set_is_tsrs_shutdown (bool a_is);
+      void set_clean_shutdown (bool a_clean_shutdown);
 
       const checkpoint_info *get_checkpoint_info (const log_lsa &checkpoint_lsa) const;
       void add_checkpoint_info (const log_lsa &chkpt_lsa, checkpoint_info &&chkpt_info);
@@ -61,9 +60,9 @@ namespace cublog
       /* flag parallel to 'log global header is shutdown':
        *  - false: server has not been clean shut down
        *  - true: has been clean shut down
-       * after start, flag is set to 'false' and the meta log is saved
+       * after start, flag is set to 'false' and the meta log is saved to ensure state is persisted
        */
-      bool m_is_tsrs_shutdown = false;
+      bool m_clean_shutdown = false;
 
       /* as the system is designed, it is not needed to hold a map of checkpoints since there should
        * be, at most, 2 checkpoints:

--- a/src/transaction/log_meta.hpp
+++ b/src/transaction/log_meta.hpp
@@ -35,11 +35,18 @@ namespace cublog
       ~meta () = default;
 
       void load_from_file (std::FILE *stream);       // load meta from meta log file
+      // TODO: function can be called from different threads (main, daemon); must be synched ???
       void flush_to_file (std::FILE *stream) const;  // write meta to disk
 
-      size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset = 0) const;
-      void pack (cubpacking::packer &serializator) const;
-      void unpack (cubpacking::unpacker &deserializator);
+      size_t get_packed_size (cubpacking::packer &serializer, std::size_t start_offset = 0) const;
+      void pack (cubpacking::packer &serializer) const;
+      void unpack (cubpacking::unpacker &deserializer);
+
+      inline bool get_is_tsrs_shutdown () const
+      {
+	return m_is_tsrs_shutdown;
+      }
+      void set_is_tsrs_shutdown (bool a_is);
 
       const checkpoint_info *get_checkpoint_info (const log_lsa &checkpoint_lsa) const;
       void add_checkpoint_info (const log_lsa &chkpt_lsa, checkpoint_info &&chkpt_info);
@@ -49,6 +56,14 @@ namespace cublog
 
     private:
       using checkpoint_container_t = std::map<log_lsa, checkpoint_info>;
+
+    private:
+      /* flag parallel to 'log global header is shutdown':
+       *  - false: server has not been clean shut down
+       *  - true: has been clean shut down
+       * after start, flag is set to 'false' and the meta log is saved
+       */
+      bool m_is_tsrs_shutdown = false;
 
       /* as the system is designed, it is not needed to hold a map of checkpoints since there should
        * be, at most, 2 checkpoints:

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7323,6 +7323,9 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
       return ER_FAILED;
     }
 
+  // *INDENT-OFF*
+  log_lsa trantable_checkpoint_lsa { NULL_LSA };
+  // *INDENT-ON*
   {
     LOG_CS_ENTER (thread_p);
     // *INDENT-OFF*
@@ -7342,7 +7345,7 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
     trantable_checkpoint_info.load_trantable_snapshot (thread_p, dummy_smallest_tran_lsa);
 
     // loading the transaction table snapshot ensures also that a snapshot lsa has been set
-    const log_lsa trantable_checkpoint_lsa = trantable_checkpoint_info.get_snapshot_lsa ();
+    trantable_checkpoint_lsa = trantable_checkpoint_info.get_snapshot_lsa ();
 
     if (detailed_logging)
       {
@@ -7359,26 +7362,26 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
 	_er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: failed; writing metalog to file\n");
 	return res_metalog_to_file;
       }
-
-    logpb_flush_pages (thread_p, &trantable_checkpoint_lsa);
-
-    // drop previous checkpoints
-    if (detailed_logging)
-      {
-	_er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: droping previous before lsa=%lld|%d\n",
-		       LSA_AS_ARGS (&trantable_checkpoint_lsa));
-      }
-    log_Gl.m_metainfo.remove_checkpoint_info_before_lsa (trantable_checkpoint_lsa);
-
-    // - in nominal conditions, there should be at most one previous trantable checkpoint
-    // - in abnormal conditions (such as when the system crashed just after adding a new trantable
-    //    checkpoint and before deleting the outdated checkpoint) there can be at most two
-    assert (log_Gl.m_metainfo.get_checkpoint_count () == 1);
-
-    // make sure new checkpoint is persisted to disk; discard possible error; if not transient, will be
-    // handled upon next attempt
-    (void) log_write_metalog_to_file ();
   }
+
+  logpb_flush_pages (thread_p, &trantable_checkpoint_lsa);
+
+  // drop previous checkpoints
+  if (detailed_logging)
+    {
+      _er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: droping previous before lsa=%lld|%d\n",
+		     LSA_AS_ARGS (&trantable_checkpoint_lsa));
+    }
+  log_Gl.m_metainfo.remove_checkpoint_info_before_lsa (trantable_checkpoint_lsa);
+
+  // - in nominal conditions, there should be at most one previous trantable checkpoint
+  // - in abnormal conditions (such as when the system crashed just after adding a new trantable
+  //    checkpoint and before deleting the outdated checkpoint) there can be at most two
+  assert (log_Gl.m_metainfo.get_checkpoint_count () == 1);
+
+  // make sure new checkpoint is persisted to disk; discard possible error; if not transient, will be
+  // handled upon next attempt
+  (void) log_write_metalog_to_file ();
 
   if (detailed_logging)
     {
@@ -7387,7 +7390,6 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
 
   return NO_ERROR;
 }
-
 
 /*
  * logpb_backup_for_volume - Execute a full backup for the given volume

--- a/unit_tests/log/test_main_log_meta.cpp
+++ b/unit_tests/log/test_main_log_meta.cpp
@@ -233,27 +233,27 @@ or_unpack_value (const char *buf, DB_VALUE *value)
 
 // checkpoint_info
 void
-cublog::checkpoint_info::pack (cubpacking::packer &serializator) const
+cublog::checkpoint_info::pack (cubpacking::packer &serializer) const
 {
-  serializator.pack_bigint (m_start_redo_lsa.pageid);
-  serializator.pack_int (m_start_redo_lsa.offset);
+  serializer.pack_bigint (m_start_redo_lsa.pageid);
+  serializer.pack_int (m_start_redo_lsa.offset);
 }
 
 size_t
-cublog::checkpoint_info::get_packed_size (cubpacking::packer &serializator, std::size_t start_offset) const
+cublog::checkpoint_info::get_packed_size (cubpacking::packer &serializer, std::size_t start_offset) const
 {
-  size_t size = serializator.get_packed_bigint_size (start_offset);
-  size += serializator.get_packed_int_size (start_offset + size);
+  size_t size = serializer.get_packed_bigint_size (start_offset);
+  size += serializer.get_packed_int_size (start_offset + size);
   return size;
 }
 
 void
-cublog::checkpoint_info::unpack (cubpacking::unpacker &deserializator)
+cublog::checkpoint_info::unpack (cubpacking::unpacker &deserializer)
 {
   int64_t bigint;
   int i;
-  deserializator.unpack_bigint (bigint);
-  deserializator.unpack_int (i);
+  deserializer.unpack_bigint (bigint);
+  deserializer.unpack_int (i);
   m_start_redo_lsa = { bigint, static_cast<std::int16_t> (i) };
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-224

In order to implement a recovery mechanism on TSRS, it is needed to know whether the TSRS (or any server, for that matter) has been clean-closed or abnormally.

- because TSRS has no other local storage aside from meta log - `cublob::meta` - a boolean flag is added to `cublog::meta` with the same semantics as `log_Gl.hdr.is_shutdown`
- read from file and initialize in `log_initialize_internal` - done by the call to `log_read_metalog_from_file`
- once server booting has started, set the flag to false 
- in `log_final` set the flag to `true` and persist metalog once more
- add a temporary log in `log_initialize_internal` to specify whether the server has been clean closed or crashed