### PR TITLE
[CBRD-24187] Append undo log record only when it is needed in catalog_drop_representation_helper

### DIFF
--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -1629,18 +1629,24 @@ catalog_drop_representation_helper (THREAD_ENTRY * thread_p, PAGE_PTR page_p, VP
 
   if (overflow_vpid.pageid != NULL_PAGEID)
     {
-      log_append_undo_recdes2 (thread_p, RVCT_UPDATE, &catalog_Id.vfid, page_p, CATALOG_HEADER_SLOT, &record);
+      /* For undo purpose, PEEK a record before update.
+       * Instead of allocating new space (heap or stack) and copying for undo records,
+       * PEEKing a record is simpler and cheaper */
+
+      RECDES undo_record = RECDES_INITIALIZER;
+      spage_get_record (thread_p, page_p, CATALOG_HEADER_SLOT, &undo_record, PEEK);
 
       CATALOG_PUT_PGHEADER_OVFL_PGID_PAGEID (record.data, NULL_PAGEID);
       CATALOG_PUT_PGHEADER_OVFL_PGID_VOLID (record.data, NULL_VOLID);
+
+      log_append_undoredo_recdes2 (thread_p, RVCT_UPDATE, &catalog_Id.vfid, page_p, CATALOG_HEADER_SLOT, &undo_record,
+				   &record);
 
       if (spage_update (thread_p, page_p, CATALOG_HEADER_SLOT, &record) != SP_SUCCESS)
 	{
 	  recdes_free_data_area (&record);
 	  return ER_FAILED;
 	}
-
-      log_append_redo_recdes2 (thread_p, RVCT_UPDATE, &catalog_Id.vfid, page_p, CATALOG_HEADER_SLOT, &record);
 
       // free data because it is used only for peeking below
       recdes_free_data_area (&record);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24187

Purpose

Undo log record for spage_update() is appended whether or not it is needed.
So, it is fixed to add undo log record only when it is needed. 
