### PR TITLE
[CBRD-24061] The problem that the TO_CHAR() function is removed even though there is a second argument

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9041,7 +9041,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
       break;
 
     case PT_TO_CHAR:
-      if (PT_IS_CHAR_STRING_TYPE (arg1_type))
+      if (PT_IS_CHAR_STRING_TYPE (arg1_type) && PT_IS_NULL_NODE (arg2))
 	{
 	  arg1->line_number = node->line_number;
 	  arg1->column_number = node->column_number;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24061

If the TO_CHAR () function has a second argument, it is modified so that it is not deleted even if the first argument is a STRING type.
