### PR TITLE
[CBRD-24235] There is a risk of being string truncated when creating an ODBC connection url string.

### DIFF
--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -554,17 +554,20 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strcpy (br_info[num_brs].cgw_link_server,
-	      ini_getstr (ini, sec_name, "CGW_LINK_SERVER", DEFAULT_EMPTY_STRING, &lineno));
-      strcpy (br_info[num_brs].cgw_link_server_ip,
-	      ini_getstr (ini, sec_name, "CGW_LINK_SERVER_IP", DEFAULT_EMPTY_STRING, &lineno));
-      strcpy (br_info[num_brs].cgw_link_server_port,
-	      ini_getstr (ini, sec_name, "CGW_LINK_SERVER_PORT", DEFAULT_EMPTY_STRING, &lineno));
-      strcpy (br_info[num_brs].cgw_link_odbc_driver_name,
-	      ini_getstr (ini, sec_name, "CGW_LINK_ODBC_DRIVER_NAME", DEFAULT_EMPTY_STRING, &lineno));
-      strcpy (br_info[num_brs].cgw_link_connect_url_property,
-	      ini_getstr (ini, sec_name, "CGW_LINK_CONNECT_URL_PROPERTY", DEFAULT_EMPTY_STRING, &lineno));
+      strncpy_bufsize (br_info[num_brs].cgw_link_server,
+		       ini_getstr (ini, sec_name, "CGW_LINK_SERVER", DEFAULT_EMPTY_STRING, &lineno));
 
+      strncpy_bufsize (br_info[num_brs].cgw_link_server_ip,
+		       ini_getstr (ini, sec_name, "CGW_LINK_SERVER_IP", DEFAULT_EMPTY_STRING, &lineno));
+
+      strncpy_bufsize (br_info[num_brs].cgw_link_server_port,
+		       ini_getstr (ini, sec_name, "CGW_LINK_SERVER_PORT", DEFAULT_EMPTY_STRING, &lineno));
+
+      strncpy_bufsize (br_info[num_brs].cgw_link_odbc_driver_name,
+		       ini_getstr (ini, sec_name, "CGW_LINK_ODBC_DRIVER_NAME", DEFAULT_EMPTY_STRING, &lineno));
+
+      strncpy_bufsize (br_info[num_brs].cgw_link_connect_url_property,
+		       ini_getstr (ini, sec_name, "CGW_LINK_CONNECT_URL_PROPERTY", DEFAULT_EMPTY_STRING, &lineno));
 
       br_info[num_brs].appl_server =
 	get_conf_value (ini_getstr (ini, sec_name, "APPL_SERVER", DEFAULT_APPL_SERVER, &lineno), tbl_appl_server);

--- a/src/broker/broker_config.h
+++ b/src/broker/broker_config.h
@@ -116,10 +116,15 @@
 #define CGW_LINK_SERVER_PORT_LEN	 10
 #define CGW_LINK_ODBC_DRIVER_NAME_LEN	 256
 #define CGW_LINK_CONNECT_URL_PROPERTY_LEN	512
-#define CGW_LINK_URL_MAX_LEN	         (CGW_LINK_SERVER_IP_LEN           \
-                                          + CGW_LINK_SERVER_PORT_LEN       \
-                                          + CGW_LINK_ODBC_DRIVER_NAME_LEN  \
-                                          + CGW_LINK_CONNECT_URL_PROPERTY_LEN)     \
+#define CGW_LINK_STRING_FORMAT_LEN 128
+#define CGW_LINK_URL_MAX_LEN	         (CGW_LINK_SERVER_IP_LEN                 \
+                                          + CGW_LINK_SERVER_PORT_LEN             \
+                                          + CGW_LINK_ODBC_DRIVER_NAME_LEN        \
+                                          + CGW_LINK_CONNECT_URL_PROPERTY_LEN    \
+                                          + SRV_CON_DBNAME_SIZE                  \
+                                          + SRV_CON_DBUSER_SIZE                  \
+                                          + SRV_CON_DBPASSWD_SIZE)               \
+                                          + CGW_LINK_STRING_FORMAT_LEN           \
 
 
 enum t_sql_log_mode_value

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -870,6 +870,9 @@ cas_main (void)
 #if defined(CAS_FOR_CGW)
   char odbc_resolved_url[CGW_LINK_URL_MAX_LEN] = { 0, };
   char odbc_connect_url[CGW_LINK_URL_MAX_LEN] = { 0, };
+  char tmp_name[SRV_CON_DBNAME_SIZE] = { 0, };
+  char tmp_user[SRV_CON_DBUSER_SIZE] = { 0, };
+  char tmp_passwd[SRV_CON_DBPASSWD_SIZE] = { 0, };
   SUPPORTED_DBMS_TYPE dbms_type = NOT_SUPPORTED_DBMS;;
 #endif
 
@@ -1246,20 +1249,23 @@ cas_main (void)
 	    dbms_type = cgw_is_supported_dbms (shm_appl->cgw_link_server);
 	    cgw_set_dbms_type (dbms_type);
 
+	    strncpy (tmp_name, db_name, SRV_CON_DBNAME_SIZE);
+	    strncpy (tmp_user, db_user, SRV_CON_DBUSER_SIZE);
+	    strncpy (tmp_passwd, db_passwd, SRV_CON_DBUSER_SIZE);
+
 	    if (dbms_type == SUPPORTED_DBMS_ORACLE)
 	      {
 		snprintf (odbc_connect_url, CGW_LINK_URL_MAX_LEN, ORACLE_CONNECT_URL_FORMAT,
 			  shm_appl->cgw_link_odbc_driver_name,
-			  db_name,
+			  tmp_name,
 			  shm_appl->cgw_link_server_port,
-			  db_name, db_user, db_passwd, shm_appl->cgw_link_connect_url_property);
+			  tmp_name, tmp_user, tmp_passwd, shm_appl->cgw_link_connect_url_property);
 
 		snprintf (odbc_resolved_url, CGW_LINK_URL_MAX_LEN, ORACLE_CONNECT_URL_FORMAT,
 			  shm_appl->cgw_link_odbc_driver_name,
-			  db_name,
+			  tmp_name,
 			  shm_appl->cgw_link_server_port,
-			  db_name, db_user, "********", shm_appl->cgw_link_connect_url_property);
-
+			  tmp_name, tmp_user, "********", shm_appl->cgw_link_connect_url_property);
 	      }
 	    else if (dbms_type == SUPPORTED_DBMS_MYSQL)
 	      {
@@ -1267,13 +1273,13 @@ cas_main (void)
 			  shm_appl->cgw_link_odbc_driver_name,
 			  shm_appl->cgw_link_server_ip,
 			  shm_appl->cgw_link_server_port,
-			  db_name, db_user, db_passwd, shm_appl->cgw_link_connect_url_property);
+			  tmp_name, tmp_user, tmp_passwd, shm_appl->cgw_link_connect_url_property);
 
 		snprintf (odbc_resolved_url, CGW_LINK_URL_MAX_LEN, MYSQL_CONNECT_URL_FORMAT,
 			  shm_appl->cgw_link_odbc_driver_name,
 			  shm_appl->cgw_link_server_ip,
 			  shm_appl->cgw_link_server_port,
-			  db_name, db_user, "********", shm_appl->cgw_link_connect_url_property);
+			  tmp_name, tmp_user, "********", shm_appl->cgw_link_connect_url_property);
 	      }
 	    else
 	      {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24235

Purpose
To connect to Oracle/Mysql using ODBC, you need to configure the connection url.
In the process of composing the connection url string, there is a risk that the string may be truncated, so it needs to be modified.

Implementation
When reading ODBC gateway parameter from cubrid_broker.conf, truncate is prevented when creating connection url using this parameter.

Remarks
N/A