### PR TITLE
[LETS-424] Integrate atomic replicator in passive transaction server replication

### DIFF
--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "log_impl.h"
+#include "log_replication_atomic.hpp"
 #include "passive_tran_server.hpp"
 #include "server_type.hpp"
 #include "system_parameter.h"
@@ -129,7 +130,7 @@ void passive_tran_server::start_log_replicator (const log_lsa &start_lsa)
 
   // passive transaction server executes replication synchronously, for the time being, due to complexity of
   // executing it in parallel while also providing a consistent view of the data
-  m_replicator.reset (new cublog::replicator (start_lsa, OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT, 0));
+  m_replicator.reset (new cublog::atomic_replicator (start_lsa));
 }
 
 void passive_tran_server::send_and_receive_stop_log_prior_dispatch ()

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "log_impl.h"
-#include "log_replication_atomic.hpp"
 #include "passive_tran_server.hpp"
 #include "server_type.hpp"
 #include "system_parameter.h"
@@ -130,7 +129,7 @@ void passive_tran_server::start_log_replicator (const log_lsa &start_lsa)
 
   // passive transaction server executes replication synchronously, for the time being, due to complexity of
   // executing it in parallel while also providing a consistent view of the data
-  m_replicator.reset (new cublog::atomic_replicator (start_lsa));
+  m_replicator.reset (new cublog::replicator (start_lsa, OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT, 0));
 }
 
 void passive_tran_server::send_and_receive_stop_log_prior_dispatch ()

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -132,6 +132,25 @@ namespace cublog
     return atomic_sequence.can_end_atomic_sequence (sysop_parent_lsa);
   }
 
+  log_lsa atomic_replication_helper::get_the_lowest_start_lsa ()
+  {
+    log_lsa min_lsa = MAX_LSA;
+
+    for (auto const &sequence_map_iterator : m_sequences_map)
+      {
+	if (sequence_map_iterator.second.get_start_lsa () < min_lsa)
+	  {
+	    min_lsa = sequence_map_iterator.second.get_start_lsa ();
+	  }
+      }
+    return min_lsa;
+  }
+
+  bool atomic_replication_helper::is_any_atomic_sequence_open () const
+  {
+    return !m_sequences_map.empty ();
+  }
+
   /********************************************************************************
    * atomic_replication_helper::atomic_replication_sequence function definitions  *
    ********************************************************************************/
@@ -203,6 +222,11 @@ namespace cublog
     assert (!LSA_ISNULL (&sysop_parent_lsa));
 
     return m_start_lsa >= sysop_parent_lsa;
+  }
+
+  log_lsa atomic_replication_helper::atomic_replication_sequence::get_start_lsa () const
+  {
+    return m_start_lsa;
   }
 
   /*********************************************************************************************************

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -146,11 +146,6 @@ namespace cublog
     return min_lsa;
   }
 
-  bool atomic_replication_helper::is_any_atomic_sequence_open () const
-  {
-    return !m_sequences_map.empty ();
-  }
-
   /********************************************************************************
    * atomic_replication_helper::atomic_replication_sequence function definitions  *
    ********************************************************************************/
@@ -361,10 +356,5 @@ namespace cublog
   void atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::set_page_ptr (const PAGE_PTR &ptr)
   {
     m_page_ptr = ptr;
-  }
-
-  LOG_LSA atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::get_lsa () const
-  {
-    return m_record_lsa;
   }
 }

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -57,6 +57,8 @@ namespace cublog
       bool check_for_page_validity (VPID vpid, TRANID tranid) const;
 #endif
       bool can_end_atomic_sequence (TRANID tranid, LOG_LSA sysop_parent_lsa) const;
+      bool is_any_atomic_sequence_open () const;
+      log_lsa get_the_lowest_start_lsa ();
 
     private:
 
@@ -81,6 +83,7 @@ namespace cublog
 	  void apply_and_unfix_sequence (THREAD_ENTRY *thread_p);
 	  int add_atomic_replication_unit (THREAD_ENTRY *thread_p, log_lsa record_lsa, LOG_RCVINDEX rcvindex, VPID vpid);
 	  bool can_end_atomic_sequence (LOG_LSA sysop_parent_lsa) const;
+	  log_lsa get_start_lsa () const;
 	private:
 	  void apply_all_log_redos (THREAD_ENTRY *thread_p);
 

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -57,7 +57,6 @@ namespace cublog
       bool check_for_page_validity (VPID vpid, TRANID tranid) const;
 #endif
       bool can_end_atomic_sequence (TRANID tranid, LOG_LSA sysop_parent_lsa) const;
-      bool is_any_atomic_sequence_open () const;
       log_lsa get_the_lowest_start_lsa ();
 
     private:
@@ -171,6 +170,11 @@ namespace cublog
 	rcv.reference_lsa = m_record_lsa;
 	log_rv_redo_record_sync_apply (thread_p, redo_context, record_info, m_vpid, rcv);
       }
+  }
+
+  inline LOG_LSA atomic_replication_helper::atomic_replication_sequence::atomic_replication_unit::get_lsa () const
+  {
+    return m_record_lsa;
   }
 }
 

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -519,18 +519,10 @@ namespace cublog
     return m_redo_lsa;
   }
 
-  log_lsa replicator::get_lowest_unapplied_lsa () const
+  log_lsa
+  replicator::get_lowest_unapplied_lsa () const
   {
-    // TODO: needs to be refactored to work with the new replicators flavors
-    if (m_parallel_replication_redo == nullptr)
-      {
-	// sync
-	return get_highest_processed_lsa ();
-      }
-
-    // a different value will return from here when the atomic replicator is added
-    // for now this part should not be reached
-    assert (false);
+    return get_highest_processed_lsa ();
   }
 
   /*********************************************************************

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -522,6 +522,9 @@ namespace cublog
   log_lsa
   replicator::get_lowest_unapplied_lsa () const
   {
+    // this function should never be called,
+    // instead the implementation in the atomic_replicator should be used
+    assert (false);
     return get_highest_processed_lsa ();
   }
 

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -74,7 +74,7 @@ namespace cublog
       /* return current progress of the replicator; non-blocking call */
       log_lsa get_highest_processed_lsa () const;
       /* return the lowest value lsa that was not applied, the next in line lsa */
-      log_lsa get_lowest_unapplied_lsa () const;
+      virtual log_lsa get_lowest_unapplied_lsa () const;
 
       log_lsa get_most_recent_trantable_snapshot_lsa () const;
 

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -257,10 +257,10 @@ namespace cublog
   void
   atomic_replicator::set_lowest_unapplied_lsa ()
   {
-    assert (m_redo_lsa != NULL_LSA);
+    assert (!LSA_ISNULL (&m_redo_lsa));
     const LOG_LSA helper_lowest_unapplied_lsa = m_atomic_helper.get_the_lowest_start_lsa ();
-    const LOG_LSA value_to_change = std::min (m_redo_lsa, helper_lowest_unapplied_lsa);
-
+    assert (!LSA_ISNULL (&helper_lowest_unapplied_lsa));
+    const LOG_LSA value_to_change = (m_redo_lsa < helper_lowest_unapplied_lsa) ? m_redo_lsa : helper_lowest_unapplied_lsa;
     {
       std::lock_guard<std::mutex> lockg (m_lowest_unapplied_lsa_mutex);
       m_lowest_unapplied_lsa = value_to_change;

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -54,7 +54,6 @@ namespace cublog
     private:
       atomic_replication_helper m_atomic_helper;
       log_lsa m_lowest_unapplied_lsa;
-      bool m_should_update_lowest_lsa = true;
       mutable std::mutex m_lowest_unapplied_lsa_mutex;
   };
 }

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -49,10 +49,13 @@ namespace cublog
       template <typename T>
       void read_and_redo_record (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header,
 				 const log_lsa &rec_lsa);
+      void set_lowest_unapplied_lsa (log_lsa value);
 
     private:
       atomic_replication_helper m_atomic_helper;
       log_lsa m_lowest_unapplied_lsa;
+      bool m_should_update_lowest_lsa = true;
+      mutable std::mutex m_lowest_unapplied_lsa_mutex;
   };
 }
 

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -49,7 +49,7 @@ namespace cublog
       template <typename T>
       void read_and_redo_record (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header,
 				 const log_lsa &rec_lsa);
-      void set_lowest_unapplied_lsa (log_lsa value);
+      void set_lowest_unapplied_lsa ();
 
     private:
       atomic_replication_helper m_atomic_helper;

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -42,6 +42,8 @@ namespace cublog
       atomic_replicator &operator= (const atomic_replicator &) = delete;
       atomic_replicator &operator= (atomic_replicator &&) = delete;
 
+      /* return the lowest value lsa that was not applied, the next in line lsa */
+      log_lsa get_lowest_unapplied_lsa () const override;
     private:
       void redo_upto (cubthread::entry &thread_entry, const log_lsa &end_redo_lsa) override;
       template <typename T>
@@ -50,6 +52,7 @@ namespace cublog
 
     private:
       atomic_replication_helper m_atomic_helper;
+      log_lsa m_lowest_unapplied_lsa;
   };
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-424

Integrated the `atomic_replicator` with the new changes that occurred on the normal replicator.
Also implemented the `lowest_unaplied_lsa` functionality that was first introduced in a previous issue.
