### PR TITLE
[LETS-586] Dump complete atomic sequences upon the dtor

### DIFF
--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2008 Search Solution Corporation
  * Copyright 2016 CUBRID Corporation
  *

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -349,15 +349,14 @@ namespace cublog
 	  {
 	    constexpr int BUF_LEN_MAX = UCHAR_MAX;
 	    char buf[BUF_LEN_MAX];
-	    char *const buf_ptr = buf;
 
-	    const int written = snprintf (buf_ptr, (size_t)BUF_LEN_MAX,
+	    const int written = snprintf (buf, (size_t) BUF_LEN_MAX,
 					  "  _W_FAILED LSA = %lld|%d  vpid = %d|%d  rcvindex = %s\n",
 					  LSA_AS_ARGS (&lsa), VPID_AS_ARGS (&vpid),
 					  rv_rcvindex_string (rcvindex));
 	    assert (BUF_LEN_MAX > written);
 
-	    m_full_dump_stream << buf_ptr; // dump to buffer already ends with newline
+	    m_full_dump_stream << buf; // dump to buffer already ends with newline
 	  }
 
 	assert (page_p == nullptr);
@@ -365,7 +364,7 @@ namespace cublog
     else
       {
 	assert (page_p != nullptr);
-	atomic_log_entry &new_entry = m_log_vec.emplace_back (lsa, vpid, rcvindex, page_p);
+	const atomic_log_entry &new_entry = m_log_vec.emplace_back (lsa, vpid, rcvindex, page_p);
 	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 	  {
 	    new_entry.dump_to_stream (m_full_dump_stream);
@@ -453,7 +452,7 @@ namespace cublog
   void
   atomic_replication_helper::atomic_log_sequence::append_control_log (LOG_RECTYPE rectype, LOG_LSA lsa)
   {
-    atomic_log_entry &new_entry = m_log_vec.emplace_back (lsa, rectype);
+    const atomic_log_entry &new_entry = m_log_vec.emplace_back (lsa, rectype);
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
@@ -466,7 +465,7 @@ namespace cublog
   atomic_replication_helper::atomic_log_sequence::append_control_log_sysop_end (
 	  LOG_LSA lsa, LOG_SYSOP_END_TYPE sysop_end_type, LOG_LSA sysop_end_last_parent_lsa)
   {
-    atomic_log_entry &new_entry = m_log_vec.emplace_back (lsa, sysop_end_type, sysop_end_last_parent_lsa);
+    const atomic_log_entry &new_entry = m_log_vec.emplace_back (lsa, sysop_end_type, sysop_end_last_parent_lsa);
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
@@ -929,7 +928,7 @@ namespace cublog
     // maybe faster to first dump to stack buffer
     dump_to_buffer (buf_ptr, buf_len);
 
-    dump_stream << (char *)buf; // dump to buffer already ends with newline
+    dump_stream << (char *) buf; // dump to buffer already ends with newline
   }
 
   /*********************************************************************************************************

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -305,6 +305,11 @@ namespace cublog
 
   atomic_replication_helper::atomic_log_sequence::~atomic_log_sequence ()
   {
+    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
+      {
+	_er_log_debug (ARG_FILE_LINE, "[ATOMIC_REPL_SEQ]\n%s\n", m_full_dump_stream.str ().c_str ());
+      }
+
     assert (m_log_vec.empty ());
   }
 
@@ -340,12 +345,31 @@ namespace cublog
 	//    be fixed, a client transactions manages to fix the page; IOW, how is the progress
 	//    of the "highest processed LSA" working wrt atomic replication sequences
 
+	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
+	  {
+	    constexpr int BUF_LEN_MAX = UCHAR_MAX;
+	    char buf[BUF_LEN_MAX];
+	    char *const buf_ptr = buf;
+
+	    const int written = snprintf (buf_ptr, (size_t)BUF_LEN_MAX,
+					  "  _W_FAILED LSA = %lld|%d  vpid = %d|%d  rcvindex = %s\n",
+					  LSA_AS_ARGS (&lsa), VPID_AS_ARGS (&vpid),
+					  rv_rcvindex_string (rcvindex));
+	    assert (BUF_LEN_MAX > written);
+
+	    m_full_dump_stream << buf_ptr; // dump to buffer already ends with newline
+	  }
+
 	assert (page_p == nullptr);
       }
     else
       {
 	assert (page_p != nullptr);
-	m_log_vec.emplace_back (lsa, vpid, rcvindex, page_p);
+	atomic_log_entry &new_entry = m_log_vec.emplace_back (lsa, vpid, rcvindex, page_p);
+	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
+	  {
+	    new_entry.dump_to_stream (m_full_dump_stream);
+	  }
       }
 
     return err_code;
@@ -429,10 +453,11 @@ namespace cublog
   void
   atomic_replication_helper::atomic_log_sequence::append_control_log (LOG_RECTYPE rectype, LOG_LSA lsa)
   {
-    m_log_vec.emplace_back (lsa, rectype);
+    atomic_log_entry &new_entry = m_log_vec.emplace_back (lsa, rectype);
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
+	new_entry.dump_to_stream (m_full_dump_stream);
 	dump ("sequence::append_control_log END");
       }
   }
@@ -441,10 +466,11 @@ namespace cublog
   atomic_replication_helper::atomic_log_sequence::append_control_log_sysop_end (
 	  LOG_LSA lsa, LOG_SYSOP_END_TYPE sysop_end_type, LOG_LSA sysop_end_last_parent_lsa)
   {
-    m_log_vec.emplace_back (lsa, sysop_end_type, sysop_end_last_parent_lsa);
+    atomic_log_entry &new_entry = m_log_vec.emplace_back (lsa, sysop_end_type, sysop_end_last_parent_lsa);
 
     if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
       {
+	new_entry.dump_to_stream (m_full_dump_stream);
 	dump ("sequence::append_control_log_sysop_end END");
       }
   }
@@ -889,6 +915,21 @@ namespace cublog
     buf_ptr += written;
     assert (buf_len >= written);
     buf_len -= written;
+  }
+
+  void
+  atomic_replication_helper::atomic_log_sequence::atomic_log_entry::dump_to_stream (
+	  std::stringstream &dump_stream) const
+  {
+    constexpr int BUF_LEN_MAX = UCHAR_MAX;
+    char buf[BUF_LEN_MAX];
+    char *buf_ptr = buf;
+    int buf_len = BUF_LEN_MAX;
+
+    // maybe faster to first dump to stack buffer
+    dump_to_buffer (buf_ptr, buf_len);
+
+    dump_stream << (char *)buf; // dump to buffer already ends with newline
   }
 
   /*********************************************************************************************************

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -22,6 +22,7 @@
 #include <map>
 #include <vector>
 #include <set>
+#include <sstream>
 
 #include "log_lsa.hpp"
 #include "log_record.hpp"
@@ -206,6 +207,7 @@ namespace cublog
 	    inline bool is_control () const;
 
 	    void dump_to_buffer (char *&buf_ptr, int &buf_len) const;
+	    void dump_to_stream (std::stringstream &dump_stream) const;
 
 	    VPID m_vpid;
 	    LOG_RECTYPE m_rectype;
@@ -290,6 +292,9 @@ namespace cublog
 	  log_rv_redo_context m_redo_context;
 	  atomic_log_entry_vector_type m_log_vec;
 	  page_ptr_bookkeeping m_page_ptr_bookkeeping;
+
+	  // temporary mechanism to log all the log entries that were part of the sequence
+	  std::stringstream m_full_dump_stream;
       };
 
       using sequence_map_type = std::map<TRANID, atomic_log_sequence>;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-586

Dump complete atomic sequences upon the dtor of an atomic sequence object.
Helps in profiling encountered scenarios of atomic sequences.