### PR TITLE
[LETS-288] replicate assigned mvccid completion

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -335,6 +335,7 @@ set(TRANSACTION_SOURCES
   ${TRANSACTION_DIR}/log_recovery_redo.cpp
   ${TRANSACTION_DIR}/log_recovery_redo_parallel.cpp
   ${TRANSACTION_DIR}/log_replication.cpp
+  ${TRANSACTION_DIR}/log_replication_mvcc.cpp
   ${TRANSACTION_DIR}/log_storage.cpp
   ${TRANSACTION_DIR}/log_system_tran.cpp
   ${TRANSACTION_DIR}/log_tran_table.c
@@ -372,6 +373,7 @@ set(TRANSACTION_HEADERS
   ${TRANSACTION_DIR}/log_recovery_redo.hpp
   ${TRANSACTION_DIR}/log_recovery_redo_parallel.hpp
   ${TRANSACTION_DIR}/log_replication.hpp
+  ${TRANSACTION_DIR}/log_replication_mvcc.hpp
   ${TRANSACTION_DIR}/log_storage.hpp
   ${TRANSACTION_DIR}/log_system_tran.hpp
   ${TRANSACTION_DIR}/log_volids.hpp

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -139,8 +139,10 @@ enum log_rectype
   LOG_START_ATOMIC_REPL = 51,
   LOG_END_ATOMIC_REPL = 52,
   LOG_TRANTABLE_SNAPSHOT = 53,
-  LOG_ASSIGNED_MVCCID = 54,	/* not used or obsolete */
-
+  LOG_ASSIGNED_MVCCID = 54,	/* There are transactions that assign an mvccid but do not also record it in a log record.
+                                   Because the log records are the only communication means from active transaction server
+                                   towards passive transaction servers, it is needed to relay such mvccid for completion
+                                   on the passive transaction server as well. */
   LOG_DUMMY_GENERIC,		/* used for flush for now. it is ridiculous to create dummy log records for every single
                                  * case. we should find a different approach */
 

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -249,7 +249,7 @@ namespace cublog
 	  case LOG_COMMIT:
 	    if (m_replicate_mvcc)
 	      {
-		m_replicator_mvccid->complete_mvccid (header.trid, true);
+		m_replicator_mvccid->complete_mvcc (header.trid, replicator_mvcc::COMMITTED);
 	      }
 	    calculate_replication_delay_or_dispatch_async<log_rec_donetime> (
 		    thread_entry, m_redo_lsa);
@@ -257,7 +257,7 @@ namespace cublog
 	  case LOG_ABORT:
 	    if (m_replicate_mvcc)
 	      {
-		m_replicator_mvccid->complete_mvccid (header.trid, false);
+		m_replicator_mvccid->complete_mvcc (header.trid, replicator_mvcc::ROLLEDBACK);
 	      }
 	    calculate_replication_delay_or_dispatch_async<log_rec_donetime> (
 		    thread_entry, m_redo_lsa);

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -155,7 +155,7 @@ namespace cublog
     m_daemon_context_manager = std::make_unique<cubthread::system_worker_entry_manager> (TT_REPLICATION);
 
     // NOTE: make sure any internal structure which is a requirement to functioning is initialized
-    // before the daemon to avoid rare-occuring race conditions
+    // before the daemon to avoid seldom-occuring race conditions
     m_daemon = cubthread::get_manager ()->create_daemon (loop, daemon_task.release (), "cublog::replicator",
 	       m_daemon_context_manager.get ());
   }
@@ -249,7 +249,6 @@ namespace cublog
 	  case LOG_COMMIT:
 	    if (m_replicate_mvcc)
 	      {
-		_er_log_debug (ARG_FILE_LINE, "CRSDBG: commit trid=%d", header.trid);
 		m_replicator_mvccid->complete_mvccid (header.trid, true);
 	      }
 	    calculate_replication_delay_or_dispatch_async<log_rec_donetime> (
@@ -258,7 +257,6 @@ namespace cublog
 	  case LOG_ABORT:
 	    if (m_replicate_mvcc)
 	      {
-		_er_log_debug (ARG_FILE_LINE, "CRSDBG: abort trid=%d", header.trid);
 		m_replicator_mvccid->complete_mvccid (header.trid, false);
 	      }
 	    calculate_replication_delay_or_dispatch_async<log_rec_donetime> (
@@ -427,7 +425,6 @@ namespace cublog
 
     const LOG_REC_ASSIGNED_MVCCID log_rec = m_redo_context.m_reader.reinterpret_copy_and_add_align<T> ();
 
-    _er_log_debug (ARG_FILE_LINE, "CRSDBG: assigned_mvccid trid=%d mvccid=%lld", tranid, (long long)log_rec.mvccid);
     m_replicator_mvccid->new_assigned_mvccid (tranid, log_rec.mvccid);
   }
 

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -25,6 +25,7 @@
 #include "log_recovery.h"
 #include "log_recovery_redo.hpp"
 #include "log_recovery_redo_parallel.hpp"
+#include "log_replication_mvcc.hpp"
 #include "object_representation.h"
 #include "page_buffer.h"
 #include "recovery.h"
@@ -112,6 +113,7 @@ namespace cublog
 
   replicator::replicator (const log_lsa &start_redo_lsa, PAGE_FETCH_MODE page_fetch_mode, int parallel_count)
     : m_bookkeep_mvcc_vacuum_info { is_page_server () }
+    , m_replicate_mvcc { is_passive_transaction_server () }
     , m_redo_lsa { start_redo_lsa }
     , m_replication_active { true }
     , m_redo_context { NULL_LSA, page_fetch_mode, log_reader::fetch_mode::FORCE }
@@ -135,6 +137,11 @@ namespace cublog
 		new cublog::redo_parallel (parallel_count, true, m_redo_lsa, m_redo_context));
       }
 
+    if (m_replicate_mvcc)
+      {
+	m_replicator_mvccid = std::make_unique<replicator_mvcc> ();
+      }
+
     // Create the daemon
     cubthread::looper loop (std::chrono::milliseconds (1));   // don't spin when there is no new log, wait a bit
     auto func_exec = std::bind (&replicator::redo_upto_nxio_lsa, std::ref (*this), std::placeholders::_1);
@@ -147,6 +154,8 @@ namespace cublog
 
     m_daemon_context_manager = std::make_unique<cubthread::system_worker_entry_manager> (TT_REPLICATION);
 
+    // NOTE: make sure any internal structure which is a requirement to functioning is initialized
+    // before the daemon to avoid rare-occuring race conditions
     m_daemon = cubthread::get_manager ()->create_daemon (loop, daemon_task.release (), "cublog::replicator",
 	       m_daemon_context_manager.get ());
   }
@@ -158,6 +167,11 @@ namespace cublog
     if (m_parallel_replication_redo != nullptr)
       {
 	m_parallel_replication_redo.reset (nullptr);
+      }
+
+    if (m_replicate_mvcc)
+      {
+	m_replicator_mvccid.reset (nullptr);
       }
   }
 
@@ -233,10 +247,20 @@ namespace cublog
 	    break;
 	  }
 	  case LOG_COMMIT:
+	    if (m_replicate_mvcc)
+	      {
+		_er_log_debug (ARG_FILE_LINE, "CRSDBG: commit trid=%d", header.trid);
+		m_replicator_mvccid->complete_mvccid (header.trid, true);
+	      }
 	    calculate_replication_delay_or_dispatch_async<log_rec_donetime> (
 		    thread_entry, m_redo_lsa);
 	    break;
 	  case LOG_ABORT:
+	    if (m_replicate_mvcc)
+	      {
+		_er_log_debug (ARG_FILE_LINE, "CRSDBG: abort trid=%d", header.trid);
+		m_replicator_mvccid->complete_mvccid (header.trid, false);
+	      }
 	    calculate_replication_delay_or_dispatch_async<log_rec_donetime> (
 		    thread_entry, m_redo_lsa);
 	    break;
@@ -254,6 +278,12 @@ namespace cublog
 	    break;
 	  case LOG_SYSOP_END:
 	    read_and_bookkeep_mvcc_vacuum<log_rec_sysop_end> (header.type, header.back_lsa, m_redo_lsa, false);
+	    break;
+	  case LOG_ASSIGNED_MVCCID:
+	    if (m_replicate_mvcc)
+	      {
+		register_assigned_mvccid<log_rec_assigned_mvccid> (header.trid);
+	      }
 	    break;
 	  default:
 	    // do nothing
@@ -388,6 +418,17 @@ namespace cublog
 	// calculate the time difference synchronously
 	log_rpl_calculate_replication_delay (&thread_entry, start_time_msec);
       }
+  }
+
+  template <typename T>
+  void replicator::register_assigned_mvccid (TRANID tranid)
+  {
+    assert (m_replicate_mvcc);
+
+    const LOG_REC_ASSIGNED_MVCCID log_rec = m_redo_context.m_reader.reinterpret_copy_and_add_align<T> ();
+
+    _er_log_debug (ARG_FILE_LINE, "CRSDBG: assigned_mvccid trid=%d mvccid=%lld", tranid, (long long)log_rec.mvccid);
+    m_replicator_mvccid->new_assigned_mvccid (tranid, log_rec.mvccid);
   }
 
   void

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -44,6 +44,7 @@ namespace cublog
   // addind this here allows to include the corresponding header only in the source
   class reusable_jobs_stack;
   class redo_parallel;
+  class replicator_mvcc;
 }
 
 namespace cublog
@@ -91,9 +92,12 @@ namespace cublog
       template <typename T>
       void calculate_replication_delay_or_dispatch_async (cubthread::entry &thread_entry,
 	  const log_lsa &rec_lsa);
+      template <typename T>
+      void register_assigned_mvccid (TRANID tranid);
 
     private:
       const bool m_bookkeep_mvcc_vacuum_info;
+      const bool m_replicate_mvcc;
       std::unique_ptr<cubthread::entry_manager> m_daemon_context_manager;
       cubthread::daemon *m_daemon = nullptr;
 
@@ -122,6 +126,8 @@ namespace cublog
       /* does not record anything; needed just to please reused recovery infrastructure
        */
       perf_stats m_perf_stat_idle;
+
+      std::unique_ptr<cublog::replicator_mvcc> m_replicator_mvccid;
   };
 }
 

--- a/src/transaction/log_replication_mvcc.cpp
+++ b/src/transaction/log_replication_mvcc.cpp
@@ -39,7 +39,7 @@ namespace cublog
   }
 
   void
-  replicator_mvcc::complete_mvccid (TRANID tranid, bool committed)
+  replicator_mvcc::complete_mvcc (TRANID tranid, bool committed)
   {
     const map_type::iterator found_it = m_mapped_mvccids.find (tranid);
 

--- a/src/transaction/log_replication_mvcc.cpp
+++ b/src/transaction/log_replication_mvcc.cpp
@@ -35,8 +35,6 @@ namespace cublog
   {
     assert (m_mapped_mvccids.find (tranid) == m_mapped_mvccids.cend ());
 
-    _er_log_debug (ARG_FILE_LINE, "CRSDBG: new_assigned_mvccid trid=%d mvccid=%lld",
-		   tranid, (long long)mvccid);
     m_mapped_mvccids.emplace (tranid, mvccid);
   }
 
@@ -48,15 +46,8 @@ namespace cublog
     if (found_it != m_mapped_mvccids.cend ())
       {
 	const MVCCID found_mvccid = found_it->second;
-	_er_log_debug (ARG_FILE_LINE, "CRSDBG: complete_mvccid FOUND trid=%d mvccid=%lld",
-		       tranid, (long long)found_mvccid);
 	log_Gl.mvcc_table.complete_mvcc (tranid, found_mvccid, committed);
 	m_mapped_mvccids.erase (found_it);
-      }
-    else
-      {
-	_er_log_debug (ARG_FILE_LINE, "CRSDBG: complete_mvccid NOTFOUND trid=%d",
-		       tranid);
       }
     // if not found, it means the transaction contains proper MVCC log records
   }

--- a/src/transaction/log_replication_mvcc.cpp
+++ b/src/transaction/log_replication_mvcc.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+
+#include "log_replication_mvcc.hpp"
+
+#include "log_impl.h"
+#include "thread_entry.hpp"
+
+namespace cublog
+{
+  replicator_mvcc::~replicator_mvcc ()
+  {
+    // passive transaction server can be shutdown at any moment, in any replication state
+    // thus, no verification here
+  }
+
+  void
+  replicator_mvcc::new_assigned_mvccid (TRANID tranid, MVCCID mvccid)
+  {
+    assert (m_mapped_mvccids.find (tranid) == m_mapped_mvccids.cend ());
+
+    _er_log_debug (ARG_FILE_LINE, "CRSDBG: new_assigned_mvccid trid=%d mvccid=%lld",
+		   tranid, (long long)mvccid);
+    m_mapped_mvccids.emplace (tranid, mvccid);
+  }
+
+  void
+  replicator_mvcc::complete_mvccid (TRANID tranid, bool committed)
+  {
+    const map_type::iterator found_it = m_mapped_mvccids.find (tranid);
+    assert (found_it != m_mapped_mvccids.cend ());
+
+    if (found_it != m_mapped_mvccids.cend ())
+      {
+	const MVCCID found_mvccid = found_it->second;
+	_er_log_debug (ARG_FILE_LINE, "CRSDBG: complete_mvccid FOUND trid=%d mvccid=%lld",
+		       tranid, (long long)found_mvccid);
+	log_Gl.mvcc_table.complete_mvcc (tranid, found_mvccid, committed);
+	m_mapped_mvccids.erase (found_it);
+      }
+    else
+      {
+	_er_log_debug (ARG_FILE_LINE, "CRSDBG: complete_mvccid NOTFOUND trid=%d",
+		       tranid);
+      }
+  }
+}

--- a/src/transaction/log_replication_mvcc.cpp
+++ b/src/transaction/log_replication_mvcc.cpp
@@ -44,7 +44,6 @@ namespace cublog
   replicator_mvcc::complete_mvccid (TRANID tranid, bool committed)
   {
     const map_type::iterator found_it = m_mapped_mvccids.find (tranid);
-    assert (found_it != m_mapped_mvccids.cend ());
 
     if (found_it != m_mapped_mvccids.cend ())
       {
@@ -59,5 +58,6 @@ namespace cublog
 	_er_log_debug (ARG_FILE_LINE, "CRSDBG: complete_mvccid NOTFOUND trid=%d",
 		       tranid);
       }
+    // if not found, it means the transaction contains proper MVCC log records
   }
 }

--- a/src/transaction/log_replication_mvcc.hpp
+++ b/src/transaction/log_replication_mvcc.hpp
@@ -1,0 +1,36 @@
+#ifndef _LOG_REPLICATION_MVCC_HPP_
+#define _LOG_REPLICATION_MVCC_HPP_
+
+#endif // _LOG_REPLICATION_MVCC_HPP_
+
+#include "log_lsa.hpp"
+#include "storage_common.h"
+
+#include <map>
+
+namespace cublog
+{
+  /*
+   * */
+  class replicator_mvcc
+  {
+    public:
+      replicator_mvcc () = default;
+
+      replicator_mvcc (const replicator_mvcc &) = delete;
+      replicator_mvcc (replicator_mvcc &&) = delete;
+
+      ~replicator_mvcc ();
+
+      replicator_mvcc &operator = (const replicator_mvcc &) = delete;
+      replicator_mvcc &operator = (replicator_mvcc &&) = delete;
+
+      void new_assigned_mvccid (TRANID tranid, MVCCID mvccid);
+      void complete_mvccid (TRANID tranid, bool committed);
+
+    private:
+      using map_type = std::map<TRANID, MVCCID>;
+
+      map_type m_mapped_mvccids;
+  };
+}

--- a/src/transaction/log_replication_mvcc.hpp
+++ b/src/transaction/log_replication_mvcc.hpp
@@ -15,6 +15,10 @@ namespace cublog
   class replicator_mvcc
   {
     public:
+      static constexpr bool COMMITTED = true;
+      static constexpr bool ROLLEDBACK = false;
+
+    public:
       replicator_mvcc () = default;
 
       replicator_mvcc (const replicator_mvcc &) = delete;
@@ -26,7 +30,7 @@ namespace cublog
       replicator_mvcc &operator = (replicator_mvcc &&) = delete;
 
       void new_assigned_mvccid (TRANID tranid, MVCCID mvccid);
-      void complete_mvccid (TRANID tranid, bool committed);
+      void complete_mvcc (TRANID tranid, bool committed);
 
     private:
       using map_type = std::map<TRANID, MVCCID>;

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4004,7 +4004,6 @@ logtb_complete_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool committed)
 	  _er_log_debug (ARG_FILE_LINE, "CRSDBG: log_append_assigned_mvccid tridx=%d mvccid=%lld",
 			 tran_index, (long long) mvccid);
 	  log_append_assigned_mvccid (thread_p, mvccid);
-	  assert (false);
 	}
       mvcc_table->complete_mvcc (tran_index, mvccid, committed);
     }

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4001,7 +4001,10 @@ logtb_complete_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool committed)
 	{
 	  // No log record contains this transaction MVCCID. The PTS replication has to also complete this MVCCID so it needs
 	  // to be notified via a log record. Add a log record containing the MVCCID.
+	  _er_log_debug (ARG_FILE_LINE, "CRSDBG: log_append_assigned_mvccid tridx=%d mvccid=%lld",
+			 tran_index, (long long) mvccid);
 	  log_append_assigned_mvccid (thread_p, mvccid);
+	  assert (false);
 	}
       mvcc_table->complete_mvcc (tran_index, mvccid, committed);
     }

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4001,8 +4001,6 @@ logtb_complete_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool committed)
 	{
 	  // No log record contains this transaction MVCCID. The PTS replication has to also complete this MVCCID so it needs
 	  // to be notified via a log record. Add a log record containing the MVCCID.
-	  _er_log_debug (ARG_FILE_LINE, "CRSDBG: log_append_assigned_mvccid tridx=%d mvccid=%lld",
-			 tran_index, (long long) mvccid);
 	  log_append_assigned_mvccid (thread_p, mvccid);
 	}
       mvcc_table->complete_mvcc (tran_index, mvccid, committed);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-288

During replication, if LOG_ASSIGNED_MVCCID is found, save the (trid, MVCCID) pair for MVCC completion.
Upon COMMIT/ABORT, if found, also complete the mvccid for that transaction.
