### PR TITLE
[LETS-289] a transaction can have at most one MVCC sub-id

### DIFF
--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1006,6 +1006,7 @@ prior_lsa_gen_undoredo_record_from_crumbs (THREAD_ENTRY *thread_p, LOG_PRIOR_NOD
 	{
 	  if (!tdes->mvccinfo.sub_ids.empty ())
 	    {
+	      assert (tdes->mvccinfo.sub_ids.size () == 1);
 	      *mvccid_p = tdes->mvccinfo.sub_ids.back ();
 	    }
 	  else

--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -336,6 +336,7 @@ namespace cublog
 	tdes->mvccinfo.id = chkpt.mvcc_id;
 	if (chkpt.mvcc_sub_id != MVCCID_NULL)
 	  {
+	    assert (tdes->mvccinfo.sub_ids.size () == 0);
 	    tdes->mvccinfo.sub_ids.emplace_back (chkpt.mvcc_sub_id);
 	  }
 	tdes->client.set_system_internal_with_user (chkpt.user_name);

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -75,6 +75,8 @@ enum log_rectype
                                  *   usually affects more than one page). end system operation also includes undo data that
                                  *   is processed during rollback or undo.
                                  *
+                                 * - LOG_SYSOP_END_LOGICAL_MVCC_UNDO: TODO:
+                                 *
                                  * - LOG_SYSOP_END_LOGICAL_COMPENSATE: system operation is used for complex logical operation
                                  *   that has the purpose of compensating a change on undo or rollback. end system operation
                                  *   also includes the LSA of previous undo log record.

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1464,6 +1464,7 @@ logtb_free_tran_mvcc_info (LOG_TDES * tdes)
   MVCC_INFO *curr_mvcc_info = &tdes->mvccinfo;
 
   curr_mvcc_info->snapshot.m_active_mvccs.finalize ();
+  assert (curr_mvcc_info->sub_ids.size () <= 1);
   curr_mvcc_info->sub_ids.clear ();
 }
 
@@ -3852,6 +3853,7 @@ logtb_find_current_mvccid (THREAD_ENTRY * thread_p)
     {
       if (!tdes->mvccinfo.sub_ids.empty ())
 	{
+	  assert (tdes->mvccinfo.sub_ids.size () == 1);
 	  id = tdes->mvccinfo.sub_ids.back ();
 	}
       else
@@ -3890,6 +3892,7 @@ logtb_get_current_mvccid (THREAD_ENTRY * thread_p)
 
   if (!tdes->mvccinfo.sub_ids.empty ())
     {
+      assert (tdes->mvccinfo.sub_ids.size () == 1);
       return tdes->mvccinfo.sub_ids.back ();
     }
 
@@ -3919,6 +3922,7 @@ logtb_is_current_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid)
     }
   else if (curr_mvcc_info->sub_ids.size () > 0)
     {
+      assert (curr_mvcc_info->sub_ids.size () == 1);
       for (size_t i = 0; i < curr_mvcc_info->sub_ids.size (); i++)
 	{
 	  if (curr_mvcc_info->sub_ids[i] == mvccid)
@@ -4508,6 +4512,7 @@ logtb_assign_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_INFO * curr_mv
 {
   assert (curr_mvcc_info != NULL);
   assert (MVCCID_IS_VALID (curr_mvcc_info->id));
+  assert (curr_mvcc_info->sub_ids.size () == 0);
   curr_mvcc_info->sub_ids.push_back (mvcc_subid);
 }
 
@@ -4532,6 +4537,7 @@ logtb_complete_sub_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 
   mvcc_table->complete_sub_mvcc (mvcc_sub_id);
   curr_mvcc_info->sub_ids.pop_back ();
+  assert (curr_mvcc_info->sub_ids.size () == 0);
 
   if (tdes->mvccinfo.snapshot.valid)
     {

--- a/src/transaction/mvcc.h
+++ b/src/transaction/mvcc.h
@@ -202,7 +202,9 @@ struct mvcc_info
   MVCCID recent_snapshot_lowest_active_mvccid;
 
   // *INDENT-OFF*
-  std::vector<MVCCID> sub_ids;		/* MVCC sub-transaction ID array */
+  std::vector<MVCCID> sub_ids;		/* MVCC sub-transaction ID array. Even if the implementation supports more than
+                                         * one transaction mvcc sub-id, in practice the scenario is never encountered and
+                                         * asserts are present everywhere in this regard. */
   // *INDENT-ON*
   bool is_sub_active;		/* true in case that sub-transaction is running */
 

--- a/src/transaction/mvcc_table.cpp
+++ b/src/transaction/mvcc_table.cpp
@@ -550,7 +550,7 @@ mvcctable::complete_sub_mvcc (MVCCID mvccid)
   // update current trans status
   m_current_trans_status.m_active_mvccs.set_inactive_mvccid (mvccid);
   m_current_trans_status.m_last_completed_mvccid = mvccid;
-  m_current_trans_status.m_last_completed_mvccid = mvcc_trans_status::SUBTRAN;
+  m_current_trans_status.m_event_type = mvcc_trans_status::SUBTRAN;
 
   // finish next trans status
   next_tran_status_finish (next_status, next_index);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-289

A transaction can have at most one MVCC sub-id.
Added asserts all over the place regarding this.

Other:
- corrected typo `m_event_type`; the variable is not used anyway (only assigned)