### PR TITLE
[CBRD-24322] Change the error message format of dblink

### DIFF
--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1391,19 +1391,19 @@ $ LOADDB
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 Das aktive Protokollvolumen (%1$s) ist zu normal, um es neu zu erstellen. Wenn Sie das aktive Protokoll entfernen, kann dies zu einem unerwarteten und irreversiblen Problem führen.

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1391,19 +1391,19 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 The active log volume (%1$s) is too sane to recreate. If you remove the active log, it could cause an unexpected and irreversible problem.

--- a/msg/en_US/cubrid.msg
+++ b/msg/en_US/cubrid.msg
@@ -1392,19 +1392,19 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 The active log volume (%1$s) is too sane to recreate. If you remove the active log, it could cause an unexpected and irreversible problem.

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1391,19 +1391,19 @@ Verifique la ruta del archivo de claves (_keys) y asegúrese de que incluya la c
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 El volumen de registro activo (%1$s) está demasiado sano para volver a crearlo. Si elimina el registro activo, podría causar un problema inesperado e irreversible.

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1391,19 +1391,19 @@ Vérifiez le chemin du fichier de clé (_keys) et assurez-vous qu'il inclut la c
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 Le volume de journal actif (%1$s) est trop sain pour être recréé. Si vous supprimez le journal actif, cela peut provoquer un problème inattendu et irréversible.

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1391,19 +1391,19 @@ Controllare il percorso del file della chiave (_keys) e assicurarsi che includa 
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 Il volume del registro attivo (%1$s) è troppo sano per essere ricreato. Se rimuovi il registro attivo, potrebbe causare un problema imprevisto e irreversibile.

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1391,19 +1391,19 @@ $ LOADDB
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 アクティブなログボリューム（%1$s）が正常すぎて、再作成できません。 アクティブなログを削除すると、予期しない不可逆的な問題が発生する可能性があります。

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1391,19 +1391,19 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 The active log volume (%1$s) is too sane to recreate. If you remove the active log, it could cause an unexpected and irreversible problem.

--- a/msg/ko_KR.euckr/cubrid.msg
+++ b/msg/ko_KR.euckr/cubrid.msg
@@ -1391,19 +1391,19 @@ $ LOADDB
 1317 dblink - 소유권을 갖는 "%1$s" 서버가 없습니다. 
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - 매개 변수 바인딩 오류.
-1320 dblink - 잘못된 ODBC Handle 입니다.
-1321 dblink - 데이터 형식 변환 오류.
-1322 dblink - %1$s(%2$d) 타입은 지원하지 않습니다.
-1323 dblink - 잘못된 Statement Handle 입니다.
-1324 dblink - Connection Handle이 잘못되었습니다.
-1325 dblink - Connection URL이 존재하지 않습니다.
-1326 dblink - 유효하지 않은 Numeric 값입니다.
-1327 dblink - "%1$s" 열의 정밀도 값이 잘못되었습니다.
+1319 매개 변수 바인딩 오류.
+1320 잘못된 ODBC Handle 입니다.
+1321 데이터 형식 변환 오류.
+1322 %1$s(%2$d) 타입은 지원하지 않습니다.
+1323 잘못된 Statement Handle 입니다.
+1324 Connection Handle이 잘못되었습니다.
+1325 Connection URL이 존재하지 않습니다.
+1326 유효하지 않은 Numeric 값입니다.
+1327 "%1$s" 열의 정밀도 값이 잘못되었습니다.
 
-1328 dblink - 잘못된 Descriptor Handle 입니다.
-1329 dblink - 지원하지 않는 DBMS 입니다.
-1330 dblink - 환경 핸들을 할당할 수 없습니다.
+1328 잘못된 Descriptor Handle 입니다.
+1329 지원하지 않는 DBMS 입니다.
+1330 환경 핸들을 할당할 수 없습니다.
 1331 Error reserved for dblink development.
 
 1332 액티브 로그 볼륨 (%1$s)에서 문제를 발견할 수 없어 재생성할 수 없습니다. 액티브 로그 볼륨을 제거할 경우에 예측할 수 없는 문제가 발생할 수 있으며, 되돌릴 수 없습니다.

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1391,19 +1391,19 @@ $ LOADDB
 1317 dblink - 소유권을 갖는 "%1$s" 서버가 없습니다. 
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - 매개 변수 바인딩 오류.
-1320 dblink - 잘못된 ODBC Handle 입니다.
-1321 dblink - 데이터 형식 변환 오류.
-1322 dblink - %1$s(%2$d) 타입은 지원하지 않습니다.
-1323 dblink - 잘못된 Statement Handle 입니다.
-1324 dblink - Connection Handle이 잘못되었습니다.
-1325 dblink - Connection URL이 존재하지 않습니다.
-1326 dblink - 유효하지 않은 Numeric 값입니다.
-1327 dblink - "%1$s" 열의 정밀도 값이 잘못되었습니다.
+1319 매개 변수 바인딩 오류.
+1320 잘못된 ODBC Handle 입니다.
+1321 데이터 형식 변환 오류.
+1322 %1$s(%2$d) 타입은 지원하지 않습니다.
+1323 잘못된 Statement Handle 입니다.
+1324 Connection Handle이 잘못되었습니다.
+1325 Connection URL이 존재하지 않습니다.
+1326 유효하지 않은 Numeric 값입니다.
+1327 "%1$s" 열의 정밀도 값이 잘못되었습니다.
 
-1328 dblink - 잘못된 Descriptor Handle 입니다.
-1329 dblink - 지원하지 않는 DBMS 입니다.
-1330 dblink - 환경 핸들을 할당할 수 없습니다.
+1328 잘못된 Descriptor Handle 입니다.
+1329 지원하지 않는 DBMS 입니다.
+1330 환경 핸들을 할당할 수 없습니다.
 1331 Error reserved for dblink development.
 
 1332 액티브 로그 볼륨 (%1$s)에서 문제를 발견할 수 없어 재생성할 수 없습니다. 액티브 로그 볼륨을 제거할 경우에 예측할 수 없는 문제가 발생할 수 있으며, 되돌릴 수 없습니다.

--- a/msg/ro_RO.utf8/cubrid.msg
+++ b/msg/ro_RO.utf8/cubrid.msg
@@ -1391,19 +1391,19 @@ Verificați calea fișierului cheie (_keys) și asigurați-vă că acesta includ
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 Volumul de jurnal activ (%1$s) este prea corect pentru a fi recreat. Dacă eliminați jurnalul activ, ar putea cauza o problemă neașteptată și ireversibilă.

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1391,19 +1391,19 @@ Anahtar dosyasının (_keys) yolunu kontrol edin ve uygun anahtarı içerdiğind
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 Etkin günlük hacmi (%1$s) yeniden oluşturulamayacak kadar makul. Etkin günlüğü kaldırırsanız, beklenmeyen ve geri dönüşü olmayan bir soruna neden olabilir.

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1391,19 +1391,19 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 The active log volume (%1$s) is too sane to recreate. If you remove the active log, it could cause an unexpected and irreversible problem.

--- a/msg/zh_CN.utf8/cubrid.msg
+++ b/msg/zh_CN.utf8/cubrid.msg
@@ -1392,19 +1392,19 @@ $ LOADDB
 1317 dblink - Not allowed "%1$s" Server.
 
 1318 [%1$5.5s][%2$d] %3$s
-1319 dblink - Parameter binding error.
-1320 dblink - Invalid ODBC handle.
-1321 dblink - Type conversion error.
-1322 dblink - not supported type %1$s(%2$d).
-1323 dblink - Invalid Statement handle.
-1324 dblink - Invalid db connection handle.
-1325 dblink - Link server connection url do not exist.
-1326 dblink - Invalid numeric value.
-1327 dblink - Invalid precision value of "%1$s" column.
+1319 Parameter binding error.
+1320 Invalid ODBC handle.
+1321 Type conversion error.
+1322 not supported type %1$s(%2$d).
+1323 Invalid Statement handle.
+1324 Invalid db connection handle.
+1325 Link server connection url do not exist.
+1326 Invalid numeric value.
+1327 Invalid precision value of "%1$s" column.
 
-1328 dblink - Invalid Descriptor handle.
-1329 dblink - Not supported dbms.
-1330 dblink - Unable to allocate an environment handle.
+1328 Invalid Descriptor handle.
+1329 Not supported dbms.
+1330 Unable to allocate an environment handle.
 1331 Error reserved for dblink development.
 
 1332 活动日志卷 (%1$s) 过于健全，无法重新创建。 如果删除活动日志，可能会导致意外且不可逆转的问题。


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24322

Purpose
To distinguish between error messages generated by dblink and general error messages, "dblink -" is added in front of dblink error messages.
However, there are cases where "dblink -" is displayed twice in the error message, so it needs to be corrected.

Implementation
N/A

Remarks
N/A