### PR TITLE
[LETS-339] Refactor log prior sender code to allow registration and removal of sinks

### DIFF
--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -21,7 +21,6 @@
 #include "error_manager.h"
 #include "log_impl.h"
 #include "log_lsa.hpp"
-#include "log_prior_send.hpp"
 #include "server_type.hpp"
 #include "system_parameter.h"
 
@@ -70,11 +69,11 @@ active_tran_server::on_boot ()
 {
   assert (is_active_transaction_server ());
 
-  cublog::prior_sender::sink_hook sink =
+  m_prior_sender_sink_hook_func =
 	  std::bind (&active_tran_server::push_request, std::ref (*this), tran_to_page_request::SEND_LOG_PRIOR_LIST,
 		     std::placeholders::_1);
 
-  log_Gl.m_prior_sender.add_sink (sink);
+  log_Gl.m_prior_sender.add_sink (m_prior_sender_sink_hook_func);
 }
 
 active_tran_server::request_handlers_map_t
@@ -85,7 +84,7 @@ active_tran_server::get_request_handlers ()
 			  std::bind (&active_tran_server::receive_saved_lsa, std::ref (*this), std::placeholders::_1));
 
   std::map<page_to_tran_request, std::function<void (cubpacking::unpacker &upk)>> handlers_map =
-	      tran_server::get_request_handlers();
+	      tran_server::get_request_handlers ();
 
   handlers_map.insert (saved_lsa_handler_value);
 

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -19,6 +19,7 @@
 #ifndef _ACTIVE_TRAN_SERVER_HPP_
 #define _ACTIVE_TRAN_SERVER_HPP_
 
+#include "log_prior_send.hpp"
 #include "tran_server.hpp"
 
 class active_tran_server : public tran_server
@@ -39,8 +40,9 @@ class active_tran_server : public tran_server
     void receive_saved_lsa (cubpacking::unpacker &upk);
 
   private:
-
     bool m_uses_remote_storage = false;
+
+    cublog::prior_sender::sink_hook_t m_prior_sender_sink_hook_func;
 };
 
 #endif // !_ACTIVE_TRAN_SERVER_HPP_

--- a/src/transaction/log_prior_send.hpp
+++ b/src/transaction/log_prior_send.hpp
@@ -35,17 +35,17 @@ namespace cublog
   class prior_sender
   {
     public:
-      using sink_hook = std::function<void (std::string &&)>;   // messages are passed to sink hooks.
+      using sink_hook_t = std::function<void (std::string &&)>;   // messages are passed to sink hooks.
 
+    public:
       void send_list (const log_prior_node *head);              // send prior node list to all sinks
 
-      // sinks management
-      void add_sink (const sink_hook &fun);                     // add a hook for a new sink
+      void add_sink (const sink_hook_t &fun);                     // add a hook for a new sink
+      void remove_sink (const sink_hook_t &fun);                  // add a hook for a new sink
       // todo: extend the sink management interface
 
     private:
-
-      std::vector<sink_hook> m_sink_hooks;                      // hooks for sinks
+      std::vector<const sink_hook_t *> m_sink_hooks;              // hooks for sinks
       std::mutex m_sink_hooks_mutex;                            // protect access on sink hooks
   };
 }

--- a/src/transaction/log_prior_send.hpp
+++ b/src/transaction/log_prior_send.hpp
@@ -38,15 +38,16 @@ namespace cublog
       using sink_hook_t = std::function<void (std::string &&)>;   // messages are passed to sink hooks.
 
     public:
-      void send_list (const log_prior_node *head);              // send prior node list to all sinks
+      void send_list (const log_prior_node *head);                // send prior node list to all sinks
 
       void add_sink (const sink_hook_t &fun);                     // add a hook for a new sink
       void remove_sink (const sink_hook_t &fun);                  // add a hook for a new sink
       // todo: extend the sink management interface
 
     private:
+      // non-owning pointers
       std::vector<const sink_hook_t *> m_sink_hooks;              // hooks for sinks
-      std::mutex m_sink_hooks_mutex;                            // protect access on sink hooks
+      std::mutex m_sink_hooks_mutex;                              // protect access on sink hooks
   };
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-339

Maintain the same existing interface based on references. Internally, keep non-owning pointers.