### PR TITLE
[CBRD-24640] Specify the upper and lower bounds of the tde_default_algorithm parameter.

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2213,7 +2213,9 @@ static bool prm_heap_info_cache_logging_default = false;
 static unsigned int prm_heap_info_cache_logging_flag = 0;
 
 int PRM_TDE_DEFAULT_ALGORITHM = TDE_ALGORITHM_AES;
-static int prm_tde_default_algorithm = TDE_ALGORITHM_AES;
+static int prm_tde_algorithm_default = TDE_ALGORITHM_AES;
+static int prm_tde_algorithm_upper = TDE_ALGORITHM_ARIA;
+static int prm_tde_algorithm_lower = TDE_ALGORITHM_NONE;
 static unsigned int prm_tde_default_algorithm_flag = 0;
 
 int PRM_ER_LOG_TDE = false;
@@ -5886,9 +5888,9 @@ SYSPRM_PARAM prm_Def[] = {
    (PRM_FOR_CLIENT | PRM_FOR_SERVER),
    PRM_KEYWORD,
    &prm_tde_default_algorithm_flag,
-   (void *) &prm_tde_default_algorithm,
+   (void *) &prm_tde_algorithm_default,
    (void *) &PRM_TDE_DEFAULT_ALGORITHM,
-   (void *) NULL, (void *) NULL,
+   (void *) &prm_tde_algorithm_upper, (void *) &prm_tde_algorithm_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24640

Purpose

The limits have been added to prevent the value changes of tde_default_algorithm parameter to a value other than TDE_ALGORITHM (TDE_ALGORITHM_NONE, TDE_ALGORITHM_AES, TDE_ALGORITHM_ARIA).
Below is an enumeration of TDE_ALGORITHM.
```
typedef enum
{
  TDE_ALGORITHM_NONE = 0,
  TDE_ALGORITHM_AES = 1,	/* AES 256 */
  TDE_ALGORITHM_ARIA = 2,	/* ARIA 256 */
} TDE_ALGORITHM;
```
<br />

The upper and lower bounds have been added here.
system_parameter.c: 5886
```
 {PRM_ID_TDE_DEFAULT_ALGORITHM,
   PRM_NAME_TDE_DEFAULT_ALGORITHM,
   (PRM_FOR_CLIENT | PRM_FOR_SERVER),
   PRM_KEYWORD,
   &prm_tde_default_algorithm_flag,
   (void *) &prm_tde_algorithm_default,
   (void *) &PRM_TDE_DEFAULT_ALGORITHM,
   (void *) &prm_tde_algorithm_upper, (void *) &prm_tde_algorithm_lower,    << here
   (char *) NULL,
```

Implementation
N/A

Remarks
N/A
