### PR TITLE
[CBRD-24085] Fix assert error while adding mvcc log record when vacuum_disable=true

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1267,6 +1267,8 @@ vacuum_boot (THREAD_ENTRY * thread_p)
   if (prm_get_bool_value (PRM_ID_DISABLE_VACUUM))
     {
       /* for debug only */
+      (void) log_Gl.mvcc_table.update_global_oldest_visible ();
+
       return NO_ERROR;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24085

### Purpose
- fix assert error while adding an mvcc log record when vacuum_disable=true
- scenario
```
vacuum_disable=1
createdb
create table
```

### Implementation
- an assert error occurs because mvcctable::get_global_oldest_visible() returns MVCCID_NULL in the prior_update_header_mvcc_info().
- accordingly, even when vacuum_disable=true, this function has been modified to never return MVCCID_NULL.
- when vacuum_disable=false, the mvcctable::update_global_oldest_visible() is called with the following call stack.
```
(void) log_Gl.mvcc_table.update_global_oldest_visible();
vacuum_data_load_and_recover()
vacuum_boot()
```

### Remarks
- N/A