### PR TITLE
[LETS-282] Add transaction MVCCID's to checkpoint information

### DIFF
--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -55,6 +55,10 @@ namespace cublog
 	lsa_utils::pack (serializator, tran_info.savept_lsa);
 	lsa_utils::pack (serializator, tran_info.tail_topresult_lsa);
 	lsa_utils::pack (serializator, tran_info.start_postpone_lsa);
+
+	serializator.pack_bigint (tran_info.mvcc_id);
+	serializator.pack_bigint (tran_info.mvcc_sub_id);
+
 	serializator.pack_c_string (tran_info.user_name, strlen (tran_info.user_name));
       }
 
@@ -93,6 +97,10 @@ namespace cublog
 	lsa_utils::unpack (deserializator, chkpt_trans.savept_lsa);
 	lsa_utils::unpack (deserializator, chkpt_trans.tail_topresult_lsa);
 	lsa_utils::unpack (deserializator, chkpt_trans.start_postpone_lsa);
+
+	deserializator.unpack_bigint (chkpt_trans.mvcc_id);
+	deserializator.unpack_bigint (chkpt_trans.mvcc_sub_id);
+
 	deserializator.unpack_c_string (chkpt_trans.user_name, LOG_USERNAME_MAX);
 
 	m_trans.push_back (chkpt_trans);
@@ -136,6 +144,10 @@ namespace cublog
 	size += lsa_utils::get_packed_size (serializator, start_offset + size);
 	size += lsa_utils::get_packed_size (serializator, start_offset + size);
 	size += lsa_utils::get_packed_size (serializator, start_offset + size);
+
+	size += serializator.get_packed_bigint_size (start_offset + size);
+	size += serializator.get_packed_bigint_size (start_offset + size);
+
 	size += serializator.get_packed_c_string_size (tran_info.user_name, strlen (tran_info.user_name), start_offset + size);
       }
 
@@ -163,6 +175,17 @@ namespace cublog
 	chkpt_tran.isloose_end = tdes.isloose_end;
 	chkpt_tran.trid = tdes.trid;
 	chkpt_tran.state = tdes.state;
+	chkpt_tran.mvcc_id = tdes.mvccinfo.id;
+
+	if (tdes.mvccinfo.sub_ids.size () == 0)
+	  {
+	    chkpt_tran.mvcc_sub_id = MVCCID_NULL;
+	  }
+	else
+	  {
+	    assert (tdes.mvccinfo.sub_ids.size () == 1);
+	    chkpt_tran.mvcc_sub_id = tdes.mvccinfo.sub_ids[0];
+	  }
 
 	LSA_COPY (&chkpt_tran.head_lsa, &tdes.head_lsa);
 	LSA_COPY (&chkpt_tran.tail_lsa, &tdes.tail_lsa);
@@ -305,6 +328,11 @@ namespace cublog
 	LSA_COPY (&tdes->savept_lsa, &chkpt.savept_lsa);
 	LSA_COPY (&tdes->tail_topresult_lsa, &chkpt.tail_topresult_lsa);
 	LSA_COPY (&tdes->rcv.tran_start_postpone_lsa, &chkpt.start_postpone_lsa);
+	tdes->mvccinfo.id = chkpt.mvcc_id;
+	if (chkpt.mvcc_sub_id != MVCCID_NULL)
+	  {
+	    tdes->mvccinfo.sub_ids.emplace_back (chkpt.mvcc_sub_id);
+	  }
 	tdes->client.set_system_internal_with_user (chkpt.user_name);
       }
 
@@ -467,6 +495,16 @@ namespace cublog
       }
 
     if (start_postpone_lsa != other.start_postpone_lsa)
+      {
+	return false;
+      }
+
+    if (mvcc_id != other.mvcc_id)
+      {
+	return false;
+      }
+
+    if (mvcc_sub_id != other.mvcc_sub_id)
       {
 	return false;
       }

--- a/src/transaction/log_checkpoint_info.hpp
+++ b/src/transaction/log_checkpoint_info.hpp
@@ -95,6 +95,9 @@ namespace cublog
     LOG_LSA savept_lsa;		/* Address of last savepoint */
     LOG_LSA tail_topresult_lsa;	/* Address of last partial abort/commit */
     LOG_LSA start_postpone_lsa;	/* Address of start postpone (if transaction was doing postpone during checkpoint) */
+
+    MVCCID mvcc_id;
+    MVCCID mvcc_sub_id;
     char user_name[LOG_USERNAME_MAX];	/* Name of the client */
 
     inline bool operator== (const tran_info &other) const;

--- a/unit_tests/log/test_main_chkpt_info.cpp
+++ b/unit_tests/log/test_main_chkpt_info.cpp
@@ -203,6 +203,8 @@ full_compare_tdes (log_tdes *td1, const log_tdes *td2, bool is_unactive_aborted)
   REQUIRE (td1->posp_nxlsa == td2->posp_nxlsa);
   REQUIRE (td1->savept_lsa == td2->savept_lsa);
   REQUIRE (td1->tail_topresult_lsa == td2->tail_topresult_lsa);
+  REQUIRE (td1->mvccinfo.id == td2->mvccinfo.id);
+  REQUIRE (td1->mvccinfo.sub_ids == td2->mvccinfo.sub_ids);
 }
 
 log_tdes *
@@ -544,6 +546,17 @@ test_env_chkpt::generate_tdes (int index)
   tdes->fl_mark_repl_recidx      = rand () % MAX_RAND;
   tdes->repl_insert_lsa          = generate_log_lsa ();
   tdes->repl_update_lsa          = generate_log_lsa ();
+
+  tdes->mvccinfo.id = std::rand () % MAX_RAND;
+
+  if (std::rand () % 2 == 0)
+    {
+      tdes->mvccinfo.sub_ids.clear();
+    }
+  else
+    {
+      tdes->mvccinfo.sub_ids.emplace_back (std::rand () % MAX_RAND);
+    }
 
   tdes->client  = generate_client (index);
   tdes->gtrinfo = generate_2pc_gtrinfo ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-282

Extended checkpoint info with MVCCID information to build initial image of MVCC table on PTS. 
Added both transaction MVCCID and sub-transaction MVCCID to checkpoint info.

This patch also modifies the checkpoint info unit test with the new functionality.