### PR TITLE
[LETS-483] [LETS-495] correct mvcc table initialization on PTS

### DIFF
--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -2379,6 +2379,8 @@ log_recovery_build_mvcc_table_from_trantable (THREAD_ENTRY *thread_p, MVCCID rep
 	    }
 	}
     }
+  assert ((max_possible_mvccid == smallest_mvccid && min_possible_mvccid == largest_mvccid)
+	  || (max_possible_mvccid != smallest_mvccid && min_possible_mvccid != largest_mvccid));
 
   if (smallest_mvccid == max_possible_mvccid && largest_mvccid == min_possible_mvccid)
     {
@@ -2418,8 +2420,6 @@ log_recovery_build_mvcc_table_from_trantable (THREAD_ENTRY *thread_p, MVCCID rep
 
       log_Gl.hdr.mvcc_next_id = largest_mvccid + 1;
     }
-
-  const MVCCID oldest_visible_mvccid = log_Gl.mvcc_table.update_global_oldest_visible ();
 }
 
 /* log_recovery_analysis_from_trantable_snapshot - perform recovery for a passive transaction server

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -205,10 +205,7 @@ log_recovery_analysis_internal (THREAD_ENTRY *thread_p, INT64 *num_redo_log_reco
 
   // Start with the record at checkpoint LSA.
   record_nav_lsa = context.get_checkpoint_lsa ();
-  if (stop_before_lsa != nullptr)
-    {
-      assert (LSA_LE (&record_nav_lsa, stop_before_lsa));
-    }
+  assert ((stop_before_lsa == nullptr) || LSA_LE (&record_nav_lsa, stop_before_lsa));
 
   // If the recovery start matches a checkpoint, use the checkpoint information.
   const cublog::checkpoint_info *chkpt_infop = log_Gl.m_metainfo.get_checkpoint_info (record_nav_lsa);

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -219,8 +219,6 @@ log_recovery_analysis_internal (THREAD_ENTRY *thread_p, INT64 *num_redo_log_reco
 	  assert (LSA_LE (&record_nav_lsa, stop_before_lsa));
 	  if (LSA_EQ (&record_nav_lsa, stop_before_lsa))
 	    {
-	      _er_log_debug (ARG_FILE_LINE, "crsdbg: log_recovery_analysis stop_before_lsa = %lld|%d\n",
-			     LSA_AS_ARGS (stop_before_lsa));
 	      break;
 	    }
 	}

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -2512,7 +2512,56 @@ log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY *thread_p,
     return true;
   });
 
-  log_Gl.mvcc_table.complete_mvccids_if_still_active (LOG_SYSTEM_TRAN_INDEX, in_gaps_mvccids, true);
+  // TODO: this addresses the following scenario:
+  //  - when passive transaction server (PTS) initializes there are actually 3 phases that are
+  //    executed to reach to an up to date MVCC table
+  //    - 1. decode, load and parse a transaction table snapshot (this contains description
+  //      for the transactions that were active on active transaction server at the moment the
+  //      snapshot was taken):
+  //      - to find out known (and unknown) MVCCISs
+  //      - initialize the mvcc table with the known MVCCIDs;
+  //      - actually, the present MVCCIDs are considered still active, yet to be completed by
+  //        subsequent steps
+  //      - keep missing MVCCIDs (those nothing is known about, see Remark1 below) in a list
+  //        for later
+  //    - 2. analyze the transactional log:
+  //      - up to a point (up to the point where the transactional log replication will pick up)
+  //      - anlysing will process found MVCCIDs (ie: complete MVCCIDs when LOG_COMMIT/LOG_ABORT
+  //        log records are found)
+  //      - this might also complete some of the missing/unknown MVCCIDs found in the
+  //        previous step
+  //    - 3. after analysing the log:
+  //      - complete the remaining unknown MVCCIDs (found in step 1)
+  //      - thus, considering that those transactions, to which these unknown MVCCIDs belong,
+  //        must have been completed somewhere in the past (ie: before the transaction table
+  //        snapshot was taken)
+  //
+  //  - Remark1: explanation about missing/unknown MVCCIDs
+  //    - say the following MVCCIDs are found in the transaction table:
+  //        42 45 49 50
+  //    - these mvccids belong to transactions that are to be completed via transactional log records
+  //      which will be subsequently processed
+  //    - there are also the "missing" MVCCIDs:
+  //        ..<=41, 43, 44, 46, 47, 48, >=51..
+  //    - nothing is known about these:
+  //      - either they belong to transactions that have been commited
+  //      - or they belong to transactions that have acquired them but did not yet add an
+  //        MVCC log record to the transactional log (due to the multhreading aspect of the
+  //        transaction system, any out-of-order situation is possible really)
+  //      - one rule of thumb might work in this case, the "older" the MVCCIDs are the greater the
+  //        chance that transactions that acquired them have already concluded and, thus, the changes
+  //        that these mvccids (or, rather, the transactions that used them) introduce are reflected
+  //        in the heap pages
+  //      - by delaying the moment at which these "missing" MVCCIDs are completed until after having
+  //        analyzed the log, the risk to accidentally complete an MVCCID that is NOT actually completed
+  //        is minimised but not completely eliminated
+  //      - another possible mitigation is to - somehow - atomically acquire an MVCCID and register it
+  //        with the transaction descriptor
+  //
+  // for the short term, there is an assert in mvcctable::complete_mvcc that will guard against
+  // such situations, but a proper solution is needed
+  //
+  log_Gl.mvcc_table.complete_mvccids_if_still_active (LOG_SYSTEM_TRAN_INDEX, in_gaps_mvccids, false);
 
   LOG_SET_CURRENT_TRAN_INDEX (thread_p, sys_tran_index);
 }

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -36,6 +36,8 @@
 
 #include <set>
 
+static void log_recovery_analysis_internal (THREAD_ENTRY *thread_p, INT64 *num_redo_log_records,
+    log_recovery_context &context, bool reset_mvcc_table, const LOG_LSA *stop_before_lsa);
 static void log_rv_analysis_handle_fetch_page_fail (THREAD_ENTRY *thread_p, log_recovery_context &context,
     LOG_PAGE *log_page_p, const LOG_RECORD_HEADER *log_rec,
     const log_lsa &prev_lsa, const log_lsa &prev_prev_lsa);
@@ -81,7 +83,7 @@ static void log_recovery_resetlog (THREAD_ENTRY *thread_p, const LOG_LSA *new_ap
 static void log_recovery_notpartof_archives (THREAD_ENTRY *thread_p, int start_arv_num, const char *info_reason);
 static int log_recovery_analysis_load_trantable_snapshot (THREAD_ENTRY *thread_p,
     const log_lsa &most_recent_trantable_snapshot_lsa, cublog::checkpoint_info &chkpt_info, log_lsa &snapshot_lsa);
-static void log_recovery_build_mvcc_table_from_trantable (THREAD_ENTRY *thread_p);
+static void log_recovery_build_mvcc_table_from_trantable (THREAD_ENTRY *thread_p, MVCCID replicated_mvcc_next_id);
 
 class corruption_checker
 {
@@ -153,6 +155,21 @@ log_rv_analysis_check_page_corruption (THREAD_ENTRY *thread_p, LOG_PAGEID pageid
 void
 log_recovery_analysis (THREAD_ENTRY *thread_p, INT64 *num_redo_log_records, log_recovery_context &context)
 {
+  log_recovery_analysis_internal (thread_p, num_redo_log_records, context, true, nullptr);
+}
+
+/*
+ * log_recovery_analysis_internal () -
+ *
+ * num_redo_log_records (out)   : the number of redo log records to process (seemingly, no other use than reporting)
+ * context (in/out)             : context information for log recovery
+ * reset_mvcc_table (in)        : whether to reset mvcc table or not
+ * stop_before_lsa (in)         : if supplied, analysis will stop before processing the log record at this LSA
+ */
+void
+log_recovery_analysis_internal (THREAD_ENTRY *thread_p, INT64 *num_redo_log_records, log_recovery_context &context,
+				bool reset_mvcc_table, const LOG_LSA *stop_before_lsa)
+{
   // Navigation LSA's
   LOG_LSA record_nav_lsa = NULL_LSA;		/* LSA used to navigate from one record to the next */
   LOG_LSA log_nav_lsa = NULL_LSA;		/* LSA used to navigate through log pages and the data inside the pages.*/
@@ -188,6 +205,10 @@ log_recovery_analysis (THREAD_ENTRY *thread_p, INT64 *num_redo_log_records, log_
 
   // Start with the record at checkpoint LSA.
   record_nav_lsa = context.get_checkpoint_lsa ();
+  if (stop_before_lsa != nullptr)
+    {
+      assert (LSA_LE (&record_nav_lsa, stop_before_lsa));
+    }
 
   // If the recovery start matches a checkpoint, use the checkpoint information.
   const cublog::checkpoint_info *chkpt_infop = log_Gl.m_metainfo.get_checkpoint_info (record_nav_lsa);
@@ -195,6 +216,16 @@ log_recovery_analysis (THREAD_ENTRY *thread_p, INT64 *num_redo_log_records, log_
   /* Check all log records in this phase */
   while (!LSA_ISNULL (&record_nav_lsa))
     {
+      if (stop_before_lsa != nullptr)
+	{
+	  assert (LSA_LE (&record_nav_lsa, stop_before_lsa));
+	  if (LSA_EQ (&record_nav_lsa, stop_before_lsa))
+	    {
+	      _er_log_debug (ARG_FILE_LINE, "crsdbg: log_recovery_analysis stop_before_lsa = %lld|%d\n",
+			     LSA_AS_ARGS (stop_before_lsa));
+	      break;
+	    }
+	}
       if (record_nav_lsa.pageid != log_nav_lsa.pageid)
 	{
 	  /* Fetch the page of record */
@@ -450,7 +481,10 @@ log_recovery_analysis (THREAD_ENTRY *thread_p, INT64 *num_redo_log_records, log_
       chkpt_infop->recovery_2pc_analysis (thread_p);
     }
 
-  log_Gl.mvcc_table.reset_start_mvccid ();
+  if (reset_mvcc_table)
+    {
+      log_Gl.mvcc_table.reset_start_mvccid ();
+    }
 
   if (prm_get_bool_value (PRM_ID_LOGPB_LOGGING_DEBUG))
     {
@@ -2281,20 +2315,20 @@ log_recovery_analysis_load_trantable_snapshot (THREAD_ENTRY *thread_p,
   assert (!most_recent_trantable_snapshot_lsa.is_null ());
 
   log_reader lr (LOG_CS_SAFE_READER);
-  int log_page_read_err = lr.set_lsa_and_fetch_page (most_recent_trantable_snapshot_lsa);
-  if (log_page_read_err != NO_ERROR)
+  const int error_code = lr.set_lsa_and_fetch_page (most_recent_trantable_snapshot_lsa);
+  if (error_code != NO_ERROR)
     {
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE,
 			 "log_recovery_analysis_load_trantable_snapshot: error reading trantable snapshot log page");
-      return log_page_read_err;
+      return error_code;
     }
 
   // always copy because the next add might advance to the next log page
   const log_rec_header log_rec_hdr = lr.reinterpret_copy_and_add_align<log_rec_header> ();
   assert (log_rec_hdr.type == LOG_TRANTABLE_SNAPSHOT);
 
-  lr.advance_when_does_not_fit (sizeof (log_rec_trantable_snapshot));
-  const log_rec_trantable_snapshot log_rec = lr.reinterpret_copy_and_add_align<log_rec_trantable_snapshot> ();
+  lr.advance_when_does_not_fit (sizeof (LOG_REC_TRANTABLE_SNAPSHOT));
+  const LOG_REC_TRANTABLE_SNAPSHOT log_rec = lr.reinterpret_copy_and_add_align<LOG_REC_TRANTABLE_SNAPSHOT> ();
   std::unique_ptr<char []> snapshot_data_buf = std::make_unique<char []> (static_cast<size_t> (log_rec.length));
   lr.copy_from_log (snapshot_data_buf.get (), log_rec.length);
 
@@ -2305,26 +2339,33 @@ log_recovery_analysis_load_trantable_snapshot (THREAD_ENTRY *thread_p,
 
   chkpt_info.unpack (unpacker);
 
-  return NO_ERROR;
+  return error_code;
 }
 
 /* log_recovery_build_mvcc_table_from_trantable - build mvcc table using transaction table
  */
 static void
-log_recovery_build_mvcc_table_from_trantable (THREAD_ENTRY *thread_p)
+log_recovery_build_mvcc_table_from_trantable (THREAD_ENTRY *thread_p, MVCCID replicated_mvcc_next_id)
 {
   assert (is_passive_transaction_server ());
   assert (LOG_CS_OWN_WRITE_MODE (thread_p));
 
-  MVCCID smallest_mvccid = std::numeric_limits<MVCCID>::max ();
-  MVCCID largest_mvccid = std::numeric_limits<MVCCID>::min ();
+  constexpr MVCCID max_possible_mvccid = std::numeric_limits<MVCCID>::max ();
+  constexpr MVCCID min_possible_mvccid = std::numeric_limits<MVCCID>::min ();
+
+  MVCCID smallest_mvccid = max_possible_mvccid;
+  MVCCID largest_mvccid = min_possible_mvccid;
   std::set<MVCCID> present_mvccids;
   for (int i = 0; i < log_Gl.trantable.num_total_indices; ++i)
     {
       if (i != LOG_SYSTEM_TRAN_INDEX)
 	{
 	  const log_tdes *const tdes = log_Gl.trantable.all_tdes[i];
-	  if (tdes != nullptr && tdes->trid != NULL_TRANID)
+	  // transaction's info relayed from the active transaction server is
+	  // artificially transferred here (see checkpoint_info::recovery_analysis); therefore
+	  // the same condition as where the transaction is relayed (checkpoint_info::load_checkpoint_trans)
+	  // cannot be used
+	  if (tdes != nullptr && tdes->trid != NULL_TRANID && MVCCID_IS_VALID (tdes->mvccinfo.id))
 	    {
 	      if (tdes->mvccinfo.id < smallest_mvccid)
 		{
@@ -2335,30 +2376,53 @@ log_recovery_build_mvcc_table_from_trantable (THREAD_ENTRY *thread_p)
 		  largest_mvccid = tdes->mvccinfo.id;
 		}
 	      present_mvccids.insert (tdes->mvccinfo.id);
+
+	      // TODO: for later, mvcc sub ids
+	      assert (tdes->mvccinfo.sub_ids.empty ());
 	    }
 	}
     }
-  log_Gl.hdr.mvcc_next_id = smallest_mvccid;
-  log_Gl.mvcc_table.reset_start_mvccid ();
 
-  if (!present_mvccids.empty ())
+  if (smallest_mvccid == max_possible_mvccid && largest_mvccid == min_possible_mvccid)
     {
-      // complete each mvccid between the smallest and the highest, that is missing from the table
-      std::set<MVCCID>::const_iterator present_mvccids_it = present_mvccids.cbegin ();
-      MVCCID prev_mvccid = *present_mvccids_it;
-      ++present_mvccids_it;
-      for (; present_mvccids_it != present_mvccids.cend (); ++present_mvccids_it)
+      // either:
+      //  - no transaction was active on the active transaction server when the trantable snapshot was taken
+      //  - or, transactions were active but none of them had a valid mvccid assigned
+      assert (MVCCID_IS_VALID (replicated_mvcc_next_id));
+      assert (present_mvccids.empty ());
+
+      log_Gl.hdr.mvcc_next_id = replicated_mvcc_next_id;
+      log_Gl.mvcc_table.reset_start_mvccid ();
+    }
+  else
+    {
+      assert (!MVCCID_IS_VALID (replicated_mvcc_next_id));
+
+      // at least one transaction was active on the active transaction server when the snapshot was taken
+      log_Gl.hdr.mvcc_next_id = smallest_mvccid;
+      log_Gl.mvcc_table.reset_start_mvccid ();
+
+      if (!present_mvccids.empty ())
 	{
-	  const MVCCID curr_mvccid = *present_mvccids_it;
-	  for (MVCCID missing_mvccid = prev_mvccid + 1; missing_mvccid < curr_mvccid; ++missing_mvccid)
+	  // complete each mvccid between the smallest and the highest, that is missing from the table
+	  std::set<MVCCID>::const_iterator present_mvccids_it = present_mvccids.cbegin ();
+	  MVCCID prev_mvccid = *present_mvccids_it;
+	  ++present_mvccids_it;
+	  for (; present_mvccids_it != present_mvccids.cend (); ++present_mvccids_it)
 	    {
-	      log_Gl.mvcc_table.complete_mvcc (LOG_SYSTEM_TRAN_INDEX, missing_mvccid, true);
+	      const MVCCID curr_mvccid = *present_mvccids_it;
+	      for (MVCCID missing_mvccid = prev_mvccid + 1; missing_mvccid < curr_mvccid; ++missing_mvccid)
+		{
+		  log_Gl.mvcc_table.complete_mvcc (LOG_SYSTEM_TRAN_INDEX, missing_mvccid, true);
+		}
+	      prev_mvccid = curr_mvccid;
 	    }
-	  prev_mvccid = curr_mvccid;
 	}
+
+      log_Gl.hdr.mvcc_next_id = largest_mvccid + 1;
     }
 
-  log_Gl.hdr.mvcc_next_id = largest_mvccid + 1;
+  const MVCCID oldest_visible_mvccid = log_Gl.mvcc_table.update_global_oldest_visible ();
 }
 
 /* log_recovery_analysis_from_trantable_snapshot - perform recovery for a passive transaction server
@@ -2368,13 +2432,18 @@ log_recovery_build_mvcc_table_from_trantable (THREAD_ENTRY *thread_p)
  * most_recent_trantable_snapshot_lsa (in): the lsa where a record containing, as payload, the packed contents
  *                                of a recent transaction table snapshot; starting from that snapshot, analyze the log
  *                                to construct an actual starting transaction table
+ * stop_analysis_before_lsa (in): stop analysis before processing the log record entry at this LSA; replication will
+ *                                start processing with the log record at this LSA (see calling point for this function)
  */
 void
 log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY *thread_p,
-    log_lsa most_recent_trantable_snapshot_lsa)
+    const log_lsa &most_recent_trantable_snapshot_lsa,
+    const log_lsa &stop_analysis_before_lsa)
 {
   assert (is_passive_transaction_server ());
   assert (LOG_CS_OWN_WRITE_MODE (thread_p));
+  assert (!LSA_ISNULL (&most_recent_trantable_snapshot_lsa));
+  assert (!LSA_ISNULL (&stop_analysis_before_lsa));
 
   // analysis changes the transaction index and leaves it in an indefinite state
   // therefore reset to system transaction index afterwards;
@@ -2395,17 +2464,25 @@ log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY *thread_p,
   chkpt_info.recovery_analysis (thread_p, start_redo_lsa);
 
   log_recovery_context log_rcv_context;
+  // log recovery analysis must actually start at the log record following the snapshot LSA, but, since
+  // the LOG_TRANTABLE_SNAPSHOT log record is not processed in any way by recovery analysis, it is safe to
+  // just start there
   log_rcv_context.init_for_recovery (snapshot_lsa);
   // no recovery is done, start redo lsa may remain invalid
   log_rcv_context.set_start_redo_lsa (NULL_LSA);
   log_rcv_context.set_end_redo_lsa (NULL_LSA);
 
+  log_recovery_build_mvcc_table_from_trantable (thread_p, chkpt_info.get_mvcc_next_id ());
+
   // passive transaction server needs to analyze up to the point its replication will pick-up things;
   // that means until the append_lsa; incidentally, end of log record should be found at the current append_lsa, so
   // analysis should stop there
-
   INT64 dummy_redo_log_record_count = 0LL;
-  log_recovery_analysis (thread_p, &dummy_redo_log_record_count, log_rcv_context);
+  // it is assumed that the analysis does not touch the mvcc table anymore
+  // it has already been initialized from the information relayed over via the trantable checkpoint
+  constexpr bool reset_mvcc_table = false;
+  log_recovery_analysis_internal (thread_p, &dummy_redo_log_record_count, log_rcv_context, reset_mvcc_table,
+				  &stop_analysis_before_lsa);
   assert (!log_rcv_context.is_restore_incomplete ());
 
   // on passive transaction server, the recovery analysis has only the role of bringing the
@@ -2416,6 +2493,4 @@ log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY *thread_p,
   });
 
   LOG_SET_CURRENT_TRAN_INDEX (thread_p, sys_tran_index);
-
-  log_recovery_build_mvcc_table_from_trantable (thread_p);
 }

--- a/src/transaction/log_recovery_analysis.hpp
+++ b/src/transaction/log_recovery_analysis.hpp
@@ -37,6 +37,6 @@ class log_recovery_context;
 void log_recovery_analysis (THREAD_ENTRY *thread_p, INT64 *num_redo_log_records, log_recovery_context &context);
 
 void log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY *thread_p,
-    log_lsa most_recent_trantable_snapshot_lsa);
+    const log_lsa &most_recent_trantable_snapshot_lsa, const log_lsa &stop_analysis_before_lsa);
 
 #endif // !_LOG_RECOVERY_ANALYSIS_HPP_

--- a/src/transaction/mvcc.c
+++ b/src/transaction/mvcc.c
@@ -105,7 +105,7 @@ mvcc_is_id_in_snapshot (THREAD_ENTRY * thread_p, MVCCID mvcc_id, MVCC_SNAPSHOT *
  *
  * Note: Check whether an active transaction is active by searching transactions
  *  status into current history position. The data from current history position
- *  is atomically checked (See logtb_get_mvcc_snapshot_data comments).
+ *  is atomically checked (See logtb_get_mvcc_snapshot comments).
  */
 STATIC_INLINE bool
 mvcc_is_active_id (THREAD_ENTRY * thread_p, MVCCID mvccid)

--- a/src/transaction/mvcc_table.cpp
+++ b/src/transaction/mvcc_table.cpp
@@ -478,6 +478,35 @@ mvcctable::complete_mvcc (int tran_index, MVCCID mvccid, bool committed)
       assert (false);
     }
 
+  if (is_passive_transaction_server ())
+    {
+      // sanity check that an mvccid is never double-completed either during PTS initialization or PTS replication
+      //
+      // TODO: this addresses the following scenario, which is difficult to catch during testing:
+      //  - when PTS initializes there are actually 3 phases that are executed to reach to an up to date
+      //    MVCC table (see function log_recovery_analysis_from_trantable_snapshot)
+      //  - 1. start with a transaction table snapshot, from which a transaction table is initialized; this
+      //      transaction table contains the transactions that were active at the moment the snapshot was taken on
+      //      the active transaction server (ATS)
+      //  - 2. after this, the current transaction table is parsed to obtain a correct mvcc table by initializing the
+      //      start MVCCID in the MVCC table and then completing the missing MVCCID's in the gaps between the smallest
+      //      present MVCCID and the largest present MVCCID that are encountered; these missing MVCCID are "assumed"
+      //      to belong to transactions that have already concluded (by either committing or aborting);
+      //      however, in reality, these MVCCID's might be in one of the following states:
+      //        - belonging to transactions (existing on ATS at the time the snapshot has been taken) that
+      //          have acquired the id but did not yet get to add a log record in the transactional log with
+      //          the MVCCID (see also the LOG_ASSIGNED_MVCCID log record which actually annotates the
+      //          transactional log record of a transaction with the acquired MVCCID that the transaction
+      //          actually never logged to a proper log record)
+      //            - these will be the problematic transactions, that, once they add a log record with the
+      //              missing MVCCID at some point after completion on PTS, will trigger the following assert
+      //        - belonging to transactions that have committed at the time the snapshot was taken
+      //            - these will not pose problems as log records from them - containing the already completed
+      //              mvccid - will not appear anymore in the transactional log
+      // for the short term, this assert will guard against such situations, but a proper solution is needed
+      assert (m_current_trans_status.m_active_mvccs.is_active (mvccid));
+    }
+
   // update current trans status
   m_current_trans_status.m_active_mvccs.set_inactive_mvccid (mvccid);
   m_current_trans_status.m_last_completed_mvccid = mvccid;

--- a/src/transaction/mvcc_table.hpp
+++ b/src/transaction/mvcc_table.hpp
@@ -32,6 +32,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <set>
 
 // forward declarations
 struct log_tdes;
@@ -79,6 +80,7 @@ class mvcctable
     void build_mvcc_info (log_tdes &tdes);
     void complete_mvcc (int tran_index, MVCCID mvccid, bool committed);
     void complete_sub_mvcc (MVCCID mvccid);
+    void complete_mvccids_if_still_active (int tran_index, const std::set<MVCCID> &mvccids, bool committed);
     MVCCID get_new_mvccid ();
     void get_two_new_mvccid (MVCCID &first, MVCCID &second);
     // update next_mvcc_id value with one received from ATS if it's larger than the current one


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-483
http://jira.cubrid.org/browse/LETS-495

Correctly initialize mvcc table on passive transaction server:
- when PTS starts, it receives boot information from the page server (PS)
- this info will contain the LSA of the most recent transaction table snapshot and `log_Gl.hdr.append_lsa` from page server (which is the LSA up to which PS is able to return transactional log pages)
- PTS then proceeds to initialization a valid mvcc table
- it first loads the transactions from the snapshot into the transaction table
- with the information up to this point (the transaction table snapshot point, as it were), it reconstructs a correct MVCC table
- afterwards, it continues by analysing the log up to the point specified by the value of `log_Gl.hdr.append_lsa` received from PS
- while analysing the log, it will maintain MVCC information in the transaction table and, when encountering transaction commits or aborts, it will also complete present mvccid's accordingly
- after finishing log analysis, the MVCC table is in a state consistent to be picked up by the - soon to be started - transactional log replication

Implementation:
- `log_initialize_passive_tran_server`
    - pass `replication_start_redo_lsa` to `log_recovery_analysis_from_trantable_snapshot` to allow `log_recovery_analysis` to know when to stop analysing the log
    - remove call to `logtb_define_trantable_log_latch` which, after log recovery analysis, will incorrectly reset an already initialized transaction table **and** the already initialized MVCC table (TODO: there is a discussion whether, after log recovery/initialization, the transaction table needs to be cleared up or not, but will be dealt with separately)
- `log_recovery_analysis_from_trantable_snapshot`:
    - do `log_recovery_build_mvcc_table_from_trantable` right after constructing the transaction table out of the information in transaction table snapshot; this will provide a basis for log recovery analysis to process log records and maintain&update the MVCC information (see Remark1 below)
    - call `log_recovery_analysis_internal` but request to stop before the LSA at which point log replication will take over
- `log_recovery_build_mvcc_table_from_trantable`: also receives the parameters `replicated_mvcc_next_id` with which, in the absence of any active transactions in the transaction table snapshot (and, consequently, in the recovered transaction table), it will initialize the MVCC table by setting `log_Gl.hdr.mvcc_next_id` and initializing the MVCC table (`log_Gl.mvcc_table.reset_start_mvccid`)
- `log_recovery_analysis_internal`:
    - separated new internal function which takes extra parameters: `reset_mvcc_table` whether to [re]initialize or not the MVCC table; `stop_before_lsa` which - if present - specifies the LSA before which the analysis should stop (this should only be the case for passive transaction server initialization as the same function is used for monolithic server recovery after a crash)
- `mvcctable::complete_mvcc`: added an assert that, mvccid's which are completed during passive transaction server's initialization do not re-appear later during replication (extensive comment in code with details) (see Remark1 below).

Remark1:
`log_recovery_build_mvcc_table_from_trantable` will leave the mvccid table in an inconsistent/unsyched state
  - will be synched after `log_recovery_analysis_internal` is executed
  - while parsing the recovered transaction table, some MVCCIDs will be found which will not be a continuous series
  - these found MVCCIDs will be recorded (left) as active in the MVCC table and will be completed later on (either during log recovery analysis or during the regular replica transaction server log replication)
  - the missing MVCCIDs (the "gaps") will contain MVCCIDs which can be in one of the following states:
    1. they belong to transactions which have already been completed (commited/aborted);
    2. they belong to transactions which have not been already completed; these can be transactions that have reserved an MVCCID but have not yet managed to insert a log record with the MVCCID to the transactional log (for this purpose, see also the case with `LOG_ASSIGNED_MVCCID` log record which, just before concluding a transaction, will insert an artificial log records to the transactional log; this is needed to ensure that **all** MVCCIDs make it from the active transaction server to the replica transaction servers for a correct mvcc table)
  - these missing MVCCIDs will be kept in a collection for completion after `log_recovery_analysis_internal` is executed
  - `log_recovery_analysis_internal` will also process the encountered MVCCID and will complete them according to the log (`LOC_COMMIT`, `LOG_ABORT` log records)
  - after `log_recovery_analysis_internal`, the missing MVCCIDs will be either (corresponding with the 1. and 2. states described above):
    1. completed because the transaction is *considered* as having already been completed in the past (before the point where the transaction snapshot was taken)
    2. ignored, because `log_recovery_analysis_internal` would have already completed the MVCCIDs as part of log records processing
  - the latter happens in function `mvcctable::complete_mvccids_if_still_active`
  - Caveat: the transactions whose MVCCIDs are completed are *considered* as having either commited or aborted in the past (before the time when the transaction table snapshot was taken on the active transaction server) although there is no guaranteed that this has happened; in practice, there can be very long running transactions which might register MVCC log records even after the `log_recovery_analysis_internal` has been executed and the regular log replication daemon is started and processes log records; this issue will be dealt with separately