### PR TITLE
[LETS-537] rename system param used for debug logging of mvccid replication

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -707,7 +707,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_ER_LOG_COMM_CHANNEL "er_log_comm_channel"
 #define PRM_NAME_ER_LOG_COMMIT_CONFIRM "er_log_commit_confirm"
 #define PRM_NAME_ER_LOG_CALC_REPL_DELAY "er_log_calculate_replication_delay"
-#define PRM_NAME_ER_LOG_PTS_REPL_DEBUG "er_log_pts_repl_debug"
+#define PRM_NAME_ER_LOG_MVCC_REPL_DEBUG "er_log_mvcc_repl_debug"
 
 #define PRM_NAME_RECOVERY_PARALLEL_COUNT "recovery_parallel_count"
 #define PRM_NAME_RECOVERY_PARALLEL_TASK_DEBUG "recovery_parallel_task_debug"
@@ -2432,9 +2432,9 @@ bool PRM_ER_LOG_CALC_REPL_DELAY = true;
 static bool prm_er_log_calc_repl_delay_default = false;
 static unsigned int prm_er_log_calc_repl_delay_flag = 0;
 
-bool PRM_ER_LOG_PTS_REPL_DEBUG = true;
-static bool prm_er_log_pts_repl_debug_default = false;
-static unsigned int prm_er_log_pts_repl_debug_flag = 0;
+bool PRM_ER_LOG_MVCC_REPL_DEBUG = true;
+static bool prm_er_log_mvcc_repl_debug_default = false;
+static unsigned int prm_er_log_mvcc_repl_debug_flag = 0;
 
 static unsigned int prm_recovery_parallel_count_flag = 0;
 static int prm_recovery_parallel_count_default = 8;
@@ -6334,13 +6334,13 @@ static SYSPRM_PARAM prm_Def[] = {
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},
-  {PRM_ID_ER_LOG_PTS_REPL_DEBUG,
-   PRM_NAME_ER_LOG_PTS_REPL_DEBUG,
+  {PRM_ID_ER_LOG_MVCC_REPL_DEBUG,
+   PRM_NAME_ER_LOG_MVCC_REPL_DEBUG,
    (PRM_HIDDEN | PRM_FOR_SERVER | PRM_USER_CHANGE),
    PRM_BOOLEAN,
-   &prm_er_log_pts_repl_debug_flag,
-   (void *) &prm_er_log_pts_repl_debug_default,
-   (void *) &PRM_ER_LOG_PTS_REPL_DEBUG,
+   &prm_er_log_mvcc_repl_debug_flag,
+   (void *) &prm_er_log_mvcc_repl_debug_default,
+   (void *) &PRM_ER_LOG_MVCC_REPL_DEBUG,
    (void *) NULL,
    (void *) NULL,
    (char *) NULL,

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -465,7 +465,9 @@ enum param_id
   PRM_ID_ER_LOG_READ_LOG_PAGE,
   PRM_ID_ER_LOG_READ_DATA_PAGE,
   PRM_ID_ER_LOG_CALC_REPL_DELAY,
-  PRM_ID_ER_LOG_PTS_REPL_DEBUG,	/* temporary parameter to support passive transaction server replication debugging */
+  /* temporary parameter to support passive transaction server replication debugging */
+  PRM_ID_ER_LOG_MVCC_REPL_DEBUG,
+  PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG,
 
   PRM_ID_RECOVERY_PARALLEL_COUNT,
   PRM_ID_RECOVERY_PARALLEL_TASK_DEBUG,

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -467,7 +467,6 @@ enum param_id
   PRM_ID_ER_LOG_CALC_REPL_DELAY,
   /* temporary parameter to support passive transaction server replication debugging */
   PRM_ID_ER_LOG_MVCC_REPL_DEBUG,
-  PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG,
 
   PRM_ID_RECOVERY_PARALLEL_COUNT,
   PRM_ID_RECOVERY_PARALLEL_TASK_DEBUG,

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -405,9 +405,9 @@ namespace cublog
 	// mvccid might be valid or not
 	if (MVCCID_IS_NORMAL (log_rec.mvcc_undo_info.mvcc_undo.mvccid))
 	  {
-	    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+	    if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
 	      {
-		_er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] %s tranid=%d MVCCID=%llu parent_MVCCID=%llu\n",
+		_er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] %s tranid=%d MVCCID=%llu parent_MVCCID=%llu\n",
 			       log_sysop_end_type_string (log_rec.type), (int)tranid,
 			       (unsigned long long)log_rec.mvcc_undo_info.mvcc_undo.mvccid,
 			       (unsigned long long)log_rec.mvcc_undo_info.parent_mvccid);
@@ -418,9 +418,9 @@ namespace cublog
       }
     else if (log_rec.type == LOG_SYSOP_END_COMMIT)
       {
-	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+	if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
 	  {
-	    _er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] %s tranid=%d\n",
+	    _er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] %s tranid=%d\n",
 			   log_sysop_end_type_string (log_rec.type), tranid);
 	  }
 	// only complete sub-ids, if found
@@ -428,9 +428,9 @@ namespace cublog
       }
     else if (log_rec.type == LOG_SYSOP_END_ABORT)
       {
-	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+	if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
 	  {
-	    _er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] %s tranid=%d\n",
+	    _er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] %s tranid=%d\n",
 			   log_sysop_end_type_string (log_rec.type), tranid);
 	  }
 	// only complete sub-ids, if found
@@ -439,9 +439,9 @@ namespace cublog
     else
       {
 	// nothing
-	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+	if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
 	  {
-	    _er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] %s tranid=%d not handled\n",
+	    _er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] %s tranid=%d not handled\n",
 			   log_sysop_end_type_string (log_rec.type), tranid);
 	  }
       }

--- a/src/transaction/log_replication_mvcc.cpp
+++ b/src/transaction/log_replication_mvcc.cpp
@@ -66,11 +66,11 @@ namespace cublog
 		    && found_it->second.m_sub_ids[0] == mvccid));
       }
 
-    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+    if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
       {
-	_er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] new_assigned_mvccid tranid=%d mvccid=%llu\n",
+	_er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] new_assigned_mvccid tranid=%d mvccid=%llu\n",
 		       tranid, (unsigned long long)mvccid);
-	dump_map ();
+	dump ();
       }
   }
 
@@ -97,13 +97,13 @@ namespace cublog
 	      {
 		// previosly seen, "main" mvccid, appears now as a sub-mvccid
 		// see comment above, before assert in new_assigned_mvccid function
-		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+		if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
 		  {
-		    _er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] new_assigned_sub_mvccid_or_mvccid"
+		    _er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] new_assigned_sub_mvccid_or_mvccid"
 				   " WARNING previosly seen main mvccid, appears now as a sub-mvccid"
 				   " tranid=%d parent_mvccid=%llu\n",
 				   tranid, (unsigned long long)parent_mvccid);
-		    dump_map ();
+		    dump ();
 		  }
 		// re-assign previosly seen "main"
 		assert (found_it->second.m_id == mvccid);
@@ -114,12 +114,12 @@ namespace cublog
 	    found_it->second.m_sub_ids.push_back (mvccid);
 	  }
 
-	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+	if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
 	  {
-	    _er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] new_assigned_sub_mvccid_or_mvccid tranid=%d"
+	    _er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] new_assigned_sub_mvccid_or_mvccid tranid=%d"
 			   " mvccid=%llu parent_mvccid=%llu\n",
 			   tranid, (unsigned long long)mvccid, (unsigned long long)parent_mvccid);
-	    dump_map ();
+	    dump ();
 	  }
       }
     else
@@ -139,11 +139,11 @@ namespace cublog
 	// all sub-ids should have already been completed
 	assert (found_it->second.m_sub_ids.empty ());
 
-	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+	if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
 	  {
-	    _er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] complete_mvcc FOUND tranid=%d mvccid=%llu %s\n",
+	    _er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] complete_mvcc FOUND tranid=%d mvccid=%llu %s\n",
 			   tranid, (unsigned long long)found_it->second.m_id, (committed ? "COMMITED" : "ABORTED"));
-	    dump_map ();
+	    dump ();
 	  }
 
 	// TODO: temporary using system transaction to complete MVCC; if this proves to be incorrect
@@ -164,11 +164,11 @@ namespace cublog
     else
       {
 	// if not found the transaction never assigned an mvccid
-	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+	if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
 	  {
-	    _er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] complete_mvcc NOT_FOUND tranid=%d %s\n",
+	    _er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] complete_mvcc NOT_FOUND tranid=%d %s\n",
 			   tranid, (committed ? "COMMITED" : "ABORTED"));
-	    dump_map ();
+	    dump ();
 	  }
       }
   }
@@ -188,11 +188,11 @@ namespace cublog
 	    assert (found_it->second.m_sub_ids.size () == 1);
 	    log_Gl.mvcc_table.complete_sub_mvcc (found_it->second.m_sub_ids.back ());
 
-	    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+	    if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
 	      {
-		_er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] complete_sub_mvcc FOUND tranid=%d mvccid=%llu\n",
+		_er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] complete_sub_mvcc FOUND tranid=%d mvccid=%llu\n",
 			       tranid, (unsigned long long)found_it->second.m_sub_ids.back ());
-		dump_map ();
+		dump ();
 	      }
 
 	    // when completing the "main" mvccid, it is expected that all sub-ids have already been completed
@@ -200,43 +200,43 @@ namespace cublog
 	  }
 	else
 	  {
-	    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+	    if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
 	      {
-		_er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] complete_sub_mvcc NOT_FOUND sub_id tranid=%d\n",
+		_er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] complete_sub_mvcc NOT_FOUND sub_id tranid=%d\n",
 			       tranid);
-		dump_map ();
+		dump ();
 	      }
 	  }
       }
     else
       {
-	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_REPL_DEBUG))
+	if (prm_get_bool_value (PRM_ID_ER_LOG_MVCC_REPL_DEBUG))
 	  {
-	    _er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] complete_sub_mvcc NOT_FOUND tranid=%d\n",
+	    _er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] complete_sub_mvcc NOT_FOUND tranid=%d\n",
 			   tranid);
-	    dump_map ();
+	    dump ();
 	  }
       }
   }
 
   void
-  replicator_mvcc::dump_map () const
+  replicator_mvcc::dump () const
   {
 #if !defined (NDEBUG)
     int index = 1;
     for (const auto &info_pair: m_mapped_mvccids)
       {
-	_er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] dump_map index=%d/%d tranid=%d mvccid=%llu\n",
+	_er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] dump index=%d/%d tranid=%d mvccid=%llu\n",
 		       index, m_mapped_mvccids.size (), info_pair.first, (unsigned long long)info_pair.second.m_id);
 	if (info_pair.second.m_sub_ids.empty ())
 	  {
-	    _er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] dump_map sub_ids: EMPTY\n");
+	    _er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] dump sub_ids: EMPTY\n");
 	  }
 	else
 	  {
 	    for (const auto &sub_id: info_pair.second.m_sub_ids)
 	      {
-		_er_log_debug (ARG_FILE_LINE, "[REPLICATOR_MVCC] dump_map sub_ids: sub_id=%llu\n",
+		_er_log_debug (ARG_FILE_LINE, "[REPL_MVCC] dump sub_ids: sub_id=%llu\n",
 			       (unsigned long long)sub_id);
 	      }
 	  }

--- a/src/transaction/log_replication_mvcc.hpp
+++ b/src/transaction/log_replication_mvcc.hpp
@@ -45,7 +45,7 @@ namespace cublog
       void complete_sub_mvcc (TRANID tranid);
 
     private:
-      void dump_map () const;
+      void dump () const;
 
     private:
       struct tran_mvccid_info

--- a/src/transaction/log_replication_mvcc.hpp
+++ b/src/transaction/log_replication_mvcc.hpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 #ifndef _LOG_REPLICATION_MVCC_HPP_
 #define _LOG_REPLICATION_MVCC_HPP_
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-537

LETS-537 also introduced an extra system parameter specifically for atomic transaction log replication. As such, the parameter `PRM_ID_ER_LOG_PTS_REPL_DEBUG` remained specifically used for MVCC replication only.
Rename accordingly.
