### PR TITLE
[LETS-236] There is no error message displayed when trying to start page server when Cubrid services are not running

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1392,8 +1392,8 @@ css_init (THREAD_ENTRY * thread_p, const char *server_name, int port_id)
     }
   else
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_NO_MASTER, 0);
-      return ER_NET_NO_MASTER;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, message_to_master.c_str () + 1);
+      return ERR_CSS_ERROR_DURING_SERVER_CONNECT;
     }
 
 shutdown:

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1390,6 +1390,11 @@ css_init (THREAD_ENTRY * thread_p, const char *server_name, int port_id)
 	  css_setup_server_loop ();
 	}
     }
+  else
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_NO_MASTER, 0);
+      return ER_NET_NO_MASTER;
+    }
 
 shutdown:
   /*

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1392,8 +1392,8 @@ css_init (THREAD_ENTRY * thread_p, const char *server_name, int port_id)
     }
   else
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, message_to_master.c_str () + 1);
-      return ERR_CSS_ERROR_DURING_SERVER_CONNECT;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_ERROR_DURING_SERVER_CONNECT, 1, server_name);
+      status = ERR_CSS_ERROR_DURING_SERVER_CONNECT;
     }
 
 shutdown:


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-236

Added `er_set` when conn is NULL due to cubrid master not running.
