### PR TITLE
[CBRD-24667] Fix error for backup_dest_path in ha_make_slavedb.sh

### DIFF
--- a/contrib/scripts/ha/ha_make_slavedb.sh
+++ b/contrib/scripts/ha/ha_make_slavedb.sh
@@ -285,13 +285,8 @@ function check_args()
 function init_conf()
 {
 	# init path
-	mkdir -p $ha_temp_home
-	if [ -n $backup_dest_path ]; then 
-		backup_dest_path=$ha_temp_home/backup
-		if [ ! -d $backup_dest_path ]; then
-			mkdir $backup_dest_path
-		fi
-	fi
+	backup_dest_path=${backup_dest_path:-$ha_temp_home/backup}
+	mkdir -p $ha_temp_home $backup_dest_path
 	repl_log_home=${repl_log_home%%/}
 	backup_dest_path=${backup_dest_path%%/}
 	backup_dest_path=$(readlink -f $backup_dest_path)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24667

**Purpose**
* Fix _backup_dest_path_ in $CUBRID/share/scripts/ha/**ha_make_slavedb.sh**
1. remain unchanged $backup_dest_path if it **is not NULL**
2. set backup_dest_path to "$ha_temp_home/backup" if it is **NULL**

**Implementation**
N/A

**Remarks**
Two 'mkdir's integrated into one:

```
mkdir -p $ha_temp_home
mkdir $backup_dest_path

mkdir -p $ha_temp_home $backup_dest_path
```
We ensure that $ha_temp_home and $backup_dest_path are not NULL at mkdir time (**if** check is not required).