### PR TITLE
[CBRD-24375] Fix to support flashback on Windows

### DIFF
--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -125,6 +125,8 @@ namespace cubthread
     , clear_trace (false)
     , tran_entries ()
     , no_supplemental_log (false)
+    , trigger_involved (false)
+    , is_cdc_daemon (false)
 #if !defined (NDEBUG)
     , fi_test_array (NULL)
     , count_private_allocators (0)

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -493,6 +493,7 @@ EXPORTS
     acldb
     vacuumdb
     tde
+    flashback
 ;
 ; libesql reference's functions
 ;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24375

Purpose

Initialize the members in thread entry and add flashback utility at windows build.