### PR TITLE
[CBRD-24347] [Regression] [shell_ext] When executing sql with valgrind, Invalid free() / delete / delete[] / realloc() occurs.

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -533,7 +533,6 @@ else(UNIX)
 endif(UNIX)
 # for dblink
 target_link_libraries(cubrid cascci)
-target_link_libraries(cubrid cubridcs)
 
 add_dependencies(cubrid ${EP_TARGETS} gen_loader_grammar gen_loader_lexer)
 

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -769,14 +769,17 @@ dblink_scan_next (DBLINK_SCAN_INFO * scan_info, val_list_node * val_list)
 	      goto error_exit;
 	    }
 	  NULL_CHECK (ind);
-
 	  if (utype == CCI_U_TYPE_JSON)
 	    {
-	      if (db_json_val_from_str ((char *) value, ind, &cci_value) < 0)
+	      JSON_DOC *json_doc = NULL;
+
+	      error = db_json_get_json_from_str ((char *) value, json_doc, ind);
+	      if (error != NO_ERROR)
 		{
-		  /* er_set is already set in db_json_val_from_str */
 		  goto close_exit;
 		}
+
+	      (void) db_make_json (&cci_value, json_doc, true);
 	    }
 	  else
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24347

When executing sql with valgrind, Invalid free() / delete / delete[] / realloc() occurs.

At the cubrid build, the library "libcubridcs" is included for dblink.
libcubrid and libcubridcs commonly has memory allocation routine, therefore the destruction can be called redundantly.
I excluded the libcubrics from build configure and also modified dblink routine which handles json doc.
