### PR TITLE
[LETS-287] Fix system operation level after atomic start

### DIFF
--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -335,14 +335,7 @@ namespace cublog
 	      }
 	  }
 
-	if (tdes->topops.last == -1)
-	  {
-	    tdes->topops.last++;
-	  }
-	else
-	  {
-	    assert (tdes->topops.last == 0);
-	  }
+
 	tdes->rcv.sysop_start_postpone_lsa = sysop.sysop_start_postpone_lsa;
 	tdes->rcv.atomic_sysop_start_lsa = sysop.atomic_sysop_start_lsa;
 	if (!sysop.sysop_start_postpone_lsa.is_null ())
@@ -358,6 +351,16 @@ namespace cublog
 	      }
 	    tdes->topops.stack[tdes->topops.last].lastparent_lsa = sysop_start_postpone.sysop_end.lastparent_lsa;
 	    tdes->topops.stack[tdes->topops.last].posp_lsa = sysop_start_postpone.posp_lsa;
+
+	    // When sysop start is found, the system operation level is also bumped
+	    if (tdes->topops.last == -1)
+	      {
+		tdes->topops.last++;
+	      }
+	    else
+	      {
+		assert (tdes->topops.last == 0);
+	      }
 	  }
 	else
 	  {

--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -335,7 +335,6 @@ namespace cublog
 	      }
 	  }
 
-
 	tdes->rcv.sysop_start_postpone_lsa = sysop.sysop_start_postpone_lsa;
 	tdes->rcv.atomic_sysop_start_lsa = sysop.atomic_sysop_start_lsa;
 	if (!sysop.sysop_start_postpone_lsa.is_null ())

--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -340,6 +340,16 @@ namespace cublog
 	tdes->rcv.atomic_sysop_start_lsa = sysop.atomic_sysop_start_lsa;
 	if (!sysop.sysop_start_postpone_lsa.is_null ())
 	  {
+	    // Bump the sysop level to save lastparent_lsa and posp_lsa.
+	    if (tdes->topops.last == -1)
+	      {
+		tdes->topops.last++;
+	      }
+	    else
+	      {
+		assert (tdes->topops.last == 0);
+	      }
+
 	    LOG_LSA log_lsa_local = sysop.sysop_start_postpone_lsa;
 	    LOG_REC_SYSOP_START_POSTPONE sysop_start_postpone;
 	    const int error_code = log_read_sysop_start_postpone (thread_p, &log_lsa_local, log_page_local, false,
@@ -351,21 +361,6 @@ namespace cublog
 	      }
 	    tdes->topops.stack[tdes->topops.last].lastparent_lsa = sysop_start_postpone.sysop_end.lastparent_lsa;
 	    tdes->topops.stack[tdes->topops.last].posp_lsa = sysop_start_postpone.posp_lsa;
-
-	    // When sysop start is found, the system operation level is also bumped
-	    if (tdes->topops.last == -1)
-	      {
-		tdes->topops.last++;
-	      }
-	    else
-	      {
-		assert (tdes->topops.last == 0);
-	      }
-	  }
-	else
-	  {
-	    tdes->topops.stack[tdes->topops.last].lastparent_lsa = sysop.atomic_sysop_start_lsa;
-	    tdes->topops.stack[tdes->topops.last].posp_lsa.set_null ();
 	  }
       }
   }

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -1209,6 +1209,7 @@ log_rv_analysis_sysop_end (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa
 
   if (tdes->state == TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE)
     {
+      // topops stack is bumped when system operation start postpone is found.
       assert (tdes->topops.last == 0);
       if (commit_start_postpone)
 	{
@@ -1234,7 +1235,9 @@ log_rv_analysis_sysop_end (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa
     }
   else
     {
-      assert (tdes->topops.last == -1);
+      // topops stack may be also bumped when start atomic system operation is found.
+      // otherwise, it is expected to be empty
+      assert (tdes->topops.last == -1 || !tdes->rcv.atomic_sysop_start_lsa.is_null ());
       tdes->topops.last = -1;
     }
 

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -1235,9 +1235,7 @@ log_rv_analysis_sysop_end (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa
     }
   else
     {
-      // topops stack may be also bumped when start atomic system operation is found.
-      // otherwise, it is expected to be empty
-      assert (tdes->topops.last == -1 || !tdes->rcv.atomic_sysop_start_lsa.is_null ());
+      assert (tdes->topops.last == -1);
       tdes->topops.last = -1;
     }
 

--- a/unit_tests/log/test_main_chkpt_info.cpp
+++ b/unit_tests/log/test_main_chkpt_info.cpp
@@ -43,6 +43,8 @@
 
 using namespace cublog;
 
+std::map<TRANID, log_tdes *> systb_System_tdes;
+
 class test_env_chkpt
 {
   public:
@@ -63,14 +65,27 @@ class test_env_chkpt
     static constexpr int MAX_RAND = 32700;
     static void require_equal (checkpoint_info before, checkpoint_info after);
 
+    LOG_TDES *find_or_insert_recovery_tdes (TRANID trid);
+    void increment_recovery_2pc ();
+    void check_recovery ();
+
     checkpoint_info *get_before ();
     checkpoint_info *get_after ();
 
+    size_t get_after_tran_count () const;
+
+
   private:
+    static size_t number_of_2pc ();
+
     checkpoint_info m_before;
     checkpoint_info m_after;
 
+    std::map<TRANID, log_tdes *> m_after_tdes_map;
+    size_t m_count_2pc_after_recovery = 0;
+    size_t m_count_2pc_in_trantable = 0;
 };
+test_env_chkpt *g_Env = nullptr;
 
 checkpoint_info *test_env_chkpt::get_before ()
 {
@@ -80,6 +95,12 @@ checkpoint_info *test_env_chkpt::get_before ()
 checkpoint_info *test_env_chkpt::get_after ()
 {
   return &m_after;
+}
+
+size_t
+test_env_chkpt::get_after_tran_count () const
+{
+  return m_after_tdes_map.size ();
 }
 
 TEST_CASE ("Test pack/unpack checkpoint_info class 1", "")
@@ -140,10 +161,6 @@ TEST_CASE ("Test pack/unpack checkpoint_info class 3", "")
   env.require_equal (*env.get_after (), after_2);
 }
 
-std::map<TRANID, log_tdes *> tran_map;
-std::map<TRANID, log_tdes *> systb_System_tdes;
-size_t count_2pc_after_recovery;
-
 TEST_CASE ("Test load and recovery on empty tran table", "")
 {
   test_env_chkpt env;
@@ -154,7 +171,7 @@ TEST_CASE ("Test load and recovery on empty tran table", "")
   env.get_after ()->load_trantable_snapshot (&thd, smallest_lsa);
   env.get_after ()->recovery_analysis (&thd, star_lsa);
   env.get_after ()->recovery_2pc_analysis (&thd);
-  REQUIRE (tran_map.size () == 0);
+  REQUIRE (env.get_after_tran_count () == 0);
 }
 
 int
@@ -188,11 +205,37 @@ full_compare_tdes (log_tdes *td1, const log_tdes *td2, bool is_unactive_aborted)
   REQUIRE (td1->tail_topresult_lsa == td2->tail_topresult_lsa);
 }
 
+log_tdes *
+test_env_chkpt::find_or_insert_recovery_tdes (TRANID trid)
+{
+  std::map<TRANID, log_tdes *>::iterator it = m_after_tdes_map.find (trid);
+  if (it == m_after_tdes_map.end ())
+    {
+      // Insert
+      log_tdes *tdes = new log_tdes ();
+      tdes->topops.last = -1;
+      tdes->rcv.sysop_start_postpone_lsa.set_null ();
+      tdes->rcv.atomic_sysop_start_lsa.set_null ();
+      m_after_tdes_map.insert (std::make_pair (trid, tdes));
+      return tdes;
+    }
+  else
+    {
+      return it->second;
+    }
+}
+
 void
-check_recovery (checkpoint_info obj)
+test_env_chkpt::increment_recovery_2pc ()
+{
+  m_count_2pc_after_recovery++;
+}
+
+void
+test_env_chkpt::check_recovery ()
 {
   std::map<TRANID, log_tdes *>::iterator itr;
-  for (itr = tran_map.begin (); itr != tran_map.end (); ++itr)
+  for (itr = m_after_tdes_map.begin (); itr != m_after_tdes_map.end (); ++itr)
     {
       REQUIRE (itr->first != NULL_TRANID);
     }
@@ -206,14 +249,14 @@ check_recovery (checkpoint_info obj)
 	  continue;
 	}
 
-      std::map<TRANID, log_tdes *>::const_iterator tdes_after_iter = tran_map.find (tdes->trid);
+      std::map<TRANID, log_tdes *>::const_iterator tdes_after_iter = m_after_tdes_map.find (tdes->trid);
 
       if (tdes->tail_lsa == NULL_LSA)
 	{
-	  REQUIRE (tdes_after_iter == tran_map.end ());
+	  REQUIRE (tdes_after_iter == m_after_tdes_map.end ());
 	  continue;
 	}
-      REQUIRE (tdes_after_iter != tran_map.end ());
+      REQUIRE (tdes_after_iter != m_after_tdes_map.end ());
       log_tdes *const tdes_after = tdes_after_iter->second;
       if ((tdes->state == TRAN_UNACTIVE_COMMITTED || tdes->state == TRAN_UNACTIVE_ABORTED)
 	  && !tdes->commit_abort_lsa.is_null ())
@@ -260,10 +303,10 @@ check_recovery (checkpoint_info obj)
 
   for (itr = systb_System_tdes.begin (); itr != systb_System_tdes.end (); ++itr)
     {
-      std::map<TRANID, log_tdes *>::const_iterator tdes_after = tran_map.find (itr->first);
+      std::map<TRANID, log_tdes *>::const_iterator tdes_after = m_after_tdes_map.find (itr->first);
       // check topops/rcv only
 
-      if (tdes_after == tran_map.end ())
+      if (tdes_after == m_after_tdes_map.end ())
 	{
 	  continue;
 	}
@@ -271,11 +314,11 @@ check_recovery (checkpoint_info obj)
       if (itr->second->rcv.sysop_start_postpone_lsa == NULL_LSA &&
 	  itr->second->rcv.atomic_sysop_start_lsa == NULL_LSA)
 	{
-	  REQUIRE (tdes_after == tran_map.end ());
+	  REQUIRE (tdes_after == m_after_tdes_map.end ());
 	}
       else
 	{
-	  REQUIRE (tdes_after != tran_map.end ());
+	  REQUIRE (tdes_after != m_after_tdes_map.end ());
 	  if (itr->second->topops.last == -1)
 	    {
 	      REQUIRE (tdes_after->second->topops.last == 0);
@@ -285,10 +328,12 @@ check_recovery (checkpoint_info obj)
 	  REQUIRE (itr->second->rcv.atomic_sysop_start_lsa == tdes_after->second->rcv.atomic_sysop_start_lsa);
 	}
     }
+
+  REQUIRE (m_count_2pc_in_trantable == m_count_2pc_after_recovery);
 }
 
 size_t
-number_of_2pc ()
+test_env_chkpt::number_of_2pc ()
 {
   size_t count = 0;
   for (int i = 1; i < log_Gl.trantable.num_total_indices; i++)
@@ -309,20 +354,21 @@ TEST_CASE ("Test load and recovery on every tran table entry ", "")
   THREAD_ENTRY thd;
 
   env.generate_tran_table ();
-  size_t count_2pc_in_trantable = number_of_2pc ();
   env.get_after ()->load_trantable_snapshot (&thd, smallest_lsa);
   env.get_after ()->recovery_analysis (&thd, start_lsa);
   env.get_after ()->recovery_2pc_analysis (&thd);
-  check_recovery (*env.get_after ());
-  REQUIRE (count_2pc_in_trantable == count_2pc_after_recovery);
+  env.check_recovery ();
 
 }
 
 test_env_chkpt::test_env_chkpt ()
 {
+  assert (g_Env == nullptr);
+  g_Env = this;
 }
 
 test_env_chkpt::test_env_chkpt (size_t size_trans, size_t size_sysops)
+  : test_env_chkpt ()
 {
   std::srand ((unsigned int) time (0));
   m_before.m_start_redo_lsa = this->generate_log_lsa ();
@@ -348,6 +394,13 @@ test_env_chkpt::test_env_chkpt (size_t size_trans, size_t size_sysops)
 
 test_env_chkpt::~test_env_chkpt ()
 {
+  assert (g_Env == this);
+  g_Env = nullptr;
+
+  for (auto it : m_after_tdes_map)
+    {
+      delete it.second;
+    }
 }
 
 checkpoint_info::tran_info
@@ -628,6 +681,8 @@ test_env_chkpt::generate_tran_table ()
   tdes->topops.last = 0;
   tdes->rcv.sysop_start_postpone_lsa = {1, 1};
   tdes->rcv.atomic_sysop_start_lsa = {1, 1};
+
+  m_count_2pc_in_trantable = number_of_2pc ();
 }
 
 //
@@ -748,44 +803,10 @@ logtb_get_system_tdes (THREAD_ENTRY *thread_p)
 }
 
 LOG_TDES *
-logtb_rv_find_allocate_tran_index (THREAD_ENTRY *thread_p, TRANID trid, const LOG_LSA *log_lsa)
+logtb_rv_find_allocate_tran_index (THREAD_ENTRY *thread_p, TRANID trid, const LOG_LSA *)
 {
   assert (trid != NULL_TRANID);
-
-  if (trid < NULL_TRANID)
-    {
-      LOG_TDES *const sys_tdes = new log_tdes ();
-      sys_tdes->topops.last = -1;
-      LSA_SET_NULL (&sys_tdes->rcv.sysop_start_postpone_lsa);
-      LSA_SET_NULL (&sys_tdes->rcv.atomic_sysop_start_lsa);
-      sys_tdes->trid = trid;
-      tran_map.insert (std::pair<TRANID, log_tdes *> (trid, sys_tdes));
-      return sys_tdes;
-    }
-
-  log_tdes *const tdes = new log_tdes ();
-  for (int i = 1; i < NUM_TOTAL_TRAN_INDICES; i++)
-    {
-      if (log_Gl.trantable.all_tdes[i] == NULL)
-	{
-	  continue;
-	}
-      if (log_Gl.trantable.all_tdes[i]->trid != NULL_TRANID && log_Gl.trantable.all_tdes[i]->trid == trid)
-	{
-	  std::map<TRANID, log_tdes *>::const_iterator inside_tdes = tran_map.find (trid);
-	  if (inside_tdes != tran_map.end ())
-	    {
-	      return inside_tdes->second;
-	    }
-	  tdes->topops.last = -1;
-	  LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
-	  LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
-	  tran_map.insert (std::pair<TRANID, log_tdes *> (trid, tdes));
-	  return tdes;
-	}
-    }
-  assert (false);
-  return tdes;
+  return g_Env->find_or_insert_recovery_tdes (trid);
 }
 
 void
@@ -869,7 +890,7 @@ logtb_find_tran_index (THREAD_ENTRY *thread_p, TRANID trid)
 void
 log_2pc_recovery_analysis_info (THREAD_ENTRY *thread_p, log_tdes *tdes, const LOG_LSA *upto_chain_lsa)
 {
-  count_2pc_after_recovery++;
+  g_Env->increment_recovery_2pc ();
 }
 
 bool

--- a/unit_tests/log/test_main_chkpt_info.cpp
+++ b/unit_tests/log/test_main_chkpt_info.cpp
@@ -214,6 +214,7 @@ test_env_chkpt::find_or_insert_recovery_tdes (TRANID trid)
       // Insert
       log_tdes *tdes = new log_tdes ();
       tdes->topops.last = -1;
+      tdes->topops.stack = nullptr;
       tdes->rcv.sysop_start_postpone_lsa.set_null ();
       tdes->rcv.atomic_sysop_start_lsa.set_null ();
       m_after_tdes_map.insert (std::make_pair (trid, tdes));
@@ -555,7 +556,7 @@ test_env_chkpt::generate_tdes (int index)
 void
 test_env_chkpt::generate_tran_table ()
 {
-  log_Gl.trantable.num_total_indices = 20;
+  log_Gl.trantable.num_total_indices = 21;
   int size = log_Gl.trantable.num_total_indices * sizeof (*log_Gl.trantable.all_tdes);
   log_Gl.trantable.all_tdes = (LOG_TDES **) malloc (size);
 
@@ -666,6 +667,7 @@ test_env_chkpt::generate_tran_table ()
   tdes->topops.last = 3;
   tdes->rcv.sysop_start_postpone_lsa = {1, 1};
   tdes->rcv.atomic_sysop_start_lsa = {1, 1};
+  ++tran_index;
 
   assert (tran_index == log_Gl.trantable.num_total_indices);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-287

Atomic sysop start is not expected to bump the system operation level during analysis. It is wrongfully bumped after checkpoint analysis.

Fix by bumping the system operation level, only if sysop start postpone is not null.

EDIT: unit test has to be updated too; also fixed some issues and reorganized some global resources/functions into test_env_chkpt.