### PR TITLE
[CBRD-24341] Automatic shared library dependency detection was disabled

### DIFF
--- a/cmake/CPackOptions.cmake.in
+++ b/cmake/CPackOptions.cmake.in
@@ -50,6 +50,7 @@ elseif(CPACK_GENERATOR STREQUAL "RPM")
     "/etc/init.d/cubrid"
     "/etc/init.d/cubrid-ha"
     )
+  set(CPACK_RPM_PACKAGE_AUTOREQ " no")
 endif()
 
 # TODO: for windows package


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24341

Purpose
To use Gateway, libodbc.so is required. However, since it is an option according to the user's selection, there is no need to check the dependency in RPM.

Implementation
N/A

Remarks
N/A