### PR TITLE
[LETS-460] [Re]organize page fix, apply and page unfix

### DIFF
--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -237,8 +237,7 @@ namespace cublog
       }
 
     redo_context.m_reader.advance_when_does_not_fit (sizeof (T));
-    const log_rv_redo_rec_info<T> record_info (m_record_lsa, rectype,
-	redo_context.m_reader.reinterpret_copy_and_add_align<T> ());
+    const log_rv_redo_rec_info<T> record_info (m_record_lsa, rectype, *redo_context.m_reader.reinterpret_cptr<T> ());
     if (log_rv_check_redo_is_needed (rcv.pgptr, record_info.m_start_lsa, redo_context.m_end_redo_lsa))
       {
 	rcv.reference_lsa = m_record_lsa;

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -25,10 +25,10 @@
 
 namespace cublog
 {
-
   /*********************************************************************
    * atomic_replication_helper function definitions                    *
    *********************************************************************/
+
   void atomic_replication_helper::add_atomic_replication_sequence (TRANID trid, log_rv_redo_context redo_context)
   {
     m_sequences_map.emplace (trid, redo_context);
@@ -111,11 +111,13 @@ namespace cublog
     m_vpid_sets_map.erase (tranid);
 #endif
   }
+
   /********************************************************************************
    * atomic_replication_helper::atomic_replication_sequence function definitions  *
    ********************************************************************************/
-  atomic_replication_helper::atomic_replication_sequence::atomic_replication_sequence (log_rv_redo_context redo_cotext)
-    : m_redo_context { redo_cotext }
+
+  atomic_replication_helper::atomic_replication_sequence::atomic_replication_sequence (log_rv_redo_context redo_context)
+    : m_redo_context { redo_context }
   {
 
   }
@@ -149,7 +151,7 @@ namespace cublog
       }
   }
 
-  void atomic_replication_helper::atomic_replication_sequence::unfix_sequence (THREAD_ENTRY *thread_p)
+  void atomic_replication_helper::atomic_replication_sequence::apply_and_unfix_sequence (THREAD_ENTRY *thread_p)
   {
     // sequenceally apply each log redo of the sequence before unfixing
     apply_all_log_redos (thread_p);
@@ -164,7 +166,6 @@ namespace cublog
 	  }
       }
   }
-
 
   /*********************************************************************************************************
    * atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit function definitions  *
@@ -197,24 +198,24 @@ namespace cublog
     switch (header.type)
       {
       case LOG_REDO_DATA:
-	apply_log_by_type<log_rec_redo> (thread_p, redo_context, header.type);
+	apply_log_by_type<LOG_REC_REDO> (thread_p, redo_context, header.type);
 	break;
       case LOG_MVCC_REDO_DATA:
-	apply_log_by_type<log_rec_mvcc_redo> (thread_p, redo_context, header.type);
+	apply_log_by_type<LOG_REC_MVCC_REDO> (thread_p, redo_context, header.type);
 	break;
       case LOG_UNDOREDO_DATA:
       case LOG_DIFF_UNDOREDO_DATA:
-	apply_log_by_type<log_rec_undoredo> (thread_p, redo_context, header.type);
+	apply_log_by_type<LOG_REC_UNDOREDO> (thread_p, redo_context, header.type);
 	break;
       case LOG_MVCC_UNDOREDO_DATA:
       case LOG_MVCC_DIFF_UNDOREDO_DATA:
-	apply_log_by_type<log_rec_mvcc_undoredo> (thread_p, redo_context, header.type);
+	apply_log_by_type<LOG_REC_MVCC_UNDOREDO> (thread_p, redo_context, header.type);
 	break;
       case LOG_RUN_POSTPONE:
-	apply_log_by_type<log_rec_run_postpone> (thread_p, redo_context, header.type);
+	apply_log_by_type<LOG_REC_RUN_POSTPONE> (thread_p, redo_context, header.type);
 	break;
       case LOG_COMPENSATE:
-	apply_log_by_type<log_rec_compensate> (thread_p, redo_context, header.type);
+	apply_log_by_type<LOG_REC_COMPENSATE> (thread_p, redo_context, header.type);
 	break;
       default:
 	break;

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -229,10 +229,12 @@ namespace cublog
     LOG_RCV rcv;
     if (m_page_ptr != nullptr)
       {
+	assert (m_page_ptr != nullptr && m_watcher.pgptr == nullptr);
 	rcv.pgptr = m_page_ptr;
       }
     else
       {
+	assert (m_page_ptr == nullptr && m_watcher.pgptr != nullptr);
 	rcv.pgptr = m_watcher.pgptr;
       }
 

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -104,7 +104,7 @@ namespace cublog
 	return;
       }
 
-    iterator->second.unfix_sequence (thread_p);
+    iterator->second.apply_and_unfix_sequence (thread_p);
     m_sequences_map.erase (iterator);
 
 #if !defined (NDEBUG)

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -238,8 +238,7 @@ namespace cublog
     redo_context.m_reader.advance_when_does_not_fit (sizeof (T));
     const log_rv_redo_rec_info<T> record_info (m_record_lsa, rectype,
 	redo_context.m_reader.reinterpret_copy_and_add_align<T> ());
-    if (log_rv_fix_page_and_check_redo_is_needed (thread_p, m_vpid, rcv.pgptr, record_info.m_start_lsa,
-	redo_context.m_end_redo_lsa, redo_context.m_page_fetch_mode))
+    if (log_rv_check_redo_is_needed (rcv.pgptr, record_info.m_start_lsa, redo_context.m_end_redo_lsa))
       {
 	rcv.reference_lsa = m_record_lsa;
 	log_rv_redo_record_sync_apply (thread_p, redo_context, record_info, m_vpid, rcv);

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -22,7 +22,6 @@
 #include "log_recovery_redo.hpp"
 #include "page_buffer.h"
 #include "system_parameter.h"
-#include "vpid_utilities.hpp"
 
 namespace cublog
 {
@@ -45,14 +44,13 @@ namespace cublog
     vpids.insert (vpid);
 #endif
 
-    m_atomic_sequences_map[tranid].emplace_back (record_lsa, vpid, rcvindex);
-    int error_code = m_atomic_sequences_map[tranid].back ().fix_page (thread_p);
+    int error_code = m_atomic_sequences_map[tranid].add_atomic_replication_unit (thread_p, record_lsa, rcvindex, vpid,
+		     redo_context, record_info);
     if (error_code != NO_ERROR)
       {
 	return error_code;
       }
 
-    m_atomic_sequences_map[tranid].back ().apply_log_redo (thread_p, redo_context, record_info);
     return NO_ERROR;
   }
 
@@ -98,24 +96,60 @@ namespace cublog
 	return;
       }
 
-    for (size_t i = 0; i < iterator->second.size (); i++)
-      {
-	iterator->second[i].unfix_page (thread_p);
-      }
-    iterator->second.clear ();
+    iterator->second.unfix_sequence (thread_p);
     m_atomic_sequences_map.erase (iterator);
 
 #if !defined (NDEBUG)
     m_atomic_sequences_vpids_map.erase (tranid);
 #endif
   }
+  /****************************************************************************
+   * atomic_replication_helper::atomic_replication_unit function definitions  *
+   ****************************************************************************/
+  template <typename T>
+  int atomic_replication_helper::atomic_replication_sequence::add_atomic_replication_unit (THREAD_ENTRY *thread_p,
+      log_lsa record_lsa, LOG_RCVINDEX rcvindex, VPID vpid, log_rv_redo_context &redo_context,
+      const log_rv_redo_rec_info<T> &record_info)
+  {
+    m_atomic_replication_unit_vector.emplace_back (record_lsa, vpid, rcvindex);
+    auto iterator = m_atomic_sequence_pages_map.find (vpid);
+    if (iterator == m_atomic_sequence_pages_map.cend ())
+      {
+	int error_code = m_atomic_replication_unit_vector.back ().fix_page (thread_p);
+	if (error_code != NO_ERROR)
+	  {
+	    return error_code;
+	  }
+	m_atomic_sequence_pages_map.emplace (vpid,  m_atomic_replication_unit_vector.back ().get_page_ptr ());
+      }
+    else
+      {
+	m_atomic_replication_unit_vector.back ().set_page_ptr (iterator->second ());
+      }
+    m_atomic_replication_unit_vector.back ().apply_log_redo (thread_p, redo_context, record_info);
+    return NO_ERROR;
+  }
+
+  void atomic_replication_helper::atomic_replication_sequence::unfix_sequence (THREAD_ENTRY *thread_p)
+  {
+    for (size_t i = 0; i < m_atomic_replication_unit_vector.size (); i++)
+      {
+	auto iterator = m_atomic_sequence_pages_map.find (m_atomic_replication_unit_vector[i].m_vpid);
+	if (iterator != m_atomic_sequence_pages_map.end ())
+	  {
+	    m_atomic_replication_unit_vector[i].unfix_page (thread_p);
+	    m_atomic_sequence_pages_map.erase (iterator);
+	  }
+      }
+  }
+
 
   /****************************************************************************
    * atomic_replication_helper::atomic_replication_unit function definitions  *
    ****************************************************************************/
 
-  atomic_replication_helper::atomic_replication_unit::atomic_replication_unit (log_lsa lsa, VPID vpid,
-      LOG_RCVINDEX rcvindex)
+  atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::atomic_replication_unit (log_lsa lsa,
+      VPID vpid, LOG_RCVINDEX rcvindex)
     : m_record_lsa { lsa }
     , m_vpid { vpid }
     , m_record_index { rcvindex }
@@ -126,14 +160,14 @@ namespace cublog
     PGBUF_INIT_WATCHER (&m_watcher, PGBUF_ORDERED_HEAP_NORMAL, PGBUF_ORDERED_NULL_HFID);
   }
 
-  atomic_replication_helper::atomic_replication_unit::~atomic_replication_unit ()
+  atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::~atomic_replication_unit ()
   {
     PGBUF_CLEAR_WATCHER (&m_watcher);
   }
 
   template <typename T>
-  void atomic_replication_helper::atomic_replication_unit::apply_log_redo (THREAD_ENTRY *thread_p,
-      log_rv_redo_context &redo_context, const log_rv_redo_rec_info<T> &record_info)
+  void atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::apply_log_redo (
+	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, const log_rv_redo_rec_info<T> &record_info)
   {
     LOG_RCV rcv;
     if (m_page_ptr != nullptr)
@@ -153,7 +187,7 @@ namespace cublog
       }
   }
 
-  int atomic_replication_helper::atomic_replication_unit::fix_page (THREAD_ENTRY *thread_p)
+  int atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::fix_page (THREAD_ENTRY *thread_p)
   {
     switch (m_record_index)
       {
@@ -194,7 +228,8 @@ namespace cublog
     return NO_ERROR;
   }
 
-  void atomic_replication_helper::atomic_replication_unit::unfix_page (THREAD_ENTRY *thread_p)
+  void atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::unfix_page (
+	  THREAD_ENTRY *thread_p)
   {
     switch (m_record_index)
       {
@@ -214,5 +249,19 @@ namespace cublog
 	pgbuf_unfix (thread_p, m_page_ptr);
 	break;
       }
+  }
+
+  PAGE_PTR atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::get_page_ptr ()
+  {
+    if (m_page_ptr != nullptr)
+      {
+	return m_page_ptr;
+      }
+    return m_watcher.pgptr;
+  }
+
+  void atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::set_page_ptr (PAGE_PTR &ptr)
+  {
+    m_page_ptr = ptr;
   }
 }

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -101,7 +101,7 @@ namespace cublog
 	      int fix_page (THREAD_ENTRY *thread_p);
 	      void unfix_page (THREAD_ENTRY *thread_p);
 	      PAGE_PTR get_page_ptr ();
-	      void set_page_ptr (PAGE_PTR &ptr);
+	      void set_page_ptr (const PAGE_PTR &ptr);
 
 	      VPID m_vpid;
 	    private:
@@ -111,14 +111,16 @@ namespace cublog
 	      LOG_RCVINDEX m_record_index;
 	  };
 
-	  std::vector<atomic_replication_unit> m_atomic_replication_unit_vector;
-	  std::map<VPID, PAGE_PTR> m_atomic_sequence_pages_map;
+	  using atomic_unit_vector = std::vector<atomic_replication_unit>;
+	  atomic_unit_vector m_units;
+	  using vpid_to_page_ptr_map = std::map<VPID, PAGE_PTR>;
+	  vpid_to_page_ptr_map m_page_map;
       };
 
-      std::map<TRANID, atomic_replication_sequence> m_atomic_sequences_map;
+      std::map<TRANID, atomic_replication_sequence> m_sequences_map;
 #if !defined (NDEBUG)
       using vpid_set_type = std::set<VPID>;
-      std::map<TRANID, vpid_set_type> m_atomic_sequences_vpids_map;
+      std::map<TRANID, vpid_set_type> m_vpid_sets_map;
 #endif
   };
 }

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -28,6 +28,7 @@
 #include "log_recovery_redo.hpp"
 #include "page_buffer.h"
 #include "thread_entry.hpp"
+#include "vpid_utilities.hpp"
 
 namespace cublog
 {
@@ -57,40 +58,64 @@ namespace cublog
 #endif
 
     private:
-      /*
-       * Atomic replication unit holds the log record information necessary for recovery redo
-       */
-      class atomic_replication_unit
+
+      class atomic_replication_sequence
       {
 	public:
-	  atomic_replication_unit () = delete;
-	  atomic_replication_unit (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex);
+	  atomic_replication_sequence () = default;
 
-	  atomic_replication_unit (const atomic_replication_unit &) = delete;
-	  atomic_replication_unit (atomic_replication_unit &&) = delete;
+	  atomic_replication_sequence (const atomic_replication_sequence &) = delete;
+	  atomic_replication_sequence (atomic_replication_sequence &&) = delete;
 
-	  ~atomic_replication_unit ();
+	  ~atomic_replication_sequence () = default;
 
-	  atomic_replication_unit &operator= (const atomic_replication_unit &) = delete;
-	  atomic_replication_unit &operator= (atomic_replication_unit &&) = delete;
+	  atomic_replication_sequence &operator= (const atomic_replication_sequence &) = delete;
+	  atomic_replication_sequence &operator= (atomic_replication_sequence &&) = delete;
 
-	  template <typename T>
-	  void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
-			       const log_rv_redo_rec_info<T> &record_info);
-	  int fix_page (THREAD_ENTRY *thread_p);
-	  void unfix_page (THREAD_ENTRY *thread_p);
-
-	  VPID m_vpid;
+	  void unfix_sequence (THREAD_ENTRY *thread_p);
 	private:
-	  log_lsa m_record_lsa;
-	  PAGE_PTR m_page_ptr;
-	  PGBUF_WATCHER m_watcher;
-	  LOG_RCVINDEX m_record_index;
+	  template <typename T>
+	  int add_atomic_replication_unit (THREAD_ENTRY *thread_p, log_lsa record_lsa, LOG_RCVINDEX rcvindex, VPID vpid,
+					   log_rv_redo_context &redo_context, const log_rv_redo_rec_info<T> &record_info);
+
+	  /*
+	   * Atomic replication unit holds the log record information necessary for recovery redo
+	   */
+	  class atomic_replication_unit
+	  {
+	    public:
+	      atomic_replication_unit () = delete;
+	      atomic_replication_unit (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex);
+
+	      atomic_replication_unit (const atomic_replication_unit &) = delete;
+	      atomic_replication_unit (atomic_replication_unit &&) = delete;
+
+	      ~atomic_replication_unit ();
+
+	      atomic_replication_unit &operator= (const atomic_replication_unit &) = delete;
+	      atomic_replication_unit &operator= (atomic_replication_unit &&) = delete;
+
+	      template <typename T>
+	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
+				   const log_rv_redo_rec_info<T> &record_info);
+	      int fix_page (THREAD_ENTRY *thread_p);
+	      void unfix_page (THREAD_ENTRY *thread_p);
+	      PAGE_PTR get_page_ptr ();
+	      void set_page_ptr (PAGE_PTR &ptr);
+
+	      VPID m_vpid;
+	    private:
+	      log_lsa m_record_lsa;
+	      PAGE_PTR m_page_ptr;
+	      PGBUF_WATCHER m_watcher;
+	      LOG_RCVINDEX m_record_index;
+	  };
+
+	  std::vector<atomic_replication_unit> m_atomic_replication_unit_vector;
+	  std::map<VPID, PAGE_PTR> m_atomic_sequence_pages_map;
       };
 
-      using atomic_replication_sequence_type = std::vector<atomic_replication_unit>;
-      std::map<TRANID, atomic_replication_sequence_type> m_atomic_sequences_map;
-
+      std::map<TRANID, atomic_replication_sequence> m_atomic_sequences_map;
 #if !defined (NDEBUG)
       using vpid_set_type = std::set<VPID>;
       std::map<TRANID, vpid_set_type> m_atomic_sequences_vpids_map;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -48,9 +48,9 @@ namespace cublog
       atomic_replication_helper &operator= (const atomic_replication_helper &) = delete;
       atomic_replication_helper &operator= (atomic_replication_helper &&) = delete;
 
-      template <typename T>
+      void add_atomic_replication_sequence (TRANID trid, log_rv_redo_context redo_context);
       int add_atomic_replication_unit (THREAD_ENTRY *thread_p, TRANID tranid, log_lsa record_lsa, LOG_RCVINDEX rcvindex,
-				       VPID vpid, log_rv_redo_context &redo_context, const log_rv_redo_rec_info<T> &record_info);
+				       VPID vpid);
       void unfix_atomic_replication_sequence (THREAD_ENTRY *thread_p, TRANID tranid);
       bool is_part_of_atomic_replication (TRANID tranid) const;
 #if !defined (NDEBUG)
@@ -58,11 +58,11 @@ namespace cublog
 #endif
 
     private:
-
       class atomic_replication_sequence
       {
 	public:
-	  atomic_replication_sequence () = default;
+	  atomic_replication_sequence () = delete;
+	  atomic_replication_sequence (log_rv_redo_context redo_cotext);
 
 	  atomic_replication_sequence (const atomic_replication_sequence &) = delete;
 	  atomic_replication_sequence (atomic_replication_sequence &&) = delete;
@@ -73,10 +73,9 @@ namespace cublog
 	  atomic_replication_sequence &operator= (atomic_replication_sequence &&) = delete;
 
 	  void unfix_sequence (THREAD_ENTRY *thread_p);
+	  int add_atomic_replication_unit (THREAD_ENTRY *thread_p, log_lsa record_lsa, LOG_RCVINDEX rcvindex, VPID vpid);
 	private:
-	  template <typename T>
-	  int add_atomic_replication_unit (THREAD_ENTRY *thread_p, log_lsa record_lsa, LOG_RCVINDEX rcvindex, VPID vpid,
-					   log_rv_redo_context &redo_context, const log_rv_redo_rec_info<T> &record_info);
+	  void apply_all_log_redos (THREAD_ENTRY *thread_p);
 
 	  /*
 	   * Atomic replication unit holds the log record information necessary for recovery redo
@@ -87,7 +86,7 @@ namespace cublog
 	      atomic_replication_unit () = delete;
 	      atomic_replication_unit (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex);
 
-	      atomic_replication_unit (const atomic_replication_unit &) = delete;
+	      atomic_replication_unit (const atomic_replication_unit &) = default;
 	      atomic_replication_unit (atomic_replication_unit &&) = delete;
 
 	      ~atomic_replication_unit ();
@@ -95,9 +94,9 @@ namespace cublog
 	      atomic_replication_unit &operator= (const atomic_replication_unit &) = delete;
 	      atomic_replication_unit &operator= (atomic_replication_unit &&) = delete;
 
+	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context);
 	      template <typename T>
-	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
-				   const log_rv_redo_rec_info<T> &record_info);
+	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, LOG_RECTYPE rectype);
 	      int fix_page (THREAD_ENTRY *thread_p);
 	      void unfix_page (THREAD_ENTRY *thread_p);
 	      PAGE_PTR get_page_ptr ();
@@ -111,6 +110,7 @@ namespace cublog
 	      LOG_RCVINDEX m_record_index;
 	  };
 
+	  log_rv_redo_context m_redo_context;
 	  using atomic_unit_vector = std::vector<atomic_replication_unit>;
 	  atomic_unit_vector m_units;
 	  using vpid_to_page_ptr_map = std::map<VPID, PAGE_PTR>;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -63,7 +63,7 @@ namespace cublog
       {
 	public:
 	  atomic_replication_sequence () = delete;
-	  atomic_replication_sequence (log_rv_redo_context redo_context);
+	  explicit atomic_replication_sequence (log_rv_redo_context redo_context);
 
 	  atomic_replication_sequence (const atomic_replication_sequence &) = delete;
 	  atomic_replication_sequence (atomic_replication_sequence &&) = delete;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -63,7 +63,7 @@ namespace cublog
       {
 	public:
 	  atomic_replication_sequence () = delete;
-	  atomic_replication_sequence (log_rv_redo_context redo_cotext);
+	  atomic_replication_sequence (log_rv_redo_context redo_context);
 
 	  atomic_replication_sequence (const atomic_replication_sequence &) = delete;
 	  atomic_replication_sequence (atomic_replication_sequence &&) = delete;
@@ -73,7 +73,7 @@ namespace cublog
 	  atomic_replication_sequence &operator= (const atomic_replication_sequence &) = delete;
 	  atomic_replication_sequence &operator= (atomic_replication_sequence &&) = delete;
 
-	  void unfix_sequence (THREAD_ENTRY *thread_p);
+	  void apply_and_unfix_sequence (THREAD_ENTRY *thread_p);
 	  int add_atomic_replication_unit (THREAD_ENTRY *thread_p, log_lsa record_lsa, LOG_RCVINDEX rcvindex, VPID vpid);
 	private:
 	  void apply_all_log_redos (THREAD_ENTRY *thread_p);

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -88,7 +88,7 @@ namespace cublog
 	      atomic_replication_unit (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex);
 
 	      atomic_replication_unit (const atomic_replication_unit &) = default;
-	      atomic_replication_unit (atomic_replication_unit &&) = delete;
+	      atomic_replication_unit (atomic_replication_unit &&) = default;
 
 	      ~atomic_replication_unit ();
 

--- a/src/transaction/log_recovery.h
+++ b/src/transaction/log_recovery.h
@@ -28,6 +28,7 @@
 #include "thread_compat.hpp"
 
 PAGE_PTR log_rv_redo_fix_page (THREAD_ENTRY * thread_p, const VPID * vpid_rcv, PAGE_FETCH_MODE page_fetch_mode);
+bool log_rv_check_redo_is_needed (const PAGE_PTR & pgptr, const LOG_LSA & rcv_lsa, const LOG_LSA & end_redo_lsa);
 bool log_rv_fix_page_and_check_redo_is_needed (THREAD_ENTRY * thread_p, const VPID & page_vpid, PAGE_PTR & pgptr,
 					       const log_lsa & rcv_lsa, const LOG_LSA & end_redo_lsa,
 					       PAGE_FETCH_MODE page_fetch_mode);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-460

Applying the log right after the fix could lead to problems as the records are fixed one by one as they come to be read by the PTS and some might be unfixed and refixed after the apply procedure leading to inconsistency.

To solve this a new order of operations has been added, the pages are now fixed one by one as necessary and then when the atomic sequence end log record appears all the records in the sequence are applied sequentially and then the pages are all unfixed. To provide the required context information for the apply the `atomic_replication_sequence` now has a new member in the form of the `log_rv_redo_context m_redo_context` and the logic follows the model of the `replicatior` class.
