### PR TITLE
[CBRD-24630] The stop command of cubrid hb (applylogdb/repl) does not work correctly when the build is generated in the QA environment, release mode and devtoolset-9

### DIFF
--- a/src/executables/commdb.c
+++ b/src/executables/commdb.c
@@ -704,7 +704,7 @@ process_is_registered_proc (CSS_CONN_ENTRY * conn, char *args)
   rid = send_request_one_arg (conn, IS_REGISTERED_HA_PROC, (char *) buffer, len);
   return_string (conn, rid, &reply_buffer, &size);
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24630

Purpose
- when the build is created in the QA env, release mode and devtoolset-9, the stop command of cubrid hb (applylogdb or replication) doesn't work correctly
- the reason is not clear. But the problem is related to the strcmp function. The following code block is in the process_is_registered_proc(). And the if condition checks the response from cub_master in order to check the copylogdb or applylogdb is alive
`if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)` 
- the problem is that the strcmp() returns a positive value even if values of arguments are equal
  - when I try to dump values of arguments as hexa, they have same values with null termination
  - when I try to compare them using memcmp(), strcmp()(again), they return 0
  - when I try to check the length of them using strlen(), they return 1 (it means values are terminated with null)
- now, I don't have any options to handle this problem. But when I change the strcmp() to strncmp(), the problem is disapeared. So I apply this fix for the regression test temparaly(or permenantly if there are no solution)

Implementation
- strcmp() -> strncmp()

Remarks
- the problem is occurred after changing devtoolset-8 to devtoolset-9
