### PR TITLE
[CBRD-24283] Fix complie warning in msg files

### DIFF
--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -152,7 +152,7 @@ Available service's utilities:\n\
     service\n\
     server\n\
     broker\n\
-    gateway\n\	
+    gateway\n\
     manager\n\
     heartbeat\n\
     javasp\n\

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -152,7 +152,7 @@ Servizi disponibili:\n\
     service\n\
     server\n\
     broker\n\
-    gateway\n\	
+    gateway\n\
     manager\n\
     heartbeat\n\
     javasp\n\

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -152,7 +152,7 @@ cubrid 管理者ユーティリティー、バージョン　%1$s\n\
     service\n\
     server\n\
     broker\n\
-    gateway\n\	
+    gateway\n\
     manager\n\
     heartbeat\n\
     javasp\n\


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24283

Purpose
Compilation warning occurred in the modified msg file.
This is because a blank was put at the end of the appended message.

Implementation
N/A

Remarks
N/A