### PR TITLE
[CBRD-23842] Fix memory coredump while producing log infos in CDC

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12550,7 +12550,7 @@ cdc_make_dml_loginfo (THREAD_ENTRY * thread_p, int trid, char *user, CDC_DML_TYP
       goto error;
     }
 
-  changed_col_idx = (int *) malloc (attr_info.num_values);
+  changed_col_idx = (int *) malloc (sizeof (int) * attr_info.num_values);
   if (changed_col_idx == NULL)
     {
       error_code = ER_OUT_OF_VIRTUAL_MEMORY;
@@ -13076,7 +13076,14 @@ cdc_compare_undoredo_dbvalue (const db_value * new_value, const db_value * old_v
 
   assert (new_value != NULL && old_value != NULL);
 
-  return db_value_compare (new_value, old_value) == 0 ? 0 : 1;
+  if (DB_IS_NULL (new_value) && DB_IS_NULL (old_value))
+    {
+      return 0;
+    }
+  else
+    {
+      return db_value_compare (new_value, old_value) == 0 ? 0 : 1;
+    }
 }
 
 static int
@@ -13191,7 +13198,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
 
 	snprintf (result + length - 2, 2, "'");
 
-	assert (strlen (result) == (length - 1));
+	assert ((int) strlen (result) == (length - 1));
 
 	ptr = or_pack_int (ptr, func_type);
 	ptr = or_pack_string (ptr, result);
@@ -14185,7 +14192,7 @@ cdc_make_loginfo (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa)
 
       if (LSA_GE (&consume->next_lsa, start_lsa))
 	{
-	  if (total_length + consume->length + MAX_ALIGNMENT > cdc_Gl.consumer.log_info_size)
+	  if ((int) (total_length + consume->length + MAX_ALIGNMENT) > cdc_Gl.consumer.log_info_size)
 	    {
 	      temp_log_infos = (char *) realloc (log_infos, total_length + consume->length + MAX_ALIGNMENT);
 	      if (temp_log_infos == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

Fixed coredump has occurred due to invalid malloc size for integer array. 

Removes warnings from cdc implementation. 

Fixed bug : 
When undo and redo record have NULL value and required to be compared to know num_changed_columns while making log infos for UPDATE statement, cdc_compare_undoredo_dbvalue() returns that undo and redo which have null values are different.  
