### PR TITLE
[CBRD-24654] When getting a NUMERIC type value, if the value after the decimal point is 0, it should be improved so that the trailing 0's are not passed.

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -712,6 +712,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_REGEXP_ENGINE "regexp_engine"
 
+#define PRM_NAME_ORACLE_STYLE_NUMBER_RETURN "oracle_style_number_return"
+
 #define PRM_VALUE_DEFAULT "DEFAULT"
 #define PRM_VALUE_MAX "MAX"
 #define PRM_VALUE_MIN "MIN"
@@ -2339,6 +2341,10 @@ static int prm_regexp_engine_lower = cubregex::engine_type::LIB_CPPSTD;
 static int prm_regexp_engine_upper = cubregex::engine_type::LIB_RE2;
 static unsigned int prm_regexp_engine_flag = 0;
 /* *INDENT-ON* */
+
+bool PRM_ORACLE_STYLE_NUMBER_RETURN = false;
+static bool prm_oracle_style_number_return_default = false;
+static unsigned int prm_oracle_style_number_return_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -6155,6 +6161,17 @@ SYSPRM_PARAM prm_Def[] = {
    (void *) &PRM_REGEXP_ENGINE,
    (void *) &prm_regexp_engine_upper,
    (void *) &prm_regexp_engine_lower,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_ORACLE_STYLE_NUMBER_RETURN,
+   PRM_NAME_ORACLE_STYLE_NUMBER_RETURN,
+   (PRM_FOR_SERVER | PRM_FORCE_SERVER),
+   PRM_BOOLEAN,
+   &prm_oracle_style_number_return_flag,
+   (void *) &prm_oracle_style_number_return_default,
+   (void *) &PRM_ORACLE_STYLE_NUMBER_RETURN,
+   (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -465,8 +465,9 @@ enum param_id
   PRM_ID_USE_USER_HOSTS,
   PRM_ID_QMGR_MAX_QUERY_PER_TRAN,
   PRM_ID_REGEXP_ENGINE,
+  PRM_ID_ORACLE_STYLE_NUMBER_RETURN,
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_REGEXP_ENGINE
+  PRM_LAST_ID = PRM_ID_ORACLE_STYLE_NUMBER_RETURN
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -3852,6 +3852,8 @@ numeric_db_value_print (const DB_VALUE * val, char *buf)
   bool found_first_non_zero = false;
   int scale = db_value_scale (val);
 
+  static bool oracle_style_number = prm_get_bool_value (PRM_ID_ORACLE_STYLE_NUMBER_RETURN);
+
   assert (val != NULL && buf != NULL);
 
   if (DB_IS_NULL (val))
@@ -3871,8 +3873,7 @@ numeric_db_value_print (const DB_VALUE * val, char *buf)
       /* Add the negative sign */
       if (temp[i] == '-')
 	{
-	  buf[nbuf] = '-';
-	  nbuf++;
+	  buf[nbuf++] = '-';
 	}
 
       /* Add decimal point */
@@ -3880,21 +3881,27 @@ numeric_db_value_print (const DB_VALUE * val, char *buf)
 	{
 	  int k = temp_size - 1;
 
-	  /* remove trailing zero */
-	  while (k > i && temp[k] == '0')
+	  if (oracle_style_number)
 	    {
-	      k--;
-	    }
+	      /* remove trailing zero */
+	      while (k > i && temp[k] == '0')
+		{
+		  k--;
+		}
 
-	  temp_size = k + 1;
-	  if (temp[k] == '0')
-	    {
-	      continue;
+	      temp_size = k + 1;
+	      if (temp[k] == '0')
+		{
+		  continue;
+		}
+	      else if (k >= i)
+		{
+		  buf[nbuf++] = '.';
+		}
 	    }
-	  else if (k >= i)
+	  else
 	    {
-	      buf[nbuf] = '.';
-	      nbuf++;
+	      buf[nbuf++] = '.';
 	    }
 	}
 
@@ -3907,8 +3914,7 @@ numeric_db_value_print (const DB_VALUE * val, char *buf)
       /* Remove leading zeroes */
       if (found_first_non_zero || i >= temp_size - scale - 1)
 	{
-	  buf[nbuf] = temp[i];
-	  nbuf++;
+	  buf[nbuf++] = temp[i];
 	}
     }
 

--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -3887,14 +3887,14 @@ numeric_db_value_print (const DB_VALUE * val, char *buf)
 	    }
 
 	  temp_size = k + 1;
-	  if (k > i)
+	  if (temp[k] == '0')
+	    {
+	      continue;
+	    }
+	  else if (k >= i)
 	    {
 	      buf[nbuf] = '.';
 	      nbuf++;
-	    }
-	  else
-	    {
-	      continue;
 	    }
 	}
 

--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -3878,8 +3878,24 @@ numeric_db_value_print (const DB_VALUE * val, char *buf)
       /* Add decimal point */
       if (i == temp_size - scale)
 	{
-	  buf[nbuf] = '.';
-	  nbuf++;
+	  int k = temp_size - 1;
+
+	  /* remove trailing zero */
+	  while (k > i && temp[k] == '0')
+	    {
+	      k--;
+	    }
+
+	  temp_size = k + 1;
+	  if (k > i)
+	    {
+	      buf[nbuf] = '.';
+	      nbuf++;
+	    }
+	  else
+	    {
+	      continue;
+	    }
 	}
 
       /* Check to see if the first significant digit has been found */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24654

If the column type is specified with a digit after the decimal point, such as numeric(38,10), different results are returned than in the case of ORACLE/TIBERO, which causes inconvenience in application modification when not familiar with CUBRID or when converting.
