### PR TITLE
[LETS-519] pass parameter by address to scope_exit

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -21107,7 +21107,7 @@ heap_delete_relocation (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * contex
 
   // *INDENT-OFF*
   // To ensure that, if started, the atomic replication area will also end.
-  scope_exit <std::function<void (void)>> log_on_exit ([&thread_p, atomic_replication_flag]()
+  scope_exit <std::function<void (void)>> log_on_exit ([&thread_p, &atomic_replication_flag]()
   {
     if (atomic_replication_flag == true)
      {
@@ -21634,7 +21634,7 @@ heap_delete_home (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, boo
 
   // *INDENT-OFF*
   // To ensure that, if started, the atomic replication area will also end.
-  scope_exit <std::function<void (void)>> log_on_exit ([&thread_p, atomic_replication_flag]()
+  scope_exit <std::function<void (void)>> log_on_exit ([&thread_p, &atomic_replication_flag]()
   {
     if (atomic_replication_flag == true)
      {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-519

`scope_exit` lambda must capture all its ctor params as pointers or by address to work correctly because they change after `scope_exit` lambda is instantiated