### PR TITLE
[LETS-250] transform global variable into a pointer and only initialize on transaction server

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -125,7 +125,9 @@ int init_server_type (const char *db_name)
 #endif
   if (g_server_type == SERVER_TYPE_TRANSACTION)
     {
-      er_code = ats_Gl.boot (db_name);
+      assert (ats_Gl == nullptr);
+      ats_Gl.reset (new active_tran_server ());
+      er_code = ats_Gl->boot (db_name);
     }
   else
     {
@@ -140,7 +142,7 @@ int init_server_type (const char *db_name)
       if (g_server_type == SERVER_TYPE_TRANSACTION)
 	{
 	  er_log_debug (ARG_FILE_LINE, "Starting server type: %s transaction\n",
-			transaction_server_type_to_string (get_transaction_server_type()));
+			transaction_server_type_to_string (get_transaction_server_type ()));
 	}
       else
 	{
@@ -169,7 +171,8 @@ void finalize_server_type ()
 {
   if (get_server_type () == SERVER_TYPE_TRANSACTION)
     {
-      ats_Gl.disconnect_page_server ();
+      ats_Gl->disconnect_page_server ();
+      ats_Gl.reset (nullptr);
     }
   else if (get_server_type () == SERVER_TYPE_PAGE)
     {
@@ -212,7 +215,7 @@ bool is_tran_server_with_remote_storage ()
 
   if (get_server_type () == SERVER_TYPE_TRANSACTION)
     {
-      return ats_Gl.uses_remote_storage ();
+      return ats_Gl->uses_remote_storage ();
     }
   return false;
 }

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -31,7 +31,7 @@
 #include <string>
 #include <utility>
 
-active_tran_server ats_Gl;
+std::unique_ptr<active_tran_server> ats_Gl;
 
 bool
 active_tran_server::uses_remote_storage () const

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -43,7 +43,7 @@ class active_tran_server : public tran_server
     bool m_uses_remote_storage = false;
 };
 
-extern active_tran_server ats_Gl;
+extern std::unique_ptr<active_tran_server> ats_Gl;
 
 #endif // !_ACTIVE_TRAN_SERVER_HPP_
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -7928,8 +7928,8 @@ pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * 
   bool is_tran_server = get_server_type () == SERVER_TYPE_TRANSACTION;
   bool is_page_server = get_server_type () == SERVER_TYPE_PAGE;
   bool is_temporary_page = pgbuf_is_temporary_volume (vpid->volid);
-  bool is_using_local_storage = is_page_server || !ats_Gl.uses_remote_storage ();
-  bool request_from_ps = is_tran_server && ats_Gl.is_page_server_connected () && !is_temporary_page;
+  bool is_using_local_storage = is_page_server || !ats_Gl->uses_remote_storage ();
+  bool request_from_ps = is_tran_server && ats_Gl->is_page_server_connected () && !is_temporary_page;
   bool read_from_local = is_using_local_storage || is_temporary_page;
   int error_code = NO_ERROR;
 
@@ -7945,7 +7945,7 @@ pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * 
   if (request_from_ps)
     {
       pgbuf_request_data_page_from_page_server (vpid);
-      auto data_page = ats_Gl.get_data_page_broker ().wait_for_page (*vpid);
+      auto data_page = ats_Gl->get_data_page_broker ().wait_for_page (*vpid);
 
       if (read_from_local)
 	{
@@ -8009,7 +8009,7 @@ pgbuf_request_data_page_from_page_server (const VPID * vpid)
 
   // *INDENT-OFF*
   /* Send a request to Page Server for the Page. */
-  auto entry_state = ats_Gl.get_data_page_broker ().register_entry (*vpid);
+  auto entry_state = ats_Gl->get_data_page_broker ().register_entry (*vpid);
   assert (entry_state == page_broker_register_entry_state::ADDED);
 
   cubpacking::packer pac;
@@ -8025,7 +8025,7 @@ pgbuf_request_data_page_from_page_server (const VPID * vpid)
   cublog::lsa_utils::pack (pac, lsa);
 
   std::string message (buffer.get (), size);
-  ats_Gl.push_request (tran_to_page_request::SEND_DATA_PAGE_FETCH, std::move (message));
+  ats_Gl->push_request (tran_to_page_request::SEND_DATA_PAGE_FETCH, std::move (message));
   if (prm_get_bool_value (PRM_ID_ER_LOG_READ_DATA_PAGE))
     {
       _er_log_debug (ARG_FILE_LINE, "[READ DATA] Sent request for Page to Page Server. VPID: %d|%d\n", VPID_AS_ARGS (vpid));

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2382,7 +2382,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   if (get_server_type () == SERVER_TYPE_TRANSACTION)
     {
       // Log page broker is required to load log header.
-      ats_Gl.init_page_brokers ();
+      ats_Gl->init_page_brokers ();
     }
 #endif
 
@@ -3245,7 +3245,7 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
     }
   else if (get_server_type () == SERVER_TYPE_TRANSACTION)
     {
-      ats_Gl.finalize_page_brokers ();
+      ats_Gl->finalize_page_brokers ();
     }
 #endif
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1600,7 +1600,7 @@ logpb_fetch_header_from_page_server (LOG_HEADER * hdr, LOG_PAGE * log_pgptr)
   request_log_page_from_page_server (LOGPB_HEADER_PAGE_ID);
 
   std::shared_ptr<log_page_owner> brokered_log_hdr_page
-    = ats_Gl.get_log_page_broker ().wait_for_page (LOGPB_HEADER_PAGE_ID);
+    = ats_Gl->get_log_page_broker ().wait_for_page (LOGPB_HEADER_PAGE_ID);
 
   const LOG_PAGE *const log_hdr_page = brokered_log_hdr_page->get_log_page ();
   const LOG_HEADER *const log_hdr = reinterpret_cast<const LOG_HEADER*> (log_hdr_page->area);
@@ -2097,10 +2097,10 @@ request_log_page_from_page_server (LOG_PAGEID log_pageid)
   std::memcpy (buffer, &log_pageid, sizeof (log_pageid));
   std::string message (buffer, BIG_INT_SIZE);
 
-  if (ats_Gl.get_log_page_broker ().register_entry (log_pageid) == page_broker_register_entry_state::ADDED)
+  if (ats_Gl->get_log_page_broker ().register_entry (log_pageid) == page_broker_register_entry_state::ADDED)
     {
       // First to add an entry must also sent the request to the page server
-      ats_Gl.push_request (tran_to_page_request::SEND_LOG_PAGE_FETCH, std::move (message));
+      ats_Gl->push_request (tran_to_page_request::SEND_LOG_PAGE_FETCH, std::move (message));
 
       if (prm_get_bool_value (PRM_ID_ER_LOG_READ_LOG_PAGE))
         {
@@ -2151,7 +2151,7 @@ logpb_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, LOG_PAGEID pa
   //  3) PS or TS with local storage + not connected to PS: only read from file
 
   const SERVER_TYPE server_type = get_server_type ();
-  if (server_type == SERVER_TYPE_TRANSACTION && ats_Gl.is_page_server_connected ())
+  if (server_type == SERVER_TYPE_TRANSACTION && ats_Gl->is_page_server_connected ())
     {
       // context 1) or 2)
       request_log_page_from_page_server (pageid);
@@ -2170,11 +2170,11 @@ logpb_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, LOG_PAGEID pa
       read_from_disk = true;
     }
 
-  if (server_type == SERVER_TYPE_TRANSACTION && ats_Gl.is_page_server_connected ())
+  if (server_type == SERVER_TYPE_TRANSACTION && ats_Gl->is_page_server_connected ())
     {
       // *INDENT-OFF*
       std::shared_ptr<log_page_owner> brokered_log_page
-          = ats_Gl.get_log_page_broker ().wait_for_page (pageid);
+          = ats_Gl->get_log_page_broker ().wait_for_page (pageid);
       // *INDENT-ON*
       const LOG_PAGE *const log_page_from_page_server = brokered_log_page->get_log_page ();
       if (read_from_disk)
@@ -4309,7 +4309,7 @@ logpb_flush_pages (THREAD_ENTRY * thread_p, const LOG_LSA * flush_lsa)
 	}
 
       // *INDENT-OFF*
-      if (get_server_type () == SERVER_TYPE_TRANSACTION && ats_Gl.is_page_server_connected ())
+      if (get_server_type () == SERVER_TYPE_TRANSACTION && ats_Gl->is_page_server_connected ())
 	{
 	  log_Gl.wait_flushed_lsa (*flush_lsa);
 	  if (prm_get_bool_value (PRM_ID_ER_LOG_COMMIT_CONFIRM))


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-250

Avoid a crash in `tran_server::~tran_server` which does not expect to be called on a page server by not initializing `ats_Gl` global variable unless actually on an [active] transaction server.

