### PR TITLE
[CBRD-24600] Problem with creating the same index with different names

### DIFF
--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -152,8 +152,6 @@ static SM_FUNCTION_INFO *classobj_make_function_index_info (DB_SEQ * func_seq);
 static DB_SEQ *classobj_make_function_index_info_seq (SM_FUNCTION_INFO * func_index_info);
 static SM_CONSTRAINT_COMPATIBILITY classobj_check_index_compatibility (SM_CLASS_CONSTRAINT * constraints,
 								       const DB_CONSTRAINT_TYPE constraint_type,
-								       const SM_PREDICATE_INFO * filter_predicate,
-								       const SM_FUNCTION_INFO * func_index_info,
 								       const SM_CLASS_CONSTRAINT * existing_con,
 								       SM_CLASS_CONSTRAINT ** primary_con);
 static int classobj_check_function_constraint_info (DB_SEQ * constraint_seq, bool * has_function_constraint);
@@ -4059,7 +4057,8 @@ classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons, OID * root_
  */
 SM_CLASS_CONSTRAINT *
 classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAINT_TYPE new_cons, const char **att_names,
-				   const int *asc_desc, const SM_PREDICATE_INFO * filter_predicate)
+				   const int *asc_desc, const SM_PREDICATE_INFO * filter_predicate,
+				   const SM_FUNCTION_INFO * func_index_info)
 {
   SM_CLASS_CONSTRAINT *cons;
   SM_ATTRIBUTE **attp;
@@ -4103,6 +4102,11 @@ classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAIN
 	    {
 	      continue;
 	    }
+	  if (((filter_predicate && !cons->filter_predicate) || (!filter_predicate && cons->filter_predicate))
+	      || ((func_index_info && !cons->func_index_info) || (!func_index_info && cons->func_index_info)))
+	    {
+	      continue;
+	    }
 
 	  len = 0;		/* init */
 	  while (*attp && *namep && !intl_identifier_casecmp ((*attp)->header.name, *namep))
@@ -4112,50 +4116,54 @@ classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAIN
 	      len++;		/* increase name number */
 	    }
 
-	  if (!*attp && !*namep && !classobj_is_possible_constraint (cons->type, new_cons))
+	  if (*attp || *namep || classobj_is_possible_constraint (cons->type, new_cons))
 	    {
-	      for (i = 0; i < len; i++)
+	      continue;
+	    }
+
+	  for (i = 0; i < len; i++)
+	    {
+	      /* if not specified, ascending order */
+	      order = (asc_desc ? asc_desc[i] : 0);
+	      assert (order == 0 || order == 1);
+	      if (order != cons->asc_desc[i])
 		{
-		  /* if not specified, ascending order */
-		  order = (asc_desc ? asc_desc[i] : 0);
-		  assert (order == 0 || order == 1);
-		  if (order != cons->asc_desc[i])
-		    {
-		      break;	/* not match */
-		    }
-		}
-
-	      if (i == len)
-		{
-		  if (filter_predicate)
-		    {
-		      if (!cons->filter_predicate)
-			{
-			  continue;
-			}
-
-		      if (!filter_predicate->pred_string || !cons->filter_predicate->pred_string)
-			{
-			  continue;
-			}
-
-		      if (strcmp (filter_predicate->pred_string, cons->filter_predicate->pred_string))
-			{
-			  continue;
-			}
-		    }
-		  else
-		    {
-		      if (cons->filter_predicate)
-			{
-			  continue;
-			}
-		    }
-
-		  return cons;
+		  break;	/* not match */
 		}
 	    }
 
+	  if (i != len)
+	    {
+	      continue;
+	    }
+
+	  if (filter_predicate)
+	    {
+	      if (!filter_predicate->pred_string || !cons->filter_predicate->pred_string)
+		{
+		  continue;
+		}
+
+	      if (strcmp (filter_predicate->pred_string, cons->filter_predicate->pred_string))
+		{
+		  continue;
+		}
+	    }
+
+	  if (func_index_info)
+	    {
+	      /* expr_str are printed tree, identifiers are already lower case */
+	      if ((func_index_info->attr_index_start != cons->func_index_info->attr_index_start)
+		  || (func_index_info->col_id != cons->func_index_info->col_id)
+		  || (func_index_info->fi_domain->is_desc != cons->func_index_info->fi_domain->is_desc)
+		  /* || (strcmp (func_index_info->expr_stream, cons->func_index_info->expr_stream)==0) */
+		  || (strcmp (func_index_info->expr_str, cons->func_index_info->expr_str) == 0))
+		{
+		  continue;
+		}
+	    }
+
+	  return cons;
 	}
     }
 
@@ -7972,9 +7980,7 @@ classobj_make_descriptor (MOP class_mop, SM_CLASS * classobj, SM_COMPONENT * com
  */
 static SM_CONSTRAINT_COMPATIBILITY
 classobj_check_index_compatibility (SM_CLASS_CONSTRAINT * constraints, const DB_CONSTRAINT_TYPE constraint_type,
-				    const SM_PREDICATE_INFO * filter_predicate,
-				    const SM_FUNCTION_INFO * func_index_info, const SM_CLASS_CONSTRAINT * existing_con,
-				    SM_CLASS_CONSTRAINT ** primary_con)
+				    const SM_CLASS_CONSTRAINT * existing_con, SM_CLASS_CONSTRAINT ** primary_con)
 {
   SM_CONSTRAINT_COMPATIBILITY ret;
 
@@ -7997,8 +8003,7 @@ classobj_check_index_compatibility (SM_CLASS_CONSTRAINT * constraints, const DB_
 
   if (DB_IS_CONSTRAINT_UNIQUE_FAMILY (constraint_type) && SM_IS_CONSTRAINT_UNIQUE_FAMILY (existing_con->type))
     {
-      ret = SM_SHARE_INDEX;
-      goto check_filter_function;
+      return SM_SHARE_INDEX;
     }
 
   if (constraint_type == DB_CONSTRAINT_FOREIGN_KEY)
@@ -8009,51 +8014,15 @@ classobj_check_index_compatibility (SM_CLASS_CONSTRAINT * constraints, const DB_
 	}
       else if (existing_con->type == SM_CONSTRAINT_INDEX)
 	{
-	  ret = SM_SHARE_INDEX;
-	  if (existing_con->filter_predicate != NULL || existing_con->func_index_info != NULL)
-	    {
-	      ret = SM_CREATE_NEW_INDEX;
-	    }
-	  return ret;
+	  return SM_SHARE_INDEX;
 	}
     }
   else if (constraint_type == DB_CONSTRAINT_INDEX && existing_con->type == SM_CONSTRAINT_FOREIGN_KEY)
     {
-      ret = SM_SHARE_INDEX;
-      if (filter_predicate != NULL || func_index_info != NULL)
-	{
-	  ret = SM_CREATE_NEW_INDEX;
-	}
-      return ret;
+      return SM_SHARE_INDEX;
     }
 
-  ret = SM_NOT_SHARE_INDEX_AND_WARNING;
-
-check_filter_function:
-  if (func_index_info && existing_con->func_index_info)
-    {
-      /* expr_str are printed tree, identifiers are already lower case */
-      if (!strcmp (func_index_info->expr_str, existing_con->func_index_info->expr_str)
-	  && (func_index_info->attr_index_start == existing_con->func_index_info->attr_index_start)
-	  && (func_index_info->col_id == existing_con->func_index_info->col_id)
-	  && (func_index_info->fi_domain->is_desc == existing_con->func_index_info->fi_domain->is_desc))
-	{
-	  return ret;
-	}
-      else
-	{
-	  return SM_CREATE_NEW_INDEX;
-	}
-    }
-  if ((func_index_info != NULL) && (existing_con->func_index_info == NULL))
-    {
-      return SM_CREATE_NEW_INDEX;
-    }
-  if ((func_index_info == NULL) && (existing_con->func_index_info != NULL))
-    {
-      return SM_CREATE_NEW_INDEX;
-    }
-  return ret;
+  return SM_NOT_SHARE_INDEX_AND_WARNING;
 }
 
 /*
@@ -8092,7 +8061,9 @@ classobj_check_index_exist (SM_CLASS_CONSTRAINT * constraints, char **out_shared
       return error;
     }
 
-  existing_con = classobj_find_constraint_by_attrs (constraints, constraint_type, att_names, asc_desc, filter_index);
+  existing_con =
+    classobj_find_constraint_by_attrs (constraints, constraint_type, att_names, asc_desc, filter_index,
+				       func_index_info);
 #if defined (ENABLE_UNUSED_FUNCTION)	/* to disable TEXT */
   if (existing_con != NULL)
     {
@@ -8104,8 +8075,7 @@ classobj_check_index_exist (SM_CLASS_CONSTRAINT * constraints, char **out_shared
     }
 #endif /* ENABLE_UNUSED_FUNCTION */
 
-  compat_state = classobj_check_index_compatibility (constraints, constraint_type, filter_index, func_index_info,
-						     existing_con, &prim_con);
+  compat_state = classobj_check_index_compatibility (constraints, constraint_type, existing_con, &prim_con);
   switch (compat_state)
     {
     case SM_CREATE_NEW_INDEX:

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4156,8 +4156,7 @@ classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAIN
 	      if ((func_index_info->attr_index_start != cons->func_index_info->attr_index_start)
 		  || (func_index_info->col_id != cons->func_index_info->col_id)
 		  || (func_index_info->fi_domain->is_desc != cons->func_index_info->fi_domain->is_desc)
-		  /* || (strcmp (func_index_info->expr_stream, cons->func_index_info->expr_stream)==0) */
-		  || (strcmp (func_index_info->expr_str, cons->func_index_info->expr_str) == 0))
+		  || (strcmp (func_index_info->expr_str, cons->func_index_info->expr_str) != 0))
 		{
 		  continue;
 		}

--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -989,7 +989,8 @@ extern SM_CLASS_CONSTRAINT *classobj_find_constraint_by_name (SM_CLASS_CONSTRAIN
 extern SM_CLASS_CONSTRAINT *classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list,
 							       DB_CONSTRAINT_TYPE new_cons, const char **att_names,
 							       const int *asc_desc,
-							       const SM_PREDICATE_INFO * filter_predicate);
+							       const SM_PREDICATE_INFO * filter_predicate,
+							       const SM_FUNCTION_INFO * func_index_info);
 extern TP_DOMAIN *classobj_find_cons_index2_col_type_list (SM_CLASS_CONSTRAINT * cons, OID * root_oid);
 extern void classobj_remove_class_constraint_node (SM_CLASS_CONSTRAINT ** constraints, SM_CLASS_CONSTRAINT * node);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24600

* fix classobj_check_index_compatibility() and classobj_find_constraint_by_attrs()

The classobj_find_constraint_by_attrs() function is the role of checking whether an index with the same configuration already exists.
The cause of the problem was that the function did not include function index information in the check target of the same configuration.
classobj_check_index_compatibility() was checking if the function index information was the same.

For example, all three indexes below use column val.
create index idx_a on tbl(val);
create index idx_b on tbl(abs(val));
create index idx_c on tbl(val);

case1) If you attempt to create idx_c after creating it in the order of idx_a and idx_b
The classobj_find_constrain_by_attrs() function returns idx_a.
In classobj_check_index_compatibility(), idx_c and idx_a are determined to have the same configuration and do not generate idx_c.

case2) If you attempt to create idx_c after creating it in the order of idx_b and idx_a
The classobj_find_constrain_by_attrs() function returns idx_b.
In classobj_check_index_compatibility(), idx_c and idx_b are determined to have different configurations and will generate idx_c.


So, here's the correction:

1) classobj_find_constrain_by_attrs() has been changed to find the same function index information as well as filter conditions.
2) classobj_check_index_compatibility() removes checks that are no longer needed.
3) Additionally, I changed the logic to a switch statement so that you can see it intuitively.

