### PR TITLE
[CBRD-24171] Fix cubmem::extensible_block's move constructor

### DIFF
--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -306,7 +306,7 @@ namespace cubmem
   extensible_block::extensible_block (extensible_block &&b)
     : extensible_block { *b.m_allocator }
   {
-    m_block = std:move (b.m_block);
+    m_block = std::move (b.m_block);
   }
 
   extensible_block::extensible_block (const block_allocator &alloc)

--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -306,6 +306,8 @@ namespace cubmem
   extensible_block::extensible_block (extensible_block &&b)
     : extensible_block { *b.m_allocator }
   {
+    m_block.dim = b.m_block.dim;
+    m_block.ptr = b.m_block.ptr;
     b.m_block.dim = 0;
     b.m_block.ptr = NULL;
   }

--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -306,10 +306,7 @@ namespace cubmem
   extensible_block::extensible_block (extensible_block &&b)
     : extensible_block { *b.m_allocator }
   {
-    m_block.dim = b.m_block.dim;
-    m_block.ptr = b.m_block.ptr;
-    b.m_block.dim = 0;
-    b.m_block.ptr = NULL;
+    m_block = std:move (b.m_block);
   }
 
   extensible_block::extensible_block (const block_allocator &alloc)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24171

Fixed the move constructor of `cubmem::extensible_block`. m_block's content is not moved.