### PR TITLE
[CBRD-24716] Add hidden parameter statdump_force_add_int_max for QA

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -1566,8 +1566,16 @@ perfmon_server_dump_stats (const UINT64 * stats, FILE * stream, const char *subs
 	    {
 	      if (pstat_Metadata[i].valtype != PSTAT_COUNTER_TIMER_VALUE)
 		{
-		  fprintf (stream, "%-29s = %10llu\n", pstat_Metadata[i].stat_name,
+		  if (prm_get_bool_value (PRM_ID_STATDUMP_FORCE_ADD_INT_MAX))
+		    {
+		      fprintf (stream, "%-29s = %10llu\n", pstat_Metadata[i].stat_name,
+			   (unsigned long long) stats_ptr[offset]+INT_MAX);
+		    }
+		  else
+		    {
+		      fprintf (stream, "%-29s = %10llu\n", pstat_Metadata[i].stat_name,
 			   (unsigned long long) stats_ptr[offset]);
+		    }
 		}
 	      else
 		{

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -1569,12 +1569,12 @@ perfmon_server_dump_stats (const UINT64 * stats, FILE * stream, const char *subs
 		  if (prm_get_bool_value (PRM_ID_STATDUMP_FORCE_ADD_INT_MAX))
 		    {
 		      fprintf (stream, "%-29s = %10llu\n", pstat_Metadata[i].stat_name,
-			   (unsigned long long) stats_ptr[offset]+INT_MAX);
+			       (unsigned long long) stats_ptr[offset] + INT_MAX);
 		    }
 		  else
 		    {
 		      fprintf (stream, "%-29s = %10llu\n", pstat_Metadata[i].stat_name,
-			   (unsigned long long) stats_ptr[offset]);
+			       (unsigned long long) stats_ptr[offset]);
 		    }
 		}
 	      else

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -722,6 +722,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_VALUE_MAX "MAX"
 #define PRM_VALUE_MIN "MIN"
 
+#define PRM_NAME_STATDUMP_FORCE_ADD_INT_MAX "statdump_force_add_int_max"
+
 /*
  * Note about ERROR_LIST and INTEGER_LIST type
  * ERROR_LIST type is an array of bool type with the size of -(ER_LAST_ERROR)
@@ -2359,6 +2361,10 @@ static unsigned int prm_regexp_engine_flag = 0;
 bool PRM_ORACLE_STYLE_NUMBER_RETURN = false;
 static bool prm_oracle_style_number_return_default = false;
 static unsigned int prm_oracle_style_number_return_flag = 0;
+
+bool PRM_STATDUMP_FORCE_ADD_INT_MAX = false;
+static bool prm_statdump_force_add_int_max_default = false;
+static unsigned int prm_statdump_force_add_int_max_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -6209,6 +6215,17 @@ SYSPRM_PARAM prm_Def[] = {
    (void *) &PRM_HA_PING_TIMEOUT,
    (void *) &prm_ha_ping_timeout_upper,
    (void *) &prm_ha_ping_timeout_lower,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_STATDUMP_FORCE_ADD_INT_MAX,
+   PRM_NAME_STATDUMP_FORCE_ADD_INT_MAX,
+   (PRM_FOR_SERVER | PRM_FOR_CLIENT | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   &prm_statdump_force_add_int_max_flag,
+   (void *) &prm_statdump_force_add_int_max_default,
+   (void *) &PRM_STATDUMP_FORCE_ADD_INT_MAX,
+   (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL}

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -468,8 +468,9 @@ enum param_id
   PRM_ID_ORACLE_STYLE_NUMBER_RETURN,
   PRM_ID_HA_TCP_PING_HOSTS,
   PRM_ID_HA_PING_TIMEOUT,
+  PRM_ID_STATDUMP_FORCE_ADD_INT_MAX,	/* Hidden parameter for QA only */
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_HA_PING_TIMEOUT
+  PRM_LAST_ID = PRM_ID_STATDUMP_FORCE_ADD_INT_MAX
 };
 typedef enum param_id PARAM_ID;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24716

**Purpose**
* related with #4084
* For QA purposes only
* to artificially adding INT_MAX to statdump output when sys para **statdump_force_add_int_max** is true

**Implementation**
N/A

**Remarks**
* statdump_force_add_int_max = false
```
 $ cubrid statdump -i 1 demodb > /dev/null &
 $ csql -u public demodb -c "select count(*) from code"
 $ cubrid statdump demodb | grep select
 Num_query_selects             =          1
```
* statdump_force_add_int_max = true
```
 $ cubrid statdump -i 1 demodb > /dev/null &
 $ csql -u public demodb -c "select count(*) from code"
 $ cubrid statdump demodb | grep select
 Num_query_selects             = 2147483648
```