### PR TITLE
[CBRD-24129] Use ADD Query instead of ADD/CHANGE Query in unloaddb

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1292,10 +1292,10 @@ static bool
 has_vclass_domains (DB_OBJECT * vclass)
 {
   /*
-   * this doesn't seem to be enough, always return 1 so we make two full passes
-   * on the query specs of all vclasses
+   * Previously, it force two full passes on the query specs of all vclasses,
+   * Now, force one pass
    */
-  return 1;
+  return 0;
 }
 
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24129

**Purpose**
Due to loaddb cannot recognize type properly for a column which contains inline view, and raise error.
We discard current forcing two pass in has_vclass_domains () for the query specs of all vclasses and take one pass.

**Implementation**

**Remarks**
After sufficient testing, refactoring is required.