### PR TITLE
[CBRD-24123] Provides hidden system parameter to set the first log page id for QA or testing purposes. (#3236)

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -695,6 +695,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_SUPPLEMENTAL_LOG "supplemental_log"
 #define PRM_NAME_CDC_LOGGING_DEBUG "cdc_logging_debug"
 
+#define PRM_NAME_FIRST_LOG_PAGEID "first_log_pageid"
+
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
 #define PRM_VALUE_MIN "MIN"
@@ -2356,6 +2358,12 @@ static unsigned int prm_supplemental_log_flag = 0;
 bool PRM_CDC_LOGGING_DEBUG = false;
 static bool prm_cdc_logging_debug_default = false;
 static unsigned int prm_cdc_logging_debug_flag = 0;
+
+UINT64 PRM_FIRST_LOG_PAGEID = 0LL;
+static UINT64 prm_first_log_pageid_default = 0LL;
+static UINT64 prm_first_log_pageid_lower = 0LL;
+static UINT64 prm_first_log_pageid_upper = LOGPAGEID_MAX;
+static unsigned int prm_first_log_pageid_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -6072,7 +6080,19 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
-   (DUP_PRM_FUNC) NULL}
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_FIRST_LOG_PAGEID,	/* Except for QA or TEST purposes, never use it. */
+   PRM_NAME_FIRST_LOG_PAGEID,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_BIGINT,
+   &prm_first_log_pageid_flag,
+   (void *) &prm_first_log_pageid_default,
+   (void *) &PRM_FIRST_LOG_PAGEID,
+   (void *) &prm_first_log_pageid_upper,
+   (void *) &prm_first_log_pageid_lower,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
 };
 
 #define NUM_PRM ((int)(sizeof(prm_Def)/sizeof(prm_Def[0])))

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -6092,7 +6092,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) &prm_first_log_pageid_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
-   (DUP_PRM_FUNC) NULL},
+   (DUP_PRM_FUNC) NULL}
 };
 
 #define NUM_PRM ((int)(sizeof(prm_Def)/sizeof(prm_Def[0])))

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -454,8 +454,9 @@ enum param_id
   PRM_ID_DDL_AUDIT_LOG_SIZE,
   PRM_ID_SUPPLEMENTAL_LOG,
   PRM_ID_CDC_LOGGING_DEBUG,
+  PRM_ID_FIRST_LOG_PAGEID,	/* Except for QA or TEST purposes, never use it. */
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_CDC_LOGGING_DEBUG
+  PRM_LAST_ID = PRM_ID_FIRST_LOG_PAGEID
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1346,7 +1346,11 @@ logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const cha
   loghdr->avg_nlocks = LOG_ESTIMATE_NOBJ_LOCKS;
   loghdr->npages = npages - 1;	/* Hdr pg is stolen */
   loghdr->db_charset = lang_charset ();
+#if !defined(NDEBUG)
+  loghdr->fpageid = (LOG_PAGEID) prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID);	/* loghdr->fpageid should always be 0 except for QA or TEST purposes. */
+#else
   loghdr->fpageid = 0;
+#endif
   loghdr->append_lsa.pageid = loghdr->fpageid;
   loghdr->append_lsa.offset = 0;
   LSA_COPY (&loghdr->chkpt_lsa, &loghdr->append_lsa);
@@ -2486,7 +2490,12 @@ logpb_fetch_start_append_page (THREAD_ENTRY * thread_p)
   logpb_log ("started logpb_fetch_start_append_page\n");
 
   /* detect empty log (page and offset of zero) */
+#if !defined(NDEBUG)
+  if ((log_Gl.hdr.append_lsa.pageid == (LOG_PAGEID) prm_get_bigint_value (PRM_ID_FIRST_LOG_PAGEID))
+      && (log_Gl.hdr.append_lsa.offset == 0))
+#else
   if ((log_Gl.hdr.append_lsa.pageid == 0) && (log_Gl.hdr.append_lsa.offset == 0))
+#endif
     {
       flag = NEW_PAGE;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24123

backport #3236