### PR TITLE
[LETS-381] regression, correct pgbuf_fix latch mode

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -2497,7 +2497,8 @@ btree_get_num_visible_oids_from_all_ovf (THREAD_ENTRY * thread_p, BTID_INT * bti
   /* search for OID into overflow page */
   while (!VPID_ISNULL (&next_ovfl_vpid))
     {
-      ovfl_page = pgbuf_fix_read_old_and_check_repl_desync (thread_p, next_ovfl_vpid, PGBUF_UNCONDITIONAL_LATCH);
+      ovfl_page = pgbuf_fix_old_and_check_repl_desync (thread_p, next_ovfl_vpid, PGBUF_LATCH_READ,
+						       PGBUF_UNCONDITIONAL_LATCH);
       if (ovfl_page == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (ret);
@@ -11137,7 +11138,8 @@ btree_find_oid_and_its_page (THREAD_ENTRY * thread_p, BTID_INT * btid_int, OID *
   do
     {
       PERF_UTIME_TRACKER_START (thread_p, &ovf_fix_time_track);
-      overflow_page = pgbuf_fix_read_old_and_check_repl_desync (thread_p, overflow_vpid, PGBUF_UNCONDITIONAL_LATCH);
+      overflow_page = pgbuf_fix_old_and_check_repl_desync (thread_p, overflow_vpid, PGBUF_LATCH_WRITE,
+							   PGBUF_UNCONDITIONAL_LATCH);
       btree_perf_ovf_oids_fix_time (thread_p, &ovf_fix_time_track);
       if (overflow_page == NULL)
 	{
@@ -22281,7 +22283,8 @@ btree_key_find_first_visible_row_from_all_ovf (THREAD_ENTRY * thread_p, BTID_INT
   /* find first visible OID into overflow page */
   while (!VPID_ISNULL (&next_ovfl_vpid))
     {
-      ovfl_page = pgbuf_fix_read_old_and_check_repl_desync (thread_p, next_ovfl_vpid, PGBUF_UNCONDITIONAL_LATCH);
+      ovfl_page = pgbuf_fix_old_and_check_repl_desync (thread_p, next_ovfl_vpid, PGBUF_LATCH_READ,
+						       PGBUF_UNCONDITIONAL_LATCH);
       if (ovfl_page == NULL)
 	{
 	  ASSERT_ERROR ();
@@ -23823,7 +23826,7 @@ btree_key_process_objects (THREAD_ENTRY * thread_p, BTID_INT * btid_int, RECDES 
     {
       /* Fix overflow page. */
       PERF_UTIME_TRACKER_START (thread_p, &ovf_fix_time_track);
-      ovf_page = pgbuf_fix_read_old_and_check_repl_desync (thread_p, ovf_vpid, PGBUF_UNCONDITIONAL_LATCH);
+      ovf_page = pgbuf_fix_old_and_check_repl_desync (thread_p, ovf_vpid, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
       btree_perf_ovf_oids_fix_time (thread_p, &ovf_fix_time_track);
       if (ovf_page == NULL)
 	{
@@ -25329,7 +25332,7 @@ btree_range_scan_select_visible_oids (THREAD_ENTRY * thread_p, BTREE_SCAN * bts)
 	   * is used when key has too many objects. See comment from BTS_IS_HARD_CAPACITY_ENOUGH. */
 	  /* Resume from next page of last overflow page. */
 	  prev_overflow_page =
-	    pgbuf_fix_read_old_and_check_repl_desync (thread_p, bts->O_vpid, PGBUF_UNCONDITIONAL_LATCH);
+	    pgbuf_fix_old_and_check_repl_desync (thread_p, bts->O_vpid, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
 	  if (prev_overflow_page == NULL)
 	    {
 	      ASSERT_ERROR_AND_SET (error_code);
@@ -25393,7 +25396,8 @@ btree_range_scan_select_visible_oids (THREAD_ENTRY * thread_p, BTREE_SCAN * bts)
     {
       /* Fix next overflow page. */
       PERF_UTIME_TRACKER_START (thread_p, &ovf_fix_time_track);
-      overflow_page = pgbuf_fix_read_old_and_check_repl_desync (thread_p, overflow_vpid, PGBUF_UNCONDITIONAL_LATCH);
+      overflow_page = pgbuf_fix_old_and_check_repl_desync (thread_p, overflow_vpid, PGBUF_LATCH_READ,
+							   PGBUF_UNCONDITIONAL_LATCH);
       btree_perf_ovf_oids_fix_time (thread_p, &ovf_fix_time_track);
       if (overflow_page == NULL)
 	{
@@ -25763,7 +25767,8 @@ btree_range_scan_find_fk_any_object (THREAD_ENTRY * thread_p, BTREE_SCAN * bts)
   while (!VPID_ISNULL (&ovf_vpid))
     {
       /* Fix overflow page. */
-      bts->O_page = pgbuf_fix_read_old_and_check_repl_desync (thread_p, ovf_vpid, PGBUF_UNCONDITIONAL_LATCH);
+      bts->O_page = pgbuf_fix_old_and_check_repl_desync (thread_p, ovf_vpid, PGBUF_LATCH_READ,
+							 PGBUF_UNCONDITIONAL_LATCH);
       if (bts->O_page == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error_code);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -24946,13 +24946,14 @@ void
 btree_range_scan_wait_for_replication (btree_scan & bts)
 {
 #if defined (SERVER_MODE)
-  assert (is_passive_transaction_server ());
-
+  // early out, on non-(passive transaction server) this lsa is set to null and unused
   if (bts.page_desync_lsa.is_null ())
     {
       // no need to wait
       return;
     }
+
+  assert (is_passive_transaction_server ());
 
   // a lock is expended in this call; currently, there's no way to avoid that lock
   get_passive_tran_server_ptr ()->wait_replication_past_target_lsa (bts.page_desync_lsa);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -24945,14 +24945,17 @@ btree_range_scan_handle_page_ahead_repl_error (THREAD_ENTRY * thread_p, btree_sc
 void
 btree_range_scan_wait_for_replication (btree_scan & bts)
 {
-#if defined (SERVER_MODE)
-  // early out, on non-(passive transaction server) this lsa is set to null and unused
+  // early out, on:
+  //  - non-passive transaction server
+  //  - stand-alone
+  // this lsa is initialized to null and unused
   if (bts.page_desync_lsa.is_null ())
     {
       // no need to wait
       return;
     }
 
+#if defined (SERVER_MODE)
   assert (is_passive_transaction_server ());
 
   // a lock is expended in this call; currently, there's no way to avoid that lock

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7549,7 +7549,7 @@ try_again:
 	      goto error;
 	    }
 	  // Check if page is ahead of replication; if it is, the bad pageid error is overwritten.
-	  (void) pgbuf_check_for_deallocated_page_or_desyncronization (thread_p, context->latch_mode, *vpid);
+	  (void) pgbuf_check_for_deallocated_page_or_desynchronization (thread_p, context->latch_mode, *vpid);
 	  ASSERT_ERROR_AND_SET (ret);
 	}
 
@@ -7601,7 +7601,7 @@ try_again:
 	      goto error;
 	    }
 	  // Check if page is ahead of replication; if it is, the bad pageid error is overwritten.
-	  (void) pgbuf_check_for_deallocated_page_or_desyncronization (thread_p, context->latch_mode, *vpid);
+	  (void) pgbuf_check_for_deallocated_page_or_desynchronization (thread_p, context->latch_mode, *vpid);
 	  ret = er_errid ();
 	}
 

--- a/src/storage/overflow_file.c
+++ b/src/storage/overflow_file.c
@@ -743,7 +743,7 @@ overflow_get_nbytes (THREAD_ENTRY * thread_p, const VPID * ovf_vpid, RECDES * re
 
   next_vpid = *ovf_vpid;
 
-  pgptr = pgbuf_fix_read_old_and_check_repl_desync (thread_p, next_vpid, PGBUF_UNCONDITIONAL_LATCH);
+  pgptr = pgbuf_fix_old_and_check_repl_desync (thread_p, next_vpid, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
   if (pgptr == NULL)
     {
       return S_ERROR;
@@ -863,7 +863,8 @@ overflow_get_nbytes (THREAD_ENTRY * thread_p, const VPID * ovf_vpid, RECDES * re
 	      return S_ERROR;
 	    }
 
-	  pgptr = pgbuf_fix_read_old_and_check_repl_desync (thread_p, next_vpid, PGBUF_UNCONDITIONAL_LATCH);
+	  pgptr = pgbuf_fix_old_and_check_repl_desync (thread_p, next_vpid, PGBUF_LATCH_READ,
+						       PGBUF_UNCONDITIONAL_LATCH);
 	  if (pgptr == NULL)
 	    {
 	      recdes->length = 0;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2280,17 +2280,22 @@ try_again:
   return pgptr;
 }
 
+/* pgbuf_fix_old_and_check_repl_desync - fix an old page with specific latch; for active transaction
+ *                  server, the behaviour is same as pgbuf_fix; for passive transaction server, an
+ *                  extra check to see whether page is ahead of replication
+ */
 PAGE_PTR
-pgbuf_fix_read_old_and_check_repl_desync (THREAD_ENTRY * thread_p, const VPID & vpid, PGBUF_LATCH_CONDITION cond)
+pgbuf_fix_old_and_check_repl_desync (THREAD_ENTRY * thread_p, const VPID & vpid, PGBUF_LATCH_MODE latch_mode,
+				     PGBUF_LATCH_CONDITION cond)
 {
   assert (is_transaction_server ());
 
-  PAGE_PTR page = pgbuf_fix (thread_p, &vpid, OLD_PAGE, PGBUF_LATCH_READ, cond);
+  PAGE_PTR page = pgbuf_fix (thread_p, &vpid, OLD_PAGE, latch_mode, cond);
 
 #if defined (SERVER_MODE)
   if (is_active_transaction_server ())
     {
-      // No replication, no page - replication desynchronization is possible
+      // No replication, no page desynchronization is possible
       // Use regular fix
       return page;
     }
@@ -2318,7 +2323,7 @@ pgbuf_fix_read_old_and_check_repl_desync (THREAD_ENTRY * thread_p, const VPID & 
       if (er_errid () == ER_PB_BAD_PAGEID)
 	{
 	  // Check if page is ahead
-	  (void) pgbuf_check_for_deallocated_page_or_desyncronization (thread_p, PGBUF_LATCH_READ, vpid);
+	  (void) pgbuf_check_for_deallocated_page_or_desynchronization (thread_p, latch_mode, vpid);
 	}
       return nullptr;
     }
@@ -2373,8 +2378,8 @@ pgbuf_check_page_ahead_of_replication (THREAD_ENTRY * thread_p, PAGE_PTR page)
 }
 
 int
-pgbuf_check_for_deallocated_page_or_desyncronization (THREAD_ENTRY * thread_p, PGBUF_LATCH_MODE latch_mode,
-						      const VPID & vpid)
+pgbuf_check_for_deallocated_page_or_desynchronization (THREAD_ENTRY * thread_p, PGBUF_LATCH_MODE latch_mode,
+						       const VPID & vpid)
 {
   assert (er_errid () == ER_PB_BAD_PAGEID);
   int ret = ER_PB_BAD_PAGEID;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2281,7 +2281,7 @@ try_again:
 }
 
 /* pgbuf_fix_old_and_check_repl_desync - fix an old page with specific latch; for active transaction
- *                  server, the behaviour is same as pgbuf_fix; for passive transaction server, an
+ *                  server, the behaviour is same as pgbuf_fix; for passive transaction server, there is an
  *                  extra check to see whether page is ahead of replication
  */
 PAGE_PTR

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -466,11 +466,11 @@ extern void pgbuf_daemons_destroy ();
 
 // Check if page is ahead of replication; only relevant on passive transaction server, don't call elsewhere.
 extern int pgbuf_check_page_ahead_of_replication (THREAD_ENTRY * thread_p, PAGE_PTR page);
-extern int pgbuf_check_for_deallocated_page_or_desyncronization (THREAD_ENTRY * thread_p, PGBUF_LATCH_MODE latch_mode,
-								 const VPID & vpid);
-// Fix an old page with read latch; and if this is a PTS, check if it is ahead of replication.
-extern PAGE_PTR pgbuf_fix_read_old_and_check_repl_desync (THREAD_ENTRY * thread_p, const VPID & vpid,
-							  PGBUF_LATCH_CONDITION cond);
+extern int pgbuf_check_for_deallocated_page_or_desynchronization (THREAD_ENTRY * thread_p, PGBUF_LATCH_MODE latch_mode,
+								  const VPID & vpid);
+// Fix an old page with specific latch; and if this is a PTS, check if it is ahead of replication.
+extern PAGE_PTR pgbuf_fix_old_and_check_repl_desync (THREAD_ENTRY * thread_p, const VPID & vpid,
+						     PGBUF_LATCH_MODE latch_mode, PGBUF_LATCH_CONDITION cond);
 
 extern int pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int arg_cnt, void **ptr);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-381

Fallout from #3271 - http://jira.cubrid.org/browse/LETS-307

In function btree_find_oid_and_its_page page, `overflow_vpid` page was previously fixed with PGBUF_LATCH_WRITE which previous patch changed to PGBUF_LATCH_READ by means of `pgbuf_fix_read_old_and_check_repl_desync` implementation.
Refactor to make latch mode explicit as argument for function pgbuf_fix_old_and_check_repl_desync and adapted callers.
Corrected minor typo.
 
