### PR TITLE
[CBRD-24103] The permission of lob sub-directory and lob files have execute permission. So it should be eliminated for the permission consistency and prevention the access.

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -4103,7 +4103,7 @@ xboot_copy (REFPTR (THREAD_ENTRY, thread_p), const char *from_dbname, const char
 	  else
 	    {
 	      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_BO_DIRECTORY_DOESNOT_EXIST, 1, p);
-	      if (mkdir (p, 0777) < 0)
+	      if (mkdir (p, 0700) < 0)
 		{
 		  cub_dirname_r (p, fixed_pathbuf, PATH_MAX);
 		  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_ES_GENERAL, 2, "POSIX", fixed_pathbuf);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24103

**Purpose**

The permission of lob sub-directory and lob files have execute permission. So it should be eliminated for the permission consistency and prevention the access.

In the xboot_copy(), mkdir() has execution permission when the cubrid copydb command executes. 
So, its permission (group and others) must be removed.

**Implementation**

In the xboot_copy(), the system call mkdir(p, 0777) must be changed to mkdir(p, 0700)

**Remarks**

N/A