### PR TITLE
[LETS-326] Extend requests_sync_client_server payload with the response sequence number

### DIFF
--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -44,12 +44,11 @@ active_tran_server::get_remote_storage_config ()
 }
 
 void
-active_tran_server::receive_saved_lsa (cubpacking::unpacker &upk)
+active_tran_server::receive_saved_lsa (page_server_conn_t::internal_payload &a_ip)
 {
-  std::string message;
+  std::string message = a_ip.pull_payload ();
   log_lsa saved_lsa;
 
-  upk.unpack_string (message);
   assert (sizeof (log_lsa) == message.size ());
   std::memcpy (&saved_lsa, message.c_str (), sizeof (log_lsa));
 
@@ -83,8 +82,8 @@ active_tran_server::get_request_handlers ()
 	  std::make_pair (page_to_tran_request::SEND_SAVED_LSA,
 			  std::bind (&active_tran_server::receive_saved_lsa, std::ref (*this), std::placeholders::_1));
 
-  std::map<page_to_tran_request, std::function<void (cubpacking::unpacker &upk)>> handlers_map =
-	      tran_server::get_request_handlers ();
+  std::map<page_to_tran_request, page_server_conn_t::incoming_request_handler_t> handlers_map =
+	  tran_server::get_request_handlers ();
 
   handlers_map.insert (saved_lsa_handler_value);
 

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -37,7 +37,7 @@ class active_tran_server : public tran_server
 
     request_handlers_map_t get_request_handlers () final override;
 
-    void receive_saved_lsa (cubpacking::unpacker &upk);
+    void receive_saved_lsa (page_server_conn_t::internal_payload &a_ip);
 
   private:
     bool m_uses_remote_storage = false;

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -92,20 +92,17 @@ page_server::connection_handler::push_request (page_to_tran_request id, std::str
 }
 
 void
-page_server::connection_handler::receive_log_prior_list (cubpacking::unpacker &upk)
+page_server::connection_handler::receive_log_prior_list (tran_server_conn_t::internal_payload &a_ip)
 {
-  std::string message;
-  upk.unpack_string (message);
-  log_Gl.get_log_prior_receiver ().push_message (std::move (message));
+  log_Gl.get_log_prior_receiver ().push_message (std::move (a_ip.pull_payload ()));
 }
 
 void
-page_server::connection_handler::receive_log_page_fetch (cubpacking::unpacker &upk)
+page_server::connection_handler::receive_log_page_fetch (tran_server_conn_t::internal_payload &a_ip)
 {
   LOG_PAGEID pageid;
-  std::string message;
+  std::string message = a_ip.pull_payload ();
 
-  upk.unpack_string (message);
   assert (message.size () == sizeof (pageid));
   std::memcpy (&pageid, message.c_str (), sizeof (pageid));
 
@@ -119,10 +116,9 @@ page_server::connection_handler::receive_log_page_fetch (cubpacking::unpacker &u
 }
 
 void
-page_server::connection_handler::receive_data_page_fetch (cubpacking::unpacker &upk)
+page_server::connection_handler::receive_data_page_fetch (tran_server_conn_t::internal_payload &a_ip)
 {
-  std::string message;
-  upk.unpack_string (message);
+  std::string message = a_ip.pull_payload ();
 
   cubpacking::unpacker message_upk (message.c_str (), message.size ());
   VPID vpid;
@@ -137,7 +133,7 @@ page_server::connection_handler::receive_data_page_fetch (cubpacking::unpacker &
 }
 
 void
-page_server::connection_handler::receive_log_boot_info_fetch (cubpacking::unpacker &upk)
+page_server::connection_handler::receive_log_boot_info_fetch (tran_server_conn_t::internal_payload &)
 {
   // empty request message
 
@@ -155,7 +151,7 @@ page_server::connection_handler::on_log_boot_info_result (std::string &&message)
 }
 
 void
-page_server::connection_handler::receive_disconnect_request (cubpacking::unpacker &upk)
+page_server::connection_handler::receive_disconnect_request (tran_server_conn_t::internal_payload &)
 {
   //start a thread to destroy the ATS to PS connection object
   std::thread disconnect_thread (&page_server::disconnect_tran_server, std::ref (m_ps), this);
@@ -163,7 +159,7 @@ page_server::connection_handler::receive_disconnect_request (cubpacking::unpacke
 }
 
 void
-page_server::connection_handler::receive_boot_info_request (cubpacking::unpacker &upk)
+page_server::connection_handler::receive_boot_info_request (tran_server_conn_t::internal_payload &)
 {
   DKNVOLS nvols_perm = disk_get_perm_volume_count ();
 

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -84,12 +84,12 @@ class page_server
 	void on_data_page_read_result (const FILEIO_PAGE *page_ptr, int error_code);
 	void on_log_boot_info_result (std::string &&message);
 
-	void receive_boot_info_request (cubpacking::unpacker &upk);
-	void receive_log_prior_list (cubpacking::unpacker &upk);
-	void receive_log_page_fetch (cubpacking::unpacker &upk);
-	void receive_data_page_fetch (cubpacking::unpacker &upk);
-	void receive_disconnect_request (cubpacking::unpacker &upk);
-	void receive_log_boot_info_fetch (cubpacking::unpacker &upk);
+	void receive_boot_info_request (tran_server_conn_t::internal_payload &a_ip);
+	void receive_log_prior_list (tran_server_conn_t::internal_payload &a_ip);
+	void receive_log_page_fetch (tran_server_conn_t::internal_payload &a_ip);
+	void receive_data_page_fetch (tran_server_conn_t::internal_payload &a_ip);
+	void receive_disconnect_request (tran_server_conn_t::internal_payload &a_ip);
+	void receive_log_boot_info_fetch (tran_server_conn_t::internal_payload &a_ip);
 
 	std::unique_ptr<tran_server_conn_t> m_conn;
 	page_server &m_ps;

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -48,8 +48,8 @@ passive_tran_server::get_request_handlers ()
 			  std::bind (&passive_tran_server::receive_log_boot_info,
 				     std::ref (*this), std::placeholders::_1));
 
-  std::map<page_to_tran_request, std::function<void (cubpacking::unpacker &upk)>> handlers_map =
-	      tran_server::get_request_handlers ();
+  std::map<page_to_tran_request, page_server_conn_t::incoming_request_handler_t> handlers_map =
+	  tran_server::get_request_handlers ();
 
   handlers_map.insert (log_boot_info_handler_value);
 
@@ -57,10 +57,9 @@ passive_tran_server::get_request_handlers ()
 }
 
 void
-passive_tran_server::receive_log_boot_info (cubpacking::unpacker &upk)
+passive_tran_server::receive_log_boot_info (page_server_conn_t::internal_payload &a_ip)
 {
-  std::string message;
-  upk.unpack_string (message);
+  std::string message = a_ip.pull_payload ();
 
   // pass to caller thread; it has the thread context needed to access engine functions
   {

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -37,7 +37,7 @@ class passive_tran_server : public tran_server
     void on_boot () final override;
     request_handlers_map_t get_request_handlers () final override;
 
-    void receive_log_boot_info (cubpacking::unpacker &upk);
+    void receive_log_boot_info (page_server_conn_t::internal_payload &a_ip);
 
   private:
     std::mutex m_log_boot_info_mtx;

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -365,10 +365,9 @@ tran_server::push_request (tran_to_page_request reqid, std::string &&payload)
 }
 
 void
-tran_server::receive_log_page (cubpacking::unpacker &upk)
+tran_server::receive_log_page (page_server_conn_t::internal_payload &a_ip)
 {
-  std::string message;
-  upk.unpack_string (message);
+  std::string message = a_ip.pull_payload ();
 
   int error_code;
   std::memcpy (&error_code, message.c_str (), sizeof (error_code));
@@ -394,10 +393,9 @@ tran_server::receive_log_page (cubpacking::unpacker &upk)
 }
 
 void
-tran_server::receive_data_page (cubpacking::unpacker &upk)
+tran_server::receive_data_page (page_server_conn_t::internal_payload &a_ip)
 {
-  std::string message;
-  upk.unpack_string (message);
+  std::string message = a_ip.pull_payload ();
 
   // The message is either an error code or the content of the data page
   if (message.size () == sizeof (int))
@@ -433,10 +431,9 @@ tran_server::receive_data_page (cubpacking::unpacker &upk)
 }
 
 void
-tran_server::receive_boot_info (cubpacking::unpacker &upk)
+tran_server::receive_boot_info (page_server_conn_t::internal_payload &a_ip)
 {
-  std::string message;
-  upk.unpack_string (message);
+  std::string message = a_ip.pull_payload ();
 
   assert (message.size () == sizeof (DKNVOLS));
   DKNVOLS nvols_perm;
@@ -466,7 +463,7 @@ tran_server::get_request_handlers ()
 	  std::make_pair (page_to_tran_request::SEND_DATA_PAGE,
 			  std::bind (&tran_server::receive_data_page, std::ref (*this), std::placeholders::_1));
 
-  std::map<page_to_tran_request, std::function<void (cubpacking::unpacker &upk)>> handlers_map;
+  std::map<page_to_tran_request, page_server_conn_t::incoming_request_handler_t> handlers_map;
 
   handlers_map.insert ({ boot_info_handler_value, log_page_handler_value, data_page_handler_value });
 

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -86,7 +86,7 @@ class tran_server
 
   protected:
     using page_server_conn_t = cubcomm::request_sync_client_server<tran_to_page_request, page_to_tran_request, std::string>;
-    using request_handlers_map_t = std::map<page_to_tran_request, typename page_server_conn_t::incoming_request_handler_t>;
+    using request_handlers_map_t = std::map<page_to_tran_request, page_server_conn_t::incoming_request_handler_t>;
 
   protected:
 
@@ -105,9 +105,9 @@ class tran_server
     int parse_server_host (const std::string &host);
     int parse_page_server_hosts_config (std::string &hosts);
     // Common request Handlers
-    void receive_boot_info (cubpacking::unpacker &upk);
-    void receive_log_page (cubpacking::unpacker &upk);
-    void receive_data_page (cubpacking::unpacker &upk);
+    void receive_boot_info (page_server_conn_t::internal_payload &a_ip);
+    void receive_log_page (page_server_conn_t::internal_payload &a_ip);
+    void receive_data_page (page_server_conn_t::internal_payload &a_ip);
 
   private:
     std::unique_ptr<page_broker<log_page_type>> m_log_page_broker;

--- a/unit_tests/log/dummy_page_server.cpp
+++ b/unit_tests/log/dummy_page_server.cpp
@@ -84,3 +84,32 @@ log_rv_redo_context::log_rv_redo_context (const log_lsa &end_redo_lsa, log_reade
 log_rv_redo_context::~log_rv_redo_context ()
 {
 }
+
+namespace cubpacking
+{
+  size_t packer::get_packed_size_overloaded (const std::uint64_t &value, size_t curr_offset)
+  {
+    assert ("function is not used in the context of this unit test" == nullptr);
+  }
+  void packer::pack_overloaded (const std::uint64_t &value)
+  {
+    assert ("function is not used in the context of this unit test" == nullptr);
+  }
+  void unpacker::unpack_overloaded (std::uint64_t &value)
+  {
+    assert ("function is not used in the context of this unit test" == nullptr);
+  }
+
+  size_t packer::get_packed_size_overloaded (const std::string &value, size_t curr_offset)
+  {
+    assert ("function is not used in the context of this unit test" == nullptr);
+  }
+  void packer::pack_overloaded (const std::string &value)
+  {
+    assert ("function is not used in the context of this unit test" == nullptr);
+  }
+  void unpacker::unpack_overloaded (std::string &value)
+  {
+    assert ("function is not used in the context of this unit test" == nullptr);
+  }
+}

--- a/unit_tests/log/dummy_page_server.cpp
+++ b/unit_tests/log/dummy_page_server.cpp
@@ -99,6 +99,7 @@ namespace cubpacking
   size_t packer::get_packed_size_overloaded (const std::uint64_t &value, size_t curr_offset)
   {
     assert ("function is not used in the context of this unit test" == nullptr);
+    return 0;
   }
   void packer::pack_overloaded (const std::uint64_t &value)
   {
@@ -112,6 +113,7 @@ namespace cubpacking
   size_t packer::get_packed_size_overloaded (const std::string &value, size_t curr_offset)
   {
     assert ("function is not used in the context of this unit test" == nullptr);
+    return 0;
   }
   void packer::pack_overloaded (const std::string &value)
   {

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -129,7 +129,6 @@ static void mock_socket_between_two_client_servers (const test_request_client_se
     const test_request_client_server_type_two &clsr2,
     mock_socket_direction &sockdir_1_to_2,
     mock_socket_direction &sockdir_2_to_1);
-
 // Testing environment for two client-server's
 class test_two_client_server_env
 {
@@ -203,6 +202,10 @@ using test_request_sync_client_server_two_t =
 
 using uq_test_request_sync_client_server_one_t = std::unique_ptr<test_request_sync_client_server_one_t>;
 using uq_test_request_sync_client_server_two_t = std::unique_ptr<test_request_sync_client_server_two_t>;
+
+// The request_sync_client_server type handler that requires to find ExpectedVal
+template <typename ReqId, ReqId ExpectedVal, typename Payload>
+static void mock_check_expected_id_sync (Payload &upk);
 
 class test_two_request_sync_client_server_env
 {
@@ -562,6 +565,15 @@ mock_check_expected_id (cubpacking::unpacker &upk)
   ++global_handled_request_count;
 }
 
+template <typename T, T Val, typename Payload>
+static void
+mock_check_expected_id_sync (Payload &a_ip)
+{
+  T readval = static_cast<T> (a_ip.pull_payload ().val);
+  REQUIRE (readval == Val);
+  ++global_handled_request_count;
+}
+
 template <typename ReqCl, typename ReqId>
 static void
 send_request_id_as_message (ReqCl &reqcl, ReqId rid)
@@ -863,17 +875,20 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_one (
   chn.set_channel_name ("sync_client_server_one");
 
   // handle requests 2 to 1
-  test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_0 = [] (cubpacking::unpacker &upk)
+  test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_0 =
+	  [] (test_request_sync_client_server_one_t::internal_payload &a_ip)
   {
-    mock_check_expected_id<reqids_2_to_1, reqids_2_to_1::_0> (upk);
+    mock_check_expected_id_sync<reqids_2_to_1, reqids_2_to_1::_0> (a_ip);
   };
-  test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_1 = [] (cubpacking::unpacker &upk)
+  test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_1 =
+	  [] (test_request_sync_client_server_one_t::internal_payload &a_ip)
   {
-    mock_check_expected_id<reqids_2_to_1, reqids_2_to_1::_1> (upk);
+    mock_check_expected_id_sync<reqids_2_to_1, reqids_2_to_1::_1> (a_ip);
   };
-  test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_2 = [] (cubpacking::unpacker &upk)
+  test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_2 =
+	  [] (test_request_sync_client_server_one_t::internal_payload &a_ip)
   {
-    mock_check_expected_id<reqids_2_to_1, reqids_2_to_1::_2> (upk);
+    mock_check_expected_id_sync<reqids_2_to_1, reqids_2_to_1::_2> (a_ip);
   };
 
   uq_test_request_sync_client_server_one_t scs_one
@@ -897,13 +912,15 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_two (
   chn.set_channel_name ("sync_client_server_two");
 
   // handle requests 1 to 2
-  test_request_sync_client_server_two_t::incoming_request_handler_t req_handler_0 = [] (cubpacking::unpacker &upk)
+  test_request_sync_client_server_two_t::incoming_request_handler_t req_handler_0 =
+	  [] (test_request_sync_client_server_two_t::internal_payload &a_ip)
   {
-    mock_check_expected_id<reqids_1_to_2, reqids_1_to_2::_0> (upk);
+    mock_check_expected_id_sync<reqids_1_to_2, reqids_1_to_2::_0> (a_ip);
   };
-  test_request_sync_client_server_two_t::incoming_request_handler_t req_handler_1 = [] (cubpacking::unpacker &upk)
+  test_request_sync_client_server_two_t::incoming_request_handler_t req_handler_1 =
+	  [] (test_request_sync_client_server_two_t::internal_payload &a_ip)
   {
-    mock_check_expected_id<reqids_1_to_2, reqids_1_to_2::_1> (upk);
+    mock_check_expected_id_sync<reqids_1_to_2, reqids_1_to_2::_1> (a_ip);
   };
 
   uq_test_request_sync_client_server_two_t scs_two


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-326

The purpose of this pull request is to adapt the request messages and request handlers to having a response sequence number in the message.

The message is decomposed into three parts:

  - The message ID, unpacked by `request_server` that determines which handler processes the request.
  - The request sequence number, unpacked by `request_sync_client_server` that determines the request-response pairing.
  - The actual user payload, that is unpacked inside the request handler.
 
The patch includes the next changes:

  - `request_sync_client_server` maintains an `internal_payload` - nested class - that pairs the user payload with a response sequence number. The response sequence number is for now always `NO_RESPONSE`.
  - `request_sync_client_server` wraps the `request_client_server` handler with its own function `unpack_and_handle`. The handlers provided to `request_sync_client_server` must be given an `internal_payload` instead of a `cubpacking::unpacker`.
  - `request_sync_client_server::push` automatically pairs the request payload with a `NO_RESPONSE` sequence number.
  - Update all handlers in transaction and page server to the new signature.
  - Updated unit tests to the new types of handlers and this patch changes.