### PR TITLE
[CBRD-24140] Change the javasp utility behavior

### DIFF
--- a/conf/cubrid.conf
+++ b/conf/cubrid.conf
@@ -25,7 +25,7 @@
 [service]
 
 # The list of processes to be started automatically by 'cubrid service start' command
-# Any combinations are available with server, broker, manager, heartbeat and javasp.
+# Any combinations are available with server, broker, manager, heartbeat.
 service=server,broker,manager
 
 # The list of database servers in all by 'cubrid service start' command.

--- a/conf/cubrid.conf
+++ b/conf/cubrid.conf
@@ -25,7 +25,7 @@
 [service]
 
 # The list of processes to be started automatically by 'cubrid service start' command
-# Any combinations are available with server, broker, manager, heartbeat.
+# Any combinations are available with server, broker, manager and heartbeat.
 service=server,broker,manager
 
 # The list of database servers in all by 'cubrid service start' command.

--- a/conf/cubrid.conf.large
+++ b/conf/cubrid.conf.large
@@ -8,7 +8,7 @@ COMMENT_THIS_LINE = TO_USE_THIS_CONFIGURATION
 [service]
 
 # The list of processes to be started automatically by 'cubrid service start' command
-# Any combinations are available with server, broker, manager, heartbeat and javasp.
+# Any combinations are available with server, broker, manager, heartbeat.
 service=server,broker,manager
 
 # The list of database servers in all by 'cubrid service start' command.

--- a/conf/cubrid.conf.large
+++ b/conf/cubrid.conf.large
@@ -8,7 +8,7 @@ COMMENT_THIS_LINE = TO_USE_THIS_CONFIGURATION
 [service]
 
 # The list of processes to be started automatically by 'cubrid service start' command
-# Any combinations are available with server, broker, manager, heartbeat.
+# Any combinations are available with server, broker, manager and heartbeat.
 service=server,broker,manager
 
 # The list of database servers in all by 'cubrid service start' command.

--- a/conf/cubrid.conf.small
+++ b/conf/cubrid.conf.small
@@ -8,7 +8,7 @@ COMMENT_THIS_LINE = TO_USE_THIS_CONFIGURATION
 [service]
 
 # The list of processes to be started automatically by 'cubrid service start' command
-# Any combinations are available with server, broker, manager, heartbeat and javasp.
+# Any combinations are available with server, broker, manager, heartbeat.
 service=server,broker,manager
 
 # The list of database servers in all by 'cubrid service start' command.

--- a/conf/cubrid.conf.small
+++ b/conf/cubrid.conf.small
@@ -8,7 +8,7 @@ COMMENT_THIS_LINE = TO_USE_THIS_CONFIGURATION
 [service]
 
 # The list of processes to be started automatically by 'cubrid service start' command
-# Any combinations are available with server, broker, manager, heartbeat.
+# Any combinations are available with server, broker, manager and heartbeat.
 service=server,broker,manager
 
 # The list of database servers in all by 'cubrid service start' command.

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -1592,6 +1592,12 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 		      status = ER_GENERIC_ERROR;
 		    }
 		  print_result (PRINT_SERVER_NAME, status, command_type);
+
+		  /* run javasp utility if server is started successfully */
+		  if (status == NO_ERROR && (is_javasp_running (token) != JAVASP_SERVER_RUNNING))
+		    {
+		      (void) process_javasp (command_type, 1, (const char **) &token, true);
+		    }
 		}
 	    }
 #endif
@@ -1613,11 +1619,6 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 	      if (token == NULL)
 		{
 		  break;
-		}
-
-	      if (is_javasp_running (token) != JAVASP_SERVER_RUNNING)
-		{
-		  (void) process_javasp (command_type, 1, (const char **) &token, false);
 		}
 
 	      print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_SERVER_NAME, PRINT_CMD_START, token);
@@ -1662,6 +1663,12 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 		      status = ER_GENERIC_ERROR;
 		    }
 		  print_result (PRINT_SERVER_NAME, status, command_type);
+
+		  /* run javasp server if DB server is started successfully */
+		  if (status == NO_ERROR && (is_javasp_running (token) != JAVASP_SERVER_RUNNING))
+		    {
+		      (void) process_javasp (command_type, 1, (const char **) &token, false);
+		    }
 		}
 	    }
 	}
@@ -1675,9 +1682,10 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 	      break;
 	    }
 
+	  /* try to stop javasp server first */
 	  if (is_javasp_running (token) == JAVASP_SERVER_RUNNING)
 	    {
-	      (void) process_javasp (command_type, 1, (const char **) &token, false);
+	      (void) process_javasp (command_type, 1, (const char **) &token, process_window_service);
 	    }
 
 	  print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_SERVER_NAME, PRINT_CMD_STOP, token);

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -1665,6 +1665,12 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 		{
 		  break;
 		}
+
+	      if (is_javasp_running (token) != JAVASP_SERVER_RUNNING)
+		{
+		  (void) process_javasp (command_type, 1, (const char **) &token, false);
+		}
+
 	      print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_SERVER_NAME, PRINT_CMD_START, token);
 
 #if !defined(WINDOWS)
@@ -1719,6 +1725,12 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 	    {
 	      break;
 	    }
+
+	  if (is_javasp_running (token) == JAVASP_SERVER_RUNNING)
+	    {
+	      (void) process_javasp (command_type, 1, (const char **) &token, false);
+	    }
+
 	  print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_SERVER_NAME, PRINT_CMD_STOP, token);
 
 	  if (is_server_running (CHECK_SERVER, token, 0))

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -1327,6 +1327,8 @@ process_service (int command_type, bool process_window_service)
 	{
 	  if (!are_all_services_stopped (0, process_window_service))
 	    {
+	      (void) process_javasp (command_type, 0, NULL, false, process_window_service);
+
 	      if (strcmp (get_property (SERVICE_START_SERVER), PROPERTY_ON) == 0
 		  && us_Property_map[SERVER_START_LIST].property_value != NULL
 		  && us_Property_map[SERVER_START_LIST].property_value[0] != '\0')
@@ -1650,20 +1652,6 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 		      status = ER_GENERIC_ERROR;
 		    }
 		  print_result (PRINT_SERVER_NAME, status, command_type);
-
-		  /* run javasp utility if server is started successfully */
-		  if (status == NO_ERROR)
-		    {
-		      if (is_javasp_running (token) != JAVASP_SERVER_RUNNING)
-			{
-			  (void) process_javasp (command_type, 1, (const char **) &token, false, true);
-			}
-		      else
-			{
-			  print_message (stdout, MSGCAT_UTIL_GENERIC_ALREADY_RUNNING_2S, PRINT_JAVASP_NAME, token);
-			  util_log_write_errid (MSGCAT_UTIL_GENERIC_ALREADY_RUNNING_2S, PRINT_JAVASP_NAME, token);
-			}
-		    }
 		}
 	    }
 #endif
@@ -1733,15 +1721,7 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 		  /* run javasp server if DB server is started successfully */
 		  if (status == NO_ERROR)
 		    {
-		      if (is_javasp_running (token) != JAVASP_SERVER_RUNNING)
-			{
-			  (void) process_javasp (command_type, 1, (const char **) &token, false, true);
-			}
-		      else
-			{
-			  print_message (stdout, MSGCAT_UTIL_GENERIC_ALREADY_RUNNING_2S, PRINT_JAVASP_NAME, token);
-			  util_log_write_errid (MSGCAT_UTIL_GENERIC_ALREADY_RUNNING_2S, PRINT_JAVASP_NAME, token);
-			}
+		      (void) process_javasp (command_type, 1, (const char **) &token, false, process_window_service);
 		    }
 		}
 	    }
@@ -2509,9 +2489,8 @@ process_javasp_start (const char *db_name, bool process_window_service)
 		}
 	    }
 	}
+      print_result (PRINT_JAVASP_NAME, status, START);
     }
-
-  print_result (PRINT_JAVASP_NAME, status, START);
   return status;
 }
 
@@ -2548,6 +2527,7 @@ process_javasp_stop (const char *db_name, bool process_window_service)
 	    }
 	  while (status != NO_ERROR && waited_secs < wait_timeout);
 	}
+      print_result (PRINT_JAVASP_NAME, status, STOP);
     }
   else
     {
@@ -2556,7 +2536,6 @@ process_javasp_stop (const char *db_name, bool process_window_service)
       util_log_write_errid (MSGCAT_UTIL_GENERIC_NOT_RUNNING_2S, PRINT_JAVASP_NAME, db_name);
     }
 
-  print_result (PRINT_JAVASP_NAME, status, STOP);
   return status;
 }
 

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -1424,8 +1424,8 @@ get_server_names (char **name_buffer)
   int offset = 0;
   /* *INDENT-OFF* */
   std::string delimiter = " ";
-  /* *INDENT-ON* */
   std::string result;
+  /* *INDENT-ON* */
   while (fgets (buf, 4096, input) != NULL)
     {
       /* *INDENT-OFF* */

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -1674,7 +1674,6 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 		{
 		  break;
 		}
-
 	      print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_SERVER_NAME, PRINT_CMD_START, token);
 
 #if !defined(WINDOWS)

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -2576,7 +2576,7 @@ static int
 process_javasp (int command_type, int argc, const char **argv, bool show_usage, bool process_window_service)
 {
   char *buf = NULL;
-  char *list = NULL, *save = NULL;
+  char *save = NULL;
   const char *delim = " ,:";
   int status = NO_ERROR;
   char *db_name = NULL;
@@ -2614,7 +2614,7 @@ process_javasp (int command_type, int argc, const char **argv, bool show_usage, 
       print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_2S, PRINT_JAVASP_NAME, PRINT_CMD_STATUS);
     }
 
-  for (list = buf; buf; list = NULL)
+  while (buf)
     {
       db_name = strtok_r (list, delim, &save);
       if (db_name == NULL)
@@ -2647,6 +2647,7 @@ exit:
     {
       free (buf);
     }
+
   return status;
 }
 

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -2598,7 +2598,7 @@ process_javasp (int command_type, int argc, const char **argv, bool show_usage, 
       strncpy (buf, argv[0], sizeof (buf) - 1);
     }
 
-  if (command_type != STATUS && strlen (buf) == 0)
+  if (command_type != STATUS && buf == NULL)
     {
       if (show_usage)
 	{
@@ -2614,7 +2614,7 @@ process_javasp (int command_type, int argc, const char **argv, bool show_usage, 
       print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_2S, PRINT_JAVASP_NAME, PRINT_CMD_STATUS);
     }
 
-  for (list = buf;; list = NULL)
+  for (list = buf; buf; list = NULL)
     {
       db_name = strtok_r (list, delim, &save);
       if (db_name == NULL)

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -2576,7 +2576,7 @@ static int
 process_javasp (int command_type, int argc, const char **argv, bool show_usage, bool process_window_service)
 {
   char *buf = NULL;
-  char *save = NULL;
+  char *list = NULL, *save = NULL;
   const char *delim = " ,:";
   int status = NO_ERROR;
   char *db_name = NULL;
@@ -2614,6 +2614,7 @@ process_javasp (int command_type, int argc, const char **argv, bool show_usage, 
       print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_2S, PRINT_JAVASP_NAME, PRINT_CMD_STATUS);
     }
 
+  list = buf;
   while (buf)
     {
       db_name = strtok_r (list, delim, &save);
@@ -2640,6 +2641,8 @@ process_javasp (int command_type, int argc, const char **argv, bool show_usage, 
 	  status = ER_GENERIC_ERROR;
 	  break;
 	}
+
+      list = NULL;
     }
 
 exit:

--- a/src/win_tools/cubridservice/cubridservice.cpp
+++ b/src/win_tools/cubridservice/cubridservice.cpp
@@ -66,8 +66,6 @@ BOOL g_isRunning = false;
 #define		SERVICE_CONTROL_SERVER_STOP	181
 #define		SERVICE_CONTROL_SERVICE_START	190
 #define		SERVICE_CONTROL_SERVICE_STOP	191
-#define		SERVICE_CONTROL_JAVASP_START	210
-#define		SERVICE_CONTROL_JAVASP_STOP		211
 
 #define		CUBRID_UTIL_CUBRID		"cubrid.exe"
 #define		CUBRID_UTIL_SERVICE		"service"
@@ -195,8 +193,6 @@ vHandler (DWORD opcode)
 
   if (opcode == SERVICE_CONTROL_SERVER_START ||
       opcode == SERVICE_CONTROL_SERVER_STOP ||
-      opcode == SERVICE_CONTROL_JAVASP_START ||
-      opcode == SERVICE_CONTROL_JAVASP_STOP ||
       opcode == SERVICE_CONTROL_BROKER_ON ||
       opcode == SERVICE_CONTROL_BROKER_OFF)
     {
@@ -326,22 +322,6 @@ vHandler (DWORD opcode)
 	args[5] = NULL;
       }
       break;
-    case SERVICE_CONTROL_JAVASP_START:
-      {
-	args[1] = CUBRID_UTIL_JAVASP;
-	args[2] = CUBRID_COMMAND_START;
-	args[4] = "--for-windows-service";
-	args[5] = NULL;
-      }
-      break;
-    case SERVICE_CONTROL_JAVASP_STOP:
-      {
-	args[1] = CUBRID_UTIL_JAVASP;
-	args[2] = CUBRID_COMMAND_STOP;
-	args[4] = "--for-windows-service";
-	args[5] = NULL;
-      }
-      break;
     default:
       vSetStatus (g_XSS);
       return;
@@ -351,8 +331,6 @@ vHandler (DWORD opcode)
 
   if (opcode == SERVICE_CONTROL_SERVER_START ||
       opcode == SERVICE_CONTROL_SERVER_STOP ||
-      opcode == SERVICE_CONTROL_JAVASP_START ||
-      opcode == SERVICE_CONTROL_JAVASP_STOP ||
       opcode == SERVICE_CONTROL_BROKER_ON ||
       opcode == SERVICE_CONTROL_BROKER_OFF)
     {

--- a/src/win_tools/cubridservice/cubridservice.cpp
+++ b/src/win_tools/cubridservice/cubridservice.cpp
@@ -66,6 +66,8 @@ BOOL g_isRunning = false;
 #define		SERVICE_CONTROL_SERVER_STOP	181
 #define		SERVICE_CONTROL_SERVICE_START	190
 #define		SERVICE_CONTROL_SERVICE_STOP	191
+#define		SERVICE_CONTROL_JAVASP_START	210
+#define		SERVICE_CONTROL_JAVASP_STOP		211
 
 #define		CUBRID_UTIL_CUBRID		"cubrid.exe"
 #define		CUBRID_UTIL_SERVICE		"service"
@@ -193,6 +195,8 @@ vHandler (DWORD opcode)
 
   if (opcode == SERVICE_CONTROL_SERVER_START ||
       opcode == SERVICE_CONTROL_SERVER_STOP ||
+      opcode == SERVICE_CONTROL_JAVASP_START ||
+      opcode == SERVICE_CONTROL_JAVASP_STOP ||
       opcode == SERVICE_CONTROL_BROKER_ON ||
       opcode == SERVICE_CONTROL_BROKER_OFF)
     {
@@ -322,6 +326,22 @@ vHandler (DWORD opcode)
 	args[5] = NULL;
       }
       break;
+    case SERVICE_CONTROL_JAVASP_START:
+      {
+	args[1] = CUBRID_UTIL_JAVASP;
+	args[2] = CUBRID_COMMAND_START;
+	args[4] = "--for-windows-service";
+	args[5] = NULL;
+      }
+      break;
+    case SERVICE_CONTROL_JAVASP_STOP:
+      {
+	args[1] = CUBRID_UTIL_JAVASP;
+	args[2] = CUBRID_COMMAND_STOP;
+	args[4] = "--for-windows-service";
+	args[5] = NULL;
+      }
+      break;
     default:
       vSetStatus (g_XSS);
       return;
@@ -331,6 +351,8 @@ vHandler (DWORD opcode)
 
   if (opcode == SERVICE_CONTROL_SERVER_START ||
       opcode == SERVICE_CONTROL_SERVER_STOP ||
+      opcode == SERVICE_CONTROL_JAVASP_START ||
+      opcode == SERVICE_CONTROL_JAVASP_STOP ||
       opcode == SERVICE_CONTROL_BROKER_ON ||
       opcode == SERVICE_CONTROL_BROKER_OFF)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24140

- implements get_server_names() which requests server names from master process
- get_server_names() is used for `cubrid service stop`, `cubrid service status`, and `cubrid javasp status` where db name is not specified.
- In `cubrid server start <db_name>` and `cubrid server stop <db_name>`, respectively, `cubrid javasp start <db_name>` and `cubrid javasp stop <db_name>` are executed together. In this case, the java_stored_procedure parameter has to be set to yes at startup.