### PR TITLE
[CBRD-24143] Allow multiple CREATE INDEX on filtered column.

### DIFF
--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4110,6 +4110,11 @@ classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAIN
 			  continue;
 			}
 
+		      if (!filter_predicate->pred_string || !cons->filter_predicate->pred_string)
+			{
+			  continue;
+			}
+
 		      if (strcmp (filter_predicate->pred_string, cons->filter_predicate->pred_string))
 			{
 			  continue;

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4062,7 +4062,7 @@ classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons, OID * root_
  */
 SM_CLASS_CONSTRAINT *
 classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAINT_TYPE new_cons, const char **att_names,
-				   const int *asc_desc)
+				   const int *asc_desc, const SM_PREDICATE_INFO * filter_predicate)
 {
   SM_CLASS_CONSTRAINT *cons;
   SM_ATTRIBUTE **attp;
@@ -4103,9 +4103,23 @@ classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAIN
 
 	      if (i == len)
 		{
-		  return cons;	/* match */
+		  if (filter_predicate)
+		    {
+		      if (!cons->filter_predicate)
+			{
+			  continue;
+			}
+
+		      if (strcmp (filter_predicate->pred_string, cons->filter_predicate->pred_string))
+			{
+			  continue;
+			}
+		    }
+
+		  return cons;
 		}
 	    }
+
 	}
     }
 
@@ -8046,7 +8060,7 @@ classobj_check_index_exist (SM_CLASS_CONSTRAINT * constraints, char **out_shared
       return error;
     }
 
-  existing_con = classobj_find_constraint_by_attrs (constraints, constraint_type, att_names, asc_desc);
+  existing_con = classobj_find_constraint_by_attrs (constraints, constraint_type, att_names, asc_desc, filter_index);
 #if defined (ENABLE_UNUSED_FUNCTION)	/* to disable TEXT */
   if (existing_con != NULL)
     {

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4110,12 +4110,7 @@ classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAIN
 			  continue;
 			}
 
-		      if (!cons->filter_predicate->pred_string)
-			{
-			  continue;
-			}
-
-		      if (!filter_predicate->pred_string)
+		      if (!filter_predicate->pred_string || !cons->filter_predicate->pred_string)
 			{
 			  continue;
 			}

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4110,7 +4110,12 @@ classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAIN
 			  continue;
 			}
 
-		      if (!filter_predicate->pred_string || !cons->filter_predicate->pred_string)
+		      if (!cons->filter_predicate->pred_string)
+			{
+			  continue;
+			}
+
+		      if (!filter_predicate->pred_string)
 			{
 			  continue;
 			}

--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -985,7 +985,8 @@ extern SM_CLASS_CONSTRAINT *classobj_find_class_index (SM_CLASS * class_, const 
 extern SM_CLASS_CONSTRAINT *classobj_find_constraint_by_name (SM_CLASS_CONSTRAINT * cons_list, const char *name);
 extern SM_CLASS_CONSTRAINT *classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list,
 							       DB_CONSTRAINT_TYPE new_cons, const char **att_names,
-							       const int *asc_desc);
+							       const int *asc_desc,
+							       const SM_PREDICATE_INFO * filter_predicate);
 extern TP_DOMAIN *classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons, OID * root_oid);
 extern void classobj_remove_class_constraint_node (SM_CLASS_CONSTRAINT ** constraints, SM_CLASS_CONSTRAINT * node);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24143

Currently, an error occurs when creating an index with a different filter predicate in the same column as follows:

```
create table foo (a int not null, b int not null, c int);
create index idx1 on foo(a, b) where c=1;
create index idx2 on foo(a, b) where c=2; <-- error occurred 
```
If the filter predicate is different, it should be done so that it can be created without error.