### PR TITLE
[CBRD-24645] When order-by of subquery is copied to main query during view merging, rownum of main query is displayed incorrectly

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -535,6 +535,7 @@ extern "C"
   extern bool pt_has_order_sensitive_agg (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_inst_or_orderby_num (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_inst_num (PARSER_CONTEXT * parser, PT_NODE * node);
+  extern bool pt_has_expr_of_inst_in_sel_list (PARSER_CONTEXT * parser, PT_NODE * select_list);
   extern bool pt_has_inst_in_where_and_select_list (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_inst_or_orderby_num_in_where (PARSER_CONTEXT * parser, PT_NODE * node);
   extern void pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3354,7 +3354,7 @@ pt_has_inst_num (PARSER_CONTEXT * parser, PT_NODE * node)
 }
 
 /*
- * pt_has_inst_num () - check if tree has an EXPR node having INST_NUM in select list
+ * pt_has_expr_of_inst_in_sel_list  () - check if tree has an EXPR node having INST_NUM in select list
  *   return: true if tree has EXPR node having INST_NUM
  *   parser(in):
  *   node(in):

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3354,6 +3354,44 @@ pt_has_inst_num (PARSER_CONTEXT * parser, PT_NODE * node)
 }
 
 /*
+ * pt_has_inst_num () - check if tree has an EXPR node having INST_NUM in select list
+ *   return: true if tree has EXPR node having INST_NUM
+ *   parser(in):
+ *   node(in):
+ */
+bool
+pt_has_expr_of_inst_in_sel_list (PARSER_CONTEXT * parser, PT_NODE * select_list)
+{
+  PT_NODE *save_next, *col;
+
+  /*
+   * FIXME!! : remove this check after expanding syntax related to orderby_num().
+   * This check is needed because the syntax below is not supported.
+   * 'select orderby_num() + 10 ...'
+   * Check MSGCAT_SEMANTIC_ORDERBYNUM_SELECT_LIST_ERR error code
+   * In XASL Generator, 'ordbynum_val' must be created as a regular variable, not db_value.
+   */
+  col = select_list;
+  while (col)
+    {
+      /* cut off next */
+      save_next = col->next;
+      col->next = NULL;
+
+      if (!PT_IS_INSTNUM (col) && pt_has_inst_num (parser, col))
+	{
+	  /* find expr of instnum */
+	  col->next = save_next;
+	  return true;
+	}
+      col->next = save_next;
+      col = col->next;
+    }
+
+  return false;
+}
+
+/*
  * pt_has_inst_in_where_and_select_list ()
  *          - check if tree has an INST_NUM or ORDERBY_NUM or GROUPBY_NUM node in where and select_list
  *   return: true if tree has INST_NUM/ORDERBY_NUM

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3354,7 +3354,7 @@ pt_has_inst_num (PARSER_CONTEXT * parser, PT_NODE * node)
 }
 
 /*
- * pt_has_expr_of_inst_in_sel_list  () - check if tree has an EXPR node having INST_NUM in select list
+ * pt_has_expr_of_inst_in_sel_list () - check if tree has an EXPR node having INST_NUM in select list
  *   return: true if tree has EXPR node having INST_NUM
  *   parser(in):
  *   node(in):

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -2171,6 +2171,10 @@ mq_update_order_by (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * quer
   /* generate orderby_num(), inst_num() */
   if (!(ord_num = parser_new_node (parser, PT_EXPR)) || !(ins_num = parser_new_node (parser, PT_EXPR)))
     {
+      if (ord_num)
+	{
+	  parser_free_tree (parser, ord_num);
+	}
       PT_ERRORm (parser, statement, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
       return NULL;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24645

When 'ORDER BY' is copied to the main query during view-merging, I fix so that 'ROWNUM' of the select list of the main query is replaced with 'ORDERBY_NUM'.
Since expression having orderby_num() such as 'orderby_num() + 1' is not supported, expr having rownum such as 'rownum+1' is restricted from view merging.
Hopefully, I'll take care of it later. 