### PR TITLE
[CBRD-24167] Remove the unused LOG_TOPOPS_TYPE type.

### DIFF
--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -390,15 +390,6 @@ struct log_topops_addresses
 				 * since it is reset during recovery to the last reference postpone address. */
 };
 
-enum log_topops_type
-{
-  LOG_TOPOPS_NORMAL,
-  LOG_TOPOPS_COMPENSATE_TRAN_ABORT,
-  LOG_TOPOPS_COMPENSATE_SYSOP_ABORT,
-  LOG_TOPOPS_POSTPONE
-};
-typedef enum log_topops_type LOG_TOPOPS_TYPE;
-
 typedef struct log_topops_stack LOG_TOPOPS_STACK;
 struct log_topops_stack
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24167

### Purpose
* `Refactoring`,  Remove `log_topops_type` in log_impl.h

### Implementation
* Remove `enum log_topops_type` and related `typedef` in log_impl.h

### Remarks
* N/A