### PR TITLE
[LETS-242] Add const to recdes/rec_header arguments that are not modified

### DIFF
--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -4253,7 +4253,7 @@ or_replace_rep_id (RECDES * record, int repid)
  * mvcc_header (out)	: MVCC Record header.
  */
 int
-or_mvcc_get_header (RECDES * record, MVCC_REC_HEADER * mvcc_header)
+or_mvcc_get_header (const RECDES * record, MVCC_REC_HEADER * mvcc_header)
 {
   OR_BUF buf;
   int rc = NO_ERROR;

--- a/src/base/object_representation_sr.h
+++ b/src/base/object_representation_sr.h
@@ -274,7 +274,7 @@ extern OR_CLASSREP **or_get_all_representation (RECDES * record, bool do_indexes
 
 extern int or_replace_rep_id (RECDES * record, int repid);
 
-extern int or_mvcc_get_header (RECDES * record, MVCC_REC_HEADER * mvcc_rec_header);
+extern int or_mvcc_get_header (const RECDES * record, MVCC_REC_HEADER * mvcc_rec_header);
 extern int or_mvcc_set_header (RECDES * record, MVCC_REC_HEADER * mvcc_rec_header);
 extern int or_mvcc_add_header (RECDES * record, MVCC_REC_HEADER * mvcc_rec_header, int bound_bit,
 			       int variable_offset_size);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -838,7 +838,7 @@ static void heap_log_delete_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, 
 static int heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, bool is_mvcc_op);
 static int heap_update_relocation (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, bool is_mvcc_op);
 static int heap_update_home (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, bool is_mvcc_op);
-static int heap_update_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, short slot_id, RECDES * recdes_p);
+static int heap_update_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, short slot_id, const RECDES * recdes_p);
 static void heap_log_update_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, VFID * vfid_p, OID * oid_p,
 				      RECDES * old_recdes_p, RECDES * new_recdes_p, LOG_RCVINDEX rcvindex);
 
@@ -16240,7 +16240,7 @@ heap_rv_undo_update (THREAD_ENTRY * thread_p, const LOG_RCV * rcv)
 /*
  * heap_rv_redo_update () - Redo the update of an object
  *   return: int
- *   rcv(in): Recovrery structure
+ *   rcv(in): Recovery structure
  */
 int
 heap_rv_redo_update (THREAD_ENTRY * thread_p, const LOG_RCV * rcv)
@@ -22437,7 +22437,7 @@ exit:
  *   returns: error code or NO_ERROR
  */
 static int
-heap_update_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, short slot_id, RECDES * recdes_p)
+heap_update_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, short slot_id, const RECDES * recdes_p)
 {
   int scancode;
   INT16 old_record_type;

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -193,8 +193,8 @@ static int spage_add_new_slot (THREAD_ENTRY * thread_p, PAGE_PTR page_p, SPAGE_H
 static int spage_take_slot_in_use (THREAD_ENTRY * thread_p, PAGE_PTR page_p, SPAGE_HEADER * page_header_p,
 				   PGSLOTID slot_id, SPAGE_SLOT * slot_p, int *out_space_p);
 
-static int spage_check_record_for_insert (RECDES * record_descriptor_p);
-static int spage_insert_data (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, RECDES * recdes, void *slotptr);
+static int spage_check_record_for_insert (const RECDES * record_descriptor_p);
+static int spage_insert_data (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, const RECDES * recdes, void *slotptr);
 static bool spage_is_record_located_at_end (SPAGE_HEADER * page_header_p, SPAGE_SLOT * slot_p);
 static void spage_reduce_a_slot (PAGE_PTR page_p);
 
@@ -223,7 +223,7 @@ static INLINE bool spage_is_unknown_slot (PGSLOTID slotid, SPAGE_HEADER * sphdr,
   __attribute__ ((ALWAYS_INLINE));
 static INLINE SPAGE_SLOT *spage_find_slot (PAGE_PTR pgptr, SPAGE_HEADER * sphdr, PGSLOTID slotid,
 					   bool is_unknown_slot_check) __attribute__ ((ALWAYS_INLINE));
-static INLINE int spage_find_slot_for_insert (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, RECDES * recdes,
+static INLINE int spage_find_slot_for_insert (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, const RECDES * recdes,
 					      PGSLOTID * slotid, void **slotptr, int *used_space)
   __attribute__ ((ALWAYS_INLINE));
 static SCAN_CODE spage_get_record_data (PAGE_PTR pgptr, SPAGE_SLOT * sptr, RECDES * recdes, bool ispeeking);
@@ -1751,7 +1751,7 @@ spage_find_empty_slot_at (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slo
  *   record_descriptor_p(in):
  */
 static int
-spage_check_record_for_insert (RECDES * record_descriptor_p)
+spage_check_record_for_insert (const RECDES * record_descriptor_p)
 {
   if (record_descriptor_p->length > spage_max_record_size ())
     {
@@ -1760,7 +1760,11 @@ spage_check_record_for_insert (RECDES * record_descriptor_p)
 
   if (record_descriptor_p->type == REC_MARKDELETED || record_descriptor_p->type == REC_DELETED_WILL_REUSE)
     {
-      record_descriptor_p->type = REC_HOME;
+      // Having deleted type record until this point is not something that is acceptable. Hopefully it never happens.
+      // Replace someday const_cast with a safe-guard that record type is not deleted. Or don't.
+      // *INDENT-OFF*
+      const_cast<RECDES *> (record_descriptor_p)->type = REC_HOME;
+      // *INDENT-ON*
     }
 
   return SP_SUCCESS;
@@ -1775,7 +1779,7 @@ spage_check_record_for_insert (RECDES * record_descriptor_p)
  *   out_slot_id_p(out): Slot identifier
  */
 int
-spage_insert (THREAD_ENTRY * thread_p, PAGE_PTR page_p, RECDES * record_descriptor_p, PGSLOTID * out_slot_id_p)
+spage_insert (THREAD_ENTRY * thread_p, PAGE_PTR page_p, const RECDES * record_descriptor_p, PGSLOTID * out_slot_id_p)
 {
   SPAGE_SLOT *slot_p;
   int used_space;
@@ -1807,7 +1811,7 @@ spage_insert (THREAD_ENTRY * thread_p, PAGE_PTR page_p, RECDES * record_descript
  *   out_used_space_p(out): Pointer to int
  */
 STATIC_INLINE int
-spage_find_slot_for_insert (THREAD_ENTRY * thread_p, PAGE_PTR page_p, RECDES * record_descriptor_p,
+spage_find_slot_for_insert (THREAD_ENTRY * thread_p, PAGE_PTR page_p, const RECDES * record_descriptor_p,
 			    PGSLOTID * out_slot_id_p, void **out_slot_p, int *out_used_space_p)
 {
   SPAGE_SLOT *slot_p;
@@ -1847,7 +1851,7 @@ spage_find_slot_for_insert (THREAD_ENTRY * thread_p, PAGE_PTR page_p, RECDES * r
  *   slot_p(in): Pointer to slotted array
  */
 static int
-spage_insert_data (THREAD_ENTRY * thread_p, PAGE_PTR page_p, RECDES * record_descriptor_p, void *slot_p)
+spage_insert_data (THREAD_ENTRY * thread_p, PAGE_PTR page_p, const RECDES * record_descriptor_p, void *slot_p)
 {
   SPAGE_SLOT *tmp_slot_p;
 
@@ -1908,7 +1912,7 @@ spage_insert_data (THREAD_ENTRY * thread_p, PAGE_PTR page_p, RECDES * record_des
  *       fit on the page, such effect is returned.
  */
 int
-spage_insert_at (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slot_id, RECDES * record_descriptor_p)
+spage_insert_at (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slot_id, const RECDES * record_descriptor_p)
 {
   SPAGE_HEADER *page_header_p;
   SPAGE_SLOT *slot_p;
@@ -1968,7 +1972,8 @@ spage_insert_at (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slot_id, REC
  *       Otherwise, the slots will be moved.
  */
 int
-spage_insert_for_recovery (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slot_id, RECDES * record_descriptor_p)
+spage_insert_for_recovery (THREAD_ENTRY * thread_p, PAGE_PTR page_p, PGSLOTID slot_id,
+			   const RECDES * record_descriptor_p)
 {
   SPAGE_HEADER *page_header_p;
   SPAGE_SLOT *slot_p;

--- a/src/storage/slotted_page.h
+++ b/src/storage/slotted_page.h
@@ -101,9 +101,9 @@ extern PGNSLOTS spage_number_of_records (PAGE_PTR pgptr);
 extern PGNSLOTS spage_number_of_slots (PAGE_PTR pgptr);
 extern void spage_initialize (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slots_type, unsigned short alignment,
 			      bool safeguard_rvspace);
-extern int spage_insert (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, RECDES * recdes, PGSLOTID * slotid);
-extern int spage_insert_at (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID slotid, RECDES * recdes);
-extern int spage_insert_for_recovery (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID slotid, RECDES * recdes);
+extern int spage_insert (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, const RECDES * recdes, PGSLOTID * slotid);
+extern int spage_insert_at (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID slotid, const RECDES * recdes);
+extern int spage_insert_for_recovery (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID slotid, const RECDES * recdes);
 extern PGSLOTID spage_delete (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID slotid);
 extern PGSLOTID spage_delete_for_recovery (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID slotid);
 extern int spage_update (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID slotid, const RECDES * recdes);

--- a/src/transaction/mvcc.c
+++ b/src/transaction/mvcc.c
@@ -306,7 +306,7 @@ mvcc_is_not_deleted_for_snapshot (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec
  * page_p (in)	      : Heap page pointer.
  */
 MVCC_SATISFIES_VACUUM_RESULT
-mvcc_satisfies_vacuum (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header, MVCCID oldest_mvccid)
+mvcc_satisfies_vacuum (THREAD_ENTRY * thread_p, const MVCC_REC_HEADER * rec_header, MVCCID oldest_mvccid)
 {
   if (!MVCC_IS_HEADER_DELID_VALID (rec_header) || MVCC_IS_REC_DELETED_SINCE_MVCCID (rec_header, oldest_mvccid))
     {

--- a/src/transaction/mvcc.h
+++ b/src/transaction/mvcc.h
@@ -277,7 +277,7 @@ extern MVCC_SATISFIES_SNAPSHOT_RESULT mvcc_satisfies_snapshot (THREAD_ENTRY * th
 extern MVCC_SATISFIES_SNAPSHOT_RESULT mvcc_is_not_deleted_for_snapshot (THREAD_ENTRY * thread_p,
 									MVCC_REC_HEADER * rec_header,
 									MVCC_SNAPSHOT * snapshot);
-extern MVCC_SATISFIES_VACUUM_RESULT mvcc_satisfies_vacuum (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header,
+extern MVCC_SATISFIES_VACUUM_RESULT mvcc_satisfies_vacuum (THREAD_ENTRY * thread_p, const MVCC_REC_HEADER * rec_header,
 							   MVCCID oldest_mvccid);
 extern MVCC_SATISFIES_DELETE_RESULT mvcc_satisfies_delete (THREAD_ENTRY * thread_p, MVCC_REC_HEADER * rec_header);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-242

Change several functions that read from a record descriptor or from a record header by adding const modifier to the respective arguments.

This pull request was extracted from a fix to the problem described in the JIRA issue. The fix itself will be open in a separate PR.