### PR TITLE
[LETS-503] add also empty active transactions to the checkpoint snapshot to make use of their potential valid MVCCID

### DIFF
--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -174,7 +174,20 @@ namespace cublog
   checkpoint_info::load_checkpoint_trans (log_tdes &tdes, LOG_LSA &smallest_lsa,
 					  bool &at_least_one_active_transaction_has_valid_mvccid)
   {
-    if (tdes.trid != NULL_TRANID && !tdes.tail_lsa.is_null () && tdes.commit_abort_lsa.is_null ())
+    // - snapshot even transactions that do not have a valid tail LSA (ie: transactions that
+    //    did not add a log record yet);
+    // - this helps cover a scenario for the initialization of a passive transaction server:
+    //    - a passive transaction server needs a consistent MVCC table when it starts
+    //    - an active transaction might request an MVCCID but might not have yet added a log record
+    //      registering that MVCCID (but that MVCCID is in the transaction descriptor already)
+    //    - thus, when initializing a passive transaction server that - still "ghost" - MVCCID (but
+    //      which will appear later in the log records registered by the transaction) will be
+    //      taken into calculation of the MVCC table (see explanation in function
+    //      log_recovery_analysis_from_trantable_snapshot)
+    // - however, this should also be taken into account when using the transaction table snapshot to
+    //    initialize a crashed active transaction server (see recovery_analysis function below)
+    //
+    if (tdes.trid != NULL_TRANID && tdes.commit_abort_lsa.is_null ())
       {
 	m_trans.emplace_back ();
 	tran_info &chkpt_tran = m_trans.back ();
@@ -312,15 +325,35 @@ namespace cublog
   }
 
   void
-  checkpoint_info::recovery_analysis (THREAD_ENTRY *thread_p, log_lsa &start_redo_lsa) const
+  checkpoint_info::recovery_analysis (THREAD_ENTRY *thread_p, log_lsa &start_redo_lsa,
+				      bool recover_empty_transactions) const
   {
-    LOG_TDES *tdes = nullptr;
-
     start_redo_lsa = m_start_redo_lsa;
 
     /* Add the transactions to the transaction table */
     for (const auto &chkpt : m_trans)
       {
+	// if tail LSA is missing, the transaction is present in the transaction table
+	// but did not yet got to adding a log record; we either need to recover these
+	// transaction or not:
+	//  - on a passive transaction server, we need these transactions because they might contain
+	//    valid MVCCID's already registered with them which are used in constructing a consistent
+	//    MVCC table
+	//  - on an active transaction server, upon recovery, these transactions offer no useful
+	//    information, and can thus be sckipped
+	if (chkpt.tail_lsa.is_null ())
+	  {
+	    if (recover_empty_transactions)
+	      {
+		// fall through to recover/register empty transactions
+	      }
+	    else
+	      {
+		// do not recover/register empty transaction
+		continue;
+	      }
+	  }
+
 	/*
 	 * If this is the first time, the transaction is seen. Assign a
 	 * new index to describe it and assume that the transaction was
@@ -328,7 +361,7 @@ namespace cublog
 	 * unilaterally aborted. The truth of this statement will be find
 	 * reading the rest of the log
 	 */
-	tdes = logtb_rv_find_allocate_tran_index (thread_p, chkpt.trid, &NULL_LSA);
+	LOG_TDES *const tdes = logtb_rv_find_allocate_tran_index (thread_p, chkpt.trid, &NULL_LSA);
 	if (tdes == NULL)
 	  {
 	    logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_recovery_analysis");
@@ -377,7 +410,7 @@ namespace cublog
 
     for (const auto &sysop : m_sysops)
       {
-	tdes = logtb_rv_find_allocate_tran_index (thread_p, sysop.trid, &NULL_LSA);
+	LOG_TDES *const tdes = logtb_rv_find_allocate_tran_index (thread_p, sysop.trid, &NULL_LSA);
 	if (tdes == NULL)
 	  {
 	    logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_recovery_analysis");

--- a/src/transaction/log_checkpoint_info.hpp
+++ b/src/transaction/log_checkpoint_info.hpp
@@ -61,7 +61,8 @@ namespace cublog
       void load_trantable_snapshot (THREAD_ENTRY *thread_p, LOG_LSA &smallest_lsa);
 
       // restore transaction table based on checkpoint info
-      void recovery_analysis (THREAD_ENTRY *thread_p, log_lsa &start_redo_lsa) const;
+      void recovery_analysis (THREAD_ENTRY *thread_p, log_lsa &start_redo_lsa,
+			      bool recover_empty_transactions) const;
       // if m_has_2pc, also do 2pc analysis
       void recovery_2pc_analysis (THREAD_ENTRY *thread_p) const;
 

--- a/src/transaction/log_checkpoint_info.hpp
+++ b/src/transaction/log_checkpoint_info.hpp
@@ -62,7 +62,7 @@ namespace cublog
 
       // restore transaction table based on checkpoint info
       void recovery_analysis (THREAD_ENTRY *thread_p, log_lsa &start_redo_lsa,
-			      bool recover_empty_transactions) const;
+			      bool skip_empty_transactions) const;
       // if m_has_2pc, also do 2pc analysis
       void recovery_2pc_analysis (THREAD_ENTRY *thread_p) const;
 

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -430,7 +430,8 @@ log_recovery_analysis_internal (THREAD_ENTRY *thread_p, INT64 *num_redo_log_reco
 	  // The transaction table snapshot was taken before the next log record was logged.
 	  // Rebuild the transaction table image based on checkpoint information
 	  LOG_LSA start_redo_lsa = NULL_LSA;
-	  chkpt_infop->recovery_analysis (thread_p, start_redo_lsa);
+	  const bool recover_empty_transactions = is_passive_transaction_server ();
+	  chkpt_infop->recovery_analysis (thread_p, start_redo_lsa, recover_empty_transactions);
 	  assert (is_tran_server_with_remote_storage () || !start_redo_lsa.is_null ());
 	  context.set_start_redo_lsa (start_redo_lsa);
 	}
@@ -2480,7 +2481,7 @@ log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY *thread_p,
     }
 
   log_lsa start_redo_lsa;
-  chkpt_info.recovery_analysis (thread_p, start_redo_lsa);
+  chkpt_info.recovery_analysis (thread_p, start_redo_lsa, true);
 
   log_recovery_context log_rcv_context;
   // log recovery analysis must actually start at the log record following the snapshot LSA, but, since

--- a/src/transaction/log_recovery_analysis.cpp
+++ b/src/transaction/log_recovery_analysis.cpp
@@ -430,8 +430,8 @@ log_recovery_analysis_internal (THREAD_ENTRY *thread_p, INT64 *num_redo_log_reco
 	  // The transaction table snapshot was taken before the next log record was logged.
 	  // Rebuild the transaction table image based on checkpoint information
 	  LOG_LSA start_redo_lsa = NULL_LSA;
-	  const bool recover_empty_transactions = is_passive_transaction_server ();
-	  chkpt_infop->recovery_analysis (thread_p, start_redo_lsa, recover_empty_transactions);
+	  const bool skip_empty_transactions = !is_passive_transaction_server ();
+	  chkpt_infop->recovery_analysis (thread_p, start_redo_lsa, skip_empty_transactions);
 	  assert (is_tran_server_with_remote_storage () || !start_redo_lsa.is_null ());
 	  context.set_start_redo_lsa (start_redo_lsa);
 	}
@@ -2481,7 +2481,8 @@ log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY *thread_p,
     }
 
   log_lsa start_redo_lsa;
-  chkpt_info.recovery_analysis (thread_p, start_redo_lsa, true);
+  constexpr bool skip_empty_transactions = false;
+  chkpt_info.recovery_analysis (thread_p, start_redo_lsa, skip_empty_transactions);
 
   log_recovery_context log_rcv_context;
   // log recovery analysis must actually start at the log record following the snapshot LSA, but, since


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-503

- add to the transaction table checkpoint even transactions that do not yet have a valid tail_lsa (ie: the have not yet added a log record to the transactional log);
- such a transaction may already have a valid MVCCID reserved which is needed to be able to correctly cosntruct a MVCC table when initializing PTS;
- adapt recovery in case of something else than passive transaction server; adapt unit test
- adapt unit tests.