### PR TITLE
[CBRD-24679] auto_commit log error in sql log

### DIFF
--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -10664,7 +10664,7 @@ ux_auto_commit (T_NET_BUF * net_buf, T_REQ_INFO * req_info)
 
   if (req_info->need_auto_commit == TRAN_AUTOCOMMIT)
     {
-      cas_log_write (0, false, "auto_commit %s", tran_was_latest_query_committed ()? "(local)" : "(server)");
+      cas_log_write (0, false, "auto_commit %s", tran_was_latest_query_committed ()? "(server)" : "(local)");
       err_code = ux_end_tran (CCI_TRAN_COMMIT, true);
       cas_log_write (0, false, "auto_commit %d", err_code);
       logddl_set_msg ("auto_commit %d", err_code);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24679

Purpose
Auto-commit is performed on the server, but in the broker's sql log, it is written that it was performed on the client.
Conversely, auto-commit is performed on the client, but the broker's sql log is written as being performed on the server.

Implementation
* Execute SQL
select count(*) from (select * from t1);
select count(a.*) from (select * from t1) a;
AS-IS
23-02-25 00:55:21.544 (0) auto_commit (local)
23-02-25 00:55:21.544 (0) auto_commit 0

23-02-25 00:55:55.762 (0) auto_commit (server)
23-02-25 00:55:55.762 (0) auto_commit 0

TO-BE
23-02-25 00:55:21.544 (0) auto_commit (server)
23-02-25 00:55:21.544 (0) auto_commit 0

23-02-25 00:55:55.762 (0) auto_commit (client)
23-02-25 00:55:55.762 (0) auto_commit 0

Remarks
N/A