### PR TITLE
[LETS-547] Passive Transaction Server updates MVCC status information to Page Server

### DIFF
--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -168,7 +168,7 @@ void passive_tran_server::start_oldest_active_mvccid_sender ()
   assert (m_oldest_active_mvccid_sender != nullptr); // when create_daemon() fails
 }
 
-void passive_tran_server::send_oldest_active_mvccid (cubthread::entry &thread_entry)
+void passive_tran_server::send_oldest_active_mvccid (cubthread::entry &)
 {
   std::string request_message;
 

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -27,6 +27,8 @@
 passive_tran_server::~passive_tran_server ()
 {
   assert (m_replicator == nullptr);
+
+  cubthread::get_manager ()->destroy_daemon (m_oldest_active_mvccid_sender);
 }
 
 bool
@@ -163,7 +165,7 @@ void passive_tran_server::start_oldest_active_mvccid_sender ()
   m_oldest_active_mvccid_sender = cubthread::get_manager ()->create_daemon (loop, sender_entry,
 				  "passive_tran_server::oldest_active_mvccid_sender");
 
-  assert (m_oldest_active_mvccid_sender != nullptr);
+  assert (m_oldest_active_mvccid_sender != nullptr); // when create_daemon() fails
 }
 
 void passive_tran_server::send_oldest_active_mvccid (cubthread::entry &thread_entry)

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -34,8 +34,9 @@ class passive_tran_server : public tran_server
     int send_and_receive_log_boot_info (THREAD_ENTRY *thread_p,
 					log_lsa &most_recent_trantable_snapshot_lsa);
     void start_log_replicator (const log_lsa &start_lsa, const log_lsa &prev_lsa);
+    void start_oldest_active_mvccid_sender ();
+
     void send_and_receive_stop_log_prior_dispatch ();
-    void send_oldest_active_mvccid ();
 
     /* highest processed lsa, to be used for retrieve pages from PS */
     log_lsa get_highest_processed_lsa () const;
@@ -45,6 +46,8 @@ class passive_tran_server : public tran_server
     void wait_replication_past_target_lsa (LOG_LSA lsa);
 
   private:
+    void send_oldest_active_mvccid (cubthread::entry &thread_entry);
+
     bool uses_remote_storage () const final override;
     bool get_remote_storage_config () final override;
     void on_boot () final override;
@@ -53,8 +56,8 @@ class passive_tran_server : public tran_server
     void receive_log_prior_list (page_server_conn_t::sequenced_payload &a_ip);
 
   private:
-
     std::unique_ptr<cublog::replicator> m_replicator;
+    cubthread::daemon *m_oldest_active_mvccid_sender = nullptr;
 };
 
 #endif // !_passive_tran_server_HPP_

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -58,6 +58,8 @@ class passive_tran_server : public tran_server
   private:
     std::unique_ptr<cublog::replicator> m_replicator;
     cubthread::daemon *m_oldest_active_mvccid_sender = nullptr;
+    /* the oldest visible mvcc id considering the replicator and RO transactions */
+    MVCCID m_oldest_active_mvccid = MVCCID_NULL;
 };
 
 #endif // !_passive_tran_server_HPP_

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1703,7 +1703,7 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
 
   logpb_initialize_logging_statistics ();
 
-  pts_ptr->send_oldest_active_mvccid ();	/* TODO not here acutally, just for testing. will be removed soon */
+  pts_ptr->start_oldest_active_mvccid_sender ();
 
   er_log_debug (ARG_FILE_LINE, "log_initialize_passive_tran_server: end of log initializaton, append_lsa = (%lld|%d)\n",
 		LSA_AS_ARGS (&log_Gl.hdr.append_lsa));

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1679,6 +1679,8 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
 
   log_daemons_init ();
 
+  pts_ptr->start_oldest_active_mvccid_sender ();
+
   pts_ptr->start_log_replicator (replication_start_redo_lsa, replication_prev_redo_lsa);
 
   // NOTE: make sure not to re-define trantable here; already defined in boot_restart_server
@@ -1702,8 +1704,6 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
   log_Gl.rcv_phase = LOG_RESTARTED;
 
   logpb_initialize_logging_statistics ();
-
-  pts_ptr->start_oldest_active_mvccid_sender ();
 
   er_log_debug (ARG_FILE_LINE, "log_initialize_passive_tran_server: end of log initializaton, append_lsa = (%lld|%d)\n",
 		LSA_AS_ARGS (&log_Gl.hdr.append_lsa));


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-547

- Get the mvccid from `log_Gl.mvcc_table.update_global_oldest_visible()`, which already takes the replicator's and active transactions' into account.
-- if no trx and replication is done, it points to the last replicated trx's mvccid + 1
- Add a daemon sending the mvccid in `class passive_tran_server`. It sends the mvccid periodically only if it's been changed.
- The deamon starts at the end of `log_initialize_passive_tran_server()`.

Please feel free to leave feedback about anything: C++ syntax/semantics, the location of variables, or whatever.