### PR TITLE
[CBRE-24401] backport: In case of using UNION in an IN clause in an inline view, a segment fault occurs

### DIFF
--- a/src/parser/query_result.c
+++ b/src/parser/query_result.c
@@ -485,7 +485,10 @@ pt_get_select_list (PARSER_CONTEXT * parser, PT_NODE * query)
 
 	  if (cnt1 != cnt2)
 	    {
-	      PT_ERRORmf2 (parser, arg1, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_ARITY_MISMATCH, cnt1, cnt2);
+	      if (!pt_has_error (parser))
+		{
+		  PT_ERRORmf2 (parser, arg1, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_ARITY_MISMATCH, cnt1, cnt2);
+		}
 	      return NULL;
 	    }
 

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5275,6 +5275,11 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
       pt_try_remove_order_by (parser, arg2);
 
       arg2_list = pt_get_select_list (parser, arg2);
+      if (arg2_list == NULL)
+	{
+	  return NULL;
+	}
+
       if (PT_IS_COLLECTION_TYPE (arg2_list->type_enum) && arg2_list->node_type == PT_FUNCTION)
 	{
 	  expr->type_enum = PT_TYPE_LOGICAL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24401

backport to #3666 
