### PR TITLE
[CBRD-24193] Replace KILLTRAN_DBA_PASSWORD_S with TDE_DBA_PASSWORD_S macro used to set dba password in function tde.

### DIFF
--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -3747,7 +3747,7 @@ tde (UTIL_FUNCTION_ARG * arg)
   delete_op_idx = utility_get_option_int_value (arg_map, TDE_DELETE_KEY_S);
 
   print_val = utility_get_option_bool_value (arg_map, TDE_PRINT_KEY_VALUE_S);
-  dba_password = utility_get_option_string_value (arg_map, KILLTRAN_DBA_PASSWORD_S, 0);
+  dba_password = utility_get_option_string_value (arg_map, TDE_DBA_PASSWORD_S, 0);
 
   if (gen_op)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24193

**Purpose**
When initializing `dba_password` in the tde function, KILLTRAN_DBA_PASSWORD_S macro is used. Both are the same p-options, but it is semantically correct to use TDE_DBA_PASSWORD_S macro in the tde function.

**Implementation**
```c
// util_cs.c
int 
tde ()
{ 
  ...
  dba_password = utility_get_option_string_value (arg_map, KILLTRAN_DBA_PASSWORD_S, 0);
 -> dba_password = utility_get_option_string_value (arg_map, TDE_DBA_PASSWORD_S, 0);
```

Remarks
N/A