### PR TITLE
[LETS-418] explicitly disconnect connection handler's log prior sync subscription in all cases

### DIFF
--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -152,6 +152,12 @@ class page_server
 	void prior_sender_sink_hook (std::string &&message) const;
 
       private:
+	/* there is another mode in which the connection handler for active transaction server
+	 * can be differentiated from the connection handler for passive transaction server: the
+	 * presence of prior sender sink hook function pointer below;
+	 * however, at some point, the hook function will be removed - following a request from
+	 * the peer transaction server and the check will no longer be valid
+	 */
 	const transaction_server_type m_server_type;
 
 	std::unique_ptr<tran_server_conn_t> m_conn;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -21,8 +21,9 @@
 
 #include "log_replication.hpp"
 #include "log_storage.hpp"
-#include "server_request_responder.hpp"
 #include "request_sync_client_server.hpp"
+#include "server_request_responder.hpp"
+#include "server_type_enum.hpp"
 #include "tran_page_requests.hpp"
 
 #include <memory>
@@ -105,7 +106,6 @@ class page_server
     void finalize_request_responder ();
 
   private:
-
     void disconnect_active_tran_server ();
     void disconnect_tran_server_async (connection_handler *conn);
     bool is_active_tran_server_connected () const;
@@ -117,7 +117,7 @@ class page_server
 		cubcomm::request_sync_client_server<page_to_tran_request, tran_to_page_request, std::string>;
 
 	connection_handler () = delete;
-	connection_handler (cubcomm::channel &chn, page_server &ps);
+	connection_handler (cubcomm::channel &chn, transaction_server_type server_type, page_server &ps);
 
 	connection_handler (const connection_handler &) = delete;
 	connection_handler (connection_handler &&) = delete;
@@ -130,8 +130,9 @@ class page_server
 	void push_request (page_to_tran_request id, std::string msg);
 	std::string get_channel_id ();
 
-      private:
+	void remove_prior_sender_sink ();
 
+      private:
 	// Request handlers for the request server:
 	void receive_boot_info_request (tran_server_conn_t::sequenced_payload &a_ip);
 	void receive_log_prior_list (tran_server_conn_t::sequenced_payload &a_ip);
@@ -151,6 +152,8 @@ class page_server
 	void prior_sender_sink_hook (std::string &&message) const;
 
       private:
+	const transaction_server_type m_server_type;
+
 	std::unique_ptr<tran_server_conn_t> m_conn;
 	page_server &m_ps;
 

--- a/src/transaction/log_prior_send.cpp
+++ b/src/transaction/log_prior_send.cpp
@@ -53,6 +53,8 @@ namespace cublog
   void
   prior_sender::add_sink (const sink_hook_t &fun)
   {
+    assert (fun != nullptr);
+
     std::unique_lock<std::mutex> ulock (m_sink_hooks_mutex);
     m_sink_hooks.push_back (&fun);
   }
@@ -60,6 +62,8 @@ namespace cublog
   void
   prior_sender::remove_sink (const sink_hook_t &fun)
   {
+    assert (fun != nullptr);
+
     std::unique_lock<std::mutex> ulock (m_sink_hooks_mutex);
 
     const auto find_it = std::find (m_sink_hooks.begin (), m_sink_hooks.end (), &fun);

--- a/src/transaction/log_recovery_redo_parallel.cpp
+++ b/src/transaction/log_recovery_redo_parallel.cpp
@@ -515,11 +515,13 @@ namespace cublog
     // since it is needed to wake the calculating loop, wake all
     m_calculate_cv.notify_all ();
 
+    constexpr std::chrono::milliseconds millis_100 { 100 };
+
     std::unique_lock<std::mutex> ulock { m_calculate_mtx };
-    m_calculate_cv.wait (ulock, [this, &a_target_lsa] ()
+    while (!m_calculate_cv.wait_for (ulock, millis_100, [this, &a_target_lsa] ()
     {
       return m_calculated_log_lsa > a_target_lsa;
-    });
+    }));
   }
 
   log_lsa


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-418

Page Server (PS) to Passive Transaction Server (PTS) log prior sender sink can be de-activated via the following routes:

- as a direct request from PTS as part of PTS's shutting down:
  - via receive_stop_log_prior_dispatch followed by receive_disconnect_request
- abnormal disconnect request following error to send data to PTS:
  - via abnormal_tran_server_disconnect
- as a request from PS itself shuttind down
  - via disconnect_all_tran_server from
    - xboot_shutdown_server first and then
    - via boot_server_all_finalize - finalize_server_type

In all these scenarios, log prior dispatch sink must be disconnected explicitly.

Implementation:
- refactored page_server::connection_handler to extract function remove_prior_sender_sink which is called in all three scenarios

Other:
- redo_parallel::min_unapplied_log_lsa_monitoring::wait_past_target_log_lsa - changed blocking condition variable wait with a loop
- asserts in prior_sender