### PR TITLE
[LETS-243] The transaction host is missing from logs

### DIFF
--- a/src/communication/communication_channel.cpp
+++ b/src/communication/communication_channel.cpp
@@ -236,4 +236,9 @@ namespace cubcomm
     return m_socket;
   }
 
+  int channel::get_port ()
+  {
+    return m_port;
+  }
+
 } /* namespace cubcomm */

--- a/src/communication/communication_channel.hpp
+++ b/src/communication/communication_channel.hpp
@@ -72,7 +72,7 @@ namespace cubcomm
       virtual css_error_code connect (const char *hostname, int port);
 
       /* creates a listener channel */
-      css_error_code accept (SOCKET socket);
+      virtual css_error_code accept (SOCKET socket);
 
       /* this function waits for events such as EPOLLIN, EPOLLOUT,
        * if (revents & EPOLLIN) != 0 it means that we have an "in" event
@@ -81,6 +81,7 @@ namespace cubcomm
 
       bool is_connection_alive () const;
       SOCKET get_socket ();
+      int get_port ();
       void close_connection ();
 
       /* this is the command that the non overridden connect will send */

--- a/src/communication/communication_channel.hpp
+++ b/src/communication/communication_channel.hpp
@@ -94,7 +94,13 @@ namespace cubcomm
 
       std::string get_channel_id () const
       {
-	return m_channel_name + "_" + m_hostname + "_" + std::to_string (m_port);
+	std::string channel_id = m_channel_name + "_" + m_hostname;
+
+	if (m_port != -1)
+	  {
+	    channel_id += "_" + std::to_string (m_port);
+	  }
+	return channel_id;
       }
 
     protected:

--- a/src/communication/communication_server_channel.cpp
+++ b/src/communication/communication_server_channel.cpp
@@ -24,10 +24,13 @@
 #include "communication_server_channel.hpp"
 
 #include "error_manager.h"
+#include "server_support.h"
 #include "system_parameter.h"  /* er_log_debug param */
 
 namespace cubcomm
 {
+#define er_log_chn_debug(...) \
+  if (prm_get_bool_value (PRM_ID_ER_LOG_COMM_CHANNEL)) _er_log_debug (ARG_FILE_LINE, "[COMM_CHN]" __VA_ARGS__)
 
   server_channel::server_channel (const char *server_name, SERVER_TYPE server_type, int max_timeout_in_ms)
     : channel (max_timeout_in_ms),
@@ -35,6 +38,11 @@ namespace cubcomm
       m_server_type (server_type)
   {
     assert (server_name != nullptr);
+  }
+
+  server_channel::server_channel (int max_timeout_in_ms)
+    : channel (max_timeout_in_ms)
+  {
   }
 
   server_channel::server_channel (server_channel &&comm)
@@ -93,8 +101,33 @@ namespace cubcomm
 	assert (!is_connection_alive ());
 	return rc;
       }
-
+    rc = send (hostname, strlen (hostname) + 1);
     return rc;
+  }
+
+  css_error_code server_channel::accept (SOCKET socket)
+  {
+    er_log_chn_debug ("[%s] Accept connection to socket = %d.\n", get_channel_id ().c_str (), socket);
+
+    if (is_connection_alive () || IS_INVALID_SOCKET (socket))
+      {
+	return INTERNAL_CSS_ERROR;
+      }
+
+    m_type = CHANNEL_TYPE::LISTENER;
+    m_socket = socket;
+    m_request = STATIC_CAST (cubcomm::server_server, css_get_master_request (socket));
+
+    char buffer[CUB_MAXHOSTNAMELEN];
+    size_t max_size = CUB_MAXHOSTNAMELEN;
+    css_error_code rc = recv (buffer, max_size);
+    m_hostname = buffer;
+    return rc;
+  }
+
+  cubcomm::server_server server_channel::get_conn_type ()
+  {
+    return m_request;
   }
 
 } /* namespace cubcomm */

--- a/src/communication/communication_server_channel.cpp
+++ b/src/communication/communication_server_channel.cpp
@@ -116,12 +116,12 @@ namespace cubcomm
 
     m_type = CHANNEL_TYPE::LISTENER;
     m_socket = socket;
-    m_request = STATIC_CAST (cubcomm::server_server, css_get_master_request (socket));
 
     char buffer[CUB_MAXHOSTNAMELEN];
     size_t max_size = CUB_MAXHOSTNAMELEN;
     css_error_code rc = recv (buffer, max_size);
     m_hostname = buffer;
+    m_request = static_cast<cubcomm::server_server> (css_get_master_request (socket));
     return rc;
   }
 

--- a/src/communication/communication_server_channel.cpp
+++ b/src/communication/communication_server_channel.cpp
@@ -121,13 +121,13 @@ namespace cubcomm
     size_t max_size = CUB_MAXHOSTNAMELEN;
     css_error_code rc = recv (buffer, max_size);
     m_hostname = buffer;
-    m_request = static_cast<cubcomm::server_server> (css_get_master_request (socket));
+    m_conn_type = static_cast<cubcomm::server_server> (css_get_master_request (socket));
     return rc;
   }
 
   cubcomm::server_server server_channel::get_conn_type ()
   {
-    return m_request;
+    return m_conn_type;
   }
 
 } /* namespace cubcomm */

--- a/src/communication/communication_server_channel.hpp
+++ b/src/communication/communication_server_channel.hpp
@@ -40,6 +40,7 @@ namespace cubcomm
   {
     public:
       server_channel (const char *server_name, SERVER_TYPE server_type, int max_timeout_in_ms = -1);
+      server_channel (int max_timeout_in_ms = -1);
       ~server_channel () = default;
 
       server_channel (const server_channel &) = delete;
@@ -49,10 +50,13 @@ namespace cubcomm
       server_channel &operator= (server_channel &&comm);
 
       css_error_code connect (const char *hostname, int port, css_command_type cmd_type);
+      css_error_code accept (SOCKET socket);
+      cubcomm::server_server get_conn_type ();
 
     private:
       std::string m_server_name;
       SERVER_TYPE m_server_type;
+      cubcomm::server_server m_request;
   };
 
 }; /* cubcomm namepace */

--- a/src/communication/communication_server_channel.hpp
+++ b/src/communication/communication_server_channel.hpp
@@ -56,7 +56,7 @@ namespace cubcomm
     private:
       std::string m_server_name;
       SERVER_TYPE m_server_type;
-      cubcomm::server_server m_request;
+      cubcomm::server_server m_conn_type;
   };
 
 }; /* cubcomm namepace */

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -212,7 +212,7 @@ static const size_t CSS_JOB_QUEUE_SCAN_COLUMN_COUNT = 4;
 static void css_setup_server_loop (void);
 static int css_check_conn (CSS_CONN_ENTRY * p);
 static void css_set_shutdown_timeout (int timeout);
-static int css_get_master_request (SOCKET master_fd);
+int css_get_master_request (SOCKET master_fd);
 static int css_process_master_request (SOCKET master_fd);
 static void css_process_shutdown_request (SOCKET master_fd);
 static void css_send_reply_to_new_client_request (CSS_CONN_ENTRY * conn, unsigned short rid, int reason);
@@ -513,7 +513,7 @@ css_master_thread (void)
  *   return:
  *   master_fd(in):
  */
-static int
+int
 css_get_master_request (SOCKET master_fd)
 {
   int request, r;
@@ -2619,10 +2619,10 @@ css_process_server_server_connect (SOCKET master_fd)
       return;
     }
   constexpr int CHANNEL_POLL_TIMEOUT = 1000;	// 1000 milliseconds = 1 second
-  cubcomm::channel chn (CHANNEL_POLL_TIMEOUT);
+  cubcomm::server_channel chn (CHANNEL_POLL_TIMEOUT);
   chn.accept (slave_fd);
-  int request = css_get_master_request (slave_fd);	//read an integer to determine connection type
-  switch (STATIC_CAST (cubcomm::server_server, request))
+  cubcomm::server_server conn_type = chn.get_conn_type ();	//read an integer to determine connection type
+  switch (conn_type)
     {
     case cubcomm::server_server::CONNECT_ACTIVE_TRAN_TO_PAGE_SERVER:
       // *INDENT-OFF*

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -92,6 +92,7 @@ extern int css_notify_ha_log_applier_state (THREAD_ENTRY * thread_p, HA_LOG_APPL
 
 extern void css_push_external_task (CSS_CONN_ENTRY * conn, cubthread::entry_task * task);
 extern void css_get_thread_stats (UINT64 * stats_out);
+extern int css_get_master_request (SOCKET master_fd);
 extern size_t css_get_num_request_workers (void);
 extern size_t css_get_num_connection_workers (void);
 extern size_t css_get_num_total_workers (void);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -242,11 +242,8 @@ page_server::set_active_tran_server_connection (cubcomm::channel &&chn)
   assert (is_page_server ());
 
   chn.set_channel_name ("ATS_PS_comm");
-  if (chn.get_port() != -1)
-    {
-      er_log_debug (ARG_FILE_LINE, "Active transaction server connected to this page server. Channel id: %s.\n",
-		    chn.get_channel_id ().c_str ());
-    }
+  er_log_debug (ARG_FILE_LINE, "Active transaction server connected to this page server. Channel id: %s.\n",
+		chn.get_channel_id ().c_str ());
 
   if (m_active_tran_server_conn != nullptr)
     {
@@ -263,11 +260,8 @@ page_server::set_passive_tran_server_connection (cubcomm::channel &&chn)
   assert (is_page_server ());
 
   chn.set_channel_name ("PTS_PS_comm");
-  if (chn.get_port() != -1)
-    {
-      er_log_debug (ARG_FILE_LINE, "Passive transaction server connected to this page server. Channel id: %s.\n",
-		    chn.get_channel_id ().c_str ());
-    }
+  er_log_debug (ARG_FILE_LINE, "Passive transaction server connected to this page server. Channel id: %s.\n",
+		chn.get_channel_id ().c_str ());
 
   m_passive_tran_server_conn.emplace_back (new connection_handler (chn, *this));
 }

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -242,8 +242,11 @@ page_server::set_active_tran_server_connection (cubcomm::channel &&chn)
   assert (is_page_server ());
 
   chn.set_channel_name ("ATS_PS_comm");
-  er_log_debug (ARG_FILE_LINE, "Active transaction server connected to this page server. Channel id: %s.\n",
-		chn.get_channel_id ().c_str ());
+  if (chn.get_port() != -1)
+    {
+      er_log_debug (ARG_FILE_LINE, "Active transaction server connected to this page server. Channel id: %s.\n",
+		    chn.get_channel_id ().c_str ());
+    }
 
   if (m_active_tran_server_conn != nullptr)
     {
@@ -260,8 +263,11 @@ page_server::set_passive_tran_server_connection (cubcomm::channel &&chn)
   assert (is_page_server ());
 
   chn.set_channel_name ("PTS_PS_comm");
-  er_log_debug (ARG_FILE_LINE, "Passive transaction server connected to this page server. Channel id: %s.\n",
-		chn.get_channel_id ().c_str ());
+  if (chn.get_port() != -1)
+    {
+      er_log_debug (ARG_FILE_LINE, "Passive transaction server connected to this page server. Channel id: %s.\n",
+		    chn.get_channel_id ().c_str ());
+    }
 
   m_passive_tran_server_conn.emplace_back (new connection_handler (chn, *this));
 }

--- a/unit_tests/log/dummy_page_server.cpp
+++ b/unit_tests/log/dummy_page_server.cpp
@@ -60,6 +60,11 @@ namespace cubcomm
   {
     return NO_ERRORS;
   }
+
+  css_error_code channel::accept (SOCKET socket)
+  {
+    return NO_ERRORS;
+  }
 }
 
 perfmon_counter_timer_tracker::perfmon_counter_timer_tracker (PERF_STAT_ID a_stat_id)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-243

Changed the connection protocol to always send the hostname when establishing a new connection. 
Also added a guard to prevent printing of invalid port connections. 
