### PR TITLE
[CBRD-24225] Added information for debugging to csql_grammar.y and csql_lexer.l

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -84,6 +84,36 @@ extern int g_msg[1024];
 extern int msg_ptr;
 extern int yybuffer_pos;
 
+#if defined(SA_MODE)
+     /*
+     ** DBG_TRACE_LEVEL is specified by referring to the following.
+     ** 0: No displayed on the screen
+     ** 1: Words extracted from csql_lexer are displayed on the screen
+     ** 2: Display the contents of application of grammar rules in csql_grammar on the screen
+     ** 3: Expression of both 1 and 2 above
+     */
+#    define DBG_TRACE_LEVEL      0
+#endif
+
+#if (DBG_TRACE_LEVEL == 1 || DBG_TRACE_LEVEL == 3) 
+#    define DBG_PRINT_TOKEN(token)            fprintf(stdout, " *** Token) [%s]\n", token);
+#    define DBG_PRINT_STRING(pre, str, post)  fprintf(stdout, " *** Token) [%s%s%s]\n", pre, str, post);
+#    define DBG_PRINT_TOKEN_END()             fprintf(stdout, "\n");
+#else
+#    define DBG_PRINT_TOKEN(token)
+#    define DBG_PRINT_STRING(pre, str, post)
+#    define DBG_PRINT_TOKEN_END()
+#endif
+
+#if (DBG_TRACE_LEVEL == 2 || DBG_TRACE_LEVEL == 3) 
+#    define DBG_TRACE_GRAMMAR(rule_head, rule_components) do {                            \
+                fprintf(stdout, " *** Rule) " #rule_head "::= "  #rule_components "\n");  \
+                fflush(stdout);                                                           \
+        } while(0)
+#else        
+#    define DBG_TRACE_GRAMMAR(rule_head, rule_components)
+#endif
+
 static void pt_fill_conn_info_container(PARSER_CONTEXT *parser, int buffer_pos, container_10 *ctn, container_2 info);
 /*%CODE_END%*/%}
 
@@ -144,19 +174,11 @@ static void pt_fill_conn_info_container(PARSER_CONTEXT *parser, int buffer_pos, 
 #define PRINT_(a) printf(a)
 #define PRINT_1(a, b) printf(a, b)
 #define PRINT_2(a, b, c) printf(a, b, c)
-#define DBG_PRINT_MATCH(...)    do { fprintf(stdout, "  *** RULE) "__VA_ARGS__);  fflush(stdout); } while(0)
-#define DBG_PRINT_MATCH_LN(...) do {                        \
-                fprintf(stdout, "  *** RULE) "__VA_ARGS__); \
-                fprintf(stdout, "\n");                      \
-                fflush(stdout);                             \
-              } while(0)
 #else
 #define DBG_PRINT
 #define PRINT_(a)
 #define PRINT_1(a, b)
 #define PRINT_2(a, b, c)
-#define DBG_PRINT_MATCH(...)    
-#define DBG_PRINT_MATCH_LN(...) 
 #endif
 
 #define STACK_SIZE	128
@@ -470,6 +492,19 @@ int g_original_buffer_len;
      }                                                  \
    PARSER_SAVE_ERR_CONTEXT ((rv), (b_p))                \
    DBG_PRINT                                            \
+} while (0)
+
+#define MAKE_MONETARY_LITERAL(rv, iv, b_p, sign_text, currency_type) do {    \
+        char *str, *txt;                                                        \
+	PT_NODE *val = parser_new_node (this_parser, PT_VALUE);                 \
+        str = pt_append_string (this_parser, NULL, (sign_text));                \
+	txt = (iv);                                                             \
+	if (val)                                                                \
+	  {                                                                     \
+	    pt_value_set_monetary (this_parser, val, str, txt, (currency_type));\
+	  }                                                                     \
+	(rv) = val;                                                             \
+	PARSER_SAVE_ERR_CONTEXT ((rv), (b_p))                                   \
 } while (0)
 
 %}
@@ -1601,7 +1636,7 @@ int g_original_buffer_len;
 %%
 
 stmt_done
-	: stmt_list
+	: stmt_list { DBG_PRINT_TOKEN_END();}
 	| /* empty */
 	;
 
@@ -1660,7 +1695,7 @@ stmt_list
 
 stmt
 	:
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt, : );
 			msg_ptr = 0;
 
 			if (this_parser->original_buffer)
@@ -1724,7 +1759,7 @@ stmt
 
 		DBG_PRINT}}
 	stmt_
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt, stmt_ );
 
 			#ifdef PARSER_DEBUG
 			if (msg_ptr == 0)
@@ -1791,20 +1826,26 @@ stmt
 	;
 stmt_
 	: create_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, : create_stmt);
+                  $$ = $1; }
 	| alter_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | alter_stmt);
+                  $$ = $1; }
 	| rename_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | rename_stmt);
+                  $$ = $1; }
 	| update_statistics_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | update_statstics_stmt);
+                  $$ = $1; }
 	| drop_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | drop_stmt);
+                  $$ = $1; }
 	| do_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | do_stmt);
+                  $$ = $1; }
 	| opt_with_clause
 	  esql_query_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt_, | opt_with_clause esql_query_stmt);
 			PT_NODE *with_clause = $1;
 			PT_NODE *stmt = $2;
 			if (stmt && with_clause)
@@ -1814,16 +1855,20 @@ stmt_
 			$$ = stmt;
 	  DBG_PRINT}}
 	| evaluate_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | evaluate_stmt);
+                  $$ = $1; }
 	| prepare_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | prepare_stmt);
+                  $$ = $1; }
 	| execute_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | execute_stmt);
+                  $$ = $1; }
 	| insert_or_replace_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | insert_or_replace_stmt);
+                  $$ = $1; }
 	| opt_with_clause
 	  update_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt_, | opt_with_clause update_stmt);
 			PT_NODE *with_clause = $1;
 			PT_NODE *stmt = $2;
 			if (stmt && with_clause)
@@ -1834,7 +1879,7 @@ stmt_
 	  DBG_PRINT}}
 	| opt_with_clause
 	  delete_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt_, | opt_with_clause delete_stmt);
 			PT_NODE *with_clause = $1;
 			PT_NODE *stmt = $2;
 			if (stmt && with_clause)
@@ -1844,25 +1889,34 @@ stmt_
 			$$ = stmt;
 	  DBG_PRINT}}
 	| show_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | show_stmt);
+                  $$ = $1; }
 	| call_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | call_stmt);
+                  $$ = $1; }
 	| auth_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | auth_stmt);
+                  $$ = $1; }
 	| transaction_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | transaction_stmt);
+                  $$ = $1; }
 	| truncate_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | truncate_stmt);
+                  $$ = $1; }
 	| merge_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | merge_stmt);
+                  $$ = $1; }
 	| set_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | set_stmt);
+                  $$ = $1; }
 	| get_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | get_stmt);
+                  $$ = $1; }
 	| kill_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | kill_stmt);
+                  $$ = $1; }
 	| DATA_TYPE___ data_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt_, | DATA_TYPE___ data_type);
 
 			PT_NODE *dt, *set_dt;
 			PT_TYPE_ENUM typ;
@@ -1908,7 +1962,7 @@ stmt_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_ATTACH); }
 	  unsigned_integer
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt_, | ATTACH unsigned_integer);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_2PC_ATTACH);
 
@@ -1925,7 +1979,7 @@ stmt_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_PREPARE); }
 	  opt_to COMMIT unsigned_integer
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt_, | PREPARE opt_to COMMIT unsigned_integer);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_PREPARE_TO_COMMIT);
 
@@ -1942,7 +1996,7 @@ stmt_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_EXECUTE); }
 	  DEFERRED TRIGGER trigger_spec_list
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt_, | EXECUTE DEFERRED TRIGGER trigger_spec_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_EXECUTE_TRIGGER);
 
@@ -1959,7 +2013,7 @@ stmt_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SCOPE); }
 	  trigger_action opt_from_table_spec_list
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt_, | SCOPE trigger_action opt_from_table_spec_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SCOPE);
 
@@ -1974,13 +2028,15 @@ stmt_
 
 		DBG_PRINT}}
 	| vacuum_stmt
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(stmt_, | vacuum_stmt);
+                  $$ = $1; }
 
 	| SET TIMEZONE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TIMEZONE); }
 	  char_string_literal
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt_, | SET TIMEZONE char_string_literal);
+
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_TIMEZONE);
 			if (node)
 			  {
@@ -1995,7 +2051,7 @@ stmt_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TIMEZONE); }
 	  char_string_literal
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(stmt_, | SET Time ZONE char_string_literal);
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_TIMEZONE);
 			if (node)
 			  {
@@ -2011,9 +2067,11 @@ stmt_
 
 opt_from_table_spec_list
 	: /* empty */
-		{ $$ = NULL; }
+		{ DBG_TRACE_GRAMMAR(opt_from_table_spec_list, : );
+                  $$ = NULL; }
 	| FROM ON_ table_spec_list
-		{ $$ = $3; }
+		{ DBG_TRACE_GRAMMAR(opt_from_table_spec_list, | FROM ON_ table_spec_list);
+                  $$ = $3; }
 	;
 
 
@@ -2022,8 +2080,7 @@ set_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_OPT_LEVEL); }
 	  LEVEL opt_of_to_eq opt_level_spec
 		{ pop_msg(); }
-		{{
-
+		{{ DBG_TRACE_GRAMMAR(set_stmt, : SET OPTIMIZATION LEVEL opt_of_to_eq opt_level_spec);
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_OPT_LVL);
 			if (node)
 			  {
@@ -2039,7 +2096,7 @@ set_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_OPT_COST); }
 	  COST opt_of char_string_literal opt_of_to_eq literal_
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET OPTIMIZATION COST opt_of char_string_literal opt_of_to_eq literal_);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_OPT_LVL);
 			if (node)
@@ -2058,7 +2115,7 @@ set_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_SYS_PARAM); }
 	  SYSTEM PARAMETERS char_string_literal_list
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET SYSTEM PARAMETERS char_string_literal_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_SYS_PARAMS);
 			if (node)
@@ -2071,7 +2128,7 @@ set_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TRAN); }
 	  TRANSACTION transaction_mode_list
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET TRANSACTION transaction_mode_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_XACTION);
 
@@ -2088,7 +2145,7 @@ set_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TRIGGER_TRACE); }
 	  TRACE trace_spec
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET TRIGGER TRACE trace_spec);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_TRIGGER);
 
@@ -2106,7 +2163,7 @@ set_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TRIGGER_DEPTH); }
 	  opt_maximum DEPTH depth_spec
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET TRIGGER opt_maximum DEPTH depth_spec);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_TRIGGER);
 
@@ -2121,7 +2178,7 @@ set_stmt
 
 		DBG_PRINT}}
 	| SET session_variable_assignment_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET session_variable_assignment_list);
 
 			PT_NODE *node =
 				parser_new_node (this_parser, PT_SET_SESSION_VARIABLES);
@@ -2134,7 +2191,7 @@ set_stmt
 
 		DBG_PRINT}}
 	| SET NAMES BINARY
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET NAMES BINARY);
 
 			PT_NODE *node = NULL;
 			PT_NODE *charset_node = NULL;
@@ -2165,7 +2222,7 @@ set_stmt
 	  NAMES char_string_literal
 	  opt_collation
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET NAMES char_string_literal opt_collation);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_NAMES);
 			if (node)
@@ -2183,7 +2240,7 @@ set_stmt
 	  NAMES IdName
 	  opt_collation
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET NAMES IdName opt_collation);
 
 			PT_NODE *node = NULL;
 			PT_NODE *charset_node = NULL;
@@ -2210,7 +2267,7 @@ set_stmt
 
 		DBG_PRINT}}
 	| SET TRACE query_trace_spec opt_trace_output_format
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET TRACE query_trace_spec opt_trace_output_format);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_QUERY_TRACE);
 
@@ -2227,33 +2284,33 @@ set_stmt
 
 query_trace_spec
 	: ON_
-		{{
+		{{ DBG_TRACE_GRAMMAR(query_trace_spec, : ON_);
 			$$ = PT_TRACE_ON;
 		DBG_PRINT}}
 	| OFF_
-		{{
+		{{ DBG_TRACE_GRAMMAR(query_trace_spec, | OFF_);
 			$$ = PT_TRACE_OFF;
 		DBG_PRINT}}
 	;
 
 opt_trace_output_format
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_trace_output_format, : );
 			$$ = PT_TRACE_FORMAT_TEXT;
 		DBG_PRINT}}
 	| OUTPUT TEXT
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_trace_output_format, | OUTPUT TEXT);
 			$$ = PT_TRACE_FORMAT_TEXT;
 		DBG_PRINT}}
 	| OUTPUT JSON
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_trace_output_format, | OUTPUT JSON);
 			$$ = PT_TRACE_FORMAT_JSON;
 		DBG_PRINT}}
 	;
 
 session_variable_assignment_list
 	: session_variable_assignment_list ',' session_variable_assignment
-		{{
+		{{ DBG_TRACE_GRAMMAR(session_variable_assignment_list, : session_variable_assignment_list ',' session_variable_assignment);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -2261,7 +2318,7 @@ session_variable_assignment_list
 		DBG_PRINT}}
 
 	| session_variable_assignment
-		{{
+		{{ DBG_TRACE_GRAMMAR(session_variable_assignment_list, | session_variable_assignment);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -2271,7 +2328,7 @@ session_variable_assignment_list
 
 session_variable_assignment
 	: session_variable '=' expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(session_variable_assignment, : session_variable '=' expression_);
 
 			PT_NODE* expr =
 				parser_make_expression (this_parser, PT_DEFINE_VARIABLE, $1, $3, NULL);
@@ -2281,7 +2338,7 @@ session_variable_assignment
 
 		DBG_PRINT}}
 	| session_variable_definition
-		{{
+		{{ DBG_TRACE_GRAMMAR(session_variable_assignment, | session_variable_definition);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -2291,7 +2348,7 @@ session_variable_assignment
 
 session_variable_definition
 	: session_variable VAR_ASSIGN expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(session_variable_definition, : session_variable VAR_ASSIGN expression_);
 
 			PT_NODE* expr =
 				parser_make_expression (this_parser, PT_DEFINE_VARIABLE, $1, $3, NULL);
@@ -2304,7 +2361,7 @@ session_variable_definition
 
 session_variable_expression
 	: session_variable
-		{{
+		{{ DBG_TRACE_GRAMMAR(session_variable_expression, : session_variable);
 
 			PT_NODE *expr = NULL;
 			expr = parser_make_expression (this_parser, PT_EVALUATE_VARIABLE, $1, NULL,
@@ -2318,14 +2375,14 @@ session_variable_expression
 
 session_variable_list
 	: session_variable_list ',' session_variable
-		{{
+		{{ DBG_TRACE_GRAMMAR(session_variable_list, : session_variable_list ',' session_variable);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| session_variable
-		{{
+		{{ DBG_TRACE_GRAMMAR(session_variable_list, | session_variable);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -2335,7 +2392,7 @@ session_variable_list
 
 session_variable
 	: '@' identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(session_variable, : '@' identifier);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			PT_NODE *id = $2;
@@ -2362,7 +2419,7 @@ get_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_STAT); }
 	  STATISTICS char_string_literal  OF class_name into_clause_opt
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(get_stmt, : GET STATISTICS char_string_literal  OF class_name into_clause_opt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_STATS);
 			if (node)
@@ -2379,7 +2436,7 @@ get_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_OPT_LEVEL); }
 	  LEVEL into_clause_opt
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET OPTIMIZATION LEVEL into_clause_opt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_OPT_LVL);
 			if (node)
@@ -2396,7 +2453,7 @@ get_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_OPT_COST); }
 	  COST opt_of char_string_literal into_clause_opt
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET OPTIMIZATION COST opt_of char_string_literal into_clause_opt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_OPT_LVL);
 			if (node)
@@ -2413,7 +2470,7 @@ get_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRAN_ISOL); }
 	  ISOLATION LEVEL into_clause_opt
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET TRANSACTION ISOLATION LEVEL into_clause_opt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_XACTION);
 
@@ -2431,7 +2488,7 @@ get_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRAN_LOCK); }
 	  LOCK_ TIMEOUT into_clause_opt
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET TRANSACTION LOCK_ TIMEOUT into_clause_opt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_XACTION);
 
@@ -2449,7 +2506,7 @@ get_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRIGGER_TRACE); }
 	  TRACE into_clause_opt
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET TRIGGER TRACE into_clause_opt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_TRIGGER);
 
@@ -2467,7 +2524,7 @@ get_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRIGGER_DEPTH); }
 	  opt_maximum DEPTH into_clause_opt
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET TRIGGER opt_maximum DEPTH into_clause_opt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_TRIGGER);
 
@@ -2488,7 +2545,7 @@ get_stmt
 
 create_stmt
 	: CREATE					/* 1 */
-		{					/* 2 */
+		{ DBG_TRACE_GRAMMAR(create_stmt, : CREATE); /* 2 */
 			PT_NODE* qc = parser_new_node(this_parser, PT_CREATE_ENTITY);
 			parser_push_hint_node(qc);
 		}
@@ -2505,7 +2562,7 @@ create_stmt
 	  opt_inherit_resolution_list			/* 13 */
 	  opt_partition_clause 				/* 14 */
           opt_create_as_clause				/* 15 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_stmt, : CREATE ~ of_class_table_type ~ class_name ~);
 
 			PT_NODE *qc = parser_pop_hint_node ();
 			PARSER_SAVE_ERR_CONTEXT (qc, @$.buffer_pos)
@@ -2558,7 +2615,7 @@ create_stmt
 	  opt_as_query_list				/* 11 */
 	  opt_with_levels_clause			/* 12 */
 	  opt_vclass_comment_spec           /* 13 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE ~ of_view_vclass class_name ~ );
 
 			PT_NODE *qc = parser_new_node (this_parser, PT_CREATE_ENTITY);
 
@@ -2589,6 +2646,7 @@ create_stmt
 		DBG_PRINT}}
 	| CREATE					/* 1 */
 		{					/* 2 */
+                        DBG_TRACE_GRAMMAR(create_stmt, | CREATE);
 			PT_NODE* node = parser_new_node (this_parser, PT_CREATE_INDEX);
 			parser_push_hint_node (node);
 			push_msg (MSGCAT_SYNTAX_INVALID_CREATE_INDEX);
@@ -2606,7 +2664,7 @@ create_stmt
 	  opt_comment_spec				/* 13 */
 	  opt_with_online				/* 14 */
 	  opt_invisible					/* 15 */
-	{{
+	{{ DBG_TRACE_GRAMMAR(create_stmt,  CREATE ~ INDEX identifier ON_ ~);
 
 			PT_NODE *node = parser_pop_hint_node ();
 			PT_NODE *ocs = parser_new_node(this_parser, PT_SPEC);
@@ -2761,7 +2819,7 @@ create_stmt
 	  opt_members
 	  opt_comment_spec
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE USER identifier ~);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_CREATE_USER);
 
@@ -2792,7 +2850,7 @@ create_stmt
 	  opt_trigger_action_time 			/* 12 */
 	  trigger_action				/* 13 */
 	  opt_comment_spec				/* 14 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE TRIGGER identifier ~);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_CREATE_TRIGGER);
 
@@ -2821,7 +2879,7 @@ create_stmt
 	  identifier 					/* 5 */
 	  opt_serial_option_list			/* 6 */
 	  opt_comment_spec				/* 7 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE SERIAL identifier ~);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_CREATE_SERIAL);
 
@@ -2868,7 +2926,7 @@ create_stmt
 	  NAME char_string_literal				/* 12, 13 */
 	  opt_comment_spec						/* 14 */
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE opt_or_replace PROCEDURE~);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_CREATE_STORED_PROCEDURE);
 			if (node)
@@ -2896,7 +2954,7 @@ create_stmt
 	  NAME char_string_literal						/* 14, 15 */
 	  opt_comment_spec								/* 16 */
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE opt_or_replace FUNCTION~);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_CREATE_STORED_PROCEDURE);
 			if (node)
@@ -2915,7 +2973,7 @@ create_stmt
 
 		DBG_PRINT}}
 	| CREATE IdName
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE IdName);
 
 			push_msg (MSGCAT_SYNTAX_INVALID_CREATE);
 			csql_yyerror_explicit (@2.first_line, @2.first_column);
@@ -2932,7 +2990,7 @@ create_stmt
 	  class_name					/* 6 */
 	  LIKE						/* 7 */
 	  class_name					/* 8 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE ~ class_name LIKE class_name ~);
 
 			PT_NODE *qc = parser_pop_hint_node ();
 
@@ -2961,7 +3019,7 @@ create_stmt
 	  LIKE						/* 8 */
 	  class_name					/* 9 */
 	  ')'						/* 10 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE ~ class_name '(' LIKE class_name ')' );
 
 			PT_NODE *qc = parser_pop_hint_node ();
 
@@ -2979,7 +3037,7 @@ create_stmt
 		DBG_PRINT}}
 
 	| CREATE SERVER dblink_server_name '(' connect_info ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE SERVER dblink_server_name '(' connect_info ')' );
                         PT_NODE *node = parser_new_node (this_parser, PT_CREATE_SERVER);
 			if (node)
 			  {
@@ -3042,20 +3100,20 @@ create_stmt
 
 opt_serial_option_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_serial_option_list, : );
 			container_10 ctn;
 			memset(&ctn, 0x00, sizeof(container_10));
 			$$ = ctn;
 		}}
 	| serial_option_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_serial_option_list, | serial_option_list);
 			$$ = $1;
 		}}
 	;
 
 serial_option_list
 	: serial_option_list of_serial_option
-		{{
+		{{ DBG_TRACE_GRAMMAR(serial_option_list, : serial_option_list of_serial_option);
 			/* container order
 			 * 1: start_val
 			 *
@@ -3150,7 +3208,7 @@ serial_option_list
 
 		DBG_PRINT}}
 	| of_serial_option
-		{{
+		{{ DBG_TRACE_GRAMMAR(serial_option_list, | of_serial_option);
 			/* container order
 			 * 1: start_val
 			 *
@@ -3210,37 +3268,37 @@ serial_option_list
 
 of_serial_option
 	: serial_start
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_serial_option, : serial_start);
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_START), $1, NULL);
 			$$ = ctn;
 		DBG_PRINT}}
 	| serial_increment
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_serial_option, | serial_increment);
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_INC), $1, NULL);
 			$$ = ctn;
 		DBG_PRINT}}
 	| serial_min
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_serial_option, | serial_min);
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_MIN), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
 		DBG_PRINT}}
 	| serial_max
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_serial_option, | serial_max);
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_MAX), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
 		DBG_PRINT}}
 	| of_cycle_nocycle
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_serial_option, | of_cycle_nocycle);
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_CYCLE), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
 		DBG_PRINT}}
 	| of_cached_num
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_serial_option, | of_cached_num);
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_CACHE), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
@@ -3250,13 +3308,13 @@ of_serial_option
 
 opt_replace
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_replace, : );
 
 			$$ = PT_CREATE_SELECT_NO_ACTION;
 
 		DBG_PRINT}}
 	| REPLACE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_replace, | REPLACE);
 
 			$$ = PT_CREATE_SELECT_REPLACE;
 
@@ -3272,7 +3330,7 @@ alter_stmt
 	  opt_hint_list					/* 3 */
 	  opt_class_type				/* 4 */
 	  only_class_name				/* 5 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, : ALTER opt_hint_list opt_class_type only_class_name);
 
 			PT_NODE *node = parser_pop_hint_node ();
 			int entity_type = ($4 == PT_EMPTY ? PT_MISC_DUMMY : $4);
@@ -3287,7 +3345,7 @@ alter_stmt
 
 		DBG_PRINT}}
 	  alter_clause_cubrid_specific
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt,  ~ alter_clause_cubrid_specific);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -3308,7 +3366,7 @@ alter_stmt
 	  opt_class_type				/* 4 */
 	  only_class_name				/* 5 */
 	  alter_clause_list				/* 6 */		%dprec 2
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER opt_hint_list opt_class_type only_class_name alter_clause_list);
 
 			PT_NODE *node = NULL;
 			int entity_type = ($4 == PT_EMPTY ? PT_MISC_DUMMY : $4);
@@ -3367,7 +3425,7 @@ alter_stmt
 	  identifier
 	  opt_password
 	  opt_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER USER identifier opt_password opt_comment_spec);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_USER);
 
@@ -3393,7 +3451,7 @@ alter_stmt
 	  identifier_list
 	  trigger_status_or_priority_or_change_owner
 	  opt_comment_spec					/* 5 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER TRIGGER identifier_list  trigger_status_or_priority_or_change_owner opt_comment_spec);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_TRIGGER);
 
@@ -3420,7 +3478,7 @@ alter_stmt
 	  TRIGGER					/* 2 */
 	  identifier				/* 3 */
 	  COMMENT comment_value		/* 4, 5 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER TRIGGER identifier COMMENT comment_value);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_TRIGGER);
 
@@ -3445,7 +3503,7 @@ alter_stmt
 	  identifier                           /* 3 */
 	  opt_serial_option_list	       	   /* 4 */
 	  opt_comment_spec				       /* 5 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER SERIAL identifier opt_serial_option_list opt_comment_spec);
 			/* container order
 			 * 0: start_val
 			 * 1: increment_val,
@@ -3518,7 +3576,7 @@ alter_stmt
 	  opt_where_clause				/* 11 */
 	  opt_comment_spec			/* 12 */
 	  REBUILD					/* 13 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER ~INDEX~ REBUILD);
 
 			PT_NODE *node = parser_pop_hint_node ();
 			PT_NODE *ocs = parser_new_node(this_parser, PT_SPEC);
@@ -3591,7 +3649,7 @@ alter_stmt
 	  ON_					/* 4 */
 	  class_name			/* 5 */
 	  COMMENT comment_value /* 6, 7 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER INDEX identifier ON_ class_name COMMENT comment_value);
 			PT_NODE* node = parser_new_node(this_parser, PT_ALTER_INDEX);
 
 			if (node)
@@ -3626,7 +3684,7 @@ alter_stmt
 	  ON_				/* 4 */
 	  class_name			/* 5 */
 	  INVISIBLE			/* 6 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER INDEX identifier ON_ class_name INVISIBLE);
 			PT_NODE* node = parser_new_node(this_parser, PT_ALTER_INDEX);
 
 			if (node)
@@ -3661,7 +3719,7 @@ alter_stmt
 	  ON_				/* 4 */
 	  class_name			/* 5 */
 	  VISIBLE			/* 6 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER INDEX identifier ON_ class_name VISIBLE);
 			PT_NODE* node = parser_new_node(this_parser, PT_ALTER_INDEX);
 
 			if (node)
@@ -3696,7 +3754,7 @@ alter_stmt
 	  AS
 	  csql_query
 	  opt_vclass_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER view_or_vclass class_name AS csql_query opt_vclass_comment_spec);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER);
 			if (node)
@@ -3719,7 +3777,7 @@ alter_stmt
 	  view_or_vclass
 	  class_name
 	  class_comment_spec		%dprec 1
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER view_or_vclass class_name class_comment_spec);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER);
 			if (node)
@@ -3740,7 +3798,7 @@ alter_stmt
 	  identifier				/* 3 */
 	  opt_owner_clause			/* 4 */
 	  opt_comment_spec			/* 5 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER procedure_or_function identifier opt_owner_clause opt_comment_spec);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_STORED_PROCEDURE);
 
@@ -3764,7 +3822,7 @@ alter_stmt
 
 		DBG_PRINT}}
 	| ALTER  SERVER  dblink_server_name alter_server_list
-                {{
+                {{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER  SERVER  dblink_server_name alter_server_list);
                         PT_NODE *node = parser_new_node (this_parser, PT_ALTER_SERVER);
 			if (node)
 			  {
@@ -3858,13 +3916,13 @@ alter_stmt
 	;
 
 view_or_vclass
-	: VIEW
-	| VCLASS
+	: VIEW   { DBG_TRACE_GRAMMAR(view_or_vclass, : VIEW ); }
+	| VCLASS { DBG_TRACE_GRAMMAR(view_or_vclass, | VCLASS ); }
 	;
 
 alter_clause_list
 	: alter_clause_list ',' prepare_alter_node alter_clause_for_alter_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_clause_list, : alter_clause_list ',' prepare_alter_node alter_clause_for_alter_list);
 
 			$$ = parser_make_link ($1, parser_get_alter_node ());
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -3877,7 +3935,7 @@ alter_clause_list
 			parser_save_alter_node (node);
 		}
 	 alter_clause_for_alter_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_clause_list, | alter_clause_for_alter_list);
 
 			$$ = parser_get_alter_node ();
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -3887,7 +3945,7 @@ alter_clause_list
 
 prepare_alter_node
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(prepare_alter_node, : );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER);
 			parser_save_alter_node (node);
@@ -3897,14 +3955,16 @@ prepare_alter_node
 
 only_class_name
 	: ONLY class_name
-		{ $$ = $2; }
+		{ DBG_TRACE_GRAMMAR(only_class_name, : ONLY class_name);
+                  $$ = $2; }
 	| class_name
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(only_class_name, | class_name);
+                  $$ = $1; }
 	;
 
 rename_stmt
 	: RENAME opt_class_type rename_class_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(rename_stmt, : RENAME opt_class_type rename_class_list);
 
 			PT_NODE *node = NULL;
 			int entity_type = ($2 == PT_EMPTY ? PT_CLASS : $2);
@@ -3919,7 +3979,7 @@ rename_stmt
 
 		DBG_PRINT}}
 	| RENAME TRIGGER class_name AS class_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(rename_stmt, | RENAME TRIGGER class_name AS class_name);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_RENAME_TRIGGER);
 
@@ -3934,7 +3994,7 @@ rename_stmt
 
 		DBG_PRINT}}
 	| RENAME SERVER dblink_server_name AS identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(rename_stmt, | RENAME SERVER dblink_server_name AS identifier);
 			PT_NODE *node = parser_new_node (this_parser, PT_RENAME_SERVER);
 			if (node)
 			  {
@@ -3951,14 +4011,14 @@ rename_stmt
 
 rename_class_list
 	: rename_class_list ',' rename_class_pair
-		{{
+		{{ DBG_TRACE_GRAMMAR(rename_class_list, : rename_class_list ',' rename_class_pair);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| rename_class_pair
-		{{
+		{{ DBG_TRACE_GRAMMAR(rename_class_list, | rename_class_pair);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -3968,7 +4028,7 @@ rename_class_list
 
 rename_class_pair
 	:  only_class_name as_or_to only_class_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(rename_class_pair, : only_class_name as_or_to only_class_name);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_RENAME);
 			if (node)
@@ -3986,13 +4046,13 @@ rename_class_pair
 
 procedure_or_function
 	: PROCEDURE
-		{{
+		{{ DBG_TRACE_GRAMMAR(procedure_or_function, : PROCEDURE);
 
 			$$ = 1;
 
 		DBG_PRINT}}
 	| FUNCTION
-		{{
+		{{ DBG_TRACE_GRAMMAR(procedure_or_function, | FUNCTION);
 
 			$$ = 2;
 
@@ -4001,9 +4061,11 @@ procedure_or_function
 
 opt_owner_clause
 	: /* empty */
-		{ $$ = NULL; }
+		{ DBG_TRACE_GRAMMAR(opt_owner_clause, : );
+                  $$ = NULL; }
 	| OWNER TO identifier
-		{ $$ = $3; }
+		{ DBG_TRACE_GRAMMAR(opt_owner_clause, | OWNER TO identifier);
+                  $$ = $3; }
 	;
 
 as_or_to
@@ -4013,7 +4075,7 @@ as_or_to
 
 truncate_stmt
 	: TRUNCATE opt_table_type class_spec opt_cascade
-		{{
+		{{ DBG_TRACE_GRAMMAR(truncate_stmt, : TRUNCATE opt_table_type class_spec opt_cascade);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRUNCATE);
 			if (node)
@@ -4030,7 +4092,7 @@ truncate_stmt
 
 do_stmt
 	: DO expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(do_stmt, :  DO expression_);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_DO);
 			if (node)
@@ -4060,7 +4122,7 @@ do_stmt
 
 drop_stmt
 	: DROP opt_class_type opt_if_exists class_spec_list opt_cascade_constraints
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, : DROP opt_class_type opt_if_exists class_spec_list opt_cascade_constraints);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP);
 			if (node)
@@ -4092,7 +4154,7 @@ drop_stmt
 	  ON_						/* 8 */
 	  only_class_name				/* 9 */
 	  opt_index_column_name_list			/* 10 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP ~INDEX~);
 
 			PT_NODE *node = parser_pop_hint_node ();
 			PT_NODE *ocs = parser_new_node(this_parser, PT_SPEC);
@@ -4145,7 +4207,7 @@ drop_stmt
 
 		DBG_PRINT}}
 	| DROP USER identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP USER identifier);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_USER);
 
@@ -4159,7 +4221,7 @@ drop_stmt
 
 		DBG_PRINT}}
 	| DROP TRIGGER identifier_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP TRIGGER identifier_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_TRIGGER);
 
@@ -4179,7 +4241,7 @@ drop_stmt
 
 		DBG_PRINT}}
 	| DROP DEFERRED TRIGGER trigger_spec_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP DEFERRED TRIGGER trigger_spec_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_REMOVE_TRIGGER);
 
@@ -4193,7 +4255,7 @@ drop_stmt
 
 		DBG_PRINT}}
 	| DROP VARIABLE_ identifier_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP VARIABLE_ identifier_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_VARIABLE);
 			if (node)
@@ -4203,7 +4265,7 @@ drop_stmt
 
 		DBG_PRINT}}
 	| DROP SERIAL opt_if_exists identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP SERIAL opt_if_exists identifier);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_SERIAL);
 			if (node)
@@ -4216,7 +4278,7 @@ drop_stmt
 
 		DBG_PRINT}}
 	| DROP PROCEDURE identifier_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP PROCEDURE identifier_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_STORED_PROCEDURE);
 
@@ -4232,7 +4294,7 @@ drop_stmt
 
 		DBG_PRINT}}
 	| DROP FUNCTION identifier_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP FUNCTION identifier_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_STORED_PROCEDURE);
 
@@ -4248,7 +4310,7 @@ drop_stmt
 
 		DBG_PRINT}}
 	| DROP SERVER opt_if_exists dblink_server_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP SERVER opt_if_exists dblink_server_name);
                         PT_NODE *node = parser_new_node (this_parser, PT_DROP_SERVER);
 
 			if (node)
@@ -4267,7 +4329,7 @@ drop_stmt
 
 		DBG_PRINT}}                
 	| deallocate_or_drop PREPARE identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, | deallocate_or_drop PREPARE identifier);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_DEALLOCATE_PREPARE);
 
@@ -4282,7 +4344,7 @@ drop_stmt
 
 		DBG_PRINT}}
 	| deallocate_or_drop VARIABLE_ session_variable_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(drop_stmt, | deallocate_or_drop VARIABLE_ session_variable_list);
 
 			PT_NODE *node =
 			  parser_new_node (this_parser, PT_DROP_SESSION_VARIABLES);
@@ -4303,14 +4365,14 @@ deallocate_or_drop
 
 opt_reverse
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_reverse, : );
 
 			parser_save_is_reverse (false);
 			$$ = false;
 
 		DBG_PRINT}}
 	| REVERSE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_reverse, | REVERSE);
 
 			parser_save_is_reverse (true);
 			$$ = true;
@@ -4320,13 +4382,13 @@ opt_reverse
 
 opt_unique
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_unique, : );
 
 			$$ = false;
 
 		DBG_PRINT}}
 	| UNIQUE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_unique, | UNIQUE);
 
 			$$ = true;
 
@@ -4335,13 +4397,13 @@ opt_unique
 
 opt_index_column_name_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_index_column_name_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| index_column_name_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_index_column_name_list, | index_column_name_list);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -4351,7 +4413,7 @@ opt_index_column_name_list
 
 index_column_name_list
 	: '(' sort_spec_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_column_name_list, '(' sort_spec_list ')');
 			if (parser_get_is_reverse())
 			{
 			  PT_NODE *node;
@@ -4369,7 +4431,7 @@ index_column_name_list
 
 update_statistics_stmt
 	: UPDATE STATISTICS ON_ only_class_name_list opt_with_fullscan
-		{{
+		{{ DBG_TRACE_GRAMMAR(update_statistics_stmt, : UPDATE STATISTICS ON_ only_class_name_list opt_with_fullscan);
 
 			PT_NODE *ups = parser_new_node (this_parser, PT_UPDATE_STATS);
 			if (ups)
@@ -4383,7 +4445,7 @@ update_statistics_stmt
 
 		DBG_PRINT}}
 	| UPDATE STATISTICS ON_ ALL CLASSES opt_with_fullscan
-		{{
+		{{ DBG_TRACE_GRAMMAR(update_statistics_stmt, | UPDATE STATISTICS ON_ ALL CLASSES opt_with_fullscan);
 
 			PT_NODE *ups = parser_new_node (this_parser, PT_UPDATE_STATS);
 			if (ups)
@@ -4397,7 +4459,7 @@ update_statistics_stmt
 
 		DBG_PRINT}}
 	| UPDATE STATISTICS ON_ CATALOG CLASSES opt_with_fullscan
-		{{
+		{{ DBG_TRACE_GRAMMAR(update_statistics_stmt, | UPDATE STATISTICS ON_ CATALOG CLASSES opt_with_fullscan);
 
 			PT_NODE *ups = parser_new_node (this_parser, PT_UPDATE_STATS);
 			if (ups)
@@ -4414,14 +4476,14 @@ update_statistics_stmt
 
 only_class_name_list
 	: only_class_name_list ',' only_class_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(only_class_name_list, : only_class_name_list ',' only_class_name);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| only_class_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(only_class_name_list, | only_class_name);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -4431,12 +4493,12 @@ only_class_name_list
 
 opt_invisible
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_invisible, : );
  			$$ = false;
 
 		DBG_PRINT}}
 	| INVISIBLE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_invisible, | INVISIBLE);
 
 			$$ = true;
 
@@ -4446,13 +4508,13 @@ opt_invisible
 
 opt_with_fullscan
         : /* empty */
-                {{
+                {{ DBG_TRACE_GRAMMAR(opt_with_fullscan, : );
 
                         $$ = 0;
 
                 DBG_PRINT}}
         | WITH FULLSCAN
-                {{
+                {{ DBG_TRACE_GRAMMAR(opt_with_fullscan, |  WITH FULLSCAN);
 
                         $$ = 1;
 
@@ -4461,18 +4523,18 @@ opt_with_fullscan
 
 opt_with_online
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_online, : );
 			$$ = 0;
 
 		DBG_PRINT}}
 	| WITH ONLINE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_online, | WITH ONLINE);
 
 			$$ = 1;  // thread count is 0
 
 		DBG_PRINT}}
 	| WITH ONLINE PARALLEL unsigned_integer
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_online, |  WITH ONLINE PARALLEL unsigned_integer);
                         const int MIN_COUNT = 1;
                         const int MAX_COUNT = 16;
                         int thread_count = $4->info.value.data_value.i;
@@ -4494,7 +4556,7 @@ opt_of_to_eq
 
 opt_level_spec
 	: ON_
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_level_spec, : ON_ );
 
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 			if (val)
@@ -4504,7 +4566,7 @@ opt_level_spec
 
 		DBG_PRINT}}
 	| OFF_
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_level_spec, | OFF_ );
 
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 			if (val)
@@ -4514,21 +4576,21 @@ opt_level_spec
 
 		DBG_PRINT}}
 	| unsigned_integer
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_level_spec, |  unsigned_integer);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| param_
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_level_spec, |  param_ );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| host_param_input
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_level_spec, |  host_param_input);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -4538,14 +4600,14 @@ opt_level_spec
 
 char_string_literal_list
 	: char_string_literal_list ',' char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_string_literal_list, : char_string_literal_list ',' char_string_literal );
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_string_literal_list, | char_string_literal);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -4555,14 +4617,14 @@ char_string_literal_list
 
 table_spec_list
 	: table_spec_list  ',' table_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_spec_list, : table_spec_list  ',' table_spec);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| table_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_spec_list, |  table_spec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -4572,7 +4634,7 @@ table_spec_list
 
 extended_table_spec_list
 	: extended_table_spec_list ',' table_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(extended_table_spec_list, : extended_table_spec_list ',' table_spec);
 
 			container_2 ctn;
 			PT_NODE *n1 = CONTAINER_AT_0 ($1);
@@ -4583,7 +4645,7 @@ extended_table_spec_list
 
 		DBG_PRINT}}
 	| extended_table_spec_list join_table_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(extended_table_spec_list, | extended_table_spec_list join_table_spec);
 
 			container_2 ctn;
 			PT_NODE *n1 = CONTAINER_AT_0 ($1);
@@ -4593,7 +4655,7 @@ extended_table_spec_list
 
 		DBG_PRINT}}
 	| '(' extended_table_spec_list join_table_spec ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(extended_table_spec_list, | '(' extended_table_spec_list join_table_spec ')');
 
 			container_2 ctn;
 			PT_NODE *n1 = CONTAINER_AT_0 ($2);
@@ -4603,7 +4665,7 @@ extended_table_spec_list
 
 		DBG_PRINT}}
 	| table_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(extended_table_spec_list, | table_spec);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $1, FROM_NUMBER (0));
@@ -4614,7 +4676,7 @@ extended_table_spec_list
 
 join_table_spec
 	: CROSS JOIN table_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(join_table_spec, : CROSS JOIN table_spec);
 
 			PT_NODE *sopt = $3;
 			if (sopt)
@@ -4624,7 +4686,7 @@ join_table_spec
 
 		DBG_PRINT}}
 	| opt_of_inner_left_right JOIN table_spec join_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(join_table_spec, | opt_of_inner_left_right JOIN table_spec join_condition);
 
 			PT_NODE *sopt = $3;
 			bool natural = false;
@@ -4653,7 +4715,7 @@ join_table_spec
 
 		DBG_PRINT}}
 	| NATURAL opt_of_inner_left_right JOIN table_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(join_table_spec, | NATURAL opt_of_inner_left_right JOIN table_spec );
 
 			PT_NODE *sopt = $4;
 			bool natural = true;
@@ -4671,7 +4733,7 @@ join_table_spec
 
 join_condition
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(join_condition, : );
 			parser_save_and_set_pseudoc (0);
 			$$ = NULL;   /* just return NULL */
 		DBG_PRINT}}
@@ -4682,7 +4744,7 @@ join_condition
 			parser_save_and_set_ic (1);
 		DBG_PRINT}}
 	  search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(join_condition, | ON_ search_condition);
 			PT_NODE *condition = $3;
 			bool instnum_flag = false;
 
@@ -4708,25 +4770,24 @@ join_condition
 
 opt_of_inner_left_right
 	: /* empty */
-		{{
-
+		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, : );
 			$$ = PT_JOIN_INNER;
 
 		DBG_PRINT}}
 	| INNER opt_outer
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, | INNER opt_outer );
 
 			$$ = PT_JOIN_INNER;
 
 		DBG_PRINT}}
 	| LEFT opt_outer
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, | LEFT opt_outer );
 
 			$$ = PT_JOIN_LEFT_OUTER;
 
 		DBG_PRINT}}
 	| RIGHT opt_outer
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, |  RIGHT opt_outer );
 
 			$$ = PT_JOIN_RIGHT_OUTER;
 
@@ -4740,14 +4801,14 @@ opt_outer
 
 table_spec
 	: '(' table_spec ')' %dprec 1
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_spec, : '(' table_spec ')' );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| original_table_spec %dprec 2
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_spec, | original_table_spec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -4756,7 +4817,7 @@ table_spec
 
 original_table_spec
 	: class_spec opt_as_identifier_attr_name opt_table_spec_index_hint_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(original_table_spec, : class_spec opt_as_identifier_attr_name opt_table_spec_index_hint_list );
 			PT_NODE *range_var = NULL;
 			PT_NODE *ent = $1;
 			if (ent)
@@ -4859,7 +4920,7 @@ original_table_spec
 
 		DBG_PRINT}}
 	| meta_class_spec opt_as_identifier_attr_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(original_table_spec, | meta_class_spec opt_as_identifier_attr_name);
 
 			PT_NODE *ent = $1;
 			if (ent)
@@ -4886,7 +4947,7 @@ original_table_spec
 
 		DBG_PRINT}}
 	| subquery opt_as_identifier_attr_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(original_table_spec, | subquery opt_as_identifier_attr_name);
 
 			PT_NODE *ent = parser_new_node (this_parser, PT_SPEC);
 			if (ent)
@@ -4916,7 +4977,7 @@ original_table_spec
 
 		DBG_PRINT}}
 	| TABLE '(' expression_ ')' opt_as_identifier_attr_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(original_table_spec, | TABLE '(' expression_ ')' opt_as_identifier_attr_name);
 
 			PT_NODE *ent = parser_new_node (this_parser, PT_SPEC);
 			if (ent)
@@ -4934,7 +4995,7 @@ original_table_spec
 
 		DBG_PRINT}}
 	| JSON_TABLE json_table_rule opt_as identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(original_table_spec, | JSON_TABLE json_table_rule opt_as identifier);
 			PT_NODE *ent = parser_new_node (this_parser, PT_SPEC);
 			if (ent)
 			  {
@@ -4947,7 +5008,7 @@ original_table_spec
 
 		DBG_PRINT}}
         | DBLINK  '('  dblink_expr ')'   dblink_identifier_col_attrs 
-                {{                       
+                {{ DBG_TRACE_GRAMMAR(original_table_spec, | DBLINK  '('  dblink_expr ')' dblink_identifier_col_attrs );                       
 			PT_NODE *ent = parser_new_node (this_parser, PT_SPEC);
 			if (ent)
 			  {
@@ -4963,7 +5024,7 @@ original_table_spec
 
 opt_table_spec_index_hint
 	: USE index_or_key '(' identifier_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint, : USE index_or_key '(' identifier_list ')' );
 
 			PT_NODE *list = $4;
 			while (list)
@@ -4977,7 +5038,7 @@ opt_table_spec_index_hint
 
 		DBG_PRINT}}
 	| FORCE index_or_key '(' identifier_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint, | FORCE index_or_key '(' identifier_list ')' );
 
 			PT_NODE *list = $4;
 			while (list)
@@ -4992,7 +5053,7 @@ opt_table_spec_index_hint
 
 		DBG_PRINT}}
 	| IGNORE_ index_or_key '(' identifier_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint, | IGNORE_ index_or_key '(' identifier_list ')' );
 
 			PT_NODE *list = $4;
 			while (list)
@@ -5010,21 +5071,21 @@ opt_table_spec_index_hint
 
 opt_table_spec_index_hint_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint_list, :);
 
 			$$ = 0;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| opt_table_spec_index_hint_list ',' opt_table_spec_index_hint
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint_list, | opt_table_spec_index_hint_list ',' opt_table_spec_index_hint );
 
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
 
 		DBG_PRINT}}
 	| opt_table_spec_index_hint
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint_list, | opt_table_spec_index_hint );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
@@ -5034,7 +5095,7 @@ opt_table_spec_index_hint_list
 
 opt_as_identifier_attr_name
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_as_identifier_attr_name, : );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, NULL);
@@ -5042,7 +5103,7 @@ opt_as_identifier_attr_name
 
 		DBG_PRINT}}
 	| opt_as identifier '(' identifier_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_as_identifier_attr_name, | opt_as identifier '(' identifier_list ')' );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, $4);
@@ -5050,7 +5111,7 @@ opt_as_identifier_attr_name
 
 		DBG_PRINT}}
 	| opt_as identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_as_identifier_attr_name, | opt_as identifier);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, NULL);
@@ -5066,14 +5127,14 @@ opt_as
 
 class_spec_list
 	: class_spec_list  ',' class_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_spec_list, : class_spec_list  ',' class_spec );
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| class_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_spec_list, | class_spec );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -5083,14 +5144,14 @@ class_spec_list
 
 class_spec
 	: only_all_class_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_spec, : only_all_class_spec );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| '(' only_all_class_spec_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_spec, | '(' only_all_class_spec_list ')' );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -5100,7 +5161,7 @@ class_spec
 
 only_all_class_spec_list
 	: only_all_class_spec_list ',' only_all_class_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(only_all_class_spec_list, : only_all_class_spec_list ',' only_all_class_spec );
 
 			PT_NODE *result = parser_make_link ($1, $3);
 			PT_NODE *p = parser_new_node (this_parser, PT_SPEC);
@@ -5111,7 +5172,7 @@ only_all_class_spec_list
 
 		DBG_PRINT}}
 	| only_all_class_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(only_all_class_spec_list, | only_all_class_spec );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -5121,7 +5182,7 @@ only_all_class_spec_list
 
 meta_class_spec
 	: CLASS only_class_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(meta_class_spec, : CLASS only_class_name );
 
 			PT_NODE *ocs = parser_new_node (this_parser, PT_SPEC);
 			if (ocs)
@@ -5141,7 +5202,7 @@ meta_class_spec
 
 only_all_class_spec
 	: only_class_name opt_partition_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(only_all_class_spec, : only_class_name opt_partition_spec );
 
 			PT_NODE *ocs = parser_new_node (this_parser, PT_SPEC);
 			if (ocs)
@@ -5160,7 +5221,7 @@ only_all_class_spec
 
 		DBG_PRINT}}
 	| ALL class_name '(' EXCEPT class_spec_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(only_all_class_spec, | ALL class_name '(' EXCEPT class_spec_list ')' );
 
 			PT_NODE *acs = parser_new_node (this_parser, PT_SPEC);
 			if (acs)
@@ -5176,7 +5237,7 @@ only_all_class_spec
 
 		DBG_PRINT}}
 	| ALL class_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(only_all_class_spec, | class_name);
 
 			PT_NODE *acs = parser_new_node (this_parser, PT_SPEC);
 			if (acs)
@@ -5194,7 +5255,7 @@ only_all_class_spec
 
 class_name
 	: identifier DOT identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_name, : identifier DOT identifier);
 
 			PT_NODE *user_node = $1;
 			PT_NODE *name_node = $3;
@@ -5214,7 +5275,7 @@ class_name
 
 		DBG_PRINT}}
 	| identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_name, | identifier);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -5224,14 +5285,14 @@ class_name
 
 class_name_list
 	: class_name_list ',' class_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_name_list, : class_name_list ',' class_name);
 
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| class_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_name_list, | class_name);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -5241,11 +5302,11 @@ class_name_list
 
 opt_partition_spec
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_partition_spec, : );
 		    $$ = NULL;
 		}}
 	| PARTITION '(' identifier ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_partition_spec, | PARTITION '(' identifier ')' );
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
@@ -5253,31 +5314,31 @@ opt_partition_spec
 
 opt_class_type
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_class_type, :);
 
 			$$ = PT_EMPTY;
 
 		DBG_PRINT}}
 	| VCLASS
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_class_type, | VCLASS);
 
 			$$ = PT_VCLASS;
 
 		DBG_PRINT}}
 	| VIEW
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_class_type, | VIEW );
 
 			$$ = PT_VCLASS;
 
 		DBG_PRINT}}
 	| CLASS
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_class_type, | CLASS );
 
 			$$ = PT_CLASS;
 
 		DBG_PRINT}}
 	| TABLE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_class_type, | TABLE );
 
 			$$ = PT_CLASS;
 
@@ -5286,19 +5347,19 @@ opt_class_type
 
 opt_table_type
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_table_type, : );
 
 			$$ = PT_EMPTY;
 
 		DBG_PRINT}}
 	| CLASS
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_table_type, | CLASS );
 
 			$$ = PT_CLASS;
 
 		DBG_PRINT}}
 	| TABLE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_table_type, | TABLE );
 
 			$$ = PT_CLASS;
 
@@ -5307,13 +5368,13 @@ opt_table_type
 
 opt_cascade
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_cascade, : );
 
 			$$ = false;
 
 		DBG_PRINT}}
 	| CASCADE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_cascade, | CASCADE );
 
 			$$ = true;
 
@@ -5322,13 +5383,13 @@ opt_cascade
 
 opt_cascade_constraints
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_cascade_constraints, : );
 
 			$$ = false;
 
 		DBG_PRINT}}
 	| CASCADE CONSTRAINTS
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_cascade_constraints, | CASCADE CONSTRAINTS );
 
 			$$ = true;
 
@@ -5347,7 +5408,7 @@ alter_clause_for_alter_list
 	| MODIFY alter_modify_clause_for_alter_list
 	| CHANGE alter_change_clause_for_alter_list
 	| OWNER TO identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_clause_for_alter_list, | OWNER TO identifier );
 			PT_NODE *alt = parser_get_alter_node();
 
 			if (alt)
@@ -5357,7 +5418,7 @@ alter_clause_for_alter_list
 			  }
 		DBG_PRINT}}
 	| charset_spec opt_collation
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_clause_for_alter_list, | charset_spec opt_collation );
 			PT_NODE *node = parser_get_alter_node();
 			PT_NODE *cs_node, *coll_node;
 			int charset, coll_id;
@@ -5387,7 +5448,7 @@ alter_clause_for_alter_list
 			  }
 		DBG_PRINT}}
 	| collation_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_clause_for_alter_list, | collation_spec );
 			PT_NODE *node = parser_get_alter_node();
 			PT_NODE *coll_node;
 			int charset, coll_id;
@@ -5411,7 +5472,7 @@ alter_clause_for_alter_list
 			  }
 		DBG_PRINT}}
 	| class_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_clause_for_alter_list, | class_comment_spec );
 			PT_NODE *alter_node = parser_get_alter_node();
 
 			if (alter_node != NULL && alter_node->info.alter.code != PT_CHANGE_COLUMN_COMMENT)
@@ -5430,7 +5491,7 @@ alter_clause_cubrid_specific
 	| ADD       alter_add_clause_for_alter_list      resolution_list_for_alter
 	| DROP     alter_drop_clause_for_alter_list      resolution_list_for_alter
 	| inherit_resolution_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_clause_cubrid_specific, | inherit_resolution_list);
 
 			PT_NODE *alt = parser_get_alter_node ();
 
@@ -5450,7 +5511,7 @@ opt_resolution_list_for_alter
 
 resolution_list_for_alter
 	: inherit_resolution_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(resolution_list_for_alter, : inherit_resolution_list );
 
 			PT_NODE *alt = parser_get_alter_node ();
 
@@ -5464,7 +5525,7 @@ resolution_list_for_alter
 
 alter_rename_clause_mysql_specific
 	: opt_to only_class_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_rename_clause_mysql_specific, : opt_to only_class_name );
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5479,7 +5540,7 @@ alter_rename_clause_mysql_specific
 
 alter_auto_increment_mysql_specific
 	: AUTO_INCREMENT '=' UNSIGNED_INTEGER
-	      {{
+	      {{ DBG_TRACE_GRAMMAR(alter_auto_increment_mysql_specific, : AUTO_INCREMENT '=' UNSIGNED_INTEGER );
 			PT_NODE *node = parser_get_alter_node ();
     			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -5503,7 +5564,7 @@ alter_auto_increment_mysql_specific
 
 alter_rename_clause_allow_multiple
 	: opt_of_attr_column_method opt_class identifier as_or_to identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_rename_clause_allow_multiple, : opt_of_attr_column_method opt_class identifier as_or_to identifier);
 
 			PT_NODE *node = parser_get_alter_node ();
 			PT_MISC_TYPE etyp = $1;
@@ -5530,7 +5591,7 @@ alter_rename_clause_allow_multiple
 
 alter_rename_clause_cubrid_specific
 	: FUNCTION opt_identifier OF opt_class identifier AS identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_rename_clause_cubrid_specific, : FUNCTION opt_identifier OF opt_class identifier AS identifier);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5550,7 +5611,7 @@ alter_rename_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| File file_path_name AS file_path_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_rename_clause_cubrid_specific, | File file_path_name AS file_path_name);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5567,25 +5628,25 @@ alter_rename_clause_cubrid_specific
 
 opt_of_attr_column_method
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_attr_column_method,  : );
 
 			$$ = PT_EMPTY;
 
 		DBG_PRINT}}
 	| ATTRIBUTE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_attr_column_method, | ATTRIBUTE );
 
 			$$ = PT_ATTRIBUTE;
 
 		DBG_PRINT}}
 	| COLUMN
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_attr_column_method, | COLUMN );
 
 			$$ = PT_ATTRIBUTE;
 
 		DBG_PRINT}}
 	| METHOD
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_attr_column_method, | METHOD );
 
 			$$ = PT_METHOD;
 		DBG_PRINT}}
@@ -5593,13 +5654,13 @@ opt_of_attr_column_method
 
 opt_class
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_class, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| CLASS
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_class, | CLASS );
 
 			$$ = 1;
 
@@ -5608,13 +5669,13 @@ opt_class
 
 opt_identifier
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_identifier, :);
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_identifier, | identifier );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -5628,8 +5689,7 @@ alter_add_clause_for_alter_list
 		{ parser_attr_type = PT_META_ATTR; }
 	  '(' attr_def_list ')'
 		{ parser_attr_type = PT_NORMAL; }
-		{{
-
+		{{ DBG_TRACE_GRAMMAR(alter_add_clause_for_alter_list, | CLASS ATTRIBUTE '(' attr_def_list ')' );
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
 			  {
@@ -5642,7 +5702,7 @@ alter_add_clause_for_alter_list
 		{ parser_attr_type = PT_META_ATTR; }
 	  attr_def
 		{ parser_attr_type = PT_NORMAL; }
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_add_clause_for_alter_list, | CLASS ATTRIBUTE attr_def );
 
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
@@ -5656,7 +5716,7 @@ alter_add_clause_for_alter_list
 	  		{ allow_attribute_ordering = true; }
 	  '(' attr_def_list ')'
 	  		{ allow_attribute_ordering = false; }
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_add_clause_for_alter_list, | opt_of_column_attribute  '(' attr_def_list ')' );
 
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
@@ -5670,7 +5730,7 @@ alter_add_clause_for_alter_list
 			{ allow_attribute_ordering = true; }
 	  attr_def
 	  		{ allow_attribute_ordering = false; }
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_add_clause_for_alter_list, | opt_of_column_attribute attr_def );
 
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
@@ -5684,7 +5744,7 @@ alter_add_clause_for_alter_list
 
 alter_add_clause_cubrid_specific
 	: File method_file_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, : File method_file_list );
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5696,7 +5756,7 @@ alter_add_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| METHOD method_def_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | METHOD method_def_list);
 
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
@@ -5707,7 +5767,7 @@ alter_add_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| METHOD method_def_list File method_file_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | METHOD method_def_list File method_file_list);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5720,7 +5780,7 @@ alter_add_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| SUPERCLASS only_class_name_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | SUPERCLASS only_class_name_list );
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5732,7 +5792,7 @@ alter_add_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| QUERY csql_query opt_vclass_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | QUERY csql_query opt_vclass_comment_spec );
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5748,7 +5808,7 @@ alter_add_clause_cubrid_specific
 		{ parser_attr_type = PT_META_ATTR; }
 	  attr_def_list_with_commas
 		{ parser_attr_type = PT_NORMAL; }
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | CLASS ATTRIBUTE attr_def_list_with_commas );
 
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
@@ -5759,7 +5819,7 @@ alter_add_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| opt_of_column_attribute attr_def_list_with_commas
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | opt_of_column_attribute attr_def_list_with_commas );
 
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
@@ -5779,7 +5839,7 @@ opt_of_column_attribute
 
 add_partition_clause
 	: PARTITIONS literal_w_o_param
-		{{
+		{{ DBG_TRACE_GRAMMAR(add_partition_clause, : PARTITIONS literal_w_o_param );
 
 			PT_NODE *node = parser_get_alter_node ();
 			node->info.alter.code = PT_ADD_HASHPARTITION;
@@ -5787,7 +5847,7 @@ add_partition_clause
 
 		DBG_PRINT}}
 	| '(' partition_def_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(add_partition_clause, | '(' partition_def_list ')' );
 
 			PT_NODE *node = parser_get_alter_node ();
 			node->info.alter.code = PT_ADD_PARTITION;
@@ -5798,7 +5858,7 @@ add_partition_clause
 
 alter_drop_clause_mysql_specific
 	: opt_reverse opt_unique index_or_key identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_mysql_specific, : opt_reverse opt_unique index_or_key identifier );
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5812,7 +5872,7 @@ alter_drop_clause_mysql_specific
 
 		DBG_PRINT}}
 	| PRIMARY KEY
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_mysql_specific, | PRIMARY KEY );
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5823,7 +5883,7 @@ alter_drop_clause_mysql_specific
 
 		DBG_PRINT}}
 	| FOREIGN KEY identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_mysql_specific, | FOREIGN KEY identifier );
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5838,7 +5898,7 @@ alter_drop_clause_mysql_specific
 
 alter_drop_clause_for_alter_list
 	: opt_of_attr_column_method normal_or_class_attr
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_for_alter_list, : opt_of_attr_column_method normal_or_class_attr );
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5850,7 +5910,7 @@ alter_drop_clause_for_alter_list
 
 		DBG_PRINT}}
 	| CONSTRAINT identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_for_alter_list, | CONSTRAINT identifier );
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5862,7 +5922,7 @@ alter_drop_clause_for_alter_list
 
 		DBG_PRINT}}
 	| PARTITION identifier_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_for_alter_list, | PARTITION identifier_list );
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5877,7 +5937,7 @@ alter_drop_clause_for_alter_list
 
 alter_drop_clause_cubrid_specific
 	: opt_of_attr_column_method normal_or_class_attr_list_with_commas
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, : opt_of_attr_column_method normal_or_class_attr_list_with_commas);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5889,7 +5949,7 @@ alter_drop_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| File method_file_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | File method_file_list);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5901,7 +5961,7 @@ alter_drop_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| SUPERCLASS only_class_name_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | SUPERCLASS only_class_name_list);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5913,7 +5973,7 @@ alter_drop_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| QUERY query_number_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | QUERY query_number_list);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5925,7 +5985,7 @@ alter_drop_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| QUERY
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | QUERY );
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5940,14 +6000,14 @@ alter_drop_clause_cubrid_specific
 
 normal_or_class_attr_list_with_commas
 	: normal_or_class_attr_list_with_commas ',' normal_or_class_attr
-		{{
+		{{ DBG_TRACE_GRAMMAR(normal_or_class_attr_list_with_commas, : normal_or_class_attr_list_with_commas ',' normal_or_class_attr);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| normal_or_class_attr ',' normal_or_class_attr
-		{{
+		{{ DBG_TRACE_GRAMMAR(normal_or_class_attr_list_with_commas, | normal_or_class_attr ',' normal_or_class_attr);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -5960,7 +6020,7 @@ alter_modify_clause_for_alter_list
 	  { allow_attribute_ordering = true; }
 	  attr_def_one
 	  { allow_attribute_ordering = false; }
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_modify_clause_for_alter_list, : opt_of_column_attribute attr_def_one);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5976,7 +6036,7 @@ alter_modify_clause_for_alter_list
 	  { allow_attribute_ordering = true; }
 	  attr_def_one
 	  { allow_attribute_ordering = false; }
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_modify_clause_for_alter_list, | CLASS ATTRIBUTE attr_def_one);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -5998,7 +6058,7 @@ alter_change_clause_for_alter_list
 	  { allow_attribute_ordering = true; }
 	  attr_def_one
 	  { allow_attribute_ordering = false; }
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_change_clause_for_alter_list, : normal_column_or_class_attribute attr_def_one);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -6020,7 +6080,7 @@ alter_change_clause_for_alter_list
 
 alter_change_clause_cubrid_specific
 	: METHOD method_def_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_change_clause_cubrid_specific, : METHOD method_def_list);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -6032,7 +6092,7 @@ alter_change_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| QUERY unsigned_integer csql_query opt_vclass_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_change_clause_cubrid_specific, | QUERY unsigned_integer csql_query opt_vclass_comment_spec);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -6046,7 +6106,7 @@ alter_change_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| QUERY csql_query opt_vclass_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_change_clause_cubrid_specific, | QUERY csql_query opt_vclass_comment_spec);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -6060,7 +6120,7 @@ alter_change_clause_cubrid_specific
 
 		DBG_PRINT}}
 	| File file_path_name AS file_path_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_change_clause_cubrid_specific, | File file_path_name AS file_path_name);
 
 			PT_NODE *node = parser_get_alter_node ();
 
@@ -6077,7 +6137,7 @@ alter_change_clause_cubrid_specific
 
 normal_or_class_attr
 	: opt_class identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(normal_or_class_attr, : opt_class identifier);
 
 			if ($1)
 			  $2->info.name.meta_class = PT_META_ATTR;
@@ -6092,14 +6152,14 @@ normal_or_class_attr
 
 query_number_list
 	: query_number_list ',' unsigned_integer
-		{{
+		{{ DBG_TRACE_GRAMMAR(query_number_list, : query_number_list ',' unsigned_integer);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| unsigned_integer
-		{{
+		{{ DBG_TRACE_GRAMMAR(query_number_list, | unsigned_integer);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -6109,7 +6169,7 @@ query_number_list
 
 alter_column_clause_mysql_specific
 	: normal_column_or_class_attribute SET DEFAULT expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_column_clause_mysql_specific, : normal_column_or_class_attribute SET DEFAULT expression_);
 
 			PT_NODE *alter_node = parser_get_alter_node ();
 
@@ -6203,7 +6263,7 @@ alter_column_clause_mysql_specific
 
 normal_column_or_class_attribute
 	: opt_of_column_attribute identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(normal_column_or_class_attribute, : opt_of_column_attribute identifier);
 
 			PT_NODE * node = $2;
 			if (node)
@@ -6215,7 +6275,7 @@ normal_column_or_class_attribute
 
 		DBG_PRINT}}
 	| CLASS ATTRIBUTE identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(normal_column_or_class_attribute, | CLASS ATTRIBUTE identifier);
 
 			PT_NODE * node = $3;
 			if (node)
@@ -6230,7 +6290,7 @@ normal_column_or_class_attribute
 
 insert_or_replace_stmt
 	: insert_name_clause insert_stmt_value_clause on_duplicate_key_update
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, : insert_name_clause insert_stmt_value_clause on_duplicate_key_update);
 
 			PT_NODE *ins = $1;
 
@@ -6245,7 +6305,7 @@ insert_or_replace_stmt
 
 		DBG_PRINT}}
 	| insert_name_clause insert_stmt_value_clause into_clause_opt
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | insert_name_clause insert_stmt_value_clause into_clause_opt);
 
 			PT_NODE *ins = $1;
 
@@ -6260,7 +6320,7 @@ insert_or_replace_stmt
 
 		DBG_PRINT}}
 	| replace_name_clause insert_stmt_value_clause into_clause_opt
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | replace_name_clause insert_stmt_value_clause into_clause_opt);
 
 			PT_NODE *ins = $1;
 
@@ -6275,7 +6335,7 @@ insert_or_replace_stmt
 
 		DBG_PRINT}}
 	| insert_set_stmt on_duplicate_key_update
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | insert_set_stmt on_duplicate_key_update);
 
 			PT_NODE *ins = $1;
 			if (ins)
@@ -6288,7 +6348,7 @@ insert_or_replace_stmt
 
 		DBG_PRINT}}
 	| insert_set_stmt into_clause_opt
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | insert_set_stmt into_clause_opt);
 
 			PT_NODE *ins = $1;
 
@@ -6302,7 +6362,7 @@ insert_or_replace_stmt
 
 		DBG_PRINT}}
 	| replace_set_stmt into_clause_opt
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | replace_set_stmt into_clause_opt);
 
 			PT_NODE *ins = $1;
 
@@ -6320,7 +6380,7 @@ insert_or_replace_stmt
 insert_set_stmt
 	: insert_stmt_keyword
 	  insert_set_stmt_header
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_set_stmt, : insert_stmt_keyword insert_set_stmt_header);
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -6329,7 +6389,7 @@ insert_set_stmt
 replace_set_stmt
 	: replace_stmt_keyword
 	  insert_set_stmt_header
-		{{
+		{{ DBG_TRACE_GRAMMAR(replace_set_stmt, : replace_stmt_keyword insert_set_stmt_header);
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -6337,7 +6397,7 @@ replace_set_stmt
 
 insert_stmt_keyword
 	: INSERT
-		{
+		{ DBG_TRACE_GRAMMAR(insert_stmt_keyword, : INSERT);
 			PT_NODE* ins = parser_new_node (this_parser, PT_INSERT);
 			parser_push_hint_node (ins);
 		}
@@ -6345,7 +6405,7 @@ insert_stmt_keyword
 
 replace_stmt_keyword
 	: REPLACE
-		{
+		{ DBG_TRACE_GRAMMAR(replace_stmt_keyword, : REPLACE);
 			PT_NODE* ins = parser_new_node (this_parser, PT_INSERT);
 			if (ins)
 			  {
@@ -6361,7 +6421,7 @@ insert_set_stmt_header
 	  only_class_name
 	  SET
 	  insert_assignment_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_set_stmt_header, : opt_hint_list opt_into only_class_name SET insert_assignment_list);
 
 			PT_NODE *ins = parser_pop_hint_node ();
 			PT_NODE *ocs = parser_new_node (this_parser, PT_SPEC);
@@ -6389,7 +6449,7 @@ insert_set_stmt_header
 
 insert_assignment_list
 	: insert_assignment_list ',' identifier '=' expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_assignment_list, : insert_assignment_list ',' identifier '=' expression_);
 
 			parser_make_link (CONTAINER_AT_0 ($1), $3);
 			parser_make_link (CONTAINER_AT_1 ($1), $5);
@@ -6398,7 +6458,7 @@ insert_assignment_list
 
 		DBG_PRINT}}
 	| insert_assignment_list ',' identifier '=' DEFAULT
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_assignment_list, | insert_assignment_list ',' identifier '=' DEFAULT );
 			PT_NODE *arg = parser_copy_tree (this_parser, $3);
 
 			if (arg)
@@ -6413,7 +6473,7 @@ insert_assignment_list
 
 		DBG_PRINT}}
 	| identifier '=' expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_assignment_list, | identifier '=' expression_ );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $1, $3);
@@ -6422,7 +6482,7 @@ insert_assignment_list
 
 		DBG_PRINT}}
 	| identifier '=' DEFAULT
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_assignment_list, | identifier '=' DEFAULT);
 
 			container_2 ctn;
 			PT_NODE *arg = parser_copy_tree (this_parser, $1);
@@ -6442,7 +6502,7 @@ insert_assignment_list
 on_duplicate_key_update
 	: ON_ DUPLICATE_ KEY UPDATE
 	  update_assignment_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(on_duplicate_key_update, : ON_ DUPLICATE_ KEY UPDATE update_assignment_list);
 
 			$$ = $5;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -6452,7 +6512,7 @@ on_duplicate_key_update
 
 insert_expression
 	: insert_name_clause insert_expression_value_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_expression, : insert_name_clause insert_expression_value_clause);
 
 			PT_NODE *ins = $1;
 
@@ -6466,7 +6526,7 @@ insert_expression
 
 		DBG_PRINT}}
 	| '(' insert_name_clause insert_expression_value_clause into_clause_opt ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_expression, | '(' insert_name_clause insert_expression_value_clause into_clause_opt ')');
 
 			PT_NODE *ins = $2;
 
@@ -6485,7 +6545,7 @@ insert_expression
 insert_name_clause
 	: insert_stmt_keyword
 	  insert_name_clause_header
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_name_clause, : insert_stmt_keyword insert_name_clause_header);
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -6494,7 +6554,7 @@ insert_name_clause
 replace_name_clause
 	: replace_stmt_keyword
 	  insert_name_clause_header
-		{{
+		{{ DBG_TRACE_GRAMMAR(replace_name_clause, : replace_stmt_keyword insert_name_clause_header);
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -6506,7 +6566,7 @@ insert_name_clause_header
 	  only_class_name
 	  opt_partition_spec
 	  opt_attr_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_name_clause_header, : opt_hint_list opt_into only_class_name opt_partition_spec opt_attr_list);
 
 			PT_NODE *ins = parser_pop_hint_node ();
 			PT_NODE *ocs = parser_new_node (this_parser, PT_SPEC);
@@ -6536,19 +6596,19 @@ insert_name_clause_header
 
 opt_attr_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_attr_list, :);
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| '(' ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_attr_list, | '(' ')' );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| '(' identifier_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_attr_list, | '(' identifier_list ')' );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -6558,19 +6618,19 @@ opt_attr_list
 
 opt_path_attr_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_path_attr_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| '(' ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_path_attr_list, |  '(' ')' );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| '(' simple_path_id_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_path_attr_list, | '(' simple_path_id_list ')' );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -6580,7 +6640,7 @@ opt_path_attr_list
 
 insert_stmt_value_clause
 	: insert_expression_value_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_stmt_value_clause, : insert_expression_value_clause );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -6588,7 +6648,7 @@ insert_stmt_value_clause
 		DBG_PRINT}}
 	| opt_with_clause
 	  csql_query_without_values_and_single_subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_stmt_value_clause, |  opt_with_clause csql_query_without_values_and_single_subquery);
 
 			PT_NODE *with_clause = $1;
 			PT_NODE *select_node = $2;
@@ -6601,7 +6661,7 @@ insert_stmt_value_clause
 		DBG_PRINT}}
 	| '(' opt_with_clause
 	  csql_query_without_values_query_no_with_clause ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_stmt_value_clause, |  '(' opt_with_clause csql_query_without_values_query_no_with_clause ')');
 			PT_NODE *with_clause = $2;
 			PT_NODE *select_node = $3;
 			select_node->info.query.with = with_clause;
@@ -6615,14 +6675,14 @@ insert_stmt_value_clause
 
 insert_expression_value_clause
 	: of_value_values insert_value_clause_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_expression_value_clause, : of_value_values insert_value_clause_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| DEFAULT opt_values
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_expression_value_clause, | DEFAULT opt_values);
 
 			PT_NODE *nls = pt_node_list (this_parser, PT_IS_DEFAULT_VALUE, NULL);
 			$$ = nls;
@@ -6648,20 +6708,19 @@ opt_into
 
 into_clause_opt
 	: /* empty */
-		{{
-
+		{{ DBG_TRACE_GRAMMAR(into_clause_opt, : );
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| INTO to_param
-		{{
+		{{ DBG_TRACE_GRAMMAR(into_clause_opt, | INTO to_param );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| TO to_param
-		{{
+		{{ DBG_TRACE_GRAMMAR(into_clause_opt, | TO to_param );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -6671,14 +6730,14 @@ into_clause_opt
 
 insert_value_clause_list
 	: insert_value_clause_list ',' insert_value_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_value_clause_list, : insert_value_clause_list ',' insert_value_clause);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| insert_value_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_value_clause_list, | insert_value_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -6688,7 +6747,7 @@ insert_value_clause_list
 
 insert_value_clause
 	: '(' insert_value_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_value_clause, : '(' insert_value_list ')' );
 
 			PT_NODE *nls = pt_node_list (this_parser, PT_IS_VALUE, $2);
 			$$ = nls;
@@ -6696,7 +6755,7 @@ insert_value_clause
 
 		DBG_PRINT}}
 	| '('')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_value_clause, | '('')' );
 
 			PT_NODE *nls = NULL;
 
@@ -6714,7 +6773,7 @@ insert_value_clause
 
 		DBG_PRINT}}
 	| DEFAULT opt_values
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_value_clause, | DEFAULT opt_values);
 
 			PT_NODE *nls = pt_node_list (this_parser, PT_IS_DEFAULT_VALUE, NULL);
 			$$ = nls;
@@ -6725,14 +6784,14 @@ insert_value_clause
 
 insert_value_list
 	: insert_value_list ',' insert_value
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_value_list, : insert_value_list ',' insert_value);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| insert_value
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_value_list, | insert_value);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -6742,21 +6801,21 @@ insert_value_list
 
 insert_value
 	: select_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_value, : select_stmt);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| normal_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_value, | normal_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| DEFAULT
-		{{
+		{{ DBG_TRACE_GRAMMAR(insert_value, | DEFAULT);
 
 			/* The argument will be filled in later, when the
 			   corresponding column name is known.
@@ -6771,7 +6830,7 @@ show_stmt
 	: SHOW
 	  opt_full
 	  TABLES
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, : SHOW opt_full TABLES);
 
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 0;  /* neither LIKE nor WHERE */
@@ -6788,7 +6847,7 @@ show_stmt
 	  TABLES
 	  LIKE
 	  expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW opt_full TABLES LIKE expression_);
 
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 1;  /* is LIKE */
@@ -6806,7 +6865,7 @@ show_stmt
 	  TABLES
 	  WHERE
 	  search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW opt_full TABLES WHERE search_condition);
 
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 2;  /* is WHERE */
@@ -6824,7 +6883,7 @@ show_stmt
 	  COLUMNS
 	  of_from_in
 	  identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW opt_full COLUMNS of_from_in identifier);
 
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 0;  /* neither LIKE nor WHERE */
@@ -6845,7 +6904,7 @@ show_stmt
 	  identifier
 	  LIKE
 	  expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW opt_full COLUMNS  of_from_in identifier LIKE expression_);
 
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 1;  /* is LIKE */
@@ -6867,7 +6926,7 @@ show_stmt
 	  identifier
 	  WHERE
 	  search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW opt_full COLUMNS of_from_in identifier WHERE search_condition);
 
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 2;  /* is WHERE */
@@ -6884,7 +6943,7 @@ show_stmt
 		DBG_PRINT}}
 	| of_describe_desc_explain
 	  identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | of_describe_desc_explain identifier);
 
 			PT_NODE *node = NULL;
 			PT_NODE *original_cls_id = $2;
@@ -6899,7 +6958,7 @@ show_stmt
 	| of_describe_desc_explain
 	  identifier
 	  identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | of_describe_desc_explain identifier identifier);
 
 			PT_NODE *node = NULL;
 			PT_NODE *original_cls_id = $2;
@@ -6914,7 +6973,7 @@ show_stmt
 	| of_describe_desc_explain
 	  identifier
 	  char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | of_describe_desc_explain identifier char_string_literal);
 
 			int like_where_syntax = 0;
 			PT_NODE *node = NULL;
@@ -6934,7 +6993,7 @@ show_stmt
 		DBG_PRINT}}
 	| SHOW
 	  COLLATION
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW COLLATION);
 
 			PT_NODE *node = NULL;
 
@@ -6948,7 +7007,7 @@ show_stmt
 	  COLLATION
 	  LIKE
 	  expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW COLLATION LIKE expression_);
 
 			const int like_where_syntax = 1;  /* is LIKE */
 			PT_NODE *node = NULL;
@@ -6966,7 +7025,7 @@ show_stmt
 	  COLLATION
 	  WHERE
 	  search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW COLLATION WHERE search_condition);
 			const int like_where_syntax = 2;  /* is WHERE */
 			PT_NODE *node = NULL;
 			PT_NODE *where_cond = $4;
@@ -6983,7 +7042,7 @@ show_stmt
 	  CREATE
 	  TABLE
 	  identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW CREATE TABLE identifier);
 
 			PT_NODE *node = NULL;
 			node = pt_make_query_show_create_table (this_parser, $4);
@@ -6996,7 +7055,7 @@ show_stmt
 	  CREATE
 	  VIEW
 	  identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW CREATE VIEW identifier);
 
 			PT_NODE *node = NULL;
 			PT_NODE *view_id = $4;
@@ -7011,7 +7070,7 @@ show_stmt
 	  GRANTS
 	  For
 	  identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW GRANTS For identifier);
 
 			PT_NODE *node = NULL;
 			PT_NODE *user_id = $4;
@@ -7028,7 +7087,7 @@ show_stmt
 	| SHOW
 	  GRANTS
 	  opt_for_current_user
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW GRANTS opt_for_current_user);
 
 			PT_NODE *node = NULL;
 
@@ -7042,7 +7101,7 @@ show_stmt
 	  of_index_indexes_keys
 	  of_from_in
 	  identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW of_index_indexes_keys of_from_in identifier);
 
 			PT_NODE *node = NULL;
 			PT_NODE *table_id = $4;
@@ -7053,7 +7112,7 @@ show_stmt
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
 	| SHOW EXEC STATISTICS ALL
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW EXEC STATISTICS ALL);
 			PT_NODE *node = NULL;
 
 			node = pt_make_query_show_exec_stats_all (this_parser);
@@ -7063,7 +7122,7 @@ show_stmt
 
 		DBG_PRINT}}
 	| SHOW EXEC STATISTICS
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW EXEC STATISTICS);
 			PT_NODE *node = NULL;
 
 			node = pt_make_query_show_exec_stats (this_parser);
@@ -7073,7 +7132,7 @@ show_stmt
 
 		DBG_PRINT}}
 	| SHOW TRACE
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW TRACE);
 			PT_NODE *node = NULL;
 
 			node = pt_make_query_show_trace (this_parser);
@@ -7082,7 +7141,7 @@ show_stmt
 
 		DBG_PRINT}}
 	| SHOW show_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type);
 			int type = $2;
 			PT_NODE *node = pt_make_query_showstmt (this_parser, type, NULL, 0, NULL);
 
@@ -7091,7 +7150,7 @@ show_stmt
 
 		DBG_PRINT}}
 	| SHOW show_type_of_like LIKE expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_of_like LIKE expression_);
 
 			const int like_where_syntax = 1;  /* is LIKE */
 			int type = $2;
@@ -7104,7 +7163,7 @@ show_stmt
 
 		DBG_PRINT}}
 	| SHOW show_type_of_where WHERE search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_of_where WHERE search_condition);
 			const int like_where_syntax = 2;  /* is WHERE */
 			int type = $2;
 			PT_NODE *where_cond = $4;
@@ -7116,7 +7175,7 @@ show_stmt
 
 		DBG_PRINT}}
 	| SHOW show_type_arg1 OF arg_value
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_arg1 OF arg_value);
 			int type = $2;
 			PT_NODE *args = $4;
 			PT_NODE *node = pt_make_query_showstmt (this_parser, type, args, 0, NULL);
@@ -7126,7 +7185,7 @@ show_stmt
 
 		DBG_PRINT}}
 	| SHOW show_type_arg1_opt opt_arg_value
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_arg1_opt opt_arg_value);
 			PT_NODE *node = NULL;
 			int type = $2;
 			PT_NODE *args = $3;
@@ -7138,7 +7197,7 @@ show_stmt
 
 		DBG_PRINT}}
 	| SHOW show_type_arg_named of_or_where named_args
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_arg_named of_or_where named_args);
 			PT_NODE *node = NULL;
 			int type = $2;
 			PT_NODE *args = $4;
@@ -7150,7 +7209,7 @@ show_stmt
 
 		DBG_PRINT}}
 	| SHOW show_type_id_dot_id OF identifier DOT identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_id_dot_id OF identifier DOT identifier);
 			int type = $2;
 			PT_NODE *node, *args = $4;
 
@@ -7165,7 +7224,7 @@ show_stmt
 
 kill_stmt
 	: KILL arg_value_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(kill_stmt, | KILL arg_value_list);
 			PT_NODE *node = parser_new_node (this_parser, PT_KILL_STMT);
 
 			if (node)
@@ -7178,7 +7237,7 @@ kill_stmt
 
 		DBG_PRINT}}
 	| KILL kill_type arg_value_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(kill_stmt, | KILL kill_type arg_value_list);
 			int type = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_KILL_STMT);
 
@@ -7352,29 +7411,29 @@ kill_type
 
 of_or_where
 	: OF
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_or_where, : OF );
 			$$ = NULL;
 		}}
 	| WHERE
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_or_where, | WHERE);
 			$$ = NULL;
 		}}
 	;
 
 named_args
 	: named_arg
-		{{
+		{{ DBG_TRACE_GRAMMAR(named_args, | named_arg);
 			$$ = $1;
 		DBG_PRINT}}
 	| named_args AND named_arg
-		{{
+		{{ DBG_TRACE_GRAMMAR(named_args, | named_args AND named_arg);
 			$$ = parser_make_link ($1, $3);
 		DBG_PRINT}}
 	;
 
 named_arg
 	: identifier '=' arg_value
-		{{
+		{{ DBG_TRACE_GRAMMAR(named_arg, | identifier '=' arg_value);
 			PT_NODE * node = parser_new_node (this_parser, PT_NAMED_ARG);
 			node->info.named_arg.name = $1;
 			node->info.named_arg.value = $3;
@@ -7384,7 +7443,7 @@ named_arg
 
 opt_arg_value
 	:
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_arg_value, : );
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  node->type_enum = PT_TYPE_NULL;
@@ -7392,21 +7451,21 @@ opt_arg_value
 			$$ = node;
 		}}
 	| OF arg_value
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_arg_value, | OF arg_value);
 			$$ = $2;
 		}}
 	;
 
 arg_value_list
 	: arg_value_list ','  arg_value
-		{{
+		{{ DBG_TRACE_GRAMMAR(arg_value_list, : arg_value_list ','  arg_value);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| arg_value
-		{{
+		{{ DBG_TRACE_GRAMMAR(arg_value_list, | arg_value);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -7416,28 +7475,28 @@ arg_value_list
 
 arg_value
 	: char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(arg_value, : char_string_literal);
 			$$ = $1;
 		DBG_PRINT}}
 	| unsigned_integer
-		{{
+		{{ DBG_TRACE_GRAMMAR(arg_value, | unsigned_integer);
 			$$ = $1;
 		DBG_PRINT}}
 	| identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(arg_value, | identifier);
 			$$ = $1;
 		DBG_PRINT}}
 	;
 
 opt_full
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_full, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| FULL
-		{{
+		{{ DBG_TRACE_GRAMMAR(arg_vopt_fullalue, | FULL);
 
 			$$ = 1;
 
@@ -7469,7 +7528,7 @@ of_index_indexes_keys
 
 update_head
 	: UPDATE
-		{
+		{ DBG_TRACE_GRAMMAR(update_head, : UPDATE);
 			PT_NODE* node = parser_new_node(this_parser, PT_UPDATE);
 			parser_push_hint_node(node);
 		}
@@ -7478,7 +7537,7 @@ update_head
 
 update_stmt
 	: update_head
-		{
+		{ DBG_TRACE_GRAMMAR(update_stmt, : update_head);
 			PT_NODE * node = parser_pop_hint_node();
 			parser_push_orderby_node (node);
 			parser_push_hint_node (node);
@@ -7490,7 +7549,7 @@ update_stmt
 	  opt_using_index_clause
 	  opt_update_orderby_clause
 	  opt_upd_del_limit_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(update_stmt, extended_table_spec_list SET update_assignment_list ~ );
 
 			PT_NODE *node = parser_pop_hint_node ();
 
@@ -7590,7 +7649,7 @@ update_stmt
 	  from_param
 	  SET
 	  update_assignment_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(update_stmt, | update_head OBJECT from_param SET update_assignment_list);
 
 			PT_NODE *node = parser_pop_hint_node ();
 			if (node)
@@ -7608,7 +7667,7 @@ update_stmt
 
 opt_of_where_cursor
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_where_cursor, : );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, 0, NULL);
@@ -7616,7 +7675,7 @@ opt_of_where_cursor
 
 		DBG_PRINT}}
 	| WHERE
-		{
+		{ DBG_TRACE_GRAMMAR(opt_of_where_cursor, | WHERE );
 			parser_save_and_set_ic(1);
 			DBG_PRINT
 		}
@@ -7625,7 +7684,7 @@ opt_of_where_cursor
 			parser_restore_ic();
 			DBG_PRINT
 		}
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_where_cursor, search_condition);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), $3);
@@ -7633,7 +7692,7 @@ opt_of_where_cursor
 
 		DBG_PRINT}}
 	| WHERE CURRENT OF identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_where_cursor, | WHERE CURRENT OF identifier);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), $4);
@@ -7645,14 +7704,14 @@ opt_of_where_cursor
 
 of_class_spec_meta_class_spec
 	: class_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_class_spec_meta_class_spec, : class_spec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| meta_class_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_class_spec_meta_class_spec, | meta_class_spec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -7662,20 +7721,20 @@ of_class_spec_meta_class_spec
 
 opt_as_identifier
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_as_identifier, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| AS identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_as_identifier, | AS identifier);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_as_identifier, | identifier);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -7685,14 +7744,14 @@ opt_as_identifier
 
 update_assignment_list
 	: update_assignment_list ',' update_assignment
-		{{
+		{{ DBG_TRACE_GRAMMAR(update_assignment_list, : update_assignment_list ',' update_assignment);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| update_assignment
-		{{
+		{{ DBG_TRACE_GRAMMAR(update_assignment_list, | update_assignment);
 
 			$$ = $1;
 
@@ -7701,14 +7760,14 @@ update_assignment_list
 
 update_assignment
 	: path_expression '=' expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(update_assignment, : path_expression '=' expression_);
 
 			$$ = parser_make_expression (this_parser, PT_ASSIGN, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| simple_path_id '=' DEFAULT
-		{{
+		{{ DBG_TRACE_GRAMMAR("update_assignment", "| simple_path_id '=' DEFAULT ");
 
 			PT_NODE *node, *node_df = NULL;
 			node = parser_copy_tree (this_parser, $1);
@@ -7722,7 +7781,7 @@ update_assignment
 
 		DBG_PRINT}}
 	| paren_path_expression_set '=' primary_w_collate
-		{{
+		{{ DBG_TRACE_GRAMMAR(update_assignment, | paren_path_expression_set '=' primary_w_collate);
 
 			PT_NODE *exp = parser_make_expression (this_parser, PT_ASSIGN, $1, NULL, NULL);
 			PT_NODE *arg1, *arg2, *list, *tmp;
@@ -7834,7 +7893,7 @@ update_assignment
 
 paren_path_expression_set
 	: '(' path_expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(paren_path_expression_set, : '(' path_expression_list ')');
 
 			PT_NODE *p = parser_new_node (this_parser, PT_EXPR);
 
@@ -7853,14 +7912,14 @@ paren_path_expression_set
 
 path_expression_list
 	: path_expression_list ',' path_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_expression_list, : path_expression_list ',' path_expression);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| path_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_expression_list, | path_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -7869,7 +7928,7 @@ path_expression_list
 
 delete_name
 	: identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(delete_name, : identifier);
 
 			PT_NODE *node = $1;
 			node->info.name.meta_class = PT_CLASS;
@@ -7878,7 +7937,7 @@ delete_name
 
 		DBG_PRINT}}
 	| identifier DOT '*'
-		{{
+		{{ DBG_TRACE_GRAMMAR(delete_name, | identifier DOT '*');
 
 			PT_NODE *node = $1;
 			node->info.name.meta_class = PT_CLASS;
@@ -7890,13 +7949,13 @@ delete_name
 
 delete_name_list
 	: delete_name_list ',' delete_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(delete_name_list, : delete_name_list ',' delete_name);
 
 			$$ = parser_make_link ($1, $3);
 
 		DBG_PRINT}}
 	| delete_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(delete_name_list, | delete_name);
 
 			$$ = $1;
 
@@ -7905,7 +7964,7 @@ delete_name_list
 
 delete_from_using
 	: delete_name_list FROM extended_table_spec_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(delete_from_using, : delete_name_list FROM extended_table_spec_list);
 
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, $1, CONTAINER_AT_0 ($3), CONTAINER_AT_1 ($3));
@@ -7914,7 +7973,7 @@ delete_from_using
 
 		DBG_PRINT}}
 	| FROM delete_name_list USING extended_table_spec_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(delete_from_using, | FROM delete_name_list USING extended_table_spec_list);
 
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, $2, CONTAINER_AT_0 ($4), CONTAINER_AT_1 ($4));
@@ -7923,7 +7982,7 @@ delete_from_using
 
 		DBG_PRINT}}
 	| FROM table_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(delete_from_using, | FROM table_spec);
 
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, NULL, $2, FROM_NUMBER(0));
@@ -7932,7 +7991,7 @@ delete_from_using
 
 		DBG_PRINT}}
 	| table_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(delete_from_using, | table_spec);
 
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, NULL, $1, FROM_NUMBER(0));
@@ -7944,7 +8003,7 @@ delete_from_using
 
 delete_stmt
 	: DELETE_				/* $1 */
-		{				/* $2 */
+		{ DBG_TRACE_GRAMMAR(delete_stmt, : DELETE_); /* $2 */
 			PT_NODE* node = parser_new_node(this_parser, PT_DELETE);
 			parser_push_hint_node(node);
 		}
@@ -7953,7 +8012,7 @@ delete_stmt
 	  opt_of_where_cursor 			/* $5 */
 	  opt_using_index_clause 		/* $6 */
 	  opt_upd_del_limit_clause		/* $7 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(delete_stmt, opt_hint_list delete_from_using opt_of_where_cursor opt_using_index_clause  opt_upd_del_limit_clause);
 
 			PT_NODE *del = parser_pop_hint_node ();
 
@@ -8052,7 +8111,7 @@ delete_stmt
 
 merge_stmt
 	: MERGE					/* $1 */
-		{				/* $2 */
+		{ DBG_TRACE_GRAMMAR(merge_stmt, : MERGE); /* $2 */
 			PT_NODE *merge = parser_new_node (this_parser, PT_MERGE);
 			parser_push_hint_node (merge);
 		}
@@ -8064,7 +8123,7 @@ merge_stmt
 	  ON_					/* $8 */
 	  search_condition			/* $9 */
 	  merge_update_insert_clause		/* $10 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(merge_stmt, opt_hint_list INTO  table_spec USING table_spec ON_ search_condition merge_update_insert_clause);
 
 			PT_NODE *merge = parser_pop_hint_node ();
 			if (merge)
@@ -8082,18 +8141,18 @@ merge_stmt
 
 merge_update_insert_clause
 	: merge_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, : merge_update_clause);
 		DBG_PRINT}}
 	| merge_insert_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, | merge_insert_clause);
 		DBG_PRINT}}
 	| merge_update_clause
 	  merge_insert_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, | merge_update_clause merge_insert_clause);
 		DBG_PRINT}}
 	| merge_insert_clause
 	  merge_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, | merge_insert_clause merge_update_clause);
 		DBG_PRINT}}
 	;
 
@@ -8102,7 +8161,7 @@ merge_update_clause
 	  update_assignment_list		/* $6 */
 	  opt_where_clause			/* $7 */
 	  opt_merge_delete_clause		/* $8 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(merge_update_clause, : WHEN MATCHED THEN UPDATE SET update_assignment_list ~);
 
 			PT_NODE *merge = parser_top_hint_node ();
 			if (merge)
@@ -8124,7 +8183,7 @@ merge_insert_clause
 	  opt_path_attr_list			/* $6 */
 	  insert_expression_value_clause	/* $7 */
 	  opt_where_clause			/* $8 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(merge_insert_clause, : WHEN NOT MATCHED THEN INSERT ~ insert_expression_value_clause ~);
 
 			PT_NODE *merge = parser_top_hint_node ();
 			if (merge)
@@ -8139,13 +8198,13 @@ merge_insert_clause
 
 opt_merge_delete_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_merge_delete_clause, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| DELETE_ WHERE search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_merge_delete_clause, | DELETE_ WHERE search_condition);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8155,7 +8214,7 @@ opt_merge_delete_clause
 
 auth_stmt
 	 : grant_head opt_with_grant_option
-		{{
+		{{ DBG_TRACE_GRAMMAR(auth_stmt, : grant_head opt_with_grant_option);
 
 			PT_NODE *node = $1;
 			PT_MISC_TYPE w = PT_NO_GRANT_OPTION;
@@ -8172,7 +8231,7 @@ auth_stmt
 
 		DBG_PRINT}}
 	| revoke_cmd on_class_list from_id_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(auth_stmt, | revoke_cmd on_class_list from_id_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_REVOKE);
 
@@ -8188,7 +8247,7 @@ auth_stmt
 
 		DBG_PRINT}}
 	| revoke_cmd from_id_list on_class_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(auth_stmt, | revoke_cmd from_id_list on_class_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_REVOKE);
 
@@ -8210,7 +8269,8 @@ revoke_cmd
 		{ push_msg(MSGCAT_SYNTAX_MISSING_AUTH_COMMAND_LIST); }
 	  author_cmd_list
 		{ pop_msg(); }
-		{ $$ = $3; }
+		{ DBG_TRACE_GRAMMAR(revoke_cmd, : REVOKE author_cmd_list);
+                  $$ = $3; }
 	;
 
 grant_cmd
@@ -8218,12 +8278,13 @@ grant_cmd
 		{ push_msg(MSGCAT_SYNTAX_MISSING_AUTH_COMMAND_LIST); }
 	  author_cmd_list
 		{ pop_msg(); }
-		{ $$ = $3; }
+		{ DBG_TRACE_GRAMMAR(grant_cmd, : GRANT author_cmd_list);
+                  $$ = $3; }
 	;
 
 grant_head
 	: grant_cmd on_class_list to_id_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(grant_head, : grant_cmd on_class_list to_id_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_GRANT);
 
@@ -8239,7 +8300,7 @@ grant_head
 
 		DBG_PRINT}}
 	| grant_cmd to_id_list on_class_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(grant_head, | grant_cmd to_id_list on_class_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_GRANT);
 
@@ -8258,13 +8319,13 @@ grant_head
 
 opt_with_grant_option
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_grant_option, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| WITH GRANT OPTION
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_grant_option, | WITH GRANT OPTION);
 
 			$$ = 1;
 
@@ -8276,7 +8337,8 @@ on_class_list
 		{ push_msg(MSGCAT_SYNTAX_MISSING_CLASS_SPEC_LIST); }
 	  class_spec_list
 		{ pop_msg(); }
-		{ $$ = $3; }
+		{ DBG_TRACE_GRAMMAR(on_class_list, : ON_ class_spec_list);
+                  $$ = $3; }
 	;
 
 to_id_list
@@ -8284,7 +8346,8 @@ to_id_list
 		{ push_msg(MSGCAT_SYNTAX_MISSING_IDENTIFIER_LIST); }
 	  identifier_list
 		{ pop_msg(); }
-		{ $$ = $3; }
+		{ DBG_TRACE_GRAMMAR(to_id_list, : TO identifier_list);
+                  $$ = $3; }
 	;
 
 from_id_list
@@ -8292,19 +8355,20 @@ from_id_list
 		{ push_msg(MSGCAT_SYNTAX_MISSING_IDENTIFIER_LIST); }
 	  identifier_list
 		{ pop_msg(); }
-		{ $$ = $3; }
+		{ DBG_TRACE_GRAMMAR(from_id_list, : FROM identifier_list);
+                  $$ = $3; }
 	;
 
 author_cmd_list
 	: author_cmd_list ',' authorized_cmd
-		{{
+		{{ DBG_TRACE_GRAMMAR(author_cmd_list, : author_cmd_list ',' authorized_cmd);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| authorized_cmd
-		{{
+		{{ DBG_TRACE_GRAMMAR(author_cmd_list, | authorized_cmd);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8314,7 +8378,7 @@ author_cmd_list
 
 authorized_cmd
 	: SELECT
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, : SELECT);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 			node->info.auth_cmd.auth_cmd = PT_SELECT_PRIV;
@@ -8324,7 +8388,7 @@ authorized_cmd
 
 		DBG_PRINT}}
 	| INSERT
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | INSERT);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
@@ -8339,7 +8403,7 @@ authorized_cmd
 
 		DBG_PRINT}}
 	| INDEX
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | INDEX);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
@@ -8354,7 +8418,7 @@ authorized_cmd
 
 		DBG_PRINT}}
 	| DELETE_
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | DELETE_);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
@@ -8370,7 +8434,7 @@ authorized_cmd
 		DBG_PRINT}}
 
 	| UPDATE '(' identifier_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | UPDATE '(' identifier_list ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 			PARSER_SAVE_ERR_CONTEXT (node, @$.buffer_pos)
@@ -8388,7 +8452,7 @@ authorized_cmd
 
 		DBG_PRINT}}
 	| UPDATE
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | UPDATE);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
@@ -8403,7 +8467,7 @@ authorized_cmd
 
 		DBG_PRINT}}
 	| ALTER
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ALTER);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
@@ -8418,7 +8482,7 @@ authorized_cmd
 
 		DBG_PRINT}}
 	| ADD
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ADD);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
@@ -8433,7 +8497,7 @@ authorized_cmd
 
 		DBG_PRINT}}
 	| DROP
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | DROP);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
@@ -8448,7 +8512,7 @@ authorized_cmd
 
 		DBG_PRINT}}
 	| EXECUTE
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | EXECUTE);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
@@ -8463,7 +8527,7 @@ authorized_cmd
 
 		DBG_PRINT}}
 	| REFERENCES
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | REFERENCES);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
@@ -8478,7 +8542,7 @@ authorized_cmd
 
 		DBG_PRINT}}
 	| ALL PRIVILEGES
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ALL PRIVILEGES);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
@@ -8493,7 +8557,7 @@ authorized_cmd
 
 		DBG_PRINT}}
 	| ALL
-		{{
+		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ALL);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
@@ -8511,7 +8575,7 @@ authorized_cmd
 
 opt_password
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_password, : );
 
 			$$ = NULL;
 
@@ -8520,7 +8584,7 @@ opt_password
 		{ push_msg(MSGCAT_SYNTAX_INVALID_PASSWORD); }
 	  char_string_literal
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_password, | PASSWORD char_string_literal);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8530,7 +8594,7 @@ opt_password
 
 opt_groups
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_groups, : );
 
 			$$ = NULL;
 
@@ -8539,7 +8603,7 @@ opt_groups
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GROUPS); }
 	  identifier_list
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_groups, | GROUPS identifier_list);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8549,7 +8613,7 @@ opt_groups
 
 opt_members
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_members, : );
 
 			$$ = NULL;
 
@@ -8558,7 +8622,7 @@ opt_members
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MEMBERS); }
 	  identifier_list
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_members, | MEMBERS identifier_list);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8568,7 +8632,7 @@ opt_members
 
 call_stmt
 	: CALL generic_function into_clause_opt
-		{{
+		{{ DBG_TRACE_GRAMMAR(call_stmt, : CALL generic_function into_clause_opt);
 
 			PT_NODE *node = $2;
 			if (node)
@@ -8588,13 +8652,13 @@ call_stmt
 
 opt_class_or_normal_attr_def_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_class_or_normal_attr_def_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| '(' class_or_normal_attr_def_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_class_or_normal_attr_def_list, | '(' class_or_normal_attr_def_list ')');
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8604,13 +8668,13 @@ opt_class_or_normal_attr_def_list
 
 opt_method_def_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_method_def_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| METHOD method_def_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_method_def_list, | METHOD method_def_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8620,13 +8684,13 @@ opt_method_def_list
 
 opt_method_files
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_method_files, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| File method_file_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_method_files, | File method_file_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8636,13 +8700,13 @@ opt_method_files
 
 opt_inherit_resolution_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_inherit_resolution_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| inherit_resolution_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_inherit_resolution_list, | inherit_resolution_list);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8652,13 +8716,15 @@ opt_inherit_resolution_list
 
 opt_table_option_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_table_option_list, : );
+
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| table_option_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_table_option_list, | table_option_list);
+
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8668,13 +8734,13 @@ opt_table_option_list
 
 opt_partition_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_partition_clause, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| partition_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_partition_clause, | partition_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8684,7 +8750,7 @@ opt_partition_clause
 
 opt_create_as_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_create_as_clause, : );
 
 			container_2 ctn;
 			SET_CONTAINER_2(ctn, NULL, NULL);
@@ -8692,7 +8758,7 @@ opt_create_as_clause
 
 		DBG_PRINT}}
 	| create_as_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_create_as_clause, | create_as_clause);
 
 			$$ = $1;
 
@@ -8701,13 +8767,13 @@ opt_create_as_clause
 
 of_class_table_type
 	: CLASS
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_class_table_type, : CLASS);
 
 			$$ = PT_CLASS;
 
 		DBG_PRINT}}
 	| TABLE
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_class_table_type, | TABLE);
 
 			$$ = PT_CLASS;
 
@@ -8721,13 +8787,13 @@ of_view_vclass
 
 opt_or_replace
 	: /*empty*/
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_or_replace, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| OR REPLACE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_or_replace, | OR REPLACE);
 
 			$$ = 1;
 
@@ -8736,13 +8802,13 @@ opt_or_replace
 
 opt_if_not_exists
 	: /*empty*/
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_if_not_exists, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| IF NOT EXISTS
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_if_not_exists, |  IF NOT EXISTS);
 
 			$$ = 1;
 
@@ -8751,13 +8817,13 @@ opt_if_not_exists
 
 opt_if_exists
 	: /*empty*/
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_if_exists, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| IF EXISTS
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_if_exists, | IF EXISTS);
 
 			$$ = 1;
 
@@ -8766,13 +8832,13 @@ opt_if_exists
 
 opt_paren_view_attr_def_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_paren_view_attr_def_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| '(' view_attr_def_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_opt_paren_view_attr_def_listif_exists, | '(' view_attr_def_list ')');
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8782,13 +8848,13 @@ opt_paren_view_attr_def_list
 
 opt_as_query_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_as_query_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| AS query_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_as_query_list, | AS query_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8798,25 +8864,25 @@ opt_as_query_list
 
 opt_with_levels_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_levels_clause, : );
 
 			$$ = PT_EMPTY;
 
 		DBG_PRINT}}
 	| WITH LOCAL CHECK OPTION
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_levels_clause, | WITH LOCAL CHECK OPTION);
 
 			$$ = PT_LOCAL;
 
 		DBG_PRINT}}
 	| WITH CASCADED CHECK OPTION
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_levels_clause, | WITH CASCADED CHECK OPTION);
 
 			$$ = PT_CASCADED;
 
 		DBG_PRINT}}
 	| WITH CHECK OPTION
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_levels_clause, | WITH CHECK OPTION);
 
 			$$ = PT_CASCADED;
 
@@ -8825,14 +8891,14 @@ opt_with_levels_clause
 
 query_list
 	: query_list ',' csql_query
-		{{
+		{{ DBG_TRACE_GRAMMAR(query_list, : query_list ',' csql_query);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| csql_query
-		{{
+		{{ DBG_TRACE_GRAMMAR(query_list, | csql_query);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8842,14 +8908,14 @@ query_list
 
 inherit_resolution_list
 	: inherit_resolution_list  ',' inherit_resolution
-		{{
+		{{ DBG_TRACE_GRAMMAR(inherit_resolution_list, : inherit_resolution_list  ',' inherit_resolution);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| INHERIT inherit_resolution
-		{{
+		{{ DBG_TRACE_GRAMMAR(inherit_resolution_list, | INHERIT inherit_resolution);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8859,7 +8925,7 @@ inherit_resolution_list
 
 inherit_resolution
 	: opt_class identifier OF identifier AS identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(inherit_resolution, : opt_class identifier OF identifier AS identifier);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_RESOLUTION);
 
@@ -8880,7 +8946,7 @@ inherit_resolution
 
 		DBG_PRINT}}
 	| opt_class identifier OF identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(inherit_resolution, | opt_class identifier OF identifier);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_RESOLUTION);
 
@@ -8903,21 +8969,21 @@ inherit_resolution
 
 table_option_list
 	: table_option_list ',' table_option
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_option_list, : table_option_list ',' table_option);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| table_option_list table_option
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_option_list, | table_option_list table_option);
 
 			$$ = parser_make_link ($1, $2);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| table_option
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_option_list, | table_option);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8927,21 +8993,21 @@ table_option_list
 
 table_option
 	: REUSE_OID
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_option, : REUSE_OID);
 
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_REUSE_OID, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| DONT_REUSE_OID
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_option, | DONT_REUSE_OID);
 
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_DONT_REUSE_OID, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| AUTO_INCREMENT '=' UNSIGNED_INTEGER
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_option, | AUTO_INCREMENT '=' UNSIGNED_INTEGER);
 
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 			if (val)
@@ -8957,29 +9023,29 @@ table_option
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		  DBG_PRINT}}
-  | class_encrypt_spec
-    {{
+	| class_encrypt_spec
+                {{ DBG_TRACE_GRAMMAR(table_option, | class_encrypt_spec);
 	
-      $$ = pt_table_option (this_parser, PT_TABLE_OPTION_ENCRYPT, $1);
+                        $$ = pt_table_option (this_parser, PT_TABLE_OPTION_ENCRYPT, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		  DBG_PRINT}}
 	| charset_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_option, | charset_spec);
 
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_CHARSET, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		  DBG_PRINT}}
 	| collation_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_option, | collation_spec);
 
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_COLLATION, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		  DBG_PRINT}}
 	| class_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_option, | class_comment_spec);
 
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_COMMENT, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -8989,20 +9055,20 @@ table_option
 
 opt_subtable_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_subtable_clause, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| UNDER only_class_name_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_subtable_clause, | UNDER only_class_name_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| AS SUBCLASS OF only_class_name_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_subtable_clause, | AS SUBCLASS OF only_class_name_list);
 
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9012,13 +9078,13 @@ opt_subtable_clause
 
 opt_constraint_id
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_constraint_id, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| CONSTRAINT identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_constraint_id, | CONSTRAINT identifier);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9028,13 +9094,13 @@ opt_constraint_id
 
 opt_constraint_opt_id
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_constraint_opt_id, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| CONSTRAINT opt_identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_constraint_opt_id, | CONSTRAINT opt_identifier);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9044,21 +9110,21 @@ opt_constraint_opt_id
 
 of_unique_foreign_check
 	: unique_constraint
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_unique_foreign_check, : unique_constraint);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| foreign_key_constraint
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_unique_foreign_check, | foreign_key_constraint);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| check_constraint
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_unique_foreign_check, | check_constraint);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9068,7 +9134,7 @@ of_unique_foreign_check
 
 opt_constraint_attr_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_constraint_attr_list, : );
 
 			container_4 ctn;
 			SET_CONTAINER_4 (ctn, FROM_NUMBER (0), FROM_NUMBER (0), FROM_NUMBER (0),
@@ -9077,7 +9143,7 @@ opt_constraint_attr_list
 
 		DBG_PRINT}}
 	| constraint_attr_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_constraint_attr_list, | constraint_attr_list);
 
 			$$ = $1;
 
@@ -9086,7 +9152,7 @@ opt_constraint_attr_list
 
 constraint_attr_list
 	: constraint_attr_list ',' constraint_attr
-		{{
+		{{ DBG_TRACE_GRAMMAR(constraint_attr_list, : constraint_attr_list ',' constraint_attr);
 
 			container_4 ctn = $1;
 			container_4 ctn_new = $3;
@@ -9107,7 +9173,7 @@ constraint_attr_list
 
 		DBG_PRINT}}
 	| constraint_attr
-		{{
+		{{ DBG_TRACE_GRAMMAR(constraint_attr_list, | constraint_attr);
 
 			$$ = $1;
 
@@ -9116,7 +9182,7 @@ constraint_attr_list
 
 unique_constraint
 	: PRIMARY KEY opt_identifier '(' index_column_identifier_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(unique_constraint, : PRIMARY KEY opt_identifier '(' index_column_identifier_list ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_CONSTRAINT);
 
@@ -9132,7 +9198,7 @@ unique_constraint
 
 		DBG_PRINT}}
 	| UNIQUE opt_of_index_key opt_identifier index_column_name_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(unique_constraint, | UNIQUE opt_of_index_key opt_identifier index_column_name_list);
 
 			PT_NODE *node = NULL;
 			PT_NODE *sort_spec_cols = $4, *name_cols = NULL, *temp;
@@ -9212,7 +9278,7 @@ foreign_key_constraint
 	  class_name					/* 8 */
 	  opt_paren_attr_list				/* 9 */
 	  opt_ref_rule_list				/* 10 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(foreign_key_constraint, : FOREIGN KEY ~ '(' index_column_identifier_list ')' REFERENCES ~);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_CONSTRAINT);
 
@@ -9237,14 +9303,14 @@ foreign_key_constraint
 
 index_column_identifier_list
 	: index_column_identifier_list ',' index_column_identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_column_identifier_list, : index_column_identifier_list ',' index_column_identifier);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| index_column_identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_column_identifier_list, | index_column_identifier);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9254,7 +9320,7 @@ index_column_identifier_list
 
 index_column_identifier
 	: identifier opt_asc_or_desc
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_column_identifier, : identifier opt_asc_or_desc);
 
 			if ($2)
 			  {
@@ -9268,19 +9334,19 @@ index_column_identifier
 
 opt_asc_or_desc
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_asc_or_desc, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| ASC
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_asc_or_desc, | ASC);
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| DESC
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_asc_or_desc, | DESC);
 
 			$$ = 1;
 
@@ -9289,13 +9355,13 @@ opt_asc_or_desc
 
 opt_paren_attr_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_paren_attr_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| '(' identifier_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_paren_attr_list, | '(' identifier_list ')');
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9305,7 +9371,7 @@ opt_paren_attr_list
 
 opt_ref_rule_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_ref_rule_list, : );
 
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_RESTRICT),
@@ -9314,7 +9380,7 @@ opt_ref_rule_list
 
 		DBG_PRINT}}
 	| ref_rule_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_ref_rule_list, | ref_rule_list);
 
 			container_3 ctn = $1;
 			if (ctn.c1 == NULL)
@@ -9328,7 +9394,7 @@ opt_ref_rule_list
 
 ref_rule_list
 	: ref_rule_list ON_ DELETE_ CASCADE
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, : ref_rule_list ON_ DELETE_ CASCADE);
 
 			container_3 ctn = $1;
 			if (ctn.c1 != NULL)
@@ -9342,7 +9408,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ref_rule_list ON_ DELETE_ NO ACTION
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ DELETE_ NO ACTION);
 
 			container_3 ctn = $1;
 			if (ctn.c1 != NULL)
@@ -9356,7 +9422,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ref_rule_list ON_ DELETE_ RESTRICT
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ DELETE_ RESTRICT);
 
 			container_3 ctn = $1;
 			if (ctn.c1 != NULL)
@@ -9370,7 +9436,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ref_rule_list ON_ DELETE_ SET Null
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ DELETE_ SET Null);
 
 			container_3 ctn = $1;
 			if (ctn.c1 != NULL)
@@ -9384,7 +9450,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ref_rule_list ON_ UPDATE NO ACTION
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ UPDATE NO ACTION);
 
 			container_3 ctn = $1;
 			if (ctn.c2 != NULL)
@@ -9398,7 +9464,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ref_rule_list ON_ UPDATE RESTRICT
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ UPDATE RESTRICT);
 
 			container_3 ctn = $1;
 			if (ctn.c2 != NULL)
@@ -9412,7 +9478,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ref_rule_list ON_ UPDATE SET Null
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ UPDATE SET Null);
 
 			container_3 ctn = $1;
 			if (ctn.c2 != NULL)
@@ -9426,7 +9492,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ON_ DELETE_ CASCADE
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ CASCADE);
 
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_CASCADE), NULL, NULL);
@@ -9434,7 +9500,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ON_ DELETE_ NO ACTION
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ NO ACTION);
 
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_NO_ACTION), NULL, NULL);
@@ -9442,7 +9508,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ON_ DELETE_ RESTRICT
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ RESTRICT);
 
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_RESTRICT), NULL, NULL);
@@ -9450,7 +9516,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ON_ DELETE_ SET Null
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ SET Null);
 
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_SET_NULL), NULL, NULL);
@@ -9458,7 +9524,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ON_ UPDATE NO ACTION
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ UPDATE NO ACTION);
 
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, NULL, FROM_NUMBER (PT_RULE_NO_ACTION), NULL);
@@ -9466,7 +9532,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ON_ UPDATE RESTRICT
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ UPDATE RESTRICT);
 
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, NULL, FROM_NUMBER (PT_RULE_RESTRICT), NULL);
@@ -9474,7 +9540,7 @@ ref_rule_list
 
 		DBG_PRINT}}
 	| ON_ UPDATE SET Null
-		{{
+		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ UPDATE SET Null);
 
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, NULL, FROM_NUMBER (PT_RULE_SET_NULL), NULL);
@@ -9486,7 +9552,7 @@ ref_rule_list
 
 check_constraint
 	: CHECK '(' search_condition ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(check_constraint, : CHECK '(' search_condition ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_CONSTRAINT);
 
@@ -9506,7 +9572,7 @@ check_constraint
 /* bool_deferrable, deferrable value, bool_initially_deferred, initially_deferred value */
 constraint_attr
 	: NOT DEFERRABLE
-		{{
+		{{ DBG_TRACE_GRAMMAR(constraint_attr, : NOT DEFERRABLE);
 
 			container_4 ctn;
 			ctn.c1 = FROM_NUMBER (1);
@@ -9517,7 +9583,7 @@ constraint_attr
 
 		DBG_PRINT}}
 	| DEFERRABLE
-		{{
+		{{ DBG_TRACE_GRAMMAR(constraint_attr, | DEFERRABLE);
 
 			container_4 ctn;
 			ctn.c1 = FROM_NUMBER (1);
@@ -9528,7 +9594,7 @@ constraint_attr
 
 		DBG_PRINT}}
 	| INITIALLY DEFERRED
-		{{
+		{{ DBG_TRACE_GRAMMAR(constraint_attr, | INITIALLY DEFERRED);
 
 			container_4 ctn;
 			ctn.c1 = FROM_NUMBER (0);
@@ -9539,7 +9605,7 @@ constraint_attr
 
 		DBG_PRINT}}
 	| INITIALLY IMMEDIATE
-		{{
+		{{ DBG_TRACE_GRAMMAR(constraint_attr, | INITIALLY IMMEDIATE);
 
 			container_4 ctn;
 			ctn.c1 = FROM_NUMBER (0);
@@ -9553,14 +9619,14 @@ constraint_attr
 
 method_def_list
 	: method_def_list ',' method_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(method_def_list, : method_def_list ',' method_def);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| method_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(method_def_list, | method_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9574,7 +9640,7 @@ method_def
 	  opt_method_def_arg_list
 	  opt_data_type
 	  opt_function_identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(method_def, : opt_class identifier opt_method_def_arg_list opt_data_type opt_function_identifier);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_METHOD_DEF);
 			PT_MISC_TYPE t = PT_NORMAL;
@@ -9598,20 +9664,20 @@ method_def
 
 opt_method_def_arg_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_method_def_arg_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| '(' arg_type_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_method_def_arg_list, | '(' arg_type_list ')');
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| '(' ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_method_def_arg_list, | '(' ')');
 
 			$$ = NULL;
 
@@ -9620,14 +9686,14 @@ opt_method_def_arg_list
 
 arg_type_list
 	: arg_type_list ',' inout_data_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(arg_type_list, : arg_type_list ',' inout_data_type);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| inout_data_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(arg_type_list, | inout_data_type);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9637,7 +9703,7 @@ arg_type_list
 
 inout_data_type
 	: opt_in_out data_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(inout_data_type, : opt_in_out data_type);
 
 			PT_NODE *at = parser_new_node (this_parser, PT_DATA_TYPE);
 
@@ -9656,7 +9722,7 @@ inout_data_type
 
 opt_data_type
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_data_type, : );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_NONE), NULL);
@@ -9664,7 +9730,7 @@ opt_data_type
 
 		DBG_PRINT}}
 	| data_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_data_type, | data_type);
 
 			$$ = $1;
 
@@ -9673,13 +9739,13 @@ opt_data_type
 
 opt_function_identifier
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_function_identifier, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| FUNCTION identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_function_identifier, | FUNCTION identifier);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9689,14 +9755,14 @@ opt_function_identifier
 
 method_file_list
 	: method_file_list ',' file_path_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(method_file_list, : method_file_list ',' file_path_name);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| file_path_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(method_file_list, | file_path_name);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9706,7 +9772,7 @@ method_file_list
 
 file_path_name
 	: char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(file_path_name, : char_string_literal);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FILE_PATH);
 			if (node)
@@ -9719,7 +9785,7 @@ file_path_name
 
 opt_class_attr_def_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_class_attr_def_list, : );
 
 			$$ = NULL;
 
@@ -9729,7 +9795,7 @@ opt_class_attr_def_list
 		{ parser_attr_type = PT_META_ATTR; }
 	 '(' attr_def_list ')'
 		{ parser_attr_type = PT_NORMAL; }
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_class_attr_def_list, | CLASS ATTRIBUTE '(' attr_def_list ')');
 
 			$$ = $5;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9739,14 +9805,14 @@ opt_class_attr_def_list
 
 class_or_normal_attr_def_list
 	: class_or_normal_attr_def_list  ',' class_or_normal_attr_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def_list, : class_or_normal_attr_def_list  ',' class_or_normal_attr_def);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| class_or_normal_attr_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def_list, | class_or_normal_attr_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9756,14 +9822,14 @@ class_or_normal_attr_def_list
 
 class_or_normal_attr_def
 	: CLASS { parser_attr_type = PT_META_ATTR; } attr_def { parser_attr_type = PT_NORMAL; }
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def, : CLASS attr_def);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| attr_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def, | attr_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9773,14 +9839,14 @@ class_or_normal_attr_def
 
 view_attr_def_list
 	: view_attr_def_list ',' view_attr_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def, : view_attr_def_list ',' view_attr_def);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| view_attr_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def, | view_attr_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9790,14 +9856,14 @@ view_attr_def_list
 
 view_attr_def
 	: attr_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(view_attr_def, : attr_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| identifier opt_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(view_attr_def, | identifier opt_comment_spec);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_ATTR_DEF);
 
@@ -9817,14 +9883,14 @@ view_attr_def
 
 attr_def_list_with_commas
 	: attr_def_list_with_commas ','  attr_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_def_list_with_commas, : attr_def_list_with_commas ','  attr_def);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| attr_def ','  attr_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_def_list_with_commas, | attr_def ','  attr_def);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9834,14 +9900,14 @@ attr_def_list_with_commas
 
 attr_def_list
 	: attr_def_list ','  attr_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_def_list, : attr_def_list ','  attr_def);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| attr_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_def_list, | attr_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9851,21 +9917,21 @@ attr_def_list
 
 attr_def
 	: attr_constraint_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_def, : attr_constraint_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| attr_index_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_def, | attr_index_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| attr_def_one
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_def, | attr_def_one);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -9878,7 +9944,7 @@ attr_constraint_def
 	  of_unique_foreign_check
 	  opt_constraint_attr_list
 	  opt_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_constraint_def, : opt_constraint_opt_id of_unique_foreign_check opt_constraint_attr_list opt_comment_spec);
 
 			PT_NODE *name = $1;
 			PT_NODE *constraint = $2;
@@ -9943,7 +10009,7 @@ attr_index_def
 	  opt_where_clause          /* 4 */
 	  opt_comment_spec          /* 5 */
 	  opt_invisible             /* 6 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_index_def, : index_or_key identifier index_column_name_list opt_where_clause opt_comment_spec opt_invisible);
 			int arg_count = 0, prefix_col_count = 0;
 			PT_NODE* node = parser_new_node(this_parser,
 							PT_CREATE_INDEX);
@@ -10012,7 +10078,7 @@ attr_index_def
 attr_def_one
 	: identifier
 	  data_type
-		{{//attr_def_one : identifier
+		{{ DBG_TRACE_GRAMMAR(attr_def_one, : identifier data_type);
 
 			PT_NODE *dt;
 			PT_TYPE_ENUM typ;
@@ -10038,7 +10104,7 @@ attr_def_one
 		DBG_PRINT}}
 	  opt_constraint_list_and_opt_column_comment
 	  opt_attr_ordering_info
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_def_one, opt_constraint_list_and_opt_column_comment opt_attr_ordering_info);
 
 			PT_NODE *node = parser_get_attr_def_one ();
 			if (node != NULL && node->info.attr_def.attr_type != PT_SHARED)
@@ -10058,13 +10124,13 @@ attr_def_one
 
 opt_attr_ordering_info
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_attr_ordering_info, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| FIRST
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_attr_ordering_info, | FIRST);
 
 			PT_NODE *ord = parser_new_node (this_parser, PT_ATTR_ORDERING);
 			PARSER_SAVE_ERR_CONTEXT (ord, @$.buffer_pos)
@@ -10083,7 +10149,7 @@ opt_attr_ordering_info
 
 		DBG_PRINT}}
 	| AFTER identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_attr_ordering_info, | AFTER identifier);
 
 			PT_NODE *ord = parser_new_node (this_parser, PT_ATTR_ORDERING);
 			PARSER_SAVE_ERR_CONTEXT (ord, @$.buffer_pos)
@@ -10105,14 +10171,16 @@ opt_attr_ordering_info
 
 opt_constraint_list_and_opt_column_comment
 	: /* empty */
-		{ $$ = 0; }
+		{ DBG_TRACE_GRAMMAR(opt_constraint_list_and_opt_column_comment, : );
+                   $$ = 0; }
 	| constraint_list_and_column_comment
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(opt_constraint_list_and_opt_column_comment, | constraint_list_and_column_comment);
+                   $$ = $1; }
 	;
 
 constraint_list_and_column_comment
 	: constraint_list_and_column_comment column_constraint_and_comment_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(constraint_list_and_column_comment, : constraint_list_and_column_comment column_constraint_and_comment_def);
 			unsigned int mask = $1;
 			unsigned int new_bit = $2;
 			unsigned int merged = mask | new_bit;
@@ -10146,53 +10214,53 @@ constraint_list_and_column_comment
 			$$ = merged;
 		}}
 	| column_constraint_and_comment_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(constraint_list_and_column_comment, | column_constraint_and_comment_def);
 			$$ = $1;
 		}}
 	;
 
 column_constraint_and_comment_def
 	: column_unique_constraint_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, : column_unique_constraint_def);
 			$$ = COLUMN_CONSTRAINT_UNIQUE;
 		}}
 	| column_primary_constraint_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_primary_constraint_def);
 			$$ = COLUMN_CONSTRAINT_PRIMARY_KEY;
 		}}
 	| column_null_constraint_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_null_constraint_def);
 			$$ = COLUMN_CONSTRAINT_NULL;
 		}}
 	| column_other_constraint_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_other_constraint_def);
 			$$ = COLUMN_CONSTRAINT_OTHERS;
 		}}
 	| column_shared_constraint_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_shared_constraint_def);
 			$$ = COLUMN_CONSTRAINT_SHARED;
 		}}
 	| column_default_constraint_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_default_constraint_def);
 			$$ = COLUMN_CONSTRAINT_DEFAULT;
 		}}
 	| column_ai_constraint_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_ai_constraint_def);
 			$$ = COLUMN_CONSTRAINT_AUTO_INCREMENT;
 		}}
 	| column_comment_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_comment_def);
 			$$ = COLUMN_CONSTRAINT_COMMENT;
 		}}
 	| column_on_update_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_on_update_def);
 			$$ = COLUMN_CONSTRAINT_ON_UPDATE;
 		}}
 	;
 
 column_unique_constraint_def
 	: opt_constraint_id UNIQUE opt_key opt_constraint_attr_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_unique_constraint_def, : opt_constraint_id UNIQUE opt_key opt_constraint_attr_list);
 
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
@@ -10234,7 +10302,7 @@ column_unique_constraint_def
 
 column_primary_constraint_def
 	: opt_constraint_id PRIMARY KEY opt_constraint_attr_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_primary_constraint_def, : opt_constraint_id PRIMARY KEY opt_constraint_attr_list);
 
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
@@ -10268,7 +10336,7 @@ column_primary_constraint_def
 
 column_null_constraint_def
 	: opt_constraint_id Null opt_constraint_attr_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_null_constraint_def, : opt_constraint_id Null opt_constraint_attr_list);
 
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
@@ -10297,7 +10365,7 @@ column_null_constraint_def
 
 		DBG_PRINT}}
 	| opt_constraint_id NOT Null opt_constraint_attr_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_null_constraint_def, | opt_constraint_id NOT Null opt_constraint_attr_list);
 
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
@@ -10337,7 +10405,7 @@ column_null_constraint_def
 
 column_other_constraint_def
 	: opt_constraint_id CHECK '(' search_condition ')' opt_constraint_attr_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_other_constraint_def, : opt_constraint_id CHECK '(' search_condition ')' opt_constraint_attr_list);
 
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
@@ -10373,7 +10441,7 @@ column_other_constraint_def
 	  opt_paren_attr_list			/* 5 */
 	  opt_ref_rule_list			/* 6 */
 	  opt_constraint_attr_list		/* 7 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_other_constraint_def, | opt_constraint_id opt_foreign_key REFERENCES class_name ~);
 
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
@@ -10437,7 +10505,7 @@ opt_foreign_key
 
 column_ai_constraint_def
 	: AUTO_INCREMENT '(' integer_text ',' integer_text ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_ai_constraint_def, : AUTO_INCREMENT '(' integer_text ',' integer_text ')');
 
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *start_val = parser_new_node (this_parser, PT_VALUE);
@@ -10477,7 +10545,7 @@ column_ai_constraint_def
 
 		DBG_PRINT}}
 	| AUTO_INCREMENT
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_ai_constraint_def, | AUTO_INCREMENT);
 
 			PT_NODE *node = parser_get_attr_def_one ();
 
@@ -10497,7 +10565,7 @@ column_ai_constraint_def
 
 column_shared_constraint_def
 	: SHARED expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_shared_constraint_def, : SHARED expression_);
 			PT_NODE *attr_node;
 			PT_NODE *node = parser_new_node (this_parser, PT_DATA_DEFAULT);
 
@@ -10517,7 +10585,7 @@ column_shared_constraint_def
 
 column_on_update_def
 	: ON_ UPDATE expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_on_update_def, : ON_ UPDATE expression_);
 			DB_DEFAULT_EXPR_TYPE default_expr_type = DB_DEFAULT_NONE;
 			PT_NODE *attr_node = parser_get_attr_def_one ();
 			PT_NODE *on_update_default_value = $3;
@@ -10568,7 +10636,7 @@ column_on_update_def
 
 column_default_constraint_def
 	: DEFAULT expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_default_constraint_def, : DEFAULT expression_);
 
 			PT_NODE *attr_node;
 			PT_NODE *node = parser_new_node (this_parser, PT_DATA_DEFAULT);
@@ -10658,14 +10726,14 @@ column_default_constraint_def
 
 attr_def_comment_list
 	: attr_def_comment_list ',' attr_def_comment
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_def_comment_list, : attr_def_comment_list ',' attr_def_comment);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
 
 		DBG_PRINT}}
 	| attr_def_comment
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_def_comment_list, | attr_def_comment);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
@@ -10675,7 +10743,7 @@ attr_def_comment_list
 
 attr_def_comment
 	: identifier opt_equalsign comment_value
-		{{
+		{{ DBG_TRACE_GRAMMAR(attr_def_comment, : identifier opt_equalsign comment_value);
 
 			PT_NODE *attr_node = parser_new_node (this_parser, PT_ATTR_DEF);
 
@@ -10694,7 +10762,7 @@ attr_def_comment
 
 column_comment_def
 	: COMMENT comment_value
-		{{
+		{{ DBG_TRACE_GRAMMAR(column_comment_def, : COMMENT comment_value);
 
 			PT_NODE *attr_node;
 			attr_node = parser_get_attr_def_one ();
@@ -10705,14 +10773,14 @@ column_comment_def
 
 transaction_mode_list
 	: transaction_mode_list ',' transaction_mode			%dprec 1
-		{{
+		{{ DBG_TRACE_GRAMMAR(transaction_mode_list, : transaction_mode_list ',' transaction_mode);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| transaction_mode						%dprec 2
-		{{
+		{{ DBG_TRACE_GRAMMAR(transaction_mode_list, | transaction_mode);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -10722,7 +10790,7 @@ transaction_mode_list
 
 transaction_mode
 	: ISOLATION LEVEL isolation_level_spec ',' isolation_level_spec		%dprec 1
-		{{
+		{{ DBG_TRACE_GRAMMAR(transaction_mode, : ISOLATION LEVEL isolation_level_spec ',' isolation_level_spec);
 
 			PT_NODE *tm = parser_new_node (this_parser, PT_ISOLATION_LVL);
 			PT_NODE *is = parser_new_node (this_parser, PT_ISOLATION_LVL);
@@ -10802,7 +10870,7 @@ transaction_mode
 
 		DBG_PRINT}}
 	| ISOLATION LEVEL isolation_level_spec			%dprec 2
-		{{
+		{{ DBG_TRACE_GRAMMAR(transaction_mode, | ISOLATION LEVEL isolation_level_spec);
 
 			PT_NODE *tm = parser_new_node (this_parser, PT_ISOLATION_LVL);
 			int async_ws_or_error = (int) TO_NUMBER (CONTAINER_AT_3 ($3));
@@ -10828,7 +10896,7 @@ transaction_mode
 
 		DBG_PRINT}}
 	| LOCK_ TIMEOUT timeout_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(transaction_mode, | LOCK_ TIMEOUT timeout_spec);
 
 			PT_NODE *tm = parser_new_node (this_parser, PT_TIMEOUT);
 
@@ -10847,7 +10915,7 @@ transaction_mode
 /* container order : level, schema, instances, async_ws */
 isolation_level_spec
 	: expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, : expression_);
 
 			container_4 ctn;
 			SET_CONTAINER_4 (ctn, $1, FROM_NUMBER (PT_NO_ISOLATION_LEVEL),
@@ -10856,7 +10924,7 @@ isolation_level_spec
 
 		DBG_PRINT}}
 	| ASYNC WORKSPACE
-		{{
+		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | ASYNC WORKSPACE);
 
 			container_4 ctn;
 			SET_CONTAINER_4 (ctn, NULL, FROM_NUMBER (PT_NO_ISOLATION_LEVEL),
@@ -10865,7 +10933,7 @@ isolation_level_spec
 
 		DBG_PRINT}}
 	| SERIALIZABLE
-		{{
+		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | SERIALIZABLE);
 
 			container_4 ctn;
 			SET_CONTAINER_4 (ctn, NULL, FROM_NUMBER (PT_SERIALIZABLE),
@@ -10874,7 +10942,7 @@ isolation_level_spec
 
 		DBG_PRINT}}
 	| CURSOR STABILITY
-		{{
+		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | CURSOR STABILITY);
 
 			container_4 ctn;
 			SET_CONTAINER_4 (ctn, NULL, FROM_NUMBER (PT_NO_ISOLATION_LEVEL),
@@ -10883,7 +10951,7 @@ isolation_level_spec
 
 		DBG_PRINT}}
 	| isolation_level_name								%dprec 1
-		{{
+		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name);
 
 			container_4 ctn;
 			PT_MISC_TYPE schema = PT_REPEATABLE_READ;
@@ -10896,7 +10964,7 @@ isolation_level_spec
 
 		DBG_PRINT}}
 	| isolation_level_name of_schema_class 						%dprec 1
-		{{
+		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name of_schema_class);
 
 			container_4 ctn;
 			PT_MISC_TYPE schema = 0;
@@ -10913,7 +10981,7 @@ isolation_level_spec
 
 		DBG_PRINT}}
 	| isolation_level_name INSTANCES						%dprec 1
-		{{
+		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name INSTANCES);
 
 			container_4 ctn;
 			PT_MISC_TYPE schema = 0;
@@ -10928,7 +10996,7 @@ isolation_level_spec
 
 		DBG_PRINT}}
 	| isolation_level_name of_schema_class ',' isolation_level_name INSTANCES	%dprec 10
-		{{
+		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name of_schema_class ',' isolation_level_name INSTANCES);
 
 			container_4 ctn;
 			PT_MISC_TYPE schema = 0;
@@ -10944,7 +11012,7 @@ isolation_level_spec
 
 		DBG_PRINT}}
 	| isolation_level_name INSTANCES ',' isolation_level_name of_schema_class	%dprec 10
-		{{
+		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name INSTANCES ',' isolation_level_name of_schema_class);
 			container_4 ctn;
 			PT_MISC_TYPE schema = 0;
 			PT_MISC_TYPE level = 0;
@@ -10967,13 +11035,13 @@ of_schema_class
 
 isolation_level_name
 	: REPEATABLE READ
-		{{
+		{{ DBG_TRACE_GRAMMAR(isolation_level_name, : REPEATABLE READ); 
 
 			$$ = PT_REPEATABLE_READ;
 
 		DBG_PRINT}}
 	| READ COMMITTED
-		{{
+		{{ DBG_TRACE_GRAMMAR(isolation_level_name, | READ COMMITTED); 
 
 			$$ = PT_READ_COMMITTED;
 
@@ -10982,7 +11050,7 @@ isolation_level_name
 
 timeout_spec
 	: INFINITE_
-		{{
+		{{ DBG_TRACE_GRAMMAR(timeout_spec, : INFINITE_);
 
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -10997,7 +11065,7 @@ timeout_spec
 
 		DBG_PRINT}}
 	| OFF_
-		{{
+		{{ DBG_TRACE_GRAMMAR(timeout_spec, | OFF_);
 
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -11012,28 +11080,28 @@ timeout_spec
 
 		DBG_PRINT}}
 	| unsigned_integer
-		{{
+		{{ DBG_TRACE_GRAMMAR(timeout_spec, | unsigned_integer);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| unsigned_real
-		{{
+		{{ DBG_TRACE_GRAMMAR(timeout_spec, | unsigned_real);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| param_
-		{{
+		{{ DBG_TRACE_GRAMMAR(timeout_spec, | param_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| host_param_input
-		{{
+		{{ DBG_TRACE_GRAMMAR(timeout_spec, | host_param_input);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -11044,7 +11112,7 @@ timeout_spec
 
 transaction_stmt
 	: COMMIT opt_work RETAIN LOCK_
-		{{
+		{{ DBG_TRACE_GRAMMAR(transaction_stmt, : COMMIT opt_work RETAIN LOCK_);
 
 			PT_NODE *comm = parser_new_node (this_parser, PT_COMMIT_WORK);
 
@@ -11058,7 +11126,7 @@ transaction_stmt
 
 		DBG_PRINT}}
 	| COMMIT opt_work
-		{{
+		{{ DBG_TRACE_GRAMMAR(timeout_spec, | COMMIT opt_work);
 
 			PT_NODE *comm = parser_new_node (this_parser, PT_COMMIT_WORK);
 			$$ = comm;
@@ -11066,7 +11134,7 @@ transaction_stmt
 
 		DBG_PRINT}}
 	| ROLLBACK opt_work TO opt_savepoint expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(timeout_spec, | ROLLBACK opt_work TO opt_savepoint expression_);
 
 			PT_NODE *roll = parser_new_node (this_parser, PT_ROLLBACK_WORK);
 
@@ -11080,7 +11148,7 @@ transaction_stmt
 
 		DBG_PRINT}}
 	| ROLLBACK opt_work
-		{{
+		{{ DBG_TRACE_GRAMMAR(timeout_spec, | ROLLBACK opt_work);
 
 			PT_NODE *roll = parser_new_node (this_parser, PT_ROLLBACK_WORK);
 			$$ = roll;
@@ -11088,7 +11156,7 @@ transaction_stmt
 
 		DBG_PRINT}}
 	| SAVEPOINT expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(timeout_spec, | expression_);
 
 			PT_NODE *svpt = parser_new_node (this_parser, PT_SAVEPOINT);
 
@@ -11121,7 +11189,7 @@ opt_to
 
 evaluate_stmt
 	: EVALUATE expression_ into_clause_opt
-		{{
+		{{ DBG_TRACE_GRAMMAR(evaluate_stmt, : EVALUATE expression_ into_clause_opt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_EVALUATE);
 
@@ -11139,7 +11207,7 @@ evaluate_stmt
 
 prepare_stmt
 	: PREPARE identifier FROM char_string
-		{{
+		{{ DBG_TRACE_GRAMMAR(prepare_stmt, : PREPARE identifier FROM char_string);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_PREPARE_STATEMENT);
 
@@ -11157,7 +11225,7 @@ prepare_stmt
 
 execute_stmt
 	: EXECUTE identifier opt_using
-		{{
+		{{ DBG_TRACE_GRAMMAR(execute_stmt, : EXECUTE identifier opt_using);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_EXECUTE_PREPARE);
 
@@ -11177,7 +11245,8 @@ execute_stmt
 
 opt_using
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_using, : );
+
 
 			$$ = NULL;
 
@@ -11186,7 +11255,7 @@ opt_using
 		{ parser_save_and_set_hvar (0); }
 		execute_using_list
 		{ parser_restore_hvar (); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_using, | USING execute_using_list);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -11196,13 +11265,13 @@ opt_using
 
 opt_status
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_status, : );
 
 			$$ = PT_MISC_DUMMY;
 
 		DBG_PRINT}}
 	| trigger_status
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_status, | trigger_status);
 
 			$$ = $1;
 
@@ -11211,13 +11280,13 @@ opt_status
 
 trigger_status
 	: STATUS ACTIVE
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_status, : STATUS ACTIVE);
 
 			$$ = PT_ACTIVE;
 
 		DBG_PRINT}}
 	| STATUS INACTIVE
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_status, | STATUS INACTIVE);
 
 			$$ = PT_INACTIVE;
 
@@ -11226,13 +11295,13 @@ trigger_status
 
 opt_priority
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_priority, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| trigger_priority
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_priority, | trigger_priority);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -11242,7 +11311,7 @@ opt_priority
 
 trigger_priority
 	: PRIORITY unsigned_real
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_priority, : PRIORITY unsigned_real);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -11252,13 +11321,13 @@ trigger_priority
 
 opt_if_trigger_condition
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_if_trigger_condition, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| IF trigger_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_if_trigger_condition, |   IF trigger_condition);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -11268,19 +11337,19 @@ opt_if_trigger_condition
 
 trigger_time
 	: BEFORE
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_time, : BEFORE);
 
 			$$ = PT_BEFORE;
 
 		DBG_PRINT}}
 	| AFTER
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_time, | AFTER);
 
 			$$ = PT_AFTER;
 
 		DBG_PRINT}}
 	| DEFERRED
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_time, | DEFERRED);
 
 			$$ = PT_DEFERRED;
 
@@ -11289,19 +11358,19 @@ trigger_time
 
 opt_trigger_action_time
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_trigger_action_time, : );
 
 			$$ = PT_MISC_DUMMY;
 
 		DBG_PRINT}}
 	| AFTER
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_trigger_action_time, | AFTER);
 
 			$$ = PT_AFTER;
 
 		DBG_PRINT}}
 	| DEFERRED
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_trigger_action_time, | DEFERRED);
 
 			$$ = PT_DEFERRED;
 
@@ -11310,7 +11379,7 @@ opt_trigger_action_time
 
 event_spec
 	: event_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(event_spec, : event_type);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_EVENT_SPEC);
 
@@ -11324,7 +11393,7 @@ event_spec
 
 		DBG_PRINT}}
 	| event_type event_target
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_trigger_aevent_specction_time, | event_type event_target);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_EVENT_SPEC);
 
@@ -11342,49 +11411,49 @@ event_spec
 
 event_type
 	: INSERT
-		{{
+		{{ DBG_TRACE_GRAMMAR(event_type, : INSERT);
 
 			$$ = PT_EV_INSERT;
 
 		DBG_PRINT}}
 	| STATEMENT INSERT
-		{{
+		{{ DBG_TRACE_GRAMMAR(event_type, | STATEMENT INSERT);
 
 			$$ = PT_EV_STMT_INSERT;
 
 		DBG_PRINT}}
 	| DELETE_
-		{{
+		{{ DBG_TRACE_GRAMMAR(event_type, | DELETE_);
 
 			$$ = PT_EV_DELETE;
 
 		DBG_PRINT}}
 	| STATEMENT DELETE_
-		{{
+		{{ DBG_TRACE_GRAMMAR(event_type, | STATEMENT DELETE_);
 
 			$$ = PT_EV_STMT_DELETE;
 
 		DBG_PRINT}}
 	| UPDATE
-		{{
+		{{ DBG_TRACE_GRAMMAR(event_type, | UPDATE);
 
 			$$ = PT_EV_UPDATE;
 
 		DBG_PRINT}}
 	| STATEMENT UPDATE
-		{{
+		{{ DBG_TRACE_GRAMMAR(event_type, | STATEMENT UPDATE);
 
 			$$ = PT_EV_STMT_UPDATE;
 
 		DBG_PRINT}}
 	| COMMIT
-		{{
+		{{ DBG_TRACE_GRAMMAR(event_type, | COMMIT);
 
 			$$ = PT_EV_COMMIT;
 
 		DBG_PRINT}}
 	| ROLLBACK
-		{{
+		{{ DBG_TRACE_GRAMMAR(event_type, | ROLLBACK);
 
 			$$ = PT_EV_ROLLBACK;
 
@@ -11393,7 +11462,7 @@ event_type
 
 event_target
 	: ON_ identifier '(' identifier ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(event_target, : ON_ identifier '(' identifier ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_EVENT_TARGET);
 
@@ -11408,7 +11477,7 @@ event_target
 
 		DBG_PRINT}}
 	| ON_ identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(event_target, | ON_ identifier);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_EVENT_TARGET);
 
@@ -11425,14 +11494,14 @@ event_target
 
 trigger_condition
 	: search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_condition, : search_condition);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| call_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_condition, | call_stmt);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -11442,7 +11511,7 @@ trigger_condition
 
 trigger_action
 	: REJECT_
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_action, : REJECT_);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
@@ -11456,7 +11525,7 @@ trigger_action
 
 		DBG_PRINT}}
 	| INVALIDATE TRANSACTION
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_action, | INVALIDATE TRANSACTION);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
@@ -11470,7 +11539,7 @@ trigger_action
 
 		DBG_PRINT}}
 	| PRINT char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_action, | PRINT char_string_literal);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
@@ -11485,7 +11554,7 @@ trigger_action
 
 		DBG_PRINT}}
 	| evaluate_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_action, | evaluate_stmt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
@@ -11500,7 +11569,7 @@ trigger_action
 
 		DBG_PRINT}}
 	| insert_or_replace_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_action, | insert_or_replace_stmt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
@@ -11515,7 +11584,7 @@ trigger_action
 
 		DBG_PRINT}}
 	| update_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_action, | update_stmt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
@@ -11530,7 +11599,7 @@ trigger_action
 
 		DBG_PRINT}}
 	| delete_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_action, | delete_stmt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
@@ -11545,7 +11614,7 @@ trigger_action
 
 		DBG_PRINT}}
 	| call_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_action, | call_stmt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
@@ -11560,7 +11629,7 @@ trigger_action
 
 		DBG_PRINT}}
 	| merge_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_action, | merge_stmt);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
@@ -11578,7 +11647,8 @@ trigger_action
 
 trigger_spec_list
 	: identifier_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_spec_list, : identifier_list);
+
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_SPEC_LIST);
 
@@ -11592,7 +11662,7 @@ trigger_spec_list
 
 		DBG_PRINT}}
 	| ALL TRIGGERS
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_spec_list, | ALL TRIGGERS);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_SPEC_LIST);
 
@@ -11609,7 +11679,7 @@ trigger_spec_list
 
 trigger_status_or_priority_or_change_owner
 	: trigger_status
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_status_or_priority_or_change_owner, : trigger_status);
 
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER ($1), NULL, NULL);
@@ -11617,7 +11687,7 @@ trigger_status_or_priority_or_change_owner
 
 		DBG_PRINT}}
 	| trigger_priority
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_status_or_priority_or_change_owner, | trigger_priority);
 
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_MISC_DUMMY), $1, NULL);
@@ -11625,7 +11695,7 @@ trigger_status_or_priority_or_change_owner
 
 		DBG_PRINT}}
 	| OWNER TO identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(trigger_status_or_priority_or_change_owner, | OWNER TO identifier);
 
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_MISC_DUMMY), NULL, $3);
@@ -11641,7 +11711,7 @@ opt_maximum
 
 trace_spec
 	: ON_
-		{{
+		{{ DBG_TRACE_GRAMMAR(trace_spec, : ON_);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 
@@ -11656,7 +11726,7 @@ trace_spec
 
 		DBG_PRINT}}
 	| OFF_
-		{{
+		{{ DBG_TRACE_GRAMMAR(trace_spec, | OFF_);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 
@@ -11671,21 +11741,21 @@ trace_spec
 
 		DBG_PRINT}}
 	| unsigned_integer
-		{{
+		{{ DBG_TRACE_GRAMMAR(trace_spec, | unsigned_integer);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| param_
-		{{
+		{{ DBG_TRACE_GRAMMAR(trace_spec, | param_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| host_param_input
-		{{
+		{{ DBG_TRACE_GRAMMAR(trace_spec, | host_param_input);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -11695,21 +11765,21 @@ trace_spec
 
 depth_spec
 	: unsigned_integer
-		{{
+		{{ DBG_TRACE_GRAMMAR(depth_spec, : unsigned_integer);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| param_
-		{{
+		{{ DBG_TRACE_GRAMMAR(depth_spec, | param_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| host_param_input
-		{{
+		{{ DBG_TRACE_GRAMMAR(depth_spec, | host_param_input);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -11719,7 +11789,7 @@ depth_spec
 
 serial_start
 	: START_ WITH integer_text
-		{{
+		{{ DBG_TRACE_GRAMMAR(serial_start, : START_ WITH integer_text);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -11739,7 +11809,7 @@ serial_start
 
 serial_increment
 	: INCREMENT BY integer_text
-		{{
+		{{ DBG_TRACE_GRAMMAR(serial_increment, : INCREMENT BY integer_text);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -11760,7 +11830,7 @@ serial_increment
 
 serial_min
 	: MINVALUE integer_text
-		{{
+		{{ DBG_TRACE_GRAMMAR(serial_min, : MINVALUE integer_text);
 
 			container_2 ctn;
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
@@ -11778,7 +11848,7 @@ serial_min
 
 		DBG_PRINT}}
 	| NOMINVALUE
-		{{
+		{{ DBG_TRACE_GRAMMAR(serial_min, | NOMINVALUE);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, FROM_NUMBER (1));
@@ -11789,7 +11859,7 @@ serial_min
 
 serial_max
 	: MAXVALUE integer_text
-		{{
+		{{ DBG_TRACE_GRAMMAR(serial_max, : MAXVALUE integer_text);
 
 			container_2 ctn;
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
@@ -11807,7 +11877,7 @@ serial_max
 
 		DBG_PRINT}}
 	| NOMAXVALUE
-		{{
+		{{ DBG_TRACE_GRAMMAR(serial_max, | NOMAXVALUE);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, FROM_NUMBER (1));
@@ -11818,7 +11888,7 @@ serial_max
 
 of_cycle_nocycle
 	: CYCLE
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_cycle_nocycle, : CYCLE);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), FROM_NUMBER (0));
@@ -11826,7 +11896,7 @@ of_cycle_nocycle
 
 		DBG_PRINT}}
 	| NOCYCLE
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_cycle_nocycle, | NOCYCLE);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), FROM_NUMBER (1));
@@ -11837,7 +11907,7 @@ of_cycle_nocycle
 
 of_cached_num
 	: CACHE unsigned_int32
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_cached_num, : CACHE unsigned_int32);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, FROM_NUMBER (0));
@@ -11845,7 +11915,7 @@ of_cached_num
 
 		DBG_PRINT}}
 	| NOCACHE
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_cached_num, | NOCACHE);
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, FROM_NUMBER (1));
 			$$ = ctn;
@@ -11855,13 +11925,13 @@ of_cached_num
 
 integer_text
 	: opt_plus UNSIGNED_INTEGER
-		{{
+		{{ DBG_TRACE_GRAMMAR(integer_text, : opt_plus UNSIGNED_INTEGER);
 
 			$$ = $2;
 
 		DBG_PRINT}}
 	| '-' UNSIGNED_INTEGER
-		{{
+		{{ DBG_TRACE_GRAMMAR(integer_text, | '-' UNSIGNED_INTEGER);
 
 			$$ = pt_append_string (this_parser, (char *) "-", $2);
 
@@ -11870,7 +11940,7 @@ integer_text
 
 uint_text
 	: UNSIGNED_INTEGER
-		{{
+		{{ DBG_TRACE_GRAMMAR(uint_text, : UNSIGNED_INTEGER);
 
 			$$ = $1;
 
@@ -11884,19 +11954,19 @@ opt_plus
 
 opt_of_data_type_cursor
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_data_type_cursor, : );
 
 			$$ = PT_TYPE_NONE;
 
 		DBG_PRINT}}
 	| data_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_data_type_cursor, | data_type);
 
 			$$ = (int) TO_NUMBER (CONTAINER_AT_0 ($1));
 
 		DBG_PRINT}}
 	| CURSOR
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_data_type_cursor, | CURSOR);
 
 			$$ = PT_TYPE_RESULTSET;
 
@@ -11911,13 +11981,13 @@ opt_of_is_as
 
 opt_sp_param_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_sp_param_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| sp_param_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_sp_param_list, | sp_param_list);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -11927,14 +11997,14 @@ opt_sp_param_list
 
 sp_param_list
 	: sp_param_list ',' sp_param_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(sp_param_list, : sp_param_list ',' sp_param_def); 
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| sp_param_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(sp_param_list, | sp_param_def); 
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -11947,7 +12017,7 @@ sp_param_def
 	  opt_sp_in_out
 	  data_type
 	  opt_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(sp_param_def, : identifier opt_sp_in_out data_type opt_comment_spec); 
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SP_PARAMETERS);
 
@@ -11968,7 +12038,7 @@ sp_param_def
 	  opt_sp_in_out
 	  CURSOR
 	  opt_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(sp_param_def, | identifier opt_sp_in_out CURSOR opt_comment_spec); 
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SP_PARAMETERS);
 
@@ -11989,13 +12059,13 @@ sp_param_def
 
 opt_sp_in_out
 	: opt_in_out
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_sp_in_out, : opt_in_out); 
 
 			$$ = $1;
 
 		DBG_PRINT}}
 	| IN_ OUT_
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_sp_in_out, | IN_ OUT_); 
 
 			$$ = PT_INPUTOUTPUT;
 
@@ -12005,7 +12075,7 @@ opt_sp_in_out
 esql_query_stmt
 	: 	{ parser_select_level++; }
 	  csql_query_select_has_no_with_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(esql_query_stmt, : csql_query_select_has_no_with_clause); 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_select_level--;
@@ -12031,14 +12101,14 @@ csql_query
 
 		DBG_PRINT}}
 	  select_expression_opt_with
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query, : select_expression_opt_with);
 
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
 
 		DBG_PRINT}}
 	  opt_orderby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query, opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 
@@ -12092,7 +12162,7 @@ csql_query
 		DBG_PRINT}}
 	opt_select_limit_clause
 	opt_for_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query, opt_select_limit_clause opt_for_update_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
@@ -12119,14 +12189,14 @@ csql_query_select_has_no_with_clause
 
 		DBG_PRINT}}
 	  select_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_select_has_no_with_clause, : select_expression);
 
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
 
 		DBG_PRINT}}
 	  opt_orderby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_select_has_no_with_clause, opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 
@@ -12180,7 +12250,7 @@ csql_query_select_has_no_with_clause
 		DBG_PRINT}}
 	opt_select_limit_clause
 	opt_for_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_select_has_no_with_clause, opt_select_limit_clause opt_for_update_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
@@ -12207,14 +12277,14 @@ csql_query_without_subquery_and_with_clause
 
 		DBG_PRINT}}
 	  select_expression_without_subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_subquery_and_with_clause, : select_expression_without_subquery);
 
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
 
 		DBG_PRINT}}
 	  opt_orderby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_subquery_and_with_clause, opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 
@@ -12268,7 +12338,7 @@ csql_query_without_subquery_and_with_clause
 		DBG_PRINT}}
 	opt_select_limit_clause
 	opt_for_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_subquery_and_with_clause, opt_select_limit_clause opt_for_update_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
@@ -12295,14 +12365,14 @@ csql_query_without_values_query
 
 		DBG_PRINT}}
 	  select_expression_without_values_query
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query, : select_expression_without_values_query);
 
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
 
 		DBG_PRINT}}
 	  opt_orderby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query, opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 
@@ -12356,7 +12426,7 @@ csql_query_without_values_query
 		DBG_PRINT}}
 	opt_select_limit_clause
 	opt_for_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query, opt_select_limit_clause	opt_for_update_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
@@ -12383,14 +12453,14 @@ csql_query_without_values_query_no_with_clause
 
 		DBG_PRINT}}
 	  select_expression_without_values_query_no_with_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query_no_with_clause, : select_expression_without_values_query_no_with_clause);
 
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
 
 		DBG_PRINT}}
 	  opt_orderby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query_no_with_clause, opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 
@@ -12444,7 +12514,7 @@ csql_query_without_values_query_no_with_clause
 		DBG_PRINT}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query_no_with_clause, opt_select_limit_clause opt_for_update_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
@@ -12471,14 +12541,14 @@ csql_query_without_values_and_single_subquery
 
 		DBG_PRINT}}
 	  select_expression_without_values_and_single_subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_and_single_subquery, : select_expression_without_values_and_single_subquery);
 
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
 
 		DBG_PRINT}}
 	  opt_orderby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_and_single_subquery,  opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 
@@ -12531,7 +12601,7 @@ csql_query_without_values_and_single_subquery
 		DBG_PRINT}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_and_single_subquery,  opt_select_limit_clause opt_for_update_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
@@ -12544,7 +12614,7 @@ csql_query_without_values_and_single_subquery
 select_expression_opt_with
 	: opt_with_clause
 	  select_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_opt_with,  opt_with_clause select_expression);
 
 			PT_NODE *with_clause = $1;
 			PT_NODE *stmt = $2;
@@ -12560,13 +12630,13 @@ select_expression_opt_with
 
 select_expression_without_subquery
 	: select_expression_without_subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_subquery, : select_expression_without_subquery);
         		PT_NODE *node = $1;
 			parser_push_orderby_node (node);
 	        }}
 
 	  opt_orderby_clause
-	        {{
+	        {{ DBG_TRACE_GRAMMAR(select_expression_without_subquery,  opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 
@@ -12608,7 +12678,7 @@ select_expression_without_subquery
 
           opt_select_limit_clause
           opt_for_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_subquery,  opt_select_limit_clause opt_for_update_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$<node>$ = node;
@@ -12617,7 +12687,7 @@ select_expression_without_subquery
                 DBG_PRINT}}
 
           table_op select_or_values_query
-                {{
+                {{ DBG_TRACE_GRAMMAR(select_expression_without_subquery,  select_or_values_query);
 
 			PT_NODE *stmt = $8;
 			PT_NODE *arg1 = $1;
@@ -12645,7 +12715,7 @@ select_expression_without_subquery
 
 		DBG_PRINT}}
 	| select_or_values_query
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_subquery, | select_or_values_query);
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
@@ -12654,12 +12724,12 @@ select_expression_without_subquery
 
 select_expression
 	: select_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression, : select_expression);
 			PT_NODE *node = $1;
 			parser_push_orderby_node (node);
 		}}
 	  opt_orderby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression, opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 
@@ -12701,7 +12771,7 @@ select_expression
 		DBG_PRINT}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression, opt_select_limit_clause opt_for_update_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$<node>$ = node;
@@ -12709,7 +12779,7 @@ select_expression
 
 		DBG_PRINT}}
 	  table_op select_or_subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression, table_op select_or_subquery);
 
 			PT_NODE *stmt = $8;
 			PT_NODE *arg1 = $1;
@@ -12736,7 +12806,7 @@ select_expression
 
 		DBG_PRINT}}
 	| select_or_subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression, | select_or_subquery);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -12746,12 +12816,12 @@ select_expression
 
 select_expression_without_values_query
 	: select_expression_without_values_query
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query, : select_expression_without_values_query);
 			PT_NODE *node = $1;
 			parser_push_orderby_node (node);
 		}}
 	  opt_orderby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query, opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 
@@ -12792,7 +12862,7 @@ select_expression_without_values_query
 		DBG_PRINT}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query, opt_select_limit_clause opt_for_update_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$<node>$ = node;
@@ -12800,7 +12870,7 @@ select_expression_without_values_query
 
 		DBG_PRINT}}
 	  table_op select_or_subquery_without_values_query
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query, table_op select_or_subquery_without_values_query);
 
 			PT_NODE *stmt = $8;
 			PT_NODE *arg1 = $1;
@@ -12827,7 +12897,7 @@ select_expression_without_values_query
 
 		DBG_PRINT}}
 	| select_or_subquery_without_values_query
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query, | select_or_subquery_without_values_query);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -12837,12 +12907,12 @@ select_expression_without_values_query
 
 select_expression_without_values_query_no_with_clause
 	: select_expression_without_values_query_no_with_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, : select_expression_without_values_query_no_with_clause);
 			PT_NODE *node = $1;
 			parser_push_orderby_node (node);
 		}}
 	  opt_orderby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 
@@ -12883,7 +12953,7 @@ select_expression_without_values_query_no_with_clause
 		DBG_PRINT}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, opt_select_limit_clause opt_for_update_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$<node>$ = node;
@@ -12891,7 +12961,7 @@ select_expression_without_values_query_no_with_clause
 
 		DBG_PRINT}}
 	  table_op select_or_subquery_without_values_query_no_with_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, table_op select_or_subquery_without_values_query_no_with_clause);
 
 			PT_NODE *stmt = $8;
 			PT_NODE *arg1 = $1;
@@ -12918,7 +12988,7 @@ select_expression_without_values_query_no_with_clause
 
 		DBG_PRINT}}
 	| select_or_subquery_without_values_query_no_with_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, | select_or_subquery_without_values_query_no_with_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -12928,12 +12998,12 @@ select_expression_without_values_query_no_with_clause
 
 select_expression_without_values_and_single_subquery
 	: select_expression_without_values_query_no_with_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, : select_expression_without_values_query_no_with_clause);
 			PT_NODE *node = $1;
 			parser_push_orderby_node (node);
 		}}
 	  opt_orderby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 
@@ -12975,7 +13045,7 @@ select_expression_without_values_and_single_subquery
 		DBG_PRINT}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, opt_select_limit_clause opt_for_update_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$<node>$ = node;
@@ -12983,7 +13053,7 @@ select_expression_without_values_and_single_subquery
 
 		DBG_PRINT}}
 	  table_op select_or_subquery_without_values_query_no_with_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, table_op select_or_subquery_without_values_query_no_with_clause);
 
 			PT_NODE *stmt = $8;
 			PT_NODE *arg1 = $1;
@@ -13010,7 +13080,7 @@ select_expression_without_values_and_single_subquery
 
 		DBG_PRINT}}
 	| select_or_nested_values_query
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, | select_or_nested_values_query);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -13020,7 +13090,7 @@ select_expression_without_values_and_single_subquery
 
 table_op
 	: Union all_distinct
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_op, : Union all_distinct);
 			PT_MISC_TYPE isAll = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_UNION);
 			if (node)
@@ -13035,7 +13105,7 @@ table_op
 
 		DBG_PRINT}}
 	| DIFFERENCE_ all_distinct
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_op, | DIFFERENCE_ all_distinct);
 
 			PT_MISC_TYPE isAll = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_DIFFERENCE);
@@ -13051,7 +13121,7 @@ table_op
 
 		DBG_PRINT}}
 	| EXCEPT all_distinct
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_op, | EXCEPT all_distinct);
 
 			PT_MISC_TYPE isAll = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_DIFFERENCE);
@@ -13067,7 +13137,7 @@ table_op
 
 		DBG_PRINT}}
 	| INTERSECTION all_distinct
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_op, | INTERSECTION all_distinct);
 
 			PT_MISC_TYPE isAll = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_INTERSECTION);
@@ -13083,7 +13153,7 @@ table_op
 
 		DBG_PRINT}}
 	| INTERSECT all_distinct
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_op, | INTERSECT all_distinct);
 
 			PT_MISC_TYPE isAll = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_INTERSECTION);
@@ -13102,21 +13172,21 @@ table_op
 
 select_or_subquery
 	: select_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_or_subquery, : select_stmt);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_or_subquery, | subquery);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| values_query
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_or_subquery, | values_query);
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
@@ -13124,12 +13194,12 @@ select_or_subquery
 
 select_or_values_query
 	: values_query
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_or_values_query, : values_query);
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
 	| select_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_or_values_query, | select_stmt);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -13139,14 +13209,14 @@ select_or_values_query
 
 select_or_subquery_without_values_query
 	: select_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_or_subquery_without_values_query, : select_stmt);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_or_subquery_without_values_query, | subquery);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -13156,14 +13226,14 @@ select_or_subquery_without_values_query
 
 select_or_subquery_without_values_query_no_with_clause
 	: select_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_or_subquery_without_values_query_no_with_clause, : select_stmt);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| subquery_without_subquery_and_with_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_or_subquery_without_values_query_no_with_clause, | subquery_without_subquery_and_with_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -13173,14 +13243,14 @@ select_or_subquery_without_values_query_no_with_clause
 
 select_or_nested_values_query
 	: select_stmt
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_or_nested_values_query, : select_stmt);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| '(' values_query ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_or_nested_values_query, | '(' values_query ')');
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
@@ -13188,7 +13258,7 @@ select_or_nested_values_query
 
 values_query
 	: of_value_values
-		{{
+		{{ DBG_TRACE_GRAMMAR(values_query, : of_value_values);
 			PT_NODE *node;
 			parser_save_found_Oracle_outer ();
 			if (parser_select_level >= 0)
@@ -13208,7 +13278,7 @@ values_query
 			  parser_push_hint_node (node);
 		DBG_PRINT}}
 		values_expression
-			{{
+			{{ DBG_TRACE_GRAMMAR(values_query, values_expression);
 				/* $3 node of type PT_NODE_LIST */
 				PT_NODE *n;
 				PT_NODE *node = parser_pop_select_stmt_node ();
@@ -13255,7 +13325,7 @@ values_query
 
 values_expression
 	: values_expression ',' values_expr_item
-		{{
+		{{ DBG_TRACE_GRAMMAR(values_expression, : values_expression ',' values_expr_item);
 			PT_NODE *node1 = $1;
 			PT_NODE *node2 = $3;
 			parser_make_link (node1, node2);
@@ -13263,14 +13333,14 @@ values_expression
 			$$ = node1;
 		DBG_PRINT}}
 	| values_expr_item
-		{{
+		{{ DBG_TRACE_GRAMMAR(values_expression, | values_expr_item);
 			$$ = $1;
 		DBG_PRINT}}
 	;
 
 values_expr_item
 	: '(' alias_enabled_expression_list_top ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(values_expr_item, : '(' alias_enabled_expression_list_top ')');
 			PT_NODE *node_value = $2;
 			PT_NODE *node_tmp = $2;
 			PT_NODE *node = NULL;
@@ -13291,7 +13361,7 @@ values_expr_item
 select_stmt
 	:
 	SELECT			/* $1 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_stmt, : SELECT);
 				/* $2 */
 			PT_NODE *node;
 			parser_save_found_Oracle_outer ();
@@ -13315,7 +13385,7 @@ select_stmt
 	all_distinct            /* $4 */
 	select_list 		/* $5 */
 	opt_select_param_list	/* $6 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_stmt, opt_hint_list all_distinct select_list opt_select_param_list);
 				/* $7 */
 			PT_MISC_TYPE isAll = $4;
 			PT_NODE *node = parser_top_select_stmt_node ();
@@ -13336,14 +13406,14 @@ select_stmt
 
 		}}
 	opt_from_clause  	/* $8 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_stmt, opt_from_clause);
 			$$ = $8;
 		}}
 	;
 
 opt_with_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_clause, : );
 
 			$$ = NULL;
 
@@ -13351,7 +13421,7 @@ opt_with_clause
 	| WITH            /* $1 */
 	  opt_recursive   /* $2 */
 	  cte_definition_list   /* $3 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_clause, | WITH opt_recursive cte_definition_list);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_WITH_CLAUSE);
 			if (node)
@@ -13371,12 +13441,12 @@ opt_with_clause
 
 opt_recursive
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_recursive, : );
 			$$ = 0;
 
 		DBG_PRINT}}
 	| RECURSIVE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_recursive, | RECURSIVE);
 			$$ = 1;
 
 		DBG_PRINT}}
@@ -13384,14 +13454,14 @@ opt_recursive
 
 cte_definition_list
 	: cte_definition_list ',' cte_definition
-		{{
+		{{ DBG_TRACE_GRAMMAR(cte_definition_list, : cte_definition_list ',' cte_definition);
 
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| cte_definition
-		{{
+		{{ DBG_TRACE_GRAMMAR(cte_definition_list, | cte_definition);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT($$, @$.buffer_pos)
@@ -13404,7 +13474,7 @@ cte_definition
 	opt_bracketed_identifier_list  /* $2 */
 	AS               /* $3 */
 	cte_query_list	/* $4 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(cte_definition, : identifier opt_bracketed_identifier_list AS cte_query_list);
 			PT_NODE *node = parser_new_node (this_parser, PT_CTE);
 			if (node)
 			  {
@@ -13427,7 +13497,7 @@ cte_query_list
 	: cte_query_list
 	table_op
 	select_or_subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(cte_query_list, : cte_query_list table_op select_or_subquery);
 
 			PT_NODE *stmt = $2;
 			PT_NODE *arg1 = $1, *arg2 = $3;
@@ -13444,7 +13514,7 @@ cte_query_list
 
 		DBG_PRINT}}
 	| select_or_subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(cte_query_list, | select_or_subquery);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT($$, @$.buffer_pos);
@@ -13454,7 +13524,7 @@ cte_query_list
 
 opt_from_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_from_clause, : );
 
 			PT_NODE *n;
 			PT_NODE *node = parser_pop_select_stmt_node ();
@@ -13494,7 +13564,7 @@ opt_from_clause
 	| FROM				/* $1 */
 	  extended_table_spec_list	/* $2 */
 		{{			/* $3 */
-
+                    DBG_TRACE_GRAMMAR(opt_from_clause, | FROM extended_table_spec_list);
 			parser_found_Oracle_outer = false;
 
 		DBG_PRINT}}
@@ -13505,7 +13575,7 @@ opt_from_clause
 	  opt_having_clause 		/* $8 */
 	  opt_using_index_clause	/* $9 */
 	  opt_with_increment_clause	/* $10 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_from_clause, opt_where_clause opt_startwith_connectby_clause ~ opt_with_increment_clause);
 
 			PT_NODE *n;
 			bool is_dummy_select;
@@ -13619,20 +13689,20 @@ opt_from_clause
 
 opt_select_param_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_select_param_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| INTO to_param_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_select_param_list, | INTO to_param_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| TO to_param_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_select_param_list, | TO to_param_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -13647,7 +13717,7 @@ opt_hint_list
 
 hint_list
 	: hint_list CPP_STYLE_HINT
-		{{
+		{{ DBG_TRACE_GRAMMAR(hint_list, | hint_list CPP_STYLE_HINT);
 
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $2;
@@ -13655,7 +13725,7 @@ hint_list
 
 		DBG_PRINT}}
 	| hint_list SQL_STYLE_HINT
-		{{
+		{{ DBG_TRACE_GRAMMAR(hint_list, | hint_list SQL_STYLE_HINT);
 
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $2;
@@ -13663,7 +13733,7 @@ hint_list
 
 		DBG_PRINT}}
 	| hint_list C_STYLE_HINT
-		{{
+		{{ DBG_TRACE_GRAMMAR(hint_list, | hint_list C_STYLE_HINT);
 
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $2;
@@ -13671,7 +13741,7 @@ hint_list
 
 		DBG_PRINT}}
 	| CPP_STYLE_HINT
-		{{
+		{{ DBG_TRACE_GRAMMAR(hint_list, | CPP_STYLE_HINT);
 
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $1;
@@ -13679,7 +13749,7 @@ hint_list
 
 		DBG_PRINT}}
 	| SQL_STYLE_HINT
-		{{
+		{{ DBG_TRACE_GRAMMAR(hint_list, | SQL_STYLE_HINT);
 
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $1;
@@ -13687,7 +13757,7 @@ hint_list
 
 		DBG_PRINT}}
 	| C_STYLE_HINT
-		{{
+		{{ DBG_TRACE_GRAMMAR(hint_list, | C_STYLE_HINT);
 
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $1;
@@ -13698,25 +13768,25 @@ hint_list
 
 all_distinct
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(all_distinct, : );
 
 			$$ = PT_EMPTY;
 
 		DBG_PRINT}}
 	| ALL
-		{{
+		{{ DBG_TRACE_GRAMMAR(all_distinct, | ALL);
 
 			$$ = PT_ALL;
 
 		DBG_PRINT}}
 	| DISTINCT
-		{{
+		{{ DBG_TRACE_GRAMMAR(all_distinct, | DISTINCT);
 
 			$$ = PT_DISTINCT;
 
 		DBG_PRINT}}
 	| UNIQUE
-		{{
+		{{ DBG_TRACE_GRAMMAR(all_distinct, | UNIQUE);
 
 			$$ = PT_DISTINCT;
 
@@ -13725,7 +13795,7 @@ all_distinct
 
 select_list
 	: '*'
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_list,  : '*');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -13736,7 +13806,7 @@ select_list
 		DBG_PRINT}}
 
 	| '*' ',' alias_enabled_expression_list_top
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_list, | '*' ',' alias_enabled_expression_list_top);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -13748,7 +13818,7 @@ select_list
 		DBG_PRINT}}
 
 	| alias_enabled_expression_list_top
-		{{
+		{{ DBG_TRACE_GRAMMAR(select_list, | alias_enabled_expression_list_top);
 			 $$ = $1;
 			 PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
@@ -13756,7 +13826,7 @@ select_list
 
 alias_enabled_expression_list_top
 	:
-		{{
+		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_list_top, : );
 
 			parser_save_and_set_ic (2);
 			parser_save_and_set_gc (2);
@@ -13767,7 +13837,7 @@ alias_enabled_expression_list_top
 
 		DBG_PRINT}}
 	  alias_enabled_expression_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_list_top, alias_enabled_expression_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -13783,14 +13853,14 @@ alias_enabled_expression_list_top
 
 alias_enabled_expression_list
 	: alias_enabled_expression_list  ',' alias_enabled_expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_list, : alias_enabled_expression_list  ',' alias_enabled_expression_);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| alias_enabled_expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_list, | alias_enabled_expression_);
 
 			PT_NODE *node = $1;
 			if (node != NULL)
@@ -13805,7 +13875,7 @@ alias_enabled_expression_list
 
 alias_enabled_expression_
 	: normal_expression opt_as_identifier %dprec 2
-		{{
+		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_, : normal_expression opt_as_identifier);
 
 			PT_NODE *subq, *id;
 			PT_NODE *node = $1;
@@ -13850,7 +13920,7 @@ alias_enabled_expression_
 
 		DBG_PRINT}}
 	| predicate_expression opt_as_identifier %dprec 1
-		{{
+		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_, | predicate_expression opt_as_identifier);
 
 			PT_NODE *id;
 			PT_NODE *node = $1;
@@ -13870,7 +13940,7 @@ alias_enabled_expression_
 
 expression_list
 	: expression_queue
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_list, : expression_queue);
 
 			$$ = CONTAINER_AT_0($1);
 
@@ -13879,7 +13949,7 @@ expression_list
 
 expression_queue
 	: expression_queue  ',' expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_queue, : expression_queue  ',' expression_);
 			container_2 new_q;
 
 			PT_NODE* q_head = CONTAINER_AT_0($1);
@@ -13892,7 +13962,7 @@ expression_queue
 
 		DBG_PRINT}}
 	| expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_queue, | expression_);
 			container_2 new_q;
 
 			SET_CONTAINER_2(new_q, $1, $1);
@@ -13904,14 +13974,14 @@ expression_queue
 
 to_param_list
 	: to_param_list ',' to_param
-		{{
+		{{ DBG_TRACE_GRAMMAR(to_param_list, : to_param_list ',' to_param);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| to_param
-		{{
+		{{ DBG_TRACE_GRAMMAR(to_param_list, | to_param);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -13921,7 +13991,7 @@ to_param_list
 
 to_param
 	: host_param_output
-		{{
+		{{ DBG_TRACE_GRAMMAR(to_param, : host_param_output);
 
 			$1->info.host_var.var_type = PT_HOST_OUT;
 			$$ = $1;
@@ -13929,7 +13999,7 @@ to_param
 
 		DBG_PRINT}}
 	| param_
-		{{
+		{{ DBG_TRACE_GRAMMAR(to_param, | param_);
 
 			PT_NODE *val = $1;
 
@@ -13945,7 +14015,7 @@ to_param
 
 		DBG_PRINT}}
 	| identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(to_param, | identifier);
 
 			PT_NODE *val = $1;
 
@@ -13964,7 +14034,7 @@ to_param
 
 from_param
 	: host_param_input
-		{{
+		{{ DBG_TRACE_GRAMMAR(from_param, : host_param_input);
 
 			PT_NODE *val = $1;
 
@@ -13979,7 +14049,7 @@ from_param
 
 		DBG_PRINT}}
 	| param_
-		{{
+		{{ DBG_TRACE_GRAMMAR(from_param, | param_);
 
 			PT_NODE *val = $1;
 
@@ -13994,7 +14064,7 @@ from_param
 
 		DBG_PRINT}}
 	| CLASS identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(from_param, | CLASS identifier);
 
 			PT_NODE *val = $2;
 
@@ -14009,7 +14079,7 @@ from_param
 
 		DBG_PRINT}}
 	| identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(from_param, | identifier);
 
 			PT_NODE *val = $1;
 
@@ -14028,7 +14098,7 @@ from_param
 
 host_param_input
 	: '?'
-		{{
+		{{ DBG_TRACE_GRAMMAR(host_param_input, : '?');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_HOST_VAR);
 
@@ -14049,7 +14119,7 @@ host_param_input
 
 		DBG_PRINT}}
 	| PARAM_HEADER uint_text
-		{{
+		{{ DBG_TRACE_GRAMMAR(host_param_input, | PARAM_HEADER uint_text);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_HOST_VAR);
 
@@ -14077,7 +14147,7 @@ host_param_input
 
 host_param_output
 	: '?'
-		{{
+		{{ DBG_TRACE_GRAMMAR(host_param_output, : '?');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_HOST_VAR);
 
@@ -14093,7 +14163,7 @@ host_param_output
 
 		DBG_PRINT}}
 	| PARAM_HEADER uint_text
-		{{
+		{{ DBG_TRACE_GRAMMAR(host_param_output, | PARAM_HEADER uint_text);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_HOST_VAR);
 
@@ -14122,7 +14192,7 @@ host_param_output
 
 param_
 	: ':' identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(param_, : ':' identifier);
 
 			$2->info.name.meta_class = PT_PARAMETER;
 			$$ = $2;
@@ -14133,12 +14203,12 @@ param_
 
 opt_where_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_where_clause, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
-	|	{
+	|	{ DBG_TRACE_GRAMMAR(opt_where_clause, | );
 			parser_save_and_set_ic (1);
 			assert (parser_prior_check == 0);
 			assert (parser_connectbyroot_check == 0);
@@ -14147,7 +14217,7 @@ opt_where_clause
 			parser_save_and_set_cbrc (1);
 		}
 	  WHERE search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_where_clause, WHERE search_condition);
 
 			parser_restore_ic ();
 			parser_restore_sysc ();
@@ -14161,7 +14231,7 @@ opt_where_clause
 
 opt_startwith_connectby_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_startwith_connectby_clause, : );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, NULL);
@@ -14169,7 +14239,7 @@ opt_startwith_connectby_clause
 
 		DBG_PRINT}}
 	| startwith_clause connectby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_startwith_connectby_clause, |  startwith_clause connectby_clause);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $1, $2);
@@ -14177,7 +14247,7 @@ opt_startwith_connectby_clause
 
 		DBG_PRINT}}
 	| connectby_clause startwith_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_startwith_connectby_clause, |  connectby_clause startwith_clause);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, $1);
@@ -14185,7 +14255,7 @@ opt_startwith_connectby_clause
 
 		DBG_PRINT}}
 	| connectby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_startwith_connectby_clause, |  connectby_clause);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, $1);
@@ -14194,11 +14264,11 @@ opt_startwith_connectby_clause
 		DBG_PRINT}}
 
 startwith_clause
-	:	{
+	:	{ DBG_TRACE_GRAMMAR(startwith_clause, : );
 			parser_save_and_set_pseudoc (0);
 		}
 	  START_ WITH search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(startwith_clause, START_ WITH search_condition);
 
 			parser_restore_pseudoc ();
 			$$ = $4;
@@ -14208,14 +14278,14 @@ startwith_clause
 	;
 
 connectby_clause
-	:	{
+	:	{ DBG_TRACE_GRAMMAR(connectby_clause, : );
 			parser_save_and_set_prc (1);
 			parser_save_and_set_serc (0);
 			parser_save_and_set_pseudoc (1);
 			parser_save_and_set_sqc (0);
 		}
 	  CONNECT BY opt_nocycle search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(connectby_clause, CONNECT BY opt_nocycle search_condition);
 
 			parser_restore_prc ();
 			parser_restore_serc ();
@@ -14230,7 +14300,7 @@ connectby_clause
 opt_nocycle
 	: /* empty */
 	| NOCYCLE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_nocycle, |  NOCYCLE);
 
 			PT_NODE *node = parser_top_select_stmt_node ();
 			if (node)
@@ -14244,13 +14314,13 @@ opt_nocycle
 
 opt_groupby_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_groupby_clause, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| GROUP_ BY group_spec_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_groupby_clause, |  GROUP_ BY group_spec_list);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -14260,13 +14330,13 @@ opt_groupby_clause
 
 opt_with_rollup
 	: /*empty*/
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_rollup, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| WITH ROLLUP
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_rollup, |  WITH ROLLUP);
 
 			$$ = 1;
 
@@ -14275,14 +14345,14 @@ opt_with_rollup
 
 group_spec_list
 	: group_spec_list ',' group_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(group_spec_list, : group_spec_list ',' group_spec);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| group_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(group_spec_list, |  group_spec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -14294,12 +14364,12 @@ group_spec_list
 // SR +3
 group_spec
 	:
-		{
+		{ DBG_TRACE_GRAMMAR(group_spec, : );
 			parser_groupby_exception = 0;
 		}
 	  expression_
 	  opt_asc_or_desc 	  /* $3 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(group_spec, expression_ opt_asc_or_desc);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SORT_SPEC);
 
@@ -14350,14 +14420,14 @@ group_spec
 
 opt_having_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_having_clause, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	|	{ parser_save_and_set_gc(1); }
 	  HAVING search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_having_clause, | HAVING search_condition);
 
 			parser_restore_gc ();
 			$$ = $3;
@@ -14368,20 +14438,20 @@ opt_having_clause
 
 opt_using_index_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_using_index_clause, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| USING INDEX index_name_keylimit_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_using_index_clause, | USING INDEX index_name_keylimit_list);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| USING INDEX NONE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_using_index_clause, | USING INDEX NONE);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_NAME);
 
@@ -14398,7 +14468,7 @@ opt_using_index_clause
 
 		DBG_PRINT}}
 	| USING INDEX ALL EXCEPT index_name_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_using_index_clause, | USING INDEX ALL EXCEPT index_name_list);
 			PT_NODE *curr;
 			PT_NODE *node = parser_new_node (this_parser, PT_NAME);
 
@@ -14437,14 +14507,14 @@ opt_using_index_clause
 
 index_name_keylimit_list
 	: index_name_keylimit_list ',' index_name_keylimit
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_name_keylimit_list, : index_name_keylimit_list ',' index_name_keylimit);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| index_name_keylimit
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_name_keylimit_list, | index_name_keylimit);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -14454,14 +14524,14 @@ index_name_keylimit_list
 
 index_name_list
 	: index_name_list ',' index_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_name_list, : index_name_list ',' index_name);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| index_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_name_list, | index_name);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -14471,7 +14541,7 @@ index_name_list
 
 index_name_keylimit
 	: index_name KEYLIMIT limit_expr
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_name_keylimit, : indeindex_name KEYLIMIT limit_exprx_name);
 
 			PT_NODE *node = $1;
 			PARSER_SAVE_ERR_CONTEXT (node, @$.buffer_pos)
@@ -14497,7 +14567,7 @@ index_name_keylimit
 
 		DBG_PRINT}}
 	| index_name KEYLIMIT limit_expr ',' limit_expr
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_name_keylimit, | index_name KEYLIMIT limit_expr ',' limit_expr);
 
 			PT_NODE *node = $1;
 			if (node)
@@ -14522,7 +14592,7 @@ index_name_keylimit
 
 		DBG_PRINT}}
 	| index_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_name_keylimit, | index_name);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -14532,7 +14602,7 @@ index_name_keylimit
 
 index_name
 	: class_name paren_plus
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_name, : class_name paren_plus);
 
 			PT_NODE *node = $1;
 			node->info.name.meta_class = PT_INDEX_NAME;
@@ -14542,7 +14612,7 @@ index_name
 
 		DBG_PRINT}}
 	| class_name paren_minus
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_name, | class_name paren_minus);
 
 			PT_NODE *node = $1;
 			node->info.name.meta_class = PT_INDEX_NAME;
@@ -14552,7 +14622,7 @@ index_name
 
 		DBG_PRINT}}
 	| class_name
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_name, | class_name);
 
 			PT_NODE *node = $1;
 			node->info.name.meta_class = PT_INDEX_NAME;
@@ -14562,7 +14632,7 @@ index_name
 
 		DBG_PRINT}}
 	| identifier DOT NONE
-		{{
+		{{ DBG_TRACE_GRAMMAR(index_name, | identifier DOT NONE);
 
 			PT_NODE *node = $1;
 			node->info.name.meta_class = PT_INDEX_NAME;
@@ -14577,20 +14647,20 @@ index_name
 
 opt_with_increment_clause
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_increment_clause, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| WITH INCREMENT For incr_arg_name_list__inc
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_increment_clause, | WITH INCREMENT For incr_arg_name_list__inc);
 
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| WITH DECREMENT For incr_arg_name_list__dec
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_with_increment_clause, | WITH DECREMENT For incr_arg_name_list__dec);
 
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -14599,9 +14669,9 @@ opt_with_increment_clause
 	;
 
 opt_for_update_clause
-	: /* empty */
+	: /* empty */ { DBG_TRACE_GRAMMAR(opt_for_update_clause, : ); }
 	| For UPDATE
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_for_update_clause, | For UPDATE);
 
 			PT_NODE *node = parser_top_orderby_node ();
 
@@ -14621,7 +14691,7 @@ opt_for_update_clause
 
 		DBG_PRINT}}
 	| For UPDATE OF class_name_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_for_update_clause, | For UPDATE OF class_name_list);
 
 			PT_NODE *node = parser_top_orderby_node ();
 			PT_NODE *names_list = $4;
@@ -14665,14 +14735,14 @@ opt_for_update_clause
 
 incr_arg_name_list__inc
 	: incr_arg_name_list__inc ',' incr_arg_name__inc
-		{{
+		{{ DBG_TRACE_GRAMMAR(incr_arg_name_list__inc, : incr_arg_name_list__inc ',' incr_arg_name__inc);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| incr_arg_name__inc
-		{{
+		{{ DBG_TRACE_GRAMMAR(incr_arg_name_list__inc, | incr_arg_name__inc);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -14682,7 +14752,7 @@ incr_arg_name_list__inc
 
 incr_arg_name__inc
 	: path_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(incr_arg_name__inc, : path_expression);
 			PT_NODE *node = $1;
 
 			if (node->node_type == PT_EXPR && node->info.expr.op == PT_INCR)
@@ -14707,14 +14777,14 @@ incr_arg_name__inc
 
 incr_arg_name_list__dec
 	: incr_arg_name_list__dec ',' incr_arg_name__dec
-		{{
+		{{ DBG_TRACE_GRAMMAR(incr_arg_name_list__dec, : incr_arg_name_list__dec ',' incr_arg_name__dec);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| incr_arg_name__dec
-		{{
+		{{ DBG_TRACE_GRAMMAR(incr_arg_name_list__dec, | incr_arg_name__dec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -14724,7 +14794,7 @@ incr_arg_name_list__dec
 
 incr_arg_name__dec
 	: path_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(incr_arg_name__dec, : path_expression);
 			PT_NODE *node = $1;
 
 			if (node->node_type == PT_EXPR && node->info.expr.op == PT_INCR)
@@ -14749,12 +14819,13 @@ incr_arg_name__dec
 
 opt_update_orderby_clause
 	: /* empty */
-		{ $$ = NULL; }
+		{ DBG_TRACE_GRAMMAR(opt_update_orderby_clause, : );
+                  $$ = NULL; }
 	| ORDER BY
 	  sort_spec_list
-		{ parser_save_and_set_oc (1); }
+		{  parser_save_and_set_oc (1); }
 	  opt_for_search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_update_orderby_clause, | ORDER BY sort_spec_listopt_for_search_condition);
 			PT_NODE *stmt = parser_pop_orderby_node ();
 
 			parser_restore_oc ();
@@ -14769,11 +14840,11 @@ opt_update_orderby_clause
 
 opt_orderby_clause
 	: /* empty */
-		{ $$ = NULL; }
+		{ DBG_TRACE_GRAMMAR(opt_orderby_clause, : );  $$ = NULL; }
 	| ORDER
 	  opt_siblings
 	  BY
-		{{
+		{{ DBG_TRACE_GRAMMAR("opt_orderby_clause", "| ORDER opt_siblings BY");
 			PT_NODE *stmt = parser_top_orderby_node ();
 
 			if (!stmt->info.query.flag.order_siblings)
@@ -14798,7 +14869,7 @@ opt_orderby_clause
 
 		DBG_PRINT}}
 	  sort_spec_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_orderby_clause, sort_spec_list);
 
 			PT_NODE *stmt = parser_top_orderby_node ();
 
@@ -14810,7 +14881,7 @@ opt_orderby_clause
 
 		DBG_PRINT}}
 	  opt_for_search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_orderby_clause, opt_for_search_condition);
 
 			PT_NODE *col, *order, *n, *temp, *list = NULL;
 			PT_NODE *stmt = parser_top_orderby_node ();
@@ -14968,7 +15039,7 @@ opt_orderby_clause
 opt_siblings
 	: /* empty */
 	| SIBLINGS
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_siblings, | SIBLINGS);
 
 			PT_NODE *stmt = parser_top_orderby_node ();
 			stmt->info.query.flag.order_siblings = true;
@@ -14985,19 +15056,19 @@ opt_siblings
 
 limit_expr
         : limit_expr '+' limit_term
-                {{
+                {{ DBG_TRACE_GRAMMAR(limit_expr, : limit_expr '+' limit_term);
                         $$ = parser_make_expression (this_parser, PT_PLUS, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
                 DBG_PRINT}}
         | limit_expr '-' limit_term
-                {{
+                {{ DBG_TRACE_GRAMMAR(limit_expr, | limit_expr '-' limit_term);
                         $$ = parser_make_expression (this_parser, PT_MINUS, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
                 DBG_PRINT}}
         | limit_term
-                {{
+                {{ DBG_TRACE_GRAMMAR(limit_expr, | limit_term);
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
@@ -15006,19 +15077,19 @@ limit_expr
 
 limit_term
         : limit_term '*' limit_factor
-                {{
+                {{ DBG_TRACE_GRAMMAR(limit_term, : limit_term '*' limit_factor);
                         $$ = parser_make_expression (this_parser, PT_TIMES, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
                 DBG_PRINT}}
         | limit_term '/' limit_factor
-                {{
+                {{ DBG_TRACE_GRAMMAR(limit_term, | limit_term '/' limit_factor);
                         $$ = parser_make_expression (this_parser, PT_DIVIDE, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
                 DBG_PRINT}}
         | limit_factor
-                {{
+                {{ DBG_TRACE_GRAMMAR(limit_term, | limit_factor);
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
@@ -15027,14 +15098,14 @@ limit_term
 
 limit_factor
         : host_param_input
-                {{
+                {{ DBG_TRACE_GRAMMAR(limit_factor, : host_param_input);
 
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
                 DBG_PRINT}}
         | unsigned_integer
-                {{
+                {{ DBG_TRACE_GRAMMAR(limit_factor, | unsigned_integer);
 
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15042,7 +15113,7 @@ limit_factor
                 DBG_PRINT}}
 
         | '(' limit_expr ')'
-                {{
+                {{ DBG_TRACE_GRAMMAR(limit_factor, | '(' limit_expr ')');
 			PT_NODE *exp = $2;
 
 			if (exp && exp->node_type == PT_EXPR)
@@ -15059,7 +15130,7 @@ limit_factor
 opt_select_limit_clause
 	: /* empty */
 	| LIMIT limit_options
-	        {{
+	        {{ DBG_TRACE_GRAMMAR(opt_select_limit_clause, | LIMIT limit_options);
 
 			PT_NODE *node = $2;
 			if (node)
@@ -15129,7 +15200,7 @@ opt_select_limit_clause
 
 limit_options
 	: limit_expr
-		{{
+		{{ DBG_TRACE_GRAMMAR(limit_options, : limit_expr);
 
 			PT_NODE *node = parser_top_orderby_node ();
 			if (node)
@@ -15142,7 +15213,7 @@ limit_options
 
 		DBG_PRINT}}
 	| limit_expr ',' limit_expr
-		{{
+		{{ DBG_TRACE_GRAMMAR(limit_options, | limit_expr ',' limit_expr);
 
 			PT_NODE *node = parser_top_orderby_node ();
 			if (node)
@@ -15161,7 +15232,7 @@ limit_options
 
 		DBG_PRINT}}
 	| limit_expr OFFSET limit_expr
-		{{
+		{{ DBG_TRACE_GRAMMAR(limit_options, | limit_expr OFFSET limit_expr);
 
 			PT_NODE *node = parser_top_orderby_node ();
 			if (node)
@@ -15183,9 +15254,10 @@ limit_options
 
 opt_upd_del_limit_clause
 	: /* empty */
-		{ $$ = NULL; }
+		{ DBG_TRACE_GRAMMAR(opt_upd_del_limit_clause, : );
+                  $$ = NULL; }
 	| LIMIT limit_expr
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_upd_del_limit_clause, | LIMIT limit_expr);
 
 			  $$ = $2;
 			  PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15195,9 +15267,10 @@ opt_upd_del_limit_clause
 
 opt_for_search_condition
 	: /* empty */
-		{ $$ = NULL; }
+		{ DBG_TRACE_GRAMMAR(opt_for_search_condition, : );
+                  $$ = NULL; }
 	| For search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_for_search_condition, | For search_condition);
 			PT_NODE *node = $2;
 			bool subquery_flag = false;
 			if (node)
@@ -15219,14 +15292,14 @@ opt_for_search_condition
 
 sort_spec_list
 	: sort_spec_list ',' sort_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(sort_spec_list, : sort_spec_list ',' sort_spec);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| sort_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(sort_spec_list, | sort_spec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15236,7 +15309,7 @@ sort_spec_list
 
 sort_spec
 	: expression_ ASC opt_nulls_first_or_last
-		{{
+		{{ DBG_TRACE_GRAMMAR(sort_spec, : expression_ ASC opt_nulls_first_or_last);
 			PT_NODE *node = parser_new_node (this_parser, PT_SORT_SPEC);
 
 			if (node)
@@ -15251,7 +15324,7 @@ sort_spec
 
 		DBG_PRINT}}
 	| expression_ DESC opt_nulls_first_or_last
-		{{
+		{{ DBG_TRACE_GRAMMAR(sort_spec, | expression_ DESC opt_nulls_first_or_last);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SORT_SPEC);
 
@@ -15267,7 +15340,7 @@ sort_spec
 
 		DBG_PRINT}}
 	| expression_ opt_nulls_first_or_last
-		{{
+		{{ DBG_TRACE_GRAMMAR(sort_spec, | expression_ opt_nulls_first_or_last);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_SORT_SPEC);
 
@@ -15286,19 +15359,19 @@ sort_spec
 
 opt_nulls_first_or_last
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_nulls_first_or_last, : );
 
 			$$ = PT_NULLS_DEFAULT;
 
 		DBG_PRINT}}
 	| NULLS FIRST
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_nulls_first_or_last, | NULLS FIRST);
 
 			$$ = PT_NULLS_FIRST;
 
 		DBG_PRINT}}
 	| NULLS LAST
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_nulls_first_or_last, | NULLS LAST);
 
 			$$ = PT_NULLS_LAST;
 
@@ -15307,14 +15380,14 @@ opt_nulls_first_or_last
 
 expression_
 	: normal_expression
-		{{DBG_PRINT_MATCH_LN("expression_ > : normal_expression");
+		{{DBG_TRACE_GRAMMAR(expression_, : normal_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| predicate_expression
-		{{DBG_PRINT_MATCH_LN("expression_ > | predicate_expression");
+		{{DBG_TRACE_GRAMMAR(expression_, | predicate_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15325,14 +15398,14 @@ expression_
 
 normal_expression
 	: session_variable_definition
-		{{
+		{{ DBG_TRACE_GRAMMAR(normal_expression, : session_variable_definition);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_strcat
-		{{
+		{{ DBG_TRACE_GRAMMAR(normal_expression, | expression_strcat);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15342,14 +15415,14 @@ normal_expression
 
 expression_strcat
 	: expression_strcat STRCAT expression_bitor
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_strcat, : expression_strcat STRCAT expression_bitor);
 
 			$$ = parser_make_expression (this_parser, PT_STRCAT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_bitor
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_strcat, | expression_bitor);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15359,14 +15432,14 @@ expression_strcat
 
 expression_bitor
 	: expression_bitor '|' expression_bitand
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_bitor, : expression_bitor '|' expression_bitand);
 
 			$$ = parser_make_expression (this_parser, PT_BIT_OR, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_bitand
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_bitor, | expression_bitand);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15376,14 +15449,14 @@ expression_bitor
 
 expression_bitand
 	: expression_bitand '&' expression_bitshift
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_bitand, : expression_bitand '&' expression_bitshift);
 
 			$$ = parser_make_expression (this_parser, PT_BIT_AND, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_bitshift
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_bitand, | expression_bitshift);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15393,21 +15466,21 @@ expression_bitand
 
 expression_bitshift
 	: expression_bitshift BITSHIFT_LEFT expression_add_sub
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_bitshift, : expression_bitshift BITSHIFT_LEFT expression_add_sub);
 
 			$$ = parser_make_expression (this_parser, PT_BITSHIFT_LEFT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_bitshift BITSHIFT_RIGHT expression_add_sub
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_bitshift, | expression_bitshift BITSHIFT_RIGHT expression_add_sub);
 
 			$$ = parser_make_expression (this_parser, PT_BITSHIFT_RIGHT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_add_sub
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_bitshift, | expression_add_sub);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15417,21 +15490,21 @@ expression_bitshift
 
 expression_add_sub
 	: expression_add_sub '+' term
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_add_sub, : expression_add_sub '+' term);
 
 			$$ = parser_make_expression (this_parser, PT_PLUS, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_add_sub '-' term
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_add_sub, | expression_add_sub '-' term);
 
 			$$ = parser_make_expression (this_parser, PT_MINUS, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| term
-		{{
+		{{ DBG_TRACE_GRAMMAR(expression_add_sub, | term);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15441,35 +15514,35 @@ expression_add_sub
 
 term
 	: term '*' factor
-		{{
+		{{ DBG_TRACE_GRAMMAR(term, : term '*' factor);
 
 			$$ = parser_make_expression (this_parser, PT_TIMES, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| term '/' factor
-		{{
+		{{ DBG_TRACE_GRAMMAR(term, | term '/' factor);
 
 			$$ = parser_make_expression (this_parser, PT_DIVIDE, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| term DIV factor
-		{{
+		{{ DBG_TRACE_GRAMMAR(term, | term DIV factor);
 
 			$$ = parser_make_expression (this_parser, PT_DIV, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| term MOD factor
-		{{
+		{{ DBG_TRACE_GRAMMAR(term, | term MOD factor);
 
 			$$ = parser_make_expression (this_parser, PT_MOD, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| factor
-		{{
+		{{ DBG_TRACE_GRAMMAR(term, | factor);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15479,14 +15552,14 @@ term
 
 factor
 	: factor '^' factor_
-		{{
+		{{ DBG_TRACE_GRAMMAR(factor, : factor '^' factor_);
 
 			$$ = parser_make_expression (this_parser, PT_BIT_XOR, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| factor_
-		{{
+		{{ DBG_TRACE_GRAMMAR(factor, | factor_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15496,35 +15569,35 @@ factor
 
 factor_
 	: primary_w_collate
-		{{
+		{{ DBG_TRACE_GRAMMAR(factor_, : primary_w_collate);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| '-' factor_
-		{{
+		{{ DBG_TRACE_GRAMMAR(factor_, | '-' factor_);
 
 			$$ = parser_make_expression (this_parser, PT_UNARY_MINUS, $2, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| '+' factor_
-		{{
+		{{ DBG_TRACE_GRAMMAR(factor_, | '+' factor_);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| '~' primary
-		{{
+		{{ DBG_TRACE_GRAMMAR(factor_, | '~' primary);
 
 			$$ = parser_make_expression (this_parser, PT_BIT_NOT, $2, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| PRIOR
-		{{
+		{{ DBG_TRACE_GRAMMAR(factor_, | PRIOR);
 
 			parser_save_and_set_sysc (0);
 			parser_save_and_set_prc (0);
@@ -15533,7 +15606,7 @@ factor_
 
 		DBG_PRINT}}
 	  primary_w_collate
-		{{
+		{{ DBG_TRACE_GRAMMAR(factor_, primary_w_collate);
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_PRIOR, $3, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT (node, @$.buffer_pos)
@@ -15553,7 +15626,7 @@ factor_
 
 		DBG_PRINT}}
 	| CONNECT_BY_ROOT
-		{{
+		{{ DBG_TRACE_GRAMMAR(factor_, | CONNECT_BY_ROOT);
 
 			parser_save_and_set_sysc (0);
 			parser_save_and_set_prc (0);
@@ -15562,7 +15635,7 @@ factor_
 
 		DBG_PRINT}}
 	  primary_w_collate
-		{{
+		{{ DBG_TRACE_GRAMMAR(factor_, primary_w_collate);
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_CONNECT_BY_ROOT, $3, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT (node, @$.buffer_pos)
@@ -15585,7 +15658,7 @@ factor_
 
 primary_w_collate
 	: primary opt_collation
-		{{
+		{{ DBG_TRACE_GRAMMAR(primary_w_collate, : primary opt_collation);
 			PT_NODE *node = $1;
 			PT_NODE *coll_node = $2;
 
@@ -15606,7 +15679,7 @@ primary_w_collate
 
 primary
 	: pseudo_column		%dprec 11
-		{{
+		{{ DBG_TRACE_GRAMMAR(primary, : pseudo_column);
 
 			if (parser_pseudocolumn_check == 0)
 			  PT_ERRORmf (this_parser, $1, MSGCAT_SET_PARSER_SEMANTIC,
@@ -15617,35 +15690,35 @@ primary
 
 		DBG_PRINT}}
 	| reserved_func		%dprec 10
-		{{
+		{{ DBG_TRACE_GRAMMAR(primary, | reserved_func);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| case_expr		%dprec 9
-		{{
+		{{ DBG_TRACE_GRAMMAR(primary, | case_expr);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| extract_expr		%dprec 8
-		{{
+		{{ DBG_TRACE_GRAMMAR(primary, | extract_expr);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| literal_w_o_param	%dprec 7
-		{{
+		{{ DBG_TRACE_GRAMMAR(primary, | literal_w_o_param);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| insert_expression	%dprec 6
-		{{
+		{{ DBG_TRACE_GRAMMAR(primary, | insert_expression);
 
 			$1->info.insert.is_subinsert = PT_IS_SUBINSERT;
 			$$ = $1;
@@ -15654,14 +15727,14 @@ primary
 
 		DBG_PRINT}}
 	| path_expression	%dprec 5
-		{{
+		{{ DBG_TRACE_GRAMMAR(primary, | path_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| '(' expression_list ')' %dprec 4
-		{{
+		{{ DBG_TRACE_GRAMMAR(primary, | '(' expression_list ')');
 			PT_NODE *exp = $2;
 			exp = pt_create_paren_expr_list (exp);
 			$$ = exp;
@@ -15669,7 +15742,7 @@ primary
 
 		DBG_PRINT}}
 	| ROW '(' expression_list ')' %dprec 4
-		{{
+		{{ DBG_TRACE_GRAMMAR(primary, | ROW '(' expression_list ')');
 			PT_NODE *exp = $3;
 			exp = pt_create_paren_expr_list (exp);
 			$$ = exp;
@@ -15677,7 +15750,7 @@ primary
 
 		DBG_PRINT}}
 	| '(' search_condition_query ')' %dprec 2
-		{{DBG_PRINT_MATCH_LN("primary > | '(' search_condition_query ')' ");
+		{{ DBG_TRACE_GRAMMAR(primary, | '(' search_condition_query ')');
 
 			PT_NODE *exp = $2;
 
@@ -15692,13 +15765,13 @@ primary
 
 		DBG_PRINT}}
 	| subquery    %dprec 1
-		{{DBG_PRINT_MATCH_LN("primary > | subquery ");
+		{{ DBG_TRACE_GRAMMAR(primary, | subquery);
 			parser_groupby_exception = PT_IS_SUBQUERY;
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
 	| session_variable_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(primary, | session_variable_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15708,14 +15781,14 @@ primary
 
 search_condition_query
 	: search_condition_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(search_condition_query, : search_condition_expression);
 
 			PT_NODE *node = $1;
 			parser_push_orderby_node (node);
 
 		DBG_PRINT}}
 	  opt_orderby_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(search_condition_query, opt_orderby_clause);
 
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
@@ -15726,7 +15799,7 @@ search_condition_query
 
 search_condition_expression
 	: search_condition
-		{{
+		{{ DBG_TRACE_GRAMMAR(search_condition_expression, : search_condition);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15736,21 +15809,21 @@ search_condition_expression
 
 pseudo_column
 	: CONNECT_BY_ISCYCLE
-		{{
+		{{ DBG_TRACE_GRAMMAR(pseudo_column, : CONNECT_BY_ISCYCLE);
 
 			$$ = parser_make_expression (this_parser, PT_CONNECT_BY_ISCYCLE, NULL, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| CONNECT_BY_ISLEAF
-		{{
+		{{ DBG_TRACE_GRAMMAR(pseudo_column, | CONNECT_BY_ISLEAF);
 
 			$$ = parser_make_expression (this_parser, PT_CONNECT_BY_ISLEAF, NULL, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| LEVEL
-		{{
+		{{ DBG_TRACE_GRAMMAR(pseudo_column, | LEVEL);
 
 			$$ = parser_make_expression (this_parser, PT_LEVEL, NULL, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -15761,7 +15834,7 @@ pseudo_column
 
 reserved_func
         : COUNT '(' '*' ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, : COUNT '(' '*' ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -15778,7 +15851,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| COUNT '(' '*' ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' '*' ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -15797,7 +15870,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| COUNT '(' of_distinct_unique expression_ ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' of_distinct_unique expression_ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -15814,7 +15887,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| COUNT '(' of_distinct_unique expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' of_distinct_unique expression_ ')' OVER '(' ~ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -15833,7 +15906,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| COUNT '(' opt_all expression_ ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' opt_all expression_ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -15850,7 +15923,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| COUNT '(' opt_all expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' opt_all expression_ ')' OVER '(' ~ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -15869,7 +15942,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_avg_max_etc '(' of_distinct_unique expression_ ')'
-		{{//reserved_func | of_avg_max_etc '(' of_distinct_unique expression_ ')'
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_avg_max_etc '(' of_distinct_unique expression_ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -15891,7 +15964,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_avg_max_etc '(' opt_all expression_ ')'
-		{{//reserved_func | of_avg_max_etc '(' opt_all expression_ ')'
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_avg_max_etc '(' opt_all expression_ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -15908,7 +15981,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_analytic '(' of_distinct_unique expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic '(' of_distinct_unique expression_ ')' OVER '(' ~ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -15930,7 +16003,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_analytic '(' opt_all expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic '(' opt_all expression_ ')' OVER '(' ~ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -15949,7 +16022,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_analytic_first_last '(' expression_ ')' opt_analytic_ignore_nulls OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_first_last '(' expression_ ')' opt_analytic_ignore_nulls OVER '(' ~ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -15971,7 +16044,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_analytic_nth_value '(' expression_ ',' expression_ ')' opt_analytic_from_last opt_analytic_ignore_nulls OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_nth_value '(' expression_ ',' expression_ ')' opt_analytic_from_last opt_analytic_ignore_nulls OVER '(' ~ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -16002,7 +16075,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_analytic_lead_lag '(' expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_lead_lag '(' expression_ ')' OVER '(' ~ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -16035,7 +16108,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_analytic_lead_lag '(' expression_ ',' expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_lead_lag '(' expression_ ',' expression_ ')' OVER '(' ~ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -16062,7 +16135,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_analytic_lead_lag '(' expression_ ',' expression_ ',' expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_lead_lag '(' expression_ ',' expression_ ',' expression_ ')' OVER '(' ~ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -16083,7 +16156,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_analytic_no_args '(' ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_no_args '(' ')' OVER '(' ~ ')');
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -16115,7 +16188,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GROUP_CONCAT); }
 		'(' of_distinct_unique expression_ opt_agg_order_by opt_group_concat_separator ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | GROUP_CONCAT '(' of_distinct_unique expression_ ~ ')' );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -16132,7 +16205,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| GROUP_CONCAT '(' opt_all opt_expression_list opt_agg_order_by opt_group_concat_separator ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | GROUP_CONCAT '(' opt_all opt_expression_list opt_agg_order_by opt_group_concat_separator ')' );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -16157,7 +16230,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| JSON_ARRAYAGG '(' expression_ ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAYAGG '(' expression_ ')' );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -16173,7 +16246,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| JSON_OBJECTAGG '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_OBJECTAGG '(' expression_list ')' );
  			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 			PT_NODE *args_list = $3;
 
@@ -16194,7 +16267,7 @@ reserved_func
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
  		DBG_PRINT}}
 	| of_percentile '(' expression_ ')' WITHIN GROUP_ '(' ORDER BY sort_spec ')' opt_over_analytic_partition_by
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_percentile '(' expression_ ')' WITHIN GROUP_ '(' ORDER BY sort_spec ')' ~ );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
@@ -16249,17 +16322,17 @@ reserved_func
 	  { push_msg(MSGCAT_SYNTAX_INVALID_INSERT_SUBSTRING); }
 	  '(' expression_list ')'
 	  { pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | INSERT '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_INSERT_SUBSTRING, $4, 4, 4);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
 	| ELT '(' opt_expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | ELT '(' opt_expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_ELT, $3, 1, 0);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
 	| POSITION '(' expression_ IN_ expression_ ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | POSITION '(' expression_ IN_ expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_POSITION, $3, $5, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -16269,7 +16342,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ FROM expression_ For expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SUBSTRING_  '(' expression_ FROM expression_ For expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_SUBSTRING, $4, $6, $8);
 			node->info.expr.qualifier = PT_SUBSTR_ORG;
@@ -16282,7 +16355,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ FROM expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SUBSTRING_  '(' expression_ FROM expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_SUBSTRING, $4, $6, NULL);
 			node->info.expr.qualifier = PT_SUBSTR_ORG;
@@ -16295,7 +16368,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ ',' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SUBSTRING_   '(' expression_ ',' expression_ ',' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_SUBSTRING, $4, $6, $8);
 			node->info.expr.qualifier = PT_SUBSTR_ORG;
@@ -16308,7 +16381,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SUBSTRING_    '(' expression_ ',' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_SUBSTRING, $4, $6, NULL);
 			node->info.expr.qualifier = PT_SUBSTR_ORG;
@@ -16321,7 +16394,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATE); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | Date  '(' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_DATEF, $4, NULL, NULL);
 			PICE (node);
@@ -16333,7 +16406,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TIME); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | Time '(' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_TIMEF, $4, NULL, NULL);
 			PICE (node);
@@ -16345,7 +16418,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_ADDDATE); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | ADDDATE '(' expression_ ',' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_ADDDATE, $4, $6, NULL);
 			PICE (node);
@@ -16357,7 +16430,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATE_ADD); }
 	  '(' expression_ ',' INTERVAL expression_ datetime_field ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | adddate_name '(' expression_ ',' INTERVAL expression_ datetime_field ')' );
 
 			PT_NODE *node;
 			PT_NODE *node_unit = parser_new_node (this_parser, PT_VALUE);
@@ -16378,7 +16451,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBDATE); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SUBDATE '(' expression_ ',' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_SUBDATE, $4, $6, NULL);
 			PICE (node);
@@ -16390,7 +16463,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATE_SUB); }
 	  '(' expression_ ',' INTERVAL expression_ datetime_field ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | subdate_name  '(' expression_ ',' INTERVAL expression_ datetime_field ')' );
 
 			PT_NODE *node;
 			PT_NODE *node_unit = parser_new_node (this_parser, PT_VALUE);
@@ -16411,7 +16484,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TIMESTAMP); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | TIMESTAMP  '(' expression_ ')' );
 			PT_NODE *arg2 = NULL;
 			PT_NODE *node = NULL;
 			arg2 = parser_new_node(this_parser, PT_VALUE);
@@ -16430,7 +16503,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TIMESTAMP); }
 		'(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | TIMESTAMP  '(' expression_ ',' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_TIMESTAMP, $4, $6, NULL); /* 2 parameters */
 			PICE (node);
@@ -16442,7 +16515,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_YEAR); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | YEAR_  '(' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_YEARF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
@@ -16454,7 +16527,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MONTH); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | MONTH_  '(' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_MONTHF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
@@ -16466,7 +16539,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DAY); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | DAY_  '(' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_DAYF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
@@ -16478,7 +16551,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_HOUR); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | HOUR_  '(' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_HOURF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
@@ -16490,7 +16563,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MINUTE); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | MINUTE_  '(' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_MINUTEF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
@@ -16502,7 +16575,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SECOND); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SECOND_  '(' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_SECONDF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
@@ -16514,7 +16587,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATABASE); }
 	  '(' ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | DATABASE  '(' ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_DATABASE, NULL, NULL, NULL);
 			PICE (node);
@@ -16526,7 +16599,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SCHEMA); }
 	  '(' ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SCHEMA  '(' ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_SCHEMA, NULL, NULL, NULL);
 			PICE (node);
@@ -16538,7 +16611,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' of_leading_trailing_both expression_ FROM expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | TRIM  '(' of_leading_trailing_both expression_ FROM expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_TRIM, $7, $5, NULL);
 			node->info.expr.qualifier = $4;
@@ -16551,7 +16624,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' of_leading_trailing_both FROM expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | TRIM  '(' of_leading_trailing_both FROM expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_TRIM, $6, NULL, NULL);
 			node->info.expr.qualifier = $4;
@@ -16564,7 +16637,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' expression_ FROM  expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | TRIM '(' expression_ FROM  expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_TRIM, $6, $4, NULL);
 			node->info.expr.qualifier = PT_BOTH;
@@ -16577,7 +16650,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | TRIM '(' expression_ ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_TRIM, $4, NULL, NULL);
 			node->info.expr.qualifier = PT_BOTH;
@@ -16590,7 +16663,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CHR); }
 	  '(' expression_ opt_using_charset ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | CHR '(' expression_ opt_using_charset ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_CHR, $4, $5, NULL);
 			PICE (node);
@@ -16602,7 +16675,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CLOB_TO_CHAR); }
 	  '(' expression_ opt_using_charset ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | CLOB_TO_CHAR '(' expression_ opt_using_charset ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_CLOB_TO_CHAR, $4, $5, NULL);
 			PICE (node);
@@ -16614,7 +16687,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CAST); }
 	  '(' expression_ AS of_cast_data_type ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | CAST '(' expression_ AS of_cast_data_type ')' );
 
 			PT_NODE *expr = parser_make_expression (this_parser, PT_CAST, $4, NULL, NULL);
 			PT_TYPE_ENUM typ = TO_NUMBER (CONTAINER_AT_0 ($6));
@@ -16646,7 +16719,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| CLASS '(' identifier ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | CLASS '(' identifier ')' );
 
 			$3->info.name.meta_class = PT_OID_ATTR;
 			$$ = $3;
@@ -16655,7 +16728,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| SYS_DATE
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_DATE );
 
 			PT_NODE *expr = parser_make_expression (this_parser, PT_SYS_DATE, NULL, NULL, NULL);
 			$$ = expr;
@@ -16663,7 +16736,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_current_date
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_date );
 
 			PT_NODE *expr = parser_make_expression (this_parser, PT_CURRENT_DATE, NULL, NULL, NULL);
 			$$ = expr;
@@ -16671,7 +16744,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| SYS_TIME_
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_TIME_ );
 
 			PT_NODE *expr = parser_make_expression (this_parser, PT_SYS_TIME, NULL, NULL, NULL);
 			$$ = expr;
@@ -16679,7 +16752,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_current_time
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_time );
 
 			PT_NODE *expr = parser_make_expression (this_parser, PT_CURRENT_TIME, NULL, NULL, NULL);
 			$$ = expr;
@@ -16687,7 +16760,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_db_timezone_
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_db_timezone_ );
 
 			PT_NODE *expr = parser_make_expression (this_parser, PT_DBTIMEZONE, NULL, NULL, NULL);
 			$$ = expr;
@@ -16695,7 +16768,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_session_timezone_
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_session_timezone_ );
 
 			PT_NODE *expr = parser_make_expression (this_parser, PT_SESSIONTIMEZONE, NULL, NULL, NULL);
 			$$ = expr;
@@ -16703,7 +16776,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| SYS_TIMESTAMP
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_TIMESTAMP );
 
 			PT_NODE *expr = parser_make_expression (this_parser, PT_SYS_TIMESTAMP, NULL, NULL, NULL);
 			$$ = expr;
@@ -16711,7 +16784,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_current_timestamps
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_timestamps );
 
 			PT_NODE *expr = parser_make_expression (this_parser, PT_CURRENT_TIMESTAMP, NULL, NULL, NULL);
 			$$ = expr;
@@ -16719,7 +16792,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| SYS_DATETIME
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_DATETIME );
 
 			PT_NODE *expr = parser_make_expression (this_parser, PT_SYS_DATETIME, NULL, NULL, NULL);
 			$$ = expr;
@@ -16727,7 +16800,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_current_datetime
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_datetime );
 
 			PT_NODE *expr = parser_make_expression (this_parser, PT_CURRENT_DATETIME, NULL, NULL, NULL);
 			$$ = expr;
@@ -16735,7 +16808,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_users
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_users );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_EXPR);
 			if (node)
@@ -16750,7 +16823,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SYSTEM_USER); }
 	  '(' ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_users '(' ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_USER, NULL, NULL, NULL);
 			PICE (node);
@@ -16762,7 +16835,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DEFAULT); }
 	  simple_path_id ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | DEFAULT '(' simple_path_id ')');
 
 			PT_NODE *node = NULL;
 			PT_NODE *path = $4;
@@ -16778,7 +16851,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| LOCAL_TRANSACTION_ID
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | LOCAL_TRANSACTION_ID);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_EXPR);
 			if (node)
@@ -16791,7 +16864,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| ROWNUM
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | ROWNUM);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_EXPR);
 
@@ -16815,7 +16888,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_ADD_MONTHS); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | ADD_MONTHS  '(' expression_ ',' expression_ ')');
 
 			$$ = parser_make_expression (this_parser, PT_ADD_MONTHS, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -16825,7 +16898,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_OCTET_LENGTH); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | OCTET_LENGTH  '(' expression_ ')');
 
 			$$ = parser_make_expression (this_parser, PT_OCTET_LENGTH, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -16835,7 +16908,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_BIT_LENGTH); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | BIT_LENGTH  '(' expression_ ')');
 
 			$$ = parser_make_expression (this_parser, PT_BIT_LENGTH, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -16845,7 +16918,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_LOWER); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | BIT_LENGTH '(' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_LOWER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -16855,7 +16928,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_LOWER); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | LCASE '(' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_LOWER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -16865,7 +16938,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_UPPER); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | UPPER '(' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_UPPER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -16875,14 +16948,14 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_UPPER); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | UCASE '(' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_UPPER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| SYS_CONNECT_BY_PATH
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_CONNECT_BY_PATH );
 
 			push_msg(MSGCAT_SYNTAX_INVALID_SYS_CONNECT_BY_PATH);
 
@@ -16894,7 +16967,7 @@ reserved_func
 		}}
 	  '(' expression_ ',' char_string_literal ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  '(' expression_ ',' char_string_literal ')' );
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_SYS_CONNECT_BY_PATH, $4, $6, NULL);
 			PT_NODE *char_string_node = $6;
@@ -16919,7 +16992,7 @@ reserved_func
 		{ push_msg (MSGCAT_SYNTAX_INVALID_IF); }
 	  '(' search_condition ',' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | IF '(' search_condition ',' expression_ ',' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_IF, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -16929,7 +17002,7 @@ reserved_func
 		{ push_msg (MSGCAT_SYNTAX_INVALID_IFNULL); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | IFNULL  '(' expression_ ',' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_IFNULL, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -16939,7 +17012,7 @@ reserved_func
 		{ push_msg (MSGCAT_SYNTAX_INVALID_ISNULL); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | ISNULL  '(' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_ISNULL, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -16949,7 +17022,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_LEFT); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | LEFT  '(' expression_ ',' expression_ ')' );
 			PT_NODE *node =
 			  parser_make_expression (this_parser, PT_LEFT, $4, $6, NULL);
 			PICE (node);
@@ -16961,7 +17034,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_RIGHT); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | RIGHT  '(' expression_ ',' expression_ ')' );
 			PT_NODE *node =
 			  parser_make_expression (this_parser, PT_RIGHT, $4, $6, NULL);
 			PICE (node);
@@ -16973,7 +17046,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MODULUS); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | MOD  '(' expression_ ',' expression_ ')' );
 			PT_NODE *node =
 			  parser_make_expression (this_parser, PT_MODULUS, $4, $6, NULL);
 			PICE (node);
@@ -16985,7 +17058,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRUNCATE); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | TRUNCATE  '(' expression_ ',' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_TRUNC, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -16995,7 +17068,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRANSLATE); }
 	  '(' expression_  ',' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | TRANSLATE  '(' expression_  ',' expression_ ',' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_TRANSLATE, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -17005,7 +17078,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRANSLATE); }
 	  '(' expression_  ',' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | REPLACE  '(' expression_  ',' expression_ ',' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_REPLACE, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -17015,7 +17088,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_REPLACE); }
 	  '(' expression_  ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | REPLACE '(' expression_  ',' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_REPLACE, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -17025,7 +17098,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_STRTODATE); }
 	  '(' expression_  ',' string_literal_or_input_hv ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | STR_TO_DATE '(' expression_  ',' string_literal_or_input_hv ')' );
 
 			$$ = parser_make_expression (this_parser, PT_STR_TO_DATE, $4, $6, parser_make_date_lang (2, NULL));
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -17035,7 +17108,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_STRTODATE); }
 	  '(' expression_  ',' Null ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | STR_TO_DATE '(' expression_  ',' Null ')' );
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  {
@@ -17051,7 +17124,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CHARSET); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | CHARSET  '(' expression_ ')' );
 			PT_NODE *node =
 			  parser_make_expression (this_parser, PT_CHARSET, $4, NULL, NULL);
 			PICE (node);
@@ -17063,7 +17136,7 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_COLLATION); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func,  | COLLATION  '(' expression_ ')' );
 			PT_NODE *node =
 			  parser_make_expression (this_parser, PT_COLLATION, $4, NULL, NULL);
 			PICE (node);
@@ -17072,7 +17145,7 @@ reserved_func
 
 		DBG_PRINT}}
 	| of_cume_dist_percent_rank_function '(' expression_list ')' WITHIN GROUP_ '('ORDER BY sort_spec_list')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_cume_dist_percent_rank_function '(' expression_list ')' WITHIN GROUP_ '('ORDER BY sort_spec_list')' );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 			if (node)
@@ -17091,134 +17164,134 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_INDEX_PREFIX); }
 	  '(' expression_  ',' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | INDEX_PREFIX  '(' expression_  ',' expression_ ',' expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_INDEX_PREFIX, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
         | JSON_ARRAY_APPEND '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAY_APPEND '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_ARRAY_APPEND, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_ARRAY_INSERT '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAY_INSERT '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_ARRAY_INSERT, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_ARRAY_LEX '(' opt_expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAY_LEX '(' opt_expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_ARRAY, $3, 0, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
 	| JSON_CONTAINS '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_CONTAINS '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_CONTAINS, $3, 2, 3);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 	      DBG_PRINT}}
 	| JSON_CONTAINS_PATH '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_CONTAINS_PATH '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_CONTAINS_PATH, $3, 3, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_DEPTH '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_DEPTH '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_DEPTH, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_EXTRACT '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_EXTRACT '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_EXTRACT, $3, 2, 0);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_GET_ALL_PATHS '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_GET_ALL_PATHS '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_GET_ALL_PATHS, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_INSERT '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_INSERT '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_INSERT, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_KEYS '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_KEYS '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_KEYS, $3, 0, 2);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_LENGTH '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_LENGTH '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_LENGTH, $3, 1, 2);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_MERGE '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_MERGE '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_MERGE, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_MERGE_PATCH '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_MERGE_PATCH '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_MERGE_PATCH, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_MERGE_PRESERVE '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_MERGE_PRESERVE '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_MERGE, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_OBJECT_LEX '(' opt_expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_OBJECT_LEX '(' opt_expression_list ')');
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_OBJECT, $3, 0, 0, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_PRETTY '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_PRETTY '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_PRETTY, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_QUOTE '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_QUOTE '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_QUOTE, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_REMOVE '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_REMOVE '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_REMOVE, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_REPLACE '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_REPLACE '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_REPLACE, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_SET '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_SET '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_SET, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_SEARCH '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_SEARCH '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_SEARCH, $3, 3, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_TYPE '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_TYPE '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_TYPE, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_UNQUOTE '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_UNQUOTE '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_UNQUOTE, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | JSON_VALID '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_VALID '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_VALID, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | simple_path_id RIGHT_ARROW CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | simple_path_id RIGHT_ARROW CHAR_STRING);
 		    PT_NODE *matcher = parser_new_node (this_parser, PT_VALUE);
                     if (matcher != NULL)
                       {
@@ -17233,7 +17306,7 @@ reserved_func
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
                 DBG_PRINT}}
         | simple_path_id DOUBLE_RIGHT_ARROW CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | simple_path_id DOUBLE_RIGHT_ARROW CHAR_STRING);
                     PT_NODE *matcher = parser_new_node (this_parser, PT_VALUE);
                     if (matcher != NULL)
                       {
@@ -17249,32 +17322,32 @@ reserved_func
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
         | BENCHMARK '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | BENCHMARK '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_BENCHMARK, $3, 2, 2);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
-		| REGEXP_COUNT '(' expression_list ')'
-		{{
+	| REGEXP_COUNT '(' expression_list ')'
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_COUNT '(' expression_list ')');
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_COUNT, $3, 2, 4);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
-		| REGEXP_INSTR '(' expression_list ')'
-		{{
+	| REGEXP_INSTR '(' expression_list ')'
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_INSTR '(' expression_list ')');
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_INSTR, $3, 2, 6);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
-		| REGEXP_LIKE '(' expression_list ')'
-		{{
+	| REGEXP_LIKE '(' expression_list ')'
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_LIKE '(' expression_list ')');
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_LIKE, $3, 2, 3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
-		| REGEXP_REPLACE '(' expression_list ')'
-		{{
+	| REGEXP_REPLACE '(' expression_list ')'
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_REPLACE '(' expression_list ')');
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_REPLACE, $3, 3, 6);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
-		| REGEXP_SUBSTR '(' expression_list ')'
-		{{
+	| REGEXP_SUBSTR '(' expression_list ')'
+		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_SUBSTR '(' expression_list ')');
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_SUBSTR, $3, 2, 5);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
@@ -17282,12 +17355,12 @@ reserved_func
 
 of_cume_dist_percent_rank_function
 	: CUME_DIST
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_cume_dist_percent_rank_function, : CUME_DIST);
 			$$ = PT_CUME_DIST;
 		DBG_PRINT}}
 
-	|PERCENT_RANK
-		{{
+	| PERCENT_RANK
+		{{ DBG_TRACE_GRAMMAR(of_cume_dist_percent_rank_function, | PERCENT_RANK);
 			$$ = PT_PERCENT_RANK;
 		DBG_PRINT}}
     ;
@@ -17612,20 +17685,20 @@ of_distinct_unique
 
 opt_group_concat_separator
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_group_concat_separator, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| SEPARATOR char_string
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_group_concat_separator, | SEPARATOR char_string);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| SEPARATOR bit_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_group_concat_separator, | SEPARATOR bit_string_literal);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -17635,13 +17708,13 @@ opt_group_concat_separator
 
 opt_agg_order_by
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_agg_order_by, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| ORDER BY sort_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_agg_order_by, | ORDER BY sort_spec);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -17651,19 +17724,19 @@ opt_agg_order_by
 
 opt_analytic_from_last
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_analytic_from_last, : );
 
 			$$ = false;
 
 		DBG_PRINT}}
 	| FROM FIRST
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_analytic_from_last, | FROM FIRST);
 
 			$$ = false;
 
 		DBG_PRINT}}
 	| FROM LAST
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_analytic_from_last, | FROM LAST);
 
 			$$ = true;
 
@@ -17672,19 +17745,19 @@ opt_analytic_from_last
 
 opt_analytic_ignore_nulls
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_analytic_ignore_nulls, : );
 
 			$$ = false;
 
 		DBG_PRINT}}
 	| RESPECT NULLS
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_analytic_ignore_nulls, | RESPECT NULLS);
 
 			$$ = false;
 
 		DBG_PRINT}}
 	| IGNORE_ NULLS
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_analytic_ignore_nulls, | IGNORE_ NULLS);
 
 			$$ = true;
 
@@ -17693,13 +17766,13 @@ opt_analytic_ignore_nulls
 
 opt_analytic_partition_by
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_analytic_partition_by, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| PARTITION BY sort_spec_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_analytic_partition_by, | PARTITION BY sort_spec_list);
 
 			PT_NODE *list;
 			$$ = $3;
@@ -17719,14 +17792,14 @@ opt_analytic_partition_by
 
 opt_over_analytic_partition_by
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_over_analytic_partition_by, : );
 
 			is_analytic_function = false;
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| OVER '(' opt_analytic_partition_by ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_over_analytic_partition_by, | OVER '(' opt_analytic_partition_by ')' );
 
 			is_analytic_function = true;
 			$$= $3;
@@ -17736,13 +17809,13 @@ opt_over_analytic_partition_by
 
 opt_analytic_order_by
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_analytic_order_by, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| ORDER BY sort_spec_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_analytic_order_by, | ORDER BY sort_spec_list );
 
 			PT_NODE *list;
 			$$ = $3;
@@ -17761,19 +17834,19 @@ opt_analytic_order_by
 
 of_leading_trailing_both
 	: LEADING_
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_leading_trailing_both, : LEADING_ );
 
 			$$ = PT_LEADING;
 
 		DBG_PRINT}}
 	| TRAILING_
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_leading_trailing_both, | TRAILING_);
 
 			$$ = PT_TRAILING;
 
 		DBG_PRINT}}
 	| BOTH_
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_leading_trailing_both, | BOTH_ );
 
 			$$ = PT_BOTH;
 
@@ -17782,12 +17855,12 @@ of_leading_trailing_both
 
 case_expr
 	: NULLIF '(' expression_ ',' expression_ ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(case_expr, : NULLIF '(' expression_ ',' expression_ ')' );
 			$$ = parser_make_expression (this_parser, PT_NULLIF, $3, $5, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
 	| COALESCE '(' expression_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(case_expr, | COALESCE '(' expression_list ')' );
 			PT_NODE *prev, *expr, *arg, *tmp;
 			int count = parser_count_list ($3);
 			int i;
@@ -17853,7 +17926,7 @@ case_expr
 
 		DBG_PRINT}}
 	| CASE expression_ simple_when_clause_list opt_else_expr END
-		{{
+		{{ DBG_TRACE_GRAMMAR(case_expr, | CASE expression_ simple_when_clause_list opt_else_expr END );
 
 			int i;
 			PT_NODE *case_oper = $2;
@@ -17911,7 +17984,7 @@ case_expr
 
 		DBG_PRINT}}
 	| CASE searched_when_clause_list opt_else_expr END
-		{{
+		{{ DBG_TRACE_GRAMMAR(case_expr, | CASE searched_when_clause_list opt_else_expr END );
 
 			int i;
 			PT_NODE *node, *prev, *curr, *p;
@@ -17959,13 +18032,13 @@ case_expr
 
 opt_else_expr
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_else_expr, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| ELSE expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_else_expr, | ELSE expression_);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -17975,14 +18048,14 @@ opt_else_expr
 
 simple_when_clause_list
 	: simple_when_clause_list simple_when_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(simple_when_clause_list, : simple_when_clause_list simple_when_clause);
 
 			$$ = parser_make_link ($1, $2);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| simple_when_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(simple_when_clause_list, | simple_when_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -17992,7 +18065,7 @@ simple_when_clause_list
 
 simple_when_clause
 	: WHEN expression_ THEN expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(simple_when_clause, : WHEN expression_ THEN expression_);
 
 			PT_NODE *node, *p, *q;
 			p = $2;
@@ -18024,14 +18097,14 @@ simple_when_clause
 
 searched_when_clause_list
 	: searched_when_clause_list searched_when_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(searched_when_clause_list, : searched_when_clause_list searched_when_clause);
 
 			$$ = parser_make_link ($1, $2);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| searched_when_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(searched_when_clause_list, | searched_when_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -18041,7 +18114,7 @@ searched_when_clause_list
 
 searched_when_clause
 	: WHEN search_condition THEN expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(searched_when_clause, : WHEN search_condition THEN expression_);
 
 			PT_NODE *node, *p;
 			node = parser_new_node (this_parser, PT_EXPR);
@@ -18070,7 +18143,7 @@ searched_when_clause
 
 extract_expr
 	: EXTRACT '(' datetime_field FROM expression_ ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(extract_expr, : EXTRACT '(' datetime_field FROM expression_ ')');
 
 			PT_NODE *tmp;
 			tmp = parser_make_expression (this_parser, PT_EXTRACT, $5, NULL, NULL);
@@ -18217,13 +18290,13 @@ datetime_field
 
 opt_on_target
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_on_target, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| ON_ primary
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_on_target, | ON_ primary);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -18233,7 +18306,7 @@ opt_on_target
 
 generic_function
 	: identifier '(' opt_expression_list ')' opt_on_target
-		{{
+		{{ DBG_TRACE_GRAMMAR(generic_function, : identifier '(' opt_expression_list ')' opt_on_target );
 
 			PT_NODE *node = NULL;
 			if ($5 == NULL)
@@ -18260,7 +18333,7 @@ generic_function
 
 generic_function_id
 	: generic_function
-		{{
+		{{ DBG_TRACE_GRAMMAR(generic_function_id, : generic_function );
 
 			PT_NODE *node = $1;
 
@@ -18302,13 +18375,13 @@ generic_function_id
 
 opt_expression_list
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_expression_list, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| expression_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_expression_list, | expression_list );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -18318,7 +18391,7 @@ opt_expression_list
 
 table_set_function_call
 	: SET subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_set_function_call, : SET subquery );
 
 			PT_NODE *func_node;
 			func_node = parser_new_node (this_parser, PT_FUNCTION);
@@ -18332,7 +18405,7 @@ table_set_function_call
 
 		DBG_PRINT}}
 	| SEQUENCE subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_set_function_call, | SEQUENCE subquery );
 
 			PT_NODE *func_node;
 			func_node = parser_new_node (this_parser, PT_FUNCTION);
@@ -18346,7 +18419,7 @@ table_set_function_call
 
 		DBG_PRINT}}
 	| LIST subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_set_function_call, | LIST subquery );
 
 			PT_NODE *func_node;
 			func_node = parser_new_node (this_parser, PT_FUNCTION);
@@ -18360,7 +18433,7 @@ table_set_function_call
 
 		DBG_PRINT}}
 	| MULTISET subquery
-		{{
+		{{ DBG_TRACE_GRAMMAR(table_set_function_call, | MULTISET subquery );
 
 			PT_NODE *func_node;
 			func_node = parser_new_node (this_parser, PT_FUNCTION);
@@ -18377,7 +18450,7 @@ table_set_function_call
 
 search_condition
 	: search_condition OR boolean_term_xor
-		{{DBG_PRINT_MATCH_LN("search_condition > : search_condition OR boolean_term_xor");
+		{{DBG_TRACE_GRAMMAR(search_condition, : search_condition OR boolean_term_xor);
 			PT_NODE *arg1 = pt_check_non_logical_expr(this_parser, $1);
 			PT_NODE *arg2 = pt_check_non_logical_expr(this_parser, $3);
 			$$ = parser_make_expression (this_parser, PT_OR, arg1, arg2, NULL);
@@ -18385,7 +18458,7 @@ search_condition
 
 		DBG_PRINT}}
 	| boolean_term_xor
-		{{DBG_PRINT_MATCH_LN("search_condition > | boolean_term_xor");
+		{{DBG_TRACE_GRAMMAR(search_condition, | boolean_term_xor);
 			$$ = pt_check_non_logical_expr(this_parser, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
@@ -18394,7 +18467,7 @@ search_condition
 
 boolean_term_xor
 	: boolean_term_xor XOR boolean_term_is
-		{{DBG_PRINT_MATCH_LN("boolean_term_xor > : boolean_term_xor XOR boolean_term_is");
+		{{DBG_TRACE_GRAMMAR(boolean_term_xor, : boolean_term_xor XOR boolean_term_is);
 			PT_NODE *arg1 = pt_check_non_logical_expr(this_parser, $1);
 			PT_NODE *arg2 = pt_check_non_logical_expr(this_parser, $3);
 			$$ = parser_make_expression (this_parser, PT_XOR, arg1, arg2, NULL);
@@ -18402,7 +18475,7 @@ boolean_term_xor
 
 		DBG_PRINT}}
 	| boolean_term_is
-		{{DBG_PRINT_MATCH_LN("boolean_term_xor > | boolean_term_is");
+		{{DBG_TRACE_GRAMMAR(boolean_term_xor, | boolean_term_is);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -18411,14 +18484,14 @@ boolean_term_xor
 
 boolean_term_is
 	: boolean_term_is is_op boolean
-		{{DBG_PRINT_MATCH_LN("boolean_term_xor > : boolean_term_is");
+		{{DBG_TRACE_GRAMMAR(boolean_term_xor, : boolean_term_is);
 	                PT_NODE *arg = pt_check_non_logical_expr(this_parser, $1);
 			$$ = parser_make_expression (this_parser, $2, arg, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| boolean_term
-		{{DBG_PRINT_MATCH_LN("boolean_term_xor > | boolean_term_is");
+		{{DBG_TRACE_GRAMMAR(boolean_term_xor, | boolean_term_is);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -18428,13 +18501,13 @@ boolean_term_is
 
 is_op
 	: IS NOT
-		{{
+		{{ DBG_TRACE_GRAMMAR(is_op, : IS NOT);
 
 			$$ = PT_IS_NOT;
 
 		DBG_PRINT}}
 	| IS
-		{{
+		{{ DBG_TRACE_GRAMMAR(is_op, | IS);
 
 			$$ = PT_IS;
 
@@ -18443,7 +18516,7 @@ is_op
 
 boolean_term
 	: boolean_term AND boolean_factor
-		{{DBG_PRINT_MATCH_LN("boolean_term > : boolean_term AND boolean_factor");
+		{{DBG_TRACE_GRAMMAR(boolean_term, : boolean_term AND boolean_factor);
 			PT_NODE *arg1 = pt_check_non_logical_expr(this_parser, $1);
 			PT_NODE *arg2 = pt_check_non_logical_expr(this_parser, $3);
 			$$ = parser_make_expression (this_parser, PT_AND, arg1, arg2, NULL);
@@ -18451,7 +18524,7 @@ boolean_term
 
 		DBG_PRINT}}
 	| boolean_factor
-		{{DBG_PRINT_MATCH_LN("boolean_term > | boolean_factor");
+		{{DBG_TRACE_GRAMMAR(boolean_term, | boolean_factor);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -18461,7 +18534,7 @@ boolean_term
 
 boolean_factor
 	: NOT predicate
-		{{DBG_PRINT_MATCH_LN("boolean_factor > : NOT predicate");
+		{{DBG_TRACE_GRAMMAR(boolean_factor, : NOT predicate);
 
 			PT_NODE *arg = pt_check_non_logical_expr(this_parser, $2);
 			$$ = parser_make_expression (this_parser, PT_NOT, arg, NULL, NULL);
@@ -18469,7 +18542,7 @@ boolean_factor
 
 		DBG_PRINT}}
 	| '!' predicate
-		{{DBG_PRINT_MATCH_LN("boolean_factor > | '!' predicate");
+		{{DBG_TRACE_GRAMMAR(boolean_factor, | '!' predicate);
 
 			PT_NODE *arg = pt_check_non_logical_expr(this_parser, $2);
 			$$ = parser_make_expression (this_parser, PT_NOT, arg, NULL, NULL);
@@ -18477,7 +18550,7 @@ boolean_factor
 
 		DBG_PRINT}}
 	| predicate
-		{{DBG_PRINT_MATCH_LN("boolean_factor > | predicate");
+		{{DBG_TRACE_GRAMMAR(boolean_factor, | predicate);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -18487,13 +18560,13 @@ boolean_factor
 
 predicate
 	: EXISTS expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate, : EXISTS expression_);
 			$$ = parser_make_expression (this_parser, PT_EXISTS, $2, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate, | expression_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -18503,7 +18576,7 @@ predicate
 
 predicate_expression
 	: predicate_expr_sub
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expression, : predicate_expr_sub);
 
 			PT_JOIN_TYPE join_type = parser_top_join_type ();
 			if (join_type == PT_JOIN_RIGHT_OUTER)
@@ -18511,7 +18584,7 @@ predicate_expression
 
 		DBG_PRINT}}
 	  opt_paren_plus
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expression, opt_paren_plus);
 
 			PT_JOIN_TYPE join_type = parser_pop_join_type ();
 			PT_NODE *e, *attr;
@@ -18598,7 +18671,7 @@ predicate_expression
 
 predicate_expr_sub
 	: pred_lhs comp_op normal_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, : pred_lhs comp_op normal_expression);
 
 			PT_NODE *e, *opd1, *opd2, *subq, *t;
 			PT_OP_TYPE op;
@@ -18737,7 +18810,7 @@ predicate_expr_sub
 
 		DBG_PRINT}}
 	| pred_lhs like_op normal_expression ESCAPE escape_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs like_op normal_expression ESCAPE escape_literal);
 
 			PT_NODE *esc = parser_make_expression (this_parser, PT_LIKE_ESCAPE, $3, $5, NULL);
 			PT_NODE *node = parser_make_expression (this_parser, $2, $1, esc, NULL);
@@ -18746,7 +18819,7 @@ predicate_expr_sub
 
 		DBG_PRINT}}
 	| pred_lhs like_op normal_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs like_op normal_expression);
 
  			if (prm_get_bool_value (PRM_ID_REQUIRE_LIKE_ESCAPE_CHARACTER)
  			    && prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES))
@@ -18761,7 +18834,7 @@ predicate_expr_sub
 
 		DBG_PRINT}}
 	| pred_lhs rlike_op normal_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs rlike_op normal_expression);
 
 			/* case sensitivity flag */
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
@@ -18781,21 +18854,21 @@ predicate_expr_sub
 
 		DBG_PRINT}}
 	| pred_lhs null_op
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs null_op);
 
 			$$ = parser_make_expression (this_parser, $2, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| pred_lhs set_op normal_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs set_op normal_expression);
 
 			$$ = parser_make_expression (this_parser, $2, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| pred_lhs between_op normal_expression AND normal_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs between_op normal_expression AND normal_expression);
 
 			PT_NODE *node = parser_make_expression (this_parser, PT_BETWEEN_AND, $3, $5, NULL);
 			$$ = parser_make_expression (this_parser, $2, $1, node, NULL);
@@ -18803,7 +18876,7 @@ predicate_expr_sub
 
 		DBG_PRINT}}
 	| pred_lhs in_op in_pred_operand
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs in_op in_pred_operand);
 
 			PT_NODE *node = parser_make_expression (this_parser, $2, $1, NULL, NULL);
 			PT_NODE *t = CONTAINER_AT_1 ($3);
@@ -18992,14 +19065,14 @@ predicate_expr_sub
 		DBG_PRINT}}
 	;
 	| pred_lhs RANGE_ '(' range_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs RANGE_ '(' range_list ')');
 
 			$$ = parser_make_expression (this_parser, PT_RANGE, $1, $4, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| pred_lhs IdName
-		{{
+		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs IdName);
 			PT_ERRORm (this_parser, $1, MSGCAT_SET_PARSER_SYNTAX,
 				    MSGCAT_SYNTAX_INVALID_RELATIONAL_OP);
 
@@ -19008,7 +19081,7 @@ predicate_expr_sub
 
 pred_lhs
 	: normal_expression opt_paren_plus
-		{{
+		{{ DBG_TRACE_GRAMMAR(pred_lhs, : normal_expression opt_paren_plus);
 
 			PT_JOIN_TYPE join_type = PT_JOIN_NONE;
 
@@ -19027,13 +19100,13 @@ pred_lhs
 
 opt_paren_plus
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_paren_plus, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| paren_plus
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_paren_plus, | paren_plus);
 
 			$$ = 1;
 
@@ -19042,7 +19115,7 @@ opt_paren_plus
 
 comp_op
 	:  '=' opt_of_all_some_any
-		{{
+		{{ DBG_TRACE_GRAMMAR(comp_op, :  '=' opt_of_all_some_any);
 
 			switch ($2)
 			  {
@@ -19062,7 +19135,7 @@ comp_op
 
 		DBG_PRINT}}
 	| COMP_NOT_EQ opt_of_all_some_any
-		{{
+		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_NOT_EQ opt_of_all_some_any);
 
 			switch ($2)
 			  {
@@ -19082,7 +19155,7 @@ comp_op
 
 		DBG_PRINT}}
 	| '>' opt_of_all_some_any
-		{{
+		{{ DBG_TRACE_GRAMMAR(comp_op, | '>' opt_of_all_some_any);
 
 			switch ($2)
 			  {
@@ -19102,7 +19175,7 @@ comp_op
 
 		DBG_PRINT}}
 	| COMP_GE opt_of_all_some_any
-		{{
+		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_GE opt_of_all_some_any);
 
 			switch ($2)
 			  {
@@ -19122,7 +19195,7 @@ comp_op
 
 		DBG_PRINT}}
 	| '<'  opt_of_all_some_any
-		{{
+		{{ DBG_TRACE_GRAMMAR(comp_op, | '<'  opt_of_all_some_any);
 
 			switch ($2)
 			  {
@@ -19142,7 +19215,7 @@ comp_op
 
 		DBG_PRINT}}
 	| COMP_LE opt_of_all_some_any
-		{{
+		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_LE opt_of_all_some_any);
 
 			switch ($2)
 			  {
@@ -19162,21 +19235,21 @@ comp_op
 
 		DBG_PRINT}}
 	| '=''=' opt_of_all_some_any
-		{{
+		{{ DBG_TRACE_GRAMMAR(comp_op, | '=''=' opt_of_all_some_any);
 
 			push_msg (MSGCAT_SYNTAX_INVALID_EQUAL_OP);
 			csql_yyerror_explicit (@1.first_line, @1.first_column);
 
 		DBG_PRINT}}
 	| '!''=' opt_of_all_some_any
-		{{
+		{{ DBG_TRACE_GRAMMAR(comp_op, | '!''=' opt_of_all_some_any);
 
 			push_msg (MSGCAT_SYNTAX_INVALID_NOT_EQUAL);
 			csql_yyerror_explicit (@1.first_line, @1.first_column);
 
 		DBG_PRINT}}
 	| COMP_NULLSAFE_EQ opt_of_all_some_any
-		{{
+		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_NULLSAFE_EQ opt_of_all_some_any);
 
 			$$ = PT_NULLSAFE_EQ;
 
@@ -19185,25 +19258,25 @@ comp_op
 
 opt_of_all_some_any
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_all_some_any, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| ALL
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_all_some_any, | ALL );
 
 			$$ = 1;
 
 		DBG_PRINT}}
 	| SOME
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_all_some_any, | SOME );
 
 			$$ = 2;
 
 		DBG_PRINT}}
 	| ANY
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_all_some_any, | ANY );
 
 			$$ = 3;
 
@@ -19212,13 +19285,13 @@ opt_of_all_some_any
 
 like_op
 	: NOT LIKE
-		{{
+		{{ DBG_TRACE_GRAMMAR(like_op, : NOT LIKE );
 
 			$$ = PT_NOT_LIKE;
 
 		DBG_PRINT}}
 	| LIKE
-		{{
+		{{ DBG_TRACE_GRAMMAR(like_op, | LIKE );
 
 			$$ = PT_LIKE;
 
@@ -19227,25 +19300,25 @@ like_op
 
 rlike_op
 	: rlike_or_regexp
-		{{
+		{{ DBG_TRACE_GRAMMAR(rlike_op, : rlike_or_regexp);
 
 			$$ = PT_RLIKE;
 
 		DBG_PRINT}}
 	| NOT rlike_or_regexp
-		{{
+		{{ DBG_TRACE_GRAMMAR(rlike_op, | NOT rlike_or_regexp);
 
 			$$ = PT_NOT_RLIKE;
 
 		DBG_PRINT}}
 	| rlike_or_regexp BINARY
-		{{
+		{{ DBG_TRACE_GRAMMAR(rlike_op, | rlike_or_regexp BINARY );
 
 			$$ = PT_RLIKE_BINARY;
 
 		DBG_PRINT}}
 	| NOT rlike_or_regexp BINARY
-		{{
+		{{ DBG_TRACE_GRAMMAR(rlike_op, | NOT rlike_or_regexp BINARY);
 
 			$$ = PT_NOT_RLIKE_BINARY;
 
@@ -19259,13 +19332,13 @@ rlike_or_regexp
 
 null_op
 	: IS NOT Null
-		{{
+		{{ DBG_TRACE_GRAMMAR(null_op, : IS NOT Null);
 
 			$$ = PT_IS_NOT_NULL;
 
 		DBG_PRINT}}
 	| IS Null
-		{{
+		{{ DBG_TRACE_GRAMMAR(null_op, | IS Null);
 
 			$$ = PT_IS_NULL;
 
@@ -19275,13 +19348,13 @@ null_op
 
 between_op
 	: NOT BETWEEN
-		{{
+		{{ DBG_TRACE_GRAMMAR(between_op, : NOT BETWEEN);
 
 			$$ = PT_NOT_BETWEEN;
 
 		DBG_PRINT}}
 	| BETWEEN
-		{{
+		{{ DBG_TRACE_GRAMMAR(between_op, | BETWEEN);
 
 			$$ = PT_BETWEEN;
 
@@ -19290,13 +19363,13 @@ between_op
 
 in_op
 	: IN_
-		{{
+		{{ DBG_TRACE_GRAMMAR(in_op, : IN_);
 
 			$$ = PT_IS_IN;
 
 		DBG_PRINT}}
 	| NOT IN_
-		{{
+		{{ DBG_TRACE_GRAMMAR(in_op, | NOT IN_);
 
 			$$ = PT_IS_NOT_IN;
 
@@ -19305,7 +19378,7 @@ in_op
 
 in_pred_operand
 	: expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(in_pred_operand, : expression_);
 			container_2 ctn;
 			PT_NODE *exp = $1;
 			if (exp && exp->flag.is_paren == 0)
@@ -19323,14 +19396,14 @@ in_pred_operand
 
 range_list
 	: range_list OR range_
-		{{
+		{{ DBG_TRACE_GRAMMAR(range_list, : range_list OR range_);
 
 			$$ = parser_make_link_or ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| range_
-		{{
+		{{ DBG_TRACE_GRAMMAR(range_list, | range_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -19340,63 +19413,63 @@ range_list
 
 range_
 	: expression_ GE_LE_ expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(range_, : expression_ GE_LE_ expression_);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GE_LE, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_ GE_LT_ expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GE_LT_ expression_);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GE_LT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_ GT_LE_ expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GT_LE_ expression_);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GT_LE, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_ GT_LT_ expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GT_LT_ expression_);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GT_LT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_ '='
-		{{
+		{{ DBG_TRACE_GRAMMAR(range_, | expression_ '=');
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_EQ_NA, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_ GE_INF_ Max
-		{{
+		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GE_INF_ Max);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GE_INF, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| expression_ GT_INF_ Max
-		{{
+		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GT_INF_ Max);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GT_INF, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| Min INF_LE_ expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(range_, | Min INF_LE_ expression_);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_INF_LE, $3, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| Min INF_LT_ expression_
-		{{
+		{{ DBG_TRACE_GRAMMAR(range_, | Min INF_LT_ expression_);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_INF_LT, $3, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -19445,7 +19518,7 @@ set_op
 
 subquery
 	: '(' csql_query ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(subquery, : '(' csql_query ')');
 
 			PT_NODE *stmt = $2;
 
@@ -19465,7 +19538,7 @@ subquery
 
 subquery_without_subquery_and_with_clause
 	: '(' csql_query_without_subquery_and_with_clause ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(subquery_without_subquery_and_with_clause, : '(' csql_query_without_subquery_and_with_clause ')');
 
 			PT_NODE *stmt = $2;
 
@@ -19486,7 +19559,7 @@ subquery_without_subquery_and_with_clause
 
 path_expression
 	: path_header path_dot NONE		%dprec 6
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_expression, : path_header path_dot NONE);
 
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
 			if (p)
@@ -19498,14 +19571,14 @@ path_expression
 
 		DBG_PRINT}}
 	| path_header path_dot IDENTITY		%dprec 5
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_expression, | path_header path_dot IDENTITY);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| path_header path_dot OBJECT		%dprec 4
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_expression, | path_header path_dot OBJECT);
 
 			PT_NODE *node = $1;
 			if (node && node->node_type == PT_NAME)
@@ -19518,7 +19591,7 @@ path_expression
 
 		DBG_PRINT}}
 	| path_header DOT '*'			%dprec 3
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_expression, | path_header DOT '*');
 
 			PT_NODE *node = $1;
 			if (node && node->node_type == PT_NAME &&
@@ -19538,7 +19611,7 @@ path_expression
 
 		DBG_PRINT}}
 	| path_id_list				%dprec 2
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_expression, | path_id_list);
 			PT_NODE *dot;
 			PT_NODE *serial_value = NULL;
 
@@ -19616,7 +19689,7 @@ path_expression
 
 path_id_list
 	: path_id_list path_dot path_id			%dprec 1
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_id_list, : path_id_list path_dot path_id);
 
 			PT_NODE *dot = parser_new_node (this_parser, PT_DOT_);
 			if (dot)
@@ -19630,7 +19703,7 @@ path_id_list
 
 		DBG_PRINT}}
 	| path_header					%dprec 2
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_id_list, | path_header);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -19640,14 +19713,14 @@ path_id_list
 
 path_header
 	: param_
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_header, : param_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| CLASS path_id
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_header, | CLASS path_id);
 
 			PT_NODE *node = $2;
 			if (node && node->node_type == PT_NAME)
@@ -19656,7 +19729,7 @@ path_header
 
 		DBG_PRINT}}
 	| path_id
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_header, | path_id);
 
 			PT_NODE *node = $1;
 			if (node && node->node_type == PT_NAME)
@@ -19669,12 +19742,12 @@ path_header
 
 path_dot
 	: DOT
-	| RIGHT_ARROW
+	| RIGHT_ARROW  { DBG_TRACE_GRAMMAR(path_dot, | RIGHT_ARROW); }
 	;
 
 path_id
 	: identifier '{' identifier '}'
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_id, : identifier '{' identifier '}');
 
 			PT_NODE *corr = $3;
 			PT_NODE *name = $1;
@@ -19686,21 +19759,21 @@ path_id
 
 		DBG_PRINT}}
 	| identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_id, | identifier);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| generic_function_id
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_id, | generic_function_id);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| table_set_function_call
-		{{
+		{{ DBG_TRACE_GRAMMAR(path_id, | table_set_function_call);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -19710,7 +19783,7 @@ path_id
 
 simple_path_id
 	: identifier DOT identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(simple_path_id, : identifier DOT identifier);
 
 			PT_NODE *dot = parser_new_node (this_parser, PT_DOT_);
 			if (dot)
@@ -19724,7 +19797,7 @@ simple_path_id
 
 		DBG_PRINT}}
 	| identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(simple_path_id, | identifier);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -19761,19 +19834,19 @@ opt_in_out
 
 negative_prec_cast_type
 	: CHAR_
-		{{
+		{{ DBG_TRACE_GRAMMAR(negative_prec_cast_type, : CHAR_);
 
 			$$ = PT_TYPE_CHAR;
 
 		DBG_PRINT}}
 	| NATIONAL CHAR_
-		{{
+		{{ DBG_TRACE_GRAMMAR(negative_prec_cast_type, |  NATIONAL CHAR_);
 
 			$$ = PT_TYPE_NCHAR;
 
 		DBG_PRINT}}
 	| NCHAR
-		{{
+		{{ DBG_TRACE_GRAMMAR(negative_prec_cast_type, | NCHAR);
 
 			$$ = PT_TYPE_NCHAR;
 
@@ -19782,12 +19855,12 @@ negative_prec_cast_type
 
 of_cast_data_type
 	: data_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_cast_data_type, : data_type);
 			$$ = $1;
 
 		DBG_PRINT}}
 	| negative_prec_cast_type '(' '-' unsigned_integer ')' opt_charset opt_collation
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_cast_data_type, | negative_prec_cast_type '(' '-' unsigned_integer ')' opt_charset opt_collation);
 			container_2 ctn;
 			PT_TYPE_ENUM typ = $1;
 			PT_NODE *len = NULL, *dt = NULL;
@@ -19865,7 +19938,7 @@ of_cast_data_type
 
 data_type
 	: nested_set primitive_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(data_type, : nested_set primitive_type);
 
 			container_2 ctn;
 			PT_TYPE_ENUM typ, e;
@@ -19890,7 +19963,7 @@ data_type
 
 		DBG_PRINT}}
 	| nested_set '(' data_type_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(data_type, | nested_set '(' data_type_list ')');
 
 			container_2 ctn;
 			PT_TYPE_ENUM typ;
@@ -19904,7 +19977,7 @@ data_type
 
 		DBG_PRINT}}
 	| nested_set '(' ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(data_type, | nested_set '(' ')');
 
 			container_2 ctn;
 			PT_TYPE_ENUM typ;
@@ -19915,7 +19988,7 @@ data_type
 
 		DBG_PRINT}}
 	| nested_set set_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(data_type, | nested_set set_type);
 
 			container_2 ctn;
 			PT_TYPE_ENUM typ;
@@ -19934,7 +20007,7 @@ data_type
 
 		DBG_PRINT}}
 	| set_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(data_type, | set_type);
 
 			container_2 ctn;
 			PT_TYPE_ENUM typ;
@@ -19944,7 +20017,7 @@ data_type
 
 		DBG_PRINT}}
 	| primitive_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(data_type, | primitive_type);
 
 			$$ = $1;
 
@@ -19953,13 +20026,13 @@ data_type
 
 nested_set
 	: nested_set set_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(nested_set, : nested_set set_type);
 
 			$$ = $1;
 
 		DBG_PRINT}}
 	| set_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(nested_set, | set_type);
 
 			$$ = $1;
 
@@ -19968,7 +20041,7 @@ nested_set
 
 data_type_list
 	: data_type_list ',' data_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(data_type_list, : data_type_list ',' data_type);
 
 			PT_NODE *dt;
 			PT_TYPE_ENUM e;
@@ -20001,7 +20074,7 @@ data_type_list
 
 		DBG_PRINT}}
 	| data_type
-		{{
+		{{ DBG_TRACE_GRAMMAR(data_type_list, | data_type);
 
 			PT_NODE *dt;
 			PT_TYPE_ENUM e;
@@ -20037,7 +20110,7 @@ data_type_list
 
 char_bit_type
 	: CHAR_ opt_varying
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_bit_type, : CHAR_ opt_varying);
 
 			if ($2)
 			  $$ = PT_TYPE_VARCHAR;
@@ -20046,13 +20119,13 @@ char_bit_type
 
 		DBG_PRINT}}
 	| VARCHAR
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_bit_type, | VARCHAR);
 
 			$$ = PT_TYPE_VARCHAR;
 
 		DBG_PRINT}}
 	| NATIONAL CHAR_ opt_varying
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_bit_type, | NATIONAL CHAR_ opt_varying);
 
 			if ($3)
 			  $$ = PT_TYPE_VARNCHAR;
@@ -20061,7 +20134,7 @@ char_bit_type
 
 		DBG_PRINT}}
 	| NCHAR	opt_varying
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_bit_type, | NCHAR	opt_varying);
 
 			if ($2)
 			  $$ = PT_TYPE_VARNCHAR;
@@ -20070,7 +20143,7 @@ char_bit_type
 
 		DBG_PRINT}}
 	| BIT opt_varying
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_bit_type, | BIT opt_varying);
 
 			if ($2)
 			  $$ = PT_TYPE_VARBIT;
@@ -20082,13 +20155,13 @@ char_bit_type
 
 opt_varying
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_varying, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| VARYING
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_varying, | VARYING);
 
 			$$ = 1;
 
@@ -20097,13 +20170,13 @@ opt_varying
 
 json_schema
 		: /* empty */
-			{{
+			{{ DBG_TRACE_GRAMMAR(json_schema, : );
 
 				$$ = 0;
 
 			DBG_PRINT}}
 		| '(' CHAR_STRING ')'
-			{{
+			{{ DBG_TRACE_GRAMMAR(json_schema, | '(' CHAR_STRING ')' );
 
 				$$ = $2;
 
@@ -20112,7 +20185,7 @@ json_schema
 
 primitive_type
 	: INTEGER opt_padding
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, : INTEGER opt_padding );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_INTEGER), NULL);
@@ -20120,7 +20193,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| SmallInt
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | SmallInt );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_SMALLINT), NULL);
@@ -20128,7 +20201,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| BIGINT
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | BIGINT );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_BIGINT), NULL);
@@ -20136,7 +20209,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| Double PRECISION
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | Double PRECISION );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DOUBLE), NULL);
@@ -20144,7 +20217,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| Double
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | Double );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DOUBLE), NULL);
@@ -20152,7 +20225,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| Date
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | Date );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATE), NULL);
@@ -20160,7 +20233,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| Time
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | Time );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIME), NULL);
@@ -20168,7 +20241,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| Utime
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | Utime );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMP), NULL);
@@ -20176,7 +20249,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| TIMESTAMP
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMP );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMP), NULL);
@@ -20184,7 +20257,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| TIMESTAMP WITH Time ZONE
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMP WITH Time ZONE );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPTZ), NULL);
@@ -20192,7 +20265,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| TIMESTAMPTZ
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMPTZ );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPTZ), NULL);
@@ -20200,7 +20273,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| TIMESTAMP WITH LOCAL Time ZONE
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMP WITH LOCAL Time ZONE );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPLTZ), NULL);
@@ -20208,7 +20281,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| TIMESTAMPLTZ
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMPLTZ );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPLTZ), NULL);
@@ -20216,7 +20289,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| DATETIME
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIME );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIME), NULL);
@@ -20224,7 +20297,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| DATETIME WITH Time ZONE
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIME WITH Time ZONE );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMETZ), NULL);
@@ -20232,7 +20305,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| DATETIMETZ
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIMETZ );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMETZ), NULL);
@@ -20240,7 +20313,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| DATETIME WITH LOCAL Time ZONE
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIME WITH LOCAL Time ZONE );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMELTZ), NULL);
@@ -20248,7 +20321,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| DATETIMELTZ
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIMELTZ );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMELTZ), NULL);
@@ -20256,7 +20329,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| Monetary
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | Monetary );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_MONETARY), NULL);
@@ -20264,7 +20337,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| JSON json_schema
-	    {{
+	    {{ DBG_TRACE_GRAMMAR(primitive_type, | JSON json_schema );
 			const char * json_schema_str = $2;
 			container_2 ctn;
 			PT_TYPE_ENUM type = PT_TYPE_JSON;
@@ -20287,7 +20360,7 @@ primitive_type
 			$$ = ctn;
 		DBG_PRINT}}
 	| OBJECT
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | OBJECT );
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_OBJECT), NULL);
 			$$ = ctn;
@@ -20296,7 +20369,7 @@ primitive_type
 	| String
 	  opt_charset
 	  opt_collation
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | String opt_charset opt_collation );
 
 			container_2 ctn;
 			PT_TYPE_ENUM typ = PT_TYPE_VARCHAR;
@@ -20356,7 +20429,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| BLOB_ opt_internal_external
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | BLOB_ opt_internal_external );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_BLOB), NULL);
@@ -20364,7 +20437,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| CLOB_ opt_internal_external
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | CLOB_ opt_internal_external );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_CLOB), NULL);
@@ -20372,7 +20445,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| class_name opt_identity
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | class_name opt_identity );
 
 			container_2 ctn;
 			PT_TYPE_ENUM typ = PT_TYPE_OBJECT;
@@ -20393,7 +20466,7 @@ primitive_type
 	  opt_prec_1
 	  opt_charset
 	  opt_collation
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | char_bit_type opt_prec_1 opt_charset opt_collation );
 
 			container_2 ctn;
 			PT_TYPE_ENUM typ = $1;
@@ -20557,7 +20630,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| NUMERIC opt_prec_2
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | NUMERIC opt_prec_2 );
 
 			container_2 ctn;
 			PT_TYPE_ENUM typ;
@@ -20605,7 +20678,7 @@ primitive_type
 
 		DBG_PRINT}}
    	| FLOAT_ opt_prec_1
-		{{
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | FLOAT_ opt_prec_1);
 
 			container_2 ctn;
 			PT_TYPE_ENUM typ;
@@ -20651,7 +20724,7 @@ primitive_type
 
 		DBG_PRINT}}
 	| ENUM '(' char_string_literal_list ')' opt_charset opt_collation
-	  {{
+	  {{ DBG_TRACE_GRAMMAR(primitive_type, | ENUM '(' char_string_literal_list ')' opt_charset opt_collation);
 			container_2 ctn;
 			int charset = -1;
 			int coll_id = -1;
@@ -20763,19 +20836,19 @@ primitive_type
 
 opt_internal_external
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_internal_external, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| INTERNAL
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_internal_external, | INTERNAL );
 
 			$$ = PT_LOB_INTERNAL;
 
 		DBG_PRINT}}
 	| EXTERNAL
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_internal_external, | EXTERNAL );
 
 			$$ = PT_LOB_EXTERNAL;
 
@@ -20784,13 +20857,13 @@ opt_internal_external
 
 opt_identity
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_identity, : );
 
 			$$ = 0;
 
 		DBG_PRINT}}
 	| IDENTITY
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_identity, | IDENTITY );
 
 			$$ = 1;
 
@@ -20799,13 +20872,13 @@ opt_identity
 
 opt_prec_1
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_prec_1, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| '(' unsigned_integer ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_prec_1, | '(' unsigned_integer ')' );
 
 			$$ = $2;
 
@@ -20814,13 +20887,13 @@ opt_prec_1
 
 opt_padding
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_padding, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| '(' unsigned_integer ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_padding, | '(' unsigned_integer ')' );
 
 			$$ = NULL;
 
@@ -20829,7 +20902,7 @@ opt_padding
 
 opt_prec_2
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_prec_2, : );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, NULL);
@@ -20837,7 +20910,7 @@ opt_prec_2
 
 		DBG_PRINT}}
 	| '(' unsigned_integer ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_prec_2, | '(' unsigned_integer ')' );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, NULL);
@@ -20845,7 +20918,7 @@ opt_prec_2
 
 		DBG_PRINT}}
 	| '(' unsigned_integer ',' unsigned_integer ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_prec_2, | '(' unsigned_integer ',' unsigned_integer ')' );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, $4);
@@ -20861,13 +20934,13 @@ of_charset
 
 opt_collation
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_collation, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| collation_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_collation, | collation_spec );
 
 			$$=$1;
 
@@ -20876,13 +20949,13 @@ opt_collation
 
 collation_spec
 	: COLLATE char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(collation_spec, : );
 
 			$$ = $2;
 
 		DBG_PRINT}}
 	| COLLATE BINARY
-		{{
+		{{ DBG_TRACE_GRAMMAR(collation_spec, | COLLATE BINARY);
 			PT_NODE *node;
 
 			node = parser_new_node (this_parser, PT_VALUE);
@@ -20899,7 +20972,7 @@ collation_spec
 			$$ = node;
 		DBG_PRINT}}
 	| COLLATE IdName
-		{{
+		{{ DBG_TRACE_GRAMMAR(collation_spec, | COLLATE IdName);
 			PT_NODE *node;
 
 			node = parser_new_node (this_parser, PT_VALUE);
@@ -20919,7 +20992,7 @@ collation_spec
 
 class_encrypt_spec
   : ENCRYPT opt_equalsign opt_encrypt_algorithm
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_encrypt_spec, : ENCRYPT opt_equalsign opt_encrypt_algorithm );
 			PT_NODE *node = NULL;
 
       node = parser_new_node (this_parser, PT_VALUE);
@@ -20937,7 +21010,7 @@ class_encrypt_spec
 
 class_comment_spec
 	: COMMENT opt_equalsign char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_comment_spec, : COMMENT opt_equalsign char_string_literal);
 			PT_NODE *node = $3;
 
 			if (node)
@@ -20959,9 +21032,10 @@ class_comment_spec
 	| COMMENT					/* 1 */
 	  ON_						/* 2 */
 	  opt_of_column_attribute			/* 3 */
-		{ parser_attr_type = PT_NORMAL; }	/* 4 */
+		{ DBG_TRACE_GRAMMAR(class_comment_spec, : COMMENT ON_ opt_of_column_attribute);
+                  parser_attr_type = PT_NORMAL; }	/* 4 */
 	  attr_def_comment_list				/* 5 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_comment_spec, attr_def_comment_list);
 			PT_NODE *alter_node = parser_get_alter_node();
 
 			if (alter_node != NULL)
@@ -20973,9 +21047,10 @@ class_comment_spec
 	| COMMENT					/* 1 */
 	  ON_						/* 2 */
 	  CLASS ATTRIBUTE				/* 3, 4 */
-		{ parser_attr_type = PT_META_ATTR; }	/* 5 */
+		{ DBG_TRACE_GRAMMAR(class_comment_spec, : COMMENT ON_ CLASS ATTRIBUTE);
+                   parser_attr_type = PT_META_ATTR; }	/* 5 */
 	  attr_def_comment_list 			/* 6 */
-		{{
+		{{ DBG_TRACE_GRAMMAR(class_comment_spec, attr_def_comment_list);
 			PT_NODE *alter_node = parser_get_alter_node();
 
 			if (alter_node != NULL)
@@ -20988,9 +21063,11 @@ class_comment_spec
 
 opt_vclass_comment_spec
 	: /* empty */
-		{ $$ = NULL; }
+		{ DBG_TRACE_GRAMMAR(opt_vclass_comment_spec, : );
+                  $$ = NULL; }
 	| class_comment_spec
-		{ $$ = $1; }
+		{ DBG_TRACE_GRAMMAR(opt_vclass_comment_spec, | class_comment_spec);
+                  $$ = $1; }
 	;
 
 opt_equalsign
@@ -21000,23 +21077,28 @@ opt_equalsign
 
 opt_encrypt_algorithm
   : /* empty */
-    { $$ = -1; }  /* default algorithm from the system parameter */
+    { DBG_TRACE_GRAMMAR(opt_encrypt_algorithm, : );  
+      $$ = -1; }  /* default algorithm from the system parameter */
   | AES
-    { $$ = 1; }   /* TDE_ALGORITHM_AES */ 
+    { DBG_TRACE_GRAMMAR(opt_encrypt_algorithm, | AES ); 
+      $$ = 1; }   /* TDE_ALGORITHM_AES */ 
   | ARIA
-    { $$ = 2; }   /* TDE_ALGORITHM_ARIA */
+    { DBG_TRACE_GRAMMAR(opt_encrypt_algorithm, | ARIA ); 
+      $$ = 2; }   /* TDE_ALGORITHM_ARIA */
   ;
 
 opt_comment_spec
 	: /* empty */
-		{ $$ = NULL; }
+		{ DBG_TRACE_GRAMMAR(opt_comment_spec, : );
+                  $$ = NULL; }
 	| COMMENT comment_value
-		{ $$ = $2; }
+		{ DBG_TRACE_GRAMMAR(opt_comment_spec, | COMMENT comment_value ); 
+                  $$ = $2; }
 	;
 
 comment_value
 	: char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(comment_value, : char_string_literal );
 			PT_NODE *node = $1;
 
 			if (node)
@@ -21039,13 +21121,13 @@ comment_value
 
 opt_charset
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_charset, : );
 
 			$$ = NULL;
 
 		DBG_PRINT}}
 	| charset_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_charset, | charset_spec);
 
 			$$ = $1;
 
@@ -21054,13 +21136,13 @@ opt_charset
 
 charset_spec
 	: of_charset char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(charset_spec, : of_charset char_string_literal );
 
 			$$ = $2;
 
 		DBG_PRINT}}
 	| of_charset BINARY
-		{{
+		{{ DBG_TRACE_GRAMMAR(charset_spec, | of_charset BINARY );
 			PT_NODE *node;
 
 			node = parser_new_node (this_parser, PT_VALUE);
@@ -21077,7 +21159,7 @@ charset_spec
 			$$ = node;
 		DBG_PRINT}}
 	| of_charset IdName
-		{{
+		{{ DBG_TRACE_GRAMMAR(charset_spec, | of_charset IdName );
 			PT_NODE *node;
 
 			node = parser_new_node (this_parser, PT_VALUE);
@@ -21097,7 +21179,7 @@ charset_spec
 
 opt_using_charset
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_using_charset, : );
 
 			int charset = lang_get_client_charset ();
 			PT_NODE *node;
@@ -21114,7 +21196,7 @@ opt_using_charset
 
 		DBG_PRINT}}
 	| USING char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_using_charset, | USING char_string_literal );
 
 			PT_NODE *charset_node = $2;
 			int dummy;
@@ -21141,7 +21223,7 @@ opt_using_charset
 
 		DBG_PRINT}}
 	| USING IdName
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_using_charset, | USING IdName );
 
 			PT_NODE *temp_node = NULL;
 			int dummy;
@@ -21180,7 +21262,7 @@ opt_using_charset
 
 		DBG_PRINT}}
 	| USING BINARY
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_using_charset, | USING BINARY );
 
 			PT_NODE *node;
 
@@ -21199,25 +21281,25 @@ opt_using_charset
 
 set_type
 	: SET_OF
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_type, : SET_OF );
 
 			$$ = PT_TYPE_SET;
 
 		DBG_PRINT}}
 	| MULTISET_OF
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_type, | MULTISET_OF );
 
 			$$ = PT_TYPE_MULTISET;
 
 		DBG_PRINT}}
 	| SEQUENCE_OF
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_type, | SEQUENCE_OF );
 
 			$$ = PT_TYPE_SEQUENCE;
 
 		DBG_PRINT}}
 	| of_container opt_of
-		{{
+		{{ DBG_TRACE_GRAMMAR(set_type, | of_container opt_of );
 
 			$$ = $1;
 
@@ -21231,14 +21313,14 @@ opt_of
 
 signed_literal_
 	: literal_
-		{{
+		{{ DBG_TRACE_GRAMMAR(signed_literal_,  : literal_ );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| '-' unsigned_integer
-		{{
+		{{ DBG_TRACE_GRAMMAR(signed_literal_, | '-' unsigned_integer );
 
 			PT_NODE *node = $2;
 			if (node != NULL)
@@ -21285,7 +21367,7 @@ signed_literal_
 
 		DBG_PRINT}}
 	| '-' unsigned_real
-		{{
+		{{ DBG_TRACE_GRAMMAR(signed_literal_,  | '-' unsigned_real);
 
 						/* not allowed partition type */
 						/* this will cause semantic error */
@@ -21324,7 +21406,7 @@ signed_literal_
 
 		DBG_PRINT}}
 	| '-' monetary_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(signed_literal_,  | '-' monetary_literal);
 
 						/* not allowed partition type */
 						/* this will cause semantic error */
@@ -21348,14 +21430,14 @@ signed_literal_
 
 literal_
 	: literal_w_o_param
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_,  : literal_w_o_param);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| param_
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_,  | param_ );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -21365,28 +21447,28 @@ literal_
 
 literal_w_o_param
 	: unsigned_integer
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param, : unsigned_integer );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| unsigned_real
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | unsigned_real );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| monetary_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  : unsigned_integer );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | char_string_literal);
 
 			PT_NODE *node = $1;
 
@@ -21397,21 +21479,21 @@ literal_w_o_param
 
 		DBG_PRINT}}
 	| bit_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | bit_string_literal );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| host_param_input
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | host_param_input );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| Null
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | Null );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -21421,14 +21503,14 @@ literal_w_o_param
 
 		DBG_PRINT}}
 	| constant_set
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param, | constant_set );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| NA
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | NA );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -21438,21 +21520,21 @@ literal_w_o_param
 
 		DBG_PRINT}}
 	| date_or_time_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param, | date_or_time_literal );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| boolean
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | boolean );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| json_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(literal_w_o_param, | json_literal );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -21461,7 +21543,7 @@ literal_w_o_param
 
 boolean
 	: True
-		{{
+		{{ DBG_TRACE_GRAMMAR(boolean, : True );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -21475,7 +21557,7 @@ boolean
 
 		DBG_PRINT}}
 	| False
-		{{
+		{{ DBG_TRACE_GRAMMAR(boolean, | False );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -21489,7 +21571,7 @@ boolean
 
 		DBG_PRINT}}
 	| UNKNOWN
-		{{
+		{{ DBG_TRACE_GRAMMAR(boolean, | UNKNOWN );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -21502,7 +21584,7 @@ boolean
 
 constant_set
 	: opt_of_container '{' expression_list '}'
-		{{
+		{{ DBG_TRACE_GRAMMAR(constant_set, : opt_of_container '{' expression_list '}' );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			PT_NODE *e;
@@ -21530,7 +21612,7 @@ constant_set
 
 		DBG_PRINT}}
 	| opt_of_container '{' '}'
-		{{
+		{{ DBG_TRACE_GRAMMAR(constant_set, | opt_of_container '{' '}' );
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 
@@ -21548,13 +21630,13 @@ constant_set
 
 opt_of_container
 	: /* empty */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_container, : );
 
 			$$ = PT_TYPE_SEQUENCE;
 
 		DBG_PRINT}}
 	| of_container
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_of_container, | of_container );
 
 			$$ = $1;
 
@@ -21563,25 +21645,25 @@ opt_of_container
 
 of_container
 	: SET
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_container, : SET );
 
 			$$ = PT_TYPE_SET;
 
 		DBG_PRINT}}
 	| MULTISET
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_container, | MULTISET );
 
 			$$ = PT_TYPE_MULTISET;
 
 		DBG_PRINT}}
 	| SEQUENCE
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_container, | SEQUENCE );
 
 			$$ = PT_TYPE_SEQUENCE;
 
 		DBG_PRINT}}
 	| LIST
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_container, | LIST );
 
 			$$ = PT_TYPE_SEQUENCE;
 
@@ -21590,14 +21672,14 @@ of_container
 
 identifier_list
 	: identifier_list ',' identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(identifier_list, : identifier_list ',' identifier );
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| identifier
-		{{
+		{{ DBG_TRACE_GRAMMAR(identifier_list, | identifier );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -21607,25 +21689,25 @@ identifier_list
 
 opt_bracketed_identifier_list
 	:	/* EMPTY */
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_bracketed_identifier_list, : );
 			$$ = NULL;
 		DBG_PRINT}}
 	| '(' identifier_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(opt_bracketed_identifier_list, | '(' identifier_list ')' );
 			$$ = $2;
 		DBG_PRINT}}
 	;
 
 simple_path_id_list
 	: simple_path_id_list ',' simple_path_id
-		{{
+		{{ DBG_TRACE_GRAMMAR(simple_path_id_list, : simple_path_id_list ',' simple_path_id);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| simple_path_id
-		{{
+		{{ DBG_TRACE_GRAMMAR(simple_path_id_list, | simple_path_id);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -21635,7 +21717,7 @@ simple_path_id_list
 
 identifier
 	: IdName
-		{{//identifier : IdName
+		{{ DBG_TRACE_GRAMMAR(identifier, : IdName);
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
 			if (p)
 			  {
@@ -21652,7 +21734,7 @@ identifier
 			$$ = p;
 		DBG_PRINT}}
 	| BracketDelimitedIdName
-		{{//identifier | BracketDelimitedIdName
+		{{ DBG_TRACE_GRAMMAR(identifier, | BracketDelimitedIdName);
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
 			if (p)
 			  {
@@ -21669,7 +21751,7 @@ identifier
 			$$ = p;
 		DBG_PRINT}}
 	| BacktickDelimitedIdName
-		{{//identifier | BacktickDelimitedIdName
+		{{ DBG_TRACE_GRAMMAR(identifier, | BacktickDelimitedIdName);
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
 			if (p)
 			  {
@@ -21686,7 +21768,7 @@ identifier
 			$$ = p;
 		DBG_PRINT}}
 	| DelimitedIdName
-		{{//identifier | DelimitedIdName
+		{{ DBG_TRACE_GRAMMAR(identifier, | DelimitedIdName);
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
 			if (p)
 			  {
@@ -21703,199 +21785,199 @@ identifier
 			$$ = p;
 		DBG_PRINT}}
 /*{{{*/
-	| ACTIVE                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ADDDATE                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| AES                              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ANALYZE                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ARCHIVE                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ARIA                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| AUTO_INCREMENT                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| BENCHMARK                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| BIT_AND                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| BIT_OR                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| BIT_XOR                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| BUFFER                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CACHE                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CAPACITY                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CHARACTER_SET_                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CHARSET                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CHR                              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CLOB_TO_CHAR                     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CLOSE                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| COLLATION                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| COLUMNS                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| COMMENT                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| COMMITTED                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| COST                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CRITICAL                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CUME_DIST                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DATE_ADD                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DATE_SUB                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DBLINK                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DBNAME                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DECREMENT                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DENSE_RANK                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DISK_SIZE                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DONT_REUSE_OID                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ELT                              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| EMPTY                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ENCRYPT                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ERROR_                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| EXPLAIN                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| FIRST_VALUE                      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| FULLSCAN                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GE_INF_                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GE_LE_                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GE_LT_                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GRANTS                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GROUPS                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GROUP_CONCAT                     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GT_INF_                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GT_LE_                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GT_LT_                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| HASH                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| HEADER                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| HEAP                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| HOST                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| IFNULL                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INACTIVE                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INCREMENT                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INDEXES                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INDEX_PREFIX                     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INFINITE_                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INF_LE_                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INF_LT_                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INSTANCES                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INVALIDATE                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INVISIBLE                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ISNULL                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JAVA                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JOB                              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_ARRAYAGG                    {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_ARRAY_APPEND                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_ARRAY_INSERT                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_ARRAY_LEX                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_CONTAINS                    {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_CONTAINS_PATH               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_DEPTH                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_EXTRACT                     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_GET_ALL_PATHS               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_INSERT                      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_KEYS                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_LENGTH                      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_MERGE                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_MERGE_PATCH                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_MERGE_PRESERVE              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_OBJECTAGG                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_OBJECT_LEX                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_PRETTY                      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_QUOTE                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_REMOVE                      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_REPLACE                     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_SEARCH                      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_SET                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_TABLE                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_TYPE                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_UNQUOTE                     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_VALID                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| KEYS                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LAG                              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LAST_VALUE                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LCASE                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LEAD                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LOCK_                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LOG                              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| MAXIMUM                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| MAXVALUE                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| MEDIAN                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| MEMBERS                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| MINVALUE                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NAME                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NESTED                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NOCACHE                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NOMAXVALUE                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NOMINVALUE                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NTH_VALUE                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NTILE                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NULLS                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| OFFSET                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ONLINE                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| OPEN                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ORDINALITY                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| OWNER                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PAGE                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PARALLEL                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PARTITIONING                     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PARTITIONS                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PASSWORD                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PATH                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PERCENTILE_CONT                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PERCENTILE_DISC                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PERCENT_RANK                     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PORT                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PRINT                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PRIORITY                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PROPERTIES                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| QUARTER                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| QUEUES                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| RANGE_                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| RANK                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REGEXP_COUNT                     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REGEXP_INSTR                     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REGEXP_LIKE                      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REGEXP_REPLACE                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REGEXP_SUBSTR                    {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REJECT_                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REMOVE                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REORGANIZE                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REPEATABLE                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| RESPECT                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| RETAIN                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REUSE_OID                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REVERSE                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ROW_NUMBER                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SECTIONS                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SEPARATOR                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SERIAL                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SERVER                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SHOW                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SLOTS                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SLOTTED                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STABILITY                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| START_                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STATEMENT                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STATUS                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STDDEV                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STDDEV_POP                       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STDDEV_SAMP                      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STR_TO_DATE                      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SUBDATE                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SYSTEM                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TABLES                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TEXT                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| THAN                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| THREADS                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TIMEOUT                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TIMEZONE                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TRACE                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TRAN                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TRIGGERS                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| UCASE                            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| UNCOMMITTED                      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| VARIANCE                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| VAR_POP                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| VAR_SAMP                         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| VISIBLE                          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| VOLUME                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| WEEK                             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| WITHIN                           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| WORKSPACE                        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}  
+	| ACTIVE                 {{ DBG_TRACE_GRAMMAR(identifier, | ACTIVE             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ADDDATE                {{ DBG_TRACE_GRAMMAR(identifier, | ADDDATE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| AES                    {{ DBG_TRACE_GRAMMAR(identifier, | AES                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ANALYZE                {{ DBG_TRACE_GRAMMAR(identifier, | ANALYZE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ARCHIVE                {{ DBG_TRACE_GRAMMAR(identifier, | ARCHIVE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ARIA                   {{ DBG_TRACE_GRAMMAR(identifier, | ARIA               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| AUTO_INCREMENT         {{ DBG_TRACE_GRAMMAR(identifier, | AUTO_INCREMENT     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| BENCHMARK              {{ DBG_TRACE_GRAMMAR(identifier, | BENCHMARK          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| BIT_AND                {{ DBG_TRACE_GRAMMAR(identifier, | BIT_AND            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| BIT_OR                 {{ DBG_TRACE_GRAMMAR(identifier, | BIT_OR             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| BIT_XOR                {{ DBG_TRACE_GRAMMAR(identifier, | BIT_XOR            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| BUFFER                 {{ DBG_TRACE_GRAMMAR(identifier, | BUFFER             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CACHE                  {{ DBG_TRACE_GRAMMAR(identifier, | CACHE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CAPACITY               {{ DBG_TRACE_GRAMMAR(identifier, | CAPACITY           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CHARACTER_SET_         {{ DBG_TRACE_GRAMMAR(identifier, | CHARACTER_SET_     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CHARSET                {{ DBG_TRACE_GRAMMAR(identifier, | CHARSET            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CHR                    {{ DBG_TRACE_GRAMMAR(identifier, | CHR                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CLOB_TO_CHAR           {{ DBG_TRACE_GRAMMAR(identifier, | CLOB_TO_CHAR       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CLOSE                  {{ DBG_TRACE_GRAMMAR(identifier, | CLOSE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| COLLATION              {{ DBG_TRACE_GRAMMAR(identifier, | COLLATION          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| COLUMNS                {{ DBG_TRACE_GRAMMAR(identifier, | COLUMNS            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| COMMENT                {{ DBG_TRACE_GRAMMAR(identifier, | COMMENT            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| COMMITTED              {{ DBG_TRACE_GRAMMAR(identifier, | COMMITTED          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| COST                   {{ DBG_TRACE_GRAMMAR(identifier, | COST               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CRITICAL               {{ DBG_TRACE_GRAMMAR(identifier, | CRITICAL           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CUME_DIST              {{ DBG_TRACE_GRAMMAR(identifier, | CUME_DIST          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DATE_ADD               {{ DBG_TRACE_GRAMMAR(identifier, | DATE_ADD           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DATE_SUB               {{ DBG_TRACE_GRAMMAR(identifier, | DATE_SUB           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DBLINK                 {{ DBG_TRACE_GRAMMAR(identifier, | DBLINK             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DBNAME                 {{ DBG_TRACE_GRAMMAR(identifier, | DBNAME             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DECREMENT              {{ DBG_TRACE_GRAMMAR(identifier, | DECREMENT          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DENSE_RANK             {{ DBG_TRACE_GRAMMAR(identifier, | DENSE_RANK         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DISK_SIZE              {{ DBG_TRACE_GRAMMAR(identifier, | DISK_SIZE          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DONT_REUSE_OID         {{ DBG_TRACE_GRAMMAR(identifier, | DONT_REUSE_OID     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ELT                    {{ DBG_TRACE_GRAMMAR(identifier, | ELT                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| EMPTY                  {{ DBG_TRACE_GRAMMAR(identifier, | EMPTY              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ENCRYPT                {{ DBG_TRACE_GRAMMAR(identifier, | ENCRYPT            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ERROR_                 {{ DBG_TRACE_GRAMMAR(identifier, | ERROR_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| EXPLAIN                {{ DBG_TRACE_GRAMMAR(identifier, | EXPLAIN            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| FIRST_VALUE            {{ DBG_TRACE_GRAMMAR(identifier, | FIRST_VALUE        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| FULLSCAN               {{ DBG_TRACE_GRAMMAR(identifier, | FULLSCAN           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GE_INF_                {{ DBG_TRACE_GRAMMAR(identifier, | GE_INF_            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GE_LE_                 {{ DBG_TRACE_GRAMMAR(identifier, | GE_LE_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GE_LT_                 {{ DBG_TRACE_GRAMMAR(identifier, | GE_LT_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GRANTS                 {{ DBG_TRACE_GRAMMAR(identifier, | GRANTS             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GROUPS                 {{ DBG_TRACE_GRAMMAR(identifier, | GROUPS             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GROUP_CONCAT           {{ DBG_TRACE_GRAMMAR(identifier, | GROUP_CONCAT       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GT_INF_                {{ DBG_TRACE_GRAMMAR(identifier, | GT_INF_            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GT_LE_                 {{ DBG_TRACE_GRAMMAR(identifier, | GT_LE_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GT_LT_                 {{ DBG_TRACE_GRAMMAR(identifier, | GT_LT_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| HASH                   {{ DBG_TRACE_GRAMMAR(identifier, | HASH               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| HEADER                 {{ DBG_TRACE_GRAMMAR(identifier, | HEADER             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| HEAP                   {{ DBG_TRACE_GRAMMAR(identifier, | HEAP               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| HOST                   {{ DBG_TRACE_GRAMMAR(identifier, | HOST               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| IFNULL                 {{ DBG_TRACE_GRAMMAR(identifier, | IFNULL             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INACTIVE               {{ DBG_TRACE_GRAMMAR(identifier, | INACTIVE           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INCREMENT              {{ DBG_TRACE_GRAMMAR(identifier, | INCREMENT          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INDEXES                {{ DBG_TRACE_GRAMMAR(identifier, | INDEXES            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INDEX_PREFIX           {{ DBG_TRACE_GRAMMAR(identifier, | INDEX_PREFIX       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INFINITE_              {{ DBG_TRACE_GRAMMAR(identifier, | INFINITE_          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INF_LE_                {{ DBG_TRACE_GRAMMAR(identifier, | INF_LE_            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INF_LT_                {{ DBG_TRACE_GRAMMAR(identifier, | INF_LT_            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INSTANCES              {{ DBG_TRACE_GRAMMAR(identifier, | INSTANCES          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INVALIDATE             {{ DBG_TRACE_GRAMMAR(identifier, | INVALIDATE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INVISIBLE              {{ DBG_TRACE_GRAMMAR(identifier, | INVISIBLE          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ISNULL                 {{ DBG_TRACE_GRAMMAR(identifier, | ISNULL             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JAVA                   {{ DBG_TRACE_GRAMMAR(identifier, | JAVA               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JOB                    {{ DBG_TRACE_GRAMMAR(identifier, | JOB                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_ARRAYAGG          {{ DBG_TRACE_GRAMMAR(identifier, | JSON_ARRAYAGG      ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_ARRAY_APPEND      {{ DBG_TRACE_GRAMMAR(identifier, | JSON_ARRAY_APPEND  ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_ARRAY_INSERT      {{ DBG_TRACE_GRAMMAR(identifier, | JSON_ARRAY_INSERT  ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_ARRAY_LEX         {{ DBG_TRACE_GRAMMAR(identifier, | JSON_ARRAY_LEX     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_CONTAINS          {{ DBG_TRACE_GRAMMAR(identifier, | JSON_CONTAINS      ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_CONTAINS_PATH     {{ DBG_TRACE_GRAMMAR(identifier, | JSON_CONTAINS_PATH ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_DEPTH             {{ DBG_TRACE_GRAMMAR(identifier, | JSON_DEPTH         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_EXTRACT           {{ DBG_TRACE_GRAMMAR(identifier, | JSON_EXTRACT       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_GET_ALL_PATHS     {{ DBG_TRACE_GRAMMAR(identifier, | JSON_GET_ALL_PATHS ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_INSERT            {{ DBG_TRACE_GRAMMAR(identifier, | JSON_INSERT        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_KEYS              {{ DBG_TRACE_GRAMMAR(identifier, | JSON_KEYS          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_LENGTH            {{ DBG_TRACE_GRAMMAR(identifier, | JSON_LENGTH        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_MERGE             {{ DBG_TRACE_GRAMMAR(identifier, | JSON_MERGE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_MERGE_PATCH       {{ DBG_TRACE_GRAMMAR(identifier, | JSON_MERGE_PATCH   ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_MERGE_PRESERVE    {{ DBG_TRACE_GRAMMAR(identifier, | JSON_MERGE_PRESERVE); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_OBJECTAGG         {{ DBG_TRACE_GRAMMAR(identifier, | JSON_OBJECTAGG     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_OBJECT_LEX        {{ DBG_TRACE_GRAMMAR(identifier, | JSON_OBJECT_LEX    ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_PRETTY            {{ DBG_TRACE_GRAMMAR(identifier, | JSON_PRETTY        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_QUOTE             {{ DBG_TRACE_GRAMMAR(identifier, | JSON_QUOTE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_REMOVE            {{ DBG_TRACE_GRAMMAR(identifier, | JSON_REMOVE        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_REPLACE           {{ DBG_TRACE_GRAMMAR(identifier, | JSON_REPLACE       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_SEARCH            {{ DBG_TRACE_GRAMMAR(identifier, | JSON_SEARCH        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_SET               {{ DBG_TRACE_GRAMMAR(identifier, | JSON_SET           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_TABLE             {{ DBG_TRACE_GRAMMAR(identifier, | JSON_TABLE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_TYPE              {{ DBG_TRACE_GRAMMAR(identifier, | JSON_TYPE          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_UNQUOTE           {{ DBG_TRACE_GRAMMAR(identifier, | JSON_UNQUOTE       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_VALID             {{ DBG_TRACE_GRAMMAR(identifier, | JSON_VALID         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| KEYS                   {{ DBG_TRACE_GRAMMAR(identifier, | KEYS               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LAG                    {{ DBG_TRACE_GRAMMAR(identifier, | LAG                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LAST_VALUE             {{ DBG_TRACE_GRAMMAR(identifier, | LAST_VALUE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LCASE                  {{ DBG_TRACE_GRAMMAR(identifier, | LCASE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LEAD                   {{ DBG_TRACE_GRAMMAR(identifier, | LEAD               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LOCK_                  {{ DBG_TRACE_GRAMMAR(identifier, | LOCK_              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LOG                    {{ DBG_TRACE_GRAMMAR(identifier, | LOG                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| MAXIMUM                {{ DBG_TRACE_GRAMMAR(identifier, | MAXIMUM            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| MAXVALUE               {{ DBG_TRACE_GRAMMAR(identifier, | MAXVALUE           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| MEDIAN                 {{ DBG_TRACE_GRAMMAR(identifier, | MEDIAN             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| MEMBERS                {{ DBG_TRACE_GRAMMAR(identifier, | MEMBERS            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| MINVALUE               {{ DBG_TRACE_GRAMMAR(identifier, | MINVALUE           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NAME                   {{ DBG_TRACE_GRAMMAR(identifier, | NAME               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NESTED                 {{ DBG_TRACE_GRAMMAR(identifier, | NESTED             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NOCACHE                {{ DBG_TRACE_GRAMMAR(identifier, | NOCACHE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NOMAXVALUE             {{ DBG_TRACE_GRAMMAR(identifier, | NOMAXVALUE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NOMINVALUE             {{ DBG_TRACE_GRAMMAR(identifier, | NOMINVALUE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NTH_VALUE              {{ DBG_TRACE_GRAMMAR(identifier, | NTH_VALUE          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NTILE                  {{ DBG_TRACE_GRAMMAR(identifier, | NTILE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NULLS                  {{ DBG_TRACE_GRAMMAR(identifier, | NULLS              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| OFFSET                 {{ DBG_TRACE_GRAMMAR(identifier, | OFFSET             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ONLINE                 {{ DBG_TRACE_GRAMMAR(identifier, | ONLINE             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| OPEN                   {{ DBG_TRACE_GRAMMAR(identifier, | OPEN               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ORDINALITY             {{ DBG_TRACE_GRAMMAR(identifier, | ORDINALITY         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| OWNER                  {{ DBG_TRACE_GRAMMAR(identifier, | OWNER              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PAGE                   {{ DBG_TRACE_GRAMMAR(identifier, | PAGE               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PARALLEL               {{ DBG_TRACE_GRAMMAR(identifier, | PARALLEL           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PARTITIONING           {{ DBG_TRACE_GRAMMAR(identifier, | PARTITIONING       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PARTITIONS             {{ DBG_TRACE_GRAMMAR(identifier, | PARTITIONS         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PASSWORD               {{ DBG_TRACE_GRAMMAR(identifier, | PASSWORD           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PATH                   {{ DBG_TRACE_GRAMMAR(identifier, | PATH               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PERCENTILE_CONT        {{ DBG_TRACE_GRAMMAR(identifier, | PERCENTILE_CONT    ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PERCENTILE_DISC        {{ DBG_TRACE_GRAMMAR(identifier, | PERCENTILE_DISC    ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PERCENT_RANK           {{ DBG_TRACE_GRAMMAR(identifier, | PERCENT_RANK       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PORT                   {{ DBG_TRACE_GRAMMAR(identifier, | PORT               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PRINT                  {{ DBG_TRACE_GRAMMAR(identifier, | PRINT              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PRIORITY               {{ DBG_TRACE_GRAMMAR(identifier, | PRIORITY           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PROPERTIES             {{ DBG_TRACE_GRAMMAR(identifier, | PROPERTIES         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| QUARTER                {{ DBG_TRACE_GRAMMAR(identifier, | QUARTER            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| QUEUES                 {{ DBG_TRACE_GRAMMAR(identifier, | QUEUES             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| RANGE_                 {{ DBG_TRACE_GRAMMAR(identifier, | RANGE_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| RANK                   {{ DBG_TRACE_GRAMMAR(identifier, | RANK               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REGEXP_COUNT           {{ DBG_TRACE_GRAMMAR(identifier, | REGEXP_COUNT       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REGEXP_INSTR           {{ DBG_TRACE_GRAMMAR(identifier, | REGEXP_INSTR       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REGEXP_LIKE            {{ DBG_TRACE_GRAMMAR(identifier, | REGEXP_LIKE        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REGEXP_REPLACE         {{ DBG_TRACE_GRAMMAR(identifier, | REGEXP_REPLACE     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REGEXP_SUBSTR          {{ DBG_TRACE_GRAMMAR(identifier, | REGEXP_SUBSTR      ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REJECT_                {{ DBG_TRACE_GRAMMAR(identifier, | REJECT_            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REMOVE                 {{ DBG_TRACE_GRAMMAR(identifier, | REMOVE             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REORGANIZE             {{ DBG_TRACE_GRAMMAR(identifier, | REORGANIZE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REPEATABLE             {{ DBG_TRACE_GRAMMAR(identifier, | REPEATABLE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| RESPECT                {{ DBG_TRACE_GRAMMAR(identifier, | RESPECT            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| RETAIN                 {{ DBG_TRACE_GRAMMAR(identifier, | RETAIN             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REUSE_OID              {{ DBG_TRACE_GRAMMAR(identifier, | REUSE_OID          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REVERSE                {{ DBG_TRACE_GRAMMAR(identifier, | REVERSE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ROW_NUMBER             {{ DBG_TRACE_GRAMMAR(identifier, | ROW_NUMBER         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SECTIONS               {{ DBG_TRACE_GRAMMAR(identifier, | SECTIONS           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SEPARATOR              {{ DBG_TRACE_GRAMMAR(identifier, | SEPARATOR          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SERIAL                 {{ DBG_TRACE_GRAMMAR(identifier, | SERIAL             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SERVER                 {{ DBG_TRACE_GRAMMAR(identifier, | SERVER             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SHOW                   {{ DBG_TRACE_GRAMMAR(identifier, | SHOW               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SLOTS                  {{ DBG_TRACE_GRAMMAR(identifier, | SLOTS              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SLOTTED                {{ DBG_TRACE_GRAMMAR(identifier, | SLOTTED            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STABILITY              {{ DBG_TRACE_GRAMMAR(identifier, | STABILITY          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| START_                 {{ DBG_TRACE_GRAMMAR(identifier, | START_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STATEMENT              {{ DBG_TRACE_GRAMMAR(identifier, | STATEMENT          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STATUS                 {{ DBG_TRACE_GRAMMAR(identifier, | STATUS             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STDDEV                 {{ DBG_TRACE_GRAMMAR(identifier, | STDDEV             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STDDEV_POP             {{ DBG_TRACE_GRAMMAR(identifier, | STDDEV_POP         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STDDEV_SAMP            {{ DBG_TRACE_GRAMMAR(identifier, | STDDEV_SAMP        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STR_TO_DATE            {{ DBG_TRACE_GRAMMAR(identifier, | STR_TO_DATE        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SUBDATE                {{ DBG_TRACE_GRAMMAR(identifier, | SUBDATE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SYSTEM                 {{ DBG_TRACE_GRAMMAR(identifier, | SYSTEM             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TABLES                 {{ DBG_TRACE_GRAMMAR(identifier, | TABLES             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TEXT                   {{ DBG_TRACE_GRAMMAR(identifier, | TEXT               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| THAN                   {{ DBG_TRACE_GRAMMAR(identifier, | THAN               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| THREADS                {{ DBG_TRACE_GRAMMAR(identifier, | THREADS            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TIMEOUT                {{ DBG_TRACE_GRAMMAR(identifier, | TIMEOUT            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TIMEZONE               {{ DBG_TRACE_GRAMMAR(identifier, | TIMEZONE           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TRACE                  {{ DBG_TRACE_GRAMMAR(identifier, | TRACE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TRAN                   {{ DBG_TRACE_GRAMMAR(identifier, | TRAN               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TRIGGERS               {{ DBG_TRACE_GRAMMAR(identifier, | TRIGGERS           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| UCASE                  {{ DBG_TRACE_GRAMMAR(identifier, | UCASE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| UNCOMMITTED            {{ DBG_TRACE_GRAMMAR(identifier, | UNCOMMITTED        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| VARIANCE               {{ DBG_TRACE_GRAMMAR(identifier, | VARIANCE           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| VAR_POP                {{ DBG_TRACE_GRAMMAR(identifier, | VAR_POP            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| VAR_SAMP               {{ DBG_TRACE_GRAMMAR(identifier, | VAR_SAMP           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| VISIBLE                {{ DBG_TRACE_GRAMMAR(identifier, | VISIBLE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| VOLUME                 {{ DBG_TRACE_GRAMMAR(identifier, | VOLUME             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| WEEK                   {{ DBG_TRACE_GRAMMAR(identifier, | WEEK               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| WITHIN                 {{ DBG_TRACE_GRAMMAR(identifier, | WITHIN             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| WORKSPACE              {{ DBG_TRACE_GRAMMAR(identifier, | WORKSPACE          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }} 
 /*}}}*/
 	;
 
 escape_literal
 	: string_literal_or_input_hv
-		{{
+		{{ DBG_TRACE_GRAMMAR(escape_literal, : string_literal_or_input_hv);
 
 			PT_NODE *node = $1;
 			$$ = node;
@@ -21903,7 +21985,7 @@ escape_literal
 
 		DBG_PRINT}}
 	| Null
-		{{
+		{{ DBG_TRACE_GRAMMAR(escape_literal, | Null);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -21916,7 +21998,7 @@ escape_literal
 
 string_literal_or_input_hv
 	: char_string_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(string_literal_or_input_hv, : char_string_literal);
 
 			PT_NODE *node = $1;
 
@@ -21927,7 +22009,7 @@ string_literal_or_input_hv
 
 		DBG_PRINT}}
 	| host_param_input
-		{{
+		{{ DBG_TRACE_GRAMMAR(string_literal_or_input_hv, | host_param_input);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -21938,7 +22020,7 @@ string_literal_or_input_hv
 
 char_string_literal
 	: char_string_literal CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_string_literal, : char_string_literal CHAR_STRING);
 
 			PT_NODE *str = $1;
 			if (str)
@@ -21955,7 +22037,7 @@ char_string_literal
 
 		DBG_PRINT}}
 	| char_string
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_string_literal, | char_string);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -21965,7 +22047,7 @@ char_string_literal
 
 char_string
 	: CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_string, : CHAR_STRING);
 
 			PT_NODE *node = NULL;
 			PT_TYPE_ENUM typ = PT_TYPE_CHAR;
@@ -22003,7 +22085,7 @@ char_string
 
 		DBG_PRINT}}
 	| NCHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_string, | NCHAR_STRING);
 			PT_NODE *node = NULL;
 			INTL_CODESET charset;
 			int collation_id;
@@ -22039,7 +22121,7 @@ char_string
 
 		DBG_PRINT}}
 	| BINARY_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_string, | BINARY_STRING);
 
 			PT_NODE *node = NULL;
 
@@ -22060,7 +22142,7 @@ char_string
 
 		DBG_PRINT}}
 	| EUCKR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_string, | EUCKR_STRING);
 
 			PT_NODE *node = NULL;
 
@@ -22081,7 +22163,7 @@ char_string
 
 		DBG_PRINT}}
 	| ISO_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_string, | ISO_STRING);
 
 			PT_NODE *node = NULL;
 
@@ -22102,7 +22184,7 @@ char_string
 
 		DBG_PRINT}}
 	| UTF8_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(char_string, | UTF8_STRING);
 
 			PT_NODE *node = NULL;
 
@@ -22127,7 +22209,7 @@ char_string
 
 bit_string_literal
 	: bit_string_literal CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(bit_string_literal, : bit_string_literal CHAR_STRING);
 
 			PT_NODE *str = $1;
 			if (str)
@@ -22144,7 +22226,7 @@ bit_string_literal
 
 		DBG_PRINT}}
 	| bit_string
-		{{
+		{{ DBG_TRACE_GRAMMAR(bit_string_literal, | bit_string);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -22154,7 +22236,7 @@ bit_string_literal
 
 bit_string
 	: BIT_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(bit_string, : BIT_STRING);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 
@@ -22172,7 +22254,7 @@ bit_string
 
 		DBG_PRINT}}
 	| HEX_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(bit_string, | HEX_STRING);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 
@@ -22193,7 +22275,7 @@ bit_string
 
 unsigned_integer
 	: UNSIGNED_INTEGER
-		{{
+		{{ DBG_TRACE_GRAMMAR(unsigned_integer, : UNSIGNED_INTEGER);
 
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 			if (val)
@@ -22245,7 +22327,7 @@ unsigned_integer
 
 unsigned_int32
 	: UNSIGNED_INTEGER
-		{{
+		{{ DBG_TRACE_GRAMMAR(unsigned_int32, : UNSIGNED_INTEGER);
 
 			PT_NODE *val;
 			int result = 0;
@@ -22272,7 +22354,7 @@ unsigned_int32
 
 unsigned_real
 	: UNSIGNED_REAL
-		{{
+		{{ DBG_TRACE_GRAMMAR(unsigned_real, : UNSIGNED_REAL);
 
 			double dval;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22327,7 +22409,7 @@ unsigned_real
 
 monetary_literal
 	: YEN_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, : YEN_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22345,7 +22427,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| DOLLAR_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | DOLLAR_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22363,7 +22445,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| WON_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | WON_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22381,7 +22463,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| TURKISH_LIRA_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | TURKISH_LIRA_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22399,7 +22481,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| BRITISH_POUND_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | BRITISH_POUND_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22416,7 +22498,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| CAMBODIAN_RIEL_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CAMBODIAN_RIEL_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22433,7 +22515,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| CHINESE_RENMINBI_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CHINESE_RENMINBI_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22450,7 +22532,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| INDIAN_RUPEE_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | INDIAN_RUPEE_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22467,7 +22549,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| RUSSIAN_RUBLE_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | RUSSIAN_RUBLE_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22484,7 +22566,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| AUSTRALIAN_DOLLAR_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | AUSTRALIAN_DOLLAR_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22501,7 +22583,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| CANADIAN_DOLLAR_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CANADIAN_DOLLAR_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22518,7 +22600,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| BRASILIAN_REAL_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | BRASILIAN_REAL_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22535,7 +22617,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| ROMANIAN_LEU_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | ROMANIAN_LEU_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22552,7 +22634,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| EURO_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | EURO_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22569,7 +22651,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| SWISS_FRANC_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | SWISS_FRANC_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22586,7 +22668,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| DANISH_KRONE_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | DANISH_KRONE_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22603,7 +22685,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| NORWEGIAN_KRONE_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | NORWEGIAN_KRONE_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22620,7 +22702,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| BULGARIAN_LEV_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | BULGARIAN_LEV_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22637,7 +22719,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| VIETNAMESE_DONG_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | VIETNAMESE_DONG_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22654,7 +22736,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| CZECH_KORUNA_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CZECH_KORUNA_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22671,7 +22753,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| POLISH_ZLOTY_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | POLISH_ZLOTY_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22688,7 +22770,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| SWEDISH_KRONA_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | SWEDISH_KRONA_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22705,7 +22787,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| CROATIAN_KUNA_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CROATIAN_KUNA_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22722,7 +22804,7 @@ monetary_literal
 
 		DBG_PRINT}}
 	| SERBIAN_DINAR_SIGN of_integer_real_literal
-		{{
+		{{ DBG_TRACE_GRAMMAR(monetary_literal, | SERBIAN_DINAR_SIGN of_integer_real_literal);
 
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
@@ -22742,19 +22824,19 @@ monetary_literal
 
 of_integer_real_literal
 	: integer_text
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_integer_real_literal, : integer_text);
 
 			$$ = $1;
 
 		DBG_PRINT}}
 	| opt_plus UNSIGNED_REAL
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_integer_real_literal, | opt_plus UNSIGNED_REAL);
 
 			$$ = $2;
 
 		DBG_PRINT}}
 	| '-' UNSIGNED_REAL
-		{{
+		{{ DBG_TRACE_GRAMMAR(of_integer_real_literal, | '-' UNSIGNED_REAL);
 
 			$$ = pt_append_string (this_parser, (char *) "-", $2);
 
@@ -22763,7 +22845,7 @@ of_integer_real_literal
 
 date_or_time_literal
 	: Date CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, : Date CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATE, $2);
@@ -22772,7 +22854,7 @@ date_or_time_literal
 
 		DBG_PRINT}}
 	| Time CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | Time CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIME, $2);
@@ -22781,7 +22863,7 @@ date_or_time_literal
 
 		DBG_PRINT}}
 	| TIMESTAMP CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMP CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIMESTAMP, $2);
@@ -22790,7 +22872,7 @@ date_or_time_literal
 
 		DBG_PRINT}}
 	| TIMESTAMP WITH Time ZONE CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMP WITH Time ZONE CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIMESTAMPTZ, $5);
@@ -22799,7 +22881,7 @@ date_or_time_literal
 
 		DBG_PRINT}}
 	| TIMESTAMPTZ CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMPTZ CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIMESTAMPTZ, $2);
@@ -22808,7 +22890,7 @@ date_or_time_literal
 
 		DBG_PRINT}}
 	| TIMESTAMPLTZ CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMPLTZ CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIMESTAMPLTZ, $2);
@@ -22817,7 +22899,7 @@ date_or_time_literal
 
 		DBG_PRINT}}
 	| TIMESTAMP WITH LOCAL Time ZONE CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMP WITH LOCAL Time ZONE CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIMESTAMPLTZ, $6);
@@ -22826,7 +22908,7 @@ date_or_time_literal
 
 		DBG_PRINT}}
 	| DATETIME CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIME CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATETIME, $2);
@@ -22835,7 +22917,7 @@ date_or_time_literal
 
 		DBG_PRINT}}
 	| DATETIME WITH Time ZONE CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIME WITH Time ZONE CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATETIMETZ, $5);
@@ -22844,7 +22926,7 @@ date_or_time_literal
 
 		DBG_PRINT}}
 	| DATETIMETZ CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIMETZ CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATETIMETZ, $2);
@@ -22853,7 +22935,7 @@ date_or_time_literal
 
 		DBG_PRINT}}
 	| DATETIMELTZ CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIMELTZ CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATETIMELTZ, $2);
@@ -22862,7 +22944,7 @@ date_or_time_literal
 
 		DBG_PRINT}}
 	| DATETIME WITH LOCAL Time ZONE CHAR_STRING
-		{{
+		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIME WITH LOCAL Time ZONE CHAR_STRING);
 
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATETIMELTZ, $6);
@@ -22874,7 +22956,7 @@ date_or_time_literal
 
 json_literal
         : JSON CHAR_STRING
-                {{
+                {{ DBG_TRACE_GRAMMAR(json_literal,  : JSON CHAR_STRING);
                 	PT_NODE *val;
 			val = pt_create_json_value (this_parser, $2);
 			$$ = val;
@@ -22884,7 +22966,7 @@ json_literal
 
 create_as_clause
 	: opt_replace AS csql_query
-		{{
+		{{ DBG_TRACE_GRAMMAR(create_as_clause, : opt_replace AS csql_query);
 			container_2 ctn;
 			SET_CONTAINER_2(ctn, FROM_NUMBER ($1), $3);
 			$$ = ctn;
@@ -22893,7 +22975,7 @@ create_as_clause
 
 partition_clause
 	: PARTITION opt_by HASH '(' expression_ ')' PARTITIONS literal_w_o_param
-		{{
+		{{ DBG_TRACE_GRAMMAR(partition_clause, : PARTITION opt_by HASH '(' expression_ ')' PARTITIONS literal_w_o_param);
 
 			PT_NODE *qc = parser_new_node (this_parser, PT_PARTITION);
 			if (qc)
@@ -22907,7 +22989,7 @@ partition_clause
 
 		DBG_PRINT}}
 	| PARTITION opt_by RANGE_ '(' expression_ ')' '(' partition_def_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(partition_clause, | PARTITION opt_by RANGE_ '(' expression_ ')' '(' partition_def_list ')');
 
 			PT_NODE *qc = parser_new_node (this_parser, PT_PARTITION);
 			if (qc)
@@ -22923,7 +23005,7 @@ partition_clause
 
 		DBG_PRINT}}
 	| PARTITION opt_by LIST '(' expression_ ')' '(' partition_def_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(partition_clause, | PARTITION opt_by LIST '(' expression_ ')' '(' partition_def_list ')');
 
 			PT_NODE *qc = parser_new_node (this_parser, PT_PARTITION);
 			if (qc)
@@ -22947,14 +23029,14 @@ opt_by
 
 partition_def_list
 	: partition_def_list ',' partition_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(partition_def_list, : partition_def_list ',' partition_def);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| partition_def
-		{{
+		{{ DBG_TRACE_GRAMMAR(partition_def_list, | partition_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -22964,7 +23046,7 @@ partition_def_list
 
 partition_def
 	: PARTITION identifier VALUES LESS THAN MAXVALUE opt_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(partition_def, : PARTITION identifier VALUES LESS THAN MAXVALUE opt_comment_spec);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_PARTS);
 			if (node)
@@ -22980,7 +23062,7 @@ partition_def
 
 		DBG_PRINT}}
 	| PARTITION identifier VALUES LESS THAN '(' signed_literal_ ')' opt_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(partition_def, | PARTITION identifier VALUES LESS THAN '(' signed_literal_ ')' opt_comment_spec);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_PARTS);
 			if (node)
@@ -22996,7 +23078,7 @@ partition_def
 
 		DBG_PRINT}}
 	| PARTITION identifier VALUES IN_ '(' signed_literal_list ')' opt_comment_spec
-		{{
+		{{ DBG_TRACE_GRAMMAR(partition_def, | PARTITION identifier VALUES IN_ '(' signed_literal_list ')' opt_comment_spec);
 
 			PT_NODE *node = parser_new_node (this_parser, PT_PARTS);
 			if (node)
@@ -23015,7 +23097,7 @@ partition_def
 
 alter_partition_clause_for_alter_list
 	: partition_clause
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, : partition_clause);
 
 			PT_NODE *alt = parser_get_alter_node ();
 
@@ -23027,7 +23109,7 @@ alter_partition_clause_for_alter_list
 
 		DBG_PRINT}}
 	| REMOVE PARTITIONING
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | REMOVE PARTITIONING);
 
 			PT_NODE *alt = parser_get_alter_node ();
 
@@ -23036,7 +23118,7 @@ alter_partition_clause_for_alter_list
 
 		DBG_PRINT}}
 	| REORGANIZE PARTITION identifier_list INTO '(' partition_def_list ')'
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | REORGANIZE PARTITION identifier_list INTO '(' partition_def_list ')');
 
 			PT_NODE *alt = parser_get_alter_node ();
 
@@ -23049,7 +23131,7 @@ alter_partition_clause_for_alter_list
 
 		DBG_PRINT}}
 	| ANALYZE PARTITION opt_all
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | ANALYZE PARTITION opt_all);
 
 			PT_NODE *alt = parser_get_alter_node ();
 
@@ -23061,7 +23143,7 @@ alter_partition_clause_for_alter_list
 
 		DBG_PRINT}}
 	| ANALYZE PARTITION identifier_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | ANALYZE PARTITION identifier_list);
 
 			PT_NODE *alt = parser_get_alter_node ();
 
@@ -23073,7 +23155,7 @@ alter_partition_clause_for_alter_list
 
 		DBG_PRINT}}
 	| COALESCE PARTITION literal_w_o_param
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | COALESCE PARTITION literal_w_o_param);
 
 			PT_NODE *alt = parser_get_alter_node ();
 
@@ -23085,7 +23167,7 @@ alter_partition_clause_for_alter_list
 
 		DBG_PRINT}}
 	 | PROMOTE PARTITION identifier_list
-		{{
+		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | PROMOTE PARTITION identifier_list);
 
 			PT_NODE *alt = parser_get_alter_node ();
 
@@ -23105,28 +23187,28 @@ opt_all
 
 execute_using_list
 	: execute_using_list ',' session_variable_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(execute_using_list, : execute_using_list ',' session_variable_expression);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| execute_using_list ',' signed_literal_
-		{{
+		{{ DBG_TRACE_GRAMMAR(execute_using_list, | execute_using_list ',' signed_literal_);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| session_variable_expression
-		{{
+		{{ DBG_TRACE_GRAMMAR(execute_using_list, | session_variable_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| signed_literal_
-		{{
+		{{ DBG_TRACE_GRAMMAR(execute_using_list, | signed_literal_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -23136,14 +23218,14 @@ execute_using_list
 
 signed_literal_list
 	: signed_literal_list ',' signed_literal_
-		{{
+		{{ DBG_TRACE_GRAMMAR(signed_literal_list, : signed_literal_list ',' signed_literal_);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
 	| signed_literal_
-		{{
+		{{ DBG_TRACE_GRAMMAR(signed_literal_list, | signed_literal_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
@@ -23171,7 +23253,7 @@ bad_tokens_for_error_message_only_dont_mind_this_rule
 
 vacuum_stmt
 	: VACUUM
-		{{
+		{{ DBG_TRACE_GRAMMAR(vacuum_stmt, : VACUUM);
 			PT_NODE *node =
 			  parser_new_node (this_parser, PT_VACUUM);
 			if (node == NULL)
@@ -23186,17 +23268,17 @@ vacuum_stmt
 
 json_table_column_behavior_rule
     : Null
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_column_behavior_rule, : Null);
         $$.m_behavior = JSON_TABLE_RETURN_NULL;
         $$.m_default_value = NULL;
       DBG_PRINT}}
     | ERROR_
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_column_behavior_rule, | ERROR_);
         $$.m_behavior = JSON_TABLE_THROW_ERROR;
         $$.m_default_value = NULL;
       DBG_PRINT}}
     | DEFAULT expression_
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_column_behavior_rule, | DEFAULT expression_);
         PT_NODE * default_value = $2;
         if (default_value->node_type != PT_VALUE)
           {
@@ -23212,31 +23294,31 @@ json_table_column_behavior_rule
 
 json_table_on_error_rule_optional
     : /* empty */
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_on_error_rule_optional, : );
         $$.m_behavior = JSON_TABLE_RETURN_NULL;
         $$.m_default_value = NULL;
       DBG_PRINT}}
     | json_table_column_behavior_rule ON_ ERROR_
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_on_error_rule_optional, | json_table_column_behavior_rule ON_ ERROR_);
         $$ = $1;
       DBG_PRINT}}
     ;
 
 json_table_on_empty_rule_optional
     : /* empty */
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_on_empty_rule_optional, : );
         $$.m_behavior = JSON_TABLE_RETURN_NULL;
         $$.m_default_value = NULL;
       DBG_PRINT}}
     | json_table_column_behavior_rule ON_ EMPTY
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_on_empty_rule_optional, | json_table_column_behavior_rule ON_ EMPTY );
         $$ = $1;
       DBG_PRINT}}
     ;
 
 json_table_column_rule
     : identifier For ORDINALITY
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_column_rule, : identifier For ORDINALITY );
         PT_NODE *pt_col = parser_new_node (this_parser, PT_JSON_TABLE_COLUMN);
         pt_col->info.json_table_column_info.name = $1;
         pt_col->info.json_table_column_info.func = JSON_TABLE_ORDINALITY;
@@ -23245,7 +23327,7 @@ json_table_column_rule
       DBG_PRINT}}
     | identifier data_type PATH CHAR_STRING json_table_on_empty_rule_optional json_table_on_error_rule_optional
     //        $1        $2   $3          $4                                $5                                $6
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | identifier data_type PATH CHAR_STRING json_table_on_empty_rule_optional json_table_on_error_rule_optional );
         PT_NODE *pt_col = parser_new_node (this_parser, PT_JSON_TABLE_COLUMN);
         pt_col->info.json_table_column_info.name = $1;
         pt_col->type_enum = TO_NUMBER (CONTAINER_AT_0 ($2));
@@ -23257,7 +23339,7 @@ json_table_column_rule
         $$ = pt_col;
       DBG_PRINT}}
     | identifier data_type EXISTS PATH CHAR_STRING
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | identifier data_type EXISTS PATH CHAR_STRING );
         PT_NODE *pt_col = parser_new_node (this_parser, PT_JSON_TABLE_COLUMN);
         pt_col->info.json_table_column_info.name = $1;
         pt_col->type_enum = TO_NUMBER (CONTAINER_AT_0 ($2));
@@ -23267,23 +23349,23 @@ json_table_column_rule
         $$ = pt_col;
       DBG_PRINT}}
     | NESTED json_table_node_rule
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | NESTED json_table_node_rule );
         $$ = $2;
       DBG_PRINT}}
     | NESTED PATH json_table_node_rule
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | NESTED PATH json_table_node_rule );
         $$ = $3;
       DBG_PRINT}}
     ;
 
 json_table_column_list_rule
     : json_table_column_list_rule ',' json_table_column_rule
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_column_list_rule,  : json_table_column_list_rule ',' json_table_column_rule );
         pt_jt_append_column_or_nested_node ($1, $3);
         $$ = $1;
       DBG_PRINT}}
     | json_table_column_rule
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_column_list_rule, | json_table_column_rule );
         PT_NODE *pt_jt_node = parser_new_node (this_parser, PT_JSON_TABLE_NODE);
         pt_jt_append_column_or_nested_node (pt_jt_node, $1);
         $$ = pt_jt_node;
@@ -23292,7 +23374,7 @@ json_table_column_list_rule
 
 json_table_node_rule
     : CHAR_STRING COLUMNS '(' json_table_column_list_rule ')'
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_node_rule,  : CHAR_STRING COLUMNS '(' json_table_column_list_rule ')' );
         PT_NODE *jt_node = $4;
         assert (jt_node != NULL);
         assert (jt_node->node_type == PT_JSON_TABLE_NODE);
@@ -23304,10 +23386,11 @@ json_table_node_rule
     ;
 
 json_table_rule
-    : {{json_table_column_count = 0;
+    : {{ DBG_TRACE_GRAMMAR(json_table_rule,  : );
+            json_table_column_count = 0;
       DBG_PRINT}}
       '(' expression_ ',' json_table_node_rule ')'
-      {{
+      {{ DBG_TRACE_GRAMMAR(json_table_rule,  '(' expression_ ',' json_table_node_rule ')' );
         PT_NODE *jt = parser_new_node (this_parser, PT_JSON_TABLE);
         jt->info.json_table_info.expr = $3;
         jt->info.json_table_info.tree = $5;
@@ -23319,14 +23402,14 @@ json_table_rule
 
 connect_info
         : connect_info ',' connect_item
-          {{
+          {{ DBG_TRACE_GRAMMAR(connect_info, : connect_info ',' connect_item );
                container_10 ctn = $1;
 
                pt_fill_conn_info_container(this_parser, @$.buffer_pos, &ctn, $3);
 	        $$ = ctn;
            DBG_PRINT }}
         | connect_item
-          {{               
+          {{ DBG_TRACE_GRAMMAR(connect_info, | connect_item );
                 container_10 ctn;
                 memset(&ctn, 0x00, sizeof(container_10));
 
@@ -23337,7 +23420,7 @@ connect_info
 
 connect_item    
         :  HOST '=' CHAR_STRING 
-          {{
+          {{ DBG_TRACE_GRAMMAR(connect_item,  :  HOST '=' CHAR_STRING  );
                 container_2 ctn;
                 PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
                 if (val)
@@ -23355,7 +23438,7 @@ connect_item
                 $$ = ctn;
             DBG_PRINT}}
         | PORT '=' UNSIGNED_INTEGER 
-          {{
+          {{ DBG_TRACE_GRAMMAR(connect_item, | PORT '=' UNSIGNED_INTEGER );
                 container_2 ctn;
                 PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
                 if (val)
@@ -23373,19 +23456,19 @@ connect_item
                 $$ = ctn;
            DBG_PRINT}}
         | DBNAME '=' identifier 
-          {{
+          {{ DBG_TRACE_GRAMMAR(connect_item,  | DBNAME '=' identifier  );
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_DBNAME), $3);
                 $$ = ctn;
            DBG_PRINT}}
         | USER '=' identifier
-          {{
+          {{ DBG_TRACE_GRAMMAR(connect_item, | USER '=' identifier);
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_USER), $3);
                 $$ = ctn;
             DBG_PRINT}}
         | PASSWORD '=' 
-          {{
+          {{ DBG_TRACE_GRAMMAR(connect_item,   | PASSWORD '='  );
                container_2 ctn;
                 PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 	        if (val)                    
@@ -23407,7 +23490,7 @@ connect_item
                  $$ = ctn;
            DBG_PRINT}}
         | PASSWORD '=' CHAR_STRING
-          {{
+          {{ DBG_TRACE_GRAMMAR(connect_item, | PASSWORD '=' CHAR_STRING );
                 container_2 ctn;
                 PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 	        if (val)                    
@@ -23429,13 +23512,13 @@ connect_item
                 $$ = ctn;
            DBG_PRINT}}
         | PROPERTIES '=' 
-          {{
+          {{ DBG_TRACE_GRAMMAR(connect_item, | PROPERTIES '=' );
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_PROPERTIES), NULL);
                 $$ = ctn;
            DBG_PRINT}}
         | PROPERTIES '=' CHAR_STRING 
-          {{
+          {{ DBG_TRACE_GRAMMAR(connect_item,  | PROPERTIES '=' CHAR_STRING );
                 container_2 ctn;
                 PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 	        if (val)                    
@@ -23456,13 +23539,13 @@ connect_item
                 $$ = ctn;
            DBG_PRINT}}
         | COMMENT '='
-          {{
+          {{ DBG_TRACE_GRAMMAR(connect_item,| COMMENT '=');
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_COMMENT), NULL);
                 $$ = ctn;
            DBG_PRINT }}
         | COMMENT '=' char_string
-          {{
+          {{ DBG_TRACE_GRAMMAR(connect_item, | COMMENT '=' char_string );
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_COMMENT), $3);
                 $$ = ctn;
@@ -23471,14 +23554,14 @@ connect_item
 
 alter_server_list
         : alter_server_list ',' alter_server_item
-          {{
+          {{ DBG_TRACE_GRAMMAR(alter_server_list, : alter_server_list ',' alter_server_item);
                container_10 ctn = $1;
 
                pt_fill_conn_info_container(this_parser, @$.buffer_pos, &ctn, $3);
 	        $$ = ctn;
            DBG_PRINT }}
         | alter_server_item
-          {{
+          {{ DBG_TRACE_GRAMMAR(alter_server_list, | alter_server_item);
                 container_10 ctn;
                 memset(&ctn, 0x00, sizeof(container_10));
 
@@ -23489,21 +23572,21 @@ alter_server_list
 
 alter_server_item
         : OWNER TO identifier
-          {{
+          {{ DBG_TRACE_GRAMMAR(alter_server_item, : OWNER TO identifier);
                 container_2 ctn;                 
 
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_OWNER), $3);
                 $$ = ctn;
           }}
         | CHANGE connect_item
-          {{   
+          {{ DBG_TRACE_GRAMMAR(alter_server_item, | CHANGE connect_item); 
 	        $$ = $2;
            DBG_PRINT}}
         ;
 
 dblink_server_name
 	: identifier DOT server_identifier
-          {{                
+          {{ DBG_TRACE_GRAMMAR(dblink_server_name, : identifier DOT server_identifier);
              if($3)
                {
                   $3->next = $1;                  
@@ -23516,14 +23599,14 @@ dblink_server_name
               PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
           DBG_PRINT}}
         | server_identifier
-          {{
+          {{ DBG_TRACE_GRAMMAR(dblink_server_name, | server_identifier);
               $$ = $1;
           DBG_PRINT}}
         ;
 
 server_identifier
         : identifier
-            {{  
+            {{ DBG_TRACE_GRAMMAR(server_identifier, : identifier);
                 if ($1)
                   {                
                      if (strchr($1->info.name.original, '.')) 
@@ -23537,7 +23620,7 @@ server_identifier
          ;
 dblink_expr
         :   dblink_conn  ','  CHAR_STRING  
-            {{
+            {{ DBG_TRACE_GRAMMAR(dblink_expr, : dblink_conn  ','  CHAR_STRING);
              PT_NODE *ct = parser_new_node(this_parser, PT_DBLINK_TABLE) ;           
              if(ct)
              {
@@ -23592,18 +23675,18 @@ dblink_expr
 
 dblink_conn:
         dblink_server_name      
-        {{  
+        {{ DBG_TRACE_GRAMMAR(dblink_conn, : dblink_server_name); 
                 $$ = $1;                
                 DBG_PRINT}}
         | dblink_conn_str
-        {{
+        {{ DBG_TRACE_GRAMMAR(dblink_conn, | dblink_conn_str);
                 $$ = $1;
 		DBG_PRINT}}
         ;   
 
 dblink_conn_str:
         CHAR_STRING
-        {{
+        {{ DBG_TRACE_GRAMMAR(dblink_conn_str, : CHAR_STRING);
                 char *zInfo[DBLINK_CONN_PARAM_CNT];     
                 char err_msg[512]; 
                 PT_NODE *node_list = NULL;
@@ -23663,7 +23746,7 @@ dblink_conn_str:
 
 dblink_identifier_col_attrs  
         :  opt_as identifier '('  dblink_column_definition_list ')' 
-        {{                
+        {{ DBG_TRACE_GRAMMAR(dblink_identifier_col_attrs,  :  opt_as identifier '('  dblink_column_definition_list ')' );
              container_2 ctn;
              
 	     SET_CONTAINER_2 (ctn, $2, $4);
@@ -23673,12 +23756,12 @@ dblink_identifier_col_attrs
 
 dblink_column_definition_list
         :  dblink_column_definition_list ','  dblink_column_definition
-           {{
+           {{ DBG_TRACE_GRAMMAR(dblink_column_definition_list, :  dblink_column_definition_list ','  dblink_column_definition );  
                 $$ = parser_make_link($1, $3);
 	        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
                 DBG_PRINT}}
         | dblink_column_definition
-           {{
+           {{ DBG_TRACE_GRAMMAR(dblink_column_definition_list, | dblink_column_definition );
                $$ = $1;
                PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
              DBG_PRINT}}
@@ -23686,7 +23769,7 @@ dblink_column_definition_list
 
 dblink_column_definition
         : identifier primitive_type
-        {{
+        {{ DBG_TRACE_GRAMMAR(dblink_column_definition,  : identifier primitive_type );
                 PT_NODE *node;              
 
                 node = parser_new_node (this_parser, PT_ATTR_DEF);

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -1241,11 +1241,13 @@ _[uU][tT][fF]8[']		{
 
 0b[0-1]+			{
 					csql_yylval.cptr = pt_append_string(this_parser, NULL, yytext + 2);
+                                        DBG_PRINT_TOKEN(yytext);
 					return BIT_STRING;
 				}
 
 0x[0-9a-fA-F]+			{
-					csql_yylval.cptr = pt_append_string(this_parser, NULL, yytext + 2);
+					csql_yylval.cptr = pt_append_string(this_parser, NULL, yytext + 2);                                        
+                                        DBG_PRINT_TOKEN(yytext);
 					return HEX_STRING;
 				}
 
@@ -1293,51 +1295,61 @@ _[uU][tT][fF]8[']		{
 
 <QUOTED_EUCKR_STRING>[']	{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("_euckr'", csql_yylval.cptr, "'");
 					return EUCKR_STRING;
 				}
 
 <QUOTED_ISO_STRING>[']		{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("_iso88591'", csql_yylval.cptr, "'");
 					return ISO_STRING;
 				}
 
 <QUOTED_BINARY_STRING>[']	{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("_binary'", csql_yylval.cptr, "'");
 					return BINARY_STRING;
 				}
 
 <QUOTED_UTF8_STRING>[']		{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("_utf8'", csql_yylval.cptr, "'");
 					return UTF8_STRING;
 				}
 
 <QUOTED_NCHAR_STRING>[']	{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("n'", csql_yylval.cptr, "'");
 					return NCHAR_STRING;
 				}
 
 <QUOTED_BIT_STRING>[']		{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("b'", csql_yylval.cptr, "'");
 					return BIT_STRING;
 				}
 
 <QUOTED_HEX_STRING>[']		{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("x'", csql_yylval.cptr, "'");
 					return HEX_STRING;
 				}
 
 <QUOTED_CHAR_STRING>[']		{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("'", csql_yylval.cptr, "'");
 					return CHAR_STRING;
 				}
 
 <DOUBLY_QUOTED_CHAR_STRING>["]	{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("\"", csql_yylval.cptr, "\"");
 					return CHAR_STRING;
 				}
 
 <DELIMITED_ID_NAME>["]		{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("\"", csql_yylval.cptr, "\"");
 					if (strlen(csql_yylval.cptr) >= 254)
 					  {
 					    csql_yylval.cptr[254] = 0;
@@ -1347,6 +1359,7 @@ _[uU][tT][fF]8[']		{
 
 <BRACKET_ID_NAME>"]"		{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("[", csql_yylval.cptr, "]");
 					if (strlen(csql_yylval.cptr) >= 254)
 					  {
 					    csql_yylval.cptr[254] = 0;
@@ -1356,6 +1369,7 @@ _[uU][tT][fF]8[']		{
 
 <BACKTICK_ID_NAME>"`"		{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("`", csql_yylval.cptr, "`");
 					if (strlen(csql_yylval.cptr) >= 254)
 					  {
 					    csql_yylval.cptr[254] = 0;
@@ -1371,12 +1385,14 @@ _[uU][tT][fF]8[']		{
 
 <QUOTED_NCHAR_STRING,QUOTED_BIT_STRING,QUOTED_HEX_STRING,QUOTED_CHAR_STRING,DOUBLY_QUOTED_CHAR_STRING,QUOTED_EUCKR_STRING,QUOTED_ISO_STRING,QUOTED_BINARY_STRING,QUOTED_UTF8_STRING><<EOF>>	{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("?", csql_yylval.cptr, "<EOF>");
 					csql_yyerror("unterminated string");
 					return UNTERMINATED_STRING;
 				}
 
 <DELIMITED_ID_NAME,BRACKET_ID_NAME,BACKTICK_ID_NAME><<EOF>>	{
 					BEGIN(INITIAL);
+                                        DBG_PRINT_STRING("?", csql_yylval.cptr, "<EOF>");
 					csql_yyerror("unterminated identifier");
 					return UNTERMINATED_IDENTIFIER;
 				}
@@ -2051,4 +2067,5 @@ begin_token (char *token)
   csql_yylloc.first_column = yycolumn;
   csql_yylloc.last_line = yylineno;
   csql_yylloc.last_column = yycolumn_end;
+  DBG_PRINT_TOKEN(token);
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24225

Added information for debugging to csql_grammar.y and csql_lexer.l

This is used when debugging information about grammar rules or information about the progress of the lexer is needed.
Change the `DBG_TRACE_LEVEL` value in the csql_grammar.y file and use it after building.
This feature is only available in SA_MODE.
The selectable option values are as follows.
```
   0: No displayed on the screen
   1: Words extracted from csql_lexer are displayed on the screen
   2: Display the contents of application of grammar rules in csql_grammar on the screen
  3: Expression of both 1 and 2 above
```
