### PR TITLE
[CBRD-24331] Fix unstable javasp utility

### DIFF
--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -214,7 +214,7 @@ main (int argc, char *argv[])
 	      {
 		SLEEP_MILISEC (0, 100);
 	      }
-      while (true);
+	    while (true);
 	  }
       }
     else if (command.compare ("stop") == 0)
@@ -293,7 +293,10 @@ javasp_start_server (const JAVASP_SERVER_INFO jsp_info, const std::string &db_na
     {
 #if !defined(WINDOWS)
       /* create a new session */
-      setsid ();
+      if (setsid() == -1)
+	{
+	  return ER_GENERIC_ERROR;
+	}
 #endif
       er_clear (); // clear error before string JVM
       status = jsp_start_server (db_name.c_str (), path.c_str (), prm_port);
@@ -302,6 +305,7 @@ javasp_start_server (const JAVASP_SERVER_INFO jsp_info, const std::string &db_na
 	{
 	  JAVASP_SERVER_INFO jsp_new_info { getpid(), jsp_server_port () };
 
+	  javasp_unlink_info (db_name.c_str ());
 	  if ((javasp_open_info_dir () && javasp_write_info (db_name.c_str (), jsp_new_info, true)))
 	    {
 	      /* succeed */

--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -210,10 +210,11 @@ main (int argc, char *argv[])
 	status = javasp_start_server (jsp_info, db_name, pathname);
 	if (status == NO_ERROR)
 	  {
-	    while (true)
+	    do
 	      {
 		SLEEP_MILISEC (0, 100);
 	      }
+      while (true);
 	  }
       }
     else if (command.compare ("stop") == 0)
@@ -301,7 +302,7 @@ javasp_start_server (const JAVASP_SERVER_INFO jsp_info, const std::string &db_na
 	{
 	  JAVASP_SERVER_INFO jsp_new_info { getpid(), jsp_server_port () };
 
-	  if ((javasp_open_info_dir () && javasp_write_info (db_name.c_str (), jsp_new_info)))
+	  if ((javasp_open_info_dir () && javasp_write_info (db_name.c_str (), jsp_new_info, true)))
 	    {
 	      /* succeed */
 	    }

--- a/src/jsp/com/cubrid/jsp/ListenerThread.java
+++ b/src/jsp/com/cubrid/jsp/ListenerThread.java
@@ -56,6 +56,7 @@ public class ListenerThread extends Thread {
                 execThread.start();
             } catch (IOException e) {
                 Server.log(e);
+                break;
             }
         }
 

--- a/src/jsp/com/cubrid/jsp/Server.java
+++ b/src/jsp/com/cubrid/jsp/Server.java
@@ -74,12 +74,20 @@ public class Server {
         if (OSValidator.IS_UNIX) {
             String socketName = rootPath + tmpPath + "/junixsocket-" + name + ".sock";
             final File socketFile = new File(socketName);
+
+            if (socketFile.exists()) {
+                socketFile.delete();
+            }
+
             try {
                 AFUNIXServerSocket udsServerSocket = AFUNIXServerSocket.newInstance();
-                udsServerSocket.bind(AFUNIXSocketAddress.of(socketFile));
+                AFUNIXSocketAddress sockAddr = AFUNIXSocketAddress.of(socketFile);
+                udsServerSocket.bind(sockAddr);
                 udsSocketListener = new ListenerThread(udsServerSocket);
             } catch (Exception e) {
                 log(e);
+                e.printStackTrace();
+                System.exit(1);
             }
         }
 
@@ -91,6 +99,7 @@ public class Server {
         } catch (Exception e) {
             log(e);
             e.printStackTrace();
+            System.exit(1);
         }
 
         Class.forName("cubrid.jdbc.driver.CUBRIDDriver");

--- a/src/jsp/com/cubrid/jsp/Server.java
+++ b/src/jsp/com/cubrid/jsp/Server.java
@@ -80,9 +80,8 @@ public class Server {
             }
 
             try {
-                AFUNIXServerSocket udsServerSocket = AFUNIXServerSocket.newInstance();
                 AFUNIXSocketAddress sockAddr = AFUNIXSocketAddress.of(socketFile);
-                udsServerSocket.bind(sockAddr);
+                AFUNIXServerSocket udsServerSocket = AFUNIXServerSocket.bindOn (sockAddr);
                 udsSocketListener = new ListenerThread(udsServerSocket);
             } catch (Exception e) {
                 log(e);

--- a/src/jsp/jsp_file.c
+++ b/src/jsp/jsp_file.c
@@ -87,6 +87,18 @@ javasp_open_info (const char *db_name, const char *mode)
   return fp;
 }
 
+void
+javasp_unlink_info (const char *db_name)
+{
+  char file_name[PATH_MAX] = { 0 };
+  char file_path[PATH_MAX] = { 0 };
+
+  snprintf (file_name, PATH_MAX, "javasp/javasp_%s.info", db_name);
+  envvar_vardir_file (file_path, PATH_MAX, file_name);
+
+  unlink (file_path);
+}
+
 bool
 javasp_get_info_file (char *buf, size_t len, const char *db_name)
 {

--- a/src/jsp/jsp_file.h
+++ b/src/jsp/jsp_file.h
@@ -47,7 +47,7 @@ extern "C"
   extern FILE *javasp_open_info (const char *db_name, const char *mode);
 
   extern bool javasp_read_info (const char *db_name, JAVASP_SERVER_INFO & info);
-  extern bool javasp_write_info (const char *db_name, JAVASP_SERVER_INFO info);
+  extern bool javasp_write_info (const char *db_name, JAVASP_SERVER_INFO info, bool claim_lock);
   extern bool javasp_reset_info (const char *db_name);
 
   extern bool javasp_get_info_file (char *buf, size_t len, const char *db_name);

--- a/src/jsp/jsp_file.h
+++ b/src/jsp/jsp_file.h
@@ -45,6 +45,7 @@ extern "C"
 
   extern bool javasp_open_info_dir ();
   extern FILE *javasp_open_info (const char *db_name, const char *mode);
+  extern void javasp_unlink_info (const char *db_name);
 
   extern bool javasp_read_info (const char *db_name, JAVASP_SERVER_INFO & info);
   extern bool javasp_write_info (const char *db_name, JAVASP_SERVER_INFO info, bool claim_lock);

--- a/src/jsp/jsp_sr.c
+++ b/src/jsp/jsp_sr.c
@@ -109,7 +109,6 @@
 #define BUF_SIZE        2048
 typedef jint (*CREATE_VM_FUNC) (JavaVM **, void **, void *);
 
-#ifdef __cplusplus
 #define JVM_GetEnv(JVM, ENV, VER)	\
 	(JVM)->GetEnv(ENV, VER)
 #define JVM_AttachCurrentThread(JVM, ENV, ARGS)	\
@@ -140,38 +139,8 @@ typedef jint (*CREATE_VM_FUNC) (JavaVM **, void **, void *);
 	(ENV)->ReleaseStringUTFChars(JSTRING, CSTRING)
 #define JVM_GetStringUTFLength(ENV, STRING)	\
 	(ENV)->GetStringUTFLength(STRING)
-#else
-#define JVM_GetEnv(JVM, ENV, VER)	\
-	(*JVM)->GetEnv(JVM, ENV, VER)
-#define JVM_AttachCurrentThread(JVM, ENV, ARGS)	\
-	(*JVM)->AttachCurrentThread(JVM, ENV, ARGS)
-#define JVM_DetachCurrentThread(JVM)	\
-	(*JVM)->DetachCurrentThread(JVM)
-#define JVM_ExceptionOccurred(ENV)	\
-	(*ENV)->ExceptionOccurred(ENV)
-#define JVM_FindClass(ENV, NAME)	\
-	(*ENV)->FindClass(ENV, NAME)
-#define JVM_GetStaticMethodID(ENV, CLAZZ, NAME, SIG)	\
-	(*ENV)->GetStaticMethodID(ENV, CLAZZ, NAME, SIG)
-#define JVM_NewStringUTF(ENV, BYTES)	\
-	(*ENV)->NewStringUTF(ENV, BYTES);
-#define JVM_NewObjectArray(ENV, LENGTH, ELEMENTCLASS, INITIALCLASS)	\
-	(*ENV)->NewObjectArray(ENV, LENGTH, ELEMENTCLASS, INITIALCLASS)
-#define JVM_SetObjectArrayElement(ENV, ARRAY, INDEX, VALUE)	\
-	(*ENV)->SetObjectArrayElement(ENV, ARRAY, INDEX, VALUE)
-#define JVM_CallStaticVoidMethod(ENV, CLAZZ, METHODID, ARGS)	\
-	(*ENV)->CallStaticVoidMethod(ENV, CLAZZ, METHODID, ARGS)
-#define JVM_CallStaticIntMethod(ENV, CLAZZ, METHODID, ARGS)	\
-	(*ENV)->CallStaticIntMethod(ENV, CLAZZ, METHODID, ARGS)
-#define JVM_CallStaticObjectMethod(ENV, CLAZZ, METHODID, ARGS)	\
-	(*ENV)->CallStaticObjectMethod(ENV, CLAZZ, METHODID, ARGS)
-#define JVM_GetStringUTF(ENV, STRING)	\
-	(*ENV)->GetStringUTFChars(ENV, STRING, NULL)
-#define JVM_ReleaseStringUTF(ENV, JSTRING, CSTRING)	\
-	(*ENV)->ReleaseStringUTFChars(ENV, JSTRING, CSTRING)
-#define JVM_GetStringUTFLength(ENV, STRING)	\
-	(*ENV)->GetStringUTFLength(ENV, STRING)
-#endif
+#define JVM_GetJavaVM(ENV, JVM)	\
+	(ENV)->GetJavaVM(JVM)
 
 static JavaVM *jvm = NULL;
 static jint sp_port = -1;
@@ -543,13 +512,12 @@ jsp_start_server (const char *db_name, const char *path, int port)
   jobjectArray args;
   JavaVMInitArgs vm_arguments;
   JavaVMOption *options;
-  int vm_n_options = 3;
+  int vm_n_options = 2;
   char classpath[PATH_MAX + 32] = { 0 };
   char logging_prop[PATH_MAX + 32] = { 0 };
   char option_debug[70];
   char debug_flag[] = "-Xdebug";
   char debug_jdwp[] = "-agentlib:jdwp=transport=dt_socket,server=y,address=%d,suspend=n";
-  char disable_sig_handle[] = "-Xrs";
   const char *envroot;
   const char *envtmp;
   char jsp_file_path[PATH_MAX];
@@ -594,16 +562,15 @@ jsp_start_server (const char *db_name, const char *path, int port)
 	goto error;
       }
 
-    int idx = 3;
+    int idx = 2;
     options[0].optionString = classpath;
     options[1].optionString = logging_prop;
-    options[2].optionString = disable_sig_handle;
     if (debug_port != -1)
       {
 	idx += 2;
 	snprintf (option_debug, sizeof (option_debug) - 1, debug_jdwp, debug_port);
-	options[3].optionString = debug_flag;
-	options[4].optionString = option_debug;
+	options[2].optionString = debug_flag;
+	options[3].optionString = option_debug;
       }
 
     for (auto it = opts.begin (); it != opts.end (); ++it)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24331

Starting javasp utility is unstable. This PR fixes the following
- avoid "java.net.SocketException: ; errno=22" is logged in infinite loop
- delete the named socket file if exists
