### PR TITLE
[CBRD-24165] Remove unused function disk_auto_volume_expansion_daemon…

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -477,13 +477,6 @@ STATIC_INLINE bool disk_compatible_type_and_purpose (DB_VOLTYPE type, DB_VOLPURP
 STATIC_INLINE void disk_check_own_reserve_for_purpose (DB_VOLPURPOSE purpose) __attribute__ ((ALWAYS_INLINE));
 static DISK_ISVALID disk_check_volume (THREAD_ENTRY * thread_p, INT16 volid, bool repair);
 
-// *INDENT-OFF*
-static cubthread::daemon *disk_Auto_volume_expansion_daemon = NULL;
-
-static void disk_auto_volume_expansion_daemon_init ();
-static void disk_auto_volume_expansion_daemon_destroy ();
-// *INDENT-ON*
-
 /************************************************************************/
 /* End of static functions                                              */
 /************************************************************************/
@@ -2451,72 +2444,6 @@ exit:
 
   return error_code;
 }
-
-#if defined (SERVER_MODE)
-int
-disk_auto_expand (THREAD_ENTRY * thread_p)
-{
-  int error_code = NO_ERROR;
-
-  /* todo: we cannot expand the volumes unless we have a transaction descriptor. we might allocate a special tdes for
-   *       auto-volume expansion thread, similar to how vacuum works. otherwise, it can be limited to extend last
-   *       volume only.
-   * for now, do nothing. we'll think about it later.
-   */
-
-  return error_code;
-}
-#endif /* SERVER_MODE */
-
-// *INDENT-OFF*
-#if defined (SERVER_MODE)
-static void
-disk_auto_expansion_execute (cubthread::entry & thread_ref)
-{
-  if (!BO_IS_SERVER_RESTARTED ())
-    {
-      // wait for boot to finish
-      return;
-    }
-
-  disk_auto_expand (&thread_ref);
-}
-#endif /* SERVER_MODE */
-
-#if defined (SERVER_MODE)
-/*
- * disk_auto_volume_expansion_daemon_init () - initialize disk auto volume expansion daemon
- */
-static void
-disk_auto_volume_expansion_daemon_init ()
-{
-  // disk auto volume expansion is not yet implemented, uncomment below code when functionality will be available
-  // see disk_auto_expand (THREAD_ENTRY *) function for more details
-  /*
-  assert (disk_Auto_volume_expansion_daemon == NULL);
-
-  std::chrono::seconds interval_time = std::chrono::seconds (60);
-  disk_Auto_volume_expansion_daemon = cubthread::get_manager ()->create_daemon (cubthread::looper (interval_time),
-				      new cubthread::entry_callable_task (disk_auto_expansion_execute));
-  */
-}
-#endif /* SERVER_MODE */
-
-#if defined (SERVER_MODE)
-/*
- * disk_auto_volume_expansion_daemon_destroy () - destroy disk auto volume expansion daemon
- */
-static void
-disk_auto_volume_expansion_daemon_destroy ()
-{
-  // disk auto volume expansion is not yet implemented, uncomment below code when functionality will be available
-  // see disk_auto_expand (THREAD_ENTRY *) function for more details
-  /*
-    cubthread::get_manager ()->destroy_daemon (disk_Auto_volume_expansion_daemon);
-  */
-}
-#endif /* SERVER_MODE */
-// *INDENT-ON*
 
 /************************************************************************/
 /* Disk cache section                                                   */
@@ -4965,11 +4892,6 @@ disk_manager_init (THREAD_ENTRY * thread_p, bool load_from_disk)
       disk_manager_final ();
       return error_code;
     }
-
-#if defined (SERVER_MODE)
-  disk_auto_volume_expansion_daemon_init ();
-#endif /* SERVER_MODE */
-
   return NO_ERROR;
 }
 
@@ -4979,10 +4901,6 @@ disk_manager_init (THREAD_ENTRY * thread_p, bool load_from_disk)
 void
 disk_manager_final (void)
 {
-#if defined (SERVER_MODE)
-  disk_auto_volume_expansion_daemon_destroy ();
-#endif /* SERVER_MODE */
-
   disk_cache_final ();
 }
 

--- a/src/storage/disk_manager.h
+++ b/src/storage/disk_manager.h
@@ -88,10 +88,6 @@ extern int disk_add_volume_extension (THREAD_ENTRY * thread_p, DB_VOLPURPOSE pur
 				      int max_write_size_in_sec, bool overwrite, VOLID * volid_out);
 extern void disk_lock_extend (void);
 extern void disk_unlock_extend (void);
-#if defined (SERVER_MODE)
-/* todo: auto-volume extension thread needs transaction descriptor */
-extern int disk_auto_expand (THREAD_ENTRY * thread_p);
-#endif /* SERVER_MODE */
 extern int disk_unformat (THREAD_ENTRY * thread_p, const char *vol_fullname);
 extern int disk_set_creation (THREAD_ENTRY * thread_p, INT16 volid, const char *new_vol_fullname,
 			      const INT64 * new_dbcreation, const LOG_LSA * new_chkptlsa, bool logchange,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24165

**Purpose**
Remove unused function disk_auto_volume_expansion_daemon_init() and the related code.
They are not implemented so i removed them.

**Implementation**
removed functions
    - disk_auto_expand()
    - disk_auto_expansion_execute()
    - disk_auto_volume_expansion_daemon_init()
    - disk_auto_volume_expansion_daemon_destroy()

**Remarks**
N/A