### PR TITLE
[CBRD-24425] Add overflow page information when showing the index capacity

### DIFF
--- a/src/parser/show_meta.c
+++ b/src/parser/show_meta.c
@@ -444,9 +444,10 @@ metadata_of_index_capacity (SHOW_ONLY_ALL flag)
     {"Index_name", "varchar(256)"},
     {"Btid", "varchar(64)"},
     {"Num_distinct_key", "int"},
-    {"Total_value", "int"},
+    {"Total_value", "bigint"},
     {"Avg_num_value_per_key", "int"},
     {"Num_leaf_page", "int"},
+    {"Num_Ovfl_page", "bigint"},
     {"Num_non_leaf_page", "int"},
     {"Num_total_page", "int"},
     {"Height", "int"},
@@ -456,7 +457,11 @@ metadata_of_index_capacity (SHOW_ONLY_ALL flag)
     {"Total_used_space", "varchar(64)"},
     {"Total_free_space", "varchar(64)"},
     {"Avg_num_page_key", "int"},
-    {"Avg_page_free_space", "varchar(64)"}
+    {"Avg_page_free_space", "varchar(64)"},
+    {"Percentage_free_space_Ovfl_page", "int"},
+    {"Average_free_space_per_Ovfl_page", "int"},
+    {"Average_Ovfl_page_count_per_key", "int"},
+    {"Max_Ovfl_page_count_in_a_key", "bigint"}
   };
 
   static const SHOWSTMT_COLUMN_ORDERBY orderby[] = {

--- a/src/parser/show_meta.c
+++ b/src/parser/show_meta.c
@@ -447,7 +447,7 @@ metadata_of_index_capacity (SHOW_ONLY_ALL flag)
     {"Total_value", "bigint"},
     {"Avg_num_value_per_key", "int"},
     {"Num_leaf_page", "int"},
-    {"Num_Ovfl_page", "bigint"},
+    {"Num_Ovfl_page", "int"},
     {"Num_non_leaf_page", "int"},
     {"Num_total_page", "int"},
     {"Height", "int"},
@@ -461,7 +461,7 @@ metadata_of_index_capacity (SHOW_ONLY_ALL flag)
     {"Percentage_free_space_Ovfl_page", "int"},
     {"Average_free_space_per_Ovfl_page", "int"},
     {"Average_Ovfl_page_count_per_key", "int"},
-    {"Max_Ovfl_page_count_in_a_key", "bigint"}
+    {"Max_Ovfl_page_count_in_a_key", "int"}
   };
 
   static const SHOWSTMT_COLUMN_ORDERBY orderby[] = {

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -22285,12 +22285,15 @@ btree_scan_for_show_index_capacity (THREAD_ENTRY * thread_p, DB_VALUE ** out_val
     }
 
   /* scan index capacity into out_values */
+  /* Refer to metadata_of_index_capacity for the order of out_values */
+
   // {"Table_name", "varchar(256)"}
   error = db_make_string_copy (out_values[idx++], class_name);
   if (error != NO_ERROR)
     {
       goto cleanup;
     }
+
   // {"Index_name", "varchar(256)"}
   error = db_make_string_copy (out_values[idx++], index_p->btname);
   if (error != NO_ERROR)
@@ -22308,24 +22311,34 @@ btree_scan_for_show_index_capacity (THREAD_ENTRY * thread_p, DB_VALUE ** out_val
 
   // {"Num_distinct_key", "int"}
   db_make_int (out_values[idx++], cpc.dis_key_cnt);
+
   // {"Total_value", "bigint"}
   db_make_bigint (out_values[idx++], cpc.tot_val_cnt);
+
   // {"Avg_num_value_per_key", "int"}
   db_make_int (out_values[idx++], cpc.avg_val_per_key);
+
   // {"Num_leaf_page", "int"}
   db_make_int (out_values[idx++], cpc.leaf_pg_cnt);
+
   // {"Num_Ovfl_page", "int"}
   db_make_int (out_values[idx++], cpc.ovfl_oid_pg.tot_pg_cnt);
+
   // {"Num_non_leaf_page", "int"}
   db_make_int (out_values[idx++], cpc.nleaf_pg_cnt);
+
   // {"Num_total_page", "int"}
   db_make_int (out_values[idx++], cpc.tot_pg_cnt + cpc.ovfl_oid_pg.tot_pg_cnt);
+
   // {"Height", "int"}
   db_make_int (out_values[idx++], cpc.height);
+
   // {"Avg_key_len", "int"}
   db_make_int (out_values[idx++], cpc.avg_key_len);
+
   // {"Avg_rec_len", "int"}
   db_make_int (out_values[idx++], cpc.avg_rec_len);
+
   // {"Total_space", "varchar(64)"}
   (void) util_byte_to_size_string (buf, 64, (UINT64) (cpc.tot_space));
   error = db_make_string_copy (out_values[idx++], buf);
@@ -22333,6 +22346,7 @@ btree_scan_for_show_index_capacity (THREAD_ENTRY * thread_p, DB_VALUE ** out_val
     {
       goto cleanup;
     }
+
   // {"Total_used_space", "varchar(64)"}
   (void) util_byte_to_size_string (buf, 64, (UINT64) (cpc.tot_used_space));
   error = db_make_string_copy (out_values[idx++], buf);
@@ -22364,12 +22378,15 @@ btree_scan_for_show_index_capacity (THREAD_ENTRY * thread_p, DB_VALUE ** out_val
   db_make_int (out_values[idx++],
 	       (cpc.ovfl_oid_pg.tot_space > 0) ?
 	       (int) ((cpc.ovfl_oid_pg.tot_free_space / cpc.ovfl_oid_pg.tot_space) * 100) : 0);
+
   // {"Average_free_space_per_Ovfl_page", "int"}
   db_make_int (out_values[idx++], (int) cpc.ovfl_oid_pg.avg_pg_free_sp);
+
   // {"Average_Ovfl_page_count_per_key", "int"}
   db_make_int (out_values[idx++],
 	       (cpc.ovfl_oid_pg.dis_key_cnt > 0) ?
 	       (int) (cpc.ovfl_oid_pg.tot_pg_cnt / cpc.ovfl_oid_pg.dis_key_cnt) : 0);
+
   // {"Max_Ovfl_page_count_in_a_key", "int"}
   db_make_int (out_values[idx++], cpc.ovfl_oid_pg.max_pg_cnt_per_key);
 

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -8614,10 +8614,6 @@ btree_get_subtree_capacity (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR p
     }
   else
     {				/* a leaf page */
-      int free_space_ovfl = 0;
-      int oid_cnt_ovfl = 0;
-      int pg_cnt_per_key = 0;
-
       /* form the cpc structure for a leaf node page */
       cpc->dis_key_cnt = key_cnt;
       cpc->leaf_pg_cnt = 1;
@@ -8645,10 +8641,11 @@ btree_get_subtree_capacity (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR p
 	  ovfl_vpid = leaf_pnt.ovfl;
 	  if (!VPID_ISNULL (&ovfl_vpid))
 	    {			/* overflow pages exist */
-	      oid_cnt_ovfl = 0;
-	      cpc->ovfl_oid_pg.dis_key_cnt += 1;
-	      pg_cnt_per_key = 0;
+	      int free_space_ovfl, oid_cnt_ovfl, pg_cnt_per_key;
 
+	      oid_cnt_ovfl = 0;
+	      pg_cnt_per_key = 0;
+	      cpc->ovfl_oid_pg.dis_key_cnt += 1;
 	      do
 		{
 		  ovfp = pgbuf_fix (thread_p, &ovfl_vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -351,11 +351,22 @@ struct btree_checkscan
   BTREE_ISCAN_OID_LIST oid_list;	/* Data area to store OIDs */
 };				/* B+tree <key-oid> check scan structure */
 
+struct btree_ovfl_oid_capacity
+{
+  int max_pg_cnt_per_key;	/* Distinct key count with overflow oid page) */
+  int dis_key_cnt;		/* Distinct key count (with ovfl pages) */
+  int64_t tot_val_cnt;		/* Total number of values stored in overflow oid pages */
+  int tot_pg_cnt;		/* Total overflow oid page count */
+  float tot_free_space;		/* Total free space in overflow oid pages */
+  float tot_space;		/* Total space occupied by overflow oid pages */
+  float avg_pg_free_sp;		/* Average free space on the occupied overflowoid page */
+};
+
 typedef struct btree_capacity BTREE_CAPACITY;
 struct btree_capacity
 {
   int dis_key_cnt;		/* Distinct key count (in leaf pages) */
-  int tot_val_cnt;		/* Total number of values stored in tree */
+  int64_t tot_val_cnt;		/* Total number of values stored in tree */
   int avg_val_per_key;		/* Average number of values (OIDs) per key */
   int leaf_pg_cnt;		/* Leaf page count */
   int nleaf_pg_cnt;		/* NonLeaf page count */
@@ -370,6 +381,7 @@ struct btree_capacity
   float tot_used_space;		/* Total used space in index */
   int avg_pg_key_cnt;		/* Average page key count (in leaf pages) */
   float avg_pg_free_sp;		/* Average page free space */
+  struct btree_ovfl_oid_capacity ovfl_oid_pg;	/* For overflow OID page */
 };
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24425

When displaying Index capacity information, additional information about the Overflow OID page is displayed.
In existing information, only information that used to represent the total number of pages has been changed. In other words, the total number of pages appears to include the number of Overflow pages.

Also, Change the property of the item "Total_value" in the SHOW INDEX CAPACITY syntax from int to bigint.

The effect of this fix affects the following commands or tools:
* cubrid diagdb -d 4
* show index capacity of
* show all indexes capacity of
