### PR TITLE
[CBRD-24200] make LOG_WILL_COMMIT obsolete and delete corresponding codes

### DIFF
--- a/src/transaction/log_2pc.c
+++ b/src/transaction/log_2pc.c
@@ -1900,7 +1900,6 @@ log_2pc_recovery_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE record_ty
 
     case LOG_COMPENSATE:
     case LOG_RUN_POSTPONE:
-    case LOG_WILL_COMMIT:
     case LOG_COMMIT_WITH_POSTPONE:
     case LOG_2PC_COMMIT_DECISION:
     case LOG_2PC_ABORT_DECISION:

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -422,9 +422,6 @@ log_to_string (LOG_RECTYPE type)
     case LOG_COMPENSATE:
       return "LOG_COMPENSATE";
 
-    case LOG_WILL_COMMIT:
-      return "LOG_WILL_COMMIT";
-
     case LOG_COMMIT_WITH_POSTPONE:
       return "LOG_COMMIT_WITH_POSTPONE";
 
@@ -6928,10 +6925,6 @@ log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type
       log_page_p = log_dump_record_commit_postpone (thread_p, out_fp, log_lsa, log_page_p);
       break;
 
-    case LOG_WILL_COMMIT:
-      fprintf (out_fp, "\n");
-      break;
-
     case LOG_COMMIT:
     case LOG_ABORT:
       log_page_p = log_dump_record_transaction_finish (thread_p, out_fp, log_lsa, log_page_p);
@@ -7913,7 +7906,6 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
 	      LSA_SET_NULL (&prev_tranlsa);
 	      break;
 
-	    case LOG_WILL_COMMIT:
 	    case LOG_COMMIT:
 	    case LOG_ABORT:
 	    case LOG_2PC_COMMIT_DECISION:
@@ -8352,7 +8344,6 @@ log_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postp
 		      /* TODO: consider to add FI here */
 		      break;
 
-		    case LOG_WILL_COMMIT:
 		    case LOG_COMMIT_WITH_POSTPONE:
 		    case LOG_SYSOP_START_POSTPONE:
 		    case LOG_2PC_PREPARE:

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -422,9 +422,6 @@ log_to_string (LOG_RECTYPE type)
     case LOG_COMPENSATE:
       return "LOG_COMPENSATE";
 
-    case LOG_WILL_COMMIT:
-      return "LOG_WILL_COMMIT";
-
     case LOG_COMMIT_WITH_POSTPONE:
       return "LOG_COMMIT_WITH_POSTPONE";
 
@@ -2280,8 +2277,8 @@ log_append_undo_crumbs (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DATA
       return;
     }
 
-  /* 
-   * if pgptr is NULL, the user data can be spilled as un-encrypted. 
+  /*
+   * if pgptr is NULL, the user data can be spilled as un-encrypted.
    * Now it seems that there is no case, but can be in the future.
    */
   if (addr->pgptr != NULL && LOG_MAY_CONTAIN_USER_DATA (rcvindex))
@@ -2936,8 +2933,8 @@ log_append_run_postpone (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, LOG_DAT
 	  return;
 	}
 
-      /* 
-       * By the comment above for this function, all the potpone log is page-oriented, 
+      /*
+       * By the comment above for this function, all the potpone log is page-oriented,
        * and have to contain page address. However, code below check if addr->pgptr is NULL.
        * So, we also check it just in case.
        */
@@ -3113,7 +3110,7 @@ log_append_compensate_internal (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, 
   compensate->length = length;
 
   /*
-   * Although compensation log is page-oriented, pgptr can be NULL 
+   * Although compensation log is page-oriented, pgptr can be NULL
    * when fails to fix the page because of an error.
    * In this case, we don't encrypt the log and it can contain user data un-encrypted.
    * After all, it is very rare and exceptional case.
@@ -4805,14 +4802,14 @@ log_append_abort_log (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * abort_
 }
 
 /*
- * log_append_supplemental_info - append supplemental log record 
+ * log_append_supplemental_info - append supplemental log record
  *
  * return: nothing
  *
  *   rec_type (in): type of supplemental log record .
  *   length (in) : length of supplemental data length.
  *   data (in) : supplemental data
- *   
+ *
  */
 void
 log_append_supplemental_info (THREAD_ENTRY * thread_p, SUPPLEMENT_REC_TYPE rec_type, int length, const void *data)
@@ -4875,7 +4872,7 @@ log_append_supplemental_lsa (THREAD_ENTRY * thread_p, SUPPLEMENT_REC_TYPE rec_ty
 {
   int size;
 
-  /* sizeof (OID) = 8, sizeof (LOG_LSA) = 8, and data contains classoid and undo, redo lsa. 
+  /* sizeof (OID) = 8, sizeof (LOG_LSA) = 8, and data contains classoid and undo, redo lsa.
    * OR_OID_SIZE and OR_LOG_LSA_SIZE are not used here, because this function just copy the memory, not using OR_PUT_* function*/
   char data[24];
 
@@ -6928,10 +6925,6 @@ log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type
       log_page_p = log_dump_record_commit_postpone (thread_p, out_fp, log_lsa, log_page_p);
       break;
 
-    case LOG_WILL_COMMIT:
-      fprintf (out_fp, "\n");
-      break;
-
     case LOG_COMMIT:
     case LOG_ABORT:
       log_page_p = log_dump_record_transaction_finish (thread_p, out_fp, log_lsa, log_page_p);
@@ -7913,7 +7906,6 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
 	      LSA_SET_NULL (&prev_tranlsa);
 	      break;
 
-	    case LOG_WILL_COMMIT:
 	    case LOG_COMMIT:
 	    case LOG_ABORT:
 	    case LOG_2PC_COMMIT_DECISION:
@@ -8352,7 +8344,6 @@ log_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postp
 		      /* TODO: consider to add FI here */
 		      break;
 
-		    case LOG_WILL_COMMIT:
 		    case LOG_COMMIT_WITH_POSTPONE:
 		    case LOG_SYSOP_START_POSTPONE:
 		    case LOG_2PC_PREPARE:
@@ -11233,7 +11224,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 
   /* Get UNDO RECDES from undo lsa */
 
-  /* Because it is unable to know exact size of data (recdes.data), can not use log_get_undo_record. 
+  /* Because it is unable to know exact size of data (recdes.data), can not use log_get_undo_record.
    * In order to use log_get_undo_record(), memory pool for recdes (assign_recdes_to_area()) is required just as scan cache where log_get_undo_record() is called. */
 
   log_page_p = (LOG_PAGE *) PTR_ALIGN (log_pgbuf, MAX_ALIGNMENT);
@@ -12317,9 +12308,9 @@ end:
 static int
 cdc_find_primary_key (THREAD_ENTRY * thread_p, OID classoid, int repr_id, int *num_attr, int **pk_attr_id)
 {
-  /*1. if PK exists, return 0 with PK column id(pk_attr_id) and number of columns(num_attr) 
-   *2. if PK does not exist, return -1 
-   *3. pk_attr_id is required to be free_and_init() from caller 
+  /*1. if PK exists, return 0 with PK column id(pk_attr_id) and number of columns(num_attr)
+   *2. if PK does not exist, return -1
+   *3. pk_attr_id is required to be free_and_init() from caller
    * */
 
   /*refer locator_check_foreign_key */
@@ -12352,7 +12343,7 @@ cdc_find_primary_key (THREAD_ENTRY * thread_p, OID classoid, int repr_id, int *n
 	    }
 	  else
 	    {
-	      // TODO : function indexes 
+	      // TODO : function indexes
 	      num_idx_att = index->func_index_info->attr_index_start;
 	      return ER_FAILED;
 	    }
@@ -12405,7 +12396,7 @@ cdc_make_error_loginfo (int trid, char *user, CDC_DML_TYPE dml_type, OID classoi
     }
 
   ptr = start_ptr = PTR_ALIGN (loginfo_buf, MAX_ALIGNMENT);
-  ptr = or_pack_int (ptr, 0);	//dummy for log info length 
+  ptr = or_pack_int (ptr, 0);	//dummy for log info length
   ptr = or_pack_int (ptr, trid);
   ptr = or_pack_string (ptr, user);
   ptr = or_pack_int (ptr, dataitem_type);
@@ -12628,7 +12619,7 @@ cdc_make_dml_loginfo (THREAD_ENTRY * thread_p, int trid, char *user, CDC_DML_TYP
     }
 
   ptr = start_ptr = PTR_ALIGN (loginfo_buf, MAX_ALIGNMENT);
-  ptr = or_pack_int (ptr, 0);	//dummy for log info length 
+  ptr = or_pack_int (ptr, 0);	//dummy for log info length
   ptr = or_pack_int (ptr, trid);
   ptr = or_pack_string (ptr, user);
   ptr = or_pack_int (ptr, dataitem_type);
@@ -12667,7 +12658,7 @@ cdc_make_dml_loginfo (THREAD_ENTRY * thread_p, int trid, char *user, CDC_DML_TYP
 	{
 	  if (cdc_compare_undoredo_dbvalue (&new_values[i], &old_values[i]) > 0)
 	    {
-	      changed_col_idx[cnt++] = i;	//TODO: replace i with def_order to reduce memory alloc and copy 
+	      changed_col_idx[cnt++] = i;	//TODO: replace i with def_order to reduce memory alloc and copy
 	    }
 	}
 
@@ -12850,7 +12841,7 @@ cdc_make_ddl_loginfo (char *supplement_data, int trid, const char *user, CDC_LOG
   int statement_length;
   char *statement;
 
-  /*ddl log info : TRID | user | data_item_type | ddl_type | object_type | OID | class OID | statement length | statement | 
+  /*ddl log info : TRID | user | data_item_type | ddl_type | object_type | OID | class OID | statement length | statement |
    * cdc_make_ddl_loginfo construct log info from ddl_type to statement */
   int loginfo_length;
   int dataitem_type = CDC_DDL;
@@ -13559,7 +13550,7 @@ cdc_loginfo_producer_daemon_init ()
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (10)); /* 주석 처리  */
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (cdc_loginfo_producer_execute);
 
-  cdc_Loginfo_producer_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "cdc_loginfo_producer"); 
+  cdc_Loginfo_producer_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "cdc_loginfo_producer");
   /* *INDENT-ON* */
 }
 
@@ -13652,8 +13643,8 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 {
   /*
    * 1. get volume list
-   * 2. get fpage from each volume 
-   * 3. get commit/abort/ha_dummy_server_state which contains time from fpage 
+   * 2. get fpage from each volume
+   * 3. get commit/abort/ha_dummy_server_state which contains time from fpage
    * */
   int begin = log_Gl.hdr.last_deleted_arv_num;
   int end = log_Gl.hdr.nxarv_num - 1;
@@ -13674,9 +13665,9 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
   int error = NO_ERROR;
 
   /*
-   * 1. traverse from the latest log volume 
-   * 2. when num_arvs > 0, no logic to handle the active log volume 
-   * 3. check condition when i = begin while finding target_arv_num 
+   * 1. traverse from the latest log volume
+   * 2. when num_arvs > 0, no logic to handle the active log volume
+   * 3. check condition when i = begin while finding target_arv_num
    */
 
   /* At first, compare the time in active log volume. */
@@ -13769,7 +13760,7 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 	    }
 	  else
 	    {
-	      /* num_arvs == 0, and active_start_time > input time 
+	      /* num_arvs == 0, and active_start_time > input time
 	       * returns oldest LSA in active log volume */
 	      if (active_start_time != 0)
 		{
@@ -14053,9 +14044,9 @@ end:
 }
 
 /*
- * arv_num (in) : archive log volume number to traverse. If it is -1, then traverse active log volume. 
- * ret_lsa (out) : lsa of the first log which contains time info 
- * time (out) : time of the first log which contains time info  
+ * arv_num (in) : archive log volume number to traverse. If it is -1, then traverse active log volume.
+ * ret_lsa (out) : lsa of the first log which contains time info
+ * time (out) : time of the first log which contains time info
  */
 
 static int
@@ -14206,7 +14197,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 /*
  * time (in/out) : Time to compare (in) and actual time of log for start_lsa (out)
- * start_lsa (in/out) : start point (in) and lsa of LOG which is found (out)  
+ * start_lsa (in/out) : start point (in) and lsa of LOG which is found (out)
  */
 
 static int
@@ -14428,7 +14419,7 @@ end:
 	}
     }
 
-//  if producer status is wait, and producer queue size is over the limit 
+//  if producer status is wait, and producer queue size is over the limit
   cdc_log
     ("cdc_make_loginfo : consume the log info entry in the queue and send to the requester.\nnumber of loginfos:(%d), total length of loginfos:(%d), next LOG_LSA to consume:(%lld | %d).",
      cdc_Gl.consumer.num_log_info, cdc_Gl.consumer.log_info_size, LSA_AS_ARGS (&cdc_Gl.consumer.next_lsa));
@@ -14623,7 +14614,7 @@ int
 cdc_set_configuration (int max_log_item, int timeout, int all_in_cond, char **user, int num_user,
 		       uint64_t * classoids, int num_class)
 {
-  /* if CDC client exits abnomaly, extraction user and classoids are not freed. 
+  /* if CDC client exits abnomaly, extraction user and classoids are not freed.
    * So, reconnection requires these variables to be reset */
   cdc_free_extraction_filter ();
 

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -53,8 +53,8 @@ enum log_rectype
   LOG_CLIENT_USER_POSTPONE_DATA = 11,	/* Obsolete */
   LOG_RUN_NEXT_CLIENT_UNDO = 12,	/* Obsolete */
   LOG_RUN_NEXT_CLIENT_POSTPONE = 13,	/* Obsolete */
+  LOG_WILL_COMMIT = 14,		/* Obsolete */
 #endif
-  LOG_WILL_COMMIT = 14,		/* Transaction will be committed */
   LOG_COMMIT_WITH_POSTPONE = 15,	/* Committing server postpone operations */
 #if 0
   LOG_COMMIT_WITH_CLIENT_USER_LOOSE_ENDS = 16,	/* Obsolete */

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -53,8 +53,8 @@ enum log_rectype
   LOG_CLIENT_USER_POSTPONE_DATA = 11,	/* Obsolete */
   LOG_RUN_NEXT_CLIENT_UNDO = 12,	/* Obsolete */
   LOG_RUN_NEXT_CLIENT_POSTPONE = 13,	/* Obsolete */
-#endif
   LOG_WILL_COMMIT = 14,		/* Transaction will be committed */
+#endif
   LOG_COMMIT_WITH_POSTPONE = 15,	/* Committing server postpone operations */
 #if 0
   LOG_COMMIT_WITH_CLIENT_USER_LOOSE_ENDS = 16,	/* Obsolete */

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -69,7 +69,6 @@ static int log_rv_analysis_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_L
 static int log_rv_analysis_run_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa, LOG_PAGE * log_page_p,
 					 LOG_LSA * check_point);
 static int log_rv_analysis_compensate (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa, LOG_PAGE * log_page_p);
-static int log_rv_analysis_will_commit (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa);
 static int log_rv_analysis_commit_with_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa,
 						 LOG_PAGE * log_page_p);
 static int log_rv_analysis_sysop_start_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa,
@@ -1121,42 +1120,6 @@ log_rv_analysis_compensate (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_
 
   compensate = (LOG_REC_COMPENSATE *) ((char *) log_page_p->area + log_lsa->offset);
   LSA_COPY (&tdes->undo_nxlsa, &compensate->undo_nxlsa);
-
-  return NO_ERROR;
-}
-
-/*
- * log_rv_analysis_will_commit -
- *
- * return: error code
- *
- *   tran_id(in):
- *   lsa(in/out):
- *
- * Note:
- */
-static int
-log_rv_analysis_will_commit (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa)
-{
-  LOG_TDES *tdes;
-
-  /*
-   * If this is the first time, the transaction is seen. Assign a new
-   * index to describe it. The transaction was in the process of
-   * getting committed at this point.
-   */
-  tdes = logtb_rv_find_allocate_tran_index (thread_p, tran_id, log_lsa);
-  if (tdes == NULL)
-    {
-      logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_rv_analysis_will_commit");
-      return ER_FAILED;
-    }
-
-  tdes->state = TRAN_UNACTIVE_WILL_COMMIT;
-
-  /* Nothing to undo */
-  LSA_SET_NULL (&tdes->undo_nxlsa);
-  LSA_COPY (&tdes->tail_lsa, log_lsa);
 
   return NO_ERROR;
 }
@@ -2267,10 +2230,6 @@ log_rv_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE log_type, int tran_
 
     case LOG_COMPENSATE:
       (void) log_rv_analysis_compensate (thread_p, tran_id, log_lsa, log_page_p);
-      break;
-
-    case LOG_WILL_COMMIT:
-      (void) log_rv_analysis_will_commit (thread_p, tran_id, log_lsa);
       break;
 
     case LOG_COMMIT_WITH_POSTPONE:
@@ -4038,7 +3997,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 	    case LOG_UNDO_DATA:
 	    case LOG_DUMMY_HEAD_POSTPONE:
 	    case LOG_POSTPONE:
-	    case LOG_WILL_COMMIT:
 	    case LOG_COMMIT_WITH_POSTPONE:
 	    case LOG_SYSOP_START_POSTPONE:
 	    case LOG_START_CHKPT:
@@ -5010,7 +4968,6 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		  break;
 
 		case LOG_RUN_POSTPONE:
-		case LOG_WILL_COMMIT:
 		case LOG_COMMIT_WITH_POSTPONE:
 		case LOG_COMMIT:
 		case LOG_SYSOP_START_POSTPONE:
@@ -5877,7 +5834,6 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
       supplement = (LOG_REC_SUPPLEMENT *) ((char *) log_pgptr->area + log_lsa.offset);
       LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_SUPPLEMENT), &log_lsa, log_pgptr);
       LOG_READ_ADD_ALIGN (thread_p, supplement->length, &log_lsa, log_pgptr);
-    case LOG_WILL_COMMIT:
     case LOG_START_CHKPT:
     case LOG_2PC_COMMIT_DECISION:
     case LOG_2PC_ABORT_DECISION:

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -69,7 +69,6 @@ static int log_rv_analysis_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_L
 static int log_rv_analysis_run_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa, LOG_PAGE * log_page_p,
 					 LOG_LSA * check_point);
 static int log_rv_analysis_compensate (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa, LOG_PAGE * log_page_p);
-static int log_rv_analysis_will_commit (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa);
 static int log_rv_analysis_commit_with_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa,
 						 LOG_PAGE * log_page_p);
 static int log_rv_analysis_sysop_start_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa,
@@ -1121,42 +1120,6 @@ log_rv_analysis_compensate (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_
 
   compensate = (LOG_REC_COMPENSATE *) ((char *) log_page_p->area + log_lsa->offset);
   LSA_COPY (&tdes->undo_nxlsa, &compensate->undo_nxlsa);
-
-  return NO_ERROR;
-}
-
-/*
- * log_rv_analysis_will_commit -
- *
- * return: error code
- *
- *   tran_id(in):
- *   lsa(in/out):
- *
- * Note:
- */
-static int
-log_rv_analysis_will_commit (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa)
-{
-  LOG_TDES *tdes;
-
-  /*
-   * If this is the first time, the transaction is seen. Assign a new
-   * index to describe it. The transaction was in the process of
-   * getting committed at this point.
-   */
-  tdes = logtb_rv_find_allocate_tran_index (thread_p, tran_id, log_lsa);
-  if (tdes == NULL)
-    {
-      logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_rv_analysis_will_commit");
-      return ER_FAILED;
-    }
-
-  tdes->state = TRAN_UNACTIVE_WILL_COMMIT;
-
-  /* Nothing to undo */
-  LSA_SET_NULL (&tdes->undo_nxlsa);
-  LSA_COPY (&tdes->tail_lsa, log_lsa);
 
   return NO_ERROR;
 }
@@ -2267,10 +2230,6 @@ log_rv_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE log_type, int tran_
 
     case LOG_COMPENSATE:
       (void) log_rv_analysis_compensate (thread_p, tran_id, log_lsa, log_page_p);
-      break;
-
-    case LOG_WILL_COMMIT:
-      (void) log_rv_analysis_will_commit (thread_p, tran_id, log_lsa);
       break;
 
     case LOG_COMMIT_WITH_POSTPONE:
@@ -4038,7 +3997,6 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 	    case LOG_UNDO_DATA:
 	    case LOG_DUMMY_HEAD_POSTPONE:
 	    case LOG_POSTPONE:
-	    case LOG_WILL_COMMIT:
 	    case LOG_COMMIT_WITH_POSTPONE:
 	    case LOG_SYSOP_START_POSTPONE:
 	    case LOG_START_CHKPT:
@@ -5010,7 +4968,6 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		  break;
 
 		case LOG_RUN_POSTPONE:
-		case LOG_WILL_COMMIT:
 		case LOG_COMMIT_WITH_POSTPONE:
 		case LOG_COMMIT:
 		case LOG_SYSOP_START_POSTPONE:
@@ -5877,7 +5834,6 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
       supplement = (LOG_REC_SUPPLEMENT *) ((char *) log_pgptr->area + log_lsa.offset);
       LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_SUPPLEMENT), &log_lsa, log_pgptr);
       LOG_READ_ADD_ALIGN (thread_p, supplement->length, &log_lsa, log_pgptr);
-    case LOG_WILL_COMMIT:
     case LOG_START_CHKPT:
     case LOG_2PC_COMMIT_DECISION:
     case LOG_2PC_ABORT_DECISION:
@@ -6544,7 +6500,7 @@ log_rv_redo_fix_page (THREAD_ENTRY * thread_p, const VPID * vpid_rcv)
   // sector reservation table are applied in parallel with the changes in pages, at times the page may appear to be
   // deallocated (part of an unreserved sector). but the changes were done while the sector was reserved and must be
   // re-applied to get a correct end result.
-  // 
+  //
   // moreover, the sector reservation check is very expensive. running this check on every page fix costs much more
   // than any time gained by skipping redoing changes on deallocated pages.
   //


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24200

Purpose
make a macro obsolete that is not used anymore

Implementation
Make 'LOG_WILL_COMMIT' obsolete and delete all corresponding codes.

Remarks
N/A