### PR TITLE
[LETS-458] return invalid values to fix VisualC++ build

### DIFF
--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -528,6 +528,7 @@ namespace cublog
      * Anyway, now get_highest_processed_lsa() is only used on PTS, so assert(false) here.
      */
     assert (false);
+    return MAX_LSA;
   }
 
   log_lsa
@@ -543,6 +544,7 @@ namespace cublog
     // a different value will return from here when the atomic replicator is added
     // for now this part should not be reached
     assert (false);
+    return MAX_LSA;
   }
 
   /*********************************************************************


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-458

fix VisualC++ build; fallout from previous patch
