### PR TITLE
[CBRD-24411] adds $CUBRID/bin to the path regardless of  the current user's path variable

### DIFF
--- a/contrib/scripts/cubrid.csh
+++ b/contrib/scripts/cubrid.csh
@@ -18,20 +18,13 @@
 setenv CUBRID /opt/cubrid
 setenv CUBRID_DATABASES $CUBRID/databases
 
-set CUBRID_BASENAME=`basename $CUBRID`
 if ( ${?LD_LIBRARY_PATH} ) then
-	set LIB_PATH = `echo $LD_LIBRARY_PATH | grep -i $CUBRID_BASENAME`
-	if ( $LIB_PATH == "" ) then
-		setenv LD_LIBRARY_PATH $CUBRID/lib:$CUBRID/cci/lib:$LD_LIBRARY_PATH
-	endif
+	setenv LD_LIBRARY_PATH $CUBRID/lib:$CUBRID/cci/lib:$LD_LIBRARY_PATH
 else
 	setenv LD_LIBRARY_PATH $CUBRID/lib:$CUBRID/cci/lib
 endif
 
-set BIN_PATH = `echo $path | grep -i $CUBRID_BASENAME`
-if ( "$BIN_PATH" == "" ) then
-	set path=($CUBRID/bin $path)
-endif
+set path=($CUBRID/bin $path)
 
 setenv SHLIB_PATH $LD_LIBRARY_PATH
 setenv LIBPATH $LD_LIBRARY_PATH

--- a/contrib/scripts/cubrid.sh
+++ b/contrib/scripts/cubrid.sh
@@ -18,21 +18,12 @@
 export CUBRID=/opt/cubrid
 export CUBRID_DATABASES=$CUBRID/databases
 
-CUBRID_BASENAME=$(basename $CUBRID)
-LIB_PATH=`echo $LD_LIBRARY_PATH | grep -i $CUBRID_BASENAME`
-if [ "$LIB_PATH" = "" ];
-then
-	export LD_LIBRARY_PATH=$CUBRID/lib:$CUBRID/cci/lib:$LD_LIBRARY_PATH
-fi
+export LD_LIBRARY_PATH=$CUBRID/lib:$CUBRID/cci/lib:$LD_LIBRARY_PATH
+export PATH=$CUBRID/bin:$PATH
 
 export SHLIB_PATH=$LD_LIBRARY_PATH
 export LIBPATH=$LD_LIBRARY_PATH
 
-BIN_PATH=`echo $PATH | grep -i $CUBRID_BASENAME`
-if [ "$BIN_PATH" = "" ];
-then
-	PATH=$CUBRID/bin:$PATH
-fi
 
 LIB=$CUBRID/lib
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24411

**Purpose**
adds $CUBRID/bin to the path regardless of the current user's path variable value. it is QA request.

**Implementation**
N/A

**Remarks**
The code below is to prevent $CUBRID/bin from being added to the path multiple times when the user repeatedly executes **.cubrid.sh**. However, if the user has a directory with the same name in the command path, there is a possibility that $CUBRID/bin is not added.

```
CUBRID_BASENAME=$(basename $CUBRID)
BIN_PATH=`echo $PATH | grep -i $CUBRID_BASENAME`
if [ "$BIN_PATH" = "" ];
then
	PATH=$CUBRID/bin:$PATH
fi
```