### PR TITLE
[CBRD-24309] Change the logic for checking if schema has been changed

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12467,21 +12467,8 @@ error:
 static bool
 cdc_check_if_schema_changed (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info)
 {
-  REPR_ID reprid = NULL_REPRID;
-  REPR_ID latest_reprid = NULL_REPRID;
-
-  reprid = or_rep_id (recdes);
-  latest_reprid = attr_info->last_classrepr->id;
-
-  if (reprid != latest_reprid)
-    {
-      /* schema has been changed */
-      return true;
-    }
-  else
-    {
-      return false;
-    }
+  /* schema has been changed */
+  return or_rep_id (recdes) != attr_info->last_classrepr->id;
 }
 
 int

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12449,6 +12449,21 @@ error:
     } \
   while (0)
 
+/*
+ * cdc_check_if_schema_changed - compare the representation in record descriptor with latest representation,
+ *                               then check if they have different representation ID
+ *
+ * return: TRUE if schema has been changed
+ *
+ * recdes (in) : the instance record descriptor
+ * attr_info (in) : attribute information structure which contains last class representation
+ *
+ * NOTE: This function is called in making log info entry for CDC and Flashback.
+ *       CDC cannot support schema-changed tables because CDC can interpret tables with schemas pre-fetched through JDBC.
+ *       Also, since the old representation does not contain information necessary to construct SQL,
+ *       such as def_order, CDC and Flashback have design issue that cannot support tables whose schema has been changed.
+ *       So this function is used to check if the schema has changed.
+ */
 static bool
 cdc_check_if_schema_changed (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info)
 {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12458,7 +12458,7 @@ cdc_check_if_schema_changed (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info)
   reprid = or_rep_id (recdes);
   latest_reprid = attr_info->last_classrepr->id;
 
-  if (reprid != last_reprid)
+  if (reprid != latest_reprid)
     {
       /* schema has been changed */
       return true;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12588,6 +12588,8 @@ cdc_make_dml_loginfo (THREAD_ENTRY * thread_p, int trid, char *user, CDC_DML_TYP
 	{
 	  heap_value = &attr_info.values[i];
 
+	  assert (heap_value->read_attrepr != NULL);
+
 	  oldval_deforder = heap_value->read_attrepr->def_order;
 
 	  memcpy (&old_values[oldval_deforder], &heap_value->dbvalue, sizeof (DB_VALUE));
@@ -12626,6 +12628,8 @@ cdc_make_dml_loginfo (THREAD_ENTRY * thread_p, int trid, char *user, CDC_DML_TYP
       for (i = 0; i < attr_info.num_values; i++)
 	{
 	  heap_value = &attr_info.values[i];
+
+	  assert (heap_value->read_attrepr != NULL);
 
 	  newval_deforder = heap_value->read_attrepr->def_order;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24309

Purpose

Changed the logic to check whether the schema has been changed. 
Previously, it was checked by checking the number of columns (attributes).
but with this PR, it was modified to check through the **representation ID**

Implementation

1. Returns an error if the latest representation ID is different from the representation ID in RECDES.
2. Remove the existing logic for detecting schema change