### PR TITLE
[CBRD-23842] Make able to connect to remote server in cdc api

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -521,7 +521,7 @@ static int
 cubrid_log_db_login (char *hostname, char *dbname, char *username, char *password)
 {
   MOP user;
-  char dbname_at_hostname[CUB_MAXHOSTNAMELEN + MAX_DBNAME_LEN] = { '\0', };
+  char dbname_at_hostname[CUB_MAXHOSTNAMELEN + CUBRID_LOG_MAX_DBNAME_LEN + 2] = { '\0', };
 
   snprintf (dbname_at_hostname, sizeof (dbname_at_hostname), "%s@%s", dbname, hostname);
 

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -43,6 +43,7 @@
 #include "object_representation.h"
 #include "dbi.h"
 #include "dbtype_def.h"
+#include "porting.h"
 
 #define CUBRID_LOG_ERROR_HANDLING(e, v) \
   do\
@@ -517,11 +518,14 @@ cubrid_log_error:
 }
 
 static int
-cubrid_log_db_login (char *dbname, char *username, char *password)
+cubrid_log_db_login (char *hostname, char *dbname, char *username, char *password)
 {
   MOP user;
+  char dbname_at_hostname[CUB_MAXHOSTNAMELEN + MAX_DBNAME_LEN] = { '\0', };
 
-  if (db_restart ("cubrid_log_api", 0, dbname) != NO_ERROR)
+  snprintf (dbname_at_hostname, sizeof (dbname_at_hostname), "%s@%s", dbname, hostname);
+
+  if (db_restart ("cubrid_log_api", 0, dbname_at_hostname) != NO_ERROR)
     {
       return CUBRID_LOG_FAILED_LOGIN;
     }
@@ -607,7 +611,7 @@ cubrid_log_connect_server (char *host, int port, char *dbname, char *id, char *p
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_INVALID_PASSWORD, trace_errbuf);
     }
 
-  if (cubrid_log_db_login (dbname, id, password) != CUBRID_LOG_SUCCESS)
+  if (cubrid_log_db_login (host, dbname, id, password) != CUBRID_LOG_SUCCESS)
     {
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_LOGIN, trace_errbuf);
     }

--- a/src/api/cubrid_log.h
+++ b/src/api/cubrid_log.h
@@ -66,6 +66,8 @@
 #define CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM      (1)
 #define CUBRID_LOG_SUCCESS_WITH_ADJUSTED_LSA    (2)
 
+#define MAX_DBNAME_LEN  64
+
 typedef struct ddl DDL;
 struct ddl
 {

--- a/src/api/cubrid_log.h
+++ b/src/api/cubrid_log.h
@@ -66,7 +66,7 @@
 #define CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM      (1)
 #define CUBRID_LOG_SUCCESS_WITH_ADJUSTED_LSA    (2)
 
-#define MAX_DBNAME_LEN  64
+#define CUBRID_LOG_MAX_DBNAME_LEN  64
 
 typedef struct ddl DDL;
 struct ddl


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

When trying to connect to remote server, an error was occurred because of host name is not passed to the function db_restart(). So, instead of passing only dbname to the db_restart(), it passed dbname@hostname to db_restart(). 
