### PR TITLE
[LETS-595] overflow heap page atomic sequence

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1881,9 +1881,7 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
     {
       /* Make sure that the page has been allocated (i.e., is a valid page) */
       /* Suppress errors if fetch mode is OLD_PAGE_IF_IN_BUFFER. */
-      const bool no_error_when = (fetch_mode == OLD_PAGE_IF_IN_BUFFER) ||
-	(is_passive_transaction_server () && (fetch_mode == OLD_PAGE_MAYBE_DEALLOCATED));
-      if (pgbuf_is_valid_page (thread_p, vpid, no_error_when, NULL, NULL) != DISK_VALID)
+      if (pgbuf_is_valid_page (thread_p, vpid, fetch_mode == OLD_PAGE_IF_IN_BUFFER, NULL, NULL) != DISK_VALID)
 	{
 	  return NULL;
 	}

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1881,7 +1881,9 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
     {
       /* Make sure that the page has been allocated (i.e., is a valid page) */
       /* Suppress errors if fetch mode is OLD_PAGE_IF_IN_BUFFER. */
-      if (pgbuf_is_valid_page (thread_p, vpid, fetch_mode == OLD_PAGE_IF_IN_BUFFER, NULL, NULL) != DISK_VALID)
+      const bool no_error_when = (fetch_mode == OLD_PAGE_IF_IN_BUFFER) ||
+	(is_passive_transaction_server () && (fetch_mode == OLD_PAGE_MAYBE_DEALLOCATED));
+      if (pgbuf_is_valid_page (thread_p, vpid, no_error_when, NULL, NULL) != DISK_VALID)
 	{
 	  return NULL;
 	}

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -667,9 +667,13 @@ namespace cublog
 	    const atomic_log_entry_vector_type::const_iterator last_but_one_entry_it = (last_entry_it - 1);
 	    const atomic_log_entry &last_but_one_entry = *last_but_one_entry_it;
 
-	    if (last_but_one_entry.m_rectype == LOG_SYSOP_ATOMIC_START) //&&
-	      // !LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) &&
-	      // (last_but_one_entry.m_lsa >= last_entry.m_sysop_end_last_parent_lsa))
+	    // NOTE: the LOG_SYSOP_END log record will have either valid or null 'lastparent_lsa' values;
+	    // for this reason, the condition here does not do any check for lastparent_lsa value;
+	    // normally, it should check that the value of lastparent_lsa is not-null and that it is less than
+	    // or equal to the lsa of the LOG_SYSOP_ATOMIC_START that started the atomic sequence;
+	    // however, when the LOG_SYSOP_ATOMIC_START log record coincides with the very start of
+	    // the transaction the value of 'lastparent_lsa' is null
+	    if (last_but_one_entry.m_rectype == LOG_SYSOP_ATOMIC_START)
 	      {
 		m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
 

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -564,7 +564,7 @@ namespace cublog
 
 	if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 	  {
-	    dump ("sequence::can_purge - START");
+	    dump ("sequence::can_purge START");
 	  }
 
 	const atomic_log_entry_vector_type::const_iterator last_entry_it = m_log_vec.cend () - 1;
@@ -591,7 +591,7 @@ namespace cublog
 
 		    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		      {
-			dump ("sequence::can_purge - after LOG_SYSOP_END - LOG_SYSOP_START_POSTPONE");
+			dump ("sequence::can_purge(2) after erase");
 		      }
 		    assert (m_log_vec.empty ());
 		  }
@@ -606,6 +606,11 @@ namespace cublog
 		  {
 		    // sysop end matches sysop atomic start; delete both start and end control log entries
 		    m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
+
+		    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
+		      {
+			dump ("sequence::can_purge(3) after erase");
+		      }
 		  }
 		else
 		  {
@@ -614,11 +619,11 @@ namespace cublog
 		    // there will, presumably, exist another log record to be processed that will
 		    // close the entire sequence (eg: LOG_END_ATOMIC_REPL)
 		    m_log_vec.erase (last_entry_it);
-		  }
 
-		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
-		  {
-		    dump ("sequence::can_purge - after LOG_SYSOP_END with non-null last_parent_lsa");
+		    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
+		      {
+			dump ("sequence::can_purge(4) after erase");
+		      }
 		  }
 	      }
 	    // isolated atomic sysop with null parent_lsa on the sysop end record
@@ -630,7 +635,7 @@ namespace cublog
 
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
-		    dump ("sequence::can_purge - after LOG_SYSOP_END with null last_parent_lsa");
+		    dump ("sequence::can_purge(5) after erase");
 		  }
 	      }
 	  }
@@ -649,25 +654,27 @@ namespace cublog
 
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
-		    dump ("sequence::can_purge - after LOG_SYSOP_END - LOG_SYSOP_END_LOGICAL_RUN_POSTPONE");
+		    dump ("sequence::can_purge(8) after erase");
 		  }
 	      }
 	  }
 	// part of scenario (4)
+	// part of scenario (5)
 	else if (LOG_SYSOP_END == last_entry.m_rectype
 		 && LOG_SYSOP_END_LOGICAL_UNDO == last_entry.m_sysop_end_type)
 	  {
 	    const atomic_log_entry_vector_type::const_iterator last_but_one_entry_it = (last_entry_it - 1);
 	    const atomic_log_entry &last_but_one_entry = *last_but_one_entry_it;
 
-	    if (!LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) &&
+	    if ((last_but_one_entry.m_rectype == LOG_SYSOP_ATOMIC_START) &&
+		!LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) &&
 		(last_but_one_entry.m_lsa >= last_entry.m_sysop_end_last_parent_lsa))
 	      {
 		m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
 
 		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		  {
-		    dump ("sequence::can_purge - after LOG_SYSOP_END - LOG_SYSOP_END_LOGICAL_UNDO");
+		    dump ("sequence::can_purge(9) after erase");
 		  }
 	      }
 	  }
@@ -693,6 +700,12 @@ namespace cublog
 		  {
 		    // remove all entries between start atomic replication and the end
 		    m_log_vec.erase (search_entry_it, m_log_vec.cend ());
+
+		    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
+		      {
+			dump ("sequence::can_purge(10) after erase");
+		      }
+
 		    break;
 		  }
 
@@ -700,17 +713,12 @@ namespace cublog
 		  {
 		    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		      {
-			dump ("sequence::can_purge - after failed LOG_END_ATOMIC_REPL");
+			dump ("sequence::can_purge(11) error");
 		      }
 
 		    assert_release ("inconsistent atomic log sequence found" == nullptr);
 		    break;
 		  }
-	      }
-
-	    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
-	      {
-		dump ("sequence::can_purge - after LOG_END_ATOMIC_REPL");
 	      }
 	  }
 

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -666,9 +666,9 @@ namespace cublog
 	    const atomic_log_entry_vector_type::const_iterator last_but_one_entry_it = (last_entry_it - 1);
 	    const atomic_log_entry &last_but_one_entry = *last_but_one_entry_it;
 
-	    if ((last_but_one_entry.m_rectype == LOG_SYSOP_ATOMIC_START) &&
-		!LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) &&
-		(last_but_one_entry.m_lsa >= last_entry.m_sysop_end_last_parent_lsa))
+	    if (last_but_one_entry.m_rectype == LOG_SYSOP_ATOMIC_START) //&&
+		// !LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) &&
+		// (last_but_one_entry.m_lsa >= last_entry.m_sysop_end_last_parent_lsa))
 	      {
 		m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
 

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -628,7 +628,8 @@ namespace cublog
 	      }
 	    // isolated atomic sysop with null parent_lsa on the sysop end record
 	    // NOTE: potential inconsistent logging
-	    else if (LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) && (initial_log_vec_size == 2)
+	    else if ((initial_log_vec_size == 2)
+		     && LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa)
 		     && LOG_SYSOP_ATOMIC_START == last_but_one_entry.m_rectype)
 	      {
 		m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -667,8 +667,8 @@ namespace cublog
 	    const atomic_log_entry &last_but_one_entry = *last_but_one_entry_it;
 
 	    if (last_but_one_entry.m_rectype == LOG_SYSOP_ATOMIC_START) //&&
-		// !LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) &&
-		// (last_but_one_entry.m_lsa >= last_entry.m_sysop_end_last_parent_lsa))
+	      // !LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) &&
+	      // (last_but_one_entry.m_lsa >= last_entry.m_sysop_end_last_parent_lsa))
 	      {
 		m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
 

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -107,6 +107,37 @@ namespace cublog
    *      LOG_SYSOP_END (with LOG_SYSOP_END_COMMIT)
    *        .. redo records ..
    *    LOG_END_ATOMIC_REPL
+   *
+   *  (5)
+   *    explicit atomic replication sequence
+   *    apparently occuring in page overflow allocation scenarios
+   *
+   *    LOG_START_ATOMIC_REPL
+   *     |   |
+   *     |   |  .. redo records .. (eg: RVDK_RESERVE_SECTORS, RVPGBUF_NEW_PAGE, RVFL_EXTDATA_ADD)
+   *     |   |
+   *     |   \--LOG_SYSOP_END with LOG_SYSOP_END_LOGICAL_UNDO
+   *     |   |
+   *     |   |  .. redo records .. (eg: RVHF_STATS[+],
+   *     |   |
+   *     |   \--LOG_SYSOP_END with LOG_SYSOP_END_COMMIT
+   *     |
+   *     |   /--LOG_SYSOP_ATOMIC_START
+   *     |   |
+   *     |   |  .. redo records .. (eg: RVFL_PARTSECT_ALLOC, RVFL_FHEAD_ALLOC, RVPGBUF_NEW_PAGE)
+   *     |   |
+   *     |   \--LOG_SYSOP_END with LOG_SYSOP_END_LOGICAL_UNDO
+   *     |
+   *     |   /--LOG_SYSOP_ATOMIC_START
+   *     |   |
+   *     |   |  .. redo records .. (eg: RVFL_PARTSECT_ALLOC, RVFL_FHEAD_ALLOC, RVPGBUF_NEW_PAGE)
+   *     |   |
+   *     |   \--LOG_SYSOP_END with LOG_SYSOP_END_LOGICAL_UNDO
+   *     |
+   *     |  .. redo records .. (eg: LOG_DUMMY_OVF_RECORD, RVOVF_NEWPAGE_INSERT[+], RVHF_UPDATE_NOTIFY_VACUUM,
+   *     |                          RVHF_SET_PREV_VERSION_LSA)
+   *     |
+   *     \--LOG_END_ATOMIC_REPL
    */
   class atomic_replication_helper
   {

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -117,22 +117,26 @@ namespace cublog
    *     |   |  .. redo records .. (eg: RVDK_RESERVE_SECTORS, RVPGBUF_NEW_PAGE, RVFL_EXTDATA_ADD)
    *     |   |
    *     |   \--LOG_SYSOP_END with LOG_SYSOP_END_LOGICAL_UNDO
+   *     |           (with valid lastparent_lsa)
    *     |   |
    *     |   |  .. redo records .. (eg: RVHF_STATS[+],
    *     |   |
    *     |   \--LOG_SYSOP_END with LOG_SYSOP_END_COMMIT
+   *     |           (with valid lastparent_lsa)
    *     |
    *     |   /--LOG_SYSOP_ATOMIC_START
    *     |   |
    *     |   |  .. redo records .. (eg: RVFL_PARTSECT_ALLOC, RVFL_FHEAD_ALLOC, RVPGBUF_NEW_PAGE)
    *     |   |
    *     |   \--LOG_SYSOP_END with LOG_SYSOP_END_LOGICAL_UNDO
+   *     |           (with valid lastparent_lsa)
    *     |
    *     |   /--LOG_SYSOP_ATOMIC_START
    *     |   |
    *     |   |  .. redo records .. (eg: RVFL_PARTSECT_ALLOC, RVFL_FHEAD_ALLOC, RVPGBUF_NEW_PAGE)
    *     |   |
    *     |   \--LOG_SYSOP_END with LOG_SYSOP_END_LOGICAL_UNDO
+   *     |           (with valid lastparent_lsa)
    *     |
    *     |  .. redo records .. (eg: LOG_DUMMY_OVF_RECORD, RVOVF_NEWPAGE_INSERT[+], RVHF_UPDATE_NOTIFY_VACUUM,
    *     |                          RVHF_SET_PREV_VERSION_LSA)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-595

Passive Transaction Server atomic replication sequence for page overflow allocation scenarios.

Avoid purging an atomic sequence by an `LOG_SYSOP_END` (with `LOG_SYSOP_END_LOGICAL_UNDO`) when that sequence was not started by a `LOG_SYSOP_ATOMIC_START` (see log sequence synopsis in the comment for `class atomic_replication_helper`).

Also drop the condition regarding `lastparent_lsa` to fit both the cases when it has a valid value and when it has a null value. This is needed to accommodate the situation when `LOG_SYSOP_ATOMIC_START` log record that starts the atomic sequence coincides with the start of the transaction (is the very first log record of a newly occurring transaction in the log).

