### PR TITLE
[LETS-406] log_global.m_prior_sender must only be initialized if/when needed

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -137,6 +137,7 @@ int init_server_type (const char *db_name)
       if (is_active_transaction_server ())
 	{
 	  ts_Gl.reset (new active_tran_server ());
+	  log_Gl.initialize_log_prior_sender ();
 	}
       else if (is_passive_transaction_server ())
 	{
@@ -158,6 +159,7 @@ int init_server_type (const char *db_name)
     {
       // page server needs a log prior receiver
       log_Gl.initialize_log_prior_receiver ();
+      log_Gl.initialize_log_prior_sender ();
     }
   else
     {
@@ -203,12 +205,18 @@ void finalize_server_type ()
 	  assert (pts_Gl != nullptr);
 	  pts_Gl = nullptr;
 	}
+
       ts_Gl->disconnect_page_server ();
+      if (is_active_transaction_server ())
+	{
+	  log_Gl.finalize_log_prior_sender ();
+	}
       ts_Gl.reset (nullptr);
     }
   else if (get_server_type () == SERVER_TYPE_PAGE)
     {
       ps_Gl.disconnect_all_tran_server ();
+      log_Gl.finalize_log_prior_sender ();
     }
   else
     {

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -157,9 +157,9 @@ int init_server_type (const char *db_name)
     }
   else if (g_server_type == SERVER_TYPE_PAGE)
     {
-      // page server needs a log prior receiver
-      log_Gl.initialize_log_prior_receiver ();
+      // page server needs a log prior sender and receiver
       log_Gl.initialize_log_prior_sender ();
+      log_Gl.initialize_log_prior_receiver ();
     }
   else
     {
@@ -205,12 +205,12 @@ void finalize_server_type ()
 	  assert (pts_Gl != nullptr);
 	  pts_Gl = nullptr;
 	}
-
-      ts_Gl->disconnect_page_server ();
       if (is_active_transaction_server ())
 	{
 	  log_Gl.finalize_log_prior_sender ();
 	}
+
+      ts_Gl->disconnect_page_server ();
       ts_Gl.reset (nullptr);
     }
   else if (get_server_type () == SERVER_TYPE_PAGE)

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -71,6 +71,7 @@ active_tran_server::on_boot ()
   m_prior_sender_sink_hook_func =
 	  std::bind (&active_tran_server::push_request, std::ref (*this), tran_to_page_request::SEND_LOG_PRIOR_LIST,
 		     std::placeholders::_1);
+
   log_Gl.m_prior_sender->add_sink (m_prior_sender_sink_hook_func);
 }
 

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -72,7 +72,11 @@ active_tran_server::on_boot ()
 	  std::bind (&active_tran_server::push_request, std::ref (*this), tran_to_page_request::SEND_LOG_PRIOR_LIST,
 		     std::placeholders::_1);
 
-  log_Gl.m_prior_sender.add_sink (m_prior_sender_sink_hook_func);
+  if (log_Gl.m_prior_sender == nullptr)
+    {
+      log_Gl.m_prior_sender = std::make_unique<cublog::prior_sender> ();
+    }
+  log_Gl.m_prior_sender->add_sink (m_prior_sender_sink_hook_func);
 }
 
 active_tran_server::request_handlers_map_t

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -71,11 +71,6 @@ active_tran_server::on_boot ()
   m_prior_sender_sink_hook_func =
 	  std::bind (&active_tran_server::push_request, std::ref (*this), tran_to_page_request::SEND_LOG_PRIOR_LIST,
 		     std::placeholders::_1);
-
-  if (log_Gl.m_prior_sender == nullptr)
-    {
-      log_Gl.m_prior_sender = std::make_unique<cublog::prior_sender> ();
-    }
   log_Gl.m_prior_sender->add_sink (m_prior_sender_sink_hook_func);
 }
 

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -278,7 +278,7 @@ page_server::connection_handler::remove_prior_sender_sink ()
 
   if (static_cast<bool> (m_prior_sender_sink_hook_func))
     {
-      log_Gl.m_prior_sender.remove_sink (m_prior_sender_sink_hook_func);
+      log_Gl.m_prior_sender->remove_sink (m_prior_sender_sink_hook_func);
       m_prior_sender_sink_hook_func = nullptr;
     }
 }

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -131,9 +131,21 @@ log_global::initialize_log_prior_receiver ()
 }
 
 void
+log_global::initialize_log_prior_sender ()
+{
+  m_prior_sender = std::make_unique<cublog::prior_sender> ();
+}
+
+void
 log_global::finalize_log_prior_receiver ()
 {
   m_prior_recver.reset (nullptr);
+}
+
+void
+log_global::finalize_log_prior_sender ()
+{
+  m_prior_sender.reset (nullptr);
 }
 
 cublog::prior_recver &

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -145,6 +145,7 @@ log_global::finalize_log_prior_receiver ()
 void
 log_global::finalize_log_prior_sender ()
 {
+  assert (m_prior_sender->is_empty ());
   m_prior_sender.reset (nullptr);
 }
 

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -75,7 +75,6 @@ log_global::log_global ()
   , bg_archive_info ()
   , mvcc_table ()
   , unique_stats_table GLOBAL_UNIQUE_STATS_TABLE_INITIALIZER
-  , m_prior_sender ()
 {
 }
 // *INDENT-ON*

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -714,8 +714,8 @@ struct log_global
 
   // *INDENT-OFF*
   cublog::meta m_metainfo;
-  cublog::prior_sender m_prior_sender;
 #if defined (SERVER_MODE)
+  std::unique_ptr<cublog::prior_sender> m_prior_sender = nullptr;
   std::unique_ptr<cublog::prior_recver> m_prior_recver = nullptr;
 #endif // SERVER_MODE = !SA_MODE
 

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -728,7 +728,9 @@ struct log_global
 
 #if defined (SERVER_MODE)
   void initialize_log_prior_receiver ();
+  void initialize_log_prior_sender ();
   void finalize_log_prior_receiver ();
+  void finalize_log_prior_sender ();
   cublog::prior_recver &get_log_prior_receiver ();
 #endif // SERVER_MODE
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3512,7 +3512,11 @@ log_pack_log_boot_info (THREAD_ENTRY &thread_r, std::string &payload_in_out,
 			  sizeof (log_lsa));
 
     // within the same locks, initialize log prior dispatch to the newly connected passive transaction server
-    log_Gl.m_prior_sender.add_sink (log_prior_sender_sink);
+    if (log_Gl.m_prior_sender == nullptr)
+      {
+        log_Gl.m_prior_sender = std::make_unique<cublog::prior_sender> ();
+      }
+    log_Gl.m_prior_sender->add_sink (log_prior_sender_sink);
     // TODO: in the future, this needs to be made explicit:
     //  - as passive transaction servers (PTS) go on/off-line at a random pace
     //  - and, as each PTS has the list of available page servers (PS) it can connect to

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3512,10 +3512,6 @@ log_pack_log_boot_info (THREAD_ENTRY &thread_r, std::string &payload_in_out,
 			  sizeof (log_lsa));
 
     // within the same locks, initialize log prior dispatch to the newly connected passive transaction server
-    if (log_Gl.m_prior_sender == nullptr)
-      {
-        log_Gl.m_prior_sender = std::make_unique<cublog::prior_sender> ();
-      }
     log_Gl.m_prior_sender->add_sink (log_prior_sender_sink);
     // TODO: in the future, this needs to be made explicit:
     //  - as passive transaction servers (PTS) go on/off-line at a random pace

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3435,10 +3435,6 @@ logpb_append_prior_lsa_list (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * list)
   assert (log_Gl.prior_info.prior_flush_list_header == NULL);
   log_Gl.prior_info.prior_flush_list_header = list;
 #if defined(SERVER_MODE)
-  if (log_Gl.m_prior_sender == nullptr)
-    {
-      log_Gl.m_prior_sender = std::make_unique < cublog::prior_sender > ();
-    }
   log_Gl.m_prior_sender->send_list (list);
 #endif // SERVER_MODE
   /* append log buffer */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3434,9 +3434,13 @@ logpb_append_prior_lsa_list (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * list)
   /* append prior_flush_list */
   assert (log_Gl.prior_info.prior_flush_list_header == NULL);
   log_Gl.prior_info.prior_flush_list_header = list;
-
-  log_Gl.m_prior_sender.send_list (list);
-
+#if defined(SERVER_MODE)
+  if (log_Gl.m_prior_sender == nullptr)
+    {
+      log_Gl.m_prior_sender = std::make_unique < cublog::prior_sender > ();
+    }
+  log_Gl.m_prior_sender->send_list (list);
+#endif // SERVER_MODE
   /* append log buffer */
   while (log_Gl.prior_info.prior_flush_list_header != NULL)
     {

--- a/src/transaction/log_prior_send.cpp
+++ b/src/transaction/log_prior_send.cpp
@@ -70,4 +70,9 @@ namespace cublog
     assert (find_it != m_sink_hooks.end ());
     m_sink_hooks.erase (find_it);
   }
+  bool
+  prior_sender::is_empty () const
+  {
+    return m_sink_hooks.empty ();
+  }
 }

--- a/src/transaction/log_prior_send.hpp
+++ b/src/transaction/log_prior_send.hpp
@@ -50,6 +50,7 @@ namespace cublog
 
       void add_sink (const sink_hook_t &fun);                     // add a hook for a new sink
       void remove_sink (const sink_hook_t &fun);                  // add a hook for a new sink
+      bool is_empty () const;
 
     private:
       // non-owning pointers


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-406

`log_global.m_prior_sender` is curently a value member.
This patch transforms it to a pointer - similar to `m_prior_recver` to be only initialized when/if needed.
Also it is changed to be only under SERVER_MODE.
