### PR TITLE
[CBRD-24282] Modify the contents of cubrid_gateway.conf

### DIFF
--- a/conf/cubrid_gateway.conf
+++ b/conf/cubrid_gateway.conf
@@ -19,23 +19,8 @@
 MASTER_SHM_ID           =50001
 ADMIN_LOG_FILE          =log/gateway/cubrid_gateway.log
 
-[%cubrid]
-SERVICE                 =ON
-SSL			=OFF
-BROKER_PORT             =50000
-MIN_NUM_APPL_SERVER     =5
-MAX_NUM_APPL_SERVER     =40
-APPL_SERVER_SHM_ID      =5000
-LOG_DIR                 =log/gateway/sql_log
-ERROR_LOG_DIR           =log/gateway/error_log
-SQL_LOG                 =ON
-TIME_TO_KILL            =120
-SESSION_TIMEOUT         =300
-KEEP_CONNECTION         =AUTO
-CCI_DEFAULT_AUTOCOMMIT  =ON
-
 [%oracle]
-SERVICE                 =ON
+SERVICE                 =OFF
 SSL			=OFF
 APPL_SERVER             =CAS_CGW
 BROKER_PORT             =53000
@@ -58,7 +43,7 @@ CGW_LINK_CONNECT_URL_PROPERTY       =
 
 
 [%mysql]
-SERVICE                 =ON
+SERVICE                 =OFF
 SSL			=OFF
 APPL_SERVER             =CAS_CGW
 BROKER_PORT             =56000
@@ -77,5 +62,5 @@ CGW_LINK_SERVER		=MYSQL
 CGW_LINK_SERVER_IP      =localhost
 CGW_LINK_SERVER_PORT    =3306 
 CGW_LINK_ODBC_DRIVER_NAME   =driver name
-CGW_LINK_CONNECT_URL_PROPERTY       ="charset=utf8"
+CGW_LINK_CONNECT_URL_PROPERTY       ="charset=utf8;PREFETCH=100;NO_CACHE=1"
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24282

Purpose
In the cubrid_gateway.conf file of the odbc gateway, unnecessary items and some modifications were found.

Implementation
* Delete unnecessary [%cubrid] section
* In the case of mysql and oracle, it cannot be used without setting some parameters, so it is necessary to change it to SERVICE = OFF.
* In the case of mysql, the memory size of CAS may increase when large data is read, so it is necessary to add mysql prefetch and no_cache properties.

Remarks
N/A