### PR TITLE
[CBRD-24660] Change small functions that are frequently called in index scans to INLINE.

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -40,7 +40,6 @@
 #include "error_manager.h"
 #include "file_io.h"
 #include "mem_block.hpp"
-#include "object_domain.h"
 #include "object_representation.h"
 #include "set_object.h"
 #include "string_buffer.hpp"
@@ -8674,52 +8673,6 @@ pr_type_name (DB_TYPE id)
     }
 
   return name;
-}
-
-/*
- * pr_is_set_type - Test to see if a type identifier is one of the set types.
- *    return: non-zero if type is one of the set types
- *    type(in):
- * Note:
- *    Since there is an unfortunate amount of special processing for
- *    the set types, this takes care of comparing against all three types.
- */
-bool
-pr_is_set_type (DB_TYPE type)
-{
-  return TP_IS_SET_TYPE (type) || type == DB_TYPE_VOBJ;
-}
-
-/*
- * pr_is_string_type - Test to see if a type identifier is one of the string
- * types.
- *    return: non-zero if type is one of the string types
- *    type(in):  type to check
- */
-int
-pr_is_string_type (DB_TYPE type)
-{
-  int status = 0;
-
-  if (type == DB_TYPE_VARCHAR || type == DB_TYPE_CHAR || type == DB_TYPE_VARNCHAR || type == DB_TYPE_NCHAR
-      || type == DB_TYPE_VARBIT || type == DB_TYPE_BIT)
-    {
-      status = 1;
-    }
-
-  return status;
-}
-
-/*
- * pr_is_prefix_key_type -
- * types.
- *    return:
- *    type(in):  type to check
- */
-int
-pr_is_prefix_key_type (DB_TYPE type)
-{
-  return (type == DB_TYPE_MIDXKEY || pr_is_string_type (type));
 }
 
 /*

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -32,6 +32,8 @@
 #ident "$Id$"
 
 #include "dbtype_def.h"
+#include "object_domain.h"
+#include "porting_inline.hpp"
 
 #include <cassert>
 #include <cstdio>
@@ -277,9 +279,9 @@ extern PR_TYPE *pr_type_from_id (DB_TYPE id);
 extern PR_TYPE *pr_find_type (const char *name);
 extern const char *pr_type_name (DB_TYPE id);
 
-extern bool pr_is_set_type (DB_TYPE type);
-extern int pr_is_string_type (DB_TYPE type);
-extern int pr_is_prefix_key_type (DB_TYPE type);
+STATIC_INLINE bool pr_is_set_type (DB_TYPE type) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE int pr_is_string_type (DB_TYPE type) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE int pr_is_prefix_key_type (DB_TYPE type) __attribute__ ((ALWAYS_INLINE));
 extern int pr_is_variable_type (DB_TYPE type);
 
 /* Size calculators */
@@ -354,6 +356,52 @@ extern int pr_Enable_string_compression;
 // *INDENT-OFF*
 #define MIDXKEY_BOUNDBITS_INIT(bufptr, nbytes)  do { if(nbytes > 0) { memset ((bufptr), 0x00, (nbytes)); } } while(0)
 // *INDENT-ON*
+
+/*
+ * pr_is_set_type - Test to see if a type identifier is one of the set types.
+ *    return: non-zero if type is one of the set types
+ *    type(in):
+ * Note:
+ *    Since there is an unfortunate amount of special processing for
+ *    the set types, this takes care of comparing against all three types.
+ */
+STATIC_INLINE bool
+pr_is_set_type (DB_TYPE type)
+{
+  return TP_IS_SET_TYPE (type) || type == DB_TYPE_VOBJ;
+}
+
+/*
+ * pr_is_string_type - Test to see if a type identifier is one of the string
+ * types.
+ *    return: non-zero if type is one of the string types
+ *    type(in):  type to check
+ */
+STATIC_INLINE int
+pr_is_string_type (DB_TYPE type)
+{
+  int status = 0;
+
+  if (type == DB_TYPE_VARCHAR || type == DB_TYPE_CHAR || type == DB_TYPE_VARNCHAR || type == DB_TYPE_NCHAR
+      || type == DB_TYPE_VARBIT || type == DB_TYPE_BIT)
+    {
+      status = 1;
+    }
+
+  return status;
+}
+
+/*
+ * pr_is_prefix_key_type -
+ * types.
+ *    return:
+ *    type(in):  type to check
+ */
+STATIC_INLINE int
+pr_is_prefix_key_type (DB_TYPE type)
+{
+  return (type == DB_TYPE_MIDXKEY || pr_is_string_type (type));
+}
 
 //////////////////////////////////////////////////////////////////////////
 // Inline/template implementation

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1916,38 +1916,6 @@ btree_get_node_level (THREAD_ENTRY * thread_p, PAGE_PTR page_ptr)
 #endif
 
 /*
- * btree_clear_key_value () -
- *   return: cleared flag
- *   clear_flag (in/out):
- *   key_value (in/out):
- */
-bool
-btree_clear_key_value (bool * clear_flag, DB_VALUE * key_value)
-{
-  if (*clear_flag == true || key_value->need_clear == true)
-    {
-      pr_clear_value (key_value);
-      *clear_flag = false;
-    }
-  // also set null
-  db_make_null (key_value);
-  return *clear_flag;
-}
-
-/*
- * btree_init_temp_key_value () -
- *   return: void
- *   clear_flag (in/out):
- *   key_value (in/out):
- */
-void
-btree_init_temp_key_value (bool * clear_flag, DB_VALUE * key_value)
-{
-  db_make_null (key_value);
-  *clear_flag = false;
-}
-
-/*
  * btree_create_overflow_key_file () - Create file for overflow keyes
  *
  * return   : Error code

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -31,7 +31,6 @@
 #include "btree_load.h"
 
 #include "btree.h"
-#include "dbtype.h"
 #include "external_sort.h"
 #include "heap_file.h"
 #include "log_append.hpp"

--- a/src/storage/btree_load.h
+++ b/src/storage/btree_load.h
@@ -29,6 +29,7 @@
 #include <assert.h>
 
 #include "btree.h"
+#include "dbtype.h"
 #include "object_representation_constants.h"
 #include "error_manager.h"
 #include "storage_common.h"
@@ -261,8 +262,8 @@ extern void btree_rv_nodehdr_dump (FILE * fp, int length, void *data);
 extern void btree_rv_mvcc_save_increments (const BTID * btid, long long key_delta, long long oid_delta,
 					   long long null_delta, RECDES * recdes);
 
-extern bool btree_clear_key_value (bool * clear_flag, DB_VALUE * key_value);
-extern void btree_init_temp_key_value (bool * clear_flag, DB_VALUE * key_value);
+STATIC_INLINE bool btree_clear_key_value (bool * clear_flag, DB_VALUE * key_value) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE void btree_init_temp_key_value (bool * clear_flag, DB_VALUE * key_value) __attribute__ ((ALWAYS_INLINE));
 extern int btree_create_overflow_key_file (THREAD_ENTRY * thread_p, BTID_INT * btid);
 extern int btree_init_overflow_header (THREAD_ENTRY * thread_p, PAGE_PTR page_ptr, BTREE_OVERFLOW_HEADER * ovf_header);
 extern int btree_init_node_header (THREAD_ENTRY * thread_p, const VFID * vfid, PAGE_PTR page_ptr,
@@ -287,5 +288,37 @@ extern int btree_get_prefix_separator (const DB_VALUE * key1, const DB_VALUE * k
 				       TP_DOMAIN * key_domain);
 
 extern int btree_get_asc_desc (THREAD_ENTRY * thread_p, BTID * btid, int col_idx, int *asc_desc);
+
+/*
+ * btree_clear_key_value () -
+ *   return: cleared flag
+ *   clear_flag (in/out):
+ *   key_value (in/out):
+ */
+STATIC_INLINE bool
+btree_clear_key_value (bool * clear_flag, DB_VALUE * key_value)
+{
+  if (*clear_flag == true || key_value->need_clear == true)
+    {
+      pr_clear_value (key_value);
+      *clear_flag = false;
+    }
+  // also set null
+  db_make_null (key_value);
+  return *clear_flag;
+}
+
+/*
+ * btree_init_temp_key_value () -
+ *   return: void
+ *   clear_flag (in/out):
+ *   key_value (in/out):
+ */
+STATIC_INLINE void
+btree_init_temp_key_value (bool * clear_flag, DB_VALUE * key_value)
+{
+  db_make_null (key_value);
+  *clear_flag = false;
+}
 
 #endif /* _BTREE_LOAD_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24660

Change small functions that are frequently called in index scans to INLINE.
- btree_clear_key_value
- btree_init_temp_key_value
- pr_is_set_type (with pr_is_string_type, pr_is_prefix_key_type)
- scan_init_filter_info