### PR TITLE
[CBRD-24499] Revert - Setting CUBRID_TMP causes nativesocket bind error in Java SP

### DIFF
--- a/src/jsp/com/cubrid/jsp/Server.java
+++ b/src/jsp/com/cubrid/jsp/Server.java
@@ -51,7 +51,7 @@ public class Server {
     private static String serverName;
     private static String spPath;
     private static String rootPath;
-    private static String udsPath;
+    private static String tmpPath;
 
     private static List<String> jvmArguments = null;
 
@@ -63,16 +63,17 @@ public class Server {
     private static Server serverInstance = null;
 
     private Server(
-            String name, String path, String version, String rPath, String uPath, String port)
+            String name, String path, String version, String rPath, String tPath, String port)
             throws IOException, ClassNotFoundException {
         serverName = name;
         spPath = path;
         rootPath = rPath;
-        udsPath = uPath;
+        tmpPath = tPath;
         shutdown = new AtomicBoolean(false);
 
         if (OSValidator.IS_UNIX) {
-            final File socketFile = new File(udsPath);
+            String socketName = rootPath + tmpPath + "/junixsocket-" + name + ".sock";
+            final File socketFile = new File(socketName);
 
             if (socketFile.exists()) {
                 socketFile.delete();
@@ -80,7 +81,7 @@ public class Server {
 
             try {
                 AFUNIXSocketAddress sockAddr = AFUNIXSocketAddress.of(socketFile);
-                AFUNIXServerSocket udsServerSocket = AFUNIXServerSocket.bindOn(sockAddr);
+                AFUNIXServerSocket udsServerSocket = AFUNIXServerSocket.bindOn (sockAddr);
                 udsSocketListener = new ListenerThread(udsServerSocket);
             } catch (Exception e) {
                 log(e);

--- a/src/jsp/jsp_comm.c
+++ b/src/jsp/jsp_comm.c
@@ -59,6 +59,7 @@
 #include "boot_sr.h"
 #endif
 
+static char *jsp_get_socket_file_path (const char *db_name);
 static SOCKET jsp_connect_server_tcp (int server_port);
 #if !defined (WINDOWS)
 static SOCKET jsp_connect_server_uds (const char *db_name);
@@ -220,7 +221,7 @@ jsp_ping (SOCKET fd)
   return NO_ERROR;
 }
 
-char *
+static char *
 jsp_get_socket_file_path (const char *db_name)
 {
   static char path[PATH_MAX];
@@ -228,19 +229,14 @@ jsp_get_socket_file_path (const char *db_name)
 
   if (need_init)
     {
-      const size_t DIR_PATH_MAX = 128;	/* Guaranteed not to exceed 108 characters, see envvar_check_environment() */
-      char dir_path[DIR_PATH_MAX] = { 0 };
       const char *cubrid_tmp = envvar_get ("TMP");
+
       if (cubrid_tmp == NULL || cubrid_tmp[0] == '\0')
 	{
-	  envvar_vardir_file (dir_path, DIR_PATH_MAX, "CUBRID_SOCK/");
-	}
-      else
-	{
-	  snprintf (dir_path, DIR_PATH_MAX, "%s/", cubrid_tmp);
+	  cubrid_tmp = "/tmp";
 	}
 
-      snprintf (path, PATH_MAX, "%s%s%s%s", dir_path, "sp_", db_name, ".sock");
+      snprintf (path, PATH_MAX, "%s%s/%s%s%s", envvar_root (), cubrid_tmp, "junixsocket-", db_name, ".sock");
       need_init = false;
     }
 

--- a/src/jsp/jsp_comm.h
+++ b/src/jsp/jsp_comm.h
@@ -77,7 +77,6 @@ extern "C"
   int jsp_readn (SOCKET fd, void *vptr, int n);
 
   int jsp_ping (SOCKET fd);
-  char *jsp_get_socket_file_path (const char *db_name);
 
 #if defined(WINDOWS)
   extern int windows_socket_startup (FARPROC hook);


### PR DESCRIPTION
Reverts CUBRID/cubrid#3871

This commit causes a hang when CI tests cbrd_24482.sql.