### PR TITLE
[LETS-386] on server boot, during recovery and until log recovery undo, inhibit comparison between local and remote storage heap pages

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8202,7 +8202,7 @@ pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * 
 	   *    active transaction server (ie: the page still exists), but the log has been applied on
 	   *    page server and the page cannot be retrieved
 	   */
-	  if (log_is_restarted_or_in_crash_recovery_but_past_redo ())
+	  if (log_is_in_crash_recovery_but_past_redo_or_restarted ())
 	    {
 #if !defined(NDEBUG)
 	      if (!(io_page->prv == second_io_page->prv))
@@ -8226,7 +8226,7 @@ pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * 
 	      const bool local_lsa_is_less_than_or_equal_to_page_server_lsa
 		= (io_page->prv.lsa <= second_io_page->prv.lsa);
 	      const bool equal_vpid = io_page->prv.volid == second_io_page->prv.volid
-		&& io_page->prv.pageid == second_io_page->prv.pageid && io_page->prv.ptype == second_io_page->prv.ptype;
+		&& io_page->prv.pageid == second_io_page->prv.pageid;
 #if !defined(NDEBUG)
 	      if (!local_lsa_is_less_than_or_equal_to_page_server_lsa && !equal_vpid)
 		{

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8185,15 +8185,66 @@ pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * 
 	  const size_t io_page_size = static_cast<size_t> (db_io_page_size ());
 	  std::unique_ptr<char []> buffer_uptr = std::make_unique<char []> (io_page_size);
 	  FILEIO_PAGE *second_io_page = reinterpret_cast<FILEIO_PAGE *> (buffer_uptr.get ());
+	  // *INDENT-ON*
 	  error_code = pgbuf_request_data_page_from_page_server (vpid, target_repl_lsa, second_io_page);
 	  if (error_code != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
 	      return error_code;
 	    }
-	  assert (io_page->prv == second_io_page->prv);
+
+	  /* NOTE:
+	   *  - heap pages are requested also during the recovery phase (after the active transaction server has
+	   *    crashed); in this case, it is normal that the pages requested from page server are out of sync with
+	   *    pages from local storage
+	   * TODO:
+	   *  - in this scenario, what if pages have been deleted, the change is not yet applied on
+	   *    active transaction server (ie: the page still exists), but the log has been applied on
+	   *    page server and the page cannot be retrieved
+	   */
+	  if (log_is_restarted_or_in_crash_recovery_but_past_redo ())
+	    {
+#if !defined(NDEBUG)
+	      if (!(io_page->prv == second_io_page->prv))
+		{
+		  er_log_debug (ARG_FILE_LINE, "pgbuf_read_page_from_file_or_page_server"
+				"past recovery redo pages not equal\n"
+				"    target repl LSA: %lld|%d\n"
+				"    local page  VPID: %d|%d  LSA: %lld|%d  ptype: %d\n"
+				"    remote page VPID: %d|%d  LSA: %lld|%d  ptype: %d\n",
+				LSA_AS_ARGS (&target_repl_lsa),
+				io_page->prv.volid, io_page->prv.pageid,
+				LSA_AS_ARGS (&io_page->prv.lsa), io_page->prv.ptype,
+				second_io_page->prv.volid, second_io_page->prv.pageid,
+				LSA_AS_ARGS (&second_io_page->prv.lsa), second_io_page->prv.ptype);
+		}
+#endif
+	      assert (io_page->prv == second_io_page->prv);
+	    }
+	  else
+	    {
+	      const bool local_lsa_is_less_than_or_equal_to_page_server_lsa
+		= (io_page->prv.lsa <= second_io_page->prv.lsa);
+	      const bool equal_vpid = io_page->prv.volid == second_io_page->prv.volid
+		&& io_page->prv.pageid == second_io_page->prv.pageid && io_page->prv.ptype == second_io_page->prv.ptype;
+#if !defined(NDEBUG)
+	      if (!local_lsa_is_less_than_or_equal_to_page_server_lsa && !equal_vpid)
+		{
+		  er_log_debug (ARG_FILE_LINE, "pgbuf_read_page_from_file_or_page_server"
+				"past recovery redo pages not equal\n"
+				"    target repl LSA: %lld|%d\n"
+				"    local page  VPID: %d|%d  LSA: %lld|%d  ptype: %d\n"
+				"    remote page VPID: %d|%d  LSA: %lld|%d  ptype: %d\n",
+				LSA_AS_ARGS (&target_repl_lsa),
+				io_page->prv.volid, io_page->prv.pageid,
+				LSA_AS_ARGS (&io_page->prv.lsa), io_page->prv.ptype,
+				second_io_page->prv.volid, second_io_page->prv.pageid,
+				LSA_AS_ARGS (&second_io_page->prv.lsa), second_io_page->prv.ptype);
+		}
+#endif
+	      assert (local_lsa_is_less_than_or_equal_to_page_server_lsa && equal_vpid);
+	    }
 	  return NO_ERROR;
-	  // *INDENT-ON*
 	}
       else
 	{

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8202,7 +8202,7 @@ pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * 
 	   *    active transaction server (ie: the page still exists), but the log has been applied on
 	   *    page server and the page cannot be retrieved
 	   */
-	  if (log_is_in_crash_recovery_but_past_redo_or_restarted ())
+	  if (log_is_in_past_redo_crash_recovery_or_restarted ())
 	    {
 #if !defined(NDEBUG)
 	      if (!(io_page->prv == second_io_page->prv))

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -546,25 +546,6 @@ log_is_in_crash_recovery (void)
 }
 
 /*
- * log_is_in_crash_recovery_and_not_year_complets_redo - completes redo recovery?
- *
- * return:
- *
- */
-bool
-log_is_in_crash_recovery_and_not_yet_completes_redo (void)
-{
-  if (log_Gl.rcv_phase == LOG_RECOVERY_ANALYSIS_PHASE || log_Gl.rcv_phase == LOG_RECOVERY_REDO_PHASE)
-    {
-      return true;
-    }
-  else
-    {
-      return false;
-    }
-}
-
-/*
  * log_get_restart_lsa - FIND RESTART LOG SEQUENCE ADDRESS
  *
  * return:

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -61,7 +61,8 @@ struct log_topop_range
 
 extern const char *log_to_string (LOG_RECTYPE type);
 extern bool log_is_in_crash_recovery (void);
-extern bool log_is_in_crash_recovery_and_not_yet_completes_redo (void);
+inline bool log_is_in_crash_recovery_and_not_yet_completes_redo (void);
+inline bool log_is_in_crash_recovery_but_past_redo_or_restarted (void);
 extern LOG_LSA *log_get_restart_lsa (void);
 extern LOG_LSA *log_get_crash_point_lsa (void);
 extern LOG_LSA *log_get_append_lsa (void);
@@ -287,5 +288,33 @@ void LOG_CS_PROMOTE (THREAD_ENTRY * thread_p);
 
 bool LOG_CS_OWN (THREAD_ENTRY * thread_p);
 bool LOG_CS_OWN_WRITE_MODE (THREAD_ENTRY * thread_p);
+
+//
+// inline implementations
+//
+
+inline bool
+log_is_in_crash_recovery_and_not_yet_completes_redo (void)
+{
+  if (log_Gl.rcv_phase == LOG_RECOVERY_ANALYSIS_PHASE || log_Gl.rcv_phase == LOG_RECOVERY_REDO_PHASE)
+    {
+      return true;
+    }
+  else
+    {
+      return false;
+    }
+}
+
+inline bool
+log_is_in_crash_recovery_but_past_redo_or_restarted (void)
+{
+  if (LOG_RESTARTED == log_Gl.rcv_phase || LOG_RECOVERY_UNDO_PHASE == log_Gl.rcv_phase
+      || LOG_RECOVERY_FINISH_2PC_PHASE == log_Gl.rcv_phase)
+    {
+      return true;
+    }
+  return false;
+}
 
 #endif /* _LOG_MANAGER_H_ */

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -62,7 +62,7 @@ struct log_topop_range
 extern const char *log_to_string (LOG_RECTYPE type);
 extern bool log_is_in_crash_recovery (void);
 inline bool log_is_in_crash_recovery_and_not_yet_completes_redo (void);
-inline bool log_is_in_crash_recovery_but_past_redo_or_restarted (void);
+inline bool log_is_in_past_redo_crash_recovery_or_restarted (void);
 extern LOG_LSA *log_get_restart_lsa (void);
 extern LOG_LSA *log_get_crash_point_lsa (void);
 extern LOG_LSA *log_get_append_lsa (void);
@@ -307,7 +307,7 @@ log_is_in_crash_recovery_and_not_yet_completes_redo (void)
 }
 
 inline bool
-log_is_in_crash_recovery_but_past_redo_or_restarted (void)
+log_is_in_past_redo_crash_recovery_or_restarted (void)
 {
   if (LOG_RESTARTED == log_Gl.rcv_phase || LOG_RECOVERY_UNDO_PHASE == log_Gl.rcv_phase
       || LOG_RECOVERY_FINISH_2PC_PHASE == log_Gl.rcv_phase)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-386

During recovery, do not strictly compare local and page server retrieved heap pages because local retrieved pages might be behind actual state due to recovery not having been performed yet.
This occurs in early stages of server boot. Once log recovery passes the "redo" sequence, pages on local (ATS) and remote (PS) storage must already be in sync and strict comparison can resume.

Other:
- made some functions inline
