### PR TITLE
[CBRD-24467] Sort-limit optimization does not work when host variable is used in limit clause.

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -24481,7 +24481,7 @@ qexec_get_orderbynum_upper_bound (THREAD_ENTRY * thread_p, PRED_EXPR * pred, VAL
       op = pred->pe.m_eval_term.et.et_comp.rel_op;
       if (lhs->type != TYPE_CONSTANT)
 	{
-	  if (lhs->type != TYPE_POS_VALUE && lhs->type != TYPE_DBVAL)
+	  if (lhs->type != TYPE_POS_VALUE && lhs->type != TYPE_DBVAL && lhs->type != TYPE_INARITH)
 	    {
 	      goto cleanup;
 	    }
@@ -24512,7 +24512,7 @@ qexec_get_orderbynum_upper_bound (THREAD_ENTRY * thread_p, PRED_EXPR * pred, VAL
 	      goto cleanup;
 	    }
 	}
-      if (rhs->type != TYPE_POS_VALUE && rhs->type != TYPE_DBVAL)
+      if (rhs->type != TYPE_POS_VALUE && rhs->type != TYPE_DBVAL && rhs->type != TYPE_INARITH)
 	{
 	  goto cleanup;
 	}

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1015,7 +1015,7 @@ xqmgr_prepare_query (THREAD_ENTRY * thread_p, COMPILE_CONTEXT * context, xasl_st
 	      if (stream->buffer == NULL && stream->xasl_header != NULL)
 		{
 		  /* also header was requested. */
-		  qfile_load_xasl_node_header (thread_p, stream->buffer, stream->xasl_header);
+		  qfile_load_xasl_node_header (thread_p, cache_entry_p->stream.buffer, stream->xasl_header);
 		}
 	      xcache_unfix (thread_p, cache_entry_p);
 	      goto exit_on_end;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24467

A problem occurred when the XASL header that stores the sort-limit optimization status was not properly fetched. 
I fixed it (xqmgr_prepare_query)

A problem occurs because TYPE_INARITH is excluded when checking whether ntopsort(IMS) optimization is possible.
An arithmetic expression was added to the limit clause, but it seems that the related routine has not been modified together.
(qexec_get_orderbynum_upper_bound)
