### PR TITLE
[LETS-425] small refactor; remove functions; TBD

### DIFF
--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -210,7 +210,7 @@ page_server::connection_handler::receive_oldest_active_mvccid (tran_server_conn_
 {
   assert (m_server_type == transaction_server_type::PASSIVE);
 
-  const auto oldest_mvccid = *reinterpret_cast<const MVCCID *const> (a_sp.pull_payload().c_str());
+  const auto oldest_mvccid = *reinterpret_cast<const MVCCID *> (a_sp.pull_payload().c_str());
 
   m_ps.m_pts_mvcc_tracker.update_oldest_active_mvccid (get_connection_id (), oldest_mvccid);
 }

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -19,7 +19,7 @@
 #ifndef _PASSIVE_TRAN_SERVER_HPP_
 #define _PASSIVE_TRAN_SERVER_HPP_
 
-#include "log_replication.hpp"
+#include "log_replication_atomic.hpp"
 #include "tran_server.hpp"
 
 class passive_tran_server : public tran_server
@@ -58,7 +58,7 @@ class passive_tran_server : public tran_server
     void stop_outgoing_page_server_messages () final override;
 
   private:
-    std::unique_ptr<cublog::replicator> m_replicator;
+    std::unique_ptr<cublog::atomic_replicator> m_replicator;
     cubthread::daemon *m_oldest_active_mvccid_sender = nullptr;
     /* the oldest visible mvcc id considering the replicator and RO transactions */
     MVCCID m_oldest_active_mvccid = MVCCID_NULL;

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -149,6 +149,17 @@ namespace cublog
   {
     LOG_LSA min_lsa = MAX_LSA;
 
+    // NOTE: the calculation is simplistic:
+    //  - even if an atomic sequence is still present; it does not mean that the start
+    //    of that sequence is the lowest unprocessed lsa
+    //  - this is caused by the fact that an atomic sequence is not applied once
+    //    in etirety; but, it is applied in bursts as guided by every new "control
+    //    log" that is processed
+    //  - the calculation can be made more accurate by more closely following the
+    //    the in burst progress of applying logs in the sequence
+    //  - however, the gain would be marginal as most atomic sequences are so small
+    //    that it would not really make a difference
+    //
     for (auto const &sequence_map_iterator : m_sequences_map)
       {
 	const atomic_log_sequence &sequence = sequence_map_iterator.second;

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -517,37 +517,6 @@ namespace cublog
     return m_most_recent_trantable_snapshot_lsa.load ();
   }
 
-  log_lsa
-  replicator::get_highest_processed_lsa () const
-  {
-    /*
-     * This is supposed to return the processed lsa by the replicator.
-     * In the case of atomic replicator on PTS, it points to the log record redone, that m_redo_lsa pointed to.
-     * However, "processed" means vague to the replicator of PS, with the parallel redo,
-     * because the replicator just put the redo records to workers and updates m_redo_lsa.
-     * Anyway, now get_highest_processed_lsa() is only used on PTS, so assert(false) here.
-     */
-    assert (false);
-    return MAX_LSA;
-  }
-
-  log_lsa
-  replicator::get_lowest_unapplied_lsa () const
-  {
-    assert (false);
-    // TODO: needs to be refactored to work with the new replicators flavors
-    if (m_parallel_replication_redo == nullptr)
-      {
-	std::lock_guard<std::mutex> lockg (m_redo_lsa_mutex);
-	return m_redo_lsa;
-      }
-
-    // a different value will return from here when the atomic replicator is added
-    // for now this part should not be reached
-    assert (false);
-    return MAX_LSA;
-  }
-
   /*********************************************************************
    * replication b-tree unique statistics - definition
    *********************************************************************/

--- a/src/transaction/log_replication.cpp
+++ b/src/transaction/log_replication.cpp
@@ -494,7 +494,6 @@ namespace cublog
   void
   replicator::wait_past_target_lsa (const log_lsa &a_target_lsa)
   {
-    // TODO: needs to be refactored to work with the new replicators flavors
     if (m_parallel_replication_redo == nullptr)
       {
 	// sync

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -71,10 +71,6 @@ namespace cublog
 
       /* wait until replication advances past the target lsa; blocking call */
       void wait_past_target_lsa (const log_lsa &a_target_lsa);
-      /* return current progress of the replicator; non-blocking call */
-      virtual log_lsa get_highest_processed_lsa () const;
-      /* return the lowest value lsa that was not applied, the next in line lsa */
-      virtual log_lsa get_lowest_unapplied_lsa () const;
 
       log_lsa get_most_recent_trantable_snapshot_lsa () const;
 

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -78,9 +78,9 @@ namespace cublog
       atomic_replicator &operator= (atomic_replicator &&) = delete;
 
       /* return current progress of the replicator */
-      log_lsa get_highest_processed_lsa () const override;
+      log_lsa get_highest_processed_lsa () const;
       /* return the lowest value lsa that was not applied, the next in line lsa */
-      log_lsa get_lowest_unapplied_lsa () const override;
+      log_lsa get_lowest_unapplied_lsa () const;
     private:
       void redo_upto (cubthread::entry &thread_entry, const log_lsa &end_redo_lsa) override;
       template <typename T>


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-425

- functions `get_highest_processed_lsa` and `get_lowest_unapplied_lsa` are only used in the derived `atomic_replicator` class
- removed these from base class `replicator` and adapted code in `passive_tran_server` class
- comments
