### PR TITLE
[LETS-219] Transfer log header and log append page to PTS

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -246,14 +246,15 @@ bool is_tran_server_with_remote_storage ()
 
 passive_tran_server *get_passive_tran_server_ptr ()
 {
-  if (is_passive_transaction_server())
+  if (is_passive_transaction_server ())
     {
       assert (pts_Gl != nullptr);
       return pts_Gl;
     }
   else
     {
-      assert (is_passive_transaction_server());
+      assert (is_passive_transaction_server ());
+      return nullptr;
     }
 }
 

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -87,14 +87,14 @@ void passive_tran_server::send_and_receive_log_boot_info (THREAD_ENTRY *thread_p
   }
 
   const int log_page_size = db_log_page_size ();
-  assert (m_log_boot_info.size () == sizeof (struct log_header) + log_page_size + sizeof (struct log_lsa));
+  assert (m_log_boot_info.size () == sizeof (log_header) + log_page_size + sizeof (log_lsa));
 
   const char *message_buf = m_log_boot_info.c_str ();
 
   // log header, copy and initialize header
-  const struct log_header *const log_hdr = reinterpret_cast<const struct log_header *> (message_buf);
+  const log_header *const log_hdr = reinterpret_cast<const log_header *> (message_buf);
   log_Gl.hdr = *log_hdr;
-  message_buf += sizeof (struct log_header);
+  message_buf += sizeof (log_header);
 
   // log append
   assert (log_Gl.append.log_pgptr == nullptr);
@@ -104,8 +104,8 @@ void passive_tran_server::send_and_receive_log_boot_info (THREAD_ENTRY *thread_p
   message_buf += log_page_size;
 
   // prev lsa
-  std::memcpy (&log_Gl.append.prev_lsa, message_buf, sizeof (struct log_lsa));
-  message_buf += sizeof (struct log_lsa);
+  std::memcpy (&log_Gl.append.prev_lsa, message_buf, sizeof (log_lsa));
+  message_buf += sizeof (log_lsa);
 
   // safe-guard that the message has been consumed
   assert (message_buf == m_log_boot_info.c_str () + m_log_boot_info.size ());

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -19,6 +19,7 @@
 #include "log_impl.h"
 #include "passive_tran_server.hpp"
 #include "server_type.hpp"
+#include "system_parameter.h"
 #include "thread_manager.hpp"
 
 bool
@@ -112,4 +113,11 @@ void passive_tran_server::send_and_receive_log_boot_info (THREAD_ENTRY *thread_p
   // do not leave m_log_boot_info empty as a safeguard as this function is only supposed
   // to be called once
   m_log_boot_info = "not empty";
+
+  if (prm_get_bool_value (PRM_ID_ER_LOG_PRIOR_TRANSFER))
+    {
+      _er_log_debug (ARG_FILE_LINE,
+		     "Received log boot info to from page server with prev_lsa = (%lld|%d), append_lsa = (%lld|%d)\n",
+		     LSA_AS_ARGS (&log_Gl.append.prev_lsa), LSA_AS_ARGS (&log_Gl.hdr.append_lsa));
+    }
 }

--- a/src/storage/async_page_fetcher.cpp
+++ b/src/storage/async_page_fetcher.cpp
@@ -114,9 +114,18 @@ namespace cublog
 
   void log_boot_info_fetch_task::execute (context_type &context)
   {
-    std::string message = log_pack_log_boot_info (&context);
+    struct log_lsa append_lsa, prev_lsa;
+
+    std::string message = log_pack_log_boot_info (&context, append_lsa, prev_lsa);
 
     m_callback (std::move (message));
+
+    if (prm_get_bool_value (PRM_ID_ER_LOG_PRIOR_TRANSFER))
+      {
+	_er_log_debug (ARG_FILE_LINE,
+		       "Sent log boot info to passive tran server with prev_lsa = (%lld|%d), append_lsa = (%lld|%d)\n",
+		       LSA_AS_ARGS (&prev_lsa), LSA_AS_ARGS (&append_lsa));
+      }
   }
 
   async_page_fetcher::async_page_fetcher ()

--- a/src/storage/async_page_fetcher.cpp
+++ b/src/storage/async_page_fetcher.cpp
@@ -114,7 +114,7 @@ namespace cublog
 
   void log_boot_info_fetch_task::execute (context_type &context)
   {
-    struct log_lsa append_lsa, prev_lsa;
+    log_lsa append_lsa, prev_lsa;
 
     std::string message = log_pack_log_boot_info (&context, append_lsa, prev_lsa);
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1621,7 +1621,10 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, (size_t) LOG_PAGESIZE);
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_initialize_passive_tran_server: out of memory");
       return;
-    }				// log header page buffer is not really needed subsequently as log header is copied directly // from page server without the help of a buffer
+    }
+  /* TODO: log header page buffer is not really needed subsequently as log header is copied directly
+   * from page server without the help of a buffer and, afterwards, it does not need to be saved hence
+   * this buffer will remain useless on the passive tran server */
 
   err_code = logpb_initialize_pool (thread_p);
   if (err_code != NO_ERROR)

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3424,7 +3424,8 @@ log_skip_logging_set_lsa (THREAD_ENTRY * thread_p, LOG_DATA_ADDR * addr)
  *              as part of the log initialization sequence
  */
 // *INDENT-OFF*
-std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p)
+std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p, struct log_lsa &append_lsa,
+                                    struct log_lsa &prev_lsa)
 {
   LOG_CS_ENTER_READ_MODE (thread_p);
   scope_exit log_cs_exit_ftor ( [thread_p] { LOG_CS_EXIT (thread_p); } );
@@ -3434,6 +3435,7 @@ std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p)
 
   // log header
   packed_message.append( reinterpret_cast<const char*> (&log_Gl.hdr), sizeof (struct log_header));
+  append_lsa = log_Gl.hdr.append_lsa;
 
   // log append
   assert (log_Gl.append.log_pgptr != nullptr);
@@ -3442,6 +3444,7 @@ std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p)
 
   // prev lsa
   packed_message.append (reinterpret_cast<const char *> (&log_Gl.append.prev_lsa), sizeof (struct log_lsa));
+  prev_lsa = log_Gl.append.prev_lsa;
 
   return packed_message;
 }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3368,16 +3368,14 @@ std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p)
   scope_exit log_cs_exit_ftor ( [thread_p] { LOG_CS_EXIT (thread_p); } );
   std::lock_guard<std::mutex> { log_Gl.prior_info.prior_lsa_mutex };
 
-  const int log_page_size = db_log_page_size ();
-
   std::string packed_message;
 
   // log header
-  assert (log_Gl.loghdr_pgptr != nullptr);
-  packed_message.append (reinterpret_cast<const char*> (log_Gl.loghdr_pgptr), log_page_size);
+  packed_message.append( reinterpret_cast<const char*> (&log_Gl.hdr), sizeof (struct log_header));
 
   // log append
   assert (log_Gl.append.log_pgptr != nullptr);
+  const int log_page_size = db_log_page_size ();
   packed_message.append (reinterpret_cast<const char*> (log_Gl.append.log_pgptr), log_page_size);
 
   // prev lsa

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1648,6 +1648,9 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
 
   logpb_initialize_logging_statistics ();
 
+  LOG_RESET_APPEND_LSA (&log_Gl.hdr.append_lsa);
+  LOG_RESET_PREV_LSA (&log_Gl.append.prev_lsa);
+
   er_log_debug (ARG_FILE_LINE, "log_initialize_passive_tran_server: end of log initializaton, append_lsa = (%lld|%d)\n",
 		LSA_AS_ARGS (&log_Gl.hdr.append_lsa));
 }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3427,17 +3427,17 @@ log_skip_logging_set_lsa (THREAD_ENTRY * thread_p, LOG_DATA_ADDR * addr)
  *              as part of the log initialization sequence
  */
 // *INDENT-OFF*
-std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p, struct log_lsa &append_lsa,
-                                    struct log_lsa &prev_lsa)
+std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p, log_lsa &append_lsa,
+                                    log_lsa &prev_lsa)
 {
   LOG_CS_ENTER_READ_MODE (thread_p);
-  scope_exit log_cs_exit_ftor ( [thread_p] { LOG_CS_EXIT (thread_p); } );
+  scope_exit log_cs_exit_ftor ([thread_p] { LOG_CS_EXIT (thread_p); });
   std::lock_guard<std::mutex> { log_Gl.prior_info.prior_lsa_mutex };
 
   std::string packed_message;
 
   // log header
-  packed_message.append( reinterpret_cast<const char*> (&log_Gl.hdr), sizeof (struct log_header));
+  packed_message.append (reinterpret_cast<const char*> (&log_Gl.hdr), sizeof (log_header));
   append_lsa = log_Gl.hdr.append_lsa;
 
   // log append
@@ -3446,7 +3446,7 @@ std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p, struct log_lsa &app
   packed_message.append (reinterpret_cast<const char*> (log_Gl.append.log_pgptr), log_page_size);
 
   // prev lsa
-  packed_message.append (reinterpret_cast<const char *> (&log_Gl.append.prev_lsa), sizeof (struct log_lsa));
+  packed_message.append (reinterpret_cast<const char *> (&log_Gl.append.prev_lsa), sizeof (log_lsa));
   prev_lsa = log_Gl.append.prev_lsa;
 
   return packed_message;

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -238,8 +238,8 @@ extern void log_update_global_btid_online_index_stats (THREAD_ENTRY * thread_p);
 extern void log_write_metalog_to_file (bool file_open_is_fatal);
 
 // *INDENT-OFF*
-extern std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p, struct log_lsa &append_lsa,
-					   struct log_lsa &prev_lsa);
+extern std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p, log_lsa &append_lsa,
+					   log_lsa &prev_lsa);
 // *INDENT-ON*
 
 #if defined (SERVER_MODE)

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -72,6 +72,7 @@ extern int log_create (THREAD_ENTRY * thread_p, const char *db_fullname, const c
 		       const char *prefix_logname, DKNPAGES npages);
 extern void log_initialize (THREAD_ENTRY * thread_p, const char *db_fullname, const char *logpath,
 			    const char *prefix_logname, bool is_media_crash, bo_restart_arg * r_args);
+extern void log_initialize_passive_tran_server (THREAD_ENTRY * thread_p);
 #if defined(ENABLE_UNUSED_FUNCTION)
 extern int log_update_compatibility_and_release (THREAD_ENTRY * thread_p, float compatibility, char release[]);
 #endif

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -238,7 +238,8 @@ extern void log_update_global_btid_online_index_stats (THREAD_ENTRY * thread_p);
 extern void log_write_metalog_to_file (bool file_open_is_fatal);
 
 // *INDENT-OFF*
-extern std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p);
+extern std::string log_pack_log_boot_info (THREAD_ENTRY * thread_p, struct log_lsa &append_lsa,
+					   struct log_lsa &prev_lsa);
 // *INDENT-ON*
 
 #if defined (SERVER_MODE)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -386,6 +386,9 @@ static int logpb_fetch_header_from_page_server (LOG_HEADER * hdr, LOG_PAGE * log
 static int logpb_fetch_header_from_file_or_page_server (THREAD_ENTRY * thread_p, const char *db_fullname,
 							const char *logpath, const char *prefix_logname,
 							LOG_HEADER * hdr);
+static void logpb_fill_or_reset_header_parameters (const struct log_header *hdr, PGLENGTH & io_page_size,
+						   PGLENGTH & log_page_size, INT64 & creation_time,
+						   float &db_compatibility, int &db_charset);
 static int logpb_compute_page_checksum (const LOG_PAGE * log_pgptr);
 
 static bool logpb_is_log_active_from_backup_useful (THREAD_ENTRY * thread_p, const char *active_log_path,
@@ -2550,6 +2553,32 @@ logpb_write_page_to_disk (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, LOG_PAG
 }
 
 /*
+ * logpb_fill_or_reset_header_parameters - initialize values from header, or reset to invalid values if no header
+ *                    argument is provided
+ */
+void
+logpb_fill_or_reset_header_parameters (const struct log_header *hdr, PGLENGTH & io_page_size, PGLENGTH & log_page_size,
+				       INT64 & creation_time, float &db_compatibility, int &db_charset)
+{
+  if (hdr != nullptr)
+    {
+      io_page_size = hdr->db_iopagesize;
+      log_page_size = hdr->db_logpagesize;
+      creation_time = hdr->db_creation;
+      db_compatibility = hdr->db_compatibility;
+      db_charset = hdr->db_charset;
+    }
+  else
+    {
+      io_page_size = -1;
+      log_page_size = -1;
+      creation_time = 0;
+      db_compatibility = -1.0;
+      db_charset = INTL_CODESET_ERROR;
+    }
+}
+
+/*
  * logpb_find_header_parameters - Find some database creation parameters
  *
  * return: iopagesize or -1
@@ -2597,10 +2626,8 @@ logpb_find_header_parameters (THREAD_ENTRY * thread_p, const bool force_read_log
   /* Is the system restarted ? */
   if (log_Gl.trantable.area != NULL && log_Gl.append.log_pgptr != NULL)
     {
-      *io_page_size = log_Gl.hdr.db_iopagesize;
-      *log_page_size = log_Gl.hdr.db_logpagesize;
-      *creation_time = log_Gl.hdr.db_creation;
-      *db_compatibility = log_Gl.hdr.db_compatibility;
+      logpb_fill_or_reset_header_parameters (&log_Gl.hdr, *io_page_size, *log_page_size, *creation_time,
+					     *db_compatibility, *db_charset);
 
       if (IO_PAGESIZE != *io_page_size || LOG_PAGESIZE != *log_page_size)
 	{
@@ -2638,11 +2665,8 @@ logpb_find_header_parameters (THREAD_ENTRY * thread_p, const bool force_read_log
       is_header_read_from_file = true;
     }
 
-  *io_page_size = hdr.db_iopagesize;
-  *log_page_size = hdr.db_logpagesize;
-  *creation_time = hdr.db_creation;
-  *db_compatibility = hdr.db_compatibility;
-  *db_charset = (int) hdr.db_charset;
+  logpb_fill_or_reset_header_parameters (&hdr, *io_page_size, *log_page_size, *creation_time,
+					 *db_compatibility, *db_charset);
 
   if (is_log_header_validated)
     {
@@ -2682,10 +2706,9 @@ logpb_find_header_parameters (THREAD_ENTRY * thread_p, const bool force_read_log
   return *io_page_size;
 
 error:
-  *io_page_size = -1;
-  *log_page_size = -1;
-  *creation_time = 0;
-  *db_compatibility = -1.0;
+  // null header argument will reset all values
+  logpb_fill_or_reset_header_parameters (nullptr, *io_page_size, *log_page_size, *creation_time,
+					 *db_compatibility, *db_charset);
 
   return *io_page_size;
 }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -386,9 +386,11 @@ static int logpb_fetch_header_from_page_server (LOG_HEADER * hdr, LOG_PAGE * log
 static int logpb_fetch_header_from_file_or_page_server (THREAD_ENTRY * thread_p, const char *db_fullname,
 							const char *logpath, const char *prefix_logname,
 							LOG_HEADER * hdr);
-static void logpb_fill_or_reset_header_parameters (const struct log_header *hdr, PGLENGTH & io_page_size,
-						   PGLENGTH & log_page_size, INT64 & creation_time,
-						   float &db_compatibility, int &db_charset);
+static void logpb_fill_header_parameters (const log_header & hdr, PGLENGTH & io_page_size,
+					  PGLENGTH & log_page_size, INT64 & creation_time, float &db_compatibility,
+					  int &db_charset);
+static void logpb_reset_header_parameters (PGLENGTH & io_page_size, PGLENGTH & log_page_size, INT64 & creation_time,
+					   float &db_compatibility, int &db_charset);
 static int logpb_compute_page_checksum (const LOG_PAGE * log_pgptr);
 
 static bool logpb_is_log_active_from_backup_useful (THREAD_ENTRY * thread_p, const char *active_log_path,
@@ -2553,29 +2555,31 @@ logpb_write_page_to_disk (THREAD_ENTRY * thread_p, LOG_PAGE * log_pgptr, LOG_PAG
 }
 
 /*
- * logpb_fill_or_reset_header_parameters - initialize values from header, or reset to invalid values if no header
- *                    argument is provided
+ * logpb_fill_header_parameters - initialize values from header
  */
 void
-logpb_fill_or_reset_header_parameters (const struct log_header *hdr, PGLENGTH & io_page_size, PGLENGTH & log_page_size,
-				       INT64 & creation_time, float &db_compatibility, int &db_charset)
+logpb_fill_header_parameters (const log_header & hdr, PGLENGTH & io_page_size, PGLENGTH & log_page_size,
+			      INT64 & creation_time, float &db_compatibility, int &db_charset)
 {
-  if (hdr != nullptr)
-    {
-      io_page_size = hdr->db_iopagesize;
-      log_page_size = hdr->db_logpagesize;
-      creation_time = hdr->db_creation;
-      db_compatibility = hdr->db_compatibility;
-      db_charset = hdr->db_charset;
-    }
-  else
-    {
-      io_page_size = -1;
-      log_page_size = -1;
-      creation_time = 0;
-      db_compatibility = -1.0;
-      db_charset = INTL_CODESET_ERROR;
-    }
+  io_page_size = hdr.db_iopagesize;
+  log_page_size = hdr.db_logpagesize;
+  creation_time = hdr.db_creation;
+  db_compatibility = hdr.db_compatibility;
+  db_charset = hdr.db_charset;
+}
+
+/*
+ * logpb_reset_header_parameters -
+ */
+void
+logpb_reset_header_parameters (PGLENGTH & io_page_size, PGLENGTH & log_page_size, INT64 & creation_time,
+			       float &db_compatibility, int &db_charset)
+{
+  io_page_size = -1;
+  log_page_size = -1;
+  creation_time = 0;
+  db_compatibility = -1.0;
+  db_charset = INTL_CODESET_ERROR;
 }
 
 /*
@@ -2626,8 +2630,8 @@ logpb_find_header_parameters (THREAD_ENTRY * thread_p, const bool force_read_log
   /* Is the system restarted ? */
   if (log_Gl.trantable.area != NULL && log_Gl.append.log_pgptr != NULL)
     {
-      logpb_fill_or_reset_header_parameters (&log_Gl.hdr, *io_page_size, *log_page_size, *creation_time,
-					     *db_compatibility, *db_charset);
+      logpb_fill_header_parameters (log_Gl.hdr, *io_page_size, *log_page_size, *creation_time,
+				    *db_compatibility, *db_charset);
 
       if (IO_PAGESIZE != *io_page_size || LOG_PAGESIZE != *log_page_size)
 	{
@@ -2665,8 +2669,7 @@ logpb_find_header_parameters (THREAD_ENTRY * thread_p, const bool force_read_log
       is_header_read_from_file = true;
     }
 
-  logpb_fill_or_reset_header_parameters (&hdr, *io_page_size, *log_page_size, *creation_time,
-					 *db_compatibility, *db_charset);
+  logpb_fill_header_parameters (hdr, *io_page_size, *log_page_size, *creation_time, *db_compatibility, *db_charset);
 
   if (is_log_header_validated)
     {
@@ -2706,9 +2709,7 @@ logpb_find_header_parameters (THREAD_ENTRY * thread_p, const bool force_read_log
   return *io_page_size;
 
 error:
-  // null header argument will reset all values
-  logpb_fill_or_reset_header_parameters (nullptr, *io_page_size, *log_page_size, *creation_time,
-					 *db_compatibility, *db_charset);
+  logpb_reset_header_parameters (*io_page_size, *log_page_size, *creation_time, *db_compatibility, *db_charset);
 
   return *io_page_size;
 }

--- a/unit_tests/log/test_main_data_page_fetcher.cpp
+++ b/unit_tests/log/test_main_data_page_fetcher.cpp
@@ -224,7 +224,7 @@ pgbuf_unfix_debug (THREAD_ENTRY *thread_p, PAGE_PTR pgptr, const char *caller_fi
 }
 
 std::string
-log_pack_log_boot_info (THREAD_ENTRY *thread_p)
+log_pack_log_boot_info (THREAD_ENTRY *, struct log_lsa &, struct log_lsa &)
 {
   assert ("function is not used in the context of this unit test" == nullptr);
   return std::string ();

--- a/unit_tests/log/test_main_log_page_fetcher.cpp
+++ b/unit_tests/log/test_main_log_page_fetcher.cpp
@@ -196,7 +196,7 @@ pgbuf_fix_release (THREAD_ENTRY *thread_p, const VPID *vpid, PAGE_FETCH_MODE fet
 }
 
 std::string
-log_pack_log_boot_info (THREAD_ENTRY *thread_p)
+log_pack_log_boot_info (THREAD_ENTRY *, struct log_lsa &, struct log_lsa &)
 {
   assert ("function is not used in the context of this unit test" == nullptr);
   return std::string ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-219

Initialize log on passive transaction server by transferring log header, log append page and prev LSA from page server.

Implementation:
- function log_initialize_passive_tran_server is called instead of log_initialize when on PTS
- log_initialize_passive_tran_server is a blocking call

Other:
- logpb_fill_or_reset_header_parameters: fix extracting parameters from log header

Tests:
- executed shell_debug suite (for the modifications regarding logpb_fill_or_reset_header_parameters)