### PR TITLE
[CBRD-24711] fix to recognize case for database name used as section name in cubrid.conf

### DIFF
--- a/src/base/ini_parser.c
+++ b/src/base/ini_parser.c
@@ -787,7 +787,7 @@ ini_hassec (const char *key)
  * Note:
  */
 int
-ini_seccmp (const char *key1, const char *key2)
+ini_seccmp (const char *key1, const char *key2, bool ignore_case)
 {
   const char *s1 = strchr (key1, ':');
   const char *s2 = strchr (key2, ':');
@@ -816,7 +816,12 @@ ini_seccmp (const char *key1, const char *key2)
       return 0;
     }
 
-  if (strncasecmp (key1, key2, key1_sec_len) == 0)
+  if (ignore_case && strncasecmp (key1, key2, key1_sec_len) == 0)
+    {
+      return key1_sec_len;
+    }
+
+  if (ignore_case == false && strncmp (key1, key2, key1_sec_len) == 0)
     {
       return key1_sec_len;
     }

--- a/src/base/ini_parser.c
+++ b/src/base/ini_parser.c
@@ -517,7 +517,11 @@ ini_parse_line (char *input_line, char *section, char *key, char *value)
 	{
 	  sprintf (section, "%c%s", leading_char, ini_str_trim (section + 1));
 	}
-      strcpy (section, ini_str_lower (section));
+
+      if (leading_char != '@')
+	{
+	  strcpy (section, ini_str_lower (section));
+	}
       status = LINE_SECTION;
     }
   else if (sscanf (line, "%[^=] = \"%[^\"]\"", key, value) == 2 || sscanf (line, "%[^=] = '%[^\']'", key, value) == 2

--- a/src/base/ini_parser.h
+++ b/src/base/ini_parser.h
@@ -49,7 +49,7 @@ extern void ini_parser_free (INI_TABLE * ini);
 extern int ini_findsec (INI_TABLE * ini, const char *sec);
 extern char *ini_getsecname (INI_TABLE * ini, int n, int *lineno);
 extern int ini_hassec (const char *key);
-extern int ini_seccmp (const char *key1, const char *key2);
+extern int ini_seccmp (const char *key1, const char *key2, bool ignore_case);
 
 extern const char *ini_getstr (INI_TABLE * ini, const char *sec, const char *key, const char *def, int *lineno);
 extern int ini_getint (INI_TABLE * ini, const char *sec, const char *key, int def, int *lineno);

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -6483,7 +6483,7 @@ static void prm_check_environment (void);
 static int prm_check_parameters (void);
 static SYSPRM_ERR sysprm_validate_escape_char_parameters (const SYSPRM_ASSIGN_VALUE * assignment_list);
 static int prm_load_by_section (INI_TABLE * ini, const char *section, bool ignore_section, bool reload,
-				const char *file, const int load_flags);
+				const char *file, const int load_flags, bool ignore_case);
 static int prm_read_and_parse_ini_file (const char *prm_file_name, const char *db_name, const bool reload,
 					const int load_flags);
 static void prm_report_bad_entry (const char *key, int line, int err, const char *where);
@@ -6967,10 +6967,11 @@ sysprm_reload_and_init (const char *db_name, const char *conf_file)
  *   reload(in):
  *   file(in):
  *   load_flags(in):
+ *   ignore_case(in):
  */
 static int
 prm_load_by_section (INI_TABLE * ini, const char *section, bool ignore_section, bool reload, const char *file,
-		     const int load_flags)
+		     const int load_flags, bool ignore_case)
 {
   int i, error;
   int sec_len;
@@ -7002,7 +7003,7 @@ prm_load_by_section (INI_TABLE * ini, const char *section, bool ignore_section, 
 
       if (ini_hassec (key))
 	{
-	  sec_len = ini_seccmp (key, section);
+	  sec_len = ini_seccmp (key, section, ignore_case);
 	  if (!sec_len)
 	    {
 	      continue;
@@ -7186,33 +7187,33 @@ prm_read_and_parse_ini_file (const char *prm_file_name, const char *db_name, con
       return PRM_ERR_FILE_ERR;
     }
 
-  error = prm_load_by_section (ini, "common", true, reload, prm_file_name, load_flags);
+  error = prm_load_by_section (ini, "common", true, reload, prm_file_name, load_flags, true);
   if (error == NO_ERROR && SYSPRM_LOAD_IS_IGNORE_HA (load_flags) && db_name != NULL && *db_name != '\0')
     {
       snprintf (sec_name, LINE_MAX, "@%s", db_name);
-      error = prm_load_by_section (ini, sec_name, true, reload, prm_file_name, load_flags);
+      error = prm_load_by_section (ini, sec_name, true, reload, prm_file_name, load_flags, false);
     }
 
 #if defined (SA_MODE)
   if (error == NO_ERROR)
     {
-      error = prm_load_by_section (ini, "standalone", true, reload, prm_file_name, load_flags);
+      error = prm_load_by_section (ini, "standalone", true, reload, prm_file_name, load_flags, true);
     }
 #endif /* SA_MODE */
 
   if (error == NO_ERROR && SYSPRM_LOAD_IS_IGNORE_HA (load_flags))
     {
-      error = prm_load_by_section (ini, "service", false, reload, prm_file_name, load_flags);
+      error = prm_load_by_section (ini, "service", false, reload, prm_file_name, load_flags, true);
     }
   if (error == NO_ERROR && !SYSPRM_LOAD_IS_IGNORE_HA (load_flags) && PRM_HA_MODE != HA_MODE_OFF
       && GETHOSTNAME (host_name, CUB_MAXHOSTNAMELEN) == 0)
     {
       snprintf (sec_name, LINE_MAX, "%%%s|*", host_name);
-      error = prm_load_by_section (ini, sec_name, true, reload, prm_file_name, load_flags);
+      error = prm_load_by_section (ini, sec_name, true, reload, prm_file_name, load_flags, true);
       if (error == NO_ERROR && getlogin_r (user_name, CUB_MAXHOSTNAMELEN) == 0)
 	{
 	  snprintf (sec_name, LINE_MAX, "%%%s|%s", host_name, user_name);
-	  error = prm_load_by_section (ini, sec_name, true, reload, prm_file_name, load_flags);
+	  error = prm_load_by_section (ini, sec_name, true, reload, prm_file_name, load_flags, true);
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24711

**Purpose**
* CUBRID recognizes **_demodb_** and **_DEMODB_** as different database names.
* database names can be used as a section name in cubrid.conf in the form of
`[@db_name]`
* ini parser, a MIT License library parser, converts all section names to lower case when it starts
* ini parser, a MIT License library parser, compare with ignore case option for the keys

**Implementation**

**Remarks**
* ini_parser.c, ini_parser.h **cannot pass CI License check**
* I think **force merge** is required due to CI License check.
