### PR TITLE
[CBRD-24131] Fix nonexpected assignment on assert statement in debug build

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15992,7 +15992,7 @@ do_drop_session_variables (PARSER_CONTEXT * parser, PT_NODE * statement)
   PT_NODE *variables = NULL;
 
   assert (statement != NULL);
-  assert (statement->node_type = PT_DROP_SESSION_VARIABLES);
+  assert (statement->node_type == PT_DROP_SESSION_VARIABLES);
 
   count = 0;
   /* count assignments */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24131

The assignment expression of the same value on assert statement is not that
we expected although currently it doesn't change the behavior of the engine.

Caller function, do_execute_statement already knows that node_type would be
PT_DROP_SESSION_VARIABLES before callee function, do_drop_session_variables.