### PR TITLE
[CBRD-24464] CREATE SERVER must be done before ADD QUERY to the view.

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1095,6 +1095,11 @@ extract_classes (extract_context & ctxt, print_output & schema_output_ctx)
       err_count++;
     }
 
+  if (export_server (schema_output_ctx) < 0)
+    {
+      err_count++;
+    }
+
   ctxt.has_indexes = emit_schema (schema_output_ctx, ctxt.classes, ctxt.do_auth, &ctxt.vclass_list_has_using_index,
 				  ctxt.storage_order);
   if (er_errid () != NO_ERROR)
@@ -1103,11 +1108,6 @@ extract_classes (extract_context & ctxt, print_output & schema_output_ctx)
     }
 
   if (emit_foreign_key (schema_output_ctx, ctxt.classes) != NO_ERROR)
-    {
-      err_count++;
-    }
-
-  if (export_server (schema_output_ctx) < 0)
     {
       err_count++;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24464

When using dblink in a view, an error occurs if the SERVER is not created. In AS-IS, ADD QUERY to a view is done before CREATE SERVER. So, the order is changed so that CREATE SERVER is done before ADD QUERY to the view.