### PR TITLE
[CBRD-24263] DBLink must support unsigned type.

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -642,7 +642,7 @@ cgw_odbc_type_to_cci_u_type (SQLLEN odbc_type, SQLLEN is_unsigned_type)
       data_type = CCI_U_TYPE_NUMERIC;
       break;
     case SQL_INTEGER:
-      if (is_unsigned_type)
+      data_type = (is_unsigned_type) ? CCI_U_TYPE_CHAR : CCI_U_TYPE_INT;
 	{
 	  data_type = CCI_U_TYPE_CHAR;
 	}

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -752,7 +752,7 @@ cgw_odbc_type_to_charset (SQLLEN odbc_type, SQLLEN is_unsigned_type)
       code_set = INTL_CODESET_ASCII;
       break;
     case SQL_INTEGER:
-      if (is_unsigned_type)
+     code_set = (is_unsigned_type) ? cgw_get_charset () : INTL_CODESET_ASCII;
 	{
 	  code_set = cgw_get_charset ();
 	}

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -2030,7 +2030,7 @@ get_c_type (SQLSMALLINT s_type, SQLLEN is_unsigned_type)
       c_type = SQL_C_BIT;
       break;
     case SQL_TINYINT:
-      if (is_unsigned_type)
+      c_type = (is_unsigned_type) ? SQL_C_CHAR : SQL_C_TINYINT;
 	{
 	  c_type = SQL_C_CHAR;
 	}

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -643,24 +643,10 @@ cgw_odbc_type_to_cci_u_type (SQLLEN odbc_type, SQLLEN is_unsigned_type)
       break;
     case SQL_INTEGER:
       data_type = (is_unsigned_type) ? CCI_U_TYPE_CHAR : CCI_U_TYPE_INT;
-	{
-	  data_type = CCI_U_TYPE_CHAR;
-	}
-      else
-	{
-	  data_type = CCI_U_TYPE_INT;
-	}
       break;
     case SQL_TINYINT:
     case SQL_SMALLINT:
-      if (is_unsigned_type)
-	{
-	  data_type = CCI_U_TYPE_CHAR;
-	}
-      else
-	{
-	  data_type = CCI_U_TYPE_SHORT;
-	}
+      data_type = (is_unsigned_type) ? CCI_U_TYPE_CHAR : CCI_U_TYPE_SHORT;
       break;
     case SQL_FLOAT:
     case SQL_REAL:
@@ -709,14 +695,7 @@ cgw_odbc_type_to_cci_u_type (SQLLEN odbc_type, SQLLEN is_unsigned_type)
       data_type = CCI_U_TYPE_DATETIME;
       break;
     case SQL_BIGINT:
-      if (is_unsigned_type)
-	{
-	  data_type = CCI_U_TYPE_CHAR;
-	}
-      else
-	{
-	  data_type = CCI_U_TYPE_BIGINT;
-	}
+      data_type = (is_unsigned_type) ? CCI_U_TYPE_CHAR : CCI_U_TYPE_BIGINT;
       break;
 #if (ODBCVER >= 0x0350)
     case SQL_GUID:
@@ -752,25 +731,11 @@ cgw_odbc_type_to_charset (SQLLEN odbc_type, SQLLEN is_unsigned_type)
       code_set = INTL_CODESET_ASCII;
       break;
     case SQL_INTEGER:
-     code_set = (is_unsigned_type) ? cgw_get_charset () : INTL_CODESET_ASCII;
-	{
-	  code_set = cgw_get_charset ();
-	}
-      else
-	{
-	  code_set = INTL_CODESET_ASCII;
-	}
+      code_set = (is_unsigned_type) ? cgw_get_charset () : INTL_CODESET_ASCII;
       break;
     case SQL_TINYINT:
     case SQL_SMALLINT:
-      if (is_unsigned_type)
-	{
-	  code_set = cgw_get_charset ();
-	}
-      else
-	{
-	  code_set = INTL_CODESET_ASCII;
-	}
+      code_set = (is_unsigned_type) ? cgw_get_charset () : INTL_CODESET_ASCII;
       break;
     case SQL_FLOAT:
       code_set = INTL_CODESET_ASCII;
@@ -820,14 +785,7 @@ cgw_odbc_type_to_charset (SQLLEN odbc_type, SQLLEN is_unsigned_type)
       code_set = INTL_CODESET_ASCII;
       break;
     case SQL_BIGINT:
-      if (is_unsigned_type)
-	{
-	  code_set = cgw_get_charset ();
-	}
-      else
-	{
-	  code_set = INTL_CODESET_ASCII;
-	}
+      code_set = (is_unsigned_type) ? cgw_get_charset () : INTL_CODESET_ASCII;
       break;
 #if (ODBCVER >= 0x0350)
     case SQL_GUID:
@@ -2031,43 +1989,15 @@ get_c_type (SQLSMALLINT s_type, SQLLEN is_unsigned_type)
       break;
     case SQL_TINYINT:
       c_type = (is_unsigned_type) ? SQL_C_CHAR : SQL_C_TINYINT;
-	{
-	  c_type = SQL_C_CHAR;
-	}
-      else
-	{
-	  c_type = SQL_C_TINYINT;
-	}
       break;
     case SQL_SMALLINT:
-      if (is_unsigned_type)
-	{
-	  c_type = SQL_C_CHAR;
-	}
-      else
-	{
-	  c_type = SQL_C_SHORT;
-	}
+      c_type = (is_unsigned_type) ? SQL_C_CHAR : SQL_C_SHORT;
       break;
     case SQL_INTEGER:
-      if (is_unsigned_type)
-	{
-	  c_type = SQL_C_CHAR;
-	}
-      else
-	{
-	  c_type = SQL_C_LONG;
-	}
+      c_type = (is_unsigned_type) ? SQL_C_CHAR : SQL_C_LONG;
       break;
     case SQL_BIGINT:
-      if (is_unsigned_type)
-	{
-	  c_type = SQL_C_CHAR;
-	}
-      else
-	{
-	  c_type = SQL_C_SBIGINT;
-	}
+      c_type = (is_unsigned_type) ? SQL_C_CHAR : SQL_C_SBIGINT;
       break;
     case SQL_REAL:
     case SQL_FLOAT:

--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -76,6 +76,7 @@ struct t_col_binder
   SQLLEN indPtr;		/* size or null     */
   SQLLEN col_data_type;		/* type of column   */
   SQLULEN col_size;
+  SQLLEN col_unsigned_type;
   struct t_col_binder *next;	/* linked list      */
 };
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24263

Purpose
MySQL and Oracle support unsigned types such as unsigned int and unsigned short.
However, Cubrid does not support unsigned type, but it must be changed to a type supported by Gateway.
In case of unsigned type, if you change it to VARCHAR, you can check it in CUBRID.

Implementation
N/A

Remarks
N/A
