### PR TITLE
[LETS-465] complete transaction mvccid on passive transaction server

### DIFF
--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -216,29 +216,29 @@ namespace cublog
 	switch (header.type)
 	  {
 	  case LOG_REDO_DATA:
-	    read_and_redo_record<log_rec_redo> (thread_entry, header, m_redo_lsa);
+	    read_and_redo_record<LOG_REC_REDO> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_MVCC_REDO_DATA:
-	    read_and_redo_record<log_rec_mvcc_redo> (thread_entry, header, m_redo_lsa);
+	    read_and_redo_record<LOG_REC_MVCC_REDO> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_UNDOREDO_DATA:
 	  case LOG_DIFF_UNDOREDO_DATA:
-	    read_and_redo_record<log_rec_undoredo> (thread_entry, header, m_redo_lsa);
+	    read_and_redo_record<LOG_REC_UNDOREDO> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_MVCC_UNDOREDO_DATA:
 	  case LOG_MVCC_DIFF_UNDOREDO_DATA:
-	    read_and_redo_record<log_rec_mvcc_undoredo> (thread_entry, header, m_redo_lsa);
+	    read_and_redo_record<LOG_REC_MVCC_UNDOREDO> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_RUN_POSTPONE:
-	    read_and_redo_record<log_rec_run_postpone> (thread_entry, header, m_redo_lsa);
+	    read_and_redo_record<LOG_REC_RUN_POSTPONE> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_COMPENSATE:
-	    read_and_redo_record<log_rec_compensate> (thread_entry, header, m_redo_lsa);
+	    read_and_redo_record<LOG_REC_COMPENSATE> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_DBEXTERN_REDO_DATA:
 	  {
-	    const log_rec_dbout_redo dbout_redo =
-		    m_redo_context.m_reader.reinterpret_copy_and_add_align<log_rec_dbout_redo> ();
+	    const LOG_REC_DBOUT_REDO dbout_redo =
+		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_DBOUT_REDO> ();
 	    log_rcv rcv;
 	    rcv.length = dbout_redo.length;
 
@@ -251,7 +251,7 @@ namespace cublog
 	      {
 		m_replicator_mvccid->complete_mvcc (header.trid, replicator_mvcc::COMMITTED);
 	      }
-	    calculate_replication_delay_or_dispatch_async<log_rec_donetime> (
+	    calculate_replication_delay_or_dispatch_async<LOG_REC_DONETIME> (
 		    thread_entry, m_redo_lsa);
 	    break;
 	  case LOG_ABORT:
@@ -259,11 +259,11 @@ namespace cublog
 	      {
 		m_replicator_mvccid->complete_mvcc (header.trid, replicator_mvcc::ABORTED);
 	      }
-	    calculate_replication_delay_or_dispatch_async<log_rec_donetime> (
+	    calculate_replication_delay_or_dispatch_async<LOG_REC_DONETIME> (
 		    thread_entry, m_redo_lsa);
 	    break;
 	  case LOG_DUMMY_HA_SERVER_STATE:
-	    calculate_replication_delay_or_dispatch_async<log_rec_ha_server_state> (
+	    calculate_replication_delay_or_dispatch_async<LOG_REC_HA_SERVER_STATE> (
 		    thread_entry, m_redo_lsa);
 	    break;
 	  case LOG_TRANTABLE_SNAPSHOT:
@@ -272,15 +272,15 @@ namespace cublog
 	    m_most_recent_trantable_snapshot_lsa.store (m_redo_lsa);
 	    break;
 	  case LOG_MVCC_UNDO_DATA:
-	    read_and_bookkeep_mvcc_vacuum<log_rec_mvcc_undo> (header.type, header.back_lsa, m_redo_lsa, true);
+	    read_and_bookkeep_mvcc_vacuum<LOG_REC_MVCC_UNDO> (header.type, header.back_lsa, m_redo_lsa, true);
 	    break;
 	  case LOG_SYSOP_END:
-	    read_and_bookkeep_mvcc_vacuum<log_rec_sysop_end> (header.type, header.back_lsa, m_redo_lsa, false);
+	    read_and_bookkeep_mvcc_vacuum<LOG_REC_SYSOP_END> (header.type, header.back_lsa, m_redo_lsa, false);
 	    break;
 	  case LOG_ASSIGNED_MVCCID:
 	    if (m_replicate_mvcc)
 	      {
-		register_assigned_mvccid<log_rec_assigned_mvccid> (header.trid);
+		register_assigned_mvccid<LOG_REC_ASSIGNED_MVCCID> (header.trid);
 	      }
 	    break;
 	  default:

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -211,29 +211,29 @@ namespace cublog
 	// read and redo a record
 	(void) m_redo_context.m_reader.set_lsa_and_fetch_page (m_redo_lsa);
 
-	const log_rec_header header = m_redo_context.m_reader.reinterpret_copy_and_add_align<log_rec_header> ();
+	const LOG_RECORD_HEADER header = m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_RECORD_HEADER> ();
 
 	switch (header.type)
 	  {
 	  case LOG_REDO_DATA:
-	    read_and_redo_record<log_rec_redo> (thread_entry, header.type, header.back_lsa, m_redo_lsa);
+	    read_and_redo_record<log_rec_redo> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_MVCC_REDO_DATA:
-	    read_and_redo_record<log_rec_mvcc_redo> (thread_entry, header.type, header.back_lsa, m_redo_lsa);
+	    read_and_redo_record<log_rec_mvcc_redo> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_UNDOREDO_DATA:
 	  case LOG_DIFF_UNDOREDO_DATA:
-	    read_and_redo_record<log_rec_undoredo> (thread_entry, header.type, header.back_lsa, m_redo_lsa);
+	    read_and_redo_record<log_rec_undoredo> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_MVCC_UNDOREDO_DATA:
 	  case LOG_MVCC_DIFF_UNDOREDO_DATA:
-	    read_and_redo_record<log_rec_mvcc_undoredo> (thread_entry, header.type, header.back_lsa, m_redo_lsa);
+	    read_and_redo_record<log_rec_mvcc_undoredo> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_RUN_POSTPONE:
-	    read_and_redo_record<log_rec_run_postpone> (thread_entry, header.type, header.back_lsa, m_redo_lsa);
+	    read_and_redo_record<log_rec_run_postpone> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_COMPENSATE:
-	    read_and_redo_record<log_rec_compensate> (thread_entry, header.type, header.back_lsa, m_redo_lsa);
+	    read_and_redo_record<log_rec_compensate> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_DBEXTERN_REDO_DATA:
 	  {
@@ -257,7 +257,7 @@ namespace cublog
 	  case LOG_ABORT:
 	    if (m_replicate_mvcc)
 	      {
-		m_replicator_mvccid->complete_mvcc (header.trid, replicator_mvcc::ROLLEDBACK);
+		m_replicator_mvccid->complete_mvcc (header.trid, replicator_mvcc::ABORTED);
 	      }
 	    calculate_replication_delay_or_dispatch_async<log_rec_donetime> (
 		    thread_entry, m_redo_lsa);
@@ -353,17 +353,21 @@ namespace cublog
 
   template <typename T>
   void
-  replicator::read_and_redo_record (cubthread::entry &thread_entry, LOG_RECTYPE rectype,
-				    const log_lsa &prev_rec_lsa, const log_lsa &rec_lsa)
+  replicator::read_and_redo_record (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header,
+				    const log_lsa &rec_lsa)
   {
     m_redo_context.m_reader.advance_when_does_not_fit (sizeof (T));
-    const log_rv_redo_rec_info<T> record_info (rec_lsa, rectype,
+    const log_rv_redo_rec_info<T> record_info (rec_lsa, rec_header.type,
 	m_redo_context.m_reader.reinterpret_copy_and_add_align<T> ());
 
     // only mvccids that pertain to redo's are processed here
     const MVCCID mvccid = log_rv_get_log_rec_mvccid (record_info.m_logrec);
     assert_correct_mvccid (record_info.m_logrec, mvccid);
-    log_replication_update_header_mvcc_vacuum_info (mvccid, prev_rec_lsa, rec_lsa, m_bookkeep_mvcc_vacuum_info);
+    log_replication_update_header_mvcc_vacuum_info (mvccid, rec_header.back_lsa, rec_lsa, m_bookkeep_mvcc_vacuum_info);
+    if (m_replicate_mvcc && MVCCID_IS_NORMAL (mvccid))
+      {
+	m_replicator_mvccid->new_assigned_mvccid (rec_header.trid, mvccid);
+      }
 
     // Redo b-tree stats differs from what the recovery usually does. Get the recovery index before deciding how to
     // proceed.

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -82,8 +82,8 @@ namespace cublog
       void redo_upto_nxio_lsa (cubthread::entry &thread_entry);
       void redo_upto (cubthread::entry &thread_entry, const log_lsa &end_redo_lsa);
       template <typename T>
-      void read_and_redo_record (cubthread::entry &thread_entry, LOG_RECTYPE rectype,
-				 const log_lsa &prev_rec_lsa, const log_lsa &rec_lsa);
+      void read_and_redo_record (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header,
+				 const log_lsa &rec_lsa);
       template <typename T>
       void read_and_bookkeep_mvcc_vacuum (LOG_RECTYPE rectype, const log_lsa &prev_rec_lsa, const log_lsa &rec_lsa,
 					  bool assert_mvccid_non_null);

--- a/src/transaction/log_replication_mvcc.cpp
+++ b/src/transaction/log_replication_mvcc.cpp
@@ -16,7 +16,6 @@
  *
  */
 
-
 #include "log_replication_mvcc.hpp"
 
 #include "log_impl.h"
@@ -33,9 +32,19 @@ namespace cublog
   void
   replicator_mvcc::new_assigned_mvccid (TRANID tranid, MVCCID mvccid)
   {
-    assert (m_mapped_mvccids.find (tranid) == m_mapped_mvccids.cend ());
+    MVCCID_IS_NORMAL (mvccid);
 
-    m_mapped_mvccids.emplace (tranid, mvccid);
+    const auto found_it = m_mapped_mvccids.find (tranid);
+    if (found_it == m_mapped_mvccids.cend ())
+      {
+	m_mapped_mvccids.emplace (tranid, mvccid);
+      }
+    else
+      {
+	// only one mvccid per transaction is assumed
+	// sub-transaction mvccid's are not implemented yet
+	assert (found_it->second == mvccid);
+      }
   }
 
   void
@@ -49,6 +58,6 @@ namespace cublog
 	log_Gl.mvcc_table.complete_mvcc (tranid, found_mvccid, committed);
 	m_mapped_mvccids.erase (found_it);
       }
-    // if not found, it means the transaction contains proper MVCC log records
+    // if not found the transaction never assigned an mvccid
   }
 }

--- a/src/transaction/log_replication_mvcc.cpp
+++ b/src/transaction/log_replication_mvcc.cpp
@@ -32,7 +32,7 @@ namespace cublog
   void
   replicator_mvcc::new_assigned_mvccid (TRANID tranid, MVCCID mvccid)
   {
-    MVCCID_IS_NORMAL (mvccid);
+    assert (MVCCID_IS_NORMAL (mvccid));
 
     const auto found_it = m_mapped_mvccids.find (tranid);
     if (found_it == m_mapped_mvccids.cend ())

--- a/src/transaction/log_replication_mvcc.hpp
+++ b/src/transaction/log_replication_mvcc.hpp
@@ -16,7 +16,7 @@ namespace cublog
   {
     public:
       static constexpr bool COMMITTED = true;
-      static constexpr bool ROLLEDBACK = false;
+      static constexpr bool ABORTED = false;
 
     public:
       replicator_mvcc () = default;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-465

Register and complete mvccid's on passive transaction server when transaction commits/aborts.

Sub-transactions (implemented as sysops) which might also allocate mvccid's will be implemented separately.

Implementation:
- mvccid extraction from log records was already present in `replicator::read_and_redo_record`
- reused the `m_replicator_mvccid` implementation already used for `LOG_ASSIGNED_MVCCID` to keep track of tranid - mvccid pairs until the occurence of either a commit or an abort
- only one `mvccid` per transaction is allowed (assert in `replicator_mvcc::new_assigned_mvccid`) - sub-transactions will be supported by a subsequent patch
