### PR TITLE
[LETS-247] Finalize thread manager after dumping error message

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1420,7 +1420,6 @@ net_server_start (THREAD_ENTRY * thread_p, const char *server_name)
       status = 2;
     }
 
-  cubthread::finalize ();
   cubthread::internal_tasks_worker_pool::finalize ();
   csect_finalize_static_critical_sections ();
   (void) sync_finalize_sync_stats ();

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -438,9 +438,7 @@ main (int argc, char **argv)
 	PRINT_AND_LOG_ERR_MSG ("%s\n", er_msg ());
 	fflush (stderr);
       }
-    // *INDENT-OFF*
-    cubthread::finalize ();
-    // *INDENT-ON*
+    thread_finalize_manager ();
     er_final (ER_ALL_FINAL);
   }
 #if defined(WINDOWS)

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -438,6 +438,7 @@ main (int argc, char **argv)
 	PRINT_AND_LOG_ERR_MSG ("%s\n", er_msg ());
 	fflush (stderr);
       }
+    cubthread::finalize ();
     er_final (ER_ALL_FINAL);
   }
 #if defined(WINDOWS)

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -438,7 +438,9 @@ main (int argc, char **argv)
 	PRINT_AND_LOG_ERR_MSG ("%s\n", er_msg ());
 	fflush (stderr);
       }
+    // *INDENT-OFF*
     cubthread::finalize ();
+    // *INDENT-ON*
     er_final (ER_ALL_FINAL);
   }
 #if defined(WINDOWS)

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -663,3 +663,8 @@ void thread_initialize_manager (THREAD_ENTRY *&thread_p)
 {
   cubthread::initialize (thread_p);
 }
+
+void thread_finalize_manager ()
+{
+  cubthread::finalize ();
+}

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -364,6 +364,7 @@ namespace cubthread
 } // namespace cubthread
 
 void thread_initialize_manager (THREAD_ENTRY *&thread_p);
+void thread_finalize_manager ();
 
 //////////////////////////////////////////////////////////////////////////
 // alias functions to be used in C legacy code

--- a/win/libcubrid/libcubrid.def
+++ b/win/libcubrid/libcubrid.def
@@ -9,13 +9,14 @@ EXPORTS
 	util_log_write_errid
 	util_log_write_errstr
 	util_log_write_command
-    	er_final
+	er_final
 	er_init
 	er_msg
 	er_set
 	getopt_long
 	set_server_type
 	thread_initialize_manager
+	thread_finalize_manager
 
 ;
 ;   porting.h


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-247

When thread manager is finalized, the error context on the main thread is lost. Calling `er_msg()` without error context crashes intentionally.

Finalize thread manager after printing `er_msg()` to avoid a crash.

