### PR TITLE
[CBRD-24237] Substitution of  in error message

### DIFF
--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -1671,7 +1671,8 @@ csql_yyerror (const char *s)
 
 	  if (after_token)
 	    {
-	      msg_size += strlen (after_token);
+              msg_size += strlen (after_token);
+              // There is no need to reset the length as we will replace "$end" with "';'".              
 	    }
 
 	  msg = (char *) csql_yyalloc (msg_size);
@@ -1705,7 +1706,20 @@ csql_yyerror (const char *s)
 
 	  if (after_token)
 	    {
-	      strcat (msg, after_token);
+              char* end_ptr = strstr (after_token, "$end");
+
+              if (!end_ptr)
+                strcat (msg, after_token);
+              else
+               {
+                 *end_ptr = '\0';
+                 strcat (msg, after_token);
+                 *end_ptr = '$';
+                 end_ptr += 4; /* strlen("$end") */
+                 strcat (msg, "';'");
+                 if(*end_ptr)
+                    strcat (msg, end_ptr);
+               } 
 	    }
 	}
       else

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -1709,7 +1709,9 @@ csql_yyerror (const char *s)
               char* end_ptr = strstr (after_token, "$end");
 
               if (!end_ptr)
-                strcat (msg, after_token);
+               {
+                 strcat (msg, after_token);
+               }
               else
                {
                  *end_ptr = '\0';
@@ -1718,7 +1720,9 @@ csql_yyerror (const char *s)
                  end_ptr += 4; /* strlen("$end") */
                  strcat (msg, "';'");
                  if(*end_ptr)
-                    strcat (msg, end_ptr);
+                   {
+                     strcat (msg, end_ptr);
+                   }
                } 
 	    }
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24237

Replaces $end of the error message with ';' and prints it.
