### PR TITLE
[CBRD-23842] Support monetary data type in cdc

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -13525,6 +13525,15 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
 
       break;
     case DB_TYPE_MONETARY:
+      {
+	valcnv_convert_value_to_string (new_value);
+
+	func_type = 7;
+	ptr = or_pack_int (ptr, func_type);
+	ptr = or_pack_string (ptr, db_get_string (new_value));
+
+	db_value_clear (new_value);
+      }
       break;
     case DB_TYPE_NULL:
       /* Can't get here because the DB_IS_NULL test covers DB_TYPE_NULL */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

Purpose

Existing CDC implementation does not support data type MONETARY, because it is deprecated.
But, even if it is deprecated, user can use MONETARY data type. 
So, it is decided to support MONETARY data type

Implementation

Use valcnv_convert_value_to_string () function to convert monetary db value to string.
