### PR TITLE
[CBRD-24148] Core dump occur when using hash list scan

### DIFF
--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -73,7 +73,7 @@ static DB_VALUE_COMPARE_RESULT qdata_hscan_key_compare (HASH_SCAN_KEY * ckey1, H
 typedef unsigned int FHS_HASH_KEY;
 #define FHS_KEY_SIZE (sizeof (FHS_HASH_KEY))
 #define FHS_ALIGNMENT ((char) FHS_KEY_SIZE)
-#define FHS_MAX_DUP_KEY 3	/* 10% of MAXNUM (PAGE 16K / RECORD 14 bytes) */
+#define FHS_MAX_DUP_KEY 100	/* 10% of MAXNUM (PAGE 16K / RECORD 14 bytes) */
 				/* TO_DO : adjust it properly using statistical information in optimizer */
 
 #define SET_VPID(dest_vpid, vol_id, page_id)  \

--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -1924,7 +1924,7 @@ fhs_binary_search_bucket (THREAD_ENTRY * thread_p, PAGE_PTR bucket_page_p, PGSLO
 	}
       else
 	{
-	  middle += (flag > 0) ? flag - 1 : 0; /* go to last slot using flag */
+	  middle += (flag > 0) ? flag - 1 : 0;	/* go to last slot using flag */
 	  low = middle + 1;
 	}
     }

--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -1924,6 +1924,11 @@ fhs_binary_search_bucket (THREAD_ENTRY * thread_p, PAGE_PTR bucket_page_p, PGSLO
 	}
       else
 	{
+	  if (flag > 0)
+	    {
+	      /* go to last slot using flag */
+	      middle = middle + flag - 1;
+	    }
 	  low = middle + 1;
 	}
     }

--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -73,7 +73,7 @@ static DB_VALUE_COMPARE_RESULT qdata_hscan_key_compare (HASH_SCAN_KEY * ckey1, H
 typedef unsigned int FHS_HASH_KEY;
 #define FHS_KEY_SIZE (sizeof (FHS_HASH_KEY))
 #define FHS_ALIGNMENT ((char) FHS_KEY_SIZE)
-#define FHS_MAX_DUP_KEY 100	/* 10% of MAXNUM (PAGE 16K / RECORD 14 bytes) */
+#define FHS_MAX_DUP_KEY 3	/* 10% of MAXNUM (PAGE 16K / RECORD 14 bytes) */
 				/* TO_DO : adjust it properly using statistical information in optimizer */
 
 #define SET_VPID(dest_vpid, vol_id, page_id)  \

--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -1924,11 +1924,7 @@ fhs_binary_search_bucket (THREAD_ENTRY * thread_p, PAGE_PTR bucket_page_p, PGSLO
 	}
       else
 	{
-	  if (flag > 0)
-	    {
-	      /* go to last slot using flag */
-	      middle = middle + flag - 1;
-	    }
+	  middle += (flag > 0) ? flag - 1 : 0; /* go to last slot using flag */
 	  low = middle + 1;
 	}
     }

--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -1924,7 +1924,7 @@ fhs_binary_search_bucket (THREAD_ENTRY * thread_p, PAGE_PTR bucket_page_p, PGSLO
 	}
       else
 	{
-	  low = (flag > 0) ? middle + flag : middle + 1;
+	  low = middle + 1;
 	}
     }
   while (high >= low);

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -8421,14 +8421,14 @@ check_hash_list_scan (LLIST_SCAN_ID * llsidp, int *val_cnt, int hash_list_scan_y
     }
   else if ((UINT64) llsidp->list_id->page_cnt * DB_PAGESIZE <= mem_limit)
     {
-      return HASH_METH_IN_MEM;
+      return HASH_METH_HASH_FILE;
     }
   else if ((UINT64) llsidp->list_id->tuple_cnt * (sizeof (HENTRY_HLS) + sizeof (QFILE_TUPLE_SIMPLE_POS)) <= mem_limit)
     {
       /* bytes of 1 row = sizeof(HENTRY_HLS) + sizeof(QFILE_TUPLE_SIMPLE_POS) = 44 bytes (64bit) */
       /* HENTRY_HLS = pointer(8bytes) * 4 = 32 bytes */
       /* SIMPLE_POS = pageid(4bytes) + volid(2bytes) + padding(2bytes) + offset(4bytes) = 12 bytes */
-      return HASH_METH_HYBRID;
+      return HASH_METH_HASH_FILE;
     }
   else
     {

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -8421,14 +8421,14 @@ check_hash_list_scan (LLIST_SCAN_ID * llsidp, int *val_cnt, int hash_list_scan_y
     }
   else if ((UINT64) llsidp->list_id->page_cnt * DB_PAGESIZE <= mem_limit)
     {
-      return HASH_METH_HASH_FILE;
+      return HASH_METH_IN_MEM;
     }
   else if ((UINT64) llsidp->list_id->tuple_cnt * (sizeof (HENTRY_HLS) + sizeof (QFILE_TUPLE_SIMPLE_POS)) <= mem_limit)
     {
       /* bytes of 1 row = sizeof(HENTRY_HLS) + sizeof(QFILE_TUPLE_SIMPLE_POS) = 44 bytes (64bit) */
       /* HENTRY_HLS = pointer(8bytes) * 4 = 32 bytes */
       /* SIMPLE_POS = pageid(4bytes) + volid(2bytes) + padding(2bytes) + offset(4bytes) = 12 bytes */
-      return HASH_METH_HASH_FILE;
+      return HASH_METH_HYBRID;
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24148

It is a core dump caused by the problem that the result is located in the middle of duplicate data during binary search.
In order to be located on the right side of the duplicate value, flag is added to middle.
