### PR TITLE
[CBRD-24619] execlude 0.0.0.0 from ping hosts

### DIFF
--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -2166,8 +2166,11 @@ hb_cluster_load_ping_host_list (char *ha_ping_host_list)
 	  break;
 	}
 
-      hb_add_ping_host (host_p);
-      num_hosts++;
+      if (strcmp (host_p, "0.0.0.0") != 0)
+        {
+          hb_add_ping_host (host_p);
+          num_hosts++;
+        }
     }
 
   return num_hosts;

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -2167,10 +2167,10 @@ hb_cluster_load_ping_host_list (char *ha_ping_host_list)
 	}
 
       if (strcmp (host_p, "0.0.0.0") != 0)
-        {
-          hb_add_ping_host (host_p);
-          num_hosts++;
-        }
+	{
+	  hb_add_ping_host (host_p);
+	  num_hosts++;
+	}
     }
 
   return num_hosts;

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -2169,7 +2169,7 @@ hb_cluster_load_ping_host_list (char *ha_ping_host_list)
 
       if (strcmp (host_p, "0.0.0.0") == 0)
 	{
-	  snprintf (buf, sizeof (buf), "We do not allow 0.0.0.0 as a ping hosts, excluded.");
+	  snprintf (buf, sizeof (buf), "We do not allow 0.0.0.0 as a ping hosts, excluded");
 	  MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HB_NODE_EVENT, 1, buf);
 	}
       else

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -2150,6 +2150,7 @@ hb_cluster_load_ping_host_list (char *ha_ping_host_list)
   int num_hosts = 0;
   char host_list[LINE_MAX];
   char *host_list_p, *host_p, *host_pp;
+  char buf[128];
 
   if (ha_ping_host_list == NULL)
     {
@@ -2166,7 +2167,12 @@ hb_cluster_load_ping_host_list (char *ha_ping_host_list)
 	  break;
 	}
 
-      if (strcmp (host_p, "0.0.0.0") != 0)
+      if (strcmp (host_p, "0.0.0.0") == 0)
+	{
+	  snprintf (buf, sizeof (buf), "We do not allow 0.0.0.0 as a ping hosts, excluded.");
+	  MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HB_NODE_EVENT, 1, buf);
+	}
+      else
 	{
 	  hb_add_ping_host (host_p);
 	  num_hosts++;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24619

**Purpose**
- To exclude 0.0.0.0 from HA ping_hosts
- even user set 0.0.0.0 as a ping hosts, it will be excluded

For example,
* if ping hosts are defined in cubrid_ha.conf as following, 
`ha_ping_hosts=0.0.0.0,192.168.2.1,192.168.1.1`
* then, actual list of ping hosts will be:
`192.168.2.1,192.168.1.1`

**Implementation**
* if 0.0.0.0 is set as a ping hosts, a message will be logged that it will be excluded from ping hosts list for HA

**Remarks**
- check with command 'cubrid hb status', then it will display ping hosts