### PR TITLE
[CBRD-24712] Change editline library source download URL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ set(WITH_LIBEXPAT_URL "https://github.com/libexpat/libexpat/releases/download/R_
 set(WITH_LIBJANSSON_URL "http://www.digip.org/jansson/releases/jansson-2.10.tar.gz")
 
 # editline library sources URL
-set(WITH_LIBEDIT_URL "http://thrysoee.dk/editline/libedit-20170329-3.1.tar.gz")
+set(WITH_LIBEDIT_URL "https://github.com/CUBRID/libedit/archive/refs/tags/libedit_v1.tar.gz")
 
 # rapidjson library sources URL
 set(WITH_RAPIDJSON_URL "https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz")


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24712

Purpose
CUBRID is building by downloading the source through an external URL to use the editline library when building.
If an error occurs in the external URL, a build may not be possible.
To prevent this build failure, the URL has been changed.

Implementation
AS-IS
http://thrysoee.dk/editline/libedit-20170329-3.1.tar.gz

TO-BE
https://github.com/CUBRID/libedit/archive/refs/tags/libedit_v1.tar.gz

Remarks
N/A