### PR TITLE
[LETS-248] flush log page buffer after recovery undo because dangling transactions might be aborted and compensating log records added

### DIFF
--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -38,10 +38,10 @@ namespace cubpacking
 
 // Transaction server class hierarchies:
 //
-//                            tran_server
-//                               /   \
-//                              /     \
-//                             /       \
+//                              tran_server
+//                               /      |
+//                              /       |
+//                             /        |
 //             active_tran_server     passive_tran_server
 //
 //

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3400,6 +3400,10 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
     }
 }
 
+/*
+ * logpb_skip_flush_append_pages - TODO, reason
+ *
+ */
 static void
 logpb_skip_flush_append_pages ()
 {

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3394,12 +3394,6 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
       // log pages are not written to local disk; they are written by page server
       // skip flushing - aka: pretend that flushing has happened
 
-      // NOTE: this branch only updates bookkeeping and does not offer the same
-      // "functional promise" as the 'else' branch (where log pages are actually
-      // written on persistent storage); in case effective persistence is needed, one must
-      // call `logpb_flush_pages` which also makes sure that the persistence happens
-      // on the page server
-
       logpb_skip_flush_append_pages ();
       return NO_ERROR;
     }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3391,6 +3391,15 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 {
   if (is_tran_server_with_remote_storage ())
     {
+      // log pages are not written to local disk; they are written by page server
+      // skip flushing - aka: pretend that flushing has happened
+
+      // NOTE: this branch only updates bookkeeping and does not offer the same
+      // "functional promise" as the 'else' branch (where log pages are actually
+      // written on persistent storage); in case effective persistence is needed, one must
+      // call `logpb_flush_pages` which also makes sure that the persistence happens
+      // on the page server
+
       logpb_skip_flush_append_pages ();
       return NO_ERROR;
     }
@@ -3401,7 +3410,8 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 }
 
 /*
- * logpb_skip_flush_append_pages - TODO, reason
+ * logpb_skip_flush_append_pages - Skip flushing append pages to disk.
+ *                  Set nxio_lsa and reset flush page count directly.
  *
  */
 static void

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -966,6 +966,9 @@ log_recovery_finish_transactions (THREAD_ENTRY * const thread_p)
   log_Gl.rcv_phase = LOG_RECOVERY_UNDO_PHASE;
   log_recovery_undo (thread_p);
 
+  // when dangling transactions are encountered during undo, compensation log records
+  // might be added - eg: log_rv_undo_record;
+  // request a flush such that all log pages are up to date
   logpb_flush_pages_direct (thread_p);
 
   // Reset boot_Db_parm in case a data volume creation was undone.

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -898,6 +898,8 @@ log_recovery_finish_transactions (THREAD_ENTRY * const thread_p)
   assert (is_tran_server_with_remote_storage ());
   assert (log_Gl.m_metainfo.is_loaded_from_file ());
 
+  assert (LOG_CS_OWN_WRITE_MODE (thread_p));
+
   const int sys_tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   assert (sys_tran_index == LOG_SYSTEM_TRAN_INDEX && LOG_FIND_TDES (sys_tran_index) != nullptr);
 
@@ -906,7 +908,12 @@ log_recovery_finish_transactions (THREAD_ENTRY * const thread_p)
   log_Gl.rcv_phase = LOG_RECOVERY_ANALYSIS_PHASE;
 
   // start with what metalog tells us
-  const auto[chkpt_lsa, chkpt_info] = log_Gl.m_metainfo.get_highest_lsa_checkpoint_info ();
+  // *INDENT-OFF*
+  const auto highest_lsa_chkpt_info = log_Gl.m_metainfo.get_highest_lsa_checkpoint_info ();
+  const log_lsa chkpt_lsa = std::get<log_lsa>(highest_lsa_chkpt_info);
+  const cublog::checkpoint_info *const chkpt_info = std::get<1>(highest_lsa_chkpt_info);
+  // *INDENT-ON*
+
   if (chkpt_info == nullptr)
     {
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE,
@@ -958,6 +965,8 @@ log_recovery_finish_transactions (THREAD_ENTRY * const thread_p)
   //
   log_Gl.rcv_phase = LOG_RECOVERY_UNDO_PHASE;
   log_recovery_undo (thread_p);
+
+  logpb_flush_pages_direct (thread_p);
 
   // Reset boot_Db_parm in case a data volume creation was undone.
   error_code = boot_reset_db_parm (thread_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-248

When dangling transactions are encountered during recovery undo, compensating log records might be added - eg: `log_rv_undo_record`.
Request a flush such that all log pages are up to date.

