### PR TITLE
[CBRD-24346] Revert the change to fix the vargrind issue

### DIFF
--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -314,7 +314,7 @@ extern int db_Disable_modifications;
   do \
     { \
       if (cdc_Gl.producer.temp_logbuf[(process_lsa)->pageid % 2].log_page_p->hdr.logical_pageid \
-          != (process_lsa)->pageid) \
+          == (process_lsa)->pageid) \
       { \
         if (logpb_fetch_page ((thread_p), (process_lsa), LOG_CS_FORCE_USE, (log_page_p)) \
             != NO_ERROR) \


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24346

Purpose

A problem occurred in fetching the log page from cdc because the macro for CDC was misunderstood and modified.

Since the log page in temp_logbuf is a copy, there may not be log records currently being added. 
Therefore, CDC_UPDATE_TEMP_LOGPAGE updates the log page in temp_logbuf when the current log records cannot be found. 
Therefore, the changes below must be reverted