### PR TITLE
[CBRD-24311] When using an internal select query, an mvcc snapshot occurs and the isolation test result is different.

### DIFF
--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -1192,7 +1192,8 @@ au_find_user (const char *user_name)
      * When au_login_method () is called, Au_user_name is not changed.
      */
     const char *current_schema_name = sc_current_schema_name ();
-    if (current_schema_name && intl_identifier_casecmp (current_schema_name, user_name) == 0)
+    if (current_schema_name && current_schema_name[0] != '\0'
+	&& intl_identifier_casecmp (current_schema_name, user_name) == 0)
       {
 	return Au_user;
       }
@@ -6308,7 +6309,7 @@ au_user_name (void)
        * When au_login_method () is called, Au_user_name is not changed.
        */
       const char *current_schema_name = sc_current_schema_name ();
-      if (current_schema_name)
+      if (current_schema_name && current_schema_name[0] != '\0')
 	{
 	  return ws_copy_string (current_schema_name);
 	}
@@ -7460,7 +7461,7 @@ au_get_user_name (MOP obj)
   if (ws_is_same_object (Au_user, obj))
     {
       const char *current_schema_name = sc_current_schema_name ();
-      if (current_schema_name)
+      if (current_schema_name && current_schema_name[0] != '\0')
 	{
 	  return ws_copy_string (current_schema_name);
 	}

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -1181,6 +1181,23 @@ au_find_user (const char *user_name)
       return NULL;
     }
 
+  {
+    /*
+     * To reduce unnecessary code execution,
+     * the current schema name can be used instead of the current user name.
+     * 
+     * Returns the current user object when the user name is the same as the current schema name.
+     * 
+     * Au_user_name cannot be used because it does not always store the current user name.
+     * When au_login_method () is called, Au_user_name is not changed.
+     */
+    const char *current_schema_name = sc_current_schema_name ();
+    if (current_schema_name && intl_identifier_casecmp (current_schema_name, user_name) == 0)
+      {
+	return Au_user;
+      }
+  }
+
   /* disable checking of internal authorization object access */
   AU_DISABLE (save);
 
@@ -6283,6 +6300,19 @@ au_user_name (void)
     {
       int save;
 
+      /*
+       * To reduce unnecessary code execution,
+       * the current schema name can be used instead of the current user name.
+       * 
+       * Au_user_name cannot be used because it does not always store the current user name.
+       * When au_login_method () is called, Au_user_name is not changed.
+       */
+      const char *current_schema_name = sc_current_schema_name ();
+      if (current_schema_name)
+	{
+	  return ws_copy_string (current_schema_name);
+	}
+
       AU_DISABLE (save);
 
       if (obj_get (Au_user, "name", &value) == NO_ERROR)
@@ -7417,6 +7447,24 @@ au_get_user_name (MOP obj)
   DB_VALUE value;
   db_make_null (&value);
   char *name = NULL;
+
+  /*
+   * To reduce unnecessary code execution,
+   * the current schema name can be used instead of the current user name.
+   * 
+   * Returns the current schema name if the user object is the same as the current user object.
+   * 
+   * Au_user_name cannot be used because it does not always store the current user name.
+   * When au_login_method () is called, Au_user_name is not changed.
+   */
+  if (ws_is_same_object (Au_user, obj))
+    {
+      const char *current_schema_name = sc_current_schema_name ();
+      if (current_schema_name)
+	{
+	  return ws_copy_string (current_schema_name);
+	}
+    }
 
   int error = obj_get (obj, "name", &value);
   if (error == NO_ERROR)

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -6309,9 +6309,11 @@ au_user_name (void)
        * When au_login_method () is called, Au_user_name is not changed.
        */
       const char *current_schema_name = sc_current_schema_name ();
+      char uppercase_name[DB_MAX_USER_LENGTH];
       if (current_schema_name && current_schema_name[0] != '\0')
 	{
-	  return ws_copy_string (current_schema_name);
+	  intl_identifier_upper (current_schema_name, uppercase_name);
+	  return ws_copy_string (uppercase_name);
 	}
 
       AU_DISABLE (save);
@@ -7461,9 +7463,11 @@ au_get_user_name (MOP obj)
   if (ws_is_same_object (Au_user, obj))
     {
       const char *current_schema_name = sc_current_schema_name ();
+      char uppercase_name[DB_MAX_USER_LENGTH];
       if (current_schema_name && current_schema_name[0] != '\0')
 	{
-	  return ws_copy_string (current_schema_name);
+	  intl_identifier_upper (current_schema_name, uppercase_name);
+	  return ws_copy_string (uppercase_name);
 	}
     }
 

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5418,6 +5418,11 @@ sm_find_synonym (const char *name)
   int error = NO_ERROR;
   int save = 0;
 
+  if (sm_check_system_class_by_name (name))
+    {
+      return NULL;
+    }
+
   synonym_class_obj = sm_find_class (CT_SYNONYM_NAME);
   if (synonym_class_obj == NULL)
     {

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5435,7 +5435,7 @@ sm_find_synonym (const char *name)
       return NULL;
     }
 
-  synonym_class_obj = sm_find_class (CT_SYNONYM_NAME);
+  synonym_class_obj = locator_find_class_with_purpose (CT_SYNONYM_NAME, false);
   if (synonym_class_obj == NULL)
     {
       ASSERT_ERROR_AND_SET (error);

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -593,6 +593,18 @@ sc_current_schema_name (void)
 }
 
 /*
+ * sc_current_schema_owner() - Returns current schema owner
+ *      return: current schema owner object
+ *
+ */
+MOP
+sc_current_schema_owner (void)
+{
+  return Current_Schema.owner;
+}
+
+
+/*
  * sm_add_static_method() - Adds an element to the static link table.
  *    The name argument and the name of the function pointed to
  *    are usually the same but this is not mandatory.

--- a/src/object/schema_manager.h
+++ b/src/object/schema_manager.h
@@ -320,7 +320,8 @@ extern int classobj_drop_foreign_key_ref (DB_SEQ ** properties, const BTID * bti
 /* currently this is a private function to be called only by AU_SET_USER */
 extern int sc_set_current_schema (MOP user);
 extern const char *sc_current_schema_name (void);
-/* Obtain (pointer to) current schema name.                            */
+extern MOP sc_current_schema_owner (void);
+/* Obtain (pointer to) current schema name. */
 
 extern int sm_has_non_null_attribute (SM_ATTRIBUTE ** attrs);
 extern void sm_free_function_index_info (SM_FUNCTION_INFO * func_index_info);

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -1332,24 +1332,11 @@ pt_check_user_exists (PARSER_CONTEXT * parser, PT_NODE * cls_ref)
 
   assert (parser != NULL);
 
-  if (!cls_ref || cls_ref->node_type != PT_NAME || (user_name = cls_ref->info.name.resolved) == NULL
-      || user_name[0] == '\0')
-    {
-      return NULL;
-    }
-
-#if defined (ENABLE_UNUSED_FUNCTION)
-  /*
-   * When this code is executed, the answer from the existing test case may be different.
-   * Previously, the problem only occurred when resolved names were used.
-   * User-specified names cause problems because they always have resolved names.
-   */
   user_name = pt_get_qualifier_name (parser, cls_ref);
   if (user_name == NULL || user_name[0] == '\0')
     {
       return NULL;
     }
-#endif
 
   result = db_find_user (user_name);
   if (!result)

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -1332,11 +1332,24 @@ pt_check_user_exists (PARSER_CONTEXT * parser, PT_NODE * cls_ref)
 
   assert (parser != NULL);
 
+  if (!cls_ref || cls_ref->node_type != PT_NAME || (user_name = cls_ref->info.name.resolved) == NULL
+      || user_name[0] == '\0')
+    {
+      return NULL;
+    }
+
+#if defined (ENABLE_UNUSED_FUNCTION)
+  /*
+   * When this code is executed, the answer from the existing test case may be different.
+   * Previously, the problem only occurred when resolved names were used.
+   * User-specified names cause problems because they always have resolved names.
+   */
   user_name = pt_get_qualifier_name (parser, cls_ref);
   if (user_name == NULL || user_name[0] == '\0')
     {
       return NULL;
     }
+#endif
 
   result = db_find_user (user_name);
   if (!result)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24311

### When using an internal select query, an mvcc snapshot occurs and the isolation test result is different.	
- In Repeatable Read, the MVCC snapshot is created when the SELECT query is executed. Even if the SELCET query is not explicitly executed, the MVCC snapshot is created when the index is scanned.
```
/* src/storage/btree.c */

BTREE_SEARCH
xbtree_find_unique (THREAD_ENTRY * thread_p, BTID * btid, SCAN_OPERATION_TYPE scan_op_type, DB_VALUE * key,
            OID * class_oid, OID * oid, bool is_all_class_srch)
{
  ~
  if (logtb_find_current_isolation (thread_p) >= TRAN_REP_READ || (find_unique_helper.lock_mode >= S_LOCK))
    {
      /*
       * Acquire snapshot in RR if not already acquired. This is needed since
       * the transaction need to know the actual visible objects - before
       * instance locking. In this way future commands of current transaction
       * may correctly detect visible objects.
       */
      (void) logtb_get_mvcc_snapshot (thread_p);
    }
~
```
- For this reason, MVCC snapshots are created when looking up a user, getting the current username, and looking up a Synonym. Creating an MVCC snapshot when executing an internal query on the system may not be the intended result of the user. Therefore, in case of index scan of the db_user and _db_synonym system tables, do not create an MVCC snapshot so that it does not differ from the previous answer in the isolation test case.