### PR TITLE
[CBRD-23974] correct dblink error message and remove rewritten print

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3770,7 +3770,7 @@ pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_
 
       parser->custom_print = save_custom;
 
-#if !defined (NDEBUG)
+#if 0
       printf ("===> rewriting query = %s\n", (char *) rewritten->bytes);
 #endif
       break;

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -526,7 +526,7 @@ dblink_bind_param (DBLINK_SCAN_INFO * scan_info, VAL_DESCR * vd, DBLINK_HOST_VAR
 	  u_type = CCI_U_TYPE_NULL;
 	  break;
 	default:
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK_UNSUPPORTED_TYPE, 0);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK_UNSUPPORTED_TYPE, 1, "unknown");
 	  return ER_DBLINK_UNSUPPORTED_TYPE;
 	}
       ret = cci_bind_param (scan_info->stmt_handle, n + 1, a_type, value, u_type, 0);
@@ -591,7 +591,6 @@ dblink_open_scan (DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
 	{
 	  if ((ret = dblink_bind_param (scan_info, vd, host_vars)) < 0)
 	    {
-	      dblink_close_scan (scan_info);
 	      return ret;
 	    }
 	}
@@ -620,8 +619,6 @@ dblink_open_scan (DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
   return NO_ERROR;
 
 error_exit:
-  dblink_close_scan (scan_info);
-
   return ER_DBLINK;
 }
 
@@ -883,7 +880,6 @@ close_exit:
     {
       pr_clear_value (&cci_value);
     }
-  dblink_close_scan (scan_info);
 
   return S_ERROR;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-2397

dblink error message "not supported type" is not printed out correctly because the dblink scan is closed redundantly.
I modified it and I also removed the "rewritten" print at debug mode.
