### PR TITLE
[CBRD-24275] seperate externalproject build/install msg from main stream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1108,6 +1108,7 @@ if(WITH_LIBOPENSSL STREQUAL "EXTERNAL")
     #e.g. https://www.openssl.org/source/openssl-1.1.1f.tar.gz
     externalproject_add(${LIBOPENSSL_TARGET}
       URL                  ${WITH_LIBOPENSSL_URL}
+      LOG_CONFIGURE        TRUE
       LOG_BUILD            TRUE
       LOG_INSTALL          TRUE
       TIMEOUT              600
@@ -1148,6 +1149,7 @@ if(WITH_LIBUNIXODBC STREQUAL "EXTERNAL")
     #e.g. http://www.unixodbc.org/unixODBC-2.3.9.tar.gz
     externalproject_add(${LIBUNIXODBC_TARGET}
       URL                  ${WITH_LIBUNIXODBC_URL}
+      LOG_CONFIGURE        TRUE
       LOG_BUILD            TRUE
       LOG_INSTALL          TRUE
       TIMEOUT              600
@@ -1180,6 +1182,7 @@ set(RAPIDJSON_TARGET rapidjson)
 externalproject_add(${RAPIDJSON_TARGET}
   # tried URL but archive gets downloaded every time. URL_MD5 may help
   URL                  ${WITH_RAPIDJSON_URL}
+  LOG_CONFIGURE        TRUE
   LOG_BUILD            TRUE
   LOG_INSTALL          TRUE
   TIMEOUT              600
@@ -1254,6 +1257,7 @@ if(WITH_CCI AND WITH_CMSERVER AND EXISTS ${CMAKE_SOURCE_DIR}/cubridmanager/serve
   if(UNIX)
     set(CMS_DEPENDS cubridcs cascci cmstat cmdep)
     externalproject_add(cubridmanager
+      LOG_CONFIGURE        TRUE
       LOG_BUILD            TRUE
       DEPENDS pre_cubridmanager ${CMS_DEPENDS}
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cubridmanager/server
@@ -1266,6 +1270,7 @@ if(WITH_CCI AND WITH_CMSERVER AND EXISTS ${CMAKE_SOURCE_DIR}/cubridmanager/serve
     set(CMS_DEPENDS cascci cmstat cmdep)
     externalproject_add(cubridmanager
       DEPENDS pre_cubridmanager ${CMS_DEPENDS}
+      LOG_CONFIGURE        TRUE
       LOG_BUILD            TRUE
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cubridmanager/server
       CONFIGURE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -913,6 +913,8 @@ if(WITH_LIBEXPAT STREQUAL "EXTERNAL")
   if(UNIX)
     externalproject_add(${LIBEXPAT_TARGET}
       URL                  ${WITH_LIBEXPAT_URL}
+      LOG_BUILD            TRUE
+      LOG_INSTALL          TRUE
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS} --without-xmlwf  --without-docbook
@@ -958,6 +960,8 @@ if(WITH_LIBJANSSON STREQUAL "EXTERNAL")
   if(UNIX)
     externalproject_add(${LIBJANSSON_TARGET}
       URL                  ${WITH_LIBJANSSON_URL}
+      LOG_BUILD            TRUE
+      LOG_INSTALL          TRUE
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS}
@@ -1034,6 +1038,8 @@ if(UNIX)
     set(LIBEDIT_TARGET libedit)
     externalproject_add(${LIBEDIT_TARGET}
       URL                  ${WITH_LIBEDIT_URL}
+      LOG_BUILD            TRUE
+      LOG_INSTALL          TRUE
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND    "LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/external/lib" ${DEFAULT_CONFIGURE_OPTS}
@@ -1102,6 +1108,8 @@ if(WITH_LIBOPENSSL STREQUAL "EXTERNAL")
     #e.g. https://www.openssl.org/source/openssl-1.1.1f.tar.gz
     externalproject_add(${LIBOPENSSL_TARGET}
       URL                  ${WITH_LIBOPENSSL_URL}
+      LOG_BUILD            TRUE
+      LOG_INSTALL          TRUE
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND    <SOURCE_DIR>/config --prefix=${CMAKE_CURRENT_BINARY_DIR}/external no-shared # ${DEFAULT_CONFIGURE_OPTS}
@@ -1140,6 +1148,8 @@ if(WITH_LIBUNIXODBC STREQUAL "EXTERNAL")
     #e.g. http://www.unixodbc.org/unixODBC-2.3.9.tar.gz
     externalproject_add(${LIBUNIXODBC_TARGET}
       URL                  ${WITH_LIBUNIXODBC_URL}
+      LOG_BUILD            TRUE
+      LOG_INSTALL          TRUE
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND    <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external # ${DEFAULT_CONFIGURE_OPTS}
@@ -1170,6 +1180,8 @@ set(RAPIDJSON_TARGET rapidjson)
 externalproject_add(${RAPIDJSON_TARGET}
   # tried URL but archive gets downloaded every time. URL_MD5 may help
   URL                  ${WITH_RAPIDJSON_URL}
+  LOG_BUILD            TRUE
+  LOG_INSTALL          TRUE
   TIMEOUT              600
   DOWNLOAD_NO_PROGRESS 1
   # don't install
@@ -1242,6 +1254,7 @@ if(WITH_CCI AND WITH_CMSERVER AND EXISTS ${CMAKE_SOURCE_DIR}/cubridmanager/serve
   if(UNIX)
     set(CMS_DEPENDS cubridcs cascci cmstat cmdep)
     externalproject_add(cubridmanager
+      LOG_BUILD            TRUE
       DEPENDS pre_cubridmanager ${CMS_DEPENDS}
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cubridmanager/server
       CONFIGURE_COMMAND sh <SOURCE_DIR>/autogen.sh
@@ -1253,6 +1266,7 @@ if(WITH_CCI AND WITH_CMSERVER AND EXISTS ${CMAKE_SOURCE_DIR}/cubridmanager/serve
     set(CMS_DEPENDS cascci cmstat cmdep)
     externalproject_add(cubridmanager
       DEPENDS pre_cubridmanager ${CMS_DEPENDS}
+      LOG_BUILD            TRUE
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cubridmanager/server
       CONFIGURE_COMMAND ""
       BUILD_COMMAND cmd /c build.bat --prefix <INSTALL_DIR> --with-cubrid-libdir <TMP_DIR> --with-cubrid-includedir <TMP_DIR> ${CMS_CONFIGURE_OPTS}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24275

**Purpose**
* make message output from build/install of **externalproject** to use it own log file instead of stdout
*  the configure, build, and install logs of external projects will be saved as separate log files in 
   ${CMAKE_CURRENT_BINARY_DIR}/external/...
* this will reduce 2800+ lines in CUBRID build log.

**Implementation**
N/A

**Remarks**
* LOG_CONFIGURE is not set to true in **libedit** because the **CUBRID build fails.**
* LOG_CONFIGURE of libexpat was excluded because off and on did not significantly affect the amount of the logfile output.