### PR TITLE
[CBRD-24743] change broker_monitor.c - from ncurses to tinfo with dlopen

### DIFF
--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -545,7 +545,12 @@ main (int argc, char **argv)
 	}
 //  FillConsoleOutputCharacter(h_console, ' ', scr_info.dwSize.X * scr_info.dwSize.Y, top_left_pos, &size);
 #else
-      win = initscr ();
+      if ((win = initscr ()) == NULL)
+	{
+	  fprintf (stderr, "fail to initialize tinfo library\n");
+	  return 127;
+	}
+
       timeout (refresh_sec * 1000);
       noecho ();
 #endif

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -2028,23 +2028,25 @@ static int
 getch ()
 {
   fd_set readfds;
-  struct timeval tv;
+  struct timeval tv, *tv_p = &tv;
   int fd = fileno (stdin);
   int timeout = get_timeout ();
   int ret = -1;
 
-  if (timeout == 0)		/* temp code for test */
+  if (timeout < 0)
     {
-      timeout = 30 * 10000;
+      tv_p = NULL;
     }
-
-  tv.tv_sec = timeout / 1000;
-  tv.tv_usec = timeout % 1000;
+  else
+    {
+      tv.tv_sec = timeout / 1000;
+      tv.tv_usec = timeout % 1000;
+    }
 
   FD_ZERO (&readfds);
   FD_SET (fd, &readfds);
 
-  ret = select (fd + 1, &readfds, (fd_set *) 0, (fd_set *) 0, &tv);
+  ret = select (fd + 1, &readfds, (fd_set *) 0, (fd_set *) 0, tv_p);
 
   if (ret <= 0)
     {

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -366,7 +366,7 @@ typedef int (*tgetent_func_t) (char *bp, const char *name);
 typedef int (*tgetflag_func_t) (char *id);
 typedef int (*tgetnum_func_t) (char *id);
 typedef char *(*tgetstr_func_t) (char *id, char **area);
-typedef int (*tputs_func_t) (const char *str, int affcnt, int (*putc)(int));
+typedef int (*tputs_func_t) (const char *str, int affcnt, int (*putc) (int));
 
 tgoto_func_t tgoto;
 tgetent_func_t tgetent;
@@ -488,7 +488,7 @@ main (int argc, char **argv)
   double elapsed_time;
 
 #if !defined (WINDOWS)
-void *win;
+  void *win;
 #endif
 
   if (argc == 2 && strcmp (argv[1], "--version") == 0)
@@ -2006,14 +2006,14 @@ endwin ()
   move (0, 0);
 
   if (dl_handle != NULL)
-  {
-    dlclose (dl_handle);
-    dl_handle = NULL;
-  }
+    {
+      dlclose (dl_handle);
+      dl_handle = NULL;
+    }
 }
 
 static void
-addstr (const char * str)
+addstr (const char *str)
 {
   if (str == NULL)
     {
@@ -2033,7 +2033,7 @@ getch ()
   int timeout = get_timeout ();
   int ret = -1;
 
-  if (timeout == 0) /* temp code for test */
+  if (timeout == 0)		/* temp code for test */
     {
       timeout = 30 * 10000;
     }
@@ -2041,8 +2041,8 @@ getch ()
   tv.tv_sec = timeout / 1000;
   tv.tv_usec = timeout % 1000;
 
-  FD_ZERO(&readfds);
-  FD_SET(fd, &readfds);
+  FD_ZERO (&readfds);
+  FD_SET (fd, &readfds);
 
   ret = select (fd + 1, &readfds, (fd_set *)0, (fd_set *)0, &tv);
 
@@ -2065,7 +2065,7 @@ stdin_noblock ()
 {
   struct termios term;
 
-  if (tcgetattr(fileno (stdin), &term) < 0)
+  if (tcgetattr (fileno (stdin), &term) < 0)
     {
       return -1;
     }
@@ -2077,7 +2077,7 @@ stdin_noblock ()
   term.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
 
   term.c_cc[VMIN] = 0;
-  term.c_cc[VTIME] = 8; /* after a byte or .8 seconds */
+  term.c_cc[VTIME] = 8;		/* after a byte or .8 seconds */
 
   /* put terminal in raw mode after flushing */
   if (tcsetattr (0, TCSAFLUSH, &term) < 0)
@@ -2097,7 +2097,7 @@ get_timeout ()
 static void
 timeout (int delay)
 {
-   Stdin_timer = delay < 0 ? 0 : delay;
+  Stdin_timer = delay < 0 ? 0 : delay;
 }
 
 static void
@@ -2116,9 +2116,9 @@ initscr ()
     {
       sprintf (tinfo_so, "libtinfo.so.%d", major_version);
       if ((dl_handle = dlopen (tinfo_so, RTLD_LAZY)) != NULL)
-        {
-          break;
-        }
+	{
+	  break;
+	}
     }
 
   if (dl_handle == NULL)
@@ -2127,37 +2127,37 @@ initscr ()
       return NULL;
     }
 
-  if ((tgoto = (tgoto_func_t) dlsym(dl_handle, "tgoto")) == NULL)
+  if ((tgoto = (tgoto_func_t) dlsym (dl_handle, "tgoto")) == NULL)
     {
       fprintf (stderr, "ERROR: Cannot find 'tgoto' function in %s.\n", tinfo_so);
       return NULL;
     }
 
-  if ((tgetent = (tgetent_func_t) dlsym(dl_handle, "tgetent")) == NULL)
+  if ((tgetent = (tgetent_func_t) dlsym (dl_handle, "tgetent")) == NULL)
     {
       fprintf (stderr, "ERROR: Cannot find 'tgetent' function in %s.\n", tinfo_so);
       return NULL;
     }
 
-  if ((tgetflag = (tgetflag_func_t) dlsym(dl_handle, "tgetflag")) == NULL)
+  if ((tgetflag = (tgetflag_func_t) dlsym (dl_handle, "tgetflag")) == NULL)
     {
       fprintf (stderr, "ERROR: Cannot find 'tgetflag' function in %s.\n", tinfo_so);
       return NULL;
     }
 
-  if ((tgetnum = (tgetnum_func_t) dlsym(dl_handle, "tgetnum")) == NULL)
+  if ((tgetnum = (tgetnum_func_t) dlsym (dl_handle, "tgetnum")) == NULL)
     {
       fprintf (stderr, "ERROR: Cannot find 'tgetnum' function in %s.\n", tinfo_so);
       return NULL;
     }
 
-  if ((tgetstr = (tgetstr_func_t) dlsym(dl_handle, "tgetstr")) == NULL)
+  if ((tgetstr = (tgetstr_func_t) dlsym (dl_handle, "tgetstr")) == NULL)
     {
       fprintf (stderr, "ERROR: Cannot find 'tgetstr' function in %s.\n", tinfo_so);
       return NULL;
     }
 
-  if ((tputs = (tputs_func_t) dlsym(dl_handle, "tputs")) == NULL)
+  if ((tputs = (tputs_func_t) dlsym (dl_handle, "tputs")) == NULL)
     {
       fprintf (stderr, "ERROR: Cannot find 'tputs' function in %s.\n", tinfo_so);
       return NULL;

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -2044,7 +2044,7 @@ getch ()
   FD_ZERO (&readfds);
   FD_SET (fd, &readfds);
 
-  ret = select (fd + 1, &readfds, (fd_set *)0, (fd_set *)0, &tv);
+  ret = select (fd + 1, &readfds, (fd_set *) 0, (fd_set *) 0, &tv);
 
   if (ret <= 0)
     {

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -357,21 +357,16 @@ static void *initscr ();
 static void noecho ();
 static void timeout (int delay);
 static void addstr (const char *);
-
 static int stdin_noblock (void);
 static int get_timeout (void);
 
 typedef char *(*tgoto_func_t) (const char *cap, int col, int row);
 typedef int (*tgetent_func_t) (char *bp, const char *name);
-typedef int (*tgetflag_func_t) (char *id);
-typedef int (*tgetnum_func_t) (char *id);
 typedef char *(*tgetstr_func_t) (char *id, char **area);
 typedef int (*tputs_func_t) (const char *str, int affcnt, int (*putc) (int));
 
 tgoto_func_t tgoto;
 tgetent_func_t tgetent;
-tgetflag_func_t tgetflag;
-tgetnum_func_t tgetnum;
 tgetstr_func_t tgetstr;
 tputs_func_t tputs;
 
@@ -2138,18 +2133,6 @@ initscr ()
   if ((tgetent = (tgetent_func_t) dlsym (dl_handle, "tgetent")) == NULL)
     {
       fprintf (stderr, "ERROR: Cannot find 'tgetent' function in %s.\n", tinfo_so);
-      return NULL;
-    }
-
-  if ((tgetflag = (tgetflag_func_t) dlsym (dl_handle, "tgetflag")) == NULL)
-    {
-      fprintf (stderr, "ERROR: Cannot find 'tgetflag' function in %s.\n", tinfo_so);
-      return NULL;
-    }
-
-  if ((tgetnum = (tgetnum_func_t) dlsym (dl_handle, "tgetnum")) == NULL)
-    {
-      fprintf (stderr, "ERROR: Cannot find 'tgetnum' function in %s.\n", tinfo_so);
       return NULL;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24743

**Purpose**
* removing ncurses dependancy from CUBRID binaries
* same way as we did for csql
* same behavior with previous 'cubrid broker status -s' but do not use ncurses and uses tinfo

**Implementation**
* run time binding of **tinfo** functions
  * tgoto (), tgetent (), tgetstr (), tputs ()
* rewrite curses to tinfo + alpha for tty handling

**Remarks**
* due to ncurses itself calls other functions, 
* it is not possible to convert current ncurses function calls of broker monitot to dlopen style, we tried
* we have an experience of converting libedit library for csql to dlopen style (libtinfo)