### PR TITLE
[LETS-425] overloaded dtor for server request responder task; adapt dependent code

### DIFF
--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -116,6 +116,8 @@ namespace cubcomm
       sequenced_payload &operator= (sequenced_payload &&other);
       sequenced_payload &operator= (const sequenced_payload &) = delete;
 
+      sequenced_payload &operator= (std::nullptr_t);
+
       void push_payload (T_PAYLOAD &&a_payload);
       T_PAYLOAD pull_payload ();
 
@@ -342,6 +344,17 @@ namespace cubcomm
 
 	other.m_rsn = NO_RESPONSE_SEQUENCE_NUMBER;
       }
+    return *this;
+  }
+
+
+  template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
+  typename request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload &
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::operator= (
+	  std::nullptr_t)
+  {
+    m_rsn = NO_RESPONSE_SEQUENCE_NUMBER;
+    m_user_payload.clear ();
     return *this;
   }
 

--- a/src/server/server_request_responder.hpp
+++ b/src/server/server_request_responder.hpp
@@ -136,6 +136,8 @@ class server_request_responder<T_CONN>::task : public cubthread::entry_task
     task (server_request_responder &request_responder, connection_t &a_conn_ref,
 	  sequenced_payload_t &&a_sp, handler_func_t &&a_func);
 
+    ~task () override;
+
     task (const task &) = delete;
     task (task &&) = delete;
 
@@ -281,6 +283,13 @@ server_request_responder<T_CONN>::task::task (server_request_responder &request_
   , m_sequenced_payload (std::move (a_sp))
   , m_function (std::move (a_func))
 {
+}
+
+template<typename T_CONN>
+server_request_responder<T_CONN>::task::~task ()
+{
+  m_sequenced_payload = nullptr;
+  m_function = nullptr;
 }
 
 template<typename T_CONN>

--- a/unit_tests/server/test_server_request_responder_main.cpp
+++ b/unit_tests/server/test_server_request_responder_main.cpp
@@ -29,7 +29,7 @@ struct test_thread_init_final
 {
   test_thread_init_final ()
   {
-    initialize_fake_system_parameters();
+    initialize_fake_system_parameters ();
 
     THREAD_ENTRY *thread_p = NULL;
     cubthread::initialize (thread_p);
@@ -62,6 +62,12 @@ class test_conn
 	  : m_rsn (a_rsn)
 	  , m_payload (a_payload)
 	{
+	}
+
+	sequenced_payload &operator= (std::nullptr_t)
+	{
+	  m_rsn = 0;
+	  m_payload = 0;
 	}
 
 	payload_t pull_payload ()


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-425

This patch changes nothing functionally, it just contains formalisms:
- add an overloaded dtor for `class server_request_responder::task`
- adapt dependent code:
  - `request_sync_client_server::sequenced_payload::operator= (std::nullptr_t)`
  - unit test
