### PR TITLE
[CBRD-24668] Problem that predicate evaluation order is not kept after view merging and push-predicate.

### DIFF
--- a/src/optimizer/plan_generation.c
+++ b/src/optimizer/plan_generation.c
@@ -1208,54 +1208,9 @@ make_pred_from_bitset (QO_ENV * env, BITSET * predset, ELIGIBILITY_FN safe)
 	  goto exit_on_error;
 	}
 
-      /* set AND predicate evaluation selectivity, rank; */
-      pointer->info.pointer.sel = QO_TERM_SELECTIVITY (term);
-      pointer->info.pointer.rank = QO_TERM_RANK (term);
-
-      /* insert to the AND predicate list by descending order of (selectivity, rank) vector; this order is used at
-       * pt_to_pred_expr_with_arg() */
-      found = false;		/* init */
-      prev = NULL;		/* init */
-      for (curr = pred_list; curr; curr = curr->next)
-	{
-	  cmp = curr->info.pointer.sel - pointer->info.pointer.sel;
-
-	  if (cmp == 0)
-	    {			/* same selectivity, re-compare rank */
-	      cmp = curr->info.pointer.rank - pointer->info.pointer.rank;
-	    }
-
-	  if (cmp <= 0)
-	    {
-	      pointer->next = curr;
-	      if (prev == NULL)
-		{		/* very the first */
-		  pred_list = pointer;
-		}
-	      else
-		{
-		  prev->next = pointer;
-		}
-	      found = true;
-	      break;
-	    }
-
-	  prev = curr;
-	}
-
-      /* append to the predicate list */
-      if (found == false)
-	{
-	  if (prev == NULL)
-	    {			/* very the first */
-	      pointer->next = pred_list;
-	      pred_list = pointer;
-	    }
-	  else
-	    {			/* very the last */
-	      prev->next = pointer;
-	    }
-	}
+      /* insert to the AND predicate list; this order is used at pt_to_pred_expr_with_arg() */
+      pointer->next = pred_list;
+      pred_list = pointer;
     }
 
   return pred_list;

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -6067,7 +6067,7 @@ qo_discover_edges (QO_ENV * env)
 	    }
 	}
     }
-  /* sort sarg-term on pred_order asc, selectivity desc, rank asc */
+  /* sort sarg-term on pred_order desc, selectivity asc, rank desc */
   for (t1 = i; t1 < env->nterms - 1; t1++)
     {
       term1 = QO_ENV_TERM (env, t1);

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -6079,11 +6079,13 @@ qo_discover_edges (QO_ENV * env)
 	    {
 	      qo_exchange (term1, term2);
 	    }
-	  else if ((QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2)) && (QO_TERM_SELECTIVITY (term1) < QO_TERM_SELECTIVITY (term2)))
+	  else if ((QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2))
+		   && (QO_TERM_SELECTIVITY (term1) < QO_TERM_SELECTIVITY (term2)))
 	    {
 	      qo_exchange (term1, term2);
 	    }
-	  else if ((QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2)) && (QO_TERM_SELECTIVITY (term1) == QO_TERM_SELECTIVITY (term2))
+	  else if ((QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2))
+		   && (QO_TERM_SELECTIVITY (term1) == QO_TERM_SELECTIVITY (term2))
 		   && QO_TERM_RANK (term1) < QO_TERM_RANK (term1))
 	    {
 	      qo_exchange (term1, term2);

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -6067,7 +6067,7 @@ qo_discover_edges (QO_ENV * env)
 	    }
 	}
     }
-  /* sort sarg-term on pred_order desc, selectivity desc, rank desc */
+  /* sort sarg-term on pred_order asc, selectivity desc, rank desc */
   for (t1 = i; t1 < env->nterms - 1; t1++)
     {
       term1 = QO_ENV_TERM (env, t1);
@@ -6080,13 +6080,13 @@ qo_discover_edges (QO_ENV * env)
 	      qo_exchange (term1, term2);
 	    }
 	  else if ((QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2))
-		   && (QO_TERM_SELECTIVITY (term1) < QO_TERM_SELECTIVITY (term2)))
+		   && (QO_TERM_SELECTIVITY (term1) > QO_TERM_SELECTIVITY (term2)))
 	    {
 	      qo_exchange (term1, term2);
 	    }
 	  else if ((QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2))
 		   && (QO_TERM_SELECTIVITY (term1) == QO_TERM_SELECTIVITY (term2))
-		   && QO_TERM_RANK (term1) < QO_TERM_RANK (term1))
+		   && QO_TERM_RANK (term1) > QO_TERM_RANK (term1))
 	    {
 	      qo_exchange (term1, term2);
 	    }

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -6067,7 +6067,7 @@ qo_discover_edges (QO_ENV * env)
 	    }
 	}
     }
-  /* sort sarg-term on pred_order asc, selectivity desc, rank desc */
+  /* sort sarg-term on pred_order asc, selectivity desc, rank asc */
   for (t1 = i; t1 < env->nterms - 1; t1++)
     {
       term1 = QO_ENV_TERM (env, t1);
@@ -6086,7 +6086,7 @@ qo_discover_edges (QO_ENV * env)
 	    }
 	  else if ((QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2))
 		   && (QO_TERM_SELECTIVITY (term1) == QO_TERM_SELECTIVITY (term2))
-		   && QO_TERM_RANK (term1) > QO_TERM_RANK (term1))
+		   && QO_TERM_RANK (term1) < QO_TERM_RANK (term1))
 	    {
 	      qo_exchange (term1, term2);
 	    }

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -581,6 +581,9 @@ qo_optimize_helper (QO_ENV * env)
 			       pt_continue_walk, NULL);
     }
 
+  get_local_subqueries (env, tree);
+  get_rank (env);
+
   /* finish the rest of the opt structures */
   qo_discover_edges (env);
 
@@ -590,8 +593,6 @@ qo_optimize_helper (QO_ENV * env)
    */
   qo_assign_eq_classes (env);
 
-  get_local_subqueries (env, tree);
-  get_rank (env);
   qo_discover_indexes (env);
   qo_discover_partitions (env);
   qo_discover_sort_limit_nodes (env);
@@ -6067,7 +6068,7 @@ qo_discover_edges (QO_ENV * env)
 	    }
 	}
     }
-  /* sort sarg-term on pred_order desc, selectivity asc, rank desc */
+  /* sort sarg-term on pred_order desc, selectivity asc, rank asc */
   for (t1 = i; t1 < env->nterms - 1; t1++)
     {
       term1 = QO_ENV_TERM (env, t1);
@@ -6086,7 +6087,7 @@ qo_discover_edges (QO_ENV * env)
 	    }
 	  else if ((QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2))
 		   && (QO_TERM_SELECTIVITY (term1) == QO_TERM_SELECTIVITY (term2))
-		   && QO_TERM_RANK (term1) < QO_TERM_RANK (term1))
+		   && QO_TERM_RANK (term1) > QO_TERM_RANK (term2))
 	    {
 	      qo_exchange (term1, term2);
 	    }

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -705,6 +705,9 @@ struct qo_term
   int *multi_col_segs;
   int multi_col_cnt;
 
+  /* for view-merge or predicate-push. pred is ordered by pred_order desc in qo_discover_edges */
+  int pred_order;
+
   /*
    * WARNING!!! WARNING!!! WARNING!!!
    *
@@ -736,6 +739,7 @@ struct qo_term
 #define QO_TERM_FLAG(t)	        (t)->flag
 #define QO_TERM_MULTI_COL_SEGS(t)  (t)->multi_col_segs
 #define QO_TERM_MULTI_COL_CNT(t)   (t)->multi_col_cnt
+#define QO_TERM_PRED_ORDER(t)   (t)->pred_order
 
 
 #define QO_TERM_EQUAL_OP             1	/* is equal op ? */

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2399,6 +2399,7 @@ struct pt_expr_info
   bool is_order_dependent;	/* true if expression is order dependent */
   PT_TYPE_ENUM recursive_type;	/* common type for recursive expression arguments (like PT_GREATEST, PT_LEAST,...) */
   int coll_modifier;		/* collation modifier = collation + 1 */
+  int pred_order;		/* for view-merge or predicate-push. pred is ordered by pred_order in qo_discover_edges */
 };
 
 /* FILE PATH INFO */
@@ -3290,8 +3291,6 @@ struct pt_pointer_info
 {
   PT_NODE *node;		/* original node pointer */
   PT_POINTER_TYPE type;		/* pointer type (normal pointer/reference) */
-  double sel;			/* selectivity factor of the predicate */
-  int rank;			/* rank factor for the same selectivity */
   bool do_walk;			/* apply walk on node bool */
 };
 

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -539,7 +539,7 @@ extern "C"
   extern bool pt_has_inst_in_where_and_select_list (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_inst_or_orderby_num_in_where (PARSER_CONTEXT * parser, PT_NODE * node);
   extern void pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level);
-  extern void pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * post_pred);
+  extern void pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * pre_pred);
   extern bool pt_has_nullable_term (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_define_vars (PARSER_CONTEXT * parser, PT_NODE * stmt);
   extern PT_NODE *pt_is_define_vars (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -539,7 +539,8 @@ extern "C"
   extern bool pt_has_inst_in_where_and_select_list (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_inst_or_orderby_num_in_where (PARSER_CONTEXT * parser, PT_NODE * node);
   extern void pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level);
-  extern void pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * pre_pred);
+  extern void pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * pre_pred, int pre_order);
+  extern int pt_get_max_pred_order (PARSER_CONTEXT * parser, PT_NODE * pred);
   extern bool pt_has_nullable_term (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_define_vars (PARSER_CONTEXT * parser, PT_NODE * stmt);
   extern PT_NODE *pt_is_define_vars (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -539,6 +539,7 @@ extern "C"
   extern bool pt_has_inst_in_where_and_select_list (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_inst_or_orderby_num_in_where (PARSER_CONTEXT * parser, PT_NODE * node);
   extern void pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level);
+  extern void pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * post_pred);
   extern bool pt_has_nullable_term (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_define_vars (PARSER_CONTEXT * parser, PT_NODE * stmt);
   extern PT_NODE *pt_is_define_vars (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3531,21 +3531,48 @@ pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level
  *          - set predicate order number
  *   parser(in):
  *   pre_pred(in):
+ *   pre_order(in):
  */
 
 void
-pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * pre_pred)
+pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * pre_pred, int pre_order)
 {
   PT_NODE *pred;
 
-  /* set pred_order + 1 to pre_pred */
+  /* set pred_order + pre_order to pre_pred */
   for (pred = pre_pred; pred; pred = pred->next)
     {
       if (pt_is_expr_node (pred))
 	{
-	  pred->info.expr.pred_order++;
+	  pred->info.expr.pred_order += pre_order;
 	}
     }
+}
+
+/*
+ * pt_get_max_pred_order ()
+ *          - get max predicate order number
+ *   parser(in):
+ *   pred(in):
+ */
+
+int
+pt_get_max_pred_order (PARSER_CONTEXT * parser, PT_NODE * predicate)
+{
+  PT_NODE *pred;
+  int max_pred_order = 0;
+
+  for (pred = predicate; pred; pred = pred->next)
+    {
+      if (pt_is_expr_node (pred))
+	{
+	  if (pred->info.expr.pred_order > max_pred_order)
+	    {
+	      max_pred_order = pred->info.expr.pred_order;
+	    }
+	}
+    }
+  return max_pred_order;
 }
 
 /*

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3530,7 +3530,7 @@ pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level
  * pt_set_pred_order ()
  *          - set predicate order number
  *   parser(in):
- *   post_pred(in):
+ *   pre_pred(in):
  */
 
 void
@@ -3538,8 +3538,8 @@ pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * pre_pred)
 {
   PT_NODE *pred;
 
-  /* set pred_order + 1 to post_pred */
-  for (pred = post_pred; pred; pred = pred->next)
+  /* set pred_order + 1 to pre_pred */
+  for (pred = pre_pred; pred; pred = pred->next)
     {
       if (pt_is_expr_node (pred))
 	{

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3527,6 +3527,28 @@ pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level
 }
 
 /*
+ * pt_set_pred_order ()
+ *          - set predicate order number
+ *   parser(in):
+ *   post_pred(in):
+ */
+
+void
+pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * post_pred)
+{
+  PT_NODE *pred;
+
+  /* set pred_order + 1 to post_pred */
+  for (pred = post_pred; pred; pred = pred->next)
+    {
+      if (pt_is_expr_node (pred))
+	{
+	  pred->info.expr.pred_order++;
+	}
+    }
+}
+
+/*
  * pt_has_nullable_term () - check if tree has an nullable term
  *				   node somewhere
  *   return: true if tree has nullable term

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3534,7 +3534,7 @@ pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level
  */
 
 void
-pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * post_pred)
+pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * pre_pred)
 {
   PT_NODE *pred;
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3817,7 +3817,7 @@ pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_
 	}
       else
 	{
-	  /* Set predicates to be evaluated later */
+	  /* Set predicates to be evaluated first */
 	  pt_set_pred_order (parser, push_term_list);
 
 	  /* push into WHERE clause */
@@ -9928,7 +9928,7 @@ mq_class_lambda (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * class_,
 	  (*where_part)->info.expr.paren_type = 1;
 	}
 
-      /* Set predicates to be evaluated later */
+      /* Set predicates to be evaluated first */
       pt_set_pred_order (parser, class_where_part);
 
       /* The "where clause" is in the form of a list of CNF "and" terms. In order to "and" together the view's "where
@@ -10593,7 +10593,7 @@ mq_inline_view_lambda (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * d
 	{
 	  (*where_part)->info.expr.paren_type = 1;
 	}
-      /* Set predicates to be evaluated later */
+      /* Set predicates to be evaluated first */
       pt_set_pred_order (parser, class_where_part);
 
       /* The "where clause" is in the form of a list of CNF "and" terms. In order to "and" together the view's "where

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3817,6 +3817,9 @@ pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_
 	}
       else
 	{
+	  /* Set predicates to be evaluated later */
+	  pt_set_pred_order (parser, push_term_list);
+
 	  /* push into WHERE clause */
 	  query->info.query.q.select.where = parser_append_node (push_term_list, query->info.query.q.select.where);
 	}
@@ -9924,6 +9927,10 @@ mq_class_lambda (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * class_,
 	{
 	  (*where_part)->info.expr.paren_type = 1;
 	}
+
+      /* Set predicates to be evaluated later */
+      pt_set_pred_order (parser, class_where_part);
+
       /* The "where clause" is in the form of a list of CNF "and" terms. In order to "and" together the view's "where
        * clause" with the statement's, we must maintain this list of terms. Using a 'PT_AND' node here will have the
        * effect of losing the "and" terms on the tail of either list. */
@@ -10586,6 +10593,9 @@ mq_inline_view_lambda (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * d
 	{
 	  (*where_part)->info.expr.paren_type = 1;
 	}
+      /* Set predicates to be evaluated later */
+      pt_set_pred_order (parser, class_where_part);
+
       /* The "where clause" is in the form of a list of CNF "and" terms. In order to "and" together the view's "where
        * clause" with the statement's, we must maintain this list of terms. Using a 'PT_AND' node here will have the
        * effect of losing the "and" terms on the tail of either list. */

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3790,6 +3790,7 @@ pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_
   PARSER_VARCHAR *rewritten = NULL;
   PARSER_VARCHAR *pushed_pred, *query_str, *col_list;
   unsigned int save_custom;
+  int max_pred_order;
 
   if (query == NULL || term_list == NULL)
     {
@@ -3818,7 +3819,8 @@ pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_
       else
 	{
 	  /* Set predicates to be evaluated first */
-	  pt_set_pred_order (parser, push_term_list);
+	  max_pred_order = pt_get_max_pred_order (parser, push_term_list);
+	  pt_set_pred_order (parser, query->info.query.q.select.where, max_pred_order + 1);
 
 	  /* push into WHERE clause */
 	  query->info.query.q.select.where = parser_append_node (push_term_list, query->info.query.q.select.where);
@@ -9929,7 +9931,7 @@ mq_class_lambda (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * class_,
 	}
 
       /* Set predicates to be evaluated first */
-      pt_set_pred_order (parser, class_where_part);
+      pt_set_pred_order (parser, class_where_part, 1);
 
       /* The "where clause" is in the form of a list of CNF "and" terms. In order to "and" together the view's "where
        * clause" with the statement's, we must maintain this list of terms. Using a 'PT_AND' node here will have the
@@ -10594,7 +10596,7 @@ mq_inline_view_lambda (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * d
 	  (*where_part)->info.expr.paren_type = 1;
 	}
       /* Set predicates to be evaluated first */
-      pt_set_pred_order (parser, class_where_part);
+      pt_set_pred_order (parser, class_where_part, 1);
 
       /* The "where clause" is in the form of a list of CNF "and" terms. In order to "and" together the view's "where
        * clause" with the statement's, we must maintain this list of terms. Using a 'PT_AND' node here will have the


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24668

1. Add PRED_ORDER to predicates. (pt_expr_info, qo_term)
2. Increases the pred_order for predicates that must be evaluated first during push-predicate and view-merge. (pt_set_pred_order() )
3. Add logic to sort based on pred_order. (qo_discover_edges() )
4. Since the sorting routine in the existing XASL gerneration is redundant, delete it and keep the sorting related routine only in the optimizer. (make_pred_from_bitset() )




