### PR TITLE
[CBRD-24689] [p11_2] Upgrade junixsocket library to the 2.6.2 version (#4163)

### DIFF
--- a/jsp/ivy.xml
+++ b/jsp/ivy.xml
@@ -8,7 +8,7 @@
     </configurations>
     <dependencies>
         <dependency org="cubrid" name="cubrid-jdbc" rev="latest.integration" conf="runtime->default"/>
-        <dependency org="com.kohlschutter.junixsocket" name="junixsocket-core" rev="2.4.0" conf="runtime->default"/>
-        <dependency org="com.kohlschutter.junixsocket" name="junixsocket-server" rev="2.4.0" conf="runtime->default"/>
+        <dependency org="com.kohlschutter.junixsocket" name="junixsocket-core" rev="2.6.2" conf="runtime->default"/>
+        <dependency org="com.kohlschutter.junixsocket" name="junixsocket-server" rev="2.6.2" conf="runtime->default"/>
     </dependencies>
 </ivy-module>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24689

backport of #4163
