### PR TITLE
[CBRD-23839] shell script for unloaddb concurrently by sub-processes

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -105,6 +105,6 @@ endif(UNIX)
 # multi-process unloaddb scripts
 if(UNIX)
   install(PROGRAMS
-    ${CMAKE_SOURCE_DIR}/contrib/script/unloaddb.sh.sh
+    ${CMAKE_SOURCE_DIR}/contrib/scripts/unloaddb.sh
     DESTINATION ${CUBRID_DATADIR}/scripts/)
 endif(UNIX)

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -102,3 +102,9 @@ if(UNIX)
     DESTINATION ${CUBRID_DATADIR}/install/)
 endif(UNIX)
 
+# multi-process unloaddb scripts
+if(UNIX)
+  install(PROGRAMS
+    ${CMAKE_SOURCE_DIR}/contrib/script/unloaddb.sh.sh
+    DESTINATION ${CUBRID_DATADIR}/scripts/)
+endif(UNIX)

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -277,12 +277,13 @@ function analyze_table_info ()
         local idx=0
         local table_name
         local db=$database
+        local query="show tables"
 
-        # Get all table names from CATALOG
+        # Get all table names if $from_file equals 0, otherwise from input file
         if [ $from_file -eq 1 ];then  # Read table name from file
                 result=$(cat $filename)
         else
-                result=$(csql $user $pass -c "select class_name from db_class where is_system_class = 'NO' AND class_type = 'CLASS' order by class_name" $db)
+                result=$(csql $user $pass -c "$query" $db)
         fi
 
         for token in $result

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -94,18 +94,9 @@ function verify_user_pass ()
 	local dbuser
 	local passwd
 	local qry_dba_grp="SELECT u.name FROM db_user AS u, TABLE(u.groups) AS g(x) where x.name = 'DBA'"
-	local retcode
 
 	dbuser=$(echo ${user} | cut -d' ' -f2-2)
 	USERNAME=$(echo ${dbuser} | tr [:lower:] [:upper:])
-
-	# check the database server is running
-	retcode=$(ps -ef | grep cub_server | grep $database | wc -l)
-
-	if [ $retcode -eq 0 ];then
-		echo "Database server '$database' is not running"
-		exit 1
-	fi
 
 	dba_groups=$(csql -u public -l -c "$qry_dba_grp" $database | grep -w $USERNAME | wc -l)
 
@@ -339,7 +330,14 @@ if [ ! -d $target_dir ];then
         echo "$target_dir: directory not exists or permission denied"
         exit
 else
-   silent_cd $target_dir
+        silent_cd $target_dir
+fi
+
+# check the database server is running
+retcode=$(ps -ef | grep cub_server | grep $database | wc -l)
+if [ $retcode -eq 0 ];then
+        echo "Database server '$database' is not running"
+        exit 1
 fi
 
 verify_user_pass

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -168,7 +168,6 @@ function get_table_size ()
         local table_name=$1
         local Avg_rec_len=0
         local table_size=0
-        local csql_output
 
         num_rows=$(csql $user $pass -l -c "show heap capacity of $table_name" $db | grep Num_recs | awk '{print $3}')
         Avg_rec_len=$(csql $user $pass -l -c "show heap capacity of $table_name" $db | grep Avg_rec_len | awk '{print $3}')

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -387,7 +387,9 @@ done
 #
 for ((i = 0; i < $num_proc; i++))
 do
-	(silent_cd $database.$i; do_unloaddb $i) &
+        if [ ${slot_size[i]} -gt 0 ];then
+	       (silent_cd $database.$i; do_unloaddb $i) &
+        fi
 done
 
 wait

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -27,7 +27,6 @@ num_tables_slot=(0 0 0 0 0 0 0 0)
 database=
 user="-u dba"
 pass=""
-password=""
 total_pages=0
 from_file=""
 target_dir=$(pwd)
@@ -95,9 +94,18 @@ function verify_user_pass ()
 	local dbuser
 	local passwd
 	local qry_dba_grp="SELECT u.name FROM db_user AS u, TABLE(u.groups) AS g(x) where x.name = 'DBA'"
+	local retcode
 
 	dbuser=$(echo ${user} | cut -d' ' -f2-2)
 	USERNAME=$(echo ${dbuser} | tr [:lower:] [:upper:])
+
+	# check the database server is running
+	retcode=$(ps -ef | grep cub_server | grep $database | wc -l)
+
+	if [ $retcode -eq 0 ];then
+		echo "Database server '$database' is not running"
+		exit 1
+	fi
 
 	dba_groups=$(csql -u public -l -c "$qry_dba_grp" $database | grep -w $USERNAME | wc -l)
 

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -143,6 +143,7 @@ function get_options ()
                         v ) verbose="yes" ;;
                         s ) opt_schema=1 ;;
                         d ) opt_data=1 ;;
+                        \? ) echo "unknown option -$OPTARG"; show_usage; exit 1 ;;
                 esac
         done
 

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -318,8 +318,6 @@ fi
 if [ ! -d $target_dir ];then
         echo "$target_dir: directory not exists or permission denied"
         exit
-else
-        silent_cd $target_dir
 fi
 
 check_database $database
@@ -367,7 +365,7 @@ do
 			exit 1
 		fi
 
-		mkdir $database.$i
+		mkdir $target_dir/$database.$i
 	fi
 done
 
@@ -377,7 +375,7 @@ done
 for ((i = 0; i < $num_proc; i++))
 do
         if [ ${slot_size[i]} -gt 0 ];then
-	       (silent_cd $database.$i; do_unloaddb $i) &
+	       (silent_cd $target_dir/$database.$i; do_unloaddb $i) &
         fi
 done
 

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #
 #  Copyright 2016 CUBRID Corporation

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -17,13 +17,15 @@
 #
 
 verbose="no"   # set 'yes' for verbose mode
+max_num_proc=16
 num_proc=8
 table_size=()
 table_selected=()
 num_tables=0
 slot_selected=0
-slot_size=(0 0 0 0 0 0 0 0)
-num_tables_slot=(0 0 0 0 0 0 0 0)
+# following two variable are depend on max_num_proc
+slot_size=(0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)
+num_tables_slot=(0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)
 database=""
 user="-u dba"
 pass=""
@@ -319,6 +321,11 @@ get_options "$@"
 if [ $num_args_remain -ne 1 ] || [ -z $database ];then
         show_usage
         exit 1
+fi
+
+if [ $num_proc -gt $max_num_proc ];then
+        echo "Num Proc exeed Max Proc. Force set num proc to $max_num_proc"
+        num_proc=$max_num_proc
 fi
 
 if [ ! -d $target_dir ];then

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -146,7 +146,7 @@ function get_options ()
         database=$*
 }
 
-function check_database ()
+function is_db_server_running ()
 {
         local db=$database
 
@@ -348,7 +348,7 @@ if [ ! -z $filename ] && [ ${filename:0:1} != "/" ];then
         filename="$cwd/"$filename
 fi
 
-check_database $database
+is_db_server_running $database
 
 logdir=$cwd"/"$database"_"unloaddb.log
 if [ -d $logdir ];then

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -131,26 +131,15 @@ function get_options ()
                         v ) verbose="yes" ;;
                 esac
         done
+
+        shift $(($OPTIND - 1))
+        database="$*"
+        echo $#
 }
 
 function silent_cd ()
 {
         cd $* > /dev/null
-}
-
-function extract_db_name ()
-{
-        local nelem=$#
-        local i
-
-        # extract last argument & set as database name
-
-        if [ $nelem -eq 0 ];then
-                show_usage
-                exit
-        fi
-
-        database=$(echo ${@:$nelem:1})
 }
 
 function get_table_size ()
@@ -324,7 +313,10 @@ trap "cleanup" SIGHUP SIGINT SIGTERM
 set -o monitor
 
 extract_db_name $*
-get_options "$@"
+if [ $(get_options "$@") -ne 1 ];then
+        show_usage
+        exit 1
+fi
 
 if [ ! -d $target_dir ];then
         echo "$target_dir: directory not exists or permission denied"

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -142,6 +142,21 @@ function get_options ()
         database=$*
 }
 
+function check_database ()
+{
+        local db=$database
+
+        # check the database server is running
+
+        db=${database%%@*}
+
+        retcode=$(ps -ef | grep cub_server | grep $db | wc -l)
+        if [ $retcode -eq 0 ];then
+                echo "Database server '$database' is not running"
+              exit 1
+        fi
+}
+
 function silent_cd ()
 {
         cd $* > /dev/null
@@ -323,6 +338,8 @@ if [ $num_args_remain -ne 1 ] || [ -z $database ];then
         exit 1
 fi
 
+check_database $database
+
 if [ $num_proc -gt $max_num_proc ];then
         echo "Num Proc exeed Max Proc. Force set num proc to $max_num_proc"
         num_proc=$max_num_proc
@@ -335,12 +352,7 @@ else
         silent_cd $target_dir
 fi
 
-# check the database server is running
-retcode=$(ps -ef | grep cub_server | grep $database | wc -l)
-if [ $retcode -eq 0 ];then
-        echo "Database server '$database' is not running"
-        exit 1
-fi
+
 
 verify_user_pass
 

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -37,7 +37,7 @@ slot=()
 
 function show_usage ()
 {
-         echo "Usage: $0 [OPTIONS] [TARGET]"
+         echo "Usage: $0 [OPTIONS] [database]"
          echo " OPTIONS"
          echo "  -t arg  Set number of parallel process; default 8"
          echo "  -i arg  input FILE of table names; default: dump all classes"

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -41,10 +41,9 @@ function show_usage ()
 {
          echo "Usage: $0 [OPTIONS] [database]"
          echo " OPTIONS"
-         echo "  -t arg  Set number of parallel process; default 8"
+         echo "  -t arg  Set number of parallel process; default 8, max 16"
          echo "  -i arg  input FILE of table names; default: dump all classes"
          echo "  -u arg  Set database user name; default dba"
-         echo "  -p arg  Set dbuser password"
          echo "  -D arg  Set directory for unloaddb output dir/files"
          echo "  -v      Set verbose mode on"
 

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -296,6 +296,10 @@ function analyze_table_info ()
                         continue
                 fi
 
+                # if table name comes from csql it is the pattern of 'code'
+                # and end with string like this
+                # "\n16 rows selected. (0.009125 sec) Committed."
+                # If it comes from file it is the pattern of code
                 if [ $from_file -eq 0 ] && [ ${token:0:1} != "'" ];then
                         break
                 fi

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -1,0 +1,394 @@
+#!/bin/sh
+#
+#
+#  Copyright 2016 CUBRID Corporation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+verbose="no"   # set 'yes' for verbose mode
+num_proc=8
+table_size=()
+table_selected=()
+num_tables=0
+slot_selected=0
+slot_size=(0 0 0 0 0 0 0 0)
+num_tables_slot=(0 0 0 0 0 0 0 0)
+database=
+user="-u dba"
+pass=""
+password=""
+total_pages=0
+from_file=""
+target_dir=$(pwd)
+
+slot=()
+
+function show_usage ()
+{
+         echo "Usage: $0 [OPTIONS] [TARGET]"
+         echo " OPTIONS"
+         echo "  -t arg  Set number of parallel process; default 8"
+         echo "  -i arg  input FILE of table names; default: dump all classes"
+         echo "  -u arg  Set database user name; default dba"
+         echo "  -p arg  Set dbuser password"
+         echo "  -D arg  Set directory for unloaddb output dir/files"
+         echo "  -v      Set verbose mode on"
+
+         echo ""
+         echo " EXAMPLES"
+         echo "  $0 -t 4 -v demodb          # unload all tables in demodb"
+         echo "  $0 -i file demodb          # unload tables listed in file in demodb"
+         echo "  $0 -u user1 -D /tmp -i file -t 4 -v demodb"
+         echo ""
+}
+
+#
+# Kill unloaddb processes in progress and delete the directory, and delete incomplete files
+# Directories/files created by the normally terminated unloaddb process is not deleted.
+#
+function cleanup ()
+{
+        local i
+        local pid
+        local exit_stat
+
+	echo "interrupted"
+
+        for ((i = 0; i < $num_proc; i++))
+        do
+                if [ -f $database.$i/unloaddb_$i.pid ];then
+                        pid=$(cat $database.$i/unloaddb_$i.pid)
+
+                        kill -0 $pid 2> /dev/null
+                        if [ $? -eq 0 ];then
+                                kill -9 $pid
+                                rm -rf $database.$i
+                        fi
+                fi
+        done
+}
+
+function get_password ()
+{
+	local password
+
+	read -sp "Enter Password : " password
+	echo $password
+	echo "" > /dev/tty
+}
+
+function verify_user_pass ()
+{
+	local msg
+	local USERNAME
+	local dbuser
+	local passwd
+	local qry_dba_grp="SELECT u.name FROM db_user AS u, TABLE(u.groups) AS g(x) where x.name = 'DBA'"
+
+	dbuser=$(echo ${user} | cut -d' ' -f2-2)
+	USERNAME=$(echo ${dbuser} | tr [:lower:] [:upper:])
+
+	dba_groups=$(csql -u public -l -c "$qry_dba_grp" $database | grep -w $USERNAME | wc -l)
+
+	if [ $USERNAME != "DBA" ] && [ $dba_groups -eq 0 ];then
+		echo "User '$dbuser' is not a member of DBA group"
+		exit 2
+	fi
+
+	# Try with NULL password
+	passwd=$(csql $user --password="" -c "SELECT 1" $database 2> /dev/null)
+
+	if [ $? -ne 0 ];then
+		passwd=$(get_password)
+		pass="-p $passwd"
+
+		passwd=$(csql $user $pass -c "SELECT 1" $database 2> /dev/null)
+		if [ $? -ne 0 ];then
+			echo "$dbuser: Incorrect or missing password"
+			exit 4
+		fi
+	fi
+}
+
+function get_options ()
+{
+         while getopts ":D:u:i:t:v" opt; do
+                case $opt in
+                        u ) user="-u $OPTARG" ;;
+                        i ) from_file="$OPTARG" ;;
+                        t ) num_proc="$OPTARG" ;;
+                        D ) target_dir="$OPTARG" ;;
+                        v ) verbose="yes" ;;
+                esac
+        done
+}
+
+function silent_cd ()
+{
+        cd $* > /dev/null
+}
+
+function extract_db_name ()
+{
+        local nelem=$#
+        local i
+
+        # extract last argument & set as database name
+
+        if [ $nelem -eq 0 ];then
+                show_usage
+                exit
+        fi
+
+        database=$(echo ${@:$nelem:1})
+}
+
+function get_table_size ()
+{
+        local num_rows=0
+        local table_name=$1
+        local row_size=0
+        local table_size=0
+
+        num_rows=$(csql $user $pass -l -c "show heap capacity of $table_name" $db | grep Num_recs | awk '{print $3}')
+        row_size=$(get_schema_size $table_name)
+        let "table_size = num_rows * row_size"
+
+        echo $table_size
+}
+
+function get_schema_size ()
+{
+        local table_name=$1
+        local size=0
+        local query=" select CAST(SUM(CASE \
+         WHEN "data_type" = 'BIGINT' THEN 8.0 \
+         WHEN "data_type" = 'INTEGER' THEN 4.0 \
+         WHEN "data_type" = 'SMALLINT' THEN 2.0 \
+         WHEN "data_type" = 'FLOAT' THEN 4.0 \
+         WHEN "data_type" = 'DOUBLE' THEN 8.0 \
+         WHEN "data_type" = 'MONETARY' THEN 12.0 \
+         WHEN "data_type" = 'STRING' THEN prec \
+         WHEN "data_type" = 'VARCHAR' THEN prec \
+         WHEN "data_type" = 'NVARCHAR' THEN prec \
+         WHEN "data_type" = 'CHAR' THEN prec \
+         WHEN "data_type" = 'NCHAR' THEN prec \
+         WHEN "data_type" = 'TIMESTAMP' THEN 8.0 \
+         WHEN "data_type" = 'DATE' THEN 4.0 \
+         WHEN "data_type" = 'TIME' THEN 4.0 \
+         WHEN "data_type" = 'DATETIME' THEN 4.0 \
+         WHEN "data_type" = 'BIT' THEN FLOOR(prec / 8.0) \
+         WHEN "data_type" = 'BIT VARYING' THEN FLOOR(prec / 8.0) \
+         ELSE 0 \
+     END) as BIGINT)  AS [size] \
+ from db_attribute where class_name = '$table_name';"
+
+        if [ $# -eq 0 ];then
+                echo "0"
+                return
+        fi
+
+        size=$(csql $user $pass -l -c "$query" $db | grep "^<0000" | awk '{print $3}')
+        echo $size
+}
+
+function find_slot ()
+{
+        local selected=0
+        local i
+        local size=${slot_size[0]}
+
+        for ((i = 0; i < $num_proc; i++))
+        do
+                if [ ${slot_size[i]} -lt $size ];then
+                        size=${slot_size[i]}
+                        selected=$i
+                fi
+        done
+
+         echo $selected
+}
+
+function do_unloaddb ()
+{
+        local slot_num=$1
+        local i
+        local file="Tables_unloaded_$database.$slot_num"
+        local num_tables_in_slot=0
+        local msg="Success"
+        local pid
+
+        for ((i = 0; i < $num_tables; i++))
+        do
+                if [ ${slot[i]} -eq $slot_num ];then
+                        let "num_tables_in_slot++"
+                        echo "${table_selected[i]}" >> $file
+                fi
+        done
+
+        if [ $verbose = "yes" ];then
+                echo "Proc $slot_num: num tables: $num_tables_in_slot, ${slot_size[$slot_num]} bytes"
+        fi
+
+        echo "process $slot_num: starting" > unloaddb_$slot_num.status
+
+	cubrid unloaddb $user $pass --input-class-only --input-class-file $file $database &
+        pid=$!
+
+        echo $pid > unloaddb_$slot_num.pid
+
+        wait $pid
+
+        if [ $? -ne 0 ];then
+                msg="Failed"
+                echo "process $slot_num: failed" > unloaddb_$slot_num.status
+        else
+                echo "process $slot_num: success" > unloaddb_$slot_num.status
+        fi
+
+        if [ $verbose = "yes" ];then
+                echo "Finished Proc $slot_num ($msg)"
+        fi
+}
+
+function analyze_table_info ()
+{
+        local found=0
+        local line
+        local idx=0
+        local table_name
+        local db=$database
+
+        # Get all table names from CATALOG
+
+        if [ X$from_file != X"" ];then  # Read table name from file
+                result=$(cat $from_file)
+        else
+                result=$(csql $user $pass -c "select class_name from db_class where is_system_class = 'NO' AND class_type = 'CLASS' order by class_name" $db)
+        fi
+
+        for token in $result
+        do
+                if  [ X$from_file = X"" ] && [ $found -eq 0 ];then
+                        str=$(echo $token | grep "====") # skip until we found table names in csql
+                        if [ $? -eq 0 ];then
+                                found=1
+                        fi
+                        continue
+                fi
+
+                if [ X$from_file = X"" ] && [ ${token:0:1} != "'" ];then
+                        break
+                fi
+
+                table_selected[idx]="$token"
+
+                if [ X$from_file = X"" ];then        # remove single quota from csql output
+                        table_selected[idx]=$(echo ${table_selected[idx]} | sed "s/[\']//g")
+                fi
+
+                let "idx++"
+
+        done
+
+        # Get the size of all tables
+        n=1
+        for ((i = 0; i < ${#table_selected[@]}; i++))
+        do
+                table_name=${table_selected[i]}
+                this_table_size=$(get_table_size $table_name)
+
+                if [ -z $this_table_size ];then
+                        echo "Unknown table: $table_name"
+                        exit
+                fi
+
+                table_size[$num_tables]="$this_table_size"
+                let "num_tables++"
+        done
+}
+
+# MAIN
+#
+trap "cleanup" SIGHUP SIGINT SIGTERM
+set -o monitor
+
+extract_db_name $*
+get_options "$@"
+
+if [ ! -d $target_dir ];then
+        echo "$target_dir: directory not exists or permission denied"
+        exit
+else
+   silent_cd $target_dir
+fi
+
+verify_user_pass
+
+echo -n "Analyzing table spacace ..."
+
+analyze_table_info $*
+
+if [ $num_tables -eq 0 ];then
+        echo "No Table SELECTED."
+        exit
+fi
+
+echo ""
+
+# Assign all tables to unloaddb slot
+# Assign and calculate total table size & num tables assigned in each slot
+for ((i = 0; i < $num_tables; i++))
+do
+        this_slot=$(find_slot)
+        tbl=${table_selected[i]}
+        slot[i]=$this_slot
+
+        let "slot_size[$this_slot]+=${table_size[$i]}"
+        let "num_tables_slot[$this_slot]++"
+        let "total_pages+=${table_size[$i]}"
+
+        if [ $verbose = "yes" ];then
+                index=$(printf "%3d" $i)
+                echo "[$index:${slot[i]}] ${table_selected[i]}: ${table_size[i]} bytes"
+        fi
+done
+
+echo "Total $num_tables tables, $total_pages pages"
+# Do unloaddb for each process
+#
+# check and create sub-directories for each process
+for ((i = 0; i < $num_proc; i++))
+do
+	if [ ${num_tables_slot[i]} -ne 0 ];then
+		if [ -f $database.$i ] || [ -d $database.$i ];then
+			echo "$database.$i: File or directory already exist."
+			exit 1
+		fi
+
+		mkdir $database.$i
+	fi
+done
+
+#
+# RUN unloaddb process cuncurrently
+#
+for ((i = 0; i < $num_proc; i++))
+do
+	(silent_cd $database.$i; do_unloaddb $i) &
+done
+
+wait
+
+echo "Completed."

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -438,7 +438,6 @@ echo ""
 for ((i = 0; i < $num_tables; i++))
 do
 	this_slot=$(find_least_loaded_proc)
-	tbl=${table_selected[i]}
 	slot[i]=$this_slot
 
 	let "slot_size[$this_slot]+=${table_size[$i]}"

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -51,6 +51,8 @@ function show_usage ()
          echo "  -u arg  Set database user name; default dba"
          echo "  -D arg  Set directory for unloaddb output dir/files"
          echo "  -v      Set verbose mode on"
+         echo "  -d      dump schema only; default: schema and objects"
+         echo "  -s      dump objects only; default: schema and objects"
 
          echo ""
          echo " EXAMPLES"

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -44,22 +44,43 @@ slot=()
 
 function show_usage ()
 {
-         echo "Usage: $0 [OPTIONS] [database]"
-         echo " OPTIONS"
-         echo "  -t arg  Set number of parallel process; default 8, max 16"
-         echo "  -i arg  input FILE of table names; default: dump all classes"
-         echo "  -u arg  Set database user name; default dba"
-         echo "  -D arg  Set directory for unloaddb output dir/files"
-         echo "  -v      Set verbose mode on"
-         echo "  -d      dump schema only; default: schema and objects"
-         echo "  -s      dump objects only; default: schema and objects"
+	echo "Usage: $0 [OPTIONS] [database]"
+	echo " OPTIONS"
+	echo "  -t arg  Set number of parallel process; default 8, max 16"
+	echo "  -i arg  input FILE of table names; default: dump all classes"
+	echo "  -u arg  Set database user name; default dba"
+	echo "  -D arg  Set directory for unloaddb output dir/files"
+	echo "  -v      Set verbose mode on"
+	echo "  -d      dump schema only; default: schema and objects"
+	echo "  -s      dump objects only; default: schema and objects"
 
-         echo ""
-         echo " EXAMPLES"
-         echo "  $0 -t 4 -v demodb          # unload all tables in demodb"
-         echo "  $0 -i file demodb          # unload tables listed in file in demodb"
-         echo "  $0 -u user1 -D /tmp -i file -t 4 -v demodb"
-         echo ""
+	echo ""
+	echo " EXAMPLES"
+	echo "  $0 -t 4 -v demodb          # unload all tables in demodb"
+	echo "  $0 -i file demodb          # unload tables listed in file in demodb"
+	echo "  $0 -u user1 -D /tmp -i file -t 4 -v demodb"
+	echo ""
+}
+
+function get_options ()
+{
+	   while getopts ":D:u:i:t:sdv" opt; do
+		    case $opt in
+				u ) user="-u $OPTARG" ;;
+				i ) filename="$OPTARG" ;from_file=1 ;;
+				t ) num_proc="$OPTARG" ;;
+				D ) target_dir="$OPTARG" ;;
+				v ) verbose="yes" ;;
+				s ) opt_schema=1 ;;
+				d ) opt_data=1 ;;
+				\? ) echo "unknown option -$OPTARG"; show_usage; exit 1 ;;
+		    esac
+	  done
+
+	  shift $(($OPTIND - 1))
+
+	  num_args_remain=$#
+	  database=$*
 }
 
 #
@@ -70,7 +91,6 @@ function cleanup ()
 {
 	local i
 	local pid
-	local exit_stat
 	local pid_file
 
 	echo "interrupted"
@@ -78,6 +98,7 @@ function cleanup ()
 	for ((i = 0; i < $num_proc; i++))
 	do
 		pid_file=$logdir/"$database"_$i.pid
+
 		if [ -f $pid_file ];then
 			pid=$(cat $pid_file)
 
@@ -125,233 +146,242 @@ function verify_user_pass ()
 
 	fi
 
-        dba_groups=$(csql $user $pass -l -c "$qry_dba_grp" $database | grep -w $USERNAME | wc -l)
-        if [ $USERNAME != "DBA" ] && [ $dba_groups -eq 0 ];then
-                echo "User '$dbuser' is not a member of DBA group"
-                exit 2
-        fi
+	# check whether this user is a member of DBA groups
+	#
+	dba_groups=$(csql $user $pass -l -c "$qry_dba_grp" $database | grep -w $USERNAME | wc -l)
+	if [ $USERNAME != "DBA" ] && [ $dba_groups -eq 0 ];then
+		echo "User '$dbuser' is not a member of DBA group"
+		exit 2
+	fi
 }
 
-function get_options ()
-{
-         while getopts ":D:u:i:t:sdv" opt; do
-                case $opt in
-                        u ) user="-u $OPTARG" ;;
-                        i ) filename="$OPTARG" ;from_file=1 ;;
-                        t ) num_proc="$OPTARG" ;;
-                        D ) target_dir="$OPTARG" ;;
-                        v ) verbose="yes" ;;
-                        s ) opt_schema=1 ;;
-                        d ) opt_data=1 ;;
-                        \? ) echo "unknown option -$OPTARG"; show_usage; exit 1 ;;
-                esac
-        done
-
-        shift $(($OPTIND - 1))
-
-        num_args_remain=$#
-        database=$*
-}
-
+#
+# exit, if subject db server is not running
+#
 function is_db_server_running ()
 {
-        local db=$database
+	local db=$database
 
-        # check the database server is running
+	db=${database%%@*}
 
-        db=${database%%@*}
-
-        retcode=$(ps -ef | grep cub_server | grep $db | wc -l)
-        if [ $retcode -eq 0 ];then
-                echo "Database server '$database' is not running"
-              exit 1
-        fi
+	retcode=$(ps -ef | grep cub_server | grep $db | wc -l)
+	if [ $retcode -eq 0 ];then
+		echo "Database server '$database' is not running"
+		exit 1
+	fi
 }
 
+#
+# when doing a cd, cd display current working directory.
+# skip it.
+#
 function silent_cd ()
 {
-        cd $* > /dev/null
+	cd $* > /dev/null
 }
 
+#
+# run csql -u dba -l -c "show heap capacity of code" demodb
+# extract Num_recs, Avg_rec_len for the table
+# size = Num_recs * Avg_rec_len
+#
 function get_table_size ()
 {
-        local Num_recs=0
-        local table_name=$1
-        local Avg_rec_len=0
-        local table_size=0
-        local csql_output
+	local Num_recs=0
+	local table_name=$1
+	local Avg_rec_len=0
+	local table_size=0
+	local csql_output
 
-        csql_output=$(csql $user $pass -l -c "show heap capacity of $table_name" $db)
+	csql_output=$(csql $user $pass -l -c "show heap capacity of $table_name" $db)
 
-        if [ $? -ne 0 ];then
+	if [ $? -ne 0 ];then
 		table_size=-1
-        else
+	else
 		Avg_rec_len=$(echo ${csql_output##*Avg_rec_len} | awk '{print $2}')
 		Num_recs=$(echo ${csql_output##*Num_recs} | awk '{print $2}')
 		let "table_size = Num_recs * Avg_rec_len"
-        fi
+	fi
 
-        echo $table_size
+	echo $table_size
 }
 
-function find_slot ()
+#
+# Find the process with the least load.
+#
+function find_least_loaded_proc ()
 {
-        local selected=0
-        local i
-        local size=${slot_size[0]}
+	local selected=0
+	local i
+	local size=${slot_size[0]}
 
-        for ((i = 0; i < $num_proc; i++))
-        do
-                if [ ${slot_size[i]} -lt $size ];then
-                        size=${slot_size[i]}
-                        selected=$i
-                fi
-        done
+	for ((i = 0; i < $num_proc; i++))
+	do
+		if [ ${slot_size[i]} -lt $size ];then
+			size=${slot_size[i]}
+			selected=$i
+		fi
+	done
 
-         echo $selected
+	echo $selected
 }
 
 function do_unloaddb ()
 {
-        local slot_num=$1
-        local i
-        local num_tables_in_slot=0
-        local msg="Success"
-        local pid
-        local buf
-        local prefix="$database"_$slot_num
-        local log_prefix=$logdir/$prefix
-        local unloaddb_log=$prefix"_unloaddb.log"
-        local current_dir=$(pwd)
-        local file=$log_prefix".files"
-        local unloaddb_opts="$user $pass --output-prefix=$prefix -d --input-class-only"
-        local opts="$user $pass -s "
-        local do_schema_unload=0
-        local do_data_unload=0
+	local slot_num=$1
+	local i
+	local num_tables_in_slot=0
+	local msg="Success"
+	local pid
+	local buf
+	local prefix="$database"_$slot_num
+	local log_prefix=$logdir/$prefix
+	local unloaddb_log=$prefix"_unloaddb.log"
+	local current_dir=$(pwd)
+	local file=$log_prefix".files"
+	local unloaddb_opts="$user $pass --output-prefix=$prefix -d --input-class-only"
+	local opts="$user $pass -s "
+	local do_schema_unload=0
+	local do_data_unload=0
 
-        for ((i = 0; i < $num_tables; i++))
-        do
-                if [ ${slot[i]} -eq $slot_num ];then
-                        let "num_tables_in_slot++"
-                        echo "${table_selected[i]}" >> $file
-                fi
-        done
+	for ((i = 0; i < $num_tables; i++))
+	do
+		if [ ${slot[i]} -eq $slot_num ];then
+			let "num_tables_in_slot++"
+			echo "${table_selected[i]}" >> $file
+		fi
+	done
 
-        if [ $verbose = "yes" ];then
-                buf=$(printf %3d $num_tables_in_slot)
-                echo "Proc $slot_num: num tables: $buf, ${slot_size[$slot_num]} bytes"
-        fi
+	if [ $verbose = "yes" ];then
+		buf=$(printf %3d $num_tables_in_slot)
+		echo "Proc $slot_num: num tables: $buf, ${slot_size[$slot_num]} bytes"
+	fi
 
-        echo "process $slot_num: starting" > $log_prefix.status
+	echo "process $slot_num: starting" > $log_prefix.status
 
-        #
-        # Do unloadb for whole schema in the process 0
-        if [ $opt_schema -eq 1 ] || [ $opt_schema -eq 0 -a $opt_data -eq 0 ];then
-                if [ $slot_num -eq 0 ];then
-                        do_schema_unload=1
-                fi
-        fi
+	#
+	# unload schema files if the following two conditions are satisfied.
+	# 1. it is 0th process
+	# 2. None of the -s -d options were given, or -s option is given
 
-        if [ $opt_data -eq 1 ] || [ $opt_schema -eq 0 -a $opt_data -eq 0 ];then
-                do_data_unload=1
-        fi
+	if [ $opt_schema -eq 1 ] || [ $opt_schema -eq 0 -a $opt_data -eq 0 ];then
+		if [ $slot_num -eq 0 ];then
+			do_schema_unload=1
+		fi
+	fi
 
-        if [ $do_schema_unload -eq 1 ];then
-                if [ $from_file -eq 1 ];then
-                        opts=$opts" --input-class-only --input-class-file $filename"
-                fi
-                (silent_cd $target_dir;cubrid unloaddb $opts $database) &
-        fi
+	if [ $opt_data -eq 1 ] || [ $opt_schema -eq 0 -a $opt_data -eq 0 ];then
+		do_data_unload=1
+	fi
 
-        if [ $do_data_unload -eq 0 ];then
-                return
-        fi
+	if [ $do_schema_unload -eq 1 ];then
+		if [ $from_file -eq 1 ];then
+			opts=$opts" --input-class-only --input-class-file $filename"
+		fi
+		(silent_cd $target_dir;cubrid unloaddb $opts $database) &
+	fi
 
-        (silent_cd $target_dir; cubrid unloaddb $unloaddb_opts --input-class-file $file $database) &
-        pid=$!
+	if [ $do_data_unload -eq 0 ];then
+		return
+	fi
 
-        echo $pid > $log_prefix.pid
+	(silent_cd $target_dir; cubrid unloaddb $unloaddb_opts --input-class-file $file $database) &
+	pid=$!
 
-        wait $pid
+	echo $pid > $log_prefix.pid
 
-        if [ $? -ne 0 ];then
-                msg="Failed"
-                echo "process $slot_num: failed" > $log_prefix.status
-        else
-                echo "process $slot_num: success" > $log_prefix.status
-        fi
+	wait $pid
 
-        # move 'cubrid unloaddb ..' output to logdir
-        if [ -f $target_dir/$unloaddb_log ];then
-                mv $target_dir/$unloaddb_log $logdir
-        fi
+	if [ $? -ne 0 ];then
+		msg="Failed"
+		echo "process $slot_num: failed" > $log_prefix.status
+	else
+		echo "process $slot_num: success" > $log_prefix.status
+	fi
 
-        if [ $verbose = "yes" ];then
-                echo "Finished Proc $slot_num ($msg)"
-        fi
+	# move unloaddb logfile to $logdir
+	if [ -f $target_dir/$unloaddb_log ];then
+		mv $target_dir/$unloaddb_log $logdir
+	fi
+
+	if [ $verbose = "yes" ];then
+		echo "Finished Proc $slot_num ($msg)"
+	fi
 }
 
+#
+# output: 2 string array, table_selected [], table_size []
+# Phase1: get all table names, if -i option is not given. Fill it to table_selected []
+# Phase2: for all tables ${table_selected}, calculate the size of the table, and
+# 	    fill it to table_size
+#
 function analyze_table_info ()
 {
-        local found=0
-        local line
-        local idx=0
-        local table_name
-        local db=$database
-        local query="show tables"
+	local found=0
+	local line
+	local idx=0
+	local table_name
+	local db=$database
+	local query="show tables"
 
-        # Get all table names if $from_file equals 0, otherwise from input file
-        if [ $from_file -eq 1 ];then  # Read table name from file
-                result=$(cat $filename)
-        else
-                result=$(csql $user $pass -c "$query" $db)
-        fi
+	# Phase1: Get all table names if $from_file equals 0, otherwise from input file
+	# and fill it to array table_selected []
 
-        for token in $result
-        do
-                if  [ $from_file -eq 0 ] && [ $found -eq 0 ];then
-                        str=$(echo $token | grep "====") # skip until we found table names in csql
-                        if [ $? -eq 0 ];then
-                                found=1
-                        fi
-                        continue
-                fi
+	if [ $from_file -eq 1 ];then  # Read table name from file
+		result=$(cat $filename)
+	else
+		result=$(csql $user $pass -c "$query" $db)
+	fi
 
-                # if table name comes from csql it is the pattern of 'code'
-                # and end with string like this
-                # "\n16 rows selected. (0.009125 sec) Committed."
-                # If it comes from file it is the pattern of code
-                if [ $from_file -eq 0 ] && [ ${token:0:1} != "'" ];then
-                        break
-                fi
+	for token in $result
+	do
+		if  [ $from_file -eq 0 ] && [ $found -eq 0 ];then
+			str=$(echo $token | grep "====") # skip until we found table names in csql
 
-                table_selected[idx]="$token"
+			if [ $? -eq 0 ];then
+				found=1
+			fi
 
-                if [ $from_file -eq 0 ];then        # remove single quota from csql output
-                        table_selected[idx]=$(echo ${table_selected[idx]} | sed "s/[\']//g")
-                fi
+			continue
+		fi
 
-                let "idx++"
+		# if table name comes from csql it is the pattern of 'code'
+		# and end with string like this
+		# "\n16 rows selected. (0.009125 sec) Committed."
+		# If it comes from file it is the pattern of code
+		#
 
-        done
+		if [ $from_file -eq 0 ] && [ ${token:0:1} != "'" ];then
+			break
+		fi
 
-        # Get the size of all tables
-        n=1
-        for ((i = 0; i < ${#table_selected[@]}; i++))
-        do
-                table_name=${table_selected[i]}
-                this_table_size=$(get_table_size $table_name)
+		table_selected[idx]="$token"
 
-                echo "$table_name: $this_table_size"
+		if [ $from_file -eq 0 ];then        # remove single quota from csql output
+			table_selected[idx]=$(echo ${table_selected[idx]} | sed "s/[\']//g")
+		fi
 
-                if [ -z $this_table_size ] || [ $this_table_size -lt 0 ];then
-                        echo "'$table_name': unknown table ($this_table_size)"
-                        exit
-                fi
+		let "idx++"
+	done
 
-                table_size[$num_tables]="$this_table_size"
-                let "num_tables++"
-        done
+	# 
+	# Phase2: calculate all table size in array table_selected[]
+	# calculate the table size to array table_size []
+	#
+
+	for ((i = 0; i < ${#table_selected[@]}; i++))
+	do
+		table_name=${table_selected[i]}
+		this_table_size=$(get_table_size $table_name)
+
+		if [ -z $this_table_size ] || [ $this_table_size -lt 0 ];then
+			echo "'$table_name': unknown table ($this_table_size)"
+			exit
+		fi
+
+		table_size[$num_tables]="$this_table_size"
+		let "num_tables++"
+	done
 }
 
 # MAIN
@@ -362,23 +392,23 @@ set -o monitor
 get_options "$@"
 
 if [ $num_args_remain -ne 1 ] || [ -z $database ];then
-        show_usage
-        exit 1
+	show_usage
+	exit 1
 fi
 
 if [ $num_proc -gt $max_num_proc ];then
-        echo "Num Proc exeed Max Proc. Force set num proc to $max_num_proc"
-        num_proc=$max_num_proc
+	echo "Num Proc exeed Max Proc. Force set num proc to $max_num_proc"
+	num_proc=$max_num_proc
 fi
 
 if [ ! -d $target_dir ];then
-        echo "$target_dir: directory not exists or permission denied"
-        exit
+	echo "$target_dir: directory not exists or permission denied"
+	exit
 fi
 
 # make full path from "/"
 if [ ! -z $filename ] && [ ${filename:0:1} != "/" ];then
-        filename="$cwd/"$filename
+	filename="$cwd/"$filename
 fi
 
 is_db_server_running $database
@@ -387,6 +417,7 @@ logdir=$cwd"/"$database"_"unloaddb.log
 if [ -d $logdir ];then
 	rm -rf $logdir
 fi
+
 mkdir $logdir
 
 verify_user_pass
@@ -396,8 +427,8 @@ echo -n "Analyzing table spacace ..."
 analyze_table_info
 
 if [ $num_tables -eq 0 ];then
-        echo "No Table SELECTED."
-        exit
+	echo "No Table SELECTED."
+	exit
 fi
 
 echo ""
@@ -406,18 +437,18 @@ echo ""
 # Assign and calculate total table size & num tables assigned in each slot
 for ((i = 0; i < $num_tables; i++))
 do
-        this_slot=$(find_slot)
-        tbl=${table_selected[i]}
-        slot[i]=$this_slot
+	this_slot=$(find_least_loaded_proc)
+	tbl=${table_selected[i]}
+	slot[i]=$this_slot
 
-        let "slot_size[$this_slot]+=${table_size[$i]}"
-        let "num_tables_slot[$this_slot]++"
-        let "total_pages+=${table_size[$i]}"
+	let "slot_size[$this_slot]+=${table_size[$i]}"
+	let "num_tables_slot[$this_slot]++"
+	let "total_pages+=${table_size[$i]}"
 
-        if [ $verbose = "yes" ];then
-                index=$(printf "%3d" $i)
-                echo "[$index:${slot[i]}] ${table_selected[i]}: ${table_size[i]} bytes"
-        fi
+	if [ $verbose = "yes" ];then
+		index=$(printf "%3d" $i)
+		echo "[$index:${slot[i]}] ${table_selected[i]}: ${table_size[i]} bytes"
+	fi
 done
 
 echo "Total $num_tables tables, $total_pages pages"
@@ -427,9 +458,9 @@ echo "Total $num_tables tables, $total_pages pages"
 #
 for ((i = 0; i < $num_proc; i++))
 do
-        if [ ${slot_size[i]} -gt 0 ];then
-	       do_unloaddb $i &
-        fi
+	if [ ${slot_size[i]} -gt 0 ];then
+		do_unloaddb $i &
+	fi
 done
 
 wait

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -203,6 +203,7 @@ function do_unloaddb ()
         local num_tables_in_slot=0
         local msg="Success"
         local pid
+        local buf
 
         for ((i = 0; i < $num_tables; i++))
         do
@@ -213,7 +214,8 @@ function do_unloaddb ()
         done
 
         if [ $verbose = "yes" ];then
-                echo "Proc $slot_num: num tables: $num_tables_in_slot, ${slot_size[$slot_num]} bytes"
+                buf=$(printf %3d $num_tables_in_slot)
+                echo "Proc $slot_num: num tables: $buf, ${slot_size[$slot_num]} bytes"
         fi
 
         echo "process $slot_num: starting" > unloaddb_$slot_num.status

--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -289,8 +289,8 @@ function analyze_table_info ()
                 table_name=${table_selected[i]}
                 this_table_size=$(get_table_size $table_name)
 
-                if [ -z $this_table_size ];then
-                        echo "Unknown table: $table_name"
+                if [ -z $this_table_size ] || [ $this_table_size -eq 0 ];then
+                        echo "'$table_name': unknown table"
                         exit
                 fi
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23839

**Purpose**
The unloaddb utility that provides multi-process (**only DBA or DBA group user able to run this script**)

**Implementation**
example:
sh unloaddb.sh -v -i input_file -u user -D /tmp -t num_process database_name

option summary:

-v: if given, print verbose information
-i: if given, table names to unload data of specified tables in this file, otherwise all tables in database will be unloaded
-u: if given, use user name user for unloaddb, otherwise dba will be used
-t: if given, maximum num_process unloaddb process will be invoked, otherwise -t 8 will be used (default)
-D: if given, target directory to create unloaddb output, otherwise current working directory will be used
-d: if given, dump objects only; default: schema and objects (same context with cubrid unloaddb utility)
-s: if given, dump schema only; default: schema and objects (same context with cubrid unloaddb utility)

If executed, for example dbname is demodb and num process is 4, following 4 files will be created on _target_ directory:
- demodb_0_objects
- demodb_1_objects
- demodb_2_objects
- demodb_3_objects

Compared to data files, schema, index, trigger files will not be splitted and containing schama/index/trigger information for subject tables, for example:
demodb_indexes
demodb_schema
demodb_trigger

Additional information in database_unloaddb.log (by example)
- demodb_unloaddb.log/demodb_0.files: unloaded table names by process 0
- demodb_unloaddb.log/demodb_0.pid: child PID of unloaddb (for kill the process by parent)
- demodb_unloaddb.log/demodb_0.status: 0th Child process result (success or fail)

**Algorithm for allocating tables to processes:**

For all tables to be unloaded, do following to assign each table to a process with the result that all process have same load to unload:

1. calculate size each table (do '**csql -u user -l -c "show heap capacity of table" database**), and pick **Num_recs**, **Avg_rec_len** as number of rows and estimated schema size respectively (Num_recs * Avg_rec_len)
2. Pick a process which has minimum size to be processed.
3. Add current table size to the process to be processed.

Remarks
This PR is created due to some inconsistency between base branch and forked one.
Refer previous PR which is closed, https://github.com/CUBRID/cubrid/pull/3284
NA
