### PR TITLE
[LETS-558] [LETS-511] completely purge the page from page buffer upon page de-alloc in atomic replication context

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -14727,12 +14727,12 @@ pgbuf_rv_dealloc_redo (THREAD_ENTRY * thread_p, const LOG_RCV * rcv)
   if (is_passive_transaction_server ())
     {
       /* on a passive transaction server; upon de-allocation, remove the page
-       * from page buffer altogether; do this to avoid the following scenario:
-       * -
-       */
+       * from page buffer altogether; needed because to provide a fail-safe mechanism
+       * for page re-allocation: when the same page is re-allocated in a subsequent
+       * transaction, the replication mechanism will fail to fix an 'PAGE_UNKNOWN' page */
 #if !defined(NDEBUG)
-      /*
-       */
+      /* crash if there are other, client, transactions waiting in line to fix the same page;
+       * architecturally, this should not be the case (as in a "monolithic" server as well) */
       PGBUF_BCB *bufptr;
       CAST_PGPTR_TO_BFPTR (bufptr, rcv->pgptr);
       assert (bufptr->next_wait_thrd == nullptr);

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -1148,6 +1148,10 @@ namespace cublog
 	// other sanity asserts inside the function
 	pgbuf_ordered_unfix (thread_p, watcher_uptr.get ());
 	break;
+      case RVPGBUF_DEALLOC:
+	assert (watcher_uptr == nullptr);
+	// TODO: do not unfix the page, it has been already flushed from the page buffer
+	break;
       default:
 	assert (watcher_uptr == nullptr);
 	// other sanity asserts inside the function


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-511
http://jira.cubrid.org/browse/LETS-558

When a page is de-allocated - via `RVPGBUF_DEALLOC` - all that is done is to mark the page as `PAGE_UNKNOWN` and mark it dirty with the idea that:
- in a "monolithic" server, there will be no other transaction that needs access to the page given that
  - all previous transactions that needed the page concluded - guaranteed by the fact that the transaction that de-allocates the page was allowed to acquire write latch for the page
  - all subsequent transactions will not "see" the page - guaranteed by mechanisms such as MVCC
- being dirty, the page buffer flush daemon will write it to disk upon next run

However, this seems to break down in Passive Transaction Server because the page buffer flush daemon does not flush the permanent pages and remove them from the page buffer (see the mechanism implemented with the help of the flag `PGBUF_BCB_FLUSH_NOT_NEEDED_FLAG`).
The page will remain dirty in the page buffer until it is needed again - most probably until a next re-allocation.
On PTS re-allocation will solely be done by the replicating thread. When the page is tried for a fix, its type will be found as `PAGE_UNKNOWN` and fixing will fail and crash due to an assert.

Completely purge the page from page buffer when applying the redo function for `RVPGBUF_DEALLOC`.
Only do this when the function is used within an Passive Transaction Server atomic replication context.

Implementation:
- The function `pgbuf_invalidate` is used to completely [force-]remove the page from page buffer; in tests, this proved as the correct level of abstraction to use to perform page removal/purging
- there is a debug time check that no other concurrent threads (user transactions) are enqueued to read the page; if there are, and the assert is invalidated it remains to be seen as what to do (ie: it will crash; current implementation is supposed to unblock a set of testing scenarios and http://jira.cubrid.org/browse/LETS-596 has been added to revisit this functionality at a later stage of LETS development);
- given the visibility explanation above this should not be case
- normally, one would expect that `pgbuf_invalidate` would also invalidate and wake those waiters informing them of the change, but no such logic seems to exist (or was not found), hence the assert was deemed as the correct mode to ensure this;
- `RVPGBUF_DEALLOC` was, as of now, only encountered in atomic replication sequences, therefore the atomic replication helper bookkeeping mechanism must not try to unfix the page as `pgbuf_invalidate` already did that - change in `pgbuf_unfix_or_ordered_unfix`

Notes:
There is also an option to not change the function `pgbuf_unfix_or_ordered_unfix` and, instead only perform the modification in the atomic replication specific code (ie: atomic replication helper class and associated functions). However, we want to keep this functionality as limited as possible (again, will be followed up with http://jira.cubrid.org/browse/LETS-596). So, if `RVPGBUF_DEALLOC` occurs outside delimited [sysop] atomic sequences of log records, the PTS will crash in (`log_rv_redo_record_sync` - `unfix_rcv_pgptr`).