### PR TITLE
[CBRD-24587] Core dumped in do_alter_server

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -20435,8 +20435,15 @@ do_alter_server (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   if (alter->xbits.bit_dbname)
     {
-      assert (alter->dbname->node_type == PT_NAME);
-      pt = (char *) alter->dbname->info.name.original;
+      assert (alter->dbname->node_type == PT_NAME || alter->dbname->node_type == PT_VALUE);
+      if (alter->dbname->node_type == PT_VALUE)
+	{
+	  pt = (char *) PT_VALUE_GET_BYTES (alter->dbname);
+	}
+      else
+	{
+	  pt = (char *) alter->dbname->info.name.original;
+	}
 
       assert (pt && *pt);
       db_make_string (&value, pt);
@@ -20450,8 +20457,15 @@ do_alter_server (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   if (alter->xbits.bit_user)
     {
-      assert (alter->user->node_type == PT_NAME);
-      pt = (char *) alter->user->info.name.original;
+      assert (alter->user->node_type == PT_NAME || alter->user->node_type == PT_VALUE);
+      if (alter->user->node_type == PT_VALUE)
+	{
+	  pt = (char *) PT_VALUE_GET_BYTES (alter->user);
+	}
+      else
+	{
+	  pt = (char *) alter->user->info.name.original;
+	}
 
       assert (pt && *pt);
       db_make_string (&value, pt);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24587

* In [CBRD-24573], it has been changed to receive DBNAME and USERNAME as strings.
 At this time, the alter server syntax was also changed, but the corresponding code was missing.
