### PR TITLE
[CBRD-24437] backport #3745 to 11.2 - DBLink query parsing error

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -2509,7 +2509,7 @@ cgw_rewrite_query (char *src_query, char **sql)
   inline_view_len = (end + 1) - (start);
   start = end + REWRITE_DELIMITER_CUBLINK_LEN + 3;
 
-  end = strstr (source, "WHERE");
+  end = strstr (inline_view + inline_view_len, "WHERE");
   if (end == NULL)
     {
       err_code = ERR_REWRITE_FAILED;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24437

Purpose
* backport #3745 to release/**11.2**

Implementation
N/A

Remarks
N/A