### PR TITLE
[LETS-250] avoid assert in tran_server dtor when page server is stopped

### DIFF
--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -34,8 +34,8 @@ static void assert_is_tran_server ();
 
 tran_server::~tran_server ()
 {
-  assert (is_transaction_server () || !is_page_server_connected ());
-  if (is_transaction_server () && is_page_server_connected ())
+  assert (is_transaction_server () || m_page_server_conn_vec.empty ());
+  if (is_transaction_server () && !m_page_server_conn_vec.empty ())
     {
       disconnect_page_server ();
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-250

Temporarily avoid crash of page server upon close, caused by dtor of global static instance of active_tran_server - tran_server.
Subsequently, a refactoring will be implemented where a tran_server will not be created at all on the page server.
