### PR TITLE
[LETS-454] add page desync asserts

### DIFF
--- a/src/base/error_manager.h
+++ b/src/base/error_manager.h
@@ -311,10 +311,11 @@ extern "C"
 #endif
 
 STATIC_INLINE void
-ASSERT_NOT_ERROR (int not_error_code)
+ASSERT_NOT_ERROR (const int not_error_code)
 {
+  assert (not_error_code != NO_ERROR);
   const int error_code = er_errid ();
-  assert (error_code == NO_ERROR || error_code != not_error_code);
+  assert (error_code != not_error_code);
 }
 
 #ifdef __cplusplus

--- a/src/base/error_manager.h
+++ b/src/base/error_manager.h
@@ -40,6 +40,7 @@
 #endif /* SERVER_MODE */
 
 #include "error_code.h"
+#include "porting_inline.hpp"
 
 #define ARG_FILE_LINE           __FILE__, __LINE__
 #define NULL_LEVEL              0
@@ -309,6 +310,13 @@ extern "C"
 }
 #endif
 
+STATIC_INLINE void
+ASSERT_NOT_ERROR (int not_error_code)
+{
+  const int error_code = er_errid ();
+  assert (error_code == NO_ERROR || error_code != not_error_code);
+}
+
 #ifdef __cplusplus
 
 #if defined (SERVER_MODE) || !defined (WINDOWS)
@@ -317,10 +325,10 @@ extern "C"
 #elif defined (CS_MODE) || defined (SA_MODE)
 // Windows CS_MODE or SA_MODE - export
 #define CUBERR_MANAGER_DLL __declspec( dllexport )
-#else				// Windows, not CS_MODE and not SA_MODE
+#else // Windows, not CS_MODE and not SA_MODE
 // import
 #define CUBERR_MANAGER_DLL __declspec( dllimport )
-#endif				// Windows, not CS_MODE and not SA_MODE
+#endif // Windows, not CS_MODE and not SA_MODE
 
 /* *INDENT-OFF* */
 namespace cuberr
@@ -338,6 +346,6 @@ namespace cuberr
 // NOTE - cuberr_manager variable is created. it may cause naming conflicts
 // NOTE - if used after jumps, expect "crosses initialization" errors
 #define ER_SAFE_INIT(msg_file, exit_arg) cuberr::manager cuberr_manager (msg_file, exit_arg)
-#endif				// c++
+#endif // c++
 
-#endif				/* _ERROR_MANAGER_H_ */
+#endif /* _ERROR_MANAGER_H_ */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1827,7 +1827,6 @@ btree_fix_root_with_info (THREAD_ENTRY * thread_p, BTID * btid, PGBUF_LATCH_MODE
 
   /* Fix root page. */
   root_page = pgbuf_fix_old_and_check_repl_desync (thread_p, *root_vpid_p, latch_mode, PGBUF_UNCONDITIONAL_LATCH);
-
   if (root_page == NULL)
     {
       /* Failed fixing root page. */
@@ -14422,9 +14421,7 @@ btree_find_boundary_leaf_with_repl_desync_check (THREAD_ENTRY * thread_p, const 
   int root_level = 0, depth = 0;
 
   desync_occured = false;
-  // TODO: temporary change to identify problem
-  const int temp_error_code = er_errid ();
-  ASSERT_NO_ERROR ();
+  ASSERT_NOT_ERROR (ER_PAGE_AHEAD_OF_REPLICATION);
 
   VPID_SET_NULL (pg_vpid);
 
@@ -22826,6 +22823,7 @@ btree_get_root_with_key (THREAD_ENTRY * thread_p, BTID * btid, BTID_INT * btid_i
   assert (root_page != NULL && *root_page == NULL);
   assert (is_leaf != NULL);
   assert (search_key != NULL);
+  ASSERT_NOT_ERROR (ER_PAGE_AHEAD_OF_REPLICATION);
 
   bool reuse_btid_int = other_args ? *((bool *) other_args) : false;
 
@@ -22900,6 +22898,7 @@ btree_advance_and_find_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_VAL
   assert (crt_page != NULL && *crt_page != NULL);
   assert (advance_to_page != NULL && *advance_to_page == NULL);
   assert (search_key != NULL);
+  ASSERT_NOT_ERROR (ER_PAGE_AHEAD_OF_REPLICATION);
 
   /* Get node header. */
   node_header = btree_get_node_header (thread_p, *crt_page);
@@ -24841,6 +24840,7 @@ btree_range_scan_descending_fix_prev_leaf (THREAD_ENTRY * thread_p, BTREE_SCAN *
   assert (bts != NULL && bts->use_desc_index == true);
   assert (key_count != NULL);
   assert (next_vpid != NULL);
+  ASSERT_NOT_ERROR (ER_PAGE_AHEAD_OF_REPLICATION);
 
   VPID_COPY (&prev_leaf_vpid, next_vpid);
 
@@ -25407,6 +25407,7 @@ btree_range_scan_select_visible_oids (THREAD_ENTRY * thread_p, BTREE_SCAN * bts)
   assert (bts->C_page != NULL);
   /* MRO optimization are not compatible with bts->need_count_only. */
   assert (!BTS_NEED_COUNT_ONLY (bts) || !BTS_IS_INDEX_MRO (bts));
+  ASSERT_NOT_ERROR (ER_PAGE_AHEAD_OF_REPLICATION);
 
   /* Index skip scan optimization has an early out when a new key is found: */
   if (BTS_IS_INDEX_ISS (bts)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-454

Added `ASSERT_NO_ERROR` in `btree_find_boundary_leaf_with_repl_desync_check` failed with sometimes with `ER_INTERRUPTED` (this occured not in scalability context, but in monolithic context).
Replace with a more narrow assertion that, in the functions where page desynch might occur, the error, if existing, is something else than `ER_PAGE_AHEAD_OF_REPLICATION`.
This will help in pinpointing two things, once the passive transaction server tests are in place:
- if page desync is occuring and it is not cleared
- where on the calling stack it should be cleared
