### PR TITLE
[CBRD-24473] Index scan cannot be used when a stored function is used in a where condition.

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -3746,6 +3746,13 @@ pt_is_pseudo_const (PT_NODE * expr)
        */
       return true;
 
+    case PT_METHOD_CALL:
+     /*
+      * Even if there are columns(PT_NAME) in the parameter of the Java Stored Procedure(METHOD_CALL),
+      * it can be guaranteed to be evaluated by the time it is referenced.
+      */
+      return true;
+
     case PT_DOT_:
       /*
        * It would be nice if we could use expressions that are

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -3747,10 +3747,10 @@ pt_is_pseudo_const (PT_NODE * expr)
       return true;
 
     case PT_METHOD_CALL:
-     /*
-      * Even if there are columns(PT_NAME) in the parameter of the Java Stored Procedure(METHOD_CALL),
-      * it can be guaranteed to be evaluated by the time it is referenced.
-      */
+      /*
+       * Even if there are columns(PT_NAME) in the parameter of the Java Stored Procedure(METHOD_CALL),
+       * it can be guaranteed to be evaluated by the time it is referenced.
+       */
       return true;
 
     case PT_DOT_:

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -21892,7 +21892,7 @@ parser_generate_xasl (PARSER_CONTEXT * parser, PT_NODE * node)
       /* translate methods in queries to our internal form */
       if (node)
 	{
-	  /* node = meth_translate (parser, node); */
+	  node = meth_translate (parser, node);
 	}
 
       if (node)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -21892,7 +21892,7 @@ parser_generate_xasl (PARSER_CONTEXT * parser, PT_NODE * node)
       /* translate methods in queries to our internal form */
       if (node)
 	{
-	  node = meth_translate (parser, node);
+	  /* node = meth_translate (parser, node); */
 	}
 
       if (node)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7693,6 +7693,14 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 	      break;
 
 	    case PT_METHOD_CALL:
+	      /*
+		 TODO : JSP containing column cannot be here because the query is rewritten in meth_translate().
+		 The index scan may not work because of the query rewrite in meth_translate().
+		 The method call should proceed in the same way as the internal function.
+		 pt_to_regu_variable() : generate regu_var for jsp function
+		 fetch_peek_dbval() : fetch regu_var for jsp function
+	      */
+
 	      /* a method call that can be evaluated as a constant expression. */
 	      regu_alloc (val);
 	      pt_evaluate_tree (parser, node, val, 1);

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7694,12 +7694,12 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 
 	    case PT_METHOD_CALL:
 	      /*
-		 TODO : JSP containing column cannot be here because the query is rewritten in meth_translate().
-		 The index scan may not work because of the query rewrite in meth_translate().
-		 The method call should proceed in the same way as the internal function.
-		 pt_to_regu_variable() : generate regu_var for jsp function
-		 fetch_peek_dbval() : fetch regu_var for jsp function
-	      */
+	         TODO : JSP containing column cannot be here because the query is rewritten in meth_translate().
+	         The index scan may not work because of the query rewrite in meth_translate().
+	         The method call should proceed in the same way as the internal function.
+	         pt_to_regu_variable() : generate regu_var for jsp function
+	         fetch_peek_dbval() : fetch regu_var for jsp function
+	       */
 
 	      /* a method call that can be evaluated as a constant expression. */
 	      regu_alloc (val);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24473

I fixed it so that the method is treated as a pseudo constant in qo_analyze_terms().

'col1 = const' <== it is indexable.

There is one more problem. Index scan on correlated columns is not possible due to query rewrite in meth_translate() (check [test cases for CBRD-24473.txt](http://jira.cubrid.org/secure/attachment/1015653/1015653_test+cases+for+CBRD-24473.txt)). I hope this will be fixed in the future.
