### PR TITLE
[LETS-507] reset all mvccids in the transaction table after analysis

### DIFF
--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1111,6 +1111,7 @@ extern void logtb_free_tran_index_with_undo_lsa (THREAD_ENTRY * thread_p, const 
 extern void logtb_initialize_tdes (LOG_TDES * tdes, int tran_index);
 extern void logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
 extern void logtb_finalize_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
+extern void logtb_clear_all_tran_mvccids ();
 extern int logtb_get_new_tran_id (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
 extern int logtb_find_tran_index (THREAD_ENTRY * thread_p, TRANID trid);
 #if defined (ENABLE_UNUSED_FUNCTION)

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1482,6 +1482,25 @@ logtb_free_tran_mvcc_info (LOG_TDES * tdes)
 }
 
 /*
+ * logtb_free_all_tran_mvcc_id - free mvccid for all transactions in the table that have one
+ *
+ * return: nothing
+ */
+void
+logtb_clear_all_tran_mvccids ()
+{
+  static_assert (LOG_SYSTEM_TRAN_INDEX == 0, "");
+  for (int tr_idx = LOG_SYSTEM_TRAN_INDEX + 1; tr_idx < log_Gl.trantable.num_total_indices; ++tr_idx)
+    {
+      log_tdes *const tdes = log_Gl.trantable.all_tdes[tr_idx];
+      if (tdes != nullptr && MVCCID_IS_VALID (tdes->mvccinfo.id))
+	{
+	  tdes->mvccinfo.id = MVCCID_NULL;
+	}
+    }
+}
+
+/*
  * logtb_clear_tdes - clear the transaction descriptor
  *
  * return: nothing..


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-507

During analysis, the mvccids are loaded from log records into the created transaction descriptors.
These mvccids are needed for the specific needs of initializing a passive transaction server (see function `log_recovery_analysis_from_trantable_snapshot`) with the final purpose of constructing a valid&up-to-date MVCC table (see function `log_recovery_build_mvcc_table_from_trantable`).
As a side effect, this also happens in all other cases, where that MVCCID is not needed (eg: recovery of  monolithic server). When analysis finishes, some of those transactions - those that have not yet committed and will be aborted anyway - still have those valid mvccids set. When such transactions descriptors will be cleaned, there is a sanity-check that the mvccid must be null.
Since the mvccid is only needed for the analysis step of the passive transaction server, for all other cases we clean-up those mvccids after the analysis step, before redo.

This is a fix for a regression introduced in tests pertaining to the monolithic server.

Add a new function to do this clean-up and call it after the `log_recovery_analysis` call.

