### PR TITLE
[LETS-399] fix PS crash upon new PTS connecting to it

### DIFF
--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -136,7 +136,7 @@ page_server::connection_handler::receive_log_boot_info_fetch (tran_server_conn_t
 {
   m_prior_sender_sink_hook_func =
 	  std::bind (&connection_handler::prior_sender_sink_hook, this, std::placeholders::_1);
-  push_async_response (&log_pack_log_boot_info, std::move (a_sp), m_prior_sender_sink_hook_func);
+  push_async_response (&log_pack_log_boot_info, std::move (a_sp), std::ref (m_prior_sender_sink_hook_func));
 }
 
 void


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-399

A reference to the `std::function` must be forwarded instead of the value.

