### PR TITLE
[CBRD-24594] fix pr_midxkey_add_elements()

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -9541,7 +9541,7 @@ pr_midxkey_add_elements (DB_VALUE * keyval, DB_VALUE * dbvals, int num_dbvals, s
   else
     {
       /* bound bits */
-      (void) pr_midxkey_init_boundbits (bound_bits, num_dbvals);
+      MIDXKEY_BOUNDBITS_INIT (bound_bits, bitmap_size);
       or_advance (&buf, bitmap_size);
     }
 

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -9541,7 +9541,7 @@ pr_midxkey_add_elements (DB_VALUE * keyval, DB_VALUE * dbvals, int num_dbvals, s
   else
     {
       /* bound bits */
-      (void) pr_midxkey_init_boundbits (bound_bits, bitmap_size);
+      (void) pr_midxkey_init_boundbits (bound_bits, num_dbvals);
       or_advance (&buf, bitmap_size);
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24594

* The parameter value was misrepresenting when calling pr_midxkey_init_boundbits() in the pr_midxkey_add_element() function.
  As a result, if there are more than nine columns, there is a problem that "boundbits" is initialized only for the preceding eight columns.
  
