### PR TITLE
[CBRD-24204] applyinfo usage is modified

### DIFF
--- a/msg/de_DE.utf8/utils.msg
+++ b/msg/de_DE.utf8/utils.msg
@@ -975,9 +975,9 @@ Anwendung: %1$s applyinfo [OPTION] Datenbanknamen\n\
 \n\
 gültige Optionen:\n\
   -r, --remote-host-name      Remote-Hostnamen; aktiven Log-Information des Remoteknoten anzeigen\n\
-  -a, --applied-info          Übernommene Information anzeigen \n\
   -L, --copied-log-path=PFAD  Pfad der kopierten Logdatenträger; kopierte Loginformation anzeigen \n\
-  -p, --page=ID               Seiten-ID; Standard: 0\n\
+  -a, --applied-info          Übernommene Information anzeigen; Die Option -L ist erforderlich \n\
+  -p, --page=ID               Seiten-ID; Die Option -L ist erforderlich; Standard: 0\n\
   -v, --verbose               ausführliche Statusmeldungen aktivieren; Standard: inaktiv\n\
   -i, --interval=S            Druckinformationen alle S secs\n
 

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -978,9 +978,9 @@ usage: %1$s applyinfo [OPTION] database-name\n\
 \n\
 valid options:\n\
   -r, --remote-host-name      remote host name; display remote node's active log information \n\
-  -a, --applied-info 	      display applied information \n\
   -L, --copied-log-path=PATH  path of copied log volumes; display copied log information \n\
-  -p, --page=ID               page id; default : 0\n\
+  -a, --applied-info 	      display applied information; the -L option is required \n\
+  -p, --page=ID               page id; the -L option is required; default : 0\n\
   -v, --verbose               enable verbose status messages; default : disable\n\
   -i, --interval=S            print information every S secs\n
 

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -978,8 +978,8 @@ usage: %1$s applyinfo [OPTION] database-name\n\
 \n\
 valid options:\n\
   -r, --remote-host-name      remote host name; display remote node's active log information \n\
-  -a, --applied-info 	      display applied information; the -L option is required \n\
   -L, --copied-log-path=PATH  path of copied log volumes; display copied log information \n\
+  -a, --applied-info 	      display applied information; the -L option is required \n\
   -p, --page=ID               page id; the -L option is required; default : 0\n\
   -v, --verbose               enable verbose status messages; default : disable\n\
   -i, --interval=S            print information every S secs\n

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -978,9 +978,9 @@ usage: %1$s applyinfo [OPTION] database-name\n\
 \n\
 valid options:\n\
   -r, --remote-host-name      remote host name; display remote node's active log information \n\
-  -a, --applied-info 	      display applied information \n\
+  -a, --applied-info 	      display applied information; the -L option is required \n\
   -L, --copied-log-path=PATH  path of copied log volumes; display copied log information \n\
-  -p, --page=ID               page id; default : 0\n\
+  -p, --page=ID               page id; the -L option is required; default : 0\n\
   -v, --verbose               enable verbose status messages; default : disable\n\
   -i, --interval=S            print information every S secs\n
 

--- a/msg/es_ES.utf8/utils.msg
+++ b/msg/es_ES.utf8/utils.msg
@@ -976,9 +976,9 @@ uso: %1$s applyinfo [OPTION] database-name\n\
 \n\
 opciones validas:\n\
   -r, --remote-host-name      nombre de host remote; mostrar la informacion de registro activa del nodo remote \n\
-  -a, --applied-info          mostrar informacion aplicada \n\
   -L, --copied-log-path=PATH  ruta de los volumenes de registro copiados; mostrar informacion de registro copiado \n\
-  -p, --page=ID               id de pagina; estandar : 0\n\
+  -a, --applied-info          mostrar informacion aplicada; se requiere la opción -L \n\
+  -p, --page=ID               id de pagina; se requiere la opción -L; estandar : 0\n\
   -v, --verbose               habilitar mensajes de estado verbose; estandar : inhabilitar\n\
   -i, --interval=S            imprimir informacion casa S segundos\n
 

--- a/msg/fr_FR.utf8/utils.msg
+++ b/msg/fr_FR.utf8/utils.msg
@@ -979,9 +979,9 @@ usage: %1$s applyinfo [OPTION] database-name\n\
 \n\
 options valids:\n\
   -r, --remote-host-name        nom d'hôte distant; affiche les informations du journal actif du noeud distant\n\
-  -a, --applied-info            affiche infomation appliquée\n\
   -L, --copied-log-path=CHEMIN  CHEMIN de volumes du journal copiés; affiche les informations du journal copié\n\
-  -p, --page=ID                 id de page; par défaut : 0\n\
+  -a, --applied-info            affiche infomation appliquée; l'option -L est obligatoire\n\
+  -p, --page=ID                 id de page; l'option -L est obligatoire; par défaut : 0\n\
   -v, --verbose                 active les messages verbeux d'état; par défaut: désactivé\n\
   -i, --interval=S              print information every S secs\n
 

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -976,9 +976,9 @@ uso: %1$s applyinfo [OPZIONE] nome-database\n\
 \n\
 opzioni valide:\n\
   -r, --remote-host-name      nome dell'host remoto; visualizzare le informazioni di log attivo del nodo remote \n\
-  -a, --applied-info          visualizzare applied infomation \n\
   -L, --copied-log-path=PATH  path di volumi di registrazione copiate; informazioni del log copiate \n\
-  -p, --page=ID               page id; predefinito : 0\n\
+  -a, --applied-info          visualizzare applied infomation; l'opzione -L è richiesta \n\
+  -p, --page=ID               page id; l'opzione -L è richiesta; predefinito : 0\n\
   -v, --verbose               attivare i messaggi dettagliati di stato; predefinito : non attivo\n\
   -i, --interval=S            print information every S secs\n
 

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -975,9 +975,9 @@ applyinfo: CUBRID HA Apply情報を出力。\n\
 \n\
 オプション:\n\
   -r, --remote-host-name      リモートホスト名; リモートノードのアクティブログ情報を出力\n\
-  -a, --applied-info          適用された情報を出力\n\
   -L, --copied-log-path=PATH  コピーしたログブリュームのパス; コピーしたログ情報を出力。\n\
-  -p, --page=ID               ページID; デフォルト : 0\n\
+  -a, --applied-info          適用された情報を出力; -Lオプションが必要です\n\
+  -p, --page=ID               ページID; -Lオプションが必要です; デフォルト : 0\n\
   -v, --verbose               多様な進行情報を出力; デフォルト: 出力しない\n\
   -i, --interval=S            S秒のたびに表示される情報を更新する。\n
 

--- a/msg/km_KH.utf8/utils.msg
+++ b/msg/km_KH.utf8/utils.msg
@@ -978,9 +978,9 @@ usage: %1$s applyinfo [OPTION] database-name\n\
 \n\
 valid options:\n\
   -r, --remote-host-name      remote host name; display remote node's active log information \n\
-  -a, --applied-info 	      display applied information \n\
   -L, --copied-log-path=PATH  path of copied log volumes; display copied log information \n\
-  -p, --page=ID               page id; default : 0\n\
+  -a, --applied-info          display applied information; the -L option is required \n\
+  -p, --page=ID               page id; the -L option is required; default : 0\n\
   -v, --verbose               enable verbose status messages; default : disable\n\
   -i, --interval=S            print information every S secs\n
 

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -74,7 +74,7 @@ $       52      dump_tz
 $       53      restoreslave
 $       54      delvoldb
 $       56      checksumdb
-$       56      tde
+$       57      tde
 
 $set 1 MSGCAT_UTIL_SET_GENERIC
 1 크기가 잘못되었거나, 잘못된 문자 '%1$c'이(가) 데이터베이스 이름 '%2$s'에 포함되어 있습니다\n
@@ -291,7 +291,7 @@ backupdb: 데이터베이스를 백업합니다.\n\
   -t, --thread-count=COUNT     백업을 수행하는 스레드 개수; 기본값: 자동\n\
       --no-compress            백업 볼륨을 압축하지 않습니다; 기본값: 압축\n\
       --sleep-msecs=N          매 1M 읽기 마다 N 밀리초를 쉽니다; 기본값: 0\n\
-  -k, --separate-keys          TDE에 사용되는 Key File (_keys)을 백업볼륨에 포함하지 않고 별개의 파일로 분리합니다.\n
+  -k, --separate-keys          TDE에 사용되는 Key File (_keys)을 백업볼륨에 포함하지 않고 별개의 파일로 분리합니다. \n
 71 \"%1$s\" 와 \"%2$s\" (은)는 함께 사용할 수 없습니다.\n
 
 
@@ -976,9 +976,9 @@ applyinfo: display CUBRID HA 복제 상태 출력\n\
 \n\
 valid options:\n\
   -r, --remote-host-name      원격 호스트 이름; 원격 노드의 활성 로그 정보 출력\n\
-  -a, --applied-info          반영된 정보 출력\n\
   -L, --copied-log-path=PATH  복사된 로그 볼륨의 경로; 복사된 로그 정보 출력\n\
-  -p, --page=ID               페이지 id; 기본값: 0\n\
+  -a, --applied-info          반영된 정보 출력; L옵션이 필요\n\
+  -p, --page=ID               페이지 id; L옵션이 필요; 기본값: 0\n\
   -v, --verbose               상세 상태 정보 출력; 기본값: 사용하지 않음\n\
   -i, --interval=S            매 S 초마다 로그 정보 출력\n
 

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -74,7 +74,7 @@ $       52      dump_tz
 $       53      restoreslave
 $       54      delvoldb
 $       56      checksumdb
-$       57      tde
+$       56      tde
 
 $set 1 MSGCAT_UTIL_SET_GENERIC
 1 크기가 잘못되었거나, 잘못된 문자 '%1$c'이(가) 데이터베이스 이름 '%2$s'에 포함되어 있습니다\n
@@ -291,7 +291,7 @@ backupdb: 데이터베이스를 백업합니다.\n\
   -t, --thread-count=COUNT     백업을 수행하는 스레드 개수; 기본값: 자동\n\
       --no-compress            백업 볼륨을 압축하지 않습니다; 기본값: 압축\n\
       --sleep-msecs=N          매 1M 읽기 마다 N 밀리초를 쉽니다; 기본값: 0\n\
-  -k, --separate-keys          TDE에 사용되는 Key File (_keys)을 백업볼륨에 포함하지 않고 별개의 파일로 분리합니다. \n
+  -k, --separate-keys          TDE에 사용되는 Key File (_keys)을 백업볼륨에 포함하지 않고 별개의 파일로 분리합니다.\n
 71 \"%1$s\" 와 \"%2$s\" (은)는 함께 사용할 수 없습니다.\n
 
 

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -976,9 +976,9 @@ applyinfo: display CUBRID HA 복제 상태 출력\n\
 \n\
 valid options:\n\
   -r, --remote-host-name      원격 호스트 이름; 원격 노드의 활성 로그 정보 출력\n\
-  -a, --applied-info          반영된 정보 출력\n\
   -L, --copied-log-path=PATH  복사된 로그 볼륨의 경로; 복사된 로그 정보 출력\n\
-  -p, --page=ID               페이지 id; 기본값: 0\n\
+  -a, --applied-info          반영된 정보 출력; L옵션이 필요\n\
+  -p, --page=ID               페이지 id; L옵션이 필요; 기본값: 0\n\
   -v, --verbose               상세 상태 정보 출력; 기본값: 사용하지 않음\n\
   -i, --interval=S            매 S 초마다 로그 정보 출력\n
 

--- a/msg/ro_RO.utf8/utils.msg
+++ b/msg/ro_RO.utf8/utils.msg
@@ -993,9 +993,9 @@ utilizare: %1$s applyinfo [OPŢIUNI] nume-bază-de-date\n\
 \n\
 opţiuni valide:\n\
   -r, --remote-host-name      numele gazdei remote; afişează informaţii despre logul activ al nodului departat \n\
-  -a, --applied-info 	      afişează informaţiile aplicate \n\
   -L, --copied-log-path=CALE  calea către volumele de log copiate; afişează informaţii despre logurile copiate\n\
-  -p, --page=ID               id de pagina; implicit : 0\n\
+  -a, --applied-info 	      afişează informaţiile aplicate; este necesară opțiunea -L \n\
+  -p, --page=ID               id de pagina; este necesară opțiunea -L; implicit : 0\n\
   -v, --verbose               activează mesaje de stare detaliate; implicit : dezactivate\n\
   -i, --interval=S            afişează informaţii la fiecare S secunde\n
 

--- a/msg/tr_TR.utf8/utils.msg
+++ b/msg/tr_TR.utf8/utils.msg
@@ -976,9 +976,9 @@ kullanım: %1$s applyinfo [SEÇENEK] database-name\n\
 \n\
 geçerli seçenekler:\n\
   -r, --remote-host-name      Uzak ana bilgisayar adı; görüntü uzak düğüm aktif log bilgileri\n\
-  -a, --applied-info 	      uygulamalı bilgilerde görüntü \n\
   -L, --copied-log-path=PATH  Kopyalanan log yoğunlukların path; görüntü kopyalanan log bilgileri \n\
-  -p, --page=ID               sayfa id; varsayılan: 0 \n\
+  -a, --applied-info 	      uygulamalı bilgilerde görüntü; -L seçeneği gereklidir \n\
+  -p, --page=ID               sayfa id; -L seçeneği gereklidir; varsayılan: 0 \n\
   -v, --verbose               Ayrıntılı durum mesajları sağlamak; varsayılan: devre dışı bırakmak\n\
   -i, --interval=S            her S saniye bilgilerini yazdırmak\n
 

--- a/msg/vi_VN.utf8/utils.msg
+++ b/msg/vi_VN.utf8/utils.msg
@@ -978,9 +978,9 @@ usage: %1$s applyinfo [OPTION] database-name\n\
 \n\
 valid options:\n\
   -r, --remote-host-name      remote host name; display remote node's active log information \n\
-  -a, --applied-info 	      display applied information \n\
   -L, --copied-log-path=PATH  path of copied log volumes; display copied log information \n\
-  -p, --page=ID               page id; default : 0\n\
+  -a, --applied-info          display applied information; the -L option is required \n\
+  -p, --page=ID               page id; the -L option is required; default : 0\n\
   -v, --verbose               enable verbose status messages; default : disable\n\
   -i, --interval=S            print information every S secs\n
 

--- a/msg/zh_CN.utf8/utils.msg
+++ b/msg/zh_CN.utf8/utils.msg
@@ -976,9 +976,9 @@ applyinfo: 显示 CUBRID HA 应用信息.\n\
 \n\
 可用选项:\n\
   -r, --remote-host-name      远程主机名; 显示远程节点的活动日志信息 \n\
-  -a, --applied-info 	      显示运用的信息 \n\
   -L, --copied-log-path=PATH  设置复制的日志卷路径; 显示复制的日志信息 \n\
-  -p, --page=ID               页 id; 默认: 0\n\
+  -a, --applied-info 	      显示运用的信息; -L 选项是必需的 \n\
+  -p, --page=ID               页 id; -L 选项是必需的; 默认: 0\n\
   -v, --verbose               显示详细状态信息; 默认 : 关闭\n\
   -i, --interval=S            设置每 S 秒打印一次信息\n
 


### PR DESCRIPTION
[http://jira.cubrid.org/browse/CBRD-24204](http://jira.cubrid.org/browse/CBRD-24204)

the utility "applyinfo" emits usage. 
-L option is required to execute the -a and -p options.
So, `the -L option is required` is added into the usage.

As mentioned closed PR, previous PR is invalid and then it is closed.
And I applied usage as like comment.
If we accept this modification, I will apply to utils.msg in the `en_US.utf8`, `km_KH.utf8` and `vi_VN.utf8`

AS-IS
```
applyinfo: display CUBRID HA Apply information.
usage: cubrid applyinfo [OPTION] database-name
valid options:
  -r, --remote-host-name      remote host name; display remote node's active log information
  -a, --applied-info          display applied information
  -L, --copied-log-path=PATH  path of copied log volumes; display copied log information
  -p, --page=ID               page id; default : 0
  -v, --verbose               enable verbose status messages; default : disable
  -i, --interval=S            print information every S secs

```

TO-BE
```
applyinfo: display CUBRID HA Apply information.
usage: cubrid applyinfo [OPTION] database-name
valid options:
  -r, --remote-host-name      remote host name; display remote node's active log information
  -a, --applied-info          display applied information; the -L option is required
  -L, --copied-log-path=PATH  path of copied log volumes; display copied log information
  -p, --page=ID               page id; the -L option is required; default : 0
  -v, --verbose               enable verbose status messages; default : disable
  -i, --interval=S            print information every S secs

```

**Implementation**

N/A
**Remarks**

N/A
