### PR TITLE
[CBRD-24659] Add linux style absolute path as windows style also

### DIFF
--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -354,7 +354,7 @@ check_is_array (const T & a)
 
 #if defined (WINDOWS)
 #define IS_ABS_PATH(p) IS_PATH_SEPARATOR((p)[0]) \
-	|| (isalpha((p)[0]) && (p)[1] == ':' && IS_PATH_SEPARATOR((p)[2]))
+	|| (isalpha((p)[0]) && (p)[1] == ':' && (IS_PATH_SEPARATOR((p)[2]) || (p)[2] == '/'))
 #else /* WINDOWS */
 #define IS_ABS_PATH(p) IS_PATH_SEPARATOR((p)[0])
 #endif /* WINDOWS */

--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -350,11 +350,15 @@ check_is_array (const T & a)
 #endif /* WINDOWS */
 #define PATH_CURRENT    '.'
 
+#if defined (WINDOWS)
+#define IS_PATH_SEPARATOR(c) ((c) == PATH_SEPARATOR || (c) == '/')
+#else
 #define IS_PATH_SEPARATOR(c) ((c) == PATH_SEPARATOR)
+#endif
 
 #if defined (WINDOWS)
 #define IS_ABS_PATH(p) IS_PATH_SEPARATOR((p)[0]) \
-	|| (isalpha((p)[0]) && (p)[1] == ':' && (IS_PATH_SEPARATOR((p)[2]) || (p)[2] == '/'))
+	|| (isalpha((p)[0]) && (p)[1] == ':' && IS_PATH_SEPARATOR((p)[2]))
 #else /* WINDOWS */
 #define IS_ABS_PATH(p) IS_PATH_SEPARATOR((p)[0])
 #endif /* WINDOWS */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24659

**Purpose**

* To add Linux style absolute file path to absolute path for Windows

* ASIS

  * C:\tmp/admin/adm.log is **absolute** path for WIndows

  * C:/tmp/admin/adm.log is relative path for WIndows 
* TOBE
 * C:\tmp/admin/adm.log is **absolute** path for WIndows
 * C:/tmp/admin/adm.log is **absolute** path for WIndows as well
 
**Implementation**

**Remarks**