### PR TITLE
[CBRD-23986] Revise the truncate query for dont_reuse_oid class

### DIFF
--- a/src/object/schema_class_truncator.cpp
+++ b/src/object/schema_class_truncator.cpp
@@ -556,7 +556,7 @@ namespace cubschema
 	AU_DISABLE (au_save);
 
 	(void) snprintf (select_query, sizeof (select_query),
-			 "SELECT COUNT(*) FROM [_db_domain] WHERE [data_type]=%d AND ([class_of].[class_name]='%s' OR [class_of] IS NULL) and rownum <= %d",
+			 "SELECT COUNT(*) FROM [_db_domain] WHERE [data_type]=%d AND ([class_of].[class_name]='%s' OR [class_of] IS NULL) AND ROWNUM <= %d",
 			 DB_TYPE_OBJECT, class_name, CNT_CATCLS_OBJECTS + 1);
 
 	session = db_open_buffer (select_query);

--- a/src/object/schema_class_truncator.cpp
+++ b/src/object/schema_class_truncator.cpp
@@ -556,7 +556,7 @@ namespace cubschema
 	AU_DISABLE (au_save);
 
 	(void) snprintf (select_query, sizeof (select_query),
-			 "SELECT COUNT(*) FROM [_db_domain] WHERE [data_type]=%d AND ([class_of].[class_name]='%s' OR [class_of] IS NULL) LIMIT %d",
+			 "SELECT COUNT(*) FROM [_db_domain] WHERE [data_type]=%d AND ([class_of].[class_name]='%s' OR [class_of] IS NULL) and rownum <= %d",
 			 DB_TYPE_OBJECT, class_name, CNT_CATCLS_OBJECTS + 1);
 
 	session = db_open_buffer (select_query);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23986

When doing TRUNCATE  a class with the DONT_REUSE_OID option, a select query is used to determine the way to truncate it:
`SELECT COUNT(*) FROM [_db_domain] WHERE [data_type]=%d AND ([class_of].[class_name]='%s' OR [class_of] IS NULL) LIMIT %d`

We add an index for consistent running time (https://github.com/CUBRID/cubrid/pull/3376), but a query rewriter makes a query doing an additional sequential scan even if there is an index. To prevent it, we revise the query which has the same meaning. See the Jira issue comment for more information.

P.S. I have done manual tests and it doesn't need new regression tests because existing ones already cover it.