### PR TITLE
[CBRD-24597] fix coerce strict with char to numeric

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -6261,9 +6261,22 @@ tp_value_coerce_strict (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
 	  {
-	    if (tp_atonumeric (src, target) != NO_ERROR)
+	    DB_VALUE temp;
+
+	    if (tp_atonumeric (src, &temp) != NO_ERROR)
 	      {
-		err = ER_FAILED;
+		if (er_errid () != NO_ERROR)
+		  {
+		    err = DOMAIN_ERROR;
+		  }
+		else
+		  {
+		    err = DOMAIN_INCOMPATIBLE;
+		  }
+	      }
+	    else
+	      {
+		err = tp_value_coerce (&temp, target, desired_domain);
 	      }
 	    break;
 	  }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24597

* When there is an index containing a numeric type and is performed in the prepare-execute method, it can be processed normally or incorrectly depending on the type of value to be bound.

Found in cases where there is an index containing a numeric type and it is done in a prepare-execute manner.
There was an error when the type of value to be bound was a string type such as char or varchar.

There are two places that use tp_atonumeric().
Called when converting character types to NUMERIC types in tp_value_coerc_strict() and tp_value_cast_internal().
First of all, you can see that there is a difference in the behavior after calling tp_atonumeric() in both functions.
tp_value_cast_internal() is calling tp_value_coercce() again.

tp_atonumeric() is replaced with a numeric form, but its precision, scale is not set to the same target that needs to be changed.
In other words, interpret the given string as it is.
Use tp_value_coercce() to change the value created in this way to the desired precision, scale again.

In tp_value_coercase_strict(), there is no process to call tp_value_coercase() to calibrate, so modify it for further processing.

```
drop if exists t2;
create table t2 (a numeric(10,3), b int);
insert into t2 values(1,1);
create index idx on t2 (a, b);
prepare s2 from 'select * from t2 where a <= ?';
execute s2 using '1';

```
