### PR TITLE
[CBRD-23846] Fix JDK 7 compatability

### DIFF
--- a/src/jsp/com/cubrid/jsp/data/CUBRIDPacker.java
+++ b/src/jsp/com/cubrid/jsp/data/CUBRIDPacker.java
@@ -31,6 +31,8 @@
 
 package com.cubrid.jsp.data;
 
+import com.cubrid.jsp.data.DBType;
+import com.cubrid.jsp.data.SOID;
 import com.cubrid.jsp.jdbc.CUBRIDServerSideResultSet;
 import cubrid.sql.CUBRIDOID;
 import java.io.UnsupportedEncodingException;
@@ -61,7 +63,7 @@ public class CUBRIDPacker {
 
     public void packInt(int value) {
         align(DataUtilities.INT_ALIGNMENT);
-        ensureSpace(Integer.BYTES);
+        ensureSpace(DataUtilities.INT_BYTES);
         buffer.putInt(value);
     }
 
@@ -101,7 +103,7 @@ public class CUBRIDPacker {
 
     public void packOID(SOID oid) {
         align(DataUtilities.INT_ALIGNMENT);
-        ensureSpace(Integer.BYTES + Short.BYTES + Short.BYTES);
+        ensureSpace(DataUtilities.INT_BYTES + DataUtilities.SHORT_BYTES + DataUtilities.SHORT_BYTES);
         packInt(oid.pageId);
         packShort(oid.slotId);
         packShort(oid.volId);
@@ -115,7 +117,7 @@ public class CUBRIDPacker {
             buffer.put(value);
             align(DataUtilities.INT_ALIGNMENT);
         } else {
-            ensureSpace(value.length + 1 + Integer.BYTES); // str + LARGE_STRING_CODE + len
+            ensureSpace(value.length + 1 + DataUtilities.INT_BYTES); // str + LARGE_STRING_CODE + len
             buffer.put((byte) DataUtilities.LARGE_STRING_CODE);
 
             align(DataUtilities.INT_ALIGNMENT);

--- a/src/jsp/com/cubrid/jsp/data/DataUtilities.java
+++ b/src/jsp/com/cubrid/jsp/data/DataUtilities.java
@@ -37,13 +37,19 @@ import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 
 public class DataUtilities {
+    public static final int CHAR_BYTES = (Byte.SIZE / 8);
+    public static final int SHORT_BYTES = (Short.SIZE / 8);
+    public static final int INT_BYTES = (Integer.SIZE / 8);
+    public static final int LONG_BYTES = (Long.SIZE / 8);
+    public static final int FLOAT_BYTES = (Float.SIZE / 8);
+    public static final int DOUBLE_BYTES = (Double.SIZE / 8);
 
-    public static final int CHAR_ALIGNMENT = Byte.BYTES;
-    public static final int SHORT_ALIGNMENT = Short.BYTES;
-    public static final int INT_ALIGNMENT = Integer.BYTES;
-    public static final int LONG_ALIGNMENT = Long.BYTES;
-    public static final int FLOAT_ALIGNMENT = Float.BYTES;
-    public static final int DOUBLE_ALIGNMENT = Double.BYTES;
+    public static final int CHAR_ALIGNMENT = CHAR_BYTES;
+    public static final int SHORT_ALIGNMENT = SHORT_BYTES;
+    public static final int INT_ALIGNMENT = INT_BYTES;
+    public static final int LONG_ALIGNMENT = LONG_BYTES;
+    public static final int FLOAT_ALIGNMENT = FLOAT_BYTES;
+    public static final int DOUBLE_ALIGNMENT = DOUBLE_BYTES;
     public static final int MAX_ALIGNMENT = DOUBLE_ALIGNMENT;
 
     public static final int MAX_SMALL_STRING_SIZE = 255;

--- a/win/build.bat
+++ b/win/build.bat
@@ -33,6 +33,7 @@ if "%JAVA_HOME%" == "" echo "ERROR: JAVA_HOME variable is not set" & GOTO :EOF
 rem clear ERRORLEVEL
 
 set SCRIPT_DIR=%~dp0
+set ANT_OPTS=-Dhttps.protocols=TLSv1.1,TLSv1.2
 
 rem set default value
 set VERSION=0


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23966

This PR supprot JDK 7 compatabiltiy. CUBRID is built and tested with JDK 7 on Windows at the CUBRID QA system.
The following is implemented
- Sets https.protocols for maven repo in build scripts.
- `(TYPE_NAME).BYTES` supprots from JDK 1.8. It is replaced with `(TYPE_NAME).SIZE / 8`
