### PR TITLE
[CBRD-24486] file_Tempcache memory handling refactoring

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -8934,7 +8934,6 @@ file_tempcache_init (void)
   if (file_Tempcache.tran_files == NULL)
     {
       pthread_mutex_destroy (&file_Tempcache.mutex);
-      free_and_init (file_Tempcache);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, memsize);
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24486

Purpose

file_manager.c: 8943
```
-  memsize = ntrans * sizeof (FILE_TEMPCACHE *);
+  memsize = ntrans * sizeof (FILE_TEMPCACHE_ENTRY *);
```
This shouldn't be a problem since it is a pointer, but it can be confusing.

file_manager.c: 500
```
-  static FILE_TEMPCACHE *file_Tempcache = NULL;
+  static FILE_TEMPCACHE file_Tempcache;
```
Reduce unnecessary heap usage for memory stability. Then fix the part where `file_Tempcache` is used as a pointer.

Implementation
N/A

Remarks
N/A