### PR TITLE
[LETS-630] reduce window of opportunity in passive transaction server atomic replication mechanism

### DIFF
--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -868,7 +868,7 @@ namespace cublog
 			   " VPID: %d|%d, LSA: %lld|%d and index %d",
 			   VPID_AS_ARGS (&m_vpid), LSA_AS_ARGS (&m_lsa), m_rcvindex);
       }
-    const log_rec_header header = redo_context.m_reader.reinterpret_copy_and_add_align<log_rec_header> ();
+    const LOG_RECORD_HEADER header = redo_context.m_reader.reinterpret_copy_and_add_align<LOG_RECORD_HEADER> ();
 
     switch (header.type)
       {

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -92,7 +92,7 @@ namespace cublog
     private:
       atomic_replication_helper m_atomic_helper;
 
-      log_lsa m_processed_lsa = NULL_LSA; /* protected by m_redo_lsa_mutex with m_redo_lsa */
+      log_lsa m_processed_lsa = NULL_LSA;
       mutable std::mutex m_processed_lsa_mutex;
 
       log_lsa m_lowest_unapplied_lsa;

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -91,8 +91,11 @@ namespace cublog
 
     private:
       atomic_replication_helper m_atomic_helper;
-      log_lsa m_lowest_unapplied_lsa;
+
       log_lsa m_processed_lsa = NULL_LSA; /* protected by m_redo_lsa_mutex with m_redo_lsa */
+      mutable std::mutex m_processed_lsa_mutex;
+
+      log_lsa m_lowest_unapplied_lsa;
       mutable std::mutex m_lowest_unapplied_lsa_mutex;
   };
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-630

Suppose that the replication must replicate an atomic sequence for which there are 2 log records for the same page (VPID1):
  - LSA(i-1)
  - LSA(i)

Chronologically, in a corner case scenario, the following sequence of actions is possible:
- the replication processes the first log record LSA(i-1) and attempts to fix the page VPID1
  - the replication fails to fix the page VPID1 because the page is not in the PTS's page buffer
- at this point the atomic replication reports as having the following state:
  - m_processed_lsa = LSA(i-2)
  - m_redo_lsa = LSA(i-1)
  - this version supposes that the currently executing instruction on the replication thread is somewhere within function `atomic_replicator::redo_upto` BEFORE the synchronized sequence where `m_processed_lsa` and `m_redo_lsa` are advanced
- a client transaction also tries to fix page VPID1 and succeeds:
  - the page is requested to Page Server to be retrieved having LSA(i-2) already processed (see implementation for `atomic_replicator::get_highest_processed_lsa`)
  - the PS waits for its own replication to have already passed LSA(i-2) (so LSA(i-2) is already applied to its respective page but LSA(i-1) is not guaranteed to have been applied to VPID1)
  - at this point, the PTS client transaction fixes for read page VPID1 with applied LSA(i-2) but not with LSA(i-1) (in the worst case scenario)
- the client transaction does its job and unfixes the page VPID1
- the replication thread steps in and attempts to fix page VPID1 to apply the log at LSA(i)
  - but the page does not contain the modification from LSA(i-1)
- this is the window of opportunity that must be avoided

This window is fixed by advancing the `atomic_replicator::m_processed_lsa` sooner such that - for the time interval where the log record (eg LSA(i-1)) is actually being processed - the replication reports that `LSA(i-1)` has *actually* been processed. Thus, it will force a client transaction that executes the corner case scenario described above to actually wait for the Page Server to have actually applied LSA(i-1) (because Page Server - as opposed to the "speculative" replication of a Passive Transaction Server - performs an "exhaustive" replication of *all* log records - thus will also apply LSA(i-1).

Implementation:
- because `m_processed_lsa` and `m_redo_lsa` (aka "about to be processed lsa") are changed at different moments, it made sense to segregate the mutexes guarding each one
- added missing calls to `set_lowest_unapplied_lsa` where needed and added comment
