### PR TITLE
[CBRD-23842] fixes hanging when meets end_of_log record

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10538,9 +10538,8 @@ cdc_log_extract (THREAD_ENTRY * thread_p, LOG_LSA * process_lsa, CDC_LOGINFO_ENT
   tmpbuf_index = process_lsa->pageid % 2;
 
   log_rec_header = LOG_GET_LOG_RECORD_HEADER (log_page_p, process_lsa);
-  nx_rec_header = LOG_GET_LOG_RECORD_HEADER (log_page_p, &log_rec_header->forw_lsa);
 
-  if (nx_rec_header->type == LOG_END_OF_LOG || LSA_ISNULL (&log_rec_header->forw_lsa))
+  if (log_rec_header->type == LOG_END_OF_LOG || LSA_ISNULL (&log_rec_header->forw_lsa))
     {
       CDC_UPDATE_TEMP_LOGPAGE (thread_p, process_lsa, log_page_p);
       error = ER_CDC_NULL_EXTRACTION_LSA;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

Local buffer that contains a log page, where the current LSA exists, can not pointing next record in next log page. 

So, this PR does not attempt to read next log record for detecting end_of_log record. 

Describe here
