### PR TITLE
[CBRD-24266] Change the default value of the loaddb utility --no-user-specified-name option to false.

### DIFF
--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1154,9 +1154,7 @@ get_loaddb_args (UTIL_ARG_MAP * arg_map, load_args * args)
   args->compare_storage_order = utility_get_option_bool_value (arg_map, LOAD_COMPARE_STORAGE_ORDER_S);
   args->table_name = table_name ? table_name : empty;
   args->ignore_class_file = ignore_class_file ? ignore_class_file : empty;
-  /* set to true for testing. When the test is complete, the option should be checked. (by youngjinj) */
-  // args->no_user_specified_name = utility_get_option_bool_value (arg_map, LOAD_NO_USER_SPECIFIED_NAME_S);
-  args->no_user_specified_name = true;
+  args->no_user_specified_name = utility_get_option_bool_value (arg_map, LOAD_NO_USER_SPECIFIED_NAME_S);
 }
 
 static void

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -6593,7 +6593,6 @@ pt_resolve_showstmt_args_unnamed (PARSER_CONTEXT * parser, const SHOWSTMT_NAMED_
   int i;
   PT_NODE *arg, *id_string;
   PT_NODE *prev = NULL, *head = NULL;
-  char lower_table_name[DB_MAX_IDENTIFIER_LENGTH];
 
   if (arg_info_count == 0)
     {
@@ -6615,8 +6614,7 @@ pt_resolve_showstmt_args_unnamed (PARSER_CONTEXT * parser, const SHOWSTMT_NAMED_
 	{
 	  /* replace identifier node with string value node */
 	  pt_set_user_specified_name (parser, arg, NULL, NULL);
-	  sm_user_specified_name (arg->info.name.original, lower_table_name, DB_MAX_IDENTIFIER_LENGTH);
-	  id_string = pt_make_string_value (parser, lower_table_name);
+	  id_string = pt_make_string_value (parser, arg->info.name.original);
 	  if (id_string == NULL)
 	    {
 	      goto error;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24266

- The default value of the loaddb utility --no-user-specified-name option was set to true for testing, change it to false for release.
- Fixed an issue where the index could not be found in the show index capacity statement. (QA shell test)
  - The index name is also changed to a user-specified name, so the index cannot be found.
