### PR TITLE
[CBRD-24593] replace select () with poll () in the BROKER

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -3342,12 +3342,12 @@ read_buffer_async (SOCKET sock_fd, char *buf, int size, int timeout)
     }
   while (ret < 0 && errno == EINTR);
 
-  if (ret < 1) /* ERROR OR TIMEOUT */
+  if (ret < 1)			/* ERROR OR TIMEOUT */
     {
       return -1;
     }
 
-  if (po[0].revents & POLLIN) /* RECEIVE NEW REQUEST */
+  if (po[0].revents & POLLOUT)	/* RECEIVE NEW REQUEST */
     {
 	 read_len = READ_FROM_SOCKET (sock_fd, buf, size);
     }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -3372,12 +3372,12 @@ write_buffer_async (SOCKET sock_fd, char *buf, int size, int timeout)
     }
   while (ret < 0 && errno == EINTR);
 
-  if (ret < 1) /* ERROR OR TIMEOUT */
+  if (ret < 1)			/* ERROR OR TIMEOUT */
     {
       return -1;
     }
 
-  if (po[0].revents & POLLOUT) /* RECEIVE NEW REQUEST */
+  if (po[0].revents & POLLOUT)	/* RECEIVE NEW REQUEST */
     {
       write_len = WRITE_TO_SOCKET (sock_fd, buf, size);
     }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1427,7 +1427,7 @@ read_from_client_with_timeout (SOCKET sock_fd, char *buf, int size, int timeout_
 
   if (IS_INVALID_SOCKET (sock_fd))
     {
-	 return -1;
+      return -1;
     }
 
 #ifdef ASYNC_MODE
@@ -1435,9 +1435,9 @@ read_from_client_with_timeout (SOCKET sock_fd, char *buf, int size, int timeout_
     {
       read_len = read_buffer_async (sock_fd, buf, size, timeout_sec);
       if (read_len <= 0)
-        {
-          return -1;
-        }
+	{
+	  return -1;
+	}
 
       buf += read_len;
       size -= read_len;
@@ -1463,7 +1463,7 @@ write_to_client_with_timeout (SOCKET sock_fd, char *buf, int size, int timeout_s
 
   if (IS_INVALID_SOCKET (sock_fd))
     {
-	 return -1;
+      return -1;
     }
 
   while (size > 0)
@@ -1471,9 +1471,9 @@ write_to_client_with_timeout (SOCKET sock_fd, char *buf, int size, int timeout_s
       write_len = write_buffer_async (sock_fd, buf, size, timeout_sec);
 
       if (write_len <= 0)
-        {
-          return -1;
-        }
+	{
+	  return -1;
+	}
 
       buf += write_len;
       size -= write_len;
@@ -3347,9 +3347,9 @@ read_buffer_async (SOCKET sock_fd, char *buf, int size, int timeout)
       return -1;
     }
 
-  if (po[0].revents & POLLOUT)	/* RECEIVE NEW REQUEST */
+  if (po[0].revents & POLLIN)	/* RECEIVE NEW REQUEST */
     {
-	 read_len = READ_FROM_SOCKET (sock_fd, buf, size);
+      read_len = READ_FROM_SOCKET (sock_fd, buf, size);
     }
 
   return read_len;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -265,6 +265,8 @@ static int write_to_client (SOCKET sock_fd, char *buf, int size);
 static int write_to_client_with_timeout (SOCKET sock_fd, char *buf, int size, int timeout_sec);
 static int read_from_client (SOCKET sock_fd, char *buf, int size);
 static int read_from_client_with_timeout (SOCKET sock_fd, char *buf, int size, int timeout_sec);
+static int read_buffer_async (SOCKET sock_fd, char *buf, int size, int timeout);
+static int write_buffer_async (SOCKET sock_fd, char *buf, int size, int timeout);
 static int run_appl_server (T_APPL_SERVER_INFO * as_info_p, int br_index, int as_index);
 static int stop_appl_server (T_APPL_SERVER_INFO * as_info_p, int br_index, int as_index);
 static void restart_appl_server (T_APPL_SERVER_INFO * as_info_p, int br_index, int as_index);
@@ -1420,50 +1422,31 @@ read_from_client (SOCKET sock_fd, char *buf, int size)
 static int
 read_from_client_with_timeout (SOCKET sock_fd, char *buf, int size, int timeout_sec)
 {
+  int len = size;
   int read_len;
-#ifdef ASYNC_MODE
-  SELECT_MASK read_mask;
-  int nfound;
-  int maxfd;
-  struct timeval timeout_val, *timeout_ptr;
 
-  if (timeout_sec < 0)
+  if (IS_INVALID_SOCKET (sock_fd))
     {
-      timeout_ptr = NULL;
+	 return -1;
     }
-  else
-    {
-      timeout_val.tv_sec = timeout_sec;
-      timeout_val.tv_usec = 0;
-      timeout_ptr = &timeout_val;
-    }
-#endif
 
 #ifdef ASYNC_MODE
-  FD_ZERO (&read_mask);
-  FD_SET (sock_fd, (fd_set *) (&read_mask));
-  maxfd = (int) sock_fd + 1;
-  nfound = select (maxfd, &read_mask, (SELECT_MASK *) 0, (SELECT_MASK *) 0, timeout_ptr);
-  if (nfound < 0)
+  while (size > 0)
     {
-      return -1;
+      read_len = read_buffer_async (sock_fd, buf, size, timeout_sec);
+      if (read_len <= 0)
+        {
+          return -1;
+        }
+
+      buf += read_len;
+      size -= read_len;
     }
+#else
+  read_len = READ_FROM_SOCKET (sock_fd, buf, size);
 #endif
 
-#ifdef ASYNC_MODE
-  if (FD_ISSET (sock_fd, (fd_set *) (&read_mask)))
-    {
-#endif
-      read_len = READ_FROM_SOCKET (sock_fd, buf, size);
-#ifdef ASYNC_MODE
-    }
-  else
-    {
-      return -1;
-    }
-#endif
-
-  return read_len;
+  return len;
 }
 
 static int
@@ -1475,53 +1458,28 @@ write_to_client (SOCKET sock_fd, char *buf, int size)
 static int
 write_to_client_with_timeout (SOCKET sock_fd, char *buf, int size, int timeout_sec)
 {
-  int write_len;
-#ifdef ASYNC_MODE
-  SELECT_MASK write_mask;
-  int nfound;
-  int maxfd;
-  struct timeval timeout_val, *timeout_ptr;
-
-  if (timeout_sec < 0)
-    {
-      timeout_ptr = NULL;
-    }
-  else
-    {
-      timeout_val.tv_sec = timeout_sec;
-      timeout_val.tv_usec = 0;
-      timeout_ptr = &timeout_val;
-    }
-#endif
+  int len = size;
+  int write_len = -1;
 
   if (IS_INVALID_SOCKET (sock_fd))
-    return -1;
-
-#ifdef ASYNC_MODE
-  FD_ZERO (&write_mask);
-  FD_SET (sock_fd, (fd_set *) (&write_mask));
-  maxfd = (int) sock_fd + 1;
-  nfound = select (maxfd, (SELECT_MASK *) 0, &write_mask, (SELECT_MASK *) 0, timeout_ptr);
-  if (nfound < 0)
     {
-      return -1;
+	 return -1;
     }
-#endif
 
-#ifdef ASYNC_MODE
-  if (FD_ISSET (sock_fd, (fd_set *) (&write_mask)))
+  while (size > 0)
     {
-#endif
-      write_len = WRITE_TO_SOCKET (sock_fd, buf, size);
-#ifdef ASYNC_MODE
-    }
-  else
-    {
-      return -1;
-    }
-#endif
+      write_len = write_buffer_async (sock_fd, buf, size, timeout_sec);
 
-  return write_len;
+      if (write_len <= 0)
+        {
+          return -1;
+        }
+
+      buf += write_len;
+      size -= write_len;
+    }
+
+  return len;
 }
 
 /*
@@ -3366,4 +3324,66 @@ get_as_slow_log_filename (char *log_filename, int len, char *broker_name, T_APPL
       // bad name
       log_filename[0] = '\0';
     }
+}
+
+static int
+read_buffer_async (SOCKET sock_fd, char *buf, int size, int timeout)
+{
+  int read_len = -1;
+  struct pollfd po[1] = { {0, 0, 0} };
+  int ret;
+
+  po[0].fd = sock_fd;
+  po[0].events = POLLIN;
+
+  do
+    {
+      ret = poll (po, 1, timeout * 1000);
+    }
+  while (ret < 0 && errno == EINTR);
+
+  if (ret < 1) /* ERROR OR TIMEOUT */
+    {
+      return -1;
+    }
+
+  if (po[0].revents & POLLIN) /* RECEIVE NEW REQUEST */
+    {
+	 read_len = READ_FROM_SOCKET (sock_fd, buf, size);
+    }
+
+  return read_len;
+}
+
+static int
+write_buffer_async (SOCKET sock_fd, char *buf, int size, int timeout)
+{
+  int write_len = -1;
+  struct pollfd po[1] = { {0, 0, 0} };
+  int ret;
+
+#ifdef ASYNC_MODE
+  po[0].fd = sock_fd;
+  po[0].events = POLLOUT;
+
+  do
+    {
+      ret = poll (po, 1, timeout * 1000);
+    }
+  while (ret < 0 && errno == EINTR);
+
+  if (ret < 1) /* ERROR OR TIMEOUT */
+    {
+      return -1;
+    }
+
+  if (po[0].revents & POLLOUT) /* RECEIVE NEW REQUEST */
+    {
+	 write_len = WRITE_TO_SOCKET (sock_fd, buf, size);
+    }
+#else
+  write_len = WRITE_TO_SOCKET (sock_fd, buf, size);
+#endif
+
+  return write_len;
 }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -194,7 +194,7 @@
 	  write_to_client(FD, (char*) &write_val, 4);	\
 	} while (0)
 
-#define JOB_COUNT_MAX		1000000
+#define JOB_COUNT_MAX		130000000
 
 /* num of collecting counts per monitoring interval */
 #define NUM_COLLECT_COUNT_PER_INTVL     4
@@ -1466,6 +1466,7 @@ write_to_client_with_timeout (SOCKET sock_fd, char *buf, int size, int timeout_s
       return -1;
     }
 
+#ifdef ASYNC_MODE
   while (size > 0)
     {
       write_len = write_buffer_async (sock_fd, buf, size, timeout_sec);
@@ -1478,6 +1479,9 @@ write_to_client_with_timeout (SOCKET sock_fd, char *buf, int size, int timeout_s
       buf += write_len;
       size -= write_len;
     }
+#else
+  len = WRITE_TO_SOCKET (sock_fd, buf, size);
+#endif
 
   return len;
 }
@@ -3362,7 +3366,6 @@ write_buffer_async (SOCKET sock_fd, char *buf, int size, int timeout)
   struct pollfd po[1] = { {0, 0, 0} };
   int ret;
 
-#ifdef ASYNC_MODE
   po[0].fd = sock_fd;
   po[0].events = POLLOUT;
 
@@ -3381,9 +3384,6 @@ write_buffer_async (SOCKET sock_fd, char *buf, int size, int timeout)
     {
       write_len = WRITE_TO_SOCKET (sock_fd, buf, size);
     }
-#else
-  write_len = WRITE_TO_SOCKET (sock_fd, buf, size);
-#endif
 
   return write_len;
 }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -3379,7 +3379,7 @@ write_buffer_async (SOCKET sock_fd, char *buf, int size, int timeout)
 
   if (po[0].revents & POLLOUT) /* RECEIVE NEW REQUEST */
     {
-	 write_len = WRITE_TO_SOCKET (sock_fd, buf, size);
+      write_len = WRITE_TO_SOCKET (sock_fd, buf, size);
     }
 #else
   write_len = WRITE_TO_SOCKET (sock_fd, buf, size);

--- a/src/broker/broker_shm.h
+++ b/src/broker/broker_shm.h
@@ -113,7 +113,7 @@
 
 #define		APPL_NAME_LENGTH	128
 
-#define		JOB_QUEUE_MAX_SIZE	2048
+#define		JOB_QUEUE_MAX_SIZE	4096
 
 #define MAX_CRYPT_STR_LENGTH            32
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24593

**Purpose**
* To handle up to 4096 connections simultaneously.
* replace select () system call to poll () because it cannot monitor more than 1024 fds naturally.

**Implementation**
N/A

**Remarks**
* This changes are critical to broker's behavior, **careful review is required**.
* By the way, current CCI able to support up to 2048 connections, we have to modify it also.
* An unit test was completed for simultaneous access of 4,000 clients.