### PR TITLE
[CBRD-23842] BIT/VARBIT was restrict to be made only for 1024bytes in CDC

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12951,7 +12951,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
     case DB_TYPE_VARBIT:
       {
 	char temp[1024];
-	char *result;
+	char *result = NULL;
 	int length, n, count;
 	char *bitstring = NULL;
 	func_type = 7;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12950,7 +12950,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
     case DB_TYPE_BIT:
     case DB_TYPE_VARBIT:
       {
-	char result[1024] = "\0";
+	char *result;
 	int length, n, count;
 	char *bitstring = NULL;
 	func_type = 7;
@@ -12969,14 +12969,23 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
 	    return ER_FAILED;
 	  }
 
+	result = (char *) malloc (length + 4);
+	if (result == NULL)
+	  {
+	    free_and_init (bitstring);
+	    return ER_OUT_OF_VIRTUAL_MEMORY;
+	  }
+
 	sprintf (result, "X'%s'", bitstring);
 
 	ptr = or_pack_int (ptr, func_type);
 	ptr = or_pack_string (ptr, result);
 
 	free_and_init (bitstring);
+	free_and_init (result);
+
+	break;
       }
-      break;
     case DB_TYPE_CHAR:
       func_type = 7;
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12973,7 +12973,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
 
 	snprintf (result, 3, "X'");
 
-	if (db_bit_string (new_value, "%X", result + 2, length) != NO_ERROR)
+	if (db_bit_string (new_value, "%X", result + 2, length - 2) != NO_ERROR)
 	  {
 	    if (result != temp)
 	      {
@@ -12984,6 +12984,8 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
 	  }
 
 	snprintf (result + length - 2, 2, "'");
+
+	assert (strlen (result) == (length - 1));
 
 	ptr = or_pack_int (ptr, func_type);
 	ptr = or_pack_string (ptr, result);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

String to represents BIT/VARBIT was restricted to make only 1024 bytes array. 

Modify it to allocate memory required size. 
