### PR TITLE
[CBRD-24609] When loading objects files online, if the schema name is not specified, the schema name of the current session must be used. (#4026)

### DIFF
--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -117,8 +117,28 @@ namespace cubload
     cubthread::entry &thread_ref = cubthread::get_entry ();
     LC_FIND_CLASSNAME found = LC_CLASSNAME_EXIST;
     LC_FIND_CLASSNAME found_again = LC_CLASSNAME_EXIST;
+    const char *dot = strchr (class_name, '.');
 
-    found = xlocator_find_class_oid (&thread_ref, class_name, &class_oid, BU_LOCK);
+    if (dot != NULL)
+      {
+	found = xlocator_find_class_oid (&thread_ref, class_name, &class_oid, BU_LOCK);
+      }
+    else
+      {
+	/* Added for backwards compatibility.
+	 *
+	 * In versions lower than 11.2, the schema name is not specified in the unloaded object file.
+	 * So, if the schema name is not specified, the schema name of the current session must be specified.
+	 */
+
+	const char *user_name = m_session.get_args ().user_name.c_str ();
+	char user_specified_name[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
+
+	snprintf (user_specified_name, DB_MAX_IDENTIFIER_LENGTH, "%s.%s", user_name, class_name);
+
+	found = xlocator_find_class_oid (&thread_ref, user_specified_name, &class_oid, BU_LOCK);
+      }
+
     if (found == LC_CLASSNAME_EXIST)
       {
 	return found;

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -117,9 +117,7 @@ namespace cubload
     cubthread::entry &thread_ref = cubthread::get_entry ();
     LC_FIND_CLASSNAME found = LC_CLASSNAME_EXIST;
     LC_FIND_CLASSNAME found_again = LC_CLASSNAME_EXIST;
-    const char *dot = strchr (class_name, '.');
-
-    if (dot != NULL)
+    if (strchr (class_name, '.'))
       {
 	found = xlocator_find_class_oid (&thread_ref, class_name, &class_oid, BU_LOCK);
       }

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -130,14 +130,13 @@ namespace cubload
 	 * So, if the schema name is not specified, the schema name of the current session must be specified.
 	 */
 
-	const char *user_name = m_session.get_args ().user_name.c_str ();
 	char user_specified_name[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
 
-	/* It should be possible to know the user of the current session. If there is no user set
-	 * in the current session, I think there is a problem during the execution of the preceding code.
-	 */
+	const char *user_name = m_session.get_args ().user_name.c_str ();
 	assert (user_name != NULL);
+
 	snprintf (user_specified_name, DB_MAX_IDENTIFIER_LENGTH, "%s.%s", user_name, class_name);
+
 	found = xlocator_find_class_oid (&thread_ref, user_specified_name, &class_oid, BU_LOCK);
       }
 

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -117,7 +117,8 @@ namespace cubload
     cubthread::entry &thread_ref = cubthread::get_entry ();
     LC_FIND_CLASSNAME found = LC_CLASSNAME_EXIST;
     LC_FIND_CLASSNAME found_again = LC_CLASSNAME_EXIST;
-    if (strchr (class_name, '.'))
+
+    if (memchr (class_name, '.', DB_MAX_SCHEMA_LENGTH))
       {
 	found = xlocator_find_class_oid (&thread_ref, class_name, &class_oid, BU_LOCK);
       }
@@ -132,8 +133,11 @@ namespace cubload
 	const char *user_name = m_session.get_args ().user_name.c_str ();
 	char user_specified_name[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
 
+	/* It should be possible to know the user of the current session. If there is no user set
+	 * in the current session, I think there is a problem during the execution of the preceding code.
+	 */
+	assert (user_name != NULL);
 	snprintf (user_specified_name, DB_MAX_IDENTIFIER_LENGTH, "%s.%s", user_name, class_name);
-
 	found = xlocator_find_class_oid (&thread_ref, user_specified_name, &class_oid, BU_LOCK);
       }
 

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -118,7 +118,7 @@ namespace cubload
     LC_FIND_CLASSNAME found = LC_CLASSNAME_EXIST;
     LC_FIND_CLASSNAME found_again = LC_CLASSNAME_EXIST;
 
-    if (memchr (class_name, '.', DB_MAX_SCHEMA_LENGTH))
+    if (strchr (class_name, '.'))
       {
 	found = xlocator_find_class_oid (&thread_ref, class_name, &class_oid, BU_LOCK);
       }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24609

backport #4026