### PR TITLE
[LETS-525] Move the last_mvcc_lsa variable into the mvcc information structure 

### DIFF
--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1582,11 +1582,11 @@ prior_lsa_next_record_internal (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LO
        *  - will not be part of any log record, and thus will not matter with regard to vacuum */
 
       // Also set the transaction last MVCC lsa.
-      tdes->last_mvcc_lsa = node->start_lsa;
+      tdes->mvccinfo.last_mvcc_lsa = node->start_lsa;
     }
   else if (node->log_header.type == LOG_MVCC_REDO_DATA)
     {
-      tdes->last_mvcc_lsa = node->start_lsa;
+      tdes->mvccinfo.last_mvcc_lsa = node->start_lsa;
       // TODO: why isn't prior_update_header_mvcc_info called in this case as for the previous 'if' scope
       // as LOG_REC_MVCC_REDO does have mvccid?
     }

--- a/src/transaction/log_checkpoint_info.cpp
+++ b/src/transaction/log_checkpoint_info.cpp
@@ -233,7 +233,7 @@ namespace cublog
 	LSA_COPY (&chkpt_tran.savept_lsa, &tdes.savept_lsa);
 	LSA_COPY (&chkpt_tran.tail_topresult_lsa, &tdes.tail_topresult_lsa);
 	LSA_COPY (&chkpt_tran.start_postpone_lsa, &tdes.rcv.tran_start_postpone_lsa);
-	chkpt_tran.last_mvcc_lsa = tdes.last_mvcc_lsa;
+	chkpt_tran.last_mvcc_lsa = tdes.mvccinfo.last_mvcc_lsa;
 	std::strncpy (chkpt_tran.user_name, tdes.client.get_db_user (), LOG_USERNAME_MAX);
 
 	if (LSA_ISNULL (&smallest_lsa) || LSA_GT (&smallest_lsa, &tdes.head_lsa))
@@ -349,7 +349,7 @@ namespace cublog
 		// do not recover/register empty transaction
 		continue;
 	      }
-            // else, fall through to recover/register empty transactions
+	    // else, fall through to recover/register empty transactions
 	  }
 
 	/*
@@ -387,7 +387,7 @@ namespace cublog
 	LSA_COPY (&tdes->savept_lsa, &chkpt.savept_lsa);
 	LSA_COPY (&tdes->tail_topresult_lsa, &chkpt.tail_topresult_lsa);
 	LSA_COPY (&tdes->rcv.tran_start_postpone_lsa, &chkpt.start_postpone_lsa);
-	tdes->last_mvcc_lsa = chkpt.last_mvcc_lsa;
+	tdes->mvccinfo.last_mvcc_lsa = chkpt.last_mvcc_lsa;
 	tdes->mvccinfo.id = chkpt.mvcc_id;
 	if (chkpt.mvcc_sub_id != MVCCID_NULL)
 	  {

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -500,7 +500,6 @@ struct log_tdes
   LOG_LSA tail_topresult_lsa;	/* Address of last partial abort/commit */
   LOG_LSA commit_abort_lsa;	/* Address of the commit/abort operation. Used by checkpoint to decide whether to
 				 * consider or not a transaction as concluded. */
-  LOG_LSA last_mvcc_lsa;	/* The address of transaction's last MVCC log record. */
   LOG_LSA page_desync_lsa;	/* Only on PTS: the LSA of a page found to be ahead of replication, that could cause a page
 				 * desynchronization issue. */
   int client_id;		/* unique client id */

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1759,7 +1759,6 @@ log_rv_analysis_assigned_mvccid (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA *
 static void
 log_rv_analysis_complete_mvccid (int tran_index, const LOG_TDES * tdes)
 {
-  //TODO: if mvccinfo is reset in complete_mvcc, then move into it
   if (is_passive_transaction_server ())
     {
       if (MVCCID_IS_VALID (tdes->mvccinfo.id))
@@ -1802,8 +1801,8 @@ log_rv_analysis_complete (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_ls
 	  // newer quick fix on top of older quick fix: mark the mvccid as completed
 	  log_rv_analysis_complete_mvccid (tran_index, tdes);
 
-	  // quick fix: reset mvccid.
-	  tdes->mvccinfo.id = MVCCID_NULL;
+	  // quick fix: reset mvcc.
+	  tdes->mvccinfo.reset ();
 	  logtb_free_tran_index (thread_p, tran_index);
 	}
       return NO_ERROR;

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1801,8 +1801,8 @@ log_rv_analysis_complete (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_ls
 	  // newer quick fix on top of older quick fix: mark the mvccid as completed
 	  log_rv_analysis_complete_mvccid (tran_index, tdes);
 
-	  // quick fix: reset mvcc.
-	  tdes->mvccinfo.reset ();
+	  // quick fix: reset mvccid.
+	  tdes->mvccinfo.id = MVCCID_NULL;
 	  logtb_free_tran_index (thread_p, tran_index);
 	}
       return NO_ERROR;

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1600,6 +1600,7 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   logtb_tran_clear_update_stats (&tdes->log_upd_stats);
 
   assert (tdes->mvccinfo.id == MVCCID_NULL);
+  tdes->mvccinfo.reset ();
 
   if (BOOT_WRITE_ON_STANDY_CLIENT_TYPE (tdes->client.client_type))
     {

--- a/src/transaction/mvcc.c
+++ b/src/transaction/mvcc.c
@@ -678,6 +678,7 @@ mvcc_info::mvcc_info ()
   , id (MVCCID_NULL)
   , recent_snapshot_lowest_active_mvccid (MVCCID_NULL)
   , sub_ids ()
+  , last_mvcc_lsa (NULL_LSA)
 {
 }
 
@@ -694,5 +695,6 @@ mvcc_info::reset ()
   id = MVCCID_NULL;
   recent_snapshot_lowest_active_mvccid = MVCCID_NULL;
   sub_ids.clear ();
+  last_mvcc_lsa.set_null ();
 }
 // *INDENT-ON*

--- a/src/transaction/mvcc.h
+++ b/src/transaction/mvcc.h
@@ -210,6 +210,8 @@ struct mvcc_info
   // *INDENT-ON*
   bool is_sub_active;		/* true in case that sub-transaction is running */
 
+  LOG_LSA last_mvcc_lsa;	/* The address of transaction's last MVCC log record. */
+
   // *INDENT-OFF*
   mvcc_info ();
   void init ();

--- a/unit_tests/log/test_main_chkpt_info.cpp
+++ b/unit_tests/log/test_main_chkpt_info.cpp
@@ -558,7 +558,7 @@ test_env_chkpt::generate_tdes (int index)
   tdes->savept_lsa = generate_log_lsa ();
   tdes->tail_topresult_lsa = generate_log_lsa ();
   tdes->commit_abort_lsa = NULL_LSA;
-  tdes->last_mvcc_lsa = generate_log_lsa ();
+  tdes->mvccinfo.last_mvcc_lsa = generate_log_lsa ();
   tdes->rcv.tran_start_postpone_lsa = generate_log_lsa ();
   tdes->wait_msecs = rand () % MAX_RAND;
   tdes->client_id  = rand () % MAX_RAND;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-525

Purpose

tdes->last_mvcc_lsa is used whenever dealing with mvcc information, 
so it would be better to move tdes->last_mvcc_lsa to tdes->mvccinfo. 
Then it can be initialized or reset together with mvcc related information in mvccinfo.init () or mvccinfo.reset ().