### PR TITLE
[LETS-251] Add log records for START/END ATOMIC REPLICATION

### DIFF
--- a/src/transaction/log_2pc.c
+++ b/src/transaction/log_2pc.c
@@ -2008,6 +2008,8 @@ log_2pc_recovery_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE record_ty
     case LOG_DUMMY_CRASH_RECOVERY:
     case LOG_REPLICATION_DATA:
     case LOG_REPLICATION_STATEMENT:
+    case LOG_START_ATOMIC_REPL:
+    case LOG_END_ATOMIC_REPL:
     case LOG_END_OF_LOG:
       /*
        * Either the prepare to commit or start 2PC record should

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -402,6 +402,8 @@ prior_lsa_alloc_and_copy_data (THREAD_ENTRY *thread_p, LOG_RECTYPE rec_type, LOG
     case LOG_REPLICATION_STATEMENT:
     case LOG_2PC_START:
     case LOG_SYSOP_ATOMIC_START:
+    case LOG_START_ATOMIC_REPL:
+    case LOG_END_ATOMIC_REPL:
       assert (rlength == 0 && rdata == NULL);
 
       error_code = prior_lsa_gen_record (thread_p, node, rec_type, ulength, udata);
@@ -1239,6 +1241,8 @@ prior_lsa_gen_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_RECTYPE 
     case LOG_2PC_COMMIT_INFORM_PARTICPS:
     case LOG_2PC_ABORT_INFORM_PARTICPS:
     case LOG_SYSOP_ATOMIC_START:
+    case LOG_START_ATOMIC_REPL:
+    case LOG_END_ATOMIC_REPL:
       assert (length == 0 && data == NULL);
       break;
 

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -6177,6 +6177,8 @@ la_log_record_process (LOG_RECORD_HEADER * lrec, LOG_LSA * final, LOG_PAGE * pg_
       break;
 
     case LOG_DUMMY_CRASH_RECOVERY:
+    case LOG_START_ATOMIC_REPL:
+    case LOG_END_ATOMIC_REPL:
       snprintf (buffer, sizeof (buffer), "process log record (type:%d). skip this log record. LSA: %lld|%d",
 		lrec->type, (long long int) final->pageid, (int) final->offset);
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, buffer);

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -6177,8 +6177,6 @@ la_log_record_process (LOG_RECORD_HEADER * lrec, LOG_LSA * final, LOG_PAGE * pg_
       break;
 
     case LOG_DUMMY_CRASH_RECOVERY:
-    case LOG_START_ATOMIC_REPL:
-    case LOG_END_ATOMIC_REPL:
       snprintf (buffer, sizeof (buffer), "process log record (type:%d). skip this log record. LSA: %lld|%d",
 		lrec->type, (long long int) final->pageid, (int) final->offset);
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, buffer);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7909,6 +7909,8 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
 	    case LOG_DUMMY_HA_SERVER_STATE:
 	    case LOG_DUMMY_OVF_RECORD:
 	    case LOG_DUMMY_GENERIC:
+	    case LOG_START_ATOMIC_REPL:
+	    case LOG_END_ATOMIC_REPL:
 	    case LOG_SUPPLEMENTAL_INFO:
 	      break;
 
@@ -7930,8 +7932,6 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
 	    case LOG_END_OF_LOG:
 	    case LOG_SMALLER_LOGREC_TYPE:
 	    case LOG_LARGER_LOGREC_TYPE:
-	    case LOG_START_ATOMIC_REPL:
-	    case LOG_END_ATOMIC_REPL:
 	    default:
 	      {
 		char msg[LINE_MAX];
@@ -8344,6 +8344,8 @@ log_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postp
 		    case LOG_DUMMY_OVF_RECORD:
 		    case LOG_DUMMY_GENERIC:
 		    case LOG_SUPPLEMENTAL_INFO:
+		    case LOG_START_ATOMIC_REPL:
+		    case LOG_END_ATOMIC_REPL:
 		      break;
 
 		    case LOG_POSTPONE:
@@ -8399,8 +8401,6 @@ log_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postp
 		    case LOG_DUMMY_CRASH_RECOVERY:
 		    case LOG_SMALLER_LOGREC_TYPE:
 		    case LOG_LARGER_LOGREC_TYPE:
-		    case LOG_START_ATOMIC_REPL:
-		    case LOG_END_ATOMIC_REPL:
 		    default:
 #if defined(CUBRID_DEBUG)
 		      er_log_debug (ARG_FILE_LINE,

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -483,6 +483,11 @@ log_to_string (LOG_RECTYPE type)
     case LOG_SYSOP_ATOMIC_START:
       return "LOG_SYSOP_ATOMIC_START";
 
+    case LOG_START_ATOMIC_REPL:
+      return "LOG_START_ATOMIC_REPL";
+    case LOG_END_ATOMIC_REPL:
+      return "LOG_END_ATOMIC_REPL";
+
     case LOG_DUMMY_HA_SERVER_STATE:
       return "LOG_DUMMY_HA_SERVER_STATE";
     case LOG_DUMMY_OVF_RECORD:
@@ -6990,6 +6995,8 @@ log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type
     case LOG_DUMMY_CRASH_RECOVERY:
     case LOG_DUMMY_OVF_RECORD:
     case LOG_DUMMY_GENERIC:
+    case LOG_START_ATOMIC_REPL:
+    case LOG_END_ATOMIC_REPL:
       fprintf (out_fp, "\n");
       /* That is all for this kind of log record */
       break;
@@ -7923,6 +7930,8 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
 	    case LOG_END_OF_LOG:
 	    case LOG_SMALLER_LOGREC_TYPE:
 	    case LOG_LARGER_LOGREC_TYPE:
+	    case LOG_START_ATOMIC_REPL:
+	    case LOG_END_ATOMIC_REPL:
 	    default:
 	      {
 		char msg[LINE_MAX];
@@ -8390,6 +8399,8 @@ log_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postp
 		    case LOG_DUMMY_CRASH_RECOVERY:
 		    case LOG_SMALLER_LOGREC_TYPE:
 		    case LOG_LARGER_LOGREC_TYPE:
+		    case LOG_START_ATOMIC_REPL:
+		    case LOG_END_ATOMIC_REPL:
 		    default:
 #if defined(CUBRID_DEBUG)
 		      er_log_debug (ARG_FILE_LINE,

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -136,6 +136,8 @@ enum log_rectype
   LOG_MVCC_DIFF_UNDOREDO_DATA = 49,	/* diff undo redo data for MVCC operations */
   LOG_SYSOP_ATOMIC_START = 50,	/* Log marker to start atomic operations that need to be rollbacked immediately after
                  * redo phase of recovery and before finishing postpones */
+  LOG_START_ATOMIC_REPL = 51,
+  LOG_END_ATOMIC_REPL = 52,
 
   LOG_DUMMY_GENERIC,		/* used for flush for now. it is ridiculous to create dummy log records for every single
                                  * case. we should find a different approach */

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2659,6 +2659,8 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		case LOG_DUMMY_GENERIC:
 		case LOG_SUPPLEMENTAL_INFO:
 		case LOG_SYSOP_ATOMIC_START:
+		case LOG_START_ATOMIC_REPL:
+		case LOG_END_ATOMIC_REPL:
 		  /* Not for UNDO ... */
 		  /* Break switch to go to previous record */
 		  break;
@@ -2749,8 +2751,6 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		case LOG_2PC_COMMIT_INFORM_PARTICPS:
 		case LOG_2PC_RECV_ACK:
 		case LOG_DUMMY_CRASH_RECOVERY:
-		case LOG_START_ATOMIC_REPL:
-		case LOG_END_ATOMIC_REPL:
 		case LOG_END_OF_LOG:
 		  /* This looks like a system error in the analysis phase */
 #if defined(CUBRID_DEBUG)

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1726,6 +1726,8 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 	    case LOG_SUPPLEMENTAL_INFO:
 	    case LOG_END_OF_LOG:
 	    case LOG_SYSOP_ATOMIC_START:
+	    case LOG_START_ATOMIC_REPL:
+	    case LOG_END_ATOMIC_REPL:
 	      break;
 
 	    case LOG_SYSOP_END:
@@ -2747,6 +2749,8 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		case LOG_2PC_COMMIT_INFORM_PARTICPS:
 		case LOG_2PC_RECV_ACK:
 		case LOG_DUMMY_CRASH_RECOVERY:
+		case LOG_START_ATOMIC_REPL:
+		case LOG_END_ATOMIC_REPL:
 		case LOG_END_OF_LOG:
 		  /* This looks like a system error in the analysis phase */
 #if defined(CUBRID_DEBUG)
@@ -3300,6 +3304,8 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
     case LOG_DUMMY_GENERIC:
     case LOG_END_OF_LOG:
     case LOG_SYSOP_ATOMIC_START:
+    case LOG_START_ATOMIC_REPL:
+    case LOG_END_ATOMIC_REPL:
       break;
 
     case LOG_REPLICATION_DATA:

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -1726,6 +1726,8 @@ log_rv_analysis_record_on_tran_server (THREAD_ENTRY *thread_p, LOG_RECTYPE log_t
     case LOG_DUMMY_OVF_RECORD:
     case LOG_DUMMY_GENERIC:
     case LOG_SUPPLEMENTAL_INFO:
+    case LOG_START_ATOMIC_REPL:
+    case LOG_END_ATOMIC_REPL:
       break;
 
     case LOG_SMALLER_LOGREC_TYPE:


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-251

Added 2 new types of log records `LOG_START_ATOMIC_REPL` and `LOG_END_ATOMIC_REPL`, to be used in the replication system.
