### PR TITLE
[CBRD-24170] Remove redundant logical code in the log_recovery_analysis function.

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2864,7 +2864,6 @@ log_recovery_analysis (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, LOG_LSA * s
 	    }
 	  if (LSA_EQ (end_redo_lsa, &lsa))
 	    {
-	      assert_release (!LSA_EQ (end_redo_lsa, &lsa));
 	      LSA_SET_NULL (&lsa);
 	      break;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24170

### Purpose
Remove redundant logical code.
log_recovery_analysis function in log_recovery.c
After passing the if statement, it is checked with assert_release() under the same condition.

### Implementation
removed the redundant assert_release()

### Remarks
N/A
