### PR TITLE
[CBRD-24645] backport for CBRD-24645, CBRD-24652

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -646,6 +646,24 @@ pt_lambda_node (PARSER_CONTEXT * parser, PT_NODE * tree_or_name, void *void_arg,
 	  return result;
 	}
     }
+  /* change inst_num() to orderby_num() */
+  if (PT_IS_INSTNUM (tree_or_name) && PT_IS_INSTNUM (lambda_name))
+    {
+      /* found match */
+      /* replace 'tree_or_name' node with 'lambda_arg->tree' */
+      next = tree_or_name->next;
+      result = parser_copy_tree_list (parser, lambda_arg->tree);
+      parser_free_node (parser, tree_or_name);
+      for (temp = result; temp->next; temp = temp->next)
+	{
+	  ;
+	}
+      temp->next = next;
+
+      lambda_arg->replace_num++;
+
+      return result;
+    }
 
   if (name_node->node_type != PT_NAME || lambda_name->node_type != PT_NAME)
     {
@@ -1060,6 +1078,17 @@ pt_lambda_with_arg (PARSER_CONTEXT * parser, PT_NODE * tree_with_names, PT_NODE 
 	    {
 	      /* change orderby_num() to groupby_num() */
 	      /* change orderby_num() to inst_num() */
+	      arg_ok = true;
+	    }
+	}
+    }
+  else if (name_node->node_type == PT_EXPR && name_node->info.expr.op == PT_INST_NUM)
+    {
+      /* change inst_num() to orderby_num() */
+      if (corresponding_tree)
+	{
+	  if (corresponding_tree->node_type == PT_EXPR && corresponding_tree->info.expr.op == PT_ORDERBY_NUM)
+	    {
 	      arg_ok = true;
 	    }
 	}

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -535,6 +535,7 @@ extern "C"
   extern bool pt_has_order_sensitive_agg (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_inst_or_orderby_num (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_inst_num (PARSER_CONTEXT * parser, PT_NODE * node);
+  extern bool pt_has_expr_of_inst_in_sel_list (PARSER_CONTEXT * parser, PT_NODE * select_list);
   extern bool pt_has_inst_in_where_and_select_list (PARSER_CONTEXT * parser, PT_NODE * node);
   extern void pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level);
   extern bool pt_has_nullable_term (PARSER_CONTEXT * parser, PT_NODE * node);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3350,6 +3350,44 @@ pt_has_inst_num (PARSER_CONTEXT * parser, PT_NODE * node)
 }
 
 /*
+ * pt_has_expr_of_inst_in_sel_list () - check if tree has an EXPR node having INST_NUM in select list
+ *   return: true if tree has EXPR node having INST_NUM
+ *   parser(in):
+ *   node(in):
+ */
+bool
+pt_has_expr_of_inst_in_sel_list (PARSER_CONTEXT * parser, PT_NODE * select_list)
+{
+  PT_NODE *save_next, *col;
+
+  /*
+   * FIXME!! : remove this check after expanding syntax related to orderby_num().
+   * This check is needed because the syntax below is not supported.
+   * 'select orderby_num() + 10 ...'
+   * Check MSGCAT_SEMANTIC_ORDERBYNUM_SELECT_LIST_ERR error code
+   * In XASL Generator, 'ordbynum_val' must be created as a regular variable, not db_value.
+   */
+  col = select_list;
+  while (col)
+    {
+      /* cut off next */
+      save_next = col->next;
+      col->next = NULL;
+
+      if (!PT_IS_INSTNUM (col) && pt_has_inst_num (parser, col))
+	{
+	  /* find expr of instnum */
+	  col->next = save_next;
+	  return true;
+	}
+      col->next = save_next;
+      col = col->next;
+    }
+
+  return false;
+}
+
+/*
  * pt_has_inst_in_where_and_select_list ()
  *          - check if tree has an INST_NUM or ORDERBY_NUM or GROUPBY_NUM node in where and select_list
  *   return: true if tree has INST_NUM/ORDERBY_NUM

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1777,8 +1777,7 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * 
   /* subquery has order_by and main query has inst_num or analytic or order-sensitive aggrigation */
   if (subquery->info.query.order_by
       && (pt_has_inst_num (parser, pred) || pt_has_analytic (parser, mainquery)
-	  || pt_has_order_sensitive_agg (parser, mainquery) ||
-	  pt_has_expr_of_inst_in_sel_list (parser, select_list)))
+	  || pt_has_order_sensitive_agg (parser, mainquery) || pt_has_expr_of_inst_in_sel_list (parser, select_list)))
     {
       /* not pushable */
       return NON_PUSHABLE;
@@ -2155,7 +2154,7 @@ mq_update_order_by (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * quer
 
   statement->info.query.order_by = parser_append_node (order_by, statement->info.query.order_by);
 
-   /* generate orderby_num(), inst_num() */
+  /* generate orderby_num(), inst_num() */
   if (!(ord_num = parser_new_node (parser, PT_EXPR)) || !(ins_num = parser_new_node (parser, PT_EXPR)))
     {
       if (ord_num)

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1662,7 +1662,7 @@ static PUSHABLE_TYPE
 mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * mainquery, PT_NODE * class_spec,
 			 bool is_vclass)
 {
-  PT_NODE *pred, *statement_spec = NULL;
+  PT_NODE *pred, *statement_spec = NULL, *select_list;
   CHECK_PUSHABLE_INFO cpi;
   bool is_pushable_query, is_outer_joined;
   bool is_only_spec;
@@ -1683,27 +1683,32 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * 
     case PT_SELECT:
       statement_spec = mainquery->info.query.q.select.from;
       pred = mainquery->info.query.q.select.where;
+      select_list = mainquery->info.query.q.select.list;
       break;
 
     case PT_UPDATE:
       statement_spec = mainquery->info.update.spec;
       pred = mainquery->info.update.search_cond;
+      select_list = NULL;
       break;
 
     case PT_DELETE:
       statement_spec = mainquery->info.delete_.spec;
       pred = mainquery->info.delete_.search_cond;
+      select_list = NULL;
       break;
 
     case PT_INSERT:
       /* since INSERT can not have a spec list or statement conditions, there is nothing to check */
       statement_spec = mainquery->info.insert.spec;
       pred = NULL;
+      select_list = NULL;
       break;
 
     case PT_MERGE:
       statement_spec = mainquery->info.merge.into;
       pred = mainquery->info.merge.insert.search_cond;
+      select_list = NULL;
       break;
 
     default:
@@ -1772,7 +1777,8 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * 
   /* subquery has order_by and main query has inst_num or analytic or order-sensitive aggrigation */
   if (subquery->info.query.order_by
       && (pt_has_inst_num (parser, pred) || pt_has_analytic (parser, mainquery)
-	  || pt_has_order_sensitive_agg (parser, mainquery)))
+	  || pt_has_order_sensitive_agg (parser, mainquery) ||
+	  pt_has_expr_of_inst_in_sel_list (parser, select_list)))
     {
       /* not pushable */
       return NON_PUSHABLE;
@@ -2005,6 +2011,7 @@ mq_update_order_by (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * quer
   PT_NODE *attributes, *attr, *prev_order;
   PT_NODE *save_data_type, *node, *result, *order_by;
   PT_NODE *free_node = NULL, *save_next;
+  PT_NODE *ord_num = NULL, *ins_num = NULL, *prev_orderby_for;
   int attr_count;
   int i;
   UINTPTR spec_id;
@@ -2147,6 +2154,28 @@ mq_update_order_by (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * quer
     }
 
   statement->info.query.order_by = parser_append_node (order_by, statement->info.query.order_by);
+
+   /* generate orderby_num(), inst_num() */
+  if (!(ord_num = parser_new_node (parser, PT_EXPR)) || !(ins_num = parser_new_node (parser, PT_EXPR)))
+    {
+      if (ord_num)
+	{
+	  parser_free_tree (parser, ord_num);
+	}
+      PT_ERRORm (parser, statement, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+      return NULL;
+    }
+  ord_num->type_enum = PT_TYPE_BIGINT;
+  ord_num->info.expr.op = PT_ORDERBY_NUM;
+  PT_EXPR_INFO_SET_FLAG (ord_num, PT_EXPR_INFO_ORDERBYNUM_C);
+
+  ins_num->type_enum = PT_TYPE_BIGINT;
+  ins_num->info.expr.op = PT_INST_NUM;
+  PT_EXPR_INFO_SET_FLAG (ins_num, PT_EXPR_INFO_INSTNUM_C);
+
+  /* replace rownum of select-list to orderby_num */
+  statement->info.query.q.select.list =
+    pt_lambda_with_arg (parser, statement->info.query.q.select.list, ins_num, ord_num, false, 0, false);
 
   if (free_node != NULL)
     {

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -8367,8 +8367,8 @@ check_hash_list_scan (LLIST_SCAN_ID * llsidp, int *val_cnt, int hash_list_scan_y
       vtype1 = REGU_VARIABLE_GET_TYPE (&probe->value);
       vtype2 = REGU_VARIABLE_GET_TYPE (&build->value);
 
-      if (((vtype1 == DB_TYPE_OBJECT || vtype1 == DB_TYPE_VOBJ) && vtype2 == DB_TYPE_OID) ||
-	  ((vtype2 == DB_TYPE_OBJECT || vtype2 == DB_TYPE_VOBJ) && vtype1 == DB_TYPE_OID))
+      if ((vtype1 == DB_TYPE_OBJECT && vtype2 == DB_TYPE_OID) || (vtype2 == DB_TYPE_OBJECT && vtype1 == DB_TYPE_OID)
+	  || (vtype1 == DB_TYPE_VOBJ || vtype2 == DB_TYPE_VOBJ))
 	{
 	  return HASH_METH_NOT_USE;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24645

backport for
[CBRD-24645] When order-by of subquery is copied to main query during view merging, rownum of main query is displayed incorrectly
[CBRD-24652] The problem performing hash list scan when VOBJECT is included in predicates.
