### PR TITLE
[CBRD-24580] Set the request from consumer to producer only by the consumer thread

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11010,7 +11010,6 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 	  cdc_log ("cdc_loginfo_producer_execute : cdc_Gl.producer.state is in CDC_PRODUCER_STATE_WAIT ");
 
 	  cdc_Gl.producer.state = CDC_PRODUCER_STATE_WAIT;
-	  cdc_Gl.producer.request = CDC_REQUEST_PRODUCER_NONE;
 
 	  pthread_mutex_lock (&cdc_Gl.producer.lock);
 	  pthread_cond_wait (&cdc_Gl.producer.wait_cond, &cdc_Gl.producer.lock);
@@ -13900,6 +13899,8 @@ void
 cdc_wakeup_producer ()
 {
   cdc_log ("cdc_wakeup_producer : consumer request the producer to wakeup");
+
+  cdc_Gl.producer.request = CDC_REQUEST_PRODUCER_NONE;
 
   pthread_cond_signal (&cdc_Gl.producer.wait_cond);
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24580

Purpose

There are two threads. CDC log consumer and producer. 
Consumer and producer pass requests to each other through cdc_Gl. 
However, the problem occurred when the producer also modified the request transmitted from the consumer to the producer. (`cdc_Gl.producer.request`)

`cdc_Gl.producer.request` is only allowed to be set by the consumer, who calls `cdc_wakeup_producer`, `cdc_pause_producer`, and `cdc_kill_producer`. 