### PR TITLE
[LETS-255] Atomic replication for heap_update_home

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -21926,6 +21926,7 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
 
   HEAP_PERF_TRACK_PREPARE (thread_p, context);
 
+  log_append_empty_record (thread_p, LOG_START_ATOMIC_REPL, NULL);
   if (is_mvcc_op)
     {
       /* log old overflow record and set prev version lsa */
@@ -22098,6 +22099,7 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
   /* Fall through to exit. */
 
 exit:
+  log_append_empty_record (thread_p, LOG_END_ATOMIC_REPL, NULL);
   return error_code;
 }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -21926,8 +21926,6 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
 
   HEAP_PERF_TRACK_PREPARE (thread_p, context);
 
-  // All situations will modify more than one page, so they are all marked as atomic for replication.
-  log_append_empty_record (thread_p, LOG_START_ATOMIC_REPL, NULL);
   if (is_mvcc_op)
     {
       /* log old overflow record and set prev version lsa */
@@ -22100,7 +22098,6 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
   /* Fall through to exit. */
 
 exit:
-  log_append_empty_record (thread_p, LOG_END_ATOMIC_REPL, NULL);
   return error_code;
 }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -21926,6 +21926,7 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
 
   HEAP_PERF_TRACK_PREPARE (thread_p, context);
 
+  // All situations will modify more than one page, so they are all marked as atomic for replication.
   log_append_empty_record (thread_p, LOG_START_ATOMIC_REPL, NULL);
   if (is_mvcc_op)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-255

Added start/end atomic replication logs to `heap_update_home` to mark the zones that modify more than one page.
