### PR TITLE
[LETS-483] log recovery analysis process MVCC information in log records and, on PTS, complete mvccid's

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1577,6 +1577,8 @@ error:
  *
  * return: nothing
  *
+ * NOTE: this function assumes that the trantable is initialized (as of now, it is done in the function
+ *  caling this one)
  */
 void
 log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
@@ -1649,6 +1651,8 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
       replication_start_redo_lsa = log_Gl.append.get_nxio_lsa ();
     }
     // prior lists from page server are being received now
+
+    assert (LSA_LE (&most_recent_trantable_snapshot_lsa, &replication_start_redo_lsa));
 
     // NOTE: following situations can happen with regard to most recent transaction table snapshot lsa:
     //  1. it is null here at destination on PTS:

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1577,8 +1577,6 @@ error:
  *
  * return: nothing
  *
- * NOTE: this function assumes that the trantable is initialized (as of now, it is done in the function
- *  caling this one)
  */
 void
 log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
@@ -1651,8 +1649,6 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
       replication_start_redo_lsa = log_Gl.append.get_nxio_lsa ();
     }
     // prior lists from page server are being received now
-
-    assert (LSA_LE (&most_recent_trantable_snapshot_lsa, &replication_start_redo_lsa));
 
     // NOTE: following situations can happen with regard to most recent transaction table snapshot lsa:
     //  1. it is null here at destination on PTS:

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -562,11 +562,7 @@ log_rv_analysis_undo_redo (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa
       assert (log_page_p != nullptr);
 
       // move read pointer past the log header which is actually read upper in the stack
-      _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete 01 trid = %d log_lsa = %lld|%d\n",
-		     tran_id, LSA_AS_ARGS (log_lsa));
       LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_RECORD_HEADER), log_lsa, log_page_p);
-      _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete 02 trid = %d log_lsa = %lld|%d\n",
-		     tran_id, LSA_AS_ARGS (log_lsa));
       switch (log_type)
 	{
 	case LOG_MVCC_UNDOREDO_DATA:
@@ -574,39 +570,27 @@ log_rv_analysis_undo_redo (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa
 	{
 	  // align to read the specific record info
 	  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_MVCC_UNDOREDO), log_lsa, log_page_p);
-	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete 03 trid = %d log_lsa = %lld|%d\n",
-			 tran_id, LSA_AS_ARGS (log_lsa));
 	  const LOG_REC_MVCC_UNDOREDO *const log_rec
 	    = (const LOG_REC_MVCC_UNDOREDO *) ((char *)log_page_p->area + log_lsa->offset);
 	  tdes->mvccinfo.id = log_rec->mvccid;
-	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete trid = %d mvccid = %llu last_mvcc_lsa = %lld|%d\n",
-			 tran_id, (unsigned long long)log_rec->mvccid, LSA_AS_ARGS (&tdes->last_mvcc_lsa));
 	  break;
 	}
 	case LOG_MVCC_UNDO_DATA:
 	{
 	  // align to read the specific record info
 	  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_MVCC_UNDO), log_lsa, log_page_p);
-	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete 04 trid = %d log_lsa = %lld|%d\n",
-			 tran_id, LSA_AS_ARGS (log_lsa));
 	  const LOG_REC_MVCC_UNDO *const log_rec
 	    = (const LOG_REC_MVCC_UNDO *) ((char *)log_page_p->area + log_lsa->offset);
 	  tdes->mvccinfo.id = log_rec->mvccid;
-	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete trid = %d mvccid = %llu last_mvcc_lsa = %lld|%d\n",
-			 tran_id, (unsigned long long)log_rec->mvccid, LSA_AS_ARGS (&tdes->last_mvcc_lsa));
 	  break;
 	}
 	case LOG_MVCC_REDO_DATA:
 	{
 	  // align to read the specific record info
 	  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_MVCC_REDO), log_lsa, log_page_p);
-	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete 05 trid = %d log_lsa = %lld|%d\n",
-			 tran_id, LSA_AS_ARGS (log_lsa));
 	  const LOG_REC_MVCC_REDO *const log_rec
 	    = (const LOG_REC_MVCC_REDO *) ((char *)log_page_p->area + log_lsa->offset);
 	  tdes->mvccinfo.id = log_rec->mvccid;
-	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete trid = %d mvccid = %llu last_mvcc_lsa = %lld|%d\n",
-			 tran_id, (unsigned long long)log_rec->mvccid, LSA_AS_ARGS (&tdes->last_mvcc_lsa));
 	  break;
 	}
 	default:

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -39,7 +39,8 @@
 static void log_rv_analysis_handle_fetch_page_fail (THREAD_ENTRY *thread_p, log_recovery_context &context,
     LOG_PAGE *log_page_p, const LOG_RECORD_HEADER *log_rec,
     const log_lsa &prev_lsa, const log_lsa &prev_prev_lsa);
-static int log_rv_analysis_undo_redo (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa, bool is_mvcc);
+static int log_rv_analysis_undo_redo (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa, LOG_PAGE *log_page_p,
+				      LOG_RECTYPE log_type, bool is_mvcc);
 static int log_rv_analysis_dummy_head_postpone (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa);
 static int log_rv_analysis_postpone (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa);
 static int log_rv_analysis_run_postpone (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa,
@@ -137,8 +138,9 @@ log_rv_analysis_check_page_corruption (THREAD_ENTRY *thread_p, LOG_PAGEID pageid
       /* Found corrupted log page. */
       if (prm_get_bool_value (PRM_ID_LOGPB_LOGGING_DEBUG))
 	{
-	  _er_log_debug (ARG_FILE_LINE, "logpb_recovery_analysis: log page %lld is corrupted due to partial flush.\n",
-			 (long long int) pageid);
+	  _er_log_debug (ARG_FILE_LINE, "logpb_recovery_analysis: log page %lld is corrupted due to partial flush"
+			 " (first_corrupted_rec_lsa = %lld|%d)\n",
+			 (long long int) pageid, LSA_AS_ARGS (&checker.get_first_corrupted_lsa ()));
 	}
     }
   return NO_ERROR;
@@ -529,7 +531,8 @@ log_rv_analysis_handle_fetch_page_fail (THREAD_ENTRY *thread_p, log_recovery_con
  * Note:
  */
 static int
-log_rv_analysis_undo_redo (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa, bool is_mvcc)
+log_rv_analysis_undo_redo (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa, LOG_PAGE *log_page_p,
+			   LOG_RECTYPE log_type, bool is_mvcc)
 {
   LOG_TDES *tdes;
 
@@ -554,6 +557,61 @@ log_rv_analysis_undo_redo (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa
   if (is_mvcc)
     {
       tdes->last_mvcc_lsa = *log_lsa;
+
+      // assign transaction mvccid from log record to transaction descriptor
+      assert (log_page_p != nullptr);
+
+      // move read pointer past the log header which is actually read upper in the stack
+      _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete 01 trid = %d log_lsa = %lld|%d\n",
+		     tran_id, LSA_AS_ARGS (log_lsa));
+      LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_RECORD_HEADER), log_lsa, log_page_p);
+      _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete 02 trid = %d log_lsa = %lld|%d\n",
+		     tran_id, LSA_AS_ARGS (log_lsa));
+      switch (log_type)
+	{
+	case LOG_MVCC_UNDOREDO_DATA:
+	case LOG_MVCC_DIFF_UNDOREDO_DATA:
+	{
+	  // align to read the specific record info
+	  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_MVCC_UNDOREDO), log_lsa, log_page_p);
+	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete 03 trid = %d log_lsa = %lld|%d\n",
+			 tran_id, LSA_AS_ARGS (log_lsa));
+	  const LOG_REC_MVCC_UNDOREDO *const log_rec
+	    = (const LOG_REC_MVCC_UNDOREDO *) ((char *)log_page_p->area + log_lsa->offset);
+	  tdes->mvccinfo.id = log_rec->mvccid;
+	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete trid = %d mvccid = %llu last_mvcc_lsa = %lld|%d\n",
+			 tran_id, (unsigned long long)log_rec->mvccid, LSA_AS_ARGS (&tdes->last_mvcc_lsa));
+	  break;
+	}
+	case LOG_MVCC_UNDO_DATA:
+	{
+	  // align to read the specific record info
+	  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_MVCC_UNDO), log_lsa, log_page_p);
+	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete 04 trid = %d log_lsa = %lld|%d\n",
+			 tran_id, LSA_AS_ARGS (log_lsa));
+	  const LOG_REC_MVCC_UNDO *const log_rec
+	    = (const LOG_REC_MVCC_UNDO *) ((char *)log_page_p->area + log_lsa->offset);
+	  tdes->mvccinfo.id = log_rec->mvccid;
+	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete trid = %d mvccid = %llu last_mvcc_lsa = %lld|%d\n",
+			 tran_id, (unsigned long long)log_rec->mvccid, LSA_AS_ARGS (&tdes->last_mvcc_lsa));
+	  break;
+	}
+	case LOG_MVCC_REDO_DATA:
+	{
+	  // align to read the specific record info
+	  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_MVCC_REDO), log_lsa, log_page_p);
+	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete 05 trid = %d log_lsa = %lld|%d\n",
+			 tran_id, LSA_AS_ARGS (log_lsa));
+	  const LOG_REC_MVCC_REDO *const log_rec
+	    = (const LOG_REC_MVCC_REDO *) ((char *)log_page_p->area + log_lsa->offset);
+	  tdes->mvccinfo.id = log_rec->mvccid;
+	  _er_log_debug (ARG_FILE_LINE, "crsdbg: an_mvcc_complete trid = %d mvccid = %llu last_mvcc_lsa = %lld|%d\n",
+			 tran_id, (unsigned long long)log_rec->mvccid, LSA_AS_ARGS (&tdes->last_mvcc_lsa));
+	  break;
+	}
+	default:
+	  assert ("other log record not expected to have mvccid" == nullptr);
+	}
     }
 
   return NO_ERROR;
@@ -965,6 +1023,9 @@ log_rv_analysis_assigned_mvccid (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *l
 
   tdes->last_mvcc_lsa = *log_lsa;
 
+  // move read pointer past the log header which is actually read upper in the stack
+  LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_RECORD_HEADER), log_lsa, log_page_p);
+  // align to read the specific record info
   LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_ASSIGNED_MVCCID), log_lsa, log_page_p);
   auto rec = (const LOG_REC_ASSIGNED_MVCCID *) (log_page_p->area + log_lsa->offset);
   tdes->mvccinfo.id = rec->mvccid;
@@ -998,8 +1059,21 @@ log_rv_analysis_complete (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa,
       // The transaction has been fully completed. Therefore, it was not active at the time of the crash.
       if (tran_index != NULL_TRAN_INDEX)
 	{
+	  // newer quick fix on top of older quick fix: mark the mvccid as completed
+	  LOG_TDES *const tdes = LOG_FIND_TDES (tran_index);
+	  if (is_passive_transaction_server ())
+	    {
+	      if (MVCCID_IS_VALID (tdes->mvccinfo.id))
+		{
+		  log_Gl.mvcc_table.complete_mvcc (tran_index, tdes->mvccinfo.id, true);
+		}
+	      else
+		{
+		  assert (LSA_ISNULL (&tdes->last_mvcc_lsa));
+		}
+	    }
 	  // quick fix: reset mvccid.
-	  LOG_FIND_TDES (tran_index)->mvccinfo.id = MVCCID_NULL;
+	  tdes->mvccinfo.id = MVCCID_NULL;
 	  logtb_free_tran_index (thread_p, tran_index);
 	}
       return NO_ERROR;
@@ -1045,8 +1119,21 @@ log_rv_analysis_complete (THREAD_ENTRY *thread_p, int tran_id, LOG_LSA *log_lsa,
       // Transaction is completed.
       if (tran_index != NULL_TRAN_INDEX)
 	{
+	  // newer quick fix on top of older quick fix: mark the mvccid as completed
+	  LOG_TDES *const tdes = LOG_FIND_TDES (tran_index);
+	  if (is_passive_transaction_server ())
+	    {
+	      if (MVCCID_IS_VALID (tdes->mvccinfo.id))
+		{
+		  log_Gl.mvcc_table.complete_mvcc (tran_index, tdes->mvccinfo.id, true);
+		}
+	      else
+		{
+		  assert (LSA_ISNULL (&tdes->last_mvcc_lsa));
+		}
+	    }
 	  // quick fix: reset mvccid.
-	  LOG_FIND_TDES (tran_index)->mvccinfo.id = MVCCID_NULL;
+	  tdes->mvccinfo.id = MVCCID_NULL;
 	  logtb_free_tran_index (thread_p, tran_index);
 	}
       return NO_ERROR;
@@ -1624,14 +1711,15 @@ log_rv_analysis_record_on_tran_server (THREAD_ENTRY *thread_p, LOG_RECTYPE log_t
     case LOG_MVCC_DIFF_UNDOREDO_DATA:
     case LOG_MVCC_UNDO_DATA:
     case LOG_MVCC_REDO_DATA:
-      (void) log_rv_analysis_undo_redo (thread_p, tran_id, log_lsa, true);
+      (void) log_rv_analysis_undo_redo (thread_p, tran_id, log_lsa, log_page_p, log_type, true);
       break;
     case LOG_UNDOREDO_DATA:
     case LOG_DIFF_UNDOREDO_DATA:
     case LOG_UNDO_DATA:
     case LOG_REDO_DATA:
     case LOG_DBEXTERN_REDO_DATA:
-      (void) log_rv_analysis_undo_redo (thread_p, tran_id, log_lsa, false);
+      // sentinel value for log record type passes as an invalid value
+      (void) log_rv_analysis_undo_redo (thread_p, tran_id, log_lsa, nullptr, LOG_SMALLER_LOGREC_TYPE, false);
       break;
 
     case LOG_DUMMY_HEAD_POSTPONE:

--- a/src/transaction/mvcc_active_tran.cpp
+++ b/src/transaction/mvcc_active_tran.cpp
@@ -438,8 +438,9 @@ mvcc_active_tran::set_bitarea_mvccid (MVCCID mvccid)
   if (m_bit_area_length > CLEANUP_THRESHOLD)
     {
       // trim all committed units from bit_area
-      size_t first_not_all_committed;
-      for (first_not_all_committed = 0; first_not_all_committed < get_area_size (); first_not_all_committed++)
+      size_t first_not_all_committed = 0;
+      const size_t area_size = get_area_size ();
+      for (; first_not_all_committed < area_size; first_not_all_committed++)
 	{
 	  if (m_bit_area[first_not_all_committed] != ALL_COMMITTED)
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-483

During log recovery analysis, process mvcc information in log records:
- populate transaction descriptor mvccid from MVCC log records;
- complete mvcc when `LOG_COMPLETE` and `LOG_ABORT` log records are parsed - this is done only in the context of passive transaction server

Other:
- correct log reading in `log_rv_analysis_assigned_mvccid` with a missing advance and align

