### PR TITLE
[LETS-254] Atomic replication for heap_update_bigone

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -21898,6 +21898,7 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
   bool is_old_home_updated;
   RECDES new_home_recdes;
   VFID ovf_vfid;
+  bool atomic_replication_flag = false;
 
   LOG_TDES *tdes = NULL;
 
@@ -21928,6 +21929,7 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
 
   // All situations will modify more than one page, so they are all marked as atomic for replication.
   log_append_empty_record (thread_p, LOG_START_ATOMIC_REPL, NULL);
+  atomic_replication_flag = true;
   if (is_mvcc_op)
     {
       /* log old overflow record and set prev version lsa */
@@ -22100,7 +22102,11 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
   /* Fall through to exit. */
 
 exit:
-  log_append_empty_record (thread_p, LOG_END_ATOMIC_REPL, NULL);
+  if (atomic_replication_flag == true)
+    {
+      log_append_empty_record (thread_p, LOG_END_ATOMIC_REPL, NULL);
+    }
+
   return error_code;
 }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -21926,6 +21926,7 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
 
   HEAP_PERF_TRACK_PREPARE (thread_p, context);
 
+  log_append_empty_record (thread_p, LOG_START_ATOMIC_REPL, NULL);
   if (is_mvcc_op)
     {
       /* log old overflow record and set prev version lsa */
@@ -22098,6 +22099,7 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
   /* Fall through to exit. */
 
 exit:
+  log_append_empty_record (thread_p, LOG_END_ATOMIC_REPL, NULL);
   return error_code;
 }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -21926,6 +21926,7 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
 
   HEAP_PERF_TRACK_PREPARE (thread_p, context);
 
+  // All situations will modify more than one page, so they are all marked as atomic for replication.
   log_append_empty_record (thread_p, LOG_START_ATOMIC_REPL, NULL);
   if (is_mvcc_op)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-254

Added start/end atomic replication logs to `heap_update_bigone` to mark the zones that modify more than one page.
