### PR TITLE
[LETS-390] Add pgbuf_fix_if_not_deallocated wrapper

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -14746,8 +14746,7 @@ pgbuf_fix_if_not_deallocated_with_repl_desync_check (THREAD_ENTRY * thread_p, co
 						     PGBUF_LATCH_MODE latch_mode, PGBUF_LATCH_CONDITION latch_condition,
 						     PAGE_PTR * page)
 {
-  int error_code =
-    pgbuf_fix_if_not_deallocated_with_caller (thread_p, vpid, latch_mode, latch_condition, page, ARG_FILE_LINE);
+  int error_code = pgbuf_fix_if_not_deallocated (thread_p, vpid, latch_mode, latch_condition, page);
 
   if (is_passive_transaction_server ())
     {

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -14754,6 +14754,14 @@ pgbuf_fix_if_not_deallocated_with_repl_desync_check (THREAD_ENTRY * thread_p, co
       if (error_code == NO_ERROR && page != nullptr)
 	{
 	  error_code = pgbuf_check_page_ahead_of_replication (thread_p, *page);
+
+	  if (error_code == ER_PAGE_AHEAD_OF_REPLICATION)
+	    {
+	      // Unfix the page
+	      pgbuf_unfix (thread_p, *page);
+	      *page = nullptr;
+	      error_code = NO_ERROR;
+	    }
 	}
     }
 

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -438,6 +438,10 @@ extern int pgbuf_rv_dealloc_undo_compensate (THREAD_ENTRY * thread_p, const LOG_
 extern int pgbuf_fix_if_not_deallocated_with_caller (THREAD_ENTRY * thead_p, const VPID * vpid,
 						     PGBUF_LATCH_MODE latch_mode, PGBUF_LATCH_CONDITION latch_condition,
 						     PAGE_PTR * page, const char *caller_file, int caller_line);
+extern int
+pgbuf_fix_if_not_deallocated_with_repl_desync_check (THREAD_ENTRY * thread_p, const VPID * vpid,
+						     PGBUF_LATCH_MODE latch_mode, PGBUF_LATCH_CONDITION latch_condition,
+						     PAGE_PTR * page);
 #if defined (NDEBUG)
 #define pgbuf_fix_if_not_deallocated(thread_p, vpid, latch_mode, latch_condition, page) \
   pgbuf_fix_if_not_deallocated_with_caller (thread_p, vpid, latch_mode, latch_condition, page, NULL, 0)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-390

Added a new wrapper function `pgbuf_fix_if_not_deallocated_with_repl_desync_check` over `pgbuf_fix_if_not_deallocated` that also looks for page desyncronization
