### PR TITLE
[CBRD-24724] retry proxy server connect 3 times, up to 1200 msec

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -206,6 +206,8 @@
 #define SOCKET_TIMEOUT_SEC	2
 #endif
 
+#define SHARD_CAS_WARMUP_MSEC	900
+
 /* server state */
 enum SERVER_STATE
 {
@@ -815,7 +817,7 @@ receiver_thr_f (void *arg)
 #if defined(LINUX)
   if (br_shard_flag == ON)
     {
-      SLEEP_MILISEC (0, 700);
+      SLEEP_MILISEC (0, SHARD_CAS_WARMUP_MSEC);
     }
 
   timeout = 5;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -206,8 +206,6 @@
 #define SOCKET_TIMEOUT_SEC	2
 #endif
 
-#define SHARD_CAS_WARMUP_MSEC	900
-
 /* server state */
 enum SERVER_STATE
 {
@@ -815,11 +813,6 @@ receiver_thr_f (void *arg)
 #endif
 
 #if defined(LINUX)
-  if (br_shard_flag == ON)
-    {
-      SLEEP_MILISEC (0, SHARD_CAS_WARMUP_MSEC);
-    }
-
   timeout = 5;
   setsockopt (sock_fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, (char *) &timeout, sizeof (timeout));
 #endif /* LINUX */

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -813,6 +813,11 @@ receiver_thr_f (void *arg)
 #endif
 
 #if defined(LINUX)
+  if (br_shard_flag == ON)
+    {
+      SLEEP_MILISEC (0, 700);
+    }
+
   timeout = 5;
   setsockopt (sock_fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, (char *) &timeout, sizeof (timeout));
 #endif /* LINUX */

--- a/src/broker/broker_proxy_conn.c
+++ b/src/broker/broker_proxy_conn.c
@@ -377,12 +377,14 @@ retry:
 	}
     }
 
+#if !defined(WINDOWS)
   if (shm_proxy_p->num_proxy > 0 && fd < 0 && retry_count++ < PROXY_SVR_CON_RETRY_COUNT)
     {
       pthread_mutex_unlock (&proxy_conn_mutex);
       SLEEP_MILISEC (0, PROXY_SVR_CON_RETRY_MSEC);
       goto retry;
     }
+#endif /* !WINDOWS */
 
 #if !defined(WINDOWS)
   pthread_mutex_unlock (&proxy_conn_mutex);

--- a/src/broker/broker_proxy_conn.c
+++ b/src/broker/broker_proxy_conn.c
@@ -377,12 +377,12 @@ retry:
 	}
     }
 
-    if (shm_proxy_p->num_proxy > 0 && fd < 0 && retry_count++ < PROXY_SVR_CON_RETRY_COUNT)
-      {
-	pthread_mutex_unlock (&proxy_conn_mutex);
-	SLEEP_MILISEC (0, PROXY_SVR_CON_RETRY_MSEC);
-	goto retry;
-      }
+  if (shm_proxy_p->num_proxy > 0 && fd < 0 && retry_count++ < PROXY_SVR_CON_RETRY_COUNT)
+    {
+      pthread_mutex_unlock (&proxy_conn_mutex);
+      SLEEP_MILISEC (0, PROXY_SVR_CON_RETRY_MSEC);
+      goto retry;
+    }
 
 #if !defined(WINDOWS)
   pthread_mutex_unlock (&proxy_conn_mutex);

--- a/src/broker/broker_proxy_conn.c
+++ b/src/broker/broker_proxy_conn.c
@@ -380,7 +380,7 @@ retry:
     if (shm_proxy_p->num_proxy > 0 && fd < 0 && retry_count++ < PROXY_SVR_CON_RETRY_COUNT)
       {
 	pthread_mutex_unlock (&proxy_conn_mutex);
-	SLEEP_MILISEC (0, PROXY_WAIT_RETRY_MSEC);
+	SLEEP_MILISEC (0, PROXY_SVR_CON_RETRY_MSEC);
 	goto retry;
       }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24724

**Description**
* when a client want to connect proxy thru broker, it may fails because shard proxy is not ready at the moment
* This is because shard proxy need some time to connect to the database server

**Implementation**
* retry when available proxy connection is not found.
* retry unto 3 times, retry interval is 400 ms

**Remarks**
* I measured proxy availability using 200ms timeout.
* first 3 tries were failed, and 4th try to find proxy was successful, 
* On an average machine the proxy needs at least 600ms at boot time.
