### PR TITLE
[CBRD-24122] Avoid waiting when stopping server

### DIFF
--- a/src/method/method_runtime_context.cpp
+++ b/src/method/method_runtime_context.cpp
@@ -123,6 +123,10 @@ namespace cubmethod
 	m_is_interrupted = false;
 	m_interrupt_reason = NO_ERROR;
 	m_is_running = false;
+
+	// notify m_group_stack becomes empty ();
+	ulock.unlock ();
+	m_cond_var.notify_all ();
       }
   }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24122

notifying waiting thread is needed for runtime_context::wait_for_interrupt()