### PR TITLE
[CBRD-23842] Fixed memory leaks in server-side processing for CDC 

### DIFF
--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -2236,6 +2236,8 @@ slog_supplement_statement (THREAD_ENTRY * thread_p, unsigned int rid, char *requ
 	}
 
       log_append_supplemental_info (thread_p, LOG_SUPPLEMENT_DDL, data_len, (void *) supplemental_data);
+
+      free_and_init (supplemental_data);
     }
 
 end:

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -13169,6 +13169,9 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       func_type = 7;
       ptr = or_pack_int (ptr, func_type);
       ptr = or_pack_string (ptr, line);
+
+      db_value_clear (&result);
+
       break;
     case DB_TYPE_TIMESTAMP:
       db_make_char (&format, strlen (timestamp_frmt), timestamp_frmt,
@@ -13181,6 +13184,8 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       func_type = 7;
       ptr = or_pack_int (ptr, func_type);
       ptr = or_pack_string (ptr, line);
+
+      db_value_clear (&result);
 
       break;
     case DB_TYPE_DATETIME:
@@ -13195,6 +13200,8 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       ptr = or_pack_int (ptr, func_type);
       ptr = or_pack_string (ptr, line);
 
+      db_value_clear (&result);
+
       break;
     case DB_TYPE_TIMESTAMPTZ:
       db_make_char (&format, strlen (timestamptz_frmt), timestamptz_frmt,
@@ -13208,6 +13215,8 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       ptr = or_pack_int (ptr, func_type);
       ptr = or_pack_string (ptr, line);
 
+      db_value_clear (&result);
+
       break;
     case DB_TYPE_DATETIMETZ:
       db_make_char (&format, strlen (datetimetz_frmt), datetimetz_frmt,
@@ -13219,6 +13228,8 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       func_type = 7;
       ptr = or_pack_int (ptr, func_type);
       ptr = or_pack_string (ptr, line);
+
+      db_value_clear (&result);
 
       break;
     case DB_TYPE_TIMESTAMPLTZ:
@@ -13235,6 +13246,8 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       ptr = or_pack_int (ptr, func_type);
       ptr = or_pack_string (ptr, line);
 
+      db_value_clear (&result);
+
       break;
     case DB_TYPE_DATETIMELTZ:
       db_make_char (&format, strlen (datetimeltz_frmt), datetimeltz_frmt,
@@ -13247,6 +13260,8 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       func_type = 7;
       ptr = or_pack_int (ptr, func_type);
       ptr = or_pack_string (ptr, line);
+
+      db_value_clear (&result);
 
       break;
     case DB_TYPE_DATE:
@@ -13261,6 +13276,8 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       func_type = 7;
       ptr = or_pack_int (ptr, func_type);
       ptr = or_pack_string (ptr, line);
+
+      db_value_clear (&result);
 
       break;
     case DB_TYPE_MONETARY:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

Remove memory leaks occurred in server side
* Free the allocated memory for supplemental log
* Free the memory allocated by internal functions like db_make_char()
