### PR TITLE
[LETS-240] Set clean shutdown metalog file on all servers

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1854,12 +1854,8 @@ log_final (THREAD_ENTRY * thread_p)
       LSA_COPY (&log_Gl.hdr.smallest_lsa_at_last_chkpt, &log_Gl.hdr.chkpt_lsa);
 
       // mark and persist that transaction server with remote storage has been correctly closed
-      if (is_tran_server_with_remote_storage ())
-	{
-	  log_Gl.m_metainfo.set_clean_shutdown (true);
-
-	  log_write_metalog_to_file ();
-	}
+      log_Gl.m_metainfo.set_clean_shutdown (true);
+      log_write_metalog_to_file ();
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-240

Metalog clean shutdown flag is used by a transaction server with remote storage to know whether it was crashed or normally shut down. For now, only transaction server with remote storage uses it.

However, when database is created, the flag is not set, because server is not considered a transaction server with remote storage. On the first boot of transaction with remote storage, recovery is run unnecessarily.

Fix by setting the clean shutdown flag in metalog regardless of server/storage type.
