### PR TITLE
[CBRD-24382] Fix segfault when target of CALL statement is not a stored procedure/function

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -8929,8 +8929,19 @@ call_stmt
 			PT_NODE *node = $2;
 			if (node)
 			  {
-			    node->info.method_call.call_or_expr = PT_IS_CALL_STMT;
-			    node->info.method_call.to_return_var = $3;
+			    if (node->node_type == PT_METHOD_CALL)
+			      {
+			        node->info.method_call.call_or_expr = PT_IS_CALL_STMT;
+			        node->info.method_call.to_return_var = $3;
+			      }
+			    else
+			      {
+			        // assuming that node is PT_EXPR or PT_FUNCTION
+			        assert (node->node_type == PT_EXPR || node->node_type == PT_FUNCTION);
+
+			        PT_ERRORmf2 (this_parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_IS_NOT_A,
+			          parser_print_tree (this_parser, node), pt_show_misc_type (PT_SP_PROCEDURE));
+			      }
 			  }
 
 			parser_cannot_prepare = true;
@@ -18614,7 +18625,9 @@ generic_function
 
 			PT_NODE *node = NULL;
 			if ($5 == NULL)
-			  node = parser_keyword_func ($1->info.name.original, $3);
+			  {
+			    node = parser_keyword_func ($1->info.name.original, $3);
+			  }
 
 			if (node == NULL)
 			  {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24382

**Motivation**
If CALL stmt is executed with a built-in function, a segmentation fault occurs. Referring to the SQL standard and the CUBRID manual, only a stored procedure can be called in the CALL statement, so an appropriate error should be returned.

**Implementation**
- In parsing, If `generic_function` is not a stored procedure/function, the parsed node type of `call_stmt` is not `PT_METHOD_CALL`. I've set an error in the case.
- For the error message, `MSGCAT_SEMANTIC_IS_NOT_A` is already defined in the parser message catalog. I've used it.

The error shows as follows.
```
csql> CALL TO_DATE('12/25/2008');

In line 1, column 15,

ERROR: before ' ; '
 to_date('12/25/2008') is not a procedure.
```