### PR TITLE
[LETS-194] logpb_flush_pages needs to be called in critical section-free context

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7367,6 +7367,12 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
   // function explicitely needs to be called in critical section-free context
   logpb_flush_pages (thread_p, &trantable_checkpoint_lsa);
 
+  // drop previous checkpoints
+  if (detailed_logging)
+    {
+      _er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: droping previous before lsa=%lld|%d\n",
+		     LSA_AS_ARGS (&trantable_checkpoint_lsa));
+    }
   {
     LOG_CS_ENTER (thread_p);
     // *INDENT-OFF*
@@ -7376,12 +7382,6 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
     });
     // *INDENT-ON*
 
-    // drop previous checkpoints
-    if (detailed_logging)
-      {
-	_er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: droping previous before lsa=%lld|%d\n",
-		       LSA_AS_ARGS (&trantable_checkpoint_lsa));
-      }
     log_Gl.m_metainfo.remove_checkpoint_info_before_lsa (trantable_checkpoint_lsa);
 
     // - in nominal conditions, there should be at most one previous trantable checkpoint
@@ -7392,12 +7392,12 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
     // make sure new checkpoint is persisted to disk; discard possible error; if not transient, will be
     // handled upon next attempt
     (void) log_write_metalog_to_file ();
-
-    if (detailed_logging)
-      {
-	_er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: finished\n");
-      }
   }
+
+  if (detailed_logging)
+    {
+      _er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: finished\n");
+    }
 
   return NO_ERROR;
 }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7323,6 +7323,9 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
       return ER_FAILED;
     }
 
+  // *INDENT-OFF*
+  log_lsa trantable_checkpoint_lsa { NULL_LSA };
+  // *INDENT-ON*
   {
     LOG_CS_ENTER (thread_p);
     // *INDENT-OFF*
@@ -7342,7 +7345,7 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
     trantable_checkpoint_info.load_trantable_snapshot (thread_p, dummy_smallest_tran_lsa);
 
     // loading the transaction table snapshot ensures also that a snapshot lsa has been set
-    const log_lsa trantable_checkpoint_lsa = trantable_checkpoint_info.get_snapshot_lsa ();
+    trantable_checkpoint_lsa = trantable_checkpoint_info.get_snapshot_lsa ();
 
     if (detailed_logging)
       {
@@ -7359,8 +7362,19 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
 	_er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: failed; writing metalog to file\n");
 	return res_metalog_to_file;
       }
+  }
 
-    logpb_flush_pages (thread_p, &trantable_checkpoint_lsa);
+  // function explicitely needs to be called in critical section-free context
+  logpb_flush_pages (thread_p, &trantable_checkpoint_lsa);
+
+  {
+    LOG_CS_ENTER (thread_p);
+    // *INDENT-OFF*
+    scope_exit<std::function<void (void)>> unlock_log_cs_on_exit ([thread_p] ()
+    {
+      LOG_CS_EXIT (thread_p);
+    });
+    // *INDENT-ON*
 
     // drop previous checkpoints
     if (detailed_logging)
@@ -7378,16 +7392,15 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
     // make sure new checkpoint is persisted to disk; discard possible error; if not transient, will be
     // handled upon next attempt
     (void) log_write_metalog_to_file ();
-  }
 
-  if (detailed_logging)
-    {
-      _er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: finished\n");
-    }
+    if (detailed_logging)
+      {
+	_er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: finished\n");
+      }
+  }
 
   return NO_ERROR;
 }
-
 
 /*
  * logpb_backup_for_volume - Execute a full backup for the given volume


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-194

Follow-up patch for LETS-194.
Function `logpb_flush_pages` specifically needs to be called in critical section-free context.
Exit CS right before calling the function and re-acquire afterwards.