### PR TITLE
[CBRD-24385] Clean up unused items after creating with xehash_create()

### DIFF
--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -2182,40 +2182,6 @@ catalog_put_representation_item (THREAD_ENTRY * thread_p, OID * class_id_p, CATA
 	      log_append_redo_recdes2 (thread_p, RVCT_UPDATE, &catalog_Id.vfid, page_p, rep_dir_p->slotid, &record);
 	      pgbuf_set_dirty (thread_p, page_p, FREE);
 	    }
-#if 0				/* TODO - dead code; do not delete me for future use */
-	  else if (success == SP_DOESNT_FIT)
-	    {
-	      assert (false);	/* is impossible */
-
-	      /* the directory needs to be deleted from the current page and moved to another page. */
-
-	      ehash_delete (thread_p, &catalog_Id.xhid, key);
-	      log_append_undoredo_recdes2 (thread_p, RVCT_DELETE, &catalog_Id.vfid, page_p, rep_dir_p->slotid,
-					   &tmp_record, NULL);
-	      recdes_free_data_area (&tmp_record);
-
-	      spage_delete (thread_p, page_p, rep_dir_p->slotid);
-	      new_space = spage_max_space_for_new_record (thread_p, page_p);
-
-	      recdes_set_data_area (&tmp_record, aligned_page_header_data, CATALOG_PAGE_HEADER_SIZE);
-
-	      if (catalog_adjust_directory_count (thread_p, page_p, &tmp_record, -1) != NO_ERROR)
-		{
-		  pgbuf_unfix_and_init (thread_p, page_p);
-		  recdes_free_data_area (&record);
-		  return ER_FAILED;
-		}
-
-	      pgbuf_set_dirty (thread_p, page_p, FREE);
-	      catalog_update_max_space (&page_id, new_space);
-
-	      if (catalog_insert_representation_item (thread_p, &record, rep_dir_p) != NO_ERROR)
-		{
-		  recdes_free_data_area (&record);
-		  return ER_FAILED;
-		}
-	    }
-#endif
 	  else
 	    {
 	      assert (false);	/* is impossible */
@@ -2539,8 +2505,6 @@ catalog_initialize (CTID * catalog_id_p)
   // protect against repeated hashmap initializations
   catalog_Hashmap.destroy ();
 
-  VFID_COPY (&catalog_Id.xhid, &catalog_id_p->xhid);
-  catalog_Id.xhid.pageid = catalog_id_p->xhid.pageid;
   catalog_Id.vfid.fileid = catalog_id_p->vfid.fileid;
   catalog_Id.vfid.volid = catalog_id_p->vfid.volid;
   catalog_Id.hpgid = catalog_id_p->hpgid;
@@ -2592,11 +2556,6 @@ catalog_create (THREAD_ENTRY * thread_p, CTID * catalog_id_p)
 
   log_sysop_start (thread_p);
 
-  if (xehash_create (thread_p, &catalog_id_p->xhid, DB_TYPE_OBJECT, 1, oid_Root_class_oid, -1, false) == NULL)
-    {
-      ASSERT_ERROR ();
-      goto error;
-    }
 
   if (file_create_with_npages (thread_p, FILE_CATALOG, 1, NULL, &catalog_id_p->vfid) != NO_ERROR)
     {

--- a/src/storage/system_catalog.h
+++ b/src/storage/system_catalog.h
@@ -45,9 +45,6 @@ typedef struct ctid CTID;
 struct ctid
 {
   VFID vfid;			/* catalog volume identifier */
-#if 1				/* TODO - not used */
-  EHID xhid;			/* extendible hash index identifier */
-#endif
   PAGEID hpgid;			/* catalog header page identifier */
 };				/* catalog identifier */
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -111,9 +111,6 @@ struct boot_dbparm
   VFID trk_vfid;		/* Tracker of files */
   HFID hfid;			/* Heap file where this information is stored. It is only used for validation purposes */
   HFID rootclass_hfid;		/* Heap file where classes are stored */
-#if 1				/* TODO - not used */
-  EHID classname_table;		/* The hash file of class names */
-#endif
   CTID ctid;			/* The catalog file */
   /* TODO: Remove me */
   VFID query_vfid;		/* Query file */
@@ -4984,13 +4981,7 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
   boot_Db_parm->trk_vfid.volid = LOG_DBFIRST_VOLID;
   boot_Db_parm->hfid.vfid.volid = LOG_DBFIRST_VOLID;
   boot_Db_parm->rootclass_hfid.vfid.volid = LOG_DBFIRST_VOLID;
-#if 1				/* TODO */
-  boot_Db_parm->classname_table.vfid.volid = LOG_DBFIRST_VOLID;
-#endif
   boot_Db_parm->ctid.vfid.volid = LOG_DBFIRST_VOLID;
-#if 1				/* TODO */
-  boot_Db_parm->ctid.xhid.vfid.volid = LOG_DBFIRST_VOLID;
-#endif
 
   (void) strncpy (boot_Db_parm->rootclass_name, ROOTCLASS_NAME, DB_SIZEOF (boot_Db_parm->rootclass_name));
   boot_Db_parm->nvols = 1;
@@ -5055,14 +5046,6 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
       assert_release (false);
       goto error;
     }
-
-#if 1				/* TODO */
-  if (xehash_create (thread_p, &boot_Db_parm->classname_table, DB_TYPE_STRING, -1, &boot_Db_parm->rootclass_oid, -1,
-		     false) == NULL)
-    {
-      goto error;
-    }
-#endif
 
   /* Initialize structures for global unique statistics */
   error_code = logtb_initialize_global_unique_stats_table (thread_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24385

There are EHID variables in the BOOT_DB_PARM and CTID structures.
Assign variables using the xehash_create() function.
However, it is not used anywhere.

For this reason, the relevant processing is removed.
