### PR TITLE
[LETS-223] Replicate changes on PTS on a single thread

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -212,7 +212,6 @@ static const size_t CSS_JOB_QUEUE_SCAN_COLUMN_COUNT = 4;
 static void css_setup_server_loop (void);
 static int css_check_conn (CSS_CONN_ENTRY * p);
 static void css_set_shutdown_timeout (int timeout);
-int css_get_master_request (SOCKET master_fd);
 static int css_process_master_request (SOCKET master_fd);
 static void css_process_shutdown_request (SOCKET master_fd);
 static void css_send_reply_to_new_client_request (CSS_CONN_ENTRY * conn, unsigned short rid, int reason);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -390,7 +390,7 @@ page_server::start_log_replicator (const log_lsa &start_lsa)
 
   const int replication_parallel_count = prm_get_integer_value (PRM_ID_REPLICATION_PARALLEL_COUNT);
   assert (replication_parallel_count >= 0);
-  m_replicator.reset (new cublog::replicator (start_lsa, replication_parallel_count));
+  m_replicator.reset (new cublog::replicator (start_lsa, RECOVERY_PAGE, replication_parallel_count));
 }
 
 void

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -359,7 +359,7 @@ page_server::push_request_to_active_tran_server (page_to_tran_request reqid, std
 cublog::replicator &
 page_server::get_replicator ()
 {
-  assert (m_replicator);
+  assert (m_replicator != nullptr);
   return *m_replicator;
 }
 
@@ -369,7 +369,9 @@ page_server::start_log_replicator (const log_lsa &start_lsa)
   assert (is_page_server ());
   assert (m_replicator == nullptr);
 
-  m_replicator.reset (new cublog::replicator (start_lsa));
+  const int replication_parallel_count = prm_get_integer_value (PRM_ID_REPLICATION_PARALLEL_COUNT);
+  assert (replication_parallel_count >= 0);
+  m_replicator.reset (new cublog::replicator (start_lsa, replication_parallel_count));
 }
 
 void

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -20,25 +20,12 @@
 #define _PAGE_SERVER_HPP_
 
 #include "async_page_fetcher.hpp"
+#include "log_replication.hpp"
 #include "log_storage.hpp"
 #include "request_sync_client_server.hpp"
 #include "tran_page_requests.hpp"
 
 #include <memory>
-
-// forward declaration
-namespace cublog
-{
-  class replicator;
-}
-namespace cubpacking
-{
-  class unpacker;
-}
-namespace cubthread
-{
-  class entry;
-}
 
 class page_server
 {

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -150,3 +150,7 @@ void passive_tran_server::start_log_replicator (const log_lsa &start_lsa)
   m_replicator.reset (new cublog::replicator (start_lsa, OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT, 0));
 }
 
+log_lsa passive_tran_server::get_replicator_lsa () const
+{
+  return m_replicator->get_redo_lsa ();
+}

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -154,3 +154,11 @@ log_lsa passive_tran_server::get_replicator_lsa () const
 {
   return m_replicator->get_redo_lsa ();
 }
+
+void passive_tran_server::finish_replication_during_shutdown (cubthread::entry &thread_entry)
+{
+  assert (m_replicator != nullptr);
+
+  m_replicator->wait_replication_finish_during_shutdown ();
+  m_replicator.reset (nullptr);
+}

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -147,6 +147,6 @@ void passive_tran_server::start_log_replicator (const log_lsa &start_lsa)
 
   // passive transaction server executes replication synchronously, for the time being, due to complexity of
   // executing it in parallel while also providing a consistent view of the data
-  m_replicator.reset (new cublog::replicator (start_lsa, 0));
+  m_replicator.reset (new cublog::replicator (start_lsa, OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT, 0));
 }
 

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -19,6 +19,7 @@
 #ifndef _PASSIVE_TRAN_SERVER_HPP_
 #define _PASSIVE_TRAN_SERVER_HPP_
 
+#include "log_replication.hpp"
 #include "tran_server.hpp"
 
 class passive_tran_server : public tran_server
@@ -27,9 +28,11 @@ class passive_tran_server : public tran_server
     passive_tran_server () : tran_server (cubcomm::server_server::CONNECT_PASSIVE_TRAN_TO_PAGE_SERVER)
     {
     }
+    ~passive_tran_server () override;
 
   public:
     void send_and_receive_log_boot_info (THREAD_ENTRY *thread_p);
+    void start_log_replicator (const log_lsa &start_lsa);
 
   private:
     bool uses_remote_storage () const final override;
@@ -44,6 +47,8 @@ class passive_tran_server : public tran_server
     std::mutex m_log_boot_info_mtx;
     std::string m_log_boot_info;
     std::condition_variable m_log_boot_info_condvar;
+
+    std::unique_ptr<cublog::replicator> m_replicator;
 };
 
 #endif // !_passive_tran_server_HPP_

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -34,6 +34,8 @@ class passive_tran_server : public tran_server
     void send_and_receive_log_boot_info (THREAD_ENTRY *thread_p);
     void start_log_replicator (const log_lsa &start_lsa);
 
+    log_lsa get_replicator_lsa () const;
+
   private:
     bool uses_remote_storage () const final override;
     bool get_remote_storage_config () final override;

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -34,7 +34,10 @@ class passive_tran_server : public tran_server
     void send_and_receive_log_boot_info (THREAD_ENTRY *thread_p);
     void start_log_replicator (const log_lsa &start_lsa);
 
+  public:
+    /* read current replicator progress */
     log_lsa get_replicator_lsa () const;
+    void finish_replication_during_shutdown (cubthread::entry &thread_entry);
 
   private:
     bool uses_remote_storage () const final override;

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -35,7 +35,7 @@ class passive_tran_server : public tran_server
     void start_log_replicator (const log_lsa &start_lsa);
 
   public:
-    /* read current replicator progress */
+    /* read replicator's current progress */
     log_lsa get_replicator_lsa () const;
     void finish_replication_during_shutdown (cubthread::entry &thread_entry);
 

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -34,7 +34,6 @@ class passive_tran_server : public tran_server
     void send_and_receive_log_boot_info (THREAD_ENTRY *thread_p);
     void start_log_replicator (const log_lsa &start_lsa);
 
-  public:
     /* read replicator's current progress */
     log_lsa get_replicator_lsa () const;
     void finish_replication_during_shutdown (cubthread::entry &thread_entry);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8017,9 +8017,9 @@ pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * 
   if (request_from_ps)
     {
       // *INDENT-OFF*
-      const auto replicator_lsa_ftor =[] ()
+      const auto replicator_lsa_ftor = [] ()
       {
-	const passive_tran_server * const pts_ptr = get_passive_tran_server_ptr ();
+	const passive_tran_server *const pts_ptr = get_passive_tran_server_ptr ();
 	return pts_ptr->get_replicator_lsa ();
       };
       // *INDENT-ON*

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3189,6 +3189,12 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
     }
   else if (get_server_type () == SERVER_TYPE_TRANSACTION)
     {
+      // NOTE: passive transaction server, regarding replication: since
+      // the state of a passive transaction server is completely transient - and read-only,
+      // there is no need to reach a consistent state of log replication before shutting down;
+      // upon restart, a passive transaction server will, again, pick up its state from the
+      // page server(s) it connects to
+
       ts_Gl->finalize_page_brokers ();
     }
 #endif

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -84,6 +84,7 @@
 #include "tde.h"
 #include "porting.h"
 #include "page_server.hpp"
+#include "passive_tran_server.hpp"
 #include "scope_exit.hpp"
 #include "server_type.hpp"
 #include "log_manager.h"
@@ -3194,6 +3195,8 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
       // there is no need to reach a consistent state of log replication before shutting down;
       // upon restart, a passive transaction server will, again, pick up its state from the
       // page server(s) it connects to
+      passive_tran_server *const pts_ptr = get_passive_tran_server_ptr ();
+      pts_ptr->finish_replication_during_shutdown (*thread_p);
 
       ts_Gl->finalize_page_brokers ();
     }

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3190,11 +3190,11 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
     }
   else if (get_server_type () == SERVER_TYPE_TRANSACTION)
     {
-      // NOTE: passive transaction server, regarding replication: since
-      // the state of a passive transaction server is completely transient - and read-only,
-      // there is no need to reach a consistent state of log replication before shutting down;
-      // upon restart, a passive transaction server will, again, pick up its state from the
-      // page server(s) it connects to
+      // NOTE: passive transaction server, regarding replication: even if a
+      // passive transaction server is completely transient - and read-only -
+      // and, thus, does not need to reach a consistent state at shutdown (because it
+      // will pick a consistent state at boot from the page server(s) it connects to), replication
+      // needs to be explicitly terminated gracefully before log infrastructure is finalized
       passive_tran_server *const pts_ptr = get_passive_tran_server_ptr ();
       pts_ptr->finish_replication_during_shutdown (*thread_p);
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1665,6 +1665,8 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
 
   logpb_initialize_logging_statistics ();
 
+  log_daemons_init ();
+
   er_log_debug (ARG_FILE_LINE, "log_initialize_passive_tran_server: end of log initializaton, append_lsa = (%lld|%d)\n",
 		LSA_AS_ARGS (&log_Gl.hdr.append_lsa));
 }
@@ -10761,12 +10763,19 @@ log_flush_daemon_init ()
 static void
 log_daemons_init ()
 {
-  log_remove_log_archive_daemon_init ();
-  log_checkpoint_daemon_init ();
-  log_checkpoint_trantable_daemon_init ();
-  log_check_ha_delay_info_daemon_init ();
-  log_clock_daemon_init ();
-  log_flush_daemon_init ();
+  if (is_passive_transaction_server ())
+    {
+      log_flush_daemon_init ();
+    }
+  else
+    {
+      log_remove_log_archive_daemon_init ();
+      log_checkpoint_daemon_init ();
+      log_checkpoint_trantable_daemon_init ();
+      log_check_ha_delay_info_daemon_init ();
+      log_clock_daemon_init ();
+      log_flush_daemon_init ();
+    }
 }
 #endif /* SERVER_MODE */
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1648,6 +1648,11 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
 
     LOG_RESET_APPEND_LSA (&log_Gl.hdr.append_lsa);
     LOG_RESET_PREV_LSA (&log_Gl.append.prev_lsa);
+
+    // while still holding prior LSA lock, initialize passive transaction server replication
+    // without losing any log record
+    const log_lsa next_io_lsa = log_Gl.append.get_nxio_lsa ();
+    pts_ptr->start_log_replicator (next_io_lsa);
   }
 
   err_code = logtb_define_trantable_log_latch (thread_p, -1);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1637,9 +1637,7 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
   passive_tran_server *const pts_ptr = get_passive_tran_server_ptr ();
   assert (pts_ptr != nullptr);
 
-  log_lsa replication_start_redo_lsa
-  {
-  NULL_LSA};
+  log_lsa replication_start_redo_lsa = NULL_LSA;
   {
     // before requesting log boot info from page server, hold a lock for the prior mutex
     // during the call, page server will also start sending log records and we must make sure to

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1118,7 +1118,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 {
   LOG_LSA lsa;			/* LSA of log record to redo */
 
-  log_rv_redo_context redo_context (context.get_end_redo_lsa (), log_reader::fetch_mode::NORMAL);
+  log_rv_redo_context redo_context (context.get_end_redo_lsa (), RECOVERY_PAGE, log_reader::fetch_mode::NORMAL);
 
   volatile TRANID tran_id;
   volatile LOG_RECTYPE log_rtype;

--- a/src/transaction/log_recovery.h
+++ b/src/transaction/log_recovery.h
@@ -22,14 +22,15 @@
 #include "log_compress.h"
 #include "log_lsa.hpp"
 #include "log_reader.hpp"
+#include "page_buffer.h"
 #include "recovery.h"
 #include "storage_common.h"
 #include "thread_compat.hpp"
 
-PAGE_PTR log_rv_redo_fix_page (THREAD_ENTRY * thread_p, const VPID * vpid_rcv);
+PAGE_PTR log_rv_redo_fix_page (THREAD_ENTRY * thread_p, const VPID * vpid_rcv, PAGE_FETCH_MODE page_fetch_mode);
 bool log_rv_fix_page_and_check_redo_is_needed (THREAD_ENTRY * thread_p, const VPID & page_vpid, log_rcv & rcv,
 					       LOG_RCVINDEX rcvindex, const log_lsa & rcv_lsa,
-					       const LOG_LSA & end_redo_lsa);
+					       const LOG_LSA & end_redo_lsa, PAGE_FETCH_MODE page_fetch_mode);
 int log_rv_get_unzip_log_data (THREAD_ENTRY * thread_p, int length, log_reader & log_pgptr_reader, LOG_ZIP * unzip_ptr,
 			       bool & is_zip);
 int log_rv_get_unzip_and_diff_redo_log_data (THREAD_ENTRY * thread_p, log_reader & log_pgptr_reader, LOG_RCV * rcv,

--- a/src/transaction/log_recovery_redo.cpp
+++ b/src/transaction/log_recovery_redo.cpp
@@ -46,16 +46,18 @@ vpid_lsa_consistency_check::cleanup ()
 vpid_lsa_consistency_check log_Gl_recovery_redo_consistency_check;
 #endif
 
-log_rv_redo_context::log_rv_redo_context (const log_lsa &end_redo_lsa, log_reader::fetch_mode fetch_mode)
+log_rv_redo_context::log_rv_redo_context (const log_lsa &end_redo_lsa, PAGE_FETCH_MODE page_fetch_mode,
+    log_reader::fetch_mode reader_fetch_page_mode)
   : m_end_redo_lsa { end_redo_lsa }
-  , m_reader_fetch_page_mode { fetch_mode }
+  , m_page_fetch_mode { page_fetch_mode }
+  , m_reader_fetch_page_mode { reader_fetch_page_mode }
 {
   log_zip_realloc_if_needed (m_undo_zip, LOGAREA_SIZE);
   log_zip_realloc_if_needed (m_redo_zip, LOGAREA_SIZE);
 }
 
-log_rv_redo_context::log_rv_redo_context (const log_rv_redo_context &o)
-  : log_rv_redo_context (o.m_end_redo_lsa, o.m_reader_fetch_page_mode)
+log_rv_redo_context::log_rv_redo_context (const log_rv_redo_context &that)
+  : log_rv_redo_context { that.m_end_redo_lsa, that.m_page_fetch_mode, that.m_reader_fetch_page_mode }
 {
 }
 

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -36,10 +36,12 @@ struct log_rv_redo_context
   LOG_ZIP m_redo_zip;
   LOG_ZIP m_undo_zip;
   const LOG_LSA m_end_redo_lsa = NULL_LSA;
+  const PAGE_FETCH_MODE m_page_fetch_mode = RECOVERY_PAGE;
   const log_reader::fetch_mode m_reader_fetch_page_mode = log_reader::fetch_mode::FORCE;
 
   log_rv_redo_context () = delete;
-  log_rv_redo_context (const log_lsa &end_redo_lsa, log_reader::fetch_mode fetch_mode);
+  log_rv_redo_context (const log_lsa &end_redo_lsa, PAGE_FETCH_MODE page_fetch_mode,
+		       log_reader::fetch_mode reader_fetch_page_mode);
   ~log_rv_redo_context ();
 
   log_rv_redo_context (const log_rv_redo_context &);

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -602,7 +602,7 @@ void log_rv_redo_record_sync (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_
 
   LOG_RCV rcv;
   if (!log_rv_fix_page_and_check_redo_is_needed (thread_p, rcv_vpid, rcv, log_data.rcvindex, record_info.m_start_lsa,
-      redo_context.m_end_redo_lsa))
+      redo_context.m_end_redo_lsa, redo_context.m_page_fetch_mode))
     {
       /* nothing else needs to be done, see explanation in function */
       assert (rcv.pgptr == nullptr);

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -97,8 +97,9 @@ namespace cublog
    * replicator - definition
    *********************************************************************/
 
-  replicator::replicator (const log_lsa &start_redo_lsa, int parallel_count)
+  replicator::replicator (const log_lsa &start_redo_lsa, PAGE_FETCH_MODE page_fetch_mode, int parallel_count)
     : m_redo_lsa { start_redo_lsa }
+    , m_redo_context { NULL_LSA, page_fetch_mode, log_reader::fetch_mode::FORCE }
     , m_perfmon_redo_sync { PSTAT_REDO_REPL_LOG_REDO_SYNC }
     , m_perf_stat_idle { cublog::perf_stats::do_not_record_t {} }
   {
@@ -173,12 +174,12 @@ namespace cublog
 
     m_perfmon_redo_sync.start ();
     // make sure the log page is refreshed. otherwise it may be outdated and new records may be missed
-    m_redo_context.m_reader.set_lsa_and_fetch_page (m_redo_lsa, log_reader::fetch_mode::FORCE);
+    (void) m_redo_context.m_reader.set_lsa_and_fetch_page (m_redo_lsa, log_reader::fetch_mode::FORCE);
 
     while (m_redo_lsa < end_redo_lsa)
       {
 	// read and redo a record
-	m_redo_context.m_reader.set_lsa_and_fetch_page (m_redo_lsa);
+	(void) m_redo_context.m_reader.set_lsa_and_fetch_page (m_redo_lsa);
 
 	const log_rec_header header = m_redo_context.m_reader.reinterpret_copy_and_add_align<log_rec_header> ();
 

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -97,7 +97,7 @@ namespace cublog
    * replicator - definition
    *********************************************************************/
 
-  replicator::replicator (const log_lsa &start_redo_lsa)
+  replicator::replicator (const log_lsa &start_redo_lsa, int parallel_count)
     : m_redo_lsa { start_redo_lsa }
     , m_perfmon_redo_sync { PSTAT_REDO_REPL_LOG_REDO_SYNC }
     , m_perf_stat_idle { cublog::perf_stats::do_not_record_t {} }
@@ -107,17 +107,15 @@ namespace cublog
     //  - race conditions, when daemon comes online, are avoided
     //  - (even making abstraction of the race conditions) no log records are needlessly
     //    processed synchronously
-    const int replication_parallel_count = prm_get_integer_value (PRM_ID_REPLICATION_PARALLEL_COUNT);
-    assert (replication_parallel_count >= 0);
-    if (replication_parallel_count > 0)
+    if (parallel_count > 0)
       {
 	// no need to reset with start redo lsa
 
 	const bool force_each_log_page_fetch = true;
 	m_reusable_jobs.reset (new cublog::reusable_jobs_stack ());
-	m_reusable_jobs->initialize (replication_parallel_count);
+	m_reusable_jobs->initialize (parallel_count);
 	m_parallel_replication_redo.reset (
-		new cublog::redo_parallel (replication_parallel_count, true, m_redo_lsa, m_redo_context));
+		new cublog::redo_parallel (parallel_count, true, m_redo_lsa, m_redo_context));
       }
 
     // Create the daemon

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -54,7 +54,7 @@ namespace cublog
   {
     public:
       replicator () = delete;
-      replicator (const log_lsa &start_redo_lsa);
+      replicator (const log_lsa &start_redo_lsa, int parallel_count);
       ~replicator ();
 
       /* function can only be called when it is ensured that 'nxio_lsa' will

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -54,8 +54,15 @@ namespace cublog
   {
     public:
       replicator () = delete;
-      replicator (const log_lsa &start_redo_lsa, int parallel_count);
+      replicator (const log_lsa &start_redo_lsa, PAGE_FETCH_MODE page_fetch_mode, int parallel_count);
+
+      replicator (const replicator &) = delete;
+      replicator (replicator &&) = delete;
+
       ~replicator ();
+
+      replicator &operator= (const replicator &) = delete;
+      replicator &operator= (replicator &&) = delete;
 
       /* function can only be called when it is ensured that 'nxio_lsa' will
        * no longer be modified (ie: increase)
@@ -85,7 +92,7 @@ namespace cublog
       log_lsa m_redo_lsa = NULL_LSA;
       mutable std::mutex m_redo_lsa_mutex;
       mutable std::condition_variable m_redo_lsa_condvar;
-      log_rv_redo_context m_redo_context { NULL_LSA, log_reader::fetch_mode::FORCE };
+      log_rv_redo_context m_redo_context;
 
       std::unique_ptr<cublog::reusable_jobs_stack> m_reusable_jobs;
       std::unique_ptr<cublog::redo_parallel> m_parallel_replication_redo;

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -65,14 +65,13 @@ namespace cublog
       replicator &operator= (replicator &&) = delete;
 
       /* function can only be called when it is ensured that 'nxio_lsa' will
-       * no longer be modified (ie: increase)
-       */
+       * no longer be modified (ie: increase) */
       void wait_replication_finish_during_shutdown () const;
 
-      /* wait until replication advances past the target lsa
-       * blocking call
-       */
+      /* wait until replication advances past the target lsa; blocking call */
       void wait_past_target_lsa (const log_lsa &a_target_lsa);
+      /* return current progress of the replicator; non-blocking call */
+      log_lsa get_redo_lsa () const;
 
     private:
       void redo_upto_nxio_lsa (cubthread::entry &thread_entry);

--- a/unit_tests/log/dummy_page_server.cpp
+++ b/unit_tests/log/dummy_page_server.cpp
@@ -22,7 +22,7 @@
 
 PSTAT_GLOBAL pstat_Global;
 
-cublog::replicator replicator_Gl_test (NULL_LSA, -1);
+cublog::replicator replicator_Gl_test (NULL_LSA, RECOVERY_PAGE, -1);
 page_server ps_Gl;
 
 namespace cublog
@@ -30,8 +30,9 @@ namespace cublog
   class reusable_jobs_stack {};
   class redo_parallel {};
 
-  replicator::replicator (const log_lsa &start_redo_lsa, int parallel_count)
-    : m_perfmon_redo_sync{ PSTAT_REDO_REPL_LOG_REDO_SYNC }
+  replicator::replicator (const log_lsa &, PAGE_FETCH_MODE page_fetch_mode, int)
+    : m_redo_context { NULL_LSA, page_fetch_mode, log_reader::fetch_mode::FORCE }
+    , m_perfmon_redo_sync { PSTAT_REDO_REPL_LOG_REDO_SYNC }
     , m_perf_stat_idle { cublog::perf_stats::do_not_record_t {} }
   {
   }
@@ -86,7 +87,7 @@ page_server::get_replicator ()
   return replicator_Gl_test;
 }
 
-log_rv_redo_context::log_rv_redo_context (const log_lsa &end_redo_lsa, log_reader::fetch_mode fetch_mode)
+log_rv_redo_context::log_rv_redo_context (const log_lsa &, PAGE_FETCH_MODE, log_reader::fetch_mode)
 {
 }
 

--- a/unit_tests/log/dummy_page_server.cpp
+++ b/unit_tests/log/dummy_page_server.cpp
@@ -22,7 +22,7 @@
 
 PSTAT_GLOBAL pstat_Global;
 
-cublog::replicator replicator_GL (NULL_LSA);
+cublog::replicator replicator_Gl_test (NULL_LSA, -1);
 page_server ps_Gl;
 
 namespace cublog
@@ -30,7 +30,7 @@ namespace cublog
   class reusable_jobs_stack {};
   class redo_parallel {};
 
-  replicator::replicator (const log_lsa &start_redo_lsa)
+  replicator::replicator (const log_lsa &start_redo_lsa, int parallel_count)
     : m_perfmon_redo_sync{ PSTAT_REDO_REPL_LOG_REDO_SYNC }
     , m_perf_stat_idle { cublog::perf_stats::do_not_record_t {} }
   {
@@ -79,7 +79,7 @@ page_server::~page_server ()
 cublog::replicator &
 page_server::get_replicator ()
 {
-  return replicator_GL;
+  return replicator_Gl_test;
 }
 
 log_rv_redo_context::log_rv_redo_context (const log_lsa &end_redo_lsa, log_reader::fetch_mode fetch_mode)

--- a/unit_tests/log/test_main_log_recovery_parallel.cpp
+++ b/unit_tests/log/test_main_log_recovery_parallel.cpp
@@ -76,7 +76,7 @@ void execute_test (const log_recovery_test_config &a_test_config,
   ux_ut_database db_online { new ut_database (a_database_config) };
   ux_ut_database db_recovery { new ut_database (a_database_config) };
 
-  log_rv_redo_context dummy_redo_context (NULL_LSA, log_reader::fetch_mode::NORMAL);
+  log_rv_redo_context dummy_redo_context (NULL_LSA, RECOVERY_PAGE, log_reader::fetch_mode::NORMAL);
 
   // infrastructure to check progress of the test
   //


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-223

Passive transaction server must replicate ATS changes on its page buffer pages to avoid fetching pages again from PS for the updated versions.
If PS only has to replicate data updates on page level, PTS has to make consistent reads concurrently with the replication.

To simplify how replication works, it will be limited to a single thread. The scope of this patch is to allow consistent queries only after the replication is completed. Consistent queries concurrent with replication will be implemented in future tasks.

Implementation:
- initialize log flush daemon on PTS to process log prior list received from PS
- start replication during passive transaction server log initialization; do this before the PTS actually starts consuming the log prior received from the PS; PTS replication is currently explicitly single threaded
- adapt to use the new page fetch mode OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT on PTS
- adapt to skip applying the log record if: page is either not returned by the attempt to fix it with the new page fetch mode; or it is returned but its LSA is greater than the current log record LSA (meaning the page retrieved from PS already contains the modifications applied by the PS replication)
- also skip applying log records for btree statistics log records
- track the highest LSA applied by replication and set it as target LSA for the data pages fetched from PS
- parameterize cublog::replicator to allow tuning it differently for PS and PTS
- gracefully shutdown replication before finalizing log on passive transaction server
