### PR TITLE
[CBRD-24157] Make invalidate_snapshot enable unconditionally in flags of CONN_ENTRY

### DIFF
--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -346,7 +346,7 @@ css_send_close_request (CSS_CONN_ENTRY * conn)
 	{
 	  flags |= NET_HEADER_FLAG_INVALIDATE_SNAPSHOT;
 	}
-      header.flags = ntohs (flags);
+      header.flags = htons (flags);
       header.db_error = htonl (conn->db_error);
       /* timeout in milli-second in css_net_send() */
       css_net_send (conn, (char *) &header, sizeof (NET_HEADER), -1);

--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -333,6 +333,15 @@ css_send_close_request (CSS_CONN_ENTRY * conn)
       header.type = htonl (CLOSE_TYPE);
       header.transaction_id = htonl (conn->get_tran_index ());
       flags = 0;
+
+  /**
+   * FIXME!!
+   * make NET_HEADER_FLAG_INVALIDATE_SNAPSHOT be enabled always due to CBRD-24157
+   *
+   * flags was mis-readed at css_read_header() and fixed at CBRD-24118.
+   * But The side effects described in CBRD-24157 occurred.
+   */
+      conn->invalidate_snapshot = 1;
       if (conn->invalidate_snapshot)
 	{
 	  flags |= NET_HEADER_FLAG_INVALIDATE_SNAPSHOT;

--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -341,8 +341,7 @@ css_send_close_request (CSS_CONN_ENTRY * conn)
    * flags was mis-readed at css_read_header() and fixed at CBRD-24118.
    * But The side effects described in CBRD-24157 occurred.
    */
-      conn->invalidate_snapshot = 1;
-      if (conn->invalidate_snapshot)
+      if (true)			// if (conn->invalidate_snapshot)
 	{
 	  flags |= NET_HEADER_FLAG_INVALIDATE_SNAPSHOT;
 	}

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1431,8 +1431,7 @@ css_abort_request (CSS_CONN_ENTRY * conn, unsigned short rid)
    * flags was mis-readed at css_read_header() and fixed at CBRD-24118.
    * But The side effects described in CBRD-24157 occurred.
    */
-  conn->invalidate_snapshot = 1;
-  if (conn->invalidate_snapshot)
+  if (true)			// if (conn->invalidate_snapshot)
     {
       flags |= NET_HEADER_FLAG_INVALIDATE_SNAPSHOT;
     }

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1424,6 +1424,14 @@ css_abort_request (CSS_CONN_ENTRY * conn, unsigned short rid)
   header.request_id = htonl (rid);
   header.transaction_id = htonl (conn->get_tran_index ());
 
+  /**
+   * FIXME!!
+   * make NET_HEADER_FLAG_INVALIDATE_SNAPSHOT be enabled always due to CBRD-24157
+   *
+   * flags was mis-readed at css_read_header() and fixed at CBRD-24118.
+   * But The side effects described in CBRD-24157 occurred.
+   */
+  conn->invalidate_snapshot = 1;
   if (conn->invalidate_snapshot)
     {
       flags |= NET_HEADER_FLAG_INVALIDATE_SNAPSHOT;

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -1486,10 +1486,19 @@ css_set_net_header (NET_HEADER * header_p, int type, short function_code, int re
   header_p->transaction_id = htonl (transaction_id);
   header_p->db_error = htonl (db_error);
 
+  /**
+   * FIXME!!
+   * make NET_HEADER_FLAG_INVALIDATE_SNAPSHOT be enabled always due to CBRD-24157
+   *
+   * flags was mis-readed at css_read_header() and fixed at CBRD-24118.
+   * But The side effects described in CBRD-24157 occurred.
+   */
+  invalidate_snapshot = 1;
   if (invalidate_snapshot)
     {
       flags |= NET_HEADER_FLAG_INVALIDATE_SNAPSHOT;
     }
+
   header_p->flags = htons (flags);
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24157

Incorrect bitset when checking invalidate_snapshot is fixed at CBRD-24118. the following shows an example.
```
... css_read_header()
{
...
- conn->invalidate_snapshot = flags | NET_HEADER_FLAG_INVALIDATE_SNAPSHOT ? 1 : 0;
+ conn->invalidate_snapshot = flags & NET_HEADER_FLAG_INVALIDATE_SNAPSHOT ? 1 : 0;
}
```
But The side effects described in CBRD-24157 occurred. To avoid regression fails, temporarily, This PR makes invalidate_snapshot enable unconditionally 