### PR TITLE
[CBRD-24662] Add a LoggingThread to access javasp's log file by only one thread

### DIFF
--- a/src/jsp/com/cubrid/jsp/LoggingThread.java
+++ b/src/jsp/com/cubrid/jsp/LoggingThread.java
@@ -1,0 +1,79 @@
+/*
+ *
+ * Copyright (c) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package com.cubrid.jsp;
+
+import java.io.IOException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class LoggingThread extends Thread {
+    private final Logger logger = Logger.getLogger("com.cubrid.jsp");
+
+    private FileHandler logHandler = null;
+    private LinkedBlockingQueue<String> logQueue = new LinkedBlockingQueue<String>();
+    private Level logginLevel = Level.SEVERE;
+
+    public LoggingThread(String path) throws SecurityException, IOException {
+        super();
+        logHandler = new FileHandler(path, true);
+        logger.addHandler(logHandler);
+    }
+
+    @Override
+    public void run() {
+        while (Thread.interrupted() == false) {
+            try {
+                String logString = logQueue.take();
+                logger.log(logginLevel, logString);
+            } catch (InterruptedException e) {
+                break;
+            }
+        }
+
+        if (logHandler != null) {
+            try {
+                logHandler.close();
+                logger.removeHandler(logHandler);
+            } catch (Throwable e) {
+            }
+        }
+    }
+
+    public void log(String str) {
+        try {
+            logQueue.put(str);
+        } catch (InterruptedException e) {
+        }
+    }
+}

--- a/src/jsp/com/cubrid/jsp/Server.java
+++ b/src/jsp/com/cubrid/jsp/Server.java
@@ -33,13 +33,13 @@ package com.cubrid.jsp;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.net.ServerSocket;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.FileHandler;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.newsclub.net.unix.AFUNIXServerSocket;
 import org.newsclub.net.unix.AFUNIXSocketAddress;
@@ -62,6 +62,8 @@ public class Server {
 
     private static Server serverInstance = null;
 
+    private static LoggingThread loggingThread = null;
+
     private Server(
             String name, String path, String version, String rPath, String uPath, String port)
             throws IOException, ClassNotFoundException {
@@ -74,6 +76,16 @@ public class Server {
         ServerSocket serverSocket = null;
         int port_number = Integer.parseInt(port);
         try {
+            String logFilePath =
+                    rootPath
+                            + File.separatorChar
+                            + LOG_DIR
+                            + File.separatorChar
+                            + serverName
+                            + "_java.log";
+            loggingThread = new LoggingThread(logFilePath);
+            loggingThread.start();
+
             if (OSValidator.IS_UNIX && port_number == -1) {
                 final File socketFile = new File(udsPath);
                 if (socketFile.exists()) {
@@ -107,6 +119,7 @@ public class Server {
             Class.forName("com.cubrid.jsp.jdbc.CUBRIDServerSideDriver");
 
             getJVMArguments(); /* store jvm options */
+
         } else {
             /* error, serverSocket is not properly initialized */
             System.exit(1);
@@ -175,6 +188,7 @@ public class Server {
     public static void stop(int status) {
         getServer().setShutdown();
         getServer().stopSocketListener();
+        loggingThread.interrupt();
         System.exit(status);
     }
 
@@ -183,30 +197,10 @@ public class Server {
     }
 
     public static void log(Throwable ex) {
-        FileHandler logHandler = null;
-
-        try {
-            logHandler =
-                    new FileHandler(
-                            rootPath
-                                    + File.separatorChar
-                                    + LOG_DIR
-                                    + File.separatorChar
-                                    + serverName
-                                    + "_java.log",
-                            true);
-            logger.addHandler(logHandler);
-            logger.log(Level.SEVERE, "", ex);
-        } catch (Throwable e) {
-        } finally {
-            if (logHandler != null) {
-                try {
-                    logHandler.close();
-                    logger.removeHandler(logHandler);
-                } catch (Throwable e) {
-                }
-            }
-        }
+        StringWriter sw = new StringWriter();
+        ex.printStackTrace(new PrintWriter(sw));
+        String exceptionAsString = sw.toString();
+        loggingThread.log(exceptionAsString);
     }
 
     public void setShutdown() {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24662

Java FileHandler creates a new file with an increasing number when there exist conflicts to a file. Because of this, If an exception occurs very quickly by many threads in the Java SP server, Many log files are generated by the FileHandler's behavior.
To avoid this behavior, This PR implements the LoggingThread to access a log file with a single thread. Other threads will put their exception into LinkedBlockingQueue. And the LoggingThread will take the log string of exception without conflict.