### PR TITLE
[CBRD-24262] If the column value is NULL, only -1 should be added to the data length and sent to the client.

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -329,7 +329,11 @@ cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding, int cursor
 
   for (this_col_binding = first_col_binding; this_col_binding; this_col_binding = this_col_binding->next)
     {
-      if (this_col_binding->indPtr != SQL_NULL_DATA)
+      if (this_col_binding->indPtr == SQL_NULL_DATA)
+	{
+	  net_buf_cp_int (net_buf, -1, NULL);
+	}
+      else
 	{
 	  str_len = this_col_binding->indPtr;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24262

Purpose
When sending the query result value to the client, it must be sent in data length and data value format. In this case, if the column value is NULL, only -1 should be sent to the data length.

Implementation
N/A

Remarks
N/A)
