### PR TITLE
[CBRD-24708] Fix segfault by OOB when converting PL variables to hv

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -3036,9 +3036,12 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 
 		parser_free_tree (parser, node);
 		node = hostvar;
+		*continue_walk = PT_LIST_WALK;
 	      }
-
-	    *continue_walk = PT_STOP_WALK;
+	    else
+	      {
+		*continue_walk = PT_STOP_WALK;
+	      }
 	  }
       }
       break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24708

When traversing symbols for PL variables in Static SQL, Parser must traverse to the end for parameterization of PL variables to avoid accessing the Out of bound of parser->host_variables array.