### PR TITLE
[CBRD-24072] Skip DEAD thread entries on SHOW THREADS

### DIFF
--- a/src/query/show_scan.c
+++ b/src/query/show_scan.c
@@ -516,6 +516,12 @@ thread_scan_mapfunc (THREAD_ENTRY & thread_ref, bool & stop_mapper, THREAD_ENTRY
   int msecs;
   DB_DATETIME time_val;
 
+  if (thrd->m_status == cubthread::entry::status::TS_DEAD)
+    {
+      // thread entry does not belong to a running thread; should not be shown in SHOW THREADS statement
+      return;
+    }
+
   vals = showstmt_alloc_tuple_in_context (caller_thread_p, ctx);
   if (vals == NULL)
     {

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -77,7 +77,7 @@ namespace cubthread
   entry::entry ()
   // public:
     : index (-1)
-    , type (TT_WORKER)
+    , type (TT_NONE)
     , emulate_tid ()
     , client_id (-1)
     , tran_index (NULL_TRAN_INDEX)

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -484,6 +484,7 @@ namespace cubthread
     // init main entry
     assert (Main_entry_p == NULL);
     Main_entry_p = new entry ();
+    Main_entry_p->type = TT_MASTER;
     Main_entry_p->index = 0;
     Main_entry_p->register_id ();
     Main_entry_p->m_status = entry::status::TS_RUN;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24012

'DEAD' thread entries have no relevance for the user. SHOW THREADS was changed to skip all dead thread entries.

Also backported scalability_dev changes regarding default thread type and the main thread type.

```
csql> show threads where Status = 'DEAD'
csql> ;

=== <Result of SELECT Command in Line 2> ===

There are no results.
0 row selected. (0.005179 sec) Committed.

1 command(s) successfully processed.
```