### PR TITLE
[LETS-473] allow reallocating page during replication on passive transaction server

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2171,18 +2171,16 @@ try_again:
 	  PGBUF_BCB_CHECK_MUTEX_LEAKS ();
 	  pgbuf_unfix (thread_p, pgptr);
 	  return NULL;
-
 	case OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT:
 	  /* - page was allocated and present in passive transaction server's page buffer
 	   * - was deallocated (by replication)
 	   * - is now requested to be allocated again (also by replication) - hence the
 	   *    assert for write access
 	   * returning null means the page will be skipped from selective passive transaction
-	   * server replication */
+	   * server replication (and will be re-retrieved from page server upon being needed again) */
 	  assert (is_passive_transaction_server ());
 	  assert (request_mode == PGBUF_LATCH_WRITE);
-	  /* fallthrough to return null */
-
+	  /* fallthrough to unfix and return null */
 	case OLD_PAGE_MAYBE_DEALLOCATED:
 	  /* OLD_PAGE_MAYBE_DEALLOCATED is called when deallocated page may be fixed. The caller wants the page only if
 	   * it is not deallocated. However, if it is deallocated, no error is required. */

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2160,6 +2160,15 @@ try_again:
 	case RECOVERY_PAGE:
 	  /* fixing deallocated page is expected. fall through to return it. */
 	  break;
+
+	case OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT:
+	  /* page was allocated; was present in passive transaction server's page buffer;
+	   * was deallocated (by replication) and is now requested to be allocated again (also
+	   * by replication); hence the assert */
+	  assert (request_mode == PGBUF_LATCH_WRITE);
+	  /* fixing deallocated page is expected. fall through to return it. */
+	  break;
+
 	case OLD_PAGE:
 	case OLD_PAGE_PREVENT_DEALLOC:
 	default:

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2162,11 +2162,12 @@ try_again:
 	  break;
 
 	case OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT:
-	  /* page was allocated; was present in passive transaction server's page buffer;
+	  /* page was allocated and present in passive transaction server's page buffer;
 	   * was deallocated (by replication) and is now requested to be allocated again (also
-	   * by replication); hence the assert */
+	   * by replication); hence the assert for write access */
+	  assert (is_passive_transaction_server ());
 	  assert (request_mode == PGBUF_LATCH_WRITE);
-	  /* fixing deallocated page is expected. fall through to return it. */
+	  /* fall through to return it. */
 	  break;
 
 	case OLD_PAGE:


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-473

On passive transaction server, a page might be de-allocated as part of the normal transactional log replication. At some future time, again as part of replication, it needs to be accessed again to be allocated.
Provide a switch case for the `OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT` fetch mode under following conditions:
- only on passive transaction server
- only if the access is request for writing - that is, from replication; it is absolutely forbidden for read-only transactions (those generated by clients connecting to passive transaction server) to access non-existing pages
