### PR TITLE
[CBRD-24469] Unit tests for Java SP Server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ message(STATUS "======== CMakeLists.txt")
 
 cmake_minimum_required(VERSION 2.8)
 
+set(CMAKE_VERBOSE_MAKEFILE ON)
 function(with_unit_tests res) # checks for -DUNIT_TESTS=ON or -DUNIT_TEST_???=ON
   get_cmake_property(vars VARIABLES)
   foreach(var ${vars})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ message(STATUS "======== CMakeLists.txt")
 
 cmake_minimum_required(VERSION 2.8)
 
-set(CMAKE_VERBOSE_MAKEFILE ON)
 function(with_unit_tests res) # checks for -DUNIT_TESTS=ON or -DUNIT_TEST_???=ON
   get_cmake_property(vars VARIABLES)
   foreach(var ${vars})

--- a/jsp/CMakeLists.txt
+++ b/jsp/CMakeLists.txt
@@ -49,7 +49,7 @@ add_custom_command(TARGET jsp_build
   COMMAND ${CMAKE_COMMAND} -E echo "copying ivy.xml to ${CMAKE_BINARY_DIR}/jsp/ivy.xml"
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/jsp/ivy.xml ${CMAKE_BINARY_DIR}/jsp/ivy.xml
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/jsp/ivysettings.xml ${CMAKE_BINARY_DIR}/jsp/ivysettings.xml
-  COMMAND ${ANT} -verbose dist -buildfile ${CMAKE_SOURCE_DIR}/jsp/build.xml -Dbasedir=. -Dversion=${BUILD_NUMBER} -Dsrc.dir=${JSP_DIR} -Divy.install.dir="${IVY_DIR}"
+  COMMAND ${ANT} dist -buildfile ${CMAKE_SOURCE_DIR}/jsp/build.xml -Dbasedir=. -Dversion=${BUILD_NUMBER} -Dsrc.dir=${JSP_DIR} -Divy.install.dir="${IVY_DIR}"
   COMMENT "Build Java SP Server with Ant ..."
 )
 

--- a/jsp/CMakeLists.txt
+++ b/jsp/CMakeLists.txt
@@ -49,7 +49,7 @@ add_custom_command(TARGET jsp_build
   COMMAND ${CMAKE_COMMAND} -E echo "copying ivy.xml to ${CMAKE_BINARY_DIR}/jsp/ivy.xml"
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/jsp/ivy.xml ${CMAKE_BINARY_DIR}/jsp/ivy.xml
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/jsp/ivysettings.xml ${CMAKE_BINARY_DIR}/jsp/ivysettings.xml
-  COMMAND ${ANT} dist -buildfile ${CMAKE_SOURCE_DIR}/jsp/build.xml -Dbasedir=. -Dversion=${BUILD_NUMBER} -Dsrc.dir=${JSP_DIR} -Divy.install.dir="${IVY_DIR}"
+  COMMAND ${ANT} -verbose dist -buildfile ${CMAKE_SOURCE_DIR}/jsp/build.xml -Dbasedir=. -Dversion=${BUILD_NUMBER} -Dsrc.dir=${JSP_DIR} -Divy.install.dir="${IVY_DIR}"
   COMMENT "Build Java SP Server with Ant ..."
 )
 

--- a/jsp/CMakeLists.txt
+++ b/jsp/CMakeLists.txt
@@ -29,7 +29,7 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/cubrid-jdbc/src)
   set(JDBC_DIR ${CMAKE_SOURCE_DIR}/cubrid-jdbc)
   set(JSP_LIB_DIR ${CMAKE_BINARY_DIR}/jsp/lib)
 
-  add_custom_command(TARGET jsp_build
+  add_custom_command(TARGET jsp_build_submodule
     COMMAND ${CMAKE_COMMAND} -E make_directory ${JSP_LIB_DIR}
     COMMAND ${CMAKE_COMMAND} -DJDBC_DIR=${JDBC_DIR} -DJSP_LIB_DIR=${JSP_LIB_DIR} -P ${CMAKE_SOURCE_DIR}/jsp/cmake/copy_submodule_jdbc.cmake
   )

--- a/jsp/CMakeLists.txt
+++ b/jsp/CMakeLists.txt
@@ -53,6 +53,14 @@ add_custom_command(TARGET jsp_build
   COMMENT "Build Java SP Server with Ant ..."
 )
 
+add_custom_target(jsp_unittest)
+add_custom_command(TARGET jsp_unittest
+  COMMAND ${CMAKE_COMMAND} -E echo "Unit test"
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/jsp/ivy.xml ${CMAKE_BINARY_DIR}/jsp/ivy.xml
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/jsp/ivysettings.xml ${CMAKE_BINARY_DIR}/jsp/ivysettings.xml
+  COMMAND ${ANT} test-junit -buildfile ${CMAKE_SOURCE_DIR}/jsp/build.xml -Dbasedir=. -Dversion=${BUILD_NUMBER} -Dsrc.dir=${JSP_DIR} -Divy.install.dir="${IVY_DIR}"
+)
+
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/jspserver.jar
   ${JSP_DIR}/logging.properties

--- a/jsp/CMakeLists.txt
+++ b/jsp/CMakeLists.txt
@@ -29,7 +29,7 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/cubrid-jdbc/src)
   set(JDBC_DIR ${CMAKE_SOURCE_DIR}/cubrid-jdbc)
   set(JSP_LIB_DIR ${CMAKE_BINARY_DIR}/jsp/lib)
 
-  add_custom_command(TARGET jsp_build_submodule
+  add_custom_command(TARGET jsp_build
     COMMAND ${CMAKE_COMMAND} -E make_directory ${JSP_LIB_DIR}
     COMMAND ${CMAKE_COMMAND} -DJDBC_DIR=${JDBC_DIR} -DJSP_LIB_DIR=${JSP_LIB_DIR} -P ${CMAKE_SOURCE_DIR}/jsp/cmake/copy_submodule_jdbc.cmake
   )
@@ -55,10 +55,8 @@ add_custom_command(TARGET jsp_build
 
 add_custom_target(jsp_unittest)
 add_custom_command(TARGET jsp_unittest
-  COMMAND ${CMAKE_COMMAND} -E echo "Unit test"
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/jsp/ivy.xml ${CMAKE_BINARY_DIR}/jsp/ivy.xml
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/jsp/ivysettings.xml ${CMAKE_BINARY_DIR}/jsp/ivysettings.xml
   COMMAND ${ANT} test-junit -buildfile ${CMAKE_SOURCE_DIR}/jsp/build.xml -Dbasedir=. -Dversion=${BUILD_NUMBER} -Dsrc.dir=${JSP_DIR} -Divy.install.dir="${IVY_DIR}"
+  COMMENT "Unit Test Java SP Server with JUnit ..."
 )
 
 install(FILES

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -86,7 +86,7 @@
             <include name="${test.src.path}/*.java"/>
         </javac>
 
-        <junit printsummary="yes" fork="yes" haltonfailure="yes">
+        <junit printsummary="yes" haltonfailure="no">
             <classpath>
                 <path refid="test.path"/>
                 <pathelement path="${classes.dir}"/>
@@ -100,12 +100,14 @@
             </batchtest>
         </junit>
 
+        <!--
         <mkdir dir="${test.reports.dir}/html"/>
         <junitreport todir="${test.reports.dir}/html">
             <fileset dir="${test.reports.dir}">
                 <include name="TEST-*.xml"/>
             </fileset>
         </junitreport>
+        -->
     </target>
 
     <target name="dist" depends="test-junit">

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -80,7 +80,7 @@
         </delete>
     </target>
 
-    <target name="test-junit" depends="compile">
+    <target name="test-junit" depends="init">
         <ivy:retrieve pattern="${dist.lib}/[artifact]-[revision].[ext]" conf="test"/>
         <javac srcdir="${src.dir}" destdir="${test.classes.dir}" source="1.6" target="1.6" includeantruntime="no" encoding="UTF-8" classpathref="test.path">
             <include name="${test.src.path}/*.java"/>
@@ -109,7 +109,7 @@
         -->
     </target>
 
-    <target name="dist" depends="test-junit">
+    <target name="dist" depends="compile">
         <manifestclasspath property="jar.classpath" jarfile="${dist.jar}">
             <classpath>
                 <fileset dir="${dist.lib}" includes="*.jar"/>

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -62,7 +62,7 @@
 
     <target name="compile" depends="init">
         <ivy:retrieve pattern="${dist.lib}/[artifact]-[revision].[ext]" conf="runtime"/>
-        <javac srcdir="${src.dir}" destdir="${classes.dir}" source="1.6" target="1.6" includeantruntime="no" encoding="UTF-8" debug="true" classpathref="runtime.path">
+        <javac srcdir="${src.dir}" destdir="${classes.dir}" source="1.8" target="1.8" includeantruntime="no" encoding="UTF-8" debug="true" classpathref="runtime.path">
             <include name="**/*.java"/>
             <exclude name="${test.src.path}/*.java"/>
         </javac>
@@ -82,7 +82,7 @@
 
     <target name="test-junit" depends="init">
         <ivy:retrieve pattern="${dist.lib}/[artifact]-[revision].[ext]" conf="test"/>
-        <javac srcdir="${src.dir}" destdir="${test.classes.dir}" source="1.6" target="1.6" includeantruntime="no" encoding="UTF-8" classpathref="test.path">
+        <javac srcdir="${src.dir}" destdir="${test.classes.dir}" source="1.8" target="1.8" includeantruntime="no" encoding="UTF-8" classpathref="test.path">
             <include name="${test.src.path}/*.java"/>
         </javac>
 

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -10,8 +10,11 @@
     <property name="src.dir" value="src/jsp"/>
     <property name="build.dir" value="bin"/>
     <property name="classes.dir" location="${build.dir}/classes"/>
+
+    <property name="test.src.path" value="com/cubrid/jsp/test"/>
     <property name="test.classes.dir" location="${build.dir}/test-classes"/>
     <property name="test.reports.dir" location="${build.dir}/test-reports"/>
+
     <property name="ivy.reports.dir"  location="${build.dir}/ivy-reports"/>
 
     <property name="external.dir" value="external"/>
@@ -61,7 +64,7 @@
         <ivy:retrieve pattern="${dist.lib}/[artifact]-[revision].[ext]" conf="runtime"/>
         <javac srcdir="${src.dir}" destdir="${classes.dir}" source="1.6" target="1.6" includeantruntime="no" encoding="UTF-8" debug="true" classpathref="runtime.path">
             <include name="**/*.java"/>
-            <exclude name="com/cubrid/jsp/test/*.java"/>
+            <exclude name="${test.src.path}/*.java"/>
         </javac>
     </target>
 
@@ -80,7 +83,7 @@
     <target name="test" depends="compile">
         <ivy:retrieve pattern="${dist.lib}/[artifact]-[revision].[ext]" conf="test"/>
         <javac srcdir="${src.dir}" destdir="${test.classes.dir}" source="1.6" target="1.6" includeantruntime="no" encoding="UTF-8" debug="true" classpathref="test.path">
-            <include name="com/cubrid/jsp/test/*.java"/>
+            <include name="${test.src.path}/*.java"/>
         </javac>
 
         <junit printsummary="yes" haltonfailure="yes">
@@ -92,7 +95,7 @@
             <formatter type="xml"/>
             <batchtest todir="${test.reports.dir}">
                 <fileset dir="${src.dir}">
-                    <include name="com/cubrid/jsp/test/*.java"/>
+                    <include name="${test.src.path}/*.java"/>
                 </fileset>
             </batchtest>
         </junit>

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -87,10 +87,10 @@
         </javac>
 
         <junit printsummary="yes" haltonfailure="no">
-            <classpath>
-                <pathelement path="${classes.dir}"/>
-                <pathelement path="${test.classes.dir}"/>
-            </classpath>
+            <classpath refid="runtime.path" />
+            <classpath refid="test.path" />
+            <classpath path="${test.classes.dir}" />
+            <classpath path="${classes.dir}" />
             <formatter type="xml"/>
             <batchtest todir="${test.reports.dir}">
                 <fileset dir="${src.dir}">

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -107,7 +107,7 @@
         </junitreport>
     </target>
 
-    <target name="dist" depends="compile, test-junit">
+    <target name="dist" depends="compile">
         <manifestclasspath property="jar.classpath" jarfile="${dist.jar}">
             <classpath>
                 <fileset dir="${dist.lib}" includes="*.jar"/>

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -86,7 +86,7 @@
             <include name="${test.src.path}/*.java"/>
         </javac>
 
-        <junit printsummary="yes" haltonfailure="yes">
+        <junit printsummary="yes" fork="yes" haltonfailure="yes">
             <classpath>
                 <path refid="test.path"/>
                 <pathelement path="${classes.dir}"/>

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -107,7 +107,7 @@
         </junitreport>
     </target>
 
-    <target name="dist" depends="compile">
+    <target name="dist" depends="compile, test-junit">
         <manifestclasspath property="jar.classpath" jarfile="${dist.jar}">
             <classpath>
                 <fileset dir="${dist.lib}" includes="*.jar"/>

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -82,14 +82,12 @@
 
     <target name="test-junit" depends="compile">
         <ivy:retrieve pattern="${dist.lib}/[artifact]-[revision].[ext]" conf="test"/>
-        <javac srcdir="${src.dir}" destdir="${test.classes.dir}" source="1.6" target="1.6" includeantruntime="no" encoding="UTF-8" debug="true" classpathref="test.path">
+        <javac srcdir="${src.dir}" destdir="${test.classes.dir}" source="1.6" target="1.6" includeantruntime="no" encoding="UTF-8" classpathref="test.path">
             <include name="${test.src.path}/*.java"/>
         </javac>
 
-        <!--
         <junit printsummary="yes" haltonfailure="no">
             <classpath>
-                <path refid="test.path"/>
                 <pathelement path="${classes.dir}"/>
                 <pathelement path="${test.classes.dir}"/>
             </classpath>
@@ -100,8 +98,7 @@
                 </fileset>
             </batchtest>
         </junit>
-        -->
-        
+
         <!--
         <mkdir dir="${test.reports.dir}/html"/>
         <junitreport todir="${test.reports.dir}/html">

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE project>
 
-<project name="Java Stored Procedure Server" default="dist" xmlns:ivy="antlib:org.apache.ivy.ant" >
+<project name="Java Stored Procedure Server" default="dist" xmlns:ivy="antlib:org.apache.ivy.ant">
     <!--
     ================
     Build properties
@@ -11,6 +11,7 @@
     <property name="build.dir" value="bin"/>
     <property name="classes.dir" location="${build.dir}/classes"/>
     <property name="test.classes.dir" location="${build.dir}/test-classes"/>
+    <property name="test.reports.dir" location="${build.dir}/test-reports"/>
     <property name="ivy.reports.dir"  location="${build.dir}/ivy-reports"/>
 
     <property name="external.dir" value="external"/>
@@ -52,12 +53,15 @@
         <mkdir dir="${build.dir}"/>
         <mkdir dir="${classes.dir}"/>
         <mkdir dir="${test.classes.dir}"/>
+        <mkdir dir="${test.reports.dir}"/>
         <mkdir dir="${ivy.reports.dir}"/>
     </target>
 
     <target name="compile" depends="init">
+        <ivy:retrieve pattern="${dist.lib}/[artifact]-[revision].[ext]" conf="runtime"/>
         <javac srcdir="${src.dir}" destdir="${classes.dir}" source="1.6" target="1.6" includeantruntime="no" encoding="UTF-8" debug="true" classpathref="runtime.path">
             <include name="**/*.java"/>
+            <exclude name="com/cubrid/jsp/test/*.java"/>
         </javac>
     </target>
 
@@ -65,6 +69,7 @@
         <delete failonerror="false" includeEmptyDirs="true">
             <fileset dir="${external.dir}"/>
             <fileset dir="${ivy.reports.dir}"/>
+            <fileset dir="${test.reports.dir}"/>
             <fileset dir="${test.classes.dir}"/>
             <fileset dir="${classes.dir}"/>
             <fileset dir="${build.dir}"/>
@@ -72,9 +77,35 @@
         </delete>
     </target>
 
-    <target name="dist" depends="compile">
-        <ivy:retrieve pattern="${dist.lib}/[artifact]-[revision].[ext]" conf="runtime"/>
-        
+    <target name="test" depends="compile">
+        <ivy:retrieve pattern="${dist.lib}/[artifact]-[revision].[ext]" conf="test"/>
+        <javac srcdir="${src.dir}" destdir="${test.classes.dir}" source="1.6" target="1.6" includeantruntime="no" encoding="UTF-8" debug="true" classpathref="test.path">
+            <include name="com/cubrid/jsp/test/*.java"/>
+        </javac>
+
+        <junit printsummary="yes" haltonfailure="yes">
+            <classpath>
+                <path refid="test.path"/>
+                <pathelement path="${classes.dir}"/>
+                <pathelement path="${test.classes.dir}"/>
+            </classpath>
+            <formatter type="xml"/>
+            <batchtest todir="${test.reports.dir}">
+                <fileset dir="${src.dir}">
+                    <include name="com/cubrid/jsp/test/*.java"/>
+                </fileset>
+            </batchtest>
+        </junit>
+
+        <mkdir dir="${test.reports.dir}/html"/>
+        <junitreport todir="${test.reports.dir}/html">
+            <fileset dir="${test.reports.dir}">
+                <include name="TEST-*.xml"/>
+            </fileset>
+        </junitreport>
+    </target>
+
+    <target name="dist" depends="test">
         <manifestclasspath property="jar.classpath" jarfile="${dist.jar}">
             <classpath>
                 <fileset dir="${dist.lib}" includes="*.jar"/>

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -99,14 +99,12 @@
             </batchtest>
         </junit>
 
-        <!--
         <mkdir dir="${test.reports.dir}/html"/>
         <junitreport todir="${test.reports.dir}/html">
             <fileset dir="${test.reports.dir}">
                 <include name="TEST-*.xml"/>
             </fileset>
         </junitreport>
-        -->
     </target>
 
     <target name="dist" depends="compile">

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -86,6 +86,7 @@
             <include name="${test.src.path}/*.java"/>
         </javac>
 
+        <!--
         <junit printsummary="yes" haltonfailure="no">
             <classpath>
                 <path refid="test.path"/>
@@ -99,7 +100,8 @@
                 </fileset>
             </batchtest>
         </junit>
-
+        -->
+        
         <!--
         <mkdir dir="${test.reports.dir}/html"/>
         <junitreport todir="${test.reports.dir}/html">

--- a/jsp/build.xml
+++ b/jsp/build.xml
@@ -80,7 +80,7 @@
         </delete>
     </target>
 
-    <target name="test" depends="compile">
+    <target name="test-junit" depends="compile">
         <ivy:retrieve pattern="${dist.lib}/[artifact]-[revision].[ext]" conf="test"/>
         <javac srcdir="${src.dir}" destdir="${test.classes.dir}" source="1.6" target="1.6" includeantruntime="no" encoding="UTF-8" debug="true" classpathref="test.path">
             <include name="${test.src.path}/*.java"/>
@@ -108,7 +108,7 @@
         </junitreport>
     </target>
 
-    <target name="dist" depends="test">
+    <target name="dist" depends="test-junit">
         <manifestclasspath property="jar.classpath" jarfile="${dist.jar}">
             <classpath>
                 <fileset dir="${dist.lib}" includes="*.jar"/>

--- a/jsp/ivy.xml
+++ b/jsp/ivy.xml
@@ -10,5 +10,6 @@
         <dependency org="cubrid" name="cubrid-jdbc" rev="latest.integration" conf="runtime->default"/>
         <dependency org="com.kohlschutter.junixsocket" name="junixsocket-core" rev="2.4.0" conf="runtime->default"/>
         <dependency org="com.kohlschutter.junixsocket" name="junixsocket-server" rev="2.4.0" conf="runtime->default"/>
+        <dependency org="junit" name="junit" rev="4.11" conf="test->default"/>
     </dependencies>
 </ivy-module>

--- a/jsp/ivy.xml
+++ b/jsp/ivy.xml
@@ -10,7 +10,7 @@
         <dependency org="cubrid" name="cubrid-jdbc" rev="latest.integration" conf="runtime->default"/>
         <dependency org="com.kohlschutter.junixsocket" name="junixsocket-core" rev="2.4.0" conf="runtime->default"/>
         <dependency org="com.kohlschutter.junixsocket" name="junixsocket-server" rev="2.4.0" conf="runtime->default"/>
-        <dependency org="junit" name="junit" rev="4.11" conf="test->default"/>
+        <dependency org="junit" name="junit" rev="4.13.2" conf="test->default"/>
         <dependency org="org.apache.ant" name="ant-junit4" rev="1.10.12" conf="test->default"/>
     </dependencies>
 </ivy-module>

--- a/jsp/ivy.xml
+++ b/jsp/ivy.xml
@@ -11,5 +11,6 @@
         <dependency org="com.kohlschutter.junixsocket" name="junixsocket-core" rev="2.4.0" conf="runtime->default"/>
         <dependency org="com.kohlschutter.junixsocket" name="junixsocket-server" rev="2.4.0" conf="runtime->default"/>
         <dependency org="junit" name="junit" rev="4.11" conf="test->default"/>
+        <dependency org="org.apache.ant" name="ant-junit4" rev="1.10.12" conf="test->default"/>
     </dependencies>
 </ivy-module>

--- a/src/jsp/com/cubrid/jsp/test/TestSample.java
+++ b/src/jsp/com/cubrid/jsp/test/TestSample.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package com.cubrid.jsp.test;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class TestSample {
+     @Test
+     public void evaluatesExpression() {
+        assertTrue(true);
+     }
+}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24469

JUnit Task is added in the build script of ant (`build.xml`). The JUnit testing classes should be placed at the path, `com/cubrid/jsp/test`. The summary will be shown when you compile with `make && make jsp_unittest` in the binary path of Cmake.
```
...
test:
[ivy:retrieve] :: retrieving :: org.cubrid#cubrid-jsp
[ivy:retrieve]  confs: [test]
[ivy:retrieve]  0 artifacts copied, 6 already retrieved (0kB/3ms)
    [junit] Running com.cubrid.jsp.test.TestSample
    [junit] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 sec

dist:

BUILD SUCCESSFUL
...
```

If any JUnit test is failed, the `make jsp_unittest` command of CMake is going to fail as follow.
```
...
test:
[ivy:retrieve] :: retrieving :: org.cubrid#cubrid-jsp
[ivy:retrieve]  confs: [test]
[ivy:retrieve]  0 artifacts copied, 6 already retrieved (0kB/3ms)
    [javac] Compiling 1 source file to /home/cubrid/regex_hgryoo/build_x86_64_debug/jsp/bin/test-classes
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 1.6
    [javac] 1 warning
    [junit] Running com.cubrid.jsp.test.TestSample
    [junit] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.027 sec

BUILD FAILED
/home/cubrid/regex_hgryoo/jsp/build.xml:86: Test com.cubrid.jsp.test.TestSample failed

Total time: 1 second
make[2]: *** [jsp/CMakeFiles/jsp_build.dir/build.make:83: jsp_build] Error 1
make[1]: *** [CMakeFiles/Makefile2:3087: jsp/CMakeFiles/jsp_build.dir/all] Error 2
make: *** [Makefile:172: all] Error 2
...
```