### PR TITLE
[CBRD-24407] Revert: Changes for lock_timeout, isolation_level in csql are reflected

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1042,7 +1042,6 @@ static unsigned int prm_lk_rollback_on_lock_escalation_flag = 0;
 
 int PRM_LK_TIMEOUT_SECS = -1;
 static int prm_lk_timeout_secs_default = -1;	/* Infinite */
-static int prm_lk_timeout_secs_upper = INT_MAX / 1000;
 static int prm_lk_timeout_secs_lower = -1;
 static unsigned int prm_lk_timeout_secs_flag = 0;
 
@@ -2729,23 +2728,23 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_LK_TIMEOUT_SECS,
    PRM_NAME_LK_TIMEOUT_SECS,
-   (PRM_FOR_CLIENT | PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_FOR_SESSION | PRM_DEPRECATED),
+   (PRM_FOR_CLIENT | PRM_USER_CHANGE | PRM_FOR_SESSION | PRM_DEPRECATED),
    PRM_INTEGER,
    &prm_lk_timeout_secs_flag,
    (void *) &prm_lk_timeout_secs_default,
    (void *) &PRM_LK_TIMEOUT_SECS,
-   (void *) &prm_lk_timeout_secs_upper, (void *) &prm_lk_timeout_secs_lower,
+   (void *) NULL, (void *) &prm_lk_timeout_secs_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_LK_TIMEOUT,
    PRM_NAME_LK_TIMEOUT,
-   (PRM_FOR_CLIENT | PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_FOR_SESSION | PRM_TIME_UNIT | PRM_DIFFER_UNIT),
+   (PRM_FOR_CLIENT | PRM_USER_CHANGE | PRM_FOR_SESSION | PRM_TIME_UNIT | PRM_DIFFER_UNIT),
    PRM_INTEGER,
    &prm_lk_timeout_secs_flag,
    (void *) &prm_lk_timeout_secs_default,
    (void *) &PRM_LK_TIMEOUT_SECS,
-   (void *) &prm_lk_timeout_secs_upper, (void *) &prm_lk_timeout_secs_lower,
+   (void *) NULL, (void *) &prm_lk_timeout_secs_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) prm_msec_to_sec,
    (DUP_PRM_FUNC) prm_sec_to_msec},
@@ -2850,7 +2849,7 @@ static SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_LOG_ISOLATION_LEVEL,
    PRM_NAME_LOG_ISOLATION_LEVEL,
-   (PRM_FOR_CLIENT | PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_FOR_SESSION),
+   (PRM_FOR_CLIENT | PRM_USER_CHANGE | PRM_FOR_SESSION),
    PRM_KEYWORD,
    &prm_log_isolation_level_flag,
    (void *) &prm_log_isolation_level_default,

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -5242,7 +5242,7 @@ check_timeout_value (PARSER_CONTEXT * parser, PT_NODE * statement, DB_VALUE * va
   if (db_value_coerce (val, val, &tp_Float_domain) == DOMAIN_COMPATIBLE)
     {
       timeout = db_get_float (val);
-      if ((timeout == -1) || (timeout >= 0 && timeout <= INT_MAX / 1000))
+      if ((timeout == -1) || (timeout >= 0))
 	{
 	  return NO_ERROR;
 	}

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1588,14 +1588,6 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   LSA_SET_NULL (&tdes->rcv.atomic_sysop_start_lsa);
   LSA_SET_NULL (&tdes->rcv.analysis_last_aborted_sysop_lsa);
   LSA_SET_NULL (&tdes->rcv.analysis_last_aborted_sysop_start_lsa);
-
-  /* reflect the session (or prm_Def) */
-  tdes->isolation = (TRAN_ISOLATION) prm_get_integer_value (PRM_ID_LOG_ISOLATION_LEVEL);
-  tdes->wait_msecs = prm_get_integer_value (PRM_ID_LK_TIMEOUT);
-  if (tdes->wait_msecs > 0)
-    {
-      tdes->wait_msecs = tdes->wait_msecs * 1000;
-    }
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24407

Purpose
* Reverts CUBRID/cubrid#3697
* There are some regression issues. So, it is reverted and re-implemented not to disturb QA works

Implementation
* N/A

Remarks
* N/A


