### PR TITLE
[CBRD-24268] Turn off the supplemental log parameter when createdb (backport  #3511)

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -593,6 +593,7 @@ createdb (UTIL_FUNCTION_ARG * arg)
   sysprm_set_force (prm_get_name (PRM_ID_PB_NBUFFERS), "1024");
   sysprm_set_force (prm_get_name (PRM_ID_XASL_CACHE_MAX_ENTRIES), "-1");
   sysprm_set_force (prm_get_name (PRM_ID_JAVA_STORED_PROCEDURE), "no");
+  sysprm_set_force (prm_get_name (PRM_ID_SUPPLEMENTAL_LOG), "0");
 
   AU_DISABLE_PASSWORDS ();
   db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24268

Purpose

Supplemental log can be logged for system classes while creating database,
because there is no information about system classes in the server when initializing database. 

backport #3511 to 11.1
