### PR TITLE
[LETS-306] Handle pages desynchronization errors in heap_get_visible_version_internal

### DIFF
--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -164,3 +164,8 @@ void passive_tran_server::finish_replication_during_shutdown (cubthread::entry &
   m_replicator->wait_replication_finish_during_shutdown ();
   m_replicator.reset (nullptr);
 }
+
+void passive_tran_server::wait_replication_pasts_target_lsa (LOG_LSA lsa)
+{
+  m_replicator->wait_past_target_lsa (lsa);
+}

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -38,6 +38,7 @@ class passive_tran_server : public tran_server
     /* read replicator's current progress */
     log_lsa get_replicator_lsa () const;
     void finish_replication_during_shutdown (cubthread::entry &thread_entry);
+    void wait_replication_pasts_target_lsa (LOG_LSA lsa);
 
   private:
     bool uses_remote_storage () const final override;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24983,7 +24983,6 @@ heap_get_visible_version_with_repl_desync (THREAD_ENTRY * thread_p, HEAP_GET_CON
   do
     {
       ret = heap_get_visible_version_with_repl_desync (thread_p, context, is_heap_scan);
-
       if (ret != S_ERROR || er_errid () != ER_PAGE_AHEAD_OF_REPLICATION)
 	{
 	  // We'll continue here only if we have a page desynchronization error. Break the loop in any other cases.

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24981,7 +24981,7 @@ heap_get_visible_version_with_repl_desync (THREAD_ENTRY * thread_p, HEAP_GET_CON
 
       if (ret != S_SUCCESS)
 	{
-	  if (er_errid () == ER_PB_BAD_PAGEID)
+	  if (er_errid () == ER_PAGE_AHEAD_OF_REPLICATION)
 	    {
 	      if (context->home_page_watcher.pgptr)
 		{

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24991,7 +24991,6 @@ heap_get_visible_version_with_repl_desync (THREAD_ENTRY * thread_p, HEAP_GET_CON
 	  pgbuf_ordered_unfix (thread_p, &context->fwd_page_watcher);
 	}
 
-      assert (is_passive_transaction_server ());
       passive_tran_server *const pts_ptr = get_passive_tran_server_ptr ();
       LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
       assert (tdes->page_desync_lsa.is_null ());

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -59,7 +59,9 @@
 #include "string_opfunc.h"
 #include "xasl.h"
 #include "xasl_unpack_info.hpp"
+#include "passive_tran_server.hpp"
 #include "scope_exit.hpp"
+#include "server_type.hpp"
 #include "stream_to_xasl.h"
 #include "query_opfunc.h"
 #include "set_object.h"
@@ -24909,7 +24911,7 @@ heap_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_
 
   heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn);
 
-  scan = heap_get_visible_version_internal (thread_p, &context, false);
+  scan = heap_get_visible_version_with_repl_desync (thread_p, &context, false);
 
   heap_clean_get_context (thread_p, &context);
 
@@ -24946,11 +24948,70 @@ heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * c
 
   heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn);
 
-  scan = heap_get_visible_version_internal (thread_p, &context, true);
+  scan = heap_get_visible_version_with_repl_desync (thread_p, &context, true);
 
   heap_clean_get_context (thread_p, &context);
 
   return scan;
+}
+
+/*
+ * heap_get_visible_version_with_repl_desync () - Retry to retrieve the visible version of an object
+ * according to snapshot util bad page id error does not show
+ *
+ *  return SCAN_CODE.
+ *  thread_p (in): Thread entry.
+ *  context (in): Heap get context.
+ *  is_heap_scan (in): required for heap_prepare_get_context
+ */
+SCAN_CODE
+heap_get_visible_version_with_repl_desync (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, bool is_heap_scan)
+{
+#if defined (SERVER_MODE)
+
+  if (is_active_transaction_server ())
+    {
+      return heap_get_visible_version_with_repl_desync (thread_p, context, is_heap_scan);
+    }
+
+  SCAN_CODE ret;
+  do
+    {
+      ret = heap_get_visible_version_with_repl_desync (thread_p, context, is_heap_scan);
+
+      if (ret != S_SUCCESS)
+	{
+	  if (er_errid () == ER_PB_BAD_PAGEID)
+	    {
+	      if (context->home_page_watcher.pgptr)
+		{
+		  /* Unfix home page. */
+		  pgbuf_ordered_unfix (thread_p, &context->home_page_watcher);
+		}
+
+	      if (context->fwd_page_watcher.pgptr != NULL)
+		{
+		  /* Unfix forward page. */
+		  pgbuf_ordered_unfix (thread_p, &context->fwd_page_watcher);
+		}
+
+	      assert (is_passive_transaction_server ());
+	      passive_tran_server *const pts_ptr = get_passive_tran_server_ptr ();
+	      LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
+	      assert (tdes->page_desync_lsa.is_null ());
+	      pts_ptr->wait_replication_pasts_target_lsa (tdes->page_desync_lsa);
+	    }
+	  else
+	    {
+	      return ret;
+	    }
+	}
+    }
+  while (ret != S_SUCCESS);
+  return ret;
+#else
+  return heap_get_visible_version_with_repl_desync (thread_p, context, is_heap_scan);
+#endif
 }
 
 /*

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -676,6 +676,8 @@ extern int heap_prepare_object_page (THREAD_ENTRY * thread_p, const OID * oid, P
 extern SCAN_CODE heap_prepare_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, bool is_heap_scan,
 					   NON_EXISTENT_HANDLING non_ex_handling_type);
 extern SCAN_CODE heap_get_record_data_when_all_ready (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context);
+extern SCAN_CODE heap_get_visible_version_with_repl_desync (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context,
+							    bool is_heap_scan);
 extern SCAN_CODE heap_get_visible_version_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context,
 						    bool is_heap_scan);
 extern SCAN_CODE heap_get_class_record (THREAD_ENTRY * thread_p, const OID * class_oid, RECDES * recdes_p,

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13286,7 +13286,7 @@ locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, R
   if (op_type == S_SELECT && lock_mode == NULL_LOCK)
     {
       /* No locking */
-      scan_code = heap_get_visible_version_internal (thread_p, &context, false);
+      scan_code = heap_get_visible_version_with_repl_desync (thread_p, &context, false);
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-306

Added a new `heap_get_visible_version_with_repl_desync` function to handle page desyncronization situations that occur inside `heap_get_visible_version_internal`.

The function is only active on passive transaction servers and will replace all calls of `heap_get_visible_version_internal`.

The function checks for the `ER_PAGE_AHEAD_OF_REPLICATION` error and unfixes the pages waits for replication and calls `heap_get_visible_version_internal` again until the error does not occur.
