### PR TITLE
[LETS-337] The remote_storage parameter is missing in single_node configuration

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -6308,7 +6308,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_REMOTE_STORAGE,
    PRM_NAME_REMOTE_STORAGE,
-   (PRM_FOR_SERVER | PRM_HIDDEN),
+   (PRM_FOR_SERVER),
    PRM_BOOLEAN,
    &prm_remote_storage_flag,
    (void *) &prm_remote_storage_default,


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-337

Removed `PRM_HIDDEN` flag for remote storage parameter to make it visible for paramdump.
