### PR TITLE
[CBRD-24130] Exclude view related STMTs in object file of unloaddb

### DIFF
--- a/src/executables/unload_object.c
+++ b/src/executables/unload_object.c
@@ -594,7 +594,8 @@ extract_objects (const char *exec_name, const char *output_dirname, const char *
 #endif /* CUBRID_DEBUG */
   for (i = 0; i < class_table->num; i++)
     {
-      if (WS_IS_DELETED (class_table->mops[i]) || class_table->mops[i] == sm_Root_class_mop)
+      if (WS_IS_DELETED (class_table->mops[i]) || class_table->mops[i] == sm_Root_class_mop
+	  || db_is_vclass (class_table->mops[i]))
 	{
 	  continue;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24130

Purpose
* On execution of unloaddb including view, it is not necessary to include things related with VIEW, only view definition in schama file is required (remove unnecessary statement in unloaddb objects file)

Implementation
N/A

Remarks
N/A