### PR TITLE
[CBRD-24718] Access log file format error for shard

### DIFF
--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -3498,7 +3498,7 @@ proxy_activate (T_BROKER_INFO * br_info_p, T_SHM_PROXY * shm_proxy_p, T_SHM_APPL
       proxy_info_p = shard_shm_find_proxy_info (shm_proxy_p, i);
 
       snprintf (proxy_info_p->access_log_file, CONF_LOG_FILE_LEN - 1, "%s/%s_%d.access", CUBRID_BASE_DIR,
-		br_info_p->name, i);
+		br_info_p->name, (i + 1));
       dir_repath (proxy_info_p->access_log_file, CONF_LOG_FILE_LEN);
 
       proxy_info_p->cur_proxy_log_mode = br_info_p->proxy_log_mode;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24718

Purpose
The number of <proxy_index> in the shard access log file is displayed as 0 (shard1_0.access).
<proxy_index> of sql, proxy, and error log starts from 1.

Implementation
AS-IS
shard1_0.access

TO-BE
shard1_1.access

Remarks
Access log file
Format : <broker_name>_<proxy_index>.access
File : shard1_1.access

SQL LOG file
Format : <broker_name><proxy_index><shard_index>_<cas_index>.sql.log
File : shard1_1_0_1.sql.log

Proxy log file
Format : <broker_name>_<proxy_index>.log
File : shard1_1.log

Error log file
Format : <broker_name><proxy_index><shard_index>_<cas_index>.err
File : shard1_1_0_1.err