### PR TITLE
[CBRD-24620] Add the code to fix the unexpected print

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -587,6 +587,8 @@ start_csql (CSQL_ARGUMENT * csql_arg)
 	  prompt = csql_Prompt_offline;
 	}
 
+      read_whole_line = false;
+
       memset (line_buf, 0, LINE_BUFFER_SIZE);
       memset (utf8_line_buf, 0, INTL_UTF8_MAX_CHAR_SIZE * LINE_BUFFER_SIZE);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24620

**Description**

The user typing that the below command to connect other users is not intuitive, while the CSQL session is connected;

CALL login ('user_name', 'password') ON CLASS db_user;
So, we should add the session command user to use more intuitive while the CSQL session is connected.

;connect user_name db_name@host_name
This can helps user to connect more intuitive while the CSQL session is connected
