### PR TITLE
[CBRD-24227] Handling multiple executions of flashback

### DIFF
--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -1707,8 +1707,9 @@
 #define ER_FLASHBACK_SCHEMA_CHANGED                 -1336
 #define ER_FLASHBACK_LOG_NOT_EXIST                  -1337
 #define ER_FLASHBACK_TIMEOUT                        -1338
+#define ER_FLASHBACK_DUPLICATED_REQUEST             -1339
 
-#define ER_LAST_ERROR                               -1339
+#define ER_LAST_ERROR                               -1340
 /*
  * CAUTION!
  *

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10820,14 +10820,27 @@ sflashback_get_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *request
   time_t start_time = 0;
   time_t end_time = 0;
 
-  if (flashback_is_duplicated_request (thread_p))
+  bool is_duplicated_request = false;
+
+  /* If multiple requests come at the same time,
+   * they can all be treated as non-duplicate requests.
+   * So, latch for check and set flashback connection is required */
+
+  flashback_lock_request ();
+
+  is_duplicated_request = flashback_is_duplicated_request (thread_p);
+  if (is_duplicated_request)
     {
       error_code = ER_FLASHBACK_DUPLICATED_REQUEST;
+
+      flashback_unlock_request ();
       goto error;
     }
   else
     {
       flashback_initialize (thread_p);
+
+      flashback_unlock_request ();
     }
 
   flashback_set_status_active ();
@@ -10929,7 +10942,12 @@ error:
 
   (void) css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));
 
-  flashback_reset ();
+  if (!is_duplicated_request)
+    {
+      /* if flashback variables are reset by duplicated request error,
+       * variables for existing connection (valid connection) can be reset */
+      flashback_reset ();
+    }
 
   return;
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10820,15 +10820,14 @@ sflashback_get_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *request
   time_t start_time = 0;
   time_t end_time = 0;
 
-  if (flashback_min_log_pageid_to_keep () != NULL_LOG_PAGEID)
+  if (flashback_is_duplicated_request (thread_p))
     {
-      /* if flashback was shutdown abnormally, flashback_min_log_pageid can not be cleared
-       * If the previous flashback was abnormally terminated,
-       * this flashback_min_log_pageid  would not have been initialized.
-       * Therefore, after all variables related to flashback are initialized, subsequent operations should be performed
-       */
-
-      flashback_reset ();
+      error_code = ER_FLASHBACK_DUPLICATED_REQUEST;
+      goto error;
+    }
+  else
+    {
+      flashback_initialize (thread_p);
     }
 
   flashback_set_status_active ();

--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -431,6 +431,7 @@ struct css_conn_entry
   bool in_transaction;		/* this client is in-transaction or out-of- */
   bool reset_on_commit;		/* set reset_on_commit when commit/abort */
 
+  bool in_flashback;		/* this client is in progress of flashback */
 #if defined(SERVER_MODE)
   int idx;			/* connection index */
   BOOT_CLIENT_TYPE client_type;

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -294,6 +294,7 @@ css_initialize_conn (CSS_CONN_ENTRY * conn, SOCKET fd)
   conn->client_id = err;
   conn->db_error = 0;
   conn->in_transaction = false;
+  conn->in_flashback = false;
   conn->reset_on_commit = false;
   conn->stop_talk = false;
   conn->ignore_repl_delay = false;
@@ -372,6 +373,7 @@ css_shutdown_conn (CSS_CONN_ENTRY * conn)
     {
       conn->status = CONN_CLOSED;
       conn->stop_talk = false;
+      conn->in_flashback = false;
       conn->stop_phase = THREAD_STOP_WORKERS_EXCEPT_LOGWR;
 
       if (conn->version_string)

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -4922,6 +4922,12 @@ flashback (UTIL_FUNCTION_ARG * arg)
   is_detail = utility_get_option_bool_value (arg_map, FLASHBACK_DETAIL_S);
   is_oldest = utility_get_option_bool_value (arg_map, FLASHBACK_OLDEST_S);
 
+  if (!prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG))
+    {
+      fprintf (stderr, "please set \"supplemental_log\" in conf/cubrid.conf\n");
+      goto error_exit;
+    }
+
   /* create table list */
   /* class existence and classoid will be found at server side. if is checked at utility side, it needs addtional access to the server through locator */
   darray = da_create (num_tables, SM_MAX_IDENTIFIER_LENGTH);
@@ -5059,12 +5065,6 @@ flashback (UTIL_FUNCTION_ARG * arg)
     }
 
   need_shutdown = true;
-
-  if (!prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG))
-    {
-      fprintf (stderr, "please set \"supplemental_log\" in conf/cubrid.conf\n");
-      goto error_exit;
-    }
 
   oid_list = (OID *) malloc (sizeof (OID) * num_tables);
   if (oid_list == NULL)

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -4922,12 +4922,6 @@ flashback (UTIL_FUNCTION_ARG * arg)
   is_detail = utility_get_option_bool_value (arg_map, FLASHBACK_DETAIL_S);
   is_oldest = utility_get_option_bool_value (arg_map, FLASHBACK_OLDEST_S);
 
-  if (!prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG))
-    {
-      fprintf (stderr, "please set \"supplemental_log\" in conf/cubrid.conf\n");
-      goto error_exit;
-    }
-
   /* create table list */
   /* class existence and classoid will be found at server side. if is checked at utility side, it needs addtional access to the server through locator */
   darray = da_create (num_tables, SM_MAX_IDENTIFIER_LENGTH);
@@ -5065,6 +5059,12 @@ flashback (UTIL_FUNCTION_ARG * arg)
     }
 
   need_shutdown = true;
+
+  if (!prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG))
+    {
+      fprintf (stderr, "please set \"supplemental_log\" in conf/cubrid.conf\n");
+      goto error_exit;
+    }
 
   oid_list = (OID *) malloc (sizeof (OID) * num_tables);
   if (oid_list == NULL)

--- a/src/transaction/flashback.c
+++ b/src/transaction/flashback.c
@@ -133,7 +133,7 @@ flashback_initialize (THREAD_ENTRY * thread_p)
 
   pthread_mutex_lock (&conn_mutex);
 
-  if (flashback_is_duplicated_request)
+  if (flashback_is_duplicated_request (thread_p))
     {
       /* er_set() */
       return ER_FLASHBACK_DUPLICATED_REQUEST;

--- a/src/transaction/flashback.c
+++ b/src/transaction/flashback.c
@@ -80,8 +80,6 @@ static pthread_mutex_t flashback_Conn_lock = PTHREAD_MUTEX_INITIALIZER;
 static bool
 flashback_is_duplicated_request (THREAD_ENTRY * thread_p)
 {
-  CSS_CONN_ENTRY *previous_conn = NULL;
-
   /* flashback_Current_conn indicates conn_entry in thread_p, and conn_entry can be reused by request handler.
    * So, status in flashback_Current_conn can be overwritten. */
 

--- a/src/transaction/flashback.c
+++ b/src/transaction/flashback.c
@@ -85,16 +85,14 @@ flashback_is_duplicated_request (THREAD_ENTRY * thread_p)
   /* flashback_Current_conn indicates conn_entry in thread_p, and conn_entry can be reused by request handler.
    * So, status in flashback_Current_conn can be overwritten. */
 
-  previous_conn = flashback_Current_conn;
-
-  if (previous_conn == NULL)
+  if (flashback_Current_conn == NULL)
     {
       /* previous flashback set flashback_Current_conn to NULL properly. (exited well) */
       return false;
     }
   else
     {
-      if (previous_conn->in_flashback == true)
+      if (flashback_Current_conn->in_flashback == true)
 	{
 	  /* previous flashback is still in progress */
 	  return true;
@@ -103,6 +101,9 @@ flashback_is_duplicated_request (THREAD_ENTRY * thread_p)
 	{
 	  /* - previous_conn is overwritten with new connection, so in_flashback value is initialized to false.
 	   * - previous flashback connection has been exited abnormally. */
+
+	  flashback_reset ();
+
 	  return false;
 	}
     }
@@ -130,7 +131,7 @@ flashback_initialize (THREAD_ENTRY * thread_p)
       return ER_FLASHBACK_DUPLICATED_REQUEST;
     }
 
-  assert (thread_p->conn_entry != NULL);
+  assert (flashback_Current_conn == NULL);
 
   flashback_Current_conn = thread_p->conn_entry;
   flashback_Current_conn->in_flashback = true;

--- a/src/transaction/flashback.c
+++ b/src/transaction/flashback.c
@@ -64,10 +64,10 @@ static volatile int flashback_Threshold_to_remove_archive = 0;	/* If the differe
 								 * the archive log volume can be deleted.
 								 */
 // *INDENT-OFF*
-static std::atomic_bool flashback_Is_active = false;	// the status value that the flashback is processing the a request
+static std::atomic_bool flashback_Is_active = false;	// the status value that the flashback is processing the request
 // *INDENT-ON*
 
-static CSS_CONN_ENTRY *flashback_Current_conn = NULL;	// the connection entry for a flashback requests
+static CSS_CONN_ENTRY *flashback_Current_conn = NULL;	// the connection entry for a flashback request
 
 static pthread_mutex_t flashback_Conn_lock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -99,7 +99,7 @@ flashback_is_duplicated_request (THREAD_ENTRY * thread_p)
 	}
       else
 	{
-	  /* - previous_conn is overwritten with new connection, so in_flashback value is initialized to false.
+	  /* - flashback_Current_conn is overwritten with new connection, so in_flashback value is initialized to false.
 	   * - previous flashback connection has been exited abnormally. */
 
 	  flashback_reset ();

--- a/src/transaction/flashback.h
+++ b/src/transaction/flashback.h
@@ -111,9 +111,6 @@ extern void flashback_cleanup (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEX
 
 extern int flashback_initialize (THREAD_ENTRY * thread_p);
 
-extern void flashback_lock_request ();
-extern void flashback_unlock_request ();
-
 extern LOG_PAGEID flashback_min_log_pageid_to_keep ();
 extern bool flashback_is_needed_to_keep_archive ();
 extern bool flashback_check_time_exceed_threshold ();

--- a/src/transaction/flashback.h
+++ b/src/transaction/flashback.h
@@ -37,6 +37,7 @@
 #include "log_lsa.hpp"
 #include "thread_compat.hpp"
 #include "oid.h"
+#include "connection_defs.h"
 
 #define FLASHBACK_MAX_NUM_TRAN_TO_SUMMARY   INT_MAX
 
@@ -108,6 +109,8 @@ typedef struct flashback_summary_context
 extern int flashback_make_summary_list (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEXT * context);
 extern void flashback_cleanup (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEXT * context);
 
+extern bool flashback_is_duplicated_request (THREAD_ENTRY * thread_p);
+extern void flashback_initialize (THREAD_ENTRY * thread_p);
 extern LOG_PAGEID flashback_min_log_pageid_to_keep ();
 extern bool flashback_is_needed_to_keep_archive ();
 extern bool flashback_check_time_exceed_threshold ();

--- a/src/transaction/flashback.h
+++ b/src/transaction/flashback.h
@@ -111,6 +111,10 @@ extern void flashback_cleanup (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEX
 
 extern bool flashback_is_duplicated_request (THREAD_ENTRY * thread_p);
 extern void flashback_initialize (THREAD_ENTRY * thread_p);
+
+extern void flashback_lock_request ();
+extern void flashback_unlock_request ();
+
 extern LOG_PAGEID flashback_min_log_pageid_to_keep ();
 extern bool flashback_is_needed_to_keep_archive ();
 extern bool flashback_check_time_exceed_threshold ();

--- a/src/transaction/flashback.h
+++ b/src/transaction/flashback.h
@@ -109,8 +109,7 @@ typedef struct flashback_summary_context
 extern int flashback_make_summary_list (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEXT * context);
 extern void flashback_cleanup (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEXT * context);
 
-extern bool flashback_is_duplicated_request (THREAD_ENTRY * thread_p);
-extern void flashback_initialize (THREAD_ENTRY * thread_p);
+extern int flashback_initialize (THREAD_ENTRY * thread_p);
 
 extern void flashback_lock_request ();
 extern void flashback_unlock_request ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24227

Purpose

For Blocking duplicated flashback execution,
it need to check if previous flashback is in progress or shutdown abnormally or exited properly. 

Implementation
To know status of previous flashback request, 
1. added flashback status in css_conn_entry for request handler (conn_entry->in_flashback)
2. maintained flashback connection entry (flashback_Current_conn)
