### PR TITLE
[LETS-560] [Regression] Broken PTS-PS page synchronization mechanism causes crash in PS

### DIFF
--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -133,13 +133,13 @@ passive_tran_server::send_and_receive_log_boot_info (THREAD_ENTRY *thread_p,
   return NO_ERROR;
 }
 
-void passive_tran_server::start_log_replicator (const log_lsa &start_lsa, const log_lsa &prev_lsa)
+void passive_tran_server::start_log_replicator (const log_lsa &start_lsa)
 {
   assert (m_replicator == nullptr);
 
   // passive transaction server executes replication synchronously, for the time being, due to complexity of
   // executing it in parallel while also providing a consistent view of the data
-  m_replicator.reset (new cublog::atomic_replicator (start_lsa, prev_lsa));
+  m_replicator.reset (new cublog::atomic_replicator (start_lsa));
 }
 
 void passive_tran_server::send_and_receive_stop_log_prior_dispatch ()

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -33,10 +33,10 @@ class passive_tran_server : public tran_server
   public:
     int send_and_receive_log_boot_info (THREAD_ENTRY *thread_p,
 					log_lsa &most_recent_trantable_snapshot_lsa);
-    void start_log_replicator (const log_lsa &start_lsa, const log_lsa &prev_lsa);
-    void start_oldest_active_mvccid_sender ();
-
     void send_and_receive_stop_log_prior_dispatch ();
+
+    void start_log_replicator (const log_lsa &start_lsa);
+    void start_oldest_active_mvccid_sender ();
 
     /* highest processed lsa, to be used for retrieve pages from PS */
     log_lsa get_highest_processed_lsa () const;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1616,7 +1616,6 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
   passive_tran_server *const pts_ptr = get_passive_tran_server_ptr ();
   assert (pts_ptr != nullptr);
   log_lsa replication_start_redo_lsa = NULL_LSA;
-  log_lsa replication_prev_redo_lsa = NULL_LSA;
   {
     LOG_CS_ENTER (thread_p);
     // *INDENT-OFF*
@@ -1647,7 +1646,6 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
       // while still holding prior LSA lock, initialize passive transaction server replication
       // with a LSA that ensures that no record is lost (ie: while still holding the mutex)
       replication_start_redo_lsa = log_Gl.append.get_nxio_lsa ();
-      replication_prev_redo_lsa = log_Gl.append.prev_lsa;
     }
     // prior lists from page server are being received now
 
@@ -1675,13 +1673,12 @@ log_initialize_passive_tran_server (THREAD_ENTRY * thread_p)
   // prior lists are consumed and flushed to log pages
 
   assert (!replication_start_redo_lsa.is_null ());
-  assert (!replication_prev_redo_lsa.is_null ());
 
   log_daemons_init ();
 
   pts_ptr->start_oldest_active_mvccid_sender ();
 
-  pts_ptr->start_log_replicator (replication_start_redo_lsa, replication_prev_redo_lsa);
+  pts_ptr->start_log_replicator (replication_start_redo_lsa);
 
   // NOTE: make sure not to re-define trantable here; already defined in boot_restart_server
   // re-defining trabtable here, will reset all transaction info (which is not needed, see below) together

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -520,25 +520,18 @@ namespace cublog
   log_lsa
   replicator::get_highest_processed_lsa () const
   {
-    /*
-     * This is supposed to return the processed lsa by the replicator.
-     * In the case of atomic replicator on PTS, it points to the log record redone, that m_redo_lsa pointed to.
-     * However, "processed" means vague to the replicator of PS, with the parallel redo,
-     * because the replicator just put the redo records to workers and updates m_redo_lsa.
-     * Anyway, now get_highest_processed_lsa() is only used on PTS, so assert(false) here.
-     */
-    assert (false);
-    return MAX_LSA;
+    std::lock_guard<std::mutex> lockg (m_redo_lsa_mutex);
+    return m_redo_lsa;
   }
 
   log_lsa
   replicator::get_lowest_unapplied_lsa () const
   {
+    // TODO: needs to be refactored to work with the new replicators flavors
     if (m_parallel_replication_redo == nullptr)
       {
-	std::lock_guard<std::mutex> lockg (m_redo_lsa_mutex);
 	// sync
-	return m_redo_lsa;
+	return get_highest_processed_lsa ();
       }
 
     // a different value will return from here when the atomic replicator is added

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -72,7 +72,7 @@ namespace cublog
       /* wait until replication advances past the target lsa; blocking call */
       void wait_past_target_lsa (const log_lsa &a_target_lsa);
       /* return current progress of the replicator; non-blocking call */
-      virtual log_lsa get_highest_processed_lsa () const;
+      log_lsa get_highest_processed_lsa () const;
       /* return the lowest value lsa that was not applied, the next in line lsa */
       virtual log_lsa get_lowest_unapplied_lsa () const;
 

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -25,10 +25,9 @@
 namespace cublog
 {
 
-  atomic_replicator::atomic_replicator (const log_lsa &start_redo_lsa, const log_lsa &prev_redo_lsa)
+  atomic_replicator::atomic_replicator (const log_lsa &start_redo_lsa)
     : replicator (start_redo_lsa, OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT, 0)
     , m_lowest_unapplied_lsa { start_redo_lsa }
-    , m_processed_lsa { prev_redo_lsa }
   {
 
   }
@@ -208,7 +207,6 @@ namespace cublog
 	  // however, this would need one more mutex lock; therefore, suffice to do it here
 	  assert (m_replication_active);
 
-	  m_processed_lsa = m_redo_lsa;
 	  m_redo_lsa = header.forw_lsa;
 	}
 
@@ -258,13 +256,6 @@ namespace cublog
 		m_parallel_replication_redo, *m_reusable_jobs.get (), m_perf_stat_idle);
 	  }
       }
-  }
-
-  log_lsa
-  atomic_replicator::get_highest_processed_lsa () const
-  {
-    std::lock_guard<std::mutex> lockg (m_redo_lsa_mutex);
-    return m_processed_lsa;
   }
 
   log_lsa

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -67,7 +67,7 @@ namespace cublog
   class atomic_replicator : public replicator
   {
     public:
-      atomic_replicator (const log_lsa &start_redo_lsa, const log_lsa &prev_redo_lsa);
+      atomic_replicator (const log_lsa &start_redo_lsa);
 
       atomic_replicator (const atomic_replicator &) = delete;
       atomic_replicator (atomic_replicator &&) = delete;
@@ -77,8 +77,6 @@ namespace cublog
       atomic_replicator &operator= (const atomic_replicator &) = delete;
       atomic_replicator &operator= (atomic_replicator &&) = delete;
 
-      /* return current progress of the replicator; non-blocking call */
-      log_lsa get_highest_processed_lsa () const override;
       /* return the lowest value lsa that was not applied, the next in line lsa */
       log_lsa get_lowest_unapplied_lsa () const override;
     private:
@@ -94,7 +92,6 @@ namespace cublog
     private:
       atomic_replication_helper m_atomic_helper;
       log_lsa m_lowest_unapplied_lsa;
-      log_lsa m_processed_lsa = NULL_LSA; /* protected by m_redo_lsa_mutex with m_redo_lsa */
       mutable std::mutex m_lowest_unapplied_lsa_mutex;
   };
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-560

Revert LETS-458, namely #3819.

 The page allocation contains several works and it’s done by setting the page type, however, they generate separate log records. The RVBT_GET_NEWPAGE on the issue is one example. The page is actually already allocated (volume sector table or file sector table are already modified), but when trying to set the page type, it is failed to fix the page because the page has no page type yet. It probably happened in all the cases where allocating a new page is replicated on PTS. 
We'll come up with a solution considering this case.
