### PR TITLE
[LETS-666] add extra perfmon metric wether slotted pages need compacting

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -186,9 +186,11 @@ static void perfmon_stat_dump_in_buffer_thread_daemon_stats (const UINT64 * stat
 static void perfmon_print_timer_to_file (FILE * stream, int stat_index, UINT64 * stats_ptr);
 static void perfmon_print_timer_to_buffer (char **s, int stat_index, UINT64 * stats_ptr, int *remained_size);
 
-static void perfmon_stat_dump_in_buffer_served_compr_page_type_impl (char *&buf_ptr, int &buf_len,
-								     const int page_type, const UINT64 page_count,
-								     const UINT64 accumulated_ratio);
+static bool perfmon_stat_dump_in_buffer_served_compr_page_type_impl (char *&buf_ptr, int &buf_len, int page_type,
+								     UINT64 page_count, UINT64 accumulated_ratio,
+								     UINT64 slotted_count,
+								     UINT64 slotted_needs_compact_count
+								     /*, const UINT64 * stats_ptr */ );
 
 static void perfmon_dbg_check_metadata_definition ();
 
@@ -4396,16 +4398,33 @@ f_load_served_compr_page_type_counters (void)
   return PERF_SERVED_COMPR_PAGE_TYPE_COUNTERS_SIZE;
 }
 
-static void
-perfmon_stat_dump_in_buffer_served_compr_page_type_impl (char *&buf_ptr, int &buf_len,
-							 const int page_type, const UINT64 page_count,
-							 const UINT64 accumulated_ratio)
+static bool
+perfmon_stat_dump_in_buffer_served_compr_page_type_impl (char *&buf_ptr, int &buf_len, int page_type,
+							 UINT64 page_count, UINT64 accumulated_ratio,
+							 UINT64 slotted_count, UINT64 slotted_needs_compact_count
+							 /*, const UINT64 * stats_ptr */ )
 {
   int written = 0;
 
+//  const int offset = PERF_SERVED_COMPR_PAGE_TYPE_COUNTERS_OFFSET (page_type, PERF_SERVED_COMPR_COUNT);
+//  assert (offset < PERF_SERVED_COMPR_PAGE_TYPE_COUNTERS_SIZE);
+//  // offset for accumulated ratio
+//  assert ((offset + PERF_SERVED_COMPR_RATIO) < PERF_SERVED_COMPR_PAGE_TYPE_COUNTERS_SIZE);
+
+//  const UINT64 page_count = stats_ptr[offset + PERF_SERVED_COMPR_COUNT];
+//  const UINT64 accumulated_ratio = stats_ptr[offset + PERF_SERVED_COMPR_RATIO];
+//  const UINT64 slotted_count = stats_ptr[offset + PERF_SERVED_COMPR_SLOTTED];
+//  const UINT64 slotted_needs_compact_count = stats_ptr[offset + PERF_SERVED_COMPR_SLOTTED_NEEDS_COMPACT];
+
+//  if (page_count == 0 && accumulated_ratio == 0 && slotted_count == 0 && slotted_needs_compact_count == 0)
+//    {
+//      return false;
+//    }
+
   // page_count
-  written = snprintf (buf_ptr, (size_t) buf_len, "%-14s,COUNT = %10llu\n",
-		      perfmon_stat_page_type_name (page_type), (long long unsigned int) page_count);
+  const char *const page_type_name = perfmon_stat_page_type_name (page_type);
+  written = snprintf (buf_ptr, (size_t) buf_len, "%-18s,COUNT         = %10llu\n",
+		      page_type_name, (long long unsigned int) page_count);
   assert (written > 0);
   buf_ptr += written;
   assert (buf_len > written);
@@ -4413,17 +4432,50 @@ perfmon_stat_dump_in_buffer_served_compr_page_type_impl (char *&buf_ptr, int &bu
   if (buf_len <= 0)
     {
       assert (false);
-      return;
+      return false;
     }
 
   // accumulated_ratio
-  written = snprintf (buf_ptr, (size_t) buf_len, "%-14s,RATIO = %10.2f [accum_ratio = %10llu]\n",
-		      perfmon_stat_page_type_name (page_type),
-		      (float) ((double) accumulated_ratio / (page_count * 100.)),
-		      (long long unsigned int) accumulated_ratio);
-
+  written = snprintf (buf_ptr, (size_t) buf_len, "%-18s,RATIO         = %10.2f\n",	/* [accum_ratio = %10llu]\n", */
+		      page_type_name, (float) ((double) accumulated_ratio / (page_count * 100.))
+		      /*, (long long unsigned int) accumulated_ratio */ );
   assert (written > 0);
+  buf_ptr += written;
   assert (buf_len > written);
+  buf_len -= written;
+  if (buf_len <= 0)
+    {
+      assert (false);
+      return false;
+    }
+
+  // slotted count
+  written = snprintf (buf_ptr, (size_t) buf_len, "%-18s,SLOTTED       = %10llu\n",
+		      page_type_name, (long long unsigned int) slotted_count);
+  assert (written > 0);
+  buf_ptr += written;
+  assert (buf_len > written);
+  buf_len -= written;
+  if (buf_len <= 0)
+    {
+      assert (false);
+      return false;
+    }
+
+  // slotted needs compact
+  written = snprintf (buf_ptr, (size_t) buf_len, "%-18s,NEEDS_COMPACT = %10llu\n",
+		      page_type_name, (long long unsigned int) slotted_needs_compact_count);
+  assert (written > 0);
+  buf_ptr += written;
+  assert (buf_len > written);
+  buf_len -= written;
+  if (buf_len <= 0)
+    {
+      assert (false);
+      return false;
+    }
+
+  return true;
 }
 
 void
@@ -4445,18 +4497,24 @@ f_dump_in_file_served_compr_page_type_counters (FILE * f_ptr, const UINT64 * sta
 	assert (offset < PERF_SERVED_COMPR_PAGE_TYPE_COUNTERS_SIZE);
 	assert ((offset + PERF_SERVED_COMPR_RATIO) < PERF_SERVED_COMPR_PAGE_TYPE_COUNTERS_SIZE);	// offset for accumulated ratio
 
-	const UINT64 counter = stats_ptr[offset + PERF_SERVED_COMPR_COUNT];
+	const UINT64 page_count = stats_ptr[offset + PERF_SERVED_COMPR_COUNT];
 	const UINT64 accumulated_ratio = stats_ptr[offset + PERF_SERVED_COMPR_RATIO];
-	if (counter == 0 && accumulated_ratio == 0)
+	const UINT64 slotted_count = stats_ptr[offset + PERF_SERVED_COMPR_SLOTTED];
+	const UINT64 slotted_needs_compact_count = stats_ptr[offset + PERF_SERVED_COMPR_SLOTTED_NEEDS_COMPACT];
+	if (page_count == 0 && accumulated_ratio == 0 && slotted_count == 0 && slotted_needs_compact_count == 0)
 	  {
 	    continue;
 	  }
 
 	char *buf_ptr = buf;
 	int buf_len = BUF_LEN_MAX;
-	perfmon_stat_dump_in_buffer_served_compr_page_type_impl (buf_ptr, buf_len, page_type, counter,
-								 accumulated_ratio);
-
+	(void) perfmon_stat_dump_in_buffer_served_compr_page_type_impl (buf_ptr, buf_len, page_type, page_count,
+									accumulated_ratio, slotted_count,
+									slotted_needs_compact_count
+									/*, stats_ptr */ );
+//        {
+//          continue;
+//        }
 	fprintf (f_ptr, "%s", buf);
       }
   }
@@ -4481,15 +4539,19 @@ f_dump_in_buffer_served_compr_page_type_counters (char **s, const UINT64 * stats
 	  assert (offset < PERF_SERVED_COMPR_PAGE_TYPE_COUNTERS_SIZE);
 	  assert ((offset + PERF_SERVED_COMPR_RATIO) < PERF_SERVED_COMPR_PAGE_TYPE_COUNTERS_SIZE);	// offset for accumulated ratio
 
-	  const UINT64 counter = stats_ptr[offset + PERF_SERVED_COMPR_COUNT];
+	  const UINT64 page_count = stats_ptr[offset + PERF_SERVED_COMPR_COUNT];
 	  const UINT64 accumulated_ratio = stats_ptr[offset + PERF_SERVED_COMPR_RATIO];
-	  if (counter == 0 && accumulated_ratio == 0)
+	  const UINT64 slotted_count = stats_ptr[offset + PERF_SERVED_COMPR_SLOTTED];
+	  const UINT64 slotted_needs_compact_count = stats_ptr[offset + PERF_SERVED_COMPR_SLOTTED_NEEDS_COMPACT];
+	  if (page_count == 0 && accumulated_ratio == 0 && slotted_count == 0 && slotted_needs_compact_count == 0)
 	    {
 	      continue;
 	    }
 
-	  perfmon_stat_dump_in_buffer_served_compr_page_type_impl (*s, *remaining_size, page_type, counter,
-								   accumulated_ratio);
+	  (void) perfmon_stat_dump_in_buffer_served_compr_page_type_impl (*s, *remaining_size, page_type, page_count,
+									  accumulated_ratio, slotted_count,
+									  slotted_needs_compact_count
+									  /*, stats_ptr */ );
 	}
     }
 }
@@ -4499,16 +4561,16 @@ f_dump_in_buffer_served_compr_page_type_counters (char **s, const UINT64 * stats
  *   return: none
  */
 void
-perfmon_compr_page_type (THREAD_ENTRY * thread_p, int page_type, int ratio)
+perfmon_compr_page_type (THREAD_ENTRY * thread_p, int page_type, int ratio, bool is_slotted, bool needs_compact)
 {
   assert (pstat_Global.initialized);
-
-  assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
 
   if ((pstat_Global.activation_flag & PERFMON_ACTIVATION_FLAG_SERVED_COMPR_PAGE_TYPE) == 0x00)
     {
       return;
     }
+
+  assert (page_type >= PERF_PAGE_UNKNOWN && page_type < PERF_PAGE_CNT);
 
   {
     const int offset = PERF_SERVED_COMPR_PAGE_TYPE_COUNTERS_OFFSET (page_type, PERF_SERVED_COMPR_COUNT);
@@ -4516,7 +4578,12 @@ perfmon_compr_page_type (THREAD_ENTRY * thread_p, int page_type, int ratio)
     assert ((offset + PERF_SERVED_COMPR_RATIO) < PERF_PAGE_PROMOTE_COUNTERS);
 
     perfmon_add_stat_at_offset (thread_p, PSTAT_SERVED_COMPR_PAGE_TYPE_COUNTERS, offset, 1);
-    perfmon_add_stat_at_offset (thread_p, PSTAT_SERVED_COMPR_PAGE_TYPE_COUNTERS, (offset + PERF_SERVED_COMPR_RATIO),
-				ratio);
+    perfmon_add_stat_at_offset (thread_p, PSTAT_SERVED_COMPR_PAGE_TYPE_COUNTERS,
+				(offset + PERF_SERVED_COMPR_RATIO), ratio);
+    assert ((needs_compact && is_slotted) || !needs_compact);
+    perfmon_add_stat_at_offset (thread_p, PSTAT_SERVED_COMPR_PAGE_TYPE_COUNTERS,
+				(offset + PERF_SERVED_COMPR_SLOTTED), (is_slotted ? 1 : 0));
+    perfmon_add_stat_at_offset (thread_p, PSTAT_SERVED_COMPR_PAGE_TYPE_COUNTERS,
+				(offset + PERF_SERVED_COMPR_SLOTTED_NEEDS_COMPACT), (needs_compact ? 1 : 0));
   }
 }

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -282,7 +282,7 @@ typedef enum
   PERF_SERVED_COMPR_COUNT = 0,
   /* per page type, the average ratio of pages compressed and served by page server */
   PERF_SERVED_COMPR_RATIO,
-  /* per page type, whether the page being server needs to be compacted or not; for non-slotted
+  /* per page type, whether the page being served needs to be compacted or not; for non-slotted
    * pages, the value is zero and irrelevant */
   PERF_SERVED_COMPR_SLOTTED_NEEDS_COMPACT,
 

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -278,8 +278,12 @@ typedef enum
 
 typedef enum
 {
-  PERF_SERVED_COMPR_COUNT = 0,	/* per page type, this many pages have been compressed and served by page server */
-  PERF_SERVED_COMPR_RATIO,	/* per page type, the average ratio of pages compressed and served by page server */
+  /* per page type, this many pages have been compressed and served by page server */
+  PERF_SERVED_COMPR_COUNT = 0,
+  /* per page type, the average ratio of pages compressed and served by page server */
+  PERF_SERVED_COMPR_RATIO,
+  /* per page type, whether the page being server needs to be compacted or not; for non-slotted
+   * pages, the value is zero and irrelevant */
   PERF_SERVED_COMPR_SLOTTED_NEEDS_COMPACT,
 
   PERF_SERVED_COMPR_PAGE_TYPE_CNT

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -280,6 +280,8 @@ typedef enum
 {
   PERF_SERVED_COMPR_COUNT = 0,	/* per page type, this many pages have been compressed and served by page server */
   PERF_SERVED_COMPR_RATIO,	/* per page type, the average ratio of pages compressed and served by page server */
+  PERF_SERVED_COMPR_SLOTTED,
+  PERF_SERVED_COMPR_SLOTTED_NEEDS_COMPACT,
 
   PERF_SERVED_COMPR_PAGE_TYPE_CNT
 } PERF_SERVED_COMPR_PAGE_TYPE;
@@ -1510,7 +1512,8 @@ extern void perfmon_pbx_fix_acquire_time (THREAD_ENTRY * thread_p, int page_type
 extern void perfmon_mvcc_snapshot (THREAD_ENTRY * thread_p, int snapshot, int rec_type, int visibility);
 extern void perfmon_db_flushed_block_volumes (THREAD_ENTRY * thread_p, int num_volumes);
 
-extern void perfmon_compr_page_type (THREAD_ENTRY * thread_p, int page_type, int ratio);
+extern void perfmon_compr_page_type (THREAD_ENTRY * thread_p, int page_type, int ratio, bool is_slotted,
+				     bool needs_compact);
 
 #endif /* SERVER_MODE || SA_MODE */
 

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -280,7 +280,6 @@ typedef enum
 {
   PERF_SERVED_COMPR_COUNT = 0,	/* per page type, this many pages have been compressed and served by page server */
   PERF_SERVED_COMPR_RATIO,	/* per page type, the average ratio of pages compressed and served by page server */
-  PERF_SERVED_COMPR_SLOTTED,
   PERF_SERVED_COMPR_SLOTTED_NEEDS_COMPACT,
 
   PERF_SERVED_COMPR_PAGE_TYPE_CNT
@@ -1512,8 +1511,7 @@ extern void perfmon_pbx_fix_acquire_time (THREAD_ENTRY * thread_p, int page_type
 extern void perfmon_mvcc_snapshot (THREAD_ENTRY * thread_p, int snapshot, int rec_type, int visibility);
 extern void perfmon_db_flushed_block_volumes (THREAD_ENTRY * thread_p, int num_volumes);
 
-extern void perfmon_compr_page_type (THREAD_ENTRY * thread_p, int page_type, int ratio, bool is_slotted,
-				     bool needs_compact);
+extern void perfmon_compr_page_type (THREAD_ENTRY * thread_p, int page_type, int ratio, bool needs_compact);
 
 #endif /* SERVER_MODE || SA_MODE */
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8468,6 +8468,7 @@ pgbuf_request_data_page_from_page_server (THREAD_ENTRY & thread_r, const VPID * 
   return error_code;
 }
 
+// *INDENT-OFF*
 void
 /*
  * pgbuf_respond_data_fetch_page_request - Page Server responds to a request for a heap page
@@ -8480,23 +8481,19 @@ void
  *    - a system parameter
  *    - if the compression algorighm was not able to compress the data, the page is sent uncompressed
  */
-// *INDENT-OFF*
 pgbuf_respond_data_fetch_page_request (THREAD_ENTRY &thread_r, std::string &payload_in_out)
-// *INDENT-ON*
 {
   assert (is_page_server ());
 
   // Unpack the message data
-  // *INDENT-OFF*
   cubpacking::unpacker message_upk (payload_in_out.c_str (), payload_in_out.size ());
   VPID vpid;
   vpid_utils::unpack (message_upk, vpid);
 
   LOG_LSA target_repl_lsa;
   cublog::lsa_utils::unpack (message_upk, target_repl_lsa);
-  // *INDENT-ON*
   int packed_fetch_mode;
-    message_upk.unpack_int (packed_fetch_mode);
+  message_upk.unpack_int (packed_fetch_mode);
   const PAGE_FETCH_MODE fetch_mode = static_cast < PAGE_FETCH_MODE > (packed_fetch_mode);
 
   // Fetch data page. But first make sure that replication hits its target LSA
@@ -8515,9 +8512,7 @@ pgbuf_respond_data_fetch_page_request (THREAD_ENTRY &thread_r, std::string &payl
       ASSERT_NO_ERROR ();
       //The found page was deallocated already
       error = ER_PB_BAD_PAGEID;
-      // *INDENT-OFF*
       payload_in_out = { reinterpret_cast<const char *> (&error), sizeof (error) };
-      // *INDENT-ON*
       if (prm_get_bool_value (PRM_ID_ER_LOG_READ_DATA_PAGE))
 	{
 	  _er_log_debug (ARG_FILE_LINE,
@@ -8529,9 +8524,7 @@ pgbuf_respond_data_fetch_page_request (THREAD_ENTRY &thread_r, std::string &payl
     {
       ASSERT_ERROR_AND_SET (error);
       // respond with the error
-      // *INDENT-OFF*
       payload_in_out = { reinterpret_cast<const char *> (&error), sizeof (error) };
-      // *INDENT-ON*
 
       if (prm_get_bool_value (PRM_ID_ER_LOG_READ_DATA_PAGE))
 	{
@@ -8547,9 +8540,7 @@ pgbuf_respond_data_fetch_page_request (THREAD_ENTRY &thread_r, std::string &payl
       assert (io_pgptr != nullptr);
 
       // pack NO_ERROR first
-      // *INDENT-OFF*
       payload_in_out = { reinterpret_cast<const char *> (&error), sizeof (error) };
-      // *INDENT-ON*
 
       // compress data that is sent over; there are 3 cases:
       //  - compression setting on and data compressed successfully
@@ -8563,7 +8554,7 @@ pgbuf_respond_data_fetch_page_request (THREAD_ENTRY &thread_r, std::string &payl
 
       // add compressed size
       const PGLENGTH compressed_length = (PGLENGTH) compressed_data_size;
-      payload_in_out.append (reinterpret_cast < const char *>(&compressed_length), sizeof (PGLENGTH));
+      payload_in_out.append (reinterpret_cast<const char *> (&compressed_length), sizeof (PGLENGTH));
 
       // add io_page
       payload_in_out.append (compressed_data, (size_t) compressed_data_size);
@@ -8604,6 +8595,7 @@ pgbuf_respond_data_fetch_page_request (THREAD_ENTRY &thread_r, std::string &payl
       pgbuf_unfix (&thread_r, page_ptr);
     }
 }
+// *INDENT-ON*
 
 void
 pgbuf_compress_page (THREAD_ENTRY & thread_r, const void *data_in, int data_in_size,

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -178,7 +178,6 @@ static int spage_get_saved_spaces_by_other_trans (THREAD_ENTRY * thread_p, SPAGE
 static int spage_get_total_saved_spaces (THREAD_ENTRY * thread_p, SPAGE_HEADER * page_header_p, PAGE_PTR page_p);
 static void spage_dump_saved_spaces_by_other_trans (THREAD_ENTRY * thread_p, FILE * fp, VPID * vpid);
 static int spage_compare_slot_offset (const void *arg1, const void *arg2);
-static bool spage_is_slotted_page_type (PAGE_TYPE ptype);
 
 static int spage_check_space (THREAD_ENTRY * thread_p, PAGE_PTR page_p, SPAGE_HEADER * page_header_p, int space);
 static void spage_set_slot (SPAGE_SLOT * slot_p, int offset, int length, INT16 type);
@@ -1137,7 +1136,7 @@ spage_compare_slot_offset (const void *arg1, const void *arg2)
  *
  *   ptype(in): page type
  */
-static bool
+bool
 spage_is_slotted_page_type (PAGE_TYPE ptype)
 {
   switch (ptype)

--- a/src/storage/slotted_page.h
+++ b/src/storage/slotted_page.h
@@ -145,6 +145,7 @@ extern int spage_max_space_for_new_record (THREAD_ENTRY * thread_p, PAGE_PTR pgp
 extern void spage_collect_statistics (PAGE_PTR pgptr, int *npages, int *nrecords, int *rec_length);
 extern int spage_max_record_size (void);
 extern int spage_check_slot_owner (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PGSLOTID slotid);
+extern bool spage_is_slotted_page_type (PAGE_TYPE ptype);
 extern int spage_compact (THREAD_ENTRY * thread_p, PAGE_PTR pgptr);
 extern bool spage_is_valid_anchor_type (const INT16 anchor_type);
 extern const char *spage_anchor_flag_string (const INT16 anchor_type);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-666

Add extra information to the existing `PERF_SERVED_COMPR_` perf extended statistics for whether the the slotted pages need also compacting.

Implementation:
- added enum value `PERF_SERVED_COMPR_SLOTTED_NEEDS_COMPACT`
- when a page is served from Page Server to a Transaction Server, check whether the page is slotted, and - if it is - whether it needs to be compacted and - if specified via the `PERFMON_ACTIVATION_FLAG_SERVED_COMPR_PAGE_TYPE` - also log this information
- extended perfmon functions to also add this information

Context:
In the monolithic server, it is the job off the vacuum daemons to ensure that the slotted pages remain in an optimal state. The reason for this might be that, chronologically, the vacuum is the last entity to touch a modified page after all the other (the modifying transaction, potential older concurrent transactions that might also need older values, ...).
In the scalability architecture, the vacuum threads compacting the page - although currently still done - it is useless, as the Active Transaction Server pages, compacted or not, will just be evicted from the page buffer after a certain time.
In the scalability architecture, in order to have the on-permanent-storage data pages also in an optimal state, it is needed that the replication threads on Page Server perform this action because these threads are the only ones that actually modify the data pages.
