### PR TITLE
[CBRD-24111] Problem with view merging when there is a variable definition ( ':=' ) in the where clause.

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -528,6 +528,8 @@ extern "C"
   extern bool pt_has_inst_in_where_and_select_list (PARSER_CONTEXT * parser, PT_NODE * node);
   extern void pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level);
   extern bool pt_has_nullable_term (PARSER_CONTEXT * parser, PT_NODE * node);
+  extern bool pt_has_define_vars (PARSER_CONTEXT * parser, PT_NODE * stmt);
+  extern PT_NODE *pt_is_define_vars (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 
   extern void pt_preset_hostvar (PARSER_CONTEXT * parser, PT_NODE * hv_node);
   extern void pt_set_expected_domain (PT_NODE * node, TP_DOMAIN * domain);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -2975,6 +2975,7 @@ pt_is_define_vars (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *cont
 {
   bool *is_define_vars = (bool *) arg;
   *continue_walk = PT_CONTINUE_WALK;
+  assert (has_define_vars != NULL);
 
   if (*is_define_vars)
     {

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -2975,7 +2975,7 @@ pt_is_define_vars (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *cont
 {
   bool *is_define_vars = (bool *) arg;
   *continue_walk = PT_CONTINUE_WALK;
-  assert (has_define_vars != NULL);
+  assert (is_define_vars != NULL);
 
   if (*is_define_vars)
     {

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -2947,6 +2947,54 @@ pt_has_aggregate (PARSER_CONTEXT * parser, PT_NODE * node)
 }
 
 /*
+ * pt_has_define_vars () - check if a statement uses define vars ':='
+ * return	: true if the statement uses define vars ':='
+ * parser (in)	: parser context
+ * stmt (in)	: statement
+ */
+bool
+pt_has_define_vars (PARSER_CONTEXT * parser, PT_NODE * stmt)
+{
+  bool has_define_vars = false;
+
+  parser_walk_tree (parser, stmt, pt_is_define_vars, &has_define_vars, NULL, NULL);
+
+  return has_define_vars;
+}
+
+/*
+ * pt_is_define_vars () - check if a node is a define vars ':='
+ * return : node
+ * parser (in) : parser context
+ * node (in)   : node
+ * arg (in)    :
+ * continue_walk (in) :
+ */
+PT_NODE *
+pt_is_define_vars (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
+{
+  bool *is_define_vars = (bool *) arg;
+  *continue_walk = PT_CONTINUE_WALK;
+
+  if (*is_define_vars)
+    {
+      /* stop checking, there already is a parameter in the statement */
+      return node;
+    }
+
+  if (node->node_type == PT_EXPR)
+    {
+      if (node->info.expr.op == PT_DEFINE_VARIABLE)
+	{
+	  *is_define_vars = true;
+	  *continue_walk = PT_STOP_WALK;
+	}
+    }
+
+  return node;
+}
+
+/*
  * pt_has_analytic () -
  *   return: true if statement has an analytic function in its parse tree
  *   parser(in):

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1632,10 +1632,11 @@ mq_update_order_by (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * quer
  * in this function, main query check is performed.
  * It should be merged in the following cases.
  *  - INSERT query
- * (MAINQUERY) It is not pushable(mergeable) in the following cases.
+ * It is not pushable(mergeable) in the following cases.
  *  - Class is Spec set(spec set??)
  *  - has CONNECT BY
  *  - view spec is outer join spec
+ *  - main query's where has define_vars ':='
  *  - subquery check ==> mq_is_pushable_subquery()
  */
 static PT_NODE *
@@ -1735,7 +1736,7 @@ mq_substitute_subquery_in_statement (PARSER_CONTEXT * parser, PT_NODE * statemen
 	  rewrite_as_derived = true;
 	}
       /* check for CONNECT BY */
-      else if (tmp_result->info.query.q.select.connect_by)
+      else if (PT_IS_SELECT (tmp_result) && tmp_result->info.query.q.select.connect_by)
 	{
 	  rewrite_as_derived = true;
 	}
@@ -1745,7 +1746,7 @@ mq_substitute_subquery_in_statement (PARSER_CONTEXT * parser, PT_NODE * statemen
 	  rewrite_as_derived = true;
 	}
       /* determine if main query's where has define_vars ':=' */
-      else if (pt_has_define_vars (parser, tmp_result->info.query.q.select.where))
+      else if (pt_has_define_vars (parser, pred))
 	{
 	  rewrite_as_derived = true;
 	}

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1744,7 +1744,12 @@ mq_substitute_subquery_in_statement (PARSER_CONTEXT * parser, PT_NODE * statemen
 	{
 	  rewrite_as_derived = true;
 	}
-      /* determine if vclass_query is pushable */
+      /* determine if main query's where has define_vars ':=' */
+      else if (pt_has_define_vars (parser, tmp_result->info.query.q.select.where))
+	{
+	  rewrite_as_derived = true;
+	}
+      /* determine if view(subquery) is pushable */
       else if (!mq_is_pushable_subquery (parser, query_spec, is_only_spec))
 	{
 	  rewrite_as_derived = true;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24111

if the variable definition(:=) is in the WHERE of the main query, I fix so that view merge is not performed.
