### PR TITLE
[CBRD-24435] When renaming a view, even if there is a not null constraint, change it so that no error occurs.

### DIFF
--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -9196,7 +9196,8 @@ do_recreate_renamed_class_indexes (const PARSER_CONTEXT * parser, const char *co
   /* We can come here by renaming a view. If there are no constraints, NO_ERROR is returned before.
    * However, views can have shared columns with the not null constraint. Renaming does not affect
    * the not null constraint. So, even if the view has a not null constraint, change it so that an error
-   * does not occur here. Change the return value from ER_OBJ_NOT_A_CLASS to NO_ERROR. (In CBRD-24435) */
+   * does not occur here. I do not think there is a view with a constraint other than a not null constraint.
+   * Change the return value from ER_OBJ_NOT_A_CLASS to NO_ERROR. (In CBRD-24435) */
   if (class_->class_type != SM_CLASS_CT)
     {
       return NO_ERROR;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -9193,9 +9193,13 @@ do_recreate_renamed_class_indexes (const PARSER_CONTEXT * parser, const char *co
       return NO_ERROR;
     }
 
+  /* We can come here by renaming a view. If there are no constraints, NO_ERROR is returned before.
+   * However, views can have shared columns with the not null constraint. Renaming does not affect
+   * the not null constraint. So, even if the view has a not null constraint, change it so that an error
+   * does not occur here. Change the return value from ER_OBJ_NOT_A_CLASS to NO_ERROR. (In CBRD-24435) */
   if (class_->class_type != SM_CLASS_CT)
     {
-      return ER_OBJ_NOT_A_CLASS;
+      return NO_ERROR;
     }
 
   for (c = class_->constraints; c; c = c->next)

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -9193,17 +9193,11 @@ do_recreate_renamed_class_indexes (const PARSER_CONTEXT * parser, const char *co
       return NO_ERROR;
     }
 
-  /*
-   * We can come here by renaming a view. In general, views have no constraints. If there are no constraints,
-   * NO_ERROR is returned before.
-   *
-   * However, views can have shared columns with a not null constraint. Renaming does not affect
-   * the not null constraint. So, even if the view has a not null constraint, change it so that an error
-   * does not occur here. I do not think there is a view with a constraint other than a not null constraint.
-   *
-   * Change the return value from ER_OBJ_NOT_A_CLASS to NO_ERROR. (In CBRD-24435)
-   * 
-   */
+  /* We can come here by renaming a view. In general, views have no constraints. If there are no constraints,
+   * NO_ERROR is returned before. However, views can have shared columns with a not null constraint.
+   * Renaming does not affect the not null constraint. So, even if the view has a not null constraint,
+   * change it so that an error does not occur here. I do not think there is a view with a constraint
+   * other than a not null constraint. Change the return value from ER_OBJ_NOT_A_CLASS to NO_ERROR. (In CBRD-24435) */
   if (class_->class_type != SM_CLASS_CT)
     {
       return NO_ERROR;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -9194,7 +9194,7 @@ do_recreate_renamed_class_indexes (const PARSER_CONTEXT * parser, const char *co
     }
 
   /* We can come here by renaming a view. If there are no constraints, NO_ERROR is returned before.
-   * However, views can have shared columns with the not null constraint. Renaming does not affect
+   * However, views can have shared columns with a not null constraint. Renaming does not affect
    * the not null constraint. So, even if the view has a not null constraint, change it so that an error
    * does not occur here. I do not think there is a view with a constraint other than a not null constraint.
    * Change the return value from ER_OBJ_NOT_A_CLASS to NO_ERROR. (In CBRD-24435) */

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -9193,11 +9193,17 @@ do_recreate_renamed_class_indexes (const PARSER_CONTEXT * parser, const char *co
       return NO_ERROR;
     }
 
-  /* We can come here by renaming a view. If there are no constraints, NO_ERROR is returned before.
+  /*
+   * We can come here by renaming a view. In general, views have no constraints. If there are no constraints,
+   * NO_ERROR is returned before.
+   *
    * However, views can have shared columns with a not null constraint. Renaming does not affect
    * the not null constraint. So, even if the view has a not null constraint, change it so that an error
    * does not occur here. I do not think there is a view with a constraint other than a not null constraint.
-   * Change the return value from ER_OBJ_NOT_A_CLASS to NO_ERROR. (In CBRD-24435) */
+   *
+   * Change the return value from ER_OBJ_NOT_A_CLASS to NO_ERROR. (In CBRD-24435)
+   * 
+   */
   if (class_->class_type != SM_CLASS_CT)
     {
       return NO_ERROR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24435

### When renaming a view, even if there is a not null constraint, change it so that no error occurs.
- In the do_recreate_renamed_class_indexes function, when a view has a constraint, the constraint is constrained a not null constraint.