### PR TITLE
[CBRD-23846] Fix degrading performance caused by setContextClassLoader()

### DIFF
--- a/src/jsp/com/cubrid/jsp/ExecuteThread.java
+++ b/src/jsp/com/cubrid/jsp/ExecuteThread.java
@@ -311,8 +311,6 @@ public class ExecuteThread extends Thread {
         }
 
         readArguments(unpacker, arguments);
-
-        setContextClassLoader(new StoredProcedureClassLoader());
     }
 
     private void processStoredProcedure() throws Exception {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23846

processPrepare() is called whenever parameters are passed to the Java SP server when calling a stored procedure. setContextClassLoader() is incorrectly calling at processPrepare(), causing serious performance degradation.
