### PR TITLE
[CBRD-24465] Replace empty databases.txt to databases.txt.sample

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1301,7 +1301,7 @@ if(USE_CUBRID_ENV)
     ${CMAKE_SOURCE_DIR}/contrib/readme/README_TAR_INSTALL
     DESTINATION ${CUBRID_PREFIXDIR})
   install(FILES
-    ${CMAKE_SOURCE_DIR}/contrib/readme/databases.txt
+    ${CMAKE_SOURCE_DIR}/contrib/readme/databases.txt.sample
     DESTINATION ${CUBRID_DATABASES})
   install(FILES
     ${CMAKE_SOURCE_DIR}/contrib/readme/README_SOCK.txt

--- a/contrib/readme/databases.txt.sample
+++ b/contrib/readme/databases.txt.sample
@@ -1,0 +1,4 @@
+# sample databases.txt for demodb
+#
+# db-name vol-path db-host log-path lob-base-path
+demodb /home/cubrid/CUBRID/demo localhost /home/cubrid/CUBRID/demo file:/home/cubrid/CUBRID/demo/lob


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24465

**Purpose**
* do not change databases.txt in the CUBRID standard distribution package,  this is because it interferes the activity in development/testing.
  * remove current empty databases/databases.txt in the CUBRID distribution
  * add database/databases.txt.sample

**Implementation**
N/A

**Remarks**
