### PR TITLE
[CBRD-23960] Fix slip of unpacking OID type in Server-side JDBC

### DIFF
--- a/demo/test/SpOIDSet.java
+++ b/demo/test/SpOIDSet.java
@@ -155,6 +155,53 @@ public class SpOIDSet {
         }
     }
 
+    /* from SpTest6.testoid1 */
+    public static CUBRIDOID testOidArgs1(CUBRIDOID oid) {
+        return oid;
+    }
+
+    public static String testOidArgs2(CUBRIDOID oid) {
+        Connection conn = null;
+        Statement stmt = null;
+        String ret = "";
+
+        try {
+            Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
+            conn = DriverManager.getConnection("jdbc:default:connection:", "", "");
+            String[] attrs = {"id"};
+
+            Integer[] values = {new Integer(10)};
+
+            conn.setAutoCommit(false);
+            ret = ret + oid.getTableName() + " | ";
+            ret = ret + oid.isInstance() + " | ";
+            ResultSet rs = oid.getValues(attrs);
+            int i = 0;
+            while (rs.next()) {
+                ret = ret + " || " + rs.getString(1);
+            }
+            oid.setValues(attrs, values);
+            oid.getValues(attrs);
+            rs = oid.getValues(attrs);
+            while (rs.next()) {
+                ret = ret + " || " + rs.getString(1);
+            }
+            oid.remove();
+            conn.close();
+            return ret;
+        } catch (SQLException e) {
+            // e.printStackTrace();
+        } catch (Exception e) {
+            // e.printStackTrace();
+        }
+        return "";
+    }
+
+    /* from SpTest6.testoid3 */
+    public static java.lang.Object[] testOidArgs3(java.lang.Object[] set) {
+        return set;
+    }
+
     /* from SpTest6.testset5 */
     public static void testset5(Integer[][] set) {
         for (int i = 0; i < set[0].length; i++) {

--- a/demo/test/testsp_schema
+++ b/demo/test/testsp_schema
@@ -39,6 +39,7 @@ CREATE OR REPLACE FUNCTION sp_plus_int_out(a IN OUT INT, b IN OUT INT) RETURN in
 CREATE OR REPLACE FUNCTION sp_plus_float(a FLOAT, b FLOAT) RETURN FLOAT as language java name 'test.SpArgumentTest.testPlusFloat(float, float) return float';
 CREATE OR REPLACE FUNCTION sp_plus_float_out(a IN OUT FLOAT, b IN OUT FLOAT) RETURN FLOAT as language java name 'test.SpArgumentTest.testPlusFloatOut(float[], float[]) return float';
 
+CREATE OR REPLACE PROCEDURE sp_oid(z object) AS LANGUAGE JAVA NAME 'test.SpArgumentTest.testOID(cubrid.sql.CUBRIDOID[])';
 CREATE OR REPLACE PROCEDURE sp_setoid(x in out set, z object) AS LANGUAGE JAVA NAME 'test.SpArgumentTest.testSetOID(cubrid.sql.CUBRIDOID[][], cubrid.sql.CUBRIDOID)';
 
 /* Returning Cursor Test */

--- a/src/jsp/com/cubrid/jsp/data/CUBRIDUnpacker.java
+++ b/src/jsp/com/cubrid/jsp/data/CUBRIDUnpacker.java
@@ -311,6 +311,7 @@ public class CUBRIDUnpacker {
                     arg = new SetValue(unpackSetValue(nCol), mode, dbType);
                 }
                 break;
+            case DBType.DB_OID:
             case DBType.DB_OBJECT:
                 {
                     SOID oid = new SOID(this);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23960

When unpacking DB_VALUE in server-side JDBC, `case DBType.DB_OID:` is slipped. Related test cases are added too