### PR TITLE
[CBRD-24287] Fix not to set ER_NET_SERVER_SHUTDOWN at the end of session.

### DIFF
--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3218,7 +3218,7 @@ session_stop_attached_threads (void *session_arg)
 
   if (session->method_rctx_p != NULL)
     {
-      session->method_rctx_p->set_interrupt (ER_NET_SERVER_SHUTDOWN);
+      session->method_rctx_p->set_interrupt (er_errid ());
       session->method_rctx_p->wait_for_interrupt ();
 
       delete session->method_rctx_p;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24287

Session_stop_attached_threads() may also be called when a session is normally ended, other than when the client is shutting down. ER_NET_SERVER_SHUTDOWN was set by mistake.
I believe that this change will solve the problem of unstable -193 error is shown instead of query results.