### PR TITLE
[CBRD-24689] Upgrade junixsocket library to the 2.6.2 version

### DIFF
--- a/jsp/ivy.xml
+++ b/jsp/ivy.xml
@@ -8,8 +8,8 @@
     </configurations>
     <dependencies>
         <dependency org="cubrid" name="cubrid-jdbc" rev="latest.integration" conf="runtime->default"/>
-        <dependency org="com.kohlschutter.junixsocket" name="junixsocket-core" rev="2.4.0" conf="runtime->default"/>
-        <dependency org="com.kohlschutter.junixsocket" name="junixsocket-server" rev="2.4.0" conf="runtime->default"/>
+        <dependency org="com.kohlschutter.junixsocket" name="junixsocket-core" rev="2.6.2" conf="runtime->default"/>
+        <dependency org="com.kohlschutter.junixsocket" name="junixsocket-server" rev="2.6.2" conf="runtime->default"/>
         <dependency org="junit" name="junit" rev="4.13.2" conf="test->default"/>
         <dependency org="org.apache.ant" name="ant-junit4" rev="1.10.12" conf="test->default"/>
     </dependencies>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24689

Junixsocket 2.4.0 version has the file descriptor leak bug. To fix the bug, The junixsocket's version should be upgraded to the 2.6.2 version (latest).