### PR TITLE
[CBRD-24681] Change the lock mode that will be released on error after the function file_tracker_interruptable_iterate () is called.

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -8258,7 +8258,7 @@ btree_repair_prev_link (THREAD_ENTRY * thread_p, OID * oid, BTID * index_btid, b
 	  break;
 	}
     }
-  /* if the break statement occurs due to an error, the lock acquired immediately before should be released. */
+  /* if the break statement occurs due to an error, the acquired lock should be released. */
   if (!OID_ISNULL (&class_oid))
     {
       lock_unlock_object (thread_p, &class_oid, oid_Root_class_oid, IX_LOCK, true);
@@ -8319,7 +8319,7 @@ btree_check_all (THREAD_ENTRY * thread_p)
 
   if (!OID_ISNULL (&class_oid))
     {
-      lock_unlock_object (thread_p, &class_oid, oid_Root_class_oid, SCH_S_LOCK, true);
+      lock_unlock_object (thread_p, &class_oid, oid_Root_class_oid, IX_LOCK, true);
     }
   return allvalid;
 }

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -8261,7 +8261,7 @@ btree_repair_prev_link (THREAD_ENTRY * thread_p, OID * oid, BTID * index_btid, b
   /* if the break statement occurs due to an error, the lock acquired immediately before should be released. */
   if (!OID_ISNULL (&class_oid))
     {
-      lock_unlock_object (thread_p, &class_oid, oid_Root_class_oid, FILE_GET_TRACKER_LOCK_MODE (FILE_BTREE), true);
+      lock_unlock_object (thread_p, &class_oid, oid_Root_class_oid, IX_LOCK, true);
     }
 
   return valid;

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -8258,9 +8258,10 @@ btree_repair_prev_link (THREAD_ENTRY * thread_p, OID * oid, BTID * index_btid, b
 	  break;
 	}
     }
+  /* if the break statement occurs due to an error, the lock acquired immediately before should be released. */
   if (!OID_ISNULL (&class_oid))
     {
-      lock_unlock_object (thread_p, &class_oid, oid_Root_class_oid, SCH_S_LOCK, true);
+      lock_unlock_object (thread_p, &class_oid, oid_Root_class_oid, FILE_GET_TRACKER_LOCK_MODE (FILE_BTREE), true);
     }
 
   return valid;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24681

**Purpose**
```
lock_unlock_object (thread_p, &class_oid, oid_Root_class_oid, "requested lock mode", "force");
```
If the parameter force is true when the function lock_unlock_object is called, the lock on the resource is released, even if the requested lock mode is different from the actual lock mode.
So requesting to release the lock different from the actual lock didn't make problems.

**Implementation**
N/A

**Remarks**
N/A