### PR TITLE
[CBRD-24609] When loading object files online, system class/vclass does not use the schema name of the current session.

### DIFF
--- a/src/executables/util_common.c
+++ b/src/executables/util_common.c
@@ -52,6 +52,93 @@ typedef enum
   NEW_DATABASE
 } DATABASE_NAME;
 
+typedef struct system_class_def SYSTEM_CLASS_DEF;
+struct system_class_def
+{
+  const char *name;
+  int len;
+};
+
+// *INDENT-OFF*
+static SYSTEM_CLASS_DEF system_classes[] = {
+  {"Rootclass", strlen ("Rootclass")},					// ROOTCLASS_NAME
+  {"dual", strlen ("dual")},						// CT_DUAL_NAME
+
+  /*
+   * authorization classes
+   *
+   * AU_ROOT_CLASS_NAME     = CT_ROOT_NAME
+   * AU_OLD_ROOT_CLASS_NAME = CT_AUTHORIZATIONS_NAME
+   * AU_USER_CLASS_NAME     = CT_USER_NAME
+   * AU_PASSWORD_CLASS_NAME = CT_PASSWORD_NAME
+   * AU_AUTH_CLASS_NAME     = CT_AUTHORIZATION_NAME
+   * AU_GRANT_CLASS_NAME
+   */
+  {"db_root", strlen ("db_root")},					// AU_ROOT_CLASS_NAME
+  {"db_user", strlen ("db_user")},					// AU_USER_CLASS_NAME
+  {"db_password", strlen ("db_password")},				// AU_PASSWORD_CLASS_NAME
+  {"db_authorization", strlen ("db_authorization")},			// AU_AUTH_CLASS_NAME
+  {"db_authorizations", strlen ("db_authorizations")},			// "db_authorizations"
+
+  /* currently, not implemented */
+  {"db_grant", strlen ("db_grant")},					// AU_GRANT_CLASS_NAME
+
+  /* 
+   * catalog classes
+   */
+  {"_db_class", strlen ("_db_class")},					// CT_CLASS_NAME
+  {"_db_attribute", strlen ("_db_attribute")}, 				// CT_ATTRIBUTE_NAME
+  {"_db_domain", strlen ("_db_domain")},				// CT_DOMAIN_NAME
+  {"_db_method", strlen ("_db_method")},				// CT_METHOD_NAME
+  {"_db_meth_sig", strlen ("_db_meth_sig")},				// CT_METHSIG_NAME
+  {"_db_meth_arg", strlen ("_db_meth_arg")},				// CT_METHARG_NAME
+  {"_db_meth_file", strlen ("_db_meth_file")},				// CT_METHFILE_NAME
+  {"_db_query_spec", strlen ("_db_query_spec")},			// CT_QUERYSPEC_NAME
+  {"_db_index", strlen ("_db_index")},					// CT_INDEX_NAME
+  {"_db_index_key", strlen ("_db_index_key")},				// CT_INDEXKEY_NAME
+  {"_db_data_type", strlen ("_db_data_type")},				// CT_DATATYPE_NAME
+  {"_db_auth", strlen ("_db_auth")},					// CT_CLASSAUTH_NAME
+  {"_db_partition", strlen ("_db_partition")},				// CT_PARTITION_NAME
+  {"_db_stored_procedure", strlen ("_db_stored_procedure")},		// CT_STORED_PROC_NAME
+  {"_db_stored_procedure_args", strlen ("_db_stored_procedure_args")},	// CT_STORED_PROC_ARGS_NAME
+  {"db_serial", strlen ("db_serial")},					// CT_SERIAL_NAME
+  {"db_ha_apply_info", strlen ("db_ha_apply_info")},			// CT_HA_APPLY_INFO_NAME
+  {"_db_collation", strlen ("_db_collation")},				// CT_COLLATION_NAME
+  {"_db_charset", strlen ("_db_charset")},				// CT_CHARSET_NAME
+  {"_db_server", strlen ("_db_server")},				// CT_DB_SERVER_NAME
+  {"_db_synonym", strlen ("_db_synonym")},				// CT_SYNONYM_NAME
+
+  {"db_trigger", strlen ("db_trigger")},				// CT_TRIGGER_NAME
+
+  /* currently, not implemented */
+  {"_db_resolution", strlen ("_db_resolution")},			// CT_RESOLUTION_NAME
+
+  /*
+   * catalog vclasses
+   */
+  {"db_class", strlen ("db_class")},					// CTV_CLASS_NAME
+  {"db_direct_super_class", strlen ("db_direct_super_class")},		// CTV_SUPER_CLASS_NAME
+  {"db_vclass", strlen ("db_vclass")},					// CTV_VCLASS_NAME
+  {"db_attribute", strlen ("db_attribute")},				// CTV_ATTRIBUTE_NAME
+  {"db_attr_setdomain_elm", strlen ("db_attr_setdomain_elm")},		// CTV_ATTR_SD_NAME
+  {"db_method", strlen ("db_method")},					// CTV_METHOD_NAME
+  {"db_meth_arg", strlen ("db_meth_arg")},				// CTV_METHARG_NAME
+  {"db_meth_arg_setdomain_elm", strlen ("db_meth_arg_setdomain_elm")},	// CTV_METHARG_SD_NAME
+  {"db_meth_file", strlen ("db_meth_file")},				// CTV_METHFILE_NAME
+  {"db_index", strlen ("db_index")},					// CTV_INDEX_NAME
+  {"db_index_key", strlen ("db_index_key")},				// CTV_INDEXKEY_NAME
+  {"db_auth", strlen ("db_auth")},					// CTV_AUTH_NAME
+  {"db_trig", strlen ("db_trig")},					// CTV_TRIGGER_NAME
+  {"db_partition", strlen ("db_partition")},				// CTV_PARTITION_NAME
+  {"db_stored_procedure", strlen ("db_stored_procedure")},		// CTV_STORED_PROC_NAME
+  {"db_stored_procedure_args", strlen ("db_stored_procedure_args")},	// CTV_STORED_PROC_ARGS_NAME
+  {"db_collation", strlen ("db_collation")},				// CTV_DB_COLLATION_NAME
+  {"db_charset", strlen ("db_charset")},				// CTV_DB_CHARSET_NAME
+  {"db_server", strlen ("db_server")},					// CTV_DB_SERVER_NAME
+  {"db_synonym", strlen ("db_synonym")}					// CTV_SYNONYM_NAME
+};
+// *INDENT-ON*
+
 static int utility_get_option_index (UTIL_ARG_MAP * arg_map, int arg_ch);
 static int check_database_name_local (const char *name, int existing_or_new_db);
 static char **util_split_ha_node (const char *str);
@@ -60,6 +147,7 @@ static char **util_split_ha_sync (const char *str);
 static int util_get_ha_parameters (char **ha_node_list_p, char **ha_db_list_p, char **ha_sync_mode_p,
 				   const char **ha_copy_log_base_p, int *ha_max_mem_size_p);
 static bool util_is_replica_node (void);
+static int utility_system_class_def_compare (const void *a, const void *b);
 
 /*
  * utility_initialize() - initialize cubrid library
@@ -1374,4 +1462,71 @@ util_get_table_list_from_file (char *fname, dynamic_array * darray)
   fclose (fp);
 
   return NO_ERROR;
+}
+
+static int
+utility_system_class_def_compare (const void *a, const void *b)
+{
+  const SYSTEM_CLASS_DEF *sa = STATIC_CAST (const SYSTEM_CLASS_DEF *, a);
+  const SYSTEM_CLASS_DEF *sb = STATIC_CAST (const SYSTEM_CLASS_DEF *, b);
+
+  if (sa->len != sb->len)
+    {
+      return sa->len - sb->len;
+    }
+
+  return strcmp (sa->name, sb->name);
+}
+
+/*
+ * sm_check_system_class_by_name () - Checks whether the class name is
+ *    the same as the system class name.
+ * return: true if the system class name, false otherwise
+ * name(in): class name
+ */
+bool
+utility_check_system_class_name (const char *class_name)
+{
+  static int was_initialized = FALSE;
+  static int count = sizeof (system_classes) / sizeof (system_classes[0]);
+
+  SYSTEM_CLASS_DEF sa;
+  int cmp = 0;
+  int i = 0;
+
+  if (class_name == NULL || class_name[0] == '\0')
+    {
+      return false;
+    }
+
+  if (!was_initialized)
+    {
+      qsort (system_classes, count, sizeof (system_classes[0]), utility_system_class_def_compare);
+      was_initialized = TRUE;
+    }
+
+  /* The user-specified name is not a system class name. */
+  if (strchr (class_name, '.') != NULL)
+    {
+      return false;
+    }
+
+  sa.name = class_name;
+  sa.len = strlen (class_name);
+
+  if (sa.len > system_classes[count - 1].len)
+    {
+      return false;
+    }
+
+  for (i = 0; i < count; i++)
+    {
+      cmp = utility_system_class_def_compare (&sa, system_classes + i);
+      if (cmp <= 0)
+	{
+	  return (cmp == 0);
+	}
+    }
+
+  return false;
 }

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -1721,6 +1721,7 @@ extern "C"
   extern INT64 utility_get_option_bigint_value (UTIL_ARG_MAP * arg_map, int arg_ch);
   extern int utility_get_option_string_table_size (UTIL_ARG_MAP * arg_map);
   extern int utility_check_class_name (const char *class_name);
+  extern bool utility_check_system_class_name (const char *class_name);
 
   extern FILE *fopen_ex (const char *filename, const char *type);
 

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -118,7 +118,7 @@ namespace cubload
     LC_FIND_CLASSNAME found = LC_CLASSNAME_EXIST;
     LC_FIND_CLASSNAME found_again = LC_CLASSNAME_EXIST;
 
-    if (strchr (class_name, '.'))
+    if (strchr (class_name, '.') || utility_check_system_class_name (class_name))
       {
 	found = xlocator_find_class_oid (&thread_ref, class_name, &class_oid, BU_LOCK);
       }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24609

When loading object files online, system class/vclass does not use the schema name of the current session.