### PR TITLE
[LETS-670] Allow the same saved_lsa as before

### DIFF
--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -169,12 +169,15 @@ active_tran_server::connection_handler::receive_saved_lsa (page_server_conn_t::s
   assert (sizeof (log_lsa) == message.size ());
   std::memcpy (&saved_lsa, message.c_str (), sizeof (log_lsa));
 
-  assert (saved_lsa > get_saved_lsa ()); // increasing monotonically
-  m_saved_lsa.store (saved_lsa);
+  assert (saved_lsa >= get_saved_lsa ()); // PS can send the same saved_lsa as before in some cases
+  if (saved_lsa > get_saved_lsa ())
+    {
+      m_saved_lsa.store (saved_lsa);
+      log_Gl.wakeup_ps_flush_waiters ();
+    }
 
-  quorum_consenesus_er_log ("Received saved LSA = %lld|%d.\n", LSA_AS_ARGS (&saved_lsa));
-
-  log_Gl.wakeup_ps_flush_waiters ();
+  quorum_consenesus_er_log ("Received saved LSA = %lld|%d from %s.\n", LSA_AS_ARGS (&saved_lsa),
+			    get_channel_id ().c_str ());
 }
 
 log_lsa


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-670

In some cases, a PS can send the same saved_lsa as before. (logpb_write_append_pages_to_disk() -> logpb_send_flushed_lsa_to_ats()). PS sends the saved_lsa whenever it flushes log pages and there seem to be some cases in which log pages are flushed but the saved_lsa is not updated. I've opted in to allowing the same saved_lsa rather than to filtering out possibly complicated cases.

- Allow the same saved_lsa as before in `active_tran_server::connection_handler::receive_saved_lsa`
- Request to update the consensus flushed LSA only if It's updated.
- Revise the debug logging to identify who updates the saved_lsa.
