### PR TITLE
[LETS-340] server-server connection error handling infrastructure for transaction server  

### DIFF
--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -148,7 +148,7 @@ namespace cubcomm
   , m_queue_autosend { new request_queue_autosend_t (*m_queue) }
   , m_outgoing_response_msgid { a_outgoing_response_msgid }
   , m_incoming_response_msgid { a_incoming_response_msgid }
-  , m_response_broker { response_partition_count, NO_ERRORS }
+  , m_response_broker { response_partition_count, NO_ERRORS, ERROR_ON_WRITE }
   {
     assert (a_incoming_request_handlers.size () > 0);
     for (const auto &pair: a_incoming_request_handlers)

--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -173,9 +173,17 @@ namespace cubcomm
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
   request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::~request_sync_client_server ()
   {
+    // terminate sending messages
     m_queue_autosend.reset (nullptr);
+
     m_queue.reset (nullptr);
+
+    // terminate receiving messages
     m_conn.reset (nullptr);
+
+    // after autosender and received threads are terminated, there can be no more responses/errors
+    // registered on the broker
+    m_response_broker.terminate ();
   }
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
@@ -215,7 +223,7 @@ namespace cubcomm
     };
 
     // Send the request
-    m_queue->push (a_outgoing_message_id, std::move (seq_payload), nullptr /*std::move (error_handler_ftor)*/);
+    m_queue->push (a_outgoing_message_id, std::move (seq_payload), std::move (error_handler_ftor));
     // function is non-blocking, it will just push the message to be sent.
     // The following broker response getter is the blocking part.
 

--- a/src/communication/response_broker.hpp
+++ b/src/communication/response_broker.hpp
@@ -90,12 +90,15 @@ namespace cubcomm
 	    T_ERROR m_error;
 	  };
 
+	  using response_payload_container_type = std::unordered_map<response_sequence_number, payload_or_error_type>;
+
+	private:
 	  const T_ERROR m_no_error;
 	  const T_ERROR m_error;
 
 	  std::mutex m_mutex;
 	  std::condition_variable m_condvar;
-	  std::unordered_map<response_sequence_number, payload_or_error_type> m_response_payloads;
+	  response_payload_container_type m_response_payloads;
 
 	  bool m_terminate;
       };
@@ -210,23 +213,17 @@ namespace cubcomm
   std::tuple<T_PAYLOAD, T_ERROR>
   response_broker<T_PAYLOAD, T_ERROR>::bucket::get_response (response_sequence_number a_rsn)
   {
-    std::tuple<T_PAYLOAD, T_ERROR> payload_or_error { T_PAYLOAD (), m_error };
-
-    auto condvar_pred = [this, &payload_or_error, a_rsn] ()
-    {
-      auto it = m_response_payloads.find (a_rsn);
-      if (it == m_response_payloads.end ())
-	{
-	  return false;
-	}
-      payload_or_error = { std::move ((*it).second.m_payload), std::move ((*it).second.m_error) };
-      m_response_payloads.erase (it);
-
-      return true;
-    };
-
     constexpr std::chrono::milliseconds millis_100 { 100 };
+
     {
+      typename response_payload_container_type::iterator found_it { m_response_payloads.end () };
+
+      auto condvar_pred = [this, &found_it, a_rsn] ()
+      {
+	found_it = m_response_payloads.find (a_rsn);
+	return (found_it != m_response_payloads.end ());
+      };
+
       std::unique_lock<std::mutex> ulock (m_mutex);
       // a way out in case neither value nor error is registered as a response
       // which can happen in case - eg - that the connection is dropped
@@ -234,13 +231,20 @@ namespace cubcomm
 	{
 	  if (m_condvar.wait_for (ulock, millis_100, condvar_pred))
 	    {
+	      assert (found_it != m_response_payloads.end ());
+	      std::tuple<T_PAYLOAD, T_ERROR> payload_or_error
+	      {
+		std::move ((*found_it).second.m_payload ),
+		std::move ((*found_it).second.m_error)
+	      };
+	      m_response_payloads.erase (found_it);
 	      return payload_or_error;
 	    }
 	}
     }
 
     // upon terminate, error response will be returned
-    return payload_or_error;
+    return std::make_tuple (T_PAYLOAD (), m_error);
   }
 
   template <typename T_PAYLOAD, typename T_ERROR>

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -55,11 +55,14 @@ page_server::connection_handler::connection_handler (cubcomm::channel &chn, page
   : m_ps (ps)
   , m_abnormal_tran_server_disconnect { false }
 {
+  constexpr size_t RESPONSE_PARTITIONING_SIZE = 1; // Arbitrarily chosen
+
   m_conn.reset (
 	  new tran_server_conn_t (std::move (chn),
   {
     // common
     {
+      // TODO: rename handler with _async / _sync
       tran_to_page_request::GET_BOOT_INFO,
       std::bind (&page_server::connection_handler::receive_boot_info_request, std::ref (*this), std::placeholders::_1)
     },
@@ -92,7 +95,8 @@ page_server::connection_handler::connection_handler (cubcomm::channel &chn, page
     }
   },
   page_to_tran_request::RESPOND,
-  tran_to_page_request::RESPOND, 1,
+  tran_to_page_request::RESPOND,
+  RESPONSE_PARTITIONING_SIZE,
   std::bind (&page_server::connection_handler::abnormal_tran_server_disconnect,
 	     std::ref (*this), std::placeholders::_1, std::placeholders::_2)));
 

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -71,7 +71,7 @@ void passive_tran_server::send_and_receive_log_boot_info (THREAD_ENTRY *thread_p
 {
   std::string log_boot_info;
 
-  send_receive (tran_to_page_request::SEND_LOG_BOOT_INFO_FETCH, std::string (), log_boot_info);
+  (void) send_receive (tran_to_page_request::SEND_LOG_BOOT_INFO_FETCH, std::string (), log_boot_info);
 
   assert (!log_boot_info.empty ());
 
@@ -129,7 +129,7 @@ void passive_tran_server::send_and_receive_stop_log_prior_dispatch ()
 
   std::string expected_empty_answer;
   // blocking call
-  send_receive (tran_to_page_request::SEND_STOP_LOG_PRIOR_DISPATCH, std::string (), expected_empty_answer);
+  (void) send_receive (tran_to_page_request::SEND_STOP_LOG_PRIOR_DISPATCH, std::string (), expected_empty_answer);
 
   // at this point, no log prior is flowing from the connected page server(s)
   // outside this context, all log prior currently present on the passive transaction server

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -288,6 +288,8 @@ tran_server::connect_to_page_server (const cubcomm::node &node, const char *db_n
 		srv_chn.get_channel_id ().c_str ());
 
   constexpr size_t RESPONSE_PARTITIONING_SIZE = 24;   // Arbitrarily chosen
+  // TODO: to reduce contention as much as possible, should be equal to the maximum number
+  // of active transactions that the system allows (PRM_ID_CSS_MAX_CLIENTS) + 1
 
   cubcomm::send_queue_error_handler no_transaction_handler { nullptr };
   // Transaction server will use message specific error handlers.

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -237,7 +237,7 @@ void
 tran_server::get_boot_info_from_page_server ()
 {
   std::string response_message;
-  send_receive (tran_to_page_request::GET_BOOT_INFO, std::string (), response_message);
+  (void) send_receive (tran_to_page_request::GET_BOOT_INFO, std::string (), response_message);
 
   DKNVOLS nvols_perm;
   std::memcpy (&nvols_perm, response_message.c_str (), sizeof (nvols_perm));

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -75,7 +75,7 @@ class tran_server
     void disconnect_page_server ();
     bool is_page_server_connected () const;
     void push_request (tran_to_page_request reqid, std::string &&payload);
-    void send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out);
+    int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out);
 
     virtual bool uses_remote_storage () const;
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8336,7 +8336,7 @@ pgbuf_request_data_page_from_page_server (const VPID * vpid, log_lsa target_repl
     }
 
   std::string response_message;
-  ts_Gl->send_receive (tran_to_page_request::SEND_DATA_PAGE_FETCH, std::move (request_message), response_message);
+  (void) ts_Gl->send_receive (tran_to_page_request::SEND_DATA_PAGE_FETCH, std::move (request_message), response_message);
 
   const char *message_buf = response_message.c_str ();
   int error_code = NO_ERROR;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -2104,7 +2104,7 @@ logpb_request_log_page_from_page_server (LOG_PAGEID log_pageid, LOG_PAGE * log_p
       _er_log_debug (ARG_FILE_LINE, "[READ LOG] Sent request for log to Page Server. Page ID: %lld \n", log_pageid);
     }
   std::string response_message;
-  ts_Gl->send_receive (tran_to_page_request::SEND_LOG_PAGE_FETCH, std::move (request_message), response_message);
+  (void) ts_Gl->send_receive (tran_to_page_request::SEND_LOG_PAGE_FETCH, std::move (request_message), response_message);
 
   assert (response_message.size () > 0);
   const char *message_ptr = response_message.c_str ();

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -687,7 +687,8 @@ TEST_CASE ("Test response broker", "")
   constexpr size_t BUCKET_COUNT = 30;
 
   cubcomm::response_sequence_number_generator rsn_gen;
-  cubcomm::response_broker<cubcomm::response_sequence_number, css_error_code> broker (BUCKET_COUNT, NO_ERRORS);
+  cubcomm::response_broker<cubcomm::response_sequence_number, css_error_code> broker (BUCKET_COUNT, NO_ERRORS,
+      ERROR_ON_WRITE);
 
   std::vector<cubcomm::response_sequence_number> requested_rsn;
   std::mutex request_mutex;

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -163,7 +163,8 @@ class test_two_client_server_env
 
 // Global op count, per each request id, is used by the server to check the requests are processed in the expected
 // order.
-std::array<int, 2> global_op_count;
+std::array<int, 2> global_in_order_processed_op_count;
+std::array<int, 2> global_out_of_order_processed_op_count;
 
 struct payload_with_op_count : public cubpacking::packable_object
 {
@@ -194,9 +195,14 @@ template <typename SCS, typename ReqId>
 static void push_scs_message_id_and_op (SCS &rssq, ReqId reqid, int op_count);
 // Server handler checks both request id and request order
 template <typename ReqId, ReqId ExpectedVal>
-static void mock_check_expected_id_and_op_count (cubpacking::unpacker &upk);
-// Function for registering mock_check_expected_id_and_op_count handlers
-static void handler_register_mock_check_expected_id_and_op_count (test_request_server &req_sr);
+static void mock_check_expected_in_order_id_and_op_count (cubpacking::unpacker &upk);
+// Function for registering mock_check_expected_in_order_id_and_op_count handlers
+static void handler_register_mock_check_expected_in_order_id_and_op_count (test_request_server &req_sr);
+// Server handler checks out-of-order request id processing
+template <typename ReqId, ReqId ExpectedVal>
+static void mock_check_expected_out_of_order_id_and_op_count (cubpacking::unpacker &upk);
+// Function for registering mock_check_expected_out_of_order_id_and_op_count handlers
+static void handler_register_mock_check_expected_out_of_order_id_and_op_count (test_request_server &req_sr);
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Stuff for two request_sync_client_server test case
@@ -457,7 +463,7 @@ TEST_CASE ("Verify request_sync_send_queue with request_client", "")
   require_all_sent_requests_are_handled ();
 }
 
-TEST_CASE ("Test request_queue_autosend", "")
+TEST_CASE ("Test in-order request_queue_autosend", "")
 {
   // Test the way requests are handled using a request_queue_autosend. All pushed requests are automatically send by
   // the request_queue_autosend. The requests are sent in the same order that they are pushed.
@@ -468,7 +474,7 @@ TEST_CASE ("Test request_queue_autosend", "")
   //	- the number of requests sent is the same as the number of requests handled
   //
 
-  test_handler_register_function hreg_fun = handler_register_mock_check_expected_id_and_op_count;
+  test_handler_register_function hreg_fun = handler_register_mock_check_expected_in_order_id_and_op_count;
   test_client_and_server_env env (hreg_fun);
 
   using test_rssq = cubcomm::request_sync_send_queue<test_request_client, payload_with_op_count>;
@@ -504,6 +510,82 @@ TEST_CASE ("Test request_queue_autosend", "")
   autosend.stop_thread ();
 
   require_all_sent_requests_are_handled ();
+}
+
+TEST_CASE ("Test out-of-order request_queue_autosend", "")
+{
+  // Test the way requests are handled using a request_queue_autosend intermingled with forced "send all".
+  // All pushed requests are automatically send by either the request_queue_autosend or by explicit sends invoked
+  // from separate threads. The requests are sent deterministically but out of order.
+  //
+  // Verify that:
+  //	- all requests are handled by the expected type of handled
+  //	- the number of requests sent is the same as the number of requests handled
+  //
+  // This scenario does not occur in production but the test stresses the implementation to ensure robustness.
+
+  test_handler_register_function hreg_fun = handler_register_mock_check_expected_out_of_order_id_and_op_count;
+  test_client_and_server_env env (hreg_fun);
+
+  using test_rssq = cubcomm::request_sync_send_queue<test_request_client, payload_with_op_count>;
+
+  test_rssq rssq (env.get_client (), nullptr);
+  test_rssq::queue_type backbuffer;
+
+  env.get_server ().start_thread ();
+
+  constexpr int total_op_count = 1000;
+
+  std::thread t1 ([&rssq]
+  {
+    for (int op_count = 0; op_count < total_op_count; ++op_count)
+      {
+	push_rssq_message_id_and_op (rssq, reqids::_0, op_count);
+      }
+  });
+  std::thread t2 ([&rssq]
+  {
+    for (int op_count = 0; op_count < total_op_count; ++op_count)
+      {
+	push_rssq_message_id_and_op (rssq, reqids::_1, op_count);
+      }
+  });
+  std::thread t3 ([&rssq]
+  {
+    test_rssq::queue_type local_buffer;
+    auto start_time = std::chrono::system_clock::now ();
+    while (std::chrono::system_clock::now () - start_time < std::chrono::seconds (1))
+      {
+	rssq.send_all (local_buffer);
+	std::this_thread::sleep_for (std::chrono::milliseconds (1));
+      }
+  });
+  std::thread t4 ([&rssq]
+  {
+    test_rssq::queue_type local_buffer;
+    auto start_time = std::chrono::system_clock::now ();
+    while (std::chrono::system_clock::now () - start_time < std::chrono::seconds (1))
+      {
+	rssq.wait_not_empty_and_send_all (local_buffer, std::chrono::milliseconds (1));
+      }
+  });
+
+  cubcomm::request_queue_autosend<test_rssq> autosend (rssq);
+  autosend.start_thread ();
+
+  t1.join ();
+  t2.join ();
+  t3.join ();
+  t4.join ();
+
+  env.wait_for_all_messages ();
+  env.get_server ().stop_thread ();
+  autosend.stop_thread ();
+
+  require_all_sent_requests_are_handled ();
+
+  REQUIRE (((total_op_count - 1) * total_op_count / 2) == global_out_of_order_processed_op_count[/*reqids::_*/0]);
+  REQUIRE (((total_op_count - 1) * total_op_count / 2) == global_out_of_order_processed_op_count[/*reqids::_*/1]);
 }
 
 TEST_CASE ("Two request_sync_client_server communicate with each other", "[dbg]")
@@ -677,8 +759,11 @@ init_globals ()
   global_sent_request_count = 0;
   global_handled_request_count = 0;
 
-  global_op_count[0] = 0;
-  global_op_count[1] = 0;
+  global_in_order_processed_op_count[/*reqids::_*/0] = 0;
+  global_in_order_processed_op_count[/*reqids::_*/1] = 0;
+
+  global_out_of_order_processed_op_count[/*reqids::_*/0] = 0;
+  global_out_of_order_processed_op_count[/*reqids::_*/1] = 0;
 }
 
 static void
@@ -725,13 +810,25 @@ push_request_id_as_message (RSSQ &rssq, ReqId rid)
 
 template <typename ReqId, ReqId ExpectedVal>
 static void
-mock_check_expected_id_and_op_count (cubpacking::unpacker &upk)
+mock_check_expected_in_order_id_and_op_count (cubpacking::unpacker &upk)
 {
   payload_with_op_count payload;
   payload.unpack (upk);
   REQUIRE (payload.val == static_cast<int> (ExpectedVal));
-  REQUIRE (global_op_count[payload.val] == payload.op_count);
-  ++global_op_count[payload.val];
+  REQUIRE (global_in_order_processed_op_count[/*reqids::_*/payload.val] == payload.op_count);
+  ++global_in_order_processed_op_count[/*reqids::_*/payload.val];
+
+  ++global_handled_request_count;
+}
+
+template <typename ReqId, ReqId ExpectedVal>
+static void
+mock_check_expected_out_of_order_id_and_op_count (cubpacking::unpacker &upk)
+{
+  payload_with_op_count payload;
+  payload.unpack (upk);
+  REQUIRE (payload.val == static_cast<int> (ExpectedVal));
+  global_out_of_order_processed_op_count[/*reqids::_*/payload.val] += payload.op_count;
 
   ++global_handled_request_count;
 }
@@ -763,15 +860,30 @@ push_scs_message_id_and_op (SCS &scs, ReqId reqid, int op_count)
 }
 
 static void
-handler_register_mock_check_expected_id_and_op_count (test_request_server &req_sr)
+handler_register_mock_check_expected_in_order_id_and_op_count (test_request_server &req_sr)
 {
   cubcomm::request_server<reqids>::server_request_handler reqh0 = [] (cubpacking::unpacker &upk)
   {
-    mock_check_expected_id_and_op_count<reqids, reqids::_0> (upk);
+    mock_check_expected_in_order_id_and_op_count<reqids, reqids::_0> (upk);
   };
   cubcomm::request_server<reqids>::server_request_handler reqh1 = [] (cubpacking::unpacker &upk)
   {
-    mock_check_expected_id_and_op_count<reqids, reqids::_1> (upk);
+    mock_check_expected_in_order_id_and_op_count<reqids, reqids::_1> (upk);
+  };
+  req_sr.register_request_handler (reqids::_0, reqh0);
+  req_sr.register_request_handler (reqids::_1, reqh1);
+}
+
+static void
+handler_register_mock_check_expected_out_of_order_id_and_op_count (test_request_server &req_sr)
+{
+  cubcomm::request_server<reqids>::server_request_handler reqh0 = [] (cubpacking::unpacker &upk)
+  {
+    mock_check_expected_out_of_order_id_and_op_count<reqids, reqids::_0> (upk);
+  };
+  cubcomm::request_server<reqids>::server_request_handler reqh1 = [] (cubpacking::unpacker &upk)
+  {
+    mock_check_expected_out_of_order_id_and_op_count<reqids, reqids::_1> (upk);
   };
   req_sr.register_request_handler (reqids::_0, reqh0);
   req_sr.register_request_handler (reqids::_1, reqh1);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-340

Infrastructure to allow message-specific error handling.
Error handling is implemented in `request_sync_send_queue` by means of the interface `send_queue_error_handler`.
Extend error handling with a message-specific error handling for each dispatched message by means of `request_sync_send_queue::push` function.
Used for handling communication errors on the active/passive transaction server side.
   
Implementation:
- extended `request_sync_send_queue::queue_item_type` with an error handler, which is first checked and handled in the `push` function in case sending fails (as a remark, network communication could be detected immediately only if the application protocol is a request-ACK type of; in this case the application protocol is more has a loose request-response structure in the sense that the response is waited for but not immediately, rather in an async optimistic-like manner; this has been chosen for performance reasons; as such, should there be a failure of the network connection, it will be detected reactively rather than pro-actively - eg. when the internal/socket's send bufffer would have filled)
- class `response_broker` is a class that facilitates simple send-and-wait-for-response roundtrips; extended with the ability to register either response or error response; the error type is a new template argument `T_ERROR` which can be registered via `register_error` and will be returned together with the response as a tuple in `response_broker::bucket::get_response`
- `response_broker` will take additional `T_ERROR` ctor arguments that tells it which is the no-error (idle value) and also a generic error for the error response value - this is needed because the used typename used for `T_ERROR` is an enum - `enum css_error_code`
- in case the response broker needs to terminate without having receive either an actual response or an error, the generic error result will be returned
- add an error handler to `request_sync_client_server::send_recv` which uses the infrastructure in `response_broker` to check whether sending succeeded or not
- `tran_server::send_receive` sets an error and returns error code which is then further handled upstream
- adapted unit tests

Other:
- more granular locking when sending messages over the network in `request_sync_send_queue::push` with the purpose of avoiding double mutex locking as much as possible added a stress unit test to ensure correctness of this change - "Test out-of-order request_queue_autosend"