### PR TITLE
[CBRD-24264] Fix the bug occurred when flashback access the nxio_lsa

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -13745,8 +13745,7 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 	  else if (error == ER_CDC_LSA_NOT_FOUND)
 	    {
 	      /* input time is too big to find log, then returns latest log */
-	      LOG_LSA nxio_lsa = log_Gl.append.get_nxio_lsa ();
-	      LSA_COPY (start_lsa, &nxio_lsa);
+	      LSA_COPY (start_lsa, &log_Gl.append.prev_lsa);
 
 	      *extraction_time = time (NULL);	/* can not know time of latest log */
 	      is_found = true;
@@ -13831,8 +13830,7 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 	      else
 		{
 		  /* num_arvs ==0 but no time info has been found in active log volume */
-		  LOG_LSA nxio_lsa = log_Gl.append.get_nxio_lsa ();
-		  LSA_COPY (start_lsa, &nxio_lsa);
+		  LSA_COPY (start_lsa, &log_Gl.append.prev_lsa);
 
 		  *extraction_time = time (NULL);	/* can not know time of latest log */
 		  is_found = true;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24264

Purpose

* log_Gl.append.nxio_lsa means lowest lsa which has not been written to the disk. 
* nxio_lsa is often synchronize with log_Gl.hdr.append_lsa. 
  * log_Gl.hdr.append_lsa means next location to append log record
* Next log record not always appended at log_Gl.hdr.append_lsa
  *  if (Length of next log record + append_lsa.offset > LOGAREA_SIZE) , then record will be appended at next page
* So, If flashback tries to access the log record in nxio_lsa, it can read garbage value.

Implementation

* when flashback get lsa using cdc_find_lsa(), it returns log_Gl.append.prev_lsa rather than nxio_lsa 
