### PR TITLE
[CBRD-24236] Change the method to get the number of query results in ODBC

### DIFF
--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -163,7 +163,6 @@ extern int cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, v
 
 // Resultset funtions
 extern int cgw_cursor_close (SQLHSTMT hstmt);
-extern int cgw_get_row_count (SQLHSTMT hstmt, SQLLEN * row_count);
 extern int cgw_row_data (SQLHSTMT hstmt, int cursor_pos);
 extern int cgw_set_stmt_attr (SQLHSTMT hstmt, SQLINTEGER attr, SQLPOINTER val, SQLINTEGER len);
 extern int cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding, int cursor_pos);

--- a/src/broker/cas_handle.h
+++ b/src/broker/cas_handle.h
@@ -227,8 +227,6 @@ struct t_srv_handle
 #endif				/* CAS_FOR_MYSQL */
 #if defined (CAS_FOR_CGW)
   T_CGW_HANDLE *cgw_handle;
-  int res_tuple_count_msg_offset;
-  int total_row_count_msg_offset;
   int total_tuple_count;
   int stmt_type;
 #endif				/* CAS_FOR_CGW */


### PR DESCRIPTION

http://jira.cubrid.org/browse/CBRD-24236

Purpose

Looking at the communication protocol between the driver and CAS, the total row count should also be included when the query execution result is sent to the driver.
So, CAS was changed to transmit INT_MAX value in total row count.

Implementation
N/A

Remarks
Related issues: CBRD-24242