### PR TITLE
[CBRD-24510] When data is deleted and the MIN, MAX function of the indexed column is called, the result value is strange.

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -16506,7 +16506,11 @@ btree_find_min_or_max_key (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key,
 	}
     }
 
-  (void) pr_clone_value (value_p, key);
+  if (is_visible)
+    {
+      (void) pr_clone_value (value_p, key);
+    }
+
   btree_clear_key_value (&clear_key, &key_value);
 
 end:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24510

Create, insert, and delete tables including indexes. If it calls the MIN and MAX functions of the index column, the result is strange.
The result must be null because the table is deleted and related index entry is nothing.
