### PR TITLE
[CBRD-24467] backport for 11.2.2

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -3706,6 +3706,13 @@ pt_is_pseudo_const (PT_NODE * expr)
        */
       return true;
 
+    case PT_METHOD_CALL:
+      /*
+       * Even if there are columns(PT_NAME) in the parameter of the Java Stored Procedure(METHOD_CALL),
+       * it can be guaranteed to be evaluated by the time it is referenced.
+       */
+      return true;
+
     case PT_DOT_:
       /*
        * It would be nice if we could use expressions that are

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7681,6 +7681,14 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 	      break;
 
 	    case PT_METHOD_CALL:
+	      /*
+	         TODO : JSP containing column cannot be here because the query is rewritten in meth_translate().
+	         The index scan may not work because of the query rewrite in meth_translate().
+	         The method call should proceed in the same way as the internal function.
+	         pt_to_regu_variable() : generate regu_var for jsp function
+	         fetch_peek_dbval() : fetch regu_var for jsp function
+	       */
+
 	      /* a method call that can be evaluated as a constant expression. */
 	      regu_alloc (val);
 	      pt_evaluate_tree (parser, node, val, 1);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -24515,7 +24515,7 @@ qexec_get_orderbynum_upper_bound (THREAD_ENTRY * thread_p, PRED_EXPR * pred, VAL
       op = pred->pe.m_eval_term.et.et_comp.rel_op;
       if (lhs->type != TYPE_CONSTANT)
 	{
-	  if (lhs->type != TYPE_POS_VALUE && lhs->type != TYPE_DBVAL)
+	  if (lhs->type != TYPE_POS_VALUE && lhs->type != TYPE_DBVAL && lhs->type != TYPE_INARITH)
 	    {
 	      goto cleanup;
 	    }
@@ -24546,7 +24546,7 @@ qexec_get_orderbynum_upper_bound (THREAD_ENTRY * thread_p, PRED_EXPR * pred, VAL
 	      goto cleanup;
 	    }
 	}
-      if (rhs->type != TYPE_POS_VALUE && rhs->type != TYPE_DBVAL)
+      if (rhs->type != TYPE_POS_VALUE && rhs->type != TYPE_DBVAL && rhs->type != TYPE_INARITH)
 	{
 	  goto cleanup;
 	}

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1015,7 +1015,7 @@ xqmgr_prepare_query (THREAD_ENTRY * thread_p, COMPILE_CONTEXT * context, xasl_st
 	      if (stream->buffer == NULL && stream->xasl_header != NULL)
 		{
 		  /* also header was requested. */
-		  qfile_load_xasl_node_header (thread_p, stream->buffer, stream->xasl_header);
+		  qfile_load_xasl_node_header (thread_p, cache_entry_p->stream.buffer, stream->xasl_header);
 		}
 	      xcache_unfix (thread_p, cache_entry_p);
 	      goto exit_on_end;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -159,7 +159,7 @@ static int reverse_key_list (KEY_VAL_RANGE * key_vals, int key_cnt);
 static int check_key_vals (KEY_VAL_RANGE * key_vals, int key_cnt, QPROC_KEY_VAL_FU * chk_fn);
 static int scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * indexal,
 				   TP_DOMAIN * btree_domainp, int num_term, REGU_VARIABLE * func, VAL_DESCR * vd,
-				   int key_minmax, bool is_iss, DB_VALUE * fetched_values);
+				   int key_minmax, bool is_iss);
 static int scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY_VAL_RANGE * key_val_range,
 				       INDX_SCAN_ID * iscan_id, TP_DOMAIN * btree_domainp, VAL_DESCR * vd);
 static int scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_limit_upper,
@@ -1482,8 +1482,7 @@ check_key_vals (KEY_VAL_RANGE * key_vals, int key_cnt, QPROC_KEY_VAL_FU * key_va
  */
 static int
 scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * indexable, TP_DOMAIN * btree_domainp,
-			int num_term, REGU_VARIABLE * func, VAL_DESCR * vd, int key_minmax, bool is_iss,
-			DB_VALUE * fetched_values)
+			int num_term, REGU_VARIABLE * func, VAL_DESCR * vd, int key_minmax, bool is_iss)
 {
   int ret = NO_ERROR;
   DB_VALUE *val = NULL;
@@ -1567,8 +1566,6 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	  goto err_exit;
 	}
 
-      pr_clear_value (&fetched_values[i]);
-      ret = pr_clone_value (val, &fetched_values[i]);
       if (ret != NO_ERROR)
 	{
 	  goto err_exit;
@@ -1674,8 +1671,11 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	}
       else
 	{
-	  assert (fetched_values != NULL);
-	  val = &fetched_values[natts];
+	  ret = fetch_peek_dbval (thread_p, &(operand->value), vd, NULL, NULL, NULL, &val);
+	  if (ret != NO_ERROR)
+	    {
+	      goto err_exit;
+	    }
 	}
 
       if (need_new_setdomain == true)
@@ -1779,8 +1779,11 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	}
       else
 	{
-	  assert (fetched_values != NULL);
-	  val = &fetched_values[i];
+	  ret = fetch_peek_dbval (thread_p, &(operand->value), vd, NULL, NULL, NULL, &val);
+	  if (ret != NO_ERROR)
+	    {
+	      goto err_exit;
+	    }
 	}
 
       if (DB_IS_NULL (val))
@@ -1958,8 +1961,7 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 
 	  ret =
 	    scan_dbvals_to_midxkey (thread_p, &key_val_range->key1, &indexable, btree_domainp,
-				    key_val_range->num_index_term, key_ranges->key1, vd, key_minmax, iscan_id->iss.use,
-				    iscan_id->fetched_values);
+				    key_val_range->num_index_term, key_ranges->key1, vd, key_minmax, iscan_id->iss.use);
 	}
       else
 	{
@@ -2006,8 +2008,7 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 
 	  ret =
 	    scan_dbvals_to_midxkey (thread_p, &key_val_range->key2, &indexable, btree_domainp,
-				    key_val_range->num_index_term, key_ranges->key2, vd, key_minmax, iscan_id->iss.use,
-				    iscan_id->fetched_values);
+				    key_val_range->num_index_term, key_ranges->key2, vd, key_minmax, iscan_id->iss.use);
 	}
       else
 	{
@@ -3080,7 +3081,6 @@ scan_open_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
   isidp->indx_cov.list_id = NULL;
   isidp->indx_cov.tplrec = NULL;
   isidp->indx_cov.lsid = NULL;
-  isidp->fetched_values = NULL;
 
   /* index scan info */
   BTS = &isidp->bt_scan;
@@ -3227,17 +3227,6 @@ scan_open_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 	{
 	  /* found multi-column key-val */
 	  need_copy_buf = true;
-
-	  /* make fetched values for scan_regu_key_to_index_key(). */
-	  isidp->fetched_values = (DB_VALUE *) db_private_alloc (thread_p, sizeof (DB_VALUE) * isidp->bt_num_attrs);
-	  if (isidp->fetched_values == NULL)
-	    {
-	      goto exit_on_error;
-	    }
-	  for (int j = 0; j < isidp->bt_num_attrs; j++)
-	    {
-	      db_make_null (&isidp->fetched_values[j]);
-	    }
 	}
       else
 	{			/* single-column index */
@@ -3304,10 +3293,6 @@ exit_on_error:
   if (isidp->key_vals)
     {
       db_private_free_and_init (thread_p, isidp->key_vals);
-    }
-  if (isidp->fetched_values)
-    {
-      db_private_free_and_init (thread_p, isidp->fetched_values);
     }
   if (isidp->bt_attr_ids)
     {
@@ -4786,14 +4771,6 @@ scan_close_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
       if (isidp->key_vals)
 	{
 	  db_private_free_and_init (thread_p, isidp->key_vals);
-	}
-      if (isidp->fetched_values)
-	{
-	  for (int j = 0; j < isidp->bt_num_attrs; j++)
-	    {
-	      pr_clear_value (&isidp->fetched_values[j]);
-	    }
-	  db_private_free_and_init (thread_p, isidp->fetched_values);
 	}
 
       /* free allocated memory for the scan */

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -238,7 +238,6 @@ struct indx_scan_id
   bool check_not_vacuumed;	/* if true then during index scan, the entries will be checked if they should've been
 				 * vacuumed. Used in checkdb. */
   DISK_ISVALID not_vacuumed_res;	/* The result of not vacuumed checking operation */
-  DB_VALUE *fetched_values;	/* used for scan_dbvals_to_midxkey() */
 };
 
 typedef struct index_node_scan_id INDEX_NODE_SCAN_ID;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24467

backport for 11.2.2
[CBRD-24467] Sort-limit optimization does not work when host variable is used in limit clause.
[CBRD-24482] Core dump occurs after function index scan
[CBRD-24487] Core dump occurs when query execution is canceled in the middle of inserting dk bucket of FHS
[CBRD-24473] Index scan cannot be used when a stored function is used in a where condition.
