### PR TITLE
[CBRD-24077] Fixed coredump occurring in vacuum when restoredb is executed with -d option.

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4178,19 +4178,7 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
 	   * in the log_Gl header. After a long session in SA_MODE, the vacuum_Data.last_page->data->blockid will
 	   * be outdated. Instead, SA_MODE updates log_Gl.hdr.vacuum_last_blockid before removing old archives.
 	   */
-	  VACUUM_LOG_BLOCKID last_blockid;
-
-	  if (vacuum_Data.is_restoredb_session)
-	    {
-	      last_blockid = vacuum_Data.last_page->data->blockid;
-	      log_Gl.hdr.vacuum_last_blockid = 0;
-	    }
-	  else
-	    {
-	      last_blockid = MAX (log_Gl.hdr.vacuum_last_blockid, vacuum_Data.last_page->data->blockid);
-	    }
-
-	  vacuum_Data.set_last_blockid (last_blockid);
+	  vacuum_Data.set_last_blockid (MAX (log_Gl.hdr.vacuum_last_blockid, vacuum_Data.last_page->data->blockid));
 
 	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 			 "vacuum_data_load_and_recover: set last_blockid = %lld to MAX("

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -4178,7 +4178,19 @@ vacuum_data_load_and_recover (THREAD_ENTRY * thread_p)
 	   * in the log_Gl header. After a long session in SA_MODE, the vacuum_Data.last_page->data->blockid will
 	   * be outdated. Instead, SA_MODE updates log_Gl.hdr.vacuum_last_blockid before removing old archives.
 	   */
-	  vacuum_Data.set_last_blockid (MAX (log_Gl.hdr.vacuum_last_blockid, vacuum_Data.last_page->data->blockid));
+	  VACUUM_LOG_BLOCKID last_blockid;
+
+	  if (vacuum_Data.is_restoredb_session)
+	    {
+	      last_blockid = vacuum_Data.last_page->data->blockid;
+	      log_Gl.hdr.vacuum_last_blockid = 0;
+	    }
+	  else
+	    {
+	      last_blockid = MAX (log_Gl.hdr.vacuum_last_blockid, vacuum_Data.last_page->data->blockid);
+	    }
+
+	  vacuum_Data.set_last_blockid (last_blockid);
 
 	  vacuum_er_log (VACUUM_ER_LOG_VACUUM_DATA | VACUUM_ER_LOG_RECOVERY,
 			 "vacuum_data_load_and_recover: set last_blockid = %lld to MAX("

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -5544,6 +5544,7 @@ log_recovery_resetlog (THREAD_ENTRY * thread_p, const LOG_LSA * new_append_lsa, 
   LOG_RESET_PREV_LSA (new_prev_lsa);
 
   log_Gl.hdr.mvcc_op_log_lsa.set_null ();
+  log_Gl.hdr.vacuum_last_blockid = 0;
 
   // set a flag that active log was reset; some operations may be affected
   log_Gl.hdr.was_active_log_reset = true;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24077

### Purpose
- The log_Gl.hdr.vacuum_last_blockid indicates the last block id that has been vacuumed in SA_MODE.
- When restoredb is executed, the vacuum data file also returns to the restore point, so the vacuum information performed in the last SA_MODE is not valid. (The important thing is that the record left by SA_MODE cannot be trusted because restoredb execution can change the database time point.)
- Looking at the reproduced cases registered in the issue, log_Gl.hdr.vacuum_last_blockid was updated with the latest information through vacuum_sa_reflect_last_blockid while diagdb was executed.
- Immediately afterward, it was restored to the past point in time through restoredb, and the vacuum data file was also restored to the past point in time.
- At this time, if the log_Gl.hdr.vacuum_last_blockid information is used, the information at the wrong time is used and a coredump occurs.

### Implementation
- N/A

### Remarks
- When vacuuming with SA_MODE, vacuum_sa_reflect_last_blockid() function always updates vacuum_sa_reflect_last_blockid and vacuum_Data.last_page->data->blockid to the same value.
- In case of abnormal termination in SA_MODE, vacuum_Data.last_page->data->blockid may be outdated than log_Gl.hdr.vacuum_last_blockid.
- A problem was found that the vacuum_sa_reflect_last_blockid() function was called even when the vacuum was set to skip the vacuum when csql and restoredb were executed. I am reviewing any issues that may arise from this, and I would like to address this as a different PR or issue.