### PR TITLE
[CBRD-24204] applyinfo usage modification

### DIFF
--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -978,9 +978,9 @@ usage: %1$s applyinfo [OPTION] database-name\n\
 \n\
 valid options:\n\
   -r, --remote-host-name      remote host name; display remote node's active log information \n\
-  -a, --applied-info 	      display applied information \n\
+  -a, --applied-info 	      display applied information; the -L option is required \n\
   -L, --copied-log-path=PATH  path of copied log volumes; display copied log information \n\
-  -p, --page=ID               page id; default : 0\n\
+  -p, --page=ID               page id; default : 0; the -L option is required \n\
   -v, --verbose               enable verbose status messages; default : disable\n\
   -i, --interval=S            print information every S secs\n
 


### PR DESCRIPTION
[http://jira.cubrid.org/browse/CBRD-24204](http://jira.cubrid.org/browse/CBRD-24204)

the utility "applyinfo" emits usage. 
-L option is required to execute the -a and -p options.
So, `the -L option is required` is added into the usage.

AS-IS
```
applyinfo: display CUBRID HA Apply information.
usage: cubrid applyinfo [OPTION] database-name
valid options:
  -r, --remote-host-name      remote host name; display remote node's active log information
  -a, --applied-info          display applied information
  -L, --copied-log-path=PATH  path of copied log volumes; display copied log information
  -p, --page=ID               page id; default : 0
  -v, --verbose               enable verbose status messages; default : disable
  -i, --interval=S            print information every S secs

```

TO-BE
```
applyinfo: display CUBRID HA Apply information.
usage: cubrid applyinfo [OPTION] database-name
valid options:
  -r, --remote-host-name      remote host name; display remote node's active log information
  -a, --applied-info          display applied information; the -L option is required
  -L, --copied-log-path=PATH  path of copied log volumes; display copied log information
  -p, --page=ID               page id; default : 0; the -L option is required
  -v, --verbose               enable verbose status messages; default : disable
  -i, --interval=S            print information every S secs

```

**Implementation**

N/A
**Remarks**

N/A