### PR TITLE
[CBRD-24567] terminate with exit () instead of _exit () for the GCOV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,9 +469,9 @@ endif(JNI_FOUND)
 
 # Build types
 if(CMAKE_BUILD_TYPE MATCHES "Coverage")
-  set(CMAKE_CXX_FLAGS_COVERAGE "-g -O0 --coverage -fprofile-arcs -ftest-coverage -std=c++17"
+  set(CMAKE_CXX_FLAGS_COVERAGE "-g -O0 --coverage -fprofile-arcs -ftest-coverage -std=c++17 -D_GCOV"
     CACHE STRING "Flags used by the c++ compiler during coverage build." FORCE)
-  set(CMAKE_C_FLAGS_COVERAGE "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+  set(CMAKE_C_FLAGS_COVERAGE "-g -O0 --coverage -fprofile-arcs -ftest-coverage -D_GCOV"
     CACHE STRING "Flags used by the c compiler during coverage build." FORCE)
   set(CMAKE_EXE_LINKER_FLAGS_COVERAGE ""
     CACHE STRING "Flags used for linking binaries during coverage build." FORCE)

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1643,7 +1643,11 @@ cas_sig_handler (int signo)
   cas_free (true);
   as_info->pid = 0;
   as_info->uts_status = UTS_STATUS_RESTART;
+#ifdef _GCOV
+  exit (0);
+#else
   _exit (0);
+#endif
 }
 
 static void


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24567

**Purpose**
* to flush coverage data when the CAS receives SIGTERM.

**Implementation**
N/A

**Remarks**