### PR TITLE
[LETS-245] er_manager is already closed when calling er_msg()

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1418,7 +1418,6 @@ net_server_start (THREAD_ENTRY * thread_p, const char *server_name)
 
   cubthread::finalize ();
   cubthread::internal_tasks_worker_pool::finalize ();
-  er_final (ER_ALL_FINAL);
   csect_finalize_static_critical_sections ();
   (void) sync_finalize_sync_stats ();
 

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -438,8 +438,8 @@ main (int argc, char **argv)
 	PRINT_AND_LOG_ERR_MSG ("%s\n", er_msg ());
 	fflush (stderr);
       }
+    er_final (ER_ALL_FINAL);
   }
-  er_final (ER_ALL_FINAL);
 #if defined(WINDOWS)
   __except (CreateMiniDump (GetExceptionInformation (), argv[1]))
   {

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -439,6 +439,7 @@ main (int argc, char **argv)
 	fflush (stderr);
       }
   }
+  er_final (ER_ALL_FINAL);
 #if defined(WINDOWS)
   __except (CreateMiniDump (GetExceptionInformation (), argv[1]))
   {

--- a/win/libcubrid/libcubrid.def
+++ b/win/libcubrid/libcubrid.def
@@ -9,6 +9,7 @@ EXPORTS
 	util_log_write_errid
 	util_log_write_errstr
 	util_log_write_command
+    er_final
 	er_init
 	er_msg
 	er_set

--- a/win/libcubrid/libcubrid.def
+++ b/win/libcubrid/libcubrid.def
@@ -9,7 +9,7 @@ EXPORTS
 	util_log_write_errid
 	util_log_write_errstr
 	util_log_write_command
-    er_final
+    	er_final
 	er_init
 	er_msg
 	er_set


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-245

In `server.c:main()` when calling `er_msg()` after `net_server_start()` has ended the er_manager is already closed.

Moved `er_final (ER_ALL_FINAL);` at the end of the main function.