### PR TITLE
[CBRD-23842] Data with char types contain trash character bit

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12970,7 +12970,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       func_type = 7;
 
       ptr = or_pack_int (ptr, func_type);
-      ptr = or_pack_string_with_length (ptr, db_get_string (new_value), new_value->data.ch.medium.size - 1);
+      ptr = or_pack_string_with_length (ptr, db_get_string (new_value), db_get_string_size (new_value) - 1);
       break;
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARCHAR:

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12967,11 +12967,25 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       }
       break;
     case DB_TYPE_CHAR:
+      {
+	const char *str;
+	int length;
+	func_type = 7;
+
+	str = db_get_char (new_value, &length);
+
+	ptr = or_pack_int (ptr, func_type);
+	ptr = or_pack_string_with_length (ptr, str, length - 1);
+	break;
+      }
     case DB_TYPE_VARCHAR:
-      func_type = 7;
-      ptr = or_pack_int (ptr, func_type);
-      ptr = or_pack_string_with_length (ptr, db_get_string (new_value), new_value->domain.char_info.length);
-      break;
+      {
+	func_type = 7;
+	ptr = or_pack_int (ptr, func_type);
+	ptr = or_pack_string (ptr, db_get_string (new_value));
+
+	break;
+      }
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
       {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12970,7 +12970,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       func_type = 7;
 
       ptr = or_pack_int (ptr, func_type);
-      ptr = or_pack_string_with_length (ptr, db_get_string (new_value), new_value->domain.char_info.length - 1);
+      ptr = or_pack_string_with_length (ptr, db_get_string (new_value), new_value->data.ch.medium.size - 1);
       break;
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARCHAR:

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12967,54 +12967,18 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       }
       break;
     case DB_TYPE_CHAR:
-      {
-	const char *str;
-	int length;
-	func_type = 7;
+      func_type = 7;
 
-	str = db_get_char (new_value, &length);
-
-	ptr = or_pack_int (ptr, func_type);
-	ptr = or_pack_string_with_length (ptr, str, length - 1);
-	break;
-      }
-    case DB_TYPE_VARCHAR:
-      {
-	func_type = 7;
-	ptr = or_pack_int (ptr, func_type);
-	ptr = or_pack_string (ptr, db_get_string (new_value));
-
-	break;
-      }
+      ptr = or_pack_int (ptr, func_type);
+      ptr = or_pack_string_with_length (ptr, db_get_string (new_value), new_value->domain.char_info.length - 1);
+      break;
     case DB_TYPE_NCHAR:
+    case DB_TYPE_VARCHAR:
     case DB_TYPE_VARNCHAR:
-      {
-	int size;
-	char *result = NULL;
-	const char *temp_string = NULL;
-	temp_string = db_get_nchar (new_value, &size);
-	if (temp_string != NULL)
-	  {
-	    result = (char *) malloc (size + 4);
-	    if (result == NULL)
-	      {
-		return ER_OUT_OF_VIRTUAL_MEMORY;
-	      }
-
-	    snprintf (result, size + 4, "N'%s'", temp_string);
-	  }
-
-	func_type = 7;
-	ptr = or_pack_int (ptr, func_type);
-	ptr = or_pack_string (ptr, result);
-
-	if (result != NULL)
-	  {
-	    free_and_init (result);
-	  }
-
-	break;
-      }
+      func_type = 7;
+      ptr = or_pack_int (ptr, func_type);
+      ptr = or_pack_string (ptr, db_get_string (new_value));
+      break;
 #define TOO_BIG_TO_MATTER       1024
     case DB_TYPE_TIME:
       db_make_char (&format, strlen (time_format), time_format,

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12995,13 +12995,13 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
 	temp_string = db_get_nchar (new_value, &size);
 	if (temp_string != NULL)
 	  {
-	    result = (char *) malloc (size + 3);
+	    result = (char *) malloc (size + 4);
 	    if (result == NULL)
 	      {
 		return ER_OUT_OF_VIRTUAL_MEMORY;
 	      }
 
-	    snprintf (result, size + 3, "N'%s'", temp_string);
+	    snprintf (result, size + 4, "N'%s'", temp_string);
 	  }
 
 	func_type = 7;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

Due to mistakes in length information for char types, it contains trash bit. 
Fixes length data when packing the data. 
