### PR TITLE
[CBRD-24541] backport 11.2 for CBRD-24541, CBRD-24538

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1637,6 +1637,7 @@ mq_substitute_spec_in_method_names (PARSER_CONTEXT * parser, PT_NODE * node, voi
  *  - select for schema
  *  - has CONNECT BY
  *  - is merge query
+ *  - is CTE query
  *  - view spec is outer join spec
  *  - main query's where has define_vars ':='
  *  - subquery has order_by and main query has inst_num or analytic or order-sensitive aggrigation function
@@ -1806,7 +1807,10 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * 
       return NON_PUSHABLE;
     }
   /* check for CTE query */
-  if (subquery->info.query.with != NULL)
+  /* TODO : Queries with CTE can be also view merged */
+  /*        After view merging, 'spec->info.spec.cte_pointer' must be changed to the copied value of the newly added WITH CLAUSE. */
+  /*        see pt_resolve_cte_specs() and pt_resolve_spec_to_cte() */
+  if (mainquery->info.query.with != NULL || subquery->info.query.with != NULL)
     {
       /* not pushable */
       return NON_PUSHABLE;
@@ -3191,6 +3195,7 @@ mq_translate_tree (PARSER_CONTEXT * parser, PT_NODE * tree, PT_NODE * spec_list,
     }
 
   tree = mq_reset_ids_in_statement (parser, tree);
+
   return tree;
 }
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1982,18 +1982,6 @@ qexec_clear_access_spec_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, ACCES
 		    {
 		      pg_cnt += qexec_clear_regu_var (thread_p, xasl_p, indx_info->key_info.key_limit_u, is_final);
 		    }
-
-		  /* Restore the BTID for future usages (needed for partition cases). */
-		  /* XASL comes from the client with the btid set to the root class of the partitions hierarchy.
-		   * Scan begins and starts with the rootclass, then jumps to a partition and sets the btid in the
-		   * XASL to the one of the partition. Execution ends and the next identical statement comes and uses
-		   * the XASL previously generated. However, the BTID was not cleared from the INDEX_INFO structure
-		   * so the execution will fail.
-		   * We need to find a better solution so that we do not write on the XASL members during execution.
-		   */
-
-		  /* TODO: Fix me!! */
-		  BTID_COPY (&indx_info->btid, &p->btid);
 		}
 	    }
 	  break;
@@ -6806,6 +6794,12 @@ qexec_close_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec)
 	  curr_spec->parts = NULL;
 	  curr_spec->curent = NULL;
 	  curr_spec->pruned = false;
+
+	  /* init btid */
+	  if (curr_spec->indexptr)
+	    {
+	      BTID_COPY (&curr_spec->indexptr->btid, &curr_spec->btid);
+	    }
 	}
       break;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24541

backport 11.2 for CBRD-24541, CBRD-24538
[CBRD-24541]Core dump occurs when 'EXISTS' operation or 'count stop' is used for index scan of partitioned table.
[CBRD-24538]Core dump occurs when a query containing cte is view merged