### PR TITLE
[CBRD-24723] Allow special characters in shard password of cubrid_broker.conf

### DIFF
--- a/src/base/ini_parser.c
+++ b/src/base/ini_parser.c
@@ -559,6 +559,16 @@ ini_parse_line (char *input_line, char *section, char *key, char *value)
       /* Generate syntax error */
       status = LINE_ERROR;
     }
+
+  if (strcmp (key, "shard_db_password") == 0 && strlen (value) > 0)
+    {
+      char dummy[512];
+
+      if (sscanf (line, "%[^=] = %[^ \t]", dummy, value) != 2)
+	{
+	  status = LINE_ERROR;
+	}
+    }
   return status;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24723

Description
* allow special character for '**shard_db_password**'

Implementation
* ini_parse_line () at ini_parser.c parse cubrid.conf
* commonly, it discard after character '#'
* before return, if the subject keyword is 'shard_db_password', reparsing value using
`sscanf (line, "%[^=] = %[^ \t]", dummy, value)`
* it means, accept a string until it encounters the blank or tab key.

Remarks
