### PR TITLE
[CBRD-24103] The permission of lob sub-directory and lob files have e…

### DIFF
--- a/src/storage/es_posix.c
+++ b/src/storage/es_posix.c
@@ -132,7 +132,7 @@ retry:
       assert (false);
       return ER_ES_INVALID_PATH;
     }
-  ret = mkdir (dirbuf, 0755);
+  ret = mkdir (dirbuf, 0744);
 #endif
 
   if (ret < 0 && errno != EEXIST)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1648,7 +1648,7 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
       else
 	{
 	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_BO_DIRECTORY_DOESNOT_EXIST, 1, lob_path);
-	  if (mkdir (lob_path, 0777) < 0)
+	  if (mkdir (lob_path, 0700) < 0)
 	    {
 	      cub_dirname_r (lob_path, fixed_pathbuf, PATH_MAX);
 	      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ES_GENERAL, 2, "POSIX", fixed_pathbuf);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -842,7 +842,7 @@ log_create_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const cha
    * Turn off creation bits for group and others
    */
 
-  (void) umask (S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH);
+  (void) umask (S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
 
   /* Initialize the log buffer pool and the log names */
   error_code = logpb_initialize_pool (thread_p);
@@ -1098,7 +1098,7 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
   rv_check_rvfuns ();
 #endif /* !NDEBUG */
 
-  (void) umask (S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH);
+  (void) umask (S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
 
   /* Make sure that the log is a valid one */
   LOG_SET_CURRENT_TRAN_INDEX (thread_p, LOG_SYSTEM_TRAN_INDEX);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -842,7 +842,7 @@ log_create_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const cha
    * Turn off creation bits for group and others
    */
 
-  (void) umask (S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+  (void) umask (S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH);
 
   /* Initialize the log buffer pool and the log names */
   error_code = logpb_initialize_pool (thread_p);
@@ -1098,7 +1098,7 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
   rv_check_rvfuns ();
 #endif /* !NDEBUG */
 
-  (void) umask (S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+  (void) umask (S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH);
 
   /* Make sure that the log is a valid one */
   LOG_SET_CURRENT_TRAN_INDEX (thread_p, LOG_SYSTEM_TRAN_INDEX);


### PR DESCRIPTION
[http://jira.cubrid.org/browse/CBRD-24103](http://jira.cubrid.org/browse/CBRD-24103)

**Purpose**
The permission of lob sub-directory and lob files have execute permission. So it should be eliminated for the permission consistency and prevention the access.

**Implementation**
`ret = mkdir (dirbuf, 0755);` is changed to `ret = mkdir (dirbuf, 0744);` in `es_make_dirs()` function

**Remarks**
N/A
