### PR TITLE
[CBRD-24173] Fix bugs occurred when getting summary information with default option

### DIFF
--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -4357,7 +4357,7 @@ flashback (UTIL_FUNCTION_ARG * arg)
 
       if (poll (&input_fd, 1, timeout * 1000))
 	{
-	  if (!scanf ("%d", &trid))
+	  if (scanf ("%d", &trid) != 1)
 	    {
 	      /* When non integer value is input, the input buffer must be flushed. */
 	      clean_stdin ();

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -4361,6 +4361,8 @@ flashback (UTIL_FUNCTION_ARG * arg)
 	    {
 	      /* When non integer value is input, the input buffer must be flushed. */
 	      clean_stdin ();
+
+	      continue;
 	    }
 	}
       else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24173

Purpose

Fix bugs when
1. Get flashback summary with a default option
  - cubrid createdb testdb en_US 
  - cubrid flashback testdb
  -> start_date is set to 10 minutes before current
  -> then start_date can be set earlier than db_creation
  -> So, if start_date is earlier than db_creation, then set start_date to db_creation. 

2. Get transaction ID as value ​​other than integer
  - Since the input buffer is not flushed by scanf, scanf can continue to run even if there is no input.
  -> if an error occurs in scanf, then flushed an input buffer

3. Missed argument for "output file" error message