### PR TITLE
[CBRD-24501] POC: extending dblink to DML

### DIFF
--- a/src/parser/xasl_generation.h
+++ b/src/parser/xasl_generation.h
@@ -138,6 +138,12 @@ extern char *query_Plan_dump_filename;
 extern FILE *query_Plan_dump_fp;
 extern bool query_Plan_dump_fp_open;
 
+extern ACCESS_SPEC_TYPE *pt_make_dblink_access_spec (ACCESS_METHOD access,
+						     PRED_EXPR * where_pred,
+						     REGU_VARIABLE_LIST pred_list,
+						     REGU_VARIABLE_LIST attr_list, char *url, char *user,
+						     char *password, int host_var_count, int *host_var_index,
+						     char *sql);
 extern REGU_VARIABLE *pt_to_regu_variable (PARSER_CONTEXT * p, PT_NODE * node, UNBOX unbox);
 extern PRED_EXPR *pt_to_pred_expr (PARSER_CONTEXT * parser, PT_NODE * node);
 extern PRED_EXPR *pt_to_pred_expr_with_arg (PARSER_CONTEXT * parser, PT_NODE * node_list, int *argp);
@@ -148,8 +154,8 @@ extern TP_DOMAIN *pt_xasl_type_enum_to_domain (const PT_TYPE_ENUM type);
 extern TP_DOMAIN *pt_xasl_node_to_domain (PARSER_CONTEXT * parser, const PT_NODE * node);
 extern PT_NODE *pt_to_upd_del_query (PARSER_CONTEXT * parser, PT_NODE * select_names, PT_NODE * select_list,
 				     PT_NODE * from, PT_NODE * with, PT_NODE * class_specs, PT_NODE * where,
-				     PT_NODE * using_index, PT_NODE * order_by, PT_NODE * orderby_for, int server_op,
-				     SCAN_OPERATION_TYPE scan_op_type);
+				     PT_NODE * using_index, PT_NODE * order_by, PT_NODE * orderby_for,
+				     int server_op, SCAN_OPERATION_TYPE scan_op_type);
 extern XASL_NODE *pt_to_insert_xasl (PARSER_CONTEXT * parser, PT_NODE * node);
 extern PRED_EXPR_WITH_CONTEXT *pt_to_pred_with_context (PARSER_CONTEXT * parser, PT_NODE * filter_pred, PT_NODE * spec);
 extern XASL_NODE *pt_to_update_xasl (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE ** non_null_attrs);

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -375,7 +375,7 @@ dblink_make_date_time_tz (T_CCI_U_TYPE utype, DB_VALUE * value_p, T_CCI_DATE_TZ 
 }
 
 static int
-dblink_bind_param (DBLINK_SCAN_INFO * scan_info, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars)
+dblink_bind_param (int stmt_handle, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars)
 {
   int i, n, ret;
   T_CCI_PARAM_INFO *param;
@@ -529,7 +529,7 @@ dblink_bind_param (DBLINK_SCAN_INFO * scan_info, VAL_DESCR * vd, DBLINK_HOST_VAR
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK_UNSUPPORTED_TYPE, 1, "unknown");
 	  return ER_DBLINK_UNSUPPORTED_TYPE;
 	}
-      ret = cci_bind_param (scan_info->stmt_handle, n + 1, a_type, value, u_type, 0);
+      ret = cci_bind_param (stmt_handle, n + 1, a_type, value, u_type, 0);
       if (ret < 0)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK_INVALID_BIND_PARAM, 0);
@@ -538,6 +538,64 @@ dblink_bind_param (DBLINK_SCAN_INFO * scan_info, VAL_DESCR * vd, DBLINK_HOST_VAR
     }
 
   return S_SUCCESS;
+}
+
+int
+dblink_execute_query (struct access_spec_node *spec, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars)
+{
+  int ret = NO_ERROR, conn_handle, stmt_handle;
+  T_CCI_ERROR err_buf;
+  char conn_url[MAX_LEN_CONNECTION_URL] = { 0, };
+  char *user_name = spec->s.dblink_node.conn_user;
+  char *password = spec->s.dblink_node.conn_password;
+  char *sql_text = spec->s.dblink_node.conn_sql;
+
+  char *find = strstr (spec->s.dblink_node.conn_url, ":?");
+  if (find)
+    {
+      snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", spec->s.dblink_node.conn_url, "&__gateway=true");
+    }
+  else
+    {
+      snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", spec->s.dblink_node.conn_url, "?__gateway=true");
+    }
+
+  conn_handle = cci_connect_with_url_ex (conn_url, user_name, password, &err_buf);
+  if (conn_handle < 0)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+      goto error_exit;
+    }
+  else
+    {
+      cci_set_autocommit (conn_handle, CCI_AUTOCOMMIT_TRUE);
+      stmt_handle = cci_prepare (conn_handle, sql_text, 0, &err_buf);
+      if (stmt_handle < 0)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+	  goto error_exit;
+	}
+
+      if (host_vars->count > 0)
+	{
+	  if ((ret = dblink_bind_param (stmt_handle, vd, host_vars)) < 0)
+	    {
+	      return ret;
+	    }
+	}
+
+      ret = cci_execute (stmt_handle, 0, 0, &err_buf);
+      if (ret < 0)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+	  goto error_exit;
+	}
+    }
+
+  return ret;
+
+error_exit:
+  return ER_DBLINK;
 }
 
 /*
@@ -589,7 +647,7 @@ dblink_open_scan (DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
 
       if (host_vars->count > 0)
 	{
-	  if ((ret = dblink_bind_param (scan_info, vd, host_vars)) < 0)
+	  if ((ret = dblink_bind_param (scan_info->stmt_handle, vd, host_vars)) < 0)
 	    {
 	      return ret;
 	    }

--- a/src/query/dblink_scan.h
+++ b/src/query/dblink_scan.h
@@ -60,6 +60,7 @@ struct dblink_scan_info
   void *col_info;		/* column information T_CCI_COL_INFO */
 };
 
+extern int dblink_execute_query (struct access_spec_node *spec, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars);
 extern int dblink_open_scan (DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
 			     VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars);
 extern int dblink_close_scan (DBLINK_SCAN_INFO * scan_info);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -13722,7 +13722,29 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 	{
 	  old_wait_msecs = xlogtb_reset_wait_msecs (thread_p, xasl->proc.update.wait_msecs);
 	}
-      error = qexec_execute_update (thread_p, xasl, false, xasl_state);
+      if (xasl->spec_list && xasl->spec_list->type == TARGET_DBLINK)
+	{
+	  int res;
+	  DBLINK_HOST_VARS host_vars;
+
+	  host_vars.count = xasl->spec_list->s.dblink_node.host_var_count;
+	  host_vars.index = xasl->spec_list->s.dblink_node.host_var_index;
+
+	  res = dblink_execute_query (xasl->spec_list, &xasl_state->vd, &host_vars);
+	  if (res < 0)
+	    {
+	      error = res;
+	    }
+	  else
+	    {
+	      xasl->list_id->tuple_cnt = res;
+	    }
+	}
+      else
+	{
+	  error = qexec_execute_update (thread_p, xasl, false, xasl_state);
+	}
+
       if (old_wait_msecs != XASL_WAIT_MSECS_NOCHANGE)
 	{
 	  (void) xlogtb_reset_wait_msecs (thread_p, old_wait_msecs);
@@ -13747,7 +13769,29 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 	{
 	  old_wait_msecs = xlogtb_reset_wait_msecs (thread_p, xasl->proc.delete_.wait_msecs);
 	}
-      error = qexec_execute_delete (thread_p, xasl, xasl_state);
+      if (xasl->spec_list && xasl->spec_list->type == TARGET_DBLINK)
+	{
+	  int res;
+	  DBLINK_HOST_VARS host_vars;
+
+	  host_vars.count = xasl->spec_list->s.dblink_node.host_var_count;
+	  host_vars.index = xasl->spec_list->s.dblink_node.host_var_index;
+
+	  res = dblink_execute_query (xasl->spec_list, &xasl_state->vd, &host_vars);
+	  if (res < 0)
+	    {
+	      error = res;
+	    }
+	  else
+	    {
+	      xasl->list_id->tuple_cnt = res;
+	    }
+	}
+      else
+	{
+	  error = qexec_execute_delete (thread_p, xasl, xasl_state);
+	}
+
       if (old_wait_msecs != XASL_WAIT_MSECS_NOCHANGE)
 	{
 	  (void) xlogtb_reset_wait_msecs (thread_p, old_wait_msecs);
@@ -13844,7 +13888,28 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 	}
 
       /* execute merge */
-      error = qexec_execute_merge (thread_p, xasl, xasl_state);
+      if (xasl->spec_list && xasl->spec_list->type == TARGET_DBLINK)
+	{
+	  int res;
+	  DBLINK_HOST_VARS host_vars;
+
+	  host_vars.count = xasl->spec_list->s.dblink_node.host_var_count;
+	  host_vars.index = xasl->spec_list->s.dblink_node.host_var_index;
+
+	  res = dblink_execute_query (xasl->spec_list, &xasl_state->vd, &host_vars);
+	  if (res < 0)
+	    {
+	      error = res;
+	    }
+	  else
+	    {
+	      xasl->list_id->tuple_cnt = res;
+	    }
+	}
+      else
+	{
+	  error = qexec_execute_merge (thread_p, xasl, xasl_state);
+	}
 
       if (old_wait_msecs != XASL_WAIT_MSECS_NOCHANGE)
 	{

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -13775,7 +13775,28 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 
       old_no_logging = thread_p->no_logging;
 
-      error = qexec_execute_insert (thread_p, xasl, xasl_state, false);
+      if (xasl->spec_list)
+	{
+	  int res;
+	  DBLINK_HOST_VARS host_vars;
+
+	  host_vars.count = xasl->spec_list->s.dblink_node.host_var_count;
+	  host_vars.index = xasl->spec_list->s.dblink_node.host_var_index;
+
+	  res = dblink_execute_query (xasl->spec_list, &xasl_state->vd, &host_vars);
+	  if (res < 0)
+	    {
+	      error = res;
+	    }
+	  else
+	    {
+	      xasl->list_id->tuple_cnt = res;
+	    }
+	}
+      else
+	{
+	  error = qexec_execute_insert (thread_p, xasl, xasl_state, false);
+	}
 
       thread_p->no_logging = old_no_logging;
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -13775,7 +13775,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 
       old_no_logging = thread_p->no_logging;
 
-      if (xasl->spec_list)
+      if (xasl->spec_list && xasl->spec_list->type == TARGET_DBLINK)
 	{
 	  int res;
 	  DBLINK_HOST_VARS host_vars;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24501

We will extend dblink to DML. First, we do POC to achieve the possiblity of syntax extension to apply to DML as like blow INSERT query.

`INSERT INTO table-name@server-name VALUES (...)
`
under the below schema
`CREATE TABLE [tt@server] (a int, b varchar);
`

Example:
```
csql> prepare st from 'insert into [tt@server] values (?, ?)';
commit all uncommit transcation
Execute OK. (0.002123 sec) Committed. (0.000104 sec)

1 command(s) successfully processed.
csql> execute st using 999, 'ABCD';
commit all uncommit transcation
1 row affected. (0.011449 sec) Committed. (0.000170 sec)

1 command(s) successfully processed.
```



