### PR TITLE
[CBRD-24416] Changing error display settings

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -2797,7 +2797,6 @@ csql (const char *argv0, CSQL_ARGUMENT * csql_arg)
       csql_Error_code = CSQL_ERR_OS_ERROR;
       goto error;
     }
-  er_set_print_property (ER_PRINT_TO_CONSOLE);
 
   /*
    * login and restart database
@@ -2856,6 +2855,7 @@ csql (const char *argv0, CSQL_ARGUMENT * csql_arg)
 	  goto error;
 	}
     }
+  er_set_print_property (ER_PRINT_TO_CONSOLE);
 
   logddl_init ();
   logddl_set_logging_enabled (prm_get_bool_value (PRM_ID_DDL_AUDIT_LOG));


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24416

Purpose
When connecting to the db in csql, the same error message is displayed twice if an incorrect password is entered.
The error message was modified to be displayed only once.

Implementation
N/A

Remarks
N/A
