### PR TITLE
[CBRD-24018] Segment fault occurs when there are more than 33 analytic functions in the select list.

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -6618,7 +6618,7 @@ qo_optimize_queries (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *co
        * statement to get targets to update. We should check whether it was already single-table-optimized. Here is an
        * example: CREATE TABLE t(p INT, c INT, x INT); INSERT INTO t VALUES(1, 11, 0), (1, 12, 0), (2, 21, 0); UPDATE t
        * SET x=0 WHERE c IN (SELECT c FROM t START WITH p=1 CONNECT BY PRIOR c=p); */
-      if (node->info.query.q.select.connect_by != NULL && !PT_IS_VALUE_NODE (node->info.query.q.select.where)
+      if (node->info.query.q.select.connect_by != NULL
 	  && !node->info.query.q.select.after_cb_filter && !node->info.query.q.select.single_table_opt)
 	{
 	  PT_NODE *join_part = NULL;

--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -5497,7 +5497,7 @@ qo_rewrite_outerjoin (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
 	      for (expr = node->info.query.q.select.where; expr; expr = expr->next)
 		{
 		  if (expr->node_type == PT_EXPR && expr->info.expr.location == 0 && expr->info.expr.op != PT_IS_NULL
-		      && expr->or_next == NULL)
+		      && expr->or_next == NULL && expr->info.expr.op != PT_AND && expr->info.expr.op != PT_OR)
 		    {
 		      save_next = expr->next;
 		      expr->next = NULL;

--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -48,6 +48,7 @@ struct spec_id_info
 {
   UINTPTR id;
   bool appears;
+  bool nullable;
 };
 
 typedef struct to_dot_info TO_DOT_INFO;
@@ -189,6 +190,50 @@ qo_check_nullable_expr (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int 
 	case PT_CONCAT_WS:
 	  /* NEED FUTURE OPTIMIZATION */
 	  (*nullable_cntp)++;
+	  break;
+	default:
+	  break;
+	}
+    }
+
+  return node;
+}
+
+/*
+ * qo_check_nullable_expr_with_spec () -
+ *   return:
+ *   parser(in):
+ *   node(in):
+ *   arg(in):
+ *   continue_walk(in):
+ */
+PT_NODE *
+qo_check_nullable_expr_with_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
+{
+  SPEC_ID_INFO *info = (SPEC_ID_INFO *) arg;
+
+  if (node->node_type == PT_EXPR)
+    {
+      /* check for nullable term: expr(..., NULL, ...) can be non-NULL */
+      switch (node->info.expr.op)
+	{
+	case PT_IS_NULL:
+	case PT_CASE:
+	case PT_COALESCE:
+	case PT_NVL:
+	case PT_NVL2:
+	case PT_DECODE:
+	case PT_IF:
+	case PT_IFNULL:
+	case PT_ISNULL:
+	case PT_CONCAT_WS:
+	    info->appears = false;
+	    parser_walk_tree (parser, node, qo_get_name_by_spec_id, info, NULL, NULL);
+	    if (info->appears)
+	      {
+		info->nullable = true;
+		*continue_walk = PT_STOP_WALK;
+	      }
 	  break;
 	default:
 	  break;
@@ -5410,10 +5455,9 @@ qo_apply_range_intersection (PARSER_CONTEXT * parser, PT_NODE ** wherep)
 static PT_NODE *
 qo_rewrite_outerjoin (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
 {
-  PT_NODE *spec, *prev_spec, *expr, *ns;
-  SPEC_ID_INFO info;
+  PT_NODE *spec, *prev_spec, *expr, *ns, *save_next;
+  SPEC_ID_INFO info, info_spec;
   RESET_LOCATION_INFO locate_info;
-  int nullable_cnt;		/* nullable terms count */
   bool rewrite_again;
 
   if (node->node_type != PT_SELECT)
@@ -5435,19 +5479,19 @@ qo_rewrite_outerjoin (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
       prev_spec = NULL;
       for (spec = node->info.query.q.select.from; spec; prev_spec = spec, spec = spec->next)
 	{
-	  if (spec->info.spec.join_type == PT_JOIN_LEFT_OUTER || spec->info.spec.join_type == PT_JOIN_RIGHT_OUTER)
+	  if (spec->info.spec.join_type == PT_JOIN_LEFT_OUTER || (spec->info.spec.join_type == PT_JOIN_RIGHT_OUTER && prev_spec))
 	    {
 	      if (spec->info.spec.join_type == PT_JOIN_LEFT_OUTER)
 		{
-		  info.id = spec->info.spec.id;
+		  info.id = info_spec.id = spec->info.spec.id;
 		}
-	      else if (prev_spec != NULL)
+	      else
 		{
-		  info.id = prev_spec->info.spec.id;
+		  info.id = info_spec.id = prev_spec->info.spec.id;
 		}
 
-	      info.appears = false;
-	      nullable_cnt = 0;
+	      info_spec.appears = false;
+	      info.nullable = false;
 
 	      /* search where list */
 	      for (expr = node->info.query.q.select.where; expr; expr = expr->next)
@@ -5455,10 +5499,15 @@ qo_rewrite_outerjoin (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
 		  if (expr->node_type == PT_EXPR && expr->info.expr.location == 0 && expr->info.expr.op != PT_IS_NULL
 		      && expr->or_next == NULL)
 		    {
-		      (void) parser_walk_leaves (parser, expr, qo_get_name_by_spec_id, &info, qo_check_nullable_expr,
-						 &nullable_cnt);
+		      save_next = expr->next;
+		      expr->next = NULL;
+		      (void) parser_walk_tree (parser, expr, NULL, NULL, qo_check_nullable_expr_with_spec, &info);
+		      (void) parser_walk_tree (parser, expr, qo_get_name_by_spec_id, &info_spec, NULL, NULL);
+		      expr->next = save_next;
+
 		      /* have found a term which makes outer join to inner */
-		      if (info.appears && nullable_cnt == 0)
+		      /* there are predicate referenced by spec and all preds are not nullable */
+		      if (info_spec.appears && !info.nullable)
 			{
 			  rewrite_again = true;
 			  spec->info.spec.join_type = PT_JOIN_INNER;

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -706,7 +706,7 @@ struct json_t;
 #define PT_IS_FALSE_WHERE_VALUE(node) \
  (((node) != NULL && (node)->node_type == PT_VALUE \
   && ((node)->type_enum == PT_TYPE_NULL \
-       || ((node)->type_enum == PT_TYPE_SET \
+       || (PT_IS_SET_TYPE (node) \
            && ((node)->info.value.data_value.set == NULL)))) ? true : false)
 
 #define PT_IS_SPEC_REAL_TABLE(spec_) PT_SPEC_IS_ENTITY(spec_)

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -2501,7 +2501,7 @@ pt_split_join_preds (PARSER_CONTEXT * parser, PT_NODE * predicates, PT_NODE ** j
     {
       bool has_filter_pred = false;
 
-      assert (PT_IS_EXPR_NODE (current_conj));
+      assert (PT_IS_EXPR_NODE (current_conj) || PT_IS_VALUE_NODE (current_conj));
       /* It is either fully CNF or not at all. */
       assert (!(current_conj->next != NULL
 		&& (PT_IS_EXPR_NODE_WITH_OPERATOR (current_conj, PT_AND)
@@ -2511,7 +2511,7 @@ pt_split_join_preds (PARSER_CONTEXT * parser, PT_NODE * predicates, PT_NODE ** j
 
       for (current_pred = current_conj; current_pred != NULL; current_pred = current_pred->or_next)
 	{
-	  assert (PT_IS_EXPR_NODE (current_pred));
+	  assert (PT_IS_EXPR_NODE (current_pred) || PT_IS_VALUE_NODE (current_pred));
 	  /* It is either fully CNF or not at all. */
 	  assert (!(current_pred->or_next != NULL
 		    && (PT_IS_EXPR_NODE_WITH_OPERATOR (current_pred, PT_AND)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -14255,6 +14255,12 @@ pt_analytic_to_metadomain (ANALYTIC_TYPE * func_p, PT_NODE * sort_list, ANALYTIC
       func_meta->key[func_meta->key_size] = idx;
       func_meta->key_size++;
       func_meta->level++;
+
+      if (func_meta->key_size >= ANALYTIC_OPT_MAX_FUNCTIONS)
+	{
+	  /* no more space in  index */
+	  return false;
+	}
     }
 
   /* all ok */
@@ -14940,6 +14946,13 @@ pt_optimize_analytic_list (PARSER_CONTEXT * parser, ANALYTIC_INFO * info, bool *
   for (func_p = info->head_list, sort_list = info->sort_lists; func_p != NULL && sort_list != NULL;
        func_p = func_p->next, sort_list = sort_list->next, af_count++)
     {
+      if (af_count >= ANALYTIC_OPT_MAX_FUNCTIONS)
+	{
+	  /* analytic function index overflow, we'll do it the old fashioned way */
+	  *no_optimization = true;
+	  return NULL;
+	}
+
       if (!pt_analytic_to_metadomain (func_p, sort_list->info.pointer.node, &af_meta[af_count], sc_index, &sc_count))
 	{
 	  /* sort spec index overflow, we'll do it the old fashioned way */

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -13395,7 +13395,7 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
   int error = NO_ERROR;
   PT_NODE *class_;
   PT_NODE *values = NULL;
-  PT_NODE *attr_list;
+  PT_NODE *attr_list, *value_clauses, *query;
   PT_NODE *update = NULL;
   PT_NODE *with = NULL;
   int save_au;
@@ -13414,6 +13414,19 @@ do_prepare_insert (PARSER_CONTEXT * parser, PT_NODE * statement)
     {
       assert (false);
       goto cleanup;
+    }
+
+  /* there can be no results, this is a compile time false where clause */
+  value_clauses = statement->info.insert.value_clauses;
+  if (value_clauses && value_clauses->info.node_list.list_type == PT_IS_SUBQUERY)
+    {
+      query = value_clauses->info.node_list.list;
+      if (PT_IS_SELECT (query) && pt_false_where (parser, query))
+	{
+	  /* tell to the execute routine that there's no XASL to execute */
+	  statement->xasl_id = NULL;
+	  goto cleanup;
+	}
     }
 
   statement->etc = NULL;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -4704,7 +4704,7 @@ wrapup:
     result = (gbstate.state == NO_ERROR || gbstate.state == SORT_PUT_STOP) ? NO_ERROR : ER_FAILED;
 
     /* check merge result */
-    if (XASL_IS_FLAGED (xasl, XASL_IS_MERGE_QUERY) && list_id->tuple_cnt != gbstate.input_recs)
+    if (result == NO_ERROR && XASL_IS_FLAGED (xasl, XASL_IS_MERGE_QUERY) && list_id->tuple_cnt != gbstate.input_recs)
       {
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MERGE_TOO_MANY_SOURCE_ROWS, 0);
 	result = ER_FAILED;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24018

backport for below.
CBRD-24018 Segment fault occurs when there are more than 33 analytic functions in the select list.
CBRD-23709 error message is displayed incorrectly in 'MERGE' clause
CBRD-23754 Outer join is incorrectly changed to inner join in queries that contain OR operation.
CBRD-23767 Index scan cannot be used in hierarchical queries when there is a value predicate like '1=1'.
CBRD-24104 'ERROR: System error (generate attr)' message occurs in INSERT + SELECT query
