### PR TITLE
[CBRD-24424] When the pt_set_user_specified_name function is called in the show statement, a core dump occurs because the continue_walk argument is NULL.

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10405,11 +10405,8 @@ pt_set_user_specified_name (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, 
 	    int error = NO_ERROR;
 	    ERROR_SET_ERROR_1ARG (error, ER_AU_DBA_ONLY, "create system class/vclass");
 	    PT_ERRORc (parser, node, er_msg ());
-
-	    if (continue_walk != NULL)
-	      {
-		*continue_walk = PT_STOP_WALK;
-	      }
+	    assert (continue_walk != NULL);
+	    *continue_walk = PT_STOP_WALK;
 	  }
 
 	return node;
@@ -10420,11 +10417,8 @@ pt_set_user_specified_name (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, 
 	if (sm_check_system_class_by_name (PT_NAME_ORIGINAL (PT_RENAME_NEW_NAME (node))))
 	  {
 	    PT_ERROR (parser, node, "It is not allowed to be renamed to the system class name.");
-
-	    if (continue_walk != NULL)
-	      {
-		*continue_walk = PT_STOP_WALK;
-	      }
+	    assert (continue_walk != NULL);
+	    *continue_walk = PT_STOP_WALK;
 	  }
 
 	return node;

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -8142,7 +8142,6 @@ pt_make_query_describe_w_identifier (PARSER_CONTEXT * parser, PT_NODE * original
 	}
     }
 
-  pt_set_user_specified_name (parser, original_cls_id, NULL, NULL);
   node = pt_make_query_show_columns (parser, original_cls_id, (where_node == NULL) ? 0 : 2, where_node, 0);
 
   return node;

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10406,7 +10406,11 @@ pt_set_user_specified_name (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, 
 	    int error = NO_ERROR;
 	    ERROR_SET_ERROR_1ARG (error, ER_AU_DBA_ONLY, "create system class/vclass");
 	    PT_ERRORc (parser, node, er_msg ());
-	    *continue_walk = PT_STOP_WALK;
+
+	    if (continue_walk != NULL)
+	      {
+		*continue_walk = PT_STOP_WALK;
+	      }
 	  }
 
 	return node;
@@ -10417,8 +10421,13 @@ pt_set_user_specified_name (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, 
 	if (sm_check_system_class_by_name (PT_NAME_ORIGINAL (PT_RENAME_NEW_NAME (node))))
 	  {
 	    PT_ERROR (parser, node, "It is not allowed to be renamed to the system class name.");
-	    *continue_walk = PT_STOP_WALK;
+
+	    if (continue_walk != NULL)
+	      {
+		*continue_walk = PT_STOP_WALK;
+	      }
 	  }
+
 	return node;
       }
       // break;
@@ -10443,7 +10452,12 @@ pt_set_user_specified_name (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, 
       PT_ERRORf2 (parser, node,
 		  "Object name [%s] not allowed. It cannot exceed %d bytes.",
 		  pt_short_print (parser, node), DB_MAX_IDENTIFIER_LENGTH - DB_MAX_USER_LENGTH);
-      *continue_walk = PT_STOP_WALK;
+
+      if (continue_walk != NULL)
+	{
+	  *continue_walk = PT_STOP_WALK;
+	}
+
       return node;
     }
 
@@ -10467,7 +10481,12 @@ pt_set_user_specified_name (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, 
       if (resolved_name != NULL)
 	{
 	  PT_ERROR (parser, node, "It is not allowed to specify an owner in the system class name.");
-	  *continue_walk = PT_STOP_WALK;
+
+	  if (continue_walk != NULL)
+	    {
+	      *continue_walk = PT_STOP_WALK;
+	    }
+
 	  return node;
 	}
 
@@ -10485,7 +10504,12 @@ pt_set_user_specified_name (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, 
     {
       PT_ERRORf2 (parser, node,
 		  "User name [%s] not allowed. It cannot exceed %d bytes.", resolved_name, DB_MAX_USER_LENGTH);
-      *continue_walk = PT_STOP_WALK;
+
+      if (continue_walk != NULL)
+	{
+	  *continue_walk = PT_STOP_WALK;
+	}
+
       return node;
     }
 

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -6670,6 +6670,11 @@ pt_resolve_showstmt_args_unnamed (PARSER_CONTEXT * parser, const SHOWSTMT_NAMED_
 	{
 	  /* replace identifier node with string value node */
 	  pt_set_user_specified_name (parser, arg, NULL, NULL);
+	  if (pt_has_error (parser))
+	    {
+	      goto error;
+	    }
+
 	  id_string = pt_make_string_value (parser, arg->info.name.original);
 	  if (id_string == NULL)
 	    {
@@ -7040,6 +7045,11 @@ pt_make_query_show_columns (PARSER_CONTEXT * parser, PT_NODE * original_cls_id, 
     }
 
   pt_set_user_specified_name (parser, original_cls_id, NULL, NULL);
+  if (pt_has_error (parser))
+    {
+      return NULL;
+    }
+
   intl_identifier_lower (original_cls_id->info.name.original, lower_table_name);
 
   db_make_int (db_valuep + 0, 0);
@@ -7221,6 +7231,10 @@ pt_make_query_show_create_table (PARSER_CONTEXT * parser, PT_NODE * table_name)
   string_buffer strbuf (alloc);
 
   pt_set_user_specified_name (parser, table_name, NULL, NULL);
+  if (pt_has_error (parser))
+    {
+      return NULL;
+    }
 
   pt_help_show_create_table (parser, table_name, strbuf);
   if (strbuf.len () == 0)
@@ -7288,6 +7302,10 @@ pt_make_query_show_create_view (PARSER_CONTEXT * parser, PT_NODE * view_identifi
   assert (view_identifier->node_type == PT_NAME);
 
   pt_set_user_specified_name (parser, view_identifier, NULL, NULL);
+  if (pt_has_error (parser))
+    {
+      return NULL;
+    }
 
   node = parser_new_node (parser, PT_SELECT);
   if (node == NULL)
@@ -8194,6 +8212,10 @@ pt_make_query_show_index (PARSER_CONTEXT * parser, PT_NODE * original_cls_id)
   assert (original_cls_id->node_type == PT_NAME);
 
   pt_set_user_specified_name (parser, original_cls_id, NULL, NULL);
+  if (pt_has_error (parser))
+    {
+      return NULL;
+    }
 
   query = parser_new_node (parser, PT_SELECT);
   if (query == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24424

### When the pt_set_user_specified_name function is called in the show statement, a core dump occurs because the continue_walk argument is NULL.
- Since the pt_set_user_specified_name function is sometimes called without going through the parser_walk_tree function, the continue_walk is set to PT_STOP_WALK only if it is not NULL.