### PR TITLE
[CBRD-24148] Core dump occur when using hash list scan (#3278)

### DIFF
--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -1924,7 +1924,8 @@ fhs_binary_search_bucket (THREAD_ENTRY * thread_p, PAGE_PTR bucket_page_p, PGSLO
 	}
       else
 	{
-	  low = (flag > 0) ? middle + flag : middle + 1;
+	  middle += (flag > 0) ? flag - 1 : 0;	/* go to last slot using flag */
+	  low = middle + 1;
 	}
     }
   while (high >= low);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24148

backport #3278
