### PR TITLE
[LETS-563] Fix a PTS not to start with mvccid already vacuumed on ATS

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3336,7 +3336,9 @@ log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY * thread_p,
   //
   log_Gl.mvcc_table.complete_mvccids_if_still_active (LOG_SYSTEM_TRAN_INDEX, in_gaps_mvccids, false);
 
-  /* Update the oldest active mvccid with the currnet mvcctable, which will be taken into account by the global ATS vacuum. */
+  /* Update the oldest active mvccid with the current mvcctable,
+   * which will be taken into account by the global ATS vacuum.
+   */
   log_Gl.mvcc_table.update_oldest_active ();
 
   if (!MVCC_ID_PRECEDES (log_rcv_context.get_largest_mvccid (), log_Gl.hdr.mvcc_next_id))

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3336,6 +3336,7 @@ log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY * thread_p,
   //
   log_Gl.mvcc_table.complete_mvccids_if_still_active (LOG_SYSTEM_TRAN_INDEX, in_gaps_mvccids, false);
 
+  /* Update the oldest active mvccid with the currnet mvcctable, which will be taken into account by the global ATS vacuum. */
   log_Gl.mvcc_table.update_oldest_active ();
 
   if (!MVCC_ID_PRECEDES (log_rcv_context.get_largest_mvccid (), log_Gl.hdr.mvcc_next_id))

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3319,6 +3319,8 @@ log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY * thread_p,
   //
   log_Gl.mvcc_table.complete_mvccids_if_still_active (LOG_SYSTEM_TRAN_INDEX, in_gaps_mvccids, false);
 
+  log_Gl.mvcc_table.reset_lowest_active ();
+
   LOG_SET_CURRENT_TRAN_INDEX (thread_p, sys_tran_index);
 }
 

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3319,7 +3319,7 @@ log_recovery_analysis_from_trantable_snapshot (THREAD_ENTRY * thread_p,
   //
   log_Gl.mvcc_table.complete_mvccids_if_still_active (LOG_SYSTEM_TRAN_INDEX, in_gaps_mvccids, false);
 
-  log_Gl.mvcc_table.reset_lowest_active ();
+  log_Gl.mvcc_table.update_oldest_active ();
 
   LOG_SET_CURRENT_TRAN_INDEX (thread_p, sys_tran_index);
 }

--- a/src/transaction/log_replication_mvcc.cpp
+++ b/src/transaction/log_replication_mvcc.cpp
@@ -153,12 +153,6 @@ namespace cublog
 	// replicator::redo_upto_nxio_lsa
 	log_Gl.mvcc_table.complete_mvcc (LOG_SYSTEM_TRAN_INDEX, found_it->second.m_id, committed);
 
-	if (committed)
-	  {
-	    /* Reset the transaction local visible oldest mvccid set temporarily in log_Gl.mvcc_table.complete_mvcc() */
-	    log_Gl.mvcc_table.reset_transaction_lowest_active (LOG_SYSTEM_TRAN_INDEX);
-	  }
-
 	m_mapped_mvccids.erase (found_it);
       }
     else

--- a/src/transaction/mvcc_table.cpp
+++ b/src/transaction/mvcc_table.cpp
@@ -554,11 +554,13 @@ mvcctable::complete_mvcc (int tran_index, MVCCID mvccid, bool committed)
        *
        * It will be set to NULL after LOG_COMMIT
        *
-       * 2. This is only the case if it's active transaction server because only ats generates log records and do vacuum.
+       * 2. This is the case only if it's ATS because only ats generates log records and do vacuum.
        *
        * 3. This also prevents ats from vacumming a version on which a RO transaction in PTS may start.
-       *  A newly connected PTS starts replicating from the end of log on PS, and a RO transaction can start with a snapshot of then.
-       *  If VACUUM clean up the modifications before its LOG_COMMIT is flushed on PS, it possibly cleans up data seen by the RO transaction on a PTS.
+       *  A newly connected PTS starts replicating from the end of log on PS,
+       *  and a RO transaction can start with a snapshot of then.
+       *  If VACUUM cleans up the modifications before its LOG_COMMIT is flushed on PS,
+       *  it possibly cleans up data seen by the RO transaction on a PTS.
        */
       MVCCID tran_lowest_active = oldest_active_get (m_transaction_lowest_visible_mvccids[tran_index], tran_index,
 				  oldest_active_event::COMPLETE_MVCC);

--- a/src/transaction/mvcc_table.cpp
+++ b/src/transaction/mvcc_table.cpp
@@ -756,11 +756,6 @@ mvcctable::update_global_oldest_visible (const MVCCID pts_oldest_visible)
 	  MVCCID ats_oldest_visible = compute_oldest_visible_mvccid ();
 	  if (m_ov_lock_count == 0)
 	    {
-	      /*
-	       * The assert below must be met to confirm there is no desynchronizaition.
-	       * But, it's allowed for now.
-	       * TODO: It is going to be dealt with soon in http://jira.cubrid.org/browse/LETS-563.
-	       */
 	      assert (m_oldest_visible.load () <= pts_oldest_visible);
 	      assert (m_oldest_visible.load () <= ats_oldest_visible);
 	      if (ats_oldest_visible < pts_oldest_visible)

--- a/src/transaction/mvcc_table.cpp
+++ b/src/transaction/mvcc_table.cpp
@@ -620,13 +620,6 @@ mvcctable::complete_mvccids_if_still_active (int tran_index, const std::set<MVCC
 }
 
 void
-mvcctable::reset_lowest_active()
-{
-  MVCCID new_lowest_active = m_current_trans_status.m_active_mvccs.compute_lowest_active_mvccid ();
-  advance_oldest_active (new_lowest_active);
-}
-
-void
 mvcctable::complete_sub_mvcc (MVCCID mvccid)
 {
   assert (MVCCID_IS_VALID (mvccid));
@@ -700,6 +693,13 @@ mvcctable::reset_transaction_lowest_active (int tran_index)
   assert (tran_index < m_transaction_lowest_visible_mvccids_size);
   oldest_active_set (m_transaction_lowest_visible_mvccids[tran_index], tran_index, MVCCID_NULL,
 		     oldest_active_event::RESET);
+}
+
+void
+mvcctable::update_oldest_active ()
+{
+  MVCCID new_lowest_active = m_current_trans_status.m_active_mvccs.compute_lowest_active_mvccid ();
+  advance_oldest_active (new_lowest_active);
 }
 
 void

--- a/src/transaction/mvcc_table.hpp
+++ b/src/transaction/mvcc_table.hpp
@@ -81,7 +81,6 @@ class mvcctable
     void complete_mvcc (int tran_index, MVCCID mvccid, bool committed);
     void complete_sub_mvcc (MVCCID mvccid);
     void complete_mvccids_if_still_active (int tran_index, const std::set<MVCCID> &mvccids, bool committed);
-    void reset_lowest_active();
     MVCCID get_new_mvccid ();
     void get_two_new_mvccid (MVCCID &first, MVCCID &second);
     // update next_mvcc_id value with one received from ATS if it's larger than the current one
@@ -90,6 +89,8 @@ class mvcctable
     bool is_active (MVCCID mvccid) const;
 
     void reset_start_mvccid ();     // not thread safe
+
+    void update_oldest_active ();
 
     MVCCID get_global_oldest_visible () const;
     MVCCID update_global_oldest_visible ();

--- a/src/transaction/mvcc_table.hpp
+++ b/src/transaction/mvcc_table.hpp
@@ -81,6 +81,7 @@ class mvcctable
     void complete_mvcc (int tran_index, MVCCID mvccid, bool committed);
     void complete_sub_mvcc (MVCCID mvccid);
     void complete_mvccids_if_still_active (int tran_index, const std::set<MVCCID> &mvccids, bool committed);
+    void reset_lowest_active();
     MVCCID get_new_mvccid ();
     void get_two_new_mvccid (MVCCID &first, MVCCID &second);
     // update next_mvcc_id value with one received from ATS if it's larger than the current one


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-563

- Update the active oldest mvccid at the end of log_recovery_analysis_from_trantable_snapshot().
- Set m_transaction_lowest_visible_mvccids[tran_index] only on ATS. LETS-555 is reverted because it doesn't make sense to set the variable while replicating.

Please see the Jira issue for more details.