### PR TITLE
[LETS-367] Active transaction server transaction table checkpointing daemon must execute upfront after instantiation

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10729,12 +10729,12 @@ log_checkpoint_daemon_init ()
 void
 log_get_checkpoint_trantable_interval (bool & is_timed_wait, cubthread::delta_time & period)
 {
+  // will only be accessed
   static bool first_call = true;
   is_timed_wait = true;
   if (!BO_IS_SERVER_RESTARTED)
     {
       period = std::chrono::milliseconds (100);
-      return;
     }
   else
     {
@@ -10742,7 +10742,6 @@ log_get_checkpoint_trantable_interval (bool & is_timed_wait, cubthread::delta_ti
         {
           first_call = false;
           period = std::chrono::milliseconds (100);
-          return;
         }
       else
         {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1548,6 +1548,11 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
 	}
     }
 
+  if (is_tran_server_with_remote_storage () && is_active_transaction_server ())
+    {
+      logpb_checkpoint_trantable (thread_p);
+    }
+
   LOG_CS_EXIT (thread_p);
 
   er_log_debug (ARG_FILE_LINE, "log_initialize_internal: end of log initializaton, append_lsa = (%lld|%d) \n",

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1548,11 +1548,6 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
 	}
     }
 
-//  if (is_tran_server_with_remote_storage () && is_active_transaction_server ())
-//    {
-//      logpb_checkpoint_trantable (thread_p);
-//    }
-
   LOG_CS_EXIT (thread_p);
 
   er_log_debug (ARG_FILE_LINE, "log_initialize_internal: end of log initializaton, append_lsa = (%lld|%d) \n",
@@ -10738,7 +10733,7 @@ log_get_checkpoint_trantable_interval (bool & is_timed_wait, cubthread::delta_ti
   is_timed_wait = true;
   if (!BO_IS_SERVER_RESTARTED)
     {
-      period = std::chrono::seconds (1);
+      period = std::chrono::milliseconds (100);
       return;
     }
   else


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-367

Currently, the daemon is set to execute at fixed 60 seconds intervals.

Because of this, after instantiation, it needs 60 seconds to create a transaction table checkpoint and add it to the log.

Transaction table checkpoints are created to be consumed when one passive transaction server comes online in order to have a baseline transaction table from which it can then start to construct a consistent transaction table in order to provide consistent responses to queries.

As such, if a passive transaction server is started within the 60 seconds interval that it takes the active transaction server to create a first transaction table checkpoint, it will not obtain the information about such a table recorded in the from the active transaction server (via the page server).

To fix this the snapshot has to be created earlier as a baseline for PTS before the daemon will enter his normal cycle.
