### PR TITLE
[CBRD-23842] Fix coredump due to not handling NULL exception in cubrid_log API (#3256)

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1418,7 +1418,15 @@ cubrid_log_make_dml (char **data_info, DML * dml)
 	    case 7:
 	      dml->cond_column_data[i] = ptr;
 	      ptr = or_unpack_string_nocopy (ptr, &dml->cond_column_data[i]);
-	      dml->cond_column_data_len[i] = (int) strlen (dml->cond_column_data[i]);
+	      if (dml->cond_column_data[i] == NULL)
+		{
+		  dml->cond_column_data_len[i] = 0;
+		}
+	      else
+		{
+		  dml->cond_column_data_len[i] = (int) strlen (dml->cond_column_data[i]);
+		}
+
 	      break;
 
 	    case 8:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

Coredump is caused by strlen (cond_column_data) if cond_column_data is returned from the server as a NULL value.

backport issue for #3256  
