### PR TITLE
[LETS-654] Do disconnect_all_tran_server() only in xboot_shutdown_server

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -215,7 +215,6 @@ void finalize_server_type ()
 	  assert (ats_Gl != nullptr);
 	  ats_Gl = nullptr;
 	}
-      ts_Gl->disconnect_all_page_servers ();
       ts_Gl.reset (nullptr);
     }
   else if (get_server_type () == SERVER_TYPE_PAGE)

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -220,7 +220,6 @@ void finalize_server_type ()
     }
   else if (get_server_type () == SERVER_TYPE_PAGE)
     {
-      ps_Gl->disconnect_all_tran_server ();
       ps_Gl.reset (nullptr);
     }
   else

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3193,20 +3193,14 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
 	  //  - finalize log infrastructure
 	  //    - done in: shutdown server routine
 	  //  - stop sending messages to page server (eg: oldest MVCCID updates)
-	  //    - done in:
-	  //        shutdown server routine
-	  //          -> boot_server_all_finalize
-	  //            -> finalize_server_type
-	  //              -> and then polymorphically in the transaction server object
-	  //                disconnect_all_page_servers routine right before sending
-	  //                the final disconnect message to Page Server(s)
+	  //    - done in: shutdown server routine
+	  //      -> and then polymorphically in the transaction server object
+	  //         disconnect_all_page_servers routine right before sending
+	  //         the final disconnect message to Page Server(s)
 	  //  - send the final disconnect message to Page Server(s)
-	  //    - done in:
-	  //        shutdown server routine (this routine)
-	  //          -> boot_server_all_finalize
-	  //            -> finalize_server_type
-	  //              -> tran_server::disconnect_all_page_servers
-	  //                -> tran_server::connection_handler::disconnect
+	  //    - done in: shutdown server routine
+	  //      -> tran_server::disconnect_all_page_servers
+	  //        -> tran_server::connection_handler::disconnect
 	  //  - delete the Passive Transaction Server object
 	  //    - done in: finalize_server_type
 
@@ -3223,6 +3217,8 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
 	  pts_ptr->finish_replication_during_shutdown (*thread_p);
 	}
 
+      ts_Gl->disconnect_all_page_servers ();
+
       // shutdown order for Active Transaction Server:
       //  - finalize log infrastructure
       //    - done in: shutdown server routine (this routine)
@@ -3233,19 +3229,13 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
       //      Page Server(s) semi-synchronously via the prior_sender::send_list routine
       //  - unregister log prior sinks (used to dispatch produced transactional log to connected
       //    Page Servers:
-      //    - done in:
-      //        shutdown server routine (this routine)
-      //          -> boot_server_all_finalize
-      //            -> finalize_server_type
-      //              -> tran_server::disconnect_all_page_servers
-      //                -> active_tran_server::connection_handler::disconnect
+      //    - done in: shutdown server routine (this routine)
+      //      -> tran_server::disconnect_all_page_servers
+      //      -> active_tran_server::connection_handler::disconnect
       //  - send the final disconnect message to all connected Page Server(s)
-      //    - done in:
-      //        shutdown server routine (this routine)
-      //          -> boot_server_all_finalize
-      //            -> finalize_server_type
-      //              -> tran_server::disconnect_all_page_servers
-      //                -> tran_server::connection_handler::disconnect
+      //    - done in: shutdown server routine (this routine)
+      //      -> tran_server::disconnect_all_page_servers
+      //      -> active_tran_server::connection_handler::disconnect
       //  - delete the Active Transaction Server object
       //    - done in:
       //        shutdown server routine (this routine)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-654

- Delete ps_Gl->disconnect_all_tran_server (); in finalize_server_type(), which is called redundantly.
- Move ps_Gl->disconnect_all_tran_server (); to xboot_shutdown_server too for code consistency.
  - Update the comment about the shutdown sequence.
- Without this, #4135 runs into an assertion failure during shutdown.