### PR TITLE
[LETS-85] Active transaction server sends the log to all page servers

### DIFF
--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -97,9 +97,10 @@ active_tran_server::on_boot ()
 
   for (size_t i = 0; i < get_connected_page_server_count (); i++)
     {
-      m_prior_sender_sink_hooks.emplace_back (std::bind (static_cast<request_functor_t> (&active_tran_server::push_request),
-					      this, i, tran_to_page_request::SEND_LOG_PRIOR_LIST, std::placeholders::_1));
-      log_Gl.m_prior_sender.add_sink (m_prior_sender_sink_hooks.back ());
+      m_prior_sender_sink_hooks.emplace_back (std::make_unique <cublog::prior_sender::sink_hook_t> (
+	  std::bind (static_cast<request_functor_t> (&active_tran_server::push_request),				      this, i,
+		     tran_to_page_request::SEND_LOG_PRIOR_LIST, std::placeholders::_1)));
+      log_Gl.m_prior_sender.add_sink (*m_prior_sender_sink_hooks.back ());
     }
 }
 
@@ -123,6 +124,6 @@ active_tran_server::stop_outgoing_page_server_messages ()
 {
   for (const auto &sink : m_prior_sender_sink_hooks)
     {
-      log_Gl.m_prior_sender.remove_sink (sink);
+      log_Gl.m_prior_sender.remove_sink (*sink);
     }
 }

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -92,14 +92,10 @@ active_tran_server::on_boot ()
 {
   assert (is_active_transaction_server ());
 
-  /* the signature of the push_request */
-  using request_functor_t = void (active_tran_server::*) (size_t, tran_to_page_request, std::string &&);
-
   for (size_t i = 0; i < get_connected_page_server_count (); i++)
     {
-      m_prior_sender_sink_hooks.emplace_back (std::make_unique <cublog::prior_sender::sink_hook_t> (
-	  std::bind (static_cast<request_functor_t> (&active_tran_server::push_request),				      this, i,
-		     tran_to_page_request::SEND_LOG_PRIOR_LIST, std::placeholders::_1)));
+      m_prior_sender_sink_hooks.emplace_back (std::make_unique <cublog::prior_sender::sink_hook_t> (std::bind (
+	  &active_tran_server::push_request_to, this, i, tran_to_page_request::SEND_LOG_PRIOR_LIST, std::placeholders::_1)));
       log_Gl.m_prior_sender.add_sink (*m_prior_sender_sink_hooks.back ());
     }
 }

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -92,7 +92,7 @@ active_tran_server::on_boot ()
 {
   assert (is_active_transaction_server ());
 
-  for (size_t i = 0; i < get_connected_page_server_count(); i++)
+  for (size_t i = 0; i < get_connected_page_server_count (); i++)
     {
       m_prior_sender_sink_hooks.emplace_back (std::bind (&active_tran_server::push_request_to, this, i,
 					      tran_to_page_request::SEND_LOG_PRIOR_LIST,

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -92,11 +92,13 @@ active_tran_server::on_boot ()
 {
   assert (is_active_transaction_server ());
 
+  /* the signature of the push_request */
+  using request_functor_t = void (active_tran_server::*) (size_t, tran_to_page_request, std::string &&);
+
   for (size_t i = 0; i < get_connected_page_server_count (); i++)
     {
-      m_prior_sender_sink_hooks.emplace_back (std::bind (&active_tran_server::push_request_to, this, i,
-					      tran_to_page_request::SEND_LOG_PRIOR_LIST,
-					      std::placeholders::_1));
+      m_prior_sender_sink_hooks.emplace_back (std::bind (static_cast<request_functor_t> (&active_tran_server::push_request),
+					      this, i, tran_to_page_request::SEND_LOG_PRIOR_LIST, std::placeholders::_1));
       log_Gl.m_prior_sender.add_sink (m_prior_sender_sink_hooks.back ());
     }
 }

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -22,7 +22,8 @@
 #include "log_prior_send.hpp"
 #include "tran_server.hpp"
 
-#include <list>
+#include <vector>
+#include <memory>
 
 class active_tran_server : public tran_server
 {
@@ -51,7 +52,7 @@ class active_tran_server : public tran_server
      * sends prior nodes to the page servers.
      * The order can differ from m_page_server_conn_vec
      */
-    std::list<cublog::prior_sender::sink_hook_t> m_prior_sender_sink_hooks;
+    std::vector<std::unique_ptr<cublog::prior_sender::sink_hook_t>> m_prior_sender_sink_hooks;
 };
 
 #endif // !_ACTIVE_TRAN_SERVER_HPP_

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -22,6 +22,8 @@
 #include "log_prior_send.hpp"
 #include "tran_server.hpp"
 
+#include <list>
+
 class active_tran_server : public tran_server
 {
   public:
@@ -45,7 +47,11 @@ class active_tran_server : public tran_server
   private:
     bool m_uses_remote_storage = false;
 
-    cublog::prior_sender::sink_hook_t m_prior_sender_sink_hook_func;
+    /*
+     * sends prior nodes to the page servers.
+     * The order can differ from m_page_server_conn_vec
+     */
+    std::list<cublog::prior_sender::sink_hook_t> m_prior_sender_sink_hooks;
 };
 
 #endif // !_ACTIVE_TRAN_SERVER_HPP_

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -360,7 +360,7 @@ tran_server::uses_remote_storage () const
 }
 
 void
-tran_server::push_request_to (size_t idx, tran_to_page_request reqid, std::string &&payload)
+tran_server::push_request (size_t idx, tran_to_page_request reqid, std::string &&payload)
 {
   assert (idx < m_page_server_conn_vec.size());
   if (!is_page_server_connected ())
@@ -375,7 +375,7 @@ void
 tran_server::push_request (tran_to_page_request reqid, std::string &&payload)
 {
   // TODO push a request to the "main connection"
-  push_request_to (0, reqid, std::move (payload));
+  push_request (0, reqid, std::move (payload));
 }
 
 int

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -366,7 +366,7 @@ tran_server::uses_remote_storage () const
 }
 
 void
-tran_server::push_request (size_t idx, tran_to_page_request reqid, std::string &&payload)
+tran_server::push_request_to (size_t idx, tran_to_page_request reqid, std::string &&payload)
 {
   assert (idx < m_page_server_conn_vec.size());
   if (!is_page_server_connected (idx))
@@ -381,7 +381,7 @@ void
 tran_server::push_request (tran_to_page_request reqid, std::string &&payload)
 {
   // TODO push a request to the "main connection"
-  push_request (0, reqid, std::move (payload));
+  push_request_to (0, reqid, std::move (payload));
 }
 
 int

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -354,6 +354,14 @@ tran_server::is_page_server_connected () const
 }
 
 bool
+tran_server::is_page_server_connected (const size_t idx) const
+{
+  assert_is_tran_server ();
+
+  return m_page_server_conn_vec.size () > idx;
+}
+
+bool
 tran_server::uses_remote_storage () const
 {
   return false;
@@ -363,7 +371,7 @@ void
 tran_server::push_request (size_t idx, tran_to_page_request reqid, std::string &&payload)
 {
   assert (idx < m_page_server_conn_vec.size());
-  if (!is_page_server_connected ())
+  if (!is_page_server_connected (idx))
     {
       return;
     }
@@ -381,7 +389,7 @@ tran_server::push_request (tran_to_page_request reqid, std::string &&payload)
 int
 tran_server::send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out) const
 {
-  assert (is_page_server_connected ());
+  assert (is_page_server_connected (0));
 
   // TODO push a request to the "main connection"
   const css_error_code error_code = m_page_server_conn_vec[0]->send_recv (reqid, std::move (payload_in), payload_out);

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -199,15 +199,13 @@ tran_server::init_page_server_hosts (const char *db_name)
   bool failed_conn = false;
   for (const cubcomm::node &node : m_connection_list)
     {
-      const int local_exit_code = connect_to_page_server (node, db_name);
-      if (local_exit_code == NO_ERROR)
+      exit_code = connect_to_page_server (node, db_name);
+      if (exit_code == NO_ERROR)
 	{
 	  ++valid_connection_count;
-	  exit_code = NO_ERROR;
 	}
       else
 	{
-	  exit_code = local_exit_code;
 	  failed_conn = true;
 	  er_log_debug (ARG_FILE_LINE, "Failed to connect to host: %s port: %d\n", node.get_host ().c_str (), node.get_port ());
 	}

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -74,6 +74,7 @@ class tran_server
 
     void disconnect_page_server ();
     bool is_page_server_connected () const;
+    void push_request_to (size_t idx, tran_to_page_request reqid, std::string &&payload);
     void push_request (tran_to_page_request reqid, std::string &&payload);
     int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out) const;
 
@@ -84,6 +85,8 @@ class tran_server
     using request_handlers_map_t = std::map<page_to_tran_request, page_server_conn_t::incoming_request_handler_t>;
 
   protected:
+
+    size_t get_connected_page_server_count () const;
 
     // Booting functions that require specialization
     virtual bool get_remote_storage_config () = 0;

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -74,7 +74,7 @@ class tran_server
 
     void disconnect_page_server ();
     bool is_page_server_connected () const;
-    void push_request_to (size_t idx, tran_to_page_request reqid, std::string &&payload);
+    void push_request (size_t idx, tran_to_page_request reqid, std::string &&payload);
     void push_request (tran_to_page_request reqid, std::string &&payload);
     int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out) const;
 

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -86,7 +86,6 @@ class tran_server
     using request_handlers_map_t = std::map<page_to_tran_request, page_server_conn_t::incoming_request_handler_t>;
 
   protected:
-
     size_t get_connected_page_server_count () const;
 
     // Booting functions that require specialization
@@ -99,7 +98,6 @@ class tran_server
     virtual request_handlers_map_t get_request_handlers ();
 
   private:
-
     int init_page_server_hosts (const char *db_name);
     int get_boot_info_from_page_server ();
     int connect_to_page_server (const cubcomm::node &node, const char *db_name);
@@ -108,7 +106,6 @@ class tran_server
     int parse_page_server_hosts_config (std::string &hosts);
 
   private:
-
     std::vector<cubcomm::node> m_connection_list;
     cubcomm::server_server m_conn_type;
     std::vector<std::unique_ptr<page_server_conn_t>> m_page_server_conn_vec;

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -75,7 +75,7 @@ class tran_server
     void disconnect_page_server ();
     bool is_page_server_connected () const;
     bool is_page_server_connected (const size_t idx) const;
-    void push_request (const size_t idx, tran_to_page_request reqid, std::string &&payload);
+    void push_request_to (size_t idx, tran_to_page_request reqid, std::string &&payload);
     void push_request (tran_to_page_request reqid, std::string &&payload);
     int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out) const;
 

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -74,7 +74,8 @@ class tran_server
 
     void disconnect_page_server ();
     bool is_page_server_connected () const;
-    void push_request (size_t idx, tran_to_page_request reqid, std::string &&payload);
+    bool is_page_server_connected (const size_t idx) const;
+    void push_request (const size_t idx, tran_to_page_request reqid, std::string &&payload);
     void push_request (tran_to_page_request reqid, std::string &&payload);
     int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out) const;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-85

- Add prior sinks for each connected page server connection.
- Set `exit_code = NO_ERROR` when a pager server connection fails to start ATS without it.
- Add `push_request_to` to request to a specific server with an index.
- I don't handle the case where some PS are disconnected while ATS is running. It's going to be handled in another issue.
