### PR TITLE
[CBRD-24215] Compensate previous error in snprintf

### DIFF
--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -804,7 +804,7 @@ make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, 
       return -1;
     }
 
-  snprintf (tempfile, size - 1, "%s/%s_%03d_%ld_%d", tempdir, prefix ? prefix : "", task_code,
+  snprintf (tempfile, size - 1, "%s/%s_%03d_%ld_%d_%d", tempdir, prefix ? prefix : "", task_code,
 	    current_time.tv_sec, current_time.tv_usec, rand () % 997);
 
   return 0;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24215

**Purpose**
- In the previous PR #3386, we missed a **%d** in snprintf (), to print rand () %997.

**Implementation**
N/A

**Remarks**
N/A