### PR TITLE
[CBRD-24535] change cubrid.[sh|csh] for ncurses links

### DIFF
--- a/contrib/scripts/cubrid.csh
+++ b/contrib/scripts/cubrid.csh
@@ -24,7 +24,7 @@ else
 	setenv LD_LIBRARY_PATH $CUBRID/lib:$CUBRID/cci/lib
 endif
 
-set path=($CUBRID/bin $path)
+set path=($CUBRID/bin /usr/sbin $path)
 set curses_lib=
 
 setenv SHLIB_PATH $LD_LIBRARY_PATH

--- a/contrib/scripts/cubrid.csh
+++ b/contrib/scripts/cubrid.csh
@@ -30,7 +30,7 @@ set curses_lib=
 setenv SHLIB_PATH $LD_LIBRARY_PATH
 setenv LIBPATH $LD_LIBRARY_PATH
 
-set is_ncurses5=`ldconfig -p | grep libncurses | grep "so.5" | wc -l`
+set is_ncurses5=`ldconfig -p | grep libncurses.so.5 | wc -l`
 if ( $is_ncurses5 == 0 && ! -f $CUBRID/lib/libncurses.so.5 ) then
   foreach lib ( libncurses libform libtinfo )
     set curses_lib=`ldconfig -p | grep $lib.so | grep -v "so.[1-4]" | sort -h | tail -1 | awk '{print $4}'`

--- a/contrib/scripts/cubrid.csh
+++ b/contrib/scripts/cubrid.csh
@@ -25,53 +25,18 @@ else
 endif
 
 set path=($CUBRID/bin $path)
+set curses_lib=
 
 setenv SHLIB_PATH $LD_LIBRARY_PATH
 setenv LIBPATH $LD_LIBRARY_PATH
 
-set LIB=$CUBRID/lib
-
-if ( -f /etc/redhat-release ) then
-        set OS=`cat /etc/system-release-cpe | cut -d':' -f'3-3'`
-else if ( -f /etc/os-release ) then
-        set OS=`cat /etc/os-release | egrep "^ID=" | cut -d'=' -f2-2`
-     endif
+set is_ncurses5=`ldconfig -p | grep libncurses | grep "so.5" | wc -l`
+if ( $is_ncurses5 == 0 && ! -f $CUBRID/lib/libncurses.so.5 ) then
+  foreach lib ( libncurses libform libtinfo )
+    set curses_lib=`ldconfig -p | grep $lib.so | grep -v "so.[1-4]" | sort -h | tail -1 | awk '{print $4}'`
+    echo "aaa $curses_lib"
+    if ( -z "$curses_lib" ) then
+      echo "$lib.so: CUBRID requires the ncurses package. Make sure the ncurses package is installed"
+    endif
+  end
 endif
-
-switch ($OS)
-  case "fedoraproject":
-  case "centos":
-  case "redhat":
-  case "rocky":
-  case "oracle":
-    if ( ! -f /lib64/libncurses.so.5 && ! -f $LIB/libncurses.so.5 ) then
-    	ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
-    	ln -s /lib64/libform.so.6 $LIB/libform.so.5
-    	ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
-    endif
-    breaksw
-  case "prolinux":
-    if ( ! -f /usr/lib64/libncurses.so.5 && ! -f $LIB/libncurses.so.5 ) then
-        ln -s /usr/lib64/libncurses.so.6 $LIB/libncurses.so.5
-        ln -s /usr/lib64/libform.so.6 $LIB/libform.so.5
-        ln -s /usr/lib64/libtinfo.so.6 $LIB/libtinfo.so.5
-    endif
-    breaksw
-  case "ubuntu":
-    if ( ! -f /lib/x86_64-linux-gnu/libncurses.so.5 && ! -f $LIB/libncurses.so.5 ) then
-      ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
-      ln -s /lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
-      ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
-    endif
-    breaksw
-  case "debian":
-    if ( ! -f /lib/x86_64-linux-gnu/libncurses.so.5 && ! -f $LIB/libncurses.so.5 ) then
-            ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
-            ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
-            ln -s /usr/lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
-    endif
-    breaksw
-  default:
-    echo "CUBRID requires the ncurses package. Make sure the ncurses package is installed"
-    breaksw
-endsw

--- a/contrib/scripts/cubrid.csh
+++ b/contrib/scripts/cubrid.csh
@@ -34,7 +34,7 @@ set is_ncurses5=`ldconfig -p | grep libncurses | grep "so.5" | wc -l`
 if ( $is_ncurses5 == 0 && ! -f $CUBRID/lib/libncurses.so.5 ) then
   foreach lib ( libncurses libform libtinfo )
     set curses_lib=`ldconfig -p | grep $lib.so | grep -v "so.[1-4]" | sort -h | tail -1 | awk '{print $4}'`
-    echo "aaa $curses_lib"
+    ln -s $curses_lib $CUBRID/lib/$lib.so.5
     if ( -z "$curses_lib" ) then
       echo "$lib.so: CUBRID requires the ncurses package. Make sure the ncurses package is installed"
     endif

--- a/contrib/scripts/cubrid.csh
+++ b/contrib/scripts/cubrid.csh
@@ -31,7 +31,7 @@ setenv SHLIB_PATH $LD_LIBRARY_PATH
 setenv LIBPATH $LD_LIBRARY_PATH
 
 set is_ncurses5=`ldconfig -p`
-if ( $? != 0 ) then
+if ( $status != 0 ) then
   echo "ldconfig: Command not found or permission denied, please check it."
   exit 1
 endif

--- a/contrib/scripts/cubrid.csh
+++ b/contrib/scripts/cubrid.csh
@@ -30,7 +30,14 @@ set curses_lib=
 setenv SHLIB_PATH $LD_LIBRARY_PATH
 setenv LIBPATH $LD_LIBRARY_PATH
 
-set is_ncurses5=`ldconfig -p | grep libncurses.so.5 | wc -l`
+set is_ncurses5=`ldconfig -p`
+if ( $? != 0 ) then
+  echo "ldconfig: Command not found or permission denied, please check it."
+  exit 1
+endif
+
+set is_ncurses5=`echo $is_ncurses5 | grep libncurses.so.5 | wc -l`
+
 if ( $is_ncurses5 == 0 && ! -f $CUBRID/lib/libncurses.so.5 ) then
   foreach lib ( libncurses libform libtinfo )
     set curses_lib=`ldconfig -p | grep $lib.so | grep -v "so.[1-4]" | sort -h | tail -1 | awk '{print $4}'`

--- a/contrib/scripts/cubrid.csh
+++ b/contrib/scripts/cubrid.csh
@@ -41,9 +41,10 @@ set is_ncurses5=`echo $is_ncurses5 | grep libncurses.so.5 | wc -l`
 if ( $is_ncurses5 == 0 && ! -f $CUBRID/lib/libncurses.so.5 ) then
   foreach lib ( libncurses libform libtinfo )
     set curses_lib=`ldconfig -p | grep $lib.so | grep -v "so.[1-4]" | sort -h | tail -1 | awk '{print $4}'`
-    ln -s $curses_lib $CUBRID/lib/$lib.so.5
     if ( -z "$curses_lib" ) then
       echo "$lib.so: CUBRID requires the ncurses package. Make sure the ncurses package is installed"
+      break
     endif
+    ln -s $curses_lib $CUBRID/lib/$lib.so.5
   end
 endif

--- a/contrib/scripts/cubrid.csh
+++ b/contrib/scripts/cubrid.csh
@@ -36,7 +36,7 @@ if ( $status != 0 ) then
   exit 1
 endif
 
-set is_ncurses5=`echo $is_ncurses5 | grep libncurses.so.5 | wc -l`
+set is_ncurses5=`ldconfig -p | grep libncurses.so.5 | wc -l`
 
 if ( $is_ncurses5 == 0 && ! -f $CUBRID/lib/libncurses.so.5 ) then
   foreach lib ( libncurses libform libtinfo )

--- a/contrib/scripts/cubrid.sh
+++ b/contrib/scripts/cubrid.sh
@@ -30,7 +30,7 @@ if [ $? -ne 0 ];then
   exit 1
 fi
 
-is_ncurses5=$(echo $is_ncurses5 | grep libncurses.so.5 | wc -l)
+is_ncurses5=$(ldconfig -p | grep libncurses.so.5 | wc -l)
 
 if [ $is_ncurses5 -eq 0 ] && [ ! -f $CUBRID/lib/libncurses.so.5 ];then
   for lib in libncurses libform libtinfo

--- a/contrib/scripts/cubrid.sh
+++ b/contrib/scripts/cubrid.sh
@@ -24,7 +24,13 @@ LIBPATH=$LD_LIBRARY_PATH
 PATH=$CUBRID/bin:/usr/sbin:$PATH
 export LD_LIBRARY_PATH SHLIB_PATH LIBPATH PATH
 
-is_ncurses5=$(ldconfig -p | grep libncurses.so.5 | wc -l)
+is_ncurses5=$(ldconfig -p)
+if [ $? -ne 0 ];then
+  echo "ldconfig: Command not found or permission denied, please check it."
+  exit 1
+fi
+
+is_ncurses5=$(echo $is_ncurses5 | grep libncurses.so.5 | wc -l)
 
 if [ $is_ncurses5 -eq 0 ] && [ ! -f $CUBRID/lib/libncurses.so.5 ];then
   for lib in libncurses libform libtinfo

--- a/contrib/scripts/cubrid.sh
+++ b/contrib/scripts/cubrid.sh
@@ -21,7 +21,7 @@ export CUBRID_DATABASES=$CUBRID/databases
 LD_LIBRARY_PATH=$CUBRID/lib:$CUBRID/cci/lib:$LD_LIBRARY_PATH
 SHLIB_PATH=$LD_LIBRARY_PATH
 LIBPATH=$LD_LIBRARY_PATH
-PATH=$CUBRID/bin:$PATH
+PATH=$CUBRID/bin:/usr/sbin:$PATH
 export LD_LIBRARY_PATH SHLIB_PATH LIBPATH PATH
 
 is_ncurses5=$(ldconfig -p | grep libncurses | grep "so.5")

--- a/contrib/scripts/cubrid.sh
+++ b/contrib/scripts/cubrid.sh
@@ -24,9 +24,9 @@ LIBPATH=$LD_LIBRARY_PATH
 PATH=$CUBRID/bin:/usr/sbin:$PATH
 export LD_LIBRARY_PATH SHLIB_PATH LIBPATH PATH
 
-is_ncurses5=$(ldconfig -p | grep libncurses | grep "so.5")
+is_ncurses5=$(ldconfig -p | grep libncurses | grep "so.5" | wc -l)
 
-if [ -z "$is_ncurses5" ] && [ ! -f $CUBRID/lib/libncurses.so.5 ];then
+if [ $is_ncurses5 -eq 0 ] && [ ! -f $CUBRID/lib/libncurses.so.5 ];then
   for lib in libncurses libform libtinfo
   do
     curses_lib=$(ldconfig -p | grep $lib.so | grep -v "so.[1-4]" | sort -h | tail -1 | awk '{print $4}')

--- a/contrib/scripts/cubrid.sh
+++ b/contrib/scripts/cubrid.sh
@@ -24,7 +24,7 @@ LIBPATH=$LD_LIBRARY_PATH
 PATH=$CUBRID/bin:/usr/sbin:$PATH
 export LD_LIBRARY_PATH SHLIB_PATH LIBPATH PATH
 
-is_ncurses5=$(ldconfig -p | grep libncurses | grep "so.5" | wc -l)
+is_ncurses5=$(ldconfig -p | grep libncurses.so.5 | wc -l)
 
 if [ $is_ncurses5 -eq 0 ] && [ ! -f $CUBRID/lib/libncurses.so.5 ];then
   for lib in libncurses libform libtinfo


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24535

**Purpose**
* Create symbolic links for:
  * libncurses.so.5
  * libform.so.5
  * libtinfo.so.5

**Implementation**
N/A

**Remarks**
* Linux distributions independent
* The key idea was provided by <hiclass@cubrid.com>