### PR TITLE
[CBRD-24410] Incorrect number of affected records when INSERT ON DUPLICATE KEY is executed

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -11432,7 +11432,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		    {
 		      assert (force_count == 1);
 
-		      xasl->list_id->tuple_cnt += force_count * 2;
+		      xasl->list_id->tuple_cnt += force_count;
 		      continue;
 		    }
 		}

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -11413,7 +11413,6 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		    {
 		      GOTO_EXIT_ON_ERROR;
 		    }
-		  xasl->list_id->tuple_cnt += removed_count;
 		}
 
 	      if (odku_assignments && insert->has_uniques)
@@ -11584,7 +11583,6 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
-	      xasl->list_id->tuple_cnt += removed_count;
 	    }
 
 	  force_count = 0;
@@ -11602,7 +11600,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	      if (force_count)
 		{
 		  assert (force_count == 1);
-		  xasl->list_id->tuple_cnt += force_count * 2;
+		  xasl->list_id->tuple_cnt += force_count;
 		}
 	    }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24410

When insert ON DUPLICATE KEY is performed, there is 1 duplicate record, and 1 record has been modified as a result. However, it says that there are two records affected.

Replace is also displayed in two cases in the same way.

csql> select * from nation where code like 'cd%';

```
=== <Result of SELECT Command in Line 1> ===
  code                  name            continent             capital
========================================================================================
  'cd0'                 'old'           NULL                  NULL
  'cd1'                 'old1'          NULL                  NULL
  'cd2'                 'old2'          NULL                  NULL
  'cd3'                 'old3'          NULL                  NULL

4 rows selected. (0.003354 sec) Committed.

1 command(s) successfully processed.
csql> INSERT INTO nation(code, name) VALUES ('cd1', 'new')
csql>   ON DUPLICATE KEY UPDATE name = 'new1', capital = 'cap1'
csql> ;
2 rows affected. (0.001580 sec) Committed.1 command(s) successfully processed. 
```
