### PR TITLE
[CBRD-24717] Check minimum and maximum values of shard key

### DIFF
--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -368,7 +368,7 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 
 	      if (shm_proxy_p == NULL)
 		{
-		  sprintf (admin_err_msg, "%s: failed to initialize proxy shared memory.", br_info->name);
+		  sprintf (admin_err_msg, "%s: failed to initialize proxy shared memory.", br_info[i].name);
 
 		  res = -1;
 		  break;
@@ -384,7 +384,7 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 	  shm_as_p = broker_shm_initialize_shm_as (&(shm_br->br_info[i]), shm_proxy_p);
 	  if (shm_as_p == NULL)
 	    {
-	      sprintf (admin_err_msg, "%s: failed to initialize appl server shared memory.", br_info->name);
+	      sprintf (admin_err_msg, "%s: failed to initialize appl server shared memory.", br_info[i].name);
 
 	      res = -1;
 	      break;

--- a/src/broker/shard_metadata.c
+++ b/src/broker/shard_metadata.c
@@ -712,7 +712,7 @@ shard_metadata_validate_key_range_internal (T_SHARD_KEY * key_p, T_SHM_SHARD_CON
       prv_range_max = range_p->max;
     }
 
-  if ((modular >= 1) && (prv_range_max > modular))
+  if ((modular >= 1) && (prv_range_max > modular - 1))
     {
       SHARD_ERR ("%s: shard range max (%d, modular %d) is invalid.\n", key_p->key_column, range_p->max, modular);
       return -1;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24717

Purpose
An error does not occur even if a value outside the shard key range is set in shard_key.txt.

Implementation
N/A

Remarks
The min of a shard key must always start from 0.
max should be set up to 255.
