### PR TITLE
[CBRD-24210] Fix an error when executing SHOW EXEC STATISTICS;

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -1652,6 +1652,8 @@ stmt_list
 			  }
 
 		DBG_PRINT}}
+        | ';'
+                {{ /* empty line*/ }}
 	;
 
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24210

After applying CBRD-24117, the error occurs.
The error occurs in the following two statements:

```
SHOW EXEC STATISTICS;
SHOW EXEC STATISTICS ALL;
```
