### PR TITLE
[CBRD-24382] Fix segfault when target of CALL statement is not a stored procedure/function (#3770)

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -8924,8 +8924,19 @@ call_stmt
 			PT_NODE *node = $2;
 			if (node)
 			  {
-			    node->info.method_call.call_or_expr = PT_IS_CALL_STMT;
-			    node->info.method_call.to_return_var = $3;
+			    if (node->node_type == PT_METHOD_CALL)
+			      {
+			        node->info.method_call.call_or_expr = PT_IS_CALL_STMT;
+			        node->info.method_call.to_return_var = $3;
+			      }
+			    else
+			      {
+			        // assuming that node is PT_EXPR or PT_FUNCTION
+			        assert (node->node_type == PT_EXPR || node->node_type == PT_FUNCTION);
+
+			        PT_ERRORmf2 (this_parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_IS_NOT_A,
+			          parser_print_tree (this_parser, node), pt_show_misc_type (PT_SP_PROCEDURE));
+			      }
 			  }
 
 			parser_cannot_prepare = true;
@@ -18609,7 +18620,9 @@ generic_function
 
 			PT_NODE *node = NULL;
 			if ($5 == NULL)
-			  node = parser_keyword_func ($1->info.name.original, $3);
+			  {
+			    node = parser_keyword_func ($1->info.name.original, $3);
+			  }
 
 			if (node == NULL)
 			  {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24382

backport #3770