### PR TITLE
[LETS-564] Store channel id when connection between PS and TS is made successfully

### DIFF
--- a/src/communication/communication_channel.cpp
+++ b/src/communication/communication_channel.cpp
@@ -164,7 +164,6 @@ namespace cubcomm
 	return INTERNAL_CSS_ERROR;
       }
 
-    m_type = CHANNEL_TYPE::INITIATOR;
     m_socket = css_tcp_client_open (hostname, port);
 
     er_log_chn_debug ("[%s] Connect to %s:%d socket = %d.\n", get_channel_id ().c_str (), hostname, port, m_socket);
@@ -174,6 +173,7 @@ namespace cubcomm
 	return REQUEST_REFUSED;
       }
 
+    m_type = CHANNEL_TYPE::INITIATOR;
     m_hostname = hostname;
     m_port = port;
 

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -109,7 +109,8 @@ class page_server
 		cubcomm::request_sync_client_server<page_to_tran_request, tran_to_page_request, std::string>;
 
 	connection_handler () = delete;
-	connection_handler (cubcomm::channel &chn, transaction_server_type server_type, page_server &ps);
+	connection_handler (cubcomm::channel &chn, transaction_server_type server_type, page_server &ps,
+			    const std::string &underlying_channel_id);
 
 	connection_handler (const connection_handler &) = delete;
 	connection_handler (connection_handler &&) = delete;
@@ -120,7 +121,7 @@ class page_server
 	connection_handler &operator= (connection_handler &&) = delete;
 
 	void push_request (page_to_tran_request id, std::string msg);
-	std::string get_channel_id ();
+	const std::string &get_channel_id () const;
 
 	void remove_prior_sender_sink ();
 
@@ -152,6 +153,7 @@ class page_server
 	 * the peer transaction server and the check will no longer be valid
 	 */
 	const transaction_server_type m_server_type;
+	const std::string m_underlying_channel_id;
 
 	std::unique_ptr<tran_server_conn_t> m_conn;
 	page_server &m_ps;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -109,8 +109,7 @@ class page_server
 		cubcomm::request_sync_client_server<page_to_tran_request, tran_to_page_request, std::string>;
 
 	connection_handler () = delete;
-	connection_handler (cubcomm::channel &chn, transaction_server_type server_type, page_server &ps,
-			    const std::string &underlying_channel_id);
+	connection_handler (cubcomm::channel &chn, transaction_server_type server_type, page_server &ps);
 
 	connection_handler (const connection_handler &) = delete;
 	connection_handler (connection_handler &&) = delete;
@@ -121,7 +120,7 @@ class page_server
 	connection_handler &operator= (connection_handler &&) = delete;
 
 	void push_request (page_to_tran_request id, std::string msg);
-	const std::string &get_channel_id () const;
+	const std::string &get_connection_id () const;
 
 	void remove_prior_sender_sink ();
 
@@ -153,7 +152,7 @@ class page_server
 	 * the peer transaction server and the check will no longer be valid
 	 */
 	const transaction_server_type m_server_type;
-	const std::string m_underlying_channel_id;
+	const std::string m_connection_id;
 
 	std::unique_ptr<tran_server_conn_t> m_conn;
 	page_server &m_ps;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-564

Purpose

PS need to find and remove the oldest active mvcc id of a specific PTS using the channel ID, but when PS try to get the channel ID while the connection is disconnected, an invalid channel ID is created. This is because the socket value is already initialized to -1.

Therefore, rather than configuring the channel ID every time PS tries to get the channel ID, it is better to use the stored channel id which is stored when it is connected successfully.