### PR TITLE
[LETS-355] update log recovery state on PTS to allow temporary volume check to work

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -5162,7 +5162,10 @@ pgbuf_is_temporary_volume (VOLID volid)
    * as such, the disk cache bookkeeping seems to "lag" behind;
    * in replication context, on the page server, prefer to just skip the check and consider
    * all volumes as permanent because page server does not deal with temporary volumes anyway */
-  if (cubthread::get_entry ().type == TT_REPLICATION)
+  /* Later edit: replication threads are also being present on passive transaction server - which has
+   * to deal with temporary volumes. Thus, restrict the test to page server context only and leave
+   * original answer for all transaction servers */
+  if (is_page_server () && cubthread::get_entry ().type == TT_REPLICATION)
     {
       return false;
     }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1683,6 +1683,10 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
       return;
     }
 
+  // not other purpose on passive transaction server than to conform various checks that rely on the recovery state
+  // one such example: the check for "is temporary volume" in page buffer
+  log_Gl.rcv_phase = LOG_RESTARTED;
+
   logpb_initialize_logging_statistics ();
 
   er_log_debug (ARG_FILE_LINE, "log_initialize_passive_tran_server: end of log initializaton, append_lsa = (%lld|%d)\n",


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-355

Passive Transaction Server is allowed to create temporary volumes. The check whether a temporary volume is influenced, for better or for worse, by the recovery state global flag (`log_Gl.rcv_phase`). On PTS, this state must be - gratuitously, because it is has no real usage otherwise - updated at some point in order to allow the temporary volume check to work correctly.
