### PR TITLE
[LETS-219] Transfer log header and log append page to PTS

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -246,8 +246,15 @@ bool is_tran_server_with_remote_storage ()
 
 passive_tran_server *get_passive_tran_server_ptr ()
 {
-  assert (pts_Gl != nullptr);
-  return pts_Gl;
+  if (is_passive_transaction_server())
+    {
+      assert (pts_Gl != nullptr);
+      return pts_Gl;
+    }
+  else
+    {
+      assert (is_passive_transaction_server());
+    }
 }
 
 #else // !SERVER_MODE = SA_MODE

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -19,6 +19,7 @@
 #include "server_type.hpp"
 
 #include "active_tran_server.hpp"
+#include "passive_tran_server.hpp"
 #include "communication_server_channel.hpp"
 #include "connection_defs.h"
 #include "error_manager.h"
@@ -134,7 +135,9 @@ int init_server_type (const char *db_name)
 	}
       else if (is_passive_transaction_server ())
 	{
-	  ts_Gl.reset (new passive_tran_server ());
+	  passive_tran_server *const pts_ptr = new passive_tran_server ();
+	  ts_Gl.reset (pts_ptr);
+	  init_passive_tran_server_shadow_ptr (pts_ptr);
 	}
       else
 	{
@@ -184,6 +187,10 @@ void finalize_server_type ()
 {
   if (get_server_type () == SERVER_TYPE_TRANSACTION)
     {
+      if (is_passive_transaction_server ())
+	{
+	  reset_passive_tran_server_shadow_ptr ();
+	}
       ts_Gl->disconnect_page_server ();
       ts_Gl.reset (nullptr);
     }

--- a/src/base/server_type.hpp
+++ b/src/base/server_type.hpp
@@ -21,6 +21,13 @@
 
 #include "server_type_enum.hpp"
 
+#include <memory>
+
+/* forward declarations
+ */
+class passive_tran_server;
+class tran_server;
+
 bool is_active_transaction_server ();
 bool is_page_server ();
 bool is_passive_transaction_server ();
@@ -32,4 +39,9 @@ transaction_server_type get_transaction_server_type ();
 void set_server_type (SERVER_TYPE type);
 void finalize_server_type ();
 int init_server_type (const char *db_name);
+
+passive_tran_server *get_passive_tran_server_ptr ();
+
+extern std::unique_ptr<tran_server> ts_Gl;
+
 #endif // _SERVER_TYPE_H_

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -18,7 +18,6 @@
 
 #include "page_server.hpp"
 
-#include "async_page_fetcher.hpp"
 #include "disk_manager.h"
 #include "error_manager.h"
 #include "log_impl.h"
@@ -115,7 +114,7 @@ page_server::connection_handler::receive_log_page_fetch (cubpacking::unpacker &u
       _er_log_debug (ARG_FILE_LINE, "Received request for log from Transaction Server. Page ID: %lld \n", pageid);
     }
 
-  m_ps.get_page_fetcher ()->fetch_log_page (pageid, std::bind (&page_server::connection_handler::on_log_page_read_result,
+  m_ps.get_page_fetcher ().fetch_log_page (pageid, std::bind (&page_server::connection_handler::on_log_page_read_result,
       this, std::placeholders::_1, std::placeholders::_2));
 }
 
@@ -132,7 +131,7 @@ page_server::connection_handler::receive_data_page_fetch (cubpacking::unpacker &
   LOG_LSA target_repl_lsa;
   cublog::lsa_utils::unpack (message_upk, target_repl_lsa);
 
-  m_ps.get_page_fetcher ()->fetch_data_page (vpid, target_repl_lsa,
+  m_ps.get_page_fetcher ().fetch_data_page (vpid, target_repl_lsa,
       std::bind (&page_server::connection_handler::on_data_page_read_result, this, std::placeholders::_1,
 		 std::placeholders::_2));
 }
@@ -144,7 +143,7 @@ page_server::connection_handler::receive_log_boot_info_fetch (cubpacking::unpack
 
   auto callback_func = std::bind (&page_server::connection_handler::on_log_boot_info_result,
 				  this, std::placeholders::_1);
-  m_ps.get_page_fetcher ()->fetch_log_boot_info (std::move (callback_func));
+  m_ps.get_page_fetcher ().fetch_log_boot_info (std::move (callback_func));
 }
 
 void
@@ -341,11 +340,11 @@ page_server::is_passive_tran_server_connected () const
   return !m_passive_tran_server_conn.empty ();
 }
 
-cublog::async_page_fetcher *
+cublog::async_page_fetcher &
 page_server::get_page_fetcher ()
 {
   assert (m_page_fetcher != nullptr);
-  return m_page_fetcher.get ();
+  return *m_page_fetcher.get ();
 }
 
 void

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -71,9 +71,8 @@ page_server::connection_handler::connection_handler (cubcomm::channel &chn, page
     },
     // passive only
     {
-      tran_to_page_request::SEND_LOG_HEADER_LOG_APPEND_PREV_LSA_FETCH,
-      std::bind (&page_server::connection_handler::receive_log_header_log_append_prev_lsa_fetch,
-		 std::ref (*this), std::placeholders::_1)
+      tran_to_page_request::SEND_LOG_INIT_BOOT_FETCH,
+      std::bind (&page_server::connection_handler::receive_log_boot_info_fetch, std::ref (*this), std::placeholders::_1)
     },
   }));
 
@@ -139,11 +138,11 @@ page_server::connection_handler::receive_data_page_fetch (cubpacking::unpacker &
 }
 
 void
-page_server::connection_handler::receive_log_header_log_append_prev_lsa_fetch (cubpacking::unpacker &upk)
+page_server::connection_handler::receive_log_boot_info_fetch (cubpacking::unpacker &upk)
 {
   // empty request message
 
-  auto callback_func = std::bind (&page_server::connection_handler::on_log_header_log_append_prev_lsa_result,
+  auto callback_func = std::bind (&page_server::connection_handler::on_log_boot_info_result,
 				  this, std::placeholders::_1);
 
   using call_func_type = std::string (*) (cubthread::entry *);
@@ -151,17 +150,17 @@ page_server::connection_handler::receive_log_header_log_append_prev_lsa_fetch (c
 
   cubthread::entry_task *const task
     = new cublog::single_arg_call_callback_task<call_func_type, callback_func_type> (
-	  log_pack_log_header_log_append_prev_lsa, std::move (callback_func));
+	  log_pack_log_boot_info, std::move (callback_func));
   // ownership goes to the thread pool that will handle it
   m_ps.get_page_fetcher ().submit_task (task);
 }
 
 void
-page_server::connection_handler::on_log_header_log_append_prev_lsa_result (std::string &&message)
+page_server::connection_handler::on_log_boot_info_result (std::string &&message)
 {
   assert (message.size () > 0);
 
-  m_conn->push (page_to_tran_request::SEND_LOG_HEADER_LOG_APPEND_PREV_LSA, std::move (message));
+  m_conn->push (page_to_tran_request::SEND_LOG_BOOT_INFO, std::move (message));
 }
 
 void

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -19,7 +19,7 @@
 #ifndef _PAGE_SERVER_HPP_
 #define _PAGE_SERVER_HPP_
 
-#include "async_page_fetcher.hpp"
+#include "log_storage.hpp"
 #include "request_sync_client_server.hpp"
 #include "tran_page_requests.hpp"
 
@@ -29,6 +29,7 @@
 namespace cublog
 {
   class replicator;
+  class async_page_fetcher;
 }
 namespace cubpacking
 {
@@ -63,7 +64,7 @@ class page_server
     void disconnect_tran_server (connection_handler *conn);
     bool is_active_tran_server_connected () const;
     bool is_passive_tran_server_connected () const;
-    cublog::async_page_fetcher &get_page_fetcher ();
+    cublog::async_page_fetcher *get_page_fetcher ();
 
   private:
     class connection_handler

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -81,14 +81,14 @@ class page_server
       private:
 	void on_log_page_read_result (const LOG_PAGE *log_page, int error_code);
 	void on_data_page_read_result (const FILEIO_PAGE *page_ptr, int error_code);
-	void on_log_header_log_append_prev_lsa_result (std::string &&message);
+	void on_log_boot_info_result (std::string &&message);
 
 	void receive_boot_info_request (cubpacking::unpacker &upk);
 	void receive_log_prior_list (cubpacking::unpacker &upk);
 	void receive_log_page_fetch (cubpacking::unpacker &upk);
 	void receive_data_page_fetch (cubpacking::unpacker &upk);
 	void receive_disconnect_request (cubpacking::unpacker &upk);
-	void receive_log_header_log_append_prev_lsa_fetch (cubpacking::unpacker &upk);
+	void receive_log_boot_info_fetch (cubpacking::unpacker &upk);
 
 	std::unique_ptr<tran_server_conn_t> m_conn;
 	page_server &m_ps;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -19,6 +19,7 @@
 #ifndef _PAGE_SERVER_HPP_
 #define _PAGE_SERVER_HPP_
 
+#include "async_page_fetcher.hpp"
 #include "log_storage.hpp"
 #include "request_sync_client_server.hpp"
 #include "tran_page_requests.hpp"
@@ -29,7 +30,6 @@
 namespace cublog
 {
   class replicator;
-  class async_page_fetcher;
 }
 namespace cubpacking
 {
@@ -64,7 +64,7 @@ class page_server
     void disconnect_tran_server (connection_handler *conn);
     bool is_active_tran_server_connected () const;
     bool is_passive_tran_server_connected () const;
-    cublog::async_page_fetcher *get_page_fetcher ();
+    cublog::async_page_fetcher &get_page_fetcher ();
 
   private:
     class connection_handler

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -49,19 +49,21 @@ class page_server
 
     void set_active_tran_server_connection (cubcomm::channel &&chn);
     void set_passive_tran_server_connection (cubcomm::channel &&chn);
-    void disconnect_active_tran_server();
-    void disconnect_tran_server (connection_handler *conn);
     void disconnect_all_tran_server ();
-    bool is_active_tran_server_connected () const;
-    bool is_passive_tran_server_connected () const;
     void push_request_to_active_tran_server (page_to_tran_request reqid, std::string &&payload);
-    cublog::async_page_fetcher &get_page_fetcher ();
     cublog::replicator &get_replicator ();
     void start_log_replicator (const log_lsa &start_lsa);
     void finish_replication_during_shutdown (cubthread::entry &thread_entry);
 
     void init_page_fetcher ();
     void finalize_page_fetcher ();
+
+  private:
+    void disconnect_active_tran_server ();
+    void disconnect_tran_server (connection_handler *conn);
+    bool is_active_tran_server_connected () const;
+    bool is_passive_tran_server_connected () const;
+    cublog::async_page_fetcher &get_page_fetcher ();
 
   private:
     class connection_handler
@@ -79,11 +81,14 @@ class page_server
       private:
 	void on_log_page_read_result (const LOG_PAGE *log_page, int error_code);
 	void on_data_page_read_result (const FILEIO_PAGE *page_ptr, int error_code);
+	void on_log_header_log_append_prev_lsa_result (std::string &&message);
+
 	void receive_boot_info_request (cubpacking::unpacker &upk);
 	void receive_log_prior_list (cubpacking::unpacker &upk);
 	void receive_log_page_fetch (cubpacking::unpacker &upk);
 	void receive_data_page_fetch (cubpacking::unpacker &upk);
 	void receive_disconnect_request (cubpacking::unpacker &upk);
+	void receive_log_header_log_append_prev_lsa_fetch (cubpacking::unpacker &upk);
 
 	std::unique_ptr<tran_server_conn_t> m_conn;
 	page_server &m_ps;

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -18,6 +18,26 @@
 
 #include "passive_tran_server.hpp"
 
+// non-owning "shadow" pointer of globally visible ps_Gl
+passive_tran_server *pts_Gl = nullptr;
+
+void
+init_passive_tran_server_shadow_ptr (passive_tran_server *ptr)
+{
+  assert (pts_Gl == nullptr);
+  assert (ptr != nullptr);
+
+  pts_Gl = ptr;
+}
+
+void
+reset_passive_tran_server_shadow_ptr ()
+{
+  assert (pts_Gl != nullptr);
+
+  pts_Gl = nullptr;
+}
+
 bool
 passive_tran_server::uses_remote_storage () const
 {

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -116,10 +116,3 @@ void passive_tran_server::send_and_receive_log_boot_info (THREAD_ENTRY *thread_p
   // to be called once
   m_log_boot_info = "not empty";
 }
-
-void send_and_receive_log_boot_info (THREAD_ENTRY *thread_p)
-{
-  passive_tran_server *const pts_ptr = get_passive_tran_server_ptr ();
-
-  pts_ptr->send_and_receive_log_boot_info (thread_p);
-}

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -18,6 +18,7 @@
 
 #include "log_impl.h"
 #include "passive_tran_server.hpp"
+#include "server_type.hpp"
 #include "thread_manager.hpp"
 
 // non-owning "shadow" pointer of globally visible ps_Gl

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -107,6 +107,10 @@ void passive_tran_server::send_and_receive_log_boot_info (THREAD_ENTRY *thread_p
 
   // prev lsa
   std::memcpy (&log_Gl.append.prev_lsa, message_buf, sizeof (struct log_lsa));
+  message_buf += sizeof (struct log_lsa);
+
+  // safe-guard that the message has been consumed
+  assert (message_buf == m_log_boot_info.c_str () + m_log_boot_info.size ());
 
   // do not leave m_log_boot_info empty as a safeguard as this function is only supposed
   // to be called once

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -16,7 +16,9 @@
  *
  */
 
+#include "log_impl.h"
 #include "passive_tran_server.hpp"
+#include "thread_manager.hpp"
 
 // non-owning "shadow" pointer of globally visible ps_Gl
 passive_tran_server *pts_Gl = nullptr;
@@ -54,4 +56,85 @@ void
 passive_tran_server::on_boot ()
 {
   assert (is_passive_transaction_server ());
+}
+
+tran_server::request_handlers_map_t
+passive_tran_server::get_request_handlers ()
+{
+  request_handlers_map_t::value_type log_header_log_append_prev_lsa_handler_value =
+	  std::make_pair (page_to_tran_request::SEND_LOG_HEADER_LOG_APPEND_PREV_LSA,
+			  std::bind (&passive_tran_server::receive_log_header_log_append_prev_lsa,
+				     std::ref (*this), std::placeholders::_1));
+
+  std::map<page_to_tran_request, std::function<void (cubpacking::unpacker &upk)>> handlers_map =
+	      tran_server::get_request_handlers ();
+
+  handlers_map.insert (log_header_log_append_prev_lsa_handler_value);
+
+  return handlers_map;
+}
+
+void
+passive_tran_server::receive_log_header_log_append_prev_lsa (cubpacking::unpacker &upk)
+{
+  std::string message;
+  upk.unpack_string (message);
+
+  const int log_page_size = db_log_page_size ();
+  assert (message.size () == (2 * log_page_size + sizeof (struct log_lsa)));
+
+  // pass to caller thread; it has the thread context needed to access engine functions
+  {
+    std::lock_guard<std::mutex> lockg { m_log_header_log_append_prev_lsa_mtx };
+    m_log_header_log_append_prev_lsa.swap (message);
+  }
+  m_log_header_log_append_prev_lsa_condvar.notify_one ();
+}
+
+void passive_tran_server::send_and_receive_log_header_log_append_prev_lsa (THREAD_ENTRY *thread_p)
+{
+  assert (m_log_header_log_append_prev_lsa.empty ());
+
+  // empty message request
+  push_request (tran_to_page_request::SEND_LOG_HEADER_LOG_APPEND_PREV_LSA_FETCH, std::string ());
+
+  {
+    std::unique_lock<std::mutex> ulock { m_log_header_log_append_prev_lsa_mtx };
+    // TODO: wait_for a limited time in case page server hangs
+    m_log_header_log_append_prev_lsa_condvar.wait (ulock, [this] ()
+    {
+      return !m_log_header_log_append_prev_lsa.empty ();
+    });
+  }
+
+  const char *message_buf = m_log_header_log_append_prev_lsa.c_str ();
+  const int log_page_size = db_log_page_size ();
+
+  // log header, copy and initialize header
+  assert (log_Gl.loghdr_pgptr != nullptr);
+  std::memcpy (reinterpret_cast<char *> (log_Gl.loghdr_pgptr), message_buf, log_page_size);
+  LOG_HEADER *const log_hdr = reinterpret_cast<LOG_HEADER *> (log_Gl.loghdr_pgptr->area);
+  log_Gl.hdr = *log_hdr;
+  message_buf += log_page_size;
+
+  // log append
+  assert (log_Gl.append.log_pgptr == nullptr);
+  /* fetch the append page; append pages are always new pages */
+  log_Gl.append.log_pgptr = logpb_create_page (thread_p, log_Gl.hdr.append_lsa.pageid);
+  std::memcpy (reinterpret_cast<char *> (log_Gl.append.log_pgptr), message_buf, log_page_size);
+  message_buf += log_page_size;
+
+  // prev lsa
+  std::memcpy (&log_Gl.append.prev_lsa, message_buf, sizeof (struct log_lsa));
+
+  // do not leave m_log_header_log_append_prev_lsa empty as a safeguard as this function is only supposed
+  // to be called once
+  m_log_header_log_append_prev_lsa = "not empty";
+}
+
+void send_and_receive_log_header_log_append_prev_lsa (THREAD_ENTRY *thread_p)
+{
+  assert (pts_Gl != nullptr);
+
+  pts_Gl->send_and_receive_log_header_log_append_prev_lsa (thread_p);
 }

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -21,26 +21,6 @@
 #include "server_type.hpp"
 #include "thread_manager.hpp"
 
-// non-owning "shadow" pointer of globally visible ps_Gl
-passive_tran_server *pts_Gl = nullptr;
-
-void
-init_passive_tran_server_shadow_ptr (passive_tran_server *ptr)
-{
-  assert (pts_Gl == nullptr);
-  assert (ptr != nullptr);
-
-  pts_Gl = ptr;
-}
-
-void
-reset_passive_tran_server_shadow_ptr ()
-{
-  assert (pts_Gl != nullptr);
-
-  pts_Gl = nullptr;
-}
-
 bool
 passive_tran_server::uses_remote_storage () const
 {
@@ -135,7 +115,7 @@ void passive_tran_server::send_and_receive_log_boot_info (THREAD_ENTRY *thread_p
 
 void send_and_receive_log_boot_info (THREAD_ENTRY *thread_p)
 {
-  assert (pts_Gl != nullptr);
+  passive_tran_server *const pts_ptr = get_passive_tran_server_ptr ();
 
-  pts_Gl->send_and_receive_log_boot_info (thread_p);
+  pts_ptr->send_and_receive_log_boot_info (thread_p);
 }

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -61,21 +61,21 @@ passive_tran_server::on_boot ()
 tran_server::request_handlers_map_t
 passive_tran_server::get_request_handlers ()
 {
-  request_handlers_map_t::value_type log_header_log_append_prev_lsa_handler_value =
-	  std::make_pair (page_to_tran_request::SEND_LOG_HEADER_LOG_APPEND_PREV_LSA,
-			  std::bind (&passive_tran_server::receive_log_header_log_append_prev_lsa,
+  request_handlers_map_t::value_type log_boot_info_handler_value =
+	  std::make_pair (page_to_tran_request::SEND_LOG_BOOT_INFO,
+			  std::bind (&passive_tran_server::receive_log_boot_info,
 				     std::ref (*this), std::placeholders::_1));
 
   std::map<page_to_tran_request, std::function<void (cubpacking::unpacker &upk)>> handlers_map =
 	      tran_server::get_request_handlers ();
 
-  handlers_map.insert (log_header_log_append_prev_lsa_handler_value);
+  handlers_map.insert (log_boot_info_handler_value);
 
   return handlers_map;
 }
 
 void
-passive_tran_server::receive_log_header_log_append_prev_lsa (cubpacking::unpacker &upk)
+passive_tran_server::receive_log_boot_info (cubpacking::unpacker &upk)
 {
   std::string message;
   upk.unpack_string (message);
@@ -85,29 +85,29 @@ passive_tran_server::receive_log_header_log_append_prev_lsa (cubpacking::unpacke
 
   // pass to caller thread; it has the thread context needed to access engine functions
   {
-    std::lock_guard<std::mutex> lockg { m_log_header_log_append_prev_lsa_mtx };
-    m_log_header_log_append_prev_lsa.swap (message);
+    std::lock_guard<std::mutex> lockg { m_log_boot_info_mtx };
+    m_log_boot_info.swap (message);
   }
-  m_log_header_log_append_prev_lsa_condvar.notify_one ();
+  m_log_boot_info_condvar.notify_one ();
 }
 
-void passive_tran_server::send_and_receive_log_header_log_append_prev_lsa (THREAD_ENTRY *thread_p)
+void passive_tran_server::send_and_receive_log_boot_info (THREAD_ENTRY *thread_p)
 {
-  assert (m_log_header_log_append_prev_lsa.empty ());
+  assert (m_log_boot_info.empty ());
 
   // empty message request
-  push_request (tran_to_page_request::SEND_LOG_HEADER_LOG_APPEND_PREV_LSA_FETCH, std::string ());
+  push_request (tran_to_page_request::SEND_LOG_INIT_BOOT_FETCH, std::string ());
 
   {
-    std::unique_lock<std::mutex> ulock { m_log_header_log_append_prev_lsa_mtx };
+    std::unique_lock<std::mutex> ulock { m_log_boot_info_mtx };
     // TODO: wait_for a limited time in case page server hangs
-    m_log_header_log_append_prev_lsa_condvar.wait (ulock, [this] ()
+    m_log_boot_info_condvar.wait (ulock, [this] ()
     {
-      return !m_log_header_log_append_prev_lsa.empty ();
+      return !m_log_boot_info.empty ();
     });
   }
 
-  const char *message_buf = m_log_header_log_append_prev_lsa.c_str ();
+  const char *message_buf = m_log_boot_info.c_str ();
   const int log_page_size = db_log_page_size ();
 
   // log header, copy and initialize header
@@ -127,14 +127,14 @@ void passive_tran_server::send_and_receive_log_header_log_append_prev_lsa (THREA
   // prev lsa
   std::memcpy (&log_Gl.append.prev_lsa, message_buf, sizeof (struct log_lsa));
 
-  // do not leave m_log_header_log_append_prev_lsa empty as a safeguard as this function is only supposed
+  // do not leave m_log_boot_info empty as a safeguard as this function is only supposed
   // to be called once
-  m_log_header_log_append_prev_lsa = "not empty";
+  m_log_boot_info = "not empty";
 }
 
-void send_and_receive_log_header_log_append_prev_lsa (THREAD_ENTRY *thread_p)
+void send_and_receive_log_boot_info (THREAD_ENTRY *thread_p)
 {
   assert (pts_Gl != nullptr);
 
-  pts_Gl->send_and_receive_log_header_log_append_prev_lsa (thread_p);
+  pts_Gl->send_and_receive_log_boot_info (thread_p);
 }

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -45,9 +45,6 @@ class passive_tran_server : public tran_server
     std::condition_variable m_log_boot_info_condvar;
 };
 
-extern void init_passive_tran_server_shadow_ptr (passive_tran_server *ptr);
-extern void reset_passive_tran_server_shadow_ptr ();
-
 extern void send_and_receive_log_boot_info (THREAD_ENTRY *thread_p);
 
 #endif // !_passive_tran_server_HPP_

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -45,6 +45,4 @@ class passive_tran_server : public tran_server
     std::condition_variable m_log_boot_info_condvar;
 };
 
-extern void send_and_receive_log_boot_info (THREAD_ENTRY *thread_p);
-
 #endif // !_passive_tran_server_HPP_

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -28,13 +28,26 @@ class passive_tran_server : public tran_server
     {
     }
 
-    bool uses_remote_storage () const final override;
+  public:
+    void send_and_receive_log_header_log_append_prev_lsa (THREAD_ENTRY *thread_p);
+
   private:
-    void on_boot () final override;
+    bool uses_remote_storage () const final override;
     bool get_remote_storage_config () final override;
+    void on_boot () final override;
+    request_handlers_map_t get_request_handlers () final override;
+
+    void receive_log_header_log_append_prev_lsa (cubpacking::unpacker &upk);
+
+  private:
+    std::mutex m_log_header_log_append_prev_lsa_mtx;
+    std::string m_log_header_log_append_prev_lsa;
+    std::condition_variable m_log_header_log_append_prev_lsa_condvar;
 };
 
 extern void init_passive_tran_server_shadow_ptr (passive_tran_server *ptr);
 extern void reset_passive_tran_server_shadow_ptr ();
+
+extern void send_and_receive_log_header_log_append_prev_lsa (THREAD_ENTRY *thread_p);
 
 #endif // !_passive_tran_server_HPP_

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -29,7 +29,7 @@ class passive_tran_server : public tran_server
     }
 
   public:
-    void send_and_receive_log_header_log_append_prev_lsa (THREAD_ENTRY *thread_p);
+    void send_and_receive_log_boot_info (THREAD_ENTRY *thread_p);
 
   private:
     bool uses_remote_storage () const final override;
@@ -37,17 +37,17 @@ class passive_tran_server : public tran_server
     void on_boot () final override;
     request_handlers_map_t get_request_handlers () final override;
 
-    void receive_log_header_log_append_prev_lsa (cubpacking::unpacker &upk);
+    void receive_log_boot_info (cubpacking::unpacker &upk);
 
   private:
-    std::mutex m_log_header_log_append_prev_lsa_mtx;
-    std::string m_log_header_log_append_prev_lsa;
-    std::condition_variable m_log_header_log_append_prev_lsa_condvar;
+    std::mutex m_log_boot_info_mtx;
+    std::string m_log_boot_info;
+    std::condition_variable m_log_boot_info_condvar;
 };
 
 extern void init_passive_tran_server_shadow_ptr (passive_tran_server *ptr);
 extern void reset_passive_tran_server_shadow_ptr ();
 
-extern void send_and_receive_log_header_log_append_prev_lsa (THREAD_ENTRY *thread_p);
+extern void send_and_receive_log_boot_info (THREAD_ENTRY *thread_p);
 
 #endif // !_passive_tran_server_HPP_

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -34,4 +34,7 @@ class passive_tran_server : public tran_server
     bool get_remote_storage_config () final override;
 };
 
+extern void init_passive_tran_server_shadow_ptr (passive_tran_server *ptr);
+extern void reset_passive_tran_server_shadow_ptr ();
+
 #endif // !_passive_tran_server_HPP_

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -31,14 +31,21 @@ enum class tran_to_page_request
   SEND_LOG_PRIOR_LIST,
 
   // Passive only
+  SEND_LOG_HEADER_LOG_APPEND_PREV_LSA_FETCH,
 };
 
 enum class page_to_tran_request
 {
+  // Common
   SEND_BOOT_INFO,
+
+  // Active only
   SEND_SAVED_LSA,
   SEND_LOG_PAGE,
-  SEND_DATA_PAGE
+  SEND_DATA_PAGE,
+
+  // Passive only
+  SEND_LOG_HEADER_LOG_APPEND_PREV_LSA,
 };
 
 #endif // !_TRAN_PAGE_REQUESTS_HPP_

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -31,7 +31,7 @@ enum class tran_to_page_request
   SEND_LOG_PRIOR_LIST,
 
   // Passive only
-  SEND_LOG_HEADER_LOG_APPEND_PREV_LSA_FETCH,
+  SEND_LOG_INIT_BOOT_FETCH,
 };
 
 enum class page_to_tran_request
@@ -45,7 +45,7 @@ enum class page_to_tran_request
   SEND_DATA_PAGE,
 
   // Passive only
-  SEND_LOG_HEADER_LOG_APPEND_PREV_LSA,
+  SEND_LOG_BOOT_INFO,
 };
 
 #endif // !_TRAN_PAGE_REQUESTS_HPP_

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -30,7 +30,6 @@
 #include <functional>
 #include <string>
 
-std::unique_ptr<tran_server> ts_Gl;
 static void assert_is_tran_server ();
 
 tran_server::~tran_server ()

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -25,7 +25,6 @@
 #include "request_sync_client_server.hpp"
 #include "tran_page_requests.hpp"
 
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -122,7 +121,5 @@ class tran_server
     std::condition_variable m_boot_info_condvar;
     bool m_is_boot_info_received = false;
 };
-
-extern std::unique_ptr<tran_server> ts_Gl;
 
 #endif // !_tran_server_HPP_

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -23,7 +23,6 @@
 #include "communication_server_channel.hpp"
 #include "page_broker.hpp"
 #include "request_sync_client_server.hpp"
-#include "server_type.hpp"
 #include "tran_page_requests.hpp"
 
 #include <memory>

--- a/src/storage/async_page_fetcher.cpp
+++ b/src/storage/async_page_fetcher.cpp
@@ -114,9 +114,9 @@ namespace cublog
 
   void log_boot_info_fetch_task::execute (context_type &context)
   {
-    const std::string str = log_pack_log_boot_info (&context);
+    std::string message = log_pack_log_boot_info (&context);
 
-    m_callback (str);
+    m_callback (std::move (message));
   }
 
   async_page_fetcher::async_page_fetcher ()

--- a/src/storage/async_page_fetcher.cpp
+++ b/src/storage/async_page_fetcher.cpp
@@ -66,7 +66,7 @@ namespace cublog
     if (m_logpageid == LOGPB_HEADER_PAGE_ID)
       {
 	// Make sure log page header is updated
-	logpb_force_flush_header_and_pages (&cubthread::get_entry ());
+	logpb_force_flush_header_and_pages (&context);
       }
     int err = logreader.set_lsa_and_fetch_page (loglsa);
     m_callback (logreader.get_page (), err);
@@ -126,6 +126,14 @@ namespace cublog
     data_page_fetch_task *const task = new data_page_fetch_task (vpid, repl_lsa, std::move (func));
 
     // Ownership is transfered to m_threads.
+    m_threads->execute (task);
+  }
+
+  void async_page_fetcher::submit_task (cubthread::entry_task *task)
+  {
+    assert (task != nullptr);
+
+    // ownership is transfered to the worker pool
     m_threads->execute (task);
   }
 }

--- a/src/storage/async_page_fetcher.hpp
+++ b/src/storage/async_page_fetcher.hpp
@@ -32,7 +32,7 @@ namespace cublog
     public:
       using log_page_callback_type = std::function<void (const LOG_PAGE *, int)>;
       using data_page_callback_type = std::function<void (const FILEIO_PAGE *, int)>;
-      using log_boot_info_callback_type = std::function<void (std::string)>;
+      using log_boot_info_callback_type = std::function<void (std::string &&)>;
 
     public:
       async_page_fetcher ();

--- a/src/storage/async_page_fetcher.hpp
+++ b/src/storage/async_page_fetcher.hpp
@@ -27,38 +27,20 @@
 
 namespace cublog
 {
-  /* generic task to be used with to call a engine function taking one argument - the thread context
-   * and returning a single result that is then passed back via the callback
-   *  - call func: takes as single argument the thread context and returns value
-   *  - callback func: takes as single argument the value returned by the call func
-   *
-   * TODO: error handling
-   */
-  template <typename CALL_FUNC, typename CALLBACK_FUNC>
-  class single_arg_call_callback_task : public cubthread::entry_task
-  {
-    public:
-      explicit single_arg_call_callback_task (CALL_FUNC &&call_func, CALLBACK_FUNC &&callback_func);
-
-      void execute (context_type &context) override;
-
-    private:
-      CALL_FUNC m_call_func;
-      CALLBACK_FUNC m_callback_func;
-  };
-
   class async_page_fetcher
   {
     public:
       using log_page_callback_type = std::function<void (const LOG_PAGE *, int)>;
       using data_page_callback_type = std::function<void (const FILEIO_PAGE *, int)>;
+      using log_boot_info_callback_type = std::function<void (std::string)>;
 
+    public:
       async_page_fetcher ();
       ~async_page_fetcher ();
 
       void fetch_log_page (LOG_PAGEID pageid, log_page_callback_type &&func);
       void fetch_data_page (const VPID &vpid, const LOG_LSA repl_lsa, data_page_callback_type &&func);
-      void submit_task (cubthread::entry_task *task);
+      void fetch_log_boot_info (log_boot_info_callback_type &&callback_func);
 
     private:
       cubthread::entry_workpool *m_threads = nullptr;
@@ -67,23 +49,6 @@ namespace cublog
       // identity as to properly identify these agains perf logging
       std::unique_ptr<cubthread::entry_manager> m_worker_pool_context_manager;
   };
-
-  template <typename CALL_FUNC, typename CALLBACK_FUNC>
-  single_arg_call_callback_task<CALL_FUNC, CALLBACK_FUNC>::single_arg_call_callback_task (
-	  CALL_FUNC &&call_func, CALLBACK_FUNC &&callback_func)
-    : m_call_func { call_func }, m_callback_func { callback_func }
-  {
-  }
-
-  /*
-   * template implementations
-   */
-
-  template <typename CALL_FUNC, typename CALLBACK_FUNC>
-  void single_arg_call_callback_task<CALL_FUNC, CALLBACK_FUNC>::execute (context_type &context)
-  {
-    m_callback_func (m_call_func (&context));
-  }
 }
 
 #endif //_ASYNC_PAGE_FETCHER_HPP_

--- a/src/storage/async_page_fetcher.hpp
+++ b/src/storage/async_page_fetcher.hpp
@@ -27,6 +27,25 @@
 
 namespace cublog
 {
+  /* generic task to be used with to call a engine function taking one argument - the thread context
+   * and returning a single result that is then passed back via the callback
+   *  - call func: takes as single argument the thread context and returns value
+   *  - callback func: takes as single argument the value returned by the call func
+   *
+   * TODO: error handling
+   */
+  template <typename CALL_FUNC, typename CALLBACK_FUNC>
+  class single_arg_call_callback_task : public cubthread::entry_task
+  {
+    public:
+      explicit single_arg_call_callback_task (CALL_FUNC &&call_func, CALLBACK_FUNC &&callback_func);
+
+      void execute (context_type &context) override;
+
+    private:
+      CALL_FUNC m_call_func;
+      CALLBACK_FUNC m_callback_func;
+  };
 
   class async_page_fetcher
   {
@@ -39,6 +58,7 @@ namespace cublog
 
       void fetch_log_page (LOG_PAGEID pageid, log_page_callback_type &&func);
       void fetch_data_page (const VPID &vpid, const LOG_LSA repl_lsa, data_page_callback_type &&func);
+      void submit_task (cubthread::entry_task *task);
 
     private:
       cubthread::entry_workpool *m_threads = nullptr;
@@ -48,6 +68,22 @@ namespace cublog
       std::unique_ptr<cubthread::entry_manager> m_worker_pool_context_manager;
   };
 
+  template <typename CALL_FUNC, typename CALLBACK_FUNC>
+  single_arg_call_callback_task<CALL_FUNC, CALLBACK_FUNC>::single_arg_call_callback_task (
+	  CALL_FUNC &&call_func, CALLBACK_FUNC &&callback_func)
+    : m_call_func { call_func }, m_callback_func { callback_func }
+  {
+  }
+
+  /*
+   * template implementations
+   */
+
+  template <typename CALL_FUNC, typename CALLBACK_FUNC>
+  void single_arg_call_callback_task<CALL_FUNC, CALLBACK_FUNC>::execute (context_type &context)
+  {
+    m_callback_func (m_call_func (&context));
+  }
 }
 
 #endif //_ASYNC_PAGE_FETCHER_HPP_

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -983,7 +983,6 @@ extern int logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr
 				    DKNPAGES npages, INT64 * db_creation);
 extern LOG_PAGE *logpb_create_header_page (THREAD_ENTRY * thread_p);
 extern void logpb_fetch_header (THREAD_ENTRY * thread_p, LOG_HEADER * hdr);
-extern void logpb_fetch_header_with_buffer (THREAD_ENTRY * thread_p, LOG_HEADER * hdr, LOG_PAGE * log_pgptr);
 extern void logpb_flush_header (THREAD_ENTRY * thread_p);
 extern int logpb_fetch_page (THREAD_ENTRY * thread_p, const LOG_LSA * req_lsa, LOG_CS_ACCESS_MODE access_mode,
 			     LOG_PAGE * log_pgptr);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3366,11 +3366,11 @@ std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p)
 
   // log header
   assert (log_Gl.loghdr_pgptr != nullptr);
-  packed_message.append(reinterpret_cast<const char*> (log_Gl.loghdr_pgptr), log_page_size);
+  packed_message.append (reinterpret_cast<const char*> (log_Gl.loghdr_pgptr), log_page_size);
 
   // log append
   assert (log_Gl.append.log_pgptr != nullptr);
-  packed_message.append(reinterpret_cast<const char*> (log_Gl.append.log_pgptr), log_page_size);
+  packed_message.append (reinterpret_cast<const char*> (log_Gl.append.log_pgptr), log_page_size);
 
   // prev lsa
   packed_message.append (reinterpret_cast<const char *> (&log_Gl.append.prev_lsa), sizeof (struct log_lsa));

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3375,8 +3375,6 @@ std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p)
   // prev lsa
   packed_message.append (reinterpret_cast<const char *> (&log_Gl.append.prev_lsa), sizeof (struct log_lsa));
 
-  assert (packed_message.size () == (2 * log_page_size + sizeof (struct log_lsa)));
-
   return packed_message;
 }
 // *INDENT-ON*

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3349,12 +3349,12 @@ log_skip_logging_set_lsa (THREAD_ENTRY * thread_p, LOG_DATA_ADDR * addr)
   return;
 }
 
-/* log_pack_log_header_log_append_prev_lsa - pack together the log header, log append pages
+/* log_pack_log_boot_info - pack together the log header, log append pages
  *              and prev lsa for the purpose of sending them to the passive transaction server
  *              as part of the log initialization sequence
  */
 // *INDENT-OFF*
-std::string log_pack_log_header_log_append_prev_lsa (THREAD_ENTRY * thread_p)
+std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p)
 {
   LOG_CS_ENTER_READ_MODE (thread_p);
   scope_exit log_cs_exit_ftor ( [thread_p] { LOG_CS_EXIT (thread_p); } );

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -229,7 +229,7 @@ extern void log_update_global_btid_online_index_stats (THREAD_ENTRY * thread_p);
 extern void log_write_metalog_to_file (bool file_open_is_fatal);
 
 // *INDENT-OFF*
-extern std::string log_pack_log_header_log_append_prev_lsa (THREAD_ENTRY * thread_p);
+extern std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p);
 // *INDENT-ON*
 
 #if defined (SERVER_MODE)

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -228,6 +228,10 @@ extern void log_update_global_btid_online_index_stats (THREAD_ENTRY * thread_p);
 
 extern void log_write_metalog_to_file (bool file_open_is_fatal);
 
+// *INDENT-OFF*
+extern std::string log_pack_log_header_log_append_prev_lsa (THREAD_ENTRY * thread_p);
+// *INDENT-ON*
+
 #if defined (SERVER_MODE)
 extern void cdc_daemons_init ();
 extern void cdc_daemons_destroy ();

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -313,6 +313,7 @@ static void logpb_dump_information (FILE * out_fp);
 static void logpb_dump_to_flush_page (FILE * out_fp);
 static void logpb_dump_pages (FILE * out_fp);
 static void logpb_initialize_backup_info (LOG_HEADER * loghdr);
+static void logpb_fetch_header_with_buffer (THREAD_ENTRY * thread_p, LOG_HEADER * hdr, LOG_PAGE * log_pgptr);
 static LOG_PAGE **logpb_writev_append_pages (THREAD_ENTRY * thread_p, LOG_PAGE ** to_flush, DKNPAGES npages);
 static int logpb_get_guess_archive_num (THREAD_ENTRY * thread_p, LOG_PAGEID pageid);
 static void logpb_set_unavailable_archive (THREAD_ENTRY * thread_p, int arv_num);

--- a/unit_tests/log/dummy_page_server.cpp
+++ b/unit_tests/log/dummy_page_server.cpp
@@ -16,6 +16,7 @@
  *
  */
 
+#include "async_page_fetcher.hpp"
 #include "log_replication.hpp"
 #include "page_server.hpp"
 

--- a/unit_tests/log/test_main_data_page_fetcher.cpp
+++ b/unit_tests/log/test_main_data_page_fetcher.cpp
@@ -223,6 +223,13 @@ pgbuf_unfix_debug (THREAD_ENTRY *thread_p, PAGE_PTR pgptr, const char *caller_fi
   delete_page (pgptr);
 }
 
+std::string
+log_pack_log_boot_info (THREAD_ENTRY *thread_p)
+{
+  assert ("function is not used in the context of this unit test" == nullptr);
+  return std::string ();
+}
+
 #if defined(NDEBUG)
 PAGE_PTR
 pgbuf_fix_release (THREAD_ENTRY *thread_p, const VPID *vpid, PAGE_FETCH_MODE fetch_mode,

--- a/unit_tests/log/test_main_log_page_fetcher.cpp
+++ b/unit_tests/log/test_main_log_page_fetcher.cpp
@@ -195,6 +195,13 @@ pgbuf_fix_release (THREAD_ENTRY *thread_p, const VPID *vpid, PAGE_FETCH_MODE fet
   return nullptr;
 }
 
+std::string
+log_pack_log_boot_info (THREAD_ENTRY *thread_p)
+{
+  assert ("function is not used in the context of this unit test" == nullptr);
+  return std::string ();
+}
+
 #if defined(NDEBUG)
 void
 pgbuf_unfix (THREAD_ENTRY *thread_p, PAGE_PTR pgptr)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-219

Infrastructure to transfer the log header page, log append page and prev lsa from page server to passive transaction server.

Implementation:
- new request id's for `LOG_BOOT_INFO` request and response
- add a passive transaction server 'shadow pointer' - `pts_Gl` - alongside the polymorphic one - `ts_Gl` - that is to be used only in passive transaction server scenarios - pointer is not visible globally, it needs to be accessed via a guarded function
- new task used to call a function that packs the log boot info into a string in an asynchronous manner
- logic to pack together log header page, log append page and prev lsa on the page server and transfer and unpack it on the passive transaction server side
-  move ts_Gl pointer to server_type to group initialization/reset of object in a single place (for consistency, in the future, ps_Gl also needs to be moved there and also transformed into a unique ptr)

