### PR TITLE
[LETS-659] response broker blocking terminate

### DIFF
--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -184,7 +184,8 @@ namespace cubcomm
 
     // if the receiving thread terminated, there will not be any more responses
     // unblock all waiting client thread - they will receive errors
-    m_response_broker.terminate ();
+    //m_response_broker.terminate ();
+    m_response_broker.terminate_blocking ();
 
     // at this point, the page server async responder must be waited for to terminate
     // processing all async requests

--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -245,7 +245,7 @@ namespace cubcomm
   {
     // Get a unique sequence number of response and group with the payload
     const response_sequence_number rsn = m_rsn_generator.get_unique_number ();
-    sequenced_payload seq_payload (rsn, std::move (a_request_payload));
+    //sequenced_payload seq_payload (rsn, std::move (a_request_payload));
 
     send_queue_error_handler error_handler_ftor = [&rsn, this] (
 		css_error_code error_code, bool &abort_further_processing)
@@ -254,8 +254,17 @@ namespace cubcomm
       this->m_response_broker.register_error (rsn, std::move (error_code));
     };
 
+    // a round-trip request is sent with the 'push' function call
+    // however, from the moment it is sent and until the response arrives, there is no
+    // trace of a request in 'this'
+    // the only at-runtime indication is that a thread waits for a condition variable on this stack
+    // how to keep track of pending requests?
+    m_response_broker.register_request (rsn);
+
     // Send the request
-    m_queue->push (a_outgoing_message_id, std::move (seq_payload), std::move (error_handler_ftor));
+    m_queue->push (a_outgoing_message_id,
+    { rsn, std::move (a_request_payload) }, //std::move (seq_payload),
+    std::move (error_handler_ftor));
     // function is non-blocking, it will just push the message to be sent.
     // The following broker response getter is the blocking part.
 

--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -184,8 +184,7 @@ namespace cubcomm
 
     // if the receiving thread terminated, there will not be any more responses
     // unblock all waiting client thread - they will receive errors
-    //m_response_broker.terminate ();
-    m_response_broker.terminate_blocking ();
+    m_response_broker.notify_terminate_and_wait ();
 
     // at this point, the page server async responder must be waited for to terminate
     // processing all async requests
@@ -246,7 +245,6 @@ namespace cubcomm
   {
     // Get a unique sequence number of response and group with the payload
     const response_sequence_number rsn = m_rsn_generator.get_unique_number ();
-    //sequenced_payload seq_payload (rsn, std::move (a_request_payload));
 
     send_queue_error_handler error_handler_ftor = [&rsn, this] (
 		css_error_code error_code, bool &abort_further_processing)
@@ -255,17 +253,15 @@ namespace cubcomm
       this->m_response_broker.register_error (rsn, std::move (error_code));
     };
 
-    // a round-trip request is sent with the 'push' function call
-    // however, from the moment it is sent and until the response arrives, there is no
-    // trace of a request in 'this'
-    // the only at-runtime indication is that a thread waits for a condition variable on this stack
-    // how to keep track of pending requests?
+    // a round-trip request is sent with the subsequent 'push' function call
+    // however, from the moment it is sent and until the response arrives, there must be
+    // a trace of a request in 'this';
+    // otherwise, the only, at runtime, indication is that a thread waits for a condition variable
+    // add an upfront entry in the broker such that all roundtrip requests are accounted for
     m_response_broker.register_request (rsn);
 
     // Send the request
-    m_queue->push (a_outgoing_message_id,
-    { rsn, std::move (a_request_payload) }, //std::move (seq_payload),
-    std::move (error_handler_ftor));
+    m_queue->push (a_outgoing_message_id, { rsn, std::move (a_request_payload) }, std::move (error_handler_ftor));
     // function is non-blocking, it will just push the message to be sent.
     // The following broker response getter is the blocking part.
 

--- a/src/communication/request_sync_send_queue.hpp
+++ b/src/communication/request_sync_send_queue.hpp
@@ -211,13 +211,13 @@ namespace cubcomm
 	    if (static_cast<bool> (queue_front.m_error_handler))
 	      {
 		// if present, invoke custom/specific handler first
-		// error handler can instruct that further processing is to be stopped (IoC)
+		// error handler can instruct that further processing is to be stopped (Inversion of Control)
 		queue_front.m_error_handler (err_code, abort_further_processing);
 	      }
 	    else if (static_cast<bool> (m_error_handler))
 	      {
 		// if present, invoke generic (fail-back) handler
-		// error handler can instruct that further processing is to be stopped (IoC)
+		// error handler can instruct that further processing is to be stopped (Inversion of Control)
 		m_error_handler (err_code, abort_further_processing);
 	      }
 	    else

--- a/src/communication/response_broker.hpp
+++ b/src/communication/response_broker.hpp
@@ -57,12 +57,14 @@ namespace cubcomm
       response_broker &operator = (const response_broker &) = delete;
       response_broker &operator = (response_broker &&) = delete;
 
+      void register_request (response_sequence_number a_rsn);
       void register_response (response_sequence_number a_rsn, T_PAYLOAD &&a_payload);
       void register_error (response_sequence_number a_rsn, T_ERROR &&a_error);
 
       std::tuple<T_PAYLOAD, T_ERROR> get_response (response_sequence_number a_rsn);
 
       void terminate ();
+      void terminate_blocking ();
 
     private:
       struct bucket
@@ -76,18 +78,21 @@ namespace cubcomm
 	  bucket &operator = (const bucket &) = delete;
 	  bucket &operator = (bucket &&) = delete;
 
+	  void register_request (response_sequence_number a_rsn);
 	  void register_response (response_sequence_number a_rsn, T_PAYLOAD &&a_payload);
 	  void register_error (response_sequence_number a_rsn, T_ERROR &&a_error);
 
 	  std::tuple<T_PAYLOAD, T_ERROR> get_response (response_sequence_number a_rsn);
 
-	  void terminate ();
+	  void notify_terminate ();
+	  void notify_terminate_and_wait ();
 
 	private:
 	  struct payload_or_error_type
 	  {
 	    T_PAYLOAD m_payload;
 	    T_ERROR m_error;
+	    bool m_response_or_error_present = false;
 	  };
 
 	  using response_payload_container_type = std::unordered_map<response_sequence_number, payload_or_error_type>;
@@ -96,6 +101,7 @@ namespace cubcomm
 	  const T_ERROR m_no_error;
 	  const T_ERROR m_error;
 
+	  // mutex and condition variable protecting the response payloads container
 	  std::mutex m_mutex;
 	  std::condition_variable m_condvar;
 	  response_payload_container_type m_response_payloads;
@@ -133,6 +139,13 @@ namespace cubcomm
 
   template <typename T_PAYLOAD, typename T_ERROR>
   void
+  response_broker<T_PAYLOAD, T_ERROR>::register_request (response_sequence_number a_rsn)
+  {
+    get_bucket (a_rsn).register_request (a_rsn);
+  }
+
+  template <typename T_PAYLOAD, typename T_ERROR>
+  void
   response_broker<T_PAYLOAD, T_ERROR>::register_response (response_sequence_number a_rsn, T_PAYLOAD &&a_payload)
   {
     get_bucket (a_rsn).register_response (a_rsn, std::move (a_payload));
@@ -146,12 +159,29 @@ namespace cubcomm
   }
 
   template <typename T_PAYLOAD, typename T_ERROR>
+  std::tuple<T_PAYLOAD, T_ERROR>
+  response_broker<T_PAYLOAD, T_ERROR>::get_response (response_sequence_number a_rsn)
+  {
+    return get_bucket (a_rsn).get_response (a_rsn);
+  }
+
+  template <typename T_PAYLOAD, typename T_ERROR>
   void
   response_broker<T_PAYLOAD, T_ERROR>::terminate ()
   {
     for (auto &bucket : m_buckets)
       {
-	bucket.terminate ();
+	bucket.notify_terminate ();
+      }
+  }
+
+  template <typename T_PAYLOAD, typename T_ERROR>
+  void
+  response_broker<T_PAYLOAD, T_ERROR>::terminate_blocking ()
+  {
+    for (auto &bucket : m_buckets)
+      {
+	bucket.notify_terminate ();
       }
   }
 
@@ -173,14 +203,30 @@ namespace cubcomm
 
   template <typename T_PAYLOAD, typename T_ERROR>
   void
+  response_broker<T_PAYLOAD, T_ERROR>::bucket::register_request (response_sequence_number a_rsn)
+  {
+    {
+      std::lock_guard<std::mutex> lk_guard (m_mutex);
+
+      assert (m_response_payloads.find (a_rsn) == m_response_payloads.cend ());
+      payload_or_error_type &ent = m_response_payloads[a_rsn];
+      ent.m_response_or_error_present = false;
+    }
+    // don't notify anything because there is no-one interested in this (the request has not even been flown out yet)
+  }
+
+  template <typename T_PAYLOAD, typename T_ERROR>
+  void
   response_broker<T_PAYLOAD, T_ERROR>::bucket::register_response (response_sequence_number a_rsn, T_PAYLOAD &&a_payload)
   {
     {
       std::lock_guard<std::mutex> lk_guard (m_mutex);
 
       payload_or_error_type &ent = m_response_payloads[a_rsn];
+      assert (!ent.m_response_or_error_present);
       ent.m_payload = std::move (a_payload);
       ent.m_error = m_no_error;
+      ent.m_response_or_error_present = true;
     }
     // notify all because there is more than one thread waiting for data on the same bucket
     // ideally, with an adequately sized bucket pool, the contention should be minimal
@@ -195,18 +241,13 @@ namespace cubcomm
       std::lock_guard<std::mutex> lockg (m_mutex);
 
       payload_or_error_type &ent = m_response_payloads[a_rsn];
+      assert (!ent.m_response_or_error_present);
       ent.m_error = std::move (a_error);
+      ent.m_response_or_error_present = true;
     }
     // notify all because there is more than one thread waiting for data on the same bucket
     // ideally, with an adequately sized bucket pool, the contention should be minimal
     m_condvar.notify_all ();
-  }
-
-  template <typename T_PAYLOAD, typename T_ERROR>
-  std::tuple<T_PAYLOAD, T_ERROR>
-  response_broker<T_PAYLOAD, T_ERROR>::get_response (response_sequence_number a_rsn)
-  {
-    return get_bucket (a_rsn).get_response (a_rsn);
   }
 
   template <typename T_PAYLOAD, typename T_ERROR>
@@ -216,30 +257,36 @@ namespace cubcomm
     constexpr std::chrono::milliseconds millis_100 { 100 };
 
     {
-      typename response_payload_container_type::iterator found_it { m_response_payloads.end () };
+      std::unique_lock<std::mutex> ulock (m_mutex);
 
-      auto condvar_pred = [this, &found_it, a_rsn] ()
+      // nobody else but us should access this payload container but must be accessed locked
+      typename response_payload_container_type::iterator found_it = m_response_payloads.find (a_rsn);
+      payload_or_error_type &ent = (*found_it).second;
+
+      auto condvar_pred = [&ent] ()
       {
-	found_it = m_response_payloads.find (a_rsn);
-	return (found_it != m_response_payloads.end ());
+	return ent.m_response_or_error_present;
       };
 
-      std::unique_lock<std::mutex> ulock (m_mutex);
       // a way out in case neither value nor error is registered as a response
       // which can happen in case - eg - that the connection is dropped
       while (!m_terminate)
 	{
 	  if (m_condvar.wait_for (ulock, millis_100, condvar_pred))
 	    {
-	      assert (found_it != m_response_payloads.end ());
+	      assert (ent.m_response_or_error_present);
 	      std::tuple<T_PAYLOAD, T_ERROR> payload_or_error
 	      {
-		std::move ((*found_it).second.m_payload ),
-		std::move ((*found_it).second.m_error)
+		std::move (ent.m_payload ),
+		std::move (ent.m_error)
 	      };
 	      m_response_payloads.erase (found_it);
 	      return payload_or_error;
 	    }
+
+	  // upon termination we have the possibility to implement a configurable behaviour:
+	  //  - either abort and return error - as done
+	  //  - or continue waiting - with a timeout - until the request is serviced
 	}
     }
 
@@ -249,7 +296,7 @@ namespace cubcomm
 
   template <typename T_PAYLOAD, typename T_ERROR>
   void
-  response_broker<T_PAYLOAD, T_ERROR>::bucket::terminate ()
+  response_broker<T_PAYLOAD, T_ERROR>::bucket::notify_terminate ()
   {
     {
       std::lock_guard<std::mutex> lockg (m_mutex);
@@ -258,6 +305,21 @@ namespace cubcomm
     // notify all because there is more than one thread waiting for data on the same bucket
     // ideally, with an adequately sized bucket pool, the contention should be minimal
     m_condvar.notify_all ();
+  }
+
+  template <typename T_PAYLOAD, typename T_ERROR>
+  void
+  response_broker<T_PAYLOAD, T_ERROR>::bucket::notify_terminate_and_wait ()
+  {
+    {
+      std::lock_guard<std::mutex> lockg (m_mutex);
+      m_terminate = true;
+    }
+    // notify all because there is more than one thread waiting for data on the same bucket
+    // ideally, with an adequately sized bucket pool, the contention should be minimal
+    m_condvar.notify_all ();
+
+    // TODO: how to wait?
   }
 
   template <typename T_PAYLOAD, typename T_ERROR>

--- a/src/communication/response_broker.hpp
+++ b/src/communication/response_broker.hpp
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
+#include "error_manager.h"
 #include <limits>
 #include <mutex>
 #include <unordered_map>
@@ -63,7 +64,7 @@ namespace cubcomm
 
       std::tuple<T_PAYLOAD, T_ERROR> get_response (response_sequence_number a_rsn);
 
-      void terminate ();
+      //void terminate ();
       void terminate_blocking ();
 
     private:
@@ -84,7 +85,7 @@ namespace cubcomm
 
 	  std::tuple<T_PAYLOAD, T_ERROR> get_response (response_sequence_number a_rsn);
 
-	  void notify_terminate ();
+	  //void notify_terminate ();
 	  void notify_terminate_and_wait ();
 
 	private:
@@ -107,6 +108,7 @@ namespace cubcomm
 	  response_payload_container_type m_response_payloads;
 
 	  bool m_terminate;
+	  std::condition_variable m_terminate_condvar;
       };
 
       bucket &get_bucket (response_sequence_number rsn);
@@ -165,15 +167,15 @@ namespace cubcomm
     return get_bucket (a_rsn).get_response (a_rsn);
   }
 
-  template <typename T_PAYLOAD, typename T_ERROR>
-  void
-  response_broker<T_PAYLOAD, T_ERROR>::terminate ()
-  {
-    for (auto &bucket : m_buckets)
-      {
-	bucket.notify_terminate ();
-      }
-  }
+//  template <typename T_PAYLOAD, typename T_ERROR>
+//  void
+//  response_broker<T_PAYLOAD, T_ERROR>::terminate ()
+//  {
+//    for (auto &bucket : m_buckets)
+//      {
+//	bucket.notify_terminate ();
+//      }
+//  }
 
   template <typename T_PAYLOAD, typename T_ERROR>
   void
@@ -181,7 +183,7 @@ namespace cubcomm
   {
     for (auto &bucket : m_buckets)
       {
-	bucket.notify_terminate ();
+	bucket.notify_terminate_and_wait ();
       }
   }
 
@@ -256,6 +258,7 @@ namespace cubcomm
   {
     constexpr std::chrono::milliseconds millis_100 { 100 };
 
+    _er_log_debug (ARG_FILE_LINE, "crsdbg: bucket::get_response entered %d\n", (int)a_rsn);
     {
       std::unique_lock<std::mutex> ulock (m_mutex);
 
@@ -285,32 +288,35 @@ namespace cubcomm
 	    }
 
 	  // upon termination we have the possibility to implement a configurable behaviour:
-	  //  - either abort and return error - as done
+	  //  - either abort and return error - as done below
 	  //  - or continue waiting - with a timeout - until the request is serviced
 	}
     }
 
     // upon terminate, error response will be returned
+    m_terminate_condvar.notify_one ();
+    _er_log_debug (ARG_FILE_LINE, "crsdbg: bucket::get_response notify_one %d\n", (int)a_rsn);
     return std::make_tuple (T_PAYLOAD (), m_error);
   }
 
-  template <typename T_PAYLOAD, typename T_ERROR>
-  void
-  response_broker<T_PAYLOAD, T_ERROR>::bucket::notify_terminate ()
-  {
-    {
-      std::lock_guard<std::mutex> lockg (m_mutex);
-      m_terminate = true;
-    }
-    // notify all because there is more than one thread waiting for data on the same bucket
-    // ideally, with an adequately sized bucket pool, the contention should be minimal
-    m_condvar.notify_all ();
-  }
+//  template <typename T_PAYLOAD, typename T_ERROR>
+//  void
+//  response_broker<T_PAYLOAD, T_ERROR>::bucket::notify_terminate ()
+//  {
+//    {
+//      std::lock_guard<std::mutex> lockg (m_mutex);
+//      m_terminate = true;
+//    }
+//    // notify all because there is more than one thread waiting for data on the same bucket
+//    // ideally, with an adequately sized bucket pool, the contention should be minimal
+//    m_condvar.notify_all ();
+//  }
 
   template <typename T_PAYLOAD, typename T_ERROR>
   void
   response_broker<T_PAYLOAD, T_ERROR>::bucket::notify_terminate_and_wait ()
   {
+    _er_log_debug (ARG_FILE_LINE, "crsdbg: bucket::notify_terminate_and_wait 01\n");
     {
       std::lock_guard<std::mutex> lockg (m_mutex);
       m_terminate = true;
@@ -318,8 +324,24 @@ namespace cubcomm
     // notify all because there is more than one thread waiting for data on the same bucket
     // ideally, with an adequately sized bucket pool, the contention should be minimal
     m_condvar.notify_all ();
+    _er_log_debug (ARG_FILE_LINE, "crsdbg: bucket::notify_terminate_and_wait 02\n");
 
-    // TODO: how to wait?
+    // wait for all requests to either be serviced or timeout
+    constexpr std::chrono::milliseconds millis_50 { 50 };
+
+    auto condvar_pred = [this] ()
+    {
+      _er_log_debug (ARG_FILE_LINE, "crsdbg: bucket::notify_terminate_and_wait 03\n");
+      return m_response_payloads.empty ();
+    };
+
+    std::unique_lock<std::mutex> payloads_container_ulock (m_mutex);
+    while (!m_terminate_condvar.wait_for (payloads_container_ulock, millis_50, condvar_pred))
+      {
+	_er_log_debug (ARG_FILE_LINE, "crsdbg: bucket::notify_terminate_and_wait 04\n");
+      }
+
+    _er_log_debug (ARG_FILE_LINE, "crsdbg: bucket::notify_terminate_and_wait 05\n");
   }
 
   template <typename T_PAYLOAD, typename T_ERROR>

--- a/src/communication/response_broker.hpp
+++ b/src/communication/response_broker.hpp
@@ -200,7 +200,9 @@ namespace cubcomm
     {
       std::lock_guard<std::mutex> lk_guard (m_mutex);
 
+      assert (!m_terminate);
       assert (m_response_payloads.find (a_rsn) == m_response_payloads.cend ());
+
       payload_or_error_type &ent = m_response_payloads[a_rsn];
       ent.m_response_or_error_present = false;
     }
@@ -213,6 +215,8 @@ namespace cubcomm
   {
     {
       std::lock_guard<std::mutex> lk_guard (m_mutex);
+
+      assert (!m_terminate);
 
       payload_or_error_type &ent = m_response_payloads[a_rsn];
       assert (!ent.m_response_or_error_present);
@@ -231,6 +235,8 @@ namespace cubcomm
   {
     {
       std::lock_guard<std::mutex> lockg (m_mutex);
+
+      assert (!m_terminate);
 
       payload_or_error_type &ent = m_response_payloads[a_rsn];
       assert (!ent.m_response_or_error_present);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -120,9 +120,12 @@ page_server::connection_handler::~connection_handler ()
 {
   assert (!m_prior_sender_sink_hook_func);
 
+  // blocking call
+  // internally, this will also wait pending outgoing roundtrip (send-receive) requests
   m_conn->stop_incoming_communication_thread ();
 
-  // wait async responder to finish processing in-flight requests
+  // blocking call
+  // wait async responder to finish processing in-flight incoming roundtrip requests
   m_ps.get_responder ().wait_connection_to_become_idle (m_conn.get ());
 
   m_conn->stop_outgoing_communication_thread ();

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -139,7 +139,7 @@ tran_server::boot (const char *db_name)
 void
 tran_server::push_request (size_t idx, tran_to_page_request reqid, std::string &&payload)
 {
-  assert (idx < m_page_server_conn_vec.size());
+  assert (idx < m_page_server_conn_vec.size ());
   m_page_server_conn_vec[idx]->push_request (reqid, std::move (payload));
 }
 
@@ -147,7 +147,7 @@ int
 tran_server::send_receive (size_t idx, tran_to_page_request reqid, std::string &&payload_in,
 			   std::string &payload_out) const
 {
-  assert (idx < m_page_server_conn_vec.size());
+  assert (idx < m_page_server_conn_vec.size ());
   return m_page_server_conn_vec[idx]->send_receive (reqid, std::move (payload_in), payload_out);
 }
 
@@ -371,7 +371,7 @@ tran_server::connection_handler::connection_handler (cubcomm::channel &&chn, tra
     request_handlers_map_t &&request_handlers)
   : m_ts { ts }
 {
-  constexpr size_t RESPONSE_PARTITIONING_SIZE = 24;   // Arbitrarily chosen
+  constexpr size_t RESPONSE_PARTITIONING_SIZE = 128;   // Arbitrarily chosen
   // TODO: to reduce contention as much as possible, should be equal to the maximum number
   // of active transactions that the system allows (PRM_ID_CSS_MAX_CLIENTS) + 1
 

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -139,7 +139,7 @@ tran_server::boot (const char *db_name)
 void
 tran_server::push_request (size_t idx, tran_to_page_request reqid, std::string &&payload)
 {
-  assert (idx < m_page_server_conn_vec.size ());
+  assert (idx < m_page_server_conn_vec.size());
   m_page_server_conn_vec[idx]->push_request (reqid, std::move (payload));
 }
 
@@ -147,7 +147,7 @@ int
 tran_server::send_receive (size_t idx, tran_to_page_request reqid, std::string &&payload_in,
 			   std::string &payload_out) const
 {
-  assert (idx < m_page_server_conn_vec.size ());
+  assert (idx < m_page_server_conn_vec.size());
   return m_page_server_conn_vec[idx]->send_receive (reqid, std::move (payload_in), payload_out);
 }
 

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -371,7 +371,7 @@ tran_server::connection_handler::connection_handler (cubcomm::channel &&chn, tra
     request_handlers_map_t &&request_handlers)
   : m_ts { ts }
 {
-  constexpr size_t RESPONSE_PARTITIONING_SIZE = 128;   // Arbitrarily chosen
+  constexpr size_t RESPONSE_PARTITIONING_SIZE = 24;   // Arbitrarily chosen
   // TODO: to reduce contention as much as possible, should be equal to the maximum number
   // of active transactions that the system allows (PRM_ID_CSS_MAX_CLIENTS) + 1
 

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -676,6 +676,17 @@ TEST_CASE ("Test response sequence number generator", "")
     }
 }
 
+TEST_CASE ("Test response broker with idle terminate", "")
+{
+  constexpr size_t BUCKET_COUNT = 30;
+
+  cubcomm::response_broker<cubcomm::response_sequence_number, css_error_code> broker (BUCKET_COUNT, NO_ERRORS,
+      ERROR_ON_READ);
+
+  // terminate broker without doing anything
+  broker.notify_terminate_and_wait ();
+}
+
 TEST_CASE ("Test response broker", "")
 {
   // Test threads simulating requesters and a thread registering responses.
@@ -726,6 +737,7 @@ TEST_CASE ("Test response broker", "")
 	  {
 	    cubcomm::response_sequence_number rsn = rsn_gen.get_unique_number ();
 
+	    broker.register_request (rsn);
 	    {
 	      std::lock_guard<std::mutex> lkguard (request_mutex);
 	      requested_rsn.push_back (rsn);
@@ -746,6 +758,47 @@ TEST_CASE ("Test response broker", "")
   for (auto &it : requester_threads)
     {
       it.join ();
+    }
+
+  broker.notify_terminate_and_wait ();
+}
+
+TEST_CASE ("Test response broker without responses and with terminate/abort", "")
+{
+  // a set of requester threads each posts a request and waits for a response that never arrives
+
+  constexpr size_t BUCKET_COUNT = 30;
+  constexpr size_t REQUEST_RESPONSE_THREAD_COUNT = 300; // more than the bucket count
+  constexpr size_t REQUEST_COUNT = 4200;
+
+  cubcomm::response_sequence_number_generator rsn_gen;
+  cubcomm::response_broker<cubcomm::response_sequence_number, css_error_code> broker (BUCKET_COUNT, NO_ERRORS,
+      ERROR_ON_READ);
+
+  // a set of threads each registers and waits for one request
+  std::array<std::thread, REQUEST_RESPONSE_THREAD_COUNT> request_response_threads;
+  for (auto &thr : request_response_threads)
+    {
+      thr = std::thread ([&] ()
+      {
+	cubcomm::response_sequence_number rsn = rsn_gen.get_unique_number ();
+	broker.register_request (rsn);
+
+	const auto [ response, error_code ] = broker.get_response (rsn);
+	REQUIRE (error_code == ERROR_ON_READ);
+	REQUIRE (response == cubcomm::response_sequence_number ());
+      }
+			);
+    }
+
+  // cautiously wait for all threads to have reached the get_response call
+  std::this_thread::sleep_for (std::chrono::milliseconds (50));
+
+  broker.notify_terminate_and_wait ();
+
+  for (auto &thr : request_response_threads)
+    {
+      thr.join ();
     }
 }
 

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -769,7 +769,6 @@ TEST_CASE ("Test response broker without responses and with terminate/abort", ""
 
   constexpr size_t BUCKET_COUNT = 30;
   constexpr size_t REQUEST_RESPONSE_THREAD_COUNT = 300; // more than the bucket count
-  constexpr size_t REQUEST_COUNT = 4200;
 
   cubcomm::response_sequence_number_generator rsn_gen;
   cubcomm::response_broker<cubcomm::response_sequence_number, css_error_code> broker (BUCKET_COUNT, NO_ERRORS,


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-659

Response broker termination function is extended into a blocking call - `notify_terminate_and_wait`.

In order to allow for this extension to work correctly it was needed to keep track of en-route requests to the peer server. Up until now, an en-route request was not marked in any way. Extended the broker with a `register_request` call which actually add and entry in the appropriate broker bucket before actually dispatching the roundtrip request, thus, allowing the terminating logic to avoid race conditions.
Adapted and extended the unit test as a result of this behavioral change.

The sync client server is modified to use the blocking call.

Currently this function is only explicitly invoked on the Page Server side. With subsequent refactorings, the functionality will be used on Transaction Servers as well.

Other:
- reworded some comments

