### PR TITLE
[LETS-397] During ATS recovery PS must serve heap pages with specific fetch mode

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8229,8 +8229,7 @@ pgbuf_read_page_from_file_or_page_server (THREAD_ENTRY * thread_p, const VPID * 
 	    }
 	  else
 	    {
-	      const bool fileio_pages_equal = (io_page->prv == second_io_page->prv)
-		|| (io_page->prv.ptype == second_io_page->prv.ptype && io_page->prv.ptype == PAGE_OVERFLOW);
+	      const bool fileio_pages_equal = (io_page->prv == second_io_page->prv);
 	      if (!fileio_pages_equal)
 		{
 		  /* on a transaction server, btree statistics is not written immediately

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8423,7 +8423,7 @@ pgbuf_respond_data_fetch_page_request (THREAD_ENTRY &thread_r, std::string &payl
 
   int error = NO_ERROR;
   PAGE_PTR page_ptr = pgbuf_fix (&thread_r, &vpid, fetch_mode, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
-  if (error == NO_ERROR && fetch_mode == RECOVERY_PAGE)
+  if (page_ptr == nullptr && fetch_mode == RECOVERY_PAGE)
     {
       ASSERT_NO_ERROR ();
       //The found page was deallocated already

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8334,7 +8334,7 @@ pgbuf_request_data_page_from_page_server (const VPID * vpid, log_lsa target_repl
   cublog::lsa_utils::pack (pac, target_repl_lsa);
 
   PAGE_FETCH_MODE fetch_mode;
-  if (log_Gl.rcv_phase >= LOG_RECOVERY_UNDO_PHASE)
+  if (log_Gl.rcv_phase >= LOG_RECOVERY_UNDO_PHASE || log_Gl.rcv_phase == LOG_RESTARTED)
     {
       fetch_mode = OLD_PAGE;
     }

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -627,7 +627,7 @@ struct trantable
 /* state of recovery process */
 enum log_recvphase
 {
-  LOG_RESTARTED,		/* Normal processing.. recovery has been executed. */
+  LOG_RESTARTED,		/* Normal processing. Recovery has been executed. */
   LOG_RECOVERY_ANALYSIS_PHASE,	/* Start recovering. Find the transactions that were active at the time of the crash */
   LOG_RECOVERY_REDO_PHASE,	/* Redoing phase */
   LOG_RECOVERY_UNDO_PHASE,	/* Undoing phase */


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-397

Changed ATS inside `pgbuf_request_data_page_from_page_server` to also send the desired fetch mode to the PS when requesting a data page.

The fetch mode that is send depends on the stage of recovery and avoids problems with de-allocated pages.
