### PR TITLE
[LETS-308] Handle page ahead replication after btree_range_scan navigation

### DIFF
--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -149,7 +149,7 @@ void passive_tran_server::finish_replication_during_shutdown (cubthread::entry &
   m_replicator.reset (nullptr);
 }
 
-void passive_tran_server::wait_replication_pasts_target_lsa (LOG_LSA lsa)
+void passive_tran_server::wait_replication_past_target_lsa (LOG_LSA lsa)
 {
   m_replicator->wait_past_target_lsa (lsa);
 }

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -39,7 +39,7 @@ class passive_tran_server : public tran_server
     /* read replicator's current progress */
     log_lsa get_replicator_lsa () const;
     void finish_replication_during_shutdown (cubthread::entry &thread_entry);
-    void wait_replication_pasts_target_lsa (LOG_LSA lsa);
+    void wait_replication_past_target_lsa (LOG_LSA lsa);
 
   private:
     bool uses_remote_storage () const final override;

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -223,7 +223,10 @@ struct btree_scan
 
   BTS_KEY_STATUS key_status;
 
-  LOG_LSA page_desync_lsa;
+  LOG_LSA page_desync_lsa;	/* Only on passive transaction server (PTS): the LSA of a page found to be
+				 * ahead of replication, that could cause a page desynchronization issue;
+				 * the LSA is used in combination with ER_PAGE_AHEAD_OF_REPLICATION error
+				 * to suspend/resume searches when desynchronization occurs */
 
   bool end_scan;
   bool end_one_iteration;

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -223,6 +223,8 @@ struct btree_scan
 
   BTS_KEY_STATUS key_status;
 
+  LOG_LSA page_desync_lsa;
+
   bool end_scan;
   bool end_one_iteration;
   bool is_interrupted;
@@ -279,6 +281,7 @@ struct btree_scan
     VPID_SET_NULL (&(bts)->leaf_rec_info.ovfl);		\
     (bts)->node_type = BTREE_LEAF_NODE;			\
     (bts)->key_status = BTS_KEY_IS_NOT_VERIFIED;	\
+    (bts)->page_desync_lsa = NULL_LSA;			\
     (bts)->end_scan = false;				\
     (bts)->end_one_iteration = false;			\
     (bts)->is_interrupted = false;			\

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -25061,7 +25061,7 @@ heap_get_visible_version_with_repl_desync (THREAD_ENTRY * thread_p, HEAP_GET_CON
       passive_tran_server *const pts_ptr = get_passive_tran_server_ptr ();
       LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
       assert (tdes->page_desync_lsa.is_null ());
-      pts_ptr->wait_replication_pasts_target_lsa (tdes->page_desync_lsa);
+      pts_ptr->wait_replication_past_target_lsa (tdes->page_desync_lsa);
       tdes->page_desync_lsa.set_null ();
     }
   while (true);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-308

Page ahead of replication errors may show up during b-tree range scan operations. This patch handles the errors after "navigation" functions (while advancing from root to current key, while reading overflow keys or while advancing from a leaf page to the next (or prev)).

The page ahead of replication problem is handled by waiting for the replication to catch-up with the page changes. If OID's that may be processed have been selected, the btree_range_scan last iteration is ended to process the OID's while replication catches up.

EDIT: the page ahead of replication error that is discovered while selecting OID's from b-tree keys is handled separately in LETS_309.