### PR TITLE
[CBRD-24155] Fix thread_core_count parameter is not properly set

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -10582,7 +10582,6 @@ prm_tune_parameters (void)
   query_cache_size_in_pages_prm = prm_find (PRM_NAME_LIST_MAX_QUERY_CACHE_PAGES, NULL);
   test_mode_prm = prm_find (PRM_NAME_TEST_MODE, NULL);
   tz_leap_second_support_prm = prm_find (PRM_NAME_TZ_LEAP_SECOND_SUPPORT, NULL);
-  thread_core_count_prm = prm_find (PRM_NAME_THREAD_CORE_COUNT, NULL);
 
   /* disable AOUT list until we fix CBRD-20741 */
   if (pb_aout_ratio_prm != NULL)
@@ -10629,6 +10628,7 @@ prm_tune_parameters (void)
 	}
 
 #if defined (SERVER_MODE)
+      thread_core_count_prm = prm_find (PRM_NAME_THREAD_CORE_COUNT, NULL);
       int safe_core_count = (css_get_max_workers () / 3);
       int system_cpu_count = cubthread::system_core_count ();
       int core_upper_limit = MIN (safe_core_count, system_cpu_count);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1320,9 +1320,9 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 #endif /* WINDOWS */
 
   // initialize worker pool for server requests
-  const std::size_t MAX_WORKERS = css_get_max_workers ();
-  const std::size_t MAX_TASK_COUNT = css_get_max_task_count ();
-  const std::size_t MAX_CONNECTIONS = css_get_max_connections ();
+#define MAX_WORKERS css_get_max_workers ()
+#define MAX_TASK_COUNT css_get_max_task_count ()
+#define MAX_CONNECTIONS css_get_max_connections ()
 
   // create request worker pool
   css_Server_request_worker_pool =


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24155

css_get_max_workers () is called before the value of "thread_core_count" parameter is propery tuned.
So that I've changed to macro to be called late