### PR TITLE
[CBRD-24437] DBLink query parsing error

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -2509,7 +2509,7 @@ cgw_rewrite_query (char *src_query, char **sql)
   inline_view_len = (end + 1) - (start);
   start = end + REWRITE_DELIMITER_CUBLINK_LEN + 3;
 
-  end = strstr (source, "WHERE");
+  end = strstr (inline_view + inline_view_len, "WHERE");
   if (end == NULL)
     {
       err_code = ERR_REWRITE_FAILED;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24437

Purpose
In order to rewrite the dblink query, the query must be parsed and recombined.
There may be multiple "WHERE" in the dblink query, but this is not considered and an issue has occurred.

Implementation
N/A

Remarks
N/A