### PR TITLE
[CBRD-24204] applyinfo with -i option did not print -a option related results on slave node when slave node shut down and then slave node operates again.

### DIFF
--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -3174,7 +3174,7 @@ applyinfo (UTIL_FUNCTION_ARG * arg)
     }
 
   check_applied_info_temp = check_applied_info = check_copied_info_temp = check_copied_info = false;
-  check_replica_info = check_applied_info_temp = check_applied_info = false;
+  check_replica_info = check_master_info_temp = check_master_info = false;
 
   database_name = utility_get_option_string_value (arg_map, OPTION_STRING_TABLE, 0);
   if (database_name == NULL)
@@ -3407,7 +3407,7 @@ applyinfo (UTIL_FUNCTION_ARG * arg)
 
       check_copied_info_temp = check_copied_info;
       check_applied_info_temp = check_applied_info;
-      check_applied_info_temp = check_applied_info;
+      check_master_info_temp = check_master_info;
 
       sleep (interval);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24204

**Description**
When applyinfo executes on the slave node, slave node stops and then -a option related prints are also stopped.
When we restart ha slave node, It does not work still.
So, we should make applyinfo utility works normal again when ha slave node works again

**Implementation**
check_applied_info_temp is created and then it is initialized by check_applied_info at the end of loop.
+) check_master_info_temp, check_copied_info_temp also added for same purpose.