### PR TITLE
[CBRD-24090] Add clone_script for Appveyor to update submodules except cubridmanager

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ matrix:
   fast_finish: true
 
 install:
-- ps: choco install ant --ignore-dependencies
+- ps: choco install ant --ignore-dependencies --no-progress
 - ps: $env:ANT_PATH="C:\ProgramData\chocolatey\lib\ant\bin\ant"
 
 clone_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,8 @@ matrix:
   fast_finish: true
 
 install:
-- cmd: choco install -y ant --package-parameters="/User"
+- ps: choco install ant --ignore-dependencies
+- ps: $env:ANT_PATH="C:\ProgramData\chocolatey\lib\ant\bin\ant"
 
 clone_script:
 - ps: >-

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,15 @@ matrix:
 install:
   - cinst ant -i
 
+clone_script:
+- cmd: >-
+    git clone -q --branch=%APPVEYOR_REPO_BRANCH% https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
+    cd %APPVEYOR_BUILD_FOLDER%
+    git checkout -qf %APPVEYOR_REPO_COMMIT%
+    git submodule sync
+    git submodule update --init
+    git rm -f cubridmanager
+
 build_script:
   - cmake -E make_directory build
   - cmake -E chdir build cmake -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ..

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ matrix:
   fast_finish: true
 
 install:
-  - cinst ant -i
+- cmd: choco install -y ant --package-parameters="/User"
 
 clone_script:
 - ps: >-

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,11 +14,11 @@ install:
 clone_script:
 - cmd: >-
     git clone -q --branch=%APPVEYOR_REPO_BRANCH% https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
-    cd %APPVEYOR_BUILD_FOLDER%
-    git checkout -qf %APPVEYOR_REPO_COMMIT%
-    git submodule sync
-    git submodule update --init
-    git rm -f cubridmanager
+    && cd %APPVEYOR_BUILD_FOLDER%
+    && git checkout -qf %APPVEYOR_REPO_COMMIT%
+    && git submodule sync
+    && git submodule update --init
+    && git rm -f cubridmanager
 
 build_script:
   - cmake -E make_directory build

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,13 +12,18 @@ install:
   - cinst ant -i
 
 clone_script:
-- cmd: >-
-    git clone -q --branch=%APPVEYOR_REPO_BRANCH% https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
-    && cd %APPVEYOR_BUILD_FOLDER%
-    && git checkout -qf %APPVEYOR_REPO_COMMIT%
-    && git submodule sync
-    && git submodule update --init
-    && git rm -f cubridmanager
+- ps: >-
+    if(-not $env:APPVEYOR_PULL_REQUEST_NUMBER) {
+      git clone -q --branch=$env:APPVEYOR_REPO_BRANCH https://github.com/$env:APPVEYOR_REPO_NAME.git $env:APPVEYOR_BUILD_FOLDER
+      cd $env:APPVEYOR_BUILD_FOLDER
+      git checkout -qf $env:APPVEYOR_REPO_COMMIT
+    } else {
+      git clone -q https://github.com/$env:APPVEYOR_REPO_NAME.git $env:APPVEYOR_BUILD_FOLDER
+      cd $env:APPVEYOR_BUILD_FOLDER
+      git fetch -q origin +refs/pull/$env:APPVEYOR_PULL_REQUEST_NUMBER/merge:
+      git checkout -qf FETCH_HEAD
+    }
+- cmd: git submodule update --init --recursive && git rm -f cubridmanager
 
 build_script:
   - cmake -E make_directory build


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24090

Added clone_script to update submodules except `cubridmanager`

Note that `cubrid-jdbc/build.bat` can't find ANT_HOME correctly. To detour this problem, I've set ANT_PATH directly.
```
call :FINDEXEC ant ANT_PATH "%ANT%"
if "%ANT_PATH%" == "" (
  if "%ANT_HOME%" == "" (
    echo "[ERROR] set environment variable is required. (ANT Or ANT_HOME)"
    GOTO :EOF 
  ) else (
    call :FINDEXEC ant ANT_PATH "%ANT_FILE%"  // ***** here should be call :FINDEXEC ant ANT_HOME "%ANT_FILE%"`
 )
)
```