### PR TITLE
[CBRD-24701] Modify packer class not to call abort in check_range() function (#4184)

### DIFF
--- a/src/base/packer.cpp
+++ b/src/base/packer.cpp
@@ -52,6 +52,7 @@ namespace cubpacking
     assert (ptr + amount <= endptr);
     if (ptr + amount > endptr)
       {
+	er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERFACE_NOT_ENOUGH_DATA_SIZE, 0);
 	abort ();
       }
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24701

This is a backport of #4184 