### PR TITLE
[CBRD-24523] Set java_stored_procedure_uds to false forcely on Windows (#3899)

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -10807,6 +10807,7 @@ prm_tune_parameters (void)
   SYSPRM_PARAM *ha_check_disk_failure_interval_prm;
   SYSPRM_PARAM *test_mode_prm;
   SYSPRM_PARAM *tz_leap_second_support_prm;
+  SYSPRM_PARAM *java_stored_procedure_uds_prm;
 
   char newval[LINE_MAX];
   char host_name[CUB_MAXHOSTNAMELEN];
@@ -10823,6 +10824,7 @@ prm_tune_parameters (void)
   ha_check_disk_failure_interval_prm = prm_find (PRM_NAME_HA_CHECK_DISK_FAILURE_INTERVAL_IN_SECS, NULL);
   test_mode_prm = prm_find (PRM_NAME_TEST_MODE, NULL);
   tz_leap_second_support_prm = prm_find (PRM_NAME_TZ_LEAP_SECOND_SUPPORT, NULL);
+  java_stored_procedure_uds_prm = prm_find (PRM_NAME_JAVA_STORED_PROCEDURE_UDS, NULL);
 
   assert (max_plan_cache_entries_prm != NULL);
   if (max_plan_cache_entries_prm == NULL)
@@ -10862,6 +10864,10 @@ prm_tune_parameters (void)
 	  prm_set (ha_check_disk_failure_interval_prm, newval, false);
 	}
     }
+
+#if defined (WINDOWS)
+  (void) prm_set (java_stored_procedure_uds_prm, "no", false);
+#endif
 
   /* disable them temporarily */
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24523

backport of #3899 