### PR TITLE
[CBRD-24263] DBLink must support unsigned type.

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -180,14 +180,6 @@ cgw_database_connect (SUPPORTED_DBMS_TYPE dbms_type, const char *connect_url, ch
       goto ODBC_ERROR;
     }
 
-  if (ODBC_SQLSUCCESS (err_code))
-    {
-      SQL_CHK_ERR (local_odbc_handle->hdbc,
-		   SQL_HANDLE_DBC,
-		   err_code = SQLSetStmtAttr (local_odbc_handle->hstmt,
-					      SQL_ATTR_CURSOR_TYPE, (SQLPOINTER) SQL_CURSOR_STATIC, SQL_IS_INTEGER));
-    }
-
   cgw_link_server_info (local_odbc_handle->hdbc);
 
   SQL_CHK_ERR (local_odbc_handle->hdbc,
@@ -236,6 +228,8 @@ cgw_execute (T_SRV_HANDLE * srv_handle)
 
   SQL_CHK_ERR (srv_handle->cgw_handle->hstmt, SQL_HANDLE_STMT, err_code = SQLExecute (srv_handle->cgw_handle->hstmt));
 
+  srv_handle->is_cursor_open = true;
+
   return NO_ERROR;
 
 ODBC_ERROR:
@@ -252,8 +246,6 @@ int
 cgw_row_data (SQLHSTMT hstmt, int cursor_pos)
 {
   SQLRETURN err_code;
-  int fetchOperation = SQL_FETCH_FIRST;
-  int fetch_offset = 0;
   int no_data = 0;
 
   if (hstmt == NULL)
@@ -262,18 +254,7 @@ cgw_row_data (SQLHSTMT hstmt, int cursor_pos)
       goto ODBC_ERROR;
     }
 
-  if (cursor_pos == 1)
-    {
-      fetch_offset = 0;
-      fetchOperation = SQL_FETCH_FIRST;
-    }
-  else if (cursor_pos > 1)
-    {
-      fetch_offset = cursor_pos;
-      fetchOperation = SQL_FETCH_ABSOLUTE;
-    }
-
-  err_code = SQLFetchScroll (hstmt, fetchOperation, fetch_offset);
+  err_code = SQLFetchScroll (hstmt, SQL_FETCH_NEXT, 0);
 
   if (err_code < 0)
     {
@@ -293,17 +274,20 @@ ODBC_ERROR:
 }
 
 int
-cgw_cursor_close (SQLHSTMT hstmt)
+cgw_cursor_close (T_SRV_HANDLE * srv_handle)
 {
   SQLRETURN err_code = 0;
 
-  if (hstmt == NULL)
+  if (srv_handle->cgw_handle->hstmt == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_STMT_HANDLE, 0);
       goto ODBC_ERROR;
     }
 
-  SQL_CHK_ERR (hstmt, SQL_HANDLE_STMT, err_code = SQLCloseCursor (hstmt));
+  SQL_CHK_ERR (srv_handle->cgw_handle->hstmt, SQL_HANDLE_STMT, err_code =
+	       SQLFreeStmt (srv_handle->cgw_handle->hstmt, SQL_CLOSE));
+
+  srv_handle->is_cursor_open = false;
 
   return err_code;
 
@@ -329,7 +313,11 @@ cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding, int cursor
 
   for (this_col_binding = first_col_binding; this_col_binding; this_col_binding = this_col_binding->next)
     {
-      if (this_col_binding->indPtr != SQL_NULL_DATA)
+      if (this_col_binding->indPtr == SQL_NULL_DATA)
+	{
+	  net_buf_cp_int (net_buf, -1, NULL);
+	}
+      else
 	{
 	  str_len = this_col_binding->indPtr;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24263

Purpose
MySQL and Oracle support unsigned types such as unsigned int and unsigned short.
However, Cubrid does not support unsigned type, but it must be changed to a type supported by Gateway.
In case of unsigned type, if you change it to VARCHAR, you can check it in CUBRID.

Implementation
N/A

Remarks
N/A)