### PR TITLE
[CBRD-24563] Change regexp_engine system parameter to PRM_KEYWORD type

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2333,6 +2333,8 @@ static unsigned int prm_max_query_per_tran_flag = 0;
 /* *INDENT-OFF* */
 int PRM_REGEXP_ENGINE = cubregex::engine_type::LIB_RE2;
 static int prm_regexp_engine_default = cubregex::engine_type::LIB_RE2;
+static int prm_regexp_engine_lower = cubregex::engine_type::LIB_CPPSTD;
+static int prm_regexp_engine_upper = cubregex::engine_type::LIB_RE2;
 static unsigned int prm_regexp_engine_flag = 0;
 /* *INDENT-ON* */
 
@@ -6149,7 +6151,8 @@ SYSPRM_PARAM prm_Def[] = {
    &prm_regexp_engine_flag,
    (void *) &prm_regexp_engine_default,
    (void *) &PRM_REGEXP_ENGINE,
-   (void *) NULL, (void *) NULL,
+   (void *) &prm_regexp_engine_upper,
+   (void *) &prm_regexp_engine_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2330,9 +2330,11 @@ static int prm_max_query_per_tran_lower = 1;
 static int prm_max_query_per_tran_upper = SHRT_MAX;
 static unsigned int prm_max_query_per_tran_flag = 0;
 
-const char *PRM_REGEXP_ENGINE = "re2";
-static const char *prm_regexp_engine_default = "re2";
+/* *INDENT-OFF* */
+int PRM_REGEXP_ENGINE = cubregex::engine_type::LIB_RE2;
+static int prm_regexp_engine_default = cubregex::engine_type::LIB_RE2;
 static unsigned int prm_regexp_engine_flag = 0;
+/* *INDENT-ON* */
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -6143,7 +6145,7 @@ SYSPRM_PARAM prm_Def[] = {
   {PRM_ID_REGEXP_ENGINE,
    PRM_NAME_REGEXP_ENGINE,
    (PRM_FOR_CLIENT | PRM_FOR_SERVER | PRM_FORCE_SERVER | PRM_USER_CHANGE | PRM_FOR_SESSION),
-   PRM_STRING,
+   PRM_KEYWORD,
    &prm_regexp_engine_flag,
    (void *) &prm_regexp_engine_default,
    (void *) &PRM_REGEXP_ENGINE,
@@ -6304,6 +6306,14 @@ static KEYVAL tde_algorithm_words[] = {
   {"aes", TDE_ALGORITHM_AES},
   {"aria", TDE_ALGORITHM_ARIA}
 };
+
+/* *INDENT-OFF* */
+using namespace cubregex;
+static KEYVAL regexp_engine_words[] = {
+  {get_engine_name(engine_type::LIB_CPPSTD), engine_type::LIB_CPPSTD},
+  {get_engine_name(engine_type::LIB_RE2), engine_type::LIB_RE2}
+};
+/* *INDENT-ON* */
 
 static const char *compat_mode_values_PRM_ANSI_QUOTES[COMPAT_ORACLE + 2] = {
   NULL,				/* COMPAT_CUBRID */
@@ -7116,16 +7126,6 @@ prm_load_by_section (INI_TABLE * ini, const char *section, bool ignore_section, 
 	  error = PRM_ERR_CANNOT_CHANGE;
 	  prm_report_bad_entry (key + sec_len, ini->lineno[i], error, file);
 	  return error;
-	}
-
-      if (strcmp (prm->name, PRM_NAME_REGEXP_ENGINE) == 0 && value)
-	{
-	  if (cubregex::check_regexp_engine_prm (value) == false)
-	    {
-	      error = PRM_ERR_BAD_VALUE;
-	      prm_report_bad_entry (key + sec_len, ini->lineno[i], error, file);
-	      return error;
-	    }
 	}
 
       error = prm_set (prm, value, true);
@@ -8261,6 +8261,10 @@ prm_print (const SYSPRM_PARAM * prm, char *buf, size_t len, PRM_PRINT_MODE print
 	{
 	  keyvalp = prm_keyword (PRM_GET_INT (prm->value), NULL, tde_algorithm_words, DIM (tde_algorithm_words));
 	}
+      else if (intl_mbs_casecmp (prm->name, PRM_NAME_REGEXP_ENGINE) == 0)
+	{
+	  keyvalp = prm_keyword (PRM_GET_INT (prm->value), NULL, regexp_engine_words, DIM (regexp_engine_words));
+	}
       else
 	{
 	  assert (false);
@@ -8560,6 +8564,10 @@ sysprm_print_sysprm_value (PARAM_ID prm_id, SYSPRM_VALUE value, char *buf, size_
       else if (intl_mbs_casecmp (prm->name, PRM_NAME_TDE_DEFAULT_ALGORITHM) == 0)
 	{
 	  keyvalp = prm_keyword (value.i, NULL, tde_algorithm_words, DIM (tde_algorithm_words));
+	}
+      else if (intl_mbs_casecmp (prm->name, PRM_NAME_REGEXP_ENGINE) == 0)
+	{
+	  keyvalp = prm_keyword (value.i, NULL, regexp_engine_words, DIM (regexp_engine_words));
 	}
       else
 	{
@@ -9772,6 +9780,10 @@ sysprm_generate_new_value (SYSPRM_PARAM * prm, const char *value, bool check, SY
 	else if (intl_mbs_casecmp (prm->name, PRM_NAME_TDE_DEFAULT_ALGORITHM) == 0)
 	  {
 	    keyvalp = prm_keyword (-1, value, tde_algorithm_words, DIM (tde_algorithm_words));
+	  }
+	else if (intl_mbs_casecmp (prm->name, PRM_NAME_REGEXP_ENGINE) == 0)
+	  {
+	    keyvalp = prm_keyword (-1, value, regexp_engine_words, DIM (regexp_engine_words));
 	  }
 	else
 	  {

--- a/src/query/string_regex.cpp
+++ b/src/query/string_regex.cpp
@@ -62,29 +62,9 @@ namespace cubregex
     "re2"
   };
 
-  bool check_regexp_engine_prm (const char *param_name)
+  const char *get_engine_name (const engine_type &type)
   {
-    assert (param_name);
-
-    if (strcmp (param_name, engine_name[LIB_CPPSTD]) == 0
-	|| strcmp (param_name, engine_name[LIB_RE2]) == 0)
-      {
-	return true;
-      }
-    return false;
-  }
-
-  engine_type get_engine_type_by_name (const char *param_name)
-  {
-    if (strcmp (param_name, engine_name[LIB_CPPSTD]) == 0)
-      {
-	return engine_type::LIB_CPPSTD;
-      }
-    else if (strcmp (param_name, engine_name[LIB_RE2]) == 0)
-      {
-	return engine_type::LIB_RE2;
-      }
-    return engine_type::LIB_NONE;
+    return engine_name[type];
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -110,13 +90,7 @@ namespace cubregex
 	return ER_QPROC_INVALID_PARAMETER;
       }
 
-    const char *engine_type_prm = prm_get_string_value (PRM_ID_REGEXP_ENGINE);
-
-#if !defined (NDEBUG)
-    assert (check_regexp_engine_prm (engine_type_prm));
-#endif
-
-    engine_type type = get_engine_type_by_name (engine_type_prm);
+    engine_type type = static_cast<engine_type> (prm_get_integer_value (PRM_ID_REGEXP_ENGINE));
 
     std::string utf8_pattern;
     if (cublocale::convert_string_to_utf8 (utf8_pattern, pattern_string, collation->codeset) == false)

--- a/src/query/string_regex.hpp
+++ b/src/query/string_regex.hpp
@@ -74,8 +74,7 @@ namespace cubregex
   };
 
   /* related to system parameter */
-  bool check_regexp_engine_prm (const char *param_name);
-  engine_type get_engine_type_by_name (const char *param_name);
+  const char *get_engine_name (const engine_type &type);
 
   /*
   * compile() - Compile regex object


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24563

PRM_KEYWORD is a better approach to validate the parameter value.
I've changed regexp_engine to PRM_KEYWORD type and set lower and upper values.