### PR TITLE
[CBRD-24162] Fix logical operation || to && on vacuum_data_page::is_index_valid function

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -8086,7 +8086,7 @@ vacuum_data_page::is_empty () const
 bool
 vacuum_data_page::is_index_valid (INT16 index) const
 {
-  return index >= index_unvacuumed || index < index_free;
+  return index >= index_unvacuumed && index < index_free;
 }
 
 INT16


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24162

Purpose
`Correct Error` 
Fix logical operation || to && on vacuum_data_page::is_index_valid function on src/query/vacuum.c

Implementation
```c
bool
vacuum_data_page::is_index_valid (INT16 index) const
{
        return index >= index_unvacuumed || index < index_free;
}
```

to

```c
bool
vacuum_data_page::is_index_valid (INT16 index) const
{
        return index >= index_unvacuumed && index < index_free;
}
```

Remarks
N/A