### PR TITLE
[CBRD-24123] Provides hidden system parameter to set the first log page id for QA or testing purposes.

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -697,6 +697,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_CDC_LOGGING_DEBUG "cdc_logging_debug"
 
 #define PRM_NAME_RECOVERY_PROGRESS_LOGGING_INTERVAL "recovery_progress_logging_interval"
+#define PRM_NAME_FIRST_LOG_PAGEID "first_log_pageid"
 
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
@@ -2369,6 +2370,12 @@ static int prm_recovery_progress_logging_interval_default = 0;
 static int prm_recovery_progress_logging_interval_lower = 0;
 static int prm_recovery_progress_logging_interval_upper = 3600;
 static unsigned int prm_recovery_progress_logging_interval_flag = 0;
+
+UINT64 PRM_FIRST_LOG_PAGEID = 0LL;
+static UINT64 prm_first_log_pageid_default = 0LL;
+static UINT64 prm_first_log_pageid_lower = 0LL;
+static UINT64 prm_first_log_pageid_upper = LOGPAGEID_MAX;
+static unsigned int prm_first_log_pageid_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -6107,6 +6114,18 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) &PRM_RECOVERY_PROGRESS_LOGGING_INTERVAL,
    (void *) &prm_recovery_progress_logging_interval_upper,
    (void *) &prm_recovery_progress_logging_interval_lower,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_FIRST_LOG_PAGEID,	/* Except for QA or TEST purposes, never use it. */
+   PRM_NAME_FIRST_LOG_PAGEID,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_BIGINT,
+   &prm_first_log_pageid_flag,
+   (void *) &prm_first_log_pageid_default,
+   (void *) &PRM_FIRST_LOG_PAGEID,
+   (void *) &prm_first_log_pageid_upper,
+   (void *) &prm_first_log_pageid_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -456,8 +456,9 @@ enum param_id
   PRM_ID_SUPPLEMENTAL_LOG,
   PRM_ID_CDC_LOGGING_DEBUG,
   PRM_ID_RECOVERY_PROGRESS_LOGGING_INTERVAL,
+  PRM_ID_FIRST_LOG_PAGEID,	/* Except for QA or TEST purposes, never use it. */
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_RECOVERY_PROGRESS_LOGGING_INTERVAL
+  PRM_LAST_ID = PRM_ID_FIRST_LOG_PAGEID
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1343,7 +1343,11 @@ logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const cha
   loghdr->avg_nlocks = LOG_ESTIMATE_NOBJ_LOCKS;
   loghdr->npages = npages - 1;	/* Hdr pg is stolen */
   loghdr->db_charset = lang_charset ();
+#if !defined(NDEBUG)
   loghdr->fpageid = (LOG_PAGEID) prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID);	/* loghdr->fpageid should always be 0 except for QA or TEST purposes. */
+#else
+  loghdr->fpageid = 0;
+#endif
   loghdr->append_lsa.pageid = loghdr->fpageid;
   loghdr->append_lsa.offset = 0;
   LSA_COPY (&loghdr->chkpt_lsa, &loghdr->append_lsa);
@@ -2482,15 +2486,8 @@ logpb_fetch_start_append_page (THREAD_ENTRY * thread_p)
 
   logpb_log ("started logpb_fetch_start_append_page\n");
 
-  if (prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID) != 0
-      && (LOG_PAGEID) prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID) == log_Gl.hdr.append_lsa.pageid
-      && log_Gl.hdr.append_lsa.offset == 0)
-    {
-      flag = NEW_PAGE;
-    }
-
   /* detect empty log (page and offset of zero) */
-  if ((log_Gl.hdr.append_lsa.pageid == 0) && (log_Gl.hdr.append_lsa.offset == 0))
+  if ((log_Gl.hdr.append_lsa.pageid == log_Gl.hdr.fpageid) && (log_Gl.hdr.append_lsa.offset == 0))
     {
       flag = NEW_PAGE;
     }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1343,7 +1343,14 @@ logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const cha
   loghdr->avg_nlocks = LOG_ESTIMATE_NOBJ_LOCKS;
   loghdr->npages = npages - 1;	/* Hdr pg is stolen */
   loghdr->db_charset = lang_charset ();
-  loghdr->fpageid = 0;
+  if (prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID) != 0)
+    {
+      loghdr->fpageid = (LOG_PAGEID) prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID);
+    }
+  else
+    {
+      loghdr->fpageid = 0;
+    }
   loghdr->append_lsa.pageid = loghdr->fpageid;
   loghdr->append_lsa.offset = 0;
   LSA_COPY (&loghdr->chkpt_lsa, &loghdr->append_lsa);
@@ -2481,6 +2488,13 @@ logpb_fetch_start_append_page (THREAD_ENTRY * thread_p)
   assert (LOG_CS_OWN_WRITE_MODE (thread_p));
 
   logpb_log ("started logpb_fetch_start_append_page\n");
+
+  if (prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID) != 0
+      && (LOG_PAGEID) prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID) == log_Gl.hdr.append_lsa.pageid
+      && log_Gl.hdr.append_lsa.offset == 0)
+    {
+      flag = NEW_PAGE;
+    }
 
   /* detect empty log (page and offset of zero) */
   if ((log_Gl.hdr.append_lsa.pageid == 0) && (log_Gl.hdr.append_lsa.offset == 0))

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -2487,7 +2487,12 @@ logpb_fetch_start_append_page (THREAD_ENTRY * thread_p)
   logpb_log ("started logpb_fetch_start_append_page\n");
 
   /* detect empty log (page and offset of zero) */
-  if ((log_Gl.hdr.append_lsa.pageid == log_Gl.hdr.fpageid) && (log_Gl.hdr.append_lsa.offset == 0))
+#if !defined(NDEBUG)
+  if ((log_Gl.hdr.append_lsa.pageid == (LOG_PAGEID) prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID))
+      && (log_Gl.hdr.append_lsa.offset == 0))
+#else
+  if ((log_Gl.hdr.append_lsa.pageid == 0) && (log_Gl.hdr.append_lsa.offset == 0))
+#endif
     {
       flag = NEW_PAGE;
     }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1343,14 +1343,7 @@ logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const cha
   loghdr->avg_nlocks = LOG_ESTIMATE_NOBJ_LOCKS;
   loghdr->npages = npages - 1;	/* Hdr pg is stolen */
   loghdr->db_charset = lang_charset ();
-  if (prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID) != 0)
-    {
-      loghdr->fpageid = (LOG_PAGEID) prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID);
-    }
-  else
-    {
-      loghdr->fpageid = 0;
-    }
+  loghdr->fpageid = (LOG_PAGEID) prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID);	/* loghdr->fpageid should always be 0 except for QA or TEST purposes. */
   loghdr->append_lsa.pageid = loghdr->fpageid;
   loghdr->append_lsa.offset = 0;
   LSA_COPY (&loghdr->chkpt_lsa, &loghdr->append_lsa);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24123

### Purpose
- The CBRD-24123 issue fixed a problem that occurred when the log_pageid exceeds INT_MAX.
- To verify this, more than INT_MAX log pages must be created, but this is a very inefficient method.
- Therefore, a hidden system parameter that can designate the first log page id when DB is created is provided so that the test can be performed smoothly.
- If you have a better way or idea than this, please let me know.

### Implementation
- Provides hidden system parameter "first_log_pageid".
- Bypassing the assert part that occurs when createdb and server are started. 

### Remarks
- Check the "First_active_log_page" with the show log header command.

```
csql> ;line on
csql> show log header;

=== <Result of SELECT Command in Line 1> ===

...
        First_active_log_page          : 2147483649
...

```
