### PR TITLE
[CBRD-24630] The stop command of cubrid hb applylogdb with -h option does not work correctly when the build is generated in the QA environment, release mode and devtoolset-9 (#4107)

### DIFF
--- a/src/executables/commdb.c
+++ b/src/executables/commdb.c
@@ -744,7 +744,7 @@ process_ha_deregister_by_pid (CSS_CONN_ENTRY * conn, char *pid_string)
   rid = send_request_one_arg (conn, DEREGISTER_HA_PROCESS_BY_PID, (char *) &pid, sizeof (pid));
   return_string (conn, rid, &reply_buffer, &size);
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -784,7 +784,7 @@ process_ha_deregister_by_args (CSS_CONN_ENTRY * conn, char *args)
   rid = send_request_one_arg (conn, DEREGISTER_HA_PROCESS_BY_ARGS, (char *) buffer, len);
   return_string (conn, rid, &reply_buffer, &size);
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -868,7 +868,7 @@ process_deactivate_heartbeat (CSS_CONN_ENTRY * conn)
 
   return_string (conn, rid, &result_reply_buffer, &size);
 #endif
-  if (size > 0 && strcmp (result_reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (result_reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -904,7 +904,7 @@ process_deact_confirm_no_server (CSS_CONN_ENTRY * conn)
   return_string (conn, rid, &reply_buffer, &size);
 #endif
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -936,7 +936,7 @@ process_deact_confirm_stop_all (CSS_CONN_ENTRY * conn)
   return_string (conn, rid, &reply_buffer, &size);
 #endif
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -969,7 +969,7 @@ process_deact_stop_all (CSS_CONN_ENTRY * conn)
   return_string (conn, rid, &reply_buffer, &size);
 #endif /* !WINDOWS */
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -1006,7 +1006,7 @@ process_activate_heartbeat (CSS_CONN_ENTRY * conn)
   return_string (conn, rid, &reply_buffer, &size);
 #endif
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -1045,7 +1045,7 @@ process_ha_start_util_process (CSS_CONN_ENTRY * conn, char *args)
   rid = send_request_one_arg (conn, START_HA_UTIL_PROCESS, (char *) buffer, len);
   return_string (conn, rid, &reply_buffer, &size);
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24630

backport #4107 