### PR TITLE
[LETS-483] explicitly delete checkpoint_info copy ctor and operators and adapt code

### DIFF
--- a/src/transaction/log_checkpoint_info.hpp
+++ b/src/transaction/log_checkpoint_info.hpp
@@ -46,8 +46,12 @@ namespace cublog
     public:
       checkpoint_info () = default;
       checkpoint_info (checkpoint_info &&) = default;
-      checkpoint_info (const checkpoint_info &) = default;
+      checkpoint_info (const checkpoint_info &) = delete;
+
       ~checkpoint_info () override = default;
+
+      checkpoint_info &operator = (checkpoint_info &&) = delete;
+      checkpoint_info &operator = (const checkpoint_info &) = delete;
 
       void pack (cubpacking::packer &serializator) const override;
       void unpack (cubpacking::unpacker &deserializator) override;

--- a/src/transaction/log_meta.cpp
+++ b/src/transaction/log_meta.cpp
@@ -31,7 +31,7 @@ namespace cublog
 
     end_offset += serializer.get_packed_bool_size (end_offset); // is shutdown
     end_offset += serializer.get_packed_int_size (end_offset); // m_checkpoints.size ()
-    for (const auto chkinfo : m_checkpoints)
+    for (const auto &chkinfo : m_checkpoints)
       {
 	end_offset += serializer.get_packed_bigint_size (end_offset);
 	end_offset += serializer.get_packed_int_size (end_offset);
@@ -45,7 +45,7 @@ namespace cublog
   {
     serializer.pack_bool (m_clean_shutdown);
     serializer.pack_to_int (m_checkpoints.size ());
-    for (const auto chkinfo : m_checkpoints)
+    for (const auto &chkinfo : m_checkpoints)
       {
 	serializer.pack_bigint (chkinfo.first.pageid);
 	serializer.pack_int (chkinfo.first.offset);
@@ -172,12 +172,6 @@ namespace cublog
   void
   meta::add_checkpoint_info (const log_lsa &chkpt_lsa, checkpoint_info &&chkpt_info)
   {
-    m_checkpoints.insert ({ chkpt_lsa, std::move (chkpt_info) });
-  }
-
-  void
-  meta::add_checkpoint_info (const log_lsa &chkpt_lsa, const checkpoint_info &chkpt_info)
-  {
     const checkpoint_container_t::const_iterator found_it = m_checkpoints.find (chkpt_lsa);
     if (found_it != m_checkpoints.cend ())
       {
@@ -186,7 +180,7 @@ namespace cublog
 	// added to the log for the purpose of being transferred to passive transaction servers
 	m_checkpoints.erase (found_it);
       }
-    m_checkpoints.insert ({ chkpt_lsa, chkpt_info });
+    m_checkpoints.insert ({chkpt_lsa, std::move (chkpt_info)});
   }
 
   size_t

--- a/src/transaction/log_meta.cpp
+++ b/src/transaction/log_meta.cpp
@@ -48,7 +48,7 @@ namespace cublog
     for (const auto &chkinfo : m_checkpoints)
       {
 	serializer.pack_bigint (chkinfo.first.pageid);
-	serializer.pack_int (chkinfo.first.offset);
+	serializer.pack_short (chkinfo.first.offset);
 	serializer.pack_overloaded (chkinfo.second);
       }
   }
@@ -64,11 +64,10 @@ namespace cublog
       {
 	log_lsa chkpt_lsa;
 	std::int64_t upk_bigint;
-	int upk_int;
+	short upk_short;
 	deserializer.unpack_bigint (upk_bigint);
-	deserializer.unpack_int (upk_int);
-	assert (upk_int <= INT16_MAX);
-	chkpt_lsa = { upk_bigint, static_cast<std::int16_t> (upk_int) };
+	deserializer.unpack_short (upk_short);
+	chkpt_lsa = { upk_bigint, static_cast<std::int16_t> (upk_short) };
 
 	checkpoint_info chkinfo;
 	deserializer.unpack_overloaded (chkinfo);

--- a/src/transaction/log_meta.hpp
+++ b/src/transaction/log_meta.hpp
@@ -48,7 +48,6 @@ namespace cublog
       const checkpoint_info *get_checkpoint_info (const log_lsa &checkpoint_lsa) const;
       std::tuple<log_lsa,  const checkpoint_info *> get_highest_lsa_checkpoint_info () const;
       void add_checkpoint_info (const log_lsa &chkpt_lsa, checkpoint_info &&chkpt_info);
-      void add_checkpoint_info (const log_lsa &chkpt_lsa, const checkpoint_info &chkpt_info);
       size_t remove_checkpoint_info_before_lsa (const log_lsa &target_lsa);
       size_t get_checkpoint_count () const;
 

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -75,8 +75,7 @@ static void log_recovery_resetlog (THREAD_ENTRY *thread_p, const LOG_LSA *new_ap
 				   const LOG_LSA *new_prev_lsa);
 static void log_recovery_notpartof_archives (THREAD_ENTRY *thread_p, int start_arv_num, const char *info_reason);
 static int log_recovery_analysis_load_trantable_snapshot (THREAD_ENTRY *thread_p,
-    log_lsa most_recent_trantable_snapshot_lsa,
-    cublog::checkpoint_info chkpt_info, log_lsa &snapshot_lsa);
+    const log_lsa &most_recent_trantable_snapshot_lsa, cublog::checkpoint_info &chkpt_info, log_lsa &snapshot_lsa);
 static void log_recovery_build_mvcc_table_from_trantable (THREAD_ENTRY *thread_p);
 
 class corruption_checker
@@ -2174,7 +2173,7 @@ corruption_checker::check_log_record (const log_lsa &record_lsa, const log_rec_h
  */
 static int
 log_recovery_analysis_load_trantable_snapshot (THREAD_ENTRY *thread_p,
-    log_lsa most_recent_trantable_snapshot_lsa, cublog::checkpoint_info chkpt_info, log_lsa &snapshot_lsa)
+    const log_lsa &most_recent_trantable_snapshot_lsa, cublog::checkpoint_info &chkpt_info, log_lsa &snapshot_lsa)
 {
   assert (!most_recent_trantable_snapshot_lsa.is_null ());
 

--- a/unit_tests/log/test_main_chkpt_info.cpp
+++ b/unit_tests/log/test_main_chkpt_info.cpp
@@ -63,7 +63,7 @@ class test_env_chkpt
     void generate_tran_table ();
 
     static constexpr int MAX_RAND = 32700;
-    static void require_equal (checkpoint_info before, checkpoint_info after);
+    static void require_equal (const checkpoint_info &before, const checkpoint_info &after);
 
     LOG_TDES *find_or_insert_recovery_tdes (TRANID trid);
     void increment_recovery_2pc ();
@@ -456,7 +456,7 @@ test_env_chkpt::generate_log_lsa ()
 }
 
 void
-test_env_chkpt::require_equal (checkpoint_info before, checkpoint_info after)
+test_env_chkpt::require_equal (const checkpoint_info &before, const checkpoint_info &after)
 {
   REQUIRE (before.m_start_redo_lsa == after.m_start_redo_lsa);
   REQUIRE (before.m_snapshot_lsa == after.m_snapshot_lsa);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-483

- explicitly delete `checkpoint_info` copy ctor to avoid accidental mistakes like the one in `log_recovery_analysis_load_trantable_snapshot` where the caller copied the variable into the function instead of passing it by reference, therefore defeating the actual purpose of the function; this copying of the `checkpoint_info` instance looks pretty severe - actually rendering the passive transaction server completely ineffective
- also deleted `checkpoint_info` operators - these were not used anyway
- adapted unit tests for the ctor deletion (especially the test "Test checkpoint_info functions" to make sure an instance of `checkpoint_info` is not used after move)
