### PR TITLE
[CBRD-24384] The core occurs if the user drops a synonym for which the target object is dropped. (#3690)

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -7477,6 +7477,7 @@ synonym_remove_xasl_by_oid (OID * oid)
   request = OR_ALIGNED_BUF_START (a_request);
   reply = OR_ALIGNED_BUF_START (a_reply);
 
+  assert (oid != NULL);
   or_pack_oid (request, oid);
 
   req_error =
@@ -7491,6 +7492,7 @@ synonym_remove_xasl_by_oid (OID * oid)
 #else /* CS_MODE */
   THREAD_ENTRY *thread_p = enter_server ();
 
+  assert (oid != NULL);
   xsynonym_remove_xasl_by_oid (thread_p, oid);
 
   exit_server (*thread_p);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -17837,7 +17837,7 @@ do_alter_synonym_internal (const char *synonym_name, const char *target_name, DB
       ASSERT_ERROR ();
     }
 
-  if (intl_identifier_casecmp (old_target_name, target_name) != 0)
+  if (old_target_obj_id != NULL && intl_identifier_casecmp (old_target_name, target_name) != 0)
     {
       synonym_remove_xasl_by_oid (old_target_obj_id);
     }
@@ -18258,7 +18258,10 @@ do_drop_synonym_internal (const char *synonym_name, const int is_public_synonym,
       ASSERT_ERROR ();
     }
 
-  synonym_remove_xasl_by_oid (old_target_obj_id);
+  if (old_target_obj_id != NULL)
+    {
+      synonym_remove_xasl_by_oid (old_target_obj_id);
+    }
 
 end:
   AU_ENABLE (save);
@@ -18443,7 +18446,10 @@ do_rename_synonym_internal (const char *old_synonym_name, const char *new_synony
       ASSERT_ERROR ();
     }
 
-  synonym_remove_xasl_by_oid (old_target_obj_id);
+  if (old_target_obj_id != NULL)
+    {
+      synonym_remove_xasl_by_oid (old_target_obj_id);
+    }
 
 end:
   if (obj_tmpl != NULL && instance_obj == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24384

backport #3690