### PR TITLE
[CBRD-24247] Do not print owner_name in SHOW CREATE TABLE/VIEW.

### DIFF
--- a/src/object/class_description.cpp
+++ b/src/object/class_description.cpp
@@ -289,7 +289,7 @@ int class_description::init (struct db_object *op, type prt_type, string_buffer 
        * this->name is set to the exact class name
        */
       sb.clear ();
-      sb ("[%s]", sm_ch_name ((MOBJ) class_));
+      sb ("[%s]", sm_remove_qualifier_name (sm_ch_name ((MOBJ) class_)));
       this->name = object_print::copy_string (sb.get_buffer ());
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24247

- The owner_name is printed in SHOW CREATE TABLE/VIEW, causing the identifier name to contain a dot (.).
- Since identifier names cannot contain dot (.), an error occurs when the resulting query is executed.
```
create user u1;
call login ('u1') on class db_user;
create table t1 (c1 int);
show create table t1;

/*
  TABLE                 CREATE TABLE
============================================
  'u1.t1'               'CREATE TABLE [u1.t1] ([c1] INTEGER) REUSE_OID, COLLATE utf8_bin'
*/

drop table t1;

CREATE TABLE [u1.t1] ([c1] INTEGER) REUSE_OID, COLLATE utf8_bin;

/*
ERROR: before '  ([c1] INTEGER) REUSE_OID, COLLATE utf8_bin; '
Identifier name [u1.t1] not allowed. It cannot contain dot(.).
*/
```
- Since there is no need to print the owner_name in SHOW CREATE TABLE/VIEW, remove it.
```
show create table t1;

  TABLE                 CREATE TABLE
============================================
  'u1.t1'               'CREATE TABLE [t1] ([c1] INTEGER) REUSE_OID, COLLATE utf8_bin'
```