### PR TITLE
[CBRD-23989] Fix ContextClassLoader is not reset when connection is pooled

### DIFF
--- a/src/jsp/com/cubrid/jsp/ExecuteThread.java
+++ b/src/jsp/com/cubrid/jsp/ExecuteThread.java
@@ -304,6 +304,8 @@ public class ExecuteThread extends Thread {
         }
 
         readArguments(unpacker, arguments);
+
+        setContextClassLoader(new StoredProcedureClassLoader());
     }
 
     private void processStoredProcedure() throws Exception {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23989

Because of CBRD-23959, ExecuteThread is reused by connection pooling, and the context class loader should be reset at the preparing phase.