### PR TITLE
[CBRD-23846] Statement handler cache does not work

### DIFF
--- a/src/method/method_invoke_group.cpp
+++ b/src/method/method_invoke_group.cpp
@@ -278,14 +278,15 @@ namespace cubmethod
   {
     int error = NO_ERROR;
 
-    destroy_resources ();
-
-    if (is_end_query)
+    if (!is_end_query)
       {
 	cubmethod::header header (METHOD_REQUEST_END, get_id());
 	std::vector<int> handler_vec (m_handler_set.begin (), m_handler_set.end ());
 	error = method_send_data_to_client (m_thread_p, header, handler_vec);
+	m_handler_set.clear ();
       }
+
+    destroy_resources ();
 
     return error;
   }
@@ -325,8 +326,6 @@ namespace cubmethod
 
     // destroy cursors used in this group
     destory_all_cursors ();
-
-    m_handler_set.clear ();
   }
 
   query_cursor *

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -384,8 +384,10 @@ qmgr_free_query_entry (THREAD_ENTRY * thread_p, QMGR_TRAN_ENTRY * tran_entry_p, 
 
   query_p->next = NULL;
 
+  pthread_mutex_lock (&tran_entry_p->mutex);
   query_p->next = tran_entry_p->free_query_entry_list_p;
   tran_entry_p->free_query_entry_list_p = query_p;
+  pthread_mutex_unlock (&tran_entry_p->mutex);
 }
 
 /*
@@ -595,7 +597,6 @@ qmgr_delete_query_entry (THREAD_ENTRY * thread_p, QUERY_ID query_id, int tran_in
 
   if (query_p == NULL)
     {
-      pthread_mutex_unlock (&tran_entry_p->mutex);
       return;
     }
 
@@ -614,8 +615,9 @@ qmgr_delete_query_entry (THREAD_ENTRY * thread_p, QUERY_ID query_id, int tran_in
       prev_query_p->next = query_p->next;
     }
 
-  qmgr_free_query_entry (thread_p, tran_entry_p, query_p);
   pthread_mutex_unlock (&tran_entry_p->mutex);
+
+  qmgr_free_query_entry (thread_p, tran_entry_p, query_p);
 }
 
 static void


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23846

`m_handler_set` is cleared before sending the end query command for reset statement handler to CAS., so that the Statement handler cache does not work.
