### PR TITLE
[CBRD-24492] Loading native library in Java SP causes UnsatisfiedLinkError

### DIFF
--- a/src/jsp/com/cubrid/jsp/ListenerThread.java
+++ b/src/jsp/com/cubrid/jsp/ListenerThread.java
@@ -52,7 +52,6 @@ public class ListenerThread extends Thread {
                 client = serverSocket.accept();
                 client.setTcpNoDelay(true);
                 Thread execThread = new ExecuteThread(client);
-                execThread.setContextClassLoader(new StoredProcedureClassLoader());
                 execThread.start();
             } catch (IOException e) {
                 Server.log(e);

--- a/src/jsp/com/cubrid/jsp/StoredProcedureClassLoader.java
+++ b/src/jsp/com/cubrid/jsp/StoredProcedureClassLoader.java
@@ -49,11 +49,9 @@ public class StoredProcedureClassLoader extends URLClassLoader {
     private FileTime lastModified = null;
 
     /* For singleton */
-    public synchronized static StoredProcedureClassLoader getInstance() {
+    public static synchronized StoredProcedureClassLoader getInstance() {
         if (instance == null) {
-                if (instance == null) {
-                    instance = new StoredProcedureClassLoader();
-                }
+            instance = new StoredProcedureClassLoader();
         }
 
         return instance;

--- a/src/jsp/com/cubrid/jsp/StoredProcedureClassLoader.java
+++ b/src/jsp/com/cubrid/jsp/StoredProcedureClassLoader.java
@@ -31,84 +31,68 @@
 
 package com.cubrid.jsp;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.net.MalformedURLException;
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.HashMap;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 
 public class StoredProcedureClassLoader extends URLClassLoader {
-    private HashMap<String, Long> files = new HashMap<String, Long>();
+    private static volatile StoredProcedureClassLoader instance = null;
 
-    private File root;
+    private static final String ROOT_PATH = Server.getSpPath() + "/java/";
+    private static final Path root = Paths.get(ROOT_PATH);
 
-    public StoredProcedureClassLoader() {
+    private FileTime lastModified = null;
+
+    /* For singleton */
+    public synchronized static StoredProcedureClassLoader getInstance() {
+        if (instance == null) {
+                if (instance == null) {
+                    instance = new StoredProcedureClassLoader();
+                }
+        }
+
+        return instance;
+    }
+
+    private StoredProcedureClassLoader() {
         super(new URL[0]);
         init();
     }
 
     private void init() {
-        root = new File(Server.getSpPath() + "/java");
         try {
-            addURL(root.toURI().toURL());
-            initJars();
-            initClasses();
-        } catch (MalformedURLException e) {
+            addURL(root.toUri().toURL());
+            lastModified = getLastModifiedTime(root);
+        } catch (IOException e) {
             Server.log(e);
         }
     }
 
-    private void initJars() throws MalformedURLException {
-        File[] jars =
-                root.listFiles(
-                        new FileFilter() {
-                            public boolean accept(File f) {
-                                return isJarFile(f);
-                            }
-                        });
-
-        if (jars == null) {
-            return;
-        }
-
-        for (int i = 0; i < jars.length; i++) {
-            files.put(jars[i].getName(), jars[i].lastModified());
-        }
-
-        for (int i = 0; i < jars.length; i++) {
-            addURL(jars[i].toURI().toURL());
-        }
-    }
-
-    private void initClasses() throws MalformedURLException {
-        File[] classes =
-                root.listFiles(
-                        new FileFilter() {
-                            public boolean accept(File f) {
-                                return isClassFile(f);
-                            }
-                        });
-
-        if (classes == null) {
-            return;
-        }
-
-        for (int i = 0; i < classes.length; i++) {
-            files.put(classes[i].getName(), classes[i].lastModified());
-            addURL(classes[i].toURI().toURL());
-        }
-    }
-
     public Class<?> loadClass(String name) throws ClassNotFoundException {
-        return super.loadClass(name);
+        try {
+            if (!isModified()) {
+                return super.loadClass(name);
+            }
+
+            instance = new StoredProcedureClassLoader();
+            return instance.loadClass(name);
+        } catch (IOException e) {
+            return null;
+        }
     }
 
-    private boolean isJarFile(File f) {
-        return f.getName().lastIndexOf(".jar") > 0;
+    private boolean isModified() throws IOException {
+        return lastModified.compareTo(getLastModifiedTime(root)) != 0;
     }
 
-    private boolean isClassFile(File f) {
-        return f.getName().lastIndexOf(".class") > 0;
+    private FileTime getLastModifiedTime(Path path) throws IOException {
+        BasicFileAttributes attr = Files.readAttributes(path, BasicFileAttributes.class);
+        FileTime lastModifiedTime = attr.lastModifiedTime();
+        return lastModifiedTime;
     }
 }

--- a/src/jsp/com/cubrid/jsp/TargetMethod.java
+++ b/src/jsp/com/cubrid/jsp/TargetMethod.java
@@ -76,7 +76,7 @@ public class TargetMethod {
     }
 
     private Class<?> getClass(String name) throws ClassNotFoundException {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ClassLoader cl = StoredProcedureClassLoader.getInstance();
         return cl.loadClass(name);
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24492

**Purpose**
Java SP server creates a new classloader per session. A classloader load classes from $CUBRID/java. If .class or .jar file is modified in the path, The new classloader reloads it. (Dynamic Class Loading). It causes UnsatisfiedLinkError: already loaded in another classloader.

**Implementation**
- The StoredProcedureClassLoader is reverted as a singleton
- The class loader only checks the root folder is modified (by Java NIO API). I expect it will show better performance than the previous one, which checked last modified all .class and .jar files in the root folder.
- If any file is modified in the root, the loader is re-instantiated. It could cause the same problem of this issue, but it can be bypassed by restarting the javasp server.