### PR TITLE
[CBRD-24123] A fatal error can occur when the logpb_get_log_buffer_index() function is called because the function argument is incorrectly cast to the invalid type. (#3210)

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -827,7 +827,7 @@ logpb_locate_page (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, PAGE_FETCH_MODE f
     }
   else
     {
-      index = logpb_get_log_buffer_index ((int) pageid);
+      index = logpb_get_log_buffer_index (pageid);
       if (index >= 0 && index < log_Pb.num_buffers)
 	{
 	  log_bufptr = &log_Pb.buffers[index];
@@ -1904,7 +1904,7 @@ logpb_copy_page (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_ACCESS_MODE 
       goto exit;
     }
 
-  index = logpb_get_log_buffer_index ((int) pageid);
+  index = logpb_get_log_buffer_index (pageid);
   if (index >= 0 && index < log_Pb.num_buffers)
     {
       log_bufptr = &log_Pb.buffers[index];


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24123

backport #3210