### PR TITLE
[LETS-287] Set the checkpoint info snapshot LSA to last record LSA

### DIFF
--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -257,7 +257,7 @@ namespace cublog
     };
     log_system_tdes::map_all_tdes (mapper);
 
-    m_snapshot_lsa = log_Gl.append.prev_lsa;
+    m_snapshot_lsa = log_Gl.prior_info.prev_lsa;
   }
 
   void


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-287

Checkpoint info snapshot LSA is wrongfully set to the LSA of last record appended to log pages. It must be the LSA of last record in prior info.
