### PR TITLE
[CBRD-24399] backport #3667 to 11.2, CUBRID setting error using install.sh 

### DIFF
--- a/contrib/install/install.sh
+++ b/contrib/install/install.sh
@@ -17,7 +17,7 @@
 #
 
 function get_cubrid_dir() {
-  cubrid_str=/CUBRID/
+  cubrid_str=/CUBRID
   cubrid_str_len=${#cubrid_str}
   current_dir="`pwd`"
 
@@ -81,7 +81,7 @@ setenv SHLIB_PATH $LD_LIBRARY_PATH
 setenv LIBPATH $LD_LIBRARY_PATH
 set path=($CUBRID/bin $path)
 
-set LIB=$CUBRID/lib:$CUBRID/cci/lib
+set LIB=$CUBRID/lib
 
 if (-f "/etc/redhat-release" ) then
   set OS=(`cat /etc/system-release-cpe | cut -d':' -f'3-3'`)
@@ -142,7 +142,7 @@ export SHLIB_PATH
 export LIBPATH
 export PATH
 
-LIB=$CUBRID/lib:$CUBRID/cci/lib
+LIB=$CUBRID/lib
 
 if [ -f /etc/redhat-release ];then
         OS=$(cat /etc/system-release-cpe | cut -d':' -f'3-3')


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24399

Purpose
This is a backport of PR #3667 to release/11.2
* Modify the path to create a symbolic link

Implementation
N/A

Remarks
N/A