### PR TITLE
[CBRD-24506] Changing the way characters are read from DBMS

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -27,11 +27,16 @@
 #include "cas_util.h"
 #include "cas_log.h"
 
-#define STRING_MAX_SIZE_LIMIT 16*1024*1024
-#define LOGIN_TIME_OUT       5
-#define NUM_OF_DIGITS(NUMBER) (int)log10(NUMBER) + 1
-#define DISCONNECTED_STATE   -1
-#define CONNECTED_STATE      0
+#ifndef WINDOWS
+#include <iconv.h>
+#endif
+
+#define STRING_MAX_SIZE         (16*1024*1024)
+#define STRING_MAX_SIZE_LIMIT   (STRING_MAX_SIZE * sizeof(wchar_t))
+#define LOGIN_TIME_OUT          5
+#define NUM_OF_DIGITS(NUMBER)   (int)log10(NUMBER) + 1
+#define DISCONNECTED_STATE      -1
+#define CONNECTED_STATE         0
 
 #define ODBC_SQLSUCCESS(rc) ((rc == SQL_SUCCESS) || (rc == SQL_SUCCESS_WITH_INFO) )
 #define SQL_CHK_ERR(h, ht, x)   {   RETCODE rc = x;\
@@ -42,6 +47,16 @@
                                 } \
                             }
 
+#define UNICODE_CODE_PAGE       "UCS-2"
+#define UTF8_CODE_PAGE          "UTF-8"
+#define CONV_STRING_BUF_SIZE    (STRING_MAX_SIZE_LIMIT + STRING_MAX_SIZE)
+
+#if defined (WINDOWS)
+#define CONV_M_TO_W(M, W, LEN)	MultiByteToWideChar(CP_ACP, 0, M, -1, W, LEN)
+#else
+#define CONV_M_TO_W(M, W, LEN)      mbstowcs(W, M, LEN)
+#endif
+#define CONV_WCS_TO_SQLWCS(string, len) cgw_wchar_to_sqlwchar((string), (len))
 
 typedef struct t_supported_dbms T_SUPPORTED_DBMS;
 struct t_supported_dbms
@@ -50,6 +65,8 @@ struct t_supported_dbms
   SUPPORTED_DBMS_TYPE dbms_type;
 };
 
+static INTL_CODESET client_charset = INTL_CODESET_UTF8;
+static char conv_out_string[CONV_STRING_BUF_SIZE + 1];
 static T_SUPPORTED_DBMS supported_dbms_list[] = { {"oracle", SUPPORTED_DBMS_ORACLE}, {"mysql", SUPPORTED_DBMS_MYSQL} };
 
 static int supported_dbms_max_num = sizeof (supported_dbms_list) / sizeof (T_SUPPORTED_DBMS);
@@ -83,8 +100,10 @@ static char *cgw_datatype_to_string (SQLLEN type);
 static char *cgw_utype_to_string (int type);
 static void cgw_free_string_array (char **array);
 static char **cgw_split_string (const char *str, const char *delim, int *num);
-
-static INTL_CODESET client_charset = INTL_CODESET_UTF8;
+static int cgw_unicode_to_utf8 (wchar_t * in_src, int in_size, char **out_target, int *out_length);
+static int cgw_conv_mtow (wchar_t * destStr, char *sourStr);
+static int cgw_uint32_to_uni16 (uint32_t i, uint16_t * u);
+static SQLWCHAR *cgw_wchar_to_sqlwchar (wchar_t * src, size_t len);
 
 
 int
@@ -140,9 +159,10 @@ cgw_database_connect (SUPPORTED_DBMS_TYPE dbms_type, const char *connect_url, ch
 		      char *db_passwd)
 {
   SQLRETURN err_code;
-  SQLCHAR out_connect_str[CGW_LINK_URL_MAX_LEN + 1];
+  wchar_t wcs_url[(CGW_LINK_URL_MAX_LEN + 1) * sizeof (wchar_t)] = { 0, };
+  SQLWCHAR *wconn_url = NULL;
+  SQLWCHAR out_connect_str[(CGW_LINK_URL_MAX_LEN + 1) * sizeof (SQLWCHAR)];
   SQLSMALLINT out_connect_str_len;
-  char connect_str[CGW_LINK_URL_MAX_LEN + 1] = { 0, };
   bool is_conneted = false;
 
   if (cgw_is_database_connected () == CONNECTED_STATE)
@@ -164,20 +184,36 @@ cgw_database_connect (SUPPORTED_DBMS_TYPE dbms_type, const char *connect_url, ch
       SQL_CHK_ERR (local_odbc_handle->hdbc,
 		   SQL_HANDLE_ENV,
 		   err_code =
-		   SQLSetConnectAttr (local_odbc_handle->hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER) LOGIN_TIME_OUT, 0));
+		   SQLSetConnectAttrW (local_odbc_handle->hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER) LOGIN_TIME_OUT,
+				       0));
     }
 
   if (connect_url != NULL && strlen (connect_url) > 0)
     {
+      err_code = cgw_conv_mtow ((wchar_t *) wcs_url, (char *) connect_url);
+      if (err_code < 0)
+	{
+	  goto ODBC_ERROR;
+	}
+
+      wconn_url = CONV_WCS_TO_SQLWCS (wcs_url, wcslen (wcs_url));
+
+      if (wconn_url == NULL)
+	{
+	  goto ODBC_ERROR;
+	}
+
       SQL_CHK_ERR (local_odbc_handle->hdbc,
 		   SQL_HANDLE_DBC,
-		   err_code = SQLDriverConnect (local_odbc_handle->hdbc,
-						NULL,
-						(SQLCHAR *) connect_url,
-						SQL_NTS,
-						out_connect_str,
-						(SQLSMALLINT) sizeof (out_connect_str),
-						&out_connect_str_len, SQL_DRIVER_NOPROMPT));
+		   err_code = SQLDriverConnectW (local_odbc_handle->hdbc,
+						 NULL,
+						 wconn_url,
+						 SQL_NTS,
+						 (SQLWCHAR *) out_connect_str,
+						 (SQLSMALLINT) sizeof (out_connect_str),
+						 &out_connect_str_len, SQL_DRIVER_NOPROMPT));
+
+      FREE_MEM (wconn_url);
       is_conneted = true;
     }
   else
@@ -199,6 +235,8 @@ cgw_database_connect (SUPPORTED_DBMS_TYPE dbms_type, const char *connect_url, ch
   return NO_ERROR;
 
 ODBC_ERROR:
+  FREE_MEM (wconn_url);
+
   if (local_odbc_handle->hdbc)
     {
       if (is_conneted)
@@ -336,6 +374,9 @@ cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding, int cursor
   SQL_DATE_STRUCT *date;
   SQL_TIME_STRUCT *time;
   SQL_TIMESTAMP_STRUCT *timestamp;
+  char *conv_string;
+  int conv_string_len = 0;
+  int conv_ret = 0;
 
   net_buf_cp_int (net_buf, cursor_pos, NULL);
 
@@ -365,15 +406,33 @@ cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding, int cursor
 	    case SQL_WLONGVARCHAR:
 	    case SQL_NUMERIC:
 	    case SQL_DECIMAL:
-	      net_buf_cp_int (net_buf, (int) str_len + 1, NULL);
-	      net_buf_cp_str (net_buf, (char *) this_col_binding->data_buffer, str_len);
+	      conv_ret =
+		cgw_unicode_to_utf8 ((wchar_t *) this_col_binding->data_buffer, str_len, &conv_string,
+				     &conv_string_len);
+	      if (conv_ret < 0)
+		{
+		  net_buf_cp_int (net_buf, -1, NULL);
+		  continue;
+		}
+
+	      net_buf_cp_int (net_buf, (int) conv_string_len, NULL);
+	      net_buf_cp_str (net_buf, (char *) conv_string, conv_string_len - 1);
 	      net_buf_cp_byte (net_buf, 0);
 	      break;
 	    case SQL_INTEGER:
 	      if (this_col_binding->col_unsigned_type)
 		{
-		  net_buf_cp_int (net_buf, (int) str_len + 1, NULL);
-		  net_buf_cp_str (net_buf, (char *) this_col_binding->data_buffer, str_len);
+		  conv_ret =
+		    cgw_unicode_to_utf8 ((wchar_t *) this_col_binding->data_buffer, str_len, &conv_string,
+					 &conv_string_len);
+		  if (conv_ret < 0)
+		    {
+		      net_buf_cp_int (net_buf, -1, NULL);
+		      continue;
+		    }
+
+		  net_buf_cp_int (net_buf, (int) conv_string_len, NULL);
+		  net_buf_cp_str (net_buf, (char *) conv_string, conv_string_len - 1);
 		  net_buf_cp_byte (net_buf, 0);
 		}
 	      else
@@ -385,8 +444,17 @@ cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding, int cursor
 	    case SQL_SMALLINT:
 	      if (this_col_binding->col_unsigned_type)
 		{
-		  net_buf_cp_int (net_buf, (int) str_len + 1, NULL);
-		  net_buf_cp_str (net_buf, (char *) this_col_binding->data_buffer, str_len);
+		  conv_ret =
+		    cgw_unicode_to_utf8 ((wchar_t *) this_col_binding->data_buffer, str_len, &conv_string,
+					 &conv_string_len);
+		  if (conv_ret < 0)
+		    {
+		      net_buf_cp_int (net_buf, -1, NULL);
+		      continue;
+		    }
+
+		  net_buf_cp_int (net_buf, (int) conv_string_len, NULL);
+		  net_buf_cp_str (net_buf, (char *) conv_string, conv_string_len - 1);
 		  net_buf_cp_byte (net_buf, 0);
 		}
 	      else
@@ -398,8 +466,17 @@ cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding, int cursor
 	    case SQL_TINYINT:
 	      if (this_col_binding->col_unsigned_type)
 		{
-		  net_buf_cp_int (net_buf, (int) str_len + 1, NULL);
-		  net_buf_cp_str (net_buf, (char *) this_col_binding->data_buffer, str_len);
+		  conv_ret =
+		    cgw_unicode_to_utf8 ((wchar_t *) this_col_binding->data_buffer, str_len, &conv_string,
+					 &conv_string_len);
+		  if (conv_ret < 0)
+		    {
+		      net_buf_cp_int (net_buf, -1, NULL);
+		      continue;
+		    }
+
+		  net_buf_cp_int (net_buf, (int) conv_string_len, NULL);
+		  net_buf_cp_str (net_buf, (char *) conv_string, conv_string_len - 1);
 		  net_buf_cp_byte (net_buf, 0);
 		}
 	      else
@@ -420,8 +497,17 @@ cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding, int cursor
 	    case SQL_BIGINT:
 	      if (this_col_binding->col_unsigned_type)
 		{
-		  net_buf_cp_int (net_buf, (int) str_len + 1, NULL);
-		  net_buf_cp_str (net_buf, (char *) this_col_binding->data_buffer, str_len);
+		  conv_ret =
+		    cgw_unicode_to_utf8 ((wchar_t *) this_col_binding->data_buffer, str_len, &conv_string,
+					 &conv_string_len);
+		  if (conv_ret < 0)
+		    {
+		      net_buf_cp_int (net_buf, -1, NULL);
+		      continue;
+		    }
+
+		  net_buf_cp_int (net_buf, conv_string_len, NULL);
+		  net_buf_cp_str (net_buf, (char *) conv_string, conv_string_len - 1);
 		  net_buf_cp_byte (net_buf, 0);
 		}
 	      else
@@ -992,6 +1078,7 @@ cgw_col_bindings (SQLHSTMT hstmt, SQLSMALLINT num_cols, T_COL_BINDER ** col_bind
 	{
 	  bind_col_size = get_datatype_size (col_data_type, col_size, precision, scale);
 	}
+      bind_col_size *= sizeof (wchar_t);
 
       if (cgw_is_support_datatype (col_data_type, bind_col_size))
 	{
@@ -1010,8 +1097,7 @@ cgw_col_bindings (SQLHSTMT hstmt, SQLSMALLINT num_cols, T_COL_BINDER ** col_bind
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERFACE_NO_MORE_MEMORY, 0);
 	      goto ODBC_ERROR;
 	    }
-
-	  this_col_binding_buff->data_buffer = MALLOC (bind_col_size);
+	  this_col_binding_buff->data_buffer = (wchar_t *) MALLOC (bind_col_size);
 	  if (!(this_col_binding_buff->data_buffer))
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERFACE_NO_MORE_MEMORY, 0);
@@ -1685,7 +1771,7 @@ numeric_string_adjust (SQL_NUMERIC_STRUCT * numeric, char *string)
   char hexstr[SQL_MAX_NUMERIC_LEN + 1] = { 0 };
   char num_val[DECIMAL_DIGIT_MAX_LEN + 1] = { 0 };
   short i;
-  int num_add_zero;
+  size_t num_add_zero;
   UINT64 number = 0;
   char *endptr = NULL;
   int error;
@@ -2013,12 +2099,12 @@ get_c_type (SQLSMALLINT s_type, SQLLEN is_unsigned_type)
     case SQL_CHAR:
     case SQL_VARCHAR:
     case SQL_LONGVARCHAR:
-      c_type = SQL_C_CHAR;
+      c_type = SQL_C_WCHAR;
       break;
     case SQL_WCHAR:
     case SQL_WVARCHAR:
     case SQL_WLONGVARCHAR:
-      c_type = SQL_C_CHAR;
+      c_type = SQL_C_WCHAR;
       break;
     case SQL_BINARY:
     case SQL_VARBINARY:
@@ -2027,22 +2113,22 @@ get_c_type (SQLSMALLINT s_type, SQLLEN is_unsigned_type)
       break;
     case SQL_DECIMAL:
     case SQL_NUMERIC:
-      c_type = SQL_C_CHAR;
+      c_type = SQL_C_WCHAR;
       break;
     case SQL_BIT:
       c_type = SQL_C_BIT;
       break;
     case SQL_TINYINT:
-      c_type = (is_unsigned_type) ? SQL_C_CHAR : SQL_C_TINYINT;
+      c_type = (is_unsigned_type) ? SQL_C_WCHAR : SQL_C_TINYINT;
       break;
     case SQL_SMALLINT:
-      c_type = (is_unsigned_type) ? SQL_C_CHAR : SQL_C_SHORT;
+      c_type = (is_unsigned_type) ? SQL_C_WCHAR : SQL_C_SHORT;
       break;
     case SQL_INTEGER:
-      c_type = (is_unsigned_type) ? SQL_C_CHAR : SQL_C_LONG;
+      c_type = (is_unsigned_type) ? SQL_C_WCHAR : SQL_C_LONG;
       break;
     case SQL_BIGINT:
-      c_type = (is_unsigned_type) ? SQL_C_CHAR : SQL_C_SBIGINT;
+      c_type = (is_unsigned_type) ? SQL_C_WCHAR : SQL_C_SBIGINT;
       break;
     case SQL_REAL:
     case SQL_FLOAT:
@@ -2725,4 +2811,156 @@ cgw_split_string (const char *str, const char *delim, int *num)
   *num = (count - 1);
   FREE_MEM (o);
   return r;
+}
+
+static int
+cgw_unicode_to_utf8 (wchar_t * in_src, int in_size, char **out_target, int *out_length)
+{
+#if defined(WINDOWS)
+  int length;
+  unsigned char *in_string = (unsigned char *) in_src;
+
+  if (in_string == NULL || out_length == NULL || out_length == NULL)
+    {
+      return (-1);
+    }
+
+  if (in_size <= 0)
+    {
+      return (-1);
+    }
+
+
+  length = WideCharToMultiByte (CP_UTF8, 0, in_src, -1, NULL, 0, NULL, NULL);
+  if (length <= 0)
+    {
+      return -1;
+    }
+
+  length = WideCharToMultiByte (CP_UTF8, 0, in_src, -1, conv_out_string, length, NULL, NULL);
+  if (length <= 0)
+    {
+      return -1;
+    }
+
+  if (out_target)
+    {
+      *out_target = conv_out_string;
+    }
+
+  if (out_length)
+    {
+      *out_length = length;
+    }
+
+#else /* WINDOWS */
+
+  iconv_t cd;
+  size_t ret = 0;
+
+  uint16_t *iconv_in = (uint16_t *) in_src;
+  char *iconv_out = conv_out_string;
+
+  size_t inlen = in_size;
+  size_t outlen_org = CONV_STRING_BUF_SIZE;
+  size_t outlen = CONV_STRING_BUF_SIZE;
+
+  if (iconv_in == NULL || out_length == NULL || out_length == NULL)
+    {
+      return (-1);
+    }
+
+  cd = iconv_open (UTF8_CODE_PAGE, UNICODE_CODE_PAGE);
+  if (cd == (iconv_t) (-1))
+    {
+      return -1;
+    }
+
+  ret = iconv (cd, (char **) &iconv_in, &inlen, &iconv_out, &outlen);
+
+  if (ret == -1)
+    {
+      iconv_close (cd);
+      return (-1);
+    }
+
+  iconv_close (cd);
+
+  if (out_target)
+    {
+      conv_out_string[outlen_org - outlen] = '\0';
+      *out_target = conv_out_string;
+    }
+
+  if (out_length)
+    {
+      *out_length = (outlen_org - outlen) + 1;
+    }
+
+#endif
+  return 0;
+}
+
+static int
+cgw_conv_mtow (wchar_t * dest_wc, char *src_mbc)
+{
+  size_t length;
+
+  if (src_mbc == NULL || dest_wc == NULL)
+    {
+      return -1;
+    }
+
+  length = strlen (src_mbc);
+  if (length == 0)
+    {
+      return -1;
+    }
+
+  CONV_M_TO_W (src_mbc, dest_wc, length);
+
+  dest_wc[length] = L'\0';
+
+  return 0;
+}
+
+static int
+cgw_uint32_to_uni16 (uint32_t i, uint16_t * u)
+{
+  if (i < 0xffff)
+    {
+      *u = (uint16_t) (i & 0xffff);
+      return 1;
+    }
+
+  return 0;
+}
+
+static SQLWCHAR *
+cgw_wchar_to_sqlwchar (wchar_t * src, size_t len)
+{
+  SQLWCHAR *dest;
+  SQLWCHAR *sqlwchar_string;
+  size_t i;
+
+  if (sizeof (wchar_t) == sizeof (SQLWCHAR))
+    {
+      dest = (SQLWCHAR *) malloc (len * sizeof (SQLWCHAR));
+      memcpy (dest, src, len * sizeof (wchar_t));
+      return dest;
+    }
+  else
+    {
+      dest = (SQLWCHAR *) malloc (2 * len * sizeof (SQLWCHAR));
+      sqlwchar_string = dest;
+
+      for (i = 0; i < len; i++)
+	{
+	  dest += cgw_uint32_to_uni16 ((uint32_t) src[i], (uint16_t *) dest);
+	}
+      *dest = 0;
+      return sqlwchar_string;
+    }
+
+  return NULL;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24506

Purpose
* Oracle/MySQL has a character set of the server and a character set of the client, respectively.
There is a risk that the server's character set and the client's character set do not match, or an error may occur whenever the character set is changed. To prevent such an error, it is necessary to change it to read in unicode using a unicode driver.

* backport of #3880 to release/11.2

Implementation
N/A

Remarks
N/A