### PR TITLE
[CBRD-24215] make temp filenames unique in CMS

### DIFF
--- a/src/cm_common/cm_dep.h
+++ b/src/cm_common/cm_dep.h
@@ -267,7 +267,7 @@ extern "C"
   int cm_util_log_write_command (int argc, char *argv[]);
 
   int make_temp_filename (char *tempfile, char *prefix, int size);
-  int make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int id, int size);
+  int make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, int size);
 
 #ifdef __cplusplus
 }

--- a/src/cm_common/cm_dep.h
+++ b/src/cm_common/cm_dep.h
@@ -266,6 +266,9 @@ extern "C"
   int cm_util_log_write_errstr (const char *format, ...);
   int cm_util_log_write_command (int argc, char *argv[]);
 
+  int make_temp_filename (char *tempfile, char *prefix, int size);
+  int make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int id, int size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -1379,6 +1379,7 @@ user_login_sa (nvplist * out, char *_dbmt_error, char *dbname, char *dbuser, cha
 
   if (make_temp_filename (tmpfile, "DBMT_ems_sa.", PATH_MAX) < 0)
     {
+      strcpy (_dbmt_error, "make_temp_filename: filename creation error");
       goto login_err;
     }
 

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -1377,9 +1377,11 @@ user_login_sa (nvplist * out, char *_dbmt_error, char *dbname, char *dbuser, cha
   char cmd_name[PATH_MAX];
   char *outmsg = NULL, *errmsg = NULL;
 
-  if (make_temp_filename (tmpfile, "DBMT_ems_sa.", PATH_MAX) < 0) {
-    goto login_err;
-  }
+  if (make_temp_filename (tmpfile, "DBMT_ems_sa.", PATH_MAX) < 0)
+    {
+      goto login_err;
+    }
+
 
   (void) envvar_tmpdir_file (outfile, PATH_MAX, tmpfile);
   if (snprintf (errfile, PATH_MAX - 1, "%s.err", outfile) < 0)

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -1372,12 +1372,15 @@ user_login_sa (nvplist * out, char *_dbmt_error, char *dbname, char *dbuser, cha
 {
   char opcode[10];
   char outfile[PATH_MAX], errfile[PATH_MAX];
-  char tmpfile[100];
+  char tmpfile[PATH_MAX];
   const char *argv[10];
   char cmd_name[PATH_MAX];
   char *outmsg = NULL, *errmsg = NULL;
 
-  snprintf (tmpfile, sizeof (tmpfile) - 1, "%s%d", "DBMT_ems_sa.", getpid ());
+  if (make_temp_filename (tmpfile, "DBMT_ems_sa.", PATH_MAX) < 0) {
+    goto login_err;
+  }
+
   (void) envvar_tmpdir_file (outfile, PATH_MAX, tmpfile);
   if (snprintf (errfile, PATH_MAX - 1, "%s.err", outfile) < 0)
     {
@@ -1528,9 +1531,13 @@ class_info_sa (const char *dbname, const char *uid, const char *passwd, char *cl
   const char *argv[10];
   char cli_ver[10];
   char opcode[10];
-  char tmpfile[100];
+  char tmpfile[PATH_MAX];
 
-  int ret = snprintf (tmpfile, sizeof (tmpfile) - 1, "%s%d", "DBMT_class_info.", getpid ());
+  if (make_temp_filename (tmpfile, "DBMT_class_info.", PATH_MAX) < 0)
+    {
+      return ERR_GENERAL_ERROR;
+    }
+
   (void) envvar_tmpdir_file (outfile, PATH_MAX, tmpfile);
   if (snprintf (errfile, PATH_MAX - 1, "%s.err", outfile) < 0)
     {
@@ -2537,9 +2544,13 @@ trigger_info_sa (const char *dbname, const char *uid, const char *passwd, nvplis
   int ret_val = ERR_NO_ERROR;
   char cmd_name[PATH_MAX];
   const char *argv[10];
-  char tmpfile[100];
+  char tmpfile[PATH_MAX];
 
-  int ret = snprintf (tmpfile, sizeof (tmpfile) - 1, "%s%d", "DBMT_trigger_info.", getpid ());
+  if (make_temp_filename (tmpfile, "DBMT_trigger_info.", PATH_MAX) < 0)
+    {
+      return ERR_GENERAL_ERROR;
+    }
+
   (void) envvar_tmpdir_file (outfile, PATH_MAX, tmpfile);
   if (snprintf (errfile, PATH_MAX - 1, "%s.err", outfile) < 0)
     {

--- a/src/cm_common/cm_mem_cpu_stat.c
+++ b/src/cm_common/cm_mem_cpu_stat.c
@@ -1301,12 +1301,18 @@ cm_get_command_result (const char *argv[], EXTRACT_FUNC func, const char *func_a
   FILE *fp = NULL;
   char outputfile[PATH_MAX];
   char errfile[PATH_MAX];
-  char tmpfile[100];
+  char tmpfile[PATH_MAX];
 
-  snprintf (tmpfile, sizeof (tmpfile) - 1, "%s%d", "cmd_res_", getpid ());
+  if (make_temp_filename (tmpfile, "cmd_res_", PATH_MAX) < 0)
+    {
+      return NULL;
+    }
   (void) envvar_tmpdir_file (outputfile, PATH_MAX, tmpfile);
 
-  snprintf (tmpfile, sizeof (tmpfile) - 1, "%s%d", "cmd_err_", getpid ());
+  if (make_temp_filename (tmpfile, "cmd_err_", PATH_MAX) < 0)
+    {
+      return NULL;
+    }
   (void) envvar_tmpdir_file (errfile, PATH_MAX, tmpfile);
 
   if (run_child (argv, 1, NULL, outputfile, errfile, NULL) < 0)

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -788,7 +788,7 @@ make_temp_filename (char *tempfile, char *prefix, int size)
 }
 
 int
-make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int id, int size)
+make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, int size)
 {
   struct timeval current_time;
 
@@ -803,7 +803,7 @@ make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int id, int siz
       return -1;
     }
 
-  snprintf (tempfile, size - 1, "%s/%s_%d_%ld_%d", tempdir, prefix ? prefix : "", id,
+  snprintf (tempfile, size - 1, "%s/%s_%03d_%ld_%d", tempdir, prefix ? prefix : "", task_code,
 	    current_time.tv_sec, current_time.tv_usec, rand () % 997);
 
   return 0;

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -398,7 +398,7 @@ cmd_server_status (void)
   char out_file[PATH_MAX];
   char cmd_name[PATH_MAX];
   const char *argv[5];
-  char tmpfile[512];
+  char tmpfile[PATH_MAX];
 
   res = new_servstat_result ();
   if (res == NULL)
@@ -415,7 +415,8 @@ cmd_server_status (void)
 
   if (make_temp_filename (tmpfile, "DBMT_util_001.", sizeof (tmpfile)) < 0)
     {
-      return res;
+      cmd_result_free (res);
+      return NULL;
     }
   (void) envvar_tmpdir_file (out_file, PATH_MAX, tmpfile);
   (void) envvar_bindir_file (cmd_name, PATH_MAX, UTIL_CUBRID);

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -803,7 +803,7 @@ make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int id, int siz
     }
 
   snprintf (tempfile, size - 1, "%s/%s_%d_%ld_%d", tempdir, prefix ? prefix : "", id,
-        current_time.tv_sec, current_time.tv_usec, rand () % 997);
+            current_time.tv_sec, current_time.tv_usec, rand () % 997);
 
   return 0;
 }

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -803,7 +803,7 @@ make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int id, int siz
     }
 
   snprintf (tempfile, size - 1, "%s/%s_%d_%ld_%d", tempdir, prefix ? prefix : "", id,
-            current_time.tv_sec, current_time.tv_usec, rand () % 997);
+	    current_time.tv_sec, current_time.tv_usec, rand () % 997);
 
   return 0;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24215

**Purpose**
- This is a defensive code in some sense of meaning.
- In CUBRID Manager Server, most temp file names looks like:
  cmd_res_{**pid**}, for example **_cmd_res_29470_**
- In the environment of multiple clients request massive CMS api at the same time, temp file name of this style may cause some problem because every clients use same file for intermediate result create/writing/reading/delete
- We must guarantee that every temp files for any client is **unique** to avoid such a contention, new temp file name style will be:
cmd_res_{**seconds**}\_{**usecs**}_{random number less than 997} , for example **_cmd_res_1645860068_17325_624_**
(it is number of seconds and microseconds since the Epoch)

**Implementation**
1. We will introduce two file name generation functions in src/cm_common/cm_utils.c
  `make_temp_filename ( )`, `make_temp_filepath ( )`
2. And change temp file name generation code in src/cm_common
3. After merging of this PR, we will replace temp file name generations code in **CUBRID/cubrid-manager-server** repo using above two functions.

**Remarks**
`gettimeofday` () is not defined in windows, so we got the code snippet from **base/porting.c**.