### PR TITLE
[LETS-281] Fix error leak creating a pgbuf_fix fail

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1977,7 +1977,7 @@ try_again:
     {
       /* The page is not found in the hash chain the caller is holding hash_anchor->hash_mutex */
 
-      if (er_errid () != NO_ERROR)
+      if (er_errid () == ER_CSS_PTHREAD_MUTEX_TRYLOCK)
 	{
 	  // error searching the hash chain
 	  pthread_mutex_unlock (&hash_anchor->hash_mutex);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -4093,6 +4093,10 @@ xboot_copy (REFPTR (THREAD_ENTRY, thread_p), const char *from_dbname, const char
 		  error_code = ER_BO_DIRECTORY_DOESNOT_EXIST;
 		  goto error;
 		}
+	      else
+		{
+		  er_clear ();
+		}
 	    }
 	}
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-281

A warning set while creating the lob path for copydb is leaked and results in a pgbuf_fix fail.

pgbuf_fix code was recently changed to try catch any errors from searching the hash chain; it used to check for a specific error code. Now it catches errors set before pgbuf_fix and leaked.

Revert the condition to check only for the specific error again. Also clear the warning set during copydb.