### PR TITLE
[CBRD-24424] When the pt_set_user_specified_name function is called in the show statement, a core dump occurs because the continue_walk argument is NULL. (#3712)

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -6617,8 +6617,14 @@ pt_resolve_showstmt_args_unnamed (PARSER_CONTEXT * parser, const SHOWSTMT_NAMED_
 
       if (arg_infos[i].type == AVT_IDENTIFIER)
 	{
+	  /* store user-specified-name in info.name.original. */
+	  parser_walk_tree (parser, arg, NULL, NULL, pt_set_user_specified_name, NULL);
+	  if (pt_has_error (parser))
+	    {
+	      goto error;
+	    }
+
 	  /* replace identifier node with string value node */
-	  pt_set_user_specified_name (parser, arg, NULL, NULL);
 	  id_string = pt_make_string_value (parser, arg->info.name.original);
 	  if (id_string == NULL)
 	    {
@@ -6988,7 +6994,13 @@ pt_make_query_show_columns (PARSER_CONTEXT * parser, PT_NODE * original_cls_id, 
       PT_SELECT_INFO_SET_FLAG (sub_query, PT_SELECT_INFO_COLS_SCHEMA);
     }
 
-  pt_set_user_specified_name (parser, original_cls_id, NULL, NULL);
+  /* store user-specified-name in info.name.original. */
+  parser_walk_tree (parser, original_cls_id, NULL, NULL, pt_set_user_specified_name, NULL);
+  if (pt_has_error (parser))
+    {
+      return NULL;
+    }
+
   intl_identifier_lower (original_cls_id->info.name.original, lower_table_name);
 
   db_make_int (db_valuep + 0, 0);
@@ -7169,7 +7181,12 @@ pt_make_query_show_create_table (PARSER_CONTEXT * parser, PT_NODE * table_name)
   parser_block_allocator alloc (parser);
   string_buffer strbuf (alloc);
 
-  pt_set_user_specified_name (parser, table_name, NULL, NULL);
+  /* store user-specified-name in info.name.original. */
+  parser_walk_tree (parser, table_name, NULL, NULL, pt_set_user_specified_name, NULL);
+  if (pt_has_error (parser))
+    {
+      return NULL;
+    }
 
   pt_help_show_create_table (parser, table_name, strbuf);
   if (strbuf.len () == 0)
@@ -7236,7 +7253,12 @@ pt_make_query_show_create_view (PARSER_CONTEXT * parser, PT_NODE * view_identifi
   assert (view_identifier != NULL);
   assert (view_identifier->node_type == PT_NAME);
 
-  pt_set_user_specified_name (parser, view_identifier, NULL, NULL);
+  /* store user-specified-name in info.name.original. */
+  parser_walk_tree (parser, view_identifier, NULL, NULL, pt_set_user_specified_name, NULL);
+  if (pt_has_error (parser))
+    {
+      return NULL;
+    }
 
   node = parser_new_node (parser, PT_SELECT);
   if (node == NULL)
@@ -8091,7 +8113,6 @@ pt_make_query_describe_w_identifier (PARSER_CONTEXT * parser, PT_NODE * original
 	}
     }
 
-  pt_set_user_specified_name (parser, original_cls_id, NULL, NULL);
   node = pt_make_query_show_columns (parser, original_cls_id, (where_node == NULL) ? 0 : 2, where_node, 0);
 
   return node;
@@ -8143,7 +8164,12 @@ pt_make_query_show_index (PARSER_CONTEXT * parser, PT_NODE * original_cls_id)
   assert (original_cls_id != NULL);
   assert (original_cls_id->node_type == PT_NAME);
 
-  pt_set_user_specified_name (parser, original_cls_id, NULL, NULL);
+  /* store user-specified-name in info.name.original. */
+  parser_walk_tree (parser, original_cls_id, NULL, NULL, pt_set_user_specified_name, NULL);
+  if (pt_has_error (parser))
+    {
+      return NULL;
+    }
 
   query = parser_new_node (parser, PT_SELECT);
   if (query == NULL)
@@ -10200,6 +10226,8 @@ pt_set_user_specified_name (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, 
   char downcase_resolved_name[DB_MAX_USER_LENGTH] = { '\0' };
   const char *user_specified_name = NULL;
 
+  assert (continue_walk != NULL);
+
   if (parser == NULL || node == NULL)
     {
       PT_ERROR (parser, node, "Invalid arguments.");
@@ -10306,6 +10334,7 @@ pt_set_user_specified_name (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, 
 	    PT_ERROR (parser, node, "It is not allowed to be renamed to the system class name.");
 	    *continue_walk = PT_STOP_WALK;
 	  }
+
 	return node;
       }
       // break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24424

backport #3712