### PR TITLE
[CBRD-24634] Delete methods that require privileges from the general user's schema file

### DIFF
--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -7678,18 +7678,24 @@ au_export_users (extract_context & ctxt, print_output & output_ctx)
 	    {
 	      if (!strlen (passbuf))
 		{
-		  output_ctx ("call [add_user]('%s', '') on class [db_root];\n", uname);
+		  if (ctxt.is_dba_user || ctxt.is_dba_group_member)
+		    {
+		      output_ctx ("call [add_user]('%s', '') on class [db_root];\n", uname);
+		    }
 		}
 	      else
 		{
-		  output_ctx ("call [add_user]('%s', '') on class [db_root] to [auser];\n", uname);
-		  if (encrypt_mode == ENCODE_PREFIX_DES)
+		  if (ctxt.is_dba_user || ctxt.is_dba_group_member)
 		    {
-		      output_ctx ("call [set_password_encoded]('%s') on [auser];\n", passbuf);
-		    }
-		  else
-		    {
-		      output_ctx ("call [set_password_encoded_sha1]('%s') on [auser];\n", passbuf);
+		      output_ctx ("call [add_user]('%s', '') on class [db_root] to [auser];\n", uname);
+		      if (encrypt_mode == ENCODE_PREFIX_DES)
+			{
+			  output_ctx ("call [set_password_encoded]('%s') on [auser];\n", passbuf);
+			}
+		      else
+			{
+			  output_ctx ("call [set_password_encoded_sha1]('%s') on [auser];\n", passbuf);
+			}
 		    }
 		}
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24634

Purpose
In the schema file, both METHODs that require privileges and METHODs that do not require privileges are used.
In the case of a general user, an error occurs when using METHOD that requires authority.
The general user's schema file must be created without METHOD requiring privileges.

Implementation
Users without privilege cannot use the following METHOD.
> call **[add_user]**('USER1', '') on class [db_root] to [auser];
> call **[add_member]**('USER1') on [g_DBA];
> call **[change_owner]**('test_t', 'USER2') on class [db_root];
>     '
>     '

Remarks
N/A
