### PR TITLE
[CBRD-23845] If a synonym already exists in "Create or replace a synonym...", an ER_WS_CLASS_NOT_CACHED error occurs.

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -2942,8 +2942,8 @@ create_stmt
 		DBG_PRINT}}
 	| CREATE					/* 1 */
 	  opt_or_replace                		/* 2 */
-		{ push_msg(MSGCAT_SYNTAX_INVALID_CREATE_PROCEDURE); }	/* 3 */
-	  PROCEDURE					/* 4 */
+	  PROCEDURE					/* 3 */
+		{ push_msg(MSGCAT_SYNTAX_INVALID_CREATE_PROCEDURE); }	/* 4 */
 	  identifier '(' opt_sp_param_list  ')'		/* 5, 6, 7, 8 */
 	  opt_of_is_as LANGUAGE JAVA			/* 9, 10, 11 */
 	  NAME char_string_literal			/* 12, 13 */
@@ -2969,8 +2969,8 @@ create_stmt
 		DBG_PRINT}}
 	| CREATE                        		/* 1 */
 	  opt_or_replace                		/* 2 */
-		{ push_msg(MSGCAT_SYNTAX_INVALID_CREATE_FUNCTION); }	/* 3 */
-	  FUNCTION					/* 4 */
+	  FUNCTION					/* 3 */
+		{ push_msg(MSGCAT_SYNTAX_INVALID_CREATE_FUNCTION); }	/* 4 */
 	  identifier '('  opt_sp_param_list  ')'	/* 5, 6, 7, 8 */
 	  RETURN opt_of_data_type_cursor		/* 9, 10 */
 	  opt_of_is_as LANGUAGE JAVA			/* 11, 12, 13 */
@@ -3120,9 +3120,9 @@ create_stmt
 		DBG_PRINT}}
 	| CREATE			/* 1 */
 	  opt_or_replace		/* 2 */
-	  	{ push_msg (MSGCAT_SYNTAX_SYNONYM_INVALID_CREATE); }	/* 3 */
-	  opt_access_modifier		/* 4 */
-	  SYNONYM			/* 5 */
+	  opt_access_modifier		/* 3 */
+	  SYNONYM			/* 4 */
+	  	{ push_msg (MSGCAT_SYNTAX_SYNONYM_INVALID_CREATE); }	/* 5 */
 	  synonym_name_without_dot	/* 6 */
 	  For				/* 7 */
 	  class_name			/* 8 */
@@ -3136,7 +3136,7 @@ create_stmt
 			if (node)
 			  {
 			    PT_SYNONYM_OR_REPLACE (node) = $2;
-			    PT_SYNONYM_ACCESS_MODIFIER (node) = $4;
+			    PT_SYNONYM_ACCESS_MODIFIER (node) = $3;
 			    PT_SYNONYM_NAME (node) = $6;
 			    PT_SYNONYM_TARGET_NAME (node) = $8;
 			    PT_SYNONYM_COMMENT (node) = $9;
@@ -3970,9 +3970,9 @@ alter_stmt
 
 		DBG_PRINT}}
 	| ALTER				/* 1 */
-		{ push_msg (MSGCAT_SYNTAX_SYNONYM_INVALID_ALTER); }	/* 2 */
-	  opt_access_modifier		/* 3 */
-	  SYNONYM			/* 4 */
+	  opt_access_modifier		/* 2 */
+	  SYNONYM			/* 3 */
+		{ push_msg (MSGCAT_SYNTAX_SYNONYM_INVALID_ALTER); }	/* 4 */
 	  synonym_name			/* 5 */
 	  For				/* 6 */
 	  class_name			/* 7 */
@@ -3985,7 +3985,7 @@ alter_stmt
 
 			if (node)
 			  {
-			    PT_SYNONYM_ACCESS_MODIFIER (node) = $3;
+			    PT_SYNONYM_ACCESS_MODIFIER (node) = $2;
 			    PT_SYNONYM_NAME (node) = $5;
 			    PT_SYNONYM_TARGET_NAME (node) = $7;
 			    PT_SYNONYM_COMMENT (node) = $8;
@@ -4096,9 +4096,9 @@ rename_stmt
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		DBG_PRINT}}
 	| RENAME			/* 1 */
-		{ push_msg (MSGCAT_SYNTAX_SYNONYM_INVALID_RENAME); }	/* 2 */
-	  opt_access_modifier		/* 3 */
-	  SYNONYM			/* 4 */
+	  opt_access_modifier		/* 2 */
+	  SYNONYM			/* 3 */
+		{ push_msg (MSGCAT_SYNTAX_SYNONYM_INVALID_RENAME); }	/* 4 */
 	  synonym_name			/* 5 */
 	  as_or_to			/* 6 */
 	  synonym_name_without_dot	/* 7 */
@@ -4110,7 +4110,7 @@ rename_stmt
 
 			if (node)
 			  {
-			    PT_SYNONYM_ACCESS_MODIFIER (node) = $3;
+			    PT_SYNONYM_ACCESS_MODIFIER (node) = $2;
 			    PT_SYNONYM_OLD_NAME (node) = $5;
 			    PT_SYNONYM_NEW_NAME (node) = $7;
 			    synonym_access_modifier = PT_SYNONYM_ACCESS_MODIFIER (node);
@@ -4446,9 +4446,9 @@ drop_stmt
 
 		DBG_PRINT}}
 	| DROP				/* 1 */
-		{ push_msg (MSGCAT_SYNTAX_SYNONYM_INVALID_DROP); }	/* 2 */
-	  opt_access_modifier		/* 3 */
-	  SYNONYM			/* 4 */
+	  opt_access_modifier		/* 2 */
+	  SYNONYM			/* 3 */
+		{ push_msg (MSGCAT_SYNTAX_SYNONYM_INVALID_DROP); }	/* 4 */
 	  opt_if_exists			/* 5 */
 	  synonym_name			/* 6 */
 	  	{ pop_msg(); }
@@ -4460,7 +4460,7 @@ drop_stmt
 
 			if (node)
 			  {
-			    PT_SYNONYM_ACCESS_MODIFIER (node) = $3;
+			    PT_SYNONYM_ACCESS_MODIFIER (node) = $2;
 			    PT_SYNONYM_IF_EXISTS (node) = $5;
 			    PT_SYNONYM_NAME (node) = $6;
 			    synonym_access_modifier = PT_SYNONYM_ACCESS_MODIFIER (node);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -138,7 +138,8 @@ static int do_alter_synonym_internal (const char *synonym_name, const char *targ
 static int do_create_synonym_internal (const char *synonym_name, DB_OBJECT * synonym_owner, const char *target_name,
 				       DB_OBJECT * target_owner, const char *comment, const int is_public_synonym,
 				       const int or_replace);
-static int do_drop_synonym_internal (const char *synonym_name, const int is_public_synonym, const int if_exists);
+static int do_drop_synonym_internal (const char *synonym_name, const int is_public_synonym, const int if_exists,
+				     DB_OBJECT * synonym_class_obj, DB_OBJECT * synonym_obj);
 static int do_rename_synonym_internal (const char *old_synonym_name, const char *new_synonym_name);
 
 #define MAX_SERIAL_INVARIANT	8
@@ -17927,43 +17928,22 @@ do_create_synonym_internal (const char *synonym_name, DB_OBJECT * synonym_owner,
   instance_obj = do_get_obj_id (&instance_obj_id, class_obj, synonym_name, "unique_name");
   if (instance_obj != NULL)
     {
-      if (or_replace == FALSE)
+      if (or_replace == TRUE)
 	{
-	  ERROR_SET_ERROR_1ARG (error, ER_SYNONYM_ALREADY_EXIST, synonym_name);
-	  goto end;
-	}
-
-      assert (or_replace == TRUE);
-
-      obj_tmpl = dbt_edit_object (instance_obj);
-      if (obj_tmpl == NULL)
-	{
-	  ASSERT_ERROR_AND_SET (error);
-	  goto end;
-	}
-
-      /* comment */
-      if (comment != NULL)
-	{
-	  db_make_string (&value, comment);
-	  error = dbt_put_internal (obj_tmpl, "comment", &value);
-	  pr_clear_value (&value);
+	  error = do_drop_synonym_internal (synonym_name, FALSE, FALSE, class_obj, instance_obj);
 	  if (error != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
-	      goto end;
+	      return error;
 	    }
+
+	  instance_obj = NULL;
 	}
       else
 	{
-	  db_make_null (&value);
-	  error = dbt_put_internal (obj_tmpl, "comment", &value);
-	  pr_clear_value (&value);
-	  if (error != NO_ERROR)
-	    {
-	      ASSERT_ERROR ();
-	      goto end;
-	    }
+	  assert (or_replace == FALSE);
+	  ERROR_SET_ERROR_1ARG (error, ER_SYNONYM_ALREADY_EXIST, synonym_name);
+	  goto end;
 	}
     }
   else
@@ -17974,66 +17954,53 @@ do_create_synonym_internal (const char *synonym_name, DB_OBJECT * synonym_owner,
 	  ERROR_SET_ERROR_1ARG (error, ER_LC_CLASSNAME_EXIST, synonym_name);
 	  goto end;
 	}
+    }
 
-      obj_tmpl = dbt_create_object (class_obj);
-      if (obj_tmpl == NULL)
-	{
-	  ASSERT_ERROR_AND_SET (error);
-	  goto end;
-	}
+  obj_tmpl = dbt_create_object (class_obj);
+  if (obj_tmpl == NULL)
+    {
+      ASSERT_ERROR_AND_SET (error);
+      goto end;
+    }
 
-      /* unique_name */
-      db_make_string (&value, synonym_name);
-      error = dbt_put_internal (obj_tmpl, "unique_name", &value);
-      pr_clear_value (&value);
-      if (error != NO_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  goto end;
-	}
+  /* unique_name */
+  db_make_string (&value, synonym_name);
+  error = dbt_put_internal (obj_tmpl, "unique_name", &value);
+  pr_clear_value (&value);
+  if (error != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      goto end;
+    }
 
-      /* synonym_name */
-      db_make_string (&value, sm_remove_qualifier_name (synonym_name));
-      error = dbt_put_internal (obj_tmpl, "name", &value);
-      pr_clear_value (&value);
-      if (error != NO_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  goto end;
-	}
+  /* synonym_name */
+  db_make_string (&value, sm_remove_qualifier_name (synonym_name));
+  error = dbt_put_internal (obj_tmpl, "name", &value);
+  pr_clear_value (&value);
+  if (error != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      goto end;
+    }
 
-      /* synonym_owner */
-      db_make_object (&value, synonym_owner);
-      error = dbt_put_internal (obj_tmpl, "owner", &value);
-      pr_clear_value (&value);
-      if (error != NO_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  goto end;
-	}
+  /* synonym_owner */
+  db_make_object (&value, synonym_owner);
+  error = dbt_put_internal (obj_tmpl, "owner", &value);
+  pr_clear_value (&value);
+  if (error != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      goto end;
+    }
 
-      /* is_public_synonym */
-      db_make_int (&value, is_public_synonym);
-      error = dbt_put_internal (obj_tmpl, "is_public", &value);
-      pr_clear_value (&value);
-      if (error != NO_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  goto end;
-	}
-
-      /* comment */
-      if (comment != NULL)
-	{
-	  db_make_string (&value, comment);
-	  error = dbt_put_internal (obj_tmpl, "comment", &value);
-	  pr_clear_value (&value);
-	  if (error != NO_ERROR)
-	    {
-	      ASSERT_ERROR ();
-	      goto end;
-	    }
-	}
+  /* is_public_synonym */
+  db_make_int (&value, is_public_synonym);
+  error = dbt_put_internal (obj_tmpl, "is_public", &value);
+  pr_clear_value (&value);
+  if (error != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      goto end;
     }
 
   /* target_unique_name */
@@ -18064,6 +18031,19 @@ do_create_synonym_internal (const char *synonym_name, DB_OBJECT * synonym_owner,
     {
       ASSERT_ERROR ();
       goto end;
+    }
+
+  /* comment */
+  if (comment != NULL)
+    {
+      db_make_string (&value, comment);
+      error = dbt_put_internal (obj_tmpl, "comment", &value);
+      pr_clear_value (&value);
+      if (error != NO_ERROR)
+	{
+	  ASSERT_ERROR ();
+	  goto end;
+	}
     }
 
   /* flush template */
@@ -18112,7 +18092,7 @@ do_drop_synonym (PARSER_CONTEXT * parser, PT_NODE * statement)
   /* if_exists */
   if_exists = PT_SYNONYM_IF_EXISTS (statement);
 
-  error = do_drop_synonym_internal (synonym_name, FALSE, if_exists);
+  error = do_drop_synonym_internal (synonym_name, FALSE, if_exists, NULL, NULL);
   if (error != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -18131,7 +18111,8 @@ do_drop_synonym (PARSER_CONTEXT * parser, PT_NODE * statement)
  * synonym_obj(in): NULL or synonym_obj
  */
 static int
-do_drop_synonym_internal (const char *synonym_name, const int is_public_synonym, const int if_exists)
+do_drop_synonym_internal (const char *synonym_name, const int is_public_synonym, const int if_exists,
+			  DB_OBJECT * synonym_class_obj, DB_OBJECT * synonym_obj)
 {
   DB_OBJECT *class_obj = NULL;
   DB_OBJECT *instance_obj = NULL;
@@ -18143,31 +18124,51 @@ do_drop_synonym_internal (const char *synonym_name, const int is_public_synonym,
 
   AU_DISABLE (save);
 
-  class_obj = sm_find_class (CT_SYNONYM_NAME);
-  if (class_obj == NULL)
+  if (synonym_class_obj != NULL)
     {
-      ASSERT_ERROR_AND_SET (error);
-      goto end;
+      class_obj = synonym_class_obj;
     }
-
-  instance_obj = do_get_obj_id (&instance_obj_id, class_obj, synonym_name, "unique_name");
-  if (instance_obj == NULL)
+  else
     {
-      if (if_exists == TRUE)
+      class_obj = sm_find_class (CT_SYNONYM_NAME);
+      if (class_obj == NULL)
 	{
-	  error = NO_ERROR;
-	  er_clear ();
+	  ASSERT_ERROR_AND_SET (error);
 	  goto end;
 	}
-      else
+    }
+
+  if (synonym_obj != NULL)
+    {
+      instance_obj = synonym_obj;
+    }
+  else
+    {
+      instance_obj = do_get_obj_id (&instance_obj_id, class_obj, synonym_name, "unique_name");
+      if (instance_obj == NULL)
 	{
-	  assert (if_exists == FALSE);
-	  ERROR_SET_ERROR_1ARG (error, ER_SYNONYM_NOT_EXIST, synonym_name);
-	  goto end;
+	  if (if_exists == TRUE)
+	    {
+	      error = NO_ERROR;
+	      er_clear ();
+	      goto end;
+	    }
+	  else
+	    {
+	      assert (if_exists == FALSE);
+	      ERROR_SET_ERROR_1ARG (error, ER_SYNONYM_NOT_EXIST, synonym_name);
+	      goto end;
+	    }
 	}
     }
 
   error = db_drop (instance_obj);
+  if (error != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+    }
+
+  error = locator_flush_instance (instance_obj);
   if (error != NO_ERROR)
     {
       ASSERT_ERROR ();

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -17809,6 +17809,14 @@ do_alter_synonym_internal (const char *synonym_name, const char *target_name, DB
   if (instance_obj == NULL)
     {
       ASSERT_ERROR_AND_SET (error);
+      goto end;
+    }
+  obj_tmpl = NULL;
+
+  error = locator_flush_instance (instance_obj);
+  if (error != NO_ERROR)
+    {
+      ASSERT_ERROR ();
     }
 
 end:
@@ -17934,10 +17942,8 @@ do_create_synonym_internal (const char *synonym_name, DB_OBJECT * synonym_owner,
 	  if (error != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
-	      return error;
+	      goto end;
 	    }
-
-	  instance_obj = NULL;
 	}
       else
 	{
@@ -18051,6 +18057,13 @@ do_create_synonym_internal (const char *synonym_name, DB_OBJECT * synonym_owner,
   if (instance_obj == NULL)
     {
       ASSERT_ERROR_AND_SET (error);
+    }
+  obj_tmpl = NULL;
+
+  error = locator_flush_instance (instance_obj);
+  if (error != NO_ERROR)
+    {
+      ASSERT_ERROR ();
     }
 
 end:
@@ -18166,6 +18179,7 @@ do_drop_synonym_internal (const char *synonym_name, const int is_public_synonym,
   if (error != NO_ERROR)
     {
       ASSERT_ERROR ();
+      goto end;
     }
 
   error = locator_flush_instance (instance_obj);
@@ -18299,6 +18313,14 @@ do_rename_synonym_internal (const char *old_synonym_name, const char *new_synony
   if (instance_obj == NULL)
     {
       ASSERT_ERROR_AND_SET (error);
+      goto end;
+    }
+  obj_tmpl = NULL;
+
+  error = locator_flush_instance (instance_obj);
+  if (error != NO_ERROR)
+    {
+      ASSERT_ERROR ();
     }
 
 end:

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -17941,6 +17941,30 @@ do_create_synonym_internal (const char *synonym_name, DB_OBJECT * synonym_owner,
 	  ASSERT_ERROR_AND_SET (error);
 	  goto end;
 	}
+
+      /* comment */
+      if (comment != NULL)
+	{
+	  db_make_string (&value, comment);
+	  error = dbt_put_internal (obj_tmpl, "comment", &value);
+	  pr_clear_value (&value);
+	  if (error != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	      goto end;
+	    }
+	}
+      else
+	{
+	  db_make_null (&value);
+	  error = dbt_put_internal (obj_tmpl, "comment", &value);
+	  pr_clear_value (&value);
+	  if (error != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	      goto end;
+	    }
+	}
     }
   else
     {
@@ -17997,6 +18021,19 @@ do_create_synonym_internal (const char *synonym_name, DB_OBJECT * synonym_owner,
 	  ASSERT_ERROR ();
 	  goto end;
 	}
+
+      /* comment */
+      if (comment != NULL)
+	{
+	  db_make_string (&value, comment);
+	  error = dbt_put_internal (obj_tmpl, "comment", &value);
+	  pr_clear_value (&value);
+	  if (error != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	      goto end;
+	    }
+	}
     }
 
   /* target_unique_name */
@@ -18027,19 +18064,6 @@ do_create_synonym_internal (const char *synonym_name, DB_OBJECT * synonym_owner,
     {
       ASSERT_ERROR ();
       goto end;
-    }
-
-  /* comment */
-  if (comment != NULL)
-    {
-      db_make_string (&value, comment);
-      error = dbt_put_internal (obj_tmpl, "comment", &value);
-      pr_clear_value (&value);
-      if (error != NO_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  goto end;
-	}
     }
 
   /* flush template */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23845

### If a synonym already exists in "Create or replace a synonym...", an ER_WS_CLASS_NOT_CACHED error occurs.
- In "create or replace synonym ...", ER_WS_CLASS_NOT_CACHED error occurs in dbt_finish_object() when a synonym already exists. The problem only occurs in HA configurations. When the query is executed on the master node, there is no problem, but when applying the log from the slave node, an ER_WS_CLASS_NOT_CACHED error occurs.

### The syntax error message to be displayed when only "create or replace" is found is being found incorrectly.
- The syntax error message to be displayed when only "create or replace" is found is being found incorrectly. Change the order of pushing syntax error messages in SYNONY, PROCEDURE, and FUNCTION.