### PR TITLE
[CBRD-24643] fix the replication failure when a large number of records are inserted by loaddb with -C option

### DIFF
--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -700,7 +700,7 @@ namespace cubload
 
     insert_errors_filtered = has_errors_filtered_for_insert (m_session.get_args().m_ignored_errors);
 
-    if (insert_errors_filtered)
+    if (insert_errors_filtered || !HA_DISABLED ())
       {
 	// In case of possible errors filtered for insert we disable the unique optimization
 	for (size_t i = 0; i < m_recdes_collected.size (); i++)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24643

Purpose
* fix the replication failure when a large number of records are inserted by loaddb with -C
* some of the records aren't replicated from master to slave
  * the applylogdb is crashed by assert on debug mode
* the reason for this is described on the jira issue
```
locator_multi_insert_force()
-> locator_insert_force (use_bulk_logging==true)
// each physical log is replaced by page log (see pgbuf_log_redo_new_page)
// in this case, the replication log cannot have lsa for the physical log for each insert
```

Implementation
* loaddb should not be call the locator_multi_insert_force()
  * because this function prevents proper logging of replication log

Remarks
* N/A