### PR TITLE
[CBRD-23842] Make log info for update when undo, redo has different representation

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1075,7 +1075,14 @@ cubrid_log_make_dml (char **data_info, DML * dml)
 	    case 7:
 	      dml->cond_column_data[i] = ptr;
 	      ptr = or_unpack_string_nocopy (ptr, &dml->cond_column_data[i]);
-	      dml->cond_column_data_len[i] = strlen (dml->cond_column_data[i]);
+	      if (dml->cond_column_data[i] == NULL)
+		{
+		  dml->cond_column_data_len[i] = 0;
+		}
+	      else
+		{
+		  dml->cond_column_data_len[i] = strlen (dml->cond_column_data[i]);
+		}
 	      break;
 
 	    case 8:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

when undo or redo record doesn't contain former representation,  cdc made empty log info to client. 

However, the update case when redo has more recent representation than undo record, it is required to make a log info.

ex) 
create table (a int) -> insert -> alter table add column b int-> update set b = ? where a = ?  