### PR TITLE
[LETS-289] new debug system parameter for PTS replication

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -707,6 +707,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_ER_LOG_COMM_CHANNEL "er_log_comm_channel"
 #define PRM_NAME_ER_LOG_COMMIT_CONFIRM "er_log_commit_confirm"
 #define PRM_NAME_ER_LOG_CALC_REPL_DELAY "er_log_calculate_replication_delay"
+#define PRM_NAME_ER_LOG_PTS_REPL_DEBUG "er_log_pts_repl_debug"
 
 #define PRM_NAME_RECOVERY_PARALLEL_COUNT "recovery_parallel_count"
 #define PRM_NAME_RECOVERY_PARALLEL_TASK_DEBUG "recovery_parallel_task_debug"
@@ -2430,6 +2431,10 @@ static unsigned int prm_er_log_read_data_page_flag = 0;
 bool PRM_ER_LOG_CALC_REPL_DELAY = true;
 static bool prm_er_log_calc_repl_delay_default = false;
 static unsigned int prm_er_log_calc_repl_delay_flag = 0;
+
+bool PRM_ER_LOG_PTS_REPL_DEBUG = true;
+static bool prm_er_log_pts_repl_debug_default = false;
+static unsigned int prm_er_log_pts_repl_debug_flag = 0;
 
 static unsigned int prm_recovery_parallel_count_flag = 0;
 static int prm_recovery_parallel_count_default = 8;
@@ -6316,6 +6321,18 @@ static SYSPRM_PARAM prm_Def[] = {
    &prm_er_log_calc_repl_delay_flag,
    (void *) &prm_er_log_calc_repl_delay_default,
    (void *) &PRM_ER_LOG_CALC_REPL_DELAY,
+   (void *) NULL,
+   (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_ER_LOG_PTS_REPL_DEBUG,
+   PRM_NAME_ER_LOG_PTS_REPL_DEBUG,
+   (PRM_HIDDEN | PRM_FOR_SERVER | PRM_USER_CHANGE),
+   PRM_BOOLEAN,
+   &prm_er_log_pts_repl_debug_flag,
+   (void *) &prm_er_log_pts_repl_debug_default,
+   (void *) &PRM_ER_LOG_PTS_REPL_DEBUG,
    (void *) NULL,
    (void *) NULL,
    (char *) NULL,

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -465,6 +465,7 @@ enum param_id
   PRM_ID_ER_LOG_READ_LOG_PAGE,
   PRM_ID_ER_LOG_READ_DATA_PAGE,
   PRM_ID_ER_LOG_CALC_REPL_DELAY,
+  PRM_ID_ER_LOG_PTS_REPL_DEBUG,	/* temporary parameter to support passive transaction server replication debugging */
 
   PRM_ID_RECOVERY_PARALLEL_COUNT,
   PRM_ID_RECOVERY_PARALLEL_TASK_DEBUG,


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-289

Added [temporary] parameter for debugging different aspects of PTS replication.
