### PR TITLE
[CBRD-24386] remove unused code in btree

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -291,11 +291,13 @@ struct recset_header
   INT16 first_slotid;		/* first slot id */
 };
 
+#if 0				/* not used */
 typedef enum
 {
   LEAF_RECORD_REGULAR = 1,
   LEAF_RECORD_OVERFLOW
 } LEAF_RECORD_TYPE;
+#endif
 
 typedef enum
 {
@@ -310,6 +312,7 @@ typedef enum
   BTREE_MERGE_FORCE,
 } BTREE_MERGE_STATUS;
 
+#if 0				/* not used */
 /* RECINS_STRUCT - redo b-tree insert recovery structure.
  */
 typedef struct recins_struct RECINS_STRUCT;
@@ -324,6 +327,7 @@ struct recins_struct
 };
 #define RECINS_STRUCT_INITIALIZER \
   { OID_INITIALIZER, OID_INITIALIZER, VPID_INITIALIZER, 0 }
+#endif
 
 /* Redo recovery of insert delete MVCCID */
 #define BTID_DOMAIN_CHECK_MAX_SIZE 1024
@@ -349,6 +353,7 @@ struct btree_stats_env
   DB_VALUE pkeys_val[BTREE_STATS_PKEYS_NUM];	/* partial key-value */
 };
 
+#if 0				/* not used */
 /* Structure used by btree_range_search to initialize and handle variables
  * needed throughout the process.
  */
@@ -396,6 +401,7 @@ struct btree_range_search_helper
   bool current_lock_request;	/* Current key needs locking */
   bool read_prev_key;		/* Previous key is read */
 };
+#endif
 
 typedef struct show_index_scan_ctx SHOW_INDEX_SCAN_CTX;
 struct show_index_scan_ctx
@@ -1780,6 +1786,11 @@ static bool btree_is_single_object_key (THREAD_ENTRY * thread_p, BTID_INT * btid
 
 static bool btree_check_locking_for_insert_unique (THREAD_ENTRY * thread_p, const BTREE_INSERT_HELPER * insert_helper);
 static bool btree_check_locking_for_delete_unique (THREAD_ENTRY * thread_p, const BTREE_DELETE_HELPER * delete_helper);
+
+static DISK_ISVALID btree_check_tree (THREAD_ENTRY * thread_p, const OID * class_oid_p, BTID * btid,
+				      const char *btname);
+static DISK_ISVALID btree_check_by_btid (THREAD_ENTRY * thread_p, BTID * btid);
+static char *btree_unpack_mvccinfo (char *ptr, BTREE_MVCC_INFO * mvcc_info, short btree_mvcc_flags);
 
 /*
  * btree_fix_root_with_info () - Fix b-tree root page and output its VPID, header and b-tree info if requested.
@@ -7707,7 +7718,7 @@ error:
  *
  * Note: Verify that all the pages of the specified index are valid.
  */
-DISK_ISVALID
+static DISK_ISVALID
 btree_check_tree (THREAD_ENTRY * thread_p, const OID * class_oid_p, BTID * btid, const char *btname)
 {
   DISK_ISVALID valid = DISK_ERROR;
@@ -7769,7 +7780,7 @@ error:
  *
  * Note: Verify that all pages of a btree indices are valid.
  */
-DISK_ISVALID
+static DISK_ISVALID
 btree_check_by_btid (THREAD_ENTRY * thread_p, BTID * btid)
 {
   DISK_ISVALID valid = DISK_ERROR;
@@ -21372,7 +21383,7 @@ btree_set_mvcc_header_ids_for_update (THREAD_ENTRY * thread_p, bool do_delete_on
  * mvcc_info (out)	 : Outputs MVCC info.
  * btree_mvcc_flags (in) : Flags that describe the packed MVCC info.
  */
-char *
+static char *
 btree_unpack_mvccinfo (char *ptr, BTREE_MVCC_INFO * mvcc_info, short btree_mvcc_flags)
 {
   assert (mvcc_info != NULL && ptr != NULL);

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -653,11 +653,7 @@ extern int btree_get_unique_statistics (THREAD_ENTRY * thread_p, BTID * btid, lo
 					long long *key_cnt);
 extern int btree_get_unique_statistics_for_count (THREAD_ENTRY * thread_p, BTID * btid, long long *oid_cnt,
 						  long long *null_cnt, long long *key_cnt);
-
 extern int btree_get_stats (THREAD_ENTRY * thread_p, BTREE_STATS * stat_info_p, bool with_fullscan);
-extern DISK_ISVALID btree_check_tree (THREAD_ENTRY * thread_p, const OID * class_oid_p, BTID * btid,
-				      const char *btname);
-extern DISK_ISVALID btree_check_by_btid (THREAD_ENTRY * thread_p, BTID * btid);
 extern int btree_get_pkey_btid (THREAD_ENTRY * thread_p, OID * cls_oid, BTID * pkey_btid);
 extern DISK_ISVALID btree_check_by_class_oid (THREAD_ENTRY * thread_p, OID * cls_oid, BTID * idx_btid);
 extern DISK_ISVALID btree_check_all (THREAD_ENTRY * thread_p);
@@ -778,7 +774,6 @@ extern void btree_set_mvcc_header_ids_for_update (THREAD_ENTRY * thread_p, bool 
 
 extern int btree_compare_btids (void *mem_btid1, void *mem_btid2);
 
-extern char *btree_unpack_mvccinfo (char *ptr, BTREE_MVCC_INFO * mvcc_info, short btree_mvcc_flags);
 extern char *btree_pack_mvccinfo (char *ptr, BTREE_MVCC_INFO * mvcc_info);
 extern int btree_packed_mvccinfo_size (BTREE_MVCC_INFO * mvcc_info);
 

--- a/src/storage/btree_load.h
+++ b/src/storage/btree_load.h
@@ -92,9 +92,9 @@
 
 /* compare two object identifiers */
 #define OIDCMP(n1, n2) \
-  ((n1).volid == (n2).volid \
-   && (n1).pageid == (n2).pageid \
-   && (n1).slotid == (n2).slotid)
+  ((n1).pageid == (n2).pageid \
+   && (n1).slotid == (n2).slotid \
+   && (n1).volid == (n2).volid)
 
 /* Header (Oth) record of the page */
 #define HEADER 0

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -2182,40 +2182,6 @@ catalog_put_representation_item (THREAD_ENTRY * thread_p, OID * class_id_p, CATA
 	      log_append_redo_recdes2 (thread_p, RVCT_UPDATE, &catalog_Id.vfid, page_p, rep_dir_p->slotid, &record);
 	      pgbuf_set_dirty (thread_p, page_p, FREE);
 	    }
-#if 0				/* TODO - dead code; do not delete me for future use */
-	  else if (success == SP_DOESNT_FIT)
-	    {
-	      assert (false);	/* is impossible */
-
-	      /* the directory needs to be deleted from the current page and moved to another page. */
-
-	      ehash_delete (thread_p, &catalog_Id.xhid, key);
-	      log_append_undoredo_recdes2 (thread_p, RVCT_DELETE, &catalog_Id.vfid, page_p, rep_dir_p->slotid,
-					   &tmp_record, NULL);
-	      recdes_free_data_area (&tmp_record);
-
-	      spage_delete (thread_p, page_p, rep_dir_p->slotid);
-	      new_space = spage_max_space_for_new_record (thread_p, page_p);
-
-	      recdes_set_data_area (&tmp_record, aligned_page_header_data, CATALOG_PAGE_HEADER_SIZE);
-
-	      if (catalog_adjust_directory_count (thread_p, page_p, &tmp_record, -1) != NO_ERROR)
-		{
-		  pgbuf_unfix_and_init (thread_p, page_p);
-		  recdes_free_data_area (&record);
-		  return ER_FAILED;
-		}
-
-	      pgbuf_set_dirty (thread_p, page_p, FREE);
-	      catalog_update_max_space (&page_id, new_space);
-
-	      if (catalog_insert_representation_item (thread_p, &record, rep_dir_p) != NO_ERROR)
-		{
-		  recdes_free_data_area (&record);
-		  return ER_FAILED;
-		}
-	    }
-#endif
 	  else
 	    {
 	      assert (false);	/* is impossible */
@@ -2539,8 +2505,6 @@ catalog_initialize (CTID * catalog_id_p)
   // protect against repeated hashmap initializations
   catalog_Hashmap.destroy ();
 
-  VFID_COPY (&catalog_Id.xhid, &catalog_id_p->xhid);
-  catalog_Id.xhid.pageid = catalog_id_p->xhid.pageid;
   catalog_Id.vfid.fileid = catalog_id_p->vfid.fileid;
   catalog_Id.vfid.volid = catalog_id_p->vfid.volid;
   catalog_Id.hpgid = catalog_id_p->hpgid;
@@ -2592,11 +2556,6 @@ catalog_create (THREAD_ENTRY * thread_p, CTID * catalog_id_p)
 
   log_sysop_start (thread_p);
 
-  if (xehash_create (thread_p, &catalog_id_p->xhid, DB_TYPE_OBJECT, 1, oid_Root_class_oid, -1, false) == NULL)
-    {
-      ASSERT_ERROR ();
-      goto error;
-    }
 
   if (file_create_with_npages (thread_p, FILE_CATALOG, 1, NULL, &catalog_id_p->vfid) != NO_ERROR)
     {

--- a/src/storage/system_catalog.h
+++ b/src/storage/system_catalog.h
@@ -45,9 +45,6 @@ typedef struct ctid CTID;
 struct ctid
 {
   VFID vfid;			/* catalog volume identifier */
-#if 1				/* TODO - not used */
-  EHID xhid;			/* extendible hash index identifier */
-#endif
   PAGEID hpgid;			/* catalog header page identifier */
 };				/* catalog identifier */
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -111,9 +111,6 @@ struct boot_dbparm
   VFID trk_vfid;		/* Tracker of files */
   HFID hfid;			/* Heap file where this information is stored. It is only used for validation purposes */
   HFID rootclass_hfid;		/* Heap file where classes are stored */
-#if 1				/* TODO - not used */
-  EHID classname_table;		/* The hash file of class names */
-#endif
   CTID ctid;			/* The catalog file */
   /* TODO: Remove me */
   VFID query_vfid;		/* Query file */
@@ -4984,13 +4981,7 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
   boot_Db_parm->trk_vfid.volid = LOG_DBFIRST_VOLID;
   boot_Db_parm->hfid.vfid.volid = LOG_DBFIRST_VOLID;
   boot_Db_parm->rootclass_hfid.vfid.volid = LOG_DBFIRST_VOLID;
-#if 1				/* TODO */
-  boot_Db_parm->classname_table.vfid.volid = LOG_DBFIRST_VOLID;
-#endif
   boot_Db_parm->ctid.vfid.volid = LOG_DBFIRST_VOLID;
-#if 1				/* TODO */
-  boot_Db_parm->ctid.xhid.vfid.volid = LOG_DBFIRST_VOLID;
-#endif
 
   (void) strncpy (boot_Db_parm->rootclass_name, ROOTCLASS_NAME, DB_SIZEOF (boot_Db_parm->rootclass_name));
   boot_Db_parm->nvols = 1;
@@ -5055,14 +5046,6 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
       assert_release (false);
       goto error;
     }
-
-#if 1				/* TODO */
-  if (xehash_create (thread_p, &boot_Db_parm->classname_table, DB_TYPE_STRING, -1, &boot_Db_parm->rootclass_oid, -1,
-		     false) == NULL)
-    {
-      goto error;
-    }
-#endif
 
   /* Initialize structures for global unique statistics */
   error_code = logtb_initialize_global_unique_stats_table (thread_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24386

In this issue, we refactoring the following matters.

There are structures and enum that are not used in the btree-related source, so it is annotated.
BTREE_RANGE_SEARCH_HELPER
RECINS_STRUCT

Change the range of use of the function to static.
btree_check_tree
btree_check_by_btid
btree_unpack_mvccinfo

Adjusts the order of comparison of OIDCMP() macros.
