### PR TITLE
[CBRD-24155] Add a system parameter to set core count for thread worker pool

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -10749,7 +10749,6 @@ prm_tune_parameters (void)
   SYSPRM_PARAM *ha_check_disk_failure_interval_prm;
   SYSPRM_PARAM *test_mode_prm;
   SYSPRM_PARAM *tz_leap_second_support_prm;
-  SYSPRM_PARAM *thread_core_count_prm;
 
   char newval[LINE_MAX];
   char host_name[CUB_MAXHOSTNAMELEN];

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -457,8 +457,9 @@ enum param_id
   PRM_ID_CDC_LOGGING_DEBUG,
   PRM_ID_RECOVERY_PROGRESS_LOGGING_INTERVAL,
   PRM_ID_FIRST_LOG_PAGEID,	/* Except for QA or TEST purposes, never use it. */
+  PRM_ID_THREAD_CORE_COUNT,
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_FIRST_LOG_PAGEID
+  PRM_LAST_ID = PRM_ID_THREAD_CORE_COUNT
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1320,9 +1320,9 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 #endif /* WINDOWS */
 
   // initialize worker pool for server requests
-  const std::size_t MAX_WORKERS = css_get_max_conn () + 1;	// = css_Num_max_conn in connection_sr.c
-  const std::size_t MAX_TASK_COUNT = 2 * MAX_WORKERS;	// not that it matters...
-  const std::size_t MAX_CONNECTIONS = css_get_max_conn () + 1;
+  const std::size_t MAX_WORKERS = css_get_max_workers ();
+  const std::size_t MAX_TASK_COUNT = css_get_max_task_count ();
+  const std::size_t MAX_CONNECTIONS = css_get_max_connections ();
 
   // create request worker pool
   css_Server_request_worker_pool =
@@ -3235,6 +3235,19 @@ css_count_transaction_worker_threads (THREAD_ENTRY * thread_p, int tran_index, i
                                                         tran_index, client_id, count);
 
   return count;
+}
+
+size_t css_get_max_workers ()
+{
+  return css_get_max_conn () + 1; // = css_Num_max_conn in connection_sr.c
+}
+size_t css_get_max_task_count ()
+{
+  return 2 * css_get_max_workers ();	// not that it matters...
+}
+size_t css_get_max_connections ()
+{
+  return css_get_max_conn () + 1;
 }
 
 static bool

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -254,6 +254,7 @@ static HA_SERVER_STATE css_transit_ha_server_state (THREAD_ENTRY * thread_p, HA_
 static bool css_get_connection_thread_pooling_configuration (void);
 static cubthread::wait_seconds css_get_connection_thread_timeout_configuration (void);
 static bool css_get_server_request_thread_pooling_configuration (void);
+static int css_get_server_request_thread_core_count_configruation (void);
 static cubthread::wait_seconds css_get_server_request_thread_timeout_configuration (void);
 static void css_start_all_threads (void);
 // *INDENT-ON*
@@ -1326,7 +1327,7 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
   // create request worker pool
   css_Server_request_worker_pool =
     cubthread::get_manager ()->create_worker_pool (MAX_WORKERS, MAX_TASK_COUNT, "transaction workers", NULL,
-						   cubthread::system_core_count (),
+						   css_get_server_request_thread_core_count_configruation (),
 						   cubthread::is_logging_configured
 						   (cubthread::LOG_WORKER_POOL_TRAN_WORKERS),
 						   css_get_server_request_thread_pooling_configuration (),
@@ -3254,6 +3255,12 @@ static bool
 css_get_server_request_thread_pooling_configuration (void)
 {
   return prm_get_bool_value (PRM_ID_THREAD_WORKER_POOLING);
+}
+
+static int
+css_get_server_request_thread_core_count_configruation (void)
+{
+  return prm_get_integer_value (PRM_ID_THREAD_CORE_COUNT);
 }
 
 static cubthread::wait_seconds

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -28,7 +28,7 @@
 #error server_support.h belongs to server or stand-alone modules
 #endif // not SERVER_MODE and not SA_MODE
 
-#include "connection_globals.h"
+#include "connection_defs.h"
 #include "connection_sr.h"
 #include "thread_entry.hpp"
 #include "thread_entry_task.hpp"

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -28,7 +28,7 @@
 #error server_support.h belongs to server or stand-alone modules
 #endif // not SERVER_MODE and not SA_MODE
 
-#include "connection_defs.h"
+#include "connection_globals.h"
 #include "connection_sr.h"
 #include "thread_entry.hpp"
 #include "thread_entry_task.hpp"
@@ -105,6 +105,10 @@ extern int css_get_client_id (THREAD_ENTRY * thread_p);
 extern unsigned int css_get_comm_request_id (THREAD_ENTRY * thread_p);
 extern struct css_conn_entry *css_get_current_conn_entry (void);
 extern int css_check_conn (CSS_CONN_ENTRY * p);
+
+extern size_t css_get_max_workers ();
+extern size_t css_get_max_task_count ();
+extern size_t css_get_max_connections ();
 
 #if defined (SERVER_MODE)
 extern int css_job_queues_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** arg_values, int arg_cnt,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24155

- a new parameter, "thread_core_count" is added
  - Change (Tune) the value entered by the user considering max_client and system core count
  - The behavior of partitioning workers according to the # of cores in the thread worker pool is changed to use "thread_core_count" as partitioning factor

please refer to the JIRA description for detailed implementation.