### PR TITLE
[CBRD-23842] Set default value for supplemental_log to zero

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2348,7 +2348,7 @@ static UINT64 prm_ddl_audit_log_size_upper = 2147483648ULL;	/* 2G */
 static unsigned int prm_ddl_audit_log_size_flag = 0;
 
 int PRM_SUPPLEMENTAL_LOG = 0;
-static int prm_supplemental_log_default = 1;
+static int prm_supplemental_log_default = 0;
 static int prm_supplemental_log_lower = 0;
 static int prm_supplemental_log_upper = 2;
 static unsigned int prm_supplemental_log_flag = 0;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

Describe here
