### PR TITLE
[CBRD-24620] Move the break position

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1486,12 +1486,12 @@ csql_do_session_cmd (char *line_read, CSQL_ARGUMENT * csql_arg)
 	    {
 	      return error_code;
 	    }
-	  break;
 	}
       else
 	{
 	  fprintf (csql_Output_fp, "CONNECT session command does not support --sysadm mode\n");
 	}
+      break;
     }
 
   return DO_CMD_SUCCESS;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24620

**Description**

The user typing that the below command to connect other users is not intuitive, while the CSQL session is connected;

CALL login ('user_name', 'password') ON CLASS db_user;
So, we should add the session command user to use more intuitive while the CSQL session is connected.

;connect user_name db_name@host_name
This can helps user to connect more intuitive while the CSQL session is connected
