### PR TITLE
[CBRD-24274] Fix the bug occurred when read from the dismounted log volume

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -14137,6 +14137,8 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
     }
   else
     {
+      LOG_ARCHIVE_CS_ENTER (thread_p);
+
       if (log_Gl.archive.vdes != NULL_VOLDES && log_Gl.archive.hdr.arv_num == arv_num)
 	{
 	  /* if target archive log volume is currenty mounted, then use that */
@@ -14145,8 +14147,6 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 	}
       else
 	{
-	  LOG_ARCHIVE_CS_ENTER (thread_p);
-
 	  aligned_hdr_pgbuf = PTR_ALIGN (hdr_pgbuf, MAX_ALIGNMENT);
 
 	  hdr_pgptr = (LOG_PAGE *) aligned_hdr_pgbuf;
@@ -14188,10 +14188,11 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 		  fileio_dismount (thread_p, vdes);
 
-		  LOG_ARCHIVE_CS_EXIT (thread_p);
 		}
 	    }
 	}
+
+      LOG_ARCHIVE_CS_EXIT (thread_p);
     }
 
   LOG_CS_EXIT (thread_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24274

Purpose

* The most recently used archive log volume can be mounted and information can be saved in log_Gl.archive (log_Gl.archive.vdes)
* In cdc_get_start_point_from_file(), if the most recent archive log volume is used, the operation is finished and dismounted.
* If another thread tries to access the archive log volume using log_Gl.archive.vdes, an error occurs because it was dismounted in the above function.

Implementation
* When using the archive volume stored in log_Gl.archive, the stored information is used
* if do not use the archive volume stored in log_Gl.archive, mount the required log volume in the same way as before to obtain information and perform dismount.
