### PR TITLE
[LETS-340] async disconnect handler in page server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "cubridmanager"]
 	path = cubridmanager
 	url = https://github.com/CUBRID/cubrid-manager-server
-	branch = 21e2d430abe8687776ac8e80ec5d67dcbad258dd
+	branch = develop
 [submodule "cubrid-jdbc"]
 	path = cubrid-jdbc
 	url = https://github.com/cubrid/cubrid-jdbc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "cubridmanager"]
 	path = cubridmanager
 	url = https://github.com/CUBRID/cubrid-manager-server
-	branch = develop
+	branch = 21e2d430abe8687776ac8e80ec5d67dcbad258dd
 [submodule "cubrid-jdbc"]
 	path = cubrid-jdbc
 	url = https://github.com/cubrid/cubrid-jdbc

--- a/src/communication/request_sync_send_queue.hpp
+++ b/src/communication/request_sync_send_queue.hpp
@@ -273,6 +273,7 @@ namespace cubcomm
     ulock.unlock ();
 
     send_queue (backbuffer);
+    assert (backbuffer.empty ());
   }
 
   //
@@ -301,7 +302,6 @@ namespace cubcomm
       {
 	// Check shutdown flag every 10 milliseconds
 	m_req_queue.wait_not_empty_and_send_all (requests, ten_millis);
-	assert (requests.empty ());
       }
   }
 

--- a/src/communication/request_sync_send_queue.hpp
+++ b/src/communication/request_sync_send_queue.hpp
@@ -273,7 +273,6 @@ namespace cubcomm
     ulock.unlock ();
 
     send_queue (backbuffer);
-    assert (backbuffer.empty ());
   }
 
   //
@@ -296,11 +295,13 @@ namespace cubcomm
   void
   request_queue_autosend<ReqQueue>::loop_send_requests ()
   {
+    constexpr auto ten_millis = std::chrono::milliseconds (10);
     typename ReqQueue::queue_type requests;
     while (!m_shutdown)
       {
 	// Check shutdown flag every 10 milliseconds
-	m_req_queue.wait_not_empty_and_send_all (requests, std::chrono::milliseconds (10));
+	m_req_queue.wait_not_empty_and_send_all (requests, ten_millis);
+	assert (requests.empty ());
       }
   }
 

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -312,10 +312,11 @@ page_server::async_disconnect_handler::disconnect_loop ()
     {
       {
 	std::unique_lock<std::mutex> ulock { m_queue_mtx };
-	while (!m_queue_cv.wait_for (ulock, one_second, [this]
-	{
-	  return !m_disconnect_queue.empty () || m_terminate.load ();
-	  }));
+	if (!m_queue_cv.wait_for (ulock, one_second,
+				  [this] { return !m_disconnect_queue.empty () || m_terminate.load (); }))
+	  {
+	    continue;
+	  }
 
 	m_disconnect_queue.swap (disconnect_work_buffer);
       }

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -305,15 +305,17 @@ page_server::async_disconnect_handler::terminate ()
 void
 page_server::async_disconnect_handler::disconnect_loop ()
 {
+  constexpr std::chrono::seconds one_second { 1 };
+
   std::queue<connection_handler_uptr_t> disconnect_work_buffer;
   while (!m_terminate.load ())
     {
       {
 	std::unique_lock<std::mutex> ulock { m_queue_mtx };
-	m_queue_cv.wait (ulock, [this]
+	while (!m_queue_cv.wait_for (ulock, one_second, [this]
 	{
 	  return !m_disconnect_queue.empty () || m_terminate.load ();
-	});
+	  }));
 
 	m_disconnect_queue.swap (disconnect_work_buffer);
       }

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -356,8 +356,6 @@ page_server::disconnect_active_tran_server ()
 		    " Disconnect active transaction server connection with channel id: %s.\n",
 		    m_active_tran_server_conn->get_channel_id ().c_str ());
       m_active_tran_server_conn.reset (nullptr);
-      // TODO: temporary
-      m_active_tran_sever_previously_connected = true;
     }
   else
     {
@@ -373,8 +371,6 @@ page_server::disconnect_tran_server_async (connection_handler *conn)
     {
       m_disconnect_handler.disconnect (std::move (m_active_tran_server_conn));
       assert (m_active_tran_server_conn == nullptr);
-      // TODO: temporary
-      m_active_tran_sever_previously_connected = true;
     }
   else
     {
@@ -438,11 +434,6 @@ page_server::push_request_to_active_tran_server (page_to_tran_request reqid, std
   if (is_active_tran_server_connected ())
     {
       m_active_tran_server_conn->push_request (reqid, std::move (payload));
-    }
-  else
-    {
-      // TODO: temporary
-      assert (m_active_tran_sever_previously_connected || is_active_tran_server_connected ());
     }
 }
 

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -356,6 +356,8 @@ page_server::disconnect_active_tran_server ()
 		    " Disconnect active transaction server connection with channel id: %s.\n",
 		    m_active_tran_server_conn->get_channel_id ().c_str ());
       m_active_tran_server_conn.reset (nullptr);
+      // TODO: temporary
+      m_active_tran_sever_previously_connected = true;
     }
   else
     {
@@ -371,6 +373,8 @@ page_server::disconnect_tran_server_async (connection_handler *conn)
     {
       m_disconnect_handler.disconnect (std::move (m_active_tran_server_conn));
       assert (m_active_tran_server_conn == nullptr);
+      // TODO: temporary
+      m_active_tran_sever_previously_connected = true;
     }
   else
     {
@@ -430,9 +434,16 @@ void
 page_server::push_request_to_active_tran_server (page_to_tran_request reqid, std::string &&payload)
 {
   assert (is_page_server ());
-  assert (is_active_tran_server_connected ());
 
-  m_active_tran_server_conn->push_request (reqid, std::move (payload));
+  if (is_active_tran_server_connected ())
+    {
+      m_active_tran_server_conn->push_request (reqid, std::move (payload));
+    }
+  else
+    {
+      // TODO: temporary
+      assert (m_active_tran_sever_previously_connected || is_active_tran_server_connected ());
+    }
 }
 
 cublog::replicator &

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -469,6 +469,11 @@ page_server::finish_replication_during_shutdown (cubthread::entry &thread_entry)
 {
   assert (m_replicator != nullptr);
 
+  // at this point, no connection to transaction server should be active
+  // after the replicator is destroyed, no further requests should be processed
+  assert (m_active_tran_server_conn == nullptr);
+  assert (m_passive_tran_server_conn.empty ());
+
   logpb_force_flush_pages (&thread_entry);
   m_replicator->wait_replication_finish_during_shutdown ();
   m_replicator.reset (nullptr);

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -138,7 +138,7 @@ class page_server
 	void disconnect_loop ();
 
       private:
-	bool m_terminate = false;
+	std::atomic_bool m_terminate;
 	std::queue<connection_handler_uptr_t> m_disconnect_queue;
 	std::mutex m_queue_mtx;
 	std::condition_variable m_queue_cv;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -118,18 +118,18 @@ class page_server
     /* helper class with the task of destroying connnection handlers and, by this,
      * also waiting for the receive and transmit threads inside the handlers to terminate
      */
-    class disconnect_handler
+    class async_disconnect_handler
     {
       public:
-	disconnect_handler ();
+	async_disconnect_handler ();
 
-	disconnect_handler (const disconnect_handler &) = delete;
-	disconnect_handler (disconnect_handler &&) = delete;
+	async_disconnect_handler (const async_disconnect_handler &) = delete;
+	async_disconnect_handler (async_disconnect_handler &&) = delete;
 
-	~disconnect_handler ();
+	~async_disconnect_handler ();
 
-	disconnect_handler &operator = (const disconnect_handler &) = delete;
-	disconnect_handler &operator = (disconnect_handler &&) = delete;
+	async_disconnect_handler &operator = (const async_disconnect_handler &) = delete;
+	async_disconnect_handler &operator = (async_disconnect_handler &&) = delete;
 
 	void disconnect (connection_handler_uptr_t &&handler);
 	void terminate ();
@@ -155,7 +155,7 @@ class page_server
 
     std::unique_ptr<responder_t> m_responder;
 
-    disconnect_handler m_disconnect_handler;
+    async_disconnect_handler m_async_disconnect_handler;
 };
 
 extern page_server ps_Gl;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -111,6 +111,7 @@ class page_server
 	// function that will, at some moment, remove that hook
 	mutable std::mutex m_prior_sender_sink_removal_mtx;
 
+	std::mutex m_abnormal_tran_server_disconnect_mtx;
 	bool m_abnormal_tran_server_disconnect;
     };
 

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -148,6 +148,8 @@ class page_server
     responder_t &get_responder ();
 
     connection_handler_uptr_t m_active_tran_server_conn;
+    // TODO: temporary
+    bool m_active_tran_sever_previously_connected = false;
     std::vector<connection_handler_uptr_t> m_passive_tran_server_conn;
 
     std::unique_ptr<cublog::replicator> m_replicator;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -57,7 +57,6 @@ class page_server
   private:
 
     void disconnect_active_tran_server ();
-    void disconnect_tran_server (connection_handler *conn);
     void disconnect_tran_server_async (connection_handler *conn);
     bool is_active_tran_server_connected () const;
 
@@ -115,6 +114,9 @@ class page_server
 	bool m_abnormal_tran_server_disconnect;
     };
 
+    /* helper class with the task of destroying connnection handlers and, by this,
+     * also waiting for the receive and transmit threads inside the handlers to terminate
+     */
     class disconnect_handler
     {
       public:
@@ -129,9 +131,6 @@ class page_server
 	disconnect_handler &operator = (disconnect_handler &&) = delete;
 
 	void disconnect (connection_handler_uptr_t &&handler);
-	//template <typename TDuration>
-	void wait_and_disconnect (std::queue<connection_handler_uptr_t> &disconnect_work_buffer/*,
-				  const TDuration &duration*/);
 	void terminate ();
 
       private:

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -148,8 +148,6 @@ class page_server
     responder_t &get_responder ();
 
     connection_handler_uptr_t m_active_tran_server_conn;
-    // TODO: temporary
-    bool m_active_tran_sever_previously_connected = false;
     std::vector<connection_handler_uptr_t> m_passive_tran_server_conn;
 
     std::unique_ptr<cublog::replicator> m_replicator;

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3177,6 +3177,7 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
   if (get_server_type () == SERVER_TYPE_PAGE)
     {
       log_Gl.finalize_log_prior_receiver ();	// stop receiving log before log_final()
+      ps_Gl.disconnect_all_tran_server ();
       ps_Gl.finish_replication_during_shutdown (*thread_p);
       ps_Gl.finalize_request_responder ();
     }

--- a/src/transaction/log_prior_recv.hpp
+++ b/src/transaction/log_prior_recv.hpp
@@ -43,7 +43,14 @@ namespace cublog
     public:
       // ctor/dtor:
       prior_recver (log_prior_lsa_info &prior_lsa_info);
+
+      prior_recver (const prior_recver &) = delete;
+      prior_recver (prior_recver &&) = delete;
+
       ~prior_recver ();
+
+      prior_recver &operator = (const prior_recver &) = delete;
+      prior_recver &operator = (prior_recver &&) = delete;
 
       void push_message (std::string &&str);                  // push message from prior_sender into message queue
 

--- a/src/transaction/log_prior_send.hpp
+++ b/src/transaction/log_prior_send.hpp
@@ -38,6 +38,14 @@ namespace cublog
       using sink_hook_t = std::function<void (std::string &&)>;   // messages are passed to sink hooks.
 
     public:
+      prior_sender () = default;
+      prior_sender (const prior_sender &) = delete;
+      prior_sender (prior_sender &&) = default;
+
+      prior_sender &operator = (const prior_sender &) = delete;
+      prior_sender &operator = (prior_sender &&) = delete;
+
+    public:
       void send_list (const log_prior_node *head);                // send prior node list to all sinks
 
       void add_sink (const sink_hook_t &fun);                     // add a hook for a new sink

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -264,7 +264,7 @@ namespace cublog
 	  std::unique_lock<std::mutex> lock (m_redo_lsa_mutex);
 
 	  // better to be checked as soon as possible during the processing loop
-	  // however, this would need one more mutex lock
+	  // however, this would need one more mutex lock; therefore, suffice to do it here
 	  assert (m_replication_active);
 
 	  m_redo_lsa = header.forw_lsa;

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -113,6 +113,7 @@ namespace cublog
   replicator::replicator (const log_lsa &start_redo_lsa, PAGE_FETCH_MODE page_fetch_mode, int parallel_count)
     : m_bookkeep_mvcc_vacuum_info { is_page_server () }
     , m_redo_lsa { start_redo_lsa }
+    , m_replication_active { true }
     , m_redo_context { NULL_LSA, page_fetch_mode, log_reader::fetch_mode::FORCE }
     , m_perfmon_redo_sync { PSTAT_REDO_REPL_LOG_REDO_SYNC }
     , m_most_recent_trantable_snapshot_lsa { NULL_LSA }
@@ -261,6 +262,11 @@ namespace cublog
 
 	{
 	  std::unique_lock<std::mutex> lock (m_redo_lsa_mutex);
+
+	  // better to be checked as soon as possible during the processing loop
+	  // however, this would need one more mutex lock
+	  assert (m_replication_active);
+
 	  m_redo_lsa = header.forw_lsa;
 	}
 	if (m_parallel_replication_redo != nullptr)
@@ -392,6 +398,11 @@ namespace cublog
     {
       return m_redo_lsa >= log_Gl.append.get_nxio_lsa ();
     });
+
+    // flag ensures the internal invariant that, once the replicator has been waited
+    // to finish work; no further log records are to be processed
+    // flag is checked and set only under redo lsa mutex
+    m_replication_active = false;
 
     // at this moment, ALL data has been dispatched for, either, async replication
     // or has been applied synchronously

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -96,6 +96,7 @@ namespace cublog
       cubthread::daemon *m_daemon = nullptr;
 
       log_lsa m_redo_lsa = NULL_LSA;
+      mutable bool m_replication_active;
       mutable std::mutex m_redo_lsa_mutex;
       mutable std::condition_variable m_redo_lsa_condvar;
       log_rv_redo_context m_redo_context;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-340

Implement a `disconnect_handler` in `page_server` that reliably makes sure to disconnect (aka: destroy) a `connection_handler`. Previous method using detached threads was not deterministic and could cause indefinite hangs.
- in `page_server::connection_handler::connection_handler` dispatch `this` to be deleted to the parent's disconnect handler
- same in `page_server::connection_handler::abnormal_tran_server_disconnect`
- `page_server::disconnect_tran_server_async` just moves the connect handler's pointer to the disconnect handler

Related changes:
- in `xboot_shutdown_server` the page server is explicitly asked to terminate all connections to transaction servers
- in `cublog::replicator` introduced an internal flag to enforce a invariant relation: after the replicator is asked to `wait_replication_finish_during_shutdown`, no further log records can be processed

Other:
- deleted some unneeded ctors