### PR TITLE
[LETS-209] Logging b-tree split/merge operations for atomic replication

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -12801,7 +12801,7 @@ btree_split_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
   rightcnt = key_cnt - leftcnt;
 
   /****************************************************************************
-   ***   STEP 5: insert sep_key to P
+   ***   STEP 2: insert sep_key to P
    ***           add undo/redo log for page P
    ***
    ***    update the parent page P to keep the middle key and to point to
@@ -12877,7 +12877,7 @@ btree_split_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
   btree_node_header_redo_log (thread_p, &btid->sys_btid->vfid, P);
 
   /*********************************************************************
-   ***  STEP 2: save undo image of Q
+   ***  STEP 3: save undo image of Q
    ***		update Q, R header info
    *********************************************************************/
   /* add undo logging for page Q */
@@ -12945,7 +12945,7 @@ btree_split_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
     }
 
   /*******************************************************************
-   ***   STEP 3: move second half of page Q to page R
+   ***   STEP 4: move second half of page Q to page R
    ***           insert fence key to Q
    ***           make redo image for Q
    *******************************************************************/
@@ -13020,7 +13020,7 @@ btree_split_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
   log_append_redo_data2 (thread_p, RVBT_COPYPAGE, &btid->sys_btid->vfid, Q, -1, DB_PAGESIZE, Q);
 
   /***************************************************************************
-   ***   STEP 4: add redo log for R
+   ***   STEP 5: add redo log for R
    ***    Log the second half of page Q for redo purposes on Page R,
    ***    the records on the second half of page Q will be inserted to page R
    ***************************************************************************/

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -26762,7 +26762,7 @@ btree_split_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 	  assert (key_count >= 3);
 
 	  /* Start system operation. */
-	  log_sysop_start (thread_p);
+	  log_sysop_start_atomic (thread_p);
 	  is_system_op_started = true;
 
 	  /* Create two new b-tree pages. */
@@ -27056,7 +27056,7 @@ btree_split_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 
   if (need_split)
     {
-      log_sysop_start (thread_p);
+      log_sysop_start_atomic (thread_p);
       is_system_op_started = true;
 
       /* Get a new page */
@@ -30214,7 +30214,7 @@ btree_merge_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 		      && (pgbuf_get_latch_mode (right_page) >= PGBUF_LATCH_WRITE));
 
 	      /* Start system operation. */
-	      log_sysop_start (thread_p);
+	      log_sysop_start_atomic (thread_p);
 	      is_system_op_started = true;
 
 	      /* Merge the three nodes into root node. */
@@ -30458,7 +30458,7 @@ btree_merge_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 			  && (pgbuf_get_latch_mode (right_page) >= PGBUF_LATCH_WRITE));
 
 		  /* Start system operation. */
-		  log_sysop_start (thread_p);
+		  log_sysop_start_atomic (thread_p);
 		  is_system_op_started = true;
 
 		  save_lsa = *pgbuf_get_lsa (*crt_page);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -26764,7 +26764,7 @@ btree_split_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 	  assert (key_count >= 3);
 
 	  /* Start system operation. */
-	  log_sysop_start /*_atomic*/ (thread_p);
+	  log_sysop_start_atomic (thread_p);
 	  is_system_op_started = true;
 
 	  /* Create two new b-tree pages. */
@@ -27058,7 +27058,7 @@ btree_split_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 
   if (need_split)
     {
-      log_sysop_start /*_atomic*/ (thread_p);
+      log_sysop_start_atomic (thread_p);
       is_system_op_started = true;
 
       /* Get a new page */
@@ -30216,7 +30216,7 @@ btree_merge_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 		      && (pgbuf_get_latch_mode (right_page) >= PGBUF_LATCH_WRITE));
 
 	      /* Start system operation. */
-	      log_sysop_start /*_atomic*/ (thread_p);
+	      log_sysop_start_atomic (thread_p);
 	      is_system_op_started = true;
 
 	      /* Merge the three nodes into root node. */
@@ -30460,7 +30460,7 @@ btree_merge_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 			  && (pgbuf_get_latch_mode (right_page) >= PGBUF_LATCH_WRITE));
 
 		  /* Start system operation. */
-		  log_sysop_start /*_atomic*/ (thread_p);
+		  log_sysop_start_atomic (thread_p);
 		  is_system_op_started = true;
 
 		  save_lsa = *pgbuf_get_lsa (*crt_page);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -26762,7 +26762,7 @@ btree_split_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 	  assert (key_count >= 3);
 
 	  /* Start system operation. */
-	  log_sysop_start_atomic (thread_p);
+	  log_sysop_start /*_atomic*/ (thread_p);
 	  is_system_op_started = true;
 
 	  /* Create two new b-tree pages. */
@@ -27056,7 +27056,7 @@ btree_split_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 
   if (need_split)
     {
-      log_sysop_start_atomic (thread_p);
+      log_sysop_start /*_atomic*/ (thread_p);
       is_system_op_started = true;
 
       /* Get a new page */
@@ -30214,7 +30214,7 @@ btree_merge_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 		      && (pgbuf_get_latch_mode (right_page) >= PGBUF_LATCH_WRITE));
 
 	      /* Start system operation. */
-	      log_sysop_start_atomic (thread_p);
+	      log_sysop_start /*_atomic*/ (thread_p);
 	      is_system_op_started = true;
 
 	      /* Merge the three nodes into root node. */
@@ -30458,7 +30458,7 @@ btree_merge_node_and_advance (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_V
 			  && (pgbuf_get_latch_mode (right_page) >= PGBUF_LATCH_WRITE));
 
 		  /* Start system operation. */
-		  log_sysop_start_atomic (thread_p);
+		  log_sysop_start /*_atomic*/ (thread_p);
 		  is_system_op_started = true;
 
 		  save_lsa = *pgbuf_get_lsa (*crt_page);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1265,7 +1265,7 @@ STATIC_INLINE int btree_count_oids (THREAD_ENTRY * thread_p, BTID_INT * btid_int
 
 static int btree_store_overflow_key (THREAD_ENTRY * thread_p, BTID_INT * btid, DB_VALUE * key, int size,
 				     BTREE_NODE_TYPE node_type, VPID * firstpg_vpid);
-static int btree_load_overflow_key (THREAD_ENTRY * thread_p, const BTID_INT * btid, VPID * firstpg_vpid, DB_VALUE * key,
+static int btree_load_overflow_key (THREAD_ENTRY * thread_p, BTID_INT * btid, VPID * firstpg_vpid, DB_VALUE * key,
 				    BTREE_NODE_TYPE node_type);
 static int btree_delete_overflow_key (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_ptr, INT16 slot_id,
 				      BTREE_NODE_TYPE node_type);
@@ -1289,7 +1289,7 @@ static void btree_insert_object_ordered_by_oid (THREAD_ENTRY * thread_p, RECDES 
 static int btree_start_overflow_page (THREAD_ENTRY * thread_p, BTID_INT * btid_int, BTREE_OBJECT_INFO * object_info,
 				      VPID * first_overflow_vpid, VPID * near_vpid, VPID * new_vpid,
 				      PAGE_PTR * new_page_ptr);
-static int btree_read_record_without_decompression (THREAD_ENTRY * thread_p, const BTID_INT * btid, RECDES * Rec,
+static int btree_read_record_without_decompression (THREAD_ENTRY * thread_p, BTID_INT * btid, RECDES * Rec,
 						    DB_VALUE * key, void *rec_header, BTREE_NODE_TYPE node_type,
 						    bool * clear_key, int *offset, int copy);
 static PAGE_PTR btree_get_new_page (THREAD_ENTRY * thread_p, BTID_INT * btid, VPID * vpid, VPID * near_vpid);
@@ -1357,10 +1357,10 @@ static DISK_ISVALID btree_find_key_from_page (THREAD_ENTRY * thread_p, BTID_INT 
 
 /* Dump & verify routines */
 static void btree_dump_root_header (THREAD_ENTRY * thread_p, FILE * fp, PAGE_PTR page_ptr);
-static void btree_dump_leaf_record (THREAD_ENTRY * thread_p, FILE * fp, const BTID_INT * btid, RECDES * rec, int n);
-static void btree_dump_non_leaf_record (THREAD_ENTRY * thread_p, FILE * fp, const BTID_INT * btid, RECDES * rec, int n,
+static void btree_dump_leaf_record (THREAD_ENTRY * thread_p, FILE * fp, BTID_INT * btid, RECDES * rec, int n);
+static void btree_dump_non_leaf_record (THREAD_ENTRY * thread_p, FILE * fp, BTID_INT * btid, RECDES * rec, int n,
 					int print_key);
-static void btree_dump_page (THREAD_ENTRY * thread_p, FILE * fp, const OID * class_oid_p, const BTID_INT * btid,
+static void btree_dump_page (THREAD_ENTRY * thread_p, FILE * fp, const OID * class_oid_p, BTID_INT * btid,
 			     const char *btname, PAGE_PTR page_ptr, VPID * pg_vpid, int depth, int level);
 
 static void btree_dump_page_with_subtree (THREAD_ENTRY * thread_p, FILE * fp, BTID_INT * btid, PAGE_PTR pg_ptr,
@@ -1371,9 +1371,9 @@ static DB_VALUE *btree_set_split_point (THREAD_ENTRY * thread_p, BTID_INT * btid
 					DB_VALUE * key, bool * clear_midkey);
 static void btree_split_test (THREAD_ENTRY * thread_p, BTID_INT * btid, DB_VALUE * key, VPID * S_vpid, PAGE_PTR S_page,
 			      BTREE_NODE_TYPE node_type);
-static int btree_verify_node (THREAD_ENTRY * thread_p, const BTID_INT * btid_int, PAGE_PTR page_ptr);
-static int btree_verify_nonleaf_node (THREAD_ENTRY * thread_p, const BTID_INT * btid_int, PAGE_PTR page_ptr);
-static int btree_verify_leaf_node (THREAD_ENTRY * thread_p, const BTID_INT * btid_int, PAGE_PTR page_ptr);
+static int btree_verify_node (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PAGE_PTR page_ptr);
+static int btree_verify_nonleaf_node (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PAGE_PTR page_ptr);
+static int btree_verify_leaf_node (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PAGE_PTR page_ptr);
 #endif
 
 static void btree_set_unknown_key_error (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key, const char *debug_msg);
@@ -1414,7 +1414,7 @@ static INLINE short btree_record_object_get_mvcc_flags (char *data) __attribute_
 static INLINE bool btree_record_object_is_flagged (char *data, short mvcc_flag) __attribute__ ((ALWAYS_INLINE));
 static void btree_leaf_record_handle_first_overflow (THREAD_ENTRY * thread_p, RECDES * recp, BTID_INT * btid_int,
 						     char **rv_undo_data_ptr, char **rv_redo_data_ptr);
-static int btree_record_get_num_oids (THREAD_ENTRY * thread_p, const BTID_INT * btid_int, RECDES * rec, int offset,
+static int btree_record_get_num_oids (THREAD_ENTRY * thread_p, BTID_INT * btid_int, RECDES * rec, int offset,
 				      BTREE_NODE_TYPE node_type);
 static int btree_record_get_num_visible_oids (THREAD_ENTRY * thread_p, BTID_INT * btid, RECDES * rec, int oid_offset,
 					      BTREE_NODE_TYPE node_type, int *max_visible_oids,
@@ -1464,11 +1464,11 @@ static DISK_ISVALID btree_repair_prev_link_by_btid (THREAD_ENTRY * thread_p, BTI
 						    char *index_name);
 static DISK_ISVALID btree_repair_prev_link_by_class_oid (THREAD_ENTRY * thread_p, OID * oid, BTID * idx_btid,
 							 bool repair);
-static bool btree_node_is_compressed (THREAD_ENTRY * thread_p, const BTID_INT * btid, PAGE_PTR page_ptr);
-static int btree_node_common_prefix (THREAD_ENTRY * thread_p, const BTID_INT * btid, PAGE_PTR page_ptr);
+static bool btree_node_is_compressed (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_ptr);
+static int btree_node_common_prefix (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_ptr);
 static int btree_recompress_record (THREAD_ENTRY * thread_p, BTID_INT * btid_int, RECDES * record, DB_VALUE * fence_key,
 				    int old_prefix, int new_prefix);
-static int btree_compress_node (THREAD_ENTRY * thread_p, const BTID_INT * btid, PAGE_PTR page_ptr);
+static int btree_compress_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_ptr);
 static const char *node_type_to_string (short node_type);
 static char *key_type_to_string (char *buf, int buf_size, TP_DOMAIN * key_type);
 static int index_attrs_to_string (char *buf, int buf_size, OR_INDEX * index_p, RECDES * recdes);
@@ -1492,8 +1492,8 @@ static int btree_or_put_mvccinfo (OR_BUF * buf, BTREE_MVCC_INFO * mvcc_info);
 static int btree_or_get_mvccinfo (OR_BUF * buf, BTREE_MVCC_INFO * mvcc_info, short btree_mvcc_flags);
 static int btree_or_put_object (OR_BUF * buf, BTID_INT * btid_int, BTREE_NODE_TYPE node_type,
 				BTREE_OBJECT_INFO * object_info);
-static int btree_or_get_object (OR_BUF * buf, const BTID_INT * btid_int, BTREE_NODE_TYPE node_type,
-				int after_key_offset, OID * oid, OID * class_oid, BTREE_MVCC_INFO * mvcc_info);
+static int btree_or_get_object (OR_BUF * buf, BTID_INT * btid_int, BTREE_NODE_TYPE node_type, int after_key_offset,
+				OID * oid, OID * class_oid, BTREE_MVCC_INFO * mvcc_info);
 static char *btree_unpack_object (char *ptr, BTID_INT * btid_int, BTREE_NODE_TYPE node_type, RECDES * record,
 				  int after_key_offset, OID * oid, OID * class_oid, BTREE_MVCC_INFO * mvcc_info);
 static char *btree_pack_object (char *ptr, BTID_INT * btid_int, BTREE_NODE_TYPE node_type, RECDES * record,
@@ -1728,8 +1728,7 @@ STATIC_INLINE void btree_insert_sysop_end (THREAD_ENTRY * thread_p, BTREE_INSERT
 STATIC_INLINE const char *btree_purpose_to_string (BTREE_OP_PURPOSE purpose) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE const char *btree_op_type_to_string (int op_type) __attribute__ ((ALWAYS_INLINE));
 
-static bool btree_is_class_oid_packed (const BTID_INT * btid_int, RECDES * record, BTREE_NODE_TYPE node_type,
-				       bool is_first);
+static bool btree_is_class_oid_packed (BTID_INT * btid_int, RECDES * record, BTREE_NODE_TYPE node_type, bool is_first);
 static bool btree_is_fixed_size (BTID_INT * btid_int, RECDES * record, BTREE_NODE_TYPE node_type, bool is_first);
 static bool btree_is_insert_data_purpose (BTREE_OP_PURPOSE purpose);
 static bool btree_is_insert_object_purpose (BTREE_OP_PURPOSE purpose);
@@ -2110,8 +2109,8 @@ exit_on_error:
  * Note: The overflow key is loaded from the pages.
  */
 static int
-btree_load_overflow_key (THREAD_ENTRY * thread_p, const BTID_INT * btid, VPID * first_overflow_page_vpid,
-			 DB_VALUE * key, BTREE_NODE_TYPE node_type)
+btree_load_overflow_key (THREAD_ENTRY * thread_p, BTID_INT * btid, VPID * first_overflow_page_vpid, DB_VALUE * key,
+			 BTREE_NODE_TYPE node_type)
 {
   RECDES rec;
   OR_BUF buf;
@@ -2430,8 +2429,7 @@ btree_leaf_record_change_overflow_link (THREAD_ENTRY * thread_p, BTID_INT * btid
  * mvcc_info (out) : First object MVCC info.
  */
 int
-btree_leaf_get_first_object (const BTID_INT * btid, RECDES * recp, OID * oidp, OID * class_oid,
-			     BTREE_MVCC_INFO * mvcc_info)
+btree_leaf_get_first_object (BTID_INT * btid, RECDES * recp, OID * oidp, OID * class_oid, BTREE_MVCC_INFO * mvcc_info)
 {
   OR_BUF record_buffer;
   int error_code = NO_ERROR;
@@ -2735,7 +2733,7 @@ btree_record_get_num_visible_oids (THREAD_ENTRY * thread_p, BTID_INT * btid, REC
  * node_type (in)	 : Leaf/overflow node type.
  */
 static int
-btree_record_get_num_oids (THREAD_ENTRY * thread_p, const BTID_INT * btid_int, RECDES * rec, int after_key_offset,
+btree_record_get_num_oids (THREAD_ENTRY * thread_p, BTID_INT * btid_int, RECDES * rec, int after_key_offset,
 			   BTREE_NODE_TYPE node_type)
 {
   int rec_oid_cnt;
@@ -4325,7 +4323,7 @@ btree_read_record (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR pgptr, REC
  *
  */
 static int
-btree_read_record_without_decompression (THREAD_ENTRY * thread_p, const BTID_INT * btid, RECDES * rec, DB_VALUE * key,
+btree_read_record_without_decompression (THREAD_ENTRY * thread_p, BTID_INT * btid, RECDES * rec, DB_VALUE * key,
 					 void *rec_header, BTREE_NODE_TYPE node_type, bool * clear_key, int *offset,
 					 int copy_key)
 {
@@ -4634,7 +4632,7 @@ btree_dump_key (FILE * fp, const DB_VALUE * key)
  * Note: Dumps the content of a leaf record, namely key and the set of values for the key.
  */
 static void
-btree_dump_leaf_record (THREAD_ENTRY * thread_p, FILE * fp, const BTID_INT * btid, RECDES * rec, int depth)
+btree_dump_leaf_record (THREAD_ENTRY * thread_p, FILE * fp, BTID_INT * btid, RECDES * rec, int depth)
 {
   OR_BUF buf;
   LEAF_REC leaf_record = { {NULL_PAGEID, NULL_VOLID}, 0 };
@@ -4893,8 +4891,7 @@ btree_dump_leaf_record (THREAD_ENTRY * thread_p, FILE * fp, const BTID_INT * bti
  * Note: Dumps the content of a nonleaf record, namely key and child page identifier.
  */
 static void
-btree_dump_non_leaf_record (THREAD_ENTRY * thread_p, FILE * fp, const BTID_INT * btid, RECDES * rec, int depth,
-			    int print_key)
+btree_dump_non_leaf_record (THREAD_ENTRY * thread_p, FILE * fp, BTID_INT * btid, RECDES * rec, int depth, int print_key)
 {
   NON_LEAF_REC non_leaf_record;
   int key_len, offset;
@@ -8845,7 +8842,7 @@ btree_print_space (FILE * fp, int n)
  * Note: Dumps the content of the given page of the tree.
  */
 static void
-btree_dump_page (THREAD_ENTRY * thread_p, FILE * fp, const OID * class_oid_p, const BTID_INT * btid, const char *btname,
+btree_dump_page (THREAD_ENTRY * thread_p, FILE * fp, const OID * class_oid_p, BTID_INT * btid, const char *btname,
 		 PAGE_PTR page_ptr, VPID * pg_vpid, int depth, int level)
 {
   int key_cnt;
@@ -12325,7 +12322,7 @@ btree_split_next_pivot (BTREE_NODE_SPLIT_INFO * split_info, float new_value, int
 }
 
 static bool
-btree_node_is_compressed (THREAD_ENTRY * thread_p, const BTID_INT * btid, PAGE_PTR page_ptr)
+btree_node_is_compressed (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_ptr)
 {
   int key_cnt;
   RECDES peek_rec;
@@ -12383,7 +12380,7 @@ btree_node_is_compressed (THREAD_ENTRY * thread_p, const BTID_INT * btid, PAGE_P
 }
 
 static int
-btree_node_common_prefix (THREAD_ENTRY * thread_p, const BTID_INT * btid, PAGE_PTR page_ptr)
+btree_node_common_prefix (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_ptr)
 {
   RECDES peek_rec;
   int diff_column;
@@ -12542,7 +12539,7 @@ btree_recompress_record (THREAD_ENTRY * thread_p, BTID_INT * btid_int, RECDES * 
 }
 
 static int
-btree_compress_node (THREAD_ENTRY * thread_p, const BTID_INT * btid, PAGE_PTR page_ptr)
+btree_compress_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_ptr)
 {
   int i, key_cnt, diff_column;
   RECDES peek_rec, rec;
@@ -19448,7 +19445,7 @@ btree_compare_oid (const void *oid_mem1, const void *oid_mem2)
 
 #if !defined(NDEBUG)
 static int
-btree_verify_node (THREAD_ENTRY * thread_p, const BTID_INT * btid_int, PAGE_PTR page_ptr)
+btree_verify_node (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PAGE_PTR page_ptr)
 {
   int ret = NO_ERROR;
   int key_cnt;
@@ -19526,7 +19523,7 @@ btree_verify_node (THREAD_ENTRY * thread_p, const BTID_INT * btid_int, PAGE_PTR 
 }
 
 static int
-btree_verify_nonleaf_node (THREAD_ENTRY * thread_p, const BTID_INT * btid_int, PAGE_PTR page_ptr)
+btree_verify_nonleaf_node (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PAGE_PTR page_ptr)
 {
   BTREE_NODE_HEADER *header = NULL;
   TP_DOMAIN *key_domain;
@@ -19621,7 +19618,7 @@ btree_verify_nonleaf_node (THREAD_ENTRY * thread_p, const BTID_INT * btid_int, P
 }
 
 static int
-btree_verify_leaf_node (THREAD_ENTRY * thread_p, const BTID_INT * btid_int, PAGE_PTR page_ptr)
+btree_verify_leaf_node (THREAD_ENTRY * thread_p, BTID_INT * btid_int, PAGE_PTR page_ptr)
 {
   BTREE_NODE_HEADER *header = NULL;
   TP_DOMAIN *key_domain;
@@ -21527,8 +21524,8 @@ btree_pack_object (char *ptr, BTID_INT * btid_int, BTREE_NODE_TYPE node_type, RE
  *	 (where second objects starts).
  */
 static int
-btree_or_get_object (OR_BUF * buf, const BTID_INT * btid_int, BTREE_NODE_TYPE node_type, int after_key_offset,
-		     OID * oid, OID * class_oid, BTREE_MVCC_INFO * mvcc_info)
+btree_or_get_object (OR_BUF * buf, BTID_INT * btid_int, BTREE_NODE_TYPE node_type, int after_key_offset, OID * oid,
+		     OID * class_oid, BTREE_MVCC_INFO * mvcc_info)
 {
   short mvcc_flags = 0;		/* MVCC flags read from object OID. */
   int error_code = NO_ERROR;	/* Error code. */
@@ -21802,7 +21799,7 @@ btree_compare_btids (void *mem_btid1, void *mem_btid2)
  *			  and if node type is leaf and if key doesn't have overflow pages).
  */
 int
-btree_check_valid_record (THREAD_ENTRY * thread_p, const BTID_INT * btid, RECDES * recp, BTREE_NODE_TYPE node_type,
+btree_check_valid_record (THREAD_ENTRY * thread_p, BTID_INT * btid, RECDES * recp, BTREE_NODE_TYPE node_type,
 			  DB_VALUE * key)
 {
 #define BTREE_CHECK_VALID_PRINT_REC_MAX_LENGTH 1024
@@ -34749,7 +34746,7 @@ btree_online_index_change_state (THREAD_ENTRY * thread_p, BTID_INT * btid_int, R
 // is_first (in)  : is object first in record?
 //
 static bool
-btree_is_class_oid_packed (const BTID_INT * btid_int, RECDES * record, BTREE_NODE_TYPE node_type, bool is_first)
+btree_is_class_oid_packed (BTID_INT * btid_int, RECDES * record, BTREE_NODE_TYPE node_type, bool is_first)
 {
   // class oid is packed if:
   // 1. index is unique and

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -765,7 +765,7 @@ extern SCAN_CODE btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid,
 
 extern int xbtree_get_key_type (THREAD_ENTRY * thread_p, BTID btid, TP_DOMAIN ** key_type);
 
-extern int btree_leaf_get_first_object (BTID_INT * btid, RECDES * recp, OID * oidp, OID * class_oid,
+extern int btree_leaf_get_first_object (const BTID_INT * btid, RECDES * recp, OID * oidp, OID * class_oid,
 					BTREE_MVCC_INFO * mvcc_info);
 extern void btree_leaf_change_first_object (THREAD_ENTRY * thread_p, RECDES * recp, BTID_INT * btid, OID * oidp,
 					    OID * class_oidp, BTREE_MVCC_INFO * mvcc_info, int *key_offset,
@@ -795,8 +795,8 @@ extern void btree_rv_read_keybuf_nocopy (THREAD_ENTRY * thread_p, char *datap, i
 extern void btree_rv_read_keybuf_two_objects (THREAD_ENTRY * thread_p, char *datap, int data_size, BTID_INT * btid_int,
 					      BTREE_OBJECT_INFO * first_version, BTREE_OBJECT_INFO * second_version,
 					      OR_BUF * key_buf);
-extern int btree_check_valid_record (THREAD_ENTRY * thread_p, BTID_INT * btid, RECDES * recp, BTREE_NODE_TYPE node_type,
-				     DB_VALUE * key);
+extern int btree_check_valid_record (THREAD_ENTRY * thread_p, const BTID_INT * btid, RECDES * recp,
+				     BTREE_NODE_TYPE node_type, DB_VALUE * key);
 extern int btree_check_foreign_key (THREAD_ENTRY * thread_p, OID * cls_oid, HFID * hfid, OID * oid, DB_VALUE * keyval,
 				    int n_attrs, OID * pk_cls_oid, BTID * pk_btid, const char *fk_name);
 

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -765,7 +765,7 @@ extern SCAN_CODE btree_get_next_node_info (THREAD_ENTRY * thread_p, BTID * btid,
 
 extern int xbtree_get_key_type (THREAD_ENTRY * thread_p, BTID btid, TP_DOMAIN ** key_type);
 
-extern int btree_leaf_get_first_object (const BTID_INT * btid, RECDES * recp, OID * oidp, OID * class_oid,
+extern int btree_leaf_get_first_object (BTID_INT * btid, RECDES * recp, OID * oidp, OID * class_oid,
 					BTREE_MVCC_INFO * mvcc_info);
 extern void btree_leaf_change_first_object (THREAD_ENTRY * thread_p, RECDES * recp, BTID_INT * btid, OID * oidp,
 					    OID * class_oidp, BTREE_MVCC_INFO * mvcc_info, int *key_offset,
@@ -795,8 +795,8 @@ extern void btree_rv_read_keybuf_nocopy (THREAD_ENTRY * thread_p, char *datap, i
 extern void btree_rv_read_keybuf_two_objects (THREAD_ENTRY * thread_p, char *datap, int data_size, BTID_INT * btid_int,
 					      BTREE_OBJECT_INFO * first_version, BTREE_OBJECT_INFO * second_version,
 					      OR_BUF * key_buf);
-extern int btree_check_valid_record (THREAD_ENTRY * thread_p, const BTID_INT * btid, RECDES * recp,
-				     BTREE_NODE_TYPE node_type, DB_VALUE * key);
+extern int btree_check_valid_record (THREAD_ENTRY * thread_p, BTID_INT * btid, RECDES * recp, BTREE_NODE_TYPE node_type,
+				     DB_VALUE * key);
 extern int btree_check_foreign_key (THREAD_ENTRY * thread_p, OID * cls_oid, HFID * hfid, OID * oid, DB_VALUE * keyval,
 				    int n_attrs, OID * pk_cls_oid, BTID * pk_btid, const char *fk_name);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-209

B-tree split/merge root/node functions have to be replicated atomically.
Replication has to fix b-tree root/parent node before the node that is split / the nodes that are merged.

Implementation
- convert log_sysop_start to log_sysop_start_atomic before btree_split_root, btree_split_node, btree_merge_root and btree_merge_node
- btree_split_node: change the order of modifications to make parent changes (in page P) before children changes (in pages Q and R)
- btree_split_node: segregate record descriptor variables between those for parent page P (`rec`) from that used for child pages Q and R (`rec_fence`) to make different steps independent of each other and thus allowing to re-order them
