### PR TITLE
[LETS-545] [LETS-537] [LETS-425] refactor Passive Transaction Server atomic replication with encountered use cases

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -708,6 +708,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_ER_LOG_COMMIT_CONFIRM "er_log_commit_confirm"
 #define PRM_NAME_ER_LOG_CALC_REPL_DELAY "er_log_calculate_replication_delay"
 #define PRM_NAME_ER_LOG_PTS_REPL_DEBUG "er_log_pts_repl_debug"
+#define PRM_NAME_ER_LOG_PTS_ATOMIC_REPL_DEBUG "er_log_pts_atomic_repl_debug"
 
 #define PRM_NAME_RECOVERY_PARALLEL_COUNT "recovery_parallel_count"
 #define PRM_NAME_RECOVERY_PARALLEL_TASK_DEBUG "recovery_parallel_task_debug"
@@ -2435,6 +2436,10 @@ static unsigned int prm_er_log_calc_repl_delay_flag = 0;
 bool PRM_ER_LOG_PTS_REPL_DEBUG = true;
 static bool prm_er_log_pts_repl_debug_default = false;
 static unsigned int prm_er_log_pts_repl_debug_flag = 0;
+
+bool PRM_ER_LOG_PTS_ATOMIC_REPL_DEBUG = true;
+static bool prm_er_log_pts_atomic_repl_debug_default = false;
+static unsigned int prm_er_log_pts_atomic_repl_debug_flag = 0;
 
 static unsigned int prm_recovery_parallel_count_flag = 0;
 static int prm_recovery_parallel_count_default = 8;
@@ -6346,6 +6351,19 @@ static SYSPRM_PARAM prm_Def[] = {
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},
+  {PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG,
+   PRM_NAME_ER_LOG_PTS_ATOMIC_REPL_DEBUG,
+   (PRM_HIDDEN | PRM_FOR_SERVER | PRM_USER_CHANGE),
+   PRM_BOOLEAN,
+   &prm_er_log_pts_atomic_repl_debug_flag,
+   (void *) &prm_er_log_pts_atomic_repl_debug_default,
+   (void *) &PRM_ER_LOG_PTS_ATOMIC_REPL_DEBUG,
+   (void *) NULL,
+   (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+
   {PRM_ID_RECOVERY_PARALLEL_COUNT,
    PRM_NAME_RECOVERY_PARALLEL_COUNT,
    (PRM_FOR_SERVER),

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -465,7 +465,9 @@ enum param_id
   PRM_ID_ER_LOG_READ_LOG_PAGE,
   PRM_ID_ER_LOG_READ_DATA_PAGE,
   PRM_ID_ER_LOG_CALC_REPL_DELAY,
-  PRM_ID_ER_LOG_PTS_REPL_DEBUG,	/* temporary parameter to support passive transaction server replication debugging */
+  /* temporary parameter to support passive transaction server replication debugging */
+  PRM_ID_ER_LOG_PTS_REPL_DEBUG,	/* actually, used for MVCC replication */
+  PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG,
 
   PRM_ID_RECOVERY_PARALLEL_COUNT,
   PRM_ID_RECOVERY_PARALLEL_TASK_DEBUG,

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -220,7 +220,8 @@ namespace cublog
 	return;
       }
 
-    sequence_it->second.apply_and_unfix_sequence (thread_p);
+    atomic_log_sequence &sequence = sequence_it->second;
+    sequence.apply_and_unfix_sequence (thread_p);
     m_sequences_map.erase (sequence_it);
 
 #if !defined (NDEBUG)
@@ -365,18 +366,63 @@ namespace cublog
   }
 
   void
+  atomic_replication_helper::atomic_log_sequence::dump ()
+  {
+#if !defined (NDEBUG)
+    char buf[PATH_MAX];
+    char *buf_ptr = buf;
+    int written = 0;
+    int left = PATH_MAX;
+
+    written = snprintf (buf_ptr, (size_t)left, "[ATOMIC_REPL] start_lsa = %lld|%d  is_sysop = %d"
+			"  postpone_started = %d  end_pospone_count = %d\n",
+			LSA_AS_ARGS (&m_start_lsa), (int)m_is_sysop,
+			(int)m_postpone_started, m_end_pospone_count);
+    assert (written > 0);
+    buf_ptr += written;
+    assert (left >= written);
+    left -= written;
+
+    for (const atomic_log_entry &log_entry : m_log_vec)
+      {
+	written = snprintf (buf_ptr, (size_t)left, "  LSA = %lld|%d  vpid = %d|%d\n  rcvindex = %s\n",
+			    LSA_AS_ARGS (&log_entry.m_record_lsa),
+			    VPID_AS_ARGS (&log_entry.m_vpid),
+			    rv_rcvindex_string (log_entry.m_record_index));
+	assert (written > 0);
+	buf_ptr += written;
+	assert (left >= written);
+	left -= written;
+      }
+    _er_log_debug (ARG_FILE_LINE, buf);
+#endif
+  }
+
+  void
   atomic_replication_helper::atomic_log_sequence::apply_and_unfix_sequence (THREAD_ENTRY *thread_p)
   {
     // Applying the log right after the fix could lead to problems as the records are fixed one by one as
     // they come to be read by the PTS and some might be unfixed and refixed after the apply procedure
-    // leading to inconsistency. To avoid this situation we sequentially apply each log redo of the sequence
-    // when the end sequence log appears and the entire sequence is fixed
+    // leading to inconsistency.
+    // To avoid this situation each log redo of the sequence is applied when the end sequence log appears
+    // and the entire sequence is already fixed.
+    // Right after applying, unfix and ref-count-down each page. The bookkeeping mechanism will take care
+    // of either unfixing the page or retaining it for a subsequent unfix.
+
+    if (prm_get_bool_value (PRM_ID_ER_LOG_DEBUG))
+      {
+	dump ();
+      }
+
     for (const auto &log_entry : m_log_vec)
       {
 	log_entry.apply_log_redo (thread_p, m_redo_context);
 	// bookkeeping actually will either unfix the page or just decrease its reference count
 	m_page_ptr_bookkeeping.unfix_page (thread_p, log_entry.m_vpid);
       }
+
+    // clear the vector of log records; page pts's might be, at this point, dangling pointers as the page ptr
+    // bookkeeping mechanims might have already unfixed the page
     m_log_vec.clear ();
   }
 

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -18,9 +18,7 @@
 
 #include "atomic_replication_helper.hpp"
 
-#if !defined (NDEBUG)
-#  include "log_manager.h"
-#endif
+#include "log_manager.h"
 #include "log_recovery.h"
 #include "log_recovery_redo.hpp"
 #include "page_buffer.h"
@@ -37,7 +35,7 @@ namespace cublog
   atomic_replication_helper::append_log (THREAD_ENTRY *thread_p, TRANID tranid,
 					 LOG_LSA record_lsa, LOG_RCVINDEX rcvindex, VPID vpid)
   {
-#if !defined (NDEBUG)
+#ifdef ATOMIC_REPL_PAGE_BELONGS_TO_SINGLE_ATOMIC_SEQUENCE_CHECK
     if (!VPID_ISNULL (&vpid) && !check_for_page_validity (vpid, tranid))
       {
 	assert (false);
@@ -62,9 +60,7 @@ namespace cublog
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
-#if !defined (NDEBUG)
 	dump ("helper::append_log");
-#endif
       }
 
     return NO_ERROR;
@@ -78,13 +74,11 @@ namespace cublog
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
-#if !defined (NDEBUG)
 	if (sequence_it != m_sequences_map.cend ())
 	  {
 	    const atomic_log_sequence &atomic_sequence = sequence_it->second;
 	    dump ("helper::start_sequence_internal");
 	  }
-#endif
       }
 
     assert (sequence_it == m_sequences_map.cend ());
@@ -98,7 +92,7 @@ namespace cublog
     emplaced_seq.initialize (trid, start_lsa);
   }
 
-#if !defined (NDEBUG)
+#ifdef ATOMIC_REPL_PAGE_BELONGS_TO_SINGLE_ATOMIC_SEQUENCE_CHECK
   bool
   atomic_replication_helper::check_for_page_validity (VPID vpid, TRANID tranid) const
   {
@@ -189,30 +183,26 @@ namespace cublog
     if (sequence.can_purge ())
       {
 	m_sequences_map.erase (sequence_it);
-#if !defined (NDEBUG)
+#ifdef ATOMIC_REPL_PAGE_BELONGS_TO_SINGLE_ATOMIC_SEQUENCE_CHECK
 	m_vpid_sets_map.erase (trid);
 #endif
 
 	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 	  {
-#if !defined (NDEBUG)
 	    const TRANID trid = sequence_it->first;
 	    _er_log_debug (ARG_FILE_LINE,
 			   "[ATOMIC_REPL] append_control_log purged trid = %d\n",
 			   trid);
-#endif
 	  }
       }
     else
       {
 	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 	  {
-#if !defined (NDEBUG)
 	    const TRANID trid = sequence_it->first;
 	    _er_log_debug (ARG_FILE_LINE,
 			   "[ATOMIC_REPL] append_control_log _not_ purged trid = %d\n",
 			   trid);
-#endif
 	  }
       }
   }
@@ -236,30 +226,26 @@ namespace cublog
     if (sequence.can_purge ())
       {
 	m_sequences_map.erase (sequence_it);
-#if !defined (NDEBUG)
+#ifdef ATOMIC_REPL_PAGE_BELONGS_TO_SINGLE_ATOMIC_SEQUENCE_CHECK
 	m_vpid_sets_map.erase (trid);
 #endif
 
 	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 	  {
-#if !defined (NDEBUG)
 	    const TRANID trid = sequence_it->first;
 	    _er_log_debug (ARG_FILE_LINE,
 			   "[ATOMIC_REPL] append_control_log_sysop_end purged trid = %d\n",
 			   trid);
-#endif
 	  }
       }
     else
       {
 	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 	  {
-#if !defined (NDEBUG)
 	    const TRANID trid = sequence_it->first;
 	    _er_log_debug (ARG_FILE_LINE,
 			   "[ATOMIC_REPL] append_control_log_sysop_end _not_ purged trid = %d\n",
 			   trid);
-#endif
 	  }
       }
   }
@@ -277,16 +263,13 @@ namespace cublog
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
-#if !defined (NDEBUG)
 	dump ("helper::forcibly_remove_idle_sequence");
-#endif
       }
 
     // sequence dtor will ensure proper idle state upon destruction
     m_sequences_map.erase (sequence_it);
   }
 
-#if !defined (NDEBUG)
   void
   atomic_replication_helper::dump (const char *message) const
   {
@@ -311,7 +294,6 @@ namespace cublog
       }
     _er_log_debug (ARG_FILE_LINE, buf);
   }
-#endif
 
   /********************************************************************************
    * atomic_replication_helper::atomic_log_sequence function definitions  *
@@ -377,9 +359,7 @@ namespace cublog
   {
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
-#if !defined (NDEBUG)
 	dump ("sequence::apply_and_unfix START");
-#endif
       }
 
     // nothing to apply and unfix
@@ -434,9 +414,7 @@ namespace cublog
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
-#if !defined (NDEBUG)
 	dump ("sequence::apply_and_unfix END");
-#endif
       }
 
     assert (all_log_entries_are_control ());
@@ -456,9 +434,7 @@ namespace cublog
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
-#if !defined (NDEBUG)
 	dump ("sequence::append_control_log END");
-#endif
       }
   }
 
@@ -470,9 +446,7 @@ namespace cublog
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
-#if !defined (NDEBUG)
 	dump ("sequence::append_control_log_sysop_end END");
-#endif
       }
   }
 
@@ -508,9 +482,7 @@ namespace cublog
 
 	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 	  {
-#if !defined (NDEBUG)
 	    dump ("sequence::can_purge - START");
-#endif
 	  }
 
 	const atomic_log_entry_vector_type::const_iterator last_entry_it = m_log_vec.cend () - 1;
@@ -536,9 +508,7 @@ namespace cublog
 
 		    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		      {
-#if !defined (NDEBUG)
 			dump ("sequence::can_purge - after LOG_SYSOP_END - LOG_SYSOP_START_POSTPONE");
-#endif
 		      }
 		    assert (m_log_vec.empty ());
 		  }
@@ -564,9 +534,7 @@ namespace cublog
 
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
-#if !defined (NDEBUG)
 		    dump ("sequence::can_purge - after LOG_SYSOP_END with non-null last_parent_lsa");
-#endif
 		  }
 	      }
 	    // isolated atomic sysop with null parent_lsa on the sysop end record
@@ -578,9 +546,7 @@ namespace cublog
 
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
-#if !defined (NDEBUG)
 		    dump ("sequence::can_purge - after LOG_SYSOP_END with null last_parent_lsa");
-#endif
 		  }
 	      }
 	  }
@@ -598,9 +564,7 @@ namespace cublog
 
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
-#if !defined (NDEBUG)
 		    dump ("sequence::can_purge - after LOG_SYSOP_END - LOG_SYSOP_END_LOGICAL_RUN_POSTPONE");
-#endif
 		  }
 	      }
 	  }
@@ -617,9 +581,7 @@ namespace cublog
 
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
-#if !defined (NDEBUG)
 		    dump ("sequence::can_purge - after LOG_SYSOP_END - LOG_SYSOP_END_LOGICAL_UNDO");
-#endif
 		  }
 	      }
 	  }
@@ -651,9 +613,7 @@ namespace cublog
 		  {
 		    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		      {
-#if !defined (NDEBUG)
 			dump ("sequence::can_purge - after failed LOG_END_ATOMIC_REPL");
-#endif
 		      }
 
 		    assert_release ("inconsistent atomic log sequence found" == nullptr);
@@ -663,9 +623,7 @@ namespace cublog
 
 	    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 	      {
-#if !defined (NDEBUG)
 		dump ("sequence::can_purge - after LOG_END_ATOMIC_REPL");
-#endif
 	      }
 	  }
 
@@ -676,9 +634,7 @@ namespace cublog
 	      {
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
-#if !defined (NDEBUG)
 		    dump ("sequence::can_purge - too many log entries");
-#endif
 		  }
 
 		assert (false);
@@ -690,7 +646,6 @@ namespace cublog
     return false;
   }
 
-#if !defined (NDEBUG)
   void
   atomic_replication_helper::atomic_log_sequence::dump (const char *message) const
   {
@@ -727,7 +682,6 @@ namespace cublog
 	log_entry.dump_to_buffer (buf_ptr, buf_len);
       }
   }
-#endif
 
   /*********************************************************************************************************
    * atomic_replication_helper::atomic_log_sequence::atomic_log_entry function definitions  *
@@ -856,7 +810,6 @@ namespace cublog
 	    m_rectype == LOG_SYSOP_START_POSTPONE);
   }
 
-#if !defined (NDEBUG)
   void
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::dump_to_buffer (
 	  char *&buf_ptr, int &buf_len) const
@@ -885,7 +838,6 @@ namespace cublog
     assert (buf_len >= written);
     buf_len -= written;
   }
-#endif
 
   /*********************************************************************************************************
    * atomic_replication_helper::atomic_log_sequence::page_ptr_info function definitions  *
@@ -994,7 +946,7 @@ namespace cublog
       }
   }
 
-#if !defined (NDEBUG)
+#ifdef ATOMIC_REPL_PAGE_PTR_BOOKKEEPING_DUMP
   void
   atomic_replication_helper::atomic_log_sequence::page_ptr_bookkeeping::dump () const
   {

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2008 Search Solution Corporation
  * Copyright 2016 CUBRID Corporation
  *
@@ -75,6 +75,7 @@ namespace cublog
       const log_rv_redo_context &redo_context)
   {
     const auto sequence_it = m_sequences_map.find (trid);
+
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
 #if !defined (NDEBUG)
@@ -85,6 +86,7 @@ namespace cublog
 	  }
 #endif
       }
+
     assert (sequence_it == m_sequences_map.cend ());
 
     const std::pair<sequence_map_type::iterator, bool> emplace_res = m_sequences_map.emplace (trid, redo_context);
@@ -228,6 +230,7 @@ namespace cublog
       }
 
     atomic_log_sequence &sequence = sequence_it->second;
+
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
 #if !defined (NDEBUG)
@@ -405,6 +408,7 @@ namespace cublog
   atomic_replication_helper::atomic_log_sequence::append_control_log (LOG_RECTYPE rectype, LOG_LSA lsa)
   {
     m_log_vec.emplace_back (lsa, rectype);
+
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
 #if !defined (NDEBUG)
@@ -418,6 +422,7 @@ namespace cublog
 	  LOG_LSA lsa, LOG_SYSOP_END_TYPE sysop_end_type, LOG_LSA sysop_end_last_parent_lsa)
   {
     m_log_vec.emplace_back (lsa, sysop_end_type, sysop_end_last_parent_lsa);
+
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
 #if !defined (NDEBUG)
@@ -463,8 +468,6 @@ namespace cublog
 #endif
 	  }
 
-	//atomic_log_entry_vector_type::const_iterator entry_it = m_log_vec.cend ();
-	//--entry_it;
 	const atomic_log_entry_vector_type::const_iterator last_entry_it = m_log_vec.cend () - 1;
 	const atomic_log_entry &last_entry = *last_entry_it;
 
@@ -485,6 +488,7 @@ namespace cublog
 		if (LOG_SYSOP_ATOMIC_START == last_last_but_one_entry.m_rectype)
 		  {
 		    m_log_vec.erase (last_last_but_one_entry_it, m_log_vec.cend ());
+
 		    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		      {
 #if !defined (NDEBUG)
@@ -512,6 +516,7 @@ namespace cublog
 		    // close the entire sequence (eg: LOG_END_ATOMIC_REPL)
 		    m_log_vec.erase (last_entry_it);
 		  }
+
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
 #if !defined (NDEBUG)
@@ -525,6 +530,7 @@ namespace cublog
 		     && LOG_SYSOP_ATOMIC_START == last_but_one_entry.m_rectype)
 	      {
 		m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
+
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
 #if !defined (NDEBUG)
@@ -544,6 +550,7 @@ namespace cublog
 		(last_but_one_entry.m_record_lsa >= last_entry.m_sysop_end_last_parent_lsa))
 	      {
 		m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
+
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
 #if !defined (NDEBUG)
@@ -562,6 +569,7 @@ namespace cublog
 		(last_but_one_entry.m_record_lsa >= last_entry.m_sysop_end_last_parent_lsa))
 	      {
 		m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
+
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
 #if !defined (NDEBUG)
@@ -602,6 +610,7 @@ namespace cublog
 			dump ("sequence::can_purge - after failed LOG_END_ATOMIC_REPL");
 #endif
 		      }
+
 		    assert_release ("inconsistent atomic log sequence found" == nullptr);
 		    break;
 		  }
@@ -626,6 +635,7 @@ namespace cublog
 		    dump ("sequence::can_purge - too many log entries");
 #endif
 		  }
+
 		assert (false);
 	      }
 	    break;

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -152,6 +152,7 @@ namespace cublog
     return false;
   }
 
+#if (0)
   void
   atomic_replication_helper::complete_one_postpone_sequence (TRANID trid)
   {
@@ -163,7 +164,6 @@ namespace cublog
     sequence.complete_one_postpone_sequence ();
   }
 
-#if (0)
   bool
   atomic_replication_helper::is_at_least_one_postpone_sequence_completed (TRANID trid) const
   {
@@ -351,6 +351,7 @@ namespace cublog
     return m_postpone_started;
   }
 
+#if (0)
   void
   atomic_replication_helper::atomic_log_sequence::complete_one_postpone_sequence ()
   {
@@ -362,7 +363,6 @@ namespace cublog
     ++m_end_pospone_count;
   }
 
-#if (0)
   bool
   atomic_replication_helper::atomic_log_sequence::is_at_least_one_postpone_sequence_completed () const
   {

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -377,10 +377,10 @@ namespace cublog
   }
 #endif
 
+#if !defined (NDEBUG)
   void
   atomic_replication_helper::atomic_log_sequence::dump ()
   {
-#if !defined (NDEBUG)
     char buf[PATH_MAX];
     char *buf_ptr = buf;
     int written = 0;
@@ -407,8 +407,8 @@ namespace cublog
 	left -= written;
       }
     _er_log_debug (ARG_FILE_LINE, buf);
-#endif
   }
+#endif
 
   void
   atomic_replication_helper::atomic_log_sequence::apply_and_unfix_sequence (THREAD_ENTRY *thread_p)
@@ -423,7 +423,9 @@ namespace cublog
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_DEBUG))
       {
+#if !defined (NDEBUG)
 	dump ();
+#endif
       }
 
     for (const auto &log_entry : m_log_vec)

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -371,12 +371,13 @@ namespace cublog
     // they come to be read by the PTS and some might be unfixed and refixed after the apply procedure
     // leading to inconsistency. To avoid this situation we sequentially apply each log redo of the sequence
     // when the end sequence log appears and the entire sequence is fixed
-    for (size_t i = 0; i < m_log_vec.size (); i++)
+    for (const auto &log_entry : m_log_vec)
       {
-	m_log_vec[i].apply_log_redo (thread_p, m_redo_context);
+	log_entry.apply_log_redo (thread_p, m_redo_context);
 	// bookkeeping actually will either unfix the page or just decrease its reference count
-	m_page_ptr_bookkeeping.unfix_page (thread_p, m_log_vec[i].m_vpid);
+	m_page_ptr_bookkeeping.unfix_page (thread_p, log_entry.m_vpid);
       }
+    m_log_vec.clear ();
   }
 
   log_lsa
@@ -409,7 +410,7 @@ namespace cublog
 
   void
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::apply_log_redo (
-	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context)
+	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context) const
   {
     const int error_code = redo_context.m_reader.set_lsa_and_fetch_page (m_record_lsa, log_reader::fetch_mode::FORCE);
     if (error_code != NO_ERROR)

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -670,7 +670,7 @@ namespace cublog
   atomic_replication_helper::atomic_log_sequence::dump_to_buffer (char *&buf_ptr, int &buf_len) const
   {
     int written = 0;
-    written = snprintf (buf_ptr, (size_t)buf_len, "    %strid = %d  start_lsa = %lld|%d"
+    written = snprintf (buf_ptr, (size_t)buf_len, "    %strid = %d  start_lsa = %lld|%d\n"
 			, (m_log_vec.empty () ? "[EMPTY]  " : ""), m_trid, LSA_AS_ARGS (&m_start_lsa));
     assert (written > 0);
     buf_ptr += written;

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -192,6 +192,28 @@ namespace cublog
 #if !defined (NDEBUG)
 	m_vpid_sets_map.erase (trid);
 #endif
+
+	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
+	  {
+#if !defined (NDEBUG)
+	    const TRANID trid = sequence_it->first;
+	    _er_log_debug (ARG_FILE_LINE,
+			   "[ATOMIC_REPL] append_control_log purged trid = %d\n",
+			   trid);
+#endif
+	  }
+      }
+    else
+      {
+	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
+	  {
+#if !defined (NDEBUG)
+	    const TRANID trid = sequence_it->first;
+	    _er_log_debug (ARG_FILE_LINE,
+			   "[ATOMIC_REPL] append_control_log _not_ purged trid = %d\n",
+			   trid);
+#endif
+	  }
       }
   }
 
@@ -217,6 +239,28 @@ namespace cublog
 #if !defined (NDEBUG)
 	m_vpid_sets_map.erase (trid);
 #endif
+
+	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
+	  {
+#if !defined (NDEBUG)
+	    const TRANID trid = sequence_it->first;
+	    _er_log_debug (ARG_FILE_LINE,
+			   "[ATOMIC_REPL] append_control_log_sysop_end purged trid = %d\n",
+			   trid);
+#endif
+	  }
+      }
+    else
+      {
+	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
+	  {
+#if !defined (NDEBUG)
+	    const TRANID trid = sequence_it->first;
+	    _er_log_debug (ARG_FILE_LINE,
+			   "[ATOMIC_REPL] append_control_log_sysop_end _not_ purged trid = %d\n",
+			   trid);
+#endif
+	  }
       }
   }
 
@@ -252,7 +296,8 @@ namespace cublog
     int buf_len = BUF_LEN_MAX;
 
     const int written = snprintf (buf_ptr, (size_t)buf_len,
-				  "[ATOMIC_REPL] %s\n",
+				  "[ATOMIC_REPL] %s%s\n",
+				  (m_sequences_map.empty () ? "[EMPTY]  " : ""),
 				  ((message != nullptr) ? message : ""));
     assert (written > 0);
     buf_ptr += written;

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -33,7 +33,7 @@ namespace cublog
 
   int
   atomic_replication_helper::append_log (THREAD_ENTRY *thread_p, TRANID tranid,
-					 LOG_LSA record_lsa, LOG_RCVINDEX rcvindex, VPID vpid)
+					 LOG_LSA lsa, LOG_RCVINDEX rcvindex, VPID vpid)
   {
 #ifdef ATOMIC_REPL_PAGE_BELONGS_TO_SINGLE_ATOMIC_SEQUENCE_CHECK
     if (!VPID_ISNULL (&vpid) && !check_for_page_validity (vpid, tranid))
@@ -52,7 +52,7 @@ namespace cublog
       }
 
     atomic_log_sequence &sequence = sequence_it->second;
-    int error_code = sequence.append_log (thread_p, record_lsa, rcvindex, vpid);
+    int error_code = sequence.append_log (thread_p, lsa, rcvindex, vpid);
     if (error_code != NO_ERROR)
       {
 	return error_code;
@@ -76,7 +76,6 @@ namespace cublog
       {
 	if (sequence_it != m_sequences_map.cend ())
 	  {
-	    const atomic_log_sequence &atomic_sequence = sequence_it->second;
 	    dump ("helper::start_sequence_internal");
 	  }
       }
@@ -166,7 +165,7 @@ namespace cublog
       LOG_RECTYPE rectype, LOG_LSA lsa, const log_rv_redo_context &redo_context)
   {
     auto sequence_it = m_sequences_map.find (trid);
-    if (sequence_it == m_sequences_map.end ())
+    if (sequence_it == m_sequences_map.cend ())
       {
 	start_sequence_internal (trid, lsa, redo_context);
 	sequence_it = m_sequences_map.find (trid);
@@ -212,7 +211,7 @@ namespace cublog
       TRANID trid, LOG_LSA lsa, LOG_SYSOP_END_TYPE sysop_end_type, LOG_LSA sysop_end_last_parent_lsa)
   {
     auto sequence_it = m_sequences_map.find (trid);
-    if (sequence_it == m_sequences_map.end ())
+    if (sequence_it == m_sequences_map.cend ())
       {
 	// this sysop does not end an atomic sequence
 	return;
@@ -253,13 +252,11 @@ namespace cublog
   void atomic_replication_helper::forcibly_remove_sequence (TRANID trid)
   {
     auto sequence_it = m_sequences_map.find (trid);
-    if (sequence_it == m_sequences_map.end ())
+    if (sequence_it == m_sequences_map.cend ())
       {
 	assert (false);
 	return;
       }
-
-    atomic_log_sequence &sequence = sequence_it->second;
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
@@ -321,7 +318,7 @@ namespace cublog
 
   int
   atomic_replication_helper::atomic_log_sequence::append_log (THREAD_ENTRY *thread_p,
-      LOG_LSA record_lsa, LOG_RCVINDEX rcvindex, VPID vpid)
+      LOG_LSA lsa, LOG_RCVINDEX rcvindex, VPID vpid)
   {
     PAGE_PTR page_p = nullptr;
     // bookkeeping fixes page, keeps all info regarding how the page was fixed (either
@@ -333,7 +330,7 @@ namespace cublog
 	// functioning of the atomic replication sequence;
 	er_log_debug (ARG_FILE_LINE, "[ATOMIC_REPL] heap page cannot be fixed, cannot add new log record"
 		      "with LSA %lld|%d to atomic sequences started at LSA %lld|%d\n",
-		      LSA_AS_ARGS (&record_lsa), LSA_AS_ARGS (&m_start_lsa));
+		      LSA_AS_ARGS (&lsa), LSA_AS_ARGS (&m_start_lsa));
 
 	// TODO:
 	//  - what happens if there is more than one log record pertaining to the same page
@@ -348,7 +345,7 @@ namespace cublog
     else
       {
 	assert (page_p != nullptr);
-	m_log_vec.emplace_back (record_lsa, vpid, rcvindex, page_p);
+	m_log_vec.emplace_back (lsa, vpid, rcvindex, page_p);
       }
 
     return err_code;
@@ -372,20 +369,21 @@ namespace cublog
     if (m_log_vec.size () == 1)
       {
 	assert (m_log_vec[0].is_control ());
-	return;
-      }
-
-    atomic_log_entry_vector_type::const_reverse_iterator rbegin_work_log_it = m_log_vec.rbegin ();
-    const atomic_log_entry &rbegin_work_log = *rbegin_work_log_it;
-    if (rbegin_work_log.is_control ())
-      {
 	assert (all_log_entries_are_control ());
 	return;
       }
 
     // search backwards for the first non-control log record entry
-    atomic_log_entry_vector_type::const_iterator first_work_log_it = m_log_vec.end ();
+    atomic_log_entry_vector_type::const_iterator first_work_log_it = m_log_vec.cend ();
     --first_work_log_it; // last in vector, must be work
+    if (first_work_log_it->is_control ())
+      {
+	// there must be no work entries in the sequence
+	// this can happen in a number of cases (eg, two LOG_SYSOP_END following each other, the
+	// first one closing an inner sysop, the second one closing an outer sysop)
+	assert (all_log_entries_are_control ());
+	return;
+      }
     assert (!first_work_log_it->is_control ());
     while (!first_work_log_it->is_control ()) // skip all work entries
       {
@@ -402,7 +400,8 @@ namespace cublog
       return entry.is_control ();
     }));
 
-    for (auto apply_it = first_work_log_it; apply_it != m_log_vec.end (); ++apply_it)
+    for (atomic_log_entry_vector_type::const_iterator apply_it = first_work_log_it
+	 ; apply_it != m_log_vec.cend (); ++apply_it)
       {
 	const atomic_log_entry &log_entry = *apply_it;
 	assert (!log_entry.is_control ());
@@ -410,7 +409,7 @@ namespace cublog
 	m_page_ptr_bookkeeping.unfix_page (thread_p, log_entry.m_vpid);
       }
 
-    m_log_vec.erase (first_work_log_it, m_log_vec.end ());
+    m_log_vec.erase (first_work_log_it, m_log_vec.cend ());
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
@@ -466,14 +465,15 @@ namespace cublog
     assert (all_log_entries_are_control ());
 
     // - after the actual payload log records in a sequences have been applied
-    //  this function tries to remove - in a consistent and controlled manner(*) -
+    //  this function removes - in a consistent and controlled manner(*) -
     //  the remaining "control" log recods;
     // - the logic here is akin to "dynamic programming" as with each new processed
     //  log record, the state is re-evaluated; similarly, with each applied sequence
     //  of consecutive payload log records, the remaining log records are re-evaluated
-    //  in this function and, if possible, removed (most of the times in pairs - start -end)
+    //  and, if possible, removed (most of the times in pairs - start -end)
     // - another benefit is that it allows for "nested" atomic replication sequences with
-    //  [almost] arbitrary structure to be processed in a controlled way:
+    //  [almost] arbitrary structure to be processed in a controlled way (that's the
+    //  reasong for the encompassing 'while' loop):
     //
     // Example:
     //
@@ -545,14 +545,15 @@ namespace cublog
 	const atomic_log_entry_vector_type::const_iterator last_entry_it = m_log_vec.cend () - 1;
 	const atomic_log_entry &last_entry = *last_entry_it;
 
-	// atomic replication sequence with an already executed postpone sequence that (maybe) contained
-	// - itself - other atomic replication sequences)
 	if (LOG_SYSOP_END == last_entry.m_rectype
 	    && LOG_SYSOP_END_COMMIT == last_entry.m_sysop_end_type)
 	  {
 	    const atomic_log_entry_vector_type::const_iterator last_but_one_entry_it = (last_entry_it - 1);
 	    const atomic_log_entry &last_but_one_entry = *last_but_one_entry_it;
 
+	    // scenario (3)
+	    // atomic replication sequence with an already executed postpone sequence that (maybe) contained
+	    // - itself - other atomic replication sequences)
 	    if (initial_log_vec_size == 3 && LOG_SYSOP_START_POSTPONE == last_but_one_entry.m_rectype)
 	      {
 		const atomic_log_entry_vector_type::const_iterator last_last_but_one_entry_it
@@ -570,12 +571,13 @@ namespace cublog
 		    assert (m_log_vec.empty ());
 		  }
 	      }
+	    // scenario (2)
 	    // if the atomic replication sequence start lsa is higher or equal to the sysop
 	    // end parent lsa, then the atomic sequence can be ended (commited & released)
 	    else if (!LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa)
-		     && (last_but_one_entry.m_record_lsa >= last_entry.m_sysop_end_last_parent_lsa))
+		     && (last_but_one_entry.m_lsa >= last_entry.m_sysop_end_last_parent_lsa))
 	      {
-		if (last_but_one_entry.m_rectype == LOG_SYSOP_ATOMIC_START)
+		if (LOG_SYSOP_ATOMIC_START == last_but_one_entry.m_rectype)
 		  {
 		    // sysop end matches sysop atomic start; delete both start and end control log entries
 		    m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
@@ -607,6 +609,7 @@ namespace cublog
 		  }
 	      }
 	  }
+	// part of scenario (3)
 	// atomic replication sequence within a postpone sequence
 	else if (LOG_SYSOP_END == last_entry.m_rectype
 		 && LOG_SYSOP_END_LOGICAL_RUN_POSTPONE == last_entry.m_sysop_end_type)
@@ -615,7 +618,7 @@ namespace cublog
 	    const atomic_log_entry &last_but_one_entry = *last_but_one_entry_it;
 
 	    if (!LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) &&
-		(last_but_one_entry.m_record_lsa >= last_entry.m_sysop_end_last_parent_lsa))
+		(last_but_one_entry.m_lsa >= last_entry.m_sysop_end_last_parent_lsa))
 	      {
 		m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
 
@@ -625,6 +628,7 @@ namespace cublog
 		  }
 	      }
 	  }
+	// part of scenario (4)
 	else if (LOG_SYSOP_END == last_entry.m_rectype
 		 && LOG_SYSOP_END_LOGICAL_UNDO == last_entry.m_sysop_end_type)
 	  {
@@ -632,7 +636,7 @@ namespace cublog
 	    const atomic_log_entry &last_but_one_entry = *last_but_one_entry_it;
 
 	    if (!LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) &&
-		(last_but_one_entry.m_record_lsa >= last_entry.m_sysop_end_last_parent_lsa))
+		(last_but_one_entry.m_lsa >= last_entry.m_sysop_end_last_parent_lsa))
 	      {
 		m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
 
@@ -642,10 +646,11 @@ namespace cublog
 		  }
 	      }
 	  }
+	// scenario (1)
 	else if (LOG_END_ATOMIC_REPL == last_entry.m_rectype)
 	  {
-	    // search backwards, until a start atomic replication log record is met; other 'sysop
-	    // ends' are allowed and skipped;
+	    // search backwards, until a start atomic replication log record is met; other LOG_SYSOP_END
+	    // encountered are allowed and skipped;
 	    // these are the sysops without a matching sysop atomic start - it is the consequence of the
 	    // known fact (optimization?): when adding consecutive 'sysop atomic start' log records only
 	    // one such log record is added
@@ -659,7 +664,7 @@ namespace cublog
 					     && (search_entry.m_rectype == LOG_SYSOP_END
 						 || search_entry.m_rectype == LOG_START_ATOMIC_REPL);
 
-		if (search_entry.m_rectype == LOG_START_ATOMIC_REPL && only_valid_control_entries)
+		if (LOG_START_ATOMIC_REPL == search_entry.m_rectype && only_valid_control_entries)
 		  {
 		    // remove all entries between start atomic replication and the end
 		    m_log_vec.erase (search_entry_it, m_log_vec.cend ());
@@ -748,15 +753,15 @@ namespace cublog
 	  LOG_LSA lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr)
     : m_vpid { vpid }
     , m_rectype { LOG_LARGER_LOGREC_TYPE }
-    , m_record_lsa { lsa }
-    , m_record_index { rcvindex }
+    , m_lsa { lsa }
+    , m_rcvindex { rcvindex }
     , m_sysop_end_type { (LOG_SYSOP_END_TYPE)-1 }
     , m_sysop_end_last_parent_lsa { NULL_LSA }
     , m_page_ptr { page_ptr }
   {
     assert (!VPID_ISNULL (&m_vpid));
-    assert (m_record_lsa != NULL_LSA);
-    assert (0 <= m_record_index &&m_record_index <= RV_LAST_LOGID);
+    assert (m_lsa != NULL_LSA);
+    assert (0 <= m_rcvindex && m_rcvindex <= RV_LAST_LOGID);
     assert (m_page_ptr != nullptr);
   }
 
@@ -764,13 +769,13 @@ namespace cublog
 	  LOG_LSA lsa, LOG_RECTYPE rectype)
     : m_vpid VPID_INITIALIZER
     , m_rectype { rectype }
-    , m_record_lsa { lsa }
-    , m_record_index { RV_NOT_DEFINED }
+    , m_lsa { lsa }
+    , m_rcvindex { RV_NOT_DEFINED }
     , m_sysop_end_type { (LOG_SYSOP_END_TYPE)-1 }
     , m_sysop_end_last_parent_lsa { NULL_LSA }
     , m_page_ptr { nullptr }
   {
-    assert (m_record_lsa != NULL_LSA);
+    assert (m_lsa != NULL_LSA);
     assert (m_rectype != LOG_LARGER_LOGREC_TYPE );
     // there is a specific ctor for sysop end
     assert (m_rectype != LOG_SYSOP_END );
@@ -780,26 +785,26 @@ namespace cublog
 	  LOG_LSA lsa, LOG_SYSOP_END_TYPE sysop_end_type, LOG_LSA sysop_end_last_parent_lsa)
     : m_vpid VPID_INITIALIZER
     , m_rectype { LOG_SYSOP_END }
-    , m_record_lsa { lsa }
-    , m_record_index { RV_NOT_DEFINED }
+    , m_lsa { lsa }
+    , m_rcvindex { RV_NOT_DEFINED }
     , m_sysop_end_type { sysop_end_type }
     , m_sysop_end_last_parent_lsa { sysop_end_last_parent_lsa }
     , m_page_ptr { nullptr }
   {
-    assert (m_record_lsa != NULL_LSA);
-    assert (LOG_SYSOP_END_COMMIT <= sysop_end_type &&sysop_end_type <= LOG_SYSOP_END_LOGICAL_RUN_POSTPONE);
+    assert (m_lsa != NULL_LSA);
+    assert (LOG_SYSOP_END_COMMIT <= sysop_end_type && sysop_end_type <= LOG_SYSOP_END_LOGICAL_RUN_POSTPONE);
     // sysop end parent lsa can also be null
   }
 
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::atomic_log_entry (atomic_log_entry &&that)
-    : m_vpid { that.m_vpid }
-    , m_rectype { that.m_rectype }
-    , m_record_lsa { that.m_record_lsa }
-    , m_record_index { that.m_record_index }
-    , m_sysop_end_type { that.m_sysop_end_type }
-    , m_sysop_end_last_parent_lsa { that.m_sysop_end_last_parent_lsa }
-    , m_page_ptr { that.m_page_ptr }
   {
+    std::swap (m_vpid, that.m_vpid);
+    std::swap (m_rectype, that.m_rectype);
+    std::swap (m_lsa, that.m_lsa);
+    std::swap (m_rcvindex, that.m_rcvindex);
+    std::swap (m_sysop_end_type, that.m_sysop_end_type);
+    std::swap (m_sysop_end_last_parent_lsa, that.m_sysop_end_last_parent_lsa);
+    std::swap (m_page_ptr, that.m_page_ptr);
   }
 
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry &
@@ -807,8 +812,8 @@ namespace cublog
   {
     std::swap (m_vpid, that.m_vpid);
     std::swap (m_rectype, that.m_rectype);
-    std::swap (m_record_lsa, that.m_record_lsa);
-    std::swap (m_record_index, that.m_record_index);
+    std::swap (m_lsa, that.m_lsa);
+    std::swap (m_rcvindex, that.m_rcvindex);
     std::swap (m_sysop_end_type, that.m_sysop_end_type);
     std::swap (m_sysop_end_last_parent_lsa, that.m_sysop_end_last_parent_lsa);
     std::swap (m_page_ptr, that.m_page_ptr);
@@ -819,13 +824,13 @@ namespace cublog
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::apply_log_redo (
 	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context) const
   {
-    const int error_code = redo_context.m_reader.set_lsa_and_fetch_page (m_record_lsa, log_reader::fetch_mode::FORCE);
+    const int error_code = redo_context.m_reader.set_lsa_and_fetch_page (m_lsa, log_reader::fetch_mode::FORCE);
     if (error_code != NO_ERROR)
       {
 	logpb_fatal_error (thread_p, true, ARG_FILE_LINE,
 			   "atomic_log_entry::apply_log_redo: error reading log page with"
 			   " VPID: %d|%d, LSA: %lld|%d and index %d",
-			   VPID_AS_ARGS (&m_vpid), LSA_AS_ARGS (&m_record_lsa), m_record_index);
+			   VPID_AS_ARGS (&m_vpid), LSA_AS_ARGS (&m_lsa), m_rcvindex);
       }
     const log_rec_header header = redo_context.m_reader.reinterpret_copy_and_add_align<log_rec_header> ();
 
@@ -857,16 +862,6 @@ namespace cublog
       }
   }
 
-  bool
-  atomic_replication_helper::atomic_log_sequence::atomic_log_entry::is_control () const
-  {
-    return (m_rectype == LOG_START_ATOMIC_REPL ||
-	    m_rectype == LOG_END_ATOMIC_REPL ||
-	    m_rectype == LOG_SYSOP_ATOMIC_START ||
-	    m_rectype == LOG_SYSOP_END ||
-	    m_rectype == LOG_SYSOP_START_POSTPONE);
-  }
-
   void
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::dump_to_buffer (
 	  char *&buf_ptr, int &buf_len) const
@@ -874,21 +869,21 @@ namespace cublog
     int written = 0;
     if (is_control ())
       {
+	const char *const sysop_end_type_str
+	  = (LOG_SYSOP_END_COMMIT <= m_sysop_end_type && m_sysop_end_type <= LOG_SYSOP_END_LOGICAL_RUN_POSTPONE)
+	    ? log_sysop_end_type_string (m_sysop_end_type) : "N_A";
 	written = snprintf (buf_ptr, (size_t)buf_len,
 			    "  _C_ LSA = %lld|%d  rectype = %s"
 			    "  sysop_end_type = %s  sysop_end_last_parent_lsa = %lld|%d\n",
-			    LSA_AS_ARGS (&m_record_lsa), log_to_string (m_rectype),
-			    ((LOG_SYSOP_END_COMMIT <= m_sysop_end_type
-			      && m_sysop_end_type <= LOG_SYSOP_END_LOGICAL_RUN_POSTPONE) ?
-			     log_sysop_end_type_string (m_sysop_end_type) : "NULL"),
-			    LSA_AS_ARGS (&m_sysop_end_last_parent_lsa));
+			    LSA_AS_ARGS (&m_lsa), log_to_string (m_rectype),
+			    sysop_end_type_str, LSA_AS_ARGS (&m_sysop_end_last_parent_lsa));
       }
     else
       {
 	assert (m_rectype == LOG_LARGER_LOGREC_TYPE);
 	written = snprintf (buf_ptr, (size_t)buf_len, "  _W_ LSA = %lld|%d  vpid = %d|%d  rcvindex = %s\n",
-			    LSA_AS_ARGS (&m_record_lsa), VPID_AS_ARGS (&m_vpid),
-			    rv_rcvindex_string (m_record_index));
+			    LSA_AS_ARGS (&m_lsa), VPID_AS_ARGS (&m_vpid),
+			    rv_rcvindex_string (m_rcvindex));
       }
     assert (written > 0);
     buf_ptr += written;
@@ -917,7 +912,7 @@ namespace cublog
 
   int
   atomic_replication_helper::atomic_log_sequence::page_ptr_bookkeeping::fix_page (
-	  THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index, PAGE_PTR &page_ptr_out)
+	  THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR &page_ptr_out)
   {
     assert (page_ptr_out == nullptr);
 
@@ -937,7 +932,7 @@ namespace cublog
       {
 	page_ptr_watcher_uptr_type page_watcher_up;
 	PAGE_PTR page_p { nullptr };
-	const int err_code = pgbuf_fix_or_ordered_fix (thread_p, vpid, rcv_index, page_watcher_up, page_p);
+	const int err_code = pgbuf_fix_or_ordered_fix (thread_p, vpid, rcvindex, page_watcher_up, page_p);
 	if (err_code != NO_ERROR)
 	  {
 	    return err_code;
@@ -949,7 +944,7 @@ namespace cublog
 
 	info_p = &insert_res.first->second;
 	info_p->m_vpid = vpid;
-	info_p->m_rcv_index = rcv_index;
+	info_p->m_rcvindex = rcvindex;
 	info_p->m_page_p = page_p;
 	page_p = nullptr;
 	info_p->m_watcher_p.swap (page_watcher_up);
@@ -983,7 +978,7 @@ namespace cublog
 	--info.m_ref_count;
 	if (info.m_ref_count == 0)
 	  {
-	    pgbuf_unfix_or_ordered_unfix (thread_p, info.m_rcv_index, info.m_watcher_p, info.m_page_p);
+	    pgbuf_unfix_or_ordered_unfix (thread_p, info.m_rcvindex, info.m_watcher_p, info.m_page_p);
 	    info.m_page_p = nullptr;
 	    if (info.m_watcher_p != nullptr)
 	      {
@@ -1023,9 +1018,9 @@ namespace cublog
     for (const auto &pair : m_page_ptr_info_map)
       {
 	const page_ptr_info &info = pair.second;
-	written = snprintf (buf_ptr, (size_t)left, "  m_vpid = %d|%d  rcv_index = %s"
+	written = snprintf (buf_ptr, (size_t)left, "  m_vpid = %d|%d  rcvindex = %s"
 			    "  page_p = %p  watcher_p = %p  ref_cnt = %d\n",
-			    VPID_AS_ARGS (&info.m_vpid), rv_rcvindex_string (info.m_rcv_index),
+			    VPID_AS_ARGS (&info.m_vpid), rv_rcvindex_string (info.m_rcvindex),
 			    (void *)info.m_page_p, (void *)info.m_watcher_p.get (), info.m_ref_count);
 	assert (written > 0);
 	buf_ptr += written;
@@ -1037,14 +1032,14 @@ namespace cublog
 #endif
 
   /*********************************************************************************************************
-   * standalone functions
+   * standalone functions implementations
    *********************************************************************************************************/
 
   int
-  pgbuf_fix_or_ordered_fix (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index,
+  pgbuf_fix_or_ordered_fix (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcvindex,
 			    std::unique_ptr<PGBUF_WATCHER> &watcher_uptr, PAGE_PTR &page_ptr)
   {
-    switch (rcv_index)
+    switch (rcvindex)
       {
       case RVHF_INSERT:
       case RVHF_DELETE:
@@ -1093,10 +1088,10 @@ namespace cublog
   }
 
   void
-  pgbuf_unfix_or_ordered_unfix (THREAD_ENTRY *thread_p, LOG_RCVINDEX rcv_index,
+  pgbuf_unfix_or_ordered_unfix (THREAD_ENTRY *thread_p, LOG_RCVINDEX rcvindex,
 				std::unique_ptr<PGBUF_WATCHER> &watcher_uptr, PAGE_PTR &page_ptr)
   {
-    switch (rcv_index)
+    switch (rcvindex)
       {
       case RVHF_INSERT:
       case RVHF_DELETE:

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -323,7 +323,7 @@ namespace cublog
 				 , is_sysop
 #endif
 				 );
-	sequence_it = m_sequences_map.begin ();
+	sequence_it = m_sequences_map.find (trid);
       }
 
     // TODO: idea, first add control log and then apply and unfix, such that apply and unfix will be able to make

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -250,7 +250,7 @@ namespace cublog
       }
   }
 
-  void atomic_replication_helper::forcibly_remove_idle_sequence (TRANID trid)
+  void atomic_replication_helper::forcibly_remove_sequence (TRANID trid)
   {
     auto sequence_it = m_sequences_map.find (trid);
     if (sequence_it == m_sequences_map.end ())
@@ -263,7 +263,7 @@ namespace cublog
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
-	dump ("helper::forcibly_remove_idle_sequence");
+	dump ("helper::forcibly_remove_sequence");
       }
 
     // sequence dtor will ensure proper idle state upon destruction

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -568,15 +568,16 @@ namespace cublog
     switch (rcv_index)
       {
       case RVHF_INSERT:
-      case RVHF_MVCC_INSERT:
       case RVHF_DELETE:
+      case RVHF_UPDATE:
+      case RVHF_MVCC_INSERT:
       case RVHF_MVCC_DELETE_REC_HOME:
       case RVHF_MVCC_DELETE_OVERFLOW:
       case RVHF_MVCC_DELETE_REC_NEWHOME:
       case RVHF_MVCC_DELETE_MODIFY_HOME:
-      case RVHF_UPDATE:
-      case RVHF_MVCC_UPDATE_OVERFLOW:
+      case RVHF_UPDATE_NOTIFY_VACUUM:
       case RVHF_INSERT_NEWHOME:
+      case RVHF_MVCC_UPDATE_OVERFLOW:
       {
 	assert (watcher_uptr == nullptr);
 
@@ -619,15 +620,16 @@ namespace cublog
     switch (rcv_index)
       {
       case RVHF_INSERT:
-      case RVHF_MVCC_INSERT:
       case RVHF_DELETE:
+      case RVHF_UPDATE:
+      case RVHF_MVCC_INSERT:
       case RVHF_MVCC_DELETE_REC_HOME:
       case RVHF_MVCC_DELETE_OVERFLOW:
       case RVHF_MVCC_DELETE_REC_NEWHOME:
       case RVHF_MVCC_DELETE_MODIFY_HOME:
-      case RVHF_UPDATE:
-      case RVHF_MVCC_UPDATE_OVERFLOW:
+      case RVHF_UPDATE_NOTIFY_VACUUM:
       case RVHF_INSERT_NEWHOME:
+      case RVHF_MVCC_UPDATE_OVERFLOW:
 	assert (page_ptr == nullptr);
 	// other sanity asserts inside the function
 	pgbuf_ordered_unfix (thread_p, watcher_uptr.get ());

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -54,10 +54,12 @@ namespace cublog
     const auto sequence_it = m_sequences_map.find (tranid);
     if (sequence_it == m_sequences_map.cend ())
       {
+	assert (false);
 	return ER_FAILED;
       }
 
-    int error_code = sequence_it->second.add_atomic_replication_log (thread_p, record_lsa, rcvindex, vpid);
+    atomic_log_sequence &sequence = sequence_it->second;
+    int error_code = sequence.add_atomic_replication_log (thread_p, record_lsa, rcvindex, vpid);
     if (error_code != NO_ERROR)
       {
 	return error_code;
@@ -106,7 +108,6 @@ namespace cublog
 
     return false;
   }
-
 
   void
   atomic_replication_helper::start_sequence_internal (TRANID trid, LOG_LSA start_lsa,
@@ -395,13 +396,15 @@ namespace cublog
     , m_record_index { rcvindex }
     , m_page_ptr { page_ptr }
   {
-    assert (lsa != NULL_LSA);
+    assert (!VPID_ISNULL (&m_vpid));
+    assert (m_record_lsa != NULL_LSA);
+    assert (0 <= m_record_index && m_record_index <= RV_LAST_LOGID);
+    assert (m_page_ptr != nullptr);
   }
 
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::atomic_log_entry (atomic_log_entry &&that)
     : atomic_log_entry (that.m_record_lsa, that.m_vpid, that.m_record_index, that.m_page_ptr)
   {
-    that.m_page_ptr = nullptr;
   }
 
   void

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -30,6 +30,29 @@ namespace cublog
    * atomic_replication_helper function definitions                    *
    *********************************************************************/
 
+#if (0)
+  void
+  atomic_replication_helper::start_sequence_or_append_to_existing (THREAD_ENTRY *thread_p,
+      TRANID trid, LOG_LSA lsa, const log_rv_redo_context &redo_context,
+      LOG_RECTYPE rec_type, LOG_RCVINDEX rcvindex, VPID vpid)
+  {
+    const auto sequence_it = m_sequences_map.find (trid);
+    if (sequence_it != m_sequences_map.cend ())
+      {
+	// extend existing
+	// regardless of the log record type, "nested" atomic replication sequences are allowed
+	// and handled in the sequence itself
+	atomic_log_sequence &sequence = sequence_it->second;
+	sequence.handle_replication_log (thread_p, lsa, rec_type, rcvindex, vpid);
+      }
+    else
+      {
+	assert (rec_type == LOG_START_ATOMIC_REPL || rec_type == LOG_SYSOP_ATOMIC_START);
+	start_sequence_internal (trid, lsa, redo_context, rec_type);
+      }
+  }
+#endif
+
   void
   atomic_replication_helper::add_atomic_replication_sequence (TRANID trid, LOG_LSA start_lsa,
       const log_rv_redo_context &redo_context)
@@ -124,6 +147,21 @@ namespace cublog
     emplaced_seq.initialize (start_lsa, is_sysop);
   }
 
+#if (0)
+  void
+  atomic_replication_helper::start_sequence_internal (TRANID trid, LOG_LSA start_lsa,
+      const log_rv_redo_context &redo_context, LOG_RECTYPE rec_type)
+  {
+    assert (m_sequences_map.find (trid) == m_sequences_map.cend ());
+
+    const std::pair<sequence_map_type::iterator, bool> emplace_res = m_sequences_map.emplace (trid, redo_context);
+    assert (emplace_res.second);
+
+    atomic_log_sequence &new_seq = emplace_res.first->second;
+    new_seq.initialize (start_lsa, rec_type);
+  }
+#endif
+
   void
   atomic_replication_helper::start_postpone_sequence (TRANID trid)
   {
@@ -134,6 +172,19 @@ namespace cublog
     atomic_log_sequence &sequence = sequence_it->second;
     sequence.start_postpone_sequence ();
   }
+
+//  void
+//  atomic_replication_helper::apply_all_before_start_postpone (THREAD_ENTRY *thread_p, TRANID trid)
+//  {
+//    const auto sequence_it = m_sequences_map.find (trid);
+//    // call should have been checked/guarded upfront
+//    assert (sequence_it != m_sequences_map.cend ());
+
+//    atomic_log_sequence &sequence = sequence_it->second;
+//    // apply and remove all log records before the current one - which is a start postpone - and
+//    // remove information about all those log records, but do not delete the sequence yet
+//    sequence.apply_all_before_start_postpone (thread_p);
+//  }
 
   bool
   atomic_replication_helper::is_postpone_sequence_started (TRANID trid) const
@@ -265,6 +316,20 @@ namespace cublog
     m_is_sysop = is_sysop;
   }
 
+#if (0)
+  void
+  atomic_replication_helper::atomic_log_sequence::initialize (LOG_LSA start_lsa, LOG_RECTYPE rec_type)
+  {
+    assert (m_log_vec.empty ());
+    assert (!LSA_ISNULL (&start_lsa));
+    assert (LOG_SMALLER_LOGREC_TYPE < rec_type && rec_type < LOG_LARGER_LOGREC_TYPE);
+
+    // we do not store the start lsa as part of the sequence
+    // rather, add a log entry that will store this information
+    m_log_vec.emplace_back (start_lsa, rec_type);
+  }
+#endif
+
   int
   atomic_replication_helper::atomic_log_sequence::add_atomic_replication_log (THREAD_ENTRY *thread_p,
       log_lsa record_lsa, LOG_RCVINDEX rcvindex, VPID vpid)
@@ -300,6 +365,39 @@ namespace cublog
     return err_code;
   }
 
+#if (0)
+  int
+  atomic_replication_helper::atomic_log_sequence::handle_replication_log (THREAD_ENTRY *thread_p,
+      log_lsa record_lsa, LOG_RECTYPE rec_type, LOG_RCVINDEX rcvindex, VPID vpid)
+  {
+    if (rec_type == LOG_SYSOP_START_POSTPONE)
+      {
+	if (rcvindex == LOG_SYSOP_END_COMMIT)
+	  {
+	    // execute all logs in the atomic sequence up to this point and remove them
+	    // except those that are used as "control" (eg. the first entry with introduced the atomic sequence)
+
+	    // the starting log record and at least one payload log record
+	    assert (m_log_vec.size () > 1);
+
+	    const size_t last_payload_index = m_log_vec.size () - 1;
+	    size_t first_payload_index = last_payload_index;
+	    while (m_log_vec[first_payload_index].is_payload_record () && first_payload_index > 0)
+	      {
+		--first_payload_index;
+	      }
+	    assert (first_payload_index > 0);
+	    assert (first_payload_index < last_payload_index);
+	  }
+      }
+    else if (false)
+      {
+
+      }
+    return -1;
+  }
+#endif
+
   bool
   atomic_replication_helper::atomic_log_sequence::can_end_sysop_sequence (const LOG_LSA &sysop_parent_lsa) const
   {
@@ -333,6 +431,20 @@ namespace cublog
 
     m_postpone_started = true;
   }
+
+//  void
+//  atomic_replication_helper::atomic_log_sequence::apply_all_before_start_postpone (THREAD_ENTRY *thread_p)
+//  {
+//    assert (m_is_sysop);
+//    assert (!m_postpone_started);
+//    assert (m_log_vec.size () > 0);
+
+//    m_postpone_started = true;
+
+//    apply_and_unfix_sequence (thread_p);
+
+//    assert (m_log_vec.empty ());
+//  }
 
   bool
   atomic_replication_helper::atomic_log_sequence::is_postpone_sequence_started () const
@@ -380,6 +492,21 @@ namespace cublog
     m_log_vec.clear ();
   }
 
+#if (0)
+  void
+  atomic_replication_helper::atomic_log_sequence::apply_and_unfix (THREAD_ENTRY *thread_p,
+      size_t first_index, size_t last_index)
+  {
+    for (size_t i = first_index; i <= last_index; ++i)
+      {
+	m_log_vec[i].apply_log_redo (thread_p, m_redo_context);
+	m_page_ptr_bookkeeping.unfix_page (thread_p, m_log_vec[i].m_vpid);
+      }
+
+    m_log_vec.erase (m_log_vec.begin () + first_index, m_log_vec.begin () + last_index + 1);
+  }
+#endif
+
   log_lsa
   atomic_replication_helper::atomic_log_sequence::get_start_lsa () const
   {
@@ -394,6 +521,9 @@ namespace cublog
 	  log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr)
     : m_vpid { vpid }
     , m_record_lsa { lsa }
+#if (0)
+    , m_rec_type { GUARD_REC_TYPE }
+#endif
     , m_record_index { rcvindex }
     , m_page_ptr { page_ptr }
   {
@@ -402,6 +532,20 @@ namespace cublog
     assert (0 <= m_record_index && m_record_index <= RV_LAST_LOGID);
     assert (m_page_ptr != nullptr);
   }
+
+#if (0)
+  atomic_replication_helper::atomic_log_sequence::atomic_log_entry::atomic_log_entry (
+	  log_lsa lsa, LOG_RECTYPE rec_type)
+    : m_vpid VPID_INITIALIZER
+    , m_record_lsa { lsa }
+    , m_rec_type { rec_type }
+    , m_record_index { GUARD_RCVINDEX }
+    , m_page_ptr { nullptr }
+  {
+    assert (m_record_lsa != NULL_LSA);
+    assert (LOG_SMALLER_LOGREC_TYPE < m_rec_type && m_rec_type < LOG_LARGER_LOGREC_TYPE);
+  }
+#endif
 
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::atomic_log_entry (atomic_log_entry &&that)
     : atomic_log_entry (that.m_record_lsa, that.m_vpid, that.m_record_index, that.m_page_ptr)
@@ -449,6 +593,16 @@ namespace cublog
 	break;
       }
   }
+
+#if (0)
+  bool
+  atomic_replication_helper::atomic_log_sequence::atomic_log_entry::is_payload_record () const
+  {
+    return (m_rec_type != LOG_SYSOP_ATOMIC_START && m_rec_type != LOG_SYSOP_END
+	    && m_rec_type != LOG_SYSOP_START_POSTPONE
+	    && m_rec_type != LOG_START_ATOMIC_REPL && m_rec_type != LOG_END_ATOMIC_REPL);
+  }
+#endif
 
   /*********************************************************************************************************
    * atomic_replication_helper::atomic_log_sequence::page_ptr_info function definitions  *

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -101,7 +101,9 @@ namespace cublog
 	// safeguard, if the atomic sequence contains a postpone [sub]sequence, that
 	// is more specific case and should have been checked upfront
 	assert (!atomic_sequence.is_postpone_sequence_started ());
+#if (0)
 	assert (!atomic_sequence.is_at_least_one_postpone_sequence_completed ());
+#endif
 
 	return atomic_sequence.can_end_sysop_sequence ();
       }
@@ -124,6 +126,7 @@ namespace cublog
     emplaced_seq.initialize (start_lsa, is_sysop);
   }
 
+#if (0)
   void
   atomic_replication_helper::start_postpone_sequence (TRANID trid)
   {
@@ -134,6 +137,7 @@ namespace cublog
     atomic_log_sequence &sequence = sequence_it->second;
     sequence.start_postpone_sequence ();
   }
+#endif
 
   bool
   atomic_replication_helper::is_postpone_sequence_started (TRANID trid) const
@@ -159,6 +163,7 @@ namespace cublog
     sequence.complete_one_postpone_sequence ();
   }
 
+#if (0)
   bool
   atomic_replication_helper::is_at_least_one_postpone_sequence_completed (TRANID trid) const
   {
@@ -171,6 +176,7 @@ namespace cublog
 
     return false;
   }
+#endif
 
 #if !defined (NDEBUG)
   bool
@@ -326,6 +332,7 @@ namespace cublog
     return false;
   }
 
+#if (0)
   void
   atomic_replication_helper::atomic_log_sequence::start_postpone_sequence ()
   {
@@ -334,6 +341,7 @@ namespace cublog
 
     m_postpone_started = true;
   }
+#endif
 
   bool
   atomic_replication_helper::atomic_log_sequence::is_postpone_sequence_started () const
@@ -346,12 +354,15 @@ namespace cublog
   void
   atomic_replication_helper::atomic_log_sequence::complete_one_postpone_sequence ()
   {
+    assert (false);
+
     assert (m_is_sysop);
     assert (m_postpone_started);
 
     ++m_end_pospone_count;
   }
 
+#if (0)
   bool
   atomic_replication_helper::atomic_log_sequence::is_at_least_one_postpone_sequence_completed () const
   {
@@ -364,6 +375,7 @@ namespace cublog
 
     return false;
   }
+#endif
 
   void
   atomic_replication_helper::atomic_log_sequence::dump ()

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -34,8 +34,8 @@ namespace cublog
    *********************************************************************/
 
   int
-  atomic_replication_helper::add_atomic_replication_log (THREAD_ENTRY *thread_p, TRANID tranid,
-      LOG_LSA record_lsa, LOG_RCVINDEX rcvindex, VPID vpid)
+  atomic_replication_helper::append_log (THREAD_ENTRY *thread_p, TRANID tranid,
+					 LOG_LSA record_lsa, LOG_RCVINDEX rcvindex, VPID vpid)
   {
 #if !defined (NDEBUG)
     if (!VPID_ISNULL (&vpid) && !check_for_page_validity (vpid, tranid))
@@ -54,7 +54,7 @@ namespace cublog
       }
 
     atomic_log_sequence &sequence = sequence_it->second;
-    int error_code = sequence.add_atomic_replication_log (thread_p, record_lsa, rcvindex, vpid);
+    int error_code = sequence.append_log (thread_p, record_lsa, rcvindex, vpid);
     if (error_code != NO_ERROR)
       {
 	return error_code;
@@ -63,7 +63,7 @@ namespace cublog
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
 #if !defined (NDEBUG)
-	dump ("helper::add_atomic_replication_log");
+	dump ("helper::append_log");
 #endif
       }
 
@@ -180,7 +180,7 @@ namespace cublog
     // be able to make the decisions taking into consideration the last control log;
     // this can be implemented later and only if needed; works as is right now
     atomic_log_sequence &sequence = sequence_it->second;
-    sequence.apply_and_unfix_sequence_ex (thread_p);
+    sequence.apply_and_unfix (thread_p);
 
     sequence.append_control_log (rectype, lsa);
 
@@ -205,7 +205,7 @@ namespace cublog
       }
 
     atomic_log_sequence &sequence = sequence_it->second;
-    sequence.apply_and_unfix_sequence_ex (thread_p);
+    sequence.apply_and_unfix (thread_p);
 
     sequence.append_control_log_sysop_end (lsa, sysop_end_type, sysop_end_last_parent_lsa);
 
@@ -290,7 +290,7 @@ namespace cublog
   }
 
   int
-  atomic_replication_helper::atomic_log_sequence::add_atomic_replication_log (THREAD_ENTRY *thread_p,
+  atomic_replication_helper::atomic_log_sequence::append_log (THREAD_ENTRY *thread_p,
       LOG_LSA record_lsa, LOG_RCVINDEX rcvindex, VPID vpid)
   {
     PAGE_PTR page_p = nullptr;
@@ -325,12 +325,12 @@ namespace cublog
   }
 
   void
-  atomic_replication_helper::atomic_log_sequence::apply_and_unfix_sequence_ex (THREAD_ENTRY *thread_p)
+  atomic_replication_helper::atomic_log_sequence::apply_and_unfix (THREAD_ENTRY *thread_p)
   {
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
 #if !defined (NDEBUG)
-	dump ("sequence::apply_and_unfix_sequence_ex START");
+	dump ("sequence::apply_and_unfix START");
 #endif
       }
 
@@ -387,7 +387,7 @@ namespace cublog
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
 #if !defined (NDEBUG)
-	dump ("sequence::apply_and_unfix_sequence_ex END");
+	dump ("sequence::apply_and_unfix END");
 #endif
       }
 

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -466,7 +466,7 @@ namespace cublog
 
   atomic_replication_helper::atomic_log_sequence::page_ptr_bookkeeping::~page_ptr_bookkeeping ()
   {
-    assert (m_.empty ());
+    assert (m_page_ptr_info_map.empty ());
   }
 
   int
@@ -477,8 +477,8 @@ namespace cublog
 
     page_ptr_info *info_p = nullptr;
 
-    const auto find_it = m_.find (vpid);
-    if (find_it != m_.cend ())
+    const auto find_it = m_page_ptr_info_map.find (vpid);
+    if (find_it != m_page_ptr_info_map.cend ())
       {
 	info_p = &find_it->second;
 
@@ -498,7 +498,7 @@ namespace cublog
 	  }
 
 	std::pair<page_ptr_info_map_type::iterator, bool> insert_res
-	  = m_.emplace (vpid, std::move (page_ptr_info ()));
+	  = m_page_ptr_info_map.emplace (vpid, std::move (page_ptr_info ()));
 	assert (insert_res.second);
 
 	info_p = &insert_res.first->second;
@@ -529,8 +529,8 @@ namespace cublog
   atomic_replication_helper::atomic_log_sequence::page_ptr_bookkeeping::unfix_page (
 	  THREAD_ENTRY *thread_p, VPID vpid)
   {
-    const auto find_it = m_.find (vpid);
-    if (find_it != m_.cend ())
+    const auto find_it = m_page_ptr_info_map.find (vpid);
+    if (find_it != m_page_ptr_info_map.cend ())
       {
 	page_ptr_info &info = find_it->second;
 
@@ -545,7 +545,7 @@ namespace cublog
 		info.m_watcher_p.reset ();
 	      }
 
-	    m_.erase (find_it);
+	    m_page_ptr_info_map.erase (find_it);
 	  }
 
 	return NO_ERROR;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -184,7 +184,7 @@ namespace cublog
 	      const LOG_RCVINDEX m_record_index;
 	      // ownership of page pointer is with the bookkeeper in the owning class; this is just a
 	      // reference to allow applying the redo function when needed
-	      PAGE_PTR m_page_ptr;
+	      PAGE_PTR const m_page_ptr;
 	  };
 
 	  using page_ptr_watcher_uptr_type = std::unique_ptr<PGBUF_WATCHER>;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -105,12 +105,16 @@ namespace cublog
       // mark the start of postpone sequence for a transaction; transaction must have
       // already started an atomic sequence; the postpone sequence can contain nested atomic
       // replication sequences which will be treated unioned with the main, already started, one
+#if (0)
       void start_postpone_sequence (TRANID trid);
+#endif
       bool is_postpone_sequence_started (TRANID trid) const;
       void complete_one_postpone_sequence (TRANID trid);
       // there is no easy way of knowing how many postpone sequences are in the transaction
       // but there should be at least one
+#if (0)
       bool is_at_least_one_postpone_sequence_completed (TRANID trid) const;
+#endif
 
       void apply_and_unfix_atomic_replication_sequence (THREAD_ENTRY *thread_p, TRANID tranid);
 
@@ -149,10 +153,14 @@ namespace cublog
 	  bool can_end_sysop_sequence (const LOG_LSA &sysop_parent_lsa) const;
 	  bool can_end_sysop_sequence () const;
 
+#if (0)
 	  void start_postpone_sequence ();
+#endif
 	  bool is_postpone_sequence_started () const;
 	  void complete_one_postpone_sequence ();
+#if (0)
 	  bool is_at_least_one_postpone_sequence_completed () const;
+#endif
 
 	  void apply_and_unfix_sequence (THREAD_ENTRY *thread_p);
 

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -224,21 +224,21 @@ namespace cublog
 	   */
 	  struct page_ptr_bookkeeping
 	  {
-	      page_ptr_bookkeeping () = default;
-	      ~page_ptr_bookkeeping ();
+	    page_ptr_bookkeeping () = default;
+	    ~page_ptr_bookkeeping ();
 
-	      page_ptr_bookkeeping (const page_ptr_bookkeeping &) = delete;
-	      page_ptr_bookkeeping (page_ptr_bookkeeping &&) = delete;
+	    page_ptr_bookkeeping (const page_ptr_bookkeeping &) = delete;
+	    page_ptr_bookkeeping (page_ptr_bookkeeping &&) = delete;
 
-	      page_ptr_bookkeeping &operator= (const page_ptr_bookkeeping &) = delete;
-	      page_ptr_bookkeeping &operator= (page_ptr_bookkeeping &&) = delete;
+	    page_ptr_bookkeeping &operator= (const page_ptr_bookkeeping &) = delete;
+	    page_ptr_bookkeeping &operator= (page_ptr_bookkeeping &&) = delete;
 
-	      int fix_page (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index, PAGE_PTR &page_ptr_out);
-	      int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
+	    int fix_page (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index, PAGE_PTR &page_ptr_out);
+	    int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
 
-	      using page_ptr_info_map_type = std::map<VPID, page_ptr_info>;
+	    using page_ptr_info_map_type = std::map<VPID, page_ptr_info>;
 
-	      page_ptr_info_map_type m_;
+	    page_ptr_info_map_type m_page_ptr_info_map;
 	  };
 
 	  using atomic_log_entry_vector_type = std::vector<atomic_log_entry>;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -158,34 +158,35 @@ namespace cublog
 
 	  log_lsa get_start_lsa () const;
 
+	private:
+	  void dump ();
+
 	private: // types
 	  /*
 	   * Holds the log record information necessary for recovery redo
 	   */
-	  class atomic_log_entry
+	  struct atomic_log_entry
 	  {
-	    public:
-	      atomic_log_entry () = delete;
-	      atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr);
+	    atomic_log_entry () = delete;
+	    atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr);
 
-	      atomic_log_entry (const atomic_log_entry &) = delete;
-	      atomic_log_entry (atomic_log_entry &&that);
+	    atomic_log_entry (const atomic_log_entry &) = delete;
+	    atomic_log_entry (atomic_log_entry &&that);
 
-	      atomic_log_entry &operator= (const atomic_log_entry &) = delete;
-	      atomic_log_entry &operator= (atomic_log_entry &&) = delete;
+	    atomic_log_entry &operator= (const atomic_log_entry &) = delete;
+	    atomic_log_entry &operator= (atomic_log_entry &&) = delete;
 
-	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context) const;
-	      template <typename T>
-	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
-				      LOG_RECTYPE rectype) const;
+	    void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context) const;
+	    template <typename T>
+	    void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
+				    LOG_RECTYPE rectype) const;
 
-	      const VPID m_vpid;
-	    private:
-	      const log_lsa m_record_lsa;
-	      const LOG_RCVINDEX m_record_index;
-	      // ownership of page pointer is with the bookkeeper in the owning class; this is just a
-	      // reference to allow applying the redo function when needed
-	      PAGE_PTR const m_page_ptr;
+	    const VPID m_vpid;
+	    const log_lsa m_record_lsa;
+	    const LOG_RCVINDEX m_record_index;
+	    // ownership of page pointer is with the bookkeeper in the owning class; this is just a
+	    // reference to allow applying the redo function when needed
+	    PAGE_PTR const m_page_ptr;
 	  };
 
 	  using page_ptr_watcher_uptr_type = std::unique_ptr<PGBUF_WATCHER>;
@@ -223,7 +224,6 @@ namespace cublog
 	   */
 	  struct page_ptr_bookkeeping
 	  {
-	    public:
 	      page_ptr_bookkeeping () = default;
 	      ~page_ptr_bookkeeping ();
 
@@ -233,14 +233,11 @@ namespace cublog
 	      page_ptr_bookkeeping &operator= (const page_ptr_bookkeeping &) = delete;
 	      page_ptr_bookkeeping &operator= (page_ptr_bookkeeping &&) = delete;
 
-	    public: // methods
 	      int fix_page (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index, PAGE_PTR &page_ptr_out);
 	      int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
 
-	    private: // types
 	      using page_ptr_info_map_type = std::map<VPID, page_ptr_info>;
 
-	    private: // variables
 	      page_ptr_info_map_type m_;
 	  };
 

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -30,6 +30,12 @@
 #include "thread_entry.hpp"
 #include "vpid_utilities.hpp"
 
+// various local checks; currently linked to the debug state (to be removed at some point)
+#if !defined (NDEBUG)
+#   define ATOMIC_REPL_PAGE_BELONGS_TO_SINGLE_ATOMIC_SEQUENCE_CHECK
+#   define ATOMIC_REPL_PAGE_PTR_BOOKKEEPING_DUMP
+#endif
+
 namespace cublog
 {
   /*
@@ -131,10 +137,10 @@ namespace cublog
 
     private: // methods
       void start_sequence_internal (TRANID trid, LOG_LSA start_lsa, const log_rv_redo_context &redo_context);
-#if !defined (NDEBUG)
+#ifdef ATOMIC_REPL_PAGE_BELONGS_TO_SINGLE_ATOMIC_SEQUENCE_CHECK
       bool check_for_page_validity (VPID vpid, TRANID tranid) const;
-      void dump (const char *message) const;
 #endif
+      void dump (const char *message) const;
 
     private: // types
       class atomic_log_sequence
@@ -168,10 +174,8 @@ namespace cublog
 	  bool all_log_entries_are_control () const;
 	  bool can_purge ();
 
-#if !defined (NDEBUG)
 	  void dump (const char *message) const;
 	  void dump_to_buffer (char *&buf_ptr, int &buf_len) const;
-#endif
 
 	private: // types
 	  /*
@@ -197,9 +201,7 @@ namespace cublog
 
 	    bool is_control () const;
 
-#if !defined (NDEBUG)
 	    void dump_to_buffer (char *&buf_ptr, int &buf_len) const;
-#endif
 
 	    VPID m_vpid;
 	    LOG_RECTYPE m_rectype;
@@ -262,7 +264,7 @@ namespace cublog
 	    int fix_page (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index, PAGE_PTR &page_ptr_out);
 	    int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
 
-#if !defined (NDEBUG)
+#ifdef ATOMIC_REPL_PAGE_PTR_BOOKKEEPING_DUMP
 	    void dump () const;
 #endif
 
@@ -288,7 +290,7 @@ namespace cublog
 
       using sequence_map_type = std::map<TRANID, atomic_log_sequence>;
 
-#if !defined (NDEBUG)
+#ifdef ATOMIC_REPL_PAGE_BELONGS_TO_SINGLE_ATOMIC_SEQUENCE_CHECK
       // check validity of atomic sequences
       // one page can only be accessed by one atomic sequence within one transaction
       // this check makes sense because, on active transaction server, there is no
@@ -300,7 +302,7 @@ namespace cublog
     private: // variables
       sequence_map_type m_sequences_map;
 
-#if !defined (NDEBUG)
+#ifdef ATOMIC_REPL_PAGE_BELONGS_TO_SINGLE_ATOMIC_SEQUENCE_CHECK
       std::map<TRANID, vpid_set_type> m_vpid_sets_map;
 #endif
   };

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -112,8 +112,8 @@ namespace cublog
 
       // add a new log record as part of an already existing atomic replication
       // sequence (be it sysop or non-sysop)
-      int add_atomic_replication_log (THREAD_ENTRY *thread_p, TRANID tranid, LOG_LSA record_lsa, LOG_RCVINDEX rcvindex,
-				      VPID vpid);
+      int append_log (THREAD_ENTRY *thread_p, TRANID tranid, LOG_LSA record_lsa,
+		      LOG_RCVINDEX rcvindex, VPID vpid);
 
       bool is_part_of_atomic_replication (TRANID tranid) const;
       bool all_log_entries_are_control (TRANID tranid) const;
@@ -155,9 +155,9 @@ namespace cublog
 	  // upon constructing a sequence
 	  void initialize (TRANID trid, LOG_LSA start_lsa);
 
-	  int add_atomic_replication_log (THREAD_ENTRY *thread_p, LOG_LSA record_lsa, LOG_RCVINDEX rcvindex, VPID vpid);
+	  int append_log (THREAD_ENTRY *thread_p, LOG_LSA record_lsa, LOG_RCVINDEX rcvindex, VPID vpid);
 
-	  void apply_and_unfix_sequence_ex (THREAD_ENTRY *thread_p);
+	  void apply_and_unfix (THREAD_ENTRY *thread_p);
 
 	  LOG_LSA get_start_lsa () const;
 

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -113,9 +113,11 @@ namespace cublog
       void start_sysop_sequence (TRANID trid, LOG_LSA start_lsa,
 				 const log_rv_redo_context &redo_context);
 #endif
+#if (0)
       // can a sysop-type atomic sequence be ended under the transaction
       bool can_end_sysop_sequence (TRANID trid, LOG_LSA sysop_parent_lsa) const;
       bool can_end_sysop_sequence (TRANID trid) const;
+#endif
 
       // mark the start of postpone sequence for a transaction; transaction must have
       // already started an atomic sequence; the postpone sequence can contain nested atomic
@@ -149,7 +151,11 @@ namespace cublog
 
     private: // methods
       void start_sequence_internal (TRANID trid, LOG_LSA start_lsa,
-				    const log_rv_redo_context &redo_context, bool is_sysop);
+				    const log_rv_redo_context &redo_context
+#if (0)
+				    , bool is_sysop
+#endif
+				    );
 #if !defined (NDEBUG)
       bool check_for_page_validity (VPID vpid, TRANID tranid) const;
       void dump (const char *message) const;
@@ -172,12 +178,18 @@ namespace cublog
 
 	  // technical: function is needed to avoid double constructing a redo_context - which is expensive -
 	  // upon constructing a sequence
-	  void initialize (TRANID trid, LOG_LSA start_lsa, bool is_sysop);
+	  void initialize (TRANID trid, LOG_LSA start_lsa
+#if (0)
+			   , bool is_sysop
+#endif
+			   );
 
 	  int add_atomic_replication_log (THREAD_ENTRY *thread_p, LOG_LSA record_lsa, LOG_RCVINDEX rcvindex, VPID vpid);
 
+#if (0)
 	  bool can_end_sysop_sequence (const LOG_LSA &sysop_parent_lsa) const;
 	  bool can_end_sysop_sequence () const;
+#endif
 
 #if (0)
 	  void start_postpone_sequence ();
@@ -306,11 +318,13 @@ namespace cublog
 	  using atomic_log_entry_vector_type = std::vector<atomic_log_entry>;
 
 	private: // variables
+	  /* the transaction this sequence belongs to; for logging/debugging purposes only */
 	  TRANID m_trid;
 	  /* The LSA of the log record which started this atomic sequence.
 	   * It is used for comparison to see whether a sysop end operation can close an
 	   * atomic replication sequence. */
 	  LOG_LSA m_start_lsa;
+#if (0)
 	  /* Separates the two types of atomic sequences:
 	   *  - sysop
 	   *  - non-sysop
@@ -318,6 +332,7 @@ namespace cublog
 	  bool m_is_sysop = false;
 	  bool m_postpone_started = false;
 	  int m_end_pospone_count = 0;
+#endif
 
 	  log_rv_redo_context m_redo_context;
 	  atomic_log_entry_vector_type m_log_vec;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -159,7 +159,9 @@ namespace cublog
 	  log_lsa get_start_lsa () const;
 
 	private: // methods
+#if (0)
 	  void apply_all_log_redos (THREAD_ENTRY *thread_p);
+#endif
 
 	private: // types
 	  /*
@@ -169,12 +171,14 @@ namespace cublog
 	  {
 	    public:
 	      atomic_log_entry () = delete;
-	      atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex);
+	      atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr);
 
 	      atomic_log_entry (const atomic_log_entry &) = delete;
 	      atomic_log_entry (atomic_log_entry &&that);
 
+#if (0)
 	      ~atomic_log_entry ();
+#endif
 
 	      atomic_log_entry &operator= (const atomic_log_entry &) = delete;
 	      atomic_log_entry &operator= (atomic_log_entry &&) = delete;
@@ -182,11 +186,13 @@ namespace cublog
 	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context);
 	      template <typename T>
 	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, LOG_RECTYPE rectype);
+#if (0)
 	      int fix_page (THREAD_ENTRY *thread_p);
 	      void unfix_page (THREAD_ENTRY *thread_p);
 	      PAGE_PTR get_page_ptr ();
 	      void set_page_ptr (const PAGE_PTR &ptr);
 	      LOG_LSA get_lsa () const;
+#endif
 
 	      const VPID m_vpid;
 	    private:
@@ -194,11 +200,72 @@ namespace cublog
 	      const LOG_RCVINDEX m_record_index;
 	      PAGE_PTR m_page_ptr;
 
+#if (0)
 	      std::unique_ptr<PGBUF_WATCHER> m_watcher_p;
+#endif
+	  };
+
+	  using page_ptr_watcher_uptr_type = std::unique_ptr<PGBUF_WATCHER>;
+
+	  struct page_ptr_info_type
+	  {
+	    page_ptr_info_type () = default;
+
+	    page_ptr_info_type (const page_ptr_info_type &) = delete;
+	    page_ptr_info_type (page_ptr_info_type &&) = default;
+
+	    page_ptr_info_type &operator= (const page_ptr_info_type &) = delete;
+	    page_ptr_info_type &operator= (page_ptr_info_type &&) = delete;
+
+	    ~page_ptr_info_type ();
+
+	    VPID m_vpid = VPID_INITIALIZER;
+	    LOG_RCVINDEX m_rcv_index = RV_NOT_DEFINED;
+	    PAGE_PTR m_page_p = nullptr;
+	    page_ptr_watcher_uptr_type m_watcher_p;
+	    int m_ref_count = -1;
+	  };
+
+	  /*
+	   * Implements a RAII-like reference counted functionality to bokkeep page pointers for
+	   * a sequence of [possibly] nested atomic replication sub-sequences.
+	   * A page can be needed by multiple levels of a nested atomic replication sequence which
+	   * perfom changes on the page. Once the page is unfixed in a sequence at a certain
+	   * level, it can be:
+	   *  - either still kept fixed if a parent [sub]sequence did the fixing and still
+	   *    needs the page
+	   *  - or unfixed if there is no parent [sub]sequence which needs the page anymore (aka:
+	   *    the [sub]sequence which just requested the fix is the outer-most one that needed
+	   *    the page in the current overall sequence of possibly nested [sub]sequences
+	   */
+	  struct page_ptr_bookkeeping
+	  {
+	    public:
+	      page_ptr_bookkeeping () = default;
+	      ~page_ptr_bookkeeping ();
+
+	      page_ptr_bookkeeping (const page_ptr_bookkeeping &) = delete;
+	      page_ptr_bookkeeping (page_ptr_bookkeeping &&) = delete;
+
+	      page_ptr_bookkeeping &operator= (const page_ptr_bookkeeping &) = delete;
+	      page_ptr_bookkeeping &operator= (page_ptr_bookkeeping &&) = delete;
+
+	    public: // methods
+	      int fix_page (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index, PAGE_PTR &page_ptr_out);
+	      int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
+
+	    private: // types
+
+	      using page_ptr_info_map_type = std::map<VPID, page_ptr_info_type>;
+
+	    private: // variables
+	      page_ptr_info_map_type m_;
 	  };
 
 	  using atomic_log_entry_vector_type = std::vector<atomic_log_entry>;
+#if (0)
 	  using vpid_to_page_ptr_map_type = std::map<VPID, PAGE_PTR>;
+#endif
 
 	private: // variables
 	  /* The LSA of the log record which started this atomic sequence.
@@ -215,7 +282,10 @@ namespace cublog
 
 	  log_rv_redo_context m_redo_context;
 	  atomic_log_entry_vector_type m_log_vec;
+#if (0)
 	  vpid_to_page_ptr_map_type m_page_map;
+#endif
+	  page_ptr_bookkeeping m_page_ptr_bookkeeping;
       };
 
       using sequence_map_type = std::map<TRANID, atomic_log_sequence>;
@@ -237,12 +307,18 @@ namespace cublog
 #endif
   };
 
+  int pgbuf_fix_or_ordered_fix (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index,
+				std::unique_ptr<PGBUF_WATCHER> &watcher_up, PAGE_PTR &page_p);
+  void pgbuf_unfix_or_ordered_unfix (THREAD_ENTRY *thread_p, LOG_RCVINDEX rcv_index,
+				     std::unique_ptr<PGBUF_WATCHER> &watcher_up, PAGE_PTR &page_p);
+
   template <typename T>
   void
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::apply_log_by_type (
 	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, LOG_RECTYPE rectype)
   {
     LOG_RCV rcv;
+#if (0)
     if (m_page_ptr != nullptr)
       {
 	assert (m_watcher_p == nullptr);
@@ -253,6 +329,9 @@ namespace cublog
 	assert (m_watcher_p != nullptr && m_watcher_p->pgptr != nullptr);
 	rcv.pgptr = m_watcher_p->pgptr;
       }
+#endif
+    assert (m_page_ptr != nullptr);
+    rcv.pgptr = m_page_ptr;
 
     redo_context.m_reader.advance_when_does_not_fit (sizeof (T));
     const log_rv_redo_rec_info<T> record_info (m_record_lsa, rectype,
@@ -264,11 +343,13 @@ namespace cublog
       }
   }
 
+#if (0)
   inline LOG_LSA
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::get_lsa () const
   {
     return m_record_lsa;
   }
+#endif
 }
 
 #endif // _ATOMIC_REPLICATION_HELPER_HPP_

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -208,7 +208,7 @@ namespace cublog
 	  };
 
 	  /*
-	   * Implements a RAII-like reference counted functionality to bokkeep page pointers for
+	   * Implements a RAII-like reference counted functionality to bookkeep page pointers for
 	   * a sequence of [possibly] nested atomic replication sub-sequences.
 	   * A page can be needed by multiple levels of a nested atomic replication sequence which
 	   * perfom changes on the page. Once the page is unfixed in a sequence at a certain

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -167,7 +167,9 @@ namespace cublog
 	  log_lsa get_start_lsa () const;
 
 	private:
+#if !defined (NDEBUG)
 	  void dump ();
+#endif
 
 	private: // types
 	  /*

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -162,30 +162,28 @@ namespace cublog
 	  /*
 	   * Holds the log record information necessary for recovery redo
 	   */
-	  class atomic_log_entry
+	  struct atomic_log_entry
 	  {
-	    public:
-	      atomic_log_entry () = delete;
-	      atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr);
+	    atomic_log_entry () = delete;
+	    atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr);
 
-	      atomic_log_entry (const atomic_log_entry &) = delete;
-	      atomic_log_entry (atomic_log_entry &&that);
+	    atomic_log_entry (const atomic_log_entry &) = delete;
+	    atomic_log_entry (atomic_log_entry &&that);
 
-	      atomic_log_entry &operator= (const atomic_log_entry &) = delete;
-	      atomic_log_entry &operator= (atomic_log_entry &&) = delete;
+	    atomic_log_entry &operator= (const atomic_log_entry &) = delete;
+	    atomic_log_entry &operator= (atomic_log_entry &&) = delete;
 
-	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context) const;
-	      template <typename T>
-	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
-				      LOG_RECTYPE rectype) const;
+	    void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context) const;
+	    template <typename T>
+	    void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
+				    LOG_RECTYPE rectype) const;
 
-	      const VPID m_vpid;
-	    private:
-	      const log_lsa m_record_lsa;
-	      const LOG_RCVINDEX m_record_index;
-	      // ownership of page pointer is with the bookkeeper in the owning class; this is just a
-	      // reference to allow applying the redo function when needed
-	      PAGE_PTR const m_page_ptr;
+	    const VPID m_vpid;
+	    const log_lsa m_record_lsa;
+	    const LOG_RCVINDEX m_record_index;
+	    // ownership of page pointer is with the bookkeeper in the owning class; this is just a
+	    // reference to allow applying the redo function when needed
+	    PAGE_PTR const m_page_ptr;
 	  };
 
 	  using page_ptr_watcher_uptr_type = std::unique_ptr<PGBUF_WATCHER>;
@@ -223,25 +221,21 @@ namespace cublog
 	   */
 	  struct page_ptr_bookkeeping
 	  {
-	    public:
-	      page_ptr_bookkeeping () = default;
-	      ~page_ptr_bookkeeping ();
+	    page_ptr_bookkeeping () = default;
+	    ~page_ptr_bookkeeping ();
 
-	      page_ptr_bookkeeping (const page_ptr_bookkeeping &) = delete;
-	      page_ptr_bookkeeping (page_ptr_bookkeeping &&) = delete;
+	    page_ptr_bookkeeping (const page_ptr_bookkeeping &) = delete;
+	    page_ptr_bookkeeping (page_ptr_bookkeeping &&) = delete;
 
-	      page_ptr_bookkeeping &operator= (const page_ptr_bookkeeping &) = delete;
-	      page_ptr_bookkeeping &operator= (page_ptr_bookkeeping &&) = delete;
+	    page_ptr_bookkeeping &operator= (const page_ptr_bookkeeping &) = delete;
+	    page_ptr_bookkeeping &operator= (page_ptr_bookkeeping &&) = delete;
 
-	    public: // methods
-	      int fix_page (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index, PAGE_PTR &page_ptr_out);
-	      int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
+	    int fix_page (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index, PAGE_PTR &page_ptr_out);
+	    int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
 
-	    private: // types
-	      using page_ptr_info_map_type = std::map<VPID, page_ptr_info>;
+	    using page_ptr_info_map_type = std::map<VPID, page_ptr_info>;
 
-	    private: // variables
-	      page_ptr_info_map_type m_;
+	    page_ptr_info_map_type m_page_ptr_info_map;
 	  };
 
 	  using atomic_log_entry_vector_type = std::vector<atomic_log_entry>;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -237,7 +237,6 @@ namespace cublog
 	      int unfix_page (THREAD_ENTRY *thread_p, VPID vpid);
 
 	    private: // types
-
 	      using page_ptr_info_map_type = std::map<VPID, page_ptr_info>;
 
 	    private: // variables
@@ -284,9 +283,13 @@ namespace cublog
   };
 
   int pgbuf_fix_or_ordered_fix (THREAD_ENTRY *thread_p, VPID vpid, LOG_RCVINDEX rcv_index,
-				std::unique_ptr<PGBUF_WATCHER> &watcher_up, PAGE_PTR &page_p);
+				std::unique_ptr<PGBUF_WATCHER> &watcher_uptr, PAGE_PTR &page_ptr);
   void pgbuf_unfix_or_ordered_unfix (THREAD_ENTRY *thread_p, LOG_RCVINDEX rcv_index,
-				     std::unique_ptr<PGBUF_WATCHER> &watcher_up, PAGE_PTR &page_p);
+				     std::unique_ptr<PGBUF_WATCHER> &watcher_uptr, PAGE_PTR &page_ptr);
+
+  /*********************************************************************************************************
+   * template functions implementations
+   *********************************************************************************************************/
 
   template <typename T>
   void

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -133,7 +133,7 @@ namespace cublog
 	      THREAD_ENTRY *thread_p, TRANID trid, LOG_LSA lsa, LOG_SYSOP_END_TYPE sysop_end_type,
 	      LOG_LSA sysop_end_last_parent_lsa);
 
-      void forcibly_remove_idle_sequence (TRANID trid);
+      void forcibly_remove_sequence (TRANID trid);
 
     private: // methods
       void start_sequence_internal (TRANID trid, LOG_LSA start_lsa, const log_rv_redo_context &redo_context);

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -86,12 +86,6 @@ namespace cublog
       atomic_replication_helper &operator= (const atomic_replication_helper &) = delete;
       atomic_replication_helper &operator= (atomic_replication_helper &&) = delete;
 
-#if (0)
-      void start_sequence_or_append_to_existing (THREAD_ENTRY *thread_p, TRANID trid, LOG_LSA lsa,
-	  const log_rv_redo_context &redo_context,
-	  LOG_RECTYPE rec_type, LOG_RCVINDEX rcvindex, VPID vpid);
-#endif
-
       // start a new non-sysop atomic replication sequence for a transaction;
       // the transaction must not already have an atomic replication sequence started
       void add_atomic_replication_sequence (TRANID trid, LOG_LSA start_lsa, const log_rv_redo_context &redo_context);
@@ -112,7 +106,6 @@ namespace cublog
       // already started an atomic sequence; the postpone sequence can contain nested atomic
       // replication sequences which will be treated unioned with the main, already started, one
       void start_postpone_sequence (TRANID trid);
-//      void apply_all_before_start_postpone (THREAD_ENTRY *thread_p, TRANID trid);
       bool is_postpone_sequence_started (TRANID trid) const;
       void complete_one_postpone_sequence (TRANID trid);
       // there is no easy way of knowing how many postpone sequences are in the transaction
@@ -128,10 +121,6 @@ namespace cublog
     private: // methods
       void start_sequence_internal (TRANID trid, LOG_LSA start_lsa,
 				    const log_rv_redo_context &redo_context, bool is_sysop);
-#if (0)
-      void start_sequence_internal (TRANID trid, LOG_LSA start_lsa,
-				    const log_rv_redo_context &redo_context, LOG_RECTYPE rec_type);
-#endif
 #if !defined (NDEBUG)
       bool check_for_page_validity (VPID vpid, TRANID tranid) const;
 #endif
@@ -154,29 +143,18 @@ namespace cublog
 	  // technical: function is needed to avoid double constructing a redo_context - which is expensive -
 	  // upon constructing a sequence
 	  void initialize (LOG_LSA start_lsa, bool is_sysop);
-#if (0)
-	  void initialize (LOG_LSA start_lsa, LOG_RECTYPE rec_type);
-#endif
 
 	  int add_atomic_replication_log (THREAD_ENTRY *thread_p, log_lsa record_lsa, LOG_RCVINDEX rcvindex, VPID vpid);
-#if (0)
-	  int handle_replication_log (THREAD_ENTRY *thread_p, log_lsa record_lsa,
-				      LOG_RECTYPE rec_type, LOG_RCVINDEX rcvindex, VPID vpid);
-#endif
 
 	  bool can_end_sysop_sequence (const LOG_LSA &sysop_parent_lsa) const;
 	  bool can_end_sysop_sequence () const;
 
 	  void start_postpone_sequence ();
-//	  void apply_all_before_start_postpone (THREAD_ENTRY *thread_p);
 	  bool is_postpone_sequence_started () const;
 	  void complete_one_postpone_sequence ();
 	  bool is_at_least_one_postpone_sequence_completed () const;
 
 	  void apply_and_unfix_sequence (THREAD_ENTRY *thread_p);
-#if (0)
-	  void apply_and_unfix (THREAD_ENTRY *thread_p, size_t first_index, size_t last_index);
-#endif
 
 	  log_lsa get_start_lsa () const;
 
@@ -186,17 +164,9 @@ namespace cublog
 	   */
 	  class atomic_log_entry
 	  {
-#if (0)
-	      static constexpr LOG_RECTYPE GUARD_REC_TYPE = LOG_LARGER_LOGREC_TYPE;
-	      static constexpr LOG_RCVINDEX GUARD_RCVINDEX = RV_LAST_LOGID;
-#endif
-
 	    public:
 	      atomic_log_entry () = delete;
 	      atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr);
-#if (0)
-	      atomic_log_entry (log_lsa lsa, LOG_RECTYPE rec_type);
-#endif
 
 	      atomic_log_entry (const atomic_log_entry &) = delete;
 	      atomic_log_entry (atomic_log_entry &&that);
@@ -209,16 +179,9 @@ namespace cublog
 	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
 				      LOG_RECTYPE rectype) const;
 
-#if (0)
-	      bool is_payload_record () const;
-#endif
-
 	      const VPID m_vpid;
 	    private:
 	      const log_lsa m_record_lsa;
-#if (0)
-	      const LOG_RECTYPE m_rec_type;
-#endif
 	      const LOG_RCVINDEX m_record_index;
 	      // ownership of page pointer is with the bookkeeper in the owning class; this is just a
 	      // reference to allow applying the redo function when needed

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -174,9 +174,10 @@ namespace cublog
 	      atomic_log_entry &operator= (const atomic_log_entry &) = delete;
 	      atomic_log_entry &operator= (atomic_log_entry &&) = delete;
 
-	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context);
+	      void apply_log_redo (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context) const;
 	      template <typename T>
-	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, LOG_RECTYPE rectype);
+	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
+				      LOG_RECTYPE rectype) const;
 
 	      const VPID m_vpid;
 	    private:
@@ -294,7 +295,7 @@ namespace cublog
   template <typename T>
   void
   atomic_replication_helper::atomic_log_sequence::atomic_log_entry::apply_log_by_type (
-	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, LOG_RECTYPE rectype)
+	  THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context, LOG_RECTYPE rectype) const
   {
     LOG_RCV rcv;
     assert (m_page_ptr != nullptr);

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -122,6 +122,8 @@ namespace cublog
 
       log_lsa get_the_lowest_start_lsa () const;
 
+      void append_control_log (TRANID trid, LOG_RECTYPE rectype, LOG_LSA lsa);
+
     private: // methods
       void start_sequence_internal (TRANID trid, LOG_LSA start_lsa,
 				    const log_rv_redo_context &redo_context, bool is_sysop);
@@ -166,6 +168,8 @@ namespace cublog
 
 	  log_lsa get_start_lsa () const;
 
+	  void append_control_log (LOG_RECTYPE rectype, LOG_LSA lsa);
+
 	private:
 #if !defined (NDEBUG)
 	  void dump ();
@@ -179,6 +183,7 @@ namespace cublog
 	  {
 	    atomic_log_entry () = delete;
 	    atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr);
+	    atomic_log_entry (log_lsa lsa, LOG_RECTYPE rectype);
 
 	    atomic_log_entry (const atomic_log_entry &) = delete;
 	    atomic_log_entry (atomic_log_entry &&that);
@@ -190,6 +195,10 @@ namespace cublog
 	    template <typename T>
 	    void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
 				    LOG_RECTYPE rectype) const;
+
+	    bool is_control () const;
+
+	    const LOG_RECTYPE m_rectype;
 
 	    const VPID m_vpid;
 	    const log_lsa m_record_lsa;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -49,7 +49,7 @@ namespace cublog
    *
    *    LOG_SYSOP_ATOMIC_START
    *        (undo|redo|undoredo|..)+
-   *    LOG_SYSOP_END
+   *    LOG_SYSOP_END with LOG_SYSOP_END_COMMIT
    *
    * 3. vacuum generated atomic sysops with nested postpone logical operations which, themselves,
    *    can contain atomic operations; these have the following layout:
@@ -109,10 +109,10 @@ namespace cublog
       void start_postpone_sequence (TRANID trid);
 #endif
       bool is_postpone_sequence_started (TRANID trid) const;
+#if (0)
       void complete_one_postpone_sequence (TRANID trid);
       // there is no easy way of knowing how many postpone sequences are in the transaction
       // but there should be at least one
-#if (0)
       bool is_at_least_one_postpone_sequence_completed (TRANID trid) const;
 #endif
 
@@ -157,8 +157,8 @@ namespace cublog
 	  void start_postpone_sequence ();
 #endif
 	  bool is_postpone_sequence_started () const;
-	  void complete_one_postpone_sequence ();
 #if (0)
+	  void complete_one_postpone_sequence ();
 	  bool is_at_least_one_postpone_sequence_completed () const;
 #endif
 

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -86,6 +86,12 @@ namespace cublog
       atomic_replication_helper &operator= (const atomic_replication_helper &) = delete;
       atomic_replication_helper &operator= (atomic_replication_helper &&) = delete;
 
+#if (0)
+      void start_sequence_or_append_to_existing (THREAD_ENTRY *thread_p, TRANID trid, LOG_LSA lsa,
+	  const log_rv_redo_context &redo_context,
+	  LOG_RECTYPE rec_type, LOG_RCVINDEX rcvindex, VPID vpid);
+#endif
+
       // start a new non-sysop atomic replication sequence for a transaction;
       // the transaction must not already have an atomic replication sequence started
       void add_atomic_replication_sequence (TRANID trid, LOG_LSA start_lsa, const log_rv_redo_context &redo_context);
@@ -106,6 +112,7 @@ namespace cublog
       // already started an atomic sequence; the postpone sequence can contain nested atomic
       // replication sequences which will be treated unioned with the main, already started, one
       void start_postpone_sequence (TRANID trid);
+//      void apply_all_before_start_postpone (THREAD_ENTRY *thread_p, TRANID trid);
       bool is_postpone_sequence_started (TRANID trid) const;
       void complete_one_postpone_sequence (TRANID trid);
       // there is no easy way of knowing how many postpone sequences are in the transaction
@@ -121,6 +128,10 @@ namespace cublog
     private: // methods
       void start_sequence_internal (TRANID trid, LOG_LSA start_lsa,
 				    const log_rv_redo_context &redo_context, bool is_sysop);
+#if (0)
+      void start_sequence_internal (TRANID trid, LOG_LSA start_lsa,
+				    const log_rv_redo_context &redo_context, LOG_RECTYPE rec_type);
+#endif
 #if !defined (NDEBUG)
       bool check_for_page_validity (VPID vpid, TRANID tranid) const;
 #endif
@@ -143,18 +154,29 @@ namespace cublog
 	  // technical: function is needed to avoid double constructing a redo_context - which is expensive -
 	  // upon constructing a sequence
 	  void initialize (LOG_LSA start_lsa, bool is_sysop);
+#if (0)
+	  void initialize (LOG_LSA start_lsa, LOG_RECTYPE rec_type);
+#endif
 
 	  int add_atomic_replication_log (THREAD_ENTRY *thread_p, log_lsa record_lsa, LOG_RCVINDEX rcvindex, VPID vpid);
+#if (0)
+	  int handle_replication_log (THREAD_ENTRY *thread_p, log_lsa record_lsa,
+				      LOG_RECTYPE rec_type, LOG_RCVINDEX rcvindex, VPID vpid);
+#endif
 
 	  bool can_end_sysop_sequence (const LOG_LSA &sysop_parent_lsa) const;
 	  bool can_end_sysop_sequence () const;
 
 	  void start_postpone_sequence ();
+//	  void apply_all_before_start_postpone (THREAD_ENTRY *thread_p);
 	  bool is_postpone_sequence_started () const;
 	  void complete_one_postpone_sequence ();
 	  bool is_at_least_one_postpone_sequence_completed () const;
 
 	  void apply_and_unfix_sequence (THREAD_ENTRY *thread_p);
+#if (0)
+	  void apply_and_unfix (THREAD_ENTRY *thread_p, size_t first_index, size_t last_index);
+#endif
 
 	  log_lsa get_start_lsa () const;
 
@@ -164,9 +186,17 @@ namespace cublog
 	   */
 	  class atomic_log_entry
 	  {
+#if (0)
+	      static constexpr LOG_RECTYPE GUARD_REC_TYPE = LOG_LARGER_LOGREC_TYPE;
+	      static constexpr LOG_RCVINDEX GUARD_RCVINDEX = RV_LAST_LOGID;
+#endif
+
 	    public:
 	      atomic_log_entry () = delete;
 	      atomic_log_entry (log_lsa lsa, VPID vpid, LOG_RCVINDEX rcvindex, PAGE_PTR page_ptr);
+#if (0)
+	      atomic_log_entry (log_lsa lsa, LOG_RECTYPE rec_type);
+#endif
 
 	      atomic_log_entry (const atomic_log_entry &) = delete;
 	      atomic_log_entry (atomic_log_entry &&that);
@@ -179,9 +209,16 @@ namespace cublog
 	      void apply_log_by_type (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_context,
 				      LOG_RECTYPE rectype) const;
 
+#if (0)
+	      bool is_payload_record () const;
+#endif
+
 	      const VPID m_vpid;
 	    private:
 	      const log_lsa m_record_lsa;
+#if (0)
+	      const LOG_RECTYPE m_rec_type;
+#endif
 	      const LOG_RCVINDEX m_record_index;
 	      // ownership of page pointer is with the bookkeeper in the owning class; this is just a
 	      // reference to allow applying the redo function when needed

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -237,6 +237,8 @@ namespace cublog
 	if (m_atomic_helper.is_part_of_atomic_replication (rec_header.trid))
 	  {
 	    const VPID log_vpid = log_rv_get_log_rec_vpid<T> (record_info.m_logrec);
+	    // return code ignored because it refers to failure to fix heap page
+	    // this is expected in the context of passive transaction server
 	    (void) m_atomic_helper.add_atomic_replication_log (&thread_entry, rec_header.trid, rec_lsa, rcvindex, log_vpid);
 	  }
 	else

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -175,7 +175,8 @@ namespace cublog
 	    const LOG_REC_SYSOP_END log_rec =
 		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_SYSOP_END> ();
 
-	    replicate_sysop_end (thread_entry, header, log_rec);
+	    m_atomic_helper.append_control_log_sysop_end (
+		    &thread_entry, header.trid, m_redo_lsa, log_rec.type, log_rec.lastparent_lsa);
 
 	    read_and_bookkeep_mvcc_vacuum<LOG_REC_SYSOP_END> (header.back_lsa, m_redo_lsa, log_rec, false);
 	    if (m_replicate_mvcc)
@@ -258,7 +259,7 @@ namespace cublog
 	    const VPID log_vpid = log_rv_get_log_rec_vpid<T> (record_info.m_logrec);
 	    // return code ignored because it refers to failure to fix heap page
 	    // this is expected in the context of passive transaction server
-	    (void) m_atomic_helper.add_atomic_replication_log (&thread_entry, rec_header.trid, rec_lsa, rcvindex, log_vpid);
+	    (void) m_atomic_helper.append_log (&thread_entry, rec_header.trid, rec_lsa, rcvindex, log_vpid);
 	  }
 	else
 	  {
@@ -318,13 +319,5 @@ namespace cublog
 	    // by an atomic sequence; that will be treated in a standalone fashion
 	  }
       }
-  }
-
-  void
-  atomic_replicator::replicate_sysop_end (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &log_header,
-					  const LOG_REC_SYSOP_END &log_rec)
-  {
-    m_atomic_helper.append_control_log_sysop_end (&thread_entry, log_header.trid,
-	m_redo_lsa, log_rec.type, log_rec.lastparent_lsa);
   }
 }

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -306,8 +306,7 @@ namespace cublog
 	if (m_atomic_helper.is_part_of_atomic_replication (rec_header.trid))
 	  {
 	    // only interprete LOG_SYSOP_START_POSTPONE if already part of an atomic replication sequence
-	    // in order to know that possible inner atomic replication sequences might appear
-	    //m_atomic_helper.start_postpone_sequence (rec_header.trid);
+	    // apply modifications for all log records which are already part of the sequence
 	    m_atomic_helper.apply_and_unfix_atomic_replication_sequence (&thread_entry, rec_header.trid);
 	  }
 	else

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -363,6 +363,7 @@ namespace cublog
       }
     else
 #endif
+#if (0)
       {
 #if (0)
 	if (log_rec.type == LOG_SYSOP_END_COMMIT
@@ -426,5 +427,8 @@ namespace cublog
 	      }
 	  }
       }
+#endif
+    m_atomic_helper.append_control_log_sysop_end (&thread_entry, log_header.trid,
+	m_redo_lsa, log_rec.type, log_rec.lastparent_lsa);
   }
 }

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -131,7 +131,7 @@ namespace cublog
 	    if (m_atomic_helper.is_part_of_atomic_replication (header.trid)
 		&& m_atomic_helper.all_log_entries_are_control (header.trid))
 	      {
-		m_atomic_helper.forcibly_remove_idle_sequence (header.trid);
+		m_atomic_helper.forcibly_remove_sequence (header.trid);
 	      }
 
 	    if (m_replicate_mvcc)

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -125,6 +125,8 @@ namespace cublog
 	    // to identify this state of a transaction (eg: at least for *2* the
 	    // recovery state could be identified by processing the log compensate records;
 	    //
+	    // for *2*, the issue http://jira.cubrid.org/browse/LETS-572 has been added;
+	    //
 	    // for now, a naive aproach of asserting and forcibly eliminating the atomic sequence
 	    assert (!m_atomic_helper.is_part_of_atomic_replication (header.trid)
 		    || m_atomic_helper.all_log_entries_are_control (header.trid));

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -156,8 +156,10 @@ namespace cublog
 	    break;
 	  case LOG_END_ATOMIC_REPL:
 	    assert (m_atomic_helper.is_part_of_atomic_replication (header.trid));
+#if (0)
 	    // non-sysop and sysop atomic replication sequences cannot mix
 	    assert (!m_atomic_helper.can_end_sysop_sequence (header.trid));
+#endif
 	    m_atomic_helper.append_control_log (&thread_entry, header.trid, header.type, m_redo_lsa, m_redo_context);
 #if (0)
 	    m_atomic_helper.apply_and_unfix_atomic_replication_sequence (&thread_entry, header.trid);

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -28,7 +28,7 @@ namespace cublog
   atomic_replicator::atomic_replicator (const log_lsa &start_redo_lsa, const log_lsa &prev_redo_lsa)
     : replicator (start_redo_lsa, OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT, 0)
     , m_lowest_unapplied_lsa { start_redo_lsa }
-    , m_processed_lsa { prev_redo_lsa }
+    //, m_processed_lsa { prev_redo_lsa }
   {
 
   }
@@ -208,7 +208,7 @@ namespace cublog
 	  // however, this would need one more mutex lock; therefore, suffice to do it here
 	  assert (m_replication_active);
 
-	  m_processed_lsa = m_redo_lsa;
+	  //m_processed_lsa = m_redo_lsa;
 	  m_redo_lsa = header.forw_lsa;
 	}
 
@@ -264,7 +264,8 @@ namespace cublog
   atomic_replicator::get_highest_processed_lsa () const
   {
     std::lock_guard<std::mutex> lockg (m_redo_lsa_mutex);
-    return m_processed_lsa;
+    return m_redo_lsa;
+    //return m_processed_lsa;
   }
 
   log_lsa

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -28,7 +28,7 @@ namespace cublog
   atomic_replicator::atomic_replicator (const log_lsa &start_redo_lsa, const log_lsa &prev_redo_lsa)
     : replicator (start_redo_lsa, OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT, 0)
     , m_lowest_unapplied_lsa { start_redo_lsa }
-    //, m_processed_lsa { prev_redo_lsa }
+    , m_processed_lsa { prev_redo_lsa }
   {
 
   }
@@ -215,7 +215,7 @@ namespace cublog
 	  // however, this would need one more mutex lock; therefore, suffice to do it here
 	  assert (m_replication_active);
 
-	  //m_processed_lsa = m_redo_lsa;
+	  m_processed_lsa = m_redo_lsa;
 	  m_redo_lsa = header.forw_lsa;
 	}
 
@@ -271,8 +271,7 @@ namespace cublog
   atomic_replicator::get_highest_processed_lsa () const
   {
     std::lock_guard<std::mutex> lockg (m_redo_lsa_mutex);
-    return m_redo_lsa;
-    //return m_processed_lsa;
+    return m_processed_lsa;
   }
 
   log_lsa

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -167,7 +167,7 @@ namespace cublog
 	  case LOG_SYSOP_START_POSTPONE:
 	    if (m_replicate_mvcc)
 	      {
-		replicate_sysop_start_postpone (header);
+		replicate_sysop_start_postpone (thread_entry, header);
 	      }
 	    break;
 	  case LOG_ASSIGNED_MVCCID:
@@ -277,7 +277,8 @@ namespace cublog
   }
 
   void
-  atomic_replicator::replicate_sysop_start_postpone (const LOG_RECORD_HEADER &rec_header)
+  atomic_replicator::replicate_sysop_start_postpone (cubthread::entry &thread_entry,
+      const LOG_RECORD_HEADER &rec_header)
   {
     // - if type is LOG_SYSOP_END_COMMIT it starts a sequence of sysop postpones
     // - after each sysop postpone, a LOG_SYSOP_END with LOG_SYSOP_END_LOGICAL_RUN_POSTPONE
@@ -295,7 +296,8 @@ namespace cublog
 	  {
 	    // only interprete LOG_SYSOP_START_POSTPONE if already part of an atomic replication sequence
 	    // in order to know that possible inner atomic replication sequences might appear
-	    m_atomic_helper.start_postpone_sequence (rec_header.trid);
+	    //m_atomic_helper.start_postpone_sequence (rec_header.trid);
+	    m_atomic_helper.apply_and_unfix_atomic_replication_sequence (&thread_entry, rec_header.trid);
 	  }
 	else
 	  {

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -87,7 +87,7 @@ namespace cublog
       void read_and_redo_record (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header,
 				 const log_lsa &rec_lsa);
       void set_lowest_unapplied_lsa ();
-      void replicate_sysop_start_postpone (const LOG_RECORD_HEADER &rec_header);
+      void replicate_sysop_start_postpone (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header);
       void replicate_sysop_end (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header,
 				const LOG_REC_SYSOP_END &log_rec);
 

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -86,8 +86,6 @@ namespace cublog
 				 const log_lsa &rec_lsa);
       void set_lowest_unapplied_lsa ();
       void replicate_sysop_start_postpone (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header);
-      void replicate_sysop_end (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header,
-				const LOG_REC_SYSOP_END &log_rec);
 
     private:
       atomic_replication_helper m_atomic_helper;

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -94,7 +94,7 @@ namespace cublog
     private:
       atomic_replication_helper m_atomic_helper;
       log_lsa m_lowest_unapplied_lsa;
-      log_lsa m_processed_lsa = NULL_LSA; /* protected by m_redo_lsa_mutex with m_redo_lsa */
+      //log_lsa m_processed_lsa = NULL_LSA; /* protected by m_redo_lsa_mutex with m_redo_lsa */
       mutable std::mutex m_lowest_unapplied_lsa_mutex;
   };
 }

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -94,7 +94,7 @@ namespace cublog
     private:
       atomic_replication_helper m_atomic_helper;
       log_lsa m_lowest_unapplied_lsa;
-      //log_lsa m_processed_lsa = NULL_LSA; /* protected by m_redo_lsa_mutex with m_redo_lsa */
+      log_lsa m_processed_lsa = NULL_LSA; /* protected by m_redo_lsa_mutex with m_redo_lsa */
       mutable std::mutex m_lowest_unapplied_lsa_mutex;
   };
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-545
http://jira.cubrid.org/browse/LETS-537
http://jira.cubrid.org/browse/LETS-425

Refactor has the purpose of allowing more control of when to actually "draw" fences to apply the log records within an atomic replication sequence within a transaction.
An atomic replication sequence can be introduced by one of the following log records: `LOG_START_ATOMIC_REPL`, `LOG_SYSOP_ATOMIC_START`.
An atomic replication sequence can be concluded by one of the following log records: `LOG_END_ATOMIC_REPL`, `LOG_SYSOP_END`, `LOG_SYSOP_START_POSTPONE`.
These are called, in the context of the modified code, "control log records".
And are added together with the "proper" log records to an atomic sequence.

Dynamics in `atomic_replication_helper`:
- each processed "control" log record which can be part of an atomic replication sequence is added - with either `append_control_log` or `append_control_log_sysop_end`
  - at this moment, there might already exist "proper" log records in the sequence which will be applied and the pages unfixed - call to `atomic_log_sequence::apply_and_unfix`
  - calling `atomic_log_sequence::apply_and_unfix` will process all "proper" log records and also dispose unfix the pages; the implementation in `page_ptr_bookkeeping` will take care whether the page must still be kept fixed or not
- each "proper" log record for which there is an atomic replication sequence open, will be added - `add_atomic_replication_log`
- after a "control" log record is added to the sequence, the sequence will be checked if it can be "purged" - with "atomic_log_sequence::can_purge"
- a sequence can be purged when certain conditions are met - more details about the precise scenarios implemented is described in the comment for the `atomic_replication_helper` - the function `can_purge` implements precisely those scenarios

Relevant changes in `atomic_replicator`:
- a lot of the logic has actually been offloaded to the helper class
- a `TODO` was added for `LOG_ABORT` due to a scenario involving crash and recovery in Active Transaction Server; but more details implementation is needed - a separate issue will be added and a back-link to the issue will be added in code

Other:
- added debug - default off - `er_log_pts_atomic_repl_debug` system parameter specifically for PTS atomic replication
- added relevant `dump` functions for all functional entities to help in debugging and

PS: there is no point in trying to review by comparing new code with the old code; most of the core part related to replication has changed; easiest is to follow above explanation