### PR TITLE
[CBRD-24716] [11.0] Add hidden parameter statdump_force_add_int_max for QA

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -1517,8 +1517,16 @@ perfmon_server_dump_stats (const UINT64 * stats, FILE * stream, const char *subs
 	    {
 	      if (pstat_Metadata[i].valtype != PSTAT_COUNTER_TIMER_VALUE)
 		{
-		  fprintf (stream, "%-29s = %10llu\n", pstat_Metadata[i].stat_name,
-			   (unsigned long long) stats_ptr[offset]);
+		  if (prm_get_bool_value (PRM_ID_STATDUMP_FORCE_ADD_INT_MAX))
+		    {
+		      fprintf (stream, "%-29s = %10llu\n", pstat_Metadata[i].stat_name,
+			       (unsigned long long) stats_ptr[offset] + INT_MAX);
+		    }
+		  else
+		    {
+		      fprintf (stream, "%-29s = %10llu\n", pstat_Metadata[i].stat_name,
+			       (unsigned long long) stats_ptr[offset]);
+		    }
 		}
 	      else
 		{

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -698,6 +698,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_VALUE_MAX "MAX"
 #define PRM_VALUE_MIN "MIN"
 
+#define PRM_NAME_STATDUMP_FORCE_ADD_INT_MAX "statdump_force_add_int_max"
+
 /*
  * Note about ERROR_LIST and INTEGER_LIST type
  * ERROR_LIST type is an array of bool type with the size of -(ER_LAST_ERROR)
@@ -2351,6 +2353,10 @@ static UINT64 prm_first_log_pageid_default = 0LL;
 static UINT64 prm_first_log_pageid_lower = 0LL;
 static UINT64 prm_first_log_pageid_upper = LOGPAGEID_MAX;
 static unsigned int prm_first_log_pageid_flag = 0;
+
+bool PRM_STATDUMP_FORCE_ADD_INT_MAX = false;
+static bool prm_statdump_force_add_int_max_default = false;
+static unsigned int prm_statdump_force_add_int_max_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -6054,6 +6060,17 @@ static SYSPRM_PARAM prm_Def[] = {
    (void *) &PRM_FIRST_LOG_PAGEID,
    (void *) &prm_first_log_pageid_upper,
    (void *) &prm_first_log_pageid_lower,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_STATDUMP_FORCE_ADD_INT_MAX,
+   PRM_NAME_STATDUMP_FORCE_ADD_INT_MAX,
+   (PRM_FOR_SERVER | PRM_FOR_CLIENT | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   &prm_statdump_force_add_int_max_flag,
+   (void *) &prm_statdump_force_add_int_max_default,
+   (void *) &PRM_STATDUMP_FORCE_ADD_INT_MAX,
+   (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL}

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -453,8 +453,9 @@ enum param_id
   PRM_ID_DDL_AUDIT_LOG,
   PRM_ID_DDL_AUDIT_LOG_SIZE,
   PRM_ID_FIRST_LOG_PAGEID,	/* Except for QA or TEST purposes, never use it. */
+  PRM_ID_STATDUMP_FORCE_ADD_INT_MAX,
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_FIRST_LOG_PAGEID
+  PRM_LAST_ID = PRM_ID_STATDUMP_FORCE_ADD_INT_MAX
 };
 typedef enum param_id PARAM_ID;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24716

**Purpose**
* this is backport of #4209 to release/11.0
* related with #4084
* For QA purposes only
* to artificially adding INT_MAX to statdump output when sys para **statdump_force_add_int_max** is true

**Implementation**
N/A

**Remarks**
* statdump_force_add_int_max = false
```
 $ cubrid statdump -i 1 demodb > /dev/null &
 $ csql -u public demodb -c "select count(*) from code"
 $ cubrid statdump demodb | grep select
 Num_query_selects             =          1
```
* statdump_force_add_int_max = true
```
 $ cubrid statdump -i 1 demodb > /dev/null &
 $ csql -u public demodb -c "select count(*) from code"
 $ cubrid statdump demodb | grep select
 Num_query_selects             = 2147483648
```