### PR TITLE
[APIS-882] cci unintentionally changes bind type short/ushort to int/uint and sends it to CAS

### DIFF
--- a/src/cci/cci_query_execute.c
+++ b/src/cci/cci_query_execute.c
@@ -6563,22 +6563,16 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
     }
 
   bind_value->u_type = u_type;
-  if (u_type == CCI_U_TYPE_SHORT)
-    {
-      bind_value->u_type = CCI_U_TYPE_INT;
-    }
-  else if (u_type == CCI_U_TYPE_USHORT)
-    {
-      bind_value->u_type = CCI_U_TYPE_UINT;
-    }
 
   switch (u_type)
     {
-    case CCI_U_TYPE_SHORT:
     case CCI_U_TYPE_INT:
-    case CCI_U_TYPE_USHORT:
     case CCI_U_TYPE_UINT:
       bind_value->size = NET_SIZE_INT;
+      break;
+    case CCI_U_TYPE_SHORT:
+    case CCI_U_TYPE_USHORT:
+      bind_value->size = NET_SIZE_SHORT;
       break;
     case CCI_U_TYPE_BIGINT:
     case CCI_U_TYPE_UBIGINT:
@@ -6704,9 +6698,7 @@ bind_value_to_net_buf (T_NET_BUF * net_buf, T_CCI_U_TYPE u_type, void *value, in
 	}
       break;
     case CCI_U_TYPE_INT:
-    case CCI_U_TYPE_SHORT:
     case CCI_U_TYPE_UINT:
-    case CCI_U_TYPE_USHORT:
       if (value == NULL)
 	{
 	  ADD_ARG_INT (net_buf, 0);
@@ -6714,6 +6706,17 @@ bind_value_to_net_buf (T_NET_BUF * net_buf, T_CCI_U_TYPE u_type, void *value, in
       else
 	{
 	  ADD_ARG_INT (net_buf, *((int *) value));
+	}
+      break;
+    case CCI_U_TYPE_SHORT:
+    case CCI_U_TYPE_USHORT:
+      if (value == NULL)
+	{
+	  ADD_ARG_SHORT (net_buf, 0);
+	}
+      else
+	{
+	  ADD_ARG_SHORT (net_buf, *((short *) value));
 	}
       break;
     case CCI_U_TYPE_FLOAT:

--- a/src/cci/cci_query_execute.h
+++ b/src/cci/cci_query_execute.h
@@ -225,6 +225,12 @@
 	  (OBJ_VAL).volid = macro_var_volid;		        \
 	} while (0)
 
+#define ADD_ARG_SHORT(BUF, VALUE)			\
+	do {					\
+	  net_buf_cp_int((BUF), NET_SIZE_SHORT);	\
+	  net_buf_cp_short((BUF), (VALUE));	\
+	} while (0)
+
 #define ADD_ARG_INT(BUF, VALUE)			\
 	do {					\
 	  net_buf_cp_int((BUF), NET_SIZE_INT);	\

--- a/src/cci/cci_query_execute.h
+++ b/src/cci/cci_query_execute.h
@@ -1,33 +1,21 @@
 /*
- * Copyright (C) 2008 Search Solution Corporation. 
- * Copyright (c) 2016 CUBRID Corporation.
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * - Redistributions of source code must retain the above copyright notice,
- *   this list of conditions and the following disclaimer.
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * - Redistributions in binary form must reproduce the above copyright notice,
- *   this list of conditions and the following disclaimer in the documentation
- *   and/or other materials provided with the distribution.
- *
- * - Neither the name of the <ORGANIZATION> nor the names of its contributors
- *   may be used to endorse or promote products derived from this software without
- *   specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
- * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
- * OF SUCH DAMAGE.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  *
  */
+
 
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-882

**Purpose**
When CCI_U_TYPE_SHORT is assigned to u_type of cci_bind_param() function, CCI sends CCI_U_TYPE_INT to CAS instead of CCI_U_TYPE_SHORT.
As a result, CAS receives the wrong type, CCI_U_TYPE_INT, instead of CCI_U_TYPE_SHORT.
This behavior can lead to errors in some situations, for example CAS Gateway to ODBC.

Since CCI_U_TYPE_INT and CCI_U_TYPE_SHORT are different types, they must be separated from each other.

**Implementation**
N/A

**Remarks**
N/A
