### PR TITLE
[LETS-326] Rename request_sync_client_server::sequenced_payload

### DIFF
--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -53,17 +53,17 @@ namespace cubcomm
 
       // The user payload (of type T_PAYLOAD) is accompanied by a response sequence number set by
       // request_sync_client_server.
-      class internal_payload : public cubpacking::packable_object
+      class sequenced_payload : public cubpacking::packable_object
       {
 	public:
-	  internal_payload () = default;
-	  internal_payload (response_sequence_number_t a_rsn, T_PAYLOAD &&a_payload);
-	  internal_payload (internal_payload &&other);
-	  internal_payload (const internal_payload &other) = delete;
-	  ~internal_payload () = default;
+	  sequenced_payload () = default;
+	  sequenced_payload (response_sequence_number_t a_rsn, T_PAYLOAD &&a_payload);
+	  sequenced_payload (sequenced_payload &&other);
+	  sequenced_payload (const sequenced_payload &other) = delete;
+	  ~sequenced_payload () = default;
 
-	  internal_payload &operator= (internal_payload &&other);
-	  internal_payload &operator= (const internal_payload &) = delete;
+	  sequenced_payload &operator= (sequenced_payload &&other);
+	  sequenced_payload &operator= (const sequenced_payload &) = delete;
 
 	  void push_payload (T_PAYLOAD &&a_payload);
 	  T_PAYLOAD pull_payload ();
@@ -77,7 +77,7 @@ namespace cubcomm
 	  T_PAYLOAD m_user_payload;
       };
 
-      using incoming_request_handler_t = std::function<void (internal_payload &)>;
+      using incoming_request_handler_t = std::function<void (sequenced_payload &)>;
 
     public:
       request_sync_client_server (cubcomm::channel &&a_channel,
@@ -99,7 +99,7 @@ namespace cubcomm
       void push (T_OUTGOING_MSG_ID a_outgoing_message_id, T_PAYLOAD &&a_payload);
 
     private:
-      using request_sync_send_queue_t = cubcomm::request_sync_send_queue<request_client_server_t, internal_payload>;
+      using request_sync_send_queue_t = cubcomm::request_sync_send_queue<request_client_server_t, sequenced_payload>;
       using request_queue_autosend_t = cubcomm::request_queue_autosend<request_sync_send_queue_t>;
 
       void unpack_and_handle (cubpacking::unpacker &deserializator, const incoming_request_handler_t &handler);
@@ -164,7 +164,7 @@ namespace cubcomm
   {
     assert (m_conn != nullptr && m_conn->is_thread_started ());
 
-    internal_payload ip (NO_RESPONSE, std::move (a_payload));
+    sequenced_payload ip (NO_RESPONSE, std::move (a_payload));
 
     m_queue->push (a_outgoing_message_id, std::move (ip));
   }
@@ -174,7 +174,7 @@ namespace cubcomm
   request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::unpack_and_handle (
 	  cubpacking::unpacker &deserializator, const incoming_request_handler_t &handler)
   {
-    internal_payload ip;
+    sequenced_payload ip;
 
     ip.unpack (deserializator);
     handler (ip);
@@ -184,7 +184,7 @@ namespace cubcomm
   // Internal payload
   //
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
-  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::internal_payload::internal_payload (
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::sequenced_payload (
 	  response_sequence_number_t a_rsn, T_PAYLOAD &&a_payload)
     : m_rsn (a_rsn)
   {
@@ -192,8 +192,8 @@ namespace cubcomm
   }
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
-  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::internal_payload::internal_payload (
-	  internal_payload &&other)
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::sequenced_payload (
+	  sequenced_payload &&other)
     : m_rsn (std::move (other.m_rsn))
     , m_user_payload (std::move (other.m_user_payload))
   {
@@ -201,9 +201,9 @@ namespace cubcomm
   }
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
-  typename request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::internal_payload &
-  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::internal_payload::operator=
-  (internal_payload &&other)
+  typename request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload &
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::operator=
+  (sequenced_payload &&other)
   {
     if (this != &other)
       {
@@ -217,7 +217,7 @@ namespace cubcomm
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
   void
-  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::internal_payload::push_payload (
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::push_payload (
 	  T_PAYLOAD &&a_payload)
   {
     m_user_payload = std::move (a_payload);
@@ -225,14 +225,14 @@ namespace cubcomm
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
   T_PAYLOAD
-  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::internal_payload::pull_payload ()
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::pull_payload ()
   {
     return std::move (m_user_payload);
   }
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
   size_t
-  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::internal_payload::get_packed_size (
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::get_packed_size (
 	  cubpacking::packer &serializator, std::size_t start_offset /*= 0*/) const
   {
     return serializator.get_all_packed_size_starting_offset (start_offset, m_rsn, m_user_payload);
@@ -240,7 +240,7 @@ namespace cubcomm
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
   void
-  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::internal_payload::pack (
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::pack (
 	  cubpacking::packer &serializator) const
   {
     serializator.pack_all (m_rsn, m_user_payload);
@@ -248,7 +248,7 @@ namespace cubcomm
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
   void
-  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::internal_payload::unpack (
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::unpack (
 	  cubpacking::unpacker &deserializator)
   {
     deserializator.unpack_all (m_rsn, m_user_payload);

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -44,7 +44,7 @@ active_tran_server::get_remote_storage_config ()
 }
 
 void
-active_tran_server::receive_saved_lsa (page_server_conn_t::internal_payload &a_ip)
+active_tran_server::receive_saved_lsa (page_server_conn_t::sequenced_payload &a_ip)
 {
   std::string message = a_ip.pull_payload ();
   log_lsa saved_lsa;

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -37,7 +37,7 @@ class active_tran_server : public tran_server
 
     request_handlers_map_t get_request_handlers () final override;
 
-    void receive_saved_lsa (page_server_conn_t::internal_payload &a_ip);
+    void receive_saved_lsa (page_server_conn_t::sequenced_payload &a_ip);
 
   private:
     bool m_uses_remote_storage = false;

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -97,13 +97,13 @@ page_server::connection_handler::push_request (page_to_tran_request id, std::str
 }
 
 void
-page_server::connection_handler::receive_log_prior_list (tran_server_conn_t::internal_payload &a_ip)
+page_server::connection_handler::receive_log_prior_list (tran_server_conn_t::sequenced_payload &a_ip)
 {
   log_Gl.get_log_prior_receiver ().push_message (std::move (a_ip.pull_payload ()));
 }
 
 void
-page_server::connection_handler::receive_log_page_fetch (tran_server_conn_t::internal_payload &a_ip)
+page_server::connection_handler::receive_log_page_fetch (tran_server_conn_t::sequenced_payload &a_ip)
 {
   LOG_PAGEID pageid;
   std::string message = a_ip.pull_payload ();
@@ -121,7 +121,7 @@ page_server::connection_handler::receive_log_page_fetch (tran_server_conn_t::int
 }
 
 void
-page_server::connection_handler::receive_data_page_fetch (tran_server_conn_t::internal_payload &a_ip)
+page_server::connection_handler::receive_data_page_fetch (tran_server_conn_t::sequenced_payload &a_ip)
 {
   std::string message = a_ip.pull_payload ();
 
@@ -138,7 +138,7 @@ page_server::connection_handler::receive_data_page_fetch (tran_server_conn_t::in
 }
 
 void
-page_server::connection_handler::receive_log_boot_info_fetch (tran_server_conn_t::internal_payload &)
+page_server::connection_handler::receive_log_boot_info_fetch (tran_server_conn_t::sequenced_payload &)
 {
   // empty request message
 
@@ -163,7 +163,7 @@ page_server::connection_handler::on_log_boot_info_result (std::string &&message)
 }
 
 void
-page_server::connection_handler::receive_disconnect_request (tran_server_conn_t::internal_payload &)
+page_server::connection_handler::receive_disconnect_request (tran_server_conn_t::sequenced_payload &)
 {
   if (m_prior_sender_sink_hook_func)
     {
@@ -177,7 +177,7 @@ page_server::connection_handler::receive_disconnect_request (tran_server_conn_t:
 }
 
 void
-page_server::connection_handler::receive_boot_info_request (tran_server_conn_t::internal_payload &)
+page_server::connection_handler::receive_boot_info_request (tran_server_conn_t::sequenced_payload &)
 {
   DKNVOLS nvols_perm = disk_get_perm_volume_count ();
 

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -84,12 +84,12 @@ class page_server
 	void on_data_page_read_result (const FILEIO_PAGE *page_ptr, int error_code);
 	void on_log_boot_info_result (std::string &&message);
 
-	void receive_boot_info_request (tran_server_conn_t::internal_payload &a_ip);
-	void receive_log_prior_list (tran_server_conn_t::internal_payload &a_ip);
-	void receive_log_page_fetch (tran_server_conn_t::internal_payload &a_ip);
-	void receive_data_page_fetch (tran_server_conn_t::internal_payload &a_ip);
-	void receive_disconnect_request (tran_server_conn_t::internal_payload &a_ip);
-	void receive_log_boot_info_fetch (tran_server_conn_t::internal_payload &a_ip);
+	void receive_boot_info_request (tran_server_conn_t::sequenced_payload &a_ip);
+	void receive_log_prior_list (tran_server_conn_t::sequenced_payload &a_ip);
+	void receive_log_page_fetch (tran_server_conn_t::sequenced_payload &a_ip);
+	void receive_data_page_fetch (tran_server_conn_t::sequenced_payload &a_ip);
+	void receive_disconnect_request (tran_server_conn_t::sequenced_payload &a_ip);
+	void receive_log_boot_info_fetch (tran_server_conn_t::sequenced_payload &a_ip);
 
 	void prior_sender_sink_hook (std::string &&message) const;
 

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -60,7 +60,7 @@ passive_tran_server::get_request_handlers ()
 }
 
 void
-passive_tran_server::receive_log_boot_info (page_server_conn_t::internal_payload &a_ip)
+passive_tran_server::receive_log_boot_info (page_server_conn_t::sequenced_payload &a_ip)
 {
   std::string message = a_ip.pull_payload ();
 
@@ -73,7 +73,7 @@ passive_tran_server::receive_log_boot_info (page_server_conn_t::internal_payload
 }
 
 void
-passive_tran_server::receive_log_prior_list (page_server_conn_t::internal_payload &a_ip)
+passive_tran_server::receive_log_prior_list (page_server_conn_t::sequenced_payload &a_ip)
 {
   std::string message = a_ip.pull_payload ();
   log_Gl.get_log_prior_receiver ().push_message (std::move (message));

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -37,8 +37,8 @@ class passive_tran_server : public tran_server
     void on_boot () final override;
     request_handlers_map_t get_request_handlers () final override;
 
-    void receive_log_boot_info (page_server_conn_t::internal_payload &a_ip);
-    void receive_log_prior_list (page_server_conn_t::internal_payload &a_ip);
+    void receive_log_boot_info (page_server_conn_t::sequenced_payload &a_ip);
+    void receive_log_prior_list (page_server_conn_t::sequenced_payload &a_ip);
 
   private:
     std::mutex m_log_boot_info_mtx;

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -365,7 +365,7 @@ tran_server::push_request (tran_to_page_request reqid, std::string &&payload)
 }
 
 void
-tran_server::receive_log_page (page_server_conn_t::internal_payload &a_ip)
+tran_server::receive_log_page (page_server_conn_t::sequenced_payload &a_ip)
 {
   std::string message = a_ip.pull_payload ();
 
@@ -393,7 +393,7 @@ tran_server::receive_log_page (page_server_conn_t::internal_payload &a_ip)
 }
 
 void
-tran_server::receive_data_page (page_server_conn_t::internal_payload &a_ip)
+tran_server::receive_data_page (page_server_conn_t::sequenced_payload &a_ip)
 {
   std::string message = a_ip.pull_payload ();
 
@@ -431,7 +431,7 @@ tran_server::receive_data_page (page_server_conn_t::internal_payload &a_ip)
 }
 
 void
-tran_server::receive_boot_info (page_server_conn_t::internal_payload &a_ip)
+tran_server::receive_boot_info (page_server_conn_t::sequenced_payload &a_ip)
 {
   std::string message = a_ip.pull_payload ();
 

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -105,9 +105,9 @@ class tran_server
     int parse_server_host (const std::string &host);
     int parse_page_server_hosts_config (std::string &hosts);
     // Common request Handlers
-    void receive_boot_info (page_server_conn_t::internal_payload &a_ip);
-    void receive_log_page (page_server_conn_t::internal_payload &a_ip);
-    void receive_data_page (page_server_conn_t::internal_payload &a_ip);
+    void receive_boot_info (page_server_conn_t::sequenced_payload &a_ip);
+    void receive_log_page (page_server_conn_t::sequenced_payload &a_ip);
+    void receive_data_page (page_server_conn_t::sequenced_payload &a_ip);
 
   private:
     std::unique_ptr<page_broker<log_page_type>> m_log_page_broker;

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -876,17 +876,17 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_one (
 
   // handle requests 2 to 1
   test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_0 =
-	  [] (test_request_sync_client_server_one_t::internal_payload &a_ip)
+	  [] (test_request_sync_client_server_one_t::sequenced_payload &a_ip)
   {
     mock_check_expected_id_sync<reqids_2_to_1, reqids_2_to_1::_0> (a_ip);
   };
   test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_1 =
-	  [] (test_request_sync_client_server_one_t::internal_payload &a_ip)
+	  [] (test_request_sync_client_server_one_t::sequenced_payload &a_ip)
   {
     mock_check_expected_id_sync<reqids_2_to_1, reqids_2_to_1::_1> (a_ip);
   };
   test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_2 =
-	  [] (test_request_sync_client_server_one_t::internal_payload &a_ip)
+	  [] (test_request_sync_client_server_one_t::sequenced_payload &a_ip)
   {
     mock_check_expected_id_sync<reqids_2_to_1, reqids_2_to_1::_2> (a_ip);
   };
@@ -913,12 +913,12 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_two (
 
   // handle requests 1 to 2
   test_request_sync_client_server_two_t::incoming_request_handler_t req_handler_0 =
-	  [] (test_request_sync_client_server_two_t::internal_payload &a_ip)
+	  [] (test_request_sync_client_server_two_t::sequenced_payload &a_ip)
   {
     mock_check_expected_id_sync<reqids_1_to_2, reqids_1_to_2::_0> (a_ip);
   };
   test_request_sync_client_server_two_t::incoming_request_handler_t req_handler_1 =
-	  [] (test_request_sync_client_server_two_t::internal_payload &a_ip)
+	  [] (test_request_sync_client_server_two_t::sequenced_payload &a_ip)
   {
     mock_check_expected_id_sync<reqids_1_to_2, reqids_1_to_2::_1> (a_ip);
   };


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-326

The name `request_sync_client_server::internal_payload` was not great, because the name "internal" would suggest that the class is not visible to the world outside `request_sync_client_server`. However, the handlers that have to be provided from outside use it in their argument signature.

Renamed as `sequenced_payload` because it adds the response sequence number to the regular payload that the requester wants to send to the other side.
