### PR TITLE
[CBRD-23846] Use mutex for query entry instead of csect

### DIFF
--- a/src/thread/critical_section.c
+++ b/src/thread/critical_section.c
@@ -77,7 +77,6 @@ static const char *csect_Names[] = {
   "LOCATOR_CLASSNAME_TABLE",
   "QPROC_QUERY_TABLE",
   "QPROC_LIST_CACHE",
-  "QPROC_QUERY_ENTRY",
   "DISK_CHECK",
   "CNV_FMT_LEXER",
   "HEAP_CHNGUESS",

--- a/src/thread/critical_section.h
+++ b/src/thread/critical_section.h
@@ -61,7 +61,6 @@ enum
   CSECT_LOCATOR_SR_CLASSNAME_TABLE,	/* Latch for classname to classOID entries */
   CSECT_QPROC_QUERY_TABLE,	/* Latch for query manager table */
   CSECT_QPROC_LIST_CACHE,	/* Latch for query result(list file) cache (mht) */
-  CSECT_QPROC_QUERY_ENTRY,	/* Latch for query entry */
   CSECT_DISK_CHECK,		/* Block changes on disk cache during check */
   CSECT_CNV_FMT_LEXER,		/* Latch for value/string format translation lexer */
   CSECT_HEAP_CHNGUESS,		/* Latch for schema change */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23846

Critical section is used because query entry is not thread-safe. Instead of Critical section, Mutex is used.
