### PR TITLE
[CBRD-24416] recording CAS error on additional log files

### DIFF
--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -7150,7 +7150,7 @@ au_perform_login (const char *name, const char *password, bool ignore_dba_privil
 			  || !match_password (dbpassword, db_get_string (&value)))
 			{
 			  error = ER_AU_INVALID_PASSWORD;
-			  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 0);
+			  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
 			}
 		    }
 		  else
@@ -7166,7 +7166,7 @@ au_perform_login (const char *name, const char *password, bool ignore_dba_privil
 		      if (dbpassword != NULL && strlen (dbpassword))
 			{
 			  error = ER_AU_INVALID_PASSWORD;
-			  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 0);
+			  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
 			}
 		    }
 		  if (pass != NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24416

**Purpose**
When an error occurs during login due to an incorrect DB password, logs should be recorded in sql log, sql slow log, and error log.
* $CUBRID/log/broker/sql_log/query_editor_2.log
* $CUBRID/log/broker/sql_log/query_editor_2.slow.log
* $CUBRID/log/broker/error_log/query_editor_2.err

**Implementation**
N/A

**Remarks**
N/A