### PR TITLE
[CBRD-24697] Clearing structures for statement handler cache of SP properly

### DIFF
--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -420,6 +420,8 @@ namespace cubmethod
       {
 	if (is_free)
 	  {
+	    m_sql_handler_map.erase (m_query_handlers[id]->get_sql_stmt());
+
 	    delete m_query_handlers[id];
 	    m_query_handlers[id] = nullptr;
 	  }

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -418,12 +418,14 @@ namespace cubmethod
       }
     if (m_query_handlers[id] != nullptr)
       {
+	// clear <query ID -> handler ID>
 	if (m_query_handlers[id]->get_query_id () != -1)
 	  {
 	    m_qid_handler_map.erase (m_query_handlers[id]->get_query_id ());
 	  }
 	if (is_free)
 	  {
+	    // clear <SQL string -> handler ID>
 	    m_sql_handler_map.erase (m_query_handlers[id]->get_sql_stmt());
 
 	    delete m_query_handlers[id];

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -379,10 +379,11 @@ namespace cubmethod
 	  }
       }
 
-    query_handler *handler = new query_handler (m_error_ctx, idx);
+    query_handler *handler = new (std::nothrow) query_handler (m_error_ctx, idx);
     if (handler == nullptr)
       {
 	assert (false);
+	return handler;
       }
 
     if (idx < handler_size)

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -178,7 +178,7 @@ namespace cubmethod
 	    const cubmethod::query_result &qresult = handler->get_result();
 	    if (qresult.stmt_type == CUBRID_STMT_SELECT)
 	      {
-		uint64_t qid = (uint64_t) handler->get_execute_info ().qresult_info.query_id;
+		uint64_t qid = (uint64_t) handler->get_query_id ();
 		m_qid_handler_map[qid] = request.handler_id;
 	      }
 	  }
@@ -415,9 +415,12 @@ namespace cubmethod
       {
 	return;
       }
-
     if (m_query_handlers[id] != nullptr)
       {
+	if (m_query_handlers[id]->get_query_id () != -1)
+	  {
+	    m_qid_handler_map.erase (m_query_handlers[id]->get_query_id ());
+	  }
 	if (is_free)
 	  {
 	    m_sql_handler_map.erase (m_query_handlers[id]->get_sql_stmt());

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -44,6 +44,7 @@ namespace cubmethod
     , m_max_col_size (-1)
     , m_has_result_set (false)
     , m_is_occupied (false)
+    , m_query_id (-1)
     , m_prepare_info ()
     , m_execute_info ()
     , m_prepare_call_info ()
@@ -94,6 +95,12 @@ namespace cubmethod
   query_handler::get_statement_type () const
   {
     return m_stmt_type;
+  }
+
+  uint64_t
+  query_handler::get_query_id () const
+  {
+    return m_query_id;
   }
 
   int
@@ -227,6 +234,7 @@ namespace cubmethod
 	/* set max_col_size */
 	m_max_col_size = max_col_size;
 	m_execute_info.handle_id = get_id ();
+	m_query_id = m_execute_info.qresult_info.query_id;
 
 	/* include column info? */
 	if (db_check_single_query (m_session) != NO_ERROR) /* ER_IT_MULTIPLE_STATEMENT */
@@ -624,6 +632,7 @@ namespace cubmethod
       }
 
     m_has_result_set = false;
+    m_query_id = -1;
   }
 
   int

--- a/src/method/method_query_handler.hpp
+++ b/src/method/method_query_handler.hpp
@@ -91,6 +91,8 @@ namespace cubmethod
       std::string get_sql_stmt () const;
       int get_statement_type () const;
 
+      uint64_t get_query_id () const;
+
       int get_num_markers ();
       bool get_is_occupied ();
       void set_is_occupied (bool flag);
@@ -159,6 +161,9 @@ namespace cubmethod
 
       /* statement handler cache */
       bool m_is_occupied; // Is occupied by CUBRIDServerSideStatement
+
+      /* query id */
+      uint64_t m_query_id;
 
       /* results */
       prepare_info m_prepare_info;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24697

This PR fixes `free_query_handle()` to clear `m_sql_handler_map` and `m_qid_handler_map` properly. It was omitted at CBRD-23627.