### PR TITLE
[LETS-484] start pts with more than one data volume

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -206,6 +206,8 @@ struct disk_cache
 
 static DISK_CACHE *disk_Cache = NULL;
 static DKNVOLS disk_Page_server_perm_volume_count = 0;	// used for transaction server with remote storage
+							// must be maintained during replication on
+							// passive transaction server (with remote storage)
 
 static DKNSECTS disk_Temp_max_sects = -2;
 
@@ -1316,6 +1318,15 @@ disk_rv_undo_format (THREAD_ENTRY * thread_p, const LOG_RCV * rcv)
 	  disk_Cache->perm_purpose_info.extend_info.volid_extend = NULL_VOLID;
 	}
 
+      if (is_tran_server_with_remote_storage ())
+	{
+	  // transaction servers with remote storage:
+	  //  - maintain a separate count of permanent volumes
+	  //  - have their own set of temporary volumes which they maintain using the disk Cache structures
+	  assert ((disk_Page_server_perm_volume_count - 1) == disk_Cache->nvols_perm);
+	  disk_Page_server_perm_volume_count--;
+	}
+
       disk_log ("disk_rv_undo_format", "remove volume %d from cache (free = %d, total = %d, max = %d).",
 		volid, free, total, max);
     }
@@ -1393,6 +1404,15 @@ disk_rv_redo_format (THREAD_ENTRY * thread_p, const LOG_RCV * rcv)
 
       disk_Cache->perm_purpose_info.extend_info.nsect_total += volheader->nsect_total;
       disk_Cache->perm_purpose_info.extend_info.nsect_max += volheader->nsect_max;
+
+      if (is_tran_server_with_remote_storage ())
+	{
+	  // transaction servers with remote storage:
+	  //  - maintain a separate count of permanent volumes
+	  //  - have their own set of temporary volumes which they maintain using the disk Cache structures
+	  assert ((disk_Page_server_perm_volume_count + 1) == disk_Cache->nvols_perm);
+	  disk_Page_server_perm_volume_count++;
+	}
     }
 
   /* fix cache... */
@@ -2253,6 +2273,15 @@ disk_add_volume (THREAD_ENTRY * thread_p, DBDEF_VOL_EXT_INFO * extinfo, VOLID * 
   if (extinfo->voltype == DB_PERMANENT_VOLTYPE)
     {
       disk_Cache->nvols_perm++;
+
+      if (is_tran_server_with_remote_storage ())
+	{
+	  // transaction servers with remote storage:
+	  //  - maintain a separate count of permanent volumes
+	  //  - have their own set of temporary volumes which they maintain using the disk Cache structures
+	  assert ((disk_Page_server_perm_volume_count + 1) == disk_Cache->nvols_perm);
+	  disk_Page_server_perm_volume_count++;
+	}
     }
   else
     {
@@ -2315,6 +2344,15 @@ exit:
       else
 	{
 	  disk_Cache->nvols_perm--;
+
+	  if (is_tran_server_with_remote_storage ())
+	    {
+	      // transaction servers with remote storage:
+	      //  - maintain a separate count of permanent volumes
+	      //  - have their own set of temporary volumes which they maintain using the disk Cache structures
+	      assert ((disk_Page_server_perm_volume_count - 1) == disk_Cache->nvols_perm);
+	      disk_Page_server_perm_volume_count--;
+	    }
 	}
     }
 
@@ -5879,7 +5917,20 @@ disk_dump_goodvol_all (THREAD_ENTRY * thread_p, INT16 volid, void *arg)
 STATIC_INLINE bool
 disk_is_valid_volid (VOLID volid)
 {
-  return volid < disk_Cache->nvols_perm || volid > LOG_MAX_DBVOLID - disk_Cache->nvols_temp;
+  // a passive transaction server (which is, implicitly, a transaction server
+  // with remote storage) maintains a separate bookkeeping of permanent data volumes
+  // which is updated when executing corresponding recovery replication functions
+  // as part of the regular replication; this way, it is able to provide a valid
+  // answer via this function
+  const bool is_valid_perm_volid = is_tran_server_with_remote_storage ()?
+    (volid < disk_Page_server_perm_volume_count) : (volid < disk_Cache->nvols_perm);
+  if (is_valid_perm_volid)
+    {
+      return is_valid_perm_volid;
+    }
+
+  // a transaction server with remote storage has its own temporary volumes that it maintains
+  return volid > (LOG_MAX_DBVOLID - disk_Cache->nvols_temp);
 }
 
 /*
@@ -6759,6 +6810,9 @@ disk_set_page_server_perm_volume_count (DKNVOLS nvols)
   // Disk manager is not initialized yet, so save the number to be used later when disk cache is loaded.
   assert (disk_Page_server_perm_volume_count == 0);
   disk_Page_server_perm_volume_count = nvols;
+  // TODO: in a number of places, there are checks that access the disk cache's number of permanent volumes
+  // if this happens on a transaction server with remote storage, the check must be adapted for both
+  // regular and transaction server with remote storage situation
 }
 
 /************************************************************************/


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-484

On transaction server with remote storage, there is a separate bookkeeping of the number of volumes (which are actually created remotely, on the page server) that must be maintained.
On such a server, the check for volume id validity is done against this separate bookkeeping - `disk_is_valid_volid`.
This patch only maintains the separate bookkeeping for active transaction server. For passive transaction server, a separate patch will do the update of the value upon replicating the `RVDK` log records.

[re-merge to testing branch `scalability_dev_demo` manually cherry-picked of an existing approved merge to `scalability_dev`]