### PR TITLE
[LETS-233] separate metalog for transaction server and page server

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -5879,10 +5879,11 @@ fileio_make_log_info_name (char *log_info_name_p, const char *log_path_p, const 
 }
 
 void
-fileio_make_log_metainfo_name (char *log_meta_name_p, const char *log_path_p, const char *db_name_p)
+fileio_make_log_metainfo_name (char *log_meta_name_p, const char *log_path_p, const char *db_name_p,
+			       bool tran_server_with_remote_storage)
 {
   sprintf (log_meta_name_p, "%s%s%s%s", log_path_p, FILEIO_PATH_SEPARATOR (log_path_p), db_name_p,
-	   FILEIO_SUFFIX_LOGMETA);
+	   tran_server_with_remote_storage ? FILEIO_SUFFIX_LOGMETA_TRAN : FILEIO_SUFFIX_LOGMETA);
 }
 
 /*

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -83,7 +83,8 @@
 #define FILEIO_SUFFIX_LOGARCHIVE     "_lgar"
 #define FILEIO_SUFFIX_TMP_LOGARCHIVE "_lgar_t"
 #define FILEIO_SUFFIX_LOGINFO        "_lginf"
-#define FILEIO_SUFFIX_LOGMETA        "_lgmeta"
+#define FILEIO_SUFFIX_LOGMETA_TRAN   "_lgmeta_tran"	/* for: transaction server */
+#define FILEIO_SUFFIX_LOGMETA        "_lgmeta"	/* for: non-scalable config, page server */
 #define FILEIO_SUFFIX_BACKUP         "_bk"
 #define FILEIO_SUFFIX_BACKUP_VOLINFO "_bkvinf"
 #define FILEIO_VOLEXT_PREFIX         "_x"

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -547,7 +547,8 @@ extern void fileio_make_removed_log_archive_name (char *logarchive_name, const c
 extern void fileio_make_log_archive_temp_name (char *log_archive_temp_name_p, const char *log_path_p,
 					       const char *db_name_p);
 extern void fileio_make_log_info_name (char *loginfo_name, const char *log_path, const char *dbname);
-extern void fileio_make_log_metainfo_name (char *log_meta_name_p, const char *log_path_p, const char *db_name_p);
+extern void fileio_make_log_metainfo_name (char *log_meta_name_p, const char *log_path_p, const char *db_name_p,
+					   bool tran_server_with_remote_storage);
 extern void fileio_make_backup_volume_info_name (char *backup_volinfo_name, const char *backinfo_path,
 						 const char *dbname);
 extern void fileio_make_backup_name (char *backup_name, const char *nopath_volname, const char *backup_path,

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10632,6 +10632,10 @@ log_read_metalog_from_file_with_create ()
       log_Gl.m_metainfo.set_clean_shutdown (true);
 
       err_code = log_create_metalog_file ();
+
+      // creation of an empty metalog file happens early during the log initialization process
+      // later on, there is a sequence where the clean shutdown flag is set to false such that
+      // an accidental server crash is correctly flagged
     }
   else
     {

--- a/src/transaction/log_meta.cpp
+++ b/src/transaction/log_meta.cpp
@@ -56,6 +56,7 @@ namespace cublog
   void
   meta::unpack (cubpacking::unpacker &deserializer)
   {
+    assert (m_checkpoints.empty ());
     size_t size;
     deserializer.unpack_bool (m_clean_shutdown);
     deserializer.unpack_from_int (size);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6872,7 +6872,7 @@ logpb_initialize_log_names (THREAD_ENTRY * thread_p, const char *db_fullname, co
    */
   fileio_make_log_active_name (log_Name_active, log_Path, log_Prefix);
   fileio_make_log_info_name (log_Name_info, log_Path, log_Prefix);
-  fileio_make_log_metainfo_name (log_Name_metainfo, log_Path, log_Prefix);
+  fileio_make_log_metainfo_name (log_Name_metainfo, log_Path, log_Prefix, is_tran_server_with_remote_storage ());
   fileio_make_backup_volume_info_name (log_Name_bkupinfo, log_Path, log_Prefix);
   fileio_make_volume_info_name (log_Name_volinfo, db_fullname);
   fileio_make_log_archive_temp_name (log_Name_bg_archive, log_Archive_path, log_Prefix);
@@ -9411,7 +9411,7 @@ logpb_copy_database (THREAD_ENTRY * thread_p, VOLID num_perm_vols, const char *t
   /*
    * Copy log meta-information file
    */
-  fileio_make_log_metainfo_name (to_volname, to_logpath, to_prefix_logname);
+  fileio_make_log_metainfo_name (to_volname, to_logpath, to_prefix_logname, false);
   // *INDENT-OFF*
   try
     {
@@ -9994,7 +9994,7 @@ logpb_rename_all_volumes_files (THREAD_ENTRY * thread_p, VOLID num_perm_vols, co
   /*
    * Rename the log meta file
    */
-  fileio_make_log_metainfo_name (to_volname, to_logpath, to_prefix_logname);
+  fileio_make_log_metainfo_name (to_volname, to_logpath, to_prefix_logname, false);
   if (fileio_rename (LOG_DBLOG_METAINFO_VOLID, log_Name_metainfo, to_volname) == NULL)
     {
       error_code = ER_FAILED;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-233

The single file that a TSRS actually uses/maintains is the metalog (for transaction table snapshoting). In order to allow execution of TSRS and PS on a single node, the servers needs to access separate metalog files. This should also cover the need of the recovery process on TSRS.

Implementation:
- a TSRS would create a metalog file upon boot-up, if not already found on disk
- separate name for TSRS-specific metalog file: _lgmeta_tran

Tested:
- manual tests with separate containers
- manual tests on single node
- recovery scenario with separate containers