### PR TITLE
[LETS-537] refactor atomic replicator helper page bookkeeping

### DIFF
--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -371,12 +371,13 @@ namespace cublog
     // they come to be read by the PTS and some might be unfixed and refixed after the apply procedure
     // leading to inconsistency. To avoid this situation we sequentially apply each log redo of the sequence
     // when the end sequence log appears and the entire sequence is fixed
-    for (size_t i = 0; i < m_log_vec.size (); i++)
+    for (const auto &log_entry : m_log_vec)
       {
-	m_log_vec[i].apply_log_redo (thread_p, m_redo_context);
+	log_entry.apply_log_redo (thread_p, m_redo_context);
 	// bookkeeping actually will either unfix the page or just decrease its reference count
-	m_page_ptr_bookkeeping.unfix_page (thread_p, m_log_vec[i].m_vpid);
+	m_page_ptr_bookkeeping.unfix_page (thread_p, log_entry.m_vpid);
       }
+    m_log_vec.clear ();
   }
 
   log_lsa
@@ -409,7 +410,7 @@ namespace cublog
 
   void
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::apply_log_redo (
-	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context)
+	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context) const
   {
     const int error_code = redo_context.m_reader.set_lsa_and_fetch_page (m_record_lsa, log_reader::fetch_mode::FORCE);
     if (error_code != NO_ERROR)

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -568,15 +568,16 @@ namespace cublog
     switch (rcv_index)
       {
       case RVHF_INSERT:
-      case RVHF_MVCC_INSERT:
       case RVHF_DELETE:
+      case RVHF_UPDATE:
+      case RVHF_MVCC_INSERT:
       case RVHF_MVCC_DELETE_REC_HOME:
       case RVHF_MVCC_DELETE_OVERFLOW:
       case RVHF_MVCC_DELETE_REC_NEWHOME:
       case RVHF_MVCC_DELETE_MODIFY_HOME:
-      case RVHF_UPDATE:
-      case RVHF_MVCC_UPDATE_OVERFLOW:
+      case RVHF_UPDATE_NOTIFY_VACUUM:
       case RVHF_INSERT_NEWHOME:
+      case RVHF_MVCC_UPDATE_OVERFLOW:
       {
 	assert (watcher_uptr == nullptr);
 
@@ -619,15 +620,16 @@ namespace cublog
     switch (rcv_index)
       {
       case RVHF_INSERT:
-      case RVHF_MVCC_INSERT:
       case RVHF_DELETE:
+      case RVHF_UPDATE:
+      case RVHF_MVCC_INSERT:
       case RVHF_MVCC_DELETE_REC_HOME:
       case RVHF_MVCC_DELETE_OVERFLOW:
       case RVHF_MVCC_DELETE_REC_NEWHOME:
       case RVHF_MVCC_DELETE_MODIFY_HOME:
-      case RVHF_UPDATE:
-      case RVHF_MVCC_UPDATE_OVERFLOW:
+      case RVHF_UPDATE_NOTIFY_VACUUM:
       case RVHF_INSERT_NEWHOME:
+      case RVHF_MVCC_UPDATE_OVERFLOW:
 	assert (page_ptr == nullptr);
 	// other sanity asserts inside the function
 	pgbuf_ordered_unfix (thread_p, watcher_uptr.get ());

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -54,10 +54,12 @@ namespace cublog
     const auto sequence_it = m_sequences_map.find (tranid);
     if (sequence_it == m_sequences_map.cend ())
       {
+	assert (false);
 	return ER_FAILED;
       }
 
-    int error_code = sequence_it->second.add_atomic_replication_log (thread_p, record_lsa, rcvindex, vpid);
+    atomic_log_sequence &sequence = sequence_it->second;
+    int error_code = sequence.add_atomic_replication_log (thread_p, record_lsa, rcvindex, vpid);
     if (error_code != NO_ERROR)
       {
 	return error_code;
@@ -106,7 +108,6 @@ namespace cublog
 
     return false;
   }
-
 
   void
   atomic_replication_helper::start_sequence_internal (TRANID trid, LOG_LSA start_lsa,
@@ -395,13 +396,15 @@ namespace cublog
     , m_record_index { rcvindex }
     , m_page_ptr { page_ptr }
   {
-    assert (lsa != NULL_LSA);
+    assert (!VPID_ISNULL (&m_vpid));
+    assert (m_record_lsa != NULL_LSA);
+    assert (0 <= m_record_index && m_record_index <= RV_LAST_LOGID);
+    assert (m_page_ptr != nullptr);
   }
 
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::atomic_log_entry (atomic_log_entry &&that)
     : atomic_log_entry (that.m_record_lsa, that.m_vpid, that.m_record_index, that.m_page_ptr)
   {
-    that.m_page_ptr = nullptr;
   }
 
   void

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -466,7 +466,7 @@ namespace cublog
 
   atomic_replication_helper::atomic_log_sequence::page_ptr_bookkeeping::~page_ptr_bookkeeping ()
   {
-    assert (m_.empty ());
+    assert (m_page_ptr_info_map.empty ());
   }
 
   int
@@ -477,8 +477,8 @@ namespace cublog
 
     page_ptr_info *info_p = nullptr;
 
-    const auto find_it = m_.find (vpid);
-    if (find_it != m_.cend ())
+    const auto find_it = m_page_ptr_info_map.find (vpid);
+    if (find_it != m_page_ptr_info_map.cend ())
       {
 	info_p = &find_it->second;
 
@@ -498,7 +498,7 @@ namespace cublog
 	  }
 
 	std::pair<page_ptr_info_map_type::iterator, bool> insert_res
-	  = m_.emplace (vpid, std::move (page_ptr_info ()));
+	  = m_page_ptr_info_map.emplace (vpid, std::move (page_ptr_info ()));
 	assert (insert_res.second);
 
 	info_p = &insert_res.first->second;
@@ -529,8 +529,8 @@ namespace cublog
   atomic_replication_helper::atomic_log_sequence::page_ptr_bookkeeping::unfix_page (
 	  THREAD_ENTRY *thread_p, VPID vpid)
   {
-    const auto find_it = m_.find (vpid);
-    if (find_it != m_.cend ())
+    const auto find_it = m_page_ptr_info_map.find (vpid);
+    if (find_it != m_page_ptr_info_map.cend ())
       {
 	page_ptr_info &info = find_it->second;
 
@@ -545,7 +545,7 @@ namespace cublog
 		info.m_watcher_p.reset ();
 	      }
 
-	    m_.erase (find_it);
+	    m_page_ptr_info_map.erase (find_it);
 	  }
 
 	return NO_ERROR;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -184,7 +184,7 @@ namespace cublog
 	      const LOG_RCVINDEX m_record_index;
 	      // ownership of page pointer is with the bookkeeper in the owning class; this is just a
 	      // reference to allow applying the redo function when needed
-	      PAGE_PTR m_page_ptr;
+	      PAGE_PTR const m_page_ptr;
 	  };
 
 	  using page_ptr_watcher_uptr_type = std::unique_ptr<PGBUF_WATCHER>;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -159,7 +159,9 @@ namespace cublog
 	  log_lsa get_start_lsa () const;
 
 	private: // methods
+#if (0)
 	  void apply_all_log_redos (THREAD_ENTRY *thread_p);
+#endif
 
 	private: // types
 	  /*
@@ -169,12 +171,14 @@ namespace cublog
 	  {
 	    public:
 	      atomic_log_entry () = delete;
-	      atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex);
+	      atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr);
 
 	      atomic_log_entry (const atomic_log_entry &) = delete;
 	      atomic_log_entry (atomic_log_entry &&that);
 
+#if (0)
 	      ~atomic_log_entry ();
+#endif
 
 	      atomic_log_entry &operator= (const atomic_log_entry &) = delete;
 	      atomic_log_entry &operator= (atomic_log_entry &&) = delete;
@@ -182,11 +186,13 @@ namespace cublog
 	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context);
 	      template <typename T>
 	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, LOG_RECTYPE rectype);
+#if (0)
 	      int fix_page (THREAD_ENTRY *thread_p);
 	      void unfix_page (THREAD_ENTRY *thread_p);
 	      PAGE_PTR get_page_ptr ();
 	      void set_page_ptr (const PAGE_PTR &ptr);
 	      LOG_LSA get_lsa () const;
+#endif
 
 	      const VPID m_vpid;
 	    private:
@@ -194,11 +200,72 @@ namespace cublog
 	      const LOG_RCVINDEX m_record_index;
 	      PAGE_PTR m_page_ptr;
 
+#if (0)
 	      std::unique_ptr<PGBUF_WATCHER> m_watcher_p;
+#endif
+	  };
+
+	  using page_ptr_watcher_uptr_type = std::unique_ptr<PGBUF_WATCHER>;
+
+	  struct page_ptr_info_type
+	  {
+	    page_ptr_info_type () = default;
+
+	    page_ptr_info_type (const page_ptr_info_type &) = delete;
+	    page_ptr_info_type (page_ptr_info_type &&) = default;
+
+	    page_ptr_info_type &operator= (const page_ptr_info_type &) = delete;
+	    page_ptr_info_type &operator= (page_ptr_info_type &&) = delete;
+
+	    ~page_ptr_info_type ();
+
+	    VPID m_vpid = VPID_INITIALIZER;
+	    LOG_RCVINDEX m_rcv_index = RV_NOT_DEFINED;
+	    PAGE_PTR m_page_p = nullptr;
+	    page_ptr_watcher_uptr_type m_watcher_p;
+	    int m_ref_count = -1;
+	  };
+
+	  /*
+	   * Implements a RAII-like reference counted functionality to bokkeep page pointers for
+	   * a sequence of [possibly] nested atomic replication sub-sequences.
+	   * A page can be needed by multiple levels of a nested atomic replication sequence which
+	   * perfom changes on the page. Once the page is unfixed in a sequence at a certain
+	   * level, it can be:
+	   *  - either still kept fixed if a parent [sub]sequence did the fixing and still
+	   *    needs the page
+	   *  - or unfixed if there is no parent [sub]sequence which needs the page anymore (aka:
+	   *    the [sub]sequence which just requested the fix is the outer-most one that needed
+	   *    the page in the current overall sequence of possibly nested [sub]sequences
+	   */
+	  struct page_ptr_bookkeeping
+	  {
+	    public:
+	      page_ptr_bookkeeping () = default;
+	      ~page_ptr_bookkeeping ();
+
+	      page_ptr_bookkeeping (const page_ptr_bookkeeping &) = delete;
+	      page_ptr_bookkeeping (page_ptr_bookkeeping &&) = delete;
+
+	      page_ptr_bookkeeping &operator= (const page_ptr_bookkeeping &) = delete;
+	      page_ptr_bookkeeping &operator= (page_ptr_bookkeeping &&) = delete;
+
+	    public: // methods
+	      int fix_page (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index, PAGE_PTR &page_ptr_out);
+	      int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
+
+	    private: // types
+
+	      using page_ptr_info_map_type = std::map<VPID, page_ptr_info_type>;
+
+	    private: // variables
+	      page_ptr_info_map_type m_;
 	  };
 
 	  using atomic_log_entry_vector_type = std::vector<atomic_log_entry>;
+#if (0)
 	  using vpid_to_page_ptr_map_type = std::map<VPID, PAGE_PTR>;
+#endif
 
 	private: // variables
 	  /* The LSA of the log record which started this atomic sequence.
@@ -215,7 +282,10 @@ namespace cublog
 
 	  log_rv_redo_context m_redo_context;
 	  atomic_log_entry_vector_type m_log_vec;
+#if (0)
 	  vpid_to_page_ptr_map_type m_page_map;
+#endif
+	  page_ptr_bookkeeping m_page_ptr_bookkeeping;
       };
 
       using sequence_map_type = std::map<TRANID, atomic_log_sequence>;
@@ -237,12 +307,18 @@ namespace cublog
 #endif
   };
 
+  int pgbuf_fix_or_ordered_fix (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index,
+				std::unique_ptr<PGBUF_WATCHER> &watcher_up, PAGE_PTR &page_p);
+  void pgbuf_unfix_or_ordered_unfix (THREAD_ENTRY *thread_p, LOG_RCVINDEX rcv_index,
+				     std::unique_ptr<PGBUF_WATCHER> &watcher_up, PAGE_PTR &page_p);
+
   template <typename T>
   void
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::apply_log_by_type (
 	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, LOG_RECTYPE rectype)
   {
     LOG_RCV rcv;
+#if (0)
     if (m_page_ptr != nullptr)
       {
 	assert (m_watcher_p == nullptr);
@@ -253,6 +329,9 @@ namespace cublog
 	assert (m_watcher_p != nullptr && m_watcher_p->pgptr != nullptr);
 	rcv.pgptr = m_watcher_p->pgptr;
       }
+#endif
+    assert (m_page_ptr != nullptr);
+    rcv.pgptr = m_page_ptr;
 
     redo_context.m_reader.advance_when_does_not_fit (sizeof (T));
     const log_rv_redo_rec_info<T> record_info (m_record_lsa, rectype,
@@ -264,11 +343,13 @@ namespace cublog
       }
   }
 
+#if (0)
   inline LOG_LSA
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::get_lsa () const
   {
     return m_record_lsa;
   }
+#endif
 }
 
 #endif // _ATOMIC_REPLICATION_HELPER_HPP_

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -208,7 +208,7 @@ namespace cublog
 	  };
 
 	  /*
-	   * Implements a RAII-like reference counted functionality to bokkeep page pointers for
+	   * Implements a RAII-like reference counted functionality to bookkeep page pointers for
 	   * a sequence of [possibly] nested atomic replication sub-sequences.
 	   * A page can be needed by multiple levels of a nested atomic replication sequence which
 	   * perfom changes on the page. Once the page is unfixed in a sequence at a certain

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -162,30 +162,28 @@ namespace cublog
 	  /*
 	   * Holds the log record information necessary for recovery redo
 	   */
-	  class atomic_log_entry
+	  struct atomic_log_entry
 	  {
-	    public:
-	      atomic_log_entry () = delete;
-	      atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr);
+	    atomic_log_entry () = delete;
+	    atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr);
 
-	      atomic_log_entry (const atomic_log_entry &) = delete;
-	      atomic_log_entry (atomic_log_entry &&that);
+	    atomic_log_entry (const atomic_log_entry &) = delete;
+	    atomic_log_entry (atomic_log_entry &&that);
 
-	      atomic_log_entry &operator= (const atomic_log_entry &) = delete;
-	      atomic_log_entry &operator= (atomic_log_entry &&) = delete;
+	    atomic_log_entry &operator= (const atomic_log_entry &) = delete;
+	    atomic_log_entry &operator= (atomic_log_entry &&) = delete;
 
-	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context) const;
-	      template <typename T>
-	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
-				      LOG_RECTYPE rectype) const;
+	    void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context) const;
+	    template <typename T>
+	    void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
+				    LOG_RECTYPE rectype) const;
 
-	      const VPID m_vpid;
-	    private:
-	      const log_lsa m_record_lsa;
-	      const LOG_RCVINDEX m_record_index;
-	      // ownership of page pointer is with the bookkeeper in the owning class; this is just a
-	      // reference to allow applying the redo function when needed
-	      PAGE_PTR const m_page_ptr;
+	    const VPID m_vpid;
+	    const log_lsa m_record_lsa;
+	    const LOG_RCVINDEX m_record_index;
+	    // ownership of page pointer is with the bookkeeper in the owning class; this is just a
+	    // reference to allow applying the redo function when needed
+	    PAGE_PTR const m_page_ptr;
 	  };
 
 	  using page_ptr_watcher_uptr_type = std::unique_ptr<PGBUF_WATCHER>;
@@ -223,25 +221,21 @@ namespace cublog
 	   */
 	  struct page_ptr_bookkeeping
 	  {
-	    public:
-	      page_ptr_bookkeeping () = default;
-	      ~page_ptr_bookkeeping ();
+	    page_ptr_bookkeeping () = default;
+	    ~page_ptr_bookkeeping ();
 
-	      page_ptr_bookkeeping (const page_ptr_bookkeeping &) = delete;
-	      page_ptr_bookkeeping (page_ptr_bookkeeping &&) = delete;
+	    page_ptr_bookkeeping (const page_ptr_bookkeeping &) = delete;
+	    page_ptr_bookkeeping (page_ptr_bookkeeping &&) = delete;
 
-	      page_ptr_bookkeeping &operator= (const page_ptr_bookkeeping &) = delete;
-	      page_ptr_bookkeeping &operator= (page_ptr_bookkeeping &&) = delete;
+	    page_ptr_bookkeeping &operator= (const page_ptr_bookkeeping &) = delete;
+	    page_ptr_bookkeeping &operator= (page_ptr_bookkeeping &&) = delete;
 
-	    public: // methods
-	      int fix_page (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index, PAGE_PTR &page_ptr_out);
-	      int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
+	    int fix_page (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index, PAGE_PTR &page_ptr_out);
+	    int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
 
-	    private: // types
-	      using page_ptr_info_map_type = std::map<VPID, page_ptr_info>;
+	    using page_ptr_info_map_type = std::map<VPID, page_ptr_info>;
 
-	    private: // variables
-	      page_ptr_info_map_type m_;
+	    page_ptr_info_map_type m_page_ptr_info_map;
 	  };
 
 	  using atomic_log_entry_vector_type = std::vector<atomic_log_entry>;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -237,7 +237,6 @@ namespace cublog
 	      int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
 
 	    private: // types
-
 	      using page_ptr_info_map_type = std::map<VPID, page_ptr_info>;
 
 	    private: // variables
@@ -284,9 +283,13 @@ namespace cublog
   };
 
   int pgbuf_fix_or_ordered_fix (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index,
-				std::unique_ptr<PGBUF_WATCHER> &watcher_up, PAGE_PTR &page_p);
+				std::unique_ptr<PGBUF_WATCHER> &watcher_uptr, PAGE_PTR &page_ptr);
   void pgbuf_unfix_or_ordered_unfix (THREAD_ENTRY *thread_p, LOG_RCVINDEX rcv_index,
-				     std::unique_ptr<PGBUF_WATCHER> &watcher_up, PAGE_PTR &page_p);
+				     std::unique_ptr<PGBUF_WATCHER> &watcher_uptr, PAGE_PTR &page_ptr);
+
+  /*********************************************************************************************************
+   * template functions implementations
+   *********************************************************************************************************/
 
   template <typename T>
   void

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -174,9 +174,10 @@ namespace cublog
 	      atomic_log_entry &operator= (const atomic_log_entry &) = delete;
 	      atomic_log_entry &operator= (atomic_log_entry &&) = delete;
 
-	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context);
+	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context) const;
 	      template <typename T>
-	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, LOG_RECTYPE rectype);
+	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
+				      LOG_RECTYPE rectype) const;
 
 	      const VPID m_vpid;
 	    private:
@@ -294,7 +295,7 @@ namespace cublog
   template <typename T>
   void
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::apply_log_by_type (
-	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, LOG_RECTYPE rectype)
+	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, LOG_RECTYPE rectype) const
   {
     LOG_RCV rcv;
     assert (m_page_ptr != nullptr);

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -237,6 +237,8 @@ namespace cublog
 	if (m_atomic_helper.is_part_of_atomic_replication (rec_header.trid))
 	  {
 	    const VPID log_vpid = log_rv_get_log_rec_vpid<T> (record_info.m_logrec);
+	    // return code ignored because it refers to failure to fix heap page
+	    // this is expected in the context of passive transaction server
 	    (void) m_atomic_helper.add_atomic_replication_log (&thread_entry, rec_header.trid, rec_lsa, rcvindex, log_vpid);
 	  }
 	else


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-537

Refactored internal bookkeeping of an atomic replication sequences to allow for atomic sequences where multiple log records refer to the same VPID.
Thus, it is needed for a "reference counting"-like functionality to be implemented such that the page is only unfixed when the last log record from a sequence that affects that page is applied and done.

Implementation:
- previously a bookkeeping functionality - but without reference counting - was implemented with the help of `vpid_to_page_ptr_map_type m_page_map`
- the functionality of this map was taken over by a new class `page_ptr_bookkeeping` which is instantiated in each atomic replication sequence instance
- this bookkeeping class knows everything about a page: vpid, recovery index, fix type (normal or ordered fix), reference count
- the only result that the class outputs is the page pointer - via the `fix_page`, `unfix_page` functions
- extra page pointer related information that existed in `atomic_log_entry` class was moved to a helper structure - `page_ptr_info` - used by the bookkeeping logic

Other:
- extracted the actual implementation of the fix/unfix in two stand-alone functions - `pgbuf_fix_or_ordered_fix` and `pgbuf_unfix_or_ordered_unfix`