### PR TITLE
[LETS-276] Allow ATS reconnection after a crash

### DIFF
--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -52,7 +52,7 @@ void page_server::set_active_tran_server_connection (cubcomm::channel &&chn)
   er_log_debug (ARG_FILE_LINE, "Active transaction server connected to this page server. Channel id: %s.\n",
 		chn.get_channel_id ().c_str ());
 
-  if (m_active_tran_server_conn)
+  if (m_active_tran_server_conn != nullptr)
     {
       // ATS must have crashed without disconnecting from us. Destroy old connection to create a new one.
       disconnect_active_tran_server ();

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -52,7 +52,13 @@ void page_server::set_active_tran_server_connection (cubcomm::channel &&chn)
   er_log_debug (ARG_FILE_LINE, "Active transaction server connected to this page server. Channel id: %s.\n",
 		chn.get_channel_id ().c_str ());
 
+  if (m_active_tran_server_conn)
+    {
+      // ATS must have crashed without disconnecting from us. Destroy old connection to create a new one.
+      disconnect_active_tran_server ();
+    }
   assert (m_active_tran_server_conn == nullptr);
+
   m_active_tran_server_conn.reset (new active_tran_server_conn_t (std::move (chn),
   {
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-276

When ATS connects to the PS, there is an assert on the PS side that no prior ATS connection exists. During a normal shutdown, the ATS will disconnect from the PS, but after a crash the connection remains. When the ATS reconnects, the PS crashes.

Fix by accepting the fact that a connection with the ATS may already exist when a new connection is created. Delete the prior connection.