### PR TITLE
[CBRD-24323] Change column string length limit in dblink

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -27,7 +27,7 @@
 #include "cas_util.h"
 #include "cas_log.h"
 
-#define LONGVARCHAR_MAX_SIZE 16*1024*1024
+#define STRING_MAX_SIZE_LIMIT 16*1024*1024
 #define LOGIN_TIME_OUT       5
 #define NUM_OF_DIGITS(NUMBER) (int)log10(NUMBER) + 1
 #define DISCONNECTED_STATE   -1
@@ -2145,7 +2145,7 @@ cgw_is_support_datatype (SQLSMALLINT data_type, SQLLEN type_size)
     case SQL_TYPE_DATE:
     case SQL_TYPE_TIME:
 #endif
-      if (data_type == SQL_LONGVARCHAR && type_size > LONGVARCHAR_MAX_SIZE)
+      if ((data_type == SQL_LONGVARCHAR || data_type == SQL_WLONGVARCHAR) && type_size > STRING_MAX_SIZE_LIMIT)
 	{
 	  support_data_type = false;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24323

Purpose
In case of variable string type of heterogeneous DBMS, it is mapped to SQL_LONGVARCHAR/SQL_WLONGVARCHAR type of ODBC. (Depending on DBMS data type)
For example, Mysql's LongText and Oracle's LONG type are mapped to SQL_LONGVARCHAR/SQL_WLONGVARCHAR.
In this case, the string length of SQL_LONGVARCHAR/SQL_WLONGVARCHAR may exceed 16 MB.
dblink does not support when the string length exceeds 16MB.
However, there is currently no string length limit for SQL_WLONGVARCHAR type, so it needs to be modified.

Implementation
N/A

Remarks
N/A