### PR TITLE
[CBRD-24078] Activate a daemon for appending ha server state logs on Windows

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10219,10 +10219,6 @@ log_clock_execute (cubthread::entry & thread_ref)
 static void
 log_check_ha_delay_info_execute (cubthread::entry &thread_ref)
 {
-#if defined(WINDOWS)
-  return;
-#endif /* WINDOWS */
-
   if (!BO_IS_SERVER_RESTARTED ())
     {
       // wait for boot to finish


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24078

Purpose

To support CDC on Windows, LOG_DUMMY_HA_SERVER_STATE logs are required to be appended on Windows. 
