### PR TITLE
[LETS-550] Load vacuum data first to prevent a potential bug

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3006,8 +3006,6 @@ vacuum_master_task::execute (cubthread::entry &thread_ref)
        * 1, 2 don't need to request the mvcc status from other server because there is no PTS,
        * which are both filtered with is_tran_server_with_remote_storage().
        */
-
-      /* TODO temporary logging. The global one will be computed taking both into account, and the vacuum runs */ 
       MVCCID global_pts_oldest_visible_mvccid = get_active_tran_server_ptr ()->get_oldest_active_mvccid_from_page_server ();
       if (global_pts_oldest_visible_mvccid == MVCCID_NULL)
         {

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -2979,6 +2979,18 @@ vacuum_master_task::execute (cubthread::entry &thread_ref)
 
   PERF_UTIME_TRACKER_START (&thread_ref, &perf_tracker);
 
+  if (!vacuum_Data.is_loaded)
+    {
+      /* Load vacuum data. */
+      /* This was initially in boot_restart_server. However, the "commit" of boot_restart_server will complain
+       * about vacuum data first and last page not being unfixed (and it will also unfix them).
+       * So, we have to load the data here (vacuum master never commits).
+       */
+      vacuum_data_load_first_and_last_page (&thread_ref);
+
+      m_cursor.set_on_vacuum_data_start ();
+    }
+
   if (is_tran_server_with_remote_storage ()) 
     {
       /* 
@@ -3014,18 +3026,6 @@ vacuum_master_task::execute (cubthread::entry &thread_ref)
     }
   
   vacuum_er_log (VACUUM_ER_LOG_MASTER, "update oldest_visible = %lld", (long long int) m_oldest_visible_mvccid);
-
-  if (!vacuum_Data.is_loaded)
-    {
-      /* Load vacuum data. */
-      /* This was initially in boot_restart_server. However, the "commit" of boot_restart_server will complain
-       * about vacuum data first and last page not being unfixed (and it will also unfix them).
-       * So, we have to load the data here (vacuum master never commits).
-       */
-      vacuum_data_load_first_and_last_page (&thread_ref);
-
-      m_cursor.set_on_vacuum_data_start ();
-    }
 
   if (!is_tran_server_with_remote_storage ())
     {

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3012,7 +3012,6 @@ vacuum_master_task::execute (cubthread::entry &thread_ref)
       if (global_pts_oldest_visible_mvccid == MVCCID_NULL)
         {
           vacuum_er_log (VACUUM_ER_LOG_MASTER, "%s", "Fail to get the oldest active mvccid across all PTS.");
-          assert (false);
           return;
         }
       


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-550

Small fix;
- The vacuum data is loaded on the master thread loop, not when the vacuum is initialized.
There is a low chance the data is not loaded, and in turn, it dumps core when it is shutdown if the vacuum master thread job returns continuously without loading the data. It can happen if connection to PS fails continuously. So, I fix the data to be loaded before any job. It would barely happen, but what is correct is correct.
- Remove an assert that says `get_active_tran_server_ptr ()->get_oldest_active_mvccid_from_page_server ()` always succeeds. The connection with PS may not work for a while for some reason. However, from the vacuum's point of view, the connection's stability doesn't need to be guaranteed. In that case, it can just restart later with the expectation it will get stable.