### PR TITLE
[CBRD-24499] Make parent directories of socket file if not exists

### DIFF
--- a/src/jsp/com/cubrid/jsp/Server.java
+++ b/src/jsp/com/cubrid/jsp/Server.java
@@ -80,6 +80,12 @@ public class Server {
                     socketFile.delete();
                 }
 
+                /* check parent directory */
+                File socketDir = socketFile.getParentFile();
+                if (!socketDir.exists()) {
+                    socketDir.mkdirs();
+                }
+
                 AFUNIXSocketAddress sockAddr = AFUNIXSocketAddress.of(socketFile);
                 serverSocket = AFUNIXServerSocket.bindOn(sockAddr);
                 portNumber = udsPortNumber;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24499

If the default path, $CUBRID/var/CUBRID_SOCK directory may be deleted in some cases, The socket file is not created
