### PR TITLE
[CBRD-24313] Don't push the correlated predicate which includes dblink subquery

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -530,6 +530,7 @@ extern "C"
   extern PT_NODE *pt_get_cursor (const PT_HOST_VARS * hv);
   extern PT_NODE *pt_get_parameters (PARSER_CONTEXT * parser, PT_NODE * statement);
 
+  extern bool pt_has_dblink (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_aggregate (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_analytic (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_order_sensitive_agg (PARSER_CONTEXT * parser, PT_NODE * node);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3058,6 +3058,36 @@ pt_get_spec_name (PARSER_CONTEXT * parser, const PT_NODE * selqry)
 }
 
 /*
+ * pt_has_dblink () -
+ *   return: true if statement has a dblink node in its parse tree
+ *   parser(in):
+ *   node(in/out):
+ */
+bool
+pt_has_dblink (PARSER_CONTEXT * parser, PT_NODE * node)
+{
+  PT_NODE *spec;
+
+  if (!node)
+    {
+      return false;
+    }
+
+  if (node->node_type == PT_SELECT)
+    {
+      if (spec = node->info.query.q.select.from)
+	{
+	  if (spec->info.spec.derived_table && spec->info.spec.derived_table->node_type == PT_DBLINK_TABLE)
+	    {
+	      return true;
+	    }
+	}
+    }
+
+  return false;
+}
+
+/*
  * pt_has_aggregate () -
  *   return: true if statement has an aggregate node in its parse tree
  *   parser(in):

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -876,6 +876,13 @@ dblink_scan_next (THREAD_ENTRY * thread_entry, DBLINK_SCAN_INFO * scan_info, val
       return S_ERROR;
     }
 
+  gettimeofday (&te, NULL);
+  end = te.tv_sec * 1000000LL + te.tv_usec;
+
+  if (dblink_log)
+    fprintf (dblink_log, "[tran-%03d] cci_cursoring: %3d(us)\n", thread_entry->tran_index, end - begin);
+  fflush (dblink_log);
+
   return S_SUCCESS;
 }
 

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -553,7 +553,7 @@ dblink_open_scan (THREAD_ENTRY * thread_entry, DBLINK_SCAN_INFO * scan_info, str
 	fprintf (dblink_log, "[tran-%03d] cci_connect: %5d(us)\n", thread_entry->tran_index, end - begin);
       fflush (dblink_log);
       begin = end;
-      cci_set_autocommit (scan_info->conn_handle, CCI_AUTOCOMMIT_FALSE);
+      cci_set_autocommit (scan_info->conn_handle, CCI_AUTOCOMMIT_TRUE);
       scan_info->stmt_handle = cci_prepare (scan_info->conn_handle, sql_text, 0, &err_buf);
       if (scan_info->stmt_handle < 0)
 	{

--- a/src/query/dblink_scan.h
+++ b/src/query/dblink_scan.h
@@ -60,10 +60,10 @@ struct dblink_scan_info
   void *col_info;		/* column information T_CCI_COL_INFO */
 };
 
-extern int dblink_open_scan (DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
+extern int dblink_open_scan (THREAD_ENTRY * thread_entry, DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
 			     VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars);
-extern int dblink_close_scan (DBLINK_SCAN_INFO * scan_info);
-extern SCAN_CODE dblink_scan_next (DBLINK_SCAN_INFO * scan_info, val_list_node * val_list);
+extern int dblink_close_scan (THREAD_ENTRY * thread_entry, DBLINK_SCAN_INFO * scan_info);
+extern SCAN_CODE dblink_scan_next (THREAD_ENTRY * thread_entry, DBLINK_SCAN_INFO * scan_info, val_list_node * val_list);
 extern SCAN_CODE dblink_scan_reset (DBLINK_SCAN_INFO * scan_info);
 
 #endif

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -4038,7 +4038,7 @@ scan_open_dblink_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
   scan_init_scan_pred (&dblid->scan_pred, NULL, spec->where_pred,
 		       ((spec->where_pred) ? eval_fnc (thread_p, spec->where_pred, &single_node_type) : NULL));
 
-  return dblink_open_scan (&scan_id->s.dblid.scan_info, spec, vd, host_vars);
+  return dblink_open_scan (thread_p, &scan_id->s.dblid.scan_info, spec, vd, host_vars);
 }
 
 /*
@@ -4942,7 +4942,7 @@ scan_close_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
       break;
 
     case S_DBLINK_SCAN:
-      dblink_close_scan (&scan_id->s.dblid.scan_info);
+      dblink_close_scan (thread_p, &scan_id->s.dblid.scan_info);
       break;
 
     case S_JSON_TABLE_SCAN:
@@ -6876,7 +6876,7 @@ scan_next_dblink_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
   /* execute dblink scan */
 
-  while ((qp_scan = dblink_scan_next (&vaidp->scan_info, scan_id->val_list)) == S_SUCCESS)
+  while ((qp_scan = dblink_scan_next (thread_p, &vaidp->scan_info, scan_id->val_list)) == S_SUCCESS)
     {
       /* evaluate the predicate to see if the tuple qualifies */
       ev_res = V_TRUE;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24313

The predicate should be pushed to the subquery for performance enhance, however, the correlated predicate should be handled carefully. The subquery includes dblink is executed at remote server not current local server, so the correlated predicate can not be handled at the server.

We should prevent from pushing the correlated predicate when the query has a dblink subquery.

The below query should be executed successfully.

```
select DISTINCT ( 
                  select col8 
                  from dblink(
                         srv1,
                         'select col1, col8 from remote_t') as t (col1 int, col8 varchar)
                  where t.col1 = local_t.col1
               ) col8
from local_t local_t;
```

to be rewritten:
```
select distinct (
	select t.col8 
	from (
		select [_dbl].col1, [_dbl].col8 
		from DBLINK(srv1, 'select col1, col8 from remote_t') 
                         as [_dbl](col1 integer, col8 varchar)) t (col1, col8) 
		where t.col1=local_t.col1
	) 
from local_t local_t
```

The below rewritten query is not correct
```
select distinct (
        select t.col8 
        from (
                select [_dbl].col1, [_dbl].col8 
                from DBLINK(srv1, 'SELECT * FROM (select col1, col8 from remote_t) AS _r(col1, col8) WHERE col1=col1'
        ) as [_dbl](col1 integer, col8 varchar)) t (col1, col8)) 
from local_t local_t
```