### PR TITLE
[LETS-484] start pts with more than one data volume

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -5917,6 +5917,11 @@ disk_dump_goodvol_all (THREAD_ENTRY * thread_p, INT16 volid, void *arg)
 STATIC_INLINE bool
 disk_is_valid_volid (VOLID volid)
 {
+  // a passive transaction server (which is, implicitly, a transaction server
+  // with remote storage) maintains a separate bookkeeping of permanent data volumes
+  // which is updated when executing corresponding recovery replication functions
+  // as part of the regular replication; this way, it is able to provide a valid
+  // answer via this function
   const bool is_valid_perm_volid = is_tran_server_with_remote_storage ()?
     (volid < disk_Page_server_perm_volume_count) : (volid < disk_Cache->nvols_perm);
   if (is_valid_perm_volid)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-484

On transaction server with remote storage, there is a separate bookkeeping of the number of volumes (which are actually created remotely, on the page server) that must be maintained.
On such a server, the check for volume id validity is done against this separate bookkeeping - `disk_is_valid_volid`.
This patch only maintains the separate bookkeeping for active transaction server. For passive transaction server, a separate patch will do the update of the value upon replicating the `RVDK` log records.
