### PR TITLE
[CBRD-24456] Add NULL guards after allocating memory in "src/transaction/lock_manager.c".

### DIFF
--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -483,7 +483,7 @@ static void lock_initialize_object_hash_table (void);
 static int lock_initialize_object_lock_entry_list (void);
 static int lock_initialize_deadlock_detection (void);
 static int lock_remove_resource (THREAD_ENTRY * thread_p, LK_RES * res_ptr);
-static void lock_finalize_tran_lock_table (int index);
+static void lock_finalize_tran_lock_table (void);
 static void lock_insert_into_tran_hold_list (LK_ENTRY * entry_ptr, int owner_tran_index);
 static int lock_delete_from_tran_hold_list (LK_ENTRY * entry_ptr, int owner_tran_index);
 static void lock_insert_into_tran_non2pl_list (LK_ENTRY * non2pl, int owner_tran_index);
@@ -1044,25 +1044,30 @@ static int
 lock_initialize_tran_lock_table (void)
 {
   LK_TRAN_LOCK *tran_lock;	/* pointer to transaction hold entry */
+  int num_trans;		/* max transaction */
   int i, j;			/* loop variable */
   LK_ENTRY *entry = NULL;
 
   /* initialize the number of transactions */
-  lk_Gl.num_trans = MAX_NTRANS;
+  num_trans = MAX_NTRANS;
+  lk_Gl.num_trans = 0;
 
   /* allocate memory space for transaction lock table */
-  lk_Gl.tran_lock_table = (LK_TRAN_LOCK *) malloc (SIZEOF_LK_TRAN_LOCK * lk_Gl.num_trans);
+  lk_Gl.tran_lock_table = (LK_TRAN_LOCK *) malloc (SIZEOF_LK_TRAN_LOCK * num_trans);
   if (lk_Gl.tran_lock_table == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
-	      (size_t) (SIZEOF_LK_TRAN_LOCK * lk_Gl.num_trans));
+	      (size_t) (SIZEOF_LK_TRAN_LOCK * num_trans));
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
   /* initialize all the entries of transaction lock table */
-  memset (lk_Gl.tran_lock_table, 0, SIZEOF_LK_TRAN_LOCK * lk_Gl.num_trans);
-  for (i = 0; i < lk_Gl.num_trans; i++)
+  memset (lk_Gl.tran_lock_table, 0, SIZEOF_LK_TRAN_LOCK * num_trans);
+  for (i = 0; i < num_trans; i++)
     {
+      /* increasing number of initialized transaction */
+      ++lk_Gl.num_trans;
+
       tran_lock = &lk_Gl.tran_lock_table[i];
       pthread_mutex_init (&tran_lock->hold_mutex, NULL);
       pthread_mutex_init (&tran_lock->non2pl_mutex, NULL);
@@ -1072,7 +1077,7 @@ lock_initialize_tran_lock_table (void)
 	  entry = (LK_ENTRY *) malloc (sizeof (LK_ENTRY));
 	  if (entry == NULL)
 	    {
-	      lock_finalize_tran_lock_table (i);
+	      lock_finalize_tran_lock_table ();
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, (size_t) (sizeof (LK_ENTRY)));
 	      return ER_OUT_OF_VIRTUAL_MEMORY;
 	    }
@@ -5679,25 +5684,19 @@ error:
  * lock_finalize_tran_lock_table - Remove lock table resource
  *
  * return: nothing
- *   index(in): The allocated index. Ignore if index is -1.
  *
  * NOTE: This function deallocates memory space for transaction lock table.
  */
 static void
-lock_finalize_tran_lock_table (int index)
+lock_finalize_tran_lock_table (void)
 {
   LK_TRAN_LOCK *tran_lock;
   int i;
 
-  /* index is not used */
-  if (index == -1)
-    {
-      index = lk_Gl.num_trans - 1;
-    }
   /* remove resources */
   if (lk_Gl.tran_lock_table != NULL)
     {
-      for (i = 0; i <= index; i++)
+      for (i = 0; i < lk_Gl.num_trans; i++)
 	{
 	  tran_lock = &lk_Gl.tran_lock_table[i];
 	  pthread_mutex_destroy (&tran_lock->hold_mutex);
@@ -5859,7 +5858,7 @@ lock_finalize (void)
     }
 
   /* transaction lock information table */
-  lock_finalize_tran_lock_table (-1);
+  lock_finalize_tran_lock_table ();
   pthread_mutex_destroy (&lk_Gl.DL_detection_mutex);
 
   /* reset max number of object locks */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24456

Purpose
In funcion `lock_initialize_tran_lock_table ()` (line 1071), there is no part to check that the memory allocation is done properly.
Add allocation check and error handling.

```
1069      for (j = 0; j < LOCK_TRAN_LOCAL_POOL_MAX_SIZE; j++)
1070	{
1071	  entry = (LK_ENTRY *) malloc (sizeof (LK_ENTRY));
                  /* need null guard */
1072	  lock_initialize_entry (entry);
```

Implementation
N/A

Remarks
N/A