### PR TITLE
[LETS-379] more accurate comments regarding transaction table checkpoint

### DIFF
--- a/src/transaction/log_meta.cpp
+++ b/src/transaction/log_meta.cpp
@@ -178,7 +178,14 @@ namespace cublog
   void
   meta::add_checkpoint_info (const log_lsa &chkpt_lsa, const checkpoint_info &chkpt_info)
   {
-    assert (m_checkpoints.find (chkpt_lsa) == m_checkpoints.cend ());
+    const checkpoint_container_t::const_iterator found_it = m_checkpoints.find (chkpt_lsa);
+    if (found_it != m_checkpoints.cend ())
+      {
+	// if same LSA checkpoint already exists, replace with new one
+	// to be in line with what happens in calling code where the checkpoint is also
+	// added to the log for the purpose of being transferred to passive transaction servers
+	m_checkpoints.erase (found_it);
+      }
     m_checkpoints.insert ({ chkpt_lsa, chkpt_info });
   }
 

--- a/src/transaction/log_meta.cpp
+++ b/src/transaction/log_meta.cpp
@@ -178,6 +178,7 @@ namespace cublog
   void
   meta::add_checkpoint_info (const log_lsa &chkpt_lsa, const checkpoint_info &chkpt_info)
   {
+    assert (m_checkpoints.find (chkpt_lsa) == m_checkpoints.cend ());
     m_checkpoints.insert ({ chkpt_lsa, chkpt_info });
   }
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7524,11 +7524,13 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
 	_er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: droping previous before lsa=%lld|%d\n",
 		       LSA_AS_ARGS (&trantable_checkpoint_lsa));
       }
+
+    // - in nominal conditions, there should be one previous checkpoint that is removed
+    // - in abnormal conditions - such as when the system crashed just after adding a new
+    //    checkpoint and before deleting the outdated checkpoint - there can be more than
+    //    one checkpoint to be removed
     log_Gl.m_metainfo.remove_checkpoint_info_before_lsa (trantable_checkpoint_lsa);
 
-    // - in nominal conditions, there should be at most one previous trantable checkpoint
-    // - in abnormal conditions (such as when the system crashed just after adding a new trantable
-    //    checkpoint and before deleting the outdated checkpoint) there can be at most two
     assert (log_Gl.m_metainfo.get_checkpoint_count () == 1);
 
     log_write_metalog_to_file (false);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-379

Extra:
When adding a checkpoint to the metalog, first check that a same-LSA checkpoint already exists.
Technically, this should never happen:
- on active transaction server (ATS), every checkpoint created is also added to the log before being added to the metalog, thus increasing the LSA
- on page server (PS), since page server consumes (replicates) the log generated by the active transaction server, the same pattern could happen there as well; the edge case, in which the page server could add a same-LSA again in the metalog, is if the checkpoint daemon has such a short execution interval that it executes two times consecutively between two log records created by the ATS

