### PR TITLE
[LETS-279] Set page desynchronization error when fixing leaf page for btree range scan

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -24860,7 +24860,7 @@ btree_range_scan_descending_fix_prev_leaf (THREAD_ENTRY * thread_p, BTREE_SCAN *
     }
   if (prev_leaf == NULL)
     {
-      /* deallocated */
+      /* deallocated or found to be ahead of replication, in either case the scan needs to restart */
       bts->force_restart_from_root = true;
       return NO_ERROR;
     }

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -24851,7 +24851,8 @@ btree_range_scan_descending_fix_prev_leaf (THREAD_ENTRY * thread_p, BTREE_SCAN *
   /* Unfix current page and retry. */
   pgbuf_unfix_and_init (thread_p, bts->C_page);
   error_code =
-    pgbuf_fix_if_not_deallocated (thread_p, &prev_leaf_vpid, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH, &prev_leaf);
+    pgbuf_fix_if_not_deallocated_with_repl_desync_check (thread_p, &prev_leaf_vpid, PGBUF_LATCH_READ,
+							 PGBUF_UNCONDITIONAL_LATCH, &prev_leaf);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -24891,7 +24892,7 @@ btree_range_scan_descending_fix_prev_leaf (THREAD_ENTRY * thread_p, BTREE_SCAN *
       if (er_errid () == ER_PAGE_AHEAD_OF_REPLICATION)
 	{
 	  bts->force_restart_from_root = true;
-	  pgbuf_unfix_and_init (thread_p, bts->C_page);
+	  pgbuf_unfix_and_init (thread_p, prev_leaf);
 	  return NO_ERROR;
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-279

On PTS, index range scans may move from a leaf page to the next/prev. The next page may be fetched from PS and may be desynchronized if that is the case the page ahead of replication error must be set.

In  the following cases the `pgbuf_fix` was changed to also check for desync: 
 -  `next_node_page` in `btree_range_scan_advance_over_filtered_keys`
 -  `prev_leaf` in `btree_range_scan_descending_fix_prev_leaf`
 -  `bts->C_page` when `bts->force_restart_from_root` is false

