### PR TITLE
[CBRD-24626] Supports an alternative way when the ping command is blocked in the HA

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -379,6 +379,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_HA_TCP_PING_HOSTS "ha_tcp_ping_hosts"
 
+#define PRM_NAME_HA_PING_TIMEOUT "ha_ping_timeout"
+
 #define PRM_NAME_HA_APPLYLOGDB_RETRY_ERROR_LIST "ha_applylogdb_retry_error_list"
 
 #define PRM_NAME_HA_APPLYLOGDB_IGNORE_ERROR_LIST "ha_applylogdb_ignore_error_list"
@@ -1455,6 +1457,12 @@ static unsigned int prm_ha_ping_hosts_flag = 0;
 const char *PRM_HA_TCP_PING_HOSTS = "";
 static const char *prm_ha_tcp_ping_hosts_default = NULL;
 static unsigned int prm_ha_tcp_ping_hosts_flag = 0;
+
+int PRM_HA_PING_TIMEOUT = 1000;
+static int prm_ha_ping_timeout_default = 1000;
+static int prm_ha_ping_timeout_upper = INT_MAX;
+static int prm_ha_ping_timeout_lower = 0;
+static unsigned int prm_ha_ping_timeout_flag = 0;
 
 int *PRM_HA_APPLYLOGDB_RETRY_ERROR_LIST = int_list_initial;
 static bool *prm_ha_applylogdb_retry_error_list_default = NULL;
@@ -6189,6 +6197,18 @@ SYSPRM_PARAM prm_Def[] = {
    (void *) &prm_ha_tcp_ping_hosts_default,
    (void *) &PRM_HA_TCP_PING_HOSTS,
    (void *) NULL, (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_HA_PING_TIMEOUT,
+   PRM_NAME_HA_PING_TIMEOUT,
+   (PRM_FOR_CLIENT | PRM_RELOADABLE | PRM_FOR_HA | PRM_HIDDEN),
+   PRM_INTEGER,
+   &prm_ha_ping_timeout_flag,
+   (void *) &prm_ha_ping_timeout_default,
+   (void *) &PRM_HA_PING_TIMEOUT,
+   (void *) &prm_ha_ping_timeout_upper,
+   (void *) &prm_ha_ping_timeout_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL}

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -377,6 +377,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_HA_PING_HOSTS "ha_ping_hosts"
 
+#define PRM_NAME_HA_TCP_PING_HOSTS "ha_tcp_ping_hosts"
+
 #define PRM_NAME_HA_APPLYLOGDB_RETRY_ERROR_LIST "ha_applylogdb_retry_error_list"
 
 #define PRM_NAME_HA_APPLYLOGDB_IGNORE_ERROR_LIST "ha_applylogdb_ignore_error_list"
@@ -1449,6 +1451,10 @@ static unsigned int prm_ha_max_heartbeat_gap_flag = 0;
 const char *PRM_HA_PING_HOSTS = "";
 static const char *prm_ha_ping_hosts_default = NULL;
 static unsigned int prm_ha_ping_hosts_flag = 0;
+
+const char *PRM_HA_TCP_PING_HOSTS = "";
+static const char *prm_ha_tcp_ping_hosts_default = NULL;
+static unsigned int prm_ha_tcp_ping_hosts_flag = 0;
 
 int *PRM_HA_APPLYLOGDB_RETRY_ERROR_LIST = int_list_initial;
 static bool *prm_ha_applylogdb_retry_error_list_default = NULL;
@@ -6175,6 +6181,17 @@ SYSPRM_PARAM prm_Def[] = {
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},
+  {PRM_ID_HA_TCP_PING_HOSTS,
+   PRM_NAME_HA_TCP_PING_HOSTS,
+   (PRM_FOR_CLIENT | PRM_RELOADABLE | PRM_FOR_HA),
+   PRM_STRING,
+   &prm_ha_tcp_ping_hosts_flag,
+   (void *) &prm_ha_tcp_ping_hosts_default,
+   (void *) &PRM_HA_TCP_PING_HOSTS,
+   (void *) NULL, (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL}
 };
 
 static int num_session_parameters = 0;

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1458,9 +1458,9 @@ const char *PRM_HA_TCP_PING_HOSTS = "";
 static const char *prm_ha_tcp_ping_hosts_default = NULL;
 static unsigned int prm_ha_tcp_ping_hosts_flag = 0;
 
-int PRM_HA_PING_TIMEOUT = 1000;
-static int prm_ha_ping_timeout_default = 1000;
-static int prm_ha_ping_timeout_upper = INT_MAX;
+int PRM_HA_PING_TIMEOUT = PRM_TCP_CONNECTION_TIMEOUT;
+static int prm_ha_ping_timeout_default = prm_tcp_connection_timeout_default;	/* NOTE: It is difficult to determine an accurate default value for TCP connection timeout, so the default value of the connection_time system parameter is followed. */
+static int prm_ha_ping_timeout_upper = INT_MAX / 1000;	/* divided by msecs */
 static int prm_ha_ping_timeout_lower = 0;
 static unsigned int prm_ha_ping_timeout_flag = 0;
 

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -467,8 +467,9 @@ enum param_id
   PRM_ID_REGEXP_ENGINE,
   PRM_ID_ORACLE_STYLE_NUMBER_RETURN,
   PRM_ID_HA_TCP_PING_HOSTS,
+  PRM_ID_HA_PING_TIMEOUT,
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_HA_TCP_PING_HOSTS
+  PRM_LAST_ID = PRM_ID_HA_PING_TIMEOUT
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -466,8 +466,9 @@ enum param_id
   PRM_ID_QMGR_MAX_QUERY_PER_TRAN,
   PRM_ID_REGEXP_ENGINE,
   PRM_ID_ORACLE_STYLE_NUMBER_RETURN,
+  PRM_ID_HA_TCP_PING_HOSTS,
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_ORACLE_STYLE_NUMBER_RETURN
+  PRM_LAST_ID = PRM_ID_HA_TCP_PING_HOSTS
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -986,7 +986,7 @@ hb_cluster_job_check_ping (HB_JOB_ARG * arg)
     {
       for (ping_host = hb_Cluster->ping_hosts; ping_host; ping_host = ping_host->next)
 	{
-	  if (ping_host->port == 0)	// prm_get_string_value (PRM_ID_HA_PING_HOSTS) != NULL
+	  if (prm_get_string_value (PRM_ID_HA_PING_HOSTS))
 	    {
 	      ping_result = hb_check_ping (ping_host->host_name);
 	    }

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -6773,7 +6773,8 @@ hb_check_tcp_ping (const char *host, int port, int timeout)
 
   css_shutdown_socket (sfd);
 
-  MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "TCP PING is success on host %s, port %d, timeout %d msecs.\n", host, port, timeout);
+  MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "TCP PING is success on host %s, port %d, timeout %d msecs.\n", host, port,
+		       timeout);
 
   return HB_PING_SUCCESS;
 }

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -2171,6 +2171,8 @@ hb_add_tcp_ping_host (char *host_name, int port)
   HB_PING_HOST_ENTRY *p;
   HB_PING_HOST_ENTRY **first_pp;
 
+  MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "%s:%d is added to the TCP PING list.\n", host_name, port);
+
   if (host_name == NULL)
     {
       return NULL;
@@ -2295,6 +2297,7 @@ hb_cluster_load_tcp_ping_host_list (char *ha_ping_host_list)
 
   if (ha_ping_host_list == NULL)
     {
+      MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "ha_tcp_ping_hosts=NULL\n");
       return 0;
     }
 
@@ -2321,7 +2324,7 @@ hb_cluster_load_tcp_ping_host_list (char *ha_ping_host_list)
 
       if (strcmp (host_p, "0.0.0.0") == 0)
 	{
-	  snprintf (buf, sizeof (buf), "We do not allow 0.0.0.0 as a ping hosts, excluded");
+	  snprintf (buf, sizeof (buf), "We do not allow 0.0.0.0 as a tcp ping hosts, excluded");
 	  MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HB_NODE_EVENT, 1, buf);
 	}
       else
@@ -2334,6 +2337,9 @@ hb_cluster_load_tcp_ping_host_list (char *ha_ping_host_list)
 	  num_hosts++;
 	}
     }
+
+  MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "ha_tcp_ping_hosts=%s is parsed into %d host:port.\n",
+		       ha_ping_host_list, num_hosts);
 
   return num_hosts;
 }
@@ -4841,7 +4847,13 @@ hb_cluster_initialize (const char *nodes, const char *replicas)
       if (hb_cluster_check_valid_ping_server () == false)
 	{
 	  pthread_mutex_unlock (&hb_Cluster->lock);
+	  MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "TCP PING is failed to initialize.\n");
 	  return ER_FAILED;
+	}
+
+      if (hb_Cluster->num_ping_hosts)
+	{
+	  MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "TCP PING is initialized successfully.\n");
 	}
     }
 
@@ -6696,6 +6708,8 @@ hb_check_tcp_ping (const char *host, int port)
     }
 
   css_shutdown_socket (sfd);
+
+  MASTER_ER_LOG_DEBUG (ARG_FILE_LINE, "TCP PING is success on host %s, port %d.\n", host, port);
 
   return HB_PING_SUCCESS;
 }

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -1410,7 +1410,7 @@ hb_cluster_check_valid_ping_server (void)
 
   for (ping_host = hb_Cluster->ping_hosts; ping_host; ping_host = ping_host->next)
     {
-      if (ping_host->port == 0)	// prm_get_string_value (PRM_ID_HA_PING_HOSTS) != NULL
+      if (prm_get_string_value (PRM_ID_HA_PING_HOSTS))
 	{
 	  ping_host->ping_result = hb_check_ping (ping_host->host_name);
 	}

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -2295,7 +2295,7 @@ hb_port_str_to_num (char *port_p)
 
   while (*(port_p + i) != '\0')
     {
-      if ((*port_p >= '0' && *port_p <= '9'))
+      if (*port_p >= '0' && *port_p <= '9')
 	{
 	  i++;
 	  num_count++;

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -128,6 +128,7 @@ static int hb_hostname_n_port_to_sockaddr (const char *host, int port, struct so
 
 /* common */
 static int hb_check_ping (const char *host);
+static int hb_check_tcp_ping (const char *host, int port);
 
 /* cluster jobs queue */
 static HB_JOB_ENTRY *hb_cluster_job_dequeue (void);
@@ -155,6 +156,7 @@ static int hb_cluster_load_group_and_node_list (char *ha_node_list, char *ha_rep
 
 /* ping host related functions */
 static HB_PING_HOST_ENTRY *hb_add_ping_host (char *host_name);
+static HB_PING_HOST_ENTRY *hb_add_tcp_ping_host (char *host_name, int port);
 static void hb_remove_ping_host (HB_PING_HOST_ENTRY * entry_p);
 static void hb_cluster_remove_all_ping_hosts (HB_PING_HOST_ENTRY * first);
 
@@ -237,6 +239,7 @@ static int hb_help_sprint_processes_info (char *buffer, int max_length);
 static int hb_help_sprint_nodes_info (char *buffer, int max_length);
 static int hb_help_sprint_jobs_info (HB_JOB * jobs, char *buffer, int max_length);
 static int hb_help_sprint_ping_host_info (char *buffer, int max_length);
+static int hb_help_sprint_tcp_ping_host_info (char *buffer, int max_length);
 
 HB_CLUSTER *hb_Cluster = NULL;
 HB_RESOURCE *hb_Resource = NULL;
@@ -313,6 +316,11 @@ static HB_JOB_FUNC hb_resource_jobs[] = {
         " HA-Ping Host Info (PING check %s)\n"
 #define HA_PING_HOSTS_FORMAT_STRING        \
           "   %-20s %s\n"
+
+#define HA_TCP_PING_HOSTS_INFO_FORMAT_STRING       \
+        " HA-Ping Host Info (TCP PING check %s)\n"
+#define HA_TCP_PING_HOSTS_FORMAT_STRING        \
+          "   %-20s:%d %s\n"
 
 #define HA_ADMIN_INFO_FORMAT_STRING                \
         " HA-Admin Info\n"
@@ -854,7 +862,15 @@ hb_cluster_job_calc_score (HB_JOB_ARG * arg)
 
       if (hb_Cluster->num_ping_hosts > 0)
 	{
-	  hb_help_sprint_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+	  if (prm_get_string_value (PRM_ID_HA_PING_HOSTS))
+	    {
+	      hb_help_sprint_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+	    }
+	  else
+	    {
+	      hb_help_sprint_tcp_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+	    }
+
 	  MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HB_NODE_EVENT, 1, hb_info_str);
 	}
 
@@ -970,7 +986,14 @@ hb_cluster_job_check_ping (HB_JOB_ARG * arg)
     {
       for (ping_host = hb_Cluster->ping_hosts; ping_host; ping_host = ping_host->next)
 	{
-	  ping_result = hb_check_ping (ping_host->host_name);
+	  if (ping_host->port == 0)	// prm_get_string_value (PRM_ID_HA_PING_HOSTS) != NULL
+	    {
+	      ping_result = hb_check_ping (ping_host->host_name);
+	    }
+	  else
+	    {
+	      ping_result = hb_check_tcp_ping (ping_host->host_name, ping_host->port);
+	    }
 
 	  ping_host->ping_result = ping_result;
 	  if (ping_result == HB_PING_SUCCESS)
@@ -1117,7 +1140,15 @@ hb_cluster_job_failover (HB_JOB_ARG * arg)
 
   if (hb_Cluster->num_ping_hosts > 0)
     {
-      hb_help_sprint_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+      if (prm_get_string_value (PRM_ID_HA_PING_HOSTS))
+	{
+	  hb_help_sprint_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+	}
+      else
+	{
+	  hb_help_sprint_tcp_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+	}
+
       MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HB_NODE_EVENT, 1, hb_info_str);
     }
 
@@ -1207,7 +1238,15 @@ hb_cluster_job_demote (HB_JOB_ARG * arg)
 
 	  if (hb_Cluster->num_ping_hosts > 0)
 	    {
-	      hb_help_sprint_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+	      if (prm_get_string_value (PRM_ID_HA_PING_HOSTS))
+		{
+		  hb_help_sprint_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+		}
+	      else
+		{
+		  hb_help_sprint_tcp_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+		}
+
 	      MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HB_NODE_EVENT, 1, hb_info_str);
 	    }
 
@@ -1274,7 +1313,15 @@ hb_cluster_job_failback (HB_JOB_ARG * arg)
 
   if (hb_Cluster->num_ping_hosts > 0)
     {
-      hb_help_sprint_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+      if (prm_get_string_value (PRM_ID_HA_PING_HOSTS))
+	{
+	  hb_help_sprint_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+	}
+      else
+	{
+	  hb_help_sprint_tcp_ping_host_info (hb_info_str, HB_INFO_STR_MAX);
+	}
+
       MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HB_NODE_EVENT, 1, hb_info_str);
     }
 
@@ -1363,7 +1410,14 @@ hb_cluster_check_valid_ping_server (void)
 
   for (ping_host = hb_Cluster->ping_hosts; ping_host; ping_host = ping_host->next)
     {
-      ping_host->ping_result = hb_check_ping (ping_host->host_name);
+      if (ping_host->port == 0)	// prm_get_string_value (PRM_ID_HA_PING_HOSTS) != NULL
+	{
+	  ping_host->ping_result = hb_check_ping (ping_host->host_name);
+	}
+      else
+	{
+	  ping_host->ping_result = hb_check_tcp_ping (ping_host->host_name, ping_host->port);
+	}
 
       if (ping_host->ping_result == HB_PING_SUCCESS)
 	{
@@ -2091,6 +2145,48 @@ hb_add_ping_host (char *host_name)
     {
       strncpy (p->host_name, host_name, sizeof (p->host_name) - 1);
       p->host_name[sizeof (p->host_name) - 1] = '\0';
+      p->port = 0;
+      p->ping_result = HB_PING_UNKNOWN;
+      p->next = NULL;
+      p->prev = NULL;
+
+      first_pp = &hb_Cluster->ping_hosts;
+
+      hb_list_add ((HB_LIST **) first_pp, (HB_LIST *) p);
+    }
+
+  return (p);
+}
+
+/*
+ * hb_add_tcp_ping_host() -
+ *   return: pointer to ping host entry
+ *
+ *   host_name(in):
+ *   port(in):
+ */
+static HB_PING_HOST_ENTRY *
+hb_add_tcp_ping_host (char *host_name, int port)
+{
+  HB_PING_HOST_ENTRY *p;
+  HB_PING_HOST_ENTRY **first_pp;
+
+  if (host_name == NULL)
+    {
+      return NULL;
+    }
+
+  if (port < 1 || port > USHRT_MAX)
+    {
+      return NULL;
+    }
+
+  p = (HB_PING_HOST_ENTRY *) malloc (sizeof (HB_PING_HOST_ENTRY));
+  if (p)
+    {
+      strncpy (p->host_name, host_name, sizeof (p->host_name) - 1);
+      p->host_name[sizeof (p->host_name) - 1] = '\0';
+      p->port = port;
       p->ping_result = HB_PING_UNKNOWN;
       p->next = NULL;
       p->prev = NULL;
@@ -2175,6 +2271,66 @@ hb_cluster_load_ping_host_list (char *ha_ping_host_list)
       else
 	{
 	  hb_add_ping_host (host_p);
+	  num_hosts++;
+	}
+    }
+
+  return num_hosts;
+}
+
+/*
+ * hb_cluster_load_tcp_ping_host_list() -
+ *   return: number of tcp ping hosts
+ *
+ *   ha_ping_host_list(in):
+ */
+static int
+hb_cluster_load_tcp_ping_host_list (char *ha_ping_host_list)
+{
+  int num_hosts = 0;
+  char host_list[LINE_MAX];
+  char *host_list_p, *host_p, *host_pp;
+  char *port_p;
+  char buf[128];
+
+  if (ha_ping_host_list == NULL)
+    {
+      return 0;
+    }
+
+  strncpy_bufsize (host_list, ha_ping_host_list);
+
+  for (host_list_p = host_list;; host_list_p = NULL)
+    {
+      host_p = strtok_r (host_list_p, " ,", &host_pp);
+      if (host_p == NULL)
+	{
+	  break;
+	}
+
+      port_p = strstr (host_p, ":");
+      if (port_p == NULL)
+	{
+	  break;
+	}
+      else
+	{
+	  *port_p = '\0';
+	  port_p++;
+	}
+
+      if (strcmp (host_p, "0.0.0.0") == 0)
+	{
+	  snprintf (buf, sizeof (buf), "We do not allow 0.0.0.0 as a ping hosts, excluded");
+	  MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HB_NODE_EVENT, 1, buf);
+	}
+      else
+	{
+	  if (hb_add_tcp_ping_host (host_p, atoi (port_p)) == NULL)
+	    {
+	      break;
+	    }
+
 	  num_hosts++;
 	}
     }
@@ -4676,6 +4832,19 @@ hb_cluster_initialize (const char *nodes, const char *replicas)
       return ER_FAILED;
     }
 
+  if (hb_Cluster->num_ping_hosts == 0)
+    {
+      /* The ha_tcp_ping_hosts can be used instead of the ha_ping_hosts in case the ICMP protocol is disabled.
+         However, both system parameters cannot be set at the same time and the ha_tcp_ping_hosts works only when the ha_ping_hosts is not set. */
+      hb_Cluster->num_ping_hosts = hb_cluster_load_tcp_ping_host_list (prm_get_string_value (PRM_ID_HA_TCP_PING_HOSTS));
+
+      if (hb_cluster_check_valid_ping_server () == false)
+	{
+	  pthread_mutex_unlock (&hb_Cluster->lock);
+	  return ER_FAILED;
+	}
+    }
+
 #if defined (HB_VERBOSE_DEBUG)
   hb_print_nodes ();
 #endif
@@ -5264,6 +5433,20 @@ hb_reload_config (void)
       goto reconfig_error;
     }
 
+  /* reload tcp ping hosts */
+  if (hb_Cluster->num_ping_hosts == 0)
+    {
+      /* The ha_tcp_ping_hosts can be used instead of the ha_ping_hosts in case the ICMP protocol is disabled.
+         However, both system parameters cannot be set at the same time and the ha_tcp_ping_hosts works only when the ha_ping_hosts is not set. */
+      hb_Cluster->num_ping_hosts = hb_cluster_load_tcp_ping_host_list (prm_get_string_value (PRM_ID_HA_TCP_PING_HOSTS));
+
+      if (hb_cluster_check_valid_ping_server () == false)
+	{
+	  pthread_mutex_unlock (&hb_Cluster->lock);
+	  return ER_FAILED;
+	}
+    }
+
   /* reload node list */
   hb_Cluster->num_nodes =
     hb_cluster_load_group_and_node_list ((char *) prm_get_string_value (PRM_ID_HA_NODE_LIST),
@@ -5526,6 +5709,94 @@ hb_get_ping_host_info_string (char **str)
     {
       p +=
 	snprintf (p, MAX ((last - p), 0), HA_PING_HOSTS_FORMAT_STRING, ping_host->host_name,
+		  hb_ping_result_string (ping_host->ping_result));
+    }
+
+  pthread_mutex_unlock (&hb_Cluster->lock);
+
+  return;
+}
+
+/*
+ * hb_get_tcp_ping_host_info_string -
+ *   return: none
+ *
+ *   str(out):
+ */
+void
+hb_get_tcp_ping_host_info_string (char **str)
+{
+  int rv, buf_size = 0, required_size = 0;
+  char *p, *last;
+  bool valid_ping_host_exists;
+  bool is_ping_check_enabled = true;
+  HB_PING_HOST_ENTRY *ping_host;
+
+  if (hb_Cluster == NULL)
+    {
+      return;
+    }
+
+  if (*str)
+    {
+      **str = 0;
+      return;
+    }
+
+  rv = pthread_mutex_lock (&hb_Cluster->lock);
+
+  if (hb_Cluster->num_ping_hosts == 0)
+    {
+      pthread_mutex_unlock (&hb_Cluster->lock);
+      return;
+    }
+
+  /* refresh ping host info */
+  valid_ping_host_exists = hb_cluster_check_valid_ping_server ();
+
+  if (valid_ping_host_exists == false && hb_cluster_is_isolated () == false)
+    {
+      is_ping_check_enabled = false;
+    }
+
+  if (is_ping_check_enabled != hb_Cluster->is_ping_check_enabled)
+    {
+      hb_cluster_job_set_expire_and_reorder (HB_CJOB_CHECK_VALID_PING_SERVER, HB_JOB_TIMER_IMMEDIATELY);
+    }
+
+  required_size = strlen (HA_TCP_PING_HOSTS_INFO_FORMAT_STRING);
+  required_size += 7;		/* length of ping check status */
+
+  buf_size += required_size;
+
+  required_size = strlen (HA_TCP_PING_HOSTS_FORMAT_STRING);
+  required_size += 6;
+  required_size += CUB_MAXHOSTNAMELEN;
+  required_size += HB_PING_STR_SIZE;	/* length of ping test result */
+  required_size *= hb_Cluster->num_ping_hosts;
+
+  buf_size += required_size;
+
+  *str = (char *) malloc (sizeof (char) * buf_size);
+  if (*str == NULL)
+    {
+      pthread_mutex_unlock (&hb_Cluster->lock);
+      MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (char) * buf_size);
+      return;
+    }
+  **str = '\0';
+
+  p = (char *) (*str);
+  last = p + buf_size;
+
+  p +=
+    snprintf (p, MAX ((last - p), 0), HA_TCP_PING_HOSTS_INFO_FORMAT_STRING,
+	      is_ping_check_enabled ? "enabled" : "disabled");
+
+  for (ping_host = hb_Cluster->ping_hosts; ping_host; ping_host = ping_host->next)
+    {
+      p +=
+	snprintf (p, MAX ((last - p), 0), HA_TCP_PING_HOSTS_FORMAT_STRING, ping_host->host_name, ping_host->port,
 		  hb_ping_result_string (ping_host->ping_result));
     }
 
@@ -6344,7 +6615,7 @@ hb_check_ping (const char *host)
   FILE *fp;
   HB_NODE_ENTRY *node;
 
-  /* If host_p is in the cluster node, then skip to check */
+  /* If host is in the cluster node, then skip to check */
   for (node = hb_Cluster->nodes; node; node = node->next)
     {
       if (are_hostnames_equal (host, node->host_name))
@@ -6389,6 +6660,46 @@ hb_check_ping (const char *host)
   return HB_PING_SUCCESS;
 }
 
+/*
+ * hb_check_tcp_ping -
+ *   return : int
+ *
+ */
+static int
+hb_check_tcp_ping (const char *host, int port)
+{
+  char buf[128];
+  HB_NODE_ENTRY *node;
+  SOCKET sfd = INVALID_SOCKET;
+
+  /* If host is in the cluster node, then skip to check */
+  for (node = hb_Cluster->nodes; node; node = node->next)
+    {
+      if (are_hostnames_equal (host, node->host_name))
+	{
+	  /* PING Host is same as cluster's host name */
+	  snprintf (buf, sizeof (buf), "Useless TCP PING host name %s", host);
+	  MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HB_NODE_EVENT, 1, buf);
+	  return HB_PING_USELESS_HOST;
+	}
+    }
+
+  sfd = css_tcp_client_open_with_timeout (host, port, 1000);
+
+  if (IS_INVALID_SOCKET (sfd))
+    {
+      /* ping failed */
+      snprintf (buf, sizeof (buf), "TCP PING failed for host %s, port %d", host, port);
+      MASTER_ER_SET (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HB_NODE_EVENT, 1, buf);
+
+      return HB_PING_FAILURE;
+    }
+
+  css_shutdown_socket (sfd);
+
+  return HB_PING_SUCCESS;
+}
+
 static int
 hb_help_sprint_ping_host_info (char *buffer, int max_length)
 {
@@ -6422,6 +6733,48 @@ hb_help_sprint_ping_host_info (char *buffer, int max_length)
     {
       p +=
 	snprintf (p, MAX ((last - p), 0), "%-20s %-20s\n", ping_host->host_name,
+		  hb_ping_result_string (ping_host->ping_result));
+    }
+  p +=
+    snprintf (p, MAX ((last - p), 0),
+	      "==============================" "==================================================\n");
+
+  return p - buffer;
+}
+
+static int
+hb_help_sprint_tcp_ping_host_info (char *buffer, int max_length)
+{
+  HB_PING_HOST_ENTRY *ping_host;
+  char *p, *last;
+
+  if (*buffer != '\0')
+    {
+      memset (buffer, 0, max_length);
+    }
+
+  p = buffer;
+  last = buffer + max_length;
+
+  p += snprintf (p, MAX ((last - p), 0), "HA TCP Ping Host Info\n");
+  p +=
+    snprintf (p, MAX ((last - p), 0),
+	      "==============================" "==================================================\n");
+
+  p +=
+    snprintf (p, MAX ((last - p), 0), " * TCP PING check is %s\n",
+	      hb_Cluster->is_ping_check_enabled ? "enabled" : "disabled");
+  p +=
+    snprintf (p, MAX ((last - p), 0),
+	      "------------------------------" "--------------------------------------------------\n");
+  p += snprintf (p, MAX ((last - p), 0), "%-20s %-20s\n", "hostname", "TCP PING check result");
+  p +=
+    snprintf (p, MAX ((last - p), 0),
+	      "------------------------------" "--------------------------------------------------\n");
+  for (ping_host = hb_Cluster->ping_hosts; ping_host; ping_host = ping_host->next)
+    {
+      p +=
+	snprintf (p, MAX ((last - p), 0), "%-20s:%d %-20s\n", ping_host->host_name, ping_host->port,
 		  hb_ping_result_string (ping_host->ping_result));
     }
   p +=

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -219,7 +219,7 @@ struct hb_ping_host_entry
   HB_PING_HOST_ENTRY **prev;
 
   char host_name[CUB_MAXHOSTNAMELEN];
-  int port;
+  int port;			/* TCP ping only */
   int ping_result;
 };
 
@@ -262,7 +262,7 @@ struct hb_cluster
 
   HB_PING_HOST_ENTRY *ping_hosts;
   int num_ping_hosts;
-  int ping_timeout;
+  int ping_timeout;		/* TCP ping only */
 
   HB_UI_NODE_ENTRY *ui_nodes;
   int num_ui_nodes;

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -219,6 +219,7 @@ struct hb_ping_host_entry
   HB_PING_HOST_ENTRY **prev;
 
   char host_name[CUB_MAXHOSTNAMELEN];
+  int port;
   int ping_result;
 };
 
@@ -393,6 +394,7 @@ extern void hb_cleanup_conn_and_start_process (CSS_CONN_ENTRY * conn, SOCKET sfd
 extern void hb_get_node_info_string (char **str, bool verbose_yn);
 extern void hb_get_process_info_string (char **str, bool verbose_yn);
 extern void hb_get_ping_host_info_string (char **str);
+extern void hb_get_tcp_ping_host_info_string (char **str);
 extern void hb_get_admin_info_string (char **str);
 extern void hb_kill_all_heartbeat_process (char **str);
 

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -262,6 +262,7 @@ struct hb_cluster
 
   HB_PING_HOST_ENTRY *ping_hosts;
   int num_ping_hosts;
+  int ping_timeout;
 
   HB_UI_NODE_ENTRY *ui_nodes;
   int num_ui_nodes;

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -919,7 +919,14 @@ css_process_ha_ping_host_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
       goto error_return;
     }
 
-  hb_get_ping_host_info_string (&buffer);
+  if (prm_get_string_value (PRM_ID_HA_PING_HOSTS))
+    {
+      hb_get_ping_host_info_string (&buffer);
+    }
+  else
+    {
+      hb_get_tcp_ping_host_info_string (&buffer);
+    }
 
   if (buffer == NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24626

Purpose
* ping check doesn't work if ICMP protocol is disabled in user environment
* in this case, additional option(candidate) is neccessary
* triage decides to support tcp ping for this

Implementation
* implement based on the ping check implementation

Remarks
* see the test scenarios attached in the jira if you needed