### PR TITLE
[CBRD-24244] Add more ini_getstr NULL check in broker_config_read_internal ()

### DIFF
--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -614,23 +614,23 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      strncpy_bufsize (br_info[num_brs].cgw_link_server,
-		       ini_getstr (ini, sec_name, "CGW_LINK_SERVER", DEFAULT_EMPTY_STRING, &lineno));
+      INI_GETSTR_CHK (s, ini, sec_name, "CGW_LINK_SERVER", DEFAULT_EMPTY_STRING, &lineno);
+      strcpy (br_info[num_brs].cgw_link_server, s);
 
-      strncpy_bufsize (br_info[num_brs].cgw_link_server_ip,
-		       ini_getstr (ini, sec_name, "CGW_LINK_SERVER_IP", DEFAULT_EMPTY_STRING, &lineno));
+      INI_GETSTR_CHK (s, ini, sec_name, "CGW_LINK_SERVER_IP", DEFAULT_EMPTY_STRING, &lineno);
+      strcpy (br_info[num_brs].cgw_link_server_ip, s);
 
-      strncpy_bufsize (br_info[num_brs].cgw_link_server_port,
-		       ini_getstr (ini, sec_name, "CGW_LINK_SERVER_PORT", DEFAULT_EMPTY_STRING, &lineno));
+      INI_GETSTR_CHK (s, ini, sec_name, "CGW_LINK_SERVER_PORT", DEFAULT_EMPTY_STRING, &lineno);
+      strcpy (br_info[num_brs].cgw_link_server_port, s);
 
-      strncpy_bufsize (br_info[num_brs].cgw_link_odbc_driver_name,
-		       ini_getstr (ini, sec_name, "CGW_LINK_ODBC_DRIVER_NAME", DEFAULT_EMPTY_STRING, &lineno));
+      INI_GETSTR_CHK (s, ini, sec_name, "CGW_LINK_ODBC_DRIVER_NAME", DEFAULT_EMPTY_STRING, &lineno);
+      strcpy (br_info[num_brs].cgw_link_odbc_driver_name, s);
 
-      strncpy_bufsize (br_info[num_brs].cgw_link_connect_url_property,
-		       ini_getstr (ini, sec_name, "CGW_LINK_CONNECT_URL_PROPERTY", DEFAULT_EMPTY_STRING, &lineno));
+      INI_GETSTR_CHK (s, ini, sec_name, "CGW_LINK_CONNECT_URL_PROPERTY", DEFAULT_EMPTY_STRING, &lineno);
+      strcpy (br_info[num_brs].cgw_link_connect_url_property, s);
 
-      br_info[num_brs].appl_server =
-	get_conf_value (ini_getstr (ini, sec_name, "APPL_SERVER", DEFAULT_APPL_SERVER, &lineno), tbl_appl_server);
+      INI_GETSTR_CHK (s, ini, sec_name, "APPL_SERVER", DEFAULT_APPL_SERVER, &lineno);
+      br_info[num_brs].appl_server = get_conf_value (s, tbl_appl_server);
       if (br_info[num_brs].appl_server < 0)
 	{
 	  errcode = PARAM_BAD_VALUE;
@@ -1418,7 +1418,6 @@ broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_bro
   admin_flag = 1;
   admin_err_msg = NULL;
 #endif /* !_UC_ADMIN_SO_ */
-
 
   if (is_first_br_conf_read)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24244

**Purpose**
- add more null return value check of ini_getstr () in broker_config_read internal ()
- This was not reflected in #3430 due to  merge conflict.

**Implementation**

**Remarks**