### PR TITLE
[CBRD-24735] When attempting 'Multiple Key Ranges Optimization (MRO)', An internal error occurs because the '1=1' predicate (data filer) generated by constant folding is not removed

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -357,6 +357,7 @@ extern "C"
   extern void pt_resolve_object (PARSER_CONTEXT * parser, PT_NODE * node);
   extern int pt_resolved (const PT_NODE * expr);
   extern bool pt_false_where (PARSER_CONTEXT * parser, PT_NODE * statement);
+  extern PT_NODE *pt_do_where_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
   extern PT_NODE *pt_where_type (PARSER_CONTEXT * parser, PT_NODE * where);
   extern PT_NODE *pt_where_type_keep_true (PARSER_CONTEXT * parser, PT_NODE * where);
   extern bool pt_false_search_condition (PARSER_CONTEXT * parser, const PT_NODE * statement);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -20358,6 +20358,8 @@ pt_semantic_type (PARSER_CONTEXT * parser, PT_NODE * tree, SEMANTIC_CHK_INFO * s
   tree = parser_walk_tree (parser, tree, pt_eval_type_pre, sc_info_ptr, pt_eval_type, sc_info_ptr);
   /* do constant folding */
   tree = parser_walk_tree (parser, tree, pt_fold_constants_pre, NULL, pt_fold_constants_post, sc_info_ptr);
+  /* do type checking again */
+  tree = parser_walk_tree (parser, tree, pt_fold_constants_pre, NULL, pt_fold_constants_post, sc_info_ptr);
   if (pt_has_error (parser))
     {
       tree = NULL;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -20359,7 +20359,7 @@ pt_semantic_type (PARSER_CONTEXT * parser, PT_NODE * tree, SEMANTIC_CHK_INFO * s
   /* do constant folding */
   tree = parser_walk_tree (parser, tree, pt_fold_constants_pre, NULL, pt_fold_constants_post, sc_info_ptr);
   /* do type checking again */
-  tree = parser_walk_tree (parser, tree, pt_fold_constants_pre, NULL, pt_fold_constants_post, sc_info_ptr);
+  tree = parser_walk_tree (parser, tree, pt_eval_type_pre, sc_info_ptr, pt_eval_type, sc_info_ptr);
   if (pt_has_error (parser))
     {
       tree = NULL;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -20408,7 +20408,7 @@ pt_semantic_type (PARSER_CONTEXT * parser, PT_NODE * tree, SEMANTIC_CHK_INFO * s
    * 
    * If this predicate remains without being removed, it becomes a data filter and MRO cannot be performed.
    *
-   * See CBRD-23983 for the details.
+   * See CBRD-24735 for the details.
    */
   tree = parser_walk_tree (parser, tree, NULL, NULL, pt_do_where_type, sc_info_ptr);
   if (pt_has_error (parser))

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -6808,8 +6808,6 @@ pt_product_sets (PARSER_CONTEXT * parser, TP_DOMAIN * domain, DB_VALUE * set1, D
 PT_NODE *
 pt_do_where_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
 {
-  SEMANTIC_CHK_INFO *sc_info = (SEMANTIC_CHK_INFO *) arg;
-
   PT_NODE *spec = NULL;
 
   if (node == NULL)
@@ -20410,7 +20408,7 @@ pt_semantic_type (PARSER_CONTEXT * parser, PT_NODE * tree, SEMANTIC_CHK_INFO * s
    *
    * See CBRD-24735 for the details.
    */
-  tree = parser_walk_tree (parser, tree, NULL, NULL, pt_do_where_type, sc_info_ptr);
+  tree = parser_walk_tree (parser, tree, NULL, NULL, pt_do_where_type, NULL);
   if (pt_has_error (parser))
     {
       tree = NULL;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -6797,6 +6797,46 @@ pt_product_sets (PARSER_CONTEXT * parser, TP_DOMAIN * domain, DB_VALUE * set1, D
   return (!pt_has_error (parser));
 }
 
+/*
+ * pt_do_where_type () -
+ *   return:
+ *   parser(in):
+ *   node(in):
+ *   arg(in):
+ *   continue_walk(in):
+ */
+PT_NODE *
+pt_do_where_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
+{
+  SEMANTIC_CHK_INFO *sc_info = (SEMANTIC_CHK_INFO *) arg;
+
+  PT_NODE *spec = NULL;
+
+  if (node == NULL)
+    {
+      return NULL;
+    }
+
+  switch (node->node_type)
+    {
+    case PT_SELECT:
+      for (spec = node->info.query.q.select.from; spec; spec = spec->next)
+	{
+	  if (spec->node_type == PT_SPEC && spec->info.spec.on_cond)
+	    {
+	      spec->info.spec.on_cond = pt_where_type (parser, spec->info.spec.on_cond);
+	    }
+	}
+
+      node->info.query.q.select.where = pt_where_type (parser, node->info.query.q.select.where);
+      break;
+
+    default:
+      break;
+    }
+
+  return node;
+}
 
 /*
  * pt_where_type () - Test for constant folded where clause,
@@ -20358,8 +20398,19 @@ pt_semantic_type (PARSER_CONTEXT * parser, PT_NODE * tree, SEMANTIC_CHK_INFO * s
   tree = parser_walk_tree (parser, tree, pt_eval_type_pre, sc_info_ptr, pt_eval_type, sc_info_ptr);
   /* do constant folding */
   tree = parser_walk_tree (parser, tree, pt_fold_constants_pre, NULL, pt_fold_constants_post, sc_info_ptr);
-  /* do type checking again */
-  tree = parser_walk_tree (parser, tree, pt_eval_type_pre, sc_info_ptr, pt_eval_type, sc_info_ptr);
+  if (pt_has_error (parser))
+    {
+      tree = NULL;
+    }
+
+  /* When pt_lambda_node is executed in mq_optimize, a removable predicate like '1=1' is generated.
+   * This predicate is removed by executing pt_where_type after pt_fold_const_expr has executed.
+   * 
+   * If this predicate remains without being removed, it becomes a data filter and MRO cannot be performed.
+   *
+   * See CBRD-23983 for the details.
+   */
+  tree = parser_walk_tree (parser, tree, NULL, NULL, pt_do_where_type, sc_info_ptr);
   if (pt_has_error (parser))
     {
       tree = NULL;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -20401,10 +20401,11 @@ pt_semantic_type (PARSER_CONTEXT * parser, PT_NODE * tree, SEMANTIC_CHK_INFO * s
       tree = NULL;
     }
 
-  /* When pt_lambda_node is executed in mq_optimize, a removable predicate like '1=1' is generated.
+  /* When qo_reduce_equality_terms is executed in mq_optimize, a removable predicate like '1=1' is generated.
    * This predicate is removed by executing pt_where_type after pt_fold_const_expr has executed.
    * 
-   * If this predicate remains without being removed, it becomes a data filter and MRO cannot be performed.
+   * If this predicate remains without being removed, it becomes a data filter and MRO (Multiple Key Ranges
+   * Optimization) cannot be performed.
    *
    * See CBRD-24735 for the details.
    */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24735

When the pt_semantic_type function runs after rewriting the query, it runs pt_where_type after the fold constant to see if there are any predicates that can be removed.

In the query below, the `1=1` predicate generated after rewriting the query should be removed.
```
pt_semantic_check: select ... from t0 inner join t1 t on t0.c1=t.c1 and t0.c1=1         where t.c1=1                                    order by 1 limit 1;
mq_translate:      select ... from t0 inner join t1 t                                   where t.c1=1 and t0.c1=t.c1 and t0.c1=1         order by 1 limit 1;
mq_optimize:       select ... from t0 inner join t1 t                                   where t.c1=1 and t0.c1=t.c1 and t0.c1=1 and 1=1 order by 1 limit 1;
    qo_reduce_equality_terms: t.c1=1 and t0.c1=t.c1 and t0.c1=1 (join_term_list: t0.c1=t.c1)
    qo_reduce_equality_terms: t.c1=1 and 1=1 and t0.c1=1        (join_term_list: t0.c1=t.c1)
    qo_reduce_equality_terms: t.c1=1 and t0.c1=t.c1 and t0.c1=1 and t0.c1=t.c1
pt_semantic_type:  select ... from t0 inner join t1 t on t0.c1=t.c1 and t0.c1=1 and 1=1 where t.c1=1                                    order by 1 limit 1;
```