### PR TITLE
[CBRD-24110] revised: Enhance performance for count(*) where no predicates

### DIFF
--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -1460,7 +1460,7 @@ btree_build_nleafs (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args, int n_nulls,
   PAGE_PTR cur_nleafpgptr = NULL;
 
   BTREE_NODE *temp;
-  BTREE_ROOT_HEADER root_header_info = { 0, }, *root_header = NULL;
+  BTREE_ROOT_HEADER root_header_info, *root_header = NULL;
   BTREE_NODE_HEADER *header = NULL;
   int key_cnt;
   int max_key_len, new_max;
@@ -1852,6 +1852,11 @@ btree_build_nleafs (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args, int n_nulls,
   VPID_SET_NULL (&(root_header->node.prev_vpid));
   root_header->node.split_info.pivot = 0.0f;
   root_header->node.split_info.index = 0;
+
+  /* the 64 bit extending should be initialized to 0 
+   * because only the 32bit count is used at this point */
+  root_header->_64.over = 0;
+  root_header->_64.num_nulls = root_header->_64.num_oids = root_header->num_keys = 0;
 
   if (load_args->btid->unique_pk)
     {

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -1460,7 +1460,7 @@ btree_build_nleafs (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args, int n_nulls,
   PAGE_PTR cur_nleafpgptr = NULL;
 
   BTREE_NODE *temp;
-  BTREE_ROOT_HEADER root_header_info, *root_header = NULL;
+  BTREE_ROOT_HEADER root_header_info = { 0, }, *root_header = NULL;
   BTREE_NODE_HEADER *header = NULL;
   int key_cnt;
   int max_key_len, new_max;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24110

While building a b-tree, the root header should be cleared before setting the statistics values.