### PR TITLE
[CBRD-24281] [Regression] [isolation] In isolation level repeatable read, the select  result of client2 is different from the previous version.

### DIFF
--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -1944,20 +1944,6 @@ db_get_user_name (void)
 }
 
 /*
- * db_get_current_user_name() - Get the user name currently connected.
- *    return: output buffer pointer or NULL on error
- *    buf(out): output buffer
- *    buf_size(in): output buffer length
- */
-char *
-db_get_current_user_name (char *buf, int buf_size)
-{
-  CHECK_CONNECT_NULL ();
-
-  return au_current_user_name (buf, buf_size);
-}
-
-/*
  * db_get_user_and_host_name() - This returns the name of the user that is
  *    currently logged in and the host name. Format for return value is
  *    user_name@host_name

--- a/src/compat/dbi.h
+++ b/src/compat/dbi.h
@@ -133,7 +133,6 @@ extern "C"
 /* Authorization */
   extern DB_OBJECT *db_get_user (void);
   extern DB_OBJECT *db_get_owner (DB_OBJECT * classobj);
-  extern char *db_get_current_user_name (char *buf, int buf_size);
   extern char *db_get_user_name (void);
   extern char *db_get_user_and_host_name (void);
   extern DB_OBJECT *db_find_user (const char *name);

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -1484,7 +1484,7 @@ ldr_find_class_by_query (const char *name, char *buf, int buf_size)
   DB_VALUE value;
   const char *query = NULL;
   char query_buf[QUERY_BUF_SIZE] = { '\0' };
-  char current_user_name[DB_MAX_USER_LENGTH] = { '\0' };
+  const char *current_schema_name = NULL;
   const char *class_name = NULL;
   int error = NO_ERROR;
 
@@ -1500,16 +1500,12 @@ ldr_find_class_by_query (const char *name, char *buf, int buf_size)
 
   assert (buf != NULL);
 
-  if (db_get_current_user_name (current_user_name, DB_MAX_USER_LENGTH) == NULL)
-    {
-      ASSERT_ERROR_AND_SET (error);
-      return error;
-    }
+  current_schema_name = sc_current_schema_name ();
 
   class_name = sm_remove_qualifier_name (name);
   query = "SELECT [unique_name] FROM [%s] WHERE [class_name] = '%s' AND [owner].[name] != UPPER ('%s')";
-  assert (QUERY_BUF_SIZE > snprintf (NULL, 0, query, CT_CLASS_NAME, class_name, current_user_name));
-  snprintf (query_buf, QUERY_BUF_SIZE, query, CT_CLASS_NAME, class_name, current_user_name);
+  assert (QUERY_BUF_SIZE > snprintf (NULL, 0, query, CT_CLASS_NAME, class_name, current_schema_name));
+  snprintf (query_buf, QUERY_BUF_SIZE, query, CT_CLASS_NAME, class_name, current_schema_name);
   assert (query_buf[0] != '\0');
 
   error = db_compile_and_execute_local (query_buf, &query_result, &query_error);

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -7146,8 +7146,6 @@ au_perform_login (const char *name, const char *password, bool ignore_dba_privil
 		{
 		  error = AU_SET_USER (user);
 
-		  error = sc_set_current_schema (user);
-
 		  /* necessary to invalidate vclass cache */
 		  sm_bump_local_schema_version ();
 		}

--- a/src/object/authenticate.h
+++ b/src/object/authenticate.h
@@ -202,7 +202,6 @@ extern int au_drop_user (MOP user);
 extern int au_set_password (MOP user, const char *password);
 extern int au_set_user_comment (MOP user, const char *comment);
 
-extern char *au_current_user_name (char *buf, int buf_size);
 extern const char *au_user_name (void);
 extern char *au_user_name_dup (void);
 extern bool au_has_user_name (void);

--- a/src/object/object_print.c
+++ b/src/object/object_print.c
@@ -392,7 +392,7 @@ help_class_names (const char *qualifier)
 		      tmp = db_get_string (&owner_name);
 		      if (tmp)
 			{
-			  snprintf (buffer, sizeof (buffer) - 1, "%s.%s", tmp, cname);
+			  snprintf (buffer, sizeof (buffer) - 1, "%s.%s", tmp, sm_remove_qualifier_name (cname));
 			}
 		      else
 			{

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -497,7 +497,6 @@ sc_set_current_schema (MOP user)
   return error;
 }
 
-#if defined(ENABLE_UNUSED_FUNCTION)
 /*
  * sc_current_schema_name() - Returns current schema name which is
  *                            the default qualifier for otherwise
@@ -505,13 +504,11 @@ sc_set_current_schema (MOP user)
  *      return: pointer to current schema name
  *
  */
-
-static const char *
+const char *
 sc_current_schema_name (void)
 {
   return (const char *) &(Current_Schema.name);
 }
-#endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
  * sm_add_static_method() - Adds an element to the static link table.
@@ -2184,7 +2181,7 @@ char *
 sm_user_specified_name (const char *name, char *buf, int buf_size)
 {
   char user_specified_name[SM_MAX_IDENTIFIER_LENGTH] = { '\0' };
-  char current_user_name[SM_MAX_USER_LENGTH] = { '\0' };
+  const char *current_schema_name = NULL;
   const char *dot = NULL;
   int error = NO_ERROR;
 
@@ -2217,21 +2214,16 @@ sm_user_specified_name (const char *name, char *buf, int buf_size)
       return sm_downcase_name (name, buf, buf_size);
     }
 
-  /* Appends the current username, making it a user-specified name. */
-  if (db_get_current_user_name (current_user_name, SM_MAX_USER_LENGTH) == NULL)
-    {
-      ASSERT_ERROR ();
-      return NULL;
-    }
+  current_schema_name = sc_current_schema_name ();
 
-  assert (snprintf (NULL, 0, "%s.%s", current_user_name, name) < buf_size);
-  assert (snprintf (NULL, 0, "%s.%s", current_user_name, name) < SM_MAX_IDENTIFIER_LENGTH);
+  assert (snprintf (NULL, 0, "%s.%s", current_schema_name, name) < buf_size);
+  assert (snprintf (NULL, 0, "%s.%s", current_schema_name, name) < SM_MAX_IDENTIFIER_LENGTH);
 
   /*
    * e.g.   name: object_name
    *      return: current_user_name.object_name
    */
-  snprintf (user_specified_name, SM_MAX_IDENTIFIER_LENGTH, "%s.%s", current_user_name, name);
+  snprintf (user_specified_name, SM_MAX_IDENTIFIER_LENGTH, "%s.%s", current_schema_name, name);
   return sm_downcase_name (user_specified_name, buf, buf_size);
 }
 

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -472,14 +472,14 @@ sc_set_current_schema (MOP user)
   int error = ER_FAILED;
   char *wsp_user_name;
 
-  Current_Schema.name[0] = '\0';
-  Current_Schema.owner = user;
   wsp_user_name = au_get_user_name (user);
-
   if (wsp_user_name == NULL)
     {
       return error;
     }
+
+  Current_Schema.name[0] = '\0';
+  Current_Schema.owner = user;
 
   /* As near as I can tell, this is the most generalized */
   /* case conversion function on our system.  If it's not */

--- a/src/object/schema_manager.h
+++ b/src/object/schema_manager.h
@@ -317,6 +317,7 @@ extern int classobj_drop_foreign_key_ref (DB_SEQ ** properties, const BTID * bti
 
 /* currently this is a private function to be called only by AU_SET_USER */
 extern int sc_set_current_schema (MOP user);
+extern const char *sc_current_schema_name (void);
 /* Obtain (pointer to) current schema name.                            */
 
 extern int sm_has_non_null_attribute (SM_ATTRIBUTE ** attrs);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10183,7 +10183,6 @@ pt_set_user_specified_name (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, 
   const char *original_name = NULL;
   const char *resolved_name = NULL;
   char downcase_resolved_name[DB_MAX_USER_LENGTH] = { '\0' };
-  char current_user_name[DB_MAX_USER_LENGTH] = { '\0' };
   const char *user_specified_name = NULL;
 
   if (parser == NULL || node == NULL)
@@ -10266,13 +10265,7 @@ pt_set_user_specified_name (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, 
 
   if (resolved_name == NULL || resolved_name[0] == '\0')
     {
-      if (db_get_current_user_name (current_user_name, DB_MAX_USER_LENGTH) == NULL)
-	{
-	  ASSERT_ERROR ();
-	  return node;
-	}
-
-      resolved_name = current_user_name;
+      resolved_name = sc_current_schema_name ();
     }
   else if (intl_identifier_lower_string_size (resolved_name) >= DB_MAX_USER_LENGTH)
     {
@@ -10372,7 +10365,7 @@ pt_get_name_without_current_user_name (const char *name)
 {
   char *dot = NULL;
   char name_copy[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
-  char current_user_name[DB_MAX_USER_LENGTH] = { '\0' };
+  const char *current_schema_name = NULL;
   const char *object_name = NULL;
   int error = NO_ERROR;
 
@@ -10396,18 +10389,14 @@ pt_get_name_without_current_user_name (const char *name)
       return name;
     }
 
-  if (db_get_current_user_name (current_user_name, DB_MAX_USER_LENGTH) == NULL)
-    {
-      ASSERT_ERROR ();
-      return name;
-    }
+  current_schema_name = sc_current_schema_name ();
 
   dot[0] = '\0';
 
-  if (intl_identifier_casecmp (name_copy, current_user_name) == 0)
+  if (intl_identifier_casecmp (name_copy, current_schema_name) == 0)
     {
       /*
-       * e.g.        name: current_user_name.object_name
+       * e.g.        name: current_schema_name.object_name
        *      object_name: object_name
        */
       object_name = strchr (name, '.') + 1;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -18426,7 +18426,7 @@ do_find_class_by_query (const char *name, char *buf, int buf_size)
   DB_VALUE value;
   const char *query = NULL;
   char query_buf[QUERY_BUF_SIZE] = { '\0' };
-  char current_user_name[DB_MAX_USER_LENGTH] = { '\0' };
+  const char *current_schema_name = NULL;
   const char *class_name = NULL;
   int error = NO_ERROR;
 
@@ -18442,16 +18442,12 @@ do_find_class_by_query (const char *name, char *buf, int buf_size)
 
   assert (buf != NULL);
 
-  if (db_get_current_user_name (current_user_name, DB_MAX_USER_LENGTH) == NULL)
-    {
-      ASSERT_ERROR_AND_SET (error);
-      return error;
-    }
+  current_schema_name = sc_current_schema_name ();
 
   class_name = sm_remove_qualifier_name (name);
   query = "SELECT [unique_name] FROM [%s] WHERE [class_name] = '%s' AND [owner].[name] != UPPER ('%s')";
-  assert (QUERY_BUF_SIZE > snprintf (NULL, 0, query, CT_CLASS_NAME, class_name, current_user_name));
-  snprintf (query_buf, QUERY_BUF_SIZE, query, CT_CLASS_NAME, class_name, current_user_name);
+  assert (QUERY_BUF_SIZE > snprintf (NULL, 0, query, CT_CLASS_NAME, class_name, current_schema_name));
+  snprintf (query_buf, QUERY_BUF_SIZE, query, CT_CLASS_NAME, class_name, current_schema_name);
   assert (query_buf[0] != '\0');
 
   error = db_compile_and_execute_local (query_buf, &query_result, &query_error);
@@ -18522,7 +18518,7 @@ do_find_serial_by_query (const char *name, char *buf, int buf_size)
   DB_VALUE value;
   const char *query = NULL;
   char query_buf[QUERY_BUF_SIZE] = { '\0' };
-  char current_user_name[DB_MAX_USER_LENGTH] = { '\0' };
+  const char *current_schema_name = NULL;
   const char *serial_name = NULL;
   int error = NO_ERROR;
 
@@ -18538,16 +18534,12 @@ do_find_serial_by_query (const char *name, char *buf, int buf_size)
 
   assert (buf != NULL);
 
-  if (db_get_current_user_name (current_user_name, DB_MAX_USER_LENGTH) == NULL)
-    {
-      ASSERT_ERROR_AND_SET (error);
-      return error;
-    }
+  current_schema_name = sc_current_schema_name ();
 
   serial_name = sm_remove_qualifier_name (name);
   query = "SELECT [unique_name] FROM [%s] WHERE [name] = '%s' AND [owner].[name] != UPPER ('%s')";
-  assert (QUERY_BUF_SIZE > snprintf (NULL, 0, query, CT_SERIAL_NAME, serial_name, current_user_name));
-  snprintf (query_buf, QUERY_BUF_SIZE, query, CT_SERIAL_NAME, serial_name, current_user_name);
+  assert (QUERY_BUF_SIZE > snprintf (NULL, 0, query, CT_SERIAL_NAME, serial_name, current_schema_name));
+  snprintf (query_buf, QUERY_BUF_SIZE, query, CT_SERIAL_NAME, serial_name, current_schema_name);
   assert (query_buf[0] != '\0');
 
   error = db_compile_and_execute_local (query_buf, &query_result, &query_error);
@@ -18625,7 +18617,7 @@ do_find_trigger_by_query (const char *name, char *buf, int buf_size)
   DB_VALUE value;
   const char *query = NULL;
   char query_buf[QUERY_BUF_SIZE] = { '\0' };
-  char current_user_name[DB_MAX_USER_LENGTH] = { '\0' };
+  const char *current_schema_name = NULL;
   const char *trigger_name = NULL;
   int error = NO_ERROR;
 
@@ -18641,16 +18633,12 @@ do_find_trigger_by_query (const char *name, char *buf, int buf_size)
 
   assert (buf != NULL);
 
-  if (db_get_current_user_name (current_user_name, DB_MAX_USER_LENGTH) == NULL)
-    {
-      ASSERT_ERROR_AND_SET (error);
-      return error;
-    }
+  current_schema_name = sc_current_schema_name ();
 
   trigger_name = sm_remove_qualifier_name (name);
   query = "SELECT [unique_name] FROM [%s] WHERE [name] = '%s' AND [owner].[name] != UPPER ('%s')";
-  assert (QUERY_BUF_SIZE > snprintf (NULL, 0, query, CT_TRIGGER_NAME, trigger_name, current_user_name));
-  snprintf (query_buf, QUERY_BUF_SIZE, query, CT_TRIGGER_NAME, trigger_name, current_user_name);
+  assert (QUERY_BUF_SIZE > snprintf (NULL, 0, query, CT_TRIGGER_NAME, trigger_name, current_schema_name));
+  snprintf (query_buf, QUERY_BUF_SIZE, query, CT_TRIGGER_NAME, trigger_name, current_schema_name);
   assert (query_buf[0] != '\0');
 
   error = db_compile_and_execute_local (query_buf, &query_result, &query_error);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24281

When creating a user-specified name, the current schema name is checked instead of the current user name.