### PR TITLE
[LETS-483] dump complete trantable snapshot

### DIFF
--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -452,6 +452,50 @@ namespace cublog
     m_start_redo_lsa = start_redo_lsa;
   }
 
+  void
+  checkpoint_info::dump (FILE *out_fp)
+  {
+    assert (out_fp != nullptr);
+
+    fprintf (out_fp, "-->> Data:\n");
+    fprintf (out_fp, "  start_redo_lsa = %lld|%d  snapshot_lsa = %lld|%d  has_2pc = %d\n",
+	     LSA_AS_ARGS (&m_start_redo_lsa), LSA_AS_ARGS (&m_snapshot_lsa), (int)m_has_2pc);
+
+    fprintf (out_fp, "  transaction_count = %u :\n", m_trans.size ());
+    int index = 0;
+    for (const auto &ti : m_trans)
+      {
+	fprintf (out_fp,
+		 "%3d isloose_end = %d  trid = %d  state = %s\n"
+		 "    head_lsa = %lld|%d  tail_lsa = %lld|%d\n"
+		 "    undo_nxlsa = %lld|%d  posp_nxlsa = %lld|%d\n"
+		 "    savept_lsa = %lld|%d\n"
+		 "    tail_topresult_lsa = %lld|%d  start_postpone_lsa = %lld|%d\n"
+		 "    last_mvcc_lsa = %lld|%d  mvcc_id = %llu  mvcc_sub_id = %llu\n"
+		 "    user_name = %s\n",
+		 index, (int)ti.isloose_end, ti.trid, log_state_string (ti.state),
+		 LSA_AS_ARGS (&ti.head_lsa), LSA_AS_ARGS (&ti.tail_lsa),
+		 LSA_AS_ARGS (&ti.undo_nxlsa), LSA_AS_ARGS (&ti.posp_nxlsa),
+		 LSA_AS_ARGS (&ti.savept_lsa),
+		 LSA_AS_ARGS (&ti.tail_topresult_lsa), LSA_AS_ARGS (&ti.start_postpone_lsa),
+		 LSA_AS_ARGS (&ti.last_mvcc_lsa), (unsigned long long)ti.mvcc_id, (unsigned long long)ti.mvcc_sub_id,
+		 (ti.user_name != nullptr ? ti.user_name : "<NULL>"));
+	++index;
+      }
+
+    fprintf (out_fp, "  sysop_count = %d :\n", m_sysops.size ());
+    index = 0;
+    for (const auto &si : m_sysops)
+      {
+	fprintf (out_fp,
+		 "%3d trid = %d  sysop_start_postpone_lsa = %lld|%d\n"
+		 "    atomic_sysop_start_lsa = %lld|%d\n",
+		 index, si.trid, LSA_AS_ARGS (&si.sysop_start_postpone_lsa),
+		 LSA_AS_ARGS (&si.atomic_sysop_start_lsa));
+	++index;
+      }
+  }
+
   bool
   checkpoint_info::tran_info::operator== (const tran_info &other) const
   {

--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -461,7 +461,7 @@ namespace cublog
     fprintf (out_fp, "  start_redo_lsa = %lld|%d  snapshot_lsa = %lld|%d  has_2pc = %d\n",
 	     LSA_AS_ARGS (&m_start_redo_lsa), LSA_AS_ARGS (&m_snapshot_lsa), (int)m_has_2pc);
 
-    fprintf (out_fp, "  transaction_count = %u :\n", m_trans.size ());
+    fprintf (out_fp, "  transaction_count = %u :\n", (unsigned) m_trans.size ());
     int index = 0;
     for (const auto &ti : m_trans)
       {
@@ -483,7 +483,7 @@ namespace cublog
 	++index;
       }
 
-    fprintf (out_fp, "  sysop_count = %d :\n", m_sysops.size ());
+    fprintf (out_fp, "  sysop_count = %u :\n", (unsigned) m_sysops.size ());
     index = 0;
     for (const auto &si : m_sysops)
       {

--- a/src/transaction/log_checkpoint_info.hpp
+++ b/src/transaction/log_checkpoint_info.hpp
@@ -68,6 +68,8 @@ namespace cublog
       size_t get_transaction_count () const;
       size_t get_sysop_count () const;
 
+      void dump (FILE *out_fp);
+
     private:
       void load_checkpoint_trans (log_tdes &tdes, LOG_LSA &smallest_lsa);
       void load_checkpoint_topop (log_tdes &tdes);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7174,13 +7174,12 @@ log_dump_record_trantable_snapshot (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_
 
   LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, size_of_log_rec, log_lsa, log_page_p);
 
-  //
   const LOG_REC_TRANTABLE_SNAPSHOT *const trantable_snapshot
     = (LOG_REC_TRANTABLE_SNAPSHOT *) (log_page_p->area + log_lsa->offset);
-  // use log record immediately before advancing the log which might also advance to a new page
+  // copy value from mapped log record before advancing the log [possibly] to a new log page
   const size_t trantable_snapshot_len = trantable_snapshot->length;
-  fprintf (out_fp, " Snapshot_LSA = %lld|%d, length =%zu\n", LSA_AS_ARGS (&trantable_snapshot->snapshot_lsa),
-	   trantable_snapshot_len);
+  fprintf (out_fp, " Snapshot_LSA = %lld|%d, length =%u\n", LSA_AS_ARGS (&trantable_snapshot->snapshot_lsa),
+	   (unsigned) trantable_snapshot_len);
   LOG_READ_ADD_ALIGN (thread_p, size_of_log_rec, log_lsa, log_page_p);
 
   cublog::checkpoint_info checkpoint_info;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7170,12 +7170,28 @@ log_dump_record_ha_server_state (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA
 static LOG_PAGE *
 log_dump_record_trantable_snapshot (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa, LOG_PAGE * log_page_p)
 {
-  const LOG_REC_TRANTABLE_SNAPSHOT *trantable_snapshot = nullptr;
-  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*trantable_snapshot), log_lsa, log_page_p);
-  trantable_snapshot = (LOG_REC_TRANTABLE_SNAPSHOT *) (log_page_p->area + log_lsa->offset);
+  constexpr size_t size_of_log_rec = sizeof (LOG_REC_TRANTABLE_SNAPSHOT);
 
-  fprintf (out_fp, " Snapshot_LSA = %lld|%d, length =%zu", LSA_AS_ARGS (&trantable_snapshot->snapshot_lsa),
-	   trantable_snapshot->length);
+  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, size_of_log_rec, log_lsa, log_page_p);
+
+  //
+  const LOG_REC_TRANTABLE_SNAPSHOT *const trantable_snapshot
+    = (LOG_REC_TRANTABLE_SNAPSHOT *) (log_page_p->area + log_lsa->offset);
+  // use log record immediately before advancing the log which might also advance to a new page
+  const size_t trantable_snapshot_len = trantable_snapshot->length;
+  fprintf (out_fp, " Snapshot_LSA = %lld|%d, length =%zu\n", LSA_AS_ARGS (&trantable_snapshot->snapshot_lsa),
+	   trantable_snapshot_len);
+  LOG_READ_ADD_ALIGN (thread_p, size_of_log_rec, log_lsa, log_page_p);
+
+  cublog::checkpoint_info checkpoint_info;
+  {
+    std::unique_ptr < char[] > data_buf = std::make_unique < char[] > (static_cast < size_t > (trantable_snapshot_len));
+    logpb_copy_from_log (thread_p, data_buf.get (), static_cast < int >(trantable_snapshot_len), log_lsa, log_page_p);
+    cubpacking::unpacker unpacker;
+    unpacker.set_buffer (data_buf.get (), trantable_snapshot_len);
+    checkpoint_info.unpack (unpacker);
+  }
+  checkpoint_info.dump (out_fp);
 
   return log_page_p;
 }

--- a/unit_tests/log/test_main_chkpt_info.cpp
+++ b/unit_tests/log/test_main_chkpt_info.cpp
@@ -1069,3 +1069,10 @@ basename_r (const char *path, char *pathbuf, size_t buflen)
 {
   return 1;
 }
+
+const char *
+log_state_string (TRAN_STATE)
+{
+  assert (false);
+  return nullptr;
+}


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-483

Extend `LOG_REC_TRANTABLE_SNAPSHOT` to include all data.
