### PR TITLE
[CBRD-24233] Changed the unload format for missing triggers and resolution.

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1641,12 +1641,16 @@ emit_resolutions (print_output & output_ctx, DB_OBJECT * class_, const char *cla
   DB_RESOLUTION *resolution_list;
   bool return_value = false;
   const char *name;
+  char owner_name[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
+  char *class_name = NULL;
 
   resolution_list = db_get_resolutions (class_);
   if (resolution_list != NULL)
     {
       name = db_get_class_name (class_);
-      output_ctx ("ALTER %s %s%s%s INHERIT", class_type, PRINT_IDENTIFIER (name));
+      SPLIT_USER_SPECIFIED_NAME (name, owner_name, class_name);
+      output_ctx ("ALTER %s %s%s%s.%s%s%s INHERIT", class_type, PRINT_IDENTIFIER (owner_name),
+		  PRINT_IDENTIFIER (class_name));
 
       for (; resolution_list != NULL; resolution_list = db_resolution_next (resolution_list))
 	{
@@ -1680,6 +1684,8 @@ static void
 emit_resolution_def (print_output & output_ctx, DB_RESOLUTION * resolution, RESOLUTION_QUALIFIER qualifier)
 {
   const char *name, *alias, *class_name;
+  char owner_name[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
+  char *class_name_p = NULL;
   DB_OBJECT *class_;
 
   class_ = db_resolution_class (resolution);
@@ -1699,6 +1705,7 @@ emit_resolution_def (print_output & output_ctx, DB_RESOLUTION * resolution, RESO
     {
       return;
     }
+  SPLIT_USER_SPECIFIED_NAME (class_name, owner_name, class_name_p);
 
   alias = db_resolution_alias (resolution);
 
@@ -1706,12 +1713,14 @@ emit_resolution_def (print_output & output_ctx, DB_RESOLUTION * resolution, RESO
     {
     case INSTANCE_RESOLUTION:
       {
-	output_ctx ("       %s%s%s OF %s%s%s", PRINT_IDENTIFIER (name), PRINT_IDENTIFIER (class_name));
+	output_ctx ("       %s%s%s OF %s%s%s.%s%s%s", PRINT_IDENTIFIER (name), PRINT_IDENTIFIER (owner_name),
+		    PRINT_IDENTIFIER (class_name_p));
 	break;
       }
     case CLASS_RESOLUTION:
       {
-	output_ctx ("CLASS  %s%s%s OF %s%s%s", PRINT_IDENTIFIER (name), PRINT_IDENTIFIER (class_name));
+	output_ctx ("CLASS  %s%s%s OF %s%s%s.%s%s%s", PRINT_IDENTIFIER (name), PRINT_IDENTIFIER (owner_name),
+		    PRINT_IDENTIFIER (class_name_p));
 	break;
       }
     }

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -1492,11 +1492,13 @@ ldr_find_class_by_query (const char *name, char *buf, int buf_size)
   query_error.err_lineno = 0;
   query_error.err_posno = 0;
 
-  if (name == NULL || name[0] == '\0' || buf == NULL)
+  if (name == NULL || name[0] == '\0')
     {
       ERROR_SET_WARNING (error, ER_OBJ_INVALID_ARGUMENTS);
       return error;
     }
+
+  assert (buf != NULL);
 
   if (db_get_current_user_name (current_user_name, DB_MAX_USER_LENGTH) == NULL)
     {
@@ -1541,9 +1543,8 @@ ldr_find_class_by_query (const char *name, char *buf, int buf_size)
 
   if (!DB_IS_NULL (&value))
     {
-      assert (strlen (db_get_string (&value)) < static_cast<size_t> (buf_size));
+      assert (strlen (db_get_string (&value)) < buf_size);
       strncpy (buf, db_get_string (&value), buf_size);
-      assert (buf[0] != '\0');
     }
   else
     {

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -5861,7 +5861,8 @@ au_change_trigger_owner (MOP trigger_mop, MOP owner_mop)
       goto end;
     }
 
-  /* TO BE: It is necessary to check the permission of the target class of the owner to be changed. *
+  /* TO BE: It is necessary to check the permission of the target class of the owner to be changed. */
+#if 0
   error = obj_get (target_class_obj, TR_ATT_CLASS, &value);
   if (error != NO_ERROR)
     {
@@ -5875,7 +5876,7 @@ au_change_trigger_owner (MOP trigger_mop, MOP owner_mop)
       ASSERT_ERROR ();
       goto end;
     }
-  /**/
+#endif
 
   owner_name = au_get_user_name (owner_mop);
   if (!owner_name)

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -5861,7 +5861,13 @@ au_change_trigger_owner (MOP trigger_mop, MOP owner_mop)
       goto end;
     }
 
-  /* TO BE: It is necessary to check the permission of the target class of the owner to be changed. */
+  /* TO BE: It is necessary to check the permission of the target class of the owner to be changed. *
+  error = obj_get (target_class_obj, TR_ATT_CLASS, &value);
+  if (error != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      goto end;
+    }
 
   error = au_fetch_class (target_class_obj, &target_class, AU_FETCH_READ, AU_SELECT);
   if (error != NO_ERROR)
@@ -5869,6 +5875,7 @@ au_change_trigger_owner (MOP trigger_mop, MOP owner_mop)
       ASSERT_ERROR ();
       goto end;
     }
+  /**/
 
   owner_name = au_get_user_name (owner_mop);
   if (!owner_name)

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -2160,15 +2160,15 @@ sm_downcase_name (const char *name, char *buf, int buf_size)
 {
   int error = NO_ERROR;
 
-  if (name == NULL || name[0] == '\0' || buf == NULL)
+  if (name == NULL || name[0] == '\0')
     {
       ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
       return NULL;
     }
 
+  assert (buf != NULL);
   assert (intl_identifier_lower_string_size (name) < buf_size);
   intl_identifier_lower (name, buf);
-  assert (buf[0] != '\0');
 
   return buf;
 }
@@ -2187,7 +2187,7 @@ sm_user_specified_name (const char *name, char *buf, int buf_size)
   char current_user_name[SM_MAX_USER_LENGTH] = { '\0' };
   int error = NO_ERROR;
 
-  if (name == NULL || name[0] == '\0' || buf == NULL)
+  if (name == NULL || name[0] == '\0')
     {
       ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
       return NULL;
@@ -2239,32 +2239,29 @@ sm_user_specified_name (const char *name, char *buf, int buf_size)
 char *
 sm_qualifier_name (const char *name, char *buf, int buf_size)
 {
-  char *dot = NULL;
-  char name_copy[SM_MAX_IDENTIFIER_LENGTH] = { '\0' };
+  const char *dot = NULL;
+  int len = 0;
   int error = NO_ERROR;
 
-  if (name == NULL || name[0] == '\0' || buf == NULL)
+  if (name == NULL || name[0] == '\0')
     {
       ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
       return NULL;
     }
 
-  assert (strlen (name) < SM_MAX_IDENTIFIER_LENGTH);
-  strncpy (name_copy, name, SM_MAX_IDENTIFIER_LENGTH);
-  assert (name_copy[0] != '\0');
-
-  dot = strchr (name_copy, '.');
-
   /* If the name is not a user-specified name, NULL is returned. */
+  dot = strchr (name, '.');
   if (dot == NULL)
     {
       return NULL;
     }
 
-  dot[0] = '\0';
-  assert (strlen (name_copy) < buf_size);
-  strncpy (buf, name_copy, buf_size);
-  assert (buf[0] != '\0');
+  len = static_cast<int>(dot - name);
+
+  assert (buf != NULL);
+  assert (len > 0 && len < buf_size);
+  memcpy(buf, name, len);
+  buf[len] = '\0';
 
   return buf;
 }
@@ -2286,6 +2283,8 @@ sm_remove_qualifier_name (const char *name)
 
   dot = strchr (name, '.');
 
+  /* There must be only one dot(.) because dot(.) cannot be used in identifier names
+   * even if the exception rule is used. */
   assert (dot == NULL || strchr (dot + 1, '.') == NULL);
 
   return dot ? (dot + 1) : name;

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -2256,11 +2256,11 @@ sm_qualifier_name (const char *name, char *buf, int buf_size)
       return NULL;
     }
 
-  len = static_cast<int>(dot - name);
+  len = STATIC_CAST (int, dot - name);
 
   assert (buf != NULL);
   assert (len > 0 && len < buf_size);
-  memcpy(buf, name, len);
+  memcpy (buf, name, len);
   buf[len] = '\0';
 
   return buf;

--- a/src/object/trigger_description.cpp
+++ b/src/object/trigger_description.cpp
@@ -244,6 +244,7 @@ tr_dump_trigger (print_output &output_ctx, DB_OBJECT *trigger_object)
   const char *name;
   char owner_name[DB_MAX_USER_LENGTH] = { '\0' };
   const char *trigger_name = NULL;
+  const char *class_name = NULL;
 
   AU_DISABLE (save);
 
@@ -256,16 +257,8 @@ tr_dump_trigger (print_output &output_ctx, DB_OBJECT *trigger_object)
   else if (trigger->status != TR_STATUS_INVALID)
     {
       /* automatically filter out invalid triggers */
-
-      if (sm_qualifier_name (trigger->name, owner_name, DB_MAX_USER_LENGTH) == NULL)
-	{
-	  ASSERT_ERROR_AND_SET (error);
-	  return error;
-	}
-      trigger_name = sm_remove_qualifier_name (trigger->name);
-
       output_ctx ("CREATE TRIGGER ");
-      output_ctx ("[%s].[%s]\n", owner_name, trigger_name);
+      output_ctx ("[%s]\n", sm_remove_qualifier_name (trigger->name));
       output_ctx ("  STATUS %s\n", tr_status_as_string (trigger->status));
       output_ctx ("  PRIORITY %f\n", trigger->priority);
 
@@ -285,8 +278,14 @@ tr_dump_trigger (print_output &output_ctx, DB_OBJECT *trigger_object)
       if (trigger->class_mop != NULL)
 	{
 	  name = db_get_class_name (trigger->class_mop);
+	  if (sm_qualifier_name (name, owner_name, DB_MAX_USER_LENGTH) == NULL)
+	    {
+	      ASSERT_ERROR_AND_SET (error);
+	      return error;
+	    }
+	  class_name = sm_remove_qualifier_name (name);
 	  output_ctx (" ON ");
-	  output_ctx ("[%s]", name);
+	  output_ctx ("[%s].[%s]", owner_name, class_name);
 
 	  if (trigger->attribute != NULL)
 	    {
@@ -418,7 +417,7 @@ tr_dump_selective_triggers (print_output &output_ctx, DB_OBJLIST *classes)
 			{
 			  tr_dump_trigger (output_ctx, trigger_object);
 			  output_ctx ("call [change_trigger_owner]('%s'," " '%s') on class [db_root];\n\n",
-				      trigger->name, get_user_name (trigger->owner));
+				      sm_remove_qualifier_name (trigger->name), get_user_name (trigger->owner));
 			}
 		    }
 		  else if (is_system_class < 0)

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -18434,11 +18434,13 @@ do_find_class_by_query (const char *name, char *buf, int buf_size)
   query_error.err_lineno = 0;
   query_error.err_posno = 0;
 
-  if (name == NULL || name[0] == '\0' || buf == NULL)
+  if (name == NULL || name[0] == '\0')
     {
       ERROR_SET_WARNING (error, ER_OBJ_INVALID_ARGUMENTS);
       return error;
     }
+
+  assert (buf != NULL);
 
   if (db_get_current_user_name (current_user_name, DB_MAX_USER_LENGTH) == NULL)
     {
@@ -18485,7 +18487,6 @@ do_find_class_by_query (const char *name, char *buf, int buf_size)
     {
       assert (strlen (db_get_string (&value)) < buf_size);
       strncpy (buf, db_get_string (&value), buf_size);
-      assert (buf[0] != '\0');
     }
   else
     {
@@ -18529,11 +18530,13 @@ do_find_serial_by_query (const char *name, char *buf, int buf_size)
   query_error.err_lineno = 0;
   query_error.err_posno = 0;
 
-  if (name == NULL || name[0] == '\0' || buf == NULL)
+  if (name == NULL || name[0] == '\0')
     {
       ERROR_SET_WARNING (error, ER_OBJ_INVALID_ARGUMENTS);
       return error;
     }
+
+  assert (buf != NULL);
 
   if (db_get_current_user_name (current_user_name, DB_MAX_USER_LENGTH) == NULL)
     {
@@ -18587,7 +18590,6 @@ do_find_serial_by_query (const char *name, char *buf, int buf_size)
     {
       assert (strlen (db_get_string (&value)) < buf_size);
       strncpy (buf, db_get_string (&value), buf_size);
-      assert (buf[0] != '\0');
     }
   else
     {
@@ -18631,11 +18633,13 @@ do_find_trigger_by_query (const char *name, char *buf, int buf_size)
   query_error.err_lineno = 0;
   query_error.err_posno = 0;
 
-  if (name == NULL || name[0] == '\0' || buf == NULL)
+  if (name == NULL || name[0] == '\0')
     {
       ERROR_SET_WARNING (error, ER_OBJ_INVALID_ARGUMENTS);
       return error;
     }
+
+  assert (buf != NULL);
 
   if (db_get_current_user_name (current_user_name, DB_MAX_USER_LENGTH) == NULL)
     {
@@ -18682,7 +18686,6 @@ do_find_trigger_by_query (const char *name, char *buf, int buf_size)
     {
       assert (strlen (db_get_string (&value)) < buf_size);
       strncpy (buf, db_get_string (&value), buf_size);
-      assert (buf[0] != '\0');
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24233

Purpose
- Changed the unload format for missing triggers and resolution.

Implementation
- Do not output the specified owner when the owner should not be specified.
  - src/object/trigger_description.cpp - tr_dump_selective_triggers (), tr_dump_trigger () 
- Outputs the specified owner name and object name separately.
  - src/object/trigger_description.cpp - tr_dump_trigger ()
  - src/executables/unload_schema.c - emit_resolutions (), emit_resolution_def ()
- Refactoring.
  - src/object/schema_manager.c - sm_qualifier_name ()
    - Remove string copy inside function.
  - Minor changes in some functions.
    - Changed checking with if statement to assert().

Remarks
- N/A