### PR TITLE
[CBRD-24523] Fix invalid port number is passed to Java SP Server on Windows

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -10824,7 +10824,6 @@ prm_tune_parameters (void)
   ha_check_disk_failure_interval_prm = prm_find (PRM_NAME_HA_CHECK_DISK_FAILURE_INTERVAL_IN_SECS, NULL);
   test_mode_prm = prm_find (PRM_NAME_TEST_MODE, NULL);
   tz_leap_second_support_prm = prm_find (PRM_NAME_TZ_LEAP_SECOND_SUPPORT, NULL);
-  java_stored_procedure_uds_prm = prm_find (PRM_NAME_JAVA_STORED_PROCEDURE_UDS, NULL);
 
   assert (max_plan_cache_entries_prm != NULL);
   if (max_plan_cache_entries_prm == NULL)
@@ -10864,10 +10863,6 @@ prm_tune_parameters (void)
 	  prm_set (ha_check_disk_failure_interval_prm, newval, false);
 	}
     }
-
-#if defined (WINDOWS)
-  (void) prm_set (java_stored_procedure_uds_prm, "no", false);
-#endif
 
   /* disable them temporarily */
 

--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -285,7 +285,7 @@ exit:
 static int
 javasp_get_port_param ()
 {
-  int prm_port = -1;
+  int prm_port = 0;
 #if defined (WINDOWS)
   const bool is_uds_mode = false;
 #else
@@ -315,8 +315,7 @@ javasp_start_server (const JAVASP_SERVER_INFO jsp_info, const std::string &db_na
 
       if (status == NO_ERROR)
 	{
-	  int port_number = prm_get_bool_value (PRM_ID_JAVA_STORED_PROCEDURE_UDS) ? JAVASP_PORT_UDS_MODE : jsp_server_port ();
-	  JAVASP_SERVER_INFO jsp_new_info { getpid(), port_number };
+	  JAVASP_SERVER_INFO jsp_new_info { getpid(), jsp_server_port () };
 
 	  javasp_unlink_info (db_name.c_str ());
 	  if ((javasp_open_info_dir () && javasp_write_info (db_name.c_str (), jsp_new_info)))

--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -94,6 +94,8 @@ static int javasp_get_server_info (const std::string &db_name, JAVASP_SERVER_INF
 static int javasp_check_argument (int argc, char *argv[], std::string &command, std::string &db_name);
 static int javasp_check_database (const std::string &db_name, std::string &db_path);
 
+static int javasp_get_port_param ();
+
 /*
  * main() - javasp main function
  */
@@ -281,6 +283,19 @@ exit:
 }
 
 static int
+javasp_get_port_param ()
+{
+  int prm_port = -1;
+#if defined (WINDOWS)
+  const bool is_uds_mode = false;
+#else
+  const bool is_uds_mode = prm_get_bool_value (PRM_ID_JAVA_STORED_PROCEDURE_UDS);
+#endif
+  prm_port = (is_uds_mode) ? JAVASP_PORT_UDS_MODE : prm_get_integer_value (PRM_ID_JAVA_STORED_PROCEDURE_PORT);
+  return prm_port;
+}
+
+static int
 javasp_start_server (const JAVASP_SERVER_INFO jsp_info, const std::string &db_name, const std::string &path)
 {
   int status = NO_ERROR;
@@ -291,23 +306,12 @@ javasp_start_server (const JAVASP_SERVER_INFO jsp_info, const std::string &db_na
     }
   else
     {
-      int prm_port = -1;
-      const bool is_uds_mode = prm_get_bool_value (PRM_ID_JAVA_STORED_PROCEDURE_UDS);
-      if (is_uds_mode)
-	{
-	  prm_port = JAVASP_PORT_UDS_MODE;
-	}
-      else
-	{
-	  prm_port = prm_get_integer_value (PRM_ID_JAVA_STORED_PROCEDURE_PORT);
-	}
-
 #if !defined(WINDOWS)
       /* create a new session */
       setsid ();
 #endif
       er_clear (); // clear error before string JVM
-      status = jsp_start_server (db_name.c_str (), path.c_str (), prm_port);
+      status = jsp_start_server (db_name.c_str (), path.c_str (), javasp_get_port_param ());
 
       if (status == NO_ERROR)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24523

Instead of tuning the system parameter (java_stored_procedure_uds), I've created a new getter function for the port parameter according to the OS.