### PR TITLE
[LETS-648] change lob directory creation permission in accordance with develop

### DIFF
--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -849,7 +849,7 @@ boot_initialize_lob_path (const char *path_arg, const char *db_path, char *path_
 	{
 	  // Directory does not exist
 	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_BO_DIRECTORY_DOESNOT_EXIST, 1, lob_dir_path);
-	  if (mkdir (lob_dir_path, 0777) < 0)
+	  if (mkdir (lob_dir_path, 0700) < 0)
 	    {
 	      cub_dirname_r (lob_dir_path, absolute_path_buf, PATH_MAX);
 	      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ES_GENERAL, 2, "POSIX", absolute_path_buf);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -4253,7 +4253,7 @@ xboot_copy (REFPTR (THREAD_ENTRY, thread_p), const char *from_dbname, const char
 	  else
 	    {
 	      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_BO_DIRECTORY_DOESNOT_EXIST, 1, p);
-	      if (mkdir (p, 0777) < 0)
+	      if (mkdir (p, 0700) < 0)
 		{
 		  cub_dirname_r (p, fixed_pathbuf, PATH_MAX);
 		  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ES_GENERAL, 2, "POSIX", fixed_pathbuf);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-648

Remark: the permission flags are also changed for the lob `mkdir` in `xboot_copy`. The develop branch left that unchanged.

Remark: in `scalability_dev` there were some small refactorings which are probably worthwhile to be also propagated upstream