### PR TITLE
[CBRD-24468] Allows loading even if the user name and the table name are separated in the object file.

### DIFF
--- a/src/loaddb/load_grammar.yy
+++ b/src/loaddb/load_grammar.yy
@@ -141,6 +141,7 @@ namespace cubload
 %token <string> SQS_String_Body
 %token <string> DQS_String_Body
 %token COMMA
+%token DOT
 
 %type <int_val> attribute_list_type
 %type <cmd_spec> class_command_spec
@@ -249,15 +250,39 @@ command_line :
   ;
 
 id_command :
+  CMD_ID IDENTIFIER DOT IDENTIFIER INT_LIT
+  {
+    DBG_PRINT ("CMD_ID IDENTIFIER DOT IDENTIFIER INT_LIT");
+    std::string name;
+    name.reserve($2->size + sizeof (".") + $4->size);
+    name.append ($2->val).append (".").append ($4->val);
+    m_driver.get_class_installer ().check_class (name.c_str (), atoi ($5->val));
+  }
+  |
   CMD_ID IDENTIFIER INT_LIT
   {
+    DBG_PRINT ("CMD_ID IDENTIFIER INT_LIT");
     m_driver.get_class_installer ().check_class ($2->val, atoi ($3->val));
   }
   ;
 
 class_command :
+  CMD_CLASS IDENTIFIER DOT IDENTIFIER class_command_spec
+  {
+    DBG_PRINT ("CMD_CLASS IDENTIFIER DOT IDENTIFIER class_command_spec");
+    std::string name;
+    name.reserve($2->size + sizeof (".") + $4->size);
+    name.append ($2->val).append (".").append ($4->val);
+    string_type name_buf (const_cast<char *> (name.c_str ()), name.size (), false);
+    m_driver.get_class_installer ().install_class (&name_buf, $5);
+
+    delete $5;
+    $5 = NULL;
+  }
+  |
   CMD_CLASS IDENTIFIER class_command_spec
   {
+    DBG_PRINT ("CMD_CLASS IDENTIFIER class_command_spec");
     m_driver.get_class_installer ().install_class ($2, $3);
 
     delete $3;

--- a/src/loaddb/load_lexer.l
+++ b/src/loaddb/load_lexer.l
@@ -478,6 +478,11 @@ using token = cubload::parser::token;
     return token::COMMA;
 }
 
+"." {
+    PRINT ("DOT %s\n", yytext);
+    return token::DOT;
+}
+
 \/\/[^\r\n]*\r?\n {
     /* C++ comments */
 }

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -4878,12 +4878,12 @@ ldr_finish_context (LDR_CONTEXT *context)
   /* Reset the action function to deal with attributes */
   ldr_act = ldr_act_attr;
 
-#if defined(CUBRID_DEBUG)
-  if ((err == NO_ERROR) && (envvar_get ("LOADER_DEBUG") != NULL))
+#if defined(CUBRID_DEBUG) || defined(CUBRID_DEBUG_TEST)
+  if (err == NO_ERROR)
     {
       if (context->inst_total)
 	{
-	  printf ("%d %s %s inserted in %d %s\n", context->inst_total, ldr_class_name (context),
+	  printf ("%ld %s %s inserted in %d %s\n", context->inst_total, ldr_class_name (context),
 		  context->inst_total == 1 ? "instance" : "instances", context->flush_total,
 		  context->flush_total == 1 ? "flush" : "flushes");
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24468

Allows loading even if the user name and the table name are separated in the object file.
```
%id [user_name].[class_name] <class_id>
%class [user_name].[class_name] ([attribute_name])
```