### PR TITLE
[CBRD-24215] backport #3386 to 10.2, Generate unique temp file names

### DIFF
--- a/src/cm_common/cm_dep.h
+++ b/src/cm_common/cm_dep.h
@@ -267,6 +267,9 @@ extern "C"
   int cm_util_log_write_errstr (const char *format, ...);
   int cm_util_log_write_command (int argc, char *argv[]);
 
+  int make_temp_filename (char *tempfile, char *prefix, int size);
+  int make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, int size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -1373,12 +1373,17 @@ user_login_sa (nvplist * out, char *_dbmt_error, char *dbname, char *dbuser, cha
 {
   char opcode[10];
   char outfile[PATH_MAX], errfile[PATH_MAX];
-  char tmpfile[100];
+  char tmpfile[PATH_MAX];
   const char *argv[10];
   char cmd_name[PATH_MAX];
   char *outmsg = NULL, *errmsg = NULL;
 
-  snprintf (tmpfile, sizeof (tmpfile) - 1, "%s%d", "DBMT_ems_sa.", getpid ());
+  if (make_temp_filename (tmpfile, "DBMT_ems_sa.", PATH_MAX) < 0)
+    {
+      strcpy (_dbmt_error, "make_temp_filename: filename creation error");
+      goto login_err;
+    }
+
   (void) envvar_tmpdir_file (outfile, PATH_MAX, tmpfile);
   if (snprintf (errfile, PATH_MAX - 1, "%s.err", outfile) < 0)
     {
@@ -1529,9 +1534,13 @@ class_info_sa (const char *dbname, const char *uid, const char *passwd, char *cl
   const char *argv[10];
   char cli_ver[10];
   char opcode[10];
-  char tmpfile[100];
+  char tmpfile[PATH_MAX];
 
-  int ret = snprintf (tmpfile, sizeof (tmpfile) - 1, "%s%d", "DBMT_class_info.", getpid ());
+  if (make_temp_filename (tmpfile, "DBMT_class_info.", PATH_MAX) < 0)
+    {
+      return ERR_GENERAL_ERROR;
+    }
+
   (void) envvar_tmpdir_file (outfile, PATH_MAX, tmpfile);
   if (snprintf (errfile, PATH_MAX - 1, "%s.err", outfile) < 0)
     {
@@ -2538,9 +2547,13 @@ trigger_info_sa (const char *dbname, const char *uid, const char *passwd, nvplis
   int ret_val = ERR_NO_ERROR;
   char cmd_name[PATH_MAX];
   const char *argv[10];
-  char tmpfile[100];
+  char tmpfile[PATH_MAX];
 
-  int ret = snprintf (tmpfile, sizeof (tmpfile) - 1, "%s%d", "DBMT_trigger_info.", getpid ());
+  if (make_temp_filename (tmpfile, "DBMT_trigger_info.", PATH_MAX) < 0)
+    {
+      return ERR_GENERAL_ERROR;
+    }
+
   (void) envvar_tmpdir_file (outfile, PATH_MAX, tmpfile);
   if (snprintf (errfile, PATH_MAX - 1, "%s.err", outfile) < 0)
     {

--- a/src/cm_common/cm_mem_cpu_stat.c
+++ b/src/cm_common/cm_mem_cpu_stat.c
@@ -1304,10 +1304,16 @@ cm_get_command_result (const char *argv[], EXTRACT_FUNC func, const char *func_a
   char errfile[PATH_MAX];
   char tmpfile[100];
 
-  snprintf (tmpfile, sizeof (tmpfile) - 1, "%s%d", "cmd_res_", getpid ());
+  if (make_temp_filename (tmpfile, "cmd_res_", PATH_MAX) < 0)
+    {
+      return NULL;
+    }
   (void) envvar_tmpdir_file (outputfile, PATH_MAX, tmpfile);
 
-  snprintf (tmpfile, sizeof (tmpfile) - 1, "%s%d", "cmd_err_", getpid ());
+  if (make_temp_filename (tmpfile, "cmd_err_", PATH_MAX) < 0)
+    {
+      return NULL;
+    }
   (void) envvar_tmpdir_file (errfile, PATH_MAX, tmpfile);
 
   if (run_child (argv, 1, NULL, outputfile, errfile, NULL) < 0)

--- a/src/cm_common/cm_mem_cpu_stat.c
+++ b/src/cm_common/cm_mem_cpu_stat.c
@@ -1302,7 +1302,7 @@ cm_get_command_result (const char *argv[], EXTRACT_FUNC func, const char *func_a
   FILE *fp = NULL;
   char outputfile[PATH_MAX];
   char errfile[PATH_MAX];
-  char tmpfile[100];
+  char tmpfile[PATH_MAX];
 
   if (make_temp_filename (tmpfile, "cmd_res_", PATH_MAX) < 0)
     {

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -31,6 +31,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <time.h>
 
 #if defined(WINDOWS)
 #include <process.h>
@@ -41,6 +42,7 @@
 #include <unistd.h>
 #include <sys/wait.h>
 #include <stdarg.h>
+#include <sys/time.h>
 #endif
 
 static T_CMD_RESULT *new_cmd_result (void);
@@ -48,6 +50,7 @@ static void close_all_fds (int init_fd);
 
 #if defined(WINDOWS)
 static int is_master_start ();
+static int gettimeofday (struct timeval *tp, void *tzp);
 #endif
 
 #define CUBRID_SERVER_LOCK_EXT     "_lgat__lock"
@@ -396,7 +399,7 @@ cmd_server_status (void)
   char out_file[PATH_MAX];
   char cmd_name[PATH_MAX];
   const char *argv[5];
-  char tmpfile[100];
+  char tmpfile[PATH_MAX];
 
   res = new_servstat_result ();
   if (res == NULL)
@@ -411,7 +414,11 @@ cmd_server_status (void)
     }
 #endif
 
-  snprintf (tmpfile, sizeof (tmpfile) - 1, "%s%d", "DBMT_util_001.", getpid ());
+  if (make_temp_filename (tmpfile, "DBMT_util_001.", sizeof (tmpfile)) < 0)
+    {
+      cmd_result_free (res);
+      return NULL;
+    }
   (void) envvar_tmpdir_file (out_file, PATH_MAX, tmpfile);
   (void) envvar_bindir_file (cmd_name, PATH_MAX, UTIL_CUBRID);
 
@@ -750,3 +757,98 @@ cm_util_log_write_command (int argc, char *argv[])
 {
   return util_log_write_command (argc, argv);
 }
+
+/*
+ * Generate unique temp file name.
+ * {prefix}{second}_{usec}_{random number: 1..997}
+ */
+
+int
+make_temp_filename (char *tempfile, char *prefix, int size)
+{
+  struct timeval current_time;
+
+  if (tempfile == NULL || prefix == NULL || size < 1)
+    {
+      return -1;
+    }
+
+  srand (time (NULL));
+  if (gettimeofday (&current_time, NULL) < 0)
+    {
+      return -1;
+    }
+
+  snprintf (tempfile, size - 1, "%s%ld_%ld_%d", prefix, current_time.tv_sec, current_time.tv_usec, rand () % 997);
+
+  return 0;
+}
+
+int
+make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, int size)
+{
+  struct timeval current_time;
+
+  if (tempfile == NULL || tempdir == NULL || size < 1)
+    {
+      return -1;
+    }
+
+  srand (time (NULL));
+  if (gettimeofday (&current_time, NULL) < 0)
+    {
+      return -1;
+    }
+
+  snprintf (tempfile, size - 1, "%s/%s_%03d_%ld_%d_%d", tempdir, prefix ? prefix : "", task_code,
+	    current_time.tv_sec, current_time.tv_usec, rand () % 997);
+
+  return 0;
+}
+
+#if defined (WINDOWS)
+/* Number of 100 nanosecond units from 1/1/1601 to 1/1/1970 */
+#define EPOCH_BIAS_IN_100NANOSECS 116444736000000000LL
+
+/*
+ * gettimeofday - Windows port of Unix gettimeofday(), from base/porting.c
+ *   return: none
+ *   tp(out): where time is stored
+ *   tzp(in): unused
+ */
+static int
+gettimeofday (struct timeval *tp, void *tzp)
+{
+/*
+ * Rapid calculation divisor for 10,000,000
+ * x/10000000 == x/128/78125 == (x>>7)/78125
+ */
+#define RAPID_CALC_DIVISOR 78125
+
+  union
+  {
+    unsigned __int64 nsec100;	/* in 100 nanosecond units */
+    FILETIME ft;
+  } now;
+
+  GetSystemTimeAsFileTime (&now.ft);
+
+  /*
+   * Optimization for sec = (long) (x / 10000000);
+   * where "x" is number of 100 nanoseconds since 1/1/1970.
+   */
+  tp->tv_sec = (long) (((now.nsec100 - EPOCH_BIAS_IN_100NANOSECS) >> 7) / RAPID_CALC_DIVISOR);
+
+  /*
+   * Optimization for usec = (long) (x % 10000000) / 10;
+   * Let c = x / b,
+   * An alternative for MOD operation (x % b) is: (x - c * b),
+   *   which consumes less time, specially, for a 64 bit "x".
+   */
+  tp->tv_usec =
+    ((long) (now.nsec100 - EPOCH_BIAS_IN_100NANOSECS - (((unsigned __int64) (tp->tv_sec * RAPID_CALC_DIVISOR)) << 7))) /
+    10;
+
+  return 0;
+}
+#endif


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24215

**Purpose**
This is a backport of PR #3386 to release/10.2

- Primary purpose is to make all temporary file names even multiple CMS clients requests same API at the same time.
- This is to avoid contention to a single file over several CMS clients

**Implementation**

**Remarks**
