### PR TITLE
[CBRD-24217] Error in data communication protocol between Driver and CAS

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -89,7 +89,7 @@ cgw_get_handle (T_CGW_HANDLE ** cgw_handle, bool is_connected)
       return ER_FAILED;
     }
 
-  if (local_odbc_handle->henv == NULL || local_odbc_handle->hdbc == NULL || local_odbc_handle->hstmt == NULL)
+  if (local_odbc_handle->henv == NULL || local_odbc_handle->hdbc == NULL)
     {
       if (is_connected)
 	{
@@ -365,7 +365,7 @@ cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding, int cursor
 	      net_buf_cp_short (net_buf, *((short *) this_col_binding->data_buffer));
 	      break;
 	    case SQL_TINYINT:
-	      net_buf_cp_int (net_buf, NET_SIZE_BYTE, NULL);
+	      net_buf_cp_int (net_buf, NET_SIZE_SHORT, NULL);
 	      net_buf_cp_short (net_buf, *((char *) this_col_binding->data_buffer));
 	      break;
 	    case SQL_FLOAT:

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -1119,8 +1119,9 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
 	  goto prepare_error;
 	}
 
-      cgw_set_stmt_attr (srv_handle->cgw_handle->hstmt, SQL_ATTR_CURSOR_TYPE, (SQLPOINTER) SQL_CURSOR_STATIC,
-			 SQL_IS_INTEGER);
+      err_code =
+	cgw_set_stmt_attr (srv_handle->cgw_handle->hstmt, SQL_ATTR_CURSOR_TYPE, (SQLPOINTER) SQL_CURSOR_STATIC,
+			   SQL_IS_INTEGER);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -1118,6 +1118,14 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
 	  goto prepare_error;
 	}
+
+      cgw_set_stmt_attr (srv_handle->cgw_handle->hstmt, SQL_ATTR_CURSOR_TYPE, (SQLPOINTER) SQL_CURSOR_STATIC,
+			 SQL_IS_INTEGER);
+      if (err_code < 0)
+	{
+	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
+	  goto prepare_error;
+	}
     }
 
   err_code = cgw_sql_prepare (srv_handle->cgw_handle->hstmt, (SQLCHAR *) sql_stmt);
@@ -3228,6 +3236,7 @@ ux_cursor_close (T_SRV_HANDLE * srv_handle)
     }
 #if defined(CAS_FOR_CGW)
   cgw_cursor_close (srv_handle->cgw_handle->hstmt);
+  srv_handle->cgw_handle->hstmt = NULL;
 #else
   ux_free_result (srv_handle->q_result[idx].result);
   srv_handle->q_result[idx].result = NULL;

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -3236,8 +3236,10 @@ ux_cursor_close (T_SRV_HANDLE * srv_handle)
       return;
     }
 #if defined(CAS_FOR_CGW)
-  cgw_cursor_close (srv_handle->cgw_handle->hstmt);
-  srv_handle->cgw_handle->hstmt = NULL;
+  if (cgw_cursor_close (srv_handle->cgw_handle->hstmt) > -1)
+    {
+      srv_handle->cgw_handle->hstmt = NULL;
+    }
 #else
   ux_free_result (srv_handle->q_result[idx].result);
   srv_handle->q_result[idx].result = NULL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24217

Purpose
In the FETCH phase of the data communication protocol between the driver and the CAS, the data size and data are put into the network buffer. At this time, the data structure according to the data size and data type must match.
In case of SQL_TINYINT type, data size should be 2 bytes, and data type should be short.

Implementation
N/A

Remarks
N/A
