### PR TITLE
[CBRD-24721] Improve the sql logging in HA

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -391,6 +391,10 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_HA_SQL_LOG_MAX_SIZE_IN_MB "ha_sql_log_max_size_in_mbytes"
 
+#define PRM_NAME_HA_SQL_LOG_PATH "ha_sql_log_path"
+
+#define PRM_NAME_HA_SQL_LOG_KEEP_COUNT "ha_sql_log_keep_count"
+
 #define PRM_NAME_HA_COPY_LOG_MAX_ARCHIVES "ha_copy_log_max_archives"
 
 #define PRM_NAME_HA_COPY_LOG_TIMEOUT "ha_copy_log_timeout"
@@ -1482,6 +1486,16 @@ static unsigned int prm_ha_applylogdb_log_wait_time_in_secs_flag = 0;
 bool PRM_HA_SQL_LOGGING = false;
 static bool prm_ha_sql_logging_default = false;
 static unsigned int prm_ha_sql_logging_flag = 0;
+
+const char *PRM_HA_SQL_LOG_PATH = "";
+static char *prm_ha_sql_log_path_default = NULL;
+static unsigned int prm_ha_sql_log_path_flag = 0;
+
+int PRM_HA_SQL_LOG_KEEP_COUNT = 2;
+static int prm_ha_sql_log_keep_count_default = 2;
+static int prm_ha_sql_log_keep_count_upper = INT_MAX;
+static int prm_ha_sql_log_keep_count_lower = 0;
+static unsigned int prm_ha_sql_log_keep_count_flag = 0;
 
 int PRM_HA_SQL_LOG_MAX_SIZE_IN_MB = INT_MIN;
 static int prm_ha_sql_log_max_size_in_mb_default = 50;
@@ -6226,6 +6240,29 @@ SYSPRM_PARAM prm_Def[] = {
    (void *) &prm_statdump_force_add_int_max_default,
    (void *) &PRM_STATDUMP_FORCE_ADD_INT_MAX,
    (void *) NULL, (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_HA_SQL_LOG_PATH,
+   PRM_NAME_HA_SQL_LOG_PATH,
+   (PRM_FOR_CLIENT | PRM_FOR_HA | PRM_HIDDEN),
+   PRM_STRING,
+   &prm_ha_sql_log_path_flag,
+   (void *) &prm_ha_sql_log_path_default,
+   (void *) &PRM_HA_SQL_LOG_PATH,
+   (void *) NULL, (void *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_HA_SQL_LOG_KEEP_COUNT,
+   PRM_NAME_HA_SQL_LOG_KEEP_COUNT,
+   (PRM_FOR_CLIENT | PRM_FOR_HA | PRM_HIDDEN),
+   PRM_INTEGER,
+   &prm_ha_sql_log_keep_count_flag,
+   (void *) &prm_ha_sql_log_keep_count_default,
+   (void *) &PRM_HA_SQL_LOG_KEEP_COUNT,
+   (void *) &prm_ha_sql_log_keep_count_upper,
+   (void *) &prm_ha_sql_log_keep_count_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL}

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1493,8 +1493,8 @@ static unsigned int prm_ha_sql_log_path_flag = 0;
 
 int PRM_HA_SQL_LOG_KEEP_COUNT = 2;
 static int prm_ha_sql_log_keep_count_default = 2;
-static int prm_ha_sql_log_keep_count_upper = INT_MAX;
-static int prm_ha_sql_log_keep_count_lower = 0;
+static int prm_ha_sql_log_keep_count_upper = 5;
+static int prm_ha_sql_log_keep_count_lower = 2;
 static unsigned int prm_ha_sql_log_keep_count_flag = 0;
 
 int PRM_HA_SQL_LOG_MAX_SIZE_IN_MB = INT_MIN;
@@ -6245,7 +6245,7 @@ SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_HA_SQL_LOG_PATH,
    PRM_NAME_HA_SQL_LOG_PATH,
-   (PRM_FOR_CLIENT | PRM_FOR_HA | PRM_HIDDEN),
+   (PRM_FOR_CLIENT | PRM_FOR_HA),
    PRM_STRING,
    &prm_ha_sql_log_path_flag,
    (void *) &prm_ha_sql_log_path_default,
@@ -6256,7 +6256,7 @@ SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_HA_SQL_LOG_KEEP_COUNT,
    PRM_NAME_HA_SQL_LOG_KEEP_COUNT,
-   (PRM_FOR_CLIENT | PRM_FOR_HA | PRM_HIDDEN),
+   (PRM_FOR_CLIENT | PRM_FOR_HA),
    PRM_INTEGER,
    &prm_ha_sql_log_keep_count_flag,
    (void *) &prm_ha_sql_log_keep_count_default,

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -393,7 +393,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_HA_SQL_LOG_PATH "ha_sql_log_path"
 
-#define PRM_NAME_HA_SQL_LOG_KEEP_COUNT "ha_sql_log_keep_count"
+#define PRM_NAME_HA_SQL_LOG_MAX_COUNT "ha_sql_log_max_count"
 
 #define PRM_NAME_HA_COPY_LOG_MAX_ARCHIVES "ha_copy_log_max_archives"
 
@@ -1491,11 +1491,11 @@ const char *PRM_HA_SQL_LOG_PATH = "";
 static char *prm_ha_sql_log_path_default = NULL;
 static unsigned int prm_ha_sql_log_path_flag = 0;
 
-int PRM_HA_SQL_LOG_KEEP_COUNT = 2;
-static int prm_ha_sql_log_keep_count_default = 2;
-static int prm_ha_sql_log_keep_count_upper = 5;
-static int prm_ha_sql_log_keep_count_lower = 2;
-static unsigned int prm_ha_sql_log_keep_count_flag = 0;
+int PRM_HA_SQL_LOG_MAX_COUNT = 2;
+static int prm_ha_sql_log_max_count_default = 2;
+static int prm_ha_sql_log_max_count_upper = 5;
+static int prm_ha_sql_log_max_count_lower = 2;
+static unsigned int prm_ha_sql_log_max_count_flag = 0;
 
 int PRM_HA_SQL_LOG_MAX_SIZE_IN_MB = INT_MIN;
 static int prm_ha_sql_log_max_size_in_mb_default = 50;
@@ -6254,15 +6254,15 @@ SYSPRM_PARAM prm_Def[] = {
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},
-  {PRM_ID_HA_SQL_LOG_KEEP_COUNT,
-   PRM_NAME_HA_SQL_LOG_KEEP_COUNT,
+  {PRM_ID_HA_SQL_LOG_MAX_COUNT,
+   PRM_NAME_HA_SQL_LOG_MAX_COUNT,
    (PRM_FOR_CLIENT | PRM_FOR_HA),
    PRM_INTEGER,
-   &prm_ha_sql_log_keep_count_flag,
-   (void *) &prm_ha_sql_log_keep_count_default,
-   (void *) &PRM_HA_SQL_LOG_KEEP_COUNT,
-   (void *) &prm_ha_sql_log_keep_count_upper,
-   (void *) &prm_ha_sql_log_keep_count_lower,
+   &prm_ha_sql_log_max_count_flag,
+   (void *) &prm_ha_sql_log_max_count_default,
+   (void *) &PRM_HA_SQL_LOG_MAX_COUNT,
+   (void *) &prm_ha_sql_log_max_count_upper,
+   (void *) &prm_ha_sql_log_max_count_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL}

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -469,8 +469,10 @@ enum param_id
   PRM_ID_HA_TCP_PING_HOSTS,
   PRM_ID_HA_PING_TIMEOUT,
   PRM_ID_STATDUMP_FORCE_ADD_INT_MAX,	/* Hidden parameter for QA only */
+  PRM_ID_HA_SQL_LOG_PATH,
+  PRM_ID_HA_SQL_LOG_KEEP_COUNT,
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_STATDUMP_FORCE_ADD_INT_MAX
+  PRM_LAST_ID = PRM_ID_HA_SQL_LOG_KEEP_COUNT
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -470,9 +470,9 @@ enum param_id
   PRM_ID_HA_PING_TIMEOUT,
   PRM_ID_STATDUMP_FORCE_ADD_INT_MAX,	/* Hidden parameter for QA only */
   PRM_ID_HA_SQL_LOG_PATH,
-  PRM_ID_HA_SQL_LOG_KEEP_COUNT,
+  PRM_ID_HA_SQL_LOG_MAX_COUNT,
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_HA_SQL_LOG_KEEP_COUNT
+  PRM_LAST_ID = PRM_ID_HA_SQL_LOG_MAX_COUNT
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/transaction/log_applier_sql_log.c
+++ b/src/transaction/log_applier_sql_log.c
@@ -638,9 +638,8 @@ sl_open_next_file (FILE * old_fp)
  *   return: error code
  *
  * Note:
- *   This function is related to the ha_sql_log_keep_count hidden system parameter.
- *   If this is set to zero, then sql log files are not deleted.
- *   If this is set to non-zero, then only that number of sql log files are kept.
+ *   This function is related to the ha_sql_log_keep_count system parameter.
+ *   This system parameter can be set from 2 to 5 and only that number of sql log files are kept.
  */
 static int
 sl_remove_oldest_file (void)

--- a/src/transaction/log_applier_sql_log.c
+++ b/src/transaction/log_applier_sql_log.c
@@ -725,11 +725,10 @@ sl_create_sql_log_dir (const char *repl_log_path, char *path_buf, int path_buf_s
 	    {
 	      if (mkdir (path_buf, 0777) < 0)
 		{
-		  snprintf (er_msg, sizeof (er_msg), "Failed to create SQL log directory \'%s\' (%s)", path_buf,
-			    strerror (errno));
+		  snprintf (er_msg, sizeof (er_msg), "Failed to create SQL log directory \'%s\'", path_buf);
 
 		  er_stack_push ();
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, er_msg);
+		  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, er_msg);
 		  er_stack_pop ();
 
 		  return ER_FAILED;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24721

Purpose
* make a limitation of the number of the sql log files generated by applylogdb when ha_enable_sql_logging=y
  * no limitation now
* support a way to set the path of this files
* for this, two system parameters ha_sql_log_path and ha_sql_log_keep_count are introduced

Implementation
* see the changed code

Remarks
* the case which the sql log file id overflows the maximum integer range will be handled in another PR in sub-task
* If reviewers see the attached test scenarios in the jira, then they can easily understand the changed behaviors of sql logging
