### PR TITLE
[LETS-509] Revert the latch condition to unconditional when fix the btree current page

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -24837,7 +24837,8 @@ btree_range_scan_descending_fix_prev_leaf (THREAD_ENTRY * thread_p, BTREE_SCAN *
   /* Pages are still linked. */
 
   /* Fix current page too. */
-  bts->C_page = pgbuf_fix_old_and_check_repl_desync (thread_p, bts->C_vpid, PGBUF_LATCH_READ, PGBUF_CONDITIONAL_LATCH);
+  bts->C_page =
+    pgbuf_fix_old_and_check_repl_desync (thread_p, bts->C_vpid, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
 
   if (bts->C_page == NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/lets-509

Purpose

Revert the change in LETS-279 which modifies the latch condition used when fixing the btree page.
If it try to fix the page using PGBUF_CONDITIONAL_LATCH, it may fail to fix the page without setting any error code. 
Then the assert statement below fails because there is no error code even if it fails to fix the page.
So, this is to change the condition from `PGBUF_CONDITIONAL_LATCH` to `PGBUF_UNCONDITIONAL_LATCH`