### PR TITLE
[CBRD-23842] Fix the bug when excute the trigger statement in CDC

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3870,8 +3870,7 @@ enum cdc_ddl_type
   CDC_ALTER,
   CDC_DROP,
   CDC_RENAME,
-  CDC_TRUNCATE,
-  CDC_TRUNCATE_CASCADE
+  CDC_TRUNCATE
 };
 typedef enum cdc_ddl_type CDC_DDL_TYPE;
 

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3870,7 +3870,8 @@ enum cdc_ddl_type
   CDC_ALTER,
   CDC_DROP,
   CDC_RENAME,
-  CDC_TRUNCATE
+  CDC_TRUNCATE,
+  CDC_TRUNCATE_CASCADE
 };
 typedef enum cdc_ddl_type CDC_DDL_TYPE;
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14950,6 +14950,8 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
   OID *classoid = NULL;
   OID *classoid_list[1024];
   OID *oid = NULL;
+  OID null_oid = OID_INITIALIZER;
+
   int stmt_length = 0;
 
   bool supp_appended = false;
@@ -15313,9 +15315,18 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
 
     case PT_CREATE_TRIGGER:
       target = PT_NODE_TR_TARGET (statement);
-      classname = target->info.event_target.class_name->info.name.original;
 
-      classoid = ws_oid (sm_find_class (classname));
+      if (target)
+	{
+	  classname = target->info.event_target.class_name->info.name.original;
+
+	  classoid = ws_oid (sm_find_class (classname));
+	}
+      else
+	{
+	  /* Trigger that does not have target (e.g. create trigger.. execute print.. ) */
+	  classoid = &null_oid;
+	}
 
       ddl_type = CDC_CREATE;
       objtype = CDC_TRIGGER;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23842

Purpose

There is the bug when creating a trigger that has no target class. 
For example, `create trigger ... execute print` statement has no target class, but existing code try to access the target class.
So, the logic for checking if the target class exists is added