### PR TITLE
[CBRD-24555] The spage_collect_statistics function should consider records deleted by vacuum when calculating the number of records in a data page

### DIFF
--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -1033,11 +1033,8 @@ spage_collect_statistics (PAGE_PTR page_p, int *npages, int *nrecords, int *rec_
     {
       if (slot_p->offset_to_record == SPAGE_EMPTY_OFFSET)
 	{
-	  continue;
-	}
+	  assert (slot_p->record_type == REC_MARKDELETED || slot_p->record_type == REC_DELETED_WILL_REUSE);
 
-      if (slot_p->record_type == REC_MARKDELETED || slot_p->record_type == REC_DELETED_WILL_REUSE)
-	{
 	  continue;
 	}
 

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -1036,6 +1036,11 @@ spage_collect_statistics (PAGE_PTR page_p, int *npages, int *nrecords, int *rec_
 	  continue;
 	}
 
+      if (slot_p->record_type == REC_MARKDELETED || slot_p->record_type == REC_DELETED_WILL_REUSE)
+	{
+	  continue;
+	}
+
       if (slot_p->record_type == REC_BIGONE)
 	{
 	  pages += 2;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24555

**Description**
- handled the requirements not to count vacuumed records in the spage_collect_statistics function
- however, vacuumed records are not already being counted
```
// spage_vacuum_slot()
slot_p->offset_to_record = SPAGE_EMPTY_OFFSET;

// spage_collect_statistics()
if (slot_p->offset_to_record == SPAGE_EMPTY_OFFSET)
  {
    continue;
  }
```
- but, I modified it for the following reasons
  - more intuitive to use slot_p->record_type instead of slot_p->offset_to_record in the spage_collect_statistics function
  - the spage_mark_deleted_slot_as_reusable function does not set slot_p->offset_to_record to SPAGE_EMPTY_OFFSET
  - defensive code by quick fix - leave 'if (slot_p->offset_to_record == SPAGE_EMPTY_OFFSET)' as it is