### PR TITLE
[CBRD-24116] Problem that in SQL without a join predicate, outer dependency is not set properly.

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -1879,6 +1879,7 @@ qo_add_dummy_join_term (QO_ENV * env, QO_NODE * p_node, QO_NODE * on_node)
     case PT_JOIN_LEFT_OUTER:
       QO_TERM_JOIN_TYPE (term) = JOIN_LEFT;
       QO_ADD_RIGHT_DEP_SET (on_node, p_node);
+      QO_ADD_OUTER_DEP_SET (on_node, p_node);
       break;
     case PT_JOIN_RIGHT_OUTER:
       QO_TERM_JOIN_TYPE (term) = JOIN_RIGHT;

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -1850,7 +1850,9 @@ qo_add_dep_term (QO_NODE * derived_node, BITSET * depend_nodes, BITSET * depend_
 static QO_TERM *
 qo_add_dummy_join_term (QO_ENV * env, QO_NODE * p_node, QO_NODE * on_node)
 {
-  QO_TERM *term;
+  int i;
+  QO_TERM *term, *temp_term;
+  QO_NODE *temp_node;
 
   QO_ASSERT (env, env->nterms < env->Nterms);
   QO_ASSERT (env, QO_NODE_IDX (p_node) >= 0);
@@ -1879,7 +1881,20 @@ qo_add_dummy_join_term (QO_ENV * env, QO_NODE * p_node, QO_NODE * on_node)
     case PT_JOIN_LEFT_OUTER:
       QO_TERM_JOIN_TYPE (term) = JOIN_LEFT;
       QO_ADD_RIGHT_DEP_SET (on_node, p_node);
-      QO_ADD_OUTER_DEP_SET (on_node, p_node);
+      for (i = 0; i < env->nterms; i++)
+	{
+	  temp_term = QO_ENV_TERM (env, i);
+	  temp_node = QO_ENV_NODE (env, QO_TERM_LOCATION (temp_term));
+	  if (temp_node == on_node && QO_OUTER_JOIN_TERM (temp_term))
+	    {
+	      break;
+	    }
+	}
+      if (i == env->nterms)
+	{
+	  /* if join term does not exists, add outer dep set */
+	  QO_ADD_OUTER_DEP_SET (on_node, p_node);
+	}
       break;
     case PT_JOIN_RIGHT_OUTER:
       QO_TERM_JOIN_TYPE (term) = JOIN_RIGHT;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24116

If the join predicate does not exist, the dummy join term is added.
When a dummy join term is added, I fix that an outer dep is set if there are no join terms related to the second node.
