### PR TITLE
[CBRD-24467] backport for 10.2.9

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2273,8 +2273,8 @@ static UINT64 prm_first_log_pageid_lower = 0LL;
 static UINT64 prm_first_log_pageid_upper = LOGPAGEID_MAX;
 static unsigned int prm_first_log_pageid_flag = 0;
 
-bool PRM_USE_STAT_ESTIMATION = false;
-static bool prm_use_stat_estimation_default = false;
+bool PRM_USE_STAT_ESTIMATION = true;
+static bool prm_use_stat_estimation_default = true;
 static unsigned int prm_use_stat_estimation_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -673,6 +673,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_FIRST_LOG_PAGEID "first_log_pageid"
 
+#define PRM_NAME_USE_STAT_ESTIMATION "use_stat_estimation"
+
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
 #define PRM_VALUE_MIN "MIN"
@@ -2270,6 +2272,10 @@ static UINT64 prm_first_log_pageid_default = 0LL;
 static UINT64 prm_first_log_pageid_lower = 0LL;
 static UINT64 prm_first_log_pageid_upper = LOGPAGEID_MAX;
 static unsigned int prm_first_log_pageid_flag = 0;
+
+bool PRM_USE_STAT_ESTIMATION = false;
+static bool prm_use_stat_estimation_default = false;
+static unsigned int prm_use_stat_estimation_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5837,6 +5843,17 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) &PRM_FIRST_LOG_PAGEID,
    (void *) &prm_first_log_pageid_upper,
    (void *) &prm_first_log_pageid_lower,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_USE_STAT_ESTIMATION,
+   PRM_NAME_USE_STAT_ESTIMATION,
+   (PRM_FOR_SERVER | PRM_USER_CHANGE),
+   PRM_BOOLEAN,
+   &prm_use_stat_estimation_flag,
+   (void *) &prm_use_stat_estimation_default,
+   (void *) &PRM_USE_STAT_ESTIMATION,
+   (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL}

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -440,8 +440,10 @@ enum param_id
 
   PRM_ID_JAVA_STORED_PROCEDURE_JVM_OPTIONS,
   PRM_ID_FIRST_LOG_PAGEID,	/* Except for QA or TEST purposes, never use it. */
+  PRM_ID_USE_STAT_ESTIMATION,
+
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_FIRST_LOG_PAGEID
+  PRM_LAST_ID = PRM_ID_USE_STAT_ESTIMATION
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -14782,7 +14782,6 @@ sm_add_constraint (MOP classop, DB_CONSTRAINT_TYPE constraint_type, const char *
 	      goto error_exit;
 	    }
 	}
-
       break;
 
     case DB_CONSTRAINT_NOT_NULL:

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -3601,6 +3601,13 @@ pt_is_pseudo_const (PT_NODE * expr)
        */
       return true;
 
+    case PT_METHOD_CALL:
+      /*
+       * Even if there are columns(PT_NAME) in the parameter of the Java Stored Procedure(METHOD_CALL),
+       * it can be guaranteed to be evaluated by the time it is referenced.
+       */
+      return true;
+
     case PT_DOT_:
       /*
        * It would be nice if we could use expressions that are

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7094,6 +7094,14 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 	      break;
 
 	    case PT_METHOD_CALL:
+	      /*
+	         TODO : JSP containing column cannot be here because the query is rewritten in meth_translate().
+	         The index scan may not work because of the query rewrite in meth_translate().
+	         The method call should proceed in the same way as the internal function.
+	         pt_to_regu_variable() : generate regu_var for jsp function
+	         fetch_peek_dbval() : fetch regu_var for jsp function
+	       */
+
 	      /* a method call that can be evaluated as a constant expression. */
 	      regu_alloc (val);
 	      pt_evaluate_tree (parser, node, val, 1);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -24489,7 +24489,7 @@ qexec_get_orderbynum_upper_bound (THREAD_ENTRY * thread_p, PRED_EXPR * pred, VAL
       op = pred->pe.m_eval_term.et.et_comp.rel_op;
       if (lhs->type != TYPE_CONSTANT)
 	{
-	  if (lhs->type != TYPE_POS_VALUE && lhs->type != TYPE_DBVAL)
+	  if (lhs->type != TYPE_POS_VALUE && lhs->type != TYPE_DBVAL && lhs->type != TYPE_INARITH)
 	    {
 	      goto cleanup;
 	    }
@@ -24520,7 +24520,7 @@ qexec_get_orderbynum_upper_bound (THREAD_ENTRY * thread_p, PRED_EXPR * pred, VAL
 	      goto cleanup;
 	    }
 	}
-      if (rhs->type != TYPE_POS_VALUE && rhs->type != TYPE_DBVAL)
+      if (rhs->type != TYPE_POS_VALUE && rhs->type != TYPE_DBVAL && rhs->type != TYPE_INARITH)
 	{
 	  goto cleanup;
 	}

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -985,7 +985,7 @@ xqmgr_prepare_query (THREAD_ENTRY * thread_p, COMPILE_CONTEXT * context, xasl_st
 	      if (stream->buffer == NULL && stream->xasl_header != NULL)
 		{
 		  /* also header was requested. */
-		  qfile_load_xasl_node_header (thread_p, stream->buffer, stream->xasl_header);
+		  qfile_load_xasl_node_header (thread_p, cache_entry_p->stream.buffer, stream->xasl_header);
 		}
 	      xcache_unfix (thread_p, cache_entry_p);
 	      goto exit_on_end;

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -2325,11 +2325,21 @@ xcache_check_recompilation_threshold (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY 
 	}
       assert (!VFID_ISNULL (&cls_info_p->ci_hfid.vfid));
 
-      if (file_get_num_user_pages (thread_p, &cls_info_p->ci_hfid.vfid, &npages) != NO_ERROR)
+      if (!prm_get_bool_value (PRM_ID_USE_STAT_ESTIMATION))
 	{
-	  ASSERT_ERROR ();
-	  catalog_free_class_info_and_init (cls_info_p);
-	  return false;
+	  /* Consider recompiling the plan when statistic is updated. */
+	  npages = cls_info_p->ci_tot_pages;
+	}
+      else
+	{
+	  /* Because statistics are automatically updated, number of real pages of file can be used */
+	  /* default of use_stat_estimation is 'false' because btree statistics estimations is so inaccurate. */
+	  if (file_get_num_user_pages (thread_p, &cls_info_p->ci_hfid.vfid, &npages) != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	      catalog_free_class_info_and_init (cls_info_p);
+	      return false;
+	    }
 	}
       if (npages > XCACHE_RT_FACTOR * xcache_entry->related_objects[relobj].tcard
 	  || npages < xcache_entry->related_objects[relobj].tcard / XCACHE_RT_FACTOR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24467

backport for 10.2.9
[CBRD-24467] Sort-limit optimization does not work when host variable is used in limit clause.
[CBRD-24473] Index scan cannot be used when a stored function is used in a where condition.
[CBRD-23926] Use statistics of pages when checking recompilation threshold.
[CBRD-23732] Optional Statistics Estimation

The default of Optional Statistics Estimation is changed from FALSE to TRUE. 