### PR TITLE
[CBRD-24729] Support API for into-lists of Static SQL

### DIFF
--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -446,6 +446,20 @@ namespace cubmethod
 		    marker = db_marker_next (marker);
 		  }
 	      }
+
+	    // into variable
+	    char **external_into_label = db_session->parser->external_into_label;
+	    if (external_into_label)
+	      {
+		for (int i = 0; i < db_session->parser->external_into_label_cnt; i++)
+		  {
+		    semantics.into_vars.push_back (external_into_label[i]);
+		    free (external_into_label[i]);
+		  }
+		free (external_into_label);
+	      }
+	    db_session->parser->external_into_label = NULL;
+	    db_session->parser->external_into_label_cnt = 0;
 	  }
 	else
 	  {

--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -1225,6 +1225,9 @@ parser_create_parser (void)
   parser->max_print_len = 0;
   parser->flag.is_auto_commit = 0;
 
+  parser->external_into_label = NULL;
+  parser->external_into_label_cnt = 0;
+
   return parser;
 }
 

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3861,6 +3861,9 @@ struct parser_context
 
   int max_print_len;		/* for pt_short_print */
 
+  char **external_into_label;
+  int external_into_label_cnt;
+
   struct
   {
     unsigned has_internal_error:1;	/* 0 or 1 */

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -9927,6 +9927,8 @@ static void
 pt_check_into_clause_for_static_sql (PARSER_CONTEXT * parser, PT_NODE * qry, int into_cnt)
 {
   // set external into labels in parser context
+  PT_NODE *into = qry->info.query.into_list;
+
   char **external_into_label = (char **) malloc (into_cnt * sizeof (char *));
   for (int i = 0; i < into_cnt; i++)
     {

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -9918,6 +9918,30 @@ pt_check_single_valued_node_post (PARSER_CONTEXT * parser, PT_NODE * node, void 
 }
 
 /*
+ * pt_check_into_clause_for_static_sql ()
+ *   return:  none
+ *   parser(in): the parser context used to derive the statement
+ *   qry(in): a SELECT/UNION/INTERSECTION/DIFFERENCE statement
+ */
+static void
+pt_check_into_clause_for_static_sql (PARSER_CONTEXT * parser, PT_NODE * qry, int into_cnt)
+{
+  // set external into labels in parser context
+  char **external_into_label = (char **) malloc (into_cnt * sizeof (char *));
+  for (int i = 0; i < into_cnt; i++)
+    {
+      external_into_label[i] = (char *) malloc (sizeof (char) * 255);
+      strncpy (external_into_label[i], into->info.name.original, 254);
+      into = into->next;
+    }
+  parser->external_into_label_cnt = into_cnt;
+  parser->external_into_label = external_into_label;
+
+  parser_free_tree (parser, qry->info.query.into_list);
+  qry->info.query.into_list = NULL;
+}
+
+/*
  * pt_check_into_clause () - check arity of any into_clause
  *                           equals arity of query
  *   return:  none
@@ -9951,6 +9975,11 @@ pt_check_into_clause (PARSER_CONTEXT * parser, PT_NODE * qry)
   if (tgt_cnt != col_cnt)
     {
       PT_ERRORmf2 (parser, into, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_COL_CNT_NE_INTO_CNT, col_cnt, tgt_cnt);
+    }
+
+  if (parser->flag.do_late_binding)
+    {
+      pt_check_into_clause_for_static_sql (parser, qry, tgt_cnt);
     }
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24729

- Add external_label_variable array to store into lists symbol names
- Remove the into_list node from the parser tree if the flag (PL/CSQL compiler is parsing static sql) is on
- The API to receive the into lists label information is already implemented in ServerAPI.java (Java SP) class