### PR TITLE
[LETS-289] new mvcc log record field - parent_mvccid

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3906,7 +3906,7 @@ vacuum_process_log_record (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, LOG_
 	  return ER_FAILED;
 	}
 
-      mvcc_undo = &sysop_end->mvcc_undo;
+      mvcc_undo = &sysop_end->mvcc_undo_info.mvcc_undo;
 
       /* Get MVCCID */
       *mvccid = mvcc_undo->mvccid;

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1008,7 +1008,7 @@ prior_lsa_gen_undoredo_record_from_crumbs (THREAD_ENTRY *thread_p, LOG_PRIOR_NOD
 	    {
 	      assert (tdes->mvccinfo.sub_ids.size () == 1);
 	      *mvccid_p = tdes->mvccinfo.sub_ids.back ();
-	      assert (MVCCID_IS_VALID (tdes->mvccinfo.id));
+	      assert (MVCCID_IS_NORMAL (tdes->mvccinfo.id));
 	    }
 	  else
 	    {
@@ -1521,7 +1521,7 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 
 	  /* Read from mvcc_undo structure */
 	  mvcc_undo = & ((LOG_REC_SYSOP_END *) node->data_header)->mvcc_undo_info.mvcc_undo;
-	  vacuum_info = &mvcc_undo ->vacuum_info;
+	  vacuum_info = &mvcc_undo->vacuum_info;
 	  mvccid = mvcc_undo->mvccid;
 
 	  /* Reset

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1190,6 +1190,9 @@ extern void logtb_get_new_subtransaction_mvccid (THREAD_ENTRY * thread_p, MVCC_I
 
 extern MVCCID logtb_find_current_mvccid (THREAD_ENTRY * thread_p);
 extern MVCCID logtb_get_current_mvccid (THREAD_ENTRY * thread_p);
+extern void logtb_get_current_mvccid_and_parent_mvccid (THREAD_ENTRY * thread_p,
+							MVCCID & mvccid, MVCCID & parent_mvccid);
+
 extern int logtb_invalidate_snapshot_data (THREAD_ENTRY * thread_p);
 extern int xlogtb_get_mvcc_snapshot (THREAD_ENTRY * thread_p);
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -4307,7 +4307,8 @@ log_sysop_end_logical_undo (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, cons
       log_record.mvcc_undo_info.mvcc_undo.undo.data.rcvindex = rcvindex;
       log_record.mvcc_undo_info.mvcc_undo.undo.length = undo_size;
 
-      MVCCID temp_mvccid = MVCCID_NULL, temp_parent_mvccid = MVCCID_NULL;
+      MVCCID temp_mvccid = MVCCID_NULL;
+      MVCCID temp_parent_mvccid = MVCCID_NULL;
       logtb_get_current_mvccid_and_parent_mvccid (thread_p, temp_mvccid, temp_parent_mvccid);
       log_record.mvcc_undo_info.mvcc_undo.mvccid = temp_mvccid;
       log_record.mvcc_undo_info.parent_mvccid = temp_parent_mvccid;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -4306,7 +4306,12 @@ log_sysop_end_logical_undo (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcvindex, cons
       log_record.mvcc_undo.undo.data.pageid = NULL_PAGEID;
       log_record.mvcc_undo.undo.data.rcvindex = rcvindex;
       log_record.mvcc_undo.undo.length = undo_size;
-      log_record.mvcc_undo.mvccid = logtb_get_current_mvccid (thread_p);
+
+      MVCCID temp_id = MVCCID_NULL, temp_parent_id = MVCCID_NULL;
+      logtb_get_current_mvccid_and_parent_mvccid (thread_p, temp_id, temp_parent_id);
+      log_record.mvcc_undo.mvccid = temp_id;
+      log_record.mvcc_undo.parent_mvccid = temp_parent_id;
+
       log_record.mvcc_undo.vacuum_info.vfid = *vfid;
       LSA_SET_NULL (&log_record.mvcc_undo.vacuum_info.prev_mvcc_op_log_lsa);
     }
@@ -6689,8 +6694,9 @@ log_dump_record_mvcc_undoredo (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA *
 	   "     Volid = %d Pageid = %d Offset = %d,\n     Undo(Before) length = %d, Redo(After) length = %d,\n",
 	   mvcc_undoredo->undoredo.data.volid, mvcc_undoredo->undoredo.data.pageid, mvcc_undoredo->undoredo.data.offset,
 	   (int) GET_ZIP_LEN (mvcc_undoredo->undoredo.ulength), (int) GET_ZIP_LEN (mvcc_undoredo->undoredo.rlength));
-  fprintf (out_fp, "     MVCCID = %llu, \n     Prev_mvcc_op_log_lsa = %lld|%d, \n     VFID = (%d, %d)\n",
-	   (long long int) mvcc_undoredo->mvccid,
+  fprintf (out_fp,
+	   "     MVCCID = %llu, parent_MVCCID = %llu, \n     Prev_mvcc_op_log_lsa = %lld|%d, \n     VFID = (%d, %d)\n",
+	   (unsigned long long int) mvcc_undoredo->mvccid, (unsigned long long) mvcc_undoredo->parent_mvccid,
 	   (long long int) mvcc_undoredo->vacuum_info.prev_mvcc_op_log_lsa.pageid,
 	   (int) mvcc_undoredo->vacuum_info.prev_mvcc_op_log_lsa.offset, mvcc_undoredo->vacuum_info.vfid.volid,
 	   mvcc_undoredo->vacuum_info.vfid.fileid);
@@ -6726,8 +6732,10 @@ log_dump_record_mvcc_undo (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log
   fprintf (out_fp, "     Volid = %d Pageid = %d Offset = %d,\n     Undo (Before) length = %d,\n",
 	   mvcc_undo->undo.data.volid, mvcc_undo->undo.data.pageid, mvcc_undo->undo.data.offset,
 	   (int) GET_ZIP_LEN (mvcc_undo->undo.length));
-  fprintf (out_fp, "     MVCCID = %llu, \n     Prev_mvcc_op_log_lsa = %lld|%d, \n     VFID = (%d, %d)\n",
-	   (long long int) mvcc_undo->mvccid, (long long int) mvcc_undo->vacuum_info.prev_mvcc_op_log_lsa.pageid,
+  fprintf (out_fp,
+	   "     MVCCID = %llu, parent_MVCCID = %llu, \n     Prev_mvcc_op_log_lsa = %lld|%d, \n     VFID = (%d, %d)\n",
+	   (unsigned long long int) mvcc_undo->mvccid, (unsigned long long) mvcc_undo->parent_mvccid,
+	   (long long int) mvcc_undo->vacuum_info.prev_mvcc_op_log_lsa.pageid,
 	   (int) mvcc_undo->vacuum_info.prev_mvcc_op_log_lsa.offset, mvcc_undo->vacuum_info.vfid.volid,
 	   mvcc_undo->vacuum_info.vfid.fileid);
 
@@ -6758,7 +6766,8 @@ log_dump_record_mvcc_redo (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log
   fprintf (out_fp, "     Volid = %d Pageid = %d Offset = %d,\n     Redo (After) length = %d,\n",
 	   mvcc_redo->redo.data.volid, mvcc_redo->redo.data.pageid, mvcc_redo->redo.data.offset,
 	   (int) GET_ZIP_LEN (mvcc_redo->redo.length));
-  fprintf (out_fp, "     MVCCID = %llu, \n", (long long int) mvcc_redo->mvccid);
+  fprintf (out_fp, "     MVCCID = %llu, parent_MVCCID = %llu,\n",
+	   (unsigned long long int) mvcc_redo->mvccid, (unsigned long long) mvcc_redo->parent_mvccid);
 
   redo_length = mvcc_redo->redo.length;
   rcvindex = mvcc_redo->redo.data.rcvindex;
@@ -7010,8 +7019,10 @@ log_dump_record_sysop_end_internal (THREAD_ENTRY * thread_p, LOG_REC_SYSOP_END *
       fprintf (out_fp, "     Volid = %d Pageid = %d Offset = %d,\n     Undo (Before) length = %d,\n",
 	       sysop_end->mvcc_undo.undo.data.volid, sysop_end->mvcc_undo.undo.data.pageid,
 	       sysop_end->mvcc_undo.undo.data.offset, (int) GET_ZIP_LEN (sysop_end->mvcc_undo.undo.length));
-      fprintf (out_fp, "     MVCCID = %llu, \n     Prev_mvcc_op_log_lsa = %lld|%d, \n     VFID = (%d, %d)",
+      fprintf (out_fp,
+	       "     MVCCID = %llu, parent_MVCCID = %llu,\n     Prev_mvcc_op_log_lsa = %lld|%d, \n     VFID = (%d, %d)",
 	       (unsigned long long int) sysop_end->mvcc_undo.mvccid,
+	       (unsigned long long) sysop_end->mvcc_undo.parent_mvccid,
 	       LSA_AS_ARGS (&sysop_end->mvcc_undo.vacuum_info.prev_mvcc_op_log_lsa),
 	       VFID_AS_ARGS (&sysop_end->mvcc_undo.vacuum_info.vfid));
 

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -219,10 +219,7 @@ typedef struct log_rec_mvcc_undoredo LOG_REC_MVCC_UNDOREDO;
 struct log_rec_mvcc_undoredo
 {
   LOG_REC_UNDOREDO undoredo;	/* Undoredo information */
-  MVCCID mvccid;		/* MVCC Identifier for transaction. If log record is for a sub-transaction, the
-				 * mvccid is that of the sub-transaction. If the subtransaction does have a valid
-				 * mvccid, the transaction must also have a valid mvccid.
-				 * The reciprocal is not true. */
+  MVCCID mvccid;		/* MVCC Identifier for transaction */
   LOG_VACUUM_INFO vacuum_info;	/* Info required for vacuum */
 };
 
@@ -231,10 +228,7 @@ typedef struct log_rec_mvcc_undo LOG_REC_MVCC_UNDO;
 struct log_rec_mvcc_undo
 {
   LOG_REC_UNDO undo;		/* Undo information */
-  MVCCID mvccid;		/* MVCC Identifier for transaction. If log record is for a sub-transaction, the
-				 * mvccid is that of the sub-transaction. If the subtransaction does have a valid
-				 * mvccid, the transaction must also have a valid mvccid.
-				 * The reciprocal is not true. */
+  MVCCID mvccid;		/* MVCC Identifier for transaction */
   LOG_VACUUM_INFO vacuum_info;	/* Info required for vacuum */
 };
 
@@ -243,10 +237,7 @@ typedef struct log_rec_mvcc_redo LOG_REC_MVCC_REDO;
 struct log_rec_mvcc_redo
 {
   LOG_REC_REDO redo;		/* Location of recovery data */
-  MVCCID mvccid;		/* MVCC Identifier for transaction. If log record is for a sub-transaction, the
-				 * mvccid is that of the sub-transaction. If the subtransaction does have a valid
-				 * mvccid, the transaction must also have a valid mvccid.
-				 * The reciprocal is not true. */
+  MVCCID mvccid;		/* MVCC Identifier for transaction */
 };
 
 /* replication log structure */
@@ -340,11 +331,12 @@ struct log_rec_sysop_end
       MVCCID parent_mvccid;	/* If transaction has an mvccid allocated by a sub-transaction, this field will
 				 * contain the transaction's "main" mvccid (which, as indicated in implementations
 				 * in logtb_get_new_subtransaction_mvccid and logtb_get_current_mvccid, must
-				 * be valid). Otherwise, null.
-				 * The purpose of this field is twofold across transactional log replication (mainly
-				 * on passive transaction server):
+				 * be valid) while the mvcc_undo.mvccid will contain the mvccid of the subtransaction.
+				 * Otherwise, null.
+				 * The purpose of this field is twofold across transactional log replication boundary
+				 * (currently only on passive transaction server):
 				 *  - to discerne the nature of the mvccid as either 'main' mvccid or sub-mvccid
-				 *  - and to allow proper completion of both mvccid and sub-mvccid */
+				 *  - and to allow proper completion of either[both] mvccid or[and] sub-mvccid */
     } mvcc_undo_info;
     LOG_LSA compensate_lsa;	/* compensate lsa for logical compensate */
     struct

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2752,12 +2752,12 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		  else if (sysop_end->type == LOG_SYSOP_END_LOGICAL_MVCC_UNDO)
 		    {
 		      /* execute undo */
-		      rcvindex = sysop_end->mvcc_undo.undo.data.rcvindex;
-		      rcv.length = sysop_end->mvcc_undo.undo.length;
-		      rcv.offset = sysop_end->mvcc_undo.undo.data.offset;
-		      rcv_vpid.volid = sysop_end->mvcc_undo.undo.data.volid;
-		      rcv_vpid.pageid = sysop_end->mvcc_undo.undo.data.pageid;
-		      rcv.mvcc_id = sysop_end->mvcc_undo.mvccid;
+		      rcvindex = sysop_end->mvcc_undo_info.mvcc_undo.undo.data.rcvindex;
+		      rcv.length = sysop_end->mvcc_undo_info.mvcc_undo.undo.length;
+		      rcv.offset = sysop_end->mvcc_undo_info.mvcc_undo.undo.data.offset;
+		      rcv_vpid.volid = sysop_end->mvcc_undo_info.mvcc_undo.undo.data.volid;
+		      rcv_vpid.pageid = sysop_end->mvcc_undo_info.mvcc_undo.undo.data.pageid;
+		      rcv.mvcc_id = sysop_end->mvcc_undo_info.mvcc_undo.mvccid;
 
 		      /* will jump to parent LSA. save it now before advancing to undo data */
 		      LSA_COPY (&prev_tranlsa, &sysop_end->lastparent_lsa);
@@ -3246,7 +3246,7 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
 	  }
 	else if (sysop_start_postpone->sysop_end.type == LOG_SYSOP_END_LOGICAL_MVCC_UNDO)
 	  {
-	    undo_size = sysop_start_postpone->sysop_end.mvcc_undo.undo.length;
+	    undo_size = sysop_start_postpone->sysop_end.mvcc_undo_info.mvcc_undo.undo.length;
 	  }
 	LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_SYSOP_START_POSTPONE), &log_lsa, log_pgptr);
 	LOG_READ_ADD_ALIGN (thread_p, undo_size, &log_lsa, log_pgptr);
@@ -3269,7 +3269,7 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
 	  }
 	else if (sysop_end->type == LOG_SYSOP_END_LOGICAL_MVCC_UNDO)
 	  {
-	    undo_size = sysop_end->mvcc_undo.undo.length;
+	    undo_size = sysop_end->mvcc_undo_info.mvcc_undo.undo.length;
 	  }
 	LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_SYSOP_END), &log_lsa, log_pgptr);
       }

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -214,7 +214,7 @@ inline MVCCID log_rv_get_log_rec_mvccid<LOG_REC_SYSOP_END> (const LOG_REC_SYSOP_
 {
   if (log_rec.type == LOG_SYSOP_END_LOGICAL_MVCC_UNDO)
     {
-      return log_rec.mvcc_undo.mvccid;
+      return log_rec.mvcc_undo_info.mvcc_undo.mvccid;
     }
   return MVCCID_NULL;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-289

A subtransaction can have it's own mvccid. If that is the case, the transaction will also have a "main" mvccid (this is visible, among others, in the way the function `logtb_get_current_mvccid` is implemented).

With existing information it is not possible to know across replication boundaries (ie: on either page server or passive transaction server) whether the mvccid transmitted in log records is either a "main" mvccid or sub-mvccid.

Added a new `parent_mvccid` in the MVCC-related union member of `LOG_REC_SYSOP_END`.
If transaction has an mvccid allocated by a sub-transaction, this new field will contain the transaction's "main" mvccid (which, as indicated in implementations in `logtb_get_new_subtransaction_mvccid` and `logtb_get_current_mvccid`, must be valid).
Otherwise, the new field should be ignored.

The purpose of this field is twofold:
- to discerne the nature of the mvccid across replication on passive transaction server and also - as either 'main' mvccid or sub-mvccid
- and to allow completion of both id's during replication

Implementation:
- introduced new anonymous struct in `LOG_REC_SYSOP_END` as union member for mvcc and  added field `parent_mvccid`
- adapted use all over
- only populated the new field where relevant in `log_sysop_end_logical_undo` with newly added function `logtb_get_current_mvccid_and_parent_mvccid`
- logged new field in dump functions where relevant

Only populating the new field is present in this patch. Using it across replication boundary will be a separate patch.