### PR TITLE
[LETS-222] New page buffer fetch mode for PTS replication

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1998,6 +1998,7 @@ try_again:
       if (lock_page_res == PGBUF_LOCK_NOT_NEEDED)
 	{
 	  // No need to load the page to page buffer
+	  assert (fetch_mode == OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT);
 	  return nullptr;
 	}
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1997,6 +1997,7 @@ try_again:
       const PGBUF_LOCK_MODE lock_page_res = pgbuf_lock_page (thread_p, vpid, fetch_mode, hash_anchor, &perf);
       if (lock_page_res == PGBUF_LOCK_NOT_NEEDED)
 	{
+	  // No need to load the page to page buffer
 	  return nullptr;
 	}
 
@@ -7371,6 +7372,9 @@ pgbuf_buffer_lock_delist_thread (THREAD_ENTRY * const thread_p, PGBUF_BUFFER_LOC
  * Note: This function is invoked only when the page is not in the buffer hash
  *       chain. The caller is holding hash_anchor->hash_mutex.
  *       Before return, the thread releases hash_anchor->hash_mutex.
+ * NOTE: function name is misleading; function does not actually lock the page, it merely
+ *       synchronizes (locks) the inter-thread access to the page retrieval (fix) mechanism
+ *
  */
 static PGBUF_LOCK_MODE
 pgbuf_lock_page (THREAD_ENTRY * const thread_p, const VPID * const vpid, PAGE_FETCH_MODE fetch_mode,
@@ -7430,14 +7434,17 @@ pgbuf_lock_page (THREAD_ENTRY * const thread_p, const VPID * const vpid, PAGE_FE
       cur_buffer_lock = cur_buffer_lock->lock_next;
     }
   assert ((pgbuf_lock_state == PGBUF_LOCK_WAITER) != (cur_buffer_lock == nullptr));	// xor
+  const bool not_found_in_buffer_lock_chain = (pgbuf_lock_state == PGBUF_LOCK_HOLDER) && (cur_buffer_lock == nullptr);
 
-  if (fetch_mode == OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT)
+  if (not_found_in_buffer_lock_chain && fetch_mode == OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT)
     {
+      // no need to lock the access to page for loading; because the page does not need to be loaded
+      pthread_mutex_unlock (&hash_anchor->hash_mutex);
       return PGBUF_LOCK_NOT_NEEDED;
     }
 
-  /* page not already in the process of being loaded/retrieved, register ourselves as the lock holder */
-  if (pgbuf_lock_state == PGBUF_LOCK_HOLDER && cur_buffer_lock == nullptr)
+  /* page not already in the process of being loaded/retrieved, register ourselves as the access lock holder */
+  if (not_found_in_buffer_lock_chain)
     {
       /* buf_lock_table is implemented to have one entry for each thread. At first design, it had one entry for each
        * thread. thread_p->index : thread entry index thread_p->tran_index : transaction entry index */
@@ -7513,6 +7520,8 @@ pgbuf_perf_register_page_lock (PAGE_FETCH_MODE fetch_mode, PGBUF_LOCK_MODE pgbuf
  *       Before return, the thread releases the hash mutex on the hash
  *       anchor and wakes up all the threads blocked on the queue of the
  *       buffer lock record.
+ * NOTE: function name is misleading; function does not actually unlocks the page, it merely
+ *       synchronizes (unlocks) the inter-thread access to the page retrieval (fix) mechanism
  */
 static int
 pgbuf_unlock_page (THREAD_ENTRY * thread_p, PGBUF_BUFFER_HASH * hash_anchor, const VPID * vpid, int need_hash_mutex)

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -170,8 +170,10 @@ typedef enum
   OLD_PAGE_PREVENT_DEALLOC,	/* Fetch existing page and mark its memory buffer, to prevent deallocation. */
   OLD_PAGE_DEALLOCATED,		/* Fetch page that has been deallocated. */
   OLD_PAGE_MAYBE_DEALLOCATED,	/* Fetch page that maybe was deallocated. */
-  RECOVERY_PAGE			/* Fetch page for recovery. The page may be new, or deallocated or normal, everything
+  RECOVERY_PAGE,		/* Fetch page for recovery. The page may be new, or deallocated or normal, everything
 				 * is possible really. */
+  OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT	/* Fetch page for passive transaction server replication. The page is requested from
+					 * page server and is in the process of being added to the page bufffer */
 } PAGE_FETCH_MODE;
 
 /* public page latch mode */


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-222

A new fetch mode is required for passive transaction server (PTS) replication. A page must be fixed if one of the next two conditions are met:
- the page is in page buffer already
- the page was requested from page server (PS) and is in the process of being added to the page buffer.

After LETS-221 refactoring, add OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT fetch mode that applies to the above conditions.

Implementation
- add OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT fetch mode
- add new enum value PGBUF_LOCK_NOT_NEEDED
- in function pgbuf_lock_page, if fetch mode is OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT and no page access lock entry is found for the page VPID (ie: page is not in the process of being retrieved from the persistent storage - be that disk or PS), return PGBUF_LOCK_NOT_NEEDED
- in pgbuf_fix, if pgbuf_lock_page returns PGBUF_LOCK_NOT_NEEDED, do not fix the page and return null