### PR TITLE
[LETS-228] Adapt cubrid_log_connect_server_internal to new server connection protocol

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -337,7 +337,9 @@ cubrid_log_connect_server_internal (char *host, int port, char *dbname)
   int err_code;
 
   char trace_errbuf[1024];
+  // *INDENT-OFF*
   std::string msg;
+  // *INDENT-ON*
 
   g_conn_entry = css_make_conn (INVALID_SOCKET);
   if (g_conn_entry == NULL)
@@ -346,11 +348,9 @@ cubrid_log_connect_server_internal (char *host, int port, char *dbname)
     }
 
   //client should connect to Transaction server
-  msg = ((char) SERVER_TYPE_TRANSACTION) + '0';
-  msg.append (dbname, std::strlen (dbname) + 1);
+  msg = css_build_message_for_server_connection (dbname, SERVER_TYPE_TRANSACTION);
   if (css_common_connect
-      (g_conn_entry, &rid, host, DATA_REQUEST, msg.c_str (), msg.length () + 1, port, g_connection_timeout,
-       true) == NULL)
+      (g_conn_entry, &rid, host, DATA_REQUEST, msg.c_str (), msg.length (), port, g_connection_timeout, true) == NULL)
     {
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT, trace_errbuf);
     }

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -41,6 +41,7 @@
 #include "network.h"
 #include "object_representation.h"
 #include "dbi.h"
+#include "server_type_enum.hpp"
 
 #define CUBRID_LOG_ERROR_HANDLING(e, v) \
   (err_code) = (e); \
@@ -336,6 +337,7 @@ cubrid_log_connect_server_internal (char *host, int port, char *dbname)
   int err_code;
 
   char trace_errbuf[1024];
+  std::string msg;
 
   g_conn_entry = css_make_conn (INVALID_SOCKET);
   if (g_conn_entry == NULL)
@@ -343,8 +345,12 @@ cubrid_log_connect_server_internal (char *host, int port, char *dbname)
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT, trace_errbuf);
     }
 
+  //client should connect to Transaction server
+  msg = ((char) SERVER_TYPE_TRANSACTION) + '0';
+  msg.append (dbname, std::strlen (dbname) + 1);
   if (css_common_connect
-      (g_conn_entry, &rid, host, DATA_REQUEST, dbname, strlen (dbname) + 1, port, g_connection_timeout, true) == NULL)
+      (g_conn_entry, &rid, host, DATA_REQUEST, msg.c_str (), msg.length () + 1, port, g_connection_timeout,
+       true) == NULL)
     {
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT, trace_errbuf);
     }

--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -441,6 +441,18 @@ css_read_one_request (CSS_CONN_ENTRY * conn, unsigned short *rid, int *request, 
 
   return rc;
 }
+// *INDENT-OFF*
+std::string
+css_build_message_for_server_connection (const char *server_name, SERVER_TYPE server_type)
+{
+  std::string msg;
+
+  msg = ((char) server_type) + '0';
+  msg.append (server_name, std::strlen (server_name) + 1);
+
+  return msg;
+}
+// *INDENT-ON*
 
 /*
  * css_receive_request () - "blocking" read for a new request
@@ -808,7 +820,9 @@ css_connect_to_cubrid_server (char *host_name, char *server_name, SERVER_TYPE se
   char *error_area;
   int error_length;
   int timeout = -1;
+  // *INDENT-OFF*
   std::string msg;
+  // *INDENT-ON*
 
   conn = css_make_conn (-1);
   if (conn == NULL)
@@ -823,8 +837,7 @@ css_connect_to_cubrid_server (char *host_name, char *server_name, SERVER_TYPE se
    * character to the numer related to the server type enum value, the rest of the
    * buffer space is used to copy the server name.
    */
-  msg = ((char) server_type) + '0';
-  msg.append (server_name, std::strlen (server_name) + 1);
+  msg = css_build_message_for_server_connection (server_name, server_type);
   retry_count = 0;
   if (css_server_connect (host_name, conn, msg.c_str (), &rid) == NULL)
     {

--- a/src/connection/connection_cl.h
+++ b/src/connection/connection_cl.h
@@ -74,4 +74,7 @@ extern int css_return_queued_error (CSS_CONN_ENTRY * conn, unsigned short reques
 				    int *rc);
 extern void css_remove_all_unexpected_packets (CSS_CONN_ENTRY * conn);
 extern int css_read_one_request (CSS_CONN_ENTRY * conn, unsigned short *rid, int *request, int *buffer_size);
+// *INDENT-OFF*
+extern std::string css_build_message_for_server_connection (const char *server_name, SERVER_TYPE server_type);
+// *INDENT-ON*
 #endif /* _CONNECTION_CL_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-228

Changed the connection protocol of cubrid_log to also send the server type when connecting.
As it is a client it can only connect to the transaction server.
