### PR TITLE
[CBRD-24226] 10.2 cm_common, pull defensive code in develop

### DIFF
--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -2956,12 +2956,20 @@ getservershmid (char *dir, char *dbname)
     }
   if (fgets (cbuf, sizeof (cbuf), fdkey_file) == NULL)
     {
+      if (fdkey_file != nullptr)
+	{
+	  fclose (fdkey_file);
+	}
       return -1;
     }
 
   result = parse_int (&shm_key, cbuf, 16);
   if (result != 0)
     {
+      if (fdkey_file != nullptr)
+	{
+	  fclose (fdkey_file);
+	}
       return -1;
     }
 

--- a/src/cm_common/cm_trigger_info_sa.c
+++ b/src/cm_common/cm_trigger_info_sa.c
@@ -85,6 +85,10 @@ main (int argc, char *argv[])
     {
       write_err_msg (errfile, (char *) db_error_string (1));
       db_shutdown ();
+      if (fp != nullptr)
+	{
+	  fclose (fp);
+	}
       return 0;
     }
 

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -520,11 +520,16 @@ read_server_status_output (T_SERVER_STATUS_RESULT * res, char *out_file)
       if (num_info > num_alloc)
 	{
 	  num_alloc += 5;
-	  info = (T_SERVER_STATUS_INFO *) realloc (info, sizeof (T_SERVER_STATUS_INFO) * num_alloc);
-	  if (info == NULL)
+	  T_SERVER_STATUS_INFO *const new_info
+	    = (T_SERVER_STATUS_INFO *) realloc (info, sizeof (T_SERVER_STATUS_INFO) * num_alloc);
+	  if (new_info == NULL)
 	    {
 	      fclose (fp);
 	      return;
+	    }
+	  else
+	    {
+	      info = new_info;
 	    }
 	}
       strcpy (info[num_info - 1].db_name, db_name);

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -524,6 +524,7 @@ read_server_status_output (T_SERVER_STATUS_RESULT * res, char *out_file)
 	    = (T_SERVER_STATUS_INFO *) realloc (info, sizeof (T_SERVER_STATUS_INFO) * num_alloc);
 	  if (new_info == NULL)
 	    {
+	      free (info);
 	      fclose (fp);
 	      return;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24226

**Purpose**
To pull some defensive code in **_develop_** into 10.2 branch, for example do **fclose ()** before return if subject **fd** is active.

Implementation
N/A

**Remarks**
N/A
