### PR TITLE
[LETS-476] Do not compare std::function instances to nullptr

### DIFF
--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -156,7 +156,7 @@ namespace cubcomm
     assert (a_incoming_request_handlers.size () > 0);
     for (const auto &pair: a_incoming_request_handlers)
       {
-	assert (pair.second != nullptr);
+	assert (pair.second);
 	register_handler (pair.first, pair.second);
       }
     // Add the handler for responses

--- a/src/communication/request_sync_send_queue.hpp
+++ b/src/communication/request_sync_send_queue.hpp
@@ -212,12 +212,12 @@ namespace cubcomm
 	     *  - change the application protocol for each message to have an associated ACK response.
 	     *  - implement a polling mechanism that, also based on ACK, detects the disconnect earlier.
 	     * */
-	    if (queue_front.m_error_handler != nullptr)
+	    if (queue_front.m_error_handler)
 	      {
 		// if present, invoke custom/specific handler first
 		queue_front.m_error_handler (err_code, m_abort_further_processing);
 	      }
-	    else if (m_error_handler != nullptr)
+	    else if (m_error_handler)
 	      {
 		// if present, invoke generic (fail-back) handler
 		m_error_handler (err_code, m_abort_further_processing);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -172,7 +172,7 @@ page_server::connection_handler::receive_stop_log_prior_dispatch (tran_server_co
 {
   // empty request message
 
-  assert (m_prior_sender_sink_hook_func != nullptr);
+  assert (m_prior_sender_sink_hook_func);
 
   remove_prior_sender_sink ();
 
@@ -276,7 +276,7 @@ page_server::connection_handler::remove_prior_sender_sink ()
 {
   std::lock_guard<std::mutex> lockg { m_prior_sender_sink_removal_mtx };
 
-  if (m_prior_sender_sink_hook_func != nullptr)
+  if (m_prior_sender_sink_hook_func)
     {
       log_Gl.m_prior_sender.remove_sink (m_prior_sender_sink_hook_func);
       m_prior_sender_sink_hook_func = nullptr;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-476

Removed comparison with `nullptr` for `std::function`, as it will also be removed in C++20
