### PR TITLE
[CBRD-23974] refined - not supported type message for dblink

### DIFF
--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1379,7 +1379,7 @@ $ LOADDB
 1305 dblink - server "%1$s" not found.
 1306 dblink - server "%1$s" already exists.
 1307 dblink - Cannot update server object.
-1308 dblink - not supported type %1%s.
+1308 dblink - not supported type %1$s.
 1309 dblink - invalid bind param.
 1310 dblink - password length exceeds max size.
 1311 dblink - encrypted password length is incorrect.

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1379,7 +1379,7 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1305 dblink - server "%1$s" not found.
 1306 dblink - server "%1$s" already exists.
 1307 dblink - Cannot update server object.
-1308 dblink - not supported type %1%s.
+1308 dblink - not supported type %1$s.
 1309 dblink - invalid bind param.
 1310 dblink - password length exceeds max size.
 1311 dblink - encrypted password length is incorrect.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23974

The unified error message is necessary for dblink as like "not supported type type-name".

- patch
  message file modified.
