### PR TITLE
[CBRD-23960] Fix segfault at the end of execute call stmt in CAS

### DIFF
--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -493,14 +493,7 @@ namespace cubmethod
 	if (m_q_result[i].copied == false && m_q_result[i].result)
 	  {
 	    DB_QUERY_RESULT *result = m_q_result[i].result;
-	    if (result && result->status != T_CLOSED)
-	      {
-		if (result->type == T_SELECT)
-		  {
-		    cursor_close (&result->res.s.cursor_id);
-		  }
-		db_free_query_result (result);
-	      }
+	    db_query_end_internal (result, false);
 	  }
 	m_q_result[i].result = NULL;
 

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -493,8 +493,14 @@ namespace cubmethod
 	if (m_q_result[i].copied == false && m_q_result[i].result)
 	  {
 	    DB_QUERY_RESULT *result = m_q_result[i].result;
-	    db_free_query_result (result);
-	    cursor_close (&result->res.s.cursor_id);
+	    if (result && result->status != T_CLOSED)
+	      {
+		if (result->type == T_SELECT)
+		  {
+		    cursor_close (&result->res.s.cursor_id);
+		  }
+		db_free_query_result (result);
+	      }
 	  }
 	m_q_result[i].result = NULL;
 

--- a/src/method/method_struct_query.cpp
+++ b/src/method/method_struct_query.cpp
@@ -612,10 +612,7 @@ namespace cubmethod
 
   execute_info::~execute_info ()
   {
-    if (call_info)
-      {
-	delete call_info;
-      }
+    call_info = nullptr;
   }
 
   void


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23960

- cursor should be closed only for T_SELECT type
- not to call db_free_query_result () if result's status is T_CLOSED
- call_info should not be freed in execute_info's destructor