### PR TITLE
[CBRD-24435] When renaming a view, even if there is a not null constraint, change it so that no error occurs. (#3744)

### DIFF
--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -8979,9 +8979,14 @@ do_recreate_renamed_class_indexes (const PARSER_CONTEXT * parser, const char *co
       return NO_ERROR;
     }
 
+  /* We can come here by renaming a view. In general, views have no constraints. If there are no constraints,
+   * NO_ERROR is returned before. However, views can have shared columns with a not null constraint.
+   * Renaming does not affect the not null constraint. So, even if the view has a not null constraint,
+   * change it so that an error does not occur here. I do not think there is a view with a constraint
+   * other than a not null constraint. Change the return value from ER_OBJ_NOT_A_CLASS to NO_ERROR. (In CBRD-24435) */
   if (class_->class_type != SM_CLASS_CT)
     {
-      return ER_OBJ_NOT_A_CLASS;
+      return NO_ERROR;
     }
 
   for (c = class_->constraints; c; c = c->next)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24435

backport #3744