### PR TITLE
[CBRD-24088] Assert_release error occurred when creating index

### DIFF
--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -5229,7 +5229,7 @@ lang_split_key_euckr (const LANG_COLLATION * lang_coll, const bool is_desc, cons
 	  str2_next = intl_nextchar_euc (str2, &char2_size);
 	  if (*str2 == ASCII_SPACE || *str2 == 0 || (*str2 == EUC_SPACE && char2_size == 2 && *(str2 + 1) == EUC_SPACE))
 	    {
-	      is_zero_weight = 0;
+	      is_zero_weight = 1;
 	    }
 	  str2 = str2_next;
 	  if (!is_zero_weight)
@@ -5252,7 +5252,7 @@ lang_split_key_euckr (const LANG_COLLATION * lang_coll, const bool is_desc, cons
 	  str1_next = intl_nextchar_euc (str1, &char1_size);
 	  if (*str1 == ASCII_SPACE || *str1 == 0 || (*str1 == EUC_SPACE && char1_size == 2 && *(str1 + 1) == EUC_SPACE))
 	    {
-	      is_zero_weight = 0;
+	      is_zero_weight = 1;
 	    }
 	  str1 = str1_next;
 	  if (!is_zero_weight)

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -4719,7 +4719,7 @@ lang_split_key_iso (const LANG_COLLATION * lang_coll, const bool is_desc, const 
   const unsigned char *str1_end, *str2_end;
   const unsigned char *str1_begin, *str2_begin;
   int key_size;
-  const unsigned int *weight = lang_coll->coll.weights_ti;
+  const unsigned int *weight = (ignore_trailing_space) ? lang_coll->coll.weights_ti : lang_coll->coll.weights;
 
   assert (key != NULL);
   assert (byte_size != NULL);
@@ -4811,7 +4811,7 @@ lang_split_key_byte (const LANG_COLLATION * lang_coll, const bool is_desc, const
   const unsigned char *str1_begin, *str2_begin;
   unsigned int w1, w2;
   int key_size;
-  const unsigned int *weight = lang_coll->coll.weights_ti;
+  const unsigned int *weight = (ignore_trailing_space) ? lang_coll->coll.weights_ti : lang_coll->coll.weights;
 
   assert (key != NULL);
   assert (byte_size != NULL);
@@ -4917,8 +4917,8 @@ lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const
 
   for (; str1 < str1_end && str2 < str2_end;)
     {
-      w1 = lang_get_w_first_el (coll, str1, CAST_BUFLEN (str1_end - str1), &str1_next, true);
-      w2 = lang_get_w_first_el (coll, str2, CAST_BUFLEN (str2_end - str2), &str2_next, true);
+      w1 = lang_get_w_first_el (coll, str1, CAST_BUFLEN (str1_end - str1), &str1_next, ignore_trailing_space);
+      w2 = lang_get_w_first_el (coll, str2, CAST_BUFLEN (str2_end - str2), &str2_next, ignore_trailing_space);
 
       if (w1 != w2)
 	{
@@ -4937,7 +4937,7 @@ lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const
       /* common part plus a character with non-zero weight from str2 */
       while (str2 < str2_end)
 	{
-	  w2 = lang_get_w_first_el (coll, str2, CAST_BUFLEN (str2_end - str2), &str2_next, true);
+	  w2 = lang_get_w_first_el (coll, str2, CAST_BUFLEN (str2_end - str2), &str2_next, ignore_trailing_space);
 	  str2 = str2_next;
 	  if (w2 != 0)
 	    {
@@ -4954,7 +4954,7 @@ lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const
       /* common part plus a character with non-zero weight from str1 */
       while (str1 < str1_end)
 	{
-	  w1 = lang_get_w_first_el (coll, str1, CAST_BUFLEN (str1_end - str1), &str1_next, true);
+	  w1 = lang_get_w_first_el (coll, str1, CAST_BUFLEN (str1_end - str1), &str1_next, ignore_trailing_space);
 	  str1 = str1_next;
 	  if (w1 != 0)
 	    {
@@ -5194,7 +5194,7 @@ lang_split_key_euckr (const LANG_COLLATION * lang_coll, const bool is_desc, cons
   int key_size, char1_size, char2_size;
   const unsigned char *str1_end, *str2_end;
   const unsigned char *str1_begin, *str2_begin;
-  const unsigned int *weight = lang_coll->coll.weights_ti;
+  const unsigned int *weight = (ignore_trailing_space) ? lang_coll->coll.weights_ti : lang_coll->coll.weights;
 
   assert (key != NULL);
   assert (byte_size != NULL);

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -4939,7 +4939,7 @@ lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const
 	{
 	  w2 = lang_get_w_first_el (coll, str2, CAST_BUFLEN (str2_end - str2), &str2_next, ignore_trailing_space);
 	  str2 = str2_next;
-	  if (w2 != 0)
+	  if (w2 != 0 && w2 != ASCII_SPACE)
 	    {
 	      break;
 	    }
@@ -4956,7 +4956,7 @@ lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const
 	{
 	  w1 = lang_get_w_first_el (coll, str1, CAST_BUFLEN (str1_end - str1), &str1_next, ignore_trailing_space);
 	  str1 = str1_next;
-	  if (w1 != 0)
+	  if (w1 != 0 && w2 != ASCII_SPACE)
 	    {
 	      break;
 	    }
@@ -5229,7 +5229,7 @@ lang_split_key_euckr (const LANG_COLLATION * lang_coll, const bool is_desc, cons
 	  str2_next = intl_nextchar_euc (str2, &char2_size);
 	  if (*str2 == ASCII_SPACE || *str2 == 0 || (*str2 == EUC_SPACE && char2_size == 2 && *(str2 + 1) == EUC_SPACE))
 	    {
-	      is_zero_weight = (weight[SPACE] == 0);
+	      is_zero_weight = 0;
 	    }
 	  str2 = str2_next;
 	  if (!is_zero_weight)
@@ -5252,7 +5252,7 @@ lang_split_key_euckr (const LANG_COLLATION * lang_coll, const bool is_desc, cons
 	  str1_next = intl_nextchar_euc (str1, &char1_size);
 	  if (*str1 == ASCII_SPACE || *str1 == 0 || (*str1 == EUC_SPACE && char1_size == 2 && *(str1 + 1) == EUC_SPACE))
 	    {
-	      is_zero_weight = (weight[SPACE] == 0);
+	      is_zero_weight = 0;
 	    }
 	  str1 = str1_next;
 	  if (!is_zero_weight)

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -5073,12 +5073,12 @@ lang_split_key_w_exp (const LANG_COLLATION * lang_coll, const bool is_desc, cons
       w2 = UCA_GET_L1_W (uca_w_l13_2[ce_index2]);
 
       /* ignore zero weights (unless character is space) */
-      if (w1 == 0)
+      if (w1 == 0 && *str1 != ASCII_SPACE)
 	{
 	  ce_index1++;
 	  num_ce1--;
 
-	  if (w2 == 0)
+	  if (w2 == 0 && *str2 != ASCII_SPACE)
 	    {
 	      ce_index2++;
 	      num_ce2--;
@@ -5086,7 +5086,7 @@ lang_split_key_w_exp (const LANG_COLLATION * lang_coll, const bool is_desc, cons
 
 	  goto read_weights1;
 	}
-      else if (w2 == 0)
+      else if (w2 == 0 && *str2 != ASCII_SPACE)
 	{
 	  ce_index2++;
 	  num_ce2--;

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -4939,7 +4939,7 @@ lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const
 	{
 	  w2 = lang_get_w_first_el (coll, str2, CAST_BUFLEN (str2_end - str2), &str2_next, ignore_trailing_space);
 	  str2 = str2_next;
-	  if (w2 != 0 && w2 != ASCII_SPACE)
+	  if (w2 != 0)
 	    {
 	      break;
 	    }
@@ -4956,7 +4956,7 @@ lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const
 	{
 	  w1 = lang_get_w_first_el (coll, str1, CAST_BUFLEN (str1_end - str1), &str1_next, ignore_trailing_space);
 	  str1 = str1_next;
-	  if (w1 != 0 && w2 != ASCII_SPACE)
+	  if (w1 != 0)
 	    {
 	      break;
 	    }
@@ -5073,12 +5073,12 @@ lang_split_key_w_exp (const LANG_COLLATION * lang_coll, const bool is_desc, cons
       w2 = UCA_GET_L1_W (uca_w_l13_2[ce_index2]);
 
       /* ignore zero weights (unless character is space) */
-      if (w1 == 0 && *str1 != ASCII_SPACE)
+      if (w1 == 0)
 	{
 	  ce_index1++;
 	  num_ce1--;
 
-	  if (w2 == 0 && *str2 != ASCII_SPACE)
+	  if (w2 == 0)
 	    {
 	      ce_index2++;
 	      num_ce2--;
@@ -5086,7 +5086,7 @@ lang_split_key_w_exp (const LANG_COLLATION * lang_coll, const bool is_desc, cons
 
 	  goto read_weights1;
 	}
-      else if (w2 == 0 && *str2 != ASCII_SPACE)
+      else if (w2 == 0)
 	{
 	  ce_index2++;
 	  num_ce2--;
@@ -5229,7 +5229,7 @@ lang_split_key_euckr (const LANG_COLLATION * lang_coll, const bool is_desc, cons
 	  str2_next = intl_nextchar_euc (str2, &char2_size);
 	  if (*str2 == ASCII_SPACE || *str2 == 0 || (*str2 == EUC_SPACE && char2_size == 2 && *(str2 + 1) == EUC_SPACE))
 	    {
-	      is_zero_weight = 1;
+	      is_zero_weight = (weight[SPACE] == 0);
 	    }
 	  str2 = str2_next;
 	  if (!is_zero_weight)
@@ -5252,7 +5252,7 @@ lang_split_key_euckr (const LANG_COLLATION * lang_coll, const bool is_desc, cons
 	  str1_next = intl_nextchar_euc (str1, &char1_size);
 	  if (*str1 == ASCII_SPACE || *str1 == 0 || (*str1 == EUC_SPACE && char1_size == 2 && *(str1 + 1) == EUC_SPACE))
 	    {
-	      is_zero_weight = 1;
+	      is_zero_weight = (weight[SPACE] == 0);
 	    }
 	  str1 = str1_next;
 	  if (!is_zero_weight)

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -4719,7 +4719,7 @@ lang_split_key_iso (const LANG_COLLATION * lang_coll, const bool is_desc, const 
   const unsigned char *str1_end, *str2_end;
   const unsigned char *str1_begin, *str2_begin;
   int key_size;
-  const unsigned int *weight = (ignore_trailing_space) ? lang_coll->coll.weights_ti : lang_coll->coll.weights;
+  const unsigned int *weight = lang_coll->coll.weights_ti;
 
   assert (key != NULL);
   assert (byte_size != NULL);
@@ -4811,7 +4811,7 @@ lang_split_key_byte (const LANG_COLLATION * lang_coll, const bool is_desc, const
   const unsigned char *str1_begin, *str2_begin;
   unsigned int w1, w2;
   int key_size;
-  const unsigned int *weight = (ignore_trailing_space) ? lang_coll->coll.weights_ti : lang_coll->coll.weights;
+  const unsigned int *weight = lang_coll->coll.weights_ti;
 
   assert (key != NULL);
   assert (byte_size != NULL);
@@ -4917,8 +4917,8 @@ lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const
 
   for (; str1 < str1_end && str2 < str2_end;)
     {
-      w1 = lang_get_w_first_el (coll, str1, CAST_BUFLEN (str1_end - str1), &str1_next, ignore_trailing_space);
-      w2 = lang_get_w_first_el (coll, str2, CAST_BUFLEN (str2_end - str2), &str2_next, ignore_trailing_space);
+      w1 = lang_get_w_first_el (coll, str1, CAST_BUFLEN (str1_end - str1), &str1_next, true);
+      w2 = lang_get_w_first_el (coll, str2, CAST_BUFLEN (str2_end - str2), &str2_next, true);
 
       if (w1 != w2)
 	{
@@ -4937,9 +4937,9 @@ lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const
       /* common part plus a character with non-zero weight from str2 */
       while (str2 < str2_end)
 	{
-	  w2 = lang_get_w_first_el (coll, str2, CAST_BUFLEN (str2_end - str2), &str2_next, ignore_trailing_space);
+	  w2 = lang_get_w_first_el (coll, str2, CAST_BUFLEN (str2_end - str2), &str2_next, true);
 	  str2 = str2_next;
-	  if (w2 != 0 && w2 != ASCII_SPACE)
+	  if (w2 != 0)
 	    {
 	      break;
 	    }
@@ -4954,9 +4954,9 @@ lang_split_key_utf8 (const LANG_COLLATION * lang_coll, const bool is_desc, const
       /* common part plus a character with non-zero weight from str1 */
       while (str1 < str1_end)
 	{
-	  w1 = lang_get_w_first_el (coll, str1, CAST_BUFLEN (str1_end - str1), &str1_next, ignore_trailing_space);
+	  w1 = lang_get_w_first_el (coll, str1, CAST_BUFLEN (str1_end - str1), &str1_next, true);
 	  str1 = str1_next;
-	  if (w1 != 0 && w2 != ASCII_SPACE)
+	  if (w1 != 0)
 	    {
 	      break;
 	    }
@@ -5073,12 +5073,12 @@ lang_split_key_w_exp (const LANG_COLLATION * lang_coll, const bool is_desc, cons
       w2 = UCA_GET_L1_W (uca_w_l13_2[ce_index2]);
 
       /* ignore zero weights (unless character is space) */
-      if (w1 == 0 && *str1 != ASCII_SPACE)
+      if (w1 == 0)
 	{
 	  ce_index1++;
 	  num_ce1--;
 
-	  if (w2 == 0 && *str2 != ASCII_SPACE)
+	  if (w2 == 0)
 	    {
 	      ce_index2++;
 	      num_ce2--;
@@ -5086,7 +5086,7 @@ lang_split_key_w_exp (const LANG_COLLATION * lang_coll, const bool is_desc, cons
 
 	  goto read_weights1;
 	}
-      else if (w2 == 0 && *str2 != ASCII_SPACE)
+      else if (w2 == 0)
 	{
 	  ce_index2++;
 	  num_ce2--;
@@ -5194,7 +5194,7 @@ lang_split_key_euckr (const LANG_COLLATION * lang_coll, const bool is_desc, cons
   int key_size, char1_size, char2_size;
   const unsigned char *str1_end, *str2_end;
   const unsigned char *str1_begin, *str2_begin;
-  const unsigned int *weight = (ignore_trailing_space) ? lang_coll->coll.weights_ti : lang_coll->coll.weights;
+  const unsigned int *weight = lang_coll->coll.weights_ti;
 
   assert (key != NULL);
   assert (byte_size != NULL);
@@ -5229,7 +5229,7 @@ lang_split_key_euckr (const LANG_COLLATION * lang_coll, const bool is_desc, cons
 	  str2_next = intl_nextchar_euc (str2, &char2_size);
 	  if (*str2 == ASCII_SPACE || *str2 == 0 || (*str2 == EUC_SPACE && char2_size == 2 && *(str2 + 1) == EUC_SPACE))
 	    {
-	      is_zero_weight = 1;
+	      is_zero_weight = (weight[SPACE] == 0);
 	    }
 	  str2 = str2_next;
 	  if (!is_zero_weight)
@@ -5252,7 +5252,7 @@ lang_split_key_euckr (const LANG_COLLATION * lang_coll, const bool is_desc, cons
 	  str1_next = intl_nextchar_euc (str1, &char1_size);
 	  if (*str1 == ASCII_SPACE || *str1 == 0 || (*str1 == EUC_SPACE && char1_size == 2 && *(str1 + 1) == EUC_SPACE))
 	    {
-	      is_zero_weight = 1;
+	      is_zero_weight = (weight[SPACE] == 0);
 	    }
 	  str1 = str1_next;
 	  if (!is_zero_weight)

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -599,38 +599,46 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
       /* We need to implicitly trim both strings since we don't want padding for the result (its of varying type) and
        * since padding can mask the logical end of both of the strings.  Trimming depends on codeset. */
 
-      if (pad_size == 1)
+      if (!ignore_trailing_space)
 	{
-	  for (t = string1 + (size1 - 1); t >= string1 && *t == pad[0]; t--, size1--)
-	    {
-	      ;
-	    }
-	  for (t = string2 + (size2 - 1); t >= string2 && *t == pad[0]; t--, size2--)
-	    {
-	      ;
-	    }
+	  ti = (db_string1->domain.char_info.type == DB_TYPE_CHAR
+		|| db_string1->domain.char_info.type == DB_TYPE_NCHAR);
 	}
-      else
+      if (ti)
 	{
-	  assert (pad_size == 2);
-
-	  for (t = string1 + (size1 - 2); t >= string1 && *t == pad[0] && *(t + 1) == pad[1];
-	       t--, t--, size1--, size1--)
+	  if (pad_size == 1)
 	    {
-	      ;
+	      for (t = string1 + (size1 - 1); t >= string1 && *t == pad[0]; t--, size1--)
+		{
+		  ;
+		}
+	      for (t = string2 + (size2 - 1); t >= string2 && *t == pad[0]; t--, size2--)
+		{
+		  ;
+		}
 	    }
-
-	  for (t = string2 + (size2 - 2); t >= string2 && *t == pad[0] && *(t + 1) == pad[1];
-	       t--, t--, size2--, size2--)
+	  else
 	    {
-	      ;
-	    }
+	      assert (pad_size == 2);
 
-	  if (codeset == INTL_CODESET_KSC5601_EUC)
-	    {
-	      /* trim also ASCII space */
-	      intl_pad_char (INTL_CODESET_ISO88591, pad, &pad_size);
-	      goto trim_again;
+	      for (t = string1 + (size1 - 2); t >= string1 && *t == pad[0] && *(t + 1) == pad[1];
+		   t--, t--, size1--, size1--)
+		{
+		  ;
+		}
+
+	      for (t = string2 + (size2 - 2); t >= string2 && *t == pad[0] && *(t + 1) == pad[1];
+		   t--, t--, size2--, size2--)
+		{
+		  ;
+		}
+
+	      if (codeset == INTL_CODESET_KSC5601_EUC)
+		{
+		  /* trim also ASCII space */
+		  intl_pad_char (INTL_CODESET_ISO88591, pad, &pad_size);
+		  goto trim_again;
+		}
 	    }
 	}
 
@@ -693,11 +701,6 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
 	}
       else
 	{
-	  if (!ignore_trailing_space)
-	    {
-	      ti = (db_string1->domain.char_info.type == DB_TYPE_CHAR
-		    || db_string1->domain.char_info.type == DB_TYPE_NCHAR);
-	    }
 	  error_status = QSTR_SPLIT_KEY (collation_id, key_domain->is_desc, string1, size1, string2, size2, &key,
 					 &result_size, ti);
 	}

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -601,8 +601,9 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
 
       if (!ignore_trailing_space)
 	{
-	  ti = (db_string1->domain.char_info.type == DB_TYPE_CHAR
-		|| db_string1->domain.char_info.type == DB_TYPE_NCHAR);
+	  ti = (db_string1->domain.char_info.type == DB_TYPE_CHAR || db_string1->domain.char_info.type == DB_TYPE_NCHAR)
+	    && (db_string2->domain.char_info.type == DB_TYPE_CHAR
+		|| db_string2->domain.char_info.type == DB_TYPE_NCHAR);
 	}
       if (ti)
 	{
@@ -702,7 +703,7 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
       else
 	{
 	  error_status = QSTR_SPLIT_KEY (collation_id, key_domain->is_desc, string1, size1, string2, size2, &key,
-					 &result_size, ti);
+					 &result_size, true);
 	}
       assert (error_status == NO_ERROR);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24088

cubrid createdb testdb ko_KR.utf8

csql>
create table tt (c1 varchar(50), c2 int);

insert into tt (
    select cast(rownum as varchar(50)), rownum from _db_class a, _db_class b, _db_class c
    union
    select cast(rownum || '  ' as varchar(50)), rownum from _db_class a, _db_class b
);

CREATE INDEX idx_tt on tt (c1);

ERROR: SYSTEM ERROR: Unable to load B+tree.

The error is caused by assert_release at **btree_get_prefix_separator** ,line 11805 or 11813.
In varchar type, not allowed ignoring trailing space as default configuration, but at splitting non-leaf node the trailing space is ignored.
So, the key comparing is not correct to find prefix of non-lead node.
I modified the code to split non-leaf node correctly not to ignore trailing space for VARCHAR type.