### PR TITLE
[LETS-210] Logging b-tree operations for atomic replication: btree_key_remove_object_and_keep_visible_first

### DIFF
--- a/src/base/stack_dump.c
+++ b/src/base/stack_dump.c
@@ -377,8 +377,9 @@ er_dump_call_stack_internal (print_output & output)
   char buffer[BUFFER_SIZE];
 
   trace_count = backtrace (return_addr, MAX_TRACE);
+  trace_count = (17 < trace_count) ? 17 : trace_count;
 
-  for (i = 0; i < trace_count; i++)
+  for (i = 3; i < trace_count; i++)
     {
       if (dladdr (return_addr[i], &dl_info) == 0)
 	{
@@ -410,7 +411,8 @@ er_dump_call_stack_internal (print_output & output)
 	    }
 	}
 
-      output ("%s(%p): %s\n", dl_info.dli_fname, func_addr_p, func_name_p);
+      //output ("%s(%p): %s\n", dl_info.dli_fname, func_addr_p, func_name_p);
+      output ("(%p): %s\n", func_addr_p, func_name_p);
     }
 
   output.flush ();

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -28598,7 +28598,7 @@ btree_key_relocate_last_into_ovf (THREAD_ENTRY * thread_p, BTID_INT * btid_int, 
   assert (offset_to_last_object > 0);
 
   /* We need to change leaf page and at least one overflow page. Start a system operation. */
-  log_sysop_start (thread_p);
+  log_sysop_start_atomic (thread_p);
   insert_helper->is_system_op_started = true;
 
   /* Copy last object into an overflow page. */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -27751,7 +27751,7 @@ btree_key_insert_new_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_VALUE
     {
       key_type = BTREE_OVERFLOW_KEY;
 
-      log_sysop_start (thread_p);
+      log_sysop_start_atomic (thread_p);
       insert_helper->is_system_op_started = true;
     }
   else
@@ -28693,7 +28693,7 @@ exit:
 }
 
 /*
- * btree_key_relocate_last_into_ovf () - Append a new object in overflow OID's pages.
+ * btree_key_append_object_into_ovf () - Append a new object in overflow OID's pages.
  *
  * return		 : Error code.
  * thread_p (in)	 : Thread entry.

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -31864,11 +31864,7 @@ btree_overflow_remove_object (THREAD_ENTRY * thread_p, DB_VALUE * key, BTID_INT 
        * If started in a parent context, it is up to the parent context to end it */
       if (delete_helper->is_system_op_started && !save_system_op_started)
 	{
-	  // only end sysop if started in current function
 	  btree_delete_sysop_end (thread_p, delete_helper);
-	  // TODO: restore is_system_op_started?
-	  // TODO: if not reset, will lead to another sysop end being added in calling function
-	  // double sysop end will broke atomic replication
 	}
     }
   else
@@ -31894,15 +31890,14 @@ btree_overflow_remove_object (THREAD_ENTRY * thread_p, DB_VALUE * key, BTID_INT 
   return NO_ERROR;
 
 error:
+  /* End system operation. Only if started in current context.
+   * If started in a parent context, it is up to the parent context to end it */
   if (delete_helper->is_system_op_started && !save_system_op_started)
     {
       assert (delete_helper->purpose != BTREE_OP_DELETE_UNDO_INSERT
 	      && delete_helper->purpose != BTREE_OP_DELETE_UNDO_INSERT_UNQ_MULTIUPD
 	      && delete_helper->purpose != BTREE_OP_DELETE_OBJECT_PHYSICAL_POSTPONED);
-      // only end sysop if started in current function
       btree_delete_sysop_end (thread_p, delete_helper);
-      // TODO: restore is_system_op_started?
-      // TODO: if not reset, will lead to another sysop end being added in calling function
     }
   assert_release (error_code != NO_ERROR);
   return error_code;

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1573,6 +1573,15 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 	  /* atomic system operation finished. */
 	  tdes->rcv.set_atomic_sysop_start_lsa (NULL_LSA);
 	}
+      else
+        {
+	  _er_log_debug (ARG_FILE_LINE,
+			 "CRSDBG: prior_lsa_next_record_internal LOG_SYSOP_START_POSTPONE ELSE_NOT\n"
+			 " sysop_start_postpone->sysop_end.lastparent_lsa=(%lld|%d)\n"
+			 " tdes->rcv.get_atomic_sysop_start_lsa=(%lld|%d)\n",
+			 LSA_AS_ARGS (&sysop_start_postpone->sysop_end.lastparent_lsa),
+			 LSA_AS_ARGS (&tdes->rcv.get_atomic_sysop_start_lsa ()));
+        }
 
       /* for correct checkpoint, this state change must be done under the protection of prior_lsa_mutex */
       tdes->state = TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE;
@@ -1584,12 +1593,22 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
       LOG_REC_SYSOP_END *sysop_end = NULL;
 
       sysop_end = (LOG_REC_SYSOP_END *) node->data_header;
+      // TODO: log this condition here; it might be the cause that atomic_sysop_start_lsa is not reset
       if (!LSA_ISNULL (&tdes->rcv.get_atomic_sysop_start_lsa ())
 	  && LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.get_atomic_sysop_start_lsa ()))
 	{
 	  /* atomic system operation finished. */
 	  tdes->rcv.set_atomic_sysop_start_lsa (NULL_LSA);
 	}
+      else
+        {
+	  _er_log_debug (ARG_FILE_LINE,
+			 "CRSDBG: prior_lsa_next_record_internal LOG_SYSOP_END ELSE_NOT\n"
+			 " sysop_end->lastparent_lsa=(%lld|%d)\n"
+			 " tdes->rcv.get_atomic_sysop_start_lsa=(%lld|%d)\n",
+			 LSA_AS_ARGS (&sysop_end->lastparent_lsa),
+			 LSA_AS_ARGS (&tdes->rcv.get_atomic_sysop_start_lsa ()));
+        }
       if (!LSA_ISNULL (&tdes->rcv.sysop_start_postpone_lsa)
 	  && LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.sysop_start_postpone_lsa))
 	{

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1568,10 +1568,10 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
       tdes->rcv.sysop_start_postpone_lsa = start_lsa;
 
       sysop_start_postpone = (LOG_REC_SYSOP_START_POSTPONE *) node->data_header;
-      if (LSA_LT (&sysop_start_postpone->sysop_end.lastparent_lsa, &tdes->rcv.atomic_sysop_start_lsa))
+      if (LSA_LT (&sysop_start_postpone->sysop_end.lastparent_lsa, &tdes->rcv.get_atomic_sysop_start_lsa ()))
 	{
 	  /* atomic system operation finished. */
-	  LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
+	  tdes->rcv.set_atomic_sysop_start_lsa (NULL_LSA);
 	}
 
       /* for correct checkpoint, this state change must be done under the protection of prior_lsa_mutex */
@@ -1584,11 +1584,11 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
       LOG_REC_SYSOP_END *sysop_end = NULL;
 
       sysop_end = (LOG_REC_SYSOP_END *) node->data_header;
-      if (!LSA_ISNULL (&tdes->rcv.atomic_sysop_start_lsa)
-	  && LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.atomic_sysop_start_lsa))
+      if (!LSA_ISNULL (&tdes->rcv.get_atomic_sysop_start_lsa ())
+	  && LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.get_atomic_sysop_start_lsa ()))
 	{
 	  /* atomic system operation finished. */
-	  LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
+	  tdes->rcv.set_atomic_sysop_start_lsa (NULL_LSA);
 	}
       if (!LSA_ISNULL (&tdes->rcv.sysop_start_postpone_lsa)
 	  && LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.sysop_start_postpone_lsa))
@@ -1605,8 +1605,8 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
   else if (node->log_header.type == LOG_SYSOP_ATOMIC_START)
     {
       /* same as with system op start postpone, we need to save these log records lsa */
-      assert (LSA_ISNULL (&tdes->rcv.atomic_sysop_start_lsa));
-      tdes->rcv.atomic_sysop_start_lsa = start_lsa;
+      assert (LSA_ISNULL (&tdes->rcv.get_atomic_sysop_start_lsa ()));
+      tdes->rcv.set_atomic_sysop_start_lsa (start_lsa);
     }
   else if (node->log_header.type == LOG_COMMIT || node->log_header.type == LOG_ABORT)
     {

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -70,8 +70,6 @@ static int prior_lsa_copy_redo_crumbs_to_node (LOG_PRIOR_NODE *node, int num_cru
 static void prior_lsa_start_append (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_TDES *tdes);
 static void prior_lsa_end_append (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node);
 static void prior_lsa_append_data (int length);
-//STATIC_INLINE void prior_extract_vacuum_info_from_prior_node (const LOG_PRIOR_NODE *node,
-//    LOG_VACUUM_INFO *&dest_vacuum_info, MVCCID &mvccid);
 static LOG_LSA prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_TDES *tdes,
     int with_lock);
 static void prior_update_header_mvcc_info (const LOG_LSA &record_lsa, MVCCID mvccid);
@@ -1452,41 +1450,6 @@ prior_update_header_mvcc_info (const LOG_LSA &record_lsa, MVCCID mvccid)
   log_Gl.hdr.does_block_need_vacuum = true;
 }
 
-//STATIC_INLINE void
-//prior_extract_vacuum_info_from_prior_node (const LOG_PRIOR_NODE *node, LOG_VACUUM_INFO *&dest_vacuum_info,
-//    MVCCID &mvccid)
-//{
-//  dest_vacuum_info = nullptr;
-//  mvccid = MVCCID_NULL;
-
-//  if (node->log_header.type == LOG_MVCC_UNDO_DATA)
-//    {
-//      /* Read from mvcc_undo structure */
-//      LOG_REC_MVCC_UNDO *const mvcc_undo = (LOG_REC_MVCC_UNDO *) node->data_header;
-//      dest_vacuum_info = &mvcc_undo->vacuum_info;
-//      mvccid = mvcc_undo->mvccid;
-//    }
-//  else if (node->log_header.type == LOG_MVCC_UNDOREDO_DATA || node->log_header.type == LOG_MVCC_DIFF_UNDOREDO_DATA)
-//    {
-//      /* Read for mvcc_undoredo structure */
-//      LOG_REC_MVCC_UNDOREDO *const mvcc_undoredo = (LOG_REC_MVCC_UNDOREDO *) node->data_header;
-//      dest_vacuum_info = &mvcc_undoredo->vacuum_info;
-//      mvccid = mvcc_undoredo->mvccid;
-//    }
-//  else if (node->log_header.type == LOG_SYSOP_END
-//	   && ((LOG_REC_SYSOP_END *)node->data_header)->type == LOG_SYSOP_END_LOGICAL_MVCC_UNDO)
-//    {
-//      /* Read from mvcc_undo structure */
-//      LOG_REC_MVCC_UNDO *const mvcc_undo = & ((LOG_REC_SYSOP_END *) node->data_header)->mvcc_undo;
-//      dest_vacuum_info = &mvcc_undo->vacuum_info;
-//      mvccid = mvcc_undo->mvccid;
-//    }
-//  else
-//    {
-//      assert ("not an mvcc prior node" == nullptr);
-//    }
-//}
-
 /*
  * prior_lsa_next_record_internal -
  *
@@ -1552,6 +1515,13 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 	  vacuum_info = &mvcc_undo->vacuum_info;
 	  mvccid = mvcc_undo->mvccid;
 
+	  /* reset tdes->rcv.sysop_start_postpone_lsa and tdes->rcv.atomic_sysop_start_lsa, if this system op is not nested.
+	   * we'll use lastparent_lsa to check if system op is nested or not. */
+	  /* TODO:
+	   *  - what if the atomic sysop is nested in another atomic sysop?
+	   *  - this will erase atomic bookkeeping from transaction descriptor;
+	   *  - should, instead of null lsa, a value from the sysop stack be used to replace on tdes recovery
+	   *    info (a value which is not kept yet) */
 	  const LOG_LSA &atomic_sysop_start_lsa = tdes->rcv.get_atomic_sysop_start_lsa ();
 	  if (!LSA_ISNULL (&atomic_sysop_start_lsa) && LSA_LT (&sysop_end->lastparent_lsa, &atomic_sysop_start_lsa))
 	    {
@@ -1640,10 +1610,12 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
     {
       /* reset tdes->rcv.sysop_start_postpone_lsa and tdes->rcv.atomic_sysop_start_lsa, if this system op is not nested.
        * we'll use lastparent_lsa to check if system op is nested or not. */
-      LOG_REC_SYSOP_END *sysop_end = NULL;
-
-      sysop_end = (LOG_REC_SYSOP_END *) node->data_header;
-      // TODO: log this condition here; it might be the cause that atomic_sysop_start_lsa is not reset
+      /* TODO:
+       *  - what if the atomic sysop is nested in another atomic sysop?
+       *  - this will erase atomic bookkeeping from transaction descriptor;
+       *  - should, instead of null lsa, a value from the sysop stack be used to replace on tdes recovery
+       *    info (a value which is not kept yet) */
+      const LOG_REC_SYSOP_END *const sysop_end = (const LOG_REC_SYSOP_END *)node->data_header;
       if (!LSA_ISNULL (&tdes->rcv.get_atomic_sysop_start_lsa ())
 	  && LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.get_atomic_sysop_start_lsa ()))
 	{

--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -226,7 +226,7 @@ namespace cublog
   checkpoint_info::load_checkpoint_topop (log_tdes &tdes)
   {
     if (tdes.trid != NULL_TRANID && (!LSA_ISNULL (&tdes.rcv.sysop_start_postpone_lsa)
-				     || !LSA_ISNULL (&tdes.rcv.atomic_sysop_start_lsa)))
+				     || !LSA_ISNULL (&tdes.rcv.get_atomic_sysop_start_lsa ())))
       {
 	/* this transaction is running system operation postpone or an atomic system operation
 	 * note: we cannot compare tdes->state with TRAN_UNACTIVE_TOPOPE_COMMITTED_WITH_POSTPONE. we are
@@ -238,7 +238,7 @@ namespace cublog
 	sysop_info &chkpt_topop = m_sysops.back ();
 	chkpt_topop.trid = tdes.trid;
 	chkpt_topop.sysop_start_postpone_lsa = tdes.rcv.sysop_start_postpone_lsa;
-	chkpt_topop.atomic_sysop_start_lsa = tdes.rcv.atomic_sysop_start_lsa;
+	chkpt_topop.atomic_sysop_start_lsa = tdes.rcv.get_atomic_sysop_start_lsa ();
       }
   }
 
@@ -369,7 +369,7 @@ namespace cublog
 	  }
 
 	tdes->rcv.sysop_start_postpone_lsa = sysop.sysop_start_postpone_lsa;
-	tdes->rcv.atomic_sysop_start_lsa = sysop.atomic_sysop_start_lsa;
+	tdes->rcv.set_atomic_sysop_start_lsa (sysop.atomic_sysop_start_lsa);
 	if (!sysop.sysop_start_postpone_lsa.is_null ())
 	  {
 	    // Bump the sysop level to save lastparent_lsa and posp_lsa.

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -471,9 +471,39 @@ struct log_rcv_tdes
   /* we need to know if file_perm_alloc or file_perm_dealloc operations have been interrupted. these operation must be
    * executed atomically (all changes applied or all rollbacked) before executing finish all postpones. to know what
    * to abort, we remember the starting LSA of such operation. */
-  LOG_LSA atomic_sysop_start_lsa;
-  LOG_LSA analysis_last_aborted_sysop_lsa;	/* to recover logical redo operation. */
+private:
+    LOG_LSA atomic_sysop_start_lsa;
+public:
+    LOG_LSA analysis_last_aborted_sysop_lsa;	/* to recover logical redo operation. */
   LOG_LSA analysis_last_aborted_sysop_start_lsa;	/* to recover logical redo operation. */
+
+public:
+  // *INDENT-OFF*
+  inline const LOG_LSA & get_atomic_sysop_start_lsa () const
+  {
+    return atomic_sysop_start_lsa;
+  }
+
+  inline void set_atomic_sysop_start_lsa (LOG_LSA new_log_lsa)
+  {
+    if (atomic_sysop_start_lsa.is_null () && !new_log_lsa.is_null ())
+      {
+	er_print_callstack (ARG_FILE_LINE, "CRSDBG: set_atomic_sysop_start_lsa NULL -> (%lld|%d)",
+			    LSA_AS_ARGS (&new_log_lsa));
+      }
+    if (!atomic_sysop_start_lsa.is_null () && new_log_lsa.is_null ())
+      {
+	er_print_callstack (ARG_FILE_LINE, "CRSDBG: set_atomic_sysop_start_lsa (%lld|%d) -> NULL",
+			    LSA_AS_ARGS (&atomic_sysop_start_lsa));
+      }
+    if (!atomic_sysop_start_lsa.is_null () && !new_log_lsa.is_null ())
+      {
+	er_print_callstack (ARG_FILE_LINE, "CRSDBG: set_atomic_sysop_start_lsa (%lld|%d) -> (%lld|%d)",
+			    LSA_AS_ARGS (&atomic_sysop_start_lsa), LSA_AS_ARGS (&new_log_lsa));
+      }
+    atomic_sysop_start_lsa = new_log_lsa;
+  }
+  // *INDENT-ON*
 };
 
 typedef struct log_tdes LOG_TDES;

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -468,10 +468,10 @@ struct log_rcv_tdes
   LOG_LSA sysop_start_postpone_lsa;
   /* we need to know where transaction postpone has started. */
   LOG_LSA tran_start_postpone_lsa;
+private:
   /* we need to know if file_perm_alloc or file_perm_dealloc operations have been interrupted. these operation must be
    * executed atomically (all changes applied or all rollbacked) before executing finish all postpones. to know what
    * to abort, we remember the starting LSA of such operation. */
-private:
     LOG_LSA atomic_sysop_start_lsa;
 public:
     LOG_LSA analysis_last_aborted_sysop_lsa;	/* to recover logical redo operation. */
@@ -484,23 +484,10 @@ public:
     return atomic_sysop_start_lsa;
   }
 
-  inline void set_atomic_sysop_start_lsa (LOG_LSA new_log_lsa)
+  inline void set_atomic_sysop_start_lsa (const LOG_LSA& new_log_lsa)
   {
-    if (atomic_sysop_start_lsa.is_null () && !new_log_lsa.is_null ())
-      {
-	er_print_callstack (ARG_FILE_LINE, "CRSDBG: set_atomic_sysop_start_lsa NULL -> (%lld|%d)",
-			    LSA_AS_ARGS (&new_log_lsa));
-      }
-    if (!atomic_sysop_start_lsa.is_null () && new_log_lsa.is_null ())
-      {
-	er_print_callstack (ARG_FILE_LINE, "CRSDBG: set_atomic_sysop_start_lsa (%lld|%d) -> NULL",
-			    LSA_AS_ARGS (&atomic_sysop_start_lsa));
-      }
-    if (!atomic_sysop_start_lsa.is_null () && !new_log_lsa.is_null ())
-      {
-	er_print_callstack (ARG_FILE_LINE, "CRSDBG: set_atomic_sysop_start_lsa (%lld|%d) -> (%lld|%d)",
-			    LSA_AS_ARGS (&atomic_sysop_start_lsa), LSA_AS_ARGS (&new_log_lsa));
-      }
+    _er_log_debug (ARG_FILE_LINE, "CRSDBG: set_atomic_sysop_start_lsa (%lld|%d) -> (%lld|%d)\n",
+                        LSA_AS_ARGS (&atomic_sysop_start_lsa), LSA_AS_ARGS (&new_log_lsa));
     atomic_sysop_start_lsa = new_log_lsa;
   }
   // *INDENT-ON*

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -486,7 +486,7 @@ public:
 
   inline void set_atomic_sysop_start_lsa (const LOG_LSA& new_log_lsa)
   {
-    _er_log_debug (ARG_FILE_LINE, "CRSDBG: set_atomic_sysop_start_lsa (%lld|%d) -> (%lld|%d)\n",
+    er_print_callstack (ARG_FILE_LINE, "CRSDBG: set_atomic_sysop_start_lsa (%lld|%d) -> (%lld|%d)\n",
                         LSA_AS_ARGS (&atomic_sysop_start_lsa), LSA_AS_ARGS (&new_log_lsa));
     atomic_sysop_start_lsa = new_log_lsa;
   }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -4518,7 +4518,7 @@ log_sysop_attach_to_outer (THREAD_ENTRY * thread_p)
       //  which)
       // - similar logic to this exists in 'log_sysop_commit_internal'
       // TODO: this might be a workaround for an issue whose root cause is elsewhere
-      tdes->rcv.set_atomic_sysop_start_lsa (NULL_LSA);
+      //tdes->rcv.set_atomic_sysop_start_lsa (NULL_LSA);
     }
 
   log_sysop_end_final (thread_p, tdes);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3983,13 +3983,22 @@ log_sysop_start (THREAD_ENTRY * thread_p)
 
   /* NOTE if tdes->topops.last >= 0, there is an already defined top system operation. */
   tdes->topops.last++;
+  // TODO: vague idea: do not copy a newwer tail_lsa as a [atomic] sysop last parent lsa if the stack
+  // already contains one non-null such last parent lsa; this, to allow nested atomic sysop's
   LSA_COPY (&tdes->topops.stack[tdes->topops.last].lastparent_lsa, &tdes->tail_lsa);
   LSA_COPY (&tdes->topop_lsa, &tdes->tail_lsa);
 
   LSA_SET_NULL (&tdes->topops.stack[tdes->topops.last].posp_lsa);
 
-  er_print_callstack (ARG_FILE_LINE, "CRSDBG: log_sysop_start after topops_last++ trid=%d topops_last=%d"
-		      " tdes_tail_lsa=(%lld|%d)\n", tdes->trid, tdes->topops.last, LSA_AS_ARGS (&tdes->tail_lsa));
+  er_print_callstack (ARG_FILE_LINE,
+		      "CRSDBG: log_sysop_start after topops_last++ tdes_trid=%d tdes_topops_last=%d tdes_tail_lsa=(%lld|%d)\n",
+		      tdes->trid, tdes->topops.last, LSA_AS_ARGS (&tdes->tail_lsa));
+  for (int topop_index = 0; topop_index <= tdes->topops.last; ++topop_index)
+    {
+      _er_log_debug ("iterate", 0, "CRSDBG: topop_index=%d lastparent_lsa=(%lld|%d), posp_lsa=(%lld|%d)\n",
+		     topop_index, LSA_AS_ARGS (&tdes->topops.stack[topop_index].lastparent_lsa),
+		     LSA_AS_ARGS (&tdes->topops.stack[topop_index].posp_lsa));
+    }
   log_dump_log_rcv_tdes (tdes->rcv, "called from log_sysop_start");
 
   perfmon_inc_stat (thread_p, PSTAT_TRAN_NUM_START_TOPOPS);
@@ -4020,13 +4029,6 @@ log_sysop_start_atomic (THREAD_ENTRY * thread_p)
     {
       er_print_callstack (ARG_FILE_LINE, "CRSDBG: log_sysop_start_atomic IF trid=%d topops_last=%d\n",
 			  tdes->trid, tdes->topops.last);
-      for (int topop_index = 0; topop_index <= tdes->topops.last; ++topop_index)
-	{
-	  _er_log_debug ("iterate", 0, "CRSDBG: log_sysop_start_atomic IF\n"
-			 " topop_index=%d lastparent_lsa=(%lld|%d), posp_lsa=(%lld|%d)\n",
-			 topop_index, LSA_AS_ARGS (&tdes->topops.stack[topop_index].lastparent_lsa),
-			 LSA_AS_ARGS (&tdes->topops.stack[topop_index].posp_lsa));
-	}
       log_dump_log_rcv_tdes (tdes->rcv, "from log_sysop_start_atomic IF");
 
       LOG_PRIOR_NODE *node =
@@ -4048,13 +4050,6 @@ log_sysop_start_atomic (THREAD_ENTRY * thread_p)
       er_print_callstack (ARG_FILE_LINE, "CRSDBG: log_sysop_start_atomic ELSE trid=%d\n"
 			  " current_sysop_start_lsa=(%lld|%d) topops_last=%d\n",
 			  tdes->trid, LSA_AS_ARGS (&current_sysop_start_lsa), tdes->topops.last);
-      for (int topop_index = 0; topop_index <= tdes->topops.last; ++topop_index)
-	{
-	  _er_log_debug ("iterate", 0, "CRSDBG: log_sysop_start_atomic ELSE\n"
-			 " topop_index=%d lastparent_lsa=(%lld|%d), posp_lsa=(%lld|%d)\n",
-			 topop_index, LSA_AS_ARGS (&tdes->topops.stack[topop_index].lastparent_lsa),
-			 LSA_AS_ARGS (&tdes->topops.stack[topop_index].posp_lsa));
-	}
       log_dump_log_rcv_tdes (tdes->rcv, "from log_sysop_start_atomic ELSE");
 
       /* this must be a nested atomic system operation. If parent is atomic, we'll be atomic too. */
@@ -4131,6 +4126,12 @@ log_sysop_end_unstack (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
     }
   er_print_callstack (ARG_FILE_LINE, "CRSDBG: log_sysop_end_unstack after topops_last-- trid=%d topops_last=%d\n",
 		      tdes->trid, tdes->topops.last);
+  for (int topop_index = 0; topop_index <= tdes->topops.last; ++topop_index)
+    {
+      _er_log_debug ("iterate", 0, "CRSDBG: topop_index=%d lastparent_lsa=(%lld|%d), posp_lsa=(%lld|%d)\n",
+		     topop_index, LSA_AS_ARGS (&tdes->topops.stack[topop_index].lastparent_lsa),
+		     LSA_AS_ARGS (&tdes->topops.stack[topop_index].posp_lsa));
+    }
   log_dump_log_rcv_tdes (tdes->rcv, "called from log_sysop_end_unstack");
 }
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3481,7 +3481,7 @@ log_pack_log_boot_info (THREAD_ENTRY &thread_r, std::string &payload_in_out,
   log_lsa append_lsa;
   log_lsa prev_lsa;
   log_lsa most_recent_trantable_snapshot_lsa;
-  
+
   {
     LOG_CS_ENTER_READ_MODE (&thread_r);
     scope_exit log_cs_exit_ftor ([&thread_r] { LOG_CS_EXIT (&thread_r); });
@@ -4229,7 +4229,8 @@ log_sysop_commit_internal (THREAD_ENTRY * thread_p, LOG_REC_SYSOP_END * log_reco
        * we don't actually allow empty logical system operation because it might hide a logic flaw. however, there are
        * unusual cases when a logical operation does not really require logging (see RVPGBUF_FLUSH_PAGE). if you create
        * such a case, you should add a dummy log record to trick this assert. */
-      assert (!LSA_ISNULL (&tdes->tail_lsa) && LSA_GT (&tdes->tail_lsa, &tdes->topops.stack[tdes->topops.last].lastparent_lsa));
+      assert (!LSA_ISNULL (&tdes->tail_lsa)
+	      && LSA_GT (&tdes->tail_lsa, &tdes->topops.stack[tdes->topops.last].lastparent_lsa));
 
       /* now that we have access to tdes, we can do some updates on log record and sanity checks */
       if (log_record->type == LOG_SYSOP_END_LOGICAL_RUN_POSTPONE)
@@ -12895,7 +12896,7 @@ cdc_find_primary_key (THREAD_ENTRY * thread_p, OID classoid, int repr_id, int *n
 
   for (int i = 0; i < rep->n_indexes; i++)
     {
-      index = rep->indexes + i;	//REVIEW : array? 
+      index = rep->indexes + i;	//REVIEW : array?
       if (index->type == BTREE_PRIMARY_KEY)
 	{
 	  has_pk = 1;
@@ -12959,7 +12960,7 @@ cdc_make_error_loginfo (int trid, char *user, CDC_DML_TYPE dml_type, OID classoi
     }
 
   ptr = start_ptr = PTR_ALIGN (loginfo_buf, MAX_ALIGNMENT);
-  ptr = or_pack_int (ptr, 0);	//dummy for log info length 
+  ptr = or_pack_int (ptr, 0);	//dummy for log info length
   ptr = or_pack_int (ptr, trid);
   ptr = or_pack_string (ptr, user);
   ptr = or_pack_int (ptr, dataitem_type);
@@ -13257,7 +13258,7 @@ cdc_make_dml_loginfo (THREAD_ENTRY * thread_p, int trid, char *user, CDC_DML_TYP
 	    {
 	      if (cdc_compare_undoredo_dbvalue (&new_values[i], &old_values[i]) > 0)
 		{
-		  changed_col_idx[cnt++] = i;	//TODO: replace i with def_order to reduce memory alloc and copy 
+		  changed_col_idx[cnt++] = i;	//TODO: replace i with def_order to reduce memory alloc and copy
 		}
 	    }
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3996,7 +3996,7 @@ log_sysop_start_atomic (THREAD_ENTRY * thread_p)
       assert_release (false);
       return;
     }
-  if (LSA_ISNULL (&tdes->rcv.atomic_sysop_start_lsa))
+  if (LSA_ISNULL (&tdes->rcv.get_atomic_sysop_start_lsa ()))
     {
       LOG_PRIOR_NODE *node =
 	prior_lsa_alloc_and_copy_data (thread_p, LOG_SYSOP_ATOMIC_START, RV_NOT_DEFINED, NULL, 0, NULL, 0, NULL);

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -905,6 +905,9 @@ log_rv_analysis_sysop_start_postpone (THREAD_ENTRY *thread_p, int tran_id, LOG_L
   if (tdes->topops.last == -1)
     {
       tdes->topops.last++;
+      er_print_callstack (ARG_FILE_LINE,
+			  "CRSDBG: log_rv_analysis_sysop_start_postpone topops_last++ trid=%d topops_last=%d\n",
+			  tdes->trid, tdes->topops.last);
     }
   else
     {

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1581,7 +1581,7 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 
   LSA_SET_NULL (&tdes->rcv.tran_start_postpone_lsa);
   LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
-  LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
+  tdes->rcv.set_atomic_sysop_start_lsa (NULL_LSA);
   LSA_SET_NULL (&tdes->rcv.analysis_last_aborted_sysop_lsa);
   LSA_SET_NULL (&tdes->rcv.analysis_last_aborted_sysop_start_lsa);
 }
@@ -1682,7 +1682,7 @@ logtb_initialize_tdes (LOG_TDES * tdes, int tran_index)
 
   LSA_SET_NULL (&tdes->rcv.tran_start_postpone_lsa);
   LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
-  LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
+  tdes->rcv.set_atomic_sysop_start_lsa (NULL_LSA);
   LSA_SET_NULL (&tdes->rcv.analysis_last_aborted_sysop_lsa);
   LSA_SET_NULL (&tdes->rcv.analysis_last_aborted_sysop_start_lsa);
 }

--- a/src/transaction/transaction_sr.c
+++ b/src/transaction/transaction_sr.c
@@ -273,11 +273,15 @@ xtran_server_end_topop (THREAD_ENTRY * thread_p, LOG_RESULT_TOPOP result, LOG_LS
 	}
       if (result == LOG_RESULT_TOPOP_COMMIT)
 	{
+          _er_log_debug (ARG_FILE_LINE, "CRSDBG: xtran_server_end_topop result=%d topop_lsa=(%lld|%d)\n",
+                         result, LSA_AS_ARGS (topop_lsa));
 	  log_sysop_commit (thread_p);
 	  state = TRAN_UNACTIVE_COMMITTED;
 	}
       else
 	{
+          _er_log_debug (ARG_FILE_LINE, "CRSDBG: xtran_server_end_topop result=%d topop_lsa=(%lld|%d)\n",
+                         result, LSA_AS_ARGS (topop_lsa));
 	  log_sysop_abort (thread_p);
 	  state = TRAN_UNACTIVE_ABORTED;
 	}
@@ -292,10 +296,12 @@ xtran_server_end_topop (THREAD_ENTRY * thread_p, LOG_RESULT_TOPOP result, LOG_LS
       break;
 
     case LOG_RESULT_TOPOP_ATTACH_TO_OUTER:
-    default:
+      _er_log_debug (ARG_FILE_LINE, "CRSDBG: xtran_server_end_topop result=%d\n", result);
       log_sysop_attach_to_outer (thread_p);
       state = tdes->state;
       break;
+    default:
+      assert ("other LOG_RESULT_TOPOP not implemented" == nullptr);
     }
 
   er_stack_pop ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-210

Change the order of b-tree operations to achieve a top-down approach/first-to-last approach.
