### PR TITLE
[LETS-584] Block ha daemon if there is no need to calculate the replication delay

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10889,9 +10889,13 @@ log_clock_daemon_init ()
 void
 log_check_ha_delay_info_daemon_init ()
 {
-  bool do_supplemental_log = prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0 ? true : false;
+  const bool do_supplemental_log = prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0 ? true : false;
+  const bool do_calc_replication_delay = prm_get_bool_value (PRM_ID_ER_LOG_CALC_REPL_DELAY);
+  const bool is_transaction_server = (get_server_type () == SERVER_TYPE_TRANSACTION);
 
-  if (HA_DISABLED () && !do_supplemental_log && get_server_type () != SERVER_TYPE_TRANSACTION)
+  const bool need_daemon = is_transaction_server && (!HA_DISABLED () || do_supplemental_log || do_calc_replication_delay);
+
+  if (!need_daemon)
     {
       return;
     }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10891,9 +10891,8 @@ log_check_ha_delay_info_daemon_init ()
 {
   const bool do_supplemental_log = prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0 ? true : false;
   const bool do_calc_replication_delay = prm_get_bool_value (PRM_ID_ER_LOG_CALC_REPL_DELAY);
-  const bool is_transaction_server = (get_server_type () == SERVER_TYPE_TRANSACTION);
 
-  const bool need_daemon = is_transaction_server && (!HA_DISABLED () || do_supplemental_log || do_calc_replication_delay);
+  const bool need_daemon = is_active_transaction_server () && (!HA_DISABLED () || do_supplemental_log || do_calc_replication_delay);
 
   if (!need_daemon)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-584

Purpose

`log_Check_ha_delay_info_daemon` is a daemon that continuously appends dummy log records every second.
Dummy log records are used only for calculating replication delay by LETS. 
Therefore, This is to prevent the daemon from running when there is no need to calculate the replication delay time.