### PR TITLE
[CBRD-23842] Fixed hanging while making CDC log infos

### DIFF
--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10487,9 +10487,9 @@ scdc_find_lsa (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int req
       cdc_reinitialize_queue (&start_lsa);
 
       while (cdc_Gl.producer.state == CDC_PRODUCER_STATE_WAIT)
-        {
-          cdc_wakeup_producer ();
-        }
+	{
+	  cdc_wakeup_producer ();
+	}
 
       ptr = or_pack_int (reply, error_code);
       ptr = or_pack_log_lsa (ptr, &start_lsa);

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10486,7 +10486,10 @@ scdc_find_lsa (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int req
 
       cdc_reinitialize_queue (&start_lsa);
 
-      cdc_wakeup_producer ();
+      while (cdc_Gl.producer.state == CDC_PRODUCER_STATE_WAIT)
+        {
+          cdc_wakeup_producer ();
+        }
 
       ptr = or_pack_int (reply, error_code);
       ptr = or_pack_log_lsa (ptr, &start_lsa);

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10486,10 +10486,7 @@ scdc_find_lsa (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int req
 
       cdc_reinitialize_queue (&start_lsa);
 
-      while (cdc_Gl.producer.state == CDC_PRODUCER_STATE_WAIT)
-	{
-	  cdc_wakeup_producer ();
-	}
+      cdc_wakeup_producer ();
 
       ptr = or_pack_int (reply, error_code);
       ptr = or_pack_log_lsa (ptr, &start_lsa);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

Fixed hang cases 
1. If log info is created for the same update statement, an ER_CDC_IGNORE_LOG_INFO_INTERNAL error is returned, but this error is handled incorrectly.
2. cdc_cleaup() requests a producer to wait without checking a state of producer. So, if producer thread is not in the running state, the wait request is queued and behave incorrectly.
