### PR TITLE
[CBRD-24186] Correct assert statement from disk_cache_load_volume 

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2559,7 +2559,7 @@ disk_cache_load_volume (THREAD_ENTRY * thread_p, INT16 volid, void *ignore)
       assert (disk_Cache->perm_purpose_info.extend_info.nsect_free
 	      <= disk_Cache->perm_purpose_info.extend_info.nsect_total);
       assert (disk_Cache->perm_purpose_info.extend_info.nsect_total
-	      <= disk_Cache->perm_purpose_info.extend_info.n_max_sects);
+	      <= disk_Cache->perm_purpose_info.extend_info.nsect_max);
 
       if (space_info.n_total_sects < space_info.n_max_sects)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24186

### Purpose
`Refactoring`

Fix typo.

### Implementation
n_max_sects-> nsect_max
```
from
assert (disk_Cache->perm_purpose_info.extend_info.nsect_total
<= disk_Cache->perm_purpose_info.extend_info.n_max_sects);
to
assert (disk_Cache->perm_purpose_info.extend_info.nsect_total
<= disk_Cache->perm_purpose_info.extend_info.nsect_max);
```

### Remarks
I apologize. I made typo,
The 'extend_info' has no member named ‘n_max_sects’
and I fix it.  I am so sorry again.