### PR TITLE
[LETS-229] Fix start redo LSA from checkpoint info

### DIFF
--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -265,6 +265,8 @@ namespace cublog
   {
     LOG_TDES *tdes = nullptr;
 
+    start_redo_lsa = m_start_redo_lsa;
+
     /* Add the transactions to the transaction table */
     for (const auto &chkpt : m_trans)
       {

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -404,8 +404,9 @@ log_recovery_analysis (THREAD_ENTRY *thread_p, INT64 *num_redo_log_records, log_
 	{
 	  // The transaction table snapshot was taken before the next log record was logged.
 	  // Rebuild the transaction table image based on checkpoint information
-	  LOG_LSA start_redo_lsa;
+	  LOG_LSA start_redo_lsa = NULL_LSA;
 	  chkpt_infop->recovery_analysis (thread_p, start_redo_lsa);
+	  assert (!start_redo_lsa.is_null ());
 	  context.set_start_redo_lsa (start_redo_lsa);
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-229

`checkpoint_info::recovery_analysis ()` does not updated start_redo_lsa argument. The arguments remains uninitialized and redo recovery crashes.

Fix by setting start_redo_lsa properly.

NOTE: a recent fix surfaced this hidden issue; `recovery_analysis` used to be skipped completely.
