### PR TITLE
[LETS-525] Fixed the core occurred during recovery on PTS

### DIFF
--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4157,6 +4157,8 @@ logtb_complete_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool committed)
 
   logtb_tran_clear_update_stats (&tdes->log_upd_stats);
 
+  tdes->last_mvcc_lsa.set_null ();
+
   if (is_perf_tracking)
     {
       tsc_getticks (&end_tick);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4133,9 +4133,13 @@ logtb_complete_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool committed)
 	  log_append_assigned_mvccid (thread_p, mvccid);
 	}
       mvcc_table->complete_mvcc (tran_index, mvccid, committed);
+
+      tdes->last_mvcc_lsa.set_null ();
     }
   else
     {
+      assert (tdes->last_mvcc_lsa.is_null ());
+
       if (committed && logtb_tran_update_all_global_unique_stats (thread_p) != NO_ERROR)
 	{
 	  assert (false);
@@ -4156,8 +4160,6 @@ logtb_complete_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool committed)
   curr_mvcc_info->reset ();
 
   logtb_tran_clear_update_stats (&tdes->log_upd_stats);
-
-  tdes->last_mvcc_lsa.set_null ();
 
   if (is_perf_tracking)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-525

Purpose

Added information related to mvcc that is not initialized at the time of commit.
The mvccid of a specific transaction is initialized, but if the address of the last mvcc log record (last_mvcc_lsa) is not initialized, a core occurs when performing recovery in PTS.
This is because PTS sees that the mvcc log of the transaction exists, but there is no mvccid.
more details are in jira. 