### PR TITLE
[CBRD-24659] [11.2] redefine absolute path for Windows

### DIFF
--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -348,7 +348,11 @@ check_is_array (const T & a)
 #endif /* WINDOWS */
 #define PATH_CURRENT    '.'
 
+#if defined (WINDOWS)
+#define IS_PATH_SEPARATOR(c) ((c) == PATH_SEPARATOR || (c) == '/')
+#else
 #define IS_PATH_SEPARATOR(c) ((c) == PATH_SEPARATOR)
+#endif
 
 #if defined (WINDOWS)
 #define IS_ABS_PATH(p) IS_PATH_SEPARATOR((p)[0]) \


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24659

**Purpose**
* To add Linux style absolute file path to absolute path for Windows
* This is backport of #4106 to the release/11.2

**Implementation**

**Remarks**