### PR TITLE
[LETS-423] Check before appling redo log 

### DIFF
--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -145,15 +145,12 @@ namespace cublog
 	rcv.pgptr = m_watcher.pgptr;
       }
 
-    if (!log_rv_fix_page_and_check_redo_is_needed (thread_p, m_vpid, rcv.pgptr, record_info.m_start_lsa,
+    if (log_rv_fix_page_and_check_redo_is_needed (thread_p, m_vpid, rcv.pgptr, record_info.m_start_lsa,
 	redo_context.m_end_redo_lsa, redo_context.m_page_fetch_mode))
       {
-	/* nothing else needs to be done, see explanation in function */
-	assert (rcv.pgptr == nullptr);
-	return;
+	rcv.reference_lsa = m_record_lsa;
+	log_rv_redo_record_sync_apply (thread_p,redo_context, record_info, m_vpid, rcv);
       }
-    rcv.reference_lsa = m_record_lsa;
-    log_rv_redo_record_sync_apply (thread_p,redo_context, record_info, m_vpid, rcv);
   }
 
   int atomic_replication_helper::atomic_replication_unit::fix_page (THREAD_ENTRY *thread_p)

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -18,6 +18,7 @@
 
 #include "atomic_replication_helper.hpp"
 
+#include "log_recovery.h"
 #include "log_recovery_redo.hpp"
 #include "page_buffer.h"
 #include "system_parameter.h"
@@ -142,6 +143,14 @@ namespace cublog
     else
       {
 	rcv.pgptr = m_watcher.pgptr;
+      }
+
+    if (!log_rv_fix_page_and_check_redo_is_needed (thread_p, m_vpid, rcv.pgptr, record_info.m_start_lsa,
+	redo_context.m_end_redo_lsa, redo_context.m_page_fetch_mode))
+      {
+	/* nothing else needs to be done, see explanation in function */
+	assert (rcv.pgptr == nullptr);
+	return;
       }
     rcv.reference_lsa = m_record_lsa;
     log_rv_redo_record_sync_apply (thread_p,redo_context, record_info, m_vpid, rcv);

--- a/src/transaction/log_recovery.h
+++ b/src/transaction/log_recovery.h
@@ -28,7 +28,7 @@
 #include "thread_compat.hpp"
 
 PAGE_PTR log_rv_redo_fix_page (THREAD_ENTRY * thread_p, const VPID * vpid_rcv, PAGE_FETCH_MODE page_fetch_mode);
-bool log_rv_fix_page_and_check_redo_is_needed (THREAD_ENTRY * thread_p, const VPID & page_vpid, log_rcv & rcv,
+bool log_rv_fix_page_and_check_redo_is_needed (THREAD_ENTRY * thread_p, const VPID & page_vpid, PAGE_PTR & pgptr,
 					       const log_lsa & rcv_lsa, const LOG_LSA & end_redo_lsa,
 					       PAGE_FETCH_MODE page_fetch_mode);
 int log_rv_get_unzip_log_data (THREAD_ENTRY * thread_p, int length, log_reader & log_pgptr_reader, LOG_ZIP * unzip_ptr,

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -730,7 +730,7 @@ void log_rv_redo_record_sync (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_
       }
   });
 
-  if (!log_rv_fix_page_and_check_redo_is_needed (thread_p, rcv_vpid, rcv, record_info.m_start_lsa,
+  if (!log_rv_fix_page_and_check_redo_is_needed (thread_p, rcv_vpid, rcv.pgptr, record_info.m_start_lsa,
       redo_context.m_end_redo_lsa, redo_context.m_page_fetch_mode))
     {
       /* nothing else needs to be done, see explanation in function */


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-423

Before appling a redo log it is important to check against the `start_lsa` in order to see if operation is still needed.
