### PR TITLE
[CBRD-24241] [Regression] [ha_repl] There is a difference when binding double type values ​​in slave

### DIFF
--- a/src/compat/db_value_printer.cpp
+++ b/src/compat/db_value_printer.cpp
@@ -275,11 +275,11 @@ void db_value_printer::describe_data (const db_value *value)
       break;
 
     case DB_TYPE_FLOAT:
-      describe_real (m_buf, db_get_float (value), DB_FLOAT_DECIMAL_PRECISION);
+      m_buf ("%f", (double) db_get_float (value));
       break;
 
     case DB_TYPE_DOUBLE:
-      describe_real (m_buf, db_get_double (value), DB_DOUBLE_DECIMAL_PRECISION);
+      m_buf ("%e", (double) db_get_double (value));
       break;
 
     case DB_TYPE_NUMERIC:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24241

The type "double" is represented as numeric by "db_value_printer describe_data" when replication query is printed.
