### PR TITLE
[CBRD-24219] Total row count error in Oracle ODBC

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -788,7 +788,7 @@ cgw_set_execute_info (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_buf, int stmt_t
   char cache_reusable = 0;
   SQLLEN tuple_count = 0;
 
-  net_buf_cp_int (net_buf, (int) tuple_count, &srv_handle->tuple_count_msg_offset);
+  net_buf_cp_int (net_buf, (int) tuple_count, &srv_handle->total_row_count_msg_offset);
   net_buf_cp_byte (net_buf, cache_reusable);
   net_buf_cp_int (net_buf, (int) srv_handle->num_q_result, NULL);
 
@@ -855,7 +855,7 @@ cgw_get_stmt_Info (T_SRV_HANDLE * srv_handle, SQLHSTMT hstmt, T_NET_BUF * net_bu
   SQL_CHK_ERR (hstmt, SQL_HANDLE_STMT, SQLRowCount (hstmt, &total_row_count));
   if (total_row_count < 0)
     {
-      net_buf_cp_int (net_buf, -1, &srv_handle->total_row_count_msg_offset);
+      net_buf_cp_int (net_buf, -1, &srv_handle->res_tuple_count_msg_offset);
     }
   else
     {

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -59,7 +59,7 @@ static void cgw_error_msg (SQLHANDLE hHandle, SQLSMALLINT hType, RETCODE retcode
 static int numeric_string_adjust (SQL_NUMERIC_STRUCT * numeric, char *string);
 static int hex_to_numeric_val (SQL_NUMERIC_STRUCT * numeric, char *hexstr);
 static int hex_to_char (char c, unsigned char *result);
-static int cgw_get_stmt_Info (SQLHSTMT hstmt, T_NET_BUF * net_buf, int stmt_type);
+static int cgw_get_stmt_Info (T_SRV_HANDLE * srv_handle, SQLHSTMT hstmt, T_NET_BUF * net_buf, int stmt_type);
 static int cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *net_value,
 			      ODBC_BIND_INFO * value_list, T_NET_BUF * net_buf);
 static char cgw_odbc_type_to_cci_u_type (SQLLEN odbc_type);
@@ -786,15 +786,15 @@ cgw_set_execute_info (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_buf, int stmt_t
 {
   SQLRETURN err_code;
   char cache_reusable = 0;
-  SQLLEN total_row_count = 0;
+  SQLLEN tuple_count = 0;
 
-  net_buf_cp_int (net_buf, (int) total_row_count, &srv_handle->total_row_count_msg_offset);
+  net_buf_cp_int (net_buf, (int) tuple_count, &srv_handle->tuple_count_msg_offset);
   net_buf_cp_byte (net_buf, cache_reusable);
   net_buf_cp_int (net_buf, (int) srv_handle->num_q_result, NULL);
 
   for (int i = 0; i < srv_handle->num_q_result; i++)
     {
-      err_code = cgw_get_stmt_Info (srv_handle->cgw_handle->hstmt, net_buf, stmt_type);
+      err_code = cgw_get_stmt_Info (srv_handle, srv_handle->cgw_handle->hstmt, net_buf, stmt_type);
       if (err_code < 0)
 	{
 	  goto ODBC_ERROR;
@@ -837,9 +837,9 @@ ODBC_ERROR:
 }
 
 static int
-cgw_get_stmt_Info (SQLHSTMT hstmt, T_NET_BUF * net_buf, int stmt_type)
+cgw_get_stmt_Info (T_SRV_HANDLE * srv_handle, SQLHSTMT hstmt, T_NET_BUF * net_buf, int stmt_type)
 {
-  SQLLEN tuple_count = 0;
+  SQLLEN total_row_count = 0;
   T_OBJECT ins_oid;
   CACHE_TIME srv_cache_time;
   char statement_type = (char) stmt_type;
@@ -852,8 +852,16 @@ cgw_get_stmt_Info (SQLHSTMT hstmt, T_NET_BUF * net_buf, int stmt_type)
 
   net_buf_cp_byte (net_buf, statement_type);
 
-  SQL_CHK_ERR (hstmt, SQL_HANDLE_STMT, SQLRowCount (hstmt, &tuple_count));
-  net_buf_cp_int (net_buf, (int) tuple_count, NULL);
+  SQL_CHK_ERR (hstmt, SQL_HANDLE_STMT, SQLRowCount (hstmt, &total_row_count));
+  if (total_row_count < 0)
+    {
+      net_buf_cp_int (net_buf, -1, &srv_handle->total_row_count_msg_offset);
+    }
+  else
+    {
+      net_buf_cp_int (net_buf, (int) total_row_count, NULL);
+    }
+
 
   memset (&ins_oid, 0, sizeof (T_OBJECT));
   net_buf_cp_object (net_buf, &ins_oid);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -5849,14 +5849,14 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 
   if (total_row_count > INT_MAX)
     {
-      srv_handle->tuple_count = INT_MAX;
+      srv_handle->total_tuple_count = INT_MAX;
     }
   else
     {
-      srv_handle->tuple_count = (int) total_row_count;
+      srv_handle->total_tuple_count = (int) total_row_count;
     }
-  net_buf_overwrite_int (net_buf, srv_handle->tuple_count_msg_offset, num_tuple);
-  net_buf_overwrite_int (net_buf, srv_handle->total_row_count_msg_offset, srv_handle->tuple_count);
+  net_buf_overwrite_int (net_buf, srv_handle->total_row_count_msg_offset, srv_handle->total_tuple_count);	// 0
+  net_buf_overwrite_int (net_buf, srv_handle->res_tuple_count_msg_offset, srv_handle->total_tuple_count);	// 10
   net_buf_overwrite_int (net_buf, num_tuple_msg_offset, num_tuple);
 
   srv_handle->cursor_pos = cursor_pos;
@@ -10460,7 +10460,7 @@ int
 get_tuple_count (T_SRV_HANDLE * srv_handle)
 {
 #if defined(CAS_FOR_CGW)
-  return srv_handle->tuple_count;
+  return srv_handle->total_tuple_count;
 #else
   return srv_handle->q_result->tuple_count;
 #endif /* CAS_FOR_CGW */

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -5855,7 +5855,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
     {
       srv_handle->tuple_count = (int) total_row_count;
     }
-  srv_handle->tuple_count = (int) total_row_count;
+  net_buf_overwrite_int (net_buf, srv_handle->tuple_count_msg_offset, num_tuple);
   net_buf_overwrite_int (net_buf, srv_handle->total_row_count_msg_offset, srv_handle->tuple_count);
   net_buf_overwrite_int (net_buf, num_tuple_msg_offset, num_tuple);
 

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -5855,8 +5855,8 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
     {
       srv_handle->total_tuple_count = (int) total_row_count;
     }
-  net_buf_overwrite_int (net_buf, srv_handle->total_row_count_msg_offset, srv_handle->total_tuple_count);	// 0
-  net_buf_overwrite_int (net_buf, srv_handle->res_tuple_count_msg_offset, srv_handle->total_tuple_count);	// 10
+  net_buf_overwrite_int (net_buf, srv_handle->total_row_count_msg_offset, srv_handle->total_tuple_count);
+  net_buf_overwrite_int (net_buf, srv_handle->res_tuple_count_msg_offset, srv_handle->total_tuple_count);
   net_buf_overwrite_int (net_buf, num_tuple_msg_offset, num_tuple);
 
   srv_handle->cursor_pos = cursor_pos;

--- a/src/broker/cas_handle.h
+++ b/src/broker/cas_handle.h
@@ -227,9 +227,9 @@ struct t_srv_handle
 #endif				/* CAS_FOR_MYSQL */
 #if defined (CAS_FOR_CGW)
   T_CGW_HANDLE *cgw_handle;
-  int tuple_count_msg_offset;
+  int res_tuple_count_msg_offset;
   int total_row_count_msg_offset;
-  int tuple_count;
+  int total_tuple_count;
   int stmt_type;
 #endif				/* CAS_FOR_CGW */
 };

--- a/src/broker/cas_handle.h
+++ b/src/broker/cas_handle.h
@@ -227,6 +227,7 @@ struct t_srv_handle
 #endif				/* CAS_FOR_MYSQL */
 #if defined (CAS_FOR_CGW)
   T_CGW_HANDLE *cgw_handle;
+  int tuple_count_msg_offset;
   int total_row_count_msg_offset;
   int tuple_count;
   int stmt_type;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24219

Purpose
When data is fetched from the driver, the CAS must transmit the total row count of the table. However, in Oracle ODBC, Total Row Count cannot be obtained before Fetch. It has been changed to obtain Total Row Count after fetch is completed.

Implementation
N/A

Remarks
N/A
