### PR TITLE
[CBRD-24326] Support user related ddl statements in CDC

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3870,9 +3870,7 @@ enum cdc_ddl_type
   CDC_ALTER,
   CDC_DROP,
   CDC_RENAME,
-  CDC_TRUNCATE,
-  CDC_GRANT,
-  CDC_REVOKE
+  CDC_TRUNCATE
 };
 typedef enum cdc_ddl_type CDC_DDL_TYPE;
 

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3871,7 +3871,8 @@ enum cdc_ddl_type
   CDC_DROP,
   CDC_RENAME,
   CDC_TRUNCATE,
-  CDC_TRUNCATE_CASCADE
+  CDC_GRANT,
+  CDC_REVOKE
 };
 typedef enum cdc_ddl_type CDC_DDL_TYPE;
 
@@ -3883,7 +3884,8 @@ enum cdc_ddl_object_type
   CDC_VIEW,
   CDC_FUNCTION,
   CDC_PROCEDURE,
-  CDC_TRIGGER
+  CDC_TRIGGER,
+  CDC_USER
 };
 typedef enum cdc_ddl_object_type CDC_DDL_OBJECT_TYPE;
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15313,16 +15313,6 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
       objtype = CDC_USER;
       break;
 
-    case PT_GRANT:
-      ddl_type = CDC_GRANT;
-      objtype = CDC_USER;
-      break;
-
-    case PT_REVOKE:
-      ddl_type = CDC_REVOKE;
-      objtype = CDC_USER;
-      break;
-
     case PT_CREATE_TRIGGER:
       target = PT_NODE_TR_TARGET (statement);
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15299,18 +15299,28 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
       break;
 
     case PT_CREATE_USER:
+      ddl_type = CDC_CREATE;
+      objtype = CDC_USER;
       break;
 
     case PT_ALTER_USER:
+      ddl_type = CDC_ALTER;
+      objtype = CDC_USER;
       break;
 
     case PT_DROP_USER:
+      ddl_type = CDC_DROP;
+      objtype = CDC_USER;
       break;
 
     case PT_GRANT:
+      ddl_type = CDC_GRANT;
+      objtype = CDC_USER;
       break;
 
     case PT_REVOKE:
+      ddl_type = CDC_REVOKE;
+      objtype = CDC_USER;
       break;
 
     case PT_CREATE_TRIGGER:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24326

Purpose

CDC was designed to support only DML and DDL that change data.

However, as the user schema function is added, 
statements to CREATE/ALTER/DROP users must be copied to the target database.

Implementation

When make a supplemental log for DDL, the ddl target object types for user related statements are added
* object type
   * USER 