### PR TITLE
[CBRD-21754] Add __declspec(dllexport) macro in porting.h for windows

### DIFF
--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -43,13 +43,15 @@
 #endif
 
 #if defined (WINDOWS)
-#define IMPORT_VAR 	__declspec(dllimport)
-#define EXPORT_VAR 	__declspec(dllexport)
-#include <WinBase.h>
+#ifdef _EXPORTING
+#define EXPORT_IMPORT    __declspec(dllexport)
 #else
-#define IMPORT_VAR 	extern
-#define EXPORT_VAR
+#define EXPORT_IMPORT    __declspec(dllimport)
 #endif
+#else /* WINDOWS */
+  // all symbols are exported by default
+#define EXPORT_IMPORT
+#endif /* WINDOWS */
 
 #if defined (WINDOWS)
 #define L_cuserid 9


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21754

**Motivation**
the legacy macro, EXPORT_VAR, IMPORT_VAR is not used in every place.
We have the .def files to specify exporting functions. But the lists are not managed well, and it is also a burden for developers.
Also, For C++ classes, when you want to export the functions in a class, every function should be explicitly specified in the .def file.

**Implementation**
As a first step of removing *.def file, I've added the MSVC keywords macro to export/import symbols to/from WIndows DLL's in porting.h.

**Remarks**
N/A
