### PR TITLE
[CBRD-24176] Support escape character for single quotation in string value

### DIFF
--- a/src/executables/csql.h
+++ b/src/executables/csql.h
@@ -364,6 +364,8 @@ extern "C"
   extern int csql_set_column_width_info (const char *column_name, int column_width);
   extern int csql_get_column_width (const char *column_name);
 
+  extern char *string_to_string (const char *string_value, char string_delimiter, char string_introducer, int length,
+				 int *result_length, bool plain_string, bool change_single_quote);
 
 #ifdef __cplusplus
 }

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -281,8 +281,6 @@ static char *bit_to_string (DB_VALUE * value, char string_delimiter, bool plain_
 static char *set_to_string (DB_VALUE * value, char begin_notation, char end_notation, int max_entries,
 			    bool plain_string, CSQL_OUTPUT_TYPE output_type, char column_encolser);
 static char *duplicate_string (const char *string);
-static char *string_to_string (const char *string_value, char string_delimiter, char string_introducer, int length,
-			       int *result_length, bool plain_string, bool change_single_quote);
 static int get_object_print_format (void);
 
 /*
@@ -1229,7 +1227,7 @@ csql_string_to_plain_string (const char *string_value, int length, int *result_l
  *   plain_string(in): refine string for plain output
  *   change_single_quote(in): refine string for query output
  */
-static char *
+char *
 string_to_string (const char *string_value, char string_delimiter, char string_introducer, int length,
 		  int *result_length, bool plain_string, bool change_single_quote)
 {

--- a/src/transaction/flashback_cl.c
+++ b/src/transaction/flashback_cl.c
@@ -430,6 +430,8 @@ flashback_process_column_data (char **data, char **sql, int *max_sql_size, DB_TY
 	  error = flashback_check_and_resize_sql_memory (sql, sql_length + result_length + 1, max_sql_size);
 	  if (error != NO_ERROR)
 	    {
+	      free_and_init (result_string);
+
 	      return error;
 	    }
 
@@ -792,7 +794,7 @@ flashback_print_delete (char **loginfo, int trid, char *user, const char *classn
     {
       /* check SQL length
        * sql + length of ", " */
-      error = flashback_check_and_resize_sql_memory (&sql, strlen (sql) + 3, &max_sql_size);
+      error = flashback_check_and_resize_sql_memory (&sql, strlen (sql) + 4, &max_sql_size);
       if (error != NO_ERROR)
 	{
 	  goto error;
@@ -996,7 +998,7 @@ flashback_print_insert (char **loginfo, int trid, char *user, const char *classn
 	{
 	  /* check SQL length
 	   * cond_sql + length of ", " */
-	  error = flashback_check_and_resize_sql_memory (&original_sql, strlen (original_sql) + 3, &max_original_size);
+	  error = flashback_check_and_resize_sql_memory (&original_sql, strlen (original_sql) + 4, &max_original_size);
 	  if (error != NO_ERROR)
 	    {
 	      goto error;

--- a/src/transaction/flashback_cl.c
+++ b/src/transaction/flashback_cl.c
@@ -779,7 +779,7 @@ flashback_print_delete (char **loginfo, int trid, char *user, const char *classn
       goto error;
     }
 
-  sprintf (sql, "insert into [%s] values ( ", classname);
+  sprintf (sql, "insert into [%s] values (", classname);
 
   ptr = or_unpack_int (ptr, &num_change_col);
   ptr = or_unpack_int (ptr, &num_cond_col);
@@ -794,7 +794,7 @@ flashback_print_delete (char **loginfo, int trid, char *user, const char *classn
     {
       /* check SQL length
        * sql + length of ", " */
-      error = flashback_check_and_resize_sql_memory (&sql, strlen (sql) + 4, &max_sql_size);
+      error = flashback_check_and_resize_sql_memory (&sql, strlen (sql) + 3, &max_sql_size);
       if (error != NO_ERROR)
 	{
 	  goto error;
@@ -807,7 +807,7 @@ flashback_print_delete (char **loginfo, int trid, char *user, const char *classn
 	}
       else
 	{
-	  strcat (sql, " );");
+	  strcat (sql, ");");
 	}
 
       attr = attr->order_link;
@@ -985,7 +985,7 @@ flashback_print_insert (char **loginfo, int trid, char *user, const char *classn
 	  goto error;
 	}
 
-      sprintf (original_sql, "insert into [%s] values ( ", classname);
+      sprintf (original_sql, "insert into [%s] values (", classname);
 
       ptr = or_unpack_int (ptr, &num_change_col);
       for (i = 0; i < num_change_col; i++)
@@ -998,7 +998,7 @@ flashback_print_insert (char **loginfo, int trid, char *user, const char *classn
 	{
 	  /* check SQL length
 	   * cond_sql + length of ", " */
-	  error = flashback_check_and_resize_sql_memory (&original_sql, strlen (original_sql) + 4, &max_original_size);
+	  error = flashback_check_and_resize_sql_memory (&original_sql, strlen (original_sql) + 3, &max_original_size);
 	  if (error != NO_ERROR)
 	    {
 	      goto error;
@@ -1011,7 +1011,7 @@ flashback_print_insert (char **loginfo, int trid, char *user, const char *classn
 	    }
 	  else
 	    {
-	      strcat (original_sql, " );");
+	      strcat (original_sql, ");");
 	    }
 
 	  attr = attr->order_link;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24176

Purpose

This is to insert an escape character to process a single quotation character. 
In order to use single quotation in the string value, we need to add escape (\') character.

if user wants to insert a value `aa'aa`, then SQL for it is as below
`INSERT INTO tbl values (' aa''aa ');`

And flashback should provide SQL statement like above. 

Implementation

Used existing csql function (string_to_string ()) which is used for making raw string value to executable string.
- string_value : original string value (aa'aa)
- delimiter : string enclosure ('\'')
- string_introducer : character that must come at the beginning of the string (e.g `X'1001'`,` B'1010'`)
- plain string : string that can contain '\n', '\t', ...
- change_single_quote : if there is a single quote in the string, then change it from `'\''` to `'\'\''` 