### PR TITLE
[CBRD-24378] Fix the restoredb not to go beyond the given time (-d)

### DIFF
--- a/src/transaction/log_2pc.c
+++ b/src/transaction/log_2pc.c
@@ -2289,6 +2289,7 @@ log_2pc_recovery_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE record_ty
     case LOG_COMPENSATE:
     case LOG_RUN_POSTPONE:
     case LOG_COMMIT_WITH_POSTPONE:
+    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
     case LOG_2PC_COMMIT_DECISION:
     case LOG_2PC_ABORT_DECISION:
     case LOG_2PC_COMMIT_INFORM_PARTICPS:

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1170,9 +1170,9 @@ enum log_rectype
   LOG_CLIENT_USER_POSTPONE_DATA = 11,	/* Obsolete */
   LOG_RUN_NEXT_CLIENT_UNDO = 12,	/* Obsolete */
   LOG_RUN_NEXT_CLIENT_POSTPONE = 13,	/* Obsolete */
-  LOG_WILL_COMMIT = 14,		/* Obsolete */
 #endif
-  LOG_COMMIT_WITH_POSTPONE = 15,	/* Committing server postpone operations */
+  LOG_COMMIT_WITH_POSTPONE = 14,	/* Transaction will be committed */
+  LOG_COMMIT_WITH_POSTPONE_OBSOLETE = 15,	/* Obsolete. It was LOG_COMMIT_WITH_POSTPONE without the donetime. It remains only for the backward compatibility and will be removed with the next major release, maybe 12.0 */
 #if 0
   LOG_COMMIT_WITH_CLIENT_USER_LOOSE_ENDS = 16,	/* Obsolete */
 #endif
@@ -1430,6 +1430,14 @@ struct log_rec_compensate
 /* This entry is included during commit */
 typedef struct log_rec_start_postpone LOG_REC_START_POSTPONE;
 struct log_rec_start_postpone
+{
+  LOG_LSA posp_lsa;
+  INT64 at_time;		/* donetime. For the time-specific recovery */
+};
+
+/* This entry is included during commit. Obsolete. See the comment of LOG_COMMIT_WITH_POSTPONE_OBSOLETE. */
+typedef struct log_rec_start_postpone_obsolete LOG_REC_START_POSTPONE_OBSOLETE;
+struct log_rec_start_postpone_obsolete
 {
   LOG_LSA posp_lsa;
 };

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -223,6 +223,8 @@ static bool log_can_skip_undo_logging (THREAD_ENTRY * thread_p, LOG_RCVINDEX rcv
 				       LOG_DATA_ADDR * addr);
 static bool log_can_skip_redo_logging (LOG_RCVINDEX rcvindex, const LOG_TDES * ignore_tdes, LOG_DATA_ADDR * addr);
 static void log_append_commit_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postpone_lsa);
+static void log_append_commit_postpone_obsolete (THREAD_ENTRY * thread_p, LOG_TDES * tdes,
+						 LOG_LSA * start_postpone_lsa);
 static void log_append_sysop_start_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes,
 					     LOG_REC_SYSOP_START_POSTPONE * sysop_start_postpone, int data_size,
 					     const char *data);
@@ -387,6 +389,9 @@ log_to_string (LOG_RECTYPE type)
 
     case LOG_COMMIT_WITH_POSTPONE:
       return "LOG_COMMIT_WITH_POSTPONE";
+
+    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
+      return "LOG_COMMIT_WITH_POSTPONE_OBSOLETE";
 
     case LOG_COMMIT:
       return "LOG_COMMIT";
@@ -4411,6 +4416,44 @@ log_append_commit_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * 
 
   start_posp = (LOG_REC_START_POSTPONE *) node->data_header;
   LSA_COPY (&start_posp->posp_lsa, start_postpone_lsa);
+  start_posp->at_time = time (NULL);
+
+  start_lsa = prior_lsa_next_record (thread_p, node, tdes);
+
+  tdes->state = TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE;
+
+  logpb_flush_pages (thread_p, &start_lsa);
+}
+
+/*
+ * log_append_commit_postpone_obsolete - APPEND COMMIT WITH POSTPONE
+ *
+ * return: nothing
+ *
+ *   tdes(in/out): State structure of transaction being committed
+ *   start_posplsa(in): Address where the first postpone log record start
+ *
+ * NOTE: The transaction is declared as committed with postpone actions.
+ *       The transaction is not fully committed until all postpone actions are executed.
+ *
+ *       The postpone operations are not invoked by this function.
+ */
+static void
+log_append_commit_postpone_obsolete (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postpone_lsa)
+{
+  LOG_REC_START_POSTPONE_OBSOLETE *start_posp;	/* Start postpone actions */
+  LOG_PRIOR_NODE *node;
+  LOG_LSA start_lsa;
+
+  node =
+    prior_lsa_alloc_and_copy_data (thread_p, LOG_COMMIT_WITH_POSTPONE_OBSOLETE, RV_NOT_DEFINED, NULL, 0, NULL, 0, NULL);
+  if (node == NULL)
+    {
+      return;
+    }
+
+  start_posp = (LOG_REC_START_POSTPONE_OBSOLETE *) node->data_header;
+  LSA_COPY (&start_posp->posp_lsa, start_postpone_lsa);
 
   start_lsa = prior_lsa_next_record (thread_p, node, tdes);
 
@@ -5277,8 +5320,8 @@ log_clear_lob_locator_list (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool at_co
 									 "LOB_TRANSIENT_DELETED"
 									 : ((entry->top->state ==
 									     LOB_PERMANENT_CREATED) ?
-									    "LOB_PERMANENT_CREATED" : (entry->top->
-												       state ==
+									    "LOB_PERMANENT_CREATED" : (entry->
+												       top->state ==
 												       LOB_PERMANENT_DELETED)
 									    ? "LOB_PERMANENT_DELETED" : "LOB_UNKNOWN")),
 		    entry->top->savept_lsa.pageid, entry->top->savept_lsa.offset);
@@ -6842,10 +6885,31 @@ static LOG_PAGE *
 log_dump_record_commit_postpone (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa, LOG_PAGE * log_page_p)
 {
   LOG_REC_START_POSTPONE *start_posp;
+  LOG_REC_DONETIME *donetime;
+  time_t tmp_time;
+  char time_val[CTIME_MAX];
 
   /* Read the DATA HEADER */
   LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*start_posp), log_lsa, log_page_p);
   start_posp = (LOG_REC_START_POSTPONE *) ((char *) log_page_p->area + log_lsa->offset);
+  tmp_time = (time_t) start_posp->at_time;
+  (void) ctime_r (&tmp_time, time_val);
+  fprintf (out_fp, ", First postpone record at before or after Page = %lld and offset = %d\n",
+	   LSA_AS_ARGS (&start_posp->posp_lsa));
+  fprintf (out_fp, "     Transaction finish time at = %s\n", time_val);
+
+  return log_page_p;
+}
+
+static LOG_PAGE *
+log_dump_record_commit_postpone_obsolete (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa,
+					  LOG_PAGE * log_page_p)
+{
+  LOG_REC_START_POSTPONE_OBSOLETE *start_posp;
+
+  /* Read the DATA HEADER */
+  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*start_posp), log_lsa, log_page_p);
+  start_posp = (LOG_REC_START_POSTPONE_OBSOLETE *) ((char *) log_page_p->area + log_lsa->offset);
   fprintf (out_fp, ", First postpone record at before or after Page = %lld and offset = %d\n",
 	   (long long int) start_posp->posp_lsa.pageid, start_posp->posp_lsa.offset);
 
@@ -7251,6 +7315,10 @@ log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type
 
     case LOG_COMMIT_WITH_POSTPONE:
       log_page_p = log_dump_record_commit_postpone (thread_p, out_fp, log_lsa, log_page_p);
+      break;
+
+    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
+      log_page_p = log_dump_record_commit_postpone_obsolete (thread_p, out_fp, log_lsa, log_page_p);
       break;
 
     case LOG_COMMIT:
@@ -8229,6 +8297,7 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
 
 	    case LOG_RUN_POSTPONE:
 	    case LOG_COMMIT_WITH_POSTPONE:
+	    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
 	    case LOG_SYSOP_START_POSTPONE:
 	      /* Undo of run postpone system operation. End here. */
 	      assert (!LOG_ISRESTARTED ());
@@ -8662,6 +8731,7 @@ log_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postp
 		      break;
 
 		    case LOG_COMMIT_WITH_POSTPONE:
+		    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
 		    case LOG_SYSOP_START_POSTPONE:
 		    case LOG_2PC_PREPARE:
 		    case LOG_2PC_START:

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3362,6 +3362,10 @@ prior_lsa_gen_record (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * node, LOG_RECTYP
       node->data_header_length = sizeof (LOG_REC_START_POSTPONE);
       break;
 
+    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
+      node->data_header_length = sizeof (LOG_REC_START_POSTPONE_OBSOLETE);
+      break;
+
     case LOG_SYSOP_START_POSTPONE:
       node->data_header_length = sizeof (LOG_REC_SYSOP_START_POSTPONE);
       break;
@@ -3496,6 +3500,7 @@ prior_lsa_alloc_and_copy_data (THREAD_ENTRY * thread_p, LOG_RECTYPE rec_type, LO
     case LOG_2PC_COMMIT_DECISION:
     case TRAN_UNACTIVE_2PC_ABORT_DECISION:
     case LOG_COMMIT_WITH_POSTPONE:
+    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
     case LOG_SYSOP_START_POSTPONE:
     case LOG_COMMIT:
     case LOG_ABORT:
@@ -3768,7 +3773,8 @@ prior_lsa_next_record_internal (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * node, 
 	  LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
 	}
     }
-  else if (node->log_header.type == LOG_COMMIT_WITH_POSTPONE)
+  else if (node->log_header.type == LOG_COMMIT_WITH_POSTPONE
+	   || node->log_header.type == LOG_COMMIT_WITH_POSTPONE_OBSOLETE)
     {
       /* we need the commit with postpone LSA for recovery. we have to save it under prior_lsa_mutex protection */
       tdes->rcv.tran_start_postpone_lsa = start_lsa;

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1194,7 +1194,7 @@ log_rv_analysis_commit_with_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_
 	   * holding a page.
 	   */
 	  log_lsa->pageid = NULL_PAGEID;
-	  log_recovery_resetlog (thread_p, &record_header_lsa, prev_lsa);
+	  log_recovery_resetlog (thread_p, &record_header_lsa, false, prev_lsa);
 	  *did_incom_recovery = true;
 	}
     }

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -70,7 +70,10 @@ static int log_rv_analysis_run_postpone (THREAD_ENTRY * thread_p, int tran_id, L
 					 LOG_LSA * check_point);
 static int log_rv_analysis_compensate (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa, LOG_PAGE * log_page_p);
 static int log_rv_analysis_commit_with_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa,
-						 LOG_PAGE * log_page_p);
+						 LOG_PAGE * log_page_p, LOG_LSA * prev_lsa, bool is_media_crash,
+						 time_t * stop_at, bool * did_incom_recovery);
+static int log_rv_analysis_commit_with_postpone_obsolete (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa,
+							  LOG_PAGE * log_page_p);
 static int log_rv_analysis_sysop_start_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa,
 						 LOG_PAGE * log_page_p);
 static int log_rv_analysis_atomic_sysop_start (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa);
@@ -1131,16 +1134,25 @@ log_rv_analysis_compensate (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_
  * return: error code
  *
  *   tran_id(in):
- *   lsa(in/out):
+ *   log_lsa(in/out):
  *   log_page_p(in/out):
+ *   lsa(in/out):
+ *   is_media_crash(in):
+ *   stop_at(in):
+ *   did_incom_recovery(in/out):
  *
  * Note:
  */
 static int
-log_rv_analysis_commit_with_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa, LOG_PAGE * log_page_p)
+log_rv_analysis_commit_with_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa, LOG_PAGE * log_page_p,
+				      LOG_LSA * prev_lsa, bool is_media_crash, time_t * stop_at,
+				      bool * did_incom_recovery)
 {
   LOG_TDES *tdes;
   LOG_REC_START_POSTPONE *start_posp;
+  time_t last_at_time;
+  char time_val[CTIME_MAX];
+  LOG_LSA record_header_lsa;
 
   /* 
    * If this is the first time, the transaction is seen. Assign a new
@@ -1151,6 +1163,87 @@ log_rv_analysis_commit_with_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_
   if (tdes == NULL)
     {
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_rv_analysis_commit_with_postpone");
+      return ER_FAILED;
+    }
+
+  LSA_COPY (&record_header_lsa, log_lsa);
+  LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_RECORD_HEADER), log_lsa, log_page_p);
+  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_START_POSTPONE), log_lsa, log_page_p);
+  start_posp = (LOG_REC_START_POSTPONE *) ((char *) log_page_p->area + log_lsa->offset);
+
+  if (is_media_crash)
+    {
+      last_at_time = (time_t) start_posp->at_time;
+      if (stop_at != NULL && *stop_at != (time_t) (-1) && difftime (*stop_at, last_at_time) < 0)
+	{
+#if !defined(NDEBUG)
+	  if (prm_get_bool_value (PRM_ID_LOG_TRACE_DEBUG))
+	    {
+	      fprintf (stdout, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_LOG, MSGCAT_LOG_STARTS));
+	      (void) ctime_r (&last_at_time, time_val);
+	      fprintf (stdout,
+		       msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_LOG, MSGCAT_LOG_INCOMPLTE_MEDIA_RECOVERY),
+		       record_header_lsa.pageid, record_header_lsa.offset, time_val);
+	      fprintf (stdout, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_LOG, MSGCAT_LOG_STARTS));
+	      fflush (stdout);
+	    }
+#endif /* !NDEBUG */
+	  /*
+	   * Reset the log active and stop the recovery process at this
+	   * point. Before reseting the log, make sure that we are not
+	   * holding a page.
+	   */
+	  log_lsa->pageid = NULL_PAGEID;
+	  log_recovery_resetlog (thread_p, &record_header_lsa, prev_lsa);
+	  *did_incom_recovery = true;
+	}
+    }
+  else
+    {
+      /*
+       * Need to read the start postpone record to set the postpone address
+       * of the transaction
+       */
+      tdes->state = TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE;
+
+      /* Nothing to undo */
+      LSA_SET_NULL (&tdes->undo_nxlsa);
+      LSA_COPY (&tdes->tail_lsa, log_lsa);
+      tdes->rcv.tran_start_postpone_lsa = tdes->tail_lsa;
+
+      LSA_COPY (&tdes->posp_nxlsa, &start_posp->posp_lsa);
+    }
+
+  return NO_ERROR;
+}
+
+/*
+ * log_rv_analysis_commit_with_postpone_obsolete-
+ *
+ * return: error code
+ *
+ *   tran_id(in):
+ *   lsa(in/out):
+ *   log_page_p(in/out):
+ *
+ * Note:
+ */
+static int
+log_rv_analysis_commit_with_postpone_obsolete (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa,
+					       LOG_PAGE * log_page_p)
+{
+  LOG_TDES *tdes;
+  LOG_REC_START_POSTPONE_OBSOLETE *start_posp;
+
+  /*
+   * If this is the first time, the transaction is seen. Assign a new
+   * index to describe it. The transaction was in the process of
+   * getting committed at this point.
+   */
+  tdes = logtb_rv_find_allocate_tran_index (thread_p, tran_id, log_lsa);
+  if (tdes == NULL)
+    {
+      logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_rv_analysis_commit_with_postpone_obsolete");
       return ER_FAILED;
     }
 
@@ -1166,9 +1259,9 @@ log_rv_analysis_commit_with_postpone (THREAD_ENTRY * thread_p, int tran_id, LOG_
    * of the transaction
    */
   LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_RECORD_HEADER), log_lsa, log_page_p);
-  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_START_POSTPONE), log_lsa, log_page_p);
+  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_START_POSTPONE_OBSOLETE), log_lsa, log_page_p);
 
-  start_posp = (LOG_REC_START_POSTPONE *) ((char *) log_page_p->area + log_lsa->offset);
+  start_posp = (LOG_REC_START_POSTPONE_OBSOLETE *) ((char *) log_page_p->area + log_lsa->offset);
   LSA_COPY (&tdes->posp_nxlsa, &start_posp->posp_lsa);
 
   return NO_ERROR;
@@ -2230,7 +2323,12 @@ log_rv_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE log_type, int tran_
       break;
 
     case LOG_COMMIT_WITH_POSTPONE:
-      (void) log_rv_analysis_commit_with_postpone (thread_p, tran_id, log_lsa, log_page_p);
+      (void) log_rv_analysis_commit_with_postpone (thread_p, tran_id, log_lsa, log_page_p, prev_lsa, is_media_crash,
+						   stop_at, did_incom_recovery);
+      break;
+
+    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
+      (void) log_rv_analysis_commit_with_postpone_obsolete (thread_p, tran_id, log_lsa, log_page_p);
       break;
 
     case LOG_SYSOP_START_POSTPONE:
@@ -3639,6 +3737,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 	    case LOG_DUMMY_HEAD_POSTPONE:
 	    case LOG_POSTPONE:
 	    case LOG_COMMIT_WITH_POSTPONE:
+	    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
 	    case LOG_SYSOP_START_POSTPONE:
 	    case LOG_START_CHKPT:
 	    case LOG_END_CHKPT:
@@ -3799,7 +3898,8 @@ log_recovery_abort_interrupted_sysop (THREAD_ENTRY * thread_p, LOG_TDES * tdes, 
       else
 	{
 	  /* safe-guard: we do not expect postpone starts */
-	  assert (logrec_head.type != LOG_COMMIT_WITH_POSTPONE && logrec_head.type != LOG_SYSOP_START_POSTPONE);
+	  assert (logrec_head.type != LOG_COMMIT_WITH_POSTPONE && logrec_head.type != LOG_COMMIT_WITH_POSTPONE_OBSOLETE
+		  && logrec_head.type != LOG_SYSOP_START_POSTPONE);
 
 	  /* move to previous */
 	  prev_lsa = logrec_head.prev_tranlsa;
@@ -4583,6 +4683,7 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 
 		case LOG_RUN_POSTPONE:
 		case LOG_COMMIT_WITH_POSTPONE:
+		case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
 		case LOG_COMMIT:
 		case LOG_SYSOP_START_POSTPONE:
 		case LOG_ABORT:
@@ -5340,6 +5441,13 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
       LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_START_POSTPONE), &log_lsa, log_pgptr);
 
       LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_START_POSTPONE), &log_lsa, log_pgptr);
+      break;
+
+    case LOG_COMMIT_WITH_POSTPONE_OBSOLETE:
+      /* Read the DATA HEADER */
+      LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_START_POSTPONE_OBSOLETE), &log_lsa, log_pgptr);
+
+      LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_START_POSTPONE_OBSOLETE), &log_lsa, log_pgptr);
       break;
 
     case LOG_COMMIT:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24378

Can't cherry-pick easily. I have resolved many conflicts manually. Please review it. 
- Most of them are just to put changes into proper files. (file name was changed and functions were moved when 10.1->10.2).
- log_recovery_resetlog arguments are changed.
- build success. The main TC attached in the Jira issue is passed.