### PR TITLE
[CBRD-24078] support CDC APIs on Windows

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -663,15 +663,15 @@ cubrid_log_error:
       free_and_init (recv_data);
     }
 
-  queue_entry = css_find_queue_entry (g_conn_entry->buffer_queue, rid);
-  if (queue_entry != NULL)
-    {
-      queue_entry->buffer = NULL;
-      css_queue_remove_header_entry_ptr (&g_conn_entry->buffer_queue, queue_entry);
-    }
-
   if (g_conn_entry != NULL)
     {
+      queue_entry = css_find_queue_entry (g_conn_entry->buffer_queue, rid);
+      if (queue_entry != NULL)
+	{
+	  queue_entry->buffer = NULL;
+	  css_queue_remove_header_entry_ptr (&g_conn_entry->buffer_queue, queue_entry);
+	}
+
       css_free_conn (g_conn_entry);
       g_conn_entry = NULL;
     }
@@ -1896,15 +1896,15 @@ cubrid_log_error:
       free_and_init (recv_data);
     }
 
-  queue_entry = css_find_queue_entry (g_conn_entry->buffer_queue, rid);
-  if (queue_entry != NULL)
-    {
-      queue_entry->buffer = NULL;
-      css_queue_remove_header_entry_ptr (&g_conn_entry->buffer_queue, queue_entry);
-    }
-
   if (g_conn_entry != NULL)
     {
+      queue_entry = css_find_queue_entry (g_conn_entry->buffer_queue, rid);
+      if (queue_entry != NULL)
+	{
+	  queue_entry->buffer = NULL;
+	  css_queue_remove_header_entry_ptr (&g_conn_entry->buffer_queue, queue_entry);
+	}
+
       css_free_conn (g_conn_entry);
       g_conn_entry = NULL;
     }

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -615,12 +615,12 @@ cubrid_log_connect_server_internal (char *host, int port, char *dbname)
       if (css_receive_data (g_conn_entry, rid, &recv_data, &recv_data_size, g_connection_timeout * 1000) != NO_ERRORS)
 	{
 	  CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT,
-				     "Failed to receive data while making new connection with server.\n");
+				     "Failed to receive the server port id from the master.\n");
 	}
 
       if (recv_data != NULL && recv_data_size == sizeof (int))
 	{
-	  int port id = ntohl (*((int *) recv_data));
+	  int port_id = ntohl (*((int *) recv_data));
 	  css_close_conn (g_conn_entry);
 
 	  if (recv_data != (char *) &reason)

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -638,6 +638,12 @@ cubrid_log_connect_server_internal (char *host, int port, char *dbname)
 					 "Failed to connect to the server with new port id (%d)\n", port_id);
 	    }
 	}
+      else
+	{
+	  CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT,
+				     "Failed to get server port id (recv_data = %s , recv_data_size = %d) \n",
+				     recv_data, recv_data_size);
+	}
     }
   else
     {

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -53,6 +53,10 @@
 #include "dbtype_def.h"
 #include "porting.h"
 
+#if defined(WINDOWS)
+#include "wintcp.h"
+#endif
+
 #define CUBRID_LOG_WRITE_TRACELOG(msg, ...) \
   do\
     {\
@@ -557,79 +561,31 @@ cubrid_log_set_extraction_user (char **user_arr, int arr_size)
 static int
 cubrid_log_connect_server_internal (char *host, int port, char *dbname)
 {
-  unsigned short rid = 0;
-
-  char *recv_data = NULL;
-  int recv_data_size;
-
-  int reason;
-
-  CSS_QUEUE_ENTRY *queue_entry;
   int err_code;
 
-  g_conn_entry = css_make_conn (INVALID_SOCKET);
+#if defined (WINDOWS)
+  (void) css_windows_startup ();
+#endif
+
+  g_conn_entry = css_connect_to_cubrid_server (host, dbname);
   if (g_conn_entry == NULL)
     {
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT, "Failed to make css_conn_entry to connect to the server\n");
-    }
-
-  if (css_common_connect
-      (host, g_conn_entry, DATA_REQUEST, dbname, (int) strlen (dbname) + 1, port, g_connection_timeout, &rid,
-       true) == NULL)
-    {
-      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT,
-				 "Failed to connect to the server. host (%s), dbname (%s), port (%d), timeout (%d sec)\n",
-				 host, dbname, port, g_connection_timeout);
-    }
-
-  css_queue_user_data_buffer (g_conn_entry, rid, sizeof (int), (char *) &reason);
-
-  if (css_receive_data (g_conn_entry, rid, &recv_data, &recv_data_size, g_connection_timeout * 1000) != NO_ERRORS)
-    {
-      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT, "Failed to receive data from server. (timeout : %d sec)\n",
-				 g_connection_timeout);
-    }
-
-  if (recv_data == NULL || recv_data_size != sizeof (int))
-    {
-      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT,
-				 "Failed to receive data from server. recv_data is %s, recv_data_size : %d (should be %d)\n",
-				 recv_data ? "not null" : "null", recv_data_size, sizeof (int));
-    }
-
-  reason = ntohl (*(int *) recv_data);
-
-  if (reason != SERVER_CONNECTED)
-    {
-      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT, NULL);
-    }
-
-  if (recv_data != NULL && recv_data != (char *) &reason)
-    {
-      free_and_init (recv_data);
     }
 
   return CUBRID_LOG_SUCCESS;
 
 cubrid_log_error:
 
-  if (recv_data != NULL && recv_data != (char *) &reason)
-    {
-      free_and_init (recv_data);
-    }
-
-  queue_entry = css_find_queue_entry (g_conn_entry->buffer_queue, rid);
-  if (queue_entry != NULL)
-    {
-      queue_entry->buffer = NULL;
-      css_queue_remove_header_entry_ptr (&g_conn_entry->buffer_queue, queue_entry);
-    }
-
   if (g_conn_entry != NULL)
     {
       css_free_conn (g_conn_entry);
       g_conn_entry = NULL;
     }
+
+#if defined (WINDOWS)
+  (void) css_windows_shutdown ();
+#endif
 
   return err_code;
 }
@@ -1930,6 +1886,10 @@ cubrid_log_finalize (void)
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_DISCONNECT, NULL);
     }
 
+#if defined (WINDOWS)
+  (void) css_windows_startup ();
+#endif
+
   (void) cubrid_log_reset_globals ();
 
   g_stage = CUBRID_LOG_STAGE_CONFIGURATION;
@@ -1937,6 +1897,10 @@ cubrid_log_finalize (void)
   return CUBRID_LOG_SUCCESS;
 
 cubrid_log_error:
+
+#if defined (WINDOWS)
+  (void) css_windows_shutdown ();
+#endif
 
   (void) cubrid_log_reset_globals ();
 

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -608,10 +608,7 @@ cubrid_log_connect_server_internal (char *host, int port, char *dbname)
 
   reason = ntohl (*(int *) recv_data);
 
-  if (recv_data != NULL)
-    {
-      free_and_init (recv_data);
-    }
+  free_and_init (recv_data);
 
 #if defined (WINDOWS)
   if (reason == SERVER_CONNECTED_NEW)

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -572,7 +572,10 @@ cubrid_log_connect_server_internal (char *host, int port, char *dbname)
   int err_code;
 
 #if defined (WINDOWS)
-  (void) css_windows_startup ();
+  if (css_windows_startup () < 0)
+    {
+      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT, "Failed to startup Windows socket\n");
+    }
 #endif
 
   g_conn_entry = css_make_conn (INVALID_SOCKET);
@@ -1978,7 +1981,7 @@ cubrid_log_finalize (void)
     }
 
 #if defined (WINDOWS)
-  (void) css_windows_startup ();
+  (void) css_windows_shutdown ();
 #endif
 
   (void) cubrid_log_reset_globals ();

--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -99,14 +99,11 @@ static CSS_CONN_ENTRY *css_Conn_anchor = NULL;
 static int css_Client_id = 0;
 
 static void css_initialize_conn (CSS_CONN_ENTRY * conn, SOCKET fd);
-static void css_close_conn (CSS_CONN_ENTRY * conn);
 static void css_dealloc_conn (CSS_CONN_ENTRY * conn);
 
 static int css_read_header (CSS_CONN_ENTRY * conn, NET_HEADER * local_header);
 static CSS_CONN_ENTRY *css_server_connect (char *host_name, CSS_CONN_ENTRY * conn, char *server_name,
 					   unsigned short *rid);
-static CSS_CONN_ENTRY *css_server_connect_part_two (char *host_name, CSS_CONN_ENTRY * conn, int port_id,
-						    unsigned short *rid);
 static int css_return_queued_data (CSS_CONN_ENTRY * conn, unsigned short request_id, char **buffer, int *buffer_size,
 				   int *rc);
 static int css_return_queued_request (CSS_CONN_ENTRY * conn, unsigned short *rid, int *request, int *buffer_size);
@@ -181,7 +178,7 @@ css_make_conn (SOCKET fd)
  *   return: void
  *   conn(in):
  */
-static void
+void
 css_close_conn (CSS_CONN_ENTRY * conn)
 {
   if (conn && !IS_INVALID_SOCKET (conn->fd))
@@ -814,7 +811,7 @@ css_server_connect (char *host_name, CSS_CONN_ENTRY * conn, char *server_name, u
  *   port_id(in):
  *   rid(in):
  */
-static CSS_CONN_ENTRY *
+CSS_CONN_ENTRY *
 css_server_connect_part_two (char *host_name, CSS_CONN_ENTRY * conn, int port_id, unsigned short *rid)
 {
   int reason = -1, buffer_size;

--- a/src/connection/connection_cl.h
+++ b/src/connection/connection_cl.h
@@ -79,5 +79,6 @@ extern int css_return_queued_error (CSS_CONN_ENTRY * conn, unsigned short reques
 extern void css_remove_all_unexpected_packets (CSS_CONN_ENTRY * conn);
 extern int css_read_one_request (CSS_CONN_ENTRY * conn, unsigned short *rid, int *request, int *buffer_size);
 extern void css_close_conn (CSS_CONN_ENTRY * conn);
-extern CSS_CONN_ENTRY *css_server_connect_part_two (char *host_name, CSS_CONN_ENTRY * conn, int port_id, unsigned short *rid);
+extern CSS_CONN_ENTRY *css_server_connect_part_two (char *host_name, CSS_CONN_ENTRY * conn, int port_id,
+						    unsigned short *rid);
 #endif /* _CONNECTION_CL_H_ */

--- a/src/connection/connection_cl.h
+++ b/src/connection/connection_cl.h
@@ -78,4 +78,6 @@ extern int css_return_queued_error (CSS_CONN_ENTRY * conn, unsigned short reques
 				    int *rc);
 extern void css_remove_all_unexpected_packets (CSS_CONN_ENTRY * conn);
 extern int css_read_one_request (CSS_CONN_ENTRY * conn, unsigned short *rid, int *request, int *buffer_size);
+extern void css_close_conn (CSS_CONN_ENTRY * conn);
+extern CSS_CONN_ENTRY *css_server_connect_part_two (char *host_name, CSS_CONN_ENTRY * conn, int port_id, unsigned short *rid);
 #endif /* _CONNECTION_CL_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24078

Purpose

Support window style server connection (new style connection) in CDC
CDC requires a connection to the server, and the method of connecting to the server on Windows is different from on Linux.
On Windows, the master process does not directly establish a connection with the server, but delivers the server's port id to the client. It needs to connect to the server again with this port id.