### PR TITLE
[LETS-198] Crash during initializating the communication between page server and transaction server

### DIFF
--- a/src/communication/request_client_server.hpp
+++ b/src/communication/request_client_server.hpp
@@ -253,7 +253,10 @@ namespace cubcomm
   template <typename MsgId>
   request_server<MsgId>::request_server (request_server &&other)
   {
-    assert (!other.m_thread.joinable ());   // cannot move if thread is started
+    // only movable if in idle phase
+    assert (!m_thread.joinable ());
+    assert (!other.m_thread.joinable ());
+
     m_channel = std::move (other.m_channel);
     m_request_handlers = std::move (other.m_request_handlers);
   }

--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -50,6 +50,8 @@ namespace cubcomm
       request_sync_client_server &operator = (request_sync_client_server &&) = delete;
 
     public:
+      void start ();
+
       /* only used by unit tests
        */
       std::string get_underlying_channel_id () const;
@@ -86,7 +88,12 @@ namespace cubcomm
 	assert (pair.second != nullptr);
 	m_conn->register_request_handler (pair.first, pair.second);
       }
+  }
 
+  template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
+  void
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::start ()
+  {
     m_conn->start_thread ();
     m_queue_autosend->start_thread ();
   }

--- a/src/communication/request_sync_send_queue.hpp
+++ b/src/communication/request_sync_send_queue.hpp
@@ -251,6 +251,8 @@ namespace cubcomm
   void
   request_queue_autosend<ReqQueue>::start_thread ()
   {
+    assert (false == m_thread.joinable ());
+
     m_shutdown = false;
     m_thread = std::thread (&request_queue_autosend<ReqQueue>::loop_send_requests, std::ref (*this));
   }

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2633,6 +2633,7 @@ css_process_server_server_connect (SOCKET master_fd)
 	}
       // *INDENT-ON*
       ps_Gl.set_active_tran_server_connection (std::move (chn));
+      ps_Gl.start ();
       break;
     default:
       assert (false);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -78,6 +78,13 @@ void page_server::set_active_tran_server_connection (cubcomm::channel &&chn)
   }));
 }
 
+void page_server::start ()
+{
+  assert (m_active_tran_server_conn != nullptr);
+
+  m_active_tran_server_conn->start ();
+}
+
 void page_server::disconnect_active_tran_server ()
 {
   if (m_active_tran_server_conn == nullptr)

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -46,6 +46,7 @@ class page_server
     ~page_server ();
 
     void set_active_tran_server_connection (cubcomm::channel &&chn);
+    void start ();
     void disconnect_active_tran_server ();
     bool is_active_tran_server_connected () const;
     void push_request_to_active_tran_server (page_to_tran_request reqid, std::string &&payload);

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -288,6 +288,7 @@ tran_server::connect_to_page_server (const cubcomm::node &node, const char *db_n
 		srv_chn.get_channel_id ().c_str ());
 
   m_page_server_conn_vec.emplace_back (new page_server_conn_t (std::move (srv_chn), get_request_handlers ()));
+  m_page_server_conn_vec.back ()->start ();
 
   return NO_ERROR;
 }

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -885,6 +885,7 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_one (
       { reqids_2_to_1::_2, req_handler_2 }
     })
   };
+  scs_one->start ();
 
   return scs_one;
 }
@@ -913,6 +914,7 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_two (
       { reqids_1_to_2::_1, req_handler_1 }
     })
   };
+  scs_two->start ();
 
   return scs_two;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-198

Page server sends confirmation back to active transaction server before setting up its resources that handle the connection.
Active transaction server almost immediately sends back a request for boot information.
The page server has crashed while handling the boot information request.

Implementation:
Fix the connection setup by sending back the confirmation only when it is safe to start handling requests.
Decouple request_sync_client_server initialization/configuration from it starting its internal threads with the help of an additional 'start' function.
As a result, request_sync_client_server only starts to process requests after it is fully constructed and initialized.

Other:
- added extra asserts
- adapted unit tests