### PR TITLE
[CBRD-24154] submodule reference branch set to 10.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cubridmanager"]
 	path = cubridmanager
 	url = https://github.com/CUBRID/cubrid-manager-server
-	branch = release/10.2p
+	branch = release/10.2


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24154

Description
Change branch of CMS submodule reference
from: 10.2p
to: 10.2
Due to invalid naming convention of 10.2p
