### PR TITLE
[CBRD-24640] Specify the upper and lower bounds of the tde_default_algorithm parameter. (#4083)

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2324,7 +2324,9 @@ static bool prm_heap_info_cache_logging_default = false;
 static unsigned int prm_heap_info_cache_logging_flag = 0;
 
 int PRM_TDE_DEFAULT_ALGORITHM = TDE_ALGORITHM_AES;
-static int prm_tde_default_algorithm = TDE_ALGORITHM_AES;
+static int prm_tde_algorithm_default = TDE_ALGORITHM_AES;
+static int prm_tde_algorithm_upper = TDE_ALGORITHM_ARIA;
+static int prm_tde_algorithm_lower = TDE_ALGORITHM_NONE;
 static unsigned int prm_tde_default_algorithm_flag = 0;
 
 int PRM_ER_LOG_TDE = false;
@@ -6018,9 +6020,9 @@ static SYSPRM_PARAM prm_Def[] = {
    (PRM_FOR_CLIENT | PRM_FOR_SERVER),
    PRM_KEYWORD,
    &prm_tde_default_algorithm_flag,
-   (void *) &prm_tde_default_algorithm,
+   (void *) &prm_tde_algorithm_default,
    (void *) &PRM_TDE_DEFAULT_ALGORITHM,
-   (void *) NULL, (void *) NULL,
+   (void *) &prm_tde_algorithm_upper, (void *) &prm_tde_algorithm_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24640

backport: #4083 (cherry-pick)
