### PR TITLE
[CBRD-24333] Fix the core due to accessing invalid LSA in flashback

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -14366,8 +14366,9 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
 	      *time = donetime->at_time;
 
 	      /* It returns LSA of next log record because LSA of current log record is useless in CDC or flashback.
-	       * But if LSA of next log record (forw_lsa) is returned before next log record is appended,
-	       * CDC or flashback can access the wrong log LSA.
+	       * But if LSA of next log record (forw_lsa) is returned
+	       * before next log record is appended (forw_lsa == log_Gl.hdr.append_lsa),
+	       * CDC or flashback can access the invalid log record.
 	       * Because, next log record is not always added at log_Gl.hdr.append_lsa */
 
 	      LSA_EQ (&forw_lsa, &log_Gl.hdr.append_lsa) ?

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -14315,6 +14315,7 @@ static int
 cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * start_lsa)
 {
   LOG_LSA process_lsa;
+  LOG_LSA cur_log_rec_lsa;
 
   LOG_RECORD_HEADER *log_rec_header;
   LOG_PAGE *log_page_p = NULL;
@@ -14350,6 +14351,8 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
   while (!LSA_ISNULL (&process_lsa))
     {
       log_rec_header = LOG_GET_LOG_RECORD_HEADER (log_page_p, &process_lsa);
+
+      LSA_COPY (&cur_log_rec_lsa, &process_lsa);
       LSA_COPY (&forw_lsa, &log_rec_header->forw_lsa);
 
       LOG_READ_ADD_ALIGN (thread_p, sizeof (*log_rec_header), &process_lsa, log_page_p);
@@ -14361,9 +14364,18 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
 	  if (donetime->at_time >= *time)
 	    {
 	      *time = donetime->at_time;
-	      LSA_COPY (start_lsa, &forw_lsa);
+
+	      /* It returns LSA of next log record because LSA of current log record is useless in CDC or flashback.
+	       * But if LSA of next log record (forw_lsa) is returned before next log record is appended,
+	       * CDC or flashback can access the wrong log LSA.
+	       * Because, next log record is not always added at log_Gl.hdr.append_lsa */
+
+	      LSA_EQ (&forw_lsa, &log_Gl.hdr.append_lsa) ?
+		LSA_COPY (start_lsa, &cur_log_rec_lsa) : LSA_COPY (start_lsa, &forw_lsa);
+
 	      return NO_ERROR;
 	    }
+
 	  LOG_READ_ADD_ALIGN (thread_p, sizeof (*donetime), &process_lsa, log_page_p);
 	}
 
@@ -14375,9 +14387,13 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
 	  if (dummy->at_time >= *time)
 	    {
 	      *time = dummy->at_time;
-	      LSA_COPY (start_lsa, &forw_lsa);
+
+	      LSA_EQ (&forw_lsa, &log_Gl.hdr.append_lsa) ?
+		LSA_COPY (start_lsa, &cur_log_rec_lsa) : LSA_COPY (start_lsa, &forw_lsa);
+
 	      return NO_ERROR;
 	    }
+
 	  LOG_READ_ADD_ALIGN (thread_p, sizeof (*dummy), &process_lsa, log_page_p);
 	}
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -14315,7 +14315,7 @@ static int
 cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * start_lsa)
 {
   LOG_LSA process_lsa;
-  LOG_LSA cur_log_rec_lsa;
+  LOG_LSA current_lsa;
 
   LOG_RECORD_HEADER *log_rec_header;
   LOG_PAGE *log_page_p = NULL;
@@ -14352,7 +14352,7 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
     {
       log_rec_header = LOG_GET_LOG_RECORD_HEADER (log_page_p, &process_lsa);
 
-      LSA_COPY (&cur_log_rec_lsa, &process_lsa);
+      LSA_COPY (&current_lsa, &process_lsa);
       LSA_COPY (&forw_lsa, &log_rec_header->forw_lsa);
 
       LOG_READ_ADD_ALIGN (thread_p, sizeof (*log_rec_header), &process_lsa, log_page_p);
@@ -14365,7 +14365,7 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
 	    {
 	      *time = donetime->at_time;
 
-	      LSA_COPY (start_lsa, &cur_log_rec_lsa);
+	      LSA_COPY (start_lsa, &current_lsa);
 
 	      return NO_ERROR;
 	    }
@@ -14382,7 +14382,7 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
 	    {
 	      *time = dummy->at_time;
 
-	      LSA_COPY (start_lsa, &cur_log_rec_lsa);
+	      LSA_COPY (start_lsa, &current_lsa);
 
 	      return NO_ERROR;
 	    }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -14365,14 +14365,7 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
 	    {
 	      *time = donetime->at_time;
 
-	      /* It returns LSA of next log record because LSA of current log record is useless in CDC or flashback.
-	       * But if LSA of next log record (forw_lsa) is returned
-	       * before next log record is appended (forw_lsa == log_Gl.hdr.append_lsa),
-	       * CDC or flashback can access the invalid log record.
-	       * Because, next log record is not always added at log_Gl.hdr.append_lsa */
-
-	      LSA_EQ (&forw_lsa, &log_Gl.hdr.append_lsa) ?
-		LSA_COPY (start_lsa, &cur_log_rec_lsa) : LSA_COPY (start_lsa, &forw_lsa);
+	      LSA_COPY (start_lsa, &cur_log_rec_lsa);
 
 	      return NO_ERROR;
 	    }
@@ -14389,8 +14382,7 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
 	    {
 	      *time = dummy->at_time;
 
-	      LSA_EQ (&forw_lsa, &log_Gl.hdr.append_lsa) ?
-		LSA_COPY (start_lsa, &cur_log_rec_lsa) : LSA_COPY (start_lsa, &forw_lsa);
+	      LSA_COPY (start_lsa, &cur_log_rec_lsa);
 
 	      return NO_ERROR;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24333

Purpose

When it try to find a LSA with a time, 
it finds a log record that have a time value which is near the input time, and returns the LSA of the next log record. 

But if LSA of the next log record is equal to log_Gl.hdr.append_lsa, which means next log record has not been appended, 
flashback or CDC can access the invalid log record because next log record is not always added at log_Gl.hdr.append_lsa. 

Implementation

* Returns LSA of current log record instead of LSA of next log record