### PR TITLE
[LETS-238] Duplicate error message when configuration parameter is misspelt

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1347,7 +1347,11 @@ net_server_start (THREAD_ENTRY * thread_p, const char *server_name)
       goto end;
     }
 
-  sysprm_load_and_init (NULL, NULL, SYSPRM_LOAD_ALL);
+  if (sysprm_load_and_init (NULL, NULL, SYSPRM_LOAD_ALL) != NO_ERROR)
+    {
+      status = -1;
+      goto end;
+    }
   sysprm_set_er_log_file (server_name);
 
   if (sync_initialize_sync_stats () != NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-233

On `SERVER_MODE` `sysprm_load_and_init` is called twice before the `cub_server` process is stopped in case of an error in the conf file.

The first call is in `net_server_start` and the second in `boot_restart_server`. For minimal impact in the code the exit code of the first `sysprm_load_and_init` is now used to determine if the server boot should continue;
