### PR TITLE
[CBRD-24320] Supports double quotation marks for query statements in DBLINK

### DIFF
--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -69,6 +69,7 @@ int g_msg[1024];
 int msg_ptr;
 
 int yybuffer_pos;
+int is_dblink_query_string = 0;
 %}
 
 %option yylineno
@@ -1242,7 +1243,7 @@ _[uU][tT][fF]8[']		{
 				}
 
 ["] 				{
-					if (prm_get_bool_value (PRM_ID_ANSI_QUOTES))
+					if (prm_get_bool_value (PRM_ID_ANSI_QUOTES) && (is_dblink_query_string == 0))
 					  {
 					    BEGIN(DELIMITED_ID_NAME);
 					  }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24320

* Allows both single and double quotation marks to be used when writing remote SQL statements in DBLINK queries.


SELECT * FROM dblink('192.168.1.8:55300:demodb:dba::', `'`SELECT col1 FROM dblink_t1`'`) as rt(col1 int); 

SELECT * FROM dblink('192.168.1.8:55300:demodb:dba::', `"`SELECT col1 FROM dblink_t1`"`) as rt(col1 int); 
