### PR TITLE
[CBRD-23762]  Misuse the variable for the maximum number of temp cache entries in the temp cache

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -9293,7 +9293,7 @@ file_tempcache_put (THREAD_ENTRY * thread_p, FILE_TEMPCACHE_ENTRY * entry)
   /* lock temporary cache */
   file_tempcache_lock ();
 
-  if (file_Tempcache->ncached_not_numerable + file_Tempcache->ncached_numerable < file_Tempcache->ncached_max)
+  if (file_Tempcache->ncached_not_numerable + file_Tempcache->ncached_numerable <= file_Tempcache->ncached_max)
     {
       /* cache not full */
       assert ((file_Tempcache->cached_not_numerable == NULL) == (file_Tempcache->ncached_not_numerable == 0));

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -9293,7 +9293,7 @@ file_tempcache_put (THREAD_ENTRY * thread_p, FILE_TEMPCACHE_ENTRY * entry)
   /* lock temporary cache */
   file_tempcache_lock ();
 
-  if (file_Tempcache->ncached_not_numerable + file_Tempcache->ncached_numerable < file_Tempcache->nfree_entries_max)
+  if (file_Tempcache->ncached_not_numerable + file_Tempcache->ncached_numerable < file_Tempcache->ncached_max)
     {
       /* cache not full */
       assert ((file_Tempcache->cached_not_numerable == NULL) == (file_Tempcache->ncached_not_numerable == 0));


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23762

### Purpose
Change variable in conditional statement
file_manager.c 9296 line 'nfree_entries_max' change to 'ncached_max'

### Implementation
N/A

### Remarks
N/A