### PR TITLE
[LETS-374] Fix checking page is ahead of replication when it is also deallocated

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7548,7 +7548,9 @@ try_again:
 	      ret = ER_PB_BAD_PAGEID;
 	      goto error;
 	    }
-	  ret = pgbuf_check_for_deallocated_page_or_desyncronization (thread_p, context->latch_mode, *vpid);
+	  // Check if page is ahead of replication; if it is, the bad pageid error is overwritten.
+	  (void) pgbuf_check_for_deallocated_page_or_desyncronization (thread_p, context->latch_mode, *vpid);
+	  ASSERT_ERROR_AND_SET (ret);
 	}
 
       goto error;
@@ -7598,7 +7600,9 @@ try_again:
 	      ret = ER_PB_BAD_PAGEID;
 	      goto error;
 	    }
-	  ret = pgbuf_check_for_deallocated_page_or_desyncronization (thread_p, context->latch_mode, *vpid);
+	  // Check if page is ahead of replication; if it is, the bad pageid error is overwritten.
+	  (void) pgbuf_check_for_deallocated_page_or_desyncronization (thread_p, context->latch_mode, *vpid);
+	  ret = er_errid ();
 	}
 
       goto error;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2315,8 +2315,11 @@ pgbuf_fix_read_old_and_check_repl_desync (THREAD_ENTRY * thread_p, const VPID & 
     {
       // Maybe page is deallocated, or maybe there was another error. If page is deallocated, the error must be
       // ER_PB_BAD_PAGEID
-
-      (void) pgbuf_check_for_deallocated_page_or_desyncronization (thread_p, PGBUF_LATCH_READ, vpid);
+      if (er_errid () == ER_PB_BAD_PAGEID)
+	{
+	  // Check if page is ahead
+	  (void) pgbuf_check_for_deallocated_page_or_desyncronization (thread_p, PGBUF_LATCH_READ, vpid);
+	}
       return nullptr;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-374

Two fixes regarding deallocated pages & ahead of replication check:

- `pgbuf_fix_read_old_and_check_repl_desync ()` only checks page is ahead of replication, if the first fix fails with bad pageid error; if other errors have occurred, the check is not required.
- `heap_prepare_get_context ()` must not return NO_ERROR if page ahead of replication check was passed, but page is deallocated. Fallback to the bad pageid error.