### PR TITLE
[CBRD-24381] Add system parameter to set window size for QA test

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -704,6 +704,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_FLASHBACK_TIMEOUT "flashback_timeout"
 #define PRM_NAME_FLASHBACK_MAX_TRANSACTION "flashback_max_transaction"
+#define PRM_NAME_FLASHBACK_WIN_SIZE "flashback_win_size"
 
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
@@ -2404,6 +2405,12 @@ static int prm_flashback_max_transaction_default = INT_MAX;
 static int prm_flashback_max_transaction_lower = 1;
 static int prm_flashback_max_transaction_upper = INT_MAX;
 static unsigned int prm_flashback_max_transaction_flag = 0;
+
+int PRM_FLASHBACK_WIN_SIZE = INT_MAX;
+static int prm_flashback_win_size_default = 0;
+static int prm_flashback_win_size_lower = 0;
+static int prm_flashback_win_size_upper = INT_MAX;
+static unsigned int prm_flashback_win_size_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -6190,6 +6197,18 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) &PRM_FLASHBACK_MAX_TRANSACTION,
    (void *) &prm_flashback_max_transaction_upper,
    (void *) &prm_flashback_max_transaction_lower,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_FLASHBACK_WIN_SIZE,
+   PRM_NAME_FLASHBACK_WIN_SIZE,
+   (PRM_FOR_CLIENT | PRM_HIDDEN),
+   PRM_INTEGER,
+   &prm_flashback_win_size_flag,
+   (void *) &prm_flashback_win_size_default,
+   (void *) &PRM_FLASHBACK_WIN_SIZE,
+   (void *) &prm_flashback_win_size_upper,
+   (void *) &prm_flashback_win_size_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL}

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -460,8 +460,9 @@ enum param_id
   PRM_ID_THREAD_CORE_COUNT,
   PRM_ID_FLASHBACK_TIMEOUT,
   PRM_ID_FLASHBACK_MAX_TRANSACTION,	/* Hidden parameter For QA test */
+  PRM_ID_FLASHBACK_WIN_SIZE,	/* Hidden parameter For QA test */
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_FLASHBACK_MAX_TRANSACTION
+  PRM_LAST_ID = PRM_ID_FLASHBACK_WIN_SIZE
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/transaction/flashback_cl.c
+++ b/src/transaction/flashback_cl.c
@@ -42,6 +42,7 @@
 #include "authenticate.h"
 #include "utility.h"
 #include "csql.h"
+#include "system_parameter.h"
 
 typedef enum
 {
@@ -56,9 +57,19 @@ flashback_util_get_winsize ()
 {
   CONSOLE_SCREEN_BUFFER_INFO csbi;
 
-  GetConsoleScreenBufferInfo (GetStdHandle (STD_OUTPUT_HANDLE), &csbi);
+  /* if window size is set for the test purpose, then use it */
 
-  return csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+  int window_size = prm_get_integer_value (PRM_ID_FLASHBACK_WIN_SIZE);
+  if (window_size > 0)
+    {
+      return window_size;
+    }
+  else
+    {
+      GetConsoleScreenBufferInfo (GetStdHandle (STD_OUTPUT_HANDLE), &csbi);
+
+      return csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+    }
 }
 
 static char
@@ -95,9 +106,19 @@ flashback_util_get_winsize ()
 {
   struct winsize w;
 
-  ioctl (STDOUT_FILENO, TIOCGWINSZ, &w);
+  /* if window size is set for test purpose, then use it */
 
-  return w.ws_row;
+  int window_size = prm_get_integer_value (PRM_ID_FLASHBACK_WIN_SIZE);
+  if (window_size > 0)
+    {
+      return window_size;
+    }
+  else
+    {
+      ioctl (STDOUT_FILENO, TIOCGWINSZ, &w);
+
+      return w.ws_row;
+    }
 }
 #endif
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24381

Purpose

For QA test for flashback, it need to provide a parameter to set a window size.
When performing flashback, after measuring the window size, a summary is output according to the size. 
However, if flashback is performed with the shell, the window size is recognized as 0 and proper testing cannot be performed.

Implementation

Add hidden system parameter : flashback_win_size