### PR TITLE
[CBRD-24585] Explicit commit/rollback statement causes invalid XASL error in SP's query

### DIFF
--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -168,12 +168,26 @@ namespace cubmethod
       {
 	if (handler->execute (request) == NO_ERROR)
 	  {
+	    int error = handler->execute (request);
+	  }
+	if (error == NO_ERROR)
+	  {
 	    /* register query_id for out resultset */
 	    const cubmethod::query_result &qresult = handler->get_result();
 	    if (qresult.stmt_type == CUBRID_STMT_SELECT)
 	      {
 		uint64_t qid = (uint64_t) handler->get_execute_info ().qresult_info.query_id;
 		m_qid_handler_map[qid] = request.handler_id;
+	      }
+	  }
+	else
+	  {
+	    else
+	      {
+		/* XASL cache is not found */
+		m_error_ctx.clear ();
+		handler->prepare_retry ();
+		handler->execute (request);
 	      }
 	  }
       }

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -166,10 +166,7 @@ namespace cubmethod
       }
     else
       {
-	if (handler->execute (request) == NO_ERROR)
-	  {
-	    int error = handler->execute (request);
-	  }
+	int error = handler->execute (request);
 	if (error == NO_ERROR)
 	  {
 	    /* register query_id for out resultset */
@@ -182,13 +179,10 @@ namespace cubmethod
 	  }
 	else
 	  {
-	    else
-	      {
-		/* XASL cache is not found */
-		m_error_ctx.clear ();
-		handler->prepare_retry ();
-		handler->execute (request);
-	      }
+	    /* XASL cache is not found */
+	    m_error_ctx.clear ();
+	    handler->prepare_retry ();
+	    handler->execute (request);
 	  }
       }
 

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -191,6 +191,16 @@ namespace cubmethod
   }
 
   int
+  query_handler::prepare_retry ()
+  {
+    if (is_prepared ())
+      {
+	return prepare (m_sql_stmt, m_prepare_flag);
+      }
+    return ER_FAILED;
+  }
+
+  int
   query_handler::execute (const execute_request &request)
   {
     int error = NO_ERROR;

--- a/src/method/method_query_handler.hpp
+++ b/src/method/method_query_handler.hpp
@@ -77,6 +77,7 @@ namespace cubmethod
 
       /* request */
       int prepare (std::string sql, int flag);
+      int prepare_retry ();
       int execute (const execute_request &request);
       get_generated_keys_info generated_keys ();
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -89,6 +89,7 @@
 #include "tz_support.h"
 #include "dbtype.h"
 #include "crypt_opfunc.h"
+#include "method_callback.hpp"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -4588,6 +4588,7 @@ do_commit (PARSER_CONTEXT * parser, PT_NODE * statement)
   /* Row count should be reset to -1 for explicit commits (i.e: commit statements) but should not be reset in
    * AUTO_COMMIT mode. This is the best place to reset it for commit statements. */
   db_update_row_count_cache (-1);
+  cubmethod::get_callback_handler ()->free_query_handle_all (true);
   return tran_commit (statement->info.commit_work.retain_lock ? true : false);
 }
 
@@ -4639,6 +4640,8 @@ do_rollback (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  db_value_clear (&val);
 	}
     }
+
+  cubmethod::get_callback_handler ()->free_query_handle_all (true);
 
   return error;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24585

- Fix SP's statement handler and statement handler cache are not cleared when commit and rollback statements were explicitly executed. It can cause referencing an invalid XASL node that has already been removed from the XASL cache
- Add defense code for query execution failure situation by SP