### PR TITLE
[CBRD-24172] Fixed code comparing transaction ID to NULL_ATTRID rather than NULL_TRANID

### DIFF
--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -6035,7 +6035,7 @@ log_tdes::is_system_main_transaction () const
 bool
 log_tdes::is_system_worker_transaction () const
 {
-  return is_system_transaction () && trid < NULL_ATTRID;
+  return is_system_transaction () && trid < NULL_TRANID;
 }
 
 bool


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24172

Purpose
- Fixed code comparing transaction ID to NULL_ATTRID rather than NULL_TRANID

Implementation
```C
bool log_tdes::is_system_worker_transaction () const
{  
    return is_system_transaction () && trid < NULL_ATTRID;
}
```
to
```C
bool log_tdes::is_system_worker_transaction () const
{  
    return is_system_transaction () && trid < NULL_TRANID;
}
```
Remarks
N/A
