### PR TITLE
[CBRD-24704] demodb is not installed when installing CUBRID engine with msi file for windows.

### DIFF
--- a/demo/make_cubrid_demo.bat
+++ b/demo/make_cubrid_demo.bat
@@ -31,6 +31,7 @@ if not "%1"=="" (
 if exist %DBNAME% goto done
 
 if NOT exist %CUBRID_DATABASES%\demodb md %CUBRID_DATABASES%\demodb
+set PATH=%PATH%;%CUBRID%\cci\bin;
 cd %CUBRID_DATABASES%\demodb
 echo ********** Creating database %DBNAME% ...
 %CUBRID%\bin\cub_admin createdb --db-volume-size=100M --log-volume-size=100M --replace %DBNAME% en_US.utf8


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24704

Purpose
Q/A Issue

Implementation
- add path(cci/bin) for 'cubrid_admin' in 'make_cubrid_demo.bat'

Remarks
BackPort