### PR TITLE
[CBRD-24665] revert #4118 - broker monitor using watch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ set(WITH_LIBEXPAT_URL "https://github.com/libexpat/libexpat/releases/download/R_
 set(WITH_LIBJANSSON_URL "http://www.digip.org/jansson/releases/jansson-2.10.tar.gz")
 
 # editline library sources URL
-set(WITH_LIBEDIT_URL "https://github.com/CUBRID/libedit/archive/refs/tags/csql_v1.1.tar.gz")
+set(WITH_LIBEDIT_URL "https://github.com/CUBRID/libedit/archive/refs/tags/libedit_v1.tar.gz")
 
 # rapidjson library sources URL
 set(WITH_RAPIDJSON_URL "https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz")
@@ -1060,7 +1060,7 @@ if(UNIX)
       LOG_INSTALL          TRUE
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
-      CONFIGURE_COMMAND    "LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/external/lib" ${DEFAULT_CONFIGURE_OPTS} LIBS=-ldl
+      CONFIGURE_COMMAND    "LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/external/lib" ${DEFAULT_CONFIGURE_OPTS}
       BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       "${LIBEDIT_BYPRODUCTS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,11 +155,13 @@ set(WITH_SYSTEM_PREFIX "SYSTEM" CACHE STRING "System library prefix (default: SY
 set(WITH_LIBEXPAT     "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with expat library (default: EXTERNAL)")
 set(WITH_LIBJANSSON   "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with jansson library (default: EXTERNAL)")
 set(WITH_LIBEDIT      "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with editline library (default: EXTERNAL)")
+set(WITH_LIBNCURSES   "${WITH_SYSTEM_PREFIX}" CACHE STRING "Build with ncurses library (default: SYSTEM)")
 set(WITH_LIBOPENSSL   "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with openssl library (default: EXTERNAL)")
 set(WITH_LIBUNIXODBC  "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with unixODBC library (default: EXTERNAL)")
 set(WITH_RE2          "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with re2 library (default: EXTERNAL)")
 
 
+message(STATUS "Build with Curses library: ${WITH_LIBNCURSES}")
 message(STATUS "Build with editline library: ${WITH_LIBEDIT}")
 message(STATUS "Build with expat library: ${WITH_LIBEXPAT}")
 message(STATUS "Build with jansson library: ${WITH_LIBJANSSON}")
@@ -1004,6 +1006,38 @@ elseif(WITH_LIBJANSSON STREQUAL "SYSTEM")
 endif()
 list(APPEND EP_INCLUDES ${LIBJANSSON_INCLUDES})
 list(APPEND EP_LIBS ${LIBJANSSON_LIBS})
+
+# WITH_LIBNCURSES can have multiple values with different meanings
+# on Linux:
+# * "SYSTEM"   - uses ncurses installed in the system (for more info check https://cmake.org/cmake/help/v3.10/module/FindCurses.html)
+set(LIBNCURSES_TARGET libncurses)
+if(UNIX)
+  if(WITH_LIBNCURSES STREQUAL "SYSTEM")
+    include(FindCurses)
+    find_package(Curses REQUIRED)
+    CHECK_LIBRARY_EXISTS("${CURSES_LIBRARIES}" wtimeout "" LIBNCURSES_HAS_WTIMEOUT)
+    set(LIBNCURSES_INCLUDES "${CURSES_INCLUDE_DIRS}")
+    set(LIBNCURSES_LIBS "${CURSES_LIBRARIES}")
+
+    if(NOT LIBNCURSES_HAS_WTIMEOUT)
+      message(STATUS "search for tinfo library")
+      find_library(TINFO_LIBRARY NAMES tinfo)
+      if(TINFO_LIBRARY)
+        message(STATUS "found tinfo library")
+        CHECK_LIBRARY_EXISTS("${TINFO_LIBRARY}" wtimeout "" TINFO_HAS_WTIMEOUT)
+        if(TINFO_HAS_WTIMEOUT)
+          set(CURSES_LIBRARIES ${CURSES_LIBRARIES} ${TINFO_LIBRARY})
+        else(TINFO_HAS_WTIMEOUT)
+          message(FATAL_ERROR "tinfo library does not have wtimeout")
+        endif(TINFO_HAS_WTIMEOUT)
+      else(TINFO_LIBRARY)
+        message(FATAL_ERROR "no tinfo library")
+      endif(TINFO_LIBRARY)
+    endif(NOT LIBNCURSES_HAS_WTIMEOUT)
+  else(WITH_LIBNCURSES STREQUAL "SYSTEM")
+    message(FATAL_ERROR "Invalid WITH_LIBNCURSES option value ${WITH_LIBNCURSES}")
+  endif(WITH_LIBNCURSES STREQUAL "SYSTEM")
+endif(UNIX)
 
 # WITH_LIBEDIT can have multiple values with different meanings
 # on Linux:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24665

**Description**
* this is revert PR of #4118 
* replace ncurses to 'watch' command

Remarks
* before we proceed to approach to use **tinfo** instead of **ncurses** in broker monitor
* This is just an intermediate version.
* we rolled back CMakeLists.txt for CI build fails, 
* as a result '**cubrid broker status -s 1**' style command is not working

