### PR TITLE
[CBRD-24392] After an index is created, filtering index is created, but not vice versa. (#3661)

### DIFF
--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4120,6 +4120,13 @@ classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAIN
 			  continue;
 			}
 		    }
+		  else
+		    {
+		      if (cons->filter_predicate)
+			{
+			  continue;
+			}
+		    }
 
 		  return cons;
 		}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24392

This is a backport for #3661 