### PR TITLE
[LETS-393] Added error code variable to btree_find_boundary_leaf_with_repl_desync_check

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -14387,7 +14387,7 @@ btree_find_boundary_leaf_with_repl_desync_check (THREAD_ENTRY * thread_p, const 
   int root_level = 0, depth = 0;
 
   desync_occured = false;
-  int error_code = er_errid ();
+  const int error_code = er_errid ();
   ASSERT_NO_ERROR ();
 
   VPID_SET_NULL (pg_vpid);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -14387,7 +14387,8 @@ btree_find_boundary_leaf_with_repl_desync_check (THREAD_ENTRY * thread_p, const 
   int root_level = 0, depth = 0;
 
   desync_occured = false;
-  const int error_code = er_errid ();
+  // TODO: temporary change to identify problem
+  const int temp_error_code = er_errid ();
   ASSERT_NO_ERROR ();
 
   VPID_SET_NULL (pg_vpid);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -14387,6 +14387,7 @@ btree_find_boundary_leaf_with_repl_desync_check (THREAD_ENTRY * thread_p, const 
   int root_level = 0, depth = 0;
 
   desync_occured = false;
+  int error_code = er_errid ();
   ASSERT_NO_ERROR ();
 
   VPID_SET_NULL (pg_vpid);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-393

Added a new local variable that store the current error code at the beginning of `btree_find_boundary_leaf_with_repl_desync_check` before the `ASSERT_NO_ERROR` to make it easier to debug the code.
