### PR TITLE
[CBRD-24168] Fixed the problem that the critical section is not returned when an error occurs after entering it in function logpb_copy_page.

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1915,9 +1915,10 @@ logpb_copy_page (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_ACCESS_MODE 
       er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_PAGE_CORRUPTED, 1, pageid);
       if (log_csect_entered)
         {
-          LOG_CS_EXIT (thread_p);
+          rv = ER_LOG_PAGE_CORRUPTED;
+          goto exit;
         }
-	  return ER_LOG_PAGE_CORRUPTED;
+      return ER_LOG_PAGE_CORRUPTED;
     }
 
   if (log_bufptr->pageid == pageid)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1913,7 +1913,11 @@ logpb_copy_page (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_ACCESS_MODE 
   else
     {
       er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_PAGE_CORRUPTED, 1, pageid);
-      return ER_LOG_PAGE_CORRUPTED;
+      if (log_csect_entered)
+        {
+          LOG_CS_EXIT (thread_p);
+        }
+	  return ER_LOG_PAGE_CORRUPTED;
     }
 
   if (log_bufptr->pageid == pageid)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1913,12 +1913,8 @@ logpb_copy_page (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_CS_ACCESS_MODE 
   else
     {
       er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_PAGE_CORRUPTED, 1, pageid);
-      if (log_csect_entered)
-        {
-          rv = ER_LOG_PAGE_CORRUPTED;
-          goto exit;
-        }
-      return ER_LOG_PAGE_CORRUPTED;
+      rv = ER_LOG_PAGE_CORRUPTED;
+      goto exit;
     }
 
   if (log_bufptr->pageid == pageid)


### PR DESCRIPTION
http://jira.cubrid.org/projects/CBRD/issues/CBRD-24168

**Purpose**
In the `logpb_copy_page()`, if the thread has entered critical section as reader and the current index in the log buffer is invalid, it should exit critical section since it's error.

**Implementation**
Inserted an escape condition to exit critical section on error.

**Remarks**
N/A