### PR TITLE
[CBRD-24327] When checking a synonym before checking a class in the semantic check, if the synonym does not exist, the error is cleared.

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5447,6 +5447,7 @@ sm_find_synonym (const char *name)
 
   if (sm_check_system_class_by_name (name))
     {
+      ERROR_SET_WARNING_1ARG (error, ER_SYNONYM_NOT_EXIST, name);
       return NULL;
     }
 

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5418,6 +5418,8 @@ sm_find_class_with_purpose (const char *name, bool for_update)
       else
 	{
 	  /* synonym_mop == NULL */
+	  ASSERT_ERROR ();
+
 	  if (er_errid () == ER_SYNONYM_NOT_EXIST)
 	    {
 	      ERROR_SET_WARNING_1ARG (error, ER_LC_UNKNOWN_CLASSNAME, realname);
@@ -5462,11 +5464,15 @@ sm_find_synonym (const char *name)
   synonym_obj = db_find_unique (synonym_class_obj, "unique_name", &value);
   AU_ENABLE (save);
 
-  /* synonym_mop == NULL */
-  if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+  if (synonym_obj == NULL)
     {
-      er_clear ();
-      ERROR_SET_WARNING_1ARG (error, ER_SYNONYM_NOT_EXIST, realname);
+      ASSERT_ERROR ();
+
+      if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+	{
+	  er_clear ();
+	  ERROR_SET_WARNING_1ARG (error, ER_SYNONYM_NOT_EXIST, realname);
+	}
     }
 
   return synonym_obj;

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5418,9 +5418,8 @@ sm_find_class_with_purpose (const char *name, bool for_update)
       else
 	{
 	  /* synonym_mop == NULL */
-	  if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+	  if (er_errid () == ER_SYNONYM_NOT_EXIST)
 	    {
-	      er_clear ();
 	      ERROR_SET_WARNING_1ARG (error, ER_LC_UNKNOWN_CLASSNAME, realname);
 	    }
 	}
@@ -5460,8 +5459,15 @@ sm_find_synonym (const char *name)
   db_make_string (&value, realname);
 
   AU_DISABLE (save);
-  synonym_obj = obj_find_unique (synonym_class_obj, "unique_name", &value, AU_FETCH_READ);
+  synonym_obj = db_find_unique (synonym_class_obj, "unique_name", &value);
   AU_ENABLE (save);
+
+  /* synonym_mop == NULL */
+  if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+    {
+      er_clear ();
+      ERROR_SET_WARNING_1ARG (error, ER_SYNONYM_NOT_EXIST, realname);
+    }
 
   return synonym_obj;
 }

--- a/src/parser/compile.c
+++ b/src/parser/compile.c
@@ -742,10 +742,6 @@ pt_add_lock_class (PARSER_CONTEXT * parser, PT_CLASS_LOCKS * lcks, PT_NODE * spe
   /* If it is a synonym name, change it to the target name. */
   class_name = spec->info.spec.entity_name->info.name.original;
   synonym_mop = db_find_synonym (class_name);
-  if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND || er_errid () == ER_LC_UNKNOWN_CLASSNAME)
-    {
-      er_clear ();
-    }
   if (synonym_mop != NULL)
     {
       class_name = db_get_synonym_target_name (synonym_mop);

--- a/src/parser/compile.c
+++ b/src/parser/compile.c
@@ -746,6 +746,14 @@ pt_add_lock_class (PARSER_CONTEXT * parser, PT_CLASS_LOCKS * lcks, PT_NODE * spe
     {
       class_name = db_get_synonym_target_name (synonym_mop);
     }
+  else
+    {
+      /* db_find_synonym () == NULL */
+      if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+	{
+	  er_clear ();
+	}
+    }
 
   sm_user_specified_name (class_name, realname, DB_MAX_IDENTIFIER_LENGTH);
 

--- a/src/parser/compile.c
+++ b/src/parser/compile.c
@@ -749,7 +749,7 @@ pt_add_lock_class (PARSER_CONTEXT * parser, PT_CLASS_LOCKS * lcks, PT_NODE * spe
   else
     {
       /* db_find_synonym () == NULL */
-      if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+      if (er_errid () == ER_SYNONYM_NOT_EXIST)
 	{
 	  er_clear ();
 	}

--- a/src/parser/compile.c
+++ b/src/parser/compile.c
@@ -690,6 +690,7 @@ pt_add_lock_class (PARSER_CONTEXT * parser, PT_CLASS_LOCKS * lcks, PT_NODE * spe
   char realname[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
   const char *class_name = NULL;
   int len = 0;
+  int error = NO_ERROR;
 
   if (lcks->num_classes >= lcks->allocated_count)
     {
@@ -748,10 +749,18 @@ pt_add_lock_class (PARSER_CONTEXT * parser, PT_CLASS_LOCKS * lcks, PT_NODE * spe
     }
   else
     {
-      /* db_find_synonym () == NULL */
-      if (er_errid () == ER_SYNONYM_NOT_EXIST)
+      /* synonym_mop == NULL */
+      ASSERT_ERROR_AND_SET (error);
+
+      if (error == ER_SYNONYM_NOT_EXIST)
 	{
 	  er_clear ();
+	  error = NO_ERROR;
+	}
+      else
+	{
+	  PT_ERRORc (parser, spec, er_msg ());
+	  return error;
 	}
     }
 

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -4740,6 +4740,7 @@ pt_check_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
       for_update = true;
     }
 
+  /* We cannot change the schema of a class by using synonym names. */
   if (db_find_synonym (cls_nam))
     {
       PT_ERRORmf (parser, alter->info.alter.entity_name, MSGCAT_SET_PARSER_SEMANTIC,
@@ -4749,7 +4750,7 @@ pt_check_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
   else
     {
       /* db_find_synonym () == NULL */
-      if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+      if (er_errid () == ER_SYNONYM_NOT_EXIST)
 	{
 	  er_clear ();
 	}
@@ -8399,6 +8400,7 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
   /* check name doesn't already exist as a class */
   name = node->info.create_entity.entity_name;
 
+  /* We cannot use an existing synonym name as a class name. */
   if (db_find_synonym (name->info.name.original))
     {
       PT_ERRORmf (parser, name, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CLASS_EXISTS, name->info.name.original);
@@ -8407,7 +8409,7 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
   else
     {
       /* db_find_synonym () == NULL */
-      if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+      if (er_errid () == ER_SYNONYM_NOT_EXIST)
 	{
 	  er_clear ();
 	}
@@ -8667,6 +8669,7 @@ pt_check_create_index (PARSER_CONTEXT * parser, PT_NODE * node)
   /* check that there trying to create an index on a class */
   name = node->info.index.indexed_class->info.spec.entity_name;
 
+  /* We cannot create index of a class by using synonym names. */
   if (db_find_synonym (name->info.name.original))
     {
       PT_ERRORmf (parser, name, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_IS_NOT_A_CLASS, name->info.name.original);
@@ -8675,7 +8678,7 @@ pt_check_create_index (PARSER_CONTEXT * parser, PT_NODE * node)
   else
     {
       /* db_find_synonym () == NULL */
-      if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+      if (er_errid () == ER_SYNONYM_NOT_EXIST)
 	{
 	  er_clear ();
 	}
@@ -9148,9 +9151,10 @@ pt_check_drop (PARSER_CONTEXT * parser, PT_NODE * node)
 	  if ((name = free_node->info.spec.entity_name) != NULL && name->node_type == PT_NAME
 	      && (cls_name = name->info.name.original) != NULL)
 	    {
+	      /* We cannot change the schema of a class by using synonym names. */
 	      if (db_find_synonym (cls_name) == NULL)
 		{
-		  if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+		  if (er_errid () == ER_SYNONYM_NOT_EXIST)
 		    {
 		      er_clear ();
 		    }
@@ -9275,6 +9279,7 @@ pt_check_drop (PARSER_CONTEXT * parser, PT_NODE * node)
 	  if ((name = temp->info.spec.entity_name) != NULL && name->node_type == PT_NAME
 	      && (cls_nam = name->info.name.original) != NULL)
 	    {
+	      /* We cannot change the schema of a class by using synonym names. */
 	      if (db_find_synonym (cls_nam))
 		{
 		  PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CLASS_DOES_NOT_EXIST, cls_nam);
@@ -9283,7 +9288,7 @@ pt_check_drop (PARSER_CONTEXT * parser, PT_NODE * node)
 	      else
 		{
 		  /* db_find_synonym () == NULL */
-		  if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+		  if (er_errid () == ER_SYNONYM_NOT_EXIST)
 		    {
 		      er_clear ();
 		    }
@@ -9536,6 +9541,7 @@ pt_check_truncate (PARSER_CONTEXT * parser, PT_NODE * node)
       if ((name = temp->info.spec.entity_name) != NULL && name->node_type == PT_NAME
 	  && (cls_nam = name->info.name.original) != NULL)
 	{
+	  /* We cannot change the schema of a class by using synonym names. */
 	  if (db_find_synonym (cls_nam))
 	    {
 	      PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CLASS_DOES_NOT_EXIST, cls_nam);
@@ -9544,7 +9550,7 @@ pt_check_truncate (PARSER_CONTEXT * parser, PT_NODE * node)
 	  else
 	    {
 	      /* db_find_synonym () == NULL */
-	      if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+	      if (er_errid () == ER_SYNONYM_NOT_EXIST)
 		{
 		  er_clear ();
 		}

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -2625,7 +2625,7 @@ do_rename (PARSER_CONTEXT * parser, PT_NODE * statement)
       if (db_find_synonym (old_name))
 	{
 	  PT_ERRORmf (parser, statement, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CLASS_DOES_NOT_EXIST, old_name);
-	  return error;
+	  goto error_exit;
 	}
 
       const char *old_qualifier_name = pt_get_qualifier_name (parser, current_rename->info.rename.old_name);

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -2627,6 +2627,14 @@ do_rename (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  PT_ERRORmf (parser, statement, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CLASS_DOES_NOT_EXIST, old_name);
 	  goto error_exit;
 	}
+      else
+	{
+	  /* db_find_synonym () == NULL */
+	  if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+	    {
+	      er_clear ();
+	    }
+	}
 
       const char *old_qualifier_name = pt_get_qualifier_name (parser, current_rename->info.rename.old_name);
       const char *new_qualifier_name = pt_get_qualifier_name (parser, current_rename->info.rename.new_name);

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -2624,7 +2624,7 @@ do_rename (PARSER_CONTEXT * parser, PT_NODE * statement)
       const char *new_name = current_rename->info.rename.new_name->info.name.original;
 
       /* We cannot change the schema of a class by using synonym names. */
-      if (db_find_synonym (old_name))
+      if (db_find_synonym (old_name) != NULL)
 	{
 	  PT_ERRORmf (parser, statement, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CLASS_DOES_NOT_EXIST, old_name);
 	  goto error_exit;
@@ -2632,9 +2632,17 @@ do_rename (PARSER_CONTEXT * parser, PT_NODE * statement)
       else
 	{
 	  /* db_find_synonym () == NULL */
+	  ASSERT_ERROR_AND_SET (error);
+
 	  if (er_errid () == ER_SYNONYM_NOT_EXIST)
 	    {
 	      er_clear ();
+	      error = NO_ERROR;
+	    }
+	  else
+	    {
+	      PT_ERRORc (parser, statement, er_msg ());
+	      goto error_exit;
 	    }
 	}
 

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -2623,6 +2623,7 @@ do_rename (PARSER_CONTEXT * parser, PT_NODE * statement)
       const char *old_name = current_rename->info.rename.old_name->info.name.original;
       const char *new_name = current_rename->info.rename.new_name->info.name.original;
 
+      /* We cannot change the schema of a class by using synonym names. */
       if (db_find_synonym (old_name))
 	{
 	  PT_ERRORmf (parser, statement, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CLASS_DOES_NOT_EXIST, old_name);
@@ -2631,7 +2632,7 @@ do_rename (PARSER_CONTEXT * parser, PT_NODE * statement)
       else
 	{
 	  /* db_find_synonym () == NULL */
-	  if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+	  if (er_errid () == ER_SYNONYM_NOT_EXIST)
 	    {
 	      er_clear ();
 	    }

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -17694,7 +17694,7 @@ do_alter_synonym (PARSER_CONTEXT * parser, PT_NODE * statement)
   sm_user_specified_name (PT_NAME_ORIGINAL (PT_SYNONYM_TARGET_NAME (statement)), target_name, DB_MAX_IDENTIFIER_LENGTH);
 
   /* target_owner */
-  target_owner_obj = au_find_user (PT_NAME_ORIGINAL (PT_SYNONYM_TARGET_OWNER_NAME (statement)));
+  target_owner_obj = db_find_user (PT_NAME_ORIGINAL (PT_SYNONYM_TARGET_OWNER_NAME (statement)));
   if (target_owner_obj == NULL)
     {
       ASSERT_ERROR_AND_SET (error);
@@ -17732,8 +17732,6 @@ do_alter_synonym_internal (const char *synonym_name, const char *target_name, DB
 {
   DB_OBJECT *class_obj = NULL;
   DB_OBJECT *instance_obj = NULL;
-  DB_OBJECT *owner_obj = NULL;
-  DB_IDENTIFIER instance_obj_id = OID_INITIALIZER;
   DB_OTMPL *obj_tmpl = NULL;
   DB_VALUE value;
   int error = NO_ERROR;
@@ -17741,20 +17739,29 @@ do_alter_synonym_internal (const char *synonym_name, const char *target_name, DB
 
   AU_DISABLE (save);
 
-  class_obj = sm_find_class (CT_SYNONYM_NAME);
+  class_obj = db_find_class (CT_SYNONYM_NAME);
   if (class_obj == NULL)
     {
       ASSERT_ERROR_AND_SET (error);
       goto end;
     }
 
-  instance_obj = do_get_obj_id (&instance_obj_id, class_obj, synonym_name, "unique_name");
+  db_make_string (&value, synonym_name);
+  instance_obj = db_find_unique (class_obj, "unique_name", &value);
   if (instance_obj == NULL)
     {
-      ERROR_SET_ERROR_1ARG (error, ER_SYNONYM_NOT_EXIST, synonym_name);
+      ASSERT_ERROR_AND_SET (error);
+
+      if (error == ER_OBJ_OBJECT_NOT_FOUND)
+	{
+	  er_clear ();
+	  ERROR_SET_WARNING_1ARG (error, ER_SYNONYM_NOT_EXIST, synonym_name);
+	}
+
       goto end;
     }
 
+  /* instance_obj != NULL */
   obj_tmpl = dbt_edit_object (instance_obj);
   if (obj_tmpl == NULL)
     {
@@ -17917,7 +17924,6 @@ do_create_synonym_internal (const char *synonym_name, DB_OBJECT * synonym_owner,
 {
   DB_OBJECT *class_obj = NULL;
   DB_OBJECT *instance_obj = NULL;
-  DB_IDENTIFIER instance_obj_id = OID_INITIALIZER;
   DB_OTMPL *obj_tmpl = NULL;
   DB_VALUE value;
   int error = NO_ERROR;
@@ -17933,35 +17939,64 @@ do_create_synonym_internal (const char *synonym_name, DB_OBJECT * synonym_owner,
       goto end;
     }
 
-  instance_obj = do_get_obj_id (&instance_obj_id, class_obj, synonym_name, "unique_name");
+  db_make_string (&value, synonym_name);
+  instance_obj = db_find_unique (class_obj, "unique_name", &value);
   if (instance_obj != NULL)
     {
-      if (or_replace == TRUE)
+      if (or_replace == FALSE)
 	{
-	  error = do_drop_synonym_internal (synonym_name, FALSE, FALSE, class_obj, instance_obj);
-	  if (error != NO_ERROR)
-	    {
-	      ASSERT_ERROR ();
-	      goto end;
-	    }
-	}
-      else
-	{
-	  assert (or_replace == FALSE);
 	  ERROR_SET_ERROR_1ARG (error, ER_SYNONYM_ALREADY_EXIST, synonym_name);
+	  goto end;
+	}
+
+      /* or_replace == TRUE */
+      error = do_drop_synonym_internal (synonym_name, FALSE, FALSE, class_obj, instance_obj);
+      if (error != NO_ERROR)
+	{
+	  ASSERT_ERROR ();
 	  goto end;
 	}
     }
   else
     {
+      /* instance_obj == NULL */
+      ASSERT_ERROR_AND_SET (error);
+
+      if (error == ER_OBJ_OBJECT_NOT_FOUND)
+	{
+	  er_clear ();
+	  error = NO_ERROR;
+	}
+      else
+	{
+	  goto end;
+	}
+
       /* Check if class exists by name. */
       if (db_find_class (synonym_name) != NULL)
 	{
 	  ERROR_SET_ERROR_1ARG (error, ER_LC_CLASSNAME_EXIST, synonym_name);
 	  goto end;
 	}
+      else
+	{
+	  /* db_find_class () == NULL */
+	  ASSERT_ERROR_AND_SET (error);
+
+	  if (er_errid () == ER_LC_UNKNOWN_CLASSNAME)
+	    {
+	      er_clear ();
+	      error = NO_ERROR;
+	    }
+	  else
+	    {
+	      goto end;
+	    }
+	}
     }
 
+  /* (instance_obj != NULL && or_replace == TRUE)
+   * || (instance_obj == NULL && db_find_class () == NULL && er_errid () == ER_LC_UNKNOWN_CLASSNAME) */
   obj_tmpl = dbt_create_object (class_obj);
   if (obj_tmpl == NULL)
     {
@@ -18129,8 +18164,6 @@ do_drop_synonym_internal (const char *synonym_name, const int is_public_synonym,
 {
   DB_OBJECT *class_obj = NULL;
   DB_OBJECT *instance_obj = NULL;
-  DB_OBJECT *owner_obj = NULL;
-  DB_IDENTIFIER instance_obj_id = OID_INITIALIZER;
   DB_VALUE value;
   int error = NO_ERROR;
   int save = 0;
@@ -18143,6 +18176,7 @@ do_drop_synonym_internal (const char *synonym_name, const int is_public_synonym,
     }
   else
     {
+      /* synonym_class_obj == NULL */
       class_obj = sm_find_class (CT_SYNONYM_NAME);
       if (class_obj == NULL)
 	{
@@ -18157,24 +18191,33 @@ do_drop_synonym_internal (const char *synonym_name, const int is_public_synonym,
     }
   else
     {
-      instance_obj = do_get_obj_id (&instance_obj_id, class_obj, synonym_name, "unique_name");
+      /* synonym_obj == NULL */
+      db_make_string (&value, synonym_name);
+      instance_obj = db_find_unique (class_obj, "unique_name", &value);
       if (instance_obj == NULL)
 	{
-	  if (if_exists == TRUE)
+	  ASSERT_ERROR_AND_SET (error);
+
+	  if (error == ER_OBJ_OBJECT_NOT_FOUND)
 	    {
-	      error = NO_ERROR;
 	      er_clear ();
-	      goto end;
+	      error = NO_ERROR;
 	    }
 	  else
 	    {
-	      assert (if_exists == FALSE);
-	      ERROR_SET_ERROR_1ARG (error, ER_SYNONYM_NOT_EXIST, synonym_name);
 	      goto end;
 	    }
+
+	  if (if_exists == FALSE)
+	    {
+	      ERROR_SET_ERROR_1ARG (error, ER_SYNONYM_NOT_EXIST, synonym_name);
+	    }
+
+	  goto end;
 	}
     }
 
+  /* instance_obj != NULL */
   error = db_drop (instance_obj);
   if (error != NO_ERROR)
     {
@@ -18244,7 +18287,6 @@ do_rename_synonym_internal (const char *old_synonym_name, const char *new_synony
   DB_OBJECT *class_obj = NULL;
   DB_OBJECT *instance_obj = NULL;
   DB_OBJECT *new_instance_obj = NULL;
-  DB_IDENTIFIER instance_obj_id = OID_INITIALIZER;
   DB_OTMPL *obj_tmpl = NULL;
   DB_VALUE value;
   int error = NO_ERROR;
@@ -18259,14 +18301,24 @@ do_rename_synonym_internal (const char *old_synonym_name, const char *new_synony
       goto end;
     }
 
-  instance_obj = do_get_obj_id (&instance_obj_id, class_obj, old_synonym_name, "unique_name");
+  db_make_string (&value, old_synonym_name);
+  instance_obj = db_find_unique (class_obj, "unique_name", &value);
   if (instance_obj == NULL)
     {
-      ERROR_SET_ERROR_1ARG (error, ER_SYNONYM_NOT_EXIST, old_synonym_name);
+      ASSERT_ERROR_AND_SET (error);
+
+      if (error == ER_OBJ_OBJECT_NOT_FOUND)
+	{
+	  er_clear ();
+	  ERROR_SET_WARNING_1ARG (error, ER_SYNONYM_NOT_EXIST, old_synonym_name);
+	}
+
       goto end;
     }
 
-  new_instance_obj = do_get_obj_id (&instance_obj_id, class_obj, new_synonym_name, "unique_name");
+  /* instance_obj != NULL */
+  db_make_string (&value, new_synonym_name);
+  new_instance_obj = db_find_unique (class_obj, "unique_name", &value);
   if (new_instance_obj != NULL)
     {
       ERROR_SET_ERROR_1ARG (error, ER_SYNONYM_ALREADY_EXIST, new_synonym_name);
@@ -18274,14 +18326,42 @@ do_rename_synonym_internal (const char *old_synonym_name, const char *new_synony
     }
   else
     {
+      /* new_instance_obj == NULL */
+      ASSERT_ERROR_AND_SET (error);
+
+      if (error == ER_OBJ_OBJECT_NOT_FOUND)
+	{
+	  er_clear ();
+	  error = NO_ERROR;
+	}
+      else
+	{
+	  goto end;
+	}
+
       /* Check if class exists by name. */
       if (db_find_class (new_synonym_name) != NULL)
 	{
 	  ERROR_SET_ERROR_1ARG (error, ER_LC_CLASSNAME_EXIST, new_synonym_name);
 	  goto end;
 	}
+      else
+	{
+	  ASSERT_ERROR_AND_SET (error);
+
+	  if (error == ER_LC_UNKNOWN_CLASSNAME)
+	    {
+	      er_clear ();
+	      error = NO_ERROR;
+	    }
+	  else
+	    {
+	      goto end;
+	    }
+	}
     }
 
+  /* instance_obj != NULL && new_instance_obj == NULL && er_errid () == ER_LC_UNKNOWN_CLASSNAME */
   obj_tmpl = dbt_edit_object (instance_obj);
   if (obj_tmpl == NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24327

### When checking a synonym before checking a class in the semantic check, if the synonym does not exist, the error is cleared.
- The db_find_synonym () and sm_find_synonym () functions set an ER_SYNONYM_NOT_EXIST error when a synonym does not exist.