### PR TITLE
[CBRD-24601] Defense code to prevent segfault by function call of NULL pointer object in method_scan (#4018)

### DIFF
--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -48,6 +48,12 @@ namespace cubscan
       if (m_method_group == nullptr) // signature is not initialized
 	{
 	  m_method_group = cubmethod::get_rctx (thread_p)->create_invoke_group (thread_p, *sig_list, true);
+	  if (!m_method_group)
+	    {
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
+		      (size_t) sizeof (cubmethod::method_invoke_group));
+	      return ER_OUT_OF_VIRTUAL_MEMORY;
+	    }
 	}
 
       if (m_list_id == nullptr)
@@ -100,7 +106,7 @@ namespace cubscan
       close_value_array ();
       pr_clear_value_vector (m_arg_vector);
 
-      if (is_final)
+      if (is_final && m_method_group)
 	{
 	  m_method_group->reset (true);
 	  m_method_group->end ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24601

backport of #4018 
