### PR TITLE
[LETS-376] Separate log_rv_redo_record_sync page fixing/unfixing and redo apply

### DIFF
--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -661,19 +661,9 @@ extern vpid_lsa_consistency_check log_Gl_recovery_redo_consistency_check;
 #endif
 
 template <typename T>
-void log_rv_redo_record_sync (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
-			      const log_rv_redo_rec_info<T> &record_info, const VPID &rcv_vpid)
+void log_rv_redo_record_sync_fix_and_apply (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
+    const log_rv_redo_rec_info<T> &record_info, const VPID &rcv_vpid, LOG_RCV &rcv)
 {
-#if !defined(NDEBUG)
-  if (log_Gl.rcv_phase != LOG_RESTARTED)
-    {
-      // bit of debug code to ensure that, should this code be executed asynchronously, within the same page,
-      // the lsa is ever-increasing, thus, not altering the order in which it has been added to the log in the first place
-      log_Gl_recovery_redo_consistency_check.check (rcv_vpid, record_info.m_start_lsa);
-    }
-#endif
-
-  LOG_RCV rcv;
   if (!log_rv_fix_page_and_check_redo_is_needed (thread_p, rcv_vpid, rcv, record_info.m_start_lsa,
       redo_context.m_end_redo_lsa, redo_context.m_page_fetch_mode))
     {
@@ -682,19 +672,7 @@ void log_rv_redo_record_sync (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_
       return;
     }
   // at this point, pgptr can be null or not
-
-  /* will take care of unfixing the page, will be correctly de-allocated as it is the same
-   * storage class as 'rcv' and allocated on the stack after 'rcv' */
-  scope_exit <std::function<void (void)>> unfix_rcv_pgptr (
-      // could have used pgbuf_unfix_and_init if it were a function
-      [&thread_p, &rcv] ()
-  {
-    if (rcv.pgptr != nullptr)
-      {
-	pgbuf_unfix (thread_p, rcv.pgptr);
-	rcv.pgptr = nullptr;
-      }
-  });
+  // continue the process
 
   rcv.length = log_rv_get_log_rec_redo_length<T> (record_info.m_logrec);
   rcv.mvcc_id = log_rv_get_log_rec_mvccid<T> (record_info.m_logrec);
@@ -735,6 +713,32 @@ void log_rv_redo_record_sync (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_
     {
       pgbuf_set_lsa (thread_p, rcv.pgptr, &record_info.m_start_lsa);
       // rcv pgptr will be automatically unfixed at the end of the parent scope
+    }
+
+}
+
+template <typename T>
+void log_rv_redo_record_sync (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
+			      const log_rv_redo_rec_info<T> &record_info, const VPID &rcv_vpid)
+{
+#if !defined(NDEBUG)
+  if (log_Gl.rcv_phase != LOG_RESTARTED)
+    {
+      // bit of debug code to ensure that, should this code be executed asynchronously, within the same page,
+      // the lsa is ever-increasing, thus, not altering the order in which it has been added to the log in the first place
+      log_Gl_recovery_redo_consistency_check.check (rcv_vpid, record_info.m_start_lsa);
+    }
+#endif
+
+  LOG_RCV rcv;
+  log_rv_redo_record_sync_fix_and_apply (thread_p, redo_context, record_info, rcv_vpid, rcv);
+
+  /* will take care of unfixing the page, will be correctly de-allocated as it is the same
+   * storage class as 'rcv' and allocated on the stack after 'rcv' */
+  if (rcv.pgptr != nullptr)
+    {
+      pgbuf_unfix (thread_p, rcv.pgptr);
+      rcv.pgptr = nullptr;
     }
 }
 

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -672,7 +672,6 @@ void log_rv_redo_record_sync_fix_and_apply (THREAD_ENTRY *thread_p, log_rv_redo_
       return;
     }
   // at this point, pgptr can be null or not
-  // continue the process
 
   rcv.length = log_rv_get_log_rec_redo_length<T> (record_info.m_logrec);
   rcv.mvcc_id = log_rv_get_log_rec_mvccid<T> (record_info.m_logrec);
@@ -731,15 +730,18 @@ void log_rv_redo_record_sync (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_
 #endif
 
   LOG_RCV rcv;
-  log_rv_redo_record_sync_fix_and_apply (thread_p, redo_context, record_info, rcv_vpid, rcv);
-
   /* will take care of unfixing the page, will be correctly de-allocated as it is the same
    * storage class as 'rcv' and allocated on the stack after 'rcv' */
-  if (rcv.pgptr != nullptr)
-    {
-      pgbuf_unfix (thread_p, rcv.pgptr);
-      rcv.pgptr = nullptr;
-    }
+  scope_exit <std::function<void (void)>> unfix_rcv_pgptr ([&thread_p, &rcv] ()
+  {
+    if (rcv.pgptr != nullptr)
+      {
+	pgbuf_unfix_and_init (thread_p, rcv.pgptr);
+      }
+  });
+
+  // process the log record
+  log_rv_redo_record_sync_fix_and_apply (thread_p, redo_context, record_info, rcv_vpid, rcv);
 }
 
 template <typename T>


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-376

Separated `log_rv_redo_record_sync` into 2 functions:
- `log_rv_redo_record_sync_fix_and_apply` that does the processing and the fixing of the log record
- `log_rv_redo_record_sync` calls the previous function and then does the unfixing
