### PR TITLE
[CBRD-24716] [10.2] Add hidden parameter statdump_force_add_int_max for QA

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -1514,8 +1514,16 @@ perfmon_server_dump_stats (const UINT64 * stats, FILE * stream, const char *subs
 	    {
 	      if (pstat_Metadata[i].valtype != PSTAT_COUNTER_TIMER_VALUE)
 		{
-		  fprintf (stream, "%-29s = %10llu\n", pstat_Metadata[i].stat_name,
-			   (unsigned long long) stats_ptr[offset]);
+		  if (prm_get_bool_value (PRM_ID_STATDUMP_FORCE_ADD_INT_MAX))
+		    {
+		      fprintf (stream, "%-29s = %10llu\n", pstat_Metadata[i].stat_name,
+			       (unsigned long long) stats_ptr[offset] + INT_MAX);
+		    }
+		  else
+		    {
+		      fprintf (stream, "%-29s = %10llu\n", pstat_Metadata[i].stat_name,
+			       (unsigned long long) stats_ptr[offset]);
+		    }
 		}
 	      else
 		{

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -679,6 +679,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_VALUE_MAX "MAX"
 #define PRM_VALUE_MIN "MIN"
 
+#define PRM_NAME_STATDUMP_FORCE_ADD_INT_MAX "statdump_force_add_int_max"
+
 /*
  * Note about ERROR_LIST and INTEGER_LIST type
  * ERROR_LIST type is an array of bool type with the size of -(ER_LAST_ERROR)
@@ -2276,6 +2278,10 @@ static unsigned int prm_first_log_pageid_flag = 0;
 bool PRM_USE_STAT_ESTIMATION = true;
 static bool prm_use_stat_estimation_default = true;
 static unsigned int prm_use_stat_estimation_flag = 0;
+
+bool PRM_STATDUMP_FORCE_ADD_INT_MAX = false;
+static bool prm_statdump_force_add_int_max_default = false;
+static unsigned int prm_statdump_force_add_int_max_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -5853,6 +5859,17 @@ static SYSPRM_PARAM prm_Def[] = {
    &prm_use_stat_estimation_flag,
    (void *) &prm_use_stat_estimation_default,
    (void *) &PRM_USE_STAT_ESTIMATION,
+   (void *) NULL, (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_STATDUMP_FORCE_ADD_INT_MAX,
+   PRM_NAME_STATDUMP_FORCE_ADD_INT_MAX,
+   (PRM_FOR_SERVER | PRM_FOR_CLIENT | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   &prm_statdump_force_add_int_max_flag,
+   (void *) &prm_statdump_force_add_int_max_default,
+   (void *) &PRM_STATDUMP_FORCE_ADD_INT_MAX,
    (void *) NULL, (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -441,9 +441,10 @@ enum param_id
   PRM_ID_JAVA_STORED_PROCEDURE_JVM_OPTIONS,
   PRM_ID_FIRST_LOG_PAGEID,	/* Except for QA or TEST purposes, never use it. */
   PRM_ID_USE_STAT_ESTIMATION,
+  PRM_ID_STATDUMP_FORCE_ADD_INT_MAX,
 
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_USE_STAT_ESTIMATION
+  PRM_LAST_ID = PRM_ID_STATDUMP_FORCE_ADD_INT_MAX
 };
 typedef enum param_id PARAM_ID;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24716

**Purpose**
* this is backport of #4209 to release/10.2
* related with #4094
* For QA purposes only
* to artificially adding INT_MAX to statdump output when sys para **statdump_force_add_int_max** is true

**Implementation**
N/A

**Remarks**
* statdump_force_add_int_max = false
```
 $ cubrid statdump -i 1 demodb > /dev/null &
 $ csql -u public demodb -c "select count(*) from code"
 $ cubrid statdump demodb | grep select
 Num_query_selects             =          1
```
* statdump_force_add_int_max = true
```
 $ cubrid statdump -i 1 demodb > /dev/null &
 $ csql -u public demodb -c "select count(*) from code"
 $ cubrid statdump demodb | grep select
 Num_query_selects             = 2147483648
```