### PR TITLE
[CBRD-24188] Register Innovation Academy students as contributors to the CREDITS file.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -12,5 +12,16 @@ Contributors are listed here:
 * shriekout
 * quartex
 * nori
+* evelon
+* Greenminalee
+* jinbekim
+* bigpel66
+* 212bypark
+* BaekChan1024
+* Yechan0815
+* minjune8506
+* keonwoo98
+* 42-saoh
+* memnoth
 
 You can also visit https://github.com/CUBRID/cubrid/graphs/contributors.


### PR DESCRIPTION
[http://jira.cubrid.org/browse/CBRD-24188](http://jira.cubrid.org/browse/CBRD-24188)

**Purpose**

- Addition the github ID of "Innovation Academy" students and Leesoo Ahn as the contributor at the "**CREDITS**" file
- The name and github ID of each contributor are written above jira.org link.

Implementation

- N/A

Remarks

- N/A
