### PR TITLE
[CBRD-24295] Gateway allows connections only to DBLink Server

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -960,17 +960,12 @@ receiver_thr_f (void *arg)
       cas_client_type = cas_req_header[SRV_CON_MSG_IDX_CLIENT_TYPE];
       if (!(strncmp (cas_req_header, SRV_CON_CLIENT_MAGIC_STR, SRV_CON_CLIENT_MAGIC_LEN) == 0
 	    || strncmp (cas_req_header, SRV_CON_CLIENT_MAGIC_STR_SSL, SRV_CON_CLIENT_MAGIC_LEN) == 0)
-#if defined(FOR_ODBC_GATEWAY)
-	  || cas_client_type != CAS_CLIENT_GATEWAY)
-#else
-	  || cas_client_type == CAS_CLIENT_GATEWAY || cas_client_type < CAS_CLIENT_TYPE_MIN
-	  || cas_client_type > CAS_CLIENT_TYPE_MAX)
-#endif
-      {
-	send_error_to_driver (clt_sock_fd, CAS_ER_NOT_AUTHORIZED_CLIENT, cas_req_header);
-	CLOSE_SOCKET (clt_sock_fd);
-	continue;
-      }
+	  || cas_client_type < CAS_CLIENT_TYPE_MIN || cas_client_type > CAS_CLIENT_TYPE_MAX)
+	{
+	  send_error_to_driver (clt_sock_fd, CAS_ER_NOT_AUTHORIZED_CLIENT, cas_req_header);
+	  CLOSE_SOCKET (clt_sock_fd);
+	  continue;
+	}
 
       if ((IS_SSL_CLIENT (cas_req_header) && shm_br->br_info[br_index].use_SSL == OFF)
 	  || (!IS_SSL_CLIENT (cas_req_header) && shm_br->br_info[br_index].use_SSL == ON))

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -869,6 +869,7 @@ cas_main (void)
   char tmp_user[SRV_CON_DBUSER_SIZE] = { 0, };
   char tmp_passwd[SRV_CON_DBPASSWD_SIZE] = { 0, };
   SUPPORTED_DBMS_TYPE dbms_type = NOT_SUPPORTED_DBMS;
+  char *find_gateway = NULL;
 #endif
 
 #if defined(CAS_FOR_ORACLE)
@@ -1243,6 +1244,15 @@ cas_main (void)
 #if !defined (CAS_FOR_CGW)
 	    err_code = ux_database_connect (db_name, db_user, db_passwd, &db_err_msg);
 #else
+	    find_gateway = strstr (url, "__gateway=true");
+	    if(find_gateway == NULL)
+	      {
+		cas_info[CAS_INFO_STATUS] = CAS_INFO_STATUS_INACTIVE;
+		net_write_error (client_sock_fd, req_info.client_version, req_info.driver_info, cas_info,
+		  cas_info_size, DBMS_ERROR_INDICATOR, CAS_ER_NOT_AUTHORIZED_CLIENT, "Authorization error");
+
+		goto finish_cas;
+	      }
 
 	    dbms_type = cgw_is_supported_dbms (shm_appl->cgw_link_server);
 	    cgw_set_dbms_type (dbms_type);

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1245,12 +1245,14 @@ cas_main (void)
 	    err_code = ux_database_connect (db_name, db_user, db_passwd, &db_err_msg);
 #else
 	    find_gateway = strstr (url, "__gateway=true");
-	    if(find_gateway == NULL)
+	    if (find_gateway == NULL)
 	      {
 		cas_info[CAS_INFO_STATUS] = CAS_INFO_STATUS_INACTIVE;
 		net_write_error (client_sock_fd, req_info.client_version, req_info.driver_info, cas_info,
-		  cas_info_size, DBMS_ERROR_INDICATOR, CAS_ER_NOT_AUTHORIZED_CLIENT, "Authorization error");
+				 cas_info_size, DBMS_ERROR_INDICATOR, CAS_ER_NOT_AUTHORIZED_CLIENT,
+				 "Authorization error");
 
+		CLOSE_SOCKET (client_sock_fd);
 		goto finish_cas;
 	      }
 
@@ -1297,6 +1299,7 @@ cas_main (void)
 		net_write_error (client_sock_fd, req_info.client_version, req_info.driver_info, cas_info,
 				 cas_info_size, DBMS_ERROR_INDICATOR, CAS_ER_NOT_AUTHORIZED_CLIENT, err_msg);
 
+		CLOSE_SOCKET (client_sock_fd);
 		goto finish_cas;
 	      }
 

--- a/win/cascci/cascci.def
+++ b/win/cascci/cascci.def
@@ -107,8 +107,7 @@ EXPORTS
 	cci_set_holdability
 	cci_get_holdability
 	cci_get_cas_info
-	cci_set_client_type
-
+	
 	cci_log_get
 	cci_log_finalize
 	cci_log_write


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24295

Purpose
Only DBLink Server should be allowed to connect to the gateway.
So, to determine whether it is DBLink Server, the connection property is added.
When DBLink Server tries to connect to the gateway, the connection is allowed only if __gateway is used in the connection property.

Implementation
N/A

Remarks
N/A

