### PR TITLE
[CBRD-24482] Core dump occurs after function index scan

### DIFF
--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -159,7 +159,7 @@ static int reverse_key_list (KEY_VAL_RANGE * key_vals, int key_cnt);
 static int check_key_vals (KEY_VAL_RANGE * key_vals, int key_cnt, QPROC_KEY_VAL_FU * chk_fn);
 static int scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * indexal,
 				   TP_DOMAIN * btree_domainp, int num_term, REGU_VARIABLE * func, VAL_DESCR * vd,
-				   int key_minmax, bool is_iss, DB_VALUE * fetched_values);
+				   int key_minmax, bool is_iss);
 static int scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY_VAL_RANGE * key_val_range,
 				       INDX_SCAN_ID * iscan_id, TP_DOMAIN * btree_domainp, VAL_DESCR * vd);
 static int scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_limit_upper,
@@ -1483,8 +1483,7 @@ check_key_vals (KEY_VAL_RANGE * key_vals, int key_cnt, QPROC_KEY_VAL_FU * key_va
  */
 static int
 scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * indexable, TP_DOMAIN * btree_domainp,
-			int num_term, REGU_VARIABLE * func, VAL_DESCR * vd, int key_minmax, bool is_iss,
-			DB_VALUE * fetched_values)
+			int num_term, REGU_VARIABLE * func, VAL_DESCR * vd, int key_minmax, bool is_iss)
 {
   int ret = NO_ERROR;
   DB_VALUE *val = NULL;
@@ -1568,8 +1567,6 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	  goto err_exit;
 	}
 
-      pr_clear_value (&fetched_values[i]);
-      ret = pr_clone_value (val, &fetched_values[i]);
       if (ret != NO_ERROR)
 	{
 	  goto err_exit;
@@ -1675,8 +1672,11 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	}
       else
 	{
-	  assert (fetched_values != NULL);
-	  val = &fetched_values[natts];
+	  ret = fetch_peek_dbval (thread_p, &(operand->value), vd, NULL, NULL, NULL, &val);
+	  if (ret != NO_ERROR)
+	    {
+	      goto err_exit;
+	    }
 	}
 
       if (need_new_setdomain == true)
@@ -1780,8 +1780,11 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	}
       else
 	{
-	  assert (fetched_values != NULL);
-	  val = &fetched_values[i];
+	  ret = fetch_peek_dbval (thread_p, &(operand->value), vd, NULL, NULL, NULL, &val);
+	  if (ret != NO_ERROR)
+	    {
+	      goto err_exit;
+	    }
 	}
 
       if (DB_IS_NULL (val))
@@ -1959,8 +1962,7 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 
 	  ret =
 	    scan_dbvals_to_midxkey (thread_p, &key_val_range->key1, &indexable, btree_domainp,
-				    key_val_range->num_index_term, key_ranges->key1, vd, key_minmax, iscan_id->iss.use,
-				    iscan_id->fetched_values);
+				    key_val_range->num_index_term, key_ranges->key1, vd, key_minmax, iscan_id->iss.use);
 	}
       else
 	{
@@ -2007,8 +2009,7 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 
 	  ret =
 	    scan_dbvals_to_midxkey (thread_p, &key_val_range->key2, &indexable, btree_domainp,
-				    key_val_range->num_index_term, key_ranges->key2, vd, key_minmax, iscan_id->iss.use,
-				    iscan_id->fetched_values);
+				    key_val_range->num_index_term, key_ranges->key2, vd, key_minmax, iscan_id->iss.use);
 	}
       else
 	{
@@ -3084,7 +3085,6 @@ scan_open_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
   isidp->indx_cov.list_id = indx_info->cov_list_id;
   isidp->indx_cov.tplrec = NULL;
   isidp->indx_cov.lsid = NULL;
-  isidp->fetched_values = NULL;
 
   /* index scan info */
   BTS = &isidp->bt_scan;
@@ -3231,17 +3231,6 @@ scan_open_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 	{
 	  /* found multi-column key-val */
 	  need_copy_buf = true;
-
-	  /* make fetched values for scan_regu_key_to_index_key(). */
-	  isidp->fetched_values = (DB_VALUE *) db_private_alloc (thread_p, sizeof (DB_VALUE) * isidp->bt_num_attrs);
-	  if (isidp->fetched_values == NULL)
-	    {
-	      goto exit_on_error;
-	    }
-	  for (int j = 0; j < isidp->bt_num_attrs; j++)
-	    {
-	      db_make_null (&isidp->fetched_values[j]);
-	    }
 	}
       else
 	{			/* single-column index */
@@ -3308,10 +3297,6 @@ exit_on_error:
   if (isidp->key_vals)
     {
       isidp->key_vals = NULL;
-    }
-  if (isidp->fetched_values)
-    {
-      db_private_free_and_init (thread_p, isidp->fetched_values);
     }
   if (isidp->bt_attr_ids)
     {
@@ -4788,14 +4773,6 @@ scan_close_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
       if (isidp->key_vals)
 	{
 	  isidp->key_vals = NULL;
-	}
-      if (isidp->fetched_values)
-	{
-	  for (int j = 0; j < isidp->bt_num_attrs; j++)
-	    {
-	      pr_clear_value (&isidp->fetched_values[j]);
-	    }
-	  db_private_free_and_init (thread_p, isidp->fetched_values);
 	}
 
       /* free allocated memory for the scan */

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -238,7 +238,6 @@ struct indx_scan_id
   bool check_not_vacuumed;	/* if true then during index scan, the entries will be checked if they should've been
 				 * vacuumed. Used in checkdb. */
   DISK_ISVALID not_vacuumed_res;	/* The result of not vacuumed checking operation */
-  DB_VALUE *fetched_values;	/* used for scan_dbvals_to_midxkey() */
 };
 
 typedef struct index_node_scan_id INDEX_NODE_SCAN_ID;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24482

I revert the case3 of [CBRD-23905](http://jira.cubrid.org/browse/CBRD-23905)

I revert case 3 for the following reasons.
- Not much performance improvement. (3%)
- Due to malloc in scan_open_scan(), performance degradation occurs in correlated subquery.
