### PR TITLE
[CBRD-24078] Fix API link error when using cubrid_log apis on windows 

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -574,7 +574,8 @@ cubrid_log_connect_server_internal (char *host, int port, char *dbname)
     }
 
   if (css_common_connect
-      (host, g_conn_entry, DATA_REQUEST, dbname, strlen (dbname) + 1, port, g_connection_timeout, &rid, true) == NULL)
+      (host, g_conn_entry, DATA_REQUEST, dbname, (int) strlen (dbname) + 1, port, g_connection_timeout, &rid,
+       true) == NULL)
     {
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT,
 				 "Failed to connect to the server. host (%s), dbname (%s), port (%d), timeout (%d sec)\n",
@@ -686,7 +687,7 @@ cubrid_log_send_configurations (void)
       ptr = or_pack_int64 (ptr, (INT64) g_extraction_table[i]);
     }
 
-  request_size = ptr - request;
+  request_size = (int) (ptr - request);
 
   if (css_send_request_with_data_buffer
       (g_conn_entry, NET_SERVER_CDC_START_SESSION, &rid, request, request_size, reply, reply_size) != NO_ERRORS)
@@ -1305,7 +1306,7 @@ cubrid_log_make_dml (char **data_info, DML * dml)
 	    case 5:
 	      dml->changed_column_data[i] = ptr;
 	      ptr = or_unpack_string_nocopy (ptr, &dml->changed_column_data[i]);
-	      dml->changed_column_data_len[i] = strlen (dml->changed_column_data[i]);
+	      dml->changed_column_data_len[i] = (int) strlen (dml->changed_column_data[i]);
 	      break;
 	    case 6:
 	      assert (0);	// unused pack func code: or_pack_stream()
@@ -1320,14 +1321,14 @@ cubrid_log_make_dml (char **data_info, DML * dml)
 		}
 	      else
 		{
-		  dml->changed_column_data_len[i] = strlen (dml->changed_column_data[i]);
+		  dml->changed_column_data_len[i] = (int) strlen (dml->changed_column_data[i]);
 		}
 	      break;
 
 	    case 8:
 	      dml->changed_column_data[i] = ptr;
 	      ptr = or_unpack_string_nocopy (ptr, &dml->changed_column_data[i]);
-	      dml->changed_column_data_len[i] = strlen (dml->changed_column_data[i]);
+	      dml->changed_column_data_len[i] = (int) strlen (dml->changed_column_data[i]);
 	      break;
 
 	    default:
@@ -1408,7 +1409,7 @@ cubrid_log_make_dml (char **data_info, DML * dml)
 	    case 5:
 	      dml->cond_column_data[i] = ptr;
 	      ptr = or_unpack_string_nocopy (ptr, &dml->cond_column_data[i]);
-	      dml->cond_column_data_len[i] = strlen (dml->cond_column_data[i]);
+	      dml->cond_column_data_len[i] = (int) strlen (dml->cond_column_data[i]);
 	      break;
 	    case 6:
 	      assert (0);	// unused pack func code: or_pack_stream()
@@ -1417,13 +1418,13 @@ cubrid_log_make_dml (char **data_info, DML * dml)
 	    case 7:
 	      dml->cond_column_data[i] = ptr;
 	      ptr = or_unpack_string_nocopy (ptr, &dml->cond_column_data[i]);
-	      dml->cond_column_data_len[i] = strlen (dml->cond_column_data[i]);
+	      dml->cond_column_data_len[i] = (int) strlen (dml->cond_column_data[i]);
 	      break;
 
 	    case 8:
 	      dml->cond_column_data[i] = ptr;
 	      ptr = or_unpack_string_nocopy (ptr, &dml->cond_column_data[i]);
-	      dml->cond_column_data_len[i] = strlen (dml->cond_column_data[i]);
+	      dml->cond_column_data_len[i] = (int) strlen (dml->cond_column_data[i]);
 	      break;
 
 	    default:
@@ -1734,10 +1735,6 @@ cubrid_log_clear_data_item (DATA_ITEM_TYPE data_item_type, CUBRID_DATA_ITEM * da
     }
 
   return CUBRID_LOG_SUCCESS;
-
-cubrid_log_error:
-
-  return err_code;
 }
 
 /*

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -956,6 +956,21 @@ EXPORTS
   mht_compare_strings_are_equal
   mht_rem
 ;
+; cubrid_log.h
+;
+  cubrid_log_set_connection_timeout
+  cubrid_log_set_extraction_timeout
+  cubrid_log_set_tracelog
+  cubrid_log_set_max_log_item
+  cubrid_log_set_all_in_cond
+  cubrid_log_set_extraction_table
+  cubrid_log_set_extraction_user
+  cubrid_log_connect_server
+  cubrid_log_find_lsa
+  cubrid_log_extract
+  cubrid_log_clear_log_item
+  cubrid_log_finalize
+;
 ; other
 ;
   setobj_type


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24078

API link error is caused by not adding cubrid_log APIs to the cubridcs.def
So, list of cubrid log apis is added to the file.
