### PR TITLE
[CBRD-24559] Revert - Use the number of unique index keys as number of objects for statistics.

### DIFF
--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -85,6 +85,7 @@ stats_client_unpack_statistics (char *buf_p)
   CLASS_STATS *class_stats_p;
   ATTR_STATS *attr_stats_p;
   BTREE_STATS *btree_stats_p;
+  int max_unique_keys;
   int i, j, k;
 
   if (buf_p == NULL)
@@ -214,6 +215,14 @@ stats_client_unpack_statistics (char *buf_p)
 	      buf_p += OR_INT_SIZE;
 	    }
 	}
+    }
+
+  /* correct estimated num_objects with unique keys */
+  max_unique_keys = OR_GET_INT (buf_p);
+  buf_p += OR_INT_SIZE;
+  if (max_unique_keys > 0)
+    {
+      class_stats_p->heap_num_objects = max_unique_keys;
     }
 
   /* validate key stats info */

--- a/src/storage/statistics_sr.c
+++ b/src/storage/statistics_sr.c
@@ -116,7 +116,6 @@ xstats_update_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, bool with_f
   OID *partitions = NULL;
   int count = 0, error_code = NO_ERROR;
   int lk_grant_code = 0;
-  int nobjs_from_unique_index = 0;
   CATALOG_ACCESS_INFO catalog_access_info = CATALOG_ACCESS_INFO_INITIALIZER;
 
   thread_p->push_resource_tracks ();
@@ -230,7 +229,14 @@ xstats_update_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, bool with_f
     }
   (void) catalog_end_access_with_dir_oid (thread_p, &catalog_access_info, NO_ERROR);
 
+  /* get npages and nobjs. do not use estimation, get correct info */
+  npages = nobjs = length = 0;
+  heap_get_num_objects (thread_p, &(cls_info_p->ci_hfid), &npages, &nobjs, &length);
+  cls_info_p->ci_tot_pages = MAX (npages, 0);
+  cls_info_p->ci_tot_objects = MAX (nobjs, 0);
+
   /* update the index statistics for each attribute */
+
   for (i = 0; i < disk_repr_p->n_fixed + disk_repr_p->n_variable; i++)
     {
       if (i < disk_repr_p->n_fixed)
@@ -253,34 +259,9 @@ xstats_update_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, bool with_f
 	      goto error;
 	    }
 
-	  /* check using nobjs from unique index */
-	  if (xbtree_get_unique_pk (thread_p, &btree_stats_p->btid))
-	    {
-	      nobjs_from_unique_index = MAX (nobjs_from_unique_index, btree_stats_p->keys);
-	    }
-
 	  assert_release (btree_stats_p->keys >= 0);
 	}			/* for (j = 0; ...) */
     }				/* for (i = 0; ...) */
-
-  /* get npages and nobjs. do not use estimation, get correct info */
-  npages = nobjs = length = 0;
-  if (nobjs_from_unique_index > 0)
-    {
-      /* use number of unique index key */
-      nobjs = nobjs_from_unique_index;
-      if (file_get_num_user_pages (thread_p, &(cls_info_p->ci_hfid.vfid), &npages) != NO_ERROR)
-	{
-	  goto error;
-	}
-    }
-  else
-    {
-      /* full scan for number of object */
-      heap_get_num_objects (thread_p, &(cls_info_p->ci_hfid), &npages, &nobjs, &length);
-    }
-  cls_info_p->ci_tot_pages = MAX (npages, 0);
-  cls_info_p->ci_tot_objects = MAX (nobjs, 0);
 
   error_code = catalog_start_access_with_dir_oid (thread_p, &catalog_access_info, X_LOCK);
   if (error_code != NO_ERROR)
@@ -452,7 +433,7 @@ xstats_get_statistics_from_server (THREAD_ENTRY * thread_p, OID * class_id_p, un
   DISK_ATTR *disk_attr_p;
   BTREE_STATS *btree_stats_p;
   OID dir_oid;
-  int npages, estimated_nobjs;
+  int npages, estimated_nobjs, max_unique_keys;
   int i, j, k, size, n_attrs, tot_n_btstats, tot_key_info_size;
   char *buf_p, *start_p;
   int key_size;
@@ -571,6 +552,8 @@ xstats_get_statistics_from_server (THREAD_ENTRY * thread_p, OID * class_id_p, un
 
   size += tot_key_info_size;	/* key_type, pkeys[] of BTREE_STATS */
 
+  size += OR_INT_SIZE;		/* max_unique_keys */
+
   start_p = buf_p = (char *) malloc (size);
   if (buf_p == NULL)
     {
@@ -581,7 +564,7 @@ xstats_get_statistics_from_server (THREAD_ENTRY * thread_p, OID * class_id_p, un
   OR_PUT_INT (buf_p, cls_info_p->ci_time_stamp);
   buf_p += OR_INT_SIZE;
 
-  npages = estimated_nobjs = -1;
+  npages = estimated_nobjs = max_unique_keys = -1;
 
   assert (cls_info_p->ci_tot_objects >= 0);
   assert (cls_info_p->ci_tot_pages >= 0);
@@ -668,6 +651,12 @@ xstats_get_statistics_from_server (THREAD_ENTRY * thread_p, OID * class_id_p, un
 
       for (j = 0, btree_stats_p = disk_attr_p->bt_stats; j < disk_attr_p->n_btstats; j++, btree_stats_p++)
 	{
+	  /* collect maximum unique keys info */
+	  if (xbtree_get_unique_pk (thread_p, &btree_stats_p->btid))
+	    {
+	      max_unique_keys = MAX (max_unique_keys, btree_stats_p->keys);
+	    }
+
 	  OR_PUT_BTID (buf_p, &btree_stats_p->btid);
 	  buf_p += OR_BTID_ALIGNED_SIZE;
 
@@ -769,6 +758,10 @@ xstats_get_statistics_from_server (THREAD_ENTRY * thread_p, OID * class_id_p, un
 	    }
 	}			/* for (j = 0, ...) */
     }
+
+  OR_PUT_INT (buf_p, max_unique_keys);
+  buf_p += OR_INT_SIZE;
+
   catalog_free_representation_and_init (disk_repr_p);
   catalog_free_class_info_and_init (cls_info_p);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24559

This issue is excluded from 11.3, in order to proceed with [CBRD-24409] Add Non-accumulative selectivity of columns.