### PR TITLE
[CBRD-24220] Add timestamp binding for oracle

### DIFF
--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1402,7 +1402,7 @@ $ LOADDB
 1327 Invalid precision value of "%1$s" column.
 
 1328 Invalid Descriptor handle.
-1329 Error reserved for dblink development.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1402,7 +1402,7 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1327 Invalid precision value of "%1$s" column.
 
 1328 Invalid Descriptor handle.
-1329 Error reserved for dblink development.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/en_US/cubrid.msg
+++ b/msg/en_US/cubrid.msg
@@ -1391,7 +1391,7 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1316 dblink - Multiple "%1$s" Server found.
 1317 dblink - Not allowed "%1$s" Server.
 
-1318 [%1$5.5s] %2$s (%3$d)
+1318 [%1$5.5s][%2$d] %3$s
 1319 Parameter binding error.
 1320 Invalid ODBC handle.
 1321 Type conversion error.
@@ -1402,8 +1402,8 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1326 Invalid numeric value.
 1327 Invalid precision value of "%1$s" column.
 
-1328 Error reserved for dblink development.
-1329 Error reserved for dblink development.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1402,7 +1402,7 @@ Verifique la ruta del archivo de claves (_keys) y asegúrese de que incluya la c
 1327 Invalid precision value of "%1$s" column.
 
 1328 Invalid Descriptor handle.
-1329 Error reserved for dblink development.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1402,7 +1402,7 @@ Vérifiez le chemin du fichier de clé (_keys) et assurez-vous qu'il inclut la c
 1327 Invalid precision value of "%1$s" column.
 
 1328 Invalid Descriptor handle.
-1329 Error reserved for dblink development.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1402,7 +1402,7 @@ Controllare il percorso del file della chiave (_keys) e assicurarsi che includa 
 1327 Invalid precision value of "%1$s" column.
 
 1328 Invalid Descriptor handle.
-1329 Error reserved for dblink development.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1402,7 +1402,7 @@ $ LOADDB
 1327 Invalid precision value of "%1$s" column.
 
 1328 Invalid Descriptor handle.
-1329 Error reserved for dblink development.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1402,7 +1402,7 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1327 Invalid precision value of "%1$s" column.
 
 1328 Invalid Descriptor handle.
-1329 Error reserved for dblink development.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/ko_KR.euckr/cubrid.msg
+++ b/msg/ko_KR.euckr/cubrid.msg
@@ -1402,7 +1402,7 @@ $ LOADDB
 1327 "%1$s" 열의 정밀도 값이 잘못되었습니다.
 
 1328 잘못된 Descriptor Handle 입니다.
-1329 Error reserved for dblink development.
+1329 지원하지 않는 DBMS 입니다.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1402,7 +1402,7 @@ $ LOADDB
 1327 "%1$s" 열의 정밀도 값이 잘못되었습니다.
 
 1328 잘못된 Descriptor Handle 입니다.
-1329 Error reserved for dblink development.
+1329 지원하지 않는 DBMS 입니다.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/ro_RO.utf8/cubrid.msg
+++ b/msg/ro_RO.utf8/cubrid.msg
@@ -1402,7 +1402,7 @@ Verificați calea fișierului cheie (_keys) și asigurați-vă că acesta includ
 1327 Invalid precision value of "%1$s" column.
 
 1328 Invalid Descriptor handle.
-1329 Error reserved for dblink development.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1402,7 +1402,7 @@ Anahtar dosyasının (_keys) yolunu kontrol edin ve uygun anahtarı içerdiğind
 1327 Invalid precision value of "%1$s" column.
 
 1328 Invalid Descriptor handle.
-1329 Error reserved for dblink development.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1402,7 +1402,7 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1327 Invalid precision value of "%1$s" column.
 
 1328 Invalid Descriptor handle.
-1329 Error reserved for dblink development.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/msg/zh_CN.utf8/cubrid.msg
+++ b/msg/zh_CN.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ $ LOADDB
 1327 Invalid precision value of "%1$s" column.
 
 1328 Invalid Descriptor handle.
-1329 Error reserved for dblink development.
+1329 Not supported dbms.
 1330 Error reserved for dblink development.
 1331 Error reserved for dblink development.
 

--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -1695,7 +1695,7 @@
 #define ER_CGW_INVALID_PRECISION_VALUE              -1327
 
 #define ER_CGW_INVALID_DESC_HANDLE                  -1328
-#define ER_DBLINK_DEV_RESERVED_ERROR29              -1329
+#define ER_CGW_NOT_SUPPORTED_DBMS                   -1329
 #define ER_DBLINK_DEV_RESERVED_ERROR30              -1330
 #define ER_DBLINK_DEV_RESERVED_ERROR31              -1331
 

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1244,6 +1244,7 @@ cas_main (void)
 #else
 
 	    dbms_type = cgw_is_supported_dbms (shm_appl->cgw_link_server);
+	    cgw_set_dbms_type (dbms_type);
 
 	    if (dbms_type == SUPPORTED_DBMS_ORACLE)
 	      {

--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -170,4 +170,5 @@ extern int cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding,
 
 extern int cgw_endtran (SQLHDBC hdbc, int tran_type);
 extern SUPPORTED_DBMS_TYPE cgw_is_supported_dbms (char *dbms);
+extern void cgw_set_dbms_type (SUPPORTED_DBMS_TYPE dbms_type);
 #endif /* _CAS_CGW_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24220

Purpose
In the case of oracle, the method of timestamp bind is different from mysql.
Added timestamp bind method for oracle.

Implementation
The bind method for timestamp type was processed for oracle and mysql respectively.

Remarks
N/A
