### PR TITLE
[LETS-423] reorganize code to allow reuse of common template functions for normal and atomic replication classes

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -335,6 +335,7 @@ set(TRANSACTION_SOURCES
   ${TRANSACTION_DIR}/log_recovery_redo.cpp
   ${TRANSACTION_DIR}/log_recovery_redo_parallel.cpp
   ${TRANSACTION_DIR}/log_replication.cpp
+  ${TRANSACTION_DIR}/log_replication_jobs.cpp
   ${TRANSACTION_DIR}/log_replication_atomic.cpp
   ${TRANSACTION_DIR}/log_replication_mvcc.cpp
   ${TRANSACTION_DIR}/log_storage.cpp
@@ -374,6 +375,8 @@ set(TRANSACTION_HEADERS
   ${TRANSACTION_DIR}/log_recovery_redo.hpp
   ${TRANSACTION_DIR}/log_recovery_redo_parallel.hpp
   ${TRANSACTION_DIR}/log_replication.hpp
+  ${TRANSACTION_DIR}/log_replication_jobs.hpp
+  ${TRANSACTION_DIR}/log_replication.cpp.hpp
   ${TRANSACTION_DIR}/log_replication_atomic.hpp
   ${TRANSACTION_DIR}/log_replication_mvcc.hpp
   ${TRANSACTION_DIR}/log_storage.hpp

--- a/src/transaction/log_recovery_redo_parallel.hpp
+++ b/src/transaction/log_recovery_redo_parallel.hpp
@@ -21,7 +21,6 @@
 
 #include "log_reader.hpp"
 #include "log_recovery_redo.hpp"
-#include "log_replication.hpp"
 #include "log_recovery_redo_perf.hpp"
 
 #if defined (SERVER_MODE)

--- a/src/transaction/log_replication.cpp.hpp
+++ b/src/transaction/log_replication.cpp.hpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef _LOG_REPLICATION_CPP_HPP_
+#define _LOG_REPLICATION_CPP_HPP_
+
+#include "log_replication.hpp"
+#include "log_replication_jobs.hpp"
+
+namespace cublog
+{
+  template <typename T>
+  void
+  replicator::read_and_bookkeep_mvcc_vacuum (const log_lsa &prev_rec_lsa, const log_lsa &rec_lsa,
+      const T &log_rec, bool assert_mvccid_non_null)
+  {
+    const MVCCID mvccid = log_rv_get_log_rec_mvccid (log_rec);
+    log_replication_update_header_mvcc_vacuum_info (mvccid, prev_rec_lsa, rec_lsa, m_bookkeep_mvcc_vacuum_info);
+  }
+
+  template <typename T>
+  void replicator::calculate_replication_delay_or_dispatch_async (cubthread::entry &thread_entry,
+      const log_lsa &rec_lsa)
+  {
+    m_redo_context.m_reader.advance_when_does_not_fit (sizeof (T));
+    const T log_rec = m_redo_context.m_reader.reinterpret_copy_and_add_align<T> ();
+    // at_time, expressed in milliseconds rather than seconds
+    const time_msec_t start_time_msec = log_rec.at_time;
+    if (m_parallel_replication_redo != nullptr)
+      {
+	// dispatch a job; the time difference will be calculated when the job is actually
+	// picked up for completion by a task; this will give an accurate estimate of the actual
+	// delay between log generation on the page server and log recovery on the page server
+	cublog::redo_job_replication_delay_impl *replication_delay_job =
+		new cublog::redo_job_replication_delay_impl (m_redo_lsa, start_time_msec);
+	// ownership of raw pointer remains with the job instance which will delete itself upon retire
+	m_parallel_replication_redo->add (replication_delay_job);
+      }
+    else
+      {
+	// calculate the time difference synchronously
+	log_rpl_calculate_replication_delay (&thread_entry, start_time_msec);
+      }
+  }
+
+}
+
+#endif // _LOG_REPLICATION_CPP_HPP_

--- a/src/transaction/log_replication.cpp.hpp
+++ b/src/transaction/log_replication.cpp.hpp
@@ -57,7 +57,6 @@ namespace cublog
 	log_rpl_calculate_replication_delay (&thread_entry, start_time_msec);
       }
   }
-
 }
 
 #endif // _LOG_REPLICATION_CPP_HPP_

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -16,7 +16,6 @@
  *
  */
 
-
 #ifndef _LOG_REPLICATION_HPP_
 #define _LOG_REPLICATION_HPP_
 
@@ -134,8 +133,6 @@ namespace cublog
       perf_stats m_perf_stat_idle;
 
       std::unique_ptr<cublog::replicator_mvcc> m_replicator_mvccid;
-
-
   };
 }
 

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -16,7 +16,9 @@
  *
  */
 
+#include "log_replication.cpp.hpp"
 #include "log_replication_atomic.hpp"
+#include "log_replication_jobs.hpp"
 
 #include "log_recovery_redo_parallel.hpp"
 

--- a/src/transaction/log_replication_jobs.cpp
+++ b/src/transaction/log_replication_jobs.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "log_replication_jobs.hpp"
+#include "util_func.h"
+
+namespace cublog
+
+{
+  redo_job_replication_delay_impl::redo_job_replication_delay_impl (
+	  const log_lsa &a_rcv_lsa, time_msec_t a_start_time_msec)
+    : redo_parallel::redo_job_base (SENTINEL_VPID, a_rcv_lsa)
+    , m_start_time_msec (a_start_time_msec)
+  {
+  }
+
+  int
+  redo_job_replication_delay_impl::execute (THREAD_ENTRY *thread_p, log_rv_redo_context &)
+  {
+    const int res = log_rpl_calculate_replication_delay (thread_p, m_start_time_msec);
+    return res;
+  }
+
+  void
+  redo_job_replication_delay_impl::retire (std::size_t)
+  {
+    delete this;
+  }
+
+  /* log_rpl_calculate_replication_delay - calculate delay based on a given start time value
+   *        and the current time and log to the perfmon infrastructure; all calculations are
+   *        done in milliseconds as that is the relevant scale needed
+   */
+  int
+  log_rpl_calculate_replication_delay (THREAD_ENTRY *thread_p, time_msec_t a_start_time_msec)
+  {
+    // skip calculation if bogus input (sometimes, it is -1);
+    // TODO: fix bogus input at the source if at all possible (debugging revealed that
+    // it happens for LOG_COMMIT messages only and there is no point at the source where the 'at_time'
+    // is not filled in)
+    if (a_start_time_msec > 0)
+      {
+	const int64_t end_time_msec = util_get_time_as_ms_since_epoch ();
+	const int64_t time_diff_msec = end_time_msec - a_start_time_msec;
+	assert (time_diff_msec >= 0);
+
+	perfmon_set_stat (thread_p, PSTAT_REDO_REPL_DELAY, static_cast<int> (time_diff_msec), false);
+
+	if (prm_get_bool_value (PRM_ID_ER_LOG_CALC_REPL_DELAY))
+	  {
+	    _er_log_debug (ARG_FILE_LINE, "[CALC_REPL_DELAY]: %9lld msec", time_diff_msec);
+	  }
+
+	return NO_ERROR;
+      }
+    else
+      {
+	er_log_debug (ARG_FILE_LINE, "log_rpl_calculate_replication_delay: "
+		      "encountered negative start time value: %lld milliseconds",
+		      a_start_time_msec);
+	return ER_FAILED;
+      }
+  }
+
+}

--- a/src/transaction/log_replication_jobs.cpp
+++ b/src/transaction/log_replication_jobs.cpp
@@ -20,7 +20,6 @@
 #include "util_func.h"
 
 namespace cublog
-
 {
   redo_job_replication_delay_impl::redo_job_replication_delay_impl (
 	  const log_lsa &a_rcv_lsa, time_msec_t a_start_time_msec)

--- a/src/transaction/log_replication_jobs.hpp
+++ b/src/transaction/log_replication_jobs.hpp
@@ -54,7 +54,6 @@ namespace cublog
     private:
       const time_msec_t m_start_time_msec;
   };
-
 }
 
 #endif // _LOG_REPLICATION_JOBS_HPP_

--- a/src/transaction/log_replication_jobs.hpp
+++ b/src/transaction/log_replication_jobs.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef _LOG_REPLICATION_JOBS_HPP_
+#define _LOG_REPLICATION_JOBS_HPP_
+
+#include "log_recovery_redo_parallel.hpp"
+#include "thread_entry.hpp"
+
+namespace cublog
+{
+  extern int log_rpl_calculate_replication_delay (THREAD_ENTRY *thread_p, time_t a_start_time_msec);
+
+  /* job implementation that performs log replication delay calculation
+   * using log records that register creation time
+   */
+  class redo_job_replication_delay_impl final : public redo_parallel::redo_job_base
+  {
+      /* sentinel VPID value needed for the internal mechanics of the parallel log recovery/replication
+       * internally, such a VPID is needed to maintain absolute order of the processing
+       * of the log records with respect to their order in the global log record
+       */
+      static constexpr vpid SENTINEL_VPID = { -2, -2 };
+
+    public:
+      redo_job_replication_delay_impl (const log_lsa &a_rcv_lsa, time_msec_t a_start_time_msec);
+
+      redo_job_replication_delay_impl (redo_job_replication_delay_impl const &) = delete;
+      redo_job_replication_delay_impl (redo_job_replication_delay_impl &&) = delete;
+
+      ~redo_job_replication_delay_impl () override = default;
+
+      redo_job_replication_delay_impl &operator = (redo_job_replication_delay_impl const &) = delete;
+      redo_job_replication_delay_impl &operator = (redo_job_replication_delay_impl &&) = delete;
+
+      int execute (THREAD_ENTRY *thread_p, log_rv_redo_context &) override;
+      void retire (std::size_t a_task_idx) override;
+
+    private:
+      const time_msec_t m_start_time_msec;
+  };
+
+}
+
+#endif // _LOG_REPLICATION_JOBS_HPP_


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-423

Reorganize code to allow reuse of templated member function between base `cublog::replicator` and `cublog::atomic_replicator`:
- separate needed jobs in separate file `log_replication_jobs`
- separate member templated functions in file `log_replication.cpp.hpp` and included it in both non-atomic and atomic compilation units
- clean includes
