### PR TITLE
[CBRD-24287] Fix checking optimization level to skip calling method in constant folding

### DIFF
--- a/src/parser/parse_evaluate.c
+++ b/src/parser/parse_evaluate.c
@@ -47,6 +47,7 @@
 #include "network_interface_cl.h"
 #include "transform.h"
 #include "dbtype.h"
+#include "optimizer.h"		/* qo_need_skip_execution () */
 
 /* associates labels with DB_VALUES */
 static MHT_TABLE *pt_Label_table = NULL;
@@ -1355,7 +1356,7 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
       break;
 
     case PT_METHOD_CALL:
-      if (prm_get_integer_value (PRM_ID_OPTIMIZATION_LEVEL) == 514)
+      if (qo_need_skip_execution ())
 	{
 	  // It is for the get_query_info.
 	  // Do not call method by constant folding


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24287

Optimization levels (2, 258, 514) not to execute the query should have been considered.
I've fixed it by calling the proper function to check the optimization level.