### PR TITLE
[CBRD-24402] backport of #3672 to 11.2, add notification of the .bash_profile creation in CUBRID install

### DIFF
--- a/cmake/CPack.STGZ_Header.sh.in
+++ b/cmake/CPack.STGZ_Header.sh.in
@@ -197,7 +197,7 @@ elif [ -f /etc/os-release ];then
 fi
 
 case $OS in
-	fedoraproject | centos | redhat)
+	fedoraproject | centos | redhat | rocky)
 		if [ ! -h /lib64/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
 			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib64/libform.so.6 $LIB/libform.so.5
@@ -218,6 +218,9 @@ case $OS in
 			ln -s /usr/lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
 		fi
 		;;
+	*)
+		echo "CUBRID requires the ncurses package. Make sure the ncurses package is installed"
+		;;
 esac
 ____cubrid__here_doc____
 
@@ -237,7 +240,7 @@ if [ -z "$SHELL" ];then
       user_sh="bash"
    else
       user_name=$(id -nu)
-      user_sh=$(egrep "^$user_name" /etc/passwd | cut -d':' -f7-7)
+      user_sh=$(egrep -w "^$user_name" /etc/passwd | cut -d':' -f7-7)
       user_sh=${user_sh:-none}
       user_sh=$(basename $user_sh)
    fi
@@ -245,8 +248,14 @@ else
         user_sh=$(basename $SHELL)
 fi
 
+bash_exist=1
 if [ $user_sh = "bash" ];then
 	sh_profile=$HOME/.bash_profile
+	if [ ! -f $sh_profile ];then
+	  bash_exist=0
+	  touch $sh_profile
+	fi
+
 	append_profile=$(grep "${PRODUCT_NAME} environment" $sh_profile)
 
 	if [ -z "$append_profile" ];then
@@ -260,6 +269,9 @@ if [ $user_sh = "bash" ];then
 	    echo 'if [ -f $HOME/.cubrid.sh ];then'                                                  >> $sh_profile
 	    echo '. $HOME/.cubrid.sh'                                                               >> $sh_profile
 	    echo 'fi'                                                                               >> $sh_profile
+	    if [ $bash_exist -eq 0 ];then
+	      echo "Notification: $sh_profile is created"
+	    fi
 	  fi
 	fi
 else

--- a/cmake/CPack_postinstall.sh.in
+++ b/cmake/CPack_postinstall.sh.in
@@ -1,6 +1,34 @@
 # Make cubrid start/shutdown automatically.
+#
+PRODUCT_NAME="CUBRID"
+
 if [ -x /sbin/chkconfig ] ; then
   /sbin/chkconfig --add cubrid
 fi
-chown cubrid:cubrid -R $RPM_INSTALL_PREFIX
+#
+bash_exist=1
+sh_profile=$RPM_INSTALL_PREFIX/.bash_profile
+if [ ! -f $sh_profile ];then
+  bash_exist=0
+  touch $sh_profile
+fi
+
+append_profile=$(grep "${PRODUCT_NAME} environment" $sh_profile)
+
+if [ -z "$append_profile" ];then
+  echo '#-------------------------------------------------------------------------------' >> $sh_profile
+  echo '# set '${PRODUCT_NAME}' environment variables'                                    >> $sh_profile
+  echo '#-------------------------------------------------------------------------------' >> $sh_profile
+  echo 'if [ -f $HOME/.cubrid.sh ];then'                                                  >> $sh_profile
+  echo '. $HOME/.cubrid.sh'                                                               >> $sh_profile
+  echo 'fi'                                                                               >> $sh_profile
+
+  if [ $bash_exist -eq 0 ];then
+    echo "Notification: $sh_profile is created"
+  fi
+fi
+
+cp $RPM_INSTALL_PREFIX/share/rpm/cubrid.sh $RPM_INSTALL_PREFIX/.cubrid.sh
+
 . $RPM_INSTALL_PREFIX/share/rpm/cubrid.sh
+chown cubrid:cubrid -R $RPM_INSTALL_PREFIX

--- a/contrib/rpm/cubrid.csh
+++ b/contrib/rpm/cubrid.csh
@@ -16,3 +16,41 @@ if ( "$BIN_PATH" == "" ) then
 	set path=($CUBRID/bin $path)
 endif
 
+set LIB=$CUBRID/lib
+
+if ( -f /etc/redhat-release ) then
+        set OS=`cat /etc/system-release-cpe | cut -d':' -f'3-3'`
+else if ( -f /etc/os-release ) then
+        set OS=`cat /etc/os-release | egrep "^ID=" | cut -d'=' -f2-2`
+     endif
+endif
+
+switch ($OS)
+  case "fedoraproject":
+  case "centos":
+  case "redhat":
+  case "rocky":
+    if ( ! -f /lib64/libncurses.so.5 && ! -f $LIB/libncurses.so.5 ) then
+    	ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
+    	ln -s /lib64/libform.so.6 $LIB/libform.so.5
+    	ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
+    endif
+    breaksw
+  case "ubuntu":
+    if ( ! -f /lib/x86_64-linux-gnu/libncurses.so.5 && ! -f $LIB/libncurses.so.5 ) then
+      ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
+      ln -s /lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
+      ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
+    endif
+    breaksw
+  case "debian":
+    if ( ! -f /lib/x86_64-linux-gnu/libncurses.so.5 && ! -f $LIB/libncurses.so.5 ) then
+            ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
+            ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
+            ln -s /usr/lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
+    endif
+    breaksw
+  default:
+    echo "CUBRID requires the ncurses package. Make sure the ncurses package is installed"
+    breaksw
+endsw

--- a/contrib/rpm/cubrid.sh
+++ b/contrib/rpm/cubrid.sh
@@ -41,7 +41,7 @@ elif [ -f /etc/os-release ];then
 fi
 
 case $OS in
-	fedoraproject | centos | redhat)
+	fedoraproject | centos | redhat | rocky)
 		if [ ! -h /lib64/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
 			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib64/libform.so.6 $LIB/libform.so.5
@@ -61,5 +61,8 @@ case $OS in
 			ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
 			ln -s /usr/lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
 		fi
+		;;
+	*)
+		echo "CUBRID requires the ncurses package. Make sure the ncurses package is installed"
 		;;
 esac


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24402

**Purpose**
* backport of #3672 to release/11.2
  * Print Notification message, if .bash_profile is newly created during CUBRID installation
  * Apply to CUBRID install.sh & rpm
  * Revise $CUBRID/share/rpm/cubrid.csh to reflect changes in cubrid.sh for ncurses related symolic link.

**Implementation**
N/A

**Remarks**
added '**rocky**' OS for ncurses6 symbolic link