### PR TITLE
[CBRD-24650] Fixed csql login error message redundant display

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -2817,7 +2817,6 @@ csql (const char *argv0, CSQL_ARGUMENT * csql_arg)
       csql_Error_code = CSQL_ERR_OS_ERROR;
       goto error;
     }
-  er_set_print_property (ER_PRINT_TO_CONSOLE);
 
   /*
    * login and restart database
@@ -2876,6 +2875,8 @@ csql (const char *argv0, CSQL_ARGUMENT * csql_arg)
 	  goto error;
 	}
     }
+
+  er_set_print_property (ER_PRINT_TO_CONSOLE);
 
   logddl_init (APP_NAME_CSQL);
   logddl_check_ddl_audit_param ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24650

Purpose
When logging in from csql, an error message is displayed on the screen several times.
Removed unnecessary messages.

Implementation
AS-IS
```
$ csql -S -u test testdb
Incorrect or missing password.
Enter Password :
Incorrect or missing password.

ERROR: Incorrect or missing password.
```

TO-BE
```
$ csql -S -u test testdb
Enter Password :

ERROR: Incorrect or missing password.
```

Remarks
N/A
