### PR TITLE
[CBRD-24677] Remove the function lock_object_with_btid () which is declared but not defined.

### DIFF
--- a/src/transaction/lock_manager.h
+++ b/src/transaction/lock_manager.h
@@ -202,8 +202,6 @@ extern int lock_object_wait_msecs (THREAD_ENTRY * thread_p, const OID * oid, con
 extern int lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag);
 extern int lock_subclass (THREAD_ENTRY * thread_p, const OID * subclass_oid, const OID * superclass_oid, LOCK lock,
 			  int cond_flag);
-extern int lock_object_with_btid (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, const BTID * btid,
-				  LOCK lock, int cond_flag);
 extern int lock_scan (THREAD_ENTRY * thread_p, const OID * class_oid, int cond_flag, LOCK class_lock);
 extern int lock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint);
 extern void lock_remove_object_lock (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24677

**Purpose**
The function lock_object_with_btid () is only declared in the header file, lock_manager.h.

**Implementation**
N/A

**Remarks**
N/A
