### PR TITLE
[LETS-305] Check page desynchronization in heap_prepare_get_context

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7468,7 +7468,6 @@ try_again:
   /* Output record type. */
   context->record_type = slot_p->record_type;
 
-#if defined (SERVER_MODE)
   if (context->record_type == REC_BIGONE || context->record_type == REC_RELOCATION)
     {
       ret = pgbuf_check_page_ahead_of_replication (thread_p, context->home_page_watcher.pgptr);
@@ -7478,7 +7477,6 @@ try_again:
 	  goto error;
 	}
     }
-#endif
 
   if (context->fwd_page_watcher.pgptr != NULL && slot_p->record_type != REC_RELOCATION
       && slot_p->record_type != REC_BIGONE)
@@ -7526,14 +7524,12 @@ try_again:
 
 	      goto error;
 	    }
-#if defined (SERVER_MODE)
 	  ret = pgbuf_check_page_ahead_of_replication (thread_p, context->fwd_page_watcher.pgptr);
 
 	  if (ret != NO_ERROR)
 	    {
 	      goto error;
 	    }
-#endif
 	  return S_SUCCESS;
 	}
       else if (ret == ER_PB_BAD_PAGEID)
@@ -7575,14 +7571,12 @@ try_again:
 	      assert (false);
 	      goto error;
 	    }
-#if defined (SERVER_MODE)
 	  ret = pgbuf_check_page_ahead_of_replication (thread_p, context->fwd_page_watcher.pgptr);
 
 	  if (ret != NO_ERROR)
 	    {
 	      goto error;
 	    }
-#endif
 	  return S_SUCCESS;
 	}
       else if (ret == ER_PB_BAD_PAGEID)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7541,18 +7541,10 @@ try_again:
 	  VPID *vpid = pgbuf_get_vpid_ptr (context->fwd_page_watcher.pgptr);
 	  if (vpid == NULL)
 	    {
+	      ret = ER_PB_BAD_PAGEID;
 	      goto error;
 	    }
-
-	  PAGE_PTR fixed_page =
-	    pgbuf_fix (thread_p, vpid, OLD_PAGE_DEALLOCATED, context->latch_mode, PGBUF_UNCONDITIONAL_LATCH);
-	  if (fixed_page == NULL)
-	    {
-	      goto error;
-	    }
-
-	  ret = ER_PAGE_AHEAD_OF_REPLICATION;
-	  goto error;
+	  ret = pgbuf_check_for_deallocated_page_or_desyncronization (thread_p, context->latch_mode, *vpid);
 	}
 
       goto error;
@@ -7598,18 +7590,10 @@ try_again:
 	  VPID *vpid = pgbuf_get_vpid_ptr (context->fwd_page_watcher.pgptr);
 	  if (vpid == NULL)
 	    {
+	      ret = ER_PB_BAD_PAGEID;
 	      goto error;
 	    }
-
-	  PAGE_PTR fixed_page =
-	    pgbuf_fix (thread_p, vpid, OLD_PAGE_DEALLOCATED, context->latch_mode, PGBUF_UNCONDITIONAL_LATCH);
-	  if (fixed_page == NULL)
-	    {
-	      goto error;
-	    }
-
-	  ret = ER_PAGE_AHEAD_OF_REPLICATION;
-	  goto error;
+	  ret = pgbuf_check_for_deallocated_page_or_desyncronization (thread_p, context->latch_mode, *vpid);
 	}
 
       goto error;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7468,6 +7468,18 @@ try_again:
   /* Output record type. */
   context->record_type = slot_p->record_type;
 
+#if defined (SERVER_MODE)
+  if (context->record_type == REC_BIGONE || context->record_type == REC_RELOCATION)
+    {
+      ret = pgbuf_check_page_ahead_of_replication (thread_p, context->home_page_watcher.pgptr);
+
+      if (ret != NO_ERROR)
+	{
+	  goto error;
+	}
+    }
+#endif
+
   if (context->fwd_page_watcher.pgptr != NULL && slot_p->record_type != REC_RELOCATION
       && slot_p->record_type != REC_BIGONE)
     {
@@ -7514,7 +7526,33 @@ try_again:
 
 	      goto error;
 	    }
+#if defined (SERVER_MODE)
+	  ret = pgbuf_check_page_ahead_of_replication (thread_p, context->fwd_page_watcher.pgptr);
+
+	  if (ret != NO_ERROR)
+	    {
+	      goto error;
+	    }
+#endif
 	  return S_SUCCESS;
+	}
+      else if (ret == ER_PB_BAD_PAGEID)
+	{
+	  VPID *vpid = pgbuf_get_vpid_ptr (context->fwd_page_watcher.pgptr);
+	  if (vpid == NULL)
+	    {
+	      goto error;
+	    }
+
+	  PAGE_PTR fixed_page =
+	    pgbuf_fix (thread_p, vpid, OLD_PAGE_DEALLOCATED, context->latch_mode, PGBUF_UNCONDITIONAL_LATCH);
+	  if (fixed_page == NULL)
+	    {
+	      goto error;
+	    }
+
+	  ret = ER_PAGE_AHEAD_OF_REPLICATION;
+	  goto error;
 	}
 
       goto error;
@@ -7545,7 +7583,33 @@ try_again:
 	      assert (false);
 	      goto error;
 	    }
+#if defined (SERVER_MODE)
+	  ret = pgbuf_check_page_ahead_of_replication (thread_p, context->fwd_page_watcher.pgptr);
+
+	  if (ret != NO_ERROR)
+	    {
+	      goto error;
+	    }
+#endif
 	  return S_SUCCESS;
+	}
+      else if (ret == ER_PB_BAD_PAGEID)
+	{
+	  VPID *vpid = pgbuf_get_vpid_ptr (context->fwd_page_watcher.pgptr);
+	  if (vpid == NULL)
+	    {
+	      goto error;
+	    }
+
+	  PAGE_PTR fixed_page =
+	    pgbuf_fix (thread_p, vpid, OLD_PAGE_DEALLOCATED, context->latch_mode, PGBUF_UNCONDITIONAL_LATCH);
+	  if (fixed_page == NULL)
+	    {
+	      goto error;
+	    }
+
+	  ret = ER_PAGE_AHEAD_OF_REPLICATION;
+	  goto error;
 	}
 
       goto error;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7471,7 +7471,6 @@ try_again:
   if (context->record_type == REC_BIGONE || context->record_type == REC_RELOCATION)
     {
       ret = pgbuf_check_page_ahead_of_replication (thread_p, context->home_page_watcher.pgptr);
-
       if (ret != NO_ERROR)
 	{
 	  goto error;
@@ -7524,8 +7523,8 @@ try_again:
 
 	      goto error;
 	    }
-	  ret = pgbuf_check_page_ahead_of_replication (thread_p, context->fwd_page_watcher.pgptr);
 
+	  ret = pgbuf_check_page_ahead_of_replication (thread_p, context->fwd_page_watcher.pgptr);
 	  if (ret != NO_ERROR)
 	    {
 	      goto error;
@@ -7571,8 +7570,8 @@ try_again:
 	      assert (false);
 	      goto error;
 	    }
-	  ret = pgbuf_check_page_ahead_of_replication (thread_p, context->fwd_page_watcher.pgptr);
 
+	  ret = pgbuf_check_page_ahead_of_replication (thread_p, context->fwd_page_watcher.pgptr);
 	  if (ret != NO_ERROR)
 	    {
 	      goto error;

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -464,10 +464,8 @@ extern void pgbuf_highest_evicted_lsa_init ();
 extern void pgbuf_daemons_destroy ();
 #endif /* SERVER_MODE */
 
-#if defined (SERVER_MODE)
 // Check if page is ahead of replication; only relevant on passive transaction server, don't call elsewhere.
 extern int pgbuf_check_page_ahead_of_replication (THREAD_ENTRY * thread_p, PAGE_PTR page);
-#endif
 extern int pgbuf_check_for_deallocated_page_or_desyncronization (THREAD_ENTRY * thread_p, PGBUF_LATCH_MODE latch_mode,
 								 const VPID & vpid);
 // Fix an old page with read latch; and if this is a PTS, check if it is ahead of replication.

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -468,6 +468,8 @@ extern void pgbuf_daemons_destroy ();
 // Check if page is ahead of replication; only relevant on passive transaction server, don't call elsewhere.
 extern int pgbuf_check_page_ahead_of_replication (THREAD_ENTRY * thread_p, PAGE_PTR page);
 #endif
+extern int pgbuf_check_for_deallocated_page_or_desyncronization (THREAD_ENTRY * thread_p, PGBUF_LATCH_MODE latch_mode,
+								 const VPID & vpid);
 // Fix an old page with read latch; and if this is a PTS, check if it is ahead of replication.
 extern PAGE_PTR pgbuf_fix_read_old_and_check_repl_desync (THREAD_ENTRY * thread_p, const VPID & vpid,
 							  PGBUF_LATCH_CONDITION cond);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-305

Added steps to verify page desynchronization inside `heap_prepare_get_context`.
The checks are as follows:

1. After fixing home page and reading the object slot, if the record type is `REC_RELOCATION` or `REC_BIGONE`, check home page LSA. If it is higher than replication LSA, register the error and return.
2. After fixing forward page, in both `REC_RELOCATION` and `REC_BIGONE` cases, check its LSA. If is ahead of replication LSA, register the error and return.
3. Forward pages may also be deallocated. If fixing failed with `ER_PB_BAD_PAGEID`, the forward page must be fixed again as `OLD_PAGE_DEALLOCATED` and its LSA checked; if it higher than replication LSA, register the proper error and return. If it is not, then `ER_PB_BAD_PAGEID` remains.
