### PR TITLE
[LETS-449] Remove the disk_Page_server_perm_volume_count and block fileIO on PTS

### DIFF
--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -237,6 +237,9 @@ page_server::connection_handler::abnormal_tran_server_disconnect (css_error_code
     }
 }
 
+/* NOTE : Since TS don't need the information about the number of permanent volume during boot,
+ *        this message has no actual use currently. However, this mechanism will be reserved,
+ *        because it can be used in the future when multiple PS's are supported. */
 void
 page_server::connection_handler::receive_boot_info_request (tran_server_conn_t::sequenced_payload &a_sp)
 {

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -243,7 +243,8 @@ page_server::connection_handler::abnormal_tran_server_disconnect (css_error_code
 void
 page_server::connection_handler::receive_boot_info_request (tran_server_conn_t::sequenced_payload &a_sp)
 {
-  DKNVOLS nvols_perm = disk_get_perm_volume_count ();
+  /* It is simply a dummy value to check whether the TS (get_boot_info_from_page_server) receives the message well */
+  DKNVOLS nvols_perm = VOLID_MAX;
 
   std::string response_message;
   response_message.reserve (sizeof (nvols_perm));

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -238,6 +238,9 @@ tran_server::init_page_server_hosts (const char *db_name)
   return exit_code;
 }
 
+
+/* TODO: Remove this boot process because the only information received from PS is the number of permanent volumes.
+ *       The number of permanent volumes is also stored in boot_Db_parm. So this process can be removed */
 int
 tran_server::get_boot_info_from_page_server ()
 {

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -255,6 +255,9 @@ tran_server::get_boot_info_from_page_server ()
   DKNVOLS nvols_perm;
   std::memcpy (&nvols_perm, response_message.c_str (), sizeof (nvols_perm));
 
+  /* Check the dummay value whether the TS receives the message from PS (receive_boot_info_request) well. */
+  assert (nvols_perm == VOLID_MAX);
+
   return NO_ERROR;
 }
 

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -238,9 +238,9 @@ tran_server::init_page_server_hosts (const char *db_name)
   return exit_code;
 }
 
-
-/* TODO: Remove this boot process because the only information received from PS is the number of permanent volumes.
- *       The number of permanent volumes is also stored in boot_Db_parm. So this process can be removed */
+/* NOTE : Since TS don't need the information about the number of permanent volume during boot,
+ *        this message has no actual use currently. However, this mechanism will be reserved,
+ *        because it can be used in the future when multiple PS's are supported. */
 int
 tran_server::get_boot_info_from_page_server ()
 {

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -252,8 +252,6 @@ tran_server::get_boot_info_from_page_server ()
   DKNVOLS nvols_perm;
   std::memcpy (&nvols_perm, response_message.c_str (), sizeof (nvols_perm));
 
-  disk_set_page_server_perm_volume_count (nvols_perm);
-
   return NO_ERROR;
 }
 

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -5884,8 +5884,14 @@ disk_is_valid_volid (VOLID volid)
     {
       /* Since PTS do not have a disk header page for newly added volume at the time of replication,
        * disk_rv_redo_format (), which requires disk header page and does update the disk_Cache,
-       * is not called during replication.
-       * Therefore, only the range of the volume ID is checked and the validity is checked by PS */
+       * is not called during replication.Thereefore, PTS knows only temporary volumes.
+       * Only the temporary volume ID is checked, and if it is not a temporary volume, only the range of volume id is checked */
+
+      const bool is_valid_temp_volid = (volid > (LOG_MAX_DBVOLID - disk_Cache->nvols_temp));
+      if (is_valid_temp_volid)
+	{
+	  return is_valid_temp_volid;
+	}
 
       return volid >= LOG_DBFIRST_VOLID && volid <= LOG_MAX_DBVOLID;
     }

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2660,6 +2660,11 @@ disk_cache_load_all_volumes (THREAD_ENTRY * thread_p)
   assert (disk_Cache != NULL);
   if (is_tran_server_with_remote_storage ())
     {
+      /* TODO: disk_Cache is not required to be initialized on PTS.
+       *       if all the disk_Cache usage parts are blocked on PTS,
+       *       then disk_Cache initialization on PTS can be blocked too.
+       */
+
       const DKNVOLS nvols_perm = xboot_find_number_permanent_volumes (thread_p);
       assert (nvols_perm > 0);
 
@@ -5884,14 +5889,8 @@ disk_is_valid_volid (VOLID volid)
     {
       /* Since PTS do not have a disk header page for newly added volume at the time of replication,
        * disk_rv_redo_format (), which requires disk header page and does update the disk_Cache,
-       * is not called during replication. Thereefore, PTS knows only temporary volumes.
-       * Only the temporary volume ID is checked, and if it is not a temporary volume, only the range of volume id is checked */
-
-      const bool is_valid_temp_volid = (volid > (LOG_MAX_DBVOLID - disk_Cache->nvols_temp));
-      if (is_valid_temp_volid)
-	{
-	  return is_valid_temp_volid;
-	}
+       * is not called during replication. Therefore, PTS knows only temporary volumes.
+       * So, it will check only the range of the volume id on PTS */
 
       return volid >= LOG_DBFIRST_VOLID && volid <= LOG_MAX_DBVOLID;
     }

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -5884,7 +5884,7 @@ disk_is_valid_volid (VOLID volid)
     {
       /* Since PTS do not have a disk header page for newly added volume at the time of replication,
        * disk_rv_redo_format (), which requires disk header page and does update the disk_Cache,
-       * is not called during replication.Thereefore, PTS knows only temporary volumes.
+       * is not called during replication. Thereefore, PTS knows only temporary volumes.
        * Only the temporary volume ID is checked, and if it is not a temporary volume, only the range of volume id is checked */
 
       const bool is_valid_temp_volid = (volid > (LOG_MAX_DBVOLID - disk_Cache->nvols_temp));
@@ -5896,13 +5896,7 @@ disk_is_valid_volid (VOLID volid)
       return volid >= LOG_DBFIRST_VOLID && volid <= LOG_MAX_DBVOLID;
     }
 
-  const bool is_valid_perm_volid = (volid < disk_Cache->nvols_perm);
-  if (is_valid_perm_volid)
-    {
-      return is_valid_perm_volid;
-    }
-
-  return volid > (LOG_MAX_DBVOLID - disk_Cache->nvols_temp);
+  return volid < disk_Cache->nvols_perm || volid > LOG_MAX_DBVOLID - disk_Cache->nvols_temp;
 }
 
 /*

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -5889,8 +5889,10 @@ disk_is_valid_volid (VOLID volid)
     {
       /* Since PTS do not have a disk header page for newly added volume at the time of replication,
        * disk_rv_redo_format (), which requires disk header page and does update the disk_Cache,
-       * is not called during replication. Therefore, PTS knows only temporary volumes.
-       * So, it will check only the range of the volume id on PTS */
+       * is not called during replication. Therefore, PTS knows only temporary volumes,
+       * and it stores the temporary volume info in disk_Cache.
+       * So, it will check only the range of the volume id on PTS here,
+       * and actual validation for permananent volume will be done on PS when PTS request a page from PS. */
 
       return volid >= LOG_DBFIRST_VOLID && volid <= LOG_MAX_DBVOLID;
     }

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -5880,7 +5880,7 @@ disk_dump_goodvol_all (THREAD_ENTRY * thread_p, INT16 volid, void *arg)
 STATIC_INLINE bool
 disk_is_valid_volid (VOLID volid)
 {
-  if (is_tran_server_with_remote_storage () && is_passive_transaction_server ())
+  if (is_passive_transaction_server ())
     {
       /* Since PTS do not have a disk header page for newly added volume at the time of replication,
        * disk_rv_redo_format (), which requires disk header page and does update the disk_Cache,

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -5880,26 +5880,23 @@ disk_dump_goodvol_all (THREAD_ENTRY * thread_p, INT16 volid, void *arg)
 STATIC_INLINE bool
 disk_is_valid_volid (VOLID volid)
 {
-  // a passive transaction server (which is, implicitly, a transaction server
-  // with remote storage) maintains a separate bookkeeping of permanent data volumes
-  // which is updated when executing corresponding recovery replication functions
-  // as part of the regular replication; this way, it is able to provide a valid
-  // answer via this function
   if (is_tran_server_with_remote_storage () && is_passive_transaction_server ())
     {
+      /* Since PTS do not have a disk header page for newly added volume at the time of replication,
+       * disk_rv_redo_format (), which requires disk header page and does update the disk_Cache,
+       * is not called during replication.
+       * Therefore, only the range of the volume ID is checked and the validity is checked by PS */
+
       return volid >= LOG_DBFIRST_VOLID && volid <= LOG_MAX_DBVOLID;
     }
-  else
-    {
-      const bool is_valid_perm_volid = (volid < disk_Cache->nvols_perm);
-      if (is_valid_perm_volid)
-	{
-	  return is_valid_perm_volid;
-	}
 
-      // a transaction server with remote storage has its own temporary volumes that it maintains
-      return volid > (LOG_MAX_DBVOLID - disk_Cache->nvols_temp);
+  const bool is_valid_perm_volid = (volid < disk_Cache->nvols_perm);
+  if (is_valid_perm_volid)
+    {
+      return is_valid_perm_volid;
     }
+
+  return volid > (LOG_MAX_DBVOLID - disk_Cache->nvols_temp);
 }
 
 /*

--- a/src/storage/disk_manager.h
+++ b/src/storage/disk_manager.h
@@ -116,7 +116,6 @@ extern DISK_ISVALID disk_check (THREAD_ENTRY * thread_p, bool repair);
 extern int disk_dump_all (THREAD_ENTRY * thread_p, FILE * fp);
 extern int disk_spacedb (THREAD_ENTRY * thread_p, SPACEDB_ALL * spaceall, SPACEDB_ONEVOL ** spacevols);
 extern DKNVOLS disk_get_perm_volume_count ();
-extern void disk_set_page_server_perm_volume_count (DKNVOLS nvols);
 
 extern int disk_volume_header_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int arg_cnt,
 					  void **ctx);

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -83,17 +83,11 @@ namespace cublog
 	    read_and_redo_record<LOG_REC_COMPENSATE> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_DBEXTERN_REDO_DATA:
-	  {
-	    m_redo_context.m_reader.advance_when_does_not_fit (sizeof (LOG_REC_DBOUT_REDO));
-	    const LOG_REC_DBOUT_REDO dbout_redo =
-		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_DBOUT_REDO> ();
-	    log_rcv rcv;
-	    rcv.length = dbout_redo.length;
-
-	    log_rv_redo_record (&thread_entry, m_redo_context.m_reader, RV_fun[dbout_redo.rcvindex].redofun, &rcv,
-				&m_redo_lsa, 0, nullptr, m_redo_context.m_redo_zip);
+            /* Recovery redo for RVDK_NEWVOL and RVDK_EXPAND_VOLUME will be called here,
+             * and fileIO operations are required for those redo function.
+             * However fileIO operations are not required in PTS, so it skip this logs
+             */
 	    break;
-	  }
 	  case LOG_COMMIT:
 	    if (m_replicate_mvcc)
 	      {

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -84,8 +84,8 @@ namespace cublog
 	    break;
 	  case LOG_DBEXTERN_REDO_DATA:
 	    /* Recovery redo for RVDK_NEWVOL and RVDK_EXPAND_VOLUME will be called here,
-	     * and fileIO operations are required for those redo function.
-	     * However fileIO operations are not required in PTS, so it skip this logs
+	     * and fileIO operations are required for those redo functions.
+	     * However fileIO operations are not required in PTS, so it skip these logs
 	     */
 	    break;
 	  case LOG_COMMIT:

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -83,10 +83,10 @@ namespace cublog
 	    read_and_redo_record<LOG_REC_COMPENSATE> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_DBEXTERN_REDO_DATA:
-            /* Recovery redo for RVDK_NEWVOL and RVDK_EXPAND_VOLUME will be called here,
-             * and fileIO operations are required for those redo function.
-             * However fileIO operations are not required in PTS, so it skip this logs
-             */
+	    /* Recovery redo for RVDK_NEWVOL and RVDK_EXPAND_VOLUME will be called here,
+	     * and fileIO operations are required for those redo function.
+	     * However fileIO operations are not required in PTS, so it skip this logs
+	     */
 	    break;
 	  case LOG_COMMIT:
 	    if (m_replicate_mvcc)

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -83,11 +83,28 @@ namespace cublog
 	    read_and_redo_record<LOG_REC_COMPENSATE> (thread_entry, header, m_redo_lsa);
 	    break;
 	  case LOG_DBEXTERN_REDO_DATA:
-	    /* Recovery redo for RVDK_NEWVOL and RVDK_EXPAND_VOLUME will be called here,
-	     * and fileIO operations are required for those redo functions.
-	     * However fileIO operations are not required in PTS, so it skip these logs
-	     */
+	  {
+	    m_redo_context.m_reader.advance_when_does_not_fit (sizeof (LOG_REC_DBOUT_REDO));
+	    const LOG_REC_DBOUT_REDO dbout_redo =
+		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_DBOUT_REDO> ();
+
+	    if (dbout_redo.rcvindex == RVDK_NEWVOL || dbout_redo.rcvindex == RVDK_EXPAND_VOLUME)
+	      {
+		/* Recovery redo for RVDK_NEWVOL and RVDK_EXPAND_VOLUME will not be replicated,
+		 * because fileIO operations are required for those redo functions.
+		 * However fileIO operations are not required in PTS, so it skip these logs
+		 */
+
+		break;
+	      }
+
+	    log_rcv rcv;
+	    rcv.length = dbout_redo.length;
+
+	    log_rv_redo_record (&thread_entry, m_redo_context.m_reader, RV_fun[dbout_redo.rcvindex].redofun, &rcv,
+				&m_redo_lsa, 0, nullptr, m_redo_context.m_redo_zip);
 	    break;
+	  }
 	  case LOG_COMMIT:
 	    if (m_replicate_mvcc)
 	      {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-449

Purpose
- Block fileIO on PTS which is not required in TS
- Remove disk_Page_server_perm_volume_count 
  - On ATS, this is used only for booting process
  - On PTS, this is not updated during replication.

more details are in Jira