### PR TITLE
[CBRD-24224] Fix error message when using tr_TR.utf8

### DIFF
--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1542,10 +1542,10 @@ $set 7 MSGCAT_SET_PARSER_SYNTAX
 103 Dizin ipuçlarının geçersiz kullanımı
 104 Bit dizgesinin uzunluğu en fazla %1$d bittir.
 105 Sözdizim hatası: unexpected
-106 , bekliyor '{'
-107 , bekliyor SELECT veya '('
-108 , bekliyor
-109 beklenmedik
+106 , expecting '{'
+107 , expecting SELECT or '('
+108 , expecting
+109 unexpected
 110 IFADESININ SONUNA
 111 Çizgide %1$d, sütununda %2$d önce '%3$c%4$s'\n
 112 Çizgide %1$d, sütununda %2$d önce %3$s\n


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24224


In the function yyreportSyntaxError(), which is automatically added by bison, when generating an error message to guide syntax errors, the following rules are generated.
```
#define YYCASE_(N, S)                   \
      case N:                           \
        yyformat = S;                   \
      break
      YYCASE_(0, YY_("syntax error"));
      YYCASE_(1, YY_("syntax error, unexpected %s"));
      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
#undef YYCASE_
```
The string generated through the above process is passed as an argument to csql_yyerror().

Appropriate processing according to multilingual character set is performed inside csql_yyerror().
At this time, since functions such as strstr() or strcmp() are used for comparison, certain error messages must be written in English regardless of the character set.
There was an error where it was written differently only in Turkish.

**TEST case**
```
mkdir ${CUBRID_DATABASES}/trdb
cubrid createdb -F ${CUBRID_DATABASES}/trdb --db-volume-size=20m --log-volume-size=20m -r trdb tr_TR.utf8

export CUBRID_MSG_LANG=tr_TR
csql -S -u dba trdb -c "delete from t1 left join t2 where t1.i=t2.i;" 
unset CUBRID_MSG_LANG
csql -S -u dba trdb -c "delete from t1 left join t2 where t1.i=t2.i;" 

cubrid deletedb trdb
rm -rf ${CUBRID_DATABASES}/trdb
```

**AS-IS**
```
1 satırında , sütun 16,

HATA: Sözdizim hatası: unexpected IFADESININ SONUNA

In line 1, column 16,

ERROR: In line 1, column 16 before ' join t2 where t1.i=t2.i;'
Syntax error: unexpected 'left', expecting $end
```

**TO-BE**
```
1 satırında , sütun 16,

HATA: Çizgide 1, sütununda 16 önce ' join t2 where t1.i=t2.i;'
Sözdizim hatası: unexpected 'left', expecting $end

In line 1, column 16,

ERROR: In line 1, column 16 before ' join t2 where t1.i=t2.i;'
Syntax error: unexpected 'left', expecting $end
```



