### PR TITLE
[CBRD-24543] remove compat directory from the CUBRID distribution

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -344,33 +344,6 @@ if(UNIX)
   target_link_libraries(unittests_bit LINK_PRIVATE cubrid)
 endif(UNIX)
 
-
-# compat utils
-if(UNIX)
-  SET_SOURCE_FILES_PROPERTIES(
-    ${EXECUTABLES_DIR}/util_front.c
-    PROPERTIES LANGUAGE CXX
-  )
-  add_executable(addvoldb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(backupdb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(checkdb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(commdb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(compactdb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(copydb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(createdb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(deletedb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(installdb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(killtran ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(loaddb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(lockdb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(optimizedb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(renamedb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(restoredb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(spacedb ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(sqlx ${EXECUTABLES_DIR}/util_front.c)
-  add_executable(unloaddb ${EXECUTABLES_DIR}/util_front.c)
-endif(UNIX)
-
 # install
 install(TARGETS
   cubridesql
@@ -388,33 +361,6 @@ install(TARGETS
   LIBRARY DESTINATION ${CUBRID_LIBDIR} COMPONENT Library
   PUBLIC_HEADER DESTINATION ${CUBRID_INCLUDEDIR} COMPONENT Header
   )
-
-# install compats
-if(UNIX)
-  install(TARGETS
-    addvoldb
-    backupdb
-    checkdb
-    commdb
-    compactdb
-    copydb
-    createdb
-    deletedb
-    installdb
-    killtran
-    loaddb
-    lockdb
-    optimizedb
-    renamedb
-    restoredb
-    spacedb
-    sqlx
-    unloaddb
-    RUNTIME DESTINATION ${CUBRID_COMPATDIR} COMPONENT Application
-    )
-  # TODO: compat scripts start|stop_cubrid?
-endif(UNIX)
-
 
 # install pdb files for debugging on windows
 if(WIN32)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24543

**Purpose**
* **Remove** the $CUBRID/**compat** directory and $CUBRID/compat/* files **from the CUBRID distribution**

**Implementation**
N/A

**Remarks**
* The '**cubrid**' front-end is sufficient to do same work for the binaries in compat/*.
  * cubrid unloaddb ... (compat/unloaddb)
  * cubrid compatdb ... (compat/compactdb)
* If a user includes $CUBRID/compat in his/her command path, 'cubrid unloaddb' can be used as an abbreviation in the form of 'unloaddb'.
* However, this can confuse users.