### PR TITLE
[CBRD-24389] Fix for creating DIR for ADMIN_LOG_FILE, in Windows

### DIFF
--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -275,11 +275,17 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 
   if (admin_log_file != NULL)
     {
-      admin_log2 = strdup (admin_log_file);
+      char buf[BROKER_PATH_MAX];
+
+#if defined (WINDOWS)
+      admin_log2 = _fullpath (buf, admin_log_file, BROKER_PATH_MAX);
+#else
+      admin_log2 = admin_log_file;
+#endif /* WINDOWS */
+
       if (admin_log2)
 	{
 	  broker_create_dir (dirname (admin_log2));
-	  free (admin_log2);
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24389

**Purpose**
* create file/directory for **ADMIN_LOG_FILE**, if it is not exists
* Directory creation fails on Windows because _dirname_() does not return the result we expect.

Implementation

Remarks
* Set **ADMIN_LOG_FILE** in cubrid_broker.conf as follows:
  ADMIN_LOG_FILE =log/broker2/cubrid_broker.log
* The function below is called to create a directory (broker_admin_pub.c:281)
  `broker_create_dir (dirname ("C:\CUBRID\/log/broker2/cubrid_broker.log"));`
* After dirname() terminates, it expands as follows.
  `broker_create_dir ("C:\CUBRID");`
