### PR TITLE
[LETS-483] relay mvcc_next_id via trantable checkpoint in certain conditions

### DIFF
--- a/src/transaction/log_checkpoint_info.hpp
+++ b/src/transaction/log_checkpoint_info.hpp
@@ -72,10 +72,13 @@ namespace cublog
       size_t get_transaction_count () const;
       size_t get_sysop_count () const;
 
+      MVCCID get_mvcc_next_id () const;
+
       void dump (FILE *out_fp);
 
     private:
-      void load_checkpoint_trans (log_tdes &tdes, LOG_LSA &smallest_lsa);
+      void load_checkpoint_trans (log_tdes &tdes, LOG_LSA &smallest_lsa,
+				  bool &at_least_one_active_transaction_has_valid_mvccid);
       void load_checkpoint_topop (log_tdes &tdes);
 
       struct tran_info;
@@ -86,6 +89,7 @@ namespace cublog
       std::vector<tran_info> m_trans;
       std::vector<sysop_info> m_sysops;
       bool m_has_2pc = false;				      // true if any LOG_ISTRAN_2PC (tdes) is true
+      MVCCID m_mvcc_next_id = MVCCID_NULL; // only filled if no transaction with valid mvccid info is present
   };
 
   struct checkpoint_info::tran_info

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7616,21 +7616,23 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
   log_lsa trantable_checkpoint_lsa = NULL_LSA;
 
   LOG_CS_ENTER (thread_p);
-    // *INDENT-OFF*
-    scope_exit<std::function<void (void)>> unlock_log_cs_on_exit ([thread_p] ()
-    {
-      LOG_CS_EXIT (thread_p);
-    });
+  // *INDENT-OFF*
+  scope_exit<std::function<void (void)>> unlock_log_cs_on_exit ([thread_p] ()
+  {
+    LOG_CS_EXIT (thread_p);
+  });
 
-    cublog::checkpoint_info trantable_checkpoint_info;
-    // *INDENT-ON*
+  cublog::checkpoint_info trantable_checkpoint_info;
+  // *INDENT-ON*
 
   if (detailed_logging)
     {
       _er_log_debug (ARG_FILE_LINE, "checkpoint_trantable: started, loading trantable\n");
     }
-  LOG_LSA dummy_smallest_tran_lsa = NULL_LSA;
-  trantable_checkpoint_info.load_trantable_snapshot (thread_p, dummy_smallest_tran_lsa);
+  {
+    LOG_LSA dummy_smallest_tran_lsa = NULL_LSA;
+    trantable_checkpoint_info.load_trantable_snapshot (thread_p, dummy_smallest_tran_lsa);
+  }
 
   // Currently the transaction table snapshot is saved in two places:
   //


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-483

Transaction table checkpoint is appended to the transactional log - `LOG_TRANTABLE_SNAPSHOT` - and is consumed by a booting-up passive transaction server to provide an intermediary snapshot from where to continue on recovery.
A passive transaction server needs to bring up to date also the table of mvccid for the next client (and in the case of passive transaction table also read-only) transaction to have a valid visibility snapshot.

When - on the active transaction server, where this snapshot is generated - via the log checkpoint trantable daemon - there are no transactions with valid active mvccid's, relay the global `mvcc_next_id` for the passive transaction table to use for initialization.

Other:
- alignment
