### PR TITLE
[CBRD-24205] Invalid xasl error occurs when plan cache removed while executing executeBatch

### DIFF
--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -2712,7 +2712,15 @@ ux_execute_array (T_SRV_HANDLE * srv_handle, int argc, void **argv, T_NET_BUF * 
 	{
 	  if (res_count == ER_QPROC_INVALID_XASLNODE && retried_query_num != num_query)
 	    {
-	      goto exec_retry_xasl_error;
+	      err_code = recompile_statement (srv_handle);
+	      if (err_code < 0)
+		{
+		  goto exec_db_error;
+		}
+	      session = (DB_SESSION *) srv_handle->session;
+	      retried_query_num = num_query;
+	      num_query--;
+	      continue;
 	    }
 	  goto exec_db_error;
 	}
@@ -2810,18 +2818,6 @@ ux_execute_array (T_SRV_HANDLE * srv_handle, int argc, void **argv, T_NET_BUF * 
 	{
 	  break;
 	}
-      continue;
-
-    exec_retry_xasl_error:
-      err_code = recompile_statement (srv_handle);
-      if (err_code < 0)
-	{
-	  goto exec_db_error;
-	}
-
-      session = (DB_SESSION *) srv_handle->session;
-      retried_query_num = num_query;
-      num_query--;
     }
 
   net_buf_overwrite_int (net_buf, num_query_msg_offset, num_query);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -2812,8 +2812,6 @@ ux_execute_array (T_SRV_HANDLE * srv_handle, int argc, void **argv, T_NET_BUF * 
       continue;
 
     exec_retry_xasl_error:
-      cas_log_write_and_end (0, false, "== xasl error : %d", num_query);
-
       if (session != NULL)
 	{
 	  db_close_session (session);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24205

Purpose
If the plan cache is deleted while executing multiple queries using executeBatch, all subsequent queries are not executed.
In this case, if the plan cache is regenerated, the query can be executed normally.
Since an error does not always occur, it can be reproduced only by forcibly deleting the plan cache during the test.

Implementation
N/A

Remarks
N/A