### PR TITLE
[CBRD-24257] It prevents the CAS memory size from increasing when a large amount of data is fetched through a query.

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -180,14 +180,6 @@ cgw_database_connect (SUPPORTED_DBMS_TYPE dbms_type, const char *connect_url, ch
       goto ODBC_ERROR;
     }
 
-  if (ODBC_SQLSUCCESS (err_code))
-    {
-      SQL_CHK_ERR (local_odbc_handle->hdbc,
-		   SQL_HANDLE_DBC,
-		   err_code = SQLSetStmtAttr (local_odbc_handle->hstmt,
-					      SQL_ATTR_CURSOR_TYPE, (SQLPOINTER) SQL_CURSOR_STATIC, SQL_IS_INTEGER));
-    }
-
   cgw_link_server_info (local_odbc_handle->hdbc);
 
   SQL_CHK_ERR (local_odbc_handle->hdbc,
@@ -252,8 +244,6 @@ int
 cgw_row_data (SQLHSTMT hstmt, int cursor_pos)
 {
   SQLRETURN err_code;
-  int fetchOperation = SQL_FETCH_FIRST;
-  int fetch_offset = 0;
   int no_data = 0;
 
   if (hstmt == NULL)
@@ -262,18 +252,7 @@ cgw_row_data (SQLHSTMT hstmt, int cursor_pos)
       goto ODBC_ERROR;
     }
 
-  if (cursor_pos == 1)
-    {
-      fetch_offset = 0;
-      fetchOperation = SQL_FETCH_FIRST;
-    }
-  else if (cursor_pos > 1)
-    {
-      fetch_offset = cursor_pos;
-      fetchOperation = SQL_FETCH_ABSOLUTE;
-    }
-
-  err_code = SQLFetchScroll (hstmt, fetchOperation, fetch_offset);
+  err_code = SQLFetchScroll (hstmt, SQL_FETCH_NEXT, 0);
 
   if (err_code < 0)
     {
@@ -303,7 +282,7 @@ cgw_cursor_close (SQLHSTMT hstmt)
       goto ODBC_ERROR;
     }
 
-  SQL_CHK_ERR (hstmt, SQL_HANDLE_STMT, err_code = SQLCloseCursor (hstmt));
+  SQL_CHK_ERR (hstmt, SQL_HANDLE_STMT, err_code = SQLFreeStmt (hstmt, SQL_CLOSE));
 
   return err_code;
 

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -228,6 +228,8 @@ cgw_execute (T_SRV_HANDLE * srv_handle)
 
   SQL_CHK_ERR (srv_handle->cgw_handle->hstmt, SQL_HANDLE_STMT, err_code = SQLExecute (srv_handle->cgw_handle->hstmt));
 
+  srv_handle->is_cursor_open = true;
+
   return NO_ERROR;
 
 ODBC_ERROR:
@@ -272,17 +274,20 @@ ODBC_ERROR:
 }
 
 int
-cgw_cursor_close (SQLHSTMT hstmt)
+cgw_cursor_close (T_SRV_HANDLE * srv_handle)
 {
   SQLRETURN err_code = 0;
 
-  if (hstmt == NULL)
+  if (srv_handle->cgw_handle->hstmt == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_STMT_HANDLE, 0);
       goto ODBC_ERROR;
     }
 
-  SQL_CHK_ERR (hstmt, SQL_HANDLE_STMT, err_code = SQLFreeStmt (hstmt, SQL_CLOSE));
+  SQL_CHK_ERR (srv_handle->cgw_handle->hstmt, SQL_HANDLE_STMT, err_code =
+	       SQLFreeStmt (srv_handle->cgw_handle->hstmt, SQL_CLOSE));
+
+  srv_handle->is_cursor_open = false;
 
   return err_code;
 

--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -163,7 +163,7 @@ extern int cgw_set_execute_info (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_buf,
 extern int cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv, ODBC_BIND_INFO ** ret_val);
 
 // Resultset funtions
-extern int cgw_cursor_close (SQLHSTMT hstmt);
+extern int cgw_cursor_close (T_SRV_HANDLE * srv_handle);
 extern int cgw_row_data (SQLHSTMT hstmt, int cursor_pos);
 extern int cgw_set_stmt_attr (SQLHSTMT hstmt, SQLINTEGER attr, SQLPOINTER val, SQLINTEGER len);
 extern int cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding, int cursor_pos);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -5747,7 +5747,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
     }
   else if (srv_handle->is_cursor_open && cursor_pos == 1 && srv_handle->cursor_pos > 1)
     {
-      cgw_cursor_close (srv_handle);
+      err_code = cgw_cursor_close (srv_handle);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);

--- a/src/broker/cas_handle.c
+++ b/src/broker/cas_handle.c
@@ -137,7 +137,7 @@ hm_new_srv_handle (T_SRV_HANDLE ** new_handle, unsigned int seq_num)
   srv_handle->cgw_handle = NULL;
   srv_handle->total_tuple_count = 0;
   srv_handle->stmt_type = CUBRID_STMT_NONE;
-  srv_handle->is_fetch_end = false;
+  srv_handle->is_cursor_open = false;
 #endif /* CAS_FOR_CGW */
 
   *new_handle = srv_handle;

--- a/src/broker/cas_handle.c
+++ b/src/broker/cas_handle.c
@@ -137,6 +137,7 @@ hm_new_srv_handle (T_SRV_HANDLE ** new_handle, unsigned int seq_num)
   srv_handle->cgw_handle = NULL;
   srv_handle->total_tuple_count = 0;
   srv_handle->stmt_type = CUBRID_STMT_NONE;
+  srv_handle->is_fetch_end = false;
 #endif /* CAS_FOR_CGW */
 
   *new_handle = srv_handle;

--- a/src/broker/cas_handle.h
+++ b/src/broker/cas_handle.h
@@ -228,6 +228,7 @@ struct t_srv_handle
   T_CGW_HANDLE *cgw_handle;
   int total_tuple_count;
   int stmt_type;
+  bool is_fetch_end;
 #endif				/* CAS_FOR_CGW */
 };
 

--- a/src/broker/cas_handle.h
+++ b/src/broker/cas_handle.h
@@ -228,7 +228,7 @@ struct t_srv_handle
   T_CGW_HANDLE *cgw_handle;
   int total_tuple_count;
   int stmt_type;
-  bool is_fetch_end;
+  bool is_cursor_open;
 #endif				/* CAS_FOR_CGW */
 };
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24257

Purpose
When a large amount of data was imported with a cursor type other than SQL_CURSOR_FORWARD_ONLY among the ODBC cursor types, the CAS (CGW) memory size increased.
It was confirmed that the memory size increases in SQLExecute for MySQL and SQLFetchScroll for Oracle.
When importing large amounts of data, if the memory size of CAS (CGW) exceeds the set memory size, CAS (CGW) restarts. At this time, the driver cannot get the data and an error occurs.

Implementation
N/A

Remarks
N/A

