### PR TITLE
[CBRD-23842] Set client side supplemental_log parameter to follow server parameter 

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -6052,7 +6052,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_SUPPLEMENTAL_LOG,
    PRM_NAME_SUPPLEMENTAL_LOG,
-   (PRM_FOR_SERVER | PRM_FOR_CLIENT),
+   (PRM_FOR_SERVER | PRM_FOR_CLIENT | PRM_FORCE_SERVER),
    PRM_INTEGER,
    &prm_supplemental_log_flag,
    (void *) &prm_supplemental_log_default,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

Clients are forced to follow server-side supplemental_log parameter setting by adding PRM_FORCE_SERVER. 

This is used when clients are connected to the server in db_restart(). 

