### PR TITLE
[LETS-653] [LETS-528] Initialize ps_Gl only when it is needed

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -160,6 +160,7 @@ int init_server_type (const char *db_name)
     }
   else if (g_server_type == SERVER_TYPE_PAGE)
     {
+      ps_Gl.reset (new page_server());
       // page server needs a log prior receiver
       log_Gl.initialize_log_prior_receiver ();
     }
@@ -217,7 +218,8 @@ void finalize_server_type ()
     }
   else if (get_server_type () == SERVER_TYPE_PAGE)
     {
-      ps_Gl.disconnect_all_tran_server ();
+      ps_Gl->disconnect_all_tran_server ();
+      ps_Gl.reset (nullptr);
     }
   else
     {

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -104,6 +104,8 @@ void set_server_type (SERVER_TYPE type)
 
 #if defined (SERVER_MODE)
 
+std::unique_ptr<page_server> ps_Gl;
+
 int init_server_type (const char *db_name)
 {
   int er_code = NO_ERROR;

--- a/src/base/server_type.hpp
+++ b/src/base/server_type.hpp
@@ -45,7 +45,7 @@ int init_server_type (const char *db_name);
 active_tran_server *get_active_tran_server_ptr ();
 passive_tran_server *get_passive_tran_server_ptr ();
 
-extern std::unique_ptr<page_server> ps_Gl;
 extern std::unique_ptr<tran_server> ts_Gl;
+extern std::unique_ptr<page_server> ps_Gl;
 
 #endif // _SERVER_TYPE_H_

--- a/src/base/server_type.hpp
+++ b/src/base/server_type.hpp
@@ -25,6 +25,7 @@
 
 /* forward declarations
  */
+class page_server;
 class tran_server;
 class active_tran_server;
 class passive_tran_server;
@@ -44,6 +45,7 @@ int init_server_type (const char *db_name);
 active_tran_server *get_active_tran_server_ptr ();
 passive_tran_server *get_passive_tran_server_ptr ();
 
+extern std::unique_ptr<page_server> ps_Gl;
 extern std::unique_ptr<tran_server> ts_Gl;
 
 #endif // _SERVER_TYPE_H_

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2634,7 +2634,7 @@ css_process_server_server_connect (SOCKET master_fd)
 	  break;
 	}
       // *INDENT-ON*
-      ps_Gl.set_active_tran_server_connection (std::move (chn));
+      ps_Gl->set_active_tran_server_connection (std::move (chn));
       break;
     case cubcomm::server_server::CONNECT_PASSIVE_TRAN_TO_PAGE_SERVER:
       // *INDENT-OFF*
@@ -2644,7 +2644,7 @@ css_process_server_server_connect (SOCKET master_fd)
           break;
         }
       // *INDENT-ON*
-      ps_Gl.set_passive_tran_server_connection (std::move (chn));
+      ps_Gl->set_passive_tran_server_connection (std::move (chn));
       break;
     default:
       assert (false);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -36,8 +36,6 @@
 #include <functional>
 #include <thread>
 
-std::unique_ptr<page_server> ps_Gl;
-
 page_server::~page_server ()
 {
   assert (m_replicator == nullptr);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -36,7 +36,7 @@
 #include <functional>
 #include <thread>
 
-page_server ps_Gl;
+std::unique_ptr<page_server> ps_Gl;
 
 page_server::~page_server ()
 {

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -249,7 +249,4 @@ class page_server
     pts_mvcc_tracker m_pts_mvcc_tracker;
 };
 
-extern std::unique_ptr<page_server> ps_Gl;
-
 #endif // !_PAGE_SERVER_HPP_
-

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -249,7 +249,7 @@ class page_server
     pts_mvcc_tracker m_pts_mvcc_tracker;
 };
 
-extern page_server ps_Gl;
+extern std::unique_ptr<page_server> ps_Gl;
 
 #endif // !_PAGE_SERVER_HPP_
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8497,7 +8497,7 @@ pgbuf_respond_data_fetch_page_request (THREAD_ENTRY &thread_r, std::string &payl
       // TODO: FIXME
       // The transaction server boots and reads pages before initializing its log module and before knowing a safe target
       // LSA for replication. A way of knowing this target LSA is required, but disable this wait until that's fixed.
-      ps_Gl.get_replicator ().wait_past_target_lsa (target_repl_lsa);
+      ps_Gl->get_replicator ().wait_past_target_lsa (target_repl_lsa);
     }
 
   int error = NO_ERROR;

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2529,8 +2529,8 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   if (get_server_type () == SERVER_TYPE_PAGE)
     {
       const log_lsa next_io_lsa = log_Gl.append.get_nxio_lsa ();
-      ps_Gl.start_log_replicator (next_io_lsa);
-      ps_Gl.init_request_responder ();
+      ps_Gl->start_log_replicator (next_io_lsa);
+      ps_Gl->init_request_responder ();
     }
 #endif // SERVER_MODE
 
@@ -3175,9 +3175,9 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
   if (get_server_type () == SERVER_TYPE_PAGE)
     {
       log_Gl.finalize_log_prior_receiver ();	// stop receiving log before log_final()
-      ps_Gl.disconnect_all_tran_server ();
-      ps_Gl.finish_replication_during_shutdown (*thread_p);
-      ps_Gl.finalize_request_responder ();
+      ps_Gl->disconnect_all_tran_server ();
+      ps_Gl->finish_replication_during_shutdown (*thread_p);
+      ps_Gl->finalize_request_responder ();
     }
   else if (get_server_type () == SERVER_TYPE_TRANSACTION)
     {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3487,7 +3487,7 @@ log_pack_log_boot_info (THREAD_ENTRY &thread_r, std::string &payload_in_out,
     prev_lsa = log_Gl.append.prev_lsa;
 
     // most recent trantable snapshot lsa
-    most_recent_trantable_snapshot_lsa = ps_Gl.get_replicator().get_most_recent_trantable_snapshot_lsa ();
+    most_recent_trantable_snapshot_lsa = ps_Gl->get_replicator().get_most_recent_trantable_snapshot_lsa ();
     payload_in_out.append(reinterpret_cast<const char *> (&most_recent_trantable_snapshot_lsa),
 			  sizeof (log_lsa));
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -4344,7 +4344,7 @@ logpb_send_flushed_lsa_to_ats ()
     }
   // *INDENT-OFF*
   std::string message (reinterpret_cast<const char *> (&saved_lsa), sizeof (saved_lsa));
-  ps_Gl.push_request_to_active_tran_server (page_to_tran_request::SEND_SAVED_LSA, std::move (message));
+  ps_Gl->push_request_to_active_tran_server (page_to_tran_request::SEND_SAVED_LSA, std::move (message));
   // *INDENT-ON*
 }
 #endif // SERVER_MODE
@@ -7309,7 +7309,7 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
   if (get_server_type () == SERVER_TYPE_PAGE && LOG_ISRESTARTED ())
     {
       // Wait the replication to catch up first
-      ps_Gl.get_replicator ().wait_past_target_lsa (new_chkpt_lsa);
+      ps_Gl->get_replicator ().wait_past_target_lsa (new_chkpt_lsa);
     }
 #endif // SERVER_MODE == not SA_MODE
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-653
http://jira.cubrid.org/browse/LETS-528 

Use unique_ptr for `ps_Gl` and initialize it only when needed. See the Jira issue.
