### PR TITLE
[LETS-272] error during recovery analysis when a sysop expected to have postpone info does not have it

### DIFF
--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -345,17 +345,25 @@ namespace cublog
 	  }
 	tdes->rcv.sysop_start_postpone_lsa = sysop.sysop_start_postpone_lsa;
 	tdes->rcv.atomic_sysop_start_lsa = sysop.atomic_sysop_start_lsa;
-	LOG_LSA log_lsa_local = sysop.sysop_start_postpone_lsa;
-	LOG_REC_SYSOP_START_POSTPONE sysop_start_postpone;
-	int error_code = log_read_sysop_start_postpone (thread_p, &log_lsa_local, log_page_local, false, &sysop_start_postpone,
-			 NULL, NULL, NULL, NULL);
-	if (error_code != NO_ERROR)
+	if (!sysop.sysop_start_postpone_lsa.is_null ())
 	  {
-	    assert (false);
-	    return;
+	    LOG_LSA log_lsa_local = sysop.sysop_start_postpone_lsa;
+	    LOG_REC_SYSOP_START_POSTPONE sysop_start_postpone;
+	    const int error_code = log_read_sysop_start_postpone (thread_p, &log_lsa_local, log_page_local, false,
+				   &sysop_start_postpone, NULL, NULL, NULL, NULL);
+	    if (error_code != NO_ERROR)
+	      {
+		assert (false);
+		return;
+	      }
+	    tdes->topops.stack[tdes->topops.last].lastparent_lsa = sysop_start_postpone.sysop_end.lastparent_lsa;
+	    tdes->topops.stack[tdes->topops.last].posp_lsa = sysop_start_postpone.posp_lsa;
 	  }
-	tdes->topops.stack[tdes->topops.last].lastparent_lsa = sysop_start_postpone.sysop_end.lastparent_lsa;
-	tdes->topops.stack[tdes->topops.last].posp_lsa = sysop_start_postpone.posp_lsa;
+	else
+	  {
+	    tdes->topops.stack[tdes->topops.last].lastparent_lsa = sysop.atomic_sysop_start_lsa;
+	    tdes->topops.stack[tdes->topops.last].posp_lsa.set_null ();
+	  }
       }
   }
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9870,6 +9870,8 @@ log_read_sysop_start_postpone (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_P
 {
   int error_code = NO_ERROR;
 
+  assert (!log_lsa->is_null ());
+
   if (log_page->hdr.logical_pageid != log_lsa->pageid)
     {
       error_code = logpb_fetch_page (thread_p, log_lsa, LOG_CS_FORCE_USE, log_page);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-272

An uncommited transaction, that is executing either system operation postpone or an atomic system operation, is assumed to contain postpone information without actually checking. 

Tests:
- passed shell debug
