### PR TITLE
[LETS-235] Disable no logging

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -4474,7 +4474,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_LOG_NO_LOGGING,
    PRM_NAME_LOG_NO_LOGGING,
-   (PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_HIDDEN),
+   (PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_HIDDEN | PRM_OBSOLETED),
    PRM_BOOLEAN,
    &prm_log_no_logging_flag,
    (void *) &prm_log_no_logging_default,

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -8771,7 +8771,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
   bool need_locking;
   UPDDEL_CLASS_INSTANCE_LOCK_INFO class_instance_lock_info, *p_class_instance_lock_info = NULL;
 
-  thread_p->no_logging = (bool) update->no_logging;
+  thread_p->no_logging = false;	// Used to be: (bool) update->no_logging;
 
   thread_p->no_supplemental_log = (bool) update->no_supplemental_log;
 
@@ -9635,7 +9635,7 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   bool need_locking;
   UPDDEL_CLASS_INSTANCE_LOCK_INFO class_instance_lock_info, *p_class_instance_lock_info = NULL;
 
-  thread_p->no_logging = (bool) delete_->no_logging;
+  thread_p->no_logging = false;	// Used to be: (bool) delete_->no_logging;
 
   thread_p->no_supplemental_log = (bool) delete_->no_supplemental_log;
 
@@ -10919,7 +10919,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   TP_DOMAIN *result_domain;
   bool has_user_format;
 
-  thread_p->no_logging = (bool) insert->no_logging;
+  thread_p->no_logging = false;	// Used to be: (bool) insert->no_logging;
 
   aptr = xasl->aptr_list;
   val_no = insert->num_vals;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1077,7 +1077,8 @@ log_initialize (THREAD_ENTRY * thread_p, const char *db_fullname, const char *lo
   log_daemons_init ();
 #endif // SERVER_MODE
 
-  log_No_logging = prm_get_bool_value (PRM_ID_LOG_NO_LOGGING);
+  log_No_logging = false;	// Used to be prm_get_bool_value (PRM_ID_LOG_NO_LOGGING);
+  // Having no log is no longer acceptable, because it breaks page server replication.
 #if !defined(NDEBUG)
   if (prm_get_bool_value (PRM_ID_LOG_TRACE_DEBUG) && log_No_logging)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-235

No logging feature breaks replication on page server (and on passive transaction servers in the future). It cannot be supported with the scalability feature.

- Make no logging system parameter obsolete.
- Ignore statements no logging hint.