### PR TITLE
[LETS-548] Page Server collects and aggregates MVCC information received from Passive Transaction Servers

### DIFF
--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -432,7 +432,8 @@ page_server::set_passive_tran_server_connection (cubcomm::channel &&chn)
 
   const auto channel_id = chn.get_channel_id ();
 
-  er_log_debug (ARG_FILE_LINE, "Passive transaction server connected to this page server. Channel id: %s.\n", channel_id);
+  er_log_debug (ARG_FILE_LINE, "Passive transaction server connected to this page server. Channel id: %s.\n",
+		channel_id.c_str ());
 
   m_passive_tran_server_conn.emplace_back (new connection_handler (chn, transaction_server_type::PASSIVE, *this));
 

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -447,8 +447,8 @@ MVCCID page_server::pts_mvcc_tracker::get_global_oldest_active_mvccid ()
     }
 
   /* it can return either
-   * - MVCCID_LAST: no PTS is being trakced
-   * - or MVCCID_ALL_VISIBLE: some PTS are connected, but hasn't update
+   * - MVCCID_LAST: no PTS is being tracked
+   * - or MVCCID_ALL_VISIBLE: at least one PTS has connected, but hasn't updated yet
    * - or the computed oldest one */
   return oldest_mvccid;
 }

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -190,12 +190,13 @@ page_server::connection_handler::receive_oldest_active_mvccid (tran_server_conn_
 {
   const MVCCID oldest_mvccid = *reinterpret_cast<const MVCCID *const> (a_sp.pull_payload().c_str());
 
-  assert (m_ps.m_pts_oldest_active_mvccid.find (get_channel_id()) != m_ps.m_pts_oldest_active_mvccid.end());
-  assert (m_ps.m_pts_oldest_active_mvccid[get_channel_id()] < oldest_mvccid);
+  const auto channel_id = get_channel_id ();
+  assert (m_ps.m_pts_oldest_active_mvccid.find (channel_id) != m_ps.m_pts_oldest_active_mvccid.end());
+  assert (m_ps.m_pts_oldest_active_mvccid[channel_id] < oldest_mvccid);
 
   /* The mutex is not needed since one entry is only updated by one PTS connection handler.
    * The mutex is only needed when the conatiner can be changed (eg. rehasing). i.e. when an entry is added or removed. */
-  m_ps.m_pts_oldest_active_mvccid[get_channel_id()] = oldest_mvccid;
+  m_ps.m_pts_oldest_active_mvccid[channel_id] = oldest_mvccid;
 }
 
 void
@@ -417,7 +418,7 @@ page_server::set_passive_tran_server_connection (cubcomm::channel &&chn)
 
   chn.set_channel_name ("PTS_PS_comm");
 
-  const auto channel_id = chn.get_channel_id ().c_str ();
+  const auto channel_id = chn.get_channel_id ();
 
   er_log_debug (ARG_FILE_LINE, "Passive transaction server connected to this page server. Channel id: %s.\n", channel_id);
 

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -188,7 +188,7 @@ page_server::connection_handler::receive_stop_log_prior_dispatch (tran_server_co
 void
 page_server::connection_handler::receive_oldest_active_mvccid (tran_server_conn_t::sequenced_payload &a_sp)
 {
-  const MVCCID oldest_mvccid = *reinterpret_cast<const MVCCID *const> (a_sp.pull_payload().c_str());
+  const auto oldest_mvccid = *reinterpret_cast<const MVCCID *const> (a_sp.pull_payload().c_str());
 
   const auto channel_id = get_channel_id ();
   assert (m_ps.m_pts_oldest_active_mvccid.find (channel_id) != m_ps.m_pts_oldest_active_mvccid.end());
@@ -197,6 +197,18 @@ page_server::connection_handler::receive_oldest_active_mvccid (tran_server_conn_
   /* The mutex is not needed since one entry is only updated by one PTS connection handler.
    * The mutex is only needed when the conatiner can be changed (eg. rehasing). i.e. when an entry is added or removed. */
   m_ps.m_pts_oldest_active_mvccid[channel_id] = oldest_mvccid;
+
+#if !defined(NDEBUG)
+  std::string msg;
+  msg.append ("receive_oldest_active_mvccid: update the oldest active mvccid to " + std::to_string (
+		      oldest_mvccid) + " of " + channel_id);
+  msg.append ("\n oldest mvcc ids:");
+  for (const auto &it : m_ps.m_pts_oldest_active_mvccid)
+    {
+      msg.append (" " + std::to_string (it.second));
+    }
+  er_log_debug (ARG_FILE_LINE, msg.c_str());
+#endif
 }
 
 void

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -398,6 +398,8 @@ void page_server::pts_mvcc_tracker::init_oldest_active_mvccid (const std::string
 
 void page_server::pts_mvcc_tracker::update_oldest_active_mvccid (const std::string &pts_channel_id, const MVCCID mvccid)
 {
+  assert (MVCCID_IS_NORMAL (mvccid));
+
   std::lock_guard<std::mutex> lockg { m_pts_oldest_active_mvccids_mtx };
 
   /*

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -202,7 +202,10 @@ page_server::connection_handler::receive_disconnect_request (tran_server_conn_t:
   // passive transaction server - it should have been disconnected beforehand
   assert (m_prior_sender_sink_hook_func == nullptr);
 
-  m_ps.m_pts_mvcc_tracker.delete_oldest_active_mvccid (get_channel_id());
+  if (m_server_type == transaction_server_type::PASSIVE)
+    {
+      m_ps.m_pts_mvcc_tracker.delete_oldest_active_mvccid (get_channel_id());
+    }
 
   m_ps.disconnect_tran_server_async (this);
 }
@@ -236,14 +239,14 @@ page_server::connection_handler::abnormal_tran_server_disconnect (css_error_code
 			(int)error_code);
 
 	  remove_prior_sender_sink ();
+
+	  m_ps.m_pts_mvcc_tracker.delete_oldest_active_mvccid (get_channel_id());
 	}
       else
 	{
 	  er_log_debug (ARG_FILE_LINE, "abnormal_tran_server_disconnect: ATS disconnected from PS. Error code: %d\n",
 			(int)error_code);
 	}
-
-      m_ps.m_pts_mvcc_tracker.delete_oldest_active_mvccid (get_channel_id());
 
       m_ps.disconnect_tran_server_async (this);
 

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -403,7 +403,7 @@ void page_server::pts_mvcc_tracker::update_oldest_active_mvccid (const std::stri
   /*
    * 1. The entry is already created when ths PTS is connected.
    * 2. It is updated by the PTS only when it move foward.
-   *    Without update, it is MVCCID_ALL_VISIBLE by default, which is lesser than any mvccid assigned.
+   *    Without update, it is MVCCID_ALL_VISIBLE by default, which is lower than any mvccid assigned.
    */
   assert (m_pts_oldest_active_mvccids.find (pts_channel_id) != m_pts_oldest_active_mvccids.end());
   assert (m_pts_oldest_active_mvccids[pts_channel_id] < mvccid);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -447,7 +447,10 @@ page_server::set_passive_tran_server_connection (cubcomm::channel &&chn)
 
   {
     std::lock_guard<std::mutex> lockg { m_pts_oldest_active_mvccids_mtx };
-    /* The entry is already created when ths PTS is connected. */
+    /* The entry must not already be present. If the same passive transaction server has been connected
+     * before, the entry must have been removed when the PTS disconnected or when the connection
+     *  to the PTS was aborted.
+     */
     assert (m_pts_oldest_active_mvccids.find (channel_id) == m_pts_oldest_active_mvccids.end());
 
     /* MVCCID_ALL_VISIBLE means that it hasn't yet received. It will prevent the ATS run vacuum. */

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -192,12 +192,11 @@ page_server::connection_handler::receive_oldest_active_mvccid (tran_server_conn_
 
   const auto oldest_mvccid = *reinterpret_cast<const MVCCID *const> (a_sp.pull_payload().c_str());
   const auto channel_id = get_channel_id ();
+  std::lock_guard<std::mutex> lockg { m_ps.m_pts_oldest_active_mvccids_mtx };
 
   assert (m_ps.m_pts_oldest_active_mvccids.find (channel_id) != m_ps.m_pts_oldest_active_mvccids.end());
   assert (m_ps.m_pts_oldest_active_mvccids[channel_id] < oldest_mvccid);
 
-  /* The mutex is not needed since one entry is only updated by one PTS connection handler.
-   * The mutex is only needed when the conatiner can be changed (eg. rehasing). i.e. when an entry is added or removed. */
   m_ps.m_pts_oldest_active_mvccids[channel_id] = oldest_mvccid;
 
 #if !defined(NDEBUG)

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -191,30 +191,8 @@ page_server::connection_handler::receive_oldest_active_mvccid (tran_server_conn_
   assert (m_server_type == transaction_server_type::PASSIVE);
 
   const auto oldest_mvccid = *reinterpret_cast<const MVCCID *const> (a_sp.pull_payload().c_str());
-  const auto channel_id = get_channel_id ();
-  std::lock_guard<std::mutex> lockg { m_ps.m_pts_oldest_active_mvccids_mtx };
 
-  /*
-   * 1. The entry is already created when ths PTS is connected.
-   * 2. It is updated by the PTS only when it move foward.
-   *    Without update, it is MVCCID_ALL_VISIBLE by default, which is lesser than any mvccid assigned.
-   */
-  assert (m_ps.m_pts_oldest_active_mvccids.find (channel_id) != m_ps.m_pts_oldest_active_mvccids.end());
-  assert (m_ps.m_pts_oldest_active_mvccids[channel_id] < oldest_mvccid);
-
-  m_ps.m_pts_oldest_active_mvccids[channel_id] = oldest_mvccid;
-
-#if !defined(NDEBUG)
-  std::string msg;
-  msg.append ("receive_oldest_active_mvccid: update the oldest active mvccid to " + std::to_string (
-		      oldest_mvccid) + " of " + channel_id);
-  msg.append ("\n oldest mvcc ids:");
-  for (const auto &it : m_ps.m_pts_oldest_active_mvccids)
-    {
-      msg.append (" " + std::to_string (it.second));
-    }
-  er_log_debug (ARG_FILE_LINE, msg.c_str());
-#endif
+  m_ps.m_pts_mvcc_tracker.update_oldest_active_mvccid (get_channel_id (), oldest_mvccid);
 }
 
 void
@@ -224,12 +202,7 @@ page_server::connection_handler::receive_disconnect_request (tran_server_conn_t:
   // passive transaction server - it should have been disconnected beforehand
   assert (m_prior_sender_sink_hook_func == nullptr);
 
-  {
-    std::lock_guard<std::mutex> lockg { m_ps.m_pts_oldest_active_mvccids_mtx };
-    /* The entry is already created when ths PTS is connected. */
-    assert (m_ps.m_pts_oldest_active_mvccids.find (get_channel_id()) != m_ps.m_pts_oldest_active_mvccids.end());
-    m_ps.m_pts_oldest_active_mvccids.erase (get_channel_id());
-  }
+  m_ps.m_pts_mvcc_tracker.delete_oldest_active_mvccid (get_channel_id());
 
   m_ps.disconnect_tran_server_async (this);
 }
@@ -270,12 +243,7 @@ page_server::connection_handler::abnormal_tran_server_disconnect (css_error_code
 			(int)error_code);
 	}
 
-      {
-	std::lock_guard<std::mutex> lockg { m_ps.m_pts_oldest_active_mvccids_mtx };
-	/* The entry is already created when ths PTS is connected. */
-	assert (m_ps.m_pts_oldest_active_mvccids.find (get_channel_id()) != m_ps.m_pts_oldest_active_mvccids.end());
-	m_ps.m_pts_oldest_active_mvccids.erase (get_channel_id());
-      }
+      m_ps.m_pts_mvcc_tracker.delete_oldest_active_mvccid (get_channel_id());
 
       m_ps.disconnect_tran_server_async (this);
 
@@ -409,6 +377,79 @@ page_server::async_disconnect_handler::disconnect_loop ()
     }
 }
 
+void page_server::pts_mvcc_tracker::init_oldest_active_mvccid (const std::string &pts_channel_id)
+{
+  std::lock_guard<std::mutex> lockg { m_pts_oldest_active_mvccids_mtx };
+  /*
+   * The entry must not already be present. If the same passive transaction server has been connected
+   * before, the entry must have been removed when the PTS disconnected or when the connection
+   *  to the PTS was aborted.
+   */
+  assert (m_pts_oldest_active_mvccids.find (pts_channel_id) == m_pts_oldest_active_mvccids.end());
+
+  /*
+   * MVCCID_ALL_VISIBLE means that it hasn't yet received. It will prevent the ATS to run vacuum.
+   * This is a guard for the window in which a PTS is connected but has't sent its oldest active mvccid.
+   * In this window, if we vaccum without considering the PTS, we possibly end up cleaning up the data
+   * a read-only transaction on the PTS see.
+   */
+  m_pts_oldest_active_mvccids[pts_channel_id] = MVCCID_ALL_VISIBLE;
+}
+
+void page_server::pts_mvcc_tracker::update_oldest_active_mvccid (const std::string &pts_channel_id, const MVCCID mvccid)
+{
+  std::lock_guard<std::mutex> lockg { m_pts_oldest_active_mvccids_mtx };
+
+  /*
+   * 1. The entry is already created when ths PTS is connected.
+   * 2. It is updated by the PTS only when it move foward.
+   *    Without update, it is MVCCID_ALL_VISIBLE by default, which is lesser than any mvccid assigned.
+   */
+  assert (m_pts_oldest_active_mvccids.find (pts_channel_id) != m_pts_oldest_active_mvccids.end());
+  assert (m_pts_oldest_active_mvccids[pts_channel_id] < mvccid);
+
+  m_pts_oldest_active_mvccids[pts_channel_id] = mvccid;
+
+#if !defined(NDEBUG)
+  std::string msg;
+  msg.append ("receive_oldest_active_mvccid: update the oldest active mvccid to " + std::to_string (
+		      mvccid) + " of " + pts_channel_id);
+  msg.append ("\n oldest mvcc ids:");
+  for (const auto &it : m_pts_oldest_active_mvccids)
+    {
+      msg.append (" " + std::to_string (it.second));
+    }
+  er_log_debug (ARG_FILE_LINE, msg.c_str());
+#endif
+}
+void page_server::pts_mvcc_tracker::delete_oldest_active_mvccid (const std::string &pts_channel_id)
+{
+  std::lock_guard<std::mutex> lockg { m_pts_oldest_active_mvccids_mtx };
+  /* The entry is already created when ths PTS is connected. */
+  assert (m_pts_oldest_active_mvccids.find (pts_channel_id) != m_pts_oldest_active_mvccids.end());
+  m_pts_oldest_active_mvccids.erase (pts_channel_id);
+}
+
+MVCCID page_server::pts_mvcc_tracker::get_global_oldest_active_mvccid ()
+{
+  std::lock_guard<std::mutex> lockg { m_pts_oldest_active_mvccids_mtx };
+
+  MVCCID oldest_mvccid = MVCCID_LAST;
+  for (const auto &it : m_pts_oldest_active_mvccids)
+    {
+      if (oldest_mvccid > it.second)
+	{
+	  oldest_mvccid = it.second;
+	}
+    }
+
+  /* it can return either
+   * - MVCCID_LAST: no PTS is being trakced
+   * - or MVCCID_ALL_VISIBLE: some PTS are connected, but hasn't update
+   * - or the computed oldest one */
+  return oldest_mvccid;
+}
+
 void
 page_server::set_active_tran_server_connection (cubcomm::channel &&chn)
 {
@@ -445,23 +486,7 @@ page_server::set_passive_tran_server_connection (cubcomm::channel &&chn)
 
   m_passive_tran_server_conn.emplace_back (new connection_handler (chn, transaction_server_type::PASSIVE, *this));
 
-  {
-    std::lock_guard<std::mutex> lockg { m_pts_oldest_active_mvccids_mtx };
-    /*
-     * The entry must not already be present. If the same passive transaction server has been connected
-     * before, the entry must have been removed when the PTS disconnected or when the connection
-     *  to the PTS was aborted.
-     */
-    assert (m_pts_oldest_active_mvccids.find (channel_id) == m_pts_oldest_active_mvccids.end());
-
-    /*
-     * MVCCID_ALL_VISIBLE means that it hasn't yet received. It will prevent the ATS to run vacuum.
-     * This is a guard for the window in which a PTS is connected but has't sent its oldest active mvccid.
-     * In this window, if we vaccum without considering the PTS, we possibly end up cleaning up the data
-     * a read-only transaction on the PTS see.
-     */
-    m_pts_oldest_active_mvccids[channel_id] = MVCCID_ALL_VISIBLE;
-  }
+  m_pts_mvcc_tracker.init_oldest_active_mvccid (channel_id);
 }
 
 void

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -414,14 +414,15 @@ void page_server::pts_mvcc_tracker::update_oldest_active_mvccid (const std::stri
 
 #if !defined(NDEBUG)
   std::string msg;
-  msg.append ("receive_oldest_active_mvccid: update the oldest active mvccid to " + std::to_string (
-		      mvccid) + " of " + pts_channel_id);
-  msg.append ("\n oldest mvcc ids:");
+  std::stringstream ss;
+  ss << "receive_oldest_active_mvccid: update the oldest active mvccid to " << mvccid << " of " << pts_channel_id <<
+     std::endl;
+  ss << "oldest mvcc ids:" ;
   for (const auto &it : m_pts_oldest_active_mvccids)
     {
-      msg.append (" " + std::to_string (it.second));
+      ss << " " << it.second;
     }
-  er_log_debug (ARG_FILE_LINE, msg.c_str());
+  er_log_debug (ARG_FILE_LINE, ss.str().c_str());
 #endif
 }
 void page_server::pts_mvcc_tracker::delete_oldest_active_mvccid (const std::string &pts_channel_id)

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -188,9 +188,11 @@ page_server::connection_handler::receive_stop_log_prior_dispatch (tran_server_co
 void
 page_server::connection_handler::receive_oldest_active_mvccid (tran_server_conn_t::sequenced_payload &a_sp)
 {
-  const auto oldest_mvccid = *reinterpret_cast<const MVCCID *const> (a_sp.pull_payload().c_str());
+  assert (m_server_type == transaction_server_type::PASSIVE);
 
+  const auto oldest_mvccid = *reinterpret_cast<const MVCCID *const> (a_sp.pull_payload().c_str());
   const auto channel_id = get_channel_id ();
+
   assert (m_ps.m_pts_oldest_active_mvccids.find (channel_id) != m_ps.m_pts_oldest_active_mvccids.end());
   assert (m_ps.m_pts_oldest_active_mvccids[channel_id] < oldest_mvccid);
 

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -210,9 +210,9 @@ class page_server
     connection_handler_uptr_t m_active_tran_server_conn;
     std::vector<connection_handler_uptr_t> m_passive_tran_server_conn;
 
-    std::unordered_map<std::string, MVCCID>
-    m_pts_oldest_active_mvccid; // <channel_id -> the oldest active mvccid of the PTS>. used by the vacuum on the ATS
-    std::mutex m_pts_oldest_active_mvccid_mtx;
+    /* <channel_id -> the oldest active mvccid of the PTS>. used by the vacuum on the ATS */
+    std::unordered_map<std::string, MVCCID> m_pts_oldest_active_mvccids;
+    std::mutex m_pts_oldest_active_mvccids_mtx;
 
     std::unique_ptr<cublog::replicator> m_replicator;
 

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -198,6 +198,35 @@ class page_server
 	std::thread m_thread;
     };
 
+    /*
+     * helper class to track the active oldest mvccids of each Page Transaction Server.
+     * This provides the globally oldest active mvcc id to the vacuum on ATS.
+     * The vacuum has to take mvcc status of all PTSes into considerations,
+     * or it would clean up some data seen by a active snapshot on a PTS.
+     */
+    class pts_mvcc_tracker
+    {
+      public:
+	pts_mvcc_tracker () = default;
+
+	pts_mvcc_tracker (const pts_mvcc_tracker &) = delete;
+	pts_mvcc_tracker (pts_mvcc_tracker &&) = delete;
+
+	pts_mvcc_tracker &operator = (const pts_mvcc_tracker &) = delete;
+	pts_mvcc_tracker &operator = (pts_mvcc_tracker &&) = delete;
+
+	void init_oldest_active_mvccid (const std::string &pts_channel_id);
+	void update_oldest_active_mvccid (const std::string &pts_channel_id, const MVCCID mvccid);
+	void delete_oldest_active_mvccid (const std::string &pts_channel_id);
+
+	MVCCID get_global_oldest_active_mvccid ();
+
+      private:
+	/* <channel_id -> the oldest active mvccid of the PTS>. used by the vacuum on the ATS */
+	std::unordered_map<std::string, MVCCID> m_pts_oldest_active_mvccids;
+	std::mutex m_pts_oldest_active_mvccids_mtx;
+    };
+
     using responder_t = server_request_responder<connection_handler::tran_server_conn_t>;
 
   private: // functions that depend on private types
@@ -210,15 +239,12 @@ class page_server
     connection_handler_uptr_t m_active_tran_server_conn;
     std::vector<connection_handler_uptr_t> m_passive_tran_server_conn;
 
-    /* <channel_id -> the oldest active mvccid of the PTS>. used by the vacuum on the ATS */
-    std::unordered_map<std::string, MVCCID> m_pts_oldest_active_mvccids;
-    std::mutex m_pts_oldest_active_mvccids_mtx;
-
     std::unique_ptr<cublog::replicator> m_replicator;
 
     std::unique_ptr<responder_t> m_responder;
 
     async_disconnect_handler m_async_disconnect_handler;
+    pts_mvcc_tracker m_pts_mvcc_tracker;
 };
 
 extern page_server ps_Gl;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -210,6 +210,10 @@ class page_server
     connection_handler_uptr_t m_active_tran_server_conn;
     std::vector<connection_handler_uptr_t> m_passive_tran_server_conn;
 
+    std::unordered_map<std::string, MVCCID>
+    m_pts_oldest_active_mvccid; // <channel_id -> the oldest active mvccid of the PTS>. used by the vacuum on the ATS
+    std::mutex m_pts_oldest_active_mvccid_mtx;
+
     std::unique_ptr<cublog::replicator> m_replicator;
 
     std::unique_ptr<responder_t> m_responder;

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -328,6 +328,7 @@ typedef int TRANID;		/* Transaction identifier */
 
 #define MVCCID_ALL_VISIBLE    ((MVCCID) 3)	/* visible for all transactions */
 #define MVCCID_FIRST	      ((MVCCID) 4)
+#define MVCCID_LAST	      ((MVCCID) -1)	/* UINT64 */
 
 /* is MVCC ID valid? */
 #define MVCCID_IS_VALID(id)	  ((id) != MVCCID_NULL)

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -328,7 +328,7 @@ typedef int TRANID;		/* Transaction identifier */
 
 #define MVCCID_ALL_VISIBLE    ((MVCCID) 3)	/* visible for all transactions */
 #define MVCCID_FIRST	      ((MVCCID) 4)
-#define MVCCID_LAST	      ((MVCCID) -1)	/* UINT64 */
+#define MVCCID_LAST	      ((MVCCID) UINT64_MAX)	/* UINT64 */
 
 /* is MVCC ID valid? */
 #define MVCCID_IS_VALID(id)	  ((id) != MVCCID_NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-548

- Add a class `pts_mvcc_tracker` in charge of tracking mvcc status from all PTSes.
- The hash map, m_pts_oldest_active_mvccids, has to be protected by a mutex when the container structure can be changed. The operations are thread-safe. It is updated and accessed by multiple threads: 
  - update an entry: each PTS connection handler
  - add an entry: css master thread handling requests
  - delete an entry: each PTS connection handler in a normal case or each PTS's request sender in an abnormal case.
  - retrieve an entry: the ATS connection handler
- I considered the connection handler's destructor as where the entry is deleted because other PS-related resources are cleaned up there. However, I think the disconnection handler is more suitable in that it's done synchronously and the entry doesn't belong to the connection.
- The channel_id used as the key of `m_pts_oldest_active_mvccids` has the same string for all PTS-PS connections, but I use it assuming it has to be different and hoping it will be fixed in another PR.  I have tested with `connection_handler*` as the key and confirmed this PR works. I can use this, but I think we should use the logical one, connection id, rather than the physical one, a pointer.