### PR TITLE
[CBRD-24366] Oracle docker image version for cubrid 11.2 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
 oraclelinux: &oraclelinux
   working_directory: /home
   docker:
-    - image: cubridci/cubridci:ol7.8 
+    - image: cubridci/cubridci:ol7.8_11.2
 
 test_defaults: &test_defaults
   steps:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24366