### PR TITLE
[CBRD-24154] Exec 10.2 tranlist with dbuser/pw

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cubridmanager"]
 	path = cubridmanager
 	url = https://github.com/CUBRID/cubrid-manager-server
-	branch = develop
+	branch = release/10.2p


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24154

**Purpose**

As the tranlist of 11.0 decided to remove user/password, while 10.2 decided to keep it, we added user/pw when we execute 10.2 tranlist from CUBRID Manager Server

- CMS 10.2 sty;e: **cubrid tranlist --user kshan --password 1234 demodb**
- CMS 11.0 style: cubrid tranlist demodb

**Implementation**

**Remarks**
NA
