### PR TITLE
[CBRD-24708] Fix type binding of parameterized PL/CSQL variable in Static SQL

### DIFF
--- a/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -2312,12 +2312,19 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
         // check (name-binding) and convert host variables used in the SQL
         if (sws.hostVars != null) {
             for (PlParamInfo pi : sws.hostVars) {
-                String sqlType = getSqlTypeNameFromCode(pi.type);
+                TypeSpec typeSpec = null;
+                String varName = Misc.getNormalizedText(pi.name);
+                if (pi.name.equals("?") == false && pi.type == DBType.DB_NULL) {
+                    // set PL/CSQL variable's type
+                    DeclVar var = symbolStack.getDeclVar(varName);
+                    typeSpec = var.typeSpec;
+                } else {
+                    String sqlType = getSqlTypeNameFromCode(pi.type);
+                    typeSpec = typeSpecs.get(sqlType);
+                }
 
-                String var = Misc.getNormalizedText(pi.name);
-                ExprId id = visitNonFuncIdentifier(var, ctx); // s408: undeclared id ...
+                ExprId id = visitNonFuncIdentifier(varName, ctx); // s408: undeclared id ...
 
-                TypeSpec typeSpec = typeSpecs.get(sqlType);
                 assert typeSpec != null;
                 hostVars.put(id, typeSpec);
             }

--- a/src/jsp/com/cubrid/plcsql/compiler/PlParamInfo.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/PlParamInfo.java
@@ -70,7 +70,8 @@ public class PlParamInfo {
         int has_value = unpacker.unpackInt();
         if (has_value == 1) {
             try {
-                this.value = unpacker.unpackValue(type, mode, type);
+                int paramType = unpacker.unpackInt();
+                this.value = unpacker.unpackValue(paramType);
             } catch (TypeMismatchException e) {
                 // TODO: error handling?
                 this.value = new NullValue();

--- a/src/jsp/com/cubrid/plcsql/compiler/SqlSemantics.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/SqlSemantics.java
@@ -102,10 +102,12 @@ public class SqlSemantics {
             }
         }
 
-        // TODO
         int intoVarsCnt = unpacker.unpackInt();
         if (intoVarsCnt > 0) {
             intoVars = new ArrayList<>();
+            for (int i = 0; i < intoVarsCnt; i++) {
+                intoVars.add(unpacker.unpackCString());
+            }
         }
     }
 }

--- a/src/jsp/com/cubrid/plcsql/compiler/SymbolStack.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/SymbolStack.java
@@ -290,6 +290,10 @@ public class SymbolStack {
         return getDecl(DeclProc.class, name);
     }
 
+    DeclVar getDeclVar(String name) {
+        return getDecl(DeclVar.class, name);
+    }
+
     DeclFunc getDeclFunc(String name) {
         DeclFunc ret = getDecl(DeclFunc.class, name);
         if (ret == null) {

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -407,7 +407,10 @@ namespace cubmethod
 	    const prepare_info &info = handler->get_prepare_info ();
 
 	    semantics.sql_type = info.stmt_type;
-	    semantics.rewritten_query = parser_print_tree (db_get_parser (db_session), db_get_statement (db_session, 0));
+
+	    PARSER_CONTEXT *parser = db_get_parser (db_session);
+	    PT_NODE *stmt = db_get_statement (db_session, 0);
+	    semantics.rewritten_query = parser_print_tree (parser, stmt);
 
 	    const std::vector<column_info> &column_infos = info.column_infos;
 	    for (const column_info &c_info : column_infos)
@@ -415,33 +418,52 @@ namespace cubmethod
 		semantics.columns.emplace_back (c_info);
 	      }
 
-	    int input_markers_cnt = db_number_of_input_markers (db_session, 1);
+	    int markers_cnt = parser->host_var_count + parser->auto_param_count;
 	    DB_MARKER *marker = db_get_input_markers (db_session, 1);
 
-	    std::vector <pl_parameter_info> &param_info = semantics.hvs;
-	    if (input_markers_cnt > 0)
+	    if (markers_cnt > 0)
 	      {
-		param_info.resize (input_markers_cnt);
+		semantics.hvs.resize (markers_cnt);
+
 		while (marker)
 		  {
 		    int idx = marker->info.host_var.index;
-
-		    pl_parameter_info &info = param_info[idx];
-
-		    info.mode = 1;
-		    if (marker->info.host_var.str)
+		    semantics.hvs[idx].mode = 1;
+		    if (marker->info.host_var.label)
 		      {
-			info.name = std::string ((char *) marker->info.host_var.str);
+			semantics.hvs[idx].name.assign ((char *) marker->info.host_var.label);
 		      }
 
-		    TP_DOMAIN *hv_expected_domain = db_session->parser->host_var_expected_domains[idx];
+		    TP_DOMAIN *hv_expected_domain = NULL;
+		    if (parser->host_var_count <= idx)
+		      {
+			// auto parameterized
+			hv_expected_domain = marker->expected_domain;
+		      }
+		    else
+		      {
+			hv_expected_domain = db_session->parser->host_var_expected_domains[idx];
+		      }
 
-		    // TODO: set type?!
+		    // safe guard
+		    if (hv_expected_domain == NULL)
+		      {
+			hv_expected_domain = pt_node_to_db_domain (parser, marker, NULL);
+		      }
 
-		    info.type = TP_DOMAIN_TYPE (hv_expected_domain);
-		    info.precision = db_domain_precision (hv_expected_domain);
-		    info.scale = (short) db_domain_scale (hv_expected_domain);
-		    info.charset = db_domain_codeset (hv_expected_domain);
+		    semantics.hvs[idx].type = TP_DOMAIN_TYPE (hv_expected_domain);
+		    semantics.hvs[idx].precision = db_domain_precision (hv_expected_domain);
+		    semantics.hvs[idx].scale = (short) db_domain_scale (hv_expected_domain);
+		    semantics.hvs[idx].charset = db_domain_codeset (hv_expected_domain);
+
+		    if (db_session->parser->host_variables[idx].domain.general_info.is_null == 0)
+		      {
+			pr_clone_value (& (db_session->parser->host_variables[idx]), & (semantics.hvs[idx].value));
+		      }
+		    else
+		      {
+			db_make_null (& (semantics.hvs[idx].value));
+		      }
 
 		    marker = db_marker_next (marker);
 		  }

--- a/src/method/method_compile.cpp
+++ b/src/method/method_compile.cpp
@@ -326,15 +326,19 @@ exit:
   }
 
   pl_parameter_info::pl_parameter_info ()
+    : mode (0)
+    , name ("?")
+    , type (DB_TYPE_NULL)
+    , precision (0)
+    , scale (0)
+    , charset (0)
   {
-    name = "?";
-    mode = 0;
-    type = DB_TYPE_NULL;
-    precision = 0;
-    scale = 0;
-    charset = 0;
+    db_make_null (&value);
+  }
 
-    value = NULL;
+  pl_parameter_info::~pl_parameter_info ()
+  {
+    db_value_clear (&value);
   }
 
   void
@@ -349,11 +353,11 @@ exit:
     serializator.pack_int (scale);
     serializator.pack_int (charset);
 
-    if (value != NULL)
+    if (value.domain.general_info.is_null == 0)
       {
 	dbvalue_java sp_val;
 	serializator.pack_int (1);
-	sp_val.value = value;
+	sp_val.value = (DB_VALUE *) &value;
 	sp_val.pack (serializator);
       }
     else
@@ -375,10 +379,10 @@ exit:
     size += serializator.get_packed_int_size (size); // charset
 
     size += serializator.get_packed_int_size (size); // value is null
-    if (value != NULL)
+    if (value.domain.general_info.is_null == 0)
       {
 	dbvalue_java sp_val;
-	sp_val.value = value;
+	sp_val.value = (DB_VALUE *) &value;
 	size += sp_val.get_packed_size (serializator, size);
       }
 
@@ -390,7 +394,4 @@ exit:
   {
     //
   }
-
-
-
 }

--- a/src/method/method_compile.hpp
+++ b/src/method/method_compile.hpp
@@ -83,6 +83,7 @@ namespace cubmethod
   struct EXPORT_IMPORT pl_parameter_info : public cubpacking::packable_object
   {
     pl_parameter_info ();
+    ~pl_parameter_info ();
 
     void pack (cubpacking::packer &serializator) const override;
     void unpack (cubpacking::unpacker &deserializator) override;
@@ -96,7 +97,7 @@ namespace cubmethod
     int scale;
     int charset;
 
-    DB_VALUE *value; // only for auto parameterized
+    DB_VALUE value; // only for auto parameterized
   };
 
 #if defined (SERVER_MODE) || defined (SA_MODE)

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -787,7 +787,7 @@ namespace cubmethod
 
     if (flag & PREPARE_STATIC_SQL)
       {
-	get_db_session()->parser->flag.do_late_binding = 1;
+	get_db_session()->parser->flag.is_parsing_static_sql = 1;
       }
 
     m_stmt_type = CUBRID_STMT_NONE;

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -10565,7 +10565,7 @@ pt_parameterize_for_static_sql (PARSER_CONTEXT * parser, PT_NODE * name_node)
   hostvar->info.host_var.label = pt_append_string (parser, NULL, name_node->info.name.original);
   hostvar->info.host_var.var_type = PT_HOST_IN;
   hostvar->info.host_var.index = parser->host_var_count;
-  hostvar->type_enum = DB_TYPE_UNKNOWN;
+  hostvar->type_enum = PT_TYPE_NONE;
 
   // Expand parser->host_variables by realloc
   int count_to_realloc = parser->host_var_count + 1;
@@ -10592,7 +10592,7 @@ pt_parameterize_for_static_sql (PARSER_CONTEXT * parser, PT_NODE * name_node)
   parser->host_var_expected_domains = larger_host_var_expected_domains;
 
   db_make_null (&parser->host_variables[parser->host_var_count]);
-  parser->host_var_expected_domains[parser->host_var_count] = pt_type_enum_to_db_domain (PT_TYPE_UNKNOWN);
+  parser->host_var_expected_domains[parser->host_var_count] = pt_type_enum_to_db_domain (PT_TYPE_NONE);
 
   ++parser->host_var_count;
   larger_host_variables = NULL;
@@ -10601,5 +10601,5 @@ pt_parameterize_for_static_sql (PARSER_CONTEXT * parser, PT_NODE * name_node)
   PT_NODE_MOVE_NUMBER_OUTERLINK (hostvar, name_node);
   parser_free_tree (parser, name_node);
 
-  return host_var;
+  return hostvar;
 }

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -2988,7 +2988,7 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 	  }
 	else
 	  {
-	    if (parser->flag.do_late_binding == 1 && er_errid () == ER_OBJ_INVALID_ATTRIBUTE)
+	    if (parser->flag.is_parsing_static_sql == 1 && er_errid () == ER_OBJ_INVALID_ATTRIBUTE)
 	      {
 		// do late binding to check the name by PL/CSQL compiler.
 		er_clear ();

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -245,6 +245,8 @@ static void pt_set_attr_list_types (PARSER_CONTEXT * parser, PT_NODE * as_attr_l
 static PT_NODE *pt_count_with_clauses (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static int pt_resolve_dblink_server_name (PARSER_CONTEXT * parser, PT_NODE * node);
 
+static PT_NODE *pt_parameterize_for_static_sql (PARSER_CONTEXT * parser, PT_NODE * node);
+
 /*
  * pt_undef_names_pre () - Set error if name matching spec is found. Used in
  *			   insert to make sure no "correlated" names are used
@@ -2990,56 +2992,11 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 	  {
 	    if (parser->flag.is_parsing_static_sql == 1 && er_errid () == ER_OBJ_INVALID_ATTRIBUTE)
 	      {
-		// do late binding to check the name by PL/CSQL compiler.
+		// clear unknown attribute error, the unknown symbol will be converted (paramterized) to host variable
 		er_clear ();
 		pt_reset_error (parser);
 
-		PT_NODE *hostvar = parser_new_node (parser, PT_HOST_VAR);
-		hostvar->info.host_var.str = pt_append_string (parser, NULL, "?");
-		hostvar->info.host_var.label = pt_append_string (parser, NULL, node->info.name.original);
-
-		hostvar->info.host_var.var_type = PT_HOST_IN;
-
-		hostvar->info.host_var.index = parser->host_var_count;
-		hostvar->type_enum = DB_TYPE_UNKNOWN;
-
-		// Expand parser->host_variables by realloc
-		int count_to_realloc = parser->host_var_count + 1;
-
-		/* We actually allocate around twice more than needed so that we don't do useless copies too often. */
-		count_to_realloc = (count_to_realloc / 2) * 4;
-
-		if (count_to_realloc == 0)
-		  {
-		    count_to_realloc = 1;
-		  }
-
-		DB_VALUE *larger_host_variables =
-		  (DB_VALUE *) realloc (parser->host_variables, count_to_realloc * sizeof (DB_VALUE));
-		if (larger_host_variables == NULL)
-		  {
-		    PT_ERRORm (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
-		    return NULL;
-		  }
-
-		TP_DOMAIN **larger_host_var_expected_domains =
-		  (TP_DOMAIN **) realloc (parser->host_var_expected_domains, count_to_realloc * sizeof (TP_DOMAIN *));
-
-		parser->host_variables = larger_host_variables;
-		parser->host_var_expected_domains = larger_host_var_expected_domains;
-
-		db_make_null (&parser->host_variables[parser->host_var_count]);
-		parser->host_var_expected_domains[parser->host_var_count] = pt_type_enum_to_db_domain (PT_TYPE_NONE);
-
-		++parser->host_var_count;
-		larger_host_variables = NULL;
-		larger_host_var_expected_domains = NULL;
-
-		PT_NODE_MOVE_NUMBER_OUTERLINK (hostvar, node);
-
-		parser_free_tree (parser, node);
-
-		node = hostvar;
+		node = pt_parameterize_for_static_sql (parser, node);
 
 		/* don't visit leaves */
 		*continue_walk = PT_LIST_WALK;
@@ -10598,4 +10555,51 @@ pt_resolve_dblink_server_name (PARSER_CONTEXT * parser, PT_NODE * node)
   pr_clear_value (&(values[2]));
 
   return NO_ERROR;
+}
+
+static PT_NODE *
+pt_parameterize_for_static_sql (PARSER_CONTEXT * parser, PT_NODE * name_node)
+{
+  PT_NODE *hostvar = parser_new_node (parser, PT_HOST_VAR);
+  hostvar->info.host_var.str = pt_append_string (parser, NULL, "?");
+  hostvar->info.host_var.label = pt_append_string (parser, NULL, name_node->info.name.original);
+  hostvar->info.host_var.var_type = PT_HOST_IN;
+  hostvar->info.host_var.index = parser->host_var_count;
+  hostvar->type_enum = DB_TYPE_UNKNOWN;
+
+  // Expand parser->host_variables by realloc
+  int count_to_realloc = parser->host_var_count + 1;
+
+  /* We actually allocate around twice more than needed so that we don't do useless copies too often. */
+  count_to_realloc = (count_to_realloc / 2) * 4;
+
+  if (count_to_realloc == 0)
+    {
+      count_to_realloc = 1;
+    }
+
+  DB_VALUE *larger_host_variables = (DB_VALUE *) realloc (parser->host_variables, count_to_realloc * sizeof (DB_VALUE));
+  if (larger_host_variables == NULL)
+    {
+      PT_ERRORm (parser, name_node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+      return NULL;
+    }
+
+  TP_DOMAIN **larger_host_var_expected_domains =
+    (TP_DOMAIN **) realloc (parser->host_var_expected_domains, count_to_realloc * sizeof (TP_DOMAIN *));
+
+  parser->host_variables = larger_host_variables;
+  parser->host_var_expected_domains = larger_host_var_expected_domains;
+
+  db_make_null (&parser->host_variables[parser->host_var_count]);
+  parser->host_var_expected_domains[parser->host_var_count] = pt_type_enum_to_db_domain (PT_TYPE_UNKNOWN);
+
+  ++parser->host_var_count;
+  larger_host_variables = NULL;
+  larger_host_var_expected_domains = NULL;
+
+  PT_NODE_MOVE_NUMBER_OUTERLINK (hostvar, name_node);
+  parser_free_tree (parser, name_node);
+
+  return host_var;
 }

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -2995,11 +2995,13 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 		pt_reset_error (parser);
 
 		PT_NODE *hostvar = parser_new_node (parser, PT_HOST_VAR);
-		hostvar->info.host_var.str = pt_append_string (parser, NULL, node->info.name.original);
+		hostvar->info.host_var.str = pt_append_string (parser, NULL, "?");
+		hostvar->info.host_var.label = pt_append_string (parser, NULL, node->info.name.original);
+
 		hostvar->info.host_var.var_type = PT_HOST_IN;
-		// hostvar->etc = (void *) pt_append_string (parser, NULL, node->info.name.original);
+
 		hostvar->info.host_var.index = parser->host_var_count;
-		hostvar->type_enum = PT_TYPE_MAYBE;
+		hostvar->type_enum = DB_TYPE_UNKNOWN;
 
 		// Expand parser->host_variables by realloc
 		int count_to_realloc = parser->host_var_count + 1;
@@ -3027,6 +3029,7 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 		parser->host_var_expected_domains = larger_host_var_expected_domains;
 
 		db_make_null (&parser->host_variables[parser->host_var_count]);
+		parser->host_var_expected_domains[parser->host_var_count] = pt_type_enum_to_db_domain (PT_TYPE_NONE);
 
 		++parser->host_var_count;
 		larger_host_variables = NULL;
@@ -3035,7 +3038,10 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 		PT_NODE_MOVE_NUMBER_OUTERLINK (hostvar, node);
 
 		parser_free_tree (parser, node);
+
 		node = hostvar;
+
+		/* don't visit leaves */
 		*continue_walk = PT_LIST_WALK;
 	      }
 	    else

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3887,7 +3887,7 @@ struct parser_context
     unsigned return_generated_keys:1;
     unsigned is_system_generated_stmt:1;
     unsigned is_auto_commit:1;	/* set to true, if auto commit. */
-    unsigned is_parsing_static_sql:1;	/* do late binding for a name */
+    unsigned is_parsing_static_sql:1;	/* For PL/CSQL's static SQL: parameterize PL/CSQL variable symbols (to host variable) */
   } flag;
 };
 

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3887,7 +3887,7 @@ struct parser_context
     unsigned return_generated_keys:1;
     unsigned is_system_generated_stmt:1;
     unsigned is_auto_commit:1;	/* set to true, if auto commit. */
-    unsigned do_late_binding:1;	/* do late binding for a name */
+    unsigned is_parsing_static_sql:1;	/* do late binding for a name */
   } flag;
 };
 

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2472,6 +2472,7 @@ struct pt_host_var_info
   const char *str;		/* ??? */
   PT_MISC_TYPE var_type;	/* PT_HOST_IN, PT_HOST_OUT, */
   int index;			/* for PT_HOST_VAR ordering */
+  const char *label;
 };
 
 /* Info for lists of PT_NODE */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24708

Host variables, not character types, have a null expected domain, so the type binding of parameterized PL/CSQL variable name is not properly resolved.

In the following, the code is an integer type, so the expected domain is set as tp_null (null domain). In the db_push_values (setting host variable value when executing the query), If the domain is null, It just tries to coerce the value at the time. So I've changed the routine to bind host variable's type in PL/CSQL compiler module
```
create or replace function test_typebinding() return string as
    n char(3) := 'KOR';

    g varchar;
    c int := 10615;
    m varchar;
begin
    select gender, name into g, m from athlete where nation_code = n and code = c;
    return m;

exception
when no_data_found then
    return 'no_data_found';
when too_many_rows then
    return 'too_many_rows ';
when others then
    return 'others';
end;
```