### PR TITLE
[CBRD-23842] Fix the bug that can not see the name of auto increment serial

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -16598,6 +16598,7 @@ heap_set_autoincrement_value (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * att
 		}
 
 	      SET_AUTO_INCREMENT_SERIAL_NAME (serial_name, classname, attr_name);
+
 	      if (OID_ISNULL (&serial_obj_oid))
 		{
 		  if (string != NULL && alloced_string == 1)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -16555,7 +16555,7 @@ heap_set_autoincrement_value (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * att
       if (att->is_autoincrement && (value->state == HEAP_UNINIT_ATTRVALUE))
 	{
 	  OID serial_obj_oid = att->auto_increment.serial_obj.load ().oid;
-	  if (OID_ISNULL (&serial_obj_oid))
+	  if (OID_ISNULL (&serial_obj_oid) || prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG))
 	    {
 	      memset (serial_name, '\0', sizeof (serial_name));
 	      recdes.data = NULL;
@@ -16598,61 +16598,63 @@ heap_set_autoincrement_value (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * att
 		}
 
 	      SET_AUTO_INCREMENT_SERIAL_NAME (serial_name, classname, attr_name);
-
-	      if (string != NULL && alloced_string == 1)
+	      if (OID_ISNULL (&serial_obj_oid))
 		{
-		  db_private_free_and_init (thread_p, string);
-		}
+		  if (string != NULL && alloced_string == 1)
+		    {
+		      db_private_free_and_init (thread_p, string);
+		    }
 
-	      free_and_init (classname);
+		  free_and_init (classname);
 
-	      if (db_make_varchar (&key_val, DB_MAX_IDENTIFIER_LENGTH, serial_name, (int) strlen (serial_name),
-				   LANG_SYS_CODESET, LANG_SYS_COLLATION) != NO_ERROR)
-		{
-		  ret = ER_FAILED;
-		  goto exit_on_error;
-		}
-
-	      status = xlocator_find_class_oid (thread_p, CT_SERIAL_NAME, &serial_class_oid, NULL_LOCK);
-	      if (status == LC_CLASSNAME_ERROR || status == LC_CLASSNAME_DELETED)
-		{
-		  ret = ER_FAILED;
-		  goto exit_on_error;
-		}
-
-	      classrep = heap_classrepr_get (thread_p, &serial_class_oid, NULL, NULL_REPRID, &idx_in_cache);
-	      if (classrep == NULL)
-		{
-		  ret = ER_FAILED;
-		  goto exit_on_error;
-		}
-
-	      if (classrep->indexes)
-		{
-		  BTREE_SEARCH search_result;
-		  OID serial_oid;
-
-		  BTID_COPY (&serial_btid, &(classrep->indexes[0].btid));
-		  search_result =
-		    xbtree_find_unique (thread_p, &serial_btid, S_SELECT, &key_val, &serial_class_oid, &serial_oid,
-					false);
-		  heap_classrepr_free_and_init (classrep, &idx_in_cache);
-		  if (search_result != BTREE_KEY_FOUND)
+		  if (db_make_varchar (&key_val, DB_MAX_IDENTIFIER_LENGTH, serial_name, (int) strlen (serial_name),
+				       LANG_SYS_CODESET, LANG_SYS_COLLATION) != NO_ERROR)
 		    {
 		      ret = ER_FAILED;
 		      goto exit_on_error;
 		    }
 
-		  assert (!OID_ISNULL (&serial_oid));
-		  or_aligned_oid null_aligned_oid = { oid_Null_oid };
-		  or_aligned_oid serial_aligned_oid = { serial_oid };
-		  att->auto_increment.serial_obj.compare_exchange_strong (null_aligned_oid, serial_aligned_oid);
-		}
-	      else
-		{
-		  heap_classrepr_free_and_init (classrep, &idx_in_cache);
-		  ret = ER_FAILED;
-		  goto exit_on_error;
+		  status = xlocator_find_class_oid (thread_p, CT_SERIAL_NAME, &serial_class_oid, NULL_LOCK);
+		  if (status == LC_CLASSNAME_ERROR || status == LC_CLASSNAME_DELETED)
+		    {
+		      ret = ER_FAILED;
+		      goto exit_on_error;
+		    }
+
+		  classrep = heap_classrepr_get (thread_p, &serial_class_oid, NULL, NULL_REPRID, &idx_in_cache);
+		  if (classrep == NULL)
+		    {
+		      ret = ER_FAILED;
+		      goto exit_on_error;
+		    }
+
+		  if (classrep->indexes)
+		    {
+		      BTREE_SEARCH search_result;
+		      OID serial_oid;
+
+		      BTID_COPY (&serial_btid, &(classrep->indexes[0].btid));
+		      search_result =
+			xbtree_find_unique (thread_p, &serial_btid, S_SELECT, &key_val, &serial_class_oid, &serial_oid,
+					    false);
+		      heap_classrepr_free_and_init (classrep, &idx_in_cache);
+		      if (search_result != BTREE_KEY_FOUND)
+			{
+			  ret = ER_FAILED;
+			  goto exit_on_error;
+			}
+
+		      assert (!OID_ISNULL (&serial_oid));
+		      or_aligned_oid null_aligned_oid = { oid_Null_oid };
+		      or_aligned_oid serial_aligned_oid = { serial_oid };
+		      att->auto_increment.serial_obj.compare_exchange_strong (null_aligned_oid, serial_aligned_oid);
+		    }
+		  else
+		    {
+		      heap_classrepr_free_and_init (classrep, &idx_in_cache);
+		      ret = ER_FAILED;
+		      goto exit_on_error;
+		    }
 		}
 	    }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

when update in serial that is made with auto increment record, there is a bug that name of the serial can not be seen. 
The serial name is generated at first insert statement, and it is recorded in the db_serial record.
So it also need to be set serial name when second insert statement has done for putting serial name in the supplemental log.