### PR TITLE
[CBRD-24630] The stop command of cubrid hb applylogdb with -h option does not work correctly when the build is generated in the QA environment, release mode and devtoolset-9 (#4107)

### DIFF
--- a/src/executables/commdb.c
+++ b/src/executables/commdb.c
@@ -745,7 +745,7 @@ process_ha_deregister_by_pid (CSS_CONN_ENTRY * conn, char *pid_string)
   rid = send_request_one_arg (conn, DEREGISTER_HA_PROCESS_BY_PID, (char *) &pid, sizeof (pid));
   return_string (conn, rid, &reply_buffer, &size);
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -785,7 +785,7 @@ process_ha_deregister_by_args (CSS_CONN_ENTRY * conn, char *args)
   rid = send_request_one_arg (conn, DEREGISTER_HA_PROCESS_BY_ARGS, (char *) buffer, len);
   return_string (conn, rid, &reply_buffer, &size);
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -869,7 +869,7 @@ process_deactivate_heartbeat (CSS_CONN_ENTRY * conn)
 
   return_string (conn, rid, &result_reply_buffer, &size);
 #endif
-  if (size > 0 && strcmp (result_reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (result_reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -905,7 +905,7 @@ process_deact_confirm_no_server (CSS_CONN_ENTRY * conn)
   return_string (conn, rid, &reply_buffer, &size);
 #endif
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -937,7 +937,7 @@ process_deact_confirm_stop_all (CSS_CONN_ENTRY * conn)
   return_string (conn, rid, &reply_buffer, &size);
 #endif
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -970,7 +970,7 @@ process_deact_stop_all (CSS_CONN_ENTRY * conn)
   return_string (conn, rid, &reply_buffer, &size);
 #endif /* !WINDOWS */
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -1007,7 +1007,7 @@ process_activate_heartbeat (CSS_CONN_ENTRY * conn)
   return_string (conn, rid, &reply_buffer, &size);
 #endif
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }
@@ -1046,7 +1046,7 @@ process_ha_start_util_process (CSS_CONN_ENTRY * conn, char *args)
   rid = send_request_one_arg (conn, START_HA_UTIL_PROCESS, (char *) buffer, len);
   return_string (conn, rid, &reply_buffer, &size);
 
-  if (size > 0 && strcmp (reply_buffer, HA_REQUEST_SUCCESS) == 0)
+  if (size > 0 && strncmp (reply_buffer, HA_REQUEST_SUCCESS, size - 1) == 0)
     {
       error = NO_ERROR;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24630

backport #4107