### PR TITLE
[LETS-471] transactional log read corrections

### DIFF
--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -89,11 +89,6 @@ MVCCID log_rv_get_log_rec_mvccid (const T &log_rec);
 /*
  */
 template <typename T>
-void assert_correct_mvccid (const T &log_rec, MVCCID mvccid);
-
-/*
- */
-template <typename T>
 VPID log_rv_get_log_rec_vpid (const T &log_rec);
 
 /*
@@ -176,6 +171,7 @@ inline MVCCID log_rv_get_log_rec_mvccid (const T &)
 template <>
 inline MVCCID log_rv_get_log_rec_mvccid<LOG_REC_MVCC_UNDOREDO> (const LOG_REC_MVCC_UNDOREDO &log_rec)
 {
+  assert (MVCCID_IS_NORMAL (log_rec.mvccid));
   return log_rec.mvccid;
 }
 
@@ -188,6 +184,7 @@ inline MVCCID log_rv_get_log_rec_mvccid<LOG_REC_UNDOREDO> (const LOG_REC_UNDORED
 template <>
 inline MVCCID log_rv_get_log_rec_mvccid<LOG_REC_MVCC_REDO> (const LOG_REC_MVCC_REDO &log_rec)
 {
+  assert (log_rec.mvccid == MVCCID_NULL);
   return log_rec.mvccid;
 }
 
@@ -214,6 +211,7 @@ inline MVCCID log_rv_get_log_rec_mvccid<LOG_REC_SYSOP_END> (const LOG_REC_SYSOP_
 {
   if (log_rec.type == LOG_SYSOP_END_LOGICAL_MVCC_UNDO)
     {
+      assert (MVCCID_IS_NORMAL (log_rec.mvcc_undo_info.mvcc_undo.mvccid));
       return log_rec.mvcc_undo_info.mvcc_undo.mvccid;
     }
   return MVCCID_NULL;
@@ -222,61 +220,8 @@ inline MVCCID log_rv_get_log_rec_mvccid<LOG_REC_SYSOP_END> (const LOG_REC_SYSOP_
 template <>
 inline MVCCID log_rv_get_log_rec_mvccid<LOG_REC_MVCC_UNDO> (const LOG_REC_MVCC_UNDO &log_rec)
 {
+  assert (MVCCID_IS_NORMAL (log_rec.mvccid));
   return log_rec.mvccid;
-}
-
-template <typename T>
-inline void assert_correct_mvccid (const T &, MVCCID)
-{
-  static_assert (sizeof (T) == 0, "purposefully not implemented");
-}
-
-template <>
-inline void assert_correct_mvccid<LOG_REC_REDO> (const LOG_REC_REDO &, MVCCID mvccid)
-{
-  assert (mvccid == MVCCID_NULL);
-}
-
-template <>
-inline void assert_correct_mvccid<LOG_REC_MVCC_REDO> (const LOG_REC_MVCC_REDO &, MVCCID mvccid)
-{
-  assert (mvccid == MVCCID_NULL);
-}
-
-template <>
-inline void assert_correct_mvccid<LOG_REC_UNDOREDO> (const LOG_REC_UNDOREDO &, MVCCID mvccid)
-{
-  assert (mvccid == MVCCID_NULL);
-}
-
-template <>
-inline void assert_correct_mvccid<LOG_REC_MVCC_UNDOREDO> (const LOG_REC_MVCC_UNDOREDO &, MVCCID mvccid)
-{
-  assert (mvccid != MVCCID_NULL);
-}
-
-template <>
-inline void assert_correct_mvccid<LOG_REC_RUN_POSTPONE> (const LOG_REC_RUN_POSTPONE &, MVCCID mvccid)
-{
-  assert (mvccid == MVCCID_NULL);
-}
-
-template <>
-inline void assert_correct_mvccid<LOG_REC_COMPENSATE> (const LOG_REC_COMPENSATE &, MVCCID mvccid)
-{
-  assert (mvccid == MVCCID_NULL);
-}
-
-template <>
-inline void assert_correct_mvccid<LOG_REC_MVCC_UNDO> (const LOG_REC_MVCC_UNDO &, MVCCID mvccid)
-{
-  assert (mvccid != MVCCID_NULL);
-}
-
-template <>
-inline void assert_correct_mvccid<LOG_REC_SYSOP_END> (const LOG_REC_SYSOP_END &log_rec, MVCCID mvccid)
-{
-  assert (log_rec.type != LOG_SYSOP_END_LOGICAL_MVCC_UNDO || mvccid != MVCCID_NULL);
 }
 
 template <typename T>

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -85,14 +85,13 @@ namespace cublog
       void read_and_redo_record (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header,
 				 const log_lsa &rec_lsa);
       template <typename T>
-      void read_and_bookkeep_mvcc_vacuum (LOG_RECTYPE rectype, const log_lsa &prev_rec_lsa, const log_lsa &rec_lsa,
-					  bool assert_mvccid_non_null);
+      void read_and_bookkeep_mvcc_vacuum (const log_lsa &prev_rec_lsa, const log_lsa &rec_lsa,
+					  const T &log_rec, bool assert_mvccid_non_null);
       template <typename T>
       void read_and_redo_btree_stats (cubthread::entry &thread_entry, const log_rv_redo_rec_info<T> &record_info);
       template <typename T>
       void calculate_replication_delay_or_dispatch_async (cubthread::entry &thread_entry,
 	  const log_lsa &rec_lsa);
-      template <typename T>
       void register_assigned_mvccid (TRANID tranid);
 
     private:


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-471

Corrected read of transactional log during replication. Checked advancement to new log page was missing in a few places - advance_when_does_not_fit.

Other changes:
- removed superfluous function `assert_correct_mvccid` and incorporated the asserts in `log_rv_get_log_rec_mvccid`
- changed `read_and_bookkeep_mvcc_vacuum` in preparation to extension where the log record is used for more than one processing - it will be needed to also process `LOG_MVCC_UNDO_DATA` and `LOG_SYSOP_END` to register/complete mvccid's (on passive transaction server only)
- template was not needed for `register_assigned_mvccid`
