### PR TITLE
[CBRD-24599] Add new csql session command 'SingleLine'

### DIFF
--- a/msg/de_DE.utf8/csql.msg
+++ b/msg/de_DE.utf8/csql.msg
@@ -186,6 +186,7 @@ $ csql help messages
    ;HISTORYList                 - Liste der ausgeführten Abfragen anzeigen.\n\
    ;HISTORYRead <history_num>   - Eintrag über die Verlaufszahl in den Befehlspuffer schreiben.\n\
    ;TRAce [ON/OFF] [text/json]  - enable/disable sql auto trace.\n\
+   ;SIngleline [ON|OFF]         - Single-Line-Modus aktivieren/deaktivieren.\n\
    ;HElp                        - Hilfe anzeigen.\n\n
 
 232 <Beschränkungen> 

--- a/msg/en_US.utf8/csql.msg
+++ b/msg/en_US.utf8/csql.msg
@@ -185,6 +185,7 @@ $ csql help messages
    ;HISTORYList                 - display list of the executed queries.\n\
    ;HISTORYRead <history_num>   - read entry on the history number into command buffer.\n\
    ;TRAce [ON/OFF] [text/json]  - enable/disable sql auto trace.\n\
+   ;SIngleline [ON|OFF]         - enable/disable single-line mode.\n\
    ;HElp                        - display this help message.\n\n
 
 232 <Constraints> 

--- a/msg/en_US/csql.msg
+++ b/msg/en_US/csql.msg
@@ -185,6 +185,7 @@ $ csql help messages
    ;HISTORYList                 - display list of the executed queries.\n\
    ;HISTORYRead <history_num>   - read entry on the history number into command buffer.\n\
    ;TRAce [ON/OFF] [text/json]  - enable/disable sql auto trace.\n\
+   ;SIngleline [ON|OFF]         - enable/disable single-line mode.\n\
    ;HElp                        - display this help message.\n\n
 
 232 <Constraints> 

--- a/msg/es_ES.utf8/csql.msg
+++ b/msg/es_ES.utf8/csql.msg
@@ -185,6 +185,7 @@ $ csql help messages
    ;HISTORYList                 - mostrar lista de las consultas ejecutadas.\n\
    ;HISTORYRead <history_num>   - leer entrada sobre el numero de historia en bufer de comando.\n\
    ;TRAce [ON/OFF] [text/json]  - enable/disable sql auto trace.\n\
+   ;SIngleline [ON|OFF]         - habilitar/deshabilitar el modo de una sola línea.\n\
    ;HElp                        - mostrar este mensaje de ayuda.\n\n
 
 232 <Restricciones>

--- a/msg/fr_FR.utf8/csql.msg
+++ b/msg/fr_FR.utf8/csql.msg
@@ -185,6 +185,7 @@ $ csql help messages
    ;HISTORYList                 - affiche la liste des requêtes exécutées.\n\
    ;HISTORYRead <history_num>   - lit l 'entrée sur le numéro d'historique dans le tampon de commande.\n\
    ;TRAce [ON/OFF] [text/json]  - enable/disable sql auto trace.\n\
+   ;SIngleline [ON|OFF]         - activer/désactiver le mode monoligne.\n\
    ;HElp                        - affiche ce message d'aide.\n\n
 
 232 <Constraints> 

--- a/msg/it_IT.utf8/csql.msg
+++ b/msg/it_IT.utf8/csql.msg
@@ -185,6 +185,7 @@ $ messaggi di aiuto csql
    ;HISTORYList                 - visualizzare l'elenco delle query eseguite.\n\
    ;HISTORYRead <history_num>   - leggere la voce del numero storia in buffer dei comandi.\n\
    ;TRAce [ON/OFF] [text/json]  - attivare/disattivare sql auto trace.\n\
+   ;SIngleline [ON|OFF]         - abilitare/disabilitare la modalità a riga singola.\n\
    ;HElp                        - visualizza questo messaggio di aiuto.\n\n
 
 232 <Vincoli> 

--- a/msg/ja_JP.utf8/csql.msg
+++ b/msg/ja_JP.utf8/csql.msg
@@ -185,6 +185,7 @@ $ csql help messages
    ;HISTORYList                 - 実行したクエリリスト表示。\n\
    ;HISTORYRead <history_num>   - ヒストリー番号のクエリをコマンドバッファーにセーブする。\n\
    ;TRAce [ON/OFF] [text/json]  - enable/disable sql auto trace.\n\
+   ;SIngleline [ON|OFF]         - 単線モードの有効化/無効化.\n\
    ;HElp                        - ヘルプメッセージ出力。\n\n
 
 232 <制約事項> 

--- a/msg/km_KH.utf8/csql.msg
+++ b/msg/km_KH.utf8/csql.msg
@@ -185,6 +185,7 @@ $ csql help messages
    ;HISTORYList                 - display list of the executed queries.\n\
    ;HISTORYRead <history_num>   - read entry on the history number into command buffer.\n\
    ;TRAce [ON/OFF] [text/json]  - enable/disable sql auto trace.\n\
+   ;SIngleline [ON|OFF]         - enable/disable single-line mode.\n\
    ;HElp                        - display this help message.\n\n
 
 232 <Constraints> 

--- a/msg/ko_KR.euckr/csql.msg
+++ b/msg/ko_KR.euckr/csql.msg
@@ -182,6 +182,7 @@ $ csql help messages
    ;HISTORYList                 - 수행된 쿼리 리스트 보기.\n\
    ;HISTORYRead <history_num>   - 히스토리 번호에 해당되는 쿼리를 명령어 버퍼에 올림.\n\
    ;TRAce [ON|OFF] [text/json]  - 쿼리 자동 트레이스 설정|해제.\n\
+   ;SIngleline [ON|OFF]         - 싱글 라인 모드 활성화|비활성화.\n\
    ;HElp                        - 도움말 메시지 출력.\n\n
 
 232 <제약사항> 

--- a/msg/ko_KR.utf8/csql.msg
+++ b/msg/ko_KR.utf8/csql.msg
@@ -182,6 +182,7 @@ $ csql help messages
    ;HISTORYList                 - 수행된 쿼리 리스트 보기.\n\
    ;HISTORYRead <history_num>   - 히스토리 번호에 해당되는 쿼리를 명령어 버퍼에 올림.\n\
    ;TRAce [ON|OFF] [text/json]  - 쿼리 자동 트레이스 설정|해제.\n\
+   ;SIngleline [ON|OFF]         - 싱글 라인 모드 활성화|비활성화.\n\
    ;HElp                        - 도움말 메시지 출력.\n\n
 
 232 <제약사항> 

--- a/msg/ro_RO.utf8/csql.msg
+++ b/msg/ro_RO.utf8/csql.msg
@@ -186,6 +186,7 @@ $ csql help messages
    ;HISTORYRead <history_num>   - citeşte în buffer-ul de comenzi înregistrarea din istoric\n\
                                   specificată prin parametru.\n\
    ;TRAce [ON/OFF] [text/json]  - enable/disable sql auto trace.\n\
+   ;SIngleline [ON|OFF]         - activați/dezactivați modul cu o singură linie.\n\
    ;HElp                        - afişează acest mesaj de ajutor.\n\n
 
 232 <Constrângeri> 

--- a/msg/tr_TR.utf8/csql.msg
+++ b/msg/tr_TR.utf8/csql.msg
@@ -185,6 +185,7 @@ $ csql help messages
    ;HISTORYList                 - çalıştırılan sorguların listesini görüntüleyebilir.\n\
    ;HISTORYRead <history_num>   - komut buffer içine geçmiş numarası üzerinde giriş okuyun.\n\
    ;TRAce [ON/OFF] [text/json]  - sql otomatik iz etkinleştirmek/devre dışı.\n\
+   ;SIngleline [ON|OFF]         - tek hat modunu etkinleştir/devre dışı bırak.\n\
    ;HElp                        - yardım mesajını görüntüler.\n\n
 
 232 <Constraints> 

--- a/msg/vi_VN.utf8/csql.msg
+++ b/msg/vi_VN.utf8/csql.msg
@@ -185,6 +185,7 @@ $ csql help messages
    ;HISTORYList                 - display list of the executed queries.\n\
    ;HISTORYRead <history_num>   - read entry on the history number into command buffer.\n\
    ;TRAce [ON/OFF] [text/json]  - enable/disable sql auto trace.\n\
+   ;SIngleline [ON|OFF]         - bật/tắt chế độ một dòng.\n\
    ;HElp                        - display this help message.\n\n
 
 232 <Constraints> 

--- a/msg/zh_CN.utf8/csql.msg
+++ b/msg/zh_CN.utf8/csql.msg
@@ -185,6 +185,7 @@ $ csql help messages
    ;HISTORYList                 - 显示已经执行的查询列表.\n\
    ;HISTORYRead <history_num>   - 将histroy_num所对应的内容读取到命令缓冲区.\n\
    ;TRAce [ON/OFF] [text/json]  - 启用/禁用 sql auto trace.\n\
+   ;SIngleline [ON|OFF]         - 启用/禁用单行模式.\n\
    ;HElp                        - 显示帮助信息.\n\n
 
 232 <系统规定参数> 

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1439,6 +1439,17 @@ csql_do_session_cmd (char *line_read, CSQL_ARGUMENT * csql_arg)
 	  fprintf (csql_Error_fp, "Auto trace isn't allowed in SA mode.\n");
 	}
       break;
+
+    case S_CMD_SINGLELINE:
+      if (!strcasecmp (argument, "on"))
+	{
+	  csql_arg->single_line_execution = true;
+	}
+      else if (!strcasecmp (argument, "off"))
+	{
+	  csql_arg->single_line_execution = false;
+	}
+      break;
     }
 
   return DO_CMD_SUCCESS;

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1449,8 +1449,10 @@ csql_do_session_cmd (char *line_read, CSQL_ARGUMENT * csql_arg)
 	{
 	  csql_arg->single_line_execution = false;
 	}
-
-      fprintf (csql_Output_fp, "SINGLELINE IS %s\n", (csql_arg->single_line_execution ? "ON" : "OFF"));
+      if (csql_Is_interactive)
+	{
+	  fprintf (csql_Output_fp, "SINGLELINE IS %s\n", (csql_arg->single_line_execution ? "ON" : "OFF"));
+	}
 
       break;
     }

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1449,6 +1449,9 @@ csql_do_session_cmd (char *line_read, CSQL_ARGUMENT * csql_arg)
 	{
 	  csql_arg->single_line_execution = false;
 	}
+
+      fprintf (csql_Output_fp, "SINGLELINE IS %s\n", (csql_arg->single_line_execution ? "ON" : "OFF"));
+
       break;
     }
 

--- a/src/executables/csql.h
+++ b/src/executables/csql.h
@@ -234,7 +234,9 @@ extern "C"
     S_CMD_HISTORY_READ,
     S_CMD_HISTORY_LIST,
 
-    S_CMD_TRACE
+    S_CMD_TRACE,
+
+    S_CMD_SINGLELINE
   } SESSION_CMD;
 
 /* iq_ function return status */

--- a/src/executables/csql_session.c
+++ b/src/executables/csql_session.c
@@ -124,7 +124,9 @@ static SESSION_CMD_TABLE csql_Session_cmd_table[] = {
   {"historyread", S_CMD_HISTORY_READ, CMD_EMPTY_FLAG},
   {"historylist", S_CMD_HISTORY_LIST, CMD_EMPTY_FLAG},
 
-  {"trace", S_CMD_TRACE, CMD_CHECK_CONNECT}
+  {"trace", S_CMD_TRACE, CMD_CHECK_CONNECT},
+
+  {"singleline", S_CMD_SINGLELINE, CMD_EMPTY_FLAG}
 };
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24599

**Purpose**

- In csql, there are two modes to handle sql statements.

        single line (with semicolon, handling sql each line)
        --no-single-line (handling the sql at once with ;xr or ;r session command)
        

- To csql change mode, we must quit the csql and restart with '--no-single-line' option or not. 
So, we need to switch the both modes while csql is working.
This session command will help user use csql more convenient.

**Implementation**

Add new csql session command.

**Remarks**

N/A