### PR TITLE
[LETS-241] Skip overflow VPID validation in btree_check_valid_record on page server

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -48,6 +48,7 @@
 #include "object_representation.h"
 #include "perf_monitor.h"
 #include "regu_var.hpp"
+#include "server_type.hpp"
 #include "fault_injection.h"
 #include "dbtype.h"
 #include "thread_manager.hpp"
@@ -21824,7 +21825,7 @@ btree_check_valid_record (THREAD_ENTRY * thread_p, BTID_INT * btid, RECDES * rec
 
       vpid_ptr = recp->data + recp->length - vpid_size;
       OR_GET_VPID (vpid_ptr, &first_overflow_vpid);
-      if (!log_is_in_crash_recovery ()
+      if (!log_is_in_crash_recovery () && get_server_type () == SERVER_TYPE_TRANSACTION
 	  && pgbuf_is_valid_page (thread_p, &first_overflow_vpid, true, NULL, NULL) == DISK_INVALID)
 	{
 	  assert (false);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-241

Page server replication applies log records in parallel. Checking the changes are valid in a b-tree record may not guarantee consistent states in other pages.

Disable btree_check_valid_record verification that overflow VPID page is valid (allocated) on the page server.