### PR TITLE
[CBRD-23839] unloaddb.sh supports multi-process

### DIFF
--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -30,6 +30,7 @@ pass=""
 password=""
 total_pages=0
 from_file=""
+target_dir=$(pwd)
 
 slot=()
 
@@ -41,6 +42,7 @@ function show_usage ()
          echo "  -i arg  input FILE of table names; default: dump all classes"
          echo "  -u arg  Set database user name; default dba"
          echo "  -p arg  Set dbuser password"
+         echo "  -D arg  Set directory for unloaddb output dir/files"
          echo "  -v      Set verbose mode on"
 
          echo ""
@@ -70,12 +72,13 @@ function veryfy_user_pass ()
 
 function get_options ()
 {
-         while getopts ":u:p:i:t:v" opt; do
+         while getopts ":D:u:p:i:t:v" opt; do
                 case $opt in
                         u ) user="-u $OPTARG" ;;
                         p ) pass="-p $OPTARG" ;;
                         i ) from_file="$OPTARG" ;;
                         t ) num_proc="$OPTARG" ;;
+                        D ) target_dir="$OPTARG" ;;
                         v ) verbose="yes" ;;
                 esac
         done
@@ -262,6 +265,14 @@ trap "cleanup; exit" SIGHUP SIGINT SIGTERM
 
 extract_db_name $*
 get_options "$@"
+
+if [ ! -d $target_dir ];then
+        echo "$target_dir: directory not exists or permission denied"
+        exit
+else
+   silent_cd $target_dir
+fi
+
 veryfy_user_pass
 
 get_table_name $*

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -99,11 +99,7 @@ function do_unloaddb ()
                 echo "Proc $slot_num: num tables: $num_tables_in_slot, page size: ${slot_size[$slot_num]}"
         fi
 
-        if [ $slot_num -eq 0 ];then
-                cubrid unloaddb -i $file $database
-        else
-                cubrid unloaddb -d -i $file $database
-        fi
+	cubrid unloaddb --input-class-only --input-class-file $file $database
 
         if [ $? -ne 0 ];then
                 msg="Failed"

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -337,17 +337,27 @@ done
 echo "Total $num_tables tables, $total_pages pages"
 # Do unloaddb for each process
 #
+# check and create sub-directories for each process
 for ((i = 0; i < $num_proc; i++))
 do
-        if [ ${num_tables_slot[i]} -ne 0 ];then
-                if [ -f $database.$i ] || [ -d $database.$i ];then
-                        echo "$database.$i: File or directory already exist."
-                        continue
-                fi
-                mkdir $database.$i
-                (silent_cd $database.$i; do_unloaddb $i) &
-        fi
+	if [ ${num_tables_slot[i]} -ne 0 ];then
+		if [ -f $database.$i ] || [ -d $database.$i ];then
+			echo "$database.$i: File or directory already exist."
+			exit 1
+		fi
+
+		mkdir $database.$i
+	fi
 done
+
+#
+# RUN unloaddb process cuncurrently
+#
+for ((i = 0; i < $num_proc; i++))
+do
+	(silent_cd $database.$i; do_unloaddb $i) &
+done
+
 wait
 
 echo "Completed."

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -25,7 +25,9 @@ slot_selected=0
 slot_size=(0 0 0 0 0 0 0 0)
 num_tables_slot=(0 0 0 0 0 0 0 0)
 database=
-user="dba"
+user="-u dba"
+pass=""
+password=""
 total_pages=0
 from_file=""
 
@@ -51,9 +53,10 @@ function show_usage ()
 
 function get_options ()
 {
-         while getopts ":u:i:t:v" opt; do
+         while getopts ":u:p:i:t:v" opt; do
                 case $opt in
-                        u ) user="$OPTARG" ;;
+                        u ) user="-u $OPTARG" ;;
+                        p ) pass="-p $OPTARG" ;;
                         i ) from_file="$OPTARG" ;;
                         t ) num_proc="$OPTARG" ;;
                         v ) verbose="yes" ;;
@@ -117,7 +120,7 @@ function do_unloaddb ()
                 echo "Proc $slot_num: num tables: $num_tables_in_slot, page size: ${slot_size[$slot_num]}"
         fi
 
-	cubrid unloaddb --input-class-only --input-class-file $file $database
+	cubrid unloaddb $user $pass --input-class-only --input-class-file $file $database
 
         if [ $? -ne 0 ];then
                 msg="Failed"
@@ -142,7 +145,7 @@ function get_table_name ()
         if [ X$from_file != X"" ];then  # Read table name from file
                 result=$(cat $from_file)
         else
-                result=$(csql -u $user -c "select class_name from db_class where is_system_class = 'NO' AND class_type = 'CLASS' order by class_name" $db)
+                result=$(csql $user $pass -c "select class_name from db_class where is_system_class = 'NO' AND class_type = 'CLASS' order by class_name" $db)
         fi
 
         for token in $result
@@ -174,7 +177,7 @@ function get_table_name ()
         for ((i = 0; i < ${#table_selected[@]}; i++))
         do
                 table_name=${table_selected[i]}
-                this_table_size=$(csql -u dba -l -c "show heap capacity of $table_name" $db | grep Num_pages | awk '{print $3}')
+                this_table_size=$(csql $user $pass -l -c "show heap capacity of $table_name" $db | grep Num_pages | awk '{print $3}')
 
                 if [ -z $this_table_size ];then
                         echo "Unknown table: $table_name"

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -144,12 +144,11 @@ function do_unloaddb ()
 
 function get_table_name ()
 {
-        local file=$HOME/.unload_temp_file
-        local db=${database:-hdb1}
         local found=0
         local line
         local idx=0
         local table_name
+        local db=$database
 
         # Get all table names from CATALOG
 

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -51,6 +51,17 @@ function show_usage ()
   echo ""
 }
 
+function veryfy_user_pass ()
+{
+         local msg
+         msg=$(csql $user $pass -c "select 1" $database)
+
+         if [ $? -ne 0 ];then
+                echo "Invalid user/pass: please check user and password"
+                exit
+         fi
+}
+
 function get_options ()
 {
          while getopts ":u:p:i:t:v" opt; do
@@ -193,6 +204,7 @@ function get_table_name ()
 
 extract_db_name $*
 get_options "$@"
+veryfy_user_pass
 
 get_table_name $*
 

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+#
+#
+#  Copyright 2016 CUBRID Corporation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+verbose="no"   # set 'yes' for verbose mode
+num_proc=8
+table=()
+table_size=()
+table_selected=()
+num_tables=0
+slot_selected=0
+slot_size=(0 0 0 0 0 0 0 0)
+num_tables_slot=(0 0 0 0 0 0 0 0)
+database=
+user="dba"
+total_pages=0
+from_file=""
+
+slot=()
+
+function get_options ()
+{
+         while getopts ":u:i:t:v" opt; do
+                case $opt in
+                        u ) user="$OPTARG" ;;
+                        i ) from_file="$OPTARG" ;;
+                        t ) num_proc="$OPTARG" ;;
+                        v ) verbose="yes" ;;
+                esac
+        done
+}
+
+function silent_cd ()
+{
+        cd $* > /dev/null
+}
+
+function extract_db_name ()
+{
+        local nelem=$#
+        local i
+
+        # extract last argument & set as database name
+
+        if [ $nelem -eq 0 ];then
+                return
+        fi
+
+        database=$(echo ${@:$nelem:1})
+}
+function find_slot ()
+{
+        local selected=0
+        local i
+        local size=${slot_size[0]}
+
+        for ((i = 0; i < $num_proc; i++))
+        do
+                if [ ${slot_size[i]} -lt $size ];then
+                        size=${slot_size[i]}
+                        selected=$i
+                fi
+        done
+
+         echo $selected
+}
+
+function do_unloaddb ()
+{
+        local slot_num=$1
+        local i
+        local file="Table_list_$database.$slot_num"
+        local num_tables_in_slot=0
+        local msg="Success"
+
+        for ((i = 0; i < $num_tables; i++))
+        do
+                if [ ${slot[i]} -eq $slot_num ];then
+                        let "num_tables_in_slot++"
+                        echo "${table_selected[i]}" >> $file
+                fi
+        done
+
+        if [ $verbose = "yes" ];then
+                echo "Proc $slot_num: num tables: $num_tables_in_slot, page size: ${slot_size[$slot_num]}"
+        fi
+
+        if [ $slot_num -eq 0 ];then
+                cubrid unloaddb -i $file $database
+        else
+                cubrid unloaddb -d -i $file $database
+        fi
+
+        if [ $? -ne 0 ];then
+                msg="Failed"
+        fi
+
+        if [ $verbose = "yes" ];then
+                echo "Finished Proc $slot_num ($msg)"
+        fi
+}
+
+function get_table_name ()
+{
+        local file=$HOME/.unload_temp_file
+        local db=${database:-hdb1}
+        local found=0
+        local line
+        local idx=0
+        local table_name
+
+        # Get all table names from CATALOG
+
+        if [ X$from_file != X"" ];then  # Read table name from file
+                result=$(cat $from_file)
+        else
+                result=$(csql -u $user -c "select class_name from db_class where is_system_class = 'NO' AND class_type = 'CLASS' order by class_name" $db)
+        fi
+
+        for token in $result
+        do
+                if  [ X$from_file = X"" ] && [ $found -eq 0 ];then
+                        str=$(echo $token | grep "====") # skip until we found table names in csql
+                        if [ $? -eq 0 ];then
+                                found=1
+                        fi
+                        continue
+                fi
+
+                if [ X$from_file = X"" ] && [ ${token:0:1} != "'" ];then
+                        break
+                fi
+
+                table_selected[idx]="$token"
+
+                if [ X$from_file = X"" ];then        # remove single quota from csql output
+                        table_selected[idx]=$(echo ${table_selected[idx]} | sed "s/[\']//g")
+                fi
+
+                let "idx++"
+
+        done
+
+        # Get the size of all tables
+        n=1
+        for ((i = 0; i < ${#table_selected[@]}; i++))
+        do
+                table_name=${table_selected[i]}
+                this_table_size=$(csql -u dba -l -c "show heap capacity of $table_name" $db | grep Num_pages | awk '{print $3}')
+
+                if [ -z $this_table_size ];then
+                        echo "Unknown table: $table_name"
+                        exit
+                fi
+
+                table_size[$num_tables]="$this_table_size"
+                let "num_tables++"
+        done
+}
+
+# MAIN
+
+extract_db_name $*
+get_options "$@"
+
+get_table_name $*
+
+if [ $num_tables -eq 0 ];then
+        echo "No Table SELECTED."
+        exit
+fi
+
+# Assign all tables to unloaddb slot
+# Assign and calculate total table size & num tables assigned in each slot
+for ((i = 0; i < $num_tables; i++))
+do
+        this_slot=$(find_slot)
+        tbl=${table_selected[i]}
+        slot[i]=$this_slot
+
+        let "slot_size[$this_slot]+=${table_size[$i]}"
+        let "num_tables_slot[$this_slot]++"
+        let "total_pages+=${table_size[$i]}"
+
+        if [ $verbose = "yes" ];then
+                index=$(printf "%3d" $i)
+                echo "[$index:${slot[i]}] ${table_selected[i]}: pages = ${table_size[i]}"
+        fi
+done
+
+echo "Total $num_tables tables, $total_pages pages"
+
+# Do unloaddb for each process
+#
+for ((i = 0; i < $num_proc; i++))
+do
+        if [ ${num_tables_slot[i]} -ne 0 ];then
+                if [ -f $database.$i ] || [ -d $database.$i ];then
+                        echo "$database.$i: File or directory already exist."
+                        continue
+                fi
+                mkdir $database.$i
+                (silent_cd $database.$i; do_unloaddb $i) &
+        fi
+done
+wait
+
+echo "Completed."

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -18,7 +18,6 @@
 
 verbose="no"   # set 'yes' for verbose mode
 num_proc=8
-table=()
 table_size=()
 table_selected=()
 num_tables=0

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -31,6 +31,24 @@ from_file=""
 
 slot=()
 
+function show_usage ()
+{
+  echo "Usage: $0 [OPTIONS] [TARGET]"
+  echo " OPTIONS"
+  echo "  -t arg  Set number of parallel process; default 8"
+  echo "  -i arg  input FILE of table names; default: dump all classes"
+  echo "  -u arg  Set database user name; default dba"
+  echo "  -p arg  Set dbuser password"
+  echo "  -v      Set verbose mode on"
+
+  echo ""
+  echo " EXAMPLES"
+  echo "  $0 -t 4 -v demodb          # unload all tables in demodb"
+  echo "  $0 -i file demodb          # unload tables listed in file in demodb"
+  echo "  $0 -u user1 -p 1234 -i file -t 4 -v demodb"
+  echo ""
+}
+
 function get_options ()
 {
          while getopts ":u:i:t:v" opt; do
@@ -56,7 +74,8 @@ function extract_db_name ()
         # extract last argument & set as database name
 
         if [ $nelem -eq 0 ];then
-                return
+                show_usage
+                exit
         fi
 
         database=$(echo ${@:$nelem:1})

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -35,20 +35,20 @@ slot=()
 
 function show_usage ()
 {
-  echo "Usage: $0 [OPTIONS] [TARGET]"
-  echo " OPTIONS"
-  echo "  -t arg  Set number of parallel process; default 8"
-  echo "  -i arg  input FILE of table names; default: dump all classes"
-  echo "  -u arg  Set database user name; default dba"
-  echo "  -p arg  Set dbuser password"
-  echo "  -v      Set verbose mode on"
+         echo "Usage: $0 [OPTIONS] [TARGET]"
+         echo " OPTIONS"
+         echo "  -t arg  Set number of parallel process; default 8"
+         echo "  -i arg  input FILE of table names; default: dump all classes"
+         echo "  -u arg  Set database user name; default dba"
+         echo "  -p arg  Set dbuser password"
+         echo "  -v      Set verbose mode on"
 
-  echo ""
-  echo " EXAMPLES"
-  echo "  $0 -t 4 -v demodb          # unload all tables in demodb"
-  echo "  $0 -i file demodb          # unload tables listed in file in demodb"
-  echo "  $0 -u user1 -p 1234 -i file -t 4 -v demodb"
-  echo ""
+         echo ""
+         echo " EXAMPLES"
+         echo "  $0 -t 4 -v demodb          # unload all tables in demodb"
+         echo "  $0 -i file demodb          # unload tables listed in file in demodb"
+         echo "  $0 -u user1 -p 1234 -i file -t 4 -v demodb"
+         echo ""
 }
 
 function veryfy_user_pass ()


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23839

**Purpose**
The **unloaddb** utility that provides multi-process. 

**Implementation**
example:
sh unloaddb.sh -v -i input_file -u user -D /tmp -t num_process _database_name_

option summary:
  -   -v: if given, print verbose information
  -  -i: if given, table names to unload data of specified tables in this file, otherwise all tables in database will be unloaded
  - -u: if given, use user name **user** for unloaddb, otherwise **dba** will be used
  - -t: if given, maximum num_process unloaddb process will be invoked, otherwise -t 8 will be used (default)
  - -D: if given, target directory to create unloaddb output, otherwise current working directory will be used

If executed, for example dbname is demodb and num process is 4, following 4 directories will be created on current working directory:
  demodb.0, demodb.1, demodb.2, demodb.3

For all tables to be unloaded, calculate number of pages for each table and pick a process which has minimum pages to unload, and assign the table to the process. (using csql -c "show heap capacity of table _table_name_")

And each directory contains file named, **Table_list_demodb**.1, it contains table names unloaded. And each directory will contain unloaddb output for tables listed in _Table_list_database_name.x_. 
 (demodb.0/Table_list_demodb.0, demodb.1/Table_list_demodb.1, ...)

**Remarks**
NA