### PR TITLE
[CBRD-24248] Support NEED_COUNT_ONLY optimization for JOIN

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7883,7 +7883,7 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 	      if (specp->next == NULL && specp->access == ACCESS_METHOD_INDEX
 		  && specp->s.cls_node.cls_regu_list_pred == NULL && specp->where_pred == NULL
 		  && !specp->indexptr->use_iss && !SCAN_IS_INDEX_MRO (&specp->s_id.s.isid)
-		  && !xptr->if_pred	/* no if predicates */)
+		  && !xptr->if_pred /* no if predicates */ )
 		{
 		  /* there are two optimization for query having count() only
 		   * 1. Skip saving data to temporary files.

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7864,7 +7864,6 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 	  /* check only one count(*) function
 	   * TO_DO : this routine can be moved to XASL generator */
 	  if (!xasl->fptr_list	/* no path expressions */
-	      && !xasl->if_pred	/* no if predicates */
 	      && !xasl->instnum_pred	/* no instnum predicate */
 	      && agg_ptr->next == NULL	/* no other aggregate functions */
 	      && agg_ptr->function == PT_COUNT_STAR)
@@ -7883,7 +7882,8 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 	      /* count(*) query will scan an index but does not have a data-filter */
 	      if (specp->next == NULL && specp->access == ACCESS_METHOD_INDEX
 		  && specp->s.cls_node.cls_regu_list_pred == NULL && specp->where_pred == NULL
-		  && !specp->indexptr->use_iss && !SCAN_IS_INDEX_MRO (&specp->s_id.s.isid))
+		  && !specp->indexptr->use_iss && !SCAN_IS_INDEX_MRO (&specp->s_id.s.isid)
+		  && !xptr->if_pred	/* no if predicates */)
 		{
 		  /* there are two optimization for query having count() only
 		   * 1. Skip saving data to temporary files.

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7958,8 +7958,10 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 
 	  if (count_star_with_iscan_opt)
 	    {
+	      /* count only query without join can skip iteration for index keys */
+	      xasl->curr_spec->s_id.position = S_BEFORE;
 	      xasl->proc.buildvalue.agg_list->accumulator.curr_cnt += (&xasl->curr_spec->s_id)->s.isid.oids_count;
-	      /* may have more scan ranges */
+	      /* may have more OIDs */
 	      continue;
 	    }
 	  /* set scan item as qualified */

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7861,22 +7861,38 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 	    }
 
 	  agg_ptr = buildvalue->agg_list;
-	  if (!xasl->scan_ptr	/* no scan procedure */
-	      && !xasl->fptr_list	/* no path expressions */
+	  /* check only one count(*) function
+	   * TO_DO : this routine can be moved to XASL generator */
+	  if (!xasl->fptr_list	/* no path expressions */
 	      && !xasl->if_pred	/* no if predicates */
 	      && !xasl->instnum_pred	/* no instnum predicate */
 	      && agg_ptr->next == NULL	/* no other aggregate functions */
 	      && agg_ptr->function == PT_COUNT_STAR)
 	    {
-	      /* only one count(*) function */
-	      ACCESS_SPEC_TYPE *specp = xasl->spec_list;
+	      ACCESS_SPEC_TYPE *specp;
+	      bool is_scan_ptr = xasl->scan_ptr ? true : false;
+	      /* get last scan_ptr */
+	      xptr = xasl;
+	      while (xptr->scan_ptr)
+		{
+		  xptr = xptr->scan_ptr;
+		}
+	      specp = xptr->spec_list;
+	      assert (specp);
+
+	      /* count(*) query will scan an index but does not have a data-filter */
 	      if (specp->next == NULL && specp->access == ACCESS_METHOD_INDEX
 		  && specp->s.cls_node.cls_regu_list_pred == NULL && specp->where_pred == NULL
 		  && !specp->indexptr->use_iss && !SCAN_IS_INDEX_MRO (&specp->s_id.s.isid))
 		{
-		  /* count(*) query will scan an index but does not have a data-filter */
+		  /* there are two optimization for query having count() only
+		   * 1. Skip saving data to temporary files.
+		   * 2. Skip iteration for each index keys (no scan ptr only) */
 		  specp->s_id.s.isid.need_count_only = true;
-		  count_star_with_iscan_opt = true;
+		  if (!is_scan_ptr)
+		    {
+		      count_star_with_iscan_opt = true;
+		    }
 		}
 	    }
 	}

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5812,14 +5812,13 @@ scan_next_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 		  return ret;
 		}
 
+	      scan_id->position = S_ON;
+	      isidp->curr_oidno = 0;	/* first oid number */
 	      if (isidp->need_count_only == true)
 		{
 		  /* no more scan is needed. just return */
 		  return S_SUCCESS;
 		}
-
-	      scan_id->position = S_ON;
-	      isidp->curr_oidno = 0;	/* first oid number */
 
 	      if (SCAN_IS_INDEX_COVERED (isidp))
 		{
@@ -5857,6 +5856,12 @@ scan_next_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	      if (isidp->curr_oidno < oids_cnt - 1)
 		{
 		  isidp->curr_oidno++;
+		  if (isidp->need_count_only == true)
+		    {
+		      /* no more scan is needed. just return */
+		      return S_SUCCESS;
+		    }
+
 		  if (!SCAN_IS_INDEX_COVERED (isidp))
 		    {
 		      if (isidp->multi_range_opt.use)
@@ -5927,13 +5932,13 @@ scan_next_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 			  return ret;
 			}
 
+		      isidp->curr_oidno = 0;	/* first oid number */
 		      if (isidp->need_count_only == true)
 			{
 			  /* no more scan is needed. just return */
 			  return S_SUCCESS;
 			}
 
-		      isidp->curr_oidno = 0;	/* first oid number */
 		      if (SCAN_IS_INDEX_COVERED (isidp))
 			{
 			  qfile_close_list (thread_p, isidp->indx_cov.list_id);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24248

There are two optimization for query having count() only without join.
- Skip saving data to temporary files.
- Skip iteration for each index keys.

Add below optimization for query having count() only with join.
- Skip saving data to temporary files.
