### PR TITLE
[LETS-334] Reset the MVCCID on descriptor with tran_index, not current thread descriptor

### DIFF
--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -1044,7 +1044,7 @@ log_rv_analysis_complete (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa,
       if (tran_index != NULL_TRAN_INDEX)
 	{
 	  // quick fix: reset mvccid.
-	  LOG_FIND_CURRENT_TDES (thread_p)->mvccinfo.id = MVCCID_NULL;
+	  LOG_FIND_TDES (tran_index)->mvccinfo.id = MVCCID_NULL;
 	  logtb_free_tran_index (thread_p, tran_index);
 	}
       return NO_ERROR;
@@ -1091,7 +1091,7 @@ log_rv_analysis_complete (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa,
       if (tran_index != NULL_TRAN_INDEX)
 	{
 	  // quick fix: reset mvccid.
-	  LOG_FIND_CURRENT_TDES (thread_p)->mvccinfo.id = MVCCID_NULL;
+	  LOG_FIND_TDES (tran_index)->mvccinfo.id = MVCCID_NULL;
 	  logtb_free_tran_index (thread_p, tran_index);
 	}
       return NO_ERROR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-334

The current thread descriptor is not the same as the transaction descriptor that belongs to the analyzed commit/abort log record. The committed/aborted transaction descriptor MVCCID must be reset, not the MVCCID on current thread's transaction descriptor.
