### PR TITLE
[CBRD-24570] Support Ninja build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,15 @@ function(target_external_dependencies depender)
   endforeach()
 endfunction(target_external_dependencies)
 
+macro(ADD_BY_PRODUCTS_VARIABLE prefix_dependee)
+  if (CMAKE_GENERATOR MATCHES "Ninja")
+    if(CMAKE_VERSION VERSION_LESS "3.2")
+      message(FATAL_ERROR "The Ninja generator requires CMake 3.2+. Try the \"Unix Makefiles\" generator instead.")
+    endif()
+    set(${prefix_dependee}_BYPRODUCTS BUILD_BYPRODUCTS "${ARGN}")
+  endif()
+endmacro()
+
 # FIXME: linux 32bit build mode not working now
 option(ENABLE_32BIT "Build for 32-bit banaries (on 64-bit platform)" OFF)
 option(ENABLE_SYSTEMTAP "Enable dynamic tracing support using systemtap" ${ENABLE_SYSTEMTAP_DEFAULT})
@@ -907,12 +916,12 @@ set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINAR
 #                  ${WITH_LIBEXPAT_ROOT_PATH}/include
 # on Windows:
 # * "EXTERNAL" - (default) uses the prebuilt library from cubrid/win/external
+set(LIBEXPAT_TARGET libexpat)
 if(WITH_LIBEXPAT STREQUAL "EXTERNAL")
-  set(LIBEXPAT_TARGET libexpat)
-  list(APPEND EP_TARGETS ${LIBEXPAT_TARGET})
   if(UNIX)
     set(LIBEXPAT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libexpat.a)
     set(LIBEXPAT_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/expat)
+    ADD_BY_PRODUCTS_VARIABLE ("LIBEXPAT" ${LIBEXPAT_LIBS})
     externalproject_add(${LIBEXPAT_TARGET}
       URL                  ${WITH_LIBEXPAT_URL}
       LOG_BUILD            TRUE
@@ -922,7 +931,7 @@ if(WITH_LIBEXPAT STREQUAL "EXTERNAL")
       CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS} --without-xmlwf  --without-docbook
       BUILD_COMMAND        make AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      BUILD_BYPRODUCTS     ${LIBEXPAT_LIBS}
+      "${LIBEXPAT_BYPRODUCTS}"
       )
   elseif(WIN32)
     set(LIBEXPAT_LIBS ${WINDOWS_EXTERNAL_LIB_DIR}/libexpat.lib)
@@ -941,6 +950,7 @@ elseif(WITH_LIBEXPAT STREQUAL "SYSTEM")
     message(STATUS "Found expat headers: ${LIBEXPAT_INCLUDES}")
   endif(UNIX)
 endif()
+list(APPEND EP_TARGETS ${LIBEXPAT_TARGET})
 list(APPEND EP_INCLUDES ${LIBEXPAT_INCLUDES})
 list(APPEND EP_LIBS ${LIBEXPAT_LIBS})
 
@@ -961,6 +971,7 @@ if(WITH_LIBJANSSON STREQUAL "EXTERNAL")
   if(UNIX)
     set(LIBJANSSON_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libjansson.a)
     set(LIBJANSSON_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/jansson)
+    ADD_BY_PRODUCTS_VARIABLE ("LIBJANSSON" ${LIBJANSSON_LIBS})
     externalproject_add(${LIBJANSSON_TARGET}
       URL                  ${WITH_LIBJANSSON_URL}
       LOG_BUILD            TRUE
@@ -970,7 +981,7 @@ if(WITH_LIBJANSSON STREQUAL "EXTERNAL")
       CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      BUILD_BYPRODUCTS     ${LIBJANSSON_LIBS}
+      "${LIBJANSSON_BYPRODUCTS}"
       )
   else(UNIX)
     # WIN32
@@ -1040,6 +1051,7 @@ if(UNIX)
     set(LIBEDIT_TARGET libedit)
     set(LIBEDIT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libedit.a)
     set(LIBEDIT_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
+    ADD_BY_PRODUCTS_VARIABLE ("LIBEDIT" ${LIBEDIT_LIBS})
     externalproject_add(${LIBEDIT_TARGET}
       URL                  ${WITH_LIBEDIT_URL}
       LOG_BUILD            TRUE
@@ -1049,7 +1061,7 @@ if(UNIX)
       CONFIGURE_COMMAND    "LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/external/lib" ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      BUILD_BYPRODUCTS     ${LIBEDIT_LIBS}
+      "${LIBEDIT_BYPRODUCTS}"
       )
     if(TARGET ${LIBNCURSES_TARGET})
       add_dependencies(${LIBEDIT_TARGET} ${LIBNCURSES_TARGET})
@@ -1081,6 +1093,7 @@ if(WIN32) # msvc-built lz4 v1.9.2 libraries
 else()
   set(LZ4_INCLUDES  ${CMAKE_BINARY_DIR}/external/Source/lz4/lib)
   set(LZ4_LIBS      ${CMAKE_BINARY_DIR}/external/Source/lz4/lib/liblz4.a)
+  ADD_BY_PRODUCTS_VARIABLE ("LZ4" ${LZ4_LIBS})
   externalproject_add(${LZ4_TARGET}
     GIT_REPOSITORY https://github.com/lz4/lz4
     GIT_TAG fdf2ef5             # https://github.com/lz4/lz4/releases/tag/v1.9.2
@@ -1088,7 +1101,7 @@ else()
     BUILD_IN_SOURCE true        # lz4 Makefile is designed to run locally
     BUILD_COMMAND make CFLAGS="-fPIC"  # to allow static linking in shared library
     INSTALL_COMMAND ""          # suppress install
-    BUILD_BYPRODUCTS            ${LZ4_LIBS}
+    "${LZ4_BYPRODUCTS}"
   )
 endif()
 list(APPEND EP_LIBS ${LZ4_LIBS})
@@ -1105,13 +1118,14 @@ list(APPEND EP_INCLUDES ${LZ4_INCLUDES})
 #                  ${WITH_LIBOPENSSL_ROOT_PATH}/include
 # on Windows:
 # * "EXTERNAL" - (default) uses the prebuilt library from cubrid/win/external
+set(LIBOPENSSL_TARGET libopenssl)
 if(WITH_LIBOPENSSL STREQUAL "EXTERNAL")
-  set(LIBOPENSSL_TARGET libopenssl)
   if(UNIX)
     #compile OpenSSL library given an internet url to a OpenSSL archive
     #e.g. https://www.openssl.org/source/openssl-1.1.1f.tar.gz
     set(LIBOPENSSL_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libssl.a ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libcrypto.a)
     set(LIBOPENSSL_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
+    ADD_BY_PRODUCTS_VARIABLE ("LIBOPENSSL" ${LIBOPENSSL_LIBS})
     externalproject_add(${LIBOPENSSL_TARGET}
       URL                  ${WITH_LIBOPENSSL_URL}
       LOG_CONFIGURE        TRUE
@@ -1122,7 +1136,7 @@ if(WITH_LIBOPENSSL STREQUAL "EXTERNAL")
       CONFIGURE_COMMAND    <SOURCE_DIR>/config --prefix=${CMAKE_CURRENT_BINARY_DIR}/external no-shared # ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install_sw AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      BUILD_BYPRODUCTS     ${LIBOPENSSL_LIBS}
+      "${LIBOPENSSL_BYPRODUCTS}"
       )
     list(APPEND EP_TARGETS ${LIBOPENSSL_TARGET})
   else(UNIX)
@@ -1154,6 +1168,7 @@ if(WITH_LIBUNIXODBC STREQUAL "EXTERNAL")
     #e.g. http://www.unixodbc.org/unixODBC-2.3.9.tar.gz
     set(LIBUNIXODBC_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libodbc.so)
     set(LIBUNIXODBC_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
+    ADD_BY_PRODUCTS_VARIABLE ("LIBUNIXODBC" ${LIBUNIXODBC_LIBS})
     externalproject_add(${LIBUNIXODBC_TARGET}
       URL                  ${WITH_LIBUNIXODBC_URL}
       LOG_CONFIGURE        TRUE
@@ -1164,7 +1179,7 @@ if(WITH_LIBUNIXODBC STREQUAL "EXTERNAL")
       CONFIGURE_COMMAND    <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external # ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      BUILD_BYPRODUCTS     ${LIBUNIXODBC_LIBS}
+      "${LIBUNIXODBC_BYPRODUCTS}"
       )
     list(APPEND EP_TARGETS ${LIBUNIXODBC_TARGET})
   endif(UNIX)
@@ -1182,6 +1197,7 @@ endif(WIN32)
 # rapidjson
 set(RAPIDJSON_TARGET rapidjson)
 set(RAPIDJSON_INCLUDES ${CMAKE_BINARY_DIR}/external/Source/rapidjson/include)
+ADD_BY_PRODUCTS_VARIABLE ("RAPIDJSON" ${RAPIDJSON_INCLUDES})
 externalproject_add(${RAPIDJSON_TARGET}
   # tried URL but archive gets downloaded every time. URL_MD5 may help
   URL                  ${WITH_RAPIDJSON_URL}
@@ -1196,7 +1212,7 @@ externalproject_add(${RAPIDJSON_TARGET}
   CMAKE_CACHE_ARGS     -DRAPIDJSON_BUILD_TESTS:STRING=off
                        -DRAPIDJSON_BUILD_DOC:STRING=off
                        -DRAPIDJSON_BUILD_EXAMPLES:STRING=off
-  BUILD_BYPRODUCTS     ${RAPIDJSON_INCLUDES}
+  "${RAPIDJSON_BYPRODUCTS}"
 )
 # add to external project targets
 list(APPEND EP_INCLUDES ${RAPIDJSON_INCLUDES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -920,6 +920,7 @@ if(WITH_LIBEXPAT STREQUAL "EXTERNAL")
       CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS} --without-xmlwf  --without-docbook
       BUILD_COMMAND        make AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      BUILD_BYPRODUCTS     ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libexpat.a
       )
     set(LIBEXPAT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libexpat.a)
     set(LIBEXPAT_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/expat)
@@ -967,6 +968,7 @@ if(WITH_LIBJANSSON STREQUAL "EXTERNAL")
       CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      BUILD_BYPRODUCTS     ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libjansson.a
       )
     set(LIBJANSSON_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libjansson.a)
     set(LIBJANSSON_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/jansson)
@@ -1045,6 +1047,7 @@ if(UNIX)
       CONFIGURE_COMMAND    "LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/external/lib" ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      BUILD_BYPRODUCTS     ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libedit.a
       )
     if(TARGET ${LIBNCURSES_TARGET})
       add_dependencies(${LIBEDIT_TARGET} ${LIBNCURSES_TARGET})
@@ -1083,6 +1086,7 @@ else()
     BUILD_IN_SOURCE true        # lz4 Makefile is designed to run locally
     BUILD_COMMAND make CFLAGS="-fPIC"  # to allow static linking in shared library
     INSTALL_COMMAND ""          # suppress install
+    BUILD_BYPRODUCTS            ${CMAKE_CURRENT_BINARY_DIR}/external/Source/lz4/lib/liblz4.a
   )
   set(LZ4_INCLUDES ${CMAKE_BINARY_DIR}/external/Source/lz4/lib)
   set(LZ4_LIBS ${CMAKE_BINARY_DIR}/external/Source/lz4/lib/liblz4.a)
@@ -1114,8 +1118,9 @@ if(WITH_LIBOPENSSL STREQUAL "EXTERNAL")
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND    <SOURCE_DIR>/config --prefix=${CMAKE_CURRENT_BINARY_DIR}/external no-shared # ${DEFAULT_CONFIGURE_OPTS}
-      BUILD_COMMAND        $(MAKE) all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      INSTALL_COMMAND      $(MAKE) install_sw AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      INSTALL_COMMAND      make install_sw AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      BUILD_BYPRODUCTS     ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libssl.a ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libcrypto.a
       )
     set(LIBOPENSSL_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libssl.a ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libcrypto.a)
     set(LIBOPENSSL_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
@@ -1155,8 +1160,9 @@ if(WITH_LIBUNIXODBC STREQUAL "EXTERNAL")
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND    <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external # ${DEFAULT_CONFIGURE_OPTS}
-      BUILD_COMMAND        $(MAKE) AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      INSTALL_COMMAND      $(MAKE) install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      BUILD_COMMAND        make AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      BUILD_BYPRODUCTS     ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libodbc.so
       )
     set(LIBUNIXODBC_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libodbc.so)
     set(LIBUNIXODBC_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -911,6 +911,8 @@ if(WITH_LIBEXPAT STREQUAL "EXTERNAL")
   set(LIBEXPAT_TARGET libexpat)
   list(APPEND EP_TARGETS ${LIBEXPAT_TARGET})
   if(UNIX)
+    set(LIBEXPAT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libexpat.a)
+    set(LIBEXPAT_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/expat)
     externalproject_add(${LIBEXPAT_TARGET}
       URL                  ${WITH_LIBEXPAT_URL}
       LOG_BUILD            TRUE
@@ -920,10 +922,8 @@ if(WITH_LIBEXPAT STREQUAL "EXTERNAL")
       CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS} --without-xmlwf  --without-docbook
       BUILD_COMMAND        make AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      BUILD_BYPRODUCTS     ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libexpat.a
+      BUILD_BYPRODUCTS     ${LIBEXPAT_LIBS}
       )
-    set(LIBEXPAT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libexpat.a)
-    set(LIBEXPAT_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/expat)
   elseif(WIN32)
     set(LIBEXPAT_LIBS ${WINDOWS_EXTERNAL_LIB_DIR}/libexpat.lib)
     set(LIBEXPAT_INCLUDES ${WINDOWS_EXTERNAL_INCLUDE_DIR})
@@ -959,6 +959,8 @@ if(WITH_LIBJANSSON STREQUAL "EXTERNAL")
   set(LIBJANSSON_TARGET libjansson)
   list(APPEND EP_TARGETS ${LIBJANSSON_TARGET})
   if(UNIX)
+    set(LIBJANSSON_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libjansson.a)
+    set(LIBJANSSON_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/jansson)
     externalproject_add(${LIBJANSSON_TARGET}
       URL                  ${WITH_LIBJANSSON_URL}
       LOG_BUILD            TRUE
@@ -968,10 +970,8 @@ if(WITH_LIBJANSSON STREQUAL "EXTERNAL")
       CONFIGURE_COMMAND    ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      BUILD_BYPRODUCTS     ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libjansson.a
+      BUILD_BYPRODUCTS     ${LIBJANSSON_LIBS}
       )
-    set(LIBJANSSON_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libjansson.a)
-    set(LIBJANSSON_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include/jansson)
   else(UNIX)
     # WIN32
     set(LIBJANSSON_LIBS ${WINDOWS_EXTERNAL_LIB_DIR}/jansson64.lib)
@@ -1038,6 +1038,8 @@ endif(UNIX)
 if(UNIX)
   if(WITH_LIBEDIT STREQUAL "EXTERNAL")
     set(LIBEDIT_TARGET libedit)
+    set(LIBEDIT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libedit.a)
+    set(LIBEDIT_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
     externalproject_add(${LIBEDIT_TARGET}
       URL                  ${WITH_LIBEDIT_URL}
       LOG_BUILD            TRUE
@@ -1047,13 +1049,11 @@ if(UNIX)
       CONFIGURE_COMMAND    "LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/external/lib" ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      BUILD_BYPRODUCTS     ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libedit.a
+      BUILD_BYPRODUCTS     ${LIBEDIT_LIBS}
       )
     if(TARGET ${LIBNCURSES_TARGET})
       add_dependencies(${LIBEDIT_TARGET} ${LIBNCURSES_TARGET})
     endif()
-    set(LIBEDIT_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libedit.a)
-    set(LIBEDIT_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
     list(APPEND EP_TARGETS ${LIBEDIT_TARGET})
   elseif(WITH_LIBEDIT STREQUAL "SYSTEM")
     find_library(LIBEDIT_LIBS NAMES libedit.a PATHS ${WITH_EXTERNAL_LIBS_PATH} ${WITH_LIBEDIT_ROOT_PATH}/lib REQUIRED)
@@ -1079,6 +1079,8 @@ if(WIN32) # msvc-built lz4 v1.9.2 libraries
     COMMAND ${CMAKE_COMMAND} -E copy ${LZ4_DLL} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/liblz4.dll
   )
 else()
+  set(LZ4_INCLUDES  ${CMAKE_BINARY_DIR}/external/Source/lz4/lib)
+  set(LZ4_LIBS      ${CMAKE_BINARY_DIR}/external/Source/lz4/lib/liblz4.a)
   externalproject_add(${LZ4_TARGET}
     GIT_REPOSITORY https://github.com/lz4/lz4
     GIT_TAG fdf2ef5             # https://github.com/lz4/lz4/releases/tag/v1.9.2
@@ -1086,10 +1088,8 @@ else()
     BUILD_IN_SOURCE true        # lz4 Makefile is designed to run locally
     BUILD_COMMAND make CFLAGS="-fPIC"  # to allow static linking in shared library
     INSTALL_COMMAND ""          # suppress install
-    BUILD_BYPRODUCTS            ${CMAKE_CURRENT_BINARY_DIR}/external/Source/lz4/lib/liblz4.a
+    BUILD_BYPRODUCTS            ${LZ4_LIBS}
   )
-  set(LZ4_INCLUDES ${CMAKE_BINARY_DIR}/external/Source/lz4/lib)
-  set(LZ4_LIBS ${CMAKE_BINARY_DIR}/external/Source/lz4/lib/liblz4.a)
 endif()
 list(APPEND EP_LIBS ${LZ4_LIBS})
 list(APPEND EP_INCLUDES ${LZ4_INCLUDES})
@@ -1110,6 +1110,8 @@ if(WITH_LIBOPENSSL STREQUAL "EXTERNAL")
   if(UNIX)
     #compile OpenSSL library given an internet url to a OpenSSL archive
     #e.g. https://www.openssl.org/source/openssl-1.1.1f.tar.gz
+    set(LIBOPENSSL_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libssl.a ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libcrypto.a)
+    set(LIBOPENSSL_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
     externalproject_add(${LIBOPENSSL_TARGET}
       URL                  ${WITH_LIBOPENSSL_URL}
       LOG_CONFIGURE        TRUE
@@ -1120,10 +1122,8 @@ if(WITH_LIBOPENSSL STREQUAL "EXTERNAL")
       CONFIGURE_COMMAND    <SOURCE_DIR>/config --prefix=${CMAKE_CURRENT_BINARY_DIR}/external no-shared # ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install_sw AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      BUILD_BYPRODUCTS     ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libssl.a ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libcrypto.a
+      BUILD_BYPRODUCTS     ${LIBOPENSSL_LIBS}
       )
-    set(LIBOPENSSL_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libssl.a ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libcrypto.a)
-    set(LIBOPENSSL_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
     list(APPEND EP_TARGETS ${LIBOPENSSL_TARGET})
   else(UNIX)
     set(LIBOPENSSL_LIBS ${WINDOWS_EXTERNAL_DIR}/openssl/lib/libssl.lib)
@@ -1152,6 +1152,8 @@ if(WITH_LIBUNIXODBC STREQUAL "EXTERNAL")
   if(UNIX)
     #compile unixODBC library given an internet url to a unixODBC archive
     #e.g. http://www.unixodbc.org/unixODBC-2.3.9.tar.gz
+    set(LIBUNIXODBC_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libodbc.so)
+    set(LIBUNIXODBC_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
     externalproject_add(${LIBUNIXODBC_TARGET}
       URL                  ${WITH_LIBUNIXODBC_URL}
       LOG_CONFIGURE        TRUE
@@ -1162,10 +1164,8 @@ if(WITH_LIBUNIXODBC STREQUAL "EXTERNAL")
       CONFIGURE_COMMAND    <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external # ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      BUILD_BYPRODUCTS     ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libodbc.so
+      BUILD_BYPRODUCTS     ${LIBUNIXODBC_LIBS}
       )
-    set(LIBUNIXODBC_LIBS ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libodbc.so)
-    set(LIBUNIXODBC_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/external/include)
     list(APPEND EP_TARGETS ${LIBUNIXODBC_TARGET})
   endif(UNIX)
 else(WITH_LIBUNIXODBC STREQUAL "EXTERNAL")
@@ -1181,6 +1181,7 @@ endif(WIN32)
 
 # rapidjson
 set(RAPIDJSON_TARGET rapidjson)
+set(RAPIDJSON_INCLUDES ${CMAKE_BINARY_DIR}/external/Source/rapidjson/include)
 externalproject_add(${RAPIDJSON_TARGET}
   # tried URL but archive gets downloaded every time. URL_MD5 may help
   URL                  ${WITH_RAPIDJSON_URL}
@@ -1195,10 +1196,10 @@ externalproject_add(${RAPIDJSON_TARGET}
   CMAKE_CACHE_ARGS     -DRAPIDJSON_BUILD_TESTS:STRING=off
                        -DRAPIDJSON_BUILD_DOC:STRING=off
                        -DRAPIDJSON_BUILD_EXAMPLES:STRING=off
+  BUILD_BYPRODUCTS     ${RAPIDJSON_INCLUDES}
 )
-# add to include directories
-include_directories(${CMAKE_BINARY_DIR}/external/Source/rapidjson/include)
 # add to external project targets
+list(APPEND EP_INCLUDES ${RAPIDJSON_INCLUDES})
 list(APPEND EP_TARGETS ${RAPIDJSON_TARGET})
 
 if(WITH_JDBC AND EXISTS ${CMAKE_SOURCE_DIR}/cubrid-jdbc/src)

--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,7 @@ script_dir=$(dirname $(readlink -f $0))
 # variables for options
 build_target="x86_64"
 build_mode="release"
+build_generator="make"
 source_dir=`pwd`
 default_java_dir="/usr/lib/jvm/java"
 java_dir=""
@@ -267,7 +268,14 @@ function build_configure ()
   else
     configure_dir="$source_dir"
   fi
-  cmake -E chdir $build_dir cmake $configure_prefix $configure_options $source_dir
+
+  generate_opt=""
+	if [ "$build_generator" = "ninja" ]; then
+    generate_opt="-G Ninja"
+	fi
+	
+  cmake -E chdir $build_dir cmake $configure_prefix $configure_options $source_dir $generate_opt
+
   [ $? -eq 0 ] && print_result "OK" || print_fatal "Configuring failed"
 }
 
@@ -454,6 +462,7 @@ function show_usage ()
   echo "  -m      Set build mode(release, debug or coverage); [default: release]"
   echo "  -i      Increase build number; [default: no]"
   echo "  -a      Run autogen.sh before build; [default: yes]"
+  echo "  -g      Specifies the generator for a build (make, ninja); [default: make]"
   echo "  -c opts Set configure options; [default: NONE]"
   echo "  -s path Set source path; [default: current directory]"
   echo "  -b path Set build path; [default: <source path>/build_<mode>_<target>]"
@@ -483,10 +492,11 @@ function show_usage ()
 
 function get_options ()
 {
-  while getopts ":t:m:is:b:p:o:aj:c:z:vh" opt; do
+  while getopts ":t:m:g:is:b:p:o:aj:c:z:vh" opt; do
     case $opt in
       t ) build_target="$OPTARG" ;;
       m ) build_mode="$OPTARG" ;;
+      g ) build_generator="$OPTARG" ;;
       s ) source_dir="$OPTARG" ;;
       b ) build_dir="$OPTARG" ;;
       p ) prefix_dir="$OPTARG" ;;
@@ -519,6 +529,11 @@ function get_options ()
   case $build_mode in
     release|debug|coverage);;
     *) show_usage; print_fatal "Mode [$build_mode] is not valid mode" ;;
+  esac
+
+  case $build_generator in
+    make|ninja);;
+    *) show_usage; print_fatal "Generator [$build_generator] is not valid mode" ;;
   esac
 
   if [ "x$build_dir" = "x" ]; then

--- a/build.sh
+++ b/build.sh
@@ -270,9 +270,9 @@ function build_configure ()
   fi
 
   generate_opt=""
-	if [ "$build_generator" = "ninja" ]; then
+  if [ "$build_generator" = "ninja" ]; then
     generate_opt="-G Ninja"
-	fi
+  fi
 	
   cmake -E chdir $build_dir cmake $configure_prefix $configure_options $source_dir $generate_opt
 
@@ -299,7 +299,14 @@ function build_install ()
 {
   # make install
   print_check "Installing"
-  cmake --build $build_dir --target install
+
+  chdir_command="cmake -E chdir $build_dir"
+  if [ "$build_generator" = "ninja" ]; then
+    $chdir_command ninja install
+	else
+    $chdir_command make install
+  fi
+
   [ $? -eq 0 ] && print_result "OK" || print_fatal "Installation failed"
 }
 

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -651,6 +651,7 @@ target_external_dependencies(cubridsa
   LIBEDIT
   LIBOPENSSL
   LZ4
+  RAPIDJSON
   )
 target_include_directories(cubridsa PRIVATE
   ${FLEX_INCLUDE_DIRS}

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -647,7 +647,6 @@ endif(UNIX)
 target_external_dependencies(cubridsa
   LIBEXPAT
   LIBJANSSON
-  LIBEXPAT
   LIBEDIT
   LIBOPENSSL
   LZ4


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24570

I've added `-g` option to specify CMake Generator in `build.sh`. Now, `-g make` and `-g ninja` are supported.
In the build folder (e.g. build_x86_64_debug), please try `ninja && ninja install`.

If the ninja generator is not found, please install by the following
```
yum install ninja-build
```