### PR TITLE
[CBRD-24455] Fix the header comment typo in lock_initialize_object_lock_entry_list()

### DIFF
--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -1108,7 +1108,7 @@ lock_initialize_object_hash_table (void)
 
 #if defined(SERVER_MODE)
 /*
- * lockk_initialize_object_lock_entry_list - Initializes the object lock entry list
+ * lock_initialize_object_lock_entry_list - Initializes the object lock entry list
  *
  * return: error code
  *


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24455

Purpose
Fix the header comment typo

Implementation
N/A

Remarks
N/A