### PR TITLE
[CBRD-24099] error during recovery analysis when a sysop expected to have postpone info does not have it

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9891,6 +9891,8 @@ log_read_sysop_start_postpone (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_P
 {
   int error_code = NO_ERROR;
 
+  assert (!log_lsa->is_null ());
+
   if (log_page->hdr.logical_pageid != log_lsa->pageid)
     {
       error_code = logpb_fetch_page (thread_p, log_lsa, LOG_CS_FORCE_USE, log_page);

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1889,17 +1889,25 @@ log_rv_analysis_end_checkpoint (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_
 	    }
 	  tdes->rcv.sysop_start_postpone_lsa = chkpt_topone->sysop_start_postpone_lsa;
 	  tdes->rcv.atomic_sysop_start_lsa = chkpt_topone->atomic_sysop_start_lsa;
-	  log_lsa_local = chkpt_topone->sysop_start_postpone_lsa;
-	  error_code =
-	    log_read_sysop_start_postpone (thread_p, &log_lsa_local, log_page_local, false, &sysop_start_postpone,
-					   NULL, NULL, NULL, NULL);
-	  if (error_code != NO_ERROR)
+	  if (!chkpt_topone->sysop_start_postpone_lsa.is_null ())
 	    {
-	      assert (false);
-	      return error_code;
+	      log_lsa_local = chkpt_topone->sysop_start_postpone_lsa;
+	      error_code =
+		log_read_sysop_start_postpone (thread_p, &log_lsa_local, log_page_local, false, &sysop_start_postpone,
+					       NULL, NULL, NULL, NULL);
+	      if (error_code != NO_ERROR)
+		{
+		  assert (false);
+		  return error_code;
+		}
+	      tdes->topops.stack[tdes->topops.last].lastparent_lsa = sysop_start_postpone.sysop_end.lastparent_lsa;
+	      tdes->topops.stack[tdes->topops.last].posp_lsa = sysop_start_postpone.posp_lsa;
 	    }
-	  tdes->topops.stack[tdes->topops.last].lastparent_lsa = sysop_start_postpone.sysop_end.lastparent_lsa;
-	  tdes->topops.stack[tdes->topops.last].posp_lsa = sysop_start_postpone.posp_lsa;
+	  else
+	    {
+	      tdes->topops.stack[tdes->topops.last].lastparent_lsa = chkpt_topone->atomic_sysop_start_lsa;
+	      tdes->topops.stack[tdes->topops.last].posp_lsa.set_null ();
+	    }
 	}
     }
 

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1575,6 +1575,7 @@ log_rv_analysis_sysop_end (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_l
 
   if (tdes->state == TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE)
     {
+      // topops stack is bumped when system operation start postpone is found.
       assert (tdes->topops.last == 0);
       if (commit_start_postpone)
 	{
@@ -1879,18 +1880,20 @@ log_rv_analysis_end_checkpoint (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_
 		}
 	    }
 
-	  if (tdes->topops.last == -1)
-	    {
-	      tdes->topops.last++;
-	    }
-	  else
-	    {
-	      assert (tdes->topops.last == 0);
-	    }
 	  tdes->rcv.sysop_start_postpone_lsa = chkpt_topone->sysop_start_postpone_lsa;
 	  tdes->rcv.atomic_sysop_start_lsa = chkpt_topone->atomic_sysop_start_lsa;
 	  if (!chkpt_topone->sysop_start_postpone_lsa.is_null ())
 	    {
+	      // Bump the sysop level to save lastparent_lsa and posp_lsa.
+	      if (tdes->topops.last == -1)
+		{
+		  tdes->topops.last++;
+		}
+	      else
+		{
+		  assert (tdes->topops.last == 0);
+		}
+
 	      log_lsa_local = chkpt_topone->sysop_start_postpone_lsa;
 	      error_code =
 		log_read_sysop_start_postpone (thread_p, &log_lsa_local, log_page_local, false, &sysop_start_postpone,
@@ -1902,11 +1905,6 @@ log_rv_analysis_end_checkpoint (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_
 		}
 	      tdes->topops.stack[tdes->topops.last].lastparent_lsa = sysop_start_postpone.sysop_end.lastparent_lsa;
 	      tdes->topops.stack[tdes->topops.last].posp_lsa = sysop_start_postpone.posp_lsa;
-	    }
-	  else
-	    {
-	      tdes->topops.stack[tdes->topops.last].lastparent_lsa = chkpt_topone->atomic_sysop_start_lsa;
-	      tdes->topops.stack[tdes->topops.last].posp_lsa.set_null ();
 	    }
 	}
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24099

- an uncommited transaction, that is executing either system operation postpone or an atomic system operation, is assumed to contain postpone information without actually checking.
- atomic sysop start is not expected to bump the system operation level during analysis. It is wrongfully bumped after checkpoint analysis.
- fix by bumping the system operation level, only if sysop start postpone is not null.
