### PR TITLE
[CBRD-24268] Fix to hide information about system class in flashback

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -593,6 +593,7 @@ createdb (UTIL_FUNCTION_ARG * arg)
   sysprm_set_force (prm_get_name (PRM_ID_PB_NBUFFERS), "1024");
   sysprm_set_force (prm_get_name (PRM_ID_XASL_CACHE_MAX_ENTRIES), "-1");
   sysprm_set_force (prm_get_name (PRM_ID_JAVA_STORED_PROCEDURE), "no");
+  sysprm_set_force (prm_get_name (PRM_ID_SUPPLEMENTAL_LOG), "0");
 
   AU_DISABLE_PASSWORDS ();
   db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);

--- a/src/transaction/flashback.c
+++ b/src/transaction/flashback.c
@@ -459,6 +459,13 @@ flashback_make_summary_list (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEXT 
 		{
 		  memcpy (&classoid, supplement_data, sizeof (OID));
 
+		  if (oid_is_system_class (&classoid))
+		    {
+		      /* while creating database, there is no information about system class in server
+		       * so that supplemental log can be logged */
+		      break;
+		    }
+
                   // *INDENT-OFF*
 		  if (std::find (context->classoids.begin(), context->classoids.end(), classoid) == context->classoids.end())
 		    {

--- a/src/transaction/flashback.c
+++ b/src/transaction/flashback.c
@@ -459,6 +459,8 @@ flashback_make_summary_list (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEXT 
 		{
 		  memcpy (&classoid, supplement_data, sizeof (OID));
 
+		  assert (oid_is_system_class (&classoid) == false);
+
                   // *INDENT-OFF*
 		  if (std::find (context->classoids.begin(), context->classoids.end(), classoid) == context->classoids.end())
 		    {

--- a/src/transaction/flashback.c
+++ b/src/transaction/flashback.c
@@ -459,13 +459,6 @@ flashback_make_summary_list (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEXT 
 		{
 		  memcpy (&classoid, supplement_data, sizeof (OID));
 
-		  if (oid_is_system_class (&classoid))
-		    {
-		      /* while creating database, there is no information about system class in server
-		       * so that supplemental log can be logged */
-		      break;
-		    }
-
                   // *INDENT-OFF*
 		  if (std::find (context->classoids.begin(), context->classoids.end(), classoid) == context->classoids.end())
 		    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24268

Purpose

Fix the bug where transactions for system classes could appear in the flashback summary.

Implementation

turn off supplemental_log parameter when creating database (createdb)