### PR TITLE
[LETS-187] Add xboot_initialize_remote_storage_server()

### DIFF
--- a/src/base/xserver_interface.h
+++ b/src/base/xserver_interface.h
@@ -60,6 +60,8 @@ extern int xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_creden
 				    PGLENGTH db_desired_pagesize, volatile DKNPAGES xlog_npages,
 				    PGLENGTH db_desired_log_page_size, OID * rootclass_oid, HFID * rootclass_hfid,
 				    int client_lock_wait, TRAN_ISOLATION client_isolation);
+extern int xboot_initialize_remote_storage_server (THREAD_ENTRY * thread_p, const char *dbname,
+						   const BOOT_DB_PATH_INFO * db_path_info);
 extern const char *xboot_get_server_session_key (void);
 extern int xboot_register_client (THREAD_ENTRY * thread_p, BOOT_CLIENT_CREDENTIAL * client_credential,
 				  int client_lock_wait, TRAN_ISOLATION client_isolation, TRAN_STATE * tran_state,

--- a/src/base/xserver_interface.h
+++ b/src/base/xserver_interface.h
@@ -60,8 +60,7 @@ extern int xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_creden
 				    PGLENGTH db_desired_pagesize, volatile DKNPAGES xlog_npages,
 				    PGLENGTH db_desired_log_page_size, OID * rootclass_oid, HFID * rootclass_hfid,
 				    int client_lock_wait, TRAN_ISOLATION client_isolation);
-extern int xboot_initialize_remote_storage_server (THREAD_ENTRY * thread_p, const char *dbname,
-						   const BOOT_DB_PATH_INFO * db_path_info);
+extern int xboot_initialize_remote_storage_server (const char *dbname, const BOOT_DB_PATH_INFO * db_path_info);
 extern const char *xboot_get_server_session_key (void);
 extern int xboot_register_client (THREAD_ENTRY * thread_p, BOOT_CLIENT_CREDENTIAL * client_credential,
 				  int client_lock_wait, TRAN_ISOLATION client_isolation, TRAN_STATE * tran_state,


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-187

Add the function that puts new database created for remote storage in databases.txt file. The function follows the code handling databases.txt entry from `xboot_initialize_server`, with the next conditions:

  - Lock dabatases.txt file while adding new entry
  - Do not overwrite existing entry; return with error if the same database already exists

Small refactoring in the xboot_initialize_server code; reorganized conditional branches to clarify the logic flow.