### PR TITLE
[CBRD-24362] Remove unnecessary assert()

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12475,8 +12475,6 @@ cdc_check_if_schema_changed (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info)
 static int
 cdc_get_attribute_size (DB_VALUE * value)
 {
-  assert (!DB_IS_NULL (value));
-
   int size = 0;
 
   switch (DB_VALUE_TYPE (value))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24362

Purpose

DB_VALUE can have a NULL data, and the CDC is also handling this, but core has occurred because inserting assert here.
This assertion is unnecessary, so this is removed