### PR TITLE
[CBRD-24096] A core dump occurs when cas writes a log after receiving a sigkill signal.

### DIFF
--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1721,7 +1721,7 @@ cas_free (bool from_sighandler)
 	    }
 	  else
 	    {
-	      cas_log_open_and_write (broker_name .0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED HARD LIMIT (%dM)",
+	      cas_log_open_and_write (broker_name, 0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED HARD LIMIT (%dM)",
 				      as_info->pdh_workset / ONE_K, shm_appl->appl_server_hard_limit / ONE_K);
 	    }
 	}

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1699,21 +1699,46 @@ cas_free (bool from_sighandler)
     {
       if ((as_info->pid == as_info->pdh_pid) && (as_info->pdh_workset > shm_appl->appl_server_max_size))
 	{
-	  cas_log_write_and_end (0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED MAX SIZE (%dM)",
-				 as_info->pdh_workset / ONE_K, shm_appl->appl_server_max_size / ONE_K);
+	  if (cas_log_get_fd_status () == CAS_LOG_FD_OPENED)
+	    {
+	      cas_log_write_and_end (0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED MAX SIZE (%dM)",
+				     as_info->pdh_workset / ONE_K, shm_appl->appl_server_max_size / ONE_K);
+	    }
+	  else
+	    {
+	      cas_log_open_and_write (broker_name, 0, true,
+				      "CAS MEMORY USAGE (%dM) HAS EXCEEDED MAX SIZE (%dM)",
+				      as_info->pdh_workset / ONE_K, shm_appl->appl_server_max_size / ONE_K);
+	    }
 	}
 
       if ((as_info->pid == as_info->pdh_pid) && (as_info->pdh_workset > shm_appl->appl_server_hard_limit))
 	{
-	  cas_log_write_and_end (0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED HARD LIMIT (%dM)",
-				 as_info->pdh_workset / ONE_K, shm_appl->appl_server_hard_limit / ONE_K);
+	  if (cas_log_get_fd_status () == CAS_LOG_FD_OPENED)
+	    {
+	      cas_log_write_and_end (0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED HARD LIMIT (%dM)",
+				     as_info->pdh_workset / ONE_K, shm_appl->appl_server_hard_limit / ONE_K);
+	    }
+	  else
+	    {
+	      cas_log_open_and_write (broker_name .0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED HARD LIMIT (%dM)",
+				      as_info->pdh_workset / ONE_K, shm_appl->appl_server_hard_limit / ONE_K);
+	    }
 	}
     }
   else
     {
       if (cas_req_count > 500)
 	{
-	  cas_log_write_and_end (0, true, "CAS REQUEST COUNT (%d) HAS EXCEEDED MAX LIMIT (%d)", cas_req_count, 500);
+	  if (cas_log_get_fd_status () == CAS_LOG_FD_OPENED)
+	    {
+	      cas_log_write_and_end (0, true, "CAS REQUEST COUNT (%d) HAS EXCEEDED MAX LIMIT (%d)", cas_req_count, 500);
+	    }
+	  else
+	    {
+	      cas_log_open_and_write (broker_name, 0, true, "CAS REQUEST COUNT (%d) HAS EXCEEDED MAX LIMIT (%d)",
+				      cas_req_count, 500);
+	    }
 	}
     }
 #else /* WINDOWS */
@@ -1727,18 +1752,42 @@ cas_free (bool from_sighandler)
 #endif
   if (as_info->psize > max_process_size)
     {
-      cas_log_write_and_end (0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED MAX SIZE (%dM)", as_info->psize / ONE_K,
-			     max_process_size / ONE_K);
+
+      if (cas_log_get_fd_status () == CAS_LOG_FD_OPENED)
+	{
+	  cas_log_write_and_end (0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED MAX SIZE (%dM)", as_info->psize / ONE_K,
+				 max_process_size / ONE_K);
+	}
+      else
+	{
+	  cas_log_open_and_write (broker_name, 0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED MAX SIZE (%dM)",
+				  as_info->psize / ONE_K, max_process_size / ONE_K);
+	}
     }
 
   if (as_info->psize > shm_appl->appl_server_hard_limit)
     {
-      cas_log_write_and_end (0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED HARD LIMIT (%dM)", as_info->psize / ONE_K,
-			     shm_appl->appl_server_hard_limit / ONE_K);
+      if (cas_log_get_fd_status () == CAS_LOG_FD_OPENED)
+	{
+	  cas_log_write_and_end (0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED HARD LIMIT (%dM)",
+				 as_info->psize / ONE_K, shm_appl->appl_server_hard_limit / ONE_K);
+	}
+      else
+	{
+	  cas_log_open_and_write (broker_name, 0, true, "CAS MEMORY USAGE (%dM) HAS EXCEEDED HARD LIMIT (%dM)",
+				  as_info->psize / ONE_K, shm_appl->appl_server_hard_limit / ONE_K);
+	}
     }
 #endif /* !WINDOWS */
+  if (cas_log_get_fd_status () == CAS_LOG_FD_OPENED)
+    {
+      cas_log_write_and_end (0, true, "CAS TERMINATED pid %d", getpid ());
+    }
+  else
+    {
+      cas_log_open_and_write (broker_name, 0, true, "CAS TERMINATED pid %d", getpid ());
+    }
 
-  cas_log_write_and_end (0, true, "CAS TERMINATED pid %d", getpid ());
   cas_log_close (true);
   cas_slow_log_close ();
   logddl_destroy ();

--- a/src/broker/cas_log.c
+++ b/src/broker/cas_log.c
@@ -92,6 +92,7 @@ static char cas_log_error_flag;
 static FILE *log_fp = NULL, *slow_log_fp = NULL;
 static char log_filepath[BROKER_PATH_MAX], slow_log_filepath[BROKER_PATH_MAX];
 static INT64 saved_log_fpos = 0;
+static CAS_LOG_FD_STATUS cas_log_fd_status = CAS_LOG_FD_NONE;
 
 static size_t cas_fwrite (const void *ptr, size_t size, size_t nmemb, FILE * stream);
 static INT64 cas_ftell (FILE * stream);
@@ -182,6 +183,7 @@ cas_log_open (char *br_name)
 	}
 
       /* note: in "a+" mode, output is always appended */
+      cas_log_fd_status = CAS_LOG_FD_OPENING;
       log_fp = cas_fopen (log_filepath, "r+");
       if (log_fp != NULL)
 	{
@@ -198,6 +200,7 @@ cas_log_open (char *br_name)
 	{
 	  setvbuf (log_fp, sql_log_buffer, _IOFBF, SQL_LOG_BUFFER_SIZE);
 	}
+      cas_log_fd_status = CAS_LOG_FD_OPENED;
     }
   else
     {
@@ -242,7 +245,9 @@ cas_log_close (bool flag)
 	  cas_fseek (log_fp, saved_log_fpos, SEEK_SET);
 	  cas_ftruncate (cas_fileno (log_fp), saved_log_fpos);
 	}
+      cas_log_fd_status = CAS_LOG_FD_CLOSING;
       cas_fclose (log_fp);
+      cas_log_fd_status = CAS_LOG_FD_CLOSED;
       log_fp = NULL;
       saved_log_fpos = 0;
     }
@@ -554,6 +559,48 @@ cas_log_write_and_end (unsigned int seq_num, bool unit_start, const char *fmt, .
       cas_log_end (SQL_LOG_MODE_ALL, -1, -1);
     }
 
+}
+
+void
+cas_log_open_and_write (char *br_name, unsigned int seq_num, bool unit_start, const char *fmt, ...)
+{
+  FILE *fp = NULL;
+  va_list ap;
+
+  if (as_info->cur_sql_log_mode != SQL_LOG_MODE_NONE)
+    {
+      if (br_name != NULL)
+	{
+	  if (log_filepath[0] == '\0')
+	    {
+	      make_sql_log_filename (FID_SQL_LOG_DIR, log_filepath, BROKER_PATH_MAX, br_name);
+	    }
+	}
+
+      fp = cas_fopen (log_filepath, "a");
+      if (fp == NULL)
+	{
+	  fp = cas_fopen (log_filepath, "w");
+	  if (fp == NULL)
+	    {
+	      return;
+	    }
+	}
+
+      va_start (ap, fmt);
+      cas_log_write_internal (fp, NULL, seq_num, (as_info->cur_sql_log_mode == SQL_LOG_MODE_ALL), fmt, ap);
+      va_end (ap);
+      cas_fputc ('\n', fp);
+
+      fclose (fp);
+      fp = NULL;
+    }
+}
+
+CAS_LOG_FD_STATUS
+cas_log_get_fd_status (void)
+{
+  return cas_log_fd_status;
 }
 
 static void

--- a/src/broker/cas_log.c
+++ b/src/broker/cas_log.c
@@ -569,11 +569,15 @@ cas_log_open_and_write (char *br_name, unsigned int seq_num, bool unit_start, co
 
   if (as_info->cur_sql_log_mode != SQL_LOG_MODE_NONE)
     {
-      if (br_name != NULL)
+      if (log_filepath[0] == '\0')
 	{
-	  if (log_filepath[0] == '\0')
+	  if (br_name != NULL)
 	    {
 	      make_sql_log_filename (FID_SQL_LOG_DIR, log_filepath, BROKER_PATH_MAX, br_name);
+	    }
+	  else
+	    {
+	      return;
 	    }
 	}
 

--- a/src/broker/cas_log.h
+++ b/src/broker/cas_log.h
@@ -33,6 +33,15 @@ typedef enum
   ACL_REJECTED
 } ACCESS_LOG_TYPE;
 
+typedef enum
+{
+  CAS_LOG_FD_NONE,
+  CAS_LOG_FD_OPENING,
+  CAS_LOG_FD_OPENED,
+  CAS_LOG_FD_CLOSING,
+  CAS_LOG_FD_CLOSED
+} CAS_LOG_FD_STATUS;
+
 extern void cas_log_open (char *br_name);
 extern void cas_log_reset (char *br_name);
 extern void cas_log_close (bool flag);
@@ -52,6 +61,8 @@ extern void cas_log_write_value_string (char *value, int size);
 extern void cas_log_write_query_string (char *query, int size);
 extern void cas_log_write_client_ip (const unsigned char *ip_addr);
 extern void cas_log_write_query_string_nonl (char *query, int size);
+extern void cas_log_open_and_write (char *br_name, unsigned int seq_num, bool unit_start, const char *fmt, ...);
+extern CAS_LOG_FD_STATUS cas_log_get_fd_status (void);
 
 #define ARG_FILE_LINE   __FILE__, __LINE__
 #if defined (NDEBUG)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24096

Purpose
A core dump occurs when cas writes a log after receiving a sigkill signal.
The cause of a core dump is that a collision occurs while process and signal use one file descriptor at the same time.
To avoid conflicts, we log using a new file descriptor.

Implementation
N/A

Remarks
N/A