### PR TITLE
[CBRD-24712] [11.0] change download URL of external library, libedit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ set(WITH_LIBEXPAT_URL "https://github.com/libexpat/libexpat/releases/download/R_
 set(WITH_LIBJANSSON_URL "http://www.digip.org/jansson/releases/jansson-2.10.tar.gz")
 
 # editline library sources URL
-set(WITH_LIBEDIT_URL "http://thrysoee.dk/editline/libedit-20170329-3.1.tar.gz")
+set(WITH_LIBEDIT_URL "https://github.com/CUBRID/libedit/archive/refs/tags/libedit_v1.tar.gz")
 
 # rapidjson library sources URL
 set(WITH_RAPIDJSON_URL "https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz")


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24712

**Purpose**
* change download URL of external library, **libedit**
* this is backport of #4200 to release/11.0

**Implementation**
* ASIS
    http://thrysoee.dk/editline/libedit-20170329-3.1.tar.gz
* TOBE
    https://github.com/CUBRID/libedit/archive/refs/tags/libedit_v1.tar.gz

Remarks
N/A
