### PR TITLE
[CBRD-24631] Fix segfault when an error occurs with return_null_on_function_errors is on

### DIFF
--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -8568,7 +8568,7 @@ qdata_regexp_function (THREAD_ENTRY * thread_p, FUNCTION_TYPE * function_p, VAL_
 	function_p->tmp_obj->compiled_regex = new cub_compiled_regex ();
       }
 
-    cub_compiled_regex *compiled_regex = function_p->tmp_obj->compiled_regex;
+    cub_compiled_regex *&compiled_regex = function_p->tmp_obj->compiled_regex;
     error_status = regexp_func (function_p->value, args, no_args, &compiled_regex);
     if (error_status != NO_ERROR)
       {

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4573,7 +4573,6 @@ db_string_rlike (const DB_VALUE * src, const DB_VALUE * pattern, const DB_VALUE 
 cleanup:
   if (error_status != NO_ERROR)
     {
-      *result = V_ERROR;
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  /* we must not return an error code */
@@ -4583,7 +4582,7 @@ cleanup:
 	}
       else
 	{
-	  error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
+	  (error_status == ER_QSTR_BAD_SRC_CODESET) ? error_status = NO_ERROR : *result = V_ERROR;
 	}
     }
 
@@ -4973,15 +4972,16 @@ db_string_regexp_instr (DB_VALUE * result, DB_VALUE * args[], int const num_args
 exit:
   if (error_status != NO_ERROR)
     {
-      db_make_null (result);
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  /* we must not return an error code */
+	  db_make_null (result);
 	  er_clear ();
 	  error_status = NO_ERROR;
 	}
       else
 	{
+	  db_make_int (result, 0);
 	  error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	}
     }
@@ -5146,6 +5146,7 @@ exit:
 	}
       else
 	{
+	  db_make_int (result, 0);
 	  error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	}
     }

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4566,7 +4566,6 @@ db_string_rlike (const DB_VALUE * src, const DB_VALUE * pattern, const DB_VALUE 
     error_status = cubregex::search (*result, *compiled_regex, src_string);
     if (error_status != NO_ERROR)
       {
-	error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	goto cleanup;
       }
   }
@@ -4581,6 +4580,10 @@ cleanup:
 	  *result = V_UNKNOWN;
 	  er_clear ();
 	  error_status = NO_ERROR;
+	}
+      else
+	{
+	  error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	}
     }
 
@@ -4742,7 +4745,6 @@ db_string_regexp_count (DB_VALUE * result, DB_VALUE * args[], int const num_args
     if (error_status != NO_ERROR)
       {
 	/* regex execution error */
-	error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	goto exit;
       }
 
@@ -4760,6 +4762,10 @@ exit:
 	  /* we must not return an error code */
 	  er_clear ();
 	  error_status = NO_ERROR;
+	}
+      else
+	{
+	  error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	}
     }
 
@@ -4956,7 +4962,6 @@ db_string_regexp_instr (DB_VALUE * result, DB_VALUE * args[], int const num_args
     if (error_status != NO_ERROR)
       {
 	/* regex execution error */
-	error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	goto exit;
       }
 
@@ -4974,6 +4979,10 @@ exit:
 	  /* we must not return an error code */
 	  er_clear ();
 	  error_status = NO_ERROR;
+	}
+      else
+	{
+	  error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	}
     }
 
@@ -5117,7 +5126,6 @@ db_string_regexp_like (DB_VALUE * result, DB_VALUE * args[], int const num_args,
     if (error_status != NO_ERROR)
       {
 	/* regex execution error */
-	error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	goto exit;
       }
 
@@ -5135,6 +5143,10 @@ exit:
 	  /* we must not return an error code */
 	  er_clear ();
 	  error_status = NO_ERROR;
+	}
+      else
+	{
+	  error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	}
     }
 
@@ -5390,6 +5402,10 @@ exit:
 	  er_clear ();
 	  error_status = NO_ERROR;
 	}
+      else
+	{
+	  error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
+	}
     }
 
   if (comp_regex == NULL)
@@ -5568,7 +5584,6 @@ db_string_regexp_substr (DB_VALUE * result, DB_VALUE * args[], int const num_arg
     if (error_status != NO_ERROR)
       {
 	/* regex execution error */
-	error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	goto exit;
       }
 
@@ -5603,6 +5618,10 @@ exit:
 	  /* we must not return an error code */
 	  er_clear ();
 	  error_status = NO_ERROR;
+	}
+      else
+	{
+	  error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	}
     }
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -4559,7 +4559,6 @@ db_string_rlike (const DB_VALUE * src, const DB_VALUE * pattern, const DB_VALUE 
     error_status = cubregex::compile (compiled_regex, pattern_string, match_str, collation);
     if (error_status != NO_ERROR)
       {
-	error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	goto cleanup;
       }
 
@@ -4576,7 +4575,6 @@ cleanup:
   if (error_status != NO_ERROR)
     {
       *result = V_ERROR;
-      comp_regex = NULL;
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  /* we must not return an error code */
@@ -4734,7 +4732,6 @@ db_string_regexp_count (DB_VALUE * result, DB_VALUE * args[], int const num_args
     error_status = cubregex::compile (compiled_regex, pattern_string, match_type_str, collation);
     if (error_status != NO_ERROR)
       {
-	error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	goto exit;
       }
 
@@ -4758,7 +4755,6 @@ exit:
   if (error_status != NO_ERROR)
     {
       db_make_int (result, 0);
-      comp_regex = NULL;
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  /* we must not return an error code */
@@ -4949,7 +4945,6 @@ db_string_regexp_instr (DB_VALUE * result, DB_VALUE * args[], int const num_args
     error_status = cubregex::compile (compiled_regex, pattern_string, match_type_str, collation);
     if (error_status != NO_ERROR)
       {
-	error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	goto exit;
       }
 
@@ -4974,7 +4969,6 @@ exit:
   if (error_status != NO_ERROR)
     {
       db_make_null (result);
-      comp_regex = NULL;
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  /* we must not return an error code */
@@ -5113,7 +5107,6 @@ db_string_regexp_like (DB_VALUE * result, DB_VALUE * args[], int const num_args,
     error_status = cubregex::compile (compiled_regex, pattern_string, match_type_str, collation);
     if (error_status != NO_ERROR)
       {
-	error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	goto exit;
       }
 
@@ -5137,7 +5130,6 @@ exit:
   if (error_status != NO_ERROR)
     {
       db_make_null (result);
-      comp_regex = NULL;
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  /* we must not return an error code */
@@ -5328,7 +5320,6 @@ db_string_regexp_replace (DB_VALUE * result, DB_VALUE * args[], int const num_ar
     error_status = cubregex::compile (compiled_regex, pattern_string, match_type_str, collation);
     if (error_status != NO_ERROR)
       {
-	error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	goto exit;
       }
 
@@ -5393,7 +5384,6 @@ exit:
   if (error_status != NO_ERROR)
     {
       db_make_null (result);
-      comp_regex = NULL;
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  /* we must not return an error code */
@@ -5566,7 +5556,6 @@ db_string_regexp_substr (DB_VALUE * result, DB_VALUE * args[], int const num_arg
     error_status = cubregex::compile (compiled_regex, pattern_string, match_type_str, collation);
     if (error_status != NO_ERROR)
       {
-	error_status = (error_status == ER_QSTR_BAD_SRC_CODESET) ? NO_ERROR : error_status;
 	goto exit;
       }
 
@@ -5609,7 +5598,6 @@ exit:
   if (error_status != NO_ERROR)
     {
       db_make_null (result);
-      comp_regex = NULL;
       if (prm_get_bool_value (PRM_ID_RETURN_NULL_ON_FUNCTION_ERRORS))
 	{
 	  /* we must not return an error code */
@@ -5622,6 +5610,7 @@ exit:
     {
       /* free memory if this function is invoked in constant folding */
       delete compiled_regex;
+      compiled_regex = NULL;
     }
   else
     {

--- a/src/query/string_regex.cpp
+++ b/src/query/string_regex.cpp
@@ -44,15 +44,22 @@ namespace cubregex
 	switch (type)
 	  {
 	  case engine_type::LIB_CPPSTD:
-	    delete compiled->std_obj;
+	    if (compiled->std_obj)
+	      {
+		delete compiled->std_obj;
+	      }
 	    break;
 	  case engine_type::LIB_RE2:
-	    delete compiled->re2_obj;
+	    if (compiled->re2_obj)
+	      {
+		delete compiled->re2_obj;
+	      }
 	    break;
 	  default:
 	    assert (false);
 	  }
 	delete compiled;
+	compiled = {nullptr};
       }
   }
 
@@ -264,16 +271,10 @@ namespace cubregex
     // delete previous compiled object
     if (cr)
       {
-	if (cr->compiled)
-	  {
-	    delete cr->compiled;
-	  }
-      }
-    else
-      {
-	cr = new compiled_regex ();
+	delete cr;
       }
 
+    cr = new compiled_regex ();
     cr->type = type;
     cr->compiled = new compiled_regex_object { nullptr };
     cr->pattern.assign (pattern_string);
@@ -292,6 +293,13 @@ namespace cubregex
 	assert (false);
 	error = ER_FAILED;
 	break;
+      }
+
+    /* compiling regex pattern failed */
+    if (error != NO_ERROR)
+      {
+	delete cr;
+	cr = nullptr;
       }
 
     return error;

--- a/src/query/string_regex.cpp
+++ b/src/query/string_regex.cpp
@@ -295,13 +295,6 @@ namespace cubregex
 	break;
       }
 
-    /* compiling regex pattern failed */
-    if (error != NO_ERROR)
-      {
-	delete cr;
-	cr = nullptr;
-      }
-
     return error;
   }
 

--- a/src/query/string_regex.hpp
+++ b/src/query/string_regex.hpp
@@ -63,7 +63,7 @@ namespace cubregex
 
     compiled_regex ()
       : type (LIB_NONE)
-      , compiled (nullptr)
+      , compiled {nullptr}
       , pattern ()
       , flags (0)
       , codeset (INTL_CODESET_NONE)

--- a/src/query/string_regex_std.cpp
+++ b/src/query/string_regex_std.cpp
@@ -147,7 +147,8 @@ namespace cubregex
 
     try
       {
-	cub_std_regex &std_reg = * (reg.compiled->std_obj);
+	cub_std_regex &std_reg = GET_STD_OBJ (reg);
+
 #if defined(WINDOWS)
 	/* HACK: case insensitive doesn't work well on Windows.
 	*  This code transforms source string into lowercase
@@ -199,7 +200,8 @@ namespace cubregex
 	    src_wstring.substr (position, src_wstring.size () - position)
     );
 
-    cub_std_regex &std_reg = * (reg.compiled->std_obj);
+    cub_std_regex &std_reg = GET_STD_OBJ (reg);
+
 #if defined(WINDOWS)
     /* HACK: case insensitive doesn't work well on Windows.
     *  This code transforms source string into lowercase
@@ -258,7 +260,7 @@ namespace cubregex
 	    src_wstring.substr (position, src_wstring.size () - position)
     );
 
-    cub_std_regex &std_reg = * (reg.compiled->std_obj);
+    cub_std_regex &std_reg = GET_STD_OBJ (reg);
 #if defined(WINDOWS)
     /* HACK: case insensitive doesn't work well on Windows.
     *  This code transforms source string into lowercase
@@ -572,7 +574,7 @@ namespace cubregex
 	    src_wstring.substr (position, src_wstring.size () - position)
     );
 
-    cub_std_regex &std_reg = * (reg.compiled->std_obj);
+    cub_std_regex &std_reg = GET_STD_OBJ (reg);
 
 #if defined(WINDOWS)
     /* HACK: case insensitive doesn't work well on Windows.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24631

During error handling, a segfault occurs because the RLIKE_TERM pointer refers to an incorrect address by `comp_regex = NULL;` . It occurs only in the case of return_null_on_function_errors is on.