### PR TITLE
[CBRD-24433] Add ODBC Data type to not suppoerted type

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -2374,8 +2374,14 @@ cgw_datatype_to_string (SQLLEN type)
       return (char *) "SQL_GUID";
       break;
 #endif
+    case SQL_WCHAR:
+      return (char *) "SQL_WCHAR";
+    case SQL_WVARCHAR:
+      return (char *) "SQL_WVARCHAR";
+    case SQL_WLONGVARCHAR:
+      return (char *) "SQL_WLONGVARCHAR";
     default:
-      return (char *) "";
+      return (char *) "Unknown type";
     }
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24433

Purpose

If the type is not supported by DBLink, an error message is displayed.
When display an error message, the data type name and data type number are display , but some data types are missing, so the data type name is not visible in the error message.

* SQL_WCHAR:
* SQL_WVARCHAR:
* SQL_WLONGVARCHAR:

Implementation


Remarks