### PR TITLE
[CBRD-24705] When attempting a covered index scan in a connect by query, encountering 'Execute: Query execution failure'

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15621,6 +15621,11 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 
       qfile_close_scan (thread_p, &lfscan_id);
 
+      if (scan_reset_scan_block (thread_p, &xasl->spec_list->s_id) == S_ERROR)
+	{
+	  GOTO_EXIT_ON_ERROR;
+	}
+
       if (qp_lfscan != S_END)
 	{
 	  GOTO_EXIT_ON_ERROR;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15621,9 +15621,20 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 
       qfile_close_scan (thread_p, &lfscan_id);
 
-      if (scan_reset_scan_block (thread_p, &xasl->spec_list->s_id) == S_ERROR)
+      if (xasl->spec_list->s_id.type == S_INDX_SCAN && SCAN_IS_INDEX_COVERED (&xasl->spec_list->s_id.s.isid))
 	{
-	  GOTO_EXIT_ON_ERROR;
+	  INDX_SCAN_ID *isidp = &xasl->spec_list->s_id.s.isid;
+
+	  /* close current list and start a new one */
+	  qfile_close_scan (thread_p, isidp->indx_cov.lsid);
+	  qfile_destroy_list (thread_p, isidp->indx_cov.list_id);
+	  isidp->indx_cov.list_id =
+	    qfile_open_list (thread_p, isidp->indx_cov.type_list, NULL, isidp->indx_cov.query_id, 0,
+			     isidp->indx_cov.list_id);
+	  if (isidp->indx_cov.list_id == NULL)
+	    {
+	      GOTO_EXIT_ON_ERROR;
+	    }
 	}
 
       if (qp_lfscan != S_END)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24705

When attempting a covered index scan in a connect by query, encountering 'Execute: Query execution failure'.
```
DROP TABLE IF EXISTS T1;
CREATE TABLE T1 (P1 INT, C1 INT, C2 VARCHAR);
CREATE INDEX I1 ON T1 (P1, C1, C2);
INSERT INTO T1 VALUES (0, 1, 'A');
INSERT INTO T1 VALUES (1, 2, 'B');
INSERT INTO T1 VALUES (2, 3, 'C');

SELECT /*+ RECOMPILE */ C1, C2 AS PATH
FROM T1
START WITH P1 = 0
CONNECT BY PRIOR C1 = P1;
/* ERROR: Execute: Query execution failure #15472. */
```

The issue is caused by not initializing the previously used `(INDX_SCAN_ID *)->indx_cov` when scanning with the next `QFILE_LIST_ID (listfile1)` in the qexec_execute_connect_by function.

To resolve the issue, add code to initialize `(INDX_SCAN_ID*)->indx_cov` after scanning `QFILE_LIST_ID (listfile1)`.

If scan_reset_scan_block function is executed, it cannot be used because `thread_p->m_qlist_count` only increases in case of non-covered index scan.

When scanning `QFILE_LIST_ID (listfile1)` for the first time, `(INDX_SCAN_ID*)->indx_cov` is initialized by executing scan_init_indx_coverage function.