### PR TITLE
[LETS-462] Allow for atomic replication sequences with multiple log records affecting the same page

### DIFF
--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -22,7 +22,6 @@
 #include "log_recovery_redo.hpp"
 #include "page_buffer.h"
 #include "system_parameter.h"
-#include "vpid_utilities.hpp"
 
 namespace cublog
 {
@@ -45,14 +44,13 @@ namespace cublog
     vpids.insert (vpid);
 #endif
 
-    m_atomic_sequences_map[tranid].emplace_back (record_lsa, vpid, rcvindex);
-    int error_code = m_atomic_sequences_map[tranid].back ().fix_page (thread_p);
+    int error_code = m_atomic_sequences_map[tranid].add_atomic_replication_unit (thread_p, record_lsa, rcvindex, vpid,
+		     redo_context, record_info);
     if (error_code != NO_ERROR)
       {
 	return error_code;
       }
 
-    m_atomic_sequences_map[tranid].back ().apply_log_redo (thread_p, redo_context, record_info);
     return NO_ERROR;
   }
 
@@ -98,24 +96,60 @@ namespace cublog
 	return;
       }
 
-    for (size_t i = 0; i < iterator->second.size (); i++)
-      {
-	iterator->second[i].unfix_page (thread_p);
-      }
-    iterator->second.clear ();
+    iterator->second.unfix_sequence (thread_p);
     m_atomic_sequences_map.erase (iterator);
 
 #if !defined (NDEBUG)
     m_atomic_sequences_vpids_map.erase (tranid);
 #endif
   }
+  /****************************************************************************
+   * atomic_replication_helper::atomic_replication_unit function definitions  *
+   ****************************************************************************/
+  template <typename T>
+  int atomic_replication_helper::atomic_replication_sequence::add_atomic_replication_unit (THREAD_ENTRY *thread_p,
+      log_lsa record_lsa, LOG_RCVINDEX rcvindex, VPID vpid, log_rv_redo_context &redo_context,
+      const log_rv_redo_rec_info<T> &record_info)
+  {
+    m_atomic_replication_unit_vector.emplace_back (record_lsa, vpid, rcvindex);
+    auto iterator = m_atomic_sequence_pages_map.find (vpid);
+    if (iterator == m_atomic_sequence_pages_map.cend ())
+      {
+	int error_code = m_atomic_replication_unit_vector.back ().fix_page (thread_p);
+	if (error_code != NO_ERROR)
+	  {
+	    return error_code;
+	  }
+	m_atomic_sequence_pages_map.emplace (vpid,  m_atomic_replication_unit_vector.back ().get_page_ptr ());
+      }
+    else
+      {
+	m_atomic_replication_unit_vector.back ().set_page_ptr (iterator->second ());
+      }
+    m_atomic_replication_unit_vector.back ().apply_log_redo (thread_p, redo_context, record_info);
+    return NO_ERROR;
+  }
+
+  void atomic_replication_helper::atomic_replication_sequence::unfix_sequence (THREAD_ENTRY *thread_p)
+  {
+    for (size_t i = 0; i < m_atomic_replication_unit_vector.size (); i++)
+      {
+	auto iterator = m_atomic_sequence_pages_map.find (m_atomic_replication_unit_vector[i].m_vpid);
+	if (iterator != m_atomic_sequence_pages_map.end ())
+	  {
+	    m_atomic_replication_unit_vector[i].unfix_page (thread_p);
+	    m_atomic_sequence_pages_map.erase (iterator);
+	  }
+      }
+  }
+
 
   /****************************************************************************
    * atomic_replication_helper::atomic_replication_unit function definitions  *
    ****************************************************************************/
 
-  atomic_replication_helper::atomic_replication_unit::atomic_replication_unit (log_lsa lsa, VPID vpid,
-      LOG_RCVINDEX rcvindex)
+  atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::atomic_replication_unit (log_lsa lsa,
+      VPID vpid, LOG_RCVINDEX rcvindex)
     : m_record_lsa { lsa }
     , m_vpid { vpid }
     , m_record_index { rcvindex }
@@ -126,14 +160,14 @@ namespace cublog
     PGBUF_INIT_WATCHER (&m_watcher, PGBUF_ORDERED_HEAP_NORMAL, PGBUF_ORDERED_NULL_HFID);
   }
 
-  atomic_replication_helper::atomic_replication_unit::~atomic_replication_unit ()
+  atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::~atomic_replication_unit ()
   {
     PGBUF_CLEAR_WATCHER (&m_watcher);
   }
 
   template <typename T>
-  void atomic_replication_helper::atomic_replication_unit::apply_log_redo (THREAD_ENTRY *thread_p,
-      log_rv_redo_context &redo_context, const log_rv_redo_rec_info<T> &record_info)
+  void atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::apply_log_redo (
+	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, const log_rv_redo_rec_info<T> &record_info)
   {
     LOG_RCV rcv;
     if (m_page_ptr != nullptr)
@@ -153,7 +187,7 @@ namespace cublog
       }
   }
 
-  int atomic_replication_helper::atomic_replication_unit::fix_page (THREAD_ENTRY *thread_p)
+  int atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::fix_page (THREAD_ENTRY *thread_p)
   {
     switch (m_record_index)
       {
@@ -194,7 +228,8 @@ namespace cublog
     return NO_ERROR;
   }
 
-  void atomic_replication_helper::atomic_replication_unit::unfix_page (THREAD_ENTRY *thread_p)
+  void atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::unfix_page (
+	  THREAD_ENTRY *thread_p)
   {
     switch (m_record_index)
       {
@@ -214,5 +249,19 @@ namespace cublog
 	pgbuf_unfix (thread_p, m_page_ptr);
 	break;
       }
+  }
+
+  PAGE_PTR atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::get_page_ptr ()
+  {
+    if (m_page_ptr != nullptr)
+      {
+	return m_page_ptr;
+      }
+    return m_watcher.pgptr;
+  }
+
+  void atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::set_page_ptr (PAGE_PTR &ptr)
+  {
+    m_page_ptr = ptr;
   }
 }

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -101,7 +101,7 @@ namespace cublog
 	      int fix_page (THREAD_ENTRY *thread_p);
 	      void unfix_page (THREAD_ENTRY *thread_p);
 	      PAGE_PTR get_page_ptr ();
-	      void set_page_ptr (PAGE_PTR &ptr);
+	      void set_page_ptr (const PAGE_PTR &ptr);
 
 	      VPID m_vpid;
 	    private:
@@ -111,14 +111,16 @@ namespace cublog
 	      LOG_RCVINDEX m_record_index;
 	  };
 
-	  std::vector<atomic_replication_unit> m_atomic_replication_unit_vector;
-	  std::map<VPID, PAGE_PTR> m_atomic_sequence_pages_map;
+	  using atomic_unit_vector = std::vector<atomic_replication_unit>;
+	  atomic_unit_vector m_units;
+	  using vpid_to_page_ptr_map = std::map<VPID, PAGE_PTR>;
+	  vpid_to_page_ptr_map m_page_map;
       };
 
-      std::map<TRANID, atomic_replication_sequence> m_atomic_sequences_map;
+      std::map<TRANID, atomic_replication_sequence> m_sequences_map;
 #if !defined (NDEBUG)
       using vpid_set_type = std::set<VPID>;
-      std::map<TRANID, vpid_set_type> m_atomic_sequences_vpids_map;
+      std::map<TRANID, vpid_set_type> m_vpid_sets_map;
 #endif
   };
 }

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -28,6 +28,7 @@
 #include "log_recovery_redo.hpp"
 #include "page_buffer.h"
 #include "thread_entry.hpp"
+#include "vpid_utilities.hpp"
 
 namespace cublog
 {
@@ -57,40 +58,64 @@ namespace cublog
 #endif
 
     private:
-      /*
-       * Atomic replication unit holds the log record information necessary for recovery redo
-       */
-      class atomic_replication_unit
+
+      class atomic_replication_sequence
       {
 	public:
-	  atomic_replication_unit () = delete;
-	  atomic_replication_unit (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex);
+	  atomic_replication_sequence () = default;
 
-	  atomic_replication_unit (const atomic_replication_unit &) = delete;
-	  atomic_replication_unit (atomic_replication_unit &&) = delete;
+	  atomic_replication_sequence (const atomic_replication_sequence &) = delete;
+	  atomic_replication_sequence (atomic_replication_sequence &&) = delete;
 
-	  ~atomic_replication_unit ();
+	  ~atomic_replication_sequence () = default;
 
-	  atomic_replication_unit &operator= (const atomic_replication_unit &) = delete;
-	  atomic_replication_unit &operator= (atomic_replication_unit &&) = delete;
+	  atomic_replication_sequence &operator= (const atomic_replication_sequence &) = delete;
+	  atomic_replication_sequence &operator= (atomic_replication_sequence &&) = delete;
 
-	  template <typename T>
-	  void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
-			       const log_rv_redo_rec_info<T> &record_info);
-	  int fix_page (THREAD_ENTRY *thread_p);
-	  void unfix_page (THREAD_ENTRY *thread_p);
-
-	  VPID m_vpid;
+	  void unfix_sequence (THREAD_ENTRY *thread_p);
 	private:
-	  log_lsa m_record_lsa;
-	  PAGE_PTR m_page_ptr;
-	  PGBUF_WATCHER m_watcher;
-	  LOG_RCVINDEX m_record_index;
+	  template <typename T>
+	  int add_atomic_replication_unit (THREAD_ENTRY *thread_p, log_lsa record_lsa, LOG_RCVINDEX rcvindex, VPID vpid,
+					   log_rv_redo_context &redo_context, const log_rv_redo_rec_info<T> &record_info);
+
+	  /*
+	   * Atomic replication unit holds the log record information necessary for recovery redo
+	   */
+	  class atomic_replication_unit
+	  {
+	    public:
+	      atomic_replication_unit () = delete;
+	      atomic_replication_unit (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex);
+
+	      atomic_replication_unit (const atomic_replication_unit &) = delete;
+	      atomic_replication_unit (atomic_replication_unit &&) = delete;
+
+	      ~atomic_replication_unit ();
+
+	      atomic_replication_unit &operator= (const atomic_replication_unit &) = delete;
+	      atomic_replication_unit &operator= (atomic_replication_unit &&) = delete;
+
+	      template <typename T>
+	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
+				   const log_rv_redo_rec_info<T> &record_info);
+	      int fix_page (THREAD_ENTRY *thread_p);
+	      void unfix_page (THREAD_ENTRY *thread_p);
+	      PAGE_PTR get_page_ptr ();
+	      void set_page_ptr (PAGE_PTR &ptr);
+
+	      VPID m_vpid;
+	    private:
+	      log_lsa m_record_lsa;
+	      PAGE_PTR m_page_ptr;
+	      PGBUF_WATCHER m_watcher;
+	      LOG_RCVINDEX m_record_index;
+	  };
+
+	  std::vector<atomic_replication_unit> m_atomic_replication_unit_vector;
+	  std::map<VPID, PAGE_PTR> m_atomic_sequence_pages_map;
       };
 
-      using atomic_replication_sequence_type = std::vector<atomic_replication_unit>;
-      std::map<TRANID, atomic_replication_sequence_type> m_atomic_sequences_map;
-
+      std::map<TRANID, atomic_replication_sequence> m_atomic_sequences_map;
 #if !defined (NDEBUG)
       using vpid_set_type = std::set<VPID>;
       std::map<TRANID, vpid_set_type> m_atomic_sequences_vpids_map;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-462

During atomic replication the same sequence might have logs that affect the same page. With existing mechanism each log had to fix its page leading to double fixes in the situation previously described. 

To overcome this issue a new class was added called 'atomic_replication_sequence', this will provide an additional map of `VPID` to `PAGE_PTR` to check before fixing if the page is already part of the sequence.

The new class hierarchy:
atomic_replication_helper
 |_______ atomic_replication_sequence
________ |______________ atomic_replication_unit
