### PR TITLE
[CBRD-24665] removing ncurses dependency from broker_monitor

### DIFF
--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -514,7 +514,12 @@ main (int argc, char **argv)
 	}
 
       free (br_vector);
-      err = system (cmd);
+
+      if (system (cmd) != 0)
+	{
+	  fprintf (stderr, "%s: -s option require Linux command: '%s'\n", argv[0], WATCH_CMD);
+	  fprintf (stderr, "Install the '%s' command to use this option.\n", WATCH_CMD);
+	}
 
       return 0;
 #endif

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -515,7 +515,7 @@ main (int argc, char **argv)
 
       free (br_vector);
 
-      if (system (cmd) != 0)
+      if (system (cmd) == 32512)
 	{
 	  fprintf (stderr, "%s: -s option require Linux command: '%s'\n", argv[0], WATCH_CMD);
 	  fprintf (stderr, "Install the '%s' command to use this option.\n", WATCH_CMD);

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -40,13 +40,6 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <conio.h>
-#else
-#if defined(AIX)
-#define _BOOL
-#include <curses.h>
-#else
-#include <curses.h>
-#endif
 #endif
 
 #if defined(WINDOWS)
@@ -380,8 +373,6 @@ str_to_screen (const char *msg)
 #ifdef WINDOWS
   DWORD size;
   (void) WriteConsole (h_console, msg, strlen (msg), &size, NULL);
-#else
-  (void) addstr (msg);
 #endif
 }
 
@@ -440,8 +431,6 @@ get_char (void)
 	}
     }
   return 0;
-#else
-  return getch ();
 #endif
 }
 
@@ -453,10 +442,6 @@ main (int argc, char **argv)
   int num_broker, master_shm_id;
   int err, i;
   char *br_vector;
-#if defined(WINDOWS)
-#else
-  WINDOW *win;
-#endif
   time_t time_old, time_cur;
   double elapsed_time;
   char cmd[PATH_MAX] = { 0, };

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -348,14 +348,12 @@ static const char *get_status_string (T_APPL_SERVER_INFO * as_info_p, char appl_
 static void get_cpu_usage_string (char *buf_p, float usage);
 
 
-#if defined(WINDOWS)
 static void move (int x, int y);
 static void refresh ();
 static void clear ();
 static void clrtobot ();
 static void clrtoeol ();
 static void endwin ();
-#endif
 
 static int metadata_monitor (double elapsed_time);
 static int client_monitor (void);
@@ -1961,6 +1959,36 @@ endwin ()
 {
   clear ();
   move (0, 0);
+}
+#else
+static void
+move (int x, int y)
+{
+}
+
+static void
+refresh ()
+{
+}
+
+static void
+clear ()
+{
+}
+
+static void
+clrtobot ()
+{
+}
+
+static void
+clrtoeol ()
+{
+}
+
+static void
+endwin ()
+{
 }
 #endif
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24665

**Purpose**
* To remove ncurses dependency on **broker_monitor**
* In Linux, **ncurses** function will not be called,
* Instead, Linux command watch will be called with given arguments (-s number will be changed to -s 0)
* User Invoked:
`cubrid broker status -s 1 -f`
* Actual action
`watch -t -n 1 cubrid broker status -s 0 -f`

**Implementation**

**Remarks**
* dummy **ncurses** functions such as endwin () are added, 
* if not, we have to refactor this code that remove all ncurses reference for the Linux.
* addstr (), getch () is called only when refresh_sec > 0 && !tty_mode in Linux,
* this situation will not be happen if (refresh_sec > 0 && !tty_mode) then 
  system call to execute watch will be called, and broker_monitor will be terminated in **Linux**.