### PR TITLE
[CBRD-24507] Fix large string handling error in Java SP

### DIFF
--- a/src/jsp/com/cubrid/jsp/data/CUBRIDUnpacker.java
+++ b/src/jsp/com/cubrid/jsp/data/CUBRIDUnpacker.java
@@ -117,13 +117,14 @@ public class CUBRIDUnpacker {
 
     public int unpackStringSize() {
         int len = (int) buffer.get();
-        if (len == 0xff) {
-            /* LARGE_STRING_CODE */
-            len = buffer.getInt();
-        }
-
         if (len < 0) {
             len = len & 0xff; // convert to unsigned
+        }
+
+        if (len == 0xff) {
+            /* LARGE_STRING_CODE */
+            align(DataUtilities.INT_ALIGNMENT);
+            len = buffer.getInt();
         }
 
         return len;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24507

Fixed a bug unpacking large string from DB server to Java SP. Please refer to the packer::pack_large_string.