### PR TITLE
[CBRD-23978] (patch to 11.0.10) execute command returns error in prepared statement includes DECODE

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -11363,7 +11363,15 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 
 		  if (rhs->node_type != PT_HOST_VAR)
 		    {
-		      d = tp_domain_resolve_default (lhs_dbtype);
+		      // TODO: It should be considered for parameterized types, refer to PT_IS_PARAMETERIZED_TYPE()
+		      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
+			{
+			  d = tp_domain_resolve (lhs_dbtype, NULL, sci.prec, sci.scale, NULL, 0);
+			}
+		      else
+			{
+			  d = tp_domain_resolve_default (lhs_dbtype);
+			}
 		    }
 		  else
 		    {
@@ -11396,7 +11404,15 @@ pt_assignment_compatible (PARSER_CONTEXT * parser, PT_NODE * lhs, PT_NODE * rhs)
 			    }
 			  else
 			    {
-			      d = tp_domain_resolve_default (lhs_dbtype);
+			      // TODO: It should be considered for parameterized types, refer to PT_IS_PARAMETERIZED_TYPE()
+			      if (lhs->type_enum == PT_TYPE_NUMERIC && lhs->data_type != NULL)
+				{
+				  d = tp_domain_resolve (lhs_dbtype, NULL, sci.prec, sci.scale, NULL, 0);
+				}
+			      else
+				{
+				  d = tp_domain_resolve_default (lhs_dbtype);
+				}
 			    }
 
 			  if (PT_HAS_COLLATION (lhs->type_enum))

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5489,8 +5489,8 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 	{
 	  PT_NODE *temp = NULL;
 	  int precision = 0, scale = 0;
-	  int units = LANG_SYS_CODESET; /* code set */
-	  int collation_id = LANG_SYS_COLLATION; /* collation_id */
+	  int units = LANG_SYS_CODESET;	/* code set */
+	  int collation_id = LANG_SYS_COLLATION;	/* collation_id */
 	  bool keep_searching = true;
 	  for (temp = arg2->data_type; temp != NULL && keep_searching; temp = temp->next)
 	    {
@@ -10276,9 +10276,10 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	  node->type_enum = PT_TYPE_NONE;
 	  break;
 	}
-      if (common_type == PT_TYPE_MAYBE)
+
+      if (common_type == PT_TYPE_MAYBE && arg1_type != PT_TYPE_NULL && arg2_type != PT_TYPE_NULL)
 	{
-	  common_type = (arg1_type == PT_TYPE_MAYBE && arg2_type != PT_TYPE_NULL) ? arg2_type : arg1_type;
+	  common_type = (arg1_type == PT_TYPE_MAYBE) ? arg2_type : arg1_type;
 	}
 
       if (common_type == PT_TYPE_MAYBE)

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5489,8 +5489,8 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 	{
 	  PT_NODE *temp = NULL;
 	  int precision = 0, scale = 0;
-	  int units = LANG_SYS_CODESET;	/* code set */
-	  int collation_id = LANG_SYS_COLLATION;	/* collation_id */
+	  int units = LANG_SYS_CODESET; /* code set */
+	  int collation_id = LANG_SYS_COLLATION; /* collation_id */
 	  bool keep_searching = true;
 	  for (temp = arg2->data_type; temp != NULL && keep_searching; temp = temp->next)
 	    {
@@ -5575,7 +5575,6 @@ pt_coerce_range_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE
 	      if (PT_IS_STRING_TYPE (common_type) && PT_IS_STRING_TYPE (temp->type_enum))
 		{
 		  /* A bigger codesets's number can represent more characters. */
-		  /* to_do : check to use functions pt_common_collation() or pt_make_cast_with_compatble_info(). */
 		  if (units < temp->info.data_type.units)
 		    {
 		      units = temp->info.data_type.units;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23978
http://jira.cubrid.org/browse/CBRD-23831
http://jira.cubrid.org/browse/CBRD-23874

This is a backport for the above issues.
