### PR TITLE
[CBRD-24626] fix bugs reported by QA after first implementation

### DIFF
--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -2284,20 +2284,21 @@ hb_cluster_load_ping_host_list (char *ha_ping_host_list)
 static int
 hb_port_str_to_num (char *port_p)
 {
-  int i = 0, num_count = 0;
-  int port = -1;
+  int num_count = 0, port = -1;
   bool is_space_after_numbers = false;
+  char *p;
 
-  if (port_p == NULL || *port_p == '\0')
+  p = port_p;
+
+  if (p == NULL || *p == '\0')
     {
       goto error;
     }
 
-  while (*(port_p + i) != '\0')
+  while (*p != '\0')
     {
-      if (*port_p >= '0' && *port_p <= '9')
+      if (*p >= '0' && *p <= '9')
 	{
-	  i++;
 	  num_count++;
 
 	  if (num_count > 5 || is_space_after_numbers == true)	/* The port number cannot exceed 5 digits. */
@@ -2305,10 +2306,8 @@ hb_port_str_to_num (char *port_p)
 	      goto error;
 	    }
 	}
-      else if (*port_p == ' ')
+      else if (*p == ' ')
 	{
-	  i++;
-
 	  if (num_count > 1)	/* atoi("80 80") returns 80. It needs an exception handling */
 	    {
 	      is_space_after_numbers = true;
@@ -2318,6 +2317,8 @@ hb_port_str_to_num (char *port_p)
 	{
 	  goto error;
 	}
+
+      p++;
     }
 
   port = atoi (port_p);
@@ -2359,7 +2360,7 @@ hb_cluster_load_tcp_ping_host_list (char *ha_ping_host_list)
 
   for (host_list_p = host_list;; host_list_p = NULL)
     {
-      host_p = strtok_r (host_list_p, " ,", &host_pp);
+      host_p = strtok_r (host_list_p, ",", &host_pp);
       if (host_p == NULL)
 	{
 	  break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24626

### Purpose
The followings are fixed:
1. modified not to allow space as a delimiter when tokenizing the string value set in the ha_tcp_ping_hosts
2. fix a bug in the function that converts port string to port number
    * see if (*port_p >= '0' && *port_p <= '9') in the hb_port_str_to_num()
    * same position is checked repeatedly
### Implementation
N/A
### Remarks
N/A
