### PR TITLE
[CBRD-24428] dblink: correct error message for repeated query execution

### DIFF
--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -843,6 +843,7 @@ dblink_scan_next (DBLINK_SCAN_INFO * scan_info, val_list_node * val_list)
       else
 	{
 	  TP_DOMAIN dom;
+	  TP_DOMAIN_STATUS status;
 
 	  tp_domain_init (&dom, (DB_TYPE) db_value_domain_type (valptrp->val));
 
@@ -851,13 +852,10 @@ dblink_scan_next (DBLINK_SCAN_INFO * scan_info, val_list_node * val_list)
 	  dom.codeset = db_get_string_codeset (valptrp->val);
 	  dom.scale = db_value_scale (valptrp->val);
 
-	  if (db_value_coerce (&cci_value, valptrp->val, &dom) != DOMAIN_COMPATIBLE)
+	  if ((status =
+	       tp_value_cast_preserve_domain (&cci_value, valptrp->val, &dom, false, true)) != DOMAIN_COMPATIBLE)
 	    {
-	      /*
-	         in repeated error case, in order to display correct error message,
-	         we need to reinitialize the domain of valptrp->val
-	       */
-	      db_value_domain_init (valptrp->val, (DB_TYPE) dom.type->id, dom.precision, dom.scale);
+	      (void) tp_domain_status_er_set (status, ARG_FILE_LINE, &cci_value, &dom);
 	      goto close_exit;
 	    }
 	}

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -853,6 +853,11 @@ dblink_scan_next (DBLINK_SCAN_INFO * scan_info, val_list_node * val_list)
 
 	  if (db_value_coerce (&cci_value, valptrp->val, &dom) != DOMAIN_COMPATIBLE)
 	    {
+	      /*
+	         in repeated error case, in order to display correct error message,
+	         we need to reinitialize the domain of valptrp->val
+	       */
+	      db_value_domain_init (valptrp->val, (DB_TYPE) dom.type->id, dom.precision, dom.scale);
 	      goto close_exit;
 	    }
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24428

The error message is not the same as prior query execution's one at error case.

```
-- remote_t is a table of remote server as created as below
CREATE TABLE remote_t (
    col1 numeric(10, 5)
);
```

```
-- First
SELECT *
FROM dblink (dblink-url or server,
             'SELECT col1 FROM remote_t') AS t(col1 time);

-- Second
SELECT *
FROM dblink (dblink-url or server,
             'SELECT col1 FROM remote_t') AS t(col1 time);
 
```

Expected Result:

```
-- First Result
ERROR: Cannot coerce value of domain "numeric" to domain "time".

-- Second Result
ERROR: Cannot coerce value of domain "numeric" to domain "time".
```
 

Actual Result:

```
-- First Result
ERROR: Cannot coerce value of domain "numeric" to domain "time".

-- Second Result
ERROR: Cannot coerce value of domain "numeric" to domain "*NULL*".
```
