### PR TITLE
[CBRD-24313] Do not push the correlated predicate which includes dblink and modify default ncard and tcard for optimizing

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -1287,8 +1287,8 @@ qo_add_node (PT_NODE * entity, QO_ENV * env)
     }
   else
     {
-      QO_NODE_NCARD (node) = 1000;	/* just guess for dblink */
-      QO_NODE_TCARD (node) = 100;	/* just guess for dblink */
+      QO_NODE_NCARD (node) = 5;	/* just guess */
+      QO_NODE_TCARD (node) = 1;	/* just guess */
 
       /* recalculate derived table size */
       if (PT_SPEC_IS_DERIVED (entity))
@@ -1313,6 +1313,10 @@ qo_add_node (PT_NODE * entity, QO_ENV * env)
 		    }
 		}
 	      break;
+	    case PT_DBLINK_TABLE:
+	      QO_NODE_NCARD (node) = 1000;	/* just guess for dblink */
+	      QO_NODE_TCARD (node) = 100;	/* just guess for dblink */
+
 	    default:
 	      break;
 	    }

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -1287,8 +1287,8 @@ qo_add_node (PT_NODE * entity, QO_ENV * env)
     }
   else
     {
-      QO_NODE_NCARD (node) = 5;	/* just guess */
-      QO_NODE_TCARD (node) = 1;	/* just guess */
+      QO_NODE_NCARD (node) = 1000;	/* just guess for dblink */
+      QO_NODE_TCARD (node) = 100;	/* just guess for dblink */
 
       /* recalculate derived table size */
       if (PT_SPEC_IS_DERIVED (entity))

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3659,24 +3659,27 @@ pt_check_pushable_term (PARSER_CONTEXT * parser, PT_NODE * term, FIND_ID_INFO * 
 
   parser_walk_leaves (parser, term, pt_find_only_name_id, infop, NULL, NULL);
 
-  if (infop->out.correlated_found && pt_has_aggregate (parser, infop->in.subquery))
+  if (infop->out.correlated_found)
     {
-      /* When a correlated term is pushed to a subquery that includes an aggregate function, */
-      /* group_by processing can be repeatedly performed. */
-      /* This may cause performance degradation. In this case, copypush is not performed. */
-      is_correlated_with_agg = true;
-    }
+      if (pt_has_aggregate (parser, infop->in.subquery))
+	{
+	  /* When a correlated term is pushed to a subquery that includes an aggregate function, */
+	  /* group_by processing can be repeatedly performed. */
+	  /* This may cause performance degradation. In this case, copypush is not performed. */
+	  is_correlated_with_agg = true;
+	}
 
-  if (infop->in.spec);
-    {
-      derived = infop->in.spec->info.spec.derived_table;
-      if (derived->node_type == PT_DBLINK_TABLE)
-        {
-	  /* When a correlated term is pushed to a subquery that includes a dblink */
-	  /* the pushed predicated can be transferred to remote server */
-	  /* This may cause error because the remote's query could not process the correlated term */
-          is_correlated_with_dblink = true;
-        }
+      if (infop->in.spec);
+      {
+	derived = infop->in.spec->info.spec.derived_table;
+	if (derived->node_type == PT_DBLINK_TABLE)
+	  {
+	    /* When a correlated term is pushed to a subquery that includes a dblink */
+	    /* the pushed predicated can be transferred to remote server */
+	    /* This may cause error because the remote's query could not process the correlated term */
+	    is_correlated_with_dblink = true;
+	  }
+      }
     }
 
   return PT_PUSHABLE_TERM (infop) && !is_correlated_with_agg && !is_correlated_with_dblink;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3669,17 +3669,17 @@ pt_check_pushable_term (PARSER_CONTEXT * parser, PT_NODE * term, FIND_ID_INFO * 
 	  is_correlated_with_agg = true;
 	}
 
-      if (infop->in.spec);
-      {
-	derived = infop->in.spec->info.spec.derived_table;
-	if (derived->node_type == PT_DBLINK_TABLE)
-	  {
-	    /* When a correlated term is pushed to a subquery that includes a dblink */
-	    /* the pushed predicated can be transferred to remote server */
-	    /* This may cause error because the remote's query could not process the correlated term */
-	    is_correlated_with_dblink = true;
-	  }
-      }
+      if (infop->in.spec)
+	{
+	  derived = infop->in.spec->info.spec.derived_table;
+	  if (derived->node_type == PT_DBLINK_TABLE)
+	    {
+	      /* When a correlated term is pushed to a subquery that includes a dblink */
+	      /* the pushed predicated can be transferred to remote server */
+	      /* This may cause error because the remote's query could not process the correlated term */
+	      is_correlated_with_dblink = true;
+	    }
+	}
     }
 
   return PT_PUSHABLE_TERM (infop) && !is_correlated_with_agg && !is_correlated_with_dblink;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24313

The predicate should be pushed to the subquery for performance enhance, however, the correlated predicate should be handled carefully. The subquery includes dblink is executed at remote server not current local server, so the correlated predicate can not be handled at the server.

We should prevent from pushing the correlated predicate when the query has a dblink subquery.

The below query should be executed successfully.

```
select DISTINCT ( 
                  select col8 
                  from dblink(
                         srv1,
                         'select col1, col8 from remote_t') as t (col1 int, col8 varchar)
                  where t.col1 = local_t.col1
               ) col8
from local_t local_t;
```
to be rewritten:

```
select distinct (
	select t.col8 
	from (
		select [_dbl].col1, [_dbl].col8 
		from DBLINK(srv1, 'select col1, col8 from remote_t') 
                         as [_dbl](col1 integer, col8 varchar)) t (col1, col8) 
		where t.col1=local_t.col1
	) 
from local_t local_t
```
The below rewritten query is not correct

```
select distinct (
        select t.col8 
        from (
                select [_dbl].col1, [_dbl].col8 
                from DBLINK(srv1, 'SELECT * FROM (select col1, col8 from remote_t) AS _r(col1, col8) WHERE col1=col1'
        ) as [_dbl](col1 integer, col8 varchar)) t (col1, col8)) 
from local_t local_t

```

In scalar subquery which includes correlated terms, optimizer should not push the correlated terms into the dblink subquery.

So, we should add the code at pt_check_pushable_term routine as below not to push:
```
      QO_NODE_NCARD (node) = 1000;	/* just guess for dblink */
      QO_NODE_TCARD (node) = 100;	/* just guess for dblink */
```
