### PR TITLE
[CBRD-24719] Add Proxy and CAS status check function

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -873,7 +873,11 @@ receiver_thr_f (void *arg)
 	  memcpy ((char *) &session_id, cas_req_header + 6, 4);
 	  session_id = ntohl (session_id);
 
-	  if (shm_br->br_info[br_index].shard_flag == OFF)
+	  if (shm_br->br_info[br_index].shard_flag == ON)
+	    {
+	      status = FN_STATUS_BUSY;
+	    }
+	  else
 	    {
 	      for (i = 0; i < shm_br->br_info[br_index].appl_server_max_num; i++)
 		{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24719

Purpose
When JDBC/CCI requests a query and does not receive a response for more than 10 seconds, the driver checks the CAS status through the broker.
However, when a shard is set, the shard broker does not have a function to check the status of the proxy and cas, so the driver judges that there is an error in the proxy and cas and terminates the communication.
A function that can check the status of proxy and cas should be added through Broker for Shard.

Implementation
In order to check the status of the proxy and the cas in the broker, a protocol for the proxy to receive the session id from the cas must be added.
In this PR, no protocols were added, only errors were temporarily bypassed.

Remarks
N/A