### PR TITLE
[CBRD-24499] Setting CUBRID_TMP causes nativesocket bind error in Java a SP (#3871)

### DIFF
--- a/src/jsp/com/cubrid/jsp/Server.java
+++ b/src/jsp/com/cubrid/jsp/Server.java
@@ -51,7 +51,7 @@ public class Server {
     private static String serverName;
     private static String spPath;
     private static String rootPath;
-    private static String tmpPath;
+    private static String udsPath;
 
     private static List<String> jvmArguments = null;
 
@@ -63,17 +63,16 @@ public class Server {
     private static Server serverInstance = null;
 
     private Server(
-            String name, String path, String version, String rPath, String tPath, String port)
+            String name, String path, String version, String rPath, String uPath, String port)
             throws IOException, ClassNotFoundException {
         serverName = name;
         spPath = path;
         rootPath = rPath;
-        tmpPath = tPath;
+        udsPath = uPath;
         shutdown = new AtomicBoolean(false);
 
         if (OSValidator.IS_UNIX) {
-            String socketName = rootPath + tmpPath + "/junixsocket-" + name + ".sock";
-            final File socketFile = new File(socketName);
+            final File socketFile = new File(udsPath);
 
             if (socketFile.exists()) {
                 socketFile.delete();
@@ -81,7 +80,7 @@ public class Server {
 
             try {
                 AFUNIXSocketAddress sockAddr = AFUNIXSocketAddress.of(socketFile);
-                AFUNIXServerSocket udsServerSocket = AFUNIXServerSocket.bindOn (sockAddr);
+                AFUNIXServerSocket udsServerSocket = AFUNIXServerSocket.bindOn(sockAddr);
                 udsSocketListener = new ListenerThread(udsServerSocket);
             } catch (Exception e) {
                 log(e);

--- a/src/jsp/jsp_comm.h
+++ b/src/jsp/jsp_comm.h
@@ -77,6 +77,7 @@ extern "C"
   int jsp_readn (SOCKET fd, void *vptr, int n);
 
   int jsp_ping (SOCKET fd);
+  char *jsp_get_socket_file_path (const char *db_name);
 
 #if defined(WINDOWS)
   extern int windows_socket_startup (FARPROC hook);

--- a/src/jsp/jsp_sr.c
+++ b/src/jsp/jsp_sr.c
@@ -44,6 +44,7 @@
 
 #include "jsp_sr.h"
 #include "jsp_file.h"
+#include "jsp_comm.h"
 
 #include "boot_sr.h"
 #include "environment_variable.h"
@@ -506,7 +507,7 @@ jsp_start_server (const char *db_name, const char *path, int port)
   jclass cls, string_cls;
   JNIEnv *env_p = NULL;
   jmethodID mid;
-  jstring jstr_dbname, jstr_path, jstr_version, jstr_envroot, jstr_port, jstr_envtmp;
+  jstring jstr_dbname, jstr_path, jstr_version, jstr_envroot, jstr_port, jstr_uds_path;
   jobjectArray args;
   JavaVMInitArgs vm_arguments;
   JavaVMOption *options;
@@ -518,7 +519,7 @@ jsp_start_server (const char *db_name, const char *path, int port)
   char debug_jdwp[] = "-agentlib:jdwp=transport=dt_socket,server=y,address=%d,suspend=n";
   char disable_sig_handle[] = "-Xrs";
   const char *envroot;
-  const char *envtmp;
+  const char *uds_path;
   char jsp_file_path[PATH_MAX];
   char port_str[6] = { 0 };
   char *loc_p, *locale;
@@ -531,10 +532,14 @@ jsp_start_server (const char *db_name, const char *path, int port)
       }
 
     envroot = envvar_root ();
-    envtmp = envvar_get ("TMP");
-    if (envtmp == NULL || envtmp[0] == '\0')
+
+    if (prm_get_bool_value (PRM_ID_JAVA_STORED_PROCEDURE_UDS) == true)
       {
-	envtmp = "/tmp";
+	uds_path = jsp_get_socket_file_path (db_name);
+      }
+    else
+      {
+	uds_path = "";
       }
 
     snprintf (classpath, sizeof (classpath) - 1, "-Djava.class.path=%s",
@@ -667,8 +672,8 @@ jsp_start_server (const char *db_name, const char *path, int port)
 	goto error;
       }
 
-    jstr_envtmp = JVM_NewStringUTF (env_p, envtmp);
-    if (jstr_envtmp == NULL)
+    jstr_uds_path = JVM_NewStringUTF (env_p, uds_path);
+    if (jstr_uds_path == NULL)
       {
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_CANNOT_START_JVM, 1,
 		"Failed to construct a new 'java.lang.String object' by NewStringUTF()");
@@ -703,7 +708,7 @@ jsp_start_server (const char *db_name, const char *path, int port)
     JVM_SetObjectArrayElement (env_p, args, 1, jstr_path);
     JVM_SetObjectArrayElement (env_p, args, 2, jstr_version);
     JVM_SetObjectArrayElement (env_p, args, 3, jstr_envroot);
-    JVM_SetObjectArrayElement (env_p, args, 4, jstr_envtmp);
+    JVM_SetObjectArrayElement (env_p, args, 4, jstr_uds_path);
     JVM_SetObjectArrayElement (env_p, args, 5, jstr_port);
 
     sp_port = JVM_CallStaticIntMethod (env_p, cls, mid, args);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24499

**Note**
This patch was reverted because of CI hang problem. But the problem is not from the commit.

*Purpose*
Setting CUBRID_TMP causes a native socket bind error because the UDS socket file is not created properly because the path is set wrongly.

*Implementation*
I've changed the UDS socket file path for javasp same as the broker's socket file inside of $CUBRID/var/CUBRID_SOCK/ if CUBRID_TMP is not set. If the CUBRID_TMP is set, the socket file will be created inside of the $CUBRID_TMP directory. The exact path of the UDS socket file is created in the cub_javasp utility, and it passes to the JVM.