### PR TITLE
[CBRD-24491] backport of #3828 to 11.2 - add prolinux and oracle for ncurses6 sym link

### DIFF
--- a/contrib/scripts/cubrid.csh
+++ b/contrib/scripts/cubrid.csh
@@ -43,10 +43,18 @@ switch ($OS)
   case "centos":
   case "redhat":
   case "rocky":
+  case "oracle":
     if ( ! -f /lib64/libncurses.so.5 && ! -f $LIB/libncurses.so.5 ) then
     	ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
     	ln -s /lib64/libform.so.6 $LIB/libform.so.5
     	ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
+    endif
+    breaksw
+  case "prolinux":
+    if ( ! -f /usr/lib64/libncurses.so.5 && ! -f $LIB/libncurses.so.5 ) then
+        ln -s /usr/lib64/libncurses.so.6 $LIB/libncurses.so.5
+        ln -s /usr/lib64/libform.so.6 $LIB/libform.so.5
+        ln -s /usr/lib64/libtinfo.so.6 $LIB/libtinfo.so.5
     endif
     breaksw
   case "ubuntu":

--- a/contrib/scripts/cubrid.sh
+++ b/contrib/scripts/cubrid.sh
@@ -34,11 +34,18 @@ elif [ -f /etc/os-release ];then
 fi
 
 case $OS in
-	fedoraproject | centos | redhat | rocky)
+	fedoraproject | centos | redhat | rocky | oracle)
 		if [ ! -h /lib64/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
 			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
 			ln -s /lib64/libform.so.6 $LIB/libform.so.5
 			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
+		fi
+		;;
+	prolinux)
+		if [ ! -h /usr/lib64/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
+			ln -s /usr/lib64/libncurses.so.6 $LIB/libncurses.so.5
+			ln -s /usr/lib64/libform.so.6 $LIB/libform.so.5
+			ln -s /usr/lib64/libtinfo.so.6 $LIB/libtinfo.so.5
 		fi
 		;;
 	ubuntu)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24491

**Purpose**
- backport of #3828 to release/11.2
- add 'prolinux' and 'oracle' to cubrid.sh for ncurses6 symbolic link

**Implementation**
N/A

**Remarks**