### PR TITLE
[LETS-627] segregated thread type for replication in two: replication for replica transaction server and for page server

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -1882,7 +1882,8 @@ perfmon_get_module_type (THREAD_ENTRY * thread_p)
     case TT_VACUUM_WORKER:
     case TT_VACUUM_MASTER:
       return PERF_MODULE_VACUUM;
-    case TT_REPLICATION:
+    case TT_REPLICATION_PS:
+    case TT_REPLICATION_PTS:
       return PERF_MODULE_REPLICATION;
     default:
       return PERF_MODULE_SYSTEM;

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -174,7 +174,7 @@ void
 page_server::connection_handler::handle_oldest_active_mvccid_request (tran_server_conn_t::sequenced_payload &a_sp)
 {
   assert (m_server_type == transaction_server_type::ACTIVE);
-  const MVCCID oldest_mvccid = m_ps.m_pts_mvcc_tracker.get_global_oldest_active_mvccid();
+  const MVCCID oldest_mvccid = m_ps.m_pts_mvcc_tracker.get_global_oldest_active_mvccid ();
 
   std::string response_message;
   response_message.append (reinterpret_cast<const char *> (&oldest_mvccid), sizeof (oldest_mvccid));
@@ -210,7 +210,7 @@ page_server::connection_handler::receive_oldest_active_mvccid (tran_server_conn_
 {
   assert (m_server_type == transaction_server_type::PASSIVE);
 
-  const auto oldest_mvccid = *reinterpret_cast<const MVCCID *> (a_sp.pull_payload().c_str());
+  const auto oldest_mvccid = *reinterpret_cast<const MVCCID *> (a_sp.pull_payload ().c_str ());
 
   m_ps.m_pts_mvcc_tracker.update_oldest_active_mvccid (get_connection_id (), oldest_mvccid);
 }
@@ -408,7 +408,7 @@ void page_server::pts_mvcc_tracker::init_oldest_active_mvccid (const std::string
    * before, the entry must have been removed when the PTS disconnected or when the connection
    *  to the PTS was aborted.
    */
-  assert (m_pts_oldest_active_mvccids.find (pts_channel_id) == m_pts_oldest_active_mvccids.end());
+  assert (m_pts_oldest_active_mvccids.find (pts_channel_id) == m_pts_oldest_active_mvccids.end ());
 
   /*
    * MVCCID_ALL_VISIBLE means that it hasn't yet received. It will prevent the ATS to run vacuum.
@@ -430,7 +430,7 @@ void page_server::pts_mvcc_tracker::update_oldest_active_mvccid (const std::stri
    * 2. It is updated by the PTS only when it move foward.
    *    Without update, it is MVCCID_ALL_VISIBLE by default, which is lower than any mvccid assigned.
    */
-  assert (m_pts_oldest_active_mvccids.find (pts_channel_id) != m_pts_oldest_active_mvccids.end());
+  assert (m_pts_oldest_active_mvccids.find (pts_channel_id) != m_pts_oldest_active_mvccids.end ());
   assert (m_pts_oldest_active_mvccids[pts_channel_id] < mvccid);
 
   m_pts_oldest_active_mvccids[pts_channel_id] = mvccid;
@@ -445,14 +445,14 @@ void page_server::pts_mvcc_tracker::update_oldest_active_mvccid (const std::stri
     {
       ss << " " << it.second;
     }
-  er_log_debug (ARG_FILE_LINE, ss.str().c_str());
+  er_log_debug (ARG_FILE_LINE, ss.str ().c_str ());
 #endif
 }
 void page_server::pts_mvcc_tracker::delete_oldest_active_mvccid (const std::string &pts_channel_id)
 {
   std::lock_guard<std::mutex> lockg { m_pts_oldest_active_mvccids_mtx };
   /* The entry is already created when ths PTS is connected. */
-  assert (m_pts_oldest_active_mvccids.find (pts_channel_id) != m_pts_oldest_active_mvccids.end());
+  assert (m_pts_oldest_active_mvccids.find (pts_channel_id) != m_pts_oldest_active_mvccids.end ());
   m_pts_oldest_active_mvccids.erase (pts_channel_id);
 }
 
@@ -629,7 +629,7 @@ page_server::start_log_replicator (const log_lsa &start_lsa)
 
   const int replication_parallel_count = prm_get_integer_value (PRM_ID_REPLICATION_PARALLEL_COUNT);
   assert (replication_parallel_count >= 0);
-  m_replicator.reset (new cublog::replicator (start_lsa, RECOVERY_PAGE, replication_parallel_count));
+  m_replicator.reset (new cublog::replicator (start_lsa, RECOVERY_PAGE, replication_parallel_count, TT_REPLICATION_PS));
 }
 
 void

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -126,7 +126,7 @@ void passive_tran_server::start_log_replicator (const log_lsa &start_lsa, const 
 
   // passive transaction server executes replication synchronously, for the time being, due to complexity of
   // executing it in parallel while also providing a consistent view of the data
-  m_replicator.reset (new cublog::atomic_replicator (start_lsa, prev_lsa));
+  m_replicator.reset (new cublog::atomic_replicator (start_lsa, prev_lsa, TT_REPLICATION_PTS));
 }
 
 void passive_tran_server::send_and_receive_stop_log_prior_dispatch ()
@@ -164,7 +164,7 @@ void passive_tran_server::send_oldest_active_mvccid (cubthread::entry &)
 {
   std::string request_message;
 
-  const auto new_oldest_active_mvccid = log_Gl.mvcc_table.update_global_oldest_visible();
+  const auto new_oldest_active_mvccid = log_Gl.mvcc_table.update_global_oldest_visible ();
   if (new_oldest_active_mvccid == m_oldest_active_mvccid)
     {
       return;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -5187,7 +5187,7 @@ pgbuf_is_temporary_volume (VOLID volid)
   /* Later edit: replication threads are also being present on passive transaction server - which has
    * to deal with temporary volumes. Thus, restrict the test to page server context only and leave
    * original answer for all transaction servers */
-  if (is_page_server () && cubthread::get_entry ().type == TT_REPLICATION)
+  if (is_page_server () && cubthread::get_entry ().type == TT_REPLICATION_PS)
     {
       return false;
     }

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -720,8 +720,10 @@ thread_type_to_string (thread_type type)
       return "SYSTEM_WORKER";
     case TT_RECOVERY:
       return "RECOVERY";
-    case TT_REPLICATION:
-      return "REPLICATION";
+    case TT_REPLICATION_PS:
+      return "REPLICATION_PS";
+    case TT_REPLICATION_PTS:
+      return "REPLICATION_PTS";
     case TT_NONE:
       return "NONE";
     }

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -131,7 +131,9 @@ enum thread_type
   TT_VACUUM_WORKER,
   TT_SYSTEM_WORKER,
   TT_RECOVERY,
-  TT_REPLICATION,
+  // specifically for scalability transactional log replication
+  TT_REPLICATION_PS,
+  TT_REPLICATION_PTS,
   TT_NONE
 };
 

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3476,7 +3476,8 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 	reusable_jobs.initialize (log_recovery_redo_parallel_count);
 	// *INDENT-OFF*
 	parallel_recovery_redo.reset(
-	    new cublog::redo_parallel (log_recovery_redo_parallel_count, false, MAX_LSA, redo_context));
+	    new cublog::redo_parallel (log_recovery_redo_parallel_count, false, MAX_LSA, redo_context,
+	                               TT_RECOVERY));
 	// *INDENT-ON*
       }
   }

--- a/src/transaction/log_recovery_redo_parallel.cpp
+++ b/src/transaction/log_recovery_redo_parallel.cpp
@@ -599,16 +599,19 @@ namespace cublog
    *********************************************************************/
 
   redo_parallel::redo_parallel (unsigned a_task_count, bool a_do_monitor_min_unapplied_log_lsa,
-				const log_lsa &a_start_main_thread_log_lsa, const log_rv_redo_context &copy_context)
+				const log_lsa &a_start_main_thread_log_lsa, const log_rv_redo_context &copy_context,
+				thread_type recovery_or_replication_thread_type)
     : m_task_count { a_task_count }
     , m_task_state_bookkeeping { a_task_count }
     , m_worker_pool { nullptr }
     , m_min_unapplied_log_lsa_calculation { a_do_monitor_min_unapplied_log_lsa, a_start_main_thread_log_lsa, m_redo_tasks }
   {
     assert (a_task_count > 0);
+    assert (TT_RECOVERY == recovery_or_replication_thread_type ||
+	    TT_REPLICATION_PS == recovery_or_replication_thread_type);
 
-    const thread_type tt = log_is_in_crash_recovery () ? TT_RECOVERY : TT_REPLICATION;
-    m_pool_context_manager = std::make_unique<cubthread::system_worker_entry_manager> (tt);
+    m_pool_context_manager = std::make_unique<cubthread::system_worker_entry_manager> (
+				     recovery_or_replication_thread_type);
 
     do_init_worker_pool (a_task_count);
     do_init_tasks (a_task_count, a_do_monitor_min_unapplied_log_lsa, copy_context);

--- a/src/transaction/log_recovery_redo_parallel.hpp
+++ b/src/transaction/log_recovery_redo_parallel.hpp
@@ -64,7 +64,8 @@ namespace cublog
       /* - worker_count: the number of parallel tasks to spin that consume jobs
        */
       redo_parallel (unsigned a_worker_count, bool a_do_monitor_min_unapplied_log_lsa,
-		     const log_lsa &a_start_main_thread_log_lsa, const log_rv_redo_context &copy_context);
+		     const log_lsa &a_start_main_thread_log_lsa, const log_rv_redo_context &copy_context,
+		     thread_type replication_thread_type);
 
       redo_parallel (const redo_parallel &) = delete;
       redo_parallel (redo_parallel &&) = delete;

--- a/src/transaction/log_replication.hpp
+++ b/src/transaction/log_replication.hpp
@@ -55,7 +55,8 @@ namespace cublog
   {
     public:
       replicator () = delete;
-      replicator (const log_lsa &start_redo_lsa, PAGE_FETCH_MODE page_fetch_mode, int parallel_count);
+      replicator (const log_lsa &start_redo_lsa, PAGE_FETCH_MODE page_fetch_mode, int parallel_count,
+		  thread_type replication_thread_type);
 
       replicator (const replicator &) = delete;
       replicator (replicator &&) = delete;

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -25,8 +25,9 @@
 namespace cublog
 {
 
-  atomic_replicator::atomic_replicator (const log_lsa &start_redo_lsa, const log_lsa &prev_redo_lsa)
-    : replicator (start_redo_lsa, OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT, 0)
+  atomic_replicator::atomic_replicator (const log_lsa &start_redo_lsa, const log_lsa &prev_redo_lsa,
+					thread_type replication_thread_type)
+    : replicator (start_redo_lsa, OLD_PAGE_IF_IN_BUFFER_OR_IN_TRANSIT, 0, replication_thread_type)
     , m_processed_lsa { prev_redo_lsa }
     , m_lowest_unapplied_lsa { start_redo_lsa }
   {

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -67,7 +67,8 @@ namespace cublog
   class atomic_replicator : public replicator
   {
     public:
-      atomic_replicator (const log_lsa &start_redo_lsa, const log_lsa &prev_redo_lsa);
+      atomic_replicator (const log_lsa &start_redo_lsa, const log_lsa &prev_redo_lsa,
+			 thread_type replication_thread_type);
 
       atomic_replicator (const atomic_replicator &) = delete;
       atomic_replicator (atomic_replicator &&) = delete;

--- a/unit_tests/log/test_main_log_recovery_parallel.cpp
+++ b/unit_tests/log/test_main_log_recovery_parallel.cpp
@@ -107,7 +107,8 @@ void execute_test (const log_recovery_test_config &a_test_config,
 
   const log_lsa start_log_lsa = global_values.get_lsa_log ();
   REQUIRE ((!start_log_lsa.is_max () && !start_log_lsa.is_null ()));
-  cublog::redo_parallel log_redo_parallel (a_test_config.parallel_count, true, start_log_lsa, dummy_redo_context);
+  cublog::redo_parallel log_redo_parallel (a_test_config.parallel_count, true, start_log_lsa, dummy_redo_context,
+      TT_REPLICATION_PS);
 
   for (size_t idx = 0u; idx < a_test_config.redo_job_count; ++idx)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-627

In page buffer, there is a mechanism to ignore changing the state of the page upon unfixing the page - see `PGBUF_THREAD_SHOULD_IGNORE_UNFIX`.
This mechanism will be extended also for transactional log replication threads (in Passive Transaction Server and Page Server).
To allow for this, the `TT_REPLICATION` thread type is needed to be split in more specific `TT_REPLICATION_PTS` and `TT_REPLICATION_PS` types.

Implementation:
- split one enum value in two;
- raised the level from where the values are propagated to `passive_tran_server` (`TT_REPLICATION_PTS`) and `page_server` (`TT_REPLICATION_PS`) management objects
- the thread types are used as such:
  - for Passive Transaction Server: one thread identifies as `TT_REPLICATION_PTS`- executed under `replicator::m_daemon_context_manager`
  - for Page Server: also the threads executed under `redo_parallel::m_pool_context_manager`

