### PR TITLE
[CBRD-24104] 'ERROR: System error (generate attr)' message occurs in INSERT + SELECT query

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -704,7 +704,7 @@ struct json_t;
 #define PT_IS_FALSE_WHERE_VALUE(node) \
  (((node) != NULL && (node)->node_type == PT_VALUE \
   && ((node)->type_enum == PT_TYPE_NULL \
-       || ((node)->type_enum == PT_TYPE_SET \
+       || (PT_IS_SET_TYPE (node) \
            && ((node)->info.value.data_value.set == NULL)))) ? true : false)
 
 #define PT_IS_SPEC_REAL_TABLE(spec_) PT_SPEC_IS_ENTITY(spec_)

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -13405,7 +13405,7 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
   int error = NO_ERROR;
   PT_NODE *class_;
   PT_NODE *values = NULL;
-  PT_NODE *attr_list;
+  PT_NODE *attr_list, *value_clauses, *query;
   PT_NODE *update = NULL;
   PT_NODE *with = NULL;
   int save_au;
@@ -13424,6 +13424,19 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
     {
       assert (false);
       goto cleanup;
+    }
+
+  /* there can be no results, this is a compile time false where clause */
+  value_clauses = statement->info.insert.value_clauses;
+  if (value_clauses && value_clauses->info.node_list.list_type == PT_IS_SUBQUERY)
+    {
+      query = value_clauses->info.node_list.list;
+      if (PT_IS_SELECT (query) && pt_false_where (parser, query))
+	{
+	  /* tell to the execute routine that there's no XASL to execute */
+	  statement->xasl_id = NULL;
+	  goto cleanup;
+	}
     }
 
   statement->etc = NULL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24104

In prepare of select, update, and delete, there is logic to skip against false query. But it doesn't exist in prepare of insert.
I add the relevant logic to prepare of insert as well.
