### PR TITLE
[CBRD-24630] The stop command of cubrid hb (applylogdb/repl) does not work correctly when the build is generated in the QA environment, release mode and devtoolset-9 (#4092)

### DIFF
--- a/src/executables/commdb.c
+++ b/src/executables/commdb.c
@@ -705,7 +705,7 @@ process_is_registered_proc (CSS_CONN_ENTRY * conn, char *args)
   rid = send_request_one_arg (conn, IS_REGISTERED_HA_PROC, (char *) buffer, len);
   return_string (conn, rid, &reply_buffer, &size);
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24630

backport https://github.com/CUBRID/cubrid/pull/4092

cherry-pick