### PR TITLE
[LETS-425] fix build; remove nullptr assignment to already moved object

### DIFF
--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -116,8 +116,6 @@ namespace cubcomm
       sequenced_payload &operator= (sequenced_payload &&other);
       sequenced_payload &operator= (const sequenced_payload &) = delete;
 
-      sequenced_payload &operator= (std::nullptr_t);
-
       void push_payload (T_PAYLOAD &&a_payload);
       T_PAYLOAD pull_payload ();
 
@@ -344,17 +342,6 @@ namespace cubcomm
 
 	other.m_rsn = NO_RESPONSE_SEQUENCE_NUMBER;
       }
-    return *this;
-  }
-
-
-  template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
-  typename request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload &
-  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::operator= (
-	  std::nullptr_t)
-  {
-    m_rsn = NO_RESPONSE_SEQUENCE_NUMBER;
-    m_user_payload.clear ();
     return *this;
   }
 

--- a/src/server/server_request_responder.hpp
+++ b/src/server/server_request_responder.hpp
@@ -288,7 +288,6 @@ server_request_responder<T_CONN>::task::task (server_request_responder &request_
 template<typename T_CONN>
 server_request_responder<T_CONN>::task::~task ()
 {
-  m_sequenced_payload = nullptr;
   m_function = nullptr;
 }
 

--- a/unit_tests/server/test_server_request_responder_main.cpp
+++ b/unit_tests/server/test_server_request_responder_main.cpp
@@ -64,12 +64,6 @@ class test_conn
 	{
 	}
 
-	sequenced_payload &operator= (std::nullptr_t)
-	{
-	  m_rsn = 0;
-	  m_payload = 0;
-	}
-
 	payload_t pull_payload ()
 	{
 	  payload_t ret = m_payload;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-425

Build fix. Unit test crashes in release mode.
Object `m_sequenced_payload` has already been moved in `server_request_responder::task::execute` method.
Therefore remove assignment to `nullptr` in `task::~task` dtor.
Remove also unused `sequenced_payload &operator= (std::nullptr_t);`.
