### PR TITLE
[CBRD-24153] Unexpected show trace result after executing run command in csql

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10015,8 +10015,11 @@ pt_make_query_show_trace (PARSER_CONTEXT * parser)
   trace_func->alias_print = pt_append_string (parser, NULL, "trace");
   select->info.query.q.select.list = parser_append_node (trace_func, select->info.query.q.select.list);
 
-  parser->flag.dont_collect_exec_stats = 1;
-  parser->query_trace = false;
+  if (parser->statement_number == 0) // This is when only the show trace statement is used.
+    {
+      parser->flag.dont_collect_exec_stats = 1;
+      parser->query_trace = false;
+    }
 
   return select;
 }

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10015,7 +10015,7 @@ pt_make_query_show_trace (PARSER_CONTEXT * parser)
   trace_func->alias_print = pt_append_string (parser, NULL, "trace");
   select->info.query.q.select.list = parser_append_node (trace_func, select->info.query.q.select.list);
 
-  if (parser->statement_number == 0) // This is when only the show trace statement is used.
+  if (parser->statement_number == 0)	// This is when only the show trace statement is used.
     {
       parser->flag.dont_collect_exec_stats = 1;
       parser->query_trace = false;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24153

**Purspose**

When executing multiple statements included "show trace", fix unexpected show trace result

**Change**

Since the pt_make_query_show_trace() of parser is always changing tracing to off,
I will add to code checking whether it is multiple statement and changing tracing to off, only when statement is show trace.

