### PR TITLE
[CBRD-24500] refactoring functions allocate index and classobj put index

### DIFF
--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -950,11 +950,8 @@ extern int classobj_copy_props (DB_SEQ * properties, MOP filter_class, DB_SEQ **
 extern void classobj_free_prop (DB_SEQ * properties);
 extern int classobj_put_prop (DB_SEQ * properties, const char *name, DB_VALUE * pvalue);
 extern int classobj_drop_prop (DB_SEQ * properties, const char *name);
-extern int classobj_put_index (DB_SEQ ** properties, SM_CONSTRAINT_TYPE type, const char *constraint_name,
-			       SM_ATTRIBUTE ** atts, const int *asc_desc, const int *attr_prefix_length,
-			       const BTID * id, SM_PREDICATE_INFO * filter_index_info, SM_FOREIGN_KEY_INFO * fk_info,
-			       char *shared_cons_name, SM_FUNCTION_INFO * func_index_info, const char *comment,
-			       SM_INDEX_STATUS index_status, bool attr_name_instead_of_id);
+extern int classobj_put_index (DB_SEQ ** properties, SM_CLASS_CONSTRAINT * con, const BTID * id,
+			       SM_FOREIGN_KEY_INFO * fk_info, char *shared_cons_name, bool attr_name_instead_of_id);
 extern int classobj_find_prop_constraint (DB_SEQ * properties, const char *prop_name, const char *cnstr_name,
 					  DB_VALUE * cnstr_val);
 

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -11146,7 +11146,7 @@ allocate_unique_constraint (MOP classop, SM_CLASS * class_, SM_CLASS_CONSTRAINT 
 	  shared_con = classobj_find_constraint_by_name (class_->constraints, con->shared_cons_name);
 	  con->index_btid = shared_con->index_btid;
 	}
-      else if (allocate_index (classop, class_, local_subclasses, con))
+      else if (allocate_index (classop, class_, local_subclasses, con) != NO_ERROR)
 	{
 	  assert (er_errid () != NO_ERROR);
 	  return er_errid ();
@@ -11221,7 +11221,7 @@ allocate_foreign_key (MOP classop, SM_CLASS * class_, SM_CLASS_CONSTRAINT * con,
 	    }
 	}
     }
-  else if (allocate_index (classop, class_, subclasses, con))
+  else if (allocate_index (classop, class_, subclasses, con) != NO_ERROR)
     {
       assert (er_errid () != NO_ERROR);
       return er_errid ();

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -10541,18 +10541,8 @@ collect_hier_class_info (MOP classop, DB_OBJLIST * subclasses, const char *const
  *   classop(in): class object
  *   class(in): class structure
  *   subclasses(in): List of subclasses
- *   con(in):
- *   attrs(in): attribute getting the index
- *   asc_desc(in): asc/desc info list
- *   unique_pk(in): non-zeor if were allocating a UNIQUE index. zero otherwise.
- *   not_null(in):
- *   reverse(in):
- *   constraint_name(in): Name of constraint.
- *   index(out): The BTID of the returned index.
- *   fk_refcls_oid(in):
- *   fk_refcls_pk_btid(in):
- *   fk_name(in):
- *   index_status(in):
+ *   con(in): SM_CLASS_CONSTRAINT
+ *          con->index(out): The BTID of the returned index. 
  */
 
 static int

--- a/src/object/schema_manager.h
+++ b/src/object/schema_manager.h
@@ -100,11 +100,6 @@ extern int ib_get_thread_count ();
 extern int sm_delete_class (const char *name);
 #endif
 
-#if 0				// TODO - remove it
-extern int sm_add_index (MOP classop, DB_CONSTRAINT_TYPE db_constraint_type, const char *constraint_name,
-			 const char **attnames, const int *asc_desc, const int *attrs_prefix_length,
-			 SM_PREDICATE_INFO * pred_info, SM_FUNCTION_INFO * fi_info, const char *comment);
-#endif
 extern int sm_get_index (MOP classop, const char *attname, BTID * index);
 extern char *sm_produce_constraint_name (const char *class_name, DB_CONSTRAINT_TYPE constraint_type,
 					 const char **att_names, const int *asc_desc, const char *given_name);

--- a/src/object/schema_template.c
+++ b/src/object/schema_template.c
@@ -1560,9 +1560,23 @@ smt_add_constraint_to_property (SM_TEMPLATE * template_, SM_CONSTRAINT_TYPE type
       goto end;
     }
 
-  if (classobj_put_index (&template_->properties, type, constraint_name, atts, asc_desc, attr_prefix_length, NULL,
-			  filter_index, fk_info, shared_cons_name, function_index, comment, index_status, true)
-      != NO_ERROR)
+  // Declare and use a temporary variable to match the prototype of the classobj_put_index() function.
+  SM_CLASS_CONSTRAINT con;
+
+  con.type = type;
+  con.name = constraint_name;
+  con.attributes = atts;
+  con.asc_desc = (int *) asc_desc;
+  con.attrs_prefix_length = (int *) attr_prefix_length;
+  con.filter_predicate = filter_index;
+  con.func_index_info = function_index;
+  con.comment = comment;
+  con.index_status = index_status;
+  con.index_btid = BTID_INITIALIZER;
+  con.fk_info = NULL;
+  con.shared_cons_name = NULL;
+
+  if (classobj_put_index (&template_->properties, &con, NULL, fk_info, shared_cons_name, true) != NO_ERROR)
     {
       ASSERT_ERROR_AND_SET (error);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24500


The allocate_index() and classbj_put_index() functions have many parameters.
But those parameters are the information that belonged to a structure.
Reduce the number of parameters to reconstruct the contents for ease of understanding.

Additionally, the sm_add_index() function was removed because it was deprecated.
The sm_is_global_only_constrain() function also has minor changes.
