### PR TITLE
[CBRD-24105] Addition '-z' and '--no-check' options with 'backupdb' u…

### DIFF
--- a/contrib/scripts/ha/ha_make_slavedb.sh
+++ b/contrib/scripts/ha/ha_make_slavedb.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+#  Copyright 2008 Search Solution Corporation
+#  Copyright 2016 CUBRID Corporation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#
 
 CURR_DIR=$(dirname $0)
 WORK_DIR=$(pwd)

--- a/contrib/scripts/ha/ha_make_slavedb.sh
+++ b/contrib/scripts/ha/ha_make_slavedb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  Copyright 2008 Search Solution Corporation
+#  
 #  Copyright 2016 CUBRID Corporation
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/scripts/ha/ha_make_slavedb.sh
+++ b/contrib/scripts/ha/ha_make_slavedb.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 #
-#  
+#  Copyright 2008 Search Solution Corporation
 #  Copyright 2016 CUBRID Corporation
-#
+# 
 #   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License
+#   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
-#
+# 
 #       http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-#
+# 
 
 CURR_DIR=$(dirname $0)
 WORK_DIR=$(pwd)

--- a/contrib/scripts/ha/ha_make_slavedb.sh
+++ b/contrib/scripts/ha/ha_make_slavedb.sh
@@ -16,7 +16,7 @@ repl_log_home=$CUBRID_DATABASES
 db_name=
 
 backup_dest_path=
-backup_option=
+backup_option="-z --no-check"
 restore_option=
 scp_option="-l 131072"		# default - limit : 16M*1024*8=131072
 ssh_port=22

--- a/contrib/scripts/ha/ha_make_slavedb.sh
+++ b/contrib/scripts/ha/ha_make_slavedb.sh
@@ -15,7 +15,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-#
 
 CURR_DIR=$(dirname $0)
 WORK_DIR=$(pwd)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24105

**Purpose**
Addition '-z' and '--no-check' options with 'backupdb' utility in the 'ha_make_slavedb.sh'. 

**Implementation**
in `$ <user>/cubrid/contrib/scripts/ha`
"ha_make_slavedb.sh" shell script is modified;
at `# optional`  category, `backup_option="-z --no-check" is written`.

So this line is affected in the "ha_make_slavedb.sh" 
 `ssh_cubrid $target_host "cubrid backupdb $backup_option -C -D $backup_dest_path -o $backupdb_output $db_name@localhost"`



**Remarks**
N/A
