### PR TITLE
[CBRD-24693] Segfault when Server-side JDBC's request is larger than 4096

### DIFF
--- a/src/jsp/com/cubrid/jsp/impl/SUConnection.java
+++ b/src/jsp/com/cubrid/jsp/impl/SUConnection.java
@@ -84,7 +84,7 @@ public class SUConnection {
         CUBRIDPacker packer = new CUBRIDPacker(outputBuffer);
         packer.packInt(SUFunctionCode.GET_DB_PARAMETER.getCode());
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         DBParameterInfo info = new DBParameterInfo(unpacker);
         return info;
     }
@@ -101,7 +101,7 @@ public class SUConnection {
         packer.packString(sql);
         packer.packInt(flag);
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         PrepareInfo info = new PrepareInfo(unpacker);
 
         SUStatement stmt = null;
@@ -124,7 +124,7 @@ public class SUConnection {
         packer.packString(arg2);
         packer.packInt(flag);
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         GetSchemaInfo info = new GetSchemaInfo(unpacker);
         SUStatement stmt = new SUStatement(this, info, arg1, arg2, type);
         return stmt;
@@ -156,7 +156,7 @@ public class SUConnection {
             bindParameter.pack(packer);
         }
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         ExecuteInfo info = new ExecuteInfo(unpacker);
         return info;
     }
@@ -171,7 +171,7 @@ public class SUConnection {
         packer.packInt(fetchSize);
         packer.packInt(fetchFlag);
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         FetchInfo info = new FetchInfo(unpacker);
         return info;
     }
@@ -182,7 +182,7 @@ public class SUConnection {
         packer.packInt(SUFunctionCode.MAKE_OUT_RS.getCode());
         packer.packBigInt(queryId);
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         MakeOutResultSetInfo info = new MakeOutResultSetInfo(unpacker);
         return info;
     }
@@ -193,7 +193,7 @@ public class SUConnection {
         packer.packInt(SUFunctionCode.NEXT_RESULT.getCode());
         packer.packInt(handlerId);
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         ExecuteInfo info = new ExecuteInfo(unpacker);
         return info;
     }
@@ -218,7 +218,7 @@ public class SUConnection {
             packer.packInt(0);
         }
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         GetByOIDInfo info = new GetByOIDInfo(unpacker);
         SUStatement stmt = new SUStatement(this, info, oid, attributeName);
         return stmt;
@@ -231,7 +231,7 @@ public class SUConnection {
         packer.packInt(SUFunctionCode.GET_GENERATED_KEYS.getCode());
         packer.packInt(handlerId);
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         GetGeneratedKeysInfo info = new GetGeneratedKeysInfo(unpacker);
         SUStatement stmt = new SUStatement(this, info);
         return stmt;
@@ -260,7 +260,7 @@ public class SUConnection {
             packer.packInt(0);
         }
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         int result = unpacker.unpackInt();
     }
 
@@ -271,7 +271,7 @@ public class SUConnection {
         packer.packInt(command);
         packer.packOID(new SOID(oid.getOID()));
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         int result = unpacker.unpackInt();
         if (command == CUBRIDServerSideConstants.IS_INSTANCE) {
             if (result == 1) {
@@ -308,7 +308,7 @@ public class SUConnection {
             packer.packInt(0); // has value
         }
 
-        CUBRIDUnpacker unpacker = request(outputBuffer);
+        CUBRIDUnpacker unpacker = request(packer.getBuffer());
         return unpacker;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24693

The CUBRIDPacker can expand the output buffer internally, so the expanded buffer should be passed to the `request()` function.