### PR TITLE
[CBRD-24378] Fix the restoredb not to go beyond the given time (-d)

### DIFF
--- a/src/transaction/log_2pc.c
+++ b/src/transaction/log_2pc.c
@@ -1901,6 +1901,7 @@ log_2pc_recovery_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE record_ty
     case LOG_COMPENSATE:
     case LOG_RUN_POSTPONE:
     case LOG_COMMIT_WITH_POSTPONE:
+    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
     case LOG_2PC_COMMIT_DECISION:
     case LOG_2PC_ABORT_DECISION:
     case LOG_2PC_COMMIT_INFORM_PARTICPS:

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1251,6 +1251,9 @@ prior_lsa_gen_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_RECTYPE 
       break;
 
     case LOG_COMMIT_WITH_POSTPONE:
+      node->data_header_length = sizeof (LOG_REC_START_POSTPONE);
+      break;
+
     case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
       node->data_header_length = sizeof (LOG_REC_START_POSTPONE_OBSOLETE);
       break;
@@ -1461,7 +1464,7 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 	  LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
 	}
     }
-  else if (node->log_header.type == LOG_COMMIT_WITH_POSTPONE_OBSOLETE)
+  else if (node->log_header.type == LOG_COMMIT_WITH_POSTPONE || node->log_header.type == LOG_COMMIT_WITH_POSTPONE_OBSOLETE)
     {
       /* we need the commit with postpone LSA for recovery. we have to save it under prior_lsa_mutex protection */
       tdes->rcv.tran_start_postpone_lsa = start_lsa;

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1464,7 +1464,8 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 	  LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
 	}
     }
-  else if (node->log_header.type == LOG_COMMIT_WITH_POSTPONE || node->log_header.type == LOG_COMMIT_WITH_POSTPONE_OBSOLETE)
+  else if (node->log_header.type == LOG_COMMIT_WITH_POSTPONE
+	   || node->log_header.type == LOG_COMMIT_WITH_POSTPONE_OBSOLETE)
     {
       /* we need the commit with postpone LSA for recovery. we have to save it under prior_lsa_mutex protection */
       tdes->rcv.tran_start_postpone_lsa = start_lsa;

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -343,6 +343,7 @@ prior_lsa_alloc_and_copy_data (THREAD_ENTRY *thread_p, LOG_RECTYPE rec_type, LOG
     case LOG_2PC_COMMIT_DECISION:
     case LOG_2PC_ABORT_DECISION:
     case LOG_COMMIT_WITH_POSTPONE:
+    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
     case LOG_SYSOP_START_POSTPONE:
     case LOG_COMMIT:
     case LOG_ABORT:
@@ -1250,7 +1251,8 @@ prior_lsa_gen_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_RECTYPE 
       break;
 
     case LOG_COMMIT_WITH_POSTPONE:
-      node->data_header_length = sizeof (LOG_REC_START_POSTPONE);
+    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
+      node->data_header_length = sizeof (LOG_REC_START_POSTPONE_OBSOLETE);
       break;
 
     case LOG_SYSOP_START_POSTPONE:
@@ -1459,7 +1461,7 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
 	  LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
 	}
     }
-  else if (node->log_header.type == LOG_COMMIT_WITH_POSTPONE)
+  else if (node->log_header.type == LOG_COMMIT_WITH_POSTPONE_OBSOLETE)
     {
       /* we need the commit with postpone LSA for recovery. we have to save it under prior_lsa_mutex protection */
       tdes->rcv.tran_start_postpone_lsa = start_lsa;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -6548,7 +6548,7 @@ log_dump_record_commit_postpone (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA
   (void) ctime_r (&tmp_time, time_val);
   fprintf (out_fp, ", First postpone record at before or after Page = %lld and offset = %d\n",
 	   LSA_AS_ARGS (&start_posp->posp_lsa));
-  fprintf (out_fp, ",       Transaction finish time at = %s\n", time_val);
+  fprintf (out_fp, "     Transaction finish time at = %s\n", time_val);
 
   return log_page_p;
 }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -215,7 +215,8 @@ static bool log_can_skip_undo_logging (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcv
 				       LOG_DATA_ADDR * addr);
 static bool log_can_skip_redo_logging (LOG_RCVINDEX rcvindex, const LOG_TDES * ignore_tdes, LOG_DATA_ADDR * addr);
 static void log_append_commit_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postpone_lsa);
-static void log_append_commit_postpone_obsolete (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postpone_lsa);
+static void log_append_commit_postpone_obsolete (THREAD_ENTRY * thread_p, LOG_TDES * tdes,
+						 LOG_LSA * start_postpone_lsa);
 static void log_append_sysop_start_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes,
 					     LOG_REC_SYSOP_START_POSTPONE * sysop_start_postpone, int data_size,
 					     const char *data);
@@ -4439,7 +4440,8 @@ log_append_commit_postpone_obsolete (THREAD_ENTRY * thread_p, LOG_TDES * tdes, L
   LOG_PRIOR_NODE *node;
   LOG_LSA start_lsa;
 
-  node = prior_lsa_alloc_and_copy_data (thread_p, LOG_COMMIT_WITH_POSTPONE_OBSOLETE, RV_NOT_DEFINED, NULL, 0, NULL, 0, NULL);
+  node =
+    prior_lsa_alloc_and_copy_data (thread_p, LOG_COMMIT_WITH_POSTPONE_OBSOLETE, RV_NOT_DEFINED, NULL, 0, NULL, 0, NULL);
   if (node == NULL)
     {
       return;
@@ -6554,7 +6556,8 @@ log_dump_record_commit_postpone (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA
 }
 
 static LOG_PAGE *
-log_dump_record_commit_postpone_obsolete (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa, LOG_PAGE * log_page_p)
+log_dump_record_commit_postpone_obsolete (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa,
+					  LOG_PAGE * log_page_p)
 {
   LOG_REC_START_POSTPONE_OBSOLETE *start_posp;
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -215,6 +215,7 @@ static bool log_can_skip_undo_logging (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcv
 				       LOG_DATA_ADDR * addr);
 static bool log_can_skip_redo_logging (LOG_RCVINDEX rcvindex, const LOG_TDES * ignore_tdes, LOG_DATA_ADDR * addr);
 static void log_append_commit_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postpone_lsa);
+static void log_append_commit_postpone_obsolete (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postpone_lsa);
 static void log_append_sysop_start_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes,
 					     LOG_REC_SYSOP_START_POSTPONE * sysop_start_postpone, int data_size,
 					     const char *data);
@@ -4397,11 +4398,48 @@ log_can_skip_redo_logging (LOG_RCVINDEX rcvindex, const LOG_TDES * ignore_tdes, 
 static void
 log_append_commit_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postpone_lsa)
 {
-  LOG_REC_START_POSTPONE_OBSOLETE *start_posp;	/* Start postpone actions */
+  LOG_REC_START_POSTPONE *start_posp;	/* Start postpone actions */
   LOG_PRIOR_NODE *node;
   LOG_LSA start_lsa;
 
   node = prior_lsa_alloc_and_copy_data (thread_p, LOG_COMMIT_WITH_POSTPONE, RV_NOT_DEFINED, NULL, 0, NULL, 0, NULL);
+  if (node == NULL)
+    {
+      return;
+    }
+
+  start_posp = (LOG_REC_START_POSTPONE *) node->data_header;
+  LSA_COPY (&start_posp->posp_lsa, start_postpone_lsa);
+  start_posp->at_time = time (NULL);
+
+  start_lsa = prior_lsa_next_record (thread_p, node, tdes);
+
+  tdes->state = TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE;
+
+  logpb_flush_pages (thread_p, &start_lsa);
+}
+
+/*
+ * log_append_commit_postpone_obsolete - APPEND COMMIT WITH POSTPONE
+ *
+ * return: nothing
+ *
+ *   tdes(in/out): State structure of transaction being committed
+ *   start_posplsa(in): Address where the first postpone log record start
+ *
+ * NOTE: The transaction is declared as committed with postpone actions.
+ *       The transaction is not fully committed until all postpone actions are executed.
+ *
+ *       The postpone operations are not invoked by this function.
+ */
+static void
+log_append_commit_postpone_obsolete (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postpone_lsa)
+{
+  LOG_REC_START_POSTPONE_OBSOLETE *start_posp;	/* Start postpone actions */
+  LOG_PRIOR_NODE *node;
+  LOG_LSA start_lsa;
+
+  node = prior_lsa_alloc_and_copy_data (thread_p, LOG_COMMIT_WITH_POSTPONE_OBSOLETE, RV_NOT_DEFINED, NULL, 0, NULL, 0, NULL);
   if (node == NULL)
     {
       return;
@@ -6498,6 +6536,26 @@ log_dump_record_compensate (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * lo
 static LOG_PAGE *
 log_dump_record_commit_postpone (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa, LOG_PAGE * log_page_p)
 {
+  LOG_REC_START_POSTPONE *start_posp;
+  LOG_REC_DONETIME *donetime;
+  time_t tmp_time;
+  char time_val[CTIME_MAX];
+
+  /* Read the DATA HEADER */
+  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*start_posp), log_lsa, log_page_p);
+  start_posp = (LOG_REC_START_POSTPONE *) ((char *) log_page_p->area + log_lsa->offset);
+  tmp_time = (time_t) start_posp->at_time;
+  (void) ctime_r (&tmp_time, time_val);
+  fprintf (out_fp, ", First postpone record at before or after Page = %lld and offset = %d\n",
+	   LSA_AS_ARGS (&start_posp->posp_lsa));
+  fprintf (out_fp, ",       Transaction finish time at = %s\n", time_val);
+
+  return log_page_p;
+}
+
+static LOG_PAGE *
+log_dump_record_commit_postpone_obsolete (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa, LOG_PAGE * log_page_p)
+{
   LOG_REC_START_POSTPONE_OBSOLETE *start_posp;
 
   /* Read the DATA HEADER */
@@ -6924,7 +6982,7 @@ log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type
       break;
 
     case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
-      log_page_p = log_dump_record_commit_postpone (thread_p, out_fp, log_lsa, log_page_p);
+      log_page_p = log_dump_record_commit_postpone_obsolete (thread_p, out_fp, log_lsa, log_page_p);
       break;
 
     case LOG_COMMIT:

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -267,6 +267,14 @@ struct log_rec_compensate
 };
 
 /* This entry is included during commit */
+typedef struct log_rec_start_postpone LOG_REC_START_POSTPONE;
+struct log_rec_start_postpone
+{
+  LOG_LSA posp_lsa;
+  INT64 at_time;		/* donetime. For the time-specific recovery */
+};
+
+/* This entry is included during commit. Obsolete. See the comment of LOG_COMMIT_WITH_POSTPONE_OBSOLETE. */
 typedef struct log_rec_start_postpone_obsolete LOG_REC_START_POSTPONE_OBSOLETE;
 struct log_rec_start_postpone_obsolete
 {

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -53,9 +53,9 @@ enum log_rectype
   LOG_CLIENT_USER_POSTPONE_DATA = 11,	/* Obsolete */
   LOG_RUN_NEXT_CLIENT_UNDO = 12,	/* Obsolete */
   LOG_RUN_NEXT_CLIENT_POSTPONE = 13,	/* Obsolete */
-  LOG_WILL_COMMIT = 14,		/* Obsolete */
 #endif
-  LOG_COMMIT_WITH_POSTPONE = 15,	/* Committing server postpone operations */
+  LOG_COMMIT_WITH_POSTPONE = 14,		/* Committing server postpone operations */
+  LOG_COMMIT_WITH_POSTPONE_OBSOLETE = 15,	/* Obsolete. It was LOG_COMMIT_WITH_POSTPONE without the donetime. It remains only for the backward compatibility and will be removed with the next major release, maybe 12.0 */
 #if 0
   LOG_COMMIT_WITH_CLIENT_USER_LOOSE_ENDS = 16,	/* Obsolete */
 #endif
@@ -267,8 +267,8 @@ struct log_rec_compensate
 };
 
 /* This entry is included during commit */
-typedef struct log_rec_start_postpone LOG_REC_START_POSTPONE;
-struct log_rec_start_postpone
+typedef struct log_rec_start_postpone_obsolete LOG_REC_START_POSTPONE_OBSOLETE;
+struct log_rec_start_postpone_obsolete
 {
   LOG_LSA posp_lsa;
 };

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1132,8 +1132,12 @@ log_rv_analysis_compensate (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_
  * return: error code
  *
  *   tran_id(in):
- *   lsa(in/out):
+ *   log_lsa(in/out):
  *   log_page_p(in/out):
+ *   lsa(in/out):
+ *   is_media_crash(in):
+ *   stop_at(in):
+ *   did_incom_recovery(in/out):
  *
  * Note:
  */

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2313,17 +2313,18 @@ log_rv_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE log_type, int tran_
     case LOG_COMPENSATE:
       (void) log_rv_analysis_compensate (thread_p, tran_id, log_lsa, log_page_p);
       break;
-
-    case LOG_SYSOP_START_POSTPONE:
-      (void) log_rv_analysis_sysop_start_postpone (thread_p, tran_id, log_lsa, log_page_p);
-      break;
-
+    
     case LOG_COMMIT_WITH_POSTPONE:
       (void) log_rv_analysis_commit_with_postpone (thread_p, tran_id, log_lsa, log_page_p, prev_lsa, is_media_crash, stop_at, did_incom_recovery);
       break;
     
     case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
       (void) log_rv_analysis_commit_with_postpone_obsolete (thread_p, tran_id, log_lsa, log_page_p);
+      break;
+
+
+    case LOG_SYSOP_START_POSTPONE:
+      (void) log_rv_analysis_sysop_start_postpone (thread_p, tran_id, log_lsa, log_page_p);
       break;
 
     case LOG_COMMIT:
@@ -4200,7 +4201,7 @@ log_recovery_abort_interrupted_sysop (THREAD_ENTRY * thread_p, LOG_TDES * tdes, 
       else
 	{
 	  /* safe-guard: we do not expect postpone starts */
-	  assert (logrec_head.type != LOG_COMMIT_WITH_POSTPONE_OBSOLETE && logrec_head.type != LOG_COMMIT_WITH_POSTPONE && logrec_head.type != LOG_SYSOP_START_POSTPONE);
+	  assert (logrec_head.type != LOG_COMMIT_WITH_POSTPONE && logrec_head.type != LOG_COMMIT_WITH_POSTPONE_OBSOLETE && logrec_head.type != LOG_SYSOP_START_POSTPONE);
 
 	  /* move to previous */
 	  prev_lsa = logrec_head.prev_tranlsa;

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2333,7 +2333,6 @@ log_rv_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE log_type, int tran_
       (void) log_rv_analysis_commit_with_postpone_obsolete (thread_p, tran_id, log_lsa, log_page_p);
       break;
 
-
     case LOG_SYSOP_START_POSTPONE:
       (void) log_rv_analysis_sysop_start_postpone (thread_p, tran_id, log_lsa, log_page_p);
       break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24378

**Purpose**
To prevent the restoredb from doing recovery beyond the given time with the -d option.

**Implementation**
- A new log record for the sysop commit is added. It includes the `donetime` like the LOG_COMMIT. This time information is used for the time-specific restore.
- For the backward compatibility, the old log record type still remains.
- The new log record type use the name of the old log record type name: LOG_COMMIT_WITH_POSTPONE.
- The name of the old record type is changed to LOG_COMMIT_WITH_POSTPONE_OBSOLETE.
- The macro number which the new log record type use was for LOG_WILL_COMMIT, which had been obsolete for a long. I believe no one has a log including this type.