### PR TITLE
[LETS-187] Server files path initialization refactoring

### DIFF
--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -259,12 +259,12 @@ db_init (const char *program, int print_version, const char *dbname, const char 
   client_credential.program_name = program;
   client_credential.process_id = -1;
 
-  db_path_info.db_path = (char *) db_path;
-  db_path_info.vol_path = (char *) vol_path;
-  db_path_info.log_path = (char *) log_path;
-  db_path_info.lob_path = (char *) lob_path;
-  db_path_info.db_host = (char *) host_name;
-  db_path_info.db_comments = (char *) comments;
+  db_path_info.db_path = db_path;
+  db_path_info.vol_path = vol_path;
+  db_path_info.log_path = log_path;
+  db_path_info.lob_path = lob_path;
+  db_path_info.db_host = host_name;
+  db_path_info.db_comments = comments;
 
   error = boot_initialize_client (&client_credential, &db_path_info, (bool) overwrite, addmore_vols_file, npages,
 				  (PGLENGTH) desired_pagesize, log_npages, (PGLENGTH) desired_log_page_size,

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -821,7 +821,7 @@ boot_initialize_lob_path (const char *path_arg, const char *db_path, char *path_
       if (realpath (lob_dir_path, absolute_path_buf) != NULL
 	  && (stat (absolute_path_buf, &stat_buf) == 0 && S_ISDIR (stat_buf.st_mode)))
 #else
-      if (realpath (lob_dir_path, fixed_pathbuf) != NULL)
+      if (realpath (lob_dir_path, absolute_path_buf) != NULL)
 #endif
 	{
 	  // Conversion successful

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -231,6 +231,11 @@ static int boot_check_timezone_checksum (BOOT_CLIENT_CREDENTIAL * client_credent
 #endif
 static int boot_client_find_and_cache_class_oids (void);
 
+// *INDENT-OFF*
+static int boot_initialize_path (const char *path_arg, const char *default_path, char *path_out);
+static int boot_initialize_lob_path (const char *path_arg, const char *db_path, char *path_out);
+// *INDENT-ON*
+
 /*
  * boot_client () -
  *
@@ -321,6 +326,10 @@ boot_initialize_client (BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_DB_PATH
   char format[BOOT_FORMAT_MAX_LENGTH];
 #endif
 
+  std::string processed_db_path;
+  std::string processed_log_path;
+  std::string processed_lob_path;
+
   assert (client_credential != NULL);
   assert (db_path_info != NULL);
 
@@ -390,51 +399,26 @@ boot_initialize_client (BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_DB_PATH
 
   /* If db_path and/or log_path are NULL find the defaults */
 
-  if (db_path_info->db_path == NULL)
+  error_code = boot_initialize_path (db_path_info->db_path, NULL, boot_Db_path_buf);
+  if (error_code != NO_ERROR)
     {
-      db_path_info->db_path = getcwd (boot_Db_path_buf, PATH_MAX);
-      if (db_path_info->db_path == NULL)
-	{
-	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_BO_CWD_FAIL, 0);
-	  error_code = ER_BO_CWD_FAIL;
-	  goto error_exit;
-	}
+      goto error_exit;
     }
-  if (db_path_info->log_path == NULL)
-    {
-      /* assign the data volume directory */
-      strcpy (boot_Log_path_buf, db_path_info->db_path);
-      db_path_info->log_path = boot_Log_path_buf;
-    }
-  if (db_path_info->lob_path == NULL)
-    {
-      /* assign the data volume directory */
-      snprintf (boot_Lob_path_buf, sizeof (boot_Lob_path_buf), "%s%s%clob", LOB_PATH_DEFAULT_PREFIX,
-		db_path_info->db_path, PATH_SEPARATOR);
-      db_path_info->lob_path = boot_Lob_path_buf;
-    }
-  else
-    {
-      ES_TYPE es_type = es_get_type (db_path_info->lob_path);
+  db_path_info->db_path = boot_Db_path_buf;
 
-      switch (es_type)
-	{
-	case ES_NONE:
-	  /* prepend default prefix */
-	  snprintf (boot_Lob_path_buf, sizeof (boot_Lob_path_buf), "%s%s", LOB_PATH_DEFAULT_PREFIX,
-		    db_path_info->lob_path);
-	  db_path_info->lob_path = boot_Lob_path_buf;
-	  break;
-#if !defined (CUBRID_OWFS)
-	case ES_OWFS:
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ES_INVALID_PATH, 1, db_path_info->lob_path);
-	  error_code = ER_ES_INVALID_PATH;
-	  goto error_exit;
-#endif /* !CUBRID_OWFS */
-	default:
-	  break;
-	}
+  error_code = boot_initialize_path (db_path_info->log_path, db_path_info->db_path, boot_Log_path_buf);
+  if (error_code != NO_ERROR)
+    {
+      goto error_exit;
     }
+  db_path_info->log_path = boot_Log_path_buf;
+
+  error_code = boot_initialize_lob_path (db_path_info->lob_path, db_path_info->db_path, boot_Lob_path_buf);
+  if (error_code != NO_ERROR)
+    {
+      goto error_exit;
+    }
+  db_path_info->lob_path = boot_Lob_path_buf;
 
   /* make sure that the full path for the database is not too long */
   length = (unsigned int) (client_credential->db_name.length () + strlen (db_path_info->db_path) + 2);
@@ -724,6 +708,142 @@ error_exit:
     }
 
   return error_code;
+}
+
+static int
+boot_initialize_path (const char *path_arg, const char *default_path, char *path_out)
+{
+  // Process the path argument and:
+  //
+  //	- If no argument is given, use default path. If there is no default path, use working directory as path
+  //	- Convert to absolute path
+  //	- Remove useless path separators.
+  //
+
+  char workdir_buf[PATH_MAX];
+  memset (workdir_buf, 0, PATH_MAX);
+
+  const char *path = path_arg;
+  if (path == nullptr)
+    {
+      // No path argument, try default path.
+      if (default_path != NULL)
+	{
+	  path = default_path;
+	}
+      else
+	{
+	  // No default path, fall back to working directory
+	  path = getcwd (workdir_buf, PATH_MAX);
+	  if (path == nullptr)
+	    {
+	      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_BO_CWD_FAIL, 0);
+	      return ER_BO_CWD_FAIL;
+	    }
+	}
+    }
+
+  // convert to absolute path
+  char realpath_buf[PATH_MAX];
+  if (realpath (path, realpath_buf) != nullptr)
+    {
+      path = realpath_buf;
+    }
+  else
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_BO_DIRECTORY_DOESNOT_EXIST, 1, path);
+      return ER_BO_DIRECTORY_DOESNOT_EXIST;
+    }
+
+  // remove useless PATH_SEPARATOR
+  char remove_useless_sep_buf[PATH_MAX];
+  boot_remove_useless_path_separator (path, remove_useless_sep_buf);
+  path = remove_useless_sep_buf;
+  
+  // done
+  strcpy (path_out, path);
+  return NO_ERROR;
+}
+
+static int
+boot_initialize_lob_path (const char *path_arg, const char *db_path, char *path_out)
+{
+  // Process the path argument and generate a normalized path containing the external storage prefix.
+  char es_path[PATH_MAX];
+  ES_TYPE es_type = ES_NONE;
+
+  if (path_arg == NULL)
+    {
+      snprintf (es_path, sizeof (es_path), "%s%s%clob", LOB_PATH_DEFAULT_PREFIX, db_path,
+		PATH_SEPARATOR);
+      es_type = ES_DEFAULT_TYPE;
+    }
+  else
+    {
+      es_type = es_get_type (path_arg);
+      switch (es_type)
+	{
+	case ES_NONE:
+	  /* prepend default prefix */
+	  snprintf (es_path, sizeof (es_path), "%s%s", LOB_PATH_DEFAULT_PREFIX, path_arg);
+	  es_type = ES_DEFAULT_TYPE;
+	  break;
+#if !defined (CUBRID_OWFS)
+	case ES_OWFS:
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ES_INVALID_PATH, 1, path_arg);
+	  return ER_ES_INVALID_PATH;
+#endif /* !CUBRID_OWFS */
+	default:
+	  strncpy_bufsize (es_path, path_arg);
+	  break;
+	}
+    }
+
+  assert (es_type != ES_NONE);
+
+  // Get the path without the external storage prefix; the prefix ends with ':'
+  char *lob_dir_path = std::strchr (es_path, ':');
+  if (lob_dir_path == nullptr)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ES_INVALID_PATH, 1, es_path);
+      return ER_ES_INVALID_PATH;
+    }
+  // Move after ':'
+  ++lob_dir_path;
+
+  if (es_get_type (es_path) == ES_POSIX)
+    {
+      // Convert to absolute path and check it exists
+      char absolute_path_buf[PATH_MAX];
+
+#if defined (WINDOWS)
+      struct stat stat_buf;
+      if (realpath (lob_dir_path, absolute_path_buf) != NULL
+	  && (stat (absolute_path_buf, &stat_buf) == 0 && S_ISDIR (stat_buf.st_mode)))
+#else
+      if (realpath (lob_dir_path, fixed_pathbuf) != NULL)
+#endif
+	{
+	  // Conversion successful
+	}
+      else
+	{
+	  // Directory does not exist
+	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_BO_DIRECTORY_DOESNOT_EXIST, 1, lob_dir_path);
+	  if (mkdir (lob_dir_path, 0777) < 0)
+	    {
+	      cub_dirname_r (lob_dir_path, absolute_path_buf, PATH_MAX);
+	      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ES_GENERAL, 2, "POSIX", absolute_path_buf);
+	      return ER_ES_GENERAL;
+	    }
+	}
+
+      // Remove useless separators and save the value to lob_dir_path (inside es_path)
+      boot_remove_useless_path_separator (absolute_path_buf, lob_dir_path);
+    }
+
+  strcpy (path_out, es_path);
+  return NO_ERROR;
 }
 
 /*

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -231,10 +231,8 @@ static int boot_check_timezone_checksum (BOOT_CLIENT_CREDENTIAL * client_credent
 #endif
 static int boot_client_find_and_cache_class_oids (void);
 
-// *INDENT-OFF*
 static int boot_initialize_path (const char *path_arg, const char *default_path, char *path_out);
 static int boot_initialize_lob_path (const char *path_arg, const char *db_path, char *path_out);
-// *INDENT-ON*
 
 /*
  * boot_client () -
@@ -325,10 +323,6 @@ boot_initialize_client (BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_DB_PATH
 #if defined (CS_MODE)
   char format[BOOT_FORMAT_MAX_LENGTH];
 #endif
-
-  std::string processed_db_path;
-  std::string processed_log_path;
-  std::string processed_lob_path;
 
   assert (client_credential != NULL);
   assert (db_path_info != NULL);
@@ -710,16 +704,15 @@ error_exit:
   return error_code;
 }
 
+// Process the path argument and:
+//
+//	- If no argument is given, use default path. If there is no default path, use working directory as path
+//	- Convert to absolute path
+//	- Remove useless path separators.
+//
 static int
 boot_initialize_path (const char *path_arg, const char *default_path, char *path_out)
 {
-  // Process the path argument and:
-  //
-  //	- If no argument is given, use default path. If there is no default path, use working directory as path
-  //	- Convert to absolute path
-  //	- Remove useless path separators.
-  //
-
   char workdir_buf[PATH_MAX];
   memset (workdir_buf, 0, PATH_MAX);
 
@@ -765,10 +758,10 @@ boot_initialize_path (const char *path_arg, const char *default_path, char *path
   return NO_ERROR;
 }
 
+// Process the path argument and generate a normalized path containing the external storage prefix.
 static int
 boot_initialize_lob_path (const char *path_arg, const char *db_path, char *path_out)
 {
-  // Process the path argument and generate a normalized path containing the external storage prefix.
   char es_path[PATH_MAX];
   ES_TYPE es_type = ES_NONE;
 
@@ -802,7 +795,9 @@ boot_initialize_lob_path (const char *path_arg, const char *db_path, char *path_
   assert (es_type != ES_NONE);
 
   // Get the path without the external storage prefix; the prefix ends with ':'
+  // *INDENT-OFF*
   char *lob_dir_path = std::strchr (es_path, ':');
+  // *INDENT-ON*
   if (lob_dir_path == nullptr)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ES_INVALID_PATH, 1, es_path);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -218,7 +218,6 @@ static int boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_C
 static int boot_remove_all_volumes (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log_path,
 				    const char *log_prefix, bool dirty_rem, bool force_delete);
 static char *boot_volume_info_log_path (char *log_path);
-static void boot_remove_useless_path_separator (const char *path, char *new_path);
 static void boot_ctrl_c_in_init_server (int ignore_signo);
 
 #if defined(CUBRID_DEBUG)
@@ -591,100 +590,6 @@ xboot_add_volume_extension (THREAD_ENTRY * thread_p, DBDEF_VOL_EXT_INFO * ext_in
     }
   assert (volid != NULL_VOLID);
   return volid;
-}
-
-/*
- * boot_remove_useless_path_separator () - Remove useless PATH_SEPARATOR in path string
- *
- * return : true or false(in case of fail)
- *
- *   path(in): Original path.
- *   new_path(out): Transformed path.
- *
- * Note: This function removes useless PATH_SEPARATOR in path string.
- *       For example,
- *       /home3/CUBRID/DB/               -->  /home3/CUBRID/DB
- *       C:\CUBRID\\\Databases\\         -->  C:\CUBRID\Databases
- *       \\pooh\user\                    -->  \\pooh\user
- *
- *       After transform..
- *       If new path string is "/" or "\", don't remove the last slash.
- *       It is survived.
- */
-static void
-boot_remove_useless_path_separator (const char *path, char *new_path)
-{
-  int slash_num = 0;		/* path separator counter */
-
-  /* path must be not null */
-  assert (path != NULL);
-  assert (new_path != NULL);
-
-  /*
-   * Before transform.
-   *   / h o m e 3 / / w o r k / c u b r i d / / / w o r k /
-   *
-   * After transform.
-   *   / h o m e 3   / w o r k / c u b r i d     / w o r k
-   */
-
-  /* Consume the preceding continuous slash chars. */
-  while (*path == PATH_SEPARATOR)
-    {
-      slash_num++;
-      path++;
-    }
-
-  /* If there is preceding consumed slash, append PATH_SEPARATOR */
-  if (slash_num)
-    {
-      *new_path++ = PATH_SEPARATOR;
-#if defined(WINDOWS)
-      /*
-       * In Windows/NT,
-       * If first duplicated PATH_SEPARATORs are appeared, they are survived.
-       * For example,
-       * \\pooh\user\ -> \\pooh\user(don't touch the first duplicated PATH_SEPARATORs)
-       */
-      if (slash_num > 1)
-	{
-	  *new_path++ = PATH_SEPARATOR;
-	}
-#endif /* WINDOWS */
-    }
-
-  /* Initialize separator counter again. */
-  slash_num = 0;
-
-  /*
-   * If current character is PATH_SEPARATOR,
-   *    skip after increasing separator counter.
-   * If current character is normal character, copy to new_path.
-   */
-  while (*path)
-    {
-      if (*path == PATH_SEPARATOR)
-	{
-	  slash_num++;
-	}
-      else
-	{
-	  /*
-	   * If there is consumed slash, append PATH_SEPARATOR.
-	   * Initialize separator counter.
-	   */
-	  if (slash_num)
-	    {
-	      *new_path++ = PATH_SEPARATOR;
-	      slash_num = 0;
-	    }
-	  *new_path++ = *path;
-	}
-      path++;
-    }
-
-  /* Assure null terminated string */
-  *new_path = '\0';
 }
 
 /*
@@ -1510,20 +1415,14 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
   DB_INFO *dir = NULL;
   volatile int dbtxt_vdes = NULL_VOLDES;
   char vol_real_path[PATH_MAX];
-  char log_pathbuf[PATH_MAX];
-  char lob_pathbuf[LOB_PATH_PREFIX_MAX + PATH_MAX];
   char dbtxt_label[PATH_MAX];
-  char fixed_pathbuf[PATH_MAX];
   char original_namebuf[PATH_MAX];
 #if defined (NDEBUG)
   char format[BOOT_FORMAT_MAX_LENGTH];
 #endif
   int error_code;
   void (*old_ctrl_c_handler) (int sig_no) = SIG_ERR;
-  struct stat stat_buf;
   bool is_exist_volume;
-  const char *db_path, *log_path, *lob_path;
-  char *p;
   THREAD_ENTRY *thread_p = NULL;
 
   assert (client_credential != NULL);
@@ -1607,93 +1506,7 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
       goto exit_on_error;
     }
 
-  /*
-   * Make sure that the db_path and log_path and lob_path are the canonicalized
-   * absolute pathnames
-   */
-
-  memset (boot_Db_directory_path, 0, sizeof (boot_Db_directory_path));
-  memset (log_pathbuf, 0, sizeof (log_pathbuf));
-  memset (lob_pathbuf, 0, sizeof (lob_pathbuf));
-
-  /*
-   * for db path,
-   * convert to absolute path, remove useless PATH_SEPARATOR
-   */
-  db_path = db_path_info->db_path;
-  if (realpath (db_path, fixed_pathbuf) != NULL)
-    {
-      db_path = fixed_pathbuf;
-    }
-  else
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_BO_DIRECTORY_DOESNOT_EXIST, 1, db_path);
-      goto exit_on_error;
-    }
-  boot_remove_useless_path_separator (db_path, boot_Db_directory_path);
-  db_path = nullptr;		// unused henceforth
-
-  /*
-   * for log path,
-   * convert to absolute path, remove useless PATH_SEPARATOR
-   */
-  log_path = db_path_info->log_path;
-  if (realpath (log_path, fixed_pathbuf) != NULL)
-    {
-      log_path = fixed_pathbuf;
-    }
-  else
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_BO_DIRECTORY_DOESNOT_EXIST, 1, log_path);
-      goto exit_on_error;
-    }
-  boot_remove_useless_path_separator (log_path, log_pathbuf);
-
-  /*
-   * for lob path,
-   * convert to absolute path, remove useless PATH_SEPARATOR
-   */
-  lob_path = db_path_info->lob_path;
-  if (es_get_type (lob_path) == ES_NONE)
-    {
-      snprintf (lob_pathbuf, sizeof (lob_pathbuf), "%s%s", LOB_PATH_DEFAULT_PREFIX, lob_path);
-      p = strchr (lob_pathbuf, ':') + 1;
-    }
-  else
-    {
-      p = strchr (strcpy (lob_pathbuf, lob_path), ':') + 1;
-    }
-  lob_path = p;
-
-  if (lob_path == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ES_INVALID_PATH, 1, lob_pathbuf);
-      return NULL_TRAN_INDEX;
-    }
-
-  if (es_get_type (lob_pathbuf) == ES_POSIX)
-    {
-#if defined (WINDOWS)
-      if (realpath (lob_path, fixed_pathbuf) != NULL
-	  && (stat (fixed_pathbuf, &stat_buf) == 0 && S_ISDIR (stat_buf.st_mode)))
-#else
-      if (realpath (lob_path, fixed_pathbuf) != NULL)
-#endif
-	{
-	  lob_path = fixed_pathbuf;
-	}
-      else
-	{
-	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_BO_DIRECTORY_DOESNOT_EXIST, 1, lob_path);
-	  if (mkdir (lob_path, 0777) < 0)
-	    {
-	      cub_dirname_r (lob_path, fixed_pathbuf, PATH_MAX);
-	      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ES_GENERAL, 2, "POSIX", fixed_pathbuf);
-	      goto exit_on_error;
-	    }
-	}
-      boot_remove_useless_path_separator (lob_path, p);
-    }
+  strncpy_bufsize (boot_Db_directory_path, db_path_info->db_path);
 
   /*
    * Compose the full name of the database
@@ -1831,7 +1644,7 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
     }
 
   error_code =
-    logpb_check_exist_any_volumes (thread_p, boot_Db_full_name, log_pathbuf, log_prefix, vol_real_path,
+    logpb_check_exist_any_volumes (thread_p, boot_Db_full_name, db_path_info->log_path, log_prefix, vol_real_path,
 				   &is_exist_volume);
   if (error_code != NO_ERROR || is_exist_volume)
     {
@@ -1848,6 +1661,7 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
 	}
       else
 	{
+	  struct stat stat_buf;
 	  if (stat (vol_real_path, &stat_buf) != 0	/* file not exist */
 	      || S_ISDIR (stat_buf.st_mode))
 	    {			/* is directory */
@@ -1884,7 +1698,7 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
     {
       tran_index =
 	boot_create_all_volumes (thread_p, client_credential, db_path_info->db_comments, db_npages, file_addmore_vols,
-				 log_pathbuf, (const char *) log_prefix, log_npages, client_lock_wait,
+				 db_path_info->log_path, (const char *) log_prefix, log_npages, client_lock_wait,
 				 client_isolation);
 
       if (tran_index != NULL_TRAN_INDEX && !boot_Init_server_is_canceled)
@@ -1918,12 +1732,12 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
 	  if (db == NULL)
 	    {
 	      db =
-		cfg_add_db (&dir, client_credential->get_db_name (), boot_Db_directory_path, log_pathbuf, lob_pathbuf,
-			    db_path_info->db_host);
+		cfg_add_db (&dir, client_credential->get_db_name (), boot_Db_directory_path, db_path_info->log_path,
+			    db_path_info->lob_path, db_path_info->db_host);
 	    }
 	  else
 	    {
-	      cfg_update_db (db, boot_Db_directory_path, log_pathbuf, lob_pathbuf, db_path_info->db_host);
+	      cfg_update_db (db, boot_Db_directory_path, db_path_info->log_path, db_path_info->lob_path, db_path_info->db_host);
 	    }
 
 	  if (db == NULL || db->name == NULL || db->pathname == NULL || db->logpath == NULL || db->lobpath == NULL
@@ -1965,7 +1779,8 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
 
   if (tran_index == NULL_TRAN_INDEX || boot_Init_server_is_canceled)
     {
-      (void) boot_remove_all_volumes (thread_p, boot_Db_full_name, log_pathbuf, (const char *) log_prefix, true, true);
+      (void) boot_remove_all_volumes (thread_p, boot_Db_full_name, db_path_info->log_path, (const char *) log_prefix,
+				      true, true);
       if (boot_Init_server_is_canceled)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERRUPTED, 0);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-187

Move (and unify) the code managing the database path, the log path and the lob path respectively, from `boot_initialize_client` and `boot_initialize_server` to separate functions.

Other changes:

  - Move `boot_remove_useless_path_separator ()` to `boot.h` to be accessible on both `boot_cl` and `boot_sr`
  - Add `const` to `boot_db_path_info` fields.
  
 This change is a building block for creating a database with local permanent data and log files. The paths configuration is a common part that needs to be reused.