### PR TITLE
[CBRD-23846] Slip closing socket that connecting with ExecuteThread in invalid state

### DIFF
--- a/src/method/method_connection_pool.cpp
+++ b/src/method/method_connection_pool.cpp
@@ -72,7 +72,7 @@ namespace cubmethod
 	// test socket
 	if (conn->is_valid() == false)
 	  {
-      jsp_disconnect_server (conn->m_socket); // disconnect connecting with ExecuteThread in invalid state
+	    jsp_disconnect_server (conn->m_socket); // disconnect connecting with ExecuteThread in invalid state
 	    conn->m_socket = jsp_connect_server (boot_db_name (), jsp_server_port ());
 	  }
 

--- a/src/method/method_connection_pool.cpp
+++ b/src/method/method_connection_pool.cpp
@@ -72,6 +72,7 @@ namespace cubmethod
 	// test socket
 	if (conn->is_valid() == false)
 	  {
+      jsp_disconnect_server (conn->m_socket); // disconnect connecting with ExecuteThread in invalid state
 	    conn->m_socket = jsp_connect_server (boot_db_name (), jsp_server_port ());
 	  }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23846

It is a trivial fix, but It can cause exhausting PIDs on the system. so a new socket can not be opened.
