### PR TITLE
[LETS-568] Synchronize mvcc_next_id of PTS with that of PS when booting PTS

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1230,11 +1230,7 @@ log_rv_analysis_mvcc_undo_redo (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * 
        * So, largest_mvccid will be updated during log_recovery_analysis () only for PTS,
        * and it will be used to set log_Gl.hdr.mvcc_next_id in log_recovery_analysis_from_trantable_snapshot ().
        */
-
-      if (MVCC_ID_PRECEDES (context.get_largest_mvccid (), tdes->mvccinfo.id))
-	{
-	  context.set_largest_mvccid (tdes->mvccinfo.id);
-	}
+      context.set_largest_mvccid (tdes->mvccinfo.id);
     }
 
   return error_code;
@@ -1773,11 +1769,7 @@ log_rv_analysis_assigned_mvccid (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA *
        * So, largest_mvccid will be updated during log_recovery_analysis () only for PTS,
        * and it will be used to set log_Gl.hdr.mvcc_next_id in log_recovery_analysis_from_trantable_snapshot ().
        */
-
-      if (MVCC_ID_PRECEDES (context.get_largest_mvccid (), tdes->mvccinfo.id))
-	{
-	  context.set_largest_mvccid (tdes->mvccinfo.id);
-	}
+      context.set_largest_mvccid (tdes->mvccinfo.id);
     }
 
   return NO_ERROR;

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1228,13 +1228,13 @@ log_rv_analysis_mvcc_undo_redo (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * 
     {
       /* Since there is no recovery redo phase on PTS, PTS does not update log_Gl.hdr.mvcc_next_id.
        * So, largest_mvccid will be updated during log_recovery_analysis () only for PTS,
-       * and it will be used to set log_Gl.hdr.mvcc_next_id.
+       * and it will be used to set log_Gl.hdr.mvcc_next_id in log_recovery_analysis_from_trantable_snapshot ().
        */
 
-      if (!MVCC_ID_PRECEDES (tdes->mvccinfo.id, context.get_largest_mvccid ()))
-        {
-          context.set_largest_mvccid (tdes->mvccinfo.id);
-        }
+      if (MVCC_ID_PRECEDES (context.get_largest_mvccid (), tdes->mvccinfo.id))
+	{
+	  context.set_largest_mvccid (tdes->mvccinfo.id);
+	}
     }
 
   return error_code;
@@ -1748,7 +1748,8 @@ log_rv_analysis_atomic_sysop_start (THREAD_ENTRY * thread_p, int tran_id, LOG_LS
 }
 
 static int
-log_rv_analysis_assigned_mvccid (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa, LOG_PAGE * log_page_p, log_recovery_context & context)
+log_rv_analysis_assigned_mvccid (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_lsa, LOG_PAGE * log_page_p,
+				 log_recovery_context & context)
 {
   LOG_TDES *tdes = logtb_rv_find_allocate_tran_index (thread_p, tran_id, log_lsa);
   if (tdes == nullptr)
@@ -1770,13 +1771,13 @@ log_rv_analysis_assigned_mvccid (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA *
     {
       /* Since there is no recovery redo phase on PTS, PTS does not update log_Gl.hdr.mvcc_next_id.
        * So, largest_mvccid will be updated during log_recovery_analysis () only for PTS,
-       * and it will be used to set log_Gl.hdr.mvcc_next_id.
+       * and it will be used to set log_Gl.hdr.mvcc_next_id in log_recovery_analysis_from_trantable_snapshot ().
        */
 
-      if (!MVCC_ID_PRECEDES (tdes->mvccinfo.id, context.get_largest_mvccid ()))
-        {
-          context.set_largest_mvccid (tdes->mvccinfo.id);
-        }
+      if (MVCC_ID_PRECEDES (context.get_largest_mvccid (), tdes->mvccinfo.id))
+	{
+	  context.set_largest_mvccid (tdes->mvccinfo.id);
+	}
     }
 
   return NO_ERROR;

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2913,8 +2913,9 @@ log_recovery_analysis_internal (THREAD_ENTRY * thread_p, INT64 * num_redo_log_re
 
       if (is_passive_transaction_server ())
 	{
-	  /* Since there is no recovery redo phase on PTS, PTS does not know the latest mvccid.
-	   * m_largest_mvccid will be updated during log_recovery_analysis () only for PTS.
+	  /* Since there is no recovery redo phase on PTS, PTS does not update log_Gl.hdr.mvcc_next_id.
+	   * So, largest_mvccid will be updated during log_recovery_analysis () only for PTS,
+	   * and it will be used to set log_Gl.hdr.mvcc_next_id.
 	   */
 	  const int tran_index = logtb_find_tran_index (thread_p, tran_id);
 	  if (tran_index != NULL_TRAN_INDEX)

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3334,10 +3334,11 @@ log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY * thread_p,
   //
   log_Gl.mvcc_table.complete_mvccids_if_still_active (LOG_SYSTEM_TRAN_INDEX, in_gaps_mvccids, false);
 
-  if (MVCC_ID_PRECEDES (log_rcv_context.get_largest_mvccid (), log_Gl.hdr.mvcc_next_id))
+  if (!MVCC_ID_PRECEDES (log_rcv_context.get_largest_mvccid (), log_Gl.hdr.mvcc_next_id))
     {
       /* The updated log_Gl.hdr.mvcc_next_id in log_recovery_build_mvcc_table_from_trantable ()
-       * may not be the latest log_Gl.hdr.mvcc_next_id among servers (ATS, PS).
+       * may not be the same as the value of log_Gl.hdr.mvcc_next_id with other servers (ATS, PS)
+       * that have progressed up to log_Gl.hdr.append_lsa.
        * Since log_Gl.hdr.mvcc_next_id is simply determined with checkpoint information,
        * if there are some mvcc operation after the checkpoint, those mvccids can not be known on PTS.
        * However, if ATS requests vacuum for mvccid performed after checkpoint, PTS cannot know about the mvccid, so a crash may occur.

--- a/src/transaction/log_recovery_context.cpp
+++ b/src/transaction/log_recovery_context.cpp
@@ -102,6 +102,12 @@ log_recovery_context::set_start_redo_lsa (const log_lsa &start_redo_lsa)
   m_start_redo_lsa = start_redo_lsa;
 }
 
+void
+log_recovery_context::set_largest_mvccid (const MVCCID mvccid)
+{
+  m_largest_mvccid = mvccid;
+}
+
 bool
 log_recovery_context::is_page_server () const
 {

--- a/src/transaction/log_recovery_context.cpp
+++ b/src/transaction/log_recovery_context.cpp
@@ -20,6 +20,7 @@
 
 #include "server_type.hpp"
 #include "thread_manager.hpp"
+#include "mvcc.h"
 
 log_recovery_context::log_recovery_context ()
 {
@@ -105,7 +106,10 @@ log_recovery_context::set_start_redo_lsa (const log_lsa &start_redo_lsa)
 void
 log_recovery_context::set_largest_mvccid (const MVCCID mvccid)
 {
-  m_largest_mvccid = mvccid;
+  if (MVCC_ID_PRECEDES (m_largest_mvccid, mvccid))
+    {
+      m_largest_mvccid = mvccid;
+    }
 }
 
 bool

--- a/src/transaction/log_recovery_context.hpp
+++ b/src/transaction/log_recovery_context.hpp
@@ -83,7 +83,7 @@ class log_recovery_context
     // Page server
     bool is_page_server () const;
 
-    // Passive transaction server
+    // For passive transaction server to know largest mvccid
     void set_largest_mvccid (const MVCCID mvccid);
 
   private:
@@ -106,7 +106,10 @@ class log_recovery_context
                                                */
     bool m_is_page_server = false;            // true for page server, false for transaction server
 
-    MVCCID m_largest_mvccid = MVCCID_NULL;
+    MVCCID m_largest_mvccid = MVCCID_NULL;    /* Since there is no recovery redo phase on PTS,
+                                               * PTS does not know the latest mvccid.
+                                               * This will be updated during log_recovery_analysis () only for PTS.
+                                               */
 
     log_lsa m_checkpoint_lsa = NULL_LSA;      // the initial checkpoint LSA, starting point for recovery analysis
     log_lsa m_start_redo_lsa = NULL_LSA;      // starting point for recovery redo

--- a/src/transaction/log_recovery_context.hpp
+++ b/src/transaction/log_recovery_context.hpp
@@ -20,6 +20,7 @@
 #define _LOG_RECOVERY_CONTEXT_HPP_
 
 #include "log_lsa.hpp"
+#include "storage_common.h"
 
 #include <time.h>
 
@@ -62,6 +63,11 @@ class log_recovery_context
       return m_restore_stop_point;
     }
 
+    inline const MVCCID &get_largest_mvccid () const
+    {
+      return m_largest_mvccid;
+    }
+
     void set_start_redo_lsa (const log_lsa &start_redo_lsa);
     void set_end_redo_lsa (const log_lsa &end_redo_lsa);
 
@@ -76,6 +82,9 @@ class log_recovery_context
 
     // Page server
     bool is_page_server () const;
+
+    // Passive transaction server
+    void set_largest_mvccid (const MVCCID mvccid);
 
   private:
     static constexpr time_t RESTORE_STOP_POINT_NONE = -1;
@@ -96,6 +105,8 @@ class log_recovery_context
                                                * false if full restore is executed
                                                */
     bool m_is_page_server = false;            // true for page server, false for transaction server
+
+    MVCCID m_largest_mvccid = MVCCID_NULL;
 
     log_lsa m_checkpoint_lsa = NULL_LSA;      // the initial checkpoint LSA, starting point for recovery analysis
     log_lsa m_start_redo_lsa = NULL_LSA;      // starting point for recovery redo


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-568

Purpose

At the time of PTS booting, the PTS determines mvcc_next_id with only checkpoint information. 
There may be a difference between the mvcc_next_id when the checkpoint is left and the mvcc_next_id when the PTS boots.
A problem may occur when ATS requests vacuuming a mvccid between the mvcc_next_id at the time of PTS booting (latest mvccid at ATS) and the mvcc_next_id at the time of leaving the checkpoint (past).
Therefore, it needs to synchronize log_Gl.hdr.mvcc_next_id with PS. 

Implementation

log_recovery_analysis() traverses log records up to log_Gl.hdr.append_lsa.
The PTS waits for the PS to finish replicating up to log_Gl.hdr.append_lsa before it completes the analysis. 
Therefore, the largest mvccid is updated during analysis phase, and largest mvccid will have the same value as log_Gl.hdr.mvcc_next_id on PS.