### PR TITLE
[CBRD-24251] Reuse ODBC connection in CAS gateway

### DIFF
--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ $ LOADDB
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 Das aktive Protokollvolumen (%1$s) ist zu normal, um es neu zu erstellen. Wenn Sie das aktive Protokoll entfernen, kann dies zu einem unerwarteten und irreversiblen Problem führen.

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 The active log volume (%1$s) is too sane to recreate. If you remove the active log, it could cause an unexpected and irreversible problem.

--- a/msg/en_US/cubrid.msg
+++ b/msg/en_US/cubrid.msg
@@ -1404,7 +1404,7 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 The active log volume (%1$s) is too sane to recreate. If you remove the active log, it could cause an unexpected and irreversible problem.

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ Verifique la ruta del archivo de claves (_keys) y asegúrese de que incluya la c
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 El volumen de registro activo (%1$s) está demasiado sano para volver a crearlo. Si elimina el registro activo, podría causar un problema inesperado e irreversible.

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ Vérifiez le chemin du fichier de clé (_keys) et assurez-vous qu'il inclut la c
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 Le volume de journal actif (%1$s) est trop sain pour être recréé. Si vous supprimez le journal actif, cela peut provoquer un problème inattendu et irréversible.

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ Controllare il percorso del file della chiave (_keys) e assicurarsi che includa 
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 Il volume del registro attivo (%1$s) è troppo sano per essere ricreato. Se rimuovi il registro attivo, potrebbe causare un problema imprevisto e irreversibile.

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ $ LOADDB
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 アクティブなログボリューム（%1$s）が正常すぎて、再作成できません。 アクティブなログを削除すると、予期しない不可逆的な問題が発生する可能性があります。

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 The active log volume (%1$s) is too sane to recreate. If you remove the active log, it could cause an unexpected and irreversible problem.

--- a/msg/ko_KR.euckr/cubrid.msg
+++ b/msg/ko_KR.euckr/cubrid.msg
@@ -1403,7 +1403,7 @@ $ LOADDB
 
 1328 잘못된 Descriptor Handle 입니다.
 1329 지원하지 않는 DBMS 입니다.
-1330 Error reserved for dblink development.
+1330 환경 핸들을 할당할 수 없습니다.
 1331 Error reserved for dblink development.
 
 1332 액티브 로그 볼륨 (%1$s)에서 문제를 발견할 수 없어 재생성할 수 없습니다. 액티브 로그 볼륨을 제거할 경우에 예측할 수 없는 문제가 발생할 수 있으며, 되돌릴 수 없습니다.

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ $ LOADDB
 
 1328 잘못된 Descriptor Handle 입니다.
 1329 지원하지 않는 DBMS 입니다.
-1330 Error reserved for dblink development.
+1330 환경 핸들을 할당할 수 없습니다.
 1331 Error reserved for dblink development.
 
 1332 액티브 로그 볼륨 (%1$s)에서 문제를 발견할 수 없어 재생성할 수 없습니다. 액티브 로그 볼륨을 제거할 경우에 예측할 수 없는 문제가 발생할 수 있으며, 되돌릴 수 없습니다.

--- a/msg/ro_RO.utf8/cubrid.msg
+++ b/msg/ro_RO.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ Verificați calea fișierului cheie (_keys) și asigurați-vă că acesta includ
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 Volumul de jurnal activ (%1$s) este prea corect pentru a fi recreat. Dacă eliminați jurnalul activ, ar putea cauza o problemă neașteptată și ireversibilă.

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ Anahtar dosyasının (_keys) yolunu kontrol edin ve uygun anahtarı içerdiğind
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 Etkin günlük hacmi (%1$s) yeniden oluşturulamayacak kadar makul. Etkin günlüğü kaldırırsanız, beklenmeyen ve geri dönüşü olmayan bir soruna neden olabilir.

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1403,7 +1403,7 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 The active log volume (%1$s) is too sane to recreate. If you remove the active log, it could cause an unexpected and irreversible problem.

--- a/msg/zh_CN.utf8/cubrid.msg
+++ b/msg/zh_CN.utf8/cubrid.msg
@@ -1404,7 +1404,7 @@ $ LOADDB
 
 1328 Invalid Descriptor handle.
 1329 Not supported dbms.
-1330 Error reserved for dblink development.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 活动日志卷 (%1$s) 过于健全，无法重新创建。 如果删除活动日志，可能会导致意外且不可逆转的问题。

--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -1696,7 +1696,7 @@
 
 #define ER_CGW_INVALID_DESC_HANDLE                  -1328
 #define ER_CGW_NOT_SUPPORTED_DBMS                   -1329
-#define ER_DBLINK_DEV_RESERVED_ERROR30              -1330
+#define ER_CGW_NOT_ALLOCATE_ENV_HANDLE              -1330
 #define ER_DBLINK_DEV_RESERVED_ERROR31              -1331
 
 #define ER_LOG_TOO_SANE_TO_RECREATE                 -1332

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1743,7 +1743,7 @@ cas_free (bool from_sighandler)
   else
     {
 #if defined(CAS_FOR_CGW)
-      cgw_destroy ();
+      cgw_cleanup ();
 #else
       ux_database_shutdown ();
 #endif /* CAS_FOR_CGW */

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -873,7 +873,7 @@ cas_main (void)
   char tmp_name[SRV_CON_DBNAME_SIZE] = { 0, };
   char tmp_user[SRV_CON_DBUSER_SIZE] = { 0, };
   char tmp_passwd[SRV_CON_DBPASSWD_SIZE] = { 0, };
-  SUPPORTED_DBMS_TYPE dbms_type = NOT_SUPPORTED_DBMS;;
+  SUPPORTED_DBMS_TYPE dbms_type = NOT_SUPPORTED_DBMS;
 #endif
 
 #if defined(CAS_FOR_ORACLE)
@@ -945,7 +945,10 @@ cas_main (void)
   logddl_init ();
 
 #if defined(CAS_FOR_CGW)
-  cgw_init_odbc_handle ();
+  if (cgw_init () < 0)
+    {
+      return -1;
+    }
 #endif /* CAS_FOR_CGW */
 
 #if defined(WINDOWS)
@@ -1292,7 +1295,7 @@ cas_main (void)
 		goto finish_cas;
 	      }
 
-	    err_code = cgw_database_connect (dbms_type, odbc_connect_url);
+	    err_code = cgw_database_connect (dbms_type, odbc_connect_url, db_name, db_user, db_passwd);
 #endif /* !CAS_FOR_CGW */
 
 	    if (err_code < 0)
@@ -1703,9 +1706,6 @@ cas_sig_handler (int signo)
   cas_free (true);
   as_info->pid = 0;
   as_info->uts_status = UTS_STATUS_RESTART;
-#if defined (CAS_FOR_CGW)
-  cgw_database_disconnect ();
-#endif
   _exit (0);
 }
 
@@ -1718,11 +1718,6 @@ cas_final (void)
   as_info->pid = 0;
   as_info->uts_status = UTS_STATUS_RESTART;
   er_final (ER_ALL_FINAL);
-
-#if defined (CAS_FOR_CGW)
-  cgw_database_disconnect ();
-#endif
-
   exit (0);
 }
 
@@ -1747,7 +1742,11 @@ cas_free (bool from_sighandler)
     }
   else
     {
+#if defined(CAS_FOR_CGW)
+      cgw_destroy ();
+#else
       ux_database_shutdown ();
+#endif /* CAS_FOR_CGW */
     }
 
   if (as_info->cur_statement_pooling && !from_sighandler)

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -137,7 +137,7 @@ cgw_database_connect (SUPPORTED_DBMS_TYPE dbms_type, const char *connect_url, ch
   SQLCHAR out_connect_str[CGW_LINK_URL_MAX_LEN + 1];
   SQLSMALLINT out_connect_str_len;
   char connect_str[CGW_LINK_URL_MAX_LEN + 1] = { 0, };
-  bool is_connet = false;
+  bool is_conneted = false;
 
   if (cgw_is_database_connected () == CONNECTED_STATE)
     {
@@ -172,7 +172,7 @@ cgw_database_connect (SUPPORTED_DBMS_TYPE dbms_type, const char *connect_url, ch
 						out_connect_str,
 						(SQLSMALLINT) sizeof (out_connect_str),
 						&out_connect_str_len, SQL_DRIVER_NOPROMPT));
-      is_connet = true;
+      is_conneted = true;
     }
   else
     {
@@ -203,7 +203,7 @@ cgw_database_connect (SUPPORTED_DBMS_TYPE dbms_type, const char *connect_url, ch
 ODBC_ERROR:
   if (local_odbc_handle->hdbc)
     {
-      if (is_connet)
+      if (is_conneted)
 	{
 	  SQLDisconnect (local_odbc_handle->hdbc);
 	}

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -107,13 +107,11 @@ ODBC_ERROR:
   return ER_FAILED;
 }
 
-int
-cgw_destroy ()
+void
+cgw_cleanup ()
 {
   cgw_cleanup_handle (local_odbc_handle);
-  return NO_ERROR;
 }
-
 
 int
 cgw_get_handle (T_CGW_HANDLE ** cgw_handle)

--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -136,7 +136,7 @@ union odbc_bind_info
 extern void test_log (char *fmt, ...);
 
 extern int cgw_init ();
-extern int cgw_destroy ();
+extern void cgw_cleanup ();
 extern int cgw_col_bindings (SQLHSTMT hstmt, SQLSMALLINT num_cols, T_COL_BINDER ** col_binding);
 extern void cgw_cleanup_binder (T_COL_BINDER * first_col_binding);
 

--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -135,22 +135,24 @@ union odbc_bind_info
 
 extern void test_log (char *fmt, ...);
 
-
+extern int cgw_init ();
+extern int cgw_destroy ();
 extern int cgw_col_bindings (SQLHSTMT hstmt, SQLSMALLINT num_cols, T_COL_BINDER ** col_binding);
 extern void cgw_cleanup_binder (T_COL_BINDER * first_col_binding);
 
 extern int cgw_init_odbc_handle (void);
-extern int cgw_get_handle (T_CGW_HANDLE ** cgw_handle, bool is_connected);
+extern int cgw_get_handle (T_CGW_HANDLE ** cgw_handle);
 extern int cgw_get_stmt_handle (SQLHDBC hdbc, SQLHSTMT * stmt);
 extern int cgw_get_driver_info (SQLHDBC hdbc, SQLUSMALLINT info_type, void *driver_info, SQLSMALLINT size);
 
 // db connection functions
-extern int cgw_database_connect (SUPPORTED_DBMS_TYPE dbms_type, const char *connect_url);
+extern int cgw_database_connect (SUPPORTED_DBMS_TYPE dbms_type, const char *connect_url, char *db_name, char *db_user,
+				 char *db_passwd);
 extern void cgw_database_disconnect (void);
 extern int cgw_is_database_connected (void);
 
 // Prepare funtions
-extern int cgw_sql_prepare (SQLHSTMT hstmt, SQLCHAR * sql_stmt);
+extern int cgw_sql_prepare (SQLCHAR * sql_stmt);
 extern int cgw_get_num_cols (SQLHSTMT hstmt, SQLSMALLINT * num_cols);
 extern int cgw_get_col_info (SQLHSTMT hstmt, T_NET_BUF * net_buf, int col_num, T_ODBC_COL_INFO * col_info);
 
@@ -158,8 +160,7 @@ extern int cgw_get_col_info (SQLHSTMT hstmt, T_NET_BUF * net_buf, int col_num, T
 extern int cgw_set_commit_mode (SQLHDBC hdbc, bool auto_commit);
 extern int cgw_execute (T_SRV_HANDLE * srv_handle);
 extern int cgw_set_execute_info (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_buf, int stmt_type);
-extern int cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv, ODBC_BIND_INFO ** ret_val,
-				T_NET_BUF * net_buf);
+extern int cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv, ODBC_BIND_INFO ** ret_val);
 
 // Resultset funtions
 extern int cgw_cursor_close (SQLHSTMT hstmt);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -758,11 +758,8 @@ ux_set_default_setting ()
 void
 ux_database_shutdown ()
 {
-#if defined(CAS_FOR_CGW)
-  cgw_database_disconnect ();
-#else
+#if !defined(CAS_FOR_CGW)
   db_shutdown ();
-#endif /* CAS_FOR_CGW */
   cas_log_debug (ARG_FILE_LINE, "ux_database_shutdown: db_shutdown()");
 #ifndef LIBCAS_FOR_JSP
   as_info->database_name[0] = '\0';
@@ -776,6 +773,7 @@ ux_database_shutdown ()
   memset (database_passwd, 0, sizeof (database_passwd));
   cas_default_isolation_level = 0;
   cas_default_lock_timeout = -1;
+#endif /* CAS_FOR_CGW */
 }
 
 #if !defined(CAS_FOR_CGW)
@@ -1064,7 +1062,7 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
       goto prepare_error;
     }
 
-  err_code = cgw_get_handle (&srv_handle->cgw_handle, true);
+  err_code = cgw_get_handle (&srv_handle->cgw_handle);
   if (err_code < 0)
     {
       err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -1110,27 +1108,7 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
       goto prepare_error;
     }
 
-  if (srv_handle->cgw_handle->hstmt == NULL)
-    {
-      err_code = cgw_get_stmt_handle (srv_handle->cgw_handle->hdbc, &srv_handle->cgw_handle->hstmt);
-      if (err_code < 0)
-	{
-	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
-	  goto prepare_error;
-	}
-
-      err_code =
-	cgw_set_stmt_attr (srv_handle->cgw_handle->hstmt, SQL_ATTR_CURSOR_TYPE, (SQLPOINTER) SQL_CURSOR_STATIC,
-			   SQL_IS_INTEGER);
-      if (err_code < 0)
-	{
-	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
-	  goto prepare_error;
-	}
-    }
-
-  err_code = cgw_sql_prepare (srv_handle->cgw_handle->hstmt, (SQLCHAR *) sql_stmt);
-
+  err_code = cgw_sql_prepare ((SQLCHAR *) sql_stmt);
   if (err_code < 0)
     {
       err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -1273,7 +1251,7 @@ ux_end_tran (int tran_type, bool reset_con_status)
 
 #if defined(CAS_FOR_CGW)
   T_CGW_HANDLE *cgw_handle = NULL;
-  cgw_get_handle (&cgw_handle, false);
+  cgw_get_handle (&cgw_handle);
   if (cgw_handle)
     {
       cgw_endtran (cgw_handle->hdbc, tran_type);
@@ -1353,7 +1331,7 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
 
   if (srv_handle->is_prepared == FALSE)
     {
-      err_code = cgw_sql_prepare (srv_handle->cgw_handle->hstmt, (SQLCHAR *) srv_handle->sql_stmt);
+      err_code = cgw_sql_prepare ((SQLCHAR *) srv_handle->sql_stmt);
 
       if (err_code < 0)
 	{
@@ -1366,7 +1344,7 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
 
   if (num_bind > 0)
     {
-      err_code = cgw_make_bind_value (srv_handle->cgw_handle, num_bind, argc, argv, &bind_data_list, net_buf);
+      err_code = cgw_make_bind_value (srv_handle->cgw_handle, num_bind, argc, argv, &bind_data_list);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -1376,7 +1354,7 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
 
   if (srv_handle->is_prepared == FALSE)
     {
-      err_code = cgw_sql_prepare (srv_handle->cgw_handle->hstmt, (SQLCHAR *) srv_handle->sql_stmt);
+      err_code = cgw_sql_prepare ((SQLCHAR *) srv_handle->sql_stmt);
 
       if (err_code != SQL_SUCCESS && err_code != SQL_SUCCESS_WITH_INFO)
 	{

--- a/src/broker/cas_function.c
+++ b/src/broker/cas_function.c
@@ -2070,9 +2070,6 @@ fn_con_close (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf, T_REQ_
     {
       logddl_free (true);
     }
-#if defined (CAS_FOR_CGW)
-  cgw_database_disconnect ();
-#endif
   return FN_CLOSE_CONN;
 }
 

--- a/src/broker/cas_handle.c
+++ b/src/broker/cas_handle.c
@@ -135,6 +135,8 @@ hm_new_srv_handle (T_SRV_HANDLE ** new_handle, unsigned int seq_num)
 
 #if defined (CAS_FOR_CGW)
   srv_handle->cgw_handle = NULL;
+  srv_handle->total_tuple_count = 0;
+  srv_handle->stmt_type = CUBRID_STMT_NONE;
 #endif /* CAS_FOR_CGW */
 
   *new_handle = srv_handle;

--- a/src/broker/cas_handle.h
+++ b/src/broker/cas_handle.h
@@ -168,7 +168,6 @@ struct t_cgw_handle
   SQLHENV henv;
   SQLHDBC hdbc;
   SQLHSTMT hstmt;
-  SQLHDESC hdesc;
 };
 #endif /* CAS_FOR_CGW */
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24251

**Purpose**
mysql server when the query is finished.
If you look at the session state with netstat when the connection to the mysql server is disconnected, you can see that the TIME_WAIT state is changed to the CLOSE state after a certain period of time has elapsed.
If there are more connections than the speed of switching from TIME_WAIT to CLOSE, it becomes impossible to connect to the mysql server due to insufficient ports.

**Implementation**
Do not repeat "connection -> close" whenever a query is executed in cgw, and if there is a reusable session, reuse it.
* When a connection request is made, it is checked whether there is an already connected session.
* If there is no connection, try to connect.
* If there is a session, it is determined whether reuse is possible. If reuse is not possible, a connection is attempted.

**Remarks**
N/A