### PR TITLE
[CBD-24361] CCI driver must be included in cmake build for engine(DBLink).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ option(USE_CUBRID_ENV "Use CUBRID environment variables" ON)
 option(WITH_JDBC "Build with JDBC driver" ON)
 option(WITH_CMSERVER "Build with Manager server" ON)
 option(UNIT_TESTS "Unit tests" OFF)
-option(WITH_CCI "Build with CCI driver" OFF)
+option(WITH_CCI "Build with CCI driver" ON)
 
 # options for external libraries (BUNDLED, EXTERAL or SYSTEM)
 # expat library sources URL


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24361

Purpose
- in Cmake, Default value('WITH CCI') for CCI driver change to true.
Implementation
N/A
Remarks
N/A