### PR TITLE
[CBRD-24097] Could not lookup the result cache entry for a query predicates with rownum.

### DIFF
--- a/src/base/memory_hash.c
+++ b/src/base/memory_hash.c
@@ -789,7 +789,7 @@ mht_compare_ptrs_are_equal (const void *key1, const void *key2)
 int
 mht_compare_dbvalues_are_equal (const void *key1, const void *key2)
 {
-  return ((key1 == key2) || (tp_value_compare ((DB_VALUE *) key1, (DB_VALUE *) key2, 0, 1) == DB_EQ));
+  return ((key1 == key2) || (tp_value_compare ((DB_VALUE *) key1, (DB_VALUE *) key2, 1, 1) == DB_EQ));
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24097

The query cache entry should be found from the hash table by the params with given query but if the params has a different type as INT an BIGINT, looking up is fail for comparing with no coercing.

The next query is an example shows this lookup fail.

applied configuration
```
cubrid.conf

max_query_cache_entries=1000
query_cache_size_in_pages=4000
```

applied table
```
create table tbl as select rownum as rn from db_class a, db_class b, db_class c;
create index cix_cub01 on tbl(rn);
```

applied query
```
csql>
csql> select /*+ query_cache */ count(*) from tbl a, tbl b where a.rn=b.rn and rownum<=9000;
csql> ;info qcache
csql> select /*+ query_cache */ count(*) from tbl a, tbl b where a.rn=b.rn and rownum<=9000;
csql> ;info qcache
```

The second query of the above's result cache should be looked up at query execution, but could not.

**Cause:**
The rownum is a bigint type, and the param type for "rownum <= 9000" in the user query is integer, but the type of param stored in the hash table is changed to bigint when cached.

The reason for changing to bigint is that in rownum <= 100 operation, rownum is bigint, so param value 9000 is coerced into bigint.

 

**Check point:**
qfile_compare_equal_db_value_array is used for comparing hash-key while looking up the hash table for result cache.

qfile_compare_equal_db_value_array calls mht_compare_dbvalues_are_equal for comparing keys, however mht_compare_dbvalues_are_equal calls tp_value_compare with "no coercing" option.

"no coercing" option is not allow DB values coerce including between INT and BIGINT.