### PR TITLE
[CBRD-24136] issue grant statement only when the grantee and the owne…

### DIFF
--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -7597,7 +7597,11 @@ class_grant_loop (print_output & output_ctx, CLASS_AUTH * auth)
 		   */
 		  if ((user->available_auth & authbits) == authbits)
 		    {
-		      issue_grant_statement (output_ctx, auth, grant, authbits);
+		      if (!ws_is_same_object(auth->users->obj, grant->user->obj))
+		        {
+		          issue_grant_statement (output_ctx, auth, grant, authbits);
+		        }
+
 		      /* turn on grant bits in the granted user */
 		      grant->user->available_auth |= authbits;
 		      /* turn off the pending grant bits in granting user */

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -7597,10 +7597,10 @@ class_grant_loop (print_output & output_ctx, CLASS_AUTH * auth)
 		   */
 		  if ((user->available_auth & authbits) == authbits)
 		    {
-		      if (!ws_is_same_object(auth->users->obj, grant->user->obj))
-		        {
-		          issue_grant_statement (output_ctx, auth, grant, authbits);
-		        }
+		      if (!ws_is_same_object (auth->users->obj, grant->user->obj))
+			{
+			  issue_grant_statement (output_ctx, auth, grant, authbits);
+			}
 
 		      /* turn on grant bits in the granted user */
 		      grant->user->available_auth |= authbits;


### PR DESCRIPTION
…r are different

http://jira.cubrid.org/browse/CBRD-24136

Purpose
* Issue GRANT statement only when the grantee and the owner are different (it is not required to because it already has permission to do that)

Implementation
N/A

Remarks
Implementation is done by the guideline of @mhoh3963, thanks for comments.