### PR TITLE
[CBRD-24260] Fixed error message handling related to DOT and RIGHT_ARROW

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -19741,7 +19741,7 @@ path_header
 	;
 
 path_dot
-	: DOT
+	: DOT          { DBG_TRACE_GRAMMAR(path_dot, : DOT); }
 	| RIGHT_ARROW  { DBG_TRACE_GRAMMAR(path_dot, | RIGHT_ARROW); }
 	;
 
@@ -23821,7 +23821,6 @@ pop_msg ()
 extern void csql_yyset_lineno (int line_number);
 int yycolumn = 0;
 int yycolumn_end = 0;
-int dot_flag = 0;
 
 int parser_function_code = PT_EMPTY;
 size_t json_table_column_count = 0;
@@ -24962,7 +24961,6 @@ parser_main (PARSER_CONTEXT * parser)
   yycolumn = yycolumn_end = 1;
   yybuffer_pos=0;
   csql_yylloc.buffer_pos=0;
-  dot_flag = 0;
 
   g_query_string = NULL;
   g_query_string_len = 0;
@@ -25062,7 +25060,6 @@ parse_one_statement (int state)
 
   yybuffer_pos=0;
   csql_yylloc.buffer_pos=0;
-  dot_flag = 0;
 
   g_query_string = NULL;
   g_query_string_len = 0;

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -47,7 +47,6 @@ static void begin_token (char *token);
 
 extern int yycolumn;
 extern int yycolumn_end;
-extern int dot_flag;
 
 int str_identifier = '\0';
 
@@ -86,6 +85,7 @@ int yybuffer_pos;
 %x QUOTED_ISO_STRING
 %x QUOTED_BINARY_STRING
 %x QUOTED_UTF8_STRING
+%x POST_DOT_OR_RIGHT_ARROW_STRING
 
 
 
@@ -1148,96 +1148,57 @@ _[uU][tT][fF]8[']		{
 						         }
 
 "."[ \t\r\n]*([a-zA-Z_#]|([\xc0-\xfe]))([a-zA-Z_#0-9]|([\x80-\xfe]))* {
-								int i = 0;
-								int len = 0;
-								if (dot_flag == 0)
-								  {
-								    yybuffer_pos -= csql_yyleng;
-								    yyless(0);
-								    dot_flag = 1;
-								    return DOT;
-								  }
-								else
-								  {
-								    begin_token(yytext);
-								    dot_flag = 0;
-								    len = strlen(yytext);
-								    if (len >= 254)
-								      {
-								        yytext[254] = 0;
-								      }
-
-								    for (i = 1; i < len - 1 && IS_BLANK_CHAR (yytext[i]); i++)
-								    ;
-
-								    csql_yylval.cptr = pt_makename(&yytext[i]);
-
-								    /* Distinguish some special words/tokens from normal identifiers (IdName).
-								     * Because these special words (companioned with DOT/RIGHT_ARROW) are
-								     * reserved for special use purpose in some clauses' context.
-								     */
-								    if (strcasecmp (csql_yylval.cptr, "NONE") == 0)
-								      {
-								        return NONE;
-								      }
-								    else if (strcasecmp (csql_yylval.cptr, "IDENTITY") == 0)
-								      {
-								        return IDENTITY;
-								      }
-								    else if (strcasecmp (csql_yylval.cptr, "OBJECT") == 0)
-								      {
-								        return OBJECT;
-								      }
-
-								    return IdName;
-								  }
-								}
+							    yybuffer_pos -= (csql_yyleng - 1);
+							    yyless(1);
+                                                            DBG_PRINT_TOKEN(yytext);
+                                                            BEGIN(POST_DOT_OR_RIGHT_ARROW_STRING);
+							    return DOT;
+							}
 
 "->"[ \t\r\n]*([a-zA-Z_#]|([\xc0-\xfe]))([a-zA-Z_#0-9]|([\x80-\xfe]))* {
-								int i = 0;
-								int len = 0;
-								if (dot_flag == 0)
-								  {
-								    yybuffer_pos -= csql_yyleng;
-								    yyless(0);
-								    dot_flag = 1;
-								    return RIGHT_ARROW;
-								  }
-								else
-								  {
-								    begin_token(yytext);
-								    dot_flag = 0;
-								    len = strlen(yytext);
-								    if (len >= 254)
-								      {
-								        yytext[254] = 0;
-								      }
+                                                           yybuffer_pos -= (csql_yyleng - 2);
+							   yyless(2);
+                                                           DBG_PRINT_TOKEN(yytext);
+                                                           BEGIN(POST_DOT_OR_RIGHT_ARROW_STRING);
+							   return RIGHT_ARROW;
+							}
 
-								    for (i = 2; i < len - 1 && IS_BLANK_CHAR (yytext[i]); i++)
-								    ;
+<POST_DOT_OR_RIGHT_ARROW_STRING>[ \t\r\n]*([a-zA-Z_#]|([\xc0-\xfe]))([a-zA-Z_#0-9]|([\x80-\xfe]))* {
+				        int i = 0;
+				        int len = 0;
+				      	  
+                                        BEGIN(INITIAL);
+                                        begin_token(yytext);
+                                        len = strlen(yytext);
+                                        if (len >= 254)
+                                          {
+                                             yytext[254] = 0;
+                                          }
 
-								    csql_yylval.cptr = pt_makename(&yytext[i]);
+                                        for (i = 0; i < len - 1 && IS_BLANK_CHAR (yytext[i]); i++)
+                                           ;
 
-								    /* Distinguish some special words/tokens from normal identifiers (IdName).
-								     * Because these special words (companioned with DOT/RIGHT_ARROW) are
-								     * reserved for special use purpose in some clauses' context.
-								     */
-								    if (strcasecmp (csql_yylval.cptr, "NONE") == 0)
-								      {
-								        return NONE;
-								      }
-								    else if (strcasecmp (csql_yylval.cptr, "IDENTITY") == 0)
-								      {
-								        return IDENTITY;
-								      }
-								    else if (strcasecmp (csql_yylval.cptr, "OBJECT") == 0)
-								      {
-								        return OBJECT;
-								      }
+                                        csql_yylval.cptr = pt_makename(&yytext[i]);
 
-								    return IdName;
-								  }
-								}
+                                        /* Distinguish some special words/tokens from normal identifiers (IdName).
+                                         * Because these special words (companioned with DOT/RIGHT_ARROW) are
+                                         * reserved for special use purpose in some clauses' context.
+                                         */
+                                        if (strcasecmp (csql_yylval.cptr, "NONE") == 0)
+                                          {
+                                             return NONE;
+                                          }
+                                        else if (strcasecmp (csql_yylval.cptr, "IDENTITY") == 0)
+                                          {
+                                             return IDENTITY;
+                                          }
+                                        else if (strcasecmp (csql_yylval.cptr, "OBJECT") == 0)
+                                          {
+                                             return OBJECT;
+                                          }
+
+                                        return IdName;
+				}
 
 0b[0-1]+			{
 					csql_yylval.cptr = pt_append_string(this_parser, NULL, yytext + 2);
@@ -1792,6 +1753,8 @@ end:
     {
       csql_yyfree (buffer);
     }
+
+  BEGIN(INITIAL);
 }
 
 int


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24260

In the process of processing DOT and RIGHT_ARROW, yyless(0) was used.
In this case, when a syntax error occurs at that point, yytext becomes '\0' in the csql_yyerror() function and the normal error handling routine cannot be used.

- Added POST_DOT_OR_RIGHT_ARROW_STRING as Lex status value.
- Delete the dot_flag variable as it is no longer needed.