### PR TITLE
[LETS-210] clear atomic_sysop_start_lsa when the last sysop is attached to the parent transaction

### DIFF
--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1524,7 +1524,8 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 	   * effectively introduced with the scalability project where, as an example, many btree sysops were
 	   * transformed in atomic sysops for the purpose of using the atomic sysop log records to achieve
 	   * functional atomic replication on passive transaction server.
-	   * As such the
+	   * As such the atomic sysop start lsa flag is only cleared when the outermost atomic sysop is
+	   * ended with a commit (LOG_SYSOP_END - LOG_SYSOP_END_COMMIT) or abort (LOG_SYSOP_END - LOG_SYSOP_END_ABORT).
 	   */
 	  if (!LSA_ISNULL (&tdes->rcv.atomic_sysop_start_lsa)
 	      && LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.atomic_sysop_start_lsa))
@@ -1602,7 +1603,8 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
        * effectively introduced with the scalability project where, as an example, many btree sysops were
        * transformed in atomic sysops for the purpose of using the atomic sysop log records to achieve
        * functional atomic replication on passive transaction server.
-       * As such the
+       * As such the atomic sysop start lsa flag is only cleared when the outermost atomic sysop is
+       * ended with a commit (LOG_SYSOP_END - LOG_SYSOP_END_COMMIT) or abort (LOG_SYSOP_END - LOG_SYSOP_END_ABORT).
        */
       const LOG_REC_SYSOP_END *const sysop_end = (const LOG_REC_SYSOP_END *)node->data_header;
       if (!LSA_ISNULL (&tdes->rcv.atomic_sysop_start_lsa)

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1515,13 +1515,17 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 	  vacuum_info = &mvcc_undo->vacuum_info;
 	  mvccid = mvcc_undo->mvccid;
 
-	  /* reset tdes->rcv.sysop_start_postpone_lsa and tdes->rcv.atomic_sysop_start_lsa, if this system op is not nested.
-	   * we'll use lastparent_lsa to check if system op is nested or not. */
-	  /* TODO:
-	   *  - what if the atomic sysop is nested in another atomic sysop?
-	   *  - this will erase atomic bookkeeping from transaction descriptor;
-	   *  - should, instead of null lsa, a value from the sysop stack be used to replace on tdes recovery
-	   *    info (a value which is not kept yet) */
+	  /* Reset
+	   *  - tdes->rcv.sysop_start_postpone_lsa
+	   *  - tdes->rcv.atomic_sysop_start_lsa
+	   * if this system op is not nested.
+	   * We'll use lastparent_lsa to check if system op is nested or not. */
+	  /* Atomic sysop's can also be nested. This is a scenario that was also possible before but it was
+	   * effectively introduced with the scalability project where, as an example, many btree sysops were
+	   * transformed in atomic sysops for the purpose of using the atomic sysop log records to achieve
+	   * functional atomic replication on passive transaction server.
+	   * As such the
+	   */
 	  if (!LSA_ISNULL (&tdes->rcv.atomic_sysop_start_lsa)
 	      && LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.atomic_sysop_start_lsa))
 	    {
@@ -1589,13 +1593,17 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
     }
   else if (node->log_header.type == LOG_SYSOP_END)
     {
-      /* reset tdes->rcv.sysop_start_postpone_lsa and tdes->rcv.atomic_sysop_start_lsa, if this system op is not nested.
-       * we'll use lastparent_lsa to check if system op is nested or not. */
-      /* TODO:
-       *  - what if the atomic sysop is nested in another atomic sysop?
-       *  - this will erase atomic bookkeeping from transaction descriptor;
-       *  - should, instead of null lsa, a value from the sysop stack be used to replace on tdes recovery
-       *    info (a value which is not kept yet) */
+      /* Reset
+       *  - tdes->rcv.sysop_start_postpone_lsa
+       *  - tdes->rcv.atomic_sysop_start_lsa
+       * if this system op is not nested.
+       * We'll use lastparent_lsa to check if system op is nested or not. */
+      /* Atomic sysop's can also be nested. This is a scenario that was also possible before but it was
+       * effectively introduced with the scalability project where, as an example, many btree sysops were
+       * transformed in atomic sysops for the purpose of using the atomic sysop log records to achieve
+       * functional atomic replication on passive transaction server.
+       * As such the
+       */
       const LOG_REC_SYSOP_END *const sysop_end = (const LOG_REC_SYSOP_END *)node->data_header;
       if (!LSA_ISNULL (&tdes->rcv.atomic_sysop_start_lsa)
 	  && LSA_LT (&sysop_end->lastparent_lsa, &tdes->rcv.atomic_sysop_start_lsa))

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -4164,7 +4164,8 @@ log_sysop_end_final (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 /*
  * log_sysop_commit_internal () - Commit system operation. This can be used just to guarantee atomicity or permanence of
  *				  all changes in system operation. Or it can be extended to also act as an undo,
- *				  compensate or run postpone log record. The type is decided using log_record argument.
+ *				  compensate or run postpone log record. The type is decided using log_record.type
+ *				  argument.
  *
  * return	              : Void.
  * thread_p (in)              : Thread entry.

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -4439,6 +4439,7 @@ log_sysop_attach_to_outer (THREAD_ENTRY * thread_p)
   /* Attach to outer: transfer postpone LSA. Not much to do really :) */
   if (tdes->topops.last - 1 >= 0)
     {
+      /* At least one more outer sysop */
       if (LSA_ISNULL (&tdes->topops.stack[tdes->topops.last - 1].posp_lsa))
 	{
 	  LSA_COPY (&tdes->topops.stack[tdes->topops.last - 1].posp_lsa,
@@ -4447,10 +4448,20 @@ log_sysop_attach_to_outer (THREAD_ENTRY * thread_p)
     }
   else
     {
+      /* No outer sysop present */
+      assert (tdes->topops.last == 0);
       if (LSA_ISNULL (&tdes->posp_nxlsa))
 	{
 	  LSA_COPY (&tdes->posp_nxlsa, &tdes->topops.stack[tdes->topops.last].posp_lsa);
 	}
+
+      // - if the last sysop has been assigned to the parent transaction, meaning that, effectively
+      //  there are no sysop's present in the transaction anymore; clean traces of atomic sysops as well;
+      // - this occurs when there are nested non-atomic sysops and atomic sysops (in whichever order, not sure
+      //  which)
+      // - similar logic to this exists in 'log_sysop_commit_internal'
+      // TODO: this might be a workaround for an issue whose root cause is elsewhere
+      LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
     }
 
   log_sysop_end_final (thread_p, tdes);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-210

Atomic sysop start lsa was not reset for the current transaction when terminating the a sysop with LOG_SYSOP_END_LOGICAL_MVCC_UNDO.
Clear `atomic_sysop_start_lsa` also when ending an atomic sysop within an mvcc transaction (the non-mvcc counterpart was already correctly reset in the same function - `prior_lsa_next_record_internal`)

Remarks:
Atomic sysop's can also be nested. This is a scenario that was also possible before but it was effectively introduced with the scalability project where, as an example, many btree sysops were transformed in atomic sysops for the purpose of using the atomic sysop log records to achieve functional atomic replication on passive transaction server. As such the atomic sysop start lsa flag is only cleared when the outermost atomic sysop is ended with a commit (LOG_SYSOP_END - LOG_SYSOP_END_COMMIT) or abort (LOG_SYSOP_END - LOG_SYSOP_END_ABORT).

Other:
- reverted extraction of function `prior_extract_vacuum_info_from_prior_node` (which was used in one single place anyway)
- extract a function `log_sysop_start_internal` and reused in `log_sysop_start_atomic` to be able to add an extra assert

For reference, atomic sysop's have been introduced with http://jira.cubrid.org/browse/CBRD-21003 and PR #563
