### PR TITLE
[CBRD-24140] Suppress javasp's utility message when javasp is started from server routine

### DIFF
--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -202,9 +202,7 @@ main (int argc, char *argv[])
 	// check java stored procedure is not enabled
 	if (prm_get_bool_value (PRM_ID_JAVA_STORED_PROCEDURE) == false)
 	  {
-	    char err_msg[PATH_MAX];
-	    snprintf (err_msg, PATH_MAX, "%s system parameter is not enabled", prm_get_name (PRM_ID_JAVA_STORED_PROCEDURE));
-	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_CANNOT_START_JVM, 1, err_msg);
+	    fprintf (stdout, "%s system parameter is not enabled\n", prm_get_name (PRM_ID_JAVA_STORED_PROCEDURE));
 	    status = ER_SP_CANNOT_START_JVM;
 	    goto exit;
 	  }

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -262,10 +262,11 @@ static int process_server (int command_type, int argc, char **argv, bool show_us
 			   bool process_window_service);
 static int process_broker (int command_type, int argc, const char **argv, bool process_window_service);
 static int process_manager (int command_type, bool process_window_service);
-static int process_javasp (int command_type, int argc, const char **argv, bool show_usage, bool process_window_service);
-static int process_javasp_start (const char *db_name, bool process_window_service);
-static int process_javasp_stop (const char *db_name, bool process_window_service);
-static int process_javasp_status (const char *db_name);
+static int process_javasp (int command_type, int argc, const char **argv, bool show_usage, bool suppress_message,
+			   bool process_window_service);
+static int process_javasp_start (const char *db_name, bool suppress_message, bool process_window_service);
+static int process_javasp_stop (const char *db_name, bool suppress_message, bool process_window_service);
+static int process_javasp_status (const char *db_name, bool suppress_message);
 static int process_heartbeat (int command_type, int argc, const char **argv);
 static int process_heartbeat_start (HA_CONF * ha_conf, int argc, const char **argv);
 static int process_heartbeat_stop (HA_CONF * ha_conf, int argc, const char **argv);
@@ -681,7 +682,7 @@ main (int argc, char *argv[])
 #endif /* !WINDOWs */
       break;
     case JAVASP_UTIL:
-      status = process_javasp (command_type, argc - 3, (const char **) &argv[3], true, process_window_service);
+      status = process_javasp (command_type, argc - 3, (const char **) &argv[3], true, false, process_window_service);
       break;
     default:
       goto usage;
@@ -1327,7 +1328,7 @@ process_service (int command_type, bool process_window_service)
 	{
 	  if (!are_all_services_stopped (0, process_window_service))
 	    {
-	      (void) process_javasp (command_type, 0, NULL, false, process_window_service);
+	      (void) process_javasp (command_type, 0, NULL, false, false, process_window_service);
 
 	      if (strcmp (get_property (SERVICE_START_SERVER), PROPERTY_ON) == 0
 		  && us_Property_map[SERVER_START_LIST].property_value != NULL
@@ -1380,7 +1381,7 @@ process_service (int command_type, bool process_window_service)
 	const char *args[] = { "-b" };
 
 	(void) process_server (command_type, 0, NULL, false, true, false);
-	(void) process_javasp (command_type, 0, NULL, true, false);
+	(void) process_javasp (command_type, 0, NULL, true, false, false);
 	(void) process_broker (command_type, 1, args, false);
 	(void) process_manager (command_type, false);
 	if (strcmp (get_property (SERVICE_START_HEARTBEAT), PROPERTY_ON) == 0)
@@ -1734,7 +1735,8 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 		  /* run javasp server if DB server is started successfully */
 		  if (status == NO_ERROR)
 		    {
-		      (void) process_javasp (command_type, 1, (const char **) &token, false, process_window_service);
+		      (void) process_javasp (command_type, 1, (const char **) &token, false, true,
+					     process_window_service);
 		    }
 		}
 	    }
@@ -1752,7 +1754,7 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 	  /* try to stop javasp server first */
 	  if (is_javasp_running (token) == JAVASP_SERVER_RUNNING)
 	    {
-	      (void) process_javasp (command_type, 1, (const char **) &token, false, process_window_service);
+	      (void) process_javasp (command_type, 1, (const char **) &token, false, true, process_window_service);
 	    }
 
 	  print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_SERVER_NAME, PRINT_CMD_STOP, token);
@@ -2436,19 +2438,25 @@ is_javasp_running (const char *server_name)
 }
 
 static int
-process_javasp_start (const char *db_name, bool process_window_service)
+process_javasp_start (const char *db_name, bool suppress_message, bool process_window_service)
 {
   static const int wait_timeout = 30;
   int waited_secs = 0;
   int pid = 0;
   int status = ER_GENERIC_ERROR;
 
-  print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_JAVASP_NAME, PRINT_CMD_START, db_name);
+  if (!suppress_message)
+    {
+      print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_JAVASP_NAME, PRINT_CMD_START, db_name);
+    }
 
   UTIL_JAVASP_SERVER_STATUS_E javasp_status = is_javasp_running (db_name);
   if (javasp_status == JAVASP_SERVER_RUNNING)
     {
-      print_message (stdout, MSGCAT_UTIL_GENERIC_ALREADY_RUNNING_2S, PRINT_JAVASP_NAME, db_name);
+      if (!suppress_message)
+	{
+	  print_message (stdout, MSGCAT_UTIL_GENERIC_ALREADY_RUNNING_2S, PRINT_JAVASP_NAME, db_name);
+	}
       util_log_write_errid (MSGCAT_UTIL_GENERIC_ALREADY_RUNNING_2S, PRINT_JAVASP_NAME, db_name);
     }
   else
@@ -2502,19 +2510,29 @@ process_javasp_start (const char *db_name, bool process_window_service)
 		}
 	    }
 	}
-      print_result (PRINT_JAVASP_NAME, status, START);
+      if (!suppress_message)
+	{
+	  print_result (PRINT_JAVASP_NAME, status, START);
+	}
+      else
+	{
+	  fprintf (stdout, "Calling java stored procedure %s allowed\n", (status == NO_ERROR) ? "is" : "is not");
+	}
     }
   return status;
 }
 
 static int
-process_javasp_stop (const char *db_name, bool process_window_service)
+process_javasp_stop (const char *db_name, bool suppress_message, bool process_window_service)
 {
   int status = NO_ERROR;
   static const int wait_timeout = 5;
   int waited_secs = 0;
 
-  print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_JAVASP_NAME, PRINT_CMD_STOP, db_name);
+  if (!suppress_message)
+    {
+      print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_JAVASP_NAME, PRINT_CMD_STOP, db_name);
+    }
   UTIL_JAVASP_SERVER_STATUS_E javasp_status = is_javasp_running (db_name);
   if (javasp_status == JAVASP_SERVER_RUNNING)
     {
@@ -2540,12 +2558,18 @@ process_javasp_stop (const char *db_name, bool process_window_service)
 	    }
 	  while (status != NO_ERROR && waited_secs < wait_timeout);
 	}
-      print_result (PRINT_JAVASP_NAME, status, STOP);
+      if (!suppress_message)
+	{
+	  print_result (PRINT_JAVASP_NAME, status, STOP);
+	}
     }
   else
     {
       status = ER_GENERIC_ERROR;
-      print_message (stdout, MSGCAT_UTIL_GENERIC_NOT_RUNNING_2S, PRINT_JAVASP_NAME, db_name);
+      if (!suppress_message)
+	{
+	  print_message (stdout, MSGCAT_UTIL_GENERIC_NOT_RUNNING_2S, PRINT_JAVASP_NAME, db_name);
+	}
       util_log_write_errid (MSGCAT_UTIL_GENERIC_NOT_RUNNING_2S, PRINT_JAVASP_NAME, db_name);
     }
 
@@ -2573,7 +2597,8 @@ process_javasp_status (const char *db_name)
 }
 
 static int
-process_javasp (int command_type, int argc, const char **argv, bool show_usage, bool process_window_service)
+process_javasp (int command_type, int argc, const char **argv, bool show_usage, bool suppress_message,
+		bool process_window_service)
 {
   const int buf_size = 4096;
   char *buf = NULL;
@@ -2594,8 +2619,7 @@ process_javasp (int command_type, int argc, const char **argv, bool show_usage, 
     }
   else				/* cubrid javasp command */
     {
-      buf = (char *) malloc (buf_size);
-      memset (buf, 0, buf_size);
+      buf = (char *) calloc (sizeof (char), buf_size);
       strncpy (buf, argv[0], buf_size);
     }
 
@@ -2610,7 +2634,7 @@ process_javasp (int command_type, int argc, const char **argv, bool show_usage, 
       goto exit;
     }
 
-  if (command_type == STATUS)
+  if (command_type == STATUS && !suppress_message)
     {
       print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_2S, PRINT_JAVASP_NAME, PRINT_CMD_STATUS);
     }
@@ -2626,14 +2650,14 @@ process_javasp (int command_type, int argc, const char **argv, bool show_usage, 
       switch (command_type)
 	{
 	case START:
-	  status = process_javasp_start (db_name, process_window_service);
+	  status = process_javasp_start (db_name, suppress_message, process_window_service);
 	  break;
 	case STOP:
-	  status = process_javasp_stop (db_name, process_window_service);
+	  status = process_javasp_stop (db_name, suppress_message, process_window_service);
 	  break;
 	case RESTART:
-	  status = process_javasp_stop (db_name, process_window_service);
-	  status = process_javasp_start (db_name, process_window_service);
+	  status = process_javasp_stop (db_name, suppress_message, process_window_service);
+	  status = process_javasp_start (db_name, suppress_message, process_window_service);
 	  break;
 	case STATUS:
 	  status = process_javasp_status (db_name);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24140

- It suppress javasp's utlity mesasge when javasp is started in process_server()
- if utility message is suppressed, console messages are displayed to give information to user whether javasp server is successfully stared or not

For `cubrid server start`,

bash> cubrid server start demodb
 
set java_stored_procedure=no in cubrid.conf
```
@ cubrid server start: demodb
This may take a long time depending on the amount of recovery works to do.
CUBRID 11.2 (11.2.0.0449) (64 debug build)
++ cubrid server start: success
java_stored_procedure system parameter is not enabled
Calling java stored procedure is not allowed
```
 
set java_stored_procedure=yes in cubrid.conf
```
@ cubrid server start: demodb
This may take a long time depending on the amount of recovery works to do.
CUBRID 11.2 (11.2.0.0449) (64 debug build)
++ cubrid server start: success
Calling java stored procedure is allowed
```

Note that if an error is occured during running javasp server
```
bash> export JAVA_HOME=invalid_path
```
```
@ cubrid server start: demodb
This may take a long time depending on the amount of recovery works to do.
CUBRID 11.2 (11.2.0.0448) (64 debug build)
++ cubrid server start: success
Java VM library is not found:
        Failed to get 'JVM_PATH' environment variable
        Failed to load libjvm from 'JAVA_HOME' environment variable:
                /usr/lib/jvm/java-1.8/jre/lib/amd64/server/libjvm.so: cannot open shared object file: No such file or directory
                /usr/lib/jvm/java-1.8/lib/server/libjvm.so: cannot open shared object file: No such file or directory.
Calling java stored procedure is not allowed
```
