### PR TITLE
[LETS-275] writing to meta log is fatal only upon initialize

### DIFF
--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -226,7 +226,7 @@ extern void log_flush_daemon_get_stats (UINT64 * statsp);
 
 extern void log_update_global_btid_online_index_stats (THREAD_ENTRY * thread_p);
 
-extern void log_write_metalog_to_file ();
+extern void log_write_metalog_to_file (bool file_open_is_fatal);
 
 #if defined (SERVER_MODE)
 extern void cdc_daemons_init ();

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7089,7 +7089,7 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
   }
 
   // Flush meta log (and checkpoint info) to disk
-  log_write_metalog_to_file ();
+  log_write_metalog_to_file (false);
   detailed_er_log ("logpb_checkpoint: wrote metalog containing checkpoint information.\n");
 
   /*
@@ -7360,7 +7360,7 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
       }
     log_Gl.m_metainfo.add_checkpoint_info (trantable_checkpoint_lsa, std::move (trantable_checkpoint_info));
 
-    log_write_metalog_to_file ();
+    log_write_metalog_to_file (false);
 
     // function explicitly needs to be called in critical section-free context
     LOG_CS_EXIT (thread_p);
@@ -7380,7 +7380,7 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
     //    checkpoint and before deleting the outdated checkpoint) there can be at most two
     assert (log_Gl.m_metainfo.get_checkpoint_count () == 1);
 
-    log_write_metalog_to_file ();
+    log_write_metalog_to_file (false);
   }
 
   if (detailed_logging)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-275

Writing to metalog is done for the following purposes:
 - saving transaction table snapshot
 - registering the clean shutdown flag

Writing to metalog is considered a fatal error in all cases, as of now.

Some of the automated tests are flawed in the sense that, at the end, the script removes the database files before actually closing the server. With the introduction of the metalog, for the uses described above, writing the metalog causes many automated tests to cause core dumps.

Fix the scripted automated tests by only considering fatal the access of metalog upon initialization. All other writes are to be reported as non-fatal errors.
