### PR TITLE
[LETS-297] cubrid hb stop db_name doesn't process

### DIFF
--- a/src/executables/commdb.c
+++ b/src/executables/commdb.c
@@ -486,7 +486,7 @@ process_ha_server_mode (CSS_CONN_ENTRY * conn, char *server_name)
 }
 
 static int
-search_server_pid (char *server_info, char *search_pattern)
+search_server_pid (const char *server_info, const char *search_pattern)
 {
   char *p = NULL;
   int pid = 0;
@@ -539,6 +539,10 @@ process_server_info_pid (CSS_CONN_ENTRY * conn, const char *server, int server_t
 	      break;
 
 	    case SERVER_TYPE_TRANSACTION:
+	      // Transaction servers are printed in two ways:
+	      //    - as "Transaction-Server" if HA is disabled
+	      //    - as "HA-Server" if HA is enabled
+	      // Search by both patterns.
 	      sprintf (search_pattern, "Transaction-Server %s (", server);
 	      pid = search_server_pid (server_info, search_pattern);
 
@@ -551,6 +555,7 @@ process_server_info_pid (CSS_CONN_ENTRY * conn, const char *server, int server_t
 
 	    default:
 	      sprintf (search_pattern, "Server %s (", server);
+	      pid = search_server_pid (server_info, search_pattern);
 	      break;
 	    }
 	  break;

--- a/src/executables/commdb.c
+++ b/src/executables/commdb.c
@@ -1102,6 +1102,13 @@ process_batch_command (CSS_CONN_ENTRY * conn)
 	{
 	  process_slave_kill (conn, (char *) commdb_Arg_server_name, commdb_Arg_shutdown_time, pid);
 	}
+
+      // kill ha server if present
+      pid = process_server_info_pid (conn, (char *) commdb_Arg_server_name, COMM_SERVER, SERVER_TYPE_ANY);
+      if (pid != 0)
+	{
+	  process_slave_kill (conn, (char *) commdb_Arg_server_name, commdb_Arg_shutdown_time, pid);
+	}
     }
 
   if (commdb_Arg_kill_all)

--- a/src/executables/commdb.c
+++ b/src/executables/commdb.c
@@ -488,7 +488,7 @@ process_ha_server_mode (CSS_CONN_ENTRY * conn, char *server_name)
 static int
 search_server_pid (const char *server_info, const char *search_pattern)
 {
-  char *p = NULL;
+  const char *p = NULL;
   int pid = 0;
 
   p = strstr (server_info, search_pattern);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-297

The `cubrid hb server stop command` did not actually close the server as it was looking for only Transaction and Page servers, due to the single node stop configuration.
