### PR TITLE
[CBRD-24331] Fix unstable javasp utility

### DIFF
--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -425,7 +425,7 @@ javasp_status_server (const JAVASP_SERVER_INFO jsp_info, const std::string &db_n
 	}
 
       // send terminate thread
-      ptr = or_pack_int (ptr, OR_INT_SIZE);
+      ptr = or_pack_int (request, OR_INT_SIZE);
       ptr = or_pack_int (ptr, SP_CODE_UTIL_TERMINATE_THREAD);
 
       nbytes = jsp_writen (socket, request, OR_INT_SIZE * 2);

--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -436,6 +436,8 @@ javasp_status_server (const JAVASP_SERVER_INFO jsp_info, const std::string &db_n
 	  goto exit;
 	}
 
+      jsp_disconnect_server (socket);
+
       int num_args = 0;
       JAVASP_STATUS_INFO status_info;
 

--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -112,7 +112,6 @@ main (int argc, char *argv[])
     {
       return ER_GENERIC_ERROR;
     }
-
 #endif /* WINDOWS */
   {
     /*
@@ -308,7 +307,7 @@ javasp_start_server (const JAVASP_SERVER_INFO jsp_info, const std::string &db_na
     {
 #if !defined(WINDOWS)
       /* create a new session */
-      setsid();
+      setsid ();
 #endif
       er_clear (); // clear error before string JVM
       status = jsp_start_server (db_name.c_str (), path.c_str (), prm_port);
@@ -318,7 +317,7 @@ javasp_start_server (const JAVASP_SERVER_INFO jsp_info, const std::string &db_na
 	  JAVASP_SERVER_INFO jsp_new_info { getpid(), jsp_server_port () };
 
 	  javasp_unlink_info (db_name.c_str ());
-	  if ((javasp_open_info_dir () && javasp_write_info (db_name.c_str (), jsp_new_info, true)))
+	  if ((javasp_open_info_dir () && javasp_write_info (db_name.c_str (), jsp_new_info)))
 	    {
 	      /* succeed */
 	    }
@@ -368,6 +367,8 @@ javasp_stop_server (const JAVASP_SERVER_INFO jsp_info, const std::string &db_nam
 	{
 	  javasp_terminate_process (jsp_info.pid);
 	}
+
+      javasp_reset_info (db_name.c_str ());
     }
 
   return status;

--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -493,7 +493,7 @@ javasp_ping_server (const int server_port, const char *db_name, char *buf)
       ptr = or_pack_int (request, OR_INT_SIZE);
       ptr = or_pack_int (ptr, SP_CODE_UTIL_TERMINATE_THREAD);
 
-      int nbytes = jsp_writen (socket, request, OR_INT_SIZE * 2);
+      nbytes = jsp_writen (socket, request, OR_INT_SIZE * 2);
       if (nbytes != OR_INT_SIZE * 2)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_NETWORK_ERROR, 1, nbytes);

--- a/src/jsp/com/cubrid/jsp/ExecuteThread.java
+++ b/src/jsp/com/cubrid/jsp/ExecuteThread.java
@@ -270,7 +270,6 @@ public class ExecuteThread extends Thread {
                 }
             }
         }
-        closeSocket();
     }
 
     private int listenCommand() throws Exception {

--- a/src/jsp/com/cubrid/jsp/ExecuteThread.java
+++ b/src/jsp/com/cubrid/jsp/ExecuteThread.java
@@ -220,6 +220,9 @@ public class ExecuteThread extends Thread {
                         }
                     case REQ_CODE_UTIL_TERMINATE_THREAD:
                         {
+                            // hacky way.. If thread is terminated and socket is closed immediately,
+                            // "ping" or "status" command does not work properly
+                            sleep(100);
                             Thread.currentThread().interrupt();
                             break;
                         }
@@ -256,12 +259,9 @@ public class ExecuteThread extends Thread {
                     }
                     Server.log(throwable);
                     try {
-                        if (throwable instanceof SQLException)
-                        {
+                        if (throwable instanceof SQLException) {
                             sendError(throwable.getMessage(), client);
-                        }
-                        else
-                        {
+                        } else {
                             sendError(throwable.toString(), client);
                         }
                     } catch (IOException e1) {
@@ -270,6 +270,7 @@ public class ExecuteThread extends Thread {
                 }
             }
         }
+        closeSocket();
     }
 
     private int listenCommand() throws Exception {

--- a/src/jsp/com/cubrid/jsp/ListenerThread.java
+++ b/src/jsp/com/cubrid/jsp/ListenerThread.java
@@ -56,6 +56,7 @@ public class ListenerThread extends Thread {
                 execThread.start();
             } catch (IOException e) {
                 Server.log(e);
+                break;
             }
         }
 

--- a/src/jsp/com/cubrid/jsp/Server.java
+++ b/src/jsp/com/cubrid/jsp/Server.java
@@ -74,12 +74,15 @@ public class Server {
         if (OSValidator.IS_UNIX) {
             String socketName = rootPath + tmpPath + "/junixsocket-" + name + ".sock";
             final File socketFile = new File(socketName);
+
             try {
-                AFUNIXServerSocket udsServerSocket = AFUNIXServerSocket.newInstance();
-                udsServerSocket.bind(AFUNIXSocketAddress.of(socketFile));
+                AFUNIXSocketAddress sockAddr = AFUNIXSocketAddress.of(socketFile);
+                AFUNIXServerSocket udsServerSocket = AFUNIXServerSocket.bindOn (sockAddr);
                 udsSocketListener = new ListenerThread(udsServerSocket);
             } catch (Exception e) {
                 log(e);
+                e.printStackTrace();
+                System.exit(1);
             }
         }
 
@@ -91,6 +94,7 @@ public class Server {
         } catch (Exception e) {
             log(e);
             e.printStackTrace();
+            System.exit(1);
         }
 
         Class.forName("cubrid.jdbc.driver.CUBRIDDriver");

--- a/src/jsp/jsp_file.c
+++ b/src/jsp/jsp_file.c
@@ -37,10 +37,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#if !defined (WINDOWS)
-#include <sys/file.h>
-#endif
-
 bool
 javasp_open_info_dir ()
 {
@@ -161,7 +157,7 @@ javasp_read_info (const char *db_name, JAVASP_SERVER_INFO & info)
 }
 
 bool
-javasp_write_info (const char *db_name, JAVASP_SERVER_INFO info, bool claim_lock)
+javasp_write_info (const char *db_name, JAVASP_SERVER_INFO info)
 {
   bool result = false;
   FILE *fp = NULL;
@@ -170,15 +166,8 @@ javasp_write_info (const char *db_name, JAVASP_SERVER_INFO info, bool claim_lock
   if (fp)
     {
       fprintf (fp, "%d %d", info.pid, info.port);
-      if (claim_lock)
-      {
-#if !defined (WINDOWS)
-        result = (flock (fileno (fp), LOCK_SH) == 0);
-#else
-        result = true;
-#endif
-      }
       fclose (fp);
+      result = true;
     }
   return result;
 }
@@ -189,5 +178,5 @@ javasp_reset_info (const char *db_name)
 // *INDENT-OFF*
   JAVASP_SERVER_INFO reset_info {-1, -1};
 // *INDENT-ON*
-  return javasp_write_info (db_name, reset_info, false);
+  return javasp_write_info (db_name, reset_info);
 }

--- a/src/jsp/jsp_file.h
+++ b/src/jsp/jsp_file.h
@@ -45,9 +45,10 @@ extern "C"
 
   extern bool javasp_open_info_dir ();
   extern FILE *javasp_open_info (const char *db_name, const char *mode);
+  extern void javasp_unlink_info (const char *db_name);
 
   extern bool javasp_read_info (const char *db_name, JAVASP_SERVER_INFO & info);
-  extern bool javasp_write_info (const char *db_name, JAVASP_SERVER_INFO info);
+  extern bool javasp_write_info (const char *db_name, JAVASP_SERVER_INFO info, bool claim_lock);
   extern bool javasp_reset_info (const char *db_name);
 
   extern bool javasp_get_info_file (char *buf, size_t len, const char *db_name);

--- a/src/jsp/jsp_file.h
+++ b/src/jsp/jsp_file.h
@@ -48,7 +48,7 @@ extern "C"
   extern void javasp_unlink_info (const char *db_name);
 
   extern bool javasp_read_info (const char *db_name, JAVASP_SERVER_INFO & info);
-  extern bool javasp_write_info (const char *db_name, JAVASP_SERVER_INFO info, bool claim_lock);
+  extern bool javasp_write_info (const char *db_name, JAVASP_SERVER_INFO info);
   extern bool javasp_reset_info (const char *db_name);
 
   extern bool javasp_get_info_file (char *buf, size_t len, const char *db_name);

--- a/src/jsp/jsp_sr.c
+++ b/src/jsp/jsp_sr.c
@@ -109,7 +109,6 @@
 #define BUF_SIZE        2048
 typedef jint (*CREATE_VM_FUNC) (JavaVM **, void **, void *);
 
-#ifdef __cplusplus
 #define JVM_GetEnv(JVM, ENV, VER)	\
 	(JVM)->GetEnv(ENV, VER)
 #define JVM_AttachCurrentThread(JVM, ENV, ARGS)	\
@@ -140,38 +139,6 @@ typedef jint (*CREATE_VM_FUNC) (JavaVM **, void **, void *);
 	(ENV)->ReleaseStringUTFChars(JSTRING, CSTRING)
 #define JVM_GetStringUTFLength(ENV, STRING)	\
 	(ENV)->GetStringUTFLength(STRING)
-#else
-#define JVM_GetEnv(JVM, ENV, VER)	\
-	(*JVM)->GetEnv(JVM, ENV, VER)
-#define JVM_AttachCurrentThread(JVM, ENV, ARGS)	\
-	(*JVM)->AttachCurrentThread(JVM, ENV, ARGS)
-#define JVM_DetachCurrentThread(JVM)	\
-	(*JVM)->DetachCurrentThread(JVM)
-#define JVM_ExceptionOccurred(ENV)	\
-	(*ENV)->ExceptionOccurred(ENV)
-#define JVM_FindClass(ENV, NAME)	\
-	(*ENV)->FindClass(ENV, NAME)
-#define JVM_GetStaticMethodID(ENV, CLAZZ, NAME, SIG)	\
-	(*ENV)->GetStaticMethodID(ENV, CLAZZ, NAME, SIG)
-#define JVM_NewStringUTF(ENV, BYTES)	\
-	(*ENV)->NewStringUTF(ENV, BYTES);
-#define JVM_NewObjectArray(ENV, LENGTH, ELEMENTCLASS, INITIALCLASS)	\
-	(*ENV)->NewObjectArray(ENV, LENGTH, ELEMENTCLASS, INITIALCLASS)
-#define JVM_SetObjectArrayElement(ENV, ARRAY, INDEX, VALUE)	\
-	(*ENV)->SetObjectArrayElement(ENV, ARRAY, INDEX, VALUE)
-#define JVM_CallStaticVoidMethod(ENV, CLAZZ, METHODID, ARGS)	\
-	(*ENV)->CallStaticVoidMethod(ENV, CLAZZ, METHODID, ARGS)
-#define JVM_CallStaticIntMethod(ENV, CLAZZ, METHODID, ARGS)	\
-	(*ENV)->CallStaticIntMethod(ENV, CLAZZ, METHODID, ARGS)
-#define JVM_CallStaticObjectMethod(ENV, CLAZZ, METHODID, ARGS)	\
-	(*ENV)->CallStaticObjectMethod(ENV, CLAZZ, METHODID, ARGS)
-#define JVM_GetStringUTF(ENV, STRING)	\
-	(*ENV)->GetStringUTFChars(ENV, STRING, NULL)
-#define JVM_ReleaseStringUTF(ENV, JSTRING, CSTRING)	\
-	(*ENV)->ReleaseStringUTFChars(ENV, JSTRING, CSTRING)
-#define JVM_GetStringUTFLength(ENV, STRING)	\
-	(*ENV)->GetStringUTFLength(ENV, STRING)
-#endif
 
 static JavaVM *jvm = NULL;
 static jint sp_port = -1;

--- a/win/cubridsa/cubridsa.def
+++ b/win/cubridsa/cubridsa.def
@@ -148,6 +148,7 @@ EXPORTS
     javasp_read_info
     javasp_reset_info
     javasp_write_info
+    javasp_unlink_info
 ;
 ; utility functions
 ;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24331

Starting javasp utility is unstable. This PR fixes the following
- avoid "java.net.SocketException: ; errno=22" is logged in infinite loop
- check the javasp process is running (`javasp_is_terminated_process ()`) in `ping` command of the javasp utility
- separate to send `ping` and `terminate thread` commands for closing socket gracefully
- add `sleep (100)` to avoid unexpected behavior caused by the socket closed immediately
  - I tried SoLinger option, but it did not work well. It is a hacky way