### PR TITLE
[CBRD-24174] Refactor the printing summary information

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -10652,8 +10652,6 @@ flashback_get_and_show_summary (dynamic_array * class_list, const char *user, ti
 	    }
 
 	  /* get summary info */
-	  ptr = or_unpack_int (ptr, &num_summary);
-
 	  error_code = flashback_unpack_and_print_summary (&ptr, summary, class_list, *oid_list);
 	}
 

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -10654,7 +10654,7 @@ flashback_get_and_show_summary (dynamic_array * class_list, const char *user, ti
 	  /* get summary info */
 	  ptr = or_unpack_int (ptr, &num_summary);
 
-	  error_code = flashback_unpack_and_print_summary (&ptr, summary, num_summary, class_list, *oid_list);
+	  error_code = flashback_unpack_and_print_summary (&ptr, summary, class_list, *oid_list);
 	}
 
       free_and_init (area);

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10711,7 +10711,7 @@ scdc_end_session (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int 
  * TODO : move to flashback_sr.c
  */
 static int
-flashback_verify_time (THREAD_ENTRY * thread_p, time_t start_time, time_t end_time, LOG_LSA * start_lsa,
+flashback_verify_time (THREAD_ENTRY * thread_p, time_t * start_time, time_t * end_time, LOG_LSA * start_lsa,
 		       LOG_LSA * end_lsa)
 {
   int error_code = NO_ERROR;
@@ -10719,14 +10719,14 @@ flashback_verify_time (THREAD_ENTRY * thread_p, time_t start_time, time_t end_ti
 
 
   /* 1. Check start_time */
-  if (start_time < log_Gl.hdr.db_creation)
+  if (*start_time < log_Gl.hdr.db_creation)
     {
       /* TODO : er_set() */
       return ER_FLASHBACK_INVALID_TIME;
     }
   else
     {
-      ret_time = start_time;
+      ret_time = *start_time;
 
       error_code = cdc_find_lsa (thread_p, &ret_time, start_lsa);
       if (error_code == NO_ERROR || error_code == ER_CDC_ADJUSTED_LSA)
@@ -10734,7 +10734,7 @@ flashback_verify_time (THREAD_ENTRY * thread_p, time_t start_time, time_t end_ti
 	  /* find log record at the time
 	   * ret_time : time of the commit record or dummy record that is found to be greater than or equal to the start_time at first */
 
-	  if (ret_time >= end_time)
+	  if (ret_time >= *end_time)
 	    {
 	      /* out of range : start_time (ret_time) can not be greater than end_time */
 	      /* TODO : er_set() */
@@ -10748,10 +10748,11 @@ flashback_verify_time (THREAD_ENTRY * thread_p, time_t start_time, time_t end_ti
 	}
     }
 
+  *start_time = ret_time;
+
   /* 2. If start_time is valid, then get end_lsa */
 
-  ret_time = end_time;
-  error_code = cdc_find_lsa (thread_p, &ret_time, end_lsa);
+  error_code = cdc_find_lsa (thread_p, end_time, end_lsa);
 
   if (!(error_code == NO_ERROR || error_code == ER_CDC_ADJUSTED_LSA))
     {
@@ -10772,7 +10773,7 @@ flashback_verify_time (THREAD_ENTRY * thread_p, time_t start_time, time_t end_ti
  * TODO : move to flashback_sr.c
  */
 static char *
-flashback_pack_summary_entry (char *ptr, FLASHBACK_SUMMARY_CONTEXT context)
+flashback_pack_summary_entry (char *ptr, FLASHBACK_SUMMARY_CONTEXT context, int *num_summary)
 {
   FLASHBACK_SUMMARY_ENTRY entry;
 
@@ -10780,6 +10781,8 @@ flashback_pack_summary_entry (char *ptr, FLASHBACK_SUMMARY_CONTEXT context)
   for (auto iter : context.summary_list)
     {
       entry = iter.second;
+      if (entry.num_insert + entry.num_update + entry.num_delete > 0)
+      {
       ptr = or_pack_int (ptr, entry.trid);
       ptr = or_pack_string (ptr, entry.user);
       ptr = or_pack_int64 (ptr, entry.start_time);
@@ -10795,6 +10798,9 @@ flashback_pack_summary_entry (char *ptr, FLASHBACK_SUMMARY_CONTEXT context)
         {
           ptr = or_pack_oid (ptr, &item);
         }
+
+      (*num_summary)++;
+      }
     }
 // *INDENT-ON*
 
@@ -10813,12 +10819,21 @@ sflashback_get_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *request
   char *ptr;
   char *start_ptr;
 
+  char *num_ptr;		//pointer in which 'number of summary' is located
+  int tmp_num;
+
   LC_FIND_CLASSNAME status;
 
   FLASHBACK_SUMMARY_CONTEXT context = { LSA_INITIALIZER, LSA_INITIALIZER, NULL, 0, 0, };
 
   time_t start_time = 0;
   time_t end_time = 0;
+
+  char *classname = NULL;
+
+  /* *INDENT-OFF* */
+  std::queue <OID> classoid_queue; //queue to return class OID in the order of the class names received from the user
+  /* *INDENT-ON* */
 
   error_code = flashback_initialize (thread_p);
   if (error_code != NO_ERROR)
@@ -10832,7 +10847,6 @@ sflashback_get_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *request
 
   for (int i = 0; i < context.num_class; i++)
     {
-      char *classname = NULL;
       OID classoid = OID_INITIALIZER;
 
       ptr = or_unpack_string_nocopy (ptr, &classname);
@@ -10845,13 +10859,14 @@ sflashback_get_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *request
 	  goto error;
 	}
 
+      classoid_queue.push (classoid);
       context.classoid_set.emplace (classoid);
     }
   ptr = or_unpack_string_nocopy (ptr, &context.user);
   ptr = or_unpack_int64 (ptr, &start_time);
   ptr = or_unpack_int64 (ptr, &end_time);
 
-  error_code = flashback_verify_time (thread_p, start_time, end_time, &context.start_lsa, &context.end_lsa);
+  error_code = flashback_verify_time (thread_p, &start_time, &end_time, &context.start_lsa, &context.end_lsa);
   if (error_code != NO_ERROR)
     {
       goto error;
@@ -10868,11 +10883,11 @@ sflashback_get_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *request
       goto error;
     }
 
-  /* area : | class oid list | num summary | summary entry list |
+  /* area : | class oid list | summary start time | summary end time | num summary | summary entry list |
    * summary entry : | trid | user | start/end time | num insert/update/delete | num class | class oid list |
    * OR_OID_SIZE * context.num_class means maximum class oid list size per summary entry */
 
-  area_size = OR_OID_SIZE * context.num_class + OR_INT_SIZE
+  area_size = OR_OID_SIZE * context.num_class + OR_INT64_SIZE + OR_INT64_SIZE + OR_INT_SIZE
     + (OR_SUMMARY_ENTRY_SIZE_WITHOUT_CLASS + OR_OID_SIZE * context.num_class) * context.num_summary;
 
   area = (char *) db_private_alloc (thread_p, area_size);
@@ -10890,15 +10905,25 @@ sflashback_get_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *request
   /* area packing : OID list | num summary | summary info list */
   ptr = area;
 
-// *INDENT-OFF*
-  for (auto iter : context.classoid_set)
+  for (int i = 0; i < context.num_class; i++)
     {
-      ptr = or_pack_oid (ptr, &iter);
+      OID tmp_oid = classoid_queue.front ();
+      ptr = or_pack_oid (ptr, &tmp_oid);
+      classoid_queue.pop ();
     }
-// *INDENT-ON*
+
+  ptr = or_pack_int64 (ptr, start_time);
+  ptr = or_pack_int64 (ptr, end_time);
+
+  num_ptr = ptr;
 
   ptr = or_pack_int (ptr, context.num_summary);
-  ptr = flashback_pack_summary_entry (ptr, context);
+  ptr = flashback_pack_summary_entry (ptr, context, &tmp_num);
+
+  if (context.num_summary != tmp_num)
+    {
+      or_pack_int (num_ptr, tmp_num);
+    }
 
   error_code =
     css_send_reply_and_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply), area,

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10820,7 +10820,7 @@ sflashback_get_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *request
   char *start_ptr;
 
   char *num_ptr;		//pointer in which 'number of summary' is located
-  int tmp_num;
+  int tmp_num = 0;
 
   LC_FIND_CLASSNAME status;
 
@@ -10830,10 +10830,6 @@ sflashback_get_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *request
   time_t end_time = 0;
 
   char *classname = NULL;
-
-  /* *INDENT-OFF* */
-  std::queue <OID> classoid_queue; //queue to return class OID in the order of the class names received from the user
-  /* *INDENT-ON* */
 
   error_code = flashback_initialize (thread_p);
   if (error_code != NO_ERROR)
@@ -10859,9 +10855,9 @@ sflashback_get_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *request
 	  goto error;
 	}
 
-      classoid_queue.push (classoid);
-      context.classoid_set.emplace (classoid);
+      context.classoids.emplace_back (classoid);
     }
+
   ptr = or_unpack_string_nocopy (ptr, &context.user);
   ptr = or_unpack_int64 (ptr, &start_time);
   ptr = or_unpack_int64 (ptr, &end_time);
@@ -10905,12 +10901,12 @@ sflashback_get_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *request
   /* area packing : OID list | num summary | summary info list */
   ptr = area;
 
-  for (int i = 0; i < context.num_class; i++)
+  // *INDENT-OFF*
+  for (auto iter : context.classoids)
     {
-      OID tmp_oid = classoid_queue.front ();
-      ptr = or_pack_oid (ptr, &tmp_oid);
-      classoid_queue.pop ();
+      ptr = or_pack_oid (ptr, &iter);
     }
+  // *INDENT-ON*
 
   ptr = or_pack_int64 (ptr, start_time);
   ptr = or_pack_int64 (ptr, end_time);

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -5092,16 +5092,33 @@ flashback (UTIL_FUNCTION_ARG * arg)
       goto error_exit;
     }
 
-  printf ("Enter transaction id : ");
-  scanf ("%d", &trid);
-
-
-  FLASHBACK_FIND_SUMMARY_ENTRY (trid, summary_info, summary_entry);
-  if (summary_entry == NULL)
+  if (summary_info.empty ())
     {
-      /* add message that can not find transaction id */
       goto error_exit;
     }
+
+  while (summary_entry == NULL)
+    {
+      printf ("Enter transaction id ( press -1 to quit) : ");
+
+      scanf ("%d", &trid);
+      if (trid == -1)
+	{
+	  goto error_exit;
+	}
+
+      FLASHBACK_FIND_SUMMARY_ENTRY (trid, summary_info, summary_entry);
+      if (summary_entry == NULL)
+	{
+	  /* add message that can not find transaction id */
+	}
+
+      printf ("\n");
+    }
+
+  start_lsa = summary_entry->start_lsa;
+  end_lsa = summary_entry->end_lsa;
+  user = summary_entry->user;
 
   do
     {

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -5099,7 +5099,7 @@ flashback (UTIL_FUNCTION_ARG * arg)
 
   while (summary_entry == NULL)
     {
-      printf ("Enter transaction id ( press -1 to quit) : ");
+      printf ("Enter transaction id (press -1 to quit): ");
 
       scanf ("%d", &trid);
       if (trid == -1)

--- a/src/transaction/flashback.c
+++ b/src/transaction/flashback.c
@@ -529,10 +529,12 @@ flashback_make_summary_list (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEXT 
 		{
 		  memcpy (&classoid, supplement_data, sizeof (OID));
 
-		  if (context->classoid_set.find (classoid) == context->classoid_set.end ())
+                  // *INDENT-OFF*
+		  if (std::find (context->classoids.begin(), context->classoids.end(), classoid) == context->classoids.end())
 		    {
 		      break;
 		    }
+                  // *INDENT-ON*
 
 		  flashback_fill_dml_summary (summary_entry, classoid, rec_type);
 

--- a/src/transaction/flashback.h
+++ b/src/transaction/flashback.h
@@ -101,7 +101,7 @@ typedef struct flashback_summary_context
   int num_summary;
   int num_class;
   // *INDENT-OFF*
-  std::unordered_set<OID> classoid_set;
+  std::vector<OID> classoids;
   std::map <TRANID, FLASHBACK_SUMMARY_ENTRY> summary_list;
   // *INDENT-ON*
 } FLASHBACK_SUMMARY_CONTEXT;

--- a/src/transaction/flashback_cl.c
+++ b/src/transaction/flashback_cl.c
@@ -235,12 +235,12 @@ flashback_unpack_and_print_summary (char **summary_buffer, FLASHBACK_SUMMARY_INF
 	      da_get (classname_list, idx, classname);
 	      if (j == 0)
 		{
-		  printf ("%s\n", classname);
+		  printf ("%-s\n", classname);
 		  line_cnt++;
 		}
 	      else
 		{
-		  printf ("%134s\n", classname);
+		  printf ("%130s%-s\n", "", classname);
 		  line_cnt++;
 		}
 	    }

--- a/src/transaction/flashback_cl.c
+++ b/src/transaction/flashback_cl.c
@@ -164,8 +164,8 @@ flashback_unpack_and_print_summary (char **summary_buffer, FLASHBACK_SUMMARY_INF
   strftime (etime_buf, 20, "%d-%m-%Y:%H:%M:%S", localtime (&summary_end_time));
 
   printf ("Flashback Summary\n");
-  printf ("Number of Transaction : %43d\n", num_summary);
-  printf ("Start date - End date : %20s - %20s\n", stime_buf, etime_buf);
+  printf ("Number of Transaction: %43d\n", num_summary);
+  printf ("Start date - End date: %20s - %20s\n", stime_buf, etime_buf);
 
   line_cnt = line_cnt + 3;
 

--- a/src/transaction/flashback_cl.c
+++ b/src/transaction/flashback_cl.c
@@ -27,9 +27,11 @@
 #include <stdio.h>
 #if defined(WINDOWS)
 #include <windows.h>
+#include <conio.h>
 #else /* WINDOWS */
 #include <sys/ioctl.h>
 #include <unistd.h>
+#include <termios.h>
 #endif /* LINUX */
 
 #include "flashback_cl.h"
@@ -45,7 +47,36 @@ flashback_util_get_winsize ()
 
   return csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
 }
+
+static char
+flashback_util_get_char ()
+{
+  int c;
+
+  c = getche ();
+
+  return c;
+}
+
 #else
+static char
+flashback_util_get_char ()
+{
+  int c;
+  static struct termios oldt, newt;
+
+  tcgetattr (STDIN_FILENO, &oldt);
+  newt = oldt;
+
+  newt.c_lflag &= ~(ICANON);
+  tcsetattr (STDIN_FILENO, TCSANOW, &newt);
+
+  c = getchar ();
+  tcsetattr (STDIN_FILENO, TCSANOW, &oldt);
+
+  return c;
+}
+
 static int
 flashback_util_get_winsize ()
 {
@@ -94,9 +125,13 @@ flashback_find_class_index (OID * oidlist, int list_size, OID classoid)
  */
 
 int
-flashback_unpack_and_print_summary (char **summary_buffer, FLASHBACK_SUMMARY_INFO_MAP * summary, int num_summary,
+flashback_unpack_and_print_summary (char **summary_buffer, FLASHBACK_SUMMARY_INFO_MAP * summary,
 				    dynamic_array * classname_list, OID * oidlist)
 {
+  time_t summary_start_time = 0;
+  time_t summary_end_time = 0;
+  int num_summary = 0;
+
   TRANID trid;
   char *user = NULL;
   time_t start_time, end_time;
@@ -110,9 +145,32 @@ flashback_unpack_and_print_summary (char **summary_buffer, FLASHBACK_SUMMARY_INF
   const int max_window_size = flashback_util_get_winsize ();
   int line_cnt = 0;
 
-  printf
-    ("Transaction id\t\tUser name\t\tStart time\t\tEnd time\t\tNum_insert\t\tNum_update\t\tNum_delete\t\tTables\n");
+  char stime_buf[20];
+  char etime_buf[20];
 
+  tmp_ptr = or_unpack_int64 (tmp_ptr, &summary_start_time);
+  tmp_ptr = or_unpack_int64 (tmp_ptr, &summary_end_time);
+
+  tmp_ptr = or_unpack_int (tmp_ptr, &num_summary);
+  if (num_summary == 0)
+    {
+      printf ("There is nothing to flashback\n");
+
+      return NO_ERROR;
+    }
+
+
+  strftime (stime_buf, 20, "%d-%m-%Y:%H:%M:%S", localtime (&summary_start_time));
+  strftime (etime_buf, 20, "%d-%m-%Y:%H:%M:%S", localtime (&summary_end_time));
+
+  printf ("Flashback Summary\n");
+  printf ("Number of Transaction : %43d\n", num_summary);
+  printf ("Start date - End date : %20s - %20s\n", stime_buf, etime_buf);
+
+  line_cnt = line_cnt + 3;
+
+  printf
+    ("Transaction id  User name                         Start time            End time              Num_insert  Num_update  Num_delete  Table\n");
   line_cnt++;
 
   for (int i = 0; i < num_summary; i++)
@@ -133,19 +191,30 @@ flashback_unpack_and_print_summary (char **summary_buffer, FLASHBACK_SUMMARY_INF
       info.trid = trid;
       info.start_lsa = start_lsa;
       info.end_lsa = end_lsa;
+      strcpy (info.user, user);
 
       summary->emplace (trid, info);
 
       if (!stop_print)
 	{
-	  char stime_buf[20];
-	  char etime_buf[20];
+	  if (start_time != 0)
+	    {
+	      strftime (stime_buf, 20, "%d-%m-%Y:%H:%M:%S", localtime (&start_time));
+	    }
 
-	  strftime (stime_buf, 20, "%d-%m-%Y:%H:%M:%S", localtime (&start_time));
-	  strftime (etime_buf, 20, "%d-%m-%Y:%H:%M:%S", localtime (&end_time));
+	  if (end_time != 0)
+	    {
+	      strftime (etime_buf, 20, "%d-%m-%Y:%H:%M:%S", localtime (&end_time));
+	    }
 
-	  printf ("\t%d\t%s\t%s\t%s\t%d\t%d\t%d\t\t", trid, user, stime_buf, etime_buf, num_insert, num_update,
-		  num_delete);
+	  printf ("%14d  ", trid);
+	  printf ("%-32s  ", user);
+	  printf ("%-20s  ", start_time == 0 ? "-" : stime_buf);
+	  printf ("%-20s  ", end_time == 0 ? "-" : etime_buf);
+
+	  printf ("%10d  ", num_insert);
+	  printf ("%10d  ", num_update);
+	  printf ("%10d  ", num_delete);
 	}
 
       for (int j = 0; j < num_table; j++)
@@ -164,21 +233,25 @@ flashback_unpack_and_print_summary (char **summary_buffer, FLASHBACK_SUMMARY_INF
 		}
 
 	      da_get (classname_list, idx, classname);
-	      printf ("%s ", classname);
+	      if (j == 0)
+		{
+		  printf ("%s\n", classname);
+		  line_cnt++;
+		}
+	      else
+		{
+		  printf ("%134s\n", classname);
+		  line_cnt++;
+		}
 	    }
-	}
-
-      if (!stop_print)
-	{
-	  printf ("\n");
-	  line_cnt++;
 	}
 
       if (line_cnt >= max_window_size)
 	{
 	  char c;
 	  printf ("press 'q' to quit or press anything to continue");
-	  c = getchar ();
+
+	  c = flashback_util_get_char ();
 	  if (c == 'q')
 	    {
 	      stop_print = true;
@@ -187,7 +260,7 @@ flashback_unpack_and_print_summary (char **summary_buffer, FLASHBACK_SUMMARY_INF
 	  line_cnt = 0;
 
 	  /* Remove the message above, because above message is no more required */
-	  printf ("\033[A\33[2K\r");
+	  printf ("\33[2K\r");
 	}
     }
 

--- a/src/transaction/flashback_cl.h
+++ b/src/transaction/flashback_cl.h
@@ -49,6 +49,7 @@
 typedef struct flashback_summary_info
 {
   TRANID trid;
+  char user[DB_MAX_USER_LENGTH + 1];
   LOG_LSA start_lsa;
   LOG_LSA end_lsa;
 } FLASHBACK_SUMMARY_INFO;
@@ -58,6 +59,6 @@ typedef std::unordered_map<TRANID, FLASHBACK_SUMMARY_INFO> FLASHBACK_SUMMARY_INF
 // *INDENT-ON*
 
 extern int flashback_unpack_and_print_summary (char **summary_buffer, FLASHBACK_SUMMARY_INFO_MAP * summary,
-					       int num_summary, dynamic_array * classname_list, OID * oidlist);
+					       dynamic_array * classname_list, OID * oidlist);
 
 #endif


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24174

Purpose

the output format is refined more neatly, and the following items are added

- add summary start-time ~ end-time
- add total transaction number
- fix the order of classoid
- add the user info when printing summary
- add retry option when user enter the wrong trained
- Only print the summary of log items that have DML
- fix 'press 'q' to quit or press anything to quit' to get character without pressing enter