### PR TITLE
[CBRD-23842] DML on table partition returns OID of partition not a root class OID

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12245,6 +12245,16 @@ cdc_make_dml_loginfo (THREAD_ENTRY * thread_p, int trid, char *user, CDC_DML_TYP
   int record_length = 0;
 
   char *loginfo_buf = NULL;
+  OID partitioned_classoid;
+
+  if ((error_code = partition_find_root_class_oid (thread_p, &classoid, &partitioned_classoid)) == NO_ERROR)
+    {
+      COPY_OID (&classoid, &partitioned_classoid);
+    }
+  else
+    {
+      goto end;
+    }
 
   cdc_log ("cdc_make_dml_loginfo : started with trid:%d, transaction user:%s, class oid:(%d|%d|%d), dml type:%d", trid,
 	   user, OID_AS_ARGS (&classoid), dml_type);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12247,9 +12247,14 @@ cdc_make_dml_loginfo (THREAD_ENTRY * thread_p, int trid, char *user, CDC_DML_TYP
   char *loginfo_buf = NULL;
   OID partitioned_classoid;
 
+  /* when partition class oid input, it is required to be changed to partitioned class oid  */
+
   if ((error_code = partition_find_root_class_oid (thread_p, &classoid, &partitioned_classoid)) == NO_ERROR)
     {
-      COPY_OID (&classoid, &partitioned_classoid);
+      if (!OID_ISNULL (&partitioned_classoid))
+	{
+	  COPY_OID (&classoid, &partitioned_classoid);
+	}
     }
   else
     {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12245,7 +12245,7 @@ cdc_make_dml_loginfo (THREAD_ENTRY * thread_p, int trid, char *user, CDC_DML_TYP
   int record_length = 0;
 
   char *loginfo_buf = NULL;
-  OID partitioned_classoid;
+  OID partitioned_classoid = OID_INITIALIZER;
 
   /* when partition class oid input, it is required to be changed to partitioned class oid  */
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

When CDC user extract a dml log item and make a sql statement with it, 
the schema information extracted with class OID is not able to be received with portition OID. 
So, if DML is operated on partition class, it returns root class(partitioned class) OID not a partition class OID. 
