### PR TITLE
[LETS-275] writing to meta log is fatal only upon initialize

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10694,7 +10694,6 @@ log_write_metalog_to_file (bool file_open_is_fatal)
     {
       const er_severity severity = file_open_is_fatal ? ER_FATAL_ERROR_SEVERITY : ER_ERROR_SEVERITY;
       er_set (severity, ARG_FILE_LINE, ER_LOG_MOUNT_FAIL, 1, log_Name_metainfo);
-      assert (false);
     }
   else
     {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10685,6 +10685,7 @@ log_read_metalog_from_file ()
 /*
  * log_write_metalog_to_file - Write meta log from log_Gl to disk
  *
+ * file_open_is_fatal (in): treat failure to open file as fatal error or not
  */
 void
 log_write_metalog_to_file (bool file_open_is_fatal)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-275

Writing to metalog is done for the following purposes:
 - saving transaction table snapshot
 - registering the clean shutdown flag

Writing to metalog is considered a fatal error in all cases, as of now.

Some of the automated tests are flawed in the sense that, at the end, the script removes the database files before actually closing the server. With the introduction of the metalog, for the uses described above, writing the metalog causes many automated tests to cause core dumps.

Fix the scripted automated tests by only considering fatal the access of metalog upon initialization. All other writes are to be reported as non-fatal errors.


