### PR TITLE
[CBRD-24391] Add primary key to code table on demodb

### DIFF
--- a/demo/demodb_schema
+++ b/demo/demodb_schema
@@ -66,6 +66,8 @@ ALTER CLASS code ADD ATTRIBUTE
        s_name character(1),
        f_name character varying(6);
 
+ALTER CLASS code ADD ATTRIBUTE
+       CONSTRAINT [pk_code] PRIMARY KEY(s_name);
 
 ALTER CLASS nation ADD ATTRIBUTE
        code character(3) NOT NULL,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24391

During the HA configuration using demodb, there is no primary key in the code table, so it takes a while to check the primary key. As it is provided as a database for demo, it would be better to add a primary key to the code table.

```
 ALTER CLASS code ADD ATTRIBUTE
 CONSTRAINT [pk_code] PRIMARY KEY(s_name);
```
 