### PR TITLE
[CBRD-24615] Result value error when using query cache in partition table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,9 +111,10 @@ workflows:
           requires:
             - build
 
+      - build_ol
       - test_medium_ol:
           requires:
-            - build
+            - build_ol
       - test_sql_ol:
           requires:
-            - build
+            - build_ol

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,36 +84,6 @@ jobs:
     parallelism: 8
     <<: *test_defaults
 
-  build_ol:
-    <<: *oraclelinux
-    environment:
-      MAKEFLAGS: -j 10
-    resource_class: large
-    steps:
-      - checkout
-      - run:
-          name: Submodules
-          command: |
-            git submodule sync
-            git submodule update --init
-      - run:
-          name: Build
-          command: |
-            mkdir -p /tmp/build_logs
-            scl enable devtoolset-8 -- /entrypoint.sh build
-            mv -f build.log /tmp/build_logs
-      - run:
-          name: Commits
-          command: |
-            mkdir -p /tmp/build_logs
-            git log | head -n 1000 > commits.log || true
-            mv -f commits.log /tmp/build_logs
-      - persist_to_workspace:
-          root: .
-          paths:
-            - CUBRID
-      - store_artifacts:
-          path: /tmp/build_logs
   test_medium_ol:
     <<: *oraclelinux
     environment:
@@ -134,12 +104,12 @@ workflows:
   build_test:
     jobs:
       - build
-      #- test_medium:
-          #requires:
-            #- build
-      #- test_sql:
-          #requires:
-            #- build
+      - test_medium:
+          requires:
+            - build
+      - test_sql:
+          requires:
+            - build
 
       - test_medium_ol:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,17 +134,16 @@ workflows:
   build_test:
     jobs:
       - build
-      - test_medium:
-          requires:
-            - build
-      - test_sql:
-          requires:
-            - build
+      #- test_medium:
+          #requires:
+            #- build
+      #- test_sql:
+          #requires:
+            #- build
 
-      - build_ol
       - test_medium_ol:
           requires:
-            - build_ol
+            - build
       - test_sql_ol:
           requires:
-            - build_ol
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,12 +104,12 @@ workflows:
   build_test:
     jobs:
       - build
-      #- test_medium:
-          #requires:
-            #- build
-      #- test_sql:
-          #requires:
-            #- build
+      - test_medium:
+          requires:
+            - build
+      - test_sql:
+          requires:
+            - build
 
       - test_medium_ol:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,36 @@ jobs:
     parallelism: 8
     <<: *test_defaults
 
+  build_ol:
+    <<: *oraclelinux
+    environment:
+      MAKEFLAGS: -j 10
+    resource_class: large
+    steps:
+      - checkout
+      - run:
+          name: Submodules
+          command: |
+            git submodule sync
+            git submodule update --init
+      - run:
+          name: Build
+          command: |
+            mkdir -p /tmp/build_logs
+            scl enable devtoolset-8 -- /entrypoint.sh build
+            mv -f build.log /tmp/build_logs
+      - run:
+          name: Commits
+          command: |
+            mkdir -p /tmp/build_logs
+            git log | head -n 1000 > commits.log || true
+            mv -f commits.log /tmp/build_logs
+      - persist_to_workspace:
+          root: .
+          paths:
+            - CUBRID
+      - store_artifacts:
+          path: /tmp/build_logs
   test_medium_ol:
     <<: *oraclelinux
     environment:
@@ -104,12 +134,12 @@ workflows:
   build_test:
     jobs:
       - build
-      - test_medium:
-          requires:
-            - build
-      - test_sql:
-          requires:
-            - build
+      #- test_medium:
+          #requires:
+            #- build
+      #- test_sql:
+          #requires:
+            #- build
 
       - build_ol
       - test_medium_ol:

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -5159,6 +5159,10 @@ locator_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 			    "locator_insert_force: qexec_clear_list_cache_by_class failed for class { %d %d %d }\n",
 			    real_class_oid.pageid, real_class_oid.slotid, real_class_oid.volid);
 	    }
+	  if (!OID_EQ (&real_class_oid, class_oid))
+	    {
+	      qmgr_add_modified_class (thread_p, class_oid);
+	    }
 	  qmgr_add_modified_class (thread_p, &real_class_oid);
 	}
 #if 0				/* TODO - dead code; do not delete me */
@@ -5329,7 +5333,11 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
   REPL_INFO repl_info;
   TDE_ALGORITHM tde_algo = TDE_ALGORITHM_NONE;
 
+  OID superclass_oid;
+
   assert (class_oid != NULL && !OID_ISNULL (class_oid));
+
+  OID_SET_NULL (&superclass_oid);
 
   /*
    * While scanning objects, the given scancache does not fix the last
@@ -5813,7 +5821,6 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 
       if (pruning_type != DB_NOT_PARTITIONED_CLASS)
 	{
-	  OID superclass_oid;
 	  OID real_class_oid;
 	  HFID real_hfid;
 	  int granted;
@@ -5979,6 +5986,10 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	      er_log_debug (ARG_FILE_LINE,
 			    "locator_update_force: qexec_clear_list_cache_by_class failed for class { %d %d %d }\n",
 			    class_oid->pageid, class_oid->slotid, class_oid->volid);
+	    }
+	  if (!OID_EQ (&superclass_oid, class_oid))
+	    {
+	      qmgr_add_modified_class (thread_p, &superclass_oid);
 	    }
 	  qmgr_add_modified_class (thread_p, class_oid);
 	}
@@ -6274,11 +6285,34 @@ locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, 
       /* remove query result cache entries which are relevant with this class */
       if (!QFILE_IS_LIST_CACHE_DISABLED)
 	{
+	  OID superclass_oid;
+	  OID real_class_oid;
+	  HFID real_hfid;
+
 	  if (qexec_clear_list_cache_by_class (thread_p, &class_oid) != NO_ERROR)
 	    {
 	      er_log_debug (ARG_FILE_LINE,
 			    "locator_delete_force: qexec_clear_list_cache_by_class failed for class { %d %d %d }\n",
 			    class_oid.pageid, class_oid.slotid, class_oid.volid);
+	    }
+
+	  OID_SET_NULL (&superclass_oid);
+
+	  HFID_COPY (&real_hfid, hfid);
+	  COPY_OID (&real_class_oid, &class_oid);
+
+	  error_code =
+	    partition_prune_update (thread_p, &class_oid, &copy_recdes, NULL, DB_PARTITIONED_CLASS, &real_class_oid,
+				    &real_hfid, &superclass_oid);
+
+	  if (error_code != NO_ERROR)
+	    {
+	      goto error;
+	    }
+
+	  if (!OID_EQ (&superclass_oid, &class_oid))
+	    {
+	      qmgr_add_modified_class (thread_p, &superclass_oid);
 	    }
 	  qmgr_add_modified_class (thread_p, &class_oid);
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24615

When using a partition table, the existing query cache does not disappear even if data is inserted or modified.

Even if it looks at the actual ";info qcache", the existing cache should disappear when data is inserted, but it remains and the previous value is retrieved.

The operation without partitioning is good.
