### PR TITLE
[CBRD-24087]  Improvement of oid_compare() function and comparison logic of codes using this function.

### DIFF
--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -8776,7 +8776,7 @@ sch_exported_keys_or_cross_reference (T_NET_BUF * net_buf, bool find_cross_ref, 
     {
       if (find_cross_ref)
 	{
-	  if (WS_ISVID (fktable_obj) || oid_compare (WS_REAL_OID (fktable_obj), &(fk_info->self_oid)) != 0)
+	  if (WS_ISVID (fktable_obj) || oid_is_equal_value (WS_REAL_OID (fktable_obj), &(fk_info->self_oid)) == false)
 	    {
 	      continue;
 	    }

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -8776,7 +8776,7 @@ sch_exported_keys_or_cross_reference (T_NET_BUF * net_buf, bool find_cross_ref, 
     {
       if (find_cross_ref)
 	{
-	  if (WS_ISVID (fktable_obj) || oid_is_equal_value (WS_REAL_OID (fktable_obj), &(fk_info->self_oid)) == false)
+	  if (WS_ISVID (fktable_obj) || OID_EQ (WS_REAL_OID (fktable_obj), &(fk_info->self_oid)) == false)
 	    {
 	      continue;
 	    }

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -10316,24 +10316,17 @@ tp_value_change_coll_and_codeset (DB_VALUE * src, DB_VALUE * dest, int coll_id, 
 static DB_VALUE_COMPARE_RESULT
 oidcmp (OID * oid1, OID * oid2)
 {
-  DB_VALUE_COMPARE_RESULT status;
-  int c;
-
-  c = oid_compare (oid1, oid2);
+  int c = oid_compare (oid1, oid2);
   if (c < 0)
     {
-      status = DB_LT;
+      return DB_LT;
     }
   else if (c > 0)
     {
-      status = DB_GT;
-    }
-  else
-    {
-      status = DB_EQ;
+      return DB_GT;
     }
 
-  return status;
+  return DB_EQ;
 }
 
 /*

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -5408,7 +5408,6 @@ mr_index_cmpdisk_object (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coer
 static DB_VALUE_COMPARE_RESULT
 mr_data_cmpdisk_object (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, int total_order, int *start_colp)
 {
-  DB_VALUE_COMPARE_RESULT c;
   OID o1, o2;
   int oidc;
 
@@ -5420,9 +5419,7 @@ mr_data_cmpdisk_object (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coerc
    * representation of objects is an OID, this is a valid optimization */
 
   oidc = oid_compare (&o1, &o2);
-  c = MR_CMP_RETURN_CODE (oidc);
-
-  return c;
+  return MR_CMP_RETURN_CODE (oidc);
 }
 
 static DB_VALUE_COMPARE_RESULT
@@ -6748,7 +6745,6 @@ mr_index_readval_oid (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int si
 static DB_VALUE_COMPARE_RESULT
 mr_index_cmpdisk_oid (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, int total_order, int *start_colp)
 {
-  DB_VALUE_COMPARE_RESULT c;
   OID o1, o2;
   int oidc;
 
@@ -6763,15 +6759,12 @@ mr_index_cmpdisk_oid (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercio
   COPYMEM (short, &o2.volid, (char *) mem2 + OR_OID_VOLID);
 
   oidc = oid_compare (&o1, &o2);
-  c = MR_CMP_RETURN_CODE (oidc);
-
-  return c;
+  return MR_CMP_RETURN_CODE (oidc);
 }
 
 static DB_VALUE_COMPARE_RESULT
 mr_data_cmpdisk_oid (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion, int total_order, int *start_colp)
 {
-  DB_VALUE_COMPARE_RESULT c;
   OID o1, o2;
   int oidc;
 
@@ -6781,15 +6774,12 @@ mr_data_cmpdisk_oid (void *mem1, void *mem2, TP_DOMAIN * domain, int do_coercion
   OR_GET_OID (mem2, &o2);
 
   oidc = oid_compare (&o1, &o2);
-  c = MR_CMP_RETURN_CODE (oidc);
-
-  return c;
+  return MR_CMP_RETURN_CODE (oidc);
 }
 
 static DB_VALUE_COMPARE_RESULT
 mr_cmpval_oid (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total_order, int *start_colp, int collation)
 {
-  DB_VALUE_COMPARE_RESULT c;
   OID *oid1, *oid2;
   int oidc;
 
@@ -6802,9 +6792,7 @@ mr_cmpval_oid (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total_
     }
 
   oidc = oid_compare (oid1, oid2);
-  c = MR_CMP_RETURN_CODE (oidc);
-
-  return c;
+  return MR_CMP_RETURN_CODE (oidc);
 }
 
 /*

--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -4751,7 +4751,7 @@ tr_check_recursivity (OID oid, OID stack[], int stack_size, bool is_statement)
   min = MIN (stack_size, TR_MAX_RECURSION_LEVEL);
   for (i = 0; i < min; i++)
     {
-      if (oid_compare (&oid, &stack[i]) == 0)
+      if (oid_is_equal_value (&oid, &stack[i]))
 	{
 	  /* this is a STATEMENT trigger, we should not go further with the action, but we should allow the call to
 	   * succeed.

--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -4751,7 +4751,7 @@ tr_check_recursivity (OID oid, OID stack[], int stack_size, bool is_statement)
   min = MIN (stack_size, TR_MAX_RECURSION_LEVEL);
   for (i = 0; i < min; i++)
     {
-      if (oid_is_equal_value (&oid, &stack[i]))
+      if (OID_EQ (&oid, &stack[i]))
 	{
 	  /* this is a STATEMENT trigger, we should not go further with the action, but we should allow the call to
 	   * succeed.

--- a/src/object/work_space.c
+++ b/src/object/work_space.c
@@ -443,6 +443,10 @@ ws_insert_mop_on_hash_link (MOP mop, int slot)
   for (p = ws_Mop_table[slot].head; p != NULL; prev = p, p = p->hash_link)
     {
       c = oid_compare (WS_OID (mop), WS_OID (p));
+      if (c > 0)
+	{
+	  continue;
+	}
 
       if (c == 0)
 	{
@@ -474,8 +478,7 @@ ws_insert_mop_on_hash_link (MOP mop, int slot)
 
 	  break;
 	}
-
-      if (c < 0)
+      else			/* if (c < 0) */
 	{
 	  break;
 	}
@@ -584,13 +587,9 @@ ws_mop_if_exists (OID * oid)
 	  for (mop = ws_Mop_table[slot].head; mop != NULL; mop = mop->hash_link)
 	    {
 	      c = oid_compare (oid, WS_OID (mop));
-	      if (c == 0)
+	      if (c <= 0)
 		{
-		  return mop;
-		}
-	      else if (c < 0)
-		{
-		  return NULL;
+		  return (c == 0) ? mop : NULL;
 		}
 	    }
 	}
@@ -652,7 +651,11 @@ ws_mop (const OID * oid, MOP class_mop)
 	  for (mop = ws_Mop_table[slot].head; mop != NULL; prev = mop, mop = mop->hash_link)
 	    {
 	      c = oid_compare (oid, WS_OID (mop));
-	      if (c == 0)
+	      if (c > 0)
+		{
+		  continue;
+		}
+	      else if (c == 0)
 		{
 		  if (mop->decached)
 		    {
@@ -684,7 +687,7 @@ ws_mop (const OID * oid, MOP class_mop)
 		    }
 		  return mop;
 		}
-	      else if (c < 0)
+	      else		/* if (c < 0) */
 		{
 		  /* find the node which is greater than I */
 		  break;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -23107,7 +23107,8 @@ pt_find_oid_scan_block (XASL_NODE * xasl, OID * oid)
     {
       /* only check required condition: OID match. Other, more sophisticated conditions should be checked from the
        * caller */
-      if (xasl->spec_list && xasl->spec_list->indexptr && oid_compare (&xasl->spec_list->indexptr->class_oid, oid) == 0)
+      if (xasl->spec_list && xasl->spec_list->indexptr
+	  && oid_is_equal_value (&xasl->spec_list->indexptr->class_oid, oid))
 	{
 	  return xasl;
 	}

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -23107,8 +23107,7 @@ pt_find_oid_scan_block (XASL_NODE * xasl, OID * oid)
     {
       /* only check required condition: OID match. Other, more sophisticated conditions should be checked from the
        * caller */
-      if (xasl->spec_list && xasl->spec_list->indexptr
-	  && oid_is_equal_value (&xasl->spec_list->indexptr->class_oid, oid))
+      if (xasl->spec_list && xasl->spec_list->indexptr && OID_EQ (&xasl->spec_list->indexptr->class_oid, oid))
 	{
 	  return xasl;
 	}

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -2308,7 +2308,7 @@ qmgr_add_modified_class (THREAD_ENTRY * thread_p, const OID * class_oid_p)
       oid_block_p = tmp_oid_block_p;
       for (i = 0, tmp_oid_p = oid_block_p->oid_array; i < oid_block_p->last_oid_idx; i++, tmp_oid_p++)
 	{
-	  if (oid_compare (class_oid_p, tmp_oid_p) == 0)
+	  if (oid_is_equal_value (class_oid_p, tmp_oid_p))
 	    {
 	      found = true;
 	      break;

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -2308,7 +2308,7 @@ qmgr_add_modified_class (THREAD_ENTRY * thread_p, const OID * class_oid_p)
       oid_block_p = tmp_oid_block_p;
       for (i = 0, tmp_oid_p = oid_block_p->oid_array; i < oid_block_p->last_oid_idx; i++, tmp_oid_p++)
 	{
-	  if (oid_is_equal_value (class_oid_p, tmp_oid_p))
+	  if (OID_EQ (class_oid_p, tmp_oid_p))
 	    {
 	      found = true;
 	      break;

--- a/src/storage/oid.c
+++ b/src/storage/oid.c
@@ -252,36 +252,18 @@ oid_compare (const void *a, const void *b)
     }
 
   diff = oid1_p->volid - oid2_p->volid;
-  if (diff > 0)
+  if (diff)
     {
-      return 1;
-    }
-  else if (diff < 0)
-    {
-      return -1;
+      return diff;
     }
 
   diff = oid1_p->pageid - oid2_p->pageid;
-  if (diff > 0)
+  if (diff)
     {
-      return 1;
-    }
-  else if (diff < 0)
-    {
-      return -1;
+      return diff;
     }
 
-  diff = oid1_p->slotid - oid2_p->slotid;
-  if (diff > 0)
-    {
-      return 1;
-    }
-  else if (diff < 0)
-    {
-      return -1;
-    }
-
-  return 0;
+  return oid1_p->slotid - oid2_p->slotid;
 }
 
 /*

--- a/src/storage/oid.c
+++ b/src/storage/oid.c
@@ -246,11 +246,6 @@ oid_compare (const void *a, const void *b)
   const OID *oid2_p = (const OID *) b;
   int diff;
 
-  if (oid1_p == oid2_p)
-    {
-      return 0;
-    }
-
   diff = oid1_p->volid - oid2_p->volid;
   if (diff)
     {

--- a/src/storage/oid.h
+++ b/src/storage/oid.h
@@ -94,41 +94,29 @@
 
 #define oid_is_equal_value(oid1, oid2)  OID_EQ((oid1), (oid2))
 #define OID_EQ(oidp1, oidp2) \
-  ((oidp1) == (oidp2) || ((oidp1)->pageid == (oidp2)->pageid && \
-			  (oidp1)->slotid == (oidp2)->slotid && \
-			  (oidp1)->volid  == (oidp2)->volid))
+  ( (oidp1)->pageid == (oidp2)->pageid && \
+    (oidp1)->slotid == (oidp2)->slotid && \
+    (oidp1)->volid  == (oidp2)->volid )
 
 #define OID_GT(oidp1, oidp2) \
-  ((oidp1) != (oidp2) &&						      \
-   ((oidp1)->volid > (oidp2)->volid ||					      \
-    ((oidp1)->volid == (oidp2)->volid && (oidp1)->pageid > (oidp2)->pageid) ||\
-    ((oidp1)->volid == (oidp2)->volid && (oidp1)->pageid == (oidp2)->pageid   \
-     && (oidp1)->slotid > (oidp2)->slotid)))
+   ( ((oidp1)->volid != (oidp2)->volid) ? ((oidp1)->volid > (oidp2)->volid)          \
+        : ((oidp1)->pageid != (oidp2)->pageid) ? ((oidp1)->pageid > (oidp2)->pageid) \
+        : ((oidp1)->slotid > (oidp2)->slotid) )
 
 #define OID_GTE(oidp1, oidp2) \
-  ((oidp1) == (oidp2) ||						      \
-   ((oidp1)->volid > (oidp2)->volid ||					      \
-    ((oidp1)->volid == (oidp2)->volid && (oidp1)->pageid > (oidp2)->pageid) ||\
-    ((oidp1)->volid == (oidp2)->volid && (oidp1)->pageid == (oidp2)->pageid   \
-     && (oidp1)->slotid > (oidp2)->slotid) ||				      \
-    ((oidp1)->volid == (oidp2)->volid && (oidp1)->pageid == (oidp2)->pageid   \
-     && (oidp1)->slotid == (oidp2)->slotid)))
+   ( ((oidp1)->volid != (oidp2)->volid) ? ((oidp1)->volid > (oidp2)->volid)          \
+        : ((oidp1)->pageid != (oidp2)->pageid) ? ((oidp1)->pageid > (oidp2)->pageid) \
+        : ((oidp1)->slotid >= (oidp2)->slotid) )
 
 #define OID_LT(oidp1, oidp2) \
-  ((oidp1) != (oidp2) &&						      \
-   ((oidp1)->volid < (oidp2)->volid ||					      \
-    ((oidp1)->volid == (oidp2)->volid && (oidp1)->pageid < (oidp2)->pageid) ||\
-    ((oidp1)->volid == (oidp2)->volid && (oidp1)->pageid == (oidp2)->pageid   \
-     && (oidp1)->slotid < (oidp2)->slotid)))
+   ( ((oidp1)->volid != (oidp2)->volid) ? ((oidp1)->volid < (oidp2)->volid)          \
+        : ((oidp1)->pageid != (oidp2)->pageid) ? ((oidp1)->pageid < (oidp2)->pageid) \
+        : ((oidp1)->slotid < (oidp2)->slotid) )
 
 #define OID_LTE(oidp1, oidp2) \
-  ((oidp1) == (oidp2) ||						      \
-   ((oidp1)->volid < (oidp2)->volid ||					      \
-    ((oidp1)->volid == (oidp2)->volid && (oidp1)->pageid < (oidp2)->pageid) ||\
-    ((oidp1)->volid == (oidp2)->volid && (oidp1)->pageid == (oidp2)->pageid   \
-     && (oidp1)->slotid < (oidp2)->slotid) ||				      \
-    ((oidp1)->volid == (oidp2)->volid && (oidp1)->pageid == (oidp2)->pageid   \
-     && (oidp1)->slotid == (oidp2)->slotid)))
+   ( ((oidp1)->volid != (oidp2)->volid) ? ((oidp1)->volid < (oidp2)->volid)          \
+        : ((oidp1)->pageid != (oidp2)->pageid) ? ((oidp1)->pageid < (oidp2)->pageid) \
+        : ((oidp1)->slotid <= (oidp2)->slotid) )
 
 /* It is used for hashing purposes */
 #define OID_PSEUDO_KEY(oidp) \

--- a/src/storage/oid.h
+++ b/src/storage/oid.h
@@ -92,6 +92,7 @@
     (oidp)->volid = NULL_VOLID; \
   } while(0)
 
+#define oid_is_equal_value(oid1, oid2)  OID_EQ((oid1), (oid2))
 #define OID_EQ(oidp1, oidp2) \
   ((oidp1) == (oidp2) || ((oidp1)->pageid == (oidp2)->pageid && \
 			  (oidp1)->slotid == (oidp2)->slotid && \

--- a/src/storage/oid.h
+++ b/src/storage/oid.h
@@ -92,7 +92,6 @@
     (oidp)->volid = NULL_VOLID; \
   } while(0)
 
-#define oid_is_equal_value(oid1, oid2)  OID_EQ((oid1), (oid2))
 #define OID_EQ(oidp1, oidp2) \
   ( (oidp1)->pageid == (oidp2)->pageid && \
     (oidp1)->slotid == (oidp2)->slotid && \


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24087

Purpose
The oid_compare() function is called when comparing OIDs in various places in the source code.
In particular, it is designated as a comparison function such as sort (qsort) and search (lsearch).
Since very frequent calls occur, we want to increase the efficiency of the code.

Implementation
  Remove unnecessary substitution statements

Remarks
N/A