### PR TITLE
[CBRD-24667] [10.2] Fix error for backup_dest_path in ha_make_slavedb.sh

### DIFF
--- a/contrib/scripts/ha/ha_make_slavedb.sh
+++ b/contrib/scripts/ha/ha_make_slavedb.sh
@@ -268,13 +268,8 @@ function check_args()
 function init_conf()
 {
 	# init path
-	mkdir -p $ha_temp_home
-	if [ -n $backup_dest_path ]; then 
-		backup_dest_path=$ha_temp_home/backup
-		if [ ! -d $backup_dest_path ]; then
-			mkdir $backup_dest_path
-		fi
-	fi
+	backup_dest_path=${backup_dest_path:-$ha_temp_home/backup}
+	mkdir -p $ha_temp_home $backup_dest_path
 	repl_log_home=${repl_log_home%%/}
 	backup_dest_path=${backup_dest_path%%/}
 	backup_dest_path=$(readlink -f $backup_dest_path)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24667

**Purpose**
* Fix backup_dest_path in $CUBRID/share/scripts/ha/ha_make_slavedb.sh
* this is backport of #4122 to release/10.2

**Implementation**
N/A

**Remarks**