### PR TITLE
[CBRD-24504] When an error occurs in a function that uses a buffer to convert an identifier name, the buffer must be initialized. (#3844)

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -2251,13 +2251,16 @@ sm_downcase_name (const char *name, char *buf, int buf_size)
 {
   int error = NO_ERROR;
 
+  assert (buf != NULL);
+  assert (buf_size > 0);
+
   if (name == NULL || name[0] == '\0')
     {
       ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
+      buf[0] = '\0';
       return NULL;
     }
 
-  assert (buf != NULL);
   assert (intl_identifier_lower_string_size (name) < buf_size);
   intl_identifier_lower (name, buf);
 
@@ -2279,9 +2282,13 @@ sm_user_specified_name (const char *name, char *buf, int buf_size)
   const char *dot = NULL;
   int error = NO_ERROR;
 
+  assert (buf != NULL);
+  assert (buf_size > 0);
+
   if (name == NULL || name[0] == '\0')
     {
       ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
+      buf[0] = '\0';
       return NULL;
     }
 
@@ -5392,10 +5399,16 @@ sm_find_class (const char *name)
 MOP
 sm_find_class_with_purpose (const char *name, bool for_update)
 {
-  char realname[SM_MAX_IDENTIFIER_LENGTH];
+  char realname[SM_MAX_IDENTIFIER_LENGTH] = { '\0' };
   MOP class_mop = NULL;
   MOP synonym_mop = NULL;
   int error = NO_ERROR;
+
+  if (name == NULL || name[0] == '\0')
+    {
+      ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
+      return NULL;
+    }
 
   sm_user_specified_name (name, realname, SM_MAX_IDENTIFIER_LENGTH);
 
@@ -5444,6 +5457,12 @@ sm_find_synonym (const char *name)
   char realname[SM_MAX_IDENTIFIER_LENGTH] = { '\0' };
   int error = NO_ERROR;
   int save = 0;
+
+  if (name == NULL || name[0] == '\0')
+    {
+      ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
+      return NULL;
+    }
 
   if (sm_check_system_class_by_name (name))
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24504

backport #3844