### PR TITLE
[CBRD-23842] Remove server hang when server stop abnormally 

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -13354,7 +13354,7 @@ cdc_daemons_init ()
 void
 cdc_daemons_destroy ()
 {
-  if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) == 0)
+  if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) == 0 || cdc_Loginfo_producer_daemon == NULL)
     {
       return;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

If the server needs to be stopped, even if it has not been initialized, server hang occurs. 

So, add condition when server try to destroy the cdc daemon.  
